### PR TITLE
move jackey include dir from server to scsynth

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,6 +143,16 @@ endif()
 
 set(AUDIOAPI "default" CACHE STRING "Audio API to use (one of {default,coreaudio,jack,portaudio})")
 
+if (AUDIOAPI STREQUAL jack)
+	# here we check for JACK metadata API
+	include(CheckIncludeFiles)
+	CHECK_INCLUDE_FILES("jack/metadata.h" JACK_USE_METADATA_API)
+	if(${JACK_USE_METADATA_API})
+		message(STATUS "using JACK metadata API")
+	    include_directories(${CMAKE_SOURCE_DIR}/external_libraries/jackey)
+	endif()
+endif()
+
 option(LIBSCSYNTH "Compile libscsynth as shared library" OFF)
 
 option(INSTALL_HELP "Install help docs and examples along with the software" ON)

--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -34,16 +34,6 @@ else()
 	endif()
 endif()
 
-if (AUDIOAPI STREQUAL jack)
-	# here we check for JACK metadata API
-	include(CheckIncludeFiles)
-	CHECK_INCLUDE_FILES("jack/metadata.h" JACK_USE_METADATA_API)
-	if(${JACK_USE_METADATA_API})
-		message(STATUS "using JACK metadata API")
-		include_directories(${PROJECT_SOURCE_DIR}/external_libraries/jackey)
-	endif()
-endif()
-
 add_subdirectory(plugins)
 add_subdirectory(scsynth)
 


### PR DESCRIPTION
From the documentation it seems the reason is that include_directories()
affects only include paths for targets in the current
CMakeLists.txt. Don't know why this worked before but moving to scsynth
CMakeLists.txt as target_include_directories() works for me.

Fixes #2145