### PR TITLE
Buffer and Bus validity checks and Errors

### DIFF
--- a/SCClassLibrary/Common/Control/Buffer.sc
+++ b/SCClassLibrary/Common/Control/Buffer.sc
@@ -330,6 +330,7 @@ Buffer {
 
 	write { arg path, headerFormat = "aiff", sampleFormat = "int24", numFrames = -1,
 						startFrame = 0, leaveOpen = false, completionMessage;
+		if(bufnum.isNil) { Error("Cannot call % on a % that has been freed".format(thisMethod.name, this.class.name)).throw };
 		path = path ?? { thisProcess.platform.recordingsDir +/+ "SC_" ++ Date.localtime.stamp ++ "." ++ headerFormat };
 		server.listSendMsg(
 			this.writeMsg(path, headerFormat, sampleFormat, numFrames, startFrame,
@@ -348,7 +349,9 @@ Buffer {
 	free { arg completionMessage;
 		if(bufnum.notNil) {
 			server.listSendMsg( this.freeMsg(completionMessage) )
-		};
+		} {
+			(this.class.name + " has already been freed").warn
+		}
 	}
 
 	freeMsg { arg completionMessage;
@@ -359,8 +362,6 @@ Buffer {
 			msg = ["/b_free", bufnum, completionMessage.value(this)];
 			bufnum = numFrames = numChannels = sampleRate = path = startFrame = nil;
 			^msg
-		} {
-			^nil
 		}
 	}
 
@@ -370,6 +371,7 @@ Buffer {
 	}
 
 	zero { arg completionMessage;
+		if(bufnum.isNil) { Error("Cannot call % on a % that has been freed".format(thisMethod.name, this.class.name)).throw };
 		server.listSendMsg(this.zeroMsg(completionMessage))
 	}
 
@@ -378,6 +380,7 @@ Buffer {
 	}
 
 	set { arg index, float ... morePairs;
+		if(bufnum.isNil) { Error("Cannot call % on a % that has been freed".format(thisMethod.name, this.class.name)).throw };
 		server.listSendMsg([\b_set, bufnum, index, float] ++ morePairs)
 	}
 
@@ -386,6 +389,7 @@ Buffer {
 	}
 
 	setn { arg ... args;
+		if(bufnum.isNil) { Error("Cannot call % on a % that has been freed".format(thisMethod.name, this.class.name)).throw };
 		server.sendMsg(*this.setnMsg(*args));
 	}
 
@@ -407,6 +411,7 @@ Buffer {
 	}
 
 	get { arg index, action;
+		if(bufnum.isNil) { Error("Cannot call % on a % that has been freed".format(thisMethod.name, this.class.name)).throw };
 		OSCFunc({ |message|
 			// The server replies with a message of the form [/b_set, bufnum, index, value].
 			// We want "value," which is at index 3.
@@ -420,6 +425,7 @@ Buffer {
 	}
 
 	getn { arg index, count, action;
+		if(bufnum.isNil) { Error("Cannot call % on a % that has been freed".format(thisMethod.name, this.class.name)).throw };
 		OSCFunc({ |message|
 			// The server replies with a message of the form
 			// [/b_setn, bufnum, starting index, length, ...sample values].
@@ -434,6 +440,7 @@ Buffer {
 	}
 
 	fill { arg startAt, numFrames, value ... more;
+		if(bufnum.isNil) { Error("Cannot call % on a % that has been freed".format(thisMethod.name, this.class.name)).throw };
 		server.listSendMsg(["/b_fill", bufnum, startAt, numFrames.asInt, value] ++ more)
 	}
 
@@ -442,6 +449,7 @@ Buffer {
 	}
 
 	normalize { arg newmax=1, asWavetable=false;
+		if(bufnum.isNil) { Error("Cannot call % on a % that has been freed".format(thisMethod.name, this.class.name)).throw };
 		server.listSendMsg(["/b_gen", bufnum, if(asWavetable, "wnormalize", "normalize"), newmax])
 	}
 
@@ -450,6 +458,7 @@ Buffer {
 	}
 
 	gen { arg genCommand, genArgs, normalize=true, asWavetable=true, clearFirst=true;
+		if(bufnum.isNil) { Error("Cannot call % on a % that has been freed".format(thisMethod.name, this.class.name)).throw };
 		server.listSendMsg(["/b_gen", bufnum, genCommand,
 			normalize.binaryValue
 			+ (asWavetable.binaryValue * 2)
@@ -466,6 +475,7 @@ Buffer {
 	}
 
 	sine1 { arg amps, normalize=true, asWavetable=true, clearFirst=true;
+		if(bufnum.isNil) { Error("Cannot call % on a % that has been freed".format(thisMethod.name, this.class.name)).throw };
 		server.listSendMsg(["/b_gen", bufnum, "sine1",
 			normalize.binaryValue
 			+ (asWavetable.binaryValue * 2)
@@ -474,6 +484,7 @@ Buffer {
 	}
 
 	sine2 { arg freqs, amps, normalize=true, asWavetable=true, clearFirst=true;
+		if(bufnum.isNil) { Error("Cannot call % on a % that has been freed".format(thisMethod.name, this.class.name)).throw };
 		server.listSendMsg(["/b_gen", bufnum, "sine2",
 			normalize.binaryValue
 			+ (asWavetable.binaryValue * 2)
@@ -482,6 +493,7 @@ Buffer {
 	}
 
 	sine3 { arg freqs, amps, phases, normalize=true, asWavetable=true, clearFirst=true;
+		if(bufnum.isNil) { Error("Cannot call % on a % that has been freed".format(thisMethod.name, this.class.name)).throw };
 		server.listSendMsg(["/b_gen", bufnum, "sine3",
 			normalize.binaryValue
 			+ (asWavetable.binaryValue * 2)
@@ -490,6 +502,7 @@ Buffer {
 	}
 
 	cheby { arg amplitudes, normalize=true, asWavetable=true, clearFirst=true;
+		if(bufnum.isNil) { Error("Cannot call % on a % that has been freed".format(thisMethod.name, this.class.name)).throw };
 		server.listSendMsg(["/b_gen", bufnum, "cheby",
 			normalize.binaryValue
 			+ (asWavetable.binaryValue * 2)
@@ -530,6 +543,7 @@ Buffer {
 	}
 
 	copyData { arg buf, dstStartAt = 0, srcStartAt = 0, numSamples = -1;
+		if(bufnum.isNil) { Error("Cannot call % on a % that has been freed".format(thisMethod.name, this.class.name)).throw };
 		server.listSendMsg(
 			this.copyMsg(buf, dstStartAt, srcStartAt, numSamples)
 		)
@@ -541,6 +555,7 @@ Buffer {
 
 	// close a file, write header, after DiskOut usage
 	close { arg completionMessage;
+		if(bufnum.isNil) { Error("Cannot call % on a % that has been freed".format(thisMethod.name, this.class.name)).throw };
 		server.listSendMsg( this.closeMsg(completionMessage) )
 	}
 
@@ -648,6 +663,7 @@ Buffer {
 	}
 
 	play { arg loop = false, mul = 1;
+		if(bufnum.isNil) { Error("Cannot call % on a % that has been freed".format(thisMethod.name, this.class.name)).throw };
 		^{ var player;
 			player = PlayBuf.ar(numChannels, bufnum, BufRateScale.kr(bufnum),
 				loop: loop.binaryValue);

--- a/SCClassLibrary/Common/Control/Bus.sc
+++ b/SCClassLibrary/Common/Control/Bus.sc
@@ -47,6 +47,7 @@ Bus {
 	}
 
 	set { arg ... values; // shouldn't be larger than this.numChannels
+		if(index.isNil) { Error("Cannot call % on a % that has been freed".format(thisMethod.name, this.class.name)).throw };
 		if(this.isSettable, {
 			server.sendBundle(nil, (["/c_set"]
 				++ values.collect({ arg v, i; [index + i , v] }).flat));
@@ -61,6 +62,7 @@ Bus {
 	}
 
 	setn { arg values;
+		if(index.isNil) { Error("Cannot call % on a % that has been freed".format(thisMethod.name, this.class.name)).throw };
 		// could throw an error if values.size > numChannels
 		if(this.isSettable, {
 			server.sendBundle(nil,
@@ -73,6 +75,7 @@ Bus {
 		}, { error("Cannot set an audio rate bus"); ^nil });
 	}
 	setAt { |offset ... values|
+		if(index.isNil) { Error("Cannot call % on a % that has been freed".format(thisMethod.name, this.class.name)).throw };
 		// shouldn't be larger than this.numChannels - offset
 		if(this.isSettable, {
 			server.sendBundle(nil, (["/c_set"]
@@ -80,6 +83,7 @@ Bus {
 		}, { error("Cannot set an audio rate bus") });
 	}
 	setnAt { |offset, values|
+		if(index.isNil) { Error("Cannot call % on a % that has been freed".format(thisMethod.name, this.class.name)).throw };
 		// could throw an error if values.size > numChannels
 		if(this.isSettable, {
 			server.sendBundle(nil,
@@ -87,6 +91,7 @@ Bus {
 		}, { error("Cannot set an audio rate bus")});
 	}
 	setPairs { | ... pairs|
+		if(index.isNil) { Error("Cannot call % on a % that has been freed".format(thisMethod.name, this.class.name)).throw };
 		if(this.isSettable, {
 			server.sendBundle(nil, (["/c_set"]
 				++ pairs.clump(2).collect({ arg pair; [pair[0] + index, pair[1]] }).flat));
@@ -94,6 +99,7 @@ Bus {
 	}
 
 	get { arg action;
+		if(index.isNil) { Error("Cannot call % on a % that has been freed".format(thisMethod.name, this.class.name)).throw };
 		if(numChannels == 1) {
 			action = action ? { |vals| "Bus % index: % value: %.\n".postf(rate, index, vals); };
 			OSCFunc({ |message|
@@ -108,6 +114,7 @@ Bus {
 	}
 
 	getn { arg count, action;
+		if(index.isNil) { Error("Cannot call % on a % that has been freed".format(thisMethod.name, this.class.name)).throw };
 		action = action ? { |vals| "Bus % index: % values: %.\n".postf(rate, index, vals) };
 		OSCFunc({ |message|
 			// The response is of the form [/c_set, index, count, ...values].
@@ -126,6 +133,7 @@ Bus {
 	}
 
 	getSynchronous {
+		if(index.isNil) { Error("Cannot call % on a % that has been freed".format(thisMethod.name, this.class.name)).throw };
 		if (not(this.isSettable)) {
 			Error("Bus-getSynchronous only works for control-rate busses").throw;
 		} {
@@ -134,6 +142,7 @@ Bus {
 	}
 
 	getnSynchronous { |count|
+		if(index.isNil) { Error("Cannot call % on a % that has been freed".format(thisMethod.name, this.class.name)).throw };
 		if (not(this.isSettable)) {
 			Error("Bus-getnSynchronous only works for control-rate busses").throw;
 		} {
@@ -142,6 +151,7 @@ Bus {
 	}
 
 	setSynchronous { |... values|
+		if(index.isNil) { Error("Cannot call % on a % that has been freed".format(thisMethod.name, this.class.name)).throw };
 		if (not(this.isSettable)) {
 			Error("Bus-setSynchronous only works for control-rate busses").throw;
 		} {
@@ -154,6 +164,7 @@ Bus {
 	}
 
 	setnSynchronous { |values|
+		if(index.isNil) { Error("Cannot call % on a % that has been freed".format(thisMethod.name, this.class.name)).throw };
 		if (not(this.isSettable)) {
 			Error("Bus-setnSynchronous only works for control-rate busses").throw;
 		} {
@@ -162,6 +173,7 @@ Bus {
 	}
 
 	fill { arg value, numChans;
+		if(index.isNil) { Error("Cannot call % on a % that has been freed".format(thisMethod.name, this.class.name)).throw };
 		// could throw an error if numChans > numChannels
 		server.sendBundle(nil,
 			["/c_fill", index, numChans, value]);
@@ -173,7 +185,7 @@ Bus {
 
 
 	free { arg clear = false;
-		if(index.isNil, { (this.asString + " has already been freed").warn; ^this });
+		if(index.isNil) { (this.class.name + " has already been freed").warn; ^this };
 		if(rate == \audio, {
 			server.audioBusAllocator.free(index);
 		}, {
@@ -208,10 +220,12 @@ Bus {
 
 	// alternate syntaxes
 	setAll { arg value;
+		if(index.isNil) { Error("Cannot call % on a % that has been freed".format(thisMethod.name, this.class.name)).throw };
 		this.fill(value, numChannels);
 	}
 
 	value_ { arg value;
+		if(index.isNil) { Error("Cannot call % on a % that has been freed".format(thisMethod.name, this.class.name)).throw };
 		this.fill(value, numChannels);
 	}
 
@@ -254,6 +268,7 @@ Bus {
 	}
 
 	play { arg target=0, outbus, fadeTime, addAction=\addToTail;
+		if(index.isNil) { Error("Cannot call % on a % that has been freed".format(thisMethod.name, this.class.name)).throw };
 		if(this.isAudioOut.not, { // returns a Synth
 			^{ this.ar }.play(target, outbus, fadeTime, addAction)
 		})


### PR DESCRIPTION
Fixes #2851 (and see discussion #2846) 

Some methods need to check that a Buffer/Bus is still valid before doing anything potentially destructive. The Server interprets 'nil' as zero in received messages. This means that Buffer and Bus index:0 are at risk of being modified when some methods are called on previously freed Buffers/Busses. 

Hopefully, this solution is acceptable. Please review and critique away! :)
