### PR TITLE
Update LFPar.schelp

### DIFF
--- a/HelpSource/Classes/LFPar.schelp
+++ b/HelpSource/Classes/LFPar.schelp
@@ -45,6 +45,11 @@ code::
 // used as both Oscillator and LFO:
 { LFPar.ar(LFPar.kr(3, 0.3, 200, 400)) * 0.1 }.play;
 
+// used as phase modulator (behaves like a triangular modulator in FM):
+// Compare:
+{SinOsc.ar(440, LFPar.ar(1, 2, mul: 8pi))}.play
+{SinOsc.ar(440 + LFTri.ar(1, mul: 8pi))}.play
+
 
 // more examples:
 


### PR DESCRIPTION
added this example to reinforce the last update I proposed to the help file - because LFPar being the integral of a triangular means you can use it as phase modulator and it'l behave like a triangular frequency modulator