### PR TITLE
Whitespace: fix some confusing mixes of tabs and spaces

### DIFF
--- a/server/plugins/DemandUGens.cpp
+++ b/server/plugins/DemandUGens.cpp
@@ -194,9 +194,9 @@ struct Dreset : public Unit
 
 struct Dconst : public Unit
 {
-  float m_total;
-  float m_runningsum;
-  float m_tolerance;
+	float m_total;
+	float m_runningsum;
+	float m_tolerance;
 };
 
 extern "C"

--- a/server/plugins/UnaryOpUGens.cpp
+++ b/server/plugins/UnaryOpUGens.cpp
@@ -549,7 +549,7 @@ void coin_1(UnaryOpUGen *unit, int inNumSamples)
 {
 	RGen& rgen = *unit->mParent->mRGen;
 	float x = ZIN0(0);
-    ZOUT0(0) = (rgen.frand() < x) ? 1.f : 0.f;
+	ZOUT0(0) = (rgen.frand() < x) ? 1.f : 0.f;
 }												
 												
 void coin_d(UnaryOpUGen *unit, int inNumSamples)
@@ -577,7 +577,7 @@ static UnaryOpFunc ChooseNormalFunc(UnaryOpUGen *unit)
 		case opThru : func = &thru_a; break;
 		case opNeg : func = &invert_a; break;
 		case opNot : func = &not_a; break;
-        case opBitNot : func = &bitNot_a; break;
+		case opBitNot : func = &bitNot_a; break;
 		case opAbs : func = &abs_a; break;
 		case opCeil : func = &ceil_a; break;
 		case opFloor : func = &floor_a; break;
@@ -642,7 +642,7 @@ static UnaryOpFunc ChooseOneFunc(UnaryOpUGen *unit)
 		case opThru : func = &thru_a; break;
 		case opNeg : func = &invert_1; break;
 		case opNot : func = &not_1; break;
-        case opBitNot : func = &bitNot_1; break;
+		case opBitNot : func = &bitNot_1; break;
 		case opAbs : func = &abs_1; break;
 		case opCeil : func = &ceil_1; break;
 		case opFloor : func = &floor_1; break;
@@ -836,7 +836,7 @@ static UnaryOpFunc ChooseNovaSimdFunc(UnaryOpUGen *unit)
 		case opThru : func = &thru_nova; break;
 		case opNeg : func = &invert_nova; break;
 		case opNot : func = &not_a; break;
-        case opBitNot : func = &bitNot_a; break;
+		case opBitNot : func = &bitNot_a; break;
 		case opAbs : func = &abs_nova; break;
 		case opCeil : func = &ceil_nova; break;
 		case opFloor : func = &floor_nova; break;

--- a/server/scsynth/ReadWriteMacros.h
+++ b/server/scsynth/ReadWriteMacros.h
@@ -36,8 +36,8 @@ inline int32 readInt8(FILE *file)
 
 inline uint32 readUInt8(FILE *file)
 {
-    uint8 res = (uint8)fgetc(file);
-    return (uint32)res;
+	uint8 res = (uint8)fgetc(file);
+	return (uint32)res;
 }
 
 inline int32 readInt16_be(FILE *file)
@@ -86,8 +86,8 @@ inline int32 readInt8(char *&buf)
 
 inline uint32 readUInt8(char *&buf)
 {
-    uint8 res = (uint8)*buf++;
-    return (uint32)res;
+	uint8 res = (uint8)*buf++;
+	return (uint32)res;
 }
 
 inline int32 readInt16_be(char *&buf)

--- a/server/scsynth/SC_ComPort.cpp
+++ b/server/scsynth/SC_ComPort.cpp
@@ -199,7 +199,7 @@ class SC_UdpInPort
 {
 	struct World * mWorld;
 	int mPortNum;
-    std::string mbindTo;
+	std::string mbindTo;
 	boost::array<char, kTextBufSize> recvBuffer;
 
 	boost::asio::ip::udp::endpoint remoteEndpoint;
@@ -209,7 +209,7 @@ class SC_UdpInPort
 #endif
 
 	void handleReceivedUDP(const boost::system::error_code& error,
-						   std::size_t bytes_transferred)
+	                       std::size_t bytes_transferred)
 	{
 		if (error == boost::asio::error::operation_aborted)
 			return;    /* we're done */
@@ -243,8 +243,8 @@ class SC_UdpInPort
 	{
 		using namespace boost;
 		udpSocket.async_receive_from(asio::buffer(recvBuffer), remoteEndpoint,
-									 boost::bind(&SC_UdpInPort::handleReceivedUDP, this,
-												 asio::placeholders::error, asio::placeholders::bytes_transferred));
+		                             boost::bind(&SC_UdpInPort::handleReceivedUDP, this,
+		                                         asio::placeholders::error, asio::placeholders::bytes_transferred));
 	}
 
 public:
