### PR TITLE
Classlib: Patterns: Pn should set flag at onset

### DIFF
--- a/SCClassLibrary/Common/Streams/FilterPatterns.sc
+++ b/SCClassLibrary/Common/Streams/FilterPatterns.sc
@@ -18,8 +18,8 @@ Pn : FilterPattern {
 			repeats.value(event).do { event = pattern.embedInStream(event) };
 		} {
 			repeats.value(event).do {
-				event = pattern.embedInStream(event);
 				event[key] = true;
+				event = pattern.embedInStream(event);
 			};
 			event[key] = false;
 		};
@@ -36,9 +36,9 @@ Pgate  : Pn {
 		var stream, output;
 		repeats.do {
 			stream = pattern.asStream;
-			output = stream.next(event);
+			output = nil;  // force new value for every repeat
 			while {
-				if (event[key] == true) { output = stream.next(event) };
+				if (event[key] == true or: { output.isNil }) { output = stream.next(event) };
 				output.notNil;
 			} {
 				event = output.copy.embedInStream(event)


### PR DESCRIPTION
From the discussion of Pn/Pgate on sc-users, I found a little bug.

Pn's help implies that it sets the flag every time the subpattern starts. But it doesn't do this for the first repeat. Pn's logic "cheats" and sets *after* the pattern, not at the beginning. This has an unintended consequence: an immediately following Pn does *not* trigger a new value in Pgate.

```
(
p = Pbind(
	\degree, Pseq([
		Pn(Pseries(0, 1, { rrand(2, 5) }), 3, \nextDur),
		Pn(Pseries(0, 1, 10), 1, \nextDur)
	], 1),
	\dur, Pgate(Pexprand(0.1, 0.25, inf), inf, \nextDur)
).trace.play;
)

( 'degree': 0, 'dur': 0.10465929123453 )
( 'degree': 1, 'dur': 0.10465929123453 )
( 'degree': 2, 'dur': 0.10465929123453 )
( 'degree': 3, 'dur': 0.10465929123453 )
( 'nextDur': true, 'degree': 0, 'dur': 0.14876536558564 )
( 'degree': 1, 'dur': 0.14876536558564 )
( 'degree': 2, 'dur': 0.14876536558564 )
( 'degree': 3, 'dur': 0.14876536558564 )
( 'degree': 4, 'dur': 0.14876536558564 )
( 'nextDur': true, 'degree': 0, 'dur': 0.14595617545395 )
( 'degree': 1, 'dur': 0.14595617545395 )
( 'degree': 2, 'dur': 0.14595617545395 )
( 'degree': 3, 'dur': 0.14595617545395 )
( 'degree': 4, 'dur': 0.14595617545395 )
( 'nextDur': false, 'degree': 0, 'dur': 0.14595617545395 )  <-- 'nextDur': false ???????
( 'degree': 1, 'dur': 0.14595617545395 )
( 'degree': 2, 'dur': 0.14595617545395 )
( 'degree': 3, 'dur': 0.14595617545395 )
( 'degree': 4, 'dur': 0.14595617545395 )
( 'degree': 5, 'dur': 0.14595617545395 )
( 'degree': 6, 'dur': 0.14595617545395 )
( 'degree': 7, 'dur': 0.14595617545395 )
( 'degree': 8, 'dur': 0.14595617545395 )
( 'degree': 9, 'dur': 0.14595617545395 )
```

After this change, the second Pn *does* trigger a new duration value.

```
( 'nextDur': true, 'degree': 0, 'dur': 0.1291245383907 )
( 'degree': 1, 'dur': 0.1291245383907 )
( 'nextDur': true, 'degree': 0, 'dur': 0.18075621535085 )
( 'degree': 1, 'dur': 0.18075621535085 )
( 'degree': 2, 'dur': 0.18075621535085 )
( 'degree': 3, 'dur': 0.18075621535085 )
( 'nextDur': true, 'degree': 0, 'dur': 0.11987889871256 )
( 'degree': 1, 'dur': 0.11987889871256 )
( 'nextDur': true, 'degree': 0, 'dur': 0.13784356186022 )  <-- here, yes!
( 'degree': 1, 'dur': 0.13784356186022 )
( 'degree': 2, 'dur': 0.13784356186022 )
( 'degree': 3, 'dur': 0.13784356186022 )
( 'degree': 4, 'dur': 0.13784356186022 )
( 'degree': 5, 'dur': 0.13784356186022 )
( 'degree': 6, 'dur': 0.13784356186022 )
( 'degree': 7, 'dur': 0.13784356186022 )
( 'degree': 8, 'dur': 0.13784356186022 )
( 'degree': 9, 'dur': 0.13784356186022 )
```