### PR TITLE
Adding drawImage example to Pen.schelp

### DIFF
--- a/HelpSource/Classes/Pen.schelp
+++ b/HelpSource/Classes/Pen.schelp
@@ -628,6 +628,18 @@ method:: lineDash
 Set the line dash pattern.
 pattern should be a link::Classes/FloatArray:: of values that specify the lengths of the painted segments and not painted segments.
 
+method:: drawImage
+Draw a bitmap image using the Image class.
+discussion::
+example:
+code::
+w = Window.new.front;
+w.view.background = Color.red;
+i = Image.open(SCDoc.helpSourceDir +/+ "images/Swamp.png");
+w.drawFunc_({
+	Pen.drawImage( Point(140, 140), i, operation: 'sourceOver', opacity:1);
+});
+
 examples::
 Simple rotating and scaling:
 code::


### PR DESCRIPTION
I've tested this reasonably well here, but it could do with further stress testing.