### PR TITLE
scide: left|right arrow keys disable completion

### DIFF
--- a/editors/sc-ide/widgets/code_editor/autocompleter.cpp
+++ b/editors/sc-ide/widgets/code_editor/autocompleter.cpp
@@ -354,6 +354,11 @@ bool AutoCompleter::eventFilter( QObject *object, QEvent *event )
     case QEvent::ShortcutOverride: {
         QKeyEvent * kevent = static_cast<QKeyEvent*>(event);
         switch(kevent->key()) {
+        case Qt::Key_Left:
+        case Qt::Key_Right:
+            if (mCompletion.menu && mCompletion.menu->isVisible())
+                mCompletion.menu->reject();
+            break;
         case Qt::Key_Escape:
             if (mCompletion.menu && mCompletion.menu->isVisible())
                 mCompletion.menu->reject();


### PR DESCRIPTION
This is a minor change but somehow I find it handy to be able to hide the completion menu with left or right arrow instead of pressing ESC.
