### PR TITLE
scdoc: redesign method rendering

### DIFF
--- a/HelpSource/scdoc.css
+++ b/HelpSource/scdoc.css
@@ -288,7 +288,7 @@ h3 {
     margin-top: 2.0em;
     margin-bottom: 1px;
     text-align: left;
-    font-size: 1.2em;
+    font-size: 1.4em;
 }
 
 h4 {
@@ -343,7 +343,7 @@ pre.code {
 .method-code {
     font-family: monospace;
     font-weight: normal;
-    font-size: 105%;
+    font-size: 1.05em !important;
     margin-bottom: 0em;
     margin-top: 0.75em;
     padding: 0.25em;

--- a/HelpSource/scdoc.css
+++ b/HelpSource/scdoc.css
@@ -296,7 +296,6 @@ h4 {
     margin-bottom: 0em;
     margin-left: 0em;
     color: #777;
-    border-bottom: 1px solid #ddd;
 }
 
 dt {
@@ -341,18 +340,17 @@ pre.code {
     margin-left: -1em;
 }
 
-.methodname, .imethodname, .cmethodname {
+.method-code {
     font-family: monospace;
-    font-size: 1em;
     font-weight: normal;
+    font-size: 105%;
     margin-bottom: 0em;
     margin-top: 0.75em;
     padding: 0.25em;
     border: none;
-    background: #e7ebe7;
 }
 
-.methodname a, .imethodname a, .cmethodname a {
+a.method-name {
     color: black;
     font-weight: bold;
 }

--- a/HelpSource/scdoc.css
+++ b/HelpSource/scdoc.css
@@ -369,7 +369,6 @@ a.method-name {
 .extmethod {
     font-size: 9pt;
     color: #444;
-    background: #fee;
     padding-left: 0.2em;
     text-align: right;
 }
@@ -377,7 +376,6 @@ a.method-name {
 .supmethod {
     font-size: 9pt;
     color: #444;
-    background: #ffe;
     padding-left: 0.2em;
     text-align: right;
 }

--- a/HelpSource/scdoc.css
+++ b/HelpSource/scdoc.css
@@ -348,6 +348,8 @@ pre.code {
     margin-top: 0.75em;
     padding: 0.25em;
     border: none;
+    padding-left: 4em;
+    text-indent: -4em;
 }
 
 a.method-name {

--- a/SCClassLibrary/SCDoc/SCDocRenderer.sc
+++ b/SCClassLibrary/SCDoc/SCDocRenderer.sc
@@ -310,67 +310,66 @@ SCDocHTMLRenderer {
 					}
 					{args2.size<minArgs} {
 						minArgs = args2.size;
-					}
-				;
-				} {
-					m = nil;
-					m2 = nil;
-					mstat = 1;
-				};
-
-				x = {
-					stream << "<h3 class='method-code'>"
-					<< "<span class='method-prefix'>" << methodCodePrefix << "</span>"
-					<< "<a class='method-name' name='" << methodTypeIndicator << mname << "' href='"
-					<< baseDir << "/Overviews/Methods.html#"
-					<< mname2 << "'>" << mname2 << "</a>"
-				};
-
-				switch (mstat,
-					// getter only
-					1, { x.value; stream << args; },
-					// getter and setter
-					3, { x.value; },
-					// method not found
-					0, {
-						"SCDoc: In %\n"
-						"  Method %% not found.".format(currDoc.fullPath, methodTypeIndicator, mname2).warn;
-						x.value;
-						stream << ": METHOD NOT FOUND!";
-					}
-				);
-
-				stream << "</h3>\n";
-
-				// has setter
-				if(mstat & 2 > 0) {
-					x.value;
-					if(args2.size<2) {
-						stream << " = " << args << "</h3>\n";
-					} {
-						stream << "_(" << args << ")</h3>\n";
-					}
-				};
-
-				m = m ?? m2;
-				m !? {
-					if(m.isExtensionOf(cls) and: {icls.isNil or: {m.isExtensionOf(icls)}}) {
-						stream << "<div class='extmethod'>From extension in <a href='"
-						<< URI.fromLocalPath(m.filenameSymbol.asString).asString << "'>"
-						<< m.filenameSymbol << "</a></div>\n";
-					} {
-						if(m.ownerClass == icls) {
-							stream << "<div class='supmethod'>From implementing class</div>\n";
-						} {
-							if(m.ownerClass != cls) {
-								m = m.ownerClass.name;
-								m = if(m.isMetaClassName) {m.asString.drop(5)} {m};
-								stream << "<div class='supmethod'>From superclass: <a href='"
-								<< baseDir << "/Classes/" << m << ".html'>" << m << "</a></div>\n";
-							}
-						}
 					};
+			} {
+				m = nil;
+				m2 = nil;
+				mstat = 1;
+			};
+
+			x = {
+				stream << "<h3 class='method-code'>"
+				<< "<span class='method-prefix'>" << methodCodePrefix << "</span>"
+				<< "<a class='method-name' name='" << methodTypeIndicator << mname << "' href='"
+				<< baseDir << "/Overviews/Methods.html#"
+				<< mname2 << "'>" << mname2 << "</a>"
+			};
+
+			switch (mstat,
+				// getter only
+				1, { x.value; stream << args; },
+				// getter and setter
+				3, { x.value; },
+				// method not found
+				0, {
+					"SCDoc: In %\n"
+					"  Method %% not found.".format(currDoc.fullPath, methodTypeIndicator, mname2).warn;
+					x.value;
+					stream << ": METHOD NOT FOUND!";
+				}
+			);
+
+			stream << "</h3>\n";
+
+			// has setter
+			if(mstat & 2 > 0) {
+				x.value;
+				if(args2.size<2) {
+					stream << " = " << args << "</h3>\n";
+				} {
+					stream << "_(" << args << ")</h3>\n";
+				}
+			};
+
+			m = m ?? m2;
+			m !? {
+				if(m.isExtensionOf(cls) and: {icls.isNil or: {m.isExtensionOf(icls)}}) {
+					stream << "<div class='extmethod'>From extension in <a href='"
+					<< URI.fromLocalPath(m.filenameSymbol.asString).asString << "'>"
+					<< m.filenameSymbol << "</a></div>\n";
+				} {
+					if(m.ownerClass == icls) {
+						stream << "<div class='supmethod'>From implementing class</div>\n";
+					} {
+						if(m.ownerClass != cls) {
+							m = m.ownerClass.name;
+							m = if(m.isMetaClassName) {m.asString.drop(5)} {m};
+							stream << "<div class='supmethod'>From superclass: <a href='"
+							<< baseDir << "/Classes/" << m << ".html'>" << m << "</a></div>\n";
+						}
+					}
 				};
+			};
 		};
 
 		if(methArgsMismatch) {

--- a/SCClassLibrary/SCDoc/SCDocRenderer.sc
+++ b/SCClassLibrary/SCDoc/SCDocRenderer.sc
@@ -2,6 +2,7 @@
 HTML renderer
 */
 SCDocHTMLRenderer {
+	classvar <binaryOperatorCharacters = "!@%&*-+=|<>?/";
 	classvar currentClass, currentImplClass, currentMethod, currArg;
 	classvar currentNArgs;
 	classvar footNotes;
@@ -260,16 +261,20 @@ SCDocHTMLRenderer {
 			\genericMethod, { "" }
 		);
 
-		methodCodePrefix = switch(
-			methodType,
-			\classMethod, { if(cls.notNil) { cls.name.asString[5..] } { "" } ++ "." },
-			\instanceMethod, { "." },
-			\genericMethod, { "." }
-		);
-
 		minArgs = inf;
 		currentMethod = nil;
 		names.do {|mname|
+			methodCodePrefix = switch(
+				methodType,
+				\classMethod, { if(cls.notNil) { cls.name.asString[5..] } { "" } ++ "." },
+				\instanceMethod, {
+					// If the method name contains any valid binary operator character, remove the
+					// "." to reduce confusion.
+					if(mname.asString.any(this.binaryOperatorCharacters.contains(_)), { "" }, { "." })
+				},
+				\genericMethod, { "" }
+			);
+
 			mname2 = this.escapeSpecialChars(mname);
 			if(cls.notNil) {
 				mstat = 0;


### PR DESCRIPTION
towards #2943. removes cluttersome gray backgrounds and horizontal lines, displays instance methods with a leading "." (except for binary operators) and classes with a leading "ClassName.".

again i can't post screenshots, just try it. to me it's a huge improvement :)