### PR TITLE
nsis: windows: add path information

### DIFF
--- a/platform/windows/supercollider.nsi
+++ b/platform/windows/supercollider.nsi
@@ -95,6 +95,10 @@ Section "Core" core_sect
   WriteRegStr HKCR "${BUNDLE_NAME}.HelpFile" "" "${BUNDLE_NAME} HelpFile"
   WriteRegStr HKCR "${BUNDLE_NAME}.HelpFile\DefaultIcon" "" "$INSTDIR\sclang.exe,0"
   WriteRegStr HKCR "${BUNDLE_NAME}.HelpFile\shell\open\command" "" '"$INSTDIR\scide.exe" "%1"'
+  
+  ; Add path information
+  WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\App Paths\scide.exe" "" "$INSTDIR\scide.exe"
+  WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\App Paths\scide.exe" "Path" "$INSTDIR"  
 
   ; Create Startmenu item
   SetShellVarContext all

--- a/platform/windows/supercollider.nsi
+++ b/platform/windows/supercollider.nsi
@@ -126,6 +126,9 @@ Section "Uninstall"
 
   DeleteRegKey HKCR ".schelp"
   DeleteRegKey HKCR "${BUNDLE_NAME}.HelpFile"
+  
+  ;Remove path information
+  DeleteRegKey HKLM "Software\Microsoft\Windows\CurrentVersion\App Paths\scide.exe"
 
   ;Try to remove StartMenu item
   SetShellVarContext all


### PR DESCRIPTION
This allows to open nicely with double click. Without this, the server
is not found.