### PR TITLE
sclang: add terminal standalone option

### DIFF
--- a/include/lang/SC_LanguageClient.h
+++ b/include/lang/SC_LanguageClient.h
@@ -80,9 +80,9 @@ public:
 
 	// library startup/shutdown
 	bool isLibraryCompiled();
-	void compileLibrary();
+	void compileLibrary(bool standalone);
 	void shutdownLibrary();
-	void recompileLibrary();
+	void recompileLibrary(bool standalone);
 
 	// interpreter access
 	void lock();

--- a/lang/LangSource/PyrLexer.cpp
+++ b/lang/LangSource/PyrLexer.cpp
@@ -2108,7 +2108,7 @@ void shutdownLibrary()
 	SC_LanguageConfig::freeLibraryConfig();
 }
 
-SC_DLLEXPORT_C bool compileLibrary()
+SC_DLLEXPORT_C bool compileLibrary(bool standalone)
 {
 	//printf("->compileLibrary\n");
 	shutdownLibrary();
@@ -2117,7 +2117,7 @@ SC_DLLEXPORT_C bool compileLibrary()
 	gNumCompiledFiles = 0;
 	compiledOK = false;
 
-	SC_LanguageConfig::readLibraryConfig();
+	SC_LanguageConfig::readLibraryConfig(standalone);
 
 	compileStartTime = elapsedRealTime();
 

--- a/lang/LangSource/SCBase.h
+++ b/lang/LangSource/SCBase.h
@@ -57,7 +57,7 @@ SC_DLLEXPORT_C void schedRun();
 SC_DLLEXPORT_C void schedStop();
 SC_DLLEXPORT_C void schedClear();
 
-SC_DLLEXPORT_C bool compileLibrary();
+SC_DLLEXPORT_C bool compileLibrary(bool standalone);
 SC_DLLEXPORT_C void runLibrary(struct PyrSymbol* selector);
 SC_DLLEXPORT_C void runInterpreter(struct VMGlobals *g, struct PyrSymbol *selector, int numArgsPushed);
 

--- a/lang/LangSource/SC_LanguageClient.cpp
+++ b/lang/LangSource/SC_LanguageClient.cpp
@@ -147,9 +147,9 @@ void SC_LanguageClient::shutdownRuntime()
 #endif
 }
 
-void SC_LanguageClient::compileLibrary()
+void SC_LanguageClient::compileLibrary(bool standalone)
 {
-	::compileLibrary();
+	::compileLibrary(standalone);
 }
 
 extern void shutdownLibrary();
@@ -159,9 +159,9 @@ void SC_LanguageClient::shutdownLibrary()
 	flush();
 }
 
-void SC_LanguageClient::recompileLibrary()
+void SC_LanguageClient::recompileLibrary(bool standalone)
 {
-	compileLibrary();
+	compileLibrary(standalone);
 }
 
 void SC_LanguageClient::setCmdLine(const char* buf, size_t size)

--- a/lang/LangSource/SC_LanguageConfig.hpp
+++ b/lang/LangSource/SC_LanguageConfig.hpp
@@ -31,7 +31,7 @@ class SC_LanguageConfig
 {
 public:
 	typedef std::vector<std::string> DirVector;
-	SC_LanguageConfig();
+	SC_LanguageConfig(bool standalone);
 
 	const DirVector& includedDirectories() { return mIncludedDirectories; }
 	const DirVector& excludedDirectories() { return mExcludedDirectories; }
@@ -52,11 +52,11 @@ public:
 		gConfigFile = fileName;
 	}
 
-	static bool readLibraryConfigYAML(const char* fileName);
+	static bool readLibraryConfigYAML(const char* fileName, bool standalone);
 	static bool writeLibraryConfigYAML(const char* fileName);
 	static void freeLibraryConfig();
-	static bool defaultLibraryConfig(void);
-	static bool readLibraryConfig();
+	static bool defaultLibraryConfig(   bool standalone);
+	static bool readLibraryConfig(bool standalone);
 
 private:
 	DirVector mIncludedDirectories;

