### PR TITLE
Add "(NRT)" to the NRT help file title (searchability)

### DIFF
--- a/HelpSource/Guides/Non-Realtime-Synthesis.schelp
+++ b/HelpSource/Guides/Non-Realtime-Synthesis.schelp
@@ -1,4 +1,4 @@
-title:: Non-Realtime Synthesis
+title:: Non-Realtime Synthesis (NRT)
 summary:: Non-realtime synthesis with binary files of OSC commands
 categories:: Server>NRT, External Control>OSC
 related:: Classes/Score


### PR DESCRIPTION
When the user searches for "NRT", the "Non-Realtime Synthesis" help file should show up