### PR TITLE
Fixed invalid .desktop file and added missing pattern to mime xml

### DIFF
--- a/editors/sc-ide/SuperColliderIDE.desktop
+++ b/editors/sc-ide/SuperColliderIDE.desktop
@@ -5,6 +5,5 @@ Exec=scide %F
 Icon=sc_ide
 Type=Application
 Terminal=false
-Patterns=*.scd;*.sc;*.schelp
-Categories=Application;Multimedia;Audio;AudioVideo
+Categories=AudioVideo;Audio;AudioVideoEditing;
 MimeType=text/x-sc;

--- a/platform/linux/supercollider.xml
+++ b/platform/linux/supercollider.xml
@@ -3,8 +3,10 @@
   <mime-type type="text/x-sc">
     <sub-class-of type="text/plain"/>
     <comment xml:lang="en">SuperCollider source code</comment>
+    <comment xml:lang="de">SuperCollider Quelltext</comment>
     <glob pattern="*.sc"/>
     <glob pattern="*.scd"/>
+    <glob pattern="*.schelp"/>
     <magic priority="30">
       <match value="/*" type="string" offset="0"/>
       <match value="//" type="string" offset="0"/>


### PR DESCRIPTION
When building for openSUSE I noticed that the .desktop file was considered invalid, this can be verified by using the command line tool: `desktop-file-validate`, this is now fixed.
I also added the missing pattern to the mime xml to correctly link sc files with the ide.