### PR TITLE
help: minor spell fixes in tutorials area

### DIFF
--- a/HelpSource/Tutorials/A-Practical-Guide/PG_02_Basic_Vocabulary.schelp
+++ b/HelpSource/Tutorials/A-Practical-Guide/PG_02_Basic_Vocabulary.schelp
@@ -286,7 +286,7 @@ definitionList::
 
 ## code::Pbeta(lo, hi, prob1, prob2, length):: || Beta distribution, where code::prob1 = α :: (alpha) and code::prob2 = β :: (beta).
 ## code::Pcauchy(mean, spread, length):: || Cauchy distribution.
-## code::Pgauss(mean, dev, length):: || Guassian (normal) distribution.
+## code::Pgauss(mean, dev, length):: || Gaussian (normal) distribution.
 ## code::Phprand(lo, hi, length):: || Returns the greater of two equal-distribution random numbers.
 ## code::Plprand(lo, hi, length):: || Returns the lesser of two equal-distribution random numbers.
 ## code::Pmeanrand(lo, hi, length):: || Returns the average of two equal-distribution random numbers, i.e., code::(x + y) / 2 ::.

--- a/HelpSource/Tutorials/A-Practical-Guide/PG_06a_Repetition_Contraint_Patterns.schelp
+++ b/HelpSource/Tutorials/A-Practical-Guide/PG_06a_Repetition_Contraint_Patterns.schelp
@@ -1,4 +1,4 @@
-title:: Pattern Guide 06a: Repetition Contraint Patterns
+title:: Pattern Guide 06a: Repetition Constraint Patterns
 summary:: Patterns that repeat values, or cut other patterns off early
 related:: Tutorials/A-Practical-Guide/PG_060_Filter_Patterns, Tutorials/A-Practical-Guide/PG_06b_Time_Based_Patterns
 categories:: Streams-Patterns-Events>A-Practical-Guide

--- a/HelpSource/Tutorials/Getting-Started/02-First-Steps.schelp
+++ b/HelpSource/Tutorials/Getting-Started/02-First-Steps.schelp
@@ -120,7 +120,7 @@ list::
 ::
 The sclang part is a sophisticated programming language with nice GUI features; and the server part is a mean, lean, efficient UNIX command line application (meaning it runs without any GUI representation).
 
-They communicate by a protocol called Open Sound Control (OSC), over either UDP or TCP, which are network protocols also used on the internet. Don't think from this that the two applications must run on different computers (they can, which can have definite performance advantages), or that they need to be connected to the internet (although it is possible to have clients and servers in diffferent parts of the world communicating!!). Most of the time they will be running on the same machine, and the 'networking' aspect of things will be relatively transparent for you.
+They communicate by a protocol called Open Sound Control (OSC), over either UDP or TCP, which are network protocols also used on the internet. Don't think from this that the two applications must run on different computers (they can, which can have definite performance advantages), or that they need to be connected to the internet (although it is possible to have clients and servers in different parts of the world communicating!!). Most of the time they will be running on the same machine, and the 'networking' aspect of things will be relatively transparent for you.
 
 You can only communicate with the server using OSC messages over the network, but luckily the language app has lots of powerful objects which represent things on the server and allow you to control them easily and elegantly. Understanding how exactly that works is crucial to mastering SC, so we'll be talking about that in some depth.
 

--- a/HelpSource/Tutorials/Getting-Started/10-SynthDefs-and-Synths.schelp
+++ b/HelpSource/Tutorials/Getting-Started/10-SynthDefs-and-Synths.schelp
@@ -15,7 +15,7 @@ section::Meet the SynthDef
 
 Up until now we've been using Functions to generate audio. This way of working is very useful for quick testing, and in cases where maximum flexibility is needed. This is because each time we execute the code, the Function is evaluated anew, which means the results can vary greatly.
 
