### PR TITLE
Classlib: Update PauseStream stream's clock upon play

### DIFF
--- a/SCClassLibrary/Common/Streams/Stream.sc
+++ b/SCClassLibrary/Common/Streams/Stream.sc
@@ -343,6 +343,7 @@ PauseStream : Stream
 		clock = argClock ? clock ? TempoClock.default;
 		streamHasEnded = false;
 		this.refresh; //stream = originalStream;
+		stream.clock = clock;
 		isWaiting = true;	// make sure that accidental play/stop/play sequences
 						// don't cause memory leaks
 		era = CmdPeriod.era;
@@ -494,6 +495,7 @@ EventStreamPlayer : PauseStream {
 		clock = argClock ? clock ? TempoClock.default;
 		streamHasEnded = false;
 		stream = originalStream;
+		stream.clock = clock;
 		isWaiting = true;	// make sure that accidental play/stop/play sequences
 						// don't cause memory leaks
 		era = CmdPeriod.era;


### PR DESCRIPTION
Bug reported on mailing list. If you re-play the same PauseStream subclass using a different clock, the PauseStream's internal `stream` variable is still pointing to the old clock. This causes errors if that clock was stopped in the meantime, e.g., by cmd-.

The fix is `stream.clock = clock` in PauseStream:play and EventStreamPlayer:play.

```
(
var myTempo = TempoClock.new(0.5);
Pdef(\test,Pbind()).play(myTempo);
)
```

Original mailing list post:

> The first time I run this code, it works, but if I stop it with Cmd+.
> and run it again, I get:
> ERROR: clock is not running.
> ERROR: Primitive '_TempoClock_BeatsToSecs' failed.
