### PR TITLE
help: chaotic generators warnings removed

### DIFF
--- a/HelpSource/Classes/CuspL.schelp
+++ b/HelpSource/Classes/CuspL.schelp
@@ -10,6 +10,15 @@ teletype::
 	x(n+1) = a - b * sqrt(|x(n)|)
 ::
 
+sclang code translation:
+
+code::
+(
+var a = 1.0, b = 1.9, xi = 0, size = 64;
+plot(size.collect { xi = a - (b * sqrt(abs(xi))) });
+)
+::
+
 classmethods::
 
 method:: ar

--- a/HelpSource/Classes/CuspL.schelp
+++ b/HelpSource/Classes/CuspL.schelp
@@ -6,10 +6,9 @@ related:: Classes/CuspN
 description::
 A linear-interpolating sound generator based on the difference equation:
 
-code::
-	x[n+1] = a - b * sqrt(abs(x[n]))
+teletype::
+	x(n+1) = a - b * sqrt(|x(n)|)
 ::
-warning:: revise formulae converted to c like code ::
 
 classmethods::
 

--- a/HelpSource/Classes/CuspN.schelp
+++ b/HelpSource/Classes/CuspN.schelp
@@ -10,6 +10,15 @@ teletype::
 	x(n+1) = a - b * sqrt(|x(n)|)
 ::
 
+sclang code translation:
+
+code::
+(
+var a = 1.0, b = 1.9, xi = 0, size = 64;
+plot(size.collect { xi = a - (b * sqrt(abs(xi))) });
+)
+::
+
 classmethods::
 
 method:: ar

--- a/HelpSource/Classes/CuspN.schelp
+++ b/HelpSource/Classes/CuspN.schelp
@@ -6,10 +6,9 @@ related:: Classes/CuspL
 description::
 A non-interpolating sound generator based on the difference equation:
 
-code::
-	x[n+1] = a - b * sqrt(abs(x[n]))
+teletype::
+	x(n+1) = a - b * sqrt(|x(n)|)
 ::
-warning:: revise formulae converted to c like code ::
 
 classmethods::
 

--- a/HelpSource/Classes/FBSineC.schelp
+++ b/HelpSource/Classes/FBSineC.schelp
@@ -13,6 +13,15 @@ teletype::
 
 This uses a linear congruential function to drive the phase indexing of a sine wave. For code:: im = 1 ::, code:: fb = 0 ::, and code:: a = 1 :: a normal sinewave results.
 
+sclang code translation:
+
+code::
+(
+var im = 1, fb = 0.1, a = 1.1, c = 0.5, xi = 0.1, yi = 0.1, size = 64;
+plot(size.collect { xi = sin((im * yi) + (fb * xi)); yi = (a * yi + c) % 2pi; xi });
+)
+::
+
 classmethods::
 method:: ar
 argument:: freq

--- a/HelpSource/Classes/FBSineC.schelp
+++ b/HelpSource/Classes/FBSineC.schelp
@@ -6,11 +6,10 @@ related:: Classes/FBSineN, Classes/FBSineL
 description::
 A cubic-interpolating sound generator based on the difference equations:
 
-code::
-	x[n+1] = sin(im * y[n] + fb * x[n])
-	y[n+1] = (a * y[n] + c) % 2pi
+teletype::
+	x(n+1) = sin(im * y(n) + fb * x(n))
+	y(n+1) = (a * y(n) + c) % 2pi
 ::
-warning:: revise formulae conversion to c like code. ::
 
 This uses a linear congruential function to drive the phase indexing of a sine wave. For code:: im = 1 ::, code:: fb = 0 ::, and code:: a = 1 :: a normal sinewave results.
 

--- a/HelpSource/Classes/FBSineL.schelp
+++ b/HelpSource/Classes/FBSineL.schelp
@@ -14,6 +14,15 @@ teletype::
 
 This uses a linear congruential function to drive the phase indexing of a sine wave. For code:: im = 1 ::, code:: fb = 0 ::, and code:: a = 1 :: a normal sinewave results.
 
+sclang code translation:
+
+code::
+(
+var im = 1, fb = 0.1, a = 1.1, c = 0.5, xi = 0.1, yi = 0.1, size = 64;
+plot(size.collect { xi = sin((im * yi) + (fb * xi)); yi = (a * yi + c) % 2pi; xi });
+)
+::
+
 classmethods::
 method:: ar
 argument:: freq

