### PR TITLE
Topic/refactor server status

### DIFF
--- a/HelpSource/Guides/News-3_7.schelp
+++ b/HelpSource/Guides/News-3_7.schelp
@@ -3,22 +3,11 @@ summary:: A summary of news in SC 3.7
 categories:: News
 related::Guides/News-3_6, Guides/News-3_5, Guides/Debugging-tips
 
-NOTE::This is an incomplete stub::
 
-NOTE::3.7 is an alpha version, which fixes many issues, but may also introduce new ones. Please do not hesitate to add them to the LINK::https://github.com/supercollider/supercollider/issues##issue tracker:: or mention them on any of the supercollider LINK::http://www.birmingham.ac.uk/facilities/ea-studios/research/supercollider/mailinglist.aspx##mailing list::.::
+NOTE::3.7.0 fixes many issues, but may also introduce new ones. See also STRONG::Known Issues:: section below. Please do not hesitate to add new issues you find to the LINK::https://github.com/supercollider/supercollider/issues##issue tracker:: or mention them on any of the supercollider LINK::http://www.birmingham.ac.uk/facilities/ea-studios/research/supercollider/mailinglist.aspx##mailing list::.::
 
 This document focusses on features, there are STRONG::many bugfixes and interesting improvements::, which can be found by exploring the recent changes file and snooping around the system itself.
 
-SECTION:: Known Issues
-
-While much has improved and many bugs from 3.6 have been fixed, there are still many known issues. For a complete list see: link::https://github.com/supercollider/supercollider/issues/::
-
-Here is one few that are worth a special mention:
-
-LIST::
-##Evaluating code in the help document doesn't work (OSX) LINK::lhttps://github.com/supercollider/supercollider/issues/1385::
-##Drag and drop files to expand paths broken (OSX): LINK::https://github.com/supercollider/supercollider/issues/1295::
-::
 
 SECTION:: Editor
 
@@ -62,7 +51,9 @@ LIST::
 
 SECTION::Server-side news
 
-Apart from UDP, the TCP-protocol is now supported
+Apart from UDP, the TCP-protocol is now supported.
+
+When mapping controls of synths to busses, their number of channels is limited to the number of control channels, avoiding a "spill-over" of mappings.
 
 SUBSECTION::List of new UGens
 
@@ -74,9 +65,13 @@ LIST::
 SUBSECTION::Improved or corrected behavior
 LIST::
 ##LINK::Classes/LinXFade2:: (correct fading direction)
-##Instances of PV_Copy are added automatically where necessary for parallel processing
+##LINK::Classes/LFPulse:: (when width = 0.5, return exacly as many 0 as 1)
+##LINK::Classes/TrigControl:: is now independent of synth order, like LINK::Classes/Control::.
+##LINK::Classes/TRand::, LINK::Classes/TExpRand::, LINK::Classes/TIRand:: (can operate at audio rate)
 ##LINK::Classes/Env#*new:: accepts a new TELETYPE::step2:: shape, which steps to a value at the end of a shape
 ##LINK::Classes/UGen#-curvelin:: is now inverse of LINK::Classes/UGen#-lincurve::
+##LINK::Classes/Server#-record:: correcty closes short files
+##In combinations of demand-ugens: Instances of PV_Copy are added automatically where necessary for parallel processing
 ::
 
 
@@ -92,6 +87,17 @@ TABLE::
 
 See link::Overviews/Operators::
 
+
+SECTION:: Known Issues
+
+While much has improved and many bugs from 3.6 have been fixed, there are still many known issues. For a complete list see: link::https://github.com/supercollider/supercollider/issues/::
+
+Here is one few that are worth a special mention:
+
+LIST::
+##Evaluating code in the help document doesn't work (OSX) LINK::lhttps://github.com/supercollider/supercollider/issues/1385::
+##Drag and drop files to expand paths broken (OSX): LINK::https://github.com/supercollider/supercollider/issues/1295::
+::
 
 
 

--- a/HelpSource/Guides/News-3_7.schelp
+++ b/HelpSource/Guides/News-3_7.schelp
@@ -7,79 +7,91 @@ NOTE::This is an incomplete stub::
 
 NOTE::3.7 is an alpha version, which fixes many issues, but may also introduce new ones. Please do not hesitate to add them to the LINK::https://github.com/supercollider/supercollider/issues##issue tracker:: or mention them on any of the supercollider LINK::http://www.birmingham.ac.uk/facilities/ea-studios/research/supercollider/mailinglist.aspx##mailing list::.::
 
-	This document focusses on features, there are STRONG::many bugfixes and interesting improvements::, which can be found by exploring the recent changes file and snooping around the system itself.
+This document focusses on features, there are STRONG::many bugfixes and interesting improvements::, which can be found by exploring the recent changes file and snooping around the system itself.
+
+SECTION:: Known Issues
+
+While much has improved and many bugs from 3.6 have been fixed, there are still many known issues. For a complete list see: link::https://github.com/supercollider/supercollider/issues/::
+
+Here is one few that are worth a special mention:
+
+LIST::
+##Evaluating code in the help document doesn't work (OSX) LINK::lhttps://github.com/supercollider/supercollider/issues/1385::
+##Drag and drop files to expand paths broken (OSX): LINK::https://github.com/supercollider/supercollider/issues/1295::
+::
+
+SECTION:: Editor
+
+LIST::
+##Menu entries for Recording, scope and server inspection
+##Modify and query IDE documents from sclang
+##Support for the Atom text editor
+::
+
+SECTION:: Language-side news
+
+LIST::
+##Improved link::Classes/Quark:: system and many new interesting Quarks.
+##LINK::Classes/TempoClock#-beats:: can be set.
+##An interface for key-value-pairs, see link::Reference/Key-Value-Pairs::
+##Refactored JITLib, see link::Other/JITLibChanges3.7:: (in particular dynamic channel expansion).
+##LINK::Classes/QuartzComposerView::
+::
 
 
-	SECTION:: Editor
+SUBSECTION::External Interfacing
 
-	LIST::
-	##Menu entries for Recording, scope and server inspection
-	##Modify and query IDE documents from sclang
-	##Support for the Atom text editor
-	::
-
-	SECTION:: Language-side news
-
-	LIST::
-	##Improved link::Classes/Quark:: system and many new interesting Quarks.
-	##LINK::Classes/TempoClock#-beats:: can be set.
-	##An interface for key-value-pairs, see link::Reference/Key-Value-Pairs::
-	##Refactored JITLib, see link::Other/JITLibChanges3.7:: (in particular dynamic channel expansion).
-	##LINK::Classes/QuartzComposerView::
-	::
+There is an entirely new HID implementation: see link::Guides/Working_with_HID::.
 
 
-	SUBSECTION::External Interfacing
+SUBSECTION::List of new methods and classes
 
-	There is an entirely new HID implementation: see link::Guides/Working_with_HID::.
+LIST::
+##link::Classes/Collection#-collectCopy::, link::Classes/Collection#-collectInPlace::
+##link::Classes/SimpleNumber#-lcm:: and link::Classes/SimpleNumber#-gcd:: have consistent interpretations of negative values and zero.
+##link::Classes/Dictionary#-embedInStream:: can be customized from within the dictionary.
+##link::Classes/Server#*remote:: Create a new Server instance corresponding to a server app running on a separate machine.
+::
 
-
-	SUBSECTION::List of new methods and classes
-
-	LIST::
-	##link::Classes/Collection#-collectCopy::, link::Classes/Collection#-collectInPlace::
-	##link::Classes/SimpleNumber#-lcm:: and link::Classes/SimpleNumber#-gcd:: have consistent interpretations of negative values and zero.
-	##link::Classes/Dictionary#-embedInStream:: can be customized from within the dictionary.
-	##link::Classes/Server#*remote:: Create a new Server instance corresponding to a server app running on a separate machine.
-	::
-
-	SUBSECTION::List of deprecated methods/classes, or that will be deprecated soon
-	LIST::
-	##GeneralHID, GeneralHIDSpec, GeneralHIDDevice (replaced by the new LINK::Classes/HID:: system)
-	::
+SUBSECTION::List of deprecated methods/classes, or that will be deprecated soon
+LIST::
+##GeneralHID, GeneralHIDSpec, GeneralHIDDevice (replaced by the new LINK::Classes/HID:: system)
+::
 
 
 
-	SECTION::Server-side news
+SECTION::Server-side news
 
-	Apart from UDP, the TCP-protocol is now supported
+Apart from UDP, the TCP-protocol is now supported
 
-	SUBSECTION::List of new UGens
+SUBSECTION::List of new UGens
 
-	LIST::
-	##NodeID (UGen that returns the current node id)
-	##LINK::Classes/Dconst::
-	::
+LIST::
+##NodeID (UGen that returns the current node id)
+##LINK::Classes/Dconst::
+::
 
-	SUBSECTION::Improved or corrected behavior
-	LIST::
-	##LINK::Classes/LinXFade2:: (correct fading direction)
-	##Instances of PV_Copy are added automatically where necessary for parallel processing
-	##LINK::Classes/Env#*new:: accepts a new TELETYPE::step2:: shape, which steps to a value at the end of a shape
-	##LINK::Classes/UGen#-curvelin:: is now inverse of LINK::Classes/UGen#-lincurve::
-	::
+SUBSECTION::Improved or corrected behavior
+LIST::
+##LINK::Classes/LinXFade2:: (correct fading direction)
+##Instances of PV_Copy are added automatically where necessary for parallel processing
+##LINK::Classes/Env#*new:: accepts a new TELETYPE::step2:: shape, which steps to a value at the end of a shape
+##LINK::Classes/UGen#-curvelin:: is now inverse of LINK::Classes/UGen#-lincurve::
+::
 
 
-	SUBSECTION::More operators work uniformly across sclang and scserver
+SUBSECTION::More operators work uniformly across sclang and scserver
 
-	The following operators have been added as ugens and work the same as in sclang:
+The following operators have been added as ugens and work the same as in sclang:
 
-	TABLE::
-	##unary operators || code::rand, rand2, linrand, bilinrand, sum3rand, coin::
+TABLE::
+##unary operators || code::rand, rand2, linrand, bilinrand, sum3rand, coin::
 
-	##binary operators || code::lcm, gcd, rrand, exprand::
-	::
+##binary operators || code::lcm, gcd, rrand, exprand::
+::
 
-	See link::Overviews/Operators::
+See link::Overviews/Operators::
 
-	
+
+
+

