### PR TITLE
Add an 'endPos' argument to PlayBuf

### DIFF
--- a/HelpSource/Classes/PlayBuf.schelp
+++ b/HelpSource/Classes/PlayBuf.schelp
@@ -42,6 +42,9 @@ argument::loop
 argument:: doneAction
 an integer representing an action to be executed when the buffer is finished playing. This can be used to free the enclosing synth, etc. See link::Reference/UGen-doneActions:: for more detail. code::doneAction:: is only evaluated if loop is 0.
 
+argument::endPos
+Last sample frame to play back. If -1 (default), will play to the end of the buffer.
+
 Examples::
 
 code::

--- a/SCClassLibrary/Common/Audio/BufIO.sc
+++ b/SCClassLibrary/Common/Audio/BufIO.sc
@@ -3,12 +3,12 @@
 */
 
 PlayBuf : MultiOutUGen {
-	*ar { arg numChannels, bufnum=0, rate=1.0, trigger=1.0, startPos=0.0, loop = 0.0, doneAction=0;
-		^this.multiNew('audio', numChannels, bufnum, rate, trigger, startPos, loop, doneAction)
+	*ar { arg numChannels, bufnum=0, rate=1.0, trigger=1.0, startPos=0.0, loop = 0.0, doneAction=0, endPos = -1.0;
+		^this.multiNew('audio', numChannels, bufnum, rate, trigger, startPos, loop, doneAction, endPos)
 	}
 
-	*kr { arg numChannels, bufnum=0, rate=1.0, trigger=1.0, startPos=0.0, loop = 0.0, doneAction=0;
-		^this.multiNew('control', numChannels, bufnum, rate, trigger, startPos, loop, doneAction)
+	*kr { arg numChannels, bufnum=0, rate=1.0, trigger=1.0, startPos=0.0, loop = 0.0, doneAction=0, endPos = -1.0;
+		^this.multiNew('control', numChannels, bufnum, rate, trigger, startPos, loop, doneAction, endPos)
 	}
 
 	init { arg argNumChannels ... theInputs;

--- a/server/plugins/DelayUGens.cpp
+++ b/server/plugins/DelayUGens.cpp
@@ -1072,6 +1072,7 @@ void PlayBuf_next_aa(PlayBuf *unit, int inNumSamples)
 	float *ratein  = ZIN(1);
 	float *trigin  = ZIN(2);
 	int32 loop     = (int32)ZIN0(4);
+	int32 endPos   = (int32)ZIN0(6);
 
 	float fbufnum  = ZIN0(0);
 	if (fbufnum != unit->m_fbufnum) {
@@ -1094,7 +1095,7 @@ void PlayBuf_next_aa(PlayBuf *unit, int inNumSamples)
 
 	CHECK_BUFFER_DATA;
 
-	double loopMax = (double)(loop ? bufFrames : bufFrames - 1);
+	double loopMax = (double)(endPos > 0 ? endPos : (loop ? bufFrames : bufFrames - 1));
 	double phase = unit->m_phase;
 	float prevtrig = unit->m_prevtrig;
 
@@ -1123,6 +1124,7 @@ void PlayBuf_next_ak(PlayBuf *unit, int inNumSamples)
 	float *ratein  = ZIN(1);
 	float trig     = ZIN0(2);
 	int32 loop     = (int32)ZIN0(4);
+	int32 endPos   = (int32)ZIN0(6);
 
 	float fbufnum  = ZIN0(0);
 	if (fbufnum != unit->m_fbufnum) {
@@ -1145,7 +1147,7 @@ void PlayBuf_next_ak(PlayBuf *unit, int inNumSamples)
 
 	CHECK_BUFFER_DATA
 
-	double loopMax = (double)(loop ? bufFrames : bufFrames - 1);
+	double loopMax = (double)(endPos > 0 ? endPos : (loop ? bufFrames : bufFrames - 1));
 	double phase = unit->m_phase;
 	if(phase == -1.) phase = bufFrames;
 	if (trig > 0.f && unit->m_prevtrig <= 0.f) {
@@ -1170,13 +1172,14 @@ void PlayBuf_next_kk(PlayBuf *unit, int inNumSamples)
 	float rate     = ZIN0(1);
 	float trig     = ZIN0(2);
 	int32 loop     = (int32)ZIN0(4);
+	int32 endPos   = (int32)ZIN0(6);
 
 	GET_BUF_SHARED
 	int numOutputs = unit->mNumOutputs;
 
 	CHECK_BUFFER_DATA
 
-	double loopMax = (double)(loop ? bufFrames : bufFrames - 1);
+	double loopMax = (double)(endPos > 0 ? endPos : (loop ? bufFrames : bufFrames - 1));
 	double phase = unit->m_phase;
 	if (trig > 0.f && unit->m_prevtrig <= 0.f) {
 		unit->mDone = false;
@@ -1198,13 +1201,14 @@ void PlayBuf_next_ka(PlayBuf *unit, int inNumSamples)
 	float rate     = ZIN0(1);
 	float *trigin  = ZIN(2);
 	int32 loop     = (int32)ZIN0(4);
+	int32 endPos   = (int32)ZIN0(6);
 
 	GET_BUF_SHARED
 	int numOutputs = unit->mNumOutputs;
 
 	CHECK_BUFFER_DATA
 
-	double loopMax = (double)(loop ? bufFrames : bufFrames - 1);
+	double loopMax = (double)(endPos > 0 ? endPos : (loop ? bufFrames : bufFrames - 1));
 	double phase = unit->m_phase;
 	float prevtrig = unit->m_prevtrig;
 	for (int i=0; i<inNumSamples; ++i) {


### PR DESCRIPTION
**I'm new to this kind of SC work so this could definitely use a thorough code review!**

Adds an 'endPos' argument to PlayBuf (discussed on the mailing list a while back). Loops back to beginning (not 'startPos') when reaches the end if ```loop = true```, otherwise does ```doneAction```