### PR TITLE
Classlib: SystemSynthDefs: Clean up temp defs properly on all platforms

### DIFF
--- a/SCClassLibrary/Common/Audio/SystemSynthDefs.sc
+++ b/SCClassLibrary/Common/Audio/SystemSynthDefs.sc
@@ -19,7 +19,7 @@ SystemSynthDefs {
 			// clean up any written synthdefs starting with "temp__"
 			var path = SynthDef.synthDefDir ++ tempNamePrefix ++ "*";
 			"Cleaning up temp synthdefs...".inform;
-			if(pathMatch(path).notEmpty) { unixCmdGetStdOut(("rm -f" + "'" ++ path ++ "'") )};
+			pathMatch(path).do { |file| File.delete(file) };
 
 			// add system synth defs
 			(1..numChannels).do { arg i;


### PR DESCRIPTION
`"rm -f '/blah/blah/synthdefs/temp__*'".unixCmd` was wrong for two reasons:

1. Shell globbing isn't guaranteed to work with a quoted path. In Ubuntu, this failed to remove temp synthdef files.
2. Not valid for Windows.

Solution: Get the paths via `pathMatch` and then use `File.delete` to remove them one by one.