### PR TITLE
Improved documentation for copyRange and copySeries

### DIFF
--- a/HelpSource/Classes/ArrayedCollection.schelp
+++ b/HelpSource/Classes/ArrayedCollection.schelp
@@ -284,8 +284,7 @@ code::
 ::
 
 method::copyRange
-Return a new ArrayedCollection which is a copy of the indexed slots of the receiver from strong::start:: to strong::end::.
-code::x.copyRange(a, b):: can also be written as code::x[a..b]::
+Return a new ArrayedCollection which is a copy of the indexed slots of the receiver from strong::start:: to strong::end::. If strong::end:: < strong::start::, an empty ArrayedCollection is returned.
 code::
 (
 var y, z;
@@ -295,10 +294,13 @@ z.postln;
 y.postln;
 )
 ::
+warning:: code::x.copyRange(a, b):: is strong::not:: equivalent to code::x[a..b]::. The latter compiles to link::#-copySeries::, which has different behavior when strong::end:: < strong::start::. ::
 
 method::copySeries
-Return a new ArrayedCollection consisting of the values starting at strong::first::, then every step of the distance between strong::first:: and strong::second::, up until strong::last::.
-code::x.copySeries(a, b, c):: can also be written as code::x[a, b..c]::
+Return a new ArrayedCollection consisting of the values starting at strong::first::, then every step of the distance between strong::first:: and strong::second::, up until strong::last::. If strong::second:: is code::nil::, a step of 1 or -1 is used as appropriate.
+
+code::x.copySeries(a, nil, c):: is equivalent to code::x[a..c]::, and code::x.copySeries(a, b, c):: is equivalent to code::x[a,b..c]::
+
 code::
 (
 var y, z;

--- a/HelpSource/Classes/SequenceableCollection.schelp
+++ b/HelpSource/Classes/SequenceableCollection.schelp
@@ -208,8 +208,7 @@ x = [2, 5, 6].blendAt(0.4);
 ::
 
 method::copyRange
-Return a new SequenceableCollection which is a copy of the indexed slots of the receiver from strong::start:: to strong::end::.
-code::x.copyRange(a, b):: can also be written as code::x[a..b]::
+Return a new SequenceableCollection which is a copy of the indexed slots of the receiver from strong::start:: to strong::end::. If strong::end:: < strong::start::, an empty collection is returned.
 code::
 (
 var y, z;
@@ -219,6 +218,7 @@ z.postln;
 y.postln;
 )
 ::
+warning:: code::x.copyRange(a, b):: is strong::not:: equivalent to code::x[a..b]::. The latter compiles to link::Classes/ArrayedCollection#-copySeries::, which has different behavior when strong::end:: < strong::start::. ::
 
 method::copyToEnd
 Return a new SequenceableCollection which is a copy of the indexed slots of the receiver from strong::start:: to the end of the collection.


### PR DESCRIPTION
Corrected errors saying that `x[a..b]` is equivalent to `copyRange`, and added warnings explicitly describing the differences between copyRange and copySeries.