### PR TITLE
Change "source" to "helpfile source" in scdoc footer

### DIFF
--- a/SCClassLibrary/SCDoc/SCDocRenderer.sc
+++ b/SCClassLibrary/SCDoc/SCDocRenderer.sc
@@ -771,7 +771,7 @@ SCDocHTMLRenderer {
     *renderFooter {|stream, doc|
         stream << "<div class='doclink'>";
         doc.fullPath !? {
-            stream << "source: <a href='" << URI.fromLocalPath(doc.fullPath).asString << "'>"
+            stream << "helpfile source: <a href='" << URI.fromLocalPath(doc.fullPath).asString << "'>"
             << doc.fullPath << "</a><br>"
         };
         stream << "link::" << doc.path << "::<br>"


### PR DESCRIPTION
Requested in #2049. The purpose is to disambiguate between helpfile source and class file source.