### PR TITLE
RLPF.schelp: adjust example to avoid exploding filter due to frequency folding when modulated.

### DIFF
--- a/HelpSource/Classes/HistoryGui.schelp
+++ b/HelpSource/Classes/HistoryGui.schelp
@@ -5,7 +5,7 @@ related:: Classes/History
 
 DESCRIPTION::
 
-HistoryGui allows easy access to History as it happens: one can read recent lines, when they were written and by whom; one can search for text strings and by author names; and one can quickly grab lines of code for rewriting. Apart from documenting just in time programming sessions, all of this can be useful in live coding performances. See e.g. the system developed by powerbooks_unplugged: link::Republic:: 
+HistoryGui allows easy access to History as it happens: one can read recent lines, when they were written and by whom; one can search for text strings and by author names; and one can quickly grab lines of code for rewriting. Apart from documenting just in time programming sessions, all of this can be useful in live coding performances. See e.g. the system developed by powerbooks_unplugged, in the Quark called Republic.
 
 The gui elements in detail:
 DEFINITIONLIST::

--- a/HelpSource/Classes/LFSaw.schelp
+++ b/HelpSource/Classes/LFSaw.schelp
@@ -20,7 +20,8 @@ argument::iphase
 
 Initial phase offset. For efficiency reasons this is a value
 ranging from 0 to 2.
-
+Note:: enter "1" for an initial phase of 0 radiants.
+A value of 0 would start the cycle at pi radiants. See the example below.::
 
 argument::mul
 Output will be multiplied by this value.
@@ -35,5 +36,22 @@ code::
 
 // used as both Oscillator and LFO:
 { LFSaw.ar(LFSaw.kr(4, 0, 200, 400), 0, 0.1) }.play
-::
 
+::
+Display special behaviour of initial phase parameter:
+code::
+// 0.15 seconds of 3-channel buffer
+b = Buffer.alloc(s, s.sampleRate * 0.15, 3);
+
+(
+// generate Signal
+m = SynthDef ("help-lfsawphase", {|rate = 20|
+	var l;
+	l = LFSaw.ar(rate, [0, 1, 2]); // three channels, three phases
+	RecordBuf.ar(l, b, doneAction: 2, loop: 0);
+	Out.ar(0, l * -20.dbamp);
+}).play(s);
+)
+
+b.plot;	// see the difference
+::

--- a/HelpSource/Classes/Paddpre.schelp
+++ b/HelpSource/Classes/Paddpre.schelp
@@ -30,8 +30,15 @@ ClassMethods::
 
 method::new
 
+argument::name
+the key
+
 argument::value
 can be a pattern or a stream. The resulting stream ends when that incoming stream ends.
+
+argument::pattern
+the pattern
+
 
 Examples::
 

--- a/HelpSource/Classes/RLPF.schelp
+++ b/HelpSource/Classes/RLPF.schelp
@@ -42,20 +42,22 @@ Examples::
 
 code::
 
