### PR TITLE
tests: don't make noise

### DIFF
--- a/testsuite/classlibrary/TestCoreUGens.sc
+++ b/testsuite/classlibrary/TestCoreUGens.sc
@@ -341,7 +341,8 @@ test_bufugens{
 
 		// Copying data from b to c:
 		{
-			RecordBuf.ar(PlayBuf.ar(numchans, b, BufRateScale.ir(b), doneAction: 2), c, loop:0) * 0.1;
+			RecordBuf.ar(PlayBuf.ar(numchans, b, BufRateScale.ir(b), doneAction: 2), c, loop:0);
+            DC.ar(0);
 		}.play;
 		Server.default.sync;
 		1.0.wait;
@@ -373,7 +374,7 @@ test_demand {
 	o.add;
 
 	tests = [
-		{LPF.ar(LeakDC.ar(Duty.ar(0.1, 0, Dseq((1..8)), 2)))}
+            {LPF.ar(LeakDC.ar(Duty.ar(0.1, 0, Dseq((1..8)), 2))); DC.ar(0);}
 	];
 
 	tests.do{|item| nodestofree = nodestofree.add(item.play.nodeID) };
@@ -393,7 +394,7 @@ test_demand {
 			5453, {testNaN = msg[3] <= 0.0 or:{msg[3] >= 1.0}}		);
 	});
 	o.add;
-	{Line.kr(1, 0, 1, 1, 0, 2); SendTrig.kr(Impulse.kr(10, 0.5), 5453, LFTri.ar(Duty.ar(0.1, 0, Dseq(#[100], 1))))}.play;
+    {Line.kr(1, 0, 1, 1, 0, 2); SendTrig.kr(Impulse.kr(10, 0.5), 5453, LFTri.ar(Duty.ar(0.1, 0, Dseq(#[100], 1)))); DC.ar(0)}.play;
 	1.5.wait;
 	s.sync;
 	this.assert(testNaN.not, "Duty+LFTri should not output NaN");
@@ -407,14 +408,12 @@ test_pitchtrackers {
 				var son = SinOsc.ar(freq);
 				var val = A2K.kr(ZeroCrossing.ar(son));
 				var dev = (freq-val).abs * XLine.kr(0.0001, 1, 0.1);
-				Out.ar(0, (son * 0.1).dup);
 				dev},
 		"Pitch.kr() tracking a Saw"
 				-> { var freq = XLine.kr(100, 1000, 10);
 				var son = Saw.ar(freq);
 				var val = Pitch.kr(son).at(0);
 				var dev = (freq-val).abs * XLine.kr(0.0001, 1, 0.1);
-				Out.ar(0, (son * 0.1).dup);
 				dev * 0.1 /* rescaled cos Pitch more variable than ZCR */ },
 		];
 	var testsIncomplete = tests.size;

--- a/testsuite/classlibrary/TestCoreUGens.sc
+++ b/testsuite/classlibrary/TestCoreUGens.sc
@@ -342,7 +342,8 @@ test_bufugens{
 		// Copying data from b to c:
 		{
 			RecordBuf.ar(PlayBuf.ar(numchans, b, BufRateScale.ir(b), doneAction: 2), c, loop:0);
-            DC.ar(0);
+			// Return silence to avoid making noise
+			0;
 		}.play;
 		Server.default.sync;
 		1.0.wait;
@@ -374,7 +375,11 @@ test_demand {
 	o.add;
 
 	tests = [
-            {LPF.ar(LeakDC.ar(Duty.ar(0.1, 0, Dseq((1..8)), 2))); DC.ar(0);}
+		{
+			LPF.ar(LeakDC.ar(Duty.ar(0.1, 0, Dseq((1..8)), 2)));
+			// Return silence to avoid making noise
+			0;
+		}
 	];
 
 	tests.do{|item| nodestofree = nodestofree.add(item.play.nodeID) };
@@ -394,7 +399,12 @@ test_demand {
 			5453, {testNaN = msg[3] <= 0.0 or:{msg[3] >= 1.0}}		);
 	});
 	o.add;
-    {Line.kr(1, 0, 1, 1, 0, 2); SendTrig.kr(Impulse.kr(10, 0.5), 5453, LFTri.ar(Duty.ar(0.1, 0, Dseq(#[100], 1)))); DC.ar(0)}.play;
+	{
+		Line.kr(1, 0, 1, 1, 0, 2);
+		SendTrig.kr(Impulse.kr(10, 0.5), 5453, LFTri.ar(Duty.ar(0.1, 0, Dseq(#[100], 1))));
+		// Return silence to avoid making noise
+		0;
+	}.play;
 	1.5.wait;
 	s.sync;
 	this.assert(testNaN.not, "Duty+LFTri should not output NaN");


### PR DESCRIPTION
This commit silences several unit tests that make noise. Fix #2548.