### PR TITLE
sclang: support for more non-standard OSC types

### DIFF
--- a/include/plugin_interface/sc_msg_iter.h
+++ b/include/plugin_interface/sc_msg_iter.h
@@ -70,10 +70,11 @@ struct sc_msg_iter
 {
 	const char *data, *rdpos, *endpos, *tags;
 	int size, count;
-
+	
 	sc_msg_iter();
 	sc_msg_iter(int inSize, const char* inData);
 	void init(int inSize, const char* inData);
+	int64 gett(int64 defaultValue = 1);
 	int32 geti(int32 defaultValue = 0);
 	float32 getf(float32 defaultValue = 0.f);
 	float64 getd(float64 defaultValue = 0.f);
@@ -109,6 +110,28 @@ inline void sc_msg_iter::init(int inSize, const char* inData)
 		tags = 0;
 		rdpos = data;
 	}
+}
+
+inline int64 sc_msg_iter::gett(int64 defaultValue)
+{
+	int64 value;
+	if (remain() <= 0) return defaultValue;
+	if (tags) {
+		if (tags[count] == 't') {
+			value = OSCtime(rdpos);
+			rdpos += sizeof(int64);
+		} else {
+			/* this is dangerous, as rdpos is not
+			   advanced accordingly while count++ takes
+				 place */
+			value = defaultValue;
+		}
+	} else {
+		value = OSCtime(rdpos);
+		rdpos += sizeof(int64);
+	}
+	count++;
+	return value;
 }
 
 inline int32 sc_msg_iter::geti(int32 defaultValue)
@@ -254,16 +277,28 @@ inline int32* sc_msg_iter::gets4(char* defaultValue)
 
 inline size_t sc_msg_iter::getbsize()
 {
+	size_t len = 0;
 	if (remain() <= 0) return 0;
-	if (tags && tags[count] != 'b') return 0;
-	return (size_t)OSCint(rdpos);
+	if (tags) {
+		if (tags[count] == 'b')
+			len = OSCint(rdpos);
+		else if (tags[count] == 'm')
+			len = 4;
+	}
+	return len;
 }
 
 inline void sc_msg_iter::getb(char* outArray, size_t size)
 {
-	size_t len = OSCint(rdpos);
-	if (size < len) return;
-	rdpos += sizeof(int32);
+	size_t len = 0;
+	if (tags[count] == 'b') {
+		len = OSCint(rdpos);
+		if (size < len) return;
+		rdpos += sizeof(int32);
+	}	else if (tags[count] == 'm') {
+		len = 4;
+		if (size < len) return;
+	}
 	size_t len4 = (len + 3) & (size_t)-4;
 	memcpy(outArray, rdpos, size);
 	rdpos += len4;
@@ -272,8 +307,13 @@ inline void sc_msg_iter::getb(char* outArray, size_t size)
 
 inline void sc_msg_iter::skipb()
 {
-	size_t len = OSCint(rdpos);
-	rdpos += sizeof(int32);
+	size_t len = 0;
+	if (tags[count] == 'b')
+	{
+		len = OSCint(rdpos);
+		rdpos += sizeof(int32);
+	} else if (tags[count] == 'm')
+		len = 4;
 	size_t len4 = (len + 3) & (size_t)-4;
 	rdpos += len4;
 	count ++;

--- a/lang/LangPrimSource/OSCData.cpp
+++ b/lang/LangPrimSource/OSCData.cpp
@@ -619,6 +619,8 @@ static PyrInt8Array* MsgToInt8Array ( sc_msg_iter& msg )
 	return obj ;
 }
 
+static const double dInfinity = std::numeric_limits<double>::infinity();
+
 PyrObject* ConvertOSCMessage(int inSize, char *inData)
 {
 	char *cmdName = inData;
@@ -661,16 +663,38 @@ PyrObject* ConvertOSCMessage(int inSize, char *inData)
                     SetSymbol(slots+i+1, getsym(msg.gets()));
                     //post("sym '%s'\n", slots[i+1].us->name);
                     break;
-                case 'b' :
-					SetObject(slots+i+1, (PyrObject*)MsgToInt8Array(msg));
-                    break;
-				case 'c':
-					SetChar(slots+i+1, (char)msg.geti());
-					break;
-				// else add the type tag as a char (jrhb 2009)
-				default:
-					SetChar(slots+i+1, tag);
-					msg.gets();
+								case 'b' : // fall through
+								case 'm' :
+										SetObject(slots+i+1, (PyrObject*)MsgToInt8Array(msg));
+										break;
+								case 'c':
+										SetChar(slots+i+1, (char)msg.geti());
+										break;
+								case 't' :
+										SetFloat(slots+i+1, OSCToElapsedTime(msg.gett()));
+										break;
+										
+								// argument tags without any associated value
+								case 'T' :
+										SetTrue(slots+i+1);
+										msg.count ++;
+										break;
+								case 'F' :
+										SetFalse(slots+i+1);
+										msg.count ++;
+										break;
+								case 'I' :
+										SetFloat(slots+i+1, dInfinity);
+										msg.count ++;
+										break;
+								case 'N' :
+										SetNil(slots+i+1);
+										msg.count ++;
+										break;
+								// else add the type tag as a char (jrhb 2009)
+								default:
+										SetChar(slots+i+1, tag);
+										msg.gets();
             }
         }
         obj->size = numElems + 1;

--- a/lang/LangPrimSource/SC_ComPort.cpp
+++ b/lang/LangPrimSource/SC_ComPort.cpp
@@ -97,6 +97,34 @@ static void dumpOSCmsg(int inSize, char* inData)
 				printf(" DATA[%zu]", msg.getbsize());
 				msg.skipb();
 				break;
+			case 'm' : {
+				char midi [4];
+				msg.getb (midi, 4);
+				printf(" MIDI[0x%02x 0x%02x 0x%02x 0x%02x]", midi[0], midi[1], midi[2], midi[3]);
+				break;
+			}
+			case 'c' :
+				printf(" %c", (char)msg.geti());
+				break;
+			case 't' :
+				printf(" %ld", msg.gett());
+				break;
+			case 'T' :
+				printf(" true");
+				msg.count ++;
+				break;
+			case 'F' :
+				printf(" false");
+				msg.count ++;
+				break;
+			case 'I' :
+				printf(" infinitum");
+				msg.count ++;
+				break;
+			case 'N' :
+				printf(" nil");
+				msg.count ++;
+				break;
 			default :
 				printf(" !unknown tag '%c' 0x%02x !", isprint(c)?c:'?', (unsigned char)c & 255);
 				goto leave;


### PR DESCRIPTION
Apart from the default OSC types 'i', 'f', 's', 'b', sclang's OSC parser
also supports non-standard types 'c', 'd'. This patch introduces some more
(widely) used/supported (e.g. by liblo, oscpack) OSC types, so that more
apps can potentially talk to sclang.

't': OSC timestamp (as in bundles)
'T': True
'F': False
'N': Nil
'I': Infinitum
'm': MIDI (4byte blob)

't' is used by the TUIO 2.0 specification, I'd like to see at least this
supported by sclangs' OSC parser. It's handled like an OSC bundle
timestamp (elapsed time).

'T', 'F', 'N', 'I' are unproblematic to support as they match 1to1 to
sclangs type system.

'm' is sometimes a preferable alternative to sending MIDI commands via blobs.
As it's actually a  special blob of fixed size, it's treated as such,
e.g. Int8Array [4].
