### PR TITLE
scel: highlight uppercase symbols in emacs

### DIFF
--- a/editors/scel/el/sclang-language.el
+++ b/editors/scel/el/sclang-language.el
@@ -48,7 +48,7 @@ The expressions are joined as alternatives with the \\| operator."
   "Regular expression matching symbols.")
 
 (defconst sclang-identifier-regexp
-  (concat "[a-z]" sclang-symbol-regexp)
+  (concat "[a-zA-Z]" sclang-symbol-regexp)
   "Regular expression matching valid identifiers.")
 
 (defconst sclang-method-name-special-chars


### PR DESCRIPTION
Noticed this when keys beginning with an uppercase letter in events weren't getting highlighted:
```supercollider
(
  highlighted: "value",
  NotHighlighted: "value"
)
```