### PR TITLE
qtcollider: defer setPropery if called inside drawFunc

### DIFF
--- a/QtCollider/QWidgetProxy.cpp
+++ b/QtCollider/QWidgetProxy.cpp
@@ -518,11 +518,11 @@ void QWidgetProxy::customPaint( QPainter *painter )
     return;
   }
 
-  QtCollider::announcePainting(this);
+  QtCollider::announcePainting();
 
   QtCollider::lockLang();
 
-  if( QtCollider::beginPainting( painter ) ) {
+  if( QtCollider::beginPainting( painter, this ) ) {
     invokeScMethod( SC_SYM(doDrawFunc), QList<QVariant>(), 0, true );
     QtCollider::endPainting();
   }

--- a/QtCollider/QWidgetProxy.cpp
+++ b/QtCollider/QWidgetProxy.cpp
@@ -518,7 +518,7 @@ void QWidgetProxy::customPaint( QPainter *painter )
     return;
   }
 
-  QtCollider::announcePainting();
+  QtCollider::announcePainting(this);
 
   QtCollider::lockLang();
 

--- a/QtCollider/painting.h
+++ b/QtCollider/painting.h
@@ -24,16 +24,17 @@
 
 class QPainter;
 class QWidget;
+class QObject;
 
 namespace QtCollider {
   // WARNING these can be called only from Qt thread (no locking needed):
-  void announcePainting();
+  void announcePainting( QObject* obj = 0 );
   bool paintingAnnounced();
 
   // WARNING language must be locked to call these:
-
   bool beginPainting( QPainter * );
   void endPainting();
+  bool isPaintingObject( QObject* obj );
 
   QPainter * globalPainter();
 }

--- a/QtCollider/painting.h
+++ b/QtCollider/painting.h
@@ -28,11 +28,11 @@ class QObject;
 
 namespace QtCollider {
   // WARNING these can be called only from Qt thread (no locking needed):
-  void announcePainting( QObject* obj = 0 );
+  void announcePainting();
   bool paintingAnnounced();
 
   // WARNING language must be locked to call these:
-  bool beginPainting( QPainter * );
+  bool beginPainting( QPainter *, QObject* obj = 0 );
   void endPainting();
   bool isPaintingObject( QObject* obj );
 

--- a/QtCollider/primitives/prim_QObject.cpp
+++ b/QtCollider/primitives/prim_QObject.cpp
@@ -26,6 +26,7 @@
 #include "../Common.h"
 #include "../type_codec.hpp"
 #include "../metatype.hpp"
+#include "../painting.h"
 
 #include <PyrObject.h>
 #include <PyrKernel.h>
@@ -301,7 +302,7 @@ QC_LANG_PRIMITIVE( QObject_SetProperty, 3, PyrSlot *r, PyrSlot *a, VMGlobals *g 
 
   QVariant val = QtCollider::get( a+1 );
 
-  if( sync ) {
+  if( sync && !QtCollider::isPaintingObject(proxy) ) {
     proxy->setProperty( property->name, val );
   } else {
     SetPropertyEvent *e = new SetPropertyEvent();

--- a/QtCollider/primitives/prim_QPen.cpp
+++ b/QtCollider/primitives/prim_QPen.cpp
@@ -38,14 +38,13 @@ static QPainterPath path;
 
 namespace QtCollider {
 
-  void announcePainting(QObject* obj) {
+  void announcePainting() {
     announced = true;
-    paintingObject = obj;
   }
   bool paintingAnnounced() { return announced; }
   bool isPaintingObject(QObject* obj) { return obj == paintingObject; }
 
-  bool beginPainting( QPainter *p )
+  bool beginPainting( QPainter *p, QObject* obj )
   {
     if( painter ) {
       qcErrorMsg( QString("Painting already in progress!") );
@@ -53,6 +52,7 @@ namespace QtCollider {
     }
 
     painter = p;
+    paintingObject = obj;
 
     painter->setRenderHint( QPainter::Antialiasing, true );
     QColor black( 0,0,0 );

--- a/QtCollider/primitives/prim_QPen.cpp
+++ b/QtCollider/primitives/prim_QPen.cpp
@@ -32,13 +32,18 @@
 #include <cmath>
 
 static bool announced = false;
+static QObject *paintingObject = NULL;
 static QPainter *painter = 0;
 static QPainterPath path;
 
 namespace QtCollider {
 
-  void announcePainting() { announced = true; }
+  void announcePainting(QObject* obj) {
+    announced = true;
+    paintingObject = obj;
+  }
   bool paintingAnnounced() { return announced; }
+  bool isPaintingObject(QObject* obj) { return obj == paintingObject; }
 
   bool beginPainting( QPainter *p )
   {
@@ -65,6 +70,7 @@ namespace QtCollider {
   {
     painter = 0;
     announced = false;
+    paintingObject = NULL;
   }
 
   QPainter *globalPainter() { return painter; }


### PR DESCRIPTION
This should avert a crash when setting the background color of a UserView from inside a drawFunc. In general, it seems extremely unsafe to synchronously set a property of a UserView while *inside* of it's drawFunc. Most properties will behave more or less identically if the set is deferred, and for some (i.e. changing view geometry) this avoids very undefined and dangerous-seeming behavior.