### PR TITLE
Fix "QNetworkRequest header not found".

### DIFF
--- a/QtCollider/CMakeLists.txt
+++ b/QtCollider/CMakeLists.txt
@@ -4,7 +4,7 @@ else()
     set(required_qt_version 4.7)
 endif()
 
-find_package (Qt4 ${required_qt_version} COMPONENTS QtCore QtGui QtWebKit)
+find_package (Qt4 ${required_qt_version} COMPONENTS QtCore QtGui QtWebKit QtNetwork)
 
 if (NOT QT4_FOUND)
     set(FIND_QT_ERROR_MSG "You are trying to compile with Qt GUI support, but a suitable version of Qt or one of its components could not be found:")

--- a/QtCollider/QtDownload.h
+++ b/QtCollider/QtDownload.h
@@ -23,8 +23,8 @@
 
 #include <QObject>
 #include <QString>
-#include <QtNetwork/QNetworkAccessManager>
-#include <QtNetwork/QNetworkReply>
+#include <QNetworkAccessManager>
+#include <QNetworkReply>
 
 
 class QtDownload : public QObject {


### PR DESCRIPTION
- The QtNetwork include path prefix is used in QtDownload.h for QNetwork* headers.
- For the QNetworkRequest header there is no QtNetwork inlude path prefix in QtDownload.cpp which gives a "header not found" compile error on ArchLinux.

Signed-off-by: Hanspeter Portner <dev@open-music-kontrollers.ch>