### PR TITLE
scdoc: redesign subheader

### DIFF
--- a/HelpSource/scdoc.css
+++ b/HelpSource/scdoc.css
@@ -201,7 +201,6 @@ a.navlink {
     color: #444;
 }
 #related {
-    text-align: right;
     font-weight: bold;
     margin-top: 0.5em;
 }
@@ -211,6 +210,12 @@ a.navlink {
 .headerimage {
     float: right;
     margin-right: 1ex;
+}
+
+#superclasses {
+    font-size: 9pt;
+    color: #444;
+    font-weight: normal;
 }
 
 .extension-indicator-ctr {
@@ -233,9 +238,9 @@ a.navlink {
 }
 
 .subheader {
-    text-align: right;
     font-size: 9pt;
     color: #444;
+    margin-top: 1em;
 }
 
 .jump {

--- a/SCClassLibrary/SCDoc/SCDoc.sc
+++ b/SCClassLibrary/SCDoc/SCDoc.sc
@@ -384,7 +384,7 @@ SCDocNode {
 SCDoc {
 
 	// Increment this whenever we make a change to the SCDoc system so that all help-files should be processed again
-	classvar version = 59;
+	classvar version = 60;
 
 	classvar <helpTargetDir;
 	classvar <helpTargetUrl;

--- a/SCClassLibrary/SCDoc/SCDocRenderer.sc
+++ b/SCClassLibrary/SCDoc/SCDocRenderer.sc
@@ -224,6 +224,14 @@ SCDocHTMLRenderer {
 		} {
 			stream << doc.title;
 		};
+		if(doc.isClassDoc and: { currentClass.notNil } and: { currentClass != Object }) {
+			stream << "<span id='superclasses'>"
+			<< " : "
+			<< (currentClass.superclasses.collect {|c|
+				"<a href=\"../Classes/"++c.name++".html\">"++c.name++"</a>"
+			}.join(" : "))
+			<< "</span>\n";
+		};
 		if(doc.isExtension) {
 			stream
 			<< "<div class='extension-indicator-ctr' title='This help file originates from a third-party quark or plugin for SuperCollider.'>"
@@ -241,22 +249,14 @@ SCDocHTMLRenderer {
 			if(currentClass.notNil) {
 				m = currentClass.filenameSymbol.asString;
 				stream << "<div id='filename'>Source: "
-				<< "<a href='" << URI.fromLocalPath(m).asString << "'>"
-				<< m.dirname << "/" << m.basename << "</a></div>";
-				if(currentClass != Object) {
-					stream << "<div id='superclasses'>"
-					<< "Inherits from: "
-					<< (currentClass.superclasses.collect {|c|
-						"<a href=\"../Classes/"++c.name++".html\">"++c.name++"</a>"
-					}.join(" : "))
-					<< "</div>\n";
-				};
+				<< "<a href='%' title='%'>".format(URI.fromLocalPath(m).asString, m)
+				<< m.basename << "</a></div>";
 				if(currentClass.subclasses.notNil) {
 					z = false;
 					stream << "<div id='subclasses'>"
 					<< "Subclasses: "
 					<< (currentClass.subclasses.collect(_.name).sort.collect {|c,i|
-						if(i==12,{z=true;"<span id='hiddensubclasses' style='display:none;'>"},{""})
+						if(i==4,{z=true;"<span id='hiddensubclasses' style='display:none;'>"},{""})
 						++"<a href=\"../Classes/"++c++".html\">"++c++"</a>"
 					}.join(", "));
 					if(z) {


### PR DESCRIPTION
Towards #2943. This commit improves the design of the subheader. It is no longer right-aligned. The source filename is reduced to include only the file name (which can still be viewed in full by hovering over or clicking), the superclasses are incorporated into the title. The "see more..." line for subclasses is cut down from 13 classes to 4.

![untitled](https://user-images.githubusercontent.com/1211064/27694713-b4fcc358-5ca1-11e7-8f3d-171ba70ee534.png)
