### PR TITLE
Add supernova to some scsynth-specific docs

### DIFF
--- a/HelpSource/Classes/ServerOptions.schelp
+++ b/HelpSource/Classes/ServerOptions.schelp
@@ -124,7 +124,7 @@ method:: ugenPluginsPath
 A path or an Array of paths. If non-nil, the standard paths are NOT searched for plugins. This corresponds with the option "-U".
 
 method:: restrictedPath
-Allows you to restrict the system paths in which scsynth is allowed to read/write files during running. A nil value (the default) means no restriction. Otherwise, set it as a string representing a single path.
+Allows you to restrict the system paths in which the server is allowed to read/write files during running. A nil value (the default) means no restriction. Otherwise, set it as a string representing a single path.
 
 method:: threads
 Number of audio threads that are spawned by supernova. For scsynth this value is ignored. If it is code::nil::or 0, it
@@ -152,7 +152,7 @@ subsection:: Other Instance Methods
 method:: asOptionsString
 argument:: port
 The port number for the resulting server app. Default value is 57110.
-Returns:: a String specifying the options in the format required by the command-line scsynth app.
+Returns:: a String specifying the options in the format required by the command-line server app (scsynth or supernova).
 
 method:: firstPrivateBus
 Returns:: the index of the first audio bus on this server which is not used by the input and output hardware.

--- a/HelpSource/Guides/ClientVsServer.schelp
+++ b/HelpSource/Guides/ClientVsServer.schelp
@@ -13,7 +13,7 @@ numberedlist::
 
 image::structureEn.png#Figure 1. Structure of the SuperCollider application::
 
-The SuperCollider application is thus made up of two distinct, autonomous, components, a server and a client. The first is named scsynth (SC-synthesizer), the second sclang (SC-language).
+The SuperCollider application is thus made up of two distinct, autonomous, components, a server and a client. For the first we have a choice between scsynth (SC-synthesizer) and supernova, and for the second we have sclang (SC-language).
 
 section:: Description
 
@@ -23,9 +23,9 @@ image::s8kfFC-clientServerEn.png#Figure 2. Client/Server architecture::
 
 In Figure 2 a generic network architecture is depicted: A number of clients communicating with a server by exchanging messages through a network. In SuperCollider the client and the server make use of a specific subset of CNMAT's Open Sound Control (OSC) protocol in order to communicate (over TCP or UDP). As a consequence, you will see many references to "OSC messages" in the help files.
 
-To avoid any possible confusion: The network is defined at an abstract level. This means that the client(s) and the server(s) can be in execution on the same physical machine. This is what normally happens when you use the SuperCollider application: two programs will run on your machine, scsynth and sclang.
+To avoid any possible confusion: The network is defined at an abstract level. This means that the client(s) and the server(s) can be in execution on the same physical machine. This is what normally happens when you use the SuperCollider application: two programs will run on your machine, scsynth (or supernova) and sclang.
 
-The server app, emphasis::scsynth::, is a lean and efficient command line program dedicated to audio synthesis and processing. It knows nothing about SC code, objects, Object Oriented Programming, or anything else to do with the SC language.
+The server app, emphasis::scsynth:: or emphasis::supernova::, is a lean and efficient command line program dedicated to audio synthesis and processing. It knows nothing about SC code, objects, Object Oriented Programming, or anything else to do with the SC language.
 
 The client of this server is emphasis::sclang::. Sclang performs two distinct tasks:
 definitionList::
@@ -39,7 +39,7 @@ code::
 s = Server.default; // create a new Server object and assign it to variable s
 s.boot;             // boot the server app, i.e. tell the server to be ready to work
 ::
-The sclang interpreter can send OSC messages to scsynth in two fashions:
+The sclang interpreter can send OSC messages to the server in two fashions:
 definitionList::
 ## directly || in this case, sclang offers a thin syntax layer which allows one to deal with raw OSC messages. All the server's functionality is in this case available "by hand" using the .sendMsg method of link::Classes/Server::, and other similar messages.
 code::
