### PR TITLE
Fix oscpack build fail on various architectures

### DIFF
--- a/external_libraries/oscpack_1_1_0/osc/OscOutboundPacketStream.h
+++ b/external_libraries/oscpack_1_1_0/osc/OscOutboundPacketStream.h
@@ -105,11 +105,6 @@ public:
     OutboundPacketStream& operator<<( const InfinitumType& rhs );
     OutboundPacketStream& operator<<( int32 rhs );
 
-#if !(defined(__x86_64__) || defined(_M_X64))
-    OutboundPacketStream& operator<<( int rhs )
-            { *this << (int32)rhs; return *this; }
-#endif
-
     OutboundPacketStream& operator<<( float rhs );
     OutboundPacketStream& operator<<( char rhs );
     OutboundPacketStream& operator<<( const RgbaColor& rhs );

--- a/external_libraries/oscpack_1_1_0/osc/OscReceivedElements.cpp
+++ b/external_libraries/oscpack_1_1_0/osc/OscReceivedElements.cpp
@@ -84,7 +84,7 @@ static inline const char* FindStr4End( const char *p, const char *end )
 
 
 // round up to the next highest multiple of 4. unless x is already a multiple of 4
-static inline uint32 RoundUp4( uint32 x ) 
+static inline uint32 RoundUp4_UInt32( uint32 x ) 
 {
     return (x + 3) & ~((uint32)0x03);
 }
@@ -249,7 +249,7 @@ int32 ReceivedMessageArgument::AsInt32Unchecked() const
 
     return u.i;
 #else
-	return *(int32*)argument_;
+	return *(int32*)argumentPtr_;
 #endif
 }
 
@@ -280,7 +280,7 @@ float ReceivedMessageArgument::AsFloatUnchecked() const
 
     return u.f;
 #else
-	return *(float*)argument_;
+	return *(float*)argumentPtr_;
 #endif
 }
 
@@ -400,7 +400,7 @@ double ReceivedMessageArgument::AsDoubleUnchecked() const
 
     return u.d;
 #else
-	return *(double*)argument_;
+	return *(double*)argumentPtr_;
 #endif
 }
 
@@ -533,7 +533,7 @@ void ReceivedMessageArgumentIterator::Advance()
             {
                 // treat blob size as an unsigned int for the purposes of this calculation
                 uint32 blobSize = ToUInt32( value_.argumentPtr_ );
-                value_.argumentPtr_ = value_.argumentPtr_ + osc::OSC_SIZEOF_INT32 + RoundUp4( blobSize );
+                value_.argumentPtr_ = value_.argumentPtr_ + osc::OSC_SIZEOF_INT32 + RoundUp4_UInt32( blobSize );
             }
             break;
 
@@ -688,7 +688,7 @@ void ReceivedMessage::Init( const char *message, osc_bundle_element_size_t size 
                                 
                             // treat blob size as an unsigned int for the purposes of this calculation
                             uint32 blobSize = ToUInt32( argument );
-                            argument = argument + osc::OSC_SIZEOF_INT32 + RoundUp4( blobSize );
+                            argument = argument + osc::OSC_SIZEOF_INT32 + RoundUp4_UInt32( blobSize );
                             if( argument > end )
                                 MalformedMessageException( "arguments exceed message size" );
                         }

--- a/external_libraries/oscpack_1_1_0/osc/OscReceivedElements.h
+++ b/external_libraries/oscpack_1_1_0/osc/OscReceivedElements.h
@@ -100,12 +100,6 @@ public:
         : contents_( contents )
         , size_( ValidateSize( (osc_bundle_element_size_t)size ) ) {}
 
-#if !(defined(__x86_64__) || defined(_M_X64))
-    ReceivedPacket( const char *contents, int size )
-        : contents_( contents )
-        , size_( ValidateSize( (osc_bundle_element_size_t)size ) ) {}
-#endif
-
     bool IsMessage() const { return !IsBundle(); }
     bool IsBundle() const;
 

--- a/external_libraries/oscpack_1_1_0/osc/OscTypes.h
+++ b/external_libraries/oscpack_1_1_0/osc/OscTypes.h
@@ -37,42 +37,17 @@
 #ifndef INCLUDED_OSCPACK_OSCTYPES_H
 #define INCLUDED_OSCPACK_OSCTYPES_H
 
+#include <stdint.h>
 
 namespace osc{
 
 // basic types
 
-#if defined(__BORLANDC__) || defined(_MSC_VER)
+typedef int64_t int64;
+typedef uint64_t uint64;
 
-typedef __int64 int64;
-typedef unsigned __int64 uint64;
-
-#elif defined(__x86_64__) || defined(_M_X64)
-
-typedef long int64;
-typedef unsigned long uint64;
-
-#else
-
-typedef long long int64;
-typedef unsigned long long uint64;
-
-#endif
-
-
-
-#if defined(__x86_64__) || defined(_M_X64)
-
-typedef signed int int32;
-typedef unsigned int uint32;
-
-#else
-
-typedef signed long int32;
-typedef unsigned long uint32;
-
-#endif
-
+typedef int32_t int32;
+typedef uint32_t uint32;
 
 enum ValueTypeSizes{
     OSC_SIZEOF_INT32 = 4,


### PR DESCRIPTION
(amd64, i386, arm64, powerpc and ppc64el...)

Upstreaming a debian patch authored by James Cowgill.
See https://bugs.debian.org/824581 for information.
The patch was new in debian supercollider package version 1:3.7.0_repack-3

I'm proposing the patch for master. It could potentially go to the 3.7 branch too but I'll assume that 3.8 is soon enough that I don't need to.