### PR TITLE
Add input validation to putPascalString

### DIFF
--- a/HelpSource/Classes/UnixFILE.schelp
+++ b/HelpSource/Classes/UnixFILE.schelp
@@ -59,6 +59,9 @@ read four bytes and return as a link::Classes/Float::.
 method::getDouble
 read eight bytes and return as a link::Classes/Float::.
 
+method::getPascalString
+Reads the next byte as an unsigned integer N, then reads the following N bytes and returns them as a link::Classes/String:.
+
 method::putChar
 write a link::Classes/Char:: as one byte.
 
@@ -79,3 +82,10 @@ write a link::Classes/Float:: as eight bytes.
 
 method::putString
 write a null terminated link::Classes/String::.
+
+method::putPascalString
+Writes code::aString:: preceded by its length represented as a single byte.
+Throws an error if code::aString:: is longer than 255 characters.
+
+method::putString0
+Writes code::aString:: followed by a zero byte, like a null-terminated C string.

--- a/HelpSource/Classes/UnixFILE.schelp
+++ b/HelpSource/Classes/UnixFILE.schelp
@@ -60,7 +60,7 @@ method::getDouble
 read eight bytes and return as a link::Classes/Float::.
 
 method::getPascalString
-Reads the next byte as an unsigned integer N, then reads the following N bytes and returns them as a link::Classes/String:.
+Reads the next byte as an unsigned integer N, then reads the following N bytes and returns them as a link::Classes/String::.
 
 method::putChar
 write a link::Classes/Char:: as one byte.

--- a/SCClassLibrary/Common/Audio/SynthDef.sc
+++ b/SCClassLibrary/Common/Audio/SynthDef.sc
@@ -390,9 +390,6 @@ SynthDef {
 			};
 		} { // catch
 			arg e;
-			if (file.respondsTo(\close)) {
-				file.close;
-			};
 			Error("SynthDef: could not write def: %".format(e.what())).throw;
 		}
 	}

