### PR TITLE
fixed 2 broken links in LevelIndicator help file

### DIFF
--- a/HelpSource/Classes/LevelIndicator.schelp
+++ b/HelpSource/Classes/LevelIndicator.schelp
@@ -23,7 +23,7 @@ returns:: A link::Classes/Float::
 
 METHOD:: warning
 METHOD:: critical
-Set the warning and critical thresholds. If meter value is above either threshold, link::#-warningColor or link::#-criticalColor will be shown, respectively (by default, yellow and red).
+Set the warning and critical thresholds. If meter value is above either threshold, link::#-warningColor:: or link::#-criticalColor:: will be shown, respectively (by default, yellow and red).
 If link::#-drawsPeak:: is true warning color will be displayed based on link::#-peakLevel:: rather than value.
 
 argument:: val


### PR DESCRIPTION
Hello,
every once in a while I encounter broken links in the Documentation.
I thought I might as well fix them.
Here is one fix in the LevelIndicator help file. 
(someone forgot the :: at the end of the links) 
Cheers,
Eric