### PR TITLE
Topic/open text file deprecated

### DIFF
--- a/SCClassLibrary/Common/Core/Kernel.sc
+++ b/SCClassLibrary/Common/Core/Kernel.sc
@@ -141,7 +141,7 @@ Class {
 	//traceAnyPathToAllInstancesOf { _TraceAnyPathToAllInstancesOf }
 
 	openCodeFile {
-		this.filenameSymbol.asString.openTextFile(this.charPos, -1);
+		this.filenameSymbol.asString.openDocument(this.charPos, -1);
 	}
 	classVars {
 		var start, end;
@@ -246,14 +246,14 @@ Process {
 			if (class.notNil, {
 				method = class.findMethod(words.at(1).asSymbol);
 				if (method.notNil, {
-					method.filenameSymbol.asString.openTextFile(method.charPos, -1);
+					method.filenameSymbol.asString.openDocument(method.charPos, -1);
 				});
 			});
 		},{
 			class = string.asSymbol.asClass;
 			if (class.notNil, {
 				class = class.classRedirect;
-				class.filenameSymbol.asString.openTextFile(class.charPos, -1);
+				class.filenameSymbol.asString.openDocument(class.charPos, -1);
 			});
 		});
 	}
@@ -474,7 +474,7 @@ Method : FunctionDef {
 	var <filenameSymbol, <charPos;
 
 	openCodeFile {
-		this.filenameSymbol.asString.openTextFile(this.charPos, -1);
+		this.filenameSymbol.asString.openDocument(this.charPos, -1);
 	}
 	hasHelpFile {
 		//should cache this in Library or classvar

--- a/SCClassLibrary/Common/Streams/History.sc
+++ b/SCClassLibrary/Common/Streams/History.sc
@@ -566,6 +566,6 @@ History { 		// adc 2006, Birmingham; rewrite 2007.
 			file2.write("\n\n\n// when: % - who: % \n\n(\n%\n)\n".format(time, tag, code));
 		};
 		file2.close;
-		if (open) { repath.openTextFile };
+		if (open) { repath.openDocument };
 	}
 }

--- a/SCClassLibrary/DefaultLibrary/Main.sc
+++ b/SCClassLibrary/DefaultLibrary/Main.sc
@@ -187,8 +187,8 @@ MethodOverride {
 		var path2 = if(overriddenPath.beginsWith("/Common")) {
 			Platform.classLibraryDir +/+ overriddenPath
 			} { overriddenPath };
-		activePath.openTextFile;
-		path2.openTextFile;
+		activePath.openDocument;
+		path2.openDocument;
 	}
 
 

--- a/SCClassLibrary/deprecated/3.8/deprecated-3.8.sc
+++ b/SCClassLibrary/deprecated/3.8/deprecated-3.8.sc
@@ -32,14 +32,14 @@
 // openTextFile is actually the same as openDocument
 + String {
 	openTextFile { arg selectionStart=0, selectionLength=0;
-		this.deprecated(thisMethod);
+		this.deprecated(thisMethod, String.findMethod(\openDocument));
 		this.openDocument(selectionStart, selectionLength)
 	}
 }
 
 + Symbol {
 	openTextFile { arg selectionStart=0, selectionLength=0;
-		this.deprecated(thisMethod);
+		this.deprecated(thisMethod, Symbol.findMethod(\openDocument));
 		^this.openDocument(selectionStart, selectionLength)
 	}
 }


### PR DESCRIPTION
Not quite sure how this happened, but somebody at some point deprecated `openTextFile` in favor of `openDocument`, which is reasonable enough in itself except:

- The warning to the user states only that the method is deprecated, but doesn't tell the user what to use instead.

- Fully 7 invocations, in six different methods, in the core class library still use `openTextFile`. It doesn't present a good impression to end-users when the main class library is not internally consistent about deprecation.

Sure, working quickly, I understand... but as a rule, if we're going to deprecate something, the job isn't finished until uses of the deprecated method have been replaced.