### PR TITLE
sclang: introduce unixCmd for array of arguments

### DIFF
--- a/SCClassLibrary/Common/Collections/SequenceableCollection.sc
+++ b/SCClassLibrary/Common/Collections/SequenceableCollection.sc
@@ -1300,4 +1300,22 @@ SequenceableCollection : Collection {
 			}
 		}
 	}
+
+	unixCmd { arg action, postOutput = true;
+		if(this.notEmpty){
+			var pid;
+			pid = this.prUnixCmd(postOutput);
+			if(action.notNil) {
+				String.unixCmdActions.put(pid, action);
+			};
+			^pid;
+		} {
+			Error("Collection should have at least the filepath of the program to run.").throw
+		}
+	}
+
+	prUnixCmd { arg postOutput = true;
+		_ArrayPOpen
+		^this.primitiveFailed
+	}
 }

--- a/common/sc_popen.h
+++ b/common/sc_popen.h
@@ -27,4 +27,5 @@
 #endif
 
 FILE * sc_popen(const char *command, pid_t *pidp, const char *type);
+FILE * sc_popen_argv(const char *filename, char *const argv[], pid_t *pidp, const char *type);
 int sc_pclose(FILE *iop, pid_t mPid);


### PR DESCRIPTION
fixes #1738 

Incorporated some of @timblechmann 's feedback. 

* changed from malloc/free to new/delete. I wasn't able to use unique_ptr for sc_process due to some very complicated type error.
* removed un-const castings.
* moved function to the same file as other unix primitives. There was no reason for it be in the array primitives file.

tested with:

["/bin/echo","hello","world"].unixCmd
["/bin/echo",1,"world"].unixCmd
[].unixCmd

x = ["/usr/local/bin/scsynth","-u","57128"].unixCmd

pid at x checks out with pgrep.