### PR TITLE
class library: node proxy, improve documentation

### DIFF
--- a/HelpSource/Classes/NodeProxy.schelp
+++ b/HelpSource/Classes/NodeProxy.schelp
@@ -153,6 +153,40 @@ a.source = { Pulse.ar(130, Saw.kr(0.3)) * 0.1 }; // change this line while runni
 argument::obj
 can be one of the supported inputs (see link::#Supported sources::)
 
+note::
+When reshaping is set, e.g. to \elastic, setting the source can change the number of channels of the proxy. This means that its bus changes, and that child proxies, which read signals from it, may also change. See the example in link::#routing::.
+::
+
+subsection::Routing
+Signals can be routed between any number of node proxies.
+
+See also: link::Classes/BusPlug#ar::, link::Classes/BusPlug#value::, link::#reshaping::.
+
+Here is a simple example, using Ndef (NodeProxy works similarly):
+
+code::
+Ndef(\maus, { MouseX.kr });
+Ndef(\haus, { Pan2.ar(Blip.ar(Ndef.kr(\maus, 1) * 70), SinOsc.kr(Ndef.ar(\maus, 1) * 5)) }).play;
+::
+
+note::
+If you don't specify the number of channels, an expression like code::Ndef.kr(\maus):: will return an Array. Subsequently, e.g. by a code::Pan2:: UGen, you may get the message:
+
+code::WARNING: Synth output should be a flat array.::
+
+If you intend the output to be really mono, make it explicit by writing: code::Ndef.kr(\maus, 1)::
+::
+
+With elastic reshaping, you can use the parent to expand the child, if you omit the number of channels in the routing:
+
+code::
+Ndef(\maus, { MouseX.kr });
+Ndef(\haus, { Blip.ar(Ndef.kr(\maus) * 70) }).play;
+Ndef(\haus).reshaping = \elastic;
+Ndef(\maus).reshaping = \elastic;
+Ndef(\maus, { LFNoise0.kr(1 ! 8) + 1 }); // now 8 parallel channels of audio are audible.
+::
+
 
 
 

--- a/SCClassLibrary/JITLib/ProxySpace/ProxySynthDef.sc
+++ b/SCClassLibrary/JITLib/ProxySpace/ProxySynthDef.sc
@@ -23,7 +23,7 @@ ProxySynthDef : SynthDef {
 			};
 			// protect from accidentally wrong array shapes
 			if(output.containsSeqColl) {
-				"Synth output should be a flat array.\n%\nFlattened to: %\nSee NodeProxy helpfile:routing".format(output, output.flat).warn;
+				"Synth output should be a flat array.\n%\nFlattened to: %\nSee NodeProxy helpfile:routing\n\n".format(output, output.flat).warn;
 				output = output.flat;
 			};
 

--- a/SCClassLibrary/JITLib/ProxySpace/ProxySynthDef.sc
+++ b/SCClassLibrary/JITLib/ProxySpace/ProxySynthDef.sc
@@ -23,7 +23,7 @@ ProxySynthDef : SynthDef {
 			};
 			// protect from accidentally wrong array shapes
 			if(output.containsSeqColl) {
-				"Synth output should be a flat array.\n%\nFlattened to: %\n".format(output, output.flat).warn;
+				"Synth output should be a flat array.\n%\nFlattened to: %\nSee NodeProxy helpfile:routing".format(output, output.flat).warn;
 				output = output.flat;
 			};
 


### PR DESCRIPTION
The message `WARNING: Synth output should be a flat array` is
documented better, and the error points to the help file.