### PR TITLE
disallow newCopyArgs in Boolean

### DIFF
--- a/SCClassLibrary/Common/Core/Boolean.sc
+++ b/SCClassLibrary/Common/Core/Boolean.sc
@@ -1,5 +1,6 @@
 Boolean {
 	*new { ^this.shouldNotImplement(thisMethod) }
+	*newCopyArgs { ^this.shouldNotImplement(thisMethod) }
 	xor { arg bool; ^(this === bool).not }
 	if { ^this.subclassResponsibility(thisMethod) }
 	not { ^this.subclassResponsibility(thisMethod) }


### PR DESCRIPTION
Without this patch True.newCopyArgs will crash the interpreter.