### PR TITLE
Rework splits

### DIFF
--- a/editors/sc-ide/CMakeLists.txt
+++ b/editors/sc-ide/CMakeLists.txt
@@ -56,6 +56,7 @@ set ( ide_moc_hdr
     widgets/util/color_widget.hpp
     widgets/util/docklet.hpp
     widgets/util/volume_widget.hpp
+    widgets/util/multi_splitter.hpp
 
     ${CMAKE_SOURCE_DIR}/QtCollider/widgets/web_page.hpp
 )
@@ -104,6 +105,7 @@ set ( ide_src
     widgets/util/docklet.cpp
     widgets/util/volume_widget.cpp
     widgets/util/status_box.cpp
+    widgets/util/multi_splitter.cpp
     widgets/style/style.cpp
 
     ${CMAKE_SOURCE_DIR}/QtCollider/widgets/web_page.cpp

--- a/editors/sc-ide/core/doc_manager.hpp
+++ b/editors/sc-ide/core/doc_manager.hpp
@@ -31,6 +31,9 @@
 #include <QTextDocument>
 #include <QPlainTextDocumentLayout>
 #include <QUuid>
+#include <QStandardItemModel>
+#include <QApplication>
+#include <QStyle>
 
 namespace ScIDE {
 
@@ -54,7 +57,9 @@ public:
     QTextDocument *textDocument() { return mDoc; }
     const QByteArray & id() { return mId; }
     const QString & filePath() { return mFilePath; }
+    
     const QString & title() { return mTitle; }
+    void setTitle(QString & newTitle) { mTitle = newTitle; mModelItem->setText(mTitle); }
 
     QFont defaultFont() const { return mDoc->defaultFont(); }
     void setDefaultFont( const QFont & font );
@@ -66,6 +71,8 @@ public:
 
     bool isPlainText() const { return mHighlighter == NULL; }
     bool isModified() const  { return mDoc->isModified(); }
+    
+    QStandardItem * modelItem() { return mModelItem; }
     
     QString textAsSCArrayOfCharCodes(int start, int range);
     QString titleAsSCArrayOfCharCodes();
@@ -89,6 +96,13 @@ public:
 public slots:
     void applySettings( Settings::Manager * );
     void resetDefaultFont();
+    void onModificationChanged(bool changed) {
+        if(changed){
+            mModelItem->setIcon(QApplication::style()->standardIcon(QStyle::SP_DialogSaveButton));
+        } else {
+            mModelItem->setIcon(QIcon());
+        }
+    }
 
 signals:
     void defaultFontChanged();
@@ -108,6 +122,7 @@ private:
     bool mMouseDownActionEnabled;
     bool mMouseUpActionEnabled;
     bool mTextChangedActionEnabled;
+    QStandardItem * mModelItem;
 };
 
 class DocumentManager : public QObject
@@ -136,6 +151,7 @@ public:
     void setActiveDocument(class Document *);
     void sendActiveDocument();
     Document * activeDocument() { return mCurrentDocument; }
+    QStandardItemModel * docModel() { return mDocumentModel; }
 
 public slots:
     // initialCursorPosition -1 means "don't change position if already open"
@@ -196,6 +212,8 @@ private:
     bool mTextMirrorEnabled;
     QString mCurrentDocumentPath;
     class Document * mCurrentDocument;
+    
+    QStandardItemModel * mDocumentModel;
 };
 
 } // namespace ScIDE

--- a/editors/sc-ide/core/doc_manager.hpp
+++ b/editors/sc-ide/core/doc_manager.hpp
@@ -141,6 +141,7 @@ public:
     }
 
     void create();
+    Document *docReplace();
     void close( Document * );
     bool save( Document * );
     bool saveAs( Document *, const QString & path );

--- a/editors/sc-ide/core/main.cpp
+++ b/editors/sc-ide/core/main.cpp
@@ -23,6 +23,7 @@
 #include "session_manager.hpp"
 #include "util/standard_dirs.hpp"
 #include "../widgets/main_window.hpp"
+#include "../widgets/multi_editor.hpp"
 #include "../widgets/help_browser.hpp"
 #include "../widgets/lookup_dialog.hpp"
 #include "../widgets/code_editor/highlighter.hpp"
@@ -277,7 +278,7 @@ void Main::openDefinition(const QString &string, QWidget * parent)
 
 void Main::openCommandLine(const QString &string)
 {
-    MainWindow::instance()->showCmdLine(string);
+    MainWindow::instance()->editor()->showCmdLine(string);
 }
 
 void Main::findReferences(const QString &string, QWidget * parent)

--- a/editors/sc-ide/widgets/code_editor/editor.cpp
+++ b/editors/sc-ide/widgets/code_editor/editor.cpp
@@ -26,6 +26,7 @@
 #include "../../core/doc_manager.hpp"
 #include "../../core/settings/manager.hpp"
 #include "../main_window.hpp"
+#include "../multi_editor.hpp"
 
 #include <QApplication>
 #include <QDebug>
@@ -782,7 +783,7 @@ void GenericCodeEditor::hideMouseCursor(QKeyEvent * event)
 
 void GenericCodeEditor::closeDocument()
 {
-    MainWindow::instance()->closeDocument();
+    MainWindow::instance()->editor()->closeDocument();
 }
 
 void GenericCodeEditor::clearSearchHighlighting()
@@ -834,6 +835,17 @@ void GenericCodeEditor::updateLineIndicator( QRect r, int dy )
         mLineIndicator->scroll(0, dy);
     else
         mLineIndicator->update(0, r.y(), mLineIndicator->width(), r.height() );
+}
+
+int GenericCodeEditor::lineNumber()
+{
+    int pos = textCursor().position();
+    if (pos < 0) return -1;
+    QTextDocument *doc = QPlainTextEdit::document();
+    if (!doc) return -1;
+
+    int lineNumber = doc->findBlock(pos).firstLineNumber();
+    return lineNumber;
 }
 
 void GenericCodeEditor::onCursorPositionChanged()

--- a/editors/sc-ide/widgets/code_editor/editor.hpp
+++ b/editors/sc-ide/widgets/code_editor/editor.hpp
@@ -55,6 +55,7 @@ public:
     void showPosition( int charPosition, int selectionLength = 0 );
     QString symbolUnderCursor();
     int inactiveFadeAlpha() { return mInactiveFadeAlpha; }
+    int lineNumber();
 
 protected:
     virtual bool event( QEvent * );

