### PR TITLE
help synthesis code cleanup

### DIFF
--- a/HelpSource/Classes/AudioIn.schelp
+++ b/HelpSource/Classes/AudioIn.schelp
@@ -34,10 +34,10 @@ code::
 (
 ServerOptions.inDevices.postln;	//  post available audio input devices
 s.meter;	// display level meters for monitoring
-SynthDef("help-AudioIn", {
+SynthDef(\helpAudioIn, { |out|
 	var input = AudioIn.ar(1); // first input
 	// delay output to tame feedback in case of microphones are configured:
-	Out.ar(0, CombN.ar(input * -25.dbamp, 0.5, 0.5, 0.001))
+	Out.ar(out, CombN.ar(input * -25.dbamp, 0.5, 0.5, 0.001))
 }).play
 )
 ::

--- a/HelpSource/Classes/BeatTrack.schelp
+++ b/HelpSource/Classes/BeatTrack.schelp
@@ -38,30 +38,29 @@ private:: init
 examples::
 
 code::
-b = Buffer.alloc(s,1024,1); //for sampling rates 44100 and 48000
-//b = Buffer.alloc(s,2048,1); //for sampling rates 88200 and 96000
 
 //this is a one minute pop song; you should load something equivalent for testing
-d=Buffer.read(s,"/Volumes/data/stevebeattrack/samples/100.wav");
+d = Buffer.read(s, "/Volumes/data/stevebeattrack/samples/100.wav");
 
 
 //you can also test at 48000 and it should work
 (
-a= SynthDef(\help_beattrack,{arg vol=1.0, beepvol=1.0, lock=0;
-var in, fft, resample;
-var trackb,trackh,trackq,tempo;
-var bsound,hsound,qsound, beep;
+a = SynthDef(\help_beattrack, { |out, vol=1.0, beepvol=1.0, lock=0|
+	var in, fft, resample;
+	var trackb, trackh, trackq, tempo;
+	var bsound, hsound, qsound, beep;
 
-in= PlayBuf.ar(1,d,BufRateScale.kr(d),1,0,1);
-//in = SoundIn.ar(0);
+	in = PlayBuf.ar(1,d, BufRateScale.kr(d),1,0,1);
+	//in = SoundIn.ar(0);
 
-fft = FFT(b, in);
+	fft = FFT(LocalBuf(1, 1024), in); // for sampling rates 44100 and 48000
 
-#trackb,trackh,trackq,tempo=BeatTrack.kr(fft, lock);
+	#trackb, trackh, trackq, tempo = BeatTrack.kr(fft, lock);
 
-beep= SinOsc.ar(1000,0.0,Decay.kr(trackb,0.1));
+	beep = SinOsc.ar(1000, 0.0, Decay.kr(trackb, 0.1));
 
-Out.ar(0,Pan2.ar((vol*in)+(beepvol*beep),0.0));
+	Out.ar(out, Pan2.ar((vol * in) + (beepvol * beep), 0.0))
+
 }).play
 )
 
@@ -76,24 +75,25 @@ a.set(\lock,0); //unfix, back to tracking
 ::
 
 track audio in (try clapping a beat or beatboxing, but allow up to 6 seconds for tracking to begin) and spawning stuff at quarters, eighths and sixteenths:
+
 code::
 (
-SynthDef(\help_beattrack2,{
-var trackb,trackh,trackq,tempo;
-var source;
-var bsound,hsound,qsound;
+SynthDef(\help_beattrack2, { |out|
+	var trackb, trackh, trackq, tempo;
+	var source;
+	var bsound, hsound, qsound;
 
-source= SoundIn.ar(0);
+	source = SoundIn.ar(0);
 
-#trackb,trackh,trackq,tempo=BeatTrack.kr(FFT(b, source));
+	#trackb, trackh, trackq, tempo = BeatTrack.kr(FFT(LocalBuf(1, 1024, source)));
 
-bsound= Pan2.ar(LPF.ar(WhiteNoise.ar*(Decay.kr(trackb,0.05)),1000),0.0);
+	bsound = Pan2.ar(LPF.ar(WhiteNoise.ar * Decay.kr(trackb, 0.05), 1000), 0.0);
 
-hsound= Pan2.ar(BPF.ar(WhiteNoise.ar*(Decay.kr(trackh,0.05)),3000,0.66),-0.5);
+	hsound = Pan2.ar(BPF.ar(WhiteNoise.ar * Decay.kr(trackh, 0.05), 3000, 0.66), -0.5);
 
-qsound= Pan2.ar(HPF.ar(WhiteNoise.ar*(Decay.kr(trackq,0.05)),5000),0.5);
+	qsound = Pan2.ar(HPF.ar(WhiteNoise.ar * Decay.kr(trackq, 0.05),5000), 0.5);
 
-Out.ar(0, bsound+hsound+qsound);
+	Out.ar(out, bsound + hsound + qsound);
 }).play;
 )
 ::

--- a/HelpSource/Classes/BeatTrack2.schelp
+++ b/HelpSource/Classes/BeatTrack2.schelp
@@ -109,8 +109,8 @@ a= SynthDef(\help_beattrack2_1, { |out, vol=1.0, beepvol=1.0, lock=0, bufnum|
 	//in = SoundIn.ar(0);
 
 	//Create some features
-	fft = FFT(LocalBuf(1, 1024), in); //for sampling rates 44100 and 48000
-	//fft = FFT(LocalBuf(1, 2048), in); //for sampling rates 88200 and 96000
+	fft = FFT(LocalBuf(1, 1024), in); // for sampling rates 44100 and 48000
+	//fft = FFT(LocalBuf(1, 2048), in); // for sampling rates 88200 and 96000
 
 	feature1 = Onsets.kr(fft, odftype:\mkl, rawodf:1);
 
@@ -135,7 +135,7 @@ a = Synth(\help_beattrack2_1, [\bufnum, b]);
 code::
 //favour higher tempi in own weighting scheme
 (
-c = Array.fill(120,{arg i; 0.5+(0.5*(i/120))});
+c = Array.fill(120, { |i| 0.5 + (0.5 * (i / 120)) });
 e = Buffer.sendCollection(s, c, 1);
 )
 ::
@@ -152,15 +152,13 @@ SynthDef(\help_beattrack2_2, { |out|
 	source = SoundIn.ar(0);
 
 	//downsampling automatic via kr from ar
-	kbus = Out.kr(0, LPF.ar(source,1000)); //([feature1, feature3]++feature2);
+	kbus = Out.kr(0, LPF.ar(source, 1000)); //([feature1, feature3]++feature2);
 
 	#trackb, trackh, trackq, tempo = BeatTrack2.kr(0,1,weightingscheme: e.bufnum);
 
-	bsound = Pan2.ar(LPF.ar(WhiteNoise.ar * (Decay.kr(trackb,0.05)),1000),0.0);
-
-	hsound = Pan2.ar(BPF.ar(WhiteNoise.ar * (Decay.kr(trackh,0.05)),3000,0.66),-0.5);
-
-	qsound = Pan2.ar(HPF.ar(WhiteNoise.ar * (Decay.kr(trackq,0.05)),5000),0.5);
+	bsound = Pan2.ar(LPF.ar(WhiteNoise.ar * (Decay.kr(trackb, 0.05)), 1000), 0.0);
+	hsound = Pan2.ar(BPF.ar(WhiteNoise.ar * (Decay.kr(trackh, 0.05)), 3000, 0.66),-0.5);
+	qsound = Pan2.ar(HPF.ar(WhiteNoise.ar * (Decay.kr(trackq, 0.05)), 5000), 0.5);
 
 	Out.ar(out, source + bsound + hsound + qsound);
 }).play;

--- a/HelpSource/Classes/BeatTrack2.schelp
+++ b/HelpSource/Classes/BeatTrack2.schelp
@@ -122,7 +122,7 @@ a= SynthDef(\help_beattrack2_1, { |out, vol=1.0, beepvol=1.0, lock=0, bufnum|
 	#trackb, trackh, trackq, tempo, phase, period, groove = BeatTrack2.kr(0, 2, 3.0, 0.02, lock, -2.5);
 
 
-	beep = SinOsc.ar(1000,0.0,Decay.kr(trackb,0.1));
+	beep = SinOsc.ar(1000, 0.0, Decay.kr(trackb, 0.1));
 	beep = Pan2.ar((vol * in) + (beepvol * beep), 0.0);
 	Out.ar(out, beep);
 }).add;

--- a/HelpSource/Classes/BeatTrack2.schelp
+++ b/HelpSource/Classes/BeatTrack2.schelp
@@ -47,54 +47,50 @@ private:: init
 examples::
 
 code::
-//required for MFCCs used below
-b = Buffer.alloc(s,1024,1); //for sampling rates 44100 and 48000
-//b = Buffer.alloc(s,2048,1); //for sampling rates 88200 and 96000
 
-//this is a one minute pop song; you should load something equivalent for testing
-d=Buffer.read(s,"/Volumes/data/stevebeattrack/samples/100.wav");
-d=Buffer.read(s,"/Volumes/data/stevebeattrack/samples/019.wav");
-
+// you should load something useful for testing, like a one minute pop song
+b = Buffer.read(s, Platform.resourceDir +/+ "sounds/a11wlk01.wav");
 
 //very feature dependent
 (
-a= SynthDef(\help_beattrack2_1,{arg vol=1.0, beepvol=1.0, lock=0;
-var in, kbus;
-var trackb,trackh,trackq,tempo, phase, period, groove;
-var bsound,hsound,qsound, beep;
-var fft;
-var feature1, feature2, feature3;
+SynthDef(\help_beattrack2_1, { |out, vol=1.0, beepvol=1.0, lock=0, bufnum|
+	var in, kbus;
+	var trackb, trackh, trackq, tempo, phase, period, groove;
+	var bsound, hsound, qsound, beep;
+	var fft;
+	var feature1, feature2, feature3;
 
-in= PlayBuf.ar(1,d.bufnum,BufRateScale.kr(d.bufnum),1,0,1);
-//in = SoundIn.ar(0);
+	in = PlayBuf.ar(1, bufnum, BufRateScale.kr(bufnum), 1, 0, 1);
+	//in = SoundIn.ar(0);
 
-//Create some features
-fft = FFT(b.bufnum, in);
+	//Create some features
+	fft = FFT(LocalBuf(1, 1024), in); //for sampling rates 44100 and 48000
+	//fft = FFT(LocalBuf(1, 2048), in); //for sampling rates 88200 and 96000
 
-feature1= RunningSum.rms(in,64);
-feature2= MFCC.kr(fft,2); //two coefficients
-feature3= A2K.kr(LPF.ar(in,1000));
+	feature1 = RunningSum.rms(in, 64);
+	feature2 = MFCC.kr(fft,2); //two coefficients
+	feature3 = A2K.kr(LPF.ar(in,1000));
 
-kbus= Out.kr(0, [feature1, feature3]++feature2);
+	kbus = Out.kr(0, [feature1, feature3] ++ feature2);
 
-//Look at four features
-#trackb,trackh,trackq,tempo, phase, period, groove=BeatTrack2.kr(0,4,2.0, 0.02, lock, -2.5);
+	//Look at four features
+	#trackb, trackh, trackq, tempo, phase, period, groove = BeatTrack2.kr(0, 4, 2.0, 0.02, lock, -2.5);
 
-beep= SinOsc.ar(1000,0.0,Decay.kr(trackb,0.1));
-
-Out.ar(0,Pan2.ar((vol*in)+(beepvol*beep),0.0));
-}).play
+	beep= SinOsc.ar(1000, 0.0, Decay.kr(trackb, 0.1));
+	beep = Pan2.ar((vol * in) + (beepvol * beep), 0.0);
+	Out.ar(out, beep);
+}).add;
 )
 
+a = Synth(\help_beattrack2_1, [\bufnum, b]);
+a.set(\vol, 0.0);
+a.set(\vol, 1.0);
 
-a.set(\vol,0.0);
-a.set(\vol,1.0);
+a.set(\beepvol, 1.0);
+a.set(\beepvol, 0.0);
 
-a.set(\beepvol,1.0);
-a.set(\beepvol,0.0);
-
-a.set(\lock,1); //fix it rigidly from current phase/period solution
-a.set(\lock,0); //unfix, back to tracking
+a.set(\lock, 1); //fix it rigidly from current phase/period solution
+a.set(\lock, 0); //unfix, back to tracking
 
 a.free;
 ::
@@ -102,82 +98,88 @@ a.free;
 code::
 //same thing, trying with Onsets UGen raw output
 (
-a= SynthDef(\help_beattrack2_1,{arg vol=1.0, beepvol=1.0, lock=0;
-var in, kbus;
-var trackb,trackh,trackq,tempo, phase, period, groove;
-var bsound,hsound,qsound, beep;
-var fft;
-var feature1, feature2, feature3;
+a= SynthDef(\help_beattrack2_1, { |out, vol=1.0, beepvol=1.0, lock=0, bufnum|
+	var in, kbus;
+	var trackb, trackh, trackq, tempo, phase, period, groove;
+	var bsound, hsound, qsound, beep;
+	var fft;
+	var feature1, feature2, feature3;
 
-in= PlayBuf.ar(1,d.bufnum,BufRateScale.kr(d.bufnum),1,0,1);
-//in = SoundIn.ar(0);
+	in = PlayBuf.ar(1, bufnum, BufRateScale.kr(bufnum),1,0,1);
+	//in = SoundIn.ar(0);
 
-//Create some features
-fft = FFT(b.bufnum, in);
+	//Create some features
+	fft = FFT(LocalBuf(1, 1024), in); //for sampling rates 44100 and 48000
+	//fft = FFT(LocalBuf(1, 2048), in); //for sampling rates 88200 and 96000
 
-feature1= Onsets.kr(fft,odftype:\mkl, rawodf:1);
+	feature1 = Onsets.kr(fft, odftype:\mkl, rawodf:1);
 
-feature2= Onsets.kr(fft,odftype:\complex, rawodf:1);//two coefficients
+	feature2 = Onsets.kr(fft, odftype:\complex, rawodf:1);//two coefficients
 
-kbus= Out.kr(0, [feature1,feature2]);
+	kbus= Out.kr(0, [feature1,feature2]);
 
-//Look at four features
-#trackb,trackh,trackq,tempo, phase, period, groove=BeatTrack2.kr(0,2,3.0, 0.02, lock, -2.5);
+	//Look at four features
+	#trackb, trackh, trackq, tempo, phase, period, groove = BeatTrack2.kr(0, 2, 3.0, 0.02, lock, -2.5);
 
-beep= SinOsc.ar(1000,0.0,Decay.kr(trackb,0.1));
 
-Out.ar(0,Pan2.ar((vol*in)+(beepvol*beep),0.0));
-}).play
+	beep = SinOsc.ar(1000,0.0,Decay.kr(trackb,0.1));
+	beep = Pan2.ar((vol * in) + (beepvol * beep), 0.0);
+	Out.ar(out, beep);
+}).add;
 )
+
+a = Synth(\help_beattrack2_1, [\bufnum, b]);
+
 ::
 
 code::
 //favour higher tempi in own weighting scheme
 (
-c=Array.fill(120,{arg i; 0.5+(0.5*(i/120))});
-e=Buffer.sendCollection(s, c, 1);
+c = Array.fill(120,{arg i; 0.5+(0.5*(i/120))});
+e = Buffer.sendCollection(s, c, 1);
 )
 ::
 
-track audio in (try clapping a beat or beatboxing, but allow up to 6 seconds for tracking to begin) and spawning stuff at quarters, eighths and sixteenths
+
 code::
+// track audio in (try clapping a beat or beatboxing, but allow up to 6 seconds for tracking to begin) and spawning stuff at quarters, eighths and sixteenths
 (
-SynthDef(\help_beattrack2_2,{
-var trackb,trackh,trackq,tempo;
-var source, kbus;
-var bsound,hsound,qsound;
+SynthDef(\help_beattrack2_2, { |out|
+	var trackb, trackh, trackq, tempo;
+	var source, kbus;
+	var bsound, hsound, qsound;
 
-source= SoundIn.ar(0); //PlayBuf.ar(1,d.bufnum,BufRateScale.kr(d.bufnum),1,0,1);
+	source = SoundIn.ar(0);
 
-//downsampling automatic via kr from ar
-kbus= Out.kr(0, LPF.ar(source,1000)); //([feature1, feature3]++feature2);
+	//downsampling automatic via kr from ar
+	kbus = Out.kr(0, LPF.ar(source,1000)); //([feature1, feature3]++feature2);
 
-#trackb,trackh,trackq,tempo=BeatTrack2.kr(0,1,weightingscheme:e.bufnum);
+	#trackb, trackh, trackq, tempo = BeatTrack2.kr(0,1,weightingscheme: e.bufnum);
 
-bsound= Pan2.ar(LPF.ar(WhiteNoise.ar*(Decay.kr(trackb,0.05)),1000),0.0);
+	bsound = Pan2.ar(LPF.ar(WhiteNoise.ar * (Decay.kr(trackb,0.05)),1000),0.0);
 
-hsound= Pan2.ar(BPF.ar(WhiteNoise.ar*(Decay.kr(trackh,0.05)),3000,0.66),-0.5);
+	hsound = Pan2.ar(BPF.ar(WhiteNoise.ar * (Decay.kr(trackh,0.05)),3000,0.66),-0.5);
 
-qsound= Pan2.ar(HPF.ar(WhiteNoise.ar*(Decay.kr(trackq,0.05)),5000),0.5);
+	qsound = Pan2.ar(HPF.ar(WhiteNoise.ar * (Decay.kr(trackq,0.05)),5000),0.5);
 
-Out.ar(0, source + bsound+hsound+qsound);
+	Out.ar(out, source + bsound + hsound + qsound);
 }).play;
 )
 ::
 
-geometric tempo placement very similar to linear, and linear easier to deal with looking up related tempi at double and half speed
+
 code::
+// geometric tempo placement very similar to linear, and linear easier to deal with looking up related tempi at double and half speed
 (
-var startbps= 1, endbps=3;
-var numtempi=100;
-var ratio;
-var tempi, periods;
+var startbps = 1, endbps = 3;
+var numtempi = 100;
+var ratio, tempi, periods;
 
-ratio= (endbps/startbps)**((numtempi-1).reciprocal);
+ratio = (endbps / startbps) ** (numtempi-1).reciprocal;
 
-tempi= Array.geom(numtempi, startbps, ratio);
+tempi = Array.geom(numtempi, startbps, ratio);
 
-periods= tempi.reciprocal;
+periods = tempi.reciprocal;
 
 Post << (tempi*60) << nl;
 Post << periods << nl;

--- a/HelpSource/Classes/Bus.schelp
+++ b/HelpSource/Classes/Bus.schelp
@@ -89,8 +89,8 @@ a = Bus.control(s, 1).set(440);
 b = Bus.control(s, 1).set(0.01);
 )
 (
-SynthDef(\rlpf, { |ffreq, rq|
-	Out.ar(0, RLPF.ar(WhiteNoise.ar(0.2), ffreq, rq))
+SynthDef(\rlpf, { |out, ffreq, rq|
+	Out.ar(out, RLPF.ar(WhiteNoise.ar(0.2), ffreq, rq))
 }).play(s, [\ffreq, a.asMap, \rq, b.asMap]);
 )
 ::
@@ -260,9 +260,9 @@ x.free;
 	// buses can also be used with kr or ar like UGens:
 (
 
-SynthDef(\help_Bus, {
+SynthDef(\help_Bus, { |out|
 	var ffreq = b.kr;
-	Out.ar(0,
+	Out.ar(out,
 		RLPF.ar(
 			LFPulse.ar(SinOsc.kr(0.2, 0, 10, 21), [0,0.1], 0.1),
 			ffreq, 0.1
@@ -279,9 +279,9 @@ b.free; // release it so it may be reallocated!
 (
 b = Bus.control(s, 4);
 
-x = SynthDef(\helpBusMulti, {
+x = SynthDef(\helpBusMulti, { |out|
 	var freqs = b.kr;
-	Out.ar(0, Splay.ar(SinOsc.ar(freqs) * Decay2.ar(Dust.ar(10 ! 4), 0.001, 0.1)) * 0.5);
+	Out.ar(out, Splay.ar(SinOsc.ar(freqs) * Decay2.ar(Dust.ar(10 ! 4), 0.001, 0.1)) * 0.5);
 }).play;
 )
 
@@ -308,16 +308,16 @@ b.getn;
 b.set(300, 500, 700, 900);
 
 (	// just get the first 2 channels
-x = SynthDef(\helpBusMulti, {
-	Out.ar(0, SinOsc.ar(b.kr(2)) * 0.2);
+x = SynthDef(\helpBusMulti, { |out|
+	Out.ar(out, SinOsc.ar(b.kr(2)) * 0.2)
 }).play;
 )
 b.set(300, 303);
 x.free;
 
 (	// just channels[[2, 3]];
-y = SynthDef(\helpBusMulti, {
-	Out.ar(0, LFNoise2.ar(b.kr(2, 2)) * 0.2);
+y = SynthDef(\helpBusMulti, { |out|
+	Out.ar(out, LFNoise2.ar(b.kr(2, 2)) * 0.2);
 }).play;
 )
 b.setAt(2, 1200);

--- a/HelpSource/Classes/Condition.schelp
+++ b/HelpSource/Classes/Condition.schelp
@@ -100,10 +100,10 @@ c.unhang;
 Waiting for Synths to end (waitForFree) uses a Condition implicitly:
 code::
 (
-SynthDef(\help, {
+SynthDef(\help, { |out|
 	var mod = LFNoise2.kr(ExpRand(0.5, 2)) * 0.5;
 	var snd =  mod * Blip.ar(Rand(200, 800) * (mod + 1));
-	Out.ar(0, snd);
+	Out.ar(out, snd);
 	FreeSelf.kr(mod < 0); // free the synth when amplitude goes below 0.
 }).add;
 )

--- a/HelpSource/Classes/Convolution.schelp
+++ b/HelpSource/Classes/Convolution.schelp
@@ -54,39 +54,46 @@ Examples::
 code::
 (
 
-	{ var input, kernel;
+{
+	var input, kernel;
 
-	input=SoundIn.ar(0);
-	kernel= Mix.ar(LFSaw.ar([300,500,800,1000]*MouseX.kr(1.0,2.0),0,1.0));
+	input = SoundIn.ar(0);
+	kernel = Mix.ar(LFSaw.ar([300,500,800,1000] * MouseX.kr(1.0, 2.0), 0, 1.0));
 
-	//must have power of two framesize
-	Out.ar(0,Convolution.ar(input,kernel, 1024, 0.5));
-	 }.play;
+	// must have power of two framesize
+	Convolution.ar(input,kernel, 1024, 0.5)
+}.play;
 
 )
 
 (
-//must have power of two framesize- FFT size will be sorted by Convolution to be double this
-//maximum is currently a=8192 for FFT of size 16384
-a=2048;
+// must have power of two framesize- FFT size will be sorted by Convolution to be double this
+// maximum is currently a=8192 for FFT of size 16384
+
+a = 2048;
 s = Server.local;
-//kernel buffer
-g = Buffer.alloc(s,a,1);
+
+// kernel buffer
+g = Buffer.alloc(s, a, 1);
 )
 
 (
-//random impulse response
-g.set(0,1.0);
-100.do({arg i; g.set(a.rand, 1.0.rand)});
+
+// random impulse response
+
+g.set(0, 1.0);
+
+100.do({ arg i; g.set(a.rand, 1.0.rand) });
 
 
-	{ var input, kernel;
+{
+	var input, kernel;
 
-	input=SoundIn.ar(0);
-	kernel= PlayBuf.ar(1,g.bufnum,BufRateScale.kr(g.bufnum),1,0,1);
+	input = SoundIn.ar(0);
+	kernel = PlayBuf.ar(1, g.bufnum,BufRateScale.kr(g.bufnum), 1, 0, 1);
 
-	Out.ar(0,Convolution.ar(input,kernel, 2*a, 0.5));
-	 }.play;
+	Convolution.ar(input, kernel, 2 * a, 0.5)
+}.play;
 
 )
 ::

--- a/HelpSource/Classes/Convolution2.schelp
+++ b/HelpSource/Classes/Convolution2.schelp
@@ -72,13 +72,13 @@ d.zero;
 
 
 (
-SynthDef( "conv-test", { arg kernel, trig=0;
+SynthDef("conv-test", { |out, kernel, trig = 0|
 	var input;
 
-	input=Impulse.ar(1);
+	input = Impulse.ar(1);
 
 	//must have power of two framesize
-	Out.ar(0,Convolution2.ar(input,kernel,trig,2048, 0.5));
+	Out.ar(out, Convolution2.ar(input, kernel, trig, 2048, 0.5));
 }).add
 
 )
@@ -131,22 +131,22 @@ g = Buffer.alloc(s,a,1);
 
 (
 g.set(0,1.0);
-100.do({arg i; g.set(a.rand, (i+1).reciprocal)});
+100.do({ arg i; g.set(a.rand, (i+1).reciprocal)});
 )
 
 (
 // random impulse response
 
-	{
+{
 	var input,inputAmp,threshhold,gate;
 
-input = SoundIn.ar(0);
-inputAmp = Amplitude.kr(input);
-threshhold = 0.02;	// noise gating threshold
-gate = Lag.kr(inputAmp > threshhold, 0.01);
+	input = SoundIn.ar(0);
+	inputAmp = Amplitude.kr(input);
+	threshhold = 0.02;	// noise gating threshold
+	gate = Lag.kr(inputAmp > threshhold, 0.01);
 
-	Out.ar(0,Convolution2.ar(input*gate,g.bufnum,0, a, 0.5));
-	 }.play;
+	Convolution2.ar(input*gate,g.bufnum,0, a, 0.5)
+}.play;
 
 )
 
@@ -157,13 +157,14 @@ b.sine1(1.0/[1,2,3,4,5,6], true, true, true);
 )
 
 (
-	{ var input, kernel;
+{
+	var input, kernel;
 
-	input=SoundIn.ar(0);
+	input = SoundIn.ar(0);
 
 	//must have power of two framesize
-	Out.ar(0,Convolution2.ar(input,b.bufnum,0, 512, 0.5));
-	 }.play;
+	Convolution2.ar(input,b.bufnum,0, 512, 0.5)
+}.play;
 
 )
 ::

--- a/HelpSource/Classes/Convolution2L.schelp
+++ b/HelpSource/Classes/Convolution2L.schelp
@@ -42,7 +42,8 @@ argument::add
 Examples::
 
 code::
-(// allocate three buffers
+// allocate three buffers
+(
 b = Buffer.alloc(s, 2048);
 c = Buffer.alloc(s, 2048);
 d = Buffer.alloc(s, 2048);
@@ -53,20 +54,18 @@ d.zero;
 )
 
 (
-50.do({ |it| c.set(20*it+10, 1.0.rand); });
-3.do({ |it| b.set(400*it+100, 1); });
-20.do({ |it| d.set(40*it+20, 1); });
+50.do { |it| c.set(20 * it + 10, 1.0.rand) };
+3.do { |it| b.set(400 * it + 100, 1) };
+20.do { |it| d.set(40 * it + 20, 1) };
 )
 ::
 code::
 (
-SynthDef(\conv_test, { arg kernel, t_trig=0;
-	var input;
-
-	input=Impulse.ar(1);
-
-	// must have power of two framesize
-	Out.ar(0, Convolution2L.ar(input, kernel, t_trig, 2048, 1, 0.5));
+SynthDef(\conv_test, { |out, kernel, t_trig=0|
+	var input = Impulse.ar(1);
+	var framesize = 2048; // must have power of two
+	var result = Convolution2L.ar(input, kernel, t_trig, framesize, 1, 0.5);
+	Out.ar(out, result);
 }).add
 )
 
@@ -79,7 +78,7 @@ x.set(\kernel, d);
 x.set(\t_trig, 1); // after this trigger, the change will take effect.
 
 d.zero;
-40.do({ |it| d.set(20*it+10, 1); });// changing the buffers' contents
+40.do { |it| d.set(20 * it + 10, 1) };// changing the buffers' contents
 x.set(\t_trig, 1); // after this trigger, the change will take effect.
 
 x.set(\kernel, b);
@@ -91,13 +90,11 @@ x.free;
 code::
 // longer crossfade
 (
-SynthDef( \conv_test2, { arg kernel, t_trig=0;
-	var input;
-
-	input=Impulse.ar(1);
-
-	// must have power of two framesize
-	Out.ar(0, Convolution2L.ar(input, kernel, t_trig, 2048, 5, 0.5));
+SynthDef(\conv_test2, { |out, kernel, t_trig=0|
+	var input = Impulse.ar(1);
+	var framesize = 2048; // must have power of two
+	var result = Convolution2L.ar(input, kernel, t_trig, 2048, 5, 0.5);
+	Out.ar(out, result);
 }).add
 )
 
@@ -110,7 +107,9 @@ x.set(\kernel, d);
 x.set(\t_trig, 1); // after this trigger, the change will take effect.
 
 d.zero;
-40.do({ |it| d.set(20*it+10, 1); });// changing the buffers' contents
+
+40.do { |it| d.set(20 * it + 10, 1) };// changing the buffers' contents
+
 x.set(\t_trig, 1); // after this trigger, the change will take effect.
 
 x.set(\kernel, b);
@@ -125,14 +124,11 @@ code::
 b = Buffer.read(s, Platform.resourceDir +/+ "sounds/a11wlk01.wav");
 
 (
-	{ var input, kernel;
-
-	input= SoundIn.ar(0);
-
-	// must have power of two framesize
+{
+	var input = SoundIn.ar(0);
+	var framesize = 2048; // must have power of two
 	Convolution2L.ar(input, b, 0, 512, 1, 0.5);
-	}.play;
-
+}.play
 )
 ::
 
@@ -142,20 +138,19 @@ code::
 (
 // must have power of two framesize- FFT size will be sorted by Convolution2 to be double this
 // maximum is currently a=8192 for FFT of size 16384
-a=2048;
+a = 2048;
 // kernel buffer
 g = Buffer.alloc(s, a, 1);
 )
 
 (
 g.set(0, 1.0);
-100.do({arg i; g.set(a.rand, (i+1).reciprocal)});
+100.do { |i| g.set(a.rand, (i + 1).reciprocal) };
 )
 
 (
 // random impulse response
-
-	{
+{
 	var input, inputAmp, threshhold, gate;
 
 	input = SoundIn.ar(0);
@@ -163,10 +158,12 @@ g.set(0, 1.0);
 	threshhold = 0.02;	// noise gating threshold
 	gate = Lag.kr(inputAmp > threshhold, 0.01);
 
-	Convolution2L.ar(input*gate, g, 0, a, 1, 0.5);
-	}.play;
-
+	Convolution2L.ar(input * gate, g, 0, a, 1, 0.5);
+}.play
 )
+
+g.free;
+
 ::
 
 code::
@@ -177,14 +174,14 @@ b.sine1(1.0/[1, 2, 3, 4, 5, 6], true, true, true);
 )
 
 (
-	{ var input, kernel;
-
-	input=SoundIn.ar(0);
-
-	// must have power of two framesize
-	Convolution2L.ar(input, b, 0, 512, 1, 0.5);
-	}.play;
-
+{
+	var input = SoundIn.ar(0);
+	var framesize = 512;
+	Convolution2L.ar(input, b, 0, framesize, 1, 0.5);
+}.play
 )
+
+b.free;
+
 ::
 

--- a/HelpSource/Classes/DelTapWr.schelp
+++ b/HelpSource/Classes/DelTapWr.schelp
@@ -27,7 +27,7 @@ code::
 b = Buffer.alloc(s, s.sampleRate * 1, 1);
 
 // write a signal into a delay, tap it at multiple times
-SynthDef(\test, {arg buffer;
+SynthDef(\test, { |out, buffer|
 	var src, tapPhase, tap1, tap2, tap3;
 	src = WhiteNoise.ar(0.2) * Decay.kr(Dust.kr(3), 0.2);
 	tapPhase = DelTapWr.ar(buffer, src);
@@ -35,9 +35,9 @@ SynthDef(\test, {arg buffer;
 		[0.2, 0.27, 0.303],  	// tap times
 		1,  					// no interp
 		[1.0, 0.4, 0.2] 		// muls for each tap
-		);
-	Out.ar(0, [src + tap2, tap1 + tap3])
-	}).add;
+	);
+	Out.ar(out, [src + tap2, tap1 + tap3])
+}).add;
 
 x = Synth(\test, [\buffer, b]);
 x.free;
@@ -49,20 +49,20 @@ code::
 b = Buffer.alloc(s, 44100, 1);
 
 // write a signal into a delay, tap it at multiple times
-SynthDef(\write, {arg buffer, cout;
+SynthDef(\write, { |buffer, cout|
 	var src, tapPhase, tap1, tap2, tap3;
 	src = WhiteNoise.ar(0.2) * Decay.kr(Dust.kr(3), 0.7);
 	tapPhase = DelTapWr.ar(buffer, src);
 	Out.kr(cout, tapPhase);
 	}).add;
 
-SynthDef(\readFilt, {arg buffer, cin;
+SynthDef(\readFilt, { |out, buffer, cin|
 	var phase, src, filt;
 	phase = In.kr(cin);
 	src = DelTapRd.ar(buffer, phase, [0.01, 0.2]);
 	filt = BPF.ar(src, 880, 0.01) * 10;
-	Out.ar(0, filt);
-	}).add;
+	Out.ar(out, filt);
+}).add;
 
 c = Bus.control;
 

--- a/HelpSource/Classes/DiskIn.schelp
+++ b/HelpSource/Classes/DiskIn.schelp
@@ -43,8 +43,8 @@ s.boot; // start the server
 
 // examples below will use this synthdef
 (
-SynthDef("help-Diskin", { arg bufnum = 0;
-	Out.ar(0, DiskIn.ar(1, bufnum));
+SynthDef("help-Diskin", { |out, bufnum = 0|
+	Out.ar(out, DiskIn.ar(1, bufnum));
 }).add
 )
 ::
@@ -84,15 +84,16 @@ r.stop; x.free; b.close; b.free; // you need to do all these to properly cleanup
 
 // cue and play right away
 (
-SynthDef("help-Diskin", { arg bufnum = 0;
-	Out.ar(0, DiskIn.ar(1, bufnum));
+SynthDef("help-Diskin", { |out, bufnum = 0|
+	Out.ar(out, DiskIn.ar(1, bufnum));
 }).add;
 )
+
 (
 x = Synth.basicNew("help-Diskin");
-m = { arg buf; x.addToHeadMsg(nil, [\bufnum,buf.bufnum])};
+m = { arg buf; x.addToHeadMsg(nil, [\bufnum, buf.bufnum])};
 
-b = Buffer.cueSoundFile(s,Platform.resourceDir +/+ "sounds/a11wlk01-44_1.aiff",0,1, completionMessage: m);
+b = Buffer.cueSoundFile(s,Platform.resourceDir +/+ "sounds/a11wlk01-44_1.aiff", 0, 1, completionMessage: m);
 
 )
 

--- a/HelpSource/Classes/DiskOut.schelp
+++ b/HelpSource/Classes/DiskOut.schelp
@@ -54,21 +54,21 @@ code::
 s.boot; // start the server
 (
 // something to record
-SynthDef("bubbles", { arg out;
+SynthDef("bubbles", { |out|
 	var f, zout;
 	f = LFSaw.kr(0.4, 0, 24, LFSaw.kr([8,7.23], 0, 3, 80)).midicps; // glissando function
 	zout = CombN.ar(SinOsc.ar(f, 0, 0.04), 0.2, 0.2, 4); // echoing sine wave
-	Out.ar(out, zout);
+	Out.ar(out, zout)
 }).add;
 
 // this will record to the disk
-SynthDef("help-Diskout", { arg bufnum;
+SynthDef("help-Diskout", { |bufnum|
 	DiskOut.ar(bufnum, In.ar(0,2));
 }).add;
 
 // this will play it back
-SynthDef("help-Diskin-2chan", { arg out, bufnum = 0;
-	Out.ar(out, DiskIn.ar(2, bufnum));
+SynthDef("help-Diskin-2chan", { |out, bufnum = 0|
+	Out.ar(out, DiskIn.ar(2, bufnum))
 }).add;
 )
 ::
@@ -76,7 +76,7 @@ SynthDef("help-Diskin-2chan", { arg out, bufnum = 0;
 subsection:: Object Style
 code::
 // start something to record
-x = Synth.new("bubbles");
+x = Synth("bubbles");
 
 // allocate a disk i/o buffer
 b= Buffer.alloc(s, 65536, 2);
@@ -97,7 +97,7 @@ b.free;
 // play it back
 (
 x = Synth.basicNew("help-Diskin-2chan");
-m = { arg buf; x.addToHeadMsg(nil, [\bufnum,buf])};
+m = { |buf| x.addToHeadMsg(nil, [\bufnum,buf])};
 
 b = Buffer.cueSoundFile(s,"~/diskouttest.aiff".standardizePath, 0, 2, completionMessage: m);
 )

--- a/HelpSource/Classes/DiskOut.schelp
+++ b/HelpSource/Classes/DiskOut.schelp
@@ -54,21 +54,21 @@ code::
 s.boot; // start the server
 (
 // something to record
-SynthDef("bubbles", {
+SynthDef("bubbles", { arg out;
 	var f, zout;
 	f = LFSaw.kr(0.4, 0, 24, LFSaw.kr([8,7.23], 0, 3, 80)).midicps; // glissando function
 	zout = CombN.ar(SinOsc.ar(f, 0, 0.04), 0.2, 0.2, 4); // echoing sine wave
-	Out.ar(0, zout);
+	Out.ar(out, zout);
 }).add;
 
 // this will record to the disk
-SynthDef("help-Diskout", {arg bufnum;
+SynthDef("help-Diskout", { arg bufnum;
 	DiskOut.ar(bufnum, In.ar(0,2));
 }).add;
 
 // this will play it back
-SynthDef("help-Diskin-2chan", { arg bufnum = 0;
-	Out.ar(0, DiskIn.ar(2, bufnum));
+SynthDef("help-Diskin-2chan", { arg out, bufnum = 0;
+	Out.ar(out, DiskIn.ar(2, bufnum));
 }).add;
 )
 ::

--- a/HelpSource/Classes/DynKlang.schelp
+++ b/HelpSource/Classes/DynKlang.schelp
@@ -42,22 +42,22 @@ play {
 
 // building new synths every 2 seconds
 (
-{
-loop({
-	play({
-		var mod = SinOsc.kr(Rand(0.1, 0.9), 0, Rand(5, 20));
-		Pan2.ar(DynKlang.ar(`[ Array.rand(12, 200.0, 2000.0), 1, mod ]), 1.0.rand)
-			* EnvGen.kr(Env.sine(4), 1, 0.02, doneAction: Done.freeSelf);
-	});
-	2.wait;
-})
-}.fork;
+fork {
+	loop {
+		play {
+			var mod = SinOsc.kr(Rand(0.1, 0.9), 0, Rand(5, 20));
+			Pan2.ar(DynKlang.ar(`[ Array.rand(12, 200.0, 2000.0), 1, mod ]), 1.0.rand)
+				* EnvGen.kr(Env.sine(4), 1, 0.02, doneAction: Done.freeSelf)
+		};
+		2.wait;
+	}
+}
 )
 
 
 // resetting the frequencies and amplitudes after the synth has been created
 (
-SynthDef('help-dynKlang', { | out,
+SynthDef('help-dynKlang', { |out,
 	freqs=#[220, 440, 880, 1760],
 	amps=#[0.35, 0.23, 0.12, 0.05],
 	phases=#[1, 1.5, 2, 2.5]|

--- a/HelpSource/Classes/DynKlang.schelp
+++ b/HelpSource/Classes/DynKlang.schelp
@@ -57,11 +57,12 @@ loop({
 
 // resetting the frequencies and amplitudes after the synth has been created
 (
-SynthDef('help-dynKlang', {| freqs=#[220, 440, 880, 1760],
+SynthDef('help-dynKlang', { | out,
+	freqs=#[220, 440, 880, 1760],
 	amps=#[0.35, 0.23, 0.12, 0.05],
 	phases=#[1, 1.5, 2, 2.5]|
 
-	Out.ar(0, DynKlang.ar(`[freqs, amps, phases]))
+	Out.ar(out, DynKlang.ar(`[freqs, amps, phases]))
 }).add
 )
 

--- a/HelpSource/Classes/DynKlank.schelp
+++ b/HelpSource/Classes/DynKlank.schelp
@@ -56,7 +56,7 @@ code::
 
 { DynKlank.ar(`[[800, 1071, 1353, 1723], nil, [1, 1, 1, 1]], PinkNoise.ar(0.007)) }.play;
 
-{ DynKlank.ar(`[[200, 671, 1153, 1723], nil, [1, 1, 1, 1]], PinkNoise.ar([0.007,0.007])) }.play;
+{ DynKlank.ar(`[[200, 671, 1153, 1723], nil, [1, 1, 1, 1]], PinkNoise.ar([0.007, 0.007])) }.play;
 
 ::
 
@@ -90,7 +90,7 @@ a.setn(\ringtimes, Array.rand(4, 0.02, 0.4) );
 
 // create multichannel controls directly with literal arrays:
 (
-SynthDef('help-dynKlank', {| out,
+SynthDef('help-dynKlank', { |out,
 	freqs (#[100, 200, 300, 400]),
 	amps (#[1, 0.3, 0.2, 0.05]),
 	rings (#[1, 1, 1, 2])|

--- a/HelpSource/Classes/DynKlank.schelp
+++ b/HelpSource/Classes/DynKlank.schelp
@@ -73,12 +73,12 @@ code::
 
 (
 // set them from outside later:
-SynthDef('help-dynKlank', {
+SynthDef('help-dynKlank', { |out|
 	var freqs, ringtimes, signal;
 	freqs = Control.names([\freqs]).kr([800, 1071, 1153, 1723]);
 	ringtimes = Control.names([\ringtimes]).kr([1, 1, 1, 1]);
 	signal = DynKlank.ar(`[freqs, nil, ringtimes ], Impulse.ar(2, 0, 0.1));
-	Out.ar(0, signal);
+	Out.ar(out, signal);
 }).add;
 )
 
@@ -86,15 +86,16 @@ a = Synth('help-dynKlank');
 
 a.setn(\freqs, Array.rand(4, 500, 2000));
 a.setn(\ringtimes, Array.rand(4, 0.2, 4) );
+a.setn(\ringtimes, Array.rand(4, 0.02, 0.4) );
 
 // create multichannel controls directly with literal arrays:
 (
-SynthDef('help-dynKlank', {|
+SynthDef('help-dynKlank', {| out,
 	freqs (#[100, 200, 300, 400]),
 	amps (#[1, 0.3, 0.2, 0.05]),
 	rings (#[1, 1, 1, 2])|
 
-	Out.ar(0, DynKlank.ar(`[freqs, amps, rings], WhiteNoise.ar * 0.001))
+	Out.ar(out, DynKlank.ar(`[freqs, amps, rings], WhiteNoise.ar * 0.001))
 }).add
 )
 

--- a/HelpSource/Classes/EZKnob.schelp
+++ b/HelpSource/Classes/EZKnob.schelp
@@ -329,7 +329,7 @@ var balanceControl, ampControl;
 var node, cmdPeriodFunc;
 
 // define a synth
-SynthDef("window-test", { arg note = 36, fc = 1000, rq = 0.25, bal=0, amp=0.4, gate = 1;
+SynthDef("window-test", { |out, note = 36, fc = 1000, rq = 0.25, bal=0, amp=0.4, gate = 1|
 		var x;
 		x = Mix.fill(4, {
 			LFSaw.ar((note + {0.1.rand2}.dup).midicps, 0, 0.02)
@@ -338,7 +338,7 @@ SynthDef("window-test", { arg note = 36, fc = 1000, rq = 0.25, bal=0, amp=0.4, g
 		x = RLPF.ar(x, fc, rq, amp).softclip;
 		x = Balance2.ar(x[0], x[1], bal);
 		x = x * EnvGen.kr(Env.cutoff, gate, doneAction: Done.freeSelf);
-		Out.ar(0, x);
+		Out.ar(out, x);
 	}, [0.1, 0.1, 0.1, 0.1, 0.1, 0]
 ).add;
 

--- a/HelpSource/Classes/EZNumber.schelp
+++ b/HelpSource/Classes/EZNumber.schelp
@@ -242,7 +242,7 @@ s.waitForBoot({
 	var node, cmdPeriodFunc;
 
 	// define a synth
-	SynthDef("window-test", { arg note = 36, fc = 1000, rq = 0.25, bal=0, amp=0.4, gate = 1;
+	SynthDef("window-test", { |out, note = 36, fc = 1000, rq = 0.25, bal=0, amp=0.4, gate = 1|
 			var x;
 			x = Mix.fill(4, {
 				LFSaw.ar((note + {0.1.rand2}.dup).midicps, 0, 0.02)
@@ -251,7 +251,7 @@ s.waitForBoot({
 			x = RLPF.ar(x, fc, rq, amp).softclip;
 			x = Balance2.ar(x[0], x[1], bal);
 			x = x * EnvGen.kr(Env.cutoff, gate, doneAction: Done.freeSelf);
-			Out.ar(0, x);
+			Out.ar(out, x);
 		}, [0.1, 0.1, 0.1, 0.1, 0.1, 0]
 	).add;
 

--- a/HelpSource/Classes/EZSlider.schelp
+++ b/HelpSource/Classes/EZSlider.schelp
@@ -285,7 +285,7 @@ var balanceControl, ampControl;
 var node, cmdPeriodFunc;
 
 // define a synth
-SynthDef("window-test", { arg note = 36, fc = 1000, rq = 0.25, bal=0, amp=0.4, gate = 1;
+SynthDef("window-test", { |out, note = 36, fc = 1000, rq = 0.25, bal=0, amp=0.4, gate = 1|
 		var x;
 		x = Mix.fill(4, {
 			LFSaw.ar((note + {0.1.rand2}.dup).midicps, 0, 0.02)
@@ -294,7 +294,7 @@ SynthDef("window-test", { arg note = 36, fc = 1000, rq = 0.25, bal=0, amp=0.4, g
 		x = RLPF.ar(x, fc, rq, amp).softclip;
 		x = Balance2.ar(x[0], x[1], bal);
 		x = x * EnvGen.kr(Env.cutoff, gate, doneAction: Done.freeSelf);
-		Out.ar(0, x);
+		Out.ar(out, x);
 	}, [0.1, 0.1, 0.1, 0.1, 0.1, 0]
 ).add;
 
@@ -382,7 +382,7 @@ var node, cmdPeriodFunc;
 var params, specs;
 
 // define a synth
-SynthDef("window-test", { arg note = 36, fc = 1000, rq = 0.25, bal = 0, amp=0.4, width=0, gate = 1;
+SynthDef("window-test", { |out, note = 36, fc = 1000, rq = 0.25, bal = 0, amp=0.4, width=0, gate = 1|
 		var x;
 		x = Mix.fill(4, {
 			VarSaw.ar((note + {0.1.rand2}.dup).midicps, 0, width, 0.02)
@@ -391,7 +391,7 @@ SynthDef("window-test", { arg note = 36, fc = 1000, rq = 0.25, bal = 0, amp=0.4,
 		x = RLPF.ar(x, fc, rq, amp).softclip;
 		x = Balance2.ar(x[0], x[1], bal);
 		x = x * EnvGen.kr(Env.cutoff, gate, 5, doneAction: Done.freeSelf);
-		Out.ar(0, x);
+		Out.ar(out, x);
 	}, [0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0]
 ).add;
 

--- a/HelpSource/Classes/Env.schelp
+++ b/HelpSource/Classes/Env.schelp
@@ -793,8 +793,8 @@ Task({
 
 // blend in a SynthDef
 (
-SynthDef(\help_EnvBlend, { | factor = 0 |
-	Out.ar(0, EnvGen.kr(blend(Env.perc, Env.sine, factor), 1.0, doneAction: Done.freeSelf)
+SynthDef(\help_EnvBlend, { | out, factor = 0 |
+	Out.ar(out, EnvGen.kr(blend(Env.perc, Env.sine, factor), 1.0, doneAction: Done.freeSelf)
 		* SinOsc.ar(440,0,0.1)
 	)
 }).add

--- a/HelpSource/Classes/EnvGen.schelp
+++ b/HelpSource/Classes/EnvGen.schelp
@@ -293,8 +293,8 @@ SynthDef(\env, { arg i_outbus=0;
 )
 
 (
-SynthDef(\sine, { |freq = 0|
-	Out.ar(0, SinOsc.ar(freq, 0, 0.2));
+SynthDef(\sine, { |out, freq = 440|
+	Out.ar(out, SinOsc.ar(freq, 0, 0.2));
 }).add;
 )
 

--- a/HelpSource/Classes/Event.schelp
+++ b/HelpSource/Classes/Event.schelp
@@ -65,7 +65,7 @@ Pbind(\type, \happyEvent, \degree, Pseq([0, 1, 2, 3, 4, 4, 5, 5, 5, 5, 4, 2, 3, 
 method::makeDefaultSynthDef
 This method is called in order to build the default SynthDef, which is stored under the key strong::\default::
 code::
-SynthDef(\default, { Out.ar(0, Line.kr(0.3, 0, 0.5) * SinOsc.ar(Rand(300, 500.0)) ) }).add; // overwrite default
+SynthDef(\default, { |out| Out.ar(out, Line.kr(0.3, 0, 0.5) * SinOsc.ar(Rand(300, 500.0)) ) }).add; // overwrite default
 (freq: 600).play;
 Event.makeDefaultSynthDef; // reset default
 (freq: 600).play;
@@ -223,7 +223,7 @@ SynthDef(\test, {
 	audio = Mix.ar(Pulse.ar(freq, 0.5));	// this is a mixture of three oscillators
 	env = Linen.kr(gate, susLevel: amp , doneAction: Done.freeSelf);
 	audio = audio * env;
-	OffsetOut.ar(0, audio);
+	OffsetOut.ar(out, audio);
 }).add;
 )
 ::

--- a/HelpSource/Classes/FFTTrigger.schelp
+++ b/HelpSource/Classes/FFTTrigger.schelp
@@ -15,29 +15,25 @@ a flag. If 0.0, the buffer will be prepared for complex data, if > 0.0, polar da
 
 examples::
 code::
-(
-s.waitForBoot({
-	b = Buffer.alloc(s, 512);
-});
-)
+
 // Reminder: This isn't the intended typical usage! It's OK to do this though.
 (
 x = {
 	var mags, phases, chain, sig;
 	// Create simple undulating magnitudes
-	mags = {FSinOsc.kr(ExpRand(0.1, 1)).range(0, 1)}.dup(100);
+	mags = { FSinOsc.kr(ExpRand(0.1, 1)).range(0, 1) }.dup(100);
 	// Then give them a "rolloff" to make the sound less unpleasant
 	mags = mags  * ((1, 0.99 .. 0.01).squared);
 	// Let's turn the bins on and off at different rates, I'm *sure* that'll sound interesting
-	mags = mags * {LFPulse.kr(2 ** IRand(-3, 5)).range(0, 1)}.dup(100);
+	mags = mags * { LFPulse.kr(2 ** IRand(-3, 5)).range(0, 1) }.dup(100);
 	// Let's ignore phase for now
 	phases = 0.dup(100);
-	chain = FFTTrigger(b, 0.5);
+	chain = FFTTrigger(LocalBuf(1, 512), 0.5);
 	// Now we can do the packing
 	chain = PackFFT(chain, 512, [mags, phases].flop.flatten, 0, 99, 1);
 	sig = IFFT(chain);
-	Out.ar(0, sig.dup);
-}.play(s);
+	sig.dup
+}.play
 )
 x.free;
 b.free;

--- a/HelpSource/Classes/FreeVerb.schelp
+++ b/HelpSource/Classes/FreeVerb.schelp
@@ -29,8 +29,8 @@ s.boot;
 
 // FreeVerb - 1x1 ugen
 (
-z = SynthDef(\src, {|mix = 0.25, room = 0.15, damp = 0.5|
-	Out.ar(0,
+z = SynthDef(\src, { |out, mix = 0.25, room = 0.15, damp = 0.5|
+	Out.ar(out,
 		FreeVerb.ar(
 			Decay.ar(Impulse.ar(1), 0.25, LFCub.ar(1200, 0, 0.1)), // mono src
 			mix, // mix 0-1
@@ -48,8 +48,8 @@ z.free
 
 // it expands as any ugen does
 (
-z = SynthDef(\src, {|mix = 0.25, room = 0.15, damp = 0.5|
-	Out.ar(0,
+z = SynthDef(\src, {|out, mix = 0.25, room = 0.15, damp = 0.5|
+	Out.ar(out,
 		FreeVerb.ar(
 			Pan2.ar(
 				Decay.ar(Impulse.ar(1), 0.25, LFCub.ar(1200, 0, 0.1)),

--- a/HelpSource/Classes/FreeVerb2.schelp
+++ b/HelpSource/Classes/FreeVerb2.schelp
@@ -31,25 +31,28 @@ s.boot;
 
 // FreeVerb2 - demo synthdef
 (
-SynthDef(\FreeVerb2x2, {|outbus, mix = 0.25, room = 0.15, damp = 0.5, amp = 1.0|
+SynthDef(\FreeVerb2x2, { |out, mix = 0.25, room = 0.15, damp = 0.5, amp = 1.0|
 	var signal;
 
-	signal = In.ar(outbus, 2);
+	signal = In.ar(out, 2);
 
-	ReplaceOut.ar(outbus,
+	ReplaceOut.ar(out,
 		FreeVerb2.ar( // FreeVerb2 - true stereo UGen
 			signal[0], // Left channel
 			signal[1], // Right Channel
-			mix, room, damp, amp)); // same params as FreeVerb 1 chn version
+			mix, room, damp, amp
+		)
+	); // same params as FreeVerb 1 chn version
 
 }).add;
 )
 
 // 2ch source
 (
-a = SynthDef(\src2x2, {
-	Out.ar(0,
-		Decay.ar(Impulse.ar(1), 0.25, LFCub.ar(1200, 0, 0.1)) ! 2 +
+a = SynthDef(\src2x2, { |out|
+	Out.ar(out,
+		Decay.ar(Impulse.ar(1), 0.25, LFCub.ar(1200, 0, 0.1)) ! 2
+		+
 		Pan2.ar(
 			Decay.ar(Impulse.ar(1, pi), 0.1, WhiteNoise.ar(0.1)),
 			LFNoise1.kr(0.5).range(-1, 1)
@@ -68,22 +71,4 @@ z.set(\damp, 0.9)
 // silence
 [a, z].do(_.free)
 
-// crucial lib example
-(
-Patch({|mix =0.33, room = 0.25, damp = 0.7, amp = 0.1|
-	var signal;
-
-	signal = Decay.ar(Impulse.ar(1), 0.25, LFCub.ar(1200)) ! 2 +
-		Pan2.ar(
-			Decay.ar(Impulse.ar(1, pi), 0.1, WhiteNoise.ar),
-			LFNoise1.kr(0.5).range(-1, 1)
-		);
-
-	FreeVerb2.ar(
-		signal[0], // Left channel
-		signal[1], // Right Channel
-		mix, room, damp, amp)
-
-}).gui
-)
 ::

--- a/HelpSource/Classes/FreqShift.schelp
+++ b/HelpSource/Classes/FreqShift.schelp
@@ -56,77 +56,83 @@ subsection:: More Examples
 send a SynthDef, run the routine then send a different SynthDef
 
 code::
-(// simple detune & pitchmod via FreqShift
-SynthDef("frqShift1",{arg frq,detune=1.5;
-	var e1,left,right;
-	e1 = EnvGen.ar(Env.new([0,0.1,0],[1,2.3]),1,doneAction: Done.freeSelf);
-	left = SinOsc.ar(frq,0,e1); // original tone
-	left = left + FreqShift.ar(left,frq*detune); // shift and add back to original
-	right = FreqShift.ar(left,SinOsc.kr(3.23,0,5));
-	Out.ar(0, [left,right] * 0.1);
+// simple detune & pitchmod via FreqShift
+(
+SynthDef(\frqShift1, { |out, freq, detune=1.5|
+	var e1, left, right;
+	e1 = EnvGen.ar(Env.new([0, 0.1, 0], [1, 2.3]),1, doneAction: Done.freeSelf);
+	left = SinOsc.ar(freq, 0, e1); // original tone
+	left = left + FreqShift.ar(left, freq * detune); // shift and add back to original
+	right = FreqShift.ar(left, SinOsc.kr(3.23, 0, 5));
+	Out.ar(out, [left,right] * 0.1);
 }).add;
 )
 
-(// the routine
+// the routine
+(
 r = Routine({
 	var table,pitch;
 	table = [0,2,4,5,7,9,11,12];
-	inf.do{
+	inf.do {
 		pitch = (48+(12*2.rand) + table.choose).midicps;
-		Synth.grain(\frqShift1, [\frq, pitch]);
+		Synth.grain(\frqShift1, [\freq, pitch]);
 		3.wait;
-		};
 	};
-).play;
+}).play;
 )
 
-(// shift pulse wave in opposite directions
-SynthDef("frqShift1",{arg frq,detune=0.15;
-	var e1,snd,left,right;
-	e1 = EnvGen.ar(Env.new([0,1,0],[0.02,3.2]),1,doneAction: Done.freeSelf);
-	snd = Pulse.ar(frq,SinOsc.kr(2.3).range(0.2,0.8),e1); // original tone
+// shift pulse wave in opposite directions
+(
+SynthDef(\frqShift1, { |out, freq, detune=0.15|
+	var e1, snd, left, right;
+	e1 = EnvGen.ar(Env.new([0, 1, 0],[0.02, 3.2]), 1, doneAction: Done.freeSelf);
+	snd = Pulse.ar(freq, SinOsc.kr(2.3).range(0.2,0.8), e1); // original tone
 	left = FreqShift.ar(snd,XLine.kr(-0.1,-200,2)); // shift and add back to original
 	right = FreqShift.ar(snd,XLine.kr(0.1,200,2));
-	Out.ar(0, [left,right] * 0.1);
+	Out.ar(out, [left, right] * 0.1);
 }).add
 )
 
-(// FreqShift >> feedback >>> FreqShiftc
-SynthDef("frqShift1",{arg frq;
+// FreqShift >> feedback >>> FreqShiftc
+(
+SynthDef("frqShift1", { |out, freq|
 	var e1,snd,snd2,in;
-	in = FreqShift.ar(InFeedback.ar(0,1)*3.2,XLine.ar(0.01,frq*1.5,1)); // shift the feedback
-	e1 = Env.new([0,0.1,0],[0.02,2.98]);
-	snd = SinOsc.ar(frq,0,EnvGen.ar(e1,1,doneAction: Done.freeSelf));
-	snd2 = FreqShift.ar(snd+in,SinOsc.ar(4.24,0.5,3),0,0.5); // subtle modulating shift
-	OffsetOut.ar([0,1], Limiter.ar(snd2+snd * 0.5,1,0.005));
+	in = FreqShift.ar(InFeedback.ar(0, 1) * 3.2, XLine.ar(0.01, freq * 1.5, 1)); // shift the feedback
+	e1 = Env.new([0, 0.1, 0], [0.02, 2.98]);
+	snd = SinOsc.ar(freq, 0, EnvGen.ar(e1, 1, doneAction: Done.freeSelf));
+	snd2 = FreqShift.ar(snd+in, SinOsc.ar(4.24, 0.5, 3), 0, 0.5); // subtle modulating shift
+	OffsetOut.ar(0, Limiter.ar(snd2 + snd * 0.5, 1, 0.005) ! 2);
 }).add;
 )
 
 
-(// ssllooww columbia tuned shift detune
+// ssllooww columbia tuned shift detune
+(
 r.stop; // stop old routine
 Buffer.read(s, Platform.resourceDir +/+ "sounds/a11wlk01.wav", bufnum:99);
 
-SynthDef("frqShift1",{arg frq, bufnum;
+SynthDef(\frqShift1, { |out, freq, bufnum|
 	var e1,snd,left,right;
-	e1 = Env.new([0,1,0],[3,1],-4);
+	e1 = Env.new([0,1,0], [3,1], -4);
 	snd = PlayBuf.ar(1, bufnum, BufRateScale.kr(bufnum) * 0.01, loop:1);
-	left = FreqShift.ar(snd,frq*2,0,EnvGen.ar(e1,1,doneAction: Done.freeSelf)); // subtle shift of the output
-	right = FreqShift.ar(snd,frq*3,0,EnvGen.ar(e1,1,doneAction: Done.freeSelf));
-	Out.ar(0, [left,right] * 3);
+	// subtle shift of the output
+	left = FreqShift.ar(snd, freq * 2, 0, EnvGen.ar(e1, 1, doneAction: Done.freeSelf));
+	right = FreqShift.ar(snd, freq * 3, 0, EnvGen.ar(e1, 1, doneAction: Done.freeSelf));
+	Out.ar(out, [left, right] * 3);
 }).add;
+)
 
-(// the routine
+// the routine
+(
 r = Routine({
-	var table,pitch;
+	var table, pitch;
 	table = [0,2,4,5,7,9,11,12];
 	inf.do{
 		pitch = (48+(12*2.rand) + table.choose).midicps;
-		s.sendMsg("s_new","frqShift1",-1,1,1, "frq", pitch, "bufnum", 99);
+		s.sendMsg(\s_new, \frqShift1, -1, 1, 1, \freq, pitch, \bufnum, 99);
 		3.wait;
 		};
-	};
-).play;
+	}).play
 )
 ::
 

--- a/HelpSource/Classes/GVerb.schelp
+++ b/HelpSource/Classes/GVerb.schelp
@@ -41,25 +41,37 @@ argument:: add
 
 examples::
 code::
-SynthDef(\test, {arg roomsize, revtime, damping, inputbw, spread = 15, drylevel, earlylevel,
-		taillevel;
-	var a = Resonz.ar(
-		Array.fill(4, {Dust.ar(2)}), 1760 * [1, 2, 4, 8], 0.01).sum * 10;
-//	var a = SoundIn.ar(0);
-//	var a = PlayBuf.ar(1, 0);
-	Out.ar(0, GVerb.ar(
-		a,
-		roomsize,
-		revtime,
-		damping,
-		inputbw,
-		spread,
-		drylevel.dbamp,
-		earlylevel.dbamp,
-		taillevel.dbamp,
-		roomsize, 0.3) + a)}).add
+(
+SynthDef(\test, { |out, roomsize, revtime, damping, inputbw, spread = 15, drylevel, earlylevel,
+	taillevel|
 
-s.boot;
+	var a = Resonz.ar(
+		Array.fill(4, { Dust.ar(2) }),
+		1760 * [1, 2, 4, 8],
+		0.01
+	).sum * 10;
+
+	//	var a = SoundIn.ar(0);
+	//	var a = PlayBuf.ar(1, 0);
+
+	Out.ar(out,
+		GVerb.ar(
+			a,
+			roomsize,
+			revtime,
+			damping,
+			inputbw,
+			spread,
+			drylevel.dbamp,
+			earlylevel.dbamp,
+			taillevel.dbamp,
+			roomsize, 0.3)
+		+ a
+	)
+}).add
+)
+
+
 s.scope(2);
 
 // bathroom

--- a/HelpSource/Classes/Gendy1.schelp
+++ b/HelpSource/Classes/Gendy1.schelp
@@ -143,8 +143,8 @@ code::
 {
     var mx, my;
 
-    mx= MouseX.kr(220,440);
-    my= MouseY.kr(0.0,1.0);
+    mx = MouseX.kr(220,440);
+    my = MouseY.kr(0.0,1.0);
 
     Pan2.ar(Gendy1.ar(2,3,1,1,minfreq:mx, maxfreq:8*mx, ampscale:my, durscale:my, initCPs:7, mul:0.3), 0.0)
 }.play
@@ -187,106 +187,122 @@ code::
 //modulate num of CPs
 {Pan2.ar(Gendy1.ar(knum:MouseX.kr(1,13),mul:0.2), 0.0)}.play
 
-
-(//Gendy into Gendy...with cartoon side effects
-{Pan2.ar(Gendy1.ar(
-    maxfreq:Gendy1.kr(5,4,0.3, 0.7, 0.1, MouseY.kr(0.1,10), 1.0, 1.0, 5,5, 500, 600),
-    knum:MouseX.kr(1,13),mul:0.2), 0.0)
-}.play
-)
+//Gendy into Gendy...with cartoon side effects
+	(
+		{
+			Pan2.ar(Gendy1.ar(
+				maxfreq:Gendy1.kr(5,4,0.3, 0.7, 0.1, MouseY.kr(0.1,10), 1.0, 1.0, 5,5, 500, 600),
+				knum:MouseX.kr(1,13),mul:0.2), 0.0)
+		}.play
+	)
 
 //use SINUS to track any oscillator and take CP positions from it, use adparam and ddparam as the inputs to sample
 {Pan2.ar(Gendy1.ar(6,6,LFPulse.kr(100, 0, 0.4, 1.0), SinOsc.kr(30, 0, 0.5),mul:0.2), 0.0)}.play
 
 
 //try out near the corners especially
-(
-{Pan2.ar(Gendy1.ar(6,6,LFPulse.kr(MouseX.kr(0,200), 0, 0.4, 1.0),
-    SinOsc.kr(MouseY.kr(0,200), 0, 0.5),mul:0.2), 0.0)}.play
-)
+	(
+		{ Pan2.ar(Gendy1.ar(6,6,LFPulse.kr(MouseX.kr(0,200), 0, 0.4, 1.0),
+			SinOsc.kr(MouseY.kr(0,200), 0, 0.5),mul:0.2), 0.0)
+		}.play
+	)
 
 //texture
-(
-{
-Mix.fill(10,{
-var freq;
+	(
+		{
+			Mix.fill(10,{
+				var freq;
 
-freq= rrand(130,160.3);
-Pan2.ar(SinOsc.ar(Gendy1.ar(6.rand,6.rand,SinOsc.kr(0.1,0,0.49,0.51),
-    SinOsc.kr(0.13,0,0.49,0.51),freq ,freq, SinOsc.kr(0.17,0,0.49,0.51),
-    SinOsc.kr(0.19,0,0.49,0.51), 12, 12, 200, 400), 0, 0.1), 1.0.rand2)
-});
-}.play
-)
+				freq= rrand(130,160.3);
+				Pan2.ar(SinOsc.ar(Gendy1.ar(6.rand,6.rand,SinOsc.kr(0.1,0,0.49,0.51),
+					SinOsc.kr(0.13,0,0.49,0.51),freq ,freq, SinOsc.kr(0.17,0,0.49,0.51),
+					SinOsc.kr(0.19,0,0.49,0.51), 12, 12, 200, 400), 0, 0.1), 1.0.rand2)
+			});
+		}.play
+	)
 
 //wahhhhhhhh- try durscale 10.0 and 0.0 too
-(
-{Pan2.ar(
-CombN.ar(
-Resonz.ar(
-Gendy1.ar(2,3,minfreq:1, maxfreq:MouseX.kr(10,700), durscale:0.1, initCPs:10),
-MouseY.kr(50,1000), 0.1)
-,0.1,0.1,5, 0.6
-)
-, 0.0)}.play
-)
+	(
+		{
+			Pan2.ar(
+				CombN.ar(
+					Resonz.ar(
+						Gendy1.ar(2,3,minfreq:1, maxfreq: MouseX.kr(10,700), durscale:0.1, initCPs:10),
+						MouseY.kr(50, 1000), 0.1)
+					,0.1,0.1,5, 0.6
+				)
+				, 0.0)
+		}.play
+	)
 
 //overkill
-(
-{
-var n;
-n=10;
+	(
+		{
+			var n;
+			n = 10;
 
-Mix.fill(n,{
-var freq, numcps;
+			Mix.fill(n, {
+				var freq, numcps;
 
-freq= rrand(130,160.3);
-numcps= rrand(2,20);
-Pan2.ar(Gendy1.ar(6.rand,6.rand,1.0.rand,1.0.rand,freq ,freq, 1.0.rand, 1.0.rand, numcps,
-    SinOsc.kr(exprand(0.02,0.2), 0, numcps/2, numcps/2), 0.5/(n.sqrt)), 1.0.rand2)
-});
-}.play
-)
+				freq= rrand(130, 160.3);
+				numcps= rrand(2, 20);
+				Pan2.ar(
+					Gendy1.ar(
+						6.rand,6.rand,1.0.rand,1.0.rand,freq ,freq, 1.0.rand, 1.0.rand, numcps,
+						SinOsc.kr(exprand(0.02,0.2), 0, numcps/2, numcps/2), 0.5/(n.sqrt)
+					),
+					1.0.rand2
+				)
+			})
+		}.play
+	)
 
 //another traffic moment
-(
-{
-    var n;
-    n=10;
+	(
+		{
+			var n;
+			n =10;
 
-    Resonz.ar(
-    Mix.fill(n,{
-    var freq, numcps;
+			Resonz.ar(
+				Mix.fill(n, {
+					var freq, numcps;
 
-    freq= rrand(50,560.3);
-    numcps= rrand(2,20);
-    Pan2.ar(Gendy1.ar(6.rand,6.rand,1.0.rand,1.0.rand,freq ,freq, 1.0.rand, 1.0.rand, numcps,
-        SinOsc.kr(exprand(0.02,0.2), 0, numcps/2, numcps/2), 0.5/(n.sqrt)), 1.0.rand2)
-    })
-    ,MouseX.kr(100,2000), MouseY.kr(0.01,1.0))
-    ;
-}.play
-)
+					freq = rrand(50,560.3);
+					numcps = rrand(2,20);
+					Pan2.ar(Gendy1.ar(6.rand,6.rand,1.0.rand,1.0.rand,freq ,freq, 1.0.rand, 1.0.rand, numcps,
+						SinOsc.kr(exprand(0.02,0.2), 0, numcps/2, numcps/2), 0.5/(n.sqrt)), 1.0.rand2)
+				}),
+				MouseX.kr(100,2000),
+				MouseY.kr(0.01,1.0)
+			)
+		}.play
+	)
 
-(
-{
-var n;
-n=15;
+	(
+		{
+			var n;
+			n=15;
 
-Out.ar(0,
-Resonz.ar(
-Mix.fill(n,{
-var freq, numcps;
 
-freq= rrand(330,460.3);
-numcps= rrand(2,20);
-Pan2.ar(Gendy1.ar(6.rand,6.rand,1.0.rand,1.0.rand,freq,MouseX.kr(freq,2*freq), 1.0.rand, 1.0.rand, numcps,
-    SinOsc.kr(exprand(0.02,0.2), 0, numcps/2, numcps/2), 0.5/(n.sqrt)), 1.0.rand2)
-})
-,MouseX.kr(100,2000), MouseY.kr(0.01,1.0))
-)
+			Resonz.ar(
+				Mix.fill(n,{
+					var freq, numcps;
 
-}.play;
-)
+					freq = rrand(330,460.3);
+					numcps = rrand(2,20);
+					Pan2.ar(
+						Gendy1.ar(
+							6.rand, 6.rand, 1.0.rand, 1.0.rand, freq,
+							MouseX.kr(freq, 2*freq), 1.0.rand, 1.0.rand, numcps,
+							SinOsc.kr(exprand(0.02,0.2), 0, numcps/2, numcps/2), 0.5/(n.sqrt)
+						),
+						1.0.rand2
+					)
+				}),
+				MouseX.kr(100, 2000), MouseY.kr(0.01, 1.0)
+			)
+
+		}.play;
+	)
 ::
 

--- a/HelpSource/Classes/Gendy1.schelp
+++ b/HelpSource/Classes/Gendy1.schelp
@@ -129,33 +129,33 @@ if you have lots of CPs and you have fast frequencies, the CPU cost goes up a lo
 ::
 
 code::
-//defaults
+// defaults
 {Pan2.ar(Gendy1.ar)}.play
 
-//wandering bass/ powerline
-{Pan2.ar(Gendy1.ar(1,1,1.0,1.0,30,100,0.3,0.05,5))}.play
+// wandering bass/ powerline
+{ Pan2.ar(Gendy1.ar(1, 1, 1.0, 1.0, 30, 100, 0.3, 0.05, 5)) }.play
 
-//play me
-{Pan2.ar(RLPF.ar(Gendy1.ar(2,3,minfreq:20,maxfreq:MouseX.kr(100,1000),durscale:0.0,initCPs:40),500,0.3,0.2),0.0)}.play
+// play me
+{ Pan2.ar(RLPF.ar(Gendy1.ar(2, 3, minfreq:20, maxfreq:MouseX.kr(100,1000), durscale:0.0, initCPs:40), 500, 0.3, 0.2), 0.0)}.play
 
-//scream! - careful with your ears for this one!
+// scream! - careful with your ears for this one!
 (
 {
     var mx, my;
 
-    mx = MouseX.kr(220,440);
-    my = MouseY.kr(0.0,1.0);
+    mx = MouseX.kr(220, 440);
+    my = MouseY.kr(0.0, 1.0);
 
     Pan2.ar(Gendy1.ar(2,3,1,1,minfreq:mx, maxfreq:8*mx, ampscale:my, durscale:my, initCPs:7, mul:0.3), 0.0)
 }.play
 )
 
 
-//1 CP = random noise effect
-{Pan2.ar(Gendy1.ar(initCPs:1))}.play
+// 1 CP = random noise effect
+{ Pan2.ar(Gendy1.ar(initCPs:1)) }.play
 
-//2 CPs = suudenly an oscillator (though a fast modulating one here)
-{Pan2.ar(Gendy1.ar(initCPs:2))}.play
+// 2 CPs = suudenly an oscillator (though a fast modulating one here)
+{ Pan2.ar(Gendy1.ar(initCPs:2)) }.play
 
 
 //used as an LFO
@@ -164,92 +164,89 @@ code::
     Pan2.ar(
         SinOsc.ar(
             Gendy1.kr(2, 4,
-                SinOsc.kr(0.1,0,0.49,0.51),
-                SinOsc.kr(0.13,0,0.49,0.51),
+                SinOsc.kr(0.1, 0, 0.49, 0.51),
+                SinOsc.kr(0.13, 0, 0.49, 0.51),
                 3.4, 3.5,
-                SinOsc.kr(0.17,0,0.49,0.51),
-                SinOsc.kr(0.19,0,0.49,0.51),
-                10,10,50, 350),
+                SinOsc.kr(0.17, 0, 0.49, 0.51),
+                SinOsc.kr(0.19, 0, 0.49, 0.51),
+                10, 10, 50, 350),
         0, 0.3),
     0.0)
 }.play
 )
 
-//wasp
-{Pan2.ar(Gendy1.ar(0, 0, SinOsc.kr(0.1, 0, 0.1, 0.9),1.0, 50,1000, 1,0.005, 12, 12, 0.2), 0.0)}.play
+// wasp
+{ Pan2.ar(Gendy1.ar(0, 0, SinOsc.kr(0.1, 0, 0.1, 0.9), 1.0, 50, 1000, 1, 0.005, 12, 12, 0.2), 0.0)}.play
 
 
-//modulate distributions
-//change of pitch as distributions change the duration structure and spectrum
-{Pan2.ar(Gendy1.ar(MouseX.kr(0,7),MouseY.kr(0,7),mul:0.2), 0.0)}.play
+// modulate distributions
+// change of pitch as distributions change the duration structure and spectrum
+{ Pan2.ar(Gendy1.ar(MouseX.kr(0, 7), MouseY.kr(0, 7), mul:0.2), 0.0) }.play
 
 
-//modulate num of CPs
-{Pan2.ar(Gendy1.ar(knum:MouseX.kr(1,13),mul:0.2), 0.0)}.play
+// modulate num of CPs
+{ Pan2.ar(Gendy1.ar(knum:MouseX.kr(1, 13), mul:0.2), 0.0) }.play
 
-//Gendy into Gendy...with cartoon side effects
+// Gendy into Gendy ... with cartoon side effects
 	(
 		{
 			Pan2.ar(Gendy1.ar(
-				maxfreq:Gendy1.kr(5,4,0.3, 0.7, 0.1, MouseY.kr(0.1,10), 1.0, 1.0, 5,5, 500, 600),
-				knum:MouseX.kr(1,13),mul:0.2), 0.0)
+				maxfreq:Gendy1.kr(5, 4, 0.3, 0.7, 0.1, MouseY.kr(0.1, 10), 1.0, 1.0, 5, 5, 500, 600),
+				knum:MouseX.kr(1, 13), mul:0.2), 0.0)
 		}.play
 	)
 
-//use SINUS to track any oscillator and take CP positions from it, use adparam and ddparam as the inputs to sample
-{Pan2.ar(Gendy1.ar(6,6,LFPulse.kr(100, 0, 0.4, 1.0), SinOsc.kr(30, 0, 0.5),mul:0.2), 0.0)}.play
+// use SINUS to track any oscillator and take CP positions from it, use adparam and ddparam as the inputs to sample
+{ Pan2.ar(Gendy1.ar(6, 6, LFPulse.kr(100, 0, 0.4, 1.0), SinOsc.kr(30, 0, 0.5), mul:0.2), 0.0) }.play
 
 
 //try out near the corners especially
 	(
-		{ Pan2.ar(Gendy1.ar(6,6,LFPulse.kr(MouseX.kr(0,200), 0, 0.4, 1.0),
+		{ 
+			Pan2.ar(Gendy1.ar(6,6,LFPulse.kr(MouseX.kr(0,200), 0, 0.4, 1.0),
 			SinOsc.kr(MouseY.kr(0,200), 0, 0.5),mul:0.2), 0.0)
 		}.play
 	)
 
-//texture
+// texture
 	(
 		{
-			Mix.fill(10,{
-				var freq;
-
-				freq= rrand(130,160.3);
-				Pan2.ar(SinOsc.ar(Gendy1.ar(6.rand,6.rand,SinOsc.kr(0.1,0,0.49,0.51),
-					SinOsc.kr(0.13,0,0.49,0.51),freq ,freq, SinOsc.kr(0.17,0,0.49,0.51),
-					SinOsc.kr(0.19,0,0.49,0.51), 12, 12, 200, 400), 0, 0.1), 1.0.rand2)
-			});
+			Mix.fill(10, {
+				var freq = rrand(130,160.3);
+				Pan2.ar(SinOsc.ar(Gendy1.ar(6.rand, 6.rand, SinOsc.kr(0.1, 0, 0.49, 0.51),
+					SinOsc.kr(0.13, 0, 0.49, 0.51), freq, freq, SinOsc.kr(0.17, 0, 0.49, 0.51),
+					SinOsc.kr(0.19, 0, 0.49, 0.51), 12, 12, 200, 400), 0, 0.1), 1.0.rand2)
+			})
 		}.play
 	)
 
-//wahhhhhhhh- try durscale 10.0 and 0.0 too
+// wahhhhhhhh- try durscale 10.0 and 0.0 too
 	(
 		{
 			Pan2.ar(
 				CombN.ar(
 					Resonz.ar(
-						Gendy1.ar(2,3,minfreq:1, maxfreq: MouseX.kr(10,700), durscale:0.1, initCPs:10),
-						MouseY.kr(50, 1000), 0.1)
-					,0.1,0.1,5, 0.6
-				)
-				, 0.0)
+						Gendy1.ar(2, 3, minfreq:1, maxfreq: MouseX.kr(10, 700), durscale:0.1, initCPs:10),
+						MouseY.kr(50, 1000), 0.1),
+					0.1, 0.1, 5, 0.6
+				),
+				0.0)
 		}.play
 	)
 
-//overkill
+// overkill
 	(
 		{
-			var n;
-			n = 10;
-
+			var n = 10;
 			Mix.fill(n, {
 				var freq, numcps;
 
-				freq= rrand(130, 160.3);
-				numcps= rrand(2, 20);
+				freq = rrand(130, 160.3);
+				numcps = rrand(2, 20);
 				Pan2.ar(
 					Gendy1.ar(
-						6.rand,6.rand,1.0.rand,1.0.rand,freq ,freq, 1.0.rand, 1.0.rand, numcps,
-						SinOsc.kr(exprand(0.02,0.2), 0, numcps/2, numcps/2), 0.5/(n.sqrt)
+						6.rand, 6.rand, 1.0.rand, 1.0.rand, freq, freq, 1.0.rand, 1.0.rand, numcps,
+						SinOsc.kr(exprand(0.02, 0.2), 0, numcps/2, numcps/2), 0.5 / (n.sqrt)
 					),
 					1.0.rand2
 				)
@@ -257,7 +254,7 @@ code::
 		}.play
 	)
 
-//another traffic moment
+// another traffic moment
 	(
 		{
 			var n;
@@ -269,8 +266,8 @@ code::
 
 					freq = rrand(50,560.3);
 					numcps = rrand(2,20);
-					Pan2.ar(Gendy1.ar(6.rand,6.rand,1.0.rand,1.0.rand,freq ,freq, 1.0.rand, 1.0.rand, numcps,
-						SinOsc.kr(exprand(0.02,0.2), 0, numcps/2, numcps/2), 0.5/(n.sqrt)), 1.0.rand2)
+					Pan2.ar(Gendy1.ar(6.rand, 6.rand, 1.0.rand, 1.0.rand, freq, freq, 1.0.rand, 1.0.rand, numcps,
+						SinOsc.kr(exprand(0.02, 0.2), 0, numcps/2, numcps/2), 0.5/(n.sqrt)), 1.0.rand2)
 				}),
 				MouseX.kr(100,2000),
 				MouseY.kr(0.01,1.0)
@@ -280,21 +277,20 @@ code::
 
 	(
 		{
-			var n;
-			n=15;
+			var n = 15;
 
 
 			Resonz.ar(
 				Mix.fill(n,{
 					var freq, numcps;
 
-					freq = rrand(330,460.3);
-					numcps = rrand(2,20);
+					freq = rrand(330, 460.3);
+					numcps = rrand(2, 20);
 					Pan2.ar(
 						Gendy1.ar(
 							6.rand, 6.rand, 1.0.rand, 1.0.rand, freq,
 							MouseX.kr(freq, 2*freq), 1.0.rand, 1.0.rand, numcps,
-							SinOsc.kr(exprand(0.02,0.2), 0, numcps/2, numcps/2), 0.5/(n.sqrt)
+							SinOsc.kr(exprand(0.02, 0.2), 0, numcps/2, numcps/2), 0.5/(n.sqrt)
 						),
 						1.0.rand2
 					)

--- a/HelpSource/Classes/GrainBuf.schelp
+++ b/HelpSource/Classes/GrainBuf.schelp
@@ -70,7 +70,7 @@ b = Buffer.read(s, Platform.resourceDir +/+ "sounds/a11wlk01-44_1.aiff");
 winenv = Env([0, 1, 0], [0.5, 0.5], [8, -8]);
 z = Buffer.sendCollection(s, winenv.discretize, 1);
 
-SynthDef(\buf_grain_test, {arg gate = 1, amp = 1, sndbuf, envbuf;
+SynthDef(\buf_grain_test, { |out, gate = 1, amp = 1, sndbuf, envbuf|
 	var pan, env, freqdev;
 	// use mouse x to control panning
 	pan = MouseX.kr(-1, 1);
@@ -79,11 +79,10 @@ SynthDef(\buf_grain_test, {arg gate = 1, amp = 1, sndbuf, envbuf;
 		gate,
 		levelScale: amp,
 		doneAction: Done.freeSelf);
-	Out.ar(0,
+	Out.ar(out,
 		GrainBuf.ar(2, Impulse.kr(10), 0.1, sndbuf, LFNoise1.kr.range(0.5, 2),
 			LFNoise2.kr(0.1).range(0, 1), 2, pan, envbuf) * env)
-	}).add;
-
+}).add;
 )
 
 // use built-in env

--- a/HelpSource/Classes/GrainFM.schelp
+++ b/HelpSource/Classes/GrainFM.schelp
@@ -60,7 +60,7 @@ var winenv;
 winenv = Env([0, 1, 0], [0.5, 0.5], [8, -8]);
 z = Buffer.sendCollection(s, winenv.discretize, 1);
 
-SynthDef(\fm_grain_test, {arg gate = 1, amp = 1, envbuf;
+SynthDef(\fm_grain_test, { |out, gate = 1, amp = 1, envbuf|
 	var pan, env, freqdev;
 	// use mouse x to control panning
 	pan = MouseX.kr(-1, 1);
@@ -71,10 +71,10 @@ SynthDef(\fm_grain_test, {arg gate = 1, amp = 1, envbuf;
 		gate,
 		levelScale: amp,
 		doneAction: Done.freeSelf);
-	Out.ar(0,
+	Out.ar(out,
 		GrainFM.ar(2, Impulse.kr(10), 0.1, 440 + freqdev, 200, LFNoise1.kr.range(1, 10),
 			pan, envbuf) * env)
-	}).add;
+}).add;
 
 )
 

--- a/HelpSource/Classes/GrainIn.schelp
+++ b/HelpSource/Classes/GrainIn.schelp
@@ -54,7 +54,7 @@ var winenv;
 winenv = Env([0, 1, 0], [0.5, 0.5], [8, -8]);
 z = Buffer.sendCollection(s, winenv.discretize, 1);
 
-SynthDef(\in_grain_test, {arg gate = 1, amp = 1, envbuf;
+SynthDef(\in_grain_test, { |out, gate = 1, amp = 1, envbuf|
 	var pan, env;
 	// use mouse x to control panning
 	pan = MouseX.kr(-1, 1);
@@ -63,9 +63,9 @@ SynthDef(\in_grain_test, {arg gate = 1, amp = 1, envbuf;
 		gate,
 		levelScale: amp,
 		doneAction: Done.freeSelf);
-	Out.ar(0,
+	Out.ar(out,
 		GrainIn.ar(2, Impulse.kr(32), 1, PinkNoise.ar * 0.05, pan, envbuf) * env)
-	}).add;
+}).add;
 
 )
 

--- a/HelpSource/Classes/GrainSin.schelp
+++ b/HelpSource/Classes/GrainSin.schelp
@@ -56,7 +56,7 @@ var winenv;
 winenv = Env([0, 1, 0], [0.5, 0.5], [8, -8]);
 z = Buffer.sendCollection(s, winenv.discretize, 1);
 
-SynthDef(\sin_grain_test, {arg gate = 1, amp = 1, envbuf;
+SynthDef(\sin_grain_test, { |out, gate = 1, amp = 1, envbuf|
 	var pan, env, freqdev;
 	// use mouse x to control panning
 	pan = MouseX.kr(-1, 1);
@@ -66,12 +66,13 @@ SynthDef(\sin_grain_test, {arg gate = 1, amp = 1, envbuf;
 		Env([0, 1, 0], [1, 1], \sin, 1),
 		gate,
 		levelScale: amp,
-		doneAction: Done.freeSelf);
-	Out.ar(0,
+		doneAction: Done.freeSelf
+	);
+	Out.ar(out,
 		GrainSin.ar(2, Impulse.kr(10), 0.1, 440 + freqdev, pan, envbuf) * env)
-	}).add;
-
+}).add;
 )
+
 s.scope
 // use built-in env
 x = Synth(\sin_grain_test, [\envbuf, -1])

--- a/HelpSource/Classes/Index.schelp
+++ b/HelpSource/Classes/Index.schelp
@@ -32,13 +32,13 @@ code::
 (
 {
 	SinOsc.ar(
-			Index.kr(
-				LocalBuf.newFrom([ 200, 300, 400, 500, 600, 800 ]),
-				LFSaw.kr(2.0).range(0, 7)
-			),
-			0,
-			0.5
-		)
+		Index.kr(
+			LocalBuf.newFrom([ 200, 300, 400, 500, 600, 800 ]),
+			LFSaw.kr(2.0).range(0, 7)
+		),
+		0,
+		0.5
+	)
 }.play;
 )
 
@@ -46,13 +46,13 @@ code::
 (
 {
 	SinOsc.ar(
-			Index.kr(
-				LocalBuf.newFrom([ 200, 300, 400, 500, 600, 800 ]),
-				MouseX.kr(0, 7)
-			),
-			0,
-			0.5
-		)
+		Index.kr(
+			LocalBuf.newFrom([ 200, 300, 400, 500, 600, 800 ]),
+			MouseX.kr(0, 7)
+		),
+		0,
+		0.5
+	)
 }.play;
 )
 
@@ -65,8 +65,8 @@ b = Buffer(s, t.size, 1);
 // alloc and set the values
 s.listSendMsg( b.allocMsg( b.setnMsg(0, t) ).postln );
 
-SynthDef(\help_Index, { arg out = 0, i_bufnum = 0;
-	Out.ar(0,
+SynthDef(\help_Index, { | out = 0, i_bufnum = 0 |
+	Out.ar(out,
 		SinOsc.ar(
 			Index.kr(
 				i_bufnum,
@@ -83,8 +83,8 @@ b.setn(*[ 200, 300, 400, 500, 600, 800 ].scramble.postln - 30);
 
 
 (
-SynthDef(\help_Index, { arg out=0,i_bufnum=0;
-	Out.ar(0,
+SynthDef(\help_Index, { |out=0, i_bufnum=0|
+	Out.ar(out,
 		SinOsc.ar(
 			Index.kr(
 				i_bufnum,

--- a/HelpSource/Classes/Index.schelp
+++ b/HelpSource/Classes/Index.schelp
@@ -65,36 +65,36 @@ b = Buffer(s, t.size, 1);
 // alloc and set the values
 s.listSendMsg( b.allocMsg( b.setnMsg(0, t) ).postln );
 
-SynthDef(\help_Index, { | out = 0, i_bufnum = 0 |
+SynthDef(\help_Index, { |out = 0, bufnum = 0|
 	Out.ar(out,
 		SinOsc.ar(
 			Index.kr(
-				i_bufnum,
+				bufnum,
 				LFSaw.kr(2).range(0, 7)
 			),
 			0,
 			0.5
 		)
 	)
-}).play(s, [\i_bufnum, b]);
+}).play(s, [\bufnum, b]);
 )
 
-b.setn(*[ 200, 300, 400, 500, 600, 800 ].scramble.postln - 30);
+b.setn(*[200, 300, 400, 500, 600, 800].scramble.postln - 30);
 
 
 (
-SynthDef(\help_Index, { |out=0, i_bufnum=0|
+SynthDef(\help_Index, { |out=0, bufnum=0|
 	Out.ar(out,
 		SinOsc.ar(
 			Index.kr(
-				i_bufnum,
+				bufnum,
 				MouseX.kr(0, BufFrames.ir(i_bufnum))
 			),
 			0,
 			0.5
 		)
 	)
-}).play(s, [\i_bufnum, b]);
+}).play(s, [\bufnum, b]);
 )
 
 b.free;

--- a/HelpSource/Classes/IndexL.schelp
+++ b/HelpSource/Classes/IndexL.schelp
@@ -21,7 +21,7 @@ code::
 {
 	SinOsc.ar(
 		IndexL.kr(
-			LocalBuf.newFrom([ 200, 300, 400, 500, 600, 800 ].scramble),
+			LocalBuf.newFrom([200, 300, 400, 500, 600, 800].scramble),
 			LFSaw.kr(2.0).range(0, 7)
 		),
 		0,
@@ -35,7 +35,7 @@ code::
 {
 	SinOsc.ar(
 		IndexL.kr(
-			LocalBuf.newFrom([ 200, 300, 400, 500, 600, 800 ].scramble),
+			LocalBuf.newFrom([200, 300, 400, 500, 600, 800].scramble),
 			MouseX.kr(0, 7)
 		),
 		0,
@@ -52,36 +52,36 @@ b = Buffer(s, t.size, 1);
 // alloc and set the values
 s.listSendMsg( b.allocMsg( b.setnMsg(0, t) ).postln );
 
-SynthDef(\help_index, { |out = 0, i_bufnum = 0|
+SynthDef(\help_index, { |out = 0, bufnum = 0|
 	Out.ar(out,
 		SinOsc.ar(
 			IndexL.kr(
-				i_bufnum,
-				LFSaw.kr(2).range(0, 7)
+				bufnum,
+				LFSaw.kr(2).range(0, BufFrames.kr(bufnum))
 			),
 			0,
 			0.5
 		)
 	)
-}).play(s, [\i_bufnum, b]);
+}).play(s, [\bufnum, b]);
 )
 
 b.setn(*[ 200, 300, 400, 500, 600, 800 ].scramble.postln - 30);
 
 
 (
-SynthDef(\help_index, { |out = 0, i_bufnum = 0|
+SynthDef(\help_index, { |out = 0, bufnum = 0|
 	Out.ar(out,
 		SinOsc.ar(
 			IndexL.kr(
-				i_bufnum,
-				MouseX.kr(0, BufFrames.ir(i_bufnum))
+				bufnum,
+				MouseX.kr(0, BufFrames.ir(bufnum))
 			),
 			0,
 			0.5
 		)
 	)
-}).play(s, [\i_bufnum, b]);
+}).play(s, [\bufnum, b]);
 )
 
 b.free;

--- a/HelpSource/Classes/IndexL.schelp
+++ b/HelpSource/Classes/IndexL.schelp
@@ -46,15 +46,14 @@ code::
 
 (
 // indexing into a changeable table
-s = Server.local;
 t = [ 200, 300, 400, 500, 600, 800 ];
 b = Buffer(s, t.size, 1);
 
 // alloc and set the values
 s.listSendMsg( b.allocMsg( b.setnMsg(0, t) ).postln );
 
-SynthDef(\help_index, { arg out = 0, i_bufnum = 0;
-	Out.ar(0,
+SynthDef(\help_index, { |out = 0, i_bufnum = 0|
+	Out.ar(out,
 		SinOsc.ar(
 			IndexL.kr(
 				i_bufnum,
@@ -71,8 +70,8 @@ b.setn(*[ 200, 300, 400, 500, 600, 800 ].scramble.postln - 30);
 
 
 (
-SynthDef(\help_index, { arg out = 0, i_bufnum = 0;
-	Out.ar(0,
+SynthDef(\help_index, { |out = 0, i_bufnum = 0|
+	Out.ar(out,
 		SinOsc.ar(
 			IndexL.kr(
 				i_bufnum,

--- a/HelpSource/Classes/KeyTrack.schelp
+++ b/HelpSource/Classes/KeyTrack.schelp
@@ -12,11 +12,6 @@ method:: kr
 
 argument:: chain
 [fft] Audio input to track. This must have been pre-analysed by a 4096 size FFT. No other FFT sizes are valid except as noted below.
-code::
-// With standard hop of half FFT size = 2048 samples
-b = Buffer.alloc(s,4096,1); // for sampling rates 44100 and 48000
-//b = Buffer.alloc(s,8192,1); // for sampling rates 88200 and 96000
-::
 
 argument:: keydecay
 [sk] Number of seconds for the influence of a window on the final key decision to decay by 40dB (to 0.01 its original value).
@@ -38,24 +33,25 @@ d = Buffer.read(s,"/Volumes/data/stevebeattrack/samples/115.wav");
 // 57 = b minor
 // 78 e minor
 // 08 Bb major
-d = Buffer.read(s, "/Users/nickcollins/Desktop/ML/training_wav/78.wav")
 
-b = Buffer.alloc(s, 4096, 1); // for sampling rates 44100 and 48000
+d = Buffer.read(s, "/Users/nickcollins/Desktop/ML/training_wav/78.wav")
 
 (
 {
-var in, fft, resample;
-var key, transientdetection;
+	var in, fft, resample;
+	var key, transientdetection;
 
-in = PlayBuf.ar(1, d, BufRateScale.kr(d), 1, 0, 1);
+	in = PlayBuf.ar(1, d, BufRateScale.kr(d), 1, 0, 1);
 
-fft = FFT(b, in);
+	// With standard hop of half FFT size = 2048 samples
+	fft = FFT(LocalBuf(1, 4096), in);  // for sampling rates 44100 and 48000
+	fft = FFT(LocalBuf(1, 8192), in);   // for sampling rates 88200 and 96000
 
-key=KeyTrack.kr(fft, 2.0, 0.5);
+	key = KeyTrack.kr(fft, 2.0, 0.5);
 
-key.poll;
+	key.poll;
 
-Out.ar(0,Pan2.ar(in));
+	Pan2.ar(in)
 }.play
 )
 ::
@@ -66,21 +62,21 @@ code::
 // alternating major and minor chords as a test
 (
 {
-var in, fft, resample;
-var key, transientdetection;
+	var in, fft, resample;
+	var key, transientdetection;
 
-in = Mix(SinOsc.ar((60 + [0, MouseX.kr(3, 4).round(1), 7]).midicps, 0, 0.1));
+	in = Mix(SinOsc.ar((60 + [0, MouseX.kr(3, 4).round(1), 7]).midicps, 0, 0.1));
 
-// major dom 7 and minor 7; major keys preferred here
-//in = Mix(SinOsc.ar((60 + (MouseY.kr(0, 11).round(1.0)) + [0, MouseX.kr(3, 4).round(1), 7, 10]).midicps, 0, 0.1));
+	// major dom 7 and minor 7; major keys preferred here
+	//in = Mix(SinOsc.ar((60 + (MouseY.kr(0, 11).round(1.0)) + [0, MouseX.kr(3, 4).round(1), 7, 10]).midicps, 0, 0.1));
 
-fft = FFT(b, in);
+	fft = FFT(LocalBuf(1, 4096), in);  // for sampling rates 44100 and 48000
 
-key = KeyTrack.kr(fft);
+	key = KeyTrack.kr(fft);
 
-key.poll;
+	key.poll;
 
-Out.ar(0,Pan2.ar(in));
+	Pan2.ar(in)
 }.play
 )
 ::
@@ -91,27 +87,26 @@ code::
 // Nice to hear what KeyTrack thinks:
 
 d = Buffer.read(s, "/Users/nickcollins/Desktop/ML/training_wav/78.wav")
-b = Buffer.alloc(s, 4096, 1); // for sampling rates 44100 and 48000
 
 (
 {
-var in, fft, resample, chord, rootnote, sympath;
-var key, transientdetection;
+	var in, fft, resample, chord, rootnote, sympath;
+	var key, transientdetection;
 
-in = PlayBuf.ar(1, d, BufRateScale.kr(d), 1, 0, 1);
+	in = PlayBuf.ar(1, d, BufRateScale.kr(d), 1, 0, 1);
 
-fft = FFT(b, in);
+	fft = FFT(LocalBuf(1, 4096), in);  // for sampling rates 44100 and 48000
 
-key = KeyTrack.kr(fft, 2.0, 0.5);
-key.poll;
-key = Median.kr(101, key); // Remove outlier wibbles
+	key = KeyTrack.kr(fft, 2.0, 0.5);
+	key.poll;
+	key = Median.kr(101, key); // Remove outlier wibbles
 
-chord = if(key<12, #[0, 4, 7], #[0, 3, 7]);
-rootnote = if(key<12, key, key-12) + 60;
+	chord = if(key < 12, #[0, 4, 7], #[0, 3, 7]);
+	rootnote = if(key < 12, key, key-12) + 60;
 
-sympath = SinOsc.ar((rootnote + chord).midicps, 0, 0.4).mean;
+	sympath = SinOsc.ar((rootnote + chord).midicps, 0, 0.4).mean;
 
-Out.ar(0,Pan2.ar(in, -0.5) + Pan2.ar(sympath, 0.5));
+	Pan2.ar(in, -0.5) + Pan2.ar(sympath, 0.5)
 }.play
 )
 ::
@@ -119,16 +114,20 @@ Out.ar(0,Pan2.ar(in, -0.5) + Pan2.ar(sympath, 0.5));
 
 
 code::
-// Research Notes:
-// See the MIREX2006 audio key tracking competition and Emilia Gomez's PhD thesis, Tonal Description of Music Audio Signals
 
-// The following code was used to create the datasets for the UGen, and would be the basis of extensions
+/*
+Research Notes:
+See the MIREX2006 audio key tracking competition and Emilia Gomez's PhD thesis, Tonal Description of Music Audio Signals
 
-// Need one set of bin data for 44100 and one for 48000
+The following code was used to create the datasets for the UGen, and would be the basis of extensions
 
-// KeyTrack calculations, need to make arrays of FFT bins and weights for each chromatic tone.
-// greater resolution, 4096 FFT, avoid lower octaves, too messy there
-// 60*6*2 output arrays
+Need one set of bin data for 44100 and one for 48000
+
+KeyTrack calculations, need to make arrays of FFT bins and weights for each chromatic tone.
+greater resolution, 4096 FFT, avoid lower octaves, too messy there
+
+60*6*2 output arrays
+*/
 
 (
 var fftN, fftBins, binsize;

--- a/HelpSource/Classes/LFSaw.schelp
+++ b/HelpSource/Classes/LFSaw.schelp
@@ -38,20 +38,10 @@ code::
 { LFSaw.ar(LFSaw.kr(4, 0, 200, 400), 0, 0.1) }.play
 
 ::
-Display special behaviour of initial phase parameter:
+
+Display the special behaviour of the initial phase parameter:
+
 code::
-// 0.15 seconds of 3-channel buffer
-b = Buffer.alloc(s, s.sampleRate * 0.15, 3);
-
-(
-// generate Signal
-m = SynthDef ("help-lfsawphase", {|rate = 20|
-	var l;
-	l = LFSaw.ar(rate, [0, 1, 2]); // three channels, three phases
-	RecordBuf.ar(l, b, doneAction: Done.freeSelf, loop: 0);
-	Out.ar(0, l * -20.dbamp);
-}).play(s);
-)
-
-b.plot;	// see the difference
+ // three channels, three phases
+{ LFSaw.ar(20, [0, 1, 2]) }.plot(0.1)
 ::

--- a/HelpSource/Classes/Lag2UD.schelp
+++ b/HelpSource/Classes/Lag2UD.schelp
@@ -18,28 +18,26 @@ argument:: lagTimeD
 
 examples::
 code::
-(
 // used to lag pitch
-       SynthDef( \lag2ud_help,
-
-	{ arg freq=300,lagup=1, lagdown=5;
-		Out.ar( 0,
-			SinOsc.ar( // sine wave
-				Lag2UD.kr( // lag the frequency
-					freq,
-					lagup,
-					lagdown
-				),
-				0, // phase
-				0.2 // sine amplitude
-			)
-		);
-	}).add;
+(
+SynthDef( \lag2ud_help, { |out, freq=300, lagup=1, lagdown=5|
+	Out.ar(out,
+		SinOsc.ar( // sine wave
+			Lag2UD.kr( // lag the frequency
+				freq,
+				lagup,
+				lagdown
+			),
+			0, // phase
+			0.2 // sine amplitude
+		)
+	);
+}).add;
 )
 
-x = Synth.new( \lag2ud_help ); // create the synth
+x = Synth(\lag2ud_help); // create the synth
 
-x.set( \freq, 500 ); // set the frequency to a higher value (takes 1 second)
-x.set( \freq, 100 ); // set the frequency to a lower value (takes 5 seconds)
+x.set(\freq, 500); // set the frequency to a higher value (takes 1 second)
+x.set(\freq, 100); // set the frequency to a lower value (takes 5 seconds)
 x.free;
 ::

--- a/HelpSource/Classes/Lag3UD.schelp
+++ b/HelpSource/Classes/Lag3UD.schelp
@@ -18,28 +18,26 @@ argument:: lagTimeD
 
 examples::
 code::
-(
 // used to lag pitch
-       SynthDef( \lag3ud_help,
-
-	{ arg freq=300,lagup=1, lagdown=5;
-		Out.ar( 0,
-			SinOsc.ar( // sine wave
-				Lag3UD.kr( // lag the frequency
-					freq,
-					lagup,
-					lagdown
-				),
-				0, // phase
-				0.2 // sine amplitude
-			)
-		);
-	}).add;
+(
+SynthDef( \lag3ud_help, { |out, freq=300, lagup=1, lagdown=5|
+	Out.ar(out,
+		SinOsc.ar( // sine wave
+			Lag3UD.kr( // lag the frequency
+				freq,
+				lagup,
+				lagdown
+			),
+			0, // phase
+			0.2 // sine amplitude
+		)
+	)
+}).add;
 )
 
-x = Synth.new( \lag3ud_help ); // create the synth
+x = Synth(\lag3ud_help); // create the synth
 
-x.set( \freq, 500 ); // set the frequency to a higher value (takes 1 second)
-x.set( \freq, 100 ); // set the frequency to a lower value (takes 5 seconds)
+x.set(\freq, 500); // set the frequency to a higher value (takes 1 second)
+x.set(\freq, 100); // set the frequency to a lower value (takes 5 seconds)
 x.free;
 ::

--- a/HelpSource/Classes/LagUD.schelp
+++ b/HelpSource/Classes/LagUD.schelp
@@ -20,10 +20,10 @@ argument:: add
 
 examples::
 code::
-( // used to lag pitch
-SynthDef( \lagud_help,
-{	arg freq=300,lagup=1, lagdown=5;
-	Out.ar( 0,
+// used to lag pitch
+(
+SynthDef(\lagud_help, { |out, freq=300, lagup=1, lagdown=5|
+	Out.ar(out,
 		SinOsc.ar( // sine wave
 			LagUD.kr( // lag the frequency
 				freq,
@@ -36,8 +36,9 @@ SynthDef( \lagud_help,
 	);
 }).add;
 )
-x = Synth.new( \lagud_help ); // create the synth
-x.set( \freq, 500 ); // set the frequency to a higher value (takes 1 second)
-x.set( \freq, 100 ); // set the frequency to a lower value (takes 5 seconds)
+
+x = Synth(\lagud_help); // create the synth
+x.set(\freq, 500); // set the frequency to a higher value (takes 1 second)
+x.set(\freq, 100); // set the frequency to a lower value (takes 5 seconds)
 x.free;
 ::

--- a/HelpSource/Classes/LinPan2.schelp
+++ b/HelpSource/Classes/LinPan2.schelp
@@ -34,10 +34,9 @@ code::
 { LinPan2.ar(SinOsc.ar(440), Line.kr(-1, 1, 5)) }.play;
 
 // ... whereas Pan2 is more smooth
-{ Pan2.ar(SinOsc.ar(440), Line.kr(-1,1,5)) }.play;
+{ Pan2.ar(SinOsc.ar(440), Line.kr(-1, 1, 5)) }.play;
 
 // other examples
-
 { LinPan2.ar(PinkNoise.ar(0.4), FSinOsc.kr(2)) }.play;
 
 { LinPan2.ar(FSinOsc.ar(800, 0, 0.1), FSinOsc.kr(3)) }.play;

--- a/HelpSource/Classes/LinPan2.schelp
+++ b/HelpSource/Classes/LinPan2.schelp
@@ -5,7 +5,7 @@ categories::  UGens>Multichannel>Panners
 
 
 Description::
-Two channel linear panner. The signal is lowered as it pans from left (or right) to center using a straight line from 1 (left or right) to 0.5 (center) for a 6dB reduction in the middle. A problem inherent to linear panning is that the perceived volume of the signal drops in the middle. Pan2 solves this by taking the square root of the linear scaling factor going from 1 (left or right) to 0.5.sqrt (~=0.707) in the center, which is about 3dB reduction. This is equal power panning. 
+Two channel linear panner. The signal is lowered as it pans from left (or right) to center using a straight line from 1 (left or right) to 0.5 (center) for a 6dB reduction in the middle. A problem inherent to linear panning is that the perceived volume of the signal drops in the middle. Pan2 solves this by taking the square root of the linear scaling factor going from 1 (left or right) to 0.5.sqrt (~=0.707) in the center, which is about 3dB reduction. This is equal power panning.
 LinPan2 sounds more like the Rhodes tremolo than Pan2.
 
 classmethods::
@@ -31,13 +31,15 @@ Examples::
 
 code::
 // hear the difference, LinPan having a slight drop in the middle (yeah, it's subtle)...
-{LinPan2.ar(SinOsc.ar(440), Line.kr(-1,1,5))}.play
+{ LinPan2.ar(SinOsc.ar(440), Line.kr(-1, 1, 5)) }.play;
 
 // ... whereas Pan2 is more smooth
-{Pan2.ar(SinOsc.ar(440), Line.kr(-1,1,5))}.play
+{ Pan2.ar(SinOsc.ar(440), Line.kr(-1,1,5)) }.play;
 
 // other examples
-play({ LinPan2.ar(PinkNoise.ar(0.4), FSinOsc.kr(2)) });
-SynthDef("help-LinPan2", {  Out.ar(0, LinPan2.ar(FSinOsc.ar(800, 0, 0.1), FSinOsc.kr(3))) }).play;
+
+{ LinPan2.ar(PinkNoise.ar(0.4), FSinOsc.kr(2)) }.play;
+
+{ LinPan2.ar(FSinOsc.ar(800, 0, 0.1), FSinOsc.kr(3)) }.play;
 ::
 

--- a/HelpSource/Classes/LocalOut.schelp
+++ b/HelpSource/Classes/LocalOut.schelp
@@ -45,22 +45,20 @@ code::
 	var source, local;
 
 	source = Decay.ar(Impulse.ar(0.3), 0.1) * WhiteNoise.ar(0.2);
-
 	local = LocalIn.ar(2) + [source, 0]; // read feedback, add to source
-
 	local = DelayN.ar(local, 0.2, 0.2); // delay sound
 
 	// reverse channels to give ping pong effect, apply decay factor
 	LocalOut.ar(local.reverse * 0.8);
 
-	Out.ar(0, local);
+	local
 }.play;
 )
 
 
 
 (
-z = SynthDef("tank", {
+z = SynthDef("tank", { |out|
 	var local, in;
 
 	in = Mix.fill(12, {
@@ -87,14 +85,14 @@ z = SynthDef("tank", {
 
 	LocalOut.ar(local);
 
-	Out.ar(0, local);
+	Out.ar(out, local);
 }).play;
 )
 
 
 
 (
-z = SynthDef("tape", {
+z = SynthDef("tape", { |out|
 	var local, in, amp;
 
 	in = SoundIn.ar([0, 1]);
@@ -115,25 +113,26 @@ z = SynthDef("tape", {
 
 	LocalOut.ar(local);
 
-	Out.ar(0, local * 0.1);
+	Out.ar(out, local * 0.1);
 }).play;
 )
 
 // Resonator, must subtract blockSize for correct tuning
 (
-var play, imp, initial;
-SynthDef("testRes", {
 
-play = LocalIn.ar(1);
-imp = Impulse.ar(1);
+{
+	var imp, local;
+	local = LocalIn.ar(1);
+	imp = Impulse.ar(1);
 
-LocalOut.ar(DelayC.ar(imp + (play * 0.995), 1, 440.reciprocal - ControlRate.ir.reciprocal)); // for feedback
+	// for feedback
+	LocalOut.ar(DelayC.ar(imp + (local * 0.995), 1, 440.reciprocal - ControlRate.ir.reciprocal));
 
-OffsetOut.ar(0, play);
+	local
 
-}).play(s);
+}.play;
 
-{SinOsc.ar(440, 0, 0.2) }.play(s, 1); // compare pitch
+{ SinOsc.ar(440, 0, 0.2) }.play; // compare pitch
 )
 
 ::

--- a/HelpSource/Classes/Loudness.schelp
+++ b/HelpSource/Classes/Loudness.schelp
@@ -6,6 +6,7 @@ related:: Classes/BeatTrack, Classes/MFCC, Classes/Onsets, Classes/Pitch, Classe
 description::
 A perceptual loudness function which outputs loudness in sones; this is a variant of an MP3 perceptual model, summing excitation in ERB bands. It models simple spectral and temporal masking, with equal loudness contour correction in ERB bands to obtain phons (relative dB), then a phon to sone transform. The final output is typically in the range of 0 to 64 sones, though higher values can occur with specific synthesised stimuli.
 
+note::Research note: This UGen is an informal juxtaposition of perceptual coding, and a Zwicker and Glasberg/Moore/Stone loudness model.::
 
 classmethods::
 method:: kr
@@ -22,22 +23,17 @@ argument:: tmask
 examples::
 code::
 // assumes hop of half fftsize, fine
-b = Buffer.alloc(s, 1024, 1); // for sampling rates 44100 and 48000
-//b = Buffer.alloc(s, 2048, 1); // for sampling rates 88200 and 96000
+
 d = Buffer.read(s, Platform.resourceDir +/+ "sounds/a11wlk01.wav");
 
 // analyse loudness and poll result
 (
 {
-var in, fft, loudness;
-
-in = PlayBuf.ar(1, d, BufRateScale.kr(d), 1, 0, 1);
-
-fft = FFT(b, in);
-
-loudness = Loudness.kr(fft).poll(50);
-
-Out.ar(0, Pan2.ar(in));
+	var in = PlayBuf.ar(1, d, BufRateScale.kr(d), 1, 0, 1);
+	var chain = FFT(LocalBuf(1, 1024), in);  // for sampling rates 44100 and 48000
+	//var chain = FFT(LocalBuf(1, 2048), in);  // for sampling rates 88200 and 96000
+	var loudness = Loudness.kr(chain).poll(50);
+	Pan2.ar(in)
 }.play
 )
 
@@ -52,31 +48,31 @@ Out.ar(0, Pan2.ar(in));
 // 0.dbamp= 1 = 64 sone
 (
 {
-var in, fft, loudness;
+	var in, chain, loudness;
 
-in = SinOsc.ar(1000, 0, 0.001); //should be 1 sone
-//in = SinOsc.ar(1000, 0, 0.01); //should be 4 sone
-//in = SinOsc.ar(1000, 0, 0.1); //should be 16 sone
-//in = SinOsc.ar(1000, 0, 1); //should be 64 sone
-//in = Saw.ar * SinOsc.ar(4);
-//in = WhiteNoise.ar;
-//in = Silent.ar; // should be small, around 2 ** ((0 - 40) / 10) = 2 ** (-4) = 0.0625
-//in = DC.ar(1);
-//in = SinOsc.ar(22050, pi * 0.5, 1);
-// fade ins
-//in = SinOsc.ar(1000, 0, Line.kr(0, 1, 2));
-//in = SinOsc.ar(1000, 0, Line.kr(0, 1, 2) ** 2);
-//in = WhiteNoise.ar(Line.kr(0, 1, 2));
-//in = PlayBuf.ar(1, d, BufRateScale.kr(d), 1, 0, 1);
+	in = SinOsc.ar(1000, 0, 0.001); //should be 1 sone
+	//in = SinOsc.ar(1000, 0, 0.01); //should be 4 sone
+	//in = SinOsc.ar(1000, 0, 0.1); //should be 16 sone
+	//in = SinOsc.ar(1000, 0, 1); //should be 64 sone
+	//in = Saw.ar * SinOsc.ar(4);
+	//in = WhiteNoise.ar;
+	//in = Silent.ar; // should be small, around 2 ** ((0 - 40) / 10) = 2 ** (-4) = 0.0625
+	//in = DC.ar(1);
+	//in = SinOsc.ar(22050, pi * 0.5, 1);
+	// fade ins
+	//in = SinOsc.ar(1000, 0, Line.kr(0, 1, 2));
+	//in = SinOsc.ar(1000, 0, Line.kr(0, 1, 2) ** 2);
+	//in = WhiteNoise.ar(Line.kr(0, 1, 2));
+	//in = PlayBuf.ar(1, d, BufRateScale.kr(d), 1, 0, 1);
 
-fft = FFT(b, in);
+	chain = FFT(LocalBuf(1, 1024), in);  // for sampling rates 44100 and 48000
+	//chain = FFT(LocalBuf(1, 2048), in);  // for sampling rates 88200 and 96000
 
-loudness = Loudness.kr(fft, 0.25, 6).poll(50);
+	loudness = Loudness.kr(chain, 0.25, 6).poll(50);
 
-Out.ar(0, Pan2.ar(in));
-K2A.ar(loudness * 0.016)
+	K2A.ar(loudness * 0.016)
 }.plot(2.0)
 )
 ::
 
-Research note: This link::Classes/UGen:: is an informal juxtaposition of perceptual coding, and a Zwicker and Glasberg/Moore/Stone loudness model.
+

--- a/HelpSource/Classes/MFCC.schelp
+++ b/HelpSource/Classes/MFCC.schelp
@@ -8,6 +8,9 @@ Generates a set of MFCCs; these are obtained from a band-based frequency represe
 
 Output values are somewhat normalised for the range 0.0 to 1.0, but there are no guarantees on exact conformance to this. Commonly, the first coefficient will be the highest value.
 
+
+note::Drafts of an MFCC UGen were prepared by both Dan Stowell and Nick Collins; their various ideas are combined here in a cross platform compatible UGen. Mel scale spacing with triangular crossfade overlap is used by default for the bands, approximately tracking the human critical band spacing and bandwidth. Variants such as BFCC (Bark) and EFCC (ERB) given similar results in practice; the Mel scale as used here is the standard as adapted from the speech recognition literature and now applied in music information retrieval.::
+
 classmethods::
 method:: kr
 
@@ -24,29 +27,27 @@ code::
 
 
 // assumes hop of half fftsize, fine
-b = Buffer.alloc(s, 1024, 1); // for sampling rates 44100 and 48000
-//b = Buffer.alloc(s, 2048, 1); // for sampling rates 88200 and 96000
 
 d = Buffer.read(s, Platform.resourceDir +/+ "sounds/a11wlk01.wav");
 
 
 (
 x = {
-var in, fft, array;
+	var in, fft, array;
 
-//in = PlayBuf.ar(1, d, BufRateScale.kr(d), 1, 0, 1);
+	//in = PlayBuf.ar(1, d, BufRateScale.kr(d), 1, 0, 1);
 
-in = SoundIn.ar(0);
+	in = SoundIn.ar(0);
+	fft = FFT(LocalBuf(1, 1024), in);  // for sampling rates 44100 and 48000
+	//fft = FFT(LocalBuf(1, 2048), in);  // for sampling rates 88200 and 96000
 
-fft = FFT(b, in);
+	array = MFCC.kr(fft);
 
-array = MFCC.kr(fft);
+	array.size.postln;
 
-array.size.postln;
+	Out.kr(0, array); // control bus out
 
-Out.kr(0, array);
-
-Out.ar(0,Pan2.ar(in));
+	Out.ar(0, Pan2.ar(in)); // audio bus out
 }.play
 )
 
@@ -75,12 +76,12 @@ w.front;
 
 r = {
 
-inf.do{
+	inf.do{
 
-c.getn(13, { arg val; { ms.value_(val * 0.9) }.defer });
+		c.getn(13, { arg val; { ms.value_(val * 0.9) }.defer });
 
-0.04.wait; // 25 frames per second
-};
+		0.04.wait; // 25 frames per second
+	};
 
 }.fork;
 
@@ -97,7 +98,7 @@ w.close;
 )
 ::
 
-Research notes: Drafts of an MFCC UGen were prepared by both Dan Stowell and Nick Collins; their various ideas are combined here in a cross platform compatible UGen. Mel scale spacing with triangular crossfade overlap is used by default for the bands, approximately tracking the human critical band spacing and bandwidth. Variants such as BFCC (Bark) and EFCC (ERB) given similar results in practice; the Mel scale as used here is the standard as adapted from the speech recognition literature and now applied in music information retrieval.
+
 
 code::
 // Calculating Mel Scale Bands; allow up to 42 coefficients, so up to 42 bands
@@ -129,10 +130,10 @@ freq_bands = 42;
 //};
 
 lintoscale = {arg freq;
-1127 * log(1 + (freq / 700))
+	1127 * log(1 + (freq / 700))
 };
 scaletolin = {arg scalepos;
-700 * (exp(scalepos / 1127.0) -1);
+	700 * (exp(scalepos / 1127.0) -1);
 };
 
 mel_freq_max = lintoscale.value(freq_max); // 1127 * log(1 + (freq_max / 700));
@@ -153,9 +154,9 @@ fft_peak[0] = (lin_peak[0] / freqperbin).asInteger;
 
 for(1, freq_bands + 1,{|n|
 
- mel_peak[n] = mel_peak[n - 1] + freq_bw_mel;
- lin_peak[n] = scaletolin.value(mel_peak[n]); // 700 * (exp(mel_peak[n] / 1127.0) -1);
- fft_peak[n] = ((lin_peak[n] / freqperbin).asInteger).min(halffftsize); // fft size //rounds down here
+	mel_peak[n] = mel_peak[n - 1] + freq_bw_mel;
+	lin_peak[n] = scaletolin.value(mel_peak[n]); // 700 * (exp(mel_peak[n] / 1127.0) -1);
+	fft_peak[n] = ((lin_peak[n] / freqperbin).asInteger).min(halffftsize); // fft size //rounds down here
 
 });
 
@@ -178,11 +179,11 @@ freq_bands.do {|i|
 	var startbin, endbin, numbins, averager;
 
 	if(i == 0,{
-	startbin = 0;
-	endbin = fft_peak[i + 1] - 1;
+		startbin = 0;
+		endbin = fft_peak[i + 1] - 1;
 	},{
-	startbin = fft_peak[i - 1] + 1;
-	endbin = fft_peak[i + 1] - 1;
+		startbin = fft_peak[i - 1] + 1;
+		endbin = fft_peak[i + 1] - 1;
 	});
 
 	numbins = endbin - startbin + 1;

--- a/HelpSource/Classes/MFCC.schelp
+++ b/HelpSource/Classes/MFCC.schelp
@@ -120,11 +120,11 @@ freq_bands = 42;
 
 //whichbandscale = 0; // 0 = mel; 1 = bark (CB) 2 = ERB
 //
-//lintoscale = {arg freq;
-//switch(whichbandscale,0,{1127 * log(1 + (freq / 700))}, 1, {}, 2, {}).value
+//lintoscale = { |freq|
+//switch(whichbandscale, 0, { 1127 * log(1 + (freq / 700))}, 1, { }, 2, { }).value
 //};
-//scaletolin = {arg scalepos;
-//switch(whichbandscale, 0, {700 * (exp(scalepos / 1127.0) -1);}, 1, {}, 2, {}).value
+//scaletolin = { |scalepos|
+//switch(whichbandscale, 0, {700 * (exp(scalepos / 1127.0) -1) }, 1, { }, 2, { }).value
 //};
 
 lintoscale = { |freq|
@@ -140,9 +140,9 @@ freq_bw_mel = (mel_freq_max - mel_freq_min) / freq_bands;
 
 [mel_freq_max, mel_freq_min, freq_bw_mel].postln;
 
-mel_peak = Array.fill(freq_bands + 2, {0.0});
-lin_peak = Array.fill(freq_bands + 2, {0.0});
-fft_peak = Array.fill(freq_bands + 2, {0.0});
+mel_peak = Array.fill(freq_bands + 2, { 0.0 });
+lin_peak = Array.fill(freq_bands + 2, { 0.0 });
+fft_peak = Array.fill(freq_bands + 2, { 0.0 });
 
 freqperbin = sr / fftsize; // SR/N
 

--- a/HelpSource/Classes/MFCC.schelp
+++ b/HelpSource/Classes/MFCC.schelp
@@ -46,16 +46,15 @@ x = {
 	array.size.postln;
 
 	Out.kr(0, array); // control bus out
-
 	Out.ar(0, Pan2.ar(in)); // audio bus out
 }.play
 )
 
 
-c = Bus.new('control', 0, 13);
+c = Bus(\control, 0, 13);
 
 // poll coefficients
-c.getn(13, { arg val; { val.plot; }.defer });
+c.getn(13, { |val| { val.plot }.defer });
 
 
 // Continuous graphical display of MFCC values; free routine before closing window
@@ -76,14 +75,13 @@ w.front;
 
 r = {
 
-	inf.do{
+	inf.do {
 
-		c.getn(13, { arg val; { ms.value_(val * 0.9) }.defer });
-
+		c.getn(13, { |val| { ms.value_(val * 0.9) }.defer });
 		0.04.wait; // 25 frames per second
-	};
+	}
 
-}.fork;
+}.fork
 
 )
 
@@ -129,11 +127,11 @@ freq_bands = 42;
 //switch(whichbandscale, 0, {700 * (exp(scalepos / 1127.0) -1);}, 1, {}, 2, {}).value
 //};
 
-lintoscale = {arg freq;
+lintoscale = { |freq|
 	1127 * log(1 + (freq / 700))
 };
-scaletolin = {arg scalepos;
-	700 * (exp(scalepos / 1127.0) -1);
+scaletolin = { |scalepos|
+	700 * (exp(scalepos / 1127.0) -1)
 };
 
 mel_freq_max = lintoscale.value(freq_max); // 1127 * log(1 + (freq_max / 700));
@@ -152,7 +150,7 @@ mel_peak[0] = mel_freq_min;
 lin_peak[0] = freq_min; // === 700 * (exp(mel_peak[0] / 1127) - 1);
 fft_peak[0] = (lin_peak[0] / freqperbin).asInteger;
 
-for(1, freq_bands + 1,{|n|
+for(1, freq_bands + 1, { |n|
 
 	mel_peak[n] = mel_peak[n - 1] + freq_bw_mel;
 	lin_peak[n] = scaletolin.value(mel_peak[n]); // 700 * (exp(mel_peak[n] / 1127.0) -1);
@@ -166,25 +164,25 @@ for(1, freq_bands + 1,{|n|
 
 //  [2 / (lin_peak[freq_bands + 1] - lin_peak[freq_bands-1]), 1.0 / (2 / (lin_peak[2] - lin_peak[0]))].postln;
 
-fftbinstart = Array.fill(freq_bands, {0});
-fftbinend = Array.fill(freq_bands, {0});
-fftbincumul = Array.fill(freq_bands+1, {0});
+fftbinstart = Array.fill(freq_bands, { 0 });
+fftbinend = Array.fill(freq_bands, { 0 });
+fftbincumul = Array.fill(freq_bands + 1, { 0 });
 fftbinmult = [];
 
 pos = 0;
 
 freq_bands.do {|i|
 
-	//var normmult=1.0; // preserve power, don't modify band power by area
+	//var normmult = 1.0; // preserve power, don't modify band power by area
 	var startbin, endbin, numbins, averager;
 
-	if(i == 0,{
+	if(i == 0) {
 		startbin = 0;
 		endbin = fft_peak[i + 1] - 1;
-	},{
+	} {
 		startbin = fft_peak[i - 1] + 1;
 		endbin = fft_peak[i + 1] - 1;
-	});
+	};
 
 	numbins = endbin - startbin + 1;
 	averager = 1.0 / numbins;
@@ -198,7 +196,7 @@ freq_bands.do {|i|
 
 	fftbinmult = fftbinmult ++ (Array.series(tmp + 1, 1.0 / (tmp + 1), 1.0 / (tmp + 1)));
 
-	tmp= endbin- (fft_peak[i]);
+	tmp = endbin - fft_peak[i];
 
 	fftbinmult = fftbinmult ++ (Array.series(tmp, 1.0 + ((-1.0) / (tmp + 1)), (-1.0) / (tmp + 1)));
 
@@ -226,11 +224,16 @@ a = (26.81 / (1 + (1960 / ((100, 200..22000))))) - 0.53;
 a.plot;
 
 // ERBs (rough calculation, only really valid under 6000Hz, real scale goes up to 42 rather than 37 in 22000 Hz)
-a = Array.fill(220,{|i| var f; f = i * 100; 11.17 * log((f + 312) / (f + 14675)) + 43.0});
+(
+a = Array.fill(220, {|i| 
+	var f = i * 100; 
+	11.17 * log((f + 312) / (f + 14675)) + 43.0 
+})
+)
 a.plot
 
 // generating DCT coefficients
 // don't generate i=0 coefficient since it
-a = Array.fill(42, {|i| cos(pi / 42.0 * ((0..41) + 0.5) * (i + 1))});
+a = Array.fill(42, {|i| cos(pi / 42.0 * ((0..41) + 0.5) * (i + 1)) });
 Post << a.flatten << nl;
 ::

--- a/HelpSource/Classes/MIDIIn.schelp
+++ b/HelpSource/Classes/MIDIIn.schelp
@@ -278,15 +278,15 @@ MIDIIn.connect;
 s.boot;
 
 (
-SynthDef("sik-goo", { arg freq=440,formfreq=100,gate=0.0,bwfreq=800;
+SynthDef("sik-goo", { |out, freq = 440, formfreq = 100, gate = 0.0, bwfreq = 800|
 	var x;
 	x = Formant.ar(
 		SinOsc.kr(0.02, 0, 10, freq),
 		formfreq,
 		bwfreq
 	);
-	x = EnvGen.kr(Env.adsr, gate,Latch.kr(gate,gate)) * x;
-	Out.ar(0, x);
+	x = EnvGen.kr(Env.adsr, gate, Latch.kr(gate, gate)) * x;
+	Out.ar(out, x);
 }).add;
 )
 
@@ -330,12 +330,17 @@ code::
 s.boot;
 
 (
-SynthDef("moto-rev", { arg ffreq=100;
+SynthDef("moto-rev", { |out, ffreq = 100|
 	var x;
-	x = RLPF.ar(LFPulse.ar(SinOsc.kr(0.2, 0, 10, 21), [0,0.1], 0.1),
-		ffreq, 0.1)
-		.clip2(0.4);
-	Out.ar(0, x);
+	x = RLPF.ar(
+		LFPulse.ar(
+			SinOsc.kr(0.2, 0, 10, 21),
+			[0, 0.1],
+			0.1
+		),
+		ffreq, 0.1
+	).clip2(0.4);
+	Out.ar(out, x);
 }).add;
 )
 
@@ -382,10 +387,10 @@ code::
 
 s.boot;
 (
-SynthDef("funk",{ arg freq = 700, amp = 0.2, gate = 1, cutoff = 20000, rez = 1, lfospeed=0;
-	var e,x,env,range,filterfreq;
+SynthDef("funk",{ | out, freq = 700, amp = 0.2, gate = 1, cutoff = 20000, rez = 1, lfospeed = 0 |
+	var e, x, env, range, filterfreq;
 	e = Env.new([0, 0.1, 0.1, 0], [0, 0.1, 0.1], 'linear', 2);
-	env=Env.adsr(0.3,1,1,1);
+	env = Env.adsr(0.3,1,1,1);
 	range = cutoff -1;
 	filterfreq = SinOsc.kr(lfospeed,0, range, cutoff).abs;
 	x = RLPF.ar(Mix.ar([
@@ -394,18 +399,18 @@ SynthDef("funk",{ arg freq = 700, amp = 0.2, gate = 1, cutoff = 20000, rez = 1, 
 		]),
 		EnvGen.kr(env,gate)*filterfreq,
 		rez);
-	Out.ar([0,1],x * EnvGen.kr(e, gate, doneAction: Done.freeSelf))
+	Out.ar(out, x * EnvGen.kr(e, gate, doneAction: Done.freeSelf))
 }).add;
 
-SynthDef("strings",{ arg freq = 700, amp = 0.2, gate = 1;
-	var x,enve;
+SynthDef("strings", { |out, freq = 700, amp = 0.2, gate = 1|
+	var x, enve;
 	enve = Env.new([0, 0.1, 0.1, 0], [2, 0.1, 1], 'linear', 2);
 	x = RLPF.ar(Mix.ar([
 			Mix.arFill(2, {Saw.ar(freq +2.rand2,0.6)}),
 			Mix.arFill(2, {Saw.ar(freq *0.5 + 2.rand2,0.6)})
 		]),
 		6000,1);
-	Out.ar([0,1],x * EnvGen.kr(enve, gate, doneAction: Done.freeSelf))
+	Out.ar(out, x * EnvGen.kr(enve, gate, doneAction: Done.freeSelf))
 }).add;
 )
 

--- a/HelpSource/Classes/MantissaMask.schelp
+++ b/HelpSource/Classes/MantissaMask.schelp
@@ -33,7 +33,7 @@ Examples::
 code::
 
 // preserve only 3 bits of mantissa.
-{ MantissaMask.ar(SinOsc.ar(SinOsc.kr(0.2,0,400,500), 0, 0.4), 3) }.play
+{ MantissaMask.ar(SinOsc.ar(SinOsc.kr(0.2, 0, 400, 500), 0, 0.4), 3) }.play
 
 // the original
 { SinOsc.ar(SinOsc.kr(0.2,0,400,500), 0, 0.4) }.play
@@ -42,25 +42,25 @@ code::
 (
 {
 	var in;
-	in = SinOsc.ar(SinOsc.kr(0.2,0,400,500), 0, 0.4);
-	Out.ar(0, in - MantissaMask.ar(in, 3));
+	in = SinOsc.ar(SinOsc.kr(0.2, 0, 400, 500), 0, 0.4);
+	in - MantissaMask.ar(in, 3)
 }.play
 )
 
 
 // preserve 7 bits of mantissa.
 // This makes the lower 16 bits of the floating point number become zero.
-{ MantissaMask.ar(SinOsc.ar(SinOsc.kr(0.2,0,400,500), 0, 0.4), 7) }.play
+{ MantissaMask.ar(SinOsc.ar(SinOsc.kr(0.2, 0, 400, 500), 0, 0.4), 7) }.play
 
 // the original
-{ SinOsc.ar(SinOsc.kr(0.2,0,400,500), 0, 0.4) }.play
+{ SinOsc.ar(SinOsc.kr(0.2, 0, 400, 500), 0, 0.4) }.play
 
 // the difference.
 (
 {
 	var in;
 	in = SinOsc.ar(SinOsc.kr(0.2,0,400,500), 0, 0.4);
-	Out.ar(0, in - MantissaMask.ar(in, 7));
+	in - MantissaMask.ar(in, 7)
 }.play
 )
 

--- a/HelpSource/Classes/MantissaMask.schelp
+++ b/HelpSource/Classes/MantissaMask.schelp
@@ -36,7 +36,7 @@ code::
 { MantissaMask.ar(SinOsc.ar(SinOsc.kr(0.2, 0, 400, 500), 0, 0.4), 3) }.play
 
 // the original
-{ SinOsc.ar(SinOsc.kr(0.2,0,400,500), 0, 0.4) }.play
+{ SinOsc.ar(SinOsc.kr(0.2, 0, 400, 500), 0, 0.4) }.play
 
 // the difference.
 (
@@ -59,7 +59,7 @@ code::
 (
 {
 	var in;
-	in = SinOsc.ar(SinOsc.kr(0.2,0,400,500), 0, 0.4);
+	in = SinOsc.ar(SinOsc.kr(0.2, 0, 400, 500), 0, 0.4);
 	in - MantissaMask.ar(in, 7)
 }.play
 )

--- a/HelpSource/Classes/MostChange.schelp
+++ b/HelpSource/Classes/MostChange.schelp
@@ -27,31 +27,33 @@ Examples::
 
 code::
 
-//doesn't work yet.
-
-d = SynthDef("help-MostChange", { arg amp=1.0;
-	var out, in1, in2;
+(
+d = SynthDef("help-MostChange", { |out, amp = 1.0|
+	var sound, in1, in2;
 	in1 = LFNoise1.ar(800, amp);
 	in2 = SinOsc.ar(800);
-	out = MostChange.ar(in1, in2) * 0.1;
-	Out.ar(0, out)
+	sound = MostChange.ar(in1, in2) * 0.1;
+	Out.ar(out, sound)
 }).play;
+)
 
 d.set(\amp, 0.1);
 d.set(\amp, 0);
 d.set(\amp, 3);
 d.free;
 
-the control that changed most is used for output:
+// the control that changed most is used for output:
 
-d = SynthDef("help-MostChange", { arg freq=440;
-	var out, internalFreq;
+(
+d = SynthDef("help-MostChange", { |out, freq = 440|
+	var sound, internalFreq;
 	internalFreq = LFNoise0.ar(0.3, 300, 800);
-	out = SinOsc.ar(
+	sound = SinOsc.ar(
 			MostChange.kr(freq, internalFreq)
 	);
-	Out.ar(0, out * 0.1)
+	Out.ar(out, sound * 0.1)
 }).play;
+)
 
 d.set(\freq, 800);
 d.set(\freq, 800); //nothing changed

--- a/HelpSource/Classes/Node.schelp
+++ b/HelpSource/Classes/Node.schelp
@@ -129,8 +129,9 @@ code::
 s.boot;
 (
 x = SynthDef("help-node-setn", {
-	arg freq1 = 440, freq2 = 440, freq3 = 440, amp1 = 0.05, amp2 = 0.05, amp3 = 0.05;
-	Out.ar(0, Mix(SinOsc.ar([freq1, freq2, freq3], 0, [amp1, amp2, amp3])));}).play(s);
+	arg out, freq1 = 440, freq2 = 440, freq3 = 440, amp1 = 0.05, amp2 = 0.05, amp3 = 0.05;
+	Out.ar(out, Mix(SinOsc.ar([freq1, freq2, freq3], 0, [amp1, amp2, amp3])))
+}).play(s);
 )
 // set 3 controls starting from \freq1, and 3 controls starting from \amp1
 x.setn(\freq1, [440, 880, 441], \amp1, [0.3, 0.1, 0.3]);
@@ -155,17 +156,18 @@ s.boot;
 (
 b = Bus.control(s, 1); b.set(880);
 c = Bus.control(s, 1);	c.set(884);
-x = SynthDef("help-Node-map", { arg freq1 = 440, freq2 = 440;
-	Out.ar(0, SinOsc.ar([freq1, freq2], 0, 0.1));
-}).play(s);)
+x = SynthDef("help-Node-map", { arg out, freq1 = 440, freq2 = 440;
+	Out.ar(out, SinOsc.ar([freq1, freq2], 0, 0.1));
+}).play(s)
+)
 x.map(\freq1, b, \freq2, c);
 x.free; b.free; c.free;
 
 // same as above with a multichannel Bus and Control
 (
 b = Bus.control(s, 2); b.set(880, 884);
-x = SynthDef("help-Node-map2", { arg freqs = #[440, 440];
-	Out.ar(0, SinOsc.ar(freqs, 0, 0.1));
+x = SynthDef("help-Node-map2", { arg out, freqs = #[440, 440];
+	Out.ar(out, SinOsc.ar(freqs, 0, 0.1));
 }).play(s);)
 x.map(\freqs, b);
 x.free; b.free;
@@ -291,10 +293,10 @@ fork {
 
 code::
 (
-SynthDef(\help, {
+SynthDef(\help, { |out|
 	var mod = LFNoise2.kr(Rand(1, 6)) * 0.2;
 	var snd = mod * Blip.ar(Rand(200, 800) * (mod + 1));
-	Out.ar(0, snd);
+	Out.ar(out, snd);
 	FreeSelf.kr(mod < 0);
 }).add;
 )

--- a/HelpSource/Classes/Node.schelp
+++ b/HelpSource/Classes/Node.schelp
@@ -82,8 +82,9 @@ If this Node is a Group this will set the running state of all Nodes within the 
 code::
 s.boot;
 (
-x = SynthDef("help-node-set", {arg freq = 440, out = 0;
-	Out.ar(out, SinOsc.ar(freq, 0, 0.1));}).play(s);
+x = SynthDef("help-node-set", { |freq = 440, out = 0|
+	Out.ar(out, SinOsc.ar(freq, 0, 0.1))
+}).play
 )
 x.run(false);
 x.run; // default is true
@@ -97,10 +98,9 @@ Controls are defined in a SynthDef as args or instances of link::Classes/Control
 code::
 s.boot;
 (
-x = SynthDef("help-node-set", {| freq = 440, out = 0 |
-	Out.ar(out, SinOsc.ar(freq, 0, 0.1));
-});
-x = x.play(s);
+x = SynthDef("help-node-set", { |freq = 440, out = 0|
+	Out.ar(out, SinOsc.ar(freq, 0, 0.1))
+}).play
 )
 x.set(\freq, 880, \out, 1); // two pairs
 x.set(0, 660, 1, 0); // freq is the first argument, so it's index is 0. out is index 1.
@@ -110,13 +110,12 @@ Values that are arrays are sent using the OSC array type-tags ($[ and $]).  Thes
 code::
 s.boot;
 (
-x = SynthDef("help-node-set", {| freq = #[440, 450, 460], out = 0 |
-	Out.ar(out, Mix(SinOsc.ar(freq, 0, 0.1)));
-});
-x = x.play(s);
+x = SynthDef("help-node-set", { |freq = #[440, 450, 460], out = 0|
+	Out.ar(out, Mix(SinOsc.ar(freq, 0, 0.1)))
+}).play
 )
-x.set(\freq, [1,2,3] * 400 + [1,2,3], \out, 1); // two pairs
-x.set(\freq, [3] * 400 + [1,2,3], \out, 1); // two pairs
+x.set(\freq, [1,2,3] * 400 + [1, 2, 3], \out, 1); // two pairs
+x.set(\freq, [3] * 400 + [1, 2, 3], \out, 1); // two pairs
 x.set(0, [660, 680, 720], 1, 0); // freq is the first argument, so it's index is 0. out is index 1.
 x.free;
 ::
@@ -131,7 +130,7 @@ s.boot;
 x = SynthDef("help-node-setn", {
 	arg out, freq1 = 440, freq2 = 440, freq3 = 440, amp1 = 0.05, amp2 = 0.05, amp3 = 0.05;
 	Out.ar(out, Mix(SinOsc.ar([freq1, freq2, freq3], 0, [amp1, amp2, amp3])))
-}).play(s);
+}).play;
 )
 // set 3 controls starting from \freq1, and 3 controls starting from \amp1
 x.setn(\freq1, [440, 880, 441], \amp1, [0.3, 0.1, 0.3]);
@@ -156,19 +155,22 @@ s.boot;
 (
 b = Bus.control(s, 1); b.set(880);
 c = Bus.control(s, 1);	c.set(884);
-x = SynthDef("help-Node-map", { arg out, freq1 = 440, freq2 = 440;
+x = SynthDef("help-Node-map", { |out, freq1 = 440, freq2 = 440|
 	Out.ar(out, SinOsc.ar([freq1, freq2], 0, 0.1));
-}).play(s)
+}).play
 )
 x.map(\freq1, b, \freq2, c);
 x.free; b.free; c.free;
 
 // same as above with a multichannel Bus and Control
 (
-b = Bus.control(s, 2); b.set(880, 884);
-x = SynthDef("help-Node-map2", { arg out, freqs = #[440, 440];
+b = Bus.control(s, 2); 
+b.set(880, 884);
+x = SynthDef("help-Node-map2", { |out, freqs = #[440, 440]|
 	Out.ar(out, SinOsc.ar(freqs, 0, 0.1));
-}).play(s);)
+}).play
+)
+
 x.map(\freqs, b);
 x.free; b.free;
 ::
@@ -206,7 +208,7 @@ method:: trace
 Causes a synth to print out the values of the inputs and outputs of its unit generators for one control period to the post window. Causes a group to print the node IDs and names of each node in the group for one control period.
 code::
 g = Group.new;
-x = Synth.head(g, "default");
+x = Synth.head(g, \default);
 x.trace;
 g.trace;
 x.free; g.free;
@@ -220,9 +222,10 @@ code::
 (
 b = s.makeBundle(false, {
 	a = Group.new(s); //create a node object
-	a.register; // register before creating on the server
-});
+	a.register // register before creating on the server
+})
 )
+
 a.isPlaying;
 s.listSendBundle(nil, b); //start the node on the server
 a.isPlaying;
@@ -285,8 +288,8 @@ discussion::
 code::
 (
 fork {
-    {SinOsc.ar(440!2) * Line.kr(0,1,5,doneAction: Done.freeSelf)}.play.waitForFree;
-    {PinkNoise.ar(1) * Line.kr(1,0,2,doneAction: Done.freeSelf)}.play.onFree {"done".postln};
+    { SinOsc.ar(440 ! 2) * Line.kr(0, 1, 5, doneAction: Done.freeSelf) }.play.waitForFree;
+    { PinkNoise.ar(1) * Line.kr(1, 0, 2, doneAction: Done.freeSelf) }.play.onFree {"done".postln};
 }
 )
 ::

--- a/HelpSource/Classes/NodeMap.schelp
+++ b/HelpSource/Classes/NodeMap.schelp
@@ -69,23 +69,23 @@ s.boot;
 
 (
 SynthDef("modsine",
-	{ arg freq=320, amp=0.2;
-		Out.ar(0, SinOsc.ar(freq, 0, amp));
+	{ | out, freq=320, amp=0.2 |
+		Out.ar(out, SinOsc.ar(freq, 0, amp));
 	}).add;
 SynthDef("lfo",
-	{ arg rate=2, busNum=0;
-		Out.kr(busNum, LFPulse.kr(rate, 0, 0.1, 0.2))
+	{ | out, rate=2 |
+		Out.kr(out, LFPulse.kr(rate, 0, 0.1, 0.2))
 	}).add;
 )
 
-//start nodes
+// start nodes
 (
 b = Bus.control(s,1);
 x = Synth("modsine");
-y = Synth.before(x, "lfo", [\busNum, b]);
+y = Synth.before(x, "lfo", [\out, b]);
 )
 
-//create some node maps
+// create some node maps
 (
 h = NodeMap.new;
 h.set(\freq, 800);
@@ -98,15 +98,15 @@ k.unmap(\amp);
 
 //apply the maps
 
-h.sendToNode(x); //the first time a new bundle is made
+h.sendToNode(x); // the first time a new bundle is made
 k.sendToNode(x);
 
-h.sendToNode(x); //the second time the cache is used
+h.sendToNode(x); // the second time the cache is used
 k.sendToNode(x);
 
 h.set(\freq, 600);
 
-h.sendToNode(x); //when a value was changed, a new bundle is made
+h.sendToNode(x); // when a value was changed, a new bundle is made
 
 //free all
 x.free; b.free; y.free;

--- a/HelpSource/Classes/Onsets.schelp
+++ b/HelpSource/Classes/Onsets.schelp
@@ -69,15 +69,6 @@ list::
 
 examples::
 code::
-(
-s.waitForBoot({
-	// Prepare the buffers
-	b = Buffer.alloc(s, 512);
-	// Feel free to load a more interesting clip!
-	// a11wlk01 is not an ideal example of musical onsets.
-	d = Buffer.read(s, Platform.resourceDir +/+ "sounds/a11wlk01.wav");
-});
-)
 
 ////////////////////////////////////////////////////////////////////////////////////////////////
 // Move the mouse to vary the threshold
@@ -90,13 +81,13 @@ x = {
 	// or, uncomment this line if you want to play the buffer in
 	//sig = PlayBuf.ar(1, d, BufRateScale.kr(d), loop: 1);
 
-	chain = FFT(b, sig);
+	chain = FFT(LocalBuf(1, 512), sig);
 
 	onsets = Onsets.kr(chain, MouseX.kr(0,1), \rcomplex);
 
 	// You'll hear percussive "ticks" whenever an onset is detected
 	pips = WhiteNoise.ar(EnvGen.kr(Env.perc(0.001, 0.1, 0.2), onsets));
-	Out.ar(0, Pan2.ar(sig, -0.75, 0.2) + Pan2.ar(pips, 0.75, 1));
+	Pan2.ar(sig, -0.75, 0.2) + Pan2.ar(pips, 0.75, 1)
 }.play;
 )
 x.free; // Free the synth
@@ -118,13 +109,13 @@ x = {
 	// or, uncomment this line if you want to play the buffer in
 	//sig = PlayBuf.ar(1, d, BufRateScale.kr(d), loop: 1);
 
-	chain = FFT(b, sig);
+	chain = FFT(LocalBuf(1, 512), sig);
 
 	onsets = Onsets.kr(chain, threshes, \rcomplex);
 
 	// Generate pips at a variety of pitches
 	pips = SinOsc.ar((threshes).linexp(0, 1, 440, 3520), 0, EnvGen.kr(Env.perc(0.001, 0.1, 0.5), onsets)).mean;
-	Out.ar(0, Pan2.ar(sig, -0.75, 0.2) + Pan2.ar(pips, 0.75, 1));
+	Pan2.ar(sig, -0.75, 0.2) + Pan2.ar(pips, 0.75, 1)
 }.play;
 )
 

--- a/HelpSource/Classes/PV_ChainUGen.schelp
+++ b/HelpSource/Classes/PV_ChainUGen.schelp
@@ -84,8 +84,8 @@ x = {
 		//[mags[30..] ++ mags[..30], phases[30..] ++ phases[..30]]; // ".rotate" doesn't work directly, but this is equivalent
 	}, frombin: 0, tobin: 250, zeroothers: 0);
 
-	Out.ar(0, 0.5 * IFFT(chain).dup);
-}.play(s);
+	0.5 * IFFT(chain).dup
+}.play
 )
 x.free;
 ::
@@ -94,7 +94,7 @@ subsection:: pvcalc2
 code::
 (
 s.waitForBoot({
-c = Buffer.read(s, Platform.resourceDir +/+ "sounds/a11wlk01.wav");
+	c = Buffer.read(s, Platform.resourceDir +/+ "sounds/a11wlk01.wav");
 })
 )
 
@@ -121,8 +121,8 @@ x = {
 	}, frombin: 0, tobin: 125, zeroothers: 0);
 
 	out = IFFT(chain);
-	Out.ar(0, 0.5 * out.dup);
-}.play(s);
+	0.5 * out.dup
+}.play
 )
 x.free;
 ::
@@ -131,7 +131,7 @@ subsection:: pvcollect
 code::
 (
 s.waitForBoot({
-c = Buffer.read(s, Platform.resourceDir +/+ "sounds/a11wlk01.wav");
+	c = Buffer.read(s, Platform.resourceDir +/+ "sounds/a11wlk01.wav");
 })
 )
 
@@ -159,8 +159,8 @@ x = {
 		if((index-LFPar.kr(0.1).range(2, 1024/20)).abs < 10, mag, 0); // Swept bandpass
 	}, frombin: 0, tobin: 250, zeroothers: 0);
 
-	Out.ar(0, 0.5 * IFFT(chain).dup);
-}.play(s);
+	0.5 * IFFT(chain).dup
+}.play
 )
 x.free;
 ::

--- a/HelpSource/Classes/PV_ConformalMap.schelp
+++ b/HelpSource/Classes/PV_ConformalMap.schelp
@@ -59,33 +59,37 @@ Examples::
 
 code::
 
-//explore the effect
+// explore the effect
+
 (
-SynthDef("conformer1", {
+SynthDef("conformer2", { |out|
+	var in, chain, sound;
+	in = Mix.ar(LFSaw.ar(SinOsc.kr(Array.rand(3,0.1,0.5),0,10,[1,1.1,1.5,1.78,2.45,6.7]*220),0,0.3));
+	chain = FFT(LocalBuf(2048), in);
+	chain = PV_ConformalMap(chain, MouseX.kr(0.01,2.0, 'exponential'), MouseY.kr(0.01,10.0, 'exponential'));
+	sound = IFFT(chain);
+
+	Out.ar(out, Pan2.ar(CombN.ar(sound, 0.1, 0.1, 10, 0.5, sound), 0, 0.3));
+}).add;
+)
+
+a = Synth("conformer2")
+a.free
+
+// sound input: use headphones to prevent feedback
+(
+SynthDef("conformer1", { |out|
 	var in, chain;
 	in = SoundIn.ar(0, 0.5);
 	chain = FFT(LocalBuf(1024), in);
-	chain=PV_ConformalMap(chain, MouseX.kr(-1.0,1.0), MouseY.kr(-1.0,1.0));
-	Out.ar(0, Pan2.ar(IFFT(chain),0));
+	chain = PV_ConformalMap(chain, MouseX.kr(-1.0,1.0), MouseY.kr(-1.0,1.0));
+	Out.ar(out, Pan2.ar(IFFT(chain), 0));
 }).add;
 )
 
 a = Synth("conformer1")
 a.free
 
-(
-SynthDef("conformer2", {
-	var in, chain, out;
-	in = Mix.ar(LFSaw.ar(SinOsc.kr(Array.rand(3,0.1,0.5),0,10,[1,1.1,1.5,1.78,2.45,6.7]*220),0,0.3));
-	chain = FFT(LocalBuf(2048), in);
-	chain=PV_ConformalMap(chain, MouseX.kr(0.01,2.0, 'exponential'), MouseY.kr(0.01,10.0, 'exponential'));
-	out=IFFT(chain);
 
-	Out.ar(0, Pan2.ar(CombN.ar(out, 0.1, 0.1, 10, 0.5, out), 0, 0.3));
-}).add;
-)
-
-a = Synth("conformer2")
-a.free
 ::
 

--- a/HelpSource/Classes/PV_Div.schelp
+++ b/HelpSource/Classes/PV_Div.schelp
@@ -34,23 +34,24 @@ x = {
 	// As with most PV_ ugens, the result is *actually* stored in the first fft buf
 	var result = PV_Div(fft2, fft1);
 
-	Out.ar(0, out.dup * 0.1);
+	out.dup * 0.1
 }.play;
 )
 
 // Now we can grab the FFT buffer and peek at the magnitudes
 (
-w = Window.new.front;
-t = Task{loop{
-	0.1.wait;
-	b.loadToFloatArray(action: {|data| {
-		w.view.children.do(_.remove);
-		w.refresh;
-		data[2..].clump(2)
-		.collect {|a| (a[0].squared + a[1].squared)}
-		.collect {|a| if(a.isNaN){ 0.post }{ a } }
-		.plot(parent: w)
-	}.defer});
+p = Plotter.new;
+t = Task {
+	loop {
+		0.1.wait;
+		b.loadToFloatArray(action: {|data|
+			{
+			p.value = data[2..]
+				.clump(2)
+				.collect {|a| a[0].squared + a[1].squared }
+				.collect {|a| if(a.isNaN) { 0.post } { a } }
+		}.defer
+		})
 }}.play;
 )
 ::

--- a/HelpSource/Classes/PV_HainsworthFoote.schelp
+++ b/HelpSource/Classes/PV_HainsworthFoote.schelp
@@ -57,47 +57,47 @@ Examples::
 
 code::
 
-//just Hainsworth metric with low threshold
+// just Hainsworth metric with low threshold
 (
-SynthDef(\fftod, {
+SynthDef(\fftod, { |out|
+	var source1, detect;
+	source1 = SoundIn.ar(0);
+	detect = PV_HainsworthFoote.ar(FFT(LocalBuf(2048),source1), 1.0, 0.0);
+	Out.ar(out, SinOsc.ar([440, 445], 0, Decay.ar(0.1 * detect, 0.1)));
+}).play(s);
+)
+
+
+// spot note transitions
+(
+SynthDef(\fftod, { |out|
+	var source1, detect;
+	source1= LFSaw.ar(LFNoise0.kr(1, 90, 400), 0, 0.5);
+	detect= PV_HainsworthFoote.ar(FFT(LocalBuf(2048), source1), 1.0, 0.0, 0.9, 0.5);
+	Out.ar(out, Pan2.ar(source1, -1.0) + Pan2.ar(SinOsc.ar(440, 0, Decay.ar(0.1 * detect, 0.1)), 1.0));
+}).play(s);
+)
+
+
+
+// Foote solo - never triggers with threshold over 1.0, threshold under mouse control
+(
+SynthDef(\fftod, { |out|
 	var source1, detect;
 	source1= SoundIn.ar(0);
-	detect= PV_HainsworthFoote.ar(FFT(LocalBuf(2048),source1), 1.0, 0.0);
-	Out.ar(0,SinOsc.ar([440,445],0,Decay.ar(0.1*detect,0.1)));
+	detect= PV_HainsworthFoote.ar(FFT(LocalBuf(2048), source1), 0.0, 1.0, MouseX.kr(0.0,1.1), 0.02);
+	Out.ar(out, Pan2.ar(source1, -1.0) + Pan2.ar(SinOsc.ar(440, 0, Decay.ar(0.1 * detect, 0.1)), 1.0));
 }).play(s);
 )
 
 
-//spot note transitions
+// compare to Amplitude UGen
 (
-SynthDef(\fftod, {
-	var source1, detect;
-	source1= LFSaw.ar(LFNoise0.kr(1,90,400),0,0.5);
-	detect= PV_HainsworthFoote.ar(FFT(LocalBuf(2048),source1), 1.0, 0.0, 0.9, 0.5);
-	Out.ar(0,Pan2.ar(source1,-1.0)+ Pan2.ar(SinOsc.ar(440,0,Decay.ar(0.1*detect,0.1)),1.0));
-}).play(s);
-)
-
-
-
-//Foote solo- never triggers with threshold over 1.0, threshold under mouse control
-(
-SynthDef(\fftod, {
-	var source1, detect;
-	source1= SoundIn.ar(0);
-	detect= PV_HainsworthFoote.ar(FFT(LocalBuf(2048),source1), 0.0, 1.0, MouseX.kr(0.0,1.1), 0.02);
-	Out.ar(0,Pan2.ar(source1,-1.0)+ Pan2.ar(SinOsc.ar(440,0,Decay.ar(0.1*detect,0.1)),1.0));
-}).play(s);
-)
-
-
-//compare to Amplitude UGen
-(
-SynthDef(\fftod, {
+SynthDef(\fftod, { |out|
 		var source1, detect;
-		source1= SoundIn.ar(0);
-		detect= (Amplitude.ar(source1)) > (MouseX.kr(0.0,1.1));
-		Out.ar(0,Pan2.ar(source1,-1.0)+ Pan2.ar(SinOsc.ar(440,0,Decay.ar(0.1*detect,0.1)),1.0));
+		source1 = SoundIn.ar(0);
+		detect= Amplitude.ar(source1) > MouseX.kr(0.0, 1.1);
+		Out.ar(out, Pan2.ar(source1, -1.0) + Pan2.ar(SinOsc.ar(440, 0, Decay.ar(0.1 * detect, 0.1)), 1.0));
 	}).play(s);
 )
 

--- a/HelpSource/Classes/PV_JensenAndersen.schelp
+++ b/HelpSource/Classes/PV_JensenAndersen.schelp
@@ -63,11 +63,12 @@ Examples::
 
 code::
 (
-SynthDef(\fftod, { var source1, detect;
-		source1 = SoundIn.ar(0);
-		detect = PV_JensenAndersen.ar(FFT(LocalBuf(2048), source1),
-			threshold:MouseX.kr(0.1,1.0));
-		Out.ar(0, SinOsc.ar([440,445], 0, Decay.ar(0.1*detect, 0.1)));
-	}).play(s);
+SynthDef(\fftod, { |out|
+	var source1, detect, chain;
+	source1 = SoundIn.ar(0);
+	chain = FFT(LocalBuf(2048), source1);
+	detect = PV_JensenAndersen.ar(chain, threshold:MouseX.kr(0.1, 1.0));
+	Out.ar(out, SinOsc.ar([440, 445], 0, Decay.ar(0.1 * detect, 0.1)));
+}).play(s);
 )
 ::

--- a/HelpSource/Classes/PV_PhaseShift270.schelp
+++ b/HelpSource/Classes/PV_PhaseShift270.schelp
@@ -24,13 +24,13 @@ code::
 s.boot;
 
 (
-{  arg out=0;
+{
 	var in, fft, fft2, shifted;
 	in = SinOsc.ar(500, 0, 0.1);
 	fft = FFT(LocalBuf(2048), in);
 	fft2 = FFT(LocalBuf(2048), in);
 	shifted = PV_PhaseShift270(fft);
-	Out.ar(0,  [IFFT(fft2), IFFT(shifted)]);
+	[IFFT(fft2), IFFT(shifted)]
 }.scope
 )
 

--- a/HelpSource/Classes/PV_PhaseShift90.schelp
+++ b/HelpSource/Classes/PV_PhaseShift90.schelp
@@ -24,13 +24,13 @@ code::
 s.boot;
 
 (
-{ arg out=0, bufnum=0;
+{ |out=0, bufnum=0|
 	var in, fft, fft2, shifted;
 	in = SinOsc.ar(500, 0, 0.1);
 	fft = FFT(LocalBuf(2048), in);
 	fft2 = FFT(LocalBuf(2048), in);
 	shifted = PV_PhaseShift90(fft);
-	Out.ar(0, [IFFT(fft2), IFFT(shifted)]);
+	Out.ar(out, [IFFT(fft2), IFFT(shifted)]);
 }.scope
 )
 

--- a/HelpSource/Classes/PackFFT.schelp
+++ b/HelpSource/Classes/PackFFT.schelp
@@ -46,11 +46,11 @@ code::
 x = {
 	var mags, phases, chain, sig;
 	// Create simple undulating magnitudes
-	mags = {FSinOsc.kr(ExpRand(0.1, 1)).range(0, 1)}.dup(100);
+	mags = { FSinOsc.kr(ExpRand(0.1, 1)).range(0, 1) }.dup(100);
 	// Then give them a "rolloff" to make the sound less unpleasant
 	mags = mags  * ((1, 0.99 .. 0.01).squared);
 	// Let's turn the bins on and off at different rates, I'm *sure* that'll sound interesting
-	mags = mags * {LFPulse.kr(2 ** IRand(-3, 5)).range(0, 1)}.dup(100);
+	mags = mags * { LFPulse.kr(2 ** IRand(-3, 5)).range(0, 1) }.dup(100);
 	// Let's ignore phase for now
 	phases = 0.dup(100);
 	// We need to create an FFT chain to feed our data in to.
@@ -59,8 +59,8 @@ x = {
 	// Now we can do the packing
 	chain = PackFFT(chain, 512, [mags, phases].flop.flatten, 0, 99, 1);
 	sig = IFFT(chain);
-	Out.ar(0, sig.dup);
-}.play(s);
+	sig.dup
+}.play
 )
 x.free;
 ::

--- a/HelpSource/Classes/Pan2.schelp
+++ b/HelpSource/Classes/Pan2.schelp
@@ -6,7 +6,7 @@ categories::  UGens>Multichannel>Panners
 
 Description::
 
-Two channel equal power panner. Pan2 takes the square root of the linear scaling factor going from 1 (left or right) to 0.5.sqrt (~=0.707) in the center, which is about 3dB reduction. With linear panning (LinPan2) the signal is lowered as it approaches center using a straight line from 1 (left or right) to 0.5 (center) for a 6dB reduction in the middle. A problem inherent to linear panning is that the perceived volume of the signal drops in the middle. Pan2 solves this. 
+Two channel equal power panner. Pan2 takes the square root of the linear scaling factor going from 1 (left or right) to 0.5.sqrt (~=0.707) in the center, which is about 3dB reduction. With linear panning (LinPan2) the signal is lowered as it approaches center using a straight line from 1 (left or right) to 0.5 (center) for a 6dB reduction in the middle. A problem inherent to linear panning is that the perceived volume of the signal drops in the middle. Pan2 solves this.
 
 
 classmethods::
@@ -31,12 +31,12 @@ A control rate level input.
 Examples::
 code::
 // hear the difference, LinPan having a slight drop in the middle...
-{LinPan2.ar(SinOsc.ar(440), Line.kr(-1,1,5))}.play
+{ LinPan2.ar(SinOsc.ar(440), Line.kr(-1, 1, 5)) }.play
 
 // ... whereas Pan2 is more smooth
-{Pan2.ar(SinOsc.ar(440), Line.kr(-1,1,5))}.play
+{ Pan2.ar(SinOsc.ar(440), Line.kr(-1, 1, 5)) }.play
 
 // other examples
-SynthDef("help-Pan2", { Out.ar(0, Pan2.ar(PinkNoise.ar(0.4), FSinOsc.kr(2), 0.3)) }).play;
+{ Pan2.ar(PinkNoise.ar(0.4), FSinOsc.kr(2), 0.3) }.play;
 ::
 

--- a/HelpSource/Classes/Pan4.schelp
+++ b/HelpSource/Classes/Pan4.schelp
@@ -39,18 +39,16 @@ Examples::
 code::
 
 // You'll only hear the front two channels on a stereo setup.
-(
-SynthDef("help-Pan4", {
-	Out.ar(0, Pan4.ar(PinkNoise.ar, FSinOsc.kr(2), FSinOsc.kr(1.2), 0.3))
-}).play;
-)
 
-play({ Pan4.ar(PinkNoise.ar, -1,  0, 0.3) }); // left pair
-play({ Pan4.ar(PinkNoise.ar,  1,  0, 0.3) }); // right pair
-play({ Pan4.ar(PinkNoise.ar,  0, -1, 0.3) }); // back pair
-play({ Pan4.ar(PinkNoise.ar,  0,  1, 0.3) }); // front pair
+{ Pan4.ar(PinkNoise.ar, FSinOsc.kr(2), FSinOsc.kr(1.2), 0.3)) }.play;
 
-play({ Pan4.ar(PinkNoise.ar,  0,  0, 0.3) }); // center
+
+{ Pan4.ar(PinkNoise.ar, -1,  0, 0.3) }.play; // left pair
+{ Pan4.ar(PinkNoise.ar,  1,  0, 0.3) }.play; // right pair
+{ Pan4.ar(PinkNoise.ar,  0, -1, 0.3) }.play; // back pair
+{ Pan4.ar(PinkNoise.ar,  0,  1, 0.3) }.play; // front pair
+
+{ Pan4.ar(PinkNoise.ar,  0,  0, 0.3) }.play; // center
 
 ::
 

--- a/HelpSource/Classes/PartConv.schelp
+++ b/HelpSource/Classes/PartConv.schelp
@@ -26,91 +26,83 @@ argument:: add
 
 examples::
 code::
-// preparation; essentially, allocate an impulse response buffer, then follow a special buffer preparation step to set up the data the plugin needs. Different options are provided commented out for loading impulse responses from soundfiles.
+
+// preparation; essentially, allocate an impulse response buffer, then
+// follow a special buffer preparation step to set up the data the plugin needs.
+// Different options are provided commented out for loading impulse responses from soundfiles.
 (
-~fftsize=2048; // also 4096 works on my machine; 1024 too often and amortisation too pushed, 8192 more high load FFT
 
-s.waitForBoot({
+ // also 4096 works on my machine; 1024 too often and amortisation too pushed, 8192 more high load FFT
+~fftsize = 2048;
 
-{
-var ir, irbuffer, bufsize;
+s.waitForBoot {
 
-	// // MONO ONLY
-	// pre-existing impulse response sound files
-	// (could also use any general soundfile too for cross-synthesis effects)
-	// irbuffer= Buffer.read(s, "/Volumes/data/audio/ir/ir2.wav");
-	// irbuffer= Buffer.read(s, "/Volumes/data/audio/ir/ir.wav");
-	// this is a two second long hall IR
-	// irbuffer= Buffer.read(s, "/Volumes/data/audio/ir/bighall2.wav");
+	{
+		var ir, irbuffer, bufsize;
 
+		// // MONO ONLY
+		// pre-existing impulse response sound files
+		// (could also use any general soundfile too for cross-synthesis effects)
+		// irbuffer = Buffer.read(s, "/Volumes/data/audio/ir/ir2.wav");
 
-	// synthesise the honourable 'Dan Stowell' impulse response
+		// synthesise the honourable 'Dan Stowell' impulse response
 
-	ir = ([1] ++0.dup(100) ++ ((1, 0.99998 .. 0).collect{|f| f =
-	f.squared.squared; f = if(f.coin){0}{f.squared}; f =
-	if(0.5.coin){0-f}{f} } * 0.1)).normalizeSum;
-	// ir.plot;
+		ir = [1] ++ 0.dup(100) ++ (
+			(1, 0.99998 .. 0)
+			.collect {|f|
+				f = f.squared.squared;
+				f = if(f.coin) { 0 }{ f.squared };
+				f = if(0.5.coin) { 0 - f } { f }
+			} * 0.1
+		);
+		ir = ir.normalizeSum;
 
-	irbuffer = Buffer.loadCollection(s, ir);
+		irbuffer = Buffer.loadCollection(s, ir);
 
-	s.sync;
+		s.sync;
 
-	bufsize= PartConv.calcBufSize(~fftsize, irbuffer);
+		bufsize = PartConv.calcBufSize(~fftsize, irbuffer);
 
-	// ~numpartitions= PartConv.calcNumPartitions(~fftsize, irbuffer);
+		// ~numpartitions= PartConv.calcNumPartitions(~fftsize, irbuffer);
 
-	~irspectrum= Buffer.alloc(s, bufsize, 1);
+		~irspectrum = Buffer.alloc(s, bufsize, 1);
+		~irspectrum.preparePartConv(irbuffer, ~fftsize);
 
-	~irspectrum.preparePartConv(irbuffer, ~fftsize);
+		s.sync;
 
-	s.sync;
+		irbuffer.free; // don't need time domain data anymore, just needed spectral version
+	}.fork;
 
-	irbuffer.free; // don't need time domain data anymore, just needed spectral version
-}.fork;
-
-});
-
+}
 )
 
 
 
-~target= Buffer.read(s, Platform.resourceDir +/+ "sounds/a11wlk01.wav");
-// ~target= Buffer.read(s, "sounds/break");
+~target = Buffer.read(s, Platform.resourceDir +/+ "sounds/a11wlk01.wav");
 
 (
-
-{ var input, kernel;
-
-input= PlayBuf.ar(1, ~target, loop:1);
-
-Out.ar(0, PartConv.ar(input, ~fftsize, ~irspectrum.bufnum, 0.5));
- }.play;
-
+{
+	var input = PlayBuf.ar(1, ~target, loop:1);
+	PartConv.ar(input, ~fftsize, ~irspectrum.bufnum, 0.5)
+}.play
 )
 
 
 // convolve with live input
 (
-
-{ var input, kernel;
-
-input= SoundIn.ar(0);
-
-Out.ar(0, PartConv.ar(input, ~fftsize, ~irspectrum.bufnum));
-}.play;
+{
+	var input = SoundIn.ar(0);
+	PartConv.ar(input, ~fftsize, ~irspectrum.bufnum)
+}.play
 )
 
 
 // should get back original impulse response (once every four seconds)
 (
-
-{ var input, kernel;
-
-input= Impulse.ar(0.25);
-
-Out.ar(0, PartConv.ar(input, ~fftsize, ~irspectrum.bufnum));
- }.play;
-
+{
+	var input = Impulse.ar(0.25);
+	PartConv.ar(input, ~fftsize, ~irspectrum.bufnum)
+}.play
 )
 
 

--- a/HelpSource/Classes/Pause.schelp
+++ b/HelpSource/Classes/Pause.schelp
@@ -29,9 +29,9 @@ code::
 
 s.boot;
 
-SynthDef("a", { Out.ar(0, SinOsc.ar(800, 0, 0.2)) }).add;
+SynthDef(\a, { Out.ar(0, SinOsc.ar(800, 0, 0.2)) }).add;
 
-SynthDef("b", { arg gate=1; Out.ar(1, PinkNoise.ar(0.3)); Pause.kr(gate, 1001); }).add;
+SynthDef(\b, { |gate = 1| Out.ar(1, PinkNoise.ar(0.3)); Pause.kr(gate, 1001) }).add;
 
 s.sendMsg(\s_new, \a, 1001, 0, 0);
 

--- a/HelpSource/Classes/Pdfsm.schelp
+++ b/HelpSource/Classes/Pdfsm.schelp
@@ -117,15 +117,17 @@ Routine({
 
 (
 SynthDef(\help_Pdfsm2,
-	{ arg freq, gate=1;
+	{ |out, freq, gate=1|
 		var n=8, env, osc;
 		env = Linen.kr( gate, 0.01, 1, 0.03, 2 );
-		osc = {Mix.fill( n, { arg i;
-			FSinOsc.ar(freq + Rand(-2.0,2.0), Rand(0, 0.05pi)) ring4:
-			FSinOsc.ar(freq * (i+1));
-		})}.dup * FSinOsc.kr(Rand(1.5,4.5),{Rand(-0.1pi,0.1pi)}.dup,0.6,env*0.4);
-		Out.ar(0, env * osc / (n*4) )
-	}).add;
+		osc = {
+			Mix.fill( n, { |i|
+				FSinOsc.ar(freq + Rand(-2.0,2.0), Rand(0, 0.05pi)) ring4:
+				FSinOsc.ar(freq * (i+1));
+			})
+		}.dup * FSinOsc.kr(Rand(1.5,4.5),{Rand(-0.1pi,0.1pi)}.dup,0.6,env*0.4);
+		Out.ar(out, env * osc / (n*4) )
+}).add;
 )
 
 (

--- a/HelpSource/Classes/PingPong.schelp
+++ b/HelpSource/Classes/PingPong.schelp
@@ -42,30 +42,32 @@ code::
 s = Server.local;
 s.waitForBoot({
 
-b = Buffer.alloc(s,44100 * 2, 2);
+b = Buffer.alloc(s, 44100 * 2, 2);
 
-SynthDef("help-PingPong",{ arg out=0,bufnum=0,feedback=0.5,delayTime=0.2;
+SynthDef("help-PingPong", { |out = 0, bufnum = 0, feedback = 0.5, delayTime = 0.2|
 	var left, right;
 	left = Decay2.ar(Impulse.ar(0.7, 0.25), 0.01, 0.25,
 		SinOsc.ar(SinOsc.kr(3.7,0,200,500)));
 	right = Decay2.ar(Impulse.ar(0.5, 0.25), 0.01, 0.25,
 		Resonz.ar(PinkNoise.ar(4), SinOsc.kr(2.7,0,1000,2500), 0.2));
 
-	Out.ar(0,
+	Out.ar(out ,
 		PingPong.ar(bufnum, [left,right], delayTime, feedback, 1)
 	)
-}).play(s,[\out, 0, \bufnum, b.bufnum,\feedback,0.5,\delayTime,0.1]);
-});
+}).play(s, [\out, 0, \bufnum, b.bufnum, \feedback, 0.5, \delayTime,0.1]);
+
+})
 )
 
+b.free;
 
 (
 s = Server.local;
 s.waitForBoot({
 
-b = Buffer.alloc(s,44100 * 2, 2);
+b = Buffer.alloc(s, 44100 * 2, 2);
 
-SynthDef("help-PingPong",{ arg out=0,bufnum=0;
+SynthDef("help-PingPong", { |out = 0, bufnum = 0|
 	var left, right;
 	left = Decay2.ar(Impulse.ar(0.7, 0.25), 0.01, 0.25,
 		SinOsc.ar(SinOsc.kr(3.7,0,200,500)));
@@ -73,32 +75,16 @@ SynthDef("help-PingPong",{ arg out=0,bufnum=0;
 		Resonz.ar(PinkNoise.ar(4), SinOsc.kr(2.7,0,1000,2500),
 0.2));
 
-	Out.ar(0,
-		PingPong.ar(bufnum, [left,right] *  EnvGen.kr(Env([1, 1, 0], [2, 0.1])),
+	Out.ar(out,
+		PingPong.ar(bufnum, [left, right] *  EnvGen.kr(Env([1, 1, 0], [2, 0.1])),
 			0.1, 0.8, 1)
 	)
-}).play(s,[\out, 0, \bufnum, b.bufnum]);
+}).play(s, [\out, 0, \bufnum, b.bufnum]);
 });
 )
 
+b.free;
 
-
-
-
-(
-
-Patch({ arg buffer,feedback=0.5,delayTime=0.2;
-	var left, right;
-	left = Decay2.ar(Impulse.ar(0.7, 0.25), 0.01, 0.25,
-		SinOsc.ar(SinOsc.kr(3.7,0,200,500)));
-	right = Decay2.ar(Impulse.ar(0.5, 0.25), 0.01, 0.25,
-		Resonz.ar(PinkNoise.ar(4), SinOsc.kr(2.7,0,1000,2500), 0.2));
-
-	PingPong.ar(buffer.bufnumIr, [left,right], delayTime, feedback, 1)
-
-}).gui
-
-)
 
 ::
 

--- a/HelpSource/Classes/Pitch.schelp
+++ b/HelpSource/Classes/Pitch.schelp
@@ -49,40 +49,41 @@ instancemethods::
 private:: init
 
 examples::
-(use headphones!)
 
 code::
+	// (use headphones!)
 
-(
-SynthDef("pitchFollow1", {
-	var in, amp, freq, hasFreq, out;
-	in = Mix.new(SoundIn.ar([0,1]));
-	amp = Amplitude.kr(in, 0.05, 0.05);
-	# freq, hasFreq = Pitch.kr(in, ampThreshold: 0.02, median: 7);
-	//freq = Lag.kr(freq.cpsmidi.round(1).midicps, 0.05);
-	out = Mix.new(VarSaw.ar(freq * [0.5,1,2], 0, LFNoise1.kr(0.3,0.1,0.1), amp));
-	6.do({
-		out = AllpassN.ar(out, 0.040, [0.040.rand,0.040.rand], 2)
-	});
-	Out.ar(0,out);
-}).play(s);
-)
+	(
+		SynthDef("pitchFollow1", { |out|
+			var in, amp, freq, hasFreq, sound;
+			in = Mix.new(SoundIn.ar([0, 1]));
+			amp = Amplitude.kr(in, 0.05, 0.05);
+			# freq, hasFreq = Pitch.kr(in, ampThreshold: 0.02, median: 7);
+			//freq = Lag.kr(freq.cpsmidi.round(1).midicps, 0.05);
+			sound = Mix.new(VarSaw.ar(freq * [0.5, 1, 2], 0, LFNoise1.kr(0.3, 0.1, 0.1), amp));
+			6.do {
+				sound = AllpassN.ar(sound, 0.040, [0.040.rand,0.040.rand], 2)
+			};
+			Out.ar(out, sound);
+		}).play
+	)
 ::
 
 code::
-(
-SynthDef("pitchFollow2", {
-	var in, amp, freq, hasFreq, out;
-	in = Mix.new(SoundIn.ar([0,1]));
-	amp = Amplitude.kr(in, 0.05, 0.05);
-	# freq, hasFreq = Pitch.kr(in, ampThreshold: 0.02, median: 7);
-	out = CombC.ar(LPF.ar(in, 1000), 0.1, (2 * freq).reciprocal, -6).distort * 0.05;
-	6.do({
-		out = AllpassN.ar(out, 0.040, [0.040.rand,0.040.rand], 2)
-	});
-	Out.ar(0,out);
-}).play(s);
-)
+
+	(
+		SynthDef("pitchFollow2", { |out|
+			var in, amp, freq, hasFreq, sound;
+			in = Mix.new(SoundIn.ar([0, 1]));
+			amp = Amplitude.kr(in, 0.05, 0.05);
+			# freq, hasFreq = Pitch.kr(in, ampThreshold: 0.02, median: 7);
+			sound = CombC.ar(LPF.ar(in, 1000), 0.1, (2 * freq + 10).reciprocal, -6).distort * 0.05;
+			6.do({
+				sound = AllpassN.ar(sound, 0.040, [0.040.rand, 0.040.rand], 2)
+			});
+			Out.ar(out, sound);
+		}).play(s);
+	)
 
 /*
 
@@ -105,14 +106,15 @@ andreavalle
 
 */
 
-(
-SynthDef.new(\RmOctaver, { var in, out = 0, freq, hasFreq;
-	in = SoundIn.ar(0);
-	# freq, hasFreq = Pitch.kr(in);
-	Out.ar(out, SinOsc.ar(freq: freq*0.5)*in+in);
-}).add;
-)
+	(
+		SynthDef(\RmOctaver, { |out|
+			var in, freq, hasFreq;
+			in = SoundIn.ar(0);
+			# freq, hasFreq = Pitch.kr(in);
+			Out.ar(out, SinOsc.ar(freq: freq * 0.5) * in + in);
+		}).add;
+	)
 
-Synth.new(\RmOctaver);
+	Synth.new(\RmOctaver);
 
 ::

--- a/HelpSource/Classes/Pwalk.schelp
+++ b/HelpSource/Classes/Pwalk.schelp
@@ -56,8 +56,8 @@ a = Pwalk(
 	0);
 x = a.asStream;
 
-SynthDef(\help_walk, { arg freq;
-	Out.ar(0, Saw.ar([freq, freq+1], 0.5) * EnvGen.kr(Env.perc(0.01, 0.1), doneAction: Done.freeSelf))
+SynthDef(\help_walk, { |out, freq|
+	Out.ar(out, Saw.ar([freq, freq+1], 0.5) * EnvGen.kr(Env.perc(0.01, 0.1), doneAction: Done.freeSelf))
 }).add;
 )
 

--- a/HelpSource/Classes/Recorder.schelp
+++ b/HelpSource/Classes/Recorder.schelp
@@ -159,14 +159,15 @@ s.boot; // start the server
 
 // something to record
 (
-SynthDef("bubbles", {
-	var f, zout;
-	f = LFSaw.kr(0.4, 0, 24, LFSaw.kr([8,7.23], 0, 3, 80)).midicps; // glissando function
-	zout = CombN.ar(SinOsc.ar(f, 0, 0.04), 0.2, 0.2, 4); // echoing sine wave
-	Out.ar(0, zout);
+SynthDef("bubbles", { |out|
+	var f, sound;
+	f = LFSaw.kr(0.4, 0, 24, LFSaw.kr([8, 7.23], 0, 3, 80)).midicps; // glissando function
+	sound = CombN.ar(SinOsc.ar(f, 0, 0.04), 0.2, 0.2, 4); // echoing sine wave
+	Out.ar(out, sound);
 }).add;
-SynthDef("tpulse", { arg out=0,freq=700,sawFreq=440.0;
-	Out.ar(out, SyncSaw.ar(freq,  sawFreq,0.1) )
+
+SynthDef("tpulse", { |out = 0, freq = 700, sawFreq = 440.0|
+	Out.ar(out, SyncSaw.ar(freq, sawFreq, 0.1))
 }).add;
 
 )

--- a/HelpSource/Classes/Score.schelp
+++ b/HelpSource/Classes/Score.schelp
@@ -141,11 +141,11 @@ subsection::NRT Examples
 code::
 // A sample synthDef
 (
-SynthDef("helpscore",{ arg freq = 440;
-	Out.ar(0,
+SynthDef("helpscore", { |out, freq = 440|
+	Out.ar(out,
 		SinOsc.ar(freq, 0, 0.2) * Line.kr(1, 0, 0.5, doneAction: Done.freeSelf)
 	)
-}).add;
+}).add
 )
 
 // write a sample file for testing
@@ -197,11 +197,11 @@ s.boot; // boot the default server
 
 // A sample synthDef
 (
-SynthDef("helpscore",{ arg freq = 440;
-	Out.ar(0,
+SynthDef("helpscore", { |out, freq = 440|
+	Out.ar(out,
 		SinOsc.ar(freq, 0, 0.2) * Line.kr(1, 0, 0.5, doneAction: Done.freeSelf)
 	)
-}).add;
+}).add
 )
 
 // write a sample file for testing

--- a/HelpSource/Classes/Server.schelp
+++ b/HelpSource/Classes/Server.schelp
@@ -574,11 +574,11 @@ s.boot; // start the server
 
 // something to record
 (
-SynthDef("bubbles", {
-	var f, zout;
+SynthDef("bubbles", { |out|
+	var f, sound;
 	f = LFSaw.kr(0.4, 0, 24, LFSaw.kr([8,7.23], 0, 3, 80)).midicps; // glissando function
-	zout = CombN.ar(SinOsc.ar(f, 0, 0.04), 0.2, 0.2, 4); // echoing sine wave
-	Out.ar(0, zout);
+	sound = CombN.ar(SinOsc.ar(f, 0, 0.04), 0.2, 0.2, 4); // echoing sine wave
+	Out.ar(out, sound);
 }).add;
 )
 

--- a/HelpSource/Classes/Slider.schelp
+++ b/HelpSource/Classes/Slider.schelp
@@ -213,7 +213,7 @@ code::
 ( // select the slider, type something and watch the post window
 w = Window.new;
 c = Slider(w, Rect(0,0,100,30));
-c.keyDownAction = { arg view, char, modifiers, unicode, keycode;
+c.keyDownAction = { |view, char, modifiers, unicode, keycode|
 [char, modifiers, unicode, keycode].postln;
 };
 w.front;
@@ -248,7 +248,7 @@ code::
 
 	(
 		s.waitForBoot({
-			SynthDef(\pluck,{ |out, freq=55|
+			SynthDef(\pluck, { |out, freq=55|
 				Out.ar(out,
 					Pluck.ar(WhiteNoise.ar(0.06),
 						EnvGen.kr(Env.perc(0,4), 1.0, doneAction: Done.freeSelf),

--- a/HelpSource/Classes/Slider.schelp
+++ b/HelpSource/Classes/Slider.schelp
@@ -212,9 +212,9 @@ subsection:: Use the slider view to accept key actions
 code::
 ( // select the slider, type something and watch the post window
 w = Window.new;
-c = Slider(w,Rect(0,0,100,30));
-c.keyDownAction = { arg view,char,modifiers,unicode,keycode;
-[char,modifiers,unicode,keycode].postln;
+c = Slider(w, Rect(0,0,100,30));
+c.keyDownAction = { arg view, char, modifiers, unicode, keycode;
+[char, modifiers, unicode, keycode].postln;
 };
 w.front;
 )
@@ -245,33 +245,35 @@ a.action = nil;
 
 subsection:: Use Slider for triggering sounds
 code::
-(
-s.waitForBoot({
-	SynthDef(\pluck,{arg freq=55;
-		Out.ar(0,
-		Pluck.ar(WhiteNoise.ar(0.06),
-			EnvGen.kr(Env.perc(0,4), 1.0, doneAction: Done.freeSelf),
-			freq.reciprocal,
-			freq.reciprocal,
-			10,
-		coef:0.1)
-		);
-	}).add;
+
+	(
+		s.waitForBoot({
+			SynthDef(\pluck,{ |out, freq=55|
+				Out.ar(out,
+					Pluck.ar(WhiteNoise.ar(0.06),
+						EnvGen.kr(Env.perc(0,4), 1.0, doneAction: Done.freeSelf),
+						freq.reciprocal,
+						freq.reciprocal,
+						10,
+						coef:0.1)
+				);
+			}).add;
 
 
-	w = Window.new("Hold arrow keys to trigger sound",Rect(300,Window.screenBounds.height-300,400,100)).front;
-	a = Slider(w, Rect(50, 20, 300, 40))
-		.value_(0.5)
-		.step_(0.05)
-		.focus
-		.action_({
-			// trigger a synth with varying frequencies
-			Synth(\pluck, [\freq,55+(1100*a.value)]);
-			w.view.background_(Gradient(Color.rand,Color.rand));
-		})
-});
+			w = Window.new("Hold arrow keys to trigger sound",
+				Rect(300,Window.screenBounds.height-300,400,100)).front;
+			a = Slider(w, Rect(50, 20, 300, 40))
+			.value_(0.5)
+			.step_(0.05)
+			.focus
+			.action_({
+				// trigger a synth with varying frequencies
+				Synth(\pluck, [\freq,55+(1100*a.value)]);
+				w.view.background_(Gradient(Color.rand,Color.rand));
+			})
+		});
 
-)
+	)
 ::
 
 subsection:: Change background color of Window

--- a/HelpSource/Classes/Slider.schelp
+++ b/HelpSource/Classes/Slider.schelp
@@ -165,7 +165,7 @@ c = NumberBox(w, Rect(20, 20, 150, 20));
 a = Slider(w, Rect(200, 60, 20, 150))
 	.action_({
 		c.value_(a.value)
-		});
+	});
 a.action.value;
 )
 ::
@@ -185,7 +185,6 @@ a = Slider(w, Rect(20, 50, 150, 20))
 		// round the float so it will fit in the NumberBox
 		});
 a.action.value;
-
 )
 ::
 
@@ -202,7 +201,7 @@ d = PopUpMenu(w, Rect(20, 60, 100, 20))
 	.items_(a)
 	.action_({
 		b.step_((a.at(d.value)).asFloat);
-		});
+	});
 StaticText(w, Rect(130, 60, 100, 20)).string_("change step");
 c = NumberBox(w, Rect(20, 20, 100, 20));
 )
@@ -214,7 +213,7 @@ code::
 w = Window.new;
 c = Slider(w, Rect(0,0,100,30));
 c.keyDownAction = { |view, char, modifiers, unicode, keycode|
-[char, modifiers, unicode, keycode].postln;
+	[char, modifiers, unicode, keycode].postln
 };
 w.front;
 )
@@ -248,6 +247,7 @@ code::
 
 	(
 		s.waitForBoot({
+			
 			SynthDef(\pluck, { |out, freq=55|
 				Out.ar(out,
 					Pluck.ar(WhiteNoise.ar(0.06),
@@ -261,14 +261,11 @@ code::
 
 
 			w = Window.new("Hold arrow keys to trigger sound",
-				Rect(300,Window.screenBounds.height-300,400,100)).front;
-			a = Slider(w, Rect(50, 20, 300, 40))
-			.value_(0.5)
-			.step_(0.05)
-			.focus
+				Rect(300, Window.screenBounds.height - 300, 400, 100)).front;
+			a = Slider(w, Rect(50, 20, 300, 40)).value_(0.5).step_(0.05).focus
 			.action_({
 				// trigger a synth with varying frequencies
-				Synth(\pluck, [\freq,55+(1100*a.value)]);
+				Synth(\pluck, [\freq, 55 + (1100 * a.value)]);
 				w.view.background_(Gradient(Color.rand,Color.rand));
 			})
 		});

--- a/HelpSource/Classes/SpecCentroid.schelp
+++ b/HelpSource/Classes/SpecCentroid.schelp
@@ -20,23 +20,20 @@ A link::Classes/Blip:: oscillator is ideal for demonstrating this because the nu
 
 code::
 s.boot;
-b = Buffer.alloc(s,2048,1);
+b = Buffer.alloc(s, 2048, 1);
 (
 x = {
-var in, chain, freq, rq, centroid;
+	var in, chain, freq, rq, centroid;
 
-//freq = LFPar.kr(0.3).exprange(100, 1000);
-freq = MouseY.kr(1000, 100, 1);
+	//freq = LFPar.kr(0.3).exprange(100, 1000);
+	freq = MouseY.kr(1000, 100, 1);
+	in = Blip.ar(freq, MouseX.kr(1, 100, 1));
+	chain = FFT(LocalBuf(2048), in);
+	centroid = SpecCentroid.kr(chain);
+	centroid.poll(10);
+	in.dup * 0.1
 
-in = Blip.ar(freq, MouseX.kr(1, 100, 1));
-
-chain = FFT(b, in);
-
-centroid = SpecCentroid.kr(chain);
-
-Out.ar(0, in.dup * 0.1);
-centroid.poll(10);
-}.play(s);
+}.play
 )
 
 x.free;

--- a/HelpSource/Classes/SpecFlatness.schelp
+++ b/HelpSource/Classes/SpecFlatness.schelp
@@ -18,33 +18,33 @@ examples::
 
 code::
 s.boot;
-b = Buffer.alloc(s,2048,1);
 
 (
 { // Example - vary mixture of white noise and pure tone with the mouse
-var in, chain, flat, flatdb, flatdbsquish;
-in = XFade2.ar(WhiteNoise.ar, SinOsc.ar, MouseX.kr(-1,1));
-chain = FFT(b, in);
-Out.ar(0, in * 0.1);
+	var in, chain, flat, flatdb, flatdbsquish;
 
-flat = SpecFlatness.kr(chain);
+	in = XFade2.ar(WhiteNoise.ar, SinOsc.ar, MouseX.kr(-1,1));
+	chain = FFT(LocalBuf(1, 2048), in);
+	Out.ar(0, in * 0.1);
 
-flatdb = 10 * flat.log; // Convert to decibels
-flatdbsquish = LinLin.kr(flatdb, -45, -1.6, 0, 1).max(-10); // Rescale db roughly to 0...1.
+	flat = SpecFlatness.kr(chain);
 
-flat.poll(10, "flatness: ");
-flatdb.poll(10, "flatness (db): ");
+	flatdb = 10 * flat.log; // Convert to decibels
+	flatdbsquish = LinLin.kr(flatdb, -45, -1.6, 0, 1).max(-10); // Rescale db roughly to 0...1.
 
-Out.kr(0, [flat, flatdbsquish]);
+	flat.poll(10, "flatness: ");
+	flatdb.poll(10, "flatness (db): ");
+
+	[flat, flatdbsquish]
 }.scope;
 )
 
 (
 { // Now try with your own voice
-var in, chain;
-in = SoundIn.ar([0,1]).mean;
-chain = FFT(b, in);
-Out.kr(0, [in, SpecFlatness.kr(chain).poll(1, "flatness: ")]);
+	var in, chain;
+	in = SoundIn.ar([0,1]).mean;
+	chain = FFT(LocalBuf(1, 2048), in);
+	Out.kr(0, [in, SpecFlatness.kr(chain).poll(1, "flatness: ")]);
 }.scope;
 )
 ::

--- a/HelpSource/Classes/SpecPcile.schelp
+++ b/HelpSource/Classes/SpecPcile.schelp
@@ -21,22 +21,20 @@ argument:: interpolate
 examples::
 
 code::
-s.boot;
-b = Buffer.alloc(s,2048,1);
 
 // Simple demo with filtering white noise, and trying to infer the cutoff freq.
 // Move the mouse.
 (
 {
-var in, chain, realcutoff, estcutoff;
-realcutoff = MouseX.kr(0.00001,22050);
-in = LPF.ar(WhiteNoise.ar, realcutoff);
-chain = FFT(b, in);
-estcutoff = Lag.kr(SpecPcile.kr(chain, 0.9), 1);
-realcutoff.poll(Impulse.kr(1), "real cutoff");
-estcutoff.poll(Impulse.kr(1), "estimated cutoff");
-Out.ar(0, in);
-Out.kr(0, estcutoff * 22050.0.reciprocal);
+	var in, chain, realcutoff, estcutoff;
+	realcutoff = MouseX.kr(0.00001,22050);
+	in = LPF.ar(WhiteNoise.ar, realcutoff);
+	chain = FFT(LocalBuf(1, 2048), in);
+	estcutoff = Lag.kr(SpecPcile.kr(chain, 0.9), 1);
+	realcutoff.poll(Impulse.kr(1), "real cutoff");
+	estcutoff.poll(Impulse.kr(1), "estimated cutoff");
+	Out.kr(0, estcutoff * 22050.0.reciprocal);
+	Out.ar(0, in);
 }.scope;
 )
 
@@ -44,13 +42,13 @@ Out.kr(0, estcutoff * 22050.0.reciprocal);
 // Specifically, change from "ssss" through to "aaaa" through to "wwww".
 (
 {
-var in, chain, perc;
-in = SoundIn.ar([0,1]).mean;
-chain = FFT(b, in);
-//Out.ar(0, in * 0.1);
-perc = SpecPcile.kr(chain, 0.5);
-Out.ar(1, LPF.ar(WhiteNoise.ar, perc)); //NB Outputting to right channel - handy on PowerBooks
-Out.kr(0, perc * 22050.0.reciprocal);
+	var in, chain, perc;
+	in = SoundIn.ar([0,1]).mean;
+	chain = FFT(LocalBuf(1, 2048), in);
+	//Out.ar(0, in * 0.1);
+	perc = SpecPcile.kr(chain, 0.5);
+	Out.kr(0, perc * 22050.0.reciprocal);
+	Out.ar(1, LPF.ar(WhiteNoise.ar, perc)); // outputting to right channel
 }.scope;
 )
 ::

--- a/HelpSource/Classes/StaticText.schelp
+++ b/HelpSource/Classes/StaticText.schelp
@@ -81,7 +81,7 @@ subsection:: Monitoring Values in a Synth
 
 code::
 (
-
+var w, a, r, b, q;
 w = Window("Frequency Monitor", Rect(200, Window.screenBounds.height-200,300,150)).front;
 
 a = StaticText(w, Rect(45, 10, 200, 20)).background_(Color.rand);
@@ -92,30 +92,38 @@ Button.new(w, Rect(45, 70, 200, 20)).states_([["close",Color.black,Color.rand]])
 
 s.waitForBoot({
 
-    b=Bus.new(\control,0,1);
+    b = Bus.new(\control, 0, 1);
 
-    q=SynthDef(\Docs_FreqMonitor, {var freq,snd;
-        freq=LFNoise0.ar(2, 400, 650);
-        snd=SinOsc.ar(freq,0,0.2);
-        Out.ar(0,snd);
-        Out.kr(b.index,freq); // output the frequency to a control bus
+    q = SynthDef(\Docs_FreqMonitor, {
+		var freq, snd;
+        freq = LFNoise0.ar(2, 400, 650);
+        snd = SinOsc.ar(freq, 0, 0.2);
+        Out.ar(0, snd);
+        Out.kr(b.index, freq); // output the frequency to a control bus
     }).play;
 
-    r= Routine{
-        {           // Set the value of the StaticText to the value in the control bus.
-                    // Setting GUI values is asynchronous, so you must use .defer in the system clock.
-                    // Also you must check if the window is still open, since Routine will continue for at least
-                    // one step after you close the window.
-        b.get( {arg v; {w.isClosed.not.if{ a.string= " Current Frequency: "++v.round(0.01)}; }.defer} );
+    r = Routine {
+		{
+			// Set the value of the StaticText to the value in the control bus.
+			// Setting GUI values is asynchronous, so you must use .defer in the system clock.
+			// Also you must check if the window is still open, since Routine will continue for at least
+			// one step after you close the window.
+			b.get({ |v|
+				{
+					w.isClosed.not.if {
+						a.string = " Current Frequency: " ++ v.round(0.01)
+					}
+				}.defer
+			});
 
-        0.01.wait;
-        }.loop
+			0.01.wait;
+		}.loop
 
     }.play
 });
 
 CmdPeriod.doOnce({w.close});
-w.onClose={r.stop; q.free; b.free }; //clean up if the window closes
+w.onClose = { r.stop; q.free; b.free }; //clean up if the window closes
 
 )
 ::
@@ -128,29 +136,36 @@ code::
 w = Window.new.front;
 w.view.background=Color.white;
 a = Array.fill(20, {StaticText(w, Rect(w.bounds.extent.x.rand, w.bounds.extent.y.rand, 160, 16))
-    .string_("Rolof's Rolex".scramble)
-    .align_(\center)
-    .stringColor_(Color.rand)
-    .font_(Font([
-        "Helvetica-Bold",
-        "Helvetica",
-        "Monaco",
-        "Arial",
-        "Gadget",
-        "MarkerFelt-Thin"
-    ].choose, 11))
+	.string_("Rolof's Rolex".scramble)
+	.align_(\center)
+	.stringColor_(Color.rand)
+	.font_(Font([
+		"Helvetica-Bold",
+		"Helvetica",
+		"Monaco",
+		"Arial",
+		"Gadget",
+		"MarkerFelt-Thin"
+	].choose, 11))
 });
 
-r = {inf.do{|i|
-    thisThread.randSeed_(1284);
-    a.do{|item|
-        // setting GUI values is asynchronous, so you must use .defer
-        {item.bounds = Rect(5+w.bounds.extent.x.rand * (cos(i*0.01)).abs,
-                    w.bounds.extent.y.rand * sin(i*0.01),
-                    160, 20)}.defer;
-    };
-    0.15.wait;
-}}.fork;
+r = {
+	inf.do { |i|
+		thisThread.randSeed_(1284);
+		a.do { |item|
+			// setting GUI values is asynchronous, so you must use .defer
+			{
+				item.bounds = Rect(
+					5 + w.bounds.extent.x.rand * (cos(i*0.01)).abs,
+					w.bounds.extent.y.rand * sin(i * 0.01),
+					160,
+					20
+				)
+			}.defer;
+		};
+		0.15.wait;
+	}
+}.fork;
 CmdPeriod.doOnce({w.close});
 w.onClose_({r.stop});
 )

--- a/HelpSource/Classes/StaticText.schelp
+++ b/HelpSource/Classes/StaticText.schelp
@@ -82,13 +82,12 @@ subsection:: Monitoring Values in a Synth
 code::
 (
 var w, a, r, b, q;
-w = Window("Frequency Monitor", Rect(200, Window.screenBounds.height-200,300,150)).front;
+w = Window("Frequency Monitor", Rect(200, Window.screenBounds.height - 200, 300, 150)).front;
 
 a = StaticText(w, Rect(45, 10, 200, 20)).background_(Color.rand);
-
 a.string = " Current Frequency ";
 
-Button.new(w, Rect(45, 70, 200, 20)).states_([["close",Color.black,Color.rand]]).action_({w.close});
+Button.new(w, Rect(45, 70, 200, 20)).states_([[ "close", Color.black, Color.rand ]]).action_({ w.close });
 
 s.waitForBoot({
 
@@ -110,7 +109,7 @@ s.waitForBoot({
 			// one step after you close the window.
 			b.get({ |v|
 				{
-					w.isClosed.not.if {
+					if(w.isClosed.not) {
 						a.string = " Current Frequency: " ++ v.round(0.01)
 					}
 				}.defer
@@ -122,9 +121,8 @@ s.waitForBoot({
     }.play
 });
 
-CmdPeriod.doOnce({w.close});
-w.onClose = { r.stop; q.free; b.free }; //clean up if the window closes
-
+CmdPeriod.doOnce({ w.close });
+w.onClose = { r.stop; q.free; b.free }; // clean up if the window closes
 )
 ::
 
@@ -135,7 +133,7 @@ code::
 (
 w = Window.new.front;
 w.view.background=Color.white;
-a = Array.fill(20, {StaticText(w, Rect(w.bounds.extent.x.rand, w.bounds.extent.y.rand, 160, 16))
+a = Array.fill(20, { StaticText(w, Rect(w.bounds.extent.x.rand, w.bounds.extent.y.rand, 160, 16))
 	.string_("Rolof's Rolex".scramble)
 	.align_(\center)
 	.stringColor_(Color.rand)
@@ -156,7 +154,7 @@ r = {
 			// setting GUI values is asynchronous, so you must use .defer
 			{
 				item.bounds = Rect(
-					5 + w.bounds.extent.x.rand * (cos(i*0.01)).abs,
+					5 + w.bounds.extent.x.rand * abs(cos(i * 0.01)),
 					w.bounds.extent.y.rand * sin(i * 0.01),
 					160,
 					20
@@ -166,7 +164,7 @@ r = {
 		0.15.wait;
 	}
 }.fork;
-CmdPeriod.doOnce({w.close});
-w.onClose_({r.stop});
+CmdPeriod.doOnce({ w.close });
+w.onClose_({ r.stop });
 )
 ::

--- a/HelpSource/Classes/Stepper.schelp
+++ b/HelpSource/Classes/Stepper.schelp
@@ -98,7 +98,7 @@ a = ({rrand(0,15)}.dup(16).degreeToKey(m) + 36).midicps;
 s.performList(\sendMsg, \b_setn, 10, 0, a.size, a);
 
 (
-SynthDef(\stepper, {
+SynthDef(\stepper, { |out|
 	var rate, clock, index, freq, ffreq, env, out, rev, lfo;
 
 	rate = MouseX.kr(1,5,1);
@@ -118,7 +118,7 @@ SynthDef(\stepper, {
 
 	// reverb
 	rev = out;
-	5.do { rev = AllpassN.ar(rev, 0.05, {0.05.rand}.dup, rrand(1.5,2.0)) };
+	5.do { rev = AllpassN.ar(rev, 0.05, { 0.05.rand }.dup, rrand(1.5,2.0)) };
 	out = out + (0.3 * rev);
 
 	out = LeakDC.ar(out);
@@ -130,7 +130,7 @@ SynthDef(\stepper, {
 	// slight bass emphasis
 	out = OnePole.ar(out, 0.9);
 
-	Out.ar(0, out);
+	Out.ar(out, out);
 
 }).add;
 )

--- a/HelpSource/Classes/StereoConvolution2L.schelp
+++ b/HelpSource/Classes/StereoConvolution2L.schelp
@@ -56,28 +56,26 @@ d.zero;
 
 
 (
-SynthDef(\conv_test, { arg kernel1, kernel2, t_trig = 0;
-	var input;
-
+SynthDef(\conv_test, { |out, kernel1, kernel2, t_trig = 0|
+	var input, result, framesize;
+	framesize = 2048; // must be a power of two
 	input = Impulse.ar(1);
-
-	// must have power of two framesize
-	Out.ar(0, StereoConvolution2L.ar(input, kernel1, kernel2, t_trig, 2048, 1, 0.5));
+	result = StereoConvolution2L.ar(input, kernel1, kernel2, t_trig, framesize, 1, 0.5);
+	Out.ar(out, result);
 }).add
-
 )
 
 
 x = Synth(\conv_test, [\kernel1, b, \kernel2, c]);
 
 // changing the buffer number:
-x.set(\kernel1,d);
-x.set(\t_trig,1); // after this trigger, the change will take effect.
-x.set(\kernel2,d);
-x.set(\t_trig,1); // after this trigger, the change will take effect.
+x.set(\kernel1, d);
+x.set(\t_trig, 1); // after this trigger, the change will take effect.
+x.set(\kernel2, d);
+x.set(\t_trig, 1); // after this trigger, the change will take effect.
 
 d.zero;
-40.do({ |it| d.set(20 * it + 10, 1); });// changing the buffers' contents
+40.do({ |it| d.set(20 * it + 10, 1); }); // changing the buffers' contents
 x.set(\t_trig, 1); // after this trigger, the change will take effect.
 
 x.set(\kernel1, b);

--- a/HelpSource/Classes/Sweep.schelp
+++ b/HelpSource/Classes/Sweep.schelp
@@ -74,13 +74,13 @@ b.free
 Sweep can be used as a resettable link::Classes/Phasor:: or link::Classes/Line:: - one that can start, pause, resume and stop. To get a resettable link::Classes/XLine:: behavior change the code::linlin:: to code::linexp:: in the SynthDef below.
 code::
 (
-SynthDef(\lineReset, {|start= 0, end= 1, dur= 1, t_trig= 1, run= 1|
-	var phasor= (Sweep.ar(t_trig, 1/dur*run)).linlin(0, 1, start, end, \minmax);
+SynthDef(\lineReset, { |out, start= 0, end= 1, dur= 1, t_trig= 1, run= 1|
+	var phasor = Sweep.ar(t_trig, run / dur).linlin(0, 1, start, end, \minmax);
 	phasor.poll;
-	Out.ar(0, SinOsc.ar(phasor, 0, 0.2));
+	Out.ar(out, SinOsc.ar(phasor, 0, 0.2));
 }).add;
 )
-a= Synth(\lineReset, [\start, 400, \end, 800, \dur, 2])
+a = Synth(\lineReset, [\start, 400, \end, 800, \dur, 2])
 a.set(\t_trig, 1)
 a.set(\run, 0)
 a.set(\run, 1)

--- a/HelpSource/Classes/Synth.schelp
+++ b/HelpSource/Classes/Synth.schelp
@@ -187,8 +187,8 @@ discussion::
 code::
 s.boot;
 (
-SynthDef("help-Synth-get", { arg freq = 440;
-	Out.ar(0, SinOsc.ar(freq, 0, 0.1));
+SynthDef("help-Synth-get", { | out, freq = 440|
+	Out.ar(out, SinOsc.ar(freq, 0, 0.1));
 }).add;
 )
 x = Synth("help-Synth-get");
@@ -233,8 +233,8 @@ Example:
 code::
 (
 s.waitForBoot({
-    SynthDef(\helpSeti, { |freqs = #[100,150,200,250]|
-        Out.ar(0, SinOsc.ar(freqs.poll,0,0.1).sum ! 2)
+    SynthDef(\helpSeti, { |out, freqs = #[100,150,200,250]|
+        Out.ar(out, SinOsc.ar(freqs.poll,0,0.1).sum ! 2)
     }).add;
     s.sync;
     x = Synth(\helpSeti);

--- a/HelpSource/Classes/SynthDef.schelp
+++ b/HelpSource/Classes/SynthDef.schelp
@@ -46,8 +46,8 @@ note:: code::if:: is implemented as a linear signal crossfade when the receiver 
 There are other ways of achieving similar results, however, often using UGens such as Rand. For example, the following def will have a single randomly generated frequency, which will be the same for every Synth based on it:
 code::
 (
-SynthDef(\help_notRand, {
-	Out.ar(0,
+SynthDef(\help_notRand, { |out|
+	Out.ar(out,
 		SinOsc.ar(rrand(400, 800), 0, 0.2) * Line.kr(1, 0, 1, doneAction: Done.freeSelf)
 	)
 }).add;
@@ -58,8 +58,8 @@ b = Synth(\help_notRand); // the same freq as a
 This one on the other hand will have a different random freq for each Synth created:
 code::
 (
-SynthDef(\help_isRand, {
-	Out.ar(0,
+SynthDef(\help_isRand, { |out|
+	Out.ar(out,
 		SinOsc.ar(Rand(400, 800), 0, 0.2) * Line.kr(1, 0, 1, doneAction: Done.freeSelf)
 	)
 }).add;
@@ -205,10 +205,10 @@ code::
 // make a simple def and send it to the server
 
 s.boot;
-SynthDef(\SimpleSine, {|freq = 440| Out.ar(0, SinOsc.ar(freq, 0, 0.2)) }).add;
+SynthDef(\SimpleSine, {|freq = 440, out| Out.ar(out, SinOsc.ar(freq, 0, 0.2)) }).add;
 
 // the above is essentially the same as the following:
-d = SynthDef.new(\SimpleSine, {|freq = 440| Out.ar(0, SinOsc.ar(freq, 0, 0.2)) });
+d = SynthDef(\SimpleSine, {|freq = 440, out| Out.ar(out, SinOsc.ar(freq, 0, 0.2)) });
 d.add;
 
 // now make a synth from it, using the default value for freq, then another with a different value
@@ -221,7 +221,7 @@ x.set(\freq, 880);
 x.free; y.free;
 
 // using the play convenience method
-x = SynthDef(\SimpleSine, {|freq = 440| Out.ar(0, SinOsc.ar(freq, 0, 0.2)) }).play
+x = SynthDef(\SimpleSine, {|freq = 440, out| Out.ar(out, SinOsc.ar(freq, 0, 0.2)) }).play
 x.free;
 ::
 
@@ -229,24 +229,24 @@ subsection:: Argument Rates
 code::
 // the following two defs are equivalent. The first uses a 't_' arg:
 (
-SynthDef(\trigTest, {|t_trig=0, freq=440| // t_trig creates a TrigControl
-	Out.ar(0, SinOsc.ar(freq+[0,1], 0, Decay2.kr(t_trig, 0.005, 1.0)));
+SynthDef(\trigTest, { |out, t_trig=0, freq=440| // t_trig creates a TrigControl
+	Out.ar(out, SinOsc.ar(freq+[0,1], 0, Decay2.kr(t_trig, 0.005, 1.0)));
 }, [0, 4]		// lag the freq by 4 seconds (the second arg), but not t_trig (won't work anyway)
 );
 )
 
 // This second version makes trig a \tr arg by specifying it in the rates array.
 (
-SynthDef(\trigTest2, {|trig=0, freq=440|
-	Out.ar(0, SinOsc.ar(freq+[0,1], 0, Decay2.kr(trig, 0.005, 1.0)));
+SynthDef(\trigTest2, { |out, trig=0, freq=440|
+	Out.ar(out, SinOsc.ar(freq+[0,1], 0, Decay2.kr(trig, 0.005, 1.0)));
 	}, [\tr, 4]		// lag the freq (lagtime: 4s), \tr creates a TrigControl for trig
 ).add;
 )
 
 // Different way of writing the same thing
 (
-SynthDef(\trigTest2, {
-	Out.ar(0, SinOsc.ar(\freq.kr(440, 4) + [0,1], 0, Decay2.kr(\trig.tr, 0.005, 1.0)));
+SynthDef(\trigTest2, { |out|
+	Out.ar(out, SinOsc.ar(\freq.kr(440, 4) + [0,1], 0, Decay2.kr(\trig.tr, 0.005, 1.0)));
 }).add;
 )
 
@@ -266,7 +266,7 @@ subsection:: Variants
 code::
 // create a def with some variants
 (
-SynthDef(\vartest, {|out=0, freq=440, amp=0.2, a = 0.01, r = 1|
+SynthDef(\vartest, { |out, freq = 440, amp = 0.2, a = 0.01, r = 1|
 	// the EnvGen with doneAction: Done.freeSelf frees the synth automatically when done
 	Out.ar(out, SinOsc.ar(freq, 0, EnvGen.kr(Env.perc(a, r, amp), doneAction: Done.freeSelf)));
 }, variants: (alpha: [a: 0.5, r: 0.5], beta: [a: 3, r: 0.01], gamma: [a: 0.01, r: 4])
@@ -289,11 +289,11 @@ subsection:: Literal Array Arguments
 code::
 // freqs has a literal array of defaults. This makes a multichannel Control of the same size.
 (
-SynthDef(\arrayarg, { | amp = 0.1, freqs = #[300, 400, 500, 600], gate = 1 |
+SynthDef(\arrayarg, { |out, amp = 0.1, freqs = #[300, 400, 500, 600], gate = 1|
 	var env, sines;
 	env = Linen.kr(gate, 0.1, 1, 1, 2) * amp;
 	sines = SinOsc.ar(freqs +.t [0,0.5]).cubed.sum; // A mix of 4 oscillators
-	Out.ar(0, sines * env);
+	Out.ar(out, sines * env);
 }, [0, 0.1, 0]).add;
 )
 
@@ -337,19 +337,19 @@ code::
 // lets you reuse the common code.
 (
 // the basic wrapper
-~makeEffect = {| name, func, lags, numChannels = 2 |
+~makeEffect = { |name, func, lags, numChannels = 2|
 
-	SynthDef(name, {| i_bus = 0, gate = 1, wet = 1|
-		var in, out, env, lfo;
+	SynthDef(name, { | i_bus = 0, gate = 1, wet = 1|
+		var in, sound, env, lfo;
 		in = In.ar(i_bus, numChannels);
 		env = Linen.kr(gate, 2, 1, 2, 2); // fade in the effect
 
 		// call the wrapped function. The in and env arguments are passed to the function
 		// as the first two arguments (prependArgs).
 		// Any other arguments of the wrapped function will be Controls.
-		out = SynthDef.wrap(func, lags, [in, env]);
+		sound = SynthDef.wrap(func, lags, [in, env]);
 
-		XOut.ar(i_bus, wet * env, out);
+		XOut.ar(i_bus, wet * env, sound);
 	}, [0, 0, 0.1] ).add;
 
 };
@@ -357,13 +357,14 @@ code::
 
 // now make a wah
 (
-~makeEffect.value(\wah, {|in, env, rate = 0.7, ffreq = 1200, depth = 0.8, rq = 0.1|
+~makeEffect.value(\wah, { |in, env, rate = 0.7, ffreq = 1200, depth = 0.8, rq = 0.1|
 	// in and env come from the wrapper. The rest are controls
  	var lfo;
 	lfo = LFNoise1.kr(rate, depth * ffreq, ffreq);
-	RLPF.ar(in, lfo, rq, 10).distort * 0.15; },
-	[0.1, 0.1, 0.1, 0.1],  // lags for rate ffreq, depth and rq
-	2	// numChannels
+	RLPF.ar(in, lfo, rq, 10).distort * 0.15;
+},
+[0.1, 0.1, 0.1, 0.1],  // lags for rate ffreq, depth and rq
+2	// numChannels
 );
 )
 
@@ -374,14 +375,15 @@ code::
 	var input;
 	input = in;
 	16.do({ input = AllpassC.ar(input, 0.04, Rand(0.001,0.04), 3)});
-	input; },
-	nil,  // no lags
-	2	// numChannels
+	input
+},
+nil,  // no lags
+2	// numChannels
 );
 )
 
 // something to process
-x = { {Decay2.ar(Dust2.ar(3), mul: PinkNoise.ar(0.2))} ! 2}.play;
+x = { { Decay2.ar(Dust2.ar(3), mul: PinkNoise.ar(0.2)) } ! 2}.play;
 
 y = Synth.tail(s, \wah);
 z = Synth.tail(s, \reverb, [\wet, 0.5]);

--- a/HelpSource/Classes/TWindex.schelp
+++ b/HelpSource/Classes/TWindex.schelp
@@ -33,21 +33,16 @@ code::
 
 //assuming normalized values
 (
-
-a = SynthDef("help-TWindex",{ arg w1=0.0, w2=0.5, w3=0.5;
-
-	var trig, index;
-	trig = Impulse.kr(6);
-	index = TWindex.kr(trig, [w1, w2, w3]);
-
-	Out.ar(0,
+a = SynthDef("help-TWindex", { |out, w1=0.0, w2=0.5, w3=0.5|
+	var trig = Impulse.kr(6);
+	var index = TWindex.kr(trig, [w1, w2, w3]);
+	Out.ar(out,
 		SinOsc.ar(
 			Select.kr(index,[400, 500, 600]),
 			0, 0.2
 		)
 	)
 }).play;
-
 )
 
 a.setn(0, [0,0,1].normalizeSum);
@@ -58,17 +53,15 @@ a.setn(0, [1,0,1].normalizeSum);
 //modulating probability values
 (
 
-a = SynthDef("help-TWindex",{ arg w1=0.0, w2=0.5;
+a = SynthDef("help-TWindex", { |out, w1=0.0, w2=0.5|
+	var trig = Impulse.kr(6);
+	var index = TWindex.kr(
+		trig,
+		[w1, w2, SinOsc.kr(0.3, 0, 0.5, 0.5)],//modulate probability
+		1 //do normalisation
+	);
 
-	var trig, index;
-	trig = Impulse.kr(6);
-	index = TWindex.kr(
-					trig,
-					[w1, w2, SinOsc.kr(0.3, 0, 0.5, 0.5)],//modulate probability
-					1 //do normalisation
-		);
-
-	Out.ar(0,
+	Out.ar(out,
 		SinOsc.ar(
 			Select.kr(index,[400, 500, 600]),
 			0, 0.2

--- a/HelpSource/Classes/Tap.schelp
+++ b/HelpSource/Classes/Tap.schelp
@@ -26,21 +26,21 @@ Tap delay; cannot be modulated
 examples::
 code::
 // Create a buffer.
-b=Buffer.alloc(s, s.sampleRate, 1); //enough space for one second of mono audio
+b = Buffer.alloc(s, s.sampleRate, 1); // enough space for one second of mono audio
 
 // Write to the Buffer with BufWr, read using two Taps, one for each ear!
 (
-SynthDef(\helpTap, {|bufnum|
+SynthDef(\helpTap, { |out, bufnum|
 	var source, capture;
 
-	source= SoundIn.ar(0); //use headphones to avoid feedback
+	source= SoundIn.ar(0); // use headphones to avoid feedback
 	capture= BufWr.ar(source, bufnum, Phasor.ar(0,1, 0, BufFrames.ir(bufnum),1));
 
-	Out.ar(0, Tap.ar(bufnum, 1, [0.1,0.9])); //multichannel expansion, so one tap each ear
+	Out.ar(out, Tap.ar(bufnum, 1, [0.1,0.9])); // multichannel expansion, so one tap each ear
 }).add;
 )
 
-x=Synth(\helpTap,[\bufnum, b]);
+x = Synth(\helpTap, [\bufnum, b]);
 
 x.free;
 ::

--- a/HelpSource/Classes/UnpackFFT.schelp
+++ b/HelpSource/Classes/UnpackFFT.schelp
@@ -32,21 +32,16 @@ code::
 
 examples::
 code::
-(
-s.waitForBoot({
-	var fftsize = 1024;
-	b = Buffer.alloc(s, fftsize, 1);
-	c = Buffer.read(s, Platform.resourceDir +/+ "sounds/a11wlk01.wav");
-})
-)
+
+c = Buffer.read(s, Platform.resourceDir +/+ "sounds/a11wlk01.wav");
 
 // This one just drags out various the values and posts them - a little bit pointless!
 (
 x = {
 	var sig, chain, unp;
-	sig = SinOsc.ar;
+	//sig = SinOsc.ar;
 	sig = PlayBuf.ar(1, c, BufRateScale.kr(c), loop: 1);
-	chain = FFT(b, sig);
+	chain = FFT(LocalBuf(1, 1024), sig);
 
 	// Using the frombin & tobin args makes it much more efficient, limiting analysis to the bins of interest
 	unp = UnpackFFT(chain, b.numFrames, frombin: 0, tobin: 4);
@@ -58,22 +53,23 @@ x = {
 		anunp.poll(chain>=0, if(index % 2 == 0,  "Magnitude", "Phase")+(index/2).floor);
 	};
 
-	(sig*0.1).dup;
-}.play(s);
+	(sig * 0.1).dup;
+}.play
 )
 x.free;
 
 // Now a simple frequency-domain manipulation, square-rooting the magnitudes AND phases.
 (
 x = {
-	var in, chain, magsphases;
-	in = PlayBuf.ar(1, c, BufRateScale.kr(c), loop: 1);
-	chain = FFT(b, in);
+	var sig, chain, magsphases, b;
+	b = LocalBuf(1, 1024);
+	sig = PlayBuf.ar(1, c, BufRateScale.kr(c), loop: 1);
+	chain = FFT(b, sig);
 	magsphases = UnpackFFT(chain, b.numFrames);
 	magsphases = magsphases.collect(_.sqrt);
 	PackFFT(chain, b.numFrames, magsphases);
 	Out.ar(0, 0.25 * IFFT(chain).dup);
-}.play(s);
+}.play
 )
 x.free;
 ::

--- a/HelpSource/Classes/VDiskIn.schelp
+++ b/HelpSource/Classes/VDiskIn.schelp
@@ -54,8 +54,8 @@ x.free; b.close; b.free;
 
 // cue and play right away
 (
-SynthDef("help-VDiskin", { arg bufnum = 0;
-	Out.ar(0, VDiskIn.ar(1, bufnum, MouseX.kr(0.5, 2.0)));
+SynthDef("help-VDiskin", { |out, bufnum = 0|
+	Out.ar(out, VDiskIn.ar(1, bufnum, MouseX.kr(0.5, 2.0)));
 }).add;
 )
 (

--- a/HelpSource/Classes/Warp1.schelp
+++ b/HelpSource/Classes/Warp1.schelp
@@ -57,21 +57,21 @@ winenv = Env([0, 1, 0], [0.5, 0.5], [8, -8]);
 b = Buffer.read(s, Platform.resourceDir +/+ "sounds/a11wlk01-44_1.aiff");
 z = Buffer.sendCollection(s, winenv.discretize, 1);
 
-SynthDef(\warp, {arg buffer = 0, envbuf = -1;
-	var out, pointer, filelength, pitch, env, dir;
+SynthDef(\warp, { |out, bufnum = 0, envbuf = -1|
+	var sound, pointer, filelength, pitch, env, dir;
 	// pointer - move from beginning to end of soundfile over 15 seconds
 	pointer = Line.kr(0, 1, 15);
 	// control pitch with MouseX
 	pitch = MouseX.kr(0.5, 2);
 	env = EnvGen.kr(Env([0.001, 1, 1, 0.001], [0.1, 14, 0.9], 'exp'), doneAction: Done.freeSelf);
-	out = Warp1.ar(1, buffer, pointer, pitch, 0.1, envbuf, 8, 0.1, 2);
-	Out.ar(0, out * env);
+	sound = Warp1.ar(1, bufnum, pointer, pitch, 0.1, envbuf, 8, 0.1, 2);
+	Out.ar(out, sound * env);
 }).add;
 
 )
 
 // use built-in env
-x = Synth(\warp, [\buffer, b, \envbuf, -1])
+x = Synth(\warp, [\bufnum, b, \envbuf, -1])
 
 // switch to the custom env
 x.set(\envbuf, z)
@@ -84,13 +84,13 @@ code::
 (
 b.free;
 b= Buffer.read(s, Platform.resourceDir +/+ "sounds/a11wlk01-44_1.aiff");
-SynthDef(\warp2, {|buffer|
-	var pointer = Phasor.ar(0, SampleDur.ir/BufDur.ir(buffer)*XLine.kr(1, 0.25, 20));
-	var out = Warp1.ar(1, buffer, pointer, 1, 0.3, -1, 16, Line.kr(0, 1, 40), 4);
-	Out.ar(0, Pan2.ar(out, pointer*2-1, 0.25));
+SynthDef(\warp2, { |out, bufnum|
+	var pointer = Phasor.ar(0, SampleDur.ir / BufDur.ir(bufnum) * XLine.kr(1, 0.25, 20));
+	var sound = Warp1.ar(1, bufnum, pointer, 1, 0.3, -1, 16, Line.kr(0, 1, 40), 4);
+	Out.ar(out, Pan2.ar(sound, pointer * 2 - 1, 0.25));
 }).add;
 )
-x = Synth(\warp2, [\buffer, b])
+x = Synth(\warp2, [\bufnum, b])
 x.free
 b.free
 ::

--- a/HelpSource/Classes/WrapIndex.schelp
+++ b/HelpSource/Classes/WrapIndex.schelp
@@ -39,28 +39,35 @@ Examples::
 
 code::
 
-(
 // indexing into a table
-s = Server.local;
+(
+{
+	var buf = LocalBuf.newFrom([ 200, 300, 400, 500, 600, 800 ]);
+	var freq = WrapIndex.kr(buf, MouseX.kr(0, BufFrames.ir(buf) * 3));
+	SinOsc.ar(freq) * 0.1
+}.play;
+)
+
+// the same using a global buffer
+(
 t = [ 200, 300, 400, 500, 600, 800 ];
-b = Buffer(s,t.size,1);
+b = Buffer(s, t.size, 1);
 
 // alloc and set the values
 s.listSendMsg( b.allocMsg( b.setnMsg(0, t) ).postln );
 
-SynthDef("help-Index",{ arg out=0,i_bufnum=0;
-	Out.ar(0,
+SynthDef(\help_Index, { |out=0, bufnum=0|
+	Out.ar(out,
 		SinOsc.ar(
 			WrapIndex.kr(
-				i_bufnum,
-				MouseX.kr(0, t.size * 3)
+				bufnum,
+				MouseX.kr(0, BufFrames.ir(bufnum) * 3)
 			),
 			0,
 			0.5
 		)
 	)
-}).play(s,[\i_bufnum,b.bufnum]);
-
+}).play(s, [\bufnum, b.bufnum]);
 )
 
 ::

--- a/HelpSource/Classes/XFade2.schelp
+++ b/HelpSource/Classes/XFade2.schelp
@@ -37,11 +37,7 @@ Examples::
 
 code::
 
-(
-SynthDef("help-XFade2", {
-	Out.ar(0, XFade2.ar( Saw.ar, SinOsc.ar , LFTri.kr(0.1) ));
-}).play
-)
+{ XFade2.ar(Saw.ar, SinOsc.ar, LFTri.kr(0.1) ) }.play
 
 ::
 

--- a/HelpSource/Guides/Debugging-tips.schelp
+++ b/HelpSource/Guides/Debugging-tips.schelp
@@ -104,7 +104,7 @@ code::
 ~synth={ arg t_trig; [LFNoise1.kr, LFNoise1.kr].poll(t_trig); }.play;
 
 // the t_ in t_trig is shorthand to cause ~synth.set(\t_trig, 1) to trigger instead of set permanently
-~synth.set(\t_trig, 1); // run this line a couple of times 
+~synth.set(\t_trig, 1); // run this line a couple of times
 ::
 
 All the examples above work the same for audio rate UGens.
@@ -153,11 +153,11 @@ It takes some practice to read a synthdef trace, but it's the ultimate source of
 For a concrete example, let's look at a synthdef that doesn't work. The intent is to generate a detuned sawtooth wave and run it through a set of parallel resonant filters whose cut-off frequencies are modulating randomly.
 We run the synth and generate the trace (reproduced below).
 code::
-SynthDef(\resonz, { |freq = 440|
+SynthDef(\resonz, { |out, freq = 440|
 	var	sig, ffreq;
 	sig = Saw.ar([freq, freq+1], 0.2);
 	ffreq = LFNoise1.kr(2, 1, 0.5);
-	Out.ar(0, Resonz.ar(sig, (800, 1000..1800) * ffreq, 0.1))
+	Out.ar(out, Resonz.ar(sig, (800, 1000..1800) * ffreq, 0.1))
 }).send(s);
 
 a = Synth(\resonz);
@@ -238,11 +238,11 @@ The resonance frequency derives from multiplying an array by a LFNoise1. Tracing
 
 If you look very carefully at the trace, you will see another problem relating to multichannel expansion. The two components of the detuned sawtooth go into alternate Resonz'es, where we expected both to go, combined, into every Resonz. To fix it, the sawtooths need to be mixed as well.
 code::
-SynthDef(\resonz, { |freq = 440|
+SynthDef(\resonz, { |out, freq = 440|
 	var	sig, ffreq;
 	sig = Mix.ar(Saw.ar([freq, freq+1], 0.2));
 	ffreq = LFNoise1.kr(2, 0.5, 1);
-	Out.ar(0, Mix.ar(Resonz.ar(sig, (800, 1000..1800) * ffreq, 0.1)))
+	Out.ar(out, Mix.ar(Resonz.ar(sig, (800, 1000..1800) * ffreq, 0.1)))
 }).send(s);
 
 a = Synth(\resonz);

--- a/HelpSource/Guides/FFT-Overview.schelp
+++ b/HelpSource/Guides/FFT-Overview.schelp
@@ -134,7 +134,7 @@ x = {
       [mags, phases].flop.clump(2).flop.flatten
   }, tobin: 250);
 
-  Out.ar(0, 0.5 * IFFT(chain).dup);
+  0.5 * IFFT(chain).dup
 }.play;
 )
 x.free; c.free;
@@ -152,7 +152,7 @@ The above may seem to work, but does not. It does result in two FFT UGens, but a
 When using multichannel expansion with FFT UGens it is necessary to ensure that each one writes to a different buffer. Here's an example of one way to do this:
 code::
 (
-SynthDef("help-multichannel FFT", { arg out=0; // bufnum is an array
+SynthDef("help-multichannel FFT", { |out=0| // bufnum is an array
 	var in, chain;
 	in = [SinOsc.ar(200, 0, 0.2), WhiteNoise.ar(0.2)];
 	chain = FFT(LocalBuf([2048, 2048]), in); // each FFT has a different buffer
@@ -167,7 +167,7 @@ SynthDef("help-multichannel FFT", { arg out=0; // bufnum is an array
 b = {Buffer.alloc(s,2048,1)}.dup;
 
 (
-SynthDef("help-multichannel FFT", { arg out=0, bufnum= #[0, 1]; // bufnum is an array
+SynthDef("help-multichannel FFT", { |out=0, bufnum= #[0, 1]| // bufnum is an array
 	var in, chain;
 	in = [SinOsc.ar(200, 0, 0.2), WhiteNoise.ar(0.2)];
 	chain = FFT(bufnum, in); // each FFT has a different buffer

--- a/HelpSource/Guides/Multichannel-Expansion.schelp
+++ b/HelpSource/Guides/Multichannel-Expansion.schelp
@@ -116,8 +116,11 @@ fork {
 Similarly, link::Classes/Function#flop#Function:flop:: returns an unevaluated function that will expand to its arguments when evaluated:
 code::
 (
-SynthDef("blip", { |freq| Out.ar(0, Line.ar(0.1, 0, 0.05, 1, 0, 2)
-	* Pulse.ar(freq * [1, 1.02])) }).send(s);
+SynthDef("blip", { |out, freq|
+	Out.ar(out,
+		Line.ar(0.1, 0, 0.05, 1, 0, 2) * Pulse.ar(freq * [1, 1.02])
+	)
+}).add;
 
 a = { |dur=1, x=1, n=10, freq=400|
 	fork { n.do {

--- a/HelpSource/Guides/NodeMessaging.schelp
+++ b/HelpSource/Guides/NodeMessaging.schelp
@@ -109,15 +109,15 @@ n = Synth(\default, [\freq, 850]);
 Argument lists generally appear as alternating pairs, with the control identifier preceding the value. Usually the control identifier is a name, as above, but it could also be an integer index. (Using integers is slightly faster for the server, but it makes the code harder to read and can introduce bugs if the SynthDef structure changes.)
 One way to find out control indices is to .add the SynthDef into a link::Classes/SynthDescLib::, then get the list of all controls out of the link::Classes/SynthDesc::.
 code::
-(
-SynthDef(\controlList, { |freq = 440, amp = 0.1, detune = #[0.999, 1.001], gate = 1, out = 0|
-	var	sig = Mix(Saw.ar(freq * (detune ++ [1]), amp)),
-		env = EnvGen.kr(Env.adsr, gate, doneAction: Done.freeSelf);
-	Out.ar(0, (sig * env) ! 2);
-}).add;
+	(
+		SynthDef(\controlList, { |out = 0, freq = 440, amp = 0.1, detune = #[0.999, 1.001], gate = 1|
+			var	sig = Mix(Saw.ar(freq * (detune ++ [1]), amp)),
+			env = EnvGen.kr(Env.adsr, gate, doneAction: Done.freeSelf);
+			Out.ar(out, (sig * env) ! 2);
+		}).add;
 
-SynthDescLib.global[\controlList]
-)
+		SynthDescLib.global[\controlList]
+	)
 ::
 Prints:
 code::

--- a/HelpSource/Guides/Non-Realtime-Synthesis.schelp
+++ b/HelpSource/Guides/Non-Realtime-Synthesis.schelp
@@ -1,4 +1,4 @@
-title:: Non-Realtime Synthesis (NRT)
+ title:: Non-Realtime Synthesis (NRT)
 summary:: Non-realtime synthesis with binary files of OSC commands
 categories:: Server>NRT, External Control>OSC
 related:: Classes/Score
@@ -31,8 +31,8 @@ f.close;
 
 // the 'NRTsine' SynthDef
 (
-SynthDef("NRTsine",{ arg freq = 440;
-	Out.ar(0,
+SynthDef("NRTsine", { |out, freq = 440|
+	Out.ar(out,
 		 SinOsc.ar(freq, 0, 0.2)
 	)
 }).writeDefFile;

--- a/HelpSource/Other/JITLibChanges3.7.schelp
+++ b/HelpSource/Other/JITLibChanges3.7.schelp
@@ -1082,7 +1082,7 @@ Ndef(\x, { |freq = 100| SinOsc.ar(freq) * 0.1 }).play;
 Ndef(\x).send([\freq, b.asMap]);
 
 // proxies as arguments of synths
-SynthDef(\x, { |z=440| Out.ar(0, Blip.ar(z) * 0.1) }).add;
+SynthDef(\x, { |z=440, out| Out.ar(out, Blip.ar(z) * 0.1) }).add;
 Ndef(\f, { MouseX.kr(400, 700) });
 (instrument: \x, z: Ndef(\f)).play;
 

--- a/HelpSource/Overviews/Operators.schelp
+++ b/HelpSource/Overviews/Operators.schelp
@@ -390,19 +390,17 @@ code::
 { // trigger an envelope
 	var trig;
 	trig = SinOsc.ar(1) > 0;
-	Out.ar(0,
-		EnvGen.kr(Env.perc, trig, doneAction: Done.none)
-			* SinOsc.ar(440,0,0.1)
-	)
+	EnvGen.kr(Env.perc, trig, doneAction: Done.none)
+			* SinOsc.ar(440, 0, 0.1)
 }.play
 )
 
 // trigger a synth
 (
-SynthDef("help-EnvGen",{ arg out=0;
+SynthDef("help-EnvGen", { arg out=0;
 	Out.ar(out,
 		EnvGen.kr(Env.perc,1.0,doneAction: Done.freeSelf)
-			* SinOsc.ar(440,0,0.1)
+			* SinOsc.ar(440, 0, 0.1)
 	)
 }).add;
 

--- a/HelpSource/Tutorials/A-Practical-Guide/PG_03_What_Is_Pbind.schelp
+++ b/HelpSource/Tutorials/A-Practical-Guide/PG_03_What_Is_Pbind.schelp
@@ -251,11 +251,11 @@ One other subtle point about synth argument names. In a SynthDef, argument names
 
 code::
 (
-SynthDef(\trig_demo, { |freq, gate = 1, t_trig = 1|	// t_trig here
+SynthDef(\trig_demo, { |out, freq = 440, gate = 1, t_trig = 1|	// t_trig here
 	var	env = Decay2.kr(t_trig, 0.01, 0.1),
 		sig = SinOsc.ar(freq, 0, env)
 			* Linen.kr(gate, 0.01, 0.1, 0.1, doneAction: Done.freeSelf);
-	Out.ar(0, sig ! 2)
+	Out.ar(out, sig ! 2)
 }).add;
 )
 

--- a/HelpSource/Tutorials/A-Practical-Guide/PG_04_Words_to_Phrases.schelp
+++ b/HelpSource/Tutorials/A-Practical-Guide/PG_04_Words_to_Phrases.schelp
@@ -36,7 +36,7 @@ But it gets even more fun -- list patterns don't care whether they're enclosing 
 
 code::
 (
-SynthDef(\bass, { |freq = 440, gate = 1, amp = 0.5, slideTime = 0.17, ffreq = 1100, width = 0.15,
+SynthDef(\bass, { |out, freq = 440, gate = 1, amp = 0.5, slideTime = 0.17, ffreq = 1100, width = 0.15,
 		detune = 1.005, preamp = 4|
 	var	sig,
 		env = Env.adsr(0.01, 0.3, 0.4, 0.1);
@@ -44,7 +44,7 @@ SynthDef(\bass, { |freq = 440, gate = 1, amp = 0.5, slideTime = 0.17, ffreq = 11
 	sig = Mix(VarSaw.ar([freq, freq * detune], 0, width, preamp)).distort * amp
 		* EnvGen.kr(env, gate, doneAction: Done.freeSelf);
 	sig = LPF.ar(sig, ffreq);
-	Out.ar(0, sig ! 2)
+	Out.ar(out, sig ! 2)
 }).add;
 )
 

--- a/HelpSource/Tutorials/Getting-Started/16-Sequencing-with-Patterns.schelp
+++ b/HelpSource/Tutorials/Getting-Started/16-Sequencing-with-Patterns.schelp
@@ -37,10 +37,10 @@ var midi, dur;
 midi = Pseq([60, 72, 71, 67, 69, 71, 72, 60, 69, 67], 1).asStream;
 dur = Pseq([2, 2, 1, 0.5, 0.5, 1, 1, 2, 2, 3], 1).asStream;
 
-SynthDef(\smooth, { |freq = 440, sustain = 1, amp = 0.5|
+SynthDef(\smooth, { |out, freq = 440, sustain = 1, amp = 0.5|
 	var sig;
 	sig = SinOsc.ar(freq, 0, amp) * EnvGen.kr(Env.linen(0.05, sustain, 0.1), doneAction: Done.freeSelf);
-	Out.ar(0, sig ! 2)
+	Out.ar(out, sig ! 2)
 }).add;
 
 r = Task({
@@ -110,10 +110,10 @@ Not only can patterns produce data for notes, but they can also play the notes t
 
 code::
 (
-SynthDef(\smooth, { |freq = 440, sustain = 1, amp = 0.5|
+SynthDef(\smooth, { |out, freq = 440, sustain = 1, amp = 0.5|
 	var sig;
 	sig = SinOsc.ar(freq, 0, amp) * EnvGen.kr(Env.linen(0.05, sustain, 0.1), doneAction: Done.freeSelf);
-	Out.ar(0, sig ! 2)
+	Out.ar(out, sig ! 2)
 }).add;
 )
 
@@ -151,7 +151,7 @@ Don't be intimidated by the bassline pattern. At a higher level, it reduces to s
 
 code::
 (
-SynthDef(\bass, { |freq = 440, gate = 1, amp = 0.5, slideTime = 0.17, ffreq = 1100, width = 0.15,
+SynthDef(\bass, { |out, freq = 440, gate = 1, amp = 0.5, slideTime = 0.17, ffreq = 1100, width = 0.15,
 		detune = 1.005, preamp = 4|
 	var	sig,
 		env = Env.adsr(0.01, 0.3, 0.4, 0.1);
@@ -159,7 +159,7 @@ SynthDef(\bass, { |freq = 440, gate = 1, amp = 0.5, slideTime = 0.17, ffreq = 11
 	sig = Mix(VarSaw.ar([freq, freq * detune], 0, width, preamp)).distort * amp
 		* EnvGen.kr(env, gate, doneAction: Done.freeSelf);
 	sig = LPF.ar(sig, ffreq);
-	Out.ar(0, sig ! 2)
+	Out.ar(out, sig ! 2)
 }).add;
 
 TempoClock.default.tempo = 132/60;
@@ -192,11 +192,11 @@ p = Pxrand([
 
 // totally cheesy, but who could resist?
 (
-SynthDef(\kik, { |preamp = 1, amp = 1|
+SynthDef(\kik, { |out, preamp = 1, amp = 1|
 	var	freq = EnvGen.kr(Env([400, 66], [0.08], -3)),
 		sig = SinOsc.ar(freq, 0.5pi, preamp).distort * amp
 			* EnvGen.kr(Env([0, 1, 0.8, 0], [0.01, 0.1, 0.2]), doneAction: Done.freeSelf);
-	Out.ar(0, sig ! 2);
+	Out.ar(out, sig ! 2);
 }).add;
 
 // before you play:

--- a/HelpSource/Tutorials/JITLib/basic_live_coding_techniques.schelp
+++ b/HelpSource/Tutorials/JITLib/basic_live_coding_techniques.schelp
@@ -15,11 +15,11 @@ d.push; // push it to current
 // this synthdef can be changed on the fly, but the synth will
 // not change from this. use expression [1] for replacing a given synth
 (
-SynthDef(\x, { |freq=440|
-	Out.ar(0,
+SynthDef(\x, { |out, freq = 440|
+	Out.ar(out,
 		Ringz.ar(Dust.ar(40), freq, 0.1)
 	)
-}).send(s);
+}).send(s)
 )
 
 // send a first synth:

--- a/HelpSource/Tutorials/Mark_Polishook_tutorial/14_Subtractive_synthesis.schelp
+++ b/HelpSource/Tutorials/Mark_Polishook_tutorial/14_Subtractive_synthesis.schelp
@@ -27,9 +27,9 @@ Use LPF, a low-pass filter to subtract high-frequency content from an input sour
 
 code::
 (
-SynthDef("subtractive", {
+SynthDef("subtractive", { arg out;
 	Out.ar(
-		0,
+		out,
 		LPF.ar(
 			Pulse.ar(440, 0.5, 0.1),	// the source to be filtered
 			Line.kr(8000, 660, 6)		// control the filter frequency with a line
@@ -47,9 +47,9 @@ RLPF, a resonant low-pass filter, removes high-frequency content and emphasizes 
 
 code::
 (
-SynthDef("passLowFreqs2", {
+SynthDef("passLowFreqs2", { arg out;
 	Out.ar(
-		0,
+		out,
 		RLPF.ar(
 			Saw.ar([220, 221] + LFNoise0.kr(1, 100, 200), 0.2),
 			[LFNoise0.kr(4, 600, 2400), LFNoise0.kr(3, 600, 2400)],

--- a/HelpSource/Tutorials/Streams-Patterns-Events3.schelp
+++ b/HelpSource/Tutorials/Streams-Patterns-Events3.schelp
@@ -13,14 +13,13 @@ code::
 //////////////////////////////////////////////////////////////
 // Note: This SynthDef used throughout this document
 (
-s = Server.local;
-SynthDef( \help_SPE3_SimpleSine, {
-	arg freq, sustain=1.0;
+SynthDef(\help_SPE3_SimpleSine, { |out, freq=440, sustain=1.0|
 	var osc;
-	osc = SinOsc.ar( [freq,freq+0.05.rand] ) * EnvGen.ar(
+	osc = SinOsc.ar( [freq, freq+0.05.rand], 0.5pi )
+	* EnvGen.ar(
 		Env.perc, doneAction: Done.freeSelf, levelScale: 0.3, timeScale: sustain
 	);
-	Out.ar(0,osc);
+	Out.ar(out, osc);
 }).add;
 )
 //////////////////////////////////////////////////////////////
@@ -169,7 +168,7 @@ var a, b;
 a = Pshuf(#[60, 61, 65, 67], inf).midicps.asStream;
 Task({
 	12.do({
-		Synth(\help_SPE3_SimpleSine,[\freq, a.next]);
+		Synth(\help_SPE3_SimpleSine, [\freq, a.next]);
 		0.5.wait;
 	});
 }).play;
@@ -253,7 +252,7 @@ a = Pseq(#[60, 62, 63, 65, 67, 63], inf) + Pseq(#[0, 0, 0, 0, -12], inf);
 a = a.asStream.midicps;
 Task({
 	25.do({
-		Synth(\help_SPE3_SimpleSine,[\freq, a.next]);
+		Synth(\help_SPE3_SimpleSine, [\freq, a.next]);
 		0.3.wait;
 	});
 }).play;
@@ -303,30 +302,30 @@ Here is an example that uses a Pattern to create a rhythmic solo. The values in 
 
 code::
 (
-SynthDef( \help_SPE3_Mridangam, { arg t_amp;
-	var out;
+SynthDef( \help_SPE3_Mridangam, { |out, t_amp|
+	var sound;
 
-	out = Resonz.ar(
+	sound = Resonz.ar(
 		WhiteNoise.ar(70) * Decay2.kr( t_amp, 0.002, 0.1 ),
 		60.midicps,
 		0.02,
 		4
 	).distort * 0.4;
 
-	Out.ar( 0, out );
-	DetectSilence.ar( out, doneAction: Done.freeSelf );
+	Out.ar(out, sound);
+	DetectSilence.ar(sound, doneAction: Done.freeSelf);
 }).add;
 
-SynthDef( \help_SPE3_Drone, {
-	var out;
-	out = LPF.ar(
+SynthDef( \help_SPE3_Drone, { |out|
+	var sound;
+	sound = LPF.ar(
 		Saw.ar([60, 60.04].midicps)
 		+
 		Saw.ar([67, 67.04].midicps),
 		108.midicps,
 		0.007
 	);
-	Out.ar( 0, out );
+	Out.ar(out, sound);
 }).add;
 )
 

--- a/HelpSource/Tutorials/Streams-Patterns-Events4.schelp
+++ b/HelpSource/Tutorials/Streams-Patterns-Events4.schelp
@@ -139,8 +139,8 @@ c = { arg pan, freq, amp;
 
 Task({
 	n.do({ arg i;
-		SynthDef("Help-SPE4-EnvirDef-" ++ i.asString, {
-			var out;
+		SynthDef("Help-SPE4-EnvirDef-" ++ i.asString, { |out|
+			var sound;
 			Environment.use({
 					// set values in the environment
 				~freq = exprand(80, 600);
@@ -149,13 +149,13 @@ Task({
 
 					// call a randomly chosen instrument function
 					// with values from the environment
-				out = [a,b,c].choose.valueEnvir;
+				sound = [a,b,c].choose.valueEnvir;
 			});
-			out = CombC.ar(out, 0.2, 0.2, 3, 1, out);
-			out = out * EnvGen.kr(
+			sound = CombC.ar(sound, 0.2, 0.2, 3, 1, out);
+			sound = sound * EnvGen.kr(
 				Env.sine, doneAction: Done.freeSelf, timeScale: 1.0 + 6.0.rand, levelScale: 0.3
 			);
-			Out.ar( 0, out );
+			Out.ar(out, sound);
 		}).send(s);
 		0.02.wait;
 	});

--- a/HelpSource/Tutorials/Tutorial.schelp
+++ b/HelpSource/Tutorials/Tutorial.schelp
@@ -63,7 +63,7 @@ m.quit; // quit the server
 It is not possible to boot a server on a remote machine, but if you have one running already or you know of one running, you can send messages to it. You create the server object using the IP address of the machine running the server and the port it is using.
 
 code::
-// create a server object for talking to the server running on a 
+// create a server object for talking to the server running on a
 // remote machine having IP address 192.168.0.47 using port #57110
 r = Server(\myServer, NetAddr("192.168.0.47", 57110));
 ::
@@ -373,7 +373,7 @@ timer.sched(0,{
 		freq = Pseq([30,40,42,40],inf).asStream;
 		cutoff = Pfunc({500.rand2+1000}).asStream;
 		rezz = 0.5;
-		inf.do({ 
+		inf.do({
 			saw.set("freq", freq.next.midicps, "cutoff", cutoff.next, "rezz", rezz, "amp", 0.1, "out", 0);
 			(wait.next*offset).wait
 		});


### PR DESCRIPTION
The main change is the standard of `SynthDef`s that use an `out` argument instead of just writing `Out.ar(0, …)`. Most FFT code now also uses `LocalBuf`.

The argument syntax is adjusted to `{ |out, freq=440| `-type style, and I fixed spacing on the way (I didn't change it where the surrounding code is decidedly different).

I tested the examples (and fixed a few broken ones).