### PR TITLE
Classlib: PlotView: Don't post spec in calcSpecs

### DIFF
--- a/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
+++ b/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
@@ -656,7 +656,6 @@ Plotter {
 				var list = data.at(i);
 				if(list.notNil) {
 					spec = spec.looseRange(list, defaultRange, *ranges.wrapAt(i));
-					spec.postcs;
 				} {
 					spec
 				};


### PR DESCRIPTION
I was startled to see this, after plotting an array:

```
ControlSpec(-10.0, 5.0, 'linear', 0.0, 0.0, "")
a Plotter
```

Generally recommended to delete debugging posts before pushing.
