### PR TITLE
Pattern.record method doesn't stop recording

### DIFF
--- a/SCClassLibrary/Common/Streams/Patterns.sc
+++ b/SCClassLibrary/Common/Streams/Patterns.sc
@@ -121,7 +121,7 @@ Pattern : AbstractFunction {
 				// Pfset has a cleanupFunc, which executes even if pattern is stopped by cmd-.
 				Pfset(nil,
 					Pseq([
-						Pfuncn { startTime = thisThread.beats; 0 },
+						Pfuncn { startTime = thisThread.beats; (type: \rest, delta: 0) },
 						(type: \on, instrument: defname, bufnum: buf, bus: bus, out: out, id: recsynth,
 							delta: 0),
 						pattern <> (out: bus),


### PR DESCRIPTION
e.g.
```
Pbind(\degree, Pseq([1,2,3,4],1)).record();
// Keeps recording even after end of pattern, cmd-. is only way to stop

Pbind(\degree, Pseq([1,2,3,4],1)).record(dur:4)
// Same problem
```
Pull request fixes this by returning a 0 duration rest event, rather than just 0.