### PR TITLE
A simple fix for quantize

### DIFF
--- a/SCClassLibrary/Common/Math/SimpleNumber.sc
+++ b/SCClassLibrary/Common/Math/SimpleNumber.sc
@@ -153,7 +153,7 @@ SimpleNumber : Number {
 	quantize { arg quantum = 1.0, tolerance = 0.05, strength = 1.0;
 		var round = round(this, quantum);
 		var diff = round - this;
-		if (abs(diff) < tolerance) {
+		if (abs(diff) > tolerance) {
 			^this + (strength * diff)
 		}{
 			^this


### PR DESCRIPTION
Currently quantize only quantizes when the difference between the quantum and the value is _smaller_ than the tolerance.
Current Code:

```
quantize { arg quantum = 1.0, tolerance = 0.05, strength = 1.0;
		var round = round(this, quantum);
		var diff = round - this;
		if (abs(diff) < tolerance) {
			^this + (strength * diff)
		}{
			^this
		}
	}

```
Changing the comparison to be ` if (abs(diff) > tolerance)` should fix this.