### PR TITLE
scide: theme: introducing built-in "dark" theme

### DIFF
--- a/editors/sc-ide/core/settings/theme.cpp
+++ b/editors/sc-ide/core/settings/theme.cpp
@@ -144,6 +144,34 @@ void Theme::fillDefault()
     addToTheme(mFormats, "postwindowemphasis", Qt::black, Qt::transparent, true);
 }
 
+void Theme::fillDark()
+{
+    addToTheme(mFormats, "text", QColor("#e4e4e4"), Qt::black);
+    addToTheme(mFormats, "currentLine", QColor("#e4e4e4"), QColor("#393939"));
+    addToTheme(mFormats, "searchResult", QColor("#e4e4e4"), QColor("#194c7f"));
+    addToTheme(mFormats, "matchingBrackets", QColor("#ff5500"), QColor("#95e000"), true);
+    addToTheme(mFormats, "mismatchedBrackets", QColor("#ffaa00"), QColor("#ff0000"));
+    addToTheme(mFormats, "evaluatedCode", QColor("#e4e4e4"), QColor("#aaaaff"));
+    addToTheme(mFormats, "whitespace", QColor("#e4e4e4"));
+    addToTheme(mFormats, "keyword", QColor("#aaaaff"), Qt::transparent, true);
+    addToTheme(mFormats, "built-in", QColor("#ffaaff"));
+    addToTheme(mFormats, "env-var", QColor("#55aa7f"));
+    addToTheme(mFormats, "class", QColor("#00aaff"), Qt::transparent, true);
+    addToTheme(mFormats, "number", QColor("#aa00ff"));
+    addToTheme(mFormats, "symbol", QColor("#555500"));
+    addToTheme(mFormats, "string", QColor("#5f5f5f"));
+    addToTheme(mFormats, "char", QColor("#ff55ff"));
+    addToTheme(mFormats, "comment", QColor("#aa9569"));
+    addToTheme(mFormats, "primitive", QColor("#aaff7f"));
+    addToTheme(mFormats, "lineNumbers", QColor("#676767"));
+    addToTheme(mFormats, "selection", QColor("#ff5500"));
+    addToTheme(mFormats, "postwindowtext", QColor("#e4e4e4"));
+    addToTheme(mFormats, "postwindowerror", QColor(209, 28, 36));
+    addToTheme(mFormats, "postwindowwarning", QColor(165, 119, 6));
+    addToTheme(mFormats, "postwindowsuccess", QColor(115, 138, 5));
+    addToTheme(mFormats, "postwindowemphasis", QColor("#e4e4e4"), Qt::transparent, true);
+}
+
 void Theme::fillUser(const QString & name, const Manager *settings)
 {
     QString group = QString("IDE/editor/themes/%1/").arg(name);
@@ -178,6 +206,9 @@ Theme::Theme(const QString & _name, Manager * settings)
     if (mName == "default") {
         fillDefault();
         mLocked = true;
+    } else if (mName == "dark") {
+        fillDark();
+        mLocked = true;
     } else {
         fillUser(mName, settings);
         mLocked = false;
@@ -193,6 +224,8 @@ Theme::Theme(const QString & _name, const QString & _source, Manager * settings)
 
     if (_source == "default") {
         fillDefault();
+    } else if (_source == "dark") {
+        fillDark();
     } else {
         fillUser(_source, settings);
     }
@@ -243,6 +276,7 @@ QList<QString> Theme::availableThemes()
     QList<QString> themes;
 
     themes.append("default");
+    themes.append("dark");
 
     mSettings->beginGroup("IDE/editor/themes");
     themes.append(mSettings->childGroups());

--- a/editors/sc-ide/core/settings/theme.hpp
+++ b/editors/sc-ide/core/settings/theme.hpp
@@ -52,6 +52,7 @@ public:
 private:
     void fillUser(const QString & theme, const Manager *settings);
     void fillDefault();
+    void fillDark();
 
     bool mLocked;
     QMap<QString, QTextCharFormat *> mFormats;


### PR DESCRIPTION
While the default theme is black on white background, the "dark" theme is mostly
white on a black background.

This theme has been provided by http://fleuryfontaine.fr/