### PR TITLE
Classlib: Pstep: Fix unnecessary creation of an array on every iteration

### DIFF
--- a/SCClassLibrary/Common/Streams/TimePatterns.sc
+++ b/SCClassLibrary/Common/Streams/TimePatterns.sc
@@ -15,7 +15,7 @@ Pstep : Pattern {
 		repeats.value(inval).do { | i |
 			stream = Ptuple([list, durs]).asStream;
 			while (
-				{ #val, dur = stream.next(inval) ? [nil, nil];
+				{ #val, dur = stream.next(inval) ?? { #[nil, nil] };
 					val.notNil;
 				},
 				{


### PR DESCRIPTION
```
#val, dur = stream.next(inval) ? [nil, nil];
```

This means, **always** create the two-item array, even if `stream.next(inval)` is not nil. Non-nil is the normal case, by far more frequent. It should be conditional to create the array, and there's no reason why it shouldn't be a literal array.
