### PR TITLE
class library: officially deprecate Watcher

### DIFF
--- a/SCClassLibrary/Common/Control/SkipJack.sc
+++ b/SCClassLibrary/Common/Control/SkipJack.sc
@@ -51,10 +51,3 @@ SkipJack {
 		if( verbose ) { ("SkipJack" + name + "stopped.").postcln };
 	}
 }
-
-Watcher : SkipJack {
-	*new { arg name = "anon", updateFunc, dt=0.2, stopTest = false;
-		"Watcher is only for backward compatibility, use SkipJack!".postln;
-		^super.newCopyArgs(updateFunc, dt, stopTest, name).init.start;
-	}
-}

--- a/SCClassLibrary/deprecated/3.9/Watcher.sc
+++ b/SCClassLibrary/deprecated/3.9/Watcher.sc
@@ -1,0 +1,6 @@
+Watcher : SkipJack {
+    *new { arg name = "anon", updateFunc, dt=0.2, stopTest = false;
+        this.deprecated(thisMethod, SkipJack.class.findMethod(\new));
+        ^super.newCopyArgs(updateFunc, dt, stopTest, name).init.start;
+    }
+}


### PR DESCRIPTION
Watcher is an alias for SkipJack provided for backward compatibility, emitting a post message that advises the user to use SkipJack instead. This commit puts Watcher on the official deprecation track for removal in 3.10.