### PR TITLE
Fix avoid calling nonexisting cleanup event type

### DIFF
--- a/SCClassLibrary/Common/Collections/EventTypesWithCleanup.sc
+++ b/SCClassLibrary/Common/Collections/EventTypesWithCleanup.sc
@@ -223,9 +223,17 @@ EventTypesWithCleanup {
 		type = ev[\type];
 		notNode = notNodeType[type] ? true;
 		if (flag || notNode) {
-			 (	parent: ev,
-				type: cleanupTypes[type]
-			).play;
+			if(cleanupTypes[type].notNil,
+				{
+					(
+						parent: ev.postln,
+						type: cleanupTypes[type]
+					).play;
+				},
+				{
+					"Cleanup type for event type '%' not found".format(type).warn;
+				}
+			);
 		}
 	}
 

--- a/SCClassLibrary/Common/Collections/EventTypesWithCleanup.sc
+++ b/SCClassLibrary/Common/Collections/EventTypesWithCleanup.sc
@@ -226,7 +226,7 @@ EventTypesWithCleanup {
 			if(cleanupTypes[type].notNil,
 				{
 					(
-						parent: ev.postln,
+						parent: ev,
 						type: cleanupTypes[type]
 					).play;
 				},


### PR DESCRIPTION
I need to have event type \sync when allocating buffers in Pproto. 

I found two earlier discussion on list about this:
http://new-supercollider-mailing-lists-forums-use-these.2681727.n2.nabble.com/EventType-sync-was-using-Pproto-for-groups-etc-td7587867.html

http://new-supercollider-mailing-lists-forums-use-these.2681727.n2.nabble.com/sync-event-type-for-patterns-td4283008.html

I can't find if this was added anytime after that.
I've tried adding the event type with:
`Event.addEventType(\sync, {|server| server.sync; });`

But that doesn't work if you stop the EventStreamPlayer from code. Like this:
```
(
s.waitForBoot({
	Event.addEventType(\sync, {|server| server.sync;});
	SynthDef(\help_playbuf, { | out=0, bufnum = 0, rate = 1, startPos = 0, amp = 0.1, sustain = 1, pan = 0, loop = 1|
		    var audio;
		    rate = rate * BufRateScale.kr(bufnum);
		    startPos = startPos * BufFrames.kr(bufnum);

		    audio = BufRd.ar(1, bufnum, Phasor.ar(0, rate, startPos, BufFrames.ir(bufnum)), 1, 1);
		    audio = EnvGen.ar(Env.sine, 1, timeScale: sustain, doneAction: 2) * audio;
		    audio = Pan2.ar(audio, pan, amp);
		    OffsetOut.ar(out, audio);
	}).add;

	s.sync;
	a = Pproto({
		    ~newgroup = (type: \group).yield;
		//     ~sf1 = SoundFile(Platform.resourceDir +/+ "sounds/a11wlk01-44_1.aiff").asEvent.yield;
		~sf1 = (type: \allocRead, path: Platform.resourceDir +/+ "sounds/a11wlk01-44_1.aiff").yield;
		(type: \sync).yield;
	},
	    Pbind(*[
		        instrument:    \help_playbuf,
		        dur:        Pseg([0,0,0.25,0.5, 0.75, 1],10).linexp(0,1,0.01,2),
		        legato:        4,
		        startPos:    Pn(Pseg([0,1], 20), inf),
		        rate:        Pwhite(1, 1).midiratio,
		        loop:        0,
		        group:        Pkey(\newgroup),
		        bufnum:        Pkey(\sf1)
	    ])
	);
	f = a.play;
});
)

f.stop; // Causes error message
```

What happens is that the sync function is called again when turning off the stream. The culprit is the EventTypesWithClean.cleanup method. If the 'cleanupTypes[type]' returns nil, the original sync function will be run once again. I've added check to avoid this from happening, and a warning when an event type without cleanup types is being run.
This commit makes the example above work, but the warning is printed when the cleanup happens. I added the warning as I see it as a user error when calling cleanup on an event type that doesn’t have a cleanup function. I think this is better than having it fail silently.

Pproto assumes that all events yielded from the makeFunction are EventTypeWithCleanup. If new event types are added and used in Pproto makeFunction this assumption will prove wrong. I will make a separate issue on this.

I made this gist for testing this change: https://gist.github.com/blacksound/3812c5259b81b5695ff4

