### PR TITLE
Add non-qt build to travis (linux)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ matrix:
   fast_finish: true
   env:
     global:
+      - TRAVIS_SCRIPT_DIR=$TRAVIS_BUILD_DIR/.travis
       - QT_PREFIX=$HOME/qt/gcc_64
       - QT_PLUGIN_PATH=$QT_PREFIX/plugins
   include:
@@ -27,30 +28,27 @@ cache:
 before_install:
  - iflin () { if [[ $TRAVIS_OS_NAME == linux ]]; then eval $@; fi; }
  - ifmac () { if [[ $TRAVIS_OS_NAME == osx ]]; then eval $@; fi; }
- - iflin .travis/before-install-linux.sh --qt=$QT
- - ifmac .travis/before-install-osx.sh
+ - iflin $TRAVIS_SCRIPT_DIR/before-install-linux.sh --qt=$QT
+ - ifmac $TRAVIS_SCRIPT_DIR/before-install-osx.sh
 
 before_script:
  - mkdir BUILD && cd BUILD
- - iflin $TRAVIS_BUILD_DIR/.travis/before-script-linux.sh --qt=$QT
- - ifmac $TRAVIS_BUILD_DIR/.travis/before-script-osx.sh
-
+ - iflin $TRAVIS_SCRIPT_DIR/before-script-linux.sh --qt=$QT
+ - ifmac $TRAVIS_SCRIPT_DIR/before-script-osx.sh
 # some paths
  - ifmac export SCLANG=$TRAVIS_BUILD_DIR/BUILD/Install/SuperCollider/SuperCollider.app/Contents/MacOS/sclang
  - iflin export SCLANG=$TRAVIS_BUILD_DIR/BUILD/Install/bin/sclang
 # prep for testing
- - sudo pip install git+https://github.com/scztt/qpm.git@qpm-unit
- - qpm quark checkout CommonTests CommonTestsGUI --location $HOME/Quarks
- - cp ../travis_test_run_proto.json ./travis_test_run.json
+ - $TRAVIS_SCRIPT_DIR/qpm-prep.sh
 
 script:
 # build
- - iflin $TRAVIS_BUILD_DIR/.travis/script-linux.sh
- - ifmac $TRAVIS_BUILD_DIR/.travis/script-osx.sh
+ - iflin $TRAVIS_SCRIPT_DIR/script-linux.sh
+ - ifmac $TRAVIS_SCRIPT_DIR/script-osx.sh
 # test
- - if [[ $QT != true ]]; then $TRAVIS_BUILD_DIR/.travis/fix-non-Qt.sh; fi
+ - if [[ $QT != true ]]; then $TRAVIS_SCRIPT_DIR/fix-non-Qt.sh; fi
  - $TRAVIS_BUILD_DIR/testsuite/sclang/launch_test.py $SCLANG
- - qpm test.run -l ./travis_test_run.json --path $SCLANG --include $HOME/Quarks
+ - $TRAVIS_SCRIPT_DIR/qpm-test.sh
 # package
  - ifmac mkdir -p $HOME/artifacts
  - (ifmac cd Install; ifmac zip -q -r $HOME/artifacts/SC-$TRAVIS_COMMIT.zip SuperCollider)

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,9 @@ before_install:
 
 before_script:
  - mkdir BUILD && cd BUILD
+ - if [[ $QT == true ]]; then export QT_PREFIX=$HOME/qt/gcc_64; fi
+ - if [[ $QT == true ]]; then export QT_PLUGIN_PATH=$QT_PREFIX/plugins; fi
+
  - $TRAVIS_BUILD_DIR/.travis/before-script-$TRAVIS_OS_NAME.sh --qt=$QT
 # prep for testing
  - if [[ $QT == true ]]; then $TRAVIS_BUILD_DIR/.travis/qpm-prep.sh; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,27 +23,19 @@ cache:
 before_install:
  - iflin () { if [[ $TRAVIS_OS_NAME == linux ]]; then eval $@; fi; }
  - ifmac () { if [[ $TRAVIS_OS_NAME == osx ]]; then eval $@; fi; }
