### PR TITLE
Sclang: print version with -v

### DIFF
--- a/lang/LangSource/SC_TerminalClient.cpp
+++ b/lang/LangSource/SC_TerminalClient.cpp
@@ -169,9 +169,7 @@ bool SC_TerminalClient::parseOptions(int& argc, char**& argv, Options& opt)
 				opt.mCallRun = true;
 				break;
 			case 'V':
-				fprintf(stdout, "sclang %s\n", SC_VersionString().c_str());
-				quit(0);
-				return false;
+				goto optPrintVersion;
 				break;
 			case 's':
 				opt.mCallStop = true;
@@ -208,6 +206,11 @@ bool SC_TerminalClient::parseOptions(int& argc, char**& argv, Options& opt)
 
  help:
 	printUsage();
+	quit(0);
+	return false;
+
+optPrintVersion:
+	fprintf(stdout, "sclang %s\n", SC_VersionString().c_str());
 	quit(0);
 	return false;
 

--- a/lang/LangSource/SC_TerminalClient.cpp
+++ b/lang/LangSource/SC_TerminalClient.cpp
@@ -170,8 +170,6 @@ bool SC_TerminalClient::parseOptions(int& argc, char**& argv, Options& opt)
 				break;
 			case 'V':
 				fprintf(stdout, "sclang %s\n", SC_VersionString().c_str());
-				//scprintf("sclang %s\n", SC_VersionString().c_str());
-				//fprintf(stdout, "Usage:\n   %s [options] [file..] [-]\n\n", getName());
 				quit(0);
 				return false;
 				break;

--- a/lang/LangSource/SC_TerminalClient.cpp
+++ b/lang/LangSource/SC_TerminalClient.cpp
@@ -113,6 +113,7 @@ void SC_TerminalClient::printUsage()
 	fprintf(stdout, "Usage:\n   %s [options] [file..] [-]\n\n", getName());
 	fprintf(stdout,
 			"Options:\n"
+			"   -v                             Print supercollider version and exit\n"
 			"   -d <path>                      Set runtime directory\n"
 			"   -D                             Enter daemon mode (no input)\n"
 			"   -g <memory-growth>[km]         Set heap growth (default %s)\n"
@@ -123,8 +124,7 @@ void SC_TerminalClient::printUsage()
 			"   -s                             Call Main.stop on shutdown\n"
 			"   -u <network-port-number>       Set UDP listening port (default %d)\n"
 			"   -i <ide-name>                  Specify IDE name (for enabling IDE-specific class code, default \"%s\")\n"
-			"   -a                             Standalone mode\n"
-			"   -V                             Print supercollider version and exit\n",
+			"   -a                             Standalone mode\n",
 			memGrowBuf,
 			memSpaceBuf,
 			opt.mPort,
@@ -134,7 +134,7 @@ void SC_TerminalClient::printUsage()
 
 bool SC_TerminalClient::parseOptions(int& argc, char**& argv, Options& opt)
 {
-	const char* optstr = ":d:Dg:hl:m:rsu:i:aV";
+	const char* optstr = ":d:Dg:hl:m:rsu:i:av";
 	int c;
 
 	// inhibit error reporting
@@ -168,7 +168,7 @@ bool SC_TerminalClient::parseOptions(int& argc, char**& argv, Options& opt)
 			case 'r':
 				opt.mCallRun = true;
 				break;
-			case 'V':
+			case 'v':
 				fprintf(stdout, "sclang %s\n", SC_VersionString().c_str());
 				quit(0);
 				return false;

--- a/lang/LangSource/SC_TerminalClient.cpp
+++ b/lang/LangSource/SC_TerminalClient.cpp
@@ -169,7 +169,9 @@ bool SC_TerminalClient::parseOptions(int& argc, char**& argv, Options& opt)
 				opt.mCallRun = true;
 				break;
 			case 'V':
-				goto optPrintVersion;
+				fprintf(stdout, "sclang %s\n", SC_VersionString().c_str());
+				quit(0);
+				return false;
 				break;
 			case 's':
 				opt.mCallStop = true;
@@ -206,11 +208,6 @@ bool SC_TerminalClient::parseOptions(int& argc, char**& argv, Options& opt)
 
  help:
 	printUsage();
-	quit(0);
-	return false;
-
-optPrintVersion:
-	fprintf(stdout, "sclang %s\n", SC_VersionString().c_str());
 	quit(0);
 	return false;
 

--- a/lang/LangSource/SC_TerminalClient.cpp
+++ b/lang/LangSource/SC_TerminalClient.cpp
@@ -57,6 +57,7 @@
 #include "VMGlobals.h"
 #include "SC_DirUtils.h"   // for gIdeName
 #include "SC_LanguageConfig.hpp"
+#include "SC_Version.hpp"
 
 static FILE* gPostDest = stdout;
 
@@ -122,7 +123,8 @@ void SC_TerminalClient::printUsage()
 			"   -s                             Call Main.stop on shutdown\n"
 			"   -u <network-port-number>       Set UDP listening port (default %d)\n"
 			"   -i <ide-name>                  Specify IDE name (for enabling IDE-specific class code, default \"%s\")\n"
-			"   -a                             Standalone mode\n",
+			"   -a                             Standalone mode\n"
+			"   -V                             Print supercollider version and exit\n",
 			memGrowBuf,
 			memSpaceBuf,
 			opt.mPort,
@@ -132,7 +134,7 @@ void SC_TerminalClient::printUsage()
 
 bool SC_TerminalClient::parseOptions(int& argc, char**& argv, Options& opt)
 {
-	const char* optstr = ":d:Dg:hl:m:rsu:i:a";
+	const char* optstr = ":d:Dg:hl:m:rsu:i:aV";
 	int c;
 
 	// inhibit error reporting
@@ -165,6 +167,13 @@ bool SC_TerminalClient::parseOptions(int& argc, char**& argv, Options& opt)
 				break;
 			case 'r':
 				opt.mCallRun = true;
+				break;
+			case 'V':
+				fprintf(stdout, "sclang %s\n", SC_VersionString().c_str());
+				//scprintf("sclang %s\n", SC_VersionString().c_str());
+				//fprintf(stdout, "Usage:\n   %s [options] [file..] [-]\n\n", getName());
+				quit(0);
+				return false;
 				break;
 			case 's':
 				opt.mCallStop = true;


### PR DESCRIPTION
Re #1324 but that one uses `-v` instead