### PR TITLE
Fix build on debian, add -fPIC to TLSF target

### DIFF
--- a/external_libraries/CMakeLists.txt
+++ b/external_libraries/CMakeLists.txt
@@ -69,9 +69,7 @@ endif()
 add_library(tlsf STATIC "TLSF-2.4.6/src/tlsf.c")
 target_compile_definitions( tlsf PRIVATE TLSF_STATISTIC=1 )
 target_include_directories( tlsf INTERFACE TLSF-2.4.6/src )
-if(CMAKE_SYSTEM_NAME MATCHES "Linux")
-	target_compile_options(tlsf PRIVATE -fPIC)
-endif()
+set_property(TARGET tlsf PROPERTY POSITION_INDEPENDENT_CODE TRUE)
 
 if(LTO)
 	set_property(TARGET oscpack tlsf

--- a/external_libraries/CMakeLists.txt
+++ b/external_libraries/CMakeLists.txt
@@ -69,6 +69,7 @@ endif()
 add_library(tlsf STATIC "TLSF-2.4.6/src/tlsf.c")
 target_compile_definitions( tlsf PRIVATE TLSF_STATISTIC=1 )
 target_include_directories( tlsf INTERFACE TLSF-2.4.6/src )
+target_compile_options(tlsf PRIVATE -fPIC)
 
 if(LTO)
 	set_property(TARGET oscpack tlsf

--- a/external_libraries/CMakeLists.txt
+++ b/external_libraries/CMakeLists.txt
@@ -69,7 +69,9 @@ endif()
 add_library(tlsf STATIC "TLSF-2.4.6/src/tlsf.c")
 target_compile_definitions( tlsf PRIVATE TLSF_STATISTIC=1 )
 target_include_directories( tlsf INTERFACE TLSF-2.4.6/src )
-target_compile_options(tlsf PRIVATE -fPIC)
+if(CMAKE_SYSTEM_NAME MATCHES "Linux")
+	target_compile_options(tlsf PRIVATE -fPIC)
+endif()
 
 if(LTO)
 	set_property(TARGET oscpack tlsf


### PR DESCRIPTION
Thanks Felipe Sateler (debian multimedia team) for diagnosing this. This patch fixes build failure of SuperCollider 3.7 on debian.

The error looks like this fwiw:

>>>> /usr/bin/ld: ../../external_libraries/libtlsf.a(tlsf.c.o): relocation
>>>> R_X86_64_32S against `.rodata' can not be used when making a shared
>>>> object; recompile with -fPIC
>>>> ../../external_libraries/libtlsf.a: error adding symbols: Bad value
