### PR TITLE
class library: allow NamedControl.new() to return non-arrayed Lag (fixing issue 973)

### DIFF
--- a/SCClassLibrary/Common/Control/GraphBuilder.sc
+++ b/SCClassLibrary/Common/Control/GraphBuilder.sc
@@ -148,7 +148,7 @@ NamedControl {
 		};
 
 		^if(lags.notNil) {
-			res.control.lag(lags.asArray).unbubble
+			res.control.lag(lags).unbubble
 		} {
 			res.control
 		}


### PR DESCRIPTION
See [this thread](http://new-supercollider-mailing-lists-forums-use-these.2681727.n2.nabble.com/Bug-with-Control-lag-and-Pan2-td7603440.html) for more details.  Basically, when using NamedControls with a single lag value in a SynthDef, the Control unexpectedly returns an array.

We should maybe wait to see if anyone on the list has any objections, or reasons why this fix could possibly be a bad idea.  I'm not an expert in this area by any means!  But I think it makes sense -- if the input is an Array of lag times, then an Array of Lags is returned.  If it's a single lag time, then a (non-array) Lag is returned.  Similar to what happens with the `value` argument for NamedControl.new().
