### PR TITLE
asStringPerc SCLang Crash

### DIFF
--- a/lang/LangPrimSource/PyrPrimitive.cpp
+++ b/lang/LangPrimSource/PyrPrimitive.cpp
@@ -390,6 +390,10 @@ int prFloat_AsStringPrec(struct VMGlobals *g, int numArgsPushed)
 	if (err) return err;
 
 	char fmt[8], str[256];
+	// if our precision is bigger than our stringsize, we can generate a very nasty buffer overflow here. So
+	if( precision <= 0 ) precision = 1;
+	if( precision >= 200 ) precision = 200; // Nothing is that big anyway. And we know we will be smaller than our 256 char string
+
 	sprintf(fmt, "%%.%dg", precision);
 	sprintf(str, fmt, slotRawFloat(a));
 


### PR DESCRIPTION
asStringPerc generates an sprintf statement based on the argument
but sprintfs into a fixed sized buffer. So the value of that argument
can lead to a buffer overflow. Just check it against reasonable lower
and upper bounds.

Addresses https://github.com/supercollider/supercollider/issues/1158