### PR TITLE
class lib: stop using OSCpathResponder

### DIFF
--- a/SCClassLibrary/Common/Audio/Poll.sc
+++ b/SCClassLibrary/Common/Audio/Poll.sc
@@ -27,19 +27,3 @@ Poll : UGen {
 		inputs = theInputs;
 	}
 }
-
-/*
-s.boot;
-
-{Poll.ar(Impulse.ar(5), Line.ar(0, 1, 1), \test2)}.play(s);
-{SinOsc.ar(220, 0, 1).poll(Impulse.ar(15), "test")}.play(s);
-
-o = OSCresponderNode(s.addr, '/tr', {arg time, resp, msg;
-	msg.postln;
-	}).add
-
-{Poll.ar(Impulse.ar(5), Line.ar(0, 1, 1), \test2, 1234)}.play(s);
-
-o.remove;
-s.quit;
-*/

--- a/SCClassLibrary/Common/Control/Buffer.sc
+++ b/SCClassLibrary/Common/Control/Buffer.sc
@@ -401,9 +401,12 @@ Buffer {
 	}
 
 	get { arg index, action;
-		OSCpathResponder(server.addr, ['/b_set', bufnum, index], { arg time, r, msg;
-			action.value(msg.at(3)); r.remove }).add;
-		server.listSendMsg(["/b_get", bufnum, index])
+		OSCFunc({ |message|
+			// The server replies with a message of the form [/b_set, bufnum, index, value].
+			// We want "value," which is at index 3.
+			action.value(message[3]);
+		}, \b_set, server.addr, argTemplate: [bufnum, index]).oneShot;
+		server.listSendMsg(["/b_get", bufnum, index]);
 	}
 
 	getMsg { arg index;
@@ -411,8 +414,12 @@ Buffer {
 	}
 
 	getn { arg index, count, action;
-		OSCpathResponder(server.addr, ['/b_setn', bufnum, index], {arg time, r, msg;
-			action.value(msg.copyToEnd(4)); r.remove } ).add;
+		OSCFunc({ |message|
+			// The server replies with a message of the form
+			// [/b_setn, bufnum, starting index, length, ...sample values].
+			// We want the sample values, which start at index 4.
+			action.value(message[4..]);
+		}, \b_setn, server.addr, argTemplate: [bufnum, index]).oneShot;
 		server.listSendMsg(["/b_getn", bufnum, index, count]);
 	}
 

--- a/SCClassLibrary/Common/Control/Buffer.sc
+++ b/SCClassLibrary/Common/Control/Buffer.sc
@@ -372,11 +372,11 @@ Buffer {
 	}
 
 	set { arg index, float ... morePairs;
-		server.listSendMsg(["/b_set", bufnum, index, float] ++ morePairs)
+		server.listSendMsg([\b_set, bufnum, index, float] ++ morePairs)
 	}
 
 	setMsg { arg index, float ... morePairs;
-		^["/b_set", bufnum, index, float] ++ morePairs
+		^[\b_set, bufnum, index, float] ++ morePairs
 	}
 
 	setn { arg ... args;
@@ -406,11 +406,11 @@ Buffer {
 			// We want "value," which is at index 3.
 			action.value(message[3]);
 		}, \b_set, server.addr, argTemplate: [bufnum, index]).oneShot;
-		server.listSendMsg(["/b_get", bufnum, index]);
+		server.listSendMsg(this.getMsg(index));
 	}
 
 	getMsg { arg index;
-		^["/b_get", bufnum, index]
+		^[\b_get, bufnum, index]
 	}
 
 	getn { arg index, count, action;
@@ -420,11 +420,11 @@ Buffer {
 			// We want the sample values, which start at index 4.
 			action.value(message[4..]);
 		}, \b_setn, server.addr, argTemplate: [bufnum, index]).oneShot;
