### PR TITLE
Fix symlinks in win build system (urgent :)

### DIFF
--- a/lang/CMakeLists.txt
+++ b/lang/CMakeLists.txt
@@ -362,6 +362,7 @@ elseif(WIN32)
       if(MSYS)
         add_custom_command(TARGET sclang
           POST_BUILD
+          COMMAND "${CMAKE_SOURCE_DIR}/platform/windows/symlinks.sh" "remove" "$<TARGET_FILE_DIR:sclang>"
           COMMAND ${CMAKE_COMMAND} -E copy_directory $<TARGET_FILE_DIR:sclang> $<TARGET_FILE_DIR:SuperCollider>
           COMMAND "${CMAKE_SOURCE_DIR}/platform/windows/symlinks.sh" "create" "${CMAKE_SOURCE_DIR}" "$<TARGET_FILE_DIR:sclang>"
           COMMENT "Copying files in target sclang to target SuperCollider (scide) and creating links to SCClassLibrary e.a."
@@ -369,6 +370,7 @@ elseif(WIN32)
       else()
         add_custom_command(TARGET sclang
           POST_BUILD
+          COMMAND cmd /C ${CMAKE_SOURCE_DIR}/platform/windows/junctions.bat remove \"$<TARGET_FILE_DIR:sclang>\"
           COMMAND ${CMAKE_COMMAND} -E copy_directory $<TARGET_FILE_DIR:sclang> $<TARGET_FILE_DIR:SuperCollider>
           COMMAND cmd /C ${CMAKE_SOURCE_DIR}/platform/windows/junctions.bat create \"$<TARGET_FILE_DIR:sclang>\" \"${CMAKE_SOURCE_DIR}\"
           COMMENT "Copying files in target sclang to target SuperCollider (scide) and creating links to SCClassLibrary e.a."

--- a/platform/windows/junctions.bat
+++ b/platform/windows/junctions.bat
@@ -11,7 +11,7 @@ IF NOT EXIST %2\SCClassLibrary (mklink /J %2\SCClassLibrary %3\SCClassLibrary)
 IF NOT EXIST %2\HelpSource (mklink /J %2\HelpSource %3\HelpSource)
 IF NOT EXIST %2\examples (mklink /J %2\examples %3\examples)
 IF NOT EXIST %2\sounds (mklink /J %2\sounds %3\sounds)
-GOTO :END
+GOTO END
 
 :REMOVE
 IF EXIST %2\SCClassLibrary (rmdir %2\SCClassLibrary)


### PR DESCRIPTION
There is a bad bug in the symlink feature #2708. If you build a second time some symlinks are overwritten with symlinks, and thereby the content of the linked files deleted (only relevant for Windows builders :) ). This should fix it.