### PR TITLE
Add type checking in `Object.perform`

### DIFF
--- a/HelpSource/Classes/Object.schelp
+++ b/HelpSource/Classes/Object.schelp
@@ -424,7 +424,7 @@ method::perform
 
 The selector argument must be a Symbol. Sends the method named by the selector with the given arguments to the receiver.
 
-If the first argument is an Array or List, this method behaves like code::performMsg::. However, this usage is strongly discouraged.
+If the first argument is an Array or List, this method behaves like code::performMsg::. However, this usage is discouraged, and code::performMsg:: ought to be used instead.
 
 method::performList
 

--- a/HelpSource/Classes/Object.schelp
+++ b/HelpSource/Classes/Object.schelp
@@ -424,6 +424,8 @@ method::perform
 
 The selector argument must be a Symbol. Sends the method named by the selector with the given arguments to the receiver.
 
+If the first argument is an Array or List, this method behaves like code::performMsg::. However, this usage is strongly discouraged.
+
 method::performList
 
 The selector argument must be a Symbol. Sends the method named by the selector with the given arguments to the receiver. If the last argument is a List or an Array, then its elements are unpacked and passed as arguments.

--- a/lang/LangPrimSource/PyrPrimitive.cpp
+++ b/lang/LangPrimSource/PyrPrimitive.cpp
@@ -1488,11 +1488,16 @@ int objectPerform(struct VMGlobals *g, int numArgsPushed)
 			goto badselector;
 		}
 		PyrObject *array = slotRawObject(listSlot);
-		if (array->size < 1) {
+		if (array->size < 1 || !IsSym) {
 			error("Array must have a selector.\n");
 			return errFailed;
 		}
 		selSlot = array->slots;
+        if (!IsSym(selSlot)) {
+            error("First element of array must be a Symbol selector.\n");
+            dumpObjectSlot(selSlot);
+            return errWrongType;
+        }
 		selector = slotRawSymbol(selSlot);
 
 		if (numArgsPushed>2) {

--- a/lang/LangPrimSource/PyrPrimitive.cpp
+++ b/lang/LangPrimSource/PyrPrimitive.cpp
@@ -1519,7 +1519,7 @@ int objectPerform(struct VMGlobals *g, int numArgsPushed)
 
 		pslot = recvrSlot;
 		qslot = selSlot;
-		for (m=0, mmax=array->size-1; m < mmax; ++m)
+		for (m = 0, mmax=array->size-1; m < mmax; ++m)
             slotCopy(++pslot, ++qslot);
 
 		g->sp += array->size - 2;

--- a/lang/LangPrimSource/PyrPrimitive.cpp
+++ b/lang/LangPrimSource/PyrPrimitive.cpp
@@ -1470,16 +1470,20 @@ int objectPerform(struct VMGlobals *g, int numArgsPushed)
 
 	recvrSlot = g->sp - numArgsPushed + 1;
 	selSlot = recvrSlot + 1;
+    
 	if (IsSym(selSlot)) {
 		selector = slotRawSymbol(selSlot);
+        
 		// move args down one to fill selector's position
 		pslot = selSlot - 1;
 		qslot = selSlot;
-		for (m=0; m<numArgsPushed - 2; ++m) slotCopy(++pslot, ++qslot);
-		g->sp -- ;
-		numArgsPushed -- ;
+		for (m = 0; m < numArgsPushed - 2; ++m)
+            slotCopy(++pslot, ++qslot);
+		g->sp--;
+		numArgsPushed--;
 		// now the stack looks just like it would for a normal message send
 	} else if (IsObj(selSlot)) {
+        // if a List was passed, cast it to an Array, else throw an error
 		listSlot = selSlot;
 		if (slotRawObject(listSlot)->classptr == class_list) {
 			listSlot = slotRawObject(listSlot)->slots;
@@ -1487,28 +1491,36 @@ int objectPerform(struct VMGlobals *g, int numArgsPushed)
 		if (NotObj(listSlot) || slotRawObject(listSlot)->classptr != class_array) {
 			goto badselector;
 		}
+        
 		PyrObject *array = slotRawObject(listSlot);
+        
 		if (array->size < 1) {
 			error("Array must have a selector.\n");
 			return errFailed;
 		}
+        
 		selSlot = array->slots;
-        if (!IsSym(selSlot)) {
+        
+        // check the first slot to see if it's a symbol
+        if (NotSym(selSlot)) {
             error("First element of array must be a Symbol selector.\n");
             dumpObjectSlot(selSlot);
             return errWrongType;
         }
+        
 		selector = slotRawSymbol(selSlot);
 
-		if (numArgsPushed>2) {
+		if (numArgsPushed > 2) {
 			qslot = recvrSlot + numArgsPushed;
 			pslot = recvrSlot + numArgsPushed + array->size - 2;
-			for (m=0; m<numArgsPushed - 2; ++m) slotCopy(--pslot, --qslot);
+			for (m = 0; m < numArgsPushed - 2; ++m)
+                slotCopy(--pslot, --qslot);
 		}
 
 		pslot = recvrSlot;
 		qslot = selSlot;
-		for (m=0,mmax=array->size-1; m<mmax; ++m) slotCopy(++pslot, ++qslot);
+		for (m=0, mmax=array->size-1; m < mmax; ++m)
+            slotCopy(++pslot, ++qslot);
 
 		g->sp += array->size - 2;
 		numArgsPushed += array->size - 2;

--- a/lang/LangPrimSource/PyrPrimitive.cpp
+++ b/lang/LangPrimSource/PyrPrimitive.cpp
@@ -1519,7 +1519,7 @@ int objectPerform(struct VMGlobals *g, int numArgsPushed)
 
 		pslot = recvrSlot;
 		qslot = selSlot;
-		for (m = 0, mmax=array->size-1; m < mmax; ++m)
+		for (m = 0, mmax = array->size-1; m < mmax; ++m)
             slotCopy(++pslot, ++qslot);
 
 		g->sp += array->size - 2;

--- a/lang/LangPrimSource/PyrPrimitive.cpp
+++ b/lang/LangPrimSource/PyrPrimitive.cpp
@@ -1488,7 +1488,7 @@ int objectPerform(struct VMGlobals *g, int numArgsPushed)
 			goto badselector;
 		}
 		PyrObject *array = slotRawObject(listSlot);
-		if (array->size < 1 || !IsSym) {
+		if (array->size < 1) {
 			error("Array must have a selector.\n");
 			return errFailed;
 		}


### PR DESCRIPTION
In response to #2615.

Attempting to interpret `3.perform([0])` now results in:
```
ERROR: First element of array must be a Symbol selector.
   Integer 0
ERROR: Primitive '_ObjectPerform' failed.
Wrong type.
```
and `3.perform(['+', 5])` still gives `8`.

Todo:
- [x] Document the behavior of `Object.perform(Array | List)`