### PR TITLE
scide: introducing yank and kill line

### DIFF
--- a/editors/sc-ide/widgets/code_editor/editor.cpp
+++ b/editors/sc-ide/widgets/code_editor/editor.cpp
@@ -38,6 +38,7 @@
 #include <QUrl>
 #include <QMimeData>
 #include <QScrollBar>
+#include <QClipboard>
 
 #ifdef Q_WS_X11
 # include <QX11Info>
@@ -1078,6 +1079,38 @@ void GenericCodeEditor::copyLineDown()
 void GenericCodeEditor::copyLineUp()
 {
     copyUpDown(true);
+}
+
+void GenericCodeEditor::copyKillLine(bool kill)
+{
+    QTextCursor cur = textCursor();
+    QClipboard *clip = QApplication::clipboard();
+
+    cur.beginEditBlock();
+
+    cur.movePosition(QTextCursor::StartOfLine);
+    cur.movePosition(QTextCursor::EndOfLine, QTextCursor::KeepAnchor);
+
+    clip->setText("\n" + cur.selectedText());
+
+    if (kill) {
+        // the first delete the selection
+        // the next one removes the empty line
+        cur.deletePreviousChar();
+        cur.deletePreviousChar();
+    }
+
+    cur.endEditBlock();
+}
+
+void GenericCodeEditor::copyLine()
+{
+    copyKillLine(false);
+}
+
+void GenericCodeEditor::killLine()
+{
+    copyKillLine(true);
 }
 
 void GenericCodeEditor::moveLineUpDown(bool up)

--- a/editors/sc-ide/widgets/code_editor/editor.hpp
+++ b/editors/sc-ide/widgets/code_editor/editor.hpp
@@ -84,6 +84,8 @@ public slots:
     void toggleOverwriteMode();
     void copyLineUp();
     void copyLineDown();
+    void copyLine();
+    void killLine();
     void moveLineUp();
     void moveLineDown();
     void gotoPreviousEmptyLine();
@@ -108,6 +110,7 @@ protected:
     void zoomFont(int steps);
 
     void copyUpDown(bool up);
+    void copyKillLine(bool);
     void moveLineUpDown(bool up);
     void gotoEmptyLineUpDown(bool up);
 

--- a/editors/sc-ide/widgets/multi_editor.cpp
+++ b/editors/sc-ide/widgets/multi_editor.cpp
@@ -372,6 +372,20 @@ void MultiEditor::createActions()
     mEditorSigMux->connect(action, SIGNAL(triggered()), SLOT(copyLineDown()));
     settings->addAction( action, "editor-copy-line-down", editorCategory);
 
+    mActions[CopyLine] = action = new QAction(
+        QIcon::fromTheme("edit-copyline"), tr("Copy current line to clipboard"), this);
+    action->setShortcut(tr("Ctrl+Y", "Copy Line"));
+    action->setShortcutContext(Qt::WidgetWithChildrenShortcut);
+    mEditorSigMux->connect(action, SIGNAL(triggered()), SLOT(copyLine()));
+    settings->addAction(action, "editor-copy-line", editorCategory);
+
+    mActions[KillLine] = action = new QAction(
+        QIcon::fromTheme("edit-killline"), tr("Remove the current line"), this);
+    action->setShortcut(tr("Ctrl+K", "Remove Line"));
+    action->setShortcutContext(Qt::WidgetWithChildrenShortcut);
+    mEditorSigMux->connect(action, SIGNAL(triggered()), SLOT(killLine()));
+    settings->addAction(action, "editor-kill-line", editorCategory);
+
     mActions[MoveLineUp] = action = new QAction(
         QIcon::fromTheme("edit-movelineup"), tr("Move Line Up"), this);
     action->setShortcut(tr("Ctrl+Shift+Up", "Move Line Up"));
@@ -598,6 +612,9 @@ void MultiEditor::createActions()
     addAction(mActions[ToggleOverwriteMode]);
     addAction(mActions[CopyLineUp]);
     addAction(mActions[CopyLineDown]);
+    addAction(mActions[CopyLine]);
+    addAction(mActions[KillLine]);
+    addAction(mActions[CopyLineDown]);
     addAction(mActions[MoveLineUp]);
     addAction(mActions[MoveLineDown]);
     addAction(mActions[GotoPreviousBlock]);
@@ -624,6 +641,8 @@ void MultiEditor::updateActions()
     mActions[ToggleOverwriteMode]->setEnabled( editor );
     mActions[CopyLineUp]->setEnabled( editor );
     mActions[CopyLineDown]->setEnabled( editor );
+    mActions[CopyLine]->setEnabled( editor );
+    mActions[KillLine]->setEnabled( editor );
     mActions[MoveLineUp]->setEnabled( editor );
     mActions[MoveLineDown]->setEnabled( editor );
     mActions[GotoPreviousEmptyLine]->setEnabled( editor );

--- a/editors/sc-ide/widgets/multi_editor.hpp
+++ b/editors/sc-ide/widgets/multi_editor.hpp
@@ -69,6 +69,8 @@ public:
 
         CopyLineUp,
         CopyLineDown,
+        CopyLine,
+        KillLine,
         MoveLineUp,
         MoveLineDown,
 


### PR DESCRIPTION
Yank (ctrl+y) copy the current line into the system clipboard.
Kill (ctrl+k) delete and copy the current line into the system clipboard.

Feature request https://github.com/supercollider/supercollider/issues/633