### PR TITLE
Quarks: fix save method

### DIFF
--- a/SCClassLibrary/Common/Quarks/Quarks.sc
+++ b/SCClassLibrary/Common/Quarks/Quarks.sc
@@ -115,7 +115,7 @@ Quarks {
 		dir = path.dirname;
 		lines = this.installed.collect({ |quark|
 			var localPath, url="", refspec;
-			localPath = this.asRelativePath(quark.localPath);
+			localPath = this.asRelativePath(quark.localPath, dir);
 			if(Git.isGit(quark.localPath), {
 				url = quark.url;
 				if(Git(quark.localPath).isDirty, {
@@ -395,7 +395,7 @@ Quarks {
 	*asRelativePath { |path, relativeToDir|
 		var d;
 		if(path.beginsWith(relativeToDir), {
-			^"." ++ path.copyToEnd(relativeToDir)
+			^"." ++ path.copyToEnd(relativeToDir.size)
 		});
 		d = Platform.userHomeDir;
 		// ~/path if in home


### PR DESCRIPTION
Update call to *asRelativePath to include dirname of file. Also fix a bug in *asRelativePath.