### PR TITLE
Chebyshev: zero-offset default change plus documentation updates

### DIFF
--- a/HelpSource/Classes/Buffer.schelp
+++ b/HelpSource/Classes/Buffer.schelp
@@ -911,7 +911,9 @@ argument:: clearFirst
 A Boolean indicating whether or not to clear the buffer before writing. The default is true.
 
 method:: cheby, chebyMsg
-Fill this buffer with a series of chebyshev polynomials, which can be defined as: code::cheby(n) = amplitude  * cos(n * acos(x))::. To eliminate a DC offset when used as a waveshaper, the wavetable is offset so that the center value is zero.
+Fill this buffer with a series of Chebyshev polynomials, which can be defined as: code::cheby(n) = amplitude  * cos(n * acos(x))::. To eliminate a DC offset when used as a waveshaper, the wavetable is offset so that the center value is zero.
+
+Similar functionality can be found in link::Classes/Signal#*chebyFill#Signal.chebyFill:: and link::Classes/Wavetable#*chebyFill#Wavetable.chebyFill::.  If you require Chebyshev polynomials that do not include the offset compensation, it is recommended to use one of these.
 argument:: amplitudes
 An Array containing amplitudes for the harmonics. The first float value specifies the amplitude for n = 1, the second float value specifies the amplitude for n = 2, and so on.
 argument:: normalize
@@ -921,6 +923,9 @@ A Boolean indicating whether or not to write to the buffer in wavetable format s
 argument:: clearFirst
 A Boolean indicating whether or not to clear the buffer before writing. The default is true.
 discussion::
+note::
+In previous versions, offsetting (to ensure the center value is zero) was performed incorrectly.  This was fixed in version 3.7, so any code that may have relied on the (wrong) behavior may need to be changed.  If using a Chebyshev buffer as a waveshaper, the simplest fix is to wrap the link::Classes/Shaper:: in a link::Classes/LeakDC:: UGen.
+::
 code::
 s.boot;
 b = Buffer.alloc(s, 512, 1, {arg buf; buf.chebyMsg([1,0,1,1,0,1])});

--- a/HelpSource/Classes/Signal.schelp
+++ b/HelpSource/Classes/Signal.schelp
@@ -22,6 +22,15 @@ an Array of phases in radians for each harmonic beginning with the fundamental.
 
 method::chebyFill
 Fill a Signal of the given size with a sum of Chebyshev polynomials at the given amplitudes. For eventual use in waveshaping by the Shaper ugen; see link::Classes/Shaper:: helpfile and link::Classes/Buffer#-cheby#Buffer:cheby:: too.
+argument::size
+the number of samples in the Signal.
+argument::amplitudes
+an link::Classes/Array:: of amplitudes for each Chebyshev polynomial beginning with order 1.
+argument::normalize
+a link::Classes/Boolean:: indicating whether to normalize the resulting Signal. If the zeroOffset argument is true, the normalization is done for use as a transfer function, using link::Classes/Signal#-normalizeTransfer#normalizeTransfer::, otherwise it just uses link::Classes/Signal#-normalize#normalize:: to make the absolute peak value 1.  Default is true.
+argument::zeroOffset
+a link::Classes/Boolean:: indicating whether to offset the middle of each polynomial to zero. If true, then a zero input will always result in a zero output when used as a link::Classes/Shaper##waveshaper::. If false, then the "raw" (unshifted) Chebyshev polynomials are used. Default is true.
+discussion::
 code::
 Signal.chebyFill(1000, [1]).plot;
 
@@ -33,15 +42,39 @@ Signal.chebyFill(1000, [0, 1, 0, 0, 0, 1], true, false).plot;
 
 Signal.chebyFill(1000, [0, 0, 1]).plot;
 Signal.chebyFill(1000, [0.3, -0.8, 1.1]).plot;
