### PR TITLE
class library: warn when trying to add UGens outside synthdef function

### DIFF
--- a/SCClassLibrary/Common/Audio/UGen.sc
+++ b/SCClassLibrary/Common/Audio/UGen.sc
@@ -264,7 +264,12 @@ UGen : AbstractFunction {
 
 	addToSynth {
 		synthDef = buildSynthDef;
-		if (synthDef.notNil, { synthDef.addUGen(this) });
+		if (synthDef.notNil, {
+			synthDef.addUGen(this);
+		}, {
+			"WARNING: UGen constructed outside of a SynthDef :".post;
+			this.class.name.postln;
+		});
 	}
 
 	collectConstants {


### PR DESCRIPTION
class library: warn when trying to add UGens outside synthdef function (closed now, revisit?)
