### PR TITLE
server plugins: Unify panning behavior of granular ugens

### DIFF
--- a/HelpSource/Classes/GrainBuf.schelp
+++ b/HelpSource/Classes/GrainBuf.schelp
@@ -39,7 +39,7 @@ determines where to pan the output.
 list::
 ## If numChannels = 1, no panning is done.
 ## If numChannels = 2, panning is similar to Pan2.
-## If numChannels > 2, pannins is the same as PanAz.
+## If numChannels > 2, panning is the same as PanAz.
 ::
 
 argument:: envbufnum

--- a/HelpSource/Classes/TGrains.schelp
+++ b/HelpSource/Classes/TGrains.schelp
@@ -7,7 +7,7 @@ Triggers generate grains from a buffer. Each grain has a Hanning envelope
 code::
 (sin2(x) for x from 0 to π)
 ::
-and is panned between two channels of multiple outputs.
+and is panned between two or more channels of output.
 
 classmethods::
 
@@ -40,9 +40,11 @@ argument::dur
 Duration of the grain in seconds.
 
 argument::pan
-A value from -1 to 1. Determines where to pan the output in the
-same manner as
-link::Classes/PanAz:: .
+determines where to pan the output.
+list::
+## If numChannels = 2, panning is similar to Pan2.
+## If numChannels > 2, panning is the same as PanAz.
+::
 
 argument::amp
 Amplitude of the grain.

--- a/HelpSource/Classes/TGrains.schelp
+++ b/HelpSource/Classes/TGrains.schelp
@@ -7,7 +7,7 @@ Triggers generate grains from a buffer. Each grain has a Hanning envelope
 code::
 (sin2(x) for x from 0 to π)
 ::
-and is panned between two or more channels of output.
+and can be panned over multichannel output.
 
 classmethods::
 
@@ -42,6 +42,7 @@ Duration of the grain in seconds.
 argument::pan
 determines where to pan the output.
 list::
+## If numChannels = 1, the pan argument is ignored.
 ## If numChannels = 2, panning is similar to Pan2.
 ## If numChannels > 2, panning is the same as PanAz.
 ::

