### PR TITLE
class library: server notify dependants correctly

### DIFF
--- a/SCClassLibrary/Common/Control/ServerStatus.sc
+++ b/SCClassLibrary/Common/Control/ServerStatus.sc
@@ -217,7 +217,7 @@ ServerStatusWatcher {
 		} {
 			if(val) {
 				this.serverRunning = true;
-				unresponsive = false;
+				this.unresponsive = false;
 				reallyDeadCount = server.options.pingsBeforeConsideredDead;
 			} {
 				reallyDeadCount = reallyDeadCount - 1;


### PR DESCRIPTION
Explicitly call setter on `unresponsive` in order to trigger the
notification of dependants, in this case the IDE.

This fixes #2082.