### PR TITLE
class library: XOut uses correct input test

### DIFF
--- a/SCClassLibrary/Common/Audio/InOut.sc
+++ b/SCClassLibrary/Common/Audio/InOut.sc
@@ -279,17 +279,6 @@ XOut : AbstractOut {
 		^0.0		// Out has no output
 	}
 	*numFixedArgs { ^2 }
-	checkInputs {
-		if (rate == 'audio', {
-			for(2, inputs.size - 1, { arg i;
-				if (inputs.at(i).rate != 'audio', {
-					^(" input at index " + i +
-						"(" + inputs.at(i) + ") is not audio rate");
-				});
-			});
-		});
-		^this.checkValidInputs
-	}
 	writesToBus { ^true }
 }
 


### PR DESCRIPTION
This is the test that was explicitly defined in the superclass for that
purpose, so use this.

```


(
var failing = [nil, []];
var working = [0, [0], [0, 0, 0]];
var stubs = [
	{ |args| LocalOut.kr(*args) },
	{ |args| Out.kr(0, *args) },
	{ |args| ReplaceOut.kr(0, *args) },
	{ |args| XOut.kr(0, 0.5, *args) },
];

var fails = failing.every { |input|
	stubs.every { |func|
		var fails = false;
		try { { func.(input) }.asSynthDef } { |err| fails = err.isException };
		if(fails.not) { "This is a case that should have failed:\n%\nOn this input:\n%\n".postf(func.cs, input) };
		fails
	}
};
var works = working.every { |input|
	stubs.every { |func|
		var works = true;
		try { { func.(input) }.asSynthDef } { |err| works = err.isException.not };
		if(works.not) { "This is a case that should not have failed:\n%\nOn this input:\n%\n".postf(func.cs, input) };
		works
	}
};

fails and: works
)
```