### PR TITLE
Update Resonz.schelp

### DIFF
--- a/HelpSource/Classes/Resonz.schelp
+++ b/HelpSource/Classes/Resonz.schelp
@@ -6,7 +6,9 @@ categories::  UGens>Filters>Linear
 
 Description::
 
-A two pole resonant filter with zeroes at
+This is the same as  link::Classes/Ringz:: , except that it has a constant gain at 0 dB instead of being constant skirt.
+
+It is a two pole resonant filter with zeroes at
 
 code::
 z = ±1


### PR DESCRIPTION
I made this changes because the help file of Ringz did relate to this object, but the opposite didn't happen. I think it only makes sense to point the relationship in both help files.

By the way, I did also just proposed a change in Rigngz's help file, as the relationship to Resonz was misleading.