### PR TITLE
Added missing closing ")" in MIDI input example.

### DIFF
--- a/HelpSource/Guides/MIDI.schelp
+++ b/HelpSource/Guides/MIDI.schelp
@@ -51,6 +51,7 @@ MIDIIn.connectAll;
 m = MIDIFunc.noteOn({ |vel, num|
 	"note % @ velocity %\n".postf(num, vel);
 });
+)
 
 // when finished
 m.free;


### PR DESCRIPTION
Added missing closing ")" in MIDI input example.
