### PR TITLE
rational numbers implementation

### DIFF
--- a/HelpSource/Classes/Rational.schelp
+++ b/HelpSource/Classes/Rational.schelp
@@ -86,7 +86,8 @@ Rational(5,7).squared // -> 25 %/ 49
 
 EXAMPLES::
 
-basic operations:
+Basic operations:
+
 code::
 a = Rational(3, 2); // a rational number
 b = 4%/5;  // // another rational number
@@ -104,6 +105,8 @@ b.max(2.32); // -> 2.32
 // force denominator to be less than 20:
 (4342%/3424).simplify(20); // -> 19 %/ 15
 
+SUBSECTION:: Sorting
+
 // sort Array of Rationals:
 d = [ 0 %/ 1, 3 %/ 5, -3 %/ 4, -1 %/ 5, 3 %/ 4, -2 %/ 3, 7 %/ 8, 1 %/ 1, -3 %/ 1, 1 %/ 6, 1 %/ 6, 7 %/ 8, -10 %/ 7, 0 %/ 1, 0 %/ 1, 5 %/ 3, 10 %/ 1, 3 %/ 5, 0 %/ 1, -2 %/ 7 ];
 
@@ -114,10 +117,30 @@ e = [1, 1.5, 3 %/ 5, 8 %/ 5, 1.342];
 e.sort;
 ::
 
+SUBSECTION:: Continued fractions
+
 Recursive function to calculate finite continued fractions:
 
 code::
 f = { |x| if(x == 0) { 2 } {  1 + Rational(1, 1 + f.(x-1))} };
 a = 10.collect({|i| f.(i)});
 a.asFloat;
+::
+
+
+SUBSECTION:: Conversions between Rational and Float
+
+Conversion between link::Classes/Float:: and Rational can have different degrees of precisions:
+
+code::
+pi; // 3.1415926535898
+a = pi.asRational(99999); // 208341 %/ 66317
+b = pi.asRational(999);   // 355 %/ 113
+c = pi.asRational(99);    // 22 %/ 7
+a.asFloat; // 3.1415926534674
+b.asFloat; // 3.141592920354
+c.asFloat; // 3.1428571428571
+pi.equalWithPrecision(a.asFloat, 0.000000001); // true
+pi.equalWithPrecision(b.asFloat, 0.00001);     // true
+pi.equalWithPrecision(c.asFloat, 0.01);        // true
 ::

--- a/HelpSource/Classes/Rational.schelp
+++ b/HelpSource/Classes/Rational.schelp
@@ -124,9 +124,10 @@ SUBSECTION:: Continued fractions
 Recursive function to calculate finite continued fractions:
 
 code::
-f = { |x| if(x == 0) { 2 } {  1 + Rational(1, 1 + f.(x-1))} };
-a = 10.collect({|i| f.(i)});
+f = { |x| if(x == 0) { 1 } {  1 + Rational(1, f.(x-1))} };
+a = 20.collect({|i| f.(i)});
 a.asFloat;
+a.plot;
 ::
 
 

--- a/HelpSource/Classes/Rational.schelp
+++ b/HelpSource/Classes/Rational.schelp
@@ -1,0 +1,120 @@
+CLASS:: Rational
+summary:: Rational number
+categories:: Math
+related:: Classes/SimpleNumber, Classes/Float, Classes/Integer
+
+DESCRIPTION::
+A rational number. Alternative syntax: code::x %/ y::
+
+note::
+Rational internally represents the numerator and the denominator as 64-bit link::Classes/Float::.
+::
+
+CLASSMETHODS::
+
+method:: new
+allocates a new Rational number.
+
+INSTANCEMETHODS::
+
+method:: +
+Addition
+code::
+Rational(3,2) + Rational(3,2) // -> 3 %/ 1
+(3 %/ 2) + (3 %/ 2) // -> 3 %/ 1
+::
+
+method:: -
+Subtraction
+code::
+Rational(6,5) - Rational(1,3) // -> 13 %/ 15
+(6 %/ 5) - (1 %/ 3) // -> 13 %/ 15
+::
+
+method:: *
+Multiplication
+code::
+Rational(3,7) + Rational(9,5) // -> 78 %/ 35
+(3 %/ 7) + (9 %/ 5) // -> 78 %/ 35
+::
+
+method:: -
+Division
+code::
+Rational(5,3) / Rational(7,5) // -> 25 %/ 21
+(5 %/ 3) + (7 %/ 5) // -> 25 %/ 21
+::
+
+method:: abs
+Absolute value.
+code::
+Rational(-5,4).abs // -> 5 %/ 4
+::
+
+method:: asFloat
+As link::Classes/Float::
+code::
+Rational(5,7).asFloat // -> 0.71428571428571
+::
+
+method:: pow
+code::
+Rational(1,2).pow(2)
+// same as:
+(1 %/ 2) ** 2 // -> 1 %/ 4
+
+Rational(4,5).pow(-4) // -> 625 %/ 256
+::
+
+method:: reciprocal
+Reciprocal
+code::
+Rational(5,7).reciprocal // -> 7 %/ 5
+::
+
+method:: squared
+Power of two
+code::
+Rational(5,7).squared // -> 25 %/ 49
+::
+
+EXAMPLES::
+
+basic operations:
+code::
+a = Rational(3, 2); // a rational number
+b = 4%/5;  // // another rational number
+c = (3%/(2%/5)); // continuous rational number
+
+a + b; // -> 23 %/ 10
+a - b; // -> 7 %/ 10
+a / b; // -> 15 %/ 8
+a * b; // -> 6 %/ 5
+a.pow(2); // -> 9 %/ 4
+
+a.min(b); // -> 4 %/ 5
+b.max(2.32); // -> 2.32
+
+// force denominator to be less than 20:
+(4342%/3424).simplify(20); // -> 19 %/ 15
+
+// sort Array of Rationals:
+d = [ 0 %/ 1, 3 %/ 5, -3 %/ 4, -1 %/ 5, 3 %/ 4, -2 %/ 3, 7 %/ 8, 1 %/ 1, -3 %/ 1, 1 %/ 6, 1 %/ 6, 7 %/ 8, -10 %/ 7, 0 %/ 1, 0 %/ 1, 5 %/ 3, 10 %/ 1, 3 %/ 5, 0 %/ 1, -2 %/ 7 ];
+
+d.sort;
+
+// sort Array with Floats and Rationals:
+e = [1, 1.5, 3 %/ 5, 8 %/ 5, 1.342];
+e.sort;
+
+::
+
+Also possible to convert Strings and other Numbers:
+
+code::
+"3/2".asRational; // -> 3 %/ 2
+
+1.5.asRational; // -> 3 %/ 2
+
+"3/2".asRational == 1.5.asRational; // true
+::

--- a/HelpSource/Classes/Rational.schelp
+++ b/HelpSource/Classes/Rational.schelp
@@ -40,8 +40,8 @@ Rational(6,5) - Rational(1,3) // -> 13 %/ 15
 method:: *
 Multiplication
 code::
-Rational(3,7) + Rational(9,5) // -> 78 %/ 35
-(3 %/ 7) + (9 %/ 5) // -> 78 %/ 35
+Rational(3,7) * Rational(9,5) // -> 27 %/ 35
+(3 %/ 7) * (9 %/ 5) // -> 27 %/ 35
 ::
 
 method:: /

--- a/HelpSource/Classes/Rational.schelp
+++ b/HelpSource/Classes/Rational.schelp
@@ -44,7 +44,7 @@ Rational(3,7) + Rational(9,5) // -> 78 %/ 35
 (3 %/ 7) + (9 %/ 5) // -> 78 %/ 35
 ::
 
-method:: -
+method:: /
 Division
 code::
 Rational(5,3) / Rational(7,5) // -> 25 %/ 21

--- a/HelpSource/Classes/Rational.schelp
+++ b/HelpSource/Classes/Rational.schelp
@@ -7,13 +7,13 @@ DESCRIPTION::
 A rational number. Alternative syntax: code::x %/ y::
 
 note::
-Operations with link::Classes/Rational:: can be one order of magnitude slower then link::Classes/Float::. Rational internally represents numerator and denominator as 64-bit link::Classes::
+Operations with link::Classes/Rational:: can be one order of magnitude slower than link::Classes/Float::. Rational internally represents numerator and denominator as 64-bit link::Classes/Float::s
 ::
 
 CLASSMETHODS::
 
 method:: new
-Allocates a new Rational number. Rational also accepts Floats and Strings. It will reduce to its lower terms.
+Rational also accepts Floats and Strings in its code::new:: instantiation method. This class will always reduce a rational expression to its lowest terms (e.g. code::3 %/ 2:: instead of code::6 %/ 4::).
 
 code::
 Rational(6,4) // -> 3 %/ 2

--- a/HelpSource/Classes/Rational.schelp
+++ b/HelpSource/Classes/Rational.schelp
@@ -112,15 +112,12 @@ d.sort;
 // sort Array with Floats and Rationals:
 e = [1, 1.5, 3 %/ 5, 8 %/ 5, 1.342];
 e.sort;
-
 ::
 
-Also possible to convert Strings and other Numbers:
+Recursive function to calculate finite continued fractions:
 
 code::
-"3/2".asRational; // -> 3 %/ 2
-
-1.5.asRational; // -> 3 %/ 2
-
-"3/2".asRational == 1.5.asRational; // true
+f = { |x| if(x == 0) { 2 } {  1 + Rational(1, 1 + f.(x-1))} };
+a = 10.collect({|i| f.(i)});
+a.asFloat;
 ::

--- a/HelpSource/Classes/Rational.schelp
+++ b/HelpSource/Classes/Rational.schelp
@@ -7,13 +7,19 @@ DESCRIPTION::
 A rational number. Alternative syntax: code::x %/ y::
 
 note::
-Rational internally represents the numerator and the denominator as 64-bit link::Classes/Float::.
+Operations with link::Classes/Rational:: can be one order of magnitude slower then link::Classes/Float::. Rational internally represents numerator and denominator as 64-bit link::Classes::
 ::
 
 CLASSMETHODS::
 
 method:: new
-allocates a new Rational number.
+Allocates a new Rational number. Rational also accepts Floats and Strings. It will reduce to its lower terms.
+
+code::
+Rational(6,4) // -> 3 %/ 2
+Rational("8/4") // -> 2 %/ 1
+Rational(0.33333) // -> 1 %/ 3
+::
 
 INSTANCEMETHODS::
 

--- a/HelpSource/Classes/Rational.schelp
+++ b/HelpSource/Classes/Rational.schelp
@@ -104,9 +104,11 @@ b.max(2.32); // -> 2.32
 
 // force denominator to be less than 20:
 (4342%/3424).simplify(20); // -> 19 %/ 15
+::
 
 SUBSECTION:: Sorting
 
+code::
 // sort Array of Rationals:
 d = [ 0 %/ 1, 3 %/ 5, -3 %/ 4, -1 %/ 5, 3 %/ 4, -2 %/ 3, 7 %/ 8, 1 %/ 1, -3 %/ 1, 1 %/ 6, 1 %/ 6, 7 %/ 8, -10 %/ 7, 0 %/ 1, 0 %/ 1, 5 %/ 3, 10 %/ 1, 3 %/ 5, 0 %/ 1, -2 %/ 7 ];
 
@@ -128,9 +130,9 @@ a.asFloat;
 ::
 
 
-SUBSECTION:: Conversions between Rational and Float
+SUBSECTION:: Conversion between Rational and Float
 
-Conversion between link::Classes/Float:: and Rational can have different degrees of precisions:
+Conversion between link::Classes/Float:: and Rational can have different degrees of precision:
 
 code::
 pi; // 3.1415926535898

--- a/HelpSource/Classes/Rational.schelp
+++ b/HelpSource/Classes/Rational.schelp
@@ -26,6 +26,12 @@ Rational(0.33333) // -> 1 %/ 3
 
 INSTANCEMETHODS::
 
+method:: %/
+Alternative syntax for code::Rational(x,y)::
+code::
+5 %/ 7 == Rational(5,7) // -> true
+::
+
 method:: +
 Addition
 code::
@@ -109,15 +115,25 @@ b.max(2.32); // -> 2.32
 (4342%/3424).simplify(20); // -> 19 %/ 15
 ::
 
+
+SUBSECTION:: Comparisons
+
+code::
+(7 %/ 3) >  (2 %/ 1) // -> true
+(6 %/ 4) <  (3 %/ 2) // -> false
+(5 %/ 5) == (4 %/ 3) // -> false
+(4 %/ 6) <= (5 %/ 4) // -> true
+(3 %/ 7) >= (6 %/ 5) // -> false
+::
+
 SUBSECTION:: Sorting
 
 code::
-// sort Array of Rationals:
 d = [ 0 %/ 1, 3 %/ 5, -3 %/ 4, -1 %/ 5, 3 %/ 4, -2 %/ 3, 7 %/ 8, 1 %/ 1, -3 %/ 1, 1 %/ 6, 1 %/ 6, 7 %/ 8, -10 %/ 7, 0 %/ 1, 0 %/ 1, 5 %/ 3, 10 %/ 1, 3 %/ 5, 0 %/ 1, -2 %/ 7 ];
 
 d.sort;
 
-// sort Array with Floats and Rationals:
+// sort an Array with Floats and Rationals:
 e = [1, 1.5, 3 %/ 5, 8 %/ 5, 1.342];
 e.sort;
 ::
@@ -149,3 +165,4 @@ pi.equalWithPrecision(a.asFloat, 0.000000001); // true
 pi.equalWithPrecision(b.asFloat, 0.00001);     // true
 pi.equalWithPrecision(c.asFloat, 0.01);        // true
 ::
+

--- a/HelpSource/Classes/Rational.schelp
+++ b/HelpSource/Classes/Rational.schelp
@@ -7,7 +7,10 @@ DESCRIPTION::
 A rational number. Alternative syntax: code::x %/ y::
 
 note::
-Operations with link::Classes/Rational:: can be one order of magnitude slower than link::Classes/Float::. Rational internally represents numerator and denominator as 64-bit link::Classes/Float::s
+LIST::
+## Operations with code::Rational:: can be one order of magnitude slower compared to link::Classes/Float::.
+## code::Rational:: internally represents numerator and denominator as 64-bit link::Classes/Float::s. If you want to initialize it with a term outside the range code::-2147483648:: to code::2147483647:: you will need to force the number to be a Float by adding a decimal zero, e.g. code::-2147483649.0:: and code::2147483648.0::.
+::
 ::
 
 CLASSMETHODS::
@@ -126,7 +129,6 @@ Recursive function to calculate finite continued fractions:
 code::
 f = { |x| if(x == 0) { 1 } {  1 + Rational(1, f.(x-1))} };
 a = 20.collect({|i| f.(i)});
-a.asFloat;
 a.plot;
 ::
 

--- a/HelpSource/Classes/Rational.schelp
+++ b/HelpSource/Classes/Rational.schelp
@@ -90,7 +90,7 @@ basic operations:
 code::
 a = Rational(3, 2); // a rational number
 b = 4%/5;  // // another rational number
-c = (3%/(2%/5)); // continuous rational number
+c = 1 %/ (1 + (1 %/ (1 + (1 %/ 2)))); // -> 3 %/ 5
 
 a + b; // -> 23 %/ 10
 a - b; // -> 7 %/ 10

