### PR TITLE
supernova: synthdef corruption - added synthef path to error message

### DIFF
--- a/server/supernova/sc/sc_synth_definition.cpp
+++ b/server/supernova/sc/sc_synth_definition.cpp
@@ -46,7 +46,7 @@ std::vector<sc_synthdef> sc_read_synthdefs_file(path const & file)
         return read_synthdef_file(file.string());
     } catch(std::exception const & e)
     {
-        cout << "Exception when parsing synthdef: " << e.what() << endl;
+        cout << "Exception when parsing synthdef file " << file.string() << ": " << e.what() << endl;
         return std::vector<sc_synthdef>();
     }
 }


### PR DESCRIPTION
A reproducer to test this:

```
(
s = Server(\test1, NetAddr("localhost",57111) );
v = Server(\test2, NetAddr("localhost",57112) )
)

(
[s,v].do(_.boot)
)

//this will cause synthdef corruption
(
[s,v].do{ |x|
SynthDef(\test, {
    Out.ar(0, SinOsc.ar() )
    }).load(x)
}
)
```
