### PR TITLE
class library: add SimpleNumber:lag family

### DIFF
--- a/SCClassLibrary/Common/Math/SimpleNumber.sc
+++ b/SCClassLibrary/Common/Math/SimpleNumber.sc
@@ -354,6 +354,10 @@ SimpleNumber : Number {
 	rate { ^'scalar' } // scalarRate constant
 	asAudioRateInput { ^if(this == 0) { Silent.ar } { DC.ar(this) } }
 
+	lag  { ^this }
+	lag2 { ^this }
+	lag3 { ^this }
+
 	// support for writing synth defs
 	writeInputSpec { arg file, synth;
 		var constIndex = synth.constants.at(this.asFloat);


### PR DESCRIPTION
i have some `generic' code, which could make use of having the lag methods on SimpleNumber, which is silently swallowed. any objections?

Signed-off-by: Tim Blechmann tim@klingt.org
