### PR TITLE
fix assign path

### DIFF
--- a/SCClassLibrary/Common/Files/SoundFile.sc
+++ b/SCClassLibrary/Common/Files/SoundFile.sc
@@ -92,8 +92,8 @@ SoundFile {
 	}
 
 	openWrite{ arg pathName;
-		pathName = pathName ? path;
-		^this.prOpenWrite(pathName)
+		path = pathName ? path;
+		^this.prOpenWrite(path)
 	}
 
 	prOpenWrite { arg pathName;


### PR DESCRIPTION
Fix for openWrite in soundFile, which assigns the path to the local instead of the object variable.
