### PR TITLE
Add cmake options list to READMEs

### DIFF
--- a/README_LINUX.md
+++ b/README_LINUX.md
@@ -112,6 +112,8 @@ builds in a specific build directory:
    $> cmake -DCMAKE_PREFIX_PATH=/path/to/qt5 ..
    ```
 
+   You can see the available build options with ```cmake -LH```.
+
  - to run the build process run:
 
    ```

--- a/README_LINUX.md
+++ b/README_LINUX.md
@@ -112,9 +112,6 @@ builds in a specific build directory:
    $> cmake -DCMAKE_PREFIX_PATH=/path/to/qt5 ..
    ```
 
-   The available cmake configuration options can be found in the "Options"
-   section of CMakeLists.txt
-
  - to run the build process run:
 
    ```

--- a/README_LINUX.md
+++ b/README_LINUX.md
@@ -112,6 +112,9 @@ builds in a specific build directory:
    $> cmake -DCMAKE_PREFIX_PATH=/path/to/qt5 ..
    ```
 
+   The available cmake configuration options can be found in the "Options"
+   section of CMakeLists.txt
+
  - to run the build process run:
 
    ```

--- a/README_OS_X.md
+++ b/README_OS_X.md
@@ -77,8 +77,6 @@ Build instructions
 
 If successful this will build the application into `build/Install/SuperCollider/`
 
-The available cmake configuration options can be found in the "Options" section of CMakeLists.txt
-
 To install, you may move this to /Applications or use it in place from the build directory.
 
 **Note**: You can also open the produced SuperCollider.xcodeproj in Xcode, and build the "Install" scheme in place of the last step. Do make sure you run the previous configuration steps.

--- a/README_OS_X.md
+++ b/README_OS_X.md
@@ -77,6 +77,8 @@ Build instructions
 
 If successful this will build the application into `build/Install/SuperCollider/`
 
+You can see the available build options with ```cmake -LH```.
+
 To install, you may move this to /Applications or use it in place from the build directory.
 
 **Note**: You can also open the produced SuperCollider.xcodeproj in Xcode, and build the "Install" scheme in place of the last step. Do make sure you run the previous configuration steps.

--- a/README_OS_X.md
+++ b/README_OS_X.md
@@ -77,6 +77,8 @@ Build instructions
 
 If successful this will build the application into `build/Install/SuperCollider/`
 
+The available cmake configuration options can be found in the "Options" section of CMakeLists.txt
+
 To install, you may move this to /Applications or use it in place from the build directory.
 
 **Note**: You can also open the produced SuperCollider.xcodeproj in Xcode, and build the "Install" scheme in place of the last step. Do make sure you run the previous configuration steps.

--- a/README_WINDOWS.md
+++ b/README_WINDOWS.md
@@ -466,8 +466,6 @@ If you want to add `supernova`, add `-DSUPERNOVA=ON`
 
       $> cmake -DSUPERNOVA=ON ..
 
-You can see the available build options with ```cmake -LH```.
-
 Remains the actual `build`. We can also use `cmake`, the following command works
 on all platforms with all generators:
 

--- a/README_WINDOWS.md
+++ b/README_WINDOWS.md
@@ -466,6 +466,8 @@ If you want to add `supernova`, add `-DSUPERNOVA=ON`
 
       $> cmake -DSUPERNOVA=ON ..
 
+The available cmake configuration options can be found in the "Options" section of CMakeLists.txt
+
 Remains the actual `build`. We can also use `cmake`, the following command works
 on all platforms with all generators:
 

--- a/README_WINDOWS.md
+++ b/README_WINDOWS.md
@@ -466,8 +466,6 @@ If you want to add `supernova`, add `-DSUPERNOVA=ON`
 
       $> cmake -DSUPERNOVA=ON ..
 
-The available cmake configuration options can be found in the "Options" section of CMakeLists.txt
-
 Remains the actual `build`. We can also use `cmake`, the following command works
 on all platforms with all generators:
 

--- a/README_WINDOWS.md
+++ b/README_WINDOWS.md
@@ -466,6 +466,8 @@ If you want to add `supernova`, add `-DSUPERNOVA=ON`
 
       $> cmake -DSUPERNOVA=ON ..
 
+You can see the available build options with ```cmake -LH```.
+
 Remains the actual `build`. We can also use `cmake`, the following command works
 on all platforms with all generators:
 


### PR DESCRIPTION
It can be hard to find the list of possible CMake build options; now it's in the README.