### PR TITLE
Fix range in Function:plot

### DIFF
--- a/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
+++ b/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
@@ -810,7 +810,7 @@ Plotter {
 		});
 	}
 
-	plot { |duration = 0.01, server, bounds, minval, maxval, separately = false|
+	plot { |duration = 0.01, server, bounds, minval= -1, maxval=1, separately = false|
 		var name = this.asCompileString, plotter;
 		if(name.size > 50 or: { name.includes(Char.nl) }) { name = "function plot" };
 		plotter = Plotter(name, bounds);


### PR DESCRIPTION
I think it would make sense to scale Function:plot between -1 and 1. Can't see that a majority of user cases would benefit from the current behaviour. In most cases people are exploring the behaviour of UGens and expecting to see it within the clipping range. 

From an educational perspective it makes sense too, IMO. I just wrote this example in a workshop and the results were confusing (until I remembered to write minval and maxval):

{SinOsc.ar(440, 0)+SinOsc.ar(440, pi)}.plot