### PR TITLE
protect NetAddr-disconnectAll from failing during shutdown

### DIFF
--- a/SCClassLibrary/Common/Control/NetAddr.sc
+++ b/SCClassLibrary/Common/Control/NetAddr.sc
@@ -43,8 +43,10 @@ NetAddr {
 	}
 
 	*disconnectAll {
-		connections.keys.do({ | netAddr |
-			netAddr.disconnect;
+		if(connections.notNil, {
+			connections.keys.do({ |netAddr|
+				netAddr.disconnect;
+			});
 		});
 	}
 


### PR DESCRIPTION
 if *initClass failed to run on startup then connections is still nil