### PR TITLE
Use major.minor.patch in Info plist version keys

### DIFF
--- a/cmake_modules/MacOSXBundleInfo.plist.in
+++ b/cmake_modules/MacOSXBundleInfo.plist.in
@@ -140,9 +140,9 @@
 	<key>CFBundleSignature</key>
 	<string>SCjm</string>
 	<key>CFBundleVersion</key>
-	<string>${PROJECT_VERSION_PATCH}</string>
+	<string>${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}${PROJECT_VERSION_PATCH}</string>
 	<key>CFBundleShortVersionString</key>
-	<string>${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}</string>
+	<string>${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}${PROJECT_VERSION_PATCH}</string>
 	<key>NSHumanReadableCopyright</key>
 	<string>(C) 2001-2012 James McCartney et al.</string>
 	<key>NSMainNibFile</key>


### PR DESCRIPTION
As discussed in https://github.com/supercollider/supercollider/issues/2471:

I opted to just put the same version information in both keys. Ideally for `CFBundleVersion` one might instead have some kind of auto-incrementing "build number" or similar, but I'm not sure there's any such data that is useable for that. With this, there's at least a logically-incrementing `major.minor.patch` in at least one consistent location for a publicly-released version, which makes it much easier to compare two versions on a system.

I omitted the second `.` to separate the version substitutions because it seemed to me that `PROJECT_VERSION_PATCH` always contains a leading dot.

Thanks for your consideration!