### PR TITLE
Classlib: Patterns: Pbind-like patterns now processRest on array items

### DIFF
--- a/SCClassLibrary/Common/Streams/FilterPatterns.sc
+++ b/SCClassLibrary/Common/Streams/FilterPatterns.sc
@@ -578,7 +578,7 @@ Pbindf : FilterPattern {
 						^outevent
 					};
 					name.do { arg key, i;
-						outevent.put(key, streamout[i]);
+						outevent.put(key, streamout[i].processRest(outevent));
 					};
 				}{
 					outevent.put(name, streamout);

--- a/SCClassLibrary/Common/Streams/Patterns.sc
+++ b/SCClassLibrary/Common/Streams/Patterns.sc
@@ -368,7 +368,7 @@ Pbind : Pattern {
 						^inevent
 					};
 					name.do { arg key, i;
-						event.put(key, streamout[i]);
+						event.put(key, streamout[i].processRest(event));
 					};
 				}{
 					event.put(name, streamout);

--- a/SCClassLibrary/Common/Streams/PmonoStreams.sc
+++ b/SCClassLibrary/Common/Streams/PmonoStreams.sc
@@ -94,7 +94,7 @@ PmonoStream : Stream {
 			streamout = streampairs[i+1].next(event);
 			streamout ?? { ^false };
 			if (name.isSequenceableCollection) {
-				name.do { | n, i | event[n] = streamout[i] };
+				name.do { | n, i | event[n] = streamout[i].processRest(event) };
 			}{
 				event[name] = streamout;
 			};


### PR DESCRIPTION
This is only for use cases such as the following. If the pattern
returns an array in another context, processRest will not be called
on the items -- no efficiency cost *except* in this relatively rare
case.

Pbind([\key1, \key2], Pseq([[0, 1], [2, Rest(3)], [4, 5]], inf))