### PR TITLE
Two small typo corrections

### DIFF
--- a/HelpSource/Classes/PinkNoise.schelp
+++ b/HelpSource/Classes/PinkNoise.schelp
@@ -9,11 +9,11 @@ Description::
 Generates noise whose spectrum falls off in power by 3 dB per octave, which gives equal power over the span of each octave.
 This version is band-limited to 8 octaves.
 
-Internally, this UGen calculates its output by  means of the Voss-McCartney algorithm.
+Internally, this UGen calculates its output by means of the Voss-McCartney algorithm.
 link::http://www.firstpr.com.au/dsp/pink-noise/allan-2/spectrum2.html::
 
 note::
-The values produced by this UGen were observed to lie with very high probability between approx. -0.65 and +0.81 (before being multiplied by mul). The signal's RMS is approximatly -16 dB.
+The values produced by this UGen were observed to lie with very high probability between approximately -0.65 and +0.81 (before being multiplied by mul). The signal's RMS is approximately -16 dB.
 ::
 
 

--- a/editors/sc-ide/translations/scide.ts
+++ b/editors/sc-ide/translations/scide.ts
@@ -4,19 +4,19 @@
 <context>
     <name>ScIDE::TextFindReplacePanel</name>
     <message numerus="yes">
-        <source>%n occurrencies found.</source>
+        <source>%n occurrences found.</source>
         <comment>Find text in document...</comment>
         <translation>
             <numerusform>%n occurrence found.</numerusform>
-            <numerusform>%n occurrencies found.</numerusform>
+            <numerusform>%n occurrences found.</numerusform>
         </translation>
     </message>
     <message numerus="yes">
-        <source>%n occurrencies replaced.</source>
+        <source>%n occurrences replaced.</source>
         <comment>Find/replace text in document...</comment>
         <translation>
             <numerusform>%n occurrence replaced.</numerusform>
-            <numerusform>%n occurrencies replaced.</numerusform>
+            <numerusform>%n occurrences replaced.</numerusform>
         </translation>
     </message>
 </context>

--- a/editors/sc-ide/translations/scide.ts
+++ b/editors/sc-ide/translations/scide.ts
@@ -4,19 +4,19 @@
 <context>
     <name>ScIDE::TextFindReplacePanel</name>
     <message numerus="yes">
-        <source>%n occurrences found.</source>
+        <source>%n matches found.</source>
         <comment>Find text in document...</comment>
         <translation>
-            <numerusform>%n occurrence found.</numerusform>
-            <numerusform>%n occurrences found.</numerusform>
+            <numerusform>%n match found.</numerusform>
+            <numerusform>%n matches found.</numerusform>
         </translation>
     </message>
     <message numerus="yes">
-        <source>%n occurrences replaced.</source>
+        <source>%n matches replaced.</source>
         <comment>Find/replace text in document...</comment>
         <translation>
-            <numerusform>%n occurrence replaced.</numerusform>
-            <numerusform>%n occurrences replaced.</numerusform>
+            <numerusform>%n match replaced.</numerusform>
+            <numerusform>%n matches replaced.</numerusform>
         </translation>
     </message>
 </context>

--- a/editors/sc-ide/translations/scide_de.ts
+++ b/editors/sc-ide/translations/scide_de.ts
@@ -2078,7 +2078,7 @@ Would you like to override it?</source>
     </message>
     <message numerus="yes">
         <location filename="../widgets/find_replace_tool.cpp" line="299"/>
-        <source>%n occurrencies found.</source>
+        <source>%n occurrences found.</source>
         <comment>Find text in document...</comment>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -2087,7 +2087,7 @@ Would you like to override it?</source>
     </message>
     <message numerus="yes">
         <location filename="../widgets/find_replace_tool.cpp" line="305"/>
-        <source>%n occurrencies replaced.</source>
+        <source>%n occurrences replaced.</source>
         <comment>Find/replace text in document...</comment>
         <translation type="unfinished">
             <numerusform></numerusform>

