### PR TITLE
classlib: Use correct spec for x coord of edits

### DIFF
--- a/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
+++ b/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
@@ -319,7 +319,7 @@ Plot {
 	}
 
 	getRelativePositionX { |x|
-		^domainSpec.map((x - plotBounds.left) / plotBounds.width)
+		^this.resampledDomainSpec.map((x - plotBounds.left) / plotBounds.width)
 	}
 
 	getRelativePositionY { |y|


### PR DESCRIPTION
resampledDomainSpec is the spec that is used when drawing the graph, so this should also be used when determining the data under the mouse position.

This fixes #264 