@@ -283,7 +283,7 @@ public:
 	boost::asio::ip::tcp::socket socket;
 
 	SC_TcpConnection(struct World * world, boost::asio::io_service & ioService,
-					 class SC_TcpInPort * parent):
+	                 class SC_TcpInPort * parent):
 		mWorld(world), socket(ioService), mParent(parent)
 	{}
 
@@ -328,10 +328,10 @@ private:
 	{
 		namespace ba = boost::asio;
 		async_read(socket, ba::buffer(&OSCMsgLength, sizeof(OSCMsgLength)),
-				   boost::bind(&SC_TcpConnection::handleLengthReceived, shared_from_this(),
-							   ba::placeholders::error,
-							   ba::placeholders::bytes_transferred)
-				   );
+		           boost::bind(&SC_TcpConnection::handleLengthReceived, shared_from_this(),
+		           ba::placeholders::error,
+		           ba::placeholders::bytes_transferred)
+		          );
 	}
 
 	int32 OSCMsgLength;
@@ -339,7 +339,7 @@ private:
 	class SC_TcpInPort * mParent;
 
 	void handleLengthReceived(const boost::system::error_code& error,
-							  size_t bytes_transferred)
+	                          size_t bytes_transferred)
 	{
 		if (error) {
 			if (error == boost::asio::error::eof)
@@ -356,13 +356,13 @@ private:
 		data = (char*)malloc(OSCMsgLength);
 
 		async_read(socket, ba::buffer(data, OSCMsgLength),
-				   boost::bind(&SC_TcpConnection::handleMsgReceived, shared_from_this(),
-							   ba::placeholders::error,
-							   ba::placeholders::bytes_transferred));
+		           boost::bind(&SC_TcpConnection::handleMsgReceived, shared_from_this(),
+		           ba::placeholders::error,
+		           ba::placeholders::bytes_transferred));
 	}
 
 	void handleMsgReceived(const boost::system::error_code& error,
-						   size_t bytes_transferred)
+	                       size_t bytes_transferred)
 	{
 		if (error) {
 			free(data);
@@ -407,7 +407,7 @@ class SC_TcpInPort
 public:
 	SC_TcpInPort(struct World * world, std::string bindTo, int inPortNum, int inMaxConnections, int inBacklog):
 		mWorld(world),
-        acceptor(ioService, boost::asio::ip::tcp::endpoint(boost::asio::ip::address::from_string(bindTo), inPortNum)),
+		acceptor(ioService, boost::asio::ip::tcp::endpoint(boost::asio::ip::address::from_string(bindTo), inPortNum)),
 		mAvailableConnections(inMaxConnections)
 	{
 		// FIXME: backlog???
@@ -429,13 +429,13 @@ public:
 			SC_TcpConnection::pointer newConnection (new SC_TcpConnection(mWorld, ioService, this));
 
 			acceptor.async_accept(newConnection->socket,
-								  boost::bind(&SC_TcpInPort::handleAccept, this, newConnection,
-											  boost::asio::placeholders::error));
+			                      boost::bind(&SC_TcpInPort::handleAccept, this, newConnection,
+			                      boost::asio::placeholders::error));
 		}
 	}
 
 	void handleAccept(SC_TcpConnection::pointer newConnection,
-					  const boost::system::error_code& error)
+	                  const boost::system::error_code& error)
 	{
 		if (!error)
 			newConnection->start();

--- a/server/scsynth/SC_ComPort.cpp
+++ b/server/scsynth/SC_ComPort.cpp
@@ -329,8 +329,8 @@ private:
 		namespace ba = boost::asio;
 		async_read(socket, ba::buffer(&OSCMsgLength, sizeof(OSCMsgLength)),
 		           boost::bind(&SC_TcpConnection::handleLengthReceived, shared_from_this(),
-		           ba::placeholders::error,
-		           ba::placeholders::bytes_transferred)
+		                       ba::placeholders::error,
+		                       ba::placeholders::bytes_transferred)
 		          );
 	}
 
