### PR TITLE
Clean build: Reorder constructor initialization lists to avoid compiler warnings

### DIFF
--- a/QtCollider/image.h
+++ b/QtCollider/image.h
@@ -41,9 +41,9 @@ class Image
 
 public:
     Image():
+        transformationMode(Qt::FastTransformation),
         m_state(Null),
-        m_painting(false),
-        transformationMode(Qt::FastTransformation)
+        m_painting(false)
     {
 
     }

--- a/QtCollider/widgets/QcGraph.cpp
+++ b/QtCollider/widgets/QcGraph.cpp
@@ -61,6 +61,7 @@ void QcGraphModel::removeAt( int i ) {
 QcGraph::QcGraph() :
   QtCollider::Style::Client(this),
   _defaultThumbSize( QSize(18,18) ),
+  _gridOn( false ),
   _style(DotElements),
   _drawLines( true ),
   _drawRects( true ),
@@ -68,7 +69,6 @@ QcGraph::QcGraph() :
   _step( 0.01 ),
   _selectionForm( ElasticSelection ),
   _xOrder( NoOrder ),
-  _gridOn( false ),
   _geometryDirty( false ),
   _lastIndex(-1)
 {

--- a/QtCollider/widgets/QcKnob.cpp
+++ b/QtCollider/widgets/QcKnob.cpp
@@ -33,8 +33,8 @@ QC_DECLARE_QWIDGET_FACTORY(QcKnob);
 QcKnob::QcKnob() :
   Style::Client(this),
   _value(0.f),
-  _mode(0),
   _step(0.01),
+  _mode(0),
   _centered(false)
 {
   setFocusPolicy( Qt::StrongFocus );

--- a/QtCollider/widgets/QcLevelIndicator.cpp
+++ b/QtCollider/widgets/QcLevelIndicator.cpp
@@ -28,11 +28,19 @@ QC_DECLARE_QWIDGET_FACTORY(QcLevelIndicator);
 
 QcLevelIndicator::QcLevelIndicator() :
   QtCollider::Style::Client(this),
-  _value( 0.f ), _warning(0.6), _critical(0.8),
-  _peak( 0.f ), _drawPeak( false ),
-  _ticks(0), _majorTicks(0), _stepWidth(10), _style(LevelIndicatorStyle::Continuous),
+  _value( 0.f ),
+  _warning(0.6),
+  _critical(0.8),
+  _peak( 0.f ),
+  _drawPeak( false ),
+  _ticks(0),
+  _majorTicks(0),
+  _stepWidth(10),
+  _style(LevelIndicatorStyle::Continuous),
   _clipped(false),
-  _meterColor(0, 255, 0), _warningColor(255, 255, 0), _criticalColor(255,100,0)
+  _meterColor(0, 255, 0),
+  _warningColor(255, 255, 0),
+  _criticalColor(255, 100, 0)
 {
   _clipTimer = new QTimer( this );
   _clipTimer->setSingleShot(true);

--- a/QtCollider/widgets/QcLevelIndicator.h
+++ b/QtCollider/widgets/QcLevelIndicator.h
@@ -74,7 +74,6 @@ private Q_SLOTS:
   void clipTimeout();
 private:
   const QColor valueColor(float value);
-  QColor _meterColor, _warningColor, _criticalColor;
   void paintEvent( QPaintEvent *e );
   float _value;
   float _warning;
@@ -87,6 +86,7 @@ private:
 	LevelIndicatorStyle _style;
   bool _clipped;
   QTimer *_clipTimer;
+  QColor _meterColor, _warningColor, _criticalColor;
 };
 
 #endif

--- a/QtCollider/widgets/image_painter.h
+++ b/QtCollider/widgets/image_painter.h
@@ -144,7 +144,6 @@ struct ImagePainter
         bool tileVertically = verticalMode == TileVertically;
         bool tileHorizontally = horizontalMode == TileHorizontally;
 
-        qreal x_origin = rect.left();
         qreal y_origin = rect.top();
         do {
             do {

--- a/lang/LangSource/SC_TerminalClient.h
+++ b/lang/LangSource/SC_TerminalClient.h
@@ -66,16 +66,17 @@ public:
 			  mCallRun(false),
 			  mCallStop(false),
 			  mStandalone(false),
-			  mArgc(0), mArgv(0)
+			  mArgc(0),
+			  mArgv(0)
 		{ }
 
 		const char*		mLibraryConfigFile;
 		bool			mDaemon;
 		bool			mCallRun;
 		bool			mCallStop;
+		bool			mStandalone;
 		int				mArgc;
 		char**			mArgv;
-		bool			mStandalone;
 	};
 
 	SC_TerminalClient(const char* name);


### PR DESCRIPTION
This reorders the initialization lists in a few headers and cpp files to avoid warnings from the compiler. None of these classes actually depend on this order of initialization, so the warning is spurious and easily fixed.

Toward #2927.