### PR TITLE
Help: Clarify series-notation docs

### DIFF
--- a/HelpSource/Classes/ArrayedCollection.schelp
+++ b/HelpSource/Classes/ArrayedCollection.schelp
@@ -310,6 +310,15 @@ y.postln;
 )
 ::
 
+note::If the intent is to copy emphasis::forward:: in an array, and you are calculating start and end indices such that code::end:: may be less than code::start::, it is not safe to use code::copySeries:: or the shortcut syntax code::x[a..b]:: because it will adapt to use a positive or negative step as needed. In this case, code::copyRange:: is recommended.
+
+code::
+a = Array.series(10, 0, 1);
+a[2..0];  // [ 2, 1, 0 ]
+a.copyRange(2, 0);  // [  ]
+::
+::
+
 method::seriesFill
 Fill the receiver with an arithmetic progression. The first element will be strong::start::, the second strong::start + step::, the third strong::start + step + step:: ...
 code::

--- a/HelpSource/Overviews/SymbolicNotations.schelp
+++ b/HelpSource/Overviews/SymbolicNotations.schelp
@@ -354,10 +354,10 @@ definitionlist::
 ## code:: (..b) :: || produces an array 0 through b
 ## code:: (a..) :: || not legal (no endpoint given)
 
-## code:: a[i..j] :: || same as code:: a.copyRange(i, j) ::
+## code:: a[i..j] :: || same as code:: a.copySeries(i, j) :: (see link::Classes/ArrayedCollection#-copySeries::)
 ## code:: a[i, j..k] :: || e.g.: code:: a[1, 3..9] :: retrieves array elements 1, 3, 5, 7, 9
-## code:: a[..j] :: || same as code:: a.copyRange(0, j) ::
-## code:: a[j..] :: || same as code:: a.copyRange(i, a.size-1) :: (this is OK--Array is finite)
+## code:: a[..j] :: || same as code:: a.copySeries(0, j) ::
+## code:: a[j..] :: || same as code:: a.copySeries(i, a.size-1) :: (this is OK--Array is finite)
 
 ## code:: ~ :: || access an environment variable
 ## code:: ~abc :: || compiles to code:: \abc.envirGet ::


### PR DESCRIPTION
After being bitten for the thousandth time by the syntax `a[x..y]` behaving differently from my expectation when y < x, I thought it would be worth clarifying in the documentation.

Also, the Symbolic Notations help file incorrectly stated that `a[x..y]` corresponds to the copyRange method. That's wrong -- it's copySeries.