### PR TITLE
Add "Clear Post Window" menu item

### DIFF
--- a/editors/sc-ide/widgets/main_window.cpp
+++ b/editors/sc-ide/widgets/main_window.cpp
@@ -409,6 +409,12 @@ void MainWindow::createActions()
     connect(action, SIGNAL(triggered()), mPostDocklet, SLOT(focus()));
     settings->addAction( action, "post-focus", ideCategory);
 
+    mActions[ClearPostWindow] = action = new QAction(tr("Clear Post Window"), this);
+    action->setStatusTip(tr("Clear post window"));
+    action->setShortcut(tr("Ctrl+Shift+P", "Clear post window"));
+    connect(action, SIGNAL(triggered()), mPostDocklet->mPostWindow, SLOT(clear()));
+    settings->addAction( action, "post-clear", ideCategory);
+
     // Language
     mActions[LookupImplementation] = action = new QAction(
         QIcon::fromTheme("window-lookupdefinition"), tr("Look Up Implementations..."), this);
@@ -637,6 +643,7 @@ void MainWindow::createMenus()
     menu->addAction( mEditors->action(MultiEditor::RemoveAllSplits) );
     menu->addSeparator();
     menu->addAction( mActions[FocusPostWindow] );
+    menu->addAction( mActions[ClearPostWindow] );
     menu->addSeparator();
     menu->addAction( mActions[ShowFullScreen] );
 

--- a/editors/sc-ide/widgets/main_window.hpp
+++ b/editors/sc-ide/widgets/main_window.hpp
@@ -88,6 +88,7 @@ public:
         CloseToolBox,
         ShowFullScreen,
         FocusPostWindow,
+        ClearPostWindow,
 
         // Settings
         ShowSettings,

--- a/editors/sc-ide/widgets/post_window.cpp
+++ b/editors/sc-ide/widgets/post_window.cpp
@@ -77,14 +77,6 @@ void PostWindow::createActions( Settings::Manager * settings )
     connect( this, SIGNAL(copyAvailable(bool)), action, SLOT(setEnabled(bool)) );
     addAction(action);
 
-    mActions[Clear] = action = new QAction(tr("Clear"), this);
-    action->setStatusTip(tr("Clear post window"));
-    action->setShortcutContext(Qt::ApplicationShortcut);
-    action->setShortcut(tr("Ctrl+Shift+P", "Clear post window"));
-    settings->addAction( action, "post-clear", postCategory );
-    connect(action, SIGNAL(triggered()), this, SLOT(clear()));
-    addAction(action);
-
     action = new QAction(this);
     action->setSeparator(true);
     addAction(action);

--- a/editors/sc-ide/widgets/post_window.hpp
+++ b/editors/sc-ide/widgets/post_window.hpp
@@ -39,7 +39,6 @@ class PostWindow:
 public:
     enum ActionRole {
         Copy,
-        Clear,
         DocClose,
         ZoomIn,
         ZoomOut,


### PR DESCRIPTION
Fix for #675.

1. Removed the `Clear` ActionRole from PostWindow.
2. Removed the definition of the "Clear post window" shortcut from PostWindow.
3. Added a `ClearPostWindow` ActionRole to MainWindow.
4. Added a definition for the "Clear Post Window"  shortcut to MainWindow and added it to the menu.
