### PR TITLE
sending audio feature extraction data in osc

### DIFF
--- a/HelpSource/Classes/SendTrig.schelp
+++ b/HelpSource/Classes/SendTrig.schelp
@@ -72,4 +72,17 @@ o = OSCFunc({ arg msg, time;
 Synth("help-SendTrig");
 
 o.free;
+
+//another example on sending audio feature extraction data in osc over network
+(
+SynthDef(\amplitudeAnalysis, {|in=0, rate=60| 
+var input = SoundIn.ar(in); 
+var amp = Amplitude.kr(input); var freq = Pitch.kr(input); var trig = Impulse.kr(rate); 
+SendReply.kr(trig, '/amp', [amp, freq]); 
+}).add;
+);
+
+(~mySynth = Synth(\amplitudeAnalysis); 
+~testNetAddr = NetAddr("127.0.0.1", 5000);)
+(OSCdef(\listener, {|msg| var amp = msg[3]; ~testNetAddr.sendMsg("Data", amp);}, '/amp');
 ::


### PR DESCRIPTION
example on sending audio feature extraction data in osc over network. something missing in 3.8 documentation. in this version there are already meaningful examples. however i took the freedom of adding one further example. please feel free to close the PR if you don't think it's meaningful.