### PR TITLE
Added resizeToBounds and resizeToHint methods

### DIFF
--- a/HelpSource/Classes/View.schelp
+++ b/HelpSource/Classes/View.schelp
@@ -255,7 +255,7 @@ METHOD:: resizeToBounds
 
 METHOD:: resizeToHint
 
-	Calls link::#-sizeHint and then resizes view to those bounds.		
+	Calls link::#-sizeHint:: and then resizes view to those bounds.		
 
 METHOD:: resize
 	Determines what happens with the view's position and size when its parent is resized. See link::Guides/GUI-Introduction#view:: for further explanation.

--- a/HelpSource/Classes/View.schelp
+++ b/HelpSource/Classes/View.schelp
@@ -248,6 +248,15 @@ METHOD:: resizeTo
 	argument:: height
 		An Int: the new vertical size of the view.
 
+METHOD:: resizeToBounds
+
+	argument:: rect
+		A Rect: the bounds to which the view will be resized.
+
+METHOD:: resizeToHint
+
+	Calls link::#-sizeHint and then resizes view to those bounds.		
+
 METHOD:: resize
 	Determines what happens with the view's position and size when its parent is resized. See link::Guides/GUI-Introduction#view:: for further explanation.
 

--- a/HelpSource/Classes/View.schelp
+++ b/HelpSource/Classes/View.schelp
@@ -255,7 +255,7 @@ METHOD:: resizeToBounds
 
 METHOD:: resizeToHint
 
-	Calls link::#-sizeHint:: and then resizes view to those bounds.		
+	Resizes view to the bounds returned by link::#sizeHint::.		
 
 METHOD:: resize
 	Determines what happens with the view's position and size when its parent is resized. See link::Guides/GUI-Introduction#view:: for further explanation.

--- a/SCClassLibrary/Common/GUI/Base/QView.sc
+++ b/SCClassLibrary/Common/GUI/Base/QView.sc
@@ -169,6 +169,15 @@ View : QObject {
 		this.bounds_( this.bounds.resizeTo( width, height ) );
 	}
 
+	resizeToBounds { arg rect;
+		this.bounds_( this.bounds.resizeTo( rect.width, rect.height ) );
+	}
+
+	resizeToHint {
+		var size = this.sizeHint;
+		this.bounds_( this.bounds.resizeTo( size.width, size.height ) );
+	}
+
 	visible {
 		^this.getProperty(\visible)
 	}

--- a/SCClassLibrary/Common/GUI/Base/QWindow.sc
+++ b/SCClassLibrary/Common/GUI/Base/QWindow.sc
@@ -176,6 +176,7 @@ Window {
 
 	sizeHint { ^view.sizeHint }
 	minSizeHint { ^view.minSizeHint }
+	resizeToHint { ^view.resizeToHint }
 	alpha_ { arg value; view.alpha_(value); }
 	addFlowLayout { arg margin, gap; ^view.addFlowLayout( margin, gap ); }
 	close { view.close; }


### PR DESCRIPTION
This PR improves the situation described in issue #195 by adding two new methods to QView : resizeToHint and reizeToBounds.

```
// not correct, view too small
w = Window("Test",Rect()).layout_(
QVLayout( QStaticText().string_("Hello layout"), QButton() )
).front;

// correct size
w = Window("Test",Rect()).layout_(
QVLayout( QStaticText().string_("Hello layout"), QButton() )
).view.resizeToHint.front;
```