### PR TITLE
server: Assume requested SR was successfully set

### DIFF
--- a/server/scsynth/SC_CoreAudio.cpp
+++ b/server/scsynth/SC_CoreAudio.cpp
@@ -535,6 +535,50 @@ SC_CoreAudioDriver::~SC_CoreAudioDriver()
 	}
 }
 
+struct AudioValueRangeComp {
+	bool operator()(const AudioValueRange& lhs, const AudioValueRange& rhs) {
+		return (lhs.mMaximum != rhs.mMaximum) ?
+			(lhs.mMaximum < rhs.mMaximum) :
+			(lhs.mMinimum < rhs.mMinimum);
+	}
+};
+
+std::vector<AudioValueRange> GetAvailableNominalSampleRates(const AudioDeviceID& device) {
+	std::vector<AudioValueRange>	result;
+	OSStatus						err;
+	UInt32							size;
+	UInt32							count;
+	std::auto_ptr<AudioValueRange>	validSampleRateRanges;
+	
+	AudioObjectPropertyAddress addr = {
+		kAudioDevicePropertyAvailableNominalSampleRates,
+		kAudioObjectPropertyScopeGlobal,
+		kAudioObjectPropertyElementMaster
+	};
+	
+	err = AudioObjectGetPropertyDataSize(device, &addr, 0, NULL, &size);
+	
+	if (err != kAudioHardwareNoError) {
+		scprintf("get kAudioDevicePropertyAvailableNominalSampleRates data size error %4.4s\n", (char*)&err);
+	} else {
+		if (size > 0) {
+			count = size / sizeof(AudioValueRange);
+			validSampleRateRanges.reset(new AudioValueRange[count]);
+			
+			err = AudioObjectGetPropertyData(device, &addr, 0, NULL, &size, validSampleRateRanges.get());
+			if (err != kAudioHardwareNoError) {
+				scprintf("get kAudioDevicePropertyAvailableNominalSampleRates error %4.4s\n", (char*)&err);
+			} else {
+				for (int i = 0; i < count; i++) {
+					result.push_back(validSampleRateRanges.get()[i]);
+				}
+			}
+		}
+	}
+	
+	return result;
+}
+
 bool SC_CoreAudioDriver::DriverSetup(int* outNumSamplesPerCallback, double* outSampleRate)
 {
 	OSStatus	err = kAudioHardwareNoError;
@@ -746,28 +790,101 @@ bool SC_CoreAudioDriver::DriverSetup(int* outNumSamplesPerCallback, double* outS
 	{
 		Float64 sampleRate = mPreferredSampleRate;
 		count = sizeof(Float64);
-		//err = AudioDeviceSetProperty(mOutputDevice, &now, 0, false, kAudioDevicePropertyNominalSampleRate, count, &sampleRate);
 
-		propertyAddress.mSelector = kAudioDevicePropertyNominalSampleRate;
-		propertyAddress.mScope = kAudioDevicePropertyScopeOutput;
+		bool sampleRateSupported = false;
+		auto availableSampleRates = GetAvailableNominalSampleRates(mOutputDevice);
+		
+		// If we've got two devices, we need to use a sample rate list from both
+		//  This won't account for cases where there are overlapping ranges, but
+		//  that seems sufficiently edge-case to ignore for now.
+		if (UseSeparateIO()) {
+			auto inputSampleRates = GetAvailableNominalSampleRates(mInputDevice);
 
-		err = AudioObjectSetPropertyData(mOutputDevice, &propertyAddress, 0, NULL, count, &sampleRate);
-
-		if (err != kAudioHardwareNoError) {
-			scprintf("set kAudioDevicePropertyNominalSampleRate error %4.4s\n", (char*)&err);
-			//return false;
+			std::vector<AudioValueRange> availableSampleRatesInputOutput(std::min(availableSampleRates.size(), inputSampleRates.size()));
+			auto rateListIter = std::set_union(
+				availableSampleRates.begin(), availableSampleRates.end(),
+				inputSampleRates.begin(), inputSampleRates.end(),
+				availableSampleRatesInputOutput.begin(),
+				AudioValueRangeComp()
+			);
+			
+			availableSampleRatesInputOutput.resize(rateListIter - availableSampleRatesInputOutput.begin());
+			availableSampleRates = availableSampleRatesInputOutput;
 		}
-		if (UseSeparateIO())
-		{
-			count = sizeof(Float64);
-			//err = AudioDeviceSetProperty(mInputDevice, &now, 0, false, kAudioDevicePropertyNominalSampleRate, count, &sampleRate);
+		
+		BOOST_FOREACH(const AudioValueRange& range, availableSampleRates) {
+			if (mPreferredSampleRate >= range.mMinimum && mPreferredSampleRate <= range.mMaximum) {
+				sampleRateSupported = true;
+				break;
+			}
+		}
+		
+		if (!sampleRateSupported) {
+			#define SR_MAX_VALUE  9999999
+			#define SR_MIN_VALUE -9999999
+			
+			Float64 nextHighestMatch = SR_MAX_VALUE;
+			Float64 nextLowestMatch = SR_MIN_VALUE;
+			
+			BOOST_FOREACH(const AudioValueRange& range, availableSampleRates) {
+				if (range.mMinimum > mPreferredSampleRate && range.mMinimum < nextHighestMatch) {
+					nextHighestMatch = range.mMinimum;
+				}
+				if (range.mMaximum < mPreferredSampleRate && range.mMaximum > nextLowestMatch) {
+					nextLowestMatch = range.mMaximum;
+				}
+			}
+			
+			if (nextHighestMatch != SR_MAX_VALUE) {
+				sampleRate = nextHighestMatch;
+				sampleRateSupported = true;
+			} else if(nextLowestMatch != SR_MIN_VALUE) {
+				sampleRate = nextLowestMatch;
+				sampleRateSupported = true;
+			} else {
+				sampleRateSupported = false;
+			}
+			
+			if (sampleRateSupported) {
+				scprintf("Requested sample rate %f was not available - attempting to use sample rate of %f\n", (double)mPreferredSampleRate, (double)sampleRate);
+			} else {
+				scprintf("Could not set requested sample rate of %f\n", (double)mPreferredSampleRate);
+				scprintf("Available sample rates:\n");
+				BOOST_FOREACH(const AudioValueRange& range, availableSampleRates) {
+					if (range.mMaximum == range.mMinimum) {
+						scprintf("\t%f\n", range.mMaximum);
+					} else {
+						scprintf("\t%f - %f\n", range.mMinimum, range.mMaximum);
+					}
+				}
+			}
+		}
+		
+		// Requested sample rate is available - we're going to set and, if we don't hit an error,
+		// assume that our set was successful.
+		if (sampleRateSupported) {
 			propertyAddress.mSelector = kAudioDevicePropertyNominalSampleRate;
-			propertyAddress.mScope = kAudioDevicePropertyScopeInput;
+			propertyAddress.mScope = kAudioDevicePropertyScopeOutput;
 
-			err = AudioObjectSetPropertyData(mInputDevice, &propertyAddress, 0, NULL, count, &sampleRate);
+			err = AudioObjectSetPropertyData(mOutputDevice, &propertyAddress, 0, NULL, count, &sampleRate);
+
 			if (err != kAudioHardwareNoError) {
 				scprintf("set kAudioDevicePropertyNominalSampleRate error %4.4s\n", (char*)&err);
 				//return false;
+			}
+			if (UseSeparateIO())
+			{
+				count = sizeof(Float64);
+
+				propertyAddress.mSelector = kAudioDevicePropertyNominalSampleRate;
+				propertyAddress.mScope = kAudioDevicePropertyScopeInput;
+
+				err = AudioObjectSetPropertyData(mInputDevice, &propertyAddress, 0, NULL, count, &sampleRate);
+				if (err != kAudioHardwareNoError) {
+					scprintf("set kAudioDevicePropertyNominalSampleRate error %4.4s\n", (char*)&err);
+				} else {
+					mExplicitSampleRate = sampleRate;
+				}
 			}
 		}
 	}
@@ -813,7 +930,7 @@ bool SC_CoreAudioDriver::DriverSetup(int* outNumSamplesPerCallback, double* outS
 			return false;
 		}
 
-		if (inputStreamDesc.mSampleRate != outputStreamDesc.mSampleRate) {
+		if (!mExplicitSampleRate && inputStreamDesc.mSampleRate != outputStreamDesc.mSampleRate) {
 			scprintf("input and output sample rates do not match. %g != %g\n", inputStreamDesc.mSampleRate, outputStreamDesc.mSampleRate);
 			return false;
 		}
@@ -1035,7 +1152,11 @@ bool SC_CoreAudioDriver::DriverSetup(int* outNumSamplesPerCallback, double* outS
 	}
 
 	*outNumSamplesPerCallback = mHardwareBufferSize / outputStreamDesc.mBytesPerFrame;
-	*outSampleRate = outputStreamDesc.mSampleRate;
+	if (mExplicitSampleRate) {
+		*outSampleRate = mExplicitSampleRate.get();
+	} else {
+		*outSampleRate = outputStreamDesc.mSampleRate;
+	}
 
 	if(mWorld->mVerbosity >= 1){
 		scprintf("<-SC_CoreAudioDriver::Setup world %p\n", mWorld);

--- a/server/scsynth/SC_CoreAudio.cpp
+++ b/server/scsynth/SC_CoreAudio.cpp
@@ -535,14 +535,6 @@ SC_CoreAudioDriver::~SC_CoreAudioDriver()
 	}
 }
 
-struct AudioValueRangeComp {
-	bool operator()(const AudioValueRange& lhs, const AudioValueRange& rhs) {
-		return (lhs.mMaximum != rhs.mMaximum) ?
-			(lhs.mMaximum < rhs.mMaximum) :
-			(lhs.mMinimum < rhs.mMinimum);
-	}
-};
-
 std::vector<AudioValueRange> GetAvailableNominalSampleRates(const AudioDeviceID& device) {
 	std::vector<AudioValueRange>	result;
 	OSStatus						err;
@@ -805,7 +797,9 @@ bool SC_CoreAudioDriver::DriverSetup(int* outNumSamplesPerCallback, double* outS
 				availableSampleRates.begin(), availableSampleRates.end(),
 				inputSampleRates.begin(), inputSampleRates.end(),
 				availableSampleRatesInputOutput.begin(),
-				AudioValueRangeComp()
+				[](const AudioValueRange& lhs, const AudioValueRange& rhs) {
+					return (lhs.mMaximum != rhs.mMaximum) ? (lhs.mMaximum < rhs.mMaximum) : (lhs.mMinimum < rhs.mMinimum);
+				}
 			);
 			
 			availableSampleRatesInputOutput.resize(rateListIter - availableSampleRatesInputOutput.begin());

--- a/server/scsynth/SC_CoreAudio.cpp
+++ b/server/scsynth/SC_CoreAudio.cpp
@@ -806,7 +806,7 @@ bool SC_CoreAudioDriver::DriverSetup(int* outNumSamplesPerCallback, double* outS
 			availableSampleRates = availableSampleRatesInputOutput;
 		}
 		
-		BOOST_FOREACH(const AudioValueRange& range, availableSampleRates) {
+		for (const AudioValueRange& range : availableSampleRates) {
 			if (mPreferredSampleRate >= range.mMinimum && mPreferredSampleRate <= range.mMaximum) {
 				sampleRateSupported = true;
 				break;
@@ -820,7 +820,7 @@ bool SC_CoreAudioDriver::DriverSetup(int* outNumSamplesPerCallback, double* outS
 			Float64 nextHighestMatch = SR_MAX_VALUE;
 			Float64 nextLowestMatch = SR_MIN_VALUE;
 			
-			BOOST_FOREACH(const AudioValueRange& range, availableSampleRates) {
+			for (const AudioValueRange& range : availableSampleRates) {
 				if (range.mMinimum > mPreferredSampleRate && range.mMinimum < nextHighestMatch) {
 					nextHighestMatch = range.mMinimum;
 				}
@@ -844,7 +844,7 @@ bool SC_CoreAudioDriver::DriverSetup(int* outNumSamplesPerCallback, double* outS
 			} else {
 				scprintf("Could not set requested sample rate of %f\n", (double)mPreferredSampleRate);
 				scprintf("Available sample rates:\n");
-				BOOST_FOREACH(const AudioValueRange& range, availableSampleRates) {
+				for (const AudioValueRange& range : availableSampleRates) {
 					if (range.mMaximum == range.mMinimum) {
 						scprintf("\t%f\n", range.mMaximum);
 					} else {

--- a/server/scsynth/SC_CoreAudio.h
+++ b/server/scsynth/SC_CoreAudio.h
@@ -27,6 +27,7 @@
 #include "OSC_Packet.h"
 #include "SC_SyncCondition.h"
 #include "PriorityQueue.h"
+#include <boost/optional.hpp>
 
 #include <SC_Lock.h>
 
@@ -174,6 +175,7 @@ protected:
 	int mNumSamplesPerCallback;
 	uint32 mPreferredHardwareBufferFrameSize;
 	uint32 mPreferredSampleRate;
+	boost::optional<uint32> mExplicitSampleRate;
 	double mBuffersPerSecond;
 	double mAvgCPU, mPeakCPU;
 	int mPeakCounter, mMaxPeakCounter;


### PR DESCRIPTION
This fixes #768 
Setting sample rate in CoreAudio is actually an asynchronous operation - you request a sample rate change, and some time in the future it (probably) happens and you are called back about it. This is a problem for us because (a) SC doesn't support the sample rate changes once the server is started, and (b) our startup routine is totally synchronous anyway. Prior to this change, when we requested a custom sample rate, we would do the SetProperty and then shortly after ask CoreAudio for the device sample rate. If the operation had not been completed yet, we would get the OLD rate - the device would set it's SR to the requested shortly after, and we would effectively be running the server at the wrong rate. Now, we *assume* that a successful SetProperty has changed the sample rate, and just use the rate we set instead of requesting it from CoreAudio. We can still be incorrect if the SR doesn't actually change, but at least we're correct MOST of the time. To increase the chances of success, we query CoreAudio for valid sample rates, and set our requested rate based on those.

A proper fix for this would be to have a properly asynchronous driver startup procedure, where we request all the properties we want, and then wait for callbacks indicating the changes have "taken" before continuing. Note that requesting a buffer size still has the same problem - the fix should be identical - this should be fixed in a different CL.