### PR TITLE
Update sysex doc

### DIFF
--- a/HelpSource/Classes/MIDIOut.schelp
+++ b/HelpSource/Classes/MIDIOut.schelp
@@ -41,6 +41,10 @@ method::connect, disconnect
 Linux only. macOS does not need to connect. On Linux it is an optional feature (see below).
 
 InstanceMethods::
+method::sysex
+Sends a sysex command to the device.
+WARNING:: On Windows, the function call must contain a full sysex message (i.e. needs to start with F0 and end with F7). 
+::
 
 private::send, prSysex
 


### PR DESCRIPTION
To indicate that on Windows you must call the function with a full sysex message