- - iflin $TRAVIS_BUILD_DIR/.travis/before-install-linux.sh --qt=$QT
- - ifmac $TRAVIS_BUILD_DIR/.travis/before-install-osx.sh
+ - $TRAVIS_BUILD_DIR/.travis/before-install-$TRAVIS_OS_NAME.sh --qt=$QT
 
 before_script:
  - mkdir BUILD && cd BUILD
- - iflin $TRAVIS_BUILD_DIR/.travis/before-script-linux.sh --qt=$QT
- - ifmac $TRAVIS_BUILD_DIR/.travis/before-script-osx.sh
-# some paths
- - ifmac export SCLANG=$TRAVIS_BUILD_DIR/BUILD/Install/SuperCollider/SuperCollider.app/Contents/MacOS/sclang
- - iflin export SCLANG=$TRAVIS_BUILD_DIR/BUILD/Install/bin/sclang
+ - $TRAVIS_BUILD_DIR/.travis/before-script-$TRAVIS_OS_NAME.sh --qt=$QT
 # prep for testing
  - if [[ $QT == true ]]; then $TRAVIS_BUILD_DIR/.travis/qpm-prep.sh; fi
 
 script:
 # build
- - iflin $TRAVIS_BUILD_DIR/.travis/script-linux.sh
- - ifmac $TRAVIS_BUILD_DIR/.travis/script-osx.sh
+ - $TRAVIS_BUILD_DIR/.travis/script-$TRAVIS_OS_NAME.sh
 # test
- - if [[ $QT != true ]]; then $TRAVIS_BUILD_DIR/.travis/fix-non-Qt.sh; fi
- - $TRAVIS_BUILD_DIR/testsuite/sclang/launch_test.py $SCLANG
- - if [[ $QT == true ]]; then $TRAVIS_BUILD_DIR/.travis/qpm-test.sh; fi
+ - $TRAVIS_BUILD_DIR/.travis/test.sh
 # package
  - ifmac mkdir -p $HOME/artifacts
  - (ifmac cd Install; ifmac zip -q -r $HOME/artifacts/SC-$TRAVIS_COMMIT.zip SuperCollider)

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ matrix:
       env: QT=false
     - os: osx
       osx_image: xcode7.3
+      env: QT=true
 
 cache:
  - apt
@@ -37,7 +38,6 @@ before_script:
 # some paths
  - ifmac export SCLANG=$TRAVIS_BUILD_DIR/BUILD/Install/SuperCollider/SuperCollider.app/Contents/MacOS/sclang
  - iflin export SCLANG=$TRAVIS_BUILD_DIR/BUILD/Install/bin/sclang
- - echo $SCLANG
 # prep for testing
  - sudo pip install git+https://github.com/scztt/qpm.git@qpm-unit
  - qpm quark checkout CommonTests CommonTestsGUI --location $HOME/Quarks
@@ -48,6 +48,7 @@ script:
  - iflin $TRAVIS_BUILD_DIR/.travis/script-linux.sh
  - ifmac $TRAVIS_BUILD_DIR/.travis/script-osx.sh
 # test
+ - if [[ $QT != true ]]; then $TRAVIS_BUILD_DIR/.travis/fix-non-Qt.sh; fi
  - $TRAVIS_BUILD_DIR/testsuite/sclang/launch_test.py $SCLANG
  - qpm test.run -l ./travis_test_run.json --path $SCLANG --include $HOME/Quarks
 # package

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,6 @@ cache:
  - bundler
 
 before_install:
- - iflin () { if [[ $TRAVIS_OS_NAME == linux ]]; then eval $@; fi; }
- - ifmac () { if [[ $TRAVIS_OS_NAME == osx ]]; then eval $@; fi; }
  - $TRAVIS_BUILD_DIR/.travis/before-install-$TRAVIS_OS_NAME.sh --qt=$QT
 
 before_script:
@@ -32,13 +30,9 @@ before_script:
  - if [[ $QT == true ]]; then $TRAVIS_BUILD_DIR/.travis/qpm-prep.sh; fi
 
 script:
