### PR TITLE
HelpBrowser: Fix unprintable chars in keyDownAction

### DIFF
--- a/SCClassLibrary/Common/GUI/tools/HelpBrowser.sc
+++ b/SCClassLibrary/Common/GUI/tools/HelpBrowser.sc
@@ -270,7 +270,7 @@ HelpBrowser {
 
 		webView.enterInterpretsSelection = true;
 		webView.keyDownAction = { arg view, char, mods;
-			if( (char.ascii == 13) && (mods.isCtrl || mods.isCmd || mods.isShift) ) {
+			if( (char.notNil and:{char.ascii == 13}) && (mods.isCtrl || mods.isCmd || mods.isShift) ) {
 				view.tryPerform(\evaluateJavaScript,"selectLine()");
 			};
 		};
@@ -278,7 +278,7 @@ HelpBrowser {
 			if( ((key == 70) && mods.isCtrl) || (char == $f && mods.isCmd) ) {
 				toggleFind.value;
 			};
-			if(char.ascii==27) {
+			if(char.notNil and:{char.ascii == 27}) {
 				if(findView.visible) {toggleFind.value};
 			}
 		};


### PR DESCRIPTION
After 035cf21b unprintable chars are assigned to nil. We now check that
char is not nil before trying to get the ascii value.