### PR TITLE
jack audio driver: remove old unused codepath for jack<0.100

### DIFF
--- a/server/scsynth/SC_Jack.cpp
+++ b/server/scsynth/SC_Jack.cpp
@@ -244,24 +244,6 @@ bool SC_JackDriver::DriverSetup(int* outNumSamples, double* outSampleRate)
 		}
 	}
 
-#ifdef SC_USE_JACK_CLIENT_NEW
-	// old style client startup for Jack <0.100 -- AG
-	if (clientName) {
-		mClient = jack_client_new(clientName);
-	} else {
-		clientName = strdup("SuperCollider");
-		mClient = jack_client_new(clientName);
-		if (mClient == 0) {
-			char uniqueName[64];
-			sprintf(uniqueName, "SuperCollider-%d", getpid());
-			clientName = strdup(uniqueName);
-			mClient = jack_client_new(uniqueName);
-		}
-	}
-	if (mClient) scprintf("%s: client name is '%s'\n", kJackDriverIdent, clientName);
-	if (serverName) free(serverName); if (clientName) free(clientName);
-	if (mClient == 0) return false;
-#else
 	mClient = jack_client_open(
 		clientName ? clientName : kJackDefaultClientName,
 		serverName ? JackServerName : JackNullOption,
@@ -270,7 +252,6 @@ bool SC_JackDriver::DriverSetup(int* outNumSamples, double* outSampleRate)
 	if (mClient == 0) return false;
 
 	scprintf("%s: client name is '%s'\n", kJackDriverIdent, jack_get_client_name(mClient));
-#endif
 
 	// create jack I/O ports
 	mInputList = new SC_JackPortList(mClient, mWorld->mNumInputs, JackPortIsInput);


### PR DESCRIPTION
Looking at the jack driver I found an old codepath, for jack<0.100 (released 2005). I'm not aware of any system that's limited to such very old jackd. Furthermore, the define being tested for (SC_USE_JACK_CLIENT_NEW) is not referenced anywhere else in the project. (The old "SConstruct" used to have an option to enable it but that went away long ago and no-one noticed.)