### PR TITLE
Topic next time on grid dispatch

### DIFF
--- a/SCClassLibrary/Common/Collections/Dictionary.sc
+++ b/SCClassLibrary/Common/Collections/Dictionary.sc
@@ -504,7 +504,7 @@ IdentityDictionary : Dictionary {
 		if(this[\nextTimeOnGrid].notNil) {
 			^this[\nextTimeOnGrid].value(this, clock)
 		} {
-			^clock.nextTimeOnGrid(this[\quant] ? 1, (this[\phase] ? 0) - (this[\offset] ? 0))
+			^clock.getNextTimeOnGrid(this[\quant] ? 1, (this[\phase] ? 0) - (this[\offset] ? 0))
 		}
 	}
 	asQuant { ^this.copy }

--- a/SCClassLibrary/Common/Collections/SequenceableCollection.sc
+++ b/SCClassLibrary/Common/Collections/SequenceableCollection.sc
@@ -1274,7 +1274,7 @@ SequenceableCollection : Collection {
 
 	// TempoClock play quantization
 	nextTimeOnGrid { arg clock;
-		^clock.nextTimeOnGrid(*this);
+		^clock.getNextTimeOnGrid(*this);
 	}
 
 	// we break up the array so that missing elements are set to nil in the Quant

--- a/SCClassLibrary/Common/Core/Clock.sc
+++ b/SCClassLibrary/Common/Core/Clock.sc
@@ -296,11 +296,15 @@ elapsed time is whatever the system clock says it is right now. elapsed time is 
 		^this.primitiveFailed
 	}
 
-	nextTimeOnGrid { arg quant = 1, phase = 0;
+	getNextTimeOnGrid { arg quant = 1, phase = 0;
 		if (quant == 0) { ^this.beats + phase };
 		if (quant < 0) { quant = beatsPerBar * quant.neg };
 		if (phase < 0) { phase = phase % quant };
 		^roundUp(this.beats - baseBarBeat - (phase % quant), quant) + baseBarBeat + phase
+	}
+
+	nextTimeOnGrid { arg quant = 1, phase = 0;
+		^this.getNextTimeOnGrid(quant, phase)
 	}
 
 	timeToNextBeat { arg quant=1.0; // logical time to next beat
@@ -371,7 +375,8 @@ elapsed time is whatever the system clock says it is right now. elapsed time is 
 	*beats { ^TempoClock.default.beats }
 	*beats2secs { | beats | ^TempoClock.default.beats2secs(beats)  }
 	*secs2beats { | secs | ^TempoClock.default.secs2beats(secs)	}
-	*nextTimeOnGrid { | quant = 1, phase = 0 | ^TempoClock.default.nextTimeOnGrid(quant, phase)	}
+	*nextTimeOnGrid { | quant = 1, phase = 0 | ^TempoClock.default.getNextTimeOnGrid(quant, phase)	}
+	*getNextTimeOnGrid { | quant = 1, phase = 0 | ^TempoClock.default.getNextTimeOnGrid(quant, phase)	}
 	*timeToNextBeat { | quant = 1 | ^TempoClock.default.timeToNextBeat(quant)  }
 
 	*setTempoAtBeat { | newTempo, beats | TempoClock.default.setTempoAtBeat(newTempo, beats)	 }

--- a/SCClassLibrary/Common/Core/Clock.sc
+++ b/SCClassLibrary/Common/Core/Clock.sc
@@ -12,11 +12,12 @@ Clock {
 	*beats2bars { ^0 }
 	*bars2beats { ^0 }
 	*timeToNextBeat { ^0 }
-	*nextTimeOnGrid { | quant = 1, phase = 0|
+	*getNextTimeOnGrid { | quant = 1, phase = 0|
 		if (quant ==0) { ^this.beats + phase };
 		if (phase < 0) { phase = phase % quant };
 		^roundUp(this.beats - (phase % quant), quant) + phase;
 	}
+	*nextTimeOnGrid { | quant = 1, phase = 0 | ^this.getNextTimeOnGrid(quant, phase) }
 }
 
 SystemClock : Clock {

--- a/SCClassLibrary/Common/Core/Nil.sc
+++ b/SCClassLibrary/Common/Core/Nil.sc
@@ -57,7 +57,7 @@ Nil {
 	}
 	play {}
 
-	nextTimeOnGrid { arg clock; ^clock !? { clock.nextTimeOnGrid } }
+	nextTimeOnGrid { arg clock; ^clock !? { clock.getNextTimeOnGrid } }
 	asQuant { ^Quant.default }  //  { ^Quant.new }
 
 	swapThisGroup {}

--- a/SCClassLibrary/Common/Math/SimpleNumber.sc
+++ b/SCClassLibrary/Common/Math/SimpleNumber.sc
@@ -464,7 +464,11 @@ SimpleNumber : Number {
 	}
 
 	nextTimeOnGrid { arg clock;
-		^clock.nextTimeOnGrid(this, 0);
+		^clock.getNextTimeOnGrid(this, 0);
+	}
+
+	getNextTimeOnGrid {
+		Error("nextTimeOnGrid needs to be called with a clock-like object as argument").throw;
 	}
 
 	playAndDelta {}

--- a/SCClassLibrary/Common/Streams/Quant.sc
+++ b/SCClassLibrary/Common/Streams/Quant.sc
@@ -2,6 +2,7 @@
 // quant and phase determine the starting time of something scheduled by a TempoClock
 // timingOffset is an additional timing factor that allows an EventStream to compute "ahead of time" enough to allow
 // negative lags for strumming a chord, etc
+
 Quant {
 	classvar	default;
 	var <>quant, <>phase, <>timingOffset;
@@ -12,7 +13,7 @@ Quant {
 	*new { |quant = 0, phase, timingOffset| ^super.newCopyArgs(quant, phase, timingOffset) }
 
 	nextTimeOnGrid { | clock |
-		^clock.nextTimeOnGrid(quant, (phase ? 0) - (timingOffset ? 0));
+		^clock.getNextTimeOnGrid(quant, (phase ? 0) - (timingOffset ? 0));
 	}
 
 	asQuant { ^this.copy }


### PR DESCRIPTION
This applies the binary op dispatch scheme to the commutative
`nextTimeOnGrid`: Because both `clock.nextTimeOnGrid(number)` and
`number. nextTimeOnGrid(clock)` are supposed to be valid, we need one
extra level of dispatch, as to avoid a loop when e.g. `1.
nextTimeOnGrid(1)` is called accidentally.

This should be discussed and tested: it is an API change. All clocks must implement `getNextTimeOnGrid`.

this fixes #1981. 

I had considered to call the method `performNextTimeOnGridOnClock` but decided that this was  overdoing it. But the name my be something worth a second thought.
