### PR TITLE
Set help browser style to "Fusion" on macOS

### DIFF
--- a/editors/sc-ide/widgets/help_browser.cpp
+++ b/editors/sc-ide/widgets/help_browser.cpp
@@ -42,6 +42,10 @@
 #include <QDebug>
 #include <QKeyEvent>
 
+#ifdef Q_OS_MAC
+#  include <QStyleFactory> // QStyleFactory::create, see below
+#endif
+
 namespace ScIDE {
 
 HelpBrowser::HelpBrowser( QWidget * parent ):
@@ -62,6 +66,12 @@ HelpBrowser::HelpBrowser( QWidget * parent ):
     // Set the style's standard palette to avoid system's palette incoherencies
     // get in the way of rendering web pages
     mWebView->setPalette( style()->standardPalette() );
+
+#ifdef Q_OS_MAC
+    // On macOS, checkboxes unwantedly appear in the top left-hand corner.
+    // See QTBUG-43366, 43070, and 42948. The workaround is to set style to fusion.
+    mWebView->setStyle( QStyleFactory::create("Fusion") );
+#endif
 
     mWebView->installEventFilter(this);
 


### PR DESCRIPTION
Fixes #2286. Checkboxes appear in the upper left-hand corner with
a QWebView in "Macintosh" style. See QTBUG 43366, 43070, 42948.
This sets the help browser's style to "Fusion" (matching the Qt GUI's
default) on macOS, which is the workaround other users/maintainers
have suggested.

Further reading:
https://bugreports.qt.io/browse/QTBUG-42948
https://bugreports.qt.io/browse/QTBUG-43070
https://bugreports.qt.io/browse/QTBUG-43366