### PR TITLE
server graceful force quit

### DIFF
--- a/HelpSource/Classes/Recorder.schelp
+++ b/HelpSource/Classes/Recorder.schelp
@@ -33,7 +33,7 @@ NOTE::
 By default, record creates the recording synth after the Server's default group and uses In.ar. Thus if you add nodes after the recording synth their output will not be captured.
 To avoid this, either use Node objects (which use the default node as their target) or (when using messaging style) use a target nodeID of 1.
 code::
-s.sendMsg("/s_new", "default", s.nextNodeID, 1,1);
+s.sendMsg("/s_new", "default", s.nextNodeID, 1, 1);
 ::
 ::
 
@@ -56,15 +56,35 @@ InstanceMethods::
 
 method:: prepareForRecord
 Allocates the necessary buffer, etc. for recording the server's output. (See code::record:: below.)
+
 argument:: path
 a link::Classes/String:: representing the path and name of the output file.
+
+argument::numChannels
+The number of output channels to record.
+
 discussion::
-If you do not specify a path than a file will be created in your recordings folder (see the note above on this) called SC_thisDateAndTime. Changes to the header or sample format, or to the number of channels must be made strong::before:: calling this.
+If you do not specify a path than a file will be created in your recordings folder (see the note above on this) called code::SC_thisDateAndTime::. Changes to the header or sample format, or to the number of channels must be made strong::before:: calling this.
+
+
 
 method:: record
 Starts or resumes recording the output.
 argument:: path
 this is optional, and is passed to code::prepareForRecord:: (above).
+
+argument:: bus
+The bus (link::Classes/Bus:: object or integer bus index), the offset at which to start to count the number of channels. You can record any adjacent number of bus channels.
+
+argument:: numChannels
+The number of output channels to record.
+
+argument:: node
+The link::Classes/Node:: to record immediately after. By default, this is the default group 1.
+
+argument:: duration
+If set, this limits recording to a given time in seconds.
+
 discussion::
 If you have not called prepareForRecord first (see above) then it will be invoked for you (but that adds a slight delay before recording starts for real).
 

--- a/HelpSource/Classes/Recorder.schelp
+++ b/HelpSource/Classes/Recorder.schelp
@@ -1,0 +1,144 @@
+class:: Recorder
+summary:: Write Audio to Harddisk
+categories:: Server>Abstractions
+related:: Classes/Server, Classes/DiskOut, Guides/Non-Realtime-Synthesis
+
+description:: A Recorder allows you to write audio to harddisk, reading from a given bus and a certain number of channels, relative to a given node. A link::Classes/Server:: has one instance, which is accessible also through the link::Classes/ScIDE::. You can use the server directly to record its output
+
+
+code::
+(
+{ SinOsc.ar(
+	SinOsc.ar(
+		XLine.kr(1, 100, 5)).exprange(*XLine.kr([20, 800], [7000, 200], 10)
+    )
+   ) * 0.1
+
+}.play;
+s.record(duration: 10);
+)
+::
+
+
+This functionality is also available through the recording button on the server windows.
+Pressing it once calls record, and pressing it again calls stopRecording (see below). When doing so the file created will be in your recordings folder and be named for the current date and time.
+The default location of the recordings folder varies from platform to platform. Setting this variable allows you to change the default.
+
+code::
+// find where the recordings are written to
+thisProcess.platform.recordingsDir
+::
+
+NOTE::
+By default, record creates the recording synth after the Server's default group and uses In.ar. Thus if you add nodes after the recording synth their output will not be captured.
+To avoid this, either use Node objects (which use the default node as their target) or (when using messaging style) use a target nodeID of 1.
+code::
+s.sendMsg("/s_new", "default", s.nextNodeID, 1,1);
+::
+::
+
+For more detail on this subject see link::Guides/Order-of-execution::, link::Reference/default_group::, and link::Guides/NodeMessaging::.
+
+See link::Classes/SoundFile:: for information on the various sample and header formats.
+Not all sample and header formats are compatible. Note that the sampling rate of the output file will be the same as that of the server app. This can be set using the Server's link::Classes/ServerOptions::.
+
+
+
+ClassMethods::
+
+method::new
+Create a new instance for a given server.
+
+argument::server
+
+
+InstanceMethods::
+
+method:: prepareForRecord
+Allocates the necessary buffer, etc. for recording the server's output. (See code::record:: below.)
+argument:: path
+a link::Classes/String:: representing the path and name of the output file.
+discussion::
+If you do not specify a path than a file will be created in your recordings folder (see the note above on this) called SC_thisDateAndTime. Changes to the header or sample format, or to the number of channels must be made strong::before:: calling this.
+
+method:: record
+Starts or resumes recording the output.
+argument:: path
+this is optional, and is passed to code::prepareForRecord:: (above).
+discussion::
+If you have not called prepareForRecord first (see above) then it will be invoked for you (but that adds a slight delay before recording starts for real).
+
+code::
+r = Recorder(s);
+{ GVerb.ar(Dust.ar(4)) }.play; // play on bus 64
+r.record(numChannels:2, duration:2);
+r.stopRecording;
+::
+
+method:: pauseRecording
+Pauses recording. Can be resumed by executing record again, or by calling resumeRecording.
+
+method:: resumeRecording
+Start recording again.
+
+method:: stopRecording
+Stops recording, closes the file, and frees the associated resources.
+discussion::
+You must call this when finished recording or the output file will be unusable. Cmd-. while recording has the same effect.
+
+method:: recHeaderFormat
+Get/set the header format (string) of the output file. The default is "aiff". Must be called strong::before:: prepareForRecord.
+
+method:: recSampleFormat
+Get/set the sample format (string) of the output file. The default is "float". Must be called strong::before:: prepareForRecord.
+
+method::recBufSize
+Get/set the size of the link::Classes/Buffer:: to use with the link::Classes/DiskOut:: UGen. This must be a power of two. The default is the code::sampleRate.nextPowerOfTwo:: or the first power of two number of samples longer than one second. Must be called strong::before:: prepareForRecord.
+
+method::isRecording
+returns true, if we are inthe process of recording
+
+method::duration
+returns the number of seconds we have been recording so far
+
+private::cmdPeriod
+private::prRecord
+private::prStopRecord
+private::makePath
+
+section::Examples
+
+
+code::
+s.boot; // start the server
+
+// something to record
+(
+SynthDef("bubbles", {
+	var f, zout;
+	f = LFSaw.kr(0.4, 0, 24, LFSaw.kr([8,7.23], 0, 3, 80)).midicps; // glissando function
+	zout = CombN.ar(SinOsc.ar(f, 0, 0.04), 0.2, 0.2, 4); // echoing sine wave
+	Out.ar(0, zout);
+}).add;
+SynthDef("tpulse", { arg out=0,freq=700,sawFreq=440.0;
+	Out.ar(out, SyncSaw.ar(freq,  sawFreq,0.1) )
+}).add;
+
+)
+
+x = Synth.new("bubbles");
+
+s.prepareForRecord; // if you want to start recording on a precise moment in time, you have to call this first.
+
+s.record; // start recording. This can also be called directly, if it isn't imprtant when precisely you need to start.
+
+s.pauseRecording; // pausable
+
+s.record // start again
+
+s.stopRecording; // this closes the file and deallocates the buffer recording node, etc.
+
+x.free; // stop the synths
+
+// look in your recordings folder and you'll find a file named for this date and time
+::

--- a/HelpSource/Classes/Recorder.schelp
+++ b/HelpSource/Classes/Recorder.schelp
@@ -85,13 +85,15 @@ The link::Classes/Node:: to record immediately after. By default, this is the de
 argument:: duration
 If set, this limits recording to a given time in seconds.
 
+note::The recording starts when the buffer has been allocated, and after the usually very short network latency. It will last for the code::duration:: exactly down to one server block size (64 samples). For scheduling the starting point of a recording precisely, call link::#-prepareForRecord:: first, and then call link::#-record:: a bundle (see link::Classes/Server#-bind:: and  link::Classes/Server#-sync::).::
+
 discussion::
 If you have not called prepareForRecord first (see above) then it will be invoked for you (but that adds a slight delay before recording starts for real).
 
 code::
 r = Recorder(s);
 { GVerb.ar(Dust.ar(4)) }.play; // play on bus 64
-r.record(numChannels:2, duration:2);
+r.record(numChannels:2);
 r.stopRecording;
 ::
 

--- a/HelpSource/Classes/Server.schelp
+++ b/HelpSource/Classes/Server.schelp
@@ -520,7 +520,6 @@ returns:: Function to be evaluated in order to clean up all actions performed in
 
 subsection:: Recording Support
 
-<<<<<<< HEAD
 The following methods are for convenience use. For recording with sample accurate start and stop times you should make your own nodes. See the link::Classes/DiskOut:: helpfile for more info. For non-realtime recording, see the link::Guides/Non-Realtime-Synthesis:: helpfile.
 
 This functionality is also available through the recording button on the server windows.

--- a/HelpSource/Classes/Server.schelp
+++ b/HelpSource/Classes/Server.schelp
@@ -5,69 +5,27 @@ related:: Classes/ServerOptions, Reference/Server-Architecture, Reference/Server
 
 description::
 
-A Server object is the client-side representation of a server app and is used to control the app from the SuperCollider language application. (See link::Guides/ClientVsServer:: for more details on the distinction.)
-It forwards OSC messages and has a number of allocators that keep track of IDs for nodes, buses and buffers.
+A Server object is a representation of a server application. It is used to control it from SuperCollider language. (See link::Guides/Server-Guide::, as well as link::Guides/ClientVsServer:: for more details on the distinction.) It forwards OSC messages and has a number of allocators that keep track of IDs for nodes, buses and buffers.
 
-The server application is a commandline program, so all commands apart from OSC messages are unix commands.
-
-The server application represented by a Server object might be running on the same machine as the client (in the same address space as the language application or separately; see below), or it may be running on a remote machine.
+The server application represented by a Server object might be running on the same machine as the sclang, or it may be running on a remote machine.
 
 Most of a Server's options are controlled through its instance of ServerOptions. See the link::Classes/ServerOptions:: helpfile for more detail.
 
-subsection:: Paths
+A server also holds an instance of a link::Classes/Recorder:: (for recording output into a file) and a link::Classes/Volume:: (master level).
 
-Server apps running on the local machine have two unix environment variables: code::SC_SYNTHDEF_PATH:: and code::SC_PLUGIN_PATH::. These indicate directories of synthdefs and ugen plugins that will be loaded at startup. These are in addition to the default synthdef/ and plugin/ directories which are hard-coded.
-
-These can be set within SC using the getenv and setenv methods of class link::Classes/String::.
-code::
-// all defs in this directory will be loaded when a local server boots
-"SC_SYNTHDEF_PATH".setenv("~/scwork/".standardizePath);
-"echo $SC_SYNTHDEF_PATH".unixCmd;
+note::
+By default, there is always one default server, which is stored in the interpreter variable 's'. E.g. you can boot the defult server by calling code::s.boot::
 ::
 
-subsection:: The default group
-
-When a Server is booted there is a top level group with an ID of 0 that defines the root of the node tree. (This is represented by a subclass of link::Classes/Group:: : link::Classes/RootNode::.)
-If the server app was booted from within SCLang (as opposed to from the command line) the method code::initTree:: will be called automatically after booting.
-This will also create a link::Reference/default_group:: with an ID of 1, which is the default group for all link::Classes/Node::s when using object style.
-This provides a predictable basic node tree so that methods such as Server-scope, Server-record, etc. can function without running into order of execution problems.
-
-The default group is persistent, i.e. it is recreated after a reboot, pressing cmd-., etc. See link::Classes/RootNode:: and link::Reference/default_group:: for more information.
-Note::
-If a Server has been booted from the command line you must call code::initTree:: manually in order to initialize the default group, if you want it. See code::initTree:: below.
+code::
+s.boot;
+{ SinOsc.ar * 0.1 }.play(s); // play a synth on the server
 ::
 
-subsection:: Local vs. Internal
-
-In general, when working with a single machine one will probably be using one of two Server objects which are created at startup and stored in the class variables link::#*local:: and link::#*internal::. In SuperCollider.app (OSX), two GUI windows are created to control these. Use link::#-makeGui:: to create a GUI window manually.
-
-The difference between the two is that the local server runs as a separate application with its own address space, and the internal server runs within the same space as the language/client app.
-
-Both local and internal server supports link::#-scope#scoping:: and link::Classes/Bus#Synchronous control bus methods#synchronous bus access::.
-
-The local server, and any other server apps running on your local machine, have the advantage that if the language app crashes, it (and thus possibly your piece) will continue to run. It is thus an inherently more robust arrangement. But note that even if the synths on the server continue to run, any language-side sequencing and control will terminate if the language app crashes.
-
-At the current time, there is generally no benefit in using the internal server, but it remains for the purposes of backwards compatibility.
-
-subsection:: The default Server
-
-There is always a default Server, which is stored in the class variable code::default::. Any link::Classes/Synth::s or link::Classes/Group::s created without a target will be created on the default server. At startup this is set to be the local server (see above), but can be set to be any Server.
-
-subsection:: Local vs. Remote Servers, Multi-client Configurations
-
-Most of the time users work with a server app running on the same machine as the SC language client. It is possible to use a server running on a different machine via a network, providing you know the IP address and port of that server. The link::#*remote:: method provides a convenient way to do this.
-
-One common variant of this approach is multiple clients using the same server. If you wish to do this you will need to set the server's link::Classes/ServerOptions#-maxLogins:: to at least the number of clients you wish to allow.  When a client registers for link::#-notify#notifications:: the server will supply a client ID. This also configures the allocators to avoid conflicts when allocating link::Classes/Node##Nodes::, link::Classes/Buffer##Buffers::, or link::Classes/Bus##Busses::.
-
-In order to use a remote server with tcp one should first boot the remote server using the code::-t:: option and then run the following code:
+The server application may be in three different states: running, not running, or unresponsive (for example while loading large files from disk).
 
 code::
-(
-s.options.protocol_(\tcp);
-s.addr.connect;
-s.startAliveThread( 0 );
-s.doWhenBooted({ "remote tcp server started".postln; s.notify; s.initTree });
-)
+s.serverRunning // returns true if it is true
 ::
 
 