--- a/editors/sc-ide/translations/scide_de.ts
+++ b/editors/sc-ide/translations/scide_de.ts
@@ -2078,7 +2078,7 @@ Would you like to override it?</source>
     </message>
     <message numerus="yes">
         <location filename="../widgets/find_replace_tool.cpp" line="299"/>
-        <source>%n occurrences found.</source>
+        <source>%n matches found.</source>
         <comment>Find text in document...</comment>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -2087,7 +2087,7 @@ Would you like to override it?</source>
     </message>
     <message numerus="yes">
         <location filename="../widgets/find_replace_tool.cpp" line="305"/>
-        <source>%n occurrences replaced.</source>
+        <source>%n matches replaced.</source>
         <comment>Find/replace text in document...</comment>
         <translation type="unfinished">
             <numerusform></numerusform>

--- a/editors/sc-ide/translations/scide_es.ts
+++ b/editors/sc-ide/translations/scide_es.ts
@@ -2078,7 +2078,7 @@ Would you like to override it?</source>
     </message>
     <message numerus="yes">
         <location filename="../widgets/find_replace_tool.cpp" line="299"/>
-        <source>%n occurrencies found.</source>
+        <source>%n occurrences found.</source>
         <comment>Find text in document...</comment>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -2087,7 +2087,7 @@ Would you like to override it?</source>
     </message>
     <message numerus="yes">
         <location filename="../widgets/find_replace_tool.cpp" line="305"/>
-        <source>%n occurrencies replaced.</source>
+        <source>%n occurrences replaced.</source>
         <comment>Find/replace text in document...</comment>
         <translation type="unfinished">
             <numerusform></numerusform>

--- a/editors/sc-ide/translations/scide_es.ts
+++ b/editors/sc-ide/translations/scide_es.ts
@@ -2078,7 +2078,7 @@ Would you like to override it?</source>
     </message>
     <message numerus="yes">
         <location filename="../widgets/find_replace_tool.cpp" line="299"/>
-        <source>%n occurrences found.</source>
+        <source>%n matches found.</source>
         <comment>Find text in document...</comment>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -2087,7 +2087,7 @@ Would you like to override it?</source>
     </message>
     <message numerus="yes">
         <location filename="../widgets/find_replace_tool.cpp" line="305"/>
-        <source>%n occurrences replaced.</source>
+        <source>%n matches replaced.</source>
         <comment>Find/replace text in document...</comment>
         <translation type="unfinished">
             <numerusform></numerusform>

--- a/editors/sc-ide/translations/scide_fr.ts
+++ b/editors/sc-ide/translations/scide_fr.ts
@@ -2078,7 +2078,7 @@ Would you like to override it?</source>
     </message>
     <message numerus="yes">
         <location filename="../widgets/find_replace_tool.cpp" line="299"/>
-        <source>%n occurrencies found.</source>
+        <source>%n occurrences found.</source>
         <comment>Find text in document...</comment>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -2087,7 +2087,7 @@ Would you like to override it?</source>
     </message>
     <message numerus="yes">
         <location filename="../widgets/find_replace_tool.cpp" line="305"/>
-        <source>%n occurrencies replaced.</source>
+        <source>%n occurrences replaced.</source>
         <comment>Find/replace text in document...</comment>
         <translation type="unfinished">
             <numerusform></numerusform>

--- a/editors/sc-ide/translations/scide_fr.ts
+++ b/editors/sc-ide/translations/scide_fr.ts
@@ -2078,7 +2078,7 @@ Would you like to override it?</source>
     </message>
     <message numerus="yes">
         <location filename="../widgets/find_replace_tool.cpp" line="299"/>
-        <source>%n occurrences found.</source>
+        <source>%n matches found.</source>
         <comment>Find text in document...</comment>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -2087,7 +2087,7 @@ Would you like to override it?</source>
     </message>
     <message numerus="yes">
         <location filename="../widgets/find_replace_tool.cpp" line="305"/>
