### PR TITLE
Incorporate these tutorial corrections

### DIFF
--- a/HelpSource/Tutorials/Getting-Started/02-First-Steps.schelp
+++ b/HelpSource/Tutorials/Getting-Started/02-First-Steps.schelp
@@ -4,7 +4,7 @@ categories:: Tutorials>Getting-Started
 related:: Tutorials/Getting-Started/00-Getting-Started-With-SC
 
 note::
-This document is OSX (SCapp) specific in key commands, though the principles extend to all platforms. See the helpfile link::Reference/KeyboardShortcuts:: for key commands in other editors.
+This document is written so that it can be used on all supported systems, though having first of all OS X in mind using the application SuperCollider.app (SCapp). Some features, e.g. menu commands, are platform specific, but the principles extend to all platforms. See the helpfile link::Reference/KeyboardShortcuts:: for key commands when using other tools such as SC enhanced editors, e.g. on Linux platforms.
 ::
 
 section::Hello World, I'm SuperCollider
@@ -34,7 +34,7 @@ code::
 "Hello World!".postln;
 ::
 
-To execute it, simply click to place the cursor somewhere on the same line as the code and then press Ctrl-Enter (Cmd-Enter on the Mac) or Shift-Enter. Try this now.
+To execute it, simply click to place the cursor somewhere on the same line as the code and then press Shift-Enter (Shift-Return on the Mac). Try this now.
 
 If all went well, you should see this in the post window.
 
@@ -43,22 +43,24 @@ Hello World!
 Hello World!
 ::
 
+Alternatively you can also first select the code you wish to execute and then press Ctrl-Enter (Cmd-Return on the Mac). Try this now.
+
 Now let's take a closer look at the code. The first bit, code::"Hello World!"::, is a kind of emphasis::Object::, called a String. An object is basically just a way of representing something in the computer, for instance a bit of text, or an oscillator, that allows you to control it and send messages to it. More about that later, but for now just understand that a String is a way of representing a bit of text.
 
 The second bit, code::.postln;::, says 'print me (or a meaningful description of me) to the post window.' Remember postln, it's your friend. You can apply it to almost anything in SC and get something meaningful back. This can be very handy when tracking down bugs in your code.
 
 Why did it print twice? Well, when you execute code in SC, it always posts the result of the last bit of code (the last statement). So it first prints because we explicitly told it to print, and then it prints the result of this operation, which happens to be the same in this case.
 
-So in this case we didn't really need the code::postln:: bit. But in the following example we would. Select both lines of text by clicking and dragging over them, and then press enter.
+So in this case we didn't really need the code::postln:: bit. But in the following example we would. Select both lines of text by clicking and dragging over them, and then execute, i.e. press Ctrl-Enter (Cmd-Return on the Mac).
 
 code::
+"Hello there, I'm SuperCollider!".postln;
 "Hello World!".postln;
-"Hello SC!".postln;
 ::
 
-The first line, 'Hello World' would not have printed if we didn't have the explicit postln. Note also that each line of code ends with a semi-colon. This is how you separate lines of code in SC. If we didn't have a semi-colon between the two lines we would get an error.
+The first line, 'Hello there, I'm SuperCollider!' would not have printed if we didn't have the explicit postln.
 
-In general when you are meant to execute several lines of code at the same time they will be surrounded by parentheses, as in the example below. This is convenient as it allows you to select the whole block of code by double clicking just inside one of the parentheses. Try it out on the example below.
+In general when you are meant to execute several lines of code at the same time they will be surrounded by parentheses, as in the example below. You can have your cursor anywhere in this region (or on the line of the parentheses on the Mac), then double-click and press Ctrl-Enter or Shift-Enter (Cmd-Return or Shift-Return on the Mac) - this selects the whole region and executes it. Try it out on the example below.
 
 code::
 (
@@ -67,9 +69,11 @@ code::
 )
 ::
 
-When code is not surrounded by parentheses it is generally intended to be executed one line at a time. You can have your cursor anywhere in this region and press Ctrl-Enter (Cmd-Enter on the Mac) - this selects the whole region and executes it.
+Double clicking inside a pair of enclosing parentheses may not select the entire region on all systems, notably not on modern Macs. On some it may only select the double clicked word. Thus it may be good, to make it a habit to stick to a particular technique. E.g. to first always check you have selected all of the intended code, regardless of the selection technique, before pressing either Ctrl-Enter or Shift-Enter (Cmd-Return or Shift-Enter on the Mac). Then stick to the technique that works best for you. Experiment with this to learn how your system behaves.
 
-Note that each of the lines within the block of code ends with a semi-colon. This is very important when executing multiple lines of code, as it's how SC knows where to separate commands. Without a semi-colon above, you would get an error posted.
+When code is not surrounded by parentheses it is generally intended to be executed one line at a time. You can have your cursor anywhere in a line of code and press Ctrl-Enter or Shift-Enter (Cmd-Return or Shift-Return on the Mac) - this selects the whole line and executes it.
+
+Note that each of the lines within the block of code ends with a semi-colon. This is very important when executing multiple lines of code. Try what happens when you execute following variant of the almost identical code.
 
 code::
 (
@@ -90,13 +94,15 @@ line 3 char 10:
 )
 ::
 
-Usually the problem actually occurs a little before that, so that's where you should look. In this case of course, it's the lack of a semi-colon at the end of the previous line.
+Usually the problem actually occurs a little before that, so that's where you should look.  In this case, it's the lack of a semi-colon at the end of the previous line.  Note that each line of code ends normally with a semi-colon.  This is how you separate lines of code in SC. Since we didn't have a semi-colon between the two lines we have gotten an error. 
 
 Using semi-colons it's possible to have more than one line of code in the same line of text. This can be handy for execution.
 
 code::
 "Call me ".post; "Ishmael?".postln;
 ::
+
+Note also, having an extra semi-colon at the very end of the last piece of code does not hurt and is tolerated by SC for reasons of convenience. 
 
 A couple of more notes about the post window. It's very useful to be able to see it, but sometimes it can get hidden behind other windows. You can bring it to the front at any time by holding down the Command key, and pressing \ . The Command key is the one with the apple symbol on it.
 
@@ -126,7 +132,7 @@ link::Guides/How-to-Use-the-Interpreter::, link::Reference/Literals::, link::Cla
 
 section::Suggested Exercise
 
-Open a new window by pressing Cmd-n or selecting 'New' from the File menu.Copy some of the posting code from the examples above and paste it into the new document. (The standard Mac Cmd-c and Cmd-v work for copy and paste, or use the Edit menu.)
+Open a new window by pressing Ctrl-N (Cmd-N on a Mac) or choose 'New' from the File menu. Save the document by giving it any name such as 'My first SC code.scd'. Note, you should always use extension '.scd' for files containing SC code. Copy some of above code examples and paste them into the new document (The standard shortcuts Ctrl-C and Ctrl-V (Cmd-C and Cmd-V on a Mac) work for copy and paste, or use the Edit menu).
 
 SC will let you edit the help files and documentation, so it's always a good idea to copy text over before changing it so as to avoid accidentally saving altered files!
 


### PR DESCRIPTION
Improving on correctness of First Steps section in SC Tutorial:

As discussed under issue
https://github.com/supercollider/supercollider/issues/1781#issuecomment-
170959978 I have now made an attempt to improve on the correctness of
the section "02. First Steps" of Tutorial "Getting Started With
SuperCollider”. This should give new users of SC a much more pleasant
experience and avoid the bad impression of SC not working as it
should/described. However, some sections are related to a bug/bugs
(https://github.com/supercollider/supercollider/issues/1786).