### PR TITLE
sc-ide: fix behaviour of right context button when out of tab

### DIFF
--- a/editors/sc-ide/widgets/multi_editor.cpp
+++ b/editors/sc-ide/widgets/multi_editor.cpp
@@ -238,10 +238,15 @@ void EditorTabBar::showContextMenu(QMouseEvent * event)
     mTabUnderCursor = tabAt(event->pos());
 
     QMenu * menu = new QMenu(this);
-
-    menu->addAction(tr("Close"),                   this, SLOT(onCloseTab())           );
-    menu->addAction(tr("Close Other Tabs"),        this, SLOT(onCloseOtherTabs())     );
-    menu->addAction(tr("Close Tabs to the Right"), this, SLOT(onCloseTabsToTheRight()));
+    // Cannot have a close tab action if we are not over a tab
+    if (mTabUnderCursor == -1){
+        menu->addAction(tr("Close All Tabs"), this, SLOT(onCloseOtherTabs()));
+    }
+    else{
+        menu->addAction(tr("Close"), this, SLOT(onCloseTab()));
+        menu->addAction(tr("Close Other Tabs"), this, SLOT(onCloseOtherTabs()));
+        menu->addAction(tr("Close Tabs to the Right"), this, SLOT(onCloseTabsToTheRight()));
+    }
 
     menu->popup(event->pos());
 }


### PR DESCRIPTION
When right -clicking in the tab area, but outside of a tab, the Close
and Close Tabs to the right options do not make sense, and in fact Close
crashes the editor.
Treat this case to offer to close all tabs.