### PR TITLE
class library: add missing proxy init in Ndef

### DIFF
--- a/SCClassLibrary/JITLib/ProxySpace/NodeProxy.sc
+++ b/SCClassLibrary/JITLib/ProxySpace/NodeProxy.sc
@@ -1023,6 +1023,7 @@ Ndef : NodeProxy {
 		res = dict.envir.at(key);
 		if(res.isNil) {
 			res = super.new(server).key_(key);
+			dict.initProxy(res);
 			dict.envir.put(key, res)
 		};
 


### PR DESCRIPTION
Unlike ProxySpace when making a NodeProxy via a ProxySpace, Ndef
wouldn’t call this method.

reproducer by Henricus J. Holtman:

```
(
p = ProxySpace.push(s);
p.clock = TempoClock.default;
p.quant = 4;

Pdefn(\nkick, -25);
Pdefn(\nhats, 10);

~out.play;

~out = ~a + ~b;

~a[0] = Pbind(\instrument, \SOSkick, \dur, Pseq([1, Rest(3)], inf), \note, Pdefn(\nkick));
~b[0] = Pbind(\instrument, \SOShats, \dur, Pseq([1, Rest(3)], inf), \note, Pdefn(\nhats));
);

~a.quant.postln; // 4
~b.quant.postln; // 4
~out.quant.postln // 4

but:

(
Ndef(\a).proxyspace.quant = 4;
Ndef(\a).proxyspace.clock = TempoClock.default;

Pdefn(\nkick, -25);
Pdefn(\nhats, 10);

Ndef(\out).play;

Ndef(\out, Ndef(\a) + Ndef(\b));

Ndef(\a)[0] = Pbind(\instrument, \SOSkick, \dur, Pseq([1, Rest(3)], inf), \note, Pdefn(\nkick));
Ndef(\b)[0] = Pbind(\instrument, \SOShats, \dur, Pseq([1, Rest(3)], inf), \note, Pdefn(\nhats));
);

Ndef(\a).quant.postln; // 4
Ndef(\b).quant.postln; // nil
Ndef(\out).quant.postln; // nil

The former is in sync, the latter probably not.

Thank you for your attention

On 10/07/2016 05:33 AM, alberto.decampo wrote:
hi,

How exactly does Ndef version fail compared to the proxyspace version ?
They do the same here (3.8b1 osx), also when I change the dur patterns and tempo.

best adc

On 07/10/2016, at 09:35 , ddw_music <jamshark70@qq.com> wrote:

Henricus J. Holtman wrote
It seems to me the 'solution' on the Ndef page:

// set default quant
Ndef(\x).proxyspace.quant = 1.0;

is equivalent to my code as long as I don't change servers.
Oh, ok, you're right, I missed the line where you assigned the Ndef
proxyspace into p:

p = Ndef(\a).proxyspace;

```