### PR TITLE
Classlib: SystemSynthDefs: Remove postln that shouldn't have been committed

### DIFF
--- a/SCClassLibrary/Common/Audio/SystemSynthDefs.sc
+++ b/SCClassLibrary/Common/Audio/SystemSynthDefs.sc
@@ -18,7 +18,7 @@ SystemSynthDefs {
 
 			// clean up any written synthdefs starting with "temp__"
 			var path = SynthDef.synthDefDir ++ tempNamePrefix ++ "*";
-			if(pathMatch(path).notEmpty) { unixCmd(("rm -f" + "'" ++ path ++ "'").postln )};
+			if(pathMatch(path).notEmpty) { unixCmd("rm -f" + "'" ++ path ++ "'") };
 
 			// add system synth defs
 			(1..numChannels).do { arg i;


### PR DESCRIPTION
As a general principle, debugging posts should be removed before checking code in.
