### PR TITLE
Add GitHub issue & PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -30,7 +30,3 @@
 // Please paste any error messages here.
 // Link to a Gist (https://gist.github.com) if the message is long.
 ```
-
-## Context
-<!--- How has this issue affected you? What are you trying to accomplish? -->
-<!--- Providing context helps us come up with a solution that is most useful in the real world -->

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -13,10 +13,6 @@
 <!--- If describing a bug, tell us what happens instead of the expected behavior -->
 <!--- If suggesting a change/improvement, explain the difference from current behavior -->
 
-## Possible Solution
-<!--- Not obligatory, but suggest a fix/reason for the bug, -->
-<!--- or ideas how to implement the addition or change -->
-
 ## Steps to reproduce (for bugs)
 
 ```supercollider
@@ -30,3 +26,7 @@
 // Please paste any error messages here.
 // Link to a Gist (https://gist.github.com) if the message is long.
 ```
+
+## Possible Solution (optional)
+<!--- Not obligatory, but suggest a fix/reason for the bug, -->
+<!--- or ideas how to implement the addition or change -->

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,5 +1,10 @@
 <!--- Provide a general summary of the issue in the Title above -->
 
+## Environment
+* SuperCollider version:
+* Operating system and version:
+<!--- Include any other relevant details about your environment (Qt version, audio driver, etc.) -->
+
 ## Expected Behavior
 <!--- If you're describing a bug, tell us what should happen -->
 <!--- If you're suggesting a change/improvement, tell us how it should work -->
@@ -29,9 +34,3 @@
 ## Context
 <!--- How has this issue affected you? What are you trying to accomplish? -->
 <!--- Providing context helps us come up with a solution that is most useful in the real world -->
-
-## Your Environment
-<!--- Include as many relevant details about the environment you experienced the bug in -->
-* Version used:
-* Operating System and version:
-

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -23,7 +23,8 @@
 ## Error message (for bugs)
 
 ```
-// Please paste any error messages here.
+// Please paste any error messages here in their entirety.
+// If this is a SuperCollider error message, include the full stack trace.
 // Link to a Gist (https://gist.github.com) if the message is long.
 ```
 

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,37 @@
+<!--- Provide a general summary of the issue in the Title above -->
+
+## Expected Behavior
+<!--- If you're describing a bug, tell us what should happen -->
+<!--- If you're suggesting a change/improvement, tell us how it should work -->
+
+## Current Behavior
+<!--- If describing a bug, tell us what happens instead of the expected behavior -->
+<!--- If suggesting a change/improvement, explain the difference from current behavior -->
+
+## Possible Solution
+<!--- Not obligatory, but suggest a fix/reason for the bug, -->
+<!--- or ideas how to implement the addition or change -->
+
+## Steps to reproduce (for bugs)
+
+```supercollider
+// Please paste SuperCollider code here.
+// Try to make your example as minimal as possible.
+```
+
+## Error message (for bugs)
+
+```
+// Please paste any error messages here.
+// Link to a Gist (https://gist.github.com) if the message is long.
+```
+
+## Context
+<!--- How has this issue affected you? What are you trying to accomplish? -->
+<!--- Providing context helps us come up with a solution that is most useful in the real world -->
+
+## Your Environment
+<!--- Include as many relevant details about the environment you experienced the bug in -->
+* Version used:
+* Operating System and version:
+

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -28,8 +28,4 @@
 // Link to a Gist (https://gist.github.com) if the message is long.
 ```
 
-## Possible Solution (optional)
-<!--- Not obligatory, but suggest a fix/reason for the bug, -->
-<!--- or ideas how to implement the addition or change -->
-
 <!--- Thanks for contributing! -->

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -30,3 +30,5 @@
 ## Possible Solution (optional)
 <!--- Not obligatory, but suggest a fix/reason for the bug, -->
 <!--- or ideas how to implement the addition or change -->
+
+<!--- Thanks for contributing! -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,11 +1,8 @@
 <!--- Provide a general summary of your changes in the title above -->
 
-## Purpose
+## Purpose and Motivation
 
-<!--- Please describe the purpose of the pull request. -->
-
-## Motivation and Context
-
+<!--- Please describe the purpose and motivation of the pull request. -->
 <!--- Why is this change required? What problem does it solve? -->
 <!--- If it fixes an open issue, please link to the issue here. -->
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -17,8 +17,8 @@
 ## Checklist
 
 - [ ] All tests are passing
-- [ ] New tests were created to address changes in PR (and tests are passing)
-- [ ] Updated README and/or documentation, if necessary
+- [ ] If necessary, new tests were created to address changes in PR (and tests are passing)
+- [ ] Updated documentation, if necessary
 - [ ] This PR is ready for review
 
 <!--- If any work remains to be done, please give a brief description here. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,27 @@
+<!--- Provide a general summary of your changes in the title above -->
+
+## Purpose
+
+<!--- Please describe the purpose of the pull request. -->
+
+## Motivation and Context
+
+<!--- Why is this change required? What problem does it solve? -->
+<!--- If it fixes an open issue, please link to the issue here. -->
+
+## Types of changes
+
+<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply: -->
+- [ ] Documentation (non-code change which corrects or adds documentation for existing features)
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to change)
+
+## Checklist
+
+- [ ] All tests are passing
+- [ ] New tests were created to address changes in PR (and tests are passing)
+- [ ] Updated README and/or documentation, if necessary
+
+<!--- Thanks for contributing! -->
+

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -19,6 +19,10 @@
 - [ ] All tests are passing
 - [ ] New tests were created to address changes in PR (and tests are passing)
 - [ ] Updated README and/or documentation, if necessary
+- [ ] This PR is ready for review
+
+<!--- If any work remains to be done, please give a brief description here. -->
+<!--- Consider providing a todo-list so we can easily track completion progress. -->
 
 <!--- Thanks for contributing! -->
 


### PR DESCRIPTION
Add issue and PR templates according to
https://github.com/blog/2111-issue-and-pull-request-templates

This helps contributors to share the right details at the start of a
thread, cutting down on miscommunication and under-informed reporting