@@ -113,21 +71,41 @@ get/set the local server, stored in classvar code::local:: (created already on i
 
 method:: internal
 get/set the internal server, stored in classvar code::internal:: (created already on initClass)
+See: link::Guides/Server-Guide::
 
 method:: default
 Get or set the default server. By default this is the local server (see above).
 discussion::
 Setting this will also assign it to the link::Classes/Interpreter:: variable 's'.
 code::
-Server.default = Server.internal; // set the internal Server to be the default Server
+// set the internal Server to be the default Server
+Server.default = Server.internal;
 s.postln; // internal
 ::
 
+subsection::Accessing all servers
+
 method:: all
-get/set the set of all servers.
+get a link::Classes/Set:: of all servers
+
+code::
+Server.all
+::
 
 method:: allRunningServers
 returns:: the set of all running servers.
+
+code::
+Server.allRunningServers
+::
+
+method:: named
+get an link::Classes/IdentityDictionary:: of all servers listed by their name
+
+code::
+Server.named.at(\default)
+::
+
 
 method:: quitAll
 quit all registered servers
@@ -137,6 +115,18 @@ query the system for any sc-server apps and hard quit them
 
 method:: freeAll
 free all nodes in all registered servers
+
+method:: hardFreeAll
+try to free all nodes in all registered servers, even if the server seems not to be running
+
+method::sync_s
+If kept true (default), when the default server is changed, also the interpreter variable s is changed.
+code::
+Server.default = Server(\alice, NetAddr("127.0.0.1", 57130));
+s.postln; // see: it is alice.
+::
+
+subsection::Switching the server application
 
 method:: supernova
 
@@ -232,14 +222,28 @@ argument:: recover
 If true, create a new node ID allocator for the server, but use the old buffer and bus allocators. This is useful if the server process did not actually stop. In normal use, the default value "false" should be used.
 argument:: onFailure
 In this method, the onFailure argument is for internal use only. If you wish to take specific actions when the server boots or fails to boot, it is recommended to use link::#-waitForBoot:: or link::#-doWhenBooted::.
+
 discussion::
-N.B. You cannot boot a server app on a remote machine.
+You cannot boot a server app on a remote machine, but you can initialise the allocators by calling this message.
 
 method:: quit
 quit the server application
 
+argument::onComplete
+A function that is called when quit has completed.
+
+argument::onFailure
+A function that is called when quit has failed.
+
+
 method:: reboot
 quit and restart the server application
+
+argument::func
+a function that is called between quit and (re-)boot.
+
+argument::onFailure
+A function that is called when quit has failed.
 
 method:: freeAll
 free all nodes in this server
@@ -334,7 +338,7 @@ Returns true if a link::Classes/ServerShmInterface:: is available. See also link
 discussion::
 The shared memory interface is initialized after first server boot.
 
-subsection:: Automatic Message Bundling
+subsection:: Message Bundling
 
 Server provides support for automatically bundling messages. This is quite convenient in object style, and ensures synchronous execution. See also link::Guides/Bundled-Messages::
 
@@ -516,6 +520,7 @@ returns:: Function to be evaluated in order to clean up all actions performed in
 
 subsection:: Recording Support
 
+<<<<<<< HEAD
 The following methods are for convenience use. For recording with sample accurate start and stop times you should make your own nodes. See the link::Classes/DiskOut:: helpfile for more info. For non-realtime recording, see the link::Guides/Non-Realtime-Synthesis:: helpfile.
 
 This functionality is also available through the recording button on the server windows.
@@ -565,6 +570,9 @@ x.free; // stop the synths
 
 // look in your recordings folder and you'll find a file named for this date and time
 ::
+=======
+Recording is done via an of link::Classes/Recorder:: - a server holds one instance implicitly.
+>>>>>>> topic/refactor-server-clean
 
 method:: prepareForRecord
 Allocates the necessary buffer, etc. for recording the server's output. (See code::record:: below.)
@@ -588,8 +596,6 @@ Stops recording, closes the file, and frees the associated resources.
 discussion::
 You must call this when finished recording or the output file will be unusable. Cmd-. while recording has the same effect.
 
-method:: recordNode
-Returns:: the current recording synth so that it can be used as a target. This should only be necessary for nodes which are not created in the default group.
 
 method:: recChannels
 Get/set the number of channels (int) to record. Is automatically set to the value of link::Classes/ServerOptions#-numOutputBusChannels:: when booting the server. Must be called strong::before:: prepareForRecord.

--- a/HelpSource/Classes/Server.schelp
+++ b/HelpSource/Classes/Server.schelp
@@ -570,9 +570,8 @@ x.free; // stop the synths
 
 // look in your recordings folder and you'll find a file named for this date and time
 ::
-=======
+
 Recording is done via an of link::Classes/Recorder:: - a server holds one instance implicitly.
->>>>>>> topic/refactor-server-clean
 
 method:: prepareForRecord
 Allocates the necessary buffer, etc. for recording the server's output. (See code::record:: below.)

--- a/HelpSource/Guides/Server-Guide.schelp
+++ b/HelpSource/Guides/Server-Guide.schelp
@@ -1,0 +1,73 @@
+title:: Server Guide
+summary:: Using Server objecs in different situations
+categories:: Server>Abstractions
+related:: Classes/Server, Classes/ServerOptions, Reference/Server-Architecture, Reference/Server-Command-Reference
+
+description::
+
+A Server object is the client-side representation of a server app and is used to control the app from the SuperCollider language application. (See link::Guides/ClientVsServer:: for more details on the distinction.)
+It forwards OSC messages and has a number of allocators that keep track of IDs for nodes, buses and buffers.
+
+The server application is a commandline program, so all commands apart from OSC messages are unix commands.
+
+The server application represented by a Server object might be running on the same machine as the client (in the same address space as the language application or separately; see below), or it may be running on a remote machine.
+
+Most of a Server's options are contolled through its instance of ServerOptions. See the link::Classes/ServerOptions:: helpfile for more detail.
+
+subsection:: Paths
+
+Server apps running on the local machine have two unix environment variables: code::SC_SYNTHDEF_PATH:: and code::SC_PLUGIN_PATH::. These indicate directories of synthdefs and ugen plugins that will be loaded at startup. These are in addition to the default synthdef/ and plugin/ directories which are hard-coded.
+
+These can be set within SC using the getenv and setenv methods of class link::Classes/String::.
+code::
+// all defs in this directory will be loaded when a local server boots
+"SC_SYNTHDEF_PATH".setenv("~/scwork/".standardizePath);
+"echo $SC_SYNTHDEF_PATH".unixCmd;
+::
+
+subsection:: The default group
+
+When a Server is booted there is a top level group with an ID of 0 that defines the root of the node tree. (This is represented by a subclass of link::Classes/Group:: : link::Classes/RootNode::.)
+If the server app was booted from within SCLang (as opposed to from the command line) the method code::initTree:: will be called automatically after booting.
+This will also create a link::Reference/default_group:: with an ID of 1, which is the default group for all link::Classes/Node::s when using object style.
+This provides a predictable basic node tree so that methods such as Server-scope, Server-record, etc. can function without running into order of execution problems.
+
+The default group is persistent, i.e. it is recreated after a reboot, pressing cmd-., etc. See link::Classes/RootNode:: and link::Reference/default_group:: for more information.
+Note::
+If a Server has been booted from the command line you must call code::initTree:: manually in order to initialize the default group, if you want it. See code::initTree:: below.
+::
+
+subsection:: Local vs. Internal
+
+In general, when working with a single machine one will probably be using one of two Server objects which are created at startup and stored in the class variables link::#*local:: and link::#*internal::. In SuperCollider.app (OSX), two GUI windows are created to control these. Use link::#-makeGui:: to create a GUI window manually.
+
+The difference between the two is that the local server runs as a separate application with its own address space, and the internal server runs within the same space as the language/client app.
+
+Both local and internal server supports link::#-scope#scoping:: and link::Classes/Bus#Synchronous control bus methods#synchronous bus access::.
+
+The local server, and any other server apps running on your local machine, have the advantage that if the language app crashes, it (and thus possibly your piece) will continue to run. It is thus an inherently more robust arrangement. But note that even if the synths on the server continue to run, any language-side sequencing and control will terminate if the language app crashes.
+
+At the current time, there is generally no benefit in using the internal server, but it remains for the purposes of backwards compatibility.
+
+subsection:: The default Server
+
+There is always a default Server, which is stored in the class variable code::default::. Any link::Classes/Synth::s or link::Classes/Group::s created without a target will be created on the default server. At startup this is set to be the local server (see above), but can be set to be any Server.
+
+subsection:: Local vs. Remote Servers, Multi-client Configurations
+
+Most of the time users work with a server app running on the same machine as the SC language client. It is possible to use a server running on a different machine via a network, providing you know the IP address and port of that server. The link::#*remote:: method provides a convenient way to do this.
+
+One common variant of this approach is multiple clients using the same server. If you wish to do this you will need to set the server's link::Classes/ServerOptions#-maxLogins:: to at least the number of clients you wish to allow.  When a client registers for link::#-notify#notifications:: the server will supply a client ID. This also configures the allocators to avoid conflicts when allocating link::Classes/Node##Nodes::, link::Classes/Buffer##Buffers::, or link::Classes/Bus##Busses::.
+
+In order to use a remote server with tcp one should first boot the remote server using the code::-t:: option and then run the following code:
+
+code::
+(
+s.options.protocol_(\tcp);
+s.addr.connect;
+s.startAliveThread( 0 );
+s.doWhenBooted({ "remote tcp server started".postln; s.notify; s.initTree });
+)
+::
+
+

--- a/SCClassLibrary/Common/Control/Buffer.sc
+++ b/SCClassLibrary/Common/Control/Buffer.sc
@@ -13,10 +13,7 @@ Buffer {
 	// doesn't send
 	*new { arg server, numFrames, numChannels, bufnum;
 		server = server ? Server.default;
-		bufnum ?? { bufnum = server.bufferAllocator.alloc(1) };
-		if(bufnum.isNil) {
-			Error("No more buffer numbers -- free some buffers before allocating more.").throw
-		};
+		bufnum ?? { bufnum = server.nextBufferNumber(1) };
 		^super.newCopyArgs(server,
 						bufnum,
 						numFrames,
@@ -25,10 +22,7 @@ Buffer {
 
 	*alloc { arg server, numFrames, numChannels = 1, completionMessage, bufnum;
 		server = server ? Server.default;
-		bufnum ?? { bufnum = server.bufferAllocator.alloc(1) };
-		if(bufnum.isNil) {
-			Error("No more buffer numbers -- free some buffers before allocating more.").throw
-		};
+		bufnum ?? { bufnum = server.nextBufferNumber(1) };
 		^super.newCopyArgs(server,
 						bufnum,
 						numFrames,
@@ -38,10 +32,7 @@ Buffer {
 
 	*allocConsecutive { arg numBufs = 1, server, numFrames, numChannels = 1, completionMessage, bufnum;
 		var	bufBase, newBuf;
-		bufBase = bufnum ?? { server.bufferAllocator.alloc(numBufs) };
-		if(bufBase.isNil) {
-			Error("No block of % consecutive buffer numbers is available.".format(numBufs)).throw
-		};
+		bufBase = bufnum ?? { server.nextBufferNumber(numBufs) };
 		^Array.fill(numBufs, { |i|
 			newBuf = Buffer.new(server, numFrames, numChannels, i + bufBase);
 			server.sendMsg(\b_alloc, i + bufBase, numFrames, numChannels,
@@ -90,10 +81,7 @@ Buffer {
 	// adds a query as a completion message
 	*read { arg server, path, startFrame = 0, numFrames = -1, action, bufnum;
 		server = server ? Server.default;
-		bufnum ?? { bufnum = server.bufferAllocator.alloc(1) };
-		if(bufnum.isNil) {
-			Error("No more buffer numbers -- free some buffers before allocating more.").throw
-		};
+		bufnum ?? { bufnum = server.nextBufferNumber(1) };
 		^super.newCopyArgs(server, bufnum)
 					.doOnInfo_(action).cache
 					.allocRead(path, startFrame, numFrames, {|buf|["/b_query", buf.bufnum] })
@@ -110,10 +98,7 @@ Buffer {
 
 	*readChannel { arg server, path, startFrame = 0, numFrames = -1, channels, action, bufnum;
 		server = server ? Server.default;
-		bufnum ?? { bufnum = server.bufferAllocator.alloc(1) };
-		if(bufnum.isNil) {
-			Error("No more buffer numbers -- free some buffers before allocating more.").throw
-		};
+		bufnum ?? { bufnum = server.nextBufferNumber(1) };
 		^super.newCopyArgs(server, bufnum)
 					.doOnInfo_(action).cache
 					.allocReadChannel(path, startFrame, numFrames, channels,
@@ -132,10 +117,7 @@ Buffer {
 
 	*readNoUpdate { arg server, path, startFrame = 0, numFrames = -1, bufnum, completionMessage;
 		server = server ? Server.default;
-		bufnum ?? { bufnum = server.bufferAllocator.alloc(1) };
-		if(bufnum.isNil) {
-			Error("No more buffer numbers -- free some buffers before allocating more.").throw
-		};
+		bufnum ?? { bufnum = server.nextBufferNumber(1) };
 		^super.newCopyArgs(server, bufnum).allocRead(path, startFrame, numFrames, completionMessage)
 	}
 
@@ -186,10 +168,7 @@ Buffer {
 	*loadCollection { arg server, collection, numChannels = 1, action;
 		var data, sndfile, path, bufnum, buffer;
 		server = server ? Server.default;
-		bufnum = server.bufferAllocator.alloc(1);
-		if(bufnum.isNil) {
-			Error("No more buffer numbers -- free some buffers before allocating more.").throw
-		};
+		bufnum ?? { bufnum = server.nextBufferNumber(1) };
 		if(server.isLocal, {
 			if(collection.isKindOf(RawArray).not) { collection = collection.as(FloatArray) };
 			sndfile = SoundFile.new;
@@ -380,15 +359,7 @@ Buffer {
 	}
 
 	*freeAll { arg server;
-		var b;
-		server = server ? Server.default;
-		server.bufferAllocator.blocks.do({ arg block;
-			(block.address .. block.address + block.size - 1).do({ |i|
-				b = b.add( ["/b_free", i] );
-			});
-			server.bufferAllocator.free(block.address);
-		});
-		server.sendBundle(nil, *b);
+		(server ? Server.default).freeAllBuffers;
 		this.clearServerCaches(server);
 	}
 
@@ -654,10 +625,7 @@ Buffer {
 	*loadDialog { arg server, startFrame = 0, numFrames, action, bufnum;
 		var buffer;
 		server = server ? Server.default;
-		bufnum ?? { bufnum = server.bufferAllocator.alloc(1) };
-		if(bufnum.isNil) {
-			Error("No more buffer numbers -- free some buffers before allocating more.").throw
-		};
+		bufnum ?? { bufnum = server.nextBufferNumber(1) };
 		buffer = super.newCopyArgs(server, bufnum).cache;
 		File.openDialog("Select a file...", { arg path;
 			buffer.doOnInfo_(action)

--- a/SCClassLibrary/Common/Control/NetAddr.sc
+++ b/SCClassLibrary/Common/Control/NetAddr.sc
@@ -11,6 +11,7 @@ NetAddr {
 		addr = if (hostname.notNil,{ hostname.gethostbyname },{ 0 });
 		^super.newCopyArgs(addr, port, hostname);
 	}
+
 	*fromIP { arg addr, port;
 		^super.newCopyArgs(addr, port, addr.asIPString)
 	}
@@ -24,6 +25,7 @@ NetAddr {
 		_MatchLangIP
 		^this.primitiveFailed;
 	}
+
 	*localEndPoint {
 		^this.new(this.langIP, this.langPort)
 	}
@@ -31,25 +33,28 @@ NetAddr {
 	*localAddr {
 		^this.new("127.0.0.1", this.langPort)
 	}
+
 	*useDoubles_ { arg flag = false;
 		_NetAddr_UseDoubles
 		^this.primitiveFailed;
 	}
+
 	*broadcastFlag {
 		_NetAddr_GetBroadcastFlag
 		^this.primitiveFailed
 	}
+
 	*broadcastFlag_ { arg flag = true;
 		_NetAddr_SetBroadcastFlag
 		^this.primitiveFailed
 	}
 
 	*disconnectAll {
-		if(connections.notNil, {
-			connections.keys.do({ |netAddr|
+		if(connections.notNil) {
+			connections.keys.do { |netAddr|
 				netAddr.disconnect;
-			});
-		});
+			}
+		}
 	}
 
 	hostname_ { arg inHostname;
@@ -57,32 +62,35 @@ NetAddr {
 		addr = inHostname.gethostbyname;
 	}
 
-
 	sendRaw { arg rawArray;
 		_NetAddr_SendRaw
 		^this.primitiveFailed;
 	}
+
 	sendMsg { arg ... args;
 		_NetAddr_SendMsg
 		^this.primitiveFailed;
 	}
+
 	// warning: this primitive will fail to send if the bundle size is too large
 	// but it will not throw an error.  this needs to be fixed
 	sendBundle { arg time ... args;
 		_NetAddr_SendBundle
 		^this.primitiveFailed;
 	}
+
 	sendStatusMsg {
 		this.sendMsg("/status");
 	}
+
 	sendClumpedBundles { arg time ... args;
 		if(args.bundleSize > 65535) {// udp max size.
-				args.clumpBundles.do { |item|
-					if(time.notNil) { time = time + 1e-9 }; // make it a nanosecond later
-					this.sendBundle(time, *item)
-				};
-			} {
-				this.sendBundle(time, *args)
+			args.clumpBundles.do { |item|
+				if(time.notNil) { time = time + 1e-9 }; // make it a nanosecond later
+				this.sendBundle(time, *item)
+			};
+		} {
+			this.sendBundle(time, *args)
 		}
 	}
 
@@ -113,34 +121,74 @@ NetAddr {
 	}
 
 	makeSyncResponder { arg condition;
-			var id = UniqueID.next;
-			var resp;
-
-			resp = OSCFunc({|msg|
-				if (msg[1] == id) {
-					resp.free;
-					condition.test = true;
-					condition.signal;
-				};
-			}, '/synced', this);
-			condition.test = false;
-			^id
+		var id = UniqueID.next;
+		var resp = OSCFunc({|msg|
+			if (msg[1] == id) {
+				resp.free;
+				condition.test = true;
+				condition.signal;
+			};
+		}, '/synced', this);
+		condition.test = false;
+		^id
 	}
 
 	isConnected {
 		^socket.notNil
 	}
+
 	connect { | disconnectHandler |
 		if (this.isConnected.not) {
 			this.prConnect;
 			connections.put(this, disconnectHandler);
-		};
+		}
 	}
+
 	disconnect {
 		if (this.isConnected) {
 			this.prDisconnect;
 			this.prConnectionClosed;
 		};
+	}
+
+	tryConnectTCP { |onComplete, onFailure, maxAttempts = 10|
+		var func = { |attempts|
+			attempts = attempts - 1;
+			try {
+				this.connect
+			} { |err|
+				if(err.isKindOf(PrimitiveFailedError) and: { err.failedPrimitiveName == '_NetAddr_Connect'}) {
+					if(attempts > 0) {
+						0.2.wait;
+						func.value(onComplete, attempts)
+					} {
+						"Couldn't connect to TCP address %:%\n".format(hostname, port).warn;
+						onFailure.value(this)
+					}
+				} {
+					err.throw;
+				}
+			}
+		};
+		fork {
+			func.value(maxAttempts);
+			onComplete.value(this);
+		}
+	}
+
+	tryDisconnectTCP { |onComplete, onFailure|
+		try {
+			this.disconnect
+		} { |err|
+			if(err.isKindOf(PrimitiveFailedError) and: { err.failedPrimitiveName == '_NetAddr_SendMsg'}) {
+				"Couldn't disconnect from TCP address %:%\n".format(hostname, port).warn;
+				onFailure.value(this)
+			} {
+				err.throw;
+			}
+		};
+		this.disconnect;
+		onComplete.value(this);
 	}
 
 	== { arg that;
@@ -181,15 +229,18 @@ NetAddr {
 		_NetAddr_Connect
 		^this.primitiveFailed;
 	}
+
 	prDisconnect {
 		_NetAddr_Disconnect
 		^this.primitiveFailed;
 	}
+
 	prConnectionClosed {
 		// called when connection is closed either by sclang or by peer
 		socket = nil;
 		connections.removeAt(this).value(this);
 	}
+
 	recover { ^this }
 }
 
@@ -204,26 +255,30 @@ BundleNetAddr : NetAddr {
 	sendRaw { arg rawArray;
 		bundle = bundle.add( rawArray );
 	}
+
 	sendMsg { arg ... args;
 		bundle = bundle.add( args );
 	}
+
 	sendBundle { arg time ... args;
 		bundle = bundle.addAll( args );
 	}
+
 	sendClumpedBundles { arg time ... args;
 		bundle = bundle.addAll( args );
 	}
+
 	sendStatusMsg {} // ignore status messages
 
 	recover {
 		^saveAddr.recover
 	}
-	hasBundle { ^true }
 
+	hasBundle { ^true }
 
 	sync { arg condition, bundles, latency;
 		bundle = bundle.add([\syncFlag, bundles, latency]);
-			// not sure about condition. here we ignore it.
+		// not sure about condition. here we ignore it.
 		async = true;
 	}
 
@@ -236,13 +291,13 @@ BundleNetAddr : NetAddr {
 			};
 
 			forkIfNeeded {
-					bundleList = this.splitBundles(time);
-					lastBundles = bundleList.pop;
-					bundleList.do { |bundles|
-						var t = bundles.removeAt(0);
-						saveAddr.sync(nil, bundles, t); // make an independent condition.
-					};
-					saveAddr.sendClumpedBundles(*lastBundles);  // time ... args
+				bundleList = this.splitBundles(time);
+				lastBundles = bundleList.pop;
+				bundleList.do { |bundles|
+					var t = bundles.removeAt(0);
+					saveAddr.sync(nil, bundles, t); // make an independent condition.
+				};
+				saveAddr.sendClumpedBundles(*lastBundles);  // time ... args
 			}
 		};
 		^bundle

--- a/SCClassLibrary/Common/Control/Node.sc
+++ b/SCClassLibrary/Common/Control/Node.sc
@@ -160,6 +160,10 @@ Node {
 		NodeWatcher.register(this, assumePlaying)
 	}
 
+	unregister {
+		NodeWatcher.unregister(this)
+	}
+
 	onFree { arg func;
 		var f = {|n, m|
 			if(m == \n_end) {

--- a/SCClassLibrary/Common/Control/Recorder.sc
+++ b/SCClassLibrary/Common/Control/Recorder.sc
@@ -1,0 +1,161 @@
+Recorder {
+
+	var <server, <>numChannels;
+	var <>recHeaderFormat, <>recSampleFormat, <>recBufSize;
+	var recordBuf, recordNode, synthDef;
+	var <paused = false, <duration = 0;
+	var <>filePrefix = "SC_";
+	var responder, id;
+
+	*new { |server|
+		^super.newCopyArgs(server)
+	}
+
+	record { |path, bus, numChannels, node, duration|
+
+		server.ifNotRunning { ^this };
+		bus = (bus ? 0).asControlInput;
+
+		if(recordBuf.isNil) {
+			fork {
+				this.prepareForRecord(path, numChannels);
+				server.sync;
+				this.record(path, bus, numChannels, node, duration) // now we are ready
+			}
+		} {
+			if(numChannels.notNil and: { numChannels != this.numChannels }) {
+				"Cannot change recording number of channels while running".warn;
+				^this
+			};
+			if(this.isRecording.not) {
+				this.prRecord(bus, node, duration);
+				server.changed(\recording, true);
+				"Recording channels % ... \npath: '%'\n"
+				.postf(bus + (0..this.numChannels - 1), recordBuf.path);
+			} {
+				if(paused) {
+					this.resumeRecording
+				} {
+					"Recording already (% seconds)".format(this.duration).warn
+				}
+			}
+		}
+	}
+
+	isRecording {
+		^recordNode.isPlaying
+	}
+
+	pauseRecording {
+		if(recordNode.isPlaying) {
+			recordNode.run(false);
+			server.changed(\pausedRecording);
+			"... paused recording.\npath: '%'\n".postf(recordBuf.path);
+		} {
+			"Not Recording".warn
+		};
+		paused = true;
+	}
+
+	resumeRecording {
+		if(recordNode.isPlaying) {
+			if(paused) {
+				recordNode.run(true);
+				server.changed(\recording, true);
+				"Resumed recording ...\npath: '%'\n".postf(recordBuf.path);
+			}
+		} {
+			"Not Recording".warn
+		};
+		paused = false;
+	}
+
+	stopRecording {
+		if(synthDef.notNil) {
+			this.prStopRecord;
+			server.changed(\recording, false);
+		} {
+			"Not Recording".warn
+		}
+	}
+
+	prepareForRecord { | path, numChannels |
+		var bufSize = recBufSize ? server.recBufSize ?? { server.sampleRate.nextPowerOfTwo };
+
+		recHeaderFormat = recHeaderFormat ? server.recHeaderFormat;
+		recSampleFormat = recSampleFormat ? server.recSampleFormat;
+		numChannels = numChannels ? server.recChannels;
+		path = if(path.isNil) { this.makePath } { path.standardizePath };
+		recordBuf = Buffer.alloc(server,
+			bufSize,
+			numChannels,
+			{| buf |
+				buf.writeMsg(path, recHeaderFormat, recSampleFormat, 0, 0, true)
+			}
+		);
+		if(recordBuf.isNil) { Error("could not allocate buffer").throw };
+		recordBuf.path = path;
+		this.numChannels = numChannels;
+		id = UniqueID.next;
+
+		synthDef = SynthDef(SystemSynthDefs.generateTempName, { |in, bufnum, duration|
+			var tick = Impulse.kr(1);
+			var timer = PulseCount.kr(tick) - 1;
+			var doneAction = if(duration <= 0, 0, 2);
+			Line.kr(0, 0, duration, doneAction:doneAction);
+			SendReply.kr(tick, '/recordingDuration', timer, id);
+			DiskOut.ar(bufnum, In.ar(in, numChannels))
+		}).send(server);
+
+		"Preparing recording on '%'\n".postf(server.name);
+	}
+
+	/* private implementation */
+
+	prRecord { |bus, node, dur|
+		recordNode = Synth.tail(node ? 0, synthDef.name, [\bufnum, recordBuf, \in, bus, \duration, dur ? -1]);
+		recordNode.register(true);
+		recordNode.onFree { this.stopRecording };
+		if(responder.isNil) {
+			responder = OSCFunc({ |msg|
+				if(msg[2] == id) {
+					duration = msg[3];
+					server.changed(\recordingDuration, duration);
+				}
+			}, '/recordingDuration', server.addr);
+		} {
+			responder.enable;
+		};
+	}
+
+	prStopRecord {
+		if(recordNode.isPlaying) { recordNode.unregister; recordNode.free; recordNode = nil };
+		server.sendMsg("/d_free", synthDef.name);
+		synthDef = nil;
+		if(recordBuf.notNil) { recordBuf.close({ |buf| buf.freeMsg }); recordBuf = nil };
+		responder.disable;
+		paused = false;
+		duration = 0;
+		server.changed(\recordingDuration, 0);
+	}
+
+	makePath {
+		var timestamp;
+		var dir = thisProcess.platform.recordingsDir;
+		if(File.exists(dir).not) {
+			dir.mkdir;
+			"created recordings directory: '%'\n".postf(dir)
+		};
+
+		// temporary kludge to fix Date's brokenness on windows
+		timestamp = if(thisProcess.platform.name == \windows) {
+			Main.elapsedTime.round(0.01)
+		} {
+			Date.localtime.stamp
+		};
+
+		^dir +/+ filePrefix ++ timestamp ++ "." ++ server.recHeaderFormat;
+	}
+
+
+}

--- a/SCClassLibrary/Common/Control/Recorder.sc
+++ b/SCClassLibrary/Common/Control/Recorder.sc
@@ -129,10 +129,16 @@ Recorder {
 	}
 
 	prStopRecord {
+		var recordPath;
 		if(recordNode.isPlaying) { recordNode.unregister; recordNode.free; recordNode = nil };
 		server.sendMsg("/d_free", synthDef.name);
 		synthDef = nil;
-		if(recordBuf.notNil) { recordBuf.close({ |buf| buf.freeMsg }); recordBuf = nil };
+		if(recordBuf.notNil) {
+			recordPath = recordBuf.path;
+			recordBuf.close({ |buf| buf.freeMsg });
+			"Recording Stopped: (%)\n".postf(recordPath.basename);
+			recordBuf = nil
+		};
 		responder.disable;
 		paused = false;
 		duration = 0;

--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -4,7 +4,7 @@ ServerOptions {
 	var <>numControlBusChannels=16384;
 	var <numInputBusChannels=2;
 	var <numOutputBusChannels=2;
-	var numBuffers=1026;
+	var <>numBuffers=1026;
 
 	var <>maxNodes=1024;
 	var <>maxSynthDefs=1024;
@@ -40,42 +40,35 @@ ServerOptions {
 
 	var <numPrivateAudioBusChannels=112;
 
+	var <>reservedNumAudioBusChannels = 0;
+	var <>reservedNumControlBusChannels = 0;
+	var <>reservedNumBuffers = 0;
 	var <>pingsBeforeConsideredDead = 5;
+
 
 	var <>maxLogins = 1;
 
+	var <>recHeaderFormat="aiff";
+	var <>recSampleFormat="float";
+	var <>recChannels = 2;
+	var <>recBufSize = nil;
+
+
 	device {
-		^if(inDevice == outDevice)
-		{
+		^if(inDevice == outDevice) {
 			inDevice
-		}
-		{
+		} {
 			[inDevice, outDevice]
 		}
 	}
 
-	device_ {
-		|dev|
+	device_ { |dev|
 		inDevice = outDevice = dev;
-	}
-
-	// max logins
-	// session-password
-
-	// prevent buffer conflicts in Server-prepareForRecord and Server-scope by
-	// ensuring reserved buffers
-
-	numBuffers {
-		^numBuffers - 2
-	}
-
-	numBuffers_ { | argNumBuffers |
-		numBuffers = argNumBuffers + 2
 	}
 
 	asOptionsString { | port = 57110 |
 		var o;
-		o = if (protocol == \tcp, " -t ", " -u ");
+		o = if(protocol == \tcp, " -t ", " -u ");
 		o = o ++ port;
 
 		o = o ++ " -a " ++ (numPrivateAudioBusChannels + numInputBusChannels + numOutputBusChannels) ;
@@ -177,22 +170,22 @@ ServerOptions {
 		^this.primitiveFailed
 	}
 
-	numPrivateAudioBusChannels_ {arg numChannels = 112;
+	numPrivateAudioBusChannels_ { |numChannels = 112|
 		numPrivateAudioBusChannels = numChannels;
 		this.recalcChannels;
 	}
 
-	numAudioBusChannels_ {arg numChannels=1024;
+	numAudioBusChannels_ { |numChannels=1024|
 		numAudioBusChannels = numChannels;
 		numPrivateAudioBusChannels = numAudioBusChannels - numInputBusChannels - numOutputBusChannels;
 	}
 
-	numInputBusChannels_ {arg numChannels=8;
+	numInputBusChannels_ { |numChannels=8|
 		numInputBusChannels = numChannels;
 		this.recalcChannels;
 	}
 
-	numOutputBusChannels_ {arg numChannels=8;
+	numOutputBusChannels_ { |numChannels=8|
 		numOutputBusChannels = numChannels;
 		this.recalcChannels;
 	}
@@ -219,6 +212,7 @@ ServerOptions {
 		^this.prListDevices(0, 1);
 	}
 }
+
 
 ServerShmInterface {
 	// order matters!
@@ -264,67 +258,92 @@ ServerShmInterface {
 	}
 }
 
-Server {
-	classvar <>local, <>internal, <default, <>named, <>set, <>program, <>sync_s = true;
 
-	var <name, <>addr, <clientID, <userSpecifiedClientID = false;
+Server {
+
+	classvar <>local, <>internal, <default;
+	classvar <>named, <>all, <>program, <>sync_s = true;
+
+	var <name, <addr, <clientID, <userSpecifiedClientID = false;
 	var <isLocal, <inProcess, <>sendQuit, <>remoteControlled;
 
 	var <>options, <>latency = 0.2, <dumpMode = 0;
 
 	var <nodeAllocator, <controlBusAllocator, <audioBusAllocator, <bufferAllocator, <scopeBufferAllocator;
 
-	var <syncThread, <syncTasks;
-
 	var <>tree;
 
-	var <window, <>scopeWindow;
-	var <emacsbuf;
-	var recordBuf, <recordNode, <>recHeaderFormat="aiff", <>recSampleFormat="float";
-	var <>recChannels=2, <>recBufSize;
-
-	var <volume, <statusWatcher;
-
-	var <pid;
-	var serverInterface;
+	var <syncThread, <syncTasks;
+	var <window, <>scopeWindow, <emacsbuf;
+	var <volume, <recorder, <statusWatcher;
+	var <pid, serverInterface;
 
 
-	*default_ { |server|
-		default = server; // sync with s?
-		if (sync_s, { thisProcess.interpreter.s = server });
-		this.all.do(_.changed(\default, server));
+	*initClass {
+		Class.initClassTree(ServerOptions);
+		Class.initClassTree(NotificationCenter);
+		named = IdentityDictionary.new;
+		all = Set.new;
+		default = local = Server.new(\localhost, NetAddr("127.0.0.1", 57110));
+		internal = Server.new(\internal, NetAddr.new);
 	}
 
-	*new { arg name, addr, options, clientID;
+	*fromName { |name|
+		^Server.named[name] ?? {
+			Server(name, NetAddr.new("127.0.0.1", 57110), ServerOptions.new)
+		}
+	}
+
+	*default_ { |server|
+		default = server;
+		if(sync_s) { thisProcess.interpreter.s = server };  // sync with s?
+		this.all.do { |each| each.changed(\default, server) };
+	}
+
+	*new { |name, addr, options, clientID|
 		^super.new.init(name, addr, options, clientID)
 	}
 
-	*remote { arg name, addr, options, clientID;
+	*remote { |name, addr, options, clientID|
 		var result;
 		result = this.new(name, addr, options, clientID);
 		result.startAliveThread;
 		^result;
 	}
 
-	*all { ^set }
-	*all_ { arg dict; set = dict }
-
-	init { arg argName, argAddr, argOptions, argClientID;
-		name = argName.asSymbol;
-		addr = argAddr;
-		if(argClientID.notNil, { userSpecifiedClientID = true });
-		clientID = argClientID ? 0;
+	init { |argName, argAddr, argOptions, argClientID|
+		this.addr = argAddr;
 		options = argOptions ? ServerOptions.new;
-		if (addr.isNil, { addr = NetAddr("127.0.0.1", 57110) });
+		clientID = argClientID ? 0;
+		if(argClientID.notNil) { userSpecifiedClientID = true };
+
+		this.newAllocators;
+
+		statusWatcher = ServerStatusWatcher(server: this);
+		volume = Volume(server: this, persist: true);
+		recorder = Recorder(server: this);
+
+		this.name = argName;
+		all.add(this);
+
+		Server.changed(\serverAdded, this);
+
+	}
+
+	addr_ { |netAddr|
+		addr = netAddr ?? { NetAddr("127.0.0.1", 57110) };
 		inProcess = addr.addr == 0;
 		isLocal = inProcess || { addr.isLocal };
 		remoteControlled = isLocal;
-		statusWatcher = ServerStatusWatcher(this);
-		named.put(name, this);
-		set.add(this);
-		this.newAllocators;
-		Server.changed(\serverAdded, this);
-		volume = Volume.new(server: this, persist: true);
+	}
+
+	name_ { |argName|
+		name = argName.asSymbol;
+		if(named.at(argName).notNil) {
+			"Server name already exists: '%'. Please use a unique name".format(name, argName).warn;
+		} {
+			named.put(name, this);
+		}
 	}
 
 	initTree {
@@ -333,12 +352,20 @@ Server {
 		tree.value(this);
 		ServerTree.run(this);
 	}
+
+	/* id allocators */
+
 	clientID_ { |val|
-		if(val.notNil and: { clientID != val }) {
+		if(val.isInteger.not) {
+			"Server % couldn't set client id to: %".format(name, val.asCompileString).warn;
+			^this
+		};
+		if(clientID != val) {
 			clientID = val;
 			this.newAllocators;
 		}
 	}
+
 	newAllocators {
 		this.newNodeAllocators;
 		this.newBusAllocators;
@@ -348,7 +375,7 @@ Server {
 	}
 
 	newNodeAllocators {
-		nodeAllocator = NodeIDAllocator(clientID, options.initialNodeID);
+		nodeAllocator = NodeIDAllocator(clientID, options.initialNodeID)
 	}
 
 	newBusAllocators {
@@ -360,92 +387,98 @@ Server {
 		numControl = options.numControlBusChannels div: n;
 		numAudio = options.numPrivateAudioBusChannels div: n;
 
-		controlBusOffset = numControl * offset;
-		audioBusOffset = options.firstPrivateBus + (numAudio * offset);
+		controlBusOffset = numControl * offset + options.reservedNumControlBusChannels;
+		audioBusOffset = options.firstPrivateBus + (numAudio * offset) + options.reservedNumAudioBusChannels;
 
 		controlBusAllocator =
-				ContiguousBlockAllocator.new(
-					numControl + controlBusOffset,
-					controlBusOffset
-				);
+		ContiguousBlockAllocator.new(numControl, controlBusOffset);
+
 		audioBusAllocator =
-				ContiguousBlockAllocator.new(
-					numAudio + audioBusOffset,
-					audioBusOffset
-				);
+		ContiguousBlockAllocator.new(numAudio, audioBusOffset);
 	}
+
 
 	newBufferAllocators {
 		var bufferOffset;
 		var offset = this.calcOffset;
 		var n = options.maxLogins ? 1;
 		var numBuffers = options.numBuffers div: n;
-		bufferOffset = numBuffers * offset;
+		bufferOffset = numBuffers * offset + options.reservedNumBuffers;
 		bufferAllocator =
-				ContiguousBlockAllocator.new(
-					numBuffers + bufferOffset,
-					bufferOffset
-				);
+		ContiguousBlockAllocator.new(numBuffers, bufferOffset);
 	}
 
 	calcOffset {
-			if(options.maxLogins.isNil) { ^0 };
+		if(options.maxLogins.isNil) { ^0 };
 		if(clientID > (options.maxLogins - 1)) {
-					"Client ID exceeds maxLogins. Some buses and buffers may overlap for remote server: %".format(this).warn;
-			};
-			^clientID % options.maxLogins;
+			"Client ID exceeds maxLogins. Some buses and buffers may overlap for remote server: %".format(this).warn;
+		};
+		^clientID % options.maxLogins
 	}
 
 	newScopeBufferAllocators {
-		if (isLocal) {
-			scopeBufferAllocator = StackNumberAllocator.new(0, 127);
+		if(isLocal) {
+			scopeBufferAllocator = StackNumberAllocator.new(0, 127)
 		}
+	}
+
+	nextBufferNumber { |n|
+		var bufnum = bufferAllocator.alloc(n);
+		if(bufnum.isNil) {
+			if(n > 1) {
+				Error("No block of % consecutive buffer numbers is available.".format(n)).throw
+			} {
+				Error("No more buffer numbers -- free some buffers before allocating more.").throw
+			}
+		};
+		^bufnum
+	}
+
+	freeAllBuffers {
+		var bundle;
+		bufferAllocator.blocks.do { arg block;
+			(block.address .. block.address + block.size - 1).do { |i|
+				bundle = bundle.add( ["/b_free", i] );
+			};
+			bufferAllocator.free(block.address);
+		};
+		this.sendBundle(nil, *bundle);
 	}
 
 	nextNodeID {
 		^nodeAllocator.alloc
 	}
+
 	nextPermNodeID {
 		^nodeAllocator.allocPerm
 	}
+
 	freePermNodeID { |id|
 		^nodeAllocator.freePerm(id)
 	}
 
-	*initClass {
-		Class.initClassTree(ServerOptions);
-		Class.initClassTree(NotificationCenter);
-		named = IdentityDictionary.new;
-		set = Set.new;
-		default = local = Server.new(\localhost, NetAddr("127.0.0.1", 57110));
-		internal = Server.new(\internal, NetAddr.new);
+
+	/* network messages */
+
+	sendMsg { |... msg|
+		addr.sendMsg(*msg)
 	}
 
-	*fromName { arg name;
-		^Server.named[name] ?? {
-			Server(name, NetAddr.new("127.0.0.1", 57110), ServerOptions.new)
-		}
-	}
-
-	// bundling support added
-	sendMsg { arg ... msg;
-		addr.sendMsg(*msg);
-	}
-	sendBundle { arg time ... msgs;
+	sendBundle { |time ... msgs|
 		addr.sendBundle(time, *msgs)
 	}
 
-	sendRaw { arg rawArray;
-		addr.sendRaw(rawArray);
+	sendRaw { |rawArray|
+		addr.sendRaw(rawArray)
 	}
 
-	sendMsgSync { arg condition ... args;
+	sendMsgSync { |condition ... args|
 		var cmdName, resp;
-		if (condition.isNil) { condition = Condition.new };
+		if(condition.isNil) { condition = Condition.new };
 		cmdName = args[0].asString;
-		if (cmdName[0] != $/) { cmdName = cmdName.insert(0, $/) };
+		if(cmdName[0] != $/) { cmdName = cmdName.insert(0, $/) };
 		resp = OSCFunc({|msg|
-			if (msg[1].asString == cmdName) {
+			if(msg[1].asString == cmdName) {
 				resp.free;
 				condition.test = true;
 				condition.signal;
@@ -456,67 +489,112 @@ Server {
 		condition.wait;
 	}
 
-	sync { arg condition, bundles, latency; // array of bundles that cause async action
+	sync { |condition, bundles, latency| // array of bundles that cause async action
 		addr.sync(condition, bundles, latency)
 	}
 
-	schedSync { arg func;
+	schedSync { |func|
 		syncTasks = syncTasks.add(func);
 		if(syncThread.isNil) {
 			syncThread = Routine.run {
-				var c; c = Condition.new;
+				var c = Condition.new;
 				while { syncTasks.notEmpty } { syncTasks.removeAt(0).value(c) };
 				syncThread = nil;
-			};
-		};
-
+			}
+		}
 	}
 
-	// bundling support added
-	listSendMsg { arg msg;
-		addr.sendMsg(*msg);
+	listSendMsg { |msg|
+		addr.sendMsg(*msg)
 	}
-	listSendBundle { arg time, msgs;
-		addr.sendBundle(time, *(msgs.asArray));
+
+	listSendBundle { |time, msgs|
+		addr.sendBundle(time, *(msgs.asArray))
+	}
+
+	reorder { |nodeList, target, addAction=\addToHead|
+		target = target.asTarget;
+		this.sendMsg(62, Node.actionNumberFor(addAction), target.nodeID, *(nodeList.collect(_.nodeID))) //"/n_order"
 	}
 
 	// load from disk locally, send remote
-	sendSynthDef { arg name, dir;
+	sendSynthDef { |name, dir|
 		var file, buffer;
 		dir = dir ? SynthDef.synthDefDir;
 		file = File(dir ++ name ++ ".scsyndef","r");
-		if (file.isNil, { ^nil });
+		if(file.isNil) { ^nil };
 		protect {
 			buffer = Int8Array.newClear(file.length);
 			file.read(buffer);
-		}{
+		} {
 			file.close;
 		};
 		this.sendMsg("/d_recv", buffer);
 	}
+
 	// tell server to load from disk
-	loadSynthDef { arg name, completionMsg, dir;
+	loadSynthDef { |name, completionMsg, dir|
 		dir = dir ? SynthDef.synthDefDir;
 		this.listSendMsg(
 			["/d_load", dir ++ name ++ ".scsyndef", completionMsg ]
 		)
 	}
+
 	//loadDir
-	loadDirectory { arg dir, completionMsg;
-		this.listSendMsg(["/d_loadDir", dir, completionMsg]);
+	loadDirectory { |dir, completionMsg|
+		this.listSendMsg(["/d_loadDir", dir, completionMsg])
 	}
 
 
+	/* network message bundling */
 
-	wait { arg responseName;
-		var routine;
-		routine = thisThread;
+	openBundle { |bundle|	// pass in a bundle that you want to
+		// continue adding to, or nil for a new bundle.
+		if(addr.hasBundle) {
+			bundle = addr.bundle.addAll(bundle);
+			addr.bundle = []; // debatable
+		};
+		addr = BundleNetAddr.copyFrom(addr, bundle);
+	}
+
+	closeBundle { |time| // set time to false if you don't want to send.
+		var bundle;
+		if(addr.hasBundle) {
+			bundle = addr.closeBundle(time);
+			addr = addr.saveAddr;
+		} {
+			"there is no open bundle.".warn
+		};
+		^bundle;
+	}
+
+	makeBundle { |time, func, bundle|
+		this.openBundle(bundle);
+		try {
+			func.value(this);
+			bundle = this.closeBundle(time);
+		} {|error|
+			addr = addr.saveAddr; // on error restore the normal NetAddr
+			error.throw
+		}
+		^bundle
+	}
+
+	bind { |func|
+		^this.makeBundle(this.latency, func)
+	}
+
+
+	/* scheduling */
+
+	wait { |responseName|
+		var routine = thisThread;
 		OSCFunc({
-			routine.resume(true);
+			routine.resume(true)
 		}, responseName, addr).oneShot;
 	}
 
-	waitForBoot { arg onComplete, limit=100, onFailure;
+	waitForBoot { |onComplete, limit = 100, onFailure|
 		// onFailure.true: why is this necessary?
 		// this.boot also calls doWhenBooted.
 		// doWhenBooted prints the normal boot failure message.
@@ -526,57 +604,95 @@ Server {
 		this.doWhenBooted(onComplete, limit, onFailure);
 	}
 
-	doWhenBooted { arg onComplete, limit=100, onFailure;
+	doWhenBooted { |onComplete, limit=100, onFailure|
 		statusWatcher.doWhenBooted(onComplete, limit, onFailure)
 	}
 
+	ifRunning { |func, failFunc|
+		^if(statusWatcher.unresponsive) {
+			"server '%' not responsive".format(this.name).inform;
+			failFunc.value(this)
+		} {
+			if(statusWatcher.serverRunning) {
+				func.value(this)
+			} {
+				"server '%' not running".format(this.name).inform;
+				failFunc.value(this)
+			}
+		}
 
-	bootSync { arg condition;
+	}
+
+	ifNotRunning { |func|
+		^ifRunning(this, nil, func)
+	}
+
+
+	bootSync { |condition|
 		condition ?? { condition = Condition.new };
 		condition.test = false;
-		this.waitForBoot({
+		this.waitForBoot {
 			// Setting func to true indicates that our condition has become true and we can go when signaled.
 			condition.test = true;
 			condition.signal
-		});
+		};
 		condition.wait;
 	}
 
-	ping { arg n=1, wait=0.1, func;
-		var result=0, pingFunc;
-		if(statusWatcher.serverRunning.not) { "server not running".postln; ^this };
+
+	ping { |n = 1, wait = 0.1, func|
+		var result = 0, pingFunc;
+		if(statusWatcher.serverRunning.not) { "server not running".inform; ^this };
 		pingFunc = {
 			Routine.run {
-					var t, dt;
-					t = Main.elapsedTime;
-					this.sync;
-					dt = Main.elapsedTime - t;
-					("measured latency:" + dt + "s").postln;
-					result = max(result, dt);
-					n = n - 1;
-					if(n > 0) {
-						SystemClock.sched(wait, {pingFunc.value; nil })
-					} {
-						("maximum determined latency of" + name + ":" + result + "s").postln;
-						func.value(result)
-					}
-				};
+				var t, dt;
+				t = Main.elapsedTime;
+				this.sync;
+				dt = Main.elapsedTime - t;
+				("measured latency:" + dt + "s").postln;
+				result = max(result, dt);
+				n = n - 1;
+				if(n > 0) {
+					SystemClock.sched(wait, { pingFunc.value; nil })
+				} {
+					("maximum determined latency of" + name + ":" + result + "s").postln;
+					func.value(result)
+				}
+			};
 		};
 		pingFunc.value;
 	}
 
+	cachedBuffersDo { |func|
+		Buffer.cachedBuffersDo(this, func)
+	}
 
-	cachedBuffersDo { |func| Buffer.cachedBuffersDo(this, func) }
-	cachedBufferAt { |bufnum| ^Buffer.cachedBufferAt(this, bufnum) }
+	cachedBufferAt { |bufnum|
+		^Buffer.cachedBufferAt(this, bufnum)
+	}
+
+	defaultGroup {
+		^Group.basicNew(this, 1)
+	}
 
 	inputBus {
-		^Bus(\audio, this.options.numOutputBusChannels, this.options.numInputBusChannels, this);
+		^Bus(\audio, this.options.numOutputBusChannels, this.options.numInputBusChannels, this)
 	}
 
 	outputBus {
-		^Bus(\audio, 0, this.options.numOutputBusChannels, this);
+		^Bus(\audio, 0, this.options.numOutputBusChannels, this)
 	}
 
+	/* recording formats */
+
+	recHeaderFormat { ^options.recHeaderFormat }
+	recHeaderFormat_ { |string| options.recHeaderFormat_(string) }
+	recSampleFormat { ^options.recSampleFormat }
+	recSampleFormat_ { |string| options.recSampleFormat_(string) }
+	recChannels { ^options.recChannels }
+	recChannels_ { |n| options.recChannels_(n) }
+	recBufSize { ^options.recBufSize }
+	recBufSize_ { |n| options.recBufSize_(n) }
 
 	/* server status */
 
@@ -591,189 +707,167 @@ Server {
 	serverRunning { ^statusWatcher.serverRunning }
 	serverBooting { ^statusWatcher.serverBooting }
 	unresponsive { ^statusWatcher.unresponsive }
-
-	startAliveThread { | delay=0.0 |
-		statusWatcher.startAliveThread(delay)
-	}
-	stopAliveThread {
-		statusWatcher.stopAliveThread
-	}
-	aliveThreadIsRunning {
-		^statusWatcher.aliveThread.isPlaying
-	}
-
-	aliveThreadPeriod_ { |val|
-		statusWatcher.aliveThreadPeriod_(val)
-	}
-	aliveThreadPeriod { |val|
-		^statusWatcher.aliveThreadPeriod
-	}
-
-
+	startAliveThread { | delay=0.0 | statusWatcher.startAliveThread(delay) }
+	stopAliveThread { statusWatcher.stopAliveThread }
+	aliveThreadIsRunning { ^statusWatcher.aliveThread.isPlaying }
+	aliveThreadPeriod_ { |val| statusWatcher.aliveThreadPeriod_(val) }
+	aliveThreadPeriod { |val| ^statusWatcher.aliveThreadPeriod }
 
 	disconnectSharedMemory {
-		if (serverInterface.notNil) {
+		if(this.hasShmInterface) {
 			"server '%' disconnected shared memory interface\n".postf(name);
 			serverInterface.disconnect;
 			serverInterface = nil;
 		}
 	}
 
-
-	*resumeThreads {
-		set.do { |server| server.statusWatcher.resumeThread }
+	connectSharedMemory {
+		var id;
+		if(this.isLocal) {
+			this.disconnectSharedMemory;
+			id = if(this.inProcess) { thisProcess.pid } { addr.port };
+			serverInterface = ServerShmInterface(id);
+		}
 	}
 
-	boot { | startAliveThread=true, recover=false, onFailure |
+	hasShmInterface { ^serverInterface.notNil }
 
-		if (statusWatcher.serverRunning) { "server already running".inform; ^this };
-		if (statusWatcher.serverBooting) { "server already booting".inform; ^this };
+	*resumeThreads {
+		all.do { |server| server.statusWatcher.resumeThread }
+	}
+
+	boot { | startAliveThread = true, recover = false, onFailure |
+
+		if(statusWatcher.unresponsive) {
+			"server '%' unresponsive, rebooting ...".format(this.name).inform;
+			this.quit(watchShutDown: false)
+		};
+		if(statusWatcher.serverRunning) { "server '%' already running".format(this.name).inform; ^this };
+		if(statusWatcher.serverBooting) { "server '%' already booting".format(this.name).inform; ^this };
+
 
 		statusWatcher.serverBooting = true;
 
-		if(startAliveThread) { statusWatcher.startAliveThread };
-		if(recover) { this.newNodeAllocators } { this.newAllocators };
-
-		statusWatcher.bootNotifyFirst = true; // unclear what this means.
 		statusWatcher.doWhenBooted({
 			statusWatcher.serverBooting = false;
-			if (recChannels.notNil and: (recChannels != options.numOutputBusChannels)) {
-				"Resetting recChannels to %".format(options.numOutputBusChannels).inform
-			};
-			recChannels = options.numOutputBusChannels;
-
-			if(sendQuit.isNil) {
-				sendQuit = this.inProcess or: {this.isLocal};
-			};
-
-			if(this.inProcess) {
-				serverInterface = ServerShmInterface(thisProcess.pid);
-			} {
-				if(isLocal) {
-					serverInterface = ServerShmInterface(addr.port);
-				}
-			};
-			if(dumpMode != 0) { this.sendMsg(\dumpOSC, dumpMode) };
-			this.initTree;
+			this.bootInit(recover);
 		}, onFailure: onFailure ? false);
 
 		if(remoteControlled.not) {
 			"You will have to manually boot remote server.".inform;
 		} {
-			this.bootServerApp;
+			this.bootServerApp({
+				if(startAliveThread) { statusWatcher.startAliveThread }
+			})
 		}
 	}
 
-	bootServerApp {
-		var f;
-		if (inProcess) {
+	bootInit { | recover = false |
+		if(recover) { this.newNodeAllocators } { this.newAllocators };
+		if(dumpMode != 0) { this.sendMsg(\dumpOSC, dumpMode) };
+		if(sendQuit.isNil) {
+			sendQuit = this.inProcess or: { this.isLocal };
+		};
+		this.connectSharedMemory;
+		this.initTree;
+	}
+
+	bootServerApp { |onComplete|
+		if(inProcess) {
 			"booting internal".inform;
 			this.bootInProcess;
 			pid = thisProcess.pid;
 		} {
 			this.disconnectSharedMemory;
-
 			pid = (program ++ options.asOptionsString(addr.port)).unixCmd;
-			if( options.protocol == \tcp ){
-				f = {
-					|attempts|
-					attempts = attempts - 1;
-					try { addr.connect } {
-						|err|
-						if (err.isKindOf(PrimitiveFailedError) and: { err.failedPrimitiveName == '_NetAddr_Connect'}) {
-							if(attempts > 0){
-								0.2.wait;
-								f.value(attempts)
-							}{
-								"Couldn't connect to server % via TCP\n".postf(this.name);
-							}
-						} {
-							err.throw;
-						}
-					}
-				};
-				fork{ f.(10) }
-			};
-			("booting " ++ addr.port.asString).inform;
-		};
-	}
-
-	reboot { arg func; // func is evaluated when server is off
-		if (isLocal.not) { "can't reboot a remote server".inform; ^this };
-		if(statusWatcher.serverRunning) {
-			Routine.run {
-				this.quit;
-				this.wait(\done);
-				0.1.wait;
-				func.value;
-				defer { this.boot }
-			}
-		} {
-			func.value;
-			this.boot
+			("booting server '%' on address: %:%").format(this.name, addr.hostname, addr.port.asString).inform;
+			if(options.protocol == \tcp, { addr.tryConnectTCP(onComplete) }, onComplete);
 		}
 	}
 
+	reboot { |func, onFailure| // func is evaluated when server is off
+		if(isLocal.not) { "can't reboot a remote server".inform; ^this };
+		if(statusWatcher.serverRunning) {
+			this.quit({
+				func.value;
+				defer { this.boot }
+			}, onFailure);
+		} {
+			func.value;
+			this.boot(onFailure: onFailure);
+		}
+	}
+
+	applicationRunning {
+		^pid.tryPerform(\pidRunning) == true
+	}
+
 	status {
+		addr.sendStatusMsg // backward compatibility
+	}
+
+	sendStatusMsg {
 		addr.sendStatusMsg
 	}
 
 	notify {
 		^statusWatcher.notify
 	}
+
 	notify_ { |flag|
 		statusWatcher.notify_(flag)
 	}
+
 	notified {
 		^statusWatcher.notified
 	}
 
-
-	dumpOSC { arg code=1;
+	dumpOSC { |code = 1|
 		/*
-			0 - turn dumping OFF.
-			1 - print the parsed contents of the message.
-			2 - print the contents in hexadecimal.
-			3 - print both the parsed and hexadecimal representations of the contents.
+		0 - turn dumping OFF.
+		1 - print the parsed contents of the message.
+		2 - print the contents in hexadecimal.
+		3 - print both the parsed and hexadecimal representations of the contents.
 		*/
 		dumpMode = code;
 		this.sendMsg(\dumpOSC, code);
 		this.changed(\dumpOSC, code);
 	}
 
-	quit { |watchShutDown = true|
+	quit { |onComplete, onFailure, watchShutDown = true|
+		var func;
 
 		addr.sendMsg("/quit");
+		if(options.protocol == \tcp) {
+			statusWatcher.quit({ addr.tryDisconnectTCP(onComplete, onFailure) }, nil, watchShutDown);
+		} {
+			statusWatcher.quit(onComplete, onFailure, watchShutDown);
+		};
 
-		statusWatcher.quit(watchShutDown);
-
-		if( options.protocol == \tcp ){ fork{ 0.1.wait; addr.disconnect } }; // sure? can we receive the above reply?
-
-		if (inProcess, {
+		if(inProcess) {
 			this.quitInProcess;
 			"quit done\n".inform;
-		},{
-			"/quit sent\n".inform;
-		});
+		} {
+			"'/quit' sent\n".inform;
+		};
 
 		pid = nil;
 		sendQuit = nil;
 
 		if(scopeWindow.notNil) { scopeWindow.quit };
-		if(volume.isPlaying) {
-			volume.free
-		};
+		if(volume.isPlaying) { volume.free };
 		RootNode(this).freeAll;
 		this.newAllocators;
 	}
 
 	*quitAll { |watchShutDown = true|
-		set.do({ arg server;
-			if (server.sendQuit === true) {
-				server.quit(watchShutDown)
-			};
-		})
+		all.do { |server|
+			if(server.sendQuit === true) {
+				server.quit(watchShutDown: watchShutDown)
+			}
+		}
 	}
+
 	*killAll {
 		// if you see Exception in World_OpenUDP: unable to bind udp socket
 		// its because you have multiple servers running, left
@@ -782,34 +876,35 @@ Server {
 
 		// this brutally kills them all off
 		thisProcess.platform.killAll(this.program.basename);
-		this.quitAll(false);
+		this.quitAll(watchShutDown: false);
 	}
+
 	freeAll {
 		this.sendMsg("/g_freeAll", 0);
 		this.sendMsg("/clearSched");
 		this.initTree;
 	}
 
-	*freeAll { arg evenRemote = false;
-		if (evenRemote) {
-			set.do { arg server;
-				if ( server.serverRunning ) { server.freeAll }
+	*freeAll { |evenRemote = false|
+		if(evenRemote) {
+			all.do { |server|
+				if( server.serverRunning ) { server.freeAll }
 			}
 		} {
-			set.do { arg server;
-				if (server.isLocal and:{ server.serverRunning }) { server.freeAll }
+			all.do { |server|
+				if(server.isLocal and:{ server.serverRunning }) { server.freeAll }
 			}
 		}
 	}
 
-	*hardFreeAll { arg evenRemote = false;
-		if (evenRemote) {
-			set.do { arg server;
+	*hardFreeAll { |evenRemote = false|
+		if(evenRemote) {
+			all.do { |server|
 				server.freeAll
 			}
 		} {
-			set.do { arg server;
-				if (server.isLocal) { server.freeAll }
+			all.do { |server|
+				if(server.isLocal) { server.freeAll }
 			}
 		}
 	}
@@ -818,43 +913,35 @@ Server {
 		^this.all.select(_.serverRunning)
 	}
 
-	// bundling support
+	/* volume control */
 
-
-	openBundle { arg bundle;	// pass in a bundle that you want to
-							// continue adding to, or nil for a new bundle.
-		if(addr.hasBundle) {
-			bundle = addr.bundle.addAll(bundle);
-			addr.bundle = []; // debatable
-		};
-		addr = BundleNetAddr.copyFrom(addr, bundle);
-	}
-	closeBundle { arg time; // set time to false if you don't want to send.
-		var bundle;
-		if(addr.hasBundle) {
-			bundle = addr.closeBundle(time);
-			addr = addr.saveAddr;
-		} {
-			"there is no open bundle.".warn
-		};
-		^bundle;
-	}
-	makeBundle { arg time, func, bundle;
-		this.openBundle(bundle);
-		try {
-			func.value(this);
-			bundle = this.closeBundle(time);
-		}{|error|
-			addr = addr.saveAddr; // on error restore the normal NetAddr
-			error.throw
-		}
-		^bundle
-	}
-	bind { arg func;
-		^this.makeBundle(this.latency, func)
+	volume_ { | newVolume |
+		volume.volume_(newVolume)
 	}
 
-	// internal server commands
+	mute {
+		volume.mute
+	}
+
+	unmute {
+		volume.unmute
+	}
+
+	/* recording output */
+
+	record { |path, bus, numChannels, node, duration| recorder.record(path, bus, numChannels, node, duration) }
+	isRecording { ^recorder.isRecording }
+	pauseRecording { recorder.pauseRecording }
+	stopRecording { recorder.stopRecording }
+	prepareForRecord { |path, numChannels| recorder.prepareForRecord(path, numChannels) }
+
+	recordNode {
+		this.deprecated(thisMethod);
+		^recorder.recordNode
+	}
+
+	/* internal server commands */
+
 	bootInProcess {
 		^options.bootInProcess;
 	}
@@ -862,160 +949,95 @@ Server {
 		_QuitInProcessServer
 		^this.primitiveFailed
 	}
-	allocSharedControls { arg numControls=1024;
+	allocSharedControls { |numControls=1024|
 		_AllocSharedControls
 		^this.primitiveFailed
 	}
-	setSharedControl { arg num, value;
+	setSharedControl { |num, value|
 		_SetSharedControl
 		^this.primitiveFailed
 	}
-	getSharedControl { arg num;
+	getSharedControl { |num|
 		_GetSharedControl
 		^this.primitiveFailed
 	}
 
-	// recording output
-	record { |path|
-		if(recordBuf.isNil) {
-			this.prepareForRecord(path);
-			Routine({
-				this.sync;
-				this.record;
-			}).play;
-		} {
-			if(this.isRecording.not) {
-				recordNode = Synth.tail(RootNode(this), "server-record",
-						[\bufnum, recordBuf.bufnum]);
-				CmdPeriod.doOnce {
-					recordNode = nil;
-					if (recordBuf.notNil) { recordBuf.close {|buf| buf.freeMsg }; recordBuf = nil; };
-				}
-			} {
-				recordNode.run(true)
-			};
-			"Recording: %\n".postf(recordBuf.path);
-		};
-	}
 
-	isRecording {
-		^recordNode.isPlaying
-	}
+	/* CmdPeriod support for Server-scope and Server-record and Server-volume */
 
-	pauseRecording {
-		recordNode.notNil.if({ recordNode.run(false); "Paused".postln }, { "Not Recording".warn });
-	}
-
-	stopRecording {
-		if(recordNode.notNil) {
-			recordNode.free;
-			recordNode = nil;
-			recordBuf.close({ |buf| buf.freeMsg });
-			"Recording Stopped: %\n".postf(recordBuf.path);
-			recordBuf = nil;
-		} {
-			"Not Recording".warn
-		};
-	}
-
-	prepareForRecord { arg path;
-		if (path.isNil) {
-			if(File.exists(thisProcess.platform.recordingsDir).not) {
-				thisProcess.platform.recordingsDir.mkdir
-			};
-
-			// temporary kludge to fix Date's brokenness on windows
-			if(thisProcess.platform.name == \windows) {
-				path = thisProcess.platform.recordingsDir +/+ "SC_" ++ Main.elapsedTime.round(0.01) ++ "." ++ recHeaderFormat;
-
-			} {
-				path = thisProcess.platform.recordingsDir +/+ "SC_" ++ Date.localtime.stamp ++ "." ++ recHeaderFormat;
-			};
-		};
-		recordBuf = Buffer.alloc(this, recBufSize ?? { this.sampleRate.nextPowerOfTwo }, recChannels,
-			{arg buf; buf.writeMsg(path, recHeaderFormat, recSampleFormat, 0, 0, true);},
-			this.options.numBuffers + 1); // prevent buffer conflicts by using reserved bufnum
-		recordBuf.path = path;
-		SynthDef("server-record", { arg bufnum;
-			DiskOut.ar(bufnum, In.ar(0, recChannels))
-		}).send(this);
-	}
-
-	// CmdPeriod support for Server-scope and Server-record and Server-volume
 	cmdPeriod {
 		addr = addr.recover;
-		this.changed(\cmdPeriod);
+		this.changed(\cmdPeriod)
 	}
 
-	doOnServerTree {
-		if(scopeWindow.notNil) { scopeWindow.run }
-	}
-
-	defaultGroup { ^Group.basicNew(this, 1) }
-
-	queryAllNodes { arg queryControls = false;
+	queryAllNodes { | queryControls = false |
 		var resp, done = false;
-		if(isLocal, {this.sendMsg("/g_dumpTree", 0, queryControls.binaryValue);}, {
-			resp = OSCFunc({ arg msg;
+		if(isLocal) {
+			this.sendMsg("/g_dumpTree", 0, queryControls.binaryValue)
+		} {
+			resp = OSCFunc({ |msg|
 				var i = 2, tabs = 0, printControls = false, dumpFunc;
-				if(msg[1] != 0, {printControls = true});
+				if(msg[1] != 0) { printControls = true };
 				("NODE TREE Group" + msg[2]).postln;
-				if(msg[3] > 0, {
+				if(msg[3] > 0) {
 					dumpFunc = {|numChildren|
 						var j;
 						tabs = tabs + 1;
-						numChildren.do({
-							if(msg[i + 1] >=0, {i = i + 2}, {
-								i = i + 3 + if(printControls, {msg[i + 3] * 2 + 1}, {0});
-							});
-							tabs.do({ "   ".post });
+						numChildren.do {
+							if(msg[i + 1] >= 0) { i = i + 2 } {
+								i = i + 3 + if(printControls) { msg[i + 3] * 2 + 1 } { 0 };
+							};
+							tabs.do { "   ".post };
 							msg[i].post; // nodeID
-							if(msg[i + 1] >=0, {
+							if(msg[i + 1] >= 0) {
 								" group".postln;
-								if(msg[i + 1] > 0, { dumpFunc.value(msg[i + 1]) });
-							}, {
+								if(msg[i + 1] > 0) { dumpFunc.value(msg[i + 1]) };
+							} {
 								(" " ++ msg[i + 2]).postln; // defname
-								if(printControls, {
-									if(msg[i + 3] > 0, {
+								if(printControls) {
+									if(msg[i + 3] > 0) {
 										" ".post;
-										tabs.do({ "   ".post });
-									});
+										tabs.do { "   ".post };
+									};
 									j = 0;
-									msg[i + 3].do({
+									msg[i + 3].do {
 										" ".post;
-										if(msg[i + 4 + j].isMemberOf(Symbol), {
+										if(msg[i + 4 + j].isMemberOf(Symbol)) {
 											(msg[i + 4 + j] ++ ": ").post;
-										});
+										};
 										msg[i + 5 + j].post;
 										j = j + 2;
-									});
+									};
 									"\n".post;
-								});
-							});
-						});
+								}
+							}
+						};
 						tabs = tabs - 1;
 					};
 					dumpFunc.value(msg[3]);
-				});
+				};
 				done = true;
 			}, '/g_queryTree.reply', addr).oneShot;
+
 			this.sendMsg("/g_queryTree", 0, queryControls.binaryValue);
 			SystemClock.sched(3, {
-				done.not.if({
+				if(done.not) {
 					resp.free;
 					"Remote server failed to respond to queryAllNodes!".warn;
-				});
-			});
-		})
+				};
+			})
+		}
 	}
+
 	printOn { |stream|
 		stream << name;
 	}
-	storeOn { arg stream;
-		var codeStr = this.switch (
-			Server.default, 			{ if (sync_s) { "s" } { "Server.default" } },
-			Server.local,				{ "Server.local" },
-			Server.internal,			{ "Server.internal" },
+
+	storeOn { |stream|
+		var codeStr = switch(this,
+			Server.default, { if(sync_s) { "s" } { "Server.default" } },
+			Server.local,	{ "Server.local" },
+			Server.internal, { "Server.internal" },
 			{ "Server.fromName(" + name.asCompileString + ")" }
 		);
 		stream << codeStr;
@@ -1024,27 +1046,8 @@ Server {
 	archiveAsCompileString { ^true }
 	archiveAsObject { ^true }
 
-	volume_ {arg newVolume;
-		volume.volume_(newVolume);
-	}
-
-	mute {
-		volume.mute;
-	}
-
-	unmute {
-		volume.unmute;
-	}
-
-	hasShmInterface { ^serverInterface.notNil }
-
-	reorder { arg nodeList, target, addAction=\addToHead;
-		target = target.asTarget;
-		this.sendMsg(62, Node.actionNumberFor(addAction), target.nodeID, *(nodeList.collect(_.nodeID))); //"/n_order"
-	}
-
 	getControlBusValue {|busIndex|
-		if (serverInterface.isNil) {
+		if(serverInterface.isNil) {
 			Error("Server-getControlBusValue only supports local servers").throw;
 		} {
 			^serverInterface.getControlBusValue(busIndex)
@@ -1052,7 +1055,7 @@ Server {
 	}
 
 	getControlBusValues {|busIndex, busChannels|
-		if (serverInterface.isNil) {
+		if(serverInterface.isNil) {
 			Error("Server-getControlBusValues only supports local servers").throw;
 		} {
 			^serverInterface.getControlBusValues(busIndex, busChannels)
@@ -1060,7 +1063,7 @@ Server {
 	}
 
 	setControlBusValue {|busIndex, value|
-		if (serverInterface.isNil) {
+		if(serverInterface.isNil) {
 			Error("Server-getControlBusValue only supports local servers").throw;
 		} {
 			^serverInterface.setControlBusValue(busIndex, value)
@@ -1068,7 +1071,7 @@ Server {
 	}
 
 	setControlBusValues {|busIndex, valueArray|
-		if (serverInterface.isNil) {
+		if(serverInterface.isNil) {
 			Error("Server-getControlBusValues only supports local servers").throw;
 		} {
 			^serverInterface.setControlBusValues(busIndex, valueArray)
@@ -1082,4 +1085,17 @@ Server {
 	*supernova {
 		this.program = this.program.replace("scsynth", "supernova")
 	}
+
+	/* backward compatibility */
+
+	*set {
+		this.deprecated(thisMethod, this.class.findMethod('all'));
+		^all
+	}
+
+	*set_ { |item|
+		this.deprecated(thisMethod, this.class.findMethod('all_'));
+		all = item
+	}
+
 }

--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -787,7 +787,7 @@ Server {
 
 	reboot { |func, onFailure| // func is evaluated when server is off
 		if(isLocal.not) { "can't reboot a remote server".inform; ^this };
-		if(statusWatcher.serverRunning) {
+		if(statusWatcher.serverRunning and: { this.unresponsive.not }) {
 			this.quit({
 				func.value;
 				defer { this.boot }
@@ -838,6 +838,12 @@ Server {
 		var func;
 
 		addr.sendMsg("/quit");
+
+		if(watchShutDown and: { this.unresponsive }) {
+			"Server '%' was unresponsive. Quitting anyway.".format(name).postln;
+			watchShutDown = false;
+		};
+
 		if(options.protocol == \tcp) {
 			statusWatcher.quit({ addr.tryDisconnectTCP(onComplete, onFailure) }, nil, watchShutDown);
 		} {

--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -779,7 +779,7 @@ Server {
 			pid = thisProcess.pid;
 		} {
 			this.disconnectSharedMemory;
-			pid = (program ++ options.asOptionsString(addr.port)).unixCmd;
+			pid = unixCmd(program ++ options.asOptionsString(addr.port), { statusWatcher.quit(watchShutDown:false) });
 			("booting server '%' on address: %:%").format(this.name, addr.hostname, addr.port.asString).inform;
 			if(options.protocol == \tcp, { addr.tryConnectTCP(onComplete) }, onComplete);
 		}

--- a/SCClassLibrary/Common/Control/ServerStatus.sc
+++ b/SCClassLibrary/Common/Control/ServerStatus.sc
@@ -111,10 +111,14 @@ ServerStatusWatcher {
 
 				AppClock.sched(3.0, {
 					if(serverReallyQuit.not) {
-						"Server '%' failed to quit after 3.0 seconds.".format(server.name).warn;
+						if(unresponsive) {
+							"Server '%' remained unresponsive during quit."
+						} {
+							"Server '%' failed to quit after 3.0 seconds."
+						}.format(server.name).warn;
 						// don't accumulate quit-watchers if /done doesn't come back
 						serverReallyQuitWatcher.free;
-						statusWatcher.disable;
+						statusWatcher !? { statusWatcher.disable };
 						onFailure.value(server)
 					}
 				})
@@ -143,7 +147,7 @@ ServerStatusWatcher {
 	}
 
 	stopStatusWatcher {
-		statusWatcher.disable;
+		statusWatcher !? { statusWatcher.disable }
 	}
 
 	startAliveThread { | delay = 0.0 |
@@ -184,7 +188,7 @@ ServerStatusWatcher {
 
 		if(running != serverRunning) {
 			serverRunning = running;
-			unresponsive = false;
+			this.unresponsive = false;
 
 			if (server.serverRunning) {
 				ServerBoot.run(server);

--- a/SCClassLibrary/Common/Control/ServerStatus.sc
+++ b/SCClassLibrary/Common/Control/ServerStatus.sc
@@ -46,8 +46,12 @@ ServerStatusWatcher {
 				failOSCFunc.free;
 			}, '/done', server.addr, argTemplate:['/notify', nil]).oneShot;
 
-			failOSCFunc = OSCFunc({|msg|
-				server.clientID = msg[2];
+			failOSCFunc = OSCFunc({|msg, time, replyAddr|
+				if(flag) {
+					"failed to switch on notifications from server. Please reboot the server '%'".format(server.name).warn;
+				} {
+					"failed to switch off notifications from server '%'.".format(server.name).warn;
+				};
 				doneOSCFunc.free;
 			}, '/fail', server.addr, argTemplate:['/notify', nil, nil]).oneShot;
 

--- a/SCClassLibrary/Common/Control/ServerStatus.sc
+++ b/SCClassLibrary/Common/Control/ServerStatus.sc
@@ -46,12 +46,8 @@ ServerStatusWatcher {
 				failOSCFunc.free;
 			}, '/done', server.addr, argTemplate:['/notify', nil]).oneShot;
 
-			failOSCFunc = OSCFunc({|msg, time, replyAddr|
-				if(flag) {
-					"failed to switch on notifications from server. Please reboot the server '%'".format(server.name).warn;
-				} {
-					"failed to switch off notifications from server '%'.".format(server.name).warn;
-				};
+			failOSCFunc = OSCFunc({|msg|
+				server.clientID = msg[2];
 				doneOSCFunc.free;
 			}, '/fail', server.addr, argTemplate:['/notify', nil, nil]).oneShot;
 

--- a/SCClassLibrary/Common/Control/ServerStatus.sc
+++ b/SCClassLibrary/Common/Control/ServerStatus.sc
@@ -47,8 +47,10 @@ ServerStatusWatcher {
 			}, '/done', server.addr, argTemplate:['/notify', nil]).oneShot;
 
 			failOSCFunc = OSCFunc({|msg|
-				server.clientID = msg[2];
 				doneOSCFunc.free;
+				Error(
+					"Failed to register with server '%' for notifications: %\n"
+					"To recover, please reboot the server.".format(server.name, msg)).throw;
 			}, '/fail', server.addr, argTemplate:['/notify', nil, nil]).oneShot;
 
 		};

--- a/SCClassLibrary/Common/Control/ServerStatus.sc
+++ b/SCClassLibrary/Common/Control/ServerStatus.sc
@@ -11,43 +11,34 @@ ServerStatusWatcher {
 	var <avgCPU, <peakCPU;
 	var <sampleRate, <actualSampleRate;
 
-	var reallyDeadCount = 0;
-	var <>bootNotifyFirst;
-
+	var reallyDeadCount = 0, bootNotifyFirst = true;
 
 	*new { |server|
 		^super.newCopyArgs(server)
 	}
 
-	quit { |watchShutDown = true|
+	quit { |onComplete, onFailure, watchShutDown = true|
 		if(watchShutDown) {
-			this.watchQuit
+			this.watchQuit(onComplete, onFailure)
 		} {
-			this.stopStatusWatcher
+			this.stopStatusWatcher;
+			onComplete.value;
 		};
 		this.stopAliveThread;
 		notified = false;
 		serverBooting = false;
 		this.serverRunning = false;
+		bootNotifyFirst = true;
 	}
 
 	notify_ { |flag = true|
 		notify = flag;
-		if(flag){
-			if(serverRunning){
-				this.sendNotifyRequest(true);
-				notified = true;
-				"Receiving notification messages from server %\n".postf(server.name);
-			}
-		}{
-			this.sendNotifyRequest(false);
-			notified = false;
-			"Switched off notification messages from server %\n".postf(server.name);
-		}
+		this.sendNotifyRequest(flag);
 	}
 
-	sendNotifyRequest { | flag=true |
+	sendNotifyRequest { |flag = true|
 		var doneOSCFunc, failOSCFunc;
+		if(serverRunning.not) { ^this };
 		notified = flag;
 		if(server.userSpecifiedClientID.not) {
 			doneOSCFunc = OSCFunc({|msg|
@@ -62,63 +53,71 @@ ServerStatusWatcher {
 
 		};
 
+		if(flag){
+			"Receiving notification messages from server '%'\n".postf(server.name)
+		} {
+			"Switched off notification messages from server '%'\n".postf(server.name);
+		};
 		server.sendMsg("/notify", flag.binaryValue);
 	}
 
-	doWhenBooted { arg onComplete, limit=100, onFailure;
+	doWhenBooted { |onComplete, limit = 100, onFailure|
 		var mBootNotifyFirst = bootNotifyFirst, postError = true;
 		bootNotifyFirst = false;
 
 		^Routine {
 			while {
-				((serverRunning.not
-					or: (serverBooting and: mBootNotifyFirst.not))
-				and: { (limit = limit - 1) > 0 })
-				and: { server.pid.tryPerform(\pidRunning) == true }
+				serverRunning.not
+				/*
+				// this is not yet implemented.
+				or: { serverBooting and: mBootNotifyFirst.not }
+				and: { (limit = limit - 1) > 0 }
+				and: { server.applicationRunning.not }
+				*/
+
 			} {
 				0.2.wait;
 			};
-
 			if(serverRunning.not, {
 				if(onFailure.notNil) {
-					postError = (onFailure.value == false);
+					postError = (onFailure.value(server) == false);
 				};
 				if(postError) {
-					"server failed to start".error;
-					"For advice: [http://supercollider.github.io/tutorials/server-failed-to-start]".postln;
+					"Server '%' on failed to start. You may need to kill all servers".format(server.name).error;
 				};
 				serverBooting = false;
 				server.changed(\serverRunning);
 			}, onComplete);
-		}.play(AppClock);
+
+		}.play(AppClock)
 	}
 
 
-	watchQuit {
+	watchQuit { |onComplete, onFailure|
 		var	serverReallyQuitWatcher, serverReallyQuit = false;
 		statusWatcher !? {
 			statusWatcher.disable;
 			if(notified) {
 				serverReallyQuitWatcher = OSCFunc({ |msg|
 					if(msg[1] == '/quit') {
-						if (statusWatcher.notNil) {
-							statusWatcher.enable;
-						};
+						statusWatcher !? { statusWatcher.enable };
 						serverReallyQuit = true;
 						serverReallyQuitWatcher.free;
-					};
+						onComplete.value;
+					}
 				}, '/done', server.addr);
 
 				AppClock.sched(3.0, {
 					if(serverReallyQuit.not) {
-						"Server % failed to quit after 3.0 seconds.".format(server.name).warn;
+						"Server '%' failed to quit after 3.0 seconds.".format(server.name).warn;
 						// don't accumulate quit-watchers if /done doesn't come back
 						serverReallyQuitWatcher.free;
 						statusWatcher.disable;
-					};
-				});
-			};
-		};
+						onFailure.value(server)
+					}
+				})
+			}
+		}
 	}
 
 
@@ -127,19 +126,13 @@ ServerStatusWatcher {
 			statusWatcher =
 			OSCFunc({ arg msg;
 				var cmd, one;
-				if(notify){
-					if(notified.not){
-						this.sendNotifyRequest;
-						"Receiving notification messages from server %\n".postf(server.name);
-					}
-				};
+				if(notify and: { notified.not }) { this.sendNotifyRequest };
 				alive = true;
 				#cmd, one, numUGens, numSynths, numGroups, numSynthDefs,
 						avgCPU, peakCPU, sampleRate, actualSampleRate = msg;
 				{
 					this.updateRunningState(true);
 					server.changed(\counts);
-					nil // no resched
 				}.defer;
 			}, '/status.reply', server.addr).fix;
 		} {
@@ -151,17 +144,17 @@ ServerStatusWatcher {
 		statusWatcher.disable;
 	}
 
-	startAliveThread { | delay=0.0 |
+	startAliveThread { | delay = 0.0 |
 		this.addStatusWatcher;
 		^aliveThread ?? {
 			aliveThread = Routine {
 				// this thread polls the server to see if it is alive
 				delay.wait;
 				loop {
-					server.status;
+					alive = false;
+					server.sendStatusMsg;
 					aliveThreadPeriod.wait;
 					this.updateRunningState(alive);
-					alive = false;
 				};
 			}.play(AppClock);
 			aliveThread
@@ -185,11 +178,10 @@ ServerStatusWatcher {
 		}
 	}
 
+	serverRunning_ { | running |
 
-	serverRunning_ { | val |
-
-		if(val != serverRunning) {
-			serverRunning = val;
+		if(running != serverRunning) {
+			serverRunning = running;
 			unresponsive = false;
 
 			if (server.serverRunning) {
@@ -200,7 +192,8 @@ ServerStatusWatcher {
 				server.disconnectSharedMemory;
 				if(server.isRecording) { server.stopRecording };
 
-				NotificationCenter.notify(server, \didQuit);
+				{ server.changed(\didQuit) }.defer;
+				NotificationCenter.notify(server, \didQuit); // why here "NotificationCenter" and below "changed"?
 
 				if(server.isLocal.not) {
 					notified = false;
@@ -211,26 +204,27 @@ ServerStatusWatcher {
 
 	}
 
-	updateRunningState { | val |
+	updateRunningState { | running |
 		if(server.addr.hasBundle) {
 			{ server.changed(\bundling) }.defer;
 		} {
-			if(val) {
+			if(running) {
 				this.serverRunning = true;
 				this.unresponsive = false;
 				reallyDeadCount = server.options.pingsBeforeConsideredDead;
 			} {
+				// parrot
 				reallyDeadCount = reallyDeadCount - 1;
 				this.unresponsive = (reallyDeadCount <= 0);
 			}
 		}
 	}
 
-
-	unresponsive_ { arg val;
+	unresponsive_ { | val |
 		if (val != unresponsive) {
 			unresponsive = val;
 			{ server.changed(\serverRunning) }.defer;
 		}
 	}
+
 }

--- a/SCClassLibrary/Common/Control/SystemActions.sc
+++ b/SCClassLibrary/Common/Control/SystemActions.sc
@@ -43,7 +43,6 @@ CmdPeriod : AbstractSystemAction {
 		if(clearClocks, {
 			SystemClock.clear;
 			AppClock.clear;
-	//		TempoClock.default.clear;
 		});
 
 		objects.copy.do({ arg item; item.doOnCmdPeriod;  });

--- a/SCClassLibrary/Common/Control/Volume.sc
+++ b/SCClassLibrary/Common/Control/Volume.sc
@@ -1,173 +1,169 @@
 Volume {
-	var startBus, numChans, <min, <max, server, persist, <ampSynth, <>window, <volume, spec;
-	var <lag, sdname, gui = false, cpFun, updateSynth, <isMuted=false;
-	var <synthNumChans;	// the actual number of channels, which might be set automatically
-	var sdInitialized;
 
-	*new { arg server, startBus = 0, numChans, min = -90, max = 6, persist = false;
-		^super.newCopyArgs(startBus, numChans, min, max, server, persist).initVolume;
+	var <server, <startBus, numChannels, <min, <max, <persist;
+
+	var <volume = 0.0, <lag = 0.1, <isMuted = false;
+
+	var ampSynth, defName, updateFunc, initFunc;
+	var <>window;
+
+	*new { | server, startBus = 0, numChannels, min = -90, max = 6, persist = false |
+		^super.newCopyArgs(server ?? { Server.default }, startBus, numChannels, min, max, persist).init;
 	}
 
-	initVolume {
-		var cond;
-		server = server ?? {Server.default};
-		volume = 0;
-		lag = 0.1;
-		gui = false;
-		updateSynth = {
-			var amp = if (isMuted.not) { volume.dbamp } { 0.0 };
-			var active = amp != 1.0;
-			if (active) {
-				if(server.serverRunning) {
-					if (ampSynth.isNil) {
-						ampSynth = Synth.after(server.defaultGroup, sdname,
-							[\volumeAmp, amp, \volumeLag, lag, \bus, startBus]);
-					}{
-						ampSynth.set(\volumeAmp, amp);
-					}
-				}
-			}{
-				if (ampSynth.notNil) { ampSynth.release; ampSynth = nil }
-			}
-		};
-
-		sdInitialized = Condition();
-		if (server.serverRunning) {
-			this.sendSynthDef
-		} {
-			ServerBoot.add ({
+	init {
+		if(server.serverRunning) { this.sendSynthDef };
+		if(initFunc.isNil) {
+			ServerBoot.add(initFunc = {
 				ampSynth = nil;
 				this.sendSynthDef;
 			}, server)
-		};
-	}
-
-	sendSynthDef {
-		if(numChans.isNil) {
-			synthNumChans = server.options.numOutputBusChannels;
-		} {
-			synthNumChans = numChans;
-		};
-
-		sdname = (\volumeAmpControl ++ synthNumChans).asSymbol;
-
-		sdInitialized = Condition();
-
-		SynthDef(sdname,
-			{ arg volumeAmp = 1, volumeLag = 0.1, gate=1, bus;
-				XOut.ar(bus,
-					Linen.kr(gate, releaseTime: 0.05, doneAction:2),
-					In.ar(bus, synthNumChans) * Lag.kr(volumeAmp, volumeLag) );
-		}).send(server);
-
-		fork {
-			server.sync(sdInitialized);
-			if (cpFun.isNil) {
-				ServerTree.add(cpFun = {
-					ampSynth = nil;
-					if (persist) { updateSynth.value; }
-				});
-			};
 		}
 	}
 
-	numChans { ^numChans ? synthNumChans ? server.options.numOutputBusChannels }
-	numChans_ { |num|
-		if(ampSynth.notNil and: { num != synthNumChans }) {
+	sendSynthDef {
+
+		forkIfNeeded {
+			var synthNumChans = this.numChannels;
+			defName = (\volumeAmpControl ++ synthNumChans).asSymbol;
+			SynthDef(defName, { | volumeAmp = 1, volumeLag = 0.1, gate=1, bus |
+					XOut.ar(bus,
+						Linen.kr(gate, releaseTime: 0.05, doneAction:2),
+						In.ar(bus, synthNumChans) * Lag.kr(volumeAmp, volumeLag)
+					);
+			}).send(server);
+
+			server.sync;
+
+			if(updateFunc.isNil) {
+				ServerTree.add(updateFunc = {
+					ampSynth = nil;
+					if(persist) { this.updateSynth }
+				})
+			}
+		}
+	}
+
+	numChannels { ^numChannels ? server.options.numOutputBusChannels }
+	numChannels_ { |num|
+		if(ampSynth.notNil and: { num != this.numChannels }) {
 			"Change in number of channels will not take effect until volume is reset to 0dB.".warn;
 		};
-		numChans = num;
+		numChannels = num;
+	}
+
+	updateSynth {
+		var amp = if(isMuted.not) { volume.dbamp } { 0.0 };
+		var active = amp != 1.0;
+		if(active) {
+			if(server.serverRunning) {
+				if(ampSynth.isNil) {
+					ampSynth = Synth.after(server.defaultGroup, defName,
+						[\volumeAmp, amp, \volumeLag, lag, \bus, startBus])
+				} {
+					ampSynth.set(\volumeAmp, amp);
+				}
+			}
+		} {
+			if(ampSynth.notNil) { ampSynth.release; ampSynth = nil }
+		}
 	}
 
 	mute {
-		if (isMuted.not) {
+		if(isMuted.not) {
 			isMuted = true;
 			this.changed(\mute, true);
-			updateSynth.value;
+			this.updateSynth;
 		}
 	}
 
 	unmute {
-		if (isMuted) {
+		if(isMuted) {
 			isMuted = false;
 			this.changed(\mute, false);
-			updateSynth.value;
+			this.updateSynth;
 		}
 	}
 
 	// sets volume back to 1 - removes the synth
 	reset {
 		isMuted = false;
-		volume = 0.0;
-		updateSynth.value;
+		this.volume = 0.0;
 	}
 
-	// cleaner with MVC - in db
-	volume_ { arg aVolume;
+	volume_ { | aVolume |
 		volume = aVolume.clip(min, max);
 		this.changed(\amp, volume);
-		updateSynth.value;
+		this.updateSynth;
 	}
 
-	lag_ { arg aLagTime;
+	lag_ { | aLagTime |
 		lag = aLagTime;
-		if (ampSynth.notNil) { ampSynth.set(\volumeLag, lag) };
+		if(ampSynth.notNil) { ampSynth.set(\volumeLag, lag) }
 	}
 
-	setVolumeRange { arg argMin, argMax;
+	setVolumeRange { | argMin, argMax |
 		var clippedVolume;
 		argMin !? { min = argMin };
 		argMax !? { max = argMax };
 		this.changed(\ampRange, min, max);
 		clippedVolume = volume.clip(min, max);
-		if (clippedVolume != volume) { this.volume_(clippedVolume) }
+		if(clippedVolume != volume) { this.volume_(clippedVolume) }
 	}
 
 
-	gui { arg window, bounds;
-		//		this.debug(\gui);
+	gui { | window, bounds |
 		^VolumeGui(this, window, bounds)
 	}
 
 	close {
 		window.close;
 	}
+
+	/* deprecated */
+
+	numChans { ^this.deprecated(thisMethod, this.class.findMethod(\numChannels)) }
+	numChans_ { ^this.deprecated(thisMethod, this.class.findMethod(\numChannels)) }
+
 }
 
-VolumeGui{
-	var <>model;
-	var window, spec, slider, box, simpleController;
+VolumeGui {
 
-	*new{|model, win, bounds|
-		^super.new.model_(model).init(win, bounds)
+	var <model, <window;
+
+	*new { | model, win, bounds |
+		^super.newCopyArgs(model).init(win, bounds)
 	}
 
-	init{|win, bounds|
-		spec = [model.min, model.max, \db].asSpec;
-		bounds = bounds ?? {Rect(100, 100, 80, 330)};
-		window = win ?? {GUI.window.new("Volume", bounds).front};
-		box = GUI.numberBox.new(window, Rect(10, 10, 60, 30))
-		.value_(model.volume) ;
-		slider = GUI.slider.new(window, Rect(10, 40, 60, 280))
-		.value_(spec.unmap(model.volume)) ;
-		slider.action_({ arg item ;
+	init { | win, bounds |
+		var slider, box, simpleController;
+		var spec = [model.min, model.max, \db].asSpec;
+		bounds = bounds ?? { Rect(100, 100, 80, 330) };
+		window = win ?? { Window.new("Volume", bounds).front };
+		box = NumberBox(window, Rect(10, 10, 60, 30))
+		.value_(model.volume);
+
+		slider = Slider(window, Rect(10, 40, 60, 280))
+		.value_(spec.unmap(model.volume));
+
+		slider.action_({ | item |
 			model.volume_(spec.map(item.value));
-		}) ;
-		box.action_({ arg item ;
-			model.volume_(item.value) ;
-		}) ;
+		});
+		box.action_({ | item |
+			model.volume_(item.value);
+		});
 		window.onClose_({
 			simpleController.remove;
 		});
+
 		simpleController = SimpleController(model)
 		.put(\amp, {|changer, what, volume|
-			this.debug(volume);
-			box.value_(volume.round(0.01)) ;
-			slider.value_(spec.unmap(volume)) ;
+			box.value_(volume.round(0.01));
+			slider.value_(spec.unmap(volume));
 		})
 		.put(\ampRange, {|changer, what, min, max|
 			spec = [min, max, \db].asSpec.debug;
-			slider.value_(spec.unmap(model.volume)) ;
+			slider.value_(spec.unmap(model.volume));
 		})
 	}
 }

--- a/SCClassLibrary/Common/GUI/PlusGUI/Control/ServerPlusGUI.sc
+++ b/SCClassLibrary/Common/GUI/PlusGUI/Control/ServerPlusGUI.sc
@@ -13,7 +13,7 @@
 
 	calculateViewBounds {
 		var width = 288, height = 98, taskBarHeight = 27; // the latter should be in SCWindow
-		var keys = set.asArray.collect(_.name).sort;
+		var keys = all.asArray.collect(_.name).sort;
 		^Rect(5, keys.indexOf(name) * (height + taskBarHeight) + 5, width, height)
 	}
 
@@ -308,8 +308,7 @@
 					if (unicode == 16rF701, { slider.decrement; });
 					if (unicode == 16rF702, { slider.decrement; });
 					nil;
-					})
-					;
+					});
 			volController = SimpleController(volume)
 				.put(\amp, {|changer, what, vol|
 					{
@@ -332,7 +331,7 @@
 
 		w.front;
 
-		serverStatusController = SimpleController(statusWatcher)
+		serverController = SimpleController(this)
 			.put(\serverRunning, {	if(this.serverRunning, running, stopped) })
 			.put(\counts,{
 				countsViews.at(0).string = statusWatcher.avgCPU.round(0.1);
@@ -341,9 +340,7 @@
 				countsViews.at(3).string = statusWatcher.numSynths;
 				countsViews.at(4).string = statusWatcher.numGroups;
 				countsViews.at(5).string = statusWatcher.numSynthDefs;
-			});
-
-		serverController = SimpleController(this)
+			})
 			.put(\bundling, bundling)
 			.put(\default, showDefault);
 		if(isLocal){

--- a/SCClassLibrary/Common/GUI/PlusGUI/Control/server-scope.sc
+++ b/SCClassLibrary/Common/GUI/PlusGUI/Control/server-scope.sc
@@ -7,7 +7,6 @@
 				this.options.numBuffers);
 				// prevent buffer conflicts by using reserved bufnum
 			scopeWindow.window.onClose = scopeWindow.window.onClose.addFunc({ scopeWindow = nil });
-			ServerTree.add(this, this);
 		} {
 			scopeWindow.setProperties(numChannels, index, bufsize, zoom, rate);
 			scopeWindow.run;

--- a/SCClassLibrary/scide_scqt/ScIDE.sc
+++ b/SCClassLibrary/scide_scqt/ScIDE.sc
@@ -425,7 +425,7 @@ ScIDE {
 		defer {
 			this.prSend(id, data)
 		}
-    }
+	}
 
 
 	// PRIVATE ///////////////////////////////////////////////////////////
@@ -626,7 +626,7 @@ Document {
 
 	close { ScIDE.close(quuid); }
 
-/*	// asynchronous get
+	/*	// asynchronous get
 	// range -1 means to the end of the Document
 	getText {|action, start = 0, range -1|
 		var funcID;
@@ -818,7 +818,7 @@ Document {
 
 	string { | rangestart, rangesize = 1 |
 		if(rangestart.isNil,{
-		^this.text;
+			^this.text;
 		});
 		^this.rangeText(rangestart, rangesize);
 	}

--- a/SCClassLibrary/scide_scqt/ScIDE.sc
+++ b/SCClassLibrary/scide_scqt/ScIDE.sc
@@ -12,9 +12,9 @@ ScIDE {
 		Class.initClassTree(Server);
 
 		StartUp.add {
-			if (ScIDE.connected) {
+			if (this.connected) {
 				this.handshake
-			};
+			}
 		}
 	}
 
@@ -42,6 +42,18 @@ ScIDE {
 		.put(\default, { | server, what, newServer |
 			("changed default server to:" + newServer.name).postln;
 			this.defaultServer = newServer;
+		})
+		.put(\dumpOSC, { | server, what, code |
+			this.send( if(code.asBoolean, \dumpOSCStarted, \dumpOSCStopped) );
+		})
+		.put(\recording, { | theChanger, what, flag |
+			this.send( if(flag.asBoolean, \recordingStarted, \recordingStopped) );
+		})
+		.put(\pausedRecording, { | theChanger, what |
+			this.send(\recordingPaused);
+		})
+		.put(\recordingDuration, { | theChanger, what, duration |
+			this.send(\recordingDuration, duration.asString);
 		})
 		.put(\dumpOSC, { | volume, what, code |
 			this.send( if(code.asBoolean, \dumpOSCStarted, \dumpOSCStopped) );
@@ -413,8 +425,7 @@ ScIDE {
 		defer {
 			this.prSend(id, data)
 		}
-	}
-
+    }
 
 
 	// PRIVATE ///////////////////////////////////////////////////////////

--- a/editors/sc-ide/core/sc_server.cpp
+++ b/editors/sc-ide/core/sc_server.cpp
@@ -51,9 +51,6 @@ ScServer::ScServer(ScProcess *scLang, Settings::Manager *settings, QObject *pare
     mUdpSocket = new QUdpSocket(this);
     startTimer(333);
 
-    mRecordTimer.setInterval(1000);
-    connect( &mRecordTimer, SIGNAL(timeout()), this, SLOT(updateRecordingAction()) );
-
     connect(scLang, SIGNAL(stateChanged(QProcess::ProcessState)),
             this, SLOT(onScLangStateChanged(QProcess::ProcessState)));
     connect(scLang, SIGNAL(response(QString,QString)),
@@ -162,10 +159,18 @@ void ScServer::createActions(Settings::Manager * settings)
     connect(action, SIGNAL(triggered()), this, SLOT(restoreVolume()));
     settings->addAction( action, "synth-server-volume-restore", synthServerCategory);
 
-    mActions[Record] = action = new QAction(this);
+    mActions[Record] = action = new QAction(tr("Recording"), this);
     action->setCheckable(true);
-    connect( action, SIGNAL(triggered(bool)), this, SLOT(setRecording(bool)) );
+    connect( action, SIGNAL(triggered(bool)), this, SLOT(sendRecording(bool)) );
     connect( action, SIGNAL(toggled(bool)), this, SIGNAL(recordingChanged(bool)) );
+    settings->addAction( action, "synth-server-record", synthServerCategory);
+
+    mActions[PauseRecord] = action = new QAction(tr("Pause Recording"), this);
+    action->setCheckable(true);
+    connect( action, SIGNAL(triggered(bool)), this, SLOT(pauseRecording(bool)) );
+    connect( action, SIGNAL(toggled(bool)), this, SLOT(pauseChanged(bool)) );
+    settings->addAction( action, "synth-server-pause-recording", synthServerCategory);
+
 
     connect( mActions[Boot], SIGNAL(changed()), this, SLOT(updateToggleRunningAction()) );
     connect( mActions[Quit], SIGNAL(changed()), this, SLOT(updateToggleRunningAction()) );
@@ -334,56 +339,66 @@ void ScServer::sendVolume( float volume )
 }
 
 bool ScServer::isRecording() const { return mIsRecording; }
+bool ScServer::isPaused() const { return mIsRecordingPaused; }
+
+
 
 void ScServer::setRecording( bool doRecord )
+    {
+        if (!isRunning())
+            return;
+
+        mIsRecording = doRecord;
+        mIsRecordingPaused = false;
+        updateRecordingAction();
+}
+
+void ScServer::pauseRecording( bool flag )
+    {
+        if(mIsRecordingPaused != flag) {
+            mIsRecordingPaused = flag;
+            if(flag) {
+                mLang->evaluateCode( QStringLiteral("ScIDE.defaultServer.pauseRecording"), true );
+            } else {
+                if(mIsRecording) {
+                setRecording(true);
+                sendRecording(true);
+               }
+            }
+            updateRecordingAction();
+        }
+}
+
+
+void ScServer::sendRecording( bool doRecord )
 {
     static const QString startRecordingCommand("ScIDE.defaultServer.record");
     static const QString stopRecordingCommand("ScIDE.defaultServer.stopRecording");
-
-    if (!isRunning() || mIsRecording == doRecord)
-        return;
-
-    mIsRecording = doRecord;
-
-    if (doRecord) {
-        mLang->evaluateCode( startRecordingCommand );
-        mRecordTime = system_clock::now();
-        mRecordTimer.start();
-    }
-    else {
-        mLang->evaluateCode( stopRecordingCommand );
-        mRecordTimer.stop();
-    }
-
-    updateRecordingAction();
+    setRecording(doRecord);
+    mLang->evaluateCode(doRecord ? startRecordingCommand : stopRecordingCommand);
 }
 
-seconds ScServer::recordingTime() const
-{
-    if (isRecording())
-        return duration_cast<seconds>( system_clock::now() - mRecordTime );
-    else
-        return seconds(0);
-}
 
 void ScServer::updateRecordingAction()
 {
     if (isRecording()) {
-        seconds time = recordingTime();
-        hours h = duration_cast<hours>(time);
-        minutes m = duration_cast<minutes>(time - h);
-        seconds s = (time - m);
+        int s = mRecordingSeconds % 60;
+        int m = mRecordingSeconds / 60 % 60;
+        int h = mRecordingSeconds / 3600;
         ostringstream msg;
         msg << "Recording: ";
-        msg << setw(2) << setfill('0') << h.count() << ':';
-        msg << setw(2) << setfill('0') << m.count() << ':';
-        msg << setw(2) << setfill('0') << s.count();
+        msg << setw(2) << setfill('0') << h << ':';
+        msg << setw(2) << setfill('0') << m << ':';
+        msg << setw(2) << setfill('0') << s;
         mActions[Record]->setText( msg.str().c_str() );
     }
     else {
+        mRecordingSeconds = 0;
         mActions[Record]->setText( "Start Recording" );
+        mIsRecordingPaused = false;
     }
     mActions[Record]->setChecked( isRecording() );
+    mActions[PauseRecord]->setChecked( mIsRecordingPaused );
 }
 
 void ScServer::onScLangStateChanged( QProcess::ProcessState )
@@ -400,7 +415,10 @@ void ScServer::onScLangReponse( const QString & selector, const QString & data )
     static QString ampRangeSelector("serverAmpRange");
     static QString startDumpOSCSelector("dumpOSCStarted");
     static QString stopDumpOSCSelector("dumpOSCStopped");
-
+    static QString startRecordingSelector("recordingStarted");
+    static QString pauseRecordingSelector("recordingPaused");
+    static QString stopRecordingSelector("recordingStopped");
+    static QString recordingDurationSelector("recordingDuration");
 
     if (selector == defaultServerRunningChangedSelector)
         handleRuningStateChangedMsg(data);
@@ -414,6 +432,26 @@ void ScServer::onScLangReponse( const QString & selector, const QString & data )
     }
     else if (selector == stopDumpOSCSelector) {
         mActions[DumpOSC]->setChecked(false);
+    }
+	else if (selector == recordingDurationSelector) {
+        bool ok;
+        float duration = data.mid(1, data.size() - 2).toFloat(&ok);
+        if (ok) {
+            mRecordingSeconds = (int) duration;
+            updateRecordingAction();
+        }
+    }
+    else if (selector == startRecordingSelector) {
+        setRecording(true);
+    }
+    else if (selector == startRecordingSelector) {
+        setRecording(true);
+    }
+    else if (selector == pauseRecordingSelector) {
+        pauseRecording(true);
+    }
+    else if (selector == stopRecordingSelector) {
+        setRecording(false);
     }
     else if (selector == ampSelector) {
         bool ok;
@@ -445,8 +483,10 @@ void ScServer::handleRuningStateChangedMsg( const QString & data )
     YAML::Parser parser(stream);
 
     bool serverRunningState, serverUnresponsive;
+
     std::string hostName;
     int port;
+
 
     YAML::Node doc;
     while(parser.GetNextDocument(doc)) {
@@ -497,7 +537,6 @@ void ScServer::onRunningStateChanged( bool running, QString const & hostName, in
         mServerAddress.clear();
         mPort = 0;
         mIsRecording = false;
-        mRecordTimer.stop();
         mUdpSocket->disconnectFromHost();
     }
 
@@ -584,6 +623,7 @@ void ScServer::updateEnabledActions()
     mActions[Volume]->setEnabled(langAndServerRunning);
     mActions[VolumeRestore]->setEnabled(langAndServerRunning);
     mActions[Record]->setEnabled(langAndServerRunning);
+    mActions[PauseRecord]->setEnabled(langAndServerRunning);
     mActions[DumpOSC]->setEnabled(langAndServerRunning);
 }
 

--- a/editors/sc-ide/core/sc_server.hpp
+++ b/editors/sc-ide/core/sc_server.hpp
@@ -60,6 +60,7 @@ public:
         VolumeDown,
         VolumeRestore,
         Record,
+        PauseRecord,
 
         ActionCount
     };
@@ -83,7 +84,9 @@ public:
     void setDumpingOSC( bool dumping );
 
     bool isRecording() const;
-    boost::chrono::seconds recordingTime() const;
+    bool isPaused() const;
+
+    int recordingTime() const;
 
 public slots:
     void boot();
@@ -104,17 +107,21 @@ public slots:
     void restoreVolume();
     void mute() { setMuted(true); }
     void unmute() { setMuted(false); }
+    void sendRecording( bool active );
     void setRecording( bool active );
+    void pauseRecording( bool flag );
 
 signals:
-    void runningStateChanged( bool running, QString const & hostName, int port, bool unresponsive );
-    void updateServerStatus (int ugenCount, int synthCount,
+	void runningStateChanged( bool running, QString const & hostName, int port, bool unresponsive );
+	void updateServerStatus (int ugenCount, int synthCount,
                              int groupCount, int defCount,
                              float avgCPU, float peakCPU);
     void volumeChanged( float volume );
     void volumeRangeChanged( float min, float max);
     void mutedChanged( bool muted );
     void recordingChanged( bool recording );
+    void pauseChanged( bool paused );
+
 
 private slots:
     void onScLangStateChanged( QProcess::ProcessState );
@@ -169,9 +176,9 @@ private:
 
     float mVolume = 0, mVolumeMin = -90, mVolumeMax = 6;
     VolumeWidget *mVolumeWidget;
-    QTimer mRecordTimer;
-    boost::chrono::system_clock::time_point mRecordTime;
+    int mRecordingSeconds;
     bool mIsRecording;
+    bool mIsRecordingPaused;
 };
 
 }

--- a/editors/sc-ide/widgets/audio_status_box.cpp
+++ b/editors/sc-ide/widgets/audio_status_box.cpp
@@ -47,6 +47,7 @@ AudioStatusBox::AudioStatusBox(ScServer *server, QWidget *parent):
     setLayout(layout);
 
     server->action(ScServer::Record)->setProperty("keep_menu_open", true);
+    server->action(ScServer::PauseRecord)->setProperty("keep_menu_open", true);
     server->action(ScServer::VolumeRestore)->setProperty("keep_menu_open", true);
     server->action(ScServer::Mute)->setProperty("keep_menu_open", true);
     server->action(ScServer::DumpOSC)->setProperty("keep_menu_open", true);
@@ -64,6 +65,7 @@ AudioStatusBox::AudioStatusBox(ScServer *server, QWidget *parent):
     addAction( server->action(ScServer::DumpOSC) );
     addActionSeparator();
     addAction( server->action(ScServer::Record) );
+	addAction( server->action(ScServer::PauseRecord) );
     addActionSeparator();
     addAction( server->action(ScServer::VolumeRestore) );
     addAction( server->action(ScServer::Mute) );
@@ -95,6 +97,7 @@ AudioStatusBox::AudioStatusBox(ScServer *server, QWidget *parent):
 
 void AudioStatusBox::onServerRunningChanged(bool running, const QString &, int, bool unresponsive)
 {
+
     if (unresponsive) {
         mStatisticsLabel->setTextColor(Qt::yellow);
         mVolumeLabel->setTextColor(Qt::yellow);
@@ -105,9 +108,9 @@ void AudioStatusBox::onServerRunningChanged(bool running, const QString &, int, 
         mStatisticsLabel->setTextColor(Qt::white);
         mVolumeLabel->setTextColor(Qt::white);
     };
-
-    if (!running)
+	if (!running) {
         updateStatistics(0, 0, 0, 0, 0, 0);
+	}
 }
 
 void AudioStatusBox::wheelEvent(QWheelEvent * event)
@@ -150,5 +153,6 @@ void AudioStatusBox::updateRecordLabel( bool recording )
 {
     mRecordLabel->setTextColor( recording ? Qt::red : QColor(30,30,30) );
 }
+
 
 } // namespace ScIDE

--- a/editors/sc-ide/widgets/main_window.cpp
+++ b/editors/sc-ide/widgets/main_window.cpp
@@ -660,6 +660,8 @@ void MainWindow::createMenus()
     menu->addAction( mMain->scServer()->action(ScServer::DumpNodeTreeWithControls) );
     menu->addAction( mMain->scServer()->action(ScServer::PlotTree) );
     menu->addAction( mMain->scServer()->action(ScServer::DumpOSC) );
+    menu->addAction( mMain->scServer()->action(ScServer::Record) );
+    menu->addAction( mMain->scServer()->action(ScServer::PauseRecord) );
     menu->addAction( mMain->scServer()->action(ScServer::VolumeUp) );
     menu->addAction( mMain->scServer()->action(ScServer::VolumeDown) );
     menu->addAction( mMain->scServer()->action(ScServer::VolumeRestore) );


### PR DESCRIPTION
Another PR on top of #2422. This follows @snappizz remark in the discussion that we get a notification from a killed process in sclang (thanks!).

I have tested this in some combinations, please have a look for side effects.

in terminal, call:
`killall scsynth`

this should now properly quit the server representation in sclang.

(again, only the last commit in this branch is relevant)