### PR TITLE
scide: sc_editor: include parenthesis in regionAroundCursor()

### DIFF
--- a/editors/sc-ide/widgets/code_editor/sc_editor.cpp
+++ b/editors/sc-ide/widgets/code_editor/sc_editor.cpp
@@ -1208,8 +1208,8 @@ QTextCursor ScCodeEditor::regionAroundCursor(const QTextCursor & cursor)
                  && bracketPairDefinesRegion(bracketPair) )
             {
                 QTextCursor regionCursor(QPlainTextEdit::document());
-                regionCursor.setPosition(bracketPair.first.position() + 1);
-                regionCursor.setPosition(bracketPair.second.position(), QTextCursor::KeepAnchor);
+                regionCursor.setPosition(bracketPair.first.position());
+                regionCursor.setPosition(bracketPair.second.position() + 1, QTextCursor::KeepAnchor);
                 return regionCursor;
             }
         } else {


### PR DESCRIPTION
When evaluating a region, the evaluated code excludes the parenthesis
which define the region. If they are included instead, we avoid a
parse error when evaluating array shortcut notations like `(1..3)`.