--- a/HelpSource/Classes/FBSineL.schelp
+++ b/HelpSource/Classes/FBSineL.schelp
@@ -6,11 +6,11 @@ related:: Classes/FBSineC, Classes/FBSineN
 description::
 A linear-interpolating sound generator based on the difference equations:
 
-code::
-	x[n+1] = sin(im * y[n] + fb * x[n])
-	y[n+1] = (a * y[n] + c) % 2pi
+teletype::
+        x(n+1) = sin(im * y(n) + fb * x(n))
+        y(n+1) = (a * y(n) + c) % 2pi
 ::
-warning:: reviser formulae conversion to c like code. ::
+
 
 This uses a linear congruential function to drive the phase indexing of a sine wave. For code:: im = 1 ::, code:: fb = 0 ::, and code:: a = 1 :: a normal sinewave results.
 

--- a/HelpSource/Classes/FBSineN.schelp
+++ b/HelpSource/Classes/FBSineN.schelp
@@ -14,6 +14,15 @@ teletype::
 
 This uses a linear congruential function to drive the phase indexing of a sine wave. For code:: im = 1 ::, code:: fb = 0 ::, and code:: a = 1 :: a normal sinewave results.
 
+sclang code translation:
+
+code::
+(
+var im = 1, fb = 0.1, a = 1.1, c = 0.5, xi = 0.1, yi = 0.1, size = 64;
+plot(size.collect { xi = sin((im * yi) + (fb * xi)); yi = (a * yi + c) % 2pi; xi });
+)
+::
+
 classmethods::
 method:: ar
 argument:: freq

--- a/HelpSource/Classes/FBSineN.schelp
+++ b/HelpSource/Classes/FBSineN.schelp
@@ -6,11 +6,11 @@ related:: Classes/FBSineL, Classes/FBSineC
 description::
 A non-interpolating sound generator based on the difference equations:
 
-code::
-	x[n+1] = sin(im * y[n] + fb * x[n])
-	y[n+1] = (a * y[n] + c) % 2pi
+teletype::
+        x(n+1) = sin(im * y(n) + fb * x(n))
+        y(n+1) = (a * y(n) + c) % 2pi
 ::
-warning:: reviser formulae conversion to c like code. ::
+
 
 This uses a linear congruential function to drive the phase indexing of a sine wave. For code:: im = 1 ::, code:: fb = 0 ::, and code:: a = 1 :: a normal sinewave results.
 

--- a/HelpSource/Classes/GbmanL.schelp
+++ b/HelpSource/Classes/GbmanL.schelp
@@ -13,6 +13,15 @@ teletype::
 
 The behavior of the system is dependent only on its initial conditions and cannot be changed once it's started.
 
+sclang code translation:
+
+code::
+(
+var xi = 1.2, yi = 2.1, size = 64;
+plot(size.collect { var x; xi = 1 - yi + abs(x = xi); yi = x; xi });
+)
+::
+
 Reference: Devaney, R. L. "The Gingerbreadman." Algorithm 3, 15-16, Jan. 1992.
 
 classmethods::

--- a/HelpSource/Classes/GbmanL.schelp
+++ b/HelpSource/Classes/GbmanL.schelp
@@ -6,11 +6,10 @@ related:: Classes/GbmanN
 description::
 A linear-interpolating sound generator based on the difference equations:
 
-code::
-	x[n+1] = 1 - y[n] + abs(x[n])
-	y[n+1] = x[n]
+teletype::
+	x(n+1) = 1 - y(n) + |x(n)|
+	y(n+1) = x(n)
 ::
-warning:: reviser formulae converted to c like code ::
 
 The behavior of the system is dependent only on its initial conditions and cannot be changed once it's started.
 

--- a/HelpSource/Classes/GbmanN.schelp
+++ b/HelpSource/Classes/GbmanN.schelp
@@ -14,6 +14,15 @@ teletype::
 
 The behavior of the system is only dependent on its initial conditions.
 
+sclang code translation:
+
+code::
+(
+var xi = 1.2, yi = 2.1, size = 64;
+plot(size.collect { var x; xi = 1 - yi + abs(x = xi); yi = x; xi });
+)
+::
+
 Reference: emphasis:: Devaney, R. L. "The Gingerbreadman." Algorithm 3, 15-16, Jan. 1992. ::
 
 classmethods::

