### PR TITLE
sclang: Fixed bug where osc bundles were being chooped midway

### DIFF
--- a/SCClassLibrary/backwards_compatibility/extMethods.sc
+++ b/SCClassLibrary/backwards_compatibility/extMethods.sc
@@ -22,8 +22,7 @@
 	asOSCArgEmbeddedArray { | array|
 		array = array.add($[);
 		this.do{ | e | array = e.asOSCArgEmbeddedArray(array) };
-		array.add($]);
-		^array;
+		^array.add($])
 	}
 
 }


### PR DESCRIPTION
new synth messages with big argument lists were creating malformed osc messages. When these messages were passed to the server, it would hang in the case of sycynth and crash with a message about malformed osc message in the case of supernova.

```
This

[ 'minAmp', 1.0, 'maxAmp', 1.0, 'amp', 1.0, 'morphFactor', 1.0, 'ampEnv', [ 0, 2, -99, -99, 1, 1, 1, 0, 0, 1, 1, 0 ], 'u_startPos', 0, 'minTrigFreq', [ 0.88642584708624, 1, -99, -99, 0.88642584708624, 1, 5, 0 ], 'maxTrigFreq', [ 0.88642584708624, 1, -99, -99, 0.88642584708624, 1, 5, 0 ], 'minFreq', [ 0.39502600368025, 1, -99, -99, 0.39502600368025, 1, 5, 5 ], 'maxFreq', [ 0.39502600368025, 1, -99, -99, 0.39502600368025, 1, 5, 5 ], 'minAttT', [ 0, 2, -99, -99, 1, 1, 1, 0, 0, 1, 1, 0 ], 'maxAttT', [ 0, 2, -99, -99, 1, 1, 1, 0, 0, 1, 1, 0 ], 'minDecT', [ 0, 2, -99, -99, 1, 1, 1, 0, 0, 1, 1, 0 ], 'maxDecT', [ 0, 2, -99, -99, 1, 1, 1, 0, 0, 1, 1, 0 ] ].asOSCArgArray.asCompileString

was creating this !!

[ 'minAmp', 1.0, 'maxAmp', 1.0, 'amp', 1.0, 'morphFactor', 1.0, 'ampEnv', $[, 0, 2, -99, -99, 1, 1, 1, 0, 0, 1, 1, 0, $], 'u_startPos', 0, 'minTrigFreq', $[, 0.88642584708624, 1, -99, -99, 0.88642584708624, 1, 5, 0, $], 'maxTrigFreq', $[, 0.88642584708624, 1, -99, -99, 0.88642584708624, 1, 5, 0, $], 'minFreq', $[, 0.39502600368025, 1, -99, -99, 0.39502600368025, 1, 5, 5, $], 'maxFreq', $[, 0.39502600368025, 1, -99, -99, 0.39502600368025, 1, 5, 5, $], 'minAttT', $[, 0, 2, -99, -99, 1, 1, 1, 0, 0, 1, 1, 0, $], 'maxAttT', $[, 0, 2, -99, -99, 1, 1, 1, 0, 0, 1, 1, 0, $], 'minDecT', $[, 0, 2, -99, -99, 1, 1, 1, 0, 0, 1, 1, 0, $], 'maxDecT', $[, 0, 2, -99, -99, 1, 1, 1, 0, 0, 1, 1, 0 ]
```