--- a/editors/sc-ide/widgets/code_editor/sc_editor.cpp
+++ b/editors/sc-ide/widgets/code_editor/sc_editor.cpp
@@ -94,7 +94,6 @@ bool ScCodeEditor::event( QEvent *e )
     default:
         break;
     }
-
     return GenericCodeEditor::event(e);
 }
 
@@ -150,7 +149,6 @@ void ScCodeEditor::keyPressEvent( QKeyEvent *e )
         doKeyAction(e);
         return;
     }
-
     case Qt::Key_Backtab:
     {
         QTextCursor cursor = textCursor();

--- a/editors/sc-ide/widgets/editor_box.cpp
+++ b/editors/sc-ide/widgets/editor_box.cpp
@@ -24,13 +24,14 @@
 
 #include <QPainter>
 #include <QScrollBar>
+#include <QPalette>
 
 namespace ScIDE {
 
 QPointer<CodeEditorBox> CodeEditorBox::gActiveBox;
 
-CodeEditorBox::CodeEditorBox(QWidget *parent) :
-    QWidget(parent)
+CodeEditorBox::CodeEditorBox(MultiSplitter *splitter, QWidget *parent) :
+    QWidget(parent), mSplitter(splitter)
 {
     setFocusPolicy(Qt::StrongFocus);
     setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
@@ -38,8 +39,9 @@ CodeEditorBox::CodeEditorBox(QWidget *parent) :
     mTopLayout = new QBoxLayout(QBoxLayout::TopToBottom);
     mLayout = new QStackedLayout();
     setLayout(mTopLayout);
-    mDocComboBox = new QComboBox();
+    mDocComboBox = new BoxPopupMenu();
     mDocComboBox->setFocusPolicy(Qt::NoFocus);
+
     mTopLayout->setSpacing(1);
     mTopLayout->setContentsMargins(0, 0, 0, 0);
     mTopLayout->addWidget(mDocComboBox);
@@ -161,7 +163,7 @@ void CodeEditorBox::onDocumentSaved(Document *doc)
 
 GenericCodeEditor *CodeEditorBox::currentEditor()
 {
-    if (mHistory.count())
+    if (!mHistory.isEmpty())
         return mHistory.first();
     else
         return 0;

--- a/editors/sc-ide/widgets/editor_box.cpp
+++ b/editors/sc-ide/widgets/editor_box.cpp
@@ -35,13 +35,30 @@ CodeEditorBox::CodeEditorBox(QWidget *parent) :
     setFocusPolicy(Qt::StrongFocus);
     setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
 
+    mTopLayout = new QBoxLayout(QBoxLayout::TopToBottom);
     mLayout = new QStackedLayout();
-    setLayout(mLayout);
-
+    setLayout(mTopLayout);
+    mDocComboBox = new QComboBox();
+    mDocComboBox->setFocusPolicy(Qt::NoFocus);
+    mTopLayout->setSpacing(1);
+    mTopLayout->setContentsMargins(0, 0, 0, 0);
+    mTopLayout->addWidget(mDocComboBox);
+    mTopLayout->addLayout(mLayout);
+    
+    mDocComboBox->setModel(Main::documentManager()->docModel());
+    
+    connect(mDocComboBox, SIGNAL(currentIndexChanged(int)), this, SLOT(onComboSelectionChanged(int)));
     connect(Main::documentManager(), SIGNAL(closed(Document*)),
             this, SLOT(onDocumentClosed(Document*)));
     connect(Main::documentManager(), SIGNAL(saved(Document*)),
             this, SLOT(onDocumentSaved(Document*)));
+}
+    
+void CodeEditorBox::onComboSelectionChanged(int index)
+{
+    if(index >=0) {
+        setDocument(Main::documentManager()->docModel()->item(index)->data().value<Document *>(), -1, 0);
+    }
 }
 
 void CodeEditorBox::setDocument(Document *doc, int pos, int selectionLength)
@@ -70,6 +87,8 @@ void CodeEditorBox::setDocument(Document *doc, int pos, int selectionLength)
         editor->setActiveAppearance(this->isActive());
         mLayout->setCurrentWidget(editor);
         setFocusProxy(editor);
+        int modelIndex = doc->modelItem()->index().row();
+        mDocComboBox->setCurrentIndex(modelIndex);
     }
 
     if (pos != -1)

--- a/editors/sc-ide/widgets/editor_box.hpp
+++ b/editors/sc-ide/widgets/editor_box.hpp
@@ -25,6 +25,12 @@
 #include <QWidget>
 #include <QStackedLayout>
 #include <QPointer>
+#include <QComboBox>
+#include <QBoxLayout>
+#include <QStandardItemModel>
+
+#include "../core/doc_manager.hpp"
+#include "../core/main.hpp"
 
 namespace ScIDE {
 
@@ -96,6 +102,7 @@ signals:
 private slots:
     void onDocumentClosed(Document*);
     void onDocumentSaved(Document*);
+    void onComboSelectionChanged(int index);
 
 private:
     int historyIndexOf(Document*);
@@ -107,6 +114,9 @@ private:
     QStackedLayout *mLayout;
     History mHistory;
     static QPointer<CodeEditorBox> gActiveBox;
+    QBoxLayout *mTopLayout;
+    QComboBox *mDocComboBox;
+    
 };
 
 } // namespace ScIDE

--- a/editors/sc-ide/widgets/find_replace_tool.cpp
+++ b/editors/sc-ide/widgets/find_replace_tool.cpp
@@ -119,19 +119,6 @@ TextFindReplacePanel::TextFindReplacePanel( QWidget * parent ):
     connect(mReplaceField, SIGNAL(returnPressed()), this, SLOT(replace()));
     // Update search results when options change:
     connect(optMenu, SIGNAL(triggered(QAction*)), this, SLOT(findAll()));
-
-    Settings::Manager *settings = Main::settings();
-    QAction *action;
-
-    action = mActions[FindNext] = new QAction(tr("Find Next"), this);
-    action->setShortcut(tr("Ctrl+G", "Find Next"));
-    connect( action, SIGNAL(triggered()), this, SLOT(findNext()) );
-    settings->addAction( action, "editor-find-next", tr("Text Editor") );
-
-    action = mActions[FindPrevious] = new QAction(tr("Find Previous"), this);
-    action->setShortcut(tr("Ctrl+Shift+G", "Find Previous"));
-    connect( action, SIGNAL(triggered()), this, SLOT(findPrevious()) );
-    settings->addAction( action, "editor-find-previous", tr("Text Editor") );
 }
 
 void TextFindReplacePanel::setMode( Mode mode )

