### PR TITLE
Reference: Server-Command: clarify Wave Fill flags

### DIFF
--- a/HelpSource/Classes/VOsc.schelp
+++ b/HelpSource/Classes/VOsc.schelp
@@ -83,6 +83,8 @@ s = Server.local;
 	a = Array.fill(n, { arg j; ((n-j)/n).squared.round(0.001) });
 	// fill table
 	s.performList(\sendMsg, \b_gen, i, \sine1, 7, a);
+	// the argument '7' here is a flag for the \sine1 wave fill method -
+	// see the "Wave Fill Commands" section in the Server Command Reference 
 });
 )
 

--- a/HelpSource/Classes/VOsc3.schelp
+++ b/HelpSource/Classes/VOsc3.schelp
@@ -90,6 +90,8 @@ s = Server.local;
 	a = Array.fill(n, { arg j; ((n-j)/n).squared.round(0.001) });
 	// fill table
 	s.performList(\sendMsg, \b_gen, i, \sine1, 7, a);
+	// the argument '7' here is a flag for the \sine1 wave fill method -
+	// see the "Wave Fill Commands" section in the Server Command Reference
 });
 )
 

--- a/HelpSource/Reference/Server-Command-Reference.schelp
+++ b/HelpSource/Reference/Server-Command-Reference.schelp
@@ -931,6 +931,15 @@ table::
 ## 4 || clear - if set then the buffer is cleared before new partials are written into it. Otherwise the new partials are summed with the existing contents of the buffer.
 ::
 
+These flags can be added together to create a unique single integer flag that describes the true/false combinations for these three options:
+
+table::
+## 3 || 1 + 2 || normalize + wavetable
+## 5 || 1 + 4 || normalize + clear
+## 6 || 2 + 4 || wavetable + clear
+## 7 || 1 + 2 + 4 || normalize + wavetable + clear
+::
+
 definitionlist::
 ## sine1 ||
 table::


### PR DESCRIPTION
I made explicit the fact that the Wave Fill Command flags can be combined by adding them together.  I did this because the use of the flag "7" in the VOsc.schelp example was puzzling to me until I dug into the source code to see that what was happening was that flags 1, 2, and 4 were being summed to give me the "normalize", "wavetable", and "clear" options in one number.

I added helpful comments to the code examples in VOsc.schelp and VOsc3.schelp to explain this, as well.