### PR TITLE
Update win32_api.hpp

### DIFF
--- a/external_libraries/boost/boost/interprocess/detail/win32_api.hpp
+++ b/external_libraries/boost/boost/interprocess/detail/win32_api.hpp
@@ -651,7 +651,7 @@ typedef OVERLAPPED interprocess_overlapped;
 
 typedef FILETIME interprocess_filetime;
 
-typedef WIN32_FIND_DATA win32_find_data;
+typedef WIN32_FIND_DATAA win32_find_data;
 
 typedef SECURITY_ATTRIBUTES interprocess_security_attributes;
 
@@ -685,8 +685,8 @@ typedef FARPROC farproc_t;
 
 struct interprocess_semaphore_basic_information
 {
-	unsigned int count;		// current semaphore count
-	unsigned int limit;		// max semaphore count
+   unsigned int count;      // current semaphore count
+   unsigned int limit;      // max semaphore count
 };
 
 struct interprocess_section_basic_information
@@ -1522,7 +1522,7 @@ struct function_address_holder
    }
 
    public:
-   static void *get(const unsigned int id)
+   static farproc_t get(const unsigned int id)
    {
       BOOST_ASSERT(id < (unsigned int)NumFunction);
       for(unsigned i = 0; FunctionStates[id] < 2; ++i){
@@ -1900,7 +1900,7 @@ inline bool unlink_file(const char *filename)
                                     , const_cast<wchar_t*>(empty_str)
                                     };
          object_attributes_t object_attr;
-	      initialize_object_attributes(&object_attr, &ustring, 0, fh, 0);
+         initialize_object_attributes(&object_attr, &ustring, 0, fh, 0);
          void* fh2 = 0;
          io_status_block_t io;
          pNtOpenFile( &fh2, delete_flag, &object_attr, &io
@@ -2263,10 +2263,10 @@ inline bool get_last_bootup_time(std::string &stamp)
 
 inline bool is_directory(const char *path)
 {
-	unsigned long attrib = GetFileAttributesA(path);
+   unsigned long attrib = GetFileAttributesA(path);
 
-	return (attrib != invalid_file_attributes &&
-	        (attrib & file_attribute_directory));
+   return (attrib != invalid_file_attributes &&
+           (attrib & file_attribute_directory));
 }
 
 inline bool get_file_mapping_size(void *file_mapping_hnd, __int64 &size)


### PR DESCRIPTION
This modification is proposed here:
http://www.boost.org/doc/libs/develop/boost/interprocess/detail/win32_api.hpp

Description here:
https://svn.boost.org/trac/boost/ticket/10325

SC-related discussion here:
https://github.com/supercollider/supercollider/pull/1165#issuecomment-54707582

Victor Bombi found this, he can build Server and Supernova after the change and I can confirm this.
