### PR TITLE
Add custom.css to help files that don't include it

### DIFF
--- a/HelpSource/BrokenLink.html
+++ b/HelpSource/BrokenLink.html
@@ -2,6 +2,7 @@
 <head>
     <title>Broken link</title>
     <link rel='stylesheet' href='./scdoc.css' type='text/css' />
+    <link rel='stylesheet' href='./custom.css' type='text/css' />
     <meta http-equiv='Content-Type' content='text/html; charset=UTF-8' />
 <noscript>
 <p>Sorry, that link was broken..

--- a/HelpSource/Browse.html
+++ b/HelpSource/Browse.html
@@ -2,6 +2,7 @@
 <head>
     <title>Document Browser</title>
     <link rel='stylesheet' href='./scdoc.css' type='text/css' />
+    <link rel='stylesheet' href='./custom.css' type='text/css' />
     <meta http-equiv='Content-Type' content='text/html; charset=UTF-8' />
     <script src="docmap.js" type="text/javascript"></script>
     <script src="scdoc.js" type="text/javascript"></script>

--- a/HelpSource/OldHelpWrapper.html
+++ b/HelpSource/OldHelpWrapper.html
@@ -2,6 +2,7 @@
 <head>
 <title>Old Help</title>
     <link rel='stylesheet' href='./scdoc.css' type='text/css' />
+    <link rel='stylesheet' href='./custom.css' type='text/css' />
     <meta http-equiv='Content-Type' content='text/html; charset=UTF-8' />
     <script src="scdoc.js" type="text/javascript"></script>
 <style>

--- a/HelpSource/Overviews/Classes.html
+++ b/HelpSource/Overviews/Classes.html
@@ -2,6 +2,7 @@
 <head>
     <title>Classes</title>
     <link rel='stylesheet' href='../scdoc.css' type='text/css' />
+    <link rel='stylesheet' href='../custom.css' type='text/css' />
     <meta http-equiv='Content-Type' content='text/html; charset=UTF-8' />
     <script src="../docmap.js" type="text/javascript"></script>
     <script src="../scdoc.js" type="text/javascript"></script>

--- a/HelpSource/Overviews/Documents.html
+++ b/HelpSource/Overviews/Documents.html
@@ -2,6 +2,7 @@
 <head>
     <title>Documents</title>
     <link rel='stylesheet' href='../scdoc.css' type='text/css' />
+    <link rel='stylesheet' href='../custom.css' type='text/css' />
     <meta http-equiv='Content-Type' content='text/html; charset=UTF-8' />
     <script src="../docmap.js" type="text/javascript"></script>
     <script src="../scdoc.js" type="text/javascript"></script>

--- a/HelpSource/Overviews/Methods.html
+++ b/HelpSource/Overviews/Methods.html
@@ -2,6 +2,7 @@
 <head>
     <title>Methods</title>
     <link rel='stylesheet' href='../scdoc.css' type='text/css' />
+    <link rel='stylesheet' href='../custom.css' type='text/css' />
     <meta http-equiv='Content-Type' content='text/html; charset=UTF-8' />
     <script src="../docmap.js" type="text/javascript"></script>
     <script src="../scdoc.js" type="text/javascript"></script>

--- a/HelpSource/Search.html
+++ b/HelpSource/Search.html
@@ -2,6 +2,7 @@
 <head>
     <title>Search</title>
     <link rel='stylesheet' href='./scdoc.css' type='text/css' />
+    <link rel='stylesheet' href='./custom.css' type='text/css' />
     <meta http-equiv='Content-Type' content='text/html; charset=UTF-8' />
     <script src="docmap.js" type="text/javascript"></script>
     <script src="scdoc.js" type="text/javascript"></script>

--- a/HelpSource/syntax_colors.html
+++ b/HelpSource/syntax_colors.html
@@ -2,6 +2,7 @@
 <head>
     <title>SCDoc syntax color test</title>
     <link rel='stylesheet' href='./scdoc.css' type='text/css' />
+    <link rel='stylesheet' href='./custom.css' type='text/css' />
     <meta http-equiv='Content-Type' content='text/html; charset=UTF-8' />
     <script src="prettify.js" type="text/javascript"></script>
     <script src="lang-sc.js" type="text/javascript"></script>


### PR DESCRIPTION
Some static HTML help files include scdoc.css but not custom.css. This corrects them.