### PR TITLE
scvim: update url to sbl/scvim

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,7 +9,7 @@
 	url = git://github.com/supercollider/hidapi.git
 [submodule "editors/scvim"]
 	path = editors/scvim
-	url = https://github.com/supercollider/scvim.git
+	url = https://github.com/sbl/scvim.git
 [submodule "external_libraries/portaudio_sc_org"]
 	path = external_libraries/portaudio_sc_org
 	url = https://github.com/supercollider/portaudio.git


### PR DESCRIPTION
Fixes #2550 

To update the submodule URL locally:

```
git submodule sync
git submodule update --init --recursive --remote
```