### PR TITLE
IDE: Send a properly formatted /status msg (not 'status')

### DIFF
--- a/editors/sc-ide/core/sc_server.cpp
+++ b/editors/sc-ide/core/sc_server.cpp
@@ -478,7 +478,7 @@ void ScServer::timerEvent(QTimerEvent * event)
     {
         char buffer[512];
         osc::OutboundPacketStream stream(buffer, 512);
-        stream << osc::BeginMessage("status");
+        stream << osc::BeginMessage("/status");
         stream << osc::MessageTerminator();
 
         qint64 sentSize = mUdpSocket->write(stream.Data(), stream.Size());


### PR DESCRIPTION
One of the fun things about using supernova for my current piece is that I'm finding all of the sloppy little things that previously escaped notice.

I turned on dumpOSC while using supernova, and found that it kept posting "received osc message [status]" -- and then found that this posted output is supposed to suppress status messages:

```
            const char * address = message.AddressPattern();
            if (strcmp(address, "/status") != 0) // we ignore /status messages
                cout << "received osc message " << message << endl;
```

So I added some debug posting and found that supernova is receiving both `/status` and `status` messages. sclang is formatting the outgoing messages properly (with leading slash), but the IDE's status bar does not include the slash.

So, now it does.