### PR TITLE
class library: deprecate AudioIn

### DIFF
--- a/SCClassLibrary/Common/Audio/SoundIn.sc
+++ b/SCClassLibrary/Common/Audio/SoundIn.sc
@@ -22,14 +22,3 @@ SoundIn  {
 		^NumOutputBuses.ir
 	}
 }
-
-// backward compatible version. Only difference: starts counting from channel 1
-
-AudioIn : SoundIn  {
-	*ar { arg channel = 0, mul=1.0, add=0.0;
-		^super.ar(channel, mul, add)
-	}
-	*channelOffset {
-		^NumOutputBuses.ir - 1
-	}
-}

--- a/SCClassLibrary/deprecated/3.9/AudioIn.sc
+++ b/SCClassLibrary/deprecated/3.9/AudioIn.sc
@@ -1,0 +1,12 @@
+// backward compatible version of SoundIn.
+// The only difference is that it counts from channel 1.
+
+AudioIn : SoundIn  {
+    *ar { arg channel = 0, mul=1.0, add=0.0;
+        this.deprecated(thisMethod, SoundIn.class.findMethod(\ar));
+        ^super.ar(channel, mul, add)
+    }
+    *channelOffset {
+        ^NumOutputBuses.ir - 1
+    }
+}


### PR DESCRIPTION
and renamed AudioIn.sc to SoundIn.sc. Fix #2429.