### PR TITLE
Classlib: fixed PatternProxy constrainStream so defaultQuant works

### DIFF
--- a/SCClassLibrary/JITLib/Patterns/Pdef.sc
+++ b/SCClassLibrary/JITLib/Patterns/Pdef.sc
@@ -23,8 +23,8 @@ PatternProxy : Pattern {
 	quant_ { arg val; quant = val }
 
 	constrainStream { arg stream;
-		if(quant.isNil or: { stream.isNil }) { ^pattern.asStream };
-		^Pseq([PfinQuant(EmbedOnce(stream), quant, clock), pattern]).asStream
+		if(this.quant.isNil or: { stream.isNil }) { ^pattern.asStream };
+		^Pseq([PfinQuant(EmbedOnce(stream), this.quant, clock), pattern]).asStream
 	}
 
 	source_ { arg obj;


### PR DESCRIPTION
Julian and I had a discussion about this on sc-users so I thought I'd turn it into a commit/push/pull.  Thanks Julian for the quick fix!  

// before the change:
Pdefn.defaultQuant = 4;
Pbindef(\x,\midinote,Pdefn(\m));
Pbindef(\x,\delta,0.5).play(quant:4);
Pdefn(\m,Pseq([60,62,64,65,67,65,64,62],inf)+12.rand);
// despite defaultQuant, every re-eval of line above takes effect immediately?
