### PR TITLE
Classlib: Fix HIDdef.element arg list passed to super.element

### DIFF
--- a/SCClassLibrary/Common/Control/HIDFunc.sc
+++ b/SCClassLibrary/Common/Control/HIDFunc.sc
@@ -540,7 +540,7 @@ HIDdef : HIDFunc {
 	*element { arg key, func, elID, deviceName, deviceInfo, argTemplate, argTemplateType, dispatcher;
 		var res = all.at(key), wasDisabled;
 		if(res.isNil) {
-			^super.element( key, func, elID, deviceName, deviceInfo, argTemplate, argTemplateType, dispatcher ).addToAll(key);
+			^super.element( func, elID, deviceName, deviceInfo, argTemplate, argTemplateType, dispatcher ).addToAll(key);
 		} {
 			if(func.notNil) {
 				wasDisabled = res.enabled.not;


### PR DESCRIPTION
'super.element' does not have a 'key' argument. So all arguments passed
to the superclass were shifted off by one in position, meaning
the superclass would behave incorrectly.

Copy/paste bug. No reason to leave it broken in 3.7.