### PR TITLE
ClassLib: SimpleNumber: biexp return calculated value

### DIFF
--- a/SCClassLibrary/Common/Math/SimpleNumber.sc
+++ b/SCClassLibrary/Common/Math/SimpleNumber.sc
@@ -307,7 +307,7 @@ SimpleNumber : Number {
 				if (this >= inMax, { ^outMax });
 			}
 		);
-		if (this >= inCenter) {
+		^if (this >= inCenter) {
 			this.explin(inCenter, inMax, outCenter, outMax, \none);
 		} {
 			this.explin(inMin, inCenter, outMin, outCenter, \none);


### PR DESCRIPTION
SimpleNumber#biexp does not return calculated value. I fixed it.
