### PR TITLE
supernova/scsynth: Buffer reading should send /b_info

### DIFF
--- a/HelpSource/Reference/Server-Command-Reference.schelp
+++ b/HelpSource/Reference/Server-Command-Reference.schelp
@@ -553,7 +553,7 @@ table::
 ::
 Allocates buffer to number of channels of file and number of samples requested, or fewer if sound file is smaller than requested. Reads sound file data from the given starting frame in the file. If the number of frames argument is less than or equal to zero, the entire file is read.
 definitionlist::
-## Asynchronous. || Replies to sender with strong::/done:: when complete.
+## Asynchronous. || Replies to sender with strong::/b_info:: and strong::/done:: when complete.
 ::
 
 subsection:: /b_allocReadChannel
@@ -572,7 +572,7 @@ table::
 
 As b_allocRead, but reads individual channels into the allocated buffer in the order specified.
 definitionlist::
-## Asynchronous. || Replies to sender with strong::/done:: when complete.
+## Asynchronous. || Replies to sender with strong::/b_info:: and strong::/done:: when complete.
 ::
 
 
@@ -590,7 +590,7 @@ table::
 Reads sound file data from the given starting frame in the file and writes it to the given starting frame in the buffer. If number of frames is less than zero, the entire file is read.
 If reading a file to be used by link::Classes/DiskIn:: ugen then you will want to set "leave file open" to one, otherwise set it to zero.
 definitionlist::
-## Asynchronous. || Replies to sender with strong::/done:: when complete.
+## Asynchronous. || Replies to sender with strong::/b_info:: and strong::/done::when complete.
 ::
 
 
@@ -612,7 +612,7 @@ table::
 
 As strong::b_read::, but reads individual channels in the order specified. The number of channels requested must match the number of channels in the buffer.
 definitionlist::
-## Asynchronous. || Replies to sender with strong::/done:: when complete.
+## Asynchronous. || Replies to sender with strong::/b_info:: and strong::/done:: when complete.
 ::
 
 

--- a/server/scsynth/SC_SequencedCommand.cpp
+++ b/server/scsynth/SC_SequencedCommand.cpp
@@ -108,6 +108,31 @@ char* allocAndRestrictPath(World *mWorld, const char* inPath, const char* restri
 	return saferPath;
 }
 
+static int send_b_info(World *inWorld, int bufindex, ReplyAddress *inReply)
+{
+	small_scpacket packet;
+
+	packet.adds("/b_info");
+	packet.maketags(5);
+	packet.addtag(',');
+
+	SndBuf* buf = World_GetBuf(inWorld, bufindex);
+
+	packet.addtag('i');
+	packet.addtag('i');
+	packet.addtag('i');
+	packet.addtag('f');
+	packet.addi(bufindex);
+	packet.addi(buf->frames);
+	packet.addi(buf->channels);
+	packet.addf(buf->samplerate);
+
+	if (packet.size())
+		CallSequencedCommand(SendReplyCmd, inWorld, packet.size(), packet.data(), inReply);
+	return 0;
+}
+
+
 SC_SequencedCommand::SC_SequencedCommand(World *inWorld, ReplyAddress *inReplyAddress)
 	: mNextStage(1), mWorld(inWorld),
 	mMsgSize(0), mMsgData(0)
@@ -129,12 +154,12 @@ int SC_SequencedCommand::Init(char* /*inData*/, int /*inSize*/)
 void SC_SequencedCommand::SendDone(const char *inCommandName)
 {
 	::SendDone(&mReplyAddress, inCommandName);
-};
+}
 
 void SC_SequencedCommand::SendDoneWithIntValue(const char *inCommandName, int value)
 {
 	::SendDoneWithIntValue(&mReplyAddress, inCommandName, value);
-};
+}
 
 void SC_SequencedCommand::CallEveryStage()
 {
@@ -688,6 +713,7 @@ bool BufReadCmd::Stage3()
 
 	mWorld->mSndBufUpdates[mBufIndex].writes ++ ;
 	SEND_COMPLETION_MSG;
+
 	return true;
 }
 

--- a/server/scsynth/SC_SequencedCommand.h
+++ b/server/scsynth/SC_SequencedCommand.h
@@ -39,17 +39,18 @@
 #include <new>
 
 #define CallSequencedCommand(T, inWorld, inSize, inData, inReply)	\
-	void* space = World_Alloc(inWorld, sizeof(T)); \
-	T *cmd = new (space) T(inWorld, inReply); \
-	if (!cmd) return kSCErr_Failed; \
-	int err = cmd->Init(inData, inSize); \
-	if (err) { \
-		cmd->~T(); \
-		World_Free(inWorld, space); \
-		return err; \
-	} \
-	if (inWorld->mRealTime) cmd->CallNextStage(); \
-	else cmd->CallEveryStage();
+	do { void* space = World_Alloc(inWorld, sizeof(T)); \
+		T *cmd = new (space) T(inWorld, inReply); \
+		if (!cmd) return kSCErr_Failed; \
+		int err = cmd->Init(inData, inSize); \
+		if (err) { \
+			cmd->~T(); \
+			World_Free(inWorld, space); \
+			return err; \
+		} \
+		if (inWorld->mRealTime) cmd->CallNextStage(); \
+		else cmd->CallEveryStage(); \
+	} while (0);
 
 
 class SC_SequencedCommand


### PR DESCRIPTION
hi all,

could someone review this patch? it fixes a nasty race condition for me.

thnx, tim

>8--------
Buffer reading issues two asynchronous commands: first it sends the buffer
filling message, then a /b_query to obtain information from the server.

this means that after waiting for Server.sync, the Buffer object is not
initialized. we avoid this server/language ping-pong by automatically
sending /b_info to avoid that the language has to explicitly send a
/b_query

Signed-off-by: Tim Blechmann <tim@klingt.org>