### PR TITLE
Fix some anchor links in help

### DIFF
--- a/HelpSource/Classes/Bus.schelp
+++ b/HelpSource/Classes/Bus.schelp
@@ -101,7 +101,7 @@ Get a new Bus that is a subset of this bus (see code::newFrom::).
 subsection:: Asynchronous Control Bus Methods
 
 The following commands apply only to control buses and are asynchronous. For synchronous access to control busses please
-consult link::#Synchronous control bus methods::.
+consult link::#Synchronous Control Bus Methods::.
 
 method:: value
 Set all channels to this float value. This command is asynchronous.

--- a/HelpSource/Classes/Env.schelp
+++ b/HelpSource/Classes/Env.schelp
@@ -44,7 +44,7 @@ Create a new envelope specification.
 
 argument::levels
 an array of levels. The first level is the initial value of the envelope. When the envelope is used with an EnvGen, levels can be any UGen (new level values are updated only when the envelope has reached that point).
-When the array of levels contains itself an array, the envelope returns a multichannel output (for a discussion, see link::#multichannel expansion::)
+When the array of levels contains itself an array, the envelope returns a multichannel output (for a discussion, see link::#Multichannel expansion::)
 
 argument::times
 an array of durations of segments in seconds. There should be one fewer duration than there are levels, but if shorter, the array is extended by wrapping around the given values.
@@ -270,7 +270,7 @@ Creates a new envelope specification where all the segments are horizontal lines
 
 argument::levels
 an array of levels. Levels can be any UGen (new level values are updated only when the envelope has reached that point).
-When the array of levels contains itself an array, the envelope returns a multichannel output (for a discussion, see link::#multichannel expansion::)
+When the array of levels contains itself an array, the envelope returns a multichannel output (for a discussion, see link::#Multichannel expansion::)
 
 argument::times
 an array of durations of segments in seconds. It should be the same size as the levels array.
@@ -616,7 +616,7 @@ argument::name
 the plot window's label name. If nil, a name will be created for you.
 
 method::asSignal
-Returns a link::Classes/Signal:: of size strong::length:: created by sampling this Env at strong::length:: number of intervals. If the envelope has multiple channels (see link::#multichannel expansion::), this method returns an array of signals.
+Returns a link::Classes/Signal:: of size strong::length:: created by sampling this Env at strong::length:: number of intervals. If the envelope has multiple channels (see link::#Multichannel expansion::), this method returns an array of signals.
 
 method::asArray
 Converts the Env to an link::Classes/Array:: in a specially ordered format. This allows for Env parameters to be settable arguments in a SynthDef. See example below under link::#-newClear::.

--- a/HelpSource/Classes/InTrig.schelp
+++ b/HelpSource/Classes/InTrig.schelp
@@ -9,7 +9,7 @@ Any time the bus is "touched", ie. has its value set (using "/c_set"
 etc.), a single impulse trigger will be generated. Its amplitude is the
 value that the bus was set to.
 
-If the bus is set link::Classes/Bus#Synchronous control bus methods#synchronously:: no trigger will be generated.
+If the bus is set link::Classes/Bus#Synchronous Control Bus Methods#synchronously:: no trigger will be generated.
 
 
 classmethods::

--- a/HelpSource/Tutorials/JITLib/jitlib_basic_concepts_02.schelp
+++ b/HelpSource/Tutorials/JITLib/jitlib_basic_concepts_02.schelp
@@ -8,12 +8,12 @@ external structure of the node proxy, referencing in proxyspace and environments
 This document covers:
 
 list::
-## link::#a)_normal_environment_lookup#a) normal environment lookup::
-## link::#b)_a_proxyspace_as_an_environment#b) a proxyspace as an environment::
-## link::#c)_using_the_proxyspace_to_change_processes_on_the_fly#c) using the proxyspace to change processes on the fly::
-## link::#d)_when_are_the_node_proxies_initialized?#d) when are the node proxies initialized?::
-## link::#e)_moving_out_of_the_proxy_space#e) moving out of the proxy space::
-## link::#f)_using_ProxySpace_together_with_other_Environments#f) using ProxySpace together with other Environments::
+## link::#a) normal environment lookup#a) normal environment lookup::
+## link::#b) a proxyspace as an environment#b) a proxyspace as an environment::
+## link::#c) using the proxyspace to change processes on the fly#c) using the proxyspace to change processes on the fly::
+## link::#d) when are the node proxies initialized?#d) when are the node proxies initialized?::
+## link::#e) moving out of the proxy space#e) moving out of the proxy space::
+## link::#f) using ProxySpace together with other Environments#f) using ProxySpace together with other Environments::
 ::
 
 section::a) normal environment lookup

--- a/HelpSource/Tutorials/JITLib/jitlib_basic_concepts_03.schelp
+++ b/HelpSource/Tutorials/JITLib/jitlib_basic_concepts_03.schelp
@@ -6,10 +6,10 @@ related:: Overviews/JITLib, Tutorials/JITLib/jitlib_basic_concepts_02, Tutorials
 internal structure of the node proxy, node order and the parameter context
 
 list::
-## link::#a)_nodeproxy_slots#a) slots::
-## link::#b)_fade_time#b) fadeTime::
-## link::#c)_play/stop,_send/free,_pause/resume#c) play/stop, send/release, pause/resume, clear::
-## link::#d)_the_parameter_context#d) the parameter context::
+## link::#a) NodeProxy slots#a) slots::
+## link::#b) fade time#b) fadeTime::
+## link::#c) play/stop, send/free, pause/resume#c) play/stop, send/release, pause/resume, clear::
+## link::#d) The parameter context#d) the parameter context::
 ::
 
 A NodeProxy has two internal contexts in which the objects are inserted: The group, which is on the server, and the nodeMap, which is a client side parameter context. As the group can contain an order of synths, there is a client side representation, in which the source objects are stored (see link::Classes/Order::).

--- a/HelpSource/Tutorials/JITLib/jitlib_basic_concepts_04.schelp
+++ b/HelpSource/Tutorials/JITLib/jitlib_basic_concepts_04.schelp
@@ -8,10 +8,10 @@ whenever the put method is called (or, in ProxySpace, the assignment operation =
 Sometimes it is desirable to time these changes relative to a clock.
 
 list::
-## link::#a)_clock#a) clock::
-## link::#b)_quant_and_offset#b) quant and offset::
-## link::#c)_connecting_client_and_server_tempo#c) client and server tempo::
-## link::#d)_sample_accurate_output#d) sample accurate output::
+## link::#a) clock#a) clock::
+## link::#b) quant and offset#b) quant and offset::
+## link::#c) connecting client and server tempo#c) client and server tempo::
+## link::#d) sample accurate output#d) sample accurate output::
 ::
 
 section::a) clock


### PR DESCRIPTION
These anchor links were broken, mostly due to case-sensitivity