### PR TITLE
plugins: EnvGen checks for prehistoric release message

### DIFF
--- a/server/plugins/LFUGens.cpp
+++ b/server/plugins/LFUGens.cpp
@@ -3189,7 +3189,7 @@ void Linen_Ctor(Linen *unit)
 	unit->m_level = 0.f;
 	unit->m_stage = 4;
 	unit->m_prevGate = 0.f;
-	if(ZIN0(0) <= 0.f) { unit->m_stage = 1; } // early release
+	if(ZIN0(0) <= -1.f) { unit->m_stage = 1; } // early release
 	Linen_next_k(unit, 1);
 }
 


### PR DESCRIPTION
This small change should fix the numerous and long-standing issues with synth release messages that arrive in the same block as the synth, such as #1063, and #1246.