-# build
  - $TRAVIS_BUILD_DIR/.travis/script-$TRAVIS_OS_NAME.sh
-# test
  - $TRAVIS_BUILD_DIR/.travis/test.sh
-# package
- - ifmac mkdir -p $HOME/artifacts
- - (ifmac cd Install; ifmac zip -q -r $HOME/artifacts/SC-$TRAVIS_COMMIT.zip SuperCollider)
+ - if [[ $TRAVIS_OS_NAME == osx ]]; then $TRAVIS_BUILD_DIR/.travis/package-osx.sh; fi
 
 before_deploy:
  # required for github releases

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,23 @@
 compiler:
  - gcc
 
-os:
- - linux
- - osx
-
-env:
-  global:
-    - QT_PREFIX=$HOME/qt/gcc_64
-    - QT_PLUGIN_PATH=$QT_PREFIX/plugins
-
-sudo: required
-dist: trusty
-osx_image: xcode7.3
+matrix:
+  fast_finish: true
+  env:
+    global:
+      - QT_PREFIX=$HOME/qt/gcc_64
+      - QT_PLUGIN_PATH=$QT_PREFIX/plugins
+  include:
+    - os: linux
+      sudo: required
+      dist: trusty
+      env: QT=true
+    - os: linux
+      sudo: required
+      dist: trusty
+      env: QT=false
+    - os: osx
+      osx_image: xcode7.3
 
 cache:
  - apt
@@ -21,18 +26,18 @@ cache:
 before_install:
  - iflin () { if [[ $TRAVIS_OS_NAME == linux ]]; then eval $@; fi; }
  - ifmac () { if [[ $TRAVIS_OS_NAME == osx ]]; then eval $@; fi; }
- - iflin .travis/before-install-linux.sh
+ - iflin .travis/before-install-linux.sh --qt=$QT
  - ifmac .travis/before-install-osx.sh
 
 before_script:
- - iflin source /opt/qt55/bin/qt55-env.sh
  - mkdir BUILD && cd BUILD
- - iflin $TRAVIS_BUILD_DIR/.travis/before-script-linux.sh
+ - iflin $TRAVIS_BUILD_DIR/.travis/before-script-linux.sh --qt=$QT
  - ifmac $TRAVIS_BUILD_DIR/.travis/before-script-osx.sh
 
 # some paths
  - ifmac export SCLANG=$TRAVIS_BUILD_DIR/BUILD/Install/SuperCollider/SuperCollider.app/Contents/MacOS/sclang
  - iflin export SCLANG=$TRAVIS_BUILD_DIR/BUILD/Install/bin/sclang
+ - echo $SCLANG
 # prep for testing
  - sudo pip install git+https://github.com/scztt/qpm.git@qpm-unit
  - qpm quark checkout CommonTests CommonTestsGUI --location $HOME/Quarks

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,6 @@ compiler:
 
 matrix:
   fast_finish: true
-  env:
-    global:
-      - TRAVIS_SCRIPT_DIR=$TRAVIS_BUILD_DIR/.travis
-      - QT_PREFIX=$HOME/qt/gcc_64
-      - QT_PLUGIN_PATH=$QT_PREFIX/plugins
   include:
     - os: linux
       sudo: required
@@ -28,27 +23,27 @@ cache:
 before_install:
  - iflin () { if [[ $TRAVIS_OS_NAME == linux ]]; then eval $@; fi; }
  - ifmac () { if [[ $TRAVIS_OS_NAME == osx ]]; then eval $@; fi; }
- - iflin $TRAVIS_SCRIPT_DIR/before-install-linux.sh --qt=$QT
- - ifmac $TRAVIS_SCRIPT_DIR/before-install-osx.sh
+ - iflin $TRAVIS_BUILD_DIR/.travis/before-install-linux.sh --qt=$QT
+ - ifmac $TRAVIS_BUILD_DIR/.travis/before-install-osx.sh
 
 before_script:
  - mkdir BUILD && cd BUILD
