### PR TITLE
Topic/level indicator

### DIFF
--- a/HelpSource/Classes/LevelIndicator.schelp
+++ b/HelpSource/Classes/LevelIndicator.schelp
@@ -22,75 +22,72 @@ A link::Classes/Float:: between 0 and 1.
 returns:: A link::Classes/Float::
 
 METHOD:: warning
-Set the warning threshold. Styles 0 and 2 (see link::#-style::) implement a warning display. If link::#-critical:: is > warning the view will turn yellow if link::#-value:: is > code::val::. If critical is <= warning the view will turn yellow if value is <= to code::val::. If link::#-drawsPeak:: is true warning will be displayed based on link::#-peakLevel:: rather than value.
+METHOD:: critical
+Set the warning and critical thresholds. If meter value is above either threshold, link::#-warningColor or link::#-criticalColor will be shown, respectively (by default, yellow and red).
+If link::#-drawsPeak:: is true warning color will be displayed based on link::#-peakLevel:: rather than value.
 
 argument:: val
 A link::Classes/Float::.
 
-code::(
-w = Window.new.front;
-a = LevelIndicator(w, Rect(10, 10, 20, 160));
+code::
+a = LevelIndicator(bounds:Rect(10, 10, 20, 160)).front;
 a.value = 0.5;
-)
 a.warning = 0.6; a.critical = 0.9;
 a.value = 0.7;
-::
-
-METHOD:: critical
-Set the warning threshold. Styles 0 and 2 (see link::#-style::) implement a critical display. If critical is > link::#-warning:: the view will turn red if link::#-value:: is > code::val::. If critical is <= warning the view will turn yellow if value is <= to code::val::. If link::#-drawsPeak:: is true critical will be displayed based on link::#-peakLevel:: rather than value.
-
-argument:: val
-A link::Classes/Float::.
-
-code::(
-w = Window.new.front;
-a = LevelIndicator(w, Rect(10, 10, 20, 160));
-a.style = 2;
-a.numSteps = 10;
-a.value = 0.5;
-)
-a.warning = 0.6; a.critical = 0.9;
-a.value = 1;
+a.value = 0.9;
 ::
 
 METHOD:: style
-note:: Not yet implemented in Qt GUI ::
 Sets the style of the view.
 
 argument:: val
-An link::Classes/Integer:: from 0 to 3. 0 = colored bar; 1 = graduated black lines; 2 = LED style (see link::#-numSteps::); 3 = LED style with custom image. (See link::#-image::.)
+An link::Classes/Integer:: from 0 to 1. 0 = colored bar; 1 = LED style (see link::#-stepWidth::)
 
-code::(
-w = Window.new.front;
-w.addFlowLayout;
-4.do({|i|
-	a = LevelIndicator(w, Rect(0, 0, 20, 200));
-	a.style = i;
-	a.numSteps = 10;
-	a.value = 0.5;
-});
+code::
+(
+w = Window().front.layout_(
+	HLayout(
+		LevelIndicator().style_(0).value_(1/3),
+		LevelIndicator().style_(1).value_(2/3),
+	)
+)
 )
 ::
 
-METHOD:: numSteps
-The number of steps used in styles 2 and 3. (See link::#-style::.)
+METHOD:: stepWidth
+The width of each led light, for style 1.
 
 argument:: val
 An positive link::Classes/Integer::.
 
-code::(
-w = Window.new.front;
-a = LevelIndicator(w, Rect(10, 10, 200, 20));
-a.style = 2;
-a.value = 1;
+code::
+(
+w = Window().front.layout_(HLayout(
+	LevelIndicator().style_(1).value_(0.8).stepWidth_(1),
+	LevelIndicator().style_(1).value_(0.8).stepWidth_(3),
+	LevelIndicator().style_(1).value_(0.8).stepWidth_(10),
+	LevelIndicator().style_(1).value_(0.8).stepWidth_(50),
+));
 )
-a.numSteps = 10;
-a.numSteps = 20;
+::
+
+METHOD:: numSteps
+The number of steps used in style 1.
+
+argument:: val
+An positive link::Classes/Integer::.
+
+code::
+(
+a = LevelIndicator(bounds:Rect(10, 10, 80, 400)).front();
+a.value = 1;
+a.style = 1;
+a.numSteps = 4;
+)
 ::
 
 METHOD:: image
 note:: Not yet implemented in Qt GUI ::
-Sets the image used in style 3. See below for an example.
 
 argument:: image
 An link::Classes/Image::. The default image is the SC cube.
@@ -101,12 +98,14 @@ The number of ticks to display in the view's scale.
 argument:: number
 An link::Classes/Integer:: >= 0.
 
-code::(
-w = Window.new.front;
-w.view.background = Color.black;
-a = LevelIndicator(w, Rect(10, 10, 300, 30));
-a.numTicks = 11;
-a.value = 0.5;
+code::
+(
+w = Window(bounds:100@400).front().background_(Color.black);
+w.layout_(HLayout(
+	LevelIndicator()
+		.numTicks_(16)
+		.value_(0.75)
+))
 )
 ::
 
@@ -116,29 +115,30 @@ The number of ticks in the view's scale which will be large sized.
 argument:: number
 An link::Classes/Integer:: >= 0.
 
-code::(
-w = Window.new.front;
-w.view.background = Color.black;
-a = LevelIndicator(w, Rect(10, 10, 300, 30));
-a.numTicks = 11;
-a.numMajorTicks = 3;
-a.value = 0.5;
+code::
+(
+w = Window(bounds:100@400).front().background_(Color.black);
+w.layout_(HLayout(
+	LevelIndicator()
+		.numMajorTicks_(16)
+		.numTicks_(16)
+		.value_(0.75)
+))
 )
 ::
 
 METHOD:: drawsPeak
-Determines whether the view draws a separate peak display. This can be useful for displaying both peak and RMS values. If drawsPeak is true link::#-warning:: and link::#-critical:: will be displayed based on link::#-peakLevel:: rather than value in link::#-style#styles:: 0 and 2.
+Determines whether the view draws a separate peak display. This can be useful for displaying both peak and RMS values. If drawsPeak is true link::#-warning:: and link::#-critical:: will be displayed based on link::#-peakLevel:: rather than value.
 
 argument:: bool
 A link::Classes/Boolean::. By default the peak is not drawn.
 
-code::(
-w = Window.new.front;
-a = LevelIndicator(w, Rect(10, 10, 300, 30));
-a.drawsPeak = true;
-a.style = 1;
-a.value = 0.5;
-a.peakLevel = 0.6;
+code::
+(
+w = Window().front().layout_(HLayout(
+	LevelIndicator().style_(0).value_(0.75).drawsPeak_(true).peakLevel_(0.9),
+	LevelIndicator().style_(1).value_(0.75).drawsPeak_(true).peakLevel_(0.9)
+))
 )
 ::
 
@@ -148,108 +148,106 @@ Sets the level of the peak display. (See link::#-drawsPeak::.)
 argument:: val
 A link::Classes/Float::.
 
-code::(
-w = Window.new.front;
-a = LevelIndicator(w, Rect(10, 10, 20, 160));
-a.drawsPeak = true;
-a.peakLevel = 0.6)
+code::
+(
+w = Window().front().layout_(HLayout(
+	LevelIndicator().style_(0).value_(0.1).drawsPeak_(true).peakLevel_(0.3),
+	LevelIndicator().style_(0).value_(0.1).drawsPeak_(true).peakLevel_(0.5),
+	LevelIndicator().style_(0).value_(0.1).drawsPeak_(true).peakLevel_(0.7),
+	LevelIndicator().style_(0).value_(0.1).drawsPeak_(true).peakLevel_(0.9),
+))
 )
 ::
 
+METHOD:: meterColor
+METHOD:: warningColor
+METHOD:: criticalColor
+Sets the color of the meter, as well as the warning and critical colors.
+
+argument:: color
+A link::Classes/Color::.
+
+code::
+(
+l = LevelIndicator(bounds:Rect(100, 100, 100, 400)).front().value_(1).style_(1);
+l.meterColor = Color.blue(0.9);
+l.warningColor = Color.blue(0.7);
+l.criticalColor = Color.blue(0.5);
+)
+::
+code::
+(
+// inverse
+l.background = Color.blue;
+l.meterColor = Color.black.alpha_(1);
+l.warningColor = Color.black.alpha_(1);
+l.criticalColor = Color.black.alpha_(0.3);
+)
+::
 
 
 EXAMPLES::
 
 code::
-s.boot;
-GUI.cocoa; // just to be sure
-
+(
 // something to meter
-(
-b = Buffer.read(s, Platform.resourceDir +/+ "sounds/a11wlk01.wav");
-x = { var colum, noise, imp, delimp, mul = 1;
-	imp = Impulse.kr(10);
-	delimp = Delay1.kr(imp);
-	colum = PlayBuf.ar(1, b, BufRateScale.kr(b), loop: 1) * mul;
-	// measure rms and Peak
-	SendReply.kr(imp, '/levels', [Amplitude.kr(colum), K2A.ar(Peak.ar(colum, delimp).lag(0, 3))]);
-	colum;
-}.play;
+Server.default.boot.doWhenBooted {
+	b = Buffer.read(s, Platform.resourceDir +/+ "sounds/a11wlk01.wav");
+
+	x = {
+		var colum, noise, imp, delimp, mul = 1;
+		imp = Impulse.kr(10);
+		delimp = Delay1.kr(imp);
+		colum = PlayBuf.ar(1, b, BufRateScale.kr(b), loop: 1) * mul;
+		// measure rms and Peak
+		SendReply.kr(imp, '/levels', [Amplitude.kr(colum), K2A.ar(Peak.ar(colum, delimp).lag(0, 3))]);
+		colum;
+	}.play;
+
+	a = LevelIndicator(bounds:Rect(100, 100, 100, 400)).front;
+	a.onClose_({ x.free; o.free; });
+	o = OSCFunc({arg msg;
+		{
+			a.value = msg[3].ampdb.linlin(-40, 0, 0, 1);
+			a.peakLevel = msg[4].ampdb.linlin(-40, 0, 0, 1);
+		}.defer;
+	}, '/levels', s.addr);
+}
 )
 
-// a window and responder
-// default style is coloured / solid
-(
-w = Window.new.front;
-a = LevelIndicator(w, Rect(10, 10, 20, 160));
-o = OSCFunc({arg msg;
-	{
-		a.value = msg[3].ampdb.linlin(-40, 0, 0, 1);
-		a.peakLevel = msg[4].ampdb.linlin(-40, 0, 0, 1);
-	}.defer;
-}, '/levels', s.addr);
-w.onClose = {o.free; x.free};
-)
-
-// styles 0 and 2 support warning and critical levels
 (
 a.warning = -6.dbamp;
 a.critical = -3.dbamp;
 )
-
 // optionally show peak level
-(
-a.warning = 0;
-a.critical = 0;
 a.drawsPeak = true;
+
+// style 1 is led
+(
+a.style = 1;
+a.stepWidth = 3;
 )
 
-// style 1 is black bars
-a.style = 1
-
-// looks good with a background
-a.background = Gradient(Color.red, Color.green, \v);
-
+// different colors
+(
+a.meterColor = Color.blue(0.9);
+a.warningColor = Color.blue(0.8);
+a.criticalColor = Color.blue(0.6);
+)
 // all styles can have ticks
 (
 a.background = Color.clear;
 a.numTicks = 11; // includes 0;
-a.numMajorTicks = 3;
 )
 
-// style 2 is LED
+// Single blinking square level indicator
 (
-a.drawsPeak = false;
-a.style = 2;
-a.numSteps = 10;
+a.style = 1;
 a.numTicks = 0;
+a.drawsPeak = false;
+a.bounds = a.bounds.resizeTo(90, 90);
+a.numSteps = 1;
 )
 
-// style 3 is as 2, but with images
-a.style = 3; // use default image
-
-// make a custom image
-(
-j = Image.new(20,20);
-j.draw({ arg image;
-var lozenge;
-lozenge = Rect(3, 3, 16, 16);
-Pen.addOval(lozenge);
-Pen.fillAxialGradient(1@1, 19@19, Color.new255(255, 165, 0), Color.new255(238, 232, 170));
-Pen.width = 1;
-Pen.strokeColor = Color.blue;
-Pen.strokeOval(lozenge);
-});
-a.image = j;
-)
-
-// be inspired
-j = Image.openURL("http://bit.ly/uSMWwp");
-
-(
-a.bounds = Rect(10, 10, 380, 80);
-a.numSteps = 5;
-a.image = j;
-)
 
 ::

--- a/HelpSource/Classes/LevelIndicator.schelp
+++ b/HelpSource/Classes/LevelIndicator.schelp
@@ -41,21 +41,21 @@ METHOD:: style
 Sets the style of the view.
 
 argument:: val
-An link::Classes/Integer:: from 0 to 1. 0 = colored bar; 1 = LED style (see link::#-stepWidth::)
+An link::Classes/QLevelIndicatorStyle:: \continuous or \led (see link::#-stepWidth::)
 
 code::
 (
 w = Window().front.layout_(
 	HLayout(
-		LevelIndicator().style_(0).value_(1/3),
-		LevelIndicator().style_(1).value_(2/3),
+		LevelIndicator().style_(\continuous).value_(1/3),
+		LevelIndicator().style_(\led).value_(2/3),
 	)
 )
 )
 ::
 
 METHOD:: stepWidth
-The width of each led light, for style 1.
+The width of each led light, for \led.
 
 argument:: val
 An positive link::Classes/Integer::.
@@ -63,16 +63,16 @@ An positive link::Classes/Integer::.
 code::
 (
 w = Window().front.layout_(HLayout(
-	LevelIndicator().style_(1).value_(0.8).stepWidth_(1),
-	LevelIndicator().style_(1).value_(0.8).stepWidth_(3),
-	LevelIndicator().style_(1).value_(0.8).stepWidth_(10),
-	LevelIndicator().style_(1).value_(0.8).stepWidth_(50),
+	LevelIndicator().style_(\led).value_(0.8).stepWidth_(1),
+	LevelIndicator().style_(\led).value_(0.8).stepWidth_(3),
+	LevelIndicator().style_(\led).value_(0.8).stepWidth_(10),
+	LevelIndicator().style_(\led).value_(0.8).stepWidth_(50),
 ));
 )
 ::
 
 METHOD:: numSteps
-The number of steps used in style 1.
+The number of steps used in \led style.
 
 argument:: val
 An positive link::Classes/Integer::.
@@ -81,7 +81,7 @@ code::
 (
 a = LevelIndicator(bounds:Rect(10, 10, 80, 400)).front();
 a.value = 1;
-a.style = 1;
+a.style = \led;
 a.numSteps = 4;
 )
 ::
@@ -136,8 +136,8 @@ A link::Classes/Boolean::. By default the peak is not drawn.
 code::
 (
 w = Window().front().layout_(HLayout(
-	LevelIndicator().style_(0).value_(0.75).drawsPeak_(true).peakLevel_(0.9),
-	LevelIndicator().style_(1).value_(0.75).drawsPeak_(true).peakLevel_(0.9)
+	LevelIndicator().style_(\continuous).value_(0.75).drawsPeak_(true).peakLevel_(0.9),
+	LevelIndicator().style_(\led).value_(0.75).drawsPeak_(true).peakLevel_(0.9)
 ))
 )
 ::
@@ -151,10 +151,10 @@ A link::Classes/Float::.
 code::
 (
 w = Window().front().layout_(HLayout(
-	LevelIndicator().style_(0).value_(0.1).drawsPeak_(true).peakLevel_(0.3),
-	LevelIndicator().style_(0).value_(0.1).drawsPeak_(true).peakLevel_(0.5),
-	LevelIndicator().style_(0).value_(0.1).drawsPeak_(true).peakLevel_(0.7),
-	LevelIndicator().style_(0).value_(0.1).drawsPeak_(true).peakLevel_(0.9),
+	LevelIndicator().style_(\continuous).value_(0.1).drawsPeak_(true).peakLevel_(0.3),
+	LevelIndicator().style_(\continuous).value_(0.1).drawsPeak_(true).peakLevel_(0.5),
+	LevelIndicator().style_(\continuous).value_(0.1).drawsPeak_(true).peakLevel_(0.7),
+	LevelIndicator().style_(\continuous).value_(0.1).drawsPeak_(true).peakLevel_(0.9),
 ))
 )
 ::
@@ -169,7 +169,7 @@ A link::Classes/Color::.
 
 code::
 (
-l = LevelIndicator(bounds:Rect(100, 100, 100, 400)).front().value_(1).style_(1);
+l = LevelIndicator(bounds:Rect(100, 100, 100, 400)).front().value_(1).style_(\led);
 l.meterColor = Color.blue(0.9);
 l.warningColor = Color.blue(0.7);
 l.criticalColor = Color.blue(0.5);
@@ -222,9 +222,8 @@ a.critical = -3.dbamp;
 // optionally show peak level
 a.drawsPeak = true;
 
-// style 1 is led
 (
-a.style = 1;
+a.style = \led;
 a.stepWidth = 3;
 )
 
@@ -242,7 +241,7 @@ a.numTicks = 11; // includes 0;
 
 // Single blinking square level indicator
 (
-a.style = 1;
+a.style = \led;
 a.numTicks = 0;
 a.drawsPeak = false;
 a.bounds = a.bounds.resizeTo(90, 90);

--- a/QtCollider/widgets/QcLevelIndicator.cpp
+++ b/QtCollider/widgets/QcLevelIndicator.cpp
@@ -30,7 +30,7 @@ QcLevelIndicator::QcLevelIndicator() :
   QtCollider::Style::Client(this),
   _value( 0.f ), _warning(0.6), _critical(0.8),
   _peak( 0.f ), _drawPeak( false ),
-  _ticks(0), _majorTicks(0), _stepWidth(10), _style(0),
+  _ticks(0), _majorTicks(0), _stepWidth(10), _style(LevelIndicatorStyle::Continuous),
   _clipped(false),
   _meterColor(0, 255, 0), _warningColor(255, 255, 0), _criticalColor(255,100,0)
 {
@@ -96,7 +96,7 @@ void QcLevelIndicator::paintEvent( QPaintEvent *e )
   p.setRenderHint(QPainter::Antialiasing, true);
 
   switch (_style) {
-    case 0: {
+    case Continuous: {
       r.setHeight( _value * length );
       p.fillRect( r, valueColor(colorValue) );
       if( _drawPeak && _peak > 0.f ) {
@@ -112,7 +112,7 @@ void QcLevelIndicator::paintEvent( QPaintEvent *e )
 		
       break;
     }
-    case 1: {
+    case LED: {
       float ledBaseline = 0;
       float spaceWidth = _stepWidth <= 3 ? 1 : 2;
       float cornerWidth = _stepWidth <= 3 ? 0 : 1.2;
@@ -151,6 +151,7 @@ void QcLevelIndicator::paintEvent( QPaintEvent *e )
         
       break;
     }
+    default: break;
   }
   
   p.setRenderHint(QPainter::Antialiasing, false);

--- a/QtCollider/widgets/QcLevelIndicator.cpp
+++ b/QtCollider/widgets/QcLevelIndicator.cpp
@@ -31,7 +31,8 @@ QcLevelIndicator::QcLevelIndicator() :
   _value( 0.f ), _warning(0.6), _critical(0.8),
   _peak( 0.f ), _drawPeak( false ),
   _ticks(0), _majorTicks(0), _stepWidth(10), _style(0),
-  _clipped(false)
+  _clipped(false),
+  _meterColor(0, 255, 0), _warningColor(255, 255, 0), _criticalColor(255,100,0)
 {
   _clipTimer = new QTimer( this );
   _clipTimer->setSingleShot(true);
@@ -39,19 +40,19 @@ QcLevelIndicator::QcLevelIndicator() :
   connect( _clipTimer, SIGNAL(timeout()), this, SLOT(clipTimeout()) );
 }
 
+const QColor QcLevelIndicator::valueColor(float value) {
+  if(value > _critical)
+    return _criticalColor;
+  else if(value > _warning)
+    return _warningColor;
+  else
+    return _meterColor;
+}
+
 void QcLevelIndicator::clipTimeout()
 {
   _clipped = false;
   update();
-}
-
-QColor QcLevelIndicator::valueColor(float value) {
-  if(value > _critical)
-    return QColor(255,100,0);
-  else if(value > _warning)
-    return QColor(255, 255, 0);
-  else
-    return QColor(0, 255, 0);
 }
 
 void QcLevelIndicator::paintEvent( QPaintEvent *e )
@@ -127,8 +128,10 @@ void QcLevelIndicator::paintEvent( QPaintEvent *e )
         float nextValue = ((ledBaseline + _stepWidth + spaceWidth) / adjustedLength);
 
         QColor c = valueColor(normValue);
-        if (nextValue > _value) // last cell
-          c.setAlpha(128 + 128 * ((_value - normValue) / (nextValue - normValue)));
+        if (nextValue > _value) { // last cell
+          c = valueColor(_value);
+          c.setAlphaF(c.alphaF() * (0.5 + 0.5 * ((_value - normValue) / (nextValue - normValue))));
+        }
         
         p.fillPath(path, QBrush(c));
         ledBaseline += stepSpacing;

--- a/QtCollider/widgets/QcLevelIndicator.h
+++ b/QtCollider/widgets/QcLevelIndicator.h
@@ -28,6 +28,8 @@
 #include <QWidget>
 #include <QTimer>
 
+static const double PI = 3.14159265358979323846264338327950288419717;
+
 class QcLevelIndicator : public QWidget, QcHelper, QtCollider::Style::Client
 {
   Q_OBJECT
@@ -38,6 +40,8 @@ class QcLevelIndicator : public QWidget, QcHelper, QtCollider::Style::Client
   Q_PROPERTY( bool drawPeak READ dummyBool WRITE setDrawPeak );
   Q_PROPERTY( int ticks READ dummyInt WRITE setTicks );
   Q_PROPERTY( int majorTicks READ dummyInt WRITE setMajorTicks );
+  Q_PROPERTY( int stepWidth READ dummyInt WRITE setStepWidth );
+  Q_PROPERTY( int style READ dummyInt WRITE setStyle );
   Q_PROPERTY( QColor grooveColor READ grooveColor WRITE setGrooveColor );
 
 public:
@@ -49,6 +53,8 @@ public:
   void setDrawPeak( bool b ) { _drawPeak = b; update(); }
   void setTicks( int i ) { _ticks = qMax(i,0); update(); }
   void setMajorTicks( int i ) { _majorTicks = qMax(i,0); update(); }
+  void setStepWidth( int i ) { _stepWidth = qMax(i,0); update(); }
+  void setStyle( int i ) { _style = qMin(qMax(i,0), 3); update(); }
   virtual QSize sizeHint() const { return QSize( 25, 150 ); }
 private Q_SLOTS:
   void clipTimeout();
@@ -61,6 +67,8 @@ private:
   bool _drawPeak;
   int _ticks;
   int _majorTicks;
+	float _stepWidth;
+	int _style;
   bool _clipped;
   QTimer *_clipTimer;
 };

--- a/QtCollider/widgets/QcLevelIndicator.h
+++ b/QtCollider/widgets/QcLevelIndicator.h
@@ -28,8 +28,6 @@
 #include <QWidget>
 #include <QTimer>
 
-static const double PI = 3.14159265358979323846264338327950288419717;
-
 class QcLevelIndicator : public QWidget, QcHelper, QtCollider::Style::Client
 {
   Q_OBJECT

--- a/QtCollider/widgets/QcLevelIndicator.h
+++ b/QtCollider/widgets/QcLevelIndicator.h
@@ -39,13 +39,19 @@ class QcLevelIndicator : public QWidget, QcHelper, QtCollider::Style::Client
   Q_PROPERTY( int ticks READ dummyInt WRITE setTicks );
   Q_PROPERTY( int majorTicks READ dummyInt WRITE setMajorTicks );
   Q_PROPERTY( int stepWidth READ dummyInt WRITE setStepWidth );
-  Q_PROPERTY( int style READ dummyInt WRITE setStyle );
+  Q_PROPERTY( LevelIndicatorStyle style READ style WRITE setStyle );
   Q_PROPERTY( QColor grooveColor READ grooveColor WRITE setGrooveColor );
   Q_PROPERTY( QColor meterColor READ dummyColor WRITE setMeterColor );
   Q_PROPERTY( QColor warningColor READ dummyColor WRITE setWarningColor );
   Q_PROPERTY( QColor criticalColor READ dummyColor WRITE setCriticalColor );
 
 public:
+  enum LevelIndicatorStyle {
+    Continuous = 0,
+    LED
+  };
+  Q_ENUMS(LevelIndicatorStyle);
+  
   QcLevelIndicator();
   void setValue( float f ) { _value = f; update(); }
   void setWarning( float f ) { _warning = f; update(); }
@@ -55,7 +61,9 @@ public:
   void setTicks( int i ) { _ticks = qMax(i,0); update(); }
   void setMajorTicks( int i ) { _majorTicks = qMax(i,0); update(); }
   void setStepWidth( int i ) { _stepWidth = qMax(i,1); update(); }
-  void setStyle( int i ) { _style = qMin(qMax(i,0), 1); update(); }
+  void setStyle( LevelIndicatorStyle i ) { _style = i; update(); }
+  void setStyle( int i ) { _style = (LevelIndicatorStyle)i; update(); }
+  LevelIndicatorStyle style() { return _style; };
 
   void setMeterColor( const QColor c ) { _meterColor = c; update(); }
   void setWarningColor( const QColor c ) { _warningColor = c; update(); }
@@ -76,7 +84,7 @@ private:
   int _ticks;
   int _majorTicks;
 	float _stepWidth;
-	int _style;
+	LevelIndicatorStyle _style;
   bool _clipped;
   QTimer *_clipTimer;
 };

--- a/QtCollider/widgets/QcLevelIndicator.h
+++ b/QtCollider/widgets/QcLevelIndicator.h
@@ -59,6 +59,7 @@ public:
 private Q_SLOTS:
   void clipTimeout();
 private:
+  QColor valueColor(float value);
   void paintEvent( QPaintEvent *e );
   float _value;
   float _warning;

--- a/QtCollider/widgets/QcLevelIndicator.h
+++ b/QtCollider/widgets/QcLevelIndicator.h
@@ -43,6 +43,9 @@ class QcLevelIndicator : public QWidget, QcHelper, QtCollider::Style::Client
   Q_PROPERTY( int stepWidth READ dummyInt WRITE setStepWidth );
   Q_PROPERTY( int style READ dummyInt WRITE setStyle );
   Q_PROPERTY( QColor grooveColor READ grooveColor WRITE setGrooveColor );
+  Q_PROPERTY( QColor meterColor READ dummyColor WRITE setMeterColor );
+  Q_PROPERTY( QColor warningColor READ dummyColor WRITE setWarningColor );
+  Q_PROPERTY( QColor criticalColor READ dummyColor WRITE setCriticalColor );
 
 public:
   QcLevelIndicator();
@@ -53,13 +56,19 @@ public:
   void setDrawPeak( bool b ) { _drawPeak = b; update(); }
   void setTicks( int i ) { _ticks = qMax(i,0); update(); }
   void setMajorTicks( int i ) { _majorTicks = qMax(i,0); update(); }
-  void setStepWidth( int i ) { _stepWidth = qMax(i,0); update(); }
-  void setStyle( int i ) { _style = qMin(qMax(i,0), 3); update(); }
+  void setStepWidth( int i ) { _stepWidth = qMax(i,1); update(); }
+  void setStyle( int i ) { _style = qMin(qMax(i,0), 1); update(); }
+
+  void setMeterColor( const QColor c ) { _meterColor = c; update(); }
+  void setWarningColor( const QColor c ) { _warningColor = c; update(); }
+  void setCriticalColor( const QColor c ) { _criticalColor = c; update(); }
+
   virtual QSize sizeHint() const { return QSize( 25, 150 ); }
 private Q_SLOTS:
   void clipTimeout();
 private:
-  QColor valueColor(float value);
+  const QColor valueColor(float value);
+  QColor _meterColor, _warningColor, _criticalColor;
   void paintEvent( QPaintEvent *e );
   float _value;
   float _warning;

--- a/SCClassLibrary/Common/GUI/Base/QLevelIndicator.sc
+++ b/SCClassLibrary/Common/GUI/Base/QLevelIndicator.sc
@@ -32,8 +32,15 @@ LevelIndicator : View {
 	background { ^this.getProperty(\grooveColor) }
 	background_ { arg color; this.setProperty(\grooveColor, color) }
 
+	meterColor_{ |color| this.setProperty(\meterColor, color) }
+	warningColor_{ |color| this.setProperty(\warningColor, color) }
+	criticalColor_{ |color| this.setProperty(\criticalColor, color) }
+
 	numSteps_ {arg val;
-		this.nonimpl("numSteps");
+		var stepWidth, length = max(this.bounds.width, this.bounds.height);
+		stepWidth = length / val;
+		stepWidth = stepWidth - (stepWidth < 3).if(1, 2);
+		this.stepWidth = stepWidth;
 	}
 
 	image_ {arg image;

--- a/SCClassLibrary/Common/GUI/Base/QLevelIndicator.sc
+++ b/SCClassLibrary/Common/GUI/Base/QLevelIndicator.sc
@@ -22,7 +22,7 @@ LevelIndicator : View {
 	}
 
 	style_ {arg val;
-		this.setProperty(\style, val);
+		this.setProperty(\style, QLevelIndicatorStyle(val));
 	}
 
 	stepWidth_{arg val;

--- a/SCClassLibrary/Common/GUI/Base/QLevelIndicator.sc
+++ b/SCClassLibrary/Common/GUI/Base/QLevelIndicator.sc
@@ -21,9 +21,12 @@ LevelIndicator : View {
 		this.setProperty(\critical, val);
 	}
 
-	// NOT IMPLEMENTED
 	style_ {arg val;
-		this.nonimpl("style");
+		this.setProperty(\style, val);
+	}
+
+	stepWidth_{arg val;
+		this.setProperty(\stepWidth, val);
 	}
 
 	background { ^this.getProperty(\grooveColor) }

--- a/SCClassLibrary/Common/GUI/Base/enums.sc
+++ b/SCClassLibrary/Common/GUI/Base/enums.sc
@@ -136,3 +136,11 @@ QColorRole {
 
 	*new { arg name; ^this.perform(name) }
 }
+
+QLevelIndicatorStyle {
+	classvar
+	<continuous = 0,
+  	<led = 1;
+
+	*new { arg style; style.isInteger.if(style, { this.perform(style) }) }
+}


### PR DESCRIPTION
This re-enables led-mode for level indicators. 

It re-works the style numbering slightly. Style #2, led indicators, becomes style #1. Style #1 used to be black bars - In lieu of this mode, I added parameters to change the colors of the level meters - so, you can achieve the same result by using style = 1 plus meterColor = Color.black. This API change seems acceptable considering legacy code that used the old styles would already have been broken for several years.

LevelIndicator:stepWidth becomes the primary way of setting the size of the led rectangles. The old numSteps is supported as well, but in 95% of cases the width of the step is a more useful value to set than the number of steps.

Finally, there's some refactoring of the way the level indicators are drawn - mainly, using transforms to get to a more reasonable coordinate system.