### PR TITLE
class library: Implement association of spec to control name during SynthDef build

### DIFF
--- a/SCClassLibrary/Common/Audio/SynthDef.sc
+++ b/SCClassLibrary/Common/Audio/SynthDef.sc
@@ -19,6 +19,7 @@ SynthDef {
 	var <>desc, <>metadata;
 
 	classvar <synthDefDir;
+	classvar <buildSpecs;
 
 	*synthDefDir_ { arg dir;
 		if (dir.last.isPathSeparator.not )
@@ -35,6 +36,10 @@ SynthDef {
 	*new { arg name, ugenGraphFunc, rates, prependArgs, variants, metadata;
 		^super.newCopyArgs(name.asSymbol).variants_(variants).metadata_(metadata).children_(Array.new(64))
 			.build(ugenGraphFunc, rates, prependArgs)
+	}
+
+	*addBuildSpec { |key, spec|
+		buildSpecs[key] = spec.asSpec;
 	}
 
 	storeArgs { ^[name, func] }
@@ -73,6 +78,7 @@ SynthDef {
 		controls = nil;
 		controlIndex = 0;
 		maxLocalBufs = nil;
+		buildSpecs = Dictionary.new;
 	}
 	buildUgenGraph { arg func, rates, prependArgs;
 		var result;

--- a/SCClassLibrary/Common/Core/Symbol.sc
+++ b/SCClassLibrary/Common/Core/Symbol.sc
@@ -237,6 +237,21 @@ Symbol {
 		^NamedControl.ar(this, val, lag)
 	}
 
+	krSpec{ |default, spec, lag, fixedLag = false|
+		SynthDef.addBuildSpec(this, spec);
+		^this.kr(default, lag, fixedLag)
+	}
+
+	irSpec { |default, spec, lag, fixedLag = false|
+		SynthDef.addBuildSpec(this, spec);
+		^this.ir(default, lag, fixedLag)
+	}
+
+	arSpec{ |default, spec, lag|
+		SynthDef.addBuildSpec(this, spec);
+		^this.ar(default, lag)
+	}
+
 	matchOSCAddressPattern { arg addressPattern;
 		_Symbol_matchOSCPattern
 		^this.primitiveFailed


### PR DESCRIPTION
edit (by @lfsaw): original discussion here: http://new-supercollider-mailing-lists-forums-use-these.2681727.n2.nabble.com/automatically-associate-ControlSpecs-to-e-g-NDef-objects-td7632480.html