### PR TITLE
Document thisMethod

### DIFF
--- a/HelpSource/Classes/Interpreter.schelp
+++ b/HelpSource/Classes/Interpreter.schelp
@@ -136,3 +136,7 @@ preProcessor = nil; // reset to nil.
 method::a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s,t,u,v,w,x,y,z
 
 Global variables ("interpreter variables") for interactive programming (see link::#Accessing::).
+
+method::functionCompileContext
+
+The compiler uses this method as a virtual context in which to compile code.

--- a/HelpSource/Classes/Method.schelp
+++ b/HelpSource/Classes/Method.schelp
@@ -27,7 +27,7 @@ a = SomeClass.new;
 a.methodThatPostsItself;
 ::
 
-It is frequently used along with error-throwing methods. For example, the implementation of code::Nil.new:: is:
+code::thisMethod:: is frequently used to pass information to error-throwing methods. For example, the implementation of code::Nil.new:: is:
 
 code::
 *new { ^this.shouldNotImplement(thisMethod) }

--- a/HelpSource/Classes/Method.schelp
+++ b/HelpSource/Classes/Method.schelp
@@ -6,6 +6,35 @@ related:: Classes/Class
 description::
 A Method is code that is a part of the set of operations upon instances of a link::Classes/Class::.
 
+subsection:: Related Keywords
+
+method:: thisMethod
+
+The global pseudo-variable code::thisMethod:: always evaluates to the enclosing Method in a class definition, much like code::thisFunction::.
+When executed outside that context, it returns link::Classes/Interpreter#-functionCompileContext::, the method within which all interpreted code executes.
+
+code::
+// if the following code were compiled as part of the class library:
+SomeClass {
+	methodThatPostsItself {
+		thisMethod.postln;
+	}
+}
+
+// then running this would post
+// "SomeClass:methodThatPostsItself"
+a = SomeClass.new;
+a.methodThatPostsItself;
+::
+
+It is frequently used along with error-throwing methods. For example, the implementation of code::Nil.new:: is:
+
+code::
+*new { ^this.shouldNotImplement(thisMethod) }
+::
+
+See also: link::Classes/Function#.thisFunction#thisFunction::.
+
 instanceMethods::
 
 method::ownerClass


### PR DESCRIPTION
Fix for #871.

Most of the documentation is boilerplate from `thisFunction`. I also had to document `Interpreter:-functionCompileContext` in order to properly explain & link from the description of `thisMethod`.