### PR TITLE
OSX: return to old default cmake install location ./Install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,6 +81,7 @@ if(APPLE)
 	set_property(DIRECTORY
 		APPEND
 		PROPERTY COMPILE_DEFINITIONS SC_DARWIN)
+	set(CMAEK_INSTALL_PREFIX "${CMAKE_BINARY_DIR}/Install")
 elseif(UNIX)
 	add_definitions(-DSC_DATA_DIR="${CMAKE_INSTALL_PREFIX}/share/SuperCollider")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,7 +81,7 @@ if(APPLE)
 	set_property(DIRECTORY
 		APPEND
 		PROPERTY COMPILE_DEFINITIONS SC_DARWIN)
-	set(CMAEK_INSTALL_PREFIX "${CMAKE_BINARY_DIR}/Install")
+	set(CMAKE_INSTALL_PREFIX "${CMAKE_BINARY_DIR}/Install")
 elseif(UNIX)
 	add_definitions(-DSC_DATA_DIR="${CMAKE_INSTALL_PREFIX}/share/SuperCollider")
 endif()


### PR DESCRIPTION
Currently it's /usr/local, which I don't think anybody uses.