### PR TITLE
ide: mark scide as able to handle multiple files

### DIFF
--- a/editors/sc-ide/SuperColliderIDE.desktop
+++ b/editors/sc-ide/SuperColliderIDE.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Name=SuperCollider IDE
 GenericName=SuperCollider IDE
-Exec=scide %f
+Exec=scide %F
 Icon=sc_ide
 Type=Application
 Terminal=false


### PR DESCRIPTION
As per the desktop entry spec[1]:

- %f: A single file name, even if multiple files are selected.
- %F:A list of files

This allows desktop environments to open multiple files in a single instance

[1] https://specifications.freedesktop.org/desktop-entry-spec/latest/ar01s06.html