### PR TITLE
Fix Scale.newFromKey with tuning argument

### DIFF
--- a/SCClassLibrary/Common/Collections/Scale.sc
+++ b/SCClassLibrary/Common/Collections/Scale.sc
@@ -24,7 +24,7 @@ Scale {
 	}
 
 	*newFromKey { |key, tuning|
-		var scale = this.at(key);
+		var scale = this.at(key).deepCopy;
 		scale ?? { ("Unknown scale " ++ key.asString).warn; ^nil };
 		tuning !? { scale.tuning_(tuning.asTuning) };
 		^scale


### PR DESCRIPTION
newFromKey was not copying the scale, which violates intent, and also
breaks usage of the 'tuning' argument which is read-only in the hardcoded
scales.
