### PR TITLE
build: fix non-SSE2 compile of SC_SndBuf.h (Fixes #1819)

### DIFF
--- a/include/plugin_interface/SC_SndBuf.h
+++ b/include/plugin_interface/SC_SndBuf.h
@@ -44,7 +44,7 @@ class rw_spinlock
 #ifdef __SSE2__
 	static inline void pause() { _mm_pause(); }
 #else
-	static inline void pause() { _mm_pause(); }
+	static inline void pause() { }
 #endif
 
 public:


### PR DESCRIPTION
This fixes compile on non-SSE2 systems - see #1819 for info. Again this PR is just for master