### PR TITLE
scide: key up after line evaluation should go to original position

### DIFF
--- a/editors/sc-ide/widgets/code_editor/sc_editor.cpp
+++ b/editors/sc-ide/widgets/code_editor/sc_editor.cpp
@@ -1325,6 +1325,7 @@ void ScCodeEditor::evaluateLine()
         if( mStepForwardEvaluation ) {
             QTextCursor newCursor = cursor;
             newCursor.movePosition(QTextCursor::NextBlock);
+            newCursor.setVerticalMovementX( cursor.verticalMovementX() );
             setTextCursor(newCursor);
         }
 
@@ -1363,6 +1364,7 @@ void ScCodeEditor::evaluateRegion()
             if( mStepForwardEvaluation ) {
                 QTextCursor newCursor = cursor;
                 newCursor.movePosition(QTextCursor::NextBlock);
+                newCursor.setVerticalMovementX( cursor.verticalMovementX() );
                 setTextCursor(newCursor);
             }
             // Adjust cursor for code blinking:


### PR DESCRIPTION
@jleben would be great if you could have a quick look
