### PR TITLE
fix: Quarks.load quark set

### DIFF
--- a/SCClassLibrary/Common/Quarks/Quark.sc
+++ b/SCClassLibrary/Common/Quarks/Quark.sc
@@ -3,8 +3,8 @@ Quark {
 	var <name, url, >refspec, data, <localPath;
 	var <changed = false, <git;
 
-	*new { |name, refspec|
-		var args = Quark.parseQuarkName(name, refspec);
+	*new { |name, refspec, url, localPath|
+		var args = Quark.parseQuarkName(name, refspec, url, localPath);
 		if(args.isNil, {
 			Error("% not found".format(name)).throw;
 		});
@@ -211,30 +211,30 @@ Quark {
 		});
 		^super.new.init(*args)
 	}
-	*parseQuarkName { |name, refspec|
+	*parseQuarkName { |name, refspec, url, localPath|
 		// determine which quark the string 'name' refers to
 		// name is one of: quarkname, url, localPath
 		// returns: [name, url, refspec, localPath]
 		var directoryEntry;
 		if(name.contains("://"), {
-			^[PathName(name).fileNameWithoutExtension(), name, refspec, nil]
+			^[PathName(name).fileNameWithoutExtension(), name, refspec, localPath]
 		});
 		if(Quarks.isPath(name), {
-			// url can be determined later by the Quark
-			^[name.basename, nil, refspec, name]
+			// if not provided then url can be determined later by the Quark
+			^[name.basename, url, refspec, name]
 		});
 		// search Quarks folders
 		(Quarks.additionalFolders ++ [Quarks.folder]).do({ |f|
-			var localPath = f +/+ name, url;
-			if(File.existsCaseSensitive(localPath), {
-				^[name, nil, refspec, localPath]
+			var lp = localPath ?? {f +/+ name};
+			if(File.existsCaseSensitive(lp), {
+				^[name, url, refspec, lp]
 			});
 		});
 		// lookup url in directory
 		directoryEntry = Quarks.findQuarkURL(name);
 		if(directoryEntry.notNil, {
 			directoryEntry = directoryEntry.split($@);
-			^[name, directoryEntry[0], refspec ? directoryEntry[1], nil]
+			^[name, url ? directoryEntry[0], refspec ? directoryEntry[1], localPath]
 		});
 		// not found
 		^nil

--- a/SCClassLibrary/Common/Quarks/QuarksGui.sc
+++ b/SCClassLibrary/Common/Quarks/QuarksGui.sc
@@ -91,7 +91,7 @@ QuarksGui {
 			.toolTip_("Install a set of quarks from a file")
 			.action_({
 				Dialog.openPanel({ |path|
-					this.runCancellable({
+					this.runCancelable({
 						this.setMsg("Installing from file:" + path);
 						0.1.wait;
 						model.load(path, {
@@ -191,7 +191,7 @@ QuarksGui {
 		lblMsg.string = msg ? "";
 	}
 	checkForUpdates { |onComplete, onCancel|
-		this.runCancellable({
+		this.runCancelable({
 			model.fetchDirectory(true);
 			model.checkForUpdates();
 		}, onComplete, onCancel)
@@ -206,7 +206,7 @@ QuarksGui {
 			0,  // QFileDialog::AcceptOpen
 			true); // just first value in paths array
 	}
-	runCancellable { |fn, onComplete, onCancel|
+	runCancelable { |fn, onComplete, onCancel|
 		var r, cancel;
 		r = Routine.run({
 			fn.protect({
@@ -577,7 +577,7 @@ QuarkRowView {
 		this.update;
 	}
 	install { |bool|
-		quarksGui.runCancellable({
+		quarksGui.runCancelable({
 			var prev, ok;
 			if(bool, {
 				// if any other is installed by same name

--- a/SCClassLibrary/Common/Quarks/QuarksGui.sc
+++ b/SCClassLibrary/Common/Quarks/QuarksGui.sc
@@ -81,7 +81,9 @@ QuarksGui {
 			.toolTip_("Save currently installed quarks to a file")
 			.action_({
 				Dialog.savePanel({ |path|
-					model.save(path)
+					this.setMsg("Saving quarks to file:" + path);
+					model.save(path);
+					this.setMsg();
 				})
 			});
 
@@ -89,9 +91,16 @@ QuarksGui {
 			.toolTip_("Install a set of quarks from a file")
 			.action_({
 				Dialog.openPanel({ |path|
-					model.load(path);
-					this.update;
-				})
+					this.runCancellable({
+						this.setMsg("Installing from file:" + path);
+						0.1.wait;
+						model.load(path, {
+							this.setMsg();
+							0.1.wait;
+							this.update;
+						});
+					});
+				});
 			});
 
 		btnRecompile = Button().states_([


### PR DESCRIPTION
previously it was failing to load a quark set file for any quarks that were not previously cloned. it would check them out (switch to the right tag) but it wouldn't clone it if needed.

also makes Quarks.load cancelable with command-.
does load with some pauses so it does not choke the main app
and updates the gui when its done