### PR TITLE
Topic/ogl filled scope

### DIFF
--- a/HelpSource/Classes/ScopeView.schelp
+++ b/HelpSource/Classes/ScopeView.schelp
@@ -58,6 +58,11 @@ METHOD:: y
     argument::
         A Float.
 
+METHOD:: fill
+    Fill area under scope.
+    argument::
+        A Boolean.
+
 METHOD:: waveColors
     The colors used to plot each of the channels.
 

--- a/QtCollider/widgets/QcScopeShm.cpp
+++ b/QtCollider/widgets/QcScopeShm.cpp
@@ -27,6 +27,7 @@
 #include <QPainter>
 #include <QTimer>
 #include <QResizeEvent>
+#include <QWindow>
 
 QC_DECLARE_QWIDGET_FACTORY(QcScopeShm);
 
@@ -42,13 +43,16 @@ QcScopeShm::QcScopeShm() :
   xZoom( 1.f ),
   yZoom( 1.f ),
   _style( 0 ),
-  _bkg( QColor(0,0,0) )
+  _bkg( QColor(0,0,0) ),
+  _fill( true )
 {
   setAttribute( Qt::WA_OpaquePaintEvent, true );
   setAutoFillBackground(false);
 
   setSizePolicy( QSizePolicy::Expanding, QSizePolicy::Expanding );
-
+  int ratio = windowHandle()->devicePixelRatio();
+  QGLWidget::resizeGL(width() * ratio, height() * ratio);
+  
   timer = new QTimer( this );
   timer->setInterval( 50 );
   connect( timer, SIGNAL( timeout() ), this, SLOT( updateScope() ) );
@@ -203,7 +207,9 @@ void QcScopeShm::paint1D( bool overlapped, int chanCount, int maxFrames, int fra
     for( int ch = 0; ch < chanCount; ch++ ) {
       float *frameData = _data + (ch * maxFrames); //frame vector
       float yOrigin = yHeight * (overlapped ? 0.5 : ch + 0.5);
-      pen.setColor( ch < colors.count() ? colors[ch] : QColor(255,255,255) );
+      QColor strokeColor = ch < colors.count() ? colors[ch] : QColor(255,255,255);
+      QColor fillColor(strokeColor); fillColor.setAlpha(0.65 * 255);
+      pen.setColor( strokeColor );
 
       painter.save();
       painter.translate( area.x(), area.y() + yOrigin );
@@ -215,6 +221,14 @@ void QcScopeShm::paint1D( bool overlapped, int chanCount, int maxFrames, int fra
       for( int f = 1; f < frameCount; ++f )
         path.lineTo( xOffset + f, frameData[f] );
 
+      if (_fill) {
+        path.lineTo(xOffset + frameCount, 0);
+        path.lineTo(0, 0);
+        path.lineTo(xOffset, frameData[0]);
+        
+        painter.fillPath(path, QBrush(fillColor));
+      }
+      
       painter.drawPath(path);
 
       painter.restore();
@@ -230,13 +244,15 @@ void QcScopeShm::paint1D( bool overlapped, int chanCount, int maxFrames, int fra
     {
       float *frameData = _data + (ch * maxFrames); //frame vector
       float yOrigin = yHeight * (overlapped ? 0.5 : ch + 0.5);
-      pen.setColor( ch < colors.count() ? colors[ch] : QColor(255,255,255) );
+      QColor strokeColor = ch < colors.count() ? colors[ch] : QColor(255,255,255);
+      QColor fillColor(strokeColor); fillColor.setAlpha(0.65 * 255);
 
       painter.save();
       painter.translate( area.x(), area.y() + yOrigin );
       painter.setPen(pen);
 
-      QPainterPath path;
+      QPainterPath pathLine;
+      QPainterPath pathFill;
 
       int p=0, f=1; // pixel, frame
       float min, max;
@@ -255,17 +271,28 @@ void QcScopeShm::paint1D( bool overlapped, int chanCount, int maxFrames, int fra
 
         qreal x = p-1;
         float y = max * yRatio;
-        path.moveTo( x, y );
+        pathLine.moveTo( x, y );
         y = qMax( min * yRatio, y+1 );
-        path.lineTo( x, y );
-
+        pathLine.lineTo( x, y );
+        
+        if (_fill) {
+          pathFill.moveTo( x, y );
+          pathFill.lineTo( x, 0 );
+        }
+        
         // flip min/max to ensure continuity
         float val = min;
         min = max;
         max = val;
       }
-
-      painter.drawPath(path);
+      
+      pen.setColor(strokeColor);
+      painter.strokePath(pathLine, pen);
+      
+      if (_fill) {
+        pen.setColor(fillColor);
+        painter.strokePath(pathFill, pen);
+      }
 
       painter.restore();
     }

--- a/QtCollider/widgets/QcScopeShm.cpp
+++ b/QtCollider/widgets/QcScopeShm.cpp
@@ -50,8 +50,6 @@ QcScopeShm::QcScopeShm() :
   setAutoFillBackground(false);
 
   setSizePolicy( QSizePolicy::Expanding, QSizePolicy::Expanding );
-  int ratio = windowHandle()->devicePixelRatio();
-  QGLWidget::resizeGL(width() * ratio, height() * ratio);
   
   timer = new QTimer( this );
   timer->setInterval( 50 );

--- a/QtCollider/widgets/QcScopeShm.h
+++ b/QtCollider/widgets/QcScopeShm.h
@@ -27,7 +27,6 @@
 #include <SC_Types.h>
 
 #include <QWidget>
-#include <QGLWidget>
 
 // FIXME: Due to Qt bug #22829, moc can not process headers that include
 // boost/type_traits/detail/has_binary_operator.hp from boost 1.48, so
@@ -40,7 +39,7 @@ namespace QtCollider
 
 using QtCollider::ScopeShm;
 
-class QcScopeShm : public QGLWidget, QcHelper
+class QcScopeShm : public QWidget, QcHelper
 {
   Q_OBJECT
   Q_PROPERTY( int serverPort READ serverPort WRITE setServerPort );

--- a/QtCollider/widgets/QcScopeShm.h
+++ b/QtCollider/widgets/QcScopeShm.h
@@ -27,6 +27,7 @@
 #include <SC_Types.h>
 
 #include <QWidget>
+#include <QGLWidget>
 
 // FIXME: Due to Qt bug #22829, moc can not process headers that include
 // boost/type_traits/detail/has_binary_operator.hp from boost 1.48, so
@@ -39,7 +40,7 @@ namespace QtCollider
 
 using QtCollider::ScopeShm;
 
-class QcScopeShm : public QWidget, QcHelper
+class QcScopeShm : public QGLWidget, QcHelper
 {
   Q_OBJECT
   Q_PROPERTY( int serverPort READ serverPort WRITE setServerPort );
@@ -51,29 +52,32 @@ class QcScopeShm : public QWidget, QcHelper
   Q_PROPERTY( int style READ style WRITE setStyle );
   Q_PROPERTY( QVariantList waveColors READ dummyVariantList WRITE setWaveColors );
   Q_PROPERTY( QColor background READ background WRITE setBackground );
+  Q_PROPERTY( bool fill READ fill WRITE setFill );
   Q_PROPERTY( int updateInterval READ updateInterval WRITE setUpdateInterval );
   Q_PROPERTY( bool running READ running );
 
   public:
     QcScopeShm();
     ~QcScopeShm();
-    int serverPort() const { return _srvPort; }
+    int serverPort() const          { return _srvPort; }
     void setServerPort( int );
     void setBufferNumber( int );
-    void setXOffset( float f ) { xOffset = f; }
-    void setYOffset( float f ) { yOffset = f; }
-    void setXZoom( float f ) { xZoom = f; }
-    void setYZoom( float f ) { yZoom = f; }
-    int style() const { return _style; }
-    void setStyle( int i ) { _style = i; }
+    void setXOffset( float f )      { xOffset = f; }
+    void setYOffset( float f )      { yOffset = f; }
+    void setXZoom( float f )        { xZoom = f; }
+    void setYZoom( float f )        { yZoom = f; }
+    int style() const               { return _style; }
+    void setStyle( int i )          { _style = i; }
     void setWaveColors( const QVariantList & colors );
-    QColor background() const { return _bkg; }
+    QColor background() const       { return _bkg; }
     void setBackground( const QColor &c ) { _bkg = c; update(); }
+    bool fill()                     { return _fill; };
+    void setFill(bool b)            { _fill = b; };
     int updateInterval() const;
     void setUpdateInterval( int i );
-    bool running() const { return _running; }
-    QSize sizeHint() const { return QSize( 500, 300 ); }
-    QSize minimumSizeHint() const { return QSize( 50, 50 ); }
+    bool running() const            { return _running; }
+    QSize sizeHint() const          { return QSize( 500, 300 ); }
+    QSize minimumSizeHint() const   { return QSize( 50, 50 ); }
   public Q_SLOTS:
     void start();
     void stop();
@@ -105,6 +109,7 @@ class QcScopeShm : public QWidget, QcHelper
     int _style;
     QList<QColor> colors;
     QColor _bkg;
+    bool _fill;
 
     QPixmap _pixmap;
 };

--- a/SCClassLibrary/Common/GUI/Base/ScopeView.sc
+++ b/SCClassLibrary/Common/GUI/Base/ScopeView.sc
@@ -1,6 +1,6 @@
 ScopeView : View {
 	var <bufnum;
-	var <xZoom=1.0, <yZoom=1.0, <x=0.0, <y=0.0;
+	var <xZoom=1.0, <yZoom=1.0, <x=0.0, <y=0.0, <fill=true;
 	var <waveColors;
 
 	*qtClass { ^'QcScopeShm' }
@@ -44,6 +44,12 @@ ScopeView : View {
 	y_ { arg aFloat;
 		y = aFloat;
 		this.setProperty( \yOffset, aFloat );
+	}
+
+	fill_ {
+		arg aFill;
+		fill = aFill;
+		this.setProperty( \fill, aFill );
 	}
 
 	waveColors_ { arg aColorArray;


### PR DESCRIPTION
This changes the QcScopeShm class to be backed by an OpenGL widget, which improves drawing frame rates somewhat. It adds an additional property (fill) to fill the area below the graph. I've defaulted fill to true because I think it looks much better.