### PR TITLE
Properly initialize mSaveTime on document open and save.

### DIFF
--- a/editors/sc-ide/core/doc_manager.cpp
+++ b/editors/sc-ide/core/doc_manager.cpp
@@ -183,6 +183,7 @@ Document *DocumentManager::open( const QString & path, int initialCursorPosition
     doc->mDoc->setModified(false);
     doc->mFilePath = filePath;
     doc->mTitle = info.fileName();
+    doc->mSaveTime = info.lastModified();
 
     if (!isRTF)
         mFsWatcher.addPath(cpath);
@@ -212,6 +213,9 @@ bool DocumentManager::reload( Document *doc )
 
     doc->mDoc->setPlainText( QString::fromUtf8( bytes.data(), bytes.size() ) );
     doc->mDoc->setModified(false);
+
+    QFileInfo info(doc->mFilePath);
+    doc->mSaveTime = info.lastModified();
 
     if (!mFsWatcher.files().contains(doc->mFilePath))
         mFsWatcher.addPath(doc->mFilePath);
@@ -319,6 +323,7 @@ void DocumentManager::onFileChanged( const QString & path )
             QFileInfo info(doc->mFilePath);
             if (doc->mSaveTime < info.lastModified()) {
                 doc->mDoc->setModified(true);
+                doc->mSaveTime = info.lastModified();
                 emit changedExternally(doc);
             }
         }


### PR DESCRIPTION
mSaveTime isn't initialized, but is used to filter events from
QFileSystemMonitor. On OSX, possibly elsewhere, fsmonitor fires a lot
of events, only some of which are file modificaitons. If mSaveTime
isn't initialized, these will randomly fire / not fire.
