### PR TITLE
scide: code editor - insert path when dropping unknown files

### DIFF
--- a/editors/sc-ide/widgets/main_window.cpp
+++ b/editors/sc-ide/widgets/main_window.cpp
@@ -1400,13 +1400,16 @@ void MainWindow::dragEnterEvent( QDragEnterEvent * event )
 }
 
 bool MainWindow::checkFileExtension( const QString & fpath ) {
-    if (fpath.endsWith(".wav") || fpath.endsWith(".mp3") || fpath.endsWith(".aiff") || fpath.endsWith(".ogg")){
-        int ret = QMessageBox::question(this, tr("Open binary file?"),
-                tr("This file has a binary file extension. Are you sure you want to open it as a text file?"),
-                QMessageBox::Ok | QMessageBox::Cancel, QMessageBox::Cancel);
-        if(ret != QMessageBox::Ok)
-            return false;
+    if (fpath.endsWith(".sc") || fpath.endsWith(".scd") || fpath.endsWith(".txt") ||
+        fpath.endsWith(".schelp")) {
+        return true;
     }
+    int ret = QMessageBox::question(this, tr("Open binary file?"), fpath +
+                tr("\n\nThe file has an unrecognized extension. It may be a binary file. Would you still like to open it?"),
+                QMessageBox::Ok | QMessageBox::Cancel, QMessageBox::Cancel);
+    if(ret != QMessageBox::Ok)
+        return false;
+
     return true;
 }
 


### PR DESCRIPTION
When dropping binary files -- in fact any files not "sensible" for the editor -- insert the file path into the editor rather than opening the file (or popping up a warning dialog). If necessary, any file type may still be opened using File -> Open (i.e. that is unchanged)...