+
+
+// This waveshaping example uses two buffers, one with zero offset and
+// the other not.
+//
+// 1. The offset version gives zero output (DC free) when waveshaping an
+// input signal with amplitude of zero (e.g. DC.ar(0)).
+//
+// 2. The non-offset version makes better use of the full (-1 to 1) range
+// when waveshaping a varying signal with amplitude near 1, but (if even
+// Chebyshev polynomial degrees are used) will have a DC offset when
+// waveshaping a signal with amplitude of zero.
+//
+// 3. Wrapping the non-offset Shaper in a LeakDC (the third signal in the
+// example) cancels out any DC offsets (third version), while making full use
+// of the -1 to 1 range.
+(
+s.waitForBoot {
+	var amplitudes = [0, 1, 1, -2, 1];
+	var sigs = [
+		Signal.chebyFill(256+1, amplitudes, normalize: true, zeroOffset: true),
+		Signal.chebyFill(256+1, amplitudes, normalize: true, zeroOffset: false)
+	];
+	b = sigs.collect{ arg sig; Buffer.loadCollection(s, sig.asWavetableNoWrap) };
+	s.sync;
+	x = {
+		var in = SinOsc.ar(100, 0, SinOsc.kr(0.1, 0, 0.5, 0.5));
+		Shaper.ar(b, in ) ++ LeakDC.ar(Shaper.ar(b[1], in))
+	}.scope;
+}
+)
+x.free; b.do(_.free); b = nil
 ::
-argument::size
-the number of samples in the Signal.
-argument::amplitudes
-an link::Classes/Array:: of amplitudes for each Chebyshev polynomial beginning with order 1.
-argument::normalize
-a link::Classes/Boolean:: indicating whether to normalize the resulting Signal. If the zeroOffset argument is true, the normalization is done for use as a transfer function, using link::Classes/Signal#-normalizeTransfer#normalizeTransfer::, otherwise it just uses link::Classes/Signal#-normalize#normalize:: to make the absolute peak value 1.  Default is true.
-argument::zeroOffset
-a link::Classes/Boolean:: indicating whether to offset the middle of each polynomial to zero. If true, then a zero input will always result in a zero output when used as a link::Classes/Shaper##waveshaper::. If false, then the "raw" (unshifted) Chebyshev polynomials are used. Default is true.
 
 method::hanningWindow
 Fill a Signal of the given size with a Hanning window.

--- a/HelpSource/Classes/Signal.schelp
+++ b/HelpSource/Classes/Signal.schelp
@@ -29,16 +29,19 @@ an link::Classes/Array:: of amplitudes for each Chebyshev polynomial beginning w
 argument::normalize
 a link::Classes/Boolean:: indicating whether to normalize the resulting Signal. If the zeroOffset argument is true, the normalization is done for use as a transfer function, using link::Classes/Signal#-normalizeTransfer#normalizeTransfer::, otherwise it just uses link::Classes/Signal#-normalize#normalize:: to make the absolute peak value 1.  Default is true.
 argument::zeroOffset
-a link::Classes/Boolean:: indicating whether to offset the middle of each polynomial to zero. If true, then a zero input will always result in a zero output when used as a link::Classes/Shaper##waveshaper::. If false, then the "raw" (unshifted) Chebyshev polynomials are used. Default is true.
+a link::Classes/Boolean:: indicating whether to offset the middle of each polynomial to zero. If true, then a zero input will always result in a zero output when used as a link::Classes/Shaper##waveshaper::. If false, then the "raw" (unshifted) Chebyshev polynomials are used. Default is false.
 discussion::
+note::
+In previous versions, chebyFill always offset the curves to ensure the center value was zero. The zeroOffset argument was added in version 3.7, and the default behavior was changed, so that it no longer offsets.
+::
 code::
 Signal.chebyFill(1000, [1]).plot;
 
-// by default, shifted to avoid DC offset when waveshaping a zero signal
-Signal.chebyFill(1000, [0, 1]).plot;
+// shifted to avoid DC offset when waveshaping a zero signal
+Signal.chebyFill(1000, [0, 1], zeroOffset: true).plot;
 
-// normalized sum of (unshifted) Chebyshev polynomials
-Signal.chebyFill(1000, [0, 1, 0, 0, 0, 1], true, false).plot;
+// normalized sum of (unshifted) Chebyshev polynomials (the default)
+Signal.chebyFill(1000, [0, 1, 0, 0, 0, 1], normalize: true, zeroOffset: false).plot;
 
 Signal.chebyFill(1000, [0, 0, 1]).plot;
 Signal.chebyFill(1000, [0.3, -0.8, 1.1]).plot;

