### PR TITLE
Apple build: Prevent supernova from being installed twice

### DIFF
--- a/server/supernova/CMakeLists.txt
+++ b/server/supernova/CMakeLists.txt
@@ -145,14 +145,11 @@ add_executable(supernova server/main.cpp ${supernova_headers})
 target_link_libraries(supernova libsupernova)
 
 
-if(APPLE)
-      set_property(TARGET supernova
-                   PROPERTY RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/editors/sc-ide/${ide_name}.app/Contents/Resources/")
-elseif(WIN32)
+if(WIN32)
 	install(TARGETS supernova
         DESTINATION "SuperCollider"
         PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
-else()
+elseif(NOT APPLE)
   install(TARGETS supernova
           DESTINATION "bin"
           PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)


### PR DESCRIPTION
Currently binaries (including supernova) land in Content/MacOS as defined here: https://github.com/supercollider/supercollider/blob/qt52/editors/sc-ide/CMakeLists.txt

Removed lines above want to install supernova again in the old location and thus create an install-error.
