### PR TITLE
Update Date.schelp

### DIFF
--- a/HelpSource/Classes/Date.schelp
+++ b/HelpSource/Classes/Date.schelp
@@ -13,7 +13,7 @@ Get current date from system and create a date object from it.
 code::
 (
 var a = Date.getDate;
-a.bootSeconds.postln;
+a.rawSeconds.postln;
 a.dayOfWeek.postln;
 a
 )


### PR DESCRIPTION
Change bootSeconds to rawSeconds. This change in the Date class seems to be from late 2012, but the helpfile was not updated.
