### PR TITLE
Pstutter vs Rest

### DIFF
--- a/SCClassLibrary/Common/Streams/FilterPatterns.sc
+++ b/SCClassLibrary/Common/Streams/FilterPatterns.sc
@@ -596,16 +596,20 @@ Pstutter : FilterPattern {
 	}
 	storeArgs { ^[n,pattern] }
 	embedInStream { arg event;
-		var inevent, nn;
+		var inevent, nn, wasRest, shouldSetRest;
 
 		var stream = pattern.asStream;
 		var nstream = n.asStream;
 
 		while {
+			wasRest = event.isRest;
 			(inevent = stream.next(event)).notNil
 		} {
+			// did *this particular stream.next* change the rest status?
+			shouldSetRest = wasRest.not and: { event.isRest };
 			if((nn = nstream.next(event)).notNil) {
 				nn.abs.do {
+					if(shouldSetRest) { event[\isRest] = true };
 					event = inevent.copy.yield;
 				};
 			} { ^event };

--- a/SCClassLibrary/Common/Streams/Rest.sc
+++ b/SCClassLibrary/Common/Streams/Rest.sc
@@ -33,6 +33,8 @@ Rest {
 			}
 		})
 	}
+	*isRest { ^true }
+	isRest { ^true }
 	value { ^dur }
 	storeOn { |stream| stream << "Rest(" << dur << ")" }
 }


### PR DESCRIPTION
Two related commits (again, putting in for master because I'm not sure these days what is the right thing).

First -- should be a no-brainer -- currently, `Rest(1).isRest` is actually false. That seems... how to put it... counterintuitive at best.

Second -- there's a case with Pstutter and Rests that doesn't work cleanly.

```
p = Pbind(\degree, Pstutter(2, Pseq([0, Rest(1), 2], 1))).asStream.all(()).do(_.postln);

( 'degree': 0 )
( 'degree': 0 )
( 'isRest': true, 'degree': 1 )
( 'degree': 1 )   // this one is wrong
( 'degree': 2 )
( 'degree': 2 )
```

For the "wrong" event: Pstutter should duplicate the output values, and when the output value to be duplicated is a Rest, I'd expect the duplicates to be rests as well. But they aren't. That's because Rests are (currently) transmitted into the output event only by a side effect -- setting 'isRest' in the event. Pstutter (currently) considers only the child stream's value, but not the side effect.

This fix (checking the side effect) isn't especially pretty, but it gets the right result.

A proper fix would be to redesign the Rest mechanism altogether. The 'isRest' side effect was a clever way to avoid implementing math operations for Rests, but as others (particularly Julian) pointed out, it complicates the Pattern internal interface. This Pstutter issue is severe enough and the fix is ugly enough that I'm finally forced to concede that, indeed, the side effect was not the right way to go.

I had actually mentioned this some time ago on sc-dev, but nobody took up the discussion and I didn't have time to pursue it further. (For that matter, I don't have any ideas for a better design.) If the discussion is going to remain stalled, then at least we should get the right behavior by whatever means.

I bundled the commits because the Pstutter fix depends on isRest. If they should be separated, let's deal with that later.
