### PR TITLE
Capitalize OS names in help files

### DIFF
--- a/HelpSource/Classes/AbstractServerAction.schelp
+++ b/HelpSource/Classes/AbstractServerAction.schelp
@@ -8,9 +8,9 @@ description::
 This is an strong::abstract superclass:: for singletons like link::Classes/ServerQuit::, which provides a place for registering functions and objects for events that should happen when something happens in the server.
 No direct call to AbstractServerAction is required.
 
-note:: not fully working on linux and windows.
+note:: not fully working on Linux and windows.
 Setting the computer to sleep on these systems causes the actions to be called.
-As to date in linux, JACK does not survive a sleep, it nevertheless behaves correctly for the time being.
+As to date in Linux, JACK does not survive a sleep, it nevertheless behaves correctly for the time being.
 ::
 
 ClassMethods::

--- a/HelpSource/Classes/Document.schelp
+++ b/HelpSource/Classes/Document.schelp
@@ -108,7 +108,7 @@ A class for implementing Document.
 
 subsection:: Path Utilities
 
-Utilities and settings for dealing with documents such as supercollider code files. By default the document directory is SuperCollider's application directory.
+Utilities and settings for dealing with documents such as SuperCollider code files. By default the document directory is SuperCollider's application directory.
 
 method:: dir
 Get/set the default document directory. The default is dependent on link::Classes/Document#implementationClass::.
