### PR TITLE
help: History: remove use of .speak in examples

### DIFF
--- a/HelpSource/Classes/History.schelp
+++ b/HelpSource/Classes/History.schelp
@@ -178,7 +178,7 @@ Document.open("~/Desktop/myTestStory.scd");	// the story file is human-readable.
 
 	// Various Internals
 	// make a new instance of History by hand:
-h = History([[0, \me, "1+2"], [1.234, \me, "q = q ? ();"], [3, \me, "\"History\".speak"]]);
+h = History([[0, \me, "1+2"], [1.234, \me, "q = q ? ();"], [3, \me, "\"History\".postln"]]);
 h.lines.printcsAll; "";
 h.lineShorts.printcsAll; "";
 
@@ -217,7 +217,7 @@ History.showLogFile;	// current logfile...
 	// filtering lines, to get subsets of all lines by key and/or searchstring:
 
 	// get indices for specific keys
-h = History([[0, \me, "a=1+2"], [1, \me, "3+5"], [1.234, \you, "q = q ? ();"], [3, \her, "\"Herstory ==== \".speak"]]);
+h = History([[0, \me, "a=1+2"], [1, \me, "3+5"], [1.234, \you, "q = q ? ();"], [3, \her, "\"Herstory ==== \".postln"]]);
 h.keys;
 h.matchKeys(\me);
 h.matchKeys(\you);


### PR DESCRIPTION
Speech is OSX only and potentially slated for removal (see #208 and [this sc-dev discussion](http://new-supercollider-mailing-lists-forums-use-these.2681727.n2.nabble.com/Time-to-get-rid-of-Speech-td7627124.html))