### PR TITLE
File.schelp: changed pathnames to fully qualified

### DIFF
--- a/HelpSource/Classes/File.schelp
+++ b/HelpSource/Classes/File.schelp
@@ -131,33 +131,33 @@ code::
 // write some string to a file:
 (
 var f, g;
-f = File("test","w");
+f = File("~/test.txt".standardizePath,"w");
 f.write("Does this work?\n is this thing on ?\n");
 f.close;
 )
 
 // read it again:
 (
-g = File("test","r");
+g = File("~/test.txt".standardizePath,"r");
 g.readAllString.postln;
 g.close;
 )
 
 // try the above with File.use:
 
-File.use("test", "w", { |f| f.write("Doesn't this work?\n is this thing really on ?\n"); });
-File.use("test", "r", { |f| f.readAllString.postln });
+File.use("~/test.txt".standardizePath, "w", { |f| f.write("Doesn't this work?\n is this thing really on ?\n"); });
+File.use("~/test.txt".standardizePath, "r", { |f| f.readAllString.postln });
 
 
 // more file writing/reading examples:
 (
 var h, k;
-h = File("test2", "wb");
+h = File("~/test.dat".standardizePath, "wb");
 h.inspect;
 h.write( FloatArray[1.1, 2.2, 3.3, pi, 3.sqrt] );
 h.close;
 
-k = File("test2", "rb");
+k = File("~/test.dat".standardizePath, "rb");
 (k.length div: 4).do({ k.getFloat.postln; });
 k.close;
 )
@@ -165,15 +165,15 @@ k.close;
 
 (
 var f, g;
-f = File("test3","w");
+f = File("~/test.txt".standardizePath,"w");
 100.do({ f.putChar([$a, $b, $c, $d, $e, $\n].choose); });
 f.close;
 
-g = File("test3","r");
+g = File("~/test.txt".standardizePath,"r");
 g.readAllString.postln;
 g.close;
 
-g = File("test3","r");
+g = File("~/test.txt".standardizePath,"r");
 g.getLine(1024).postln;
 "*".postln;
 g.getLine(1024).postln;
@@ -187,14 +187,14 @@ g.close;
 
 (
 //var f, g;
-f = File("test3","wb");
+f = File("~/test.dat".standardizePath,"wb");
 f.inspect;
 100.do({ f.putFloat(1.0.rand); });
 
 f.inspect;
 f.close;
 
-g = File("test3","rb");
+g = File("~/test.dat".standardizePath,"rb");
 100.do({
 	g.getFloat.postln;
 });
@@ -204,9 +204,8 @@ g.close;
 
 (
 //var f, g;
-f = File("test3","r");
+f = File("~/test.dat".standardizePath,"r");
 f.inspect;
-f.getLine(1024).postln;
 f.close;
 )
 ::


### PR DESCRIPTION
through the use of .standardizePath
removed f.getline(1024).postln in last example

see: http://new-supercollider-mailing-lists-forums-use-these.2681727.n2.nabble.com/File-examples-fail-tp7611446.html
