### PR TITLE
Classlib: Don't try to free a buffer after it was already freed

### DIFF
--- a/SCClassLibrary/Common/Control/Buffer.sc
+++ b/SCClassLibrary/Common/Control/Buffer.sc
@@ -346,16 +346,22 @@ Buffer {
 	}
 
 	free { arg completionMessage;
-		server.listSendMsg( this.freeMsg(completionMessage) )
+		if(bufnum.notNil) {
+			server.listSendMsg( this.freeMsg(completionMessage) )
+		};
 	}
 
 	freeMsg { arg completionMessage;
 		var msg;
-		this.uncache;
-		server.bufferAllocator.free(bufnum);
-		msg = ["/b_free", bufnum, completionMessage.value(this)];
-		bufnum = numFrames = numChannels = sampleRate = path = startFrame = nil;
-		^msg
+		if(bufnum.notNil) {
+			this.uncache;
+			server.bufferAllocator.free(bufnum);
+			msg = ["/b_free", bufnum, completionMessage.value(this)];
+			bufnum = numFrames = numChannels = sampleRate = path = startFrame = nil;
+			^msg
+		} {
+			^nil
+		}
 	}
 
 	*freeAll { arg server;


### PR DESCRIPTION
Neither `Buffer:free` nor `Buffer:freeMsg` check to see if `bufnum` is valid before issuing `/b_free` to the server. This interacts badly with a "feature" of the server where a nil parameter is interpreted as 0.

```
s.boot;

b = Buffer.read(s, Platform.resourceDir +/+ "sounds/a11wlk01.wav");

a = { PlayBuf.ar(1, b, loop: 1).dup }.play;

c = Buffer.alloc(s, 4096, 1);

// c has a bufnum, so the command is ["/b_free", 1], no problem
c.free;

// c's bufnum has been cleared -- 'free' should logically be a no-op now
// Instead, the command is ["/b_free", nil]
// The server evaluates it as ["/b_free", 0]
c.free;

-> Buffer UGen: no buffer data
```

... with the result that the second `c.free` ends up releasing **b**'s data from the server!

It's a small bug fix, but I would consider this important for 3.9. It's unacceptable for an operation on one Buffer object to destroy a totally different one.