### PR TITLE
Gc fixes and doc final

### DIFF
--- a/HelpSource/Guides/WritingPrimitives.schelp
+++ b/HelpSource/Guides/WritingPrimitives.schelp
@@ -71,32 +71,157 @@ Cocoa). Or set the object at teletype::receiver:: which again is at teletype::(g
 
 section:: Guidelines
 
-subsection:: GC safety
+subsection:: Creating objects in primitives, and GC safety
 
-If possible, you should avoid creating objects in a primitive. Primitives are much simpler to write and debug if you pass in an object that you create in SC code and fill in its slots in the primitive.
+SuperCollider uses a garbage collector to manage memory allocation and collection where needed.footnote::Some SC language objects, such as numbers, boolean types, chars, and symbols are stored directly within a PyrSlot, and do not require allocation. (Symbols are a special case: A reference to a location in the global symbol table is stored, where each defined symbol is permanently stored.):: In order to meet the requirements of good real time performance, a small and bounded amount of garbage collection may be triggered each time an object is created. This consists of incrementally examining all objects and determining if they are reachable (see below) or not. Unreachable objects may have their memory reallocated to new objects.
 
-When you do fill in slots in an object with other objects, you must call teletype::g->gc->GCWrite(object, other_object):: in order to notify the garbage collector that you have modified a slot that it may have already scanned.
+The following points are important to understanding how the GC works, and how to avoid bugs:
+list::
+##An object is emphasis::reachable:: if it has
+list::
+  ##been stored on the stack, or
+  ##been stored in an sclang variable, or a class variable, or
+  ##been stored in another object that fulfills one of the above criteria
+::
+##The GC marks objects as one of the following:
+list::
+  ##strong::White:: - To be examined
+  ##strong::Grey:: - Reachable, but containing objects which themselves have not been fully inspected and marked grey or black
+  ##strong::Black:: - Reachable, with any contained objects all fully inspected
+  ##strong::Free:: - Unreachable; memory is available for reuse
+::
+##If triggered, garbage collection will happen emphasis::before:: allocating the new object.
+##The newly created object will be marked as strong::white:: (to be examined).
+::
 
-If you create more than one object in a primitive you must make sure that all the previously created objects are reachable before you allocate another. In other words you must store them on the stack or in another object's slots before creating another. Creating objects can call the garbage collector and if you have not made your objects reachable, they can get collected out from under you.
+SC provides a number of functions which create new objects. These include teletype::instantiateObject::, teletype::newPyrObject::, teletype::newPyrString::, and teletype::newPyrArray::. Before any calls to such functions it is crucial that all previously created objects have been made reachable. If this is not done, it is possible that such objects will be marked as strong::free::. Since a freed object's memory may not be immediately reused, problems may not arise at the time your primitive is called, leading to extremely hard to find bugs.
+
+Alternatively, most object creation functions include a teletype::bool runGC:: argument. If set to false, this will guarantee that the garbage collector does not run on this allocation. While not ideal, as it is best that GC activity is amortised to the extent possible, this option is safe, since the status of any previously created objects will not be changed.
+
+The following two examples are both safe:
+definitionlist::
+##Make the newly created object reachable:
+||teletype::
+PyrSlot* arg = g->sp;
+PyrObject *array1 = newPyrArray(g->gc, 2, 0, true); // runGC = true
+SetObject(arg, array1); // make the array reachable on the stack
+PyrObject *array2 = newPyrArray(g->gc, 2, 0, true);
+...
+::
+##Set teletype::runGC:: to false:
+||teletype::
+PyrSlot* arg = g->sp;
+// runGC = true
+PyrObject *array1 = newPyrArray(g->gc, 2, 0, true);
+// runGC = false so GC is not triggered, and array1 can't be freed
+PyrObject *array2 = newPyrArray(g->gc, 2, 0, false);
+...
+::
+::
+Care must be taken when writing utility functions which themselves create new objects, since this may happen somewhat opaquely and the calling context may not be known. Functions which may call themselves recursively also need special attention. In such cases setting teletype::runGC:: to false may be the safest option, or including a teletype::runGC:: arg so that GC behaviour is explicit. teletype::MsgToInt8Array:: is one example of such a function.
+
+teletype::
+static PyrInt8Array* MsgToInt8Array ( sc_msg_iter& msg, bool runGC )
+{
+	int size = msg.getbsize() ;
+	VMGlobals *g = gMainVMGlobals ;
+	PyrInt8Array *obj = newPyrInt8Array ( g->gc , size , 0 , runGC ) ;
+	obj->size = size ;
+	msg.getb ( (char *)obj->b , obj->size ) ;
+	return obj ;
+}
+::
+
+Setting an object into another object's internal slot (e.g. with teletype::SetObject:: or teletype::slotCopy::) also requires care. If the parent object is emphasis::black:: (reachable and examined), the GC needs to be notified of the change. For this reason, you must usually call teletype::g->gc->GCWrite(parentObject, childObject):: after using one of these methods. The emphasis::only:: exceptions to this rule are cases in which the parent object is known to be white (unexamined). This will be true if:
+list::
+##It is the last created object, or
+##Any subsequently created objects were allocated with teletype::runGC = false:: (i.e. the GC cannot have run in the interim), emphasis::and::
+##It has not had GCWrite called upon it
+::
+
+The following two examples are both safe:
+definitionlist::
+##Run GCWrite as parent may not be white:
+||teletype::
+PyrSlot* arg = g->sp;
+PyrObject *array = newPyrArray(g->gc, 2, 0, true); // runGC = true
+SetObject(arg, array); // make the array reachable on the stack
+PyrObject *str = newPyrString(g->gc, "Hello", 0, true); // runGC = true
+SetObject(array->slots, str);
+// we must call GCWrite, since array may not be white
+g->gc->GCWrite(array, str);
+...
+::
+##We know that parent emphasis::is:: white:
+||teletype::
+PyrObject *array = newPyrArray(g->gc, 2, 0, true); // runGC = true
+PyrObject *str = newPyrString(g->gc, "Hello", 0, false); // runGC = false
+SetObject(array->slots, str);
+// we don't need GCWrite, since array must still be white
+...
+::
+::
+
+If you emphasis::know:: that the child object is still white, then you can use teletype::GCWriteNew:: instead of teletype::GCWrite::. The child object will still be white if the GC has not been triggered since it was created, and you have not previously called GCWrite on it.
+
+If placing an object inside another has modified its size (e.g. adding an object to an array), you must correctly adjust its size by teletype::parent->size = newSize::. Both this and calling GCWrite (if necessary) should be done before any further object allocations. It is best practice to do them immediately if possible.
+
+definitionlist::
+##This is safe:
+||teletype::
+PyrSlot* arg = g->sp;
+int size = 10;
+PyrObject *array = newPyrArray(g->gc, size, 0, true); // runGC = true
+SetObject(arg, array);
+for(i=0; i<numLists; ++i) {
+  PyrObject *str = newPyrString(g->gc, "Hello", 0, true); // runGC = true
+  SetObject(array->slots + i, str);
+  // str must still be white so we can use GCWriteNew
+  g->gc->GCWriteNew(array, str);
+  // increment size immediately
+  //so it is accurate on next allocation
+  array->size++;
+}
+...
+::
+##This is emphasis::not:: safe:
+||teletype::
+PyrSlot* arg = g->sp;
+int size = 10;
+PyrObject *array = newPyrArray(g->gc, size, 0, true); // runGC = true
+// setting size to final value here means
+// it is *not* accurate on next allocation below
+array->size = size;
+SetObject(arg, array);
+for(i=0; i<numLists; ++i) {
+  PyrObject *str = newPyrString(g->gc, "Hello", 0, true); // runGC = true
+  SetObject(array->slots + i, str);
+  g->gc->GCWriteNew(array, str);
+}
+...
+::
+::
+
+It is good practice to avoid creating objects in a primitive at all where possible. Primitives are much simpler to write and debug if you pass in an object that you create in SC code and fill in its slots in the primitive.
 
 note::
-To summarize, before calling any function that might allocate (like teletype::newPyr*::) you strong::must:: make sure these critera are fulfilled:
+To summarize, before calling any function that might allocate (like teletype::newPyr*::) you strong::must:: make sure these criteria are fulfilled:
 numberedlist::
 ## All objects previously created must be reachable, which means they must exist
     list::
     ## on the teletype::g->sp:: stack
-    ## or, in a lang-side class/instance variable
+    ## or, in a lang-side variable or class variable.
     ## or, in a slot of another object that fulfils these criteria.
     ::
 ## If any object ( teletype::child:: ) was put inside a slot of another object ( teletype::parent:: ), you must have
     list::
-    ## called teletype::g->gc->GCWrite(parent, child):: afterwards
+    ## called teletype::g->gc->GCWrite(parent, child):: afterwards unless you strong::know:: that the parent is still white (unexamined), or GCWriteNew if you also strong::know:: that the child is white
     ## and, set teletype::parent->size:: to the correct value
     ::
 ::
 ::
 
-Here's an example of how it may look:
+Here's an example of how a complete primitive might look:
 teletype::
 int prMyPrimitive(struct VMGlobals* g, int numArgsPushed)
 {
@@ -108,15 +233,17 @@ int prMyPrimitive(struct VMGlobals* g, int numArgsPushed)
     if(err) return err;
 
     PyrObject *array = newPyrArray(g->gc, 2, 0, true);
-    array->size = 0;
+    // array->size = 0 at creation; max size is 2
     SetObject(arg, array); // return value
 
     // NOTE: array is now reachable on the stack, since arg refers to g->sp
 
     PyrObject *str1 = newPyrString(g->gc, "Hello", 0, true);
     SetObject(array->slots, str1);
-    array->size++;
-    g->gc->GCWrite(array, str1);
+    array->size++; // immediately increment array's size
+    // array may not be white, so call GCWrite
+    // but we know str is white, so can use GCWriteNew instead
+    g->gc->GCWriteNew(array, str1);
 
     // NOTE: str1 is now reachable in array, which is reachable on the stack
 
@@ -127,7 +254,7 @@ int prMyPrimitive(struct VMGlobals* g, int numArgsPushed)
     return errNone;
 }
 ::
-If we would have put teletype::SetObject(arg, array);:: at the end of this function, teletype::array:: would strong::not:: have been reachable at the call to teletype::newPyrString::, thus breaking the rules and introducing bugs that sooner or later would crash SuperCollider (but most probably not in the faulty code but somewhere else, making it very hard to find!)
+If we would have put teletype::SetObject(arg, array);:: at the end of this function, teletype::array:: would strong::not:: have been reachable at the call to teletype::newPyrString::, and thus may have been marked teletype::free::, resulting in a hard to track down bug.
 
 warning::Do not store pointers to PyrObjects in C/C++ variables unless you can absolutely guarantee that they cannot be garbage
 collected. For example the File and SCWindow classes do this by storing the objects in an array in a classvar. The

--- a/QtCollider/QcApplication.cpp
+++ b/QtCollider/QcApplication.cpp
@@ -113,7 +113,7 @@ void QcApplication::interpret( const QString &str, bool print )
       PyrString *strObj = newPyrString( g->gc, str.toStdString().c_str(), 0, true );
 
       SetObject(&slotRawInterpreter(&g->process->interpreter)->cmdLine, strObj);
-      g->gc->GCWrite(slotRawObject(&g->process->interpreter), strObj);
+      g->gc->GCWriteNew(slotRawObject(&g->process->interpreter), strObj); // we know strObj is white so we can use GCWriteNew
 
       runLibrary( print ? SC_SYM(interpretPrintCmdLine) : SC_SYM(interpretCmdLine) );
   }

