### PR TITLE
class library: HID: fix else statement in findAvailable

### DIFF
--- a/SCClassLibrary/Common/Control/HID_API.sc
+++ b/SCClassLibrary/Common/Control/HID_API.sc
@@ -68,10 +68,10 @@ HID {
 			available = IdentityDictionary.new;
 			devlist.do { |it, i|
 				available.put( i, HIDInfo.new( *it ) );
-			} { // no devices found
+			};
+		}{ // no devices found
 				"HID: no devices found".postln;
-			}
-		};
+		}
 		"HID: found % devices\n".postf( devlist.size );
 		^available
 	}

--- a/SCClassLibrary/Common/Control/HID_API.sc
+++ b/SCClassLibrary/Common/Control/HID_API.sc
@@ -71,7 +71,7 @@ HID {
 			};
 		}{ // no devices found
 				"HID: no devices found".postln;
-		}
+		};
 		"HID: found % devices\n".postf( devlist.size );
 		^available
 	}


### PR DESCRIPTION
There was a mixup in curly brackets in findAvailable, causing an else statement to never be reached.
This is fixed in this pull request.