### PR TITLE
ide: Add standalone option in settings.

### DIFF
--- a/editors/sc-ide/core/sc_process.cpp
+++ b/editors/sc-ide/core/sc_process.cpp
@@ -135,6 +135,7 @@ void ScProcess::startLanguage (void)
 
     QString workingDirectory = settings->value("runtimeDir").toString();
     QString configFile = settings->value("configFile").toString();
+    bool standalone = settings->value("standalone").toBool();
 
     settings->endGroup();
 
@@ -149,6 +150,8 @@ void ScProcess::startLanguage (void)
     if(!configFile.isEmpty())
         sclangArguments << "-l" << configFile;
     sclangArguments << "-i" << "scqt";
+    if(standalone)
+        sclangArguments << "-a";
 
     if(!workingDirectory.isEmpty())
         setWorkingDirectory(workingDirectory);

--- a/editors/sc-ide/forms/settings_sclang.ui
+++ b/editors/sc-ide/forms/settings_sclang.ui
@@ -213,11 +213,22 @@
        </widget>
       </item>
       <item row="4" column="1">
-       <widget class="QCheckBox" name="sclang_post_inline_warnings">
-        <property name="text">
-         <string>Post Inline Warnings</string>
-        </property>
-       </widget>
+       <layout class="QHBoxLayout" name="interpreter_options">
+        <item>
+         <widget class="QCheckBox" name="sclang_post_inline_warnings">
+          <property name="text">
+           <string>Post Inline Warnings</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QCheckBox" name="sclang_standalone_mode">
+          <property name="text">
+           <string>Exclude default search paths</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
       </item>
      </layout>
     </widget>

--- a/editors/sc-ide/widgets/settings/sclang_page.cpp
+++ b/editors/sc-ide/widgets/settings/sclang_page.cpp
@@ -76,6 +76,7 @@ void SclangPage::load( Manager *s )
 
     ui->autoStart->setChecked( s->value("autoStart").toBool() );
     ui->runtimeDir->setText( s->value("runtimeDir").toString() );
+    ui->sclang_standalone_mode->setChecked(s->value("standalone").toBool());
 
     QStringList availConfigFiles = availableLanguageConfigFiles();
     QString configSelectedLanguageConfigFile = s->value("configFile").toString();
@@ -98,6 +99,7 @@ void SclangPage::store( Manager *s )
     s->setValue("autoStart", ui->autoStart->isChecked());
     s->setValue("runtimeDir", ui->runtimeDir->text());
     s->setValue("configFile", ui->activeConfigFileComboBox->currentText());
+    s->setValue("standalone", ui->sclang_standalone_mode->isChecked());
     s->endGroup();
 
     writeLanguageConfig();


### PR DESCRIPTION
This can be useful for debugging purposes, or for devs that want to use the class library of the git local copy (would superseed the symlink option of cmake).