### PR TITLE
Classlib: JIT: Improved handling of SimpleNumbers as sources in NodeProxy

### DIFF
--- a/SCClassLibrary/JITLib/ProxySpace/NodeProxy.sc
+++ b/SCClassLibrary/JITLib/ProxySpace/NodeProxy.sc
@@ -130,7 +130,7 @@ NodeProxy : BusPlug {
 		};
 
 		orderIndex = index ? 0;
-		container = obj.makeProxyControl(channelOffset, this);
+		container = obj.makeProxyControl(channelOffset, this, orderIndex);
 		if(container !== objects[orderIndex]) {
 			container.build(this, orderIndex); // bus allocation happens here
 

--- a/SCClassLibrary/JITLib/ProxySpace/ProxyInterfaces.sc
+++ b/SCClassLibrary/JITLib/ProxySpace/ProxyInterfaces.sc
@@ -333,13 +333,14 @@ SynthDefControl : SynthControl {
 }
 
 ScalarSynthControl : SynthDefControl {
-	*new { |source, channelOffset = 0, proxy|
-		var existing = proxy.objects[channelOffset];
+	*new { |source, channelOffset = 0, proxy, index(0)|
+		var existing = proxy.objects[index],
+		ctlName = ("value" ++ index).asSymbol;
 		if(existing.class !== this) {
-			proxy.nodeMap.set(\value, source);
+			proxy.nodeMap.set(ctlName, source);
 			^super.new(source, channelOffset, proxy)
 		} {
-			proxy.set(\value, source);
+			proxy.set(ctlName, source);
 			existing.source = source;
 			^existing
 		}

--- a/SCClassLibrary/JITLib/ProxySpace/wrapForNodeProxy.sc
+++ b/SCClassLibrary/JITLib/ProxySpace/wrapForNodeProxy.sc
@@ -14,8 +14,8 @@
 		^SynthDefControl
 	}
 
-	makeProxyControl { arg channelOffset = 0, proxy;
-		^this.proxyControlClass.new(this, channelOffset, proxy);
+	makeProxyControl { arg channelOffset = 0, proxy, index(0);
+		^this.proxyControlClass.new(this, channelOffset, proxy, index);
 	}
 
 
@@ -29,7 +29,7 @@
 		argNames = this.argNames;
 		^ProxySynthDef(
 			SystemSynthDefs.tempNamePrefix ++ proxy.generateUniqueName ++ index,
-			this.prepareForProxySynthDef(proxy),
+			this.prepareForProxySynthDef(proxy, channelOffset, index),
 			proxy.nodeMap.ratesFor(argNames),
 			nil,
 			true,
@@ -64,9 +64,9 @@
 + SimpleNumber {
 	proxyControlClass { ^ScalarSynthControl }
 
-	prepareForProxySynthDef { arg proxy;
+	prepareForProxySynthDef { arg proxy, channelOffset, index(0);
 		proxy.initBus(\control, 1);
-		^{ NamedControl(\value, this, proxy.rate, 0.05) }
+		^{ NamedControl(("value" ++ index).asSymbol, this, proxy.rate, 0.05) }
 	}
 }
 
@@ -83,9 +83,9 @@
 + RawArray {
 	proxyControlClass { ^ScalarSynthControl }
 
-	prepareForProxySynthDef { arg proxy;
+	prepareForProxySynthDef { arg proxy, channelOffset, index(0);
 		proxy.initBus(\control, this.size);
-		^{ NamedControl(\value, this, proxy.rate, 0.05) }
+		^{ NamedControl(("value" ++ index).asSymbol, this, proxy.rate, 0.05) }
 	}
 }
 


### PR DESCRIPTION
These patches change the behavior of numbers as NodeProxy sources.
- Old behavior: `np.source = 440` would create a `DC.kr` synth. Changing the source to another number would create another `DC.kr` synth, cross fading against the old one. If the source changes were rapid -- say, from a GUI -- you would get multiple cross fades overlapping and summing, producing large spikes in the value. (That's not to mention the inefficiency of creating a new SynthDef for every value.)
- New behavior: `np.source = 440` creates a synth with a NamedControl (in a new proxy interface class, ScalarSynthControl). Changing the source to another number first checks if the proxy interface is already a ScalarSynthControl. If yes, it just sets the control, no new synth.

I've been using this for a few weeks and it works well. RawArrays are also supported.

I did have to change some method signatures, to pass the proxy object and index into the proxy interfaces. There might be some disagreement about that. So my main reason to submit the pull request is to have a place to track the discussion.

I wouldn't mind a different implementation that gets the same result.
