### PR TITLE
Fix multiple .schelp files (grammar, missing args, broken links, missing methods)

### DIFF
--- a/HelpSource/Classes/Image.schelp
+++ b/HelpSource/Classes/Image.schelp
@@ -224,12 +224,6 @@ i.plot;
 i.free;
 ::
 
-METHOD::accelerated
-if true, the receiver currently use the CoreImage model, possibly caching its data on GPU, if not the bitmap model. Set it to switch representation.
-WARNING::
-this method should never be used directly unless you know perfectly what you are doing. Since the Image will switch internally and manage itself the syncronization between representations.
-::
-
 METHOD::interpolation
 get or set the level of interpolation used when rendering the image - it has not effect when the Image is accelerated. see link::#*interpolations:: for a valid range of values.
 code::

--- a/HelpSource/Classes/Image.schelp
+++ b/HelpSource/Classes/Image.schelp
@@ -55,8 +55,8 @@ i = Image.color(400, 200, Color.blue(0.9,0.1));
 i.plot(freeOnClose:true);
 ::
 
-ARGUMENT::args
-multiple arguments. the last argument should be a valid link::Classes/Color::
+ARGUMENT::... args
+Multiple arguments. the last argument should be a valid link::Classes/Color::
 
 METHOD::open
 Creates a new Image instance from the local file at strong::path::.

--- a/HelpSource/Classes/Image.schelp
+++ b/HelpSource/Classes/Image.schelp
@@ -34,17 +34,12 @@ i = Image.new(400@200);	// Create a 400x200 pixel Image.
 i.dump;
 i.free;
 ::
-## link::Classes/String:: to create an image from a strong::local file:: or from an strong::URL:: (http://, ftp://, file:///)
+## link::Classes/String:: to create an image from a strong::local file::
 code::
 //	Path string
 i = Image.new(SCDoc.helpSourceDir +/+ "images/Swamp.png"); // add a path to your image
 [i.width, i.height].postln;
 i.plot;
-i.free;
-//	URL string - NOT IMPLEMENTE YET
-i = Image.new("http://www.google.com/intl/en_ALL/images/logo.gif");
-i.plot;
-i.url;
 i.free;
 ::
 ::

--- a/HelpSource/Classes/Image.schelp
+++ b/HelpSource/Classes/Image.schelp
@@ -305,6 +305,9 @@ the location where to save it
 ARGUMENT::format
 (optional) format to use. see Image.formats for supported formats. If nil, it will get the format depending on the path extension.
 
+ARGUMENT::quality
+The quality factor must be in the range 0 to 100 or -1. Specify 0 to obtain small compressed files, 100 for large uncompressed files, and -1 (the default) to use the default settings.
+
 SUBSECTION::rendering
 
 METHOD::plot

--- a/HelpSource/Classes/Image.schelp
+++ b/HelpSource/Classes/Image.schelp
@@ -44,6 +44,10 @@ i.free;
 ::
 ::
 
+ARGUMENT::height
+If strong::multiple:: is a number, then this argument indicates the height of the new image.
+
+
 METHOD::color
 Creates a new Image instance filled with the specified color.
 code::

--- a/HelpSource/Classes/Image.schelp
+++ b/HelpSource/Classes/Image.schelp
@@ -13,24 +13,24 @@ CLASSMETHODS::
 PRIVATE::initClass, prFromWindowRect, prFreeAll
 
 METHOD::new
-Creates a new Image instance. multiple stands here for multiple arguments.
+Creates a new Image instance. "multiple" here stands for multiple arguments.
 
 ARGUMENT::multiple
-May be a...
+Any of the following:
 list::
 ## link::Classes/Number:: to create an strong::empty:: image of size multiple as width and height
 code::
-i = Image.new(400);		// Create a 400x400 pixels Image.
+i = Image.new(400);		// Create a 400x400 pixel Image.
 i.dump;
 i.free;
 
-i = Image.new(400, 200);	// Create a 400x200 pixels Image.
+i = Image.new(400, 200);	// Create a 400x200 pixel Image.
 i.dump;
 i.free;
 ::
 ## link::Classes/Point:: to create an strong::empty:: image of size multiple.x as width and multiple.y as height
 code::