--- a/editors/sc-ide/widgets/find_replace_tool.hpp
+++ b/editors/sc-ide/widgets/find_replace_tool.hpp
@@ -46,13 +46,6 @@ public:
         Replace
     };
 
-    enum ActionRole {
-        FindNext,
-        FindPrevious,
-
-        ActionCount
-    };
-
 public:
     TextFindReplacePanel( QWidget * parent = 0 );
 
@@ -69,8 +62,6 @@ public:
     bool wholeWords() const { return mWholeWordAction->isChecked(); }
     QRegExp regexp();
     QTextDocument::FindFlags flags();
-
-    QAction *action ( ActionRole role ) { return mActions[role]; }
 
 public Q_SLOTS:
     void findNext();
@@ -101,7 +92,6 @@ private:
     QAction *mMatchCaseAction;
     QAction *mRegExpAction;
     QAction *mWholeWordAction;
-    QAction *mActions[ActionCount];
 
     QGridLayout *mGrid;
 

--- a/editors/sc-ide/widgets/help_browser.cpp
+++ b/editors/sc-ide/widgets/help_browser.cpp
@@ -22,6 +22,7 @@
 
 #include "help_browser.hpp"
 #include "main_window.hpp"
+#include "multi_editor.hpp"
 #include "../core/sc_process.hpp"
 #include "../core/main.hpp"
 #include "../core/util/overriding_action.hpp"
@@ -106,8 +107,8 @@ void HelpBrowser::createActions()
     mActions[GoHome] = action = new QAction(tr("Home"), this);
     connect( action, SIGNAL(triggered()), this, SLOT(goHome()) );
 
-    mActions[DocClose] = ovrAction = new OverridingAction(tr("Close"), this);
-    connect( ovrAction, SIGNAL(triggered()), this, SLOT(closeDocument()) );
+    mActions[DocClose] = ovrAction = new OverridingAction(tr("Close Window"), this);
+    connect( ovrAction, SIGNAL(triggered()), this, SLOT(removeWindow()) );
     ovrAction->addToWidget(mWebView);
 
     mActions[ZoomIn] = ovrAction = new OverridingAction(tr("Zoom In"), this);
@@ -126,6 +127,10 @@ void HelpBrowser::createActions()
     connect(ovrAction, SIGNAL(triggered()), this, SLOT(evaluateSelection()));
     ovrAction->addToWidget(mWebView);
 
+    mActions[SwitchSplit] = ovrAction = new OverridingAction(tr("Switch Editor"), this);
+    connect(ovrAction, SIGNAL(triggered()), this, SLOT(switchSplit()));
+    ovrAction->addToWidget(mWebView);
+
     // For the sake of display:
     mWebView->pageAction(QWebPage::Copy)->setShortcut( QKeySequence::Copy );
     mWebView->pageAction(QWebPage::Paste)->setShortcut( QKeySequence::Paste );
@@ -135,7 +140,9 @@ void HelpBrowser::applySettings( Settings::Manager *settings )
 {
     settings->beginGroup("IDE/shortcuts");
 
-    mActions[DocClose]->setShortcut( settings->shortcut("ide-document-close") );
+    mActions[SwitchSplit]->setShortcut( settings->shortcut("editor-split-switch") );
+
+    mActions[DocClose]->setShortcut( settings->shortcut("window-remove") );
 
     mActions[ZoomIn]->setShortcut( settings->shortcut("editor-enlarge-font") );
 
@@ -161,9 +168,14 @@ void HelpBrowser::goHome()
     sendRequest(code);
 }
 
-void HelpBrowser::closeDocument()
+void HelpBrowser::removeWindow()
 {
     MainWindow::instance()->helpBrowserDocklet()->close();
+}
+
+void HelpBrowser::switchSplit()
+{
+    MainWindow::instance()->editor()->switchSplit();
 }
 
 void HelpBrowser::gotoHelpFor( const QString & symbol )
@@ -355,6 +367,8 @@ void HelpBrowser::onContextMenuRequest( const QPoint & pos )
     menu.addAction( mActions[ZoomIn] );
     menu.addAction( mActions[ZoomOut] );
     menu.addAction( mActions[ResetZoom] );
+
+    menu.addAction( mActions[SwitchSplit] );
 
     menu.addAction( mActions[DocClose] );
 

--- a/editors/sc-ide/widgets/help_browser.hpp
+++ b/editors/sc-ide/widgets/help_browser.hpp
@@ -87,6 +87,7 @@ public:
         ZoomOut,
         ResetZoom,
         Evaluate,
+        SwitchSplit,
 
         ActionCount
     };
@@ -105,7 +106,8 @@ public:
 public slots:
     void applySettings( Settings::Manager * );
     void goHome();
-    void closeDocument();
+    void removeWindow();
+    void switchSplit();
     void zoomIn();
     void zoomOut();
     void resetZoom();

--- a/editors/sc-ide/widgets/lookup_dialog.cpp
+++ b/editors/sc-ide/widgets/lookup_dialog.cpp
@@ -22,6 +22,7 @@
 #include "main_window.hpp"
 #include "../core/sc_introspection.hpp"
 #include "../core/main.hpp"
+#include "multi_editor.hpp"
 
 #include <QVBoxLayout>
 #include <QHeaderView>