@@ -357,8 +357,9 @@ private:
 
 		async_read(socket, ba::buffer(data, OSCMsgLength),
 		           boost::bind(&SC_TcpConnection::handleMsgReceived, shared_from_this(),
-		           ba::placeholders::error,
-		           ba::placeholders::bytes_transferred));
+		                       ba::placeholders::error,
+		                       ba::placeholders::bytes_transferred)
+		          );
 	}
 
 	void handleMsgReceived(const boost::system::error_code& error,
@@ -430,7 +431,7 @@ public:
 
 			acceptor.async_accept(newConnection->socket,
 			                      boost::bind(&SC_TcpInPort::handleAccept, this, newConnection,
-			                      boost::asio::placeholders::error));
+			                                  boost::asio::placeholders::error));
 		}
 	}
 

--- a/server/scsynth/SC_CoreAudio.h
+++ b/server/scsynth/SC_CoreAudio.h
@@ -158,7 +158,7 @@ PacketStatus PerformCompletionMsg(World *world, const OSC_Packet& packet);
 class SC_AudioDriver
 {
 protected:
-    int64 mOSCincrement;
+	int64 mOSCincrement;
 	struct World *mWorld;
 	double mOSCtoSamples;
 	int mSampleTime;
@@ -277,7 +277,7 @@ class SC_CoreAudioDriver : public SC_AudioDriver
 									void* defptr);
 
 protected:
-    // Driver interface methods
+	// Driver interface methods
 	virtual bool DriverSetup(int* outNumSamplesPerCallback, double* outSampleRate);
 	virtual bool DriverStart();
 	virtual bool DriverStop();
@@ -288,12 +288,12 @@ protected:
 public:
 	int builtinoutputflag_; 
 	
-    SC_CoreAudioDriver(struct World *inWorld);
+	SC_CoreAudioDriver(struct World *inWorld);
 	virtual ~SC_CoreAudioDriver();
 
 	bool StopStart(); 
 	
-    void Run(const AudioBufferList* inInputData, AudioBufferList* outOutputData, int64 oscTime);
+	void Run(const AudioBufferList* inInputData, AudioBufferList* outOutputData, int64 oscTime);
 
 	bool UseInput() { return mInputDevice != kAudioDeviceUnknown; }
 	bool UseSeparateIO() { return UseInput() && mInputDevice != mOutputDevice; }
@@ -315,18 +315,18 @@ class SC_iCoreAudioDriver : public SC_AudioDriver
 	AudioStreamBasicDescription	outputStreamDesc;	// info about the default device
 
 protected:
-    // Driver interface methods
+	// Driver interface methods
 	virtual bool DriverSetup(int* outNumSamplesPerCallback, double* outSampleRate);
 	virtual bool DriverStart();
 	virtual bool DriverStop();
 
 public:
-    SC_iCoreAudioDriver(struct World *inWorld);
+	SC_iCoreAudioDriver(struct World *inWorld);
 	virtual ~SC_iCoreAudioDriver();
 
-    void Run(const AudioBufferList* inInputData, AudioBufferList* outOutputData, int64 oscTime);
+	void Run(const AudioBufferList* inInputData, AudioBufferList* outOutputData, int64 oscTime);
 
-    AudioBufferList * buflist;
+	AudioBufferList * buflist;
 	AudioBufferList * floatInputList;
 	AudioBufferList * floatOutputList;
 	AudioConverterRef converter_in_to_F32;
@@ -354,22 +354,22 @@ class SC_AndroidJNIAudioDriver : public SC_AudioDriver
 
 protected:
 
-    // Driver interface methods
-        virtual bool DriverSetup(int* outNumSamplesPerCallback, double* outSampleRate);
-        virtual bool DriverStart();
-        virtual bool DriverStop();
+	// Driver interface methods
+		virtual bool DriverSetup(int* outNumSamplesPerCallback, double* outSampleRate);
+		virtual bool DriverStart();
+		virtual bool DriverStop();
         
 public:
