### PR TITLE
scide: add OSX delete word ctrl+w shortcut

### DIFF
--- a/editors/sc-ide/widgets/code_editor/editor.cpp
+++ b/editors/sc-ide/widgets/code_editor/editor.cpp
@@ -1149,6 +1149,18 @@ void GenericCodeEditor::moveLineDown()
     moveLineUpDown(false);
 }
 
+void GenericCodeEditor::deleteWord()
+{
+    QTextCursor cur = textCursor();
+
+    cur.beginEditBlock();
+
+    cur.movePosition(QTextCursor::StartOfWord, QTextCursor::KeepAnchor);
+    cur.deletePreviousChar();
+
+    cur.endEditBlock();
+}
+
 void GenericCodeEditor::gotoPreviousEmptyLine()
 {
     gotoEmptyLineUpDown(true);

--- a/editors/sc-ide/widgets/code_editor/editor.hpp
+++ b/editors/sc-ide/widgets/code_editor/editor.hpp
@@ -86,6 +86,7 @@ public slots:
     void copyLineDown();
     void moveLineUp();
     void moveLineDown();
+    void deleteWord();
     void gotoPreviousEmptyLine();
     void gotoNextEmptyLine();
     void setActiveAppearance(bool active);

--- a/editors/sc-ide/widgets/multi_editor.cpp
+++ b/editors/sc-ide/widgets/multi_editor.cpp
@@ -386,6 +386,15 @@ void MultiEditor::createActions()
     mEditorSigMux->connect(action, SIGNAL(triggered()), SLOT(moveLineDown()));
     settings->addAction( action, "editor-move-line-down", editorCategory);
 
+#ifdef Q_OS_MAC
+    mActions[DeleteWord] = action = new QAction(
+        QIcon::fromTheme("edit-deleteword"), tr("Delete Word"), this);
+    action->setShortcut(tr("Meta+W", "Delete Word"));
+    action->setShortcutContext(Qt::WidgetWithChildrenShortcut);
+    mEditorSigMux->connect(action, SIGNAL(triggered()), SLOT(deleteWord()));
+    settings->addAction(action, "delete-word", editorCategory);
+#endif
+
     mActions[GotoPreviousBlock] = action = new QAction(
         QIcon::fromTheme("edit-gotopreviousblock"), tr("Go to Previous Block"), this);
     action->setShortcut(tr("Ctrl+[", "Go to Previous Block"));
@@ -600,6 +609,9 @@ void MultiEditor::createActions()
     addAction(mActions[CopyLineDown]);
     addAction(mActions[MoveLineUp]);
     addAction(mActions[MoveLineDown]);
+#ifdef Q_OS_MAC
+    addAction(mActions[DeleteWord]);
+#endif
     addAction(mActions[GotoPreviousBlock]);
     addAction(mActions[GotoNextBlock]);
     addAction(mActions[SelectEnclosingBlock]);
@@ -626,6 +638,9 @@ void MultiEditor::updateActions()
     mActions[CopyLineDown]->setEnabled( editor );
     mActions[MoveLineUp]->setEnabled( editor );
     mActions[MoveLineDown]->setEnabled( editor );
+#ifdef Q_OS_MAC
+    mActions[DeleteWord]->setEnabled( editor );
+#endif
     mActions[GotoPreviousEmptyLine]->setEnabled( editor );
     mActions[GotoNextEmptyLine]->setEnabled( editor );
     mActions[DocClose]->setEnabled( editor );

--- a/editors/sc-ide/widgets/multi_editor.cpp
+++ b/editors/sc-ide/widgets/multi_editor.cpp
@@ -386,14 +386,14 @@ void MultiEditor::createActions()
     mEditorSigMux->connect(action, SIGNAL(triggered()), SLOT(moveLineDown()));
     settings->addAction( action, "editor-move-line-down", editorCategory);
 
-#ifdef Q_OS_MAC
     mActions[DeleteWord] = action = new QAction(
         QIcon::fromTheme("edit-deleteword"), tr("Delete Word"), this);
+#ifdef Q_OS_MAC
     action->setShortcut(tr("Meta+W", "Delete Word"));
+#endif
     action->setShortcutContext(Qt::WidgetWithChildrenShortcut);
     mEditorSigMux->connect(action, SIGNAL(triggered()), SLOT(deleteWord()));
     settings->addAction(action, "delete-word", editorCategory);
-#endif
 
     mActions[GotoPreviousBlock] = action = new QAction(
         QIcon::fromTheme("edit-gotopreviousblock"), tr("Go to Previous Block"), this);
@@ -609,9 +609,7 @@ void MultiEditor::createActions()
     addAction(mActions[CopyLineDown]);
     addAction(mActions[MoveLineUp]);
     addAction(mActions[MoveLineDown]);
-#ifdef Q_OS_MAC
     addAction(mActions[DeleteWord]);
-#endif
     addAction(mActions[GotoPreviousBlock]);
     addAction(mActions[GotoNextBlock]);
     addAction(mActions[SelectEnclosingBlock]);
@@ -638,9 +636,7 @@ void MultiEditor::updateActions()
     mActions[CopyLineDown]->setEnabled( editor );
     mActions[MoveLineUp]->setEnabled( editor );
     mActions[MoveLineDown]->setEnabled( editor );
-#ifdef Q_OS_MAC
     mActions[DeleteWord]->setEnabled( editor );
-#endif
     mActions[GotoPreviousEmptyLine]->setEnabled( editor );
     mActions[GotoNextEmptyLine]->setEnabled( editor );
     mActions[DocClose]->setEnabled( editor );

--- a/editors/sc-ide/widgets/multi_editor.hpp
+++ b/editors/sc-ide/widgets/multi_editor.hpp
@@ -71,10 +71,7 @@ public:
         CopyLineDown,
         MoveLineUp,
         MoveLineDown,
-
-#ifdef Q_OS_MAC
 	DeleteWord,
-#endif
 
         GotoPreviousBlock,
         GotoNextBlock,

--- a/editors/sc-ide/widgets/multi_editor.hpp
+++ b/editors/sc-ide/widgets/multi_editor.hpp
@@ -72,6 +72,10 @@ public:
         MoveLineUp,
         MoveLineDown,
 
+#ifdef Q_OS_MAC
+	DeleteWord,
+#endif
+
         GotoPreviousBlock,
         GotoNextBlock,
         SelectEnclosingBlock,


### PR DESCRIPTION
This patch adds to scide the well-known terminal shortcut ctrl+w. This shortcut
is applied to OSX only because of a conflict with the close shortcut.