### PR TITLE
midi: make midi work in Windows

### DIFF
--- a/lang/LangPrimSource/SC_PortMIDI.cpp
+++ b/lang/LangPrimSource/SC_PortMIDI.cpp
@@ -186,7 +186,7 @@ static int midiProcessPartialSystemPacket(uint32_t msg)
 			case 0xFC:
 			case 0xFE:
 				gRunningStatus = 0; // clear running status
-				++g->sp; SetInt(g->sp, (p[i] >> 4) & 0xF);
+				++g->sp; SetInt(g->sp, p[i] & 0xF);
 				++g->sp; SetInt(g->sp, 0);
 				runInterpreter(g, s_midiSysrtAction, 4);
 				i++;


### PR DESCRIPTION
Some initial changes to make midi work in Windows. The main things are:
- Do not open the Microsoft MIDI Mapper device, otherwise we get
multiple allocation errors (I am guessing that the midi mapper tries to
open another device too).
- Open MIDI Input devices on init, if requested by numInputs
- Pass numIn and numOut to the init call, as received by the language
(but is gets 0, when nil, this is wrong)
- For the time being, do nothing on MIDI reset

I have not tested connecting and disconnecting discrete MIDI ports for
now.

Attached a screenshot of my session. I will post the script in the next comment.

Also note, that at least on my 3.7win compilation, I have to delete the Japanese version of Mark's tutorial, otherwise sclang dies while indexing the documentation.

![miditest](https://cloud.githubusercontent.com/assets/1238515/14857272/7eff2ec6-0c93-11e6-8c39-e8b24b77393f.PNG)