### PR TITLE
scsynth: support for receiving nested OSC bundles.

### DIFF
--- a/server/scsynth/SC_ComPort.cpp
+++ b/server/scsynth/SC_ComPort.cpp
@@ -268,7 +268,6 @@ void hexdump(int size, char* data)
 
 static bool dumpOSCbndl(int indent, int size, char *inData)
 {
-	int i;
 	char* data = inData + 8;
 	char* dataEnd = inData + size;
 
@@ -281,7 +280,7 @@ static bool dumpOSCbndl(int indent, int size, char *inData)
 		data += sizeof(int32);
 
 		scprintf("\n");
-		for (i=0; i<indent+1; i++) scprintf("  ");
+		for (int i=0; i<indent+1; i++) scprintf("  ");
 
 		if (!strcmp(data, "#bundle"))
 			contentPrinted = dumpOSCbndl(indent+1, msgSize, data);
@@ -291,7 +290,7 @@ static bool dumpOSCbndl(int indent, int size, char *inData)
 		if ( (data < dataEnd) && contentPrinted) scprintf(",");
 	}
 	scprintf("\n");
-	for (i=0; i<indent; i++) scprintf("  ");
+	for (int i=0; i<indent; i++) scprintf("  ");
 	scprintf("]");
 
 	return true;
@@ -357,7 +356,6 @@ static bool UnrollOSCPacket(World *inWorld, int inSize, char *inData, OSC_Packet
 
 				// process this packet without its nested bundle(s)
 				if(!ProcessOSCPacket(inWorld, inPacket)) {
-					scprintf("command FIFO full\n");
 					free(buf);
 					return false;
 				}
@@ -386,7 +384,6 @@ static bool UnrollOSCPacket(World *inWorld, int inSize, char *inData, OSC_Packet
 			memcpy(buf, inData, inSize);
 
 			if(!ProcessOSCPacket(inWorld, inPacket)) {
-				scprintf("command FIFO full\n");
 				free(buf);
 				return false;
 			}
@@ -398,7 +395,6 @@ static bool UnrollOSCPacket(World *inWorld, int inSize, char *inData, OSC_Packet
 		memcpy(buf, inData, inSize);
 
 		if(!ProcessOSCPacket(inWorld, inPacket)) {
-			scprintf("command FIFO full\n");
 			free(buf);
 			return false;
 		}

--- a/server/scsynth/SC_CoreAudio.cpp
+++ b/server/scsynth/SC_CoreAudio.cpp
@@ -215,6 +215,8 @@ bool ProcessOSCPacket(World *inWorld, OSC_Packet *inPacket)
 		fifoMsg.Set(inWorld, Perform_ToEngine_Msg, FreeOSCPacket, (void*)inPacket);
 		result = driver->SendOscPacketMsgToEngine(fifoMsg);
 	static_cast<SC_Lock*>(inWorld->mDriverLock)->unlock();
+	if (!result)
+		scprintf("command FIFO full\n");
 	return result;
 }
 


### PR DESCRIPTION
I'm sending messages directly to scsynth from microcontrollers and want to pack
as much messages into a single UDP packet as possible to save cycles and bandwith.

My messages don't have all the same timestamp. Some need to be executed immediately,
other later.

To be able to pack messages with different timestamps into the same UDP packet,
I make use of nested OSC bundles. This patch adds support to scsynth to handle nested OSC
bundles, as it cannot handle them right now.

As this enhances a sensible part of scsynth, I propose that this patch needs some thorough review...

scsynth right now cannot receive nested OSC bundles, this patch adds
support for it. To play nicely with the current way of scheduling
bundles, it does so by unrolling(unnesting) nested bundles  before
handing them over via the FIFO to the realtime thread.

the example incoming packet with nested bundles:

```
[ #bundle IMMEDIATE
    [ /tick, 13]
    [ #bundle IMMEDIATE
       [ /s_new, 1000, ...]
    ]
    [ /tock, 14]
    [ #bundle +1ms
        [ /n_set, 1000, 'gate', 1, ...]
    ]
]
```

is unrolled to three individual packets each consisting of a single bundle:

```
[ #bundle IMMEDIATE
    [ /tick, 13]
    [ /tock, 14]
]

[ #bundle IMMEDIATE
    [ /s_new, 1000, ...]
]

[ #bundle +1ms
    [ /n_set, 1000, 'gate', 1, ...]
]
```

Signed-off-by: Hanspeter Portner agenthp@users.sf.net
