### PR TITLE
scdoc: typo in HID_permissions.schelp

### DIFF
--- a/HelpSource/Guides/HID_permissions.schelp
+++ b/HelpSource/Guides/HID_permissions.schelp
@@ -1,6 +1,6 @@
 title:: HID permissions
 summary:: Details how to configure your computer to set the permissions to access HID's
-categories:: External control>HID
+categories:: External Control>HID
 related:: Guides/Working_with_HID, Classes/HID
 
 section:: On Linux


### PR DESCRIPTION
changed External control -> External Control so that it ends up in the right scdoc category