### PR TITLE
Non-characters pass ASCII code 0 to key actions

### DIFF
--- a/HelpSource/Classes/Document.schelp
+++ b/HelpSource/Classes/Document.schelp
@@ -328,7 +328,7 @@ Document.current.mouseUpAction = nil; // clear mouseUpActiont
 method:: keyDownAction
 Get/set the action to be performed on link::Classes/Document#keyDown::.
 argument:: value
-An instance of link::Classes/Function:: or link::Classes/FunctionList::. The arguments passed to the function are: code::char::, code::modifiers::, code::unicode::, code::keycode::.
+An instance of link::Classes/Function:: or link::Classes/FunctionList::. The arguments passed to the function are: code::char::, code::modifiers::, code::unicode::, code::keycode::. See link::Classes/View#Key actions:: for details on these arguments.
 discussion::
 code::
 Document.current.keyDownAction = { arg ...args; args.postln };
@@ -339,7 +339,8 @@ Document.current.keyDownAction = nil;
 method:: keyUpAction
 Get/set the action to be performed on link::Classes/Document#keyUp::.
 argument:: value
-An instance of link::Classes/Function:: or link::Classes/FunctionList::. The arguments passed to the function are: code::char::, code::modifiers::, code::unicode::, code::keycode::.
+An instance of link::Classes/Function:: or link::Classes/FunctionList::. The arguments passed to the function are: code::char::, code::modifiers::, code::unicode::, code::keycode::. See link::Classes/View#Key actions:: for details on these arguments.
+discussion::
 code::
 Document.current.keyUpAction = { arg ...args; args.postln };
 // now type some text

--- a/HelpSource/Classes/View.schelp
+++ b/HelpSource/Classes/View.schelp
@@ -568,7 +568,8 @@ When the key action object is evaluated, it is passed one or more arguments from
 list::
 ## strong::view:: - The view.
 
-## strong::char:: - The character associated with the key, possibly unprintable. Character sequences (for example é) get passed as two characters, the first one blank ( ), the second one is the unmodified character (e). This will also vary depending on the nationality the keyboard is set to. note:: Only printable characters are passed. If a key is not associated with any printable character, nil will be passed instead.::
+## strong::char:: - The character (link::Classes/Char::) associated with the key, possibly unprintable. Character sequences (for example é) get passed as two characters, the first one blank ( ), the second one is the unmodified character (e). This will also vary depending on the nationality the keyboard is set to.
+note:: Only characters with an ASCII code are passed. Non-ASCII keys (Ctrl/Alt/Cmd/Shift modifiers, arrow keys and other control sequences) will pass a link::Classes/Char:: with ASCII code 0. (Ctrl-characters emphasis::do:: have ASCII codes, and are passed as a Char. The Ctrl key by itself also triggers the key action, but with ASCII code 0.) A useful test is link::Classes/Char#-isPrint::.::
 
 ## strong::modifiers:: - A bitwise or of integers indicating the modifier keys in effect. You can examine individual flag settings using the C bitwise AND operator. For a list of these, see link::Reference/Modifiers::.
 

--- a/SCClassLibrary/Common/GUI/Base/QView.sc
+++ b/SCClassLibrary/Common/GUI/Base/QView.sc
@@ -612,7 +612,6 @@ View : QObject {
 
 	keyDownEvent { arg char, modifiers, unicode, keycode, key, spontaneous;
 		modifiers = QKeyModifiers.toCocoa(modifiers);
-		if (char.ascii == 0) { char = nil };
 
 		if( spontaneous ) {
 			// this event has never been propagated to parent yet
@@ -628,7 +627,6 @@ View : QObject {
 
 	keyUpEvent { arg char, modifiers, unicode, keycode, key, spontaneous;
 		modifiers = QKeyModifiers.toCocoa(modifiers);
-		if (char.ascii == 0) { char = nil };
 
 		if( spontaneous ) {
 			// this event has never been propagated to parent yet


### PR DESCRIPTION
Per discussion under issue #1554.