### PR TITLE
server: catch exceptions when initializing units

### DIFF
--- a/server/scsynth/SC_Graph.cpp
+++ b/server/scsynth/SC_Graph.cpp
@@ -432,7 +432,7 @@ void Graph_Ctor(World *inWorld, GraphDef *inGraphDef, Graph *graph, sc_msg_iter 
 }
 
 // Calls the unit's Ctor func.
-void InitializeUnit(Unit* unit)
+inline void InitializeUnit(Unit* unit)
 {
 	try {
 		(*unit->mUnitDef->mUnitCtorFunc)(unit);

--- a/server/scsynth/SC_Graph.cpp
+++ b/server/scsynth/SC_Graph.cpp
@@ -431,6 +431,20 @@ void Graph_Ctor(World *inWorld, GraphDef *inGraphDef, Graph *graph, sc_msg_iter 
 	inGraphDef->mRefCount ++ ;
 }
 
+// Calls the unit's Ctor func.
+void InitializeUnit(Unit* unit)
+{
+	try {
+		(*unit->mUnitDef->mUnitCtorFunc)(unit);
+	} catch (std::exception& exc) {
+		// Permanently clear the outputs of the unit
+		Unit_ZeroOutputs(unit, 1);
+		unit->mCalcFunc = (UnitCalcFunc)&Unit_ZeroOutputs;
+		char* unitName = (char*)unit->mUnitDef->mUnitDefName;
+		printf("ERROR: could not initialize UGen %s: %s\n", unitName, exc.what());
+	}
+}
+
 void Graph_FirstCalc(Graph *inGraph)
 {
 	//scprintf("->Graph_FirstCalc\n");
@@ -438,8 +452,7 @@ void Graph_FirstCalc(Graph *inGraph)
 	Unit **units = inGraph->mUnits;
 	for (uint32 i=0; i<numUnits; ++i) {
 		Unit *unit = units[i];
-		// call constructor
-		(*unit->mUnitDef->mUnitCtorFunc)(unit);
+		InitializeUnit(unit);
 	}
 	//scprintf("<-Graph_FirstCalc\n");
 
@@ -457,8 +470,7 @@ void Graph_NullFirstCalc(Graph *inGraph)
 	Unit **units = inGraph->mUnits;
 	for (uint32 i=0; i<numUnits; ++i) {
 		Unit *unit = units[i];
-		// call constructor
-		(*unit->mUnitDef->mUnitCtorFunc)(unit);
+		InitializeUnit(unit);
 	}
 	//scprintf("<-Graph_FirstCalc\n");
 


### PR DESCRIPTION
**Note: this affects a core component of scsynth, and I am not an experienced scsynth developer. Please discuss at length before merge.**

This commit causes scsynth to catch all exceptions thrown during the Ctor function. If an exception is caught, the failure is graceful: an error message is printed to the user and the misbehaving ugen is set to output 0. The rest of the ugen graph is unaffected.

The motivation is to catch RTAlloc failures. Many ugens check for failed RTAlloc, but as described in #782, there are also many that don't. The ugens that fail to make this check usually end up crashing the server, because RTAlloc returns NULL when it fails.

We could just fix all those ugens, but I believe there is a better solution than putting a burden on ugen developers. The real-time memory allocator also throws an exception. If we catch that, we can properly handle the situation and inform the user. This commit catches exceptions *only* at Ctor, so this won't fix RTAlloc when it is called in a calculation function, but this is enough to cover 90% of cases.

To show how this commit improves fault tolerance, consider the following code, which tries to allocate a 200-second delay buffer:

    { DelayC.ar(SinOsc.ar, 200, 200) }.plot(0.001);

At 48kHz, this adds up to a 65536MiB buffer (note that DelayC rounds up the number of samples to the next power of 2), so it is bound to fail with the default RT memory size of 8MiB. The question is how the error is handled.

With the current master, this code gives me a huge number of errors at the JACK driver level:

    JackDriver: exception in real time: alloc failed, increase server's memory allocation (e.g. via ServerOptions)

I don't know about other audio servers. Anyone want to test on OS X?

With this PR, this code produces only one error:

    ERROR: could not initialize UGen DelayC: alloc failed, increase server's memory allocation (e.g. via ServerOptions)

I am not aware of other conditions in the core library where a UGen throws an exception during its Ctor func. I could be wrong, though! If that's the case, then we need to look at these other exceptions and decide whether they are worth zeroing out over. Maybe the exception thrown by RTAlloc, as well as this catch, can be specialized to `std::bad_alloc` -- or even a subclass of that -- so we can ensure that we aren't catching exceptions we shouldn't be catching.