### PR TITLE
Patch runtime ScIDE error

### DIFF
--- a/editors/sc-ide/core/sc_server.cpp
+++ b/editors/sc-ide/core/sc_server.cpp
@@ -168,7 +168,7 @@ void ScServer::createActions(Settings::Manager * settings)
     mActions[PauseRecord] = action = new QAction(tr("Pause Recording"), this);
     action->setCheckable(true);
     connect( action, SIGNAL(triggered(bool)), this, SLOT(pauseRecording(bool)) );
-    connect( action, SIGNAL(toggled(bool)), this, SLOT(pauseChanged(bool)) );
+    connect( action, SIGNAL(toggled(bool)), this, SIGNAL(pauseChanged(bool)) );
     settings->addAction( action, "synth-server-pause-recording", synthServerCategory);
 
 


### PR DESCRIPTION
Eliminates the following error message thrown during ScIDE startup:
```
QObject::connect: No such slot ScIDE::ScServer::pauseChanged(bool) in
/Users/brianheim/git/supercollider/editors/sc-ide/core/sc_server.cpp:171
```

pauseChanged is a signal, not slot, of ScServer. (see [corresponding header file](https://github.com/supercollider/supercollider/blob/master/editors/sc-ide/core/sc_server.hpp#L91-L123) and [compare these code blocks](https://github.com/brianlheim/supercollider/blob/06c7eabb4437a375b45c33e9b5c2904f2427686a/editors/sc-ide/core/sc_server.cpp#L162-L172)).