### PR TITLE
lang: prevent Signal.chebyFill from returning nan

### DIFF
--- a/lang/LangPrimSource/PyrSignalPrim.cpp
+++ b/lang/LangPrimSource/PyrSignalPrim.cpp
@@ -348,7 +348,7 @@ int prSignalAddChebyshev(struct VMGlobals *g, int numArgsPushed)
 	out = (float*)(signal->slots) - 1;
 	x = -1.0;
 	step = 2.0 / (signal->size - 1);
-	UNROLL_CODE(signal->size, out, *++out += cos(harmonic * acos(x)) * amp; x += step; );
+	UNROLL_CODE(signal->size, out, *++out += cos(harmonic * acos(sc_min(x, 1.0))) * amp; x += step; );
 
 	return errNone;
 }


### PR DESCRIPTION
The method Signal.chebyFill() would often return `nan`as the final value in the array -- it depended on the size of Signal asked for.  This happened because `acos(1 + someTinyAccumulatedRoundingError)` returns `nan`.  The desired value at the end of the loop should be acos of exactly 1.0, so now I just ensure the argument never exceeds one.