### PR TITLE
scide: DocumentSelectPopUp - convert to Popup to fix lost KeyRelease event

### DIFF
--- a/editors/sc-ide/widgets/multi_editor.cpp
+++ b/editors/sc-ide/widgets/multi_editor.cpp
@@ -55,7 +55,7 @@ class DocumentSelectPopUp : public QDialog
 {
 public:
     DocumentSelectPopUp(const CodeEditorBox::History & history, QWidget * parent):
-        QDialog(parent, Qt::Dialog | Qt::FramelessWindowHint)
+        QDialog(parent, Qt::Popup | Qt::FramelessWindowHint)
     {
         mModel = new QStandardItemModel(this);
         populateModel(history);


### PR DESCRIPTION
ctrl-tab executes this dialog, but the KeyRelease event may be lost if
the window flag is not marked as Qt::Popup

Signed-off-by: Tim Blechmann <tim@klingt.org>