### PR TITLE
Classlib: Add 'rewind' to CollStream

### DIFF
--- a/SCClassLibrary/Common/Streams/IOStream.sc
+++ b/SCClassLibrary/Common/Streams/IOStream.sc
@@ -59,6 +59,9 @@ CollStream : IOStream {
 	pos_ { arg toPos;
 		pos = toPos.clip(0, collection.size);
 	}
+	rewind { |n = 1|
+		pos = max(0, pos - n);
+	}
 	peek {
 		^collection.at(pos)
 	}


### PR DESCRIPTION
I've been using CollStream as part of a parser, and it's very useful to roll back 1 or more characters.

Currently:

```
stream.pos = stream.pos - 1;
```

Proposed:

```
stream.rewind(1);
```

No rush on this.

(CollStream is as yet undocumented, btw.)