- - iflin $TRAVIS_SCRIPT_DIR/before-script-linux.sh --qt=$QT
- - ifmac $TRAVIS_SCRIPT_DIR/before-script-osx.sh
+ - iflin $TRAVIS_BUILD_DIR/.travis/before-script-linux.sh --qt=$QT
+ - ifmac $TRAVIS_BUILD_DIR/.travis/before-script-osx.sh
 # some paths
  - ifmac export SCLANG=$TRAVIS_BUILD_DIR/BUILD/Install/SuperCollider/SuperCollider.app/Contents/MacOS/sclang
  - iflin export SCLANG=$TRAVIS_BUILD_DIR/BUILD/Install/bin/sclang
 # prep for testing
- - $TRAVIS_SCRIPT_DIR/qpm-prep.sh
+ - if [[ $QT == true ]]; then $TRAVIS_BUILD_DIR/.travis/qpm-prep.sh; fi
 
 script:
 # build
- - iflin $TRAVIS_SCRIPT_DIR/script-linux.sh
- - ifmac $TRAVIS_SCRIPT_DIR/script-osx.sh
+ - iflin $TRAVIS_BUILD_DIR/.travis/script-linux.sh
+ - ifmac $TRAVIS_BUILD_DIR/.travis/script-osx.sh
 # test
- - if [[ $QT != true ]]; then $TRAVIS_SCRIPT_DIR/fix-non-Qt.sh; fi
+ - if [[ $QT != true ]]; then $TRAVIS_BUILD_DIR/.travis/fix-non-Qt.sh; fi
  - $TRAVIS_BUILD_DIR/testsuite/sclang/launch_test.py $SCLANG
- - $TRAVIS_SCRIPT_DIR/qpm-test.sh
+ - if [[ $QT == true ]]; then $TRAVIS_BUILD_DIR/.travis/qpm-test.sh; fi
 # package
  - ifmac mkdir -p $HOME/artifacts
  - (ifmac cd Install; ifmac zip -q -r $HOME/artifacts/SC-$TRAVIS_COMMIT.zip SuperCollider)

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,11 @@ os:
  - linux
  - osx
 
+env:
+  global:
+    - QT_PREFIX=$HOME/qt/gcc_64
+    - QT_PLUGIN_PATH=$QT_PREFIX/plugins
+
 sudo: required
 dist: trusty
 osx_image: xcode7.3
@@ -14,32 +19,17 @@ cache:
  - bundler
 
 before_install:
- - ifmac () { if [[ $TRAVIS_OS_NAME == osx ]]; then eval $@; fi; }
  - iflin () { if [[ $TRAVIS_OS_NAME == linux ]]; then eval $@; fi; }
- - ifmac brew update
- - ifmac brew tap homebrew/versions
- - ifmac brew outdated cmake || brew upgrade cmake
- - ifmac brew install qt55 libsndfile python || true
- - ifmac brew link qt55 --force
- - iflin npm install -g lintspaces-cli
- - iflin sudo add-apt-repository --yes ppa:ubuntu-toolchain-r/test
- - iflin sudo add-apt-repository --yes ppa:beineri/opt-qt551-trusty
- - iflin sudo apt-get update
- - iflin sudo apt-get install --yes build-essential gcc-4.9 g++-4.9 cmake pkg-config qt55base qt55location qt55declarative qt55sensors qt55tools qt55webengine qt55webchannel qt55webkit qt55xmlpatterns  libjack-jackd2-dev libsndfile1-dev libasound2-dev libavahi-client-dev libreadline6-dev libfftw3-dev libicu-dev libxt-dev libudev-dev
- - iflin sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.9 60 --slave /usr/bin/g++ g++ /usr/bin/g++-4.9
- - iflin sudo update-alternatives --auto gcc
+ - ifmac () { if [[ $TRAVIS_OS_NAME == osx ]]; then eval $@; fi; }
+ - iflin .travis/before-install-linux.sh
+ - ifmac .travis/before-install-osx.sh
 
 before_script:
- - iflin $TRAVIS_BUILD_DIR/.travis/lint.sh $TRAVIS_BUILD_DIR
  - iflin source /opt/qt55/bin/qt55-env.sh
