### PR TITLE
Help: Fix envelope handling in a pattern-cookbook example

### DIFF
--- a/HelpSource/Tutorials/A-Practical-Guide/PG_Cookbook01_Basic_Sequencing.schelp
+++ b/HelpSource/Tutorials/A-Practical-Guide/PG_Cookbook01_Basic_Sequencing.schelp
@@ -82,11 +82,11 @@ code::
 b = Buffer.read(s, Platform.resourceDir +/+ "sounds/a11wlk01.wav");
 
 SynthDef(\stretchedFragments, { |out, bufnum, start, time = 1, stretch = 1, amp = 1, attack = 0.01, decay = 0.05|
-	var	sig = PlayBuf.ar(1, bufnum, rate: stretch.reciprocal, startPos: start, doneAction:2);
-	sig = PitchShift.ar(sig, pitchRatio: stretch)
-		* EnvGen.kr(Env.linen(attack, time, decay), doneAction: 2);
-	Out.ar(out, sig ! 2)
-}).add;	// note add! Without this, arguments won't work
+	var sig = PlayBuf.ar(1, bufnum, rate: stretch.reciprocal, startPos: start), eg;
+	sig = PitchShift.ar(sig, pitchRatio: stretch);
+	eg = EnvGen.kr(Env.linen(attack, time, decay), sig.abs > 0, doneAction: 2);
+	Out.ar(out, (sig * eg) ! 2)
+}).add; // note add! Without this, arguments won't work
 )
 
 (


### PR DESCRIPTION
Addresses an issue raised on sc-users, in which it seemed that increasing the envelope's attack time had no effect, because of PitchShift's inherent delay. Solution: Use PitchShift itself to trigger the envelope's onset.
