### PR TITLE
ide: Workaround for completion help view crash

### DIFF
--- a/editors/sc-ide/widgets/code_editor/completion_menu.cpp
+++ b/editors/sc-ide/widgets/code_editor/completion_menu.cpp
@@ -39,7 +39,7 @@ CompletionMenu::CompletionMenu(QWidget * parent):
     mListView->setFrameShape(QFrame::NoFrame);
     mListView->setFixedHeight(200);
 
-    mTextBrowser = new QTextBrowser();
+    mTextBrowser = new CompletionTextBrowser();
     mTextBrowser->setFrameShape(QFrame::NoFrame);
     mTextBrowser->setReadOnly(true);
     mTextBrowser->setFixedSize(500, 400);

--- a/editors/sc-ide/widgets/code_editor/completion_menu.hpp
+++ b/editors/sc-ide/widgets/code_editor/completion_menu.hpp
@@ -35,6 +35,17 @@
 namespace ScIDE {
 
 namespace ScLanguage { struct Method; struct Class; }
+  
+class CompletionTextBrowser : public QTextBrowser
+{
+    // FIXME: Workaround for bug #1452 - crash when dragging/copying text from completion help window
+    // QT seems to delete the QMimeData before it's finished with it, causing a crash.
+    // The only way to avoid is to return no MIME data at all.
+    QMimeData *createMimeDataFromSelection() const
+    {
+        return NULL;
+    };
+};
 
 class CompletionMenu : public PopUpWidget
 {
@@ -64,7 +75,7 @@ private:
     QListView *mListView;
     QStandardItemModel *mModel;
     QSortFilterProxyModel *mFilterModel;
-    QTextBrowser *mTextBrowser;
+    CompletionTextBrowser *mTextBrowser;
     QHBoxLayout *mLayout;
     int mCompletionRole;
 


### PR DESCRIPTION
Dragging or copying text from the help view that pops up during completion results in a crash. It appears that QT deletes the QMimeData corresponding to the copied/dragged chunk too soon, and referencing it later on causes a crash. I attempted various overrides of createMimeDataFromSelection (returning e.g. plain text, etc), and it always crashed except when we simply return NULL. This results in text from that view not being copyable / draggable but this is better than a crash. This is probably a deep QT bug.