### PR TITLE
class library: GridLayout - fix position when using spanning

### DIFF
--- a/SCClassLibrary/Common/GUI/Base/QLayout.sc
+++ b/SCClassLibrary/Common/GUI/Base/QLayout.sc
@@ -101,11 +101,17 @@ GridLayout : Layout {
 		var data;
 		grid = this.new;
 		rows.do { |row, r|
+			var offset = 0;
 			if( row.size > 0 ) {
 				row.do { |item, c|
+					var colSpan;
 					if( item.notNil ) {
 						data = this.parse( item, r, c );
+						colSpan = data[4];
+						data[2] = data[2] + offset;
 						grid.invokeMethod( \addItem, [data], true );
+						// If there's spanning, store offset for next elements column
+						if (colSpan > 1) { offset = offset + (colSpan - 1) };
 					};
 				};
 			};
@@ -118,11 +124,17 @@ GridLayout : Layout {
 		var data;
 		grid = this.new;
 		cols.do { |col, c|
+			var offset = 0;
 			if( col.size > 0 ) {
 				col.do { |item, r|
+					var rowSpan;
 					if( item.notNil ) {
 						data = this.parse( item, r, c );
+						rowSpan = data[3];
+						data[1] = data[1] + offset;
 						grid.invokeMethod( \addItem, [data], true );
+						// If there's spanning, store offset for next elements row
+						if (rowSpan > 1) { offset = offset + (rowSpan - 1) };
 					};
 				};
 			};


### PR DESCRIPTION
Fix #1383

```javascript
(
g = GridLayout.rows(
    [[Button(), c: 2], [Button(), c: 2], Button()],
    [[Button(), c: 5]]
);
w = Window("", 200@100).layout_(g).front();
)
```
![qtbugfixed01](https://cloud.githubusercontent.com/assets/271068/6882373/d390de92-d582-11e4-9c58-de049d819952.gif)
```javascript
(
g = GridLayout.columns(
    [Slider2D(), Slider2D(), Slider2D(), Slider2D(), Slider2D()],
    [[Slider2D(), r: 2], [Slider2D(), r: 2], Slider2D()],
    [[Slider2D(), r: 5]]
);
w = Window("", 200@100).layout_(g).front();
)
```
![qtbugfixed02](https://cloud.githubusercontent.com/assets/271068/6882374/e5b54bd0-d582-11e4-9f45-82a41064c715.gif)
