### PR TITLE
server: failed notify reports failure

### DIFF
--- a/SCClassLibrary/Common/Control/ServerStatus.sc
+++ b/SCClassLibrary/Common/Control/ServerStatus.sc
@@ -56,8 +56,6 @@ ServerStatusWatcher {
 			}, '/done', server.addr, argTemplate:['/notify', nil]).oneShot;
 
 			failOSCFunc = OSCFunc({|msg, time, replyAddr|
-				//replyAddr.sendMsg("/quit");
-				server.addr = replyAddr;
 				"failed to notify sclang by scserver. Please reboot the server '%'".format(server.name).warn;
 				doneOSCFunc.free;
 			}, '/fail', server.addr, argTemplate:['/notify', nil, nil]).oneShot;

--- a/SCClassLibrary/Common/Control/ServerStatus.sc
+++ b/SCClassLibrary/Common/Control/ServerStatus.sc
@@ -55,8 +55,10 @@ ServerStatusWatcher {
 				failOSCFunc.free;
 			}, '/done', server.addr, argTemplate:['/notify', nil]).oneShot;
 
-			failOSCFunc = OSCFunc({|msg|
-				server.clientID = msg[2];
+			failOSCFunc = OSCFunc({|msg, time, replyAddr|
+				//replyAddr.sendMsg("/quit");
+				server.addr = replyAddr;
+				"failed to notify sclang by scserver. Please reboot the server '%'".format(server.name).warn;
 				doneOSCFunc.free;
 			}, '/fail', server.addr, argTemplate:['/notify', nil, nil]).oneShot;
 


### PR DESCRIPTION
The server shouldn’t try to set the clientID on failure.

This fixes #2328. Related to #1914.

This is still a partial solution.