### PR TITLE
class lib: don't post "cleaning up temp synthdefs" if no SynthDefs are being cleaned up

### DIFF
--- a/SCClassLibrary/Common/Audio/SystemSynthDefs.sc
+++ b/SCClassLibrary/Common/Audio/SystemSynthDefs.sc
@@ -19,8 +19,13 @@ SystemSynthDefs {
 			// clean up any written synthdefs starting with "temp__"
 			var path = SynthDef.synthDefDir ++ tempNamePrefix ++ "*";
 			var match = pathMatch(path);
-			if(match.notEmpty) { "Cleaning up temporary SynthDefs...".postln };
-			pathMatch(path).do { |file| File.delete(file) };
+			if(match.notEmpty) {
+				"Cleaning up % temporary SynthDef%...\n".postf(
+					match.size,
+					if(match.size == 1, { "" }, { "s" })
+				);
+				match.do { |file| File.delete(file) };
+			};
 
 			// add system synth defs
 			(1..numChannels).do { arg i;

--- a/SCClassLibrary/Common/Audio/SystemSynthDefs.sc
+++ b/SCClassLibrary/Common/Audio/SystemSynthDefs.sc
@@ -18,7 +18,8 @@ SystemSynthDefs {
 
 			// clean up any written synthdefs starting with "temp__"
 			var path = SynthDef.synthDefDir ++ tempNamePrefix ++ "*";
-			"Cleaning up temp synthdefs...".postln;
+			var match = pathMatch(path);
+			if(match.notEmpty) { "Cleaning up temporary SynthDefs...".postln };
 			pathMatch(path).do { |file| File.delete(file) };
 
 			// add system synth defs


### PR DESCRIPTION
Most users use SynthDefs in memory, so there are no SynthDef files to be cleaned. This commit suppresses the "cleaning up temp synthdefs" message if it's not doing anything. I also capitalized "SynthDefs" and expanded "temp" to "temporary."