### PR TITLE
classlib (quarks): Defer svn path checking until needed; try{} the check

### DIFF
--- a/SCClassLibrary/Common/Quarks/QuarkSVNRepository.sc
+++ b/SCClassLibrary/Common/Quarks/QuarkSVNRepository.sc
@@ -10,10 +10,10 @@ QuarkSVNRepository
 	classvar <>svnpath="/usr/local/bin/svn";
 	var <url, <local;
 
-	*initClass {
+	*initSVNDetails {
 		var res;
 		svnpath = [svnpath, "/usr/local/bin/svn", "/usr/bin/svn", "/opt/local/bin/svn", "/sw/bin/svn"].detect({ |path|
-			File.exists(path);
+			try { File.exists(path) } { false }
 		});
 		if(svnpath.isNil and:{thisProcess.platform.hasFeature(\unixPipes)}){
 			// Try and detect whether svn is in the path, and could be called just via "svn"
@@ -25,6 +25,7 @@ QuarkSVNRepository
 	}
 
 	*new { | url, local |
+		QuarkSVNRepository.initSVNDetails;
 		if(svnpath.isNil) {
 			if(thisProcess.platform.name==\windows){
 				Post


### PR DESCRIPTION
Discussed on the mailing list. Nobody had any comments on my patch, so here you go.

Should also go in 3.6, I expect.