-    SC_AndroidJNIAudioDriver(struct World *inWorld);
-        virtual ~SC_AndroidJNIAudioDriver();
+	SC_AndroidJNIAudioDriver(struct World *inWorld);
+		virtual ~SC_AndroidJNIAudioDriver();
 
-        void genaudio(short* arri, int numSamples);
+		void genaudio(short* arri, int numSamples);
 
 };
 
 inline SC_AudioDriver* SC_NewAudioDriver(struct World *inWorld)
 {
-    return new SC_AndroidJNIAudioDriver(inWorld);
+	return new SC_AndroidJNIAudioDriver(inWorld);
 }
 
 #endif // SC_AUDIO_API == SC_AUDIO_API_ANDROIDJNI

--- a/server/scsynth/SC_CoreAudio.h
+++ b/server/scsynth/SC_CoreAudio.h
@@ -355,15 +355,15 @@ class SC_AndroidJNIAudioDriver : public SC_AudioDriver
 protected:
 
 	// Driver interface methods
-		virtual bool DriverSetup(int* outNumSamplesPerCallback, double* outSampleRate);
-		virtual bool DriverStart();
-		virtual bool DriverStop();
+	virtual bool DriverSetup(int* outNumSamplesPerCallback, double* outSampleRate);
+	virtual bool DriverStart();
+	virtual bool DriverStop();
         
 public:
 	SC_AndroidJNIAudioDriver(struct World *inWorld);
-		virtual ~SC_AndroidJNIAudioDriver();
+	virtual ~SC_AndroidJNIAudioDriver();
 
-		void genaudio(short* arri, int numSamples);
+	void genaudio(short* arri, int numSamples);
 
 };
 

--- a/server/scsynth/SC_Jack.cpp
+++ b/server/scsynth/SC_Jack.cpp
@@ -121,9 +121,9 @@ private:
 	{
 		int err = jack_connect(mClient, src, dst);
 		scprintf("%s: %s %s to %s\n",
-				 kJackDriverIdent,
-				 err ? "couldn't connect " : "connected ",
-				 src, dst);
+		         kJackDriverIdent,
+		         err ? "couldn't connect " : "connected ",
+		         src, dst);
 	}
 
 	void ConnectClientInputs(const char * pattern);
@@ -411,8 +411,8 @@ void SC_JackDriver::Run()
 	if (++tick >= 10) {
 		tick = 0;
 		scprintf("DLL: t %.6f p %.9f sr %.6f e %.9f avg(e) %.9f inc %.9f\n",
-				 mDLL.PeriodTime(), mDLL.Period(), mDLL.SampleRate(),
-				 mDLL.Error(), mDLL.AvgError(), mOSCincrement * kOSCtoSecs);
+		         mDLL.PeriodTime(), mDLL.Period(), mDLL.SampleRate(),
+		         mDLL.Error(), mDLL.AvgError(), mOSCincrement * kOSCtoSecs);
 	}
 #endif
 #else

