### PR TITLE
QcWebView: use int instead of enum for linkDelegationPolicy

### DIFF
--- a/QtCollider/widgets/QcWebView.cpp
+++ b/QtCollider/widgets/QcWebView.cpp
@@ -94,14 +94,14 @@ QString WebView::plainText () const
   return page()->mainFrame()->toPlainText();
 }
 
-QWebPage::LinkDelegationPolicy WebView::linkDelegationPolicy () const
+int WebView::linkDelegationPolicy () const
 {
-  return page()->linkDelegationPolicy();
+  return (int)page()->linkDelegationPolicy();
 }
 
-void WebView::setLinkDelegationPolicy ( QWebPage::LinkDelegationPolicy p )
+void WebView::setLinkDelegationPolicy ( int p )
 {
-  page()->setLinkDelegationPolicy( p );
+  page()->setLinkDelegationPolicy( (QWebPage::LinkDelegationPolicy)p );
 }
 
 bool WebView::delegateReload() const

--- a/QtCollider/widgets/QcWebView.h
+++ b/QtCollider/widgets/QcWebView.h
@@ -36,7 +36,7 @@ class WebView : public QWebView
   Q_PROPERTY( QString url READ url WRITE setUrl );
   Q_PROPERTY( QString html READ html )
   Q_PROPERTY( QString plainText READ plainText )
-  Q_PROPERTY( QWebPage::LinkDelegationPolicy linkDelegationPolicy
+  Q_PROPERTY( int linkDelegationPolicy
               READ linkDelegationPolicy WRITE setLinkDelegationPolicy )
   Q_PROPERTY( bool delegateReload READ delegateReload WRITE setDelegateReload );
   Q_PROPERTY( bool enterInterpretsSelection
@@ -67,8 +67,8 @@ public:
   QString html () const;
   QString plainText () const;
 
-  QWebPage::LinkDelegationPolicy linkDelegationPolicy () const;
-  void setLinkDelegationPolicy ( QWebPage::LinkDelegationPolicy );
+  int linkDelegationPolicy () const;
+  void setLinkDelegationPolicy ( int );
   bool delegateReload() const;
   void setDelegateReload( bool );
   bool interpretSelection() const { return _interpretSelection; }


### PR DESCRIPTION
Fixes #2295

Use `int` type instead of QWebPage::LinkDelegationPolicy
The property was failing to connect because something somewhere didn't
recognize that an enum can be cast to an int.