@@ -76,7 +76,7 @@ section:: Pros/Cons
 The client/server architecture provides three main advantages:
 definitionList::
 ## stability || if the client crashes, the server keeps on working, i.e. the audio does not stop. This is intuitively relevant for a live situation. Vice versa, the server can crash letting you still manage the situation from the client.
-## modularity || synthesis is one thing, control another. Separating the two aspects allows one to (for example) control scsynth from applications besides sclang. The only important thing is that they are able to send the right OSC messages to the server.
+## modularity || synthesis is one thing, control another. Separating the two aspects allows one to (for example) control the server from applications other than sclang. The only important thing is that they are able to send the right OSC messages to the server.
 ## remote control || the client/server network can be external to your computer, e.g. over the Internet. This allows one to control an audio server in Alaska from a client (sclang or other) in India, for example.
 ::
 
@@ -88,12 +88,12 @@ definitionlist::
 
 section:: A final remark for the advanced reader
 
-Apart from sclang, it is possible to control scsynth from any other client which provides for OSC messaging (e.g. from Java, Python, Max/MSP, etc.). For networking, see link::Reference/Server-Architecture::, link::Classes/NetAddr::, link::Classes/OSCFunc::.
+Apart from sclang, it is possible to control the server from any other client which provides for OSC messaging (e.g. from Java, Python, Max/MSP, etc.). For networking, see link::Reference/Server-Architecture::, link::Classes/NetAddr::, link::Classes/OSCFunc::.
 
-In general however, sclang is the preferable way to communicate with scsynth for three reasons:
+In general however, sclang is the preferable way to communicate with the server for three reasons:
 list::
 ## it gives you the expressive power of the SuperCollider language;
-## the language is explicitly fitted to scsynth's needs (and, more importantly, to musician's ones)
-## it allows one to create and load SynthDefs onto scsynth (see link::Classes/SynthDef::), which is a not such an easy task to accomplished in another client app.
+## the language is explicitly fitted to the server's needs (and, more importantly, to musician's ones)
+## it allows one to create and load SynthDefs onto the server (see link::Classes/SynthDef::), which not all client apps are able to do
 ::
 

--- a/HelpSource/Guides/WritingUGens.schelp
+++ b/HelpSource/Guides/WritingUGens.schelp
@@ -66,10 +66,10 @@ list::
 A plugin file can contain more than one UGen, and it can also define things other than UGens such as buffer fill
 ("/b_gen") commands.
 
-When scsynth boots, it will look for plugin files in code::Platform.userExtensionDir::. Since sclang also looks for
+When the server boots, it will look for plugin files in code::Platform.userExtensionDir::. Since sclang also looks for
 class files in the same location, the class file and the library file can go in the same place.
 
-Plug-ins are loaded during the startup of scsynth, so the server will have to be restarted after (re-)compiling a
+Plug-ins are loaded during the startup of the server, so it will have to be restarted after (re-)compiling a
 plugin. If you modify the plugin file but not the class file, you don't need to reboot the interpreter.
 
 section:: FAUST
@@ -81,7 +81,7 @@ FAUST provides a shell script useful for SuperCollider users called code::faust2
 file into a class file and server plugin, which you can then drop into your extensions directory.
 
 FAUST plugins are often quick to develop and can be painlessly ported to other environments. Unfortunately, they can't
-take advantage of all of scsynth's features, such as accessing Buffers or random number generators, and some UGens
+take advantage of all of the server's features, such as accessing Buffers or random number generators, and some UGens
 featuring very complex logic are difficult or impossible to write in FAUST. Furthermore, the FAUST compiler is quite
 intelligent but it might not always offer the best efficiency in its results. If a UGen you are developing hits these
 limitations, it is time to move on to handwritten C++.
@@ -102,7 +102,7 @@ internal buffers, and demonstrates how to do cubic interpolation from an array o
 
 section:: Anatomy of a UGen
 