--- a/HelpSource/Classes/GbmanN.schelp
+++ b/HelpSource/Classes/GbmanN.schelp
@@ -6,11 +6,11 @@ related:: Classes/GbmanL
 description::
 A non-interpolating sound generator based on the difference equations:
 
-code::
-	x[n+1] = 1 - y[n] + abs(x[n])
-	y[n+1] = x[n]
+teletype::
+        x(n+1) = 1 - y(n) + |x(n)|
+        y(n+1) = x(n)
 ::
-warning:: reviser formulae converted to c like code ::
+
 
 The behavior of the system is only dependent on its initial conditions.
 

--- a/HelpSource/Classes/HenonC.schelp
+++ b/HelpSource/Classes/HenonC.schelp
@@ -12,6 +12,15 @@ teletype::
 
 This equation was discovered by French astronomer Michel Hénon while studying the orbits of stars in globular clusters.
 
+sclang code translation:
+
+code::
+(
+var a = 1.4, b = 0.3, x0 = 0, x1 = 1, size = 64;
+plot(size.collect { var aux = 1 - (a * (x1 ** 2)) + (b * x0); x0 = x1; x1 = aux; aux });
+)
+::
+
 classmethods::
 method:: ar
 argument:: freq

--- a/HelpSource/Classes/HenonC.schelp
+++ b/HelpSource/Classes/HenonC.schelp
@@ -6,10 +6,9 @@ related:: Classes/HenonN, Classes/HenonL
 description::
 A cubic-interpolating sound generator based on the difference equation:
 
-code::
-	x[n+2] = 1 - a * pow(x[n+1], 2) + b * x[n]
+teletype::
+	x(n+2) = 1 - a * x(n+1)^2 + b * x(n)
 ::
-warning:: revise formulae converted to c like code. ::
 
 This equation was discovered by French astronomer Michel Hénon while studying the orbits of stars in globular clusters.
 

--- a/HelpSource/Classes/HenonL.schelp
+++ b/HelpSource/Classes/HenonL.schelp
@@ -12,6 +12,15 @@ teletype::
 
 This equation was discovered by French astronomer Michel Hénon while studying the orbits of stars in globular clusters.
 
+sclang code translation:
+
+code::
+(
+var a = 1.4, b = 0.3, x0 = 0, x1 = 1, size = 64;
+plot(size.collect { var aux = 1 - (a * (x1 ** 2)) + (b * x0); x0 = x1; x1 = aux; aux });
+)
+::
+
 classmethods::
 method:: ar
 argument:: freq

--- a/HelpSource/Classes/HenonL.schelp
+++ b/HelpSource/Classes/HenonL.schelp
@@ -6,10 +6,9 @@ related:: Classes/HenonC, Classes/HenonN
 description::
 A linear-interpolating sound generator based on the difference equation:
 
-code::
-	x[n+2] = 1 - a * pow(x[n+1], 2) + b * x[n]
+teletype::
+        x(n+2) = 1 - a * x(n+1)^2 + b * x(n)
 ::
-warning:: revise formulae converted to c like code. ::
 
 This equation was discovered by French astronomer Michel Hénon while studying the orbits of stars in globular clusters.
 

--- a/HelpSource/Classes/HenonN.schelp
+++ b/HelpSource/Classes/HenonN.schelp
@@ -12,6 +12,15 @@ teletype::
 
 This equation was discovered by French astronomer Michel Hénon while studying the orbits of stars in globular clusters.
 
+sclang code translation:
+
+code::
+(
+var a = 1.4, b = 0.3, x0 = 0, x1 = 1, size = 64;
+plot(size.collect { var aux = 1 - (a * (x1 ** 2)) + (b * x0); x0 = x1; x1 = aux; aux });
+)
+::
+
 classmethods::
 method:: ar
 argument:: freq

--- a/HelpSource/Classes/HenonN.schelp
+++ b/HelpSource/Classes/HenonN.schelp
@@ -6,10 +6,9 @@ related:: Classes/HenonL, Classes/HenonC
 description::
 A non-interpolating sound generator based on the difference equation:
 
-code::
-	x[n+2] = 1 - a * pow(x[n+1], 2) + b * x[n]
+teletype::
+        x(n+2) = 1 - a * x(n+1)^2 + b * x(n)
 ::
