### PR TITLE
sclang: set max scroll according to req'd value

### DIFF
--- a/QtCollider/widgets/QcScrollArea.cpp
+++ b/QtCollider/widgets/QcScrollArea.cpp
@@ -135,6 +135,11 @@ QPointF QcScrollArea::visibleOrigin() const
 
 void QcScrollArea::setVisibleOrigin( const QPointF &pt )
 {
+  if (horizontalScrollBar()->maximum() < pt.x())
+    horizontalScrollBar()->setMaximum(pt.x());
+  if (verticalScrollBar()->maximum() < pt.y())
+    verticalScrollBar()->setMaximum(pt.y());
+  
   horizontalScrollBar()->setValue( pt.x() );
   verticalScrollBar()->setValue( pt.y() );
 }


### PR DESCRIPTION
Setting some geometry-related properties at view creation time gets a bit weird, because layout is often not calculated immediately. In case of #823, the initial layout of the view gets calculated in a slightly deferred event fired in response to .front(), meaning that when visibleOrigin_ is called, the scrollbars still haven't been adjusted according to the layed-out window contents (specifically, at creation time the max scroll value is 0). Fixing this by getting layout to happen at the right time is hard - fortunately, it looks like scrollbar behavior is smart enough that, when we request a specific visibleOrigin, we can simply increase the scrollbar max value as needed - even when manually setting a max, the scrollbars seem to re-adjust properly as the contents of the scroll area are sized.