### PR TITLE
Class Library: Object - performance improvements for Object.dup 

### DIFF
--- a/SCClassLibrary/Common/Core/Object.sc
+++ b/SCClassLibrary/Common/Core/Object.sc
@@ -128,7 +128,9 @@ Object  {
 		^this.primitiveFailed
 	}
 	dup { arg n = 2;
-		^Array.fill(n, { this.copy });
+		var array = Array(n);
+		n.do {|i| array.add(this.copy) };
+		^array
 	}
 	! { arg n;
 		^this.dup(n)


### PR DESCRIPTION
before:
bench{
 10.do({
   nil.dup(1000000)
 })
} // time to run: 2.6241684029992 seconds.

after:
 bench{
   10.do({
   nil.dup(1000000)
 })
} // time to run: 1.5116338950011 seconds.
