### PR TITLE
Improve "Writing UGens" documentation

### DIFF
--- a/HelpSource/Guides/WritingUGens.schelp
+++ b/HelpSource/Guides/WritingUGens.schelp
@@ -3,11 +3,11 @@ summary:: Get started with writing unit generators
 categories:: Internals
 related:: Reference/ServerPluginAPI
 
-section:: Pseudo-ugens
+section:: Pseudo-UGens
 
-Pseudo-ugens are useful when you want to abbreviate a certain configuration of UGens that gets used repeatedly. A
-pseudo-ugen is a class that superficially resembles a UGen class, but it only returns a composition of existing UGens.
-Pseudo-ugens exist only in the client -- the server isn't aware of them and only receives their components.
+Pseudo-UGens are useful when you want to abbreviate a certain configuration of UGens that gets used repeatedly. A
+pseudo-UGen is a class that superficially resembles a UGen class, but it only returns a composition of existing UGens.
+Pseudo-UGens exist only in the client -- the server isn't aware of them and only receives their components.
 
 The below example has only a code::.ar:: method, but you can just as easily have both code::.ar:: and code::.kr::
 methods.
@@ -20,16 +20,16 @@ BoringMixer {
 }
 ::
 
-Examples of pseudo-ugens found in SC include link::Classes/BLowPass4:: and link::Classes/BHiPass4::, which break down
+Examples of pseudo-UGens found in SC include link::Classes/BLowPass4:: and link::Classes/BHiPass4::, which break down
 into link::Classes/SOS:: UGens.
 
 There are very few restrictions on what these classes can contain, but you should keep the following in mind:
 
 list::
-## It is courteous to leave a note in your class's help file that identifies it as a pseudo-ugen.
-## To avoid confusion, pseudo-ugens should not inherit from the base class link::Classes/UGen::.
+## It is courteous to leave a note in your class's help file that identifies it as a pseudo-UGen.
+## To avoid confusion, pseudo-UGens should not inherit from the base class link::Classes/UGen::.
 ## A SynthDef can only have two link::Classes/LocalIn::/link::Classes/LocalOut:: pairings — one for control rate and one
-for audio rate. Putting LocalIn and LocalOut in a pseudo-ugen is a bad idea, as it could interfere with other feedback
+for audio rate. Putting LocalIn and LocalOut in a pseudo-UGen is a bad idea, as it could interfere with other feedback
 loops in the SynthDef.
 ::
 
@@ -48,7 +48,7 @@ list::
 ## code::*.scx:: for OS X
 ::
 
-A plugin file can contain more than one UGen, and it can also define things other than ugens such as buffer fill
+A plugin file can contain more than one UGen, and it can also define things other than UGens such as buffer fill
 ("/b_gen") commands.
 
 When scsynth boots, it will look for plugin files in code::Platform.userExtensionDir::. Since sclang also looks for
@@ -66,7 +66,7 @@ FAUST provides a shell script useful for SuperCollider users called code::faust2
 file into a class file and server plugin, which you can then drop into your extensions directory.
 
 FAUST plugins are often quick to develop and can be painlessly ported to other environments. Unfortunately, they can't
-take advantage of all of scsynth's features, such as accessing Buffers or random number generators, and some ugens
+take advantage of all of scsynth's features, such as accessing Buffers or random number generators, and some UGens
 featuring very complex logic are difficult or impossible to write in FAUST. Furthermore, the FAUST compiler is quite
 intelligent but it might not always offer the best efficiency in its results. If a UGen you are developing hits these
 limitations, it is time to move on to handwritten C++.
@@ -358,9 +358,9 @@ In order to prevent deadlocks, a simple deadlock prevention scheme is implemente
 
 list::
 ## Lock resources only when required: few unit generators actually require the access to more than one resource at the same time.
-   The main exception of this rule are the FFT Chain ugens, which access multiple buffers at the same time. There is no known unit
+   The main exception of this rule are the FFT Chain UGens, which access multiple buffers at the same time. There is no known unit
    generator, which accesses both buffers and busses at the same time.
-## Acquire reader locks if possible. Since multiple ugens can acquire a reader lock to the same resource at the same time, their
+## Acquire reader locks if possible. Since multiple UGens can acquire a reader lock to the same resource at the same time, their
    use reduces contention.
 ## Resources have to be acquired in a well-defined order: busses should be acquired before buffers and resources with a high index
    should be acquired before resources with a low index.

--- a/HelpSource/Guides/WritingUGens.schelp
+++ b/HelpSource/Guides/WritingUGens.schelp
@@ -2,6 +2,109 @@ title:: Writing Unit Generators
 summary:: Get started with writing unit generators
 categories:: Internals
 
+section:: Pseudo-ugens
+
+Pseudo-ugens are useful when you want to abbreviate a certain configuration of UGens that gets used repeatedly. A pseudo-ugen is a class that superficially resembles a UGen class, but it only returns a composition of existing UGens. Pseudo-ugens exist only in the client -- the server isn't aware of them and only receives their components.
+
+The below example has only a code::.ar:: method, but you can just as easily have both code::.ar:: and code::.kr:: methods.
+
+code::
+Chorus {
+    *ar { arg in, lfofreq = 2, maxdepth = 0.1, depth = 0.005;
+        ^(in + DelayC.ar(lfofreq, maxdepth, depth)) * 0.7;
+    }
+}
+::
+
+Examples of pseudo-ugens found in SC include link::Classes/BLowPass4:: and link::Classes/BHiPass4::, which break down into link::Classes/SOS:: UGens.
+
+There are very few restrictions on what these classes can contain, but you should keep the following in mind:
+
+list::
+## It is courteous to leave a note in your class's help file that identifies it as a pseudo-ugen.
+## To avoid confusion, pseudo-ugens should not inherit from the base class link::Classes/UGen::.
+## A SynthDef can only have two link::Classes/LocalIn::/link::Classes/LocalOut:: pairings — one for control rate and one for audio rate. Putting LocalIn and LocalOut in a pseudo-ugen is a bad idea, as it could interfere with other feedback loops in the SynthDef.
+::
+
+section:: Basics of real UGens
+
+A real UGen needs two components: a plugin for the server, and a class for the language. The class goes in an ordinary code::*.sc:: file, and defines the interface for your UGen in the language. This class is generally just a few lines of code that ultimately call the class method link::Classes/UGen#-multiNew::.
+
+The server plugin is where the actual UGen behavior is defined. It is given by a platform-dependent library file: code::*.so:: for *nix, code::*.dll:: for Windows, and code::*.scx:: for OS X [fact check needed on the last two -NH]. A library file can contain more than one UGen.
+
+When scsynth boots, it will look for such library files in code::Platform.userExtensionDir::. Since sclang also looks for class files in the same location, the class file and the library file can go in the same place.
+
+section:: Using FAUST
+
+FAUST is an open source DSP language that describes real-time audio units. Its greatest strength is that it can be compiled into a huge variety of contexts: standalone GUI applications, Flash plugins, Max/MSP or Pure Data externals, CSOUND opcodes, VST plugins, etc. It can also compile to SuperCollider plugins, providing the easiest way to create real UGens in SuperCollider.
+
+First, write a FAUST program such as the below:
+
+code::
+process = + : *(0.5);
+::
+
+which is a boring ugen that just averages its two inputs. Save this as BoringMixer.dsp, and run the following at the command line:
+
+code::
+faust2supercollider BoringMixer.dsp
+::
+
+This will generate BoringMixer.sc and BoringMixer.so files in the current directory. Both of these need to go into your extensions directory. After installing them, reboot both the interpreter and the server, and a class named code::FaustBoringMixer:: should show up in sclang. You can verify that code::FaustBoringMixer.ar:: and code::FaustBoringMixer.kr:: both work as expected.
+
+section:: Manual compilation
+
+faust2supercollider is not actually the FAUST compiler. It's a handy shell script that hides a somewhat more complicated process: first, it compiles your FAUST .dsp file into a C++ file with the SuperCollider architecture, and then into a shared library usable by scsynth. It generates a file for sclang on the side.
+
+On another note, it would be nice to get rid of the Faust prefix on our ugen. We'll take this as an opportunity to walk through the above manual process. (It also makes for a good transition into the next section, where we'll reuse some of these steps.) Get yourself into an empty directory, drop your DSP file there and compile into C++ with the following command:
+
+code::
+faust -a supercollider.cpp BoringMixer.dsp -o BoringMixer.cpp
+::
+
+This is the actual FAUST compiler. We're compiling BoringMixer.dsp using the SuperCollider architecture (as indicated by the argument to the -a option) and writing output to BoringMixer.cpp.
+
+Next we'll set up a build system with CMake. This is overkill for just compiling one ugen, but this results in a rigorous, cross-platform environment that we'll be using again when we start constructing UGens by hand. Create a file in the same directory called `CMakeLists.txt` and add the following:
+
+code::
+cmake_minimum_required (VERSION 2.8)
+project (MyUGens)
+
+include_directories(${SC_PATH}/include/plugin_interface)
+include_directories(${SC_PATH}/include/common)
+include_directories(${SC_PATH}/external_libraries/libsndfile/)
+
+set(CMAKE_SHARED_MODULE_PREFIX "")
+if(APPLE OR WIN32)
+set(CMAKE_SHARED_MODULE_SUFFIX ".scx")
+endif()
+
+add_library(BoringMixer MODULE BoringMixer.cpp)
+::
+
+You can replace the MyUGens name with anything else.
+
+To compile, you'll need to have a copy of the SuperCollider source code sitting around (since your plugin uses includes provided by SC). Having obtained that:
+
+code::
+cmake -G "Unix Makefiles" -DSC_PATH=/path/to/SuperCollider-Source/
+make
+::
+
+If all goes well, compilation will complete and a file named BoringMixer.so should show up in the current directory.
+
+We'll also create an sclang class file by hand:
+
+code::
+BoringMixer : UGen {
+	*ar { |left, right|
+		^this.multiNew('audio', left, right);
+	}
+}
+::
+
+Save this as BoringMixer.sc (although any name will do, really) and copy both the .so file and the .sc file into somewhere in the code::Platform.userExtensionDir:: directory. Reboot the interpreter and server and you will have a working code::BoringMixer:: ugen.
+
 section:: How Unit Generator plug-ins work.
 
 The server loads unit generator plug-ins when it starts up. Unit Generator plug-ins are dynamically loaded libraries

