### PR TITLE
GC fixes and doc

### DIFF
--- a/HelpSource/Guides/WritingPrimitives.schelp
+++ b/HelpSource/Guides/WritingPrimitives.schelp
@@ -71,32 +71,118 @@ Cocoa). Or set the object at teletype::receiver:: which again is at teletype::(g
 
 section:: Guidelines
 
-subsection:: GC safety
+subsection:: Creating objects in primitives, and GC safety
 
-If possible, you should avoid creating objects in a primitive. Primitives are much simpler to write and debug if you pass in an object that you create in SC code and fill in its slots in the primitive.
+SuperCollider uses a garbage collector to manage memory allocation and collection where needed.footnote::Some SC language objects, such as numbers, boolean types, chars, and symbols are stored directly within a PyrSlot, and do not require allocation. (Symbols are a special case: A reference to a location in the global symbol table is stored, where each defined symbol is permanently stored.):: In order to meet the requirements of good real time performance, a small and bounded amount of garbage collection may be triggered each time an object is created. This consists of incrementally examining all objects and determining if they are reachable (see below) or not. Unreachable objects may have their memory reallocated to new objects.
 
-When you do fill in slots in an object with other objects, you must call teletype::g->gc->GCWrite(object, other_object):: in order to notify the garbage collector that you have modified a slot that it may have already scanned.
+The following points are important to understanding how the GC works, and how to avoid bugs:
+list::
+##An object is emphasis::reachable:: if it has
+list::
+  ##been stored on the stack, or
+  ##been stored in an sclang variable, or a class variable, or
+  ##been stored in another object that fulfills one of the above criteria
+::
+##The GC marks objects as one of the following:
+list::
+  ##strong::White:: - To be examined
+  ##strong::Grey:: - Reachable, but containing objects which themselves have not been fully inspected and marked grey or black
+  ##strong::Black:: - Reachable, with any contained objects all fully inspected
+  ##strong::Free:: - Unreachable; memory is available for reuse
+::
+##If triggered, garbage collection will happen emphasis::before:: allocating the new object.
+##The newly created object will be marked as strong::white:: (to be examined).
+::
 
-If you create more than one object in a primitive you must make sure that all the previously created objects are reachable before you allocate another. In other words you must store them on the stack or in another object's slots before creating another. Creating objects can call the garbage collector and if you have not made your objects reachable, they can get collected out from under you.
+SC provides a number of functions which create new objects. These include teletype::instantiateObject::, teletype::newPyrObject::, teletype::newPyrString::, and teletype::newPyrArray::. Before any calls to such functions it is crucial that all previously created objects have been made reachable. If this is not done, it is possible that such objects will be marked as strong::free::. Since a freed object's memory may not be immediately reused, problems may not arise at the time your primitive is called, leading to extremely hard to find bugs.
+
+Alternatively, most object creation functions include a teletype::bool runGC:: argument. If set to false, this will guarantee that the garbage collector does not run on this allocation. While not ideal, as it is best that GC activity is amortised to the extent possible, this option is safe, since the status of any previously created objects will not be changed.
+
+The following two examples are both safe:
+definitionlist::
+##Make the newly created object reachable:
+||teletype::
+PyrSlot* arg = g->sp;
+PyrObject *array1 = newPyrArray(g->gc, 2, 0, true); // runGC = true
+SetObject(arg, array1); // make the array reachable on the stack
+PyrObject *array2 = newPyrArray(g->gc, 2, 0, true);
+...
+::
+##Set teletype::runGC:: to false:
+||teletype::
+PyrSlot* arg = g->sp;
+// runGC = true
+PyrObject *array1 = newPyrArray(g->gc, 2, 0, true);
+// runGC = false so GC is not triggered, and array1 can't be freed
+PyrObject *array2 = newPyrArray(g->gc, 2, 0, false);
+...
+::
+::
+Care must be taken when writing utility functions which themselves create new objects, since this may happen somewhat opaquely and the calling context may not be known. In such cases setting teletype::runGC:: to false may be the safest option, or including a teletype::runGC:: arg so that GC behaviour is explicit. teletype::MsgToInt8Array:: is one example of such a function.
+
+teletype::
+static PyrInt8Array* MsgToInt8Array ( sc_msg_iter& msg, bool runGC )
+{
+	int size = msg.getbsize() ;
+	VMGlobals *g = gMainVMGlobals ;
+	PyrInt8Array *obj = newPyrInt8Array ( g->gc , size , 0 , runGC ) ;
+	obj->size = size ;
+	msg.getb ( (char *)obj->b , obj->size ) ;
+	return obj ;
+}
+::
+
+Setting an object into another object's internal slot (e.g. with teletype::SetObject:: or teletype::slotCopy::) also requires care. If the parent object is emphasis::black:: (reachable and examined), the GC needs to be notified of the change. For this reason, you must usually call teletype::g->gc->GCWrite(parentObject, childObject):: after using one of these methods. The emphasis::only:: exceptions to this rule are cases in which the parent object is known to be white (unexamined). This will be true if:
+list::
+##It is the last created object, or
+##Any subsequently created objects were allocated with teletype::runGC = false:: (i.e. the GC cannot have run in the interim), emphasis::and::
+##It has not had GCWrite called upon it
+::
+
+The following two examples are both safe:
+definitionlist::
+##Run GCWrite as parent may not be white:
+||teletype::
+PyrObject *array = newPyrArray(g->gc, 2, 0, true); // runGC = true
+SetObject(arg, array); // make the array reachable on the stack
+PyrObject *str = newPyrString(g->gc, "Hello", 0, true); // runGC = true
+SetObject(array->slots, str);
+// we must call GCWrite, since array may not be white
+g->gc->GCWrite(array, str);
+...
+::
+##We know that parent emphasis::is:: white:
+||teletype::
+PyrObject *array = newPyrArray(g->gc, 2, 0, true); // runGC = true
+PyrObject *str = newPyrString(g->gc, "Hello", 0, false); // runGC = false
+SetObject(array->slots, str);
+// we don't need GCWrite, since array must still be white
+...
+::
+::
+
+If placing an object inside another has modified its size (e.g. adding an object to an array), you must correctly adjust its size by teletype::parent->size = newSize::. Both this and calling GCWrite (if necessary) should be done before any further object allocations. It is best practice to do them immediately if possible.
+
+It is good practice to avoid creating objects in a primitive at all where possible. Primitives are much simpler to write and debug if you pass in an object that you create in SC code and fill in its slots in the primitive.
 
 note::
-To summarize, before calling any function that might allocate (like teletype::newPyr*::) you strong::must:: make sure these critera are fulfilled:
+To summarize, before calling any function that might allocate (like teletype::newPyr*::) you strong::must:: make sure these criteria are fulfilled:
 numberedlist::
 ## All objects previously created must be reachable, which means they must exist
     list::
     ## on the teletype::g->sp:: stack
-    ## or, in a lang-side class/instance variable
+    ## or, in a lang-side variable or class variable.
     ## or, in a slot of another object that fulfils these criteria.
     ::
 ## If any object ( teletype::child:: ) was put inside a slot of another object ( teletype::parent:: ), you must have
     list::
-    ## called teletype::g->gc->GCWrite(parent, child):: afterwards
+    ## called teletype::g->gc->GCWrite(parent, child):: afterwards unless you strong::know:: that the parent is still white (unexamined)
     ## and, set teletype::parent->size:: to the correct value
     ::
 ::
 ::
 
-Here's an example of how it may look:
+Here's an example of how a complete primitive might look:
 teletype::
 int prMyPrimitive(struct VMGlobals* g, int numArgsPushed)
 {
@@ -115,8 +201,8 @@ int prMyPrimitive(struct VMGlobals* g, int numArgsPushed)
 
     PyrObject *str1 = newPyrString(g->gc, "Hello", 0, true);
     SetObject(array->slots, str1);
-    array->size++;
-    g->gc->GCWrite(array, str1);
+    array->size++; // immediately increment array's size
+    g->gc->GCWrite(array, str1); // array may not be white, so call GCWrite
 
     // NOTE: str1 is now reachable in array, which is reachable on the stack
 
@@ -127,7 +213,7 @@ int prMyPrimitive(struct VMGlobals* g, int numArgsPushed)
     return errNone;
 }
 ::
-If we would have put teletype::SetObject(arg, array);:: at the end of this function, teletype::array:: would strong::not:: have been reachable at the call to teletype::newPyrString::, thus breaking the rules and introducing bugs that sooner or later would crash SuperCollider (but most probably not in the faulty code but somewhere else, making it very hard to find!)
+If we would have put teletype::SetObject(arg, array);:: at the end of this function, teletype::array:: would strong::not:: have been reachable at the call to teletype::newPyrString::, and thus may have been marked teletype::free::, resulting in a hard to track down bug.
 
 warning::Do not store pointers to PyrObjects in C/C++ variables unless you can absolutely guarantee that they cannot be garbage
 collected. For example the File and SCWindow classes do this by storing the objects in an array in a classvar. The

--- a/HelpSource/Guides/WritingPrimitives.schelp
+++ b/HelpSource/Guides/WritingPrimitives.schelp
@@ -143,6 +143,7 @@ The following two examples are both safe:
 definitionlist::
 ##Run GCWrite as parent may not be white:
 ||teletype::
+PyrSlot* arg = g->sp;
 PyrObject *array = newPyrArray(g->gc, 2, 0, true); // runGC = true
 SetObject(arg, array); // make the array reachable on the stack
 PyrObject *str = newPyrString(g->gc, "Hello", 0, true); // runGC = true
@@ -162,6 +163,41 @@ SetObject(array->slots, str);
 ::
 
 If placing an object inside another has modified its size (e.g. adding an object to an array), you must correctly adjust its size by teletype::parent->size = newSize::. Both this and calling GCWrite (if necessary) should be done before any further object allocations. It is best practice to do them immediately if possible.
+
+definitionlist::
+##This is safe:
+||teletype::
+PyrSlot* arg = g->sp;
+int size = 10;
+PyrObject *array = newPyrArray(g->gc, size, 0, true); // runGC = true
+SetObject(arg, array);
+for(i=0; i<numLists; ++i) {
+  PyrObject *str = newPyrString(g->gc, "Hello", 0, true); // runGC = true
+  SetObject(array->slots + i, str);
+  g->gc->GCWrite(array, str);
+  // increment size immediately
+  //so it is accurate on next allocation
+  array->size++;
+}
+...
+::
+##This is emphasis::not:: safe:
+||teletype::
+PyrSlot* arg = g->sp;
+int size = 10;
+PyrObject *array = newPyrArray(g->gc, size, 0, true); // runGC = true
+// setting size to final value here means
+// it is *not* accurate on next allocation
+array->size = size;
+SetObject(arg, array);
+for(i=0; i<numLists; ++i) {
+  PyrObject *str = newPyrString(g->gc, "Hello", 0, true); // runGC = true
+  SetObject(array->slots + i, str);
+  g->gc->GCWrite(array, str);
+}
+...
+::
+::
 
 It is good practice to avoid creating objects in a primitive at all where possible. Primitives are much simpler to write and debug if you pass in an object that you create in SC code and fill in its slots in the primitive.
 
@@ -194,7 +230,7 @@ int prMyPrimitive(struct VMGlobals* g, int numArgsPushed)
     if(err) return err;
 
     PyrObject *array = newPyrArray(g->gc, 2, 0, true);
-    array->size = 0;
+    // array->size = 0 at creation; max size is 2
     SetObject(arg, array); // return value
 
     // NOTE: array is now reachable on the stack, since arg refers to g->sp

--- a/SCDoc/SCDocPrim.cpp
+++ b/SCDoc/SCDocPrim.cpp
@@ -38,6 +38,7 @@ PyrSymbol *s_scdoc_node;
 static void _doc_traverse(struct VMGlobals* g, DocNode *n, PyrObject *parent, PyrSlot *slot)
 {
     PyrObject *result = instantiateObject( g->gc, s_scdoc_node->u.classobj, 0, false, false );
+	result->size = 0;
 	SetObject(slot, result);
 	if(parent) g->gc->GCWrite(parent, result);
 

--- a/SCDoc/SCDocPrim.cpp
+++ b/SCDoc/SCDocPrim.cpp
@@ -38,7 +38,6 @@ PyrSymbol *s_scdoc_node;
 static void _doc_traverse(struct VMGlobals* g, DocNode *n, PyrObject *parent, PyrSlot *slot)
 {
     PyrObject *result = instantiateObject( g->gc, s_scdoc_node->u.classobj, 0, false, false );
-    result->size = 0;
 	SetObject(slot, result);
 	if(parent) g->gc->GCWrite(parent, result);
 
@@ -55,7 +54,6 @@ static void _doc_traverse(struct VMGlobals* g, DocNode *n, PyrObject *parent, Py
 
     if(n->n_childs) {
         PyrObject *array = newPyrArray(g->gc, n->n_childs, 0, true);
-        array->size = 0;
         SetObject(result->slots+result->size++, array);
         g->gc->GCWrite(result, array);
         for(int i=0; i<n->n_childs; i++) {

--- a/SCDoc/SCDocPrim.cpp
+++ b/SCDoc/SCDocPrim.cpp
@@ -37,34 +37,34 @@ PyrSymbol *s_scdoc_node;
 
 static void _doc_traverse(struct VMGlobals* g, DocNode *n, PyrObject *parent, PyrSlot *slot)
 {
-    PyrObject *result = instantiateObject( g->gc, s_scdoc_node->u.classobj, 0, false, false );
-	result->size = 0;
+    PyrObject *result = instantiateObject( g->gc, s_scdoc_node->u.classobj, 0, false, true );
 	SetObject(slot, result);
-	if(parent) g->gc->GCWrite(parent, result);
+	if(parent) {
+		g->gc->GCWrite(parent, result);
+		parent->size++;
+	}
 
+	// initialise the instance vars
     PyrSymbol *id = getsym(n->id);
-    SetSymbol(result->slots+result->size++, id);
+    SetSymbol(result->slots, id); // id
 
+	// text
     if(n->text) {
         PyrObject *str = (PyrObject*) newPyrString(g->gc, n->text, 0, true);
-        SetObject(result->slots+result->size++, str);
+        SetObject(result->slots+1, str);
         g->gc->GCWrite(result, str);
-    } else {
-        SetNil(result->slots+result->size++);
     }
-
+	
+	// children
     if(n->n_childs) {
         PyrObject *array = newPyrArray(g->gc, n->n_childs, 0, true);
-        SetObject(result->slots+result->size++, array);
+        SetObject(result->slots+2, array);
         g->gc->GCWrite(result, array);
         for(int i=0; i<n->n_childs; i++) {
-            array->size++;
             _doc_traverse(g, n->children[i], array, array->slots+i);
         }
-    } else {
-        SetNil(result->slots+result->size++);
-    }
-    result->size += 3; // makeDiv, notPrivOnly, sort
+	}
+    // makeDiv, notPrivOnly, sort remain nil for now
 }
 
 

--- a/lang/LangPrimSource/OSCData.cpp
+++ b/lang/LangPrimSource/OSCData.cpp
@@ -60,7 +60,7 @@ InternalSynthServerGlobals gInternalSynthServer = { 0, kNumDefaultSharedControls
 
 SC_UdpInPort* gUDPport = 0;
 
-PyrString* newPyrString(VMGlobals *g, char *s, int flags, bool collect);
+PyrString* newPyrString(VMGlobals *g, char *s, int flags, bool runGC);
 
 PyrSymbol *s_call, *s_write, *s_recvoscmsg, *s_recvoscbndl, *s_netaddr;
 extern bool compiledOK;
@@ -559,12 +559,12 @@ static int prArray_OSCBytes(VMGlobals *g, int numArgsPushed)
 // Create a new <PyrInt8Array> object and copy data from `msg.getb'.
 // Bytes are properly untyped, but there is no <UInt8Array> type.
 
-static PyrInt8Array* MsgToInt8Array ( sc_msg_iter& msg, bool collect ) ;
-static PyrInt8Array* MsgToInt8Array ( sc_msg_iter& msg, bool collect )
+static PyrInt8Array* MsgToInt8Array ( sc_msg_iter& msg, bool runGC ) ;
+static PyrInt8Array* MsgToInt8Array ( sc_msg_iter& msg, bool runGC )
 {
 	int size = msg.getbsize() ;
 	VMGlobals *g = gMainVMGlobals ;
-	PyrInt8Array *obj = newPyrInt8Array ( g->gc , size , 0 , collect ) ;
+	PyrInt8Array *obj = newPyrInt8Array ( g->gc , size , 0 , runGC ) ;
 	obj->size = size ;
 	msg.getb ( (char *)obj->b , obj->size ) ;
 	return obj ;

--- a/lang/LangPrimSource/OSCData.cpp
+++ b/lang/LangPrimSource/OSCData.cpp
@@ -559,12 +559,12 @@ static int prArray_OSCBytes(VMGlobals *g, int numArgsPushed)
 // Create a new <PyrInt8Array> object and copy data from `msg.getb'.
 // Bytes are properly untyped, but there is no <UInt8Array> type.
 
-static PyrInt8Array* MsgToInt8Array ( sc_msg_iter& msg ) ;
-static PyrInt8Array* MsgToInt8Array ( sc_msg_iter& msg )
+static PyrInt8Array* MsgToInt8Array ( sc_msg_iter& msg, bool collect ) ;
+static PyrInt8Array* MsgToInt8Array ( sc_msg_iter& msg, bool collect )
 {
 	int size = msg.getbsize() ;
 	VMGlobals *g = gMainVMGlobals ;
-	PyrInt8Array *obj = newPyrInt8Array ( g->gc , size , 0 , true ) ;
+	PyrInt8Array *obj = newPyrInt8Array ( g->gc , size , 0 , collect ) ;
 	obj->size = size ;
 	msg.getb ( (char *)obj->b , obj->size ) ;
 	return obj ;
@@ -616,7 +616,7 @@ static PyrObject* ConvertOSCMessage(int inSize, char *inData)
 			break;
 		case 'b' : // fall through
 		case 'm' :
-			SetObject(slots+i+1, (PyrObject*)MsgToInt8Array(msg));
+			SetObject(slots+i+1, (PyrObject*)MsgToInt8Array(msg, false));
 			break;
 		case 'c':
 			SetChar(slots+i+1, (char)msg.geti());

--- a/lang/LangPrimSource/PyrArrayPrimitives.cpp
+++ b/lang/LangPrimSource/PyrArrayPrimitives.cpp
@@ -2342,7 +2342,6 @@ int prArrayUnlace(struct VMGlobals *g, int numArgsPushed)
 	if (err) return err;
 
 	obj2 = instantiateObject(g->gc, obj1->classptr, numLists, false, true);
-	obj2->size = numLists;
 	slots2 = obj2->slots;
 
 	SetObject(b, obj2); // store reference on stack, so both source and destination objects can be reached by the gc
@@ -2362,6 +2361,7 @@ int prArrayUnlace(struct VMGlobals *g, int numArgsPushed)
 		}
 		SetObject(slots2 + i, obj3);
 		g->gc->GCWrite(obj2, obj3);
+		obj2->size++;
 	}
 
 	SetRaw(a, obj2);

--- a/lang/LangPrimSource/PyrArrayPrimitives.cpp
+++ b/lang/LangPrimSource/PyrArrayPrimitives.cpp
@@ -2358,6 +2358,7 @@ int prArrayUnlace(struct VMGlobals *g, int numArgsPushed)
 			}
 		}
 		SetObject(slots2 + i, obj3);
+		g->gc->GCWrite(obj2, obj3);
 	}
 
 	SetRaw(a, obj2);

--- a/lang/LangPrimSource/PyrArrayPrimitives.cpp
+++ b/lang/LangPrimSource/PyrArrayPrimitives.cpp
@@ -1773,7 +1773,7 @@ int prArrayPermute(struct VMGlobals *g, int numArgsPushed)
 
 int prArrayAllTuples(struct VMGlobals *g, int numArgsPushed)
 {
-	PyrSlot *a, *b, *slots1, *slots2, *slots3;
+	PyrSlot *a, *b, *slots1, *slots2, *slots3, *slotToCopy;
 	PyrObject *obj1, *obj2, *obj3;
 
 	a = g->sp - 1;
@@ -1803,11 +1803,14 @@ int prArrayAllTuples(struct VMGlobals *g, int numArgsPushed)
 		for (int j=tupSize-1; j >= 0; --j) {
 			if (isKindOfSlot(slots1+j, class_array)) {
 				PyrObject *obj4 = slotRawObject(&slots1[j]);
-				slotCopy(&slots3[j], &obj4->slots[k % obj4->size]);
-				g->gc->GCWrite(obj3, obj4);
+				slotToCopy = &obj4->slots[k % obj4->size];
+				slotCopy(&slots3[j], slotToCopy);
+				g->gc->GCWrite(obj3, slotToCopy);
 				k /= obj4->size;
 			} else {
-				slotCopy(&slots3[j], &slots1[j]);
+				slotToCopy = &slots1[j];
+				slotCopy(&slots3[j], slotToCopy);
+				g->gc->GCWrite(obj3, slotToCopy);
 			}
 		}
 		obj3->size = tupSize;

--- a/lang/LangPrimSource/PyrFilePrim.cpp
+++ b/lang/LangPrimSource/PyrFilePrim.cpp
@@ -1462,6 +1462,8 @@ int prSFOpenRead(struct VMGlobals *g, int numArgsPushed)
 	a = g->sp - 1;
 	b = g->sp;
 
+	PyrObject *obj1 = slotRawObject(a);
+
 	if (!isKindOfSlot(b, class_string)) return errWrongType;
 	if (slotRawObject(b)->size > PATH_MAX - 1) return errFailed;
 
@@ -1473,16 +1475,18 @@ int prSFOpenRead(struct VMGlobals *g, int numArgsPushed)
 
 
 	if (file) {
-		SetPtr(slotRawObject(a)->slots + 0, file);
+		SetPtr(obj1->slots + 0, file);
 		sndfileFormatInfoToStrings(&info, &headerstr, &sampleformatstr);
 		//headerFormatToString(&info, &headerstr);
 		PyrString *hpstr = newPyrString(g->gc, headerstr, 0, true);
-		SetObject(slotRawObject(a)->slots+1, hpstr);
+		SetObject(obj1->slots+1, hpstr);
+		g->gc->GCWrite(obj1, (PyrObjectHdr*)hpstr);
 		PyrString *smpstr = newPyrString(g->gc, sampleformatstr, 0, true);
-		SetObject(slotRawObject(a)->slots+2, smpstr);
-		SetInt(slotRawObject(a)->slots + 3, info.frames);
-		SetInt(slotRawObject(a)->slots + 4, info.channels);
-		SetInt(slotRawObject(a)->slots + 5, info.samplerate);
+		SetObject(obj1->slots+2, smpstr);
+		g->gc->GCWrite(obj1, (PyrObjectHdr*)smpstr);
+		SetInt(obj1->slots + 3, info.frames);
+		SetInt(obj1->slots + 4, info.channels);
+		SetInt(obj1->slots + 5, info.samplerate);
 
 		SetTrue(a);
 	} else {

--- a/lang/LangPrimSource/PyrListPrim.cpp
+++ b/lang/LangPrimSource/PyrListPrim.cpp
@@ -77,30 +77,35 @@ int prArrayMultiChanExpand(struct VMGlobals *g, int numArgsPushed)
 
 	obj2 = newPyrArray(g->gc, maxlen, 0, true);
 	obj2->size = maxlen;
+	SetObject(a, obj2);
 	slots2 = obj2->slots;
 	for (i=0; i<maxlen; ++i) {
-		obj3 = newPyrArray(g->gc, size, 0, false);
+		obj3 = newPyrArray(g->gc, size, 0, true);
 		obj3->size = size;
 		SetObject(slots2 + i, obj3);
+		g->gc->GCWrite(obj2, obj3);
 		slots1 = obj1->slots;
 		slots3 = obj3->slots;
 		for (j=0; j<size; ++j) {
 			slot = slots1 + j;
 			if (IsObj(slot)) {
 				if (slotRawObject(slot)->classptr == class_array && slotRawObject(slot)->size > 0) {
+					PyrSlot *slotToCopy;
 					obj4 = slotRawObject(slot);
 					slots4 = obj4->slots;
-					slotCopy(&slots3[j],&slots4[i % obj4->size]);
+					slotToCopy = &slots4[i % obj4->size];
+					slotCopy(&slots3[j],slotToCopy);
+					g->gc->GCWrite(obj3, slotToCopy);
 				} else {
 					slotCopy(&slots3[j],slot);
+					g->gc->GCWrite(obj3, obj1);
 				}
 			} else {
 				slotCopy(&slots3[j],slot);
+				g->gc->GCWrite(obj3, slot);
 			}
 		}
 	}
-
-	SetObject(a, obj2);
 
 	return errNone;
 }

--- a/lang/LangPrimSource/PyrListPrim.cpp
+++ b/lang/LangPrimSource/PyrListPrim.cpp
@@ -76,7 +76,6 @@ int prArrayMultiChanExpand(struct VMGlobals *g, int numArgsPushed)
 	}
 
 	obj2 = newPyrArray(g->gc, maxlen, 0, true);
-	obj2->size = maxlen;
 	SetObject(a, obj2);
 	slots2 = obj2->slots;
 	for (i=0; i<maxlen; ++i) {
@@ -84,6 +83,7 @@ int prArrayMultiChanExpand(struct VMGlobals *g, int numArgsPushed)
 		obj3->size = size;
 		SetObject(slots2 + i, obj3);
 		g->gc->GCWrite(obj2, obj3);
+		obj2->size++;
 		slots1 = obj1->slots;
 		slots3 = obj3->slots;
 		for (j=0; j<size; ++j) {
@@ -98,11 +98,10 @@ int prArrayMultiChanExpand(struct VMGlobals *g, int numArgsPushed)
 					g->gc->GCWrite(obj3, slotToCopy);
 				} else {
 					slotCopy(&slots3[j],slot);
-					g->gc->GCWrite(obj3, obj1);
+					g->gc->GCWrite(obj3, slot);
 				}
 			} else {
-				slotCopy(&slots3[j],slot);
-				g->gc->GCWrite(obj3, slot);
+				slotCopy(&slots3[j],slot); // we don't need GCWrite here, as slot is not an object
 			}
 		}
 	}

--- a/lang/LangPrimSource/PyrPrimitive.cpp
+++ b/lang/LangPrimSource/PyrPrimitive.cpp
@@ -3459,12 +3459,12 @@ static int prLanguageConfig_getLibraryPaths(struct VMGlobals * g, int numArgsPus
 	size_t numberOfPaths = dirVector.size();
 	PyrObject * resultArray = newPyrArray(g->gc, numberOfPaths, 0, true);
 	SetObject(result, resultArray);
-	resultArray->size = numberOfPaths;
 
 	for (size_t i = 0; i != numberOfPaths; ++i) {
 		PyrString * pyrString = newPyrString(g->gc, dirVector[i].c_str(), 0, true);
 		SetObject(resultArray->slots + i, pyrString);
 		g->gc->GCWrite( resultArray,  pyrString );
+		resultArray->size++;
 	}
 	return errNone;
 }

--- a/lang/LangPrimSource/PyrPrimitive.cpp
+++ b/lang/LangPrimSource/PyrPrimitive.cpp
@@ -2082,7 +2082,7 @@ private:
 		PyrMethod *meth = slotRawMethod(&frame->method);
 		PyrMethodRaw * methraw = METHRAW(meth);
 
-		PyrObject* debugFrameObj = instantiateObject(g->gc, getsym("DebugFrame")->u.classobj, 0, false, true);
+		PyrObject* debugFrameObj = instantiateObject(g->gc, getsym("DebugFrame")->u.classobj, 0, false, false);
 		SetObject(outSlot, debugFrameObj);
 
 		SetObject(debugFrameObj->slots + 0, meth);

--- a/lang/LangPrimSource/PyrPrimitive.cpp
+++ b/lang/LangPrimSource/PyrPrimitive.cpp
@@ -2956,9 +2956,9 @@ void switchToThread(VMGlobals *g, PyrThread *newthread, int oldstate, int *numAr
 }
 
 void initPyrThread(VMGlobals *g, PyrThread *thread, PyrSlot *func, int stacksize, PyrInt32Array* rgenArray,
-	double beats, double seconds, PyrSlot* clock, bool collect);
+	double beats, double seconds, PyrSlot* clock, bool runGC);
 void initPyrThread(VMGlobals *g, PyrThread *thread, PyrSlot *func, int stacksize, PyrInt32Array* rgenArray,
-	double beats, double seconds, PyrSlot* clock, bool collect)
+	double beats, double seconds, PyrSlot* clock, bool runGC)
 {
 	PyrObject *array;
 	PyrGC* gc = g->gc;
@@ -2966,7 +2966,7 @@ void initPyrThread(VMGlobals *g, PyrThread *thread, PyrSlot *func, int stacksize
 	slotCopy(&thread->func, func);
 	gc->GCWrite(thread, func);
 
-	array = newPyrArray(gc, stacksize, 0, collect);
+	array = newPyrArray(gc, stacksize, 0, runGC);
 	SetObject(&thread->stack, array);
 	gc->GCWrite(thread, array);
 

--- a/lang/LangPrimSource/PyrStringPrim.cpp
+++ b/lang/LangPrimSource/PyrStringPrim.cpp
@@ -409,7 +409,6 @@ static int prString_FindRegexp(struct VMGlobals *g, int numArgsPushed)
 	int match_count = matches.size();
 
 	PyrObject *result_array = newPyrArray(g->gc, match_count, 0, true);
-	result_array->size = 0;
 	SetObject(a, result_array);
 
 	if( !match_count ) return errNone;
@@ -960,7 +959,6 @@ static void yaml_traverse(struct VMGlobals* g, const YAML::Node & node, PyrObjec
 
 		case YAML::NodeType::Sequence:
 			result = newPyrArray(g->gc, node.size(), 0, true);
-			result->size = 0;
 			SetObject(slot, result);
 			if(parent) g->gc->GCWrite(parent, result);
 			for (unsigned int i = 0; i < node.size(); i++) {
@@ -977,8 +975,7 @@ static void yaml_traverse(struct VMGlobals* g, const YAML::Node & node, PyrObjec
 			if(parent) g->gc->GCWrite(parent, result);
 
 			PyrObject *array = newPyrArray(g->gc, node.size()*2, 0, true);
-			array->size = 0;
-			result->size = 2; // ?
+			result->size = 2;
 			SetObject(result->slots, array);      // array
 			SetInt(result->slots+1, node.size()); // size
 			g->gc->GCWrite(result, array);

--- a/lang/LangPrimSource/SC_HID_api.cpp
+++ b/lang/LangPrimSource/SC_HID_api.cpp
@@ -502,6 +502,8 @@ int prHID_API_BuildDeviceList(VMGlobals* g, int numArgsPushed){
 		struct hid_device_info *cur_dev = SC_HID_APIManager::instance().devinfos;
 		while( cur_dev ){
 			PyrObject* devInfo = newPyrArray(g->gc, 11 * sizeof(PyrObject), 0 , true);
+			SetObject(allDevsArray->slots+allDevsArray->size++, devInfo );
+			g->gc->GCWrite(allDevsArray, devInfo);
 
 			SetInt(devInfo->slots+devInfo->size++, cur_dev->vendor_id);
 			SetInt(devInfo->slots+devInfo->size++, cur_dev->product_id);
@@ -549,9 +551,6 @@ int prHID_API_BuildDeviceList(VMGlobals* g, int numArgsPushed){
 
 			SetInt(devInfo->slots+devInfo->size++, cur_dev->usage_page);
 			SetInt(devInfo->slots+devInfo->size++, cur_dev->usage);
-
-			SetObject(allDevsArray->slots+allDevsArray->size++, devInfo );
-			g->gc->GCWrite(allDevsArray, devInfo);
 
 			cur_dev = cur_dev->next;
 		}

--- a/lang/LangPrimSource/SC_Speech.mm
+++ b/lang/LangPrimSource/SC_Speech.mm
@@ -372,6 +372,7 @@ int prGetSpeechVoiceNames(struct VMGlobals *g, int numArgsPushed){
 	NSString * aVoice = NULL;
 	NSEnumerator * voiceEnumerator = [[NSSpeechSynthesizer availableVoices] objectEnumerator];
 	PyrObject* allVoices = newPyrArray(g->gc, (int) [[NSSpeechSynthesizer availableVoices] count]  * sizeof(PyrObject), 0 , true);
+	SetObject(a, allVoices);
 
 	while(aVoice = [voiceEnumerator nextObject]) {
 		NSDictionary * dictionaryOfVoiceAttributes = [NSSpeechSynthesizer attributesForVoice:aVoice];
@@ -384,7 +385,6 @@ int prGetSpeechVoiceNames(struct VMGlobals *g, int numArgsPushed){
 	}
 	[autoreleasepool release];
 
-	SetObject(a, allVoices);
 	return errNone;
 
 }

--- a/lang/LangSource/GC.cpp
+++ b/lang/LangSource/GC.cpp
@@ -344,7 +344,7 @@ void PyrGC::BecomeImmutable(PyrObject *inObject)
 
 void DumpBackTrace(VMGlobals *g);
 
-HOT PyrObject *PyrGC::New(size_t inNumBytes, long inFlags, long inFormat, bool inCollect)
+HOT PyrObject *PyrGC::New(size_t inNumBytes, long inFlags, long inFormat, bool inRunCollection)
 {
 	PyrObject *obj = NULL;
 
@@ -369,7 +369,7 @@ HOT PyrObject *PyrGC::New(size_t inNumBytes, long inFlags, long inFormat, bool i
 	mNumAllocs++;
 
 	mNumToScan += credit;
-	obj = Allocate(inNumBytes, sizeclass, inCollect);
+	obj = Allocate(inNumBytes, sizeclass, inRunCollection);
 
 	obj->obj_format = inFormat;
 	obj->obj_flags = inFlags & 255;
@@ -420,7 +420,7 @@ HOT PyrObject *PyrGC::NewFrame(size_t inNumBytes, long inFlags, long inFormat, b
 	return obj;
 }
 
-PyrObject *PyrGC::NewFinalizer(ObjFuncPtr finalizeFunc, PyrObject *inObject, bool inCollect)
+PyrObject *PyrGC::NewFinalizer(ObjFuncPtr finalizeFunc, PyrObject *inObject, bool inRunCollection)
 {
 	PyrObject *obj = NULL;
 
@@ -437,7 +437,7 @@ PyrObject *PyrGC::NewFinalizer(ObjFuncPtr finalizeFunc, PyrObject *inObject, boo
 	mAllocTotal += credit;
 	mNumAllocs++;
 
-	if (inCollect && mNumToScan >= kScanThreshold) {
+	if (inRunCollection && mNumToScan >= kScanThreshold) {
 		Collect();
 	}
 

--- a/lang/LangSource/GC.h
+++ b/lang/LangSource/GC.h
@@ -322,12 +322,12 @@ inline void PyrGC::ToGrey2(PyrObjectHdr* obj)
 	mNumGrey ++ ;
 }
 
-inline PyrObject * PyrGC::Allocate(size_t inNumBytes, int32 sizeclass, bool inCollect)
+inline PyrObject * PyrGC::Allocate(size_t inNumBytes, int32 sizeclass, bool inRunCollection)
 {
-	if (inCollect && mNumToScan >= kScanThreshold)
+	if (inRunCollection && mNumToScan >= kScanThreshold)
 		Collect();
 	else {
-		if (inCollect)
+		if (inRunCollection)
 			mUncollectedAllocations = 0;
 		else
 			++mUncollectedAllocations;

--- a/lang/LangSource/PyrInterpreter3.cpp
+++ b/lang/LangSource/PyrInterpreter3.cpp
@@ -151,7 +151,7 @@ void runAwakeMessage(VMGlobals *g)
 }
 
 void initPyrThread(VMGlobals *g, PyrThread *thread, PyrSlot *func, int stacksize, PyrInt32Array* rgenArray,
-	double beats, double seconds, PyrSlot* clock, bool collect);
+	double beats, double seconds, PyrSlot* clock, bool runGC);
 int32 timeseed();
 
 PyrProcess* newPyrProcess(VMGlobals *g, PyrClass *procclassobj)

--- a/lang/LangSource/PyrObject.cpp
+++ b/lang/LangSource/PyrObject.cpp
@@ -1779,7 +1779,7 @@ void initClasses()
 }
 
 PyrObject* instantiateObject(class PyrGC *gc, PyrClass* classobj, int size,
-	bool fill, bool collect)
+	bool fill, bool runGC)
 {
 	PyrObject *newobj, *proto;
 	int numbytes, format, flags;
@@ -1790,7 +1790,7 @@ PyrObject* instantiateObject(class PyrGC *gc, PyrClass* classobj, int size,
 	if (slotRawInt(&classobj->classFlags) & classHasIndexableInstances) {
 		// create an indexable object
 		numbytes = size * gFormatElemSize[format];
-		newobj = gc->New(numbytes, flags, format, collect);
+		newobj = gc->New(numbytes, flags, format, runGC);
 		if (fill) {
 			newobj->size = size;
 			if (format == obj_slot) {
@@ -1806,14 +1806,14 @@ PyrObject* instantiateObject(class PyrGC *gc, PyrClass* classobj, int size,
 			proto = slotRawObject(&classobj->iprototype);
 			size = proto->size;
 			numbytes = size * sizeof(PyrSlot);
-			newobj = gc->New(numbytes, flags, format, collect);
+			newobj = gc->New(numbytes, flags, format, runGC);
 			newobj->size = size;
 			if (size) {
 				memcpy(newobj->slots, proto->slots, numbytes);
 			}
 		} else {
 			numbytes = 0;
-			newobj = gc->New(numbytes, flags, format, collect);
+			newobj = gc->New(numbytes, flags, format, runGC);
 			newobj->size = 0;
 		}
 	}
@@ -1821,8 +1821,8 @@ PyrObject* instantiateObject(class PyrGC *gc, PyrClass* classobj, int size,
 	return newobj;
 }
 
-PyrObject* instantiateObjectLight(class PyrGC *gc, PyrClass* classobj, int size, bool collect);
-PyrObject* instantiateObjectLight(class PyrGC *gc, PyrClass* classobj, int size, bool collect)
+PyrObject* instantiateObjectLight(class PyrGC *gc, PyrClass* classobj, int size, bool runGC);
+PyrObject* instantiateObjectLight(class PyrGC *gc, PyrClass* classobj, int size, bool runGC)
 {
 	PyrObject *newobj, *proto;
 	int numbytes, format, flags;
@@ -1842,14 +1842,14 @@ PyrObject* instantiateObjectLight(class PyrGC *gc, PyrClass* classobj, int size,
 			numbytes = 0;
 		}
 	}
-	newobj = gc->New(numbytes, flags, format, collect);
+	newobj = gc->New(numbytes, flags, format, runGC);
 	newobj->size = size;
 	newobj->classptr = classobj;
 
 	return newobj;
 }
 
-PyrObject* copyObject(class PyrGC *gc, PyrObject *inobj, bool collect)
+PyrObject* copyObject(class PyrGC *gc, PyrObject *inobj, bool runGC)
 {
 	PyrObject *newobj;
 
@@ -1860,7 +1860,7 @@ PyrObject* copyObject(class PyrGC *gc, PyrObject *inobj, bool collect)
 	int elemsize = gFormatElemSize[inobj->obj_format];
 	int numbytes = inobj->size * elemsize;
 
-	newobj = gc->New(numbytes, flags, inobj->obj_format, collect);
+	newobj = gc->New(numbytes, flags, inobj->obj_format, runGC);
 
 	newobj->size = inobj->size;
 	newobj->classptr = inobj->classptr;
@@ -1869,7 +1869,7 @@ PyrObject* copyObject(class PyrGC *gc, PyrObject *inobj, bool collect)
 	return newobj;
 }
 
-PyrObject* copyObjectRange(class PyrGC *gc, PyrObject *inobj, int start, int end, bool collect)
+PyrObject* copyObjectRange(class PyrGC *gc, PyrObject *inobj, int start, int end, bool runGC)
 {
 	PyrObject *newobj;
 
@@ -1885,7 +1885,7 @@ PyrObject* copyObjectRange(class PyrGC *gc, PyrObject *inobj, int start, int end
 	int flags = ~(obj_immutable) & inobj->obj_flags;
 		flags = ~(obj_permanent) & flags;
 
-	newobj = gc->New(numbytes, flags, inobj->obj_format, collect);
+	newobj = gc->New(numbytes, flags, inobj->obj_format, runGC);
 	newobj->size = length;
 	newobj->classptr = inobj->classptr;
 
@@ -2345,12 +2345,12 @@ void zeroSlots(PyrSlot* slot, int size)
 	fillSlots(slot, size, &zero);
 }
 
-PyrObject* newPyrObject(class PyrGC *gc, size_t inNumBytes, int inFlags, int inFormat, bool inCollect)
+PyrObject* newPyrObject(class PyrGC *gc, size_t inNumBytes, int inFlags, int inFormat, bool inRunGC)
 {
-	return gc->New(inNumBytes, inFlags, inFormat, inCollect);
+	return gc->New(inNumBytes, inFlags, inFormat, inRunGC);
 }
 
-PyrObject* newPyrArray(class PyrGC *gc, int size, int flags, bool collect)
+PyrObject* newPyrArray(class PyrGC *gc, int size, int flags, bool runGC)
 {
 	PyrObject* array;
 
@@ -2358,72 +2358,72 @@ PyrObject* newPyrArray(class PyrGC *gc, int size, int flags, bool collect)
 	if (!gc)
 		array = PyrGC::NewPermanent(numbytes, flags, obj_slot);
 	else
-		array = gc->New(numbytes, flags, obj_slot, collect);
+		array = gc->New(numbytes, flags, obj_slot, runGC);
 	array->classptr = class_array;
 	return array;
 }
 
-PyrSymbolArray* newPyrSymbolArray(class PyrGC *gc, int size, int flags, bool collect)
+PyrSymbolArray* newPyrSymbolArray(class PyrGC *gc, int size, int flags, bool runGC)
 {
 	PyrSymbolArray* array;
 
 	int numbytes = size * sizeof(PyrSymbol*);
 	if (!gc) array = (PyrSymbolArray*)PyrGC::NewPermanent(numbytes, flags, obj_symbol);
-	else array = (PyrSymbolArray*)gc->New(numbytes, flags, obj_symbol, collect);
+	else array = (PyrSymbolArray*)gc->New(numbytes, flags, obj_symbol, runGC);
 	array->classptr = class_symbolarray;
 	return array;
 }
 
-PyrInt8Array* newPyrInt8Array(class PyrGC *gc, int size, int flags, bool collect)
+PyrInt8Array* newPyrInt8Array(class PyrGC *gc, int size, int flags, bool runGC)
 {
 	PyrInt8Array* array;
 
 	if (!gc) array = (PyrInt8Array*)PyrGC::NewPermanent(size, flags, obj_int8);
-	else array = (PyrInt8Array*)gc->New(size, flags, obj_int8, collect);
+	else array = (PyrInt8Array*)gc->New(size, flags, obj_int8, runGC);
 	array->classptr = class_int8array;
 	return array;
 }
 
-PyrInt32Array* newPyrInt32Array(class PyrGC *gc, int size, int flags, bool collect)
+PyrInt32Array* newPyrInt32Array(class PyrGC *gc, int size, int flags, bool runGC)
 {
 	PyrInt32Array* array;
 	int numbytes = size * sizeof(int32);
 	if (!gc) array = (PyrInt32Array*)PyrGC::NewPermanent(numbytes, flags, obj_int32);
-	else array = (PyrInt32Array*)gc->New(numbytes, flags, obj_int32, collect);
+	else array = (PyrInt32Array*)gc->New(numbytes, flags, obj_int32, runGC);
 	array->classptr = class_int32array;
 	return array;
 }
 
-PyrDoubleArray* newPyrDoubleArray(class PyrGC *gc, int size, int flags, bool collect)
+PyrDoubleArray* newPyrDoubleArray(class PyrGC *gc, int size, int flags, bool runGC)
 {
 	PyrDoubleArray* array;
 
 	int numbytes = size * sizeof(double);
 	if (!gc) array = (PyrDoubleArray*)PyrGC::NewPermanent(numbytes, flags, obj_double);
-	else array = (PyrDoubleArray*)gc->New(size, flags, obj_double, collect);
+	else array = (PyrDoubleArray*)gc->New(size, flags, obj_double, runGC);
 	array->classptr = class_doublearray;
 	return array;
 }
 
-PyrString* newPyrString(class PyrGC *gc, const char *s, int flags, bool collect)
+PyrString* newPyrString(class PyrGC *gc, const char *s, int flags, bool runGC)
 {
 	PyrString* string;
 	int length = strlen(s);
 
 	if (!gc) string = (PyrString*)PyrGC::NewPermanent(length, flags, obj_char);
-	else string = (PyrString*)gc->New(length, flags, obj_char, collect);
+	else string = (PyrString*)gc->New(length, flags, obj_char, runGC);
 	string->classptr = class_string;
 	string->size = length;
 	memcpy(string->s, s, length);
 	return string;
 }
 
-PyrString* newPyrStringN(class PyrGC *gc, int length, int flags, bool collect)
+PyrString* newPyrStringN(class PyrGC *gc, int length, int flags, bool runGC)
 {
 	PyrString* string;
 
 	if (!gc) string = (PyrString*)PyrGC::NewPermanent(length, flags, obj_char);
-	else string = (PyrString*)gc->New(length, flags, obj_char, collect);
+	else string = (PyrString*)gc->New(length, flags, obj_char, runGC);
 	string->classptr = class_string;
 	string->size = length; // filled with garbage!
 	return string;


### PR DESCRIPTION
This is an improved version of #1615. In addition to fixes there (updated after comments, and whitespace corrected) it renames the ```collect``` arg in object creation funcs to ```runGC``` in order to make its purpose clearer (this was a bit confusing), and substantially updates the Writing Primitives helpfile (understanding is the first step in not hosing the GC...).