### PR TITLE
class library: rename two PV ugens that are not

### DIFF
--- a/HelpSource/Classes/PV_HainsworthFoote.schelp
+++ b/HelpSource/Classes/PV_HainsworthFoote.schelp
@@ -1,6 +1,6 @@
-class:: PV_HainsworthFoote
+class:: HainsworthFoote
 summary:: FFT onset detector.
-related:: Classes/PV_JensenAndersen
+related:: Classes/JensenAndersen
 categories::  UGens>FFT
 
 
@@ -62,7 +62,7 @@ code::
 SynthDef(\fftod, {
 	var source1, detect;
 	source1= AudioIn.ar(1);
-	detect= PV_HainsworthFoote.ar(FFT(LocalBuf(2048),source1), 1.0, 0.0);
+	detect= HainsworthFoote.ar(FFT(LocalBuf(2048),source1), 1.0, 0.0);
 	Out.ar(0,SinOsc.ar([440,445],0,Decay.ar(0.1*detect,0.1)));
 }).play(s);
 )
@@ -73,7 +73,7 @@ SynthDef(\fftod, {
 SynthDef(\fftod, {
 	var source1, detect;
 	source1= LFSaw.ar(LFNoise0.kr(1,90,400),0,0.5);
-	detect= PV_HainsworthFoote.ar(FFT(LocalBuf(2048),source1), 1.0, 0.0, 0.9, 0.5);
+	detect= HainsworthFoote.ar(FFT(LocalBuf(2048),source1), 1.0, 0.0, 0.9, 0.5);
 	Out.ar(0,Pan2.ar(source1,-1.0)+ Pan2.ar(SinOsc.ar(440,0,Decay.ar(0.1*detect,0.1)),1.0));
 }).play(s);
 )
@@ -85,7 +85,7 @@ SynthDef(\fftod, {
 SynthDef(\fftod, {
 	var source1, detect;
 	source1= AudioIn.ar(1);
-	detect= PV_HainsworthFoote.ar(FFT(LocalBuf(2048),source1), 0.0, 1.0, MouseX.kr(0.0,1.1), 0.02);
+	detect= HainsworthFoote.ar(FFT(LocalBuf(2048),source1), 0.0, 1.0, MouseX.kr(0.0,1.1), 0.02);
 	Out.ar(0,Pan2.ar(source1,-1.0)+ Pan2.ar(SinOsc.ar(440,0,Decay.ar(0.1*detect,0.1)),1.0));
 }).play(s);
 )

--- a/HelpSource/Classes/PV_JensenAndersen.schelp
+++ b/HelpSource/Classes/PV_JensenAndersen.schelp
@@ -1,6 +1,6 @@
-class:: PV_JensenAndersen
+class:: JensenAndersen
 summary:: FFT feature detector for onset detection.
-related:: Classes/PV_HainsworthFoote
+related:: Classes/HainsworthFoote
 categories::  UGens>FFT
 
 
@@ -65,7 +65,7 @@ code::
 (
 SynthDef(\fftod, { var source1, detect;
 		source1 = AudioIn.ar(1);
-		detect = PV_JensenAndersen.ar(FFT(LocalBuf(2048), source1),
+		detect = JensenAndersen.ar(FFT(LocalBuf(2048), source1),
 			threshold:MouseX.kr(0.1,1.0));
 		Out.ar(0, SinOsc.ar([440,445], 0, Decay.ar(0.1*detect, 0.1)));
 	}).play(s);

--- a/SCClassLibrary/Common/Audio/FFT2.sc
+++ b/SCClassLibrary/Common/Audio/FFT2.sc
@@ -56,18 +56,22 @@ Convolution3 : UGen {
 
 
 //jensen andersen inspired FFT feature detector
-PV_JensenAndersen : PV_ChainUGen {
+JensenAndersen : PV_ChainUGen {
 	*ar { arg buffer, propsc=0.25, prophfe=0.25, prophfc=0.25, propsf=0.25, threshold=1.0, waittime=0.04;
 		^this.multiNew('audio', buffer, propsc, prophfe, prophfc, propsf,  threshold, waittime);
 	}
 }
 
 
-PV_HainsworthFoote : PV_ChainUGen {
+HainsworthFoote : PV_ChainUGen {
 	*ar { arg buffer, proph=0.0, propf=0.0, threshold=1.0, waittime=0.04;
 		^this.multiNew('audio', buffer, proph, propf, threshold, waittime);
 	}
 }
+
+// backwards compatibility
+PV_JensenAndersen : JensenAndersen {}
+PV_HainsworthFoote : PV_HainsworthFoote {}
 
 //not FFT but useful for time domain onset detection
 RunningSum : UGen {

--- a/SCClassLibrary/Common/Audio/FFT2.sc
+++ b/SCClassLibrary/Common/Audio/FFT2.sc
@@ -56,22 +56,25 @@ Convolution3 : UGen {
 
 
 //jensen andersen inspired FFT feature detector
-JensenAndersen : PV_ChainUGen {
+
+JensenAndersen : PV_JensenAndersen {}
+HainsworthFoote : PV_HainsworthFoote {}
+
+
+// backwards compatibility
+PV_JensenAndersen : PV_ChainUGen {
 	*ar { arg buffer, propsc=0.25, prophfe=0.25, prophfc=0.25, propsf=0.25, threshold=1.0, waittime=0.04;
 		^this.multiNew('audio', buffer, propsc, prophfe, prophfc, propsf,  threshold, waittime);
 	}
 }
 
-
-HainsworthFoote : PV_ChainUGen {
+PV_HainsworthFoote : PV_ChainUGen {
 	*ar { arg buffer, proph=0.0, propf=0.0, threshold=1.0, waittime=0.04;
 		^this.multiNew('audio', buffer, proph, propf, threshold, waittime);
 	}
 }
 
-// backwards compatibility
-PV_JensenAndersen : JensenAndersen {}
-PV_HainsworthFoote : PV_HainsworthFoote {}
+
 
 //not FFT but useful for time domain onset detection
 RunningSum : UGen {


### PR DESCRIPTION
The prefix PV_ is used for ugens that take an fft and return a new fft.
This fixes #2470.