### PR TITLE
Topic/rate fallthrough

### DIFF
--- a/SCClassLibrary/Common/Audio/InOut.sc
+++ b/SCClassLibrary/Common/Audio/InOut.sc
@@ -213,6 +213,10 @@ AbstractOut : UGen {
 						"(" + inputs.at(i) + ") is not audio rate");
 				});
 			});
+		}, {
+			if(inputs.size <= 1, {
+				^"missing input at index 1"
+			})
 		});
 		^this.checkValidInputs
 	}

--- a/SCClassLibrary/Common/Collections/SequenceableCollection.sc
+++ b/SCClassLibrary/Common/Collections/SequenceableCollection.sc
@@ -915,7 +915,7 @@ SequenceableCollection : Collection {
 	rate {
 		var rate, rates;
 		if(this.size == 1) { ^this.first.rate };
-		^this.collect { arg item; item.rate ? 'scalar' }.minItem;
+		^this.collect({ arg item; item.rate ? 'scalar' }).minItem
 		// 'scalar' > 'control' > 'audio'
 	}
 

--- a/SCClassLibrary/Common/Collections/SequenceableCollection.sc
+++ b/SCClassLibrary/Common/Collections/SequenceableCollection.sc
@@ -914,8 +914,8 @@ SequenceableCollection : Collection {
 
 	rate {
 		var rate, rates;
-		if(this.size == 1, { ^this.first.rate });
-		^this.collect({ arg item; item.rate }).minItem;
+		if(this.size == 1) { ^this.first.rate };
+		^this.collect { arg item; item.rate ? 'scalar' }.minItem;
 		// 'scalar' > 'control' > 'audio'
 	}
 


### PR DESCRIPTION
When determining the rate of a collection of objects, the maximal rate
is returned. Now if the rate happens to be nil, we just assume scalar.
This allows the error to be thrown a bit later, in the UGen that takes
the object as an input. This fixes #1771