### PR TITLE
Help: Add required standardizePath into Image:write example

### DIFF
--- a/HelpSource/Classes/Image.schelp
+++ b/HelpSource/Classes/Image.schelp
@@ -274,7 +274,7 @@ write the Image to a file.
 code::
 i = Image.new(SCDoc.helpSourceDir +/+ "images/Swamp.png");
 i.dump
-i.write("~/Desktop/my_image.png");
+i.write("~/Desktop/my_image.png".standardizePath);
 i.free;
 
 //	storeOn / asCompileString


### PR DESCRIPTION
PrimitiveFailedError without this