### PR TITLE
scdoc: Append "| SuperCollider Help" to all <title> elements

### DIFF
--- a/HelpSource/BrokenLink.html
+++ b/HelpSource/BrokenLink.html
@@ -1,4 +1,5 @@
-<html>
+<!doctype html>
+<html lang="en">
 <head>
     <title>Broken link</title>
     <link rel='stylesheet' href='./scdoc.css' type='text/css' />

--- a/HelpSource/Browse.html
+++ b/HelpSource/Browse.html
@@ -1,10 +1,14 @@
-<html>
+<!doctype html>
+<html lang="en">
 <head>
-    <title>Document Browser</title>
+    <title>Document Browser | SuperCollider Help</title>
     <link rel='stylesheet' href='./scdoc.css' type='text/css' />
     <link rel='stylesheet' href='./custom.css' type='text/css' />
     <link rel='stylesheet' href='./browse.css' type='text/css' />
     <meta http-equiv='Content-Type' content='text/html; charset=UTF-8' />
+    <script>
+        var scdoc_title = "Document Browser";
+    </script>
     <script src="docmap.js" type="text/javascript"></script>
     <script src="scdoc.js" type="text/javascript"></script>
     <script src="browse.js"></script>

--- a/HelpSource/Overviews/Classes.html
+++ b/HelpSource/Overviews/Classes.html
@@ -1,9 +1,13 @@
-<html>
+<!doctype html>
+<html lang="en">
 <head>
-    <title>Classes</title>
+    <title>Classes | SuperCollider Help</title>
     <link rel='stylesheet' href='../scdoc.css' type='text/css' />
     <link rel='stylesheet' href='../custom.css' type='text/css' />
     <meta http-equiv='Content-Type' content='text/html; charset=UTF-8' />
+    <script>
+        var scdoc_title = "Classes";
+    </script>
     <script src="../docmap.js" type="text/javascript"></script>
     <script src="../scdoc.js" type="text/javascript"></script>
 <noscript>

--- a/HelpSource/Overviews/Documents.html
+++ b/HelpSource/Overviews/Documents.html
@@ -1,9 +1,13 @@
-<html>
+<!doctype html>
+<html lang="en">
 <head>
-    <title>Documents</title>
+    <title>Documents | SuperCollider Help</title>
     <link rel='stylesheet' href='../scdoc.css' type='text/css' />
     <link rel='stylesheet' href='../custom.css' type='text/css' />
     <meta http-equiv='Content-Type' content='text/html; charset=UTF-8' />
+    <script>
+        var scdoc_title = "Documents";
+    </script>
     <script src="../docmap.js" type="text/javascript"></script>
     <script src="../scdoc.js" type="text/javascript"></script>
 <noscript>

--- a/HelpSource/Overviews/Methods.html
+++ b/HelpSource/Overviews/Methods.html
@@ -1,9 +1,13 @@
-<html>
+<!doctype html>
+<html lang="en">
 <head>
-    <title>Methods</title>
+    <title>Methods | SuperCollider Help</title>
     <link rel='stylesheet' href='../scdoc.css' type='text/css' />
     <link rel='stylesheet' href='../custom.css' type='text/css' />
     <meta http-equiv='Content-Type' content='text/html; charset=UTF-8' />
+    <script>
+        var scdoc_title = "Methods";
+    </script>
     <script src="../docmap.js" type="text/javascript"></script>
     <script src="../scdoc.js" type="text/javascript"></script>
 <noscript>

--- a/HelpSource/Search.html
+++ b/HelpSource/Search.html
@@ -1,9 +1,13 @@
-<html>
+<!doctype html>
+<html lang="en">
 <head>
-    <title>Search</title>
+    <title>Search | SuperCollider Help</title>
     <link rel='stylesheet' href='./scdoc.css' type='text/css' />
     <link rel='stylesheet' href='./custom.css' type='text/css' />
     <meta http-equiv='Content-Type' content='text/html; charset=UTF-8' />
+    <script>
+        var scdoc_title = "Search";
+    </script>
     <script src="docmap.js" type="text/javascript"></script>
     <script src="scdoc.js" type="text/javascript"></script>
     <script src="search.js"></script>

