### PR TITLE
IDE: Server status bar should send properly formatted /status message (not 'status')

### DIFF
--- a/editors/sc-ide/core/sc_server.cpp
+++ b/editors/sc-ide/core/sc_server.cpp
@@ -478,7 +478,7 @@ void ScServer::timerEvent(QTimerEvent * event)
     {
         char buffer[512];
         osc::OutboundPacketStream stream(buffer, 512);
-        stream << osc::BeginMessage("status");
+        stream << osc::BeginMessage("/status");
         stream << osc::MessageTerminator();
 
         qint64 sentSize = mUdpSocket->write(stream.Data(), stream.Size());


### PR DESCRIPTION
Per discussion under #2445, resubmitting for 3.8.

Post-3.8, this should also go into master.
