### PR TITLE
Fix NRT file paths

### DIFF
--- a/SCClassLibrary/Common/Control/Score.sc
+++ b/SCClassLibrary/Common/Control/Score.sc
@@ -99,7 +99,7 @@ Score {
 	recordNRT { arg oscFilePath, outputFilePath, inputFilePath, sampleRate = 44100, headerFormat =
 		"AIFF", sampleFormat = "int16", options, completionString="", duration = nil, action = nil;
 		if(oscFilePath.isNil) {
-			oscFilePath = PathName.tmp +/+ "temp_oscscore%" ++ UniqueID.next;
+			oscFilePath = PathName.tmp +/+ "temp_oscscore" ++ UniqueID.next;
 		};
 		this.writeOSCFile(oscFilePath, 0, duration);
 		unixCmd(program + " -N" + oscFilePath.quote

--- a/SCClassLibrary/Common/Control/asScore/asScore.sc
+++ b/SCClassLibrary/Common/Control/asScore/asScore.sc
@@ -14,7 +14,7 @@
 			headerFormat = "AIFF", sampleFormat = "int16", options, inputFilePath, action;
 
 		var file, oscFilePath, score;
-		oscFilePath = PathName.tmp +/+ "temp_oscscore%" ++ UniqueID.next;
+		oscFilePath = PathName.tmp +/+ "temp_oscscore" ++ UniqueID.next;
 		score = this.asScore(maxTime);
 		score.recordNRT(
 			oscFilePath, path, inputFilePath, sampleRate, headerFormat, sampleFormat,


### PR DESCRIPTION
Addresses:
- Score:recordNRT forced the user to generate her own osc file path, which is a pointless inconvenience. (A further refinement here would be to delete the temp file automatically.)
- Object:render used a relative path for the osc score file, relying on sclang's working directory to be sensible. That was never safe.
- Score threw confusing errors if it was unable to write a file. Now it will throw proper, descriptive errors.
