### PR TITLE
Topic/select reject indices

### DIFF
--- a/HelpSource/Classes/SequenceableCollection.schelp
+++ b/HelpSource/Classes/SequenceableCollection.schelp
@@ -136,6 +136,39 @@ y = List[ 10, 5, 77, 55, 12, 123];
 y.indexOfGreaterThan(70);
 ::
 
+method::selectIndex
+Return a new collection of same type as receiver which consists of all indices of those elements of the receiver for which function answers code::true::. The function is passed two arguments, the item and an integer index.
+
+code::
+#[a, b, c, g, h, h, j, h].selectIndex({|item, i| item === \h})
+::
+
+If you want to control what type of collection is returned, use link::Classes/Collection#selectIndexAs::
+
+method::selectIndexAs
+Return a new collection of type emphasis::class:: which consists of all indices of those elements of the receiver for which function answers code::true::. The function is passed two arguments, the item and an integer index.
+
+code::
+#[a, b, c, g, h, h, j, h].selectIndexAs({|item, i| item === \h}, Set)
+::
+
+
+method::rejectIndex
+Return a new collection of same type as receiver which consists of all indices of those elements of the receiver for which function answers code::false::. The function is passed two arguments, the item and an integer index.
+
+code::
+#[a, b, c, g, h, h, j, h].rejectIndex({|item, i| item === \h})
+::
+
+If you want to control what type of collection is returned, use link::Classes/Collection#selectIndexAs::
+
+method::rejectIndexAs
+Return a new collection of type emphasis::class:: which consists of all indices of those elements of the receiver for which function answers code::false::. The function is passed two arguments, the item and an integer index.
+
+code::
+#[a, b, c, g, h, h, j, h].rejectIndexAs({|item, i| item === \h}, Set)
+::
+
 copymethod:: Collection -maxIndex
 
 copymethod:: Collection -minIndex

--- a/HelpSource/Classes/SequenceableCollection.schelp
+++ b/HelpSource/Classes/SequenceableCollection.schelp
@@ -136,37 +136,37 @@ y = List[ 10, 5, 77, 55, 12, 123];
 y.indexOfGreaterThan(70);
 ::
 
-method::selectIndex
+method::selectIndices
 Return a new collection of same type as receiver which consists of all indices of those elements of the receiver for which function answers code::true::. The function is passed two arguments, the item and an integer index.
 
 code::
-#[a, b, c, g, h, h, j, h].selectIndex({|item, i| item === \h})
+#[a, b, c, g, h, h, j, h].selectIndices({|item, i| item === \h})
 ::
 
-If you want to control what type of collection is returned, use link::Classes/Collection#selectIndexAs::
+If you want to control what type of collection is returned, use link::Classes/Collection#selectIndicesAs::
 
-method::selectIndexAs
+method::selectIndicesAs
 Return a new collection of type emphasis::class:: which consists of all indices of those elements of the receiver for which function answers code::true::. The function is passed two arguments, the item and an integer index.
 
 code::
-#[a, b, c, g, h, h, j, h].selectIndexAs({|item, i| item === \h}, Set)
+#[a, b, c, g, h, h, j, h].selectIndicesAs({|item, i| item === \h}, Set)
 ::
 
 
-method::rejectIndex
+method::rejectIndices
 Return a new collection of same type as receiver which consists of all indices of those elements of the receiver for which function answers code::false::. The function is passed two arguments, the item and an integer index.
 
 code::
-#[a, b, c, g, h, h, j, h].rejectIndex({|item, i| item === \h})
+#[a, b, c, g, h, h, j, h].rejectIndices({|item, i| item === \h})
 ::
 
-If you want to control what type of collection is returned, use link::Classes/Collection#selectIndexAs::
+If you want to control what type of collection is returned, use link::Classes/Collection#selectIndicesAs::
 
-method::rejectIndexAs
+method::rejectIndicesAs
 Return a new collection of type emphasis::class:: which consists of all indices of those elements of the receiver for which function answers code::false::. The function is passed two arguments, the item and an integer index.
 
 code::
-#[a, b, c, g, h, h, j, h].rejectIndexAs({|item, i| item === \h}, Set)
+#[a, b, c, g, h, h, j, h].rejectIndicesAs({|item, i| item === \h}, Set)
 ::
 
 copymethod:: Collection -maxIndex

--- a/SCClassLibrary/Common/Collections/SequenceableCollection.sc
+++ b/SCClassLibrary/Common/Collections/SequenceableCollection.sc
@@ -242,6 +242,24 @@ SequenceableCollection : Collection {
 		^((val - a) / div) + i - 1
 	}
 
+	selectIndex { | function |
+		^this.selectIndexAs(function, this.species);
+	}
+	selectIndexAs { | function, class |
+		var res = class.new(this.size);
+		this.do {|elem, i| if (function.value(elem, i)) { res.add(i) } }
+		^res;
+	}
+
+	rejectIndex { | function |
+		^this.rejectIndexAs(function, this.species);
+	}
+	rejectIndexAs { | function, class |
+		var res = class.new(this.size);
+		this.do {|elem, i| if (function.value(elem, i).not) { res.add(i) } }
+		^res;
+	}
+
 	isSeries { arg step;
 		if(this.size <= 1) { ^true };
 		this.doAdjacentPairs { |a, b|

--- a/SCClassLibrary/Common/Collections/SequenceableCollection.sc
+++ b/SCClassLibrary/Common/Collections/SequenceableCollection.sc
@@ -242,19 +242,19 @@ SequenceableCollection : Collection {
 		^((val - a) / div) + i - 1
 	}
 
-	selectIndex { | function |
+	selectIndices { | function |
 		^this.selectIndexAs(function, this.species);
 	}
-	selectIndexAs { | function, class |
+	selectIndicesAs { | function, class |
 		var res = class.new(this.size);
 		this.do {|elem, i| if (function.value(elem, i)) { res.add(i) } }
 		^res;
 	}
 
-	rejectIndex { | function |
+	rejectIndices { | function |
 		^this.rejectIndexAs(function, this.species);
 	}
-	rejectIndexAs { | function, class |
+	rejectIndicesAs { | function, class |
 		var res = class.new(this.size);
 		this.do {|elem, i| if (function.value(elem, i).not) { res.add(i) } }
 		^res;


### PR DESCRIPTION
*this is a second try after messing up [first attempt](https://github.com/supercollider/supercollider/pull/1572)* 

this adds methods 

```
selectIndices(function)
selectIndices(function)

selectIndicesAs(function, class)
rejectIndicesAs(function, class)
```

to ```SequenceableCollection```. They are straight-forward implementations complementing ```select``` and ```reject``` with a way to return indices rather than values as does ```detectIndex``` for ```detect```.

