### PR TITLE
class library: make server action *remove consistent with *add

### DIFF
--- a/HelpSource/Classes/AbstractServerAction.schelp
+++ b/HelpSource/Classes/AbstractServerAction.schelp
@@ -38,10 +38,10 @@ argument::object
 Can either be a link::Classes/Function:: to be evaluated (as first arg the server is passed in), or an link::Classes/Object:: that implements the message returned by link::#-functionSelector::. strong::One object is only registered once::, so that multiple additions don't cause multiple calls.
 
 argument::server
-Server for which to register. If the symbol strong::\default:: is passed in, the action is called for the current default server. If the symbol strong::\all:: is passed in, the action is called for all current servers. If server is nil, it is added to \default.
+Server for which to register. If the symbol strong::\default:: is passed in, the action is called for the current default server. If the symbol strong::\all:: is passed in, the action is called for all current servers. If server is nil, it is added to \all.
 
 method::remove
-Remove an item or object from registry. If server is nil, remove from strong::default:: key.
+Remove an item or object from registry. If server is nil, remove from strong::all:: key.
 
 method::removeServer
 Remove all items that are registered for a given server.

--- a/SCClassLibrary/Common/Control/SystemActions.sc
+++ b/SCClassLibrary/Common/Control/SystemActions.sc
@@ -162,7 +162,7 @@ AbstractServerAction : AbstractSystemAction {
 	}
 
 	*remove { arg object, server;
-		if(server.isNil) { server = \default };
+		if(server.isNil) { server = \all };
 		this.objects !? { this.objects.at(server).remove(object) };
 	}
 


### PR DESCRIPTION
When adding an object to a server action without telling what server is
meant, it adds to “all”. This should be the same for when removing an
object.

This fixes #2747.