### PR TITLE
lang: Add editable property to QWebView

### DIFF
--- a/HelpSource/Classes/WebView.schelp
+++ b/HelpSource/Classes/WebView.schelp
@@ -87,6 +87,10 @@ METHOD:: setFontFamily
     Argument:: specific
         A font family name to be assigned to the generic family; a String.
 
+METHOD:: editable
+    Get or set whether the entire web page is editable.
+    Argument::
+        A Boolean.
 
 SUBSECTION:: Actions
 

--- a/QtCollider/widgets/QcWebView.cpp
+++ b/QtCollider/widgets/QcWebView.cpp
@@ -38,7 +38,8 @@ namespace QtCollider {
 
 WebView::WebView( QWidget *parent ) :
   QWebView( parent ),
-  _interpretSelection(false)
+  _interpretSelection(false),
+  _editable(false)
 {
   QtCollider::WebPage *page = new WebPage(this);
   page->setDelegateReload(true);
@@ -61,6 +62,8 @@ WebView::WebView( QWidget *parent ) :
 
   connect( page, SIGNAL(jsConsoleMsg(const QString&, int, const QString&)),
            this, SIGNAL(jsConsoleMsg(const QString&, int, const QString&)) );
+    
+  connect( this, SIGNAL(loadFinished(bool)), this, SLOT(updateEditable(bool)) );
 }
 
 QString WebView::url() const

--- a/QtCollider/widgets/QcWebView.h
+++ b/QtCollider/widgets/QcWebView.h
@@ -41,6 +41,8 @@ class WebView : public QWebView
   Q_PROPERTY( bool delegateReload READ delegateReload WRITE setDelegateReload );
   Q_PROPERTY( bool enterInterpretsSelection
               READ interpretSelection WRITE setInterpretSelection );
+  Q_PROPERTY( bool editable
+               READ editable WRITE setEditable );
 
 public:
   Q_INVOKABLE void setHtml ( const QString &html, const QString &baseUrl = QString() );
@@ -71,6 +73,8 @@ public:
   void setDelegateReload( bool );
   bool interpretSelection() const { return _interpretSelection; }
   void setInterpretSelection( bool b ) { _interpretSelection = b; }
+    bool editable() const { return _editable; }
+  void setEditable( bool b ) { _editable = b; page()->setContentEditable(b); }
 
   inline static QUrl urlFromString( const QString & str ) {
       return QUrl::fromUserInput(str);
@@ -83,9 +87,11 @@ protected:
 private Q_SLOTS:
   void onLinkClicked( const QUrl & );
   void onPageReload();
+  void updateEditable(bool ok) { if(ok) page()->setContentEditable(_editable); }
 
 private:
   bool _interpretSelection;
+  bool _editable;
 };
 
 } // namespace QtCollider

--- a/SCClassLibrary/QtCollider/QWebView.sc
+++ b/SCClassLibrary/QtCollider/QWebView.sc
@@ -113,6 +113,12 @@ QWebView : QView {
     this.setProperty( \enterInterpretsSelection, bool );
   }
 
+	editable { ^this.getProperty( \editable ); }
+
+  editable_ { arg bool;
+    this.setProperty( \editable, bool );
+  }
+
   // Set a specific font family to be used in place of a CSS-specified generic font family.
   // The 'generic' argument must be one of the following symbols:
   // \standard, \fixed, \serif, \sansSerif, \cursive, \fantasy


### PR DESCRIPTION
SCWebView had this feature, but QWebView never has. It's not needed for help files, but this provides an easy way to edit examples in rich text files without having to write javascript.

Signed-off-by: Scott Wilson i@scottwilson.ca
