### PR TITLE
Date.schelp: corrected peculiar format example

### DIFF
--- a/HelpSource/Classes/Date.schelp
+++ b/HelpSource/Classes/Date.schelp
@@ -70,7 +70,7 @@ method::format
 Obtain a date string with a given format. The character % is replaced by the appropriate value, which is derived from the letter that follows.
 code::
 Date.getDate.format("Today is %A. It is around %I o'clock (%p), in %B.");
-Date.getDate.format("%Y-%d-%e-%Hh%m");
+Date.getDate.format("%d/%m/%Y %H:%M");  // DD/MM/YYYY hh:mm
 ::
 
 discussion::


### PR DESCRIPTION
%m and %e are both for day of month (the latter with preceding space, if single digit), minute is %M not %m