### PR TITLE
replaced CubicTo with QuadTo

### DIFF
--- a/SCClassLibrary/Common/GUI/Base/QPen.sc
+++ b/SCClassLibrary/Common/GUI/Base/QPen.sc
@@ -157,7 +157,7 @@ Pen {
 	}
 
 	*quadCurveTo { arg endPoint, cPoint;
-		_QPen_CubicTo
+		_QPen_QuadTo
 		^this.primitiveFailed;
 	}
 


### PR DESCRIPTION
it seems that "quadCurveTo" should point on "quadTo" prim and not "cubTo" ??