### PR TITLE
Update Lexer to allow symbols like \1a

### DIFF
--- a/lang/LangSource/PyrLexer.cpp
+++ b/lang/LangSource/PyrLexer.cpp
@@ -563,38 +563,14 @@ ident:
 symbol1:
 	c = input();
 
-	if ((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || c == '_') goto symbol2;
-	else if (c >= '0' && c <= '9') goto symbol4;
-	else {
-		unput(c);
-		yytext[yylen] = 0;
-		r = processsymbol(yytext) ;
-		goto leave;
-	}
-
-symbol2:
-	c = input();
-
 	if ((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z')
-		|| c == '_' || (c >= '0' && c <= '9')) goto symbol2;
+		|| c == '_' || (c >= '0' && c <= '9')) goto symbol1;
 	else {
 		unput(c);
 		yytext[yylen] = 0;
 		r = processsymbol(yytext) ;
 		goto leave;
 	}
-
-symbol4:
-	c = input();
-	if (c >= '0' && c <= '9') goto symbol4;
-	else {
-		unput(c);
-		yytext[yylen] = 0;
-		r = processsymbol(yytext) ;
-		goto leave;
-	}
-
-
 
 binop:
 

--- a/testsuite/classlibrary/TestParser.sc
+++ b/testsuite/classlibrary/TestParser.sc
@@ -7,11 +7,11 @@ TestParser : UnitTest {
 		var testCs, testCsValue;
 
 		/* A test compile string, and its interpreted value.
-		 * Will be added to the end of a test comment to make sure it
-		 * does/doesn't get interpreted as expected. Will also be
-		 * added to the start of an error-causing string to make sure
-		 * it causes an error.
-		 */
+		* Will be added to the end of a test comment to make sure it
+		* does/doesn't get interpreted as expected. Will also be
+		* added to the start of an error-causing string to make sure
+		* it causes an error.
+		*/
 		testCs = " 3\n";
 		testCsValue = 3;
 
@@ -49,9 +49,9 @@ TestParser : UnitTest {
 		];
 
 		/* These should throw an error when interpreted.
-		 * Since the errors from .interpret cannot be caught, this just tests
-		 * that it returns nil no matter where the test string is added.
-		 */
+		* Since the errors from .interpret cannot be caught, this just tests
+		* that it returns nil no matter where the test string is added.
+		*/
 		errorTests = [
 			"*/",
 			"*/*",
@@ -94,6 +94,76 @@ TestParser : UnitTest {
 			this.assertEquals((testCs ++ commentString).interpret, nil, message);
 
 			courtesyMessage.postln;
+		}
+	}
+
+	test_symbolLiterals {
+		// if something is broken, these will fail just by virtue of being declared.
+		var testString = "12ab_";
+		var symbolStrings = Array.fill(string.size, string.rotate(_));
+		var messageProto = "'%' should be a legal symbol literal when";
+
+		var testCs = ";3";
+		var testCsValue = 3;
+
+		symbolStrings.do {
+			|symbolString|
+			var message = messageProto.format(symbolString) + "preceded by backslash";
+			var interpretString = "\\" ++ symbolString ++ testCs;
+
+			this.assertEquals(interpretString.interpret, testCsValue, message);
+
+			message = messageProto.format(symbolString) + "enclosed in single quotes";
+			interpretString = "'" ++ symbolString ++ "'" ++ testCs;
+
+			this.assertEquals(interpretString.interpret, testCsValue, message);
+		}
+
+		// symbols containing spaces are valid with single quotes, but not with backslash
+		testString = "12 ab _";
+		symbolStrings = Array.fill(string.size, string.rotate(_));
+		messageProto = "'%' should be % symbol when";
+
+		symbolStrings.do {
+			|symbolString|
+			var courtesyMessage = "NOTE: The parsing error thrown above is intentional — currently testing bizarre symbols with .interpret";
+			var message = messageProto.format(symbolString, "an illegal") + "preceded by backslash";
+			var interpretString = "\\" ++ symbolString ++ testCs;
+
+			this.assertEquals(interpretString.interpret, nil, message);
+			courtesyMessage.postln;
+
+			message = messageProto.format(symbolString, "a legal") + "enclosed in single quotes";
+			interpretString = "'" ++ symbolString ++ "'" ++ testCs;
+
+			this.assertEquals(interpretString.interpret, testCsValue, message);
+		}
+
+		// escape sequences just give the escaped character with single quotes, but are illegal with backslash
+		// test every char from space (32) to ~ (126) -- 127 is non-printing
+		symbolStrings = (32..126).collect({
+			|x|
+			"\\" ++ x.asAscii;
+		});
+
+		messageProto = "'%' should be % symbol when";
+
+		symbolStrings.do {
+			|symbolString|
+			var courtesyMessage = "NOTE: The parsing error thrown above is intentional — currently testing bizarre symbols with .interpret";
+			var message;
+			var interpretString;
+
+			// test backslash as error-producing
+			interpretString = "\\" ++ symbolString ++ testCs;
+			message = "'%' should be an illegal symbol when preceded by backslash".format(symbolString);
+			this.assertEquals(interpretString.interpret, nil, message);
+			courtesyMessage.postln;
+
+			// test single quotes as successful
+			interpretString = "\'" ++ symbolString ++ "\'";
+			message = "'%' should be the same as '%' when enclosed in single quotes".format(symbolString, symbolString[1]);
+			this.assertEquals(interpretString.interpret.asString, symbolString[1].asSymbol, message);
 		}
 	}
 }

--- a/testsuite/classlibrary/TestParser.sc
+++ b/testsuite/classlibrary/TestParser.sc
@@ -100,7 +100,7 @@ TestParser : UnitTest {
 	test_symbolLiterals {
 		// if something is broken, these will fail just by virtue of being declared.
 		var testString = "12ab_";
-		var symbolStrings = Array.fill(string.size, string.rotate(_));
+		var symbolStrings = Array.fill(testString.size, testString.rotate(_));
 		var messageProto = "'%' should be a legal symbol literal when";
 
 		var testCs = ";3";
@@ -117,11 +117,11 @@ TestParser : UnitTest {
 			interpretString = "'" ++ symbolString ++ "'" ++ testCs;
 
 			this.assertEquals(interpretString.interpret, testCsValue, message);
-		}
+		};
 
 		// symbols containing spaces are valid with single quotes, but not with backslash
 		testString = "12 ab _";
-		symbolStrings = Array.fill(string.size, string.rotate(_));
+		symbolStrings = Array.fill(testString.size, testString.rotate(_));
 		messageProto = "'%' should be % symbol when";
 
 		symbolStrings.do {
@@ -137,7 +137,7 @@ TestParser : UnitTest {
 			interpretString = "'" ++ symbolString ++ "'" ++ testCs;
 
 			this.assertEquals(interpretString.interpret, testCsValue, message);
-		}
+		};
 
 		// escape sequences just give the escaped character with single quotes, but are illegal with backslash
 		// test every char from space (32) to ~ (126) -- 127 is non-printing
@@ -163,7 +163,7 @@ TestParser : UnitTest {
 			// test single quotes as successful
 			interpretString = "\'" ++ symbolString ++ "\'";
 			message = "'%' should be the same as '%' when enclosed in single quotes".format(symbolString, symbolString[1]);
-			this.assertEquals(interpretString.interpret.asString, symbolString[1].asSymbol, message);
-		}
+			this.assertEquals(interpretString.interpret, symbolString[1].asSymbol, message);
+		};
 	}
 }


### PR DESCRIPTION
Previously, symbols beginning with a backslash and combining digits and letters would throw a parse error if the first character was a digit, even though the same symbol could be notated without a problem in single quotes. This commit gets rid of some unnessary goto splits in the lexer that were causing the issue.

Also adding regression tests to TestParser.sc.