### PR TITLE
ide: fix crash on session switch

### DIFF
--- a/editors/sc-ide/core/doc_manager.cpp
+++ b/editors/sc-ide/core/doc_manager.cpp
@@ -479,7 +479,7 @@ void DocumentManager::close( Document *doc )
             .arg(doc->id().constData());
     Main::evaluateCodeIfCompiled( command, true );
 
-    delete doc;
+    doc->deleteLater();
 }
 
 bool DocumentManager::save( Document *doc )

--- a/editors/sc-ide/core/sig_mux.cpp
+++ b/editors/sc-ide/core/sig_mux.cpp
@@ -41,6 +41,22 @@ void SignalMultiplexer::connect(QObject *sender, const char *signal, const char 
     mConnections << conn;
     connect(conn);
 }
+    
+bool SignalMultiplexer::disconnect(QObject *sender)
+{
+    bool result = false;
+    QList<Connection>::Iterator it;
+    for (it = mConnections.begin(); it != mConnections.end(); ++it) {
+        Connection conn = *it;
+        if ((QObject*)conn.sender == sender) {
+            disconnect(conn);
+            mConnections.erase(it);
+            result = true;
+        }
+    }
+    
+    return result;
+}
 
 bool SignalMultiplexer::disconnect(QObject *sender, const char *signal, const char *slot)
 {

--- a/editors/sc-ide/core/sig_mux.hpp
+++ b/editors/sc-ide/core/sig_mux.hpp
@@ -43,7 +43,8 @@ public:
     bool disconnect(QObject *sender, const char *signal, const char *slot);
     void connect(const char *signal, QObject *receiver, const char *slot, ConnectionMode = ConnectionNecessary);
     bool disconnect(const char *signal, QObject *receiver, const char *slot);
-
+    bool disconnect(QObject *sender);
+    
     QObject *currentObject() const { return mObject; }
 
 public slots:


### PR DESCRIPTION
The prevents a crash when iteratively closing all documents. Each doc close triggers a chain of signals that can result in - what appears to be - an already-removed document being referenced by a tab. This change prevents the crash directly by disconnecting the currentChanged signal, which avoids the chain of signals. It also adds some seatbelts in case of bad / null documents, and uses deleteLater() to delete the document, rather than a raw delete. The `Document*`'s should probably be changed to smart pointers - the signal logic when managing documents is complex enough that it's hard to analytically show that there isn't some pending signal or reference to a document floating around after DocumentManager::close(*) is called.