### PR TITLE
nested OSC bundle support for scsynth (issue #776)

### DIFF
--- a/server/scsynth/SC_CoreAudio.cpp
+++ b/server/scsynth/SC_CoreAudio.cpp
@@ -255,7 +255,23 @@ void PerformOSCBundle(World *inWorld, OSC_Packet *inPacket)
 		int32 msgSize = ntohl(*(int32*)data);
 		data += sizeof(int32);
 		//scprintf("msgSize %d\n", msgSize);
-		PerformOSCMessage(inWorld, msgSize, data, &inPacket->mReplyAddr);
+
+		if (gIsBundle.checkIsBundle((int32*)data)) {
+			// handle nested bundle
+			OSC_Packet* bndl = (OSC_Packet*)malloc(sizeof(OSC_Packet));
+			bndl->mData = (char *)malloc(msgSize * sizeof(char));
+			memcpy(bndl->mData, data, msgSize);
+			bndl->mSize = msgSize;
+			bndl->mIsBundle = true;
+			bndl->mReplyAddr = inPacket->mReplyAddr;
+			PacketStatus status = PerformOSCPacket(inWorld, bndl, SC_ScheduledEvent::FreeInNRT);
+			if (status == PacketPerformed) {
+				SC_ScheduledEvent::FreeInNRT(inWorld, bndl);
+			}
+		} else {
+			// handle nested message
+			PerformOSCMessage(inWorld, msgSize, data, &inPacket->mReplyAddr);
+		}
 		data += msgSize;
 	}
 


### PR DESCRIPTION
A patch to introduce support for nested OSC bundles to scsynth (as part of issue #776).

I've taken the simplest approach to implement nested OSC bundles by using the existent infrastructure by means of a simple recursive function call when a nested bundle has been found.

By doing so, only bundles on the first nesting level of a root bundle will be scheduled (if requested so by the timetag). But this is fine according to the spec, as it says the following about scheduling of multi-level nested bundles:

"When bundles contain other bundles, the OSC Time Tag of the enclosed bundle must be greater than or equal to the OSC Time Tag of the enclosing bundle."
