### PR TITLE
class library: FunctionList copies before iterating.

### DIFF
--- a/HelpSource/Classes/Collection.schelp
+++ b/HelpSource/Classes/Collection.schelp
@@ -243,6 +243,20 @@ code::
 [1,2,3,4,5].inject([], _++_); // [ 1, 2, 3, 4, 5 ]
 ::
 
+method::collectInPlace
+Iterate over the collection and replace each item with a new one, returned by the function. This can be useful when one wants to aviod creating a new array in memory. In most cases, it is better to use link::#-collect::.
+
+code::
+a = [1, 5, 3, 4];
+a.collectInPlace { |x| 2 ** x };
+a; // changed
+
+// compare:
+a = [1, 5, 3, 4];
+a.collect { |x| 2 ** x };
+a; // remains unchanged
+::
+
 method::any
 Answer whether strong::function:: answers link::Classes/True:: for any item in the receiver. The function is passed two arguments, the item and an integer index.
 code::

--- a/SCClassLibrary/Common/Collections/Collection.sc
+++ b/SCClassLibrary/Common/Collections/Collection.sc
@@ -177,6 +177,9 @@ Collection {
 		}
 		^res;
 	}
+	collectInPlace { |function |
+		this.do { |item, i| this.put(i, function.value(item, i)) }
+	}
 	detect { | function |
 		this.do {|elem, i| if (function.value(elem, i)) { ^elem } }
 		^nil;

--- a/SCClassLibrary/Common/Control/ResponseDefs.sc
+++ b/SCClassLibrary/Common/Control/ResponseDefs.sc
@@ -129,7 +129,7 @@ AbstractWrappingDispatcher :  AbstractDispatcher {
 		func = this.wrapFunc(funcProxy);
 		wrappedFuncs[funcProxy] = func;
 		keys = this.getKeysForFuncProxy(funcProxy);
-		keys.do({|key| active[key] = active[key].copy.addFunc(func) }); // support multiple keys
+		keys.do({|key| active[key] = active[key].addFunc(func) }); // support multiple keys
 		if(registered.not, {this.register});
 	}
 
@@ -138,7 +138,7 @@ AbstractWrappingDispatcher :  AbstractDispatcher {
 		funcProxy.removeDependant(this);
 		keys = this.getKeysForFuncProxy(funcProxy);
 		func = wrappedFuncs[funcProxy];
-		keys.do({|key| active[key] = active[key].copy.removeFunc(func) }); // support multiple keys
+		keys.do({|key| active[key] = active[key].removeFunc(func) }); // support multiple keys
 		wrappedFuncs[funcProxy] = nil;
 		if(active.size == 0, {this.unregister});
 	}
@@ -150,7 +150,7 @@ AbstractWrappingDispatcher :  AbstractDispatcher {
 		oldFunc = wrappedFuncs[funcProxy];
 		wrappedFuncs[funcProxy] = func;
 		keys = this.getKeysForFuncProxy(funcProxy);
-		keys.do({|key| active[key] = active[key].copy.replaceFunc(oldFunc, func) }); // support multiple keys
+		keys.do({|key| active[key] = active[key].replaceFunc(oldFunc, func) }); // support multiple keys
 	}
 
 	wrapFunc { this.subclassResponsibility(thisMethod) }

--- a/SCClassLibrary/Common/Core/AbstractFunction.sc
+++ b/SCClassLibrary/Common/Core/AbstractFunction.sc
@@ -331,29 +331,29 @@ FunctionList : AbstractFunction {
 	}
 
 	value { arg ... args;
-		var res = array.collect(_.valueArray(args));
+		var res = array.copy.collectInPlace(_.valueArray(args));
 		^if(flopped) { res.flop } { res }
 	}
 	valueArray { arg args;
-		var res = array.collect(_.valueArray(args));
+		var res = array.copy.collectInPlace(_.valueArray(args));
 		^if(flopped) { res.flop } { res }
 	}
 	valueEnvir { arg ... args;
-		var res = array.collect(_.valueArrayEnvir(args));
+		var res = array.copy.collectInPlace(_.valueArrayEnvir(args));
 		^if(flopped) { res.flop } { res }
 	}
 	valueArrayEnvir { arg args;
-		var res = array.collect(_.valueArrayEnvir(args));
+		var res = array.copy.collectInPlace(_.valueArrayEnvir(args));
 		^if(flopped) { res.flop } { res }
 	}
 	do { arg function;
 		array.do(function)
 	}
 	flop {
-		if(flopped.not) {array = array.collect(_.flop) }; flopped = true;
+		if(flopped.not) { array = array.collect(_.flop) }; flopped = true;
 	}
 	envirFlop {
-		if(flopped.not) {array = array.collect(_.envirFlop) }; flopped = true;
+		if(flopped.not) { array = array.collect(_.envirFlop) }; flopped = true;
 	}
 	storeArgs { ^[array] }
 	copy { ^super.copy.array_(array.copy) }

--- a/SCClassLibrary/Common/Core/Nil.sc
+++ b/SCClassLibrary/Common/Core/Nil.sc
@@ -33,6 +33,7 @@ Nil {
 	collectAs {}
 	selectAs {}
 	rejectAs {}
+	collectInPlace {}
 
 	// dependancy operators are no-ops
 	dependants {


### PR DESCRIPTION
The added collectInPlace method saves on object allocation for methods that are called very often.

This fixes #1329.