### PR TITLE
sclang: primitives for array dimensions

### DIFF
--- a/SCClassLibrary/Common/Collections/Array.sc
+++ b/SCClassLibrary/Common/Collections/Array.sc
@@ -103,38 +103,47 @@ Array[slot] : ArrayedCollection {
 		_ArrayLace
 		^this.primitiveFailed
 	}
+
 	permute { arg nthPermutation;
 		_ArrayPermute
 		^this.primitiveFailed
 	}
+
 	allTuples { arg maxTuples = 16384;
 		_ArrayAllTuples
 		^this.primitiveFailed
 	}
+
 	wrapExtend { arg length;
 		_ArrayExtendWrap
 		^this.primitiveFailed
 	}
+
 	foldExtend { arg length;
 		_ArrayExtendFold
 		^this.primitiveFailed
 	}
+
 	clipExtend { arg length;
 		_ArrayExtendLast
 		^this.primitiveFailed
 	}
+
 	slide { arg windowLength=3, stepSize=1;
 		_ArraySlide
 		^this.primitiveFailed
 	}
+
 	containsSeqColl {
 		_ArrayContainsSeqColl
 		^this.primitiveFailed
 	}
+
 	maxDepth { arg max = 1;
 		_ArrayMaxDepth
 		^super.maxDepth(max)
 	}
