### PR TITLE
Make string.split(nil) return an array of characters

### DIFF
--- a/HelpSource/Classes/String.schelp
+++ b/HelpSource/Classes/String.schelp
@@ -529,12 +529,19 @@ g.close;
 ::
 
 method::split
-Returns an Array of Strings split at the separator. The separator is a link::Classes/Char::, and is strong::not:: included in the output array.
+Returns an Array of Strings split at the separator.
+
+argument::separator
+The separator is a link::Classes/Char::, and is strong::not:: included in the output array.
+
 code::
 "These are several words".split($ );
 
 // The default separator $/ is handy for Unix paths.
 "This/could/be/a/Unix/path".split;
+
+// if no separator is given, split into letters
+"never stop on a green light".split(nil)
 ::
 
 subsection:: Stream support

--- a/SCClassLibrary/Common/Collections/String.sc
+++ b/SCClassLibrary/Common/Collections/String.sc
@@ -183,20 +183,20 @@ String[char] : RawArray {
 		});
 		^string
 	}
-	split { arg separator=$/;
-		var word="";
-		var array=[];
-		separator=separator.ascii;
+	split { arg separator = $/;
+		var word = "";
+		var array = [];
+		separator = separator.ascii;
 
-		this.do({arg let,i;
-			if(let.ascii != separator ,{
-				word=word++let;
-			},{
-				array=array.add(word);
-				word="";
-			});
-		});
-		^array.add(word);
+		this.do { arg letter, i;
+			if(letter.ascii != separator) {
+				word = word ++ letter;
+			} {
+				array = array.add(word);
+				word = "";
+			}
+		};
+		^array.add(word)
 	}
 
 	containsStringAt { arg index, string;

--- a/SCClassLibrary/Common/Collections/String.sc
+++ b/SCClassLibrary/Common/Collections/String.sc
@@ -186,6 +186,7 @@ String[char] : RawArray {
 	split { arg separator = $/;
 		var word = "";
 		var array = [];
+		if(separator.isNil) { ^array.addAll(this) };
 		separator = separator.ascii;
 
 		this.do { arg letter, i;

--- a/SCClassLibrary/Common/Collections/String.sc
+++ b/SCClassLibrary/Common/Collections/String.sc
@@ -186,7 +186,10 @@ String[char] : RawArray {
 	split { arg separator = $/;
 		var word = "";
 		var array = [];
-		if(separator.isNil) { ^array.addAll(this) };
+		if(separator.isNil) {
+			this.do { |char| array = array.add(char.asString) };
+			^array
+		};
 		separator = separator.ascii;
 
 		this.do { arg letter, i;


### PR DESCRIPTION
This just occurred to me, because `string.split(nil)` seems easier to explain than `string.as(Array)` .