### PR TITLE
Lang: canCallOS should not be true when calling doUnixCmdAction

### DIFF
--- a/lang/LangPrimSource/PyrUnixPrim.cpp
+++ b/lang/LangPrimSource/PyrUnixPrim.cpp
@@ -139,12 +139,10 @@ static void string_popen_thread_func(struct sc_process *process)
 	gLangMutex.lock();
 	if(compiledOK) {
 		VMGlobals *g = gMainVMGlobals;
-		g->canCallOS = true;
 		++g->sp;  SetObject(g->sp, class_string);
 		++g->sp; SetInt(g->sp, res);
 		++g->sp; SetInt(g->sp, pid);
 		runInterpreter(g, s_unixCmdAction, 3);
-		g->canCallOS = false;
 	}
 	gLangMutex.unlock();
 }


### PR DESCRIPTION
http://new-supercollider-mailing-lists-forums-use-these.2681727.n2.nabble.com/What-is-QSocketNotifier-Can-only-be-used-with-threads-started-with-QThread-tp7633245p7633253.html

In short: If you use GUI objects in an action function for `unixCmd`, the GUI objects do not display.

```
"ls".unixCmd({
	defer {
		StaticText(nil, Rect.aboutPoint(Window.screenBounds.center, 80, 60))
		.string_("Hello").align_(\center)
		.front
	}
});
```

Debugging details are in the mailing list post. The gist is that `doUnixCmdAction` runs the function in a thread that is marked as GUI-safe (`this.canCallOS`), but it isn't really GUI-safe. So even `defer` doesn't help, because `defer` skips scheduling on AppClock if `this.canCallOS` is true.

Debugging in a commandline script, I saw "QSocketNotifier: Can only be used with threads started with QThread" -- which makes sense: if the unixCmd process is being started from a plain thread, and this thread is responsible for the finishing action, and `defer` isn't really deferring, then we would be in the wrong type of thread.

It turns out, when the unixCmd `action` was introduced (https://github.com/supercollider/supercollider/commit/71476d9bdd8ea2c94321753de65df6d65db27d74), it assumed that it should be a `canCallOS` thread. Maybe Cocoa supported GUI objects from that thread, or maybe nobody ever tried. In any case, it isn't a valid assumption for Qt, so I propose removing the lines that set and reset `g->canCallOS`. Tested with the above case, and it does solve the problem.

The other possible fix might be to use QThread instead of SC_Thread here:

https://github.com/supercollider/supercollider/blame/master/lang/LangPrimSource/PyrUnixPrim.cpp#L182

But that's a more invasive change with unknown side effects.

It's reasonable to require `defer` in a unixCmd action -- it's already required for OSC and MIDI actions. This fix merely makes `defer` do what you would expect.

PS Why would you want to use GUI objects in a unixCmd action? If you're running a `sclang script.scd` or an OSX standalone, the user is probably not looking at the post window or console -- so the best way to give feedback to the end-user is using GUIs. E.g., if a unixCmd fails or the server crashes, you want to let the user know.