### PR TITLE
class library: translations between key value pairs, asscociations, and dictionaries

### DIFF
--- a/SCClassLibrary/Common/Collections/Collection.sc
+++ b/SCClassLibrary/Common/Collections/Collection.sc
@@ -548,49 +548,49 @@ Collection {
 	asSortedList { | function | ^SortedList.new(this.size, function).addAll(this) }
 
 	asAssociations {
-        var res;
-        if(this.hasAssociations) { ^this };
-        res = Array.new(this.size div: 2);
-        this.pairsDo { |key, val| res.add(key -> val) }
-        ^res
-    }
+		var res;
+		if(this.hasAssociations) { ^this };
+		res = Array.new(this.size div: 2);
+		this.pairsDo { |key, val| res.add(key -> val) }
+		^res
+	}
 
-    asPairs {
-        var res;
-        if(this.hasAssociations.not) { ^this };
-        res = Array.new(this.size div: 2);
-        this.do { |assoc| res.add(assoc.key).add(assoc.value) }
-        ^res
-    }
+	asPairs {
+		var res;
+		if(this.hasAssociations.not) { ^this };
+		res = Array.new(this.size div: 2);
+		this.do { |assoc| res.add(assoc.key).add(assoc.value) }
+		^res
+	}
 
-    asDict { |mergeFunc|
-        var res = IdentityDictionary.new; // another dispute: Dictionary would default to a very inefficient lookup.
-        if(mergeFunc.notNil) { ^this.asDictWith(mergeFunc) };
-        if(this.hasAssociations) {
-            this.do { |assoc|
-                res.put(assoc.key, assoc.value)
-            }
-        } {
-            this.pairsDo { |key, val|
-                res.put(key, val)
-            }
-        };
-        ^res
-    }
+	asDict { |mergeFunc|
+		var res = IdentityDictionary.new; // another dispute: Dictionary would default to a very inefficient lookup.
+		if(mergeFunc.notNil) { ^this.asDictWith(mergeFunc) };
+		if(this.hasAssociations) {
+			this.do { |assoc|
+				res.put(assoc.key, assoc.value)
+			}
+		} {
+			this.pairsDo { |key, val|
+				res.put(key, val)
+			}
+		};
+		^res
+	}
 
