### PR TITLE
HelpSource: MIDIFunc: show how to free a MIDIFunc

### DIFF
--- a/HelpSource/Classes/MIDIFunc.schelp
+++ b/HelpSource/Classes/MIDIFunc.schelp
@@ -193,10 +193,18 @@ EXAMPLES::
 
 code::
 MIDIIn.connectAll
-MIDIFunc.cc({arg ...args; args.postln}, 1); // match cc 1
-MIDIFunc.cc({arg ...args; args.postln}, 1, 1); // match cc1, chan 1
-MIDIFunc.cc({arg ...args; args.postln}, (1..10)); // match cc 1-10
-MIDIFunc.noteOn({arg ...args; args.postln}); // match any noteOn
+
+a = MIDIFunc.cc({arg ...args; args.postln}, 1); // match cc 1
+a.free; // cleanup
+
+b = MIDIFunc.cc({arg ...args; args.postln}, 1, 1); // match cc1, chan 1
+b.free; // cleanup
+
+c = MIDIFunc.cc({arg ...args; args.postln}, (1..10)); // match cc 1-10
+c.free; // cleanup
+
+n = MIDIFunc.noteOn({arg ...args; args.postln}); // match any noteOn
+n.free; // cleanup
 
 MIDIIn.doNoteOnAction(1, 1, 64, 64); // spoof a note on
 MIDIIn.doControlAction(1, 1, 1, 64); // spoof a cc


### PR DESCRIPTION
When using several MIDIFunc, assigning all of them to the same variable
will lead to confusing results as each MIDIFunc will continue to exist
on top of the old one.

This commit shows the good practice: add a variable to each MIDIFunc
example line and show how to free them.
