### PR TITLE
Makes Vim support more reliable by sending larger buffers

### DIFF
--- a/editors/scvim/ftplugin/supercollider.vim
+++ b/editors/scvim/ftplugin/supercollider.vim
@@ -235,10 +235,13 @@ function SendLineToSC(linenum)
   "silent exe cmd
 endfunction
 
+let s:trackoflines = ""
+
 function! SClang_send()
-  let cmd = ".w! >> " . s:sclangPipeLoc
-  exe cmd
+  let s:trackoflines .= getline(".") . "\n"
   if line(".") == a:lastline
+    call SendToSC(s:trackoflines)
+    let s:trackoflines = ""
     call SendToSC('')
     "redraw!
   endif


### PR DESCRIPTION
The Vim plugin was practically unusable before, throwing errors occasionally because it was sending everything to sclang line by line. The simple fix here fixes such problems. I have tested it for a few days. Big difference in experience.