### PR TITLE
Classlib: Shortcut Event.default wherever possible

### DIFF
--- a/SCClassLibrary/Common/Control/asScore/ScoreStreamPlayer.sc
+++ b/SCClassLibrary/Common/Control/asScore/ScoreStreamPlayer.sc
@@ -65,7 +65,7 @@ ScoreStreamPlayer : Server {
 			}
 		);
 
-		event = event ? Event.default;
+		event = event ?? { Event.default };
 		event = event.copy.putAll(proto);
 		beats = timeOffset;
 		tempo = 1;

--- a/SCClassLibrary/Common/Streams/FilterPatterns.sc
+++ b/SCClassLibrary/Common/Streams/FilterPatterns.sc
@@ -544,7 +544,7 @@ Pbindf : FilterPattern {
 	var <>patternpairs;
 	*new { arg pattern ... pairs;
 		if (pairs.size.odd, { Error("Pbindf should have odd number of args.\n").throw });
-		^super.new(pattern ? Event.default).patternpairs_(pairs)
+		^super.new(pattern ?? { Event.default }).patternpairs_(pairs)
 	}
 	storeArgs { ^[pattern] ++ patternpairs }
 	embedInStream { arg event;

--- a/SCClassLibrary/Common/Streams/PatternConductor.sc
+++ b/SCClassLibrary/Common/Streams/PatternConductor.sc
@@ -12,7 +12,7 @@ PatternConductor  {
 	*new { |patterns, event, quant|
 		^super.new
 			.patterns_(patterns.asArray)
-			.event_(event ? Event.default)
+			.event_(event ?? { Event.default })
 			.quant_(quant ? 0).tempo_(1).defaultPauseTempo_(1e-8).defaultStopTempo_(1e+8);
 	}
 

--- a/SCClassLibrary/Common/Streams/Stream.sc
+++ b/SCClassLibrary/Common/Streams/Stream.sc
@@ -300,7 +300,7 @@ StreamClutch : Stream {
 		reset = true
 	}
 	step { arg inval;
-		value = stream.next(inval ? Event.default)
+		value = stream.next(inval ?? { Event.default })
 	}
 
 }
@@ -435,7 +435,7 @@ EventStreamPlayer : PauseStream {
 	var <>event, <>muteCount = 0, <>cleanup, <>routine;
 
 	*new { arg stream, event;
-		^super.new(stream).event_(event ? Event.default).init;
+		^super.new(stream).event_(event ?? { Event.default }).init;
 	}
 
 	init {


### PR DESCRIPTION
`event ?? { Event.default }` and NOT `event ? Event.default`
The latter creates wasted objects that may never be used.

Can't believe how many of these were still in there.