### PR TITLE
quarks: throw an error when updating without name

### DIFF
--- a/SCClassLibrary/Common/Quarks/Quarks.sc
+++ b/SCClassLibrary/Common/Quarks/Quarks.sc
@@ -141,7 +141,11 @@ Quarks {
 		// by quark name or by supplying a local path
 		// resolving / ~/ ./
 		// is it a git
-		var quark, localPath = this.quarkNameAsLocalPath(name);
+		var quark, localPath;
+		if(name.isNil, {
+			("Missing required argument: quark name").throw;
+		});
+		localPath = this.quarkNameAsLocalPath(name);
 		if(Git.isGit(localPath), {
 			Quark.fromLocalPath(localPath).update();
 		}, {


### PR DESCRIPTION
Fix #2180 