### PR TITLE
Fix broken TGrains `amp` handling

### DIFF
--- a/server/plugins/DelayUGens.cpp
+++ b/server/plugins/DelayUGens.cpp
@@ -6216,8 +6216,8 @@ void TGrains_next(TGrains *unit, int inNumSamples)
 					pan = sc_clip(pan * 0.5f + 0.5f, 0.f, 1.f);
 					panangle = pan * pi2_f;
 				}
-				pan1 = grain->pan1 = cos(panangle);
-				pan2 = grain->pan2 = sin(panangle);
+				pan1 = grain->pan1 = amp * cos(panangle);
+				pan2 = grain->pan2 = amp * sin(panangle);
 			} else {
 				grain->chan = 0;
 				pan1 = grain->pan1 = 1.;

--- a/server/plugins/DelayUGens.cpp
+++ b/server/plugins/DelayUGens.cpp
@@ -6220,7 +6220,7 @@ void TGrains_next(TGrains *unit, int inNumSamples)
 				pan2 = grain->pan2 = amp * sin(panangle);
 			} else {
 				grain->chan = 0;
-				pan1 = grain->pan1 = 1.;
+				pan1 = grain->pan1 = amp;
 				pan2 = grain->pan2 = 0.;
 			}
 			double w = pi / counter;


### PR DESCRIPTION
Fixes #2807, a regression caused by #2136 (https://github.com/supercollider/supercollider/pull/2136/commits/f35a3f7f1552266fda04e326474dd678177b2ba5).

This should work correctly now:
```supercollider
b = Buffer.read(s, Platform.resourceDir +/+ "sounds/a11wlk01.wav");
{ // This should fade in... but starts at full volume
	TGrains.ar(2, Impulse.ar(15), b, centerPos: Line.ar(0, 5, 10, doneAction: 2), amp: Line.ar(0, 1, 10));
}.play;
```