### PR TITLE
Fix Array.schelp

### DIFF
--- a/HelpSource/Classes/Array.schelp
+++ b/HelpSource/Classes/Array.schelp
@@ -57,17 +57,17 @@ copymethod:: ArrayedCollection *series
 
 copymethod:: ArrayedCollection *iota
 
-copymethod:: Collection *interpolation
+copymethod:: SequenceableCollection *interpolation
 
-copymethod:: Collection *rand
+copymethod:: SequenceableCollection *rand
 
-copymethod:: Collection *rand2
+copymethod:: SequenceableCollection *rand2
 
-copymethod:: Collection *linrand
+copymethod:: SequenceableCollection *linrand
 
-copymethod:: Collection *exprand
+copymethod:: SequenceableCollection *exprand
 
-copymethod:: Collection *fib
+copymethod:: SequenceableCollection *fib
 
 
 

--- a/HelpSource/Classes/Array.schelp
+++ b/HelpSource/Classes/Array.schelp
@@ -81,15 +81,11 @@ copymethod:: ArrayedCollection -put
 
 copymethod:: ArrayedCollection -insert
 
-copymethod:: ArrayedCollection -overWrite
-
 copymethod:: ArrayedCollection -clipAt
 
 copymethod:: ArrayedCollection -wrapAt
 
 copymethod:: ArrayedCollection -foldAt
-
-copymethod:: ArrayedCollection -slice
 
 copymethod:: ArrayedCollection -clipPut
 
@@ -120,10 +116,6 @@ copymethod:: ArrayedCollection -reverseDo
 copymethod:: ArrayedCollection -deepCollect
 
 copymethod:: ArrayedCollection -reshape
-
-copymethod:: ArrayedCollection -bubble
-
-copymethod:: ArrayedCollection -unbubble
 
 copymethod:: ArrayedCollection -windex
 


### PR DESCRIPTION
Array.schelp throws "method not found" warnings when it's parsed. I changed the `copymethod::` requests to point to the correct help file when it exists, and deleted `copymethod::` requests for documentation that doesn't exist yet.