### PR TITLE
server: don't set client id on failure

### DIFF
--- a/SCClassLibrary/Common/Control/ServerStatus.sc
+++ b/SCClassLibrary/Common/Control/ServerStatus.sc
@@ -56,8 +56,8 @@ ServerStatusWatcher {
 			}, '/done', server.addr, argTemplate:['/notify', nil]).oneShot;
 
 			failOSCFunc = OSCFunc({|msg|
-				server.clientID = msg[2];
 				doneOSCFunc.free;
+				Error("Failed to register with scsynth for notifications: %".format(msg)).throw;
 			}, '/fail', server.addr, argTemplate:['/notify', nil, nil]).oneShot;
 
 		};

--- a/SCClassLibrary/Common/Control/ServerStatus.sc
+++ b/SCClassLibrary/Common/Control/ServerStatus.sc
@@ -57,7 +57,9 @@ ServerStatusWatcher {
 
 			failOSCFunc = OSCFunc({|msg|
 				doneOSCFunc.free;
-				Error("Failed to register with scsynth for notifications: %".format(msg)).throw;
+				Error(
+					"Failed to register with server '%' for notifications: %\n"
+					"To recover, please reboot the server.".format(server.name, msg)).throw;
 			}, '/fail', server.addr, argTemplate:['/notify', nil, nil]).oneShot;
 
 		};


### PR DESCRIPTION
don't set client ID if notify failed, and throw an error.

This fixes #2328. Related to #1914.
