### PR TITLE
GUI: Fix SoundFileView grid behavior

### DIFF
--- a/HelpSource/Classes/SoundFileView.schelp
+++ b/HelpSource/Classes/SoundFileView.schelp
@@ -420,7 +420,7 @@ METHOD:: gridOffset
     Sets the grid offset.
 
     argument::
-        An integer.
+        Grid blocks are offset by this value (in seconds).
 
 METHOD:: gridColor
 

--- a/QtCollider/widgets/soundfileview/view.cpp
+++ b/QtCollider/widgets/soundfileview/view.cpp
@@ -516,8 +516,10 @@ void QcWaveform::paintEvent( QPaintEvent *ev )
     p.setBrush( _gridColor );
     p.scale( (double) width() / dur_in_secs, 1.0 );
 
-    // Wrap the offset to [0%, 100%) of the grid resolution.
-    double offset = std::fmod(_gridOffset, _gridResolution * 2);
+    // Wrap the offset to (-100%, 100%) of the grid resolution. Subtract by
+    // beg_in_secs to account for zoom+timeshift.
+    double beg_in_secs = _beg / sfInfo.samplerate;
+    double offset = std::fmod(_gridOffset - beg_in_secs, _gridResolution * 2);
 
     // Catch the case where the grid is [50% - 100%) offset from the start
     // in order to draw the portion off the left side of the view.

--- a/QtCollider/widgets/soundfileview/view.cpp
+++ b/QtCollider/widgets/soundfileview/view.cpp
@@ -49,8 +49,8 @@ QcWaveform::QcWaveform( QWidget * parent ) : QWidget( parent ),
   _curSel(0),
 
   _showCursor(false),
-  _cursorEditable(true),
   _cursorPos(0),
+  _cursorEditable(true),
 
   _showGrid(true),
   _gridResolution(1.0),
@@ -62,10 +62,10 @@ QcWaveform::QcWaveform( QWidget * parent ) : QWidget( parent ),
 
   pixmap(0),
   _bkgColor( QColor(0,0,0) ),
-  _cursorColor( QColor(255,0,0) ),
-  _gridColor( QColor(100,100,200) ),
   _peakColor( QColor(242,178,0) ),
   _rmsColor( QColor(255,255,0) ),
+  _cursorColor( QColor(255,0,0) ),
+  _gridColor( QColor(100,100,200) ),
   dirty(false),
   _drawWaveform(true)
 {

--- a/QtCollider/widgets/soundfileview/view.cpp
+++ b/QtCollider/widgets/soundfileview/view.cpp
@@ -503,26 +503,6 @@ void QcWaveform::paintEvent( QPaintEvent *ev )
     dirty = false;
   }
 
-  // draw selections
-
-  p.save();
-
-  p.scale( (double) width() / _dur, 1.0 );
-  p.translate( _beg * -1.0, 0.0 );
-  p.setPen( Qt::NoPen );
-
-  int i;
-  for( i = 0; i < 64; ++i ) {
-    const Selection &s = _selections[i];
-    if( s.size > 0 ) {
-      QRectF r ( s.start, 0, s.size, height() );
-      p.setBrush( s.color );
-      p.drawRect( r );
-    }
-  }
-
-  p.restore();
-
   // draw time grid
 
   if( _showGrid && sfInfo.samplerate > 0 && _gridResolution > 0.f ) {
@@ -552,6 +532,26 @@ void QcWaveform::paintEvent( QPaintEvent *ev )
 
     p.restore();
   }
+
+  // draw selections
+
+  p.save();
+
+  p.scale( (double) width() / _dur, 1.0 );
+  p.translate( _beg * -1.0, 0.0 );
+  p.setPen( Qt::NoPen );
+
+  int i;
+  for( i = 0; i < 64; ++i ) {
+    const Selection &s = _selections[i];
+    if( s.size > 0 ) {
+      QRectF r ( s.start, 0, s.size, height() );
+      p.setBrush( s.color );
+      p.drawRect( r );
+    }
+  }
+
+  p.restore();
 
   // paste the waveform pixmap on screen
 

--- a/QtCollider/widgets/soundfileview/view.hpp
+++ b/QtCollider/widgets/soundfileview/view.hpp
@@ -94,7 +94,13 @@ public:
 public:
 
   struct Selection {
-    Selection() : start(0), size(0), editable(true), color(QColor(0,0,150)) {}
+    Selection() :
+      start(0),
+      size(0),
+      editable(true),
+      color(QColor(128, 128, 128, 192))
+    { }
+
     sf_count_t start;
     sf_count_t size;
     bool editable;


### PR DESCRIPTION
This fixes #2033, an issue regarding the `gridResolution` and `gridOffset` behaviors of `SoundFileView` as well as a problem with selections not being visible.

# Test code

```supercollider
(
w = Window.new("soundfile test", Rect(200, 300, 740, 100));
a = SoundFileView.new(w, Rect(20,20, 700, 60));
f = SoundFile.new;
f.openRead(Platform.resourceDir +/+ "sounds/a11wlk01.wav");

a.soundfile = f;
a.read(0, f.numFrames);
a.timeCursorOn_(true);
a.gridResolution = 2;
a.gridOffset = 0;
w.front;
)

// other resolution and offset values
a.gridResolution = 1;
a.gridResolution = 0.5;
a.gridOffset = 0.25;
a.gridOffset = 0.75;

// also try zooming with shift+mouse-drag
```

# Previous behavior

- The leftmost grid block was only half revealed.
- The grid blocked the selection highlight.
- Setting `gridResolution <= 1` did not work: the entire view would become the grid color.
- The grid resolution did not match the desired value.

# New behavior

- Leftmost grid block is fully revealed.
- Selection highlight appears on top of grid.
- Setting `gridResolution` to any value is now supported.
- Grid resolution matches desired value.

I have also tested this to make sure that zoom and offset behavior is preserved.

# Description of solution

The previous implementation had some incorrect math that I rewrote; see commit messages/code for details. I also fixed a few compiler warnings in the same file and changed the default selection color to something that I would call "better". Finally, I changed the documentation to correctly describe what `gridOffset` does; I noticed it was incorrect while working on this.