### PR TITLE
Help: WritingClasses: Extension methods are like obj-c categories

### DIFF
--- a/HelpSource/Guides/WritingClasses.schelp
+++ b/HelpSource/Guides/WritingClasses.schelp
@@ -255,7 +255,7 @@ MyClass {
 
 section:: External Method Files
 
-Methods may be added to Classes in separate files.  This is equivalent to Protocols in Objective-C.  By convention, the
+Methods may be added to Classes in separate files.  This is equivalent to Categories in Objective-C.  By convention, the
 file name starts with a lower case letter: the name of the method or feature that the methods are supporting.
 
 code::


### PR DESCRIPTION
Per a Facebook thread:

- D. Ogborn PS - by the way, in the SC documentation it says "protocols" but I do believe this is more like "categories" since it is about the implementation of the method also
- G. Newsome Definitely not equivalent to an Objective-C protocol. Is equivalent to an Objective-C category. Documentation is incorrect. Nice to know that this feature is part of SC as it's incredibly handy.

I don't know objective C so I don't feel qualified to evaluate these statements. But the pull request is here for other obj-c savvy developers to merge if correct.