### PR TITLE
sclang: protect keysValuesArrayDo primitive

### DIFF
--- a/lang/LangSource/PyrInterpreter3.cpp
+++ b/lang/LangSource/PyrInterpreter3.cpp
@@ -1756,11 +1756,9 @@ HOT void Interpret(VMGlobals *g)
 				// Dictionary-keysValuesArrayDo
 				case 13 : {
 					PyrSlot * vars = g->frame->vars;
-					int m = slotRawInt(&vars[3]);
-					PyrObject * obj = slotRawObject(&vars[1]);
 					
 					if (IsNil(&vars[1])) {
-						error("primitive failed: keysValuesArrayDo first argument should be an array.\n");
+						error("Dictionary-keysValuesArrayDo: first argument should not be nil.\n");
 						
 						slotCopy(++sp, &g->receiver);
 						numArgsPushed = 1;
@@ -1769,6 +1767,11 @@ HOT void Interpret(VMGlobals *g)
 						
 						goto class_lookup;
 					}
+
+					int m = slotRawInt(&vars[3]);
+					PyrObject * obj = slotRawObject(&vars[1]);
+					
+					
 					
 					if ( m < obj->size ) {
 						slot = obj->slots + m;	// key

--- a/lang/LangSource/PyrInterpreter3.cpp
+++ b/lang/LangSource/PyrInterpreter3.cpp
@@ -1761,7 +1761,7 @@ HOT void Interpret(VMGlobals *g)
 						error("Dictionary-keysValuesArrayDo: first argument should not be nil.\n");
 						
 						slotCopy(++sp, &g->receiver);
-						numArgsPushed = 1;
+						numArgsPushed = 0;
 						selector = gSpecialSelectors[opmPrimitiveFailed];
 						slot = sp;
 						

--- a/lang/LangSource/PyrInterpreter3.cpp
+++ b/lang/LangSource/PyrInterpreter3.cpp
@@ -1758,6 +1758,18 @@ HOT void Interpret(VMGlobals *g)
 					PyrSlot * vars = g->frame->vars;
 					int m = slotRawInt(&vars[3]);
 					PyrObject * obj = slotRawObject(&vars[1]);
+					
+					if (IsNil(&vars[1])) {
+						error("primitive failed: keysValuesArrayDo first argument should be an array.\n");
+						
+						slotCopy(++sp, &g->receiver);
+						numArgsPushed = 1;
+						selector = gSpecialSelectors[opmPrimitiveFailed];
+						slot = sp;
+						
+						goto class_lookup;
+					}
+					
 					if ( m < obj->size ) {
 						slot = obj->slots + m;	// key
 						while (IsNil(slot)) {

--- a/testsuite/classlibrary/TestDictionary.sc
+++ b/testsuite/classlibrary/TestDictionary.sc
@@ -1,0 +1,16 @@
+TestDictionary : UnitTest {
+
+	test_keysValuesArrayDo {
+
+		this.assert(().keysValuesArrayDo([]) == (), "keysValuesArrayDo on an empty dictionary should do nothing");
+
+		this.assert(
+			try { ().keysValuesArrayDo(nil) } { |err|
+				err.isKindOf(PrimitiveFailedError)
+			},
+			"calling keysValuesArrayDo on nil should throw a PrimitiveFailedError"
+		)
+
+	}
+
+}

--- a/testsuite/classlibrary/TestDictionary.sc
+++ b/testsuite/classlibrary/TestDictionary.sc
@@ -2,10 +2,10 @@ TestDictionary : UnitTest {
 
 	test_keysValuesArrayDo {
 
-		this.assert(().keysValuesArrayDo([]) == (), "keysValuesArrayDo on an empty dictionary should do nothing");
+		this.assert(Dictionary[].keysValuesArrayDo([]) == (), "keysValuesArrayDo on an empty dictionary should do nothing");
 
 		this.assert(
-			try { ().keysValuesArrayDo(nil) } { |err|
+			try { Dictionary[].keysValuesArrayDo(nil) } { |err|
 				err.isKindOf(PrimitiveFailedError)
 			},
 			"calling keysValuesArrayDo on nil should throw a PrimitiveFailedError"

--- a/testsuite/classlibrary/TestDictionary.sc
+++ b/testsuite/classlibrary/TestDictionary.sc
@@ -2,7 +2,7 @@ TestDictionary : UnitTest {
 
 	test_keysValuesArrayDo {
 
-		this.assert(Dictionary[].keysValuesArrayDo([]) == (), "keysValuesArrayDo on an empty dictionary should do nothing");
+		this.assert(Dictionary[].keysValuesArrayDo([]) == Dictionary[], "keysValuesArrayDo on an empty dictionary should do nothing");
 
 		this.assert(
 			try { Dictionary[].keysValuesArrayDo(nil) } { |err|


### PR DESCRIPTION
This can happen in corner cases. Fixes #852.