-i = Image.new(400@200);	// Create a 400x200 pixels Image.
+i = Image.new(400@200);	// Create a 400x200 pixel Image.
 i.dump;
 i.free;
 ::

--- a/HelpSource/Classes/Interpreter.schelp
+++ b/HelpSource/Classes/Interpreter.schelp
@@ -1,7 +1,7 @@
 class::Interpreter
 summary:: The interpreter defines a context in which interactive commands are compiled and executed.
 categories:: Core>Kernel
-related::How-to-Use-the-Interpreter
+related::Guides/How to Use the Interpreter
 
 description::
 The interpreter is an object that handles the translation and execution of code at runtime. It is that what runs any program code and defines a context for it.

--- a/HelpSource/Classes/LinSelectX.schelp
+++ b/HelpSource/Classes/LinSelectX.schelp
@@ -11,6 +11,7 @@ method:: ar, kr
 
 argument:: which
 argument:: array
+argument:: wrap
 
 examples::
 code::

--- a/HelpSource/Classes/NdefGui.schelp
+++ b/HelpSource/Classes/NdefGui.schelp
@@ -85,16 +85,15 @@ not a class var, but the method that inits buttonFuncs.
 
 InstanceMethods::
 
-subsection::Instance Variables
+subsection::Variables
 
-As in all JITGuis:
+See link::Classes/JITGui:: for more instance methods.
 
-... object, numItems, parent, bounds; zone, minSize, defPos, skin, font, skipjack ...
+Various views the NdefGui has if they were present in the options:
 
 method::nameView, typeView, monitorGui, paramGui, fadeBox, pauseBut, sendBut, edBut, wakeBut
-Various views the NdefGui has if they were present in the options.
 
-subsection::Instance Methods
+subsection::Basic Methods
 
 method::edits
 the paramGui's widgets (usually, EZSliders)
@@ -119,11 +118,11 @@ method::proxy
 an alias to method object, object_
 
 
-strong::Standard JITGui methods: ::
+subsection::Standard JITGui Methods
 
 method:: setDefaults, accepts, getState, checkUpdate
 
-strong:: Methods that make the various gui elements: ::
+subsection::GUI Element Creation
 
 method:: makeViews, makeNameView, makeTypeView, makeClrBut, makeWakeBut, makeResetBut, makeScopeBut, makeDocBut, makeEndBut, makeFadeBox, makeMonitor, makePauseBut, makeSendBut, makeEdBut, makeRipBut, makePollBut
 

--- a/HelpSource/Classes/ObjectGui.schelp
+++ b/HelpSource/Classes/ObjectGui.schelp
@@ -59,10 +59,10 @@ returns:: this
 METHOD:: update
 When the model is changed and the .changed method is called then .update is called on all dependants including this gui object.  Update the views you have placed in the guiBody.
 
-argument:: changed
+argument:: theChanged
 The model.  Within your gui class the model is already in the instance variable 'model'.
 
-argument:: changer
+argument:: theChanger
 Depends on the conventions of how .changed was called.  If an object called someModel.changed(this) then it is supplying itself as the changer and will be passed through here.  Sometimes a flag is used: someModel.changed('points') and the gui may know of and participate in that convention.  Sometimes no changer is passed in.
 
 

