### PR TITLE
Add CLion directories to main gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,7 @@ common/Packager/SuperCollider*.dmg
 
 # CLion files
 .idea
-cmake-build-debug
+cmake-build-*
 
 #build directories
 /build*

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,10 @@ common/Packager/LinuxExclusions.txt
 common/Packager/SuperCollider*.tar.gz
 common/Packager/SuperCollider*.dmg
 
+# CLion files
+.idea
+cmake-build-debug
+
 #build directories
 /build*
 


### PR DESCRIPTION
This ignores the default directories generated by CLion.

Other projects that do this, for reference:

https://github.com/lballabio/QuantLib/blob/master/.gitignore
https://github.com/aws/aws-sdk-cpp/blob/master/.gitignore
https://github.com/zhuhaow/libnekit-c/commit/32d77b609e67e9e2f3eb27ea9a66540a4979bc3b