### PR TITLE
Topic/quarks window is path

### DIFF
--- a/SCClassLibrary/Common/Quarks/Quarks.sc
+++ b/SCClassLibrary/Common/Quarks/Quarks.sc
@@ -340,7 +340,8 @@ Quarks {
 		});
 	}
 	*isPath { |string|
-		^string.findRegexp("^[~\\.]?/").size != 0
+		var re = if(thisProcess.platform.name !== 'windows', "^[~\\.]?/", "^(\\\\|[a-zA-Z]:)");
+		^string.findRegexp(re).size != 0
 	}
 	*asAbsolutePath { |path, relativeTo|
 		^if(path.at(0).isPathSeparator, {

--- a/SCClassLibrary/Common/Quarks/Quarks.sc
+++ b/SCClassLibrary/Common/Quarks/Quarks.sc
@@ -19,7 +19,8 @@ Quarks {
 			// local path / ~/ ./
 			path = this.asAbsolutePath(name);
 			if(File.exists(path).not, {
-				("Quarks-install: path does not exist" + path).warn;
+				("Quarks-install: path does not exist" + path).error;
+				^nil
 			});
 			quark = Quark.fromLocalPath(path);
 			this.installQuark(quark);


### PR DESCRIPTION
Fixes #1451  - detecting if a string is a path when on windows

Change: stop with and error if installing a non-existing path. Otherwise it cascades on and would just have to be stopped anyway.