### PR TITLE
Colorize lines in the post window.

### DIFF
--- a/SCClassLibrary/Common/Core/Kernel.sc
+++ b/SCClassLibrary/Common/Core/Kernel.sc
@@ -566,7 +566,7 @@ Interpreter {
 		res = func.value;
 		thisProcess.nowExecutingPath = nil;
 		codeDump.value(code, res, func, this);
-		res.postln;
+		("-> " ++ res).postln;
 	}
 
 	interpret { arg string ... args;

--- a/editors/sc-ide/core/settings/manager.cpp
+++ b/editors/sc-ide/core/settings/manager.cpp
@@ -146,6 +146,14 @@ void Manager::initHighlightingDefaults()
     setDefault( "char", makeHlFormat( QColor(0,115,0).lighter(shade) ) );
     setDefault( "comment", makeHlFormat( QColor(191,0,0).lighter(shade) ) );
     setDefault( "primitive", makeHlFormat( QColor(51,51,191).lighter(shade) ) );
+    
+    setDefault("postwindowerror", makeHlFormat(QColor(209, 28, 36)));
+    setDefault("postwindowwarning", makeHlFormat(QColor(165, 119, 6)));
+    setDefault("postwindowsuccess", makeHlFormat(QColor(115, 138, 5)));
+    
+    QTextCharFormat emphasisFormat;
+    emphasisFormat.setFontWeight(QFont::Bold);
+    setDefault("postwindowemphasis", QVariant::fromValue(emphasisFormat));
 }
 
 bool Manager::contains ( const QString & key ) const

--- a/editors/sc-ide/widgets/post_window.hpp
+++ b/editors/sc-ide/widgets/post_window.hpp
@@ -91,6 +91,7 @@ private:
     void createActions( Settings::Manager * );
     void updateActionShortcuts( Settings::Manager * );
     void zoomFont(int steps);
+    QTextCharFormat formatForPostLine(QStringRef line);
 
     QAction * mActions[ActionCount];
     /*

--- a/editors/sc-ide/widgets/settings/editor_page.cpp
+++ b/editors/sc-ide/widgets/settings/editor_page.cpp
@@ -163,6 +163,14 @@ void EditorPage::loadGeneralTextFormats( Manager *settings )
     addTextFormat( mGeneralFormatsItem, tr("Selected Text"), "selection",
                    settings->value( "selection" ).value<QTextCharFormat>(),
                    selectionDefaultFormat );
+    
+    QTextCharFormat postWindowDefaultFormat;
+    postWindowDefaultFormat.setBackground( palette.brush(QPalette::Mid) );
+    postWindowDefaultFormat.setForeground( palette.brush(QPalette::ButtonText) );
+    
+    addTextFormat( mGeneralFormatsItem, tr("Post Window Text"), "postwindowtext",
+                  settings->value( "postwindowtext" ).value<QTextCharFormat>(),
+                  postWindowDefaultFormat );
 
     static char const * const keys[] = {
         "currentLine", "searchResult", "matchingBrackets", "mismatchedBrackets", "evaluatedCode"
@@ -170,7 +178,8 @@ void EditorPage::loadGeneralTextFormats( Manager *settings )
 
     static QStringList strings = QStringList()
             << tr("Current Line") << tr("Search Result") << tr("Matching Brackets")
-            << tr("Mismatched Brackets") << tr("Evaluated Code");
+            << tr("Mismatched Brackets") << tr("Evaluated Code")
+    ;
 
     static int count = strings.count();
 
@@ -187,14 +196,17 @@ void EditorPage::loadSyntaxTextFormats( Manager *settings )
 
     static char const * const keys[] = {
         "whitespace", "keyword", "built-in", "env-var", "class", "number",
-        "symbol", "string", "char", "comment", "primitive"
+        "symbol", "string", "char", "comment", "primitive",
+        "postwindowerror", "postwindowwarning", "postwindowsuccess", "postwindowemphasis"
     };
 
     static QStringList strings = QStringList()
             << tr("Whitespace")
             << tr("Keyword") << tr("Built-in Value") << tr("Environment Variable")
             << tr("Class") << tr("Number") << tr("Symbol") << tr("String") << tr("Char")
-            << tr("Comment") << tr("Primitive");
+            << tr("Comment") << tr("Primitive")
+            << tr("Post Window Error") << tr("Post Window Warning") << ("Post Window Success") << ("Post Window Emphasis")
+    ;
 
     static int count = strings.count();
 


### PR DESCRIPTION
Allow custom colorization of some lines in the post window. Line markers include:
ERROR:
WARNING:
-> (for the string result of code evaluated in the interpreter)
**\* (usable for emphasis)

The intention was to make sure any changes in posted text would still be usable / useful to non-IDE clients without color, and to keep it minimal and informative, in the interest of aesthetics. Colorizing is only done on the first line of an error / warning - doing multiple lines was ugly, hard on the eyes, and often spilled over into unrelated text.
