### PR TITLE
Prevent Emacs fontification failure with lots of classes - Fixes #248

### DIFF
--- a/editors/scel/el/sclang-language.el
+++ b/editors/scel/el/sclang-language.el
@@ -220,6 +220,10 @@ low-resource systems."
  (lambda (arg)
    (when (and sclang-use-symbol-table arg)
      (setq sclang-symbol-table (sort arg 'string<))
+     (setq sclang-class-list (remove-if
+                              (lambda (x) (or (not (sclang-class-name-p x))
+                                              (sclang-string-match "^Meta_" x)))
+                              sclang-symbol-table))
      (sclang-update-font-lock))))
 
 (add-hook 'sclang-library-startup-hook

--- a/editors/scel/el/sclang-language.el
+++ b/editors/scel/el/sclang-language.el
@@ -207,6 +207,9 @@ low-resource systems."
 (defvar sclang-symbol-table nil
   "List of all defined symbols.")
 
+(defvar sclang-class-list nil
+  "List of all defined classes.")
+
 (defvar sclang-symbol-history nil
   "List of recent symbols read from the minibuffer.")
 


### PR DESCRIPTION
Hi,

These changes should prevent Emacs from failing to fontify class names when lots of classes exist in sclang (i.e. when many quarks are installed). I've elaborated in the commit messages, but the general idea of these changes is this:

- instead of generating a huge regexp containing every class name in SuperCollider, just use a general class regexp, which is: any word starting with a capital letter. Before SuperCollider is started, all words starting with a capital letter will be highlighted as class names. After SC is started, only words starting with a capital letter that are actually class names will be highlighted.
- when sclang starts, we generate a list of classes and store it in `sclang-class-list` so we can refer back to it later during fontification (lines 223-226 in sclang-language.el).
- when fontification happens after SC is started, we check all words that start with a capital letter. if they're in the `sclang-class-list` then we know that they're an actual class and we color them as such. if they're not in `sclang-class-list` then it's not a class, so we don't color it.

I've been using these changes locally on my own machine for about a year now and have not had any problems with them so I figured it was time to submit a pull request so everyone can benefit from them. I've tested these changes myself and have not had any issues. I've made other changes to the elisp but I made sure to only stage the relevant ones to #248. I also included one minor change to line 268 in sclang-mode.el which is to just add a space between the function name and the argument, because that was bothering me.