### PR TITLE
Fix roomsize logic for GVerb UGen

### DIFF
--- a/HelpSource/Classes/GVerb.schelp
+++ b/HelpSource/Classes/GVerb.schelp
@@ -19,7 +19,7 @@ method:: ar
 argument:: in
 mono input.
 argument:: roomsize
-in squared meters.
+1 to maxroomsize - 1, in squared meters.
 argument:: revtime
 in seconds.
 argument:: damping
@@ -35,7 +35,7 @@ amount of early reflection level.
 argument:: taillevel
 amount of tail level.
 argument:: maxroomsize
-to set the size of the delay lines. Defaults to roomsize + 1.
+>= 2, in square meters, to set the size of the delay lines. Defaults to roomsize + 1.
 argument:: mul
 argument:: add
 

--- a/SCClassLibrary/Common/Audio/GVerb.sc
+++ b/SCClassLibrary/Common/Audio/GVerb.sc
@@ -1,7 +1,7 @@
 GVerb : MultiOutUGen {
 
 	*ar { arg in, roomsize = 10, revtime = 3, damping = 0.5, inputbw =  0.5, spread = 15,
-			drylevel = 1, earlyreflevel = 0.7, taillevel = 0.5, maxroomsize = 300, mul = 1,
+			drylevel = 1, earlyreflevel = 0.7, taillevel = 0.5, maxroomsize = roomsize + 1, mul = 1,
 			add = 0;
 		^this.multiNew('audio', in, roomsize, revtime, damping, inputbw, spread, drylevel,
 			earlyreflevel, taillevel, maxroomsize).madd(mul, add);

--- a/server/plugins/ReverbUGens.cpp
+++ b/server/plugins/ReverbUGens.cpp
@@ -1204,7 +1204,12 @@ void GVerb_Ctor(GVerb *unit)
     unit->earlylevel = 0.; // IN0(7);
     unit->taillevel = 0.; //IN0(8);
 
-    float maxroomsize = unit->maxroomsize = IN0(9);
+    float maxroomsize = unit->maxroomsize = (IN0(9) < 2.0)? 2.0 : IN0(9);
+
+    if (roomsize >= maxroomsize)
+	    roomsize = unit->roomsize = maxroomsize - 1;
+    if (roomsize < 1.0)
+	    roomsize = unit->roomsize = 1.0;
 
     float maxdelay = unit->maxdelay = SAMPLERATE*maxroomsize/340.f;
     float largestdelay = unit->largestdelay = SAMPLERATE*roomsize/340.f;


### PR DESCRIPTION
This set of patches fixes 2 bugs in the roomsize logic of the GVerb UGen.
-  roomsize/maxroomsize values were not checked in the Ctor, but they were in the next() function (through a call to gverb_set_roomsize when the value changes), causing some issues if initializing the synth with invalid values (see commit message for details)
- maxroomsize default value changed to roomsize + 1 instead of 300, to be consistent with help file
- Help file updated to account for these changes.