--- a/HelpSource/Classes/Wavetable.schelp
+++ b/HelpSource/Classes/Wavetable.schelp
@@ -29,16 +29,19 @@ an link::Classes/Array:: of amplitudes for each Chebyshev polynomial beginning w
 argument::normalize
 a link::Classes/Boolean:: indicating whether to normalize the resulting Wavetable. If the zeroOffset argument is true, the normalization is done for use as a transfer function, using link::Classes/Signal#-normalizeTransfer#normalizeTransfer::, otherwise it just uses link::Classes/Signal#-normalize#normalize:: to make the absolute peak value 1.  Default is true.
 argument::zeroOffset
-a link::Classes/Boolean:: indicating whether to offset the middle of each polynomial to zero. If true, then a zero input will always result in a zero output when used as a link::Classes/Shaper##waveshaper::. If false, then the "raw" (unshifted) Chebyshev polynomials are used. Default is true.
+a link::Classes/Boolean:: indicating whether to offset the middle of each polynomial to zero. If true, then a zero input will always result in a zero output when used as a link::Classes/Shaper##waveshaper::. If false, then the "raw" (unshifted) Chebyshev polynomials are used. Default is false.
 discussion::
+note::
+In previous versions, chebyFill always offset the curves to ensure the center value was zero. The zeroOffset argument was added in version 3.7, and the default behavior was changed, so that it no longer offsets.
+::
 code::
 Wavetable.chebyFill(513, [1]).plot;
 
-// by default, shifted to avoid DC offset when waveshaping a zero signal:
-Wavetable.chebyFill(513, [0, 1]).plot;
+// shifted to avoid DC offset when waveshaping a zero signal
+Wavetable.chebyFill(513, [0, 1], zeroOffset: true).plot;
 
-// normalized sum of (unshifted) Chebyshev polynomials:
-Wavetable.chebyFill(513, [0, 1, 0, 0, 0, 1], true, false).plot;
+// normalized sum of (unshifted) Chebyshev polynomials (the default)
+Wavetable.chebyFill(513, [0, 1, 0, 0, 0, 1], normalize: true, zeroOffset: false).plot;
 
 Wavetable.chebyFill(513, [0, 0, 1]).plot;
 Wavetable.chebyFill(513, [0.3, -0.8, 1.1]).plot;

--- a/HelpSource/Classes/Wavetable.schelp
+++ b/HelpSource/Classes/Wavetable.schelp
@@ -22,6 +22,15 @@ an Array of phases in radians for each harmonic beginning with the fundamental.
 
 method::chebyFill
 Fill a Wavetable of the given size with a sum of Chebyshev polynomials at the given amplitudes for use in waveshaping by the link::Classes/Shaper:: ugen.
+argument::size
+must be a power of 2 plus 1, eventual wavetable is next power of two size up.
+argument::amplitudes
+an link::Classes/Array:: of amplitudes for each Chebyshev polynomial beginning with order 1.
+argument::normalize
+a link::Classes/Boolean:: indicating whether to normalize the resulting Wavetable. If the zeroOffset argument is true, the normalization is done for use as a transfer function, using link::Classes/Signal#-normalizeTransfer#normalizeTransfer::, otherwise it just uses link::Classes/Signal#-normalize#normalize:: to make the absolute peak value 1.  Default is true.
+argument::zeroOffset
+a link::Classes/Boolean:: indicating whether to offset the middle of each polynomial to zero. If true, then a zero input will always result in a zero output when used as a link::Classes/Shaper##waveshaper::. If false, then the "raw" (unshifted) Chebyshev polynomials are used. Default is true.
+discussion::
 code::
 Wavetable.chebyFill(513, [1]).plot;
 
@@ -33,15 +42,39 @@ Wavetable.chebyFill(513, [0, 1, 0, 0, 0, 1], true, false).plot;
 
 Wavetable.chebyFill(513, [0, 0, 1]).plot;
 Wavetable.chebyFill(513, [0.3, -0.8, 1.1]).plot;