-warning:: revise formulae converted to c like code. ::
 
 This equation was discovered by French astronomer Michel Hénon while studying the orbits of stars in globular clusters.
 

--- a/HelpSource/Classes/LatoocarfianC.schelp
+++ b/HelpSource/Classes/LatoocarfianC.schelp
@@ -8,10 +8,23 @@ A cubic-interpolating sound generator based on a function given in Clifford Pick
 
 teletype::
 	x(n+1) = sin(b * y(n)) + c * sin(b * x(n))
-	y(n+1) = sin(a * y(n)) + d * sin(a * x(n))
+	y(n+1) = sin(a * x(n)) + d * sin(a * y(n))
 ::
 
 According to Pickover, parameters code::a:: and code::b:: should be in the range from -3 to +3, and parameters code::c:: and code::d:: should be in the range from 0.5 to 1.5. The function can, depending on the parameters given, give continuous chaotic output, converge to a single value (silence) or oscillate in a cycle (tone).
+
+sclang code translation:
+
+code::
+(
+var a = 1, b = 3, c = 0.5, d = 0.5, xi = 0.5, yi = 0.5, size = 64;
+plot(size.collect { var x = xi;
+xi = sin(b * yi) + (c * sin(b * xi));
+yi = sin(a * x) + (d * sin(a * yi));
+xi
+});
+)
+::
 
 note::This UGen is experimental and not optimized currently, so is rather hoggish of CPU.::
 

--- a/HelpSource/Classes/LatoocarfianC.schelp
+++ b/HelpSource/Classes/LatoocarfianC.schelp
@@ -6,11 +6,10 @@ related:: Classes/LatoocarfianN, Classes/LatoocarfianL
 description::
 A cubic-interpolating sound generator based on a function given in Clifford Pickover's book Chaos In Wonderland, pg 26. The function is:
 
-code::
-	x[n+1] = sin(b * y[n]) + c * sin(b * x[n])
-	y[n+1] = sin(a * y[n]) + d * sin(a * x[n])
+teletype::
+	x(n+1) = sin(b * y(n)) + c * sin(b * x(n))
+	y(n+1) = sin(a * y(n)) + d * sin(a * x(n))
 ::
-warning:: revise formulae conversion to c like code ::
 
 According to Pickover, parameters code::a:: and code::b:: should be in the range from -3 to +3, and parameters code::c:: and code::d:: should be in the range from 0.5 to 1.5. The function can, depending on the parameters given, give continuous chaotic output, converge to a single value (silence) or oscillate in a cycle (tone).
 

--- a/HelpSource/Classes/LatoocarfianL.schelp
+++ b/HelpSource/Classes/LatoocarfianL.schelp
@@ -8,10 +8,23 @@ A linear-interpolating sound generator based on a function given in Clifford Pic
 
 teletype::
         x(n+1) = sin(b * y(n)) + c * sin(b * x(n))
-        y(n+1) = sin(a * y(n)) + d * sin(a * x(n))
+        y(n+1) = sin(a * x(n)) + d * sin(a * y(n))
 ::
 
 According to Pickover, parameters code::a:: and code::b:: should be in the range from -3 to +3, and parameters code::c:: and code::d:: should be in the range from 0.5 to 1.5. The function can, depending on the parameters given, give continuous chaotic output, converge to a single value (silence) or oscillate in a cycle (tone).
+
+sclang code translation:
+
+code::
+(
+var a = 1, b = 3, c = 0.5, d = 0.5, xi = 0.5, yi = 0.5, size = 64;
+plot(size.collect { var x = xi;
+xi = sin(b * yi) + (c * sin(b * xi));
+yi = sin(a * x) + (d * sin(a * yi));
+xi
+});
+)
+::
 
 note::This UGen is experimental and not optimized currently, so is rather hoggish of CPU.::
 

--- a/HelpSource/Classes/LatoocarfianL.schelp
+++ b/HelpSource/Classes/LatoocarfianL.schelp
@@ -6,11 +6,10 @@ related:: Classes/LatoocarfianC, Classes/LatoocarfianN
 description::
 A linear-interpolating sound generator based on a function given in Clifford Pickover's book Chaos In Wonderland, pg 26. The function is:
 
