### PR TITLE
scdoc: redesign top bar

### DIFF
--- a/HelpSource/Browse.html
+++ b/HelpSource/Browse.html
@@ -23,7 +23,6 @@
 <div class='contents'>
 <div id="menubar"></div>
 <div class='header'>
-    <div id='label'><span id='folder'>SuperCollider</span></div>
     <h1>Document Browser</h1>
     <div id='summary'>Browse categories</div>
 </div>

--- a/HelpSource/Browse.html
+++ b/HelpSource/Browse.html
@@ -8,6 +8,7 @@
     <meta http-equiv='Content-Type' content='text/html; charset=UTF-8' />
     <script>
         var scdoc_title = "Document Browser";
+        var scdoc_sc_version = "";
     </script>
     <script src="docmap.js" type="text/javascript"></script>
     <script src="scdoc.js" type="text/javascript"></script>

--- a/HelpSource/Browse.html
+++ b/HelpSource/Browse.html
@@ -20,8 +20,8 @@
 <p>JavaScript is not available, redirecting to <a href="Overviews/Categories.html">static category overview</a>...-->
 <p>The document browser needs JavaScript.
 </noscript>
-<ul id="menubar"></ul>
 <div class='contents'>
+<div id="menubar"></div>
 <div class='header'>
     <div id='label'><span id='folder'>SuperCollider</span></div>
     <h1>Document Browser</h1>

