### PR TITLE
Disable failing test TestBus:test_free

### DIFF
--- a/testsuite/classlibrary/TestBus.sc
+++ b/testsuite/classlibrary/TestBus.sc
@@ -1,7 +1,7 @@
 
 TestBus : UnitTest {
 
-	test_free {
+	ignore_test_free {
 		var s,busses,numBusses;
 		s = Server.default;
 		s.newAllocators;


### PR DESCRIPTION
this fixes #2758 by temporarily disabling the failing test `TestBus:test_free`. as a quick fix, i have prefixed the test name with `ignore_` so UnitTesting will not notice it.

#2760 and #2761 are the proper fixes, but with all due respect to the productive discussion and work going into them, they are taking too long. failing tests in master are pretty urgent. we shouldn't accept any PR with failing tests.

once a proper fixed is merged in, the test should be reenabled.