### PR TITLE
scsynth: line option to bind to specific address (master)

### DIFF
--- a/include/server/SC_WorldOptions.h
+++ b/include/server/SC_WorldOptions.h
@@ -104,7 +104,7 @@ SCSYNTH_DLLEXPORT_C void SetPrintFunc(PrintFunc func);
 SCSYNTH_DLLEXPORT_C struct World* World_New(struct WorldOptions *inOptions);
 SCSYNTH_DLLEXPORT_C void World_Cleanup(struct World *inWorld, bool unload_plugins = false);
 SCSYNTH_DLLEXPORT_C void World_NonRealTimeSynthesis(struct World *inWorld, struct WorldOptions *inOptions);
-SCSYNTH_DLLEXPORT_C int World_OpenUDP(struct World *inWorld, int inPort);
+SCSYNTH_DLLEXPORT_C int World_OpenUDP(struct World *inWorld, const char *bindTo, int inPort);
 SCSYNTH_DLLEXPORT_C int World_OpenTCP(struct World *inWorld, int inPort, int inMaxConnections, int inBacklog);
 SCSYNTH_DLLEXPORT_C void World_WaitForQuit(struct World *inWorld, bool unload_plugins = false);
 SCSYNTH_DLLEXPORT_C bool World_SendPacket(struct World *inWorld, int inSize, char *inData, ReplyFunc inFunc);

--- a/include/server/SC_WorldOptions.h
+++ b/include/server/SC_WorldOptions.h
@@ -105,7 +105,7 @@ SCSYNTH_DLLEXPORT_C struct World* World_New(struct WorldOptions *inOptions);
 SCSYNTH_DLLEXPORT_C void World_Cleanup(struct World *inWorld, bool unload_plugins = false);
 SCSYNTH_DLLEXPORT_C void World_NonRealTimeSynthesis(struct World *inWorld, struct WorldOptions *inOptions);
 SCSYNTH_DLLEXPORT_C int World_OpenUDP(struct World *inWorld, const char *bindTo, int inPort);
-SCSYNTH_DLLEXPORT_C int World_OpenTCP(struct World *inWorld, int inPort, int inMaxConnections, int inBacklog);
+SCSYNTH_DLLEXPORT_C int World_OpenTCP(struct World *inWorld, const char *bindTo, int inPort, int inMaxConnections, int inBacklog);
 SCSYNTH_DLLEXPORT_C void World_WaitForQuit(struct World *inWorld, bool unload_plugins = false);
 SCSYNTH_DLLEXPORT_C bool World_SendPacket(struct World *inWorld, int inSize, char *inData, ReplyFunc inFunc);
 SCSYNTH_DLLEXPORT_C bool World_SendPacketWithContext(struct World *inWorld, int inSize, char *inData, ReplyFunc inFunc, void *inContext);

--- a/server/scsynth/SC_ComPort.cpp
+++ b/server/scsynth/SC_ComPort.cpp
@@ -401,9 +401,9 @@ class SC_TcpInPort
 	friend class SC_TcpConnection;
 
 public:
-	SC_TcpInPort(struct World * world, int inPortNum, int inMaxConnections, int inBacklog):
+	SC_TcpInPort(struct World * world, std::string bindTo, int inPortNum, int inMaxConnections, int inBacklog):
 		mWorld(world),
