### PR TITLE
class library: improving Pstep input handling and documentation

### DIFF
--- a/HelpSource/Classes/Pstep.schelp
+++ b/HelpSource/Classes/Pstep.schelp
@@ -1,15 +1,13 @@
 class:: Pstep
 summary:: timed, sample-and-hold embedding of values
-related:: Classes/Pseg, Classes/PstepDur
+related:: Classes/Pseg
 categories:: Streams-Patterns-Events>Patterns>Time
 
 description::
 
-Pstep and link::Classes/PstepDur:: are both "sample and hold" patterns: The value returned by teletype::next:: is held at each value in teletype::levels:: for the corresponding duration in teletype::durs::. This cycling is similar to link::Classes/Ptuple::, in that the current repeat ends when eiher pattern returns nil.
+Pstep is a "sample and hold" pattern: The value returned by teletype::next:: is held at each value in teletype::levels:: for the corresponding duration in teletype::durs::. This cycling is similar to link::Classes/Ptuple::, in that the current repeat ends when eiher pattern returns nil.
 
 Pstep measures elapsed time using the thread's logical time. That is, it assumes it will be evaluated only exactly when needed, not before.
-
-link::Classes/PstepDur:: measures time based on the input event's delta. Provided that duration keys have already been set in the event, PstepDur may be polled in advance.
 
 See link::Classes/Pseg:: for a pattern whose value changes like an link::Classes/Env::.
 

--- a/HelpSource/Classes/Pstep.schelp
+++ b/HelpSource/Classes/Pstep.schelp
@@ -1,16 +1,31 @@
 class:: Pstep
-summary:: timed embedding of values
-related:: Classes/Pseg
+summary:: timed, sample-and-hold embedding of values
+related:: Classes/Pseg, Classes/PstepDur
 categories:: Streams-Patterns-Events>Patterns>Time
 
 description::
 
-Pstep is good for representing chord progressions, scale progressions, accent patterns, etc.
+Pstep and link::Classes/PstepDur:: are both "sample and hold" patterns: The value returned by teletype::next:: is held at each value in teletype::levels:: for the corresponding duration in teletype::durs::. This cycling is similar to link::Classes/Ptuple::, in that the current repeat ends when eiher pattern returns nil.
+
+Pstep measures elapsed time using the thread's logical time. That is, it assumes it will be evaluated only exactly when needed, not before.
+
+link::Classes/PstepDur:: measures time based on the input event's delta. Provided that duration keys have already been set in the event, PstepDur may be polled in advance.
+
+See link::Classes/Pseg:: for a pattern whose value changes like an link::Classes/Env::.
 
 ClassMethods::
 
 method::new
-Levelpattern can return individual values, arrays, or events. The value returned by levelpattern is returned for the duration returned by durpattern.
+Create an instance of Pstep.
+
+argument::levels
+A number, collection, or link::Classes/Pattern:: that returns the levels.
+
+argument::durs
+A number, collection, or link::Classes/Pattern:: that returns segments durations in beats.
+
+argument::repeats
+An integer, or teletype::inf::.
 
 Examples::
 
@@ -27,7 +42,7 @@ p = Pstep(
 );
 Ppar([p, p]).play;
 )
-// change degree independant of number of events that have been playing
+// change degree independently of number of events that have been playing
 
 (
 Pchain(

--- a/SCClassLibrary/Common/Streams/TimePatterns.sc
+++ b/SCClassLibrary/Common/Streams/TimePatterns.sc
@@ -4,7 +4,10 @@ Pstep : Pattern {
 	*new { arg levels, durs = 1, repeats = 1;
 		^super.newCopyArgs(levels, durs, repeats).init
 	}
-	init { if (list.isKindOf(Collection)) { list = Pseq(list); } }
+	init {
+		if (list.isKindOf(Collection)) { list = Pseq(list); };
+		if (durs.isKindOf(Collection)) { durs = Pseq(durs); };
+	}
 
 	embedInStream { arg inval;
 		var stream, val,dur;

--- a/SCClassLibrary/Common/Streams/TimePatterns.sc
+++ b/SCClassLibrary/Common/Streams/TimePatterns.sc
@@ -5,8 +5,8 @@ Pstep : Pattern {
 		^super.newCopyArgs(levels, durs, repeats).init
 	}
 	init {
-		if (list.isKindOf(Collection)) { list = Pseq(list); };
-		if (durs.isKindOf(Collection)) { durs = Pseq(durs); };
+		if (list.isSequenceableCollection) { list = Pseq(list); };
+		if (durs.isSequenceableCollection) { durs = Pseq(durs); };
 	}
 
 	embedInStream { arg inval;


### PR DESCRIPTION
This is a fix for issue #2489. I pulled most of the description from PstepDur. While testing out the class I also noticed that it handles `levels` being a list but not `durs`, and I couldn't see a reason why not, so I added a single line to `Pstep.init` to take care of that.