### PR TITLE
sclang: Fix to get Object: render to work on Windows

### DIFF
--- a/SCClassLibrary/Common/Control/asScore/asScore.sc
+++ b/SCClassLibrary/Common/Control/asScore/asScore.sc
@@ -18,7 +18,7 @@
 		score = this.asScore(maxTime);
 		score.recordNRT(
 			oscFilePath, path, inputFilePath, sampleRate, headerFormat, sampleFormat,
-			options, "; rm" + oscFilePath, action: action;
+			options, "", action: {File.delete(oscFilePath)}.addFunc(action);
 		);
 	}
 


### PR DESCRIPTION
Due to reliance on "rm" command for oscfile removal invocations of Object: render such as the one below threw an error on Windows.

Pbind(\instrument, \default).render(thisProcess.platform.recordingsDir +/+ "test.aif", 1)

The error you get on Windows is "ERROR: Invalid option ;" thrown from scsynth.exe.

I propose to rely on File.delete instead of "rm".