### PR TITLE
Classlib: Add NodeProxy:trace

### DIFF
--- a/SCClassLibrary/JITLib/ProxySpace/NodeProxy.sc
+++ b/SCClassLibrary/JITLib/ProxySpace/NodeProxy.sc
@@ -546,6 +546,17 @@ NodeProxy : BusPlug {
 		^NdefGui(this, nSliders ? this.getKeysValues.size.max(5), parent, bounds);
 	}
 
+	trace { |index = 0|
+		var obj = objects[index];
+		if(obj.nodeID.notNil) {
+			server.sendMsg(\n_trace, obj.nodeID);
+		} {
+			"Cannot trace a% %".format(
+				if(obj.class.name.asString.first.isVowel) { "n" } { "" },
+				obj.class.name
+			).warn;
+		};
+	}
 
 
 
@@ -1052,6 +1063,5 @@ Ndef : NodeProxy {
 		};
 		stream << this.class.name << "(" <<< this.key << serverString << ")"
 	}
-
 
 }


### PR DESCRIPTION
I should have submitted this ages ago... just a convenience method.

```
// Without the new method (you've got to be kidding me):
s.sendMsg(\n_trace, Ndef(\name).objects[0].nodeID);

// With the new method:
Ndef(\name).trace;
```

PS Should this be for 3.7 or master? I don't know... at this point it's all rather confusing to me. So I'm putting it into master and somebody else can decide to back port it into 3.7.