### PR TITLE
ass Filters: warning in help-docs about filter frequencies close to zero

### DIFF
--- a/HelpSource/Classes/BAllPass.schelp
+++ b/HelpSource/Classes/BAllPass.schelp
@@ -16,6 +16,7 @@ argument:: in
 input signal to be processed.
 argument:: freq
 center frequency.
+WARNING: due to the nature of its implementation frequency values close to 0 may cause glitches and/or extremely loud audio artifacts!
 argument:: rq
 the reciprocal of Q. bandwidth / cutoffFreq.
 argument:: mul

--- a/HelpSource/Classes/BBandPass.schelp
+++ b/HelpSource/Classes/BBandPass.schelp
@@ -17,6 +17,7 @@ argument:: in
 input signal to be processed.
 argument:: freq
 center frequency.
+WARNING: due to the nature of its implementation frequency values close to 0 may cause glitches and/or extremely loud audio artifacts!
 argument:: bw
 the bandwidth in octaves between -3 dB frequencies.
 argument:: mul

--- a/HelpSource/Classes/BBandStop.schelp
+++ b/HelpSource/Classes/BBandStop.schelp
@@ -17,6 +17,7 @@ argument:: in
 input signal to be processed.
 argument:: freq
 center frequency.
+WARNING: due to the nature of its implementation frequency values close to 0 may cause glitches and/or extremely loud audio artifacts!
 argument:: bw
 the bandwidth in octaves between -3 dB frequencies.
 argument:: mul

--- a/HelpSource/Classes/BHiPass.schelp
+++ b/HelpSource/Classes/BHiPass.schelp
@@ -17,6 +17,7 @@ argument:: in
 input signal to be processed.
 argument:: freq
 cutoff frequency.
+WARNING: due to the nature of its implementation frequency values close to 0 may cause glitches and/or extremely loud audio artifacts!
 argument:: rq
 the reciprocal of Q.  bandwidth / cutoffFreq.
 argument:: mul

--- a/HelpSource/Classes/BHiPass4.schelp
+++ b/HelpSource/Classes/BHiPass4.schelp
@@ -19,6 +19,7 @@ argument:: in
 input signal to be processed.
 argument:: freq
 cutoff frequency.
+WARNING: due to the nature of its implementation frequency values close to 0 may cause glitches and/or extremely loud audio artifacts!
 argument:: rq
 the reciprocal of Q.  bandwidth / cutoffFreq.
 argument:: mul

--- a/HelpSource/Classes/BHiShelf.schelp
+++ b/HelpSource/Classes/BHiShelf.schelp
@@ -16,6 +16,7 @@ method:: ar
 argument:: in
 input signal to be processed.
 argument:: freq
+WARNING: due to the nature of its implementation frequency values close to 0 may cause glitches and/or extremely loud audio artifacts!
 center frequency.
 argument:: rs
 the reciprocal of S. Shell boost/cut slope. When S = 1, the shelf slope is as steep as it can be and remain monotonically increasing or decreasing gain with frequency. The shelf slope, in dB/octave, remains proportional to S for all other values for a fixed code::freq/SampleRate.ir:: and code::db::.

--- a/HelpSource/Classes/BLowPass.schelp
+++ b/HelpSource/Classes/BLowPass.schelp
@@ -17,6 +17,7 @@ argument:: in
 input signal to be processed.
 argument:: freq
 cutoff frequency.
+WARNING: due to the nature of its implementation frequency values close to 0 may cause glitches and/or extremely loud audio artifacts!
 argument:: rq
 the reciprocal of Q. bandwidth / cutoffFreq.
 argument:: mul

--- a/HelpSource/Classes/BLowPass4.schelp
+++ b/HelpSource/Classes/BLowPass4.schelp
@@ -19,6 +19,7 @@ argument:: in
 input signal to be processed.
 argument:: freq
 cutoff frequency.
+WARNING: due to the nature of its implementation frequency values close to 0 may cause glitches and/or extremely loud audio artifacts!
 argument:: rq
 the reciprocal of Q. bandwidth / cutoffFreq.
 argument:: mul

