### PR TITLE
class library: Psym1 warns if passed an array

### DIFF
--- a/SCClassLibrary/JITLib/Patterns/Psym.sc
+++ b/SCClassLibrary/JITLib/Patterns/Psym.sc
@@ -114,7 +114,10 @@ Psym1 : Psym {
 			which = str.next(inval);
 			which.notNil
 		} {
-			pat = this.getPattern(which);
+			if(which.isSequenceableCollection) {
+				Error("Psym1 cannot embed arrayed keys: %\n".format(which)).throw;
+			};
+			pat = this.lookUp(which);
 			currentStream = streams.at(pat);
 			if(currentStream.isNil) {
 				currentStream = pat.asStream;


### PR DESCRIPTION
This fixes #2315. In the future, we could take a look at a way to
implement this, for now better throw an error.