-        <source>%n occurrences replaced.</source>
+        <source>%n matches replaced.</source>
         <comment>Find/replace text in document...</comment>
         <translation type="unfinished">
             <numerusform></numerusform>

--- a/editors/sc-ide/translations/scide_ja.ts
+++ b/editors/sc-ide/translations/scide_ja.ts
@@ -2078,7 +2078,7 @@ Would you like to override it?</source>
     </message>
     <message numerus="yes">
         <location filename="../widgets/find_replace_tool.cpp" line="299"/>
-        <source>%n occurrencies found.</source>
+        <source>%n occurrences found.</source>
         <comment>Find text in document...</comment>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -2086,7 +2086,7 @@ Would you like to override it?</source>
     </message>
     <message numerus="yes">
         <location filename="../widgets/find_replace_tool.cpp" line="305"/>
-        <source>%n occurrencies replaced.</source>
+        <source>%n occurrences replaced.</source>
         <comment>Find/replace text in document...</comment>
         <translation type="unfinished">
             <numerusform></numerusform>

--- a/editors/sc-ide/translations/scide_ja.ts
+++ b/editors/sc-ide/translations/scide_ja.ts
@@ -2078,7 +2078,7 @@ Would you like to override it?</source>
     </message>
     <message numerus="yes">
         <location filename="../widgets/find_replace_tool.cpp" line="299"/>
-        <source>%n occurrences found.</source>
+        <source>%n matches found.</source>
         <comment>Find text in document...</comment>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -2086,7 +2086,7 @@ Would you like to override it?</source>
     </message>
     <message numerus="yes">
         <location filename="../widgets/find_replace_tool.cpp" line="305"/>
-        <source>%n occurrences replaced.</source>
+        <source>%n matches replaced.</source>
         <comment>Find/replace text in document...</comment>
         <translation type="unfinished">
             <numerusform></numerusform>

--- a/editors/sc-ide/translations/scide_pt.ts
+++ b/editors/sc-ide/translations/scide_pt.ts
@@ -2078,7 +2078,7 @@ Would you like to override it?</source>
     </message>
     <message numerus="yes">
         <location filename="../widgets/find_replace_tool.cpp" line="299"/>
-        <source>%n occurrencies found.</source>
+        <source>%n occurrences found.</source>
         <comment>Find text in document...</comment>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -2087,7 +2087,7 @@ Would you like to override it?</source>
     </message>
     <message numerus="yes">
         <location filename="../widgets/find_replace_tool.cpp" line="305"/>
-        <source>%n occurrencies replaced.</source>
+        <source>%n occurrences replaced.</source>
         <comment>Find/replace text in document...</comment>
         <translation type="unfinished">
             <numerusform></numerusform>

--- a/editors/sc-ide/translations/scide_pt.ts
+++ b/editors/sc-ide/translations/scide_pt.ts
@@ -2078,7 +2078,7 @@ Would you like to override it?</source>
     </message>
     <message numerus="yes">
         <location filename="../widgets/find_replace_tool.cpp" line="299"/>
-        <source>%n occurrences found.</source>
+        <source>%n matches found.</source>
         <comment>Find text in document...</comment>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -2087,7 +2087,7 @@ Would you like to override it?</source>
     </message>
     <message numerus="yes">
         <location filename="../widgets/find_replace_tool.cpp" line="305"/>
-        <source>%n occurrences replaced.</source>
+        <source>%n matches replaced.</source>
         <comment>Find/replace text in document...</comment>
         <translation type="unfinished">
             <numerusform></numerusform>

--- a/editors/sc-ide/translations/scide_ru.ts
+++ b/editors/sc-ide/translations/scide_ru.ts
@@ -2078,7 +2078,7 @@ Would you like to override it?</source>
     </message>
     <message numerus="yes">
         <location filename="../widgets/find_replace_tool.cpp" line="299"/>
-        <source>%n occurrences found.</source>
+        <source>%n matches found.</source>
         <comment>Find text in document...</comment>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -2088,7 +2088,7 @@ Would you like to override it?</source>
     </message>
     <message numerus="yes">
         <location filename="../widgets/find_replace_tool.cpp" line="305"/>
