### PR TITLE
scdoc: redesign label/categories

### DIFF
--- a/HelpSource/Browse.html
+++ b/HelpSource/Browse.html
@@ -18,7 +18,7 @@
 <ul id="menubar"></ul>
 <div class='contents'>
 <div class='header'>
-    <div id='label'>SuperCollider</div>
+    <div id='label'><span id='folder'>SuperCollider</span></div>
     <h1>Document Browser</h1>
     <div id='summary'>Browse categories</div>
 </div>

--- a/HelpSource/OldHelpWrapper.html
+++ b/HelpSource/OldHelpWrapper.html
@@ -34,7 +34,7 @@ window.onhashchange = checkHash;
 <body onload="onLoad()">
 <div class='contents'>
 <div class='header'>
-    <div id='label'>SuperCollider OLD HELP</div>
+    <div id='label'><span id='folder'>SuperCollider Old Help</span></div>
     <h1 id="oldtitle"></h1>
     <div id="summary">
     This file still uses the old help format, please convert to <a id="newlink">the new help system</a>.

--- a/HelpSource/Overviews/Classes.html
+++ b/HelpSource/Overviews/Classes.html
@@ -125,7 +125,7 @@ function showdocs() {
 <body onload="did_load()">
 <div class='contents'>
 <div class='header'>
-    <div id='label'>SuperCollider OVERVIEWS</div>
+    <div id='label'><span id='folder'>SuperCollider Overviews</span></div>
     <h1>Classes</h1>
     <div id='summary'>Alphabetical index of all classes</div>
 </div>

--- a/HelpSource/Overviews/Documents.html
+++ b/HelpSource/Overviews/Documents.html
@@ -130,7 +130,7 @@ function showdocs() {
 <body onload="did_load()">
 <div class='contents'>
 <div class='header'>
-    <div id='label'>SuperCollider OVERVIEWS</div>
+    <div id='label'><span id='folder'>SuperCollider Overviews</span></div>
     <h1>Documents</h1>
     <div id='summary'>Alphabetical index of all documents</div>
 </div>

--- a/HelpSource/Overviews/Methods.html
+++ b/HelpSource/Overviews/Methods.html
@@ -240,7 +240,7 @@ window.onhashchange = showmethods;
 <body onload="did_load()">
 <div class='contents'>
 <div class='header'>
-    <div id='label'>SuperCollider OVERVIEWS</div>
+    <div id='label'><span id='folder'>SuperCollider Overviews</span></div>
     <h1>Methods</h1>
     <div id='summary'>Alphabetical index of all methods</div>
 </div>

--- a/HelpSource/Search.html
+++ b/HelpSource/Search.html
@@ -17,7 +17,7 @@
 
 <div class='contents'>
 <div class='header'>
-    <div id='label'>SuperCollider</div>
+    <div id='label'><span id='folder'>SuperCollider</span></div>
     <h1>Search</h1>
     <div id='summary'>Search all documents</div>
 </div>

--- a/HelpSource/scdoc.css
+++ b/HelpSource/scdoc.css
@@ -188,18 +188,15 @@ a.navlink {
 .header {
   border-bottom: 2.5px solid #000; padding-bottom:0.18em;
 }
-#label, #label a {
-    font-weight: bold;
-    color: #999;
-    border-bottom: 1px solid #bbb;
+
+#label {
+    color: #666;
+    font-size: 0.9em;
 }
+
 #summary {
     font-weight: normal;
     font-size: 1.1em;
-}
-#categories {
-    color: #888;
-    font-size: 9pt;
 }
 #related {
     text-align: right;

--- a/SCClassLibrary/SCDoc/SCDocRenderer.sc
+++ b/SCClassLibrary/SCDoc/SCDocRenderer.sc
@@ -137,15 +137,17 @@ SCDocHTMLRenderer {
 		<< "<body onload='fixTOC();prettyPrint()'>\n"
 		<< "<div class='contents'>\n"
 		<< "<div class='header'>\n"
-		<< "<div id='label'>SuperCollider " << folder.asString.toUpper;
+		<< "<div id='label'>\n"
+		<< "<span id='folder'>SuperCollider " << Main.version << " " << folder.asString;
 		if(doc.isExtension) {
 			stream << " (extension)";
 		};
-		stream << "</div>\n";
+		stream << "</span>\n";
 
 		doc.categories !? {
 			stream
-			<< "<div id='categories'>"
+			<< " | "
+			<< "<span id='categories'>"
 
 			<< (doc.categories.collect { | path |
 				// get all the components of a category path ("UGens>Generators>Deterministic")
@@ -156,12 +158,14 @@ SCDocHTMLRenderer {
 				pathElems.collect { | elem, i |
 					var atag = "<a href='" ++ baseDir +/+ "Browse.html#";
 					atag ++ pathElems[0..i].join(">") ++ "'>"++ elem ++"</a>"
-				}.join(">");
+				}.join("&#8201;&gt;&#8201;"); // &#8201; is a thin space
 
 			}.join(" | "))
 
-			<< "</div>\n";
+			<< "</span>\n";
 		};
+
+		stream << "</div>";
 
 		stream << "<h1>";
 		if((doc.title=="Help") and: {((thisProcess.platform.name===\windows) and: (folder=="Help")) or: {folder==""}}) {
@@ -799,7 +803,7 @@ SCDocHTMLRenderer {
 			<< doc.fullPath << "</a><br>"
 		};
 		stream << "link::" << doc.path << "::<br>"
-		<< "sc version: " << Main.version << "</div>"
+		<< "</div>"
 		<< "</div></body></html>";
 	}
 


### PR DESCRIPTION
towards #2943. remove horizontal line for better use of negative space, use a darker shade of gray for accessibility, uncapitalize the shouty "CLASSES," add version number to header and remove version number from footer, combine folder and categories into a single line, add thin spaces around breadcrumb `>` for better visual balance