### PR TITLE
fix #1476 stack corruption triggered by calling a git unixCmd

### DIFF
--- a/SCClassLibrary/Common/Quarks/Git.sc
+++ b/SCClassLibrary/Common/Quarks/Git.sc
@@ -91,7 +91,8 @@ Git {
 		}
 	}
 	shaForTag { |tag|
-		^this.git(["rev-list", tag]).copyFromStart(39)
+		var out = this.git(["rev-list", tag, "--max-count=1"]);
+		^out.copyFromStart(39)
 	}
 	git { |args, cd=true|
 		var cmd;


### PR DESCRIPTION
`git rev-list tagname` can return a large list of unneeded hash references.
this was triggering some stack corruption. glory goes to @scztt for the solution