### PR TITLE
build: fixup_bundle on Resources/scsynth

### DIFF
--- a/editors/sc-ide/CMakeLists.txt
+++ b/editors/sc-ide/CMakeLists.txt
@@ -345,11 +345,11 @@ if(APPLE)
 
     install(CODE "
            file(GLOB_RECURSE QTPLUGINS
-                  \"${plugin_dest_dir}/*.dylib\")
+                \"${plugin_dest_dir}/*.dylib\")
            file(GLOB_RECURSE SCPLUGINS
-                  \"${CMAKE_INSTALL_PREFIX}/SuperCollider/SuperCollider.app/Contents/Resources/plugins/*.scx\")
+                \"${CMAKE_INSTALL_PREFIX}/SuperCollider/SuperCollider.app/Contents/Resources/plugins/*.scx\")
                 include(BundleUtilities)
-                fixup_bundle(\"${CMAKE_INSTALL_PREFIX}/SuperCollider/SuperCollider.app\" \"\${QTPLUGINS};\${SCPLUGINS}\" \"${QT_LIBRARY_DIR}\")
+                fixup_bundle(\"${CMAKE_INSTALL_PREFIX}/SuperCollider/SuperCollider.app\" \"\${QTPLUGINS};\${SCPLUGINS};${CMAKE_INSTALL_PREFIX}/SuperCollider/SuperCollider.app/Contents/Resources/scsynth\" \"${QT_LIBRARY_DIR}\")
                 #fixup_qt5_executable(\"${CMAKE_INSTALL_PREFIX}/SuperCollider/SuperCollider.app\")
                 " COMPONENT Runtime)
 


### PR DESCRIPTION
This is the 2nd copy of scsynth - the one that we actually run.
Without running fixup_bundle on it libsndfile was linked externally
and the build was failing at verify_app.

Fixes https://github.com/supercollider/supercollider/issues/2303