### PR TITLE
improve SequenceableCollection flatten

### DIFF
--- a/SCClassLibrary/Common/Collections/SequenceableCollection.sc
+++ b/SCClassLibrary/Common/Collections/SequenceableCollection.sc
@@ -428,13 +428,7 @@ SequenceableCollection : Collection {
 	}
 
 	prFlat { |list|
-		this.do({ arg item, i;
-			if (item.respondsTo('prFlat'), {
-				list = item.prFlat(list);
-			},{
-				list = list.add(item);
-			});
-		});
+		this.do({ |item| list = item.prFlat(list) });
 		^list
 	}
 

--- a/SCClassLibrary/Common/Collections/SequenceableCollection.sc
+++ b/SCClassLibrary/Common/Collections/SequenceableCollection.sc
@@ -419,11 +419,7 @@ SequenceableCollection : Collection {
 
 		list = this.species.new;
 		this.do({ arg item;
-			if (item.respondsTo('flatten'), {
-				list = list.addAll(item.flatten(numLevels));
-			},{
-				list = list.add(item);
-			});
+			list = list.addAll(item.flatten(numLevels))
 		});
 		^list
 	}

--- a/SCClassLibrary/Common/Collections/SequenceableCollection.sc
+++ b/SCClassLibrary/Common/Collections/SequenceableCollection.sc
@@ -406,21 +406,21 @@ SequenceableCollection : Collection {
 	curdle { arg probability;
 		^this.separate({ probability.coin });
 	}
-	flatten { arg numLevels=1;
+	flatten { |numLevels=1|
 		var list;
 
-		if(numLevels < 0, {
+		if(numLevels < 0) {
 			^this.flatten(max(this.maxDepth + numLevels, 0));
-		}, {
-			if (numLevels == 0, { ^this })
-		});
+		} {
+			if (numLevels == 0) { ^this }
+		};
 
 		numLevels = numLevels - 1;
 
 		list = this.species.new;
-		this.do({ arg item;
+		this.do { |item|
 			list = list.addAll(item.flatten(numLevels))
-		});
+		};
 		^list
 	}
 
@@ -429,7 +429,7 @@ SequenceableCollection : Collection {
 	}
 
 	prFlat { |list|
-		this.do({ |item| list = item.prFlat(list) });
+		this.do { |item| list = item.prFlat(list) };
 		^list
 	}
 

--- a/SCClassLibrary/Common/Collections/SequenceableCollection.sc
+++ b/SCClassLibrary/Common/Collections/SequenceableCollection.sc
@@ -409,7 +409,12 @@ SequenceableCollection : Collection {
 	flatten { arg numLevels=1;
 		var list;
 
-		if (numLevels <= 0, { ^this });
+		if(numLevels < 0, {
+			^this.flatten(max(this.maxDepth + numLevels, 0));
+		}, {
+			if (numLevels == 0, { ^this })
+		});
+
 		numLevels = numLevels - 1;
 
 		list = this.species.new;

--- a/SCClassLibrary/Common/Core/Object.sc
+++ b/SCClassLibrary/Common/Core/Object.sc
@@ -39,7 +39,7 @@ Object  {
 	//accessing
 	size { ^0 }
 	indexedSize { ^0 }
-	flatSize { ^1	}
+	flatSize { ^1 }
 
 	do { arg function; function.value(this, 0) }
 	generate { arg function, state; this.do(function); ^state }
@@ -903,5 +903,10 @@ Object  {
 
 	help {
 		this.class.asString.help
+	}
+
+	// support for SequenceableCollection flat
+	prFlat { |list|
+		^list.add(this)
 	}
 }

--- a/SCClassLibrary/Common/Core/Object.sc
+++ b/SCClassLibrary/Common/Core/Object.sc
@@ -404,6 +404,7 @@ Object  {
 		if (levels <= 1) { ^[this] };
 		^[this.bubble(depth,levels-1)]
 	}
+	flatten { ^this }
 
 	// compatibility with sequenceable collection
 
@@ -909,4 +910,5 @@ Object  {
 	prFlat { |list|
 		^list.add(this)
 	}
+
 }


### PR DESCRIPTION
This improves performance of `flat` and `flatten` and provides a flatten from bottom for negative levels.

```
(
(-3..3).do { |i|
    i.postln;
    [[1], 2, [[3, 4], 5], [[[]]], [[[6]]], 7, 8, []].flatten(i).postln
}
)
```

returns

```
-3
[ [ 1 ], 2, [ [ 3, 4 ], 5 ], [ [ [  ] ] ], [ [ [ 6 ] ] ], 7, 8, [  ] ]
-2
[ 1, 2, [ 3, 4 ], 5, [ [  ] ], [ [ 6 ] ], 7, 8 ]
-1
[ 1, 2, 3, 4, 5, [  ], [ 6 ], 7, 8 ]
0
[ [ 1 ], 2, [ [ 3, 4 ], 5 ], [ [ [  ] ] ], [ [ [ 6 ] ] ], 7, 8, [  ] ]
1
[ 1, 2, [ 3, 4 ], 5, [ [  ] ], [ [ 6 ] ], 7, 8 ]
2
[ 1, 2, 3, 4, 5, [  ], [ 6 ], 7, 8 ]
3
[ 1, 2, 3, 4, 5, 6, 7, 8 ]
```
