### PR TITLE
cmake: refuse to build if unrecognised AUDIOAPI

### DIFF
--- a/server/scsynth/CMakeLists.txt
+++ b/server/scsynth/CMakeLists.txt
@@ -16,7 +16,7 @@ if(AUDIOAPI STREQUAL "default")
 endif()
 
 if(NOT AUDIOAPI MATCHES "^(jack|coreaudio|portaudio)$")
-	message(WARNING "Unrecognised audio API: ${AUDIOAPI}")
+	message(FATAL_ERROR "Unrecognised audio API: ${AUDIOAPI}")
 endif()
 
 if(AUDIOAPI STREQUAL jack)


### PR DESCRIPTION
If the flag AUDIOAPI takes an unrecognised value, really we should error out, rather than merely warning.