### PR TITLE
class library(GUI): rename arguments - *new

### DIFF
--- a/SCClassLibrary/Common/GUI/Base/BasicViews.sc
+++ b/SCClassLibrary/Common/GUI/Base/BasicViews.sc
@@ -195,8 +195,8 @@ ScrollView : AbstractScroll {
 StaticText : TextViewBase {
 	*qtClass { ^'QLabel' }
 
-	*new { arg aParent, aBounds;
-		var obj = super.new( aParent, aBounds );
+	*new { arg parent, bounds;
+		var obj = super.new( parent, bounds );
 		obj.setProperty(\wordWrap, true);
 		^obj;
 	}

--- a/SCClassLibrary/Common/GUI/Base/QNumberBox.sc
+++ b/SCClassLibrary/Common/GUI/Base/QNumberBox.sc
@@ -6,8 +6,8 @@ NumberBox : QAbstractStepValue {
 
 	*qtClass { ^'QcNumberBox' }
 
-	*new { arg aParent, aBounds;
-		var obj = super.new( aParent, aBounds );
+	*new { arg parent, bounds;
+		var obj = super.new( parent, bounds );
 		obj.initNumberBox;
 		^obj;
 	}


### PR DESCRIPTION
```
affects classes: NumberBox and StaticText
```

Other GUI views appear to use the convention *new(parent, bounds),
whereas above classes use *new(aParent, aBounds).

Problematic when using named arguments, e.g:

```
(
b = Rect(0, 0, 4, 4);
ListView.new(bounds: b);         // fine
NumberBox.new(bounds: b);        // not fine
StaticText.new(bounds: b);
)
```
