### PR TITLE
lang: Do not re-reset nowExecutingPath when stopping a routine

### DIFF
--- a/lang/LangPrimSource/PyrPrimitive.cpp
+++ b/lang/LangPrimSource/PyrPrimitive.cpp
@@ -3359,7 +3359,6 @@ int prRoutineStop(struct VMGlobals *g, int numArgsPushed)
 
 
 	if (state == tSuspended || state == tInit) {
-		slotCopy(&g->process->nowExecutingPath, &thread->oldExecutingPath);
 		SetNil(&g->thread->terminalValue);
 		SetRaw(&thread->state, tDone);
 		slotRawObject(&thread->stack)->size = 0;


### PR DESCRIPTION
Fixes #2540. Also, I've been running with this change for about a month, with no problem.

It might look strange to remove a state reset upon stop, but the line is redundant.

- The Routine object's oldExecutingPath variable is set only when entering the routine, by `next`. This is correct: If the routine is sleeping, then there is no oldExecutingPath.

- oldExecutingPath is, therefore, valid only when the routine is in state `tRunning`. (Routine states: https://github.com/supercollider/supercollider/blob/master/lang/LangSource/PyrKernel.h#L105 )

- The branch where I'm removing the line is only for states `tSuspended` or `tInit`.

- So, oldExecutingPath is invalid here, and we shouldn't be putting invalid data into the interpreter's state.

Note also that it's forbidden to stop a routine while the same routine is running: https://github.com/supercollider/supercollider/blob/master/lang/LangPrimSource/PyrPrimitive.cpp#L3368