### PR TITLE
sclang: workaround webkit scrollbar hiding bug

### DIFF
--- a/QtCollider/style/ProxyStyle.cpp
+++ b/QtCollider/style/ProxyStyle.cpp
@@ -10,24 +10,17 @@ using namespace QtCollider;
 void ProxyStyle::drawComplexControl ( ComplexControl ctrl, const QStyleOptionComplex *opt,
                                       QPainter *p, const QWidget * w) const
 {
-  // FIXME this is a workaround for the WebKit bug #35681.
-
+  // FIXME: this is a workaround for the WebKit bug #104116 (or a variation on it).
   if( ctrl == QStyle::CC_ScrollBar
       && qobject_cast<const QWebView*>(w) != 0
       && opt->type == QStyleOption::SO_Slider )
   {
-    const QPoint topLeft = opt->rect.topLeft();
-
-    p->save();
-    p->translate( topLeft );
-
+    // WebKit tries to hide scrollbars, but mistakenly hides QWebView - NULL-ify styleObject to prevent.
     const QStyleOptionSlider *optSlider = static_cast<const QStyleOptionSlider*>(opt);
     QStyleOptionSlider opt2( *optSlider );
-    opt2.rect.moveTo( QPoint(0, 0) );
+    opt2.styleObject = NULL;
 
     QProxyStyle::drawComplexControl( ctrl, &opt2, p, w );
-
-    p->restore();
 
     return;
   }

--- a/editors/sc-ide/widgets/style/style.cpp
+++ b/editors/sc-ide/widgets/style/style.cpp
@@ -29,6 +29,7 @@
 #include <QToolButton>
 #include <QLayout>
 #include <QDebug>
+#include <QWebView>
 
 namespace ScIDE {
 
@@ -76,6 +77,20 @@ void Style::drawComplexControl
     }
 
     switch(control) {
+    // FIXME: this is a workaround for the WebKit bug #104116 (or a variation on it).
+    case QStyle::CC_ScrollBar:
+    {
+        if (qobject_cast<const QWebView*>(widget) != 0 && option->type == QStyleOption::SO_Slider)
+        {
+            // WebKit tries to hide scrollbars, but mistakenly hides QWebView - NULL-ify styleObject to prevent.
+            const QStyleOptionSlider *optSlider = static_cast<const QStyleOptionSlider*>(option);
+            QStyleOptionSlider opt2( *optSlider );
+            opt2.styleObject = NULL;
+            
+            QProxyStyle::drawComplexControl( control, &opt2, painter, widget );
+            return;
+        }
+    }
     case QStyle::CC_ToolButton:
     {
         // TODO: We only draw either text, or icon, or arrow


### PR DESCRIPTION
A bug in qt webkit results in animations related to scrollbar opacity and hidden-ness pointing to the QWebView instead of the scrollbars (see https://bugs.webkit.org/show_bug.cgi?id=104116). As a result, the QWebView gets hidden instead of the scrollbars in many cases. This bug was seemingly fixed, but in a very specific and limited way - either it has regressed, or we're running afoul because of our custom style. Regardless, we can work around by implementing the same fix referenced in the aforementioned bug in our own custom styles. Also  - this change removes an OLD webkit scrollbar hack, because it appears to no longer be a problem. This MAY fix the problems with help disappearing in the IDE as well.