### PR TITLE
Classlib: Rest: Add 'value' method to simplify mixing rests and numbers

### DIFF
--- a/SCClassLibrary/Common/Streams/Rest.sc
+++ b/SCClassLibrary/Common/Streams/Rest.sc
@@ -33,7 +33,7 @@ Rest {
 			}
 		})
 	}
-
+	value { ^dur }
 	storeOn { |stream| stream << "Rest(" << dur << ")" }
 }
 


### PR DESCRIPTION
Without this commit, it's unnecessarily difficult to iterate over an array containing both numbers and rests.

```
a = [1, 2, Rest(3), 4];
a.sum;  // binary operator '+' failed

// insane
a.sum { |item| if(item.isKindOf(Rest)) { item.dur } { item } };
```

With the change, you can just do `a.sum(_.value)`, piece of cake.
