### PR TITLE
lang: don't drop backslashes

### DIFF
--- a/lang/LangPrimSource/PyrStringPrim.cpp
+++ b/lang/LangPrimSource/PyrStringPrim.cpp
@@ -163,6 +163,7 @@ int prString_Format(struct VMGlobals *g, int numArgsPushed)
 				buf[k++] = '%';
 			} else {
 				i--;
+                buf[k++] = '\\';
 			}
 		} else {
 			buf[k++] = ch;


### PR DESCRIPTION
In case of a backslash with no following %, we want to push the backslash to the output string.

fixes #1291