### PR TITLE
Ensuring that Method:keyValuePairsFromArgs returns empty array if argNam...

### DIFF
--- a/SCClassLibrary/Common/Audio/InfoUGens.sc
+++ b/SCClassLibrary/Common/Audio/InfoUGens.sc
@@ -29,7 +29,7 @@ NumInputBuses : InfoUGenBase {}
 NumAudioBuses : InfoUGenBase {}
 NumControlBuses : InfoUGenBase {}
 NumBuffers : InfoUGenBase {}
-NodeID : InfoUGenBase {}
+ThisSynthID : InfoUGenBase {}
 NumRunningSynths : InfoUGenBase {
 	*kr {
 		^this.multiNew('control')

--- a/SCClassLibrary/Common/Core/Kernel.sc
+++ b/SCClassLibrary/Common/Core/Kernel.sc
@@ -458,9 +458,9 @@ FunctionDef {
 
 	keyValuePairsFromArgs {
 		var argNames, argVals;
-		argNames = this.argNames;
-		if(argNames.isNil) { ^[] };
-		argVals = this.prototypeFrame.keep(argNames.size);
+		if(this.argNames.isNil, { ^[] });
+		argNames = this.argNames.drop(1); // first argName is "this"
+		argVals = this.prototypeFrame.drop(1).keep(argNames.size);
 		^[argNames, argVals].flop.flatten
 	}
 

--- a/SCClassLibrary/Common/Core/Kernel.sc
+++ b/SCClassLibrary/Common/Core/Kernel.sc
@@ -506,9 +506,12 @@ Method : FunctionDef {
 		functionRefs.notNil.if({references = references.add(this)});
 		^references
 	}
+
 	keyValuePairsFromArgs {
-		var argNames = this.argNames.drop(1); // first argName is "this"
-		var argVals = this.prototypeFrame.drop(1).keep(argNames.size);
+		var argNames, argVals;
+		if(this.argNames.isNil, { ^[] });
+		argNames = this.argNames.drop(1); // first argName is "this"
+		argVals = this.prototypeFrame.drop(1).keep(argNames.size);
 		^[argNames, argVals].flop.flatten
 	}
 }

--- a/server/plugins/DelayUGens.cpp
+++ b/server/plugins/DelayUGens.cpp
@@ -270,7 +270,7 @@ extern "C"
 	void NumAudioBuses_Ctor(Unit *unit, int inNumSamples);
 	void NumControlBuses_Ctor(Unit *unit, int inNumSamples);
 	void NumBuffers_Ctor(Unit *unit, int inNumSamples);
-	void NodeID_Ctor(Unit *unit, int inNumSamples);
+	void ThisSynthID_Ctor(Unit *unit, int inNumSamples);
 	void NumRunningSynths_Ctor(Unit *unit, int inNumSamples);
 	void NumRunningSynths_next(Unit *unit, int inNumSamples);
 
@@ -535,7 +535,7 @@ void NumBuffers_Ctor(Unit *unit, int inNumSamples)
 	ZOUT0(0) = unit->mWorld->mNumSndBufs;
 }
 
-void NodeID_Ctor(Unit *unit, int inNumSamples)
+void ThisSynthID_Ctor(Unit *unit, int inNumSamples)
 {
 	ZOUT0(0) = (float) unit->mParent->mNode.mID;
 }
@@ -7758,7 +7758,7 @@ PluginLoad(Delay)
 	DefineInfoUnit(NumControlBuses);
 	DefineInfoUnit(NumBuffers);
 	DefineInfoUnit(NumRunningSynths);
-	DefineInfoUnit(NodeID);
+	DefineInfoUnit(ThisSynthID);
 
 #define DefineBufInfoUnit(name) \
 	(*ft->fDefineUnit)(#name, sizeof(BufInfoUnit), (UnitCtorFunc)&name##_Ctor, 0, 0);


### PR DESCRIPTION
The test code below illustrates the bug. In short, all Methods that have .argNames nil fails .argumentString.

```
(
	~methodsThatFailed = List.new;
	~methodsThatPassed = List.new;
	Object.allSubclasses.do({arg item;
		item.methods.do({arg jtem;
			var method = jtem;
			try {
				method.argumentString;
				".argumentString PASSED for: %".format(method.asString).postln;
				~methodsThatPassed.add( method);
			} {|err|
				".argumentString FAILED for: %".format(method.asString).postln;
				~methodsThatFailed.add(method);
			}
		});
	});
)

//Many failed
~methodsThatFailed.size
//The ones that failed have argNames == nil
~methodsThatFailed.every({arg item; item.argNames == nil})
//The opposite is true for the ones that passed
~methodsThatPassed.every({arg item; item.argNames != nil})
```

This method was broken in 0552034fdc38949d3bc23b740762c114949062cc

With this PR all the tests passes, but it will need further testing.