### PR TITLE
scsynth:SC_GraphDef.cpp correct d_removed packet definition

### DIFF
--- a/server/scsynth/SC_GraphDef.cpp
+++ b/server/scsynth/SC_GraphDef.cpp
@@ -579,7 +579,7 @@ void GraphDef_DeleteMsg(World *inWorld, GraphDef *inDef)
 
 	small_scpacket packet;
 	packet.adds("/d_removed");
-	packet.maketags(1);
+	packet.maketags(2);
 	packet.addtag(',');
 	packet.addtag('s');
 	packet.adds((char*)inDef->mNodeDef.mName);


### PR DESCRIPTION
this error is there form 2012.
I happened working for a tcp connection on my lua client.
I dont know why it does not happens on sclang.