-		server.listSendMsg(["/b_getn", bufnum, index, count]);
+		server.listSendMsg(this.getnMsg(index, count));
 	}
 
 	getnMsg { arg index, count;
-		^["/b_getn", bufnum, index, count]
+		^[\b_getn, bufnum, index, count]
 	}
 
 	fill { arg startAt, numFrames, value ... more;

--- a/SCClassLibrary/Common/Control/Bus.sc
+++ b/SCClassLibrary/Common/Control/Bus.sc
@@ -96,8 +96,11 @@ Bus {
 	get { arg action;
 		if(numChannels == 1) {
 			action = action ? { |vals| "Bus % index: % value: %.\n".postf(rate, index, vals); };
-			OSCpathResponder(server.addr, ['/c_set', index], { arg time, r, msg;
-				action.value(msg.at(2)); r.remove }).add;
+			OSCFunc({ |message|
+				// The response is of the form [/c_set, index, value].
+				// We want "value," which is at index 2.
+				action.value(message[2]);
+			}, \c_set, server.addr, argTemplate: [index]).oneShot;
 			server.listSendMsg(["/c_get", index]);
 		} {
 			this.getn(numChannels, action)
@@ -106,8 +109,11 @@ Bus {
 
 	getn { arg count, action;
 		action = action ? { |vals| "Bus % index: % values: %.\n".postf(rate, index, vals) };
-		OSCpathResponder(server.addr, ['/c_setn', index], { arg time, r, msg;
-			action.value(msg.copyToEnd(3)); r.remove }).add;
+		OSCFunc({ |message|
+			// The response is of the form [/c_set, index, count, ...values].
+			// We want the values, which are at indexes 3 and above.
+			action.value(message[3..]);
+		}, \c_setn, server.addr, argTemplate: [index]).oneShot;
 		server.listSendMsg(this.getnMsg(count));
 	}
 

--- a/SCClassLibrary/Common/Control/Bus.sc
+++ b/SCClassLibrary/Common/Control/Bus.sc
@@ -101,7 +101,7 @@ Bus {
 				// We want "value," which is at index 2.
 				action.value(message[2]);
 			}, \c_set, server.addr, argTemplate: [index]).oneShot;
-			server.listSendMsg(["/c_get", index]);
+			server.listSendMsg([\c_get, index]);
 		} {
 			this.getn(numChannels, action)
 		};
@@ -118,11 +118,11 @@ Bus {
 	}
 
 	getMsg {
-		^["/c_get", index];
+		^[\c_get, index];
 	}
 
 	getnMsg { arg count;
-		^["/c_getn", index, count ? numChannels];
+		^[\c_getn, index, count ? numChannels];
 	}
 
 	getSynchronous {

--- a/SCClassLibrary/Common/Control/Node.sc
+++ b/SCClassLibrary/Common/Control/Node.sc
@@ -530,8 +530,12 @@ Synth : Node {
 	}
 
 	get { arg index, action;
-		OSCpathResponder(server.addr, ['/n_set', nodeID, index], { arg time, r, msg;
-			action.value(msg.at(3)); r.remove }).add;
+		OSCFunc({ |message|
+			// The server replies with a message of the form
+			// [/n_set, node ID, index, value].
+			// We want "value," which is at index 3.
+			action.value(message[3]);
+		}, \n_set, server.addr, argTemplate: [nodeID, index]).oneShot;
 		server.sendMsg(44, nodeID, index)	//"/s_get"
 	}
 
@@ -540,8 +544,12 @@ Synth : Node {
 	}
 
 	getn { arg index, count, action;
-		OSCpathResponder(server.addr, ['/n_setn', nodeID, index], {arg time, r, msg;
-			action.value(msg.copyToEnd(4)); r.remove } ).add;
+		OSCFunc({ |message|
+			// The server replies with a message of the form
+			// [/n_setn, node ID, index, count, ...values].
+			// We want "valuse," which are at indexes 4 and above.
+			action.value(message[4..]);
+		}, \n_setn, server.addr, argTemplate: [nodeID, index]).oneShot;
 		server.sendMsg(45, nodeID, index, count) //"/s_getn"
 	}
 

--- a/SCClassLibrary/Common/Control/Node.sc
+++ b/SCClassLibrary/Common/Control/Node.sc
@@ -547,7 +547,7 @@ Synth : Node {
 		OSCFunc({ |message|
 			// The server replies with a message of the form
 			// [/n_setn, node ID, index, count, ...values].
-			// We want "valuse," which are at indexes 4 and above.
+			// We want "values," which are at indexes 4 and above.
 			action.value(message[4..]);
 		}, \n_setn, server.addr, argTemplate: [nodeID, index]).oneShot;
 		server.sendMsg(45, nodeID, index, count) //"/s_getn"

--- a/testsuite/classlibrary/TestBuffer.sc
+++ b/testsuite/classlibrary/TestBuffer.sc
@@ -62,22 +62,17 @@ TestBuffer : UnitTest {
 	// Test basen on JP's test code, for the bug which DS introduced in svn rev 9362, and JP fixed in svn rev 9371
 	// Note that the "expected values" used in this test depend precisely on the samples in a11wlk01.wav, so will need updating if that changes.
 	test_allocAndQuery {
-		var o,p, expectq, expectg, s=this.s, sfpath, sf, b;
+		var expectq, expectg, s=this.s, sfpath, sf, b;
 		this.bootServer;
 		Buffer.freeAll;
 
-		o = OSCresponderNode(s.addr, '/b_info', {arg time, resp, msg;
-			msg.postln;
-			this.assertEquals(msg, expectq, "/b_info data returned from a /b_query message should be as expected");
-		});
+		OSCFunc({ |message|
+			this.assertEquals(message, expectq, "/b_info data returned from a /b_query message should be as expected");
+		}, \b_info, s.addr).oneShot;
 
-		p = OSCresponderNode(s.addr, '/b_set', {arg time, resp, msg;
-			msg.postln;
-			this.assertEquals(msg, expectg, "/b_set data returned from a /b_get message should be as expected");
-		});
-
-		o.add;
-		p.add;
+		OSCFunc({ |message|
+			this.assertEquals(message, expectg, "/b_set data returned from a /b_get message should be as expected");
+		}, \b_set, s.addr).oneShot;
 
 		// Hmm, seems not all systems have the standard soundfile available
 		// s.sendMsg(\b_allocRead, 1, "sounds/a11wlk01.wav");
@@ -117,9 +112,6 @@ TestBuffer : UnitTest {
 
 		0.4.wait;
 		s.sync;
-
-		o.remove;
-		p.remove;
 
 
 	}

--- a/testsuite/classlibrary/TestBuffer.sc
+++ b/testsuite/classlibrary/TestBuffer.sc
@@ -3,28 +3,28 @@ Buffer.test
 UnitTest.gui
 */
 TestBuffer : UnitTest {
-	
+
 	test_freeAll {
 		var n;
-		
+
 		this.bootServer;
-		
+
 		Buffer.freeAll;
 		n = Buffer(Server.default,44100,2);
 		this.assertEquals( Server.default.bufferAllocator.blocks.size , 1 , " allocated one buffer");
 		Buffer.freeAll;
 		this.assertEquals( Server.default.bufferAllocator.blocks.size , 0 , "freeAll : no buffers allocated");
-		
+
 	}
-	
+
 	test_serverlang_dataexchange {
 		var d, b;
-		
+
 		this.bootServer;
-		
+
 		// Random data for test
 		d = {1.0.rand}.dup(Server.default.sampleRate);
-		
+
 		// send then load
 		b = Buffer.sendCollection(Server.default, d);
 		0.2.wait;
@@ -41,7 +41,7 @@ TestBuffer : UnitTest {
 		b = Buffer.loadCollection(Server.default, d);
 		0.2.wait;
 		Server.default.sync;
-		b.loadToFloatArray(0, -1, action:{|data| 
+		b.loadToFloatArray(0, -1, action:{|data|
 			this.assert(data.size==d.size,       "test_serverlang_dataexchange loadCollection->loadToFloatArray received full-length data (%==%)".format(data.size, d.size));
 			this.assertArrayFloatEquals(data, d, "test_serverlang_dataexchange loadCollection->loadToFloatArray", report: true)
 		});
@@ -50,35 +50,35 @@ TestBuffer : UnitTest {
 		// zero the Buffer and check that it worked
 		b.zero;
 		Server.default.sync;
-		b.loadToFloatArray(0, -1, action:{|data| 
+		b.loadToFloatArray(0, -1, action:{|data|
 			this.assertArrayFloatEquals(data, 0, "Buffer:zero should give a buffer containing zeroes", report: true)
 		});
 		Server.default.sync;
 		b.free;
 		Server.default.sync;
 	}
-	
-	
+
+
 	// Test basen on JP's test code, for the bug which DS introduced in svn rev 9362, and JP fixed in svn rev 9371
 	// Note that the "expected values" used in this test depend precisely on the samples in a11wlk01.wav, so will need updating if that changes.
 	test_allocAndQuery {
 		var o,p, expectq, expectg, s=this.s, sfpath, sf, b;
 		this.bootServer;
 		Buffer.freeAll;
-		
+
 		o = OSCresponderNode(s.addr, '/b_info', {arg time, resp, msg;
 			msg.postln;
 			this.assertEquals(msg, expectq, "/b_info data returned from a /b_query message should be as expected");
 		});
-			
+
 		p = OSCresponderNode(s.addr, '/b_set', {arg time, resp, msg;
 			msg.postln;
 			this.assertEquals(msg, expectg, "/b_set data returned from a /b_get message should be as expected");
 		});
-			
+
 		o.add;
 		p.add;
-		
+
 		// Hmm, seems not all systems have the standard soundfile available
 		// s.sendMsg(\b_allocRead, 1, "sounds/a11wlk01.wav");
 		// So instead we use this from the SoundFile helpfile:
@@ -95,33 +95,33 @@ TestBuffer : UnitTest {
 
 		0.4.wait;
 		s.sync;
-		
+
 		expectq = [ '/b_info', 1, 44100, 1, 44100 ];
 		expectg = [ '/b_set', 1, 1000, 0.43011474609375 ];
 		s.sendMsg(\b_query, 1);
 		s.sendMsg(\b_get, 1, 1000);
-		
+
 		0.4.wait;
 		s.sync;
-		
+
 		s.sendMsg(\b_alloc, 3, 30000);
 		s.sendMsg(\b_read, 3, sfpath, 0, 30000);
-		
+
 		0.4.wait;
 		s.sync;
-		
+
 		expectq = [ '/b_info', 3, 30000, 1, 44100 ];
 		expectg = [ '/b_set', 3, 1000, 0.43011474609375 ];
 		s.sendMsg(\b_query, 3);
 		s.sendMsg(\b_get, 3, 1000);
-		
+
 		0.4.wait;
 		s.sync;
-		
+
 		o.remove;
 		p.remove;
-		
-		
+
+
 	}
 
 	test_cheby {
@@ -174,6 +174,51 @@ TestBuffer : UnitTest {
 		^sig[sig.size >> 1]
 	}
 
+	test_get {
+		var s, buffer, collection;
+		var get_value;
+		s = this.s;
+		this.bootServer;
+
+		collection = [88.88, 8, 888.8, 8.88];
+		buffer = Buffer.sendCollection(s, collection);
+		s.sync;
+
+		get_value = 0;
+		buffer.get(2, { |value|
+			get_value = value;
+		});
+
+		0.1.wait;
+
+		// Some precision is lost when converting to 32-bit float, hence the use of
+		// assertFloatEquals.
+		this.assertFloatEquals(get_value, collection[2], "Buffer:get works", 0.001);
+
+		buffer.free;
+	}
+
+	test_getn {
+		var s, buffer, collection;
+		var getn_values;
+		s = this.s;
+		this.bootServer;
+
+		collection = [88.88, 8, 888.8, 8.88];
+		buffer = Buffer.sendCollection(s, collection);
+		s.sync;
+
+		getn_values = [0, 0];
+		buffer.getn(2, 2, { |values|
+			getn_values = values;
+		});
+
+		0.1.wait;
+
+		// See comments in test_get.
+		this.assertArrayFloatEquals(getn_values, collection[2..3], "Buffer:getn works", 0.001);
+
+		buffer.free;
+	}
+
 }
-
-

--- a/testsuite/classlibrary/TestBus.sc
+++ b/testsuite/classlibrary/TestBus.sc
@@ -1,22 +1,22 @@
 
 TestBus : UnitTest {
-	
+
 	test_free {
 		var s,busses,numBusses;
 		s = Server.default;
 		s.newAllocators;
-		
+
 		numBusses = s.options.numAudioBusChannels - (s.options.numOutputBusChannels + s.options.numInputBusChannels);
-		
-		busses = Array.fill( numBusses,{ 
+
+		busses = Array.fill( numBusses,{
 									Bus.audio(s,1);
 							});
 		this.assert(busses.every(_.notNil),"should be able to allocate all busses");
 		this.assertEquals( busses.select(_.notNil).size, numBusses," should be numAudioBusChannels busses");
-		
+
 		busses.do({ |b| b.free });
-		
-		busses = Array.fill( numBusses,{ 
+
+		busses = Array.fill( numBusses,{
 									Bus.audio(s,1);
 							});
 
@@ -29,21 +29,72 @@ TestBus : UnitTest {
 		s = Server.default;
 		s.newAllocators;
 
-		busses = Array.fill( s.options.numControlBusChannels,{ 
+		busses = Array.fill( s.options.numControlBusChannels,{
 									Bus.control(s,1);
 							});
 		this.assertEquals( busses.select(_.notNil).size, s.options.numControlBusChannels," should be numControlBusChannels busses");
-		
+
 		busses.do({ |b| b.free });
-		
-		busses = Array.fill( s.options.numControlBusChannels,{ 
+
+		busses = Array.fill( s.options.numControlBusChannels,{
 									Bus.control(s,1);
 							});
 
 		this.assertEquals( busses.select(_.notNil).size, s.options.numControlBusChannels," should be numControlBusChannels busses able to allocate again after freeing all");
 	}
-	
+
 	// note: server reboot does not de-allocate busses
 	// and isn't supposed to
+
+	test_get {
+		var s, bus, set_value, get_value;
+		s = this.s;
+		this.bootServer;
+
+		set_value = 88.88;
+		bus = Bus.control(s);
+		s.sync;
+
+		bus.set(set_value);
+		s.sync;
+
+		get_value = 0;
+		bus.get({ |value|
+			get_value = value;
+		});
+
+		0.2.wait;
+
+		// Some precision is lost when converting to 32-bit float, hence the use of
+		// assertFloatEquals.
+		this.assertFloatEquals(get_value, set_value, "Bus:get works", 0.001);
+
+		bus.free;
+	}
+
+	test_getn {
+		var s, bus, set_values, get_values;
+		s = this.s;
+		this.bootServer;
+
+		set_values = [88.88, 8, 888.8, 8.88];
+		bus = Bus.control(s, set_values.size);
+		s.sync;
+
+		bus.setn(set_values);
+		s.sync;
+
+		get_values = [0, 0];
+		bus.getn(2, { |values|
+			get_values = values;
+		});
+
+		0.2.wait;
+
+		// See comments in test_get.
+		this.assertArrayFloatEquals(get_values, set_values[0..1], "Bus:getn works", 0.001);
+
+		bus.free;
+	}
 
 }

--- a/testsuite/classlibrary/TestEvent.sc
+++ b/testsuite/classlibrary/TestEvent.sc
@@ -3,45 +3,45 @@ TestEvent.run
 UnitTest.gui
 */
 TestEvent : UnitTest {
-	
+
 	var prevMsg, prevLatency;
-	
+
 	test_equality {
-	
+
 		var a,b,c, x, y, keys, values;
-		
+
 		a = (a: 100, b: 200, c: [1, 2, 3]);
 		b = (a: 100, b: 200, c: [1, 2, 3]);
 		c = (a: 100, b: 200, c: [1, 2, 4]);
-		
+
 		this.assert( a == b, "2 identically specified Events should be equal");
 
 		this.assert( a != c, "2 different Events should not be equal");
-		
+
 		this.assert( a == a, "an Events should equal itself");
-		
+
 		x = ().putPairs([{ |i| ("key_" ++ i).asSymbol }.dup(80), 0].flop.flat);
 		keys = x.keys.asArray;
 		values = keys.collect { |key| x.at(key) };
-		
+
 		this.assert(values.includes(nil).not, "an Event responds to all its keys");
-		
+
 		x.use {
 			y = ().putPairs(keys.envirPairs);
 		};
-		
+
 		this.assert(x == y, "an Event remains invariant under transformation to envirPairs");
-		
+
 	}
-	
+
 	test_server_messages {
 		// type note
 		var event = (
-			type: \note, 
-			instrument: \xxx_test, 
-			server: this, 
+			type: \note,
+			instrument: \xxx_test,
+			server: this,
 			note: 0,
-			octave: 6, 
+			octave: 6,
 			ctranspose: 1,
 			zzzz: 0,
 			latency: 0,
@@ -49,24 +49,24 @@ TestEvent : UnitTest {
 		);
 		var i, msg1, finishTest = false;
 		var isPlaying;
-		
+
 		SynthDef(\xxx_test, { |freq, zzzz, gate = 1|
-			
+
 		}).add;
-		
-		this.assert(SynthDescLib.global.at(\xxx_test).canFreeSynth.not, 
+
+		this.assert(SynthDescLib.global.at(\xxx_test).canFreeSynth.not,
 			"SynthDesc detects that Synth can't free itself");
-		
+
 		SynthDef(\xxx_test, { |freq, zzzz, gate = 1|
 			EnvGen.kr(Env.asr, gate, doneAction:2)
 		}).add;
-		
-		this.assert(SynthDescLib.global.at(\xxx_test).canFreeSynth, 
+
+		this.assert(SynthDescLib.global.at(\xxx_test).canFreeSynth,
 			"SynthDesc detects that Synth can free itself");
-		
+
 		event.play;
 		0.5.wait;
-		
+
 		msg1 = prevMsg[0];
 		i = msg1.indexOf(\freq);
 		this.assert(msg1[i+1].cpsmidi == 73, "note 0 octave 6 ctranspose 1 equals midinote 73");
@@ -74,36 +74,17 @@ TestEvent : UnitTest {
 		this.assert(msg1.includes(\zzzz), "SynthDesc provides parameters to send in message");
 		this.assert(event[\hasGate] == true, "Event detects gate in SynthDesc");
 		this.assert(finishTest, "Event evaluates finish action");
-		this.assert(prevLatency == 0, 
+		this.assert(prevLatency == 0,
 			"latency specified in the event should override server latency");
 		prevMsg = nil;
 		prevLatency = nil;
-		/*
-		
-		Server.default.boot;
-		this.wait({ Server.default.serverRunning }, "server failed to boot");
-		SynthDef(\xxx_test, { |gate = 1, doneAction = 0|
-			EnvGen.kr(Env.asr(0, 1, 0.1), gate, doneAction:doneAction)
-		}).memStore;
-		event = (instrument: \xxx_test, sustain: 200, server: Server.default, doneAction: 2);
-		event.play;
-		0.5.wait;
-		OSCresponderNode(addr, '/g_queryTree.reply', { arg time, responder, msg;
-		}).addOnce;
-		this.assert(synth.isPlaying, "event should play");
-		0.5.wait;
-		event.release;
-		0.5.wait;
-		this.assert(synth.isPlaying.not, "event should release");
-		
-		*/
 	}
-		
+
 	sendMsg { |... args| prevMsg = prevMsg.add(args) }
 	sendBundle { |latency, args| prevMsg = prevMsg.add(args); prevLatency = latency; }
 
 	nextNodeID { ^-1 }
 	latency { ^0.2 }
-	
+
 }
 

--- a/testsuite/classlibrary/TestNode.sc
+++ b/testsuite/classlibrary/TestNode.sc
@@ -1,53 +1,53 @@
 TestNode : UnitTest {
 
-    test_get {
-        var s, node, set_value, get_value;
-        this.bootServer;
-        s = this.s;
+	test_get {
+		var s, node, set_value, get_value;
+		this.bootServer;
+		s = this.s;
 
-        SynthDef(\test_get, {
-            |control = 8|
-        }).add;
-        s.sync;
-        set_value = 888;
-        node = Synth(\test_get, [control: set_value]);
-        s.sync;
+		SynthDef(\test_get, {
+			|control = 8|
+		}).add;
+		s.sync;
+		set_value = 888;
+		node = Synth(\test_get, [control: set_value]);
+		s.sync;
 
-        get_value = 0;
-        node.get(\control, { |value|
-            get_value = value;
-        });
-        0.1.wait;
+		get_value = 0;
+		node.get(\control, { |value|
+			get_value = value;
+		});
+		0.1.wait;
 
-        this.assertFloatEquals(get_value, set_value, "Node:get works", 0.001);
-        node.free;
-    }
+		this.assertFloatEquals(get_value, set_value, "Node:get works", 0.001);
+		node.free;
+	}
 
-    test_getn {
-        var s, node, setn_values, getn_values;
-        this.bootServer;
-        s = this.s;
+	test_getn {
+		var s, node, setn_values, getn_values;
+		this.bootServer;
+		s = this.s;
 
-        SynthDef(\test_getn, {
-            |control1 = 2, control2 = 22.2, control3 = 222|
-        }).add;
-        s.sync;
-        setn_values = [888, 88.8, 8.88];
-        node = Synth(\test_getn, [
-            control1: setn_values[0],
-            control2: setn_values[1],
-            control3: setn_values[2]
-        ]);
-        s.sync;
+		SynthDef(\test_getn, {
+			|control1 = 2, control2 = 22.2, control3 = 222|
+		}).add;
+		s.sync;
+		setn_values = [888, 88.8, 8.88];
+		node = Synth(\test_getn, [
+			control1: setn_values[0],
+			control2: setn_values[1],
+			control3: setn_values[2]
+		]);
+		s.sync;
 
-        getn_values = 0;
-        node.getn(0, 3, { |values|
-            getn_values = values;
-        });
-        0.1.wait;
+		getn_values = 0;
+		node.getn(0, 3, { |values|
+			getn_values = values;
+		});
+		0.1.wait;
 
-        this.assertArrayFloatEquals(getn_values, setn_values, "Node:getn works", 0.001);
-        node.free;
-    }
+		this.assertArrayFloatEquals(getn_values, setn_values, "Node:getn works", 0.001);
+		node.free;
+	}
 
 }

--- a/testsuite/classlibrary/TestNode.sc
+++ b/testsuite/classlibrary/TestNode.sc
@@ -1,0 +1,53 @@
+TestNode : UnitTest {
+
+    test_get {
+        var s, node, set_value, get_value;
+        this.bootServer;
+        s = this.s;
+
+        SynthDef(\test_get, {
+            |control = 8|
+        }).add;
+        s.sync;
+        set_value = 888;
+        node = Synth(\test_get, [control: set_value]);
+        s.sync;
+
+        get_value = 0;
+        node.get(\control, { |value|
+            get_value = value;
+        });
+        0.1.wait;
+
+        this.assertFloatEquals(get_value, set_value, "Node:get works", 0.001);
+        node.free;
+    }
+
+    test_getn {
+        var s, node, setn_values, getn_values;
+        this.bootServer;
+        s = this.s;
+
+        SynthDef(\test_getn, {
+            |control1 = 2, control2 = 22.2, control3 = 222|
+        }).add;
+        s.sync;
+        setn_values = [888, 88.8, 8.88];
+        node = Synth(\test_getn, [
+            control1: setn_values[0],
+            control2: setn_values[1],
+            control3: setn_values[2]
+        ]);
+        s.sync;
+
+        getn_values = 0;
+        node.getn(0, 3, { |values|
+            getn_values = values;
+        });
+        0.1.wait;
+
+        this.assertArrayFloatEquals(getn_values, setn_values, "Node:getn works", 0.001);
+        node.free;
+    }
+
+}


### PR DESCRIPTION
Fix #2721. Removes uses of OSCpathResponder in Buffer, Bus, and Node. Unit tests are needed here.