### PR TITLE
Classlib: GUI: Reinstate proper functioning of ObjectGui system

### DIFF
--- a/SCClassLibrary/Common/GUI/tools/guicrucial/gui.sc
+++ b/SCClassLibrary/Common/GUI/tools/guicrucial/gui.sc
@@ -2,7 +2,7 @@
 + Object {
 
 	gui { arg parent,bounds ... args;
-		^ObjectGui.new(this, parent, bounds, *args);
+		^this.guiClass.new(this).performList(\gui,[parent,bounds] ++ args);
 	}
 	guiClass { ^ObjectGui }
 }


### PR DESCRIPTION
Patched by James Harkins jamshark70@dewdrop-world.net

Object:gui _should_ look up the implementing class by the method
'guiClass'. Commit 019586cb0ba20d7c9d851e2449dac7911bbb0952 improperly
removed this and hardcoded ObjectGui instead -- thus breaking every
class that implements 'guiClass' but not 'gui'.

The crucial GUIs are not Qt views. They are more like Controllers
in MVC. 'guiClass' here was never a redirect and it shouldn't have
been touched.
