### PR TITLE
class lib: Env:-kr/-ar : rename arguments to match functionality

### DIFF
--- a/HelpSource/Classes/Env.schelp
+++ b/HelpSource/Classes/Env.schelp
@@ -508,7 +508,21 @@ If strong::gate:: < 0, force release with time code:: -1.0 - gate ::. See link::
 
 argument::timeScale
 
-Scales the durations of the segments.
+The durations of the segments are multiplied by this value. This
+value can be modulated, but is only sampled at the start of a new
+envelope segment.
+
+argument::levelScale
+
+The levels of the breakpoints are multiplied by this value. This
+value can be modulated, but is only sampled at the start of a new
+envelope segment.
+
+argument::levelBias
+
+This value is added as an offset to the levels of the breakpoints.
+This value can be modulated, but is only sampled at the start of a
+new envelope segment.
 
 discussion::
 code::

--- a/HelpSource/Classes/EnvGen.schelp
+++ b/HelpSource/Classes/EnvGen.schelp
@@ -43,18 +43,21 @@ If strong::gate:: < 0, force release with time code:: -1.0 - gate ::. See link::
 
 argument::levelScale
 
-Scales the levels of the breakpoints.
-
+The levels of the breakpoints are multiplied by this value. This
+value can be modulated, but is only sampled at the start of a new
+envelope segment.
 
 argument::levelBias
 
-Offsets the levels of the breakpoints.
-
+This value is added as an offset to the levels of the breakpoints.
+This value can be modulated, but is only sampled at the start of a
+new envelope segment.
 
 argument::timeScale
 
-Scales the durations of the segments.
-
+The durations of the segments are multiplied by this value. This
+value can be modulated, but is only sampled at the start of a new
+envelope segment.
 
 argument::doneAction
 

--- a/SCClassLibrary/Common/Audio/Env.sc
+++ b/SCClassLibrary/Common/Audio/Env.sc
@@ -42,12 +42,12 @@ Env {
 		shapeNames.freeze;
 	}
 
-	kr { arg doneAction = 0, gate = 1.0, timeScale = 1.0, mul = 1.0, add = 0.0;
-		^EnvGen.kr(this, gate, mul, add, timeScale, doneAction)
+	kr { arg doneAction = 0, gate = 1.0, timeScale = 1.0, levelScale = 1.0, levelBias = 0.0;
+		^EnvGen.kr(this, gate, levelScale, levelBias, timeScale, doneAction)
 	}
 
-	ar { arg doneAction = 0, gate = 1.0, timeScale = 1.0, mul = 1.0, add = 0.0;
-		^EnvGen.ar(this, gate, mul, add, timeScale, doneAction)
+	ar { arg doneAction = 0, gate = 1.0, timeScale = 1.0, levelScale = 1.0, levelBias = 0.0;
+		^EnvGen.ar(this, gate, levelScale, levelBias, timeScale, doneAction)
 	}
 
 	levels_ { arg z;


### PR DESCRIPTION
Fix for #2858.

# Issue

The old argument names were misleading. `EnvGen.kr/ar` actually use their 'mul' and 'add' for levelScale and levelBias, which are not the same thing.

# Solution

Rename them to match the corresponding arguments to EnvGen.ar/kr. Also update the documentation to reflect these changes. I chose this solution because it's the least intrusive and seemed to have general support.