### PR TITLE
Classlib: Don't try to free a buffer after it was already freed

### DIFF
--- a/SCClassLibrary/Common/Control/Buffer.sc
+++ b/SCClassLibrary/Common/Control/Buffer.sc
@@ -367,16 +367,22 @@ Buffer {
 	}
 
 	free { arg completionMessage;
-		server.listSendMsg( this.freeMsg(completionMessage) )
+		if(bufnum.notNil) {
+			server.listSendMsg( this.freeMsg(completionMessage) )
+		};
 	}
 
 	freeMsg { arg completionMessage;
 		var msg;
-		this.uncache;
-		server.bufferAllocator.free(bufnum);
-		msg = ["/b_free", bufnum, completionMessage.value(this)];
-		bufnum = numFrames = numChannels = sampleRate = path = startFrame = nil;
-		^msg
+		if(bufnum.notNil) {
+			this.uncache;
+			server.bufferAllocator.free(bufnum);
+			msg = ["/b_free", bufnum, completionMessage.value(this)];
+			bufnum = numFrames = numChannels = sampleRate = path = startFrame = nil;
+			^msg
+		} {
+			^nil
+		}
 	}
 
 	*freeAll { arg server;


### PR DESCRIPTION
```
b = Buffer.alloc(s, 100, 1);
c = Buffer.alloc(s, 100, 1);
c.free;
c.free;
```

The second `c.free` issues a [/b_free, nil] to the server, which it interprets as [/b_free, 0] -- killing `b`!!!

This checks for the bufnum being nil before sending any b_free messages.

As a side note, I've just been bitten by this bug in probably the last 3 consecutive days of coding. It was really extremely annoying. I have other editorial comments about that, but I'll keep them to myself as they are not exactly family friendly.