### PR TITLE
Classlib: SCDoc: Do not render 'getter' links for non-existent getters

### DIFF
--- a/SCClassLibrary/SCDoc/SCDocRenderer.sc
+++ b/SCClassLibrary/SCDoc/SCDocRenderer.sc
@@ -280,16 +280,16 @@ SCDocHTMLRenderer {
                 << mname2 << "'>" << mname2 << "</a>"
             };
 
-            x.value;
             switch (mstat,
                 // getter only
-                1, { stream << " " << args << "</h3>\n"; },
+                1, { x.value; stream << " " << args << "</h3>\n"; },
                 // getter and setter
-                3, { stream << "</h3>\n"; },
+                3, { x.value; stream << "</h3>\n"; },
                 // method not found
                 0, {
                     "SCDoc: In %\n"
                     "  Method %% not found.".format(currDoc.fullPath,pfx,mname2).warn;
+                    x.value;
                     stream << ": METHOD NOT FOUND!</h3>\n";
                 }
             );


### PR DESCRIPTION
Fix #837.

The method renderer checks for getters and setters, and stores the status in `mstat`:

0 = not found
1 = method name only
2 = setter only
3 = getter and setter

Without this change, it writes the method name (without `_`) in *all* cases, without checking `mstat`. But it should write this only if `mstat != 2`. So I move the `x.value` inside the `switch` branches, so that it will be omitted for case 2.