### PR TITLE
class library: adverb argument for reduce

### DIFF
--- a/HelpSource/Classes/SequenceableCollection.schelp
+++ b/HelpSource/Classes/SequenceableCollection.schelp
@@ -599,15 +599,29 @@ code::
 ::
 
 method::reduce
-Applies the method named by operator to the first and second elements of the collection - then applies the method to the result and to the third element of the collection - then applies the method to the result and to the fourth element of the collection - and so on, until the end of the array.
+Applies the method named by operator to the first and second elements of the collection, and then applies the method to the result and to the third element of the collection, then applies the method to the result and to the fourth element of the collection, and so on, until the end of the array.
+
+argument::operator
+May be a link::Classes/Function:: (taking two or three arguments) or a link::Classes/Symbol:: (method selector).
+
+
 code::
 [3, 4, 5, 6].reduce('*'); // this is the same as [3, 4, 5, 6].product
 [3, 4, 5, 6].reduce(\lcm); // Lowest common multiple of the whole set of numbers
 ["d", "e", (0..9), "h"].reduce('++'); // concatenation
 [3, 4, 5, 6].reduce({ |a, b| sin(a) * sin(b) }); // product of sines
 ::
-argument::operator
-may be a link::Classes/Function:: or a link::Classes/Symbol::.
+
+
+argument::adverb
+An optional adverb to be used together with the operator (see link::Reference/Adverbs::). If the operator is a functions, the adverb is passed as a third argument.
+
+code::
+// compare:
+[1, 2] *.x [10, 20, 30]
+[[1, 2], [10, 20, 30]].reduce('*', 'x')
+[[1, 2], [10, 20, 30], [1000, 2000]].reduce('+', 'x') // but you can combine more
+::
 
 method::convertDigits
 Returns an integer resulting from interpreting the elements as digits to a given base (default 10). See also asDigits in link::Classes/Integer#asDigits:: for the complementary method.

--- a/HelpSource/Classes/SequenceableCollection.schelp
+++ b/HelpSource/Classes/SequenceableCollection.schelp
@@ -601,6 +601,8 @@ code::
 method::reduce
 Applies the method named by operator to the first and second elements of the collection, and then applies the method to the result and to the third element of the collection, then applies the method to the result and to the fourth element of the collection, and so on, until the end of the array.
 
+If the collection contains only one element, it is returned as the result. If the collection is empty, returns code::nil::.
+
 argument::operator
 May be a link::Classes/Function:: (taking two or three arguments) or a link::Classes/Symbol:: (method selector).
 

--- a/SCClassLibrary/Common/Collections/SequenceableCollection.sc
+++ b/SCClassLibrary/Common/Collections/SequenceableCollection.sc
@@ -1264,15 +1264,15 @@ SequenceableCollection : Collection {
 		index = index % this.size;
 		^this.put(index, value)
 	}
-	reduce { arg operator;
+	reduce { arg operator, adverb;
 		var once = true, result;
 		if(this.size==1){ ^this[0] };
 		this.doAdjacentPairs {|a, b|
 			if (once) {
 				once = false;
-				result = operator.applyTo(a, b);
+				result = operator.applyTo(a, b, adverb);
 			}{
-				result =  operator.applyTo(result, b);
+				result =  operator.applyTo(result, b, adverb);
 			};
 		};
 		^result


### PR DESCRIPTION
The method `reduce` takes a binary operator selector (or an appropriate
function) and applies it to the collection’s items incrementally.

This patch allows us to pass an adverb to the operator, as commonly
expected for binary operations. If the operator is a function, the
adverb is the third argument.

These two expressions return the same value:
```
[1, 2] *.t [10, 20, 30]
[[1, 2], [10, 20, 30]].reduce('*', 't')
```

This feature is justified because it exposes the interface of binary
operators and calculations by reduce are very compact.