### PR TITLE
Topic fix allocations

### DIFF
--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -360,7 +360,7 @@ Server {
 		var n = options.maxLogins ? 1;
 
 		numControl = options.numControlBusChannels div: n;
-		numAudio = options.numAudioBusChannels div: n;
+		numAudio = options.numPrivateAudioBusChannels div: n;
 
 		controlBusOffset = numControl * offset;
 		audioBusOffset = options.firstPrivateBus + (numAudio * offset);

--- a/SCClassLibrary/JITLib/ProxySpace/BusPlug.sc
+++ b/SCClassLibrary/JITLib/ProxySpace/BusPlug.sc
@@ -150,7 +150,8 @@ BusPlug : AbstractFunction {
 
 	// you have to stop and play explicitly
 	setBus { | inBus |
-		if(bus != inBus and: { inBus.notNil }) {
+		if(inBus.isNil) { Error("BusPlug:setBus: bus can't be set to nil.").throw };
+		if(bus != inBus) {
 			//postf("% has new bus: % \nold bus was: %\n", this, inBus, bus);
 			this.freeBus;
 			bus = inBus;


### PR DESCRIPTION
This is a fix for the allocation problem that has has become exposed  in `NodeProxy`.


```
//—first example

s.reboot
(
60.do{|i|
	Ndef(("asdf"++i).asSymbol.postln, {SinOsc.ar((40+i).midicps,0,0.1)!2});
};
)

Ndef(\asdf54).play  //sounding
Ndef(\asdf54).stop
Ndef(\asdf55).play  //sounding
Ndef(\asdf55).stop
Ndef(\asdf56).play  //silence
Ndef(\asdf56).stop
Ndef(\asdf57).play  //silence
Ndef(\asdf57).stop
Ndef(\asdf58).play  //silence
Ndef(\asdf58).stop
Ndef(\asdf59).play  //silence
Ndef(\asdf59).stop

//would be nice with a warning


//—second example...

//recompile
s.reboot
(
66.do{|i|
	Ndef(("asdf"++i).asSymbol.postln, {SinOsc.ar((40+i).midicps,0,0.1)!2});
};
)

//loud sound without any .play.  post window say...
//"ERROR: Meta_Bus:audio: failed to get an audio bus allocated. numChannels: 2 server: localhost"

//good with a warning, but why the leaking sound?  i never called .play


if i bump up this option...
s.options.numAudioBusChannels= 256;
or change s.options.numOutputBusChannels the problems go away (temporarily)

```