### PR TITLE
Classlib: Quarks: Fix typo in incompatibility message (SC: camel case…

### DIFF
--- a/SCClassLibrary/Common/Quarks/Quarks.sc
+++ b/SCClassLibrary/Common/Quarks/Quarks.sc
@@ -183,7 +183,7 @@ Quarks {
 			deps,
 			incompatible = { arg name;
 				(quark.name
-					+ "reports an incompatibility with this Super Collider version"
+					+ "reports an incompatibility with this SuperCollider version"
 					+ "or with other already installed quarks."
 				).inform;
 				false


### PR DESCRIPTION
Sorry... it's a small thing, but seeing `Super Collider` (with space) in the post window hurt my eyes.