### PR TITLE
Classlib: File *existsCaseSensitive fix to handle Windows dir paths

### DIFF
--- a/SCClassLibrary/Common/Files/File.sc
+++ b/SCClassLibrary/Common/Files/File.sc
@@ -34,7 +34,17 @@ File : UnixFILE {
 		^if(systemIsCaseSensitive) {
 			this.exists(pathName)
 		} {
-			(pathName.dirname+/+"*").pathMatch.detect{|x|x.compare(pathName)==0}.notNil
+			// if pathNAme points to a directory,
+			// the comparison should strip any trailing path separator
+			if(pathName.last.isPathSeparator) {
+				pathName = pathName.drop(-1);
+			};
+			(pathName.dirname +/+ "*").pathMatch.any { |x|
+				if(x.last.isPathSeparator) {
+					x = x.drop(-1);
+				};
+				x.compare(pathName) == 0
+			}
 		}
 	}
 	*realpath { arg pathName;


### PR DESCRIPTION
Test case in Windows:

```
File.existsCaseSensitive(Platform.userAppSupportDir);
```

Returns `false` without the fix, and `true` with it.

Fixes #1668.