### PR TITLE
IFFT.schelp: fix example

### DIFF
--- a/HelpSource/Classes/IFFT.schelp
+++ b/HelpSource/Classes/IFFT.schelp
@@ -41,13 +41,13 @@ Examples::
 code::
 
 // without any modification, convert FFT chain (frequency domain signal) back to audio (time domain signal)
-{
-	var in, chain;
-	in = WhiteNoise.ar(0.01);
-	chain = FFT(LocalBuf(2048), in);
-	IFFT.ar(chain) // inverse FFT
-	);
+(
+{   var in, chain;
+    in = WhiteNoise.ar;
+    chain = FFT(LocalBuf(2048), in);
+    IFFT.ar(chain) * -20.dbamp // inverse FFT
 }.play;
+)
 
 ::
 


### PR DESCRIPTION
removed excess parenthesis and semicolon, made the example more accessible 
