### PR TITLE
Handle spaces in SCDoc internal links

### DIFF
--- a/HelpSource/scdoc.js
+++ b/HelpSource/scdoc.js
@@ -105,7 +105,7 @@ function addInheritedMethods() {
             var m = mets[j];
             if(doc.methods.indexOf("_"+m.slice(1))<0) { // ignore methods already documented in this helpfile
                 var li = document.createElement("li");
-                li.innerHTML = "<a href='"+helpRoot+"/"+s.path+".html#"+m.slice(1)+"'>"+m.slice(2)+"</a>";
+                li.innerHTML = "<a href='"+helpRoot+"/"+s.path+".html#"+encodeURIComponent(m.slice(1))+"'>"+m.slice(2)+"</a>";
                 if(m[1]=="*") {
                     d[0].appendChild(li);
                 } else

--- a/SCClassLibrary/SCDoc/SCDocRenderer.sc
+++ b/SCClassLibrary/SCDoc/SCDocRenderer.sc
@@ -26,11 +26,17 @@ SCDocHTMLRenderer {
         };
         ^x;
     }
+	*escapeSpacesInAnchor { |str|
+		^str.replace(" ", "%20")
+	}
 
     *htmlForLink {|link,escape=true|
         var n, m, f, c, doc;
         // FIXME: how slow is this? can we optimize
         #n, m, f = link.split($#); // link, anchor, label
+		if(m.size > 0) {
+			m = this.escapeSpacesInAnchor(m);
+		};
         ^if ("^[a-zA-Z]+://.+".matchRegexp(link) or: (link.first==$/)) {
             if(f.size<1) {f=link};
             c = if(m.size>0) {n++"#"++m} {n};
@@ -396,11 +402,11 @@ SCDocHTMLRenderer {
                 stream << "<span class='soft'>" << this.escapeSpecialChars(node.text) << "</span>";
             },
             \ANCHOR, {
-                stream << "<a class='anchor' name='" << node.text << "'>&nbsp;</a>";
+				stream << "<a class='anchor' name='" << this.escapeSpacesInAnchor(node.text) << "'>&nbsp;</a>";
             },
             \KEYWORD, {
                 node.children.do {|child|
-                    stream << "<a class='anchor' name='kw_" << child.text << "'>&nbsp;</a>";
+					stream << "<a class='anchor' name='kw_" << this.escapeSpacesInAnchor(child.text) << "'>&nbsp;</a>";
                 }
             },
             \IMAGE, {
@@ -624,7 +630,7 @@ SCDocHTMLRenderer {
                 this.renderChildren(stream, node);
             },
             \SECTION, {
-                stream << "<h2><a class='anchor' name='" << node.text
+				stream << "<h2><a class='anchor' name='" << this.escapeSpacesInAnchor(node.text)
                 << "'>" << this.escapeSpecialChars(node.text) << "</a></h2>\n";
                 if(node.makeDiv.isNil) {
                     this.renderChildren(stream, node);
@@ -635,7 +641,7 @@ SCDocHTMLRenderer {
                 };
             },
             \SUBSECTION, {
-                stream << "<h3><a class='anchor' name='" << node.text
+				stream << "<h3><a class='anchor' name='" << this.escapeSpacesInAnchor(node.text)
                 << "'>" << this.escapeSpecialChars(node.text) << "</a></h3>\n";
                 if(node.makeDiv.isNil) {
                     this.renderChildren(stream, node);
@@ -681,32 +687,32 @@ SCDocHTMLRenderer {
                     \CMETHOD, {
                         stream << "<li class='toc3'>"
                         << (n.children[0].children.collect{|m|
-                            "<a href='#*"++m.text++"'>"++this.escapeSpecialChars(m.text)++"</a> ";
+							"<a href='#*"++m.text++"'>"++this.escapeSpecialChars(m.text)++"</a> ";
                         }.join(" "))
                         << "</li>\n";
                     },
                     \IMETHOD, {
                         stream << "<li class='toc3'>"
                         << (n.children[0].children.collect{|m|
-                            "<a href='#-"++m.text++"'>"++this.escapeSpecialChars(m.text)++"</a> ";
+							"<a href='#-"++m.text++"'>"++this.escapeSpecialChars(m.text)++"</a> ";
                         }.join(" "))
                         << "</li>\n";
                     },
                     \METHOD, {
                         stream << "<li class='toc3'>"
                         << (n.children[0].children.collect{|m|
-                            "<a href='#."++m.text++"'>"++this.escapeSpecialChars(m.text)++"</a> ";
+							"<a href='#."++m.text++"'>"++this.escapeSpecialChars(m.text)++"</a> ";
                         }.join(" "))
                         << "</li>\n";
                     },
 
                     \SECTION, {
-                        stream << "<li class='toc1'><a href='#" << n.text << "'>"
+						stream << "<li class='toc1'><a href='#" << this.escapeSpacesInAnchor(n.text) << "'>"
                         << this.escapeSpecialChars(n.text) << "</a></li>\n";
                         this.renderTOC(stream, n);
                     },
                     \SUBSECTION, {
-                        stream << "<li class='toc2'><a href='#" << n.text << "'>"
+						stream << "<li class='toc2'><a href='#" << this.escapeSpacesInAnchor(n.text) << "'>"
                         << this.escapeSpecialChars(n.text) << "</a></li>\n";
                         this.renderTOC(stream, n);
                     }


### PR DESCRIPTION
Fixes #1650. I cherrypicked a451a06 because I was too lazy to figure out how to properly deal with the scvim submodule. (If I tried to checkout James' branch then I got an error that the scvim directory would be overwritten.)

@jamshark70 Please try this and let me know if it fixes the bug. I can't reproduce it in Firefox.