### PR TITLE
SuperCollider projects

### DIFF
--- a/SCClassLibrary/Common/Core/LanguageConfig.sc
+++ b/SCClassLibrary/Common/Core/LanguageConfig.sc
@@ -8,8 +8,32 @@ LanguageConfig {
 		_LanguageConfig_getCurrentConfigPath
 	}
 
+	*currentDirectory {
+		_LanguageConfig_getCurrentConfigDirectory
+		^this.primitiveFailed
+	}
+
+	*prMakeAbsoluteToProjectRoot { |paths|
+		var root;
+		^if( LanguageConfig.projectOpen ) {
+			root = this.currentDirectory;
+			paths.collect{ |p|
+				if( PathName(p).isRelativePath ) {
+					root +/+ p
+				} {
+					p
+				}
+			}
+		} {
+			paths
+		}
+	}
+
 	*includePaths {
 		_LanguageConfig_getIncludePaths
+	}
+	*includePathsAbsolute {
+		^this.prMakeAbsoluteToProjectRoot(this.includePaths)
 	}
 	*addIncludePath {|aPath|
 		_LanguageConfig_addIncludePath
@@ -22,6 +46,9 @@ LanguageConfig {
 
 	*excludePaths {
 		_LanguageConfig_getExcludePaths
+	}
+	*excludePathsAbsolute {
+		^this.prMakeAbsoluteToProjectRoot(this.excludePaths)
 	}
 	*addExcludePath {|aPath|
 		_LanguageConfig_addExcludePath
@@ -37,6 +64,16 @@ LanguageConfig {
 	}
 	*postInlineWarnings_ {|aBoolean|
 		_LanguageConfig_setPostInlineWarnings
+		^this.primitiveFailed
+	}
+
+	*projectOpen {
+		_LanguageConfig_getProjectOpen
+		^this.primitiveFailed
+	}
+
+	*defaultPathsExcluded {
+		_LanguageConfig_getExcludeDefaultPaths
 		^this.primitiveFailed
 	}
 }

--- a/SCClassLibrary/Common/Quarks/Quarks.sc
+++ b/SCClassLibrary/Common/Quarks/Quarks.sc
@@ -149,12 +149,12 @@ Quarks {
 		});
 	}
 	*installed {
-		^LanguageConfig.includePaths
+		^LanguageConfig.includePathsAbsolute
 			.collect(Quark.fromLocalPath(_))
 	}
 	*installedPaths {
 		^installedPaths ?? {
-			installedPaths = LanguageConfig.includePaths.collect({ |apath|
+			installedPaths = LanguageConfig.includePathsAbsolute.collect({ |apath|
 				apath.withoutTrailingSlash
 			});
 		}
@@ -212,7 +212,7 @@ Quarks {
 
 	*link { |path|
 		path = path.withoutTrailingSlash;
-		if(LanguageConfig.includePaths.includesEqual(path).not, {
+		if(LanguageConfig.includePathsAbsolute.includesEqual(path).not, {
 			path.debug("Adding path");
 			LanguageConfig.addIncludePath(path);
 			LanguageConfig.store(LanguageConfig.currentPath);
@@ -223,7 +223,7 @@ Quarks {
 	}
 	*unlink { |path|
 		path = path.withoutTrailingSlash;
-		if(LanguageConfig.includePaths.includesEqual(path), {
+		if(LanguageConfig.includePathsAbsolute.includesEqual(path), {
 			path.debug("Removing path");
 			LanguageConfig.removeIncludePath(path);
 			LanguageConfig.store(LanguageConfig.currentPath);
@@ -234,7 +234,9 @@ Quarks {
 	}
 
 	*initClass {
-		folder = Platform.userAppSupportDir +/+ "downloaded-quarks";
+		folder = if(LanguageConfig.projectOpen){
+			LanguageConfig.currentDirectory
+		}{ Platform.userAppSupportDir } +/+ "downloaded-quarks";
 		additionalFolders = additionalFolders ? [];
 		if(File.exists(folder).not, {
 			folder.mkdir();
@@ -302,7 +304,7 @@ Quarks {
 		additionalFolders.do({ |folder|
 			(folder +/+ "*").pathMatch.do(f);
 		});
-		LanguageConfig.includePaths.do(f);
+		LanguageConfig.includePathsAbsolute.do(f);
 		^all.values
 	}
 	*fetchDirectory { |force=true|

--- a/SCClassLibrary/Platform/Platform.sc
+++ b/SCClassLibrary/Platform/Platform.sc
@@ -91,9 +91,12 @@ Platform {
 		}
 	}
 
-	loadStartupFiles { this.startupFiles.do{|afile|
-		afile = afile.standardizePath;
-		if(File.exists(afile), {afile.load})
+	loadStartupFiles {
+		if (LanguageConfig.defaultPathsExcluded.not) {
+			this.startupFiles.do{|afile|
+				afile = afile.standardizePath;
+				if(File.exists(afile), {afile.load})
+			}
 		}
 	}
 

--- a/editors/sc-ide/CMakeLists.txt
+++ b/editors/sc-ide/CMakeLists.txt
@@ -89,6 +89,7 @@ set ( ide_moc_hdr
     widgets/settings/dialog.hpp
     widgets/settings/general_page.hpp
     widgets/settings/sclang_page.hpp
+    widgets/settings/sclang_project_page.hpp
     widgets/settings/editor_page.hpp
     widgets/settings/shortcuts_page.hpp
     widgets/util/path_chooser_widget.hpp
@@ -141,6 +142,7 @@ set ( ide_src
     widgets/settings/dialog.cpp
     widgets/settings/general_page.cpp
     widgets/settings/sclang_page.cpp
+    widgets/settings/sclang_project_page.cpp
     widgets/settings/editor_page.cpp
     widgets/settings/shortcuts_page.cpp
     widgets/util/gui_utilities.cpp
@@ -164,6 +166,7 @@ set( ide_forms
     forms/settings_dialog.ui
     forms/settings_general.ui
     forms/settings_sclang.ui
+    forms/settings_sclang_project.ui
     forms/settings_editor.ui
     forms/settings_shortcuts.ui
 )

--- a/editors/sc-ide/core/sc_process.cpp
+++ b/editors/sc-ide/core/sc_process.cpp
@@ -114,6 +114,11 @@ void ScProcess::updateToggleRunningAction()
     mActions[ToggleRunning]->setShortcut( targetAction->shortcut() );
 }
 
+bool ScProcess::running()
+{
+    return state() == QProcess::Running;
+}
+
 void ScProcess::toggleRunning()
 {
     switch(state()) {
@@ -152,8 +157,6 @@ void ScProcess::startLanguage (void)
     if(!configFile.isEmpty())
         sclangArguments << "-l" << configFile;
     sclangArguments << "-i" << "scqt";
-    if(standalone)
-        sclangArguments << "-a";
 
     if(!workingDirectory.isEmpty())
         setWorkingDirectory(workingDirectory);

--- a/editors/sc-ide/core/sc_process.hpp
+++ b/editors/sc-ide/core/sc_process.hpp
@@ -82,6 +82,7 @@ public:
     void updateSelectionMirrorForDocument ( class Document * doc, int start, int range);
 
 public slots:
+    bool running();
     void toggleRunning();
     void startLanguage (void);
     void stopLanguage (void);

--- a/editors/sc-ide/forms/settings_sclang_project.ui
+++ b/editors/sc-ide/forms/settings_sclang_project.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
- <class>SclangConfigPage</class>
- <widget class="QWidget" name="SclangConfigPage">
+ <class>SclangProjectConfigPage</class>
+ <widget class="QWidget" name="SclangProjectConfigPage">
   <property name="geometry">
    <rect>
     <x>0</x>
@@ -37,55 +37,12 @@
       <item row="1" column="1">
        <widget class="ScIDE::PathChooserWidget" name="runtimeDir"/>
       </item>
-      <item row="2" column="0">
+      <item row="2" column="0" colspan="2">
        <widget class="QLabel" name="activeConfigFileLabel">
         <property name="text">
-         <string>Active config file:</string>
+         <string>Current Project:</string>
         </property>
        </widget>
-      </item>
-      <item row="2" column="1">
-       <layout class="QHBoxLayout" name="horizontalLayout">
-        <item>
-         <widget class="QComboBox" name="activeConfigFileComboBox">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QToolButton" name="sclang_add_configfile">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="toolTip">
-           <string>Save a new config file</string>
-          </property>
-          <property name="text">
-           <string>+</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QToolButton" name="sclang_remove_configfile">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="text">
-           <string>-</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
       </item>
      </layout>
     </widget>
@@ -102,7 +59,7 @@
       </sizepolicy>
      </property>
      <property name="title">
-      <string>Interpreter Options (stored in current active config file)</string>
+      <string>Interpreter Options (stored in current project file)</string>
      </property>
      <property name="flat">
       <bool>false</bool>
@@ -213,7 +170,7 @@
        </widget>
       </item>
       <item row="4" column="1">
-       <layout class="QHBoxLayout" name="interpreter_options">
+       <layout class="QHBoxLayout" name="horizontalLayout_2">
         <item>
          <widget class="QCheckBox" name="sclang_post_inline_warnings">
           <property name="text">

--- a/editors/sc-ide/widgets/main_window.hpp
+++ b/editors/sc-ide/widgets/main_window.hpp
@@ -29,6 +29,8 @@
 
 #include "util/status_box.hpp"
 
+#include <functional>
+
 namespace ScIDE {
 
 class Main;
@@ -70,6 +72,11 @@ public:
         DocCloseAll,
         DocReload,
         ClearRecentDocs,
+        ProjectNew,
+        ProjectOpen,
+        ProjectSaveAs,
+        ProjectClose,
+        ClearRecentProjects,
 
         // Sessions
         NewSession,
@@ -148,6 +155,11 @@ public Q_SLOTS:
     void closeDocument();
     void closeAllDocuments();
 
+    void newProject();
+    void openProject();
+    void closeProject();
+    void saveProjectAs();
+
     void showCmdLine();
     void showCmdLine( const QString & );
     void showFindTool();
@@ -176,6 +188,8 @@ private Q_SLOTS:
     void onDocDialogFinished();
     void updateRecentDocsMenu();
     void onOpenRecentDocument( QAction * );
+    void onOpenRecentProject( QAction * );
+    void clearRecentProjects();
     void onOpenSessionAction( QAction * );
     void updateWindowTitle();
     void toggleFullScreen();
@@ -208,10 +222,15 @@ private:
     template <class T> void restoreWindowState(T * settings);
     void updateSessionsMenu();
     void updateClockWidget( bool isFullScreen );
+    void prOpenProject(QString path);
     void openSession( QString const & sessionName );
     bool checkFileExtension( const QString & fpath );
     void toggleInterpreterActions( bool enabled);
+    void applyRecentProjectsSettings( Settings::Manager * );
+    void addToRecentProjects( QString path);
+    void updateRecentProjectsMenu();
     void applyCursorBlinkingSettings( Settings::Manager * );
+    static void projectWriteDialog(std::function<void (QString)>);
     QString documentOpenPath() const;
     QString documentSavePath( Document * ) const;
 
@@ -244,6 +263,10 @@ private:
     DocumentsDialog * mDocDialog;
 
     QString mLastDocumentSavePath;
+
+    QMenu * mRecentProjectsMenu;
+    QStringList mRecentProjects;
+    static const int mMaxRecentProjects = 10;
 
     static MainWindow *mInstance;
 };

--- a/editors/sc-ide/widgets/settings/dialog.cpp
+++ b/editors/sc-ide/widgets/settings/dialog.cpp
@@ -22,6 +22,7 @@
 #include "ui_settings_dialog.h"
 #include "general_page.hpp"
 #include "sclang_page.hpp"
+#include "sclang_project_page.hpp"
 #include "editor_page.hpp"
 #include "shortcuts_page.hpp"
 #include "../../core/settings/manager.hpp"
@@ -54,7 +55,9 @@ Dialog::Dialog( Manager *settings, QWidget * parent ):
     connect(this, SIGNAL(storeRequest(Manager*)), w, SLOT(store(Manager*)));
     connect(this, SIGNAL(loadRequest(Manager*)), w, SLOT(load(Manager*)));
 
-    w = new SclangPage;
+    if( settings->value("IDE/interpreter/project").toBool() )
+    { w = new SclangProjectPage; } else
+    { w = new SclangPage; }
     ui->configPageStack->addWidget(w);
     ui->configPageList->addItem (
         new QListWidgetItem(QIcon::fromTheme("applications-system"), tr("Interpreter")));

--- a/editors/sc-ide/widgets/settings/sclang_project_page.hpp
+++ b/editors/sc-ide/widgets/settings/sclang_project_page.hpp
@@ -1,0 +1,72 @@
+/*
+    SuperCollider Qt IDE
+    Copyright (c) 2012 Jakob Leben & Tim Blechmann
+    http://www.audiosynth.com
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
+*/
+
+#ifndef SCIDE_WIDGETS_SETTINGS_SCLANG_PROJECT_PAGE_HPP_INCLUDED
+#define SCIDE_WIDGETS_SETTINGS_SCLANG_PROJECT_PAGE_HPP_INCLUDED
+
+#include <QWidget>
+#include <QDir>
+#include <functional>
+
+namespace Ui {
+    class SclangProjectConfigPage;
+}
+
+namespace ScIDE { namespace Settings {
+
+class Manager;
+
+class SclangProjectPage : public QWidget
+{
+    Q_OBJECT
+
+public:
+	SclangProjectPage(QWidget *parent = 0);
+	~SclangProjectPage();
+
+public Q_SLOTS:
+    void load( Manager * );
+    void store( Manager * );
+
+private Q_SLOTS:
+    void addIncludePath();
+    void removeIncludePath();
+
+    void addExcludePath();
+    void removeExcludePath();
+    void markSclangConfigDirty() { sclangConfigDirty = true; }
+
+private:
+    void readLanguageConfig(QString configFile);
+    void writeLanguageConfig(QString configFile);
+    void doRelativeProject(std::function<void(QString)> func, QString path);
+
+    Ui::SclangProjectConfigPage *ui;
+
+    bool sclangConfigDirty;
+    bool project;
+    QString selectedLanguageConfigFile;
+    std::string selectedLanguageConfigFileDir;
+    QDir qSelectedLanguageConfigFileDir;
+};
+
+}} // namespace ScIDE::Settings
+
+#endif // SCIDE_WIDGETS_SETTINGS_SCLANG_PAGE_HPP_INCLUDED

--- a/include/lang/SC_LanguageClient.h
+++ b/include/lang/SC_LanguageClient.h
@@ -80,9 +80,9 @@ public:
 
 	// library startup/shutdown
 	bool isLibraryCompiled();
-	void compileLibrary(bool standalone);
+	void compileLibrary();
 	void shutdownLibrary();
-	void recompileLibrary(bool standalone);
+	void recompileLibrary();
 
 	// interpreter access
 	void lock();

--- a/lang/LangPrimSource/PyrPrimitive.cpp
+++ b/lang/LangPrimSource/PyrPrimitive.cpp
@@ -3535,12 +3535,31 @@ static int prLanguageConfig_getCurrentConfigPath(struct VMGlobals * g, int numAr
 {
 	PyrSlot *a = g->sp;
 	PyrString* str = newPyrString(g->gc, gLanguageConfig->getCurrentConfigPath(), 0, false);
-    if(str->size == 0) {
-        SetNil(a);
-    } else {
-        SetObject(a, str);
-    }
-    
+	if(str->size == 0) {
+		SetNil(a);
+	} else {
+		SetObject(a, str);
+	}
+
+	return errNone;
+}
+
+static int prLanguageConfig_getCurrentConfigDirectory(struct VMGlobals * g, int numArgsPushed)
+{
+	PyrSlot *a = g->sp;
+	PyrString* str = newPyrString(g->gc, gLanguageConfig->getConfigFileDirectory().c_str(), 0, false);
+	PyrString* str2 = newPyrString(g->gc, gLanguageConfig->getCurrentConfigPath(), 0, false);
+	//return nil if no lang file was used.
+	if(str2->size == 0) {
+		SetNil(a);
+	} else {
+		if(str->size == 0) {
+			SetNil(a);
+		} else {
+			SetObject(a, str);
+		}
+	}
+
 	return errNone;
 }
 
@@ -3584,6 +3603,19 @@ static int prLanguageConfig_setPostInlineWarnings(struct VMGlobals * g, int numA
 	return errNone;
 }
 
+static int prLanguageConfig_getExcludeDefaultPaths(struct VMGlobals * g, int numArgsPushed)
+{
+    PyrSlot *result = g->sp;
+    SetBool(result, gLanguageConfig->getExcludeDefaultPaths());
+    return errNone;
+}
+
+static int prLanguageConfig_getProjectOpen(struct VMGlobals * g, int numArgsPushed)
+{
+	PyrSlot *result = g->sp;
+	SetBool(result, gLanguageConfig->getProject());
+	return errNone;
+}
 
 static int prVersionMajor(struct VMGlobals * g, int numArgsPushed)
 {
@@ -4162,6 +4194,7 @@ void initPrimitives()
 
 	definePrimitive(base, index++, "_AppClock_SchedNotify", prAppClockSchedNotify, 1, 0);
 	definePrimitive(base, index++, "_LanguageConfig_getCurrentConfigPath", prLanguageConfig_getCurrentConfigPath, 1, 0);
+	definePrimitive(base, index++, "_LanguageConfig_getCurrentConfigDirectory", prLanguageConfig_getCurrentConfigDirectory, 1, 0);
 	definePrimitive(base, index++, "_LanguageConfig_getIncludePaths", prLanguageConfig_getIncludePaths, 1, 0);
 	definePrimitive(base, index++, "_LanguageConfig_getExcludePaths", prLanguageConfig_getExcludePaths, 1, 0);
 	definePrimitive(base, index++, "_LanguageConfig_addIncludePath", prLanguageConfig_addIncludePath, 2, 0);
@@ -4171,6 +4204,8 @@ void initPrimitives()
 	definePrimitive(base, index++, "_LanguageConfig_writeConfigFile", prLanguageConfig_writeConfigFile, 2, 0);
 	definePrimitive(base, index++, "_LanguageConfig_getPostInlineWarnings", prLanguageConfig_getPostInlineWarnings, 1, 0);
 	definePrimitive(base, index++, "_LanguageConfig_setPostInlineWarnings", prLanguageConfig_setPostInlineWarnings, 2, 0);
+	definePrimitive(base, index++, "_LanguageConfig_getExcludeDefaultPaths", prLanguageConfig_getExcludeDefaultPaths, 1, 0);
+	definePrimitive(base, index++, "_LanguageConfig_getProjectOpen", prLanguageConfig_getProjectOpen, 1, 0);
 
 	definePrimitive(base, index++, "_SC_VersionMajor", prVersionMajor, 1, 0);
 	definePrimitive(base, index++, "_SC_VersionMinor", prVersionMinor, 1, 0);

--- a/lang/LangSource/PyrLexer.cpp
+++ b/lang/LangSource/PyrLexer.cpp
@@ -28,6 +28,7 @@
 #include <cerrno>
 #include <limits>
 #include <set>
+#include <functional>
 
 #ifdef _WIN32
 # include <direct.h>
@@ -1920,6 +1921,31 @@ void finiPassOne()
 
 static bool passOne_ProcessDir(const char *dirname, int level)
 {
+	std::string dirname_s;
+	bool isProjectPath = false;
+	auto compareAndReplacePrefix = [](std::string &a, const std::string &b, const std::string &replace)
+	{
+		size_t pos = 0;
+		size_t l =  b.length();
+		if( a.compare(pos, l, b) == 0 )
+			a.replace(pos, l, replace);
+	};
+
+	if( level == 0) {
+		dirname_s = dirname;
+		compareAndReplacePrefix(dirname_s, "%ResourceDirectory%", gLanguageConfig->mResourceDir);
+		compareAndReplacePrefix(dirname_s, "%SystemExtensionDirectory%", gLanguageConfig->mSystemExtensionDir);
+		compareAndReplacePrefix(dirname_s, "%UserExtensionDirectory%", gLanguageConfig->mUserExtensionDir);
+		if( gLanguageConfig->getProject() ) {
+			boost::filesystem::path bfsdirname = boost::filesystem::path(dirname_s);
+			if( !bfsdirname.is_absolute() ){
+				isProjectPath = true;
+				dirname_s = (gLanguageConfig->getConfigFileDirectory() /= bfsdirname).string();
+			}
+		}
+		dirname = dirname_s.c_str();
+	}
+
 	if (!sc_DirectoryExists(dirname))
 		return true;
 
@@ -1929,12 +1955,16 @@ static bool passOne_ProcessDir(const char *dirname, int level)
 
 	bool success = true;
 
-	if (gLanguageConfig && gLanguageConfig->pathIsExcluded(dirname)) {
+	if (gLanguageConfig->pathIsExcluded(dirname)) {
 		post("\texcluding dir: '%s'\n", dirname);
 		return success;
 	}
-
-	if (level == 0) post("\tcompiling dir: '%s'\n", dirname);
+	
+	if(isProjectPath) {
+		if (level == 0) post("\tcompiling dir from project: '%s'\n", dirname);
+	} else {
+		if (level == 0) post("\tcompiling dir: '%s'\n", dirname);
+	}
 
 	SC_DirHandle *dir = sc_OpenDir(dirname);
 	if (!dir) {
@@ -2011,9 +2041,9 @@ bool passOne_ProcessOneFile(const char * filenamearg, int level)
 		return success;
 	}
 
-	if (gLanguageConfig && gLanguageConfig->pathIsExcluded(filename)) {
-	  post("\texcluding file: '%s'\n", filename);
-	  return success;
+	if (gLanguageConfig->pathIsExcluded(filename)) {
+		post("\texcluding file: '%s'\n", filename);
+		return success;
 	}
 
 	if (isValidSourceFileName(filename)) {
@@ -2115,7 +2145,7 @@ void shutdownLibrary()
 	SC_LanguageConfig::freeLibraryConfig();
 }
 
-SCLANG_DLLEXPORT_C bool compileLibrary(bool standalone)
+SCLANG_DLLEXPORT_C bool compileLibrary()
 {
 	//printf("->compileLibrary\n");
 	shutdownLibrary();
@@ -2124,7 +2154,7 @@ SCLANG_DLLEXPORT_C bool compileLibrary(bool standalone)
 	gNumCompiledFiles = 0;
 	compiledOK = false;
 
-	SC_LanguageConfig::readLibraryConfig(standalone);
+	SC_LanguageConfig::readLibraryConfig();
 
 	compileStartTime = elapsedTime();
 

--- a/lang/LangSource/SCBase.h
+++ b/lang/LangSource/SCBase.h
@@ -57,7 +57,7 @@ SCLANG_DLLEXPORT_C void schedRun();
 SCLANG_DLLEXPORT_C void schedStop();
 SCLANG_DLLEXPORT_C void schedClear();
 
-SCLANG_DLLEXPORT_C bool compileLibrary(bool standalone);
+SCLANG_DLLEXPORT_C bool compileLibrary();
 SCLANG_DLLEXPORT_C void runLibrary(struct PyrSymbol* selector);
 SCLANG_DLLEXPORT_C void runInterpreter(struct VMGlobals *g, struct PyrSymbol *selector, int numArgsPushed);
 

--- a/lang/LangSource/SC_LanguageClient.cpp
+++ b/lang/LangSource/SC_LanguageClient.cpp
@@ -147,9 +147,9 @@ void SC_LanguageClient::shutdownRuntime()
 #endif
 }
 
-void SC_LanguageClient::compileLibrary(bool standalone)
+void SC_LanguageClient::compileLibrary()
 {
-	::compileLibrary(standalone);
+	::compileLibrary();
 }
 
 extern void shutdownLibrary();
@@ -159,9 +159,9 @@ void SC_LanguageClient::shutdownLibrary()
 	flush();
 }
 
-void SC_LanguageClient::recompileLibrary(bool standalone)
+void SC_LanguageClient::recompileLibrary()
 {
-	compileLibrary(standalone);
+	compileLibrary();
 }
 
 void SC_LanguageClient::setCmdLine(const char* buf, size_t size)

--- a/lang/LangSource/SC_LanguageConfig.hpp
+++ b/lang/LangSource/SC_LanguageConfig.hpp
@@ -26,18 +26,22 @@
 
 #include <vector>
 #include <string>
+#include <boost/filesystem.hpp>
 
 class SC_LanguageConfig
 {
 public:
+	SC_LanguageConfig(const char* fileName);
 	typedef std::vector<std::string> DirVector;
-	SC_LanguageConfig(bool standalone);
+	void setDefaultPaths();
 
 	const DirVector& includedDirectories() { return mIncludedDirectories; }
 	const DirVector& excludedDirectories() { return mExcludedDirectories; }
 
 	void postExcludedDirectories(void);
 	bool forEachIncludedDirectory(bool (*func)(const char *, int));
+	void doRelativeProject(std::function<void(const char *path)> func, const char *path);
+	void doRelativeProject(std::function<void(std::string path)> func, std::string path);
 
 	bool pathIsExcluded(const char *path);
 
@@ -51,19 +55,34 @@ public:
 	{
 		gConfigFile = fileName;
 	}
-
-	static bool readLibraryConfigYAML(const char* fileName, bool standalone);
+	
+	static bool readLibraryConfigYAML(const char* fileName);
 	static bool writeLibraryConfigYAML(const char* fileName);
 	static void freeLibraryConfig();
-	static bool defaultLibraryConfig(   bool standalone);
-	static bool readLibraryConfig(bool standalone);
+	static bool defaultLibraryConfig();
+	static bool readLibraryConfig();
 	
 	const char* getCurrentConfigPath();
+	boost::filesystem::path getConfigFileDirectory() { return mConfigFileDirectory; }
+
+	bool getExcludeDefaultPaths() const;
+	void setExcludeDefaultPaths(bool value);
+
+	bool getProject() const;
+	void setProject(bool value);
+
+	std::string mResourceDir;
+	std::string mSystemExtensionDir;
+	std::string mUserExtensionDir;
 
 private:
 	DirVector mIncludedDirectories;
 	DirVector mExcludedDirectories;
 	DirVector mDefaultClassLibraryDirectories;
+	bool mExcludeDefaultPaths = false;
+	bool mProject = false;
+	boost::filesystem::path mConfigFileDirectory;
+
 	static std::string gConfigFile;
 };
 

--- a/lang/LangSource/SC_TerminalClient.cpp
+++ b/lang/LangSource/SC_TerminalClient.cpp
@@ -123,8 +123,7 @@ void SC_TerminalClient::printUsage()
 			"   -r                             Call Main.run on startup\n"
 			"   -s                             Call Main.stop on shutdown\n"
 			"   -u <network-port-number>       Set UDP listening port (default %d)\n"
-			"   -i <ide-name>                  Specify IDE name (for enabling IDE-specific class code, default \"%s\")\n"
-			"   -a                             Standalone mode (exclude SCClassLibrary and user and system Extensions folders from search path)\n",
+			"   -i <ide-name>                  Specify IDE name (for enabling IDE-specific class code, default \"%s\")\n",
 			memGrowBuf,
 			memSpaceBuf,
 			opt.mPort,
@@ -134,7 +133,7 @@ void SC_TerminalClient::printUsage()
 
 bool SC_TerminalClient::parseOptions(int& argc, char**& argv, Options& opt)
 {
-	const char* optstr = ":d:Dg:hl:m:rsu:i:av";
+	const char* optstr = ":d:Dg:hl:m:rsu:i:v";
 	int c;
 
 	// inhibit error reporting
@@ -190,9 +189,6 @@ bool SC_TerminalClient::parseOptions(int& argc, char**& argv, Options& opt)
 				break;
 			case 'i':
 				gIdeName = optarg;
-				break;
-			case 'a':
-				opt.mStandalone = true;
 				break;
 			default:
 				::post("%s: unknown error (getopt)\n", getName());
@@ -250,13 +246,14 @@ int SC_TerminalClient::run(int argc, char** argv)
 	// read library configuration file
 	if (opt.mLibraryConfigFile)
 		SC_LanguageConfig::setConfigFile(opt.mLibraryConfigFile);
-	SC_LanguageConfig::readLibraryConfig(opt.mStandalone);
+
+	SC_LanguageConfig::readLibraryConfig();
 
 	// initialize runtime
 	initRuntime(opt);
 
 	// startup library
-	compileLibrary(opt.mStandalone);
+	compileLibrary();
 
 	// enter main loop
 	if (codeFile) executeFile(codeFile);
@@ -286,7 +283,7 @@ int SC_TerminalClient::run(int argc, char** argv)
 
 void SC_TerminalClient::recompileLibrary()
 {
-    SC_LanguageClient::recompileLibrary(mOptions.mStandalone);
+    SC_LanguageClient::recompileLibrary();
 }
 
 void SC_TerminalClient::quit(int code)

--- a/lang/LangSource/SC_TerminalClient.h
+++ b/lang/LangSource/SC_TerminalClient.h
@@ -65,7 +65,6 @@ public:
 			  mDaemon(false),
 			  mCallRun(false),
 			  mCallStop(false),
-			  mStandalone(false),
 			  mArgc(0), mArgv(0)
 		{ }
 
@@ -75,7 +74,6 @@ public:
 		bool			mCallStop;
 		int				mArgc;
 		char**			mArgv;
-		bool			mStandalone;
 	};
 
 	SC_TerminalClient(const char* name);


### PR DESCRIPTION
Details about this feature can be found at issue #311 and in the commit messages.

The sclang language config "project" key makes possible having both projects in the IDE as well as sclang standalones, since they have similar requirements.

This introduces a change in the command line options of sclang, removing the -a option. The rationale is that with -a a lang file has to be used anyhow otherwise the class library will not compile as it doesn't find an SCClassLibrary, therefore might as well make that an option which is settable in the language config file which also makes it easier to manage. This also changes the header API to the state it was in before pull-request #1021, it is unfortunate going back and forth, but I do think it is better as it is in this pull-request.

This pull-request contains some extensive changes, so it would require some extensive testing, review and discussion. I would especially be grateful if someone with good c++ knowledge could have a look at the memory management, one of the aspects of c++ I'm less familiar with. Whenever possible I tried to use stl containers and c++11 features. I would especially welcome comments from the two main creators of the IDE ( @timblechmann and @jleben ) , I hope I stayed coherent with their original design.

There is a test project available [here](https://github.com/miguel-negrao/TestSCProject). Clone the repo somewhere,  make sure to init the submodules also (Quarks are included as submodules) and do "File->Open project".

There is an sclang standlone template available for testing [here](https://github.com/miguel-negrao/scStandalone), it requires copying the binaries, and is mostly Linux only for now, someone would have to do the OSX part... but it works over here.

I think #1957 would be a useful addition on top of this pull-request, and I would be willing to implement that, but I would defer discussion of that to after this pull-request gets reviewed.

![captura de ecra de 2016-04-18 17-47-10](https://cloud.githubusercontent.com/assets/382777/14612225/edb4b438-058d-11e6-936d-19956a618898.png)
![captura de ecra de 2016-04-18 17-46-41](https://cloud.githubusercontent.com/assets/382777/14612226/edb808d6-058d-11e6-9996-5152ebf31e13.png)

Comparison of projects to other similar features:

| feature | normal SC | SC project in IDE | sclang standalone (based on projects) | old SC.app standalones | ide based osx standalones (adc) |
| --- | --- | --- | --- | --- | --- |
| possible to exclude default paths | yes | yes | yes | yes | excludes default paths of SuperCollider but loads them from the new app library folders |
| same ide can open different self-contained code bases | no | yes | no | no | no |
| quarks download to self-contained folder | no | yes | yes | ? | yes |
| has self-contained sclang, scsynth, etc | no | no | yes | yes | yes |
| possible to exchange the project/code with others in reliable way | no | yes (assuming ide, sclang and scsynth are compatible) | yes | yes | yes |
| similar to | n.a. | a QtCreator, XCode, etc project | an application | an application | an application |
