### PR TITLE
sc ide: sc editor: slight improvement of matching token insertion

### DIFF
--- a/editors/sc-ide/widgets/code_editor/sc_editor.cpp
+++ b/editors/sc-ide/widgets/code_editor/sc_editor.cpp
@@ -387,7 +387,6 @@ bool ScCodeEditor::insertMatchingTokens( const QString & text )
         if (isClosingToken && document->characterAt(cursorPosition) == token) {
             cursor.movePosition(QTextCursor::NextCharacter);
             cursor.setVerticalMovementX(-1);
-            setTextCursor(cursor);
         }
         else if (isOpeningToken) {
             cursor.beginEditBlock();
@@ -396,11 +395,12 @@ bool ScCodeEditor::insertMatchingTokens( const QString & text )
             cursor.endEditBlock();
             cursor.movePosition(QTextCursor::PreviousCharacter);
             cursor.setVerticalMovementX(-1);
-            setTextCursor(cursor);
         }
         else
             return false;
     }
+
+    setTextCursor(cursor);
 
     return true;
 }


### PR DESCRIPTION
When inserting a matching token with a selected text, be sure
to move the cursor after the inserted matching token.
