### PR TITLE
class library: sclang can derive current interpreter config path for IDE

### DIFF
--- a/SCClassLibrary/Common/Quarks/Quarks.sc
+++ b/SCClassLibrary/Common/Quarks/Quarks.sc
@@ -36,7 +36,7 @@ Quarks {
 		this.installed.do({ |quark|
 			LanguageConfig.removeIncludePath(quark.localPath);
 		});
-		LanguageConfig.store();
+		LanguageConfig.store(Platform.languageConfigFilePath);
 		cache = Dictionary.new;
 	}
 	*load { |path|
@@ -184,7 +184,7 @@ Quarks {
 		if(LanguageConfig.includePaths.includesEqual(path).not, {
 			path.debug("Adding path");
 			LanguageConfig.addIncludePath(path);
-			LanguageConfig.store();
+			LanguageConfig.store(Platform.languageConfigFilePath);
 			^true
 		});
 		^false
@@ -194,7 +194,7 @@ Quarks {
 		if(LanguageConfig.includePaths.includesEqual(path), {
 			path.debug("Removing path");
 			LanguageConfig.removeIncludePath(path);
-			LanguageConfig.store();
+			LanguageConfig.store(Platform.languageConfigFilePath);
 			^true
 		});
 		^false

--- a/SCClassLibrary/Platform/Platform.sc
+++ b/SCClassLibrary/Platform/Platform.sc
@@ -72,7 +72,9 @@ Platform
 	*clearMetadata { |path| ^thisProcess.platform.clearMetadata(path) }
 
 	languageConfigFilePath {
-		var path = configFilePath ?? { this.userAppSupportDir +/+ "sc_ide_conf.yaml" };
+		var path;
+		if(configFilePath.notNil) { ^configFilePath };
+		path = this.userAppSupportDir +/+ "sc_ide_conf.yaml";
 		^try {
 			path.parseYAMLFile["IDE"]["interpreter"]["configFile"]
 		} ? "sclang_conf.yaml"

--- a/SCClassLibrary/Platform/Platform.sc
+++ b/SCClassLibrary/Platform/Platform.sc
@@ -6,7 +6,7 @@ Platform
 	classvar <>makeServerWindowAction, <>makeSynthDescWindowAction, <>openHelpFileAction, <>openHTMLFileAction;
 
 	var <classLibraryDir, <helpDir, <>recordingsDir, features;
-	var <>devpath;
+	var <>devpath, <>configFilePath;
 
 	*initClass {
 		defaultStartupFile = this.userConfigDir +/+ "startup.scd"
@@ -70,6 +70,17 @@ Platform
 
 	clearMetadata { |path| ^this.subclassResponsibility }
 	*clearMetadata { |path| ^thisProcess.platform.clearMetadata(path) }
+
+	languageConfigFilePath {
+		var path = configFilePath ?? { this.userAppSupportDir +/+ "sc_ide_conf.yaml" };
+		^try {
+			path.parseYAMLFile["IDE"]["interpreter"]["configFile"]
+		} ? "sclang_conf.yaml"
+	}
+	*languageConfigFilePath {
+		^thisProcess.platform.languageConfigFilePath
+	}
+
 
 	// startup/shutdown hooks
 	startup { }

--- a/SCClassLibrary/scide_scqt/ScIDE.sc
+++ b/SCClassLibrary/scide_scqt/ScIDE.sc
@@ -299,6 +299,13 @@ ScIDE {
 		});
 	}
 
+	*languageConfigFilePath {
+		var configFilePath = Platform.userAppSupportDir +/+ "sc_ide_conf.yaml";
+		^try {
+			configFilePath.parseYAMLFile["IDE"]["interpreter"]["configFile"]
+		}
+	}
+
 	*cmdPeriod { docRoutine.play(AppClock) }
 
 	*processUrl { |urlString, doneAction|
@@ -350,15 +357,15 @@ ScIDE {
 	*setTextByQUuid {|quuid, funcID, text, start = 0, range = -1|
 		this.prSend(\setDocumentText, [quuid, funcID, text, start, range]);
 	}
-    
+
     *setSelectionByQUuid {|quuid, start, length|
         this.prSend(\setDocumentSelection, [quuid, start, length]);
     }
-	
+
 	*setEditablebyQUuid {|quuid, editable|
 		this.prSend(\setDocumentEditable, [quuid, editable]);
 	}
-	
+
 	*setPromptsToSavebyQUuid {|quuid, prompts|
 		this.prSend(\setDocumentPromptsToSave, [quuid, prompts]);
 	}
@@ -366,7 +373,7 @@ ScIDE {
 	*setCurrentDocumentByQUuid {|quuid|
 		this.prSend(\setCurrentDocument, [quuid]);
 	}
-	
+
 	*removeDocUndoByQUuid {|quuid|
 		this.prSend(\removeDocUndo, [quuid]);
 	}
@@ -386,11 +393,11 @@ ScIDE {
 	*setDocumentKeyUpEnabled {|quuid, bool|
 		this.prSend(\enableDocumentKeyUpAction, [quuid, bool]);
 	}
-	
+
 	*setDocumentGlobalKeyDownEnabled {|bool|
 		this.prSend(\enableDocumentGlobalKeyDownAction, [bool]);
 	}
-	
+
 	*setDocumentGlobalKeyUpEnabled {|bool|
 		this.prSend(\enableDocumentGlobalKeyUpAction, [bool]);
 	}
@@ -639,7 +646,7 @@ Document {
 		_ScIDE_SetDocTextMirror
 		this.primitiveFailed
 	}
-    
+
     prSetSelectionMirror {|quuid, start, size|
 		_ScIDE_SetDocSelectionMirror
 		this.primitiveFailed
@@ -895,12 +902,12 @@ Document {
 		this.prSetSelectionMirror(quuid, start, length); // set the backend mirror
         ScIDE.setSelectionByQUuid(quuid, start, length); // set the IDE doc
     }
-    
+
 	editable_ { | bool=true |
 		editable = bool;
 		ScIDE.setEditablebyQUuid(quuid, bool);
 	}
-	
+
 	promptToSave_ { | bool |
 		promptToSave = bool;
 		ScIDE.setPromptsToSavebyQUuid(quuid, bool);

--- a/SCClassLibrary/scide_scqt/ScIDE.sc
+++ b/SCClassLibrary/scide_scqt/ScIDE.sc
@@ -299,13 +299,6 @@ ScIDE {
 		});
 	}
 
-	*languageConfigFilePath {
-		var configFilePath = Platform.userAppSupportDir +/+ "sc_ide_conf.yaml";
-		^try {
-			configFilePath.parseYAMLFile["IDE"]["interpreter"]["configFile"]
-		} ? "sclang_conf.yaml"
-	}
-
 	*cmdPeriod { docRoutine.play(AppClock) }
 
 	*processUrl { |urlString, doneAction|

--- a/SCClassLibrary/scide_scqt/ScIDE.sc
+++ b/SCClassLibrary/scide_scqt/ScIDE.sc
@@ -303,7 +303,7 @@ ScIDE {
 		var configFilePath = Platform.userAppSupportDir +/+ "sc_ide_conf.yaml";
 		^try {
 			configFilePath.parseYAMLFile["IDE"]["interpreter"]["configFile"]
-		}
+		} ? "sclang_conf.yaml"
 	}
 
 	*cmdPeriod { docRoutine.play(AppClock) }


### PR DESCRIPTION
This would make it possible to add paths to the current LanguageConfig via the Quarks and save it there, too.

I'm not sure about where exactly the link between IDE and sclang is supposed to be, in particular when this path is used. Maybe Platform is a better place?

