### PR TITLE
scdoc: left align extension/superclass text

### DIFF
--- a/HelpSource/scdoc.css
+++ b/HelpSource/scdoc.css
@@ -374,14 +374,12 @@ a.method-name {
     font-size: 9pt;
     color: #444;
     padding-left: 0.2em;
-    text-align: right;
 }
 
 .supmethod {
     font-size: 9pt;
     color: #444;
     padding-left: 0.2em;
-    text-align: right;
 }
 
 table.arguments {


### PR DESCRIPTION
towards #2943. there's no good reason for these to be right aligned, and it looks kinda messy. follow up to #2966, with apologies to julian
![untitled](https://user-images.githubusercontent.com/1211064/27986977-b7c5de46-63bb-11e7-8c63-d481b9f9ee28.png)

