### PR TITLE
fixing std::bind not found bug

### DIFF
--- a/lang/LangPrimSource/PyrSerialPrim.cpp
+++ b/lang/LangPrimSource/PyrSerialPrim.cpp
@@ -36,6 +36,7 @@
 #include <termios.h>
 #include <unistd.h>
 #include <boost/atomic.hpp>
+#include <functional>
 
 #include <stdexcept>
 #include <sstream>


### PR DESCRIPTION
```
/home/hlolli/supercollider/supercollider/lang/LangPrimSource/PyrSerialPrim.cpp:343:25: error: ‘bind’ is not a member of ‘std’
   SC_Thread thread(std::bind(&SerialPort::threadLoop, this));
                         ^~~~
/home/hlolli/supercollider/supercollider/lang/LangPrimSource/PyrSerialPrim.cpp:343:25: note: suggested alternative: ‘find’
   SC_Thread thread(std::bind(&SerialPort::threadLoop, this));
                         ^~~~
                         find
```

This error message I get from compiling the master branch on Supercollider. Some short google-ing led me to https://stackoverflow.com/questions/14261013/bind-is-not-a-member-of-std which says it has to do with conflicts in c++ v 11. Boost library has a synonymous function that can be used here, which makes Supercollider compile successfully.

I'm running on Fedora 25 on gcc version 7.1.

as an extra, I was also missing a dependency that cmake didn't warn me about: libatomic. I think this should be added as requirement to the cmake file.