### PR TITLE
scel: Fix mode-line update

### DIFF
--- a/editors/scel/el/sclang-server.el
+++ b/editors/scel/el/sclang-server.el
@@ -159,7 +159,7 @@
   (interactive)
   (sclang-set-server)
   (setq sclang-server-info-string (sclang-get-server-info-string))
-  (force-mode-line-update))
+  (force-mode-line-update t))
 
 ;; =====================================================================
 ;; language control


### PR DESCRIPTION
`(force-mode-line-update)`  updates only the mode-line of  the current buffer. Providing a non-nil argument updates the mode-line of all buffers. This is particularly useful when having a split view with the server buffer and another buffer where current buffer is not the server buffer. (probably  a very common use case).