### PR TITLE
scsynth: /b_read[Channel]: fix failure in sf_open caused by uninitialized memory

### DIFF
--- a/server/scsynth/SC_SequencedCommand.cpp
+++ b/server/scsynth/SC_SequencedCommand.cpp
@@ -631,6 +631,7 @@ bool BufReadCmd::Stage2()
 	return false;
 #else
 	SF_INFO fileinfo;
+	memset(&fileinfo, 0, sizeof(fileinfo));
 
 	SndBuf *buf = World_GetNRTBuf(mWorld, mBufIndex);
 	int framesToEnd = buf->frames - mBufOffset;
@@ -920,6 +921,7 @@ bool BufReadChannelCmd::Stage2()
 	return false;
 #else
 	SF_INFO fileinfo;
+	memset(&fileinfo, 0, sizeof(fileinfo));
 
 	SndBuf *buf = World_GetNRTBuf(mWorld, mBufIndex);
 	int framesToEnd = buf->frames - mBufOffset;


### PR DESCRIPTION
This fixes #2474, an uninitialized memory issue in /b_read and /b_readChannel which was causing nondeterministic failures in Buffer.cueSoundFile. libsndfile's sf_open takes as input a pointer to an SF_INFO struct, to which it writes its soundfile metadata. However, the SF_INFO struct's "format" parameter of the struct must be set to zero, otherwise (as best as I can tell from the sf_open docs) the audio is read in a raw format. Failure to initialize the SF_INFO memory is therefore a bad idea, and zeroing out the memory ensures that the raw format is not accidentally invoked.

Thanks to @Sciss and @bagong for helping to investigate this issue.