--- a/HelpSource/OldHelpWrapper.html
+++ b/HelpSource/OldHelpWrapper.html
@@ -30,9 +30,9 @@ function onLoad() {
 window.onhashchange = checkHash;
 </script>
 </head>
-<ul id="menubar"></ul>
 <body onload="onLoad()">
 <div class='contents'>
+<div id="menubar"></div>
 <div class='header'>
     <div id='label'><span id='folder'>SuperCollider Old Help</span></div>
     <h1 id="oldtitle"></h1>

--- a/HelpSource/Overviews/Classes.html
+++ b/HelpSource/Overviews/Classes.html
@@ -7,6 +7,7 @@
     <meta http-equiv='Content-Type' content='text/html; charset=UTF-8' />
     <script>
         var scdoc_title = "Classes";
+        var scdoc_sc_version = "";
     </script>
     <script src="../docmap.js" type="text/javascript"></script>
     <script src="../scdoc.js" type="text/javascript"></script>

--- a/HelpSource/Overviews/Classes.html
+++ b/HelpSource/Overviews/Classes.html
@@ -124,11 +124,9 @@ function showdocs() {
 }
 </script>
 </head>
-
-<ul id="menubar"></ul>
-
 <body onload="did_load()">
 <div class='contents'>
+<div id="menubar"></div>
 <div class='header'>
     <div id='label'><span id='folder'>SuperCollider Overviews</span></div>
     <h1>Classes</h1>

--- a/HelpSource/Overviews/Classes.html
+++ b/HelpSource/Overviews/Classes.html
@@ -128,7 +128,7 @@ function showdocs() {
 <div class='contents'>
 <div id="menubar"></div>
 <div class='header'>
-    <div id='label'><span id='folder'>SuperCollider Overviews</span></div>
+    <div id='label'><span id='folder'>Overviews</span></div>
     <h1>Classes</h1>
     <div id='summary'>Alphabetical index of all classes</div>
 </div>

--- a/HelpSource/Overviews/Documents.html
+++ b/HelpSource/Overviews/Documents.html
@@ -134,7 +134,7 @@ function showdocs() {
 <div class='contents'>
 <div id="menubar"></div>
 <div class='header'>
-    <div id='label'><span id='folder'>SuperCollider Overviews</span></div>
+    <div id='label'><span id='folder'>Overviews</span></div>
     <h1>Documents</h1>
     <div id='summary'>Alphabetical index of all documents</div>
 </div>

--- a/HelpSource/Overviews/Documents.html
+++ b/HelpSource/Overviews/Documents.html
@@ -130,10 +130,9 @@ function showdocs() {
 }
 </script>
 </head>
-<ul id="menubar"></ul>
-
 <body onload="did_load()">
 <div class='contents'>
+<div id="menubar"></div>
 <div class='header'>
     <div id='label'><span id='folder'>SuperCollider Overviews</span></div>
     <h1>Documents</h1>

--- a/HelpSource/Overviews/Documents.html
+++ b/HelpSource/Overviews/Documents.html
@@ -7,6 +7,7 @@
     <meta http-equiv='Content-Type' content='text/html; charset=UTF-8' />
     <script>
         var scdoc_title = "Documents";
+        var scdoc_sc_version = "";
     </script>
     <script src="../docmap.js" type="text/javascript"></script>
     <script src="../scdoc.js" type="text/javascript"></script>

--- a/HelpSource/Overviews/Methods.html
+++ b/HelpSource/Overviews/Methods.html
@@ -7,6 +7,7 @@
     <meta http-equiv='Content-Type' content='text/html; charset=UTF-8' />
     <script>
         var scdoc_title = "Methods";
+        var scdoc_sc_version = "";
     </script>
     <script src="../docmap.js" type="text/javascript"></script>
     <script src="../scdoc.js" type="text/javascript"></script>

--- a/HelpSource/Overviews/Methods.html
+++ b/HelpSource/Overviews/Methods.html
@@ -244,7 +244,7 @@ window.onhashchange = showmethods;
 <div class='contents'>
 <div id="menubar"></div>
 <div class='header'>
-    <div id='label'><span id='folder'>SuperCollider Overviews</span></div>
+    <div id='label'><span id='folder'>Overviews</span></div>
     <h1>Methods</h1>
     <div id='summary'>Alphabetical index of all methods</div>
 </div>

--- a/HelpSource/Overviews/Methods.html
+++ b/HelpSource/Overviews/Methods.html
@@ -240,10 +240,9 @@ window.onhashchange = showmethods;
 </script>
 
 </head>
-<ul id="menubar"></ul>
-
 <body onload="did_load()">
 <div class='contents'>
+<div id="menubar"></div>
 <div class='header'>
     <div id='label'><span id='folder'>SuperCollider Overviews</span></div>
     <h1>Methods</h1>

--- a/HelpSource/Search.html
+++ b/HelpSource/Search.html
@@ -22,7 +22,6 @@
 <div class='contents'>
 <div id="menubar"></div>
 <div class='header'>
-    <div id='label'><span id='folder'>SuperCollider</span></div>
     <h1>Search</h1>
     <div id='summary'>Search all documents</div>
 </div>

--- a/HelpSource/Search.html
+++ b/HelpSource/Search.html
@@ -7,6 +7,7 @@
     <meta http-equiv='Content-Type' content='text/html; charset=UTF-8' />
     <script>
         var scdoc_title = "Search";
+        var scdoc_sc_version = "";
     </script>
     <script src="docmap.js" type="text/javascript"></script>
     <script src="scdoc.js" type="text/javascript"></script>

--- a/HelpSource/Search.html
+++ b/HelpSource/Search.html
@@ -15,12 +15,12 @@
 </head>
 
 <body onload="onLoad()">
-<ul id="menubar"></ul>
 <noscript>
 <p>The search page needs JavaScript.</p>
 </noscript>
 
 <div class='contents'>
+<div id="menubar"></div>
 <div class='header'>
     <div id='label'><span id='folder'>SuperCollider</span></div>
     <h1>Search</h1>

--- a/HelpSource/scdoc.css
+++ b/HelpSource/scdoc.css
@@ -15,10 +15,9 @@ html {
 }
 
 div.contents {
-    margin: 1em;
+    margin: 0 1em;
     padding-left: 0.3em;
     padding-right: 0.3em;
-    padding-top: 1.5em;
     padding-bottom: 0.5em;
 }
 
@@ -102,29 +101,30 @@ a.subclass_toggle:hover {
 
 #menubar {
     font-family: Arial, Helvetica, sans-serif;
+    text-indent: 0;
+    padding: 0;
     width: 100%;
-    position: fixed;
-/*    background: #555;*/
-    background: #eee;
-    top: 0px;
-    padding: 2px;
-    margin: 0px;
-    border-bottom: 1px solid #bbb;
-/*    border-bottom: 2px solid #999;*/
-    z-index: 30;
+    padding: 0.5em 0;
+    border-bottom: 1px solid #ccc;
+    margin-bottom: 1em;
 }
 
 #menubar .menuitem {
-    list-style: none;
-    float:left;
-    margin:0;
-    padding:0px;
+    margin: 0;
+    padding: 0px;
     padding-left: 0.75em;
     padding-right: 0.75em;
-/*    border-right: 1px solid #999;*/
     border-right: 1px solid #ddd;
     font-size: 10pt;
-    display: block;
+    display: inline-block;
+}
+
+#menubar .menuitem:first-child {
+    padding-left: 0;
+}
+
+#menubar .menuitem:last-child {
+    border-right: none;
 }
 
 .menuitem a {

--- a/HelpSource/scdoc.css
+++ b/HelpSource/scdoc.css
@@ -186,7 +186,7 @@ a.navlink {
 
 
 .header {
-  border-bottom: 2.5px solid #000; padding-bottom:0.18em;
+  padding-bottom: 0.18em;
 }
 
 #label {
@@ -197,6 +197,8 @@ a.navlink {
 #summary {
     font-weight: normal;
     font-size: 1.1em;
+    font-style: italic;
+    color: #444;
 }
 #related {
     text-align: right;

--- a/HelpSource/scdoc.js
+++ b/HelpSource/scdoc.js
@@ -500,7 +500,7 @@ function fixTOC() {
 // make header menu
     var bar = document.getElementById("menubar");
     menubar = bar;
-    var nav = ["Home","Browse","Search"];
+    var nav = ["SuperCollider " + scdoc_sc_version, "Browse", "Search"];
     var url = ["Help.html","Browse.html","Search.html"];
     for(var i=0;i<nav.length;i++) {
         var li = document.createElement("li");

--- a/HelpSource/scdoc.js
+++ b/HelpSource/scdoc.js
@@ -502,19 +502,20 @@ function fixTOC() {
     menubar = bar;
     var nav = ["SuperCollider " + scdoc_sc_version, "Browse", "Search"];
     var url = ["Help.html","Browse.html","Search.html"];
+    var nav_item;
     for(var i=0;i<nav.length;i++) {
-        var li = document.createElement("li");
-        li.className = "menuitem";
+        nav_item = document.createElement("div");
+        nav_item.className = "menuitem";
         var a = document.createElement("a");
         a.innerHTML = nav[i];
         a.setAttribute("href",helpRoot+"/"+url[i]);
         a.className = "navLink";
-        li.appendChild(a);
-        bar.appendChild(li);
+        nav_item.appendChild(a);
+        bar.appendChild(nav_item);
     }
 
-    var li = document.createElement("li");
-    li.className = "menuitem";
+    nav_item = document.createElement("div");
+    nav_item.className = "menuitem";
     var a = document.createElement("a");
     a.innerHTML = "Indexes &#9660;";
     a.setAttribute("href","#");
@@ -532,12 +533,12 @@ function fixTOC() {
         b.innerHTML = nav[i];
         m1.appendChild(b);
     }
-    li.appendChild(a);
-    li.appendChild(m1);
-    bar.appendChild(li);
+    nav_item.appendChild(a);
+    nav_item.appendChild(m1);
+    bar.appendChild(nav_item);
 
-    var li = document.createElement("li");
-    li.className = "menuitem";
+    nav_item = document.createElement("div");
+    nav_item.className = "menuitem";
     var x = document.createElement("span");
     x.id = "topdoctitle";
     x.appendChild(document.createTextNode(scdoc_title));
@@ -545,8 +546,8 @@ function fixTOC() {
         scroll(0,0);
         return false;
     }
-    li.appendChild(x)
-    bar.appendChild(li);
+    nav_item.appendChild(x)
+    bar.appendChild(nav_item);
 
     var t = document.getElementById("toc");
     toc = t;
@@ -570,13 +571,13 @@ function fixTOC() {
         var a = document.createElement("a");
         a.setAttribute("href","#");
         a.innerHTML = "Table of contents &#9660;";
-        li.appendChild(a);
+        nav_item.appendChild(a);
         a.onclick = function() {
             ts.focus();
             toggleMenu(t);
             return false;
         };
-        li.appendChild(t.parentNode.removeChild(t));
+        nav_item.appendChild(t.parentNode.removeChild(t));
         var p = document.createElement("a");
         p.setAttribute("href","#");
         p.className = "popoutlink";

--- a/SCClassLibrary/SCDoc/SCDoc.sc
+++ b/SCClassLibrary/SCDoc/SCDoc.sc
@@ -384,7 +384,7 @@ SCDocNode {
 SCDoc {
 
 	// Increment this whenever we make a change to the SCDoc system so that all help-files should be processed again
-	classvar version = 58;
+	classvar version = 59;
 
 	classvar <helpTargetDir;
 	classvar <helpTargetUrl;

--- a/SCClassLibrary/SCDoc/SCDocRenderer.sc
+++ b/SCClassLibrary/SCDoc/SCDocRenderer.sc
@@ -166,6 +166,7 @@ SCDocHTMLRenderer {
 		<< "<script>\n"
 		<< "var helpRoot = '" << baseDir << "';\n"
 		<< "var scdoc_title = '" << doc.title << "';\n"
+		<< "var scdoc_sc_version = '" << Main.version << "';\n"
 		<< "</script>\n"
 		<< "<script src='" << baseDir << "/scdoc.js' type='text/javascript'></script>\n"
 		<< "<script src='" << baseDir << "/docmap.js' type='text/javascript'></script>\n" // FIXME: remove?
@@ -179,16 +180,19 @@ SCDocHTMLRenderer {
 		<< "<div class='contents'>\n"
 		<< "<div class='header'>\n"
 		<< "<div id='label'>\n"
-		<< "<span id='folder'>SuperCollider " << Main.version << " " << folder.asString;
+		<< "<span id='folder'>" << folder.asString;
 		if(doc.isExtension) {
 			stream << " (extension)";
 		};
 		stream << "</span>\n";
 
 		doc.categories !? {
-			stream
-			<< " | "
-			<< "<span id='categories'>"
+			// Prevent the label from starting with "|".
+			if(folder.asString.size > 0) {
+				stream << " | "
+			};
+
+			stream << "<span id='categories'>"
 
 			<< (doc.categories.collect { | path |
 				// get all the components of a category path ("UGens>Generators>Deterministic")

--- a/SCClassLibrary/SCDoc/SCDocRenderer.sc
+++ b/SCClassLibrary/SCDoc/SCDocRenderer.sc
@@ -178,39 +178,44 @@ SCDocHTMLRenderer {
 		<< "<body onload='fixTOC();prettyPrint()'>\n"
 		<< "<div class='contents'>\n"
 		<< "<div id='menubar'></div>\n"
-		<< "<div class='header'>\n"
-		<< "<div id='label'>\n"
-		<< "<span id='folder'>" << folder.asString;
-		if(doc.isExtension) {
-			stream << " (extension)";
-		};
-		stream << "</span>\n";
+		<< "<div class='header'>\n";
 
-		doc.categories !? {
-			// Prevent the label from starting with "|".
-			if(folder.asString.size > 0) {
-				stream << " | "
+
+		if(thisIsTheMainHelpFile.not) {
+			stream
+			<< "<div id='label'>\n"
+			<< "<span id='folder'>" << folder.asString;
+			if(doc.isExtension) {
+				stream << " (extension)";
+			};
+			stream << "</span>\n";
+
+			doc.categories !? {
+				// Prevent the label from starting with "|".
+				if(folder.asString.size > 0) {
+					stream << " | "
+				};
+
+				stream << "<span id='categories'>"
+
+				<< (doc.categories.collect { | path |
+					// get all the components of a category path ("UGens>Generators>Deterministic")
+					// we link each crumb of the breadcrumbs separately.
+					var pathElems = path.split($>);
+
+					// the href for "UGens" will be "UGens", for "Generators" "UGens>Generators", etc.
+					pathElems.collect { | elem, i |
+						var atag = "<a href='" ++ baseDir +/+ "Browse.html#";
+						atag ++ pathElems[0..i].join(">") ++ "'>"++ elem ++"</a>"
+					}.join("&#8201;&gt;&#8201;"); // &#8201; is a thin space
+
+				}.join(" | "))
+
+				<< "</span>\n";
 			};
 
-			stream << "<span id='categories'>"
-
-			<< (doc.categories.collect { | path |
-				// get all the components of a category path ("UGens>Generators>Deterministic")
-				// we link each crumb of the breadcrumbs separately.
-				var pathElems = path.split($>);
-
-				// the href for "UGens" will be "UGens", for "Generators" "UGens>Generators", etc.
-				pathElems.collect { | elem, i |
-					var atag = "<a href='" ++ baseDir +/+ "Browse.html#";
-					atag ++ pathElems[0..i].join(">") ++ "'>"++ elem ++"</a>"
-				}.join("&#8201;&gt;&#8201;"); // &#8201; is a thin space
-
-			}.join(" | "))
-
-			<< "</span>\n";
+			stream << "</div>";
 		};
-
-		stream << "</div>";
 
 		stream << "<h1>";
 		if(thisIsTheMainHelpFile) {

--- a/SCClassLibrary/SCDoc/SCDocRenderer.sc
+++ b/SCClassLibrary/SCDoc/SCDocRenderer.sc
@@ -175,9 +175,9 @@ SCDocHTMLRenderer {
 		<< "</head>\n";
 
 		stream
-		<< "<ul id='menubar'></ul>\n"
 		<< "<body onload='fixTOC();prettyPrint()'>\n"
 		<< "<div class='contents'>\n"
+		<< "<div id='menubar'></div>\n"
 		<< "<div class='header'>\n"
 		<< "<div id='label'>\n"
 		<< "<span id='folder'>" << folder.asString;


### PR DESCRIPTION
uuuugggh whens github going to fix their damn image upload feature.

anyways, so this might be a little controversial, since it "undocks" the top bar in the help files. the main advantage is reducing visual clutter (and looking a touch more modern). as discussed at #2943, there's a problem where this top bar competes with the decorations on the help window. the disadvantage is that now you have to scroll back up to find what page you're on, and to access Browse/Search/Table of contents. it is of course still possible to navigate back to the home page in one click.

before you pull out the pitchforks, i'd like to point out that no other documentation system i've seen has this `position: fixed` menu. ~~also, i don't think i've been in a situation where i need to know what page i'm on.~~ duhhhh i forgot about internal links. search is also easy accessible with Ctrl+D.

this also removes the big black horizontal line in the header, which ruins the visual separation between the header/subtitle and the source/inheritance/see also text. plus the right-alignment is ugly. i have an idea for how to overcome this, but i'll take care of that in a separate PR.