### PR TITLE
sclang: add functionality of scp-ing SynthDef when it's too big to send over osc

### DIFF
--- a/SCClassLibrary/Common/Audio/SynthDef.sc
+++ b/SCClassLibrary/Common/Audio/SynthDef.sc
@@ -580,6 +580,7 @@ SynthDef {
 	}
 
 	doSend { |server, completionMsg|
+		var filename, options, command;
 		var bytes = this.asBytes;
 		if (bytes.size < (65535 div: 4)) {
 			server.sendMsg("/d_recv", bytes, completionMsg)
@@ -589,7 +590,22 @@ SynthDef {
 				this.writeDefFile(synthDefDir);
 				server.sendMsg("/d_load", synthDefDir ++ name ++ ".scsyndef", completionMsg)
 			} {
-				"SynthDef % too big for sending.".format(name).warn;
+				options = server.options;
+				if( options.sshSynthDefs and: { options.sshRemoteSynthDefDir.notNil }
+					and: { options.sshUser.notNil } ) {
+					"SynthDef % too big for sending. Retrying by scp-ing synthdef file".format(name).warn;
+					this.writeDefFile(synthDefDir);
+					filename = name ++ ".scsyndef";
+					command = "scp % %@%:%".format(synthDefDir ++ filename, options.sshUser,
+						server.addr.ip, options.sshRemoteSynthDefDir.shellQuote);
+					if( command.systemCmd == 0 ) {
+						server.sendMsg("/d_load", (options.sshRemoteSynthDefDir++filename).shellQuote, completionMsg)
+					} {
+						"scp command failed:\n%".format(command).postln
+					}
+				} {
+					"SynthDef % too big for sending.".format(name).warn;
+				}
 			}
 		}
 	}

--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -28,6 +28,9 @@ ServerOptions
 
 	var <>verbosity = 0;
 	var <>zeroConf = false; // Whether server publishes port to Bonjour, etc.
+	var <>sshSynthDefs = false;
+	var <>sshRemoteSynthDefDir;
+	var <>sshUser;
 
 	var <>restrictedPath = nil;
 	var <>ugenPluginsPath = nil;


### PR DESCRIPTION
When working with a server on a remote machine one can't send big synthdefs over osc.  This patch allows to bypass that limitation by scp-ing the synthdef file over to the remote machine.  ssh must be properly configured with ssh keys installed so that no password is needed. Note that remote folder paths with spaces must be properly escapped.

Example usage:

```
Server.default = s = Server("remote", NetAddr("143.117.78.26",57110));

s.options.sshSynthDefs = true;
s.options.sshUser = "mnegrao";
s.options.sshRemoteSynthDefDir = "Library/Application\\ Support/SuperCollider/synthdefs/"

s.makeWindow
s.initTree

SynthDef(\aaabbbccc, { 1000.collect{ Saw.ar(100) }.sum }).add
Synth(\aaabbbccc)
s.freeAll
```

Note that paths on the remote directory have to be escaped.