### PR TITLE
sclang bugfix: proper handling of Open Sound Control Blob Arguments

### DIFF
--- a/lang/LangPrimSource/OSCData.cpp
+++ b/lang/LangPrimSource/OSCData.cpp
@@ -608,8 +608,8 @@ int prArray_OSCBytes(VMGlobals *g, int numArgsPushed)
 // Create a new <PyrInt8Array> object and copy data from `msg.getb'.
 // Bytes are properly untyped, but there is no <UInt8Array> type.
 
-static PyrInt8Array* MsgToInt8Array ( sc_msg_iter msg ) ;
-static PyrInt8Array* MsgToInt8Array ( sc_msg_iter msg )
+static PyrInt8Array* MsgToInt8Array ( sc_msg_iter& msg ) ;
+static PyrInt8Array* MsgToInt8Array ( sc_msg_iter& msg )
 {
 	int size = msg.getbsize() ;
 	VMGlobals *g = gMainVMGlobals ;


### PR DESCRIPTION
Right now, only one OSC Blob argument can be read by sclang and when intermingled with other arguments it only consistently works as last argument:

works with current sclang:
/test b 0x01             -> [[0x01]]
/test ib 12 0x01         -> [12, [0x01]]

does not work with current sclang:
/test bb 0x01 0x02       -> [[0x01], [0x01]]
/test bi 0x01 12         -> [[0x01], [0x01]]

The problem is that the tag counter (msg.counter) is not increased as intended, because MsgToInt8Array clones the sc_msg_iter struct. Using a reference argument in MsgToInt8Array() fixes the problem.

does now work:
/test bb 0x01 0x02       -> [[0x01], [0x02]]
/test bi 0x01 12         -> [[0x01], 12]