--- a/HelpSource/Classes/BLowShelf.schelp
+++ b/HelpSource/Classes/BLowShelf.schelp
@@ -17,6 +17,7 @@ argument:: in
 input signal to be processed.
 argument:: freq
 center frequency.
+WARNING: due to the nature of its implementation frequency values close to 0 may cause glitches and/or extremely loud audio artifacts!
 argument:: rs
 the reciprocal of S. Shell boost/cut slope. When S = 1, the shelf slope is as steep as it can be and remain monotonically increasing or decreasing gain with frequency. The shelf slope, in dB/octave, remains proportional to S for all other values for a fixed code::freq/SampleRate.ir:: and code::db::.
 argument:: db

--- a/HelpSource/Classes/BPF.schelp
+++ b/HelpSource/Classes/BPF.schelp
@@ -21,7 +21,7 @@ The input signal.
 argument::freq
 
 Centre frequency in Hertz.
-
+WARNING: due to the nature of its implementation frequency values close to 0 may cause glitches and/or extremely loud audio artifacts!
 
 argument::rq
 

--- a/HelpSource/Classes/BPeakEQ.schelp
+++ b/HelpSource/Classes/BPeakEQ.schelp
@@ -17,6 +17,7 @@ argument:: in
 input signal to be processed.
 argument:: freq
 center frequency.
+WARNING: due to the nature of its implementation frequency values close to 0 may cause glitches and/or extremely loud audio artifacts!
 argument:: rq
 the reciprocal of Q. bandwidth / cutoffFreq.
 argument:: db

--- a/HelpSource/Classes/BRF.schelp
+++ b/HelpSource/Classes/BRF.schelp
@@ -21,7 +21,7 @@ The input signal.
 argument::freq
 
 Cutoff frequency in Hertz.
-
+WARNING: due to the nature of its implementation frequency values close to 0 may cause glitches and/or extremely loud audio artifacts!
 
 argument::rq
 

--- a/HelpSource/Classes/LPF.schelp
+++ b/HelpSource/Classes/LPF.schelp
@@ -21,7 +21,7 @@ The input signal.
 argument::freq
 
 Cutoff frequency in Hertz.
-
+WARNING: due to the nature of its implementation frequency values close to 0 may cause glitches and/or extremely loud audio artifacts!
 
 argument::mul
 

--- a/HelpSource/Classes/RHPF.schelp
+++ b/HelpSource/Classes/RHPF.schelp
@@ -21,7 +21,7 @@ The input signal.
 argument::freq
 
 Cuttoff frequency in Hertz.
-
+WARNING: due to the nature of its implementation frequency values close to 0 may cause glitches and/or extremely loud audio artifacts!
 
 argument::rq
 

--- a/HelpSource/Classes/RLPF.schelp
+++ b/HelpSource/Classes/RLPF.schelp
@@ -21,7 +21,7 @@ The input signal.
 argument::freq
 
 Cuttoff frequency in Hertz.
-
+WARNING: due to the nature of its implementation frequency values close to 0 may cause glitches and/or extremely loud audio artifacts!
 
 argument::rq
 

--- a/HelpSource/Classes/Resonz.schelp
+++ b/HelpSource/Classes/Resonz.schelp
@@ -30,7 +30,7 @@ The input signal.
 argument::freq
 
 Resonant frequency in Hertz.
-
+WARNING: due to the nature of its implementation frequency values close to 0 may cause glitches and/or extremely loud audio artifacts!
 
 argument::bwr
 


### PR DESCRIPTION
BPF LPF RLPF, RHPF., Resonz., BBandPass, BAllPass, BBandStop., BHiPass, BHiPass4, BLowPass, BLowPass4, BHiShelf, BLowShelf, BPeakEQ, BRF are potentially getting nasty at filter frequencies close to zero.
Somehow they didn't make it into the the PR for https://github.com/supercollider/supercollider/commit/ce1d22330330803918e748ce978cb5f8ea5e1b9b