### PR TITLE
Fix presumed bug in d0f475d (min should be max). Fixes #1842

### DIFF
--- a/lang/LangSource/PyrObject.cpp
+++ b/lang/LangSource/PyrObject.cpp
@@ -1187,7 +1187,7 @@ void buildBigMethodMatrix()
 #endif
 
 	const int cpuCount = thread::hardware_concurrency();
-	boost::basic_thread_pool pool( std::min( cpuCount - 1, 1 ) );
+	boost::basic_thread_pool pool( std::max( cpuCount - 1, 1 ) );
 
 	// pyrmalloc:
 	// lifetime: kill after compile


### PR DESCRIPTION
This caused lang freeze on ARM Cortex A8 devices, presumably because they are single-concurrency and the bug led to a thread pool of size zero.