### PR TITLE
fix-DiskOut

### DIFF
--- a/HelpSource/Classes/Server.schelp
+++ b/HelpSource/Classes/Server.schelp
@@ -592,6 +592,9 @@ Get/set the header format (string) of the output file. The default is "aiff". Mu
 method:: recSampleFormat
 Get/set the sample format (string) of the output file. The default is "float". Must be called strong::before:: prepareForRecord.
 
+method::recBufSize
+Get/set the size of the link::Classes/Buffer:: to use with the link::Classes/DiskOut:: UGen. This must be a power of two. The default is the code::sampleRate.nextPowerOfTwo:: or the first power of two number of samples longer than one second. Must be called strong::before:: prepareForRecord.
+
 subsection:: Asynchronous Commands
 
 Server provides support for waiting on the completion of asynchronous OSC-commands such as reading or writing soundfiles. N.B. The following methods must be called from within a running link::Classes/Routine::. Explicitly passing in a link::Classes/Condition:: allows multiple elements to depend on different conditions. The examples below should make clear how all this works.

--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -285,7 +285,7 @@ Server {
 	var <window, <>scopeWindow;
 	var <emacsbuf;
 	var recordBuf, <recordNode, <>recHeaderFormat="aiff", <>recSampleFormat="float";
-	var <>recChannels=2;
+	var <>recChannels=2, <>recBufSize;
 
 	var <volume;
 
@@ -1033,7 +1033,7 @@ Server {
 				path = thisProcess.platform.recordingsDir +/+ "SC_" ++ Date.localtime.stamp ++ "." ++ recHeaderFormat;
 			};
 		};
-		recordBuf = Buffer.alloc(this, 65536 * 16, recChannels,
+		recordBuf = Buffer.alloc(this, recBufSize ?? { sampleRate.nextPowerOfTwo }, recChannels,
 			{arg buf; buf.writeMsg(path, recHeaderFormat, recSampleFormat, 0, 0, true);},
 			this.options.numBuffers + 1); // prevent buffer conflicts by using reserved bufnum
 		recordBuf.path = path;

--- a/server/plugins/DiskIO_UGens.cpp
+++ b/server/plugins/DiskIO_UGens.cpp
@@ -84,6 +84,7 @@ extern "C"
 
 	void DiskOut_next(DiskOut *unit, int inNumSamples);
 	void DiskOut_Ctor(DiskOut* unit);
+    void DiskOut_Dtor(DiskOut* unit);
 
 	void VDiskIn_next(VDiskIn *unit, int inNumSamples);
 	void VDiskIn_first(VDiskIn *unit, int inNumSamples);
@@ -400,6 +401,33 @@ sendMessage:
 
 }
 
+void DiskOut_Dtor(DiskOut* unit)
+{
+    GET_BUF
+    
+    uint32 framepos = unit->m_framepos;
+    uint32 bufFrames2 = bufFrames >> 1;
+    // check that we didn't just write
+    if (framepos != 0 && framepos != bufFrames2) {
+        // if not write the last chunk of samples
+        uint32 writeStart;
+        if (framepos > bufFrames2) {
+            writeStart = bufFrames2;
+        } else {
+            writeStart = 0;
+        }
+        DiskIOMsg msg;
+        msg.mWorld = unit->mWorld;
+        msg.mCommand = kDiskCmd_Write;
+        msg.mBufNum = (int)fbufnum;
+        msg.mPos = writeStart;
+        msg.mFrames = framepos - writeStart;
+        msg.mChannels = bufChannels;
+        //printf("sendMessage %d  %d %d %d\n", msg.mBufNum, msg.mPos, msg.mFrames, msg.mChannels);
+        gDiskIO.Write(msg);
+    }
+}
+
 
 void VDiskIn_Ctor(VDiskIn* unit)
 {
@@ -620,7 +648,7 @@ PluginLoad(DiskIO)
 	gDiskIO.launchThread();
 
 	DefineSimpleUnit(DiskIn);
-	DefineSimpleUnit(DiskOut);
+	DefineDtorUnit(DiskOut);
 	DefineSimpleUnit(VDiskIn);
 }
 


### PR DESCRIPTION
This aims to fix a bug where DiskOut didn't always write the last chunk of samples. This should solve the problem discussed in Issue #1380 (although the default size should still be collected as suggested) and discussed on sc-dev in this thread: https://www.listarc.bham.ac.uk/lists/sc-dev/msg53886.html

It adds a Dtor which writes an extra msg to the DiskIO fifo if needed when the UGen is destroyed. There should be no API incompatibilities AFAICS.