### PR TITLE
Correct an overshoot reported in bug 1355. This overshoot happens bec…

### DIFF
--- a/server/plugins/DemandUGens.cpp
+++ b/server/plugins/DemandUGens.cpp
@@ -819,7 +819,7 @@ void DemandEnvGen_next_k(DemandEnvGen *unit, int inNumSamples)
 							double a1 = (endLevel - level) / (1.0 - exp(curve));
 							unit->m_a2 = level + a1;
 							unit->m_b1 = a1;
-							unit->m_grow = exp(curve / count);
+							unit->m_grow = exp(curve / ceil( count) );
 						}
 					} break;
 					case shape_Squared : {
@@ -1079,7 +1079,7 @@ void DemandEnvGen_next_a(DemandEnvGen *unit, int inNumSamples)
 							double a1 = (endLevel - level) / (1.0 - exp(curve));
 							unit->m_a2 = level + a1;
 							unit->m_b1 = a1;
-							unit->m_grow = exp(curve / count);
+							unit->m_grow = exp(curve / ciel( count) );
 						}
 					} break;
 					case shape_Squared : {


### PR DESCRIPTION
…ause

the curve is "grown" an integer number of times (==phase) but the growth
factor is set to exp( curve / count ) (where count is initialized as phase)
so at very high curve, that small 0.3 of an extra phase being different than the
1 of the extra count gets amplified. Fix the problem by setting the growth rate
to match the actual number of applications, which is exp( curve / ceil( count ) ).
This will mean there's a slight inconsistency in very high curve oscillations.