### PR TITLE
Topic/fix dependency versions and case problems

### DIFF
--- a/HelpSource/Classes/DiskOut.schelp
+++ b/HelpSource/Classes/DiskOut.schelp
@@ -108,7 +108,7 @@ subsection:: Messaging Style
 code::
 // The same thing done in Messaging Style (less overhead but without the convienence of objects)
 // This does nothing different from the Messaging Style example.
-// If any of the following is confusing, stick to Messaging Style
+// If any of the following is confusing, stick to Object Style
 // and ignore this part.
 
 // start something to record

--- a/SCClassLibrary/Common/Quarks/Quark.sc
+++ b/SCClassLibrary/Common/Quarks/Quark.sc
@@ -20,12 +20,6 @@ Quark {
 		# url, refspec = directoryEntry.split($@);
 		^super.new.init(name, url, refspec)
 	}
-	*canonicalName { |inName|
-		var found = Quarks.directory.keys.detect({ |name|
-			Quark.nameEquals(inName, name)
-		});
-		if (found.notNil) { ^found } { ^inName };
-	}
 	*nameEquals { |a, b|
 		^(a.compare(b, true) == 0);
 	}
@@ -38,7 +32,7 @@ Quark {
 		^(a == b);
 	}
 	init { |argName, argUrl, argRefspec, argLocalPath|
-		name = Quark.canonicalName(argName);
+		name = argName;
 		url = argUrl;
 		refspec = argRefspec;
 		localPath = argLocalPath ?? {Quarks.folder +/+ name};

--- a/SCClassLibrary/Common/Quarks/Quark.sc
+++ b/SCClassLibrary/Common/Quarks/Quark.sc
@@ -20,10 +20,6 @@ Quark {
 		# url, refspec = directoryEntry.split($@);
 		^super.new.init(name, url, refspec)
 	}
-	*nameEquals { |a, b|
-		^(a.compare(b, true) == 0);
-	}
-
 	*versionEquals { |a, b|
 		a = a.asString;
 		b = b.asString;
@@ -301,7 +297,7 @@ QuarkDependency {
 	}
 
 	conflictsWith { |inName, inVersion|
-		if (Quark.nameEquals(name, inName), {
+		if (name == inName, {
 			if (inVersion.notNil && version.notNil, {
 				if (Quark.versionEquals(inVersion, version).not, {
 					^true;
@@ -313,7 +309,7 @@ QuarkDependency {
 	}
 
 	isMetBy { |inName, inVersion|
-		var isMet = Quark.nameEquals(name, inName);
+		var isMet = (name == inName);
 		if (version.notNil, {
 			isMet = isMet && Quark.versionEquals(version, inVersion);
 		});

--- a/SCClassLibrary/Common/Quarks/Quark.sc
+++ b/SCClassLibrary/Common/Quarks/Quark.sc
@@ -141,25 +141,25 @@ Quark {
 	*findMatch { |dependency, pending|
 		var found;
 
-		Quarks.installed.do { |q|
-			if (dependency.isMetBy(q.name, q.version)) { ^q };
-		};
+		Quarks.installed.do({ |q|
+			if (dependency.isMetBy(q.name, q.version), { ^q });
+		});
 
 		pending.do { |q|
-			if (dependency.isMetBy(q.name, q.version)) { ^q };
+			if (dependency.isMetBy(q.name, q.version), { ^q });
 		};
 
 		found = Quark(dependency.name);
-		if (found.isDownloaded.not) { found.checkout() };
-		if (dependency.isMetBy(found.name, found.version)) {
+		if (found.isDownloaded.not, { found.checkout() });
+		if (dependency.isMetBy(found.name, found.version), {
 			^found;
-		};
-		found.tags.do {
+		});
+		found.tags.do({
 			|tag|
-			if (dependency.isMetBy(dependency.name, tag)) {
+			if (dependency.isMetBy(dependency.name, tag), {
 				^Quark(dependency.name, tag)
-			}
-		};
+			})
+		});
 
 		^nil
 	}
@@ -175,16 +175,16 @@ Quark {
 		var conflict, quark, dependencies, foundQuarks = Dictionary.new;
 
 		dependencies = this.dependencies();
-		dependencies.do { |d|
+		dependencies.do({ |d|
 			allDeps.add("%@%".format(this.name, this.version) -> d)
-		};
+		});
 
 		dependencies.do({ |dep|
 			quark = Quark.findMatch(dep);
 
-			if (quark.isNil) {
+			if (quark.isNil, {
 				Error("No quark found that satisfies dependency: %".format(dep.asString())).throw;
-			};
+			});
 
 			quark.checkout();
 			quark.deepDependencies(allDeps).debug(quark).do({ |qb|
@@ -203,14 +203,14 @@ Quark {
 			^QuarkDependency(dep)
 		};
 
-		if (dep.isKindOf(Association)) {
+		if (dep.isKindOf(Association), {
 			^QuarkDependency.fromAssociation(dep)
-		};
+		});
 
-		if (dep.isSequenceableCollection) {
+		if (dep.isSequenceableCollection, {
 			# name, version, url = dep;
 			^QuarkDependency(url ++ name, version);
-		};
+		});
 
 		Error("Cannot parse dependency:" + this + dep).throw;
 	}
@@ -283,7 +283,7 @@ QuarkDependency {
 
 	*fromAssociation { |association|
 		var str = association.key.asString();
-		if (association.value.notNil) { str = str ++ "@" ++ association.value.asString() };
+		if (association.value.notNil, { str = str ++ "@" ++ association.value.asString() });
 		^QuarkDependency(str);
 	}
 
@@ -307,22 +307,22 @@ QuarkDependency {
 	}
 
 	conflictsWith { |inName, inVersion|
-		if (Quark.nameEquals(name, inName)) {
-			if (inVersion.notNil && version.notNil) {
-				if (Quark.versionEquals(inVersion, version).not) {
+		if (Quark.nameEquals(name, inName), {
+			if (inVersion.notNil && version.notNil, {
+				if (Quark.versionEquals(inVersion, version).not, {
 					^true;
-				}
-			}
-		};
+				})
+			})
+		});
 
 		^false;
 	}
 
 	isMetBy { |inName, inVersion|
 		var isMet = Quark.nameEquals(name, inName);
-		if (version.notNil) {
+		if (version.notNil, {
 			isMet = isMet && Quark.versionEquals(version, inVersion);
-		};
+		});
 		^isMet;
 	}
 

--- a/SCClassLibrary/Common/Quarks/Quark.sc
+++ b/SCClassLibrary/Common/Quarks/Quark.sc
@@ -20,6 +20,12 @@ Quark {
 		# url, refspec = directoryEntry.split($@);
 		^super.new.init(name, url, refspec)
 	}
+	*canonicalName { |inName|
+		var found = Quarks.directory.keys.detect({ |name|
+			Quark.nameEquals(inName, name)
+		});
+		if (found.notNil) { ^found } { ^inName };
+	}
 	*nameEquals { |a, b|
 		^(a.compare(b, true) == 0);
 	}
@@ -32,7 +38,7 @@ Quark {
 		^(a == b);
 	}
 	init { |argName, argUrl, argRefspec, argLocalPath|
-		name = argName;
+		name = Quark.canonicalName(argName);
 		url = argUrl;
 		refspec = argRefspec;
 		localPath = argLocalPath ?? {Quarks.folder +/+ name};

--- a/SCClassLibrary/Common/Quarks/Quark.sc
+++ b/SCClassLibrary/Common/Quarks/Quark.sc
@@ -286,7 +286,7 @@ QuarkDependency {
 	conflictsWith { |inName, inVersion|
 		if (Quark.nameEquals(name, inName)) {
 			if (inVersion.notNil && version.notNil) {
-				if (QuarkDependency.versionEquals(inVersion, version).not) {
+				if (Quark.versionEquals(inVersion, version).not) {
 					^true;
 				}
 			}
@@ -298,7 +298,7 @@ QuarkDependency {
 	isMetBy { |inName, inVersion|
 		var isMet = Quark.nameEquals(name, inName);
 		if (version.notNil) {
-			isMet = isMet && QuarkDependency.versionEquals(version, inVersion);
+			isMet = isMet && Quark.versionEquals(version, inVersion);
 		};
 		^isMet;
 	}

--- a/SCClassLibrary/Common/Quarks/Quark.sc
+++ b/SCClassLibrary/Common/Quarks/Quark.sc
@@ -117,7 +117,31 @@ Quark {
 			data = nil;
 		});
 	}
+	*findMatch { |dependency, pending|
+		var found;
 
+		Quarks.installed.do { |q|
+			if (dependency.isMetBy(q.name, q.version)) { ^q };
+		};
+
+		pending.do { |q|
+			if (dependency.isMetBy(q.name, q.version)) { ^q };
+		};
+
+		found = Quark(dependency.name);
+		if (found.isDownloaded.not) { found.checkout() };
+		if (dependency.isMetBy(found.name, found.version)) {
+			^found;
+		};
+		found.tags.do {
+			|tag|
+			if (dependency.isMetBy(dependency.name, tag)) {
+				^Quark(dependency.name, tag)
+			}
+		};
+
+		^nil
+	}
 	dependencies {
 		var deps = this.data['dependencies'] ?? {^[]};
 		if(deps.isSequenceableCollection.not, {

--- a/SCClassLibrary/Common/Quarks/Quark.sc
+++ b/SCClassLibrary/Common/Quarks/Quark.sc
@@ -295,12 +295,12 @@ QuarkDependency {
 		^false;
 	}
 
-	isFulfilledBy { |inName, inVersion|
-		var fulfilled = Quark.nameEquals(name, inName);
+	isMetBy { |inName, inVersion|
+		var isMet = Quark.nameEquals(name, inName);
 		if (version.notNil) {
-			fulfilled = fulfilled && QuarkDependency.versionEquals(version, inVersion);
+			isMet = isMet && QuarkDependency.versionEquals(version, inVersion);
 		};
-		^fulfilled;
+		^isMet;
 	}
 
 	asString {

--- a/SCClassLibrary/Common/Quarks/Quarks.sc
+++ b/SCClassLibrary/Common/Quarks/Quarks.sc
@@ -31,7 +31,7 @@ Quarks {
 	*uninstall { |name|
 		// by quark name or local path
 		this.installed.do { |q|
-			if(Quark.nameEquals(q.name, name), {
+			if(q.name == name, {
 				this.unlink(q.localPath)
 			});
 		};
@@ -44,7 +44,7 @@ Quarks {
 			LanguageConfig.removeIncludePath(quark.localPath);
 		});
 		LanguageConfig.store(LanguageConfig.currentPath);
-		cache = QuarkDictionary.new;
+		cache = Dictionary.new;
 	}
 	*load { |path|
 		// install a list of quarks from a text file
@@ -175,12 +175,8 @@ Quarks {
 	*pathIsInstalled{ |path|
 		path = path.withoutTrailingSlash;
 		^LanguageConfig.includePaths.any({ |apath|
-			this.pathEquals(path, apath);
+			apath.withoutTrailingSlash == path
 		})
-	}
-	*pathEquals {
-		|a, b|
-		^(a.withoutTrailingSlash.compare(b.withoutTrailingSlash, true) == 0);
 	}
 	*openFolder {
 		this.folder.openOS;
@@ -199,7 +195,7 @@ Quarks {
 				).inform;
 				false
 			},
-			prev = this.installed.detect({ |q| Quark.nameEquals(q.name, quark.name) });
+			prev = this.installed.detect({ |q| q.name == quark.name });
 
 		if(prev.notNil and: {prev.localPath != quark.localPath}, {
 			("A version of % is already installed at %".format(quark, prev.localPath)).error;
@@ -258,7 +254,7 @@ Quarks {
 		if(File.exists(folder).not, {
 			folder.mkdir();
 		});
-		cache = QuarkDictionary.new;
+		cache = Dictionary.new;
 	}
 	*at { |name|
 		var q;
@@ -345,7 +341,7 @@ Quarks {
 	}
 	*prReadDirectoryFile { |dirTxtPath|
 		var file;
-		directory = QuarkDictionary.new;
+		directory = Dictionary.new;
 		file = File.open(dirTxtPath, "r");
 		{
 			var line, kv;
@@ -417,23 +413,4 @@ Quarks {
 	}
 	// quarks fetch all available quark specs
 	// directory.json
-}
-
-QuarkDictionary : Dictionary {
-	scanFor { arg argKey;
-		var maxHash = array.size div: 2;
-		var start = (argKey.isString.if({ argKey.toLower }, { argKey }).hash % maxHash) * 2;
-		var end = array.size-1;
-		var i = start;
-		forBy( start, end, 2, { arg i;
-			var key = array.at(i);
-			if ( key.isNil or: { Quark.nameEquals(key, argKey) }, { ^i });
-		});
-		end = start - 1;
-		forBy( 0, start-2, 2, { arg i;
-			var key = array.at(i);
-			if ( key.isNil or: { Quark.nameEquals(key, argKey) }, { ^i });
-		});
-		^-2
-	}
 }

--- a/SCClassLibrary/Common/Quarks/Quarks.sc
+++ b/SCClassLibrary/Common/Quarks/Quarks.sc
@@ -147,7 +147,7 @@ Quarks {
 			// If we have a clean and installed quark,
 			// we can refer to it more generically than a local path.
 			specifier = specifier ++ url;
-		} {
+		}, {
 			// Okay, we need to specify local path
 			specifier = specifier ++ "%=%".format(localPath, url ?? quark.name);
 		});

--- a/SCClassLibrary/Common/Quarks/Quarks.sc
+++ b/SCClassLibrary/Common/Quarks/Quarks.sc
@@ -21,7 +21,7 @@ Quarks {
 			if(File.exists(path).not, {
 				("Quarks-install: path does not exist" + path).warn;
 			});
-			if(this.pathIsInstalled(path).not) {
+			if(this.pathIsInstalled(path).not, {
 				quark = Quark.fromLocalPath(path);
 				this.installQuark(quark);
 				^quark
@@ -62,9 +62,9 @@ Quarks {
 			line.notNil;
 		}, {
 			#name, refspec = this.parseQuarkSpecifier(line, dir);
-			if (name.notNil) {
+			if (name.notNil, {
 				this.install(name, refspec);
-			}
+			});
 		});
 	}
 	*parseQuarkSpecifier { |line, relativeTo|
@@ -77,28 +77,28 @@ Quarks {
 
 		result = [nil, nil];
 
-			// resolve any paths relative to the quark file
+		// resolve any paths relative to the quark file
 		match = line.findRegexp(localRe);
-			if(match.size > 0, {
-				localPath = match[1][1];
-				name = localPath.basename;
-				url = match[2][1];
+		if(match.size > 0, {
+			localPath = match[1][1];
+			name = localPath.basename;
+			url = match[2][1];
 			refspec = match[3] !? { match[3][1] };
 			result = [this.asAbsolutePath(localPath, relativeTo), refspec];
-			}, {
-				match = line.findRegexp(nameRe);
-				if(match.size > 0, {
-					name = match[1][1];
+		}, {
+			match = line.findRegexp(nameRe);
+			if(match.size > 0, {
+				name = match[1][1];
 				refspec = match[2] !? { match[2][1] };
-					if(Quarks.isPath(name), {
+				if(Quarks.isPath(name), {
 					result = [this.asAbsolutePath(name, relativeTo), refspec];
-					}, {
-					result = [name, refspec];
-					});
 				}, {
-					"Unreadable line: %".format(line).error;
+					result = [name, refspec];
 				});
+			}, {
+				"Unreadable line: %".format(line).error;
 			});
+		});
 
 		^result;
 	}
@@ -126,35 +126,35 @@ Quarks {
 
 		localPath = this.asRelativePath(quark.localPath, relativeTo);
 
-			if(Git.isGit(quark.localPath), {
-				url = quark.url;
-				if(Git(quark.localPath).isDirty, {
-					("Working copy is dirty" + quark.localPath).warn;
-				}, {
-					refspec = quark.refspec;
-				if (quark.localPath.beginsWith(Quarks.folder)) {
+		if(Git.isGit(quark.localPath), {
+			url = quark.url;
+			if(Git(quark.localPath).isDirty, {
+				("Working copy is dirty" + quark.localPath).warn;
+			}, {
+				refspec = quark.refspec;
+				if (quark.localPath.beginsWith(Quarks.folder), {
 					isCleanAndInstalled = true;
-				}
-				});
+				})
 			});
+		});
 
-		if (Quarks.findQuarkURL(quark.name).notNil) {
+		if (Quarks.findQuarkURL(quark.name).notNil, {
 			// If we have the quark in the directory, we can simplify by using it's name.
 			url = quark.name;
-		};
+		});
 
-		if (isCleanAndInstalled) {
+		if (isCleanAndInstalled, {
 			// If we have a clean and installed quark,
 			// we can refer to it more generically than a local path.
 			specifier = specifier ++ url;
 		} {
 			// Okay, we need to specify local path
 			specifier = specifier ++ "%=%".format(localPath, url ?? quark.name);
-		};
+		});
 
 		if(refspec.size() > 0, {
 			specifier = specifier ++ "@" ++ refspec;
-			});
+		});
 
 		^specifier;
 	}
@@ -218,7 +218,7 @@ Quarks {
 			conflict = dependencies.detect({ |prior| prior.value.conflictsWith(quark.name, quark.version) });
 			if (conflict.notNil) {
 				"The quark %@% conflicts with dependency '%' (via %)".format(
-						quark.name, quark.version, conflict.value, conflict.key).error;
+					quark.name, quark.version, conflict.value, conflict.key).error;
 				^false;
 			};
 		});
@@ -326,7 +326,7 @@ Quarks {
 			("Failed to read quarks directory listing: % %".format(if(fetch, directoryUrl, dirTxtPath), err)).error;
 			if(fetch, {
 				// if fetch failed, try read from cache
-				 if(File.exists(dirTxtPath), {
+				if(File.exists(dirTxtPath), {
 					this.prReadDirectoryFile(dirTxtPath);
 				});
 			}, {

--- a/SCClassLibrary/Common/Quarks/Quarks.sc
+++ b/SCClassLibrary/Common/Quarks/Quarks.sc
@@ -205,8 +205,15 @@ Quarks {
 		if(quark.isCompatible().not, {
 			^incompatible.value(quark.name);
 		});
-		dependencies = List();
-		dependentQuarks = quark.deepDependencies(dependencies);
+
+		try({
+			dependencies = List();
+			dependentQuarks = quark.deepDependencies(dependencies);
+		}, { |e|
+			e.errorString.inform;
+			^false
+		});
+
 		dependentQuarks.do({ |quark|
 			if(quark.isCompatible().not, {
 				^incompatible.value(quark.name);

--- a/SCClassLibrary/Common/Quarks/Quarks.sc
+++ b/SCClassLibrary/Common/Quarks/Quarks.sc
@@ -43,10 +43,6 @@ Quarks {
 		// install a list of quarks from a text file
 		var file, line, dir,re, nameRe;
 		var match, localPath, url, name, refspec;
-		// localPath=url[@refspec]
-		re = "^([^=]+)=?([^@]+)@?(.*)$";
-		// quarkname[@refspec]
-		nameRe = "^([^@]+)@?(.*)$";
 		path = this.asAbsolutePath(path);
 		dir = path.dirname;
 		if(File.exists(path).not, {
@@ -56,37 +52,49 @@ Quarks {
 		file = File.open(path, "r");
 		while({
 			line = file.getLine();
-			line.notNil
+			line.notNil;
 		}, {
-			// resolve any paths relative to the quark file
-			match = line.findRegexp(re);
+			#name, refspec = this.parseQuarkSpecifier(line, dir);
+			if (name.notNil) {
+				this.install(name, refspec);
+			}
+		});
+	}
+	*parseQuarkSpecifier {
+		|line, relativeTo|
+		var localRe, nameRe, result, name, refspec, localPath, match, url;
+
+		// localPath=url[@refspec]
+		localRe = "^([^=]+)=([^@]+)@?(.*)$";
+		// quarkname[@refspec]
+		nameRe = "^([^@]+)@?(.*)$";
+
+		result = [nil, nil];
+
+		// resolve any paths relative to the quark file
+		match = line.findRegexp(localRe);
+		if(match.size > 0, {
+			localPath = match[1][1];
+			name = localPath.basename;
+			url = match[2][1];
+			refspec = match[3] !? { match[3][1] };
+			result = [this.asAbsolutePath(localPath, relativeTo), refspec];
+		}, {
+			match = line.findRegexp(nameRe);
 			if(match.size > 0, {
-				localPath = match[1][1];
-				name = localPath.basename;
-				url = match[2][1];
-				refspec = match[3];
-				if(refspec.notNil, {
-					refspec = refspec[1];
-				});
-				this.install(this.asAbsolutePath(localPath, dir), refspec);
-			}, {
-				match = line.findRegexp(nameRe);
-				if(match.size > 0, {
-					name = match[1][1];
-					refspec = match[2];
-					if(refspec.notNil, {
-						refspec = refspec[1];
-					});
-					if(Quarks.isPath(name), {
-						this.install(this.asAbsolutePath(name, dir), refspec);
-					}, {
-						this.install(name, refspec);
-					});
+				name = match[1][1];
+				refspec = match[2] !? { match[2][1] };
+				if(Quarks.isPath(name), {
+					result = [this.asAbsolutePath(name, relativeTo), refspec];
 				}, {
-					"Unreadable line: %".format(line).error;
+					result = [name, refspec];
 				});
+			}, {
+				"Unreadable line: %".format(line).error;
 			});
 		});
+
+		^result;
 	}
 	*save { |path|
 		// save currently installed quarks to a text file
@@ -94,28 +102,56 @@ Quarks {
 		var file, dir, lines;
 		path = this.asAbsolutePath(path);
 		dir = path.dirname;
-		lines = this.installed.collect({ |quark|
-			var localPath, url="", refspec;
-			localPath = this.asRelativePath(quark.localPath);
-			if(Git.isGit(quark.localPath), {
-				url = quark.url;
-				if(Git(quark.localPath).isDirty, {
-					("Working copy is dirty" + quark.localPath).warn;
-				}, {
-					refspec = quark.refspec;
-				});
-			});
-			if(refspec.notNil, {
-				"%=%@%".format(localPath, url, refspec)
-			}, {
-				"%=%".format(localPath, url)
-			});
+
+		lines = this.installed.collect({
+			|quark|
+			this.savedQuarkSpecifier(quark, dir);
 		});
+
 		file = File.open(path, "w");
 		lines = lines.join(Char.nl);
 		file.write(lines);
 		file.close();
 		^lines
+	}
+	*savedQuarkSpecifier {
+		|quark, relativeTo|
+		var line, localPath, url, refspec, isGit, isCleanAndInstalled = false, isInDirectory = false;
+		var specifier = "";
+
+		localPath = this.asRelativePath(quark.localPath, relativeTo);
+
+		if(Git.isGit(quark.localPath), {
+			url = quark.url;
+			if(Git(quark.localPath).isDirty, {
+				("Working copy is dirty" + quark.localPath).warn;
+			}, {
+				refspec = quark.refspec;
+				if (quark.localPath.beginsWith(Quarks.folder)) {
+					isCleanAndInstalled = true;
+				}
+			});
+		});
+
+		if (Quarks.findQuarkURL(quark.name).notNil) {
+			// If we have the quark in the directory, we can simplify by using it's name.
+			url = quark.name;
+		};
+
+		if (isCleanAndInstalled) {
+			// If we have a clean and installed quark,
+			// we can refer to it more generically than a local path.
+			specifier = specifier ++ url;
+		} {
+			// Okay, we need to specify local path
+			specifier = specifier ++ "%=%".format(localPath, url ?? quark.name);
+		};
+
+		if(refspec.size() > 0, {
+			specifier = specifier ++ "@" ++ refspec;
+		});
+
+		^specifier;
 	}
 	*update { |name|
 		// by quark name or by supplying a local path
@@ -332,7 +368,7 @@ Quarks {
 	*asRelativePath { |path, relativeToDir|
 		var d;
 		if(path.beginsWith(relativeToDir), {
-			^"." ++ path.copyToEnd(relativeToDir)
+			^"." ++ path.copyToEnd(relativeToDir.size())
 		});
 		d = Platform.userHomeDir;
 		// ~/path if in home

--- a/SCClassLibrary/Common/Quarks/Quarks.sc
+++ b/SCClassLibrary/Common/Quarks/Quarks.sc
@@ -18,7 +18,9 @@ Quarks {
 			if(File.exists(path).not, {
 				("Path does not exist" + path).warn;
 			});
-			this.link(path);
+			if(this.pathIsInstalled(path).not) {
+				this.link(path);
+			};
 		});
 	}
 	*uninstall { |name|


### PR DESCRIPTION
This pr:
- fixes a bunch of bugs related to differing cases in quark names (i.e. "Arduino" versus "arduino")
- enables parsing of dependencies of the form "quarkname@version", as well as just enabling version-based dependencies in general (which were not working).