### PR TITLE
Classlib: MIDISysexDispatcher keys must be an array, not a large integer

### DIFF
--- a/SCClassLibrary/Common/Control/ResponseDefs.sc
+++ b/SCClassLibrary/Common/Control/ResponseDefs.sc
@@ -468,7 +468,7 @@ MIDIMessageDispatcherNV : MIDIMessageDispatcher {
 // for \sysex
 MIDISysexDispatcher : MIDIMessageDispatcher {
 
-	getKeysForFuncProxy {|funcProxy| ^(funcProxy.srcID ? \all)}
+	getKeysForFuncProxy { |funcProxy| ^(funcProxy.srcID ? \all).asArray }
 
 	value {|srcID, data|
 		active[srcID].value(data, srcID);
@@ -532,7 +532,7 @@ MIDISysDataDispatcher : MIDIMessageDispatcher {
 }
 
 MIDISysDataDropIndDispatcher : MIDISysDataDispatcher {
-	
+
 	value {|srcID, index, data|
 		active[index].value(data, srcID);
 	}


### PR DESCRIPTION
`getKeysForFuncProxy` should always return a collection, because of where it's used:

https://github.com/supercollider/supercollider/blob/master/SCClassLibrary/Common/Control/ResponseDefs.sc#L131-L132

```
		keys = this.getKeysForFuncProxy(funcProxy);
		keys.do({|key| active[key] = active[key].addFunc(func) }); // support multiple keys
```

All of the other MIDI***Dispatcher classes do `asArray` in getKeysForFuncProxy... MIDISysexDispatcher, uniquely, does not:

```
	getKeysForFuncProxy {|funcProxy| ^(funcProxy.srcID ? \all)}
```

So, when the srcID is a very large integer, `keys` becomes a large integer, and then `keys.do` will add a new item into `active` that number of times. Millions of times. Potentially-crashy numbers of times.

Fixes #2937.