--- a/SCClassLibrary/Common/Audio/SynthDef.sc
+++ b/SCClassLibrary/Common/Audio/SynthDef.sc
@@ -321,72 +321,78 @@ SynthDef {
 		// This describes the file format for the synthdef files.
 		var allControlNamesTemp, allControlNamesMap;
 
-		file.putPascalString(name.asString);
+		try {
+			file.putPascalString(name.asString);
 
-		this.writeConstants(file);
+			this.writeConstants(file);
 
-		//controls have been added by the Control UGens
-		file.putInt32(controls.size);
-		controls.do { | item |
-			file.putFloat(item);
-		};
-
-		allControlNamesTemp = allControlNames.reject { |cn| cn.rate == \noncontrol };
-		file.putInt32(allControlNamesTemp.size);
-		allControlNamesTemp.do { | item |
-			if (item.name.notNil) {
-				file.putPascalString(item.name.asString);
-				file.putInt32(item.index);
+			//controls have been added by the Control UGens
+			file.putInt32(controls.size);
+			controls.do { | item |
+				file.putFloat(item);
 			};
-		};
 
-		file.putInt32(children.size);
-		children.do { | item |
-			item.writeDef(file);
-		};
-
-		file.putInt16(variants.size);
-		if (variants.size > 0) {
-			allControlNamesMap = ();
-			allControlNamesTemp.do { |cn|
-				allControlNamesMap[cn.name] = cn;
-			};
-			variants.keysValuesDo {|varname, pairs|
-				var varcontrols;
-
-				varname = name ++ "." ++ varname;
-				if (varname.size > 32) {
-					Post << "variant '" << varname << "' name too long.\n";
-					^nil
+			allControlNamesTemp = allControlNames.reject { |cn| cn.rate == \noncontrol };
+			file.putInt32(allControlNamesTemp.size);
+			allControlNamesTemp.do { | item |
+				if (item.name.notNil) {
+					file.putPascalString(item.name.asString);
+					file.putInt32(item.index);
 				};
-				varcontrols = controls.copy;
-				pairs.pairsDo { |cname, values|
-					var cn, index;
-					cn = allControlNamesMap[cname];
-					if (cn.notNil) {
-						values = values.asArray;
-						if (values.size > cn.defaultValue.asArray.size) {
-							postf("variant: '%' control: '%' size mismatch.\n",
+			};
+
+			file.putInt32(children.size);
+			children.do { | item |
+				item.writeDef(file);
+			};
+
+			file.putInt16(variants.size);
+			if (variants.size > 0) {
+				allControlNamesMap = ();
+				allControlNamesTemp.do { |cn|
+					allControlNamesMap[cn.name] = cn;
+				};
+				variants.keysValuesDo {|varname, pairs|
+					var varcontrols;
+
+					varname = name ++ "." ++ varname;
+					if (varname.size > 32) {
+						Post << "variant '" << varname << "' name too long.\n";
+						^nil
+					};
+					varcontrols = controls.copy;
+					pairs.pairsDo { |cname, values|
+						var cn, index;
+						cn = allControlNamesMap[cname];
+						if (cn.notNil) {
+							values = values.asArray;
+							if (values.size > cn.defaultValue.asArray.size) {
+								postf("variant: '%' control: '%' size mismatch.\n",
+									varname, cname);
+								^nil
+							}{
+								index = cn.index;
+								values.do {|val, i|
+									varcontrols[index + i] = val;
+								}
+							}
+						}{
+							postf("variant: '%' control: '%' not found.\n",
 								varname, cname);
 							^nil
-						}{
-							index = cn.index;
-							values.do {|val, i|
-								varcontrols[index + i] = val;
-							}
 						}
-					}{
-						postf("variant: '%' control: '%' not found.\n",
-								varname, cname);
-						^nil
-					}
-				};
-				file.putPascalString(varname);
-				varcontrols.do { | item |
-					file.putFloat(item);
+					};
+					file.putPascalString(varname);
+					varcontrols.do { | item |
+						file.putFloat(item);
+					};
 				};
 			};
-		};
+		} { // catch
+			arg e;
+			file.close;
+			Error("SynthDef: could not write def: %".format(e.what())).throw;
+		}
 	}
 
 	writeConstants { arg file;

--- a/SCClassLibrary/Common/Audio/SynthDef.sc
+++ b/SCClassLibrary/Common/Audio/SynthDef.sc
@@ -390,7 +390,9 @@ SynthDef {
 			};
 		} { // catch
 			arg e;
-			file.close;
+			if (file.respondsTo(\close)) {
+				file.close;
+			};
 			Error("SynthDef: could not write def: %".format(e.what())).throw;
 		}
 	}

--- a/SCClassLibrary/Common/Audio/SynthDefOld.sc
+++ b/SCClassLibrary/Common/Audio/SynthDefOld.sc
@@ -150,9 +150,6 @@ SynthDefOld : SynthDef {
 			//[this.class.name, file.length].postln;
 		} { // catch
 			arg e;
-			if (file.respondsTo(\close)) {
-				file.close;
-			};
 			Error("UGen: could not write def: %".format(e.what())).throw;
 		}
 	}

--- a/SCClassLibrary/Common/Audio/SynthDefOld.sc
+++ b/SCClassLibrary/Common/Audio/SynthDefOld.sc
@@ -90,7 +90,9 @@ SynthDefOld : SynthDef {
 			}
 		} { // catch
 			arg e;
-			file.close;
+			if (file.respondsTo(\close)) {
+				file.close;
+			};
 			Error("SynthDefOld: could not write def: %".format(e.what())).throw;
 		}
 	}
@@ -148,7 +150,9 @@ SynthDefOld : SynthDef {
 			//[this.class.name, file.length].postln;
 		} { // catch
 			arg e;
-			file.close;
+			if (file.respondsTo(\close)) {
+				file.close;
+			};
 			Error("UGen: could not write def: %".format(e.what())).throw;
 		}
 	}

--- a/SCClassLibrary/Common/Audio/SynthDefOld.sc
+++ b/SCClassLibrary/Common/Audio/SynthDefOld.sc
@@ -21,71 +21,77 @@ SynthDefOld : SynthDef {
 		// This describes the file format for the synthdef files.
 		var allControlNamesTemp, allControlNamesMap;
 
-		file.putPascalString(name.asString);
+		try {
+			file.putPascalString(name.asString);
 
-		this.writeConstants(file);
+			this.writeConstants(file);
 
-		//controls have been added by the Control UGens
-		file.putInt16(controls.size);
-		controls.do { | item |
-			file.putFloat(item);
-		};
-
-		allControlNamesTemp = allControlNames.reject { |cn| cn.rate == \noncontrol };
-		file.putInt16(allControlNamesTemp.size);
-		allControlNamesTemp.do { | item |
-			if (item.name.notNil) {
-				file.putPascalString(item.name.asString);
-				file.putInt16(item.index);
+			//controls have been added by the Control UGens
+			file.putInt16(controls.size);
+			controls.do { | item |
+				file.putFloat(item);
 			};
-		};
 
-		file.putInt16(children.size);
-		children.do { | item |
-			item.writeDefOld(file);
-		};
-
-		file.putInt16(variants.size);
-		if (variants.size > 0) {
-			allControlNamesMap = ();
-			allControlNamesTemp.do { |cn|
-				allControlNamesMap[cn.name] = cn;
-			};
-			variants.keysValuesDo {|varname, pairs|
-				var varcontrols;
-
-				varname = name ++ "." ++ varname;
-				if (varname.size > 32) {
-					Post << "variant '" << varname << "' name too long.\n";
-					^nil
+			allControlNamesTemp = allControlNames.reject { |cn| cn.rate == \noncontrol };
+			file.putInt16(allControlNamesTemp.size);
+			allControlNamesTemp.do { | item |
+				if (item.name.notNil) {
+					file.putPascalString(item.name.asString);
+					file.putInt16(item.index);
 				};
-				varcontrols = controls.copy;
-				pairs.pairsDo { |cname, values|
-					var cn, index;
-					cn = allControlNamesMap[cname];
-					if (cn.notNil) {
-						values = values.asArray;
-						if (values.size > cn.defaultValue.asArray.size) {
-							postf("variant: '%' control: '%' size mismatch.\n",
+			};
+
+			file.putInt16(children.size);
+			children.do { | item |
+				item.writeDefOld(file);
+			};
+
+			file.putInt16(variants.size);
+			if (variants.size > 0) {
+				allControlNamesMap = ();
+				allControlNamesTemp.do { |cn|
+					allControlNamesMap[cn.name] = cn;
+				};
+				variants.keysValuesDo {|varname, pairs|
+					var varcontrols;
+
+					varname = name ++ "." ++ varname;
+					if (varname.size > 32) {
+						Post << "variant '" << varname << "' name too long.\n";
+						^nil
+					};
+					varcontrols = controls.copy;
+					pairs.pairsDo { |cname, values|
+						var cn, index;
+						cn = allControlNamesMap[cname];
+						if (cn.notNil) {
+							values = values.asArray;
+							if (values.size > cn.defaultValue.asArray.size) {
+								postf("variant: '%' control: '%' size mismatch.\n",
+									varname, cname);
+								^nil
+							}{
+								index = cn.index;
+								values.do {|val, i|
+									varcontrols[index + i] = val;
+								}
+							}
+						}{
+							postf("variant: '%' control: '%' not found.\n",
 								varname, cname);
 							^nil
-						}{
-							index = cn.index;
-							values.do {|val, i|
-								varcontrols[index + i] = val;
-							}
 						}
-					}{
-						postf("variant: '%' control: '%' not found.\n",
-								varname, cname);
-						^nil
-					}
+					};
+					file.putPascalString(varname);
+					varcontrols.do { | item |
+						file.putFloat(item);
+					};
 				};
-				file.putPascalString(varname);
-				varcontrols.do { | item |
-					file.putFloat(item);
-				};
-			};
+			}
+		} { // catch
+			arg e;
+			file.close;
+			Error("SynthDefOld: could not write def: %".format(e.what())).throw;
 		}
 	}
 
@@ -128,17 +134,23 @@ SynthDefOld : SynthDef {
 
 	writeDefOld { arg file;
 		//[\WR, this.class.name, rate, this.numInputs, this.numOutputs].postln;
-		file.putPascalString(this.name);
-		file.putInt8(this.rateNumber);
-		file.putInt16(this.numInputs);
-		file.putInt16(this.numOutputs);
-		file.putInt16(this.specialIndex);
-		// write wire spec indices.
-		inputs.do({ arg input;
-			input.writeInputSpecOld(file, synthDef);
-		});
-		this.writeOutputSpecs(file);
-		//[this.class.name, file.length].postln;
+		try {
+			file.putPascalString(this.name);
+			file.putInt8(this.rateNumber);
+			file.putInt16(this.numInputs);
+			file.putInt16(this.numOutputs);
+			file.putInt16(this.specialIndex);
+			// write wire spec indices.
+			inputs.do({ arg input;
+				input.writeInputSpecOld(file, synthDef);
+			});
+			this.writeOutputSpecs(file);
+			//[this.class.name, file.length].postln;
+		} { // catch
+			arg e;
+			file.close;
+			Error("UGen: could not write def: %".format(e.what())).throw;
+		}
 	}
 
 	writeInputSpecOld { arg file, synthDef;

--- a/SCClassLibrary/Common/Audio/UGen.sc
+++ b/SCClassLibrary/Common/Audio/UGen.sc
@@ -450,16 +450,22 @@ UGen : AbstractFunction {
 		^this.class.name.asString;
 	}
 	writeDef { arg file;
-		file.putPascalString(this.name);
-		file.putInt8(this.rateNumber);
-		file.putInt32(this.numInputs);
-		file.putInt32(this.numOutputs);
-		file.putInt16(this.specialIndex);
-		// write wire spec indices.
-		inputs.do({ arg input;
-			input.writeInputSpec(file, synthDef);
-		});
-		this.writeOutputSpecs(file);
+		try {
+			file.putPascalString(this.name);
+			file.putInt8(this.rateNumber);
+			file.putInt32(this.numInputs);
+			file.putInt32(this.numOutputs);
+			file.putInt16(this.specialIndex);
+			// write wire spec indices.
+			inputs.do({ arg input;
+				input.writeInputSpec(file, synthDef);
+			});
+			this.writeOutputSpecs(file);
+		} {
+			arg e;
+			file.close();
+			Error("UGen: could not write def: %".format(e.what())).throw;
+		}
 	}
 
 	initTopoSort {

--- a/SCClassLibrary/Common/Audio/UGen.sc
+++ b/SCClassLibrary/Common/Audio/UGen.sc
@@ -463,7 +463,9 @@ UGen : AbstractFunction {
 			this.writeOutputSpecs(file);
 		} {
 			arg e;
-			file.close();
+			if (file.respondsTo(\close)) {
+				file.close;
+			};
 			Error("UGen: could not write def: %".format(e.what())).throw;
 		}
 	}

--- a/SCClassLibrary/Common/Audio/UGen.sc
+++ b/SCClassLibrary/Common/Audio/UGen.sc
@@ -463,9 +463,6 @@ UGen : AbstractFunction {
 			this.writeOutputSpecs(file);
 		} {
 			arg e;
-			if (file.respondsTo(\close)) {
-				file.close;
-			};
 			Error("UGen: could not write def: %".format(e.what())).throw;
 		}
 	}

--- a/SCClassLibrary/Common/Streams/IOStream.sc
+++ b/SCClassLibrary/Common/Streams/IOStream.sc
@@ -170,7 +170,11 @@ CollStream : IOStream {
 	putString { arg aString;
 		aString.do({ arg char; this.putChar(char); });
 	}
+
 	putPascalString { arg aString;
+		if(aString.size >= 256) {
+			Error("putPascalString: input string must be shorter than 256 chars.").throw;
+		};
 		this.putInt8(aString.size);
 		this.putString(aString);
 	}

--- a/SCClassLibrary/Common/Streams/IOStream.sc
+++ b/SCClassLibrary/Common/Streams/IOStream.sc
@@ -173,7 +173,7 @@ CollStream : IOStream {
 
 	putPascalString { arg aString;
 		if(aString.size >= 256) {
-			Error("putPascalString: input string must be shorter than 256 chars.").throw;
+			Error("putPascalString: input string must be shorter than 256 chars: \"%\"".format(aString)).throw;
 		};
 		this.putInt8(aString.size);
 		this.putString(aString);

--- a/SCClassLibrary/Common/Unix/UnixFILE.sc
+++ b/SCClassLibrary/Common/Unix/UnixFILE.sc
@@ -121,10 +121,15 @@ UnixFILE : IOStream {
 		this.putString(aString);
 		this.putInt8(0);
 	}
+
 	putPascalString { arg aString;
+		if(aString.size >= 256) {
+			Error("putPascalString: input string must be shorter than 256 chars.").throw;
+		};
 		this.putInt8(aString.size);
 		this.putString(aString);
 	}
+
 	getPascalString {
 		var size, string;
 		size = this.getInt8;
@@ -132,6 +137,7 @@ UnixFILE : IOStream {
 		this.read(string);
 		^string
 	}
+
 	// PRIVATE
 	addOpenFile {
 		openFiles = openFiles.add(this);

--- a/SCClassLibrary/Common/Unix/UnixFILE.sc
+++ b/SCClassLibrary/Common/Unix/UnixFILE.sc
@@ -124,7 +124,7 @@ UnixFILE : IOStream {
 
 	putPascalString { arg aString;
 		if(aString.size >= 256) {
-			Error("putPascalString: input string must be shorter than 256 chars.").throw;
+			Error("putPascalString: input string must be shorter than 256 chars: \"%\"".format(aString)).throw;
 		};
 		this.putInt8(aString.size);
 		this.putString(aString);


### PR DESCRIPTION
Fix for #2803.

## Issue

```supercollider
SynthDef(($a!256).join, {}).add; // causes a crash
```

This was because `putPascalString` wasn't properly checking that it could properly represent its argument before printing: if a string with `size >= 256` was passed in, it would silently write `size % 256` followed by the string.

## Proposed solution

This PR adds a validation check in `putPascalString` (in both UNIXFile and CollStream) that throws an error when its input string has `str.size >= 256`. It also wraps calls to this method in the standard class lib with a try-catch. I thought this would be the best approach because it allows us to print a more relevant error message.

Originally I decided to protect the error by closing the passed-in file in the catch block, but on second thought I nixed it since the method isn't responsible for opening the file in the first place (it's also protected in most calls like Object:-writeDefFile).

## Results

Trying the code above now produces:

```
ERROR: SynthDef: could not write def: putPascalString: input string must be shorter than 256 chars.
CALL STACK:
	Exception:reportError   0x116724628
		arg this = <instance of Error>
	Nil:handleError   0x116724d48
		arg this = nil
		arg error = <instance of Error>
	Thread:handleError   0x1166da488
		arg this = <instance of Thread>
		arg error = <instance of Error>
	Object:throw   0x1166d24f8
		arg this = <instance of Error>
	SynthDef:writeDef   0x118fc6e48
		arg this = <instance of SynthDef>
		arg file = <instance of CollStream>
		var allControlNamesTemp = nil
		var allControlNamesMap = nil
	ArrayedCollection:do   0x1166dd818
		arg this = [*1]
		arg function = <instance of Function>
		var i = 0
	Collection:writeDef   0x1166d3fa8
		arg this = [*1]
		arg file = <instance of CollStream>
	SynthDef:asBytes   0x118e3e5b8
		arg this = <instance of SynthDef>
		var stream = <instance of CollStream>
	SynthDef:asSynthDesc   0x118fc71d8
		arg this = <instance of SynthDef>
		arg libname = 'global'
		arg keepDef = true
		var lib = nil
		var stream = nil
	SynthDef:add   0x118fc7438
		arg this = <instance of SynthDef>
		arg libname = nil
		arg completionMsg = nil
		arg keepDef = true
		var servers = nil
		var desc = nil
	Interpreter:interpretPrintCmdLine   0x118fc9318
		arg this = <instance of Interpreter>
		var res = nil
		var func = <instance of Function>
		var code = "SynthDef(($a!256).join, {})...."
		var doc = nil
		var ideClass = <instance of Meta_ScIDE>
	Process:interpretPrintCmdLine   0x118e3f638
		arg this = <instance of Main>
^^ The preceding error dump is for ERROR: SynthDef: could not write def: putPascalString: input string must be shorter than 256 chars.
```