--- a/SCClassLibrary/Common/Collections/SequenceableCollection.sc
+++ b/SCClassLibrary/Common/Collections/SequenceableCollection.sc
@@ -1301,6 +1301,15 @@ SequenceableCollection : Collection {
 	// we break up the array so that missing elements are set to nil in the Quant
 	asQuant { ^Quant(*this) }
 
+	// Rational support
+	asRational { arg maxDenominator = 100;
+		if (this.size == 2 and: this[0].isKindOf(Integer) and: this[1].isKindOf(Integer)) {
+			^Rational(this[0], this[1])
+		} {
+			^this.collect { |i| i.asRational(maxDenominator) }
+		};
+	}
+
 //	asUGenInput { ^this.asArray.asUGenInput }
 
 	schedBundleArrayOnClock { |clock, bundleArray, lag = 0, server, latency|

--- a/SCClassLibrary/Common/Collections/SequenceableCollection.sc
+++ b/SCClassLibrary/Common/Collections/SequenceableCollection.sc
@@ -1303,11 +1303,7 @@ SequenceableCollection : Collection {
 
 	// Rational support
 	asRational { arg maxDenominator = 100;
-		if (this.size == 2 and: this[0].isKindOf(Integer) and: this[1].isKindOf(Integer)) {
-			^Rational(this[0], this[1])
-		} {
-			^this.collect { |i| i.asRational(maxDenominator) }
-		};
+		^this.collect { |i| i.asRational(maxDenominator) }
 	}
 
 //	asUGenInput { ^this.asArray.asUGenInput }

--- a/SCClassLibrary/Common/Collections/String.sc
+++ b/SCClassLibrary/Common/Collections/String.sc
@@ -529,4 +529,7 @@ String[char] : RawArray {
 		^this.primitiveFailed
 	}
 
+	asRational {
+		^Rational(this.split[0].asInteger, this.split[1].asInteger)
+	}
 }

--- a/SCClassLibrary/Common/Collections/String.sc
+++ b/SCClassLibrary/Common/Collections/String.sc
@@ -530,6 +530,7 @@ String[char] : RawArray {
 	}
 
 	asRational {
-		^Rational(this.split[0].asInteger, this.split[1].asInteger)
+		var stringArray = this.split($/ );
+		^Rational(stringArray[0].asInteger, stringArray[1].asInteger)
 	}
 }

--- a/SCClassLibrary/Common/Collections/String.sc
+++ b/SCClassLibrary/Common/Collections/String.sc
@@ -531,6 +531,6 @@ String[char] : RawArray {
 
 	asRational {
 		var stringArray = this.split($/ );
-		^Rational(stringArray[0].asInteger, stringArray[1].asInteger)
+		^Rational(stringArray[0].asFloat, stringArray[1].asFloat)
 	}
 }

--- a/SCClassLibrary/Common/Core/AbstractFunction.sc
+++ b/SCClassLibrary/Common/Core/AbstractFunction.sc
@@ -25,6 +25,9 @@ AbstractFunction {
 	performBinaryOpOnComplex { arg aSelector, aComplex, adverb;
 		^this.reverseComposeBinaryOp(aSelector, aComplex, adverb)
 	}
+	performBinaryOpOnRational { arg aSelector, aRational, adverb;
+		^this.reverseComposeBinaryOp(aSelector, aRational, adverb)
+	}
 	performBinaryOpOnSeqColl { arg aSelector, aSeqColl, adverb;
 		^this.reverseComposeBinaryOp(aSelector, aSeqColl, adverb)
 	}

--- a/SCClassLibrary/Common/Core/Object.sc
+++ b/SCClassLibrary/Common/Core/Object.sc
@@ -638,6 +638,9 @@ Object  {
 	performBinaryOpOnUGen { arg aSelector, thing, adverb;
 		^this.performBinaryOpOnSomething(aSelector, thing, adverb)
 	}
+	performBinaryOpOnRational { arg aSelector, thing, adverb;
+		^this.performBinaryOpOnSomething(aSelector, thing, adverb)
+    }
 
 	writeDefFile { arg name, dir, overwrite = (true);
 

--- a/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
+++ b/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
@@ -742,8 +742,8 @@ Plotter {
 			} {
 				elem
 			}
+			if (elem.isKindOf(Rational)) { elem.asFloat } { elem };
 		};
-		if (elem.isKindOf(Rational)) { elem.asFloat } { elem };
 		plotter.setValue(
 			array,
 			findSpecs: true,

--- a/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
+++ b/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
@@ -741,7 +741,7 @@ Plotter {
 				elem.asMultichannelSignal.flop
 			} {
 				elem
-			}
+			};
 			if (elem.isKindOf(Rational)) { elem.asFloat } { elem };
 		};
 		plotter.setValue(

--- a/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
+++ b/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
@@ -743,6 +743,7 @@ Plotter {
 				elem
 			}
 		};
+		if (elem.isKindOf(Rational)) { elem.asFloat } { elem };
 		plotter.setValue(
 			array,
 			findSpecs: true,

--- a/SCClassLibrary/Common/Math/Number.sc
+++ b/SCClassLibrary/Common/Math/Number.sc
@@ -26,6 +26,11 @@ Number : Magnitude {
 	real { ^this }
 	imag { ^0.0 }
 
+	//rational
+	numerator { ^this}
+	denominator { ^1}
+	rational { arg denominator=1; ^Rational(this, denominator) }
+	
 	// conversion
 	@ { arg aNumber; ^Point.new(this, aNumber) }
 	complex { arg imaginaryPart; ^Complex.new(this, imaginaryPart) }

--- a/SCClassLibrary/Common/Math/Rational.sc
+++ b/SCClassLibrary/Common/Math/Rational.sc
@@ -13,7 +13,7 @@ Rational : Number {
 
 	reduce {
 		var d;
-		if (denominator == 0) {"Rational has zero denominator".error};
+		if (denominator == 0) {"Rational has zero denominator".error; ^inf};
 		d = this.factor;
 		numerator   = (this.numerator/d).abs * d.sign;
 		denominator = (this.denominator/d).abs;
@@ -92,19 +92,25 @@ Rational : Number {
 		^((this.numerator * aNumber.denominator) != (this.denominator * aNumber.numerator))
 	}
 
-	pow { arg aNumber;
+	pow { arg n;
+
+        if (n.isInteger.not) {"Exponent is not Integer".error};
+
 		^case
-		{ aNumber == 0 }
-		{ (1.as(this.species)) }
+		{ n == 0 } { Rational(1,1) }
 
-
-		{ aNumber > 0  }
-		{ (this.species.new(this.numerator.pow(aNumber.asFloat), this.denominator.pow(aNumber.asFloat))) }
-
-		{ aNumber < 0  }
-		{
+		// if n is a for non-negative integer
+		{ n > 0 } {
+			this.class.new(
+				this.numerator.pow(n),
+				this.denominator.pow(n)
+			)
+		}
+		// if n is negative integer
+		{ n < 0  } {
+			// if numerator ≠ 0
 			if((this.numerator == 0).not) {
-				this.reciprocal.pow(aNumber.abs)
+				this.reciprocal.pow(n.abs)
 			} {
 				"Rational has zero denominator".error;
 			}
@@ -132,11 +138,18 @@ Rational : Number {
 	}
 
 	isNegative { ^this.numerator.isNegative }
+
 	isPositive { ^this.numerator.isPositive }
+
 	neg { ^(this * (-1)) }
-	sqrt { ^this.pow(this.class.new(1,2)) }
+
+	// sqrt { ^this.pow(this.class.new(1,2)) }
+
 	squared { ^this.pow(this.class.new(2,1)) }
+
 	cubed { ^this.pow(this.class.new(3,1)) }
+
 	abs { ^this.class.new(numerator.abs, denominator) }
+
 }
 

--- a/SCClassLibrary/Common/Math/Rational.sc
+++ b/SCClassLibrary/Common/Math/Rational.sc
@@ -26,7 +26,7 @@ Rational : Number {
 	}
 
 	factor {
-		var d = gcd(this.numerator.asInteger, this.denominator.asInteger);
+		var d = gcd(this.numerator.asInteger, this.denominator.asInteger).abs;
 		if (denominator < 0) { d = d.neg };
 		if (numerator   < 0) { d = d.neg };
 		^d

--- a/SCClassLibrary/Common/Math/Rational.sc
+++ b/SCClassLibrary/Common/Math/Rational.sc
@@ -13,7 +13,7 @@ Rational : Number {
 
 	reduce {
 		var d;
-		if (denominator == 0) {"Rational has zero denominator".error; ^inf};
+		if (denominator == 0) {"Rational has zero denominator".error};
 		d = this.factor;
 		numerator   = (this.numerator/d).abs * d.sign;
 		denominator = (this.denominator/d).abs;
@@ -106,7 +106,7 @@ Rational : Number {
 			if((this.numerator == 0).not) {
 				this.reciprocal.pow(aNumber.abs)
 			} {
-				"Rational has zero denominator".error; inf
+				"Rational has zero denominator".error;
 			}
 		}
 	}
@@ -131,25 +131,12 @@ Rational : Number {
 		^(this.numerator * aNumber.denominator) >= (this.denominator * aNumber.numerator)
 	}
 
-	isNegative {
-		^this.numerator.isNegative
-	}
-
-	isPositive {
-		^this.numerator.isPositive
-	}
-
-	neg {
-		^(this * (-1))
-	}
-
-	sqrt { ^this.pow(this.species.new(1,2)) }
-
-	squared { ^this.pow(this.species.new(2,1)) }
-
-	cubed { ^this.pow(this.species.new(3,1)) }
-
+	isNegative { ^this.numerator.isNegative }
+	isPositive { ^this.numerator.isPositive }
+	neg { ^(this * (-1)) }
+	sqrt { ^this.pow(this.class.new(1,2)) }
+	squared { ^this.pow(this.class.new(2,1)) }
+	cubed { ^this.pow(this.class.new(3,1)) }
 	abs { ^this.class.new(numerator.abs, denominator) }
-
 }
-										
+

--- a/SCClassLibrary/Common/Math/Rational.sc
+++ b/SCClassLibrary/Common/Math/Rational.sc
@@ -141,13 +141,13 @@ Rational : Number {
 
 	isPositive { ^this.numerator.isPositive }
 
-	neg { ^(this * (-1)) }
+	neg { ^this.class.new(numerator.neg,denominator)}
 
 	// sqrt { ^this.pow(this.class.new(1,2)) }
 
-	squared { ^this.pow(this.class.new(2,1)) }
+	squared { ^this.pow(2) }
 
-	cubed { ^this.pow(this.class.new(3,1)) }
+	cubed { ^this.pow(3) }
 
 	abs { ^this.class.new(numerator.abs, denominator) }
 

--- a/SCClassLibrary/Common/Math/Rational.sc
+++ b/SCClassLibrary/Common/Math/Rational.sc
@@ -7,23 +7,25 @@ Rational : Number {
 
 	reduce {
 		var d;
-		if (this.numerator.isKindOf(Number)) {
-			if (this.numerator.isKindOf(Rational) || this.denominator.isKindOf(Rational)){
-				^(numerator.asRational / denominator.asRational)
-			};
-			if (this.numerator.frac == 0 && this.denominator.frac == 0) {
-				d = this.factor;
-				numerator   = ((this.numerator/d).abs * d.sign).round;
-				denominator = (this.denominator/d).abs.round;
-				if (denominator == 0) {"Rational has zero denominator".error};
-			} {
-				^(this.numerator / this.denominator).asRational
-			}
-		} {
-			if (this.numerator.isKindOf(String)) {
-				^this.numerator.asRational
-			}
-		}
+        if (this.numerator.isKindOf(Number)) {
+
+            if (this.numerator.isKindOf(Rational) || this.denominator.isKindOf(Rational)){
+                ^(numerator.asRational / denominator.asRational)
+            };
+
+            if (this.numerator.frac == 0 && this.denominator.frac == 0) {
+                d = this.factor;
+                if (denominator == 0) {"Rational has zero denominator".error;^inf};
+                numerator   = ((this.numerator/d).abs * d.sign).round;
+                denominator = (this.denominator/d).abs.round;
+            } {
+                ^(this.numerator / this.denominator).asRational
+            }
+        } {
+            if (this.numerator.isKindOf(String)) {
+                ^this.numerator.asRational
+            }
+        }
 	}
 
 	factor {
@@ -34,7 +36,7 @@ Rational : Number {
 	}
 
 	reduceNestedRationals {
-		^if(numerator.isRational or: {denominator.isRational}) {
+        ^if(numerator.isRational or: {denominator.isRational}) {
 			(numerator.asRational / denominator.asRational)
 		};
 	}
@@ -55,7 +57,7 @@ Rational : Number {
 
 	asRational { ^this }
 
-	asFloat { ^this.numerator / this.denominator }
+    asFloat { ^(this.numerator / this.denominator).asFloat }
 
 	asInteger { ^(this.numerator / this.denominator).asInteger }
 
@@ -64,7 +66,7 @@ Rational : Number {
 	reciprocal { ^Rational(this.denominator, this.numerator) }
 
 	// printOn { arg stream;
-	//	stream << "Rational( " << numerator << ", " << denominator << " )";
+	// 	stream << "Rational( " << numerator << ", " << denominator << " )";
 	// }
 
 	printOn { arg stream;
@@ -107,7 +109,7 @@ Rational : Number {
 
 	pow { arg n;
 
-		if (n.isInteger.not) {"Exponent is not Integer".error};
+        /*if (n.isInteger.not) {"Exponent is not Integer".error};*/
 
 		^case
 		{ n == 0 } { Rational(1,1) }
@@ -132,8 +134,8 @@ Rational : Number {
 
 
 
-	simplify { arg maxDenominator=20;
-		^this.asFloat.asRational(maxDenominator)
+	simplify { arg maxDenominator=20, fasterBetter=false;
+		^this.asFloat.asRational(maxDenominator,fasterBetter)
 	}
 
 	< { arg aNumber;
@@ -152,22 +154,16 @@ Rational : Number {
 		^(this.numerator * aNumber.denominator) >= (this.denominator * aNumber.numerator)
 	}
 
-	isNegative {
-		^this.numerator.isNegative
-	}
+	isNegative { ^this.numerator.isNegative}
 
-	isPositive {
-		^this.numerator.isPositive
-	}
+	isPositive { ^this.numerator.isPositive }
 
-	neg {
-		^(this * (-1))
-	}
+	neg { ^(this * (-1)) }
 
 	squared { ^this.pow(2) }
 
 	cubed { ^this.pow(3) }
 
-	abs { ^this.class.new(numerator.abs, denominator) }
-}
+    abs { ^this.class.new(numerator.abs, denominator) }
 
+}

--- a/SCClassLibrary/Common/Math/Rational.sc
+++ b/SCClassLibrary/Common/Math/Rational.sc
@@ -149,7 +149,7 @@ Rational : Number {
 
 	cubed { ^this.pow(this.species.new(3,1)) }
 
-	abs { ^this.species.new(this.numerator.abs.asInteger, this.denominator.abs.asInteger) }
+	abs { ^this.class.new(numerator.abs, denominator) }
 
 }
 										

--- a/SCClassLibrary/Common/Math/Rational.sc
+++ b/SCClassLibrary/Common/Math/Rational.sc
@@ -1,189 +1,155 @@
 Rational : Number {
-	var <>numerator, <>denominator;
+	var <numerator, <denominator;
 
-	*new { arg numerator, denominator = 1;
-		^super.new.initRational(numerator, denominator);
+	*new {  arg numerator, denominator;
+		^super.newCopyArgs(numerator, denominator).reduce
 	}
 
-	*newFromString { arg thisString;
-		^thisString.asRational;
+	*newFrom { arg that; ^that.asRational }
+
+	numerator_ { arg newNum; numerator = newNum; this.reduce }
+
+	denominator_ { arg newDen; denominator = newDen; this.reduce }
+
+	reduce {
+		var d;
+		if (denominator == 0) {"Rational has zero denominator".error; ^inf};
+		d = this.factor;
+		numerator   = (this.numerator/d).abs * d.sign;
+		denominator = (this.denominator/d).abs;
 	}
 
-	initRational { arg thisNumerator, thisDenominator;
-		var factor;
-		if(thisNumerator.isString) {
-			^thisNumerator.asRational
-		} {
-			if(thisNumerator.isKindOf(Rational) or: thisDenominator.isKindOf(Rational)) {
-				^(thisNumerator.asRational / thisDenominator.asRational)
-			} {
-				if(thisNumerator.frac == 0 and: thisDenominator.frac == 0) {
-					if(thisDenominator == 0) {
-						this.numerator_(0);
-						this.denominator_(0);
-					} {
-						factor = gcd(thisNumerator.abs.asInteger, thisDenominator.abs.asInteger);
-						(thisDenominator < 0).if({factor = factor.neg});
-						(thisNumerator   < 0).if({factor = factor.neg});
-						this.numerator_((((thisNumerator/factor).abs) * factor.sign).asInteger);
-						this.denominator_((thisDenominator/factor).abs.asInteger);
-					};
-				} {
-					^(thisNumerator / thisDenominator).asRational
-				};
-			};
+	reduceNestedRationals {
+		^if(numerator.isRational or: denominator.isRational) {
+			(numerator.asRational / denominator.asRational)
 		};
 	}
-	
+
+	factor {
+		var d = gcd(this.numerator.asInteger, this.denominator.asInteger);
+		if (denominator < 0) { d = d.neg };
+		if (numerator   < 0) { d = d.neg };
+		^d
+	}
+
 	performBinaryOpOnSimpleNumber { arg aSelector, aNumber, adverb;
 		^aNumber.asRational.perform(aSelector, this, adverb)
 	}
-	
+
 	isRational { ^true }
-	
+
 	%/ { arg aNumber; ^Rational(this, aNumber) }
-	
+
 	asRational { ^this }
-	
-	as { arg aSimilarClass; ^aSimilarClass.new(this.numerator, this.denominator) }
-	
-	asArray { ^[this.numerator, this.denominator]}
-	
-	asFloat { ^(this.numerator / this.denominator)}
-	
-	asInteger { ^((this.numerator / this.denominator).asInteger) }
-	
+
+	asFloat { ^this.numerator / this.denominator }
+
+	asInteger { ^(this.numerator / this.denominator).asInteger }
+
 	asInt { ^this.asInteger }
-	
+
 	reciprocal { ^Rational(this.denominator, this.numerator) }
-	
+
+	// printOn { arg stream;
+	//	stream << "Rational( " << numerator << ", " << denominator << " )";
+	// }
+
 	printOn { arg stream;
-		stream << "Rational( " << numerator << ", " << denominator << " )";
+		stream <<  numerator << " %/ " << denominator;
 	}
-	
-	hash { ^numerator.hash << 2 bitXor: denominator.hash } 
-	
+
+	hash { ^this.instVarHash }
+
 	+ { arg aNumber, adverb;
-		if(aNumber.isNumber) {
-			^this.species.new(
-				(this.numerator * aNumber.denominator) + (this.denominator * aNumber.numerator),
-				this.denominator * aNumber.denominator)
-		} {
-			^aNumber.performBinaryOpOnRational('+', this, adverb)
-		};
+		^this.class.new(
+			(this.numerator * aNumber.denominator) + (this.denominator * aNumber.numerator),
+			this.denominator * aNumber.denominator)
 	}
-	
+
 	- { arg aNumber, adverb;
-		if(aNumber.isKindOf(Rational)) {
-			^this.species.new(
-				(this.numerator * aNumber.denominator) - (this.denominator * aNumber.numerator),
-				this.denominator * aNumber.denominator )
-		}  {
-			^aNumber.performBinaryOpOnRational('-', this, adverb)
-		};	
+		^this.class.new(
+			(this.numerator * aNumber.denominator) - (this.denominator * aNumber.numerator),
+			this.denominator * aNumber.denominator )
 	}
-	
+
 	* { arg aNumber, adverb;
-		if(aNumber.isKindOf(Rational)) {
-			^this.species.new(
-				this.numerator * aNumber.numerator,
-				this.denominator * aNumber.denominator)
-		} {
-			^aNumber.performBinaryOpOnRational('*', this, adverb)
-		};
+		^this.class.new(
+			this.numerator * aNumber.numerator,
+			this.denominator * aNumber.denominator)
 	}
-	
-	
+
 	/ { arg aNumber, adverb;
-		if(aNumber.isKindOf(Rational)) {
-			^this.species.new(
-				this.numerator * aNumber.denominator,
-				this.denominator * aNumber.numerator )
-		} {
-			^aNumber.performBinaryOpOnRational('/', this, adverb)
+		^this.class.new(
+			this.numerator * aNumber.denominator,
+			this.denominator * aNumber.numerator )
+	}
+
+	== { arg aNumber, adverb;
+		^((this.numerator * aNumber.denominator) == (this.denominator * aNumber.numerator))
+	}
+
+	!= { arg aNumber, adverb;
+		^((this.numerator * aNumber.denominator) != (this.denominator * aNumber.numerator))
+	}
+
+	pow { arg aNumber;
+		^case
+		{ aNumber == 0 }
+		{ (1.as(this.species)) }
+
+
+		{ aNumber > 0  }
+		{ (this.species.new(this.numerator.pow(aNumber.asFloat), this.denominator.pow(aNumber.asFloat))) }
+
+		{ aNumber < 0  }
+		{
+			if((this.numerator == 0).not) {
+				this.reciprocal.pow(aNumber.abs)
+			} {
+				"Rational has zero denominator".error; inf
+			}
 		}
 	}
-	
-	== { arg aNumber, adverb;
-		if(aNumber.isKindOf(Rational)) {
-			^((this.numerator * aNumber.denominator) == (this.denominator * aNumber.numerator))
-		} {
-			^aNumber.performBinaryOpOnRational('==', this, adverb)
-		}	
-	}
-	
-	!= { arg aNumber, adverb;
-		if(aNumber.isKindOf(Rational)) {
-			^((this.numerator * aNumber.denominator) != (this.denominator * aNumber.numerator))
-		} {
-			^aNumber.performBinaryOpOnRational('!=', this, adverb)
-		}	
-	}
-	
-	pow { arg aNumber;
-		case
-		{ aNumber == 0 } { ^(1.as(this.species)) }
-		{ aNumber > 0  } { ^(this.species.new(this.numerator.pow(aNumber.asFloat), this.denominator.pow(aNumber.asFloat))) }
-		{ aNumber < 0  } {
-			if((this.numerator == 0).not) {
-				^this.reciprocal.pow(aNumber.abs)
-			} {
-				"Numerator can't be 0".error;
-			};
-		};
-	}
-	
+
 	simplify { arg maxDenominator=20;
 		^this.asFloat.asRational(maxDenominator)
 	}
-	
+
 	< { arg aNumber;
-		^(this.asFloat < aNumber.asFloat)
+		^(this.numerator * aNumber.denominator) < (this.denominator * aNumber.numerator)
 	}
-	
+
 	> { arg aNumber;
-		^(this.asFloat > aNumber.asFloat)
+		^(this.numerator * aNumber.denominator) > (this.denominator * aNumber.numerator)
 	}
-	
+
 	<= { arg aNumber;
-		^(this.asFloat <= aNumber.asFloat)
+		^(this.numerator * aNumber.denominator) <= (this.denominator * aNumber.numerator)
 	}
-	
+
 	>= { arg aNumber;
-		^(this.asFloat >= aNumber.asFloat)
+		^(this.numerator * aNumber.denominator) >= (this.denominator * aNumber.numerator)
 	}
-	
+
 	isNegative {
 		^this.numerator.isNegative
 	}
-	
+
 	isPositive {
 		^this.numerator.isPositive
 	}
-	
+
 	neg {
 		^(this * (-1))
 	}
-	
-	max { arg aNumber;
-		var rationalArray, floatArray;
-		rationalArray = [this, aNumber];
-		floatArray = rationalArray.asFloat;
-		^rationalArray.at(floatArray.indexOf(floatArray.max));
-	}
-	
-	min { arg aNumber;
-		var rationalArray, floatArray;
-		rationalArray = [this, aNumber];
-		floatArray = rationalArray.asFloat;
-		^rationalArray.at(floatArray.indexOf(floatArray.min));
-	}
-	
+
 	sqrt { ^this.pow(this.species.new(1,2)) }
 
 	squared { ^this.pow(this.species.new(2,1)) }
 
 	cubed { ^this.pow(this.species.new(3,1)) }
 
-	abs { ^this.species.new(this.numerator.abs.asInteger, this.denominator) }
+	abs { ^this.species.new(this.numerator.abs.asInteger, this.denominator.abs.asInteger) }
+
 }
+										

--- a/SCClassLibrary/Common/Math/Rational.sc
+++ b/SCClassLibrary/Common/Math/Rational.sc
@@ -7,51 +7,41 @@ Rational : Number {
 
 	reduce {
 		var d;
-        if (this.numerator.isKindOf(Number)) {
-
-            if (this.numerator.isKindOf(Rational) || this.denominator.isKindOf(Rational)){
-                ^(numerator.asRational / denominator.asRational)
-            };
-
-            if (this.numerator.frac == 0 && this.denominator.frac == 0) {
-
-                if (denominator == 0) {
-                    if (numerator == 0) {
-                        "Rational has zero denominator".error;^0/0
-                    }{
-                        "Rational has zero denominator".error;^inf
-                    }
-                };
-
-                d = this.factor;
-                numerator = ((this.numerator/d).abs * d.sign).round;
-                denominator = (this.denominator/d).abs.round;
-                ^Rational.fromReducedInts(numerator,denominator);
-            } {
-                ^(this.numerator / this.denominator).asRational
-            }
-        } {
-            if (this.numerator.isKindOf(String)) {
-                ^this.numerator.asRational
-            }
-        }
+		if (this.numerator.isKindOf(Number)) {
+			if (this.numerator.isKindOf(Rational) || this.denominator.isKindOf(Rational)){
+				^(numerator.asRational / denominator.asRational)
+			};
+			if (this.numerator.frac == 0 && this.denominator.frac == 0) {
+				if (denominator == 0) {
+					if (numerator == 0) {
+						"Rational has zero denominator".error;^0/0
+					}{
+						"Rational has zero denominator".error;^inf
+					}
+				};
+				d = this.factor;
+				numerator = ((this.numerator/d).abs * d.sign).round;
+				denominator = (this.denominator/d).abs.round;
+				^Rational.fromReducedInts(numerator,denominator);
+			} {
+				^(this.numerator / this.denominator).asRational
+			}
+		} {
+			if (this.numerator.isKindOf(String)) {
+				^this.numerator.asRational
+			}
+		}
 	}
 
-    *fromReducedInts { arg numerator=1.0, denominator=1.0;
-        ^super.newCopyArgs(numerator, denominator);
-    }
+	*fromReducedInts { arg numerator=1.0, denominator=1.0;
+		^super.newCopyArgs(numerator, denominator);
+	}
 
 	factor {
 		var d = gcd(this.numerator.asInteger, this.denominator.asInteger).abs;
 		if (denominator < 0) { d = d.neg };
 		if (numerator   < 0) { d = d.neg };
-		^d.asFloat
-	}
-
-	reduceNestedRationals {
-        ^if(numerator.isRational or: {denominator.isRational}) {
-			(numerator.asRational / denominator.asRational)
-		};
+		^d
 	}
 
 	*newFrom { arg that; ^that.asRational }
@@ -70,7 +60,7 @@ Rational : Number {
 
 	asRational { ^this }
 
-    asFloat { ^(this.numerator / this.denominator).asFloat }
+	asFloat { ^(this.numerator / this.denominator).asFloat }
 
 	asInteger { ^(this.numerator / this.denominator).asInteger }
 
@@ -79,7 +69,7 @@ Rational : Number {
 	reciprocal { ^Rational(this.denominator, this.numerator) }
 
 	// printOn { arg stream;
-	// 	stream << "Rational( " << numerator << ", " << denominator << " )";
+	//	stream << "Rational( " << numerator << ", " << denominator << " )";
 	// }
 
 	printOn { arg stream;
@@ -122,7 +112,7 @@ Rational : Number {
 
 	pow { arg n;
 
-        /*if (n.isInteger.not) {"Exponent is not Integer".error};*/
+		/*if (n.isInteger.not) {"Exponent is not Integer".error};*/
 
 		^case
 		{ n == 0 } { Rational(1,1) }
@@ -144,8 +134,6 @@ Rational : Number {
 			}
 		}
 	}
-
-
 
 	simplify { arg maxDenominator=20, fasterBetter=false;
 		^this.asFloat.asRational(maxDenominator,fasterBetter)
@@ -177,58 +165,7 @@ Rational : Number {
 
 	cubed { ^this.pow(3) }
 
-    abs { ^this.class.new(numerator.abs, denominator) }
+	abs { ^this.class.new(numerator.abs, denominator) }
 
 }
 
-
-+ SimpleNumber {
-	asRational { arg maxDenominator=100,fasterBetter=false;
-		var fraction = this.asFraction(maxDenominator,fasterBetter);
-		^Rational(fraction[0], fraction[1])
-	}
-
-	isRational { ^false }
-
-	%/ { arg aNumber; ^Rational(this, aNumber) }
-
-	performBinaryOpOnRational { arg aSelector, rational, adverb;
-		^rational.perform(aSelector, this.asRational, adverb)
-	}
-}
-
-+ Integer {
-	asRational { ^Rational(this, 1) }
-	as { arg aSimilarClass; ^aSimilarClass.new(this.numerator, 1 ) }
-}
-
-+ Number {
-	numerator { ^this}
-	denominator { ^1}
-	rational { arg denominator=1; ^Rational(this, denominator) }
-}
-
-+ SequenceableCollection {
-	asRational { arg maxDenominator = 100;
-		^this.collect { |i| i.asRational(maxDenominator) }
-	}
-}
-
-+ String {
-	asRational {
-		var stringArray = this.split($/ );
-		^Rational(stringArray[0].asFloat, stringArray[1].asFloat)
-	}
-}
-
-+ AbstractFunction {
-	performBinaryOpOnRational { arg aSelector, aRational, adverb;
-		^this.reverseComposeBinaryOp(aSelector, aRational, adverb)
-	}
-}
-
-+ Object {
-	performBinaryOpOnRational { arg aSelector, thing, adverb;
-		^this.performBinaryOpOnSomething(aSelector, thing, adverb)
-	}
-}

--- a/SCClassLibrary/Common/Math/Rational.sc
+++ b/SCClassLibrary/Common/Math/Rational.sc
@@ -18,7 +18,7 @@ Rational : Number {
 
                 if (denominator == 0) {
                     if (numerator == 0) {
-                        "Rational has zero numerator and denominator".error;^0/0
+                        "Rational has zero denominator".error;^0/0
                     }{
                         "Rational has zero denominator".error;^inf
 					}
@@ -26,6 +26,7 @@ Rational : Number {
 
                 numerator   = ((this.numerator/d).abs * d.sign).round;
                 denominator = (this.denominator/d).abs.round;
+				^Rational.fromReducedInts(numerator,denominator);
 
             } {
                 ^(this.numerator / this.denominator).asRational
@@ -35,6 +36,10 @@ Rational : Number {
                 ^this.numerator.asRational
             }
         }
+	}
+
+	*fromReducedInts { arg numerator=1, denominator=1;
+        ^super.newCopyArgs(numerator, denominator);
 	}
 
 	factor {

--- a/SCClassLibrary/Common/Math/Rational.sc
+++ b/SCClassLibrary/Common/Math/Rational.sc
@@ -169,55 +169,5 @@ Rational : Number {
 	cubed { ^this.pow(3) }
 
 	abs { ^this.class.new(numerator.abs, denominator) }
-
-
 }
 
-
-+ SimpleNumber {
-	asRational { arg maxDenominator=100;
-		var fraction = this.asFraction(maxDenominator);
-		^Rational(fraction[0], fraction[1])
-	}
-	isRational { ^false }
-	%/ { arg aNumber; ^Rational(this, aNumber) }
-	performBinaryOpOnRational { arg aSelector, rational, adverb;
-		^rational.perform(aSelector, this.asRational, adverb)
-	}
-}
-
-+ Integer {
-	asRational { ^Rational(this, 1) }
-	as { arg aSimilarClass; ^aSimilarClass.new(this.numerator, 1 ) }
-}
-
-+ Number {
-	numerator { ^this}
-	denominator { ^1}
-	rational { arg denominator=1; ^Rational(this, denominator) }
-}
-
-+ SequenceableCollection {
-	asRational { arg maxDenominator = 100;
-		^this.collect { |i| i.asRational(maxDenominator) }
-	}
-}
-
-+ String {
-	asRational {
-		var stringArray = this.split($/ );
-		^Rational(stringArray[0].asInteger, stringArray[1].asInteger)
-	}
-}
-
-+ AbstractFunction {
-	performBinaryOpOnRational { arg aSelector, aRational, adverb;
-		^this.reverseComposeBinaryOp(aSelector, aRational, adverb)
-	}
-}
-
-+ Object {
-	performBinaryOpOnRational { arg aSelector, thing, adverb;
-		^this.performBinaryOpOnSomething(aSelector, thing, adverb)
-	}
-}

--- a/SCClassLibrary/Common/Math/Rational.sc
+++ b/SCClassLibrary/Common/Math/Rational.sc
@@ -1,0 +1,194 @@
+Rational : Number {
+	var <>numerator, <>denominator;
+
+	*new { arg numerator, denominator = 1;
+		^super.new.initRational(numerator, denominator);
+	}
+
+	*newFromString { arg thisString;
+		^thisString.asRational;
+	}
+
+	initRational { arg thisNumerator, thisDenominator;
+		var factor;
+		if(thisNumerator.isString) {
+			^thisNumerator.asRational
+		} {
+			if(thisNumerator.isKindOf(Rational) or: thisDenominator.isKindOf(Rational)) {
+				^(thisNumerator.asRational / thisDenominator.asRational)
+			} {
+				if(thisNumerator.frac == 0 and: thisDenominator.frac == 0) {
+					if(thisDenominator == 0) {
+						this.numerator_(0);
+						this.denominator_(0);
+					} {
+						factor = gcd(thisNumerator.abs.asInteger, thisDenominator.abs.asInteger);
+						(thisDenominator < 0).if({factor = factor.neg});
+						(thisNumerator   < 0).if({factor = factor.neg});
+						this.numerator_((((thisNumerator/factor).abs) * factor.sign).asInteger);
+						this.denominator_((thisDenominator/factor).abs.asInteger);
+					};
+				} {
+					^(thisNumerator / thisDenominator).asRational
+				};
+			};
+		};
+	}
+	
+	performBinaryOpOnSimpleNumber { arg aSelector, aNumber, adverb;
+		^aNumber.asRational.perform(aSelector, this, adverb)
+	}
+	
+	isRational { ^true }
+	
+	%/ { arg aNumber; ^Rational(this, aNumber) }
+	
+	asRational { ^this }
+	
+	as { arg aSimilarClass; ^aSimilarClass.new(this.numerator, this.denominator) }
+	
+	asArray { ^[this.numerator, this.denominator]}
+	
+	asFloat { ^(this.numerator / this.denominator)}
+	
+	asInteger { ^((this.numerator / this.denominator).asInteger) }
+	
+	asInt { ^this.asInteger }
+	
+	reciprocal { ^Rational(this.denominator, this.numerator) }
+	
+	printOn { arg stream;
+		stream << "Rational( " << numerator << ", " << denominator << " )";
+	}
+	
+	hash { ^numerator.hash << 2 bitXor: denominator.hash } 
+	
+	+ { arg aNumber, adverb;
+		if(aNumber.isNumber) {
+			^this.species.new(
+				(this.numerator * aNumber.denominator) + (this.denominator * aNumber.numerator),
+				this.denominator * aNumber.denominator)
+		} {
+			^aNumber.performBinaryOpOnRational('+', this, adverb)
+		};
+	}
+	
+	- { arg aNumber, adverb;
+		if(aNumber.isKindOf(Rational)) {
+			^this.species.new(
+				(this.numerator * aNumber.denominator) - (this.denominator * aNumber.numerator),
+				this.denominator * aNumber.denominator )
+		}  {
+			^aNumber.performBinaryOpOnRational('-', this, adverb)
+		};	
+	}
+	
+	* { arg aNumber, adverb;
+		if(aNumber.isKindOf(Rational)) {
+			^this.species.new(
+				this.numerator * aNumber.numerator,
+				this.denominator * aNumber.denominator)
+		} {
+			^aNumber.performBinaryOpOnRational('*', this, adverb)
+		};
+	}
+	
+	
+	/ { arg aNumber, adverb;
+		if(aNumber.isKindOf(Rational)) {
+			^this.species.new(
+				this.numerator * aNumber.denominator,
+				this.denominator * aNumber.numerator )
+		} {
+			^aNumber.performBinaryOpOnRational('/', this, adverb)
+		}
+	}
+	
+	== { arg aNumber, adverb;
+		if(aNumber.isKindOf(Rational)) {
+			^((this.numerator * aNumber.denominator) == (this.denominator * aNumber.numerator))
+		} {
+			^aNumber.performBinaryOpOnRational('==', this, adverb)
+		}	
+	}
+	
+	!= { arg aNumber, adverb;
+		if(aNumber.isKindOf(Rational)) {
+			^((this.numerator * aNumber.denominator) != (this.denominator * aNumber.numerator))
+		} {
+			^aNumber.performBinaryOpOnRational('!=', this, adverb)
+		}	
+	}
+	
+	pow { arg aNumber;
+		case
+		{ aNumber == 0 } { ^(1.as(this.species)) }
+		{ aNumber > 0  } { ^(this.species.new(this.numerator.pow(aNumber.asFloat), this.denominator.pow(aNumber.asFloat))) }
+		{ aNumber < 0  } {
+			if((this.numerator == 0).not) {
+				^this.reciprocal.pow(aNumber.abs)
+			} {
+				"Numerator can't be 0".warn;
+			};
+		};
+	}
+	
+	simplify { arg maxDenominator=20;
+		^this.asFloat.asRational(maxDenominator)
+	}
+	
+	< { arg aNumber;
+		^(this.asFloat < aNumber.asFloat)
+	}
+	
+	> { arg aNumber;
+		^(this.asFloat > aNumber.asFloat)
+	}
+	
+	<= { arg aNumber;
+		^(this.asFloat <= aNumber.asFloat)
+	}
+	
+	>= { arg aNumber;
+		^(this.asFloat >= aNumber.asFloat)
+	}
+	
+	isNegative {
+		^this.numerator.isNegative
+	}
+	
+	isPositive {
+		^this.numerator.isPositive
+	}
+	
+	neg {
+		^(this * (-1))
+	}
+	
+	mod {
+		if (this.isNegative) {
+			^this.neg
+		} {
+			^this
+		};
+	}
+	
+	max { arg aNumber;
+		var rationalArray, floatArray;
+		rationalArray = [this, aNumber];
+		floatArray = rationalArray.asFloat;
+		^rationalArray.at(floatArray.indexOf(floatArray.max));
+	}
+	
+	min { arg aNumber;
+		var rationalArray, floatArray;
+		rationalArray = [this, aNumber];
+		floatArray = rationalArray.asFloat;
+		^rationalArray.at(floatArray.indexOf(floatArray.min));
+	}
+	
+	sqrt { ^this.pow(this.species.new(1,2)) }
+	squared { ^this.pow(this.species.new(2,1)) }
+	cubed { ^this.pow(this.species.new(3,1)) }	
+	abs { ^this.species.new(this.numerator.abs.asInteger, this.denominator.abs.asInteger) }
+}

--- a/SCClassLibrary/Common/Math/Rational.sc
+++ b/SCClassLibrary/Common/Math/Rational.sc
@@ -15,9 +15,18 @@ Rational : Number {
 
             if (this.numerator.frac == 0 && this.denominator.frac == 0) {
                 d = this.factor;
-                if (denominator == 0) {"Rational has zero denominator".error;^inf};
+
+                if (denominator == 0) {
+                    if (numerator == 0) {
+                        "Rational has zero numerator and denominator".error;^0/0
+                    }{
+                        "Rational has zero denominator".error;^inf
+					}
+				};
+
                 numerator   = ((this.numerator/d).abs * d.sign).round;
                 denominator = (this.denominator/d).abs.round;
+
             } {
                 ^(this.numerator / this.denominator).asRational
             }

--- a/SCClassLibrary/Common/Math/Rational.sc
+++ b/SCClassLibrary/Common/Math/Rational.sc
@@ -128,7 +128,7 @@ Rational : Number {
 			if((this.numerator == 0).not) {
 				^this.reciprocal.pow(aNumber.abs)
 			} {
-				"Numerator can't be 0".warn;
+				"Numerator can't be 0".error;
 			};
 		};
 	}
@@ -165,14 +165,6 @@ Rational : Number {
 		^(this * (-1))
 	}
 	
-	mod {
-		if (this.isNegative) {
-			^this.neg
-		} {
-			^this
-		};
-	}
-	
 	max { arg aNumber;
 		var rationalArray, floatArray;
 		rationalArray = [this, aNumber];
@@ -188,7 +180,10 @@ Rational : Number {
 	}
 	
 	sqrt { ^this.pow(this.species.new(1,2)) }
+
 	squared { ^this.pow(this.species.new(2,1)) }
-	cubed { ^this.pow(this.species.new(3,1)) }	
-	abs { ^this.species.new(this.numerator.abs.asInteger, this.denominator.abs.asInteger) }
+
+	cubed { ^this.pow(this.species.new(3,1)) }
+
+	abs { ^this.species.new(this.numerator.abs.asInteger, this.denominator) }
 }

--- a/SCClassLibrary/Common/Math/SimpleNumber.sc
+++ b/SCClassLibrary/Common/Math/SimpleNumber.sc
@@ -501,7 +501,6 @@ SimpleNumber : Number {
 
 	asRational { arg maxDenominator=100,fasterBetter=false;
 		var fraction = this.asFraction(maxDenominator,fasterBetter);
-		if (this.isNaN) {^inf};
 		^Rational(fraction[0], fraction[1])
 	}
 

--- a/SCClassLibrary/Common/Math/SimpleNumber.sc
+++ b/SCClassLibrary/Common/Math/SimpleNumber.sc
@@ -499,8 +499,9 @@ SimpleNumber : Number {
 		^this.primitiveFailed
 	}
 
-	asRational { arg maxDenominator=100;
-		var fraction = this.asFraction(maxDenominator);
+	asRational { arg maxDenominator=100,fasterBetter=false;
+		var fraction = this.asFraction(maxDenominator,fasterBetter);
+		if (this.isNaN) {^inf};
 		^Rational(fraction[0], fraction[1])
 	}
 

--- a/SCClassLibrary/Common/Math/SimpleNumber.sc
+++ b/SCClassLibrary/Common/Math/SimpleNumber.sc
@@ -498,6 +498,20 @@ SimpleNumber : Number {
 		// if fasterBetter is true it may find a much closer approximation and do it faster.
 		^this.primitiveFailed
 	}
+
+	asRational { arg maxDenominator=100;
+		var fraction = this.asFraction(maxDenominator);
+		^Rational(fraction[0], fraction[1])
+	}
+
+	isRational { ^false }
+
+	%/ { arg aNumber; ^Rational(this, aNumber) }
+
+	performBinaryOpOnRational { arg aSelector, rational, adverb;
+		^rational.perform(aSelector, this.asRational, adverb)
+	}
+
 	prSimpleNumberSeries { arg second, last;
 		_SimpleNumberSeries
 		^this.primitiveFailed

--- a/testsuite/classlibrary/TestRational.sc
+++ b/testsuite/classlibrary/TestRational.sc
@@ -404,7 +404,7 @@ TestRational : UnitTest {
             this.assertEquals(
                 (a + b) * c,
                 (a * c) + (b * c),
-                format( "Associative property 1 test with %, % and % passed.", a, b, c)
+                format( "Distributive property 1 test with %, % and % passed.", a, b, c)
             );
         }
     }

--- a/testsuite/classlibrary/TestRational.sc
+++ b/testsuite/classlibrary/TestRational.sc
@@ -11,22 +11,21 @@ TestRational : UnitTest {
 
 	setRandSeed { arg seed=123; thisThread.randSeed = seed }
 
-	test_ZeroDenominator {
+	test_Zero {
 		var array;
 
-		this.assertEquals(
-			Rational(0,0),
-			inf, // or nan?
-			format( "Zero Denominator with Rational(0,0)==inf test passed.")
+		this.assert(
+			Rational(0,0).isNaN,
+			format( "Zero Denominator with Rational(0,0).isNaN test passed.")
 		);
 		this.assertEquals(
 			Rational(1,0),
-			inf, // or nan?
+			inf, 
 			format( "Zero Denominator test with Rational(1,0)==inf passed.")
 		);
 		this.assertEquals(
 			Rational(9999,0),
-			inf, // or nan?
+			inf, 
 			format( "Zero Denominator test with Rational(9999,0)==inf passed.")
 		);
 		this.assertEquals(

--- a/testsuite/classlibrary/TestRational.sc
+++ b/testsuite/classlibrary/TestRational.sc
@@ -5,454 +5,461 @@ UnitTest.gui
 
 TestRational : UnitTest {
 
-    var minIntVal= -1000, maxIntVal=1000;
-    var minFloatVal= -1000.1, maxFloatVal=1000.1;
-    var numTests = 1000;
-
-    setRandSeed { arg seed=123; thisThread.randSeed = seed }
-
-    test_ZeroDenominator {
-        var array;
-
-        this.assertEquals(
-            Rational(0,0),
-            inf, // or nan?
-            format( "Zero Denominator with Rational(0,0)==inf test passed.")
-        );
-        this.assertEquals(
-            Rational(1,0),
-            inf, // or nan?
-            format( "Zero Denominator test with Rational(1,0)==inf passed.")
-        );
-        this.assertEquals(
-            Rational(9999,0),
-            inf, // or nan?
-            format( "Zero Denominator test with Rational(9999,0)==inf passed.")
-        );
-        this.assertEquals(
-            Rational(0,1),
-            Rational(0,9999),
-            format( "Zero Denominator test with Rational(0,1)==Rational(0,9999) passed.")
-        );
-    }
-
-    test_reciprocal {
-        var report = true;
-
-        this.setRandSeed;
-
-        numTests.do {
-            var x = rrand(minIntVal,maxIntVal);
-            var y = 1 + maxIntVal.rand * [-1,1].choose;
-            var z = Rational(x,y);
-            this.assertEquals(
-                z,
-                z.reciprocal.reciprocal,
-                format( "Reciprocal test with % passed.", z),
-                report: report
-            );
-            }
-    }
-
-    test_newFromString {
-        this.setRandSeed;
-
-        numTests.do({
-            var x = rrand(minIntVal,maxIntVal);
-            var y = 1 + maxIntVal.rand * [-1,1].choose;
-            var xStr = x.asString;
-            var yStr = y.asString;
-            var rat1 = Rational(x,y);
-            var rat2 = Rational.newFrom(xStr ++ "/"++ yStr);
-
-            this.assertEquals(
-                rat1,
-                rat2,
-                format( "String entry test with % passed.", rat1)
-            );
-        });
-    }
-
-    test_strangeStringInput {
-
-        var strangeStrings = [
-            "3 %/ 2  ",
-            "3  /  2 ",
-            "3    /   2 ",
-            "   3    / 2    ",
-            "    3     / 2      ",
-            "    3   %    /   2   ",
-            "    3    /    2 ",
-            "        3       %      /         2 "
-        ];
-
-
-        strangeStrings.do({ arg i, j;
-            this.assertEquals(
-                Rational(i),
-                Rational(3,2),
-                format( "String entry # % test with Rational(%) passed.", j, i)
-            );
-
-        });
-    }
-
-
-    test_commutativeAdd {
-
-        this.setRandSeed;
-
-        numTests.do {
-            var x1 = rrand(minIntVal,maxIntVal);
-            var y1 = 1 + maxIntVal.rand * [-1,1].choose;
-            var x2 = rrand(minIntVal,maxIntVal);
-            var y2 = 1 + maxIntVal.rand;
-            var z1 = Rational(x1,y1);
-            var z2 = Rational(x2,y2);
-            this.assertEquals(
-                z1 + z2,
-                z2 + z1,
-                format( "Commutative Add test with % and % passed.", z1, z2)
-            );
-            }
-    }
-
-    test_commutativeMul {
-
-        this.setRandSeed;
-
-        numTests.do {
-            var x1 = rrand(minIntVal,maxIntVal);
-            var y1 = 1 + maxIntVal.rand * [-1,1].choose;
-            var x2 = rrand(minIntVal,maxIntVal);
-            var y2 = 1 + maxIntVal.rand * [-1,1].choose;
-            var z1 = Rational(x1,y1);
-            var z2 = Rational(x2,y2);
-            this.assertEquals(
-                z1 * z2,
-                z2 * z1,
-                format( "Commutative Add test with % and % passed.", z1, z2));
-            }
-    }
-
-    test_Additive_Inverse {
-
-        this.setRandSeed;
-
-        numTests.do {
-            var x = rrand(minIntVal,maxIntVal);
-            var y = 1 + maxIntVal.rand * [1,1.neg].choose;
-            var rat=Rational(x,y);
-
-            this.assertEquals(
-                Rational(x * (-1), y),
-                Rational(x, y * (-1)),
-                format( "Additive Inverse test 1 with % passed.", rat)
-            );
-            this.assertEquals(
-                (-1) * rat,
-                Rational(x * (-1), y),
-                format( "Additive Inverse test 2 with % passed.", rat)
-            );
-            this.assertEquals(
-                (-1) * rat,
-                Rational(x, y * (-1)),
-                format( "Additive Inverse test 3 with % passed.", rat)
-            )
-        }
-    }
-
-    test_Multiplicative_Inverse {
-
-        this.setRandSeed;
-
-        numTests.do {
-            var x    = 1 + maxIntVal.rand * [-1,1].choose;
-            var y    = 1 + maxIntVal.rand * [-1,1].choose;
-            var rat1 = Rational(x,y);
-            var rat2 = Rational(y,x);
-
-            this.assertEquals(
-                rat1.pow(-1),
-                rat2,
-                format( "Multiplicative Inverse test with % passed.", rat1)
-            );
-        }
-    }
-
-    test_Div_Eq_ReciprocalMul  {
-
-        numTests.do {
-            var x1 = rrand(minIntVal,maxIntVal);
-            var y1 = 1 + maxIntVal.rand * [-1,1].choose;
-            var x2 = 1 + maxIntVal.rand * [-1,1].choose;
-            var y2 = 1 + maxIntVal.rand * [-1,1].choose;
-            var z1 = Rational(x1,y1);
-            var z2 = Rational(x2,y2);
-            this.assertEquals(
-                z1 / z2,
-                z1 * z2.reciprocal,
-                format( "Division is equivalent to multiplying by the reciprocal test with % and %", z1, z2));
-            }
-    }
-
-    test_Neg_Subtraction {
-
-        this.setRandSeed;
-
-        numTests.do {
-            var x1 = rrand(minIntVal,maxIntVal);
-            var y1 = 1 + maxIntVal.rand * [-1,1].choose;
-            var x2 = rrand(minIntVal,maxIntVal);
-            var y2 = 1 + maxIntVal.rand * [-1,1].choose;
-            var z1 = Rational(x1,y1);
-            var z2 = Rational(x2,y2);
-            this.assertEquals(
-                z1 - z2,
-                z2.neg - z1.neg,
-                format( "Subtraction and Inverse test with % and % passed.", z1, z2));
-            }
-    }
-
-    test_reciprocal_Div {
-
-        this.setRandSeed;
-
-        numTests.do {
-            var x1 = 1 + maxIntVal.rand * [-1,1].choose;
-            var y1 = 1 + maxIntVal.rand * [-1,1].choose;
-            var x2 = 1 + maxIntVal.rand * [-1,1].choose;
-            var y2 = 1 + maxIntVal.rand * [-1,1].choose;
-            var z1 = Rational(x1,y1);
-            var z2 = Rational(x2,y2);
-            this.assertEquals(
-                z1 / z2,
-                (z2 / z1).reciprocal,
-                format( "Div + reciprocal test with % and % passed.", z1, z2));
-            }
-    }
-
-    test_Sort_and_Scramble  {
-        var listSize = 1000;
-
-        this.setRandSeed;
-
-        //numTests.do {
-        10.do {
-            var ratList;
-            ratList = Array.fill(
-                listSize,
-                {
-                    Rational(
-                        rrand(minIntVal, maxIntVal),
-                         1 + maxIntVal.rand * [-1,1].choose;)
-                }
-                );
-            this.assertEquals(
-                ratList.sort,
-                ratList.scramble.sort,
-                format( "Sort and Scramble test passed.")
-            );
-        }
-    }
-
-    test_Sort_and_asFloat  {
-        var listSize = 1000;
-
-        this.setRandSeed;
-
-        //numTests.do {
-        10.do {
-            var ratList;
-
-            ratList = Array.fill(
-                listSize,
-                {
-                    Rational(
-                        rrand(minIntVal, maxIntVal),
-                        1 + maxIntVal.rand * [-1,1].choose;)
-                }
-                );
-
-            this.assertEquals(
-                ratList.scramble.sort.asFloat,
-                ratList.scramble.asFloat.sort,
-                format( "Sort and asFloat test passed.")
-            );
-        }
-    }
-
-    test_Mul_Inverse_DifferentExponents_NonZeroIntInput {
-
-        this.setRandSeed;
-
-        numTests.do {
-            var maxVal = 100;
-            var x1 = 1 + maxVal.rand * [-1,1].choose;
-            var y1 = 1 + maxVal.rand * [-1,1].choose;
-            var rat = Rational(x1,y1);
-            var maxExponent = 6;
-
-            maxExponent.do({arg i;
-                this.assertEquals(
-                    rat.pow(i * (-1)),
-                    rat.pow(i).reciprocal,
-                    format( "Multiplicative inverse with different exponents test with exp: % and rat: % passed.", i, rat));
-
-            })
-
-        }
-    }
-
-    test_Float_Rat_Float {
-
-        this.setRandSeed;
-
-        numTests.do {
-            var maxVal = 1000.01;
-            var x = 1 + maxVal.rand * [1,1.neg].choose;
-            var y = 1 + maxVal.rand * [1,1.neg].choose;
-            var rat = Rational(x,y);
-            var float = x/y;
-
-            this.assertFloatEquals(
-                a: rat.asFloat,
-                b: float.asRational.asFloat,
-                message: format(
-                    "Float/Rational conversion with  rat: % and float: % passed.", rat, float),
-                within: 0.000001
-            );
-        }
-    }
-
-    test_Rat_Float_Rat {
-
-        this.setRandSeed;
-
-        numTests.do {
-            var maxVal = 100;
-            var x = 1 + maxVal.rand * [1,1.neg].choose;
-            var y = 1 + maxVal.rand * [1,1.neg].choose;
-            var rat = Rational(x,y);
-            var float = x/y;
-
-            this.assertEquals(
-                a: rat,
-                b: float.asRational.asFloat.asRational,
-                message: format(
-                    "Float/Rational conversion with rat: % and float: % passed.", rat, float)
-            );
-        }
-    }
-
-
-    test_Exponentiation {
-
-        this.setRandSeed;
-
-       numTests.do {
-            var maxVal = 9;
-            var x = 1 + maxVal.rand;
-            var y = 1 + maxVal.rand;
-            var r = Rational(x,y);
-            var e = rrand(1, 5).round;
-            this.assertEquals(
-                r,
-                r.pow(e).pow(e.reciprocal),
-                format(
-                    "Exponentiation rational: % and exponent: % passed.", r, e));
-        }
-    }
-
-    // associative property
-    test_AssociativeAdd {
-        this.setRandSeed;
-        numTests.do {
-            var x1 = rrand(minIntVal,maxIntVal);
-            var y1 = 1 + maxIntVal.rand * [-1,1].choose;
-            var x2 = rrand(minIntVal,maxIntVal);
-            var y2 = 1 + maxIntVal.rand * [-1,1].choose;
-            var x3 = rrand(minIntVal,maxIntVal);
-            var y3 = 1 + maxIntVal.rand * [-1,1].choose;
-            var z1 = Rational(x1,y1);
-            var z2 = Rational(x2,y2);
-            var z3 = Rational(x3,y3);
-            this.assertEquals(
-                (z1 + z2) + z3,
-                z1 + (z2 + z3),
-                format( "Associative Sum test with %, % and %passed.", z1, z2, z3))
-        }
-    }
-
-    test_AssociativeMul {
-
-        this.setRandSeed;
-
-        numTests.do {
-            var x1 = rrand(minIntVal,maxIntVal);
-            var y1 = 1 + maxIntVal.rand * [-1,1].choose;
-            var x2 = rrand(minIntVal,maxIntVal);
-            var y2 = 1 + maxIntVal.rand * [-1,1].choose;
-            var x3 = rrand(minIntVal,maxIntVal);
-            var y3 = 1 + maxIntVal.rand * [-1,1].choose;
-            var z1 = Rational(x1,y1);
-            var z2 = Rational(x2,y2);
-            var z3 = Rational(x3,y3);
-
-            this.assertEquals(
-                (z1 * z2) * z3,
-                z1 * (z2 * z3),
-                format( "Associative Mul test with %, % and %passed.", z1, z2, z3));
-        }
-    }
-
-    // distributive property
-    // (a + b) * c = (a * c) + (b * c)
-    test_Distributive_1_PositiveIntInput {
-
-        this.setRandSeed;
-
-        numTests.do {
-            var minVal = 1;
-            var maxVal = 20;
-            var x1 = rrand(minVal,maxVal);
-            var y1 = 1 + maxVal.rand ;
-            var x2 = rrand(minVal,maxVal);
-            var y2 = 1 + maxVal.rand ;
-            var x3 = rrand(minVal,maxVal);
-            var y3 = 1 + maxVal.rand ;
-            var a = Rational(x1,y1);
-            var b = Rational(x2,y2);
-            var c = Rational(x3,y3);
-
-            this.assertEquals(
-                (a + b) * c,
-                (a * c) + (b * c),
-                format( "Associative property 1 test with %, % and % passed.", a, b, c)
-            );
-        }
-    }
-
-    test_commutativeAdd_Array {
-
-        this.setRandSeed;
-
-        numTests.do {
-            var n = 20;
-            var minVal = -10;
-            var maxVal = 10;
-            var xs = Array.fill(n, {rrand(minVal,maxVal)});
-            var ys = Array.fill(n, {1 + maxVal.rand * [-1,1].choose});
-            var rats;
-
-            rats = n.collect({arg i; Rational(xs[i], ys[i])});
-
-            this.assertEquals(
-                rats.scramble.sum,
-                rats.scramble.sum,
-                format( "Commutative with Array summation test with %", rats));
-        }
-    }
+	var minIntVal= -1000, maxIntVal=1000;
+	var minFloatVal= -1000.1, maxFloatVal=1000.1;
+	var numTests = 1000;
+
+	setRandSeed { arg seed=123; thisThread.randSeed = seed }
+
+	test_ZeroDenominator {
+		var array;
+
+		this.assertEquals(
+			Rational(0,0),
+			inf, // or nan?
+			format( "Zero Denominator with Rational(0,0)==inf test passed.")
+		);
+		this.assertEquals(
+			Rational(1,0),
+			inf, // or nan?
+			format( "Zero Denominator test with Rational(1,0)==inf passed.")
+		);
+		this.assertEquals(
+			Rational(9999,0),
+			inf, // or nan?
+			format( "Zero Denominator test with Rational(9999,0)==inf passed.")
+		);
+		this.assertEquals(
+			Rational(0,1),
+			Rational(0,9999),
+			format( "Zero Denominator test with Rational(0,1)==Rational(0,9999) passed.")
+		);
+	}
+
+	test_reciprocal {
+		var report = true;
+
+		this.setRandSeed;
+
+		numTests.do {
+			var x = rrand(minIntVal,maxIntVal);
+			var y = 1 + maxIntVal.rand * [-1,1].choose;
+			var z = Rational(x,y);
+			this.assertEquals(
+				z,
+				z.reciprocal.reciprocal,
+				format( "Reciprocal test with % passed.", z),
+				report: report
+			);
+			}
+	}
+
+	test_newFromString {
+		this.setRandSeed;
+
+		numTests.do({
+			var x = rrand(minIntVal,maxIntVal);
+			var y = 1 + maxIntVal.rand * [-1,1].choose;
+			var xStr = x.asString;
+			var yStr = y.asString;
+			var rat1 = Rational(x,y);
+			var rat2 = Rational.newFrom(xStr ++ "/"++ yStr);
+
+			this.assertEquals(
+				rat1,
+				rat2,
+				format( "String entry test with % passed.", rat1)
+			);
+		});
+	}
+
+	test_strangeStringInput {
+
+		var strangeStrings = [
+			"3 %/ 2  ",
+			"3  /  2 ",
+			"3    /   2 ",
+			"   3    / 2    ",
+			"    3     / 2      ",
+			"    3   %    /   2   ",
+			"    3    /    2 ",
+			"        3       %      /         2 "
+		];
+
+
+		strangeStrings.do({ arg i, j;
+			this.assertEquals(
+				Rational(i),
+				Rational(3,2),
+				format( "String entry # % test with Rational(%) passed.", j, i)
+			);
+
+		});
+	}
+
+	test_StringInput_Floats {
+		this.assertEquals(
+			"1 / 0.1".asRational,
+			Rational(10,1),
+			format( "String input test with '1 / 0.1' as Rational(10,1) passed.")
+		)
+	}
+
+	test_commutativeAdd {
+
+		this.setRandSeed;
+
+		numTests.do {
+			var x1 = rrand(minIntVal,maxIntVal);
+			var y1 = 1 + maxIntVal.rand * [-1,1].choose;
+			var x2 = rrand(minIntVal,maxIntVal);
+			var y2 = 1 + maxIntVal.rand;
+			var z1 = Rational(x1,y1);
+			var z2 = Rational(x2,y2);
+			this.assertEquals(
+				z1 + z2,
+				z2 + z1,
+				format( "Commutative Add test with % and % passed.", z1, z2)
+			);
+			}
+	}
+
+	test_commutativeMul {
+
+		this.setRandSeed;
+
+		numTests.do {
+			var x1 = rrand(minIntVal,maxIntVal);
+			var y1 = 1 + maxIntVal.rand * [-1,1].choose;
+			var x2 = rrand(minIntVal,maxIntVal);
+			var y2 = 1 + maxIntVal.rand * [-1,1].choose;
+			var z1 = Rational(x1,y1);
+			var z2 = Rational(x2,y2);
+			this.assertEquals(
+				z1 * z2,
+				z2 * z1,
+				format( "Commutative Add test with % and % passed.", z1, z2));
+			}
+	}
+
+	test_Additive_Inverse {
+
+		this.setRandSeed;
+
+		numTests.do {
+			var x = rrand(minIntVal,maxIntVal);
+			var y = 1 + maxIntVal.rand * [1,1.neg].choose;
+			var rat=Rational(x,y);
+
+			this.assertEquals(
+				Rational(x * (-1), y),
+				Rational(x, y * (-1)),
+				format( "Additive Inverse test 1 with % passed.", rat)
+			);
+			this.assertEquals(
+				(-1) * rat,
+				Rational(x * (-1), y),
+				format( "Additive Inverse test 2 with % passed.", rat)
+			);
+			this.assertEquals(
+				(-1) * rat,
+				Rational(x, y * (-1)),
+				format( "Additive Inverse test 3 with % passed.", rat)
+			)
+		}
+	}
+
+	test_Multiplicative_Inverse {
+
+		this.setRandSeed;
+
+		numTests.do {
+			var x    = 1 + maxIntVal.rand * [-1,1].choose;
+			var y    = 1 + maxIntVal.rand * [-1,1].choose;
+			var rat1 = Rational(x,y);
+			var rat2 = Rational(y,x);
+
+			this.assertEquals(
+				rat1.pow(-1),
+				rat2,
+				format( "Multiplicative Inverse test with % passed.", rat1)
+			);
+		}
+	}
+
+	test_Div_Eq_ReciprocalMul  {
+
+		numTests.do {
+			var x1 = rrand(minIntVal,maxIntVal);
+			var y1 = 1 + maxIntVal.rand * [-1,1].choose;
+			var x2 = 1 + maxIntVal.rand * [-1,1].choose;
+			var y2 = 1 + maxIntVal.rand * [-1,1].choose;
+			var z1 = Rational(x1,y1);
+			var z2 = Rational(x2,y2);
+			this.assertEquals(
+				z1 / z2,
+				z1 * z2.reciprocal,
+				format( "Division is equivalent to multiplying by the reciprocal test with % and %", z1, z2));
+			}
+	}
+
+	test_Neg_Subtraction {
+
+		this.setRandSeed;
+
+		numTests.do {
+			var x1 = rrand(minIntVal,maxIntVal);
+			var y1 = 1 + maxIntVal.rand * [-1,1].choose;
+			var x2 = rrand(minIntVal,maxIntVal);
+			var y2 = 1 + maxIntVal.rand * [-1,1].choose;
+			var z1 = Rational(x1,y1);
+			var z2 = Rational(x2,y2);
+			this.assertEquals(
+				z1 - z2,
+				z2.neg - z1.neg,
+				format( "Subtraction and Inverse test with % and % passed.", z1, z2));
+			}
+	}
+
+	test_reciprocal_Div {
+
+		this.setRandSeed;
+
+		numTests.do {
+			var x1 = 1 + maxIntVal.rand * [-1,1].choose;
+			var y1 = 1 + maxIntVal.rand * [-1,1].choose;
+			var x2 = 1 + maxIntVal.rand * [-1,1].choose;
+			var y2 = 1 + maxIntVal.rand * [-1,1].choose;
+			var z1 = Rational(x1,y1);
+			var z2 = Rational(x2,y2);
+			this.assertEquals(
+				z1 / z2,
+				(z2 / z1).reciprocal,
+				format( "Div + reciprocal test with % and % passed.", z1, z2));
+			}
+	}
+
+	test_Sort_and_Scramble  {
+		var listSize = 1000;
+
+		this.setRandSeed;
+
+		//numTests.do {
+		10.do {
+			var ratList;
+			ratList = Array.fill(
+				listSize,
+				{
+					Rational(
+						rrand(minIntVal, maxIntVal),
+						 1 + maxIntVal.rand * [-1,1].choose;)
+				}
+				);
+			this.assertEquals(
+				ratList.sort,
+				ratList.scramble.sort,
+				format( "Sort and Scramble test passed.")
+			);
+		}
+	}
+
+	test_Sort_and_asFloat  {
+		var listSize = 1000;
+
+		this.setRandSeed;
+
+		//numTests.do {
+		10.do {
+			var ratList;
+
+			ratList = Array.fill(
+				listSize,
+				{
+					Rational(
+						rrand(minIntVal, maxIntVal),
+						1 + maxIntVal.rand * [-1,1].choose;)
+				}
+				);
+
+			this.assertEquals(
+				ratList.scramble.sort.asFloat,
+				ratList.scramble.asFloat.sort,
+				format( "Sort and asFloat test passed.")
+			);
+		}
+	}
+
+	test_Mul_Inverse_DifferentExponents_NonZeroIntInput {
+
+		this.setRandSeed;
+
+		numTests.do {
+			var maxVal = 100;
+			var x1 = 1 + maxVal.rand * [-1,1].choose;
+			var y1 = 1 + maxVal.rand * [-1,1].choose;
+			var rat = Rational(x1,y1);
+			var maxExponent = 6;
+
+			maxExponent.do({arg i;
+				this.assertEquals(
+					rat.pow(i * (-1)),
+					rat.pow(i).reciprocal,
+					format( "Multiplicative inverse with different exponents test with exp: % and rat: % passed.", i, rat));
+
+			})
+
+		}
+	}
+
+	test_Float_Rat_Float {
+
+		this.setRandSeed;
+
+		numTests.do {
+			var maxVal = 1000.01;
+			var x = 1 + maxVal.rand * [1,1.neg].choose;
+			var y = 1 + maxVal.rand * [1,1.neg].choose;
+			var rat = Rational(x,y);
+			var float = x/y;
+
+			this.assertFloatEquals(
+				a: rat.asFloat,
+				b: float.asRational.asFloat,
+				message: format(
+					"Float/Rational conversion with  rat: % and float: % passed.", rat, float),
+				within: 0.000001
+			);
+		}
+	}
+
+	test_Rat_Float_Rat {
+
+		this.setRandSeed;
+
+		numTests.do {
+			var maxVal = 100;
+			var x = 1 + maxVal.rand * [1,1.neg].choose;
+			var y = 1 + maxVal.rand * [1,1.neg].choose;
+			var rat = Rational(x,y);
+			var float = x/y;
+
+			this.assertEquals(
+				a: rat,
+				b: float.asRational.asFloat.asRational,
+				message: format(
+					"Float/Rational conversion with rat: % and float: % passed.", rat, float)
+			);
+		}
+	}
+
+
+	test_Exponentiation {
+
+		this.setRandSeed;
+
+	   numTests.do {
+			var maxVal = 9;
+			var x = 1 + maxVal.rand;
+			var y = 1 + maxVal.rand;
+			var r = Rational(x,y);
+			var e = rrand(1, 5).round;
+			this.assertEquals(
+				r,
+				r.pow(e).pow(e.reciprocal),
+				format(
+					"Exponentiation rational: % and exponent: % passed.", r, e));
+		}
+	}
+
+	// associative property
+	test_AssociativeAdd {
+		this.setRandSeed;
+		numTests.do {
+			var x1 = rrand(minIntVal,maxIntVal);
+			var y1 = 1 + maxIntVal.rand * [-1,1].choose;
+			var x2 = rrand(minIntVal,maxIntVal);
+			var y2 = 1 + maxIntVal.rand * [-1,1].choose;
+			var x3 = rrand(minIntVal,maxIntVal);
+			var y3 = 1 + maxIntVal.rand * [-1,1].choose;
+			var z1 = Rational(x1,y1);
+			var z2 = Rational(x2,y2);
+			var z3 = Rational(x3,y3);
+			this.assertEquals(
+				(z1 + z2) + z3,
+				z1 + (z2 + z3),
+				format( "Associative Sum test with %, % and %passed.", z1, z2, z3))
+		}
+	}
+
+	test_AssociativeMul {
+
+		this.setRandSeed;
+
+		numTests.do {
+			var x1 = rrand(minIntVal,maxIntVal);
+			var y1 = 1 + maxIntVal.rand * [-1,1].choose;
+			var x2 = rrand(minIntVal,maxIntVal);
+			var y2 = 1 + maxIntVal.rand * [-1,1].choose;
+			var x3 = rrand(minIntVal,maxIntVal);
+			var y3 = 1 + maxIntVal.rand * [-1,1].choose;
+			var z1 = Rational(x1,y1);
+			var z2 = Rational(x2,y2);
+			var z3 = Rational(x3,y3);
+
+			this.assertEquals(
+				(z1 * z2) * z3,
+				z1 * (z2 * z3),
+				format( "Associative Mul test with %, % and %passed.", z1, z2, z3));
+		}
+	}
+
+	// distributive property
+	// (a + b) * c = (a * c) + (b * c)
+	test_Distributive_1_PositiveIntInput {
+
+		this.setRandSeed;
+
+		numTests.do {
+			var minVal = 1;
+			var maxVal = 20;
+			var x1 = rrand(minVal,maxVal);
+			var y1 = 1 + maxVal.rand ;
+			var x2 = rrand(minVal,maxVal);
+			var y2 = 1 + maxVal.rand ;
+			var x3 = rrand(minVal,maxVal);
+			var y3 = 1 + maxVal.rand ;
+			var a = Rational(x1,y1);
+			var b = Rational(x2,y2);
+			var c = Rational(x3,y3);
+
+			this.assertEquals(
+				(a + b) * c,
+				(a * c) + (b * c),
+				format( "Associative property 1 test with %, % and % passed.", a, b, c)
+			);
+		}
+	}
+
+	test_commutativeAdd_Array {
+
+		this.setRandSeed;
+
+		numTests.do {
+			var n = 20;
+			var minVal = -10;
+			var maxVal = 10;
+			var xs = Array.fill(n, {rrand(minVal,maxVal)});
+			var ys = Array.fill(n, {1 + maxVal.rand * [-1,1].choose});
+			var rats;
+
+			rats = n.collect({arg i; Rational(xs[i], ys[i])});
+
+			this.assertEquals(
+				rats.scramble.sum,
+				rats.scramble.sum,
+				format( "Commutative with Array summation test with %", rats));
+		}
+	}
 }
 
 

--- a/testsuite/classlibrary/TestRational.sc
+++ b/testsuite/classlibrary/TestRational.sc
@@ -1,0 +1,185 @@
+/*
+TestRational.run
+UnitTest.gui
+*/
+
+TestRational : UnitTest {
+
+    var minIntVal= -1000, maxIntVal=1000;
+    var minFloatVal= -1000.1, maxFloatVal=1000.1;
+    var numTests = 1000;
+
+    test_reciprocal_NonZeroIntInput {
+        numTests.do {
+            var x = rrand(minIntVal,maxIntVal);
+            var y = 1 + maxIntVal.rand * [-1,1].choose;
+            var z = Rational(x,y);
+            this.assertEquals(
+                z,
+                z.reciprocal.reciprocal,
+                format( "Reciprocal test with % passed.", z)
+            );
+            }
+    }
+
+    test_newFromString_NonZeroIntInput {
+        numTests.do {
+            var x = rrand(minIntVal,maxIntVal);
+            var y = 1 + maxIntVal.rand * [-1,1].choose;
+            var xStr = x.asString;
+            var yStr = y.asString;
+            var rat1 = Rational(x,y);
+            var rat2 = Rational.newFrom(xStr ++ "/"++ yStr);
+            this.assertEquals(
+                rat1,
+                rat2,
+                format( "String entry test with % passed.", rat1)
+            );
+        }
+    }
+
+    test_commutativeAdd_NonZeroIntInput {
+        numTests.do {
+            var x1 = rrand(minIntVal,maxIntVal);
+            var y1 = 1 + maxIntVal.rand * [-1,1].choose;
+            var x2 = rrand(minIntVal,maxIntVal);
+            var y2 = 1 + maxIntVal.rand;
+            var z1 = Rational(x1,y1);
+            var z2 = Rational(x2,y2);
+            this.assertEquals(
+                z1 + z2,
+                z2 + z1,
+                format( "Commutative Add test with % and % passed.", z1, z2));
+            }
+    }
+
+    test_commutativeMul_NonZeroIntInput {
+        numTests.do {
+            var x1 = rrand(minIntVal,maxIntVal);
+            var y1 = 1 + maxIntVal.rand * [-1,1].choose;
+            var x2 = rrand(minIntVal,maxIntVal);
+            var y2 = 1 + maxIntVal.rand * [-1,1].choose;
+            var z1 = Rational(x1,y1);
+            var z2 = Rational(x2,y2);
+            this.assertEquals(
+                z1 * z2,
+                z2 * z1,
+                format( "Commutative Add test with % and % passed.", z1, z2));
+            }
+    }
+
+    test_Additive_Inverse_NonZeroIntInput {
+        numTests.do {
+            var x = rrand(minIntVal,maxIntVal);
+            var y = 1 + maxIntVal.rand * [-1,1].choose;
+            var rat=Rational(x,y);
+
+            this.assertEquals(
+                Rational(x * (-1), y),
+                Rational(x, y * (-1)),
+                format( "Additive Inverse test 1 with % passed.", rat)
+            );
+            this.assertEquals(
+                (-1) * rat,
+                Rational(x * (-1), y),
+                format( "Additive Inverse test 2 with % passed.", rat));
+            this.assertEquals(
+                (-1) * rat,
+                Rational(x, y * (-1)),
+                format( "Additive Inverse test 3 with % passed.", rat));
+        }
+    }
+
+    test_Div_Eq_ReciprocalMul_NonZeroIntInput  {
+        numTests.do {
+            var x1 = rrand(minIntVal,maxIntVal);
+            var y1 = 1 + maxIntVal.rand * [-1,1].choose;
+            var x2 = 1 + maxIntVal.rand * [-1,1].choose;
+            var y2 = 1 + maxIntVal.rand * [-1,1].choose;
+            var z1 = Rational(x1,y1);
+            var z2 = Rational(x2,y2);
+            this.assertEquals(
+                z1 / z2,
+                z1 * z2.reciprocal,
+                format( "Division is equivalent to multiplying by the reciprocal test with % and %", z1, z2));
+            }
+    }
+
+    test_Neg_Subtraction_NonZeroIntInput {
+        numTests.do {
+            var x1 = rrand(minIntVal,maxIntVal);
+            var y1 = 1 + maxIntVal.rand * [-1,1].choose;
+            var x2 = rrand(minIntVal,maxIntVal);
+            var y2 = 1 + maxIntVal.rand * [-1,1].choose;
+            var z1 = Rational(x1,y1);
+            var z2 = Rational(x2,y2);
+            this.assertEquals(
+                z1 - z2,
+                z2.neg - z1.neg,
+                format( "Subtraction and Inverse test with % and % passed.", z1, z2));
+            }
+    }
+
+    test_reciprocal_Div_NonZeroIntInput {
+        numTests.do {
+            var x1 = rrand(minIntVal,maxIntVal);
+            var y1 = 1 + maxIntVal.rand * [-1,1].choose;
+            var x2 = rrand(minIntVal,maxIntVal);
+            var y2 = 1 + maxIntVal.rand * [-1,1].choose;
+            var z1 = Rational(x1,y1);
+            var z2 = Rational(x2,y2);
+            this.assertEquals(
+                z1 / z2,
+                (z2 / z1).reciprocal,
+                format( "Div + reciprocal test with % and % passed.", z1, z2));
+            }
+    }
+
+    test_Sort_and_Scramble_NonZeroIntInput  {
+        var listSize = 1000;
+
+        //numTests.do {
+        10.do {
+            var ratList;
+            ratList = Array.fill(
+                listSize,
+                {
+                    Rational(
+                        rrand(minIntVal, maxIntVal),
+                         1 + maxIntVal.rand * [-1,1].choose;)
+                }
+                );
+            this.assertEquals(
+                ratList.sort,
+                ratList.scramble.sort,
+                format( "Sort and Scramble test passed.")
+            );
+        }
+    }
+
+    test_Sort_and_asFloat_NonZeroIntInput  {
+        var listSize = 1000;
+
+        //numTests.do {
+        10.do {
+            var ratList;
+
+            ratList = Array.fill(
+                listSize,
+                {
+                    Rational(
+                        rrand(minIntVal, maxIntVal),
+                        1 + maxIntVal.rand * [-1,1].choose;)
+                }
+                );
+
+            this.assertEquals(
+                ratList.scramble.sort.asFloat,
+                ratList.scramble.asFloat.sort,
+                format( "Sort and asFloat test passed.")
+            );
+        }
+    }
+
+}
+

--- a/testsuite/classlibrary/TestRational.sc
+++ b/testsuite/classlibrary/TestRational.sc
@@ -5,267 +5,306 @@ UnitTest.gui
 
 TestRational : UnitTest {
 
-	var minIntVal= -1000, maxIntVal=1000;
-	var minFloatVal= -1000.1, maxFloatVal=1000.1;
-	var numTests = 1000;
+    var minIntVal= -1000, maxIntVal=1000;
+    var minFloatVal= -1000.1, maxFloatVal=1000.1;
+    var numTests = 1000;
 
-	test_reciprocal_NonZeroIntInput {
-		numTests.do {
-			var x = rrand(minIntVal,maxIntVal);
-			var y = 1 + maxIntVal.rand * [-1,1].choose;
-			var z = Rational(x,y);
-			this.assertEquals(
-				z,
-				z.reciprocal.reciprocal,
-				format( "Reciprocal test with % passed.", z)
-			);
-			}
-	}
+    test_reciprocal_NonZeroIntInput {
+        numTests.do {
+            var x = rrand(minIntVal,maxIntVal);
+            var y = 1 + maxIntVal.rand * [-1,1].choose;
+            var z = Rational(x,y);
+            this.assertEquals(
+                z,
+                z.reciprocal.reciprocal,
+                format( "Reciprocal test with % passed.", z)
+            );
+            }
+    }
 
-	test_newFromString_NonZeroIntInput {
-		numTests.do {
-			var x = rrand(minIntVal,maxIntVal);
-			var y = 1 + maxIntVal.rand * [-1,1].choose;
-			var xStr = x.asString;
-			var yStr = y.asString;
-			var rat1 = Rational(x,y);
-			var rat2 = Rational.newFrom(xStr ++ "/"++ yStr);
-			this.assertEquals(
-				rat1,
-				rat2,
-				format( "String entry test with % passed.", rat1)
-			);
-		}
-	}
+    test_newFromString_NonZeroIntInput {
+        numTests.do {
+            var x = rrand(minIntVal,maxIntVal);
+            var y = 1 + maxIntVal.rand * [-1,1].choose;
+            var xStr = x.asString;
+            var yStr = y.asString;
+            var rat1 = Rational(x,y);
+            var rat2 = Rational.newFrom(xStr ++ "/"++ yStr);
+            this.assertEquals(
+                rat1,
+                rat2,
+                format( "String entry test with % passed.", rat1)
+            );
+        }
+    }
 
-	test_commutativeAdd_NonZeroIntInput {
-		numTests.do {
-			var x1 = rrand(minIntVal,maxIntVal);
-			var y1 = 1 + maxIntVal.rand * [-1,1].choose;
-			var x2 = rrand(minIntVal,maxIntVal);
-			var y2 = 1 + maxIntVal.rand;
-			var z1 = Rational(x1,y1);
-			var z2 = Rational(x2,y2);
-			this.assertEquals(
-				z1 + z2,
-				z2 + z1,
-				format( "Commutative Add test with % and % passed.", z1, z2));
-			}
-	}
+    test_commutativeAdd_NonZeroIntInput {
+        numTests.do {
+            var x1 = rrand(minIntVal,maxIntVal);
+            var y1 = 1 + maxIntVal.rand * [-1,1].choose;
+            var x2 = rrand(minIntVal,maxIntVal);
+            var y2 = 1 + maxIntVal.rand;
+            var z1 = Rational(x1,y1);
+            var z2 = Rational(x2,y2);
+            this.assertEquals(
+                z1 + z2,
+                z2 + z1,
+                format( "Commutative Add test with % and % passed.", z1, z2));
+            }
+    }
 
-	test_commutativeMul_NonZeroIntInput {
-		numTests.do {
-			var x1 = rrand(minIntVal,maxIntVal);
-			var y1 = 1 + maxIntVal.rand * [-1,1].choose;
-			var x2 = rrand(minIntVal,maxIntVal);
-			var y2 = 1 + maxIntVal.rand * [-1,1].choose;
-			var z1 = Rational(x1,y1);
-			var z2 = Rational(x2,y2);
-			this.assertEquals(
-				z1 * z2,
-				z2 * z1,
-				format( "Commutative Add test with % and % passed.", z1, z2));
-			}
-	}
+    test_commutativeMul_NonZeroIntInput {
+        numTests.do {
+            var x1 = rrand(minIntVal,maxIntVal);
+            var y1 = 1 + maxIntVal.rand * [-1,1].choose;
+            var x2 = rrand(minIntVal,maxIntVal);
+            var y2 = 1 + maxIntVal.rand * [-1,1].choose;
+            var z1 = Rational(x1,y1);
+            var z2 = Rational(x2,y2);
+            this.assertEquals(
+                z1 * z2,
+                z2 * z1,
+                format( "Commutative Add test with % and % passed.", z1, z2));
+            }
+    }
 
-	test_Additive_Inverse_NonZeroIntInput {
-		numTests.do {
-			var x = rrand(minIntVal,maxIntVal);
-			var y = 1 + maxIntVal.rand * [1,1.neg].choose;
-			var rat=Rational(x,y);
+    test_Additive_Inverse_NonZeroIntInput {
+        numTests.do {
+            var x = rrand(minIntVal,maxIntVal);
+            var y = 1 + maxIntVal.rand * [1,1.neg].choose;
+            var rat=Rational(x,y);
 
-			this.assertEquals(
-				Rational(x * (-1), y),
-				Rational(x, y * (-1)),
-				format( "Additive Inverse test 1 with % passed.", rat)
-			);
-			this.assertEquals(
-				(-1) * rat,
-				Rational(x * (-1), y),
-				format( "Additive Inverse test 2 with % passed.", rat)
-			);
-			this.assertEquals(
-				(-1) * rat,
-				Rational(x, y * (-1)),
-				format( "Additive Inverse test 3 with % passed.", rat)
-			)
-		}
-	}
+            this.assertEquals(
+                Rational(x * (-1), y),
+                Rational(x, y * (-1)),
+                format( "Additive Inverse test 1 with % passed.", rat)
+            );
+            this.assertEquals(
+                (-1) * rat,
+                Rational(x * (-1), y),
+                format( "Additive Inverse test 2 with % passed.", rat)
+            );
+            this.assertEquals(
+                (-1) * rat,
+                Rational(x, y * (-1)),
+                format( "Additive Inverse test 3 with % passed.", rat)
+            )
+        }
+    }
 
-	test_Multiplicative_Inverse_NonZeroIntInput {
-		numTests.do {
-			var x    = 1 + maxIntVal.rand * [-1,1].choose;
-			var y    = 1 + maxIntVal.rand * [-1,1].choose;
-			var rat1 = Rational(x,y);
-			var rat2 = Rational(y,x);
+    test_Multiplicative_Inverse_NonZeroIntInput {
+        numTests.do {
+            var x    = 1 + maxIntVal.rand * [-1,1].choose;
+            var y    = 1 + maxIntVal.rand * [-1,1].choose;
+            var rat1 = Rational(x,y);
+            var rat2 = Rational(y,x);
 
-			this.assertEquals(
-				rat1.pow(-1),
-				rat2,
-				format( "Multiplicative Inverse test with % passed.", rat1)
-			);
-		}
-	}
+            this.assertEquals(
+                rat1.pow(-1),
+                rat2,
+                format( "Multiplicative Inverse test with % passed.", rat1)
+            );
+        }
+    }
 
-	test_Div_Eq_ReciprocalMul_NonZeroIntInput  {
-		numTests.do {
-			var x1 = rrand(minIntVal,maxIntVal);
-			var y1 = 1 + maxIntVal.rand * [-1,1].choose;
-			var x2 = 1 + maxIntVal.rand * [-1,1].choose;
-			var y2 = 1 + maxIntVal.rand * [-1,1].choose;
-			var z1 = Rational(x1,y1);
-			var z2 = Rational(x2,y2);
-			this.assertEquals(
-				z1 / z2,
-				z1 * z2.reciprocal,
-				format( "Division is equivalent to multiplying by the reciprocal test with % and %", z1, z2));
-			}
-	}
+    test_Div_Eq_ReciprocalMul_NonZeroIntInput  {
+        numTests.do {
+            var x1 = rrand(minIntVal,maxIntVal);
+            var y1 = 1 + maxIntVal.rand * [-1,1].choose;
+            var x2 = 1 + maxIntVal.rand * [-1,1].choose;
+            var y2 = 1 + maxIntVal.rand * [-1,1].choose;
+            var z1 = Rational(x1,y1);
+            var z2 = Rational(x2,y2);
+            this.assertEquals(
+                z1 / z2,
+                z1 * z2.reciprocal,
+                format( "Division is equivalent to multiplying by the reciprocal test with % and %", z1, z2));
+            }
+    }
 
-	test_Neg_Subtraction_NonZeroIntInput {
-		numTests.do {
-			var x1 = rrand(minIntVal,maxIntVal);
-			var y1 = 1 + maxIntVal.rand * [-1,1].choose;
-			var x2 = rrand(minIntVal,maxIntVal);
-			var y2 = 1 + maxIntVal.rand * [-1,1].choose;
-			var z1 = Rational(x1,y1);
-			var z2 = Rational(x2,y2);
-			this.assertEquals(
-				z1 - z2,
-				z2.neg - z1.neg,
-				format( "Subtraction and Inverse test with % and % passed.", z1, z2));
-			}
-	}
+    test_Neg_Subtraction_NonZeroIntInput {
+        numTests.do {
+            var x1 = rrand(minIntVal,maxIntVal);
+            var y1 = 1 + maxIntVal.rand * [-1,1].choose;
+            var x2 = rrand(minIntVal,maxIntVal);
+            var y2 = 1 + maxIntVal.rand * [-1,1].choose;
+            var z1 = Rational(x1,y1);
+            var z2 = Rational(x2,y2);
+            this.assertEquals(
+                z1 - z2,
+                z2.neg - z1.neg,
+                format( "Subtraction and Inverse test with % and % passed.", z1, z2));
+            }
+    }
 
-	test_reciprocal_Div_NonZeroIntInput {
-		numTests.do {
-			var x1 = rrand(minIntVal,maxIntVal);
-			var y1 = 1 + maxIntVal.rand * [-1,1].choose;
-			var x2 = rrand(minIntVal,maxIntVal);
-			var y2 = 1 + maxIntVal.rand * [-1,1].choose;
-			var z1 = Rational(x1,y1);
-			var z2 = Rational(x2,y2);
-			this.assertEquals(
-				z1 / z2,
-				(z2 / z1).reciprocal,
-				format( "Div + reciprocal test with % and % passed.", z1, z2));
-			}
-	}
+    test_reciprocal_Div_NonZeroIntInput {
+        numTests.do {
+            var x1 = rrand(minIntVal,maxIntVal);
+            var y1 = 1 + maxIntVal.rand * [-1,1].choose;
+            var x2 = rrand(minIntVal,maxIntVal);
+            var y2 = 1 + maxIntVal.rand * [-1,1].choose;
+            var z1 = Rational(x1,y1);
+            var z2 = Rational(x2,y2);
+            this.assertEquals(
+                z1 / z2,
+                (z2 / z1).reciprocal,
+                format( "Div + reciprocal test with % and % passed.", z1, z2));
+            }
+    }
 
-	test_Sort_and_Scramble_NonZeroIntInput  {
-		var listSize = 1000;
+    test_Sort_and_Scramble_NonZeroIntInput  {
+        var listSize = 1000;
 
-		//numTests.do {
-		10.do {
-			var ratList;
-			ratList = Array.fill(
-				listSize,
-				{
-					Rational(
-						rrand(minIntVal, maxIntVal),
-						 1 + maxIntVal.rand * [-1,1].choose;)
-				}
-				);
-			this.assertEquals(
-				ratList.sort,
-				ratList.scramble.sort,
-				format( "Sort and Scramble test passed.")
-			);
-		}
-	}
+        //numTests.do {
+        10.do {
+            var ratList;
+            ratList = Array.fill(
+                listSize,
+                {
+                    Rational(
+                        rrand(minIntVal, maxIntVal),
+                         1 + maxIntVal.rand * [-1,1].choose;)
+                }
+                );
+            this.assertEquals(
+                ratList.sort,
+                ratList.scramble.sort,
+                format( "Sort and Scramble test passed.")
+            );
+        }
+    }
 
-	test_Sort_and_asFloat_NonZeroIntInput  {
-		var listSize = 1000;
+    test_Sort_and_asFloat_NonZeroIntInput  {
+        var listSize = 1000;
 
-		//numTests.do {
-		10.do {
-			var ratList;
+        //numTests.do {
+        10.do {
+            var ratList;
 
-			ratList = Array.fill(
-				listSize,
-				{
-					Rational(
-						rrand(minIntVal, maxIntVal),
-						1 + maxIntVal.rand * [-1,1].choose;)
-				}
-				);
+            ratList = Array.fill(
+                listSize,
+                {
+                    Rational(
+                        rrand(minIntVal, maxIntVal),
+                        1 + maxIntVal.rand * [-1,1].choose;)
+                }
+                );
 
-			this.assertEquals(
-				ratList.scramble.sort.asFloat,
-				ratList.scramble.asFloat.sort,
-				format( "Sort and asFloat test passed.")
-			);
-		}
-	}
+            this.assertEquals(
+                ratList.scramble.sort.asFloat,
+                ratList.scramble.asFloat.sort,
+                format( "Sort and asFloat test passed.")
+            );
+        }
+    }
 
-	test_Mul_Inverse_DifferentExponents_NonZeroIntInput {
-		numTests.do {
-			var maxVal = 100;
-			var x1 = 1 + maxVal.rand * [-1,1].choose;
-			var y1 = 1 + maxVal.rand * [-1,1].choose;
-			var rat = Rational(x1,y1);
-			var maxExponent = 6;
+    test_Mul_Inverse_DifferentExponents_NonZeroIntInput {
+        numTests.do {
+            var maxVal = 100;
+            var x1 = 1 + maxVal.rand * [-1,1].choose;
+            var y1 = 1 + maxVal.rand * [-1,1].choose;
+            var rat = Rational(x1,y1);
+            var maxExponent = 6;
 
-			maxExponent.do({arg i;
-				this.assertEquals(
-					rat.pow(i * (-1)),
-					rat.pow(i).reciprocal,
-					format( "Multiplicative inverse with different exponents test with exp: % and rat: % passed.", i, rat));
+            maxExponent.do({arg i;
+                this.assertEquals(
+                    rat.pow(i * (-1)),
+                    rat.pow(i).reciprocal,
+                    format( "Multiplicative inverse with different exponents test with exp: % and rat: % passed.", i, rat));
 
-			})
+            })
 
-		}
-	}
+        }
+    }
 
-	test_Float_Rat_Float {
-		numTests.do {
-			var maxVal = 1000.01;
-			var x = 1 + maxVal.rand * [1,1.neg].choose;
-			var y = 1 + maxVal.rand * [1,1.neg].choose;
-			var rat = Rational(x,y);
-			var float = x/y;
+    test_Float_Rat_Float {
+        numTests.do {
+            var maxVal = 1000.01;
+            var x = 1 + maxVal.rand * [1,1.neg].choose;
+            var y = 1 + maxVal.rand * [1,1.neg].choose;
+            var rat = Rational(x,y);
+            var float = x/y;
 
-			this.assertFloatEquals(
-				a: rat.asFloat,
-				b: float.asRational.asFloat,
-				message: format(
-					"Float/Rational conversion with  rat: % and float: % passed.", rat, float),
-				within: 0.000001
-			);
-		}
-	}
+            this.assertFloatEquals(
+                a: rat.asFloat,
+                b: float.asRational.asFloat,
+                message: format(
+                    "Float/Rational conversion with  rat: % and float: % passed.", rat, float),
+                within: 0.000001
+            );
+        }
+    }
 
-	test_Rat_Float_Rat {
-		numTests.do {
-			var maxVal = 100;
-			var x = 1 + maxVal.rand * [1,1.neg].choose;
-			var y = 1 + maxVal.rand * [1,1.neg].choose;
-			var rat = Rational(x,y);
-			var float = x/y;
+    test_Rat_Float_Rat {
+        numTests.do {
+            var maxVal = 100;
+            var x = 1 + maxVal.rand * [1,1.neg].choose;
+            var y = 1 + maxVal.rand * [1,1.neg].choose;
+            var rat = Rational(x,y);
+            var float = x/y;
 
-			this.assertEquals(
-				a: rat,
-				b: float.asRational.asFloat.asRational,
-				message: format(
-					"Float/Rational conversion with rat: % and float: % passed.", rat, float)
-			);
-		}
-	}
+            this.assertEquals(
+                a: rat,
+                b: float.asRational.asFloat.asRational,
+                message: format(
+                    "Float/Rational conversion with rat: % and float: % passed.", rat, float)
+            );
+        }
+    }
 
-	test_Exponentiation {
-	   numTests.do {
-			var maxVal = 9;
-			var x = 1 + maxVal.rand;
-			var y = 1 + maxVal.rand;
-			var r = Rational(x,y);
-			var e = rrand(1, 5).round;
-			this.assertEquals(
-				r,
-				r.pow(e).pow(e.reciprocal),
-				format(
-					"Exponentiation rational: % and exponent: % passed.", r, e));
-		}
-	}
+
+    test_Exponentiation {
+       numTests.do {
+            var maxVal = 9;
+            var x = 1 + maxVal.rand;
+            var y = 1 + maxVal.rand;
+            var r = Rational(x,y);
+            var e = rrand(1, 5).round;
+            this.assertEquals(
+                r,
+                r.pow(e).pow(e.reciprocal),
+                format(
+                    "Exponentiation rational: % and exponent: % passed.", r, e));
+        }
+    }
+
+    test_AssociativeAdd_NonZeroIntInput {
+        numTests.do {
+            var x1 = rrand(minIntVal,maxIntVal);
+            var y1 = 1 + maxIntVal.rand * [-1,1].choose;
+            var x2 = rrand(minIntVal,maxIntVal);
+            var y2 = 1 + maxIntVal.rand * [-1,1].choose;
+            var x3 = rrand(minIntVal,maxIntVal);
+            var y3 = 1 + maxIntVal.rand * [-1,1].choose;
+            var z1 = Rational(x1,y1);
+            var z2 = Rational(x2,y2);
+            var z3 = Rational(x3,y3);
+
+            this.assertEquals(
+                (z1 + z2) + z3,
+                z1 + (z2 + z3),
+                format( "Associative Sum test with %, % and %passed.", z1, z2, z3));
+        }
+    }
+
+    test_AssociativeMul_NonZeroIntInput {
+        numTests.do {
+            var x1 = rrand(minIntVal,maxIntVal);
+            var y1 = 1 + maxIntVal.rand * [-1,1].choose;
+            var x2 = rrand(minIntVal,maxIntVal);
+            var y2 = 1 + maxIntVal.rand * [-1,1].choose;
+            var x3 = rrand(minIntVal,maxIntVal);
+            var y3 = 1 + maxIntVal.rand * [-1,1].choose;
+            var z1 = Rational(x1,y1);
+            var z2 = Rational(x2,y2);
+            var z3 = Rational(x3,y3);
+
+            this.assertEquals(
+                (z1 * z2) * z3,
+                z1 * (z2 * z3),
+                format( "Associative Mul test with %, % and %passed.", z1, z2, z3));
+        }
+    }
 
 }
 

--- a/testsuite/classlibrary/TestRational.sc
+++ b/testsuite/classlibrary/TestRational.sc
@@ -5,331 +5,348 @@ UnitTest.gui
 
 TestRational : UnitTest {
 
-    var minIntVal= -1000, maxIntVal=1000;
-    var minFloatVal= -1000.1, maxFloatVal=1000.1;
-    var numTests = 1000;
+	var minIntVal= -1000, maxIntVal=1000;
+	var minFloatVal= -1000.1, maxFloatVal=1000.1;
+	var numTests = 1000;
 
-    test_reciprocal_NonZeroIntInput {
-        numTests.do {
-            var x = rrand(minIntVal,maxIntVal);
-            var y = 1 + maxIntVal.rand * [-1,1].choose;
-            var z = Rational(x,y);
-            this.assertEquals(
-                z,
-                z.reciprocal.reciprocal,
-                format( "Reciprocal test with % passed.", z)
-            );
-            }
-    }
+	test_reciprocal_NonZeroIntInput {
+		numTests.do {
+			var x = rrand(minIntVal,maxIntVal);
+			var y = 1 + maxIntVal.rand * [-1,1].choose;
+			var z = Rational(x,y);
+			this.assertEquals(
+				z,
+				z.reciprocal.reciprocal,
+				format( "Reciprocal test with % passed.", z)
+			);
+			}
+	}
 
-    test_newFromString_NonZeroIntInput {
-        numTests.do {
-            var x = rrand(minIntVal,maxIntVal);
-            var y = 1 + maxIntVal.rand * [-1,1].choose;
-            var xStr = x.asString;
-            var yStr = y.asString;
-            var rat1 = Rational(x,y);
-            var rat2 = Rational.newFrom(xStr ++ "/"++ yStr);
-            this.assertEquals(
-                rat1,
-                rat2,
-                format( "String entry test with % passed.", rat1)
-            );
-        }
-    }
+	test_newFromString_NonZeroIntInput {
+		numTests.do {
+			var x = rrand(minIntVal,maxIntVal);
+			var y = 1 + maxIntVal.rand * [-1,1].choose;
+			var xStr = x.asString;
+			var yStr = y.asString;
+			var rat1 = Rational(x,y);
+			var rat2 = Rational.newFrom(xStr ++ "/"++ yStr);
+			this.assertEquals(
+				rat1,
+				rat2,
+				format( "String entry test with % passed.", rat1)
+			);
+		}
+	}
 
-    test_commutativeAdd_NonZeroIntInput {
-        numTests.do {
-            var x1 = rrand(minIntVal,maxIntVal);
-            var y1 = 1 + maxIntVal.rand * [-1,1].choose;
-            var x2 = rrand(minIntVal,maxIntVal);
-            var y2 = 1 + maxIntVal.rand;
-            var z1 = Rational(x1,y1);
-            var z2 = Rational(x2,y2);
-            this.assertEquals(
-                z1 + z2,
-                z2 + z1,
-                format( "Commutative Add test with % and % passed.", z1, z2));
-            }
-    }
+	test_commutativeAdd_NonZeroIntInput {
+		numTests.do {
+			var x1 = rrand(minIntVal,maxIntVal);
+			var y1 = 1 + maxIntVal.rand * [-1,1].choose;
+			var x2 = rrand(minIntVal,maxIntVal);
+			var y2 = 1 + maxIntVal.rand;
+			var z1 = Rational(x1,y1);
+			var z2 = Rational(x2,y2);
+			this.assertEquals(
+				z1 + z2,
+				z2 + z1,
+				format( "Commutative Add test with % and % passed.", z1, z2));
+			}
+	}
 
-    test_commutativeMul_NonZeroIntInput {
-        numTests.do {
-            var x1 = rrand(minIntVal,maxIntVal);
-            var y1 = 1 + maxIntVal.rand * [-1,1].choose;
-            var x2 = rrand(minIntVal,maxIntVal);
-            var y2 = 1 + maxIntVal.rand * [-1,1].choose;
-            var z1 = Rational(x1,y1);
-            var z2 = Rational(x2,y2);
-            this.assertEquals(
-                z1 * z2,
-                z2 * z1,
-                format( "Commutative Add test with % and % passed.", z1, z2));
-            }
-    }
+	test_commutativeMul_NonZeroIntInput {
+		numTests.do {
+			var x1 = rrand(minIntVal,maxIntVal);
+			var y1 = 1 + maxIntVal.rand * [-1,1].choose;
+			var x2 = rrand(minIntVal,maxIntVal);
+			var y2 = 1 + maxIntVal.rand * [-1,1].choose;
+			var z1 = Rational(x1,y1);
+			var z2 = Rational(x2,y2);
+			this.assertEquals(
+				z1 * z2,
+				z2 * z1,
+				format( "Commutative Add test with % and % passed.", z1, z2));
+			}
+	}
 
-    test_Additive_Inverse_NonZeroIntInput {
-        numTests.do {
-            var x = rrand(minIntVal,maxIntVal);
-            var y = 1 + maxIntVal.rand * [1,1.neg].choose;
-            var rat=Rational(x,y);
+	test_Additive_Inverse_NonZeroIntInput {
+		numTests.do {
+			var x = rrand(minIntVal,maxIntVal);
+			var y = 1 + maxIntVal.rand * [1,1.neg].choose;
+			var rat=Rational(x,y);
 
-            this.assertEquals(
-                Rational(x * (-1), y),
-                Rational(x, y * (-1)),
-                format( "Additive Inverse test 1 with % passed.", rat)
-            );
-            this.assertEquals(
-                (-1) * rat,
-                Rational(x * (-1), y),
-                format( "Additive Inverse test 2 with % passed.", rat)
-            );
-            this.assertEquals(
-                (-1) * rat,
-                Rational(x, y * (-1)),
-                format( "Additive Inverse test 3 with % passed.", rat)
-            )
-        }
-    }
+			this.assertEquals(
+				Rational(x * (-1), y),
+				Rational(x, y * (-1)),
+				format( "Additive Inverse test 1 with % passed.", rat)
+			);
+			this.assertEquals(
+				(-1) * rat,
+				Rational(x * (-1), y),
+				format( "Additive Inverse test 2 with % passed.", rat)
+			);
+			this.assertEquals(
+				(-1) * rat,
+				Rational(x, y * (-1)),
+				format( "Additive Inverse test 3 with % passed.", rat)
+			)
+		}
+	}
 
-    test_Multiplicative_Inverse_NonZeroIntInput {
-        numTests.do {
-            var x    = 1 + maxIntVal.rand * [-1,1].choose;
-            var y    = 1 + maxIntVal.rand * [-1,1].choose;
-            var rat1 = Rational(x,y);
-            var rat2 = Rational(y,x);
+	test_Multiplicative_Inverse_NonZeroIntInput {
+		numTests.do {
+			var x    = 1 + maxIntVal.rand * [-1,1].choose;
+			var y    = 1 + maxIntVal.rand * [-1,1].choose;
+			var rat1 = Rational(x,y);
+			var rat2 = Rational(y,x);
 
-            this.assertEquals(
-                rat1.pow(-1),
-                rat2,
-                format( "Multiplicative Inverse test with % passed.", rat1)
-            );
-        }
-    }
+			this.assertEquals(
+				rat1.pow(-1),
+				rat2,
+				format( "Multiplicative Inverse test with % passed.", rat1)
+			);
+		}
+	}
 
-    test_Div_Eq_ReciprocalMul_NonZeroIntInput  {
-        numTests.do {
-            var x1 = rrand(minIntVal,maxIntVal);
-            var y1 = 1 + maxIntVal.rand * [-1,1].choose;
-            var x2 = 1 + maxIntVal.rand * [-1,1].choose;
-            var y2 = 1 + maxIntVal.rand * [-1,1].choose;
-            var z1 = Rational(x1,y1);
-            var z2 = Rational(x2,y2);
-            this.assertEquals(
-                z1 / z2,
-                z1 * z2.reciprocal,
-                format( "Division is equivalent to multiplying by the reciprocal test with % and %", z1, z2));
-            }
-    }
+	test_Div_Eq_ReciprocalMul_NonZeroIntInput  {
+		numTests.do {
+			var x1 = rrand(minIntVal,maxIntVal);
+			var y1 = 1 + maxIntVal.rand * [-1,1].choose;
+			var x2 = 1 + maxIntVal.rand * [-1,1].choose;
+			var y2 = 1 + maxIntVal.rand * [-1,1].choose;
+			var z1 = Rational(x1,y1);
+			var z2 = Rational(x2,y2);
+			this.assertEquals(
+				z1 / z2,
+				z1 * z2.reciprocal,
+				format( "Division is equivalent to multiplying by the reciprocal test with % and %", z1, z2));
+			}
+	}
 
-    test_Neg_Subtraction_NonZeroIntInput {
-        numTests.do {
-            var x1 = rrand(minIntVal,maxIntVal);
-            var y1 = 1 + maxIntVal.rand * [-1,1].choose;
-            var x2 = rrand(minIntVal,maxIntVal);
-            var y2 = 1 + maxIntVal.rand * [-1,1].choose;
-            var z1 = Rational(x1,y1);
-            var z2 = Rational(x2,y2);
-            this.assertEquals(
-                z1 - z2,
-                z2.neg - z1.neg,
-                format( "Subtraction and Inverse test with % and % passed.", z1, z2));
-            }
-    }
+	test_Neg_Subtraction_NonZeroIntInput {
+		numTests.do {
+			var x1 = rrand(minIntVal,maxIntVal);
+			var y1 = 1 + maxIntVal.rand * [-1,1].choose;
+			var x2 = rrand(minIntVal,maxIntVal);
+			var y2 = 1 + maxIntVal.rand * [-1,1].choose;
+			var z1 = Rational(x1,y1);
+			var z2 = Rational(x2,y2);
+			this.assertEquals(
+				z1 - z2,
+				z2.neg - z1.neg,
+				format( "Subtraction and Inverse test with % and % passed.", z1, z2));
+			}
+	}
 
-    test_reciprocal_Div_NonZeroIntInput {
-        numTests.do {
-            var x1 = rrand(minIntVal,maxIntVal);
-            var y1 = 1 + maxIntVal.rand * [-1,1].choose;
-            var x2 = rrand(minIntVal,maxIntVal);
-            var y2 = 1 + maxIntVal.rand * [-1,1].choose;
-            var z1 = Rational(x1,y1);
-            var z2 = Rational(x2,y2);
-            this.assertEquals(
-                z1 / z2,
-                (z2 / z1).reciprocal,
-                format( "Div + reciprocal test with % and % passed.", z1, z2));
-            }
-    }
+	test_reciprocal_Div_NonZeroIntInput {
+		numTests.do {
+			var x1 = rrand(minIntVal,maxIntVal);
+			var y1 = 1 + maxIntVal.rand * [-1,1].choose;
+			var x2 = rrand(minIntVal,maxIntVal);
+			var y2 = 1 + maxIntVal.rand * [-1,1].choose;
+			var z1 = Rational(x1,y1);
+			var z2 = Rational(x2,y2);
+			this.assertEquals(
+				z1 / z2,
+				(z2 / z1).reciprocal,
+				format( "Div + reciprocal test with % and % passed.", z1, z2));
+			}
+	}
 
-    test_Sort_and_Scramble_NonZeroIntInput  {
-        var listSize = 1000;
+	test_Sort_and_Scramble_NonZeroIntInput  {
+		var listSize = 1000;
 
-        //numTests.do {
-        10.do {
-            var ratList;
-            ratList = Array.fill(
-                listSize,
-                {
-                    Rational(
-                        rrand(minIntVal, maxIntVal),
-                         1 + maxIntVal.rand * [-1,1].choose;)
-                }
-                );
-            this.assertEquals(
-                ratList.sort,
-                ratList.scramble.sort,
-                format( "Sort and Scramble test passed.")
-            );
-        }
-    }
+		//numTests.do {
+		10.do {
+			var ratList;
+			ratList = Array.fill(
+				listSize,
+				{
+					Rational(
+						rrand(minIntVal, maxIntVal),
+						 1 + maxIntVal.rand * [-1,1].choose;)
+				}
+				);
+			this.assertEquals(
+				ratList.sort,
+				ratList.scramble.sort,
+				format( "Sort and Scramble test passed.")
+			);
+		}
+	}
 
-    test_Sort_and_asFloat_NonZeroIntInput  {
-        var listSize = 1000;
+	test_Sort_and_asFloat_NonZeroIntInput  {
+		var listSize = 1000;
 
-        //numTests.do {
-        10.do {
-            var ratList;
+		//numTests.do {
+		10.do {
+			var ratList;
 
-            ratList = Array.fill(
-                listSize,
-                {
-                    Rational(
-                        rrand(minIntVal, maxIntVal),
-                        1 + maxIntVal.rand * [-1,1].choose;)
-                }
-                );
+			ratList = Array.fill(
+				listSize,
+				{
+					Rational(
+						rrand(minIntVal, maxIntVal),
+						1 + maxIntVal.rand * [-1,1].choose;)
+				}
+				);
 
-            this.assertEquals(
-                ratList.scramble.sort.asFloat,
-                ratList.scramble.asFloat.sort,
-                format( "Sort and asFloat test passed.")
-            );
-        }
-    }
+			this.assertEquals(
+				ratList.scramble.sort.asFloat,
+				ratList.scramble.asFloat.sort,
+				format( "Sort and asFloat test passed.")
+			);
+		}
+	}
 
-    test_Mul_Inverse_DifferentExponents_NonZeroIntInput {
-        numTests.do {
-            var maxVal = 100;
-            var x1 = 1 + maxVal.rand * [-1,1].choose;
-            var y1 = 1 + maxVal.rand * [-1,1].choose;
-            var rat = Rational(x1,y1);
-            var maxExponent = 6;
+	test_Mul_Inverse_DifferentExponents_NonZeroIntInput {
+		numTests.do {
+			var maxVal = 100;
+			var x1 = 1 + maxVal.rand * [-1,1].choose;
+			var y1 = 1 + maxVal.rand * [-1,1].choose;
+			var rat = Rational(x1,y1);
+			var maxExponent = 6;
 
-            maxExponent.do({arg i;
-                this.assertEquals(
-                    rat.pow(i * (-1)),
-                    rat.pow(i).reciprocal,
-                    format( "Multiplicative inverse with different exponents test with exp: % and rat: % passed.", i, rat));
+			maxExponent.do({arg i;
+				this.assertEquals(
+					rat.pow(i * (-1)),
+					rat.pow(i).reciprocal,
+					format( "Multiplicative inverse with different exponents test with exp: % and rat: % passed.", i, rat));
 
-            })
+			})
 
-        }
-    }
+		}
+	}
 
-    test_Float_Rat_Float {
-        numTests.do {
-            var maxVal = 1000.01;
-            var x = 1 + maxVal.rand * [1,1.neg].choose;
-            var y = 1 + maxVal.rand * [1,1.neg].choose;
-            var rat = Rational(x,y);
-            var float = x/y;
+	test_Float_Rat_Float {
+		numTests.do {
+			var maxVal = 1000.01;
+			var x = 1 + maxVal.rand * [1,1.neg].choose;
+			var y = 1 + maxVal.rand * [1,1.neg].choose;
+			var rat = Rational(x,y);
+			var float = x/y;
 
-            this.assertFloatEquals(
-                a: rat.asFloat,
-                b: float.asRational.asFloat,
-                message: format(
-                    "Float/Rational conversion with  rat: % and float: % passed.", rat, float),
-                within: 0.000001
-            );
-        }
-    }
+			this.assertFloatEquals(
+				a: rat.asFloat,
+				b: float.asRational.asFloat,
+				message: format(
+					"Float/Rational conversion with  rat: % and float: % passed.", rat, float),
+				within: 0.000001
+			);
+		}
+	}
 
-    test_Rat_Float_Rat {
-        numTests.do {
-            var maxVal = 100;
-            var x = 1 + maxVal.rand * [1,1.neg].choose;
-            var y = 1 + maxVal.rand * [1,1.neg].choose;
-            var rat = Rational(x,y);
-            var float = x/y;
+	test_Rat_Float_Rat {
+		numTests.do {
+			var maxVal = 100;
+			var x = 1 + maxVal.rand * [1,1.neg].choose;
+			var y = 1 + maxVal.rand * [1,1.neg].choose;
+			var rat = Rational(x,y);
+			var float = x/y;
 
-            this.assertEquals(
-                a: rat,
-                b: float.asRational.asFloat.asRational,
-                message: format(
-                    "Float/Rational conversion with rat: % and float: % passed.", rat, float)
-            );
-        }
-    }
+			this.assertEquals(
+				a: rat,
+				b: float.asRational.asFloat.asRational,
+				message: format(
+					"Float/Rational conversion with rat: % and float: % passed.", rat, float)
+			);
+		}
+	}
 
 
-    test_Exponentiation {
-       numTests.do {
-            var maxVal = 9;
-            var x = 1 + maxVal.rand;
-            var y = 1 + maxVal.rand;
-            var r = Rational(x,y);
-            var e = rrand(1, 5).round;
-            this.assertEquals(
-                r,
-                r.pow(e).pow(e.reciprocal),
-                format(
-                    "Exponentiation rational: % and exponent: % passed.", r, e));
-        }
-    }
+	test_Exponentiation {
+	   numTests.do {
+			var maxVal = 9;
+			var x = 1 + maxVal.rand;
+			var y = 1 + maxVal.rand;
+			var r = Rational(x,y);
+			var e = rrand(1, 5).round;
+			this.assertEquals(
+				r,
+				r.pow(e).pow(e.reciprocal),
+				format(
+					"Exponentiation rational: % and exponent: % passed.", r, e));
+		}
+	}
 
-    // associative property
-    test_AssociativeAdd_NonZeroIntInput {
-        numTests.do {
-            var x1 = rrand(minIntVal,maxIntVal);
-            var y1 = 1 + maxIntVal.rand * [-1,1].choose;
-            var x2 = rrand(minIntVal,maxIntVal);
-            var y2 = 1 + maxIntVal.rand * [-1,1].choose;
-            var x3 = rrand(minIntVal,maxIntVal);
-            var y3 = 1 + maxIntVal.rand * [-1,1].choose;
-            var z1 = Rational(x1,y1);
-            var z2 = Rational(x2,y2);
-            var z3 = Rational(x3,y3);
+	// associative property
+	test_AssociativeAdd_NonZeroIntInput {
+		numTests.do {
+			var x1 = rrand(minIntVal,maxIntVal);
+			var y1 = 1 + maxIntVal.rand * [-1,1].choose;
+			var x2 = rrand(minIntVal,maxIntVal);
+			var y2 = 1 + maxIntVal.rand * [-1,1].choose;
+			var x3 = rrand(minIntVal,maxIntVal);
+			var y3 = 1 + maxIntVal.rand * [-1,1].choose;
+			var z1 = Rational(x1,y1);
+			var z2 = Rational(x2,y2);
+			var z3 = Rational(x3,y3);
 
-            this.assertEquals(
-                (z1 + z2) + z3,
-                z1 + (z2 + z3),
-                format( "Associative Sum test with %, % and %passed.", z1, z2, z3));
-        }
-    }
+			this.assertEquals(
+				(z1 + z2) + z3,
+				z1 + (z2 + z3),
+				format( "Associative Sum test with %, % and %passed.", z1, z2, z3));
+		}
+	}
 
-    test_AssociativeMul_NonZeroIntInput {
-        numTests.do {
-            var x1 = rrand(minIntVal,maxIntVal);
-            var y1 = 1 + maxIntVal.rand * [-1,1].choose;
-            var x2 = rrand(minIntVal,maxIntVal);
-            var y2 = 1 + maxIntVal.rand * [-1,1].choose;
-            var x3 = rrand(minIntVal,maxIntVal);
-            var y3 = 1 + maxIntVal.rand * [-1,1].choose;
-            var z1 = Rational(x1,y1);
-            var z2 = Rational(x2,y2);
-            var z3 = Rational(x3,y3);
+	test_AssociativeMul_NonZeroIntInput {
+		numTests.do {
+			var x1 = rrand(minIntVal,maxIntVal);
+			var y1 = 1 + maxIntVal.rand * [-1,1].choose;
+			var x2 = rrand(minIntVal,maxIntVal);
+			var y2 = 1 + maxIntVal.rand * [-1,1].choose;
+			var x3 = rrand(minIntVal,maxIntVal);
+			var y3 = 1 + maxIntVal.rand * [-1,1].choose;
+			var z1 = Rational(x1,y1);
+			var z2 = Rational(x2,y2);
+			var z3 = Rational(x3,y3);
 
-            this.assertEquals(
-                (z1 * z2) * z3,
-                z1 * (z2 * z3),
-                format( "Associative Mul test with %, % and %passed.", z1, z2, z3));
-        }
-    }
+			this.assertEquals(
+				(z1 * z2) * z3,
+				z1 * (z2 * z3),
+				format( "Associative Mul test with %, % and %passed.", z1, z2, z3));
+		}
+	}
 
-     // distributive property
-    //(a + b) * c = (a * c) + (b * c)
-    test_Distributive_1_PositiveIntInput {
-        numTests.do {
-            var minVal = 1;
-            var maxVal = 20;
-            var x1 = rrand(minVal,maxVal);
-            var y1 = 1 + maxVal.rand ;
-            var x2 = rrand(minVal,maxVal);
-            var y2 = 1 + maxVal.rand ;
-            var x3 = rrand(minVal,maxVal);
-            var y3 = 1 + maxVal.rand ;
-            var a = Rational(x1,y1);
-            var b = Rational(x2,y2);
-            var c = Rational(x3,y3);
+	// distributive property
+	// (a + b) * c = (a * c) + (b * c)
+	test_Distributive_1_PositiveIntInput {
+		numTests.do {
+			var minVal = 1;
+			var maxVal = 20;
+			var x1 = rrand(minVal,maxVal);
+			var y1 = 1 + maxVal.rand ;
+			var x2 = rrand(minVal,maxVal);
+			var y2 = 1 + maxVal.rand ;
+			var x3 = rrand(minVal,maxVal);
+			var y3 = 1 + maxVal.rand ;
+			var a = Rational(x1,y1);
+			var b = Rational(x2,y2);
+			var c = Rational(x3,y3);
 
-            this.assertEquals(
-                (a + b) * c,
-                (a * c) + (b * c),
-                format( "Associative property 2 test with %, % and % passed.", a, b, c)
-            );
-        }
-    }
+			this.assertEquals(
+				(a + b) * c,
+				(a * c) + (b * c),
+				format( "Associative property 1 test with %, % and % passed.", a, b, c)
+			);
+		}
+	}
+
+	test_commutativeAdd_Array_NonZeroIntInput {
+		numTests.do {
+			var n = 20;
+			var minVal = -10;
+			var maxVal = 10;
+			var xs = Array.fill(n, {rrand(minVal,maxVal)});
+			var ys = Array.fill(n, {1 + maxVal.rand * [-1,1].choose});
+			var rats;
+
+			rats = n.collect({arg i; Rational(xs[i], ys[i])});
+			this.assertEquals(
+				rats.scramble.sum,
+				rats.scramble.sum,
+				format( "Commutative with Array summation test with %", rats));
+		}
+	}
 }
 
 

--- a/testsuite/classlibrary/TestRational.sc
+++ b/testsuite/classlibrary/TestRational.sc
@@ -71,7 +71,7 @@ TestRational : UnitTest {
     test_Additive_Inverse_NonZeroIntInput {
         numTests.do {
             var x = rrand(minIntVal,maxIntVal);
-            var y = 1 + maxIntVal.rand * [-1,1].choose;
+            var y = 1 + maxIntVal.rand * [1,1.neg].choose;
             var rat=Rational(x,y);
 
             this.assertEquals(
@@ -82,11 +82,28 @@ TestRational : UnitTest {
             this.assertEquals(
                 (-1) * rat,
                 Rational(x * (-1), y),
-                format( "Additive Inverse test 2 with % passed.", rat));
+                format( "Additive Inverse test 2 with % passed.", rat)
+            );
             this.assertEquals(
                 (-1) * rat,
                 Rational(x, y * (-1)),
-                format( "Additive Inverse test 3 with % passed.", rat));
+                format( "Additive Inverse test 3 with % passed.", rat)
+            )
+        }
+    }
+
+    test_Multiplicative_Inverse_NonZeroIntInput {
+        numTests.do {
+            var x    = 1 + maxIntVal.rand * [-1,1].choose;
+            var y    = 1 + maxIntVal.rand * [-1,1].choose;
+            var rat1 = Rational(x,y);
+            var rat2 = Rational(y,x);
+
+            this.assertEquals(
+                rat1.pow(-1),
+                rat2,
+                format( "Multiplicative Inverse test with % passed.", rat1)
+            );
         }
     }
 
@@ -181,5 +198,27 @@ TestRational : UnitTest {
         }
     }
 
+    test_Mul_Inverse_DifferentExponents_NonZeroIntInput {
+        numTests.do {
+            var maxVal = 100;
+            var x1 = 1 + maxVal.rand * [-1,1].choose;
+            var y1 = 1 + maxVal.rand * [-1,1].choose;
+            var rat = Rational(x1,y1);
+            var maxExponent = 6;
+
+            maxExponent.do({arg i;
+                this.assertEquals(
+                rat.pow(i * (-1)),
+                rat.pow(i).reciprocal,
+                format( "Multiplicative inverse with different exponents test with exp: % and rat: % passed.", i, rat));
+
+            })
+
+            }
+    }
 }
 
+/*
+TestRational.run
+UnitTest.gui
+*/

--- a/testsuite/classlibrary/TestRational.sc
+++ b/testsuite/classlibrary/TestRational.sc
@@ -36,7 +36,6 @@ TestRational : UnitTest {
         );
     }
 
-
     test_reciprocal {
         var report = true;
 
@@ -56,23 +55,48 @@ TestRational : UnitTest {
     }
 
     test_newFromString {
-
         this.setRandSeed;
 
-        numTests.do {
+        numTests.do({
             var x = rrand(minIntVal,maxIntVal);
             var y = 1 + maxIntVal.rand * [-1,1].choose;
             var xStr = x.asString;
             var yStr = y.asString;
             var rat1 = Rational(x,y);
             var rat2 = Rational.newFrom(xStr ++ "/"++ yStr);
+
             this.assertEquals(
                 rat1,
                 rat2,
                 format( "String entry test with % passed.", rat1)
             );
-        }
+        });
     }
+
+    test_strangeStringInput {
+
+        var strangeStrings = [
+            "3 %/ 2  ",
+            "3  /  2 ",
+            "3    /   2 ",
+            "   3    / 2    ",
+            "    3     / 2      ",
+            "    3   %    /   2   ",
+            "    3    /    2 ",
+            "        3       %      /         2 "
+        ];
+
+
+        strangeStrings.do({ arg i, j;
+            this.assertEquals(
+                Rational(i),
+                Rational(3,2),
+                format( "String entry # % test with Rational(%) passed.", j, i)
+            );
+
+        });
+    }
+
 
     test_commutativeAdd {
 
@@ -404,7 +428,7 @@ TestRational : UnitTest {
             this.assertEquals(
                 (a + b) * c,
                 (a * c) + (b * c),
-                format( "Distributive property 1 test with %, % and % passed.", a, b, c)
+                format( "Associative property 1 test with %, % and % passed.", a, b, c)
             );
         }
     }

--- a/testsuite/classlibrary/TestRational.sc
+++ b/testsuite/classlibrary/TestRational.sc
@@ -5,348 +5,430 @@ UnitTest.gui
 
 TestRational : UnitTest {
 
-	var minIntVal= -1000, maxIntVal=1000;
-	var minFloatVal= -1000.1, maxFloatVal=1000.1;
-	var numTests = 1000;
+    var minIntVal= -1000, maxIntVal=1000;
+    var minFloatVal= -1000.1, maxFloatVal=1000.1;
+    var numTests = 1000;
 
-	test_reciprocal_NonZeroIntInput {
-		numTests.do {
-			var x = rrand(minIntVal,maxIntVal);
-			var y = 1 + maxIntVal.rand * [-1,1].choose;
-			var z = Rational(x,y);
-			this.assertEquals(
-				z,
-				z.reciprocal.reciprocal,
-				format( "Reciprocal test with % passed.", z)
-			);
-			}
-	}
+    setRandSeed { arg seed=123; thisThread.randSeed = seed }
 
-	test_newFromString_NonZeroIntInput {
-		numTests.do {
-			var x = rrand(minIntVal,maxIntVal);
-			var y = 1 + maxIntVal.rand * [-1,1].choose;
-			var xStr = x.asString;
-			var yStr = y.asString;
-			var rat1 = Rational(x,y);
-			var rat2 = Rational.newFrom(xStr ++ "/"++ yStr);
-			this.assertEquals(
-				rat1,
-				rat2,
-				format( "String entry test with % passed.", rat1)
-			);
-		}
-	}
+    test_ZeroDenominator {
+        var array;
 
-	test_commutativeAdd_NonZeroIntInput {
-		numTests.do {
-			var x1 = rrand(minIntVal,maxIntVal);
-			var y1 = 1 + maxIntVal.rand * [-1,1].choose;
-			var x2 = rrand(minIntVal,maxIntVal);
-			var y2 = 1 + maxIntVal.rand;
-			var z1 = Rational(x1,y1);
-			var z2 = Rational(x2,y2);
-			this.assertEquals(
-				z1 + z2,
-				z2 + z1,
-				format( "Commutative Add test with % and % passed.", z1, z2));
-			}
-	}
-
-	test_commutativeMul_NonZeroIntInput {
-		numTests.do {
-			var x1 = rrand(minIntVal,maxIntVal);
-			var y1 = 1 + maxIntVal.rand * [-1,1].choose;
-			var x2 = rrand(minIntVal,maxIntVal);
-			var y2 = 1 + maxIntVal.rand * [-1,1].choose;
-			var z1 = Rational(x1,y1);
-			var z2 = Rational(x2,y2);
-			this.assertEquals(
-				z1 * z2,
-				z2 * z1,
-				format( "Commutative Add test with % and % passed.", z1, z2));
-			}
-	}
-
-	test_Additive_Inverse_NonZeroIntInput {
-		numTests.do {
-			var x = rrand(minIntVal,maxIntVal);
-			var y = 1 + maxIntVal.rand * [1,1.neg].choose;
-			var rat=Rational(x,y);
-
-			this.assertEquals(
-				Rational(x * (-1), y),
-				Rational(x, y * (-1)),
-				format( "Additive Inverse test 1 with % passed.", rat)
-			);
-			this.assertEquals(
-				(-1) * rat,
-				Rational(x * (-1), y),
-				format( "Additive Inverse test 2 with % passed.", rat)
-			);
-			this.assertEquals(
-				(-1) * rat,
-				Rational(x, y * (-1)),
-				format( "Additive Inverse test 3 with % passed.", rat)
-			)
-		}
-	}
-
-	test_Multiplicative_Inverse_NonZeroIntInput {
-		numTests.do {
-			var x    = 1 + maxIntVal.rand * [-1,1].choose;
-			var y    = 1 + maxIntVal.rand * [-1,1].choose;
-			var rat1 = Rational(x,y);
-			var rat2 = Rational(y,x);
-
-			this.assertEquals(
-				rat1.pow(-1),
-				rat2,
-				format( "Multiplicative Inverse test with % passed.", rat1)
-			);
-		}
-	}
-
-	test_Div_Eq_ReciprocalMul_NonZeroIntInput  {
-		numTests.do {
-			var x1 = rrand(minIntVal,maxIntVal);
-			var y1 = 1 + maxIntVal.rand * [-1,1].choose;
-			var x2 = 1 + maxIntVal.rand * [-1,1].choose;
-			var y2 = 1 + maxIntVal.rand * [-1,1].choose;
-			var z1 = Rational(x1,y1);
-			var z2 = Rational(x2,y2);
-			this.assertEquals(
-				z1 / z2,
-				z1 * z2.reciprocal,
-				format( "Division is equivalent to multiplying by the reciprocal test with % and %", z1, z2));
-			}
-	}
-
-	test_Neg_Subtraction_NonZeroIntInput {
-		numTests.do {
-			var x1 = rrand(minIntVal,maxIntVal);
-			var y1 = 1 + maxIntVal.rand * [-1,1].choose;
-			var x2 = rrand(minIntVal,maxIntVal);
-			var y2 = 1 + maxIntVal.rand * [-1,1].choose;
-			var z1 = Rational(x1,y1);
-			var z2 = Rational(x2,y2);
-			this.assertEquals(
-				z1 - z2,
-				z2.neg - z1.neg,
-				format( "Subtraction and Inverse test with % and % passed.", z1, z2));
-			}
-	}
-
-	test_reciprocal_Div_NonZeroIntInput {
-		numTests.do {
-			var x1 = rrand(minIntVal,maxIntVal);
-			var y1 = 1 + maxIntVal.rand * [-1,1].choose;
-			var x2 = rrand(minIntVal,maxIntVal);
-			var y2 = 1 + maxIntVal.rand * [-1,1].choose;
-			var z1 = Rational(x1,y1);
-			var z2 = Rational(x2,y2);
-			this.assertEquals(
-				z1 / z2,
-				(z2 / z1).reciprocal,
-				format( "Div + reciprocal test with % and % passed.", z1, z2));
-			}
-	}
-
-	test_Sort_and_Scramble_NonZeroIntInput  {
-		var listSize = 1000;
-
-		//numTests.do {
-		10.do {
-			var ratList;
-			ratList = Array.fill(
-				listSize,
-				{
-					Rational(
-						rrand(minIntVal, maxIntVal),
-						 1 + maxIntVal.rand * [-1,1].choose;)
-				}
-				);
-			this.assertEquals(
-				ratList.sort,
-				ratList.scramble.sort,
-				format( "Sort and Scramble test passed.")
-			);
-		}
-	}
-
-	test_Sort_and_asFloat_NonZeroIntInput  {
-		var listSize = 1000;
-
-		//numTests.do {
-		10.do {
-			var ratList;
-
-			ratList = Array.fill(
-				listSize,
-				{
-					Rational(
-						rrand(minIntVal, maxIntVal),
-						1 + maxIntVal.rand * [-1,1].choose;)
-				}
-				);
-
-			this.assertEquals(
-				ratList.scramble.sort.asFloat,
-				ratList.scramble.asFloat.sort,
-				format( "Sort and asFloat test passed.")
-			);
-		}
-	}
-
-	test_Mul_Inverse_DifferentExponents_NonZeroIntInput {
-		numTests.do {
-			var maxVal = 100;
-			var x1 = 1 + maxVal.rand * [-1,1].choose;
-			var y1 = 1 + maxVal.rand * [-1,1].choose;
-			var rat = Rational(x1,y1);
-			var maxExponent = 6;
-
-			maxExponent.do({arg i;
-				this.assertEquals(
-					rat.pow(i * (-1)),
-					rat.pow(i).reciprocal,
-					format( "Multiplicative inverse with different exponents test with exp: % and rat: % passed.", i, rat));
-
-			})
-
-		}
-	}
-
-	test_Float_Rat_Float {
-		numTests.do {
-			var maxVal = 1000.01;
-			var x = 1 + maxVal.rand * [1,1.neg].choose;
-			var y = 1 + maxVal.rand * [1,1.neg].choose;
-			var rat = Rational(x,y);
-			var float = x/y;
-
-			this.assertFloatEquals(
-				a: rat.asFloat,
-				b: float.asRational.asFloat,
-				message: format(
-					"Float/Rational conversion with  rat: % and float: % passed.", rat, float),
-				within: 0.000001
-			);
-		}
-	}
-
-	test_Rat_Float_Rat {
-		numTests.do {
-			var maxVal = 100;
-			var x = 1 + maxVal.rand * [1,1.neg].choose;
-			var y = 1 + maxVal.rand * [1,1.neg].choose;
-			var rat = Rational(x,y);
-			var float = x/y;
-
-			this.assertEquals(
-				a: rat,
-				b: float.asRational.asFloat.asRational,
-				message: format(
-					"Float/Rational conversion with rat: % and float: % passed.", rat, float)
-			);
-		}
-	}
+        this.assertEquals(
+            Rational(0,0),
+            inf, // or nan?
+            format( "Zero Denominator with Rational(0,0)==inf test passed.")
+        );
+        this.assertEquals(
+            Rational(1,0),
+            inf, // or nan?
+            format( "Zero Denominator test with Rational(1,0)==inf passed.")
+        );
+        this.assertEquals(
+            Rational(9999,0),
+            inf, // or nan?
+            format( "Zero Denominator test with Rational(9999,0)==inf passed.")
+        );
+        this.assertEquals(
+            Rational(0,1),
+            Rational(0,9999),
+            format( "Zero Denominator test with Rational(0,1)==Rational(0,9999) passed.")
+        );
+    }
 
 
-	test_Exponentiation {
-	   numTests.do {
-			var maxVal = 9;
-			var x = 1 + maxVal.rand;
-			var y = 1 + maxVal.rand;
-			var r = Rational(x,y);
-			var e = rrand(1, 5).round;
-			this.assertEquals(
-				r,
-				r.pow(e).pow(e.reciprocal),
-				format(
-					"Exponentiation rational: % and exponent: % passed.", r, e));
-		}
-	}
+    test_reciprocal {
+        var report = true;
 
-	// associative property
-	test_AssociativeAdd_NonZeroIntInput {
-		numTests.do {
-			var x1 = rrand(minIntVal,maxIntVal);
-			var y1 = 1 + maxIntVal.rand * [-1,1].choose;
-			var x2 = rrand(minIntVal,maxIntVal);
-			var y2 = 1 + maxIntVal.rand * [-1,1].choose;
-			var x3 = rrand(minIntVal,maxIntVal);
-			var y3 = 1 + maxIntVal.rand * [-1,1].choose;
-			var z1 = Rational(x1,y1);
-			var z2 = Rational(x2,y2);
-			var z3 = Rational(x3,y3);
+        this.setRandSeed;
 
-			this.assertEquals(
-				(z1 + z2) + z3,
-				z1 + (z2 + z3),
-				format( "Associative Sum test with %, % and %passed.", z1, z2, z3));
-		}
-	}
+        numTests.do {
+            var x = rrand(minIntVal,maxIntVal);
+            var y = 1 + maxIntVal.rand * [-1,1].choose;
+            var z = Rational(x,y);
+            this.assertEquals(
+                z,
+                z.reciprocal.reciprocal,
+                format( "Reciprocal test with % passed.", z),
+                report: report
+            );
+            }
+    }
 
-	test_AssociativeMul_NonZeroIntInput {
-		numTests.do {
-			var x1 = rrand(minIntVal,maxIntVal);
-			var y1 = 1 + maxIntVal.rand * [-1,1].choose;
-			var x2 = rrand(minIntVal,maxIntVal);
-			var y2 = 1 + maxIntVal.rand * [-1,1].choose;
-			var x3 = rrand(minIntVal,maxIntVal);
-			var y3 = 1 + maxIntVal.rand * [-1,1].choose;
-			var z1 = Rational(x1,y1);
-			var z2 = Rational(x2,y2);
-			var z3 = Rational(x3,y3);
+    test_newFromString {
 
-			this.assertEquals(
-				(z1 * z2) * z3,
-				z1 * (z2 * z3),
-				format( "Associative Mul test with %, % and %passed.", z1, z2, z3));
-		}
-	}
+        this.setRandSeed;
 
-	// distributive property
-	// (a + b) * c = (a * c) + (b * c)
-	test_Distributive_1_PositiveIntInput {
-		numTests.do {
-			var minVal = 1;
-			var maxVal = 20;
-			var x1 = rrand(minVal,maxVal);
-			var y1 = 1 + maxVal.rand ;
-			var x2 = rrand(minVal,maxVal);
-			var y2 = 1 + maxVal.rand ;
-			var x3 = rrand(minVal,maxVal);
-			var y3 = 1 + maxVal.rand ;
-			var a = Rational(x1,y1);
-			var b = Rational(x2,y2);
-			var c = Rational(x3,y3);
+        numTests.do {
+            var x = rrand(minIntVal,maxIntVal);
+            var y = 1 + maxIntVal.rand * [-1,1].choose;
+            var xStr = x.asString;
+            var yStr = y.asString;
+            var rat1 = Rational(x,y);
+            var rat2 = Rational.newFrom(xStr ++ "/"++ yStr);
+            this.assertEquals(
+                rat1,
+                rat2,
+                format( "String entry test with % passed.", rat1)
+            );
+        }
+    }
 
-			this.assertEquals(
-				(a + b) * c,
-				(a * c) + (b * c),
-				format( "Associative property 1 test with %, % and % passed.", a, b, c)
-			);
-		}
-	}
+    test_commutativeAdd {
 
-	test_commutativeAdd_Array_NonZeroIntInput {
-		numTests.do {
-			var n = 20;
-			var minVal = -10;
-			var maxVal = 10;
-			var xs = Array.fill(n, {rrand(minVal,maxVal)});
-			var ys = Array.fill(n, {1 + maxVal.rand * [-1,1].choose});
-			var rats;
+        this.setRandSeed;
 
-			rats = n.collect({arg i; Rational(xs[i], ys[i])});
-			this.assertEquals(
-				rats.scramble.sum,
-				rats.scramble.sum,
-				format( "Commutative with Array summation test with %", rats));
-		}
-	}
+        numTests.do {
+            var x1 = rrand(minIntVal,maxIntVal);
+            var y1 = 1 + maxIntVal.rand * [-1,1].choose;
+            var x2 = rrand(minIntVal,maxIntVal);
+            var y2 = 1 + maxIntVal.rand;
+            var z1 = Rational(x1,y1);
+            var z2 = Rational(x2,y2);
+            this.assertEquals(
+                z1 + z2,
+                z2 + z1,
+                format( "Commutative Add test with % and % passed.", z1, z2)
+            );
+            }
+    }
+
+    test_commutativeMul {
+
+        this.setRandSeed;
+
+        numTests.do {
+            var x1 = rrand(minIntVal,maxIntVal);
+            var y1 = 1 + maxIntVal.rand * [-1,1].choose;
+            var x2 = rrand(minIntVal,maxIntVal);
+            var y2 = 1 + maxIntVal.rand * [-1,1].choose;
+            var z1 = Rational(x1,y1);
+            var z2 = Rational(x2,y2);
+            this.assertEquals(
+                z1 * z2,
+                z2 * z1,
+                format( "Commutative Add test with % and % passed.", z1, z2));
+            }
+    }
+
+    test_Additive_Inverse {
+
+        this.setRandSeed;
+
+        numTests.do {
+            var x = rrand(minIntVal,maxIntVal);
+            var y = 1 + maxIntVal.rand * [1,1.neg].choose;
+            var rat=Rational(x,y);
+
+            this.assertEquals(
+                Rational(x * (-1), y),
+                Rational(x, y * (-1)),
+                format( "Additive Inverse test 1 with % passed.", rat)
+            );
+            this.assertEquals(
+                (-1) * rat,
+                Rational(x * (-1), y),
+                format( "Additive Inverse test 2 with % passed.", rat)
+            );
+            this.assertEquals(
+                (-1) * rat,
+                Rational(x, y * (-1)),
+                format( "Additive Inverse test 3 with % passed.", rat)
+            )
+        }
+    }
+
+    test_Multiplicative_Inverse {
+
+        this.setRandSeed;
+
+        numTests.do {
+            var x    = 1 + maxIntVal.rand * [-1,1].choose;
+            var y    = 1 + maxIntVal.rand * [-1,1].choose;
+            var rat1 = Rational(x,y);
+            var rat2 = Rational(y,x);
+
+            this.assertEquals(
+                rat1.pow(-1),
+                rat2,
+                format( "Multiplicative Inverse test with % passed.", rat1)
+            );
+        }
+    }
+
+    test_Div_Eq_ReciprocalMul  {
+
+        numTests.do {
+            var x1 = rrand(minIntVal,maxIntVal);
+            var y1 = 1 + maxIntVal.rand * [-1,1].choose;
+            var x2 = 1 + maxIntVal.rand * [-1,1].choose;
+            var y2 = 1 + maxIntVal.rand * [-1,1].choose;
+            var z1 = Rational(x1,y1);
+            var z2 = Rational(x2,y2);
+            this.assertEquals(
+                z1 / z2,
+                z1 * z2.reciprocal,
+                format( "Division is equivalent to multiplying by the reciprocal test with % and %", z1, z2));
+            }
+    }
+
+    test_Neg_Subtraction {
+
+        this.setRandSeed;
+
+        numTests.do {
+            var x1 = rrand(minIntVal,maxIntVal);
+            var y1 = 1 + maxIntVal.rand * [-1,1].choose;
+            var x2 = rrand(minIntVal,maxIntVal);
+            var y2 = 1 + maxIntVal.rand * [-1,1].choose;
+            var z1 = Rational(x1,y1);
+            var z2 = Rational(x2,y2);
+            this.assertEquals(
+                z1 - z2,
+                z2.neg - z1.neg,
+                format( "Subtraction and Inverse test with % and % passed.", z1, z2));
+            }
+    }
+
+    test_reciprocal_Div {
+
+        this.setRandSeed;
+
+        numTests.do {
+            var x1 = 1 + maxIntVal.rand * [-1,1].choose;
+            var y1 = 1 + maxIntVal.rand * [-1,1].choose;
+            var x2 = 1 + maxIntVal.rand * [-1,1].choose;
+            var y2 = 1 + maxIntVal.rand * [-1,1].choose;
+            var z1 = Rational(x1,y1);
+            var z2 = Rational(x2,y2);
+            this.assertEquals(
+                z1 / z2,
+                (z2 / z1).reciprocal,
+                format( "Div + reciprocal test with % and % passed.", z1, z2));
+            }
+    }
+
+    test_Sort_and_Scramble  {
+        var listSize = 1000;
+
+        this.setRandSeed;
+
+        //numTests.do {
+        10.do {
+            var ratList;
+            ratList = Array.fill(
+                listSize,
+                {
+                    Rational(
+                        rrand(minIntVal, maxIntVal),
+                         1 + maxIntVal.rand * [-1,1].choose;)
+                }
+                );
+            this.assertEquals(
+                ratList.sort,
+                ratList.scramble.sort,
+                format( "Sort and Scramble test passed.")
+            );
+        }
+    }
+
+    test_Sort_and_asFloat  {
+        var listSize = 1000;
+
+        this.setRandSeed;
+
+        //numTests.do {
+        10.do {
+            var ratList;
+
+            ratList = Array.fill(
+                listSize,
+                {
+                    Rational(
+                        rrand(minIntVal, maxIntVal),
+                        1 + maxIntVal.rand * [-1,1].choose;)
+                }
+                );
+
+            this.assertEquals(
+                ratList.scramble.sort.asFloat,
+                ratList.scramble.asFloat.sort,
+                format( "Sort and asFloat test passed.")
+            );
+        }
+    }
+
+    test_Mul_Inverse_DifferentExponents_NonZeroIntInput {
+
+        this.setRandSeed;
+
+        numTests.do {
+            var maxVal = 100;
+            var x1 = 1 + maxVal.rand * [-1,1].choose;
+            var y1 = 1 + maxVal.rand * [-1,1].choose;
+            var rat = Rational(x1,y1);
+            var maxExponent = 6;
+
+            maxExponent.do({arg i;
+                this.assertEquals(
+                    rat.pow(i * (-1)),
+                    rat.pow(i).reciprocal,
+                    format( "Multiplicative inverse with different exponents test with exp: % and rat: % passed.", i, rat));
+
+            })
+
+        }
+    }
+
+    test_Float_Rat_Float {
+
+        this.setRandSeed;
+
+        numTests.do {
+            var maxVal = 1000.01;
+            var x = 1 + maxVal.rand * [1,1.neg].choose;
+            var y = 1 + maxVal.rand * [1,1.neg].choose;
+            var rat = Rational(x,y);
+            var float = x/y;
+
+            this.assertFloatEquals(
+                a: rat.asFloat,
+                b: float.asRational.asFloat,
+                message: format(
+                    "Float/Rational conversion with  rat: % and float: % passed.", rat, float),
+                within: 0.000001
+            );
+        }
+    }
+
+    test_Rat_Float_Rat {
+
+        this.setRandSeed;
+
+        numTests.do {
+            var maxVal = 100;
+            var x = 1 + maxVal.rand * [1,1.neg].choose;
+            var y = 1 + maxVal.rand * [1,1.neg].choose;
+            var rat = Rational(x,y);
+            var float = x/y;
+
+            this.assertEquals(
+                a: rat,
+                b: float.asRational.asFloat.asRational,
+                message: format(
+                    "Float/Rational conversion with rat: % and float: % passed.", rat, float)
+            );
+        }
+    }
+
+
+    test_Exponentiation {
+
+        this.setRandSeed;
+
+       numTests.do {
+            var maxVal = 9;
+            var x = 1 + maxVal.rand;
+            var y = 1 + maxVal.rand;
+            var r = Rational(x,y);
+            var e = rrand(1, 5).round;
+            this.assertEquals(
+                r,
+                r.pow(e).pow(e.reciprocal),
+                format(
+                    "Exponentiation rational: % and exponent: % passed.", r, e));
+        }
+    }
+
+    // associative property
+    test_AssociativeAdd {
+        this.setRandSeed;
+        numTests.do {
+            var x1 = rrand(minIntVal,maxIntVal);
+            var y1 = 1 + maxIntVal.rand * [-1,1].choose;
+            var x2 = rrand(minIntVal,maxIntVal);
+            var y2 = 1 + maxIntVal.rand * [-1,1].choose;
+            var x3 = rrand(minIntVal,maxIntVal);
+            var y3 = 1 + maxIntVal.rand * [-1,1].choose;
+            var z1 = Rational(x1,y1);
+            var z2 = Rational(x2,y2);
+            var z3 = Rational(x3,y3);
+            this.assertEquals(
+                (z1 + z2) + z3,
+                z1 + (z2 + z3),
+                format( "Associative Sum test with %, % and %passed.", z1, z2, z3))
+        }
+    }
+
+    test_AssociativeMul {
+
+        this.setRandSeed;
+
+        numTests.do {
+            var x1 = rrand(minIntVal,maxIntVal);
+            var y1 = 1 + maxIntVal.rand * [-1,1].choose;
+            var x2 = rrand(minIntVal,maxIntVal);
+            var y2 = 1 + maxIntVal.rand * [-1,1].choose;
+            var x3 = rrand(minIntVal,maxIntVal);
+            var y3 = 1 + maxIntVal.rand * [-1,1].choose;
+            var z1 = Rational(x1,y1);
+            var z2 = Rational(x2,y2);
+            var z3 = Rational(x3,y3);
+
+            this.assertEquals(
+                (z1 * z2) * z3,
+                z1 * (z2 * z3),
+                format( "Associative Mul test with %, % and %passed.", z1, z2, z3));
+        }
+    }
+
+    // distributive property
+    // (a + b) * c = (a * c) + (b * c)
+    test_Distributive_1_PositiveIntInput {
+
+        this.setRandSeed;
+
+        numTests.do {
+            var minVal = 1;
+            var maxVal = 20;
+            var x1 = rrand(minVal,maxVal);
+            var y1 = 1 + maxVal.rand ;
+            var x2 = rrand(minVal,maxVal);
+            var y2 = 1 + maxVal.rand ;
+            var x3 = rrand(minVal,maxVal);
+            var y3 = 1 + maxVal.rand ;
+            var a = Rational(x1,y1);
+            var b = Rational(x2,y2);
+            var c = Rational(x3,y3);
+
+            this.assertEquals(
+                (a + b) * c,
+                (a * c) + (b * c),
+                format( "Associative property 1 test with %, % and % passed.", a, b, c)
+            );
+        }
+    }
+
+    test_commutativeAdd_Array {
+
+        this.setRandSeed;
+
+        numTests.do {
+            var n = 20;
+            var minVal = -10;
+            var maxVal = 10;
+            var xs = Array.fill(n, {rrand(minVal,maxVal)});
+            var ys = Array.fill(n, {1 + maxVal.rand * [-1,1].choose});
+            var rats;
+
+            rats = n.collect({arg i; Rational(xs[i], ys[i])});
+
+            this.assertEquals(
+                rats.scramble.sum,
+                rats.scramble.sum,
+                format( "Commutative with Array summation test with %", rats));
+        }
+    }
 }
 
 

--- a/testsuite/classlibrary/TestRational.sc
+++ b/testsuite/classlibrary/TestRational.sc
@@ -6,530 +6,545 @@ TestRational().numTests_(100).seed_(999.rand).isVerbose_(true).run;
 
 TestRational : UnitTest {
 
-	var <>minIntVal= -1000, <>maxIntVal=1000;
-	var <>minFloatVal= -1000.1, <>maxFloatVal=1000.1;
-	var <>numTests = 100;
-	var <>seed = 123;
-	var <>isVerbose = false;
-
-	setUp { thisThread.randSeed = seed }
-
-	test_Zeros {
-		var array;
-
-		this.assert(
-			Rational(0,0).isNaN,
-			format( "Zeros with Rational(0,0).isNaN test passed.")
-		);
-		this.assert(
-			Rational(rrand(1,10),rrand(1,10)) != Rational(1,0),
-			format( "Zeros with Rational(rrand(1,10),rrand(1,10))!=Rational(1,0) test passed.")
-		);
-		this.assert(
-			Rational(rrand(1,10),rrand(1,10)) != Rational(0,0),
-			format( "Zeros with Rational(rrand(1,10),rrand(1,10))!=Rational(0,0) test passed.")
-		);
-		this.assertEquals(
-			Rational(1,0),
-			inf,
-			format( "Zeros test with Rational(1,0)==inf passed.")
-		);
-		this.assertEquals(
-			Rational(9999,0),
-			inf,
-			format( "Zeros test with Rational(9999,0)==inf passed.")
-		);
-		100.do {
-			this.assertEquals(
-				Rational(9999.rand,0),
-				Rational(9999.rand,0),
-				format( "Zeros test with Rational(9999.rand,0)==Rational(9999.rand,0) passed."),
-				isVerbose
-			)
-		};
-		this.assertEquals(
-			Rational(0,1),
-			Rational(0,9999),
-			format( "Zeros test with Rational(0,1)==Rational(0,9999) passed.")
-		);
-	}
-
-	test_BigNumbers {
-
-		this.assert(
-			(2147483646 %/ 1) + 1 == (2147483647 %/ 1),
-			format( "Big_Numbers `(2147483646 %/ 1) + 1` test passed."));
-
-		this.assert(
-			(2147483647.0 %/ 1) + 1 ==  (2147483648.0 %/ 1),
-			format( "Big_Numbers with `(2147483647.0 %/ 1) + 1` test passed."));
-
-		this.assert(
-			Rational(2147483647.0, 1) * 2 == ( 4294967294.0 %/ 1),
-			format( "Big_Numbers with ` Rational(2147483647.0, 1) * 2` test passed."));
-
-		this.assert(
-			(-2147483646 %/ 1) - 1 == (-2147483647 %/ 1),
-			format( "Big_Numbers with `(-2147483646 %/ 1) - 1` test passed."));
-
-	}
-
-	test_Pi_Precision {
-		var a = pi.asRational(99999);
-		var b = pi.asRational(999);
-		var c = pi.asRational(99);
-
-		this.assert(
-			pi.equalWithPrecision(a.asFloat, 0.000000001),
-			format( "Pi_Precision with `pi.asRational(99999)` test passed.")
-		);
-
-		this.assert(
-			pi.equalWithPrecision(b.asFloat, 0.00001),
-			format( "Pi_Precision with `pi.asRational(999)` test passed.")
-		);
-
-		this.assert(
-			pi.equalWithPrecision(c.asFloat, 0.01),
-			format( "Pi_Precision with `pi.asRational(99)` test passed.")
-		);
-
-	}
-
-	test_Reciprocals {
-
-		numTests.do {
-			var x = rrand(minIntVal,maxIntVal);
-			var y = 1 + maxIntVal.rand * [-1,1].choose;
-			var z = Rational(x,y);
-			this.assertEquals(
-				z,
-				z.reciprocal.reciprocal,
-				format( "Reciprocal test 1 with % passed.", z),
-				isVerbose
-			);
-			};
-
-		numTests.do {
-			var x = rrand(1,999);
-			var y = rrand(1,999);
-			var z = Rational(x,y);
-			this.assertEquals(
-				z * z.reciprocal,
-				Rational(1,1),
-				format( "Reciprocal test 2 with % passed.", z),
-				isVerbose
-			);
-			}
-
-	}
-
-
-	test_newFromString {
-
-		numTests.do({
-			var x = rrand(minIntVal,maxIntVal);
-			var y = 1 + maxIntVal.rand * [-1,1].choose;
-			var xStr = x.asString;
-			var yStr = y.asString;
-			var rat1 = Rational(x,y);
-			var rat2 = Rational.newFrom(xStr ++ "/"++ yStr);
-
-			this.assertEquals(
-				rat1,
-				rat2,
-				format( "String entry test with % passed.", rat1),
-				isVerbose
-			);
-		});
-	}
-
-	test_strangeStringInput {
-
-		var strangeStrings = [
-			"3 %/ 2  ",
-			"3  /  2 ",
-			"3    /   2 ",
-			"   3    / 2    ",
-			"    3     / 2      ",
-			"    3   %    /   2   ",
-			"    3    /    2 ",
-			"        3       %      /         2 "
-		];
-
-		strangeStrings.do({ arg i, j;
-			this.assertEquals(
-				Rational(i),
-				Rational(3,2),
-				format( "String entry # % test with Rational(%) passed.", j, i),
-				isVerbose
-			);
-
-		});
-	}
-
-	test_StringInput_Floats {
-		this.assertEquals(
-			"1 / 0.1".asRational,
-			Rational(10,1),
-			format( "String input test with '1 / 0.1' as Rational(10,1) passed.")
-		)
-	}
-
-	test_commutativeAdd {
-
-		numTests.do {
-			var x1 = rrand(minIntVal,maxIntVal);
-			var y1 = 1 + maxIntVal.rand * [-1,1].choose;
-			var x2 = rrand(minIntVal,maxIntVal);
-			var y2 = 1 + maxIntVal.rand;
-			var z1 = Rational(x1,y1);
-			var z2 = Rational(x2,y2);
-			this.assertEquals(
-				z1 + z2,
-				z2 + z1,
-				format( "Commutative Add test with % and % passed.", z1, z2),
-				isVerbose
-			);
-			}
-	}
-
-	test_commutativeMul {
-
-		numTests.do {
-			var x1 = rrand(minIntVal,maxIntVal);
-			var y1 = 1 + maxIntVal.rand * [-1,1].choose;
-			var x2 = rrand(minIntVal,maxIntVal);
-			var y2 = 1 + maxIntVal.rand * [-1,1].choose;
-			var z1 = Rational(x1,y1);
-			var z2 = Rational(x2,y2);
-			this.assertEquals(
-				z1 * z2,
-				z2 * z1,
-				format( "Commutative Add test with % and % passed.", z1, z2),
-				isVerbose
-			);
-			}
-	}
-
-	test_Additive_Inverse {
-
-
-		numTests.do {
-			var x = rrand(minIntVal,maxIntVal);
-			var y = 1 + maxIntVal.rand * [1,1.neg].choose;
-			var rat=Rational(x,y);
-
-			this.assertEquals(
-				Rational(x * (-1), y),
-				Rational(x, y * (-1)),
-				format( "Additive Inverse test 1 with % passed.", rat),
-				isVerbose
-			);
-			this.assertEquals(
-				(-1) * rat,
-				Rational(x * (-1), y),
-				format( "Additive Inverse test 2 with % passed.", rat),
-				isVerbose
-			);
-			this.assertEquals(
-				(-1) * rat,
-				Rational(x, y * (-1)),
-				format( "Additive Inverse test 3 with % passed.", rat),
-				isVerbose
-			)
-		}
-	}
-
-	test_Multiplicative_Inverse {
-
-		numTests.do {
-			var x    = 1 + maxIntVal.rand * [-1,1].choose;
-			var y    = 1 + maxIntVal.rand * [-1,1].choose;
-			var rat1 = Rational(x,y);
-			var rat2 = Rational(y,x);
-
-			this.assertEquals(
-				rat1.pow(-1),
-				rat2,
-				format( "Multiplicative Inverse test with % passed.", rat1),
-				isVerbose
-			);
-		}
-	}
-
-	test_Div_Eq_ReciprocalMul  {
-
-		numTests.do {
-			var x1 = rrand(minIntVal,maxIntVal);
-			var y1 = 1 + maxIntVal.rand * [-1,1].choose;
-			var x2 = 1 + maxIntVal.rand * [-1,1].choose;
-			var y2 = 1 + maxIntVal.rand * [-1,1].choose;
-			var z1 = Rational(x1,y1);
-			var z2 = Rational(x2,y2);
-			this.assertEquals(
-				z1 / z2,
-				z1 * z2.reciprocal,
-				format( "Division is equivalent to multiplying by the reciprocal test with % and %", z1, z2),
-				isVerbose
-			);
-			}
-	}
-
-	test_Neg_Subtraction {
-
-		numTests.do {
-			var x1 = rrand(minIntVal,maxIntVal);
-			var y1 = 1 + maxIntVal.rand * [-1,1].choose;
-			var x2 = rrand(minIntVal,maxIntVal);
-			var y2 = 1 + maxIntVal.rand * [-1,1].choose;
-			var z1 = Rational(x1,y1);
-			var z2 = Rational(x2,y2);
-			this.assertEquals(
-				z1 - z2,
-				z2.neg - z1.neg,
-				format( "Subtraction and Inverse test with % and % passed.", z1, z2),
-				isVerbose
-			);
-			}
-	}
-
-	test_reciprocal_Div {
-
-		numTests.do {
-			var x1 = 1 + maxIntVal.rand * [-1,1].choose;
-			var y1 = 1 + maxIntVal.rand * [-1,1].choose;
-			var x2 = 1 + maxIntVal.rand * [-1,1].choose;
-			var y2 = 1 + maxIntVal.rand * [-1,1].choose;
-			var z1 = Rational(x1,y1);
-			var z2 = Rational(x2,y2);
-			this.assertEquals(
-				z1 / z2,
-				(z2 / z1).reciprocal,
-				format( "Div + reciprocal test with % and % passed.", z1, z2),
-				isVerbose
-			);
-			}
-	}
-
-	test_Sort_and_Scramble  {
-		var listSize = 100;
-
-		numTests.do {
-			var ratList;
-			ratList = Array.fill(
-				listSize,
-				{
-					Rational(
-						rrand(minIntVal, maxIntVal),
-						 1 + maxIntVal.rand * [-1,1].choose;)
-				}
-				);
-			this.assertEquals(
-				ratList.sort,
-				ratList.scramble.sort,
-				format( "Sort and Scramble test passed."),
-				isVerbose
-			);
-		}
-	}
-
-	test_Sort_and_asFloat  {
-		var listSize = 100;
-
-		numTests.do {
-			var ratList;
-
-			ratList = Array.fill(
-				listSize,
-				{
-					Rational(
-						rrand(minIntVal, maxIntVal),
-						1 + maxIntVal.rand * [-1,1].choose;)
-				}
-				);
-
-			this.assertEquals(
-				ratList.scramble.sort.asFloat,
-				ratList.scramble.asFloat.sort,
-				format( "Sort and asFloat test passed."),
-				isVerbose
-			);
-		}
-	}
-
-	test_Mul_Inverse_DifferentExponents_NonZeroIntInput {
-
-		numTests.do {
-			var maxVal = 100;
-			var x1 = 1 + maxVal.rand * [-1,1].choose;
-			var y1 = 1 + maxVal.rand * [-1,1].choose;
-			var rat = Rational(x1,y1);
-			var maxExponent = 6;
-
-			maxExponent.do({arg i;
-				this.assertEquals(
-					rat.pow(i * (-1)),
-					rat.pow(i).reciprocal,
-					format( "Multiplicative inverse with different exponents test with exp: % and rat: % passed.", i, rat),
-					isVerbose
-				);
-
-			})
-
-		}
-	}
-
-	test_Float_Rat_Float {
-
-		numTests.do {
-			var maxVal = 1000.01;
-			var x = 1 + maxVal.rand * [1,1.neg].choose;
-			var y = 1 + maxVal.rand * [1,1.neg].choose;
-			var rat = Rational(x,y);
-			var float = x/y;
-
-			this.assertFloatEquals(
-				a: rat.asFloat,
-				b: float.asRational.asFloat,
-				message: format(
-					"Float/Rational conversion with  rat: % and float: % passed.", rat, float),
-				within: 0.000001,
-				report: isVerbose
-			);
-		}
-	}
-
-	test_Rat_Float_Rat {
-
-		numTests.do {
-			var maxVal = 100;
-			var x = 1 + maxVal.rand * [1,1.neg].choose;
-			var y = 1 + maxVal.rand * [1,1.neg].choose;
-			var rat = Rational(x,y);
-			var float = x/y;
-
-			this.assertEquals(
-				a: rat,
-				b: float.asRational.asFloat.asRational,
-				message: format(
-					"Float/Rational conversion with rat: % and float: % passed.", rat, float),
-				report: isVerbose
-			);
-		}
-	}
-
-
-	test_Exponentiation {
-
-	   numTests.do {
-			var maxVal = 9;
-			var x = 1 + maxVal.rand;
-			var y = 1 + maxVal.rand;
-			var r = Rational(x,y);
-			var e = rrand(1, 5).round;
-			this.assertEquals(
-				r,
-				r.pow(e).pow(e.reciprocal),
-				format(
-					"Exponentiation rational: % and exponent: % passed.", r, e),
-				report: isVerbose
-			);
-		}
-	}
-
-	// associative property
-	test_AssociativeAdd {
-
-		numTests.do {
-			var x1 = rrand(minIntVal,maxIntVal);
-			var y1 = 1 + maxIntVal.rand * [-1,1].choose;
-			var x2 = rrand(minIntVal,maxIntVal);
-			var y2 = 1 + maxIntVal.rand * [-1,1].choose;
-			var x3 = rrand(minIntVal,maxIntVal);
-			var y3 = 1 + maxIntVal.rand * [-1,1].choose;
-			var z1 = Rational(x1,y1);
-			var z2 = Rational(x2,y2);
-			var z3 = Rational(x3,y3);
-			this.assertEquals(
-				(z1 + z2) + z3,
-				z1 + (z2 + z3),
-				format( "Associative Sum test with %, % and %passed.", z1, z2, z3),
-				report: isVerbose
-			)
-		}
-	}
-
-	test_AssociativeMul {
-
-		numTests.do {
-			var x1 = rrand(minIntVal,maxIntVal);
-			var y1 = 1 + maxIntVal.rand * [-1,1].choose;
-			var x2 = rrand(minIntVal,maxIntVal);
-			var y2 = 1 + maxIntVal.rand * [-1,1].choose;
-			var x3 = rrand(minIntVal,maxIntVal);
-			var y3 = 1 + maxIntVal.rand * [-1,1].choose;
-			var z1 = Rational(x1,y1);
-			var z2 = Rational(x2,y2);
-			var z3 = Rational(x3,y3);
-
-			this.assertEquals(
-				(z1 * z2) * z3,
-				z1 * (z2 * z3),
-				format( "Associative Mul test with %, % and %passed.", z1, z2, z3),
-				report: isVerbose
-			);
-		}
-	}
-
-	//Distributive property of multiplication over itself
-	// (a + b) * c = (a * c) + (b * c)
-
-	test_Distributive_1_PositiveIntInput {
-
-		numTests.do {
-			var minVal = 1;
-			var maxVal = 20;
-			var x1 = rrand(minVal,maxVal);
-			var y1 = 1 + maxVal.rand ;
-			var x2 = rrand(minVal,maxVal);
-			var y2 = 1 + maxVal.rand ;
-			var x3 = rrand(minVal,maxVal);
-			var y3 = 1 + maxVal.rand ;
-			var a = Rational(x1,y1);
-			var b = Rational(x2,y2);
-			var c = Rational(x3,y3);
-
-			this.assertEquals(
-				(a + b) * c,
-				(a * c) + (b * c),
-				format( "Associative property 1 test with %, % and % passed.", a, b, c),
-				report: isVerbose
-			);
-		}
-	}
-
-
-	test_commutativeAdd_Array {
-
-		numTests.do {
-			var n = 20;
-			var minVal = -10;
-			var maxVal = 10;
-			var xs = Array.fill(n, {rrand(minVal,maxVal)});
-			var ys = Array.fill(n, {1 + maxVal.rand * [-1,1].choose});
-			var rats;
-
-			rats = n.collect({arg i; Rational(xs[i], ys[i])});
-
-			this.assertEquals(
-				rats.scramble.sum,
-				rats.scramble.sum,
-				format( "Commutative with Array summation test with %", rats),
-				report: isVerbose
-			);
-		}
-	}
+    var <>minIntVal= -1000, <>maxIntVal=1000;
+    var <>minFloatVal= -1000.1, <>maxFloatVal=1000.1;
+    var <>numTests = 100;
+    var <>seed = 123;
+    var <>isVerbose = false;
+
+    setUp { thisThread.randSeed = seed }
+
+    test_Zeros {
+        var array;
+
+        this.assert(
+            Rational(0,0).isNaN,
+            format( "Zeros with Rational(0,0).isNaN test passed.")
+        );
+        this.assert(
+            Rational(rrand(1,10),rrand(1,10)) != Rational(1,0),
+            format( "Zeros with Rational(rrand(1,10),rrand(1,10))!=Rational(1,0) test passed.")
+        );
+        this.assert(
+            Rational(rrand(1,10),rrand(1,10)) != Rational(0,0),
+            format( "Zeros with Rational(rrand(1,10),rrand(1,10))!=Rational(0,0) test passed.")
+        );
+        this.assertEquals(
+            Rational(1,0),
+            inf,
+            format( "Zeros test with Rational(1,0)==inf passed.")
+        );
+        this.assertEquals(
+            Rational(9999,0),
+            inf,
+            format( "Zeros test with Rational(9999,0)==inf passed.")
+        );
+        100.do {
+            this.assertEquals(
+                Rational(9999.rand,0),
+                Rational(9999.rand,0),
+                format( "Zeros test with Rational(9999.rand,0)==Rational(9999.rand,0) passed."),
+                isVerbose
+            )
+        };
+        this.assertEquals(
+            Rational(0,1),
+            Rational(0,9999),
+            format( "Zeros test with Rational(0,1)==Rational(0,9999) passed.")
+        );
+    }
+
+    test_Setter {
+
+        var rat;
+
+        rat = 1 %/ 2;
+        rat.numerator_(3);
+        rat.denominator_(3);
+
+        this.assert(
+            rat == Rational(1,1),
+            format( "Setter with Rational(1,2) test passed.")
+        );
+
+    }
+
+    test_BigNumbers {
+
+        this.assert(
+            (2147483646 %/ 1) + 1 == (2147483647 %/ 1),
+            format( "Big_Numbers `(2147483646 %/ 1) + 1` test passed."));
+
+        this.assert(
+            (2147483647.0 %/ 1) + 1 ==  (2147483648.0 %/ 1),
+            format( "Big_Numbers with `(2147483647.0 %/ 1) + 1` test passed."));
+
+        this.assert(
+            Rational(2147483647.0, 1) * 2 == ( 4294967294.0 %/ 1),
+            format( "Big_Numbers with ` Rational(2147483647.0, 1) * 2` test passed."));
+
+        this.assert(
+            (-2147483646 %/ 1) - 1 == (-2147483647 %/ 1),
+            format( "Big_Numbers with `(-2147483646 %/ 1) - 1` test passed."));
+
+    }
+
+    test_Pi_Precision {
+        var a = pi.asRational(99999);
+        var b = pi.asRational(999);
+        var c = pi.asRational(99);
+
+        this.assert(
+            pi.equalWithPrecision(a.asFloat, 0.000000001),
+            format( "Pi_Precision with `pi.asRational(99999)` test passed.")
+        );
+
+        this.assert(
+            pi.equalWithPrecision(b.asFloat, 0.00001),
+            format( "Pi_Precision with `pi.asRational(999)` test passed.")
+        );
+
+        this.assert(
+            pi.equalWithPrecision(c.asFloat, 0.01),
+            format( "Pi_Precision with `pi.asRational(99)` test passed.")
+        );
+
+    }
+
+    test_Reciprocals {
+
+        numTests.do {
+            var x = rrand(minIntVal,maxIntVal);
+            var y = 1 + maxIntVal.rand * [-1,1].choose;
+            var z = Rational(x,y);
+            this.assertEquals(
+                z,
+                z.reciprocal.reciprocal,
+                format( "Reciprocal test 1 with % passed.", z),
+                isVerbose
+            );
+            };
+
+        numTests.do {
+            var x = rrand(1,999);
+            var y = rrand(1,999);
+            var z = Rational(x,y);
+            this.assertEquals(
+                z * z.reciprocal,
+                Rational(1,1),
+                format( "Reciprocal test 2 with % passed.", z),
+                isVerbose
+            );
+            }
+
+    }
+
+
+    test_newFromString {
+
+        numTests.do({
+            var x = rrand(minIntVal,maxIntVal);
+            var y = 1 + maxIntVal.rand * [-1,1].choose;
+            var xStr = x.asString;
+            var yStr = y.asString;
+            var rat1 = Rational(x,y);
+            var rat2 = Rational.newFrom(xStr ++ "/"++ yStr);
+
+            this.assertEquals(
+                rat1,
+                rat2,
+                format( "String entry test with % passed.", rat1),
+                isVerbose
+            );
+        });
+    }
+
+    test_strangeStringInput {
+
+        var strangeStrings = [
+            "3 %/ 2  ",
+            "3  /  2 ",
+            "3    /   2 ",
+            "   3    / 2    ",
+            "    3     / 2      ",
+            "    3   %    /   2   ",
+            "    3    /    2 ",
+            "        3       %      /         2 "
+        ];
+
+        strangeStrings.do({ arg i, j;
+            this.assertEquals(
+                Rational(i),
+                Rational(3,2),
+                format( "String entry # % test with Rational(%) passed.", j, i),
+                isVerbose
+            );
+
+        });
+    }
+
+    test_StringInput_Floats {
+        this.assertEquals(
+            "1 / 0.1".asRational,
+            Rational(10,1),
+            format( "String input test with '1 / 0.1' as Rational(10,1) passed.")
+        )
+    }
+
+    test_commutativeAdd {
+
+        numTests.do {
+            var x1 = rrand(minIntVal,maxIntVal);
+            var y1 = 1 + maxIntVal.rand * [-1,1].choose;
+            var x2 = rrand(minIntVal,maxIntVal);
+            var y2 = 1 + maxIntVal.rand;
+            var z1 = Rational(x1,y1);
+            var z2 = Rational(x2,y2);
+            this.assertEquals(
+                z1 + z2,
+                z2 + z1,
+                format( "Commutative Add test with % and % passed.", z1, z2),
+                isVerbose
+            );
+            }
+    }
+
+    test_commutativeMul {
+
+        numTests.do {
+            var x1 = rrand(minIntVal,maxIntVal);
+            var y1 = 1 + maxIntVal.rand * [-1,1].choose;
+            var x2 = rrand(minIntVal,maxIntVal);
+            var y2 = 1 + maxIntVal.rand * [-1,1].choose;
+            var z1 = Rational(x1,y1);
+            var z2 = Rational(x2,y2);
+            this.assertEquals(
+                z1 * z2,
+                z2 * z1,
+                format( "Commutative Add test with % and % passed.", z1, z2),
+                isVerbose
+            );
+            }
+    }
+
+    test_Additive_Inverse {
+
+
+        numTests.do {
+            var x = rrand(minIntVal,maxIntVal);
+            var y = 1 + maxIntVal.rand * [1,1.neg].choose;
+            var rat=Rational(x,y);
+
+            this.assertEquals(
+                Rational(x * (-1), y),
+                Rational(x, y * (-1)),
+                format( "Additive Inverse test 1 with % passed.", rat),
+                isVerbose
+            );
+            this.assertEquals(
+                (-1) * rat,
+                Rational(x * (-1), y),
+                format( "Additive Inverse test 2 with % passed.", rat),
+                isVerbose
+            );
+            this.assertEquals(
+                (-1) * rat,
+                Rational(x, y * (-1)),
+                format( "Additive Inverse test 3 with % passed.", rat),
+                isVerbose
+            )
+        }
+    }
+
+    test_Multiplicative_Inverse {
+
+        numTests.do {
+            var x    = 1 + maxIntVal.rand * [-1,1].choose;
+            var y    = 1 + maxIntVal.rand * [-1,1].choose;
+            var rat1 = Rational(x,y);
+            var rat2 = Rational(y,x);
+
+            this.assertEquals(
+                rat1.pow(-1),
+                rat2,
+                format( "Multiplicative Inverse test with % passed.", rat1),
+                isVerbose
+            );
+        }
+    }
+
+    test_Div_Eq_ReciprocalMul  {
+
+        numTests.do {
+            var x1 = rrand(minIntVal,maxIntVal);
+            var y1 = 1 + maxIntVal.rand * [-1,1].choose;
+            var x2 = 1 + maxIntVal.rand * [-1,1].choose;
+            var y2 = 1 + maxIntVal.rand * [-1,1].choose;
+            var z1 = Rational(x1,y1);
+            var z2 = Rational(x2,y2);
+            this.assertEquals(
+                z1 / z2,
+                z1 * z2.reciprocal,
+                format( "Division is equivalent to multiplying by the reciprocal test with % and %", z1, z2),
+                isVerbose
+            );
+            }
+    }
+
+    test_Neg_Subtraction {
+
+        numTests.do {
+            var x1 = rrand(minIntVal,maxIntVal);
+            var y1 = 1 + maxIntVal.rand * [-1,1].choose;
+            var x2 = rrand(minIntVal,maxIntVal);
+            var y2 = 1 + maxIntVal.rand * [-1,1].choose;
+            var z1 = Rational(x1,y1);
+            var z2 = Rational(x2,y2);
+            this.assertEquals(
+                z1 - z2,
+                z2.neg - z1.neg,
+                format( "Subtraction and Inverse test with % and % passed.", z1, z2),
+                isVerbose
+            );
+            }
+    }
+
+    test_reciprocal_Div {
+
+        numTests.do {
+            var x1 = 1 + maxIntVal.rand * [-1,1].choose;
+            var y1 = 1 + maxIntVal.rand * [-1,1].choose;
+            var x2 = 1 + maxIntVal.rand * [-1,1].choose;
+            var y2 = 1 + maxIntVal.rand * [-1,1].choose;
+            var z1 = Rational(x1,y1);
+            var z2 = Rational(x2,y2);
+            this.assertEquals(
+                z1 / z2,
+                (z2 / z1).reciprocal,
+                format( "Div + reciprocal test with % and % passed.", z1, z2),
+                isVerbose
+            );
+            }
+    }
+
+    test_Sort_and_Scramble  {
+        var listSize = 100;
+
+        numTests.do {
+            var ratList;
+            ratList = Array.fill(
+                listSize,
+                {
+                    Rational(
+                        rrand(minIntVal, maxIntVal),
+                         1 + maxIntVal.rand * [-1,1].choose;)
+                }
+                );
+            this.assertEquals(
+                ratList.sort,
+                ratList.scramble.sort,
+                format( "Sort and Scramble test passed."),
+                isVerbose
+            );
+        }
+    }
+
+    test_Sort_and_asFloat  {
+        var listSize = 100;
+
+        numTests.do {
+            var ratList;
+
+            ratList = Array.fill(
+                listSize,
+                {
+                    Rational(
+                        rrand(minIntVal, maxIntVal),
+                        1 + maxIntVal.rand * [-1,1].choose;)
+                }
+                );
+
+            this.assertEquals(
+                ratList.scramble.sort.asFloat,
+                ratList.scramble.asFloat.sort,
+                format( "Sort and asFloat test passed."),
+                isVerbose
+            );
+        }
+    }
+
+    test_Mul_Inverse_DifferentExponents_NonZeroIntInput {
+
+        numTests.do {
+            var maxVal = 100;
+            var x1 = 1 + maxVal.rand * [-1,1].choose;
+            var y1 = 1 + maxVal.rand * [-1,1].choose;
+            var rat = Rational(x1,y1);
+            var maxExponent = 6;
+
+            maxExponent.do({arg i;
+                this.assertEquals(
+                    rat.pow(i * (-1)),
+                    rat.pow(i).reciprocal,
+                    format( "Multiplicative inverse with different exponents test with exp: % and rat: % passed.", i, rat),
+                    isVerbose
+                );
+
+            })
+
+        }
+    }
+
+    test_Float_Rat_Float {
+
+        numTests.do {
+            var maxVal = 1000.01;
+            var x = 1 + maxVal.rand * [1,1.neg].choose;
+            var y = 1 + maxVal.rand * [1,1.neg].choose;
+            var rat = Rational(x,y);
+            var float = x/y;
+
+            this.assertFloatEquals(
+                a: rat.asFloat,
+                b: float.asRational.asFloat,
+                message: format(
+                    "Float/Rational conversion with  rat: % and float: % passed.", rat, float),
+                within: 0.000001,
+                report: isVerbose
+            );
+        }
+    }
+
+    test_Rat_Float_Rat {
+
+        numTests.do {
+            var maxVal = 100;
+            var x = 1 + maxVal.rand * [1,1.neg].choose;
+            var y = 1 + maxVal.rand * [1,1.neg].choose;
+            var rat = Rational(x,y);
+            var float = x/y;
+
+            this.assertEquals(
+                a: rat,
+                b: float.asRational.asFloat.asRational,
+                message: format(
+                    "Float/Rational conversion with rat: % and float: % passed.", rat, float),
+                report: isVerbose
+            );
+        }
+    }
+
+
+    test_Exponentiation {
+
+       numTests.do {
+            var maxVal = 9;
+            var x = 1 + maxVal.rand;
+            var y = 1 + maxVal.rand;
+            var r = Rational(x,y);
+            var e = rrand(1, 5).round;
+            this.assertEquals(
+                r,
+                r.pow(e).pow(e.reciprocal),
+                format(
+                    "Exponentiation rational: % and exponent: % passed.", r, e),
+                report: isVerbose
+            );
+        }
+    }
+
+    // associative property
+    test_AssociativeAdd {
+
+        numTests.do {
+            var x1 = rrand(minIntVal,maxIntVal);
+            var y1 = 1 + maxIntVal.rand * [-1,1].choose;
+            var x2 = rrand(minIntVal,maxIntVal);
+            var y2 = 1 + maxIntVal.rand * [-1,1].choose;
+            var x3 = rrand(minIntVal,maxIntVal);
+            var y3 = 1 + maxIntVal.rand * [-1,1].choose;
+            var z1 = Rational(x1,y1);
+            var z2 = Rational(x2,y2);
+            var z3 = Rational(x3,y3);
+            this.assertEquals(
+                (z1 + z2) + z3,
+                z1 + (z2 + z3),
+                format( "Associative Sum test with %, % and %passed.", z1, z2, z3),
+                report: isVerbose
+            )
+        }
+    }
+
+    test_AssociativeMul {
+
+        numTests.do {
+            var x1 = rrand(minIntVal,maxIntVal);
+            var y1 = 1 + maxIntVal.rand * [-1,1].choose;
+            var x2 = rrand(minIntVal,maxIntVal);
+            var y2 = 1 + maxIntVal.rand * [-1,1].choose;
+            var x3 = rrand(minIntVal,maxIntVal);
+            var y3 = 1 + maxIntVal.rand * [-1,1].choose;
+            var z1 = Rational(x1,y1);
+            var z2 = Rational(x2,y2);
+            var z3 = Rational(x3,y3);
+
+            this.assertEquals(
+                (z1 * z2) * z3,
+                z1 * (z2 * z3),
+                format( "Associative Mul test with %, % and %passed.", z1, z2, z3),
+                report: isVerbose
+            );
+        }
+    }
+
+    //Distributive property of multiplication over itself
+    // (a + b) * c = (a * c) + (b * c)
+
+    test_Distributive_1_PositiveIntInput {
+
+        numTests.do {
+            var minVal = 1;
+            var maxVal = 20;
+            var x1 = rrand(minVal,maxVal);
+            var y1 = 1 + maxVal.rand ;
+            var x2 = rrand(minVal,maxVal);
+            var y2 = 1 + maxVal.rand ;
+            var x3 = rrand(minVal,maxVal);
+            var y3 = 1 + maxVal.rand ;
+            var a = Rational(x1,y1);
+            var b = Rational(x2,y2);
+            var c = Rational(x3,y3);
+
+            this.assertEquals(
+                (a + b) * c,
+                (a * c) + (b * c),
+                format( "Associative property 1 test with %, % and % passed.", a, b, c),
+                report: isVerbose
+            );
+        }
+    }
+
+
+    test_commutativeAdd_Array {
+
+        numTests.do {
+            var n = 20;
+            var minVal = -10;
+            var maxVal = 10;
+            var xs = Array.fill(n, {rrand(minVal,maxVal)});
+            var ys = Array.fill(n, {1 + maxVal.rand * [-1,1].choose});
+            var rats;
+
+            rats = n.collect({arg i; Rational(xs[i], ys[i])});
+
+            this.assertEquals(
+                rats.scramble.sum,
+                rats.scramble.sum,
+                format( "Commutative with Array summation test with %", rats),
+                report: isVerbose
+            );
+        }
+    }
 }
 
 /*

--- a/testsuite/classlibrary/TestRational.sc
+++ b/testsuite/classlibrary/TestRational.sc
@@ -268,6 +268,7 @@ TestRational : UnitTest {
         }
     }
 
+    // associative property
     test_AssociativeAdd_NonZeroIntInput {
         numTests.do {
             var x1 = rrand(minIntVal,maxIntVal);
@@ -306,6 +307,29 @@ TestRational : UnitTest {
         }
     }
 
+     // distributive property
+    //(a + b) * c = (a * c) + (b * c)
+    test_Distributive_1_PositiveIntInput {
+        numTests.do {
+            var minVal = 1;
+            var maxVal = 20;
+            var x1 = rrand(minVal,maxVal);
+            var y1 = 1 + maxVal.rand ;
+            var x2 = rrand(minVal,maxVal);
+            var y2 = 1 + maxVal.rand ;
+            var x3 = rrand(minVal,maxVal);
+            var y3 = 1 + maxVal.rand ;
+            var a = Rational(x1,y1);
+            var b = Rational(x2,y2);
+            var c = Rational(x3,y3);
+
+            this.assertEquals(
+                (a + b) * c,
+                (a * c) + (b * c),
+                format( "Associative property 2 test with %, % and % passed.", a, b, c)
+            );
+        }
+    }
 }
 
 

--- a/testsuite/classlibrary/TestRational.sc
+++ b/testsuite/classlibrary/TestRational.sc
@@ -5,218 +5,270 @@ UnitTest.gui
 
 TestRational : UnitTest {
 
-    var minIntVal= -1000, maxIntVal=1000;
-    var minFloatVal= -1000.1, maxFloatVal=1000.1;
-    var numTests = 1000;
+	var minIntVal= -1000, maxIntVal=1000;
+	var minFloatVal= -1000.1, maxFloatVal=1000.1;
+	var numTests = 1000;
 
-    test_reciprocal_NonZeroIntInput {
-        numTests.do {
-            var x = rrand(minIntVal,maxIntVal);
-            var y = 1 + maxIntVal.rand * [-1,1].choose;
-            var z = Rational(x,y);
-            this.assertEquals(
-                z,
-                z.reciprocal.reciprocal,
-                format( "Reciprocal test with % passed.", z)
-            );
-            }
-    }
+	test_reciprocal_NonZeroIntInput {
+		numTests.do {
+			var x = rrand(minIntVal,maxIntVal);
+			var y = 1 + maxIntVal.rand * [-1,1].choose;
+			var z = Rational(x,y);
+			this.assertEquals(
+				z,
+				z.reciprocal.reciprocal,
+				format( "Reciprocal test with % passed.", z)
+			);
+			}
+	}
 
-    test_newFromString_NonZeroIntInput {
-        numTests.do {
-            var x = rrand(minIntVal,maxIntVal);
-            var y = 1 + maxIntVal.rand * [-1,1].choose;
-            var xStr = x.asString;
-            var yStr = y.asString;
-            var rat1 = Rational(x,y);
-            var rat2 = Rational.newFrom(xStr ++ "/"++ yStr);
-            this.assertEquals(
-                rat1,
-                rat2,
-                format( "String entry test with % passed.", rat1)
-            );
-        }
-    }
+	test_newFromString_NonZeroIntInput {
+		numTests.do {
+			var x = rrand(minIntVal,maxIntVal);
+			var y = 1 + maxIntVal.rand * [-1,1].choose;
+			var xStr = x.asString;
+			var yStr = y.asString;
+			var rat1 = Rational(x,y);
+			var rat2 = Rational.newFrom(xStr ++ "/"++ yStr);
+			this.assertEquals(
+				rat1,
+				rat2,
+				format( "String entry test with % passed.", rat1)
+			);
+		}
+	}
 
-    test_commutativeAdd_NonZeroIntInput {
-        numTests.do {
-            var x1 = rrand(minIntVal,maxIntVal);
-            var y1 = 1 + maxIntVal.rand * [-1,1].choose;
-            var x2 = rrand(minIntVal,maxIntVal);
-            var y2 = 1 + maxIntVal.rand;
-            var z1 = Rational(x1,y1);
-            var z2 = Rational(x2,y2);
-            this.assertEquals(
-                z1 + z2,
-                z2 + z1,
-                format( "Commutative Add test with % and % passed.", z1, z2));
-            }
-    }
+	test_commutativeAdd_NonZeroIntInput {
+		numTests.do {
+			var x1 = rrand(minIntVal,maxIntVal);
+			var y1 = 1 + maxIntVal.rand * [-1,1].choose;
+			var x2 = rrand(minIntVal,maxIntVal);
+			var y2 = 1 + maxIntVal.rand;
+			var z1 = Rational(x1,y1);
+			var z2 = Rational(x2,y2);
+			this.assertEquals(
+				z1 + z2,
+				z2 + z1,
+				format( "Commutative Add test with % and % passed.", z1, z2));
+			}
+	}
 
-    test_commutativeMul_NonZeroIntInput {
-        numTests.do {
-            var x1 = rrand(minIntVal,maxIntVal);
-            var y1 = 1 + maxIntVal.rand * [-1,1].choose;
-            var x2 = rrand(minIntVal,maxIntVal);
-            var y2 = 1 + maxIntVal.rand * [-1,1].choose;
-            var z1 = Rational(x1,y1);
-            var z2 = Rational(x2,y2);
-            this.assertEquals(
-                z1 * z2,
-                z2 * z1,
-                format( "Commutative Add test with % and % passed.", z1, z2));
-            }
-    }
+	test_commutativeMul_NonZeroIntInput {
+		numTests.do {
+			var x1 = rrand(minIntVal,maxIntVal);
+			var y1 = 1 + maxIntVal.rand * [-1,1].choose;
+			var x2 = rrand(minIntVal,maxIntVal);
+			var y2 = 1 + maxIntVal.rand * [-1,1].choose;
+			var z1 = Rational(x1,y1);
+			var z2 = Rational(x2,y2);
+			this.assertEquals(
+				z1 * z2,
+				z2 * z1,
+				format( "Commutative Add test with % and % passed.", z1, z2));
+			}
+	}
 
-    test_Additive_Inverse_NonZeroIntInput {
-        numTests.do {
-            var x = rrand(minIntVal,maxIntVal);
-            var y = 1 + maxIntVal.rand * [1,1.neg].choose;
-            var rat=Rational(x,y);
+	test_Additive_Inverse_NonZeroIntInput {
+		numTests.do {
+			var x = rrand(minIntVal,maxIntVal);
+			var y = 1 + maxIntVal.rand * [1,1.neg].choose;
+			var rat=Rational(x,y);
 
-            this.assertEquals(
-                Rational(x * (-1), y),
-                Rational(x, y * (-1)),
-                format( "Additive Inverse test 1 with % passed.", rat)
-            );
-            this.assertEquals(
-                (-1) * rat,
-                Rational(x * (-1), y),
-                format( "Additive Inverse test 2 with % passed.", rat)
-            );
-            this.assertEquals(
-                (-1) * rat,
-                Rational(x, y * (-1)),
-                format( "Additive Inverse test 3 with % passed.", rat)
-            )
-        }
-    }
+			this.assertEquals(
+				Rational(x * (-1), y),
+				Rational(x, y * (-1)),
+				format( "Additive Inverse test 1 with % passed.", rat)
+			);
+			this.assertEquals(
+				(-1) * rat,
+				Rational(x * (-1), y),
+				format( "Additive Inverse test 2 with % passed.", rat)
+			);
+			this.assertEquals(
+				(-1) * rat,
+				Rational(x, y * (-1)),
+				format( "Additive Inverse test 3 with % passed.", rat)
+			)
+		}
+	}
 
-    test_Multiplicative_Inverse_NonZeroIntInput {
-        numTests.do {
-            var x    = 1 + maxIntVal.rand * [-1,1].choose;
-            var y    = 1 + maxIntVal.rand * [-1,1].choose;
-            var rat1 = Rational(x,y);
-            var rat2 = Rational(y,x);
+	test_Multiplicative_Inverse_NonZeroIntInput {
+		numTests.do {
+			var x    = 1 + maxIntVal.rand * [-1,1].choose;
+			var y    = 1 + maxIntVal.rand * [-1,1].choose;
+			var rat1 = Rational(x,y);
+			var rat2 = Rational(y,x);
 
-            this.assertEquals(
-                rat1.pow(-1),
-                rat2,
-                format( "Multiplicative Inverse test with % passed.", rat1)
-            );
-        }
-    }
+			this.assertEquals(
+				rat1.pow(-1),
+				rat2,
+				format( "Multiplicative Inverse test with % passed.", rat1)
+			);
+		}
+	}
 
-    test_Div_Eq_ReciprocalMul_NonZeroIntInput  {
-        numTests.do {
-            var x1 = rrand(minIntVal,maxIntVal);
-            var y1 = 1 + maxIntVal.rand * [-1,1].choose;
-            var x2 = 1 + maxIntVal.rand * [-1,1].choose;
-            var y2 = 1 + maxIntVal.rand * [-1,1].choose;
-            var z1 = Rational(x1,y1);
-            var z2 = Rational(x2,y2);
-            this.assertEquals(
-                z1 / z2,
-                z1 * z2.reciprocal,
-                format( "Division is equivalent to multiplying by the reciprocal test with % and %", z1, z2));
-            }
-    }
+	test_Div_Eq_ReciprocalMul_NonZeroIntInput  {
+		numTests.do {
+			var x1 = rrand(minIntVal,maxIntVal);
+			var y1 = 1 + maxIntVal.rand * [-1,1].choose;
+			var x2 = 1 + maxIntVal.rand * [-1,1].choose;
+			var y2 = 1 + maxIntVal.rand * [-1,1].choose;
+			var z1 = Rational(x1,y1);
+			var z2 = Rational(x2,y2);
+			this.assertEquals(
+				z1 / z2,
+				z1 * z2.reciprocal,
+				format( "Division is equivalent to multiplying by the reciprocal test with % and %", z1, z2));
+			}
+	}
 
-    test_Neg_Subtraction_NonZeroIntInput {
-        numTests.do {
-            var x1 = rrand(minIntVal,maxIntVal);
-            var y1 = 1 + maxIntVal.rand * [-1,1].choose;
-            var x2 = rrand(minIntVal,maxIntVal);
-            var y2 = 1 + maxIntVal.rand * [-1,1].choose;
-            var z1 = Rational(x1,y1);
-            var z2 = Rational(x2,y2);
-            this.assertEquals(
-                z1 - z2,
-                z2.neg - z1.neg,
-                format( "Subtraction and Inverse test with % and % passed.", z1, z2));
-            }
-    }
+	test_Neg_Subtraction_NonZeroIntInput {
+		numTests.do {
+			var x1 = rrand(minIntVal,maxIntVal);
+			var y1 = 1 + maxIntVal.rand * [-1,1].choose;
+			var x2 = rrand(minIntVal,maxIntVal);
+			var y2 = 1 + maxIntVal.rand * [-1,1].choose;
+			var z1 = Rational(x1,y1);
+			var z2 = Rational(x2,y2);
+			this.assertEquals(
+				z1 - z2,
+				z2.neg - z1.neg,
+				format( "Subtraction and Inverse test with % and % passed.", z1, z2));
+			}
+	}
 
-    test_reciprocal_Div_NonZeroIntInput {
-        numTests.do {
-            var x1 = rrand(minIntVal,maxIntVal);
-            var y1 = 1 + maxIntVal.rand * [-1,1].choose;
-            var x2 = rrand(minIntVal,maxIntVal);
-            var y2 = 1 + maxIntVal.rand * [-1,1].choose;
-            var z1 = Rational(x1,y1);
-            var z2 = Rational(x2,y2);
-            this.assertEquals(
-                z1 / z2,
-                (z2 / z1).reciprocal,
-                format( "Div + reciprocal test with % and % passed.", z1, z2));
-            }
-    }
+	test_reciprocal_Div_NonZeroIntInput {
+		numTests.do {
+			var x1 = rrand(minIntVal,maxIntVal);
+			var y1 = 1 + maxIntVal.rand * [-1,1].choose;
+			var x2 = rrand(minIntVal,maxIntVal);
+			var y2 = 1 + maxIntVal.rand * [-1,1].choose;
+			var z1 = Rational(x1,y1);
+			var z2 = Rational(x2,y2);
+			this.assertEquals(
+				z1 / z2,
+				(z2 / z1).reciprocal,
+				format( "Div + reciprocal test with % and % passed.", z1, z2));
+			}
+	}
 
-    test_Sort_and_Scramble_NonZeroIntInput  {
-        var listSize = 1000;
+	test_Sort_and_Scramble_NonZeroIntInput  {
+		var listSize = 1000;
 
-        //numTests.do {
-        10.do {
-            var ratList;
-            ratList = Array.fill(
-                listSize,
-                {
-                    Rational(
-                        rrand(minIntVal, maxIntVal),
-                         1 + maxIntVal.rand * [-1,1].choose;)
-                }
-                );
-            this.assertEquals(
-                ratList.sort,
-                ratList.scramble.sort,
-                format( "Sort and Scramble test passed.")
-            );
-        }
-    }
+		//numTests.do {
+		10.do {
+			var ratList;
+			ratList = Array.fill(
+				listSize,
+				{
+					Rational(
+						rrand(minIntVal, maxIntVal),
+						 1 + maxIntVal.rand * [-1,1].choose;)
+				}
+				);
+			this.assertEquals(
+				ratList.sort,
+				ratList.scramble.sort,
+				format( "Sort and Scramble test passed.")
+			);
+		}
+	}
 
-    test_Sort_and_asFloat_NonZeroIntInput  {
-        var listSize = 1000;
+	test_Sort_and_asFloat_NonZeroIntInput  {
+		var listSize = 1000;
 
-        //numTests.do {
-        10.do {
-            var ratList;
+		//numTests.do {
+		10.do {
+			var ratList;
 
-            ratList = Array.fill(
-                listSize,
-                {
-                    Rational(
-                        rrand(minIntVal, maxIntVal),
-                        1 + maxIntVal.rand * [-1,1].choose;)
-                }
-                );
+			ratList = Array.fill(
+				listSize,
+				{
+					Rational(
+						rrand(minIntVal, maxIntVal),
+						1 + maxIntVal.rand * [-1,1].choose;)
+				}
+				);
 
-            this.assertEquals(
-                ratList.scramble.sort.asFloat,
-                ratList.scramble.asFloat.sort,
-                format( "Sort and asFloat test passed.")
-            );
-        }
-    }
+			this.assertEquals(
+				ratList.scramble.sort.asFloat,
+				ratList.scramble.asFloat.sort,
+				format( "Sort and asFloat test passed.")
+			);
+		}
+	}
 
-    test_Mul_Inverse_DifferentExponents_NonZeroIntInput {
-        numTests.do {
-            var maxVal = 100;
-            var x1 = 1 + maxVal.rand * [-1,1].choose;
-            var y1 = 1 + maxVal.rand * [-1,1].choose;
-            var rat = Rational(x1,y1);
-            var maxExponent = 6;
+	test_Mul_Inverse_DifferentExponents_NonZeroIntInput {
+		numTests.do {
+			var maxVal = 100;
+			var x1 = 1 + maxVal.rand * [-1,1].choose;
+			var y1 = 1 + maxVal.rand * [-1,1].choose;
+			var rat = Rational(x1,y1);
+			var maxExponent = 6;
 
-            maxExponent.do({arg i;
-                this.assertEquals(
-                rat.pow(i * (-1)),
-                rat.pow(i).reciprocal,
-                format( "Multiplicative inverse with different exponents test with exp: % and rat: % passed.", i, rat));
+			maxExponent.do({arg i;
+				this.assertEquals(
+					rat.pow(i * (-1)),
+					rat.pow(i).reciprocal,
+					format( "Multiplicative inverse with different exponents test with exp: % and rat: % passed.", i, rat));
 
-            })
+			})
 
-            }
-    }
+		}
+	}
+
+	test_Float_Rat_Float {
+		numTests.do {
+			var maxVal = 1000.01;
+			var x = 1 + maxVal.rand * [1,1.neg].choose;
+			var y = 1 + maxVal.rand * [1,1.neg].choose;
+			var rat = Rational(x,y);
+			var float = x/y;
+
+			this.assertFloatEquals(
+				a: rat.asFloat,
+				b: float.asRational.asFloat,
+				message: format(
+					"Float/Rational conversion with  rat: % and float: % passed.", rat, float),
+				within: 0.000001
+			);
+		}
+	}
+
+	test_Rat_Float_Rat {
+		numTests.do {
+			var maxVal = 100;
+			var x = 1 + maxVal.rand * [1,1.neg].choose;
+			var y = 1 + maxVal.rand * [1,1.neg].choose;
+			var rat = Rational(x,y);
+			var float = x/y;
+
+			this.assertEquals(
+				a: rat,
+				b: float.asRational.asFloat.asRational,
+				message: format(
+					"Float/Rational conversion with rat: % and float: % passed.", rat, float)
+			);
+		}
+	}
+
+	test_Exponentiation {
+	   numTests.do {
+			var maxVal = 9;
+			var x = 1 + maxVal.rand;
+			var y = 1 + maxVal.rand;
+			var r = Rational(x,y);
+			var e = rrand(1, 5).round;
+			this.assertEquals(
+				r,
+				r.pow(e).pow(e.reciprocal),
+				format(
+					"Exponentiation rational: % and exponent: % passed.", r, e));
+		}
+	}
+
 }
+
 
 /*
 TestRational.run

--- a/testsuite/classlibrary/TestRational.sc
+++ b/testsuite/classlibrary/TestRational.sc
@@ -1,44 +1,102 @@
 /*
-TestRational.run
 UnitTest.gui
+TestRational.run
+TestRational().numTests_(100).seed_(999.rand).isVerbose_(true).run;
 */
 
 TestRational : UnitTest {
 
-	var minIntVal= -1000, maxIntVal=1000;
-	var minFloatVal= -1000.1, maxFloatVal=1000.1;
-	var numTests = 1000;
+	var <>minIntVal= -1000, <>maxIntVal=1000;
+	var <>minFloatVal= -1000.1, <>maxFloatVal=1000.1;
+	var <>numTests = 100;
+	var <>seed = 123;
+	var <>isVerbose = false;
 
-	setRandSeed { arg seed=123; thisThread.randSeed = seed }
+	setUp { thisThread.randSeed = seed }
 
-	test_Zero {
+	test_Zeros {
 		var array;
 
 		this.assert(
 			Rational(0,0).isNaN,
-			format( "Zero Denominator with Rational(0,0).isNaN test passed.")
+			format( "Zeros with Rational(0,0).isNaN test passed.")
+		);
+		this.assert(
+			Rational(rrand(1,10),rrand(1,10)) != Rational(1,0),
+			format( "Zeros with Rational(rrand(1,10),rrand(1,10))!=Rational(1,0) test passed.")
+		);
+		this.assert(
+			Rational(rrand(1,10),rrand(1,10)) != Rational(0,0),
+			format( "Zeros with Rational(rrand(1,10),rrand(1,10))!=Rational(0,0) test passed.")
 		);
 		this.assertEquals(
 			Rational(1,0),
-			inf, 
-			format( "Zero Denominator test with Rational(1,0)==inf passed.")
+			inf,
+			format( "Zeros test with Rational(1,0)==inf passed.")
 		);
 		this.assertEquals(
 			Rational(9999,0),
-			inf, 
-			format( "Zero Denominator test with Rational(9999,0)==inf passed.")
+			inf,
+			format( "Zeros test with Rational(9999,0)==inf passed.")
 		);
+		100.do {
+			this.assertEquals(
+				Rational(9999.rand,0),
+				Rational(9999.rand,0),
+				format( "Zeros test with Rational(9999.rand,0)==Rational(9999.rand,0) passed."),
+				isVerbose
+			)
+		};
 		this.assertEquals(
 			Rational(0,1),
 			Rational(0,9999),
-			format( "Zero Denominator test with Rational(0,1)==Rational(0,9999) passed.")
+			format( "Zeros test with Rational(0,1)==Rational(0,9999) passed.")
 		);
 	}
 
-	test_reciprocal {
-		var report = true;
+	test_BigNumbers {
 
-		this.setRandSeed;
+		this.assert(
+			(2147483646 %/ 1) + 1 == (2147483647 %/ 1),
+			format( "Big_Numbers `(2147483646 %/ 1) + 1` test passed."));
+
+		this.assert(
+			(2147483647.0 %/ 1) + 1 ==  (2147483648.0 %/ 1),
+			format( "Big_Numbers with `(2147483647.0 %/ 1) + 1` test passed."));
+
+		this.assert(
+			Rational(2147483647.0, 1) * 2 == ( 4294967294.0 %/ 1),
+			format( "Big_Numbers with ` Rational(2147483647.0, 1) * 2` test passed."));
+
+		this.assert(
+			(-2147483646 %/ 1) - 1 == (-2147483647 %/ 1),
+			format( "Big_Numbers with `(-2147483646 %/ 1) - 1` test passed."));
+
+	}
+
+	test_Pi_Precision {
+		var a = pi.asRational(99999);
+		var b = pi.asRational(999);
+		var c = pi.asRational(99);
+
+		this.assert(
+			pi.equalWithPrecision(a.asFloat, 0.000000001),
+			format( "Pi_Precision with `pi.asRational(99999)` test passed.")
+		);
+
+		this.assert(
+			pi.equalWithPrecision(b.asFloat, 0.00001),
+			format( "Pi_Precision with `pi.asRational(999)` test passed.")
+		);
+
+		this.assert(
+			pi.equalWithPrecision(c.asFloat, 0.01),
+			format( "Pi_Precision with `pi.asRational(99)` test passed.")
+		);
+
+	}
+
+	test_Reciprocals {
 
 		numTests.do {
 			var x = rrand(minIntVal,maxIntVal);
@@ -47,14 +105,27 @@ TestRational : UnitTest {
 			this.assertEquals(
 				z,
 				z.reciprocal.reciprocal,
-				format( "Reciprocal test with % passed.", z),
-				report: report
+				format( "Reciprocal test 1 with % passed.", z),
+				isVerbose
+			);
+			};
+
+		numTests.do {
+			var x = rrand(1,999);
+			var y = rrand(1,999);
+			var z = Rational(x,y);
+			this.assertEquals(
+				z * z.reciprocal,
+				Rational(1,1),
+				format( "Reciprocal test 2 with % passed.", z),
+				isVerbose
 			);
 			}
+
 	}
 
+
 	test_newFromString {
-		this.setRandSeed;
 
 		numTests.do({
 			var x = rrand(minIntVal,maxIntVal);
@@ -67,7 +138,8 @@ TestRational : UnitTest {
 			this.assertEquals(
 				rat1,
 				rat2,
-				format( "String entry test with % passed.", rat1)
+				format( "String entry test with % passed.", rat1),
+				isVerbose
 			);
 		});
 	}
@@ -85,12 +157,12 @@ TestRational : UnitTest {
 			"        3       %      /         2 "
 		];
 
-
 		strangeStrings.do({ arg i, j;
 			this.assertEquals(
 				Rational(i),
 				Rational(3,2),
-				format( "String entry # % test with Rational(%) passed.", j, i)
+				format( "String entry # % test with Rational(%) passed.", j, i),
+				isVerbose
 			);
 
 		});
@@ -106,8 +178,6 @@ TestRational : UnitTest {
 
 	test_commutativeAdd {
 
-		this.setRandSeed;
-
 		numTests.do {
 			var x1 = rrand(minIntVal,maxIntVal);
 			var y1 = 1 + maxIntVal.rand * [-1,1].choose;
@@ -118,14 +188,13 @@ TestRational : UnitTest {
 			this.assertEquals(
 				z1 + z2,
 				z2 + z1,
-				format( "Commutative Add test with % and % passed.", z1, z2)
+				format( "Commutative Add test with % and % passed.", z1, z2),
+				isVerbose
 			);
 			}
 	}
 
 	test_commutativeMul {
-
-		this.setRandSeed;
 
 		numTests.do {
 			var x1 = rrand(minIntVal,maxIntVal);
@@ -137,13 +206,14 @@ TestRational : UnitTest {
 			this.assertEquals(
 				z1 * z2,
 				z2 * z1,
-				format( "Commutative Add test with % and % passed.", z1, z2));
+				format( "Commutative Add test with % and % passed.", z1, z2),
+				isVerbose
+			);
 			}
 	}
 
 	test_Additive_Inverse {
 
-		this.setRandSeed;
 
 		numTests.do {
 			var x = rrand(minIntVal,maxIntVal);
@@ -153,24 +223,25 @@ TestRational : UnitTest {
 			this.assertEquals(
 				Rational(x * (-1), y),
 				Rational(x, y * (-1)),
-				format( "Additive Inverse test 1 with % passed.", rat)
+				format( "Additive Inverse test 1 with % passed.", rat),
+				isVerbose
 			);
 			this.assertEquals(
 				(-1) * rat,
 				Rational(x * (-1), y),
-				format( "Additive Inverse test 2 with % passed.", rat)
+				format( "Additive Inverse test 2 with % passed.", rat),
+				isVerbose
 			);
 			this.assertEquals(
 				(-1) * rat,
 				Rational(x, y * (-1)),
-				format( "Additive Inverse test 3 with % passed.", rat)
+				format( "Additive Inverse test 3 with % passed.", rat),
+				isVerbose
 			)
 		}
 	}
 
 	test_Multiplicative_Inverse {
-
-		this.setRandSeed;
 
 		numTests.do {
 			var x    = 1 + maxIntVal.rand * [-1,1].choose;
@@ -181,7 +252,8 @@ TestRational : UnitTest {
 			this.assertEquals(
 				rat1.pow(-1),
 				rat2,
-				format( "Multiplicative Inverse test with % passed.", rat1)
+				format( "Multiplicative Inverse test with % passed.", rat1),
+				isVerbose
 			);
 		}
 	}
@@ -198,13 +270,13 @@ TestRational : UnitTest {
 			this.assertEquals(
 				z1 / z2,
 				z1 * z2.reciprocal,
-				format( "Division is equivalent to multiplying by the reciprocal test with % and %", z1, z2));
+				format( "Division is equivalent to multiplying by the reciprocal test with % and %", z1, z2),
+				isVerbose
+			);
 			}
 	}
 
 	test_Neg_Subtraction {
-
-		this.setRandSeed;
 
 		numTests.do {
 			var x1 = rrand(minIntVal,maxIntVal);
@@ -216,13 +288,13 @@ TestRational : UnitTest {
 			this.assertEquals(
 				z1 - z2,
 				z2.neg - z1.neg,
-				format( "Subtraction and Inverse test with % and % passed.", z1, z2));
+				format( "Subtraction and Inverse test with % and % passed.", z1, z2),
+				isVerbose
+			);
 			}
 	}
 
 	test_reciprocal_Div {
-
-		this.setRandSeed;
 
 		numTests.do {
 			var x1 = 1 + maxIntVal.rand * [-1,1].choose;
@@ -234,17 +306,16 @@ TestRational : UnitTest {
 			this.assertEquals(
 				z1 / z2,
 				(z2 / z1).reciprocal,
-				format( "Div + reciprocal test with % and % passed.", z1, z2));
+				format( "Div + reciprocal test with % and % passed.", z1, z2),
+				isVerbose
+			);
 			}
 	}
 
 	test_Sort_and_Scramble  {
-		var listSize = 1000;
+		var listSize = 100;
 
-		this.setRandSeed;
-
-		//numTests.do {
-		10.do {
+		numTests.do {
 			var ratList;
 			ratList = Array.fill(
 				listSize,
@@ -257,18 +328,16 @@ TestRational : UnitTest {
 			this.assertEquals(
 				ratList.sort,
 				ratList.scramble.sort,
-				format( "Sort and Scramble test passed.")
+				format( "Sort and Scramble test passed."),
+				isVerbose
 			);
 		}
 	}
 
 	test_Sort_and_asFloat  {
-		var listSize = 1000;
+		var listSize = 100;
 
-		this.setRandSeed;
-
-		//numTests.do {
-		10.do {
+		numTests.do {
 			var ratList;
 
 			ratList = Array.fill(
@@ -283,14 +352,13 @@ TestRational : UnitTest {
 			this.assertEquals(
 				ratList.scramble.sort.asFloat,
 				ratList.scramble.asFloat.sort,
-				format( "Sort and asFloat test passed.")
+				format( "Sort and asFloat test passed."),
+				isVerbose
 			);
 		}
 	}
 
 	test_Mul_Inverse_DifferentExponents_NonZeroIntInput {
-
-		this.setRandSeed;
 
 		numTests.do {
 			var maxVal = 100;
@@ -303,7 +371,9 @@ TestRational : UnitTest {
 				this.assertEquals(
 					rat.pow(i * (-1)),
 					rat.pow(i).reciprocal,
-					format( "Multiplicative inverse with different exponents test with exp: % and rat: % passed.", i, rat));
+					format( "Multiplicative inverse with different exponents test with exp: % and rat: % passed.", i, rat),
+					isVerbose
+				);
 
 			})
 
@@ -311,8 +381,6 @@ TestRational : UnitTest {
 	}
 
 	test_Float_Rat_Float {
-
-		this.setRandSeed;
 
 		numTests.do {
 			var maxVal = 1000.01;
@@ -326,14 +394,13 @@ TestRational : UnitTest {
 				b: float.asRational.asFloat,
 				message: format(
 					"Float/Rational conversion with  rat: % and float: % passed.", rat, float),
-				within: 0.000001
+				within: 0.000001,
+				report: isVerbose
 			);
 		}
 	}
 
 	test_Rat_Float_Rat {
-
-		this.setRandSeed;
 
 		numTests.do {
 			var maxVal = 100;
@@ -346,15 +413,14 @@ TestRational : UnitTest {
 				a: rat,
 				b: float.asRational.asFloat.asRational,
 				message: format(
-					"Float/Rational conversion with rat: % and float: % passed.", rat, float)
+					"Float/Rational conversion with rat: % and float: % passed.", rat, float),
+				report: isVerbose
 			);
 		}
 	}
 
 
 	test_Exponentiation {
-
-		this.setRandSeed;
 
 	   numTests.do {
 			var maxVal = 9;
@@ -366,13 +432,15 @@ TestRational : UnitTest {
 				r,
 				r.pow(e).pow(e.reciprocal),
 				format(
-					"Exponentiation rational: % and exponent: % passed.", r, e));
+					"Exponentiation rational: % and exponent: % passed.", r, e),
+				report: isVerbose
+			);
 		}
 	}
 
 	// associative property
 	test_AssociativeAdd {
-		this.setRandSeed;
+
 		numTests.do {
 			var x1 = rrand(minIntVal,maxIntVal);
 			var y1 = 1 + maxIntVal.rand * [-1,1].choose;
@@ -386,13 +454,13 @@ TestRational : UnitTest {
 			this.assertEquals(
 				(z1 + z2) + z3,
 				z1 + (z2 + z3),
-				format( "Associative Sum test with %, % and %passed.", z1, z2, z3))
+				format( "Associative Sum test with %, % and %passed.", z1, z2, z3),
+				report: isVerbose
+			)
 		}
 	}
 
 	test_AssociativeMul {
-
-		this.setRandSeed;
 
 		numTests.do {
 			var x1 = rrand(minIntVal,maxIntVal);
@@ -408,15 +476,16 @@ TestRational : UnitTest {
 			this.assertEquals(
 				(z1 * z2) * z3,
 				z1 * (z2 * z3),
-				format( "Associative Mul test with %, % and %passed.", z1, z2, z3));
+				format( "Associative Mul test with %, % and %passed.", z1, z2, z3),
+				report: isVerbose
+			);
 		}
 	}
 
-	// distributive property
+	//Distributive property of multiplication over itself
 	// (a + b) * c = (a * c) + (b * c)
-	test_Distributive_1_PositiveIntInput {
 
-		this.setRandSeed;
+	test_Distributive_1_PositiveIntInput {
 
 		numTests.do {
 			var minVal = 1;
@@ -434,14 +503,14 @@ TestRational : UnitTest {
 			this.assertEquals(
 				(a + b) * c,
 				(a * c) + (b * c),
-				format( "Associative property 1 test with %, % and % passed.", a, b, c)
+				format( "Associative property 1 test with %, % and % passed.", a, b, c),
+				report: isVerbose
 			);
 		}
 	}
 
-	test_commutativeAdd_Array {
 
-		this.setRandSeed;
+	test_commutativeAdd_Array {
 
 		numTests.do {
 			var n = 20;
@@ -456,13 +525,15 @@ TestRational : UnitTest {
 			this.assertEquals(
 				rats.scramble.sum,
 				rats.scramble.sum,
-				format( "Commutative with Array summation test with %", rats));
+				format( "Commutative with Array summation test with %", rats),
+				report: isVerbose
+			);
 		}
 	}
 }
 
-
 /*
-TestRational.run
 UnitTest.gui
+TestRational.run
+TestRational().numTests_(100).seed_(999.rand).isVerbose_(true).run;
 */


### PR DESCRIPTION
A ℚ class can be very useful to work with metric durations (8th, quarter notes, etc.), tuplets, just intonation intervals, etc. Specially useful for safer arithmetic operations (`+ - * /` etc.), equality, inequality etc.  Otherwise, the chances to get floating-point approximation errors aren't negligible. A language specific to music such as SC should be able to work with this type.

Examples:

```supercollider
a = Rational(3, 2); // a rational number
b = 4%/5; // alternative syntax
c = (3%/(2%/5)); // nested rational numbers
a + b; // -> Rational( 23, 10 )
a - b; // -> Rational( 7, 10 )
a / b; // -> Rational( 15, 8 )
a * b; // -> Rational( 6, 5 )
a.pow(2); -> Rational( 9, 4 )
Rational(3,2).cubed // -> Rational( 27, 8 )
4 + (4%/3)  // -> Rational( 16, 3 )
a.min(b); // -> Rational( 4, 5 )
b.max(2.32); // -> 2.32
// force denominator to be less than 20:
(4342%/3424).simplify(20); // -> Rational( 19, 15 )
```