### PR TITLE
Travis: add `group: edge` for Ubuntu builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,12 @@ matrix:
       sudo: required
       dist: trusty
       env: QT=true
+      group: edge
     - os: linux
       sudo: required
       dist: trusty
       env: QT=false
+      group: edge
     - os: osx
       osx_image: xcode7.3
       env: QT=true

--- a/.travis/before-install-linux.sh
+++ b/.travis/before-install-linux.sh
@@ -6,7 +6,7 @@ sudo add-apt-repository --yes ppa:beineri/opt-qt551-trusty
 sudo apt-get update
 sudo apt-get install --yes build-essential gcc-4.9 g++-4.9 cmake pkg-config libjack-jackd2-dev libsndfile1-dev libasound2-dev libavahi-client-dev libreadline6-dev libfftw3-dev libicu-dev libxt-dev libudev-dev
 if [[ -n "$1" && "$1" == "--qt=true" ]]; then
-	sudo apt-get install --yes qt55base qt55location qt55declarative qt55sensors qt55tools qt55webengine qt55webchannel qt55webkit qt55xmlpatterns
+	sudo apt-get install --yes libgl1-mesa-dev qt55base qt55location qt55declarative qt55sensors qt55tools qt55webengine qt55webchannel qt55webkit qt55xmlpatterns
 fi
 sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.9 60 --slave /usr/bin/g++ g++ /usr/bin/g++-4.9
 sudo update-alternatives --auto gcc


### PR DESCRIPTION
See https://blog.travis-ci.com/2017-06-19-trusty-updates-2017-Q2 for details

In a nutshell: Travis says to add this line to config for Ubuntu builds because there'll be an update tomorrow.