### PR TITLE
plugins: fix FOS initialization

### DIFF
--- a/server/plugins/FilterUGens.cpp
+++ b/server/plugins/FilterUGens.cpp
@@ -3799,9 +3799,9 @@ void FOS_Ctor(FOS* unit)
 		}
 	};
 	unit->m_y1 = 0.f;
-	unit->m_a0 = 0.f;
-	unit->m_a1 = 0.f;
-	unit->m_b1 = 0.f;
+	unit->m_a0 = ZIN0(1);
+	unit->m_a1 = ZIN0(2);
+	unit->m_b1 = ZIN0(3);
 	FOS_next_1(unit, 1);
 }
 


### PR DESCRIPTION
Fixed an initialization issue where FOS with control-rate coefficient inputs would initialize its coefficients to zero and ramp to the correct coefficients in the first control period. Fix #2656.

Test case:

    { FOS.ar(Impulse.ar(SampleRate.ir / 4), 1, 0, 0); }.plot(0.005)

Unit tests coming soon.