### PR TITLE
fix inconsistent state of clock when tempo is set via setTempoAtSec

### DIFF
--- a/HelpSource/Classes/TempoClock.schelp
+++ b/HelpSource/Classes/TempoClock.schelp
@@ -80,7 +80,7 @@ method::clear
 Removes all tasks from the scheduling queue.
 
 method::tempo
-Sets or gets the current tempo in beats per second.
+Sets or gets the current tempo in beats per second at the current strong::logical time::.
 code::
 t= TempoClock.new;
 t.tempo_(2.0); // equivalent to t.tempo = 2.0;
@@ -88,6 +88,29 @@ t.tempo;
 t.tempo_(72/60) // 72 beats per minute
 t.tempo;
 ::
+
+method::etempo
+Sets or gets the current tempo at the current strong::elapsed time::. This allows you to set it to zero or even a negative value.
+code::
+t= TempoClock.new;
+t.etempo_(0); // halts.
+t.tempo;
+t.beats;
+t.beats; // remain the same
+t.etempo_(1) // start again.
+t.beats; // move on
+::
+
+note::
+When code::tempo <= 0::, you can only set it via code::etempo_:: and not via code::tempo_::.
+::
+
+method::setTempoAtBeat
+Sets or gets the current tempo assuming a given strong::logical time::.
+
+
+method::setTempoAtSec
+Sets or gets the current tempo assuming a given strong::elapsed time::.
 
 method::permanent
 Sets or gets a link::Classes/Boolean:: value indicating whether the clock will survive cmd-period. If false the clock is stopped (and thus removed) on cmd-period. If true the clock survives cmd-period. It is false by default.

--- a/HelpSource/Classes/TempoClock.schelp
+++ b/HelpSource/Classes/TempoClock.schelp
@@ -90,27 +90,7 @@ t.tempo;
 ::
 
 method::etempo
-Sets or gets the current tempo at the current strong::elapsed time::. This allows you to set it to zero or even a negative value.
-code::
-t= TempoClock.new;
-t.etempo_(0); // halts.
-t.tempo;
-t.beats;
-t.beats; // remain the same
-t.etempo_(1) // start again.
-t.beats; // move on
-::
-
-note::
-When code::tempo <= 0::, you can only set it via code::etempo_:: and not via code::tempo_::.
-::
-
-method::setTempoAtBeat
-Sets or gets the current tempo assuming a given strong::logical time::.
-
-
-method::setTempoAtSec
-Sets or gets the current tempo assuming a given strong::elapsed time::.
+Sets or gets the current tempo at the current strong::elapsed time::.
 
 method::permanent
 Sets or gets a link::Classes/Boolean:: value indicating whether the clock will survive cmd-period. If false the clock is stopped (and thus removed) on cmd-period. If true the clock survives cmd-period. It is false by default.

--- a/HelpSource/Guides/ServerTiming.schelp
+++ b/HelpSource/Guides/ServerTiming.schelp
@@ -1,7 +1,7 @@
-title:: Server OSC timing
-summary:: Server bundling latency and OSC timing
+title:: Scheduling and Server timing
+summary:: Server bundling latency and OSC timing, logical and physical time
 categories:: Server>Architecture, External Control>OSC, Scheduling
-related:: Classes/Server
+related:: Classes/Server, Classes/TempoClock
 
 To ensure correct timing of events on the server, OSC messages may be sent with a time stamp, indicating the precise time the sound is expected to hit the hardware output.
 

--- a/SCClassLibrary/Common/Core/Clock.sc
+++ b/SCClassLibrary/Common/Core/Clock.sc
@@ -250,7 +250,7 @@ elapsed time is whatever the system clock says it is right now. elapsed time is 
 		_TempoClock_SchedAbs
 		^this.primitiveFailed
 	}
-	clear { | releaseNodes = true |
+	clear { arg releaseNodes = true;
 		// flag tells EventStreamPlayers that CmdPeriod is removing them, so
 		// nodes are already freed
 		// NOTE: queue is an Array, not a PriorityQueue, but it's used as such internally. That's why each item uses 3 slots.
@@ -277,7 +277,7 @@ elapsed time is whatever the system clock says it is right now. elapsed time is 
 		this.setMeterAtBeat(newBeatsPerBar, thisThread.beats);
 	}
 
-	// for setting the tempo at the current elapsed time .
+	// for setting the tempo at the current elapsed time.
 	etempo_ { arg newTempo;
 		this.setTempoAtSec(newTempo, Main.elapsedTime);
 		this.changed(\tempo);

--- a/SCClassLibrary/Common/Core/Clock.sc
+++ b/SCClassLibrary/Common/Core/Clock.sc
@@ -267,7 +267,7 @@ elapsed time is whatever the system clock says it is right now. elapsed time is 
 	// (even another TempoClock's logical time).
 	tempo_ { arg newTempo;
 		this.setTempoAtBeat(newTempo, this.beats);
-		this.changed(\tempo);  // this line is added
+		this.changed(\tempo);
 	}
 	beatsPerBar_ { arg newBeatsPerBar;
 		if (thisThread.clock != this) {
@@ -280,6 +280,7 @@ elapsed time is whatever the system clock says it is right now. elapsed time is 
 	// for setting the tempo at the current elapsed time .
 	etempo_ { arg newTempo;
 		this.setTempoAtSec(newTempo, Main.elapsedTime);
+		this.changed(\tempo);
 	}
 
 	beats2secs { arg beats;

--- a/lang/LangPrimSource/PyrSched.cpp
+++ b/lang/LangPrimSource/PyrSched.cpp
@@ -1200,12 +1200,18 @@ int prTempoClock_SetTempoAtBeat(struct VMGlobals *g, int numArgsPushed)
 		error("clock is not running.\n");
 		return errFailed;
 	}
+	if(clock->mTempo <= 0.f) {
+		error("cannot set tempo from this method. The message 'etempo_' can be used instead.\n");
+		// prTempoClock_SetTempoAtTime can be used.
+		return errFailed;
+	}
 
 	double tempo, beat;
 	int err = slotDoubleVal(b, &tempo);
 	if (err) return errFailed;
 	if (tempo <= 0.) {
-		error("invalid tempo %g\n", tempo);
+		error("invalid tempo %g. The message 'etempo_' can be used instead.\n", tempo);
+		// prTempoClock_SetTempoAtTime can be used.
 		return errFailed;
 	}
 


### PR DESCRIPTION
This fixes #2077.

Someone with deeper insight into clock scheduling could check if the explanations in the helpfile are ok.
