### PR TITLE
Fix TCP connect for IPs > 127.x.x.x

### DIFF
--- a/lang/LangPrimSource/OSCData.cpp
+++ b/lang/LangPrimSource/OSCData.cpp
@@ -394,8 +394,10 @@ static int prNetAddr_Connect(VMGlobals *g, int numArgsPushed)
 	err = slotIntVal(netAddrObj->slots + ivxNetAddr_Hostaddr, &addr);
 	if (err) return err;
 
+	unsigned long ulAddress = (unsigned int)addr;
+
 	try {
-		SC_TcpClientPort *comPort = new SC_TcpClientPort(addr, port, netAddrTcpClientNotifyFunc, netAddrObj);
+		SC_TcpClientPort *comPort = new SC_TcpClientPort(ulAddress, port, netAddrTcpClientNotifyFunc, netAddrObj);
 		SetPtr(netAddrObj->slots + ivxNetAddr_Socket, comPort);
 	} catch (std::exception const & e) {
 		printf("NetAddr-Connect failed with exception: %s\n", e.what());

--- a/lang/LangPrimSource/SC_ComPort.cpp
+++ b/lang/LangPrimSource/SC_ComPort.cpp
@@ -228,7 +228,7 @@ void SC_TcpConnection::handleMsgReceived(const boost::system::error_code &error,
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-SC_TcpClientPort::SC_TcpClientPort(long inAddress, int inPort, ClientNotifyFunc notifyFunc, void *clientData):
+SC_TcpClientPort::SC_TcpClientPort(unsigned long inAddress, int inPort, ClientNotifyFunc notifyFunc, void *clientData):
 	socket(ioService),
 	endpoint(boost::asio::ip::address_v4(inAddress), inPort),
 	mClientNotifyFunc(notifyFunc),

--- a/lang/LangPrimSource/SC_ComPort.h
+++ b/lang/LangPrimSource/SC_ComPort.h
@@ -112,7 +112,7 @@ public:
 	typedef void (*ClientNotifyFunc)(void* clientData);
 
 public:
-	SC_TcpClientPort(long inAddress, int inPort, ClientNotifyFunc notifyFunc=0, void* clientData=0);
+	SC_TcpClientPort(unsigned long inAddress, int inPort, ClientNotifyFunc notifyFunc=0, void* clientData=0);
 	int Close();
 
 	boost::asio::ip::tcp::socket & Socket () { return socket; }


### PR DESCRIPTION
32-bit IPs from sclang are read as signed integers. They thus need to be
interpreted/cast to unsigned for IPs > 127.x.x.x to be valid. This is
already done for UDP ports, but has been forgotten to be taken care of
for TCP ports.

e.g. this raises a boost error, because an int is first cast to a long and then to an unsigned long instead of the correct detour via an unsigned int.

    a = NetAddr("192.168.1.177", 3333);
    a.connect;