### PR TITLE
Allow setting LIB_SUFFIX variable to install libraries into lib64 etc

### DIFF
--- a/README_LINUX.md
+++ b/README_LINUX.md
@@ -147,6 +147,15 @@ builds in a specific build directory:
    $> cmake -DCMAKE_BUILD_TYPE=Release ..
    ```
 
+   In some situations it is preferable to install libraries and plugins
+   not in the `lib` directory but in a suffixed one, e.g. `lib64`.
+   In such a case you can set the cmake variable `LIB_SUFFIX`.
+   For example if you whish to install into `lib64`:
+
+   ```
+   $> cmake -DLIB_SUFFIX=64 ..
+   ```
+
  - to install the whole program, run:
 
    ```

--- a/editors/sced/CMakeLists.txt
+++ b/editors/sced/CMakeLists.txt
@@ -14,10 +14,10 @@ if(NOT WIN32 AND SC_ED EQUAL 2)
             DESTINATION share/gtksourceview-2.0/language-specs)
 
     install(FILES data/sced.gedit-plugin
-            DESTINATION lib/gedit-2/plugins)
+            DESTINATION lib${LIB_SUFFIX}/gedit-2/plugins)
 
     install(DIRECTORY sced
-            DESTINATION lib/gedit-2/plugins)
+            DESTINATION lib${LIB_SUFFIX}/gedit-2/plugins)
 
 elseif(NOT WIN32 AND SC_ED EQUAL 3)
 
@@ -29,7 +29,7 @@ elseif(NOT WIN32 AND SC_ED EQUAL 3)
             DESTINATION share/gtksourceview-3.0/language-specs)
 
     install(FILES ${CMAKE_CURRENT_BINARY_DIR}/sced3/supercollider.plugin sced3/supercollider.py
-            DESTINATION lib/gedit/plugins)
+            DESTINATION lib${LIB_SUFFIX}/gedit/plugins)
 
 elseif(WIN32)
 

--- a/server/plugins/CMakeLists.txt
+++ b/server/plugins/CMakeLists.txt
@@ -301,7 +301,7 @@ elseif(APPLE)
 
 else()
 	install(TARGETS ${plugins} ${supernova_plugins}
-			DESTINATION "lib/SuperCollider/plugins"
+			DESTINATION "lib${LIB_SUFFIX}/SuperCollider/plugins"
 			PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
 endif()
 

--- a/server/scsynth/CMakeLists.txt
+++ b/server/scsynth/CMakeLists.txt
@@ -150,7 +150,7 @@ elseif(NOT NO_LIBSNDFILE)
 endif(SNDFILE_FOUND)
 
 if(UNIX AND NOT APPLE)
-	target_compile_definitions(libscsynth PUBLIC "SC_PLUGIN_DIR=\"${CMAKE_INSTALL_PREFIX}/lib/SuperCollider/plugins\"")
+	target_compile_definitions(libscsynth PUBLIC "SC_PLUGIN_DIR=\"${CMAKE_INSTALL_PREFIX}/lib${LIB_SUFFIX}/SuperCollider/plugins\"")
 endif()
 
 
@@ -284,7 +284,7 @@ elseif(WIN32)
 else()
 	install(TARGETS ${INSTALL_TARGETS}
 			RUNTIME DESTINATION "bin"
-			LIBRARY DESTINATION "lib"
+			LIBRARY DESTINATION "lib${LIB_SUFFIX}"
 			PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
 endif()
 

--- a/server/supernova/server/main.cpp
+++ b/server/supernova/server/main.cpp
@@ -245,6 +245,7 @@ void set_plugin_paths(server_arguments const & args, nova::sc_ugen_factory * fac
         const path home = resolve_home();
         std::vector<path> folders = { "/usr/local/lib/SuperCollider/plugins",
                                       "/usr/lib/SuperCollider/plugins",
+                                      "/usr/lib64/SuperCollider/plugins",
                                       home / "/.local/share/SuperCollider/Extensions",
                                       home / "share/SuperCollider/plugins" };
 


### PR DESCRIPTION
Some distributions require native binaries / libraries to be install into a library directory with a suffix, e.g. the most common one is lib64.
With cmake a common way to solve this is to use the `LIB_SUFFIX` variable, even some buildsystem use this when building with cmake (e.g. openSUSE's and fedoras RPM buildsystems define this variable for cmake calls).