-		acceptor(ioService, boost::asio::ip::tcp::endpoint(boost::asio::ip::tcp::v4(), inPortNum)),
+        acceptor(ioService, boost::asio::ip::tcp::endpoint(boost::asio::ip::address::from_string(bindTo), inPortNum)),
 		mAvailableConnections(inMaxConnections)
 	{
 		// FIXME: backlog???
@@ -513,7 +513,7 @@ SCSYNTH_DLLEXPORT_C bool World_SendPacket(World *inWorld, int inSize, char *inDa
 	return World_SendPacketWithContext(inWorld, inSize, inData, inFunc, 0);
 }
 
-SCSYNTH_DLLEXPORT_C int World_OpenUDP(struct World *inWorld, const char* bindTo, int inPort)
+SCSYNTH_DLLEXPORT_C int World_OpenUDP(struct World *inWorld, const char *bindTo, int inPort)
 {
 	try {
 		new SC_UdpInPort(inWorld, bindTo, inPort);
@@ -525,10 +525,10 @@ SCSYNTH_DLLEXPORT_C int World_OpenUDP(struct World *inWorld, const char* bindTo,
 	return false;
 }
 
-SCSYNTH_DLLEXPORT_C int World_OpenTCP(struct World *inWorld, int inPort, int inMaxConnections, int inBacklog)
+SCSYNTH_DLLEXPORT_C int World_OpenTCP(struct World *inWorld, const char *bindTo, int inPort, int inMaxConnections, int inBacklog)
 {
 	try {
-		new SC_TcpInPort(inWorld, inPort, inMaxConnections, inBacklog);
+		new SC_TcpInPort(inWorld, bindTo, inPort, inMaxConnections, inBacklog);
 		return true;
 	} catch (std::exception& exc) {
 		scprintf("Exception in World_OpenTCP: %s\n", exc.what());

--- a/server/scsynth/scsynth_main.cpp
+++ b/server/scsynth/scsynth_main.cpp
@@ -147,7 +147,7 @@ int main(int argc, char* argv[])
 	WorldOptions options = kDefaultWorldOptions;
 
 	for (int i=1; i<argc;) {
-		if (argv[i][0] != '-' || argv[i][1] == 0 || strchr("utaioczblndpmwZrCNSDIOMHvVRUhPL", argv[i][1]) == 0) {
+		if (argv[i][0] != '-' || argv[i][1] == 0 || strchr("utBaioczblndpmwZrCNSDIOMHvVRUhPL", argv[i][1]) == 0) {
 			scprintf("ERROR: Invalid option %s\n", argv[i]);
 			Usage();
 		}

--- a/server/scsynth/scsynth_main.cpp
+++ b/server/scsynth/scsynth_main.cpp
@@ -350,7 +350,7 @@ int main(int argc, char* argv[])
 		}
 	}
 	if (tcpPortNum >= 0) {
-		if (!World_OpenTCP(world, tcpPortNum, options.mMaxLogins, 8)) {
+		if (!World_OpenTCP(world, bindTo.c_str(), tcpPortNum, options.mMaxLogins, 8)) {
 			World_Cleanup(world,true);
 			return 1;
 		}

--- a/server/scsynth/scsynth_main.cpp
+++ b/server/scsynth/scsynth_main.cpp
@@ -141,6 +141,7 @@ int main(int argc, char* argv[])
 
 	int udpPortNum = -1;
 	int tcpPortNum = -1;
+	std::string bindTo("0.0.0.0");
 
 	WorldOptions options = kDefaultWorldOptions;
 
@@ -158,6 +159,10 @@ int main(int argc, char* argv[])
 			case 't' :
 				checkNumArgs(2);
 				tcpPortNum = atoi(argv[j+1]);
+				break;
+			case 'B':
+				checkNumArgs(2);
+				bindTo = argv[j+1];
 				break;
 			case 'a' :
 				checkNumArgs(2);
@@ -339,7 +344,7 @@ int main(int argc, char* argv[])
 	}
 
 	if (udpPortNum >= 0) {
-		if (!World_OpenUDP(world, udpPortNum)) {
+		if (!World_OpenUDP(world, bindTo.c_str(), udpPortNum)) {
 			World_Cleanup(world,true);
 			return 1;
 		}

--- a/server/scsynth/scsynth_main.cpp
+++ b/server/scsynth/scsynth_main.cpp
@@ -54,6 +54,7 @@ void Usage()
 		"   -v print the supercollider version and exit\n"
 		"   -u <udp-port-number>    a port number 0-65535\n"
 		"   -t <tcp-port-number>    a port number 0-65535\n"
+		"   -B <bind-to-address>    an IP address\n"
 		"   -c <number-of-control-bus-channels> (default %d)\n"
 		"   -a <number-of-audio-bus-channels>   (default %d)\n"
 		"   -i <number-of-input-bus-channels>   (default %d)\n"


### PR DESCRIPTION
Add a new command option (-B) to bind to an specific address. The idea
is to allow to bind to the loopback port so that it does not ask for
firewall permissions.

The default is 0.0.0.0, to not change the current behaviour.

This is equivalent to #2081, but on master. I will close #2081 now.