### PR TITLE
Bump required windows version to Windows 7

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,7 +110,7 @@ elseif(UNIX)
 endif()
 
 if(WIN32)
-    add_definitions(-DWIN32_LEAN_AND_MEAN -DNOMINMAX -D_WIN32_WINNT=0x0500)
+    add_definitions(-DWIN32_LEAN_AND_MEAN -DNOMINMAX -D_WIN32_WINNT=0x0601)
 
     # correctly link the static Boost Thread library:
     add_definitions(-DBOOST_THREAD_USE_LIB)


### PR DESCRIPTION
This is required for some new APIs.

It is probably ok to leave at Vista, but I don't think many people will
be using that now. It may be worth asking.

@bagong, as you requested I am putting this as a separate commit, to make it more evident.