### PR TITLE
Fix Document path sync problems

### DIFF
--- a/SCClassLibrary/scide_scqt/ScIDE.sc
+++ b/SCClassLibrary/scide_scqt/ScIDE.sc
@@ -474,7 +474,11 @@ Document {
 		isEdited = isEdited.booleanValue;
 		chars = String.fill(chars.size, {|i| chars[i].asAscii});
 		title = String.fill(title.size, {|i| title[i].asAscii});
-		path = String.fill(path.size, {|i| path[i].asAscii});
+		if(path.isArray) {
+			path = String.fill(path.size, {|i| path[i].asAscii});
+		} {
+			path = nil;
+		};
 		if((doc = this.findByQUuid(quuid)).isNil, {
 			doc = super.new.initFromIDE(quuid, title, chars, isEdited, path, selStart, selSize);
 			allDocuments = allDocuments.add(doc);

--- a/editors/sc-ide/core/doc_manager.cpp
+++ b/editors/sc-ide/core/doc_manager.cpp
@@ -554,6 +554,7 @@ bool DocumentManager::doSaveAs( Document *doc, const QString & path )
         mFsWatcher.addPath(cpath);
 
     Q_EMIT(saved(doc));
+    syncLangDocument(doc);
 
     return true;
 }
@@ -1305,7 +1306,7 @@ void DocumentManager::syncLangDocument(Document *doc)
         range = doc->initialSelectionRange();
     }
     QString command =
-            QStringLiteral("Document.syncFromIDE(\'%1\', %2, %3, %4, \'%5\', %6, %7)")
+            QStringLiteral("Document.syncFromIDE(\'%1\', %2, %3, %4, %5, %6, %7)")
             .arg(doc->id().constData())
             .arg(doc->titleAsSCArrayOfCharCodes())
             .arg(doc->textAsSCArrayOfCharCodes(0, -1))

--- a/editors/sc-ide/core/doc_manager.cpp
+++ b/editors/sc-ide/core/doc_manager.cpp
@@ -166,7 +166,7 @@ QString Document::pathAsSCArrayOfCharCodes()
 {
     QString path;
     if(mFilePath.isEmpty()) {
-        path = QStringLiteral("nil");
+        return QStringLiteral("nil");
     } else {
         path = mFilePath;
     }


### PR DESCRIPTION
Two commits:

1. Should be straightforward: fix the typo that enclosed the path array in single quotes, and add a call to `syncLangDocument` into `DocumentManager::doSaveAs`. I've tested, and this fixes the problems in #2217 with opening and saving documents.

2. Perhaps needs a little discussion. After fixing open/save, now "New document" sets the Document object's path to a string `"nil"`. This seems... shall we say... poorly thought out. My second commit here ensures that the path is a `nil` object (so you can ask `Document.current.path.isNil` and get the right answer). But it might also be useful to set it to an empty string `""`. My gut feeling is that a true `nil` is better, but I'm open to being persuaded the other way. This finishes fixing #2217.