### PR TITLE
Update LFPar.schelp

### DIFF
--- a/HelpSource/Classes/LFPar.schelp
+++ b/HelpSource/Classes/LFPar.schelp
@@ -6,7 +6,7 @@ categories::  UGens>Generators>Deterministic
 
 Description::
 
-A sine-like shape made of two parabolas.  It has audible odd harmonics and is non-band-limited.
+A sine-like shape made of two parabolas and the integral of a triangular wave.  It has audible odd harmonics and is non-band-limited.
 Output ranges from -1 to +1.
 
 classmethods::


### PR DESCRIPTION
As confirmed and discussed recently in the supercollider list, this is in fact the integral of a triangular wave, so it is a nice information to show in the help file.

Because it is the integral of a triangular wave, and just like the integral of any other wave function, this oscillator behaves according to a triangular modulator in FM If used as a modulator in PM. So it's nice to confirm in the help file it's the integral of a triangular in the help file for those who know about these implications.