+
 	maxSizeAtDepth { arg rank;
 		_ArrayMaxSizeAtDepth
 		^super.maxSizeAtDepth(rank)

--- a/SCClassLibrary/Common/Collections/Array.sc
+++ b/SCClassLibrary/Common/Collections/Array.sc
@@ -131,6 +131,14 @@ Array[slot] : ArrayedCollection {
 		_ArrayContainsSeqColl
 		^this.primitiveFailed
 	}
+	maxDepth { arg max = 1;
+		_ArrayMaxDepth
+		^super.maxDepth(max)
+	}
+	maxSizeAtDepth { arg rank;
+		_ArrayMaxSizeAtDepth
+		^super.maxSizeAtDepth(rank)
+	}
 
 	//************** inconsistent argnames, see SequenceableColllection unlace!
 	unlace { arg clumpSize=2, numChan=1, clip=false;

--- a/lang/LangPrimSource/PyrArrayPrimitives.cpp
+++ b/lang/LangPrimSource/PyrArrayPrimitives.cpp
@@ -2089,7 +2089,7 @@ int prArrayContainsSeqColl(struct VMGlobals *g, int numArgsPushed)
 	return errNone;
 }
 
-inline int sc_arrayMaxDepth(PyrSlot *a, int depth)
+int sc_arrayMaxDepth(PyrSlot *a, int depth)
 {
 	PyrSlot *slot, *endptr;
 	PyrObject *obj;
@@ -2133,7 +2133,7 @@ int prArrayMaxDepth(struct VMGlobals *g, int numArgsPushed)
 	return errNone;
 }
 
-inline int sc_arrayMaxSizeAtDepth(PyrSlot *a, int rank)
+int sc_arrayMaxSizeAtDepth(PyrSlot *a, int rank)
 {
 	PyrSlot *slot, *endptr;
 	PyrObject *obj;

--- a/lang/LangPrimSource/PyrArrayPrimitives.cpp
+++ b/lang/LangPrimSource/PyrArrayPrimitives.cpp
@@ -64,6 +64,8 @@ int prArrayPyramid(VMGlobals *g, int numArgsPushed);
 int prArraySlide(VMGlobals *g, int numArgsPushed);
 int prArrayLace(VMGlobals *g, int numArgsPushed);
 int prArrayContainsSeqColl(VMGlobals *g, int numArgsPushed);
+int prArrayMaxDepth(VMGlobals *g, int numArgsPushed);
+int prArrayMaxSizeAtDepth(VMGlobals *g, int numArgsPushed);
 int prArrayWIndex(VMGlobals *g, int numArgsPushed);
 int prArrayNormalizeSum(VMGlobals *g, int numArgsPushed);
 int prArrayIndexOfGreaterThan(VMGlobals *g, int numArgsPushed);
@@ -2087,6 +2089,96 @@ int prArrayContainsSeqColl(struct VMGlobals *g, int numArgsPushed)
 	return errNone;
 }
 
+inline int sc_arrayMaxDepth(PyrSlot *a, int depth)
+{
+	PyrSlot *slot, *endptr;
+	PyrObject *obj;
+	int size, newdepth;
+	newdepth = depth;
+	obj = slotRawObject(a);
+	size = obj->size;
+	slot = obj->slots - 1;
+	endptr = slot + size;
+	while (slot < endptr) {
+		++slot;
+		if (IsObj(slot)) {
+			if (isKindOf(slotRawObject(slot), class_collection)) {
+				if (isKindOf(slotRawObject(slot), class_arrayed_collection)) {
+					newdepth = sc_arrayMaxDepth(slot, depth + 1);
+					if(newdepth < 0) return -1;
+					newdepth = sc_max(depth, newdepth);
+				} else {
+					return -1;  // bail out
+				}
+			}
+		}
+	}
+	return newdepth;
+
+}
+
+int prArrayMaxDepth(struct VMGlobals *g, int numArgsPushed)
+{
+	PyrSlot *a, *b;
+
+	a = g->sp - 1;
+	b = g->sp;
+	
+	int maxdepth;
+	int err = slotIntVal(b, &maxdepth);
+	if (err) return err;
+	maxdepth = sc_arrayMaxDepth(a, maxdepth);
+	if(maxdepth < 0) return errFailed;
+	SetInt(a, maxdepth);
+	return errNone;
+}
+
+inline int sc_arrayMaxSizeAtDepth(PyrSlot *a, int rank)
+{
+	PyrSlot *slot, *endptr;
+	PyrObject *obj;
+	int size, newsize;
+	newsize = 0;
+	obj = slotRawObject(a);
+	size = obj->size;
+	slot = obj->slots - 1;
+	endptr = slot + size;
+	if(rank <= 0) return size;
+	while (slot < endptr) {
+		++slot;
+		if (IsObj(slot)) {
+			if (isKindOf(slotRawObject(slot), class_collection)) {
+				if (isKindOf(slotRawObject(slot), class_arrayed_collection)) {
+					newsize = sc_arrayMaxSizeAtDepth(slot, rank - 1);
+					if(newsize < 0) return -1;
+					newsize = sc_max(newsize, size);
+				} else {
+					return -1; // error
+				}
+			}
+		}
+	}
+	return newsize;
+	
+}
+
+int prArrayMaxSizeAtDepth(struct VMGlobals *g, int numArgsPushed)
+{
+	PyrSlot *a, *b;
+	
+	a = g->sp - 1;
+	b = g->sp;
+	
+	int rank;
+	int err = slotIntVal(b, &rank);
+	if (err) return err;
+	rank = sc_arrayMaxSizeAtDepth(a, rank);
+	if(rank < 0) return errFailed;
+	SetInt(a, rank);
+	return errNone;
+}
+
+
 int prArrayNormalizeSum(struct VMGlobals *g, int numArgsPushed)
 {
 	PyrSlot *a, *slots2;
@@ -2424,6 +2516,8 @@ void initArrayPrimitives()
 	definePrimitive(base, index++, "_ArrayStutter", prArrayStutter, 2, 0);
 	definePrimitive(base, index++, "_ArraySlide", prArraySlide, 3, 0);
 	definePrimitive(base, index++, "_ArrayContainsSeqColl", prArrayContainsSeqColl, 1, 0);
+	definePrimitive(base, index++, "_ArrayMaxDepth", prArrayMaxDepth, 2, 0);
+	definePrimitive(base, index++, "_ArrayMaxSizeAtDepth", prArrayMaxSizeAtDepth, 2, 0);
 
 	definePrimitive(base, index++, "_ArrayEnvAt", prArrayEnvAt, 2, 0);
 	definePrimitive(base, index++, "_ArrayIndexOfGreaterThan", prArrayIndexOfGreaterThan, 2, 0);

--- a/lang/LangPrimSource/PyrArrayPrimitives.cpp
+++ b/lang/LangPrimSource/PyrArrayPrimitives.cpp
@@ -2066,7 +2066,8 @@ int sc_arrayMaxDepth(PyrSlot *a, int depth)
 			if (isKindOf(slotRawObject(slot), class_collection)) {
 				if (isKindOf(slotRawObject(slot), class_arrayed_collection)) {
 					newdepth = sc_arrayMaxDepth(slot, depth + 1);
-					if(newdepth < 0) return -1;
+					if(newdepth < 0)
+						return -1;
 					newdepth = sc_max(depth, newdepth);
 				} else {
 					return -1;  // bail out
@@ -2111,7 +2112,8 @@ int sc_arrayMaxSizeAtDepth(PyrSlot *a, int rank)
 			if (isKindOf(slotRawObject(slot), class_collection)) {
 				if (isKindOf(slotRawObject(slot), class_arrayed_collection)) {
 					newsize = sc_arrayMaxSizeAtDepth(slot, rank - 1);
-					if(newsize < 0) return -1;
+					if(newsize < 0)
+						return -1;
 					newsize = sc_max(newsize, size);
 				} else {
 					return -1; // error
@@ -2134,7 +2136,8 @@ int prArrayMaxSizeAtDepth(struct VMGlobals *g, int numArgsPushed)
 	int err = slotIntVal(b, &rank);
 	if (err) return err;
 	rank = sc_arrayMaxSizeAtDepth(a, rank);
-	if(rank < 0) return errFailed;
+	if(rank < 0) return
+		errFailed;
 	SetInt(a, rank);
 	return errNone;
 }

--- a/lang/LangPrimSource/PyrArrayPrimitives.cpp
+++ b/lang/LangPrimSource/PyrArrayPrimitives.cpp
@@ -28,47 +28,8 @@ Primitives for Arrays.
 #include "PyrPrimitive.h"
 #include "SC_InlineBinaryOp.h"
 #include "SC_Constants.h"
+#include "PyrArrayPrimitives.h"
 #include <string.h>
-
-int basicSize(VMGlobals *g, int numArgsPushed);
-int basicMaxSize(VMGlobals *g, int numArgsPushed);
-
-int basicSwap(struct VMGlobals *g, int numArgsPushed);
-int basicAt(VMGlobals *g, int numArgsPushed);
-int basicRemoveAt(VMGlobals *g, int numArgsPushed);
-int basicClipAt(VMGlobals *g, int numArgsPushed);
-int basicWrapAt(VMGlobals *g, int numArgsPushed);
-int basicFoldAt(VMGlobals *g, int numArgsPushed);
-int basicPut(VMGlobals *g, int numArgsPushed);
-int basicClipPut(VMGlobals *g, int numArgsPushed);
-int basicWrapPut(VMGlobals *g, int numArgsPushed);
-int basicFoldPut(VMGlobals *g, int numArgsPushed);
-
-int prArrayAdd(VMGlobals *g, int numArgsPushed);
-int prArrayFill(VMGlobals *g, int numArgsPushed);
-int prArrayPop(VMGlobals *g, int numArgsPushed);
-int prArrayGrow(VMGlobals *g, int numArgsPushed);
-int prArrayCat(VMGlobals *g, int numArgsPushed);
-
-int prArrayReverse(VMGlobals *g, int numArgsPushed);
-int prArrayScramble(VMGlobals *g, int numArgsPushed);
-int prArrayRotate(VMGlobals *g, int numArgsPushed);
-int prArrayStutter(VMGlobals *g, int numArgsPushed);
-int prArrayMirror(VMGlobals *g, int numArgsPushed);
-int prArrayMirror1(VMGlobals *g, int numArgsPushed);
-int prArrayMirror2(VMGlobals *g, int numArgsPushed);
-int prArrayExtendWrap(VMGlobals *g, int numArgsPushed);
-int prArrayExtendFold(VMGlobals *g, int numArgsPushed);
-int prArrayPermute(VMGlobals *g, int numArgsPushed);
-int prArrayPyramid(VMGlobals *g, int numArgsPushed);
-int prArraySlide(VMGlobals *g, int numArgsPushed);
-int prArrayLace(VMGlobals *g, int numArgsPushed);
-int prArrayContainsSeqColl(VMGlobals *g, int numArgsPushed);
-int prArrayMaxDepth(VMGlobals *g, int numArgsPushed);
-int prArrayMaxSizeAtDepth(VMGlobals *g, int numArgsPushed);
-int prArrayWIndex(VMGlobals *g, int numArgsPushed);
-int prArrayNormalizeSum(VMGlobals *g, int numArgsPushed);
-int prArrayIndexOfGreaterThan(VMGlobals *g, int numArgsPushed);
 
 
 int basicSize(struct VMGlobals *g, int numArgsPushed)

--- a/lang/LangPrimSource/PyrArrayPrimitives.h
+++ b/lang/LangPrimSource/PyrArrayPrimitives.h
@@ -1,0 +1,67 @@
+/*
+	SuperCollider real time audio synthesis system
+    Copyright (c) 2002 James McCartney. All rights reserved.
+	http://www.audiosynth.com
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
+*/
+
+#ifndef _PYRARRAYPRIM_H_
+#define _PYRARRAYPRIM_H_
+
+
+int basicSize(VMGlobals *g, int numArgsPushed);
+int basicMaxSize(VMGlobals *g, int numArgsPushed);
+
+int basicSwap(struct VMGlobals *g, int numArgsPushed);
+int basicAt(VMGlobals *g, int numArgsPushed);
+int basicRemoveAt(VMGlobals *g, int numArgsPushed);
+int basicClipAt(VMGlobals *g, int numArgsPushed);
+int basicWrapAt(VMGlobals *g, int numArgsPushed);
+int basicFoldAt(VMGlobals *g, int numArgsPushed);
+int basicPut(VMGlobals *g, int numArgsPushed);
+int basicClipPut(VMGlobals *g, int numArgsPushed);
+int basicWrapPut(VMGlobals *g, int numArgsPushed);
+int basicFoldPut(VMGlobals *g, int numArgsPushed);
+
+int prArrayAdd(VMGlobals *g, int numArgsPushed);
+int prArrayFill(VMGlobals *g, int numArgsPushed);
+int prArrayPop(VMGlobals *g, int numArgsPushed);
+int prArrayGrow(VMGlobals *g, int numArgsPushed);
+int prArrayCat(VMGlobals *g, int numArgsPushed);
+
+int prArrayReverse(VMGlobals *g, int numArgsPushed);
+int prArrayScramble(VMGlobals *g, int numArgsPushed);
+int prArrayRotate(VMGlobals *g, int numArgsPushed);
+int prArrayStutter(VMGlobals *g, int numArgsPushed);
+int prArrayMirror(VMGlobals *g, int numArgsPushed);
+int prArrayMirror1(VMGlobals *g, int numArgsPushed);
+int prArrayMirror2(VMGlobals *g, int numArgsPushed);
+int prArrayExtendWrap(VMGlobals *g, int numArgsPushed);
+int prArrayExtendFold(VMGlobals *g, int numArgsPushed);
+int prArrayPermute(VMGlobals *g, int numArgsPushed);
+int prArrayPyramid(VMGlobals *g, int numArgsPushed);
+int prArraySlide(VMGlobals *g, int numArgsPushed);
+int prArrayLace(VMGlobals *g, int numArgsPushed);
+int prArrayContainsSeqColl(VMGlobals *g, int numArgsPushed);
+int prArrayMaxDepth(VMGlobals *g, int numArgsPushed);
+int prArrayMaxSizeAtDepth(VMGlobals *g, int numArgsPushed);
+int prArrayWIndex(VMGlobals *g, int numArgsPushed);
+int prArrayNormalizeSum(VMGlobals *g, int numArgsPushed);
+int prArrayIndexOfGreaterThan(VMGlobals *g, int numArgsPushed);
+
+
+
+#endif


### PR DESCRIPTION
These primitives speed up the measurement of depth and size at a
certain depth. They bail out to the sclang implementation if an array
includes a non-array-sequenceable collection.