### PR TITLE
Qt gui: Allow TextView selectedString_ to work if selection size is 0

### DIFF
--- a/QtCollider/widgets/QcTextEdit.cpp
+++ b/QtCollider/widgets/QcTextEdit.cpp
@@ -98,8 +98,8 @@ void QcTextEdit::replaceSelectedText( const QString &string )
   QTextCursor cursor( textCursor() );
   if( cursor.hasSelection() ) {
     cursor.removeSelectedText();
-    cursor.insertText( string );
-  }
+  };
+  cursor.insertText( string );
 }
 
 QString QcTextEdit::currentLine() const


### PR DESCRIPTION
So I just wrote DDWSnippets, and part of the intent was to allow its use with TextViews, but then I found:

```
t = TextView(nil, Rect(800, 200, 500, 400)).front;
t.selectedString_("test");
```

Guess what... this inserts nothing.

Why? Because QcTextEdit declares that you should not be able to insert text if there is no current selection spanning at least one character, by accidentally putting `cursor.insertText( string );` inside the `if` block.

```
void QcTextEdit::replaceSelectedText( const QString &string )
{
  QTextCursor cursor( textCursor() );
  if( cursor.hasSelection() ) {
    cursor.removeSelectedText();
    cursor.insertText( string );
  }
}
```

`Document:selectedString_` does not share this restriction.

Fixed here.