### PR TITLE
Clean build: remove some unused variables

### DIFF
--- a/editors/sc-ide/core/settings/theme.cpp
+++ b/editors/sc-ide/core/settings/theme.cpp
@@ -313,7 +313,6 @@ void Theme::remove()
     if (mLocked)
         return;
 
-    QMap<QString, QTextCharFormat *>::const_iterator i = mFormats.begin();
     QString key = QStringLiteral("IDE/editor/themes/").append(mName);
 
     mSettings->remove(key);

--- a/lang/LangPrimSource/PyrArrayPrimitives.cpp
+++ b/lang/LangPrimSource/PyrArrayPrimitives.cpp
@@ -1070,7 +1070,7 @@ int prArrayFill(struct VMGlobals *g, int numArgsPushed)
 	PyrObject *array;
 	PyrSymbol *sym;
 	int i;
-	int format, tag;
+	int format;
 	int err, ival;
 	double fval;
 
@@ -1080,8 +1080,8 @@ int prArrayFill(struct VMGlobals *g, int numArgsPushed)
 
 	array = slotRawObject(a);
 	format = slotRawObject(a)->obj_format;
-	tag = gFormatElemTag[format];
-	/*if (tag > 0) {
+	/*int tag = gFormatElemTag[format];
+	if (tag > 0) {
 		if (GetTag(b) != tag) return errWrongType;
 	} else if (tag == 0) {
 		if (NotFloat(b)) return errWrongType;

--- a/server/plugins/GrainUGens.cpp
+++ b/server/plugins/GrainUGens.cpp
@@ -1,5 +1,5 @@
 /*
- *  JoshUGens.cpp
+ *  GrainUGens.cpp
  *  xSC3plugins
  *
  *  Created by Josh Parmenter on 2/4/05.

--- a/server/plugins/GrainUGens.cpp
+++ b/server/plugins/GrainUGens.cpp
@@ -35,8 +35,6 @@ static InterfaceTable *ft;
 
 const int kMaxGrains = 64;
 
-const int kMaxSynthGrains = 512;
-
 struct GrainInG
 {
 	double b1, y1, y2, curamp, winPos, winInc; // envelope


### PR DESCRIPTION
Toward #2927. This removes some compiler warnings about unused variables by either deleting them or moving them within the relevant comment block.