### PR TITLE
Make sure NodeProxy generates unique name.

### DIFF
--- a/SCClassLibrary/JITLib/ProxySpace/NodeProxy.sc
+++ b/SCClassLibrary/JITLib/ProxySpace/NodeProxy.sc
@@ -936,10 +936,13 @@ NodeProxy : BusPlug {
 	}
 
 	generateUniqueName {
-		// if named, give us the name so we see it
+		var uniqueName = this.identityHash;
+		// if named, add the name so we see it
 		// in synthdef names of the server's nodes.
-		var key = this.key ?? this.identityHash.abs;
-		^server.clientID.asString ++ key ++ "_";
+		if(this.key.notNil, {
+			uniqueName = this.key ++ uniqueName;
+		});
+		^server.clientID.asString ++ uniqueName ++ "_";
 	}
 
 	prepareOutput {


### PR DESCRIPTION
I sadly haven't been able to make a concise reproducer for this bug as this happens within a larger system. When I generate large NodeProxys at the same from a group of MIDI buttons, the same SynthDef is created on the server, even though the client side representation generates different synths.

I tracked down the culprit to be the NodeProxy .generateUniqueName method. This method assumes that the NodeProxys 'this.key' returns a unique name.
This assumption proves to be wrong if the NodeProxy resides in different dictionaries but are stored with the same key. I'm using NodeProxy class directly, storing them in different dictionaries, but with the same key 'nodeProxy'. This causes the SynthDef names that are created to be not unique based on instance.

When simultaneous synthDefs are sent to the server, using the same SynthDef name, the server/lang communication becomes unsynced, so when the synths are created, only one SynthDef with that unique name is defined on the server.

+Eirik