- - mkdir BUILD
- - cd BUILD
+ - mkdir BUILD && cd BUILD
+ - iflin $TRAVIS_BUILD_DIR/.travis/before-script-linux.sh
+ - ifmac $TRAVIS_BUILD_DIR/.travis/before-script-osx.sh
 
- - export QT_PREFIX=$HOME/qt/gcc_64
- - export QT_PLUGIN_PATH=$QT_PREFIX/plugins
- - export COMMIT_NAME=$TRAVIS_COMMIT
- - ifmac cmake -G"Xcode" -DCMAKE_PREFIX_PATH=`brew --prefix qt55` -DCMAKE_OSX_DEPLOYMENT_TARGET=10.7 .. --debug-output
- - iflin cmake -DSC_EL=no -DCMAKE_INSTALL_PREFIX:PATH=$PWD/Install -DCMAKE_BUILD_TYPE=Release .. --debug-output
 # some paths
  - ifmac export SCLANG=$TRAVIS_BUILD_DIR/BUILD/Install/SuperCollider/SuperCollider.app/Contents/MacOS/sclang
  - iflin export SCLANG=$TRAVIS_BUILD_DIR/BUILD/Install/bin/sclang
@@ -50,21 +40,21 @@ before_script:
 
 script:
 # build
- - iflin sudo make install
- - ifmac cmake --build . --config Release --target install
+ - iflin $TRAVIS_BUILD_DIR/.travis/script-linux.sh
+ - ifmac $TRAVIS_BUILD_DIR/.travis/script-osx.sh
 # test
  - $TRAVIS_BUILD_DIR/testsuite/sclang/launch_test.py $SCLANG
  - qpm test.run -l ./travis_test_run.json --path $SCLANG --include $HOME/Quarks
 # package
  - ifmac mkdir -p $HOME/artifacts
- - (ifmac cd Install; ifmac zip -q -r $HOME/artifacts/SC-$COMMIT_NAME.zip SuperCollider)
+ - (ifmac cd Install; ifmac zip -q -r $HOME/artifacts/SC-$TRAVIS_COMMIT.zip SuperCollider)
 
 before_deploy:
  # required for github releases
  - git fetch --tags
  - export BUILD_PREFIX=$TRAVIS_REPO_SLUG/$TRAVIS_OS_NAME
  - export S3_BUILDS_LOCATION=builds/$BUILD_PREFIX
- - export S3_URL=https://supercollider.s3.amazonaws.com/$S3_BUILDS_LOCATION/SC-$COMMIT_NAME.zip
+ - export S3_URL=https://supercollider.s3.amazonaws.com/$S3_BUILDS_LOCATION/SC-$TRAVIS_COMMIT.zip
  - export FWD_HTML='<html><head><meta http-equiv="refresh" content="0; url='$S3_URL'" /></head></html>'
  # put everything to be archived in artifacts/
  - mkdir -p "$HOME/artifacts/${TRAVIS_BRANCH%/*}"
@@ -90,7 +80,7 @@ deploy:
  # github releases - only tags
  - provider: releases
    api_key: $GITHUB_KEY
-   file: $HOME/artifacts/SC-$COMMIT_NAME.zip
+   file: $HOME/artifacts/SC-$TRAVIS_COMMIT.zip
    prerelease: true
    skip_cleanup: true
    on:

--- a/.travis/before-install-linux.sh
+++ b/.travis/before-install-linux.sh
@@ -5,6 +5,8 @@ sudo add-apt-repository --yes ppa:ubuntu-toolchain-r/test
 sudo add-apt-repository --yes ppa:beineri/opt-qt551-trusty
 sudo apt-get update
 sudo apt-get install --yes build-essential gcc-4.9 g++-4.9 cmake pkg-config libjack-jackd2-dev libsndfile1-dev libasound2-dev libavahi-client-dev libreadline6-dev libfftw3-dev libicu-dev libxt-dev libudev-dev
