### PR TITLE
ide: reword "Use ComboBox" options

### DIFF
--- a/editors/sc-ide/forms/settings_editor.ui
+++ b/editors/sc-ide/forms/settings_editor.ui
@@ -321,14 +321,14 @@
         <item>
          <widget class="QCheckBox" name="useComboBox">
           <property name="text">
-           <string>Use a dropdown instead of tabs in the editor view</string>
+           <string>Use a drop-down instead of tabs in the editor view</string>
           </property>
          </widget>
         </item>
         <item>
          <widget class="QCheckBox" name="useComboBoxWhenSplitting">
           <property name="text">
-           <string>Switch to dropdown mode when splitting the editor view</string>
+           <string>Switch to drop-down mode when splitting the editor view</string>
           </property>
          </widget>
         </item>

--- a/editors/sc-ide/forms/settings_editor.ui
+++ b/editors/sc-ide/forms/settings_editor.ui
@@ -321,14 +321,14 @@
         <item>
          <widget class="QCheckBox" name="useComboBox">
           <property name="text">
-           <string>Use ComboBox</string>
+           <string>Use a dropdown instead of tabs in the editor view</string>
           </property>
          </widget>
         </item>
         <item>
          <widget class="QCheckBox" name="useComboBoxWhenSplitting">
           <property name="text">
-           <string>Convert automatically to ComboBox when splitting</string>
+           <string>Switch to dropdown mode when splitting the editor view</string>
           </property>
          </widget>
         </item>


### PR DESCRIPTION
New options were introduced in #2555 that allow using a combobox instead of tabs in the editor view. This commit improves the wording of these options in the settings window to be easier to understand. 

I prefer the term "dropdown" to "combobox." I'm sure more people understand what "dropdown" means.