### PR TITLE
scsynth: implement /version command

### DIFF
--- a/HelpSource/Reference/Server-Command-Reference.schelp
+++ b/HelpSource/Reference/Server-Command-Reference.schelp
@@ -124,10 +124,14 @@ definitionlist::
 ## int || Major version number. Equivalent to sclang's code::Main.scVersionMajor::.
 ## int || Minor version number. Equivalent to sclang's code::Main.scVersionMinor::.
 ## string || Patch version name. Equivalent to sclang's code::Main.scVersionPostfix::.
+## string || Git branch name.
+## string || First seven hex digits of the commit hash.
 ::
 ::
 
 The standard human-readable version string can be constructed by concatenating code:: major_version ++ "." ++ minor_version ++ patch_version ::. Since version information is easily accessible to sclang users via the methods described above, this command is mostly useful for alternate clients.
+
+The git branch name and commit hash could be anything if the user has forked SC, so they should only be used for display and user interface purposes.
 
 section:: Synth Definition Commands
 

--- a/HelpSource/Reference/Server-Command-Reference.schelp
+++ b/HelpSource/Reference/Server-Command-Reference.schelp
@@ -115,6 +115,20 @@ However, even if this is not done, the next bundle or message received will begi
 
 Temporary error suppression may not affect asynchronous commands in every case.
 
+subsection:: /version
+
+Query the SuperCollider version. Replies to sender with the following message:
+definitionlist::
+## /version.reply || table::
+## string || Program name. May be "scsynth" or "supernova".
+## int || Major version number. Equivalent to sclang's code::Main.scVersionMajor::.
+## int || Minor version number. Equivalent to sclang's code::Main.scVersionMinor::.
+## string || Patch version name. Equivalent to sclang's code::Main.scVersionPostfix::.
+::
+::
+
+The standard human-readable version string can be constructed by concatenating code:: major_version ++ "." ++ minor_version ++ patch_version ::. Since version information is easily accessible to sclang users via the methods described above, this command is mostly useful for alternate clients.
+
 section:: Synth Definition Commands
 
 subsection:: /d_recv

--- a/include/server/SC_OSC_Commands.h
+++ b/include/server/SC_OSC_Commands.h
@@ -109,7 +109,10 @@ enum {
 	cmd_n_order = 62,
 
 	cmd_p_new = 63,
-	NUMBER_OF_COMMANDS = 64
+
+	cmd_version = 64,
+
+	NUMBER_OF_COMMANDS = 65
 };
 
 #endif /* _SC_OSC_Commands_ */

--- a/server/scsynth/SC_MiscCmds.cpp
+++ b/server/scsynth/SC_MiscCmds.cpp
@@ -1334,12 +1334,16 @@ SCErr meth_version(World *inWorld, int inSize, char *inData, ReplyAddress* inRep
 
 	small_scpacket packet;
 	packet.adds("/version");
-	packet.maketags(3);
+	packet.maketags(5);
 	packet.addtag(',');
 	packet.addtag('s');
 	packet.adds("scsynth");
+	packet.addtag('i');
+	packet.addi(SC_VersionMajor);
+	packet.addtag('i');
+	packet.addi(SC_VersionMinor);
 	packet.addtag('s');
-	packet.adds(SC_VersionString().c_str());
+	packet.adds(SC_VersionPatch);
 
 	CallSequencedCommand(SendReplyCmd, inWorld, packet.size(), packet.data(), inReply);
 

--- a/server/scsynth/SC_MiscCmds.cpp
+++ b/server/scsynth/SC_MiscCmds.cpp
@@ -1333,7 +1333,7 @@ SCErr meth_version(World *inWorld, int inSize, char *inData, ReplyAddress* inRep
 	sc_msg_iter msg(inSize, inData);
 
 	small_scpacket packet;
-	packet.adds("/version");
+	packet.adds("/version.reply");
 	packet.maketags(5);
 	packet.addtag(',');
 	packet.addtag('s');

--- a/server/scsynth/SC_MiscCmds.cpp
+++ b/server/scsynth/SC_MiscCmds.cpp
@@ -33,6 +33,7 @@
 #include "SC_Prototypes.h"
 #include "scsynthsend.h"
 #include "SC_WorldOptions.h"
+#include "SC_Version.hpp"
 
 extern int gMissingNodeID;
 
@@ -1326,6 +1327,25 @@ SCErr meth_dumpOSC(World *inWorld, int inSize, char *inData, ReplyAddress *inRep
 	return kSCErr_None;
 }
 
+SCErr meth_version(World *inWorld, int inSize, char *inData, ReplyAddress *inReply);
+SCErr meth_version(World *inWorld, int inSize, char *inData, ReplyAddress* inReply)
+{
+	sc_msg_iter msg(inSize, inData);
+
+	small_scpacket packet;
+	packet.adds("/version");
+	packet.maketags(3);
+	packet.addtag(',');
+	packet.addtag('s');
+	packet.adds("scsynth");
+	packet.addtag('s');
+	packet.adds(SC_VersionString().c_str());
+
+	CallSequencedCommand(SendReplyCmd, inWorld, packet.size(), packet.data(), inReply);
+
+	return kSCErr_None;
+}
+
 SCErr meth_b_set(World *inWorld, int inSize, char *inData, ReplyAddress *inReply);
 SCErr meth_b_set(World *inWorld, int inSize, char *inData, ReplyAddress* /*inReply*/)
 {
@@ -1862,6 +1882,7 @@ void initMiscCommands()
 	NEW_COMMAND(status);
 	NEW_COMMAND(quit);
 	NEW_COMMAND(clearSched);
+	NEW_COMMAND(version);
 
 	NEW_COMMAND(d_recv);
 	NEW_COMMAND(d_load);

--- a/server/scsynth/SC_MiscCmds.cpp
+++ b/server/scsynth/SC_MiscCmds.cpp
@@ -1334,7 +1334,7 @@ SCErr meth_version(World *inWorld, int inSize, char *inData, ReplyAddress* inRep
 
 	small_scpacket packet;
 	packet.adds("/version.reply");
-	packet.maketags(5);
+	packet.maketags(7);
 	packet.addtag(',');
 	packet.addtag('s');
 	packet.adds("scsynth");
@@ -1344,6 +1344,10 @@ SCErr meth_version(World *inWorld, int inSize, char *inData, ReplyAddress* inRep
 	packet.addi(SC_VersionMinor);
 	packet.addtag('s');
 	packet.adds(SC_VersionPatch);
+	packet.addtag('s');
+	packet.adds(SC_Branch);
+	packet.addtag('s');
+	packet.adds(SC_CommitHash);
 
 	CallSequencedCommand(SendReplyCmd, inWorld, packet.size(), packet.data(), inReply);
 


### PR DESCRIPTION
This fixes #2544 for scsynth, but not for supernova.