### PR TITLE
sclang: fix accidental number literal

### DIFF
--- a/lang/LangSource/PyrLexer.cpp
+++ b/lang/LangSource/PyrLexer.cpp
@@ -1187,6 +1187,7 @@ int processaccidental2(char *s)
 	}
 
 	if (semitones > 4.) semitones = 4.;
+	else if (semitones < -4.) semitones = -4.;
 
 	SetFloat(&slot, degree + semitones/10.);
 	node = newPyrSlotNode(&slot);


### PR DESCRIPTION
before

```
69ssssss // 69.4 ('s' is applied 4 times)
69bbbbbb // 68.4 ('b' is applied limitless)
```

fixed

```
69ssssss // 69.4 ('s' is applied 4 times)
69bbbbbb // 68.6 ('b' is applied 4 times)
```
