### PR TITLE
Fix emacs show-method bug

### DIFF
--- a/editors/scel/el/sclang-language.el
+++ b/editors/scel/el/sclang-language.el
@@ -71,7 +71,7 @@ The expressions are joined as alternatives with the \\| operator."
   "Regular expression matching method names.")
 
 (defconst sclang-class-name-regexp
-  "\\(?:Meta_\\)?[A-Z]\\(?:\\sw\\|\\s_\\)*"
+  "\\<\\(?:Meta_\\)?[A-Z]\\(?:\\sw\\|\\s_\\)*"
   "Regular expression matching class names.")
 
 (defconst sclang-primitive-name-regexp


### PR DESCRIPTION
Fix #132.  Incorrect regexp caused methods names with a capital letter to be interpreted as a class name.  Adding a start of word \\< seems to fix it.