--- a/HelpSource/Classes/PV_Conj.schelp
+++ b/HelpSource/Classes/PV_Conj.schelp
@@ -7,8 +7,8 @@ Converts the FFT frames to their complex conjugate (i.e. reverses the sign of th
 
 classmethods::
 method:: new
-argument:: chain
-fft chain.
+argument:: buffer
+FFT chain.
 
 examples::
 code::

--- a/HelpSource/Classes/Padd.schelp
+++ b/HelpSource/Classes/Padd.schelp
@@ -7,8 +7,12 @@ ClassMethods::
 
 method::new
 
+argument::name
+
 argument::value
 can be a pattern or a stream. The resulting stream ends when that incoming stream ends.
+
+argument::pattern
 
 Examples::
 

--- a/HelpSource/Classes/PatternProxy.schelp
+++ b/HelpSource/Classes/PatternProxy.schelp
@@ -22,7 +22,7 @@ method::defaultQuant
 set the default quantization value for the class. (default: nil)
 
 method::defaultValue
-a default return value, if no source is given. the default is 1.0 (it is not 0.0 in order to make it safe for durations). This is used in link::-endless::.
+a default return value, if no source is given. the default is 1.0 (it is not 0.0 in order to make it safe for durations). This is used in link::#-endless::.
 
 InstanceMethods::
 

--- a/HelpSource/Classes/PdefGui.schelp
+++ b/HelpSource/Classes/PdefGui.schelp
@@ -145,7 +145,7 @@ a compileString that recreates the Pdef's envir at edKey.
 method::editStrings
 a compileString that recreates the Pdef's envir at edKeys.
 
-argument::edKey
+argument::edKeys
 Default value is nil.
 
 code::

--- a/HelpSource/Classes/Pen.schelp
+++ b/HelpSource/Classes/Pen.schelp
@@ -46,7 +46,7 @@ Draws a quad bezier curve from the current position to point.
 strong::cpoint1:: is a control point determining the curve's curvature.
 argument:: endPoint
 An instance of link::Classes/Point::
-argument:: cPoint1
+argument:: cPoint
 An instance of link::Classes/Point::
 
 method:: arcTo

--- a/HelpSource/Classes/Pen.schelp
+++ b/HelpSource/Classes/Pen.schelp
@@ -43,7 +43,7 @@ An instance of link::Classes/Point::
 
 method:: quadCurveTo
 Draws a quad bezier curve from the current position to point.
-strong::cpoint1:: is a control point determining the curve's curvature.
+strong::cpoint:: is a control point determining the curve's curvature.
 argument:: endPoint
 An instance of link::Classes/Point::
 argument:: cPoint

--- a/HelpSource/Classes/Pmulp.schelp
+++ b/HelpSource/Classes/Pmulp.schelp
@@ -11,8 +11,12 @@ ClassMethods::
 
 method::new
 
+argument::name
+
 argument::value
 can be a pattern, a stream or an array. The resulting stream ends when that incoming stream ends.
+
+argument::pattern
 
 Examples::
 

--- a/HelpSource/Classes/Pmulpre.schelp
+++ b/HelpSource/Classes/Pmulpre.schelp
@@ -30,8 +30,12 @@ ClassMethods::
 
 method::new
 
+argument::name
+
 argument::value
 can be a pattern or a stream. The resulting stream ends when that incoming stream ends.
+
+argument::pattern
 
 Examples::
 

--- a/HelpSource/Classes/ProgramChangeResponder.schelp
+++ b/HelpSource/Classes/ProgramChangeResponder.schelp
@@ -18,11 +18,11 @@ The src number may be the system UID (obtained from code:: MIDIClient.sources[in
 argument::chan
 An link::Classes/Integer:: between 0 and 15 that selects which MIDI channel to match. nil matches all. May also be a link::Classes/Function:: which will be evaluated to determine the match. eg: { |val| val < 2 }
 
-argument::num
+argument::value
 An link::Classes/Integer:: between 0 and 127 that selects which program change number to match. nil matches all. May also be a link::Classes/Function:: which will be evaluated to determine the match. eg: { |val| val >= 4 }
 
 argument::install
-If true, then if the midi event is matched, cease testing any further responders. Note that doing this will prevent any other responders of this type from responding, including ones added behind the scenes in classes. Note also that this functionality is sensitive to the order in which responders are added. 
+If true, then if the midi event is matched, cease testing any further responders. Note that doing this will prevent any other responders of this type from responding, including ones added behind the scenes in classes. Note also that this functionality is sensitive to the order in which responders are added.
 
 Examples::
 

--- a/HelpSource/Classes/Psetp.schelp
+++ b/HelpSource/Classes/Psetp.schelp
@@ -11,8 +11,12 @@ ClassMethods::
 
 method::new
 
+argument::name
+
 argument::value
 can be a pattern, a stream or an array. The resulting stream ends when that incoming stream ends.
+
+argument::pattern
 
 Examples::
 

--- a/HelpSource/Classes/Pspawner.schelp
+++ b/HelpSource/Classes/Pspawner.schelp
@@ -11,7 +11,7 @@ ClassMethods::
 
 method::new
 
-argument::function
+argument::routineFunc
 The function defines a link::Classes/Routine:: that receives a link::Classes/Spawner:: as its sole argument. All control of subpatterns is through the spawner.
 
 link::Classes/Spawner:: responds to the messages:
@@ -114,7 +114,7 @@ p = Pspawner({ | sp |
 	sp.par(Pbind(*[octave: 7, degree: pat, dur: 1/6, db: -20]) );
 	sp.wait(4);
 	sp.par(Pbind(*[octave: 4, degree: pat, dur: 1/4]) );
-	
+
 	sp.wait(8);
 	sp.suspendAll;
 });

--- a/HelpSource/Classes/Quark.schelp
+++ b/HelpSource/Classes/Quark.schelp
@@ -41,6 +41,8 @@ ARGUMENT:: dep
 ARGUMENT:: forQuark
 returns:: this
 
+PRIVATE::prMakeDep
+
 INSTANCEMETHODS::
 
 METHOD:: name
@@ -140,3 +142,5 @@ returns:: this
 METHOD:: parseQuarkFile
 private
 returns:: this
+
+PRIVATE::prCollectDependencies

--- a/HelpSource/Classes/Quark.schelp
+++ b/HelpSource/Classes/Quark.schelp
@@ -35,6 +35,11 @@ ARGUMENT:: url
 ARGUMENT:: localPath
 returns:: this
 
+METHOD:: parseDependency
+private
+ARGUMENT:: dep
+ARGUMENT:: forQuark
+returns:: this
 
 INSTANCEMETHODS::
 
@@ -127,11 +132,6 @@ METHOD:: changed
 After un/installing or checking out, state is set to changed.
 code smell: this is for the gui
 returns:: Boolean
-
-METHOD:: parseDependency
-private
-ARGUMENT:: dep
-returns:: this
 
 METHOD:: printOn
 ARGUMENT:: stream

--- a/HelpSource/Classes/Quark.schelp
+++ b/HelpSource/Classes/Quark.schelp
@@ -13,6 +13,8 @@ METHOD:: new
 ARGUMENT:: name
 Quark name, git url or local path (absolute or relative)
 ARGUMENT:: refspec
+ARGUMENT:: url
+ARGUMENT:: localPath
 returns:: this
 
 METHOD:: fromLocalPath
@@ -23,12 +25,14 @@ returns:: this
 METHOD:: fromDirectoryEntry
 alternate constructor
 ARGUMENT:: name
-ARGUMENT:: quarkUrl
+ARGUMENT:: directoryEntry
 returns:: this
 
 METHOD:: parseQuarkName
 ARGUMENT:: name
 ARGUMENT:: refspec
+ARGUMENT:: url
+ARGUMENT:: localPath
 returns:: this
 
 

--- a/HelpSource/Classes/RawArray.schelp
+++ b/HelpSource/Classes/RawArray.schelp
@@ -8,6 +8,3 @@ RawArray is the abstract superclass of a group of array classes that hold raw da
 INSTANCEMETHODS::
 
 private::archiveAsCompileString, archiveAsObject
-
-method::write
-Writes the array as a file.

--- a/HelpSource/Guides/How-to-Use-the-Interpreter.schelp
+++ b/HelpSource/Guides/How-to-Use-the-Interpreter.schelp
@@ -1,4 +1,4 @@
-title:: How-to-Use-the-Interpreter
+title:: How to Use the Interpreter
 summary:: Basic tutorial on how to run code
 categories:: Frontends, Tutorials
 


### PR DESCRIPTION
I hope it's okay that I bundled these all together--most are pretty uncontroversial, and I figured it was better than making 20 separate PRs.

I've been using this code to find SCDoc warnings:
```
a = SCDoc.indexAllDocuments;
fork {a.documents.keys.do {|x| HelpBrowser.openHelpFor(x); 0.05.wait}};
```

The majority of these commits fix the issues that generate those warnings. The rest are grammar fixes and similar issues that I discovered during that process. More than happy to discuss and/or walk back changes.