### PR TITLE
removed method::preferencesAction

### DIFF
--- a/HelpSource/Classes/Main.schelp
+++ b/HelpSource/Classes/Main.schelp
@@ -143,16 +143,6 @@ method::pid
 
 Returns:: The operating system's pid (process ID) for the process.
 
-method::preferencesAction
-note::SCApp only!::
-
-A function to evaluate when the SuperCollider preferences menu is selected.
-
-code::
-thisProcess.preferencesAction = { arg process; SCWindow.new.front; }
-::
-
-
 method::recompile
 
 Recompiles the class library. This is equivalent to restarting SC. Currently OSX (SuperCollider.app) only.


### PR DESCRIPTION
This should go in the helpfile of: OSXPlatform:

method::preferencesAction
note::SCApp only!::

A function to evaluate when the SuperCollider preferences menu is selected.

code::
thisProcess.preferencesAction = { arg process; SCWindow.new.front; }
::