### PR TITLE
Plugins: Clip NOVA functions should update unit-> variables

### DIFF
--- a/server/plugins/LFUGens.cpp
+++ b/server/plugins/LFUGens.cpp
@@ -1993,6 +1993,7 @@ void Clip_next_nova_ki(Clip* unit, int inNumSamples)
 
 	float lo_slope = CALCSLOPE(next_lo, lo);
 	nova::clip_vec_simd(OUT(0), IN(0), slope_argument(lo, lo_slope), hi, inNumSamples);
+	unit->m_lo = next_lo;
 }
 
 void Clip_next_nova_ik(Clip* unit, int inNumSamples)
@@ -2008,6 +2009,7 @@ void Clip_next_nova_ik(Clip* unit, int inNumSamples)
 
 	float hi_slope = CALCSLOPE(next_hi, hi);
 	nova::clip_vec_simd(OUT(0), IN(0), lo, slope_argument(hi, hi_slope), inNumSamples);
+	unit->m_hi = next_hi;
 }
 
 void Clip_next_nova_kk(Clip* unit, int inNumSamples)
@@ -2036,6 +2038,8 @@ void Clip_next_nova_kk(Clip* unit, int inNumSamples)
 	float hi_slope = CALCSLOPE(next_hi, hi);
 
 	nova::clip_vec_simd(OUT(0), IN(0), slope_argument(lo, lo_slope), slope_argument(hi, hi_slope), inNumSamples);
+	unit->m_lo = next_lo;
+	unit->m_hi = next_hi;
 }
 
 void Clip_next_nova_ai(Clip* unit, int inNumSamples)
@@ -2057,6 +2061,7 @@ void Clip_next_nova_ak(Clip* unit, int inNumSamples)
 	float hi_slope = CALCSLOPE(next_hi, hi);
 
 	nova::clip_vec_simd(OUT(0), IN(0), IN(1), slope_argument(hi, hi_slope), inNumSamples);
+	unit->m_hi = next_hi;
 }
 
 void Clip_next_nova_ia(Clip* unit, int inNumSamples)
@@ -2077,6 +2082,7 @@ void Clip_next_nova_ka(Clip* unit, int inNumSamples)
 
 	float lo_slope = CALCSLOPE(next_lo, lo);
 	nova::clip_vec_simd(OUT(0), IN(0), slope_argument(lo, lo_slope), IN(2), inNumSamples);
+	unit->m_lo = next_lo;
 }
 
 


### PR DESCRIPTION
Bug reported on the mailing list: `kr` inputs to an `ar` Clip unit produce a sawtooth wave when changed.

This is because the original author of the SIMD calculation functions (38f2d28dec52750bc22da9883a853f7b48b6ba7f) forgot to update the struct member variables with new data from the inputs, meaning that every subsequent control cycle would attempt to ramp to the new value.

```
(
/* Start the synth, everything is correct... */
a = {
	arg control = 0.2;
	Clip.ar(DC.ar(), control, 0.4);
}.scope;
)

/* Until I change the control value */
a.set(\control, 0.25);

/* At this point I hear and see high-pitched oscillation that's
samplerate-dependant. */
```
