### PR TITLE
build: use direct test to decide if SSE available

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,11 +115,18 @@ option(FINAL_BUILD "Build as single source file." OFF)
 
 option(FFT_GREEN "Use internal 'Green' FFT lib rather than FFTW. (Not recommended.)" OFF)
 
-if(NOT ${CMAKE_SYSTEM_PROCESSOR} MATCHES "^arm")
+include (${CMAKE_ROOT}/Modules/CheckCXXCompilerFlag.cmake)
+CHECK_CXX_COMPILER_FLAG(-msse HAS_CXX_SSE)
+if (HAS_CXX_SSE)
     option(SSE "Compile with support for SSE instructions." ON)
-    option(SSE2 "Compile with support for SSE2 instructions." ON)
-else() # ARM platforms do not have SSE
+else()
     set(SSE OFF)
+endif()
+
+CHECK_CXX_COMPILER_FLAG(-msse2 HAS_CXX_SSE2)
+if (HAS_CXX_SSE2)
+    option(SSE2 "Compile with support for SSE2 instructions." ON)
+else()
     set(SSE2 OFF)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,7 +115,7 @@ option(FINAL_BUILD "Build as single source file." OFF)
 
 option(FFT_GREEN "Use internal 'Green' FFT lib rather than FFTW. (Not recommended.)" OFF)
 
-include (${CMAKE_ROOT}/Modules/CheckCXXCompilerFlag.cmake)
+include (CheckCXXCompilerFlag)
 CHECK_CXX_COMPILER_FLAG(-msse HAS_CXX_SSE)
 if (HAS_CXX_SSE)
     option(SSE "Compile with support for SSE instructions." ON)


### PR DESCRIPTION
Use direct test to decide if SSE available, rather than guessing from the CPU name. As recommended for the sc3-plugins project at: https://github.com/supercollider/sc3-plugins/pull/73