### PR TITLE
ide: fix memory leak

### DIFF
--- a/editors/sc-ide/primitives/sc_ipc_client.cpp
+++ b/editors/sc-ide/primitives/sc_ipc_client.cpp
@@ -384,9 +384,9 @@ int ScIDE_SetDocTextMirror(struct VMGlobals *g, int numArgsPushed)
     
     if(length == -1) return errWrongType;
     
-    char * text = (char*)malloc(length + 1);
+    std::vector<char> text(length + 1);
     
-    if (slotStrVal( textSlot, text, length + 1))
+    if (slotStrVal( textSlot, text.data(), length + 1))
         return errWrongType;
     
     int pos, range, err = errNone;
@@ -399,10 +399,8 @@ int ScIDE_SetDocTextMirror(struct VMGlobals *g, int numArgsPushed)
     if (err) return err;
     
     QByteArray key = QByteArray(id);
-    QString docText = QString(text);
-    
-    free(text);
-    
+    QString docText = QString(text.data());
+        
     gIpcClient->setTextMirrorForDocument(key, docText, pos, range);
 
     return errNone;


### PR DESCRIPTION
I think the use of vector is correct here, someone else should check. I tryed doing a cout of 'text.data()' and the text of the file is posted correctly, so slotStrVal seems to be working correctly with the pointer returned from data().