### PR TITLE
plugins: implement Sanitize UGen

### DIFF
--- a/HelpSource/Classes/Sanitize.schelp
+++ b/HelpSource/Classes/Sanitize.schelp
@@ -1,0 +1,16 @@
+class:: Sanitize
+summary:: Zero out infinity, NaN, and denormals
+categories:: UGens>Info
+
+description::
+Replaces infinities, NaNs, and subnormal numbers (denormals) with zeros. The method link::Classes/UGen#-sanitize:: provides a shorthand for this.
+
+CheckBadValues allows you to discriminate specific kinds of bad values and print information about them to the post window.
+
+classmethods::
+
+method:: ar, kr
+argument:: in
+::
+
+examples::

--- a/HelpSource/Classes/Sanitize.schelp
+++ b/HelpSource/Classes/Sanitize.schelp
@@ -3,7 +3,7 @@ summary:: Remove infinity, NaN, and denormals
 categories:: UGens>Info
 
 description::
-Replaces infinities, NaNs, and subnormal numbers (denormals) with a value of your choice, usually zero. The method link::Classes/UGen#-sanitize:: provides a shorthand for this.
+Replaces infinities, NaNs, and subnormal numbers (denormals) with a given signal, zero by default. The method link::Classes/UGen#-sanitize:: provides a shorthand for this.
 
 See also link::Classes/CheckBadValues::, which allows you to discriminate specific kinds of bad values and print information about them to the post window.
 

--- a/HelpSource/Classes/Sanitize.schelp
+++ b/HelpSource/Classes/Sanitize.schelp
@@ -1,9 +1,9 @@
 class:: Sanitize
-summary:: Zero out infinity, NaN, and denormals
+summary:: Remove infinity, NaN, and denormals
 categories:: UGens>Info
 
 description::
-Replaces infinities, NaNs, and subnormal numbers (denormals) with zeros. The method link::Classes/UGen#-sanitize:: provides a shorthand for this.
+Replaces infinities, NaNs, and subnormal numbers (denormals) with a value of your choice, usually zero. The method link::Classes/UGen#-sanitize:: provides a shorthand for this.
 
 See also link::Classes/CheckBadValues::, which allows you to discriminate specific kinds of bad values and print information about them to the post window.
 
@@ -11,5 +11,9 @@ classmethods::
 
 method:: ar, kr
 argument:: in
+Input signal to sanitize.
+
+argument:: replace
+The signal that replaces bad values.
 
 examples::

--- a/HelpSource/Classes/Sanitize.schelp
+++ b/HelpSource/Classes/Sanitize.schelp
@@ -5,12 +5,11 @@ categories:: UGens>Info
 description::
 Replaces infinities, NaNs, and subnormal numbers (denormals) with zeros. The method link::Classes/UGen#-sanitize:: provides a shorthand for this.
 
-CheckBadValues allows you to discriminate specific kinds of bad values and print information about them to the post window.
+See also link::Classes/CheckBadValues::, which allows you to discriminate specific kinds of bad values and print information about them to the post window.
 
 classmethods::
 
 method:: ar, kr
 argument:: in
-::
 
 examples::

