### PR TITLE
class library: implement audio rate lag control

### DIFF
--- a/SCClassLibrary/Common/Audio/InOut.sc
+++ b/SCClassLibrary/Common/Audio/InOut.sc
@@ -123,6 +123,9 @@ LagControl : Control {
 		});
 		^outputs
 	}
+	*ar { arg values, lags;
+		^AudioControl.ar(values).lag(lags)
+	}
 	*ir {
 		^this.shouldNotImplement(thisMethod)
 	}

--- a/SCClassLibrary/Common/Control/GraphBuilder.sc
+++ b/SCClassLibrary/Common/Control/GraphBuilder.sc
@@ -131,7 +131,11 @@ NamedControl {
 
 		if(fixedLag && lags.notNil && prefix.isNil) {
 			buildSynthDef.addKr(name, values.unbubble);
-			control = LagControl.kr(values.flat.unbubble, lags);
+			if(rate === \audio) {
+				control = LagControl.ar(values.flat.unbubble, lags)
+			} {
+				control = LagControl.kr(values.flat.unbubble, lags)
+			};
 		} {
 			if(prefix == $a or: {rate === \audio}) {
 				buildSynthDef.addAr(name, values.unbubble);


### PR DESCRIPTION
This fixes issues with `\name.ar` when a lag is given.