### PR TITLE
build system: disable sc_vim, sc_ed and sc_el by default

### DIFF
--- a/editors/CMakeLists.txt
+++ b/editors/CMakeLists.txt
@@ -1,13 +1,6 @@
-
-if(CMAKE_SYSTEM_NAME MATCHES "Linux")
-	option(SC_EL "Build emacs-based IDE." ON)
-    option(SC_ED "Build gedit-based IDE." ON)
-    option(SC_VIM "Build vim-based IDE." ON)
-else()
-	option(SC_EL "Build emacs-based IDE." OFF)
-    option(SC_ED "Build gedit-based IDE." OFF)
-    option(SC_VIM "Build vim-based IDE." OFF)
-endif()
+option(SC_EL "Build emacs-based IDE." OFF)
+option(SC_ED "Build gedit-based IDE." OFF)
+option(SC_VIM "Build vim-based IDE." OFF)
 
 if(SC_IDE)
 	message(STATUS "Building the Qt IDE")
@@ -33,4 +26,3 @@ if(SC_VIM)
 		add_subdirectory(scvim)
 	endif()
 endif()
-


### PR DESCRIPTION
This disables `scvim`, `scel` and `sced` by default on linux.

I guess `scide` is mature enough to not have those external editors built by default and avoid for the majority of users an additional build flag.