### PR TITLE
Classlib: Server.sc: Prevent an inadvertent "non-inlined function" warning

### DIFF
--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -796,10 +796,8 @@ Server {
 		if(userSpecifiedClientID.not , {
 			doneOSCFunc = OSCFunc({|msg|
 				if(flag && { msg[2] != clientID }, {
-					var newID;
-					newID = msg[2];
-					if(newID.notNil, {
-						clientID = newID;
+					if(msg[2].notNil, {
+						clientID = msg[2];
 						this.newAllocators;
 					})
 				});


### PR DESCRIPTION
Long running pet peeve of mine... IMO, no code should ever go into the main class library that triggers non-inlined function warnings, unless there is _absolutely_ no other way to handle it. The variable declaration is 100% superfluous in this case.
