### PR TITLE
Font.schelp: fixes https://github.com/supercollider/supercollider/issues/1811 and gives example windows more space

### DIFF
--- a/HelpSource/Classes/Font.schelp
+++ b/HelpSource/Classes/Font.schelp
@@ -94,7 +94,7 @@ An instance of link::Classes/String::.
 
 method:: size
 Gets/sets the size of the font.
-Setting this variable is always considered as setting the link::#-pixelSize::, while getting it will return any size set. See link::#-hasPointSize:: for distinction.::
+Setting this variable is always considered as setting the link::#-pixelSize::, while getting it will return any size set. See link::#-hasPointSize:: for distinction.
 
 argument:: pixelSize
 A Float.
@@ -195,15 +195,15 @@ w.view.decorator = f = FlowLayout(w.view.bounds,Point(4, 4),Point(4, 2));
 ].do({ arg name;
 	var v, s, n, spec, p, height = 16;
 
-		v = StaticText(w, Rect(0, 0, 56, height + 2));
+		v = StaticText(w, Rect(0, 0, 110, height + 20));
 		v.font = Font(name, 13);
 		v.string = name;
 
-		s = Button(w, Rect(0, 0, 140, height + 2));
+		s = Button(w, Rect(0, 0, 140, height + 20));
 		s.font = Font(name, 13);
 		s.states = [[name]];
 
-		n = NumberBox(w, Rect(0, 0, 56, height + 2));
+		n = NumberBox(w, Rect(0, 0, 56, height + 20));
 		n.font = Font(name, 13);
 		n.object = pi;
 
@@ -217,7 +217,7 @@ w.front;
 (
 var w, f, i = 0;
 
-w = Window("Fonts", Rect(128, 64, 820, 760));
+w = Window("Fonts", Rect(128, 64, 1024, 768));
 b = ScrollView(w, w.view.bounds);
 
 b.decorator = f = FlowLayout(b.bounds, Point(4,4), Point(4,2));
@@ -226,16 +226,16 @@ Font.availableFonts.do({ arg name;
 	var v, s, n, spec, p, height = 16, font;
 	font = Font(name,13);
 
-		v = StaticText(b, Rect(0, 0, 56, height + 2));
+		v = StaticText(b, Rect(0, 0, 120, height + 20));
 		v.font = font;
 		v.string = name;
 
-		s = Button(b, Rect(0, 0, 140, height + 2));
+		s = Button(b, Rect(0, 0, 140, height + 20));
 		s.font = font;
 		s.states = [[name]];
 		s.action = { font.asCompileString.postln; };
 
-		n = NumberBox(b, Rect(0, 0, 56, height + 2));
+		n = NumberBox(b, Rect(0, 0, 56, height + 20));
 		n.font = font;
 		n.object = pi;
 	if( (i = i + 1) % 3 == 0,{


### PR DESCRIPTION
fixes https://github.com/supercollider/supercollider/issues/1811,
also, allowing for more space for the last two examples