### PR TITLE
Several help improvements

### DIFF
--- a/HelpSource/Classes/AllpassC.schelp
+++ b/HelpSource/Classes/AllpassC.schelp
@@ -1,12 +1,25 @@
 class:: AllpassC
-summary:: All pass delay line with cubic interpolation.
+summary:: Schroeder allpass delay line with cubic interpolation.
 related:: Classes/AllpassL, Classes/AllpassN, Classes/BufAllpassC
 categories::  UGens>Delays
 
 
 Description::
 
-All pass delay line with cubic interpolation. See also
+A Schroeder allpass filter is given by the difference equations
+
+code::
+s(t) = x(t) + k * s(t - D)
+y(t) = -k * s(t) + s(t - D)
+::
+
+where code::x(t):: is the input signal, code::y(t):: is the output signal,
+code::D:: is the delay time, and code::k:: is the allpass coefficient.
+
+In this UGen, code::k:: is computed as
+code::k == 0.001 ** (delay / decay.abs) * decay.sign:: (0.001 is -60 dBFS).
+
+See also
 link::Classes/AllpassN::  which uses no interpolation, and
 link::Classes/AllpassL::  which uses linear interpolation.
 Cubic interpolation is more computationally expensive than linear,

--- a/HelpSource/Classes/AllpassL.schelp
+++ b/HelpSource/Classes/AllpassL.schelp
@@ -1,12 +1,25 @@
 class:: AllpassL
-summary:: All pass delay line with linear interpolation.
+summary:: Schroeder allpass delay line with linear interpolation.
 related:: Classes/AllpassC, Classes/AllpassN, Classes/BufAllpassL
 categories::  UGens>Delays
 
 
 Description::
 
-All pass delay line with linear interpolation. See also
+A Schroeder allpass filter is given by the difference equations
+
+code::
+s(t) = x(t) + k * s(t - D)
+y(t) = -k * s(t) + s(t - D)
+::
+
+where code::x(t):: is the input signal, code::y(t):: is the output signal,
+code::D:: is the delay time, and code::k:: is the allpass coefficient.
+
+In this UGen, code::k:: is computed as
+code::k == 0.001 ** (delay / decay.abs) * decay.sign:: (0.001 is -60 dBFS).
+
+See also
 link::Classes/AllpassN::  which uses no interpolation, and
 link::Classes/AllpassC::  which uses cubic interpolation.
 Cubic interpolation is more computationally expensive than linear,
@@ -42,7 +55,7 @@ code::
 // Since the allpass delay has no audible effect as a resonator on
 // steady state sound ...
 
-{ AllpassC.ar(WhiteNoise.ar(0.1), 0.01, XLine.kr(0.0001, 0.01, 20), 0.2) }.play;
+{ AllpassL.ar(WhiteNoise.ar(0.1), 0.01, XLine.kr(0.0001, 0.01, 20), 0.2) }.play;
 
 // ...these examples add the input to the effected sound and compare variants so that you can hear
 // the effect of the phase comb:

--- a/HelpSource/Classes/AllpassN.schelp
+++ b/HelpSource/Classes/AllpassN.schelp
@@ -20,7 +20,7 @@ In this UGen, code::k:: is computed as
 code::k == 0.001 ** (delay / decay.abs) * decay.sign:: (0.001 is -60 dBFS).
 
 This UGen quantizes the delay time to the nearest sample period, and will
-also produce aliasing artifacts if the delay time is modulated. If these
+produce aliasing artifacts if the delay time is modulated. If these
 are undesirable properties, the more CPU-expensive alternatives are
 link::Classes/AllpassL:: which uses linear interpolation, and
 link::Classes/AllpassC:: which uses cubic interpolation.
@@ -39,7 +39,7 @@ argument::delaytime
 Delay time in seconds.
 
 argument::decaytime
-Time for the echoes to decay by 60 decibels. If this time is negative then the feedback coefficient will be negative, thus emphasizing only odd harmonics at an octave lower.
+Time for the echoes to decay by 60 decibels. If this time is negative, then the feedback coefficient will be negative, thus emphasizing only odd harmonics at an octave lower.
 
 argument::mul
 Output will be multiplied by this value.

