### PR TITLE
Help: Clarify VDiskIn's outgoing OSC is not the file position

### DIFF
--- a/HelpSource/Classes/VDiskIn.schelp
+++ b/HelpSource/Classes/VDiskIn.schelp
@@ -29,7 +29,7 @@ argument:: loop
 If loop is set to 1, the soundfile will loop.
 
 argument:: sendID
-If a sendID is given, the UGen sends an osc message with this id and the file position each time it reloads the buffer: code::['/diskin', nodeID, sendID, frame]::
+If a sendID is given, the UGen sends an osc message with this id and the frame index emphasis::relative to the onset of the Synth:: each time it reloads the buffer: code::['/diskin', nodeID, sendID, frame]::. The true frame index into the file is determined by the code::startFrame:: given when reading the initial buffer's worth of data (using link::Classes/Buffer#-cueSoundFile:: or link::Classes/Buffer#-read::). VDiskIn does not have access to the frame index used to cue the buffer. So, the frame index sent by OSC begins with 0 at the start of the synth node. The user is responsible for adding the cue point: code::cueStartFrame + msg[3]::.
 
 discussion::
 This UGen will set the link::Classes/Done##'done' flag:: when finished playing.

--- a/HelpSource/Classes/VDiskIn.schelp
+++ b/HelpSource/Classes/VDiskIn.schelp
@@ -29,7 +29,10 @@ argument:: loop
 If loop is set to 1, the soundfile will loop.
 
 argument:: sendID
-If a sendID is given, the UGen sends an osc message with this id and the frame index emphasis::relative to the onset of the Synth:: each time it reloads the buffer: code::['/diskin', nodeID, sendID, frame]::. The true frame index into the file is determined by the code::startFrame:: given when reading the initial buffer's worth of data (using link::Classes/Buffer#-cueSoundFile:: or link::Classes/Buffer#-read::). VDiskIn does not have access to the frame index used to cue the buffer. So, the frame index sent by OSC begins with 0 at the start of the synth node. The user is responsible for adding the cue point: code::cueStartFrame + msg[3]::.
+If a sendID is given, the UGen sends an OSC message with this ID and the frame index emphasis::relative to the onset of the Synth:: each time it reloads the buffer: code::['/diskin', nodeID, sendID, frame]::.
+The true frame index into the file is determined by the code::startFrame:: given when reading the initial buffer's worth of data, using link::Classes/Buffer#-cueSoundFile:: or link::Classes/Buffer#-read::.
+VDiskIn does not have access to the frame index used to cue the buffer. So, the frame index sent by OSC is always 0 at the start of the synth node.
+The user is responsible for adding the cue point: code::cueStartFrame + msg[3]::.
 
 discussion::
 This UGen will set the link::Classes/Done##'done' flag:: when finished playing.


### PR DESCRIPTION
Clarifying a point that is slightly misleading in VDiskIn help. The old wording says that the OSC message will send back the *frame index within the file*, but this is not true. It always starts with 0 at synth onset. If you cued the buffer into the middle of the file, the real file position is `cuePoint + msg[3]`.

Documentation should not assume that the user will always play the file from the beginning.