--- a/QtCollider/primitives/prim_QImage.cpp
+++ b/QtCollider/primitives/prim_QImage.cpp
@@ -477,7 +477,7 @@ QC_LANG_PRIMITIVE( QImage_Formats, 1, PyrSlot *r, PyrSlot *a, VMGlobals *g )
         PyrString *str = newPyrString( g->gc, formats[i].constData(), obj_immutable, false );
         SetObject(array->slots+i, str);
         ++array->size;
-        g->gc->GCWrite( array, array->slots+i );
+        g->gc->GCWriteNew( array, str ); // we know str is white so we can use GCWriteNew
     }
 
     return errNone;

--- a/QtCollider/primitives/prim_QQuartzComposer.mm
+++ b/QtCollider/primitives/prim_QQuartzComposer.mm
@@ -175,8 +175,7 @@ static int getSCObjectForNSObject(PyrSlot *slot, id nsObject, NSString *type, VM
             array = newPyrArray(g->gc, 4, 0, false);
             array->size = 4;
             nilSlots(array->slots, array->size);
-            SetObject(dict->slots + ivxIdentDict_array, array);
-            g->gc->GCWriteNew(dict, array); // we know array is white so we can use GCWriteNew
+            SetObject(dict->slots + ivxIdentDict_array, array); // we know that dict is white so don't need GCWrite
             SetObject(slot, dict);
             
             NSEnumerator *enumerator = [nsObject keyEnumerator];

--- a/QtCollider/primitives/prim_QQuartzComposer.mm
+++ b/QtCollider/primitives/prim_QQuartzComposer.mm
@@ -176,7 +176,7 @@ static int getSCObjectForNSObject(PyrSlot *slot, id nsObject, NSString *type, VM
             array->size = 4;
             nilSlots(array->slots, array->size);
             SetObject(dict->slots + ivxIdentDict_array, array);
-            g->gc->GCWrite(dict, array);
+            g->gc->GCWriteNew(dict, array); // we know array is white so we can use GCWriteNew
             SetObject(slot, dict);
             
             NSEnumerator *enumerator = [nsObject keyEnumerator];

--- a/SCDoc/SCDocPrim.cpp
+++ b/SCDoc/SCDocPrim.cpp
@@ -41,7 +41,7 @@ static void _doc_traverse(struct VMGlobals* g, DocNode *n, PyrObject *parent, Py
 	SetObject(slot, result);
 	if(parent) {
 		assert(isKindOf(parent, class_array));
-		g->gc->GCWrite(parent, result);
+		g->gc->GCWriteNew(parent, result); // we know result is white so we can use GCWriteNew
 		parent->size++;
 	}
 
@@ -53,14 +53,14 @@ static void _doc_traverse(struct VMGlobals* g, DocNode *n, PyrObject *parent, Py
     if(n->text) {
         PyrObject *str = (PyrObject*) newPyrString(g->gc, n->text, 0, true);
         SetObject(result->slots+1, str);
-        g->gc->GCWriteNew(result, str); // we know str is white
+        g->gc->GCWriteNew(result, str); // we know str is white so we can use GCWriteNew
     }
 	
 	// children
     if(n->n_childs) {
         PyrObject *array = newPyrArray(g->gc, n->n_childs, 0, true);
         SetObject(result->slots+2, array);
-        g->gc->GCWriteNew(result, array); // we know array is white
+        g->gc->GCWriteNew(result, array); // we know array is white so we can use GCWriteNew
         for(int i=0; i<n->n_childs; i++) {
             _doc_traverse(g, n->children[i], array, array->slots+i);
         }

--- a/SCDoc/SCDocPrim.cpp
+++ b/SCDoc/SCDocPrim.cpp
@@ -37,35 +37,35 @@ PyrSymbol *s_scdoc_node;
 
 static void _doc_traverse(struct VMGlobals* g, DocNode *n, PyrObject *parent, PyrSlot *slot)
 {
-    PyrObject *result = instantiateObject( g->gc, s_scdoc_node->u.classobj, 0, false, false );
-    result->size = 0;
+    PyrObject *result = instantiateObject( g->gc, s_scdoc_node->u.classobj, 0, false, true );
 	SetObject(slot, result);
-	if(parent) g->gc->GCWrite(parent, result);
+	if(parent) {
+		assert(isKindOf(parent, class_array));
+		g->gc->GCWrite(parent, result);
+		parent->size++;
+	}
 
+	// initialise the instance vars
     PyrSymbol *id = getsym(n->id);
-    SetSymbol(result->slots+result->size++, id);
+    SetSymbol(result->slots, id); // id
 
+	// text
     if(n->text) {
         PyrObject *str = (PyrObject*) newPyrString(g->gc, n->text, 0, true);
-        SetObject(result->slots+result->size++, str);
-        g->gc->GCWrite(result, str);
-    } else {
-        SetNil(result->slots+result->size++);
+        SetObject(result->slots+1, str);
+        g->gc->GCWriteNew(result, str); // we know str is white
     }
-
+	
+	// children
     if(n->n_childs) {
         PyrObject *array = newPyrArray(g->gc, n->n_childs, 0, true);
-        array->size = 0;
-        SetObject(result->slots+result->size++, array);
-        g->gc->GCWrite(result, array);
+        SetObject(result->slots+2, array);
+        g->gc->GCWriteNew(result, array); // we know array is white
         for(int i=0; i<n->n_childs; i++) {
-            array->size++;
             _doc_traverse(g, n->children[i], array, array->slots+i);
         }
-    } else {
-        SetNil(result->slots+result->size++);
-    }
-    result->size += 3; // makeDiv, notPrivOnly, sort
+	}
+    // makeDiv, notPrivOnly, sort remain nil for now
 }
 
 

--- a/lang/LangPrimSource/OSCData.cpp
+++ b/lang/LangPrimSource/OSCData.cpp
@@ -60,7 +60,7 @@ InternalSynthServerGlobals gInternalSynthServer = { 0, kNumDefaultSharedControls
 
 SC_UdpInPort* gUDPport = 0;
 
-PyrString* newPyrString(VMGlobals *g, char *s, int flags, bool collect);
+PyrString* newPyrString(VMGlobals *g, char *s, int flags, bool runGC);
 
 PyrSymbol *s_call, *s_write, *s_recvoscmsg, *s_recvoscbndl, *s_netaddr;
 extern bool compiledOK;
@@ -559,12 +559,12 @@ static int prArray_OSCBytes(VMGlobals *g, int numArgsPushed)
 // Create a new <PyrInt8Array> object and copy data from `msg.getb'.
 // Bytes are properly untyped, but there is no <UInt8Array> type.
 
-static PyrInt8Array* MsgToInt8Array ( sc_msg_iter& msg, bool collect ) ;
-static PyrInt8Array* MsgToInt8Array ( sc_msg_iter& msg, bool collect )
+static PyrInt8Array* MsgToInt8Array ( sc_msg_iter& msg, bool runGC ) ;
+static PyrInt8Array* MsgToInt8Array ( sc_msg_iter& msg, bool runGC )
 {
 	int size = msg.getbsize() ;
 	VMGlobals *g = gMainVMGlobals ;
-	PyrInt8Array *obj = newPyrInt8Array ( g->gc , size , 0 , collect ) ;
+	PyrInt8Array *obj = newPyrInt8Array ( g->gc , size , 0 , runGC ) ;
 	obj->size = size ;
 	msg.getb ( (char *)obj->b , obj->size ) ;
 	return obj ;

--- a/lang/LangPrimSource/OSCData.cpp
+++ b/lang/LangPrimSource/OSCData.cpp
@@ -559,12 +559,12 @@ static int prArray_OSCBytes(VMGlobals *g, int numArgsPushed)
 // Create a new <PyrInt8Array> object and copy data from `msg.getb'.
 // Bytes are properly untyped, but there is no <UInt8Array> type.
 
-static PyrInt8Array* MsgToInt8Array ( sc_msg_iter& msg ) ;
-static PyrInt8Array* MsgToInt8Array ( sc_msg_iter& msg )
+static PyrInt8Array* MsgToInt8Array ( sc_msg_iter& msg, bool collect ) ;
+static PyrInt8Array* MsgToInt8Array ( sc_msg_iter& msg, bool collect )
 {
 	int size = msg.getbsize() ;
 	VMGlobals *g = gMainVMGlobals ;
-	PyrInt8Array *obj = newPyrInt8Array ( g->gc , size , 0 , true ) ;
+	PyrInt8Array *obj = newPyrInt8Array ( g->gc , size , 0 , collect ) ;
 	obj->size = size ;
 	msg.getb ( (char *)obj->b , obj->size ) ;
 	return obj ;
@@ -616,7 +616,7 @@ static PyrObject* ConvertOSCMessage(int inSize, char *inData)
 			break;
 		case 'b' : // fall through
 		case 'm' :
-			SetObject(slots+i+1, (PyrObject*)MsgToInt8Array(msg));
+			SetObject(slots+i+1, (PyrObject*)MsgToInt8Array(msg, false));
 			break;
 		case 'c':
 			SetChar(slots+i+1, (char)msg.geti());

--- a/lang/LangPrimSource/PyrArrayPrimitives.cpp
+++ b/lang/LangPrimSource/PyrArrayPrimitives.cpp
@@ -2360,7 +2360,7 @@ int prArrayUnlace(struct VMGlobals *g, int numArgsPushed)
 			}
 		}
 		SetObject(slots2 + i, obj3);
-		g->gc->GCWrite(obj2, obj3);
+		g->gc->GCWriteNew(obj2, obj3); // we know obj3 is white so we can use GCWriteNew
 		obj2->size++;
 	}
 

--- a/lang/LangPrimSource/PyrArrayPrimitives.cpp
+++ b/lang/LangPrimSource/PyrArrayPrimitives.cpp
@@ -2339,7 +2339,6 @@ int prArrayUnlace(struct VMGlobals *g, int numArgsPushed)
 	if (err) return err;
 
 	obj2 = instantiateObject(g->gc, obj1->classptr, numLists, false, true);
-	obj2->size = numLists;
 	slots2 = obj2->slots;
 
 	SetObject(b, obj2); // store reference on stack, so both source and destination objects can be reached by the gc
@@ -2358,6 +2357,8 @@ int prArrayUnlace(struct VMGlobals *g, int numArgsPushed)
 			}
 		}
 		SetObject(slots2 + i, obj3);
+		g->gc->GCWrite(obj2, obj3);
+		obj2->size++;
 	}
 
 	SetRaw(a, obj2);

--- a/lang/LangPrimSource/PyrArrayPrimitives.cpp
+++ b/lang/LangPrimSource/PyrArrayPrimitives.cpp
@@ -1773,7 +1773,7 @@ int prArrayPermute(struct VMGlobals *g, int numArgsPushed)
 
 int prArrayAllTuples(struct VMGlobals *g, int numArgsPushed)
 {
-	PyrSlot *a, *b, *slots1, *slots2, *slots3;
+	PyrSlot *a, *b, *slots1, *slots2, *slots3, *slotToCopy;
 	PyrObject *obj1, *obj2, *obj3;
 
 	a = g->sp - 1;
@@ -1803,11 +1803,14 @@ int prArrayAllTuples(struct VMGlobals *g, int numArgsPushed)
 		for (int j=tupSize-1; j >= 0; --j) {
 			if (isKindOfSlot(slots1+j, class_array)) {
 				PyrObject *obj4 = slotRawObject(&slots1[j]);
-				slotCopy(&slots3[j], &obj4->slots[k % obj4->size]);
-				g->gc->GCWrite(obj3, obj4);
+				slotToCopy = &obj4->slots[k % obj4->size];
+				slotCopy(&slots3[j], slotToCopy);
+				g->gc->GCWrite(obj3, slotToCopy);
 				k /= obj4->size;
 			} else {
-				slotCopy(&slots3[j], &slots1[j]);
+				slotToCopy = &slots1[j];
+				slotCopy(&slots3[j], slotToCopy);
+				g->gc->GCWrite(obj3, slotToCopy);
 			}
 		}
 		obj3->size = tupSize;

--- a/lang/LangPrimSource/PyrFilePrim.cpp
+++ b/lang/LangPrimSource/PyrFilePrim.cpp
@@ -1462,6 +1462,8 @@ int prSFOpenRead(struct VMGlobals *g, int numArgsPushed)
 	a = g->sp - 1;
 	b = g->sp;
 
+	PyrObject *obj1 = slotRawObject(a);
+
 	if (!isKindOfSlot(b, class_string)) return errWrongType;
 	if (slotRawObject(b)->size > PATH_MAX - 1) return errFailed;
 
@@ -1473,16 +1475,18 @@ int prSFOpenRead(struct VMGlobals *g, int numArgsPushed)
 
 
 	if (file) {
-		SetPtr(slotRawObject(a)->slots + 0, file);
+		SetPtr(obj1->slots + 0, file);
 		sndfileFormatInfoToStrings(&info, &headerstr, &sampleformatstr);
 		//headerFormatToString(&info, &headerstr);
 		PyrString *hpstr = newPyrString(g->gc, headerstr, 0, true);
-		SetObject(slotRawObject(a)->slots+1, hpstr);
+		SetObject(obj1->slots+1, hpstr);
+		g->gc->GCWrite(obj1, (PyrObjectHdr*)hpstr);
 		PyrString *smpstr = newPyrString(g->gc, sampleformatstr, 0, true);
-		SetObject(slotRawObject(a)->slots+2, smpstr);
-		SetInt(slotRawObject(a)->slots + 3, info.frames);
-		SetInt(slotRawObject(a)->slots + 4, info.channels);
-		SetInt(slotRawObject(a)->slots + 5, info.samplerate);
+		SetObject(obj1->slots+2, smpstr);
+		g->gc->GCWrite(obj1, (PyrObjectHdr*)smpstr);
+		SetInt(obj1->slots + 3, info.frames);
+		SetInt(obj1->slots + 4, info.channels);
+		SetInt(obj1->slots + 5, info.samplerate);
 
 		SetTrue(a);
 	} else {

--- a/lang/LangPrimSource/PyrFilePrim.cpp
+++ b/lang/LangPrimSource/PyrFilePrim.cpp
@@ -1480,10 +1480,10 @@ int prSFOpenRead(struct VMGlobals *g, int numArgsPushed)
 		//headerFormatToString(&info, &headerstr);
 		PyrString *hpstr = newPyrString(g->gc, headerstr, 0, true);
 		SetObject(obj1->slots+1, hpstr);
-		g->gc->GCWrite(obj1, (PyrObjectHdr*)hpstr);
+		g->gc->GCWriteNew(obj1, (PyrObjectHdr*)hpstr); // we know hpstr is white so we can use GCWriteNew
 		PyrString *smpstr = newPyrString(g->gc, sampleformatstr, 0, true);
 		SetObject(obj1->slots+2, smpstr);
-		g->gc->GCWrite(obj1, (PyrObjectHdr*)smpstr);
+		g->gc->GCWriteNew(obj1, (PyrObjectHdr*)smpstr); // we know smpstr is white so we can use GCWriteNew
 		SetInt(obj1->slots + 3, info.frames);
 		SetInt(obj1->slots + 4, info.channels);
 		SetInt(obj1->slots + 5, info.samplerate);
@@ -1783,7 +1783,7 @@ int prDirectory_At(struct VMGlobals *g, int numArgsPushed)
 
 	PyrString *nameString = newPyrString(g->gc, name, 0, true);
 	SetObject(entryName, nameString);
-	g->gc->GCWrite(slotRawObject(b), (PyrObject*)nameString);
+	g->gc->GCWriteNew(slotRawObject(b), (PyrObject*)nameString); // we know nameString is white so we can use GCWriteNew
 
 	memcpy(fullPathName, slotRawObject(dirPathSlot)s->s, dirPathLength);
 	fullPathName[dirPathLength] = DELIMITOR;
@@ -1791,7 +1791,7 @@ int prDirectory_At(struct VMGlobals *g, int numArgsPushed)
 
 	PyrString *pathString = newPyrString(g->gc, fullPathName, 0, true);
 	SetObject(entryPath, pathString);
-	g->gc->GCWrite(slotRawObject(b), (PyrObject*)pathString);
+	g->gc->GCWriteNew(slotRawObject(b), (PyrObject*)pathString); // we know pathString is white so we can use GCWriteNew
 
 	if (isDirectory) { SetTrue(entryIsDir); } else { SetFalse(entryIsDir); }
 	if (isVisible) { SetTrue(entryIsVisible); } else { SetFalse(entryIsVisible); }

--- a/lang/LangPrimSource/PyrListPrim.cpp
+++ b/lang/LangPrimSource/PyrListPrim.cpp
@@ -82,7 +82,7 @@ int prArrayMultiChanExpand(struct VMGlobals *g, int numArgsPushed)
 		obj3 = newPyrArray(g->gc, size, 0, true);
 		obj3->size = size;
 		SetObject(slots2 + i, obj3);
-		g->gc->GCWrite(obj2, obj3);
+		g->gc->GCWriteNew(obj2, obj3); // we know obj3 is white so we can use GCWriteNew
 		obj2->size++;
 		slots1 = obj1->slots;
 		slots3 = obj3->slots;
@@ -250,7 +250,7 @@ int identDictPut(struct VMGlobals *g, PyrObject *dict, PyrSlot *key, PyrSlot *va
 				}
 			}
 			SetRaw(&dict->slots[ivxIdentDict_array], newarray);
-			g->gc->GCWrite(dict, newarray);
+			g->gc->GCWriteNew(dict, newarray); // we know newarray is white so we can use GCWriteNew
 		}
 	}
 	return errNone;
