### PR TITLE
Initialize openPorts variable before startup.scd file is executed.

### DIFF
--- a/SCClassLibrary/DefaultLibrary/Main.sc
+++ b/SCClassLibrary/DefaultLibrary/Main.sc
@@ -20,8 +20,8 @@ Main : Process {
 		interpreter.s = Server.default;
 		GUI.fromID( this.platform.defaultGUIScheme );
 		GeneralHID.fromID( this.platform.defaultHIDScheme );
-		this.platform.startup;
 		openPorts = Set[NetAddr.langPort];
+		this.platform.startup;
 		StartUp.run;
 
 		("Welcome to SuperCollider %.".format(Main.version)


### PR DESCRIPTION
This change makes opening ports (using OSCdef or OSCfunc) in
startup.scd possible.
