### PR TITLE
Adjust Help title for Windows return value of folder

### DIFF
--- a/SCClassLibrary/SCDoc/SCDocRenderer.sc
+++ b/SCClassLibrary/SCDoc/SCDocRenderer.sc
@@ -153,7 +153,7 @@ SCDocHTMLRenderer {
 		};
 
 		stream << "<h1>";
-		if((folder=="") and: {doc.title=="Help"}) {
+		if((doc.title=="Help") and: {((thisProcess.platform.name===\windows) and: (folder=="Help")) or: {folder==""}}) {
 			stream << "SuperCollider " << Main.version;
 			stream << "<span class='headerimage'><img src='" << baseDir << "/images/SC_icon.png'/></span>";
 		} {


### PR DESCRIPTION
Windows returns "Help" for var folder. Is this a correct fix (@snappizz?) (tried on Windows and Mac)? Currently the old "Help" is displayed as title on Windows.