--- a/SCClassLibrary/Common/Audio/BasicOpsUGen.sc
+++ b/SCClassLibrary/Common/Audio/BasicOpsUGen.sc
@@ -153,6 +153,7 @@ BinaryOpUGen : BasicOpUGen {
 		#a, b = inputs;
 
 		if (b.isKindOf(UnaryOpUGen) and: { b.operator == 'neg' }) {
+			"b".postln;
 			// a + b.neg -> a - b
 			if (b.descendants.size == 1) {
 				buildSynthDef.removeUGen(b);
@@ -163,6 +164,7 @@ BinaryOpUGen : BasicOpUGen {
 		};
 
 		if (a.isKindOf(UnaryOpUGen) and: { a.operator == 'neg' }) {
+			"a".postln;
 			// a.neg + b -> b - a
 			if (a.descendants.size == 1) {
 				buildSynthDef.removeUGen(a);

--- a/SCClassLibrary/Common/Audio/BasicOpsUGen.sc
+++ b/SCClassLibrary/Common/Audio/BasicOpsUGen.sc
@@ -153,7 +153,6 @@ BinaryOpUGen : BasicOpUGen {
 		#a, b = inputs;
 
 		if (b.isKindOf(UnaryOpUGen) and: { b.operator == 'neg' }) {
-			"b".postln;
 			// a + b.neg -> a - b
 			if (b.descendants.size == 1) {
 				buildSynthDef.removeUGen(b);
@@ -164,7 +163,6 @@ BinaryOpUGen : BasicOpUGen {
 		};
 
 		if (a.isKindOf(UnaryOpUGen) and: { a.operator == 'neg' }) {
-			"a".postln;
 			// a.neg + b -> b - a
 			if (a.descendants.size == 1) {
 				buildSynthDef.removeUGen(a);

--- a/SCClassLibrary/Common/Control/Buffer.sc
+++ b/SCClassLibrary/Common/Control/Buffer.sc
@@ -13,10 +13,7 @@ Buffer {
 	// doesn't send
 	*new { arg server, numFrames, numChannels, bufnum;
 		server = server ? Server.default;
-		bufnum ?? { bufnum = server.bufferAllocator.alloc(1) };
-		if(bufnum.isNil) {
-			Error("No more buffer numbers -- free some buffers before allocating more.").throw
-		};
+		bufnum ?? { bufnum = server.nextBufferNumber(1) };
 		^super.newCopyArgs(server,
 						bufnum,
 						numFrames,
@@ -25,10 +22,7 @@ Buffer {
 
 	*alloc { arg server, numFrames, numChannels = 1, completionMessage, bufnum;
 		server = server ? Server.default;
-		bufnum ?? { bufnum = server.bufferAllocator.alloc(1) };
-		if(bufnum.isNil) {
-			Error("No more buffer numbers -- free some buffers before allocating more.").throw
-		};
+		bufnum ?? { bufnum = server.nextBufferNumber(1) };
 		^super.newCopyArgs(server,
 						bufnum,
 						numFrames,
@@ -38,10 +32,7 @@ Buffer {
 
 	*allocConsecutive { arg numBufs = 1, server, numFrames, numChannels = 1, completionMessage, bufnum;
 		var	bufBase, newBuf;
-		bufBase = bufnum ?? { server.bufferAllocator.alloc(numBufs) };
-		if(bufBase.isNil) {
-			Error("No block of % consecutive buffer numbers is available.".format(numBufs)).throw
-		};
+		bufBase = bufnum ?? { server.nextBufferNumber(numBufs) };
 		^Array.fill(numBufs, { |i|
 			newBuf = Buffer.new(server, numFrames, numChannels, i + bufBase);
 			server.sendMsg(\b_alloc, i + bufBase, numFrames, numChannels,
@@ -90,10 +81,7 @@ Buffer {
 	// adds a query as a completion message
 	*read { arg server, path, startFrame = 0, numFrames = -1, action, bufnum;
 		server = server ? Server.default;
-		bufnum ?? { bufnum = server.bufferAllocator.alloc(1) };
-		if(bufnum.isNil) {
-			Error("No more buffer numbers -- free some buffers before allocating more.").throw
-		};
+		bufnum ?? { bufnum = server.nextBufferNumber(1) };
 		^super.newCopyArgs(server, bufnum)
 					.doOnInfo_(action).cache
 					.allocRead(path, startFrame, numFrames, {|buf|["/b_query", buf.bufnum] })
@@ -110,10 +98,7 @@ Buffer {
 
 	*readChannel { arg server, path, startFrame = 0, numFrames = -1, channels, action, bufnum;
 		server = server ? Server.default;
-		bufnum ?? { bufnum = server.bufferAllocator.alloc(1) };
-		if(bufnum.isNil) {
-			Error("No more buffer numbers -- free some buffers before allocating more.").throw
-		};
+		bufnum ?? { bufnum = server.nextBufferNumber(1) };
 		^super.newCopyArgs(server, bufnum)
 					.doOnInfo_(action).cache
 					.allocReadChannel(path, startFrame, numFrames, channels,
@@ -132,10 +117,7 @@ Buffer {
 
 	*readNoUpdate { arg server, path, startFrame = 0, numFrames = -1, bufnum, completionMessage;
 		server = server ? Server.default;
-		bufnum ?? { bufnum = server.bufferAllocator.alloc(1) };
-		if(bufnum.isNil) {
-			Error("No more buffer numbers -- free some buffers before allocating more.").throw
-		};
+		bufnum ?? { bufnum = server.nextBufferNumber(1) };
 		^super.newCopyArgs(server, bufnum).allocRead(path, startFrame, numFrames, completionMessage)
 	}
 
@@ -186,10 +168,7 @@ Buffer {
 	*loadCollection { arg server, collection, numChannels = 1, action;
 		var data, sndfile, path, bufnum, buffer;
 		server = server ? Server.default;
-		bufnum = server.bufferAllocator.alloc(1);
-		if(bufnum.isNil) {
-			Error("No more buffer numbers -- free some buffers before allocating more.").throw
-		};
+		bufnum ?? { bufnum = server.nextBufferNumber(1) };
 		if(server.isLocal, {
 			if(collection.isKindOf(RawArray).not) { collection = collection.as(FloatArray) };
 			sndfile = SoundFile.new;
@@ -654,10 +633,7 @@ Buffer {
 	*loadDialog { arg server, startFrame = 0, numFrames, action, bufnum;
 		var buffer;
 		server = server ? Server.default;
-		bufnum ?? { bufnum = server.bufferAllocator.alloc(1) };
-		if(bufnum.isNil) {
-			Error("No more buffer numbers -- free some buffers before allocating more.").throw
-		};
+		bufnum ?? { bufnum = server.nextBufferNumber(1) };
 		buffer = super.newCopyArgs(server, bufnum).cache;
 		File.openDialog("Select a file...", { arg path;
 			buffer.doOnInfo_(action)

--- a/SCClassLibrary/Common/Control/Buffer.sc
+++ b/SCClassLibrary/Common/Control/Buffer.sc
@@ -359,15 +359,7 @@ Buffer {
 	}
 
 	*freeAll { arg server;
-		var b;
-		server = server ? Server.default;
-		server.bufferAllocator.blocks.do({ arg block;
-			(block.address .. block.address + block.size - 1).do({ |i|
-				b = b.add( ["/b_free", i] );
-			});
-			server.bufferAllocator.free(block.address);
-		});
-		server.sendBundle(nil, *b);
+		(server ? Server.default).freeAllBuffers;
 		this.clearServerCaches(server);
 	}
 

--- a/SCClassLibrary/Common/Control/Recorder.sc
+++ b/SCClassLibrary/Common/Control/Recorder.sc
@@ -9,7 +9,7 @@ Recorder {
 		^super.newCopyArgs(server)
 	}
 
-	record { |path, bus, numChannels|
+	record { |path, bus, numChannels, node|
 		if(server.serverRunning.not) {
 			"server '%' not running".format(server.name).postln;
 			^this
@@ -18,11 +18,11 @@ Recorder {
 			fork {
 				this.prepareForRecord(path, bus, numChannels);
 				server.sync;
-				this.record;
+				this.record(path, bus, numChannels, node)
 			}
 		} {
 			if(this.isRecording.not) {
-				recordNode = Synth.tail(RootNode(server), synthDef.name, [\bufnum, recordBuf]);
+				recordNode = Synth.tail(node ? 0, synthDef.name, [\bufnum, recordBuf]);
 				CmdPeriod.doOnce { this.stopRecording }
 			} {
 				recordNode.run(true)

--- a/SCClassLibrary/Common/Control/Recorder.sc
+++ b/SCClassLibrary/Common/Control/Recorder.sc
@@ -52,7 +52,7 @@ Recorder {
 	pauseRecording {
 		if(recordNode.notNil) {
 			recordNode.run(false);
-			server.changed(\recording, false); // for now
+			server.changed(\recording, false);
 			"... paused recording.\npath: '%'\n".postf(recordBuf.path);
 		} {
 			"Not Recording".warn
@@ -62,6 +62,7 @@ Recorder {
 	resumeRecording {
 		if(recordNode.isPlaying) {
 			recordNode.run(true);
+			server.changed(\recording, true);
 			"Resumed recording ...\npath: '%'\n".postf(recordBuf.path);
 		} {
 			"Not Recording".warn

--- a/SCClassLibrary/Common/Control/Recorder.sc
+++ b/SCClassLibrary/Common/Control/Recorder.sc
@@ -10,10 +10,9 @@ Recorder {
 	}
 
 	record { |path, bus, numChannels, node|
-		if(server.serverRunning.not) {
-			"server '%' not running".format(server.name).postln;
-			^this
-		};
+
+		server.ifNotRunning { ^this };
+
 		if(recordBuf.isNil) {
 			fork {
 				this.prepareForRecord(path, numChannels);

--- a/SCClassLibrary/Common/Control/Recorder.sc
+++ b/SCClassLibrary/Common/Control/Recorder.sc
@@ -35,7 +35,8 @@ Recorder {
 				.postf(bus + (0..numChannels - 1), recordBuf.path);
 			} {
 				this.resumeRecording
-			}
+			};
+			server.changed(\recording, true);
 
 		}
 	}
@@ -51,6 +52,7 @@ Recorder {
 	pauseRecording {
 		if(recordNode.notNil) {
 			recordNode.run(false);
+			server.changed(\recording, false); // for now
 			"... paused recording.\npath: '%'\n".postf(recordBuf.path);
 		} {
 			"Not Recording".warn
@@ -72,6 +74,7 @@ Recorder {
 			recordNode = nil;
 			server.sendMsg("/d_free", synthDef.name);
 			synthDef = nil;
+			server.changed(\recording, false);
 			"Recording stopped, written to\npath: '%'\n".postf(recordBuf.path);
 			if (recordBuf.notNil) {
 				recordBuf.close({ |buf| buf.freeMsg });

--- a/SCClassLibrary/Common/Control/Recorder.sc
+++ b/SCClassLibrary/Common/Control/Recorder.sc
@@ -31,13 +31,8 @@ Recorder {
 				recordNode.register(true);
 				CmdPeriod.add(this);
 				numChannels = this.numChannels;
-				if(numChannels > 1) {
-					"Recording channels % - % ... \npath: '%'\n"
-					.postf(bus, bus + numChannels - 1, recordBuf.path);
-				} {
-					"Recording channel % ... \npath: '%'\n"
-					.postf(bus, recordBuf.path);
-				};
+				"Recording channels % ... \npath: '%'\n"
+				.postf(bus + (0..numChannels - 1), recordBuf.path);
 			} {
 				this.resumeRecording
 			}
@@ -77,7 +72,7 @@ Recorder {
 			recordNode = nil;
 			server.sendMsg("/d_free", synthDef.name);
 			synthDef = nil;
-			"Recording Stopped.\npath: '%'\n".postf(recordBuf.path);
+			"Recording stopped, written to\npath: '%'\n".postf(recordBuf.path);
 			if (recordBuf.notNil) {
 				recordBuf.close({ |buf| buf.freeMsg });
 				recordBuf = nil;

--- a/SCClassLibrary/Common/Control/Recorder.sc
+++ b/SCClassLibrary/Common/Control/Recorder.sc
@@ -1,0 +1,103 @@
+Recorder {
+
+	var <server, <bus, <numChannels;
+	var recordBuf, recordNode;
+
+	*new { |server, bus, numChannels|
+		^super.newCopyArgs(server, bus, numChannels)
+	}
+
+	record { |path|
+		if(server.serverRunning.not) {
+			"server '%' not running".format(server.name).postln;
+			^this
+		};
+		if(recordBuf.isNil) {
+			fork {
+				this.prepareForRecord(path);
+				server.sync;
+				this.record;
+			}
+		} {
+			if(this.isRecording.not) {
+				recordNode = Synth.tail(RootNode(server), 'server-record', [\bufnum, recordBuf.bufnum]);
+				CmdPeriod.doOnce {
+					recordNode = nil;
+					if (recordBuf.notNil) {
+						recordBuf.close {|buf| buf.freeMsg };
+						recordBuf = nil
+					}
+				}
+			} {
+				recordNode.run(true)
+			};
+			"Recording: %\n".postf(recordBuf.path);
+		}
+	}
+
+	isRecording {
+		^recordNode.isPlaying
+	}
+
+	pauseRecording {
+		if(recordNode.notNil) {
+			recordNode.run(false);
+			"Paused".postln
+		} {
+			"Not Recording".warn
+		}
+	}
+
+	stopRecording {
+		if(recordNode.notNil) {
+			recordNode.free;
+			recordNode = nil;
+			recordBuf.close({ |buf| buf.freeMsg });
+			"Recording Stopped: %\n".postf(recordBuf.path);
+			recordBuf = nil;
+		} {
+			"Not Recording".warn
+		}
+	}
+
+	prepareForRecord { | path |
+		var bufSize = server.recBufSize ?? { server.sampleRate.nextPowerOfTwo };
+		var recChannels = numChannels ? server.recChannels;
+		var recHeaderFormat = server.recHeaderFormat;
+		var recSampleFormat = server.recSampleFormat;
+		var bufnum = server.options.numBuffers + 1; // prevent buffer conflicts by using reserved bufnum
+		path = path ?? { this.makePath };
+		recordBuf = Buffer.alloc(server,
+			bufSize,
+			recChannels,
+			{| buf |
+				buf.writeMsg(path, recHeaderFormat, recSampleFormat, 0, 0, true)
+			},
+			bufnum
+		);
+		recordBuf.path = path;
+
+		SynthDef('server-record', { | bufnum |
+			DiskOut.ar(bufnum, In.ar(bus ? 0, recChannels))
+		}).send(server);
+	}
+
+	makePath {
+		var timestamp;
+		var dir = thisProcess.platform.recordingsDir;
+		if(File.exists(dir).not) {
+			thisProcess.platform.recordingsDir.mkdir
+		};
+
+		// temporary kludge to fix Date's brokenness on windows
+		timestamp = if(thisProcess.platform.name == \windows) {
+			Main.elapsedTime.round(0.01)
+		} {
+			Date.localtime.stamp
+		};
+
+		^dir +/+ "SC_" ++ timestamp ++ "." ++ server.recHeaderFormat;
+	}
+
+
+}

--- a/SCClassLibrary/Common/Control/Recorder.sc
+++ b/SCClassLibrary/Common/Control/Recorder.sc
@@ -23,12 +23,18 @@ Recorder {
 		} {
 			if(this.isRecording.not) {
 				recordNode = Synth.tail(node ? 0, synthDef.name, [\bufnum, recordBuf]);
-				CmdPeriod.doOnce { this.stopRecording }
+				recordNode.register(true);
+				CmdPeriod.add(this);
+				"Recording ... \npath: '%'\n".postf(recordBuf.path);
 			} {
-				recordNode.run(true)
-			};
-			"Recording ... \npath: '%'\n".postf(recordBuf.path);
+				this.resumeRecording
+			}
+
 		}
+	}
+
+	cmdPeriod {
+		this.stopRecording
 	}
 
 	isRecording {
@@ -38,7 +44,16 @@ Recorder {
 	pauseRecording {
 		if(recordNode.notNil) {
 			recordNode.run(false);
-			"Paused".postln
+			"... paused recording.\npath: '%'\n".postf(recordBuf.path);
+		} {
+			"Not Recording".warn
+		}
+	}
+
+	resumeRecording {
+		if(recordNode.isPlaying) {
+			recordNode.run(true);
+			"Resumed recording ...\npath: '%'\n".postf(recordBuf.path);
 		} {
 			"Not Recording".warn
 		}
@@ -54,7 +69,8 @@ Recorder {
 			if (recordBuf.notNil) {
 				recordBuf.close({ |buf| buf.freeMsg });
 				recordBuf = nil;
-			}
+			};
+			CmdPeriod.remove(this);
 		} {
 			"Not Recording".warn
 		}

--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -276,9 +276,7 @@ Server {
 	var <nodeAllocator, <controlBusAllocator, <audioBusAllocator, <bufferAllocator, <scopeBufferAllocator;
 
 	var <serverRunning = false, <>serverBooting = false, <unresponsive = false;
-	var <>numUGens=0, <>numSynths=0, <>numGroups=0, <>numSynthDefs=0;
-	var <>avgCPU, <>peakCPU;
-	var <>sampleRate, <>actualSampleRate;
+
 
 	var <syncThread, <syncTasks;
 	var statusWatcher;
@@ -625,6 +623,18 @@ Server {
 		}
 	}
 
+	/* backward compatibility */
+
+	numUGens { ^statusWatcher.numUGens }
+	numSynths { ^statusWatcher.numSynths }
+	numGroups { ^statusWatcher.numGroups }
+	numSynthDefs { ^statusWatcher.numSynthDefs }
+	avgCPU { ^statusWatcher.avgCPU }
+	peakCPU { ^statusWatcher.peakCPU }
+	sampleRate { ^statusWatcher.sampleRate }
+	actualSampleRate { ^statusWatcher.actualSampleRate }
+
+
 	/* server status */
 
 	startAliveThread { | delay=0.0 |
@@ -644,11 +654,7 @@ Server {
 		^statusWatcher.aliveThreadPeriod
 	}
 
-	updateInfoFromOSC { |msg|
-		var cmd, one;
-		#cmd, one, numUGens, numSynths, numGroups, numSynthDefs,
-						avgCPU, peakCPU, sampleRate, actualSampleRate = msg;
-	}
+
 
 	disconnectSharedMemory {
 		if (serverInterface.notNil) {
@@ -978,7 +984,7 @@ Server {
 				path = thisProcess.platform.recordingsDir +/+ "SC_" ++ Date.localtime.stamp ++ "." ++ recHeaderFormat;
 			};
 		};
-		recordBuf = Buffer.alloc(this, recBufSize ?? { sampleRate.nextPowerOfTwo }, recChannels,
+		recordBuf = Buffer.alloc(this, recBufSize ?? { this.sampleRate.nextPowerOfTwo }, recChannels,
 			{arg buf; buf.writeMsg(path, recHeaderFormat, recSampleFormat, 0, 0, true);},
 			this.options.numBuffers + 1); // prevent buffer conflicts by using reserved bufnum
 		recordBuf.path = path;

--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -510,7 +510,6 @@ Server {
 	}
 
 	serverRunning_ { arg val;
-
 		if (val != serverRunning) {
 			serverRunning = val;
 			unresponsive = false;
@@ -532,9 +531,9 @@ Server {
 					notified = false;
 				};
 			};
-			this.changed(\serverRunning)
-			//{ this.changed(\serverRunning) }.defer;
-		}
+			{ this.changed(\serverRunning) }.defer;
+		};
+
 	}
 
 	updateRunningState { arg val;
@@ -542,7 +541,7 @@ Server {
 			{ this.changed(\bundling) }.defer;
 		} {
 			if(val) {
-				serverRunning = true;
+				this.serverRunning = true;
 				this.unresponsive = false;
 				reallyDeadCount = this.options.pingsBeforeConsideredDead;
 			} {
@@ -555,7 +554,6 @@ Server {
 	unresponsive_ { arg val;
 		if (val != unresponsive) {
 			unresponsive = val;
-			this.changed(\serverRunning)
 			{ this.changed(\serverRunning) }.defer;
 		}
 	}

--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -409,7 +409,7 @@ Server {
 		if(clientID > (options.maxLogins - 1)) {
 			"Client ID exceeds maxLogins. Some buses and buffers may overlap for remote server: %".format(this).warn;
 		};
-		^clientID % options.maxLogins;
+		^clientID % options.maxLogins
 	}
 
 	newScopeBufferAllocators {

--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -721,9 +721,11 @@ Server {
 
 	connectSharedMemory {
 		var id;
-		this.disconnectSharedMemory;
-		id = if(this.inProcess) { thisProcess.pid } { addr.port };
-		serverInterface = ServerShmInterface(id);
+		if(this.isLocal) {
+			this.disconnectSharedMemory;
+			id = if(this.inProcess) { thisProcess.pid } { addr.port };
+			serverInterface = ServerShmInterface(id);
+		}
 	}
 
 	hasShmInterface { ^serverInterface.notNil }

--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -261,7 +261,7 @@ Server {
 	classvar <>local, <>internal, <default;
 	classvar <>named, <>all, <>program, <>sync_s = true;
 
-	var <name, <addr, <clientID, userSpecifiedClientID = false;
+	var <name, <addr, <clientID, <userSpecifiedClientID = false;
 	var <isLocal, <inProcess, <>sendQuit, <>remoteControlled;
 
 	var <>options, <>latency = 0.2, <dumpMode = 0;

--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -858,8 +858,9 @@ Server {
 		this.changed(\dumpOSC, code);
 	}
 
-	quit {
+	quit { |watchShutDown = true|
 		var	serverReallyQuitWatcher, serverReallyQuit = false;
+		if(watchShutDown.not) { statusWatcher.disable; statusWatcher = nil };
 		statusWatcher !? {
 			statusWatcher.disable;
 			if(notified) {
@@ -872,10 +873,11 @@ Server {
 						serverReallyQuitWatcher.free;
 					};
 				}, '/done', addr);
-				// don't accumulate quit-watchers if /done doesn't come back
+
 				AppClock.sched(3.0, {
 					if(serverReallyQuit.not) {
 						"Server % failed to quit after 3.0 seconds.".format(this.name).warn;
+						// don't accumulate quit-watchers if /done doesn't come back
 						serverReallyQuitWatcher.free;
 					};
 				});
@@ -904,10 +906,10 @@ Server {
 		this.newAllocators;
 	}
 
-	*quitAll {
+	*quitAll { |watchShutDown = true|
 		set.do({ arg server;
 			if (server.sendQuit === true) {
-				server.quit
+				server.quit(watchShutDown)
 			};
 		})
 	}
@@ -919,7 +921,7 @@ Server {
 
 		// this brutally kills them all off
 		thisProcess.platform.killAll(this.program.basename);
-		this.quitAll;
+		this.quitAll(false);
 	}
 	freeAll {
 		this.sendMsg("/g_freeAll", 0);

--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -275,7 +275,7 @@ Server {
 
 	var <nodeAllocator, <controlBusAllocator, <audioBusAllocator, <bufferAllocator, <scopeBufferAllocator;
 
-	var <>serverRunning = false, <>serverBooting = false, <>unresponsive = false;
+	var <serverRunning = false, <>serverBooting = false, <unresponsive = false;
 	var <>numUGens=0, <>numSynths=0, <>numGroups=0, <>numSynthDefs=0;
 	var <>avgCPU, <>peakCPU;
 	var <>sampleRate, <>actualSampleRate;
@@ -605,6 +605,20 @@ Server {
 		^Bus(\audio, 0, this.options.numOutputBusChannels, this);
 	}
 
+	serverRunning_ { arg val;
+		if (val != serverRunning) {
+			serverRunning = val;
+			{ this.changed(\serverRunning) }.defer;
+		}
+	}
+
+	unresponsive_ { arg val;
+		if (val != unresponsive) {
+			unresponsive = val;
+			{ this.changed(\serverRunning) }.defer;
+		}
+	}
+
 	/* server status */
 
 	startAliveThread {
@@ -781,7 +795,7 @@ Server {
 		pid = nil;
 		serverBooting = false;
 		sendQuit = nil;
-		this.serverRunning = false;
+		serverStatus.serverRunning = false;
 		if(scopeWindow.notNil) { scopeWindow.quit };
 		if(volume.isPlaying) {
 			volume.free
@@ -907,7 +921,7 @@ Server {
 				this.record;
 			}).play;
 		}{
-			if(recordNode.isNil){
+			if(this.isRecording) {
 				recordNode = Synth.tail(RootNode(this), "server-record",
 						[\bufnum, recordBuf.bufnum]);
 				CmdPeriod.doOnce {
@@ -919,6 +933,10 @@ Server {
 			};
 			"Recording: %\n".postf(recordBuf.path);
 		};
+	}
+
+	isRecording {
+		^recordNode.isNil
 	}
 
 	pauseRecording {

--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -746,6 +746,9 @@ Server {
 	notify {
 		^serverStatus.notify
 	}
+	notify_ { |flag|
+		serverStatus.notify(flag)
+	}
 	notified {
 		^serverStatus.notified
 	}

--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -422,6 +422,17 @@ Server {
 		^bufnum
 	}
 
+	freeAllBuffers {
+		var bundle;
+		bufferAllocator.blocks.do { arg block;
+			(block.address .. block.address + block.size - 1).do { |i|
+				bundle = bundle.add( ["/b_free", i] );
+			};
+			bufferAllocator.free(block.address);
+		};
+		this.sendBundle(nil, *bundle);
+	}
+
 	nextNodeID {
 		^nodeAllocator.alloc
 	}

--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -261,7 +261,7 @@ Server {
 	classvar <>local, <>internal, <default;
 	classvar <>named, <>all, <>program, <>sync_s = true;
 
-	var <name, <>addr, <clientID, userSpecifiedClientID = false;
+	var <name, <addr, <clientID, userSpecifiedClientID = false;
 	var <isLocal, <inProcess, <>sendQuit, <>remoteControlled;
 
 	var <>options, <>latency = 0.2, <dumpMode = 0;
@@ -309,22 +309,31 @@ Server {
 	}
 
 	init { |argName, argAddr, argOptions, argClientID|
+
 		name = argName.asSymbol;
-		addr = argAddr;
-		if(argClientID.notNil) { userSpecifiedClientID = true };
-		clientID = argClientID ? 0;
+		this.addr = argAddr;
 		options = argOptions ? ServerOptions.new;
-		if(addr.isNil) { addr = NetAddr("127.0.0.1", 57110) };
+		clientID = argClientID ? 0;
+		if(argClientID.notNil) { userSpecifiedClientID = true };
+
+		this.newAllocators;
+
+		statusWatcher = ServerStatusWatcher(server: this);
+		volume = Volume(server: this, persist: true);
+		recorder = Recorder(server: this);
+
+
+		all.add(this);
+		named.put(name, this);
+		Server.changed(\serverAdded, this);
+
+	}
+
+	addr_ { |netAddr|
+		addr = netAddr ?? { NetAddr("127.0.0.1", 57110) };
 		inProcess = addr.addr == 0;
 		isLocal = inProcess || { addr.isLocal };
 		remoteControlled = isLocal;
-		statusWatcher = ServerStatusWatcher(this);
-		named.put(name, this);
-		all.add(this);
-		this.newAllocators;
-		Server.changed(\serverAdded, this);
-		volume = Volume(server: this, persist: true);
-		recorder = Recorder(this);
 	}
 
 	initTree {

--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -579,7 +579,7 @@ Server {
 	}
 
 
-	/* backward compatibility */
+	/* server status */
 
 	numUGens { ^statusWatcher.numUGens }
 	numSynths { ^statusWatcher.numSynths }
@@ -592,9 +592,6 @@ Server {
 	serverRunning { ^statusWatcher.serverRunning }
 	serverBooting { ^statusWatcher.serverBooting }
 	unresponsive { ^statusWatcher.unresponsive }
-
-
-	/* server status */
 
 	startAliveThread { | delay=0.0 |
 		statusWatcher.startAliveThread(delay)
@@ -726,7 +723,7 @@ Server {
 		^statusWatcher.notify
 	}
 	notify_ { |flag|
-		statusWatcher.notify(flag)
+		statusWatcher.notify_(flag)
 	}
 	notified {
 		^statusWatcher.notified

--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -3,10 +3,10 @@ ServerOptions
 	// order of variables is important here. Only add new instance variables to the end.
 
 	var <numAudioBusChannels = 128;
-	var <>numControlBusChannels = 4096;
 	var <numInputBusChannels = 2;
 	var <numOutputBusChannels = 2;
-	var numBuffers = 1026;
+	var <>numControlBusChannels = 4096;
+	var <>numBuffers = 1026;
 
 	var <>maxNodes = 1024;
 	var <>maxSynthDefs = 1024;
@@ -65,17 +65,6 @@ ServerOptions
 
 	device_ { |dev|
 		inDevice = outDevice = dev;
-	}
-
-	// prevent buffer conflicts in Server-prepareForRecord and Server-scope
-	// by ensuring reserved buffers:
-
-	numBuffers {
-		^numBuffers - 2
-	}
-
-	numBuffers_ { | argNumBuffers |
-		numBuffers = argNumBuffers + 2
 	}
 
 	asOptionsString { | port = 57110 |
@@ -885,11 +874,11 @@ Server {
 
 	/* recording output */
 
-	record { |path| recorder.record(path) }
+	record { |path, bus, numChannels| recorder.record(path, bus, numChannels) }
 	isRecording { ^recorder.isRecording }
 	pauseRecording { recorder.pauseRecording }
 	stopRecording { recorder.stopRecording }
-	prepareForRecord { |path| recorder.prepareForRecord(path) }
+	prepareForRecord { |path, bus, numChannels| recorder.prepareForRecord(path, bus, numChannels) }
 
 	recordNode {
 		this.deprecated(thisMethod);

--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -738,7 +738,6 @@ Server {
 
 		if(startAliveThread) { statusWatcher.startAliveThread };
 
-		statusWatcher.bootNotifyFirst = true; // unclear what this means.
 		statusWatcher.doWhenBooted({
 			statusWatcher.serverBooting = false;
 			this.bootInit(recover);

--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -796,6 +796,10 @@ Server {
 		}
 	}
 
+	applicationRunning {
+		^pid.tryPerform(\pidRunning) == true
+	}
+
 	status {
 		addr.sendStatusMsg // backward compatibility
 	}

--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -42,6 +42,10 @@ ServerOptions
 
 	var <numPrivateAudioBusChannels = 112;
 
+	var <>reservedNumAudioBusChannels = 0;
+	var <>reservedNumControlBusChannels = 0;
+	var <>reservedNumBuffers = 0;
+
 	var <>pingsBeforeConsideredDead = 5;
 
 	var <>maxLogins = 1;
@@ -341,6 +345,10 @@ Server {
 		ServerTree.run(this);
 	}
 
+
+
+	/* id allocators */
+
 	clientID_ { |val|
 		if(val.notNil and: { clientID != val }) {
 			clientID = val;
@@ -369,8 +377,8 @@ Server {
 		numControl = options.numControlBusChannels div: n;
 		numAudio = options.numAudioBusChannels div: n;
 
-		controlBusOffset = numControl * offset;
-		audioBusOffset = options.firstPrivateBus + (numAudio * offset);
+		controlBusOffset = numControl * offset + options.reservedNumControlBusChannels;
+		audioBusOffset = options.firstPrivateBus + (numAudio * offset) + options.reservedNumAudioBusChannels;
 
 		controlBusAllocator =
 		ContiguousBlockAllocator.new(numControl, controlBusOffset);
@@ -380,15 +388,12 @@ Server {
 	}
 
 
-
-	/* node ids */
-
 	newBufferAllocators {
 		var bufferOffset;
 		var offset = this.calcOffset;
 		var n = options.maxLogins ? 1;
 		var numBuffers = options.numBuffers div: n;
-		bufferOffset = numBuffers * offset;
+		bufferOffset = numBuffers * offset + options.reservedNumBuffers;
 		bufferAllocator =
 		ContiguousBlockAllocator.new(numBuffers, bufferOffset);
 	}

--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -268,7 +268,7 @@ ServerShmInterface {
 Server {
 	classvar <>local, <>internal, <default, <>named, <>set, <>program, <>sync_s = true;
 
-	var <name, <>addr, <>clientID, userSpecifiedClientID = false;
+	var <name, <>addr, <clientID, userSpecifiedClientID = false;
 	var <isLocal, <inProcess, <>sendQuit, <>remoteControlled;
 
 	var <>options, <>latency = 0.2, <dumpMode = 0;
@@ -342,6 +342,12 @@ Server {
 		this.sendMsg("/g_new", 1, 0, 0);
 		tree.value(this);
 		ServerTree.run(this);
+	}
+	clientID_ { |val|
+		if(val.notNil and: { clientID != val }) {
+			clientID = val;
+			this.newAllocators;
+		}
 	}
 	newAllocators {
 		this.newNodeAllocators;
@@ -621,8 +627,8 @@ Server {
 
 	/* server status */
 
-	startAliveThread {
-		serverStatus.startAliveThread
+	startAliveThread { | delay=0.0 |
+		serverStatus.startAliveThread(delay)
 	}
 	stopAliveThread {
 		serverStatus.stopAliveThread
@@ -781,21 +787,24 @@ Server {
 	}
 
 	quit { |watchShutDown = true|
-		if(watchShutDown) { serverStatus.watchQuit } { serverStatus.stopStatusWatcher };
+
 		addr.sendMsg("/quit");
+
+		serverStatus.quit(watchShutDown);
+
 		if( options.protocol == \tcp ){ fork{ 0.1.wait; addr.disconnect } }; // sure? can we receive the above reply?
-		serverStatus.stopAliveThread;
+
 		if (inProcess, {
 			this.quitInProcess;
 			"quit done\n".inform;
 		},{
 			"/quit sent\n".inform;
 		});
-		serverStatus.notified = false;
+
 		pid = nil;
 		serverBooting = false;
 		sendQuit = nil;
-		serverStatus.serverRunning = false;
+
 		if(scopeWindow.notNil) { scopeWindow.quit };
 		if(volume.isPlaying) {
 			volume.free
@@ -936,7 +945,7 @@ Server {
 	}
 
 	isRecording {
-		^recordNode.isNil
+		^recordNode.isPlaying
 	}
 
 	pauseRecording {

--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -787,6 +787,10 @@ Server {
 	}
 
 	status {
+		addr.sendStatusMsg // backward compatibility
+	}
+
+	sendStatusMsg {
 		addr.sendStatusMsg
 	}
 

--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -874,7 +874,7 @@ Server {
 
 	/* recording output */
 
-	record { |path, bus, numChannels| recorder.record(path, bus, numChannels) }
+	record { |path, bus, numChannels, node| recorder.record(path, bus, numChannels, node) }
 	isRecording { ^recorder.isRecording }
 	pauseRecording { recorder.pauseRecording }
 	stopRecording { recorder.stopRecording }

--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -878,7 +878,7 @@ Server {
 	isRecording { ^recorder.isRecording }
 	pauseRecording { recorder.pauseRecording }
 	stopRecording { recorder.stopRecording }
-	prepareForRecord { |path, bus, numChannels| recorder.prepareForRecord(path, bus, numChannels) }
+	prepareForRecord { |path, numChannels| recorder.prepareForRecord(path, numChannels) }
 
 	recordNode {
 		this.deprecated(thisMethod);

--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -758,7 +758,7 @@ Server {
 				this.wait(\done);
 				0.1.wait;
 				func.value;
-				this.boot;
+				defer { this.boot }
 			}
 		} {
 			func.value;

--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -284,10 +284,10 @@ Server {
 	var recordBuf, <recordNode, <>recHeaderFormat="aiff", <>recSampleFormat="float";
 	var <>recChannels=2, <>recBufSize;
 
-	var <volume;
+	var <volume, <statusWatcher;
 
 	var <pid;
-	var serverInterface, statusWatcher;
+	var serverInterface;
 
 
 	*default_ { |server|
@@ -624,12 +624,8 @@ Server {
 	}
 
 
-
 	*resumeThreads {
-		set.do({ arg server;
-			server.stopAliveThread;
-			server.startAliveThread(server.aliveThreadPeriod);
-		});
+		set.do { |server| server.statusWatcher.resumeThread }
 	}
 
 	boot { | startAliveThread=true, recover=false, onFailure |

--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -281,7 +281,7 @@ Server {
 	var <>sampleRate, <>actualSampleRate;
 
 	var <syncThread, <syncTasks;
-	var serverStatus;
+	var statusWatcher;
 
 	var <>tree;
 
@@ -328,7 +328,7 @@ Server {
 		inProcess = addr.addr == 0;
 		isLocal = inProcess || { addr.isLocal };
 		remoteControlled = isLocal;
-		serverStatus = ServerStatus(this);
+		statusWatcher = ServerStatusWatcher(this);
 		serverRunning = false;
 		named.put(name, this);
 		set.add(this);
@@ -628,20 +628,20 @@ Server {
 	/* server status */
 
 	startAliveThread { | delay=0.0 |
-		serverStatus.startAliveThread(delay)
+		statusWatcher.startAliveThread(delay)
 	}
 	stopAliveThread {
-		serverStatus.stopAliveThread
+		statusWatcher.stopAliveThread
 	}
 	aliveThreadIsRunning {
-		^serverStatus.aliveThreadIsRunning
+		^statusWatcher.aliveThreadIsRunning
 	}
 
 	aliveThreadPeriod_ { |val|
-		serverStatus.aliveThreadPeriod_(val)
+		statusWatcher.aliveThreadPeriod_(val)
 	}
 	aliveThreadPeriod { |val|
-		^serverStatus.aliveThreadPeriod
+		^statusWatcher.aliveThreadPeriod
 	}
 
 	updateInfoFromOSC { |msg|
@@ -673,7 +673,7 @@ Server {
 
 		serverBooting = true;
 
-		if(startAliveThread, { serverStatus.startAliveThread });
+		if(startAliveThread, { statusWatcher.startAliveThread });
 		if(recover) { this.newNodeAllocators } { this.newAllocators };
 
 		bootNotifyFirst = true;
@@ -764,13 +764,13 @@ Server {
 	}
 
 	notify {
-		^serverStatus.notify
+		^statusWatcher.notify
 	}
 	notify_ { |flag|
-		serverStatus.notify(flag)
+		statusWatcher.notify(flag)
 	}
 	notified {
-		^serverStatus.notified
+		^statusWatcher.notified
 	}
 
 
@@ -790,7 +790,7 @@ Server {
 
 		addr.sendMsg("/quit");
 
-		serverStatus.quit(watchShutDown);
+		statusWatcher.quit(watchShutDown);
 
 		if( options.protocol == \tcp ){ fork{ 0.1.wait; addr.disconnect } }; // sure? can we receive the above reply?
 

--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -275,11 +275,7 @@ Server {
 
 	var <nodeAllocator, <controlBusAllocator, <audioBusAllocator, <bufferAllocator, <scopeBufferAllocator;
 
-	var <serverRunning = false, <>serverBooting = false, <unresponsive = false;
-
-
 	var <syncThread, <syncTasks;
-	var statusWatcher;
 
 	var <>tree;
 
@@ -291,9 +287,7 @@ Server {
 	var <volume;
 
 	var <pid;
-	var serverInterface;
-
-	var bootNotifyFirst; // ??
+	var serverInterface, statusWatcher;
 
 
 	*default_ { |server|
@@ -327,7 +321,6 @@ Server {
 		isLocal = inProcess || { addr.isLocal };
 		remoteControlled = isLocal;
 		statusWatcher = ServerStatusWatcher(this);
-		serverRunning = false;
 		named.put(name, this);
 		set.add(this);
 		this.newAllocators;
@@ -530,36 +523,12 @@ Server {
 		// doWhenBooted prints the normal boot failure message.
 		// if the server fails to boot, the failure error gets posted TWICE.
 		// So, we suppress one of them.
-		if(serverRunning.not) { this.boot(onFailure: true) };
+		if(this.serverRunning.not) { this.boot(onFailure: true) };
 		this.doWhenBooted(onComplete, limit, onFailure);
 	}
 
 	doWhenBooted { arg onComplete, limit=100, onFailure;
-		var mBootNotifyFirst = bootNotifyFirst, postError = true;
-		bootNotifyFirst = false;
-
-		^Routine({
-			while({
-				((serverRunning.not
-					or: (serverBooting and: mBootNotifyFirst.not))
-				and: {(limit = limit - 1) > 0})
-				and: { pid.tryPerform(\pidRunning) == true }
-			},{
-				0.2.wait;
-			});
-
-			if(serverRunning.not,{
-				if(onFailure.notNil) {
-					postError = (onFailure.value == false);
-				};
-				if(postError) {
-					"server failed to start".error;
-					"For advice: [http://supercollider.sf.net/wiki/index.php/ERROR:_server_failed_to_start]".postln;
-				};
-				serverBooting = false;
-				this.changed(\serverRunning);
-			}, onComplete);
-		}).play(AppClock);
+		statusWatcher.doWhenBooted(onComplete, limit, onFailure)
 	}
 
 
@@ -576,7 +545,7 @@ Server {
 
 	ping { arg n=1, wait=0.1, func;
 		var result=0, pingFunc;
-		if(serverRunning.not) { "server not running".postln; ^this };
+		if(statusWatcher.serverRunning.not) { "server not running".postln; ^this };
 		pingFunc = {
 			Routine.run {
 					var t, dt;
@@ -609,19 +578,6 @@ Server {
 		^Bus(\audio, 0, this.options.numOutputBusChannels, this);
 	}
 
-	serverRunning_ { arg val;
-		if (val != serverRunning) {
-			serverRunning = val;
-			{ this.changed(\serverRunning) }.defer;
-		}
-	}
-
-	unresponsive_ { arg val;
-		if (val != unresponsive) {
-			unresponsive = val;
-			{ this.changed(\serverRunning) }.defer;
-		}
-	}
 
 	/* backward compatibility */
 
@@ -633,6 +589,9 @@ Server {
 	peakCPU { ^statusWatcher.peakCPU }
 	sampleRate { ^statusWatcher.sampleRate }
 	actualSampleRate { ^statusWatcher.actualSampleRate }
+	serverRunning { ^statusWatcher.serverRunning }
+	serverBooting { ^statusWatcher.serverBooting }
+	unresponsive { ^statusWatcher.unresponsive }
 
 
 	/* server status */
@@ -644,7 +603,7 @@ Server {
 		statusWatcher.stopAliveThread
 	}
 	aliveThreadIsRunning {
-		^statusWatcher.aliveThreadIsRunning
+		^statusWatcher.aliveThread.isPlaying
 	}
 
 	aliveThreadPeriod_ { |val|
@@ -673,42 +632,44 @@ Server {
 		});
 	}
 
-	boot { arg startAliveThread=true, recover=false, onFailure;
-		if (serverRunning, { "server already running".inform; ^this });
-		if (serverBooting, { "server already booting".inform; ^this });
+	boot { | startAliveThread=true, recover=false, onFailure |
 
-		serverBooting = true;
+		if (statusWatcher.serverRunning) { "server already running".inform; ^this };
+		if (statusWatcher.serverBooting) { "server already booting".inform; ^this };
 
-		if(startAliveThread, { statusWatcher.startAliveThread });
+		statusWatcher.serverBooting = true;
+
+		if(startAliveThread) { statusWatcher.startAliveThread };
 		if(recover) { this.newNodeAllocators } { this.newAllocators };
 
-		bootNotifyFirst = true;
-		this.doWhenBooted({
-			serverBooting = false;
+		statusWatcher.bootNotifyFirst = true; // unclear what this means.
+		statusWatcher.doWhenBooted({
+			statusWatcher.serverBooting = false;
 			if (recChannels.notNil and: (recChannels != options.numOutputBusChannels)) {
 				"Resetting recChannels to %".format(options.numOutputBusChannels).inform
 			};
 			recChannels = options.numOutputBusChannels;
 
-			if (sendQuit.isNil) {
+			if(sendQuit.isNil) {
 				sendQuit = this.inProcess or: {this.isLocal};
 			};
 
-			if (this.inProcess) {
+			if(this.inProcess) {
 				serverInterface = ServerShmInterface(thisProcess.pid);
 			} {
-				if (isLocal) {
+				if(isLocal) {
 					serverInterface = ServerShmInterface(addr.port);
 				}
 			};
 			if(dumpMode != 0) { this.sendMsg(\dumpOSC, dumpMode) };
 			this.initTree;
 		}, onFailure: onFailure ? false);
-		if (remoteControlled.not, {
+
+		if(remoteControlled.not) {
 			"You will have to manually boot remote server.".inform;
-		},{
+		} {
 			this.bootServerApp;
-		});
+		}
 	}
 
 	bootServerApp {
@@ -718,11 +679,7 @@ Server {
 			this.bootInProcess;
 			pid = thisProcess.pid;
 		} {
-			if (serverInterface.notNil) {
-				serverInterface.disconnect;
-				serverInterface = nil;
-				"server disconnected shared memory interface".postln;
-			};
+			this.disconnectSharedMemory;
 
 			pid = (program ++ options.asOptionsString(addr.port)).unixCmd;
 			if( options.protocol == \tcp ){
@@ -751,7 +708,7 @@ Server {
 
 	reboot { arg func; // func is evaluated when server is off
 		if (isLocal.not) { "can't reboot a remote server".inform; ^this };
-		if(serverRunning) {
+		if(statusWatcher.serverRunning) {
 			Routine.run {
 				this.quit;
 				this.wait(\done);
@@ -808,7 +765,6 @@ Server {
 		});
 
 		pid = nil;
-		serverBooting = false;
 		sendQuit = nil;
 
 		if(scopeWindow.notNil) { scopeWindow.quit };
@@ -929,14 +885,14 @@ Server {
 
 	// recording output
 	record { |path|
-		if(recordBuf.isNil){
+		if(recordBuf.isNil) {
 			this.prepareForRecord(path);
 			Routine({
 				this.sync;
 				this.record;
 			}).play;
-		}{
-			if(this.isRecording) {
+		} {
+			if(this.isRecording.not) {
 				recordNode = Synth.tail(RootNode(this), "server-record",
 						[\bufnum, recordBuf.bufnum]);
 				CmdPeriod.doOnce {

--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -310,7 +310,6 @@ Server {
 
 	init { |argName, argAddr, argOptions, argClientID|
 
-		name = argName.asSymbol;
 		this.addr = argAddr;
 		options = argOptions ? ServerOptions.new;
 		clientID = argClientID ? 0;
@@ -322,9 +321,9 @@ Server {
 		volume = Volume(server: this, persist: true);
 		recorder = Recorder(server: this);
 
-
+		this.name = argName;
 		all.add(this);
-		named.put(name, this);
+
 		Server.changed(\serverAdded, this);
 
 	}
@@ -334,6 +333,15 @@ Server {
 		inProcess = addr.addr == 0;
 		isLocal = inProcess || { addr.isLocal };
 		remoteControlled = isLocal;
+	}
+
+	name_ { |argName|
+		name = argName.asSymbol;
+		if(named.at(argName).notNil) {
+			"Server name already exists: '%'. Please use a unique name".format(name, argName).warn;
+		} {
+			named.put(name, this);
+		}
 	}
 
 	initTree {

--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -410,6 +410,18 @@ Server {
 		}
 	}
 
+	nextBufferNumber { |n|
+		var bufnum = bufferAllocator.alloc(n);
+		if(bufnum.isNil) {
+			if(n > 1) {
+				Error("No block of % consecutive buffer numbers is available.".format(n)).throw
+			} {
+				Error("No more buffer numbers -- free some buffers before allocating more.").throw
+			}
+		};
+		^bufnum
+	}
+
 	nextNodeID {
 		^nodeAllocator.alloc
 	}

--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -1,14 +1,15 @@
 ServerOptions
 {
 	// order of variables is important here. Only add new instance variables to the end.
-	var <numAudioBusChannels=128;
-	var <>numControlBusChannels=4096;
-	var <numInputBusChannels=2;
-	var <numOutputBusChannels=2;
+
+	var <numAudioBusChannels = 128;
+	var <>numControlBusChannels = 4096;
+	var <numInputBusChannels = 2;
+	var <numOutputBusChannels = 2;
 	var numBuffers=1026;
 
-	var <>maxNodes=1024;
-	var <>maxSynthDefs=1024;
+	var <>maxNodes = 1024;
+	var <>maxSynthDefs = 1024;
 	var <>protocol = \udp;
 	var <>blockSize = 64;
 	var <>hardwareBufferSize = nil;
@@ -39,7 +40,7 @@ ServerOptions
 	var <>threads = nil; // for supernova
 	var <>useSystemClock = false;  // for supernova
 
-	var <numPrivateAudioBusChannels=112;
+	var <numPrivateAudioBusChannels = 112;
 
 	var <>pingsBeforeConsideredDead = 5;
 
@@ -62,11 +63,8 @@ ServerOptions
 		inDevice = outDevice = dev;
 	}
 
-	// max logins
-	// session-password
-
-	// prevent buffer conflicts in Server-prepareForRecord and Server-scope by
-	// ensuring reserved buffers
+	// prevent buffer conflicts in Server-prepareForRecord and Server-scope
+	// by ensuring reserved buffers:
 
 	numBuffers {
 		^numBuffers - 2
@@ -78,96 +76,93 @@ ServerOptions
 
 	asOptionsString { | port = 57110 |
 		var o;
-		o = if (protocol == \tcp, " -t ", " -u ");
+		o = if(protocol == \tcp, " -t ", " -u ");
 		o = o ++ port;
 
-		o = o ++ " -a " ++ (numPrivateAudioBusChannels + numInputBusChannels + numOutputBusChannels) ;
+		o = o ++ " -a " ++ (numPrivateAudioBusChannels + numInputBusChannels + numOutputBusChannels);
 
-		if (numControlBusChannels != 4096, {
-			o = o ++ " -c " ++ numControlBusChannels;
-		});
-		if (numInputBusChannels != 8, {
-			o = o ++ " -i " ++ numInputBusChannels;
-		});
-		if (numOutputBusChannels != 8, {
-			o = o ++ " -o " ++ numOutputBusChannels;
-		});
-		if (numBuffers != 1024, {
-			o = o ++ " -b " ++ numBuffers;
-		});
-		if (maxNodes != 1024, {
-			o = o ++ " -n " ++ maxNodes;
-		});
-		if (maxSynthDefs != 1024, {
-			o = o ++ " -d " ++ maxSynthDefs;
-		});
-		if (blockSize != 64, {
-			o = o ++ " -z " ++ blockSize;
-		});
-		if (hardwareBufferSize.notNil, {
-			o = o ++ " -Z " ++ hardwareBufferSize;
-		});
-		if (memSize != 8192, {
-			o = o ++ " -m " ++ memSize;
-		});
-		if (numRGens != 64, {
-			o = o ++ " -r " ++ numRGens;
-		});
-		if (numWireBufs != 64, {
-			o = o ++ " -w " ++ numWireBufs;
-		});
-		if (sampleRate.notNil, {
-			o = o ++ " -S " ++ sampleRate;
-		});
-		if (loadDefs.not, {
-			o = o ++ " -D 0";
-		});
-		if (inputStreamsEnabled.notNil, {
-			o = o ++ " -I " ++ inputStreamsEnabled ;
-		});
-		if (outputStreamsEnabled.notNil, {
-			o = o ++ " -O " ++ outputStreamsEnabled ;
-		});
-		if ((thisProcess.platform.name!=\osx) or: {inDevice == outDevice})
-		{
-			if (inDevice.notNil,
-			{
-				o = o ++ " -H %".format(inDevice.quote);
-			});
-		}
-		{
-			o = o ++ " -H % %".format(inDevice.asString.quote, outDevice.asString.quote);
+		if(numControlBusChannels != 4096) {
+			o = o ++ " -c " ++ numControlBusChannels
 		};
-		if (verbosity != 0, {
-			o = o ++ " -v " ++ verbosity;
-		});
-		if (zeroConf.not, {
-			o = o ++ " -R 0";
-		});
-		if (restrictedPath.notNil, {
-			o = o ++ " -P " ++ restrictedPath;
-		});
-		if (ugenPluginsPath.notNil, {
+		if(numInputBusChannels != 8) {
+			o = o ++ " -i " ++ numInputBusChannels
+		};
+		if(numOutputBusChannels != 8) {
+			o = o ++ " -o " ++ numOutputBusChannels
+		};
+		if(numBuffers != 1024) {
+			o = o ++ " -b " ++ numBuffers
+		};
+		if(maxNodes != 1024) {
+			o = o ++ " -n " ++ maxNodes
+		};
+		if(maxSynthDefs != 1024) {
+			o = o ++ " -d " ++ maxSynthDefs
+		};
+		if(blockSize != 64) {
+			o = o ++ " -z " ++ blockSize
+		};
+		if(hardwareBufferSize.notNil) {
+			o = o ++ " -Z " ++ hardwareBufferSize
+		};
+		if(memSize != 8192) {
+			o = o ++ " -m " ++ memSize
+		};
+		if(numRGens != 64) {
+			o = o ++ " -r " ++ numRGens
+		};
+		if(numWireBufs != 64) {
+			o = o ++ " -w " ++ numWireBufs
+		};
+		if(sampleRate.notNil) {
+			o = o ++ " -S " ++ sampleRate
+		};
+		if(loadDefs.not) {
+			o = o ++ " -D 0";
+		};
+		if(inputStreamsEnabled.notNil) {
+			o = o ++ " -I " ++ inputStreamsEnabled
+		};
+		if(outputStreamsEnabled.notNil) {
+			o = o ++ " -O " ++ outputStreamsEnabled
+		};
+		if((thisProcess.platform.name!=\osx) or: { inDevice == outDevice } ) {
+			if(inDevice.notNil) {
+				o = o ++ " -H %".format(inDevice.quote)
+			}
+		} {
+			o = o ++ " -H % %".format(inDevice.asString.quote, outDevice.asString.quote)
+		};
+		if(verbosity != 0) {
+			o = o ++ " -v " ++ verbosity
+		};
+		if(zeroConf.not) {
+			o = o ++ " -R 0"
+		};
+		if(restrictedPath.notNil) {
+			o = o ++ " -P " ++ restrictedPath
+		};
+		if(ugenPluginsPath.notNil) {
 			o = o ++ " -U " ++ if(ugenPluginsPath.isString) {
 				ugenPluginsPath
 			} {
-				ugenPluginsPath.join("; ");
-			};
-		});
-		if (memoryLocking, {
-			o = o ++ " -L";
-		});
-		if (threads.notNil, {
-			if (Server.program.asString.endsWith("supernova")) {
-				o = o ++ " -T " ++ threads;
+				ugenPluginsPath.join("; ")
 			}
-		});
-		if (useSystemClock.notNil, {
+		};
+		if(memoryLocking) {
+			o = o ++ " -L"
+		};
+		if(threads.notNil) {
+			if(Server.program.asString.endsWith("supernova")) {
+				o = o ++ " -T " ++ threads
+			}
+		};
+		if(useSystemClock.notNil) {
 			o = o ++ " -C " ++ useSystemClock.asInteger
-		});
-		if (maxLogins.notNil, {
-			o = o ++ " -l " ++ maxLogins;
-		});
+		};
+		if(maxLogins.notNil) {
+			o = o ++ " -l " ++ maxLogins
+		};
 		^o
 	}
 
@@ -185,17 +180,17 @@ ServerOptions
 		this.recalcChannels;
 	}
 
-	numAudioBusChannels_ { |numChannels=128|
+	numAudioBusChannels_ { |numChannels = 128|
 		numAudioBusChannels = numChannels;
 		numPrivateAudioBusChannels = numAudioBusChannels - numInputBusChannels - numOutputBusChannels;
 	}
 
-	numInputBusChannels_ { |numChannels=8|
+	numInputBusChannels_ { |numChannels = 8|
 		numInputBusChannels = numChannels;
 		this.recalcChannels;
 	}
 
-	numOutputBusChannels_ { |numChannels=8|
+	numOutputBusChannels_ { |numChannels = 8|
 		numOutputBusChannels = numChannels;
 		this.recalcChannels;
 	}
@@ -210,15 +205,15 @@ ServerOptions
 	}
 
 	*devices {
-		^this.prListDevices(1, 1);
+		^this.prListDevices(1, 1)
 	}
 
 	*inDevices {
-		^this.prListDevices(1, 0);
+		^this.prListDevices(1, 0)
 	}
 
 	*outDevices {
-		^this.prListDevices(0, 1);
+		^this.prListDevices(0, 1)
 	}
 }
 
@@ -266,8 +261,11 @@ ServerShmInterface {
 	}
 }
 
+
 Server {
-	classvar <>local, <>internal, <default, <>named, <>set, <>program, <>sync_s = true;
+
+	classvar <>local, <>internal, <default;
+	classvar <>named, <>set, <>program, <>sync_s = true;
 
 	var <name, <>addr, <clientID, userSpecifiedClientID = false;
 	var <isLocal, <inProcess, <>sendQuit, <>remoteControlled;
@@ -276,17 +274,12 @@ Server {
 
 	var <nodeAllocator, <controlBusAllocator, <audioBusAllocator, <bufferAllocator, <scopeBufferAllocator;
 
-	var <syncThread, <syncTasks;
-
 	var <>tree;
 
-	var <window, <>scopeWindow;
-	var <emacsbuf;
-
+	var <syncThread, <syncTasks;
+	var <window, <>scopeWindow, <emacsbuf;
 	var <volume, <recorder, <statusWatcher;
-
-	var <pid;
-	var serverInterface;
+	var <pid, serverInterface;
 
 	*initClass {
 		Class.initClassTree(ServerOptions);
@@ -304,9 +297,9 @@ Server {
 	}
 
 	*default_ { |server|
-		default = server; // sync with s?
-		if (sync_s, { thisProcess.interpreter.s = server });
-		this.all.do(_.changed(\default, server));
+		default = server;
+		if(sync_s) { thisProcess.interpreter.s = server };  // sync with s?
+		this.all.do { |each| each.changed(\default, server) };
 	}
 
 	*new { |name, addr, options, clientID|
@@ -328,10 +321,10 @@ Server {
 	init { |argName, argAddr, argOptions, argClientID|
 		name = argName.asSymbol;
 		addr = argAddr;
-		if(argClientID.notNil, { userSpecifiedClientID = true });
+		if(argClientID.notNil) { userSpecifiedClientID = true };
 		clientID = argClientID ? 0;
 		options = argOptions ? ServerOptions.new;
-		if (addr.isNil, { addr = NetAddr("127.0.0.1", 57110) });
+		if(addr.isNil) { addr = NetAddr("127.0.0.1", 57110) };
 		inProcess = addr.addr == 0;
 		isLocal = inProcess || { addr.isLocal };
 		remoteControlled = isLocal;
@@ -350,12 +343,14 @@ Server {
 		tree.value(this);
 		ServerTree.run(this);
 	}
+
 	clientID_ { |val|
 		if(val.notNil and: { clientID != val }) {
 			clientID = val;
 			this.newAllocators;
 		}
 	}
+
 	newAllocators {
 		this.newNodeAllocators;
 		this.newBusAllocators;
@@ -365,7 +360,7 @@ Server {
 	}
 
 	newNodeAllocators {
-		nodeAllocator = NodeIDAllocator(clientID, options.initialNodeID);
+		nodeAllocator = NodeIDAllocator(clientID, options.initialNodeID)
 	}
 
 	newBusAllocators {
@@ -381,15 +376,15 @@ Server {
 		audioBusOffset = options.firstPrivateBus + (numAudio * offset);
 
 		controlBusAllocator =
-				ContiguousBlockAllocator.new(
-					numControl + controlBusOffset,
-					controlBusOffset
-				);
+		ContiguousBlockAllocator.new(
+			numControl + controlBusOffset,
+			controlBusOffset
+		);
 		audioBusAllocator =
-				ContiguousBlockAllocator.new(
-					numAudio + audioBusOffset,
-					audioBusOffset
-				);
+		ContiguousBlockAllocator.new(
+			numAudio + audioBusOffset,
+			audioBusOffset
+		);
 	}
 
 
@@ -403,32 +398,34 @@ Server {
 		var numBuffers = options.numBuffers div: n;
 		bufferOffset = numBuffers * offset;
 		bufferAllocator =
-				ContiguousBlockAllocator.new(
-					numBuffers + bufferOffset,
-					bufferOffset
-				);
+		ContiguousBlockAllocator.new(
+			numBuffers + bufferOffset,
+			bufferOffset
+		);
 	}
 
 	calcOffset {
-			if(options.maxLogins.isNil) { ^0 };
+		if(options.maxLogins.isNil) { ^0 };
 		if(clientID > (options.maxLogins - 1)) {
-					"Client ID exceeds maxLogins. Some buses and buffers may overlap for remote server: %".format(this).warn;
-			};
-			^clientID % options.maxLogins;
+			"Client ID exceeds maxLogins. Some buses and buffers may overlap for remote server: %".format(this).warn;
+		};
+		^clientID % options.maxLogins;
 	}
 
 	newScopeBufferAllocators {
-		if (isLocal) {
-			scopeBufferAllocator = StackNumberAllocator.new(0, 127);
+		if(isLocal) {
+			scopeBufferAllocator = StackNumberAllocator.new(0, 127)
 		}
 	}
 
 	nextNodeID {
 		^nodeAllocator.alloc
 	}
+
 	nextPermNodeID {
 		^nodeAllocator.allocPerm
 	}
+
 	freePermNodeID { |id|
 		^nodeAllocator.freePerm(id)
 	}
@@ -437,23 +434,24 @@ Server {
 	/* network messages */
 
 	sendMsg { |... msg|
-		addr.sendMsg(*msg);
+		addr.sendMsg(*msg)
 	}
+
 	sendBundle { |time ... msgs|
 		addr.sendBundle(time, *msgs)
 	}
 
 	sendRaw { |rawArray|
-		addr.sendRaw(rawArray);
+		addr.sendRaw(rawArray)
 	}
 
 	sendMsgSync { |condition ... args|
 		var cmdName, resp;
-		if (condition.isNil) { condition = Condition.new };
+		if(condition.isNil) { condition = Condition.new };
 		cmdName = args[0].asString;
-		if (cmdName[0] != $/) { cmdName = cmdName.insert(0, $/) };
+		if(cmdName[0] != $/) { cmdName = cmdName.insert(0, $/) };
 		resp = OSCFunc({|msg|
-			if (msg[1].asString == cmdName) {
+			if(msg[1].asString == cmdName) {
 				resp.free;
 				condition.test = true;
 				condition.signal;
@@ -472,25 +470,24 @@ Server {
 		syncTasks = syncTasks.add(func);
 		if(syncThread.isNil) {
 			syncThread = Routine.run {
-				var c; c = Condition.new;
+				var c = Condition.new;
 				while { syncTasks.notEmpty } { syncTasks.removeAt(0).value(c) };
 				syncThread = nil;
-		 	};
-		};
-
+			}
+		}
 	}
 
 	listSendMsg { |msg|
-		addr.sendMsg(*msg);
+		addr.sendMsg(*msg)
 	}
 
 	listSendBundle { |time, msgs|
-		addr.sendBundle(time, *(msgs.asArray));
+		addr.sendBundle(time, *(msgs.asArray))
 	}
 
 	reorder { |nodeList, target, addAction=\addToHead|
 		target = target.asTarget;
-		this.sendMsg(62, Node.actionNumberFor(addAction), target.nodeID, *(nodeList.collect(_.nodeID))); //"/n_order"
+		this.sendMsg(62, Node.actionNumberFor(addAction), target.nodeID, *(nodeList.collect(_.nodeID))) //"/n_order"
 	}
 
 	// load from disk locally, send remote
@@ -498,15 +495,16 @@ Server {
 		var file, buffer;
 		dir = dir ? SynthDef.synthDefDir;
 		file = File(dir ++ name ++ ".scsyndef","r");
-		if (file.isNil, { ^nil });
+		if(file.isNil) { ^nil };
 		protect {
 			buffer = Int8Array.newClear(file.length);
 			file.read(buffer);
-		}{
+		} {
 			file.close;
 		};
 		this.sendMsg("/d_recv", buffer);
 	}
+
 	// tell server to load from disk
 	loadSynthDef { |name, completionMsg, dir|
 		dir = dir ? SynthDef.synthDefDir;
@@ -514,16 +512,17 @@ Server {
 			["/d_load", dir ++ name ++ ".scsyndef", completionMsg ]
 		)
 	}
+
 	//loadDir
 	loadDirectory { |dir, completionMsg|
-		this.listSendMsg(["/d_loadDir", dir, completionMsg]);
+		this.listSendMsg(["/d_loadDir", dir, completionMsg])
 	}
 
 
 	/* network message bundling */
 
 	openBundle { |bundle|	// pass in a bundle that you want to
-							// continue adding to, or nil for a new bundle.
+		// continue adding to, or nil for a new bundle.
 		if(addr.hasBundle) {
 			bundle = addr.bundle.addAll(bundle);
 			addr.bundle = []; // debatable
@@ -547,7 +546,7 @@ Server {
 		try {
 			func.value(this);
 			bundle = this.closeBundle(time);
-		}{|error|
+		} {|error|
 			addr = addr.saveAddr; // on error restore the normal NetAddr
 			error.throw
 		}
@@ -562,14 +561,13 @@ Server {
 	/* scheduling */
 
 	wait { |responseName|
-		var routine;
-		routine = thisThread;
+		var routine = thisThread;
 		OSCFunc({
-			routine.resume(true);
+			routine.resume(true)
 		}, responseName, addr).oneShot;
 	}
 
-	waitForBoot { |onComplete, limit=100, onFailure|
+	waitForBoot { |onComplete, limit = 100, onFailure|
 		// onFailure.true: why is this necessary?
 		// this.boot also calls doWhenBooted.
 		// doWhenBooted prints the normal boot failure message.
@@ -587,83 +585,68 @@ Server {
 	bootSync { |condition|
 		condition ?? { condition = Condition.new };
 		condition.test = false;
-		this.waitForBoot({
+		this.waitForBoot {
 			// Setting func to true indicates that our condition has become true and we can go when signaled.
 			condition.test = true;
 			condition.signal
-		});
+		};
 		condition.wait;
 	}
 
 
-	ping { |n=1, wait=0.1, func|
-		var result=0, pingFunc;
+	ping { |n = 1, wait = 0.1, func|
+		var result = 0, pingFunc;
 		if(statusWatcher.serverRunning.not) { "server not running".postln; ^this };
 		pingFunc = {
 			Routine.run {
-					var t, dt;
-					t = Main.elapsedTime;
-					this.sync;
-					dt = Main.elapsedTime - t;
-					("measured latency:" + dt + "s").postln;
-					result = max(result, dt);
-					n = n - 1;
-					if(n > 0) {
-						SystemClock.sched(wait, { pingFunc.value; nil })
-					} {
-						("maximum determined latency of" + name + ":" + result + "s").postln;
-						func.value(result)
-					}
-				};
+				var t, dt;
+				t = Main.elapsedTime;
+				this.sync;
+				dt = Main.elapsedTime - t;
+				("measured latency:" + dt + "s").postln;
+				result = max(result, dt);
+				n = n - 1;
+				if(n > 0) {
+					SystemClock.sched(wait, { pingFunc.value; nil })
+				} {
+					("maximum determined latency of" + name + ":" + result + "s").postln;
+					func.value(result)
+				}
+			};
 		};
 		pingFunc.value;
 	}
 
-	cachedBuffersDo { |func| Buffer.cachedBuffersDo(this, func) }
-	cachedBufferAt { |bufnum| ^Buffer.cachedBufferAt(this, bufnum) }
-	defaultGroup { ^Group.basicNew(this, 1) }
+	cachedBuffersDo { |func|
+		Buffer.cachedBuffersDo(this, func)
+	}
+
+	cachedBufferAt { |bufnum|
+		^Buffer.cachedBufferAt(this, bufnum)
+	}
+
+	defaultGroup {
+		^Group.basicNew(this, 1)
+	}
 
 	inputBus {
-		^Bus(\audio, this.options.numOutputBusChannels, this.options.numInputBusChannels, this);
+		^Bus(\audio, this.options.numOutputBusChannels, this.options.numInputBusChannels, this)
 	}
 
 	outputBus {
-		^Bus(\audio, 0, this.options.numOutputBusChannels, this);
+		^Bus(\audio, 0, this.options.numOutputBusChannels, this)
 	}
 
 	/* recording formats */
 
-	recHeaderFormat {
-		^options.recHeaderFormat
-	}
-
-	recHeaderFormat_ { |string|
-		options.recHeaderFormat_(string)
-	}
-
-	recSampleFormat {
-		^options.recSampleFormat
-	}
-
-	recSampleFormat_ { |string|
-		options.recSampleFormat_(string)
-	}
-
-	recChannels {
-		^options.recChannels
-	}
-
-	recChannels_ { |n|
-		options.recChannels_(n)
-	}
-
-	recBufSize {
-		^options.recBufSize
-	}
-
-	recBufSize_ { |n|
-		options.recBufSize_(n)
-	}
+	recHeaderFormat { ^options.recHeaderFormat }
+	recHeaderFormat_ { |string| options.recHeaderFormat_(string) }
+	recSampleFormat { ^options.recSampleFormat }
+	recSampleFormat_ { |string| options.recSampleFormat_(string) }
+	recChannels { ^options.recChannels }
+	recChannels_ { |n| options.recChannels_(n) }
+	recBufSize { ^options.recBufSize }
+	recBufSize_ { |n| options.recBufSize_(n) }
 
 
 	/* server status */
@@ -680,30 +663,20 @@ Server {
 	serverBooting { ^statusWatcher.serverBooting }
 	unresponsive { ^statusWatcher.unresponsive }
 
-	startAliveThread { | delay=0.0 |
-		statusWatcher.startAliveThread(delay)
-	}
-	stopAliveThread {
-		statusWatcher.stopAliveThread
-	}
-	aliveThreadIsRunning {
-		^statusWatcher.aliveThread.isPlaying
-	}
-
-	aliveThreadPeriod_ { |val|
-		statusWatcher.aliveThreadPeriod_(val)
-	}
-	aliveThreadPeriod { |val|
-		^statusWatcher.aliveThreadPeriod
-	}
+	startAliveThread { | delay=0.0 | statusWatcher.startAliveThread(delay) }
+	stopAliveThread { statusWatcher.stopAliveThread }
+	aliveThreadIsRunning { ^statusWatcher.aliveThread.isPlaying }
+	aliveThreadPeriod_ { |val| statusWatcher.aliveThreadPeriod_(val) }
+	aliveThreadPeriod { |val| ^statusWatcher.aliveThreadPeriod }
 
 	disconnectSharedMemory {
-		if (this.hasShmInterface) {
+		if(this.hasShmInterface) {
 			"server '%' disconnected shared memory interface\n".postf(name);
 			serverInterface.disconnect;
 			serverInterface = nil;
 		}
 	}
+
 	connectSharedMemory {
 		var id;
 		this.disconnectSharedMemory;
@@ -717,10 +690,10 @@ Server {
 		set.do { |server| server.statusWatcher.resumeThread }
 	}
 
-	boot { | startAliveThread=true, recover=false, onFailure |
+	boot { | startAliveThread = true, recover = false, onFailure |
 
-		if (statusWatcher.serverRunning) { "server already running".inform; ^this };
-		if (statusWatcher.serverBooting) { "server already booting".inform; ^this };
+		if(statusWatcher.serverRunning) { "server already running".inform; ^this };
+		if(statusWatcher.serverBooting) { "server already booting".inform; ^this };
 
 		statusWatcher.serverBooting = true;
 
@@ -751,7 +724,7 @@ Server {
 
 	bootServerApp {
 		var f;
-		if (inProcess) {
+		if(inProcess) {
 			"booting internal".inform;
 			this.bootInProcess;
 			pid = thisProcess.pid;
@@ -759,17 +732,15 @@ Server {
 			this.disconnectSharedMemory;
 
 			pid = (program ++ options.asOptionsString(addr.port)).unixCmd;
-			if( options.protocol == \tcp ){
-				f = {
-					|attempts|
+			if(options.protocol == \tcp) {
+				f = { |attempts|
 					attempts = attempts - 1;
-					try { addr.connect } {
-						|err|
-						if (err.isKindOf(PrimitiveFailedError) and: { err.failedPrimitiveName == '_NetAddr_Connect'}) {
-							if(attempts > 0){
+					try { addr.connect } { |err|
+						if(err.isKindOf(PrimitiveFailedError) and: { err.failedPrimitiveName == '_NetAddr_Connect'}) {
+							if(attempts > 0) {
 								0.2.wait;
 								f.value(attempts)
-							}{
+							} {
 								"Couldn't connect to server % via TCP\n".postf(this.name);
 							}
 						} {
@@ -784,7 +755,7 @@ Server {
 	}
 
 	reboot { |func| // func is evaluated when server is off
-		if (isLocal.not) { "can't reboot a remote server".inform; ^this };
+		if(isLocal.not) { "can't reboot a remote server".inform; ^this };
 		if(statusWatcher.serverRunning) {
 			Routine.run {
 				this.quit;
@@ -806,20 +777,21 @@ Server {
 	notify {
 		^statusWatcher.notify
 	}
+
 	notify_ { |flag|
 		statusWatcher.notify_(flag)
 	}
+
 	notified {
 		^statusWatcher.notified
 	}
 
-
-	dumpOSC { |code=1|
+	dumpOSC { |code = 1|
 		/*
-			0 - turn dumping OFF.
-			1 - print the parsed contents of the message.
-			2 - print the contents in hexadecimal.
-			3 - print both the parsed and hexadecimal representations of the contents.
+		0 - turn dumping OFF.
+		1 - print the parsed contents of the message.
+		2 - print the contents in hexadecimal.
+		3 - print both the parsed and hexadecimal representations of the contents.
 		*/
 		dumpMode = code;
 		this.sendMsg(\dumpOSC, code);
@@ -832,33 +804,32 @@ Server {
 
 		statusWatcher.quit(watchShutDown);
 
-		if( options.protocol == \tcp ){ fork{ 0.1.wait; addr.disconnect } }; // sure? can we receive the above reply?
+		if( options.protocol == \tcp ) { fork { 0.1.wait; addr.disconnect } }; // sure? can we receive the above reply?
 
-		if (inProcess, {
+		if(inProcess) {
 			this.quitInProcess;
 			"quit done\n".inform;
-		},{
+		} {
 			"/quit sent\n".inform;
-		});
+		};
 
 		pid = nil;
 		sendQuit = nil;
 
 		if(scopeWindow.notNil) { scopeWindow.quit };
-		if(volume.isPlaying) {
-			volume.free
-		};
+		if(volume.isPlaying) { volume.free };
 		RootNode(this).freeAll;
 		this.newAllocators;
 	}
 
 	*quitAll { |watchShutDown = true|
-		set.do({ |server|
-			if (server.sendQuit === true) {
+		set.do { |server|
+			if(server.sendQuit === true) {
 				server.quit(watchShutDown)
-			};
-		})
+			}
+		}
 	}
+
 	*killAll {
 		// if you see Exception in World_OpenUDP: unable to bind udp socket
 		// its because you have multiple servers running, left
@@ -869,6 +840,7 @@ Server {
 		thisProcess.platform.killAll(this.program.basename);
 		this.quitAll(false);
 	}
+
 	freeAll {
 		this.sendMsg("/g_freeAll", 0);
 		this.sendMsg("/clearSched");
@@ -876,25 +848,25 @@ Server {
 	}
 
 	*freeAll { |evenRemote = false|
-		if (evenRemote) {
+		if(evenRemote) {
 			set.do { |server|
-				if ( server.serverRunning ) { server.freeAll }
+				if( server.serverRunning ) { server.freeAll }
 			}
 		} {
 			set.do { |server|
-				if (server.isLocal and:{ server.serverRunning }) { server.freeAll }
+				if(server.isLocal and:{ server.serverRunning }) { server.freeAll }
 			}
 		}
 	}
 
 	*hardFreeAll { |evenRemote = false|
-		if (evenRemote) {
+		if(evenRemote) {
 			set.do { |server|
 				server.freeAll
 			}
 		} {
 			set.do { |server|
-				if (server.isLocal) { server.freeAll }
+				if(server.isLocal) { server.freeAll }
 			}
 		}
 	}
@@ -906,38 +878,24 @@ Server {
 	/* volume control */
 
 	volume_ { | newVolume |
-		volume.volume_(newVolume);
+		volume.volume_(newVolume)
 	}
 
 	mute {
-		volume.mute;
+		volume.mute
 	}
 
 	unmute {
-		volume.unmute;
+		volume.unmute
 	}
 
 	/* recording output */
 
-	record { |path|
-		recorder.record(path);
-	}
-
-	isRecording {
-		^recorder.isRecording
-	}
-
-	pauseRecording {
-		recorder.pauseRecording
-	}
-
-	stopRecording {
-		recorder.stopRecording
-	}
-
-	prepareForRecord { |path|
-		recorder.prepareForRecord(path)
-	}
+	record { |path| recorder.record(path) }
+	isRecording { ^recorder.isRecording }
+	pauseRecording { recorder.pauseRecording }
+	stopRecording { recorder.stopRecording }
+	prepareForRecord { |path| recorder.prepareForRecord(path) }
 
 	recordNode {
 		this.deprecated(thisMethod);
@@ -972,7 +930,7 @@ Server {
 
 	cmdPeriod {
 		addr = addr.recover;
-		this.changed(\cmdPeriod);
+		this.changed(\cmdPeriod)
 	}
 
 	doOnServerTree {
@@ -981,67 +939,72 @@ Server {
 
 	queryAllNodes { | queryControls = false |
 		var resp, done = false;
-		if(isLocal, {this.sendMsg("/g_dumpTree", 0, queryControls.binaryValue);}, {
+		if(isLocal) {
+			this.sendMsg("/g_dumpTree", 0, queryControls.binaryValue)
+		} {
 			resp = OSCFunc({ |msg|
 				var i = 2, tabs = 0, printControls = false, dumpFunc;
-				if(msg[1] != 0, {printControls = true});
+				if(msg[1] != 0) { printControls = true };
 				("NODE TREE Group" + msg[2]).postln;
-				if(msg[3] > 0, {
+				if(msg[3] > 0) {
 					dumpFunc = {|numChildren|
 						var j;
 						tabs = tabs + 1;
-						numChildren.do({
-							if(msg[i + 1] >=0, {i = i + 2}, {
-								i = i + 3 + if(printControls, {msg[i + 3] * 2 + 1}, {0});
-							});
-							tabs.do({ "   ".post });
+						numChildren.do {
+							if(msg[i + 1] >= 0) { i = i + 2 } {
+								i = i + 3 + if(printControls) { msg[i + 3] * 2 + 1 } { 0 };
+							};
+							tabs.do { "   ".post };
 							msg[i].post; // nodeID
-							if(msg[i + 1] >=0, {
+							if(msg[i + 1] >= 0) {
 								" group".postln;
-								if(msg[i + 1] > 0, { dumpFunc.value(msg[i + 1]) });
-							}, {
+								if(msg[i + 1] > 0) { dumpFunc.value(msg[i + 1]) };
+							} {
 								(" " ++ msg[i + 2]).postln; // defname
-								if(printControls, {
-									if(msg[i + 3] > 0, {
+								if(printControls) {
+									if(msg[i + 3] > 0) {
 										" ".post;
-										tabs.do({ "   ".post });
-									});
+										tabs.do { "   ".post };
+									};
 									j = 0;
-									msg[i + 3].do({
+									msg[i + 3].do {
 										" ".post;
-										if(msg[i + 4 + j].isMemberOf(Symbol), {
+										if(msg[i + 4 + j].isMemberOf(Symbol)) {
 											(msg[i + 4 + j] ++ ": ").post;
-										});
+										};
 										msg[i + 5 + j].post;
 										j = j + 2;
-									});
+									};
 									"\n".post;
-								});
-							});
-						});
+								}
+							}
+						};
 						tabs = tabs - 1;
 					};
 					dumpFunc.value(msg[3]);
-				});
+				};
 				done = true;
 			}, '/g_queryTree.reply', addr).oneShot;
+
 			this.sendMsg("/g_queryTree", 0, queryControls.binaryValue);
 			SystemClock.sched(3, {
-				done.not.if({
+				if(done.not) {
 					resp.free;
 					"Remote server failed to respond to queryAllNodes!".warn;
-				});
-			});
-		})
+				};
+			})
+		}
 	}
+
 	printOn { |stream|
 		stream << name;
 	}
+
 	storeOn { |stream|
-		var codeStr = this.switch (
-			Server.default, 			{ if (sync_s) { "s" } { "Server.default" } },
-			Server.local,				{ "Server.local" },
-			Server.internal,			{ "Server.internal" },
+		var codeStr = switch(this,
+			Server.default, { if(sync_s) { "s" } { "Server.default" } },
+			Server.local,	{ "Server.local" },
+			Server.internal, { "Server.internal" },
 			{ "Server.fromName(" + name.asCompileString + ")" }
 		);
 		stream << codeStr;
@@ -1051,7 +1014,7 @@ Server {
 	archiveAsObject { ^true }
 
 	getControlBusValue {|busIndex|
-		if (serverInterface.isNil) {
+		if(serverInterface.isNil) {
 			Error("Server-getControlBusValue only supports local servers").throw;
 		} {
 			^serverInterface.getControlBusValue(busIndex)
@@ -1059,7 +1022,7 @@ Server {
 	}
 
 	getControlBusValues {|busIndex, busChannels|
-		if (serverInterface.isNil) {
+		if(serverInterface.isNil) {
 			Error("Server-getControlBusValues only supports local servers").throw;
 		} {
 			^serverInterface.getControlBusValues(busIndex, busChannels)
@@ -1067,7 +1030,7 @@ Server {
 	}
 
 	setControlBusValue {|busIndex, value|
-		if (serverInterface.isNil) {
+		if(serverInterface.isNil) {
 			Error("Server-getControlBusValue only supports local servers").throw;
 		} {
 			^serverInterface.setControlBusValue(busIndex, value)
@@ -1075,7 +1038,7 @@ Server {
 	}
 
 	setControlBusValues {|busIndex, valueArray|
-		if (serverInterface.isNil) {
+		if(serverInterface.isNil) {
 			Error("Server-getControlBusValues only supports local servers").throw;
 		} {
 			^serverInterface.setControlBusValues(busIndex, valueArray)

--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -6,7 +6,7 @@ ServerOptions
 	var <>numControlBusChannels = 4096;
 	var <numInputBusChannels = 2;
 	var <numOutputBusChannels = 2;
-	var numBuffers=1026;
+	var numBuffers = 1026;
 
 	var <>maxNodes = 1024;
 	var <>maxSynthDefs = 1024;
@@ -169,6 +169,7 @@ ServerOptions
 	firstPrivateBus { // after the outs and ins
 		^numOutputBusChannels + numInputBusChannels
 	}
+
 
 	bootInProcess {
 		_BootInProcessServer
@@ -372,15 +373,10 @@ Server {
 		audioBusOffset = options.firstPrivateBus + (numAudio * offset);
 
 		controlBusAllocator =
-		ContiguousBlockAllocator.new(
-			numControl + controlBusOffset,
-			controlBusOffset
-		);
+		ContiguousBlockAllocator.new(numControl, controlBusOffset);
+
 		audioBusAllocator =
-		ContiguousBlockAllocator.new(
-			numAudio + audioBusOffset,
-			audioBusOffset
-		);
+		ContiguousBlockAllocator.new(numAudio, audioBusOffset);
 	}
 
 
@@ -394,10 +390,7 @@ Server {
 		var numBuffers = options.numBuffers div: n;
 		bufferOffset = numBuffers * offset;
 		bufferAllocator =
-		ContiguousBlockAllocator.new(
-			numBuffers + bufferOffset,
-			bufferOffset
-		);
+		ContiguousBlockAllocator.new(numBuffers, bufferOffset);
 	}
 
 	calcOffset {

--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -283,7 +283,7 @@ Server {
 	var <avgCPU, <peakCPU;
 	var <sampleRate, <actualSampleRate;
 
-	var alive = false, booting = false, aliveThread, <>aliveThreadPeriod = 0.7, statusWatcher;
+	var alive = false, booting = false, <unresponsive = false, aliveThread, <>aliveThreadPeriod = 0.7, statusWatcher;
 	var <>tree;
 
 	var <window, <>scopeWindow;
@@ -523,33 +523,35 @@ Server {
 			if(val.not) {
 				reallyDeadCount = reallyDeadCount - 1;
 			};
-			if (val != serverRunning or: { reallyDeadCount == 0 }) {
-				if(thisProcess.platform.isSleeping.not) {
-					serverRunning = val;
+			if (val != serverRunning) {
+				serverRunning = val;
 
-					if (serverRunning.not) {
-						if(reallyDeadCount <= 0) {
-							ServerQuit.run(this);
+				if (serverRunning.not) {
+					if(reallyDeadCount <= 0) {
+						ServerQuit.run(this);
 
-							if (serverInterface.notNil) {
-								serverInterface.disconnect;
-								serverInterface = nil;
-							};
-
-							NotificationCenter.notify(this, \didQuit);
-							recordNode = nil;
-							if(this.isLocal.not) {
-								notified = false;
-							};
+						if (serverInterface.notNil) {
+							"server disconnected shared memory interface".postln;
+							serverInterface.disconnect;
+							serverInterface = nil;
 						};
-					} {
-						if(reallyDeadCount <= 0) {
-							ServerBoot.run(this);
+
+						NotificationCenter.notify(this, \didQuit);
+						recordNode = nil;
+						if(this.isLocal.not) {
+							notified = false;
 						};
-						reallyDeadCount = this.options.pingsBeforeConsideredDead;
 					};
-					{ this.changed(\serverRunning); }.defer;
-				}
+				} {
+					if(reallyDeadCount <= 0) {
+						ServerBoot.run(this);
+					};
+					reallyDeadCount = this.options.pingsBeforeConsideredDead;
+				};
+				{ this.changed(\serverRunning) }.defer;
+
+			} {
+				unresponsive = (reallyDeadCount == 0);
 			}
 		};
 	}
@@ -712,6 +714,8 @@ Server {
 		if (serverBooting, { "server already booting".inform; ^this });
 
 		serverBooting = true;
+		unresponsive = false;
+
 		if(startAliveThread, { this.startAliveThread });
 		if(recover) { this.newNodeAllocators } { this.newAllocators };
 		bootNotifyFirst = true;
@@ -753,6 +757,7 @@ Server {
 			if (serverInterface.notNil) {
 				serverInterface.disconnect;
 				serverInterface = nil;
+				"server disconnected shared memory interface".postln;
 			};
 
 			pid = (program ++ options.asOptionsString(addr.port)).unixCmd;

--- a/SCClassLibrary/Common/Control/ServerStatus.sc
+++ b/SCClassLibrary/Common/Control/ServerStatus.sc
@@ -2,7 +2,7 @@ ServerStatusWatcher {
 
 	var server;
 
-	var <>notified = false, <notify = false;
+	var <>notified = false, <notify = true;
 	var alive = false, <aliveThread, <>aliveThreadPeriod = 0.7, statusWatcher;
 
 	var <serverRunning = false, <>serverBooting = false, <unresponsive = false;

--- a/SCClassLibrary/Common/Control/ServerStatus.sc
+++ b/SCClassLibrary/Common/Control/ServerStatus.sc
@@ -1,0 +1,189 @@
+ServerStatusWatcher {
+
+	var server;
+
+	var <>notified = false, <notify = false;
+	var alive = false, aliveThread, <>aliveThreadPeriod = 0.7, statusWatcher;
+
+	var <numUGens=0, <numSynths=0, <numGroups=0, <numSynthDefs=0;
+	var <avgCPU, <peakCPU;
+	var <sampleRate, <actualSampleRate;
+
+	var reallyDeadCount = 0;
+
+	*new { |server|
+		^super.newCopyArgs(server)
+	}
+
+	quit { |watchShutDown = true|
+		if(watchShutDown) {
+			this.watchQuit
+		} {
+			this.stopStatusWatcher
+		};
+		this.stopAliveThread;
+		notified = false;
+		this.serverRunning = false;
+	}
+
+	notify_ { |flag = true|
+		notify = flag;
+		if(flag){
+			if(server.serverRunning){
+				this.sendNotifyRequest(true);
+				notified = true;
+				"Receiving notification messages from server %\n".postf(server.name);
+			}
+		}{
+			this.sendNotifyRequest(false);
+			notified = false;
+			"Switched off notification messages from server %\n".postf(server.name);
+		}
+	}
+
+	sendNotifyRequest { | flag=true |
+		var doneOSCFunc, failOSCFunc;
+		notified = flag;
+		if(server.userSpecifiedClientID.not, {
+			doneOSCFunc = OSCFunc({|msg|
+				if(flag) { server.clientID = msg[2] };
+				failOSCFunc.free;
+			}, '/done', server.addr, argTemplate:['/notify', nil]).oneShot;
+
+			failOSCFunc = OSCFunc({|msg|
+				server.clientID = msg[2];
+				doneOSCFunc.free;
+			}, '/fail', server.addr, argTemplate:['/notify', nil, nil]).oneShot;
+
+		});
+
+		server.sendMsg("/notify", flag.binaryValue);
+	}
+
+
+	watchQuit {
+		var	serverReallyQuitWatcher, serverReallyQuit = false;
+		statusWatcher !? {
+			statusWatcher.disable;
+			if(notified) {
+				serverReallyQuitWatcher = OSCFunc({ |msg|
+					if(msg[1] == '/quit') {
+						if (statusWatcher.notNil) {
+							statusWatcher.enable;
+						};
+						serverReallyQuit = true;
+						serverReallyQuitWatcher.free;
+					};
+				}, '/done', server.addr);
+
+				AppClock.sched(3.0, {
+					if(serverReallyQuit.not) {
+						"Server % failed to quit after 3.0 seconds.".format(server.name).warn;
+						// don't accumulate quit-watchers if /done doesn't come back
+						serverReallyQuitWatcher.free;
+						statusWatcher.disable;
+					};
+				});
+			};
+		};
+	}
+
+
+	addStatusWatcher {
+		if(statusWatcher.isNil) {
+			statusWatcher =
+			OSCFunc({ arg msg;
+				var cmd, one;
+				if(notify){
+					if(notified.not){
+						this.sendNotifyRequest;
+						"Receiving notification messages from server %\n".postf(server.name);
+					}
+				};
+				alive = true;
+				#cmd, one, numUGens, numSynths, numGroups, numSynthDefs,
+						avgCPU, peakCPU, sampleRate, actualSampleRate = msg;
+				{
+					this.updateRunningState(true);
+					this.changed(\counts);
+					nil // no resched
+				}.defer;
+			}, '/status.reply', server.addr).fix;
+		} {
+			statusWatcher.enable;
+		}
+	}
+
+	stopStatusWatcher {
+		statusWatcher.disable;
+	}
+
+	startAliveThread { | delay=0.0 |
+		this.addStatusWatcher;
+		^aliveThread ?? {
+			aliveThread = Routine({
+				// this thread polls the server to see if it is alive
+				delay.wait;
+				loop({
+					server.status;
+					aliveThreadPeriod.wait;
+					this.updateRunningState(alive);
+					alive = false;
+				});
+			});
+			AppClock.play(aliveThread);
+			aliveThread
+		}
+	}
+
+	stopAliveThread {
+		alive = false;
+		aliveThread.stop;
+		aliveThread = nil;
+		statusWatcher.free;
+		statusWatcher = nil;
+	}
+
+	aliveThreadIsRunning {
+		^aliveThread.notNil and: { aliveThread.isPlaying }
+	}
+
+
+	serverRunning_ { | val |
+
+		server.serverRunning = val;
+		server.unresponsive = false;
+
+		if (server.serverRunning) {
+			ServerBoot.run(server);
+		} {
+			ServerQuit.run(server);
+
+			server.disconnectSharedMemory;
+			if(server.isRecording) { server.stopRecording };
+
+			NotificationCenter.notify(server, \didQuit);
+
+			if(server.isLocal.not) {
+				notified = false;
+			};
+		}
+
+	}
+
+	updateRunningState { | val |
+		if(server.addr.hasBundle) {
+			{ server.changed(\bundling) }.defer;
+		} {
+			if(val) {
+				this.serverRunning = true;
+				server.unresponsive = false;
+				reallyDeadCount = server.options.pingsBeforeConsideredDead;
+			} {
+				reallyDeadCount = reallyDeadCount - 1;
+				server.unresponsive = (reallyDeadCount <= 0);
+			}
+		}
+	}
+
+}

--- a/SCClassLibrary/Common/Control/ServerStatus.sc
+++ b/SCClassLibrary/Common/Control/ServerStatus.sc
@@ -154,7 +154,6 @@ ServerStatusWatcher {
 	startAliveThread { | delay=0.0 |
 		this.addStatusWatcher;
 		^aliveThread ?? {
-			"new AliveThread".postln;
 			aliveThread = Routine {
 				// this thread polls the server to see if it is alive
 				delay.wait;
@@ -177,6 +176,13 @@ ServerStatusWatcher {
 		aliveThread.stop;
 		alive = false;
 		aliveThread = nil;
+	}
+
+	resumeThread {
+		aliveThread !? {
+			this.stopAliveThread;
+			this.startAliveThread;
+		}
 	}
 
 

--- a/SCClassLibrary/Common/Control/ServerStatus.sc
+++ b/SCClassLibrary/Common/Control/ServerStatus.sc
@@ -153,14 +153,12 @@ ServerStatusWatcher {
 
 	startAliveThread { | delay=0.0 |
 		this.addStatusWatcher;
-		[\aliveThread, aliveThread.cs].postln;
 		^aliveThread ?? {
 			"new AliveThread".postln;
 			aliveThread = Routine {
 				// this thread polls the server to see if it is alive
 				delay.wait;
 				loop {
-					aliveThread.identityHash.postln;
 					server.status;
 					aliveThreadPeriod.wait;
 					this.updateRunningState(alive);
@@ -172,7 +170,7 @@ ServerStatusWatcher {
 	}
 
 	stopAliveThread {
-		"stopAliveThread".postln;
+
 		statusWatcher.free;
 		statusWatcher = nil;
 
@@ -183,9 +181,10 @@ ServerStatusWatcher {
 
 
 	serverRunning_ { | val |
+
 		if(val != serverRunning) {
 			serverRunning = val;
-			//unresponsive = false;
+			unresponsive = false;
 
 			if (server.serverRunning) {
 				ServerBoot.run(server);
@@ -210,14 +209,13 @@ ServerStatusWatcher {
 		if(server.addr.hasBundle) {
 			{ server.changed(\bundling) }.defer;
 		} {
-			//[\reallyDeadCount, reallyDeadCount].postln;
 			if(val) {
 				this.serverRunning = true;
-				//unresponsive = false;
+				unresponsive = false;
 				reallyDeadCount = server.options.pingsBeforeConsideredDead;
 			} {
 				reallyDeadCount = reallyDeadCount - 1;
-				//this.unresponsive = (reallyDeadCount <= 0);
+				this.unresponsive = (reallyDeadCount <= 0);
 			}
 		}
 	}
@@ -226,7 +224,7 @@ ServerStatusWatcher {
 	unresponsive_ { arg val;
 		if (val != unresponsive) {
 			unresponsive = val;
-			{ this.changed(\serverRunning) }.defer;
+			{ server.changed(\serverRunning) }.defer;
 		}
 	}
 

--- a/SCClassLibrary/Common/Control/ServerStatus.sc
+++ b/SCClassLibrary/Common/Control/ServerStatus.sc
@@ -11,9 +11,7 @@ ServerStatusWatcher {
 	var <avgCPU, <peakCPU;
 	var <sampleRate, <actualSampleRate;
 
-	var reallyDeadCount = 0;
-	var <>bootNotifyFirst;
-
+	var reallyDeadCount = 0, bootNotifyFirst = true;
 
 	*new { |server|
 		^super.newCopyArgs(server)
@@ -29,6 +27,7 @@ ServerStatusWatcher {
 		notified = false;
 		serverBooting = false;
 		this.serverRunning = false;
+		bootNotifyFirst = true;
 	}
 
 	notify_ { |flag = true|
@@ -85,6 +84,7 @@ ServerStatusWatcher {
 				serverBooting = false;
 				server.changed(\serverRunning);
 			}, onComplete);
+
 		}.play(AppClock)
 	}
 
@@ -145,10 +145,10 @@ ServerStatusWatcher {
 				// this thread polls the server to see if it is alive
 				delay.wait;
 				loop {
+					alive = false;
 					server.status;
 					aliveThreadPeriod.wait;
 					this.updateRunningState(alive);
-					alive = false;
 				};
 			}.play(AppClock);
 			aliveThread
@@ -208,6 +208,7 @@ ServerStatusWatcher {
 				this.unresponsive = false;
 				reallyDeadCount = server.options.pingsBeforeConsideredDead;
 			} {
+				// parrot
 				reallyDeadCount = reallyDeadCount - 1;
 				this.unresponsive = (reallyDeadCount <= 0);
 			}

--- a/SCClassLibrary/Common/Control/ServerStatus.sc
+++ b/SCClassLibrary/Common/Control/ServerStatus.sc
@@ -148,7 +148,7 @@ ServerStatusWatcher {
 				delay.wait;
 				loop {
 					alive = false;
-					server.status;
+					server.sendStatusMsg;
 					aliveThreadPeriod.wait;
 					this.updateRunningState(alive);
 				};

--- a/SCClassLibrary/Common/Control/ServerStatus.sc
+++ b/SCClassLibrary/Common/Control/ServerStatus.sc
@@ -215,7 +215,7 @@ ServerStatusWatcher {
 		} {
 			if(running) {
 				this.serverRunning = true;
-				unresponsive = false;
+				this.unresponsive = false;
 				reallyDeadCount = server.options.pingsBeforeConsideredDead;
 			} {
 				reallyDeadCount = reallyDeadCount - 1;

--- a/SCClassLibrary/Common/Control/ServerStatus.sc
+++ b/SCClassLibrary/Common/Control/ServerStatus.sc
@@ -67,13 +67,16 @@ ServerStatusWatcher {
 		^Routine {
 			while {
 				serverRunning.not
+				/*
+				// this is not yet implemented.
 				or: { serverBooting and: mBootNotifyFirst.not }
 				and: { (limit = limit - 1) > 0 }
-				and: { server.pid.tryPerform(\pidRunning) == true }
+				and: { server.applicationRunning.not }
+				*/
+
 			} {
 				0.2.wait;
 			};
-
 			if(serverRunning.not, {
 				if(onFailure.notNil) {
 					postError = (onFailure.value(server) == false);

--- a/SCClassLibrary/Common/Control/ServerStatus.sc
+++ b/SCClassLibrary/Common/Control/ServerStatus.sc
@@ -39,7 +39,7 @@ ServerStatusWatcher {
 				notified = true;
 				"Receiving notification messages from server %\n".postf(server.name);
 			}
-		}{
+		} {
 			this.sendNotifyRequest(false);
 			notified = false;
 			"Switched off notification messages from server %\n".postf(server.name);
@@ -90,7 +90,7 @@ ServerStatusWatcher {
 				serverBooting = false;
 				server.changed(\serverRunning);
 			}, onComplete);
-		}.play(AppClock);
+		}.play(AppClock)
 	}
 
 
@@ -115,10 +115,10 @@ ServerStatusWatcher {
 						// don't accumulate quit-watchers if /done doesn't come back
 						serverReallyQuitWatcher.free;
 						statusWatcher.disable;
-					};
-				});
-			};
-		};
+					}
+				})
+			}
+		}
 	}
 
 
@@ -186,10 +186,10 @@ ServerStatusWatcher {
 	}
 
 
-	serverRunning_ { | val |
+	serverRunning_ { | running |
 
-		if(val != serverRunning) {
-			serverRunning = val;
+		if(running != serverRunning) {
+			serverRunning = running;
 			unresponsive = false;
 
 			if (server.serverRunning) {
@@ -211,11 +211,11 @@ ServerStatusWatcher {
 
 	}
 
-	updateRunningState { | val |
+	updateRunningState { | running |
 		if(server.addr.hasBundle) {
 			{ server.changed(\bundling) }.defer;
 		} {
-			if(val) {
+			if(running) {
 				this.serverRunning = true;
 				unresponsive = false;
 				reallyDeadCount = server.options.pingsBeforeConsideredDead;
@@ -227,7 +227,7 @@ ServerStatusWatcher {
 	}
 
 
-	unresponsive_ { arg val;
+	unresponsive_ { | val |
 		if (val != unresponsive) {
 			unresponsive = val;
 			{ server.changed(\serverRunning) }.defer;

--- a/SCClassLibrary/Common/Control/ServerStatus.sc
+++ b/SCClassLibrary/Common/Control/ServerStatus.sc
@@ -46,7 +46,7 @@ ServerStatusWatcher {
 		}
 	}
 
-	sendNotifyRequest { | flag=true |
+	sendNotifyRequest { |flag = true|
 		var doneOSCFunc, failOSCFunc;
 		notified = flag;
 		if(server.userSpecifiedClientID.not) {
@@ -65,15 +65,15 @@ ServerStatusWatcher {
 		server.sendMsg("/notify", flag.binaryValue);
 	}
 
-	doWhenBooted { arg onComplete, limit=100, onFailure;
+	doWhenBooted { |onComplete, limit = 100, onFailure|
 		var mBootNotifyFirst = bootNotifyFirst, postError = true;
 		bootNotifyFirst = false;
 
 		^Routine {
 			while {
-				((serverRunning.not
-					or: (serverBooting and: mBootNotifyFirst.not))
-				and: { (limit = limit - 1) > 0 })
+				serverRunning.not
+				or: { serverBooting and: mBootNotifyFirst.not }
+				and: { (limit = limit - 1) > 0 }
 				and: { server.pid.tryPerform(\pidRunning) == true }
 			} {
 				0.2.wait;
@@ -101,12 +101,10 @@ ServerStatusWatcher {
 			if(notified) {
 				serverReallyQuitWatcher = OSCFunc({ |msg|
 					if(msg[1] == '/quit') {
-						if (statusWatcher.notNil) {
-							statusWatcher.enable;
-						};
+						statusWatcher!? { statusWatcher.enable };
 						serverReallyQuit = true;
 						serverReallyQuitWatcher.free;
-					};
+					}
 				}, '/done', server.addr);
 
 				AppClock.sched(3.0, {
@@ -128,7 +126,7 @@ ServerStatusWatcher {
 			OSCFunc({ arg msg;
 				var cmd, one;
 				if(notify){
-					if(notified.not){
+					if(notified.not) {
 						this.sendNotifyRequest;
 						"Receiving notification messages from server %\n".postf(server.name);
 					}
@@ -151,7 +149,7 @@ ServerStatusWatcher {
 		statusWatcher.disable;
 	}
 
-	startAliveThread { | delay=0.0 |
+	startAliveThread { | delay = 0.0 |
 		this.addStatusWatcher;
 		^aliveThread ?? {
 			aliveThread = Routine {

--- a/SCClassLibrary/Common/Control/SystemActions.sc
+++ b/SCClassLibrary/Common/Control/SystemActions.sc
@@ -43,7 +43,6 @@ CmdPeriod : AbstractSystemAction {
 		if(clearClocks, {
 			SystemClock.clear;
 			AppClock.clear;
-	//		TempoClock.default.clear;
 		});
 
 		objects.copy.do({ arg item; item.doOnCmdPeriod;  });

--- a/SCClassLibrary/Common/Control/Volume.sc
+++ b/SCClassLibrary/Common/Control/Volume.sc
@@ -1,10 +1,11 @@
 Volume {
+
 	var startBus, numChans, <min, <max, server, persist, <ampSynth, <>window, <volume, spec;
 	var <lag, sdname, gui = false, cpFun, updateSynth, <isMuted=false;
 	var <synthNumChans;	// the actual number of channels, which might be set automatically
 	var sdInitialized;
 
-	*new { arg server, startBus = 0, numChans, min = -90, max = 6, persist = false;
+	*new { | server, startBus = 0, numChans, min = -90, max = 6, persist = false |
 		^super.newCopyArgs(startBus, numChans, min, max, server, persist).initVolume;
 	}
 
@@ -15,24 +16,24 @@ Volume {
 		lag = 0.1;
 		gui = false;
 		updateSynth = {
-			var amp = if (isMuted.not) { volume.dbamp } { 0.0 };
+			var amp = if(isMuted.not) { volume.dbamp } { 0.0 };
 			var active = amp != 1.0;
-			if (active) {
+			if(active) {
 				if(server.serverRunning) {
-					if (ampSynth.isNil) {
+					if(ampSynth.isNil) {
 						ampSynth = Synth.after(server.defaultGroup, sdname,
-							[\volumeAmp, amp, \volumeLag, lag, \bus, startBus]);
-					}{
+							[\volumeAmp, amp, \volumeLag, lag, \bus, startBus])
+					} {
 						ampSynth.set(\volumeAmp, amp);
 					}
 				}
-			}{
-				if (ampSynth.notNil) { ampSynth.release; ampSynth = nil }
+			} {
+				if(ampSynth.notNil) { ampSynth.release; ampSynth = nil }
 			}
 		};
 
 		sdInitialized = Condition();
-		if (server.serverRunning) {
+		if(server.serverRunning) {
 			this.sendSynthDef
 		} {
 			ServerBoot.add ({
@@ -57,15 +58,16 @@ Volume {
 			{ arg volumeAmp = 1, volumeLag = 0.1, gate=1, bus;
 				XOut.ar(bus,
 					Linen.kr(gate, releaseTime: 0.05, doneAction:2),
-					In.ar(bus, synthNumChans) * Lag.kr(volumeAmp, volumeLag) );
+					In.ar(bus, synthNumChans) * Lag.kr(volumeAmp, volumeLag)
+				);
 		}).send(server);
 
 		fork {
 			server.sync(sdInitialized);
-			if (cpFun.isNil) {
+			if(cpFun.isNil) {
 				ServerTree.add(cpFun = {
 					ampSynth = nil;
-					if (persist) { updateSynth.value; }
+					if(persist) { updateSynth.value; }
 				});
 			};
 		}
@@ -80,7 +82,7 @@ Volume {
 	}
 
 	mute {
-		if (isMuted.not) {
+		if(isMuted.not) {
 			isMuted = true;
 			this.changed(\mute, true);
 			updateSynth.value;
@@ -88,7 +90,7 @@ Volume {
 	}
 
 	unmute {
-		if (isMuted) {
+		if(isMuted) {
 			isMuted = false;
 			this.changed(\mute, false);
 			updateSynth.value;
@@ -103,29 +105,28 @@ Volume {
 	}
 
 	// cleaner with MVC - in db
-	volume_ { arg aVolume;
+	volume_ { | aVolume |
 		volume = aVolume.clip(min, max);
 		this.changed(\amp, volume);
 		updateSynth.value;
 	}
 
-	lag_ { arg aLagTime;
+	lag_ { | aLagTime |
 		lag = aLagTime;
-		if (ampSynth.notNil) { ampSynth.set(\volumeLag, lag) };
+		if(ampSynth.notNil) { ampSynth.set(\volumeLag, lag) };
 	}
 
-	setVolumeRange { arg argMin, argMax;
+	setVolumeRange { | argMin, argMax |
 		var clippedVolume;
 		argMin !? { min = argMin };
 		argMax !? { max = argMax };
 		this.changed(\ampRange, min, max);
 		clippedVolume = volume.clip(min, max);
-		if (clippedVolume != volume) { this.volume_(clippedVolume) }
+		if(clippedVolume != volume) { this.volume_(clippedVolume) }
 	}
 
 
-	gui { arg window, bounds;
-		//		this.debug(\gui);
+	gui { | window, bounds |
 		^VolumeGui(this, window, bounds)
 	}
 
@@ -134,40 +135,44 @@ Volume {
 	}
 }
 
-VolumeGui{
+VolumeGui {
+
 	var <>model;
 	var window, spec, slider, box, simpleController;
 
-	*new{|model, win, bounds|
+	*new { | model, win, bounds |
 		^super.new.model_(model).init(win, bounds)
 	}
 
-	init{|win, bounds|
+	init { | win, bounds |
 		spec = [model.min, model.max, \db].asSpec;
 		bounds = bounds ?? {Rect(100, 100, 80, 330)};
-		window = win ?? {GUI.window.new("Volume", bounds).front};
+		window = win ?? { GUI.window.new("Volume", bounds).front };
 		box = GUI.numberBox.new(window, Rect(10, 10, 60, 30))
-		.value_(model.volume) ;
+		.value_(model.volume);
+
 		slider = GUI.slider.new(window, Rect(10, 40, 60, 280))
-		.value_(spec.unmap(model.volume)) ;
-		slider.action_({ arg item ;
+		.value_(spec.unmap(model.volume));
+
+		slider.action_({ arg item;
 			model.volume_(spec.map(item.value));
-		}) ;
-		box.action_({ arg item ;
-			model.volume_(item.value) ;
-		}) ;
+		});
+		box.action_({ arg item;
+			model.volume_(item.value);
+		});
 		window.onClose_({
 			simpleController.remove;
 		});
+
 		simpleController = SimpleController(model)
 		.put(\amp, {|changer, what, volume|
 			this.debug(volume);
-			box.value_(volume.round(0.01)) ;
-			slider.value_(spec.unmap(volume)) ;
+			box.value_(volume.round(0.01));
+			slider.value_(spec.unmap(volume));
 		})
 		.put(\ampRange, {|changer, what, min, max|
 			spec = [min, max, \db].asSpec.debug;
-			slider.value_(spec.unmap(model.volume)) ;
+			slider.value_(spec.unmap(model.volume));
 		})
 	}
 }

--- a/SCClassLibrary/Common/Control/Volume.sc
+++ b/SCClassLibrary/Common/Control/Volume.sc
@@ -1,91 +1,79 @@
 Volume {
 
-	var startBus, numChans, <min, <max, server, persist, <ampSynth, <>window, <volume, spec;
-	var <lag, sdname, gui = false, cpFun, updateSynth, <isMuted=false;
-	var <synthNumChans;	// the actual number of channels, which might be set automatically
-	var sdInitialized;
+	var <server, <startBus, numChannels, <min, <max, <persist;
 
-	*new { | server, startBus = 0, numChans, min = -90, max = 6, persist = false |
-		^super.newCopyArgs(startBus, numChans, min, max, server, persist).initVolume;
+	var <volume = 0.0, <lag = 0.1, <isMuted = false;
+
+	var ampSynth, defName, updateFunc, initFunc;
+	var <>window;
+
+	*new { | server, startBus = 0, numChannels, min = -90, max = 6, persist = false |
+		^super.newCopyArgs(server ?? { Server.default }, startBus, numChannels, min, max, persist).init;
 	}
 
-	initVolume {
-		var cond;
-		server = server ?? {Server.default};
-		volume = 0;
-		lag = 0.1;
-		gui = false;
-		updateSynth = {
-			var amp = if(isMuted.not) { volume.dbamp } { 0.0 };
-			var active = amp != 1.0;
-			if(active) {
-				if(server.serverRunning) {
-					if(ampSynth.isNil) {
-						ampSynth = Synth.after(server.defaultGroup, sdname,
-							[\volumeAmp, amp, \volumeLag, lag, \bus, startBus])
-					} {
-						ampSynth.set(\volumeAmp, amp);
-					}
-				}
-			} {
-				if(ampSynth.notNil) { ampSynth.release; ampSynth = nil }
-			}
-		};
-
-		sdInitialized = Condition();
-		if(server.serverRunning) {
-			this.sendSynthDef
-		} {
-			ServerBoot.add ({
+	init {
+		if(server.serverRunning) { this.sendSynthDef };
+		if(initFunc.isNil) {
+			ServerBoot.add(initFunc = {
 				ampSynth = nil;
 				this.sendSynthDef;
 			}, server)
-		};
-	}
-
-	sendSynthDef {
-		if(numChans.isNil) {
-			synthNumChans = server.options.numOutputBusChannels;
-		} {
-			synthNumChans = numChans;
-		};
-
-		sdname = (\volumeAmpControl ++ synthNumChans).asSymbol;
-
-		sdInitialized = Condition();
-
-		SynthDef(sdname,
-			{ arg volumeAmp = 1, volumeLag = 0.1, gate=1, bus;
-				XOut.ar(bus,
-					Linen.kr(gate, releaseTime: 0.05, doneAction:2),
-					In.ar(bus, synthNumChans) * Lag.kr(volumeAmp, volumeLag)
-				);
-		}).send(server);
-
-		fork {
-			server.sync(sdInitialized);
-			if(cpFun.isNil) {
-				ServerTree.add(cpFun = {
-					ampSynth = nil;
-					if(persist) { updateSynth.value; }
-				});
-			};
 		}
 	}
 
-	numChans { ^numChans ? synthNumChans ? server.options.numOutputBusChannels }
-	numChans_ { |num|
-		if(ampSynth.notNil and: { num != synthNumChans }) {
+	sendSynthDef {
+
+		forkIfNeeded {
+			var synthNumChans = this.numChannels;
+			defName = (\volumeAmpControl ++ synthNumChans).asSymbol;
+			SynthDef(defName, { | volumeAmp = 1, volumeLag = 0.1, gate=1, bus |
+					XOut.ar(bus,
+						Linen.kr(gate, releaseTime: 0.05, doneAction:2),
+						In.ar(bus, synthNumChans) * Lag.kr(volumeAmp, volumeLag)
+					);
+			}).send(server);
+
+			server.sync;
+
+			if(updateFunc.isNil) {
+				ServerTree.add(updateFunc = {
+					ampSynth = nil;
+					if(persist) { this.updateSynth }
+				})
+			}
+		}
+	}
+
+	numChannels { ^numChannels ? server.options.numOutputBusChannels }
+	numChannels_ { |num|
+		if(ampSynth.notNil and: { num != this.numChannels }) {
 			"Change in number of channels will not take effect until volume is reset to 0dB.".warn;
 		};
-		numChans = num;
+		numChannels = num;
+	}
+
+	updateSynth {
+		var amp = if(isMuted.not) { volume.dbamp } { 0.0 };
+		var active = amp != 1.0;
+		if(active) {
+			if(server.serverRunning) {
+				if(ampSynth.isNil) {
+					ampSynth = Synth.after(server.defaultGroup, defName,
+						[\volumeAmp, amp, \volumeLag, lag, \bus, startBus])
+				} {
+					ampSynth.set(\volumeAmp, amp);
+				}
+			}
+		} {
+			if(ampSynth.notNil) { ampSynth.release; ampSynth = nil }
+		}
 	}
 
 	mute {
 		if(isMuted.not) {
 			isMuted = true;
 			this.changed(\mute, true);
-			updateSynth.value;
+			this.updateSynth;
 		}
 	}
 
@@ -93,27 +81,25 @@ Volume {
 		if(isMuted) {
 			isMuted = false;
 			this.changed(\mute, false);
-			updateSynth.value;
+			this.updateSynth;
 		}
 	}
 
 	// sets volume back to 1 - removes the synth
 	reset {
 		isMuted = false;
-		volume = 0.0;
-		updateSynth.value;
+		this.volume = 0.0;
 	}
 
-	// cleaner with MVC - in db
 	volume_ { | aVolume |
 		volume = aVolume.clip(min, max);
 		this.changed(\amp, volume);
-		updateSynth.value;
+		this.updateSynth;
 	}
 
 	lag_ { | aLagTime |
 		lag = aLagTime;
-		if(ampSynth.notNil) { ampSynth.set(\volumeLag, lag) };
+		if(ampSynth.notNil) { ampSynth.set(\volumeLag, lag) }
 	}
 
 	setVolumeRange { | argMin, argMax |
@@ -133,31 +119,37 @@ Volume {
 	close {
 		window.close;
 	}
+
+	/* deprecated */
+
+	numChans { ^this.deprecated(thisMethod, this.class.findMethod(\numChannels)) }
+	numChans_ { ^this.deprecated(thisMethod, this.class.findMethod(\numChannels)) }
+
 }
 
 VolumeGui {
 
-	var <>model;
-	var window, spec, slider, box, simpleController;
+	var <model, <window;
 
 	*new { | model, win, bounds |
-		^super.new.model_(model).init(win, bounds)
+		^super.newCopyArgs(model).init(win, bounds)
 	}
 
 	init { | win, bounds |
-		spec = [model.min, model.max, \db].asSpec;
-		bounds = bounds ?? {Rect(100, 100, 80, 330)};
-		window = win ?? { GUI.window.new("Volume", bounds).front };
-		box = GUI.numberBox.new(window, Rect(10, 10, 60, 30))
+		var slider, box, simpleController;
+		var spec = [model.min, model.max, \db].asSpec;
+		bounds = bounds ?? { Rect(100, 100, 80, 330) };
+		window = win ?? { Window.new("Volume", bounds).front };
+		box = NumberBox(window, Rect(10, 10, 60, 30))
 		.value_(model.volume);
 
-		slider = GUI.slider.new(window, Rect(10, 40, 60, 280))
+		slider = Slider(window, Rect(10, 40, 60, 280))
 		.value_(spec.unmap(model.volume));
 
-		slider.action_({ arg item;
+		slider.action_({ | item |
 			model.volume_(spec.map(item.value));
 		});
-		box.action_({ arg item;
+		box.action_({ | item |
 			model.volume_(item.value);
 		});
 		window.onClose_({
@@ -166,7 +158,6 @@ VolumeGui {
 
 		simpleController = SimpleController(model)
 		.put(\amp, {|changer, what, volume|
-			this.debug(volume);
 			box.value_(volume.round(0.01));
 			slider.value_(spec.unmap(volume));
 		})

--- a/SCClassLibrary/Common/GUI/PlusGUI/Control/ServerPlusGUI.sc
+++ b/SCClassLibrary/Common/GUI/PlusGUI/Control/ServerPlusGUI.sc
@@ -13,7 +13,7 @@
 
 	calculateViewBounds {
 		var width = 288, height = 98, taskBarHeight = 27; // the latter should be in SCWindow
-		var keys = set.asArray.collect(_.name).sort;
+		var keys = all.asArray.collect(_.name).sort;
 		^Rect(5, keys.indexOf(name) * (height + taskBarHeight) + 5, width, height)
 	}
 

--- a/SCClassLibrary/Common/GUI/PlusGUI/Control/ServerPlusGUI.sc
+++ b/SCClassLibrary/Common/GUI/PlusGUI/Control/ServerPlusGUI.sc
@@ -333,12 +333,12 @@
 		ctlr = SimpleController(this)
 			.put(\serverRunning, {	if(serverRunning,running,stopped) })
 			.put(\counts,{
-				countsViews.at(0).string = avgCPU.round(0.1);
-				countsViews.at(1).string = peakCPU.round(0.1);
-				countsViews.at(2).string = numUGens;
-				countsViews.at(3).string = numSynths;
-				countsViews.at(4).string = numGroups;
-				countsViews.at(5).string = numSynthDefs;
+				countsViews.at(0).string = statusWatcher.avgCPU.round(0.1);
+				countsViews.at(1).string = statusWatcher.peakCPU.round(0.1);
+				countsViews.at(2).string = statusWatcher.numUGens;
+				countsViews.at(3).string = statusWatcher.numSynths;
+				countsViews.at(4).string = statusWatcher.numGroups;
+				countsViews.at(5).string = statusWatcher.numSynthDefs;
 			})
 			.put(\bundling, bundling)
 			.put(\default, showDefault);

--- a/SCClassLibrary/Common/GUI/PlusGUI/Control/ServerPlusGUI.sc
+++ b/SCClassLibrary/Common/GUI/PlusGUI/Control/ServerPlusGUI.sc
@@ -63,7 +63,7 @@
 					this.quit;
 				});
 			};
-			booter.setProperty(\value,serverRunning.binaryValue);
+			booter.setProperty(\value, this.serverRunning.binaryValue);
 
 			killer = gui.button.new(w, Rect(0,0, 20, 18));
 			killer.states = [["K"]];
@@ -76,7 +76,7 @@
 		active.string = this.name.asString;
 		active.align = \center;
 		active.font = Font.sansSerif( 12 ).boldVariant;
-		if(serverRunning,running,stopped);
+		if(this.serverRunning, running, stopped);
 
 		makeDefault = gui.button.new(w, Rect(0,0, 54, 18));
 		makeDefault.font = font;
@@ -109,8 +109,8 @@
 				{char === $n } { this.queryAllNodes(false) }
 				{char === $N } { this.queryAllNodes(true) }
 				{char === $l } { this.tryPerform(\meter) }
-				{char === $p}  { if(serverRunning) { this.plotTree } }
-				{char === $ }  { if(serverRunning.not) { this.boot } }
+				{char === $p}  { if(this.serverRunning) { this.plotTree } }
+				{char === $ }  { if(this.serverRunning.not) { this.boot } }
 				{char === $s } { if( (this.isLocal and: (GUI.id == \qt)) or: ( this.inProcess ))
 					                 {this.scope(options.numOutputBusChannels)}
 					                 {warn("Scope not supported")}
@@ -171,7 +171,7 @@
 			};
 			stopDump = {
 				this.dumpOSC(0);
-				if(serverRunning) { this.startAliveThread };
+				if(this.serverRunning) { this.startAliveThread };
 				dumping = false;
 				w.name = label;
 				CmdPeriod.remove(blockAliveThread);
@@ -215,7 +215,7 @@
 			makeDefault.value = (Server.default == this).binaryValue;
 		};
 
-		if(serverRunning,running,stopped);
+		if(this.serverRunning, running, stopped);
 
 		w.view.decorator.nextLine;
 
@@ -270,13 +270,13 @@
 					["M", nil, faintRed]
 					])
 				.action_({arg me;
-					this.serverRunning.if({
+					if(this.serverRunning) {
 						muteActions[me.value].value;
-						}, {
+					} {
 						"The server must be booted to mute it".warn;
 						me.value_(0);
-						})
-					});
+					}
+				});
 
 			volumeNum = gui.numberBox.new(w, Rect(0, 0, 28, 18))
 				.font_(font)
@@ -331,7 +331,7 @@
  		w.front;
 
 		ctlr = SimpleController(this)
-			.put(\serverRunning, {	if(serverRunning,running,stopped) })
+			.put(\serverRunning, {	if(this.serverRunning, running, stopped) })
 			.put(\counts,{
 				countsViews.at(0).string = statusWatcher.avgCPU.round(0.1);
 				countsViews.at(1).string = statusWatcher.peakCPU.round(0.1);

--- a/SCClassLibrary/scide_scqt/ScIDE.sc
+++ b/SCClassLibrary/scide_scqt/ScIDE.sc
@@ -47,6 +47,9 @@ ScIDE {
 		})
 		.put(\dumpOSC, { | volume, what, code |
 			this.prSend( if(code.asBoolean, \dumpOSCStarted, \dumpOSCStopped) );
+		})
+		.put(\recording, { | volume, what, code |
+			this.prSend( if(code.asBoolean, \recordingStarted, \recordingStopped) );
 		});
 
 		volumeController.remove;

--- a/SCClassLibrary/scide_scqt/ScIDE.sc
+++ b/SCClassLibrary/scide_scqt/ScIDE.sc
@@ -50,6 +50,9 @@ ScIDE {
 		})
 		.put(\recording, { | volume, what, code |
 			this.prSend( if(code.asBoolean, \recordingStarted, \recordingStopped) );
+		})
+		.put(\pausedRecording, { | volume, what |
+			this.prSend(\recordingPaused);
 		});
 
 		volumeController.remove;

--- a/SCClassLibrary/scide_scqt/ScIDE.sc
+++ b/SCClassLibrary/scide_scqt/ScIDE.sc
@@ -39,7 +39,7 @@ ScIDE {
 		serverController = SimpleController(server)
 		.put(\serverRunning, { | server, what, extraArg |
 			this.prSend(\defaultServerRunningChanged, [
-				server.serverRunning, server.addr.hostname, server.addr.port, server.unresponsive]);
+				server.serverRunning, server.addr.hostname, server.addr.port, server.unresponsive].postln);
 		})
 		.put(\default, { | server, what, newServer |
 			("changed default server to:" + newServer.name).postln;
@@ -66,7 +66,7 @@ ScIDE {
 		defaultServer = server;
 
 		this.prSend(\defaultServerRunningChanged, [
-			server.serverRunning, server.addr.hostname, server.addr.port, server.unresponsive]);
+			server.serverRunning, server.addr.hostname, server.addr.port, server.unresponsive].postln);
 		this.prSend( if(server.volume.isMuted, \serverMuted, \serverUnmuted) );
 		this.prSend( if(server.dumpMode.asBoolean, \dumpOSCStarted, \dumpOSCStopped) );
 		this.prSend( \serverAmpRange, "%,%".format(server.volume.min, server.volume.max) );

--- a/SCClassLibrary/scide_scqt/ScIDE.sc
+++ b/SCClassLibrary/scide_scqt/ScIDE.sc
@@ -39,7 +39,7 @@ ScIDE {
 		serverController = SimpleController(server)
 		.put(\serverRunning, { | server, what, extraArg |
 			this.prSend(\defaultServerRunningChanged, [
-				server.serverRunning, server.addr.hostname, server.addr.port]);
+				server.serverRunning, server.addr.hostname, server.addr.port, server.unresponsive].postln);
 		})
 		.put(\default, { | server, what, newServer |
 			("changed default server to:" + newServer.name).postln;
@@ -66,7 +66,7 @@ ScIDE {
 		defaultServer = server;
 
 		this.prSend(\defaultServerRunningChanged, [
-			server.serverRunning, server.addr.hostname, server.addr.port]);
+			server.serverRunning, server.addr.hostname, server.addr.port, server.unresponsive].postln);
 		this.prSend( if(server.volume.isMuted, \serverMuted, \serverUnmuted) );
 		this.prSend( if(server.dumpMode.asBoolean, \dumpOSCStarted, \dumpOSCStopped) );
 		this.prSend( \serverAmpRange, "%,%".format(server.volume.min, server.volume.max) );
@@ -350,15 +350,15 @@ ScIDE {
 	*setTextByQUuid {|quuid, funcID, text, start = 0, range = -1|
 		this.prSend(\setDocumentText, [quuid, funcID, text, start, range]);
 	}
-    
+
     *setSelectionByQUuid {|quuid, start, length|
         this.prSend(\setDocumentSelection, [quuid, start, length]);
     }
-	
+
 	*setEditablebyQUuid {|quuid, editable|
 		this.prSend(\setDocumentEditable, [quuid, editable]);
 	}
-	
+
 	*setPromptsToSavebyQUuid {|quuid, prompts|
 		this.prSend(\setDocumentPromptsToSave, [quuid, prompts]);
 	}
@@ -366,7 +366,7 @@ ScIDE {
 	*setCurrentDocumentByQUuid {|quuid|
 		this.prSend(\setCurrentDocument, [quuid]);
 	}
-	
+
 	*removeDocUndoByQUuid {|quuid|
 		this.prSend(\removeDocUndo, [quuid]);
 	}
@@ -386,11 +386,11 @@ ScIDE {
 	*setDocumentKeyUpEnabled {|quuid, bool|
 		this.prSend(\enableDocumentKeyUpAction, [quuid, bool]);
 	}
-	
+
 	*setDocumentGlobalKeyDownEnabled {|bool|
 		this.prSend(\enableDocumentGlobalKeyDownAction, [bool]);
 	}
-	
+
 	*setDocumentGlobalKeyUpEnabled {|bool|
 		this.prSend(\enableDocumentGlobalKeyUpAction, [bool]);
 	}
@@ -639,7 +639,7 @@ Document {
 		_ScIDE_SetDocTextMirror
 		this.primitiveFailed
 	}
-    
+
     prSetSelectionMirror {|quuid, start, size|
 		_ScIDE_SetDocSelectionMirror
 		this.primitiveFailed
@@ -899,12 +899,12 @@ Document {
 		this.prSetSelectionMirror(quuid, start, length); // set the backend mirror
         ScIDE.setSelectionByQUuid(quuid, start, length); // set the IDE doc
     }
-    
+
 	editable_ { | bool=true |
 		editable = bool;
 		ScIDE.setEditablebyQUuid(quuid, bool);
 	}
-	
+
 	promptToSave_ { | bool |
 		promptToSave = bool;
 		ScIDE.setPromptsToSavebyQUuid(quuid, bool);

--- a/SCClassLibrary/scide_scqt/ScIDE.sc
+++ b/SCClassLibrary/scide_scqt/ScIDE.sc
@@ -39,7 +39,7 @@ ScIDE {
 		serverController = SimpleController(server)
 		.put(\serverRunning, { | server, what, extraArg |
 			this.prSend(\defaultServerRunningChanged, [
-				server.serverRunning, server.addr.hostname, server.addr.port, server.unresponsive].postln);
+				server.serverRunning, server.addr.hostname, server.addr.port, server.unresponsive]);
 		})
 		.put(\default, { | server, what, newServer |
 			("changed default server to:" + newServer.name).postln;
@@ -66,7 +66,7 @@ ScIDE {
 		defaultServer = server;
 
 		this.prSend(\defaultServerRunningChanged, [
-			server.serverRunning, server.addr.hostname, server.addr.port, server.unresponsive].postln);
+			server.serverRunning, server.addr.hostname, server.addr.port, server.unresponsive]);
 		this.prSend( if(server.volume.isMuted, \serverMuted, \serverUnmuted) );
 		this.prSend( if(server.dumpMode.asBoolean, \dumpOSCStarted, \dumpOSCStopped) );
 		this.prSend( \serverAmpRange, "%,%".format(server.volume.min, server.volume.max) );

--- a/SCClassLibrary/scide_scqt/ScIDE.sc
+++ b/SCClassLibrary/scide_scqt/ScIDE.sc
@@ -45,13 +45,13 @@ ScIDE {
 			("changed default server to:" + newServer.name).postln;
 			this.defaultServer = newServer;
 		})
-		.put(\dumpOSC, { | volume, what, code |
+		.put(\dumpOSC, { | server, what, code |
 			this.prSend( if(code.asBoolean, \dumpOSCStarted, \dumpOSCStopped) );
 		})
-		.put(\recording, { | volume, what, code |
-			this.prSend( if(code.asBoolean, \recordingStarted, \recordingStopped) );
+		.put(\recording, { | theChanger, what, flag |
+			this.prSend( if(flag.asBoolean, \recordingStarted, \recordingStopped) );
 		})
-		.put(\pausedRecording, { | volume, what |
+		.put(\pausedRecording, { | theChanger, what |
 			this.prSend(\recordingPaused);
 		});
 

--- a/SCClassLibrary/scide_scqt/ScIDE.sc
+++ b/SCClassLibrary/scide_scqt/ScIDE.sc
@@ -53,6 +53,9 @@ ScIDE {
 		})
 		.put(\pausedRecording, { | theChanger, what |
 			this.prSend(\recordingPaused);
+		})
+		.put(\recordingDuration, { | theChanger, what, duration |
+			this.prSend(\recordingDuration, duration.asString);
 		});
 
 		volumeController.remove;

--- a/editors/sc-ide/core/sc_server.cpp
+++ b/editors/sc-ide/core/sc_server.cpp
@@ -162,12 +162,12 @@ void ScServer::createActions(Settings::Manager * settings)
     connect( action, SIGNAL(toggled(bool)), this, SIGNAL(recordingChanged(bool)) );
     settings->addAction( action, "synth-server-record", synthServerCategory);
 
-	mActions[PauseRecord] = action = new QAction(tr("Pause Recording"), this);
-	 action->setCheckable(true);
-	connect( action, SIGNAL(triggered(bool)), this, SLOT(pauseRecording(bool)) );
-	//connect( action, SIGNAL(toggled(bool)), this, SLOT(pauseRecording(bool)) );
-	settings->addAction( action, "synth-server-pause-recording", synthServerCategory);
-	
+    mActions[PauseRecord] = action = new QAction(tr("Pause Recording"), this);
+    action->setCheckable(true);
+    connect( action, SIGNAL(triggered(bool)), this, SLOT(pauseRecording(bool)) );
+    //connect( action, SIGNAL(toggled(bool)), this, SLOT(pauseRecording(bool)) );
+    settings->addAction( action, "synth-server-pause-recording", synthServerCategory);
+
 
     connect( mActions[Boot], SIGNAL(changed()), this, SLOT(updateToggleRunningAction()) );
     connect( mActions[Quit], SIGNAL(changed()), this, SLOT(updateToggleRunningAction()) );
@@ -325,51 +325,51 @@ bool ScServer::isRecording() const { return mIsRecording; }
 
 
 void ScServer::setRecording( bool doRecord )
-{
-    if (!isRunning())
-        return;
+    {
+        if (!isRunning())
+            return;
 
-	if(!mIsRecording) {
-		mRecordTime = system_clock::now();
-	} else if(mIsRecordingPaused) {
-		mRecordTime = mRecordTime + (system_clock::now() - mPauseTime);
-	}
+        if(!mIsRecording) {
+            mRecordTime = system_clock::now();
+        } else if(mIsRecordingPaused) {
+            mRecordTime = mRecordTime + (system_clock::now() - mPauseTime);
+        }
 
-    mIsRecording = doRecord;
+        mIsRecording = doRecord;
 
-	if (doRecord) {
-		mRecordTimer.start();
-	} else {
-		mRecordTimer.stop();
-	}
-	mIsRecordingPaused = false;
-    updateRecordingAction();
+        if (doRecord) {
+            mRecordTimer.start();
+        } else {
+            mRecordTimer.stop();
+        }
+        mIsRecordingPaused = false;
+        updateRecordingAction();
 }
 
 void ScServer::pauseRecording( bool flag )
-{
-	if(flag) {
-		if (isRunning()) {
-			mRecordTimer.stop();
-			mPauseTime = system_clock::now();
-			updateRecordingAction();
-		}
-		mIsRecordingPaused = true;
-	}
-	else {
-		if(mIsRecording) {
-			setRecording(true);
-		}
-	}
+    {
+        if(flag) {
+            if (isRunning()) {
+                mRecordTimer.stop();
+                mPauseTime = system_clock::now();
+                updateRecordingAction();
+            }
+            mIsRecordingPaused = true;
+        }
+        else {
+            if(mIsRecording) {
+                setRecording(true);
+            }
+        }
 }
 
 
 void ScServer::sendRecording( bool doRecord )
 {
-	static const QString startRecordingCommand("ScIDE.defaultServer.record");
-	static const QString stopRecordingCommand("ScIDE.defaultServer.stopRecording");
-	setRecording(doRecord);
-	mLang->evaluateCode(doRecord ? startRecordingCommand : stopRecordingCommand);
+    static const QString startRecordingCommand("ScIDE.defaultServer.record");
+    static const QString stopRecordingCommand("ScIDE.defaultServer.stopRecording");
+    setRecording(doRecord);
+    mLang->evaluateCode(doRecord ? startRecordingCommand : stopRecordingCommand);
 }
 
 
@@ -399,8 +399,7 @@ void ScServer::updateRecordingAction()
         mActions[Record]->setText( "Start Recording" );
     }
     mActions[Record]->setChecked( isRecording() );
-	mActions[PauseRecord]->setChecked( mIsRecordingPaused );
-	
+    mActions[PauseRecord]->setChecked( mIsRecordingPaused );
 }
 
 void ScServer::onScLangStateChanged( QProcess::ProcessState )
@@ -415,11 +414,11 @@ void ScServer::onScLangReponse( const QString & selector, const QString & data )
     static QString unmutedSelector("serverUnmuted");
     static QString ampSelector("serverAmp");
     static QString ampRangeSelector("serverAmpRange");
-	static QString startDumpOSCSelector("dumpOSCStarted");
-	static QString stopDumpOSCSelector("dumpOSCStopped");
-	static QString startRecordingSelector("recordingStarted");
-	static QString pauseRecordingSelector("recordingPaused");
-	static QString stopRecordingSelector("recordingStopped");
+    static QString startDumpOSCSelector("dumpOSCStarted");
+    static QString stopDumpOSCSelector("dumpOSCStopped");
+    static QString startRecordingSelector("recordingStarted");
+    static QString pauseRecordingSelector("recordingPaused");
+    static QString stopRecordingSelector("recordingStopped");
 
 
     if (selector == defaultServerRunningChangedSelector)
@@ -435,15 +434,15 @@ void ScServer::onScLangReponse( const QString & selector, const QString & data )
 	else if (selector == stopDumpOSCSelector) {
         mActions[DumpOSC]->setChecked(false);
     }
-	else if (selector == startRecordingSelector) {
-		setRecording(true);
-	}
-	else if (selector == pauseRecordingSelector) {
-		pauseRecording(true);
-	}
-	else if (selector == stopRecordingSelector) {
-		setRecording(false);
-	}
+    else if (selector == startRecordingSelector) {
+        setRecording(true);
+    }
+    else if (selector == pauseRecordingSelector) {
+        pauseRecording(true);
+    }
+    else if (selector == stopRecordingSelector) {
+        setRecording(false);
+    }
     else if (selector == ampSelector) {
         bool ok;
         float volume = data.mid(1, data.size() - 2).toFloat(&ok);
@@ -493,9 +492,9 @@ void ScServer::handleRuningStateChangedMsg( const QString & data )
 
         success = doc[2].Read(port);
         if (!success) return; // LATER: report error?
-		
-		success = doc[3].Read(serverUnresponsive);
-		if (!success) return; // LATER: report error?
+
+        success = doc[3].Read(serverUnresponsive);
+        if (!success) return; // LATER: report error?
     }
 
     QString qstrHostName( hostName.c_str() );
@@ -617,7 +616,7 @@ void ScServer::updateEnabledActions()
     mActions[Volume]->setEnabled(langAndServerRunning);
     mActions[VolumeRestore]->setEnabled(langAndServerRunning);
     mActions[Record]->setEnabled(langAndServerRunning);
-	mActions[PauseRecord]->setEnabled(langAndServerRunning);
+    mActions[PauseRecord]->setEnabled(langAndServerRunning);
     mActions[DumpOSC]->setEnabled(langAndServerRunning);
 }
 

--- a/editors/sc-ide/core/sc_server.cpp
+++ b/editors/sc-ide/core/sc_server.cpp
@@ -346,20 +346,22 @@ void ScServer::setRecording( bool doRecord )
 
 void ScServer::pauseRecording( bool flag )
     {
-        if(flag) {
-            if (isRunning()) {
-                mRecordTimer.stop();
-                mPauseTime = recordingTime();
-                updateRecordingAction();
+        if(mIsRecordingPaused != flag) {
+            if(flag) {
+                if (isRunning()) {
+                    mRecordTimer.stop();
+                    mPauseTime = recordingTime();
+                    updateRecordingAction();
+                }
+                mIsRecordingPaused = true;
+                mLang->evaluateCode( QString("ScIDE.defaultServer.pauseRecording"), true );
             }
-            mIsRecordingPaused = true;
-            mLang->evaluateCode( QString("ScIDE.defaultServer.pauseRecording"), true );
-        }
-        else {
-            if(mIsRecording) {
-                setRecording(true);
+            else {
+                if(mIsRecording) {
+                    setRecording(true);
+                }
             }
-        }
+    }
 }
 
 

--- a/editors/sc-ide/core/sc_server.cpp
+++ b/editors/sc-ide/core/sc_server.cpp
@@ -156,10 +156,13 @@ void ScServer::createActions(Settings::Manager * settings)
     connect(action, SIGNAL(triggered()), this, SLOT(restoreVolume()));
     settings->addAction( action, "synth-server-volume-restore", synthServerCategory);
 
-    mActions[Record] = action = new QAction(this);
+    mActions[Record] = action = new QAction(tr("Recording"), this);
     action->setCheckable(true);
     connect( action, SIGNAL(triggered(bool)), this, SLOT(setRecording(bool)) );
     connect( action, SIGNAL(toggled(bool)), this, SIGNAL(recordingChanged(bool)) );
+    settings->addAction( action, "synth-server-record", synthServerCategory);
+
+
 
     connect( mActions[Boot], SIGNAL(changed()), this, SLOT(updateToggleRunningAction()) );
     connect( mActions[Quit], SIGNAL(changed()), this, SLOT(updateToggleRunningAction()) );
@@ -380,6 +383,8 @@ void ScServer::onScLangReponse( const QString & selector, const QString & data )
     static QString ampRangeSelector("serverAmpRange");
 	static QString startDumpOSCSelector("dumpOSCStarted");
 	static QString stopDumpOSCSelector("dumpOSCStopped");
+	static QString startRecordingSelector("recordingStarted");
+	static QString stopRecordingSelector("recordingStopped");
 
 
     if (selector == defaultServerRunningChangedSelector)
@@ -395,6 +400,12 @@ void ScServer::onScLangReponse( const QString & selector, const QString & data )
 	else if (selector == stopDumpOSCSelector) {
         mActions[DumpOSC]->setChecked(false);
     }
+	else if (selector == startRecordingSelector) {
+		mActions[Record]->setChecked(true);
+	}
+	else if (selector == stopRecordingSelector) {
+		mActions[Record]->setChecked(false);
+	}
     else if (selector == ampSelector) {
         bool ok;
         float volume = data.mid(1, data.size() - 2).toFloat(&ok);

--- a/editors/sc-ide/core/sc_server.cpp
+++ b/editors/sc-ide/core/sc_server.cpp
@@ -427,7 +427,7 @@ void ScServer::handleRuningStateChangedMsg( const QString & data )
     stream << data.toStdString();
     YAML::Parser parser(stream);
 
-    bool serverRunningState;
+    bool serverRunningState, serverUnresponsive;
     std::string hostName;
     int port;
 
@@ -443,13 +443,16 @@ void ScServer::handleRuningStateChangedMsg( const QString & data )
 
         success = doc[2].Read(port);
         if (!success) return; // LATER: report error?
+		
+		success = doc[3].Read(serverUnresponsive);
+		if (!success) return; // LATER: report error?
     }
 
     QString qstrHostName( hostName.c_str() );
 
-    onRunningStateChanged( serverRunningState, qstrHostName, port );
+    onRunningStateChanged( serverRunningState, qstrHostName, port);
 
-    emit runningStateChange( serverRunningState, qstrHostName, port );
+    emit runningStateChange( serverRunningState, qstrHostName, port, serverUnresponsive );
 }
 
 void ScServer::timerEvent(QTimerEvent * event)

--- a/editors/sc-ide/core/sc_server.hpp
+++ b/editors/sc-ide/core/sc_server.hpp
@@ -103,7 +103,7 @@ public slots:
     void setRecording( bool active );
 
 signals:
-    void runningStateChange( bool running, QString const & hostName, int port );
+    void runningStateChange( bool running, QString const & hostName, int port, bool unresponsive );
     void updateServerStatus (int ugenCount, int synthCount,
                              int groupCount, int defCount,
                              float avgCPU, float peakCPU);

--- a/editors/sc-ide/core/sc_server.hpp
+++ b/editors/sc-ide/core/sc_server.hpp
@@ -59,7 +59,7 @@ public:
         VolumeDown,
         VolumeRestore,
         Record,
-		PauseRecord,
+        PauseRecord,
 
         ActionCount
     };

--- a/editors/sc-ide/core/sc_server.hpp
+++ b/editors/sc-ide/core/sc_server.hpp
@@ -100,6 +100,7 @@ public slots:
     void restoreVolume();
     void mute() { setMuted(true); }
     void unmute() { setMuted(false); }
+    void sendRecording( bool active );
     void setRecording( bool active );
 
 signals:

--- a/editors/sc-ide/core/sc_server.hpp
+++ b/editors/sc-ide/core/sc_server.hpp
@@ -80,7 +80,10 @@ public:
     void setDumpingOSC( bool dumping );
 
     bool isRecording() const;
+    bool isPaused() const;
+
     boost::chrono::seconds recordingTime() const;
+    boost::chrono::system_clock::time_point beginningOfRecording() const;
 
 public slots:
     void boot();
@@ -113,6 +116,8 @@ signals:
     void volumeChanged( float volume );
     void mutedChanged( bool muted );
     void recordingChanged( bool recording );
+    void pauseChanged( bool paused );
+
 
 private slots:
     void onScLangStateChanged( QProcess::ProcessState );
@@ -168,7 +173,7 @@ private:
     VolumeWidget *mVolumeWidget;
     QTimer mRecordTimer;
     boost::chrono::system_clock::time_point mRecordTime;
-    boost::chrono::system_clock::time_point mPauseTime;
+    boost::chrono::seconds mPauseTime;
     bool mIsRecording;
     bool mIsRecordingPaused;
 };

--- a/editors/sc-ide/core/sc_server.hpp
+++ b/editors/sc-ide/core/sc_server.hpp
@@ -59,6 +59,7 @@ public:
         VolumeDown,
         VolumeRestore,
         Record,
+		PauseRecord,
 
         ActionCount
     };
@@ -102,6 +103,7 @@ public slots:
     void unmute() { setMuted(false); }
     void sendRecording( bool active );
     void setRecording( bool active );
+    void pauseRecording( bool flag );
 
 signals:
     void runningStateChange( bool running, QString const & hostName, int port, bool unresponsive );
@@ -166,7 +168,9 @@ private:
     VolumeWidget *mVolumeWidget;
     QTimer mRecordTimer;
     boost::chrono::system_clock::time_point mRecordTime;
+    boost::chrono::system_clock::time_point mPauseTime;
     bool mIsRecording;
+    bool mIsRecordingPaused;
 };
 
 }

--- a/editors/sc-ide/core/sc_server.hpp
+++ b/editors/sc-ide/core/sc_server.hpp
@@ -82,8 +82,7 @@ public:
     bool isRecording() const;
     bool isPaused() const;
 
-    boost::chrono::seconds recordingTime() const;
-    boost::chrono::system_clock::time_point beginningOfRecording() const;
+    int recordingTime() const;
 
 public slots:
     void boot();
@@ -171,9 +170,7 @@ private:
     QAction * mActions[ActionCount];
 
     VolumeWidget *mVolumeWidget;
-    QTimer mRecordTimer;
-    boost::chrono::system_clock::time_point mRecordTime;
-    boost::chrono::seconds mPauseTime;
+    int mRecordTime;
     bool mIsRecording;
     bool mIsRecordingPaused;
 };

--- a/editors/sc-ide/widgets/audio_status_box.cpp
+++ b/editors/sc-ide/widgets/audio_status_box.cpp
@@ -54,6 +54,7 @@ AudioStatusBox::AudioStatusBox(ScServer *server, QWidget *parent):
     setLayout(layout);
 
     server->action(ScServer::Record)->setProperty("keep_menu_open", true);
+	server->action(ScServer::PauseRecord)->setProperty("keep_menu_open", true);
     server->action(ScServer::VolumeRestore)->setProperty("keep_menu_open", true);
     server->action(ScServer::Mute)->setProperty("keep_menu_open", true);
     server->action(ScServer::DumpOSC)->setProperty("keep_menu_open", true);
@@ -72,6 +73,7 @@ AudioStatusBox::AudioStatusBox(ScServer *server, QWidget *parent):
     addAction( server->action(ScServer::DumpOSC) );
     addActionSeparator();
     addAction( server->action(ScServer::Record) );
+	addAction( server->action(ScServer::PauseRecord) );
     addActionSeparator();
     addAction( server->action(ScServer::VolumeRestore) );
     addAction( server->action(ScServer::Mute) );

--- a/editors/sc-ide/widgets/audio_status_box.cpp
+++ b/editors/sc-ide/widgets/audio_status_box.cpp
@@ -107,12 +107,12 @@ void AudioStatusBox::onServerStatusReply(int ugens, int synths, int groups, int 
 void AudioStatusBox::onServerRunningChanged(bool running, const QString &, int, bool unresponsive)
 {
 	
-	if(running) {
-		mStatisticsLabel->setTextColor(Qt::green);
-		mVolumeLabel->setTextColor(Qt::green);
-	} else if (unresponsive) {
+	if (unresponsive) {
 		mStatisticsLabel->setTextColor(Qt::yellow);
 		mVolumeLabel->setTextColor(Qt::yellow);
+	} else if(running) {
+		mStatisticsLabel->setTextColor(Qt::green);
+		mVolumeLabel->setTextColor(Qt::green);
 	} else {
 		mStatisticsLabel->setTextColor(Qt::white);
 		mVolumeLabel->setTextColor(Qt::white);

--- a/editors/sc-ide/widgets/audio_status_box.cpp
+++ b/editors/sc-ide/widgets/audio_status_box.cpp
@@ -86,13 +86,11 @@ AudioStatusBox::AudioStatusBox(ScServer *server, QWidget *parent):
     connect(server, SIGNAL(volumeChanged(float)), this, SLOT(updateVolumeLabel(float)));
     connect(server, SIGNAL(mutedChanged(bool)), this, SLOT(updateMuteLabel(bool)));
     connect(server, SIGNAL(recordingChanged(bool)), this, SLOT(updateRecordLabel(bool)));
-    connect(server, SIGNAL(pauseChanged(bool)), this, SLOT(updateRecordLabelPause(bool)));
 
     onServerRunningChanged(false, "", 0, false);
     updateVolumeLabel( mServer->volume() );
     updateMuteLabel( mServer->isMuted() );
     updateRecordLabel( mServer->isRecording() );
-    updateRecordLabelPause( mServer->isPaused() );
 }
 
 void AudioStatusBox::onServerStatusReply(int ugens, int synths, int groups, int synthDefs,
@@ -166,15 +164,5 @@ void AudioStatusBox::updateRecordLabel( bool recording )
     mRecordLabel->setTextColor( recording ? Qt::red : QColor(30,30,30) );
 }
 
-void AudioStatusBox::updateRecordLabelPause( bool paused )
-{
-    if(paused) {
-         mRecordLabel->setTextColor(Qt::yellow);
-    } else if ( mServer->isRecording() ) {
-        mRecordLabel->setTextColor(Qt::red);
-    } else {
-        mRecordLabel->setTextColor(QColor(30,30,30));
-    }
-}
 
 } // namespace ScIDE

--- a/editors/sc-ide/widgets/audio_status_box.cpp
+++ b/editors/sc-ide/widgets/audio_status_box.cpp
@@ -86,11 +86,13 @@ AudioStatusBox::AudioStatusBox(ScServer *server, QWidget *parent):
     connect(server, SIGNAL(volumeChanged(float)), this, SLOT(updateVolumeLabel(float)));
     connect(server, SIGNAL(mutedChanged(bool)), this, SLOT(updateMuteLabel(bool)));
     connect(server, SIGNAL(recordingChanged(bool)), this, SLOT(updateRecordLabel(bool)));
+    connect(server, SIGNAL(pauseChanged(bool)), this, SLOT(updateRecordLabelPause(bool)));
 
     onServerRunningChanged(false, "", 0, false);
     updateVolumeLabel( mServer->volume() );
     updateMuteLabel( mServer->isMuted() );
     updateRecordLabel( mServer->isRecording() );
+    updateRecordLabelPause( mServer->isPaused() );
 }
 
 void AudioStatusBox::onServerStatusReply(int ugens, int synths, int groups, int synthDefs,
@@ -162,6 +164,17 @@ void AudioStatusBox::updateMuteLabel( bool muted )
 void AudioStatusBox::updateRecordLabel( bool recording )
 {
     mRecordLabel->setTextColor( recording ? Qt::red : QColor(30,30,30) );
+}
+
+void AudioStatusBox::updateRecordLabelPause( bool paused )
+{
+    if(paused) {
+         mRecordLabel->setTextColor(Qt::yellow);
+    } else if ( mServer->isRecording() ) {
+        mRecordLabel->setTextColor(Qt::red);
+    } else {
+        mRecordLabel->setTextColor(QColor(30,30,30));
+    }
 }
 
 } // namespace ScIDE

--- a/editors/sc-ide/widgets/audio_status_box.cpp
+++ b/editors/sc-ide/widgets/audio_status_box.cpp
@@ -109,16 +109,16 @@ void AudioStatusBox::onServerStatusReply(int ugens, int synths, int groups, int 
 void AudioStatusBox::onServerRunningChanged(bool running, const QString &, int, bool unresponsive)
 {
 	
-	if (unresponsive) {
-		mStatisticsLabel->setTextColor(Qt::yellow);
-		mVolumeLabel->setTextColor(Qt::yellow);
-	} else if(running) {
-		mStatisticsLabel->setTextColor(Qt::green);
-		mVolumeLabel->setTextColor(Qt::green);
-	} else {
-		mStatisticsLabel->setTextColor(Qt::white);
-		mVolumeLabel->setTextColor(Qt::white);
-	};
+    if (unresponsive) {
+        mStatisticsLabel->setTextColor(Qt::yellow);
+        mVolumeLabel->setTextColor(Qt::yellow);
+    } else if(running) {
+        mStatisticsLabel->setTextColor(Qt::green);
+        mVolumeLabel->setTextColor(Qt::green);
+    } else {
+        mStatisticsLabel->setTextColor(Qt::white);
+        mVolumeLabel->setTextColor(Qt::white);
+    };
 	
     if (!running)
         onServerStatusReply(0, 0, 0, 0, 0, 0);

--- a/editors/sc-ide/widgets/audio_status_box.cpp
+++ b/editors/sc-ide/widgets/audio_status_box.cpp
@@ -77,15 +77,15 @@ AudioStatusBox::AudioStatusBox(ScServer *server, QWidget *parent):
     addAction( server->action(ScServer::Mute) );
     addAction( server->action(ScServer::Volume) );
 
-    connect(server, SIGNAL(runningStateChange(bool,QString,int)),
-            this, SLOT(onServerRunningChanged(bool,QString,int)));
+    connect(server, SIGNAL(runningStateChange(bool,QString,int,bool)),
+            this, SLOT(onServerRunningChanged(bool,QString,int,bool)));
     connect(server, SIGNAL(updateServerStatus(int,int,int,int,float,float)),
             this, SLOT(onServerStatusReply(int,int,int,int,float,float)));
     connect(server, SIGNAL(volumeChanged(float)), this, SLOT(updateVolumeLabel(float)));
     connect(server, SIGNAL(mutedChanged(bool)), this, SLOT(updateMuteLabel(bool)));
     connect(server, SIGNAL(recordingChanged(bool)), this, SLOT(updateRecordLabel(bool)));
 
-    onServerRunningChanged(false, "", 0);
+    onServerRunningChanged(false, "", 0, false);
     updateVolumeLabel( mServer->volume() );
     updateMuteLabel( mServer->isMuted() );
     updateRecordLabel( mServer->isRecording() );
@@ -104,11 +104,20 @@ void AudioStatusBox::onServerStatusReply(int ugens, int synths, int groups, int 
     updateStatistics();
 }
 
-void AudioStatusBox::onServerRunningChanged(bool running, const QString &, int)
+void AudioStatusBox::onServerRunningChanged(bool running, const QString &, int, bool unresponsive)
 {
-    mStatisticsLabel->setTextColor( running ? Qt::green : Qt::white);
-    mVolumeLabel->setTextColor( running ? Qt::green : Qt::white );
-
+	
+	if(running) {
+		mStatisticsLabel->setTextColor(Qt::green);
+		mVolumeLabel->setTextColor(Qt::green);
+	} else if (unresponsive) {
+		mStatisticsLabel->setTextColor(Qt::yellow);
+		mVolumeLabel->setTextColor(Qt::yellow);
+	} else {
+		mStatisticsLabel->setTextColor(Qt::white);
+		mVolumeLabel->setTextColor(Qt::white);
+	};
+	
     if (!running)
         onServerStatusReply(0, 0, 0, 0, 0, 0);
 }

--- a/editors/sc-ide/widgets/audio_status_box.hpp
+++ b/editors/sc-ide/widgets/audio_status_box.hpp
@@ -41,7 +41,6 @@ private slots:
     void updateVolumeLabel(float volume);
     void updateMuteLabel(bool muted);
     void updateRecordLabel(bool recording);
-    void updateRecordLabelPause(bool paused);
 
 
 protected:

--- a/editors/sc-ide/widgets/audio_status_box.hpp
+++ b/editors/sc-ide/widgets/audio_status_box.hpp
@@ -35,7 +35,7 @@ public:
 private slots:
     void onServerStatusReply(int ugens, int synths, int groups, int synthDefs,
                              float avgCPU, float peakCPU);
-    void onServerRunningChanged( bool running, QString const & hostName, int port );
+    void onServerRunningChanged( bool running, QString const & hostName, int port, bool unresponsive );
 
     void updateStatistics();
     void updateVolumeLabel(float volume);

--- a/editors/sc-ide/widgets/audio_status_box.hpp
+++ b/editors/sc-ide/widgets/audio_status_box.hpp
@@ -41,6 +41,8 @@ private slots:
     void updateVolumeLabel(float volume);
     void updateMuteLabel(bool muted);
     void updateRecordLabel(bool recording);
+    void updateRecordLabelPause(bool paused);
+
 
 protected:
     void wheelEvent(QWheelEvent *);

--- a/editors/sc-ide/widgets/main_window.cpp
+++ b/editors/sc-ide/widgets/main_window.cpp
@@ -659,6 +659,7 @@ void MainWindow::createMenus()
     menu->addAction( mMain->scServer()->action(ScServer::PlotTree) );
     menu->addAction( mMain->scServer()->action(ScServer::DumpOSC) );
 	menu->addAction( mMain->scServer()->action(ScServer::Record) );
+	menu->addAction( mMain->scServer()->action(ScServer::PauseRecord) );
     menu->addAction( mMain->scServer()->action(ScServer::VolumeUp) );
     menu->addAction( mMain->scServer()->action(ScServer::VolumeDown) );
     menu->addAction( mMain->scServer()->action(ScServer::VolumeRestore) );

--- a/editors/sc-ide/widgets/main_window.cpp
+++ b/editors/sc-ide/widgets/main_window.cpp
@@ -658,6 +658,7 @@ void MainWindow::createMenus()
     menu->addAction( mMain->scServer()->action(ScServer::DumpNodeTreeWithControls) );
     menu->addAction( mMain->scServer()->action(ScServer::PlotTree) );
     menu->addAction( mMain->scServer()->action(ScServer::DumpOSC) );
+	menu->addAction( mMain->scServer()->action(ScServer::Record) );
     menu->addAction( mMain->scServer()->action(ScServer::VolumeUp) );
     menu->addAction( mMain->scServer()->action(ScServer::VolumeDown) );
     menu->addAction( mMain->scServer()->action(ScServer::VolumeRestore) );


### PR DESCRIPTION
This PR is still being developed, but it shouldn't break and can be tested.

This fixes #774 and fixes #889: instead of just assuming that the server is dead, it is taken to be unresponsive. It also fixes #1484.

It factors out all statusWatcher and recording functionality to a separate class (````ServerStatusWatcher```` and ````Recorder````).  This branch also implements the updating of recording display in the IDE.

There is some more refactoring, in the server code itself, the Volume class, and also the allocation of buffers in Buffer.

While I took care to keep the old interface, this refactor **may break code** that relies on instance variables in ````Server````, these problems are usually easy to solve, by writing, e.g. ````this.avgCPU```` instead of ````avgCPU````.

