### PR TITLE
scdoc: typo in Working_with_HID.schelp

### DIFF
--- a/HelpSource/Guides/Working_with_HID.schelp
+++ b/HelpSource/Guides/Working_with_HID.schelp
@@ -1,6 +1,6 @@
 title:: Working with HID
 summary:: A guide to using HID devices for control input
-categories:: External control>HID
+categories:: External Control>HID
 related:: Classes/HID, Classes/HIDFunc
 
 section:: Introduction


### PR DESCRIPTION
changed External control -> External Control so that it ends up in the right scdoc category