### PR TITLE
Revert "LFSaw.schelp: Note and example for special initial-phase behaviour"

### DIFF
--- a/HelpSource/Classes/LFSaw.schelp
+++ b/HelpSource/Classes/LFSaw.schelp
@@ -20,8 +20,7 @@ argument::iphase
 
 Initial phase offset. For efficiency reasons this is a value
 ranging from 0 to 2.
-Note:: enter "1" for an initial phase of 0 radiants.
-A value of 0 would start the cycle at pi radiants. See the example below.::
+
 
 argument::mul
 Output will be multiplied by this value.
@@ -36,22 +35,5 @@ code::
 
 // used as both Oscillator and LFO:
 { LFSaw.ar(LFSaw.kr(4, 0, 200, 400), 0, 0.1) }.play
-
 ::
-Display special behaviour of initial phase parameter:
-code::
-// 0.15 seconds of 3-channel buffer
-b = Buffer.alloc(s, s.sampleRate * 0.15, 3);
 
-(
-// generate Signal
-m = SynthDef ("help-lfsawphase", {|rate = 20|
-	var l;
-	l = LFSaw.ar(rate, [0, 1, 2]); // three channels, three phases
-	RecordBuf.ar(l, b, doneAction: 2, loop: 0);
-	Out.ar(0, l * -20.dbamp);
-}).play(s);
-)
-
-b.plot;	// see the difference
-::


### PR DESCRIPTION
This reverts commit 381a3ff0a1c086eb93199149e3fbdfbf1f596c5c which was based on a wrong assumption.
All is well!