--- a/HelpSource/Classes/AllpassN.schelp
+++ b/HelpSource/Classes/AllpassN.schelp
@@ -1,17 +1,29 @@
 class:: AllpassN
-summary:: All pass delay line with no interpolation.
+summary:: Schroeder allpass delay line with no interpolation.
 related:: Classes/AllpassC, Classes/AllpassL, Classes/BufAllpassN
 categories::  UGens>Delays
 
 
 Description::
 
-All pass delay line with no interpolation. See also
-link::Classes/AllpassL::  which uses linear interpolation, and
-link::Classes/AllpassC::  which uses cubic interpolation.
-Cubic interpolation is more computationally expensive than linear,
-but more accurate.
+A Schroeder allpass filter is given by the difference equations
 
+code::
+s(t) = x(t) + k * s(t - D)
+y(t) = -k * s(t) + s(t - D)
+::
+
+where code::x(t):: is the input signal, code::y(t):: is the output signal,
+code::D:: is the delay time, and code::k:: is the allpass coefficient.
+
+In this UGen, code::k:: is computed as
+code::k == 0.001 ** (delay / decay.abs) * decay.sign:: (0.001 is -60 dBFS).
+
+This UGen quantizes the delay time to the nearest sample period, and will
+also produce aliasing artifacts if the delay time is modulated. If these
+are undesirable properties, the more CPU-expensive alternatives are
+link::Classes/AllpassL:: which uses linear interpolation, and
+link::Classes/AllpassC:: which uses cubic interpolation.
 
 classmethods::
 
@@ -42,7 +54,7 @@ code::
 // Since the allpass delay has no audible effect as a resonator on
 // steady state sound ...
 
-{ AllpassC.ar(WhiteNoise.ar(0.1), 0.01, XLine.kr(0.0001, 0.01, 20), 0.2) }.play;
+{ AllpassN.ar(WhiteNoise.ar(0.1), 0.01, XLine.kr(0.0001, 0.01, 20), 0.2) }.play;
 
 // ...these examples add the input to the effected sound and compare variants so that you can hear
 // the effect of the phase comb:

--- a/HelpSource/Classes/Buffer.schelp
+++ b/HelpSource/Classes/Buffer.schelp
@@ -4,7 +4,11 @@ categories:: Server>Abstractions
 
 description::
 
