### PR TITLE
Fix behavior of nested multiline comments

### DIFF
--- a/lang/LangSource/PyrLexer.cpp
+++ b/lang/LangSource/PyrLexer.cpp
@@ -774,7 +774,7 @@ symbol3 : {
 		}
 		if (c == 0) {
 			asRelativePath(curfilename,extPath);
-			post("Open ended symbol ... started on line %d in file '%s'\n",
+			post("Open ended symbol started on line %d in file '%s'\n",
 				startline+errLineOffset, extPath);
 			yylen = 0;
 			r = 0;
@@ -808,9 +808,9 @@ string1 : {
 			if (c == 0) break;
 		}
 		if (c == 0) {
-			asRelativePath(curfilename,extPath);
-			post("Open ended string ... started on line %d in file '%s'\n",
-				startline+errLineOffset, extPath);
+			asRelativePath(curfilename, extPath);
+			post("Open ended string started on line %d in file '%s'\n",
+				startline + errLineOffset, extPath);
 			yylen = 0;
 			r = 0;
 			goto leave;
@@ -854,9 +854,9 @@ comment2 : {
 		} while (c != 0);
 		yylen = 0;
 		if (c == 0) {
-			asRelativePath(curfilename,extPath);
-			post("Open ended comment ... started on line %d in file '%s'\n",
-				startline+errLineOffset, extPath);
+			asRelativePath(curfilename, extPath);
+			post("Open ended comment started on line %d in file '%s'\n",
+				startline + errLineOffset, extPath);
 			r = 0;
 			goto leave;
 		}
@@ -1471,7 +1471,7 @@ symbol3 : {
 		if (c == 0) {
 			char extPath[MAXPATHLEN];
 			asRelativePath(curfilename, extPath);
-			post("Open ended symbol ... started on line %d in file '%s'\n",
+			post("Open ended symbol started on line %d in file '%s'\n",
 				 startline, extPath);
 			goto error2;
 		}
@@ -1492,7 +1492,7 @@ string1 : {
 		if (c == 0) {
 			char extPath[MAXPATHLEN];
 			asRelativePath(curfilename, extPath);
-			post("Open ended string ... started on line %d in file '%s'\n",
+			post("Open ended string started on line %d in file '%s'\n",
 				 startline, extPath);
 			goto error2;
 		}
@@ -1523,7 +1523,7 @@ comment2 : {
 		if (c == 0) {
 			char extPath[MAXPATHLEN];
 			asRelativePath(curfilename, extPath);
-			post("Open ended comment ... started on line %d in file '%s'\n",
+			post("Open ended comment started on line %d in file '%s'\n",
 				 startline, extPath);
 			goto error2;
 		}

--- a/lang/LangSource/PyrLexer.cpp
+++ b/lang/LangSource/PyrLexer.cpp
@@ -849,7 +849,10 @@ comment2 : {
                     break;
                 else
                     prevc = c, c = input0(); // eat both characters
-			} else if (c == '*' && prevc == '/') clevel++;
+            } else if (c == '*' && prevc == '/') {
+                clevel++;
+                prevc = c, c = input0(); // eat both characters
+            }
 			prevc = c;
 		} while (c != 0);
 		yylen = 0;
@@ -1517,7 +1520,10 @@ comment2 : {
                     break;
                 else
                     prevc = c, c = input0(); // eat both characters
-			} else if (c == '*' && prevc == '/') clevel++;
+            } else if (c == '*' && prevc == '/') {
+                clevel++;
+                prevc = c, c = input0(); // eat both characters
+            }
 			prevc = c;
 		} while (c != 0);
 		if (c == 0) {

--- a/lang/LangSource/PyrLexer.cpp
+++ b/lang/LangSource/PyrLexer.cpp
@@ -845,7 +845,10 @@ comment2 : {
 		do {
 			c = input0();
 			if (c == '/' && prevc == '*') {
-				if (--clevel <= 0) break;
+				if (--clevel <= 0)
+                    break;
+                else
+                    prevc = c, c = input0(); // eat both characters
 			} else if (c == '*' && prevc == '/') clevel++;
 			prevc = c;
 		} while (c != 0);
@@ -1510,7 +1513,10 @@ comment2 : {
 		do {
 			c = input0();
 			if (c == '/' && prevc == '*') {
-				if (--clevel <= 0) break;
+                if (--clevel <= 0)
+                    break;
+                else
+                    prevc = c, c = input0(); // eat both characters
 			} else if (c == '*' && prevc == '/') clevel++;
 			prevc = c;
 		} while (c != 0);

--- a/testsuite/classlibrary/TestParser.sc
+++ b/testsuite/classlibrary/TestParser.sc
@@ -1,0 +1,98 @@
+TestParser : UnitTest {
+
+	// tests block comments /* */
+	test_blockComments {
+		var openTests, closedTests, errorTests;
+		var testCs, testCsValue;
+
+		/* A test compile string, and its interpreted value.
+		 * Will be added to the end of a test comment to make sure it
+		 * does/doesn't get interpreted as expected. Will also be
+		 * added to the start of an error-causing string to make sure
+		 * it causes an error.
+		 */
+		testCs = " 3\n";
+		testCsValue = 3;
+
+		// Tests open-ended block comments; these should return 'nil' if you add any text after them.
+		openTests = [
+			"/*", // crazy strings first
+			"/*/",
+			"/*/*",
+			"/*/*/",
+			"/*/*/*",
+			"/*/* */",
+			"/*/**/*",
+			"/*/* */*",
+			"/*/*/*/",
+			"/*/*/*/*",
+			"/*//* */", // '//*' interpreted as '/*' here
+
+			"/* /*", // sanity check
+			"/* /* */",
+			"/* /* /* */ */"
+		];
+
+		// Tests closed block comments; code after one of these strings will be executed.
+		closedTests = [
+			"/**/",
+			"/*/**/*/",
+			"/*/*/**/*/*/",
+			"/*// */",
+			"/* // */", // line comment begun in block comment doesn't count
+			"/*//* */ */", // '//*' interpreted as '/*' here
+
+			"/* */", // sanity check
+			"/* /* */ */",
+			"/* /* /* */ */ */"
+		];
+
+		/* These should throw an error when interpreted.
+		 * Since the errors from .interpret cannot be caught, this just tests
+		 * that it returns nil no matter where the test string is added.
+		 */
+		errorTests = [
+			"*/",
+			"*/*",
+			"*/*/",
+			"/**/*",
+			"/**/*/",
+			"/**/ */",
+			"/* */*/",
+			"/* */ */",
+			"/*/**/*/*",
+			"/*/**/*/*/",
+
+			"///*\n*/", // block comment begun in line comment doesn't count (this would probably make the lang blow up if it failed anyway)
+			"// /*\n*/"
+		];
+
+		openTests.do {
+			|commentString|
+			var message = "'%' should be an open-ended comment.".format(commentString);
+
+			this.assertEquals(commentString.interpret, nil, message);
+			this.assertEquals((commentString ++ testCs).interpret, nil, message);
+		};
+
+		closedTests.do {
+			|commentString|
+			var message = "'%' should be a closed block comment.".format(commentString);
+
+			this.assertEquals(commentString.interpret, nil, message);
+			this.assertEquals((commentString ++ testCs).interpret, testCsValue, message);
+		};
+
+		errorTests.do {
+			|commentString|
+			var message = "'%' should throw a parsing error when interpreted.".format(commentString);
+			var courtesyMessage = "NOTE: The parsing errors thrown above are intentional — currently testing bizarre strings with .interpret";
+
+			this.assertEquals(commentString.interpret, nil, message);
+			this.assertEquals((commentString ++ testCs).interpret, nil, message);
+			this.assertEquals((testCs ++ commentString).interpret, nil, message);
+
+			courtesyMessage.postln;
+		}
+	}
+}

--- a/testsuite/classlibrary/TestParser.sc
+++ b/testsuite/classlibrary/TestParser.sc
@@ -1,6 +1,7 @@
 TestParser : UnitTest {
 
-	// tests block comments /* */
+	// Regression tests for a specific bug in block comment parsing.
+	// See https://github.com/supercollider/supercollider/issues/2624
 	test_blockComments {
 		var openTests, closedTests, errorTests;
 		var testCs, testCsValue;


### PR DESCRIPTION
Fix for #2624.

Code in PyrLexer.cpp used to be:
```
		do {
			c = input0();
			if (c == '/' && prevc == '*') {
				if (--clevel <= 0) break;
			} else if (c == '*' && prevc == '/') clevel++;
			prevc = c;
		} while (c != 0);
```

When the lexer encountered a string like `/* /* */*/`, it would count the `*/*/` as `--clevel` for `*/`, then `++clevel` for `/*`, then `--clevel` for `*/`. I added a few lines so that it immediately eats up any `*/` or `/*` encountered.

Also changed the interpreter messages for open-ended strings/symbols/comments to remove the spurious `...`.

This works for me now:
`/*/* */*/` -> `nil`
`/* /* */ */` -> `nil`
`/*/* */*` -> `Open ended`
`3/*/**/*/*3` -> `9`
