### PR TITLE
ide: add show/hide line number feature

### DIFF
--- a/editors/sc-ide/widgets/code_editor/editor.cpp
+++ b/editors/sc-ide/widgets/code_editor/editor.cpp
@@ -103,7 +103,6 @@ GenericCodeEditor::GenericCodeEditor( Document *doc, QWidget *parent ):
     QTextDocument *tdoc = doc->textDocument();
     QPlainTextEdit::setDocument(tdoc);
     onDocumentFontChanged();
-    mLineIndicator->setLineCount(blockCount());
 
     applySettings( Main::settings() );
 }
@@ -114,6 +113,7 @@ void GenericCodeEditor::applySettings( Settings::Manager *settings )
 
     bool lineWrap = settings->value("lineWrap").toBool();
     bool showWhitespace = settings->value("showWhitespace").toBool();
+    bool showLinenumber = settings->value("showLinenumber").toBool();
     mInactiveFadeAlpha = settings->value("inactiveEditorFadeAlpha").toInt();
 
     QPalette palette;
@@ -163,6 +163,8 @@ void GenericCodeEditor::applySettings( Settings::Manager *settings )
 
     setLineWrapMode( lineWrap ? QPlainTextEdit::WidgetWidth : QPlainTextEdit::NoWrap );
     setShowWhitespace( showWhitespace );
+    setShowLinenumber( showLinenumber );
+    mLineIndicator->setLineCount(blockCount());
     setPalette(palette);
     
     setActiveAppearance(hasFocus());
@@ -183,6 +185,11 @@ void GenericCodeEditor::setShowWhitespace(bool show)
     else
         opt.setFlags( opt.flags() & ~QTextOption::ShowTabsAndSpaces );
     doc->setDefaultTextOption(opt);
+}
+
+void GenericCodeEditor::setShowLinenumber(bool show)
+{
+    mLineIndicator->setHideLineIndicator( !show );
 }
 
 static bool findInBlock(QTextDocument *doc, const QTextBlock &block, const QRegExp &expr, int offset,

--- a/editors/sc-ide/widgets/code_editor/editor.hpp
+++ b/editors/sc-ide/widgets/code_editor/editor.hpp
@@ -46,6 +46,7 @@ public:
     QTextDocument *textDocument() { return QPlainTextEdit::document(); }
     void setDocument( Document * );
     bool showWhitespace();
+    bool showLinenumber();
     bool find( const QRegExp &expr, QTextDocument::FindFlags options = 0);
     bool replace( const QRegExp &expr, const QString &replacement, QTextDocument::FindFlags options = 0);
     int findAll( const QRegExp &expr, QTextDocument::FindFlags options = 0 );
@@ -78,6 +79,7 @@ public slots:
     void zoomOut(int steps = 1);
     void resetFontSize();
     void setShowWhitespace(bool);
+    void setShowLinenumber(bool);
     void clearSearchHighlighting();
     void toggleOverwriteMode();
     void copyLineUp();

--- a/editors/sc-ide/widgets/code_editor/line_indicator.cpp
+++ b/editors/sc-ide/widgets/code_editor/line_indicator.cpp
@@ -84,11 +84,20 @@ void LineIndicator::mouseDoubleClickEvent( QMouseEvent *e )
 int LineIndicator::widthForLineCount( int lineCount )
 {
     int digits = 2;
+
+    if (hideLineIndicator)
+	return 0;
+
     while( lineCount >= 100 ) {
         lineCount /= 10;
         ++digits;
     }
 
     return 6 + fontMetrics().width('9') * digits;
+}
+
+void LineIndicator::setHideLineIndicator( bool hide )
+{
+	hideLineIndicator = hide;
 }
 

--- a/editors/sc-ide/widgets/code_editor/line_indicator.hpp
+++ b/editors/sc-ide/widgets/code_editor/line_indicator.hpp
@@ -31,6 +31,7 @@ class LineIndicator : public QWidget
 
 public:
     LineIndicator( class GenericCodeEditor *editor );
+    void setHideLineIndicator( bool hide);
 Q_SIGNALS:
     void widthChanged();
 public Q_SLOTS:
@@ -47,6 +48,7 @@ private:
     class GenericCodeEditor *mEditor;
     int mLineCount;
     int mLastCursorPos;
+    bool hideLineIndicator;
 };
 
 }

