### PR TITLE
classlib: Don't pass unprintables in key events

### DIFF
--- a/SCClassLibrary/Common/GUI/Base/QView.sc
+++ b/SCClassLibrary/Common/GUI/Base/QView.sc
@@ -612,6 +612,7 @@ View : QObject {
 
 	keyDownEvent { arg char, modifiers, unicode, keycode, key, spontaneous;
 		modifiers = QKeyModifiers.toCocoa(modifiers);
+		if (char.ascii == 0) { char = nil };
 
 		if( spontaneous ) {
 			// this event has never been propagated to parent yet
@@ -627,6 +628,7 @@ View : QObject {
 
 	keyUpEvent { arg char, modifiers, unicode, keycode, key, spontaneous;
 		modifiers = QKeyModifiers.toCocoa(modifiers);
+		if (char.ascii == 0) { char = nil };
 
 		if( spontaneous ) {
 			// this event has never been propagated to parent yet


### PR DESCRIPTION
Documentation says that the char argument of keydown/keyup events is the printable character typed, or nil. We are currently passing an ascii zero character instead - the fix is to pass nil in this case.