### PR TITLE
Classlib: Pfuncn: Like Pfunc, this should call processRest before yield

### DIFF
--- a/SCClassLibrary/Common/Streams/Patterns.sc
+++ b/SCClassLibrary/Common/Streams/Patterns.sc
@@ -182,7 +182,7 @@ Pfuncn : Pattern {
 	storeArgs { ^[func,repeats] }
 	embedInStream {  arg inval;
 		repeats.value(inval).do({
-			inval = func.value(inval).yield;
+			inval = func.value(inval).processRest(inval).yield;
 		});
 		^inval
 	}


### PR DESCRIPTION
Pfunc had been fixed a while back, to process Rests in the resulting event properly. But that fix inadvertently left out Pfuncn. This PR corrects that oversight.