@@ -316,7 +316,7 @@ int prIdentDict_PutGet(struct VMGlobals *g, int numArgsPushed)
 				}
 			}
 			SetRaw(&dict->slots[ivxIdentDict_array], newarray);
-			g->gc->GCWrite(dict, newarray);
+			g->gc->GCWriteNew(dict, newarray); // we know newarray is white so we can use GCWriteNew
 		}
 	}
 	--g->sp;
@@ -540,7 +540,7 @@ void PriorityQueueAdd(struct VMGlobals *g, PyrObject* queueobj, PyrSlot* item, d
 		schedq->size = 1;
 		SetInt(schedq->slots + 0, 0); // stability count
 		SetObject(schedqSlot, schedq);
-		g->gc->GCWrite(queueobj, schedq);
+		g->gc->GCWriteNew(queueobj, schedq); // we know schedq is white so we can use GCWriteNew
 	} else {
 		schedq = slotRawObject(schedqSlot);
 		maxsize = ARRAYMAXINDEXSIZE(schedq);
@@ -554,7 +554,7 @@ void PriorityQueueAdd(struct VMGlobals *g, PyrObject* queueobj, PyrSlot* item, d
 			assert(IsInt(newschedq->slots));
 
 			SetObject(schedqSlot, newschedq);
-			g->gc->GCWrite(queueobj, newschedq);
+			g->gc->GCWriteNew(queueobj, newschedq); // we know newschedq is white so we can use GCWriteNew
 
 			schedq = newschedq;
 		}

--- a/lang/LangPrimSource/PyrListPrim.cpp
+++ b/lang/LangPrimSource/PyrListPrim.cpp
@@ -76,31 +76,35 @@ int prArrayMultiChanExpand(struct VMGlobals *g, int numArgsPushed)
 	}
 
 	obj2 = newPyrArray(g->gc, maxlen, 0, true);
