### PR TITLE
IDE: Fix YAML parsing issue affecting Document.selectedString_

### DIFF
--- a/editors/sc-ide/core/doc_manager.cpp
+++ b/editors/sc-ide/core/doc_manager.cpp
@@ -36,6 +36,12 @@
 
 #include <yaml-cpp/yaml.h>
 
+#ifdef SC_DEBUG_DOC_MANAGER
+#   include <iostream>
+    using std::cerr;
+    using std::endl;
+#endif
+
 using namespace ScIDE;
 
 Document::Document(bool isPlainText, const QByteArray & id,
@@ -772,7 +778,10 @@ void DocumentManager::handleNewDocScRequest( const QString & data )
             syncLangDocument(document);
             Q_EMIT( opened(document, 0, 0) );
         }
-    } catch(...) {
+    } catch(std::exception const& e) {
+#ifdef SC_DEBUG_DOC_MANAGER
+        cerr <<  "DocumentManager::" << __func__ << ": could not handle request: " << e.what() << endl;
+#endif
         return;
     }
 }
@@ -793,7 +802,10 @@ void DocumentManager::handleOpenFileScRequest( const QString & data )
             // we don't need to sync with lang in this case
             open(QString(path.c_str()), position, selectionLength, true, id.c_str(), false);
         }
-    } catch(...) {
+    } catch(std::exception const& e) {
+#ifdef SC_DEBUG_DOC_MANAGER
+        cerr <<  "DocumentManager::" << __func__ << ": could not handle request: " << e.what() << endl;
+#endif
         return;
     }
 }
@@ -819,7 +831,10 @@ void DocumentManager::handleGetDocTextScRequest( const QString & data )
                 Main::evaluateCode ( command, true );
             }
         }
-    } catch(...) {
+    } catch(std::exception const& e) {
+#ifdef SC_DEBUG_DOC_MANAGER
+        cerr <<  "DocumentManager::" << __func__ << ": could not handle request: " << e.what() << endl;
+#endif
         return;
     }
 }
@@ -859,7 +874,10 @@ void DocumentManager::handleSetDocTextScRequest( const QString & data )
                 }
             }
         }
-    } catch(...) {
+    } catch(std::exception const& e) {
+#ifdef SC_DEBUG_DOC_MANAGER
+        cerr <<  "DocumentManager::" << __func__ << ": could not handle request: " << e.what() << endl;
+#endif
         return;
     }
 }
@@ -883,7 +901,10 @@ void DocumentManager::handleSetDocSelectionScRequest( const QString & data )
                 }
             }
         }
-    } catch(...) {
+    } catch(std::exception const& e) {
+#ifdef SC_DEBUG_DOC_MANAGER
+        cerr <<  "DocumentManager::" << __func__ << ": could not handle request: " << e.what() << endl;
+#endif
         return;
     }
 }
@@ -907,7 +928,10 @@ void DocumentManager::handleSetDocEditableScRequest( const QString & data )
                 }
             }
         }
-    } catch(...) {
+    } catch(std::exception const& e) {
+#ifdef SC_DEBUG_DOC_MANAGER
+        cerr <<  "DocumentManager::" << __func__ << ": could not handle request: " << e.what() << endl;
+#endif
         return;
     }
 }
@@ -928,7 +952,10 @@ void DocumentManager::handleSetDocPromptsToSaveScRequest( const QString & data )
                 document->setPromptsToSave(promptsToSave);
             }
         }
-    } catch(...) {
+    } catch(std::exception const& e) {
+#ifdef SC_DEBUG_DOC_MANAGER
+        cerr <<  "DocumentManager::" << __func__ << ": could not handle request: " << e.what() << endl;
+#endif
         return;
     }
 }
@@ -947,7 +974,10 @@ void DocumentManager::handleSetCurrentDocScRequest( const QString & data )
             if(document)
                 Q_EMIT( showRequest(document) );
         }
-    } catch(...) {
+    } catch(std::exception const& e) {
+#ifdef SC_DEBUG_DOC_MANAGER
+        cerr <<  "DocumentManager::" << __func__ << ": could not handle request: " << e.what() << endl;
+#endif
         return;
     }
 }
@@ -969,7 +999,10 @@ void DocumentManager::handleRemoveDocUndoScRequest( const QString & data )
                 textDoc->setModified(false);
             }
         }
-    } catch(...) {
+    } catch(std::exception const& e) {
+#ifdef SC_DEBUG_DOC_MANAGER
+        cerr <<  "DocumentManager::" << __func__ << ": could not handle request: " << e.what() << endl;
+#endif
         return;
     }
 }
@@ -988,7 +1021,10 @@ void DocumentManager::handleCloseDocScRequest( const QString & data )
                 close(document);
             }
         }
