### PR TITLE
Fix LocalOut check

### DIFF
--- a/SCClassLibrary/Common/Audio/InOut.sc
+++ b/SCClassLibrary/Common/Audio/InOut.sc
@@ -217,7 +217,7 @@ AbstractOut : UGen {
 				});
 			});
 		}, {
-			if(inputs.size <= 1, {
+			if(inputs.size <= this.class.numFixedArgs, {
 				^"missing input at index 1"
 			})
 		});


### PR DESCRIPTION
A test:
```
{ LocalOut.kr(0) }.asSynthDef; // works
{ LocalOut.kr([0]) }.asSynthDef; // works
{ LocalOut.kr() }.asSynthDef; // fails
{ LocalOut.kr([]) }.asSynthDef; // fails
```