--- a/lang/LangSource/SC_TerminalClient.cpp
+++ b/lang/LangSource/SC_TerminalClient.cpp
@@ -117,7 +117,8 @@ void SC_TerminalClient::printUsage()
 			"   -r                             Call Main.run on startup\n"
 			"   -s                             Call Main.stop on shutdown\n"
 			"   -u <network-port-number>       Set UDP listening port (default %d)\n"
-			"   -i <ide-name>                  Specify IDE name (for enabling IDE-specific class code, default \"%s\")\n",
+			"   -i <ide-name>                  Specify IDE name (for enabling IDE-specific class code, default \"%s\")\n"
+			"   -a                             Standalone mode\n",
 			memGrowBuf,
 			memSpaceBuf,
 			opt.mPort,
@@ -127,7 +128,7 @@ void SC_TerminalClient::printUsage()
 
 bool SC_TerminalClient::parseOptions(int& argc, char**& argv, Options& opt)
 {
-	const char* optstr = ":d:Dg:hl:m:rsu:i:";
+	const char* optstr = ":d:Dg:hl:m:rsu:i:a";
 	int c;
 
 	// inhibit error reporting
@@ -178,6 +179,9 @@ bool SC_TerminalClient::parseOptions(int& argc, char**& argv, Options& opt)
 				break;
 			case 'i':
 				gIdeName = optarg;
+				break;
+			case 'a':
+				opt.mStandalone = true;
 				break;
 			default:
 				::post("%s: unknown error (getopt)\n", getName());
@@ -235,14 +239,13 @@ int SC_TerminalClient::run(int argc, char** argv)
 	// read library configuration file
 	if (opt.mLibraryConfigFile)
 		SC_LanguageConfig::setConfigFile(opt.mLibraryConfigFile);
-
-	SC_LanguageConfig::readLibraryConfig();
+	SC_LanguageConfig::readLibraryConfig(opt.mStandalone);
 
 	// initialize runtime
 	initRuntime(opt);
 
 	// startup library
-	compileLibrary();
+	compileLibrary(opt.mStandalone);
 
 	// enter main loop
 	if (codeFile) executeFile(codeFile);
@@ -268,6 +271,11 @@ int SC_TerminalClient::run(int argc, char** argv)
 	shutdownRuntime();
 
 	return mReturnCode;
+}
+
+void SC_TerminalClient::recompileLibrary()
+{
+    SC_LanguageClient::recompileLibrary(mOptions.mStandalone);
 }
 
 void SC_TerminalClient::quit(int code)

--- a/lang/LangSource/SC_TerminalClient.h
+++ b/lang/LangSource/SC_TerminalClient.h
@@ -66,6 +66,7 @@ public:
 			  mDaemon(false),
 			  mCallRun(false),
 			  mCallStop(false),
+			  mStandalone(false),
 			  mArgc(0), mArgv(0)
 		{ }
 
@@ -75,6 +76,7 @@ public:
 		bool			mCallStop;
 		int				mArgc;
 		char**			mArgv;
+		bool			mStandalone;
 	};
 
 	SC_TerminalClient(const char* name);
@@ -84,6 +86,7 @@ public:
 
 	int run(int argc, char** argv);
 	void quit(int code);
+	void recompileLibrary();
 
 	virtual void postText(const char* str, size_t len);
 	virtual void postFlush(const char* str, size_t len);


### PR DESCRIPTION
Add the option to tell sclang via command line option not to load any classes from the default locations in order to make it easier to make sclang based standalones

My c/c++ is very rusty, I'm not familiar with it's coding practices, and I'm not familiar with the sclang code base, so maybe the way I implemented this is not the right way to do it.  I'm also not 100% sure that change is not affecting normal supercollider use, although my intention was that if you don't pass the -a option to sclang everything should behave the same.

Running ./lang/sclang -a -l config.yaml with a yaml file pointing to a class library folder somewhere compiles the library fine and ignores everything in the default locations for extensions, etc. It also ignores the default location for a yaml file.

Also, I'm not sure if there are issues with indentation. My git gui program and Qt creator show the new code at the same indentation as the rest around it, but in github the indentation appears to be off. 
