### PR TITLE
Fix QLocalSocket problem under Windows

### DIFF
--- a/common/localsocket_utils.cpp
+++ b/common/localsocket_utils.cpp
@@ -1,0 +1,18 @@
+#include "localsocket_utils.hpp"
+
+
+qint32 ArrayToInt(QByteArray source)
+{
+    qint32 temp;
+    QDataStream data(&source, QIODevice::ReadWrite);
+    data >> temp;
+    return temp;
+}
+
+QByteArray IntToArray(qint32 source)
+{
+    QByteArray temp;
+    QDataStream data(&temp, QIODevice::ReadWrite);
+    data << source;
+    return temp;
+}

--- a/common/localsocket_utils.hpp
+++ b/common/localsocket_utils.hpp
@@ -11,13 +11,13 @@ QByteArray IntToArray(qint32 source);
 qint32 ArrayToInt(QByteArray source);
 
 template <typename T>
-void sendSelectorAndList(QLocalSocket *socket, const QString& selector, const T& list)
+void sendSelectorAndData(QLocalSocket *socket, const QString& selector, const T& data)
 {
     QByteArray baToStream;
     QDataStream stream(&baToStream, QIODevice::WriteOnly);
     stream.setVersion(QDataStream::Qt_4_6);
     stream << selector;
-    stream << list;
+    stream << data;
     // Write the length so that we know how long it is on the other end
     int len = baToStream.length();
     QByteArray baLen = IntToArray(len);

--- a/common/localsocket_utils.hpp
+++ b/common/localsocket_utils.hpp
@@ -1,0 +1,31 @@
+#ifndef SCIDE_LOCALSOCKET_UTILS_HPP
+#define SCIDE_LOCALSOCKET_UTILS_HPP
+
+#include <QByteArray>
+#include <QLocalSocket>
+#include <QDataStream>
+
+// Aux functions for LocalSocket data handling
+// Make template so that it supports QVariantLists and QStringList, which are te data types that we send in sc_process and main
+QByteArray IntToArray(qint32 source);
+qint32 ArrayToInt(QByteArray source);
+
+template <typename T>
+void sendSelectorAndList(QLocalSocket *socket, const QString& selector, const T& list)
+{
+    QByteArray baToStream;
+    QDataStream stream(&baToStream, QIODevice::WriteOnly);
+    stream.setVersion(QDataStream::Qt_4_6);
+    stream << selector;
+    stream << list;
+    // Write the length so that we know how long it is on the other end
+    int len = baToStream.length();
+    QByteArray baLen = IntToArray(len);
+    socket->write(baLen);
+    socket->write(baToStream);
+    socket->flush();
+}
+
+
+#endif
+

--- a/editors/sc-ide/CMakeLists.txt
+++ b/editors/sc-ide/CMakeLists.txt
@@ -100,6 +100,7 @@ set ( ide_moc_hdr
     widgets/util/volume_widget.hpp
 
     ${CMAKE_SOURCE_DIR}/QtCollider/widgets/web_page.hpp
+    ${CMAKE_SOURCE_DIR}/common/localsocket_utils.cpp
 )
 
 file (GLOB_RECURSE all_hdr *hpp)

--- a/editors/sc-ide/CMakeLists.txt
+++ b/editors/sc-ide/CMakeLists.txt
@@ -154,6 +154,7 @@ set ( ide_src
     ${CMAKE_SOURCE_DIR}/QtCollider/widgets/web_page.cpp
 
     ${CMAKE_SOURCE_DIR}/common/SC_TextUtils.cpp
+    ${CMAKE_SOURCE_DIR}/common/localsocket_utils.cpp
 
     ${CMAKE_SOURCE_DIR}/SCDoc/SCDoc.cpp
     ${CMAKE_SOURCE_DIR}/SCDoc/SCDoc.tab.cpp

--- a/editors/sc-ide/core/main.cpp
+++ b/editors/sc-ide/core/main.cpp
@@ -28,6 +28,7 @@
 #include "../widgets/code_editor/highlighter.hpp"
 #include "../widgets/style/style.hpp"
 #include "../../../QtCollider/hacks/hacks_mac.hpp"
+#include "localsocket_utils.hpp"
 
 #include "yaml-cpp/node.h"
 #include "yaml-cpp/parser.h"
@@ -145,11 +146,7 @@ bool SingleInstanceGuard::tryConnect(QStringList const & arguments)
             }
 
             if (socket->waitForConnected(200)) {
-                QDataStream stream(socket.data());
-                stream.setVersion(QDataStream::Qt_4_6);
-
-                stream << QStringLiteral("open");
-                stream << canonicalArguments;
+                sendSelectorAndList(socket.data(), QStringLiteral("open"), canonicalArguments);
                 if (!socket->waitForBytesWritten(300))
                     qWarning("SingleInstanceGuard: writing data to another IDE instance timed out");
 
@@ -173,27 +170,40 @@ bool SingleInstanceGuard::tryConnect(QStringList const & arguments)
 
 void SingleInstanceGuard::onIpcData()
 {
-    QByteArray ipcData = mIpcSocket->readAll();
+    mIpcData.append(mIpcSocket->readAll());
 
-    QBuffer receivedData ( &ipcData );
-    receivedData.open ( QIODevice::ReadOnly );
+    // After we have put the data in the buffer, process it    
+    int avail = mIpcData.length();
+    do{
+        if (mReadSize == 0 && avail > 4){
+            mReadSize = ArrayToInt(mIpcData.left(4));
+            mIpcData.remove(0, 4);
+            avail -= 4;
+        }
 
-    QDataStream in ( &receivedData );
-    in.setVersion ( QDataStream::Qt_4_6 );
-    QString id;
-    in >> id;
-    if ( in.status() != QDataStream::Ok )
-        return;
+        if (mReadSize > 0 && avail >= mReadSize){
+            QByteArray baReceived(mIpcData.left(mReadSize));
+            mIpcData.remove(0, mReadSize);
+            mReadSize = 0;
 
-    QStringList message;
-    in >> message;
-    if ( in.status() != QDataStream::Ok )
-        return;
+            QDataStream in(baReceived);
+            in.setVersion(QDataStream::Qt_4_6);
+            QString selector;
+            in >> selector;
+            if (in.status() != QDataStream::Ok)
+                return;
 
-    if (id == QStringLiteral("open")) {
-        foreach (QString path, message)
-            Main::documentManager()->open(path);
-    }
+            QStringList message;
+            in >> message;
+            if (in.status() != QDataStream::Ok)
+                return;
+
+            if (selector == QStringLiteral("open")) {
+                foreach(QString path, message)
+                    Main::documentManager()->open(path);
+            }
+        }
+    } while ((mReadSize == 0 && avail > 4) || (mReadSize > 0 && avail > mReadSize));
 }
 
 

--- a/editors/sc-ide/core/main.cpp
+++ b/editors/sc-ide/core/main.cpp
@@ -146,7 +146,7 @@ bool SingleInstanceGuard::tryConnect(QStringList const & arguments)
             }
 
             if (socket->waitForConnected(200)) {
-                sendSelectorAndList(socket.data(), QStringLiteral("open"), canonicalArguments);
+                sendSelectorAndData(socket.data(), QStringLiteral("open"), canonicalArguments);
                 if (!socket->waitForBytesWritten(300))
                     qWarning("SingleInstanceGuard: writing data to another IDE instance timed out");
 

--- a/editors/sc-ide/core/main.hpp
+++ b/editors/sc-ide/core/main.hpp
@@ -45,6 +45,7 @@ class SingleInstanceGuard:
     Q_OBJECT
 
 public:
+    SingleInstanceGuard() : mReadSize(0){};
     bool tryConnect(QStringList const & arguments);
 
 public Q_SLOTS:
@@ -60,6 +61,8 @@ public Q_SLOTS:
 private:
     QLocalServer * mIpcServer;
     QLocalSocket * mIpcSocket;
+    int mReadSize;
+    QByteArray mIpcData;
 };
 
 class Main:

--- a/editors/sc-ide/core/sc_process.cpp
+++ b/editors/sc-ide/core/sc_process.cpp
@@ -321,7 +321,6 @@ void ScProcess::postQuitNotification()
 }
 
 
