### PR TITLE
Cleanup PyrObject.cpp:initSymbols()

### DIFF
--- a/lang/LangPrimSource/PyrPrimitive.cpp
+++ b/lang/LangPrimSource/PyrPrimitive.cpp
@@ -89,8 +89,6 @@ typedef struct {
 
 extern PrimitiveTable gPrimitiveTable;
 
-extern PyrSlot o_nullframe;
-
 
 int getPrimitiveNumArgs(int index)
 {

--- a/lang/LangSource/PredefinedSymbols.h
+++ b/lang/LangSource/PredefinedSymbols.h
@@ -20,8 +20,7 @@
 
 
 extern PyrSymbol *s_func, *s_absfunc;
-extern PyrSymbol *s_docmdline;
-extern PyrSymbol *s_nocomprendo;
+extern PyrSymbol *s_doesNotUnderstand;
 extern PyrSymbol *s_curProcess, *s_curMethod, *s_curBlock, *s_curClosure, *s_curThread;
 extern PyrSymbol *s_startup;
 extern PyrSymbol *s_shutdown;

--- a/lang/LangSource/PredefinedSymbols.h
+++ b/lang/LangSource/PredefinedSymbols.h
@@ -24,6 +24,6 @@ extern PyrSymbol *s_docmdline;
 extern PyrSymbol *s_nocomprendo;
 extern PyrSymbol *s_curProcess, *s_curMethod, *s_curBlock, *s_curClosure, *s_curThread;
 extern PyrSymbol *s_startup;
-extern PyrSymbol *s_hardwaresetup, *s_shutdown;
+extern PyrSymbol *s_shutdown;
 extern PyrSymbol *s_envirGet, *s_envirPut;
 

--- a/lang/LangSource/PyrLexer.cpp
+++ b/lang/LangSource/PyrLexer.cpp
@@ -2050,7 +2050,6 @@ void compileSucceeded()
 
 			g->canCallOS = true;
 			//++g->sp; SetObject(g->sp, g->process);
-			//runInterpreter(g, s_hardwaresetup, 1);
 
 			++g->sp; SetObject(g->sp, g->process);
 			runInterpreter(g, s_startup, 1);

--- a/lang/LangSource/PyrLexer.cpp
+++ b/lang/LangSource/PyrLexer.cpp
@@ -2049,7 +2049,6 @@ void compileSucceeded()
 			VMGlobals *g = gMainVMGlobals;
 
 			g->canCallOS = true;
-			//++g->sp; SetObject(g->sp, g->process);
 
 			++g->sp; SetObject(g->sp, g->process);
 			runInterpreter(g, s_startup, 1);

--- a/lang/LangSource/PyrMessage.cpp
+++ b/lang/LangSource/PyrMessage.cpp
@@ -717,7 +717,7 @@ void doesNotUnderstandWithKeys(VMGlobals *g, PyrSymbol *selector,
 
 	classobj = classOfSlot(recvrSlot);
 
-	index = slotRawInt(&classobj->classIndex) + s_nocomprendo->u.index;
+	index = slotRawInt(&classobj->classIndex) + s_doesNotUnderstand->u.index;
 	meth = gRowTable[index];
 
 
@@ -790,7 +790,7 @@ void doesNotUnderstand(VMGlobals *g, PyrSymbol *selector,
 
 	classobj = classOfSlot(recvrSlot);
 
-	index = slotRawInt(&classobj->classIndex) + s_nocomprendo->u.index;
+	index = slotRawInt(&classobj->classIndex) + s_doesNotUnderstand->u.index;
 	meth = gRowTable[index];
 
 

--- a/lang/LangSource/PyrObject.cpp
+++ b/lang/LangSource/PyrObject.cpp
@@ -114,7 +114,7 @@ PyrSymbol *s_list, *s_method, *s_fundef, *s_frame, *s_class;
 PyrSymbol *s_symbol, *s_nil;
 PyrSymbol *s_boolean, *s_true, *s_false;
 PyrSymbol *s_int, *s_char, *s_color, *s_float, *s_complex;
-PyrSymbol *s_rawptr, *s_objptr;
+PyrSymbol *s_rawptr;
 PyrSymbol *s_string;
 PyrSymbol *s_magnitude, *s_number, *s_collection, *s_ordered_collection;
 PyrSymbol *s_arrayed_collection;
@@ -215,7 +215,6 @@ void initSymbols()
 	s_char = getsym("Char");
 	s_color = getsym("Color");
 	s_rawptr = getsym("RawPointer");
-	s_objptr = getsym("ObjectPointer");
 	s_string = getsym("String");
 	s_magnitude = getsym("Magnitude");
 	s_number = getsym("Number");

--- a/lang/LangSource/PyrObject.cpp
+++ b/lang/LangSource/PyrObject.cpp
@@ -245,23 +245,24 @@ void initSymbols()
     s_ugen = getsym("UGen");
     s_outputproxy = getsym("OutputProxy");
     s_env = getsym("Env");
+    s_synth = getsym("Synth");
+    s_environment = getsym("Environment");
+    s_event = getsym("Event");
 
-	s_synth = getsym("Synth");
-	s_environment = getsym("Environment");
-	s_event = getsym("Event");
-	s_shutdown = getsym("shutdown");
-
-	s_interpretCmdLine = getsym("interpretCmdLine");
-	s_interpretPrintCmdLine = getsym("interpretPrintCmdLine");
-
+    // interpreter
+    s_interpretCmdLine = getsym("interpretCmdLine");
+    s_interpretPrintCmdLine = getsym("interpretPrintCmdLine");
+    
 	s_doesNotUnderstand = getsym("doesNotUnderstand");
     
+    s_startup = getsym("startup");
     s_awake = getsym("awake");
+    s_shutdown = getsym("shutdown");
     
+    // methods
 	s_run = getsym("run");
 	s_stop = getsym("stop");
 	s_tick = getsym("tick");
-	s_startup = getsym("startup");
 	s_next = getsym("next");
 	s_value = getsym("value");
 	s_performList = getsym("performList");

--- a/lang/LangSource/PyrObject.cpp
+++ b/lang/LangSource/PyrObject.cpp
@@ -165,7 +165,7 @@ PyrSymbol *s_new, *s_ref, *s_value, *s_at, *s_put;
 PyrSymbol *s_performList, *s_superPerformList;
 PyrSymbol *s_series, *s_copyseries, *s_putseries;
 PyrSymbol *s_envirGet, *s_envirPut;
-PyrSymbol *s_synth, *s_spawn, *s_environment, *s_event;
+PyrSymbol *s_synth, *s_environment, *s_event;
 PyrSymbol *s_hardwaresetup, *s_shutdown;
 PyrSymbol *s_super, *s_this;
 PyrSlot o_nil, o_true, o_false, o_end;
@@ -253,7 +253,6 @@ void initSymbols()
     s_env = getsym("Env");
 
 	s_synth = getsym("Synth");
-	s_spawn = getsym("BasicSpawn");
 	s_environment = getsym("Environment");
 	s_event = getsym("Event");
 	s_hardwaresetup = getsym("hardwareSetup");

--- a/lang/LangSource/PyrObject.cpp
+++ b/lang/LangSource/PyrObject.cpp
@@ -275,13 +275,19 @@ void initSymbols()
 	s_putseries = getsym("putSeries");
     
 	s_envirGet = getsym("envirGet");
-	s_envirPut = getsym("envirPut");
+    s_envirPut = getsym("envirPut");
+    
+    // set special value slots
+    SetSymbol(&o_none, s_none);
 
 	SetNil(&o_nil);
 	SetFalse(&o_false);
 	SetTrue(&o_true);
     
-    SetSymbol(&o_none, s_none);
+    SetInt(&o_negone, -1);
+    SetInt(&o_zero, 0);
+    SetInt(&o_one, 1);
+    SetInt(&o_two, 2);
 
 	SetFloat(&o_fhalf, .5);
 	SetFloat(&o_fnegone, -1.);
@@ -289,19 +295,16 @@ void initSymbols()
 	SetFloat(&o_fone, 1.);
     SetFloat(&o_ftwo, 2.);
     SetFloat(&o_inf, std::numeric_limits<double>::infinity());
-    
-	SetInt(&o_negone, -1);
-	SetInt(&o_zero, 0);
-	SetInt(&o_one, 1);
-	SetInt(&o_two, 2);
 
 	slotCopy(&gSpecialValues[svNil], &o_nil);
 	slotCopy(&gSpecialValues[svFalse], &o_false);
 	slotCopy(&gSpecialValues[svTrue], &o_true);
+    
 	slotCopy(&gSpecialValues[svNegOne], &o_negone);
 	slotCopy(&gSpecialValues[svZero], &o_zero);
 	slotCopy(&gSpecialValues[svOne], &o_one);
 	slotCopy(&gSpecialValues[svTwo], &o_two);
+    
 	slotCopy(&gSpecialValues[svFHalf], &o_fhalf);
 	slotCopy(&gSpecialValues[svFNegOne], &o_fnegone);
 	slotCopy(&gSpecialValues[svFZero], &o_fzero);
@@ -309,6 +312,7 @@ void initSymbols()
 	slotCopy(&gSpecialValues[svFTwo], &o_ftwo);
 	slotCopy(&gSpecialValues[svInf], &o_inf);
 
+    
 	gFormatElemSize[obj_notindexed] = sizeof(PyrSlot);
 	gFormatElemSize[obj_slot  ] = sizeof(PyrSlot);
 	gFormatElemSize[obj_double] = sizeof(double);

--- a/lang/LangSource/PyrObject.cpp
+++ b/lang/LangSource/PyrObject.cpp
@@ -143,7 +143,6 @@ PyrSymbol *s_prstart;
 PyrSymbol *s_interpreter;
 PyrSymbol *s_finalizer;
 PyrSymbol *s_awake;
-PyrSymbol *s_appclock;
 PyrSymbol *s_systemclock;
 PyrSymbol *s_server_shm_interface;
 PyrSymbol *s_interpretCmdLine, *s_interpretPrintCmdLine;
@@ -238,7 +237,6 @@ void initSymbols()
 	s_task = getsym("Task");
 	s_interpreter = getsym("Interpreter");
 	s_finalizer = getsym("Finalizer");
-	s_appclock = getsym("AppClock");
 	s_systemclock = getsym("SystemClock");
     s_server_shm_interface = getsym("ServerShmInterface");
     s_env = getsym("Env");

--- a/lang/LangSource/PyrObject.cpp
+++ b/lang/LangSource/PyrObject.cpp
@@ -179,13 +179,21 @@ PyrSlot o_emptyarray, o_onenilarray, o_argnamethis;
 
 void initSymbols()
 {
+    // basic keywords
 	s_new = getsym("new");
-	s_ref = getsym("Ref");
 	s_none = getsym("none");
-	s_object = getsym("Object");
 	s_this = getsym("this");
 	s_super = getsym("super");
-
+    
+    s_curProcess = getsym("thisProcess");
+    s_curThread = getsym("thisThread");
+    s_curMethod = getsym("thisMethod");
+    s_curBlock = getsym("thisFunctionDef");
+    s_curClosure = getsym("thisFunction");
+    
+    // classes
+    s_object = getsym("Object");
+    s_ref = getsym("Ref");
 	s_dictionary = getsym("Dictionary");
 	s_bag = getsym("Bag");
 	s_set = getsym("Set");
@@ -245,7 +253,10 @@ void initSymbols()
 	s_awake = getsym("awake");
 	s_appclock = getsym("AppClock");
 	s_systemclock = getsym("SystemClock");
-	s_server_shm_interface = getsym("ServerShmInterface");
+    s_server_shm_interface = getsym("ServerShmInterface");
+    s_ugen = getsym("UGen");
+    s_outputproxy = getsym("OutputProxy");
+    s_env = getsym("Env");
 
 	s_linear = getsym("linear");
 	s_exponential = getsym("exponential");
@@ -266,14 +277,7 @@ void initSymbols()
 
 	s_nocomprendo = getsym("doesNotUnderstand");
 
-	s_curProcess = getsym("thisProcess");
-	s_curThread = getsym("thisThread");
-	s_curMethod = getsym("thisMethod");
-	s_curBlock = getsym("thisFunctionDef");
-	s_curClosure = getsym("thisFunction");
-	//s_sampleRate = getsym("gSR");
-	//s_logicalClock = getsym("gTime");
-	//s_audioClock = getsym("gAudioTime");
+    
 	s_audio = getsym("audio");
 	s_control = getsym("control");
 	s_scalar = getsym("scalar");
@@ -292,11 +296,7 @@ void initSymbols()
 	s_series = getsym("prSimpleNumberSeries");
 	s_copyseries = getsym("copySeries");
 	s_putseries = getsym("putSeries");
-
-	s_ugen = getsym("UGen");
-	s_outputproxy = getsym("OutputProxy");
-	s_env = getsym("Env");
-
+    
 	s_envirGet = getsym("envirGet");
 	s_envirPut = getsym("envirPut");
 

--- a/lang/LangSource/PyrObject.cpp
+++ b/lang/LangSource/PyrObject.cpp
@@ -165,7 +165,7 @@ PyrSymbol *s_new, *s_ref, *s_value, *s_at, *s_put;
 PyrSymbol *s_performList, *s_superPerformList;
 PyrSymbol *s_series, *s_copyseries, *s_putseries;
 PyrSymbol *s_envirGet, *s_envirPut;
-PyrSymbol *s_synth, *s_spawn, *s_environment, *s_event;
+PyrSymbol *s_synth, *s_environment, *s_event;
 PyrSymbol *s_hardwaresetup, *s_shutdown;
 PyrSymbol *s_super, *s_this;
 PyrSlot o_nil, o_true, o_false, o_end;

--- a/lang/LangSource/PyrObject.cpp
+++ b/lang/LangSource/PyrObject.cpp
@@ -148,13 +148,12 @@ PyrSymbol *s_systemclock;
 PyrSymbol *s_server_shm_interface;
 PyrSymbol *s_interpretCmdLine, *s_interpretPrintCmdLine;
 
-PyrSymbol *s_nocomprendo;
+PyrSymbol *s_doesNotUnderstand;
 PyrSymbol *s_curProcess, *s_curMethod, *s_curBlock, *s_curClosure, *s_curThread;
 //PyrSymbol *s_sampleRate;
 //PyrSymbol *s_audioClock, *s_logicalClock;
 PyrSymbol *s_run, *s_stop, *s_tick;
 PyrSymbol *s_startup;
-PyrSymbol *s_docmdline;
 PyrSymbol *s_next;
 PyrSymbol *s_env;
 PyrSymbol *s_ugen, *s_outputproxy;
@@ -257,7 +256,7 @@ void initSymbols()
 	s_interpretCmdLine = getsym("interpretCmdLine");
 	s_interpretPrintCmdLine = getsym("interpretPrintCmdLine");
 
-	s_nocomprendo = getsym("doesNotUnderstand"); // rename
+	s_doesNotUnderstand = getsym("doesNotUnderstand");
     
     s_awake = getsym("awake");
     
@@ -265,7 +264,6 @@ void initSymbols()
 	s_stop = getsym("stop");
 	s_tick = getsym("tick");
 	s_startup = getsym("startup");
-	s_docmdline = getsym("doCmdLine");
 	s_next = getsym("next");
 	s_value = getsym("value");
 	s_performList = getsym("performList");

--- a/lang/LangSource/PyrObject.cpp
+++ b/lang/LangSource/PyrObject.cpp
@@ -130,7 +130,6 @@ PyrSymbol *s_int32array;
 PyrSymbol *s_symbolarray;
 PyrSymbol *s_doublearray;
 PyrSymbol *s_floatarray;
-PyrSymbol *s_point;
 PyrSymbol *s_rect;
 PyrSymbol *s_func, *s_absfunc;
 PyrSymbol *s_stream;
@@ -225,7 +224,6 @@ void initSymbols()
 	s_floatarray = getsym("FloatArray");
 	s_doublearray = getsym("DoubleArray");
 	s_complex = getsym("Complex");
-	s_point = getsym("Point");
 	s_rect = getsym("Rect");
 	s_absfunc = getsym("AbstractFunction");
 	s_func = getsym("Function");

--- a/lang/LangSource/PyrObject.cpp
+++ b/lang/LangSource/PyrObject.cpp
@@ -167,7 +167,6 @@ PyrSymbol *s_series, *s_copyseries, *s_putseries;
 PyrSymbol *s_envirGet, *s_envirPut;
 PyrSymbol *s_synth, *s_spawn, *s_environment, *s_event;
 PyrSymbol *s_hardwaresetup, *s_shutdown;
-PyrSymbol *s_linear, *s_exponential, *s_gate;
 PyrSymbol *s_super, *s_this;
 PyrSlot o_nil, o_true, o_false, o_end;
 PyrSlot o_pi, o_twopi;
@@ -253,10 +252,6 @@ void initSymbols()
     s_ugen = getsym("UGen");
     s_outputproxy = getsym("OutputProxy");
     s_env = getsym("Env");
-
-	s_linear = getsym("linear");
-	s_exponential = getsym("exponential");
-	s_gate = getsym("gate");
 
 	s_synth = getsym("Synth");
 	s_spawn = getsym("BasicSpawn");

--- a/lang/LangSource/PyrObject.cpp
+++ b/lang/LangSource/PyrObject.cpp
@@ -222,13 +222,11 @@ void initSymbols()
 	s_number = getsym("Number");
 	s_simple_number = getsym("SimpleNumber");
 	s_collection = getsym("Collection");
-	//s_ordered_collection = getsym("OrderedCollection");
 	s_arrayed_collection = getsym("ArrayedCollection");
 	s_sequenceable_collection = getsym("SequenceableCollection");
 	s_boolean = getsym("Boolean");
 	s_signal = getsym("Signal");
 	s_wavetable = getsym("Wavetable");
-	//s_signalnode = getsym("SignalNode");
 	s_rawarray = getsym("RawArray");
 	s_int8array = getsym("Int8Array");
 	s_int16array = getsym("Int16Array");
@@ -247,10 +245,8 @@ void initSymbols()
 	s_thread = getsym("Thread");
 	s_routine = getsym("Routine");
 	s_task = getsym("Task");
-	s_prstart = getsym("prStart");
 	s_interpreter = getsym("Interpreter");
 	s_finalizer = getsym("Finalizer");
-	s_awake = getsym("awake");
 	s_appclock = getsym("AppClock");
 	s_systemclock = getsym("SystemClock");
     s_server_shm_interface = getsym("ServerShmInterface");
@@ -262,8 +258,6 @@ void initSymbols()
 	s_exponential = getsym("exponential");
 	s_gate = getsym("gate");
 
-	//s_dsp = getsym("DSP");
-	//s_dspsettings = getsym("DSPSettings");
 	s_synth = getsym("Synth");
 	s_spawn = getsym("BasicSpawn");
 	s_environment = getsym("Environment");
@@ -274,9 +268,9 @@ void initSymbols()
 	s_interpretCmdLine = getsym("interpretCmdLine");
 	s_interpretPrintCmdLine = getsym("interpretPrintCmdLine");
 
-
-	s_nocomprendo = getsym("doesNotUnderstand");
-
+	s_nocomprendo = getsym("doesNotUnderstand"); // rename
+    
+    s_awake = getsym("awake");
     
 	s_audio = getsym("audio");
 	s_control = getsym("control");
@@ -291,8 +285,8 @@ void initSymbols()
 	s_performList = getsym("performList");
 	s_superPerformList = getsym("superPerformList");
 	s_at = getsym("at");
-	s_put = getsym("put");
-
+    s_put = getsym("put");
+    s_prstart = getsym("prStart");
 	s_series = getsym("prSimpleNumberSeries");
 	s_copyseries = getsym("copySeries");
 	s_putseries = getsym("putSeries");

--- a/lang/LangSource/PyrObject.cpp
+++ b/lang/LangSource/PyrObject.cpp
@@ -165,7 +165,7 @@ PyrSymbol *s_new, *s_ref, *s_value, *s_at, *s_put;
 PyrSymbol *s_performList, *s_superPerformList;
 PyrSymbol *s_series, *s_copyseries, *s_putseries;
 PyrSymbol *s_envirGet, *s_envirPut;
-PyrSymbol *s_synth, *s_environment, *s_event;
+PyrSymbol *s_synth, *s_spawn, *s_environment, *s_event;
 PyrSymbol *s_hardwaresetup, *s_shutdown;
 PyrSymbol *s_super, *s_this;
 PyrSlot o_nil, o_true, o_false, o_end;

--- a/lang/LangSource/PyrObject.cpp
+++ b/lang/LangSource/PyrObject.cpp
@@ -314,17 +314,17 @@ void initSymbols()
 	gFormatElemSize[obj_slot  ] = sizeof(PyrSlot);
 	gFormatElemSize[obj_double] = sizeof(double);
 	gFormatElemSize[obj_float ] = sizeof(float);
-	gFormatElemSize[obj_int32  ] = sizeof(int32);
+	gFormatElemSize[obj_int32 ] = sizeof(int32);
 	gFormatElemSize[obj_int16 ] = sizeof(int16);
 	gFormatElemSize[obj_int8  ] = sizeof(int8);
 	gFormatElemSize[obj_char  ] = sizeof(char);
-	gFormatElemSize[obj_symbol  ] = sizeof(PyrSymbol*);
+	gFormatElemSize[obj_symbol] = sizeof(PyrSymbol*);
 
 	gFormatElemCapc[obj_notindexed] = sizeof(PyrSlot) / sizeof(PyrSlot);
 	gFormatElemCapc[obj_slot  ] = sizeof(PyrSlot) / sizeof(PyrSlot);
 	gFormatElemCapc[obj_double] = sizeof(PyrSlot) / sizeof(double);
 	gFormatElemCapc[obj_float ] = sizeof(PyrSlot) / sizeof(float);
-	gFormatElemCapc[obj_int32  ] = sizeof(PyrSlot) / sizeof(int32);
+	gFormatElemCapc[obj_int32 ] = sizeof(PyrSlot) / sizeof(int32);
 	gFormatElemCapc[obj_int16 ] = sizeof(PyrSlot) / sizeof(int16);
 	gFormatElemCapc[obj_int8  ] = sizeof(PyrSlot) / sizeof(int8);
 	gFormatElemCapc[obj_char  ] = sizeof(PyrSlot) / sizeof(char);
@@ -334,7 +334,7 @@ void initSymbols()
 	gFormatElemTag[obj_slot  ] = -1;
 	gFormatElemTag[obj_double] = 0;
 	gFormatElemTag[obj_float ] = 0;
-	gFormatElemTag[obj_int32  ] = tagInt;
+	gFormatElemTag[obj_int32 ] = tagInt;
 	gFormatElemTag[obj_int16 ] = tagInt;
 	gFormatElemTag[obj_int8  ] = tagInt;
 	gFormatElemTag[obj_char  ] = tagChar;

--- a/lang/LangSource/PyrObject.cpp
+++ b/lang/LangSource/PyrObject.cpp
@@ -154,7 +154,6 @@ PyrSymbol *s_run, *s_stop, *s_tick;
 PyrSymbol *s_startup;
 PyrSymbol *s_next;
 PyrSymbol *s_env;
-PyrSymbol *s_ugen, *s_outputproxy;
 PyrSymbol *s_new, *s_ref, *s_value, *s_at, *s_put;
 PyrSymbol *s_performList, *s_superPerformList;
 PyrSymbol *s_series, *s_copyseries, *s_putseries;
@@ -242,8 +241,6 @@ void initSymbols()
 	s_appclock = getsym("AppClock");
 	s_systemclock = getsym("SystemClock");
     s_server_shm_interface = getsym("ServerShmInterface");
-    s_ugen = getsym("UGen");
-    s_outputproxy = getsym("OutputProxy");
     s_env = getsym("Env");
     s_synth = getsym("Synth");
     s_environment = getsym("Environment");

--- a/lang/LangSource/PyrObject.cpp
+++ b/lang/LangSource/PyrObject.cpp
@@ -163,7 +163,7 @@ PyrSymbol *s_performList, *s_superPerformList;
 PyrSymbol *s_series, *s_copyseries, *s_putseries;
 PyrSymbol *s_envirGet, *s_envirPut;
 PyrSymbol *s_synth, *s_environment, *s_event;
-PyrSymbol *s_hardwaresetup, *s_shutdown;
+PyrSymbol *s_shutdown;
 PyrSymbol *s_super, *s_this;
 PyrSlot o_nil, o_true, o_false, o_end;
 PyrSlot o_pi, o_twopi;
@@ -252,7 +252,6 @@ void initSymbols()
 	s_synth = getsym("Synth");
 	s_environment = getsym("Environment");
 	s_event = getsym("Event");
-	s_hardwaresetup = getsym("hardwareSetup");
 	s_shutdown = getsym("shutdown");
 
 	s_interpretCmdLine = getsym("interpretCmdLine");

--- a/lang/LangSource/PyrObject.cpp
+++ b/lang/LangSource/PyrObject.cpp
@@ -150,8 +150,6 @@ PyrSymbol *s_interpretCmdLine, *s_interpretPrintCmdLine;
 
 PyrSymbol *s_doesNotUnderstand;
 PyrSymbol *s_curProcess, *s_curMethod, *s_curBlock, *s_curClosure, *s_curThread;
-//PyrSymbol *s_sampleRate;
-//PyrSymbol *s_audioClock, *s_logicalClock;
 PyrSymbol *s_run, *s_stop, *s_tick;
 PyrSymbol *s_startup;
 PyrSymbol *s_next;

--- a/lang/LangSource/PyrObject.cpp
+++ b/lang/LangSource/PyrObject.cpp
@@ -162,6 +162,7 @@ PyrSymbol *s_envirGet, *s_envirPut;
 PyrSymbol *s_synth, *s_environment, *s_event;
 PyrSymbol *s_shutdown;
 PyrSymbol *s_super, *s_this;
+
 PyrSlot o_nil, o_true, o_false;
 PyrSlot o_fhalf, o_fnegone, o_fzero, o_fone, o_ftwo, o_inf;
 PyrSlot o_negone, o_zero, o_one, o_two;
@@ -279,18 +280,20 @@ void initSymbols()
 	SetNil(&o_nil);
 	SetFalse(&o_false);
 	SetTrue(&o_true);
+    
+    SetSymbol(&o_none, s_none);
 
 	SetFloat(&o_fhalf, .5);
 	SetFloat(&o_fnegone, -1.);
 	SetFloat(&o_fzero, 0.);
 	SetFloat(&o_fone, 1.);
-	SetFloat(&o_ftwo, 2.);
+    SetFloat(&o_ftwo, 2.);
+    SetFloat(&o_inf, std::numeric_limits<double>::infinity());
+    
 	SetInt(&o_negone, -1);
 	SetInt(&o_zero, 0);
 	SetInt(&o_one, 1);
 	SetInt(&o_two, 2);
-	SetSymbol(&o_none, s_none);
-	SetFloat(&o_inf, std::numeric_limits<double>::infinity());
 
 	slotCopy(&gSpecialValues[svNil], &o_nil);
 	slotCopy(&gSpecialValues[svFalse], &o_false);

--- a/lang/LangSource/PyrObject.cpp
+++ b/lang/LangSource/PyrObject.cpp
@@ -166,7 +166,7 @@ PyrSlot o_nil, o_true, o_false, o_end;
 PyrSlot o_pi, o_twopi;
 PyrSlot o_fhalf, o_fnegone, o_fzero, o_fone, o_ftwo, o_inf;
 PyrSlot o_negtwo, o_negone, o_zero, o_one, o_two;
-PyrSlot o_nullframe, o_none;
+PyrSlot o_none;
 PyrSlot o_emptyarray, o_onenilarray, o_argnamethis;
 
 

--- a/lang/LangSource/PyrObject.cpp
+++ b/lang/LangSource/PyrObject.cpp
@@ -163,9 +163,8 @@ PyrSymbol *s_synth, *s_environment, *s_event;
 PyrSymbol *s_shutdown;
 PyrSymbol *s_super, *s_this;
 PyrSlot o_nil, o_true, o_false;
-PyrSlot o_pi, o_twopi;
 PyrSlot o_fhalf, o_fnegone, o_fzero, o_fone, o_ftwo, o_inf;
-PyrSlot o_negtwo, o_negone, o_zero, o_one, o_two;
+PyrSlot o_negone, o_zero, o_one, o_two;
 PyrSlot o_none;
 PyrSlot o_emptyarray, o_onenilarray, o_argnamethis;
 
@@ -281,14 +280,11 @@ void initSymbols()
 	SetFalse(&o_false);
 	SetTrue(&o_true);
 
-	SetFloat(&o_pi, pi);
-	SetFloat(&o_twopi, twopi);
 	SetFloat(&o_fhalf, .5);
 	SetFloat(&o_fnegone, -1.);
 	SetFloat(&o_fzero, 0.);
 	SetFloat(&o_fone, 1.);
 	SetFloat(&o_ftwo, 2.);
-	SetInt(&o_negtwo, -2);
 	SetInt(&o_negone, -1);
 	SetInt(&o_zero, 0);
 	SetInt(&o_one, 1);

--- a/lang/LangSource/PyrObject.cpp
+++ b/lang/LangSource/PyrObject.cpp
@@ -155,9 +155,6 @@ PyrSymbol *s_curProcess, *s_curMethod, *s_curBlock, *s_curClosure, *s_curThread;
 PyrSymbol *s_run, *s_stop, *s_tick;
 PyrSymbol *s_startup;
 PyrSymbol *s_docmdline;
-PyrSymbol *s_audio;
-PyrSymbol *s_control;
-PyrSymbol *s_scalar;
 PyrSymbol *s_next;
 PyrSymbol *s_env;
 PyrSymbol *s_ugen, *s_outputproxy;
@@ -265,9 +262,6 @@ void initSymbols()
     
     s_awake = getsym("awake");
     
-	s_audio = getsym("audio");
-	s_control = getsym("control");
-	s_scalar = getsym("scalar");
 	s_run = getsym("run");
 	s_stop = getsym("stop");
 	s_tick = getsym("tick");

--- a/lang/LangSource/PyrObject.cpp
+++ b/lang/LangSource/PyrObject.cpp
@@ -162,7 +162,7 @@ PyrSymbol *s_envirGet, *s_envirPut;
 PyrSymbol *s_synth, *s_environment, *s_event;
 PyrSymbol *s_shutdown;
 PyrSymbol *s_super, *s_this;
-PyrSlot o_nil, o_true, o_false, o_end;
+PyrSlot o_nil, o_true, o_false;
 PyrSlot o_pi, o_twopi;
 PyrSlot o_fhalf, o_fnegone, o_fzero, o_fone, o_ftwo, o_inf;
 PyrSlot o_negtwo, o_negone, o_zero, o_one, o_two;

--- a/lang/LangSource/PyrObject.h
+++ b/lang/LangSource/PyrObject.h
@@ -205,7 +205,6 @@ extern PyrSymbol *s_process;
 extern PyrSymbol *s_main;
 extern PyrSymbol *s_thread;
 extern PyrSymbol *s_routine;
-extern PyrSymbol *s_linear, *s_exponential, *s_gate;
 extern PyrSymbol *s_env;
 
 extern PyrSymbol *s_audio, *s_control, *s_scalar;

--- a/lang/LangSource/PyrObject.h
+++ b/lang/LangSource/PyrObject.h
@@ -183,7 +183,7 @@ extern PyrSymbol *s_list, *s_method, *s_fundef, *s_frame, *s_class;
 extern PyrSymbol *s_symbol, *s_nil;
 extern PyrSymbol *s_boolean, *s_true, *s_false;
 extern PyrSymbol *s_int, *s_char, *s_color, *s_float, *s_complex;
-extern PyrSymbol *s_rawptr, *s_objptr;
+extern PyrSymbol *s_rawptr;
 extern PyrSymbol *s_string;
 extern PyrSymbol *s_magnitude, *s_number, *s_collection;
 extern PyrSymbol *s_ordered_collection;

--- a/lang/LangSource/PyrObject.h
+++ b/lang/LangSource/PyrObject.h
@@ -218,7 +218,7 @@ extern PyrSymbol *s_performList;
 extern PyrSymbol *s_superPerformList;
 extern PyrSymbol *s_ugen, *s_outputproxy;
 extern PyrSymbol *s_new, *s_ref;
-extern PyrSymbol *s_synth, *s_spawn, *s_environment, *s_event;
+extern PyrSymbol *s_synth, *s_environment, *s_event;
 extern PyrSymbol *s_interpreter;
 extern PyrSymbol *s_finalizer;
 extern PyrSymbol *s_awake;

--- a/lang/LangSource/PyrObject.h
+++ b/lang/LangSource/PyrObject.h
@@ -198,7 +198,6 @@ extern PyrSymbol *s_int32array;
 extern PyrSymbol *s_symbolarray;
 extern PyrSymbol *s_floatarray;
 extern PyrSymbol *s_doublearray;
-extern PyrSymbol *s_point;
 extern PyrSymbol *s_rect;
 extern PyrSymbol *s_stream;
 extern PyrSymbol *s_process;

--- a/lang/LangSource/PyrObject.h
+++ b/lang/LangSource/PyrObject.h
@@ -215,7 +215,6 @@ extern PyrSymbol *s_series, *s_copyseries, *s_putseries;
 extern PyrSymbol *s_value;
 extern PyrSymbol *s_performList;
 extern PyrSymbol *s_superPerformList;
-extern PyrSymbol *s_ugen, *s_outputproxy;
 extern PyrSymbol *s_new, *s_ref;
 extern PyrSymbol *s_synth, *s_environment, *s_event;
 extern PyrSymbol *s_interpreter;

--- a/lang/LangSource/PyrObject.h
+++ b/lang/LangSource/PyrObject.h
@@ -218,7 +218,7 @@ extern PyrSymbol *s_performList;
 extern PyrSymbol *s_superPerformList;
 extern PyrSymbol *s_ugen, *s_outputproxy;
 extern PyrSymbol *s_new, *s_ref;
-extern PyrSymbol *s_synth, *s_environment, *s_event;
+extern PyrSymbol *s_synth, *s_spawn, *s_environment, *s_event;
 extern PyrSymbol *s_interpreter;
 extern PyrSymbol *s_finalizer;
 extern PyrSymbol *s_awake;

--- a/lang/LangSource/PyrObject.h
+++ b/lang/LangSource/PyrObject.h
@@ -207,7 +207,6 @@ extern PyrSymbol *s_thread;
 extern PyrSymbol *s_routine;
 extern PyrSymbol *s_env;
 
-extern PyrSymbol *s_audio, *s_control, *s_scalar;
 extern PyrSymbol *s_run, *s_stop, *s_tick;
 extern PyrSymbol *s_next;
 extern PyrSymbol *s_at;

--- a/lang/LangSource/PyrObject.h
+++ b/lang/LangSource/PyrObject.h
@@ -220,7 +220,6 @@ extern PyrSymbol *s_synth, *s_environment, *s_event;
 extern PyrSymbol *s_interpreter;
 extern PyrSymbol *s_finalizer;
 extern PyrSymbol *s_awake;
-extern PyrSymbol *s_appclock;
 extern PyrSymbol *s_systemclock;
 extern PyrSymbol *s_server_shm_interface;
 extern PyrSymbol *s_interpretCmdLine, *s_interpretPrintCmdLine;

--- a/lang/LangSource/PyrParseNode.cpp
+++ b/lang/LangSource/PyrParseNode.cpp
@@ -1451,7 +1451,7 @@ void PyrMethodNode::compile(PyrSlot *result)
 				numArgs, getPrimitiveNumArgs(methraw->specialIndex));
 		}
 		*/
-	} else if (slotRawSymbol(&gCompilingMethod->name) == s_nocomprendo) {
+	} else if (slotRawSymbol(&gCompilingMethod->name) == s_doesNotUnderstand) {
 		methType = methNormal;
 	} else {
 		int bodyType = mBody->mClassno;

--- a/lang/LangSource/PyrParseNode.cpp
+++ b/lang/LangSource/PyrParseNode.cpp
@@ -1076,11 +1076,6 @@ int checkPushAllButFirstTwoArgs(PyrParseNode *actualArg, int numArgs)
 				return push_Normal;
 			}
 			nameNode = (PyrPushNameNode*)actualArg;
-			/*if (slotRawSymbol(&gCompilingClass->name) == s_ugen) {
-				post("check meth %s  %d  '%s' '%s'\n", slotRawSymbol(&gCompilingMethod->name)->name, i,
-					slotRawSymbol(&nameNode->mSlot)->name,
-					block->argNames.uosym->symbols[i]->name);
-			}*/
 			if (slotRawSymbol(&nameNode->mSlot) != slotRawSymbolArray(&block->argNames)->symbols[i]) {
 				return push_Normal;
 			}

--- a/lang/LangSource/PyrSlot.h
+++ b/lang/LangSource/PyrSlot.h
@@ -37,9 +37,8 @@ A PyrSlot is an 8-byte value which is either a double precision float or a
 #endif
 
 extern PyrSlot o_nil, o_true, o_false, o_inf;
-extern PyrSlot o_pi, o_twopi;
 extern PyrSlot o_fhalf, o_fnegone, o_fzero, o_fone, o_ftwo;
-extern PyrSlot o_negtwo, o_negone, o_zero, o_one, o_two;
+extern PyrSlot o_negone, o_zero, o_one, o_two;
 extern PyrSlot o_emptyarray, o_onenilarray, o_argnamethis;
 
 extern PyrSymbol *s_object; // "Object"


### PR DESCRIPTION
Major changes: 

- Removes ~15~ 19 unused variables in PyrObject.cpp
- Rearrange and label sections of `initSymbols` method for clarity

~Also, if anyone knows why specifically Object, Boolean, Collection, etc. are counted as special symbols above other class names, it would be great to get an explanation on that. Otherwise I'll do some digging on my own.~ Never mind, it's pretty obvious why now.