### PR TITLE
lang: cancel pending stdin operation when exiting

### DIFF
--- a/lang/LangSource/SC_TerminalClient.cpp
+++ b/lang/LangSource/SC_TerminalClient.cpp
@@ -579,7 +579,7 @@ void SC_TerminalClient::inputThreadFn()
 
 	startInputRead();
 
-	boost::asio::io_service::work work(mInputService);
+	mWorkInputService = new boost::asio::io_service::work(mInputService);
 	mInputService.run();
 }
 
@@ -632,6 +632,7 @@ void SC_TerminalClient::startInput()
 void SC_TerminalClient::endInput()
 {
 	mStdIn.cancel();
+	delete mWorkInputService;
 	mInputService.stop();
 	postfl("main: waiting for input thread to join...\n");
 	mInputThread.join();

--- a/lang/LangSource/SC_TerminalClient.cpp
+++ b/lang/LangSource/SC_TerminalClient.cpp
@@ -631,6 +631,7 @@ void SC_TerminalClient::startInput()
 
 void SC_TerminalClient::endInput()
 {
+	mStdIn.cancel();
 	mInputService.stop();
 	postfl("main: waiting for input thread to join...\n");
 	mInputThread.join();

--- a/lang/LangSource/SC_TerminalClient.h
+++ b/lang/LangSource/SC_TerminalClient.h
@@ -162,6 +162,7 @@ protected:
 	boost::asio::io_service mIoService;
 private:
 	boost::asio::io_service::work mWork;
+	boost::asio::io_service::work *mWorkInputService;
 	boost::asio::basic_waitable_timer<std::chrono::system_clock> mTimer;
 
 	// input io service


### PR DESCRIPTION
On Windows (not sure in other OSs) need to cancel the pending read
operation to be able to exit. Otherwise it will wait to get a keystroke
before proceeding further. This is reported in issue #1578.

Note that this does not completely solve the problem reported, but it is not necessary to press a key anymore. We still get the status 3 on exit.

Not sure if this is required on other OS. If not, we should put a conditional compilation to make it only on Windows.