### PR TITLE
QSlider: fix orientation on bounds change

### DIFF
--- a/HelpSource/Classes/Slider.schelp
+++ b/HelpSource/Classes/Slider.schelp
@@ -57,7 +57,7 @@ METHOD:: orientation
 	The orientation of the Slider - the direction in which the handle moves. The default value depends on the size of the view when created.
 
 	argument::
-		One of the two Symbols: \horizontal or \vertical.
+		One of the following Symbols: \horizontal (also \h) or \vertical (also \v).
 
 METHOD:: thumbSize
 	The size of the handle - its width or height, depending on link::#-orientation::.

--- a/SCClassLibrary/Common/GUI/Base/QSlider.sc
+++ b/SCClassLibrary/Common/GUI/Base/QSlider.sc
@@ -8,6 +8,11 @@ Slider : QAbstractStepValue {
 		^super.new( parent, bounds ).initSlider( bounds );
 	}
 
+	bounds_ { arg bounds;
+		this.initSlider( bounds );
+		^super.bounds_( bounds );
+	}
+
 	value {
 		^this.getProperty( \value );
 	}

--- a/SCClassLibrary/Common/GUI/Base/QSlider.sc
+++ b/SCClassLibrary/Common/GUI/Base/QSlider.sc
@@ -53,7 +53,11 @@ Slider : QAbstractStepValue {
 
 	orientation_ { arg aSymbol;
 		orientation = aSymbol;
-		this.setProperty( \orientation, QOrientation(aSymbol) );
+		switch( orientation,
+			\h, { orientation = \horizontal },
+			\v, { orientation = \vertical },
+		);
+		this.setProperty( \orientation, QOrientation(orientation) );
 	}
 
 	defaultKeyDownAction {  arg char, modifiers, unicode, keycode, key;


### PR DESCRIPTION
Fix #2824 

ps: just added `\h` and `\v`¸ shortcuts for `orientation_()` as a bonus as something was wrong in that method anyway :) cc @jamshark70  