### PR TITLE
jitlib: better warnings when Server is not available

### DIFF
--- a/SCClassLibrary/JITLib/ProxySpace/NodeProxy.sc
+++ b/SCClassLibrary/JITLib/ProxySpace/NodeProxy.sc
@@ -450,6 +450,7 @@ NodeProxy : BusPlug {
 
 	spawn { | extraArgs, index = 0 |
 		var bundle, obj, i;
+		if(server.serverRunning.not) { "server '%' not running\n".postf(server); ^this };
 		obj = objects.at(index);
 		if(obj.notNil) {
 			i = this.index;
@@ -464,6 +465,7 @@ NodeProxy : BusPlug {
 	send { | extraArgs, index, freeLast = true |
 		var bundle, obj, fadeTime = this.fadeTime;
 		if(objects.isEmpty) { ^this };
+		if(server.serverRunning.not) { "server '%' not running\n".postf(server); ^this };
 		if(index.isNil) {
 			bundle = this.getBundle;
 			if(freeLast) { this.stopAllToBundle(bundle, fadeTime) };
@@ -489,11 +491,13 @@ NodeProxy : BusPlug {
 
 	sendEach { | extraArgs, freeLast = true |
 		var bundle;
+		if(server.serverRunning.not) { "server '%' not running\n".postf(server); ^this };
 		bundle = this.getBundle;
 		if(freeLast, { this.stopAllToBundle(bundle) });
 		if(loaded.not) { this.loadToBundle(bundle) };
 		this.sendEachToBundle(bundle, extraArgs);
-		bundle.schedSend(server);
+		bundle.schedSend(server)
+
 
 	}
 
@@ -511,6 +515,7 @@ NodeProxy : BusPlug {
 
 	deepWakeUp {
 		var bundle = MixedBundle.new;
+		if(server.serverRunning.not) { "server '%' not running\n".postf(server); ^this };
 		this.wakeUpToBundle(bundle);
 		bundle.schedSend(server, clock ? TempoClock.default, quant)
 	}


### PR DESCRIPTION
this patch adds warnings and escapes when server is not running and
node proxy is passed messages that only work when server is running.