### PR TITLE
Fix SC try / catch behaviour for primitive exception errors

### DIFF
--- a/lang/LangPrimSource/PyrPrimitive.cpp
+++ b/lang/LangPrimSource/PyrPrimitive.cpp
@@ -3829,7 +3829,7 @@ void doPrimitive(VMGlobals* g, PyrMethod* meth, int numArgsPushed)
 		g->lastExceptions[g->thread] = std::make_pair(std::current_exception(), meth);
 		err = errException;
 	} catch (...) {
-		g->lastExceptions[g->thread] = std::make_pair(std::make_exception_ptr(nullptr), meth);
+		g->lastExceptions[g->thread] = std::make_pair(nullptr, meth);
 		err = errException;
 	}
 	if (err <= errNone) g->sp -= g->numpop;
@@ -3870,7 +3870,7 @@ void doPrimitiveWithKeys(VMGlobals* g, PyrMethod* meth, int allArgsPushed, int n
 			g->lastExceptions[g->thread] = std::make_pair(std::current_exception(), meth);
 			err = errException;
 		} catch (...) {
-			g->lastExceptions[g->thread] = std::make_pair(std::make_exception_ptr(nullptr), meth);
+			g->lastExceptions[g->thread] = std::make_pair(nullptr, meth);
 			err = errException;
 		}
 		if (err <= errNone) g->sp -= g->numpop;
@@ -3938,7 +3938,7 @@ void doPrimitiveWithKeys(VMGlobals* g, PyrMethod* meth, int allArgsPushed, int n
 			g->lastExceptions[g->thread] = std::make_pair(std::current_exception(), meth);
 			err = errException;
 		} catch (...) {
-			g->lastExceptions[g->thread] = std::make_pair(std::make_exception_ptr(nullptr), meth);
+			g->lastExceptions[g->thread] = std::make_pair(nullptr, meth);
 			err = errException;
 		}
 		if (err <= errNone) g->sp -= g->numpop;

--- a/lang/LangPrimSource/PyrPrimitive.cpp
+++ b/lang/LangPrimSource/PyrPrimitive.cpp
@@ -297,7 +297,7 @@ int prPrimitiveErrorString(struct VMGlobals *g, int numArgsPushed)
 {
 	PyrSlot *a;
 	PyrString *string;
-	const char *str;
+	std::string str;
 	std::exception_ptr lastPrimitiveException;
 	char *lastPrimitiveExceptionClass, *lastPrimitiveExceptionMethod;
 
@@ -326,21 +326,18 @@ int prPrimitiveErrorString(struct VMGlobals *g, int numArgsPushed)
 				} catch(const std::exception& e) {
 					
 					const char *errorString = e.what();
-					std::string result = std::string("caught exception \'") + errorString + "\' in primitive in method " + lastPrimitiveExceptionClass + ":" + lastPrimitiveExceptionMethod;
-					string = newPyrString(g->gc, result.c_str(), 0, true);
-					SetObject(a, string);
-					return errNone;
+					str = std::string("caught exception \'") + errorString + "\' in primitive in method " + lastPrimitiveExceptionClass + ":" + lastPrimitiveExceptionMethod;
+					break;
 				}
 			} else {
-				std::string result = std::string("caught unknown exception in primitive in method ") + lastPrimitiveExceptionClass + ":" + lastPrimitiveExceptionMethod;
-				str = result.c_str();
+				str = std::string("caught unknown exception in primitive in method ") + lastPrimitiveExceptionClass + ":" + lastPrimitiveExceptionMethod;
 				break;
 			}
 			break;
 		}
 		default : str = "Failed.";
 	}
-	string = newPyrString(g->gc, str, 0, true);
+	string = newPyrString(g->gc, str.c_str(), 0, true);
 	SetObject(a, string);
 	return errNone;
 }

--- a/lang/LangSource/VMGlobals.h
+++ b/lang/LangSource/VMGlobals.h
@@ -30,6 +30,7 @@ Each virtual machine has a copy of VMGlobals, which contains the state of the vi
 #include "SC_AllocPool.h"
 #include "SC_RGen.h"
 #include <setjmp.h>
+#include <map>
 
 #define TAILCALLOPTIMIZE 1
 
@@ -77,6 +78,9 @@ struct VMGlobals {
 
 	// scratch context
 	long execMethod;
+	
+	// primitive exceptions
+	std::map<PyrThread*, std::pair<std::exception_ptr, PyrMethod*>> lastExceptions;
 } ;
 
 inline void FifoMsg::Perform(struct VMGlobals* g)


### PR DESCRIPTION
- the previous version posted exception errors in ```doPrimitive```, rather than setting them in the Error via ```prPrimitiveErrorString``` as for other primitive errors. This prevented sclang try / catch from truly catching the error.
- This could be annoying in cases like network music situations, where a stream of errors resulting from another host going down could not be handled as desired even though the problem had nothing to do with SC, or even the local machine.
- this version fixes that, and makes the error message clearer and more informative

I'd be grateful if someone can check this and confirm this is the proper/best way to handle this.