-	obj2->size = maxlen;
+	SetObject(a, obj2);
 	slots2 = obj2->slots;
 	for (i=0; i<maxlen; ++i) {
-		obj3 = newPyrArray(g->gc, size, 0, false);
+		obj3 = newPyrArray(g->gc, size, 0, true);
 		obj3->size = size;
 		SetObject(slots2 + i, obj3);
+		g->gc->GCWrite(obj2, obj3);
+		obj2->size++;
 		slots1 = obj1->slots;
 		slots3 = obj3->slots;
 		for (j=0; j<size; ++j) {
 			slot = slots1 + j;
 			if (IsObj(slot)) {
 				if (slotRawObject(slot)->classptr == class_array && slotRawObject(slot)->size > 0) {
+					PyrSlot *slotToCopy;
 					obj4 = slotRawObject(slot);
 					slots4 = obj4->slots;
-					slotCopy(&slots3[j],&slots4[i % obj4->size]);
+					slotToCopy = &slots4[i % obj4->size];
+					slotCopy(&slots3[j],slotToCopy);
+					g->gc->GCWrite(obj3, slotToCopy);
 				} else {
 					slotCopy(&slots3[j],slot);
+					g->gc->GCWrite(obj3, slot);
 				}
 			} else {
-				slotCopy(&slots3[j],slot);
+				slotCopy(&slots3[j],slot); // we don't need GCWrite here, as slot is not an object
 			}
 		}
 	}
-
-	SetObject(a, obj2);
 
 	return errNone;
 }

--- a/lang/LangPrimSource/PyrPrimitive.cpp
+++ b/lang/LangPrimSource/PyrPrimitive.cpp
@@ -3459,12 +3459,12 @@ static int prLanguageConfig_getLibraryPaths(struct VMGlobals * g, int numArgsPus
 	size_t numberOfPaths = dirVector.size();
 	PyrObject * resultArray = newPyrArray(g->gc, numberOfPaths, 0, true);
 	SetObject(result, resultArray);
-	resultArray->size = numberOfPaths;
 
 	for (size_t i = 0; i != numberOfPaths; ++i) {
 		PyrString * pyrString = newPyrString(g->gc, dirVector[i].c_str(), 0, true);
 		SetObject(resultArray->slots + i, pyrString);
 		g->gc->GCWrite( resultArray,  pyrString );
+		resultArray->size++;
 	}
 	return errNone;
 }

--- a/lang/LangPrimSource/PyrPrimitive.cpp
+++ b/lang/LangPrimSource/PyrPrimitive.cpp
@@ -2082,7 +2082,7 @@ private:
 		PyrMethod *meth = slotRawMethod(&frame->method);
 		PyrMethodRaw * methraw = METHRAW(meth);
 
-		PyrObject* debugFrameObj = instantiateObject(g->gc, getsym("DebugFrame")->u.classobj, 0, false, true);
+		PyrObject* debugFrameObj = instantiateObject(g->gc, getsym("DebugFrame")->u.classobj, 0, false, false);
 		SetObject(outSlot, debugFrameObj);
 
 		SetObject(debugFrameObj->slots + 0, meth);

--- a/lang/LangPrimSource/PyrPrimitive.cpp
+++ b/lang/LangPrimSource/PyrPrimitive.cpp
@@ -2968,7 +2968,7 @@ void initPyrThread(VMGlobals *g, PyrThread *thread, PyrSlot *func, int stacksize
 
 	array = newPyrArray(gc, stacksize, 0, runGC);
 	SetObject(&thread->stack, array);
-	gc->GCWrite(thread, array);
+	gc->GCWriteNew(thread, array); // we know array is white so we can use GCWriteNew
 
 	SetInt(&thread->state, tInit);
 
@@ -3065,7 +3065,7 @@ int prThreadRandSeed(struct VMGlobals *g, int numArgsPushed)
 		g->rgen = (RGen*)(rgenArray->i);
 	}
 	SetObject(&thread->randData, rgenArray);
-	g->gc->GCWrite(thread, rgenArray);
+	g->gc->GCWriteNew(thread, rgenArray); // we know rgenArray is white so we can use GCWriteNew
 
 	return errNone;
 }
