### PR TITLE
Topic triggers assume zero init

### DIFF
--- a/server/plugins/Convolution.cpp
+++ b/server/plugins/Convolution.cpp
@@ -333,7 +333,6 @@ void Convolution2_Ctor(Convolution2 *unit)
 		unit->m_pos = 0;
 
 		unit->m_prevtrig = 0.f;
-		unit->m_prevtrig = ZIN0(2);
 
 		if ( unit->m_framesize >= world->mFullRate.mBufLength ) {
 			SETCALC(Convolution2_next);

--- a/server/plugins/NoiseUGens.cpp
+++ b/server/plugins/NoiseUGens.cpp
@@ -619,7 +619,7 @@ void TRand_Ctor(TRand* unit)
 			SETCALC(TRand_next_aa);
 		} else { SETCALC(TRand_next_a); }
 	} else { SETCALC(TRand_next_k); }
-	unit->m_trig = ZIN0(2);
+	unit->m_trig = 0.f;
 }
 
 
@@ -704,7 +704,7 @@ void TExpRand_Ctor(TExpRand* unit)
 			SETCALC(TExpRand_next_aa);
 		} else { SETCALC(TExpRand_next_a); }
 	} else { SETCALC(TExpRand_next_k); }
-	unit->m_trig = ZIN0(2);
+	unit->m_trig = 0.f;
 }
 
 
@@ -801,7 +801,7 @@ void TIRand_Ctor(TIRand* unit)
 			SETCALC(TIRand_next_aa);
 		} else { SETCALC(TIRand_next_a); }
 	} else { SETCALC(TIRand_next_k); }
-	unit->m_trig = ZIN0(2);
+	unit->m_trig = 0.f;
 }
 
 
@@ -814,7 +814,7 @@ void CoinGate_Ctor(CoinGate* unit)
 	} else {
 		SETCALC(CoinGate_next_k);
 	}
-	unit->m_trig = ZIN0(1);
+	unit->m_trig = 0.f;
 }
 
 void CoinGate_next_k(CoinGate* unit, int inNumSamples)

--- a/server/plugins/TriggerUGens.cpp
+++ b/server/plugins/TriggerUGens.cpp
@@ -884,7 +884,7 @@ void Poll_Ctor(Poll* unit)
 		SETCALC(Poll_next_kk);
 	}
 
-	unit->m_trig = IN0(0);
+	unit->m_trig = 0.f;
 	const int idSize = (int)IN0(3); // number of chars in the id string
 	unit->m_id_string = (char*)RTAlloc(unit->mWorld, (idSize + 1) * sizeof(char));
 
@@ -1652,7 +1652,7 @@ void Sweep_Ctor(Sweep *unit)
 		}
 	}
 
-	unit->m_previn = ZIN0(0);
+	unit->m_previn = 0.f;
 	ZOUT0(0) = unit->mLevel = 0.f;
 }
 
@@ -1800,7 +1800,7 @@ void Phasor_Ctor(Phasor *unit)
 		SETCALC(Phasor_next_ak);
 	}
 
-	unit->m_previn = ZIN0(0);
+	unit->m_previn = 0.f;
 	ZOUT0(0) = unit->mLevel = ZIN0(2);
 }
 
@@ -2206,6 +2206,7 @@ void RunningMin_next_aa(RunningMin *unit, int inNumSamples)
 
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 void RunningMax_Ctor(RunningMax *unit)
 {
 	if (INRATE(1) == calc_FullRate) {


### PR DESCRIPTION
This is an attempt to make the initial behaviour of trigger ugens more
predictable. If a non-zero trig input happens at the first sample, it
is assumed that this is a trigger.

This is mostly the case already, but this patch series changes: 
- Poll
- Sweep
- Phasor
- Convolution2
- TRand
- TIRand
- TExpRand

This is yet untested.

Related to: #2333
