### PR TITLE
Topic/simplify gui documentation

### DIFF
--- a/HelpSource/Classes/EnvelopeView.schelp
+++ b/HelpSource/Classes/EnvelopeView.schelp
@@ -13,7 +13,7 @@ You can also define nodes with arrays of x and y values using link::#-value::, a
 
 SUBSECTION:: Appearance
 
-In strong::Qt GUI::, the view supports two strong::display styles::: the default one draws nodes as small dots, with labels next to them, while another style draws nodes as rounded rectangles with labels drawn inside. See link::#-style::.
+The view supports two strong::display styles::: the default one draws nodes as small dots, with labels next to them, while another style draws nodes as rounded rectangles with labels drawn inside. See link::#-style::.
 
 A strong::label:: for each of the nodes can be set using link::#-strings:: and link::#-setString::.
 
@@ -21,11 +21,11 @@ SUBSECTION:: Interaction
 
 Nodes can be selected and moved using mouse. Shift-clicking a node will add it to the selection.
 
-You can also move selected nodes and change selection using keyboard. In strong::Qt::, pressing the arrow keys will move selected nodes (as long as link::#-step:: is larger than 0). Pressing the left or right arrow keys while holding down Alt will select previous or next node, and holding down Shift will extend selection to the left or to the right. Other GUI kits may differ.
+You can also move selected nodes and change selection using keyboard. Pressing the arrow keys will move selected nodes (as long as link::#-step:: is larger than 0). Pressing the left or right arrow keys while holding down Alt will select previous or next node, and holding down Shift will extend selection to the left or to the right. Other GUI kits may differ.
 
-In strong::Qt::, link::#-keepHorizontalOrder:: allows you to enforce the order of nodes in horizontal direction to match their index order. In that case, node movement to the left and to the right will be restricted by the positions of their immediate neighbours. This is especially useful when EnvelopeView is used to display an link::Classes/Env::.
+link::#-keepHorizontalOrder:: allows you to enforce the order of nodes in horizontal direction to match their index order. In that case, node movement to the left and to the right will be restricted by the positions of their immediate neighbours. This is especially useful when EnvelopeView is used to display an link::Classes/Env::.
 
-In strong::Qt::, link::#-elasticSelection:: determines whether moving multiple nodes will be blocked altogether if any of the nodes meet an obstacle (the view bounds or a neighbour node), or only those individual nodes will be blocked.
+link::#-elasticSelection:: determines whether moving multiple nodes will be blocked altogether if any of the nodes meet an obstacle (the view bounds or a neighbour node), or only those individual nodes will be blocked.
 
 Node selection can also be changed programmatically using link::#-index::, link::#-selectIndex::, and link::#-deselectIndex::. The link::#-index#current:: node can be moved programmatically using link::#-x:: and link::#-y::.
 
@@ -144,14 +144,13 @@ METHOD:: connect
 		An Array of Integers - indexes of nodes, each to become the second end to a new connection created.
 
 METHOD:: selection
-	note::Only in Qt GUI::
 	Returns an array of indexes of all selected nodes.
 
 
 SUBSECTION:: Appearance
 
 METHOD:: style
-    NOTE:: Only available in Qt GUI ::
+
 
     One of the following drawing styles:
 
@@ -249,11 +248,7 @@ SUBSECTION:: Interaction
 METHOD:: index
 	The index of the emphasis::current:: node, i.e. the node affected by link::#-x:: and link::#-y:: methods.
 
-    In strong::Qt::, this is the selected node with lowest index, or -1 if no selection.
-
-    In strong::Cocoa::, this is the last node selected, or -1 if no selection.
-
-    In strong::SwingOSC::, this is the last node clicked, regardless of selection.
+    This is the selected node with lowest index, or -1 if no selection.
 
 	argument::
 		An Integer.
@@ -298,7 +293,6 @@ METHOD:: step
 		A Float.
 
 METHOD:: keepHorizontalOrder
-	note:: Only available in strong::Qt GUI:: ::
 
 	Whether the position of nodes on the horizontal axis shall be restricted by their immediate neighbours (in order of their index).
 
@@ -308,7 +302,6 @@ METHOD:: keepHorizontalOrder
 		A Boolean.
 
 METHOD:: elasticSelection
-	note:: Only available in strong::Qt GUI:: ::
 
 	Whether the relative positions of nodes within the selection can change when the selection is moved using mouse or keyboard, in order to adapt to obstacles (the view bounds or, in case link::#-keepHorizontalOrder:: is code::true::, a neighbour node).
 
@@ -330,7 +323,7 @@ METHOD:: defaultKeyDownAction
 
     Implements the default behavior on key presses.
 
-    In Qt, the default behavior is defined in the C++ implementation of the view instead of this method. See link::Classes/View#Key and mouse event processing:: for explanation of how to override the behavior.
+    The default behavior is defined in the C++ implementation of the view instead of this method. See link::Classes/View#Key and mouse event processing:: for explanation of how to override the behavior.
 
 
 

--- a/HelpSource/Classes/Font.schelp
+++ b/HelpSource/Classes/Font.schelp
@@ -12,8 +12,6 @@ private::key
 
 method:: new
 
-note:: The strong::bold::, strong::italic:: and strong::isPointSize:: arguments are only available in Qt GUI.
-::
 
 argument:: name
 An instance of link::Classes/String::. Must coincide with the name of a font on the system. See link::#*availableFonts::.
@@ -63,10 +61,9 @@ The default monospace face Font.
 method:: default
 The global default Font.
 
-In Qt GUI, setting this property is equivalent to code::Font.setDefault(font)::. See link::#*setDefault:: for details.
+Setting this property is equivalent to code::Font.setDefault(font)::. See link::#*setDefault:: for details.
 
 method:: setDefault
-note::Only available in Qt GUI::
 Sets the global default font. Properties of the code::font:: argument will be combined with properties of the default system font, and those of individual views.
 
 Optionally, a class can be given, so only views of that class will be affected.
@@ -97,25 +94,22 @@ An instance of link::Classes/String::.
 
 method:: size
 Gets/sets the size of the font.
-note:: In Qt GUI, setting this variable is always considered as setting the link::#-pixelSize::, while getting it will return any size set. In other GUI kits, size is always considered as pixel-size anyway. See link::#-hasPointSize:: for distinction.::
+Setting this variable is always considered as setting the link::#-pixelSize::, while getting it will return any size set. See link::#-hasPointSize:: for distinction.::
 
 argument:: pixelSize
 A Float.
 
 method:: hasPointSize
-note::Only in Qt GUI::
 A Boolean variable indicating whether the link::#-size:: is regarded as pixel-size (precise amount of pixels), or point-size (adapting to screen resolution).
 To change this, you need to set the size via link::#-pixelSize:: or link::#-pointSize::.
 
 method:: pixelSize
-note::Only in Qt GUI::
 Gets or sets the pixel-size of the font. When getting, returns nil if the font has point-size instead. See link::#-hasPointSize:: for distinction.
 Argument::
 	Any number, but note that floats will be rounded to integer values when setting pixel-size.
 
 
 method:: pointSize
-note::Only in Qt GUI::
 Gets or sets the point-size of the font. When getting, returns nil if the font has pixel-size instead. See link::#-hasPointSize:: for distinction.
 Argument::
 	A Float.
@@ -123,9 +117,8 @@ Argument::
 method:: setDefault
 Makes this instance of Font the default.
 
-In Qt GUI, this is equivalent to calling link::#*setDefault:: with this Font and the given class as arguments.
+This is equivalent to calling link::#*setDefault:: with this Font and the given class as arguments.
 
-In other GUI kits, this is equivalent to setting the link::#*default:: property.
 
 method:: storeArgs
 (?)

--- a/HelpSource/Classes/GUI.schelp
+++ b/HelpSource/Classes/GUI.schelp
@@ -7,7 +7,7 @@ related:: Overviews/GUI-Classes, Guides/GUI-Introduction, Classes/ViewRedirect
 description::
 SuperCollider currently supports three operating system platforms: Macintosh OSX, UNIX (Linux and FreeBSD) and Windows (with some limitations).
 
-note::The redirect system has been deprecated, please use the view classes directly.::
+warning::The redirect system has been deprecated, please use the view classes directly.::
 
 Graphical User Interface (GUI) code, for the most part, does not need to worry about which platform is executing the code because of the strong::view redirect:: system. At any time, one and only one strong::GUI kit:: is active. This determines which GUI classes will be used for rendering. These classes, the active views, have prefixes for the GUI kit that created the view object: SCWindow vs. JSCWindow vs. QWindow.
 

--- a/HelpSource/Classes/Gradient.schelp
+++ b/HelpSource/Classes/Gradient.schelp
@@ -5,7 +5,7 @@ related:: Classes/Color, Classes/HiliteGradient
 
 description::
 
-note:: The use of Gradient is strong::not supported yet in Qt GUI::. When Gradient is used in place of Color, the average gradient color will be used instead. ::
+note:: The use of Gradient is strong::not supported yet::. When Gradient is used in place of Color, the average gradient color will be used instead. ::
 
 classmethods::
 

--- a/HelpSource/Classes/GridLayout.schelp
+++ b/HelpSource/Classes/GridLayout.schelp
@@ -5,8 +5,6 @@ related:: Classes/HLayout, Classes/VLayout, Classes/StackLayout, Guides/GUI-Layo
 
 DESCRIPTION::
 
-note:: GridLayout is only implemented in strong::Qt GUI:: ::
-
 GridLayout distributes its space into a strong::grid of rows and columns::, where each item can occupy strong::one or more cells::.
 
 You can construct the layout in two ways using link::#*rows:: and link::#*columns::. In the former constructor you pass arrays of items by rows, and in the latter by columns. Items can also be added later using link::#-add:: and link::#-addSpanning::. To remove an item, simply use link::Classes/View#-remove:: for views, or link::Classes/QObject#-destroy:: for views or layouts.

--- a/HelpSource/Classes/Image.schelp
+++ b/HelpSource/Classes/Image.schelp
@@ -1,11 +1,11 @@
 class:: Image
 summary:: image component
 categories:: GUI>Views
-related:: View
+related:: Classes/View
 
 DESCRIPTION::
 
-Image enables the drawing of images in the SuperCollider GUI. 
+Image enables the drawing of images in the SuperCollider GUI.
 
 
 CLASSMETHODS::
@@ -554,7 +554,7 @@ NOTE::
 Compositing operations are currently disabled for tileInRect
 ::
 
-ARGUMENT::fraction
+ARGUMENT::opacity
 the opacity to use, ranging from 0.0 (fully transparent) to 1.0 (fully opaque)
 
 SUBSECTION::Instance Methods / accessing and setting pixels
@@ -692,7 +692,7 @@ code::
 ARGUMENT::array
 an link::Classes/Int32Array:: of size strong::rect::.width * strong::rect::.height containing all pixel values as 32bit Integer
 
-ARGUMENT::rect
+ARGUMENT::region
 a rectangle defining the portion to update in the receiver. By default strong::rect:: is nil, meaning full image size.
 
 ARGUMENT::start

--- a/HelpSource/Classes/Layout.schelp
+++ b/HelpSource/Classes/Layout.schelp
@@ -1,6 +1,6 @@
 Class:: Layout
 summary:: Superclass of all GUI layouts
-categories:: GUI>Kits>Qt
+categories:: GUI>Layout
 related:: Classes/HLayout, Classes/VLayout, Classes/GridLayout, Classes/StackLayout, Guides/GUI-Layout-Management
 
 description::

--- a/HelpSource/Classes/LevelIndicator.schelp
+++ b/HelpSource/Classes/LevelIndicator.schelp
@@ -54,7 +54,7 @@ a.value = 1;
 ::
 
 METHOD:: style
-note:: Not yet implemented in Qt GUI ::
+note:: Not yet implemented ::
 Sets the style of the view.
 
 argument:: val
@@ -89,7 +89,7 @@ a.numSteps = 20;
 ::
 
 METHOD:: image
-note:: Not yet implemented in Qt GUI ::
+note:: Not yet implemented ::
 Sets the image used in style 3. See below for an example.
 
 argument:: image

--- a/HelpSource/Classes/LineLayout.schelp
+++ b/HelpSource/Classes/LineLayout.schelp
@@ -1,6 +1,6 @@
 CLASS:: LineLayout
 summary:: Superclass of layouts that distribute views in a line
-categories:: GUI>Kits>Qt
+categories:: GUI>Layout
 related:: Classes/HLayout, Classes/VLayout, Classes/GridLayout, Classes/StackLayout, Guides/GUI-Layout-Management
 
 DESCRIPTION::

--- a/HelpSource/Classes/ListView.schelp
+++ b/HelpSource/Classes/ListView.schelp
@@ -31,7 +31,6 @@ METHOD:: items
 		An Array of Strings, each String defining the text to represent an item.
 
 METHOD:: clear
-    note:: Only available in Qt GUI ::
     Removes all items.
 
 METHOD:: value
@@ -44,7 +43,6 @@ METHOD:: valueAction
 	Sets link::#-value:: and triggers the link::#-action::.
 
 METHOD:: selection
-	note::Only in Qt GUI::
 	An array of all selected indexes. When setting selection, either an array or a single integer may be used.
 
 	Note that this may be different than link::#-value:: when link::#-selectionMode:: allows multiple items to be selected. When setting selection in single-item selection mode, only the last index will remain selected.
@@ -82,7 +80,6 @@ METHOD:: hiliteColor
 SUBSECTION:: Interaction
 
 METHOD:: selectionMode
-	note:: Only available in Qt GUI ::
 
 	The allowed mode of item selection, according to the following table:
 
@@ -106,8 +103,8 @@ METHOD:: action
 	The action object evaluated whenever the user changes the emphasis::current:: item, i.e. when link::#-value:: changes as a result of GUI interaction.
 
 METHOD:: selectionAction
-	note::Only in Qt GUI::
-	The action object evaluated whenever link::#-selection:: changes.
+
+The action object evaluated whenever link::#-selection:: changes.
 
 METHOD:: enterKeyAction
 	The action object evaluated whenever the user presses the Enter (Return) key.

--- a/HelpSource/Classes/MultiSliderView.schelp
+++ b/HelpSource/Classes/MultiSliderView.schelp
@@ -19,14 +19,9 @@ PRIVATE:: key
 
 METHOD:: new
 
-	note:: strong:: In Qt GUI: ::
 
 	A new MultiSliderView is created empty, without any columns. link::#-size:: or link::#-value:: has to be set in order to create some columns.
 	::
-
-	note:: strong:: Other GUI kits: ::
-
-	A new MultiSliderView is created with code::bounds.width/12:: sliders. However, the default link::#-thumbSize:: is 12 and the default link::#-gap:: is 1. The view width has to be code::13*n+2:: for all the sliders to automatically fit in the view.
 
 	So if you want a specific number of sliders, then it is best to specify the link::#-size:: and set link::#-elasticMode:: to 1. Then you will get a MultiSliderView which distributes link::#-size:: amount of sliders over code::bounds.width::, where the slider widths are at maximum link::#-indexThumbSize:: (default 12) and the link::#-gap:: is adjusted accordingly.
 	::
@@ -229,8 +224,8 @@ METHOD:: defaultKeyDownAction
 
 	table::
 	## strong::Key::   || strong::Effect::
-	## up arrow        || Qt: increment -currentValue by -step; Cocoa: decrement -gap by 1
-	## down arrow      || Qt: decrement -currentValue by -step; Cocoa: increment -gap by 1
+	## up arrow        || increment -currentValue by -step
+	## down arrow      || decrement -currentValue by -step
 	## right arrow     || increment -index by 1
 	## left arrow      || decrement -index by 1
 	::

--- a/HelpSource/Classes/Pen.schelp
+++ b/HelpSource/Classes/Pen.schelp
@@ -441,7 +441,6 @@ w.refresh;
 
 method:: matrix
 Gets or sets the coordinate system transformation matrix.
-note::Getter only available in Qt GUI::
 
 See link::#Matrix example:: for an example.
 

--- a/HelpSource/Classes/PopUpMenu.schelp
+++ b/HelpSource/Classes/PopUpMenu.schelp
@@ -26,7 +26,6 @@ METHOD:: items
 		An Array of Strings or Symbols.
 
 METHOD:: clear
- note:: Only available in Qt GUI ::
  Removes all items.
 
 METHOD:: item

--- a/HelpSource/Classes/ScrollView.schelp
+++ b/HelpSource/Classes/ScrollView.schelp
@@ -13,7 +13,7 @@ The view places the children onto a emphasis::canvas::, which may then be scroll
 
 The size of the canvas is always equal to the collective bounds of the children, and automatically adjusts when they are added, moved, resized and removed. If you wish to set it to a particular size, you could do so by first placing e.g. a link::Classes/CompositeView:: (or another container) of desired size, and then placing all the other views into that container.
 
-Exceptionally though, in strong::Qt GUI:: you can strong::replace the canvas:: with any other view (e.g. simply with link::Classes/View::), which allows you to install a link::Classes/Layout##layout:: on it. In that case, the canvas will fill the whole visible area of the ScrollView, if the layout contents allow so, or a larger area, if the layout contents demand so. Effectively, the strong::contents will resize:: together with the ScrollView, unless their size constraints prevent that, and if link::#-autohidesScrollers:: is code::true::, a scrollbar will only be shown if the contents can not be resized small enough in the scrollbar's direction. See link::#-canvas:: for further explanation.
+Exceptionally though, you can strong::replace the canvas:: with any other view (e.g. simply with link::Classes/View::), which allows you to install a link::Classes/Layout##layout:: on it. In that case, the canvas will fill the whole visible area of the ScrollView, if the layout contents allow so, or a larger area, if the layout contents demand so. Effectively, the strong::contents will resize:: together with the ScrollView, unless their size constraints prevent that, and if link::#-autohidesScrollers:: is code::true::, a scrollbar will only be shown if the contents can not be resized small enough in the scrollbar's direction. See link::#-canvas:: for further explanation.
 
 subsection:: Restrictions
 
@@ -35,7 +35,6 @@ INSTANCEMETHODS::
 SUBSECTION:: Geometry
 
 METHOD:: canvas
-    note:: Only in Qt GUI ::
 
     Returns the current canvas that carries the child views, or replaces it with another.
 
@@ -89,7 +88,6 @@ METHOD:: hasVerticalScroller
 
 METHOD:: autoScrolls
 
-    note:: Not implemented yet in Qt GUI ::
 
     Sets or gets whether the view scrolls automatically when you drag on a child view past the edge of visible bounds.
 
@@ -114,7 +112,6 @@ EXAMPLES::
 
 SUBSECTION:: Layout management on the canvas
 
-note:: Only works with Qt GUI ::
 
 By replacing the canvas of the ScrollView with a View, and installing a layout on it, the contents will expand to the edge of the ScrollView, and only exceed the edge if necessary.
 

--- a/HelpSource/Classes/SoundFileView.schelp
+++ b/HelpSource/Classes/SoundFileView.schelp
@@ -8,7 +8,9 @@ DESCRIPTION::
 
 A sound file viewer with numerous options.
 
-In strong::Qt GUI:: you can strong::zoom:: in and out using Shift + right-click + mouse-up/down; likewise, you can strong::scroll:: using right-click + mouse-left/right.
+Zoom in and out using Shift + right-click + mouse-up/down;
+
+Scroll using right-click + mouse-left/right.
 
 CLASSMETHODS::
 
@@ -29,7 +31,7 @@ METHOD:: read
 
     Reads a section of the link::#-soundfile:: and displays it in the view. For large files, you may want to use readWithTask instead.
 
-    note:: In Qt GUI, the 'block' argument has no effect; the display resolution is infinite. ::
+    The 'block' argument has no effect; the display resolution is infinite.
 
     argument:: startFrame
         The beginning of the section, in frames.
@@ -48,7 +50,7 @@ METHOD:: readFile
 
     Reads a section of an open instance of SoundFile, and displays it in the view. For large files, you may want to use the method readWithTask instead.
 
-    note:: In Qt GUI, the 'block' argument has no effect; the display resolution is infinite. ::
+   The 'block' argument has no effect; the display resolution is infinite.
 
     argument:: soundfile
         An open instance of SoundFile.
@@ -69,10 +71,7 @@ METHOD:: readWithTask
 
     Reads a section of the link::#-soundfile:: asynchronously (in the background), updating the link::#-readProgress:: along the way. If the code::showProgress:: argument is code::true::, a SoundFileViewProgressWindow opens to show the progress.
 
-    note:: In Qt GUI:
-        The 'block' argument has no effect; the display resolution is infinite.
-        The 'showProgress' argument has no effect; the view always displays reading progress within itself.
-    ::
+   The 'block' argument has no effect; the display resolution is infinite. The 'showProgress' argument has no effect; the view always displays reading progress within itself.
 
     argument:: startFrame
         The beginning of the section, in frames.
@@ -94,7 +93,6 @@ METHOD:: readFileWithTask
 
     Reads a section of an open instance of SoundFile asynchronously (in the background), updating the link::#-readProgress:: along the way. If the code::showProgress:: argument is code::true::, a SoundFileViewProgressWindow opens to show the progress.
 
-    note:: In Qt GUI:
         The 'block' argument has no effect; the display resolution is infinite.
         The 'showProgress' argument has no effect; the view always displays reading progress within itself.
     ::
@@ -121,7 +119,7 @@ METHOD:: data
 
     Gets the display data, or sets custom data instead of a sound file.
 
-    note:: In Qt and SwingOSC it is not possible to get the data. ::
+    It is not possible to get the data.
 
     In Cocoa and SwingOSC, setting this property is equivalent to link::#-setData:: with number of channels and sample rate of the current link::#-soundfile:: (if any), while in Qt it always assumes 1 channel and sample rate of 44100 Hz. Use link::#-setData:: instead if you want more control.
 

--- a/HelpSource/Classes/SoundFileView.schelp
+++ b/HelpSource/Classes/SoundFileView.schelp
@@ -121,7 +121,7 @@ METHOD:: data
 
     It is not possible to get the data.
 
-    In Cocoa and SwingOSC, setting this property is equivalent to link::#-setData:: with number of channels and sample rate of the current link::#-soundfile:: (if any), while in Qt it always assumes 1 channel and sample rate of 44100 Hz. Use link::#-setData:: instead if you want more control.
+   Setting this property assumes 1 channel and sample rate of 44100 Hz. Use link::#-setData:: instead if you want more control.
 
     argument::
         An Array of Floats; multiple channel data should be interleaved.
@@ -130,13 +130,12 @@ METHOD:: setData
 
     Sets custom display data instead of a sound file, interpreting it using specified number of channels and sample rate.
 
-    note:: In Qt GUI, the 'block' argument has no effect; the display resolution is infinite. ::
 
     argument:: arr
         An Array of Floats; multiple channel data should be interleaved.
 
     argument:: block
-        The block size - visual resolution of the display. An Integer of the form 2**n.
+The block size - visual resolution of the display. An Integer of the form 2**n. (since the port to QT, the 'block' argument has no effect; the display resolution is infinite).
 
     argument:: startframe
         An integer.
@@ -148,8 +147,9 @@ METHOD:: setData
         An integer.
 
 METHOD:: alloc
-    NOTE:: Only in Qt GUI ::
-    Allocates a desired amount of display channels and frames; all frames have initial value of 0.
+
+Allocates a desired amount of display channels and frames; all frames have initial value of 0.
+
     argument:: frames
         An Integer.
     argument:: channels
@@ -158,8 +158,8 @@ METHOD:: alloc
         An Integer.
 
 METHOD:: set
-    NOTE:: Only in Qt GUI ::
-    Overwrites a range of display data with another data. This method can be used after link::#-alloc:: or link::#-setData:: has been called, but not while the view is displaying a sound file.
+
+Overwrites a range of display data with another data. This method can be used after link::#-alloc:: or link::#-setData:: has been called, but not while the view is displaying a sound file.
 
     argument:: offset
         The frame at which to start overwriting; an Integer.
@@ -378,7 +378,7 @@ METHOD:: setEditableSelectionSize
 
 METHOD:: readSelection
 
-    note:: Not in Qt GUI ::
+    note:: Not implemented ::
 
     Read the data within a selection.
 
@@ -390,7 +390,7 @@ METHOD:: readSelection
 
 METHOD:: readSelectionWithTask
 
-    note:: Not in Qt GUI ::
+    note:: Not implemented ::
 
     Read the data within the current selection asynchronously (in the background), showing the progress in a separate window.
 
@@ -473,7 +473,7 @@ EXAMPLES::
 SUBSECTION:: Basic example
 
 code::
-// In Qt GUI:
+
 // To zoom in/out: Shift + right-click + mouse-up/down
 // To scroll: right-click + mouse-left/right
 (
@@ -517,7 +517,6 @@ a.read(0, f.numFrames);     // read in the entire file.
 a.refresh;                  // refresh to display the file.
 )
 
-// In Qt GUI:
 // To zoom in/out: Shift + right-click + mouse-up/down
 // To scroll: right-click + mouse-left/right
 
@@ -527,15 +526,10 @@ a.read.refresh;                     // read entire file by default
 a.read(f.numFrames / 2).refresh;    // read second half
 a.read(0, -1).refresh;              // -1 also reads entire file, like buffer.
 
-// In Qt GUI, the resolution of the view is always infinite;
+// the resolution of the view is always infinite;
 // you can always zoom in until you see a single sample.
 
-// In other GUI kits, 'block' sets the resolution of the view (default is 64).
-// i.e. the view keeps peak values for each block of e.g. 64 samples
-// rather than the entire waveform.
-a.read(0, -1, block: 32).refresh;
-a.read(0, -1, block: 24).refresh;
-a.read(0, -1, block: 16).refresh;
+a.read(0, -1).refresh;
 
 // for longer files, you can use:
 a.readWithTask;

--- a/HelpSource/Classes/StackLayout.schelp
+++ b/HelpSource/Classes/StackLayout.schelp
@@ -5,8 +5,6 @@ related:: Classes/HLayout, Classes/VLayout, Classes/GridLayout, Guides/GUI-Layou
 
 DESCRIPTION::
 
-note:: StackLayout is only implemented in strong::Qt GUI:: ::
-
 StackLayout manages several views stacked into the same space. It has two modes: it can either switch the view that is visible, hiding the others, or it can keep all of them visible, switching the one that is on top.
 
 The second mode is useful for example for overlaying a view with a link::Classes/UserView::, on which you can then draw additional information. If you still want to be able to interact with the view below using the mouse, you can make the one above ignore the mouse using link::Classes/View#-acceptsMouse::. See the link::#examples#example:: below.

--- a/HelpSource/Classes/Stethoscope.schelp
+++ b/HelpSource/Classes/Stethoscope.schelp
@@ -119,11 +119,7 @@ METHOD:: numChannels
         An Integer.
 
 METHOD:: bufsize
-    The size of the scoping buffer.
-
-    In strong::Swing:: and strong::Cococa:: GUI kits, this is the amount of signal frames that will be accumulated before they are displayed. However, it is strong::NOT ensured:: that the onsets of displayed portions of signals fall within any constant period. In other words, it is undefined how many frames will pass between one displayed portion, and another.
-
-    In strong::Qt:: GUI, this is not the issue; code::bufsize:: only defines the maximum allowed link::#-cycle::.
+   Defines the maximum allowed link::#-cycle::.
 
 METHOD:: cycle
     note:: Only available in Qt GUI ::
@@ -154,7 +150,7 @@ METHOD:: zoom
 METHOD:: xZoom
     Magnifies the displayed wave horizontally to the given factor.
 
-    In strong::Qt GUI::, this sets link::#-cycle:: to code::1024 * xZoom.reciprocal::.
+    This sets link::#-cycle:: to code::1024 * xZoom.reciprocal::.
 
     argument::
         A Float.

--- a/HelpSource/Classes/TextView.schelp
+++ b/HelpSource/Classes/TextView.schelp
@@ -231,7 +231,7 @@ METHOD:: autohidesScrollers
 
 SUBSECTION:: Drag and Drop
 
-note:: Default drag-and-drop behavior of TextView is not defined in standard SC methods (see link::Classes/View#subclassing::), but in the view implementation instead (except for link::#-defaultGetDrag:: in Qt GUI). It may or may not be overridable by adding your own handlers (see link::Classes/View#Drag and drop::), depending on the GUI kit in use.
+note:: Default drag-and-drop behavior of TextView is not defined in standard SC methods (see link::Classes/View#subclassing::), but in the view implementation instead (except for link::#-defaultGetDrag::). It may or may not be overridable by adding your own handlers (see link::Classes/View#Drag and drop::), depending on the GUI kit in use.
 ::
 
 Dragging from TextView will give the selected text in a String as drag data, while dropping will accept any object and insert it link::Classes/Object#-asString#as String:: at the drop location.

--- a/HelpSource/Classes/TreeViewItem.schelp
+++ b/HelpSource/Classes/TreeViewItem.schelp
@@ -1,6 +1,6 @@
 CLASS:: TreeViewItem
 summary:: An item in TreeView
-categories:: GUI>Kits>Qt
+categories:: GUI>Views
 
 DESCRIPTION::
 

--- a/HelpSource/Classes/UserView.schelp
+++ b/HelpSource/Classes/UserView.schelp
@@ -82,11 +82,8 @@ METHOD:: animate
 		A Boolean.
 
 METHOD:: frameRate
-	The interval at which the view regularily redraws itself, if link::#-animate:: is code::true::.
+	The interval at which the view regularily redraws itself, if link::#-animate:: is code::true::. You can change the desired frame rate by setting this variable.
 
-	In strong:: Qt GUI :: you can change the desired frame rate by setting this variable.
-
-	In strong:: Cocoa GUI :: this variable is not settable. Instead, use code::thisProcess.setDeferredTaskInterval(1/fps):: to change the global interval used for animation frame rate.
 
 	The default frame rate is 60fps.
 

--- a/HelpSource/Classes/View.schelp
+++ b/HelpSource/Classes/View.schelp
@@ -778,17 +778,23 @@ METHOD:: mouseLeave
 
 METHOD:: defaultGetDrag
 
+note::Not yet implemented::
+
 	The view's default method to determine the content of the drag&drop operation just initiated.
 
 	returns:: The object to be set as link::#*currentDrag::. If nil is returned, the drag&drop operation will not begin.
 
 METHOD:: defaultCanReceiveDrag
 
+note::Not yet implemented::
+
 	The view's default evaluation whether the content of the ongoing drag&drop operation can be accepted.
 
 	returns:: A Boolean stating whether link::#*currentDrag:: is useful. If false is returned, the drop will not be handled by this view.
 
 METHOD:: defaultReceiveDrag
+
+note::Not yet implemented::
 
 	The view's default handling of the data dropped on it (stored in link::#*currentDrag::).
 

--- a/HelpSource/Classes/Window.schelp
+++ b/HelpSource/Classes/Window.schelp
@@ -9,7 +9,7 @@ The Window is the most fundamental element of the GUI. It occupies a rectangular
 A child view is added into a window by passing the window to the view's constructor. See link::Classes/View#*new::.
 
 note::
-In strong::Qt GUI:: there is no distinction between windows, views, and containers; a View can be displayed directly on screen, and can contain other views. Therefore, visual descriptions of Window and most of the methods that are specific to Window in other GUI kits, also apply to and make part of View in Qt, and are thus shared by all its subclasses.
+There is no distinction between windows, views, and containers; a View can be displayed directly on screen, and can contain other views. Therefore, visual descriptions of Window and most of the methods that are specific to Window in other GUI kits, also apply to and make part of View in Qt, and are thus shared by all its subclasses.
 
 The Window class is provided in Qt GUI for compatibility as well as convenience: e.g. unlike View, Window will be created by default in the center of the screen, and various aspects can be conveniently controlled using its constructor arguments.
 ::
@@ -86,7 +86,7 @@ METHOD:: currentSheet
 SUBSECTION:: Visibility
 
 METHOD:: front
-	Displays the window on the screen (In Qt GUI this has the same effect as setting link::#-visible:: to true).
+	Displays the window on the screen (This has the same effect as setting link::#-visible:: to true).
 
 METHOD:: minimize
 	Hides the window, only keeping its representation in the dock, taskbar, etc..
@@ -107,7 +107,6 @@ METHOD:: alwaysOnTop
 		A Boolean.
 
 METHOD:: visible
-	note:: only in Qt GUI ::
 
 	Whether the window is visible.
 
@@ -150,7 +149,7 @@ METHOD:: setInnerExtent
 
 	Resizes the window, keeping its position intact.
 
-	In strong:: Qt GUI ::, this is equivalent to link::Classes/View#-resizeTo:: called on the link::#-view::.
+	This is equivalent to link::Classes/View#-resizeTo:: called on the link::#-view::.
 
 	argument:: w
 		An Integer width in pixels.
@@ -158,11 +157,9 @@ METHOD:: setInnerExtent
 		An Integer height in pixels.
 
 METHOD:: sizeHint
-	note:: only in Qt GUI ::
 	Redirects to link::Classes/View#-sizeHint:: of the link::#-view::.
 
 METHOD:: minSizeHint
-	note:: only in Qt GUI ::
 	Redirects to link::Classes/View#-minSizeHint:: of the link::#-view::.
 
 METHOD:: addFlowLayout
@@ -178,7 +175,6 @@ METHOD:: addFlowLayout
 	returns:: The new FlowLayout instance.
 
 METHOD:: layout
-	note:: only in Qt GUI ::
 	Redirects to link::Classes/View#-layout:: of the link::#-view::.
 
 


### PR DESCRIPTION
This makes the GUI documentation a bit easier to understand, especially for newcomers.

Under the assumption that QT is now the only properly supported GUI system, these patches remove most notes and warnings about GUI kit differences.

Some things are left, mainly because related classes and methods should first be properly deprecated, and it is better to keep the information.