-{ RLPF.ar(Saw.ar(200, 0.1), FSinOsc.kr(XLine.kr(0.7, 300, 20), 0, 3600, 4000), 0.2) }.play;
+{ RLPF.ar(Saw.ar(200, 0.1), SinOsc.ar(XLine.kr(0.7, 300, 20), 0, 3600, 4000), 0.2) }.play;
 
 
 (
-{ 	var ctl = RLPF.ar(Saw.ar(5, 0.1), 25, 0.03);
+{ var ctl = RLPF.ar(Saw.ar(5, 0.1), 25, 0.03);
 	SinOsc.ar(ctl * 200 + 400) * 0.1;
 }.play;
 )
 
+
 (
-{ 	var ctl = RLPF.ar(Saw.ar(5,0.1), MouseX.kr(2, 200, 1), MouseY.kr(0.01, 1, 1));
+{ var ctl = RLPF.ar(Saw.ar(5,0.1), MouseX.kr(2, 200, 1), MouseY.kr(0.01, 1, 1));
 	SinOsc.ar(ctl * 200 + 400) * 0.1;
 }.play;
 )
 
 ::
+
 

--- a/HelpSource/Classes/SCControlView.schelp
+++ b/HelpSource/Classes/SCControlView.schelp
@@ -1,7 +1,0 @@
-class:: SCControlView
-summary:: An abstract class for backward compatibility
-categories:: GUI>Kits>Cocoa
-
-warning::
-For backward compatibility only. Inherits everything from link::Classes/SCView::. No new methods.
-::

--- a/HelpSource/Classes/SinOsc.schelp
+++ b/HelpSource/Classes/SinOsc.schelp
@@ -1,13 +1,25 @@
 class:: SinOsc
 summary:: Interpolating sine wavetable oscillator.
-related:: Classes/FSinOsc, Classes/SinOscFB
+related:: Classes/Osc, Classes/FSinOsc, Classes/SinOscFB, Classes/PMOsc, Classes/Klang
 categories::  UGens>Generators>Deterministic
 
 
 Description::
 
-This is the same as  link::Classes/Osc::  except that the table is
-a sine table of 8192 entries.
+Generates a sine wave.
+Uses a wavetable lookup oscillator with linear interpolation.
+Frequency and phase modulation are provided for audio-rate modulation.
+Technically, code::SinOsc:: uses the same implementation as  link::Classes/Osc::  except that its table is fixed to be a sine wave made of code::8192:: samples.
+
+subsection:: Other sinewaves oscillators
+
+LIST::
+## link::Classes/FSinOsc:: – fast sinewave oscillator
+## link::Classes/SinOscFB:: – sinewave with phase feedback
+## link::Classes/PMOsc:: – phase modulation sine oscillator
+## link::Classes/Klang:: – bank of sinewave oscillators
+## link::Classes/DynKlang:: – modulable bank of sinewave oscillators
+::
 
 
 classmethods::
@@ -16,10 +28,12 @@ method::ar, kr
 
 argument::freq
 Frequency in Hertz.
+Sampled at audio-rate.
 
 argument::phase
-Phase offset or modulator in radians.
-(Note: phase values should be within the range +-8pi. If your phase values are larger then simply use code::.mod(2pi):: to wrap them.)
+Phase in radians.
+Sampled at audio-rate.
+note::phase values should be within the range +-8pi. If your phase values are larger then simply use code::.mod(2pi):: to wrap them.::
 
 argument::mul
 Output will be multiplied by this value.
@@ -27,19 +41,22 @@ Output will be multiplied by this value.
 argument::add
 This value will be added to the output.
 
+
 Examples::
 
 code::
 
+// create an audio-rate sine wave at 200 Hz,
+// starting with phase 0 and an amplitude of 0.5
 { SinOsc.ar(200, 0, 0.5) }.play;
 
-// modulate freq
+// modulate the frequency with an exponential ramp
 { SinOsc.ar(XLine.kr(2000, 200), 0, 0.5) }.play;
 
-// modulate freq
+// more complex frequency modulatation
 { SinOsc.ar(SinOsc.ar(XLine.kr(1, 1000, 9), 0, 200, 800), 0, 0.25) }.play;
 
-// modulate phase
+// phase modulation (see also PMOsc)
 { SinOsc.ar(800, SinOsc.ar(XLine.kr(1, 1000, 9), 0, 2pi), 0.25) }.play;
 
 ::

--- a/HelpSource/Classes/SoundFile.schelp
+++ b/HelpSource/Classes/SoundFile.schelp
@@ -83,6 +83,10 @@ e = f[1].cue;
 e = f[1].cue( (addAction: 2, group: 1) );	// synth will play ahead of the default group
 ::
 
+argument:: closeWhenDone
+
+A flag to indicate wether the code::SoundFile:: will be closed after it's done playing. Default is False.
+
 subsection::Read/Write
 
 method::openRead

--- a/HelpSource/Classes/Tdef.schelp
+++ b/HelpSource/Classes/Tdef.schelp
@@ -91,8 +91,14 @@ A single Tdef may serve as a definition for multiple tasks. These methods show h
 method::fork
 Play an independent task in parallel.
 
+argument::clock
+the clock on which to play the forked task
+
 argument::quant
 can be an array of [quant, phase, offset], or a link::Classes/Quant:: value.
+
+argument::event
+an event to pass into the forked task
 
 method::embed
 Pass a value (typically an link::Classes/Event::) into the task function, and embed the Tdef in the stream.
@@ -107,6 +113,10 @@ For live coding, each Tdef also may control one instance that plays one task. Th
 method::play
 Starts the Tdef and creates a player.
 
+argument::argClock
+a clock on which to play the Tdef
+argument::doReset
+a flag whether to reset the task if already playing
 argument::quant
 can be an array of [quant, phase, offset] or a link::Classes/Quant:: value.
 


### PR DESCRIPTION

Signed-off-by: Michael Zacherl <github-mz01@blauwurf.info>