### PR TITLE
BusPlug fading to number

### DIFF
--- a/SCClassLibrary/Common/Audio/SystemSynthDefs.sc
+++ b/SCClassLibrary/Common/Audio/SystemSynthDefs.sc
@@ -39,10 +39,18 @@ SystemSynthDefs {
 					DiskOut.ar(i_bufNum, InFeedback.ar(i_in, i));
 				}).add;
 
-				SynthDef("system_setbus_audio_" ++ i, { arg out = 0, fadeTime = 0, curve = 0, gate = 1;
+				SynthDef("system_setbus_hold_audio_" ++ i, { arg out = 0, fadeTime = 0, curve = 0, gate = 1;
 					var values = NamedControl.ir(\values, 0 ! i);
 					var env = Env([In.ar(out, i), values, values], [1, 0], curve, 1);
 					var sig = EnvGen.ar(env, gate + Impulse.kr(0), timeScale: fadeTime, doneAction: 2);
+					ReplaceOut.ar(out, sig);
+				}, [\ir, \kr, \ir, \kr]).add;
+
+				SynthDef("system_setbus_audio_" ++ i, { arg out = 0, fadeTime = 0, curve = 0, gate = 1;
+					var values = NamedControl.ir(\values, 0 ! i);
+					var env = Env([-1, 1, 1, -1], [1, 0, 1], curve, 1);
+					var envgen = EnvGen.kr(env, gate + Impulse.kr(0), timeScale: fadeTime, doneAction: 2);
+					var sig = LinXFade2.ar(In.ar(out, i), DC.ar(values), envgen);
 					ReplaceOut.ar(out, sig);
 				}, [\ir, \kr, \ir, \kr]).add;
 

--- a/SCClassLibrary/Common/Collections/Event.sc
+++ b/SCClassLibrary/Common/Collections/Event.sc
@@ -708,7 +708,12 @@ Event : Environment {
 							).throw;
 						};
 						if (~id.isNil) { ~id = server.nextNodeID };
-						instrument = "system_setbus_%_%".format(~rate.value ? \control, numChannels);
+						// the instrumentType can be system_setbus or system_setbus_hold
+						instrument = format(
+							if(~hold != true) { "system_setbus_%_%" } { "system_setbus_hold_%_%" },
+							~rate.value ? \control,
+							numChannels
+						);
 						// addToTail, so that old bus value can be overridden:
 						bundle = [9, instrument, ~id, 1, ~group.asControlInput,
 							"values", array,

--- a/SCClassLibrary/JITLib/ProxySpace/wrapForNodeProxy.sc
+++ b/SCClassLibrary/JITLib/ProxySpace/wrapForNodeProxy.sc
@@ -96,12 +96,13 @@
 			channelOffset: channelOffset,
 			finish: #{
 				var proxy = ~proxy;
+				~array = ~array.wrapExtend(proxy.numChannels);
 				~out = proxy.index + ~channelOffset;
 				~group = proxy.group;
 				~rate = proxy.rate;
 				~numChannels = proxy.numChannels;
 				~fadeTime = proxy.fadeTime;
-				~curve = proxy.nodeMap.at(\curve);
+				~curve = proxy.nodeMap.at(\curve) ? 1.0;
 			}
 		)
 	}


### PR DESCRIPTION
This is a (minor) API change in the `setBus` event: it holds previous bus values only when `~hold = true`.

