### PR TITLE
fixes #1369 LanguageConfig.current returns "", should return nil

### DIFF
--- a/lang/LangPrimSource/PyrPrimitive.cpp
+++ b/lang/LangPrimSource/PyrPrimitive.cpp
@@ -3531,8 +3531,13 @@ static int prLanguageConfig_removeExcludePath(struct VMGlobals * g, int numArgsP
 static int prLanguageConfig_getCurrentConfigPath(struct VMGlobals * g, int numArgsPushed)
 {
 	PyrSlot *a = g->sp;
-	PyrString* string = newPyrString(g->gc, gLanguageConfig->getCurrentConfigPath(), 0, false);
-	SetObject(a, string);
+	PyrString* str = newPyrString(g->gc, gLanguageConfig->getCurrentConfigPath(), 0, false);
+    if(str->size == 0) {
+        SetNil(a);
+    } else {
+        SetObject(a, str);
+    }
+    
 	return errNone;
 }
 


### PR DESCRIPTION
To test this, trash your ~/Library/Application Support/SuperCollider so that there is no existing ide config or lang config.

Startup supercollider. 

```supercollider
LanguageConfig.currentPath
```

should return nil.

This also fixes Quarks from trying to write to a config file of ""

Quarks.gui, install something, recompile.  Quarks.gui again and you should see the paths are saved to the config.

A language config file should exist with the default sclang_config.yaml

