### PR TITLE
Update documentation for MIDIOut:-sysex

### DIFF
--- a/HelpSource/Classes/MIDIOut.schelp
+++ b/HelpSource/Classes/MIDIOut.schelp
@@ -42,7 +42,7 @@ Linux only. MacOS does not need to connect. On Linux it is an optional feature (
 
 InstanceMethods::
 method::sysex
-Sends a sysex command to the device.
+Sends a sysex command represented as an link::Classes/Int8Array:: to the device.
 
 note::
 On Windows, the function call must contain a full sysex message. In other words,
@@ -50,7 +50,7 @@ it must start with 0xF0 (240 or -16) and end with 0xF7 (247 or -9).
 ::
 
 argument:: packet
-An link::Classes/Int8Array:: of data bytes.
+An Int8Array of data bytes to be sent.
 
 private::send, prSysex
 

--- a/HelpSource/Classes/MIDIOut.schelp
+++ b/HelpSource/Classes/MIDIOut.schelp
@@ -77,7 +77,7 @@ MIDIIn.sysex = { arg uid, packet; [uid,packet].postln };
 MIDIIn.sysrt = { arg src, chan, val;  [src, chan, val].postln; };
 MIDIIn.smpte = { arg src, chan, val;  [src, chan, val].postln; };
 
-m.sysex(Int8Array[ 16rf0, 0, 0, 27, 11, 0,16rf7])
+m.sysex(Int8Array[0xF0, 0, 0, 27, 11, 0, 0xF7])
 
 m.smpte(24, 16)
 m.midiClock

--- a/HelpSource/Classes/MIDIOut.schelp
+++ b/HelpSource/Classes/MIDIOut.schelp
@@ -44,13 +44,13 @@ InstanceMethods::
 method::sysex
 Sends a sysex command to the device.
 
-argument:: packet
-An link::Classes/Int8Array:: of data bytes.
-
 note::
 On Windows, the function call must contain a full sysex message. In other words,
 it must start with 0xF0 (240 or -16) and end with 0xF7 (247 or -9).
 ::
+
+argument:: packet
+An link::Classes/Int8Array:: of data bytes.
 
 private::send, prSysex
 

--- a/HelpSource/Classes/MIDIOut.schelp
+++ b/HelpSource/Classes/MIDIOut.schelp
@@ -38,7 +38,7 @@ MIDIClient.destinations;
 ::
 
 method::connect, disconnect
-Linux only. macOS does not need to connect. On Linux it is an optional feature (see below).
+Linux only. MacOS does not need to connect. On Linux it is an optional feature (see below).
 
 InstanceMethods::
 method::sysex

--- a/HelpSource/Classes/MIDIOut.schelp
+++ b/HelpSource/Classes/MIDIOut.schelp
@@ -43,7 +43,13 @@ Linux only. MacOS does not need to connect. On Linux it is an optional feature (
 InstanceMethods::
 method::sysex
 Sends a sysex command to the device.
-WARNING:: On Windows, the function call must contain a full sysex message (i.e. needs to start with F0 and end with F7). 
+
+argument:: packet
+An link::Classes/Int8Array:: of data bytes.
+
+note::
+On Windows, the function call must contain a full sysex message. In other words,
+it must start with 0xF0 (240 or -16) and end with 0xF7 (247 or -9).
 ::
 
 private::send, prSysex


### PR DESCRIPTION
This has confused at least one user: http://new-supercollider-mailing-lists-forums-use-these.2681727.n2.nabble.com/sysex-failure-td7630588.html#a7630591

It needs to be made clear that it will only accept an `Int8Array`.