@@ -38,7 +39,7 @@ namespace ScIDE {
 GenericLookupDialog::GenericLookupDialog( QWidget * parent ):
     QDialog(parent)
 {
-    addAction(MainWindow::instance()->action(MainWindow::LookupDocumentationForCursor));
+    addAction(MainWindow::instance()->editor()->action(MultiEditor::LookupDocumentationForCursor));
 
     mQueryEdit = new QLineEdit(this);
 

--- a/editors/sc-ide/widgets/main_window.hpp
+++ b/editors/sc-ide/widgets/main_window.hpp
@@ -28,6 +28,7 @@
 #include <QStatusBar>
 
 #include "util/status_box.hpp"
+#include "../../sc-ide/core/sig_mux.hpp"
 
 namespace ScIDE {
 
@@ -58,50 +59,10 @@ public:
 
     enum ActionRole {
         // File
-        Quit = 0,
-        DocNew,
-        DocOpen,
-        DocOpenStartup,
-        DocOpenSupportDir,
-        DocSave,
-        DocSaveAs,
-        DocSaveAll,
-        DocCloseAll,
-        DocReload,
         ClearRecentDocs,
 
-        // Sessions
-        NewSession,
-        SaveSessionAs,
-        ManageSessions,
-        OpenSessionSwitchDialog,
-
-        // Edit
-        Find,
-        Replace,
-
-        // View
-        ShowCmdLine,
-        CmdLineForCursor,
-        ShowGoToLineTool,
-        CloseToolBox,
-        ShowFullScreen,
-        FocusPostWindow,
-
-        // Settings
-        ShowSettings,
-
-        // Language
-        LookupImplementation,
-        LookupImplementationForCursor,
-        LookupReferences,
-        LookupReferencesForCursor,
-
         // Help
-        Help,
         HelpAboutIDE,
-        LookupDocumentationForCursor,
-        LookupDocumentation,
         ShowAbout,
         ShowAboutQT,
 
@@ -123,32 +84,24 @@ public:
     PostDocklet * postDocklet() { return mPostDocklet; }
 
     static MainWindow *instance() { return mInstance; }
+    MultiEditor *editor() { return mEditors; }
+    QMenuBar *menu() { return mainMenu; }
+
     Settings::Manager *setting();
 
     static bool close( Document * );
     static bool save( Document *, bool forceChoose = false );
     static bool reload( Document * );
+    void saveSessionChanged();
+
+    QMenuBar *createMenus();
+
+    QString documentOpenPath() const;
+    void openSession( QString const & sessionName );
+    void updateSessionsMenu();
 
 public Q_SLOTS:
-    void newSession();
-    void saveCurrentSessionAs();
-    void openSessionsDialog();
-
-    void newDocument();
-    void openDocument();
-    void saveDocument();
-    void saveDocumentAs();
-    void saveAllDocuments();
-    void reloadDocument();
-    void closeDocument();
-    void closeAllDocuments();
-
-    void showCmdLine();
-    void showCmdLine( const QString & );
-    void showFindTool();
-    void showReplaceTool();
-    void showGoToLineTool();
-    void hideToolBox();
+    void postFocus();
 
     void showSettings();
 
@@ -159,9 +112,6 @@ public Q_SLOTS:
     void showStatusMessage( QString const & string );
 
 private Q_SLOTS:
-    void openStartupFile();
-    void openUserSupportDirectory();
-
     void switchSession( Session *session );
     void saveSession( Session *session );
     void onInterpreterStateChanged( QProcess::ProcessState );
@@ -184,7 +134,6 @@ private Q_SLOTS:
     void lookupDocumentation();
     void applySettings( Settings::Manager * );
     void storeSettings( Settings::Manager * );
-    void showSwitchSessionDialog();
     void showAbout();
     void showAboutQT();
     void cmdLineForCursor();
@@ -197,16 +146,12 @@ protected:
 
 private:
     void createActions();
-    void createMenus();
     template <class T> void saveWindowState(T * settings);
     template <class T> void restoreWindowState(T * settings);
-    void updateSessionsMenu();
     void updateClockWidget( bool isFullScreen );
-    void openSession( QString const & sessionName );
     bool checkFileExtension( const QString & fpath );
     void toggleInterpreterActions( bool enabled);
     void applyCursorBlinkingSettings( Settings::Manager * );
-    QString documentOpenPath() const;
     QString documentSavePath( Document * ) const;
 
     Main *mMain;
@@ -217,14 +162,9 @@ private:
 
     MultiEditor *mEditors;
 
-    // Tools
-    ToolBox *mToolBox;
-    CmdLine *mCmdLine;
-    GoToLineTool *mGoToLineTool;
-    TextFindReplacePanel *mFindReplaceTool;
-
     // Status bar
     QStatusBar  *mStatusBar;
+    QMenuBar *mainMenu;
     StatusBox *mLangStatus;
     StatusBox *mServerStatus;
     ClockStatusBox *mClockLabel;

--- a/editors/sc-ide/widgets/multi_editor.hpp
+++ b/editors/sc-ide/widgets/multi_editor.hpp
@@ -21,8 +21,12 @@
 #ifndef SCIDE_WIDGETS_MULTI_EDITOR_HPP_INCLUDED
 #define SCIDE_WIDGETS_MULTI_EDITOR_HPP_INCLUDED
 
+#include "../core/doc_manager.hpp"
+#include "../core/main.hpp"
+#include "editor_box.hpp"
+#include "main_window.hpp"
+
 #include <QWidget>
-#include <QTabBar>
 #include <QAction>
 #include <QPushButton>
 #include <QToolButton>
@@ -33,6 +37,11 @@
 #include <QTextDocument>
 #include <QSplitter>
 #include <QSignalMapper>
+#include <QPointer>
+#include <QStandardItemModel>
+#include <QDialog>
+#include <QListView>
+#include <QPainter>
 
 namespace ScIDE {
 
@@ -44,6 +53,11 @@ class Main;
 class MultiSplitter;
 struct Session;
 class SignalMultiplexer;
+class ToolBox;
+class TextFindReplacePanel;
+class GoToLineTool;
+class CmdLine;
+class EditorWindow;
 
 namespace Settings { class Manager; }
 
@@ -84,7 +98,6 @@ public:
         SelectRegion,
 
         // View
-        DocClose,
         EnlargeFont,
         ShrinkFont,
         ResetFontSize,
@@ -94,10 +107,13 @@ public:
         NextDocument,
         PreviousDocument,
         SwitchDocument,
+        SwitchSplit,
 
         SplitHorizontally,
         SplitVertically,
+        SplitNewWindow,
         RemoveCurrentSplit,
+        RemoveCurrentWindow,
         RemoveAllSplits,
 
         // Language
@@ -105,18 +121,71 @@ public:
         EvaluateRegion,
         EvaluateLine,
 
+        // File
+        Quit,
+        DocNew,
+        DocOpen,
+        DocOpenStartup,
+        DocOpenSupportDir,
+        DocSave,
+        DocSaveAs,
+        DocSaveAll,
+        DocClose,
+        DocCloseAll,
+        DocReload,
+
+        // Session
+        NewSession,
+        SaveSessionAs,
+        ManageSessions,
+        OpenSessionSwitchDialog,
+
+        // Edit
+        Find,
+        FindNext,
+        FindPrevious,
+        Replace,
+
+        // View
+        ShowCmdLine,
+        CmdLineForCursor,
+        ShowGoToLineTool,
+        CloseToolBox,
+        ShowFullScreen,
+        FocusPostWindow,
+
+        // Settings
+        ShowSettings,
+
+        // Language
+        LookupImplementation,
+        LookupImplementationForCursor,
+        LookupReferences,
+
+        // Help
+        Help,
+        LookupReferencesForCursor,
+        LookupDocumentationForCursor,
+        LookupDocumentation,        
+
         ActionRoleCount
     };
 
+    typedef QList< CodeEditorBox * > History;
+
     MultiEditor( Main *, QWidget * parent = 0 );
 
-    int tabCount() { return mTabs->count(); }
-    Document * documentForTab( int index );
-    int tabForDocument( Document * doc );
+    Document * documentForIndex( int index );
+    int indexForDocument( Document * doc );
 
     GenericCodeEditor *currentEditor();
     CodeEditorBox *currentBox() { return mCurrentEditorBox; }
+    CodeEditorBox *returnDefaultBox() { return defaultBox; }
+    bool tempModeIsOn() { return tempMode; }
+    QVariantList originalDocumentList() { return originalDocumentsList; }
     void split( Qt::Orientation direction );
+    SignalMultiplexer * boxSigMux() { return mBoxSigMux; }
+    History & splitHistory() { return mEditorHistory; }
 
     QAction * action( ActionRole role )
         { return mActions[role]; }
@@ -125,31 +194,55 @@ public:
     void switchSession( Session * );
 
 signals:
+    void activated( MultiEditor *);
     void currentDocumentChanged( Document * );
 
 public slots:
-
     void setCurrent( Document * );
 
     void showNextDocument();
     void showPreviousDocument();
     void switchDocument();
-
+    void switchSplit();
     void splitHorizontally() { split(Qt::Horizontal); }
     void splitVertically() { split(Qt::Vertical); }
     void removeCurrentSplit();
     void removeAllSplits();
+    void splitNewWindow();
+    void removeWindow();
 
     void setShowWhitespace(bool on);
 
+    void showCmdLine( const QString & );
+
+    void saveDocument();
+    void saveDocumentAs();
+    void saveAllDocuments();
+    void closeDocument();
+    void reloadDocument();
+    void closeAllDocuments();
+    void hideToolBox();
+
 private slots:
+    void newDocument();
+    void openDocument();
+    void openStartupFile();
+    void openUserSupportDirectory();
+    void newSession();
+    void saveCurrentSessionAs();
+    void openSessionsDialog();
+    void showSwitchSessionDialog();
+    void showCmdLine();
+    void showGoToLineTool();
+    void showFindTool();
+    void showReplaceTool();
+    void findNext();
+    void findPrevious();
     void applySettings( Settings::Manager * );
     void onOpen( Document *, int initialCursorPosition, int selectionLength );
     void onClose( Document * );
     void show( Document *, int cursorPosition = -1, int selectionLenght = 0 );
     void update( Document * );
-    void onCloseRequest( int index );
-    void onCurrentTabChanged( int index );
     void onCurrentEditorChanged( GenericCodeEditor * );
     void onBoxActivated( CodeEditorBox * );
     void onDocModified( QObject * );
@@ -159,12 +252,18 @@ private:
     void breakSignalConnections();
     void createActions();
     void updateActions();
-    int addTab( Document * );
-    CodeEditorBox *newBox();
+    int addDoc( Document * );
+    CodeEditorBox *newBox(MultiSplitter *);
     void setCurrentBox( CodeEditorBox * );
     void setCurrentEditor( GenericCodeEditor * );
     void loadBoxState( CodeEditorBox *box, const QVariantList & data, const QList<Document *> & documentList );
-    void loadSplitterState( QSplitter *, const QVariantMap & data, const QList<Document *> & documentList );
+    void loadSplitterState( MultiSplitter *, const QVariantMap & data, const QList<Document *> & documentList, MultiSplitter *);
+    void addSplitToHistory(CodeEditorBox *box);
+    void removeSplitFromHistory(CodeEditorBox *box);
+    void setCurrentSplitInHistory(CodeEditorBox *box);
+    bool checkIfWindowWasClosed();
+    EditorWindow *makeNewWindow();
+    QVBoxLayout *setNewLayout(MultiSplitter *);
 
     QAction *mActions[ActionRoleCount];
 
@@ -173,11 +272,158 @@ private:
     QSignalMapper mDocModifiedSigMap;
 
     // gui
-    QTabBar *mTabs;
+    QList<Document *> mDocs;
     CodeEditorBox *mCurrentEditorBox;
     MultiSplitter *mSplitter;
     QIcon mDocModifiedIcon;
+    CodeEditorBox *defaultBox;
+
+    Main *mMain;
+    QList<MultiSplitter *> editorList;
+    QList<ToolBox *> toolBoxList;
+    QList<CmdLine *> cmdLineList;
+    QList<TextFindReplacePanel *> replaceToolList;
+    QList<GoToLineTool *> GoToLineToolList;
+    bool tempMode;
+    bool sessionChanged;
+    QVariantList originalDocumentsList;
+    bool windowIsDeleted = false;
+
+    History mEditorHistory;
 };
+    
+    class EditorWindow : public QWidget
+    {
+    public:
+        EditorWindow(QWidget * parent = 0):
+        QWidget(parent)
+        { }
+        
+        void closeEvent(QCloseEvent *event)
+        {
+            MultiEditor *editor = MainWindow::instance()->editor();
+            editor->removeWindow();
+        }
+    };
+    
+    class EditorSelectPopUp : public QDialog
+    {
+    public:
+        EditorSelectPopUp(MultiEditor::History & history, QWidget * parent):
+        QDialog(parent, Qt::Popup)
+        {
+            mModel = new QStandardItemModel(this);
+            populateModel(history);
+            
+            mListView = new QListView();
+            mListView->setModel(mModel);
+            mListView->setFrameShape(QFrame::NoFrame);
+            
+            QHBoxLayout *layout = new QHBoxLayout(this);
+            layout->addWidget(mListView);
+            layout->setContentsMargins(1,1,1,1);
+            
+            connect(mListView, SIGNAL(activated(QModelIndex)), this, SLOT(accept()));
+            
+            mListView->setFocus(Qt::OtherFocusReason);
+            
+            QModelIndex nextIndex = mModel->index(1, 0);
+            mListView->setCurrentIndex(nextIndex);
+            
+            mListView->setEditTriggers(QAbstractItemView::NoEditTriggers);
+        }
+        
+        CodeEditorBox * exec( const QPoint & pos )
+        {
+            move(pos);
+            if (QDialog::exec())
+                return currentSplit();
+            else
+                return 0;
+        }
+        
+    private:
+        bool event(QEvent * event)
+        {
+            if (event->type() == QEvent::ShortcutOverride) {
+                event->accept();
+                return true;
+            }
+            return QWidget::event(event);
+        }
+        
+        void keyReleaseEvent (QKeyEvent * ke)
+        {
+            // adapted from qtcreator
+            if (ke->modifiers() == 0
+                /*HACK this is to overcome some event inconsistencies between platforms*/
+                || (ke->modifiers() == Qt::AltModifier
+                    && (ke->key() == Qt::Key_Alt || ke->key() == -1))) {
+                    ke->accept();
+                    accept();
+                }
+            QDialog::keyReleaseEvent(ke);
+        }
+        
+        void keyPressEvent(QKeyEvent * ke)
+        {
+            switch (ke->key()) {
+                case Qt::Key_E:
+                    cycleDown();
+                    ke->accept();
+                    return;
+                    
+                case Qt::Key_Escape:
+                    reject();
+                    return;
+                    
+                default:
+                    ;
+            }
+            
+            QDialog::keyPressEvent(ke);
+        }
+        
+        void paintEvent( QPaintEvent * )
+        {
+            QPainter painter(this);
+            painter.setBrush(Qt::NoBrush);
+            painter.setPen(palette().color(QPalette::Dark));
+            painter.drawRect(rect().adjusted(0,0,-1,-1));
+        }
+        
+        void cycleDown()
+        {
+            int row = mListView->currentIndex().row() + 1;
+            if (!mModel->hasIndex(row, 0))
+                row = 0;
+            
+            QModelIndex nextIndex = mModel->index(row, 0);
+            mListView->setCurrentIndex(nextIndex);
+        }
+        
+        void cycleUp()
+        {
+            int row = mListView->currentIndex().row() - 1;
+            if (!mModel->hasIndex(row, 0))
+                row = mModel->rowCount() - 1;
+            
+            QModelIndex nextIndex = mModel->index(row, 0);
+            mListView->setCurrentIndex(nextIndex);
+        }
+        
+        CodeEditorBox * currentSplit()
+        {
+            QStandardItem * currentItem = mModel->itemFromIndex(mListView->currentIndex());
+            return currentItem ? currentItem->data().value<CodeEditorBox*>()
+            : NULL;
+        }
+        
+        void populateModel( MultiEditor::History & history );
+        
+        QListView *mListView;
+        QStandardItemModel *mModel;
+    };
 
 } // namespace ScIDE
 

--- a/editors/sc-ide/widgets/post_window.cpp
+++ b/editors/sc-ide/widgets/post_window.cpp
@@ -20,6 +20,7 @@
 
 #include "main_window.hpp"
 #include "post_window.hpp"
+#include "multi_editor.hpp"
 #include "util/gui_utilities.hpp"
 #include "../core/main.hpp"
 #include "../core/settings/manager.hpp"
@@ -89,7 +90,7 @@ void PostWindow::createActions( Settings::Manager * settings )
 
     mActions[DocClose] = ovrAction = new OverridingAction(tr("Close"), this);
     action->setStatusTip(tr("Close the current document"));
-    connect( ovrAction, SIGNAL(triggered()), this, SLOT(closeDocument()) );
+    connect( ovrAction, SIGNAL(triggered()), this, SLOT(removeWindow()) );
     ovrAction->addToWidget(this);
 
     mActions[ZoomIn] = ovrAction = new OverridingAction(tr("Enlarge Font"), this);
@@ -106,6 +107,11 @@ void PostWindow::createActions( Settings::Manager * settings )
 
     mActions[ResetZoom] = ovrAction = new OverridingAction(tr("Reset Font Size"), this);
     connect(ovrAction, SIGNAL(triggered()), this, SLOT(resetZoom()));
+    ovrAction->addToWidget(this);
+
+    mActions[SwitchSplit] = ovrAction = new OverridingAction(tr("Switch Editor"), this);
+    action->setStatusTip(tr("Switch between editors"));
+    connect( ovrAction, SIGNAL(triggered()), this, SLOT(switchSplit()) );
     ovrAction->addToWidget(this);
 
     action = new QAction(this);
@@ -131,16 +137,22 @@ void PostWindow::createActions( Settings::Manager * settings )
 void PostWindow::updateActionShortcuts( Settings::Manager * settings )
 {
     settings->beginGroup("IDE/shortcuts");
-    mActions[DocClose]->setShortcut( settings->shortcut("ide-document-close") );
+    mActions[DocClose]->setShortcut( settings->shortcut("window-remove") );
     mActions[ZoomIn]->setShortcut( settings->shortcut("editor-enlarge-font") );
     mActions[ZoomOut]->setShortcut( settings->shortcut("editor-shrink-font") );
     mActions[ResetZoom]->setShortcut( settings->shortcut("editor-reset-font-size") );
+    mActions[SwitchSplit]->setShortcut( settings->shortcut("editor-split-switch") );
     settings->endGroup();
 }
 
-void PostWindow::closeDocument()
+void PostWindow::removeWindow()
 {
     MainWindow::instance()->postDocklet()->close();
+}
+
+void PostWindow::switchSplit()
+{
+    MainWindow::instance()->editor()->switchSplit();
 }
 
 void PostWindow::applySettings(Settings::Manager * settings)

--- a/editors/sc-ide/widgets/post_window.hpp
+++ b/editors/sc-ide/widgets/post_window.hpp
@@ -44,6 +44,7 @@ public:
         ZoomIn,
         ZoomOut,
         ResetZoom,
+        SwitchSplit,
         LineWrap,
         AutoScroll,
 
@@ -71,7 +72,8 @@ public slots:
     void zoomOut(int steps = 1);
     void resetZoom();
 
-    void closeDocument();
+    void removeWindow();
+    void switchSplit();
     bool openDocumentation();
     void openDefinition();
     void openCommandLine();

--- a/editors/sc-ide/widgets/util/multi_splitter.cpp
+++ b/editors/sc-ide/widgets/util/multi_splitter.cpp
@@ -1,0 +1,178 @@
+/*
+ SuperCollider Qt IDE
+ Copyright (c) 2012 Jakob Leben & Tim Blechmann
+ http://www.audiosynth.com
+ 
+ This program is free software; you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation; either version 2 of the License, or
+ (at your option) any later version.
+ 
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with this program; if not, write to the Free Software
+ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
+ */
+
+#include "multi_splitter.hpp"
+
+namespace ScIDE {
+    
+    MultiSplitter::MultiSplitter(EditorWindow *window, QWidget *parent):
+        QSplitter(parent)
+        {
+            setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+            //if the splitter has opened on a new editor, it stores the window's address in order to close it when switch-session is called.
+            mWindow = window;
+            
+            mCmdLine = new CmdLine(tr("Command Line:"));
+            connect(mCmdLine, SIGNAL(invoked(QString, bool)),
+                    Main::scProcess(), SLOT(evaluateCode(QString, bool)));
+            
+            mReplaceTool = new TextFindReplacePanel;
+            
+            mGoToLineTool = new GoToLineTool();
+            connect(mGoToLineTool, SIGNAL(activated(int)), this, SLOT(hideToolBox()));
+            
+            mToolBox = new ToolBox;
+            mToolBox->addWidget(mCmdLine);
+            mToolBox->addWidget(mReplaceTool);
+            mToolBox->addWidget(mGoToLineTool);
+            mToolBox->hide();
+        }
+        
+        ToolBox * MultiSplitter::toolBox() { return mToolBox; }
+        CmdLine * MultiSplitter::cmdLine() { return mCmdLine; }
+        TextFindReplacePanel * MultiSplitter::findReplaceTool() { return mReplaceTool; }
+        GoToLineTool * MultiSplitter::goToLineTool() { return mGoToLineTool; }
+        
+        void MultiSplitter::addSplit(CodeEditorBox *split) {
+            splitList << split;
+        }
+        
+        void MultiSplitter::removeSplit(CodeEditorBox *split) {
+            splitList.removeOne(split);
+        }
+        
+        QList<CodeEditorBox*> MultiSplitter::splits() { return splitList; }
+        
+        void MultiSplitter::insertWidget( QWidget *widget, QWidget *neighbour, Qt::Orientation direction )
+        {
+            if (!neighbour || !widgetIsChild(neighbour)) {
+                qWarning("MultiSplitter: neighbour widget invalid");
+                return;
+            }
+            
+            QSplitter *parentSplitter = parentSplitterOf(neighbour);
+            Q_ASSERT(parentSplitter);
+            int posInParent = parentSplitter->indexOf(neighbour);
+            Q_ASSERT(posInParent != -1);
+            
+            if (parentSplitter->orientation() == direction) {
+                parentSplitter->insertWidget(posInParent + 1, widget);
+            }
+            else if (parentSplitter->count() < 2)
+            {
+                parentSplitter->setOrientation(direction);
+                parentSplitter->addWidget(widget);
+            }
+            else {
+                // store parent's current distribution:
+                QList<int> parentsSizes = parentSplitter->sizes();
+                QSplitter * splitter = new QSplitter(direction);
+                // move the neighbour to the new splitter, and add the new widget:
+                splitter->addWidget(neighbour);
+                splitter->addWidget(widget);
+                // insert the new splitter at the neighbour's old position:
+                parentSplitter->insertWidget(posInParent, splitter);
+                // restore parent's old distribution, affected by operations above:
+                parentSplitter->setSizes(parentsSizes);
+                // change the parent to the new splitter, for operations below:
+                parentSplitter = splitter;
+            }
+            
+            setEqualSizes(parentSplitter);
+        }
+        
+        void MultiSplitter::removeWidget( QWidget *widget )
+        {
+            if (!widget || !widgetIsChild(widget)) {
+                qWarning("MultiSplitter: widget invalid");
+                return;
+            }
+            
+            QSplitter *parent = parentSplitterOf(widget);
+            if (parent == this && parent->count() < 2) {
+                qWarning("MultiSplitter: can not remove last widget");
+                return;
+            }
+            
+            delete widget;
+            
+            Q_ASSERT(parent->count());
+            
+            if (parent->count() == 1) {
+                QWidget *neighbour = parent->widget(0);
+                if (parent != this) {
+                    // replace parent splitter with it's only child
+                    QSplitter *grandParent = parentSplitterOf(parent);
+                    QList<int> grandParentsSizes = grandParent->sizes();
+                    int posInParent = grandParent->indexOf(parent);
+                    Q_ASSERT(posInParent != -1);
+                    grandParent->insertWidget(posInParent, neighbour);
+                    delete parent;
+                    grandParent->setSizes(grandParentsSizes);
+                }
+                else {
+                    // replace child splitter with it's own children
+                    QSplitter *splitter = qobject_cast<QSplitter*>(neighbour);
+                    if (splitter) {
+                        QList<int> childSizes = splitter->sizes();
+                        Qt::Orientation childOrientation = splitter->orientation();
+                        int childCount = splitter->count();
+                        while(childCount--)
+                            parent->addWidget(splitter->widget(0)); // 0 is always another widget
+                        delete splitter;
+                        parent->setOrientation(childOrientation);
+                        parent->setSizes(childSizes);
+                    }
+                }
+            }
+        }
+
+        void MultiSplitter::hideToolBox() { MainWindow::instance()->editor()->hideToolBox(); }
+    
+        QSplitter * MultiSplitter::parentSplitterOf( QWidget *widget )
+        {
+            return qobject_cast<QSplitter*>( widget->parent() );
+        }
+        
+        void MultiSplitter::setEqualSizes(QSplitter *splitter)
+        {
+            int widgetCount = splitter->count();
+            int splitterSize = splitter->orientation() == Qt::Horizontal ?
+            splitter->size().width() : splitter->size().height();
+            QList<int> newWidgetSizes;
+            int singleWidgetSize = splitterSize / widgetCount;
+            for( int idx = 0; idx < widgetCount; ++idx )
+                newWidgetSizes << singleWidgetSize;
+            splitter->setSizes( newWidgetSizes );
+        }
+        
+        bool MultiSplitter::widgetIsChild( QWidget *widget )
+        {
+            QObject *object = widget->parent();
+            while (object) {
+                if (object == this)
+                    return true;
+                object = object->parent();
+            }
+            return false;
+        }
+
+    
+} // namespace ScIDE

--- a/editors/sc-ide/widgets/util/multi_splitter.hpp
+++ b/editors/sc-ide/widgets/util/multi_splitter.hpp
@@ -22,106 +22,58 @@
 #define SCIDE_WIDGETS_UTIL_MULTI_SPLITTER_HPP_INCLUDED
 
 #include <QSplitter>
+#include <QWidget>
+
+#include "../editor_box.hpp"
+#include "../cmd_line.hpp"
+#include "../find_replace_tool.hpp"
+#include "../goto_line_tool.hpp"
+#include "../tool_box.hpp"
+#include "../main_window.hpp"
+#include "../multi_editor.hpp"
 
 namespace ScIDE {
 
+class CodeEditorBox;
+class EditorWindow;
+class CmdLine;
+class ToolBox;
+class CmdLine;
+class TextFindReplacePanel;
+class GoToLineTool;
+class MainWindow;
+
 class MultiSplitter : public QSplitter
 {
+    Q_OBJECT
+    
 public:
-    explicit MultiSplitter(QWidget *parent = 0):
-        QSplitter(parent)
-    {
-        setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
-    }
+    explicit MultiSplitter(EditorWindow *window, QWidget *parent = 0);
 
-    void insertWidget( QWidget *widget, QWidget *neighbour, Qt::Orientation direction )
-    {
-        if (!neighbour || !widgetIsChild(neighbour)) {
-            qWarning("MultiSplitter: neighbour widget invalid");
-            return;
-        }
+    EditorWindow *returnWindow() { return mWindow; }
 
-        QSplitter *parentSplitter = parentSplitterOf(neighbour);
-        Q_ASSERT(parentSplitter);
-        int posInParent = parentSplitter->indexOf(neighbour);
-        Q_ASSERT(posInParent != -1);
+    ToolBox *toolBox();
+    CmdLine *cmdLine();
+    TextFindReplacePanel *findReplaceTool();
+    GoToLineTool *goToLineTool();
 
-        if (parentSplitter->orientation() == direction) {
-            parentSplitter->insertWidget(posInParent + 1, widget);
-        }
-        else if (parentSplitter->count() < 2)
-        {
-            parentSplitter->setOrientation(direction);
-            parentSplitter->addWidget(widget);
-        }
-        else {
-            // store parent's current distribution:
-            QList<int> parentsSizes = parentSplitter->sizes();
-            QSplitter * splitter = new QSplitter(direction);
-            // move the neighbour to the new splitter, and add the new widget:
-            splitter->addWidget(neighbour);
-            splitter->addWidget(widget);
-            // insert the new splitter at the neighbour's old position:
-            parentSplitter->insertWidget(posInParent, splitter);
-            // restore parent's old distribution, affected by operations above:
-            parentSplitter->setSizes(parentsSizes);
-            // change the parent to the new splitter, for operations below:
-            parentSplitter = splitter;
-        }
+    void addSplit(CodeEditorBox *split);
 
-        setEqualSizes(parentSplitter);
-    }
+    void removeSplit(CodeEditorBox *split);
 
-    void removeWidget( QWidget *widget )
-    {
-        if (!widget || !widgetIsChild(widget)) {
-            qWarning("MultiSplitter: widget invalid");
-            return;
-        }
+    QList<CodeEditorBox*> splits();
 
-        QSplitter *parent = parentSplitterOf(widget);
-        if (parent == this && parent->count() < 2) {
-            qWarning("MultiSplitter: can not remove last widget");
-            return;
-        }
+    void insertWidget( QWidget *widget, QWidget *neighbour, Qt::Orientation direction );
 
-        delete widget;
-
-        Q_ASSERT(parent->count());
-
-        if (parent->count() == 1) {
-            QWidget *neighbour = parent->widget(0);
-            if (parent != this) {
-                // replace parent splitter with it's only child
-                QSplitter *grandParent = parentSplitterOf(parent);
-                QList<int> grandParentsSizes = grandParent->sizes();
-                int posInParent = grandParent->indexOf(parent);
-                Q_ASSERT(posInParent != -1);
-                grandParent->insertWidget(posInParent, neighbour);
-                delete parent;
-                grandParent->setSizes(grandParentsSizes);
-            }
-            else {
-                // replace child splitter with it's own children
-                QSplitter *splitter = qobject_cast<QSplitter*>(neighbour);
-                if (splitter) {
-                    QList<int> childSizes = splitter->sizes();
-                    Qt::Orientation childOrientation = splitter->orientation();
-                    int childCount = splitter->count();
-                    while(childCount--)
-                        parent->addWidget(splitter->widget(0)); // 0 is always another widget
-                    delete splitter;
-                    parent->setOrientation(childOrientation);
-                    parent->setSizes(childSizes);
-                }
-            }
-        }
-    }
+    void removeWidget( QWidget *widget );
 
     template<typename T> T* findChild()
     {
         return MultiSplitter::findChild<T>(this);
     }
+    
+private slots:
+    void hideToolBox();
 
 private:
     template<typename T> static T* findChild( QSplitter * splitter ) {
@@ -141,33 +93,18 @@ private:
         return 0;
     }
 
-    QSplitter *parentSplitterOf( QWidget *widget )
-    {
-        return qobject_cast<QSplitter*>( widget->parent() );
-    }
+    QSplitter *parentSplitterOf( QWidget *widget );
 
-    void setEqualSizes(QSplitter *splitter)
-    {
-        int widgetCount = splitter->count();
-        int splitterSize = splitter->orientation() == Qt::Horizontal ?
-                    splitter->size().width() : splitter->size().height();
-        QList<int> newWidgetSizes;
-        int singleWidgetSize = splitterSize / widgetCount;
-        for( int idx = 0; idx < widgetCount; ++idx )
-            newWidgetSizes << singleWidgetSize;
-        splitter->setSizes( newWidgetSizes );
-    }
+    void setEqualSizes(QSplitter *splitter);
 
-    bool widgetIsChild( QWidget *widget )
-    {
-        QObject *object = widget->parent();
-        while (object) {
-            if (object == this)
-                return true;
-            object = object->parent();
-        }
-        return false;
-    }
+    bool widgetIsChild( QWidget *widget );
+
+    EditorWindow *mWindow;
+    QList<CodeEditorBox *> splitList;
+    ToolBox * mToolBox;
+    CmdLine * mCmdLine;
+    TextFindReplacePanel * mReplaceTool;
+    GoToLineTool * mGoToLineTool;
 };
 
 } // namespace ScIDE


### PR DESCRIPTION
This branch reworks the IDE interface for split editor views in the following broad ways:

* The previous interface shared a single tab bar between all editor splits. This uses a combobox per split instead, which is visually much clearer.
* The changes also allow for separate editor windows.

This is a fairly involved change, and it seems likely that it is not optimal and may contain some errors. Code review is especially welcome for those reasons!

Credit should go to Luca Danieli, who did most of the work on this.