### PR TITLE
Classlib: Event:processRest needs to return itself

### DIFF
--- a/SCClassLibrary/Common/Streams/Rest.sc
+++ b/SCClassLibrary/Common/Streams/Rest.sc
@@ -49,6 +49,9 @@ Rest {
 	}
 }
 
++ Event {
+	processRest { ^this }
+}
 
 + SimpleNumber {
 	// Some patterns call .delta on the eventstream's yield value


### PR DESCRIPTION
I used to debug some Event issues like so:

```
(
Pbind(
    \degree, Pseq([0], 1)
).collect { |ev| thisThread.clock.sched(0, { ev.keys.debug }); ev }
.play;
)
```

So... the Pbind would return an event. Event:playAndDelta would play it. Then the scheduled function would wake up and have access to the work that Event:play did.

But tonight I find that the event instance passed into collect is not identical to the one that is played...? I inserted a "this.dump" into Event:play, and:

```
(
Pbind(
    \degree, Pseq([0], 1)
).collect { |ev| "collect:".debug; ev.dump; ev }
.play;
)
```

collect:
Instance of Event {    (0x6b2f0c8, gc=E0, fmt=00, flg=00, set=03) ...
Instance of Event {    (0x5347f48, gc=E4, fmt=00, flg=00, set=03) ...

So I managed to break a very useful technique by implementing Collection:processRest (which needed to be done).

TL;DR Let's please move ahead with the Rest redesign, because even *I* have had enough of this nonsense by now.