### PR TITLE
Fix mingw gcc-6.2 ICE.

### DIFF
--- a/common/SC_Win32Utils.h
+++ b/common/SC_Win32Utils.h
@@ -51,6 +51,7 @@
 #define pipe win32_pipe
 
 #if _MSC_VER
+typedef int pid_t;
 #define snprintf _snprintf
 #endif
 

--- a/common/SC_Win32Utils.h
+++ b/common/SC_Win32Utils.h
@@ -49,7 +49,6 @@
 #define basename win32_basename
 #define dirname win32_dirname
 #define pipe win32_pipe
-typedef int pid_t;
 
 #if _MSC_VER
 #define snprintf _snprintf

--- a/external_libraries/boost/boost/thread/executors/basic_thread_pool.hpp
+++ b/external_libraries/boost/boost/thread/executors/basic_thread_pool.hpp
@@ -137,7 +137,12 @@ namespace executors
         for (unsigned i = 0; i < thread_count; ++i)
         {
 #if 1
+#ifndef __MINGW32__
           thread th (&basic_thread_pool::worker_thread, this);
+#else
+          auto worker = [=](){this->worker_thread();};
+          thread th (worker);
+#endif
           threads.push_back(thread_t(boost::move(th)));
 #else
           threads.push_back(thread_t(&basic_thread_pool::worker_thread, this)); // do not compile

--- a/lang/LangSource/GC.cpp
+++ b/lang/LangSource/GC.cpp
@@ -1033,7 +1033,7 @@ bool PyrGC::BlackToWhiteCheck(PyrObject *objA)
 			if (IsObj(slot) && slotRawObject(slot)) {
 				objB = slotRawObject(slot);
 			}
-			if (objB && (unsigned long)objB < 100) {
+			if (objB && (uintptr_t)objB < 100) {
 				fprintf(stderr, "weird obj ptr\n");
 				return false;
 			}
@@ -1277,5 +1277,3 @@ void PyrGC::throwMemfailed(size_t inNumBytes)
 	post("alloc failed. size = %d\n", inNumBytes);
 	MEMFAILED;
 }
-
-


### PR DESCRIPTION
This fixes [mingw gcc-4.9+ ICE](https://gist.github.com/bagong/0084f016cb80e61e0949c0f5b0f130a6)

I can now build HEAD supercollider with stock MSYS2 64-bit gcc compiler/libraries (no manual tools/libraries installation).

Perhaps, this should be submitted to `boost` in the first place, though.

I've also guarded this with `__MINGW32__` since I'm not sure if another platform's GCCs suffer from the problem.