@@ -560,7 +560,7 @@ fork({
 )
 ::
 
-Changing the default look of documents can be done with the help of the link::#*initAction:: method. Run the following example once. Afterwards all newly created documents will have a dark grey background. To make this change happen every time you start supercollider, put the code inside your startup.scd file (and optionally wrap it in a code::{}.defer(0.1):: ).
+Changing the default look of documents can be done with the help of the link::#*initAction:: method. Run the following example once. Afterwards all newly created documents will have a dark grey background. To make this change happen every time you start SuperCollider, put the code inside your startup.scd file (and optionally wrap it in a code::{}.defer(0.1):: ).
 code::
 (
 Document.listener.background = Color.red;	//a special color for post document

--- a/HelpSource/Classes/FlowView.schelp
+++ b/HelpSource/Classes/FlowView.schelp
@@ -161,7 +161,7 @@ f = FlowView.new;
 
 GUI.slider.new(f, Rect(0,0,100,100));
 
-// sc composite view
+// SuperCollider composite view
 g = f.comp({ arg g;
 	GUI.slider.new(g, Rect(50,30,50,100)).background_(Color.rand);
 	GUI.slider.new(g, Rect(120,30,50,100)).background_(Color.rand);

--- a/HelpSource/Classes/LID.schelp
+++ b/HelpSource/Classes/LID.schelp
@@ -4,7 +4,7 @@ categories:: Platform>Linux, External Control>HID
 related:: Classes/HID, Classes/LIDInfo, Classes/LIDSlot, Classes/LIDGui
 
 description::
-This class provides a way to access devices in the linux input layer, which supports many input devices (mouse, keyboard, joystick, gamepad, tablet) and busses (serial, PS/2, USB).
+This class provides a way to access devices in the Linux input layer, which supports many input devices (mouse, keyboard, joystick, gamepad, tablet) and busses (serial, PS/2, USB).
 
 NOTE::For external HID devices it is recommended to use the link::Classes/HID:: interface, as described in link::Guides/Working_with_HID::, as it will ensure that your code is cross platform compatible. Only in cases where the raw HID interface does not provide access because the device needs a special driver (and this driver is provided in Linux kernel), or in case you want to access internal devices, you should use this class.
 ::

--- a/HelpSource/Classes/Pipe.schelp
+++ b/HelpSource/Classes/Pipe.schelp
@@ -37,7 +37,7 @@ returns:: The exit status of the command (an Integer).
 Examples::
 
 note::
-For anyone still using OS X 10.3, unix commands like pipe do not work when the server is booted; quit the server, otherwise sc crashes. More recent OS X is not affected.
+For anyone still using OS X 10.3, unix commands like pipe do not work when the server is booted; quit the server, otherwise SuperCollider crashes. More recent OS X is not affected.
 ::
 
 code::

--- a/HelpSource/Classes/Pipe.schelp
+++ b/HelpSource/Classes/Pipe.schelp
@@ -1,10 +1,10 @@
 class:: Pipe
-summary:: pipe stdin to, or stdout from, a unix shell command
+summary:: pipe stdin to, or stdout from, a UNIX shell command
 related:: Classes/UnixFILE
 categories:: Files
 
 description::
-Pipe stdin to, or stdout from, a unix shell command. Pipe treats the shell command as if it were a UnixFILE, and returns nil when done. See link::Classes/UnixFILE:: for details of the access methods. Pipe must be explicitly closed. Do not rely on the garbage collector to do this for you!
+Pipe stdin to, or stdout from, a UNIX shell command. Pipe treats the shell command as if it were a UnixFILE, and returns nil when done. See link::Classes/UnixFILE:: for details of the access methods. Pipe must be explicitly closed. Do not rely on the garbage collector to do this for you!
 
 ClassMethods::
 
@@ -37,7 +37,7 @@ returns:: The exit status of the command (an Integer).
 Examples::
 
 note::
-For anyone still using OS X 10.3, unix commands like pipe do not work when the server is booted; quit the server, otherwise SuperCollider crashes. More recent OS X is not affected.
+For anyone still using OS X 10.3, UNIX commands like pipe do not work when the server is booted; quit the server, otherwise SuperCollider crashes. More recent OS X is not affected.
 ::
 
 code::

--- a/HelpSource/Classes/SCImage.schelp
+++ b/HelpSource/Classes/SCImage.schelp
@@ -5,7 +5,7 @@ related:: Classes/SCImageFilter, Classes/SCImageKernel
 
 DESCRIPTION::
 
-SCImage is an image component for the Mac OS X supercollider client. SCImage is currently a wrapper around different models : you can use it for bitmap operations, image embedding for custom UI and for more advanced image processing as applying filters and kernels, both provided with the CoreImage framework.
+SCImage is an image component for the Mac OS X SuperCollider client. SCImage is currently a wrapper around different models : you can use it for bitmap operations, image embedding for custom UI and for more advanced image processing as applying filters and kernels, both provided with the CoreImage framework.
 
 SCImage currently supports most formats including tiff, bmp, gif, jpeg, png, tga...ect.. for reading. But for for writing it supports only those in code::SCImage.formats::.
 

--- a/HelpSource/Classes/SCImageFilter.schelp
+++ b/HelpSource/Classes/SCImageFilter.schelp
@@ -69,7 +69,7 @@ METHOD::attributes
 returns an link::Classes/IdentityDictionary:: containing for each association:
 list::
 ## the attribute/property name as the key.
-## the supercollider link::Classes/Class:: you should use as an argument to set the attribute.
+## the SuperCollider link::Classes/Class:: you should use as an argument to set the attribute.
 ::
 Once you know the attributes you can set them like using normal instance setters, use the name and append '_'.
 code::

--- a/HelpSource/Classes/SerialPort.schelp
+++ b/HelpSource/Classes/SerialPort.schelp
@@ -48,7 +48,7 @@ SerialPort.listDevices;
 method::devicePattern
 change device selection
 code::
-SerialPort.devicePattern = "/dev/ttyUSB*"; // linux usb serial
+SerialPort.devicePattern = "/dev/ttyUSB*"; // Linux usb serial
 SerialPort.devices;
 
 SerialPort.devicePattern = nil;

--- a/HelpSource/Classes/String.schelp
+++ b/HelpSource/Classes/String.schelp
@@ -548,7 +548,7 @@ Despite the fact that the method is called 'unixCmd', strong::it does work in Wi
 ::
 
 method::unixCmd
-Execute a unix command strong::asynchronously:: using the standard shell (sh).
+Execute a UNIX command strong::asynchronously:: using the standard shell (sh).
 argument:: action
 A link::Classes/Function:: that is called when the process has exited. It is passed two arguments: the exit code and pid of the exited process.
 argument:: postOutput
@@ -570,9 +570,9 @@ code::
 ::
 
 method::systemCmd
-Executes a unix command strong::synchronously:: using the standard shell (sh).
+Executes a UNIX command strong::synchronously:: using the standard shell (sh).
 
-returns:: Error code of the unix command
+returns:: Error code of the UNIX command
 
 method::runInTerminal
 Execute the String in a new terminal window (strong::asynchronously::).

--- a/HelpSource/Guides/Glossary.schelp
+++ b/HelpSource/Guides/Glossary.schelp
@@ -13,7 +13,7 @@ keyword:: class
 
 ## client
 keyword:: client
-|| SC is divided into two separate applications: The client and the server. The client is where the supercollider language is implemented and where one executes code. The server actually synthesizes the audio, contains the node tree of synths and groups and responds to Open Sound Control messages from the client. See link::Guides/ClientVsServer:: for more information.
+|| SC is divided into two separate applications: The client and the server. The client is where the SuperCollider language is implemented and where one executes code. The server actually synthesizes the audio, contains the node tree of synths and groups and responds to Open Sound Control messages from the client. See link::Guides/ClientVsServer:: for more information.
 
 ## group
 keyword:: group
@@ -72,7 +72,7 @@ keyword:: receiver
 
 ## server
 keyword:: server
-|| SC is divided into two separate applications: The client and the server. The client is where the supercollider language is implemented and where one executes code. The server actually synthesizes the audio, contains the node tree of synths and groups and responds to Open Sound Control messages from the client. See See link::Guides/ClientVsServer:: for more information.
+|| SC is divided into two separate applications: The client and the server. The client is where the SuperCollider language is implemented and where one executes code. The server actually synthesizes the audio, contains the node tree of synths and groups and responds to Open Sound Control messages from the client. See See link::Guides/ClientVsServer:: for more information.
 
 ## synth
 keyword:: synth

--- a/HelpSource/Guides/News-3_5.schelp
+++ b/HelpSource/Guides/News-3_5.schelp
@@ -32,7 +32,7 @@ Old platform-specific startup file locations have been deprecated. The new start
 
 subsection:: Language configuration files
 
-The linux-only library configuration file has been deprecated. It is replaced by a cross-platform language configuration
+The Linux-only library configuration file has been deprecated. It is replaced by a cross-platform language configuration
 file, which is located at code::Platform.userConfigDir +/+ "sclang_conf.yaml" :: . It can be configured via the
 link::Classes/LanguageConfig:: class.
 
@@ -175,7 +175,7 @@ since no external FFT libraries are required.
 subsection:: Supernova
 
 A new multi-processor implementation of scsynth. Parallelism of the synthesis graph is exposed to the user via the
-link::Classes/ParGroup:: class. Supernova is currently linux-only. It is not provided in the OSX/Windows binaries. In
+link::Classes/ParGroup:: class. Supernova is currently Linux-only. It is not provided in the OSX/Windows binaries. In
 order to play patterns inside a ParGroup, the link::Classes/PparGroup:: can be used. Scsynth emulates parallel groups
 with groups.
 

--- a/HelpSource/Guides/Server-Guide.schelp
+++ b/HelpSource/Guides/Server-Guide.schelp
@@ -8,7 +8,7 @@ description::
 A Server object is the client-side representation of a server app and is used to control the app from the SuperCollider language application. (See link::Guides/ClientVsServer:: for more details on the distinction.)
 It forwards OSC messages and has a number of allocators that keep track of IDs for nodes, buses and buffers.
 
-The server application is a commandline program, so all commands apart from OSC messages are unix commands.
+The server application is a commandline program, so all commands apart from OSC messages are UNIX commands.
 
 The server application represented by a Server object might be running on the same machine as the client (in the same address space as the language application or separately; see below), or it may be running on a remote machine.
 
@@ -16,7 +16,7 @@ Most of a Server's options are contolled through its instance of ServerOptions. 
 
 subsection:: Paths
 
-Server apps running on the local machine have two unix environment variables: code::SC_SYNTHDEF_PATH:: and code::SC_PLUGIN_PATH::. These indicate directories of synthdefs and ugen plugins that will be loaded at startup. These are in addition to the default synthdef/ and plugin/ directories which are hard-coded.
+Server apps running on the local machine have two UNIX environment variables: code::SC_SYNTHDEF_PATH:: and code::SC_PLUGIN_PATH::. These indicate directories of synthdefs and ugen plugins that will be loaded at startup. These are in addition to the default synthdef/ and plugin/ directories which are hard-coded.
 
 These can be set within SC using the getenv and setenv methods of class link::Classes/String::.
 code::

--- a/HelpSource/Guides/UsingQuarks.schelp
+++ b/HelpSource/Guides/UsingQuarks.schelp
@@ -224,7 +224,7 @@ code::
 {quark name}.quark
 ::
 
-and is a supercollider file that returns an IdentifyDictionary
+and is a SuperCollider file that returns an IdentityDictionary
 
 code::
 (

--- a/HelpSource/Guides/WritingClasses.schelp
+++ b/HelpSource/Guides/WritingClasses.schelp
@@ -6,8 +6,8 @@ related:: Reference/Classes
 For a basic tutorial on how standard object-orientated classes are composed, look elsewhere
 link::http://www.google.com/search?q=oop+class+tutorial::
 
-note:: Class definitions are statically compiled when you launch supercollider or "recompile the library." This means
-that class definitions must be saved into a file with the extension .sc, in a disk location where supercollider looks
+note:: Class definitions are statically compiled when you launch SuperCollider or "recompile the library." This means
+that class definitions must be saved into a file with the extension .sc, in a disk location where SuperCollider looks
 for classes. Saving into the main class library (SCClassLibrary) is generally not recommended. It's preferable to use
 either the user or system extension directories.
 

--- a/HelpSource/Guides/WritingHelp.schelp
+++ b/HelpSource/Guides/WritingHelp.schelp
@@ -325,7 +325,7 @@ section:: Contributing with the documentation
 
 The easiest way to contribute to the documentation is:
 
-    1. Fork the supercollider repository https://github.com/supercollider/supercollider
+    1. Fork the SuperCollider repository https://github.com/supercollider/supercollider
     2. Clone your repository
     code::
     git clone --recursive git://github.com/{your_username}/supercollider.git
@@ -338,4 +338,4 @@ The easiest way to contribute to the documentation is:
     code::
     git push origin -u doc_updates
     ::
-    5. Submit your pull request through github, from your branch doc_updates to supercollider master
+    5. Submit your pull request through github, from your branch doc_updates to SuperCollider master

--- a/HelpSource/Overviews/JITLib.schelp
+++ b/HelpSource/Overviews/JITLib.schelp
@@ -40,7 +40,7 @@ such as server messaging and pattern proxies which are not covered in tutorial f
 definitionList::
 ## content: ||
 definitionList::
-## placeholders in sc || link::Tutorials/JITLib/jitlib_basic_concepts_01::
+## placeholders in SuperCollider || link::Tutorials/JITLib/jitlib_basic_concepts_01::
 ## referencing and environments || link::Tutorials/JITLib/jitlib_basic_concepts_02::
 ## internal structure of node proxy || link::Tutorials/JITLib/jitlib_basic_concepts_03::
 ## timing in node proxy || link::Tutorials/JITLib/jitlib_basic_concepts_04::

--- a/HelpSource/Tutorials/Getting-Started/01-Introductory-Remarks.schelp
+++ b/HelpSource/Tutorials/Getting-Started/01-Introductory-Remarks.schelp
@@ -5,7 +5,7 @@ related:: Tutorials/Getting-Started/00-Getting-Started-With-SC
 
 The following text is intended to serve as an introduction to SuperCollider 3, an object-oriented language for sound synthesis and digital signal processing (DSP). This tutorial does not assume a background in computer science, but does assume basic familiarity with your computer and its OS, as well as a basic knowledge of acoustics and digital audio. (I'm assuming here that words like frequency and sample will not cause any confusion.)
 
-The tutorial is written from a Mac OSX perspective, but much of it should apply to linux and windows as well. The parts which specifically differ have mostly to do with GUI aspects (Graphical User Interface).
+The tutorial is written from a Mac OSX perspective, but much of it should apply to Linux and Windows as well. The parts which specifically differ have mostly to do with GUI aspects (Graphical User Interface).
 
 I should acknowledge that this tutorial is 'by' me in only a limited sense. In writing it I have drawn freely upon the general documentation, which was written by a number of people. This document is not intended to replace those (often more detailed) sources, and refers the reader to them constantly for further information.
 

--- a/HelpSource/Tutorials/JITLib/jitlib_basic_concepts_01.schelp
+++ b/HelpSource/Tutorials/JITLib/jitlib_basic_concepts_01.schelp
@@ -1,9 +1,9 @@
 title:: jitlib_basic_concepts_01
-summary:: some placeholders in supercollider
+summary:: some placeholders in SuperCollider
 categories:: Libraries>JITLib>Tutorials, Tutorials>JITLib
 related:: Overviews/JITLib, Tutorials/JITLib/jitlib_basic_concepts_02
 
-This helpfile explains some basic concepts of interactive programming with supercollider and proxy space.
+This helpfile explains some basic concepts of interactive programming with SuperCollider and proxy space.
 
 section::What is a proxy?
 

--- a/HelpSource/Tutorials/JITLib/jitlib_networking.schelp
+++ b/HelpSource/Tutorials/JITLib/jitlib_networking.schelp
@@ -16,7 +16,7 @@ subsection::before you start
 remember to synchronize your system clocks. This can be done by:
 definitionList::
 ## in OS X || SystemPreferences>Date&Time: set emphasis::"Set Date & Time automatically":: to true.
-## in linux || set the ntp clock
+## in Linux || set the ntp clock
 ::
 a local time server is better than the apple time server. if you cannot sync the time, you can set the server latency to code::nil::. This will break the pattern's functionality though.
 

--- a/HelpSource/Tutorials/JITLib/proxyspace_examples.schelp
+++ b/HelpSource/Tutorials/JITLib/proxyspace_examples.schelp
@@ -88,7 +88,7 @@ code::
 
 
 
-// supercollider 'differential equations'
+// SuperCollider 'differential equations'
 
 ~out = { SinOsc.ar(Slope.ar(~out.ar) * MouseX.kr(1000, 18000, 1)) * 0.1 + SinOsc.ar(100, 0, 0.1) };
 

--- a/HelpSource/Tutorials/Mark_Polishook_tutorial/05_The_network.schelp
+++ b/HelpSource/Tutorials/Mark_Polishook_tutorial/05_The_network.schelp
@@ -47,7 +47,7 @@ code::
 // the ip number has to be valid and the server, wherever it is, has to be running
 // servers cannot be booted remotely, eg, a program on one machine can't boot a server on another
 // this example assumes the server on the remote machine was booted from within
-// supercollider and not from the terminal
+// SuperCollider and not from the terminal
 s = Server("aServer", NetAddr("... an ip number ...", 56789));
 
 // define a synthesis engine ... exactly as in the previous example


### PR DESCRIPTION
This PR adds stylistic consistency by capitalizing "Linux", "Windows", "SuperCollider", and "UNIX" where appropriate.