### PR TITLE
Do not allocate all channels reported by Pa_GetDeviceInfo / use memcpy instead of for-loop

### DIFF
--- a/server/scsynth/SC_PortAudio.cpp
+++ b/server/scsynth/SC_PortAudio.cpp
@@ -228,7 +228,7 @@ int SC_PortAudioDriver::PortAudioCallback( const void *input, void *output,
 			{
 				const float *src = inBuffers[k] + bufFramePos;
 				float *dst = inBuses + k * bufFrames;
-				for (int n = 0; n < bufFrames; ++n) *dst++ = *src++;
+				memcpy(dst, src, bufFrames*sizeof(float));
 				*tch++ = bufCounter;
 			}
 
@@ -264,10 +264,10 @@ int SC_PortAudioDriver::PortAudioCallback( const void *input, void *output,
 			for (int k = 0; k < mOutputChannelCount; ++k) {
 				float *dst = outBuffers[k] + bufFramePos;
 				if (*tch++ == bufCounter) {
-					float *src = outBuses + k * bufFrames;
-					for (int n = 0; n < bufFrames; ++n) *dst++ = *src++;
+					const float *src = outBuses + k * bufFrames;
+					memcpy(dst, src, bufFrames*sizeof(float));
 				} else {
-					for (int n = 0; n < bufFrames; ++n) *dst++ = 0.0f;
+					memset(dst, 0, bufFrames*sizeof(float));
 				}
 			}
 

--- a/server/scsynth/SC_PortAudio.cpp
+++ b/server/scsynth/SC_PortAudio.cpp
@@ -192,8 +192,6 @@ int SC_PortAudioDriver::PortAudioCallback( const void *input, void *output,
 		mToEngine.Perform();
 		mOscPacketsToEngine.Perform();
 
-		int numInputs = mInputChannelCount;
-		int numOutputs = mOutputChannelCount;
 		const float **inBuffers = (const float**)input;
 		float **outBuffers = (float**)output;
 
@@ -205,9 +203,6 @@ int SC_PortAudioDriver::PortAudioCallback( const void *input, void *output,
 		float *outBuses = mWorld->mAudioBus;
 		int32 *inTouched = mWorld->mAudioBusTouched + mWorld->mNumOutputs;
 		int32 *outTouched = mWorld->mAudioBusTouched;
-
-		int minInputs = std::min<size_t>(numInputs, mWorld->mNumInputs);
-		int minOutputs = std::min<size_t>(numOutputs, mWorld->mNumOutputs);
 
 		int bufFramePos = 0;
 #ifdef SC_PA_USE_DLL
@@ -229,7 +224,7 @@ int SC_PortAudioDriver::PortAudioCallback( const void *input, void *output,
 
 			// copy+touch inputs
 			tch = inTouched;
-			for (int k = 0; k < minInputs; ++k)
+			for (int k = 0; k < mInputChannelCount; ++k)
 			{
 				const float *src = inBuffers[k] + bufFramePos;
 				float *dst = inBuses + k * bufFrames;
@@ -260,13 +255,13 @@ int SC_PortAudioDriver::PortAudioCallback( const void *input, void *output,
 				event.Perform();
 			}
 			world->mSampleOffset = 0;
-			world->mSubsampleOffset = 0.f;
+			world->mSubsampleOffset = 0.0f;
 
 			World_Run(world);
 
 			// copy touched outputs
 			tch = outTouched;
-			for (int k = 0; k < minOutputs; ++k) {
+			for (int k = 0; k < mOutputChannelCount; ++k) {
 				float *dst = outBuffers[k] + bufFramePos;
 				if (*tch++ == bufCounter) {
 					float *src = outBuses + k * bufFrames;
@@ -340,7 +335,7 @@ bool SC_PortAudioDriver::DriverSetup(int* outNumSamples, double* outSampleRate)
 	for( int i=0; i<numDevices; i++ ) {
 		pdi = Pa_GetDeviceInfo( i );
 		apiInfo = Pa_GetHostApiInfo(pdi->hostApi);
-		fprintf(stdout, "  - %s : %s   (device #%d with %d ins %d outs)\n",apiInfo->name,pdi->name, i, pdi->maxInputChannels, pdi->maxOutputChannels);
+		fprintf(stdout, "  - %s : %s   (device #%d with %d ins %d outs)\n", apiInfo->name,pdi->name, i, pdi->maxInputChannels, pdi->maxOutputChannels);
 	}
 
 	mDeviceInOut[0] = paNoDevice;
@@ -372,8 +367,9 @@ bool SC_PortAudioDriver::DriverSetup(int* outNumSamples, double* outSampleRate)
 		fprintf(stdout, "\nBooting with:\n");
 		PaSampleFormat fmt = paFloat32 | paNonInterleaved;
 		if (mDeviceInOut[0]!=paNoDevice){
-			mInputChannelCount = Pa_GetDeviceInfo( mDeviceInOut[0] )->maxInputChannels;
-			fprintf(stdout, "  In: %s : %s \n",
+			// avoid to allocate the 128 virtual channels reported by the portaudio library for ALSA "default"
+			mInputChannelCount = std::min<size_t>(mWorld->mNumInputs, Pa_GetDeviceInfo( mDeviceInOut[0] )->maxInputChannels);
+			fprintf(stdout, "  In: %s : %s\n",
 			Pa_GetHostApiInfo(Pa_GetDeviceInfo( mDeviceInOut[0] )->hostApi)->name,
 			Pa_GetDeviceInfo( mDeviceInOut[0] )->name);
 		}else{
@@ -381,8 +377,9 @@ bool SC_PortAudioDriver::DriverSetup(int* outNumSamples, double* outSampleRate)
 		}
 
 		if (mDeviceInOut[1]!=paNoDevice){
-			mOutputChannelCount = Pa_GetDeviceInfo( mDeviceInOut[1] )->maxOutputChannels;
-			fprintf(stdout, "  Out: %s : %s \n",
+			// avoid to allocate the 128 virtual channels reported by the portaudio library for ALSA "default"
+			mOutputChannelCount =  std::min<size_t>(mWorld->mNumOutputs, Pa_GetDeviceInfo( mDeviceInOut[1] )->maxOutputChannels);
+			fprintf(stdout, "  Out: %s : %s\n",
 			Pa_GetHostApiInfo(Pa_GetDeviceInfo( mDeviceInOut[1] )->hostApi)->name,
 			Pa_GetDeviceInfo( mDeviceInOut[1] )->name);
 		}else{

--- a/server/scsynth/SC_PortAudio.cpp
+++ b/server/scsynth/SC_PortAudio.cpp
@@ -228,7 +228,7 @@ int SC_PortAudioDriver::PortAudioCallback( const void *input, void *output,
 			{
 				const float *src = inBuffers[k] + bufFramePos;
 				float *dst = inBuses + k * bufFrames;
-				memcpy(dst, src, bufFrames*sizeof(float));
+				memcpy(dst, src, bufFrames * sizeof(float));
 				*tch++ = bufCounter;
 			}
 
@@ -265,9 +265,9 @@ int SC_PortAudioDriver::PortAudioCallback( const void *input, void *output,
 				float *dst = outBuffers[k] + bufFramePos;
 				if (*tch++ == bufCounter) {
 					const float *src = outBuses + k * bufFrames;
-					memcpy(dst, src, bufFrames*sizeof(float));
+					memcpy(dst, src, bufFrames * sizeof(float));
 				} else {
-					memset(dst, 0, bufFrames*sizeof(float));
+					memset(dst, 0, bufFrames * sizeof(float));
 				}
 			}
 


### PR DESCRIPTION
On Linux, SuperCollider's PortAudio driver talks to ALSA (or to PulseAudio using PulseAudio's ALSA compatibility layer).

By default, the current audio driver will use the `default` audio device and [allocate *all* channels](https://github.com/supercollider/supercollider/blob/c017920b29d3fb76b230c14411c46be39b04e9f3/server/scsynth/SC_PortAudio.cpp#L418) reported back by `Pa_GetDeviceInfo()`.

On pure ALSA, the `default` device reports 128 in/out channels.
On PulseAudio, it reports 32 in/out channels.

It isn't necessary to allocate all channels, the application only needs to request the number of channels it actually uses. I didn't find a good explanation for why PortAudio reports these many virtual channels, but [this mailing list thread](http://music.columbia.edu/pipermail/portaudio/2014-February/015820.html) basically boils down to "don't worry, it's an artefact of the ALSA API and you're fine with simply allocating the number of channels you need and not more".

So that's what this patch does.

Also, both src and dst are float, so we can use memcpy/memset.

I tested this on XUbuntu 15.10 and there was no change in behaviour compared to the current git version. (Both the current git version and my patched version do not work with pure ALSA, but do work with PulseAudio. I will file a separate issue #1944 for debugging that.)

This will require testing. @sonoro1234 - could you please have a look?