### PR TITLE
Server.sc: option for scsynth's verbosity now is "V" not "v".

### DIFF
--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -136,7 +136,7 @@ ServerOptions {
 			o = o ++ " -H % %".format(inDevice.asString.quote, outDevice.asString.quote);
 		};
 		if (verbosity != 0, {
-			o = o ++ " -v " ++ verbosity;
+			o = o ++ " -V " ++ verbosity;
 		});
 		if (zeroConf.not, {
 			o = o ++ " -R 0";


### PR DESCRIPTION
This seems to have changed at some point, 3.6.6 is ok.
fixes https://github.com/supercollider/supercollider/issues/1825