### PR TITLE
sclang: primitive for Array maxDepth

### DIFF
--- a/SCClassLibrary/Common/Collections/Array.sc
+++ b/SCClassLibrary/Common/Collections/Array.sc
@@ -133,7 +133,11 @@ Array[slot] : ArrayedCollection {
 	}
 	maxDepth { arg max = 1;
 		_ArrayMaxDepth
-		^this.primitiveFailed
+		^super.maxDepth(max)
+	}
+	maxSizeAtDepth { arg rank;
+		_ArrayMaxSizeAtDepth
+		^super.maxSizeAtDepth(rank)
 	}
 
 	//************** inconsistent argnames, see SequenceableColllection unlace!

--- a/SCClassLibrary/Common/Collections/Array.sc
+++ b/SCClassLibrary/Common/Collections/Array.sc
@@ -131,6 +131,10 @@ Array[slot] : ArrayedCollection {
 		_ArrayContainsSeqColl
 		^this.primitiveFailed
 	}
+	maxDepth { arg max = 1;
+		_ArrayMaxDepth
+		^this.primitiveFailed
+	}
 
 	//************** inconsistent argnames, see SequenceableColllection unlace!
 	unlace { arg clumpSize=2, numChan=1, clip=false;

--- a/lang/LangPrimSource/PyrArrayPrimitives.cpp
+++ b/lang/LangPrimSource/PyrArrayPrimitives.cpp
@@ -65,6 +65,7 @@ int prArraySlide(VMGlobals *g, int numArgsPushed);
 int prArrayLace(VMGlobals *g, int numArgsPushed);
 int prArrayContainsSeqColl(VMGlobals *g, int numArgsPushed);
 int prArrayMaxDepth(VMGlobals *g, int numArgsPushed);
+int prArrayMaxSizeAtDepth(VMGlobals *g, int numArgsPushed);
 int prArrayWIndex(VMGlobals *g, int numArgsPushed);
 int prArrayNormalizeSum(VMGlobals *g, int numArgsPushed);
 int prArrayIndexOfGreaterThan(VMGlobals *g, int numArgsPushed);
@@ -2101,12 +2102,18 @@ inline int sc_arrayMaxDepth(PyrSlot *a, int depth)
 	while (slot < endptr) {
 		++slot;
 		if (IsObj(slot)) {
-			if (isKindOf(slotRawObject(slot), class_sequenceable_collection)) {
-				newdepth = sc_max(newdepth, sc_arrayMaxDepth(slot, depth + 1));
+			if (isKindOf(slotRawObject(slot), class_collection)) {
+				if (isKindOf(slotRawObject(slot), class_arrayed_collection)) {
+					newdepth = sc_arrayMaxDepth(slot, depth + 1);
+					if(newdepth < 0) return -1;
+					depth = sc_max(depth, newdepth);
+				} else {
+					return -1;  // bail out
+				}
 			}
 		}
 	}
-	return newdepth;
+	return depth;
 
 }
 
@@ -2121,7 +2128,53 @@ int prArrayMaxDepth(struct VMGlobals *g, int numArgsPushed)
 	int err = slotIntVal(b, &maxdepth);
 	if (err) return err;
 	maxdepth = sc_arrayMaxDepth(a, maxdepth);
+	if(maxdepth < 0) return errFailed;
 	SetInt(a, maxdepth);
+	return errNone;
+}
+
+inline int sc_arrayMaxSizeAtDepth(PyrSlot *a, int rank)
+{
+	PyrSlot *slot, *endptr;
+	PyrObject *obj;
+	int size, newsize;
+	newsize = 0;
+	obj = slotRawObject(a);
+	size = obj->size;
+	slot = obj->slots - 1;
+	endptr = slot + size;
+	if(rank <= 0) return size;
+	while (slot < endptr) {
+		++slot;
+		if (IsObj(slot)) {
+			if (isKindOf(slotRawObject(slot), class_collection)) {
+				if (isKindOf(slotRawObject(slot), class_arrayed_collection)) {
+					newsize = sc_arrayMaxSizeAtDepth(slot, rank - 1);
+					if(newsize < 0) return -1;
+					size = sc_max(newsize, size);
+				} else {
+					return -1; // error
+				}
+			}
+		}
+	}
+	return newsize;
+	
+}
+
+int prArrayMaxSizeAtDepth(struct VMGlobals *g, int numArgsPushed)
+{
+	PyrSlot *a, *b;
+	
+	a = g->sp - 1;
+	b = g->sp;
+	
+	int rank;
+	int err = slotIntVal(b, &rank);
+	if (err) return err;
+	rank = sc_arrayMaxSizeAtDepth(a, rank);
+	if(rank < 0) return errFailed;
+	SetInt(a, rank);
 	return errNone;
 }
 
@@ -2464,7 +2517,7 @@ void initArrayPrimitives()
 	definePrimitive(base, index++, "_ArraySlide", prArraySlide, 3, 0);
 	definePrimitive(base, index++, "_ArrayContainsSeqColl", prArrayContainsSeqColl, 1, 0);
 	definePrimitive(base, index++, "_ArrayMaxDepth", prArrayMaxDepth, 2, 0);
-
+	definePrimitive(base, index++, "_ArrayMaxSizeAtDepth", prArrayMaxSizeAtDepth, 2, 0);
 
 	definePrimitive(base, index++, "_ArrayEnvAt", prArrayEnvAt, 2, 0);
 	definePrimitive(base, index++, "_ArrayIndexOfGreaterThan", prArrayIndexOfGreaterThan, 2, 0);

--- a/lang/LangPrimSource/PyrArrayPrimitives.cpp
+++ b/lang/LangPrimSource/PyrArrayPrimitives.cpp
@@ -2102,7 +2102,7 @@ inline int sc_arrayMaxDepth(PyrSlot *a, int depth)
 		++slot;
 		if (IsObj(slot)) {
 			if (isKindOf(slotRawObject(slot), class_sequenceable_collection)) {
-				newdepth = sc_arrayMaxDepth(slot, depth + 1);
+				newdepth = sc_max(newdepth, sc_arrayMaxDepth(slot, depth + 1));
 			}
 		}
 	}


### PR DESCRIPTION
For large arrays, maxDepth is now much faster. This speeds up flopDeep.