### PR TITLE
class library: NodeProxy - tolerant handling of nested output

### DIFF
--- a/SCClassLibrary/JITLib/ProxySpace/ProxySynthDef.sc
+++ b/SCClassLibrary/JITLib/ProxySpace/ProxySynthDef.sc
@@ -21,10 +21,17 @@ ProxySynthDef : SynthDef {
 			if(output.isKindOf(UGen) and: { output.synthDef != UGen.buildSynthDef }) {
 				Error("Cannot share UGens between NodeProxies:" + output).throw
 			};
-			// protect from accidentally wrong array shapes
+
+			// protect from accidentally returning wrong array shapes
 			if(output.containsSeqColl) {
-				"Synth output should be a flat array.\n%\nFlattened to: %\nSee NodeProxy helpfile:routing\n\n".format(output, output.flat).warn;
-				output = output.flat;
+				// try first unbubble singletons, these are ok
+				output = output.collect { |each| each.unbubble };
+				// otherwise flatten, but warn
+				if(output.containsSeqColl) {
+					"Synth output should be a flat array.\n%\nFlattened to: %\n"
+					"See NodeProxy helpfile:routing\n\n".format(output, output.flat).warn;
+					output = output.flat;
+				};
 			};
 
 			output = output ? 0.0;


### PR DESCRIPTION
In many situations, one would expect `proxy.ar` to return a single
channel, but it returns an array (there are good reasons for this,
discussed in NodeProxy help under routing).

But in order to avoid being overly strict, we treat a singleton channel
as a channel for a proxy _input_ (that is the result of the UGen
function).

It will still warn if there are more UGens in the nested arrays.