### PR TITLE
Make sure Spec is inited before ControlSpec

### DIFF
--- a/SCClassLibrary/Common/Control/Spec.sc
+++ b/SCClassLibrary/Common/Control/Spec.sc
@@ -164,6 +164,7 @@ ControlSpec : Spec {
 
 
 	*initClass {
+		Class.initClassTree(Spec);
 		Class.initClassTree(Warp);
 		Class.initClassTree(Server);
 		specs = specs.addAll([


### PR DESCRIPTION
Fixes #2318 

Using Class.initClassTree(ControlSpec) in a class could init ControlSpec before Spec causing default specs added in ControlSpec.initClass to be discarded. This is fixed by this one-liner.

