### PR TITLE
Fix: Install quark dependencies with refspecs

### DIFF
--- a/SCClassLibrary/Common/Quarks/Quark.sc
+++ b/SCClassLibrary/Common/Quarks/Quark.sc
@@ -189,7 +189,7 @@ Quark {
 		// search Quarks folders
 		(Quarks.additionalFolders ++ [Quarks.folder]).do({ |f|
 			var localPath = f +/+ name, url;
-			if(File.exists(localPath), {
+			if(File.existsCaseSensitive(localPath), {
 				^[name, nil, refspec, localPath]
 			});
 		});

--- a/SCClassLibrary/Common/Quarks/Quark.sc
+++ b/SCClassLibrary/Common/Quarks/Quark.sc
@@ -44,11 +44,11 @@ Quark {
 	}
 	refspec {
 		^refspec ?? {
-			git.refspec
+			git !? { git.refspec }
 		}
 	}
 	tags {
-		^git.tags
+		^git !? { git.tags }
 	}
 	isDownloaded {
 		^File.exists(this.localPath)
@@ -214,8 +214,9 @@ Quark {
 	}
 
 	printOn { arg stream;
+		var v = this.version ? this.refspec;
 		stream << "Quark: " << name;
-		if(this.version.notNil,{ stream << " [" << this.version << "]"; });
+		if(v.notNil,{ stream << "[" << v << "]" });
 	}
 	help {
 		var p = this.data['schelp'];

--- a/SCClassLibrary/Common/Quarks/Quarks.sc
+++ b/SCClassLibrary/Common/Quarks/Quarks.sc
@@ -337,7 +337,7 @@ Quarks {
 		});
 	}
 	*isPath { |string|
-		^string.findRegexp("^[~\.]?/").size != 0
+		^string.findRegexp("^[~\\.]?/").size != 0
 	}
 	*asAbsolutePath { |path, relativeTo|
 		^if(path.at(0).isPathSeparator, {

--- a/SCClassLibrary/Common/Quarks/Quarks.sc
+++ b/SCClassLibrary/Common/Quarks/Quarks.sc
@@ -169,16 +169,13 @@ Quarks {
 		if(quark.isCompatible().not, {
 			^incompatible.value(quark.name);
 		});
-		deps = quark.deepDependencies;
-		deps.do({ |dep|
-			if(dep.isCompatible().not, {
-				^incompatible.value(dep.name);
+		quark.dependencies.do { |dep|
+			var ok = dep.install();
+			if(ok.not, {
+				("Failed to install" + quark.name).error;
+				^false
 			});
-			dep.checkout();
-		});
-		deps.do({ |dep|
-			this.link(dep.localPath);
-		});
+		};
 		this.link(quark.localPath);
 		(quark.name + "installed").inform;
 		^true


### PR DESCRIPTION
Installs dependencies (including their dependencies) instead of just checking them out and linking them.

Fixes https://github.com/supercollider/supercollider/issues/1377

Parses refspecs in dependencies as advertised.
Also catches named quarks that are not found, posts the ERROR and returns nil.

```supercollider
Quark.parseDependency("Bjorklund");
Quark.parseDependency("DoesntExist");

Quark.parseDependency("crucial-library@tags/4.1.4");
Quark.parseDependency("crucial-library@tags/bad-tag");

Quark.parseDependency("DoesntExist@tags/4.1.4");

Quark.parseDependency("UnitTesting" -> 1.0)
Quark.parseDependency("DoesntExist" -> 1.0)

Quark.parseDependency(["UnitTesting", 1.0, "svn://sourceforge.net/etc/usw"])
Quark.parseDependency(["DoesntExist", 1.0, "svn://sourceforge.net/etc/usw"])


Quark.parseDependency("https://example.com/_404_.git");

Quark.parseDependency("https://github.com/crucialfelix/Mx.git");

Quark.parseQuarkName("https://github.com/crucialfelix/Mx.git")
```