@@ -3463,7 +3463,7 @@ static int prLanguageConfig_getLibraryPaths(struct VMGlobals * g, int numArgsPus
 	for (size_t i = 0; i != numberOfPaths; ++i) {
 		PyrString * pyrString = newPyrString(g->gc, dirVector[i].c_str(), 0, true);
 		SetObject(resultArray->slots + i, pyrString);
-		g->gc->GCWrite( resultArray,  pyrString );
+		g->gc->GCWriteNew( resultArray,  pyrString ); // we know pyrString is white so we can use GCWriteNew
 		resultArray->size++;
 	}
 	return errNone;

--- a/lang/LangPrimSource/PyrPrimitive.cpp
+++ b/lang/LangPrimSource/PyrPrimitive.cpp
@@ -2956,9 +2956,9 @@ void switchToThread(VMGlobals *g, PyrThread *newthread, int oldstate, int *numAr
 }
 
 void initPyrThread(VMGlobals *g, PyrThread *thread, PyrSlot *func, int stacksize, PyrInt32Array* rgenArray,
-	double beats, double seconds, PyrSlot* clock, bool collect);
+	double beats, double seconds, PyrSlot* clock, bool runGC);
 void initPyrThread(VMGlobals *g, PyrThread *thread, PyrSlot *func, int stacksize, PyrInt32Array* rgenArray,
-	double beats, double seconds, PyrSlot* clock, bool collect)
+	double beats, double seconds, PyrSlot* clock, bool runGC)
 {
 	PyrObject *array;
 	PyrGC* gc = g->gc;
@@ -2966,7 +2966,7 @@ void initPyrThread(VMGlobals *g, PyrThread *thread, PyrSlot *func, int stacksize
 	slotCopy(&thread->func, func);
 	gc->GCWrite(thread, func);
 
-	array = newPyrArray(gc, stacksize, 0, collect);
+	array = newPyrArray(gc, stacksize, 0, runGC);
 	SetObject(&thread->stack, array);
 	gc->GCWrite(thread, array);
 

--- a/lang/LangPrimSource/PyrStringPrim.cpp
+++ b/lang/LangPrimSource/PyrStringPrim.cpp
@@ -409,7 +409,6 @@ static int prString_FindRegexp(struct VMGlobals *g, int numArgsPushed)
 	int match_count = matches.size();
 
 	PyrObject *result_array = newPyrArray(g->gc, match_count, 0, true);
-	result_array->size = 0;
 	SetObject(a, result_array);
 
 	if( !match_count ) return errNone;
@@ -960,7 +959,6 @@ static void yaml_traverse(struct VMGlobals* g, const YAML::Node & node, PyrObjec
 
 		case YAML::NodeType::Sequence:
 			result = newPyrArray(g->gc, node.size(), 0, true);
-			result->size = 0;
 			SetObject(slot, result);
 			if(parent) g->gc->GCWrite(parent, result);
 			for (unsigned int i = 0; i < node.size(); i++) {
@@ -977,8 +975,7 @@ static void yaml_traverse(struct VMGlobals* g, const YAML::Node & node, PyrObjec
 			if(parent) g->gc->GCWrite(parent, result);
 
 			PyrObject *array = newPyrArray(g->gc, node.size()*2, 0, true);
-			array->size = 0;
-			result->size = 2; // ?
+			result->size = 2;
 			SetObject(result->slots, array);      // array
 			SetInt(result->slots+1, node.size()); // size
 			g->gc->GCWrite(result, array);

--- a/lang/LangPrimSource/PyrStringPrim.cpp
+++ b/lang/LangPrimSource/PyrStringPrim.cpp
@@ -421,7 +421,7 @@ static int prString_FindRegexp(struct VMGlobals *g, int numArgsPushed)
 		PyrObject *array = newPyrArray(g->gc, 2, 0, true);
 		SetObject(result_array->slots + i, array);
 		result_array->size++;
-		g->gc->GCWrite(result_array, array);
+		g->gc->GCWriteNew(result_array, array); // we know array is white so we can use GCWriteNew
 
 		PyrString *matched_string = newPyrStringN(g->gc, len, 0, true);
 		memcpy(matched_string->s, stringBegin + pos, len);
@@ -429,7 +429,7 @@ static int prString_FindRegexp(struct VMGlobals *g, int numArgsPushed)
 		array->size = 2;
 		SetInt(array->slots, pos + offset);
 		SetObject(array->slots+1, matched_string);
-		g->gc->GCWrite(array, matched_string);
+		g->gc->GCWrite(array, matched_string); // we know matched_string is white so we can use GCWriteNew
 	};
 
 	return errNone;
@@ -490,7 +490,7 @@ static int prString_FindRegexpAt(struct VMGlobals *g, int numArgsPushed)
 	array->size = 2;
 	SetInt(array->slots+1, matched_len);
 	SetObject(array->slots, matched_string);
-	g->gc->GCWrite(array, matched_string);
+	g->gc->GCWriteNew(array, matched_string); // we know matched_string is white so we can use GCWriteNew
 
 	return errNone;
 }
@@ -570,7 +570,7 @@ int prStringPathMatch(struct VMGlobals *g, int numArgsPushed)
 	for (unsigned int i=0; i<pglob.gl_pathc; ++i) {
 		PyrObject *string = (PyrObject*)newPyrString(g->gc, pglob.gl_pathv[i], 0, true);
 		SetObject(array->slots+i, string);
-		g->gc->GCWrite(array, string);
+		g->gc->GCWriteNew(array, string); // we know string is white so we can use GCWriteNew
 		array->size++;
 	}
 
@@ -647,7 +647,7 @@ int prStringPathMatch(struct VMGlobals *g, int numArgsPushed)
       const char* fullPath = strPath.c_str();
       PyrObject *string = (PyrObject*)newPyrString(g->gc, fullPath, 0, true);
       SetObject(array->slots+i, string);
-      g->gc->GCWrite(array, string);
+      g->gc->GCWriteNew(array, string); // we know string is white so we can use GCWriteNew
       array->size++;
       i++;
     }
@@ -954,13 +954,13 @@ static void yaml_traverse(struct VMGlobals* g, const YAML::Node & node, PyrObjec
 			node >> out;
 			result = (PyrObject*)newPyrString(g->gc, out.c_str(), 0, true);
 			SetObject(slot, result);
-			if(parent) g->gc->GCWrite(parent, result);
+			if(parent) g->gc->GCWriteNew(parent, result); // we know result is white so we can use GCWriteNew
 			break;
 
 		case YAML::NodeType::Sequence:
 			result = newPyrArray(g->gc, node.size(), 0, true);
 			SetObject(slot, result);
-			if(parent) g->gc->GCWrite(parent, result);
+			if(parent) g->gc->GCWriteNew(parent, result); // we know result is white so we can use GCWriteNew
 			for (unsigned int i = 0; i < node.size(); i++) {
 				const YAML::Node & subnode = node[i];
 				result->size++;
@@ -972,13 +972,13 @@ static void yaml_traverse(struct VMGlobals* g, const YAML::Node & node, PyrObjec
 		{
 			result = instantiateObject( g->gc, s_dictionary->u.classobj, 0, false, true );
 			SetObject(slot, result);
-			if(parent) g->gc->GCWrite(parent, result);
+			if(parent) g->gc->GCWriteNew(parent, result); // we know result is white so we can use GCWriteNew
 
 			PyrObject *array = newPyrArray(g->gc, node.size()*2, 0, true);
 			result->size = 2;
 			SetObject(result->slots, array);      // array
 			SetInt(result->slots+1, node.size()); // size
-			g->gc->GCWrite(result, array);
+			g->gc->GCWriteNew(result, array); // we know array is white so we can use GCWriteNew
 
 			int j = 0;
 			for (YAML::Iterator i = node.begin(); i != node.end(); ++i) {
@@ -988,7 +988,7 @@ static void yaml_traverse(struct VMGlobals* g, const YAML::Node & node, PyrObjec
 				PyrObject *pkey = (PyrObject*)newPyrString(g->gc, out.c_str(), 0, true);
 				SetObject(array->slots+j, pkey);
 				array->size++;
-				g->gc->GCWrite(array, pkey);
+				g->gc->GCWriteNew(array, pkey); // we know pkey is white so we can use GCWriteNew
 
 				array->size++;
 				yaml_traverse(g, value, array, array->slots+j+1);

--- a/lang/LangPrimSource/SC_CoreAudioPrim.cpp
+++ b/lang/LangPrimSource/SC_CoreAudioPrim.cpp
@@ -127,7 +127,7 @@ int listDevices(struct VMGlobals *g, int type)
         PyrString *string = newPyrString(g->gc, name, 0, true);
         SetObject(devArray->slots+j, string);
         devArray->size++;
-        g->gc->GCWrite(devArray, (PyrObject*)string);
+        g->gc->GCWriteNew(devArray, (PyrObject*)string); // we know array is white so we can use GCWriteNew
 
 		free(name);
 		j++;

--- a/lang/LangPrimSource/SC_CoreMIDI.cpp
+++ b/lang/LangPrimSource/SC_CoreMIDI.cpp
@@ -433,27 +433,27 @@ int prListMIDIEndpoints(struct VMGlobals *g, int numArgsPushed)
 
 	PyrObject* idarraySo = newPyrArray(g->gc, numSrc * sizeof(SInt32), 0 , true);
 		SetObject(idarray->slots+idarray->size++, idarraySo);
-		g->gc->GCWrite(idarray, idarraySo);
+		g->gc->GCWriteNew(idarray, idarraySo); // we know idarraySo is white so we can use GCWriteNew
 
 	PyrObject* devarraySo = newPyrArray(g->gc, numSrc * sizeof(PyrObject), 0 , true);
 		SetObject(idarray->slots+idarray->size++, devarraySo);
-		g->gc->GCWrite(idarray, devarraySo);
+		g->gc->GCWriteNew(idarray, devarraySo); // we know devarraySo is white so we can use GCWriteNew
 
 		PyrObject* namearraySo = newPyrArray(g->gc, numSrc * sizeof(PyrObject), 0 , true);
 		SetObject(idarray->slots+idarray->size++, namearraySo);
-		g->gc->GCWrite(idarray, namearraySo);
+		g->gc->GCWriteNew(idarray, namearraySo); // we know namearraySo is white so we can use GCWriteNew
 
 	PyrObject* idarrayDe = newPyrArray(g->gc, numDst * sizeof(SInt32), 0 , true);
 		SetObject(idarray->slots+idarray->size++, idarrayDe);
-		g->gc->GCWrite(idarray, idarrayDe);
+		g->gc->GCWriteNew(idarray, idarrayDe); // we know idarrayDe is white so we can use GCWriteNew
 
 	PyrObject* namearrayDe = newPyrArray(g->gc, numDst * sizeof(PyrObject), 0 , true);
 		SetObject(idarray->slots+idarray->size++, namearrayDe);
-		g->gc->GCWrite(idarray, namearrayDe);
+		g->gc->GCWriteNew(idarray, namearrayDe); // we know namearrayDe is white so we can use GCWriteNew
 
 	PyrObject* devarrayDe = newPyrArray(g->gc, numDst * sizeof(PyrObject), 0 , true);
 		SetObject(idarray->slots+idarray->size++, devarrayDe);
-		g->gc->GCWrite(idarray, devarrayDe);
+		g->gc->GCWriteNew(idarray, devarrayDe); // we know devarrayDe is white so we can use GCWriteNew
 
 
 	for (int i=0; i<numSrc; ++i) {
@@ -489,12 +489,12 @@ int prListMIDIEndpoints(struct VMGlobals *g, int numArgsPushed)
 		PyrString *string = newPyrString(g->gc, cendname, 0, true);
 		SetObject(namearraySo->slots+i, string);
 		namearraySo->size++;
-		g->gc->GCWrite(namearraySo, (PyrObject*)string);
+		g->gc->GCWriteNew(namearraySo, (PyrObject*)string); // we know string is white so we can use GCWriteNew
 
 		PyrString *devstring = newPyrString(g->gc, cdevname, 0, true);
 		SetObject(devarraySo->slots+i, devstring);
 		devarraySo->size++;
-		g->gc->GCWrite(devarraySo, (PyrObject*)devstring);
+		g->gc->GCWriteNew(devarraySo, (PyrObject*)devstring); // we know devString is white so we can use GCWriteNew
 
 		SetInt(idarraySo->slots+i, id);
 		idarraySo->size++;
@@ -539,12 +539,12 @@ int prListMIDIEndpoints(struct VMGlobals *g, int numArgsPushed)
 
 		PyrString *string = newPyrString(g->gc, cendname, 0, true);
 		SetObject(namearrayDe->slots+namearrayDe->size++, string);
-		g->gc->GCWrite(namearrayDe, (PyrObject*)string);
+		g->gc->GCWriteNew(namearrayDe, (PyrObject*)string); // we know string is white so we can use GCWriteNew
 
 		PyrString *devstring = newPyrString(g->gc, cdevname, 0, true);
 
 		SetObject(devarrayDe->slots+devarrayDe->size++, devstring);
-		g->gc->GCWrite(devarrayDe, (PyrObject*)devstring);
+		g->gc->GCWriteNew(devarrayDe, (PyrObject*)devstring); // we know devstring is white so we can use GCWriteNew
 
 		SetInt(idarrayDe->slots+idarrayDe->size++, id);
 

--- a/lang/LangPrimSource/SC_HID_api.cpp
+++ b/lang/LangPrimSource/SC_HID_api.cpp
@@ -503,14 +503,14 @@ int prHID_API_BuildDeviceList(VMGlobals* g, int numArgsPushed){
 		while( cur_dev ){
 			PyrObject* devInfo = newPyrArray(g->gc, 11 * sizeof(PyrObject), 0 , true);
 			SetObject(allDevsArray->slots+allDevsArray->size++, devInfo );
-			g->gc->GCWrite(allDevsArray, devInfo);
+			g->gc->GCWriteNew(allDevsArray, devInfo); // we know devInfo is white so we can use GCWriteNew
 
 			SetInt(devInfo->slots+devInfo->size++, cur_dev->vendor_id);
 			SetInt(devInfo->slots+devInfo->size++, cur_dev->product_id);
 
 			PyrString *dev_path_name = newPyrString(g->gc, cur_dev->path, 0, true );
 			SetObject(devInfo->slots+devInfo->size++, dev_path_name);
-			g->gc->GCWrite(devInfo, dev_path_name);
+			g->gc->GCWriteNew(devInfo, dev_path_name); // we know dev_path_name is white so we can use GCWriteNew
 
 			const char * mystring;
 			if ( cur_dev->serial_number != NULL )
@@ -520,7 +520,7 @@ int prHID_API_BuildDeviceList(VMGlobals* g, int numArgsPushed){
 
 			PyrString *dev_serial = newPyrString(g->gc, mystring, 0, true );
 			SetObject(devInfo->slots+devInfo->size++, dev_serial);
-			g->gc->GCWrite(devInfo, dev_serial);
+			g->gc->GCWriteNew(devInfo, dev_serial); // we know dev_serial is white so we can use GCWriteNew
 
 			if (mystring != emptyString) free((void*)mystring);
 			if ( cur_dev->manufacturer_string != NULL )
@@ -530,7 +530,7 @@ int prHID_API_BuildDeviceList(VMGlobals* g, int numArgsPushed){
 
 			PyrString *dev_man_name = newPyrString(g->gc, mystring, 0, true );
 			SetObject(devInfo->slots+devInfo->size++, dev_man_name);
-			g->gc->GCWrite(devInfo, dev_man_name);
+			g->gc->GCWriteNew(devInfo, dev_man_name); // we know dev_man_name is white so we can use GCWriteNew
 
 			if (mystring != emptyString) free((void*)mystring);
 
@@ -541,7 +541,7 @@ int prHID_API_BuildDeviceList(VMGlobals* g, int numArgsPushed){
 
 			PyrString *dev_prod_name = newPyrString(g->gc, mystring, 0, true );
 			SetObject(devInfo->slots+devInfo->size++, dev_prod_name);
-			g->gc->GCWrite(devInfo, dev_prod_name);
+			g->gc->GCWriteNew(devInfo, dev_prod_name); // we know dev_prod_name is white so we can use GCWriteNew
 
 			if (mystring != emptyString)
 				free((void*)mystring);
@@ -647,7 +647,7 @@ int prHID_API_GetInfo( VMGlobals* g, int numArgsPushed ){
 
 		PyrString *dev_path_name = newPyrString(g->gc, cur_dev->path, 0, true );
 		SetObject(devInfo->slots+devInfo->size++, dev_path_name);
-		g->gc->GCWrite(devInfo, dev_path_name);
+		g->gc->GCWriteNew(devInfo, dev_path_name); // we know dev_path_name is white so we can use GCWriteNew
 
 		const char * mystring;
 		if ( cur_dev->serial_number != NULL ){
@@ -658,7 +658,7 @@ int prHID_API_GetInfo( VMGlobals* g, int numArgsPushed ){
 
 		PyrString *dev_serial = newPyrString(g->gc, mystring, 0, true );
 		SetObject(devInfo->slots+devInfo->size++, dev_serial);
-		g->gc->GCWrite(devInfo, dev_serial);
+		g->gc->GCWriteNew(devInfo, dev_serial); // we know dev_serial is white so we can use GCWriteNew
 
 		if (mystring != emptyString)
 			free((void*)mystring);
@@ -670,7 +670,7 @@ int prHID_API_GetInfo( VMGlobals* g, int numArgsPushed ){
 		}
 		PyrString *dev_man_name = newPyrString(g->gc, mystring, 0, true );
 		SetObject(devInfo->slots+devInfo->size++, dev_man_name);
-		g->gc->GCWrite(devInfo, dev_man_name);
+		g->gc->GCWriteNew(devInfo, dev_man_name); // we know dev_man_name is white so we can use GCWriteNew
 		if (mystring != emptyString)
 			free((void*)mystring);
 
@@ -682,7 +682,7 @@ int prHID_API_GetInfo( VMGlobals* g, int numArgsPushed ){
 		}
 		PyrString *dev_prod_name = newPyrString(g->gc, mystring, 0, true );
 		SetObject(devInfo->slots+devInfo->size++, dev_prod_name);
-		g->gc->GCWrite(devInfo, dev_prod_name);
+		g->gc->GCWriteNew(devInfo, dev_prod_name); // we know dev_prod_name is white so we can use GCWriteNew
 		if (mystring != emptyString)
 			free((void*)mystring);
 

--- a/lang/LangPrimSource/SC_HID_api.cpp
+++ b/lang/LangPrimSource/SC_HID_api.cpp
@@ -502,6 +502,8 @@ int prHID_API_BuildDeviceList(VMGlobals* g, int numArgsPushed){
 		struct hid_device_info *cur_dev = SC_HID_APIManager::instance().devinfos;
 		while( cur_dev ){
 			PyrObject* devInfo = newPyrArray(g->gc, 11 * sizeof(PyrObject), 0 , true);
+			SetObject(allDevsArray->slots+allDevsArray->size++, devInfo );
+			g->gc->GCWrite(allDevsArray, devInfo);
 
 			SetInt(devInfo->slots+devInfo->size++, cur_dev->vendor_id);
 			SetInt(devInfo->slots+devInfo->size++, cur_dev->product_id);
@@ -549,9 +551,6 @@ int prHID_API_BuildDeviceList(VMGlobals* g, int numArgsPushed){
 
 			SetInt(devInfo->slots+devInfo->size++, cur_dev->usage_page);
 			SetInt(devInfo->slots+devInfo->size++, cur_dev->usage);
-
-			SetObject(allDevsArray->slots+allDevsArray->size++, devInfo );
-			g->gc->GCWrite(allDevsArray, devInfo);
 
 			cur_dev = cur_dev->next;
 		}

--- a/lang/LangPrimSource/SC_Speech.mm
+++ b/lang/LangPrimSource/SC_Speech.mm
@@ -372,6 +372,7 @@ int prGetSpeechVoiceNames(struct VMGlobals *g, int numArgsPushed){
 	NSString * aVoice = NULL;
 	NSEnumerator * voiceEnumerator = [[NSSpeechSynthesizer availableVoices] objectEnumerator];
 	PyrObject* allVoices = newPyrArray(g->gc, (int) [[NSSpeechSynthesizer availableVoices] count]  * sizeof(PyrObject), 0 , true);
+	SetObject(a, allVoices);
 
 	while(aVoice = [voiceEnumerator nextObject]) {
 		NSDictionary * dictionaryOfVoiceAttributes = [NSSpeechSynthesizer attributesForVoice:aVoice];
@@ -384,7 +385,6 @@ int prGetSpeechVoiceNames(struct VMGlobals *g, int numArgsPushed){
 	}
 	[autoreleasepool release];
 
-	SetObject(a, allVoices);
 	return errNone;
 
 }

--- a/lang/LangPrimSource/SC_Speech.mm
+++ b/lang/LangPrimSource/SC_Speech.mm
@@ -380,7 +380,7 @@ int prGetSpeechVoiceNames(struct VMGlobals *g, int numArgsPushed){
 
 		PyrString *namestring = newPyrString(g->gc, [voiceDisplayName cStringUsingEncoding:[NSString defaultCStringEncoding]], 0, true);
 		SetObject(allVoices->slots+allVoices->size++, namestring);
-		g->gc->GCWrite(allVoices, (PyrObject*) namestring);
+		g->gc->GCWriteNew(allVoices, (PyrObject*) namestring); // we know namestring is white so we can use GCWriteNew
 
 	}
 	[autoreleasepool release];

--- a/lang/LangSource/GC.cpp
+++ b/lang/LangSource/GC.cpp
@@ -344,7 +344,7 @@ void PyrGC::BecomeImmutable(PyrObject *inObject)
 
 void DumpBackTrace(VMGlobals *g);
 
-HOT PyrObject *PyrGC::New(size_t inNumBytes, long inFlags, long inFormat, bool inCollect)
+HOT PyrObject *PyrGC::New(size_t inNumBytes, long inFlags, long inFormat, bool inRunCollection)
 {
 	PyrObject *obj = NULL;
 
@@ -369,7 +369,7 @@ HOT PyrObject *PyrGC::New(size_t inNumBytes, long inFlags, long inFormat, bool i
 	mNumAllocs++;
 
 	mNumToScan += credit;
-	obj = Allocate(inNumBytes, sizeclass, inCollect);
+	obj = Allocate(inNumBytes, sizeclass, inRunCollection);
 
 	obj->obj_format = inFormat;
 	obj->obj_flags = inFlags & 255;
@@ -420,7 +420,7 @@ HOT PyrObject *PyrGC::NewFrame(size_t inNumBytes, long inFlags, long inFormat, b
 	return obj;
 }
 
-PyrObject *PyrGC::NewFinalizer(ObjFuncPtr finalizeFunc, PyrObject *inObject, bool inCollect)
+PyrObject *PyrGC::NewFinalizer(ObjFuncPtr finalizeFunc, PyrObject *inObject, bool inRunCollection)
 {
 	PyrObject *obj = NULL;
 
@@ -437,7 +437,7 @@ PyrObject *PyrGC::NewFinalizer(ObjFuncPtr finalizeFunc, PyrObject *inObject, boo
 	mAllocTotal += credit;
 	mNumAllocs++;
 
-	if (inCollect && mNumToScan >= kScanThreshold) {
+	if (inRunCollection && mNumToScan >= kScanThreshold) {
 		Collect();
 	}
 

--- a/lang/LangSource/GC.h
+++ b/lang/LangSource/GC.h
@@ -322,12 +322,12 @@ inline void PyrGC::ToGrey2(PyrObjectHdr* obj)
 	mNumGrey ++ ;
 }
 
-inline PyrObject * PyrGC::Allocate(size_t inNumBytes, int32 sizeclass, bool inCollect)
+inline PyrObject * PyrGC::Allocate(size_t inNumBytes, int32 sizeclass, bool inRunCollection)
 {
-	if (inCollect && mNumToScan >= kScanThreshold)
+	if (inRunCollection && mNumToScan >= kScanThreshold)
 		Collect();
 	else {
-		if (inCollect)
+		if (inRunCollection)
 			mUncollectedAllocations = 0;
 		else
 			++mUncollectedAllocations;

--- a/lang/LangSource/GC.h
+++ b/lang/LangSource/GC.h
@@ -128,6 +128,7 @@ public:
 	// when you know the child is white
 	void GCWriteNew(PyrObjectHdr* inParent, PyrObjectHdr* inChild)
 		{
+			assert(IsWhite(inChild));
 			if (IsBlack(inParent)) {
 				ToGrey(inChild);
 			}

--- a/lang/LangSource/PyrInterpreter3.cpp
+++ b/lang/LangSource/PyrInterpreter3.cpp
@@ -151,7 +151,7 @@ void runAwakeMessage(VMGlobals *g)
 }
 
 void initPyrThread(VMGlobals *g, PyrThread *thread, PyrSlot *func, int stacksize, PyrInt32Array* rgenArray,
-	double beats, double seconds, PyrSlot* clock, bool collect);
+	double beats, double seconds, PyrSlot* clock, bool runGC);
 int32 timeseed();
 
 PyrProcess* newPyrProcess(VMGlobals *g, PyrClass *procclassobj)

--- a/lang/LangSource/PyrObject.cpp
+++ b/lang/LangSource/PyrObject.cpp
@@ -2770,5 +2770,5 @@ void InstallFinalizer(VMGlobals* g, PyrObject *inObj, int slotIndex, ObjFuncPtr 
 {
 	PyrObject *finalizer = g->gc->NewFinalizer(inFunc, inObj, false);
 	SetObject(inObj->slots + slotIndex, finalizer);
-	g->gc->GCWrite(inObj, finalizer);
+	g->gc->GCWriteNew(inObj, finalizer); // we know finalizer is white so we can use GCWriteNew
 }

--- a/lang/LangSource/PyrObject.cpp
+++ b/lang/LangSource/PyrObject.cpp
@@ -1779,7 +1779,7 @@ void initClasses()
 }
 
 PyrObject* instantiateObject(class PyrGC *gc, PyrClass* classobj, int size,
-	bool fill, bool collect)
+	bool fill, bool runGC)
 {
 	PyrObject *newobj, *proto;
 	int numbytes, format, flags;
@@ -1790,7 +1790,7 @@ PyrObject* instantiateObject(class PyrGC *gc, PyrClass* classobj, int size,
 	if (slotRawInt(&classobj->classFlags) & classHasIndexableInstances) {
 		// create an indexable object
 		numbytes = size * gFormatElemSize[format];
-		newobj = gc->New(numbytes, flags, format, collect);
+		newobj = gc->New(numbytes, flags, format, runGC);
 		if (fill) {
 			newobj->size = size;
 			if (format == obj_slot) {
@@ -1806,14 +1806,14 @@ PyrObject* instantiateObject(class PyrGC *gc, PyrClass* classobj, int size,
 			proto = slotRawObject(&classobj->iprototype);
 			size = proto->size;
 			numbytes = size * sizeof(PyrSlot);
-			newobj = gc->New(numbytes, flags, format, collect);
+			newobj = gc->New(numbytes, flags, format, runGC);
 			newobj->size = size;
 			if (size) {
 				memcpy(newobj->slots, proto->slots, numbytes);
 			}
 		} else {
 			numbytes = 0;
-			newobj = gc->New(numbytes, flags, format, collect);
+			newobj = gc->New(numbytes, flags, format, runGC);
 			newobj->size = 0;
 		}
 	}
@@ -1821,8 +1821,8 @@ PyrObject* instantiateObject(class PyrGC *gc, PyrClass* classobj, int size,
 	return newobj;
 }
 
-PyrObject* instantiateObjectLight(class PyrGC *gc, PyrClass* classobj, int size, bool collect);
-PyrObject* instantiateObjectLight(class PyrGC *gc, PyrClass* classobj, int size, bool collect)
+PyrObject* instantiateObjectLight(class PyrGC *gc, PyrClass* classobj, int size, bool runGC);
+PyrObject* instantiateObjectLight(class PyrGC *gc, PyrClass* classobj, int size, bool runGC)
 {
 	PyrObject *newobj, *proto;
 	int numbytes, format, flags;
@@ -1842,14 +1842,14 @@ PyrObject* instantiateObjectLight(class PyrGC *gc, PyrClass* classobj, int size,
 			numbytes = 0;
 		}
 	}
-	newobj = gc->New(numbytes, flags, format, collect);
+	newobj = gc->New(numbytes, flags, format, runGC);
 	newobj->size = size;
 	newobj->classptr = classobj;
 
 	return newobj;
 }
 
-PyrObject* copyObject(class PyrGC *gc, PyrObject *inobj, bool collect)
+PyrObject* copyObject(class PyrGC *gc, PyrObject *inobj, bool runGC)
 {
 	PyrObject *newobj;
 
@@ -1860,7 +1860,7 @@ PyrObject* copyObject(class PyrGC *gc, PyrObject *inobj, bool collect)
 	int elemsize = gFormatElemSize[inobj->obj_format];
 	int numbytes = inobj->size * elemsize;
 
-	newobj = gc->New(numbytes, flags, inobj->obj_format, collect);
+	newobj = gc->New(numbytes, flags, inobj->obj_format, runGC);
 
 	newobj->size = inobj->size;
 	newobj->classptr = inobj->classptr;
@@ -1869,7 +1869,7 @@ PyrObject* copyObject(class PyrGC *gc, PyrObject *inobj, bool collect)
 	return newobj;
 }
 
-PyrObject* copyObjectRange(class PyrGC *gc, PyrObject *inobj, int start, int end, bool collect)
+PyrObject* copyObjectRange(class PyrGC *gc, PyrObject *inobj, int start, int end, bool runGC)
 {
 	PyrObject *newobj;
 
@@ -1885,7 +1885,7 @@ PyrObject* copyObjectRange(class PyrGC *gc, PyrObject *inobj, int start, int end
 	int flags = ~(obj_immutable) & inobj->obj_flags;
 		flags = ~(obj_permanent) & flags;
 
-	newobj = gc->New(numbytes, flags, inobj->obj_format, collect);
+	newobj = gc->New(numbytes, flags, inobj->obj_format, runGC);
 	newobj->size = length;
 	newobj->classptr = inobj->classptr;
 
@@ -2345,12 +2345,12 @@ void zeroSlots(PyrSlot* slot, int size)
 	fillSlots(slot, size, &zero);
 }
 
-PyrObject* newPyrObject(class PyrGC *gc, size_t inNumBytes, int inFlags, int inFormat, bool inCollect)
+PyrObject* newPyrObject(class PyrGC *gc, size_t inNumBytes, int inFlags, int inFormat, bool inRunGC)
 {
-	return gc->New(inNumBytes, inFlags, inFormat, inCollect);
+	return gc->New(inNumBytes, inFlags, inFormat, inRunGC);
 }
 
-PyrObject* newPyrArray(class PyrGC *gc, int size, int flags, bool collect)
+PyrObject* newPyrArray(class PyrGC *gc, int size, int flags, bool runGC)
 {
 	PyrObject* array;
 
@@ -2358,72 +2358,72 @@ PyrObject* newPyrArray(class PyrGC *gc, int size, int flags, bool collect)
 	if (!gc)
 		array = PyrGC::NewPermanent(numbytes, flags, obj_slot);
 	else
-		array = gc->New(numbytes, flags, obj_slot, collect);
+		array = gc->New(numbytes, flags, obj_slot, runGC);
 	array->classptr = class_array;
 	return array;
 }
 
-PyrSymbolArray* newPyrSymbolArray(class PyrGC *gc, int size, int flags, bool collect)
+PyrSymbolArray* newPyrSymbolArray(class PyrGC *gc, int size, int flags, bool runGC)
 {
 	PyrSymbolArray* array;
 
 	int numbytes = size * sizeof(PyrSymbol*);
 	if (!gc) array = (PyrSymbolArray*)PyrGC::NewPermanent(numbytes, flags, obj_symbol);
-	else array = (PyrSymbolArray*)gc->New(numbytes, flags, obj_symbol, collect);
+	else array = (PyrSymbolArray*)gc->New(numbytes, flags, obj_symbol, runGC);
 	array->classptr = class_symbolarray;
 	return array;
 }
 
-PyrInt8Array* newPyrInt8Array(class PyrGC *gc, int size, int flags, bool collect)
+PyrInt8Array* newPyrInt8Array(class PyrGC *gc, int size, int flags, bool runGC)
 {
 	PyrInt8Array* array;
 
 	if (!gc) array = (PyrInt8Array*)PyrGC::NewPermanent(size, flags, obj_int8);
-	else array = (PyrInt8Array*)gc->New(size, flags, obj_int8, collect);
+	else array = (PyrInt8Array*)gc->New(size, flags, obj_int8, runGC);
 	array->classptr = class_int8array;
 	return array;
 }
 
-PyrInt32Array* newPyrInt32Array(class PyrGC *gc, int size, int flags, bool collect)
+PyrInt32Array* newPyrInt32Array(class PyrGC *gc, int size, int flags, bool runGC)
 {
 	PyrInt32Array* array;
 	int numbytes = size * sizeof(int32);
 	if (!gc) array = (PyrInt32Array*)PyrGC::NewPermanent(numbytes, flags, obj_int32);
-	else array = (PyrInt32Array*)gc->New(numbytes, flags, obj_int32, collect);
+	else array = (PyrInt32Array*)gc->New(numbytes, flags, obj_int32, runGC);
 	array->classptr = class_int32array;
 	return array;
 }
 
-PyrDoubleArray* newPyrDoubleArray(class PyrGC *gc, int size, int flags, bool collect)
+PyrDoubleArray* newPyrDoubleArray(class PyrGC *gc, int size, int flags, bool runGC)
 {
 	PyrDoubleArray* array;
 
 	int numbytes = size * sizeof(double);
 	if (!gc) array = (PyrDoubleArray*)PyrGC::NewPermanent(numbytes, flags, obj_double);
-	else array = (PyrDoubleArray*)gc->New(size, flags, obj_double, collect);
+	else array = (PyrDoubleArray*)gc->New(size, flags, obj_double, runGC);
 	array->classptr = class_doublearray;
 	return array;
 }
 
-PyrString* newPyrString(class PyrGC *gc, const char *s, int flags, bool collect)
+PyrString* newPyrString(class PyrGC *gc, const char *s, int flags, bool runGC)
 {
 	PyrString* string;
 	int length = strlen(s);
 
 	if (!gc) string = (PyrString*)PyrGC::NewPermanent(length, flags, obj_char);
-	else string = (PyrString*)gc->New(length, flags, obj_char, collect);
+	else string = (PyrString*)gc->New(length, flags, obj_char, runGC);
 	string->classptr = class_string;
 	string->size = length;
 	memcpy(string->s, s, length);
 	return string;
 }
 
-PyrString* newPyrStringN(class PyrGC *gc, int length, int flags, bool collect)
+PyrString* newPyrStringN(class PyrGC *gc, int length, int flags, bool runGC)
 {
 	PyrString* string;
 
 	if (!gc) string = (PyrString*)PyrGC::NewPermanent(length, flags, obj_char);
-	else string = (PyrString*)gc->New(length, flags, obj_char, collect);
+	else string = (PyrString*)gc->New(length, flags, obj_char, runGC);
 	string->classptr = class_string;
 	string->size = length; // filled with garbage!
 	return string;

--- a/lang/LangSource/SC_LanguageClient.cpp
+++ b/lang/LangSource/SC_LanguageClient.cpp
@@ -175,7 +175,7 @@ void SC_LanguageClient::setCmdLine(const char* buf, size_t size)
 			memcpy(strobj->s, buf, size);
 
 			SetObject(&slotRawInterpreter(&g->process->interpreter)->cmdLine, strobj);
-			g->gc->GCWrite(slotRawObject(&g->process->interpreter), strobj);
+			g->gc->GCWriteNew(slotRawObject(&g->process->interpreter), strobj); // we know strobj is white so we can use GCWriteNew
 		}
 		unlock();
     }

--- a/lang/LangSource/SC_TerminalClient.cpp
+++ b/lang/LangSource/SC_TerminalClient.cpp
@@ -658,7 +658,7 @@ int SC_TerminalClient::prArgv(struct VMGlobals* g, int)
 		PyrString* str = newPyrString(g->gc, argv[i], 0, true);
 		SetObject(argvObj->slots+i, str);
 		argvObj->size++;
-		g->gc->GCWrite(argvObj, (PyrObject*)str);
+		g->gc->GCWriteNew(argvObj, (PyrObject*)str); // we know str is white so we can use GCWriteNew
 	}
 
 	return errNone;


### PR DESCRIPTION
Okay, again a cleaned up version of #1618. Only big difference is a commit changing calls to GCWrite to GCWriteNew where appropriate, and an assert statement in GCWriteNew to help catch any future misuse of it in debug builds.

Overall this amounts to a fairly detailed review of most calls to object creation (instantiateObject, newPyr*, etc.), and write barrier (GCWrite, etc.) funcs. Although as noted in #1476 the API should probably be reworked to make these sorts of issues impossible, this was not too onerous and is probably worth doing before releases. (I can't promise I've caught absolutely everything, but it was worth doing, and more eyes are always better!) I've also updated the Writing Primitives doc, which will hopefully be of use in avoiding such mistakes for as long as the current approach lasts. 

NB There are a substantial number of fixes to potentially serious GC bugs in this, so I'd suggest any last reviews/tests, and then merge. 3.7 should not go out with these unfixed.