### PR TITLE
Quarks GUI tiny improvements

### DIFF
--- a/SCClassLibrary/Common/Quarks/Quarks.sc
+++ b/SCClassLibrary/Common/Quarks/Quarks.sc
@@ -165,6 +165,9 @@ Quarks {
 			("A version of % is already installed at %".format(quark, prev.localPath)).error;
 			^false
 		});
+
+		"Installing %".format(quark.name).inform;
+
 		quark.checkout();
 		if(quark.isCompatible().not, {
 			^incompatible.value(quark.name);

--- a/SCClassLibrary/Common/Quarks/QuarksGui.sc
+++ b/SCClassLibrary/Common/Quarks/QuarksGui.sc
@@ -328,7 +328,7 @@ QuarkDetailView {
 
 			model.data.keysValuesDo({ |k, v|
 				if(#[\name, \summary, \url, \path, \dependencies, \version].includes(k).not) {
-					this.pushRow(k.asString, v.asString);
+					this.pushRow(k.asString, v.value().asString);
 				}
 			});
 


### PR DESCRIPTION
This:
- fixes the *isCompatible* string in the quark description
- informs the user that a quark is being downloaded

While trying the new quark gui with a relatively slow internet, I got confused because I first thought that nothing happened with `Quarks.install('http://...')`..