### PR TITLE
Chebyshev polynomials: various fixes (issue #1500)

### DIFF
--- a/HelpSource/Classes/Signal.schelp
+++ b/HelpSource/Classes/Signal.schelp
@@ -24,7 +24,8 @@ method::chebyFill
 Fill a Signal of the given size with a sum of Chebyshev polynomials at the given amplitudes. For eventual use in waveshaping by the Shaper ugen; see link::Classes/Shaper:: helpfile and link::Classes/Buffer#-cheby#Buffer:cheby:: too.
 code::
 Signal.chebyFill(1000, [1]).plot;
-Signal.chebyFill(1000, [0, 1]).plot;
+Signal.chebyFill(1000, [0, 1]).plot;  // shifted to avoid DC offset when waveshaping a zero signal
+Signal.chebyFill(1000, [0, 1], false, false).plot;  // raw (unshifted) Chebyshev polynomial
 Signal.chebyFill(1000, [0, 0, 1]).plot;
 Signal.chebyFill(1000, [0.3, -0.8, 1.1]).plot;
 ::
@@ -33,7 +34,9 @@ the number of samples in the Signal.
 argument::amplitudes
 an link::Classes/Array:: of amplitudes for each Chebyshev polynomial beginning with order 1.
 argument::normalize
-a link::Classes/Boolean::
+a link::Classes/Boolean:: indicating whether to normalize the resulting Signal (for use as a transfer function) using link::Classes/Signal#-normalizeTransfer#normalizeTransfer::.  Default is true.
+argument::zeroOffset
+a link::Classes/Boolean:: indicating whether to offset the middle of each polynomial to zero. If true, then a zero input will always result in a zero output when used as a link::Classes/Shaper##waveshaper::. Default is true. Only relevant when the normalize argument is false, since link::Classes/Signal#-normalizeTransfer#normalizeTransfer:: performs zero-compensation (in addition to normalizing).
 
 method::hanningWindow
 Fill a Signal of the given size with a Hanning window.

--- a/HelpSource/Classes/Signal.schelp
+++ b/HelpSource/Classes/Signal.schelp
@@ -24,8 +24,13 @@ method::chebyFill
 Fill a Signal of the given size with a sum of Chebyshev polynomials at the given amplitudes. For eventual use in waveshaping by the Shaper ugen; see link::Classes/Shaper:: helpfile and link::Classes/Buffer#-cheby#Buffer:cheby:: too.
 code::
 Signal.chebyFill(1000, [1]).plot;
-Signal.chebyFill(1000, [0, 1]).plot;  // shifted to avoid DC offset when waveshaping a zero signal
-Signal.chebyFill(1000, [0, 1], false, false).plot;  // raw (unshifted) Chebyshev polynomial
+
+// by default, shifted to avoid DC offset when waveshaping a zero signal
+Signal.chebyFill(1000, [0, 1]).plot;
+
+// normalized sum of (unshifted) Chebyshev polynomials
+Signal.chebyFill(1000, [0, 1, 0, 0, 0, 1], true, false).plot;
+
 Signal.chebyFill(1000, [0, 0, 1]).plot;
 Signal.chebyFill(1000, [0.3, -0.8, 1.1]).plot;
 ::
@@ -34,9 +39,9 @@ the number of samples in the Signal.
 argument::amplitudes
 an link::Classes/Array:: of amplitudes for each Chebyshev polynomial beginning with order 1.
 argument::normalize
-a link::Classes/Boolean:: indicating whether to normalize the resulting Signal (for use as a transfer function) using link::Classes/Signal#-normalizeTransfer#normalizeTransfer::.  Default is true.
+a link::Classes/Boolean:: indicating whether to normalize the resulting Signal. If the zeroOffset argument is true, the normalization is done for use as a transfer function, using link::Classes/Signal#-normalizeTransfer#normalizeTransfer::, otherwise it just uses link::Classes/Signal#-normalize#normalize:: to make the absolute peak value 1.  Default is true.
 argument::zeroOffset
-a link::Classes/Boolean:: indicating whether to offset the middle of each polynomial to zero. If true, then a zero input will always result in a zero output when used as a link::Classes/Shaper##waveshaper::. Default is true. Only relevant when the normalize argument is false, since link::Classes/Signal#-normalizeTransfer#normalizeTransfer:: performs zero-compensation (in addition to normalizing).
+a link::Classes/Boolean:: indicating whether to offset the middle of each polynomial to zero. If true, then a zero input will always result in a zero output when used as a link::Classes/Shaper##waveshaper::. If false, then the "raw" (unshifted) Chebyshev polynomials are used. Default is true.
 
 method::hanningWindow
 Fill a Signal of the given size with a Hanning window.

--- a/HelpSource/Classes/Wavetable.schelp
+++ b/HelpSource/Classes/Wavetable.schelp
@@ -21,19 +21,22 @@ argument::phases
 an Array of phases in radians for each harmonic beginning with the fundamental.
 
 method::chebyFill
-Fill a Wavetable of the given size with a sum of Chebyshev polynomials at the given amplitudes for use in waveshaping by the link::Classes/Shaper:: ugen. The Wavetable will be normalized.
+Fill a Wavetable of the given size with a sum of Chebyshev polynomials at the given amplitudes for use in waveshaping by the link::Classes/Shaper:: ugen.
 code::
 Wavetable.chebyFill(513, [1]).plot;
-Wavetable.chebyFill(513, [0, 1]).plot;
+Wavetable.chebyFill(513, [0, 1]).plot; // shifted to avoid DC offset when waveshaping a zero signal
+Wavetable.chebyFill(513, [0, 1], false, false).plot;  // raw (unshifted) Chebyshev polynomial
 Wavetable.chebyFill(513, [0, 0, 1]).plot;
 Wavetable.chebyFill(513, [0.3, -0.8, 1.1]).plot;
 ::
 argument::size
 must be a power of 2 plus 1, eventual wavetable is next power of two size up.
 argument::amplitudes
-an Array of amplitudes for each Chebyshev polynomial beginning with order 1.
+an link::Classes/Array:: of amplitudes for each Chebyshev polynomial beginning with order 1.
 argument::normalize
-A link::Classes/Boolean::.
+a link::Classes/Boolean:: indicating whether to normalize the resulting Wavetable (for use as a transfer function) using link::Classes/Signal#-normalizeTransfer#normalizeTransfer::.  Default is true.
+argument::zeroOffset
+a link::Classes/Boolean:: indicating whether to offset the middle of each polynomial to zero. If true, then a zero input will always result in a zero output when used as a link::Classes/Shaper##waveshaper::. Default is true. Only relevant when the normalize argument is false, since link::Classes/Signal#-normalizeTransfer#normalizeTransfer:: performs zero-compensation (in addition to normalizing).
 
 INSTANCEMETHODS::
 

--- a/HelpSource/Classes/Wavetable.schelp
+++ b/HelpSource/Classes/Wavetable.schelp
@@ -24,8 +24,13 @@ method::chebyFill
 Fill a Wavetable of the given size with a sum of Chebyshev polynomials at the given amplitudes for use in waveshaping by the link::Classes/Shaper:: ugen.
 code::
 Wavetable.chebyFill(513, [1]).plot;
-Wavetable.chebyFill(513, [0, 1]).plot; // shifted to avoid DC offset when waveshaping a zero signal
-Wavetable.chebyFill(513, [0, 1], false, false).plot;  // raw (unshifted) Chebyshev polynomial
+
+// by default, shifted to avoid DC offset when waveshaping a zero signal:
+Wavetable.chebyFill(513, [0, 1]).plot;
+
+// normalized sum of (unshifted) Chebyshev polynomials:
+Wavetable.chebyFill(513, [0, 1, 0, 0, 0, 1], true, false).plot;
+
 Wavetable.chebyFill(513, [0, 0, 1]).plot;
 Wavetable.chebyFill(513, [0.3, -0.8, 1.1]).plot;
 ::
@@ -34,9 +39,9 @@ must be a power of 2 plus 1, eventual wavetable is next power of two size up.
 argument::amplitudes
 an link::Classes/Array:: of amplitudes for each Chebyshev polynomial beginning with order 1.
 argument::normalize
-a link::Classes/Boolean:: indicating whether to normalize the resulting Wavetable (for use as a transfer function) using link::Classes/Signal#-normalizeTransfer#normalizeTransfer::.  Default is true.
+a link::Classes/Boolean:: indicating whether to normalize the resulting Wavetable. If the zeroOffset argument is true, the normalization is done for use as a transfer function, using link::Classes/Signal#-normalizeTransfer#normalizeTransfer::, otherwise it just uses link::Classes/Signal#-normalize#normalize:: to make the absolute peak value 1.  Default is true.
 argument::zeroOffset
-a link::Classes/Boolean:: indicating whether to offset the middle of each polynomial to zero. If true, then a zero input will always result in a zero output when used as a link::Classes/Shaper##waveshaper::. Default is true. Only relevant when the normalize argument is false, since link::Classes/Signal#-normalizeTransfer#normalizeTransfer:: performs zero-compensation (in addition to normalizing).
+a link::Classes/Boolean:: indicating whether to offset the middle of each polynomial to zero. If true, then a zero input will always result in a zero output when used as a link::Classes/Shaper##waveshaper::. If false, then the "raw" (unshifted) Chebyshev polynomials are used. Default is true.
 
 INSTANCEMETHODS::
 

--- a/SCClassLibrary/Common/Math/Signal.sc
+++ b/SCClassLibrary/Common/Math/Signal.sc
@@ -3,8 +3,8 @@ Signal[float] : FloatArray {
 	*sineFill { arg size, amplitudes, phases;
 		^Signal.newClear(size).sineFill(amplitudes, phases).normalize
 	}
-	*chebyFill { arg size, amplitudes, normalize=true;
-		^Signal.newClear(size).chebyFill(amplitudes, normalize); //.normalizeTransfer //shouldn't normalize by default!
+	*chebyFill { arg size, amplitudes, normalize=true, zeroOffset=true;
+		^Signal.newClear(size).chebyFill(amplitudes, normalize, zeroOffset);
 	}
 	*hammingWindow { arg size, pad=0;
 		if (pad == 0, {
@@ -169,14 +169,21 @@ Signal[float] : FloatArray {
 	}
 	chebyFill { arg amplitudes, normalize=true, zeroOffset=true;
 		this.fill(0.0);
-		amplitudes.do({ arg amp, i; this.addChebyshev(i+1, amp);
+		amplitudes.do({ arg amp, i;
+			this.addChebyshev(i+1, amp);
 			if (zeroOffset) {
 				if(i%4==1,{this.offset(amp)});
 				if(i%4==3,{this.offset(-1*amp)});
-			}
-		}); //corrections for JMC DC offsets, as per Buffer:cheby
+			} //corrections for JMC DC offsets, as per Buffer:cheby
+		});
 
-		if(normalize,{this.normalizeTransfer}); //no automatic cheby
+		if (normalize) {
+			if (zeroOffset) {
+				this.normalizeTransfer
+			} {
+				this.normalize
+			}
+		};
 	}
 
 	//old version
@@ -314,9 +321,9 @@ Wavetable[float] : FloatArray {
 	}
 
 	//size must be N/2+1 for N power of two; N is eventual size of wavetable
-	*chebyFill { arg size, amplitudes, normalize=true;
+	*chebyFill { arg size, amplitudes, normalize=true, zeroOffset=true;
 
-		^Signal.chebyFill(size, amplitudes, normalize).asWavetableNoWrap; //asWavetable causes wrap here, problem
+		^Signal.chebyFill(size, amplitudes, normalize, zeroOffset).asWavetableNoWrap; //asWavetable causes wrap here, problem
 	}
 
 	*chebyFill_old { arg size, amplitudes;

--- a/SCClassLibrary/Common/Math/Signal.sc
+++ b/SCClassLibrary/Common/Math/Signal.sc
@@ -167,9 +167,14 @@ Signal[float] : FloatArray {
 		_SignalAddChebyshev
 		^this.primitiveFailed
 	}
-	chebyFill { arg amplitudes, normalize=true;
+	chebyFill { arg amplitudes, normalize=true, zeroOffset=true;
 		this.fill(0.0);
-		amplitudes.do({ arg amp, i; this.addChebyshev(i+1, amp); if(i%4==1,{this.offset(1)}); if(i%4==3,{this.offset(-1)}); }); //corrections for JMC DC offsets, as per Buffer:cheby
+		amplitudes.do({ arg amp, i; this.addChebyshev(i+1, amp);
+			if (zeroOffset) {
+				if(i%4==1,{this.offset(amp)});
+				if(i%4==3,{this.offset(-1*amp)});
+			}
+		}); //corrections for JMC DC offsets, as per Buffer:cheby
 
 		if(normalize,{this.normalizeTransfer}); //no automatic cheby
 	}

--- a/server/plugins/OscUGens.cpp
+++ b/server/plugins/OscUGens.cpp
@@ -3456,7 +3456,7 @@ static void add_chebyshev(int size, float *data, double partial, double amp)
 	double phase = -1.0;
 	double offset = -amp * cos (partial * pi2);
 	for (int i=0; i<size; ++i) {
-		data[i] += amp * cos (partial * acos (phase)) - offset;
+		data[i] += amp * cos (partial * acos (phase)) + offset;
 		phase += w;
 	}
 }
@@ -3468,10 +3468,10 @@ static void add_wchebyshev(int size, float *data, double partial, double amp)
 	double w = 2.0 / (double)size2;
 	double phase = -1.0;
 	double offset = -amp * cos (partial * pi2);
-	double cur = amp * cos (partial * acos (phase))-offset;
+	double cur = amp * cos (partial * acos (phase)) + offset;
 	phase += w;
 	for (int i=0; i<size; i+=2) {
-		double next = amp * cos (partial * acos (phase)) - offset;
+		double next = amp * cos (partial * acos (phase)) + offset;
 		data[i] += 2 * cur - next;
 		data[i+1] += next - cur;
 		cur = next;


### PR DESCRIPTION
These are several things I found while looking at the issues raised in #1500.  Besides adding the ability to produce the "raw" Chebyshev polynomials (by passing `normalize: false`and a new option `zeroOffset: false` to Signal.chebyFill and Wavetable.chebyFill), I fixed two problems I found along the way:

1. `Signal.chebyFill` was not taking amplitudes into account when offsetting for DC.  The fix was there, but it always added or subtracted 1 in the the relevant places.  Worst of all, for amplitudes of 0 it came across (whose poly degrees would otherwise need offsetting), it was always adding and subtracting 1!  This was probably not noticed, because with `normalize: true` (default) it shifted the whole thing to lie between -1 and 1.

2. `Buffer.chebyMsg` (and `Buffer.cheby`) were not adding the DC offset in the proper direction!  The idea is to ensure that the middle value is at zero. Now fixed, this gives the same result as Signal.chebyFill (when `zeroOffset` is true -- the default case).

I also added a bit of documentation for the old normalize argument and my new zeroOffset argument.