### PR TITLE
class library: Env#*step easier creation of step envelopes

### DIFF
--- a/HelpSource/Classes/Env.schelp
+++ b/HelpSource/Classes/Env.schelp
@@ -251,7 +251,38 @@ a.set(\gate, 0); // alternatively, you can write a.release;
 b.set(\gate, 0);
 ::
 
+method::step
+Creates a new envelope specification where all the segments are horizontal lines. Given n values of times only n levels need to be provided, corresponding to the fixed value of each segment.
 
+argument::levels
+an array of levels. Levels can be any UGen (new level values are updated only when the envelope has reached that point).
+When the array of levels contains itself an array, the envelope returns a multichannel output (for a discussion, see link::#multichannel expansion::)
+
+argument::times
+an array of durations of segments in seconds. It should be the same size as the levels array.
+
+argument::releaseNode
+an link::Classes/Integer:: or nil. The envelope will sustain at the release node until released.
+
+argument::loopNode
+an link::Classes/Integer:: or nil. If not nil the output will loop through those nodes startign at the loop node to the node immediately preceeding the release node, before back to the loop node, and so on. Note that the envelope only transitions to the release node when released. Examples are below. The loop is escaped when a gate signal is sent, when the output transitions to the release node, as described below.
+
+argument::offset
+an offset to all time values (only applies in link::Classes/IEnvGen::).
+
+discussion::
+code::
+(
+{
+	var env = Env.step([0.0, 0.5, 0.7, 1.0, 0.9, 0.0], [0.5, 0.1, 0.2, 1.0, 1.5,3]);
+	var envgen = EnvGen.ar(env, doneAction: 2);
+	SinOsc.ar(
+		envgen * 1000 + 440
+	) * envgen * 0.1
+}.play
+);
+
+::
 
 method::adsr
 Creates a new envelope specification which is shaped like traditional analog attack-decay-sustain-release (adsr) envelopes.

--- a/SCClassLibrary/Common/Audio/Env.sc
+++ b/SCClassLibrary/Common/Audio/Env.sc
@@ -157,6 +157,13 @@ Env {
 		^this.xyc(pairs +++ curve);
 	}
 
+	*step { |levels = #[0,1], times = #[1,1], releaseNode, loopNode, offset = 0|
+		if( levels.size != times.size ) {
+			Error("Env#*step : levels and times must have same size").throw
+		};
+		^Env([levels[0]]++levels, times, \step, releaseNode, loopNode, offset)
+	}
+
 	// envelopes with sustain
 
 	*cutoff { arg releaseTime = 0.1, level = 1.0, curve = \lin;


### PR DESCRIPTION
Simplifies the creation of envelopes that only contain \env segments, in which case only the same number of levels as times are needed in order to fully specify the envelope.

If this gets the go ahead I can add also a mention in Env.schelp to the pull request.
