### PR TITLE
Classlib: GUI: View must not throw an error for default drag methods

### DIFF
--- a/SCClassLibrary/Common/GUI/Base/QView.sc
+++ b/SCClassLibrary/Common/GUI/Base/QView.sc
@@ -441,9 +441,9 @@ View : QObject {
 		this.setDragEventsEnabled( true );
 	}
 
-	defaultGetDrag { ^thisMethod.notYetImplemented }
-	defaultCanReceiveDrag { ^thisMethod.notYetImplemented }
-	defaultReceiveDrag { ^thisMethod.notYetImplemented }
+	defaultGetDrag { ^nil }
+	defaultCanReceiveDrag { ^false }
+	defaultReceiveDrag {}
 
 	toFrontAction_ { arg aFunction;
 		toFrontAction = aFunction;


### PR DESCRIPTION
Fixes #2804.

I was trying to back off from dev work, but... it's really really annoying when I drag a view in my standard GUI and the post window barfs up a bunch of errors.