--- a/SCClassLibrary/Common/Audio/CheckBadValues.sc
+++ b/SCClassLibrary/Common/Audio/CheckBadValues.sc
@@ -18,12 +18,12 @@ CheckBadValues : UGen {
 
 Sanitize : UGen {
 
-	*ar {arg in = 0.0;
-		^this.multiNew('audio', in);
+	*ar { |in = 0.0, replace = 0.0|
+		^this.multiNew('audio', in, replace);
 	}
 
-	*kr {arg in = 0.0;
-		^this.multiNew('control', in);
+	*kr { |in = 0.0, replace = 0.0|
+		^this.multiNew('control', in, replace);
 	}
 
 	checkInputs {

--- a/SCClassLibrary/Common/Audio/CheckBadValues.sc
+++ b/SCClassLibrary/Common/Audio/CheckBadValues.sc
@@ -18,12 +18,12 @@ CheckBadValues : UGen {
 
 Sanitize : UGen {
 
-	*ar {arg in = 0.0, id = 0, post = 0;
-		^this.multiNew('audio', in, id, post);
+	*ar {arg in = 0.0;
+		^this.multiNew('audio', in);
 	}
 
-	*kr {arg in = 0.0, id = 0, post = 0;
-		^this.multiNew('control', in, id, post);
+	*kr {arg in = 0.0;
+		^this.multiNew('control', in);
 	}
 
 	checkInputs {

--- a/SCClassLibrary/Common/Audio/CheckBadValues.sc
+++ b/SCClassLibrary/Common/Audio/CheckBadValues.sc
@@ -15,3 +15,21 @@ CheckBadValues : UGen {
 		^this.checkValidInputs
 	}
 }
+
+Sanitize : UGen {
+
+	*ar {arg in = 0.0, id = 0, post = 0;
+		^this.multiNew('audio', in, id, post);
+	}
+
+	*kr {arg in = 0.0, id = 0, post = 0;
+		^this.multiNew('control', in, id, post);
+	}
+
+	checkInputs {
+		if ((rate==\audio) and:{ inputs.at(0).rate != \audio}) {
+			^("audio-rate, yet first input is not audio-rate");
+		};
+		^this.checkValidInputs
+	}
+}

--- a/SCClassLibrary/Common/Audio/UGen.sc
+++ b/SCClassLibrary/Common/Audio/UGen.sc
@@ -260,7 +260,7 @@ UGen : AbstractFunction {
 	}
 
 	sanitize {
-		^Sanitize.perform(this.methodSelectorForRate);
+		^Sanitize.perform(this.methodSelectorForRate, this);
 	}
 
 	signalRange { ^\bipolar }

--- a/SCClassLibrary/Common/Audio/UGen.sc
+++ b/SCClassLibrary/Common/Audio/UGen.sc
@@ -259,6 +259,10 @@ UGen : AbstractFunction {
 		^ModDif.multiNew(this.rate, this, that, mod)
 	}
 
+	sanitize {
+		^Sanitize.perform(this.methodSelectorForRate);
+	}
+
 	signalRange { ^\bipolar }
 	@ { arg y; ^Point.new(this, y) } // dynamic geometry support
 

--- a/SCClassLibrary/Common/Collections/SequenceableCollection.sc
+++ b/SCClassLibrary/Common/Collections/SequenceableCollection.sc
@@ -1318,4 +1318,8 @@ SequenceableCollection : Collection {
 		_ArrayPOpen
 		^this.primitiveFailed
 	}
+
+	sanitize { arg ... args;
+		^this.multiChannelPerform(\sanitize, *args);
+	}
 }

--- a/server/plugins/TestUGens.cpp
+++ b/server/plugins/TestUGens.cpp
@@ -54,7 +54,9 @@ static const char *CheckBadValues_fpclassString(int fpclass);
 inline int CheckBadValues_fold_fpclasses(int fpclass);
 
 static void Sanitize_Ctor(Sanitize* unit);
-static void Sanitize_next(Sanitize* unit, int inNumSamples);
+static void Sanitize_next_aa(Sanitize* unit, int inNumSamples);
+static void Sanitize_next_ak(Sanitize* unit, int inNumSamples);
+static void Sanitize_next_kk(Sanitize* unit, int inNumSamples);
 
 //////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -191,32 +193,79 @@ inline int CheckBadValues_fold_fpclasses(int fpclass)
 
 void Sanitize_Ctor(Sanitize* unit)
 {
-	SETCALC(Sanitize_next);
-	Sanitize_next(unit, 1);
+	if (INRATE(0) == calc_FullRate) {
+		if (INRATE(1) == calc_FullRate) {
+			SETCALC(Sanitize_next_aa);
+		} else {
+			SETCALC(Sanitize_next_ak);
+		}
+	} else {
+		SETCALC(Sanitize_next_kk);
+	}
+	Sanitize_next_kk(unit, 1);
 }
 
 
-void Sanitize_next(Sanitize* unit, int inNumSamples)
+void Sanitize_next_aa(Sanitize* unit, int inNumSamples)
 {
 	float *in = IN(0);
+	float *replace = IN(1);
 	float *out = OUT(0);
 
 	float samp;
-	int classification;
 	for (int i = 0; i < inNumSamples; i++)
 	{
 		samp = in[i];
-		classification = sc_fpclassify(samp);
-		switch (classification)
+		switch (sc_fpclassify(samp))
 		{
 		case FP_INFINITE:
 		case FP_NAN:
 		case FP_SUBNORMAL:
-			out[i] = 0;
+			out[i] = replace[i];
 			break;
 		default:
 			out[i] = samp;
 		};
+	};
+}
+
+void Sanitize_next_ak(Sanitize* unit, int inNumSamples)
+{
+	float *in = IN(0);
+	float replace = IN0(1);
+	float *out = OUT(0);
+
+	float samp;
+	for (int i = 0; i < inNumSamples; i++)
+	{
+		samp = in[i];
+		switch (sc_fpclassify(samp))
+		{
+		case FP_INFINITE:
+		case FP_NAN:
+		case FP_SUBNORMAL:
+			out[i] = replace;
+			break;
+		default:
+			out[i] = samp;
+		};
+	};
+}
+
+void Sanitize_next_kk(Sanitize* unit, int inNumSamples)
+{
+	float samp = IN0(0);
+	float replace = IN0(1);
+
+	switch (sc_fpclassify(samp))
+	{
+	case FP_INFINITE:
+	case FP_NAN:
+	case FP_SUBNORMAL:
+		OUT0(0) = replace;
+		break;
+	default:
+		OUT0(0) = samp;
 	};
 }
 


### PR DESCRIPTION
A few open questions with this one.

Do we also need `SimpleNumber:sanitize`? How should it be implemented?

Should we add support for post output? I chose to leave it out since it seemed like too much duplication of functionality with CheckBadValues — use CheckBadValues if you want to debug, and use Sanitize if you want to stop worrying about bad values altogether. Another option is to duplicate the `post` option and have it off by default.