### PR TITLE
build: cmake backward compatibility with 2.8.11

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ if (CMAKE_SYSTEM_NAME MATCHES "Linux")
 	set(LINUX 1)
 endif()
 
-cmake_minimum_required (VERSION 2.8.12)
+cmake_minimum_required (VERSION 2.8.11)
 
 include("SCVersion.txt")
 set(PROJECT_VERSION "${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}${PROJECT_VERSION_PATCH}")

--- a/external_libraries/CMakeLists.txt
+++ b/external_libraries/CMakeLists.txt
@@ -49,7 +49,7 @@ if(NOT Boost_FOUND) # we compile boost ourselves
 
 
 	if(CMAKE_SYSTEM_NAME MATCHES "Linux")
-		target_compile_options(boost_thread PRIVATE -fPIC)
+		set_property(TARGET boost_thread APPEND PROPERTY COMPILE_FLAGS "-fPIC")
 		target_link_libraries(boost_thread rt)
 	endif()
 
@@ -92,7 +92,7 @@ if(NOT YAMLCPP_FOUND)
   set_property( TARGET yaml PROPERTY FOLDER 3rdparty )
 
   if(CMAKE_COMPILER_IS_GNUCXX)
-    target_compile_options(yaml PRIVATE -Wno-deprecated-declarations)
+    set_property(TARGET yaml APPEND PROPERTY COMPILE_FLAGS -Wno-deprecated-declarations)
   endif()
 
 endif()


### PR DESCRIPTION
I believe this small tweak restores compatibility with cmake 2.8.11.

Debian wheezy only has as far as 2.8.11 available; that's the main motivator for this.
(Not a big deal on ubuntu.)