### PR TITLE
class library: assume scalar rate as minimum

### DIFF
--- a/SCClassLibrary/Common/Collections/SequenceableCollection.sc
+++ b/SCClassLibrary/Common/Collections/SequenceableCollection.sc
@@ -915,7 +915,7 @@ SequenceableCollection : Collection {
 	rate {
 		var rate, rates;
 		if(this.size == 1) { ^this.first.rate };
-		^this.collect { arg item; item.rate ? 'scalar' }.minItem;
+		^this.collect({ arg item; item.rate ? 'scalar' }).minItem
 		// 'scalar' > 'control' > 'audio'
 	}
 

--- a/SCClassLibrary/Common/Collections/SequenceableCollection.sc
+++ b/SCClassLibrary/Common/Collections/SequenceableCollection.sc
@@ -914,8 +914,8 @@ SequenceableCollection : Collection {
 
 	rate {
 		var rate, rates;
-		if(this.size == 1, { ^this.first.rate });
-		^this.collect({ arg item; item.rate }).minItem;
+		if(this.size == 1) { ^this.first.rate };
+		^this.collect { arg item; item.rate ? 'scalar' }.minItem;
 		// 'scalar' > 'control' > 'audio'
 	}
 

--- a/include/plugin_interface/SC_InlineUnaryOp.h
+++ b/include/plugin_interface/SC_InlineUnaryOp.h
@@ -285,6 +285,13 @@ inline float32 sc_frac(float32 x)
 }
 
 
+////////////////////////////////
+
+inline float32 sc_bitNot(float32 x)
+{
+	return (float32) ~ (int)x;
+}
+
 inline float32 sc_lg3interp(float32 x1, float32 a, float32 b, float32 c, float32 d)
 {
 	// cubic lagrange interpolator

--- a/server/plugins/UnaryOpUGens.cpp
+++ b/server/plugins/UnaryOpUGens.cpp
@@ -275,6 +275,8 @@ inline F sc_not(F x)
 }
 
 DEFINE_UNARY_OP_FUNCS(not, sc_not)
+DEFINE_UNARY_OP_FUNCS(bitNot, sc_bitNot)
+
 
 void zero_a(UnaryOpUGen *unit, int inNumSamples)
 {
@@ -574,6 +576,7 @@ static UnaryOpFunc ChooseNormalFunc(UnaryOpUGen *unit)
 		case opThru : func = &thru_a; break;
 		case opNeg : func = &invert_a; break;
 		case opNot : func = &not_a; break;
+        case opBitNot : func = &bitNot_a; break;
 		case opAbs : func = &abs_a; break;
 		case opCeil : func = &ceil_a; break;
 		case opFloor : func = &floor_a; break;
@@ -638,6 +641,7 @@ static UnaryOpFunc ChooseOneFunc(UnaryOpUGen *unit)
 		case opThru : func = &thru_a; break;
 		case opNeg : func = &invert_1; break;
 		case opNot : func = &not_1; break;
+        case opBitNot : func = &bitNot_1; break;
 		case opAbs : func = &abs_1; break;
 		case opCeil : func = &ceil_1; break;
 		case opFloor : func = &floor_1; break;
@@ -703,6 +707,7 @@ static UnaryOpFunc ChooseDemandFunc(UnaryOpUGen *unit)
 		case opThru : func = &thru_d; break;
 		case opNeg : func = &invert_d; break;
 		case opNot : func = &not_d; break;
+		case opBitNot : func = &bitNot_d; break;
 		case opAbs : func = &abs_d; break;
 		case opCeil : func = &ceil_d; break;
 		case opFloor : func = &floor_d; break;
@@ -771,6 +776,7 @@ static UnaryOpFunc ChooseNovaSimdFunc(UnaryOpUGen *unit)
 		case opThru : func = &thru_nova; break;
 		case opNeg : return &invert_nova_64;
 		case opNot : func = &not_a; break;
+		case opBitNot : func = &bitNot_a; break;
 		case opAbs : return &abs_nova_64;
 		case opCeil : func = &ceil_nova_64; break;
 		case opFloor : func = &floor_nova_64; break;
@@ -829,6 +835,7 @@ static UnaryOpFunc ChooseNovaSimdFunc(UnaryOpUGen *unit)
 		case opThru : func = &thru_nova; break;
 		case opNeg : func = &invert_nova; break;
 		case opNot : func = &not_a; break;
+        case opBitNot : func = &bitNot_a; break;
 		case opAbs : func = &abs_nova; break;
 		case opCeil : func = &ceil_nova; break;
 		case opFloor : func = &floor_nova; break;


### PR DESCRIPTION
When determining the rate of a collection of objects, the maximal rate
is returned. Now if the rate happens to be nil, we just assume scalar.
This allows the error to be thrown a bit later, in the UGen that takes
the object as an input. This fixes #1771