-        <source>%n occurrences replaced.</source>
+        <source>%n matches replaced.</source>
         <comment>Find/replace text in document...</comment>
         <translation type="unfinished">
             <numerusform></numerusform>

--- a/editors/sc-ide/translations/scide_ru.ts
+++ b/editors/sc-ide/translations/scide_ru.ts
@@ -2078,7 +2078,7 @@ Would you like to override it?</source>
     </message>
     <message numerus="yes">
         <location filename="../widgets/find_replace_tool.cpp" line="299"/>
-        <source>%n occurrencies found.</source>
+        <source>%n occurrences found.</source>
         <comment>Find text in document...</comment>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -2088,7 +2088,7 @@ Would you like to override it?</source>
     </message>
     <message numerus="yes">
         <location filename="../widgets/find_replace_tool.cpp" line="305"/>
-        <source>%n occurrencies replaced.</source>
+        <source>%n occurrences replaced.</source>
         <comment>Find/replace text in document...</comment>
         <translation type="unfinished">
             <numerusform></numerusform>

--- a/editors/sc-ide/translations/scide_sl.ts
+++ b/editors/sc-ide/translations/scide_sl.ts
@@ -2078,7 +2078,7 @@ Would you like to override it?</source>
     </message>
     <message numerus="yes">
         <location filename="../widgets/find_replace_tool.cpp" line="299"/>
-        <source>%n occurrencies found.</source>
+        <source>%n occurrences found.</source>
         <comment>Find text in document...</comment>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -2089,7 +2089,7 @@ Would you like to override it?</source>
     </message>
     <message numerus="yes">
         <location filename="../widgets/find_replace_tool.cpp" line="305"/>
-        <source>%n occurrencies replaced.</source>
+        <source>%n occurrences replaced.</source>
         <comment>Find/replace text in document...</comment>
         <translation type="unfinished">
             <numerusform></numerusform>

--- a/editors/sc-ide/translations/scide_sl.ts
+++ b/editors/sc-ide/translations/scide_sl.ts
@@ -2078,7 +2078,7 @@ Would you like to override it?</source>
     </message>
     <message numerus="yes">
         <location filename="../widgets/find_replace_tool.cpp" line="299"/>
-        <source>%n occurrences found.</source>
+        <source>%n matches found.</source>
         <comment>Find text in document...</comment>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -2089,7 +2089,7 @@ Would you like to override it?</source>
     </message>
     <message numerus="yes">
         <location filename="../widgets/find_replace_tool.cpp" line="305"/>
-        <source>%n occurrences replaced.</source>
+        <source>%n matches replaced.</source>
         <comment>Find/replace text in document...</comment>
         <translation type="unfinished">
             <numerusform></numerusform>

--- a/editors/sc-ide/translations/scide_sv.ts
+++ b/editors/sc-ide/translations/scide_sv.ts
@@ -2078,7 +2078,7 @@ Would you like to override it?</source>
     </message>
     <message numerus="yes">
         <location filename="../widgets/find_replace_tool.cpp" line="299"/>
-        <source>%n occurrencies found.</source>
+        <source>%n occurrences found.</source>
         <comment>Find text in document...</comment>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -2087,7 +2087,7 @@ Would you like to override it?</source>
     </message>
     <message numerus="yes">
         <location filename="../widgets/find_replace_tool.cpp" line="305"/>
-        <source>%n occurrencies replaced.</source>
+        <source>%n occurrences replaced.</source>
         <comment>Find/replace text in document...</comment>
         <translation type="unfinished">
             <numerusform></numerusform>

--- a/editors/sc-ide/translations/scide_sv.ts
+++ b/editors/sc-ide/translations/scide_sv.ts
@@ -2078,7 +2078,7 @@ Would you like to override it?</source>
     </message>
     <message numerus="yes">
         <location filename="../widgets/find_replace_tool.cpp" line="299"/>