--- a/HelpSource/Guides/WritingUGens.schelp
+++ b/HelpSource/Guides/WritingUGens.schelp
@@ -91,7 +91,13 @@ section:: Example Plugins
 To get an idea of the necessary ingredients for writing UGens, it's often best to poke around at complete examples.
 We've set up a GitHub repository at https://github.com/supercollider/example-plugins, which contains some example
 plugins numbered roughly by complexity. Each directory in that repository is self-contained with its own build system,
-so you can copy out a directory to form a starting point for your own UGens.
+so you can copy out a directory to form a starting point for your own UGens. The source codes of these plugins are
+heavily commented.
+
+The first example, BoringMixer, is very minimal. The UGen is stateless and has only one calculation function, which is
+audio rate.
+
+The second example, MySaw, introduces states and multiple calculation functions.
 
 section:: Anatomy of a UGen
 

--- a/HelpSource/Guides/WritingUGens.schelp
+++ b/HelpSource/Guides/WritingUGens.schelp
@@ -9,9 +9,9 @@ Pseudo-ugens are useful when you want to abbreviate a certain configuration of U
 The below example has only a code::.ar:: method, but you can just as easily have both code::.ar:: and code::.kr:: methods.
 
 code::
-Chorus {
-    *ar { arg in, lfofreq = 2, maxdepth = 0.1, depth = 0.005;
-        ^(in + DelayC.ar(lfofreq, maxdepth, depth)) * 0.7;
+BoringMixer {
+    *ar { arg left, right;
+        ^(left + right) * 0.5;
     }
 }
 ::
@@ -34,9 +34,11 @@ The server plugin is where the actual UGen behavior is defined. It is given by a
 
 When scsynth boots, it will look for such library files in code::Platform.userExtensionDir::. Since sclang also looks for class files in the same location, the class file and the library file can go in the same place.
 
-section:: Using FAUST
+section:: FAUST (the easy way)
 
-FAUST is an open source DSP language that describes real-time audio units. Its greatest strength is that it can be compiled into a huge variety of contexts: standalone GUI applications, Flash plugins, Max/MSP or Pure Data externals, CSOUND opcodes, VST plugins, etc. It can also compile to SuperCollider plugins, providing the easiest way to create real UGens in SuperCollider.
+note:: This section is currently Linux only. Please expand to include instructions for other platforms. ::
+
+FAUST footnote::http://faust.grame.fr/:: is an open source DSP language that describes real-time audio units. Its greatest strength is that it can be compiled into a huge variety of contexts: standalone GUI applications, Flash plugins, Max/MSP or Pure Data externals, CSOUND opcodes, VST plugins, etc. It can also compile to SuperCollider plugins, providing the easiest way to create real UGens in SuperCollider.
 
 First, write a FAUST program such as the below:
 
@@ -52,11 +54,13 @@ faust2supercollider BoringMixer.dsp
 
 This will generate BoringMixer.sc and BoringMixer.so files in the current directory. Both of these need to go into your extensions directory. After installing them, reboot both the interpreter and the server, and a class named code::FaustBoringMixer:: should show up in sclang. You can verify that code::FaustBoringMixer.ar:: and code::FaustBoringMixer.kr:: both work as expected.
 
-section:: Manual compilation
+section:: FAUST (the hard way)
+
+note:: This section is currently Linux only. Please expand to include instructions for other platforms. ::
 
 faust2supercollider is not actually the FAUST compiler. It's a handy shell script that hides a somewhat more complicated process: first, it compiles your FAUST .dsp file into a C++ file with the SuperCollider architecture, and then into a shared library usable by scsynth. It generates a file for sclang on the side.
 
-On another note, it would be nice to get rid of the Faust prefix on our ugen. We'll take this as an opportunity to walk through the above manual process. (It also makes for a good transition into the next section, where we'll reuse some of these steps.) Get yourself into an empty directory, drop your DSP file there and compile into C++ with the following command:
+On another note, it would be nice to get rid of the Faust prefix on our ugen. We'll take this as an opportunity to walk through the above manual process, making for a good transition into hand-written C++ ugens. Get yourself into an empty directory, drop your DSP file there and compile into C++ with the following command:
 
 code::
 faust -a supercollider.cpp BoringMixer.dsp -o BoringMixer.cpp

--- a/HelpSource/Guides/WritingUGens.schelp
+++ b/HelpSource/Guides/WritingUGens.schelp
@@ -97,7 +97,8 @@ heavily commented.
 The first example, BoringMixer, is very minimal. The UGen is stateless and has only one calculation function, which is
 audio rate.
 
-The second example, MySaw, introduces states and multiple calculation functions.
+MySaw introduces states and multiple calculation functions. AnalogEcho introduces real-time memory management through
+internal buffers, and demonstrates how to do cubic interpolation from an array of samples.
 
 section:: Anatomy of a UGen
 

--- a/HelpSource/Guides/WritingUGens.schelp
+++ b/HelpSource/Guides/WritingUGens.schelp
@@ -4,9 +4,12 @@ categories:: Internals
 
 section:: Pseudo-ugens
 
-Pseudo-ugens are useful when you want to abbreviate a certain configuration of UGens that gets used repeatedly. A pseudo-ugen is a class that superficially resembles a UGen class, but it only returns a composition of existing UGens. Pseudo-ugens exist only in the client -- the server isn't aware of them and only receives their components.
+Pseudo-ugens are useful when you want to abbreviate a certain configuration of UGens that gets used repeatedly. A
+pseudo-ugen is a class that superficially resembles a UGen class, but it only returns a composition of existing UGens.
+Pseudo-ugens exist only in the client -- the server isn't aware of them and only receives their components.
 
-The below example has only a code::.ar:: method, but you can just as easily have both code::.ar:: and code::.kr:: methods.
+The below example has only a code::.ar:: method, but you can just as easily have both code::.ar:: and code::.kr::
+methods.
 
 code::
 BoringMixer {
@@ -16,21 +19,27 @@ BoringMixer {
 }
 ::
 
-Examples of pseudo-ugens found in SC include link::Classes/BLowPass4:: and link::Classes/BHiPass4::, which break down into link::Classes/SOS:: UGens.
+Examples of pseudo-ugens found in SC include link::Classes/BLowPass4:: and link::Classes/BHiPass4::, which break down
+into link::Classes/SOS:: UGens.
 
 There are very few restrictions on what these classes can contain, but you should keep the following in mind:
 
 list::
 ## It is courteous to leave a note in your class's help file that identifies it as a pseudo-ugen.
 ## To avoid confusion, pseudo-ugens should not inherit from the base class link::Classes/UGen::.
-## A SynthDef can only have two link::Classes/LocalIn::/link::Classes/LocalOut:: pairings — one for control rate and one for audio rate. Putting LocalIn and LocalOut in a pseudo-ugen is a bad idea, as it could interfere with other feedback loops in the SynthDef.
+## A SynthDef can only have two link::Classes/LocalIn::/link::Classes/LocalOut:: pairings — one for control rate and one
+for audio rate. Putting LocalIn and LocalOut in a pseudo-ugen is a bad idea, as it could interfere with other feedback
+loops in the SynthDef.
 ::
 
 section:: Basics of UGens
 
-A (real) UGen needs two components: a plugin for the server, and a class for the language. The class goes in an ordinary code::*.sc:: file, and defines the interface for your UGen in the language. This class is generally just a few lines of code that ultimately call the class method link::Classes/UGen#-multiNew::.
+A (real) UGen needs two components: a plugin for the server, and a class for the language. The class goes in an ordinary
+code::*.sc:: file, and defines the interface for your UGen in the language. This class is generally just a few lines of
+code that ultimately call the class method link::Classes/UGen#-multiNew::.
 
-The server plugin is where the actual UGen behavior is defined. It is given by a dynamically loaded library written in C++, whose format is platform-dependent:
+The server plugin is where the actual UGen behavior is defined. It is given by a dynamically loaded library written in
+C++, whose format is platform-dependent:
 
 list::
 ## code::*.so:: for *nix
@@ -38,90 +47,28 @@ list::
 ## code::*.scx:: for OS X
 ::
 
-A plugin file can contain more than one UGen, and it can also define things other than ugens such as buffer fill ("/b_gen") commands.
+A plugin file can contain more than one UGen, and it can also define things other than ugens such as buffer fill
+("/b_gen") commands.
 
-When scsynth boots, it will look for plugin files in code::Platform.userExtensionDir::. Since sclang also looks for class files in the same location, the class file and the library file can go in the same place.
+When scsynth boots, it will look for plugin files in code::Platform.userExtensionDir::. Since sclang also looks for
+class files in the same location, the class file and the library file can go in the same place.
 
-Plug-ins are loaded during the startup of scsynth, so the server will have to be restarted after (re-)compiling a plugin. If you modify the plugin file but not the class file, you don't need to reboot the interpreter.
+Plug-ins are loaded during the startup of scsynth, so the server will have to be restarted after (re-)compiling a
+plugin. If you modify the plugin file but not the class file, you don't need to reboot the interpreter.
 
 section:: FAUST
 
-note:: This section is currently Linux only. Please expand to include instructions for other platforms. ::
+FAUST footnote::http://faust.grame.fr/:: is an open source DSP language that describes real-time audio units. It can
+compile to SuperCollider plugins, providing an easy way to create UGens in SuperCollider.
 
-FAUST footnote::http://faust.grame.fr/:: is an open source DSP language that describes real-time audio units. Its greatest strength is that it can be compiled into a huge variety of contexts: standalone GUI applications, Flash plugins, Max/MSP or Pure Data externals, CSOUND opcodes, VST plugins, etc. It can also compile to SuperCollider plugins, providing the easiest way to create real UGens in SuperCollider.
+FAUST provides a shell script useful for SuperCollider users called code::faust2supercollider::. This compiles a .dsp
+file into a class file and server plugin, which you can then drop into your extensions directory.
 
-subsection:: The easy way
-
-First, write a FAUST program such as the below:
-
-code::
-process = + : *(0.5);
-::
-
-which is a boring ugen that just averages its two inputs. Save this as BoringMixer.dsp, and run the following at the command line:
-
-code::
-faust2supercollider BoringMixer.dsp
-::
-
-This will generate BoringMixer.sc and BoringMixer.so files in the current directory. Both of these need to go into your extensions directory. After installing them, reboot both the interpreter and the server, and a class named code::FaustBoringMixer:: should show up in sclang. You can verify that code::FaustBoringMixer.ar:: and code::FaustBoringMixer.kr:: both work as expected.
-
-subsection:: The hard way
-
-note:: This section is currently Linux only. Please expand to include instructions for other platforms. ::
-
-faust2supercollider is not actually the FAUST compiler. It's a handy shell script that hides a somewhat more complicated process: first, it compiles your FAUST .dsp file into a C++ file with the SuperCollider architecture, and then into a shared library usable by scsynth. It generates a file for sclang on the side.
-
-On another note, it would be nice to get rid of the Faust prefix on our ugen. We'll take this as an opportunity to walk through the above manual process, making for a good transition into hand-written C++ ugens. Get yourself into an empty directory, drop your DSP file there and compile into C++ with the following command:
-
-code::
-faust -a supercollider.cpp BoringMixer.dsp -o BoringMixer.cpp
-::
-
-This is the actual FAUST compiler. We're compiling BoringMixer.dsp using the SuperCollider architecture (as indicated by the argument to the -a option) and writing output to BoringMixer.cpp.
-
-Next we'll set up a build system with CMake. This is overkill for just compiling one ugen, but this results in a rigorous, cross-platform environment that we'll be using again when we start constructing UGens by hand. Create a file in the same directory called `CMakeLists.txt` and add the following:
-
-code::
-cmake_minimum_required (VERSION 2.8)
-project (MyUGens)
-
-include_directories(${SC_PATH}/include/plugin_interface)
-include_directories(${SC_PATH}/include/common)
-include_directories(${SC_PATH}/external_libraries/libsndfile/)
-
-set(CMAKE_SHARED_MODULE_PREFIX "")
-if(APPLE OR WIN32)
-set(CMAKE_SHARED_MODULE_SUFFIX ".scx")
-endif()
-
-add_library(BoringMixer MODULE BoringMixer.cpp)
-::
-
-You can replace the MyUGens name with anything else.
-
-To compile, you'll need to have a copy of the SuperCollider source code sitting around (since your plugin uses includes provided by SC). Having obtained that:
-
-code::
-cmake -G "Unix Makefiles" -DSC_PATH=/path/to/SuperCollider-Source/
-make
-::
-
-If all goes well, compilation will complete and a file named BoringMixer.so should show up in the current directory.
-
-We'll also create an sclang class file by hand:
-
-code::
-BoringMixer : UGen {
-	*ar { |left, right|
-		^this.multiNew('audio', left, right);
-	}
-}
-::
-
-Save this as BoringMixer.sc (although any name will do, really) and copy both the .so file and the .sc file into somewhere in the code::Platform.userExtensionDir:: directory. Reboot the interpreter and server and you will have a working code::BoringMixer:: ugen.
-
-FAUST plugins are easy to develop and can be painlessly ported to other environments. Unfortunately, they can't take advantage of all of scsynth's features, such as accessing Buffers or random number generators, and some ugens featuring very complex logic are difficult or impossible to write in FAUST. FAUST is most ideal for audio units that are easy to express with block diagrams. Furthermore, the FAUST compiler is quite intelligent but it might not always offer the best efficiency in its results. If a ugen you are developing hits these limitations, it is time to move on to handwritten C++.
+FAUST plugins are often quick to develop and can be painlessly ported to other environments. Unfortunately, they can't
+take advantage of all of scsynth's features, such as accessing Buffers or random number generators, and some ugens
+featuring very complex logic are difficult or impossible to write in FAUST. Furthermore, the FAUST compiler is quite
+intelligent but it might not always offer the best efficiency in its results. If a ugen you are developing hits these
+limitations, it is time to move on to handwritten C++.
 
 section:: The Entry Point
 

--- a/HelpSource/Guides/WritingUGens.schelp
+++ b/HelpSource/Guides/WritingUGens.schelp
@@ -67,8 +67,14 @@ file into a class file and server plugin, which you can then drop into your exte
 FAUST plugins are often quick to develop and can be painlessly ported to other environments. Unfortunately, they can't
 take advantage of all of scsynth's features, such as accessing Buffers or random number generators, and some ugens
 featuring very complex logic are difficult or impossible to write in FAUST. Furthermore, the FAUST compiler is quite
-intelligent but it might not always offer the best efficiency in its results. If a ugen you are developing hits these
+intelligent but it might not always offer the best efficiency in its results. If a UGen you are developing hits these
 limitations, it is time to move on to handwritten C++.
+
+section:: A Minimal Working Example
+
+To get an idea of the necessary ingredients for writing UGens, it's often best to poke around at a complete example.
+We've set up a GitHub repository at https://github.com/snappizz/plugin-example. You can fork this to create your own
+UGens.
 
 section:: The Entry Point
 
@@ -98,6 +104,20 @@ list::
 ## The unit generator destructor is named code::PluginName_Dtor::
 ::
 
+section:: The Calculation Function
+
+The meat of the UGen is its calculation function, which gets called every control period with the UGen object as an
+argument. (This is for control-rate and audio-rate UGens -- demand-rate is different.) In this function, the UGen reads
+from its inputs and writes to its outputs.
+
+The calculation function is selected in the code::PluginName_Ctor:: function with the code::SETCALC:: macro. You can
+name the calculation function whatever you want, but the convention is code::PluginName_next::.
+
+UGens often have multiple calculation functions, depending on the rate of the UGen itself and the rate of its inputs.
+For example, Phasor can be .ar or .kr, and its argument can be either .ar or .kr. So it has four calculation functions:
+Phasor_next_aa, Phasor_next_ak, Phasor_next_ka, and Phasor_next_kk. You don't need to be this thorough for your own
+UGens, however. For example, link::Classes/FreeVerb:: has only one calculation function. Who would want a control-rate
+reverb?
 
 section:: A Simple Unit Generator Plugin
 
@@ -107,7 +127,8 @@ example implements a simple Sawtooth oscillator
 
 subsection:: C++-side Definition of Unit Generators
 
-The following code shows the C++ source of a simple unit generator.
+The following code shows the C++ source of a simple unit generator. It's the same as MySaw.cpp in the example
+repository.
 
 code::
 #include "SC_PlugIn.h"

--- a/HelpSource/Guides/WritingUGens.schelp
+++ b/HelpSource/Guides/WritingUGens.schelp
@@ -1,6 +1,7 @@
 title:: Writing Unit Generators
 summary:: Get started with writing unit generators
 categories:: Internals
+related:: Reference/ServerPluginAPI
 
 section:: Pseudo-ugens
 

--- a/HelpSource/Guides/WritingUGens.schelp
+++ b/HelpSource/Guides/WritingUGens.schelp
@@ -26,19 +26,31 @@ list::
 ## A SynthDef can only have two link::Classes/LocalIn::/link::Classes/LocalOut:: pairings — one for control rate and one for audio rate. Putting LocalIn and LocalOut in a pseudo-ugen is a bad idea, as it could interfere with other feedback loops in the SynthDef.
 ::
 
-section:: Basics of real UGens
+section:: Basics of UGens
 
-A real UGen needs two components: a plugin for the server, and a class for the language. The class goes in an ordinary code::*.sc:: file, and defines the interface for your UGen in the language. This class is generally just a few lines of code that ultimately call the class method link::Classes/UGen#-multiNew::.
+A (real) UGen needs two components: a plugin for the server, and a class for the language. The class goes in an ordinary code::*.sc:: file, and defines the interface for your UGen in the language. This class is generally just a few lines of code that ultimately call the class method link::Classes/UGen#-multiNew::.
 
-The server plugin is where the actual UGen behavior is defined. It is given by a platform-dependent library file: code::*.so:: for *nix, code::*.dll:: for Windows, and code::*.scx:: for OS X [fact check needed on the last two -NH]. A library file can contain more than one UGen.
+The server plugin is where the actual UGen behavior is defined. It is given by a dynamically loaded library written in C++, whose format is platform-dependent:
 
-When scsynth boots, it will look for such library files in code::Platform.userExtensionDir::. Since sclang also looks for class files in the same location, the class file and the library file can go in the same place.
+list::
+## code::*.so:: for *nix
+## code::*.dll:: for Windows
+## code::*.scx:: for OS X
+::
 
-section:: FAUST (the easy way)
+A plugin file can contain more than one UGen, and it can also define things other than ugens such as buffer fill ("/b_gen") commands.
+
+When scsynth boots, it will look for plugin files in code::Platform.userExtensionDir::. Since sclang also looks for class files in the same location, the class file and the library file can go in the same place.
+
+Plug-ins are loaded during the startup of scsynth, so the server will have to be restarted after (re-)compiling a plugin. If you modify the plugin file but not the class file, you don't need to reboot the interpreter.
+
+section:: FAUST
 
 note:: This section is currently Linux only. Please expand to include instructions for other platforms. ::
 
 FAUST footnote::http://faust.grame.fr/:: is an open source DSP language that describes real-time audio units. Its greatest strength is that it can be compiled into a huge variety of contexts: standalone GUI applications, Flash plugins, Max/MSP or Pure Data externals, CSOUND opcodes, VST plugins, etc. It can also compile to SuperCollider plugins, providing the easiest way to create real UGens in SuperCollider.
+
+subsection:: The easy way
 
 First, write a FAUST program such as the below:
 
@@ -54,7 +66,7 @@ faust2supercollider BoringMixer.dsp
 
 This will generate BoringMixer.sc and BoringMixer.so files in the current directory. Both of these need to go into your extensions directory. After installing them, reboot both the interpreter and the server, and a class named code::FaustBoringMixer:: should show up in sclang. You can verify that code::FaustBoringMixer.ar:: and code::FaustBoringMixer.kr:: both work as expected.
 
-section:: FAUST (the hard way)
+subsection:: The hard way
 
 note:: This section is currently Linux only. Please expand to include instructions for other platforms. ::
 
@@ -109,13 +121,7 @@ BoringMixer : UGen {
 
 Save this as BoringMixer.sc (although any name will do, really) and copy both the .so file and the .sc file into somewhere in the code::Platform.userExtensionDir:: directory. Reboot the interpreter and server and you will have a working code::BoringMixer:: ugen.
 
-section:: How Unit Generator plug-ins work.
-
-The server loads unit generator plug-ins when it starts up. Unit Generator plug-ins are dynamically loaded libraries
-written in C++. Each library may contain one or multiple unit generator definitions. A plug-in can also define things
-other than unit generators such as buffer fill ("/b_gen") commands. Plug-ins are loaded during the startup of the
-synthesis server. Therefore the server will have to be restarted after (re-)compiling the plugin.
-
+FAUST plugins are easy to develop and can be painlessly ported to other environments. Unfortunately, they can't take advantage of all of scsynth's features, such as accessing Buffers or random number generators, and some ugens featuring very complex logic are difficult or impossible to write in FAUST. FAUST is most ideal for audio units that are easy to express with block diagrams. Furthermore, the FAUST compiler is quite intelligent but it might not always offer the best efficiency in its results. If a ugen you are developing hits these limitations, it is time to move on to handwritten C++.
 
 section:: The Entry Point
 

--- a/HelpSource/Guides/WritingUGens.schelp
+++ b/HelpSource/Guides/WritingUGens.schelp
@@ -93,7 +93,12 @@ We've set up a GitHub repository at https://github.com/supercollider/example-plu
 plugins numbered roughly by complexity. Each directory in that repository is self-contained with its own build system,
 so you can copy out a directory to form a starting point for your own UGens.
 
-section:: The Entry Point
+section:: Anatomy of a UGen
+
+The SC source code has a header file, code::server/plugins/SC_Plugin.h::, that gives you your interface to the scsynth
+architecture as well as a bunch of helper functions. These are documented at link::Reference/ServerPluginAPI::.
+
+subsection:: The Entry Point
 
 When the library is loaded the server calls a function in the library, which is defined by the code::PluginLoad()::
 macro.  This entry point has two responsibilities:
@@ -121,7 +126,7 @@ list::
 ## The unit generator destructor is named code::PluginName_Dtor::
 ::
 
-section:: The Calculation Function
+subsection:: The Calculation Function
 
 The meat of the UGen is its calculation function, which gets called every control period with the UGen object as an
 argument. (This is for control-rate and audio-rate UGens -- demand-rate is different.) In this function, the UGen reads
@@ -136,202 +141,12 @@ Phasor_next_aa, Phasor_next_ak, Phasor_next_ka, and Phasor_next_kk. You don't ne
 UGens, however. For example, link::Classes/FreeVerb:: has only one calculation function. Who would want a control-rate
 reverb?
 
-section:: A Simple Unit Generator Plugin
-
-Unit generator plugins require two parts: A C++ part, which implements the server-side code that is loaded as a
-dynamically loaded library, and an SCLang class, that is required to build the link::Classes/SynthDef::. The following
-example implements a simple Sawtooth oscillator
-
-subsection:: C++-side Definition of Unit Generators
-
-The following code shows the C++ source of a simple unit generator. It's the same as MySaw.cpp in the example
-repository.
-
-code::
-#include "SC_PlugIn.h"
-
-// InterfaceTable contains pointers to functions in the host (server).
-static InterfaceTable *ft;
-
-// declare struct to hold unit generator state
-struct MySaw : public Unit
-{
-	double mPhase; // phase of the oscillator, from -1 to 1.
-	float mFreqMul; // a constant for multiplying frequency
-};
-
-// declare unit generator functions
-static void MySaw_next_a(MySaw *unit, int inNumSamples);
-static void MySaw_next_k(MySaw *unit, int inNumSamples);
-static void MySaw_Ctor(MySaw* unit);
-
-
-//////////////////////////////////////////////////////////////////
-
-// Ctor is called to initialize the unit generator.
-// It only executes once.
-
-// A Ctor usually does 3 things.
-// 1. set the calculation function.
-// 2. initialize the unit generator state variables.
-// 3. calculate one sample of output.
-void MySaw_Ctor(MySaw* unit)
-{
-	// 1. set the calculation function.
-	if (INRATE(0) == calc_FullRate) {
-		// if the frequency argument is audio rate
-		SETCALC(MySaw_next_a);
-	} else {
-		// if the frequency argument is control rate (or a scalar).
-		SETCALC(MySaw_next_k);
-	}
-
-	// 2. initialize the unit generator state variables.
-	// initialize a constant for multiplying the frequency
-	unit->mFreqMul = 2.0 * SAMPLEDUR;
-	// get initial phase of oscillator
-	unit->mPhase = IN0(1);
-
-	// 3. calculate one sample of output.
-	MySaw_next_k(unit, 1);
-}
-
-
-//////////////////////////////////////////////////////////////////
-
-// The calculation function executes once per control period
-// which is typically 64 samples.
-
-// calculation function for an audio rate frequency argument
-void MySaw_next_a(MySaw *unit, int inNumSamples)
-{
-	// get the pointer to the output buffer
-	float *out = OUT(0);
-
-	// get the pointer to the input buffer
-	float *freq = IN(0);
-
-	// get phase and freqmul constant from struct and store it in a
-	// local variable.
-	// The optimizer will cause them to be loaded it into a register.
-	float freqmul = unit->mFreqMul;
-	double phase = unit->mPhase;
-
-	// perform a loop for the number of samples in the control period.
-	// If this unit is audio rate then inNumSamples will be 64 or whatever
-	// the block size is. If this unit is control rate then inNumSamples will
-	// be 1.
-	for (int i=0; i < inNumSamples; ++i)
-	{
-		// out must be written last for in place operation
-		float z = phase;
-		phase += freq[i] * freqmul;
-
-		// these if statements wrap the phase a +1 or -1.
-		if (phase >= 1.f) phase -= 2.f;
-		else if (phase <= -1.f) phase += 2.f;
-
-		// write the output
-		out[i] = z;
-	}
-
-	// store the phase back to the struct
-	unit->mPhase = phase;
-}
-
-//////////////////////////////////////////////////////////////////
-
-// calculation function for a control rate frequency argument
-void MySaw_next_k(MySaw *unit, int inNumSamples)
-{
-	// get the pointer to the output buffer
-	float *out = OUT(0);
-
-	// freq is control rate, so calculate it once.
-	float freq = IN0(0) * unit->mFreqMul;
-
-	// get phase from struct and store it in a local variable.
-	// The optimizer will cause it to be loaded it into a register.
-	double phase = unit->mPhase;
-
-	// since the frequency is not changing then we can simplify the loops
-	// by separating the cases of positive or negative frequencies.
-	// This will make them run faster because there is less code inside the loop.
-	if (freq >= 0.f) {
-		// positive frequencies
-		for (int i=0; i < inNumSamples; ++i)
-		{
-			out[i] = phase;
-			phase += freq;
-			if (phase >= 1.f) phase -= 2.f;
-		}
-	} else {
-		// negative frequencies
-		for (int i=0; i < inNumSamples; ++i)
-		{
-			out[i] = phase;
-			phase += freq;
-			if (phase <= -1.f) phase += 2.f;
-		}
-	}
-
-	// store the phase back to the struct
-	unit->mPhase = phase;
-}
-
-
-// the entry point is called by the host when the plug-in is loaded
-PluginLoad(MySaw)
-{
-    // InterfaceTable *inTable implicitly given as argument to the load function
-	ft = inTable; // store pointer to InterfaceTable
-
-	DefineSimpleUnit(MySaw);
-}
-::
-
-subsection:: SCLang-side Definition of Unit Generators
-
-SuperCollider requires an SCLang class in order to build SynthDefs.
-
-The arguments to the MySaw UGen are code::freq:: and code::iphase::.  The code::multiNew:: method handles multi channel
-expansion.  The code::madd:: method provides support for the mul and add arguments. It will create a MulAdd UGen if
-necessary. You could write the class without mul and add arguments, but providing them makes it more convenient for the
-user. See link::Guides/WritingClasses:: for details on writing sclang classes.
-
-code::
-// without mul and add.
-MySaw : UGen {
-	*ar { arg freq = 440.0, iphase = 0.0;
-		^this.multiNew('audio', freq, iphase)
-	}
-	*kr { arg freq = 440.0, iphase = 0.0;
-		^this.multiNew('control', freq, iphase)
-	}
-}
-::
-
 subsection:: Building Unit Generator Plugins
 
 The most portable way to build plugins is using cmake footnote::http://www.cmake.org::, a cross-platform build
-system. In order build the example with cmake, the following code should go into a code::CMakeLists.txt:: file.
+system.
 
-code::
-cmake_minimum_required (VERSION 2.8)
-project (MySaw)
-
-include_directories(${SC_PATH}/include/plugin_interface)
-include_directories(${SC_PATH}/include/common)
-include_directories(${SC_PATH}/external_libraries/libsndfile/)
-
-set(CMAKE_SHARED_MODULE_PREFIX "")
-if(APPLE OR WIN32)
-set(CMAKE_SHARED_MODULE_SUFFIX ".scx")
-endif()
-
-add_library(MySaw MODULE MySaw.cpp)
-::
-
+The examples in the example repository contain code::CMakeLists.txt:: files.
 
 section:: Coding Guidelines
 
@@ -350,7 +165,7 @@ definitionList::
 ::
 
 
-section:: Thread Safety
+subsection:: Thread Safety
 
 There are two different implementations of the SuperCollider server. strong::scsynth:: is the traditional server and
 strong::supernova:: is a new implementation with support for multi-processor audio synthesis. Since the plugins in

--- a/HelpSource/Guides/WritingUGens.schelp
+++ b/HelpSource/Guides/WritingUGens.schelp
@@ -3,11 +3,26 @@ summary:: Get started with writing unit generators
 categories:: Internals
 related:: Reference/ServerPluginAPI
 
+SuperCollider has a vast library of unit generators that can be assembled in unlimited ways, but sometimes even those
+aren't sufficient. You may have a need for an unusual signal processing algorithm, or you're running into efficiency
+problems that can be solved by condensing parts of your SynthDef into a single UGen.
+
+UGens are defined in server plugins written in C++. Server plugins are not to be confused with quarks, which extend the
+SuperCollider language. UGens exist more or less independently of the interpreter and you don't need much familiarity
+with SC to write them.
+
+Writing UGens is not too difficult, but it's arguably far less convenient and intuitive than the high-level tools that
+SuperCollider provides. You'll need a build system and a good amount of boilerplate code -- even fairly basic signal
+processing operations can require a lot of code. You don't have an instant live coding environment, and mistakes can
+easily crash the server. SuperCollider's UGens are stable and well-tested, and custom UGens are best viewed as a last
+resort for when the limitations of SC are impassable.
+
 section:: Pseudo-UGens
 
-Pseudo-UGens are useful when you want to abbreviate a certain configuration of UGens that gets used repeatedly. A
-pseudo-UGen is a class that superficially resembles a UGen class, but it only returns a composition of existing UGens.
-Pseudo-UGens exist only in the client -- the server isn't aware of them and only receives their components.
+Before we proceed to the real UGens, we'll take a quick detour for the sake of completeness. A pseudo-UGen is a bit of
+SuperCollider code that abbreviates a certain configuration of UGens that gets used repeatedly. A pseudo-UGen is a class
+that superficially resembles a UGen class, but it only returns a composition of existing UGens. It has no efficiency
+savings, but it does save typing.
 
 The below example has only a code::.ar:: method, but you can just as easily have both code::.ar:: and code::.kr::
 methods.
@@ -71,11 +86,12 @@ featuring very complex logic are difficult or impossible to write in FAUST. Furt
 intelligent but it might not always offer the best efficiency in its results. If a UGen you are developing hits these
 limitations, it is time to move on to handwritten C++.
 
-section:: A Minimal Working Example
+section:: Example Plugins
 
-To get an idea of the necessary ingredients for writing UGens, it's often best to poke around at a complete example.
-We've set up a GitHub repository at https://github.com/snappizz/plugin-example. You can fork this to create your own
-UGens.
+To get an idea of the necessary ingredients for writing UGens, it's often best to poke around at complete examples.
+We've set up a GitHub repository at https://github.com/supercollider/example-plugins, which contains some example
+plugins numbered roughly by complexity. Each directory in that repository is self-contained with its own build system,
+so you can copy out a directory to form a starting point for your own UGens.
 
 section:: The Entry Point
 

--- a/HelpSource/Reference/ServerPluginAPI.schelp
+++ b/HelpSource/Reference/ServerPluginAPI.schelp
@@ -142,6 +142,11 @@ sc_atan2
 
 section:: Unroll macros
 
+The macros in this section are legacy features. They are seen in many of SuperCollider's built-in ugens, and are
+intended to provide more efficient alternatives to the standard code::for (int i = 0; i < inNumSamples; i++) { out[i]
+= in[i] }:: loop. These efficiency savings are negligible on modern systems and use of these macros is not recommended,
+especially since they make debugging difficult.
+
 definitionlist::
 ## code::LOOP(length, stmt)::
 || Execute code code::stmt::, code::length:: times.

--- a/HelpSource/Reference/ServerPluginAPI.schelp
+++ b/HelpSource/Reference/ServerPluginAPI.schelp
@@ -1,0 +1,189 @@
+title:: Server Plugin API
+summary:: Writing unit generators
+categories:: Internals
+
+section:: Input rates
+
+These four constants identify the calculation rates of inputs in SuperCollider.
+
+definitionlist::
+## code::calc_ScalarRate::
+|| Initial rate. Conventionally known in the language as ".ir".
+
+## code::calc_BufRate::
+|| Control rate. Conventionally known in the language as ".kr". 
+
+## code::calc_FullRate::
+|| Audio rate. Conventionally known in the language as ".ar".
+
+## code::calc_DemandRate::
+|| Demand rate. 
+::
+
+section:: UGen I/O
+
+definitionlist::
+## code::IN(index)::
+|| A single block of audio-rate input as a float* at the given index. Index 0 is the first input to the ugen, index 1 the second input, and so forth.
+
+## code::IN0(index)::
+|| A single sample of control-rate input as a float, at the given index.
+
+## code::OUT(index)::
+|| A single block of audio-rate output as a float* at the given index.
+
+## code::OUT0(index)::
+|| A single sample of control-rate input as a float, at the given index.
+
+## code::INRATE(index)::
+|| Get the rate of a given input index. This will be one of the four rates.
+::
+
+section:: Unary operators
+
+definitionlist::
+## code::bool sc_isnan(float/double x)::
+|| Is code::x:: NaN?
+
+## code::bool sc_isfinite(float/double x)::
+|| Is code::x:: finite?
+
+## code::int32 sc_grayCode(int32 x)::
+|| Convert binary to Gray code.
+::
+
+The following unary functions are available for both float32 and float64, and are the same as in sclang (minus the "sc_" prefixes):
+
+code::
+sc_log2
+sc_log10
+sc_midicps
+sc_cpsmidi
+sc_midiratio
+sc_ratiomidi
+sc_octcps
+sc_cpsoct
+sc_ampdb
+sc_dbamp
+sc_cubed
+sc_sqrt
+sc_hanwindow
+sc_welwindow
+sc_triwindow
+sc_rectwindow
+sc_scurve
+sc_ramp
+sc_sign
+sc_distort
+sc_softclip
+sc_trunc
+sc_ceil
+sc_floor
+sc_reciprocal
+sc_frac
+::
+
+The following unary functions are available for both float32 and float64, but have no sclang equivalent:
+
+definitionlist::
+## code::zapgremlins(x)::
+|| Replaces NaNs, infinities, very large and very small numbers (including denormals) with zero. This is useful in ugen feedback to safeguard from pathological behavior. (Note lack of sc_ prefix.)
+
+## code::sc_bitriwindow::
+|| Alternative to code::sc_triwindow:: using absolute value.
+
+## code::sc_scurve0(x)::
+|| Same as code::sc_scurve::, but assumes that code::x:: is in the interval [0, 1].
+
+## code::sc_distortneg(x)::
+|| A one-sided distortion function. Same as code::distort:: for code::x > 0::, and the identity function for code::x <= 0::.
+
+## code::taylorsin(x)::
+|| Taylor series approximation of code::sin(x):: out to code::x**9 / 9!::. (Note lack of sc_ prefix.)
+
+## code::sc_lg3interp(x1, a, b, c, d)::
+|| Cubic Lagrange interpolator.
+
+## code::sc_CalcFeedback(delaytime, decaytime)::
+|| Determines the feedback coefficient for a feedback comb filter with the given delay and decay times.
+
+## code::sc_wrap1(x)::
+|| Same as code::sc_wrap::, but wraps only once.
+
+## code::sc_fold1(x)::
+|| Same as code::sc_fold::, but folds only once.
+::
+
+section:: Unroll macros
+
+Audio-rate ugens often use loops that look like this:
+
+code::
+float* in = IN(0);
+float* out = OUT(0);
+for (int i = 0; i < inNumSamples; i++) {
+	out[i] = in[i] * 0.5;
+}
+::
+
+The indexing operations code::out[i]:: and code::in[i]:: invoke pointer addition at every sample. We can speed this up by using increments rather than addition, and speed it up further by using pre-increments, not post-increments (so there is no need for the CPU to preserve the old value). The result is the following:
+
+code::
+float* in = IN(0) - 1;
+float* out = OUT(0) - 1;
+for (int i = 0; i < inNumSamples; i++) {
+	*(++out) = *(++in) * 0.5;
+}
+::
+
+A header file by the name of "Unroll.h" provides macros that clean up this code a bit:
+
+code::
+float* in = ZIN(0);
+float* out = ZOUT(0);
+LOOP1(inNumSamples,
+	ZXP(out) = ZXP(in) * 0.5;
+);
+::
+
+These seem like negligible improvements, but real-time audio can be very sensitive to efficiency losses. Many of SC's built-in ugens use the above format.
+
+definitionlist::
+## code::LOOP(length, stmt)::
+|| Execute code code::stmt::, code::length:: times.
+
+## code::LOOP1(length, stmt)::
+|| A faster drop-in alternative to code::LOOP::, which assumes that code::length > 0:: so a branch instruction is saved. This is recommended for the well-known "inNumSamples loop" because inNumSamples is never zero.
+
+## code::LooP(length) stmt::
+|| An alternative to LOOP/LOOP1 that is more debugger-friendly. The body of the loop comes after the call to code::LooP::.
+
+## code::ZIN(index)::
+|| Similar to code::IN::, but subtracts 1 from the pointer to correct for off-by-one errors when using code::LOOP:: and code::ZXP::.
+
+## code::ZOUT(index)::
+|| Same as code::OUT::, but subtracts 1 from the pointer to correct for off-by-one errors when using code::LOOP:: and code::ZXP::.
+
+## code::ZIN0(index)::
+|| Alias for code::IN0::. 
+
+## code::ZOUT0(index)::
+|| Alias for code::OUT0::.
+
+## code::ZXP(z)::
+|| Pre-increment and dereference code::z::.
+
+## code::ZX(z)::
+|| Dereference code::z::.
+
+## code::PZ(z)::
+|| Pre-increment code::z::.
+
+## code::ZP(z)::
+|| Does nothing.
+
+## code::ZOFF::
+|| Return 1.
+::
+
+The macros on this list -- especially the last few -- seem odd and unnecessary, and that is because the Unroll macros are designed to be swappable in case a platform is found where post-increment is faster.

--- a/HelpSource/Reference/ServerPluginAPI.schelp
+++ b/HelpSource/Reference/ServerPluginAPI.schelp
@@ -89,7 +89,7 @@ definitionlist::
 ## code::zapgremlins(x)::
 || Replaces NaNs, infinities, very large and very small numbers (including denormals) with zero. This is useful in ugen feedback to safeguard from pathological behavior. (Note lack of sc_ prefix.)
 
-## code::sc_bitriwindow::
+## code::sc_bitriwindow(x)::
 || Alternative to code::sc_triwindow:: using absolute value.
 
 ## code::sc_scurve0(x)::
@@ -108,52 +108,46 @@ definitionlist::
 || Determines the feedback coefficient for a feedback comb filter with the given delay and decay times.
 
 ## code::sc_wrap1(x)::
-|| Same as code::sc_wrap::, but wraps only once.
+|| Wrap code::x:: around ±1, wrapping only once.
 
 ## code::sc_fold1(x)::
-|| Same as code::sc_fold::, but folds only once.
+|| Fold code::x:: around ±1, folding only once.
+::
+
+section:: Binary operators
+
+definitionlist::
+## code::sc_mod(in, hi)::
+|| code::in:: modulo code::hi::.
+
+## code::sc_wrap(in, lo, hi [, range])::
+||
+
+## code::sc_fold(in, lo, hi [, range [, range2]])::
+||
+
+## code::sc_pow(a, b)::
+|| Compute code::pow(a, b)::, retaining the sign of code::a::.
+::
+
+The following functions are available for both floats and doubles, and are the same as in sclang (minus the "sc_" prefixes):
+
+code::
+sc_mod
+sc_round
+sc_roundUp
+sc_trunc
+sc_atan2
 ::
 
 section:: Unroll macros
-
-Audio-rate ugens often use loops that look like this:
-
-code::
-float* in = IN(0);
-float* out = OUT(0);
-for (int i = 0; i < inNumSamples; i++) {
-	out[i] = in[i] * 0.5;
-}
-::
-
-The indexing operations code::out[i]:: and code::in[i]:: invoke pointer addition at every sample. We can speed this up by using increments rather than addition, and speed it up further by using pre-increments, not post-increments (so there is no need for the CPU to preserve the old value). The result is the following:
-
-code::
-float* in = IN(0) - 1;
-float* out = OUT(0) - 1;
-for (int i = 0; i < inNumSamples; i++) {
-	*(++out) = *(++in) * 0.5;
-}
-::
-
-A header file by the name of "Unroll.h" provides macros that clean up this code a bit:
-
-code::
-float* in = ZIN(0);
-float* out = ZOUT(0);
-LOOP1(inNumSamples,
-	ZXP(out) = ZXP(in) * 0.5;
-);
-::
-
-These seem like negligible improvements, but real-time audio can be very sensitive to efficiency losses. Many of SC's built-in ugens use the above format.
 
 definitionlist::
 ## code::LOOP(length, stmt)::
 || Execute code code::stmt::, code::length:: times.
 
 ## code::LOOP1(length, stmt)::
-|| A faster drop-in alternative to code::LOOP::, which assumes that code::length > 0:: so a branch instruction is saved. This is recommended for the well-known "inNumSamples loop" because inNumSamples is never zero.
+|| A faster drop-in alternative to code::LOOP::, which assumes that code::length > 0:: so a branch instruction is saved.
 
 ## code::LooP(length) stmt::
 || An alternative to LOOP/LOOP1 that is more debugger-friendly. The body of the loop comes after the call to code::LooP::.
@@ -185,5 +179,3 @@ definitionlist::
 ## code::ZOFF::
 || Return 1.
 ::
-
-The macros on this list -- especially the last few -- seem odd and unnecessary, and that is because the Unroll macros are designed to be swappable in case a platform is found where post-increment is faster.

--- a/HelpSource/Reference/ServerPluginAPI.schelp
+++ b/HelpSource/Reference/ServerPluginAPI.schelp
@@ -1,6 +1,7 @@
 title:: Server Plugin API
-summary:: Writing unit generators
+summary:: Reference for writing unit generators
 categories:: Internals
+related:: Guides/WritingUGens
 
 section:: Input rates
 

--- a/HelpSource/Reference/ServerPluginAPI.schelp
+++ b/HelpSource/Reference/ServerPluginAPI.schelp
@@ -22,6 +22,8 @@ definitionlist::
 
 section:: UGen basics
 
+These helper macros assume that there is a ugen object called code::unit:: in the local scope.
+
 definitionlist::
 ## code::IN(index)::
 || A single block of audio-rate input as a float* at the given index. Index 0 is the first input to the ugen, index 1 the second input, and so forth.
@@ -318,6 +320,37 @@ list::
 ## code::sc_sqrsum(a, b)::
 ## code::sc_sqrdif(a, b)::
 ## code::sc_atan2(a, b):: (legacy -- use code::std\::atan2::)
+::
+
+section:: Constants
+
+The following constants are doubles:
+
+list::
+## code::pi::
+## code::pi2:: = pi/2
+## code::pi32:: = 3pi/2
+## code::twopi:: = 2pi
+## code::rtwopi:: (1/2pi)
+## code::log001:: = log(0.001)
+## code::log01:: = log(0.01)
+## code::log1:: = log(0.1)
+## code::rlog2:: = 1/log(2)
+## code::sqrt2:: = sqrt(2)
+## code::rsqrt2:: = 1/sqrt(2)
+## code::truncDouble:: = 3 * 2^51 (used to truncate precision)
+::
+
+The following constants are floats:
+
+list::
+## code::pi_f::
+## code::pi2_f::
+## code::pi32_f::
+## code::twopi_f::
+## code::sqrt2_f::
+## code::rsqrt2_f::
+## code::truncFloat:: = 3 * 2^22 (used to truncate precision)
 ::
 
 section:: Unroll macros

--- a/HelpSource/Reference/ServerPluginAPI.schelp
+++ b/HelpSource/Reference/ServerPluginAPI.schelp
@@ -20,7 +20,7 @@ definitionlist::
 || Demand rate. 
 ::
 
-section:: UGen I/O
+section:: UGen basics
 
 definitionlist::
 ## code::IN(index)::
@@ -37,6 +37,82 @@ definitionlist::
 
 ## code::INRATE(index)::
 || Get the rate of a given input index. This will be one of the four rates.
+
+## code::INBUFLENGTH(index)::
+|| Get the block size of a given input index.
+
+## code::SAMPLERATE::
+|| Sample rate of the server in Hertz.
+
+## code::SAMPLEDUR::
+|| Sample period of the server in seconds.
+
+## code::BUFLENGTH::
+|| Length in samples of an audio buffer (that is, the number of samples in a control period).
+
+## code::BUFRATE::
+|| Control rate of the server in Hertz.
+
+## code::BUFDUR::
+|| Control period of the server in seconds.
+
+## code::FULLRATE::
+||
+
+## code::FULLBUFLENGTH::
+||
+::
+
+section:: Buffers
+
+definitionlist::
+## code::GET_BUF::
+|| The recommended way to retrieve a buffer. Take the first input of this UGen and use it as a buffer number. This dumps
+a number of variables into the local scope:
+
+list::
+## code::buf:: - a pointer to the code::SndBuf:: instance
+## code::bufData:: - the raw float data from the buffer
+## code::bufChannels:: - the number of channels in the buffer
+## code::bufSamples:: - the number of samples in the buffer
+## code::bufFrames:: - the number of frames in the buffer
+::
+
+The buffer is locked using the code::LOCK_SNDBUF:: macro. Buffer lock operations are specific to supernova, and don't
+do anything in vanilla scsynth.
+
+## code::GET_BUF_SHARED::
+|| Like code::GET_BUF::, but the buffer is locked using code::LOCK_SNDBUF_SHARED::.
+
+## code::SIMPLE_GET_BUF::
+|| Like code::GET_BUF::, but only creates the code::buf:: variable and does not lock the buffer.
+
+## code::SIMPLE_GET_BUF_EXCLUSIVE::
+|| Like code::SIMPLE_GET_BUF::, but locks the buffer with code::LOCK_SNDBUF::.
+
+## code::SIMPLE_GET_BUF_SHARED::
+|| Like code::SIMPLE_GET_BUF::, but locks the buffer with code::LOCK_SNDBUF_SHARED::.
+::
+
+The following macros are for use in supernova. They still exist in scsynth, but will have no effect.
+
+code::
+ACQUIRE_BUS_AUDIO(index)
+ACQUIRE_BUS_AUDIO_SHARED(index)
+RELEASE_BUS_AUDIO(index)
+RELEASE_BUS_AUDIO_SHARED(index)
+LOCK_SNDBUF(buf)
+LOCK_SNDBUF_SHARED(buf)
+LOCK_SNDBUF2(buf1, buf2)
+LOCK_SNDBUF2_SHARED(buf1, buf2)
+LOCK_SNDBUF2_EXCLUSIVE_SHARED(buf1, buf2)
+LOCK_SNDBUF2_SHARED_EXCLUSIVE(buf1, buf2)
+ACQUIRE_SNDBUF(buf)
+ACQUIRE_SNDBUF_SHARED(buf)
+RELEASE_SNDBUF(buf)
+RELEASE_SNDBUF_SHARED(buf)
+ACQUIRE_BUS_CONTROL(index)
+RELEASE_BUS_CONTROL(index)
 ::
 
 section:: Unary operators

--- a/HelpSource/Reference/ServerPluginAPI.schelp
+++ b/HelpSource/Reference/ServerPluginAPI.schelp
@@ -43,51 +43,53 @@ section:: Unary operators
 
 definitionlist::
 ## code::bool sc_isnan(float/double x)::
-|| Is code::x:: NaN?
+|| Checks whether code::x:: is NaN. This is a legacy function, use code::std\::isnan:: instead.
 
 ## code::bool sc_isfinite(float/double x)::
-|| Is code::x:: finite?
+|| Checks whether code::x:: is finite. This is a legacy function, use code::std\::isfinite:: instead.
 
 ## code::int32 sc_grayCode(int32 x)::
 || Convert binary to Gray code.
 ::
 
-The following unary functions are available for both float32 and float64, and are the same as in sclang (minus the "sc_" prefixes):
+The following unary functions are available for both float32 and float64, and are the same as in sclang (minus the "sc_"
+prefixes):
 
-code::
-sc_log2
-sc_log10
-sc_midicps
-sc_cpsmidi
-sc_midiratio
-sc_ratiomidi
-sc_octcps
-sc_cpsoct
-sc_ampdb
-sc_dbamp
-sc_cubed
-sc_sqrt
-sc_hanwindow
-sc_welwindow
-sc_triwindow
-sc_rectwindow
-sc_scurve
-sc_ramp
-sc_sign
-sc_distort
-sc_softclip
-sc_trunc
-sc_ceil
-sc_floor
-sc_reciprocal
-sc_frac
+list::
+## code::sc_midicps::
+## code::sc_cpsmidi::
+## code::sc_midiratio::
+## code::sc_ratiomidi::
+## code::sc_octcps::
+## code::sc_cpsoct::
+## code::sc_ampdb::
+## code::sc_dbamp::
+## code::sc_cubed::
+## code::sc_sqrt::
+## code::sc_hanwindow::
+## code::sc_welwindow::
+## code::sc_triwindow::
+## code::sc_rectwindow::
+## code::sc_scurve::
+## code::sc_ramp::
+## code::sc_sign::
+## code::sc_distort::
+## code::sc_softclip::
+## code::sc_ceil::
+## code::sc_floor::
+## code::sc_reciprocal::
+## code::sc_frac::
+## code::sc_log2:: (legacy -- use code::std\::log2(std\::abs(x))::)
+## code::sc_log10:: (legacy -- use code::std\::log10(std\::abs(x))::)
+## code::sc_trunc:: (legacy -- use code::std\::trunc::)
 ::
 
 The following unary functions are available for both float32 and float64, but have no sclang equivalent:
 
 definitionlist::
 ## code::zapgremlins(x)::
-|| Replaces NaNs, infinities, very large and very small numbers (including denormals) with zero. This is useful in ugen feedback to safeguard from pathological behavior. (Note lack of sc_ prefix.)
+|| Replaces NaNs, infinities, very large and very small numbers (including denormals) with zero. This is useful in ugen
+feedback to safeguard from pathological behavior. (Note lack of sc_ prefix.)
 
 ## code::sc_bitriwindow(x)::
 || Alternative to code::sc_triwindow:: using absolute value.
@@ -117,9 +119,6 @@ definitionlist::
 section:: Binary operators
 
 definitionlist::
-## code::sc_mod(in, hi)::
-|| code::in:: modulo code::hi::.
-
 ## code::sc_wrap(in, lo, hi [, range])::
 ||
 
@@ -128,16 +127,45 @@ definitionlist::
 
 ## code::sc_pow(a, b)::
 || Compute code::pow(a, b)::, retaining the sign of code::a::.
+
+## code::sc_powi(x, unsigned int n)::
+|| Compute code::x^n::, not necessarily retaining the sign of code::x::.
+
+## code::sc_hypotx(x, y)::
+|| Compute code::abs(x) + abs(y) - (min(abs(x), abs(y)) * (sqrt(2) - 1))::, the minimum distance one will have to travel
+from the origin to (x,y) using only orthogonal and diagonal movements.
 ::
 
-The following functions are available for both floats and doubles, and are the same as in sclang (minus the "sc_" prefixes):
+The following functions are the same as in sclang (minus the "sc_" prefixes):
 
-code::
-sc_mod
-sc_round
-sc_roundUp
-sc_trunc
-sc_atan2
+list::
+## code::sc_mod(in, hi):: (floats, doubles, ints)
+## code::sc_round(x, quant):: (floats, doubles, ints)
+## code::sc_roundUp(x, quant):: (floats, doubles, ints)
+## code::sc_trunc(x, quant):: (floats, doubles, ints)
+## code::sc_gcd(a, b):: (ints, longs, floats)
+## code::sc_lcm(a, b):: (ints, longs, floats)
+## code::sc_bitAnd(a, b):: (ints)
+## code::sc_bitOr(a, b):: (ints)
+## code::sc_leftShift(a, b):: (ints)
+## code::sc_rightShift(a, b):: (ints)
+## code::sc_unsignedRightShift(a, b):: (ints)
+## code::sc_thresh(a, b)::
+## code::sc_clip2(a, b)::
+## code::sc_wrap2(a, b)::
+## code::sc_fold2(a, b)::
+## code::sc_excess(a, b)::
+## code::sc_scaleneg(a, b)::
+## code::sc_amclip(a, b)::
+## code::sc_ring1(a, b)::
+## code::sc_ring2(a, b)::
+## code::sc_ring3(a, b)::
+## code::sc_ring4(a, b)::
+## code::sc_difsqr(a, b)::
+## code::sc_sumsqr(a, b)::
+## code::sc_sqrsum(a, b)::
+## code::sc_sqrdif(a, b)::
+## code::sc_atan2(a, b):: (legacy -- use code::std\::atan2::)
 ::
 
 section:: Unroll macros

--- a/HelpSource/Reference/ServerPluginAPI.schelp
+++ b/HelpSource/Reference/ServerPluginAPI.schelp
@@ -115,6 +115,82 @@ ACQUIRE_BUS_CONTROL(index)
 RELEASE_BUS_CONTROL(index)
 ::
 
+section:: RGen
+
+RGen is a pseudorandom number generator API. Most ugen developers are not interested in seeding their own RGens and
+would prefer to draw from a global RGen instance supplied by SuperCollider. This can be retrieved with the code:
+
+code::
+RGen& rgen = *unit->mParent->mRGen;
+::
+
+definitionlist::
+## code::uint32 RGen\::trand()::
+|| Return a uniformly distributed random 32-bit integer.
+
+## code::double RGen\::drand()::
+|| Return a uniformly distributed random double in [0,1).
+
+## code::float RGen\::frand()::
+|| Random float in [0,1).
+
+## code::float RGen\::frand0()::
+|| Random float in [1,2).
+
+## code::float RGen\::frand2()::
+|| Random float in [-1,1).
+
+## code::float RGen\::frand8()::
+|| Random float in [-0.125,0.125).
+
+## code::float RGen\::fcoin()::
+|| Either -1 or +1.
+
+## code::float RGen\::flinrand()::
+|| Linearly distributed random float in [0,1), with a bias towards the 0 end.
+
+## code::float RGen\::fbilinrand()::
+|| Bilinearly distributed random float in (-1,1), with a bias towards 0.
+
+## code::float RGen\::fsum3rand()::
+|| A crude but fast approximation to a Gaussian distribution. Results are always in the range (-1,1). The variance is
+1/6 and the standard deviation is 0.41. footnote:: The formula is code::(rand() + rand() + rand() - 1.5) * 2/3::,
+technically a shifted and stretched order-3 Irwin-Hall distribution. ::
+
+## code::int32 RGen\::irand(int32 scale)::
+|| Random int in [0,scale).
+
+## code::int32 RGen\::irand2(int32 scale)::
+|| Random int in [-scale,+scale].
+
+## code::int32 RGen\::ilinrand(int32 scale)::
+|| Linearly distributed random int in [0,scale), with a bias towards the 0 end.
+
+## code::int32 RGen\::ibilinrand(int32 scale)::
+|| Bilinearly distributed random int in (-scale,scale), with a bias towards the 0.
+
+## code::double RGen\::linrand()::
+|| Linearly distributed random double in [0,1), with a bias towards the 0 end.
+
+## code::double RGen\::bilinrand()::
+|| Bilinearly distributed random double in (-1,1), with a bias towards 0.
+
+## code::double RGen\::exprandrng(double lo, double hi)::
+|| Exponentially distributed random double in [lo,hi).
+
+## code::double RGen\::exprand(double scale)::
+||
+
+## code::double RGen\::biexprand(double scale)::
+||
+
+## code::double RGen\::exprand(double scale)::
+||
+
+## code::double RGen\::sum3rand(double scale)::
+|| Double version of code::RGen\::fsum3rand::.
+::
+
 section:: Unary operators
 
 definitionlist::

--- a/HelpSource/Reference/ServerPluginAPI.schelp
+++ b/HelpSource/Reference/ServerPluginAPI.schelp
@@ -11,13 +11,13 @@ definitionlist::
 || Initial rate. Conventionally known in the language as ".ir".
 
 ## code::calc_BufRate::
-|| Control rate. Conventionally known in the language as ".kr". 
+|| Control rate. Conventionally known in the language as ".kr".
 
 ## code::calc_FullRate::
 || Audio rate. Conventionally known in the language as ".ar".
 
 ## code::calc_DemandRate::
-|| Demand rate. 
+|| Demand rate.
 ::
 
 section:: UGen basics
@@ -344,7 +344,7 @@ definitionlist::
 || Same as code::OUT::, but subtracts 1 from the pointer to correct for off-by-one errors when using code::LOOP:: and code::ZXP::.
 
 ## code::ZIN0(index)::
-|| Alias for code::IN0::. 
+|| Alias for code::IN0::.
 
 ## code::ZOUT0(index)::
 || Alias for code::OUT0::.


### PR DESCRIPTION
**Work in progress, do not merge!**

The goal here is twofold -- to make the slope to ugen development much gentler, and to make the API docs more comprehensive. We start off with an explanation of pseudo-ugens, then introduce FAUST, then gradually transition to manually written C++ ugens.

Feel free to contribute and give feedback on whether this is a good approach. I would like help with porting the FAUST instructions for Windows and OS X users, since I have no experience running it on those platforms.