### PR TITLE
scsynth: dont use deinitialize plugins

### DIFF
--- a/server/scsynth/SC_World.cpp
+++ b/server/scsynth/SC_World.cpp
@@ -1005,7 +1005,7 @@ void World_Start(World *inWorld)
 void World_Cleanup(World *world)
 {
 	if (!world) return;
-	deinitialize_library();
+
 	scsynth::stopAsioThread();
 
 	HiddenWorld *hw = world->hw;


### PR DESCRIPTION
This would basically revert situation. Dont deleted the code but make it not used