### PR TITLE
Cmake change for WinHelp and LICENSE.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -381,6 +381,7 @@ elseif(APPLE)
 		README_OS_X.md
 		ChangeLog
 		AUTHORS
+		COPYING
 		MOVED_STUFF.txt
 	)
 else()
@@ -389,11 +390,15 @@ else()
 		README_LINUX.md
 		ChangeLog
 		AUTHORS
+		COPYING
 	)
 endif()
 
 install(FILES ${AdditionalInstallFiles} DESTINATION ${auxresourcesdir})
-install(FILES ${CMAKE_SOURCE_DIR}/COPYING DESTINATION ${auxresourcesdir} RENAME LICENSE.txt)
+
+if(WIN32)
+	install(FILES COPYING DESTINATION ${auxresourcesdir} RENAME LICENSE.txt)
+endif()
 
 
 if(INSTALL_HELP)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -368,12 +368,11 @@ elseif(APPLE)
 	install(DIRECTORY examples DESTINATION ${auxresourcesdir})
 endif()
 
-if (WIN32)
+if(WIN32)
 	set( AdditionalInstallFiles
 		README.md
 		README_WINDOWS.md
 		ChangeLog
-		COPYING
 		AUTHORS
 	)
 elseif(APPLE)
@@ -381,7 +380,6 @@ elseif(APPLE)
 		README.md
 		README_OS_X.md
 		ChangeLog
-		COPYING
 		AUTHORS
 		MOVED_STUFF.txt
 	)
@@ -390,12 +388,13 @@ else()
 		README.md
 		README_LINUX.md
 		ChangeLog
-		COPYING
 		AUTHORS
 	)
 endif()
 
 install(FILES ${AdditionalInstallFiles} DESTINATION ${auxresourcesdir})
+install(FILES ${CMAKE_SOURCE_DIR}/COPYING DESTINATION ${auxresourcesdir} RENAME LICENSE.txt)
+
 
 if(INSTALL_HELP)
 	if(SC_SYMLINK_CLASSLIB AND APPLE)
@@ -405,6 +404,13 @@ if(INSTALL_HELP)
 		endif()
 		install( CODE
 					"EXECUTE_PROCESS(COMMAND ln -shF ${CMAKE_CURRENT_SOURCE_DIR}/HelpSource ${CMAKE_INSTALL_PREFIX}/${auxresourcesdir}/HelpSource )" )
+	elseif(WIN32)
+		install(DIRECTORY HelpSource
+			DESTINATION ${CMAKE_INSTALL_PREFIX}/${auxresourcesdir}
+			REGEX ${SCCLASSLIB_EXCLUDE_REGEX} EXCLUDE
+			PATTERN "*~" EXCLUDE
+			PATTERN "*#" EXCLUDE
+		)
 	elseif(NOT APPLE)
 		install(DIRECTORY HelpSource
 			DESTINATION ${auxresourcesdir}

--- a/platform/windows/CMakeLists.txt
+++ b/platform/windows/CMakeLists.txt
@@ -1,11 +1,3 @@
-install(FILES ${CMAKE_SOURCE_DIR}/COPYING
-    DESTINATION SuperCollider
-    RENAME LICENSE.txt
-)
-install(FILES ${CMAKE_SOURCE_DIR}/README_WINDOWS.md
-    DESTINATION SuperCollider
-    RENAME README.md
-)
 install(FILES ${CMAKE_SOURCE_DIR}/platform/windows/Resources/sc_cube.ico
     DESTINATION .
 )

--- a/platform/windows/supercollider.nsi
+++ b/platform/windows/supercollider.nsi
@@ -72,7 +72,7 @@ Section "Core" core_sect
 	WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\SuperCollider-${SC_VERSION}" "UninstallString" "$INSTDIR\Uninstall.exe"
 	WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\SuperCollider-${SC_VERSION}" "HelpLink" "http://doc.sccode.org/"
 	WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\SuperCollider-${SC_VERSION}" "URLUpdateInfo" "http://sourceforge.net/projects/supercollider/files/Windows/"
-	WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\SuperCollider-${SC_VERSION}" "URLInfoAbout" "http://supercollider.sourceforge.net/"
+	WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\SuperCollider-${SC_VERSION}" "URLInfoAbout" "http://supercollider.github.io"
 	WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\SuperCollider-${SC_VERSION}" "DisplayVersion" "${SC_VERSION}"
 	WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\SuperCollider-${SC_VERSION}" "DisplayIcon" "$INSTDIR\sclang.exe"
 	WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\SuperCollider-${SC_VERSION}" "NoModify" 1


### PR DESCRIPTION
Two little changes:
- makes Help work on Windows (tested on Windows and crosschecked on Mac) - looks strange but the previous one didn't work
- should rename COPYING to LICENSE.txt on all platforms (tested on Mac and Windows)
