### PR TITLE
sclang: fix float radix with pi

### DIFF
--- a/lang/LangSource/PyrLexer.cpp
+++ b/lang/LangSource/PyrLexer.cpp
@@ -1075,7 +1075,7 @@ int processfloatradix(char *s, int n, int radix)
 	SetFloat(&slot, sc_strtof(s, n, radix));
 	node = newPyrSlotNode(&slot);
 	zzval = (long)node;
-	return INTEGER;
+	return SC_FLOAT;
 }
 
 int processint(char *s)


### PR DESCRIPTION
``` supercollider
10r1.0pi // 0 (bug) -> 3.141592...(fixed)
```
