### PR TITLE
gitignore: ignore scratch files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,8 +16,9 @@ common/Packager/LinuxExclusions.txt
 common/Packager/SuperCollider*.tar.gz
 common/Packager/SuperCollider*.dmg
 
-#build directories
+# build directories
 /build*
 
 *~
 *.orig
+scratch*


### PR DESCRIPTION
just a little convenience. useful to keep notes, test files, etc. in the repo directory by prefixing their filename with "scratch".

[here's an example of another project that does this](https://github.com/nCoda/lychee/blob/main/.gitignore).