-A buffer is most often used to hold sampled audio, such as a soundfile loaded into memory, but can be used to hold other types of data as well. It is a globally available array of floating-point numbers on the server. The Buffer class encapsulates a number of common tasks, OSC messages, and capabilities related to server-side buffers – see the examples lower down this document for many examples of using Buffers for sound playback and recording.
+A Buffer object is a client-side abstraction for a server-side buffer. (SuperCollider's server-client architecture is a common source of confusion when working with Buffer objects, so please see link::Guides/ClientVsServer::.)
+
+A buffer is most often used to hold sampled audio, such as a soundfile loaded into memory, but can be used to hold other types of data as well. Technically speaking, a buffer on the server is a globally available, multichannel array of 32-bit floating-point numbers. It also has an associated sample rate, represented in Hertz as a 64-bit float.
+
+The Buffer class encapsulates a number of common tasks, OSC messages, and capabilities related to server-side buffers – see the examples lower down this document for many examples of using Buffers for sound playback and recording.
 
 Buffers are commonly used with link::Classes/PlayBuf::, link::Classes/RecordBuf::, link::Classes/DiskIn::, link::Classes/DiskOut::, link::Classes/BufWr::, link::Classes/BufRd::, and other UGens. (See their individual help files for more examples.) Buffers can be freed or altered even while being accessed. See link::Reference/Server-Architecture:: for some technical details.
 
@@ -428,6 +432,8 @@ Returns the number of channels in the corresponding server-side buffer.
 
 method:: sampleRate
 Returns the sample rate of the corresponding server-side buffer.
+
+Changing this value only changes what the buffer thinks its sample rate is. It does not resample the buffer.
 
 method:: path
 Returns a string containing the path of a soundfile that has been loaded into the corresponding server-side buffer.

--- a/HelpSource/Classes/Buffer.schelp
+++ b/HelpSource/Classes/Buffer.schelp
@@ -433,7 +433,7 @@ Returns the number of channels in the corresponding server-side buffer.
 method:: sampleRate
 Returns the sample rate of the corresponding server-side buffer.
 
-Changing this value only changes what the buffer thinks its sample rate is. It does not resample the buffer.
+Changing this value only changes what the buffer thinks its sample rate is. It does not resample the buffer's content.
 
 method:: path
 Returns a string containing the path of a soundfile that has been loaded into the corresponding server-side buffer.

--- a/HelpSource/Classes/CombC.schelp
+++ b/HelpSource/Classes/CombC.schelp
@@ -29,6 +29,8 @@ Delay time in seconds.
 argument::decaytime
 Time for the echoes to decay by 60 decibels. If this time is negative then the feedback coefficient will be negative, thus emphasizing only odd harmonics at an octave lower.
 
+Large decay times are sensitive to DC bias, so use a link::Classes/LeakDC:: if this is an issue.
+
 Infinite decay times are permitted. A decay time of code::inf:: leads to a feedback coefficient of 1, and a decay time of code::-inf:: leads to a feedback coefficient of -1.
 
 argument::mul

--- a/HelpSource/Classes/CombL.schelp
+++ b/HelpSource/Classes/CombL.schelp
@@ -29,6 +29,8 @@ Delay time in seconds.
 argument::decaytime
 Time for the echoes to decay by 60 decibels. If this time is negative then the feedback coefficient will be negative, thus emphasizing only odd harmonics at an octave lower.
 
+Large decay times are sensitive to DC bias, so use a link::Classes/LeakDC:: if this is an issue.
+
 Infinite decay times are permitted. A decay time of code::inf:: leads to a feedback coefficient of 1, and a decay time of code::-inf:: leads to a feedback coefficient of -1.
 
 argument::mul

--- a/HelpSource/Classes/CombN.schelp
+++ b/HelpSource/Classes/CombN.schelp
@@ -31,6 +31,8 @@ Delay time in seconds.
 argument::decaytime
 Time for the echoes to decay by 60 decibels. If this time is negative, then the feedback coefficient will be negative, thus emphasizing only odd harmonics at an octave lower.
 
+Large decay times are sensitive to DC bias, so use a link::Classes/LeakDC:: if this is an issue.
+
 Infinite decay times are permitted. A decay time of code::inf:: leads to a feedback coefficient of 1, and a decay time of code::-inf:: leads to a feedback coefficient of -1.
 
 argument::mul

--- a/HelpSource/Classes/Float.schelp
+++ b/HelpSource/Classes/Float.schelp
@@ -29,8 +29,8 @@ argument:: function
 The function to iterate.
 
 method:: coin
-Perform a random test whose probability of success in a range from
-zero to one is this and return the result.
+Let emphasis::x:: be the receiver clipped to the range [0, 1]. With probability emphasis::x::, return true. With probability 1 - emphasis::x::, return false.
+
 returns:: a link::Classes/Boolean::
 discussion::
 code::

--- a/HelpSource/Classes/SimpleNumber.schelp
+++ b/HelpSource/Classes/SimpleNumber.schelp
@@ -856,7 +856,7 @@ prints this on the given stream
 subsection:: random
 
 method:: coin
-Answers a Boolean which is the result of a random test whose probability of success in a range from zero to one is this.
+Let emphasis::x:: be the receiver clipped to the range [0, 1]. With probability emphasis::x::, return true. With probability 1 - emphasis::x::, return false.
 
 method:: rand
 returns:: Random number from zero up to the receiver, exclusive.


### PR DESCRIPTION
Since I'm pretty confident that these are uncontroversial, I'm grouping them all in one PR. In summary:

- Much clearer wording for SimpleNumber:coin.
- Add a note about DC bias sensitivity in Comb*.
- Expand Allpass* documentation to state explicitly that these are Schroeder allpasses ([example of use](https://ccrma.stanford.edu/~jos/pasp/Schroeder_Allpass_Sections.html)), and give difference equations.
- Elaborate some technical details on Buffer.