### PR TITLE
Switch to hidapi subomodule in sc org repo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,7 +6,7 @@
 	url = git://github.com/timblechmann/nova-tt.git
 [submodule "external_libraries/hidapi"]
 	path = external_libraries/hidapi
-	url = git://github.com/sensestage/hidapi.git
+	url = git://github.com/supercollider/hidapi.git
 [submodule "editors/scvim"]
 	path = editors/scvim
 	url = https://github.com/supercollider/scvim.git


### PR DESCRIPTION
This suggestion is coordinated with @sensestage and was primarily motivated by the current initiative to get HID on Windows to work in a period where @sensestage might be too busy to pay full attention.

Just taking the repo "as is" and switching the source link in .gitmodules with the submodule set to the same commit seems to lead to a completely seamless switch. I haven't experienced any file conflicts/warnings locally when switching branches after this change...

Note that we also started a sketch of a Wiki relating to hid-information/data in the new repo within the SuperCollider organisation.