### PR TITLE
lang: remove several startup messages

### DIFF
--- a/lang/LangPrimSource/PyrPrimitive.cpp
+++ b/lang/LangPrimSource/PyrPrimitive.cpp
@@ -4294,7 +4294,6 @@ void initOpenGLPrimitives();
 	initSCDocPrimitives();
 
 	s_recvmsg = getsym("receiveMsg");
-	// post("\tNumPrimitives = %d\n", nextPrimitiveIndex());
 }
 
 void deinitPrimitives()

--- a/lang/LangPrimSource/PyrPrimitive.cpp
+++ b/lang/LangPrimSource/PyrPrimitive.cpp
@@ -3544,7 +3544,7 @@ static int prLanguageConfig_getCurrentConfigPath(struct VMGlobals * g, int numAr
     } else {
         SetObject(a, str);
     }
-    
+
 	return errNone;
 }
 
@@ -4245,7 +4245,7 @@ void initSchedPrimitives();
 
 void initHIDAPIPrimitives();
 	initHIDAPIPrimitives();
-	
+
 #if defined(__APPLE__) || defined(HAVE_ALSA) || defined(HAVE_PORTMIDI)
 void initMIDIPrimitives();
 	initMIDIPrimitives();
@@ -4265,7 +4265,7 @@ void initSerialPrimitives();
 void initWiiPrimitives();
 	initWiiPrimitives();
 #endif
-	
+
 #endif
 #ifdef __APPLE__
 void initCoreAudioPrimitives();
@@ -4294,7 +4294,7 @@ void initOpenGLPrimitives();
 	initSCDocPrimitives();
 
 	s_recvmsg = getsym("receiveMsg");
-	post("\tNumPrimitives = %d\n", nextPrimitiveIndex());
+	// post("\tNumPrimitives = %d\n", nextPrimitiveIndex());
 }
 
 void deinitPrimitives()

--- a/lang/LangSource/PyrLexer.cpp
+++ b/lang/LangSource/PyrLexer.cpp
@@ -1762,21 +1762,12 @@ void traverseFullDepTree2()
 		} else {
 			double elapsed;
 			buildBigMethodMatrix();
-			SymbolTable* symbolTable = gMainVMGlobals->symbolTable;
-			//post("\tNumber of Symbols %d\n", symbolTable->NumItems());
-			//post("\tByte Code Size %d\n", totalByteCodes);
-			//elapsed = TickCount() - compileStartTime;
-			//elapsed = 0;
-			elapsed = elapsedTime() - compileStartTime;
-			//post("\tcompiled %d files in %.2f seconds\n",
-			//	 gNumCompiledFiles, elapsed );
 			if(numOverwrites == 1){
 				post("\nInfo: One method is currently overwritten by an extension. To see which, execute:\nMethodOverride.printAll\n\n");
 			}
 			else if(numOverwrites > 1){
 				post("\nInfo: %i methods are currently overwritten by extensions. To see which, execute:\nMethodOverride.printAll\n\n", numOverwrites);
 			}
-			//post("compile done\n");
 		}
 	}
 }
@@ -1877,7 +1868,6 @@ void pyrmath_init_globs();
 
 void initPassOne()
 {
-	//post("initPassOne started\n");
 	aboutToFreeRuntime();
 
 	//dump_pool_histo(pyr_pool_runtime);
@@ -1908,7 +1898,6 @@ void initPassOne()
 	compiledOK = false;
 	compiledDirectories.clear();
 	sc_InitCompileDirectory();
-	//post("initPassOne done\n");
 }
 
 void finiPassOne()
@@ -2138,8 +2127,6 @@ SCLANG_DLLEXPORT_C bool compileLibrary(bool standalone)
 
 	bool res = passOne();
 	if (res) {
-
-		//postfl("\tpass 1 done\n");
 
 		if (!compileErrors) {
 			buildDepTree();

--- a/lang/LangSource/PyrLexer.cpp
+++ b/lang/LangSource/PyrLexer.cpp
@@ -1763,20 +1763,20 @@ void traverseFullDepTree2()
 			double elapsed;
 			buildBigMethodMatrix();
 			SymbolTable* symbolTable = gMainVMGlobals->symbolTable;
-			post("\tNumber of Symbols %d\n", symbolTable->NumItems());
-			post("\tByte Code Size %d\n", totalByteCodes);
+			//post("\tNumber of Symbols %d\n", symbolTable->NumItems());
+			//post("\tByte Code Size %d\n", totalByteCodes);
 			//elapsed = TickCount() - compileStartTime;
 			//elapsed = 0;
 			elapsed = elapsedTime() - compileStartTime;
-			post("\tcompiled %d files in %.2f seconds\n",
-				 gNumCompiledFiles, elapsed );
+			//post("\tcompiled %d files in %.2f seconds\n",
+			//	 gNumCompiledFiles, elapsed );
 			if(numOverwrites == 1){
 				post("\nInfo: One method is currently overwritten by an extension. To see which, execute:\nMethodOverride.printAll\n\n");
 			}
 			else if(numOverwrites > 1){
 				post("\nInfo: %i methods are currently overwritten by extensions. To see which, execute:\nMethodOverride.printAll\n\n", numOverwrites);
 			}
-			post("compile done\n");
+			//post("compile done\n");
 		}
 	}
 }
@@ -1877,7 +1877,7 @@ void pyrmath_init_globs();
 
 void initPassOne()
 {
-	post("initPassOne started\n");
+	//post("initPassOne started\n");
 	aboutToFreeRuntime();
 
 	//dump_pool_histo(pyr_pool_runtime);
@@ -1908,7 +1908,7 @@ void initPassOne()
 	compiledOK = false;
 	compiledDirectories.clear();
 	sc_InitCompileDirectory();
-	post("initPassOne done\n");
+	//post("initPassOne done\n");
 }
 
 void finiPassOne()
@@ -2139,7 +2139,7 @@ SCLANG_DLLEXPORT_C bool compileLibrary(bool standalone)
 	bool res = passOne();
 	if (res) {
 
-		postfl("\tpass 1 done\n");
+		//postfl("\tpass 1 done\n");
 
 		if (!compileErrors) {
 			buildDepTree();

--- a/lang/LangSource/PyrObject.cpp
+++ b/lang/LangSource/PyrObject.cpp
@@ -1233,14 +1233,14 @@ void buildBigMethodMatrix()
 
 #ifndef _MSC_VER
 	pool.try_executing_one();
-#endif	
+#endif
 	filledClassIndices.wait();
 #ifdef _MSC_VER
 	size_t numentries = fillClassRows(class_object, bigTable);
 #else
 	size_t numentries = fillClassRows(class_object, bigTable, pool);
 #endif
-	post("\tnumentries = %lu / %d = %.2g\n", numentries, bigTableSize, (double)numentries/(double)bigTableSize);
+	//post("\tnumentries = %lu / %d = %.2g\n", numentries, bigTableSize, (double)numentries/(double)bigTableSize);
 
 
 	ColumnDescriptor * filledSelectors = filledSelectorsFuture.get();
@@ -1374,9 +1374,9 @@ void buildBigMethodMatrix()
 			100. * (double)numFilled/(rowTableSize/sizeof(PyrMethod*)));
 	}
 #endif
-	post("\t%d method selectors, %d classes\n", numSelectors, numClasses);
-	post("\tmethod table size %d bytes, ", rowTableSize);
-	post("big table size %d\n", numSelectors * numClasses * sizeof(PyrMethod*));
+	//post("\t%d method selectors, %d classes\n", numSelectors, numClasses);
+	//post("\tmethod table size %d bytes, ", rowTableSize);
+	//post("big table size %d\n", numSelectors * numClasses * sizeof(PyrMethod*));
 	//postfl("%p %p %p\n", classes, bigTable, sels);
 /*
 	// not necessary since the entire pool will be freed..

--- a/lang/LangSource/PyrObject.cpp
+++ b/lang/LangSource/PyrObject.cpp
@@ -1240,7 +1240,6 @@ void buildBigMethodMatrix()
 #else
 	size_t numentries = fillClassRows(class_object, bigTable, pool);
 #endif
-	//post("\tnumentries = %lu / %d = %.2g\n", numentries, bigTableSize, (double)numentries/(double)bigTableSize);
 
 
 	ColumnDescriptor * filledSelectors = filledSelectorsFuture.get();
@@ -1374,9 +1373,6 @@ void buildBigMethodMatrix()
 			100. * (double)numFilled/(rowTableSize/sizeof(PyrMethod*)));
 	}
 #endif
-	//post("\t%d method selectors, %d classes\n", numSelectors, numClasses);
-	//post("\tmethod table size %d bytes, ", rowTableSize);
-	//post("big table size %d\n", numSelectors * numClasses * sizeof(PyrMethod*));
 	//postfl("%p %p %p\n", classes, bigTable, sels);
 /*
 	// not necessary since the entire pool will be freed..


### PR DESCRIPTION
In an effort to clean up the output that sclang produces in the post window on boot, this commit removes several extraneous debug messages. In particular:
- initPassOne started/done
- NumPrimitives = #
- pass 1 done
- numentries = # / # = #
- # method selectors, # classes
- method table size # bytes, big table size #
- Number of Symbols #
- Byte Code Size #
- compiled # files in # seconds

Most of these are both useless and incomprehensible to anyone except SuperCollider developers, so they have been commented out. Care must be taken in removing or altering further messages, because supercollider.js (and possibly other interfaces to sclang?) [parses the startup output](https://github.com/crucialfelix/supercolliderjs/blob/develop/src/lang/internals/sclang-io.js). The removals in this commit should not affect supercollider.js, however.