-        <source>%n occurrences found.</source>
+        <source>%n matches found.</source>
         <comment>Find text in document...</comment>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -2087,7 +2087,7 @@ Would you like to override it?</source>
     </message>
     <message numerus="yes">
         <location filename="../widgets/find_replace_tool.cpp" line="305"/>
-        <source>%n occurrences replaced.</source>
+        <source>%n matches replaced.</source>
         <comment>Find/replace text in document...</comment>
         <translation type="unfinished">
             <numerusform></numerusform>

--- a/editors/sc-ide/translations/scide_zh.ts
+++ b/editors/sc-ide/translations/scide_zh.ts
@@ -2078,7 +2078,7 @@ Would you like to override it?</source>
     </message>
     <message numerus="yes">
         <location filename="../widgets/find_replace_tool.cpp" line="299"/>
-        <source>%n occurrencies found.</source>
+        <source>%n occurrences found.</source>
         <comment>Find text in document...</comment>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -2086,7 +2086,7 @@ Would you like to override it?</source>
     </message>
     <message numerus="yes">
         <location filename="../widgets/find_replace_tool.cpp" line="305"/>
-        <source>%n occurrencies replaced.</source>
+        <source>%n occurrences replaced.</source>
         <comment>Find/replace text in document...</comment>
         <translation type="unfinished">
             <numerusform></numerusform>

--- a/editors/sc-ide/translations/scide_zh.ts
+++ b/editors/sc-ide/translations/scide_zh.ts
@@ -2078,7 +2078,7 @@ Would you like to override it?</source>
     </message>
     <message numerus="yes">
         <location filename="../widgets/find_replace_tool.cpp" line="299"/>
-        <source>%n occurrences found.</source>
+        <source>%n matches found.</source>
         <comment>Find text in document...</comment>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -2086,7 +2086,7 @@ Would you like to override it?</source>
     </message>
     <message numerus="yes">
         <location filename="../widgets/find_replace_tool.cpp" line="305"/>
-        <source>%n occurrences replaced.</source>
+        <source>%n matches replaced.</source>
         <comment>Find/replace text in document...</comment>
         <translation type="unfinished">
             <numerusform></numerusform>

--- a/editors/sc-ide/widgets/find_replace_tool.cpp
+++ b/editors/sc-ide/widgets/find_replace_tool.cpp
@@ -296,13 +296,13 @@ void TextFindReplacePanel::replaceAll()
 
 void TextFindReplacePanel::reportFoundOccurrencies( int count )
 {
-    QString message = tr("%n occurrencies found.", "Find text in document...", count);
+    QString message = tr("%n occurrences found.", "Find text in document...", count);
     MainWindow::instance()->showStatusMessage( message );
 }
 
 void TextFindReplacePanel::reportReplacedOccurrencies( int count )
 {
-    QString message = tr("%n occurrencies replaced.", "Find/replace text in document...", count);
+    QString message = tr("%n occurrences replaced.", "Find/replace text in document...", count);
     MainWindow::instance()->showStatusMessage( message );
 }
 

--- a/editors/sc-ide/widgets/find_replace_tool.cpp
+++ b/editors/sc-ide/widgets/find_replace_tool.cpp
@@ -296,13 +296,13 @@ void TextFindReplacePanel::replaceAll()
 
 void TextFindReplacePanel::reportFoundOccurrencies( int count )
 {
-    QString message = tr("%n occurrences found.", "Find text in document...", count);
+    QString message = tr("%n matches found.", "Find text in document...", count);
     MainWindow::instance()->showStatusMessage( message );
 }
 
 void TextFindReplacePanel::reportReplacedOccurrencies( int count )
 {
-    QString message = tr("%n occurrences replaced.", "Find/replace text in document...", count);
+    QString message = tr("%n matches replaced.", "Find/replace text in document...", count);
     MainWindow::instance()->showStatusMessage( message );
 }
 


### PR DESCRIPTION
In addition to cleanup from #2689, this fixes a typo that's been bugging me since I first started using SuperCollider—"3 _occurrencies_ found" when executing search-and-replace.