### PR TITLE
Deprecate Speech

### DIFF
--- a/HelpSource/Classes/Speech.schelp
+++ b/HelpSource/Classes/Speech.schelp
@@ -1,8 +1,20 @@
 class:: Speech
-summary:: lets you use the Apple speech synthesizer
+summary:: [DEPRECATED] lets you use the Apple speech synthesizer
 categories:: Platform>OSX
 
 description::
+
+warning::
+Speech has been deprecated for a number of reasons:
+
+list::
+## The audio output is independent of the server, so it has major limitations when attempting to use it in SC compositions.
+## The core library should be small, and speech synthesis is too niche to merit inclusion.
+## It is OS X only, and adding cross-platform compatibility is nontrivial.
+::
+
+The recommended alternative is code:: "say".unixCmd ::. For alternative freeware TTS systems that may have better cross-platform support, we suggest eSpeak, Festival, MBROLA, and pico2wave.
+::
 
 code::
 "hi i'm talking with the default voice now, i guess".speak;

--- a/HelpSource/Classes/String.schelp
+++ b/HelpSource/Classes/String.schelp
@@ -752,7 +752,7 @@ code::
 subsection::Misc methods
 
 method::speak
-Sends string to the speech synthesiser of the OS. (OS X only.) see: link::Classes/Speech::
+Deprecated. See link::Classes/Speech:: for the full reason and possible replacements. Sends string to the OS X speech synthesizer.
 code::
 "hi i'm talking with the default voice now, i guess".speak;
 ::

--- a/SCClassLibrary/Common/Collections/String.sc
+++ b/SCClassLibrary/Common/Collections/String.sc
@@ -508,13 +508,6 @@ String[char] : RawArray {
 		^time * sign;
 	}
 
-	speak { arg channel = 0, force = false;
-		// FIXME: this should better be handled by Platform than GUI
-		var speech = GUI.current.speech;
-		if( speech.initialized.not, { speech.init });
-		speech.channels[ channel ].speak( this, force );
-	}
-
 	toLower {
 		^this.collect(_.toLower)
 	}

--- a/SCClassLibrary/deprecated/3.8/osx/Speech.sc
+++ b/SCClassLibrary/deprecated/3.8/osx/Speech.sc
@@ -146,9 +146,10 @@ Speech {
 
 + String {
 	speak { arg channel = 0, force = false;
+		var speech;
 		this.deprecated(thisMethod);
 		// FIXME: this should better be handled by Platform than GUI
-		var speech = GUI.current.speech;
+		speech = GUI.current.speech;
 		if( speech.initialized.not, { speech.init });
 		speech.channels[ channel ].speak( this, force );
 	}

--- a/SCClassLibrary/deprecated/3.8/osx/Speech.sc
+++ b/SCClassLibrary/deprecated/3.8/osx/Speech.sc
@@ -59,6 +59,7 @@ SpeechChannel{
 
 
 	speak{|string, force=false|
+		this.deprecated(thisMethod);
 		if(force.not){
 			this.prSpeak(channel, string);
 			^this
@@ -118,6 +119,7 @@ Speech {
 	}
 	//private
 	*init { arg num= 1;
+		this.deprecated(thisMethod);
 		initialized = true;
 		channels = Array.new(num);
 		wordActions = Array.newClear(num);
@@ -139,6 +141,16 @@ Speech {
 	*doSpeechDoneAction { arg chan;
 		doneAction.value(chan);
 		doneActions[chan].value(channels[chan]);
+	}
+}
+
++ String {
+	speak { arg channel = 0, force = false;
+		this.deprecated(thisMethod);
+		// FIXME: this should better be handled by Platform than GUI
+		var speech = GUI.current.speech;
+		if( speech.initialized.not, { speech.init });
+		speech.channels[ channel ].speak( this, force );
 	}
 }
 


### PR DESCRIPTION
The last two times I brought this up -- on [sc-dev](http://new-supercollider-mailing-lists-forums-use-these.2681727.n2.nabble.com/Time-to-get-rid-of-Speech-td7627124.html) and [on this issue](https://github.com/supercollider/supercollider/issues/208#issuecomment-236780563) -- I only received responses in agreement. I'm filing this to help bring more attention in case there are any detractors.

I have made some very good progress on my SuperCollider adaptor to MAGE/pHTS, which runs on the server and can therefore be filtered and/or recorded, unlike Speech. I considered advertising it in the deprecation warning, but it's not ready for general use yet.