### PR TITLE
validate that a refspec refers to an existing tag

### DIFF
--- a/SCClassLibrary/Common/Quarks/Quark.sc
+++ b/SCClassLibrary/Common/Quarks/Quark.sc
@@ -79,6 +79,7 @@ Quark {
 	}
 
 	checkout {
+		var rs;
 		if(this.isDownloaded.not, {
 			if(this.url.isNil, {
 				Error("No git url, cannot checkout quark" + this).throw;
@@ -100,15 +101,30 @@ Quark {
 				if(refspec == "HEAD", {
 					git.pull()
 				}, {
-					// when do you have to fetch ?
-					// if offline then you do not want to fetch
-					// just checkout. fast switching
-					git.checkout(refspec)
+					rs = this.validateRefspec(refspec);
+					git.checkout(rs)
 				});
 			});
 			changed = true;
 			data = nil;
 		});
+	}
+	validateRefspec { |refspec|
+		var tag;
+		if(refspec == "HEAD"
+			or: {refspec.findRegexp("^[a-zA-Z0-9]{40}$").size != 0}, {
+			^refspec
+		});
+		if(refspec.beginsWith("tags/").not, {
+			tag = refspec;
+			refspec = "tags/" ++ tag;
+		}, {
+			tag = refspec.copyToEnd(5);
+		});
+		if(this.tags.includesEqual(tag).not, {
+			Error("Tag not found:" + this + tag).throw;
+		});
+		^refspec
 	}
 	checkForUpdates {
 		var tags;

--- a/SCClassLibrary/Common/Quarks/Quark.sc
+++ b/SCClassLibrary/Common/Quarks/Quark.sc
@@ -102,7 +102,9 @@ Quark {
 					git.pull()
 				}, {
 					rs = this.validateRefspec(refspec);
-					git.checkout(rs)
+					if(rs.notNil, {
+						git.checkout(rs)
+					});
 				});
 			});
 			changed = true;
@@ -122,7 +124,8 @@ Quark {
 			tag = refspec.copyToEnd(5);
 		});
 		if(this.tags.includesEqual(tag).not, {
-			Error("Tag not found:" + this + tag).throw;
+			("Tag not found:" + this + tag + Char.nl + "Possible tags:" + this.tags).warn;
+			^nil
 		});
 		^refspec
 	}


### PR DESCRIPTION
prepend tags/ if missing so that Quarks.install("thingy", "v0.2") works

unixCmd does not detect the exit code, so a failure to checkout was not detected

fixes #1531 