-code::
-	x[n+1] = sin(b * y[n]) + c * sin(b * x[n])
-	y[n+1] = sin(a * y[n]) + d * sin(a * x[n])
+teletype::
+        x(n+1) = sin(b * y(n)) + c * sin(b * x(n))
+        y(n+1) = sin(a * y(n)) + d * sin(a * x(n))
 ::
-warning:: revise formulae conversion to c like code ::
 
 According to Pickover, parameters code::a:: and code::b:: should be in the range from -3 to +3, and parameters code::c:: and code::d:: should be in the range from 0.5 to 1.5. The function can, depending on the parameters given, give continuous chaotic output, converge to a single value (silence) or oscillate in a cycle (tone).
 

--- a/HelpSource/Classes/LatoocarfianN.schelp
+++ b/HelpSource/Classes/LatoocarfianN.schelp
@@ -8,10 +8,23 @@ A non-interpolating sound generator based on a function given in Clifford Pickov
 
 teletype::
         x(n+1) = sin(b * y(n)) + c * sin(b * x(n))
-        y(n+1) = sin(a * y(n)) + d * sin(a * x(n))
+        y(n+1) = sin(a * x(n)) + d * sin(a * y(n))
 ::
 
 According to Pickover, parameters code::a:: and code::b:: should be in the range from -3 to +3, and parameters code::c:: and code::d:: should be in the range from 0.5 to 1.5. The function can, depending on the parameters given, give continuous chaotic output, converge to a single value (silence) or oscillate in a cycle (tone).
+
+sclang code translation:
+
+code::
+(
+var a = 1, b = 3, c = 0.5, d = 0.5, xi = 0.5, yi = 0.5, size = 64;
+plot(size.collect { var x = xi;
+xi = sin(b * yi) + (c * sin(b * xi));
+yi = sin(a * x) + (d * sin(a * yi));
+xi
+});
+)
+::
 
 note::This UGen is experimental and not optimized currently, so is rather hoggish of CPU.::
 

--- a/HelpSource/Classes/LatoocarfianN.schelp
+++ b/HelpSource/Classes/LatoocarfianN.schelp
@@ -6,11 +6,10 @@ related:: Classes/LatoocarfianL, Classes/LatoocarfianC
 description::
 A non-interpolating sound generator based on a function given in Clifford Pickover's book Chaos In Wonderland, pg 26. The function is:
 
-code::
-	x[n+1] = sin(b * y[n]) + c * sin(b * x[n])
-	y[n+1] = sin(a * y[n]) + d * sin(a * x[n])
+teletype::
+        x(n+1) = sin(b * y(n)) + c * sin(b * x(n))
+        y(n+1) = sin(a * y(n)) + d * sin(a * x(n))
 ::
-warning:: revise formulae conversion to c like code ::
 
 According to Pickover, parameters code::a:: and code::b:: should be in the range from -3 to +3, and parameters code::c:: and code::d:: should be in the range from 0.5 to 1.5. The function can, depending on the parameters given, give continuous chaotic output, converge to a single value (silence) or oscillate in a cycle (tone).
 

--- a/HelpSource/Classes/LinCongC.schelp
+++ b/HelpSource/Classes/LinCongC.schelp
@@ -12,6 +12,15 @@ teletype::
 
 The output signal is automatically scaled to a range of [-1, 1].
 
+sclang code translation:
+
+code::
+(
+var a = 1.1, c = 0.13, m = 1, xi = 0, size = 64;
+plot(size.collect { xi = (a * xi + c) % m });
+)
+::
+
 classmethods::
 method:: ar
 argument:: freq

--- a/HelpSource/Classes/LinCongC.schelp
+++ b/HelpSource/Classes/LinCongC.schelp
@@ -6,10 +6,9 @@ related:: Classes/LinCongN, Classes/LinCongL
 description::
 A cubic-interpolating sound generator based on the difference equation:
 
-code::
-	x[n+1] = (a * x[n] + c) % m
+teletype::
+	x(n+1) = (a * x(n) + c) % m
 ::
-warning:: revise formulae converted to c like code ::
 
 The output signal is automatically scaled to a range of [-1, 1].
 

--- a/HelpSource/Classes/LinCongL.schelp
+++ b/HelpSource/Classes/LinCongL.schelp
@@ -12,6 +12,15 @@ teletype::
 
 The output signal is automatically scaled to a range of [-1, 1].
 
+sclang code translation:
+
+code::
+(
+var a = 1.1, c = 0.13, m = 1, xi = 0, size = 64;
+plot(size.collect { xi = (a * xi + c) % m });
+)
+::
+
 classmethods::
 method:: ar
 argument:: freq

