### PR TITLE
sclang: introduce unixCmd for array of arguments

### DIFF
--- a/SCClassLibrary/Common/Collections/SequenceableCollection.sc
+++ b/SCClassLibrary/Common/Collections/SequenceableCollection.sc
@@ -1300,4 +1300,22 @@ SequenceableCollection : Collection {
 			}
 		}
 	}
+
+	unixCmd { arg action, postOutput = true;
+		if(this.notEmpty){
+			var pid;
+			pid = this.prUnixCmd(postOutput);
+			if(action.notNil) {
+				String.unixCmdActions.put(pid, action);
+			};
+			^pid;
+		} {
+			Error("Collection should have at least the filepath of the program to run.").throw
+		}
+	}
+
+	prUnixCmd { arg postOutput = true;
+		_ArrayPOpen
+		^this.primitiveFailed
+	}
 }

--- a/common/sc_popen.cpp
+++ b/common/sc_popen.cpp
@@ -31,10 +31,19 @@
 FILE *
 sc_popen(const char *command, pid_t *pidp, const char *type)
 {
+	char *argv[4];
+	argv[0] = (char *)"sh";
+	argv[1] = (char *)"-c";
+	argv[2] = (char *)command;
+	argv[3] = NULL;
+	return sc_popen_argv((char *)"/bin/sh", argv, pidp, type);
+}
+
+FILE *
+sc_popen_argv(const char *filename, char *const argv[], pid_t *pidp, const char *type)
+{
 	FILE *iop;
 	int pdes[2], pid, twoway;
-	char *argv[4];
-
 	/*
 	 * Lite2 introduced two-way popen() pipes using _socketpair().
 	 * FreeBSD's pipe() is bidirectional, so we use that.
@@ -49,11 +58,6 @@ sc_popen(const char *command, pid_t *pidp, const char *type)
 	}
 	if (pipe(pdes) < 0)
 		return (NULL);
-
-	argv[0] = (char *)"sh";
-	argv[1] = (char *)"-c";
-	argv[2] = (char *)command;
-	argv[3] = NULL;
 
 	switch (pid = fork()) {
 	case -1:			/* Error. */
@@ -87,7 +91,7 @@ sc_popen(const char *command, pid_t *pidp, const char *type)
 			(void)close(pdes[1]);
 		}
 
-		execve("/bin/sh", argv, environ);
+		execve(filename, argv, environ);
 		exit(127);
 		/* NOTREACHED */
 	}

--- a/common/sc_popen.h
+++ b/common/sc_popen.h
@@ -27,4 +27,5 @@
 #endif
 
 FILE * sc_popen(const char *command, pid_t *pidp, const char *type);
+FILE * sc_popen_argv(const char *filename, char *const argv[], pid_t *pidp, const char *type);
 int sc_pclose(FILE *iop, pid_t mPid);


### PR DESCRIPTION
fixes #1738 

My c++ is rusty, can someone review this ? 

tested with:

    ["/bin/echo","hello","world"].unixCmd
    ["/bin/echo",1,"world"].unixCmd
    [].unixCmd
   x = ["/usr/local/bin/scsynth","-u","57128"].unixCmd

pid at x checks out with pgrep.

The first argument should be the program filepath as explained in http://linux.die.net/man/2/execve.
Currently everything must be strings, could call .asString on each argument if that seems appropriate.

Some questions in the code.