### PR TITLE
Classlib: Add 'isRest' to Rest

### DIFF
--- a/SCClassLibrary/Common/Streams/Rest.sc
+++ b/SCClassLibrary/Common/Streams/Rest.sc
@@ -33,6 +33,8 @@ Rest {
 			}
 		})
 	}
+	*isRest { ^true }
+	isRest { ^true }
 	value { ^dur }
 	storeOn { |stream| stream << "Rest(" << dur << ")" }
 }


### PR DESCRIPTION
Without this, `Rest(1).isRest` is false!