### PR TITLE
QView.sc: removes residue OS X Space after closing a fullscreen window. 

### DIFF
--- a/SCClassLibrary/Common/GUI/Base/QView.sc
+++ b/SCClassLibrary/Common/GUI/Base/QView.sc
@@ -326,6 +326,7 @@ View : QObject {
 	}
 
 	close {
+		if( this.getProperty( \fullScreen ) ) { this.invokeMethod( \showNormal, synchronous:false ) };
 		if( deleteOnClose )
 		{ this.remove; }
 		{ this.visible_( false ); }


### PR DESCRIPTION
Fix or workaround for https://github.com/supercollider/supercollider/issues/1506
applicable on all platforms, switches back to normal window before closing.