### PR TITLE
sc-ide: middle mouse button closes tab

### DIFF
--- a/editors/sc-ide/widgets/multi_editor.cpp
+++ b/editors/sc-ide/widgets/multi_editor.cpp
@@ -215,6 +215,12 @@ void EditorTabBar::mousePressEvent(QMouseEvent *event)
         event->accept();
         return;
     }
+    else if (event->button() == Qt::MiddleButton){
+        mTabUnderCursor = tabAt(event->pos());
+        onCloseTab();
+        event->accept();
+        return;
+    }
 
     QTabBar::mousePressEvent(event);
 }


### PR DESCRIPTION
Just like in other modern editors and browsers