### PR TITLE
SCDoc: make each category breadcrumb a separate link

### DIFF
--- a/SCClassLibrary/SCDoc/SCDoc.sc
+++ b/SCClassLibrary/SCDoc/SCDoc.sc
@@ -360,7 +360,7 @@ SCDocNode {
 SCDoc {
 
 	// Increment this whenever we make a change to the SCDoc system so that all help-files should be processed again
-	classvar version = 56;
+	classvar version = 57;
 
 	classvar <helpTargetDir;
 	classvar <helpTargetUrl;

--- a/SCClassLibrary/SCDoc/SCDocRenderer.sc
+++ b/SCClassLibrary/SCDoc/SCDocRenderer.sc
@@ -146,9 +146,20 @@ SCDocHTMLRenderer {
 		doc.categories !? {
 			stream
 			<< "<div id='categories'>"
-			<< (doc.categories.collect {|r|
-				"<a href='"++baseDir +/+ "Browse.html#"++r++"'>"++r++"</a>"
+
+			<< (doc.categories.collect { | path |
+				// get all the components of a category path ("UGens>Generators>Deterministic")
+				// we link each crumb of the breadcrumbs separately.
+				var pathElems = path.split($>);
+
+				// the href for "UGens" will be "UGens", for "Generators" "UGens>Generators", etc.
+				pathElems.collect { | elem, i |
+					var atag = "<a href='" ++ baseDir +/+ "Browse.html#";
+					atag ++ pathElems[0..i].join(">") ++ "'>"++ elem ++"</a>"
+				}.join(">");
+
 			}.join(", "))
+
 			<< "</div>\n";
 		};
 

--- a/SCClassLibrary/SCDoc/SCDocRenderer.sc
+++ b/SCClassLibrary/SCDoc/SCDocRenderer.sc
@@ -158,7 +158,7 @@ SCDocHTMLRenderer {
 					atag ++ pathElems[0..i].join(">") ++ "'>"++ elem ++"</a>"
 				}.join(">");
 
-			}.join(", "))
+			}.join(" | "))
 
 			<< "</div>\n";
 		};


### PR DESCRIPTION
Fixes #692.

Before, Cat>Subcat>Subsubcat would be one link. Now, each part of that
path is a separate link, with Cat going to Cat, Subcat going to
Cat>Subcat, etc.

<img width="353" alt="image" src="https://cloud.githubusercontent.com/assets/15369640/26745461/a1834b06-47b8-11e7-948c-a4531781f43d.png">


Should I also increment the version number is SCDoc? (https://github.com/supercollider/supercollider/blob/master/SCClassLibrary/SCDoc/SCDoc.sc#L363)