### PR TITLE
sclang: fix crash during SerialPort cleanup

### DIFF
--- a/SCClassLibrary/Common/Control/SerialPort.sc
+++ b/SCClassLibrary/Common/Control/SerialPort.sc
@@ -53,8 +53,7 @@ SerialPort
 			xonxoff
 		)
 	}
-	// if port should be able to reopen, this method should be called "open"
-	// but as close doesn't currently work and crashes sclang, we just don't ever use it for reopening.
+
 	initSerialPort { | ... args |
 		semaphore = Semaphore(0);
 		if ( dataptr.isNil ){
@@ -126,18 +125,18 @@ SerialPort
 		^this.primitiveFailed
 	}
 	prClose {
-		//_SerialPort_Close
-		_SerialPort_Cleanup // for now: just cleanup. close crashes sclang
+		_SerialPort_Close
 		^this.primitiveFailed
 	}
 	primCleanup {
+		// _SerialPort_Cleanup must be called from the AppClock thread.
 		_SerialPort_Cleanup
 		^this.primitiveFailed
 	}
 	prCleanup{
 		if (this.isOpen) {
-			this.primCleanup;
 			allPorts.remove(this);
+			defer({ this.primCleanup }, 0);
 		}
 	}
 	prPut { | byte |


### PR DESCRIPTION
The SerialPort destructor calls join, which crashes if run from the SerialPort thread itself. To close, SerialPort is flagged such that the thread will exit it's run loop, close the port, and then call prDoneAction, which in turn calls prCleanup - this ALWAYS happens from the SerialPort thread itself, meaning it always crashes.

This fixes by (a) ensuring that prCleanup always defers to the main thread, (b) erroring the primitive if we try to call it from the SerialPort thread, (c) asserting if we hit the destructor on the SerialPort thread (which should make problems here easier to track, at least). We are currently not destroying SerialPort backend objects (or removing the threads) properly when the language quits - I'll fix this in a separate commit, though there are no bad effects at the moment (unless you count computer scientists giving annoyed looks).