### PR TITLE
Fix outdated use of String replace in QuarksGui

### DIFF
--- a/SCClassLibrary/Common/Quarks/QuarksGui.sc
+++ b/SCClassLibrary/Common/Quarks/QuarksGui.sc
@@ -627,6 +627,6 @@ QuarkRowView {
 		// 1 is the install button. its not possible to sort by this column
 		treeItem.setString(2, quark.name ? "");
 		treeItem.setString(3, (quark.version ? "").asString);
-		treeItem.setString(4, (quark.summary ? "").replace(Char.nl," ").replace(Char.tab, ""));
+		treeItem.setString(4, (quark.summary ? "").replace("\n"," ").replace("\t", ""));
 	}
 }


### PR DESCRIPTION
QuarksGui throws an error now because of a breaking change to the replace method of String.