-sudo apt-get install --yes qt55base qt55location qt55declarative qt55sensors qt55tools qt55webengine qt55webchannel qt55webkit qt55xmlpatterns
+if [[ -n "$1" && "$1" == "--qt=true" ]]; then
+	sudo apt-get install --yes qt55base qt55location qt55declarative qt55sensors qt55tools qt55webengine qt55webchannel qt55webkit qt55xmlpatterns
+fi
 sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.9 60 --slave /usr/bin/g++ g++ /usr/bin/g++-4.9
 sudo update-alternatives --auto gcc

--- a/.travis/before-install-linux.sh
+++ b/.travis/before-install-linux.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+npm install -g lintspaces-cli
+sudo add-apt-repository --yes ppa:ubuntu-toolchain-r/test
+sudo add-apt-repository --yes ppa:beineri/opt-qt551-trusty
+sudo apt-get update
+sudo apt-get install --yes build-essential gcc-4.9 g++-4.9 cmake pkg-config libjack-jackd2-dev libsndfile1-dev libasound2-dev libavahi-client-dev libreadline6-dev libfftw3-dev libicu-dev libxt-dev libudev-dev
+sudo apt-get install --yes qt55base qt55location qt55declarative qt55sensors qt55tools qt55webengine qt55webchannel qt55webkit qt55xmlpatterns
+sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.9 60 --slave /usr/bin/g++ g++ /usr/bin/g++-4.9
+sudo update-alternatives --auto gcc

--- a/.travis/before-install-osx.sh
+++ b/.travis/before-install-osx.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+brew update
+brew tap homebrew/versions
+brew outdated cmake || brew upgrade cmake
+brew install libsndfile python || true
+brew install qt55 || true
+brew link qt55 --force

--- a/.travis/before-script-linux.sh
+++ b/.travis/before-script-linux.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
 
 ./lint.sh $TRAVIS_BUILD_DIR
-cmake -DSC_EL=no -DCMAKE_INSTALL_PREFIX:PATH=$TRAVIS_BUILD_DIR/build/Install -DCMAKE_BUILD_TYPE=Release $TRAVIS_BUILD_DIR --debug-output
+if [[ -n "$1" && "$1" == "--qt=true" ]]; then
+	source /opt/qt55/bin/qt55-env.sh
+	cmake -DSC_EL=OFF -DCMAKE_INSTALL_PREFIX:PATH=$TRAVIS_BUILD_DIR/BUILD/Install -DCMAKE_BUILD_TYPE=Release $TRAVIS_BUILD_DIR --debug-output
+else
+	cmake -DSC_EL=OFF -DSC_QT=OFF -DSC_IDE=OFF -DCMAKE_INSTALL_PREFIX:PATH=$TRAVIS_BUILD_DIR/BUILD/Install -DCMAKE_BUILD_TYPE=Release $TRAVIS_BUILD_DIR --debug-output
+fi

--- a/.travis/before-script-linux.sh
+++ b/.travis/before-script-linux.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+./lint.sh $TRAVIS_BUILD_DIR
+cmake -DSC_EL=no -DCMAKE_INSTALL_PREFIX:PATH=$TRAVIS_BUILD_DIR/build/Install -DCMAKE_BUILD_TYPE=Release $TRAVIS_BUILD_DIR --debug-output

--- a/.travis/before-script-osx.sh
+++ b/.travis/before-script-osx.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+cmake -G"Xcode" -DCMAKE_PREFIX_PATH=`brew --prefix qt55` -DCMAKE_OSX_DEPLOYMENT_TARGET=10.7 $TRAVIS_BUILD_DIR --debug-output

--- a/.travis/fix-non-Qt.sh
+++ b/.travis/fix-non-Qt.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+sudo mv $TRAVIS_BUILD_DIR/BUILD/Install/share/SuperCollider/SCClassLibrary/Common/GUI $TRAVIS_BUILD_DIR/BUILD/Install/share/SuperCollider/SCClassLibrary/scide_scqt/GUI
+sudo mv $TRAVIS_BUILD_DIR/BUILD/Install/share/SuperCollider/SCClassLibrary/JITLib/GUI $TRAVIS_BUILD_DIR/BUILD/Install/share/SuperCollider/SCClassLibrary/scide_scqt/JITLibGUI