-The server, however, doesn't understand Functions, or OOP, or the SC language. It wants information on how to create audio output in a special form called a synth definition. A synth defintion is data about UGens and how they're interconnected. This is sent in a kind of special optimised form, called 'byte code', which the server can deal with very efficiently.
+The server, however, doesn't understand Functions, or OOP, or the SC language. It wants information on how to create audio output in a special form called a synth definition. A synth definition is data about UGens and how they're interconnected. This is sent in a kind of special optimised form, called 'byte code', which the server can deal with very efficiently.
 
 Once the server has a synth definition, it can very efficiently use it to make a number of synths based on it. Synths on the server are basically just things that make or process sound, or produce control signals to drive other synths.
 

--- a/HelpSource/Tutorials/JITLib/jitlib_basic_concepts_01.schelp
+++ b/HelpSource/Tutorials/JITLib/jitlib_basic_concepts_01.schelp
@@ -21,7 +21,7 @@ code::
 // create a new Ref object
 y = `(nil);
 
-// you can start to calcuate with y, even if its value is not yet given:
+// you can start to calculate with y, even if its value is not yet given:
 z = y + 10; // returns a function
 
 // now the source can be set:
@@ -46,7 +46,7 @@ z = y + 10; // this fails.
 // an environment without sufficient defaults has the same problem:
 
 currentEnvironment.postln; // anEnvironment
-~x; // access the enironment: there is nothing stored: nil
+~x; // access the environment: there is nothing stored: nil
 ~x = 9; // store something
 ~x; 	// now 9 is stored
 ~x + 100; // calculate with it

--- a/HelpSource/Tutorials/JITLib/jitlib_basic_concepts_02.schelp
+++ b/HelpSource/Tutorials/JITLib/jitlib_basic_concepts_02.schelp
@@ -189,7 +189,7 @@ This initialisation happens whenever the proxy is first used. Later, the proxy c
 
 code::
 ~u.play(0, 2);	// initialize 2 audio channels (default). 0 is the output bus number.
-		// if the proxy is not inititialized, play defaults to 2 channels.
+		// if the proxy is not initialized, play defaults to 2 channels.
 		// here it is explicitly given only to make it more clear.
 ~u = { PinkNoise.ar(0.2) }; // use only one
 ~u.numChannels;	// 2 channels

--- a/HelpSource/Tutorials/JITLib/jitlib_efficiency.schelp
+++ b/HelpSource/Tutorials/JITLib/jitlib_efficiency.schelp
@@ -5,7 +5,7 @@ related:: Overviews/JITLib
 
 link::Classes/NodeProxy:: (and, in disguise link::Classes/ProxySpace::) represent "pronouns", placeholders for all kinds of sound producing objects that are able to write to a specific bus on the server.
 
-To prepare such an object for playing, different objects require different things, some very little, some more. As working with the placeolders does not show directly which actions are very efficient and whic ones are not, it is shown here more in detail.
+To prepare such an object for playing, different objects require different things, some very little, some more. As working with the placeholders does not show directly which actions are very efficient and which ones are not, it is shown here more in detail.
 
 This is also important if you want to automate certain processes (e.g. for control by an external interface or a task) - some things (a) are not meant to be used in certain ways and better solutions should be used instead then, others are much more efficient (b, c).
 
@@ -46,7 +46,7 @@ code::
 ~a.refresh; ~a.wakeUp; // waking up a stopped proxy does not require a resend
 ::
 
-these resend the synth with new properies
+these resend the synth with new properties
 
 code::
 ~a.send(...)	// directly sends a message. the mapping bundle of the proxy is cached

--- a/HelpSource/Tutorials/JITLib/recursive_phrasing.schelp
+++ b/HelpSource/Tutorials/JITLib/recursive_phrasing.schelp
@@ -124,7 +124,7 @@ Pdef(\sweep,
 )
 )
 
-// play directly, emebdded in stream (see Pdef.help)
+// play directly, embedded in stream (see Pdef.help)
 
 Pn(Pdef(\sweep), 2).play;
 Pdef(\sweep).fork; // play without changing player state (see Pdef.help)

--- a/HelpSource/Tutorials/JITLib/the_lazy_proxy.schelp
+++ b/HelpSource/Tutorials/JITLib/the_lazy_proxy.schelp
@@ -85,7 +85,7 @@ code::
 ~x = ~e;
 ::
 
-if a rate-1 proxy is used as rate-2 input, the rate is converted and the channels are expanded in the ususal multichannel expansion pattern:
+if a rate-1 proxy is used as rate-2 input, the rate is converted and the channels are expanded in the usual multichannel expansion pattern:
 
 code::
 ~f.defineBus(\control);

--- a/HelpSource/Tutorials/Mark_Polishook_tutorial/03_Comments.schelp
+++ b/HelpSource/Tutorials/Mark_Polishook_tutorial/03_Comments.schelp
@@ -40,7 +40,7 @@ comment
  */
 ::
 
-If (when) evaluated, a comment will return nil, which is the value SuperCollider uses for unitialized data.
+If (when) evaluated, a comment will return nil, which is the value SuperCollider uses for uninitialized data.
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 

--- a/HelpSource/Tutorials/Mark_Polishook_tutorial/04_Help.schelp
+++ b/HelpSource/Tutorials/Mark_Polishook_tutorial/04_Help.schelp
@@ -19,7 +19,7 @@ Use the Find and Find Next commands, available through the Edit menu, to search 
 
 section::grep
 
-Use grep in the Terminal (in the Applications->Utilities folder) to search for all occurences of a given word or phrase. For example, to see all documents that use the LFSaw class, evaluate (in the Terminal application)
+Use grep in the Terminal (in the Applications->Utilities folder) to search for all occurrences of a given word or phrase. For example, to see all documents that use the LFSaw class, evaluate (in the Terminal application)
 
 code::
 grep -r LFSaw /Applications/SuperCollider

--- a/HelpSource/Tutorials/Mark_Polishook_tutorial/07_SynthDefs.schelp
+++ b/HelpSource/Tutorials/Mark_Polishook_tutorial/07_SynthDefs.schelp
@@ -94,13 +94,13 @@ Use the synthdef browser to examine synthdefs that have been written to disk.
 
 code::
 (
-// a synthdef browswer
+// a synthdef browser
 SynthDescLib.global.read;
 SynthDescLib.global.browse;
 )
 ::
 
-The middle box (in the top row) shows the names of synthsdefs. Each name, when selected, causes the other boxes to display the ugens, controls, and inputs and outputs for a particular synthdef.
+The middle box (in the top row) shows the names of synthdefs. Each name, when selected, causes the other boxes to display the ugens, controls, and inputs and outputs for a particular synthdef.
 
 The box labeled "SynthDef controls" is useful because it shows the arguments that can be passed to a given synthdef.
 

--- a/HelpSource/Tutorials/Mark_Polishook_tutorial/15_Groups.schelp
+++ b/HelpSource/Tutorials/Mark_Polishook_tutorial/15_Groups.schelp
@@ -21,7 +21,7 @@ link::Browse#UGens::
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
-Many synthesis processes, because they use more than a few ugens, are often best divided into component parts. This can make code modular, resusable, and easier to read.
+Many synthesis processes, because they use more than a few ugens, are often best divided into component parts. This can make code modular, reusable, and easier to read.
 
 The link::Classes/Group:: class, which is the means to specify a collection of nodes, provides a mechanism through which to control several synths at once.
 

--- a/HelpSource/Tutorials/Mark_Polishook_tutorial/17_Delays_reverbs.schelp
+++ b/HelpSource/Tutorials/Mark_Polishook_tutorial/17_Delays_reverbs.schelp
@@ -61,7 +61,7 @@ Synth.head(~effects, "aDelay");
 
 section::Feedback filters
 
-Comb and Allpass filters are examples of ugens that feed some of their output back into their input. Allpass filters change the phase of signals passed through them. For this reason, they're useful even though don't seeem to differ much from comb filters.
+Comb and Allpass filters are examples of ugens that feed some of their output back into their input. Allpass filters change the phase of signals passed through them. For this reason, they're useful even though don't seem to differ much from comb filters.
 
 code::
 /////////////////////////////////////////////////////////////////////////////////////////

--- a/HelpSource/Tutorials/Mark_Polishook_tutorial/21_Syntax_errors.schelp
+++ b/HelpSource/Tutorials/Mark_Polishook_tutorial/21_Syntax_errors.schelp
@@ -22,7 +22,7 @@ nil
 section::Common errors
 
 numberedList::
-## the name of a class or a variable is mispelled
+## the name of a class or a variable is misspelled
 ## a variable is used before being declared
 ## a parenthesis or a square or curly brace is missing or used in the wrong context
 ## a required comma or semicolon is missing or used improperly
@@ -33,7 +33,7 @@ numberedList::
 Two helpful commands in the SuperCollider Edit menu:
 
 numberedList::
-## "Go to Line ..." transports you to the line number of your choice. Use this when an error message identifies the line number on which a problem occured.
+## "Go to Line ..." transports you to the line number of your choice. Use this when an error message identifies the line number on which a problem occurred.
 
 ## "Find" searches for words or phrases. Use "Find" to locate code that has been identified in error messages or to replace all instances of an improperly spelled word.
 ::

--- a/HelpSource/Tutorials/Mark_Polishook_tutorial/22_Runtime_errors.schelp
+++ b/HelpSource/Tutorials/Mark_Polishook_tutorial/22_Runtime_errors.schelp
@@ -147,9 +147,9 @@ CALL STACK:
 		arg this = <instance of Main>
 ::
 
-section::Unitialized variable (binary operation fails)
+section::Uninitialized variable (binary operation fails)
 
-Here, the variable a is initialized to an integer and the variable b isn't initialized. Multiplying a (the integer 10) by b (nil, the value that SuperCollider uses for unitialized data) will create a runtime error.
+Here, the variable a is initialized to an integer and the variable b isn't initialized. Multiplying a (the integer 10) by b (nil, the value that SuperCollider uses for uninitialized data) will create a runtime error.
 
 code::
 (

--- a/HelpSource/Tutorials/Streams-Patterns-Events4.schelp
+++ b/HelpSource/Tutorials/Streams-Patterns-Events4.schelp
@@ -3,7 +3,7 @@ summary:: Environment & Event
 related:: Tutorials/Streams-Patterns-Events1, Tutorials/Streams-Patterns-Events2, Tutorials/Streams-Patterns-Events3, Tutorials/Streams-Patterns-Events5, Tutorials/Streams-Patterns-Events6, Tutorials/Streams-Patterns-Events7
 categories:: Tutorials>Streams-Patterns-Events
 
-The preceeding sections showed how to use Streams and Patterns to generate complex sequences of values for a single parameter at a time.
+The preceding sections showed how to use Streams and Patterns to generate complex sequences of values for a single parameter at a time.
 
 This section covers Environments and Events, which are used to build a symbolic event framework for patterns, allowing you to control all aspects of a composition using patterns.
 

--- a/HelpSource/Tutorials/Streams-Patterns-Events5.schelp
+++ b/HelpSource/Tutorials/Streams-Patterns-Events5.schelp
@@ -45,7 +45,7 @@ Event.default contains a function bound to the Symbol code::'finish':: which is 
 
 section::The pitch model
 
-Event.default implements a multi level pitch model which allows composition using modal scale degrees, equal division note values, midi note values, or frequencies in Hertz. These different ways of specifying the pitch can all be used interchangably.
+Event.default implements a multi level pitch model which allows composition using modal scale degrees, equal division note values, midi note values, or frequencies in Hertz. These different ways of specifying the pitch can all be used interchangeably.
 
 The way this works is due to the default values bound to the Symbols of the pitch model.
 


### PR DESCRIPTION
Just some minor typos and spelling fixed in the tutorial area of the help documentation