### PR TITLE
Add missing method 'recordingsDir'

### DIFF
--- a/HelpSource/Classes/Platform.schelp
+++ b/HelpSource/Classes/Platform.schelp
@@ -68,8 +68,8 @@ platform specific path separator
 method:: resourceDir
 platform specific resource directory
 
-method:: defaultTempDir
-default directory for temporary files
+method:: recordingsDir 
+platform recordings directory
 
 subsection:: Features
 
@@ -91,6 +91,7 @@ recompile class library
 
 
 subsection:: Directories and filesystem stuff
+
 method:: classLibraryDir
 location of the bundled class library
 
@@ -100,14 +101,17 @@ location of the bundled help files
 method:: systemAppSupportDir
 system application support directory
 
+method:: systemExtensionDir
+system extension directory (see link::Guides/UsingExtensions::)
+
+method:: userHomeDir
+user home directory
+
 method:: userAppSupportDir
 user application support directory
 
 method:: userConfigDir
 directory for configuration files
-
-method:: systemExtensionDir
-system extension directory (see link::Guides/UsingExtensions::)
 
 method:: userExtensionDir
 user extension directory (see link::Guides/UsingExtensions::)
@@ -118,11 +122,11 @@ platform specific directory for class files (see link::Guides/UsingExtensions::)
 method:: pathSeparator
 platform specific path separator
 
+method:: recordingsDir
+platform recordings directory
+
 method:: resourceDir
 platform specific resource directory
-
-method:: recordingsDir
-recording directory
 
 method:: defaultTempDir
 default directory for temporary files

--- a/HelpSource/Classes/Platform.schelp
+++ b/HelpSource/Classes/Platform.schelp
@@ -44,14 +44,17 @@ location of the bundled help files
 method:: systemAppSupportDir
 system application support directory
 
+method:: systemExtensionDir
+system extension directory (see link::Guides/UsingExtensions::)
+
+method:: userHomeDir
+user home directory
+
 method:: userAppSupportDir
 user application support directory
 
 method:: userConfigDir
 directory for configuration files
-
-method:: systemExtensionDir
-system extension directory (see link::Guides/UsingExtensions::)
 
 method:: userExtensionDir
 user extension directory (see link::Guides/UsingExtensions::)

--- a/HelpSource/Classes/Platform.schelp
+++ b/HelpSource/Classes/Platform.schelp
@@ -71,6 +71,9 @@ platform specific resource directory
 method:: recordingsDir 
 platform recordings directory
 
+method:: defaultTempDir
+default directory for temporary files
+
 subsection:: Features
 
 method:: when

--- a/SCClassLibrary/Platform/Platform.sc
+++ b/SCClassLibrary/Platform/Platform.sc
@@ -50,6 +50,8 @@ Platform {
 	resourceDir { _Platform_resourceDir }
 	*resourceDir { ^thisProcess.platform.resourceDir }
 
+	recordingsDir { ^thisProcess.platform.recordingsDir }
+
 	defaultTempDir { ^this.subclassResponsibility() }
 	*defaultTempDir { ^thisProcess.platform.defaultTempDir }
 

--- a/SCClassLibrary/Platform/Platform.sc
+++ b/SCClassLibrary/Platform/Platform.sc
@@ -50,7 +50,7 @@ Platform {
 	resourceDir { _Platform_resourceDir }
 	*resourceDir { ^thisProcess.platform.resourceDir }
 
-	recordingsDir { ^thisProcess.platform.recordingsDir }
+	*recordingsDir { ^thisProcess.platform.recordingsDir }
 
 	defaultTempDir { ^this.subclassResponsibility() }
 	*defaultTempDir { ^thisProcess.platform.defaultTempDir }


### PR DESCRIPTION
This PR adds the already documented but missing class method 'recordingsDir' to Platform.sc. I also added documentation for the method 'userHomeDir'. 