### PR TITLE
Classlib: Collection:processRest must return the processed value

### DIFF
--- a/SCClassLibrary/Common/Streams/Rest.sc
+++ b/SCClassLibrary/Common/Streams/Rest.sc
@@ -45,7 +45,7 @@ Rest {
 
 + Collection {
 	processRest { |inval|
-		this.do(_.processRest(inval))
+		^this.collect(_.processRest(inval))
 	}
 }
 


### PR DESCRIPTION
```
(
p = Pseries(0, 1, inf).collect { |x|
	if(x.odd) { [x, Rest(x)] } { [x, x] }
}.asStream;
)

p.next(());  // [ 0, 0 ], ok

p.next(());  // [ 1, a Rest ] not OK
```

I never noticed this before because `Pbind` does `processRest` on array items distributed to keys -- but I had a case where a (private) pattern expects an array of values, and `processRest` on the array was returning the original array instead of the processed array.

With the fix:

```
(
p = Pseries(0, 1, inf).collect { |x|
	if(x.odd) { [x, Rest(x)] } { [x, x] }
}.asStream;
)

p.next(());  // [ 0, 0 ], ok

p.next(e = ());  // [ 1, 1 ], OK
e  // ( 'isRest': true ), OK
```