### PR TITLE
help: update byte code example

### DIFF
--- a/HelpSource/Classes/LanguageConfig.schelp
+++ b/HelpSource/Classes/LanguageConfig.schelp
@@ -55,3 +55,10 @@ subsection:: Compiler Warnings
 
 METHOD:: postInlineWarnings
 Get or set the compiler flag, whether warnings should be posted if a FunctionDef cannot be inlined.
+
+code::
+LanguageConfig.postInlineWarnings_(true) // warn
+if(0.5.coin) { var x; x = 10.rand; x + 1 } { 10 };
+LanguageConfig.postInlineWarnings_(false) // ignore it.
+if(0.5.coin) { var x; x = 10.rand; x + 1 } { 10 };
+::

--- a/HelpSource/Reference/Control-Structures.schelp
+++ b/HelpSource/Reference/Control-Structures.schelp
@@ -250,7 +250,7 @@ BYTECODES: (20)
  16   B0       TailCallReturnFromFunction
  17   C1 3A    SendSpecialMsg 'postln'
  19   F2       BlockReturn
-a FunctionDef in closed FunctionDef
+-> < closed FunctionDef >
 ::
 
 Failure to inline due to variable declarations:
@@ -267,9 +267,11 @@ code::
 )
 
 WARNING: FunctionDef contains variable declarations and so will not be inlined.
-   in file 'selected text'
-   line 4 char 14 :
-  		var notHere;•
+  in file 'selected text'
+  line 4 char 14:
+
+  		var notHere;
+
   		"hello".postln;
 -----------------------------------
 BYTECODES: (13)
@@ -281,6 +283,14 @@ BYTECODES: (13)
   9   B0       TailCallReturnFromFunction
  10   C3 0B    SendSpecialMsg 'if'
  12   F2       BlockReturn
-a FunctionDef in closed FunctionDef
+-> < closed FunctionDef >
 ::
+
+You can switch on and off the above warning (see: link::Classes/LanguageConfig#*postInlineWarnings::)
+
+code::
+LanguageConfig.postInlineWarnings_(true) // warn
+LanguageConfig.postInlineWarnings_(false) // ignore it.
+::
+
 

--- a/HelpSource/Reference/Control-Structures.schelp
+++ b/HelpSource/Reference/Control-Structures.schelp
@@ -227,38 +227,44 @@ section:: Inline optimization
 
 code::if::, code::while::, code::switch:: and code::case:: expressions are optimized (i.e. inlined) by the compiler if they do not contain variable declarations in the functions. The optimization plucks the code from the functions and uses a more efficient jump statement:
 code::
+(
 {
-	if( 6 == 9,{
+	if(6 == 9, {
 		"hello".postln;
 	},{
-		"hello".postln;
+		"world".postln;
 	})
 }.def.dumpByteCodes
+)
 
-BYTECODES: (18)
-  0   FE 06    PushPosInt 6
-  2   FE 09    PushPosInt 9
+BYTECODES: (20)
+  0   2C 06    PushInt 6
+  2   2C 09    PushInt 9
   4   E6       SendSpecialBinaryArithMsg '=='
-  5   F8 00 06 JumpIfFalse 6  (14)
-  8   42       PushLiteral "hello"
-  9   A1 00    SendMsg 'postln'
- 11   FC 00 03 JumpFwd 3  (17)
- 14   41       PushLiteral "hello"
- 15   A1 00    SendMsg 'postln'
- 17   F2       BlockReturn
+  5   F8 00 07 JumpIfFalse 7  (15)
+  8   41       PushLiteral "hello"
+  9   B0       TailCallReturnFromFunction
+ 10   C1 3A    SendSpecialMsg 'postln'
+ 12   FC 00 04 JumpFwd 4  (19)
+ 15   40       PushLiteral "world"
+ 16   B0       TailCallReturnFromFunction
+ 17   C1 3A    SendSpecialMsg 'postln'
+ 19   F2       BlockReturn
 a FunctionDef in closed FunctionDef
 ::
 
 Failure to inline due to variable declarations:
 code::
+(
 {
-	if( 6 == 9,{
+	if(6 == 9, {
 		var notHere;
 		"hello".postln;
 	},{
-		"hello".postln;
+		"world".postln;
 	})
 }.def.dumpByteCodes
+)
 
 WARNING: FunctionDef contains variable declarations and so will not be inlined.
    in file 'selected text'
@@ -266,14 +272,15 @@ WARNING: FunctionDef contains variable declarations and so will not be inlined.
   		var notHere;•
   		"hello".postln;
 -----------------------------------
-BYTECODES: (12)
-  0   FE 06    PushPosInt 6
-  2   FE 09    PushPosInt 9
+BYTECODES: (13)
+  0   2C 06    PushInt 6
+  2   2C 09    PushInt 9
   4   E6       SendSpecialBinaryArithMsg '=='
-  5   04 00    PushLiteralX instance of FunctionDef in closed FunctionDef
-  7   04 01    PushLiteralX instance of FunctionDef in closed FunctionDef
-  9   C3 0B    SendSpecialMsg 'if'
- 11   F2       BlockReturn
+  5   04 00    PushLiteralX instance of FunctionDef - closed
+  7   04 01    PushLiteralX instance of FunctionDef - closed
+  9   B0       TailCallReturnFromFunction
+ 10   C3 0B    SendSpecialMsg 'if'
+ 12   F2       BlockReturn
 a FunctionDef in closed FunctionDef
 ::
 


### PR DESCRIPTION
This makes the output of the code the same as the displayed one, and
make it a little more readable.

Note that the example showed code that was produced with
`Process.tailCallOptimize = false`, this is changed here. I hope that doesn't make it too complicated, but it is the output that the "average user" will see.