### PR TITLE
Subclass searches

### DIFF
--- a/SCClassLibrary/Common/GUI/PlusGUI/Core/ClassBrowser.sc
+++ b/SCClassLibrary/Common/GUI/PlusGUI/Core/ClassBrowser.sc
@@ -263,7 +263,27 @@ ClassBrowser {
 	searchClasses { |string, rootNumber, matchCase, addHistory = true|
 		var	pool, rootdir, result,
 			searchType = searchMenuKeys[rootNumber] ? \classSearch,
-			isClassSearch;
+			isClassSearch,
+			warning = {
+				var w;
+				w = Window("Invalid search", Rect.aboutPoint(Window.screenBounds.center, 170, 60))
+				.layout_(VLayout(
+					StaticText().align_(\center)
+					.string_("This search requires a class to be selected"),
+					HLayout(
+						StaticText(),  // padding to push button to horiz. center
+						Button().states_([["OK"]])
+						.action_({ w.close })
+						.maxWidth_(80),
+						StaticText()
+					)
+				))
+				.endFrontAction_({
+					w.endFrontAction_(nil).close;
+				})
+				.front;
+				^this  // early exit
+			};
 		string = string ?? { "" };
 		matchCase = matchCase > 0;
 		switch(rootNumber)
@@ -276,30 +296,36 @@ ClassBrowser {
 				pool = Class.allClasses;
 			}
 			{ 2 } {
-				isClassSearch = true;
-				pool = this.currentClass.allSubclasses.asArray
+				if(this.currentClass.notNil) {
+					isClassSearch = true;
+					pool = this.currentClass.allSubclasses.asArray
+				} { warning.value };
 			}
 			{ 3 } {
-				isClassSearch = false;
-				pool = this.currentClass.allSubclasses ++ [this.currentClass];
-				if(this.currentClass.isMetaClass.not) {
-					pool = pool ++ pool.collect(_.class);
-				};
+				if(this.currentClass.notNil) {
+					isClassSearch = false;
+					pool = this.currentClass.allSubclasses ++ [this.currentClass];
+					if(this.currentClass.isMetaClass.not) {
+						pool = pool ++ pool.collect(_.class);
+					};
+				} { warning.value };
 			}
 			{ 4 } {
-				isClassSearch = true;
-				rootdir = PathName(currentState.currentClass.filenameSymbol.asString).pathOnly;
-				pool = Class.allClasses.select({ |class|
-					PathName(class.filenameSymbol.asString).pathOnly == rootdir
-				});
+				if(this.currentClass.notNil) {
+					isClassSearch = true;
+					rootdir = PathName(currentState.currentClass.filenameSymbol.asString).pathOnly;
+					pool = Class.allClasses.select({ |class|
+						PathName(class.filenameSymbol.asString).pathOnly == rootdir
+					});
 
-				if(string.isEmpty) {
-					this.makeState(
-						pool.reject(_.isMetaClass).sort({ |a, b| a.name < b.name }),
-						searchType
-					);
-					^this	// just to force early exit
-				};
+					if(string.isEmpty) {
+						this.makeState(
+							pool.reject(_.isMetaClass).sort({ |a, b| a.name < b.name }),
+							searchType
+						);
+						^this	// just to force early exit
+					};
+				} { warning.value };
 			};
 		if (isClassSearch)
 		{

--- a/SCClassLibrary/Common/GUI/PlusGUI/Core/ClassBrowser.sc
+++ b/SCClassLibrary/Common/GUI/PlusGUI/Core/ClassBrowser.sc
@@ -277,11 +277,11 @@ ClassBrowser {
 			}
 			{ 2 } {
 				isClassSearch = true;
-				pool = this.currentClass.allSubclasses
+				pool = this.currentClass.allSubclasses.asArray
 			}
 			{ 3 } {
 				isClassSearch = false;
-				pool = this.currentClass.allSubclasses ++ this.currentClass;
+				pool = this.currentClass.allSubclasses ++ [this.currentClass];
 				if(this.currentClass.isMetaClass.not) {
 					pool = pool ++ pool.collect(_.class);
 				};

--- a/SCClassLibrary/Common/GUI/PlusGUI/Core/ClassBrowser.sc
+++ b/SCClassLibrary/Common/GUI/PlusGUI/Core/ClassBrowser.sc
@@ -282,7 +282,6 @@ ClassBrowser {
 					w.endFrontAction_(nil).close;
 				})
 				.front;
-				^this  // early exit
 			};
 		string = string ?? { "" };
 		matchCase = matchCase > 0;
@@ -299,7 +298,7 @@ ClassBrowser {
 				if(this.currentClass.notNil) {
 					isClassSearch = true;
 					pool = this.currentClass.allSubclasses.asArray
-				} { warning.value };
+				} { ^warning.value };  // early exit
 			}
 			{ 3 } {
 				if(this.currentClass.notNil) {
@@ -308,7 +307,7 @@ ClassBrowser {
 					if(this.currentClass.isMetaClass.not) {
 						pool = pool ++ pool.collect(_.class);
 					};
-				} { warning.value };
+				} { ^warning.value };  // early exit
 			}
 			{ 4 } {
 				if(this.currentClass.notNil) {
@@ -323,9 +322,9 @@ ClassBrowser {
 							pool.reject(_.isMetaClass).sort({ |a, b| a.name < b.name }),
 							searchType
 						);
-						^this	// just to force early exit
+						^this	// early exit
 					};
-				} { warning.value };
+				} { ^warning.value };  // early exit
 			};
 		if (isClassSearch)
 		{


### PR DESCRIPTION
These 2 commits fix ugly error messages that could be posted for invalid class browser searches that depend on a root class to be selected.

Usability improvement -- changes no core functionality.