--- a/editors/sc-ide/widgets/main_window.cpp
+++ b/editors/sc-ide/widgets/main_window.cpp
@@ -610,6 +610,7 @@ void MainWindow::createMenus()
     menu->addAction( mEditors->action(MultiEditor::ResetFontSize) );
     menu->addSeparator();
     menu->addAction( mEditors->action(MultiEditor::ShowWhitespace) );
+    menu->addAction( mEditors->action(MultiEditor::ShowLinenumber) );
     menu->addSeparator();
     menu->addAction( mEditors->action(MultiEditor::NextDocument) );
     menu->addAction( mEditors->action(MultiEditor::PreviousDocument) );

--- a/editors/sc-ide/widgets/multi_editor.cpp
+++ b/editors/sc-ide/widgets/multi_editor.cpp
@@ -484,6 +484,12 @@ void MultiEditor::createActions()
     connect(action, SIGNAL(triggered(bool)), this, SLOT(setShowWhitespace(bool)));
     settings->addAction( action, "editor-toggle-show-whitespace", editorCategory);
 
+    mActions[ShowLinenumber] = action = new QAction(tr("Show Line Number"), this);
+    action->setCheckable(true);
+    action->setShortcutContext(Qt::WidgetWithChildrenShortcut);
+    connect(action, SIGNAL(triggered(bool)), this, SLOT(setShowLinenumber(bool)));
+    settings->addAction( action, "editor-toggle-show-line-number", editorCategory);
+
     mActions[IndentWithSpaces] = action = new QAction(tr("Use Spaces for Indentation"), this);
     action->setCheckable(true);
     action->setStatusTip( tr("Indent with spaces instead of tabs") );
@@ -582,6 +588,7 @@ void MultiEditor::createActions()
     addAction(mActions[EnlargeFont]);
     addAction(mActions[ShrinkFont]);
     addAction(mActions[ShowWhitespace]);
+    addAction(mActions[ShowLinenumber]);
     addAction(mActions[IndentWithSpaces]);
     addAction(mActions[EvaluateCurrentDocument]);
     addAction(mActions[EvaluateRegion]);
@@ -646,7 +653,9 @@ void MultiEditor::updateActions()
 void MultiEditor::applySettings( Settings::Manager * settings )
 {
     bool show_whitespace = settings->value("IDE/editor/showWhitespace").toBool();
+    bool show_linenumber = settings->value("IDE/editor/showLinenumber").toBool();
     mActions[ShowWhitespace]->setChecked( show_whitespace );
+    mActions[ShowLinenumber]->setChecked( show_linenumber );
 }
 
 static QVariantList saveBoxState( CodeEditorBox *box, const QList<Document*> & documentList )
@@ -1089,6 +1098,12 @@ void MultiEditor::removeAllSplits()
 void MultiEditor::setShowWhitespace(bool showWhitespace)
 {
     Main::settings()->setValue("IDE/editor/showWhitespace", showWhitespace);
+    Main::instance()->applySettings();
+}
+
+void MultiEditor::setShowLinenumber(bool showLinenumber)
+{
+    Main::settings()->setValue("IDE/editor/showLinenumber", showLinenumber);
     Main::instance()->applySettings();
 }
 

--- a/editors/sc-ide/widgets/multi_editor.hpp
+++ b/editors/sc-ide/widgets/multi_editor.hpp
@@ -89,6 +89,7 @@ public:
         ShrinkFont,
         ResetFontSize,
         ShowWhitespace,
+	ShowLinenumber,
         IndentWithSpaces,
 
         NextDocument,
@@ -141,6 +142,7 @@ public slots:
     void removeAllSplits();
 
     void setShowWhitespace(bool on);
+    void setShowLinenumber(bool on);
 
 private slots:
     void applySettings( Settings::Manager * );


### PR DESCRIPTION
This patch brings the ability to hide line numbering into sc-ide. See the following enhancement request : https://github.com/supercollider/supercollider/issues/585
