### PR TITLE
class library: don't declare variables in an if statement, please.

### DIFF
--- a/SCClassLibrary/Common/Collections/SequenceableCollection.sc
+++ b/SCClassLibrary/Common/Collections/SequenceableCollection.sc
@@ -1302,13 +1302,13 @@ SequenceableCollection : Collection {
 	}
 
 	unixCmd { arg action, postOutput = true;
-		if(this.notEmpty){
-			var pid;
+		var pid;
+		if(this.notEmpty) {
 			pid = this.prUnixCmd(postOutput);
 			if(action.notNil) {
 				String.unixCmdActions.put(pid, action);
 			};
-			^pid;
+			^pid
 		} {
 			Error("Collection should have at least the filepath of the program to run.").throw
 		}


### PR DESCRIPTION
In the class library, variable declarations should always happen
outside statements that can be inlined, like `if` or `while`.
Developers should have switched on the interpreter preference “Post
Inline Warnings”.

I think the preference default should be `on`, to avoid such issues.