### PR TITLE
build: fix PanUGens to build when NOVA_SIMD=OFF

### DIFF
--- a/server/plugins/PanUGens.cpp
+++ b/server/plugins/PanUGens.cpp
@@ -743,17 +743,24 @@ void LinXFade2_Ctor(LinXFade2 *unit)
 		break;
 
 	case calc_BufRate:
+#ifdef NOVA_SIMD
 		if (!(BUFLENGTH & 15))
 			SETCALC(LinXFade2_next_k_nova);
 		else
 			SETCALC(LinXFade2_next_k);
+#else
+		SETCALC(LinXFade2_next_k);
+#endif
 		break;
-
 	case calc_ScalarRate:
+#ifdef NOVA_SIMD
 		if (!(BUFLENGTH & 15))
 			SETCALC(LinXFade2_next_i_nova);
 		else
 			SETCALC(LinXFade2_next_i);
+#else
+		SETCALC(LinXFade2_next_i);
+#endif
 		break;
 	}
 


### PR DESCRIPTION
Simple patch that already made it to master. I was thinking of proposing this for 3.7.1 but if you see it's simple enough for 3.7.0 then go for it. Without this patch, setting NOVA_SIMD=OFF simply causes the SC build to fail.

(cherry picked from commit a630e05b67cd60d801af87db1373428f4da832ee)