-    asDictWith { |mergeFunc|
-        var res = IdentityDictionary.new;
-        if(this.hasAssociations) {
-            this.do { |assoc|
-                res.mergeItem(assoc.key, assoc.value, mergeFunc)
-            }
-        } {
-            this.pairsDo { |key, val|
-                res.mergeItem(key, val, mergeFunc)
-            }
-        };
-        ^res
-    }
+	asDictWith { |mergeFunc|
+		var res = IdentityDictionary.new;
+		if(this.hasAssociations) {
+			this.do { |assoc|
+				res.mergeItem(assoc.key, assoc.value, mergeFunc)
+			}
+		} {
+			this.pairsDo { |key, val|
+				res.mergeItem(key, val, mergeFunc)
+			}
+		};
+		^res
+	}
 
 	powerset {
 		var species = this.species;

--- a/SCClassLibrary/Common/Collections/Collection.sc
+++ b/SCClassLibrary/Common/Collections/Collection.sc
@@ -101,7 +101,7 @@ Collection {
 	notEmpty { ^this.size > 0 }
 	asCollection { ^this }
 	isCollection { ^true }
-	hasAssociations { ^this.subclassResponsibility(thisMethod) }
+	isAssociationArray { ^this.subclassResponsibility(thisMethod) }
 
 	add { ^this.subclassResponsibility(thisMethod) }
 	addAll { | aCollection | aCollection.asCollection.do { | item | this.add(item) } }
@@ -549,7 +549,7 @@ Collection {
 
 	asAssociations {
 		var res;
-		if(this.hasAssociations) { ^this };
+		if(this.isAssociationArray) { ^this };
 		res = Array.new(this.size div: 2);
 		this.pairsDo { |key, val| res.add(key -> val) }
 		^res
@@ -557,7 +557,7 @@ Collection {
 
 	asPairs {
 		var res;
-		if(this.hasAssociations.not) { ^this };
+		if(this.isAssociationArray.not) { ^this };
 		res = Array.new(this.size div: 2);
 		this.do { |assoc| res.add(assoc.key).add(assoc.value) }
 		^res
@@ -566,7 +566,7 @@ Collection {
 	asDict { |mergeFunc|
 		var res = IdentityDictionary.new; // another dispute: Dictionary would default to a very inefficient lookup.
 		if(mergeFunc.notNil) { ^this.asDictWith(mergeFunc) };
-		if(this.hasAssociations) {
+		if(this.isAssociationArray) {
 			this.do { |assoc|
 				res.put(assoc.key, assoc.value)
 			}
@@ -580,7 +580,7 @@ Collection {
 
 	asDictWith { |mergeFunc|
 		var res = IdentityDictionary.new;
-		if(this.hasAssociations) {
+		if(this.isAssociationArray) {
 			this.do { |assoc|
 				res.mergeItem(assoc.key, assoc.value, mergeFunc)
 			}

--- a/SCClassLibrary/Common/Collections/Collection.sc
+++ b/SCClassLibrary/Common/Collections/Collection.sc
@@ -101,6 +101,7 @@ Collection {
 	notEmpty { ^this.size > 0 }
 	asCollection { ^this }
 	isCollection { ^true }
+	hasAssociations { ^this.subclassResponsibility(thisMethod) }
 
 	add { ^this.subclassResponsibility(thisMethod) }
 	addAll { | aCollection | aCollection.asCollection.do { | item | this.add(item) } }
@@ -540,11 +541,56 @@ Collection {
 	}
 	isSubsetOf { | that | ^that.includesAll(this) }
 
-	asArray { ^Array.new(this.size).addAll(this); }
-	asBag { ^Bag.new(this.size).addAll(this); }
-	asList { ^List.new(this.size).addAll(this); }
-	asSet { ^Set.new(this.size).addAll(this); }
-	asSortedList { | function | ^SortedList.new(this.size, function).addAll(this); }
+	asArray { ^Array.new(this.size).addAll(this) }
+	asBag { ^Bag.new(this.size).addAll(this) }
+	asList { ^List.new(this.size).addAll(this) }
+	asSet { ^Set.new(this.size).addAll(this) }
+	asSortedList { | function | ^SortedList.new(this.size, function).addAll(this) }
+
+	asAssociations {
+        var res;
+        if(this.hasAssociations) { ^this };
+        res = Array.new(this.size div: 2);
+        this.pairsDo { |key, val| res.add(key -> val) }
+        ^res
+    }
+
+    asPairs {
+        var res;
+        if(this.hasAssociations.not) { ^this };
+        res = Array.new(this.size div: 2);
+        this.do { |assoc| res.add(assoc.key).add(assoc.value) }
+        ^res
+    }
+
+    asDict { |mergeFunc|
+        var res = IdentityDictionary.new; // another dispute: Dictionary would default to a very inefficient lookup.
+        if(mergeFunc.notNil) { ^this.asDictWith(mergeFunc) };
+        if(this.hasAssociations) {
+            this.do { |assoc|
+                res.put(assoc.key, assoc.value)
+            }
+        } {
+            this.pairsDo { |key, val|
+                res.put(key, val)
+            }
+        };
+        ^res
+    }
+
+    asDictWith { |mergeFunc|
+        var res = IdentityDictionary.new;
+        if(this.hasAssociations) {
+            this.do { |assoc|
+                res.mergeItem(assoc.key, assoc.value, mergeFunc)
+            }
+        } {
+            this.pairsDo { |key, val|
+                res.mergeItem(key, val, mergeFunc)
+            }
+        };
+        ^res
+    }
 
 	powerset {
 		var species = this.species;

--- a/SCClassLibrary/Common/Collections/Dictionary.sc
+++ b/SCClassLibrary/Common/Collections/Dictionary.sc
@@ -198,16 +198,16 @@ Dictionary : Set {
 	}
 
 
-    mergeItem { |key, val, func|
-        var old;
-        if(func.notNil) {
-            old = this.at(key);
-            if(old.notNil) {
-                 val = func.value(val, old)
-            }
-        };
-        this.put(key, val)
-    }
+	mergeItem { |key, val, func|
+		var old;
+		if(func.notNil) {
+			old = this.at(key);
+			if(old.notNil) {
+				 val = func.value(val, old)
+			}
+		};
+		this.put(key, val)
+	}
 
 	blend { |that, blend = 0.5, fill = true, specs|
 
@@ -293,13 +293,13 @@ Dictionary : Set {
 
 	hasAssociations { ^false }
 
-    asPairs {
-        ^this.getPairs
-    }
+	asPairs {
+		^this.getPairs
+	}
 
-    asDict {
-        ^this
-    }
+	asDict {
+		^this
+	}
 
 
 	// PRIVATE IMPLEMENTATION

--- a/SCClassLibrary/Common/Collections/Dictionary.sc
+++ b/SCClassLibrary/Common/Collections/Dictionary.sc
@@ -197,6 +197,18 @@ Dictionary : Set {
 		^res
 	}
 
+
+    mergeItem { |key, val, func|
+        var old;
+        if(func.notNil) {
+            old = this.at(key);
+            if(old.notNil) {
+                 val = func.value(val, old)
+            }
+        };
+        this.put(key, val)
+    }
+
 	blend { |that, blend = 0.5, fill = true, specs|
 
 		^this.merge(that, { |a, b, key|
@@ -278,6 +290,17 @@ Dictionary : Set {
 		this.keysValuesDo { |key, val| array.add(key); array.add(val) };
 		^array
 	}
+
+	hasAssociations { ^false }
+
+    asPairs {
+        ^this.getPairs
+    }
+
+    asDict {
+        ^this
+    }
+
 
 	// PRIVATE IMPLEMENTATION
 	keysValuesArrayDo { arg argArray, function;

--- a/SCClassLibrary/Common/Collections/Dictionary.sc
+++ b/SCClassLibrary/Common/Collections/Dictionary.sc
@@ -291,7 +291,7 @@ Dictionary : Set {
 		^array
 	}
 
-	hasAssociations { ^false }
+	isAssociationArray { ^false }
 
 	asPairs {
 		^this.getPairs

--- a/SCClassLibrary/Common/Collections/SequenceableCollection.sc
+++ b/SCClassLibrary/Common/Collections/SequenceableCollection.sc
@@ -654,6 +654,7 @@ SequenceableCollection : Collection {
 
 	isSequenceableCollection { ^true }
 	containsSeqColl { ^this.any(_.isSequenceableCollection) }
+	hasAssociations { ^this.at(0).isKindOf(Association) }
 
 	// unary math ops
 	neg { ^this.performUnaryOp('neg') }

--- a/SCClassLibrary/Common/Collections/SequenceableCollection.sc
+++ b/SCClassLibrary/Common/Collections/SequenceableCollection.sc
@@ -654,7 +654,7 @@ SequenceableCollection : Collection {
 
 	isSequenceableCollection { ^true }
 	containsSeqColl { ^this.any(_.isSequenceableCollection) }
-	hasAssociations { ^this.at(0).isKindOf(Association) }
+	isAssociationArray { ^this.at(0).isKindOf(Association) }
 
 	// unary math ops
 	neg { ^this.performUnaryOp('neg') }


### PR DESCRIPTION
This solution was suggested in the discussion about inject and it fixes #1245. The additional methods provides convenient transition between three commonly used and useful data structures:

key value pairs: common representation of arguments
collections of associations: ordering, array and collection methods
dictionaries: fast lookup, event compatibility

A possible improvement could be a primitive for the hasAssociations method, which currently prone to be misunderstood (too inefficient would have been the other choice).