### PR TITLE
normalizeSum fix, divide values by abs sum

### DIFF
--- a/lang/LangPrimSource/PyrArrayPrimitives.cpp
+++ b/lang/LangPrimSource/PyrArrayPrimitives.cpp
@@ -2103,6 +2103,7 @@ int prArrayNormalizeSum(struct VMGlobals *g, int numArgsPushed)
 		sum += w;
 		SetFloat(&slots2[i], w);
 	}
+	sum = sc_abs(sum);
 	rsum = 1./sum;
 	for (i=0; i<size; ++i) {
 		double d = slotRawFloat(&slots2[i]);


### PR DESCRIPTION
Should divide by absolute sum in primitive code instead?

(
var ar, correctNormalizeSum;
correctNormalizeSum = {arg val; val / val.sumabs};
ar = [-3.7, 3.8].normalizeSum;
"current primitive code: %\n".postf(ar.normalizeSum);
"should be %\n".postf(correctNormalizeSum.value(ar));
)
