### PR TITLE
fix #1668 - make existsCaseSensitive work for directories

### DIFF
--- a/SCClassLibrary/Common/Files/File.sc
+++ b/SCClassLibrary/Common/Files/File.sc
@@ -34,7 +34,9 @@ File : UnixFILE {
 		^if(systemIsCaseSensitive) {
 			this.exists(pathName)
 		} {
-			(pathName.dirname+/+"*").pathMatch.detect{|x|x.compare(pathName)==0}.notNil
+			(pathName.dirname +/+ "*").pathMatch
+				.detect({ |x| x.withoutTrailingSlash.compare(pathName.withoutTrailingSlash) == 0 })
+				.notNil
 		}
 	}
 	*realpath { arg pathName;


### PR DESCRIPTION
tested on a case insensitive file system using this:
var pathName = "/Users/crucial/Library/Application Support/SuperCollider/downloaded-quarks/splines";
(pathName.dirname+/+"*").pathMatch.detect{|x|x.withoutTrailingSlash.compare(pathName.withoutTrailingSlash)==0}.notNil