--- a/.travis/package-osx.sh
+++ b/.travis/package-osx.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+mkdir -p $HOME/artifacts
+
+cd $TRAVIS_BUILD_DIR/BUILD/Install
+zip -q -r $HOME/artifacts/SC-$TRAVIS_COMMIT.zip SuperCollider

--- a/.travis/qpm-prep.sh
+++ b/.travis/qpm-prep.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+cd $TRAVIS_BUILD_DIR/BUILD
+sudo pip install git+https://github.com/scztt/qpm.git@qpm-unit
+qpm quark checkout CommonTests CommonTestsGUI --location $HOME/Quarks
+cp ../travis_test_run_proto.json ./travis_test_run.json

--- a/.travis/qpm-test.sh
+++ b/.travis/qpm-test.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+qpm test.run -l $TRAVIS_BUILD_DIR/BUILD/travis_test_run.json --path $SCLANG --include $HOME/Quarks

--- a/.travis/script-linux.sh
+++ b/.travis/script-linux.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+sudo make install

--- a/.travis/script-osx.sh
+++ b/.travis/script-osx.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-cmake --build $TRAVIS_BUILD_DIR/build --config Release --target install
+cmake --build $TRAVIS_BUILD_DIR/BUILD --config Release --target install

--- a/.travis/script-osx.sh
+++ b/.travis/script-osx.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+cmake --build $TRAVIS_BUILD_DIR/build --config Release --target install

--- a/.travis/test.sh
+++ b/.travis/test.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+if [[ $TRAVIS_OS_NAME == linux ]]; then
+	export SCLANG=$TRAVIS_BUILD_DIR/BUILD/Install/bin/sclang
+else
+	export SCLANG=$TRAVIS_BUILD_DIR/BUILD/Install/SuperCollider/SuperCollider.app/Contents/MacOS/sclang
+fi
+
+if [[ $QT != true ]]; then ./fix-non-Qt.sh; fi
+
+$TRAVIS_BUILD_DIR/testsuite/sclang/launch_test.py $SCLANG
+
+if [[ $QT == true ]]; then $TRAVIS_BUILD_DIR/.travis/qpm-test.sh; fi

--- a/.travis/test.sh
+++ b/.travis/test.sh
@@ -6,7 +6,7 @@ else
 	export SCLANG=$TRAVIS_BUILD_DIR/BUILD/Install/SuperCollider/SuperCollider.app/Contents/MacOS/sclang
 fi
 
-if [[ $QT != true ]]; then ./fix-non-Qt.sh; fi
+if [[ $QT != true ]]; then $TRAVIS_BUILD_DIR/.travis/fix-non-Qt.sh; fi
 
 $TRAVIS_BUILD_DIR/testsuite/sclang/launch_test.py $SCLANG
 


### PR DESCRIPTION
Re #2306 

This adds the following improvements:

- non-qt build for *linux only* (think *rpi*)
- speed up build time down to 28min (instead of 52min) thanks to parallel matrix-builds
- cleanup `.travis.yml` by moving a lot of code in `.travis/*` scripts

Note the following though:

- there's one *qpm* test failing [1] so I disabled `qpm` tests for the linux-non-QT build
- I couldn't get non-QT build on osx (travis) [2]
- osx package is **untested**
- I'm not sure that `QT_PLUGIN_PATH` is correctly set or used, any help on that would be much appreciated

![travis](https://cloud.githubusercontent.com/assets/271068/18249578/7f3ffa48-737f-11e6-88b6-da482cee1900.gif)

[1] [qpm test error](https://travis-ci.org/gusano/supercollider/jobs/157491200) with `TestPlotter:test_suppliedBounds (0.0s)ERROR: Message 'new' not understood`, I guess @scztt could help ;)
[2] non-Qt will not build on osx (they fail with [*QtCollider* related errors](https://travis-ci.org/gusano/supercollider/jobs/157459610)) and I have no osx machine to test further down