### PR TITLE
string: regex: rename firstRegexp

### DIFF
--- a/HelpSource/Classes/String.schelp
+++ b/HelpSource/Classes/String.schelp
@@ -313,19 +313,19 @@ code::
 "aaaabaaa".findAllRegexp("a+");
 ::
 
-method::firstRegexp
-Match a regular expression, at given offset, returning the match and the length of the match in an Array, or nil when there's no matches.
-Will not search entire string.
+method::findRegexpAt
+Match a regular expression at the given offset, returning the match and the length of the match in an Array, or nil if it doesn't match.
+The match must begin right at the offset.
 
 code::
-"foobaroob".firstRegexp("o*b+", 0); // nil
-"foobaroob".firstRegexp("o*b+", 1); // [ oob, 3 ]
-"foobaroob".firstRegexp("o*b+", 2); // [ ob,  2 ]
-"foobaroob".firstRegexp("o*b+", 3); // [ b,   1 ]
-"foobaroob".firstRegexp("o*b+", 4); // nil
-"foobaroob".firstRegexp("o*b+", 5); // nil
-"foobaroob".firstRegexp("o*b+", 6); // [ oob, 3 ]
-"foobaroob".firstRegexp("o*b+", 7); // [ ob,  2 ]
+"foobaroob".findRegexpAt("o*b+", 0); // nil
+"foobaroob".findRegexpAt("o*b+", 1); // [ oob, 3 ]
+"foobaroob".findRegexpAt("o*b+", 2); // [ ob,  2 ]
+"foobaroob".findRegexpAt("o*b+", 3); // [ b,   1 ]
+"foobaroob".findRegexpAt("o*b+", 4); // nil
+"foobaroob".findRegexpAt("o*b+", 5); // nil
+"foobaroob".findRegexpAt("o*b+", 6); // [ oob, 3 ]
+"foobaroob".findRegexpAt("o*b+", 7); // [ ob,  2 ]
 ::
 
 subsection:: Searching strings

--- a/SCClassLibrary/Common/Collections/String.sc
+++ b/SCClassLibrary/Common/Collections/String.sc
@@ -198,9 +198,9 @@ String[char] : RawArray {
 		^this.find(string, true, offset).notNil
 	}
 
-	firstRegexp { arg regexp, offset = 0;
-	   _String_FirstRegexp
-	   ^this.primitiveFailed
+	findRegexpAt { arg regexp, offset = 0;
+		_String_FindRegexpAt
+		^this.primitiveFailed
 	}
 
 	findRegexp { arg regexp, offset = 0;

--- a/lang/LangPrimSource/PyrStringPrim.cpp
+++ b/lang/LangPrimSource/PyrStringPrim.cpp
@@ -435,7 +435,7 @@ static int prString_FindRegexp(struct VMGlobals *g, int numArgsPushed)
 	return errNone;
 }
 
-static int prString_FirstRegexp(struct VMGlobals *g, int numArgsPushed)
+static int prString_FindRegexpAt(struct VMGlobals *g, int numArgsPushed)
 {
 	/* not reentrant */
 	static detail::regex_lru_cache regex_lru_cache(boost::regex_constants::ECMAScript);
@@ -477,7 +477,7 @@ static int prString_FirstRegexp(struct VMGlobals *g, int numArgsPushed)
 			return errNone;
 		}
 	} catch (std::exception const & e) {
-		postfl("Warning: Exception in _String_FirstRegexp - %s\n", e.what());
+		postfl("Warning: Exception in _String_FindRegexpAt - %s\n", e.what());
 		return errFailed;
 	}
 
@@ -1071,7 +1071,7 @@ void initStringPrimitives()
 	definePrimitive(base, index++, "_String_Format", prString_Format, 2, 0);
 	definePrimitive(base, index++, "_String_Regexp", prString_Regexp, 4, 0);
 	definePrimitive(base, index++, "_String_FindRegexp", prString_FindRegexp, 3, 0);
-	definePrimitive(base, index++, "_String_FirstRegexp", prString_FirstRegexp, 3, 0);
+	definePrimitive(base, index++, "_String_FindRegexpAt", prString_FindRegexpAt, 3, 0);
 	definePrimitive(base, index++, "_StripRtf", prStripRtf, 1, 0);
 	definePrimitive(base, index++, "_StripHtml", prStripHtml, 1, 0);
 	definePrimitive(base, index++, "_String_StandardizePath", prString_StandardizePath, 1, 0);


### PR DESCRIPTION
Renaming firstRegexp to findRegexpAt, as discussed in #1248 