--- a/HelpSource/scdoc.js
+++ b/HelpSource/scdoc.js
@@ -83,7 +83,7 @@ function resize_handler() {
 
 function addInheritedMethods() {
     if(! /\/Classes\/[^\/]+/.test(window.location.pathname)) return; // skip this if not a class doc
-    var doc = docmap["Classes/"+document.title];
+    var doc = docmap["Classes/" + scdoc_title];
     if(!doc) return;
     if(doc.implementor) {
         var sups = docmap["Classes/"+doc.implementor].superclasses;
@@ -540,7 +540,7 @@ function fixTOC() {
     li.className = "menuitem";
     var x = document.createElement("span");
     x.id = "topdoctitle";
-    x.appendChild(document.createTextNode(document.title));
+    x.appendChild(document.createTextNode(scdoc_title));
     x.onclick = function() {
         scroll(0,0);
         return false;

--- a/SCClassLibrary/SCDoc/SCDocRenderer.sc
+++ b/SCClassLibrary/SCDoc/SCDocRenderer.sc
@@ -109,6 +109,7 @@ SCDocHTMLRenderer {
 
 	*renderHeader {|stream, doc|
 		var x, cats, m, z;
+		var thisIsTheMainHelpFile;
 		var folder = doc.path.dirname;
 		var undocumented = false;
 		if(folder==".",{folder=""});
@@ -119,17 +120,34 @@ SCDocHTMLRenderer {
 			baseDir = baseDir ++ "/..";
 		};
 
+		thisIsTheMainHelpFile = (doc.title=="Help") and:
+			{((thisProcess.platform.name===\windows) and: (folder=="Help")) or: {folder==""}};
+
 		stream
-		<< "<html><head><title>" << doc.title << "</title>\n"
+		<< "<!doctype html>"
+		<< "<html lang='en'>"
+		<< "<head><title>";
+
+		if(thisIsTheMainHelpFile) {
+			stream << "SuperCollider " << Main.version << " Help";
+		} {
+			stream << doc.title << " | SuperCollider " << Main.version << " Help";
+		};
+
+		stream
+		<< "</title>\n"
 		<< "<link rel='stylesheet' href='" << baseDir << "/scdoc.css' type='text/css' />\n"
 		<< "<link rel='stylesheet' href='" << baseDir << "/frontend.css' type='text/css' />\n"
 		<< "<link rel='stylesheet' href='" << baseDir << "/custom.css' type='text/css' />\n"
 		<< "<meta http-equiv='Content-Type' content='text/html; charset=UTF-8' />\n"
+		<< "<script>\n"
+		<< "var helpRoot = '" << baseDir << "';\n"
+		<< "var scdoc_title = '" << doc.title << "';\n"
+		<< "</script>\n"
 		<< "<script src='" << baseDir << "/scdoc.js' type='text/javascript'></script>\n"
 		<< "<script src='" << baseDir << "/docmap.js' type='text/javascript'></script>\n" // FIXME: remove?
 		<< "<script src='" << baseDir << "/prettify.js' type='text/javascript'></script>\n"
 		<< "<script src='" << baseDir << "/lang-sc.js' type='text/javascript'></script>\n"
-		<< "<script type='text/javascript'>var helpRoot='" << baseDir << "';</script>\n"
 		<< "</head>\n";
 
 		stream
@@ -153,7 +171,7 @@ SCDocHTMLRenderer {
 		};
 
 		stream << "<h1>";
-		if((doc.title=="Help") and: {((thisProcess.platform.name===\windows) and: (folder=="Help")) or: {folder==""}}) {
+		if(thisIsTheMainHelpFile) {
 			stream << "SuperCollider " << Main.version;
 			stream << "<span class='headerimage'><img src='" << baseDir << "/images/SC_icon.png'/></span>";
 		} {

--- a/SCClassLibrary/SCDoc/SCDocRenderer.sc
+++ b/SCClassLibrary/SCDoc/SCDocRenderer.sc
@@ -120,8 +120,10 @@ SCDocHTMLRenderer {
 			baseDir = baseDir ++ "/..";
 		};
 
-		thisIsTheMainHelpFile = (doc.title=="Help") and:
-			{((thisProcess.platform.name===\windows) and: (folder=="Help")) or: {folder==""}};
+		thisIsTheMainHelpFile = (doc.title == "Help") and: {
+			(folder == "") or:
+			{ (thisProcess.platform.name === \windows) and: { folder == "Help" } }
+		};
 
 		stream
 		<< "<!doctype html>"


### PR DESCRIPTION
appends the suffix `| SuperCollider [version] Help` to the <title> element of every generated HTML file in SCDoc. (It's not possible to dynamically get the version in some static files like Search and Browse, so I just added `| SuperCollider Help` to those.) also, added html5 doctypes and lang attributes while we're at it.

(the new `<script>` tags don't have `type="text/javascript"` because [its no longer required](https://www.w3.org/TR/html5/scripting-1.html#attr-script-type).)

for some reason this changed the style of the links in the header, i dunno why.