### PR TITLE
Fix logic errors and unused variables

### DIFF
--- a/lang/LangPrimSource/OSCData.cpp
+++ b/lang/LangPrimSource/OSCData.cpp
@@ -409,7 +409,7 @@ static int prNetAddr_Connect(VMGlobals *g, int numArgsPushed)
 
 static int prNetAddr_Disconnect(VMGlobals *g, int numArgsPushed)
 {
-	int err;
+	int err = errNone;
 
 	PyrSlot* netAddrSlot = g->sp;
 	PyrObject* netAddrObj = slotRawObject(netAddrSlot);

--- a/lang/LangPrimSource/SC_HID_api.cpp
+++ b/lang/LangPrimSource/SC_HID_api.cpp
@@ -489,8 +489,6 @@ int prHID_API_BuildDeviceList(VMGlobals* g, int numArgsPushed){
 	PyrSlot *self = args + 0;
 	// no arguments
 
-	int err;
-
 	const char emptyString[] = "";
 
 	// iterate over available devices and return info to language to populate the list there
@@ -876,7 +874,6 @@ int prHID_API_GetElementInfo( VMGlobals* g, int numArgsPushed ){
 
 int prHID_API_SetElementOutput( VMGlobals* g, int numArgsPushed ){
 	PyrSlot *args = g->sp - numArgsPushed + 1;
-	PyrSlot* self = args + 0;
 	PyrSlot* arg1  = args + 1;
 	PyrSlot* arg2  = args + 2;
 	PyrSlot* arg3  = args + 3;
@@ -919,7 +916,6 @@ int prHID_API_SetElementOutput( VMGlobals* g, int numArgsPushed ){
 
 int prHID_API_SetElementRepeat( VMGlobals* g, int numArgsPushed ){
 	PyrSlot *args = g->sp - numArgsPushed + 1;
-	PyrSlot* self = args + 0;
 	PyrSlot* arg1  = args + 1;
 	PyrSlot* arg2  = args + 2;
 	PyrSlot* arg3  = args + 3;

--- a/lang/LangPrimSource/SC_HID_api.cpp
+++ b/lang/LangPrimSource/SC_HID_api.cpp
@@ -869,23 +869,23 @@ int prHID_API_GetElementInfo( VMGlobals* g, int numArgsPushed ){
 }
 
 int prHID_API_SetElementOutput( VMGlobals* g, int numArgsPushed ){
-	PyrSlot *args = g->sp - numArgsPushed + 1;
-	PyrSlot* arg1  = args + 1;
-	PyrSlot* arg2  = args + 2;
-	PyrSlot* arg3  = args + 3;
+	PyrSlot * args = g->sp - numArgsPushed + 1;
+	PyrSlot * joyIdSlot     = args + 1;
+	PyrSlot * elementIdSlot = args + 2;
+	PyrSlot * valueSlot     = args + 3;
 
 	int err;
 	int joyid;
 	int elementid;
 	int value;
 
-	err = slotIntVal( arg1, &joyid );
+	err = slotIntVal( joyIdSlot, &joyid );
 	if ( err != errNone ) return err;
 
-	err = slotIntVal( arg2, &elementid );
+	err = slotIntVal( elementIdSlot, &elementid );
 	if ( err != errNone ) return err;
 
-	err = slotIntVal( arg3, &value );
+	err = slotIntVal( valueSlot, &value );
 	if ( err != errNone ) return err;
 
 	struct hid_dev_desc * devdesc = SC_HID_APIManager::instance().get_device( joyid );
@@ -911,23 +911,23 @@ int prHID_API_SetElementOutput( VMGlobals* g, int numArgsPushed ){
 }
 
 int prHID_API_SetElementRepeat( VMGlobals* g, int numArgsPushed ){
-	PyrSlot *args = g->sp - numArgsPushed + 1;
-	PyrSlot* arg1  = args + 1;
-	PyrSlot* arg2  = args + 2;
-	PyrSlot* arg3  = args + 3;
+	PyrSlot * args = g->sp - numArgsPushed + 1;
+	PyrSlot * joyIdSlot     = args + 1;
+	PyrSlot * elementIdSlot = args + 2;
+	PyrSlot * valueSlot     = args + 3;
 
 	int err;
 	int joyid;
 	int elementid;
 	int value;
 
-	err = slotIntVal( arg1, &joyid );
+	err = slotIntVal( joyIdSlot, &joyid );
 	if ( err != errNone ) return err;
 
-	err = slotIntVal( arg2, &elementid );
+	err = slotIntVal( elementIdSlot, &elementid );
 	if ( err != errNone ) return err;
 
-	err = slotIntVal( arg3, &value );
+	err = slotIntVal( valueSlot, &value );
 	if ( err != errNone ) return err;
 
 	struct hid_dev_desc * devdesc = SC_HID_APIManager::instance().get_device( joyid );

--- a/lang/LangPrimSource/SC_HID_api.cpp
+++ b/lang/LangPrimSource/SC_HID_api.cpp
@@ -348,16 +348,12 @@ SC_HID_APIManager::~SC_HID_APIManager()
 
 int SC_HID_APIManager::init()
 {
-	int result;
 	number_of_hids = 0;
 	mShouldBeRunning = true;
-	if ( !m_running ){
-		result = initialize_hidapi();
-	}
-	if ( !m_running ){
-		return errFailed;
-	}
-	return result;
+	if ( !m_running )
+		initialize_hidapi();
+
+	return m_running ? errNone : errFailed;
 }
 
 int SC_HID_APIManager::closeAll()


### PR DESCRIPTION
Toward #2927.

This initializes an uninitialized variable, simplifies logic that could return garbage, removes unused variables, and renames some proximal variables to be more descriptive.

See the commit history for more details.

This removes 2 logic issues and 2 unused variable warnings.