### PR TITLE
ide: track files opened in a session switch in the recent documents menu

### DIFF
--- a/editors/sc-ide/widgets/multi_editor.cpp
+++ b/editors/sc-ide/widgets/multi_editor.cpp
@@ -882,7 +882,7 @@ void MultiEditor::switchSession( Session *session )
         QVariantList docDataList = session->value("documents").value<QVariantList>();
         foreach( const QVariant & docData, docDataList ) {
             QString filePath = docData.toString();
-            Document * doc = docManager->open(filePath, -1, 0, false);
+            Document * doc = docManager->open(filePath, -1, 0, true);
             documentList << doc;
         }
 


### PR DESCRIPTION
This fixes #1287.
This behavior (i.e. adding documents opened via session switch) seems fine to me, but it was explicitly disabled before.