### PR TITLE
class library: protect MultiOutUGen from void numChannels

### DIFF
--- a/SCClassLibrary/Common/Audio/UGen.sc
+++ b/SCClassLibrary/Common/Audio/UGen.sc
@@ -529,6 +529,9 @@ MultiOutUGen : UGen {
 	}
 
 	initOutputs { arg numChannels, rate;
+		if(numChannels.isNil or: { numChannels < 1 }, {
+			Error("%: wrong number of channels (%)".format(this, numChannels)).throw
+		});
 		channels = Array.fill(numChannels, { arg i;
 			OutputProxy(rate, this, i);
 		});


### PR DESCRIPTION
Both 0 and nil make no sense for MultiOutUGen. This fixes #1686.