### PR TITLE
Classlib: QPenPrinter: Add 'bounds' method

### DIFF
--- a/SCClassLibrary/Common/GUI/Base/QPenPrinter.sc
+++ b/SCClassLibrary/Common/GUI/Base/QPenPrinter.sc
@@ -60,4 +60,6 @@ QPenPrinter : QObject {
 	fromPage { ^this.getProperty(\fromPage) }
 	toPage { ^this.getProperty(\toPage) }
 	pageSize { ^this.pageRect.size }
+
+	bounds { ^this.pageRect }
 }


### PR DESCRIPTION
This PR makes it simpler to use the same function as a UserView drawFunc and also with QPenPrinter.

Use case: Say I want to print vector graphics from a user view. I test the drawFunc in a user view (easier to see the results immediately). I want the function to adapt to the view size, so the function begins:

```
u.drawFunc = { |view|
    var b = view.bounds.moveTo(0, 0);
    ...
};
```

Now I've got it looking right, so I want to use it in QPenPrinter, but guess what? "Message 'bounds' not understood." So then I have to edit the function to call `pageRect` instead, or write something really silly like:

```
var b = if(view.isKindOf(QPenPrinter)) {
    view.pageRect
} {
    view.bounds
}.moveTo(0, 0);
```

Since the QPenPrinter is basically a stand-in for the user view, I think it should also respond to `bounds`.
