### PR TITLE
scdoc: lighten horizontal lines

### DIFF
--- a/HelpSource/scdoc.css
+++ b/HelpSource/scdoc.css
@@ -277,7 +277,7 @@ h1 {
 }
 
 h2 {
-    border-bottom: 2px solid #ccc;
+    border-bottom: 1px solid #ddd;
     margin-top: 1.0em;
     text-align: left;
     margin-bottom: 2px;


### PR DESCRIPTION
for #2943.

make horizontal lines under `<h2>` elements less bold.

sorry, github's image upload feature is glitchin out on me and i can't upload screenshots.