### PR TITLE
class library: fix possible sync problem in NodeProxy clear

### DIFF
--- a/SCClassLibrary/JITLib/ProxySpace/NodeProxy.sc
+++ b/SCClassLibrary/JITLib/ProxySpace/NodeProxy.sc
@@ -51,7 +51,7 @@ NodeProxy : BusPlug {
 		var oldGroup = group;
 		if(this.isPlaying) {
 			bundle = MixedBundle.new;
-			if(fadeTime.notNil) { 
+			if(fadeTime.notNil) {
 				bundle.add([15, group.nodeID, "fadeTime", fadeTime]) // n_set
 			};
 			this.stopAllToBundle(bundle, fadeTime);

--- a/SCClassLibrary/JITLib/ProxySpace/NodeProxy.sc
+++ b/SCClassLibrary/JITLib/ProxySpace/NodeProxy.sc
@@ -47,16 +47,19 @@ NodeProxy : BusPlug {
 	isPlaying { ^group.isPlaying }
 
 	free { | fadeTime, freeGroup = true |
-		var bundle;
+		var bundle, freetime;
 		var oldGroup = group;
 		if(this.isPlaying) {
 			bundle = MixedBundle.new;
-			if(fadeTime.notNil) { bundle.add([15, group.nodeID, "fadeTime", fadeTime]) };
+			if(fadeTime.notNil) { 
+				bundle.add([15, group.nodeID, "fadeTime", fadeTime]) // n_set
+			};
 			this.stopAllToBundle(bundle, fadeTime);
 			if(freeGroup) {
 				oldGroup = group;
 				group = nil;
-				bundle.sched((fadeTime ? this.fadeTime) + (server.latency ? 0), { oldGroup.free });
+				freetime = (fadeTime ? this.fadeTime) + (server.latency ? 0) + 1e-9; // delay a tiny little
+				server.sendBundle(freetime, [11, oldGroup.nodeID]); // n_free
 			};
 			bundle.send(server);
 			this.changed(\free, [fadeTime, freeGroup]);


### PR DESCRIPTION
`MixedBundle` allows to schedule a function when sending happens. This
is what was used to schedule into the future the clearing of the old
group. It is much better to just delegate this to the server. Because
group  objects are registered by NodeProxy with the NodeWatcher, it is
also released correctly. ( `NodeWatcher.newFrom(s).nodes`).

We need to add a very small offset between the bundle timestamps, so their order is guaranteed on the server.