### PR TITLE
[patch v2] ide: add hide line number feature

### DIFF
--- a/editors/sc-ide/core/settings/manager.cpp
+++ b/editors/sc-ide/core/settings/manager.cpp
@@ -61,6 +61,7 @@ void Manager::initDefaults()
     setDefault("highlightBracketContents", true);
     setDefault("inactiveEditorFadeAlpha", 64);
     setDefault("insertMatchingTokens", false);
+    setDefault("showLinenumber", true);
 
     setDefault("blinkDuration", 600);
 

--- a/editors/sc-ide/forms/settings_editor.ui
+++ b/editors/sc-ide/forms/settings_editor.ui
@@ -233,6 +233,13 @@
          </widget>
         </item>
         <item>
+         <widget class="QCheckBox" name="showLinenumber">
+          <property name="text">
+           <string>Show line number</string>
+          </property>
+         </widget>
+        </item>
+        <item>
          <layout class="QHBoxLayout" name="horizontalLayout_3">
           <item>
            <widget class="QLabel" name="label_12">

--- a/editors/sc-ide/widgets/code_editor/editor.cpp
+++ b/editors/sc-ide/widgets/code_editor/editor.cpp
@@ -103,7 +103,6 @@ GenericCodeEditor::GenericCodeEditor( Document *doc, QWidget *parent ):
     QTextDocument *tdoc = doc->textDocument();
     QPlainTextEdit::setDocument(tdoc);
     onDocumentFontChanged();
-    mLineIndicator->setLineCount(blockCount());
 
     applySettings( Main::settings() );
 }
@@ -114,6 +113,7 @@ void GenericCodeEditor::applySettings( Settings::Manager *settings )
 
     bool lineWrap = settings->value("lineWrap").toBool();
     bool showWhitespace = settings->value("showWhitespace").toBool();
+    bool showLinenumber = settings->value("showLinenumber").toBool();
     mInactiveFadeAlpha = settings->value("inactiveEditorFadeAlpha").toInt();
 
     QPalette palette;
@@ -163,6 +163,8 @@ void GenericCodeEditor::applySettings( Settings::Manager *settings )
 
     setLineWrapMode( lineWrap ? QPlainTextEdit::WidgetWidth : QPlainTextEdit::NoWrap );
     setShowWhitespace( showWhitespace );
+    setShowLinenumber( showLinenumber );
+    mLineIndicator->setLineCount(blockCount());
     setPalette(palette);
     
     setActiveAppearance(hasFocus());
@@ -183,6 +185,11 @@ void GenericCodeEditor::setShowWhitespace(bool show)
     else
         opt.setFlags( opt.flags() & ~QTextOption::ShowTabsAndSpaces );
     doc->setDefaultTextOption(opt);
+}
+
+void GenericCodeEditor::setShowLinenumber(bool show)
+{
+    mLineIndicator->setHideLineIndicator( !show );
 }
 
 static bool findInBlock(QTextDocument *doc, const QTextBlock &block, const QRegExp &expr, int offset,

--- a/editors/sc-ide/widgets/code_editor/editor.hpp
+++ b/editors/sc-ide/widgets/code_editor/editor.hpp
@@ -46,6 +46,8 @@ public:
     QTextDocument *textDocument() { return QPlainTextEdit::document(); }
     void setDocument( Document * );
     bool showWhitespace();
+    bool showLinenumber();
+    void setShowLinenumber(bool);
     bool find( const QRegExp &expr, QTextDocument::FindFlags options = 0);
     bool replace( const QRegExp &expr, const QString &replacement, QTextDocument::FindFlags options = 0);
     int findAll( const QRegExp &expr, QTextDocument::FindFlags options = 0 );

--- a/editors/sc-ide/widgets/code_editor/line_indicator.cpp
+++ b/editors/sc-ide/widgets/code_editor/line_indicator.cpp
@@ -84,11 +84,20 @@ void LineIndicator::mouseDoubleClickEvent( QMouseEvent *e )
 int LineIndicator::widthForLineCount( int lineCount )
 {
     int digits = 2;
+
+    if (hideLineIndicator)
+        return 0;
+
     while( lineCount >= 100 ) {
         lineCount /= 10;
         ++digits;
     }
 
     return 6 + fontMetrics().width('9') * digits;
+}
+
+void LineIndicator::setHideLineIndicator( bool hide )
+{
+    hideLineIndicator = hide;
 }
 

--- a/editors/sc-ide/widgets/code_editor/line_indicator.hpp
+++ b/editors/sc-ide/widgets/code_editor/line_indicator.hpp
@@ -31,6 +31,7 @@ class LineIndicator : public QWidget
 
 public:
     LineIndicator( class GenericCodeEditor *editor );
+    void setHideLineIndicator( bool hide);
 Q_SIGNALS:
     void widthChanged();
 public Q_SLOTS:
@@ -47,6 +48,7 @@ private:
     class GenericCodeEditor *mEditor;
     int mLineCount;
     int mLastCursorPos;
+    bool hideLineIndicator;
 };
 
 }

--- a/editors/sc-ide/widgets/settings/editor_page.cpp
+++ b/editors/sc-ide/widgets/settings/editor_page.cpp
@@ -86,6 +86,7 @@ void EditorPage::load( Manager *s )
     ui->highlightCurrentLine->setChecked( s->value("highlightCurrentLine").toBool() );
     ui->highlightBracketContents->setChecked( s->value("highlightBracketContents").toBool() );
     ui->inactiveEditorFadeAlpha->setValue( s->value("inactiveEditorFadeAlpha").toInt() );
+    ui->showLinenumber->setChecked( s->value("showLinenumber").toBool() );
 
     s->beginGroup("font");
     QString fontFamily = s->value("family").toString();
@@ -230,6 +231,7 @@ void EditorPage::store( Manager *s )
     s->setValue("highlightCurrentLine", ui->highlightCurrentLine->isChecked());
     s->setValue("highlightBracketContents", ui->highlightBracketContents->isChecked());
     s->setValue("inactiveEditorFadeAlpha", ui->inactiveEditorFadeAlpha->value());
+    s->setValue("showLinenumber", ui->showLinenumber->isChecked());
 
     s->setValue("blinkDuration", ui->blinkDuration->value());
 


### PR DESCRIPTION
This feature is available into the editor/display section of the
preference dialog.

This is the second version of this following pull request: https://github.com/supercollider/supercollider/pull/1121

changelog since v1:
- use spaces and no tabs
- set show line number as default value
- access the feature using the preferences dialog instead of the menu bar
