### PR TITLE
plugin interface: fix compile failure with gcc-4.9

### DIFF
--- a/include/plugin_interface/SC_InlineUnaryOp.h
+++ b/include/plugin_interface/SC_InlineUnaryOp.h
@@ -290,8 +290,7 @@ inline float32 sc_ceil(float32 x)
 {
 #ifdef __SSE4_1__
 	__m128 a = _mm_set_ss(x);
-	const int cntrl = _MM_FROUND_TO_POS_INF;
-	__m128 b = _mm_round_ss(a, a, cntrl);
+	__m128 b = _mm_round_ss(a, a, _MM_FROUND_TO_POS_INF);
 	return _mm_cvtss_f32(b);
 #else
 	return std::ceil(x);
@@ -302,8 +301,7 @@ inline float32 sc_floor(float32 x)
 {
 #ifdef __SSE4_1__
 	__m128 a = _mm_set_ss(x);
-	const int cntrl = _MM_FROUND_TO_NEG_INF;
-	__m128 b = _mm_round_ss(a, a, cntrl);
+	__m128 b = _mm_round_ss(a, a, _MM_FROUND_TO_NEG_INF);
 	return _mm_cvtss_f32(b);
 #else
 	return std::floor(x);


### PR DESCRIPTION
gcc's builtins are reqired to be constexpr