### PR TITLE
Winbuild: link rather than copy class, help- and some other files into the target build-folder

### DIFF
--- a/editors/sc-ide/CMakeLists.txt
+++ b/editors/sc-ide/CMakeLists.txt
@@ -363,6 +363,11 @@ elseif(WIN32)
         set_target_properties(SuperCollider PROPERTIES RUNTIME_OUTPUT_DIRECTORY "$<CONFIG>")
     endif(NOT MSVC)
 
+    add_custom_command(TARGET SuperCollider
+      PRE_BUILD
+      COMMAND cmd /C ${CMAKE_SOURCE_DIR}/platform/windows/junctions.bat create \"$<TARGET_FILE_DIR:SuperCollider>\" \"${CMAKE_SOURCE_DIR}\"
+    )
+
     foreach(translation ${translations})
       add_custom_command(TARGET SuperCollider
         POST_BUILD

--- a/editors/sc-ide/CMakeLists.txt
+++ b/editors/sc-ide/CMakeLists.txt
@@ -363,10 +363,19 @@ elseif(WIN32)
         set_target_properties(SuperCollider PROPERTIES RUNTIME_OUTPUT_DIRECTORY "$<CONFIG>")
     endif(NOT MSVC)
 
-    add_custom_command(TARGET SuperCollider
-      PRE_BUILD
-      COMMAND cmd /C ${CMAKE_SOURCE_DIR}/platform/windows/junctions.bat create \"$<TARGET_FILE_DIR:SuperCollider>\" \"${CMAKE_SOURCE_DIR}\"
-    )
+    if(MSYS)
+      add_custom_command(TARGET SuperCollider
+        PRE_BUILD
+        COMMAND "${CMAKE_SOURCE_DIR}/platform/windows/symlinks.sh" "create" "${CMAKE_SOURCE_DIR}" "$<TARGET_FILE_DIR:SuperCollider>"
+        COMMENT "Creating links to SCClassLibrary, HelpSource, examples and sounds"
+      )
+    else()
+      add_custom_command(TARGET SuperCollider
+        PRE_BUILD
+        COMMAND cmd /C ${CMAKE_SOURCE_DIR}/platform/windows/junctions.bat create \"$<TARGET_FILE_DIR:SuperCollider>\" \"${CMAKE_SOURCE_DIR}\"
+        COMMENT "Creating links to SCClassLibrary, HelpSource, examples and sounds"
+      )
+    endif()
 
     foreach(translation ${translations})
       add_custom_command(TARGET SuperCollider

--- a/lang/CMakeLists.txt
+++ b/lang/CMakeLists.txt
@@ -331,24 +331,6 @@ elseif(WIN32)
         set_target_properties(sclang PROPERTIES RUNTIME_OUTPUT_DIRECTORY "$<CONFIG>")
     endif(NOT MSVC)
 
-    add_custom_command(TARGET sclang
-        PRE_BUILD
-        COMMAND ${CMAKE_COMMAND} -E copy_directory "${CMAKE_SOURCE_DIR}/SCClassLibrary" $<TARGET_FILE_DIR:sclang>/SCClassLibrary
-        COMMAND ${CMAKE_COMMAND} -E copy_directory "${CMAKE_SOURCE_DIR}/HelpSource" $<TARGET_FILE_DIR:sclang>/HelpSource
-        COMMAND ${CMAKE_COMMAND} -E copy_directory "${CMAKE_SOURCE_DIR}/examples" $<TARGET_FILE_DIR:sclang>/examples
-        COMMAND ${CMAKE_COMMAND} -E copy_directory "${CMAKE_SOURCE_DIR}/sounds" $<TARGET_FILE_DIR:sclang>/sounds
-    )
-
-    if(NOT SC_QT)  # TODP: clean (and cross platform) solution for language boot for case SC_QT=OFF (this is a quick fix for language boot error)
-        add_custom_command(TARGET sclang
-            PRE_BUILD
-            COMMAND ${CMAKE_COMMAND} -E copy_directory "${CMAKE_SOURCE_DIR}/SCClassLibrary/Common/GUI" $<TARGET_FILE_DIR:sclang>/SCClassLibrary/scide_scqt/Common/GUI
-            COMMAND ${CMAKE_COMMAND} -E copy_directory "${CMAKE_SOURCE_DIR}/SCClassLibrary/JITLib/GUI" $<TARGET_FILE_DIR:sclang>/SCClassLibrary/scide_scqt/JITLib/GUI
-            COMMAND ${CMAKE_COMMAND} -E remove_directory $<TARGET_FILE_DIR:sclang>/SCClassLibrary/Common/GUI
-            COMMAND ${CMAKE_COMMAND} -E remove_directory $<TARGET_FILE_DIR:sclang>/SCClassLibrary/JITLib/GUI
-        )
-    endif(NOT SC_QT)
-
     set(SC_WIN_DLL_DIRS)
     if(SNDFILE_LIBRARY_DIR)
       list(APPEND SC_WIN_DLL_DIRS "${SNDFILE_LIBRARY_DIR}")
@@ -372,6 +354,7 @@ elseif(WIN32)
         add_custom_command(TARGET sclang
             POST_BUILD
             COMMAND ${CMAKE_COMMAND} -E copy_directory $<TARGET_FILE_DIR:sclang> $<TARGET_FILE_DIR:SuperCollider>
+            COMMAND cmd /C ${CMAKE_SOURCE_DIR}/platform/windows/junctions.bat create \"$<TARGET_FILE_DIR:sclang>\" \"${CMAKE_SOURCE_DIR}\"
       )
     endif(SC_IDE)
 

--- a/lang/CMakeLists.txt
+++ b/lang/CMakeLists.txt
@@ -351,11 +351,21 @@ elseif(WIN32)
     endif(QT_BIN_PATH)
 
     if(SC_IDE)
+      if(MSYS)
         add_custom_command(TARGET sclang
-            POST_BUILD
-            COMMAND ${CMAKE_COMMAND} -E copy_directory $<TARGET_FILE_DIR:sclang> $<TARGET_FILE_DIR:SuperCollider>
-            COMMAND cmd /C ${CMAKE_SOURCE_DIR}/platform/windows/junctions.bat create \"$<TARGET_FILE_DIR:sclang>\" \"${CMAKE_SOURCE_DIR}\"
-      )
+          POST_BUILD
+          COMMAND ${CMAKE_COMMAND} -E copy_directory $<TARGET_FILE_DIR:sclang> $<TARGET_FILE_DIR:SuperCollider>
+          COMMAND "${CMAKE_SOURCE_DIR}/platform/windows/symlinks.sh" "create" "${CMAKE_SOURCE_DIR}" "$<TARGET_FILE_DIR:sclang>"
+          COMMENT "Copying files in target sclang to target SuperCollider (scide) and creating links to SCClassLibrary e.a."
+        )
+      else()
+        add_custom_command(TARGET sclang
+          POST_BUILD
+          COMMAND ${CMAKE_COMMAND} -E copy_directory $<TARGET_FILE_DIR:sclang> $<TARGET_FILE_DIR:SuperCollider>
+          COMMAND cmd /C ${CMAKE_SOURCE_DIR}/platform/windows/junctions.bat create \"$<TARGET_FILE_DIR:sclang>\" \"${CMAKE_SOURCE_DIR}\"
+          COMMENT "Copying files in target sclang to target SuperCollider (scide) and creating links to SCClassLibrary e.a."
+        )
+      endif()
     endif(SC_IDE)
 
     install(TARGETS sclang

--- a/platform/windows/junctions.bat
+++ b/platform/windows/junctions.bat
@@ -1,0 +1,22 @@
+@ECHO OFF
+
+REM USE: junctions.bat create <link> <target>
+REM USE: junctions.bat remove <link>
+REM For both, link and target, the parent folder of the folder group SCClassLibrary, HelpSource, examples and sounds has to be given
+
+GOTO %1
+
+:CREATE
+IF NOT EXIST %2\SCClassLibrary (mklink /J %2\SCClassLibrary %3\SCClassLibrary)
+IF NOT EXIST %2\HelpSource (mklink /J %2\HelpSource %3\HelpSource)
+IF NOT EXIST %2\examples (mklink /J %2\examples %3\examples)
+IF NOT EXIST %2\sounds (mklink /J %2\sounds %3\sounds)
+GOTO :END
+
+:REMOVE
+IF EXIST %2\SCClassLibrary (rmdir %2\SCClassLibrary)
+IF EXIST %2\HelpSource (rmdir %2\HelpSource)
+IF EXIST %2\examples (rmdir %2\examples)
+IF EXIST %2\sounds (rmdir %2\sounds)
+
+:END

--- a/platform/windows/symlinks.sh
+++ b/platform/windows/symlinks.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# USE: symlinks.sh create <target> <link>
+# USE: symlinks.sh remove <link>
+# For both, link and target, the parent folder of the folder group SCClassLibrary, HelpSource, examples and sounds has to be given
+# rm -r does *not* remove the files contained in the target dir ;). This seems to be a peculiarity of msys2 symlink support
+
+if [ "$1" = "create" ]; then
+  if [ ! -e "$3/SCClassLibrary" ]; then ln -s "$2/SCClassLibrary" "$3/SCClassLibrary"; fi
+  if [ ! -e "$3/HelpSource" ]; then ln -s "$2/HelpSource" "$3/HelpSource"; fi
+  if [ ! -e "$3/examples" ]; then ln -s "$2/examples" "$3/examples"; fi
+  if [ ! -e "$3/sounds" ]; then ln -s "$2/sounds" "$3/sounds"; fi
+elif [ "$1" = "remove" ]; then
+  if [ -e "$2/SCClassLibrary" ]; then rm -r "$2/SCClassLibrary"; fi
+  if [ -e "$2/HelpSource" ]; then ln rm -r "$2/HelpSource"; fi
+  if [ -e "$2/examples" ]; then ln rm -r "$2/examples"; fi
+  if [ -e "$2/sounds" ]; then ln rm -r "$2/sounds"; fi
+else
+  echo 'ERROR: First argument must be "create" or "remove"';
+fi


### PR DESCRIPTION
For VS and MinGW native "junctions" are used
For MSYS symlinks
see #2479