### PR TITLE
sclang: support for receiving nested OSC bundles.

### DIFF
--- a/HelpSource/Guides/OSC_communication.schelp
+++ b/HelpSource/Guides/OSC_communication.schelp
@@ -57,7 +57,7 @@ OSCFunc.trace(false); // Turn posting off
 
 section::Custom OSC message processing
 
-All incoming OSC messages call the message recvOSCmessage, or recvOSCbundle in link::Classes/Main::. If needed, one can add a custom link::Classes/Function:: or other object to Main's recvOSCFunc variable. Although one can do this directly using the corresponding setter, it is better to use the link::Classes/Main#-addOSCRecvFunc:: and link::Classes/Main#-removeOSCRecvFunc:: to avoid overwriting any other functions that may have been added by class code.
+All incoming OSC messages call the message recvOSCmessage in link::Classes/Main::. If needed, one can add a custom link::Classes/Function:: or other object to Main's recvOSCFunc variable. Although one can do this directly using the corresponding setter, it is better to use the link::Classes/Main#-addOSCRecvFunc:: and link::Classes/Main#-removeOSCRecvFunc:: to avoid overwriting any other functions that may have been added by class code.
 code::
 // this example is basically like OSCFunc.trace but filters out
 // /status.reply messages

--- a/SCClassLibrary/DefaultLibrary/Main.sc
+++ b/SCClassLibrary/DefaultLibrary/Main.sc
@@ -79,13 +79,6 @@ Main : Process {
 		OSCresponder.respond(time, replyAddr, msg);
 	}
 
-	recvOSCbundle { arg time, replyAddr, recvPort ... msgs;
-		// this method is called when an OSC bundle is received.
-		msgs.do({ arg msg;
-			this.recvOSCmessage(time, replyAddr, recvPort, msg);
-		});
-	}
-
 	addOSCRecvFunc { |func| prRecvOSCFunc = prRecvOSCFunc.addFunc(func) }
 
 	removeOSCRecvFunc { |func| prRecvOSCFunc = prRecvOSCFunc.removeFunc(func) }


### PR DESCRIPTION
OSC bundles cannot only contain OSC messages, but other bundles, too. This patch adds support to sclang for receiving such nested OSC bundles.

The method recvOSCbundle is not used anymore and was therefore deleted. Message dispatching is solely done via recvOSCmessage.

The function ConvertOSCBundle is not used anywhere, seems to be dead code to me, so it has been removed.
