### PR TITLE
Classlib: Change NetAddr's default port to nil

### DIFF
--- a/SCClassLibrary/Common/Control/NetAddr.sc
+++ b/SCClassLibrary/Common/Control/NetAddr.sc
@@ -1,17 +1,17 @@
 NetAddr {
-	var <addr=0, <>port=0, <hostname, <socket;
+	var <addr=0, <>port, <hostname, <socket;
 	classvar connections;
 
 	*initClass {
 		connections = IdentityDictionary.new;
 	}
 
-	*new { arg hostname, port=0;
+	*new { arg hostname, port;
 		var addr;
 		addr = if (hostname.notNil,{ hostname.gethostbyname },{ 0 });
 		^super.newCopyArgs(addr, port, hostname);
 	}
-	*fromIP { arg addr, port=0;
+	*fromIP { arg addr, port;
 		^super.newCopyArgs(addr, port, addr.asIPString)
 	}
 


### PR DESCRIPTION
This makes it easier to create a NetAddr to match any port from a given IP.
