### PR TITLE
UGen-scope.sc: fixes method to determine default server

### DIFF
--- a/SCClassLibrary/Common/GUI/PlusGUI/Control/UGen-scope.sc
+++ b/SCClassLibrary/Common/GUI/PlusGUI/Control/UGen-scope.sc
@@ -1,6 +1,6 @@
 + UGen {
 	scope { arg name = "UGen Scope", bufsize = 4096, zoom = 1.0;
-		var server = Stethoscope.defaultServer;
+		var server = Server.default;
 		^SynthDef.wrap({ var bus, numChannels, rate, scope;
 			numChannels = this.numChannels;
 			rate = this.rate;

--- a/SCClassLibrary/Common/GUI/tools/Stethoscope.sc
+++ b/SCClassLibrary/Common/GUI/tools/Stethoscope.sc
@@ -45,7 +45,7 @@ Stethoscope {
 		zoom = 1.0, rate = \audio, view, bufnum;
 		var bus;
 
-		if(server.isNil) {server = this.defaultServer};
+		if(server.isNil) {server = Server.default};
 		if(server.isLocal.not) {Error("Can not scope on remote server.").throw};
 
 		bus = Bus(rate, index, numChannels, server);


### PR DESCRIPTION
before, this didn't work: { SinOsc.ar(100).scope(\SinOsc) }.play;
but this worked: { SinOsc.ar([100]).scope(\SinOsc) }.play;