--- a/HelpSource/Classes/LinCongL.schelp
+++ b/HelpSource/Classes/LinCongL.schelp
@@ -6,10 +6,9 @@ related:: Classes/LinCongC, Classes/LinCongN
 description::
 A linear-interpolating sound generator based on the difference equation:
 
-code::
-	x[n+1] = (a * x[n] + c) % m
+teletype::
+        x(n+1) = (a * x(n) + c) % m
 ::
-warning:: revise formulae converted to c like code ::
 
 The output signal is automatically scaled to a range of [-1, 1].
 

--- a/HelpSource/Classes/LinCongN.schelp
+++ b/HelpSource/Classes/LinCongN.schelp
@@ -12,6 +12,15 @@ teletype::
 
 The output signal is automatically scaled to a range of [-1, 1].
 
+sclang code translation:
+
+code::
+(
+var a = 1.1, c = 0.13, m = 1, xi = 0, size = 64;
+plot(size.collect { xi = (a * xi + c) % m });
+)
+::
+
 classmethods::
 method:: ar
 argument:: freq

--- a/HelpSource/Classes/LinCongN.schelp
+++ b/HelpSource/Classes/LinCongN.schelp
@@ -6,10 +6,9 @@ related:: Classes/LinCongL, Classes/LinCongC
 description::
 A non-interpolating sound generator based on the difference equation:
 
-code::
-	x[n+1] = (a * x[n] + c) % m
+teletype::
+        x(n+1) = (a * x(n) + c) % m
 ::
-warning:: revise formulae converted to c like code ::
 
 The output signal is automatically scaled to a range of [-1, 1].
 

--- a/HelpSource/Classes/LorenzL.schelp
+++ b/HelpSource/Classes/LorenzL.schelp
@@ -5,12 +5,11 @@ categories:: UGens>Generators>Chaotic
 description::
 A strange attractor discovered by Edward N. Lorenz while studying mathematical models of the atmosphere. The system is composed of three ordinary differential equations:
 
-code::
+teletype::
 	x' = s * (y - x)
 	y' = x * (r - z) - y
 	z' = x * y - b * z
 ::
