### PR TITLE
sclang: Ensure git object is defined for checkout

### DIFF
--- a/SCClassLibrary/Common/Quarks/Quark.sc
+++ b/SCClassLibrary/Common/Quarks/Quark.sc
@@ -101,11 +101,13 @@ Quark {
 
 	checkout {
 		var rs;
+		if(git.isNil, {
+			git = Git(localPath);
+		});
 		if(this.isDownloaded.not, {
 			if(this.url.isNil, {
 				Error("No git url, cannot checkout quark" + this).throw;
 			});
-			git = Git(localPath);
 			git.clone(url);
 			// get tags etc
 			git.fetch();


### PR DESCRIPTION
For some checkout scenarios, we can call Quark:checkout without Quark:git being defined, resulting in an error. You can repro this before the change by running this with a clean repo:

    Quark("ServerView").install

Figuring out WHY git is undefined in this case is difficult - it's very order-dependent, and seems to happen only during some nested installs. This fix is a local/safe/obvious fix: make sure git is defined.

@crucialfelix: This is pretty critical - without this, installing at least some quarks is currently blocked. It might be worth searching for a more general fix in case there are other code paths for which Quark:git is nil. It seems safe enough to just lazily create it in a getter, and change any ```git``` references to ```this.git``` - but I'd rather run things by you for a more general change like that.