+
+
+// This waveshaping example uses two buffers, one with zero offset and
+// the other not.
+//
+// 1. The offset version gives zero output (DC free) when waveshaping an
+// input signal with amplitude of zero (e.g. DC.ar(0)).
+//
+// 2. The non-offset version makes better use of the full (-1 to 1) range
+// when waveshaping a varying signal with amplitude near 1, but (if even
+// Chebyshev polynomial degrees are used) will have a DC offset when
+// waveshaping a signal with amplitude of zero.
+//
+// 3. Wrapping the non-offset Shaper in a LeakDC (the third signal in the
+// example) cancels out any DC offsets (third version), while making full use
+// of the -1 to 1 range.
+(
+s.waitForBoot {
+	var amplitudes = [0, 1, 1, -2, 1];
+	var wavs = [
+		Wavetable.chebyFill(256+1, amplitudes, normalize: true, zeroOffset: true),
+		Wavetable.chebyFill(256+1, amplitudes, normalize: true, zeroOffset: false)
+	];
+	b = wavs.collect{ arg wav; Buffer.loadCollection(s, wav) };
+	s.sync;
+	x = {
+		var in = SinOsc.ar(100, 0, SinOsc.kr(0.1, 0, 0.5, 0.5));
+		Shaper.ar(b, in ) ++ LeakDC.ar(Shaper.ar(b[1], in))
+	}.scope;
+}
+)
+x.free; b.do(_.free); b = nil;
 ::
-argument::size
-must be a power of 2 plus 1, eventual wavetable is next power of two size up.
-argument::amplitudes
-an link::Classes/Array:: of amplitudes for each Chebyshev polynomial beginning with order 1.
-argument::normalize
-a link::Classes/Boolean:: indicating whether to normalize the resulting Wavetable. If the zeroOffset argument is true, the normalization is done for use as a transfer function, using link::Classes/Signal#-normalizeTransfer#normalizeTransfer::, otherwise it just uses link::Classes/Signal#-normalize#normalize:: to make the absolute peak value 1.  Default is true.
-argument::zeroOffset
-a link::Classes/Boolean:: indicating whether to offset the middle of each polynomial to zero. If true, then a zero input will always result in a zero output when used as a link::Classes/Shaper##waveshaper::. If false, then the "raw" (unshifted) Chebyshev polynomials are used. Default is true.
 
 INSTANCEMETHODS::
 

--- a/SCClassLibrary/Common/Math/Signal.sc
+++ b/SCClassLibrary/Common/Math/Signal.sc
@@ -3,7 +3,7 @@ Signal[float] : FloatArray {
 	*sineFill { arg size, amplitudes, phases;
 		^Signal.newClear(size).sineFill(amplitudes, phases).normalize
 	}
-	*chebyFill { arg size, amplitudes, normalize=true, zeroOffset=true;
+	*chebyFill { arg size, amplitudes, normalize=true, zeroOffset=false;
 		^Signal.newClear(size).chebyFill(amplitudes, normalize, zeroOffset);
 	}
 	*hammingWindow { arg size, pad=0;
@@ -167,7 +167,7 @@ Signal[float] : FloatArray {
 		_SignalAddChebyshev
 		^this.primitiveFailed
 	}
-	chebyFill { arg amplitudes, normalize=true, zeroOffset=true;
+	chebyFill { arg amplitudes, normalize=true, zeroOffset=false;
 		this.fill(0.0);
 		amplitudes.do({ arg amp, i;
 			this.addChebyshev(i+1, amp);
@@ -321,7 +321,7 @@ Wavetable[float] : FloatArray {
 	}
 
 	//size must be N/2+1 for N power of two; N is eventual size of wavetable
-	*chebyFill { arg size, amplitudes, normalize=true, zeroOffset=true;
+	*chebyFill { arg size, amplitudes, normalize=true, zeroOffset=false;
 
 		^Signal.chebyFill(size, amplitudes, normalize, zeroOffset).asWavetableNoWrap; //asWavetable causes wrap here, problem
 	}


### PR DESCRIPTION
- added a note about the change to `Buffer.cheby`'s (fixed) behavior in 3.7, as per @telephon comment in #1504.
- added real-world waveshaping examples for `Signal.chebyFill` and `Wavetable.chebyFill`, and moved all the examples below (where they should be), in a "Discussion" section.
- the `Signal.chebyFill` and `Wavetable.chebyFill` methods **no longer offset the center value to zero by default**, as per discussion with @telephon, @porres. Notes to this effect were added to the help files.

I considered adding the "zero offset" functionality to `Buffer.cheby` as well, but decided against it, because of the way the OSC chebyMsg is created.  I would break existing functionality, because I'd need to insert a new OSC argument *before* the list of amplitudes (which must be last, since they are of variable length).  I added a note that one should use `{Signal,Wavetable}.chebyFill` if one wants more complete functionality (and they now contain working examples).  If breaking old behavior is okay, I could also fix `chebyMsg` to support the `zeroOffset` argument, but I'm not sure this is necessary.