### PR TITLE
Disable Nagle's algorithm for scsynth TCP

### DIFF
--- a/server/scsynth/SC_ComPort.cpp
+++ b/server/scsynth/SC_ComPort.cpp
@@ -296,6 +296,10 @@ public:
 		int32 size;
 		int32 msglen;
 
+		boost::system::error_code error;
+		boost::asio::ip::tcp::no_delay noDelayOption(true);
+		socket.set_option(noDelayOption, error);
+
 		// first message must be the password. 4 tries.
 		bool validated = mWorld->hw->mPassword[0] == 0;
 		for (int i=0; !validated && i<4; ++i) {


### PR DESCRIPTION
**This could use a thorough look - I'm new to working on the servers**


> Applications that expect real time responses can react poorly with Nagle's algorithm. Applications such as networked multiplayer video games expect that actions in the game are sent immediately, while the algorithm purposefully delays transmission, increasing bandwidth efficiency at the expense of latency. For this reason applications with low-bandwidth time-sensitive transmissions typically use TCP_NODELAY to bypass the Nagle delay.
https://en.wikipedia.org/wiki/Nagle's_algorithm


sclang and supernova appear to already do this, but scsynth appears not to (and @redFrik 's results on the mailing list *seem* to be consistent with that idea)
