### PR TITLE
Signal.schelp: small typo fix in play:loop desc

### DIFF
--- a/HelpSource/Classes/VOsc3.schelp
+++ b/HelpSource/Classes/VOsc3.schelp
@@ -90,6 +90,8 @@ s = Server.local;
 	a = Array.fill(n, { arg j; ((n-j)/n).squared.round(0.001) });
 	// fill table
 	s.performList(\sendMsg, \b_gen, i, \sine1, 7, a);
+	// the argument '7' here is a flag for the \sine1 wave fill method -
+	// see the "Wave Fill Commands" section in the Server Command Reference
 });
 )
 


### PR DESCRIPTION
Changed a small typo in the description of the loop arg for the play method.