### PR TITLE
ide: hide toolbox after changing box focus

### DIFF
--- a/editors/sc-ide/widgets/main_window.cpp
+++ b/editors/sc-ide/widgets/main_window.cpp
@@ -1534,7 +1534,6 @@ void MainWindow::showReplaceTool()
 
 void MainWindow::hideToolBox()
 {
-    mToolBox->hide();
     GenericCodeEditor *editor = mEditors->currentEditor();
     if (editor) {
         // This slot is mapped to Escape, so also clear highlighting
@@ -1543,6 +1542,8 @@ void MainWindow::hideToolBox()
         if (!editor->hasFocus())
             editor->setFocus(Qt::OtherFocusReason);
     }
+
+    mToolBox->hide();
 }
 
 void MainWindow::showSettings()


### PR DESCRIPTION
Hiding the toolbox causes focus to revert - in that case, Qt handles the focus logic, and seems to pick the first widget in the chain. Instead, we need to set focus to the correct editor box ourselves, and *then* hide the toolbox.

Fixes #1363