### PR TITLE
editor: windows: fix double click when app already open

### DIFF
--- a/editors/sc-ide/core/main.cpp
+++ b/editors/sc-ide/core/main.cpp
@@ -131,6 +131,7 @@ int main( int argc, char *argv[] )
 void SingleInstanceGuard::onNewIpcConnection()
 {
     mIpcSocket = mIpcServer->nextPendingConnection();
+	mIpcChannel->setSocket(mIpcSocket);
     connect(mIpcSocket, SIGNAL(disconnected()), mIpcSocket, SLOT(deleteLater()));
     connect(mIpcSocket, SIGNAL(readyRead()), this, SLOT(onIpcData()));
 }
@@ -162,8 +163,9 @@ bool SingleInstanceGuard::tryConnect(QStringList const & arguments)
     mIpcServer = new QTcpServer(this);
     bool listening = mIpcServer->listen(QHostAddress(QHostAddress::LocalHost), SingleInstanceGuard::Port);
     if (listening) {
-        mIpcChannel = new ScIpcChannel(mIpcServer->nextPendingConnection(), QString("SingleInstanceGuard"), this);
-
+		// socket is NULL here in Windows, so we pass it in onNewIpcConnection()
+        QTcpSocket *socket = mIpcServer->nextPendingConnection();
+        mIpcChannel = new ScIpcChannel(socket, QString("SingleInstanceGuard"), this);
         connect(mIpcServer, SIGNAL(newConnection()), this, SLOT(onNewIpcConnection()));
         return false;
     }

--- a/editors/sc-ide/primitives/sc_ipc_channel.cpp
+++ b/editors/sc-ide/primitives/sc_ipc_channel.cpp
@@ -43,6 +43,10 @@ void ScIpcChannel::bail() {
   mIpcHandler = nullptr;
 }
 
+void ScIpcChannel::setSocket(QTcpSocket *socket){
+  mSocket = socket;
+}
+
 void ScIpcChannel::log(const QString &message) {
   if (mIpcHandler != nullptr)
     mIpcHandler->onIpcLog(QString("%1 - IPC - %2\n").arg(mTag, message));

--- a/editors/sc-ide/primitives/sc_ipc_channel.hpp
+++ b/editors/sc-ide/primitives/sc_ipc_channel.hpp
@@ -57,6 +57,8 @@ public:
   ScIpcChannel(QTcpSocket *socket, const QString &tag, IIpcHandler *logger);
   ~ScIpcChannel();
 
+  void setSocket(QTcpSocket *socket);
+
   void log(const QString &message);
 
   void read();


### PR DESCRIPTION
When you double click on an scd file, and scide was already opened,
scide was ignoring that. The issue is that the IPC mechanism to
communicate with the running instance was using a socket that was not
there yet. I have moved the allocation of the socket to the point where
the connection is made, and it is working ok now.