### PR TITLE
Classlib: GUI: Support "has-a" GUI objects by calling asView within Layouts

### DIFF
--- a/SCClassLibrary/Common/GUI/Base/QLayout.sc
+++ b/SCClassLibrary/Common/GUI/Base/QLayout.sc
@@ -6,6 +6,7 @@ Layout : QObject {
 	margins_ { arg margins;
 		this.setProperty( \margins, margins + [0,0,0,0] );
 	}
+	asView { ^this }
 }
 
 // LINE LAYOUTS ///////////////////////////////////////////////////
@@ -21,7 +22,7 @@ LineLayout : Layout {
 		var key;
 		var i;
 		if( in.isKindOf(Array) ) {
-			out[0] = in[0];
+			out[0] = in[0].asView;
 			i = 1;
 			while { i + 1 < in.size } {
 				key = in[i];
@@ -32,25 +33,25 @@ LineLayout : Layout {
 				i = i + 2;
 			};
 		}{
-			out[0] = in;
+			out[0] = in.asView;
 		};
 		^out;
 	}
 
 	add { arg item, stretch = 0, align;
-		this.invokeMethod( \addItem, [[item, stretch, QAlignment(align)]], true );
+		this.invokeMethod( \addItem, [[item.asView, stretch, QAlignment(align)]], true );
 	}
 
 	insert { arg item, index=0, stretch = 0, align;
-		this.invokeMethod( \insertItem, [[item, index, stretch, QAlignment(align)]], true );
+		this.invokeMethod( \insertItem, [[item.asView, index, stretch, QAlignment(align)]], true );
 	}
 
 	setStretch { arg item, stretch;
-		this.invokeMethod( \setStretch, [item, stretch], true );
+		this.invokeMethod( \setStretch, [item.asView, stretch], true );
 	}
 
 	setAlignment { arg item, align;
-		this.invokeMethod( \setAlignment, [item, QAlignment(align)], true );
+		this.invokeMethod( \setAlignment, [item.asView, QAlignment(align)], true );
 	}
 }
 
@@ -78,7 +79,7 @@ GridLayout : Layout {
 		var key;
 		var i;
 		if( in.isKindOf(Array) ) {
-			out[0] = in[0];
+			out[0] = in[0].asView;
 			i = 1;
 			while { i + 1 < in.size } {
 				key = in[i];
@@ -90,7 +91,7 @@ GridLayout : Layout {
 				i = i + 2;
 			};
 		}{
-			out[0] = in;
+			out[0] = in.asView;
 		};
 		^out;
 	}
@@ -143,11 +144,11 @@ GridLayout : Layout {
 	}
 
 	add { arg item, row, column, align;
-		this.invokeMethod( \addItem, [[item, row, column, 1, 1, QAlignment(align)]], true );
+		this.invokeMethod( \addItem, [[item.asView, row, column, 1, 1, QAlignment(align)]], true );
 	}
 
 	addSpanning { arg item, row, column, rowSpan=1, columnSpan=1, align;
-		this.invokeMethod( \addItem, [[item, row, column,
+		this.invokeMethod( \addItem, [[item.asView, row, column,
 			rowSpan, columnSpan,
 			QAlignment(align)
 		]], true );
@@ -194,11 +195,11 @@ StackLayout : Layout {
 
 	*qtClass { ^'QcStackLayout' }
 
-	*new { arg ...views; ^super.new([views]) }
+	*new { arg ...views; ^super.new([views.collect(_.asView)]) }
 
-	add { arg view; this.insert(view, -1) }
+	add { arg view; this.insert(view.asView, -1) }
 
-	insert { arg view, index = 0; this.invokeMethod( \insertWidget, [index, view] ) }
+	insert { arg view, index = 0; this.invokeMethod( \insertWidget, [index, view.asView] ) }
 
 	index { ^this.getProperty(\currentIndex) }
 	index_ { arg value; this.setProperty(\currentIndex, value) }


### PR DESCRIPTION
Currently, it is needlessly difficult to use subclasses of `SCViewHolder` in Qt layouts.

Qt layouts expect all of the member views to be Qt-native objects. However, "has-a" (rather than "is-a") is a standard way to extend the behavior of an object and there is no compelling reason why Qt layouts should rule this out.

This PR adds `.asView` to the items added into a layout. Normal Qt GUI objects simply return themselves. An SCViewHolder returns the view that is being wrapped. (I also had to add an `asView` method to the abstract Layout class, as layouts may be used within other layouts.)

Example: See https://github.com/jamshark70/ddwGUIEnhancements/blob/master/LayoutValueSlider.sc

```
w = Window("test", Rect(800, 200, 400, 50)).front;
w.view.layout = VLayout(
	HLayout(
		StaticText().maxWidth_(80).string_("label:"),
		LayoutValueSlider()
	)
);
```

Without the PR, you have to do `LayoutValueSlider().asView` by hand, which is a bit silly.