### PR TITLE
Topic/source preview

### DIFF
--- a/editors/sc-ide/core/sc_introspection.cpp
+++ b/editors/sc-ide/core/sc_introspection.cpp
@@ -294,6 +294,12 @@ Introspection::ClassMethodMap Introspection::constructMethodMap(const Class * kl
     }
     return methodMap;
 }
+  
+bool Method::matches(const QString& toMatch) const
+{
+    return toMatch.isEmpty() ? true : name.get().startsWith(toMatch, Qt::CaseInsensitive);
+}
+
 
 QString Method::signature( SignatureStyle style ) const
 {

--- a/editors/sc-ide/core/sc_introspection.hpp
+++ b/editors/sc-ide/core/sc_introspection.hpp
@@ -84,7 +84,8 @@ struct Method {
         SignatureWithArgumentsAndDefaultValues
     };
 
-    QString signature( SignatureStyle style ) const;
+    QString   signature( SignatureStyle style ) const;
+    bool      matches(const QString& toMatch) const;
 
     Class *ownerClass;
     FlyweightString name;

--- a/editors/sc-ide/widgets/code_editor/sc_editor.cpp
+++ b/editors/sc-ide/widgets/code_editor/sc_editor.cpp
@@ -84,9 +84,11 @@ bool ScCodeEditor::event( QEvent *e )
         QKeyEvent *ke = static_cast<QKeyEvent*>(e);
         switch (ke->key()) {
         case Qt::Key_Tab:
-            indent();
-            e->accept();
-            return true;
+            if (!tabChangesFocus()) {
+                indent();
+                e->accept();
+                return true;
+            }
         default:
             break;
         }

--- a/editors/sc-ide/widgets/lookup_dialog.cpp
+++ b/editors/sc-ide/widgets/lookup_dialog.cpp
@@ -330,7 +330,7 @@ QList<QStandardItem*> GenericLookupDialog::makeDialogItem( QString const & displ
     return ret;
 }
 
-QStandardItemModel * LookupDialog::modelForClass(const QString &className)
+QStandardItemModel * LookupDialog::modelForClass(const QString &className, const QString &methodName)
 {
     const Introspection & introspection = Main::scProcess()->introspection();
     const Class *klass = introspection.findClass(className);
@@ -346,32 +346,39 @@ QStandardItemModel * LookupDialog::modelForClass(const QString &className)
 
         QString displayPath = introspection.compactLibraryPath(klass->definition.path);
 
-        parentItem->appendRow(makeDialogItem(klass->name.get(), displayPath,
-                                             klass->definition.path.get(),
-                                             klass->definition.position,
-                                             klass->name.get(), QString(""),
-                                             true ));
+        if (methodName.isEmpty()) {
+            parentItem->appendRow(makeDialogItem(klass->name.get(), displayPath,
+                                                 klass->definition.path.get(),
+                                                 klass->definition.position,
+                                                 klass->name.get(), QString(""),
+                                                 true ));
+        }
 
         foreach (const Method * method, metaClass->methods) {
             QString signature = method->signature( Method::SignatureWithoutArguments );
             QString displayPath = introspection.compactLibraryPath(method->definition.path);
-
-            parentItem->appendRow(makeDialogItem( signature, displayPath,
-                                                  method->definition.path.get(),
-                                                  method->definition.position,
-                                                  metaClass->name.get(), method->name.get(),
-                                                  false ));
+          
+            if (method->matches(methodName)) {
+                parentItem->appendRow(makeDialogItem( signature, displayPath,
+                                                      method->definition.path.get(),
+                                                      method->definition.position,
+                                                      metaClass->name.get(), method->name.get(),
+                                                      false ));
+            }
         }
 
         foreach (const Method * method, klass->methods) {
             QString signature = method->signature( Method::SignatureWithoutArguments );
             QString displayPath = introspection.compactLibraryPath(method->definition.path);
 
-            parentItem->appendRow(makeDialogItem( signature, displayPath,
-                                                  method->definition.path.get(),
-                                                  method->definition.position,
-                                                  klass->name.get(), method->name.get(),
-                                                  false ));
+
+            if (method->matches(methodName)) {
+                parentItem->appendRow(makeDialogItem( signature, displayPath,
+                                                      method->definition.path.get(),
+                                                      method->definition.position,
+                                                      klass->name.get(), method->name.get(),
+                                                      false ));
+            }
         }
 
         klass = klass->superClass;
@@ -459,7 +466,13 @@ QStandardItemModel * LookupDialog::modelForPartialQuery(const QString & queryStr
 
 bool LookupDialog::performClassQuery(const QString & className)
 {
-    QStandardItemModel * model = modelForClass(className);
+    QStandardItemModel * model;
+    if (className.contains(QChar(':'))) {
+        QStringList split = className.split(":");
+        model = modelForClass(split[0].trimmed(), split[1].trimmed());
+    } else {
+        model = modelForClass(className);
+    }
     setModel(model);
     return model;
 }

--- a/editors/sc-ide/widgets/lookup_dialog.cpp
+++ b/editors/sc-ide/widgets/lookup_dialog.cpp
@@ -53,6 +53,7 @@ GenericLookupDialog::GenericLookupDialog( QWidget * parent ):
     mPreviewEditor = new ScCodeEditor(mPreviewDocument);
     mPreviewEditor->setReadOnly(true);
     mPreviewEditor->setVisible(false);
+    mPreviewEditor->setTabChangesFocus(true);
   
     QVBoxLayout *layout = new QVBoxLayout;
     layout->setContentsMargins(0,0,0,0);

--- a/editors/sc-ide/widgets/lookup_dialog.cpp
+++ b/editors/sc-ide/widgets/lookup_dialog.cpp
@@ -51,9 +51,8 @@ GenericLookupDialog::GenericLookupDialog( QWidget * parent ):
   
     mPreviewDocument = new Document(false);
     mPreviewEditor = new ScCodeEditor(mPreviewDocument);
+    mPreviewEditor->setReadOnly(true);
   
-    QHBoxLayout *hlayout = new QHBoxLayout;
-    hlayout->setMargin(0);
     QVBoxLayout *layout = new QVBoxLayout;
     layout->setContentsMargins(0,0,0,0);
     layout->setSpacing(1);
@@ -111,17 +110,18 @@ void GenericLookupDialog::currentChanged(const QModelIndex &item, const QModelIn
     
     if (cpath.isEmpty()) {
       MainWindow::instance()->showStatusMessage (
-                                                 tr("Cannot open file: %1 (file does not exist)").arg(path) );
-      return 0;
+        tr("Cannot open file: %1 (file does not exist)").arg(path) );
+      return;
     }
     
     // Open the file
     QFile file(cpath);
     if(!file.open(QIODevice::ReadOnly)) {
       MainWindow::instance()->showStatusMessage(
-                                                tr("Cannot open file for reading: %1").arg(cpath));
-      return 0;
+        tr("Cannot open file for reading: %1").arg(cpath));
+      return;
     }
+  
     QByteArray bytes( file.readAll() );
     file.close();
   
@@ -129,11 +129,7 @@ void GenericLookupDialog::currentChanged(const QModelIndex &item, const QModelIn
     stream.setCodec("UTF-8");
     stream.setAutoDetectUnicode(true);
 
-    mPreviewDocument->setTextInRange( stream.readAll(), 0, -1 );
-//    mPreviewDocument->setModified(false);
-//    mPreviewDocument->mFilePath = filePath;
-//    mPreviewDocument->setTitle("");
-  
+    mPreviewDocument->setTextInRange( stream.readAll(), 0, -1 );  
     mPreviewEditor->showPosition(pos, 0);
     mPreviewEditor->selectCurrentRegion();
 }

--- a/editors/sc-ide/widgets/lookup_dialog.cpp
+++ b/editors/sc-ide/widgets/lookup_dialog.cpp
@@ -52,6 +52,7 @@ GenericLookupDialog::GenericLookupDialog( QWidget * parent ):
     mPreviewDocument = new Document(false);
     mPreviewEditor = new ScCodeEditor(mPreviewDocument);
     mPreviewEditor->setReadOnly(true);
+    mPreviewEditor->setVisible(false);
   
     QVBoxLayout *layout = new QVBoxLayout;
     layout->setContentsMargins(0,0,0,0);
@@ -259,12 +260,16 @@ void LookupDialog::performQuery()
     mIsPartialQuery = false;
     if (queryString[0].isUpper()) {
         bool success = performClassQuery(queryString);
+        mPreviewEditor->setVisible(success);
+
         if (success) {
             focusResults();
             return;
         }
     } else {
         bool success = performMethodQuery(queryString);
+        mPreviewEditor->setVisible(success);
+
         if (success) {
             focusResults();
             return;
@@ -272,6 +277,7 @@ void LookupDialog::performQuery()
     }
 
     bool success = performPartialQuery(queryString);
+    mPreviewEditor->setVisible(success);
     if (success)
         focusResults();
 }

--- a/editors/sc-ide/widgets/lookup_dialog.hpp
+++ b/editors/sc-ide/widgets/lookup_dialog.hpp
@@ -86,7 +86,7 @@ private slots:
     void onAccepted(QModelIndex);
 
 private:
-    QStandardItemModel * modelForClass(const QString & className);
+    QStandardItemModel * modelForClass(const QString & className, const QString & methodName = QString());
     QStandardItemModel * modelForMethod(const QString & methodName);
     QStandardItemModel * modelForPartialQuery(const QString & queryString);
     bool performClassQuery(const QString & className);

--- a/editors/sc-ide/widgets/lookup_dialog.hpp
+++ b/editors/sc-ide/widgets/lookup_dialog.hpp
@@ -27,6 +27,7 @@
 #include <QTreeWidget>
 
 #include "../core/sc_process.hpp"
+#include "code_editor/sc_editor.hpp"
 
 namespace ScIDE {
 
@@ -44,12 +45,14 @@ public:
     explicit GenericLookupDialog(QWidget *parent = 0);
     void query( const QString & query ) { mQueryEdit->setText(query); this->performQuery(); }
     void clearQuery() { mQueryEdit->clear(); }
+    void setModel(QStandardItemModel*);
 
 public Q_SLOTS:
     bool openDocumentation();
 
 protected Q_SLOTS:
     virtual void onAccepted(QModelIndex);
+    void currentChanged(const QModelIndex &, const QModelIndex &);
 
 private Q_SLOTS:
     virtual void performQuery() = 0;
@@ -67,6 +70,8 @@ protected:
 
     QTreeView *mResult;
     QLineEdit *mQueryEdit;
+    Document *mPreviewDocument;
+    ScCodeEditor *mPreviewEditor;
 };
 
 class LookupDialog : public GenericLookupDialog


### PR DESCRIPTION
This PR adds a window at the bottom of the "Look Up Implementations" and "Look Up References" windows, that shows a preview of the source code for the currently selected item. The majority of the time, look-up functionality is used for reference purposes - this allows quick reference to the source of the method in question, without requiring actually opening the file in the IDE.