### PR TITLE
lang: Fix TCP bugs

### DIFF
--- a/lang/LangPrimSource/OSCData.cpp
+++ b/lang/LangPrimSource/OSCData.cpp
@@ -658,7 +658,7 @@ static PyrObject* ConvertReplyAddress(ReplyAddress *inReply)
 	PyrObject *obj = instantiateObject(g->gc, s_netaddr->u.classobj, 2, true, false);
 	PyrSlot *slots = obj->slots;
 	SetInt(slots+0, inReply->mAddress.to_v4().to_ulong());
-	SetInt(slots+1, sc_ntohs(inReply->mPort));
+	SetInt(slots+1, inReply->mPort);
 	return obj;
 }
 

--- a/lang/LangPrimSource/SC_ComPort.cpp
+++ b/lang/LangPrimSource/SC_ComPort.cpp
@@ -129,7 +129,7 @@ void SC_UdpInPort::handleReceivedUDP(const boost::system::error_code& error,
 
 	packet->mReplyAddr.mProtocol  = kUDP;
 	packet->mReplyAddr.mAddress   = remoteEndpoint.address();
-	packet->mReplyAddr.mPort      = sc_htons(remoteEndpoint.port());
+	packet->mReplyAddr.mPort      = remoteEndpoint.port();
 	packet->mReplyAddr.mSocket    = udpSocket.native_handle();
 
 	char *data = (char*)malloc(bytesTransferred);
@@ -295,11 +295,12 @@ void SC_TcpClientPort::handleMsgReceived(const boost::system::error_code &error,
 	packet->mReplyAddr.mProtocol = kTCP;
 	packet->mReplyAddr.mSocket   = socket.native_handle();
 	packet->mReplyAddr.mAddress  = socket.remote_endpoint().address();
+    packet->mReplyAddr.mPort      = socket.remote_endpoint().port();
 
 	packet->mSize                 = OSCMsgLength;
 	packet->mData                 = data;
 
-	ProcessOSCPacket(packet, endpoint.port(), timeReceived);
+	ProcessOSCPacket(packet, socket.local_endpoint().port(), timeReceived);
 
 	startReceive();
 }


### PR DESCRIPTION
This fixes Issue #1099. The problem was to do with the way in which incoming TCP messages were constructed before passing to the lang:
- The remote port info was not being set at all, and was then being converted from network to host order in ConvertReplyAddress. This was not needed as boost::asio::ip always gives ports in host order. UDP only worked because port was converted to network order and then back in ConvertReplyAddress, so that was removed as well.
- The received on port was being set to the remote port, so that was also corrected.

@timblechmann could you please take a look at this, and made sure I've done this correctly?
