### PR TITLE
Help: Note sr-dependent amplitude in Ringz and related filters

### DIFF
--- a/HelpSource/Classes/DynKlank.schelp
+++ b/HelpSource/Classes/DynKlank.schelp
@@ -13,6 +13,10 @@ the time for the mode to decay by 60 dB.
 
 Unlike  link::Classes/Klank::, all parameters in DynKlank can be changed in real-time after it has been started.
 
+Note::
+The amplitude of the resulting signal depends on the server's sample rate. See link::Classes/Ringz#Interaction with sample rate#Ringz: Interaction with sample rate:: for details.
+::
+
 
 classmethods::
 

--- a/HelpSource/Classes/Formlet.schelp
+++ b/HelpSource/Classes/Formlet.schelp
@@ -19,6 +19,10 @@ The great advantage to this filter over FOF is that there is no limit to
 the number of overlapping grains since the grain is just the impulse
 response of the filter.
 
+Note::
+The amplitude of the resulting signal depends on the server's sample rate. See link::Classes/Ringz#Interaction with sample rate#Ringz: Interaction with sample rate:: for details.
+::
+
 
 classmethods::
 

--- a/HelpSource/Classes/Klank.schelp
+++ b/HelpSource/Classes/Klank.schelp
@@ -12,6 +12,12 @@ simulate the resonant modes of an object. Each mode is given a ring time,
 which is the time for the mode to decay by 60 dB.
 Note::for dynamic changes of parameters refer to link::Classes/DynKlank:: ::
 
+Note::
+The amplitude of the resulting signal depends on the server's sample rate. See link::Classes/Ringz#Interaction with sample rate#Ringz: Interaction with sample rate:: for details.
+::
+
+Klank is a bank of Ringz filters. link::Classes/Formlet:: is equivalent to code::Ringz.ar(... decay...) - Ring.ar(... attack...)::. Therefore, a more efficient way to make a bank of fixed-parameter Formlet filters is code::Klank(`decaySpecs, ...) - Klank.ar(`attackSpecs, ...):: or code::Klank.ar(`specs, ..., decayscale: decay) - Klank.ar(`specs, ..., decayscale: attack)::.
+
 classmethods::
 
 method::ar

--- a/HelpSource/Classes/Ringz.schelp
+++ b/HelpSource/Classes/Ringz.schelp
@@ -71,3 +71,28 @@ code::
 )
 ::
 
+Section:: Interaction with sample rate
+
+Ringz (and UGens that are based on it: link::Classes/Klank::, link::Classes/DynKlank:: and link::Classes/Formlet::) are "sample-rate independent" with respect to emphasis::impulses:: at the input. That is, given single-sample impulses, the output signal at different sample rates should be the same frequency and amplitude.
+
+This design has a side effect: If the input is not made of impulses, the output amplitude depends on the sample rate. Higher sample rates produce louder signals, by an amount proportional to the ratio between sample rates.
+
+code::
+(
+a = {
+	// rectangular pulse exciter (deterministic input)
+	var exc = EnvGen.ar(Env([1, 1, 0], [0.01, 0], \lin)),
+	sig = Ringz.ar(exc, 440, decaytime: 0.2),
+	rms = sqrt(Integrator.ar(sig.squared) * (0.2 / SampleRate.ir)),
+	end = DetectSilence.ar(sig, doneAction: 2);
+	rms.poll(end);
+	Silent.ar(1)
+}.play;
+)
+::
+
+At 44.1kHz, this prints a RMS amplitude of 1.0758. At 88.2kHz, the amplitude doubles.
+
+Modal synthesis (simulating the vibrating modes of a struck surface) feeds a short, decaying burst of noise into Ringz-style resonators. This is a common use case that emphasis::is:: subject to this amplitude effect.
+
+If you will need the results to be compatible at different sample rates, make sure to scale the volume appropriately: if code::sig:: is the Ringz, Klank or Formlet signal, use code::sig * (originalSampleRate / SampleRate.ir):: and substitute the right value in place of code::originalSampleRate::.

--- a/HelpSource/Classes/Ringz.schelp
+++ b/HelpSource/Classes/Ringz.schelp
@@ -75,7 +75,7 @@ Section:: Interaction with sample rate
 
 Ringz (and UGens that are based on it: link::Classes/Klank::, link::Classes/DynKlank:: and link::Classes/Formlet::) are "sample-rate independent" with respect to emphasis::impulses:: at the input. That is, given single-sample impulses, the output signal at different sample rates should be the same frequency and amplitude.
 
-This design has a side effect: If the input is not made of impulses, the output amplitude depends on the sample rate. Higher sample rates produce louder signals, by an amount proportional to the ratio between sample rates.
+This design has a side effect: If the input is not made of impulses, the output amplitude is proportional to the sample rate.
 
 code::
 (
@@ -91,7 +91,7 @@ a = {
 )
 ::
 
-At 44.1kHz, this prints a RMS amplitude of 1.0758. At 88.2kHz, the amplitude doubles.
+At 44.1 kHz, this prints a RMS amplitude of 1.0758. At 88.2 kHz, the amplitude doubles.
 
 Modal synthesis (simulating the vibrating modes of a struck surface) feeds a short, decaying burst of noise into Ringz-style resonators. This is a common use case that emphasis::is:: subject to this amplitude effect.
 


### PR DESCRIPTION
Explain SR-related amplitude effect -- thanks to Nathan Ho for the explanation. Added to Ringz, with links in Klank, DynKlank and Formlet.

Also add a little note to Klank about a neat trick for a bank of Formlets.