### PR TITLE
QtCollider: TextView: Get code for enterInterpretsSelection from block()

### DIFF
--- a/QtCollider/widgets/QcTextEdit.cpp
+++ b/QtCollider/widgets/QcTextEdit.cpp
@@ -178,16 +178,15 @@ void QcTextEdit::keyPressEvent( QKeyEvent *e )
       && ( e->key() == Qt::Key_Return || e->key() == Qt::Key_Enter ) )
   {
     QTextCursor c(textCursor());
-
-    if ( !c.hasSelection() ) {
-      c.movePosition( QTextCursor::StartOfLine );
-      c.movePosition( QTextCursor::EndOfLine, QTextCursor::KeepAnchor );
-    }
+    QString code;
 
     if ( c.hasSelection() ) {
-      QString selection( c.selectedText() );
-      Q_EMIT( interpret( prepareText(selection) ) );
+      code = c.selectedText();
+    } {
+      code = c.block().text();
     }
+
+    Q_EMIT( interpret( prepareText(code) ) );
 
     return;
   }


### PR DESCRIPTION
Fixes a discrepancy between text selection for enterInterpretsSelection vs.
aTextView.currentLine.

Submitting formally as a PR based on @telephon's comment on issue #1637.