--- a/server/scsynth/SC_MiscCmds.cpp
+++ b/server/scsynth/SC_MiscCmds.cpp
@@ -570,7 +570,7 @@ SCErr meth_n_set(World *inWorld, int inSize, char *inData, ReplyAddress* /*inRep
 //	    while (loop);
 //	}
 //    }
-    return kSCErr_None;
+	return kSCErr_None;
 }
 
 SCErr meth_n_setn(World *inWorld, int inSize, char *inData, ReplyAddress *inReply);

--- a/server/scsynth/SC_Node.cpp
+++ b/server/scsynth/SC_Node.cpp
@@ -100,25 +100,25 @@ void Node_Remove(Node* s)
 void Node_RemoveID(Node *inNode)
 {
 	if (inNode->mID == 0) return; // failed
-  
-  World* world = inNode->mWorld;
+
+	World* world = inNode->mWorld;
 	if (!World_RemoveNode(world, inNode)) {
 		int err = kSCErr_Failed; // shouldn't happen..
 		throw err;
 	}
-  
+
 	HiddenWorld* hw = world->hw;
 	int id = hw->mHiddenID = (hw->mHiddenID - 8) | 0x80000000;
 	inNode->mID = id;
 	inNode->mHash = Hash(id);
-  if (!World_AddNode(world, inNode)) {
+	if (!World_AddNode(world, inNode)) {
 		scprintf("mysterious failure in Node_RemoveID\n");
 		Node_Delete(inNode);
 		// enums are uncatchable. must throw an int.
 		int err = kSCErr_Failed; // shouldn't happen..
 		throw err;
-  }
-  
+	}
+
 	//inWorld->hw->mRecentID = id;
 }
 

--- a/server/scsynth/SC_SequencedCommand.cpp
+++ b/server/scsynth/SC_SequencedCommand.cpp
@@ -530,7 +530,7 @@ bool BufAllocReadCmd::Stage2()
 {
 #ifdef NO_LIBSNDFILE
 	SendFailure(&mReplyAddress, "/b_allocRead", "scsynth compiled without libsndfile\n");
- 	scprintf("scsynth compiled without libsndfile\n");
+	scprintf("scsynth compiled without libsndfile\n");
 	return false;
 #else
 	SndBuf *buf = World_GetNRTBuf(mWorld, mBufIndex);
@@ -627,7 +627,7 @@ bool BufReadCmd::Stage2()
 {
 #ifdef NO_LIBSNDFILE
 	SendFailure(&mReplyAddress, "/b_read", "scsynth compiled without libsndfile\n");
- 	scprintf("scsynth compiled without libsndfile\n");
+	scprintf("scsynth compiled without libsndfile\n");
 	return false;
 #else
 	SF_INFO fileinfo;
@@ -792,7 +792,7 @@ bool BufAllocReadChannelCmd::Stage2()
 {
 #ifdef NO_LIBSNDFILE
 	SendFailure(&mReplyAddress, "/b_allocReadChannel", "scsynth compiled without libsndfile\n");
- 	scprintf("scsynth compiled without libsndfile\n");
+	scprintf("scsynth compiled without libsndfile\n");
 	return false;
 #else
 	SndBuf *buf = World_GetNRTBuf(mWorld, mBufIndex);
@@ -916,7 +916,7 @@ bool BufReadChannelCmd::Stage2()
 {
 #ifdef NO_LIBSNDFILE
 	SendFailure(&mReplyAddress, "/b_readChannel", "scsynth compiled without libsndfile\n");
- 	scprintf("scsynth compiled without libsndfile\n");
+	scprintf("scsynth compiled without libsndfile\n");
 	return false;
 #else
 	SF_INFO fileinfo;
@@ -1025,7 +1025,7 @@ int BufWriteCmd::Init(char *inData, int inSize)
 {
 #ifdef NO_LIBSNDFILE
 	SendFailure(&mReplyAddress, "/b_write", "scsynth compiled without libsndfile\n");
- 	scprintf("scsynth compiled without libsndfile\n");
+	scprintf("scsynth compiled without libsndfile\n");
 	return false;
 #else
 	sc_msg_iter msg(inSize, inData);
@@ -1146,7 +1146,7 @@ bool BufCloseCmd::Stage2()
 {
 #ifdef NO_LIBSNDFILE
 	SendFailure(&mReplyAddress, "/b_close", "scsynth compiled without libsndfile\n");
- 	scprintf("scsynth compiled without libsndfile\n");
+	scprintf("scsynth compiled without libsndfile\n");
 	return false;
 #else
 	SndBuf *buf = World_GetNRTBuf(mWorld, mBufIndex);

--- a/server/scsynth/iPhone/iscsynthAppDelegate.h
+++ b/server/scsynth/iPhone/iscsynthAppDelegate.h
@@ -9,7 +9,7 @@
 #import <UIKit/UIKit.h>
 
 @interface iscsynthAppDelegate : NSObject <UIApplicationDelegate> {
-    UIWindow *window;
+	UIWindow *window;
 	IBOutlet UITabBarController *tabBarController;
 	IBOutlet UITableViewController *tableViewController;
 }

--- a/server/supernova/utilities/freelist.hpp
+++ b/server/supernova/utilities/freelist.hpp
@@ -41,8 +41,8 @@ public:
         pool_(tagged_ptr(nullptr))
     {}
 
-	freelist( freelist const & rhs )             = delete;
-	freelist & operator=( freelist const & rhs ) = delete;
+    freelist( freelist const & rhs )             = delete;
+    freelist & operator=( freelist const & rhs ) = delete;
 
     void * pop (void)
     {


### PR DESCRIPTION
Clean up a few ambiguous mixes of spaces and tabs. Note this is conservative: mixes for layout, like:

```
\tfoo(2
\t    5);
```

have not been removed.