-#include <string>
 void ScProcess::onIpcData()
 {
     mIpcData.append(mIpcSocket->readAll());
@@ -351,9 +350,7 @@ void ScProcess::onIpcData()
             if (in.status() != QDataStream::Ok)
                 return;
 
-            std::string s1(selector.toLatin1().data());
-            std::string s2(message.toLatin1().data());
-
+            onResponse(selector, message);
             emit response(selector, message);
         }
     } while ((mReadSize == 0 && avail > 4) || (mReadSize > 0 && avail > mReadSize));

--- a/editors/sc-ide/core/sc_process.cpp
+++ b/editors/sc-ide/core/sc_process.cpp
@@ -48,8 +48,7 @@ ScProcess::ScProcess( Settings::Manager * settings, QObject * parent ):
     mIpcSocket(NULL),
     mIpcServerName("SCIde_" + QString::number(QCoreApplication::applicationPid())),
     mTerminationRequested(false),
-    mCompiled(false),
-    mReadSize(0)
+    mCompiled(false)
 {
     prepareActions(settings);
 

--- a/editors/sc-ide/core/sc_process.cpp
+++ b/editors/sc-ide/core/sc_process.cpp
@@ -390,7 +390,7 @@ void ScProcess::onStart()
     
 void ScProcess::updateTextMirrorForDocument ( Document * doc, int position, int charsRemoved, int charsAdded )
 {
-    QString str("!updateDocText/");
+    QString str(QStringLiteral("!updateDocText/"));
     str.append(doc->id());
     str.append("/");
     str.append(QString::number(position));
@@ -417,7 +417,7 @@ void ScProcess::updateTextMirrorForDocument ( Document * doc, int position, int 
     
 void ScProcess::updateSelectionMirrorForDocument ( Document * doc, int start, int range )
 {
-    QString str("!updateDocSelection/");
+    QString str(QStringLiteral("!updateDocSelection/"));
     str.append(doc->id());
     str.append("/");
     str.append(QString::number(start));
@@ -426,9 +426,11 @@ void ScProcess::updateSelectionMirrorForDocument ( Document * doc, int start, in
     str.append("&");
 
     try {
-        if (!mIpcSocket) return;
+        if (!mIpcSocket) 
+            return;
 
-        if (mIpcSocket->state() != QAbstractSocket::ConnectedState) return;
+        if (mIpcSocket->state() != QAbstractSocket::ConnectedState) 
+            return;
 
         // Write the length and the QString itself, so that we know how long it is on the other end
         int len = str.length();

--- a/editors/sc-ide/core/sc_process.hpp
+++ b/editors/sc-ide/core/sc_process.hpp
@@ -113,7 +113,7 @@ private:
     void prepareActions(Settings::Manager * settings);
     void postQuitNotification();
 
-    QByteArray ScProcess::IntToArray(qint32 source);
+    QByteArray IntToArray(qint32 source);
 
     QAction * mActions[ActionCount];
 

--- a/editors/sc-ide/core/sc_process.hpp
+++ b/editors/sc-ide/core/sc_process.hpp
@@ -121,6 +121,7 @@ private:
     QLocalSocket *mIpcSocket;
     QString mIpcServerName;
     QByteArray mIpcData;
+    int mReadSize;
 
     bool mTerminationRequested;
     QDateTime mTerminationRequestTime;

--- a/editors/sc-ide/core/sc_process.hpp
+++ b/editors/sc-ide/core/sc_process.hpp
@@ -111,10 +111,7 @@ private:
     void onResponse( const QString & selector, const QString & data );
 
     void prepareActions(Settings::Manager * settings);
-    void postQuitNotification();
-
-    QByteArray IntToArray(qint32 source);
-
+    void postQuitNotification();    
     QAction * mActions[ActionCount];
 
     ScLanguage::Introspection mIntrospection;
@@ -175,7 +172,6 @@ private:
     QUuid mId;
     ScProcess *mSc;
 };
-
 }
 
 #endif

--- a/editors/sc-ide/core/sc_process.hpp
+++ b/editors/sc-ide/core/sc_process.hpp
@@ -113,6 +113,8 @@ private:
     void prepareActions(Settings::Manager * settings);
     void postQuitNotification();
 
+    QByteArray ScProcess::IntToArray(qint32 source);
+
     QAction * mActions[ActionCount];
 
     ScLanguage::Introspection mIntrospection;

--- a/editors/sc-ide/core/sc_process.hpp
+++ b/editors/sc-ide/core/sc_process.hpp
@@ -121,7 +121,7 @@ private:
     QLocalSocket *mIpcSocket;
     QString mIpcServerName;
     QByteArray mIpcData;
-    int mReadSize;
+    int mReadSize = 0;
 
     bool mTerminationRequested;
     QDateTime mTerminationRequestTime;

--- a/editors/sc-ide/primitives/sc_ipc_client.cpp
+++ b/editors/sc-ide/primitives/sc_ipc_client.cpp
@@ -38,8 +38,6 @@
 #include "sc_ipc_client.hpp"
 #include "localsocket_utils.hpp"
 
-#define DEBUG_IPC
-
 SCIpcClient::SCIpcClient( const char * ideName ):
         mSocket(NULL),
         mReadSize(0)

--- a/editors/sc-ide/primitives/sc_ipc_client.cpp
+++ b/editors/sc-ide/primitives/sc_ipc_client.cpp
@@ -325,15 +325,15 @@ int ScIDE_Send(struct VMGlobals *g, int numArgsPushed)
     }
 
     PyrSlot * idSlot = g->sp - 1;
-    char selector[255];
-    if (slotStrVal( idSlot, selector, 255 ))
+    char id[255];
+    if (slotStrVal( idSlot, id, 255 ))
         return errWrongType;
 
     PyrSlot * argSlot = g->sp;
 
     try {
         YAMLSerializer serializer(argSlot);
-        sendSelectorAndData(gIpcClient->mSocket, selector, QString::fromUtf8(serializer.data()));
+        sendSelectorAndData(gIpcClient->mSocket, QString(id), QString::fromUtf8(serializer.data()));
     } catch (std::exception const & e) {
         postfl("Exception during ScIDE_Send: %s\n", e.what());
         return errFailed;

--- a/editors/sc-ide/primitives/sc_ipc_client.cpp
+++ b/editors/sc-ide/primitives/sc_ipc_client.cpp
@@ -56,7 +56,7 @@ SCIpcClient::~SCIpcClient()
     mSocket->disconnectFromServer();
 }
 
-void SCIpcClient::readIDEData() {    
+void SCIpcClient::readIDEData() {
     mIpcData.append(mSocket->readAll());
 
     // After we have put the data in the buffer, process it    

--- a/editors/sc-ide/primitives/sc_ipc_client.cpp
+++ b/editors/sc-ide/primitives/sc_ipc_client.cpp
@@ -39,8 +39,7 @@
 #include "localsocket_utils.hpp"
 
 SCIpcClient::SCIpcClient( const char * ideName ):
-        mSocket(NULL),
-        mReadSize(0)
+        mSocket(NULL)
 {
     mSocket = new QLocalSocket();
     mSocket->connectToServer(QString(ideName));
@@ -111,7 +110,6 @@ void SCIpcClient::updateDocText( const QVariantList & argList )
     QString newChars = argList[3].toString();
 #ifdef DEBUG_IPC
     post("RECEIVED updateDocText with args id: %s, pos: %d, charsR: %d, newC: %s\n", quuid.constData(), pos, charsRemoved, newChars.toLatin1().data());
-    fflush(stdout);
 #endif
     setTextMirrorForDocument(quuid, newChars, pos, charsRemoved);
 }
@@ -122,8 +120,7 @@ void SCIpcClient::updateDocSelection( const QVariantList & argList )
     int start = argList[1].toInt();
     int range = argList[2].toInt();
 #ifdef DEBUG_IPC
-    printf("RECEIVED updateDocSelection with args start: %d, range: %d\n", start, range);
-    fflush(stdout);
+    post("RECEIVED updateDocText with args id: %s, pos: %d, charsR: %d, newC: %s\n", quuid.constData(), pos, charsRemoved, newChars.toLatin1().data());
 #endif
     setSelectionMirrorForDocument(quuid, start, range);
 }

--- a/editors/sc-ide/primitives/sc_ipc_client.cpp
+++ b/editors/sc-ide/primitives/sc_ipc_client.cpp
@@ -41,7 +41,8 @@
 SCIpcClient::SCIpcClient( const char * ideName ):
         mSocket(NULL),
         mUpdateDocTextRegex("!updateDocText/([\\{\\}\\-A-Za-z0-9]+)/(\\d+)/(\\d+)/(.*)&", QRegularExpression::DotMatchesEverythingOption),
-        mUpdateDocSelRegex("!updateDocSelection/([\\{\\}\\-A-Za-z0-9]+)/(\\d+)/(\\d+)&")
+        mUpdateDocSelRegex("!updateDocSelection/([\\{\\}\\-A-Za-z0-9]+)/(\\d+)/(\\d+)&"),
+        mReadSize(0)
 {
     mSocket = new QLocalSocket();
     mSocket->connectToServer(QString(ideName));
@@ -59,22 +60,22 @@ SCIpcClient::~SCIpcClient()
 }
 
 void SCIpcClient::readIDEData() {
-    static int readSize = 0;
+    
     QByteArray ba = mSocket->readAll();
     mIpcData.append(ba);
 
     // After we have put the data in the buffer, process it    
     int avail = mIpcData.length();
-    if (readSize == 0 && avail > 4){
-        readSize = ArrayToInt(mIpcData.left(4));
+    if (mReadSize == 0 && avail > 4){
+        mReadSize = ArrayToInt(mIpcData.left(4));
         mIpcData.remove(0, 4);
         avail -= 4;
     }
 
-    if (readSize > 0 && avail >= readSize){
-        QString str(mIpcData.left(readSize));
-        mIpcData.remove(0, readSize);
-        readSize = 0;
+    if (mReadSize > 0 && avail >= mReadSize){
+        QString str(mIpcData.left(mReadSize));
+        mIpcData.remove(0, mReadSize);
+        mReadSize = 0;
         QVariantList argList;
         QRegularExpressionMatch match;
         match = mUpdateDocTextRegex.match(str);

--- a/editors/sc-ide/primitives/sc_ipc_client.hpp
+++ b/editors/sc-ide/primitives/sc_ipc_client.hpp
@@ -63,9 +63,6 @@ private:
     QHash<QByteArray, QPair<int, int>> mDocumentSelectionMirrors;
     QMutex mTextMirrorHashMutex;
     QMutex mSelMirrorHashMutex;
-
-    QRegularExpression mUpdateDocTextRegex;
-    QRegularExpression mUpdateDocSelRegex;
 };
 
 

--- a/editors/sc-ide/primitives/sc_ipc_client.hpp
+++ b/editors/sc-ide/primitives/sc_ipc_client.hpp
@@ -54,8 +54,6 @@ private:
     void updateDocText( const QVariantList & argList );
     void updateDocSelection( const QVariantList & argList );
     
-
-    
     int mReadSize;
     QByteArray mIpcData;
     QHash<QByteArray, QString> mDocumentTextMirrors;

--- a/editors/sc-ide/primitives/sc_ipc_client.hpp
+++ b/editors/sc-ide/primitives/sc_ipc_client.hpp
@@ -57,6 +57,7 @@ private:
     
     qint32 SCIpcClient::ArrayToInt(QByteArray source);
     
+    int mReadSize;
     QByteArray mIpcData;
     QHash<QByteArray, QString> mDocumentTextMirrors;
     QHash<QByteArray, QPair<int, int>> mDocumentSelectionMirrors;

--- a/editors/sc-ide/primitives/sc_ipc_client.hpp
+++ b/editors/sc-ide/primitives/sc_ipc_client.hpp
@@ -25,7 +25,6 @@
 #include <QLocalSocket>
 #include <QMutex>
 #include <QHash>
-#include <QRegularExpression>
 
 class SCIpcClient : public QObject
 {

--- a/editors/sc-ide/primitives/sc_ipc_client.hpp
+++ b/editors/sc-ide/primitives/sc_ipc_client.hpp
@@ -54,7 +54,7 @@ private:
     void updateDocText( const QVariantList & argList );
     void updateDocSelection( const QVariantList & argList );
     
-    qint32 ArrayToInt(QByteArray source);
+
     
     int mReadSize;
     QByteArray mIpcData;

--- a/editors/sc-ide/primitives/sc_ipc_client.hpp
+++ b/editors/sc-ide/primitives/sc_ipc_client.hpp
@@ -25,6 +25,7 @@
 #include <QLocalSocket>
 #include <QMutex>
 #include <QHash>
+#include <QRegularExpression>
 
 class SCIpcClient : public QObject
 {
@@ -54,11 +55,16 @@ private:
     void updateDocText( const QVariantList & argList );
     void updateDocSelection( const QVariantList & argList );
     
+    qint32 SCIpcClient::ArrayToInt(QByteArray source);
+    
     QByteArray mIpcData;
     QHash<QByteArray, QString> mDocumentTextMirrors;
     QHash<QByteArray, QPair<int, int>> mDocumentSelectionMirrors;
     QMutex mTextMirrorHashMutex;
     QMutex mSelMirrorHashMutex;
+
+    QRegularExpression mUpdateDocTextRegex;
+    QRegularExpression mUpdateDocSelRegex;
 };
 
 

--- a/editors/sc-ide/primitives/sc_ipc_client.hpp
+++ b/editors/sc-ide/primitives/sc_ipc_client.hpp
@@ -54,7 +54,7 @@ private:
     void updateDocText( const QVariantList & argList );
     void updateDocSelection( const QVariantList & argList );
     
-    int mReadSize;
+    int mReadSize = 0;
     QByteArray mIpcData;
     QHash<QByteArray, QString> mDocumentTextMirrors;
     QHash<QByteArray, QPair<int, int>> mDocumentSelectionMirrors;

--- a/editors/sc-ide/primitives/sc_ipc_client.hpp
+++ b/editors/sc-ide/primitives/sc_ipc_client.hpp
@@ -55,7 +55,7 @@ private:
     void updateDocText( const QVariantList & argList );
     void updateDocSelection( const QVariantList & argList );
     
-    qint32 SCIpcClient::ArrayToInt(QByteArray source);
+    qint32 ArrayToInt(QByteArray source);
     
     int mReadSize;
     QByteArray mIpcData;

--- a/lang/CMakeLists.txt
+++ b/lang/CMakeLists.txt
@@ -83,7 +83,7 @@ set(sclang_sources
 	${CMAKE_SOURCE_DIR}/common/SC_StringBuffer.cpp
 	${CMAKE_SOURCE_DIR}/common/SC_StringParser.cpp
 	${CMAKE_SOURCE_DIR}/common/SC_TextUtils.cpp
-    ${CMAKE_SOURCE_DIR}/common/localsocket_utils.cpp
+	${CMAKE_SOURCE_DIR}/common/localsocket_utils.cpp
 
 	${CMAKE_SOURCE_DIR}/common/sc_popen.cpp
 )

--- a/lang/CMakeLists.txt
+++ b/lang/CMakeLists.txt
@@ -83,6 +83,7 @@ set(sclang_sources
 	${CMAKE_SOURCE_DIR}/common/SC_StringBuffer.cpp
 	${CMAKE_SOURCE_DIR}/common/SC_StringParser.cpp
 	${CMAKE_SOURCE_DIR}/common/SC_TextUtils.cpp
+    ${CMAKE_SOURCE_DIR}/common/localsocket_utils.cpp
 
 	${CMAKE_SOURCE_DIR}/common/sc_popen.cpp
 )


### PR DESCRIPTION
Still Work in Progress.

For now, it fixes the Windows crash, so this should enable us to move
the Windows development to master again, which we should try to do ASAP.

Since QLocalSocket under Windows is unreliable (it might cut messages),
it is not advised to use QDataStream.

I have changed it to a messaging system based on strings and REs. At the
beginning of each message I put the length of the message, so that the
receiving side knows how much to retrieve.

The change for now is only for the messages coming from SCProcess to
sc_ipc_client direction. **I don't know if something similar needs to be
done in the other direction, or where..., please advise**