-The SC source code has a header file, code::server/plugins/SC_Plugin.h::, that gives you your interface to the scsynth
+The SC source code has a header file, code::include/plugin_interface/SC_PlugIn.h::, that gives you your interface to the server
 architecture as well as a bunch of helper functions. These are documented at link::Reference/ServerPluginAPI::.
 
 subsection:: The Entry Point

--- a/HelpSource/Tutorials/Tutorial.schelp
+++ b/HelpSource/Tutorials/Tutorial.schelp
@@ -28,7 +28,7 @@ i = Server.internal;
 
 strong::VERY IMPORTANT:: : This line must be executed for the variable 'i' to be set. The mechanics are different depending on your platform. The MacOSX standard is to place the cursor anywhere on this line and press the "Enter" key on the numeric keypad. Pressing the main return key does not execute code! This allows you to write code fragments of multiple lines. To execute a multi-line block of code, select the block and press "Enter." For convenience, a code block can be enclosed in parentheses, and the entire block selected by double-clicking just inside either parenthesis. (For instructions in other editors (e.g. on Linux or Windows), consult the documentation specific to that platform. See also the helpfile link::Reference/KeyboardShortcuts:: for key commands in other editors.) If you don't have an enter key, then you can use ctrl-Return, Ctrl-c, fn-Return (on Some Macs), or Shift-Return.
 
-The local server runs on the same machine as the SuperCollider application, but is a separate program, 'scsynth'.
+The local server runs on the same machine as the SuperCollider application, but is a separate program, 'scsynth' (or 'supernova').
 Note:: By default the interpreter variable code::s:: is set to the local server at startup. For further information see the link::Classes/Server:: helpfile.
 ::
 

--- a/README_LINUX.md
+++ b/README_LINUX.md
@@ -4,7 +4,7 @@ Supercollider 3 for linux
 Intro
 -----
 
-SuperCollider is a synthesis engine (scsynth) and programming language (sclang), originally Mac-based but now very widely used and actively developed on Linux.
+SuperCollider is a synthesis engine (scsynth or supernova) and programming language (sclang), originally Mac-based but now very widely used and actively developed on Linux.
 
 Stefan Kersten first ported the code to Linux in 2003.
 
@@ -207,11 +207,11 @@ Debian Multimedia team. Repository (with debian/ folder):
 http://anonscm.debian.org/gitweb/?p=pkg-multimedia/supercollider.git;a=summary
 
 
-Running scsynth (standalone)
+Running scsynth or supernova (standalone)
 ----------------------------
 
-Run `scsynth` without options to get an option summary. Don't forget to
-start jackd before trying to use scsynth. If you want to add
+Run `scsynth --help`  or `supernova --help` to get an option summary. Don't forget to
+start jackd before starting the server. If you want to add
 directories to supercollider's search path or assign default jack
 ports, set up your environment as described below.
 
@@ -263,7 +263,7 @@ Environment
 The jack audio driver interface is configured based on various
 environment variables:
 
- * SC_JACK_DEFAULT_INPUTS comma separated list of jack ports that scsynth's inputs should connect to by default
+ * SC_JACK_DEFAULT_INPUTS comma separated list of jack ports that the server's inputs should connect to by default
 
    ```
    $> export SC_JACK_DEFAULT_INPUTS="system:capture_1,system:capture_2"
@@ -275,7 +275,7 @@ environment variables:
    $> export SC_JACK_DEFAULT_INPUTS="system"
    ```
 
- * SC_JACK_DEFAULT_OUTPUTS comma separated list of jack ports that scsynth's outputs should be connected to by default.
+ * SC_JACK_DEFAULT_OUTPUTS comma separated list of jack ports that the server's outputs should be connected to by default.
 
    ```
    $> export SC_JACK_DEFAULT_OUTPUTS="system:playback_1,system:playback_2"


### PR DESCRIPTION
Many docs refer to 'scsynth' when they are talking about the server. I've fixed these in documentation. As supernova is apparently best-supported in Linux, I haven't touched the OS X or Windows READMEs.

I also fixed a path to include/plugin_interface/SC_PlugIn.h

