### PR TITLE
Windows: fix incorrectly escaped paths passed to shell

### DIFF
--- a/HelpSource/Classes/Platform.schelp
+++ b/HelpSource/Classes/Platform.schelp
@@ -74,6 +74,15 @@ platform recordings directory
 method:: defaultTempDir
 default directory for temporary files
 
+method:: formatPathForCmdLine
+
+argument:: path
+A path string.
+
+returns:: The input string formatted as a command-line argument. On Windows this
+method quotes the string. On Unix-based systems this method escapes space
+characters with a backslash.
+
 subsection:: Features
 
 method:: when

--- a/SCClassLibrary/Common/Quarks/Git.sc
+++ b/SCClassLibrary/Common/Quarks/Git.sc
@@ -12,7 +12,7 @@ Git {
 		this.git([
 			"clone",
 			url,
-			localPath.escapeChar($ )
+			thisProcess.platform.formatPathForCmdLine(localPath)
 		], false);
 		this.url = url;
 	}
@@ -114,7 +114,7 @@ Git {
 		var cmd, result="";
 
 		if(cd, {
-			cmd = ["cd", localPath.escapeChar($ ), "&&", "git"];
+			cmd = ["cd", thisProcess.platform.formatPathForCmdLine(localPath), "&&", "git"];
 		},{
 			cmd = ["git"];
 		});

--- a/SCClassLibrary/Platform/Platform.sc
+++ b/SCClassLibrary/Platform/Platform.sc
@@ -182,7 +182,9 @@ Platform {
 
 	// used to format paths correctly for command-line calls
 	// On Windows, encloses with quotes; on Unix systems, escapes spaces.
-	formatPathForCmdLine { ^this.subclassResponsibility }
+	formatPathForCmdLine { |path|
+		^this.subclassResponsibility
+	}
 
 }
 

--- a/SCClassLibrary/Platform/Platform.sc
+++ b/SCClassLibrary/Platform/Platform.sc
@@ -179,6 +179,11 @@ Platform {
 	killAll { |cmdLineArgs|
 		^this.subclassResponsibility(\killAll)
 	}
+
+	// used to format paths correctly for command-line calls
+	// On Windows, encloses with quotes; on Unix systems, escapes spaces.
+	formatPathForCmdLine { ^this.subclassResponsibility }
+
 }
 
 UnixPlatform : Platform {
@@ -214,4 +219,9 @@ UnixPlatform : Platform {
 			File.exists(path);
 		});
 	}
+
+	formatPathForCmdLine { |path|
+		^path.escapeChar($ );
+	}
+
 }

--- a/SCClassLibrary/Platform/windows/WindowsPlatform.sc
+++ b/SCClassLibrary/Platform/windows/WindowsPlatform.sc
@@ -49,4 +49,8 @@ WindowsPlatform : Platform {
 		_WinPlatform_myDocumentsDir
 		^this.primitiveFailed
 	}
+
+	formatPathForCmdLine { |path|
+		^path.quote;
+	}
 }


### PR DESCRIPTION
This PR adds a new function `Platform:-formatPathForCmdLine` that handles path formatting for command line calls across platforms. On Platform, it throws a subclass responsibility error. On WindowsPlatform, it quotes the string. On UnixPlatform, it escapes spaces.

The new function is used to solve an issue where bad paths are passed to the Windows shell in `Git.sc`—see https://github.com/supercollider/supercollider/pull/2722#issue-208840763 for details.

Hasn't been tested yet.