### PR TITLE
Main:startup: initialize openPorts before StartUp.run to enable OSCFunc ...

### DIFF
--- a/SCClassLibrary/DefaultLibrary/Main.sc
+++ b/SCClassLibrary/DefaultLibrary/Main.sc
@@ -21,8 +21,8 @@ Main : Process {
 		GUI.fromID( this.platform.defaultGUIScheme );
 		GeneralHID.fromID( this.platform.defaultHIDScheme );
 		this.platform.startup;
-		StartUp.run;
 		openPorts = Set[NetAddr.langPort];
+		StartUp.run;
 
 		("Welcome to SuperCollider %.".format(Main.version)
 			+ (Platform.ideName.switch(


### PR DESCRIPTION
Main:startup: initialize openPorts before StartUp.run to enable OSCFunc creation with custom ports at StartUp.
