### PR TITLE
RecordBuf.schelp: corrected Synthnames for proper playback, lower volume for overdub

### DIFF
--- a/HelpSource/Classes/RecordBuf.schelp
+++ b/HelpSource/Classes/RecordBuf.schelp
@@ -66,7 +66,7 @@ SynthDef(\help_RecordBuf, { arg out = 0, bufnum = 0;
 
 // play it back
 (
-SynthDef(\help_RecordBuf_overdub, { arg out = 0, bufnum = 0;
+SynthDef(\help_RecordBuf_playback, { arg out = 0, bufnum = 0;
 	var playbuf;
 	playbuf = PlayBuf.ar(1,bufnum);
 	FreeSelfWhenDone.kr(playbuf); // frees the synth when the PlayBuf is finished
@@ -80,12 +80,12 @@ SynthDef(\help_RecordBuf_overdub, { arg out=0, bufnum=0;
 	var formant;
 	formant = Formant.ar(XLine.kr(200, 1000, 4), 2000, 800, 0.125);
 	// mixes equally with existing data
-	RecordBuf.ar(formant, bufnum, 0, 0.5, 0.5, doneAction: 2, loop: 0);
+	RecordBuf.ar(formant, bufnum, 0, 0.3, 0.5, doneAction: 2, loop: 0);
 }).play(s, [\out, 0, \bufnum, b]);
 )
 
 // play back the overdubbed version
-Synth.new(\help_RecordBuf_overdub, [\out, 0, \bufnum, b], s);
+Synth.new(\help_RecordBuf_playback, [\out, 0, \bufnum, b], s);
 
 // write the contents of the buffer to a file (see Buffer for more options)
 (


### PR DESCRIPTION
Signed-off-by: Michael Zacherl <github-mz01@blauwurf.info>