### PR TITLE
Update Ringz.schelp

### DIFF
--- a/HelpSource/Classes/Ringz.schelp
+++ b/HelpSource/Classes/Ringz.schelp
@@ -6,9 +6,8 @@ categories::  UGens>Filters>Linear
 
 Description::
 
-This is the same as  link::Classes/Resonz:: , except that instead of a
-resonance parameter, the bandwidth is specified in a 60dB ring decay
-time. One Ringz is equivalent to one component of the
+This is the same as  link::Classes/Resonz:: , except that it is constant skirt gain filter, meaning that the peak gain depends on the value of Q. Also, instead of the
+resonance parameter in Resonz, the bandwidth is specified in a 60dB ring decay time. One Ringz is equivalent to one component of the
 link::Classes/Klank::  UGen.
 
 


### PR DESCRIPTION
I made this change because the help file, as it was originally written, did really throw me off by believe that both Resonz and Ringz were in fact the exact same filter, being the only exception how you set the filter parameters. I added more information regarding the relationship between Resonz and Ringz so the differences and similirarities between them is made clearer. 

The help file of Resonz should also be updated to also state the relatioship between these two objects. It doesn't make sense to make the relationship in this help file but completely omit it in the other one. So I'm also going to propose some changes in the help file of Resonz to make it like this one.