### PR TITLE
plugins: fix 10 trigger UGens that did not initialize ZOUT correcly

### DIFF
--- a/server/plugins/TriggerUGens.cpp
+++ b/server/plugins/TriggerUGens.cpp
@@ -394,7 +394,7 @@ void Trig1_Ctor(Trig1 *unit)
 	unit->mCounter = 0;
 	unit->m_prevtrig = 0.f;
 
-	ZOUT0(0) = 0.f;
+	Trig1_next(unit, 1);
 }
 
 void Trig1_next(Trig1 *unit, int inNumSamples)
@@ -574,7 +574,7 @@ void Trig_Ctor(Trig *unit)
 	unit->m_prevtrig = 0.f;
 	unit->mLevel = 0.f;
 
-	ZOUT0(0) = 0.f;
+	Trig_next(unit, 1);
 }
 
 void Trig_next(Trig *unit, int inNumSamples)
@@ -970,7 +970,7 @@ void SetResetFF_Ctor(SetResetFF *unit)
 	unit->m_prevreset = 0.f;
 	unit->mLevel = 0.f;
 
-	ZOUT0(0) = 0.f;
+	SetResetFF_next_k(unit, 1);
 }
 
 
@@ -1190,7 +1190,7 @@ void Gate_Ctor(Gate *unit)
 
 	unit->mLevel = 0.f;
 
-	ZOUT0(0) = 0.f;
+	Gate_next_ak(unit, 1);
 }
 
 
@@ -1241,7 +1241,7 @@ void Schmidt_Ctor(Schmidt *unit)
 
 	unit->mLevel = 0.f;
 
-	ZOUT0(0) = 0.f;
+	Schmidt_next(unit, 1);
 }
 
 void Schmidt_next(Schmidt *unit, int inNumSamples)
@@ -1273,7 +1273,7 @@ void PulseDivider_Ctor(PulseDivider *unit)
 	unit->mLevel = 0.f;
 	unit->mCounter = (long)floor(ZIN0(2) + 0.5);
 
-	ZOUT0(0) = 0.f;
+	PulseDivider_next(unit, 1);
 }
 
 
@@ -1322,7 +1322,7 @@ void PulseCount_Ctor(PulseCount *unit)
 	unit->m_prevreset = 0.f;
 	unit->mLevel = 0.f;
 
-	ZOUT0(0) = 0.f;
+	PulseCount_next_k(unit, 1);
 }
 
 
@@ -1413,7 +1413,7 @@ void Stepper_Ctor(Stepper *unit)
 	unit->m_prevreset = 0.f;
 	unit->mLevel = (float)resetval;
 
-	ZOUT0(0) = 0.f;
+	Stepper_next_ak(unit, 1);
 }
 
 
@@ -1507,7 +1507,7 @@ void TDelay_Ctor(TDelay *unit)
 	unit->m_prevtrig = 0.f;
 	unit->mCounter = 0;
 
-	ZOUT0(0) = 0.f;
+	TDelay_next(unit, 1);
 }
 
 


### PR DESCRIPTION
Test case. It uses EnvGen to isolate the initial output values produced by these units' Ctors, showing that the "primed" outputs do not take into account a trigger that comes in during the first calculation block.

    (
    SynthDef(\test, {
    	var ugens = [
    		{ |trig, dur| Trig1.kr(trig, dur) },
    		{ |trig, dur| Trig.kr(trig, dur) },
    		{ |trig| SetResetFF.kr(trig) },
    		{ |in, trig| Gate.kr(in, trig) },
    		{ |in, lo, hi| Schmidt.kr(in, lo, hi) },
    		{ |trig| PulseDivider.kr(trig, 2, 1) },
    		{ |trig| PulseCount.kr(trig) },
    		{ |trig| Stepper.kr(trig) },
    		{ |in, delay| TDelay.kr(in, delay) }
    	],
    	args = (
    		trig: Impulse.kr(0),
    		dur: 0.1,
    		in: DC.kr(10),
    		lo: 0,
    		hi: 1,
    		delay: 0
    	),
    	lateTrig = DelayN.kr(args[\trig], 0.1, 0.1);
    
    	args.use {
    		ugens.do { |func, i|
    			var value = func.valueEnvir;
    			Poll.kr(lateTrig, EnvGen.kr(Env([value, value], [0.1])), i.asString);
    		};
    	};
    	Line.kr(0, 0, 0.25, doneAction: 2);
    }).play;
    )

Before the fix:

    0: 0
    1: 0
    2: 0
    5: 0
    6: 0
    7: 0
    3: 0
    4: 0
    8: 0

After the fix:

    0: 1
    1: 1
    2: 1
    5: 1
    6: 1
    7: 1
    3: 10  <<-- Gate.kr correctly outputs 'in' == 10
    4: 1
    8: 0  <<-- TDelay.kr(something, 0) seems to be a strange case... separate issue
