### PR TITLE
sclang: increase maximum number of midi ports

### DIFF
--- a/lang/LangPrimSource/SC_CoreMIDI.cpp
+++ b/lang/LangPrimSource/SC_CoreMIDI.cpp
@@ -327,8 +327,8 @@ int initMIDI(int numIn, int numOut)
 	int enc = kCFStringEncodingMacRoman;
 
 	midiCleanUp();
-	if(numIn > kMaxMidiPorts) { sprintf("MIDI: note that maximum midi in ports is limited to %d.\n", kMaxMidiPorts); }
-	if(numOut > kMaxMidiPorts) { sprintf("MIDI: note that maximum midi out ports is limited to %d.\n", kMaxMidiPorts); }
+	if(numIn > kMaxMidiPorts) { printf("MIDI: note that maximum midi in ports is limited to %d.\n", kMaxMidiPorts); }
+	if(numOut > kMaxMidiPorts) { printf("MIDI: note that maximum midi out ports is limited to %d.\n", kMaxMidiPorts); }
 	numIn = sc_clip(numIn, 1, kMaxMidiPorts);
 	numOut = sc_clip(numOut, 1, kMaxMidiPorts);
 

--- a/lang/LangPrimSource/SC_CoreMIDI.cpp
+++ b/lang/LangPrimSource/SC_CoreMIDI.cpp
@@ -327,6 +327,8 @@ int initMIDI(int numIn, int numOut)
 	int enc = kCFStringEncodingMacRoman;
 
 	midiCleanUp();
+	if(numIn > kMaxMidiPorts) { sprintf("MIDI: note that maximum midi in ports is limited to %d.\n", kMaxMidiPorts); }
+	if(numOut > kMaxMidiPorts) { sprintf("MIDI: note that maximum midi out ports is limited to %d.\n", kMaxMidiPorts); }
 	numIn = sc_clip(numIn, 1, kMaxMidiPorts);
 	numOut = sc_clip(numOut, 1, kMaxMidiPorts);
 

--- a/lang/LangPrimSource/SC_CoreMIDI.cpp
+++ b/lang/LangPrimSource/SC_CoreMIDI.cpp
@@ -67,7 +67,7 @@ PyrSymbol* s_midiSMPTEAction;
 PyrSymbol * s_midiin;
 PyrSymbol * s_numMIDIDev;
 PyrSymbol * s_midiclient;
-const int kMaxMidiPorts = 16;
+const int kMaxMidiPorts = 128;
 MIDIClientRef gMIDIClient = 0;
 MIDIPortRef gMIDIInPort[kMaxMidiPorts], gMIDIOutPort[kMaxMidiPorts];
 int gNumMIDIInPorts = 0, gNumMIDIOutPorts = 0;

--- a/lang/LangPrimSource/SC_PortMIDI.cpp
+++ b/lang/LangPrimSource/SC_PortMIDI.cpp
@@ -355,6 +355,8 @@ static int initMIDI(int numIn, int numOut)
 	/* Here, numIn and numOut are 0, even if the inputs to lang (MIDIClient init) were nil, but according to the documentation, it should be the number of inputs or outputs. 
 	   That matches what I see in MIDIOut.sc -> MIDIClient *init, in which it is setting that to sources.size, and destinations.size, so I guess that the problem is that 
 	   this information is not known at this point, or there is something missing. */
+	if(numIn > kMaxMidiPorts) { std::printf("MIDI: note that maximum midi in ports is limited to %i.\n", kMaxMidiPorts);
+	if(numOut > kMaxMidiPorts) { std::printf("MIDI: note that maximum midi out ports is limited to %i.\n", kMaxMidiPorts);
 	numIn = sc_clip(numIn, 1, kMaxMidiPorts);
 	numOut = sc_clip(numOut, 1, kMaxMidiPorts);
 

--- a/lang/LangPrimSource/SC_PortMIDI.cpp
+++ b/lang/LangPrimSource/SC_PortMIDI.cpp
@@ -355,8 +355,8 @@ static int initMIDI(int numIn, int numOut)
 	/* Here, numIn and numOut are 0, even if the inputs to lang (MIDIClient init) were nil, but according to the documentation, it should be the number of inputs or outputs. 
 	   That matches what I see in MIDIOut.sc -> MIDIClient *init, in which it is setting that to sources.size, and destinations.size, so I guess that the problem is that 
 	   this information is not known at this point, or there is something missing. */
-	if(numIn > kMaxMidiPorts) { std::printf("MIDI: note that maximum midi in ports is limited to %i.\n", kMaxMidiPorts);
-	if(numOut > kMaxMidiPorts) { std::printf("MIDI: note that maximum midi out ports is limited to %i.\n", kMaxMidiPorts);
+	if(numIn > kMaxMidiPorts) { std::printf("MIDI: note that maximum midi in ports is limited to %i.\n", kMaxMidiPorts); }
+	if(numOut > kMaxMidiPorts) { std::printf("MIDI: note that maximum midi out ports is limited to %i.\n", kMaxMidiPorts); }
 	numIn = sc_clip(numIn, 1, kMaxMidiPorts);
 	numOut = sc_clip(numOut, 1, kMaxMidiPorts);
 

--- a/lang/LangPrimSource/SC_PortMIDI.cpp
+++ b/lang/LangPrimSource/SC_PortMIDI.cpp
@@ -69,7 +69,7 @@ PyrSymbol* s_midiin;
 PyrSymbol* s_numMIDIDev;
 PyrSymbol* s_midiclient;
 
-const int kMaxMidiPorts = 16;
+const int kMaxMidiPorts = 128;
 int gNumMIDIInPorts = 0, gNumMIDIOutPorts = 0;
 bool gMIDIInitialized = false;
 


### PR DESCRIPTION
The limit of 16 was hit too easily.

This fixes #2492, perhaps.

