### PR TITLE
plugins: Impulse Ctor initial output = 1 for iphase = 0

### DIFF
--- a/server/plugins/LFUGens.cpp
+++ b/server/plugins/LFUGens.cpp
@@ -1029,12 +1029,15 @@ void Impulse_Ctor(Impulse* unit)
 		}
 	}
 
-
 	unit->mPhaseOffset = 0.f;
 	unit->mFreqMul = unit->mRate->mSampleDur;
+
 	if (unit->mPhase == 0.f) unit->mPhase = 1.f;
 
-	ZOUT0(0) = 0.f;
+	if (unit->mPhase == 1.f)
+		ZOUT0(0) = 1.f;
+	else
+		ZOUT0(0) = 0.f;
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Per the last few comments in #2343, this is a fix for the specific case of Impulse outputting 1 for its first sample. (This is the default case, because `iphase` is 0 by default.)

**Problem:** An initial impulse is often used to initialize other units. Often, the other units' initialization depends on the trigger being available to the Ctor. But currently, `Impulse_Ctor` outputs 0 when the first sample from `_next` will be 1. In that case, downstream units initialize to an unexpected value.

**Proposed solution:** Specifically when iphase == 0, Ctor sets its output to 1.0. (There are a couple of other cases in the Ctor where the phase is set to 1.0, so that it will wrap around in the first `_next` and output 1.0 -- this PR will produce 1.0 in the Ctor for those cases as well.)

There's a bit of room for debate, based on the fact that we can't decide whether the Ctor's output sample should match `_next`'s first output, or if it's a "pre-sample." I tend toward the former, while `Impulse` currently does the latter -- with the concrete impact that it's currently impossible to initialize units correctly in many cases. A case might be made for the latter -- but, if that's the decision, then IMO it would be mandatory to add an `InitImpulse` UGen with no iphase argument, whose Ctor init-sample is 1.

User impact: Every few months, I run into a new variant of the same problem. Maybe nobody else uses initial Impulses, but I seem to use them a lot, and they aren't reliable.