### PR TITLE
plugins: fix Pitch median filter size

### DIFF
--- a/server/plugins/DelayUGens.cpp
+++ b/server/plugins/DelayUGens.cpp
@@ -1786,7 +1786,7 @@ void Pitch_Ctor(Pitch *unit)
 	int maxbins = (int)ZIN0(kPitchMaxBins);
 	unit->m_maxlog2bins = LOG2CEIL(maxbins);
 
-	unit->m_medianSize = sc_clip((int)ZIN0(0), 0, kMAXMEDIANSIZE);  // (int)ZIN0(kPitchMedian);
+	unit->m_medianSize = sc_clip((int)ZIN0(kPitchMedian), 0, kMAXMEDIANSIZE);
 	unit->m_ampthresh = ZIN0(kPitchAmpThreshold);
 	unit->m_peakthresh = ZIN0(kPitchPeakThreshold);
 


### PR DESCRIPTION
fixes #2904. test case:

    { Pitch.kr(SinOsc.ar(440 * Hasher.ar(Sweep.ar)), median: 10)[0] }.plot(0.5);

changing `median` has no effect in master, and this commit seems to fix it.