--- a/SCClassLibrary/Common/Audio/BufIO.sc
+++ b/SCClassLibrary/Common/Audio/BufIO.sc
@@ -21,10 +21,6 @@ PlayBuf : MultiOutUGen {
 TGrains : MultiOutUGen {
 	*ar { arg numChannels, trigger=0, bufnum=0, rate=1, centerPos=0,
 			dur=0.1, pan=0, amp=0.1, interp=4;
-		if (numChannels < 2) {
-			 "TGrains needs at least two channels.".error;
-			 ^nil
-		}
 		^this.multiNew('audio', numChannels, trigger, bufnum, rate, centerPos,
 				dur, pan, amp, interp)
 	}

--- a/server/plugins/DelayUGens.cpp
+++ b/server/plugins/DelayUGens.cpp
@@ -6057,7 +6057,7 @@ inline double sc_gloop(double in, double hi)
 		float d = table3[0]; \
 		float outval = amp * cubicinterp(fracphase, a, b, c, d); \
 		ZXP(out1) += outval * pan1; \
-		ZXP(out2) += outval * pan2; \
+		if (numOutputs > 1) { ZXP(out2) += outval * pan2; } \
 		double y0 = b1 * y1 - y2; \
 		y2 = y1; \
 		y1 = y0; \
@@ -6077,7 +6077,7 @@ inline double sc_gloop(double in, double hi)
 		float c = table2[0]; \
 		float outval = amp * (b + fracphase * (c - b)); \
 		ZXP(out1) += outval * pan1; \
-		ZXP(out2) += outval * pan2; \
+		if (numOutputs > 1) { ZXP(out2) += outval * pan2; } \
 		double y0 = b1 * y1 - y2; \
 		y2 = y1; \
 		y1 = y0; \
@@ -6200,21 +6200,29 @@ void TGrains_next(TGrains *unit, int inNumSamples)
 			grain->interp = (int)IN_AT(unit, 7, i);
 
 			float panangle;
-			if (numOutputs > 2) {
-				pan = sc_wrap(pan * 0.5f, 0.f, 1.f);
-				float cpan = numOutputs * pan + 0.5;
-				float ipan = floor(cpan);
-				float panfrac = cpan - ipan;
-				panangle = panfrac * pi2_f;
-				grain->chan = (int)ipan;
-				if (grain->chan >= (int)numOutputs) grain->chan -= numOutputs;
+			float pan1, pan2;
+			if (numOutputs > 1) {
+				if (numOutputs > 2) {
+					pan = sc_wrap(pan * 0.5f, 0.f, 1.f);
+					float cpan = numOutputs * pan + 0.5f;
+					float ipan = floor(cpan);
+					float panfrac = cpan - ipan;
+					panangle = panfrac * pi2_f;
+					grain->chan = (int)ipan;
+					if (grain->chan >= (int)numOutputs)
+						grain->chan -= numOutputs;
+				} else {
+					grain->chan = 0;
+					pan = sc_clip(pan * 0.5f + 0.5f, 0.f, 1.f);
+					panangle = pan * pi2_f;
+				}
+				pan1 = grain->pan1 = cos(panangle);
+				pan2 = grain->pan2 = sin(panangle);
 			} else {
 				grain->chan = 0;
-				pan = sc_clip(pan * 0.5f + 0.5f, 0.f, 1.f);
-				panangle = pan * pi2_f;
+				pan1 = grain->pan1 = 1.;
+				pan2 = grain->pan2 = 0.;
 			}
-			float pan1 = grain->pan1 = amp * cos(panangle);
-			float pan2 = grain->pan2 = amp * sin(panangle);
 			double w = pi / counter;
 			double b1 = grain->b1 = 2. * cos(w);
 			double y1 = sin(w);

--- a/server/plugins/DelayUGens.cpp
+++ b/server/plugins/DelayUGens.cpp
@@ -6210,7 +6210,7 @@ void TGrains_next(TGrains *unit, int inNumSamples)
 				if (grain->chan >= (int)numOutputs) grain->chan -= numOutputs;
 			} else {
 				grain->chan = 0;
-				pan = sc_wrap(pan * 0.5f + 0.5f, 0.f, 1.f);
+				pan = sc_clip(pan * 0.5f + 0.5f, 0.f, 1.f);
 				panangle = pan * pi2_f;
 			}
 			float pan1 = grain->pan1 = amp * cos(panangle);

--- a/server/plugins/GrainUGens.cpp
+++ b/server/plugins/GrainUGens.cpp
@@ -395,15 +395,20 @@ static inline bool getGrainWin(Unit * unit, float wintype, SndBuf *& window, con
 	float panangle, pan1, pan2;											\
 	float *out1, *out2;													\
 	if (numOutputs > 1) {												\
-		if (numOutputs == 2) pan = pan * 0.5f;							\
-		pan = sc_wrap(pan * 0.5f, 0.f, 1.f);							\
-		float cpan = numOutputs * pan + 0.5f;							\
-		float ipan = floor(cpan);										\
-		float panfrac = cpan - ipan;									\
-		panangle = panfrac * pi2_f;										\
-		grain->chan = (int)ipan;										\
-		if (grain->chan >= (int)numOutputs)								\
-			grain->chan -= numOutputs;									\
+		if (numOutputs > 2) {											\
+			pan = sc_wrap(pan * 0.5f, 0.f, 1.f);						\
+			float cpan = numOutputs * pan + 0.5f;						\
+			float ipan = floor(cpan);									\
+			float panfrac = cpan - ipan;								\
+			panangle = panfrac * pi2_f;									\
+			grain->chan = (int)ipan;									\
+			if (grain->chan >= (int)numOutputs)							\
+				grain->chan -= numOutputs;								\
+		} else {														\
+			grain->chan = 0;											\
+			pan = sc_clip(pan * 0.5f + 0.5f, 0.f, 1.f);					\
+			panangle = pan * pi2_f;										\
+		}																\
 		pan1 = grain->pan1 = cos(panangle);								\
 		pan2 = grain->pan2 = sin(panangle);								\
 	} else {															\


### PR DESCRIPTION
The pan argument to TGrains has two problems, originally reported for [TGrains2 in sc3-plugins](https://github.com/supercollider/sc3-plugins/issues/81). One of them is a documentation issue, which says that it behaves like PanAz. The intended behavior is more like GrainBuf, which behaves like Pan2 when the number of channels is 2, and like PanAz for 3 or more channels.

Furthermore, the math of the pan argument is not a correct emulation of Pan2. Here is a crude way to visualize the problem, by plotting a pan from -2 to 2:

    b = Buffer.read(s, Platform.resourceDir +/+ "sounds/a11wlk01.wav");
    { Pan2.ar(SinOsc.ar(440), Line.kr(-2, 2, 1)) }.plot(1.0)
    { TGrains.ar(2, Impulse.ar(100), b, dur: 0.01, pan: Line.kr(-2, 2, 1)) }.plot(1.0)

<img width="934" alt="screen shot 2016-08-23 at 15 07 18" src="https://cloud.githubusercontent.com/assets/218738/17892803/5b0a7388-6943-11e6-97e4-bd9abf6feabd.png">


TGrains wraps around at +-1. Pan2 clips.

This fixes both problems. I also couldn't resist fixing a typo in GrainBuf.