### PR TITLE
class library: make control set atomic

### DIFF
--- a/SCClassLibrary/Common/Control/OSCBundle.sc
+++ b/SCClassLibrary/Common/Control/OSCBundle.sc
@@ -56,7 +56,7 @@ OSCBundle {
 
 	prSend { arg server, delta,timeOfRequest;
 		if(messages.notNil, {
-			server.listSendBundle(delta ?? { server.latency }, messages);
+			server.listSendBundle(delta ?? { server.latency }, messages.collect { |x| x.value });
 		})
 	}
 
@@ -115,7 +115,7 @@ MixedBundle : OSCBundle {
 			});
 		};
 		if(messages.notNil) {
-			server.listSendBundle(delta, messages);
+			server.listSendBundle(delta, messages.collect { |x| x.value });
 		};
 		this.doSendFunctions;
 	}

--- a/SCClassLibrary/Common/Control/OSCBundle.sc
+++ b/SCClassLibrary/Common/Control/OSCBundle.sc
@@ -56,7 +56,8 @@ OSCBundle {
 
 	prSend { arg server, delta,timeOfRequest;
 		if(messages.notNil, {
-			server.listSendBundle(delta ?? { server.latency }, messages.collect { |x| x.value });
+			if(removeOnCancel.notNil) { messages = messages.collect { |x| x.value } };
+			server.listSendBundle(delta ?? { server.latency }, messages);
 		})
 	}
 
@@ -115,7 +116,8 @@ MixedBundle : OSCBundle {
 			});
 		};
 		if(messages.notNil) {
-			server.listSendBundle(delta, messages.collect { |x| x.value });
+			if(removeOnCancel.notNil) { messages = messages.collect { |x| x.value } };
+			server.listSendBundle(delta, messages);
 		};
 		this.doSendFunctions;
 	}

--- a/SCClassLibrary/JITLib/ProxySpace/NodeProxy.sc
+++ b/SCClassLibrary/JITLib/ProxySpace/NodeProxy.sc
@@ -745,7 +745,7 @@ NodeProxy : BusPlug {
 
 	// bundle: apply the node map settings to the entire group
 	sendAllToBundle { | bundle, extraArgs |
-		var args = Thunk { nodeMap.asOSCArgArray ++ extraArgs.value.asOSCArgArray };
+		var args = Thunk({ nodeMap.asOSCArgArray ++ extraArgs.value.asOSCArgArray });
 		objects.do { arg item;
 			item.playToBundle(bundle, args, this);
 		}

--- a/SCClassLibrary/JITLib/ProxySpace/NodeProxy.sc
+++ b/SCClassLibrary/JITLib/ProxySpace/NodeProxy.sc
@@ -746,7 +746,7 @@ NodeProxy : BusPlug {
 
 	// bundle: apply the node map settings to the entire group
 	sendAllToBundle { | bundle, extraArgs |
-		extraArgs = nodeMap.asOSCArgArray ++ extraArgs.value.asOSCArgArray;
+		extraArgs = { nodeMap.asOSCArgArray ++ extraArgs.value.asOSCArgArray };
 		objects.do { arg item;
 			item.playToBundle(bundle, extraArgs, this);
 		}
@@ -762,7 +762,7 @@ NodeProxy : BusPlug {
 	// bundle: send single object
 	sendObjectToBundle { | bundle, object, extraArgs, index |
 		var target, nodes;
-		var synthID = object.playToBundle(bundle, nodeMap.asOSCArgArray ++ extraArgs.value.asOSCArgArray, this);
+		var synthID = object.playToBundle(bundle, { nodeMap.asOSCArgArray ++ extraArgs.value.asOSCArgArray }, this);
 		if(synthID.notNil) {
 			if(index.notNil and: { objects.size > 1 }) { // if nil, all are sent anyway
 				// make list of nodeIDs following the index

--- a/SCClassLibrary/JITLib/ProxySpace/NodeProxy.sc
+++ b/SCClassLibrary/JITLib/ProxySpace/NodeProxy.sc
@@ -401,13 +401,13 @@ NodeProxy : BusPlug {
 
 	// play proxy as source of receiver
 	<-- { | proxy |
-		var bundle = MixedBundle.new, dt = 0.1;
+		var bundle = MixedBundle.new, fadeTime = this.fadeTime;
 		this.source = proxy;
 
 		if(proxy.monitor.isPlaying) {
-			proxy.stop(fadeTime: dt);
+			proxy.stop(fadeTime: fadeTime);
 			if(monitor.isPlaying.not) {
-				this.playToBundle(bundle, fadeTime: dt)
+				this.playToBundle(bundle, fadeTime: fadeTime)
 			}
 		};
 		bundle.add(proxy.moveBeforeMsg(this));
@@ -463,11 +463,11 @@ NodeProxy : BusPlug {
 
 
 	send { | extraArgs, index, freeLast = true |
-		var bundle, obj;
+		var bundle, obj, fadeTime = this.fadeTime;
 		if(objects.isEmpty) { ^this };
 		if(index.isNil) {
 			bundle = this.getBundle;
-			if(freeLast) { this.stopAllToBundle(bundle) };
+			if(freeLast) { this.stopAllToBundle(bundle, fadeTime) };
 			if(loaded.not) { this.loadToBundle(bundle) };
 			this.sendAllToBundle(bundle, extraArgs);
 			bundle.schedSend(server);
@@ -476,7 +476,7 @@ NodeProxy : BusPlug {
 			obj = objects.at(index);
 			if(obj.notNil) {
 				bundle = this.getBundle;
-				if(freeLast) { obj.stopToBundle(bundle) };
+				if(freeLast) { obj.stopToBundle(bundle, fadeTime) };
 				if(loaded.not) { this.loadToBundle(bundle) };
 				this.sendObjectToBundle(bundle, obj, extraArgs, index);
 				bundle.schedSend(server);
@@ -746,9 +746,9 @@ NodeProxy : BusPlug {
 
 	// bundle: apply the node map settings to the entire group
 	sendAllToBundle { | bundle, extraArgs |
-		extraArgs = { nodeMap.asOSCArgArray ++ extraArgs.value.asOSCArgArray };
+		var args = Thunk { nodeMap.asOSCArgArray ++ extraArgs.value.asOSCArgArray };
 		objects.do { arg item;
-			item.playToBundle(bundle, extraArgs, this);
+			item.playToBundle(bundle, args, this);
 		}
 	}
 

--- a/SCClassLibrary/JITLib/ProxySpace/NodeProxy.sc
+++ b/SCClassLibrary/JITLib/ProxySpace/NodeProxy.sc
@@ -455,8 +455,7 @@ NodeProxy : BusPlug {
 			i = this.index;
 			bundle = this.getBundle;
 			if(loaded.not) { this.loadToBundle(bundle) };
-			obj.spawnToBundle(bundle, extraArgs, this);
-			nodeMap.addToBundle(bundle, -1);
+			obj.spawnToBundle(bundle, { nodeMap.asOSCArgArray ++ extraArgs.value.asOSCArgArray }, this);
 			bundle.schedSend(server);
 		}
 	}

--- a/SCClassLibrary/JITLib/ProxySpace/ProxyInterfaces.sc
+++ b/SCClassLibrary/JITLib/ProxySpace/ProxyInterfaces.sc
@@ -222,7 +222,7 @@ SynthControl : AbstractPlayControl {
 
 	spawnToBundle { | bundle, extraArgs, target, addAction = 0 | // assumes self freeing
 		var targetID = target.asTarget.nodeID;
-		bundle.add([9, this.asDefName, -1, addAction, targetID] ++ extraArgs.asOSCArgArray);
+		bundle.add([9, this.asDefName, -1, addAction, targetID] ++ extraArgs.value.asOSCArgArray);
 	}
 
 	playToBundle { | bundle, extraArgs, target, addAction = 1 |
@@ -255,7 +255,7 @@ SynthControl : AbstractPlayControl {
 	}
 
 	set { | ... args |
-		server.sendBundle(server.latency, ["/n_set", nodeID] ++ args);
+		server.sendBundle(server.latency, ["/n_set", nodeID] ++ args.asOSCArgArray);
 	}
 
 	pause { | clock, quant = 1 |

--- a/SCClassLibrary/JITLib/ProxySpace/ProxyInterfaces.sc
+++ b/SCClassLibrary/JITLib/ProxySpace/ProxyInterfaces.sc
@@ -176,7 +176,7 @@ PatternControl : StreamControl {
 			str = source.buildForProxy(proxy, channelOffset);
 			if(args.notNil) {
 				event = str.event;
-				args.pairsDo { arg key, val; event[key] = val }
+				args.value.pairsDo { arg key, val; event[key] = val }
 			};
 			array = array.add(str);
 			// no latency (latency is in stream already)
@@ -230,7 +230,7 @@ SynthControl : AbstractPlayControl {
 		server = target.server;
 		group = target.asTarget;
 		nodeID = server.nextNodeID;
-		bundle.addCancel([9, this.asDefName, nodeID, addAction, group.nodeID]++extraArgs.asOSCArgArray);
+		bundle.addCancel({ [9, this.asDefName, nodeID, addAction, group.nodeID] ++ extraArgs.value });
 		if(paused) { bundle.addCancel(["/n_run", nodeID, 0]) };
 		prevBundle = bundle;
 		^nodeID

--- a/SCClassLibrary/JITLib/ProxySpace/ProxyInterfaces.sc
+++ b/SCClassLibrary/JITLib/ProxySpace/ProxyInterfaces.sc
@@ -222,7 +222,7 @@ SynthControl : AbstractPlayControl {
 
 	spawnToBundle { | bundle, extraArgs, target, addAction = 0 | // assumes self freeing
 		var targetID = target.asTarget.nodeID;
-		bundle.add([9, this.asDefName, -1, addAction, targetID] ++ extraArgs.value.asOSCArgArray);
+		bundle.addCancel({ [9, this.asDefName, -1, addAction, targetID] ++ extraArgs.value });
 	}
 
 	playToBundle { | bundle, extraArgs, target, addAction = 1 |


### PR DESCRIPTION
this fix by @telephon fixes an annoying behaviour in NodeProxies:

```
Ndef(\sine).clear


(
Ndef(\sine, {SinOsc.ar(\freq.kr(100)!2).tanh});
Ndef(\sine).set(\freq, 200);
)

-> Ndef('sine')
FAILURE IN SERVER /n_set Node 1010 not found
```

Previous behaviour:
```
1. set source: create a bundle that:
1a. sends synth def
1b. waits for completion, then sends synth with args
2. set controls: create a bundle that:
2a. sets group

temporal order will be: 1a. 2a. 1b.
```

now, it does it different... (maybe ask @telephon for details..)
I use this branch extensively for a week now and think that it works perfectly.