### PR TITLE
sc class library: SeqCollection.clump: fix clump, fixing #658

### DIFF
--- a/SCClassLibrary/Common/Collections/SequenceableCollection.sc
+++ b/SCClassLibrary/Common/Collections/SequenceableCollection.sc
@@ -359,9 +359,9 @@ SequenceableCollection : Collection {
 		var list = Array.new((this.size / groupSize).roundUp.asInteger);
 		var sublist = this.species.new(groupSize);
 		this.do({ arg item;
-			sublist.add(item);
+			sublist = sublist.add(item);
 			if (sublist.size >= groupSize, {
-				list.add(sublist);
+				list = list.add(sublist);
 				sublist = this.species.new(groupSize);
 			});
 		});


### PR DESCRIPTION
In clump, Collection.add was used without assigning the return
value back to the variable, resulting in a bug with a groupsize
of ca. 4.5
