### PR TITLE
plugins/LFUGens: generate symmetrical waveforms in LFPulse

### DIFF
--- a/server/plugins/LFUGens.cpp
+++ b/server/plugins/LFUGens.cpp
@@ -463,7 +463,7 @@ void LFPulse_next_a(LFPulse *unit, int inNumSamples)
 			phase -= 1.f;
 			duty = unit->mDuty = nextDuty;
 			// output at least one sample from the opposite polarity
-			z = duty < 0.5f ? 1.f : 0.f;
+			z = duty <= 0.5f ? 1.f : 0.f;
 		} else {
 			z = phase < duty ? 1.f : 0.f;
 		}
@@ -488,7 +488,7 @@ void LFPulse_next_k(LFPulse *unit, int inNumSamples)
 			phase -= 1.f;
 			duty = unit->mDuty = nextDuty;
 			// output at least one sample from the opposite polarity
-			z = duty < 0.5f ? 1.f : 0.f;
+			z = duty <= 0.5f ? 1.f : 0.f;
 		} else {
 			z = phase < duty ? 1.f : 0.f;
 		}


### PR DESCRIPTION
Fixes issue #1501 (of special interest: the default case when duty is 0.5).

Now, when you specify the default duty cycle (`width`) of 0.5, and a frequency that should allow an even number of "ups and downs" (e.g. an even multiple of the sampling rate, below Nyquist), it does.  Previously, it tended to drift (you'd see this if you ran an Integrator over the output).

It will still drift if the frequency is not an even multiple of the sample rate, but this can't be avoided.  This is due to the fact that it's always desired (according to a comment in the code) to output at least one sample from the "opposite polarity" in each period.  If this constraint were relaxed, then it could more closely average the correct duty over several cycles.  Right now, for a waveform period of seven samples, LFPulse will output three high and four low samples.  If it didn't "reset" every period, then it could have an occasional correcting sample, but this might introduce other artifacts.
