### PR TITLE
supernova: don't delete shared memory data

### DIFF
--- a/server/supernova/sc/sc_plugin_interface.cpp
+++ b/server/supernova/sc/sc_plugin_interface.cpp
@@ -815,7 +815,6 @@ void sc_done_action_handler::apply_done_actions(void)
 sc_plugin_interface::~sc_plugin_interface(void)
 {
     delete[] world.mAudioBusTouched;
-    delete[] world.mControlBus;
     delete[] world.mControlBusTouched;
     delete[] world.mSndBufs;
     delete[] world.mSndBufsNonRealTimeMirror;


### PR DESCRIPTION
fixes crash on exit