### PR TITLE
class library: streamArg correctly yields

### DIFF
--- a/SCClassLibrary/Common/Core/Object.sc
+++ b/SCClassLibrary/Common/Core/Object.sc
@@ -237,7 +237,7 @@ Object  {
 		^if(embed) {
 			Routine { arg inval; this.embedInStream(inval) }
 		} {
-			Routine { loop { this.yield } }
+			Routine { arg inval; loop { inval = this.next(inval).yield } }
 		}
 	}
 


### PR DESCRIPTION
A stream returned from streamArg should call next before yield. This is
to mimic the `next` that the stream-consumer calls on the stream.

This fixes #2109.