### PR TITLE
Fix for #657; copy/paste to OS X Mail loses tabs

### DIFF
--- a/editors/sc-ide/widgets/code_editor/editor.cpp
+++ b/editors/sc-ide/widgets/code_editor/editor.cpp
@@ -903,4 +903,13 @@ void GenericCodeEditor::hideMouseCursor()
         QApplication::setOverrideCursor( Qt::BlankCursor );
 }
 
+QMimeData *GenericCodeEditor::createMimeDataFromSelection() const
+{
+    // Here, we bundle up just the plaintext (not HTML, as is the default) of
+    // the editor's selected contents.
+    QMimeData *data = new QMimeData;
+    data->setText(textCursor().selection().toPlainText());
+    return data;
+}
+
 } // namespace ScIDE

--- a/editors/sc-ide/widgets/code_editor/editor.hpp
+++ b/editors/sc-ide/widgets/code_editor/editor.hpp
@@ -59,7 +59,7 @@ protected:
     virtual void wheelEvent( QWheelEvent * );
     virtual void dragEnterEvent( QDragEnterEvent * );
     void hideMouseCursor(QKeyEvent *);
-
+    virtual QMimeData *createMimeDataFromSelection() const;
 
 public slots:
     void applySettings( Settings::Manager * );

--- a/editors/sc-ide/widgets/post_window.cpp
+++ b/editors/sc-ide/widgets/post_window.cpp
@@ -33,6 +33,7 @@
 #include <QScrollBar>
 #include <QShortcut>
 #include <QKeyEvent>
+#include <QTextDocumentFragment>
 
 namespace ScIDE {
 
@@ -266,6 +267,15 @@ void PostWindow::mouseDoubleClickEvent(QMouseEvent *e)
     extendSelectionForEnvVar(this, textCursor());
 
     cursor.endEditBlock();
+}
+
+QMimeData *PostWindow::createMimeDataFromSelection() const
+{
+    // Here, we bundle up just the plaintext (not HTML, as is the default) of
+    // the post window's selected contents.
+    QMimeData *data = new QMimeData;
+    data->setText(textCursor().selection().toPlainText());
+    return data;
 }
 
 bool PostWindow::openDocumentation()

--- a/editors/sc-ide/widgets/post_window.hpp
+++ b/editors/sc-ide/widgets/post_window.hpp
@@ -77,6 +77,7 @@ protected:
     virtual void wheelEvent( QWheelEvent * );
     virtual void focusOutEvent (QFocusEvent *e);
     virtual void mouseDoubleClickEvent(QMouseEvent *e);
+    virtual QMimeData *createMimeDataFromSelection() const;
 
 private slots:
     void onAutoScrollTriggered(bool);


### PR DESCRIPTION
In the mail thread for issue #657, Jakob mentioned: "In any case, I think it would make sense to make the code editor only copy plain text, as that's what code really is."

If you do want to do that, you can take this pull request.  It makes copying from the code editor or the post window have MIME type "text/plain".  Please do check it, though -- this is my first foray in to the wonderful world of SC and Qt code.  I tested on OS X 10.8, and also checked that it works with characters from another character set (Spanish - ISO), not just basic ASCII.

I did not change the behaviour everywhere.  For example, I didn't touch the Help window or TextView widgets, because those potentially should be formatted (or have the possibility?).  Note that these also don't paste very nicely -- you don't get any formatting at all when copying from the Help window, for example, even to OS X's TextEdit app (which handles the pasting of code properly, and did so even before this fix).

If there is anywhere else you think this may be needed, please let me know!

Thanks,
Glen.
