### PR TITLE
Revert "syntax highlight and allow running code from schelp files"

### DIFF
--- a/editors/sc-ide/core/doc_manager.cpp
+++ b/editors/sc-ide/core/doc_manager.cpp
@@ -346,8 +346,7 @@ Document *DocumentManager::open( const QString & path, int initialCursorPosition
     closeSingleUntitledIfUnmodified();
 
     const bool fileIsPlainText = !(info.suffix() == QString("sc") ||
-                                  (info.suffix() == QString("scd")) ||
-                                  (info.suffix() == QString("schelp")));
+                                   (info.suffix() == QString("scd")));
 
     Document *doc = createDocument( fileIsPlainText, id );
     doc->mDoc->setPlainText( decodeDocument(bytes) );
@@ -531,8 +530,7 @@ bool DocumentManager::doSaveAs( Document *doc, const QString & path )
     info.refresh();
 
     const bool fileIsPlainText = !(info.suffix() == QString("sc") ||
-                                  (info.suffix() == QString("scd")) ||
-                                  (info.suffix() == QString("schelp")));
+                                   (info.suffix() == QString("scd")));
 
     doc->mFilePath = cpath;
     doc->mTitle = info.fileName();


### PR DESCRIPTION
This reverts commit e1c7009ba8a61534b202ab7e436174bac7b28860.