### PR TITLE
fix #1895 : update Quark by `git pull` and `git checkout master`

### DIFF
--- a/SCClassLibrary/Common/Quarks/Git.sc
+++ b/SCClassLibrary/Common/Quarks/Git.sc
@@ -18,7 +18,7 @@ Git {
 		this.url = url;
 	}
 	pull {
-		this.git(["pull"])
+		this.git(["pull", "origin", "master"])
 	}
 	checkout { |refspec|
 		this.git(["checkout", refspec])

--- a/SCClassLibrary/Common/Quarks/Quark.sc
+++ b/SCClassLibrary/Common/Quarks/Quark.sc
@@ -82,6 +82,18 @@ Quark {
 		data = nil;
 		^success
 	}
+	update {
+		if(Git.isGit(localPath), {
+			data = git = refspec = nil;
+			changed = true;
+			git = Git(localPath);
+			git.pull();
+			git.checkout("master");
+			("Quark '%' updated to version: % tag: % refspec: %".format(name, this.version, this.git.tag, this.refspec)).inform;
+		}, {
+			("Quark" + name + "was not installed using git, cannot update.").warn;
+		});
+	}
 	uninstall {
 		Quarks.uninstallQuark(this);
 		changed = true;

--- a/SCClassLibrary/Common/Quarks/Quarks.sc
+++ b/SCClassLibrary/Common/Quarks/Quarks.sc
@@ -141,9 +141,9 @@ Quarks {
 		// by quark name or by supplying a local path
 		// resolving / ~/ ./
 		// is it a git
-		var localPath = this.quarkNameAsLocalPath(name);
+		var quark, localPath = this.quarkNameAsLocalPath(name);
 		if(Git.isGit(localPath), {
-			Git(localPath).pull;
+			Quark.fromLocalPath(localPath).update();
 		}, {
 			("Quark" + name + "was not installed using git, cannot update.").warn;
 		});


### PR DESCRIPTION
Even though it was doing git pull, it would not have repositioned to the tip if you had for any reason checked out a different tip (detached HEAD). This has to assume that master is the only branch where the latest update can be found. 

If somebody needs to specify a different branch then they need to do release with tags and check it out by tag.