### PR TITLE
Win: fix some cases of problems with space in path (Server startup an…

### DIFF
--- a/SCClassLibrary/Common/Quarks/Git.sc
+++ b/SCClassLibrary/Common/Quarks/Git.sc
@@ -10,12 +10,21 @@ Git {
 		^super.new.localPath_(localPath)
 	}
 	clone { |url|
-		this.git([
-			"clone",
-			url,
-			localPath.escapeChar($ )
-		], false);
-		this.url = url;
+		if(thisProcess.platform.name === 'windows', {
+			this.git([
+				"clone",
+				url,
+				localPath.quote
+			], false);
+			this.url = url;
+		}, {
+			this.git([
+				"clone",
+				url,
+				localPath.escapeChar($ )
+			], false);
+			this.url = url;
+		});
 	}
 	pull {
 		this.git(["pull", "origin", "master"])
@@ -99,7 +108,11 @@ Git {
 		var cmd, result="";
 
 		if(cd, {
-			cmd = ["cd", localPath.escapeChar($ ), "&&", "git"];
+			if(thisProcess.platform.name === 'windows', {
+				cmd = ["cd", localPath.quote, "&&", "git"];
+			}, {
+				cmd = ["cd", localPath.escapeChar($ ), "&&", "git"];
+			});
 		},{
 			cmd = ["git"];
 		});

--- a/SCClassLibrary/Platform/windows/WindowsPlatform.sc
+++ b/SCClassLibrary/Platform/windows/WindowsPlatform.sc
@@ -13,7 +13,8 @@ WindowsPlatform : Platform {
 
 	startup {
 		// Server setup
-		Server.program = "scsynth.exe";
+		var srvProg = Platform.resourceDir.quote;
+		Server.program = "start /B /HIGH /D % scsynth.exe".format(srvProg);
 
 		// Score setup
 		Score.program = Server.program;


### PR DESCRIPTION
#…d Quarks)

The general issue is here that the system-conform way of making spaces in paths possible on Windows is wrapping the paths in double quotation marks, whereas Unix escapes the spaces with `\`.
So every sclang statement that uses .escapeChar($ ) will break on Windows. Windows does provide kind of a compatibility mode for space escaping, using `^` rather than `\`, but it's quite complicated (e.g. when paths are combined with arguments), and the use of ^ as escape char in Windows is far from exquivalent to the use of `\` in Unix.

Apart from escapeChar() there are more subtle issue here, like in the server-command (Server.program in platform/windows/WindowsPlatform.sc). I suspect the old implementation tried  to circumvent any problems with bad paths by keeping it out of the server command. But the side effects are bad too, they just go unnoticed as long as people only use SC from the ide and start it with a application link (which set's the working directory). The current server command doesn't break with spaces. It also works with a path like this `"c:\Users\xèy\Documents\Super Collider"`. But that's not because of a fix, but because server-path seems not to be hit by the non-ascii problem.

Another thing I bumped into is that File.exist() doesn't work properly when used with a path that contains (a) space(s). File.exist goes straight into a primitive... ;)

#2440
#2719

Oh, wow, just saw that a lot of research has been done on SCDoc Windows problem. That looks promising!
