### PR TITLE
lang: NetAddr: correctly disconnect tcp socket

### DIFF
--- a/lang/LangPrimSource/OSCData.cpp
+++ b/lang/LangPrimSource/OSCData.cpp
@@ -397,13 +397,18 @@ static int prNetAddr_Connect(VMGlobals *g, int numArgsPushed)
 
 static int prNetAddr_Disconnect(VMGlobals *g, int numArgsPushed)
 {
+	int err;
+	
 	PyrSlot* netAddrSlot = g->sp;
 	PyrObject* netAddrObj = slotRawObject(netAddrSlot);
 
 	SC_TcpClientPort *comPort = (SC_TcpClientPort*)slotRawPtr(netAddrObj->slots + ivxNetAddr_Socket);
-	if (comPort) comPort->Close();
+	if (comPort) {
+		err = comPort->Close();
+		SetPtr(netAddrObj->slots + ivxNetAddr_Socket, NULL);
+	}
 
-	return errNone;
+	return err;
 }
 
 

--- a/lang/LangPrimSource/SC_ComPort.cpp
+++ b/lang/LangPrimSource/SC_ComPort.cpp
@@ -305,7 +305,19 @@ void SC_TcpClientPort::handleMsgReceived(const boost::system::error_code &error,
 	startReceive();
 }
 
-void SC_TcpClientPort::Close()
+int SC_TcpClientPort::Close()
 {
-	socket.shutdown(boost::asio::ip::tcp::socket::shutdown_both);
+	boost::system::error_code error;
+
+	socket.shutdown(boost::asio::ip::tcp::socket::shutdown_both, error);
+	socket.close();
+	
+	if (error) {
+		if( error != boost::asio::error::not_connected ) {
+			::error("Socket shutdown failed, closed socket anyway. %s", error.message().c_str() );
+			return errFailed;
+		}
+	}
+	
+	return errNone;
 }

--- a/lang/LangPrimSource/SC_ComPort.h
+++ b/lang/LangPrimSource/SC_ComPort.h
@@ -113,7 +113,7 @@ public:
 
 public:
 	SC_TcpClientPort(long inAddress, int inPort, ClientNotifyFunc notifyFunc=0, void* clientData=0);
-	void Close();
+	int Close();
 
 	boost::asio::ip::tcp::socket & Socket () { return socket; }
 


### PR DESCRIPTION
NetAddr#disconnect should close the underlying boost TCP socket in order for the port to be available again for use, and should handle the common error that happen when shuting down the TCP connection, if the connection was already terminated from the other side. After the SC_TcpClientPort is closed it is no longer usable therefore the socket variable of NetAddr should be set to null, making NetAddr#isConnected correctly report the status of the connection.