### PR TITLE
before booting, find zombie servers, stop and advise if needed.

### DIFF
--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -639,7 +639,7 @@ Server {
 		condition.wait;
 	}
 
-	findZombie { |wait = 0.1, trueFunc, falseFunc|
+	findZombies { |wait = 0.1, trueFunc, falseFunc|
 		var foundZombie = false;
 		fork {
 			this.sync;
@@ -759,11 +759,11 @@ Server {
 		if(statusWatcher.serverRunning) { "server '%' already running".format(this.name).inform; ^this };
 		if(statusWatcher.serverBooting) { "server '%' already booting".format(this.name).inform; ^this };
 
-		this.findZombie(0.1, {
+		this.findZombies(0.1, {
 
-			warn("Could not boot server, because zombie present at %.\n".format(this.addr.cs));
-			"// Kill zombies first, then try booting again:"
-			"\nServer.killAll;\n%.boot;".postf(this.cs);
+			warn("Cannot boot server because of a zombie server at %.".format(this.addr.cs));
+			"// Kill zombie(s) first, then try booting again:"
+			"\nServer.killAll;\n%.boot;\n".postf(this.cs);
 		}, {
 			// all is well
 

--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -654,6 +654,8 @@ Server {
 		}
 	}
 
+	pidRunning { ^pid.notNil and: { pid.pidRunning } }
+
 	ping { |n = 1, wait = 0.1, func|
 		var result = 0, pingFunc;
 		if(statusWatcher.serverRunning.not) { "server not running".inform; ^this };

--- a/SCClassLibrary/Common/Control/ServerStatus.sc
+++ b/SCClassLibrary/Common/Control/ServerStatus.sc
@@ -160,7 +160,7 @@ ServerStatusWatcher {
 					alive = false;
 					server.sendStatusMsg;
 					aliveThreadPeriod.wait;
-					this.updateRunningState(alive);
+					this.updateRunningState(alive or: server.pidRunning);
 				};
 			}.play(AppClock);
 			aliveThread


### PR DESCRIPTION
s.boot can end in a complicated hang when there is a zombie server. 
This happens e.g. after sclang crashed, or after hard interpreter reboot:
s.boot fails with "Exception in World_OpenUDP: bind: Address already in use ", 
and s. will not reboot because it thinks it is already booting.

This PR checks whether there is already a server responding at the desired address and port, 
and if so, informs about it. Reproducer:

```
// test finding zombies first
s.findZombies(0.1, { "found.".postln }, { "none".postln });

// make sure there are no scsynth processed around
Server.killAll;
s.findZombies(0.1, { "found.".postln }, { "none".postln });

// Start a zombie server - reports that server is booted
x = (Server.program + s.options.asOptionsString(s.addr.port)).unixCmd;
s.findZombies(0.1, { "found.".postln }, { "none".postln });

// try booting s - fails ...
s.boot; // 
// --- ... and informs with:
WARNING: Cannot boot server because of a zombie server at NetAddr.new("127.0.0.1", 57110).
// Kill zombies first, then try booting again:
Server.killAll;
s.boot;
// ---
```
So one knows what to do. 