### PR TITLE
classlib: protect v.value()

### DIFF
--- a/SCClassLibrary/Common/Quarks/QuarksGui.sc
+++ b/SCClassLibrary/Common/Quarks/QuarksGui.sc
@@ -328,7 +328,7 @@ QuarkDetailView {
 
 			model.data.keysValuesDo({ |k, v|
 				if(#[\name, \summary, \url, \path, \dependencies, \version].includes(k).not) {
-					this.pushRow(k.asString, v.value().asString);
+					this.pushRow(k.asString, protect({ v.value() }).asString);
 				}
 			});
 


### PR DESCRIPTION
This can be a function, so it needs to be protected.