### PR TITLE
Topic/timing cleanup

### DIFF
--- a/SCClassLibrary/Common/Core/Kernel.sc
+++ b/SCClassLibrary/Common/Core/Kernel.sc
@@ -382,6 +382,8 @@ Process {
 	shallowCopy { ^this }
 
 	*elapsedTime { _ElapsedTime }
+    
+    *monotonicClockTime { _monotonicClockTime }
 
 	storeOn { arg stream;
 		stream << "thisProcess";

--- a/lang/LangPrimSource/PyrSched.cpp
+++ b/lang/LangPrimSource/PyrSched.cpp
@@ -842,18 +842,20 @@ void* TempoClock::Run()
 
 		// wait until an event is ready
 		double elapsedBeats;
+        chrono::nanoseconds schedSecs;
+        chrono::high_resolution_clock::time_point schedPoint;
 		do {
 			elapsedBeats = ElapsedBeats();
 			if (elapsedBeats >= slotRawFloat(mQueue->slots)) break;
 
-			chrono::system_clock::time_point absTime;
-
 			//printf("event ready at %g . elapsed beats %g\n", mQueue->slots->uf, elapsedBeats);
 			double wakeTime = BeatsToSecs(slotRawFloat(mQueue->slots));
-			ElapsedTimeToChrono(wakeTime, absTime);
+            
+            schedSecs = chrono::duration_cast<chrono::nanoseconds>(chrono::duration<double>(wakeTime));
+            schedPoint = hrTimeOfInitialization + schedSecs;
 
 			//printf("wait until an event is ready. wake %g  now %g\n", wakeTime, elapsedTime());
-			mCondition.wait_until(lock, absTime);
+			mCondition.wait_until(lock, schedPoint);
 			//printf("mRun b %d\n", mRun);
 			if (!mRun) goto leave;
 			//printf("time diff %g\n", elapsedTime() - mQueue->slots->uf);

--- a/lang/LangPrimSource/PyrSched.cpp
+++ b/lang/LangPrimSource/PyrSched.cpp
@@ -426,16 +426,15 @@ static void schedRunFunc()
 		//postfl("wait until an event is ready\n");
 
 		// wait until an event is ready
-		double elapsed;
+        chrono::nanoseconds schedSecs;
+        chrono::high_resolution_clock::time_point now, schedPoint;
 		do {
-			elapsed = elapsedTime();
-			if (elapsed >= slotRawFloat(inQueue->slots + 1)) break;
-			chrono::system_clock::time_point absTime;
-
-			ElapsedTimeToChrono(slotRawFloat(inQueue->slots + 1), absTime);
-
+            now = chrono::high_resolution_clock::now();
+            schedSecs = chrono::duration_cast<chrono::nanoseconds>(chrono::duration<double>(slotRawFloat(inQueue->slots + 1)));
+            schedPoint = hrTimeOfInitialization + schedSecs;
+            if(now >= schedPoint) break;
 			//postfl("wait until an event is ready\n");
-			gSchedCond.wait_until(lock, absTime);
+			gSchedCond.wait_until(lock, schedPoint);
 			if (!gRunSched) goto leave;
 			//postfl("time diff %g\n", elapsedTime() - inQueue->slots->uf);
 		} while (inQueue->size > 1);
@@ -444,7 +443,7 @@ static void schedRunFunc()
 
 		// perform all events that are ready
 		//postfl("perform all events that are ready\n");
-		while ((inQueue->size > 1) && elapsed >= slotRawFloat(inQueue->slots + 1)) {
+		while ((inQueue->size > 1) && now >= hrTimeOfInitialization + chrono::duration_cast<chrono::nanoseconds>(chrono::duration<double>(slotRawFloat(inQueue->slots + 1)))) {
 			double schedtime, delta;
 			PyrSlot task;
 

--- a/lang/LangPrimSource/PyrSched.cpp
+++ b/lang/LangPrimSource/PyrSched.cpp
@@ -426,11 +426,11 @@ static void schedRunFunc()
 		//postfl("wait until an event is ready\n");
 
 		// wait until an event is ready
-        chrono::nanoseconds schedSecs;
+        chrono::high_resolution_clock::duration schedSecs;
         chrono::high_resolution_clock::time_point now, schedPoint;
 		do {
             now = chrono::high_resolution_clock::now();
-            schedSecs = chrono::duration_cast<chrono::nanoseconds>(chrono::duration<double>(slotRawFloat(inQueue->slots + 1)));
+            schedSecs = chrono::duration_cast<chrono::high_resolution_clock::duration>(chrono::duration<double>(slotRawFloat(inQueue->slots + 1)));
             schedPoint = hrTimeOfInitialization + schedSecs;
             if(now >= schedPoint) break;
 			//postfl("wait until an event is ready\n");
@@ -443,7 +443,7 @@ static void schedRunFunc()
 
 		// perform all events that are ready
 		//postfl("perform all events that are ready\n");
-		while ((inQueue->size > 1) && now >= hrTimeOfInitialization + chrono::duration_cast<chrono::nanoseconds>(chrono::duration<double>(slotRawFloat(inQueue->slots + 1)))) {
+		while ((inQueue->size > 1) && now >= hrTimeOfInitialization + chrono::duration_cast<chrono::high_resolution_clock::duration>(chrono::duration<double>(slotRawFloat(inQueue->slots + 1)))) {
 			double schedtime, delta;
 			PyrSlot task;
 
@@ -842,7 +842,7 @@ void* TempoClock::Run()
 
 		// wait until an event is ready
 		double elapsedBeats;
-        chrono::nanoseconds schedSecs;
+        chrono::high_resolution_clock::duration schedSecs;
         chrono::high_resolution_clock::time_point schedPoint;
 		do {
 			elapsedBeats = ElapsedBeats();
@@ -851,7 +851,7 @@ void* TempoClock::Run()
 			//printf("event ready at %g . elapsed beats %g\n", mQueue->slots->uf, elapsedBeats);
 			double wakeTime = BeatsToSecs(slotRawFloat(mQueue->slots));
             
-            schedSecs = chrono::duration_cast<chrono::nanoseconds>(chrono::duration<double>(wakeTime));
+            schedSecs = chrono::duration_cast<chrono::high_resolution_clock::duration>(chrono::duration<double>(wakeTime));
             schedPoint = hrTimeOfInitialization + schedSecs;
 
 			//printf("wait until an event is ready. wake %g  now %g\n", wakeTime, elapsedTime());

--- a/lang/LangPrimSource/PyrSched.cpp
+++ b/lang/LangPrimSource/PyrSched.cpp
@@ -26,8 +26,8 @@
 #include "PyrSymbol.h"
 #ifdef SC_DARWIN
 # include <CoreAudio/HostTime.h>
-# include <sys/time.h>
 #endif
+#include <sys/time.h>
 #include <stdarg.h>
 #include <stdlib.h>
 #include <string.h>

--- a/lang/LangPrimSource/PyrSched.cpp
+++ b/lang/LangPrimSource/PyrSched.cpp
@@ -227,6 +227,9 @@ static void syncOSCOffsetWithTimeOfDay();
 void resyncThread();
 #endif // SC_DARWIN
 
+// Use the highest resolution clock available for monotonic clock time
+typedef typename std::conditional<chrono::high_resolution_clock::is_steady, chrono::high_resolution_clock, chrono::steady_clock>::type monotonic_clock;
+
 static chrono::high_resolution_clock::time_point hrTimeOfInitialization;
 
 template <typename DurationType>
@@ -267,6 +270,11 @@ double elapsedTime()
 #else
 	return DurToFloat(chrono::system_clock::now().time_since_epoch());
 #endif
+}
+
+double monotonicClockTime()
+{
+	return DurToFloat(monotonic_clock::now().time_since_epoch());
 }
 
 double elapsedRealTime()
@@ -1373,6 +1381,12 @@ int prElapsedTime(struct VMGlobals *g, int numArgsPushed)
 	return errNone;
 }
 
+int prmonotonicClockTime(struct VMGlobals *g, int numArgsPushed)
+{
+	SetFloat(g->sp, monotonicClockTime());
+	return errNone;
+}
+
 void initSchedPrimitives()
 {
 	int base, index=0;
@@ -1401,4 +1415,5 @@ void initSchedPrimitives()
 	definePrimitive(base, index++, "_SystemClock_SchedAbs", prSystemClock_SchedAbs, 3, 0);
 
 	definePrimitive(base, index++, "_ElapsedTime", prElapsedTime, 1, 0);
+    definePrimitive(base, index++, "_monotonicClockTime", prmonotonicClockTime, 1, 0);
 }

--- a/lang/LangSource/GC.cpp
+++ b/lang/LangSource/GC.cpp
@@ -49,7 +49,7 @@ int checkScans = 0;
 int checkPartialScans = 0;
 int checkSlotsScanned = 0;
 
-double elapsedRealTime();
+double elapsedTime();
 
 inline void PyrGC::beginPause()
 {
@@ -59,12 +59,12 @@ inline void PyrGC::beginPause()
 	checkNumToScan = mNumToScan;
 	checkPartialScans = mNumPartialScans;
 	checkSlotsScanned = mSlotsScanned;
-	pauseBeginTime = elapsedRealTime();
+	pauseBeginTime = elapsedTime();
 }
 
 inline void PyrGC::endPause()
 {
-	double pauseTime = elapsedRealTime() - pauseBeginTime;
+	double pauseTime = elapsedTime() - pauseBeginTime;
 	if (pauseTime > 0.001) numPausesGreaterThanOneMillisecond++;
 	if (pauseTime > maxPauseTime) {
 		maxPauseTime = pauseTime;

--- a/lang/LangSource/PyrInterpreter3.cpp
+++ b/lang/LangSource/PyrInterpreter3.cpp
@@ -61,7 +61,7 @@ double timeNow();
 
 int32 timeseed()
 {
-	using namespace boost::chrono;
+	using namespace chrono;
 
 	high_resolution_clock::time_point now = high_resolution_clock::now();
 	high_resolution_clock::duration since_epoch = now.time_since_epoch();
@@ -69,7 +69,7 @@ int32 timeseed()
 	seconds     secs     = duration_cast<seconds>(since_epoch);
 	nanoseconds nanosecs = since_epoch - secs;
 
-	boost::int_least64_t seed = secs.count() ^ nanosecs.count();
+	int_least64_t seed = secs.count() ^ nanosecs.count();
 
 	return (int32)seed;
 }

--- a/lang/LangSource/PyrLexer.cpp
+++ b/lang/LangSource/PyrLexer.cpp
@@ -1764,7 +1764,7 @@ void traverseFullDepTree2()
 			post("\tByte Code Size %d\n", totalByteCodes);
 			//elapsed = TickCount() - compileStartTime;
 			//elapsed = 0;
-			elapsed = elapsedRealTime() - compileStartTime;
+			elapsed = elapsedTime() - compileStartTime;
 			post("\tcompiled %d files in %.2f seconds\n",
 				 gNumCompiledFiles, elapsed );
 			if(numOverwrites == 1){
@@ -2121,7 +2121,7 @@ SC_DLLEXPORT_C bool compileLibrary(bool standalone)
 
 	SC_LanguageConfig::readLibraryConfig(standalone);
 
-	compileStartTime = elapsedRealTime();
+	compileStartTime = elapsedTime();
 
 	totalByteCodes = 0;
 

--- a/lang/LangSource/PyrObject.cpp
+++ b/lang/LangSource/PyrObject.cpp
@@ -1073,7 +1073,7 @@ int compareColDescs(const void *va, const void *vb)
 
 #define CHECK_METHOD_LOOKUP_TABLE_BUILD_TIME 0
 #if CHECK_METHOD_LOOKUP_TABLE_BUILD_TIME
-double elapsedRealTime();
+double elapsedTime();
 #endif
 
 static size_t fillClassRow(PyrClass *classobj, PyrMethod** bigTable);
@@ -1178,7 +1178,7 @@ void buildBigMethodMatrix()
 	//post("allocate arrays\n");
 
 #if CHECK_METHOD_LOOKUP_TABLE_BUILD_TIME
-	double t0 = elapsedRealTime();
+	double t0 = elapsedTime();
 #endif
 
 	// pyrmalloc:
@@ -1291,7 +1291,7 @@ void buildBigMethodMatrix()
 	//post("popSum %d\n", popSum);
 
 #if CHECK_METHOD_LOOKUP_TABLE_BUILD_TIME
-	post("building table took %.3g seconds\n", elapsedRealTime() - t0);
+	post("building table took %.3g seconds\n", elapsedTime() - t0);
 	{
 		int numFilled = 0;
 		for (i=0; i<rowTableSize/sizeof(PyrMethod*); ++i) {

--- a/lang/LangSource/PyrSched.h
+++ b/lang/LangSource/PyrSched.h
@@ -30,6 +30,7 @@ extern timed_mutex gLangMutex;
 
 double elapsedTime();
 double elapsedRealTime();
+double monotonicClockTime();
 int64 OSCTime();
 
 int64 ElapsedTimeToOSC(double elapsed);

--- a/lang/LangSource/PyrSched.h
+++ b/lang/LangSource/PyrSched.h
@@ -29,7 +29,6 @@
 extern timed_mutex gLangMutex;
 
 double elapsedTime();
-double elapsedRealTime();
 double monotonicClockTime();
 int64 OSCTime();
 


### PR DESCRIPTION
This PR arises from some extended discussions regarding the timing implementation on the list. It adds one new feature, cleans up some stuff, and unifies the lang timing implementation across platforms.

One question: This PR uses chrono::high_resolution_clock for elapsedTime and scheduling. According to the C++11 spec high_resolution_clock may or may not be steady. So the question is whether it is more important that the clock be monotonic, or that it be high resolution. If the former, chrono::steady_clock could be used instead. NB
- In current master it is not steady, this could cause problems, but I think only in very rare cases (e.g. scheduling across daylight savings time adjustments).
- On OSX steady_clock and high_resolution_clock are the same, both mach_absolute_time, which is monotonic.
- On other platforms what they are seems to depend on which compiler is used, etc.

I have not been able to test this on Windows or Linux, so someone please do!