### PR TITLE
class library display path in quark gui

### DIFF
--- a/SCClassLibrary/Common/Quarks/QuarksGui.sc
+++ b/SCClassLibrary/Common/Quarks/QuarksGui.sc
@@ -255,7 +255,7 @@ QuarkDetailView {
 		^view
 	}
 	update {
-		var tags, refspec, isInstalled = false, isDownloaded = false,
+		var tags, refspec, isInstalled = false, isDownloaded = false, path,
 			url,
 			webpage,
 			dependencies,
@@ -301,7 +301,9 @@ QuarkDetailView {
 			});
 
 			if(isDownloaded or: isInstalled, {
-				this.pushRow("Local path", makeBtn.value("Open Folder", {
+				path =  model.localPath;
+				if(path.size > 64) { path = "..." + path.keep(-64) };
+				this.pushRow("Local path", makeBtn.value("Open Folder:" + path, {
 					this.openLocalPath;
 				}));
 			});

--- a/SCClassLibrary/JITLib/ProxySpace/ProxySynthDef.sc
+++ b/SCClassLibrary/JITLib/ProxySpace/ProxySynthDef.sc
@@ -23,7 +23,7 @@ ProxySynthDef : SynthDef {
 			};
 			// protect from accidentally wrong array shapes
 			if(output.containsSeqColl) {
-				"Synth output should be a flat array.\n%".format(output).warn;
+				"Synth output should be a flat array.\n%\nFlattened to: %\n".format(output, output.flat).warn;
 				output = output.flat;
 			};
 


### PR DESCRIPTION
This is useful when there are several repositories of he same quark,
typically one in the own repo and the other one in downloaded-quarks.

If the path is too long to be displayed, it is shortened and prefixed
with “…”.

