### PR TITLE
Topic/fix scrollbar hiding osx

### DIFF
--- a/QtCollider/QcApplication.cpp
+++ b/QtCollider/QcApplication.cpp
@@ -65,6 +65,8 @@ static bool QtColliderUseGui(void)
 // undefine some interfering X11 definitions
 #undef KeyPress
 
+bool QcApplication::_systemHasMouseWheel = false;
+
 QcApplication::QcApplication( int & argc, char ** argv )
 : QApplication( argc, argv, QtColliderUseGui() )
 {
@@ -148,6 +150,10 @@ bool QcApplication::notify( QObject * object, QEvent * event )
             interpret(cmdPeriodCommand, false);
         }
         break;
+    }
+    case QEvent::Wheel: {
+      _systemHasMouseWheel = true;
+      break;
     }
     default:
         break;

--- a/QtCollider/QcApplication.h
+++ b/QtCollider/QcApplication.h
@@ -56,6 +56,7 @@ class QcApplication : public QApplication
     static void processEvents() {
       if( _instance ) _instance->_eventProc.work();
     }
+    static inline bool SystemHasMouseWheel() { return _systemHasMouseWheel; }
 
   public Q_SLOTS:
     void interpret( const QString & code, bool printResult = true );
@@ -70,6 +71,7 @@ class QcApplication : public QApplication
 
     static QMutex _mutex;
     static QcApplication *_instance;
+    static bool _systemHasMouseWheel;
 
     bool _handleCmdPeriod;
 };

--- a/QtCollider/hacks/hacks_mac.hpp
+++ b/QtCollider/hacks/hacks_mac.hpp
@@ -30,6 +30,7 @@ namespace Mac {
 bool IsCmdPeriodKeyUp(void * event);
 bool IsCmdPeriodKeyDown(void * event);
 bool isKeyWindow ( QWidget *w );
+bool AlwaysShowScrollbars();
 void activateApp ();
     
 } // namespace Mac

--- a/QtCollider/hacks/hacks_mac.mm
+++ b/QtCollider/hacks/hacks_mac.mm
@@ -58,6 +58,11 @@ bool IsCmdPeriodKeyUp(void * event)
     }
     return false;
 }
+  
+bool AlwaysShowScrollbars() {
+    return ([NSScroller preferredScrollerStyle] == NSScrollerStyleLegacy);
+}
+
 
 void activateApp() {
     [NSApp activateIgnoringOtherApps:YES];

--- a/QtCollider/style/ProxyStyle.cpp
+++ b/QtCollider/style/ProxyStyle.cpp
@@ -4,9 +4,27 @@
 #include <QStyleOptionSlider>
 #include <QPainter>
 
+#ifdef Q_OS_MAC
+  #include "../hacks/hacks_mac.hpp"
+#endif
+
 using namespace QtCollider;
 
+static bool AlwaysShowScrollbars() {
 #ifdef Q_OS_MAC
+  return QtCollider::Mac::AlwaysShowScrollbars();
+  
+#elif Q_OS_X11
+  return true;
+
+#elif Q_OS_WIN
+  return true;
+
+#else
+  return true;
+#endif
+};
+
 void ProxyStyle::drawComplexControl ( ComplexControl ctrl, const QStyleOptionComplex *opt,
                                       QPainter *p, const QWidget * w) const
 {
@@ -21,31 +39,28 @@ void ProxyStyle::drawComplexControl ( ComplexControl ctrl, const QStyleOptionCom
     opt2.styleObject = NULL;
 
     QProxyStyle::drawComplexControl( ctrl, &opt2, p, w );
-
+    return;
+  }
+  
+  if (ctrl == QStyle::CC_ScrollBar && AlwaysShowScrollbars()) {
+    const QStyleOptionSlider *optSlider = static_cast<const QStyleOptionSlider*>(opt);
+    QStyleOptionSlider opt2( *optSlider );
+    opt2.state = State_On;
+    QProxyStyle::drawComplexControl( ctrl, static_cast<const QStyleOptionComplex*>(&opt2), p, w );
     return;
   }
 
-	if (ctrl == QStyle::CC_ScrollBar) {
-		const QStyleOptionSlider *optSlider = static_cast<const QStyleOptionSlider*>(opt);
-		QStyleOptionSlider opt2( *optSlider );
-		opt2.state = State_On;
-		QProxyStyle::drawComplexControl( ctrl, static_cast<const QStyleOptionComplex*>(&opt2), p, w );
-
-		return;
-	}
-
   QProxyStyle::drawComplexControl( ctrl, opt, p, w );
 }
-#endif
 
 int ProxyStyle::styleHint ( StyleHint hint, const QStyleOption * option,
                             const QWidget * widget, QStyleHintReturn * returnData ) const
 {
   switch( hint ) {
-//    case QStyle::SH_Slider_AbsoluteSetButtons:
-//      return Qt::LeftButton;
-//    case QStyle::SH_Slider_PageSetButtons:
-//      return Qt::NoButton;
+    case QStyle::SH_Slider_AbsoluteSetButtons:
+      return Qt::LeftButton;
+    case QStyle::SH_Slider_PageSetButtons:
+      return Qt::NoButton;
     case QStyle::SH_ScrollBar_Transient:
       return 1;
     default:

--- a/QtCollider/style/ProxyStyle.cpp
+++ b/QtCollider/style/ProxyStyle.cpp
@@ -25,6 +25,15 @@ void ProxyStyle::drawComplexControl ( ComplexControl ctrl, const QStyleOptionCom
     return;
   }
 
+	if (ctrl == QStyle::CC_ScrollBar) {
+		const QStyleOptionSlider *optSlider = static_cast<const QStyleOptionSlider*>(opt);
+		QStyleOptionSlider opt2( *optSlider );
+		opt2.state = State_On;
+		QProxyStyle::drawComplexControl( ctrl, static_cast<const QStyleOptionComplex*>(&opt2), p, w );
+
+		return;
+	}
+
   QProxyStyle::drawComplexControl( ctrl, opt, p, w );
 }
 #endif
@@ -33,10 +42,10 @@ int ProxyStyle::styleHint ( StyleHint hint, const QStyleOption * option,
                             const QWidget * widget, QStyleHintReturn * returnData ) const
 {
   switch( hint ) {
-    case QStyle::SH_Slider_AbsoluteSetButtons:
-      return Qt::LeftButton;
-    case QStyle::SH_Slider_PageSetButtons:
-      return Qt::NoButton;
+//    case QStyle::SH_Slider_AbsoluteSetButtons:
+//      return Qt::LeftButton;
+//    case QStyle::SH_Slider_PageSetButtons:
+//      return Qt::NoButton;
     case QStyle::SH_ScrollBar_Transient:
       return 1;
     default:

--- a/QtCollider/style/ProxyStyle.cpp
+++ b/QtCollider/style/ProxyStyle.cpp
@@ -1,5 +1,7 @@
 #include "ProxyStyle.hpp"
 
+#include "../QcApplication.h"
+
 #include <QWebView>
 #include <QStyleOptionSlider>
 #include <QPainter>
@@ -13,15 +15,15 @@ using namespace QtCollider;
 static bool AlwaysShowScrollbars() {
 #ifdef Q_OS_MAC
   return QtCollider::Mac::AlwaysShowScrollbars();
-  
+
 #elif Q_OS_X11
-  return true;
+  return !QcApplication::SystemHasMouseWheel();
 
 #elif Q_OS_WIN
-  return true;
+  return !QcApplication::SystemHasMouseWheel();
 
 #else
-  return true;
+  return !QcApplication::SystemHasMouseWheel();
 #endif
 };
 

--- a/QtCollider/style/ProxyStyle.hpp
+++ b/QtCollider/style/ProxyStyle.hpp
@@ -10,10 +10,8 @@ class ProxyStyle : public QProxyStyle
 public:
   ProxyStyle ( QStyle *style = 0 ) : QProxyStyle(style) { }
 
-#ifdef Q_OS_MAC
   virtual void drawComplexControl ( ComplexControl, const QStyleOptionComplex *,
                             QPainter *, const QWidget * w = 0 ) const;
-#endif
 
   virtual int styleHint ( StyleHint, const QStyleOption * = 0,
                           const QWidget * = 0, QStyleHintReturn * = 0 ) const;


### PR DESCRIPTION
This makes sclang honor the "Show scroll bars" preference on mac. 

In addition, this works around cases on systems that either don't have a mouse wheel, or users that don't use it: in those cases, the scrollbars will auto-hide making scrolling hard to access / non-obvious. We default to always showing scrollbars until we receive a wheel event, at which point we allow normal hiding behavior. The BETTER solution here is to provide an AlwaysShowScrollbars() API for Windows and X11 that matches the mac API, so sclang follows the system-wide prefs. Ubuntu has a preferences for similar overlay scrollbars, and my GUESS is that Windows does as well - however, I can't find them, and don't have a system to easily test on. If any Win / Lin developers want to research this, it should be easy to modify from here.