### PR TITLE
ide: better newline behavior within brackets

### DIFF
--- a/editors/sc-ide/widgets/code_editor/sc_editor.cpp
+++ b/editors/sc-ide/widgets/code_editor/sc_editor.cpp
@@ -174,8 +174,15 @@ void ScCodeEditor::keyPressEvent( QKeyEvent *e )
     {
         QTextBlock cursorBlock = cursor.block();
         int cursorPosInBlock = cursor.position() - cursorBlock.position();
+        
+        TokenIterator prevToken = TokenIterator::leftOf(cursorBlock, cursorPosInBlock);
         TokenIterator nextToken = TokenIterator::rightOf(cursorBlock, cursorPosInBlock);
-        if ( nextToken.block() == cursorBlock && nextToken.type() == Token::ClosingBracket )
+        
+        if (   nextToken.block() == cursorBlock
+            && nextToken.type() == Token::ClosingBracket
+            && prevToken.type() != Token::ClosingBracket // no double-newline if cursor is between closing brackets, i.e. ])
+            && !(prevToken.block().firstLineNumber() < nextToken.block().firstLineNumber()) // no double-nl if only whitespace to the left
+        )
         {
             cursor.beginEditBlock();
             cursor.insertBlock();


### PR DESCRIPTION
This adds two additional conditions for creating a double-newline when hitting return w/in brackets. We should NOT add a double-newline if we're in between two closing brackets - i.e. ]], ]), etc.
And, we should NOT add a double-newline if the closing bracket to the right of the cursor is the first thing on the line.

This avoids several spurious double-newlines that are common in SC code (see bug #814, for example). Note that this still allows a double-newline if you're adding function arguments to a function over multiple lines. Hitting return in this case:
    ([1, 2], [3, 4],<return>)
(i.e. with a comma before the return) will create a double-newline.