### PR TITLE
Change title of main help file from "Help" to "SuperCollider [version]"

### DIFF
--- a/SCClassLibrary/SCDoc/SCDocRenderer.sc
+++ b/SCClassLibrary/SCDoc/SCDocRenderer.sc
@@ -146,9 +146,12 @@ SCDocHTMLRenderer {
             << "</div>\n";
         };
 
-        stream << "<h1>" << doc.title;
+        stream << "<h1>";
         if((folder=="") and: {doc.title=="Help"}) {
+            stream << "SuperCollider " << Main.version;
             stream << "<span class='headerimage'><img src='" << baseDir << "/images/SC_icon.png'/></span>";
+        } {
+            stream << doc.title;
         };
         stream
         << "</h1>\n"


### PR DESCRIPTION
This title is the most prominent text that appears on the screen when launching scide. Having it say "Help" looks rather unprofessional.