### PR TITLE
build: modify trunc() calls to compile on gcc 4.8.4

### DIFF
--- a/include/plugin_interface/SC_InlineBinaryOp.h
+++ b/include/plugin_interface/SC_InlineBinaryOp.h
@@ -422,13 +422,13 @@ inline long sc_lcm(long a, long b)
 
 inline float sc_gcd(float u, float v)
 {
-	return (float) sc_gcd((long) std::trunc(u), (long) std::trunc(v));
+	return (float) sc_gcd((long) trunc(u), (long) trunc(v));
 }
 
 
 inline float sc_lcm(float u, float v)
 {
-    return (float) sc_lcm((long) std::trunc(u), (long) std::trunc(v));
+    return (float) sc_lcm((long) trunc(u), (long) trunc(v));
 }
 
 


### PR DESCRIPTION
Issue doesn't seem to come up when compiling SC, but does when compiling sc3-plugins. I'm on Ubuntu 14.04.3 LTS.