### PR TITLE
Add two qt5 packages to dependencies list

### DIFF
--- a/README_LINUX.md
+++ b/README_LINUX.md
@@ -105,7 +105,7 @@ for building supercollider:
  - pkg-config
  - subversion (required by the Quarks class at run-time)
  - cmake (on some platforms, cmake >= 2.9 may require manual build)
- - qt5-default qt5-qmake qttools5-dev qttools5-dev-tools qtdeclarative5-dev libqt5webkit5-dev
+ - qt5-default qt5-qmake qttools5-dev qttools5-dev-tools qtdeclarative5-dev libqt5webkit5-dev qtpositioning5-dev libqt5sensors5-dev
  
 
 Building


### PR DESCRIPTION
Needed, at least on Ubuntu 15.04