-    } catch(...) {
+    } catch(std::exception const& e) {
+#ifdef SC_DEBUG_DOC_MANAGER
+        cerr <<  "DocumentManager::" << __func__ << ": could not handle request: " << e.what() << endl;
+#endif
         return;
     }
 }
@@ -1009,7 +1045,10 @@ void DocumentManager::handleSetDocTitleScRequest( const QString & data )
                 Q_EMIT(titleChanged(document));
             }
         }
-    } catch(...) {
+    } catch(std::exception const& e) {
+#ifdef SC_DEBUG_DOC_MANAGER
+        cerr <<  "DocumentManager::" << __func__ << ": could not handle request: " << e.what() << endl;
+#endif
         return;
     }
 }
@@ -1030,7 +1069,10 @@ bool DocumentManager::parseActionEnabledRequest( const QString & data, std::stri
 
             return true;
         }
-    } catch(...) {
+    } catch(std::exception const& e) {
+#ifdef SC_DEBUG_DOC_MANAGER
+        cerr <<  "DocumentManager::" << __func__ << ": could not handle request: " << e.what() << endl;
+#endif
     }
     return false;
 }
@@ -1073,7 +1115,10 @@ void DocumentManager::handleEnableGlobalKeyDownScRequest( const QString & data )
             bool enabled = doc[0].as<bool>(enabled);
             mGlobalKeyDownEnabled = enabled;
         }
-    } catch( ... ) {
+    } catch(std::exception const& e) {
+#ifdef SC_DEBUG_DOC_MANAGER
+        cerr <<  "DocumentManager::" << __func__ << ": could not handle request: " << e.what() << endl;
+#endif
     }
 }
 
@@ -1089,7 +1134,10 @@ void DocumentManager::handleEnableGlobalKeyUpScRequest( const QString & data )
 
             mGlobalKeyUpEnabled = enabled;
         }
-    } catch( ... ) {
+    } catch(std::exception const& e) {
+#ifdef SC_DEBUG_DOC_MANAGER
+        cerr <<  "DocumentManager::" << __func__ << ": could not handle request: " << e.what() << endl;
+#endif
     }
 }
 
@@ -1168,7 +1216,10 @@ void DocumentManager::handleEnableTextMirrorScRequest( const QString & data )
                 Main::scProcess()->post(warning);
             }
         }
-    } catch(...) {
+    } catch(std::exception const& e) {
+#ifdef SC_DEBUG_DOC_MANAGER
+        cerr <<  "DocumentManager::" << __func__ << ": could not handle request: " << e.what() << endl;
+#endif
     }
 }
 

--- a/editors/sc-ide/core/doc_manager.cpp
+++ b/editors/sc-ide/core/doc_manager.cpp
@@ -36,12 +36,6 @@
 
 #include <yaml-cpp/yaml.h>
 
-#ifdef SC_DEBUG_DOC_MANAGER
-#   include <iostream>
-    using std::cerr;
-    using std::endl;
-#endif
-
 using namespace ScIDE;
 
 Document::Document(bool isPlainText, const QByteArray & id,
@@ -778,10 +772,8 @@ void DocumentManager::handleNewDocScRequest( const QString & data )
             syncLangDocument(document);
             Q_EMIT( opened(document, 0, 0) );
         }
-    } catch(std::exception const& e) {
-#ifdef SC_DEBUG_DOC_MANAGER
-        cerr <<  "DocumentManager::" << __func__ << ": could not handle request: " << e.what() << endl;
-#endif
+    } catch (std::exception const& e) {
+        qWarning() << "DocumentManager::" << __func__ << ": could not handle request:" << e.what();
         return;
     }
 }
@@ -802,10 +794,8 @@ void DocumentManager::handleOpenFileScRequest( const QString & data )
             // we don't need to sync with lang in this case
             open(QString(path.c_str()), position, selectionLength, true, id.c_str(), false);
         }
-    } catch(std::exception const& e) {
-#ifdef SC_DEBUG_DOC_MANAGER
-        cerr <<  "DocumentManager::" << __func__ << ": could not handle request: " << e.what() << endl;
-#endif
+    } catch (std::exception const& e) {
+        qWarning() << "DocumentManager::" << __func__ << ": could not handle request:" << e.what() << endl;
         return;
     }
 }
@@ -831,10 +821,8 @@ void DocumentManager::handleGetDocTextScRequest( const QString & data )
                 Main::evaluateCode ( command, true );
             }
         }
-    } catch(std::exception const& e) {
-#ifdef SC_DEBUG_DOC_MANAGER
-        cerr <<  "DocumentManager::" << __func__ << ": could not handle request: " << e.what() << endl;
-#endif
+    } catch (std::exception const& e) {
+        qWarning() << "DocumentManager::" << __func__ << ": could not handle request:" << e.what() << endl;
         return;
     }
 }
@@ -874,10 +862,8 @@ void DocumentManager::handleSetDocTextScRequest( const QString & data )
                 }
             }
         }
-    } catch(std::exception const& e) {
-#ifdef SC_DEBUG_DOC_MANAGER
-        cerr <<  "DocumentManager::" << __func__ << ": could not handle request: " << e.what() << endl;
-#endif
+    } catch (std::exception const& e) {
+        qWarning() << "DocumentManager::" << __func__ << ": could not handle request:" << e.what();
         return;
     }
 }
@@ -901,10 +887,8 @@ void DocumentManager::handleSetDocSelectionScRequest( const QString & data )
                 }
             }
         }
-    } catch(std::exception const& e) {
-#ifdef SC_DEBUG_DOC_MANAGER
-        cerr <<  "DocumentManager::" << __func__ << ": could not handle request: " << e.what() << endl;
-#endif
+    } catch (std::exception const& e) {
+        qWarning() << "DocumentManager::" << __func__ << ": could not handle request:" << e.what();
         return;
     }
 }
@@ -928,10 +912,8 @@ void DocumentManager::handleSetDocEditableScRequest( const QString & data )
                 }
             }
         }
-    } catch(std::exception const& e) {
-#ifdef SC_DEBUG_DOC_MANAGER
-        cerr <<  "DocumentManager::" << __func__ << ": could not handle request: " << e.what() << endl;
-#endif
+    } catch (std::exception const& e) {
+        qWarning() << "DocumentManager::" << __func__ << ": could not handle request:" << e.what();
         return;
     }
 }
@@ -952,10 +934,8 @@ void DocumentManager::handleSetDocPromptsToSaveScRequest( const QString & data )
                 document->setPromptsToSave(promptsToSave);
             }
         }
-    } catch(std::exception const& e) {
-#ifdef SC_DEBUG_DOC_MANAGER
-        cerr <<  "DocumentManager::" << __func__ << ": could not handle request: " << e.what() << endl;
-#endif
+    } catch (std::exception const& e) {
+        qWarning() << "DocumentManager::" << __func__ << ": could not handle request:" << e.what();
         return;
     }
 }
@@ -974,10 +954,8 @@ void DocumentManager::handleSetCurrentDocScRequest( const QString & data )
             if(document)
                 Q_EMIT( showRequest(document) );
         }
-    } catch(std::exception const& e) {
-#ifdef SC_DEBUG_DOC_MANAGER
-        cerr <<  "DocumentManager::" << __func__ << ": could not handle request: " << e.what() << endl;
-#endif
+    } catch (std::exception const& e) {
+        qWarning() << "DocumentManager::" << __func__ << ": could not handle request:" << e.what();
         return;
     }
 }
@@ -999,10 +977,8 @@ void DocumentManager::handleRemoveDocUndoScRequest( const QString & data )
                 textDoc->setModified(false);
             }
         }
-    } catch(std::exception const& e) {
-#ifdef SC_DEBUG_DOC_MANAGER
-        cerr <<  "DocumentManager::" << __func__ << ": could not handle request: " << e.what() << endl;
-#endif
+    } catch (std::exception const& e) {
+        qWarning() << "DocumentManager::" << __func__ << ": could not handle request:" << e.what();
         return;
     }
 }
@@ -1021,10 +997,8 @@ void DocumentManager::handleCloseDocScRequest( const QString & data )
                 close(document);
             }
         }
-    } catch(std::exception const& e) {
-#ifdef SC_DEBUG_DOC_MANAGER
-        cerr <<  "DocumentManager::" << __func__ << ": could not handle request: " << e.what() << endl;
-#endif
+    } catch (std::exception const& e) {
+        qWarning() << "DocumentManager::" << __func__ << ": could not handle request:" << e.what();
         return;
     }
 }
@@ -1045,10 +1019,8 @@ void DocumentManager::handleSetDocTitleScRequest( const QString & data )
                 Q_EMIT(titleChanged(document));
             }
         }
-    } catch(std::exception const& e) {
-#ifdef SC_DEBUG_DOC_MANAGER
-        cerr <<  "DocumentManager::" << __func__ << ": could not handle request: " << e.what() << endl;
-#endif
+    } catch (std::exception const& e) {
+        qWarning() << "DocumentManager::" << __func__ << ": could not handle request:" << e.what();
         return;
     }
 }
@@ -1069,10 +1041,8 @@ bool DocumentManager::parseActionEnabledRequest( const QString & data, std::stri
 
             return true;
         }
-    } catch(std::exception const& e) {
-#ifdef SC_DEBUG_DOC_MANAGER
-        cerr <<  "DocumentManager::" << __func__ << ": could not handle request: " << e.what() << endl;
-#endif
+    } catch (std::exception const& e) {
+        qWarning() << "DocumentManager::" << __func__ << ": could not handle request:" << e.what();
     }
     return false;
 }
@@ -1115,10 +1085,8 @@ void DocumentManager::handleEnableGlobalKeyDownScRequest( const QString & data )
             bool enabled = doc[0].as<bool>(enabled);
             mGlobalKeyDownEnabled = enabled;
         }
-    } catch(std::exception const& e) {
-#ifdef SC_DEBUG_DOC_MANAGER
-        cerr <<  "DocumentManager::" << __func__ << ": could not handle request: " << e.what() << endl;
-#endif
+    } catch (std::exception const& e) {
+        qWarning() << "DocumentManager::" << __func__ << ": could not handle request:" << e.what();
     }
 }
 
@@ -1134,10 +1102,8 @@ void DocumentManager::handleEnableGlobalKeyUpScRequest( const QString & data )
 
             mGlobalKeyUpEnabled = enabled;
         }
-    } catch(std::exception const& e) {
-#ifdef SC_DEBUG_DOC_MANAGER
-        cerr <<  "DocumentManager::" << __func__ << ": could not handle request: " << e.what() << endl;
-#endif
+    } catch (std::exception const& e) {
+        qWarning() << "DocumentManager::" << __func__ << ": could not handle request:" << e.what();
     }
 }
 
@@ -1216,10 +1182,8 @@ void DocumentManager::handleEnableTextMirrorScRequest( const QString & data )
                 Main::scProcess()->post(warning);
             }
         }
-    } catch(std::exception const& e) {
-#ifdef SC_DEBUG_DOC_MANAGER
-        cerr <<  "DocumentManager::" << __func__ << ": could not handle request: " << e.what() << endl;
-#endif
+    } catch (std::exception const& e) {
+        qWarning() << "DocumentManager::" << __func__ << ": could not handle request:" << e.what();
     }
 }
 

--- a/editors/sc-ide/core/doc_manager.cpp
+++ b/editors/sc-ide/core/doc_manager.cpp
@@ -832,11 +832,11 @@ void DocumentManager::handleSetDocTextScRequest( const QString & data )
             if ( !doc.IsSequence() )
                 return;
 
-            std::string id     = doc[0].as<std::string>();
-            std::string funcID = doc[1].as<std::string>();
-            std::string text   = doc[2].as<std::string>();
-            int start          = doc[3].as<int>();
-            int range          = doc[4].as<int>();
+            // Parse funcID (doc[1]) later, if it was not null.
+            std::string id   = doc[0].as<std::string>();
+            std::string text = doc[2].as<std::string>();
+            int start        = doc[3].as<int>();
+            int range        = doc[4].as<int>();
 
             Document *document = documentForId(id.c_str());
             if(document) {
@@ -851,8 +851,12 @@ void DocumentManager::handleSetDocTextScRequest( const QString & data )
                     connect(document->textDocument(), SIGNAL(contentsChange(int, int, int)), this, SLOT(updateCurrentDocContents(int, int, int)));
                 }
 
-                QString command = QStringLiteral("Document.executeAsyncResponse(\'%1\')").arg(funcID.c_str());
-                Main::evaluateCode ( command, true );
+                // Only execute a call if a function name was passed.
+                if (!doc[1].IsNull()) {
+                    std::string funcID = doc[1].as<std::string>("");
+                    QString command = QStringLiteral("Document.executeAsyncResponse(\'%1\')").arg(funcID.c_str());
+                    Main::evaluateCode ( command, true );
+                }
             }
         }
     } catch(...) {


### PR DESCRIPTION
### Issue

```supercollider
Document.current.selectedText_("abc");
```
Expected behavior: add `abc` to current document.
Actual behavior: nothing.

### Diagnosis

In `DocumentManager::handleSetDocTextScRequest`, which is called to set document text in the IDE, the parameter `funcID` is `Null` in many instances, which would cause the function to bail out early while trying to parse a null node as a string:

```cpp
std::string funcID = doc[1].as<std::string>(); // throws if doc[1].IsNull()
```

### Solution

After this commit, `funcID` is only parsed if it is not null, and a function call to `Document.executeAsyncResponse` is, again, only made if the funcID is non-null.

### Other notes

I added debugging code to the try-catch blocks in this file so this is easier to diagnose in the future. I don't have time to check if any other functions are similarly afflicted with early exits, but thought it would be helpful not to cover my tracks here. The macro to define is `SC_DEBUG_DOC_MANAGER`.

A less intrusive option would have been to add a fallback:

```cpp
std::string funcID = doc[1].as<std::string>(""); // will return an empty string instead of throwing
```

However, this would cause a call to
```supercollider
Document.executeAsyncResponse('');
```
even if `funcID` were null, which is not expected behavior, since you actually could add the association `'' -> { /* do something */ }` to an `IdentityDictionary`.