### PR TITLE
help: Add zoom to common WebView

### DIFF
--- a/HelpSource/Classes/HelpBrowser.schelp
+++ b/HelpSource/Classes/HelpBrowser.schelp
@@ -68,3 +68,12 @@ Go back.
 method:: goForward
 Go forward.
 
+method:: zoomIn
+Zoom In.
+
+method:: zoomOut
+Zoom Out.
+
+method:: resetZoom
+Reset zoom.
+

--- a/QtCollider/widgets/QcWebView.cpp
+++ b/QtCollider/widgets/QcWebView.cpp
@@ -137,6 +137,25 @@ void WebView::findText( const QString &searchText, bool reversed )
   QWebView::findText( searchText, flags );
 }
 
+void WebView::zoomIn()
+{
+    qreal zoomFactor = QWebView::zoomFactor();
+    zoomFactor = qMin( zoomFactor + 0.1, 2.0 );
+    QWebView::setZoomFactor(zoomFactor);
+}
+
+void WebView::zoomOut()
+{
+    qreal zoomFactor = QWebView::zoomFactor();
+    zoomFactor = qMax( zoomFactor - 0.1, 0.1 );
+    QWebView::setZoomFactor(zoomFactor);
+}
+
+void WebView::resetZoom()
+{
+    QWebView::setZoomFactor(1.0);
+}
+
 void WebView::onLinkClicked( const QUrl &url )
 {
   Q_EMIT( linkActivated( url.toString() ) );

--- a/QtCollider/widgets/QcWebView.h
+++ b/QtCollider/widgets/QcWebView.h
@@ -48,6 +48,9 @@ public:
   Q_INVOKABLE void setHtml ( const QString &html, const QString &baseUrl = QString() );
   Q_INVOKABLE void evaluateJavaScript ( const QString &script );
   Q_INVOKABLE void setFontFamily( int genericFontFamily, const QString & fontFamily );
+  Q_INVOKABLE void zoomIn();
+  Q_INVOKABLE void zoomOut();
+  Q_INVOKABLE void resetZoom();
 
 public Q_SLOTS:
   void findText( const QString &searchText, bool reversed = false );

--- a/SCClassLibrary/Common/GUI/Base/QWebView.sc
+++ b/SCClassLibrary/Common/GUI/Base/QWebView.sc
@@ -34,6 +34,12 @@ WebView : View {
 
 	forward { this.invokeMethod( 'forward' ); }
 
+	zoomIn { this.invokeMethod( 'zoomIn' ); }
+
+	zoomOut { this.invokeMethod( 'zoomOut' ); }
+
+	resetZoom { this.invokeMethod( 'resetZoom' ); }
+
 	findText { arg string, reverse = false;
 		this.invokeMethod( \findText, [string, reverse] );
 	}

--- a/SCClassLibrary/Common/GUI/tools/HelpBrowser.sc
+++ b/SCClassLibrary/Common/GUI/tools/HelpBrowser.sc
@@ -116,6 +116,12 @@ HelpBrowser {
 
 	goForward { webView.forward; }
 
+	zoomIn { webView.zoomIn; }
+
+	zoomOut { webView.zoomOut; }
+
+	resetZoom { webView.resetZoom; }
+
 /* ------------------------------ private ------------------------------ */
 
 	init { arg aHomeUrl, aNewWin;
@@ -146,7 +152,7 @@ HelpBrowser {
 
 		h = strh + vPad;
 		x = marg; y = marg;
-		[[\Back,"<"], [\Forward,">"], [\Reload, "Reload"]].do { |item|
+		[[\Back,"<"], [\Forward,">"], [\Reload, "Reload"], [\ZoomIn, "Zoom In"], [\ZoomOut, "Zoom Out",], [\ResetZoom, "Reset zoom"]].do { |item|
 			var str = item[1];
 			var w = str.bounds.width + hPad;
 			toolbar[item[0]] = Button( window, Rect(x,y,w,h) ).states_([[str]]);
@@ -286,6 +292,9 @@ HelpBrowser {
 		toolbar[\Back].action = { this.goBack };
 		toolbar[\Forward].action = { this.goForward };
 		toolbar[\Reload].action = { this.goTo( webView.url ) };
+		toolbar[\ZoomIn].action = { this.zoomIn };
+		toolbar[\ZoomOut].action = { this.zoomOut };
+		toolbar[\ResetZoom].action = { this.resetZoom };
 		txtFind.action = { |x| webView.findText( x.string ) };
 	}
 


### PR DESCRIPTION
Zoom option are not present in Help Browser in other IDE like scvim making the documentation harder to read on High DPI screen, this patch add the logic of zooming in WebView and some buttons in HelpBrowers for glue, maybe this should be in a separate commit ?
