### PR TITLE
Update SimpleNumber-partition for more intelligent input handling

### DIFF
--- a/HelpSource/Classes/Float.schelp
+++ b/HelpSource/Classes/Float.schelp
@@ -25,6 +25,21 @@ iterates function from this-1 to 0
 argument:: function
 The function to iterate.
 
+method:: partition
+randomly partition a number into parts of at least min size.
+argument:: parts
+number of parts
+argument:: min
+the minimum size
+
+discussion::
+code::
+75.0.partition(8, 3.0);
+75.0.partition(75, 0.95);
+-75.0.partition(9, 3.5);
+10.0.partition(2, 6.0); // throws an error (2 * 6.0 > 10.0)
+::
+
 method:: coin
 Perform a random test whose probability of success in a range from
 zero to one is this and return the result.

--- a/HelpSource/Classes/Integer.schelp
+++ b/HelpSource/Classes/Integer.schelp
@@ -77,6 +77,21 @@ argument:: exclude
 an link::Classes/Integer::.
 returns:: a random value from this.neg to this, excluding the value exclude.
 
+method:: partition
+randomly partition a number into parts of at least min size.
+argument:: parts
+number of parts
+argument:: min
+the minimum size
+
+discussion::
+code::
+75.partition(8, 3);
+75.partition(75, 1);
+-75.partition(9, 3);
+10.partition(2, 6); // throws an error
+::
+
 subsection:: Conversion
 
 method:: asAscii

--- a/HelpSource/Classes/SimpleNumber.schelp
+++ b/HelpSource/Classes/SimpleNumber.schelp
@@ -896,19 +896,6 @@ code::
 (0..1000).collect { |num| gauss(0.0, num) }.plot;
 ::
 
-method:: partition
-randomly partition a number into parts of at least min size.
-argument:: parts
-number of parts
-argument:: min
-the minimum size
-
-discussion::
-code::
-75.partition(8, 3);
-75.partition(75, 1);
-::
-
 
 subsection:: UGen Compatibility Methods
 

--- a/SCClassLibrary/Common/Math/Float.sc
+++ b/SCClassLibrary/Common/Math/Float.sc
@@ -80,4 +80,13 @@ Float : SimpleNumber {
 		"Float:switch is unsafe, rounding via Float:asInteger:switch".warn;
 		^this.asInteger.switch(*cases)
 	}
+	
+	partition { arg parts=2, min=1;
+		// randomly partition a number into parts of at least min size :
+		var n = this.abs - (min * parts);
+		if(n < 0) {
+			Error("Float-partition min (%) is too high to partition % into % parts.".format(min, this, parts)).throw;
+		};
+		^Array.rand(parts-1,0,n).sort.add(n).differentiate + min * this.sign;
+	}
 }

--- a/SCClassLibrary/Common/Math/Integer.sc
+++ b/SCClassLibrary/Common/Math/Integer.sc
@@ -219,6 +219,15 @@ Integer : SimpleNumber {
 			^product
 		}*/
 	}
+	
+	partition { arg parts=2, min=1;
+		// randomly partition a number into parts of at least min size :
+		var n = this.abs - (min - 1 * parts);
+		if(n < parts) {
+			Error("Integer-partition min (%) is too high to partition % into % parts.".format(min, this, parts)).throw;
+		};
+		^(1..n-1).scramble.keep(parts-1).sort.add(n).differentiate + (min - 1) * this.sign;
+	}
 
 		// support for modifiers keys
 	isCaps { ^this.bitAnd(65536) == 65536}

--- a/SCClassLibrary/Common/Math/SimpleNumber.sc
+++ b/SCClassLibrary/Common/Math/SimpleNumber.sc
@@ -457,12 +457,6 @@ SimpleNumber : Number {
 		^scale.performNearestInScale(this, stepsPerOctave);
 	}
 
-	partition { arg parts=2, min=1;
-		// randomly partition a number into parts of at least min size :
-		var n = this - (min - 1 * parts);
-		^(1..n-1).scramble.keep(parts-1).sort.add(n).differentiate + (min - 1)
-	}
-
 	nextTimeOnGrid { arg clock;
 		^clock.nextTimeOnGrid(this, 0);
 	}


### PR DESCRIPTION
Despite being declared in SimpleNumber.sc, the `partition` method does not behave intelligently when passed floating point input. For example,

`10.1.partition(5, 1)` -> `[2, 1, 3, 2, 2.1]`

This is a result of the implementation of `partition`. The line

`^(1..n-1).scramble.keep(parts-1).sort.add(n).differentiate`

is to blame, as it creates an array of integers and ensures that the fractional part of whatever float is passed is always added to the final array element.

I've written a `Float-partition` method based on the original that provides a true floating-point partition with a random distribution. For example:

`300.0.partition(5, 0.1)` -> `[ 77.170352971554, 151.00796130896, 30.255907392502, 23.019015169144, 18.546763157845 ]`

In order to add it to the main SC library I'm proposing the following changes:

* move `SimpleNumber-partition` to `Integer-partition`
* add `Float-partition`
* update the help files accordingly

I've also added slight error checking to these two methods to throw an error whenever `min * parts > this`, and modified them such that they can partition negative numbers as well.

This is my first time submitting a pull request to SC-master so please let me know if I've done this right!

-Brian