### PR TITLE
boost: fix build error with recent versions of glibc

### DIFF
--- a/external_libraries/boost/boost/cstdint.hpp
+++ b/external_libraries/boost/boost/cstdint.hpp
@@ -41,8 +41,10 @@
 // so we disable use of stdint.h when GLIBC does not define __GLIBC_HAVE_LONG_LONG.
 // See https://svn.boost.org/trac/boost/ticket/3548 and http://sources.redhat.com/bugzilla/show_bug.cgi?id=10990
 //
-#if defined(BOOST_HAS_STDINT_H) && (!defined(__GLIBC__) || defined(__GLIBC_HAVE_LONG_LONG))
-
+#if defined(BOOST_HAS_STDINT_H)                                 \
+    && (!defined(__GLIBC__)                                       \
+        || defined(__GLIBC_HAVE_LONG_LONG)                        \
+        || (defined(__GLIBC__) && ((__GLIBC__ > 2) || ((__GLIBC__ == 2) && (__GLIBC_MINOR__ >= 17)))))
 // The following #include is an implementation artifact; not part of interface.
 # ifdef __hpux
 // HP-UX has a vaguely nice <stdint.h> in a non-standard location


### PR DESCRIPTION
This fixes building with `gcc-4.8.2` and recent `glibc`.

Original patch is at https://svn.boost.org/trac/boost/changeset/84950.
