### PR TITLE
AbstractServerAction improvement

### DIFF
--- a/SCClassLibrary/Common/Control/SystemActions.sc
+++ b/SCClassLibrary/Common/Control/SystemActions.sc
@@ -163,7 +163,7 @@ AbstractServerAction : AbstractSystemAction {
 	}
 
 	*remove { arg object, server;
-		if(server.isNil) { server = \default };
+		if(server.isNil) { server = \all };
 		this.objects !? { this.objects.at(server).remove(object) };
 	}
 


### PR DESCRIPTION
Changed this.objects[\all] instead of this.objects[\default] for the default server in remove function in AbstractServerAction so PersistentNodeTrees will work without specifying server.
