### PR TITLE
class library: store floats with full precision

### DIFF
--- a/SCClassLibrary/Common/Math/Float.sc
+++ b/SCClassLibrary/Common/Math/Float.sc
@@ -71,6 +71,11 @@ Float : SimpleNumber {
 		}
 	}
 
+	asCompileString {
+		// do not rely on _ObjectCompileString, because precision is too low
+		^String.streamContents { |stream| this.storeOn(stream) }
+	}
+
 	switch { | ... cases|
 		"Float:switch is unsafe, rounding via Float:asInteger:switch".warn;
 		^this.asInteger.switch(*cases)


### PR DESCRIPTION
This fixes old issues with Object.writeArchive. However it makes code
generated with asCompileString more “verbose”.