### PR TITLE
Classlib: Move default Event's ~callback into the ~play function

### DIFF
--- a/HelpSource/Tutorials/A-Practical-Guide/PG_08_Event_Types_and_Parameters.schelp
+++ b/HelpSource/Tutorials/A-Practical-Guide/PG_08_Event_Types_and_Parameters.schelp
@@ -55,6 +55,13 @@ definitionList::
 ## \out || Generally used for the output bus of a link::Classes/Synth::. When using link::Classes/Pbus:: or link::Classes/Pfxb::, an audio bus is allocated to isolate the pattern's signal. All events from the pattern receive the new bus number in the code::\out:: slot, and SynthDefs being played should use an code::out:: argument for the target of output UGens, e.g., code::Out.ar(out, ...):: .
 ::
 
+subsection::User function hooks
+
+definitionList::
+## \finish || A function that will be executed after code::play:: has been called, but before event type processing. Use this to manipulate event data.
+## \callback || A function that will be executed after the Event has finished all its work. The code::callback:: may be used for bookkeeping. Finished Events are expected to store new node IDs under code::~id::; with the IDs, you can register functions to watch node status or set node controls, for instance. The function receives the finished event as its argument.
+::
+
 section::Event Types
 
 subsection::Node control
@@ -86,7 +93,6 @@ p.stop;
 ## on || Start a Synth node (or nodes) without releasing. The node ID(s) are in the event's code::~id:: variable. Those IDs can be used with the off, set and kill event types.
 definitionList::
 ## Standard Timing and Node control arguments ||
-## callback || A function that will be executed after creating the nodes. Use this for bookkeeping, to keep track of the node IDs for later use. The function receives the finished event as its argument.
 ## (sendGate and strum parameters are not used) ||
 ::
 

--- a/SCClassLibrary/Common/Collections/Event.sc
+++ b/SCClassLibrary/Common/Collections/Event.sc
@@ -416,7 +416,7 @@ Event : Environment {
 				play: #{
 					var tempo, server;
 
-					~finish.value;
+					~finish.value(currentEnvironment);
 
 					server = ~server ?? { Server.default };
 
@@ -425,6 +425,8 @@ Event : Environment {
 						thisThread.clock.tempo = tempo;
 					};
 					if(currentEnvironment.isRest.not) { ~eventTypes[~type].value(server) };
+
+					~callback.value(currentEnvironment);
 				},
 
 				// synth / node interface
@@ -632,7 +634,6 @@ Event : Environment {
 
 						~server = server;
 						~id = ids;
-						~callback.value(currentEnvironment)
 					},
 
 					set: #{|server|
@@ -846,6 +847,7 @@ Event : Environment {
 							ids = ids.add(id);
 							b[2] = id;
 						};
+						~id = ids;
 
 						if ((addAction == 0) || (addAction == 3)) {
 							bndl = bndl.reverse;


### PR DESCRIPTION
Formerly, ~callback was valid only for event type \on. But there's no reason why it shouldn't be valid for other event types. So, let's make it general.

Documented in the Practical Guide to Patterns chapter on event types. This was the only place that ever documented ~callback; for that matter, I can't find documentation on ~finish anywhere else either.

Addresses #2375 and possibly other issues.

Test case:

```
p = Pmono(\default,
    \degree, Pwhite(0, 7, inf),
    \dur, 0.25,
    \callback, {
        var resp;
        if(~type == \monoNote) {
            ~id.debug("made node id");
            resp = OSCFunc({ |msg|
                msg[1].debug("stopped");
                resp.free;
            }, \n_end, s.addr, argTemplate: [~id]);
        };
    }
).play;

p.stop;
```
