### PR TITLE
ide: Fix triggering of doc modified signal

### DIFF
--- a/editors/sc-ide/core/doc_manager.cpp
+++ b/editors/sc-ide/core/doc_manager.cpp
@@ -526,6 +526,7 @@ bool DocumentManager::doSaveAs( Document *doc, const QString & path )
 
     QString str = doc->textDocument()->toPlainText();
     file.write(str.toUtf8());
+    file.flush();
     file.close();
 
     info.refresh();
@@ -534,10 +535,17 @@ bool DocumentManager::doSaveAs( Document *doc, const QString & path )
                                   (info.suffix() == QString("scd")) ||
                                   (info.suffix() == QString("schelp")));
 
+    // It's possible the mod time has not been updated - if it looks like that is the case,
+    // just set it one second in the future, so we don't trip the external modification alarm.
+    if (doc->mSaveTime == info.lastModified()) {
+        doc->mSaveTime = QDateTime::currentDateTime().addMSecs(1000);
+    } else {
+        doc->mSaveTime = info.lastModified();
+    }
+
     doc->mFilePath = cpath;
     doc->mTitle = info.fileName();
     doc->mDoc->setModified(false);
-    doc->mSaveTime = info.lastModified();
     doc->setPlainText(fileIsPlainText);
     doc->removeTmpFile();
 


### PR DESCRIPTION
This is an attempt to fix #758. There is no easy solution, because QFile objects don't fire a signal when the write is finished, and when the write cache is heavily backlogged I presume there's a delay in updating the mod date.

Those affected can test in this build:
http://supercollider.s3.amazonaws.com/builds/supercollider/supercollider/osx/SC-96380ae258bcdf87e8ca587482a14cb51d535ba5.zip