### PR TITLE
cmake: fix build on archlinux

### DIFF
--- a/lang/CMakeLists.txt
+++ b/lang/CMakeLists.txt
@@ -307,6 +307,11 @@ set_property(TARGET sclang
 	APPEND
 	PROPERTY COMPILE_DEFINITIONS USE_SC_TERMINAL_CLIENT BUILDING_SUPERCOLLIDER)
 
+if (ARCHLINUX)
+    set_property(TARGET sclang
+                 APPEND PROPERTY LINK_FLAGS "-lpthread")
+endif()
+
 if(LTO)
 	set_property(TARGET sclang libsclang
 					APPEND PROPERTY COMPILE_FLAGS "-flto -flto-report")

--- a/server/scsynth/CMakeLists.txt
+++ b/server/scsynth/CMakeLists.txt
@@ -208,6 +208,11 @@ file(GLOB_RECURSE all_headers ../../*hpp)
 add_executable(scsynth scsynth_main.cpp ${all_headers})
 target_link_libraries(scsynth libscsynth)
 
+if (ARCHLINUX)
+    set_property(TARGET scsynth
+                 APPEND PROPERTY LINK_FLAGS "-lpthread")
+endif()
+
 if(LTO)
     set_property(TARGET scsynth libscsynth
                  APPEND PROPERTY COMPILE_FLAGS "-flto -flto-report")


### PR DESCRIPTION
- add "ARCHLINUX" cmake option
- add `-lpthread` to scsynth and sclang link flags
- fix "undefined reference to symbol 'pthread_mutexattr_settype@@GLIBC_2.2.5'" error

Reported in [this thread](http://new-supercollider-mailing-lists-forums-use-these.2681727.n2.nabble.com/link-failure-for-pthreads-on-Arch-Linux-td7594503.html)