-warning:: revise formulae converted to c like code (x', y', z'!!!) ::
 
 The time step amount code::h:: determines the rate at which the ODE is evaluated. Higher values will increase the rate, but cause more instability. A safe choice is the default amount of 0.05.
 

--- a/HelpSource/Classes/QuadC.schelp
+++ b/HelpSource/Classes/QuadC.schelp
@@ -10,6 +10,15 @@ teletype::
 	x(n+1) = a * x(n)^2 + b * x(n) + c
 ::
 
+sclang code translation:
+
+code::
+(
+var a = 1, b = -1, c = -0.75, xi = 0, size = 64;
+plot(size.collect { xi = (a * (xi ** 2)) + (b * xi) + c; xi });
+)
+::
+
 classmethods::
 method:: ar
 argument:: freq

--- a/HelpSource/Classes/QuadC.schelp
+++ b/HelpSource/Classes/QuadC.schelp
@@ -6,10 +6,9 @@ related:: Classes/QuadN, Classes/QuadL
 description::
 A cubic-interpolating sound generator based on the difference equation:
 
-code::
-	x[n+1] = a * pow(x[n], 2) + b * x[n] + c
+teletype::
+	x(n+1) = a * x(n)^2 + b * x(n) + c
 ::
-warning:: revise formulae conversion to c like code ::
 
 classmethods::
 method:: ar

--- a/HelpSource/Classes/QuadL.schelp
+++ b/HelpSource/Classes/QuadL.schelp
@@ -10,6 +10,15 @@ teletype::
 	x(n+1) = a * x(n)^2 + b * x(n) + c
 ::
 
+sclang code translation:
+
+code::
+(
+var a = 1, b = -1, c = -0.75, xi = 0, size = 64;
+plot(size.collect { xi = (a * (xi ** 2)) + (b * xi) + c; xi });
+)
+::
+
 classmethods::
 method:: ar
 argument:: freq

--- a/HelpSource/Classes/QuadL.schelp
+++ b/HelpSource/Classes/QuadL.schelp
@@ -6,10 +6,9 @@ related:: Classes/QuadC, Classes/QuadN
 description::
 A linear-interpolating sound generator based on the difference equation:
 
-code::
-	x[n+1] = a * pow(x[n], 2) + b * x[n] + c
+teletype::
+	x(n+1) = a * x(n)^2 + b * x(n) + c
 ::
-warning:: revise formulae conversion to c like code ::
 
 classmethods::
 method:: ar

--- a/HelpSource/Classes/QuadN.schelp
+++ b/HelpSource/Classes/QuadN.schelp
@@ -10,6 +10,15 @@ teletype::
         x(n+1) = a * x(n)^2 + b * x(n) + c
 ::
 
+sclang code translation:
+
+code::
+(
+var a = 1, b = -1, c = -0.75, xi = 0, size = 64;
+plot(size.collect { xi = (a * (xi ** 2)) + (b * xi) + c; xi });
+)
+::
+
 classmethods::
 method:: ar
 argument:: freq

--- a/HelpSource/Classes/QuadN.schelp
+++ b/HelpSource/Classes/QuadN.schelp
@@ -6,10 +6,9 @@ related:: Classes/QuadL, Classes/QuadC
 description::
 A non-interpolating sound generator based on the difference equation:
 
-code::
-	x[n+1] = a * pow(x[n], 2) + b * x[n] + c
+teletype::
+        x(n+1) = a * x(n)^2 + b * x(n) + c
 ::
-warning:: revise formulae conversion to c like code ::
 
 classmethods::
 method:: ar

--- a/HelpSource/Classes/StandardL.schelp
+++ b/HelpSource/Classes/StandardL.schelp
@@ -13,6 +13,15 @@ teletype::
 
 The standard map is an area preserving map of a cylinder discovered by the plasma physicist Boris Chirikov.
 
+sclang code translation:
+
+code::
+(
+var k = 1, xi = 0.5, yi = 0, size = 64;
+plot(size.collect { yi = yi + (k * sin(xi)) % 2pi; xi = (xi + yi) % 2pi; xi - pi * 0.3183098861837907 });
+)
+::
+
 classmethods::
 method:: ar
 argument:: freq

--- a/HelpSource/Classes/StandardL.schelp
+++ b/HelpSource/Classes/StandardL.schelp
@@ -6,11 +6,10 @@ related:: Classes/StandardN
 description::
 A linear-interpolating sound generator based on the difference equations:
 
-code::
-	x[n+1] = (x[n] + y[n+1]) % 2pi
-	y[n+1] = (y[n] + k * sin(x[n])) % 2pi
+teletype::
+	x(n+1) = (x(n) + y(n+1)) % 2pi
+	y(n+1) = (y(n) + k * sin(x(n))) % 2pi
 ::
-warning:: revise formulae conversion to c like code ::
 
 The standard map is an area preserving map of a cylinder discovered by the plasma physicist Boris Chirikov.
 

--- a/HelpSource/Classes/StandardN.schelp
+++ b/HelpSource/Classes/StandardN.schelp
@@ -13,6 +13,15 @@ teletype::
 
 The standard map is an area preserving map of a cylinder discovered by the plasma physicist Boris Chirikov.
 
+sclang code translation:
+
+code::
+(
+var k = 1, xi = 0.5, yi = 0, size = 64;
+plot(size.collect { yi = yi + (k * sin(xi)) % 2pi; xi = (xi + yi) % 2pi; xi - pi * 0.3183098861837907 });
+)
+::
+
 classmethods::
 method:: ar
 argument:: freq

--- a/HelpSource/Classes/StandardN.schelp
+++ b/HelpSource/Classes/StandardN.schelp
@@ -6,11 +6,10 @@ related:: Classes/StandardL
 description::
 A non-interpolating sound generator based on the difference equations:
 
-code::
-	x[n+1] = (x[n] + y[n+1]) % 2pi
-	y[n+1] = (y[n] + k * sin(x[n])) % 2pi
+teletype::
+        x(n+1) = (x(n) + y(n+1)) % 2pi
+        y(n+1) = (y(n) + k * sin(x(n))) % 2pi
 ::
-warning:: revise formulae conversion to c like code ::
 
 The standard map is an area preserving map of a cylinder discovered by the plasma physicist Boris Chirikov.
 


### PR DESCRIPTION
This patch is for removing unnecessary comments and homogenize the math notation with the bhob ugens (taken as example).