### PR TITLE
Fix JITLib GUIs to work with StreamControls created from numbers

### DIFF
--- a/SCClassLibrary/JITLib/GUI/NdefParamGui.sc
+++ b/SCClassLibrary/JITLib/GUI/NdefParamGui.sc
@@ -163,7 +163,11 @@ NdefParamGui : EnvirGui {
 	}
 
 	setFunc { |key|
-		^{ |sl| object.set(key, sl.value) }
+		if(object.objects.notEmpty and: { object.objects.array.first.isKindOf(SynthControl) }) {
+			^{ |sl| object.set(key, sl.value) }
+		} {
+			^{ |sl| object.source = sl.value }
+		};
 	}
 
 	clearField { |index|

--- a/SCClassLibrary/JITLib/ProxySpace/ProxyInterfaces.sc
+++ b/SCClassLibrary/JITLib/ProxySpace/ProxyInterfaces.sc
@@ -68,6 +68,7 @@ AbstractPlayControl {
 StreamControl : AbstractPlayControl {
 
 	var stream, <clock;
+	var controlName;
 
 	playToBundle { | bundle |
 		// no latency (latency is in stream already)
@@ -79,6 +80,9 @@ StreamControl : AbstractPlayControl {
 		clock = proxy.clock;
 		paused = proxy.paused;
 		stream = source.buildForProxy(proxy, channelOffset, orderIndex);
+		if(source.isNumber) {
+			controlName = ControlName(proxy.key ?? { \value }, orderIndex, \control, source);
+		};
 		^true;
 	}
 
@@ -96,6 +100,13 @@ StreamControl : AbstractPlayControl {
 		}
 	}
 	stop { stream.stop }
+
+	// Numeric StreamControls must provide a GUI-able control
+	controlNames {
+		if(controlName.notNil) {
+			^[controlName]
+		} { ^nil };
+	}
 
 	copyState { |control|
 		// stream can't be copied.


### PR DESCRIPTION
    s.boot;
    p = ProxySpace.new.push;
    p.gui;
    
    ~freq = 200;

Without this PR, the NdefParamGui will show *no slider* for freq!

The two commits here make the GUI behave as you would expect. Also working in this revision is `~freq.addSpec(\freq, [100, 800, \exp])` -- it would be nice to eliminate the redundancy of `~freq` vs `\freq` but I don't see a clean way to do that, given the proxyspace/proxygui structure.

Rest of my test code:

    ~sin = { SinOsc.ar(~freq.kr, 0, 0.1).dup };
    ~sin.play;
    
    ~freq.addSpec(\freq, [100, 800, \exp]);

Julian, OK?