### PR TITLE
out-comment s_tick

### DIFF
--- a/editors/scapp/GUIPrimitives.M
+++ b/editors/scapp/GUIPrimitives.M
@@ -48,7 +48,6 @@ extern NSTextView* gPostView;
 PyrSymbol *s_draw;
 PyrSymbol *s_font;
 PyrSymbol *s_closed;
-// PyrSymbol *s_tick;
 PyrSymbol *s_doaction;
 PyrSymbol *s_didBecomeKey;
 PyrSymbol *s_didResignKey;
@@ -3915,7 +3914,6 @@ void initGUIPrimitives()
         s_draw = getsym("draw");
         s_font = getsym("SCFont");
         s_closed = getsym("closed");
-//        s_tick = getsym("tick");
         s_doaction = getsym("doAction");
 		s_didBecomeKey = getsym("didBecomeKey");
         s_didResignKey = getsym("didResignKey");


### PR DESCRIPTION
Merge pull request #703 broke 'no-ide compiles' due to the duplicate symbol 's_tick' introduced by commit 8807e9ec300a358fa9ff72fc5a759ac813219c83. I guess, occurrence of  's_tick' in 'GUIPrimitives.m' is a left-over and should be removed there.
