### PR TITLE
classlib: note nums / cc channels must be integers

### DIFF
--- a/SCClassLibrary/Common/Control/MIDIResponder.sc
+++ b/SCClassLibrary/Common/Control/MIDIResponder.sc
@@ -41,6 +41,7 @@ NoteOnResponder : MIDIResponder {
 	classvar <norinit = false,<nonr;
 
 	*new { arg function, src, chan, num, veloc, install=true,swallowEvent=false;
+		num = num.isNumber.if({ num.asInteger }, num);
 		^super.new.function_(function)
 			.matchEvent_(MIDIEvent(nil, src, chan, num, veloc))
 			.swallowEvent_(swallowEvent)
@@ -105,6 +106,7 @@ CCResponder : MIDIResponder {
 	classvar <ccinit = false,<ccr,<ccnumr;
 
 	*new { arg function, src, chan, num, value, install=true,swallowEvent=false;
+		num = num.isNumber.if({ num.asInteger }, num);
 		^super.new.function_(function).swallowEvent_(swallowEvent)
 			.matchEvent_(MIDIEvent(nil, src, chan, num, value))
 			.init(install)

--- a/SCClassLibrary/Common/Control/ResponseDefs.sc
+++ b/SCClassLibrary/Common/Control/ResponseDefs.sc
@@ -787,6 +787,7 @@ MIDIFunc : AbstractResponderFunc {
 
 	init {|argfunc, argmsgNum, argchan, argType, argsrcID, argtempl, argdisp|
 		msgNum = argmsgNum ? msgNum;
+		msgNum = msgNum.isNumber.if({ msgNum.asInteger }, msgNum);
 		chan = argchan ? chan;
 		srcID = argsrcID ? srcID;
 		func = argfunc ? func;


### PR DESCRIPTION
Protect against non-integral values for note and cc number. Ordinarily inputting invalid values here would be user error - however, it's plausible that a note or cc num here might be the product of some calculation which could have caused an implicit conversion to float, which would cause a silent failure. Fixes #325