### PR TITLE
lang: Not wait for keystroke when exiting

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,7 +110,7 @@ elseif(UNIX)
 endif()
 
 if(WIN32)
-    add_definitions(-DWIN32_LEAN_AND_MEAN -DNOMINMAX -D_WIN32_WINNT=0x0601)
+    add_definitions(-DWIN32_LEAN_AND_MEAN -DNOMINMAX -D_WIN32_WINNT=0x0600)
 
     # correctly link the static Boost Thread library:
     add_definitions(-DBOOST_THREAD_USE_LIB)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,7 +110,7 @@ elseif(UNIX)
 endif()
 
 if(WIN32)
-    add_definitions(-DWIN32_LEAN_AND_MEAN -DNOMINMAX -D_WIN32_WINNT=0x0500)
+    add_definitions(-DWIN32_LEAN_AND_MEAN -DNOMINMAX -D_WIN32_WINNT=0x0601)
 
     # correctly link the static Boost Thread library:
     add_definitions(-DBOOST_THREAD_USE_LIB)

--- a/editors/sc-ide/core/sc_process.cpp
+++ b/editors/sc-ide/core/sc_process.cpp
@@ -186,8 +186,7 @@ void ScProcess::stopLanguage (void)
         return;
     }
 
-    evaluateCode("0.exit", true);
-    closeWriteChannel();
+    evaluateCode("0.exit", true);    
 
     mCompiled = false;
     mTerminationRequested   = true;
@@ -200,6 +199,7 @@ void ScProcess::stopLanguage (void)
         if (!reallyFinished)
             emit statusMessage(tr("Failed to stop interpreter!"));
     }
+	closeWriteChannel();
     mTerminationRequested = false;
 }
 

--- a/editors/sc-ide/core/sc_process.cpp
+++ b/editors/sc-ide/core/sc_process.cpp
@@ -193,13 +193,9 @@ void ScProcess::stopLanguage (void)
     mTerminationRequested   = true;
     mTerminationRequestTime = QDateTime::currentDateTimeUtc();
 
-    bool finished = waitForFinished(200);
+    bool finished = waitForFinished(1000);
     if ( !finished && (state() != QProcess::NotRunning) ) {
-#ifdef Q_OS_WIN32
-    kill();
-#else
     terminate();
-#endif
         bool reallyFinished = waitForFinished(200);
         if (!reallyFinished)
             emit statusMessage(tr("Failed to stop interpreter!"));

--- a/editors/sc-ide/core/sc_process.cpp
+++ b/editors/sc-ide/core/sc_process.cpp
@@ -192,7 +192,7 @@ void ScProcess::stopLanguage (void)
     mTerminationRequested   = true;
     mTerminationRequestTime = QDateTime::currentDateTimeUtc();
 
-    bool finished = waitForFinished(1000);
+    bool finished = waitForFinished(3000);
     if ( !finished && (state() != QProcess::NotRunning) ) {
     terminate();
         bool reallyFinished = waitForFinished(200);

--- a/lang/LangSource/SC_LanguageClient.cpp
+++ b/lang/LangSource/SC_LanguageClient.cpp
@@ -142,7 +142,8 @@ extern thread gResyncThread;
 void SC_LanguageClient::shutdownRuntime()
 {
 	cleanup_OSC();
-#if __APPLE__
+
+#if __APPLE__ || _WIN32
 	gResyncThread.detach(); // leak!
 #endif
 }

--- a/lang/LangSource/SC_TerminalClient.cpp
+++ b/lang/LangSource/SC_TerminalClient.cpp
@@ -528,13 +528,11 @@ void SC_TerminalClient::startInputRead()
 		else {
 			DWORD bytes_transferred;
 
-			postfl("Going to ReadFile()\n");
 			::ReadFile(GetStdHandle(STD_INPUT_HANDLE),
 					   inputBuffer.data(),
 					   inputBuffer.size(),
 					   &bytes_transferred,
 					   nullptr);
-			postfl("Done ReadFile()\n");
 			onInputRead(error, bytes_transferred);
 		}
 	});
@@ -633,13 +631,10 @@ void SC_TerminalClient::startInput()
 
 void SC_TerminalClient::endInput()
 {
-	postfl("endInput()\n");
 #ifdef _WIN32
 	::CancelIoEx(GetStdHandle(STD_INPUT_HANDLE), nullptr);
 #endif
-	postfl("endInput() 2\n");
 	mInputService.stop();
-	postfl("endInput() 3\n");
 	mStdIn.cancel();
 	postfl("main: waiting for input thread to join...\n");
 	mInputThread.join();

--- a/lang/LangSource/SC_TerminalClient.cpp
+++ b/lang/LangSource/SC_TerminalClient.cpp
@@ -631,12 +631,12 @@ void SC_TerminalClient::startInput()
 
 void SC_TerminalClient::endInput()
 {
+	mInputService.stop();
+	mStdIn.cancel();
 #ifdef _WIN32
 	// Note this breaks Windows XP compatibility, since this function is only defined in Vista and later 
 	::CancelIoEx(GetStdHandle(STD_INPUT_HANDLE), nullptr);
 #endif
-	mInputService.stop();
-	mStdIn.cancel();
 	postfl("main: waiting for input thread to join...\n");
 	mInputThread.join();
 	postfl("main: quitting...\n");

--- a/lang/LangSource/SC_TerminalClient.cpp
+++ b/lang/LangSource/SC_TerminalClient.cpp
@@ -632,6 +632,7 @@ void SC_TerminalClient::startInput()
 void SC_TerminalClient::endInput()
 {
 #ifdef _WIN32
+	// Note this breaks Windows XP compatibility, since this function is only defined in Vista and later 
 	::CancelIoEx(GetStdHandle(STD_INPUT_HANDLE), nullptr);
 #endif
 	mInputService.stop();

--- a/lang/LangSource/SC_TerminalClient.cpp
+++ b/lang/LangSource/SC_TerminalClient.cpp
@@ -37,6 +37,7 @@
 # include "SC_Win32Utils.h"
 # include <io.h>
 # include <windows.h>
+# include <ioapiset.h>
 #endif
 
 #ifdef __APPLE__
@@ -631,6 +632,7 @@ void SC_TerminalClient::startInput()
 
 void SC_TerminalClient::endInput()
 {
+	::CancelIoEx(GetStdHandle(STD_INPUT_HANDLE), nullptr);
 	mInputService.stop();
 	postfl("main: waiting for input thread to join...\n");
 	mInputThread.join();

--- a/lang/LangSource/SC_TerminalClient.cpp
+++ b/lang/LangSource/SC_TerminalClient.cpp
@@ -528,12 +528,13 @@ void SC_TerminalClient::startInputRead()
 		else {
 			DWORD bytes_transferred;
 
+			postfl("Going to ReadFile()\n");
 			::ReadFile(GetStdHandle(STD_INPUT_HANDLE),
 					   inputBuffer.data(),
 					   inputBuffer.size(),
 					   &bytes_transferred,
 					   nullptr);
-
+			postfl("Done ReadFile()\n");
 			onInputRead(error, bytes_transferred);
 		}
 	});
@@ -632,8 +633,14 @@ void SC_TerminalClient::startInput()
 
 void SC_TerminalClient::endInput()
 {
+	postfl("endInput()\n");
+#ifdef _WIN32
 	::CancelIoEx(GetStdHandle(STD_INPUT_HANDLE), nullptr);
+#endif
+	postfl("endInput() 2\n");
 	mInputService.stop();
+	postfl("endInput() 3\n");
+	mStdIn.cancel();
 	postfl("main: waiting for input thread to join...\n");
 	mInputThread.join();
 	postfl("main: quitting...\n");


### PR DESCRIPTION
On Windows (not sure in other OSs) need to cancel the pending read
operation to be able to exit. Otherwise it will wait to get a keystroke
before proceeding further. This is reported in issue #1578.

Note that this does not completely solve the problem reported, but it is not necessary to press a key anymore. We still get the status 3 on exit.