### PR TITLE
don't escape spaces in rendered link text

### DIFF
--- a/SCClassLibrary/SCDoc/SCDoc.sc
+++ b/SCClassLibrary/SCDoc/SCDoc.sc
@@ -384,7 +384,7 @@ SCDocNode {
 SCDoc {
 
 	// Increment this whenever we make a change to the SCDoc system so that all help-files should be processed again
-	classvar version = 60;
+	classvar version = 61;
 
 	classvar <helpTargetDir;
 	classvar <helpTargetUrl;

--- a/SCClassLibrary/SCDoc/SCDocRenderer.sc
+++ b/SCClassLibrary/SCDoc/SCDocRenderer.sc
@@ -83,9 +83,9 @@ SCDocHTMLRenderer {
 		};
 
 		if(linkAnchor.isEmpty) {
-			^linkBase
+			^result
 		} {
-			^linkBase ++ "#" ++ this.escapeSpacesInAnchor(linkAnchor);
+			^result ++ "#" ++ this.escapeSpacesInAnchor(linkAnchor);
 		}
 	}
 

--- a/SCClassLibrary/SCDoc/SCDocRenderer.sc
+++ b/SCClassLibrary/SCDoc/SCDocRenderer.sc
@@ -66,7 +66,9 @@ SCDocHTMLRenderer {
 	*htmlForLink { |link, escape = true|
 		var linkBase, linkAnchor, linkText, linkTarget, doc;
 		// FIXME: how slow is this? can we optimize
-		#linkBase, linkAnchor, linkText = link.split($#); // link, anchor, label
+
+		// Get the link base, anchor, and text from the original string
+		#linkBase, linkAnchor, linkText = link.split($#);
 
 		if(linkAnchor.size > 0) {
 			linkAnchor = this.escapeSpacesInAnchor(linkAnchor);
@@ -89,11 +91,11 @@ SCDocHTMLRenderer {
 			// If the link base is non-empty, it is a link to something in another document
 			if(linkBase.size>0) {
 
-			    // Compose the target as being relative to the help system base directory
-				linkTarget = baseDir +/+ linkBase;
-
 				// Find the document referred to by this link
 				doc = SCDoc.documents[linkBase];
+
+				// Compose the target as being relative to the help system base directory
+				linkTarget = baseDir +/+ linkBase;
 
 				// If this is an existing document, just add .html to get the target
 				if(doc.notNil) {

--- a/SCClassLibrary/SCDoc/SCDocRenderer.sc
+++ b/SCClassLibrary/SCDoc/SCDocRenderer.sc
@@ -52,15 +52,15 @@ SCDocHTMLRenderer {
 	}
 
 	*htmlForLink {|link,escape=true|
-		var n, m, f, c, doc;
+		var n, linkAnchor, f, c, doc;
 		// FIXME: how slow is this? can we optimize
-		#n, m, f = link.split($#); // link, anchor, label
-		if(m.size > 0) {
-			m = this.escapeSpacesInAnchor(m);
+		#n, linkAnchor, f = link.split($#); // link, anchor, label
+		if(linkAnchor.size > 0) {
+			linkAnchor = this.escapeSpacesInAnchor(linkAnchor);
 		};
 		^if ("^[a-zA-Z]+://.+".matchRegexp(link) or: (link.first==$/)) {
 			if(f.size<1) {f=link};
-			c = if(m.size>0) {n++"#"++m} {n};
+			c = if(linkAnchor.size>0) {n++"#"++linkAnchor} {n};
 			if(escape) { f = this.escapeSpecialChars(f) };
 			"<a href=\""++c++"\">"++f++"</a>";
 		} {
@@ -86,15 +86,15 @@ SCDocHTMLRenderer {
 			} {
 				c = ""; // link inside same document
 			};
-			if(m.size>0) { c = c ++ "#" ++ m }; // add #anchor
+			if(linkAnchor.size>0) { c = c ++ "#" ++ linkAnchor }; // add #anchor
 			if(f.size<1) { // no label
 				if(n.size>0) {
 					f = if(doc.notNil) {doc.title} {n.basename};
-					if(m.size>0) {
-						f = f++": "++m;
+					if(linkAnchor.size>0) {
+						f = f++": "++linkAnchor;
 					}
 				} {
-					f = if(m.size>0) {m} {"(empty link)"};
+					f = if(linkAnchor.size>0) {linkAnchor} {"(empty link)"};
 				};
 			};
 			if(escape) { f = this.escapeSpecialChars(f) };

--- a/SCClassLibrary/SCDoc/SCDocRenderer.sc
+++ b/SCClassLibrary/SCDoc/SCDocRenderer.sc
@@ -68,9 +68,13 @@ SCDocHTMLRenderer {
 		// FIXME: how slow is this? can we optimize
 
 		// Get the link base, anchor, and text from the original string
+		// Replace them with empty strings if any are nil
 		#linkBase, linkAnchor, linkText = link.split($#);
+		linkBase = linkBase ? "";
+		linkAnchor = linkAnchor ? "";
+		linkText = linkText ? "";
 
-		if(linkAnchor.size > 0) {
+		if(linkAnchor.empty.not) {
 			linkAnchor = this.escapeSpacesInAnchor(linkAnchor);
 		};
 
@@ -81,10 +85,10 @@ SCDocHTMLRenderer {
 			// Process a link that goes to a URL outside the help system
 
 			// If there was no link text, set it to be the same as the original link
-			if(linkText.size < 1) {linkText = link};
+			if(linkText.isEmpty) {linkText = link};
 
 			// Set the link target to be the link base plus its anchor, if there was one
-			linkTarget = if(linkAnchor.size > 0) {linkBase ++ "#" ++ linkAnchor} {linkBase};
+			linkTarget = if(linkAnchor.isEmpty.not) {linkBase ++ "#" ++ linkAnchor} {linkBase};
 		} {
 		    // Process a link that goes to a URL within the help system
 
@@ -92,7 +96,7 @@ SCDocHTMLRenderer {
 			var doc = nil;
 
 			// If the link base is non-empty, it is a link to something in another document
-			if(linkBase.size>0) {
+			if(linkBase.isEmpty.not) {
 
 				// Compose the target as being relative to the help system base directory
 				linkTarget = baseDir +/+ linkBase;
@@ -126,21 +130,21 @@ SCDocHTMLRenderer {
 			};
 
 			// If there was an anchor, add it to the link target
-			if(linkAnchor.size > 0) { linkTarget = linkTarget ++ "#" ++ linkAnchor };
+			if(linkAnchor.isEmpty.not) { linkTarget = linkTarget ++ "#" ++ linkAnchor };
 
 			// If there was no label, generate one from the base and/or anchor.
 			// FIXME: the anchor's spaces have already been escaped here, which causes issue #2337.
-			if(linkText.size < 1) {
+			if(linkText.isEmpty) {
 
 				// If the base was non-empty, generate it by combining the filename and the anchor.
 				// Otherwise, if there was an anchor, use that. Otherwise, use "(empty link)"
-				if(linkBase.size > 0) {
+				if(linkBase.isEmpty.not) {
 					linkText = if(doc.notNil) {doc.title} {linkBase.basename};
-					if(linkAnchor.size > 0) {
+					if(linkAnchor.isEmpty.not) {
 						linkText = linkText ++ ": " ++ linkAnchor;
 					}
 				} {
-					linkText = if(linkAnchor.size > 0) {linkAnchor} {"(empty link)"};
+					linkText = if(linkAnchor.isEmpty.not) {linkAnchor} {"(empty link)"};
 				};
 			};
 		};

--- a/SCClassLibrary/SCDoc/SCDocRenderer.sc
+++ b/SCClassLibrary/SCDoc/SCDocRenderer.sc
@@ -52,7 +52,7 @@ SCDocHTMLRenderer {
 	}
 
 	// Find the target (what goes after href=) for a link that stays inside the hlp system
-	*prLinkTargetForLink { |linkBase, originalLink|
+	*prLinkTargetForInternalLink { |linkBase, linkAnchor, originalLink|
 		var result;
 
 		if(linkBase.isEmpty) {

--- a/SCClassLibrary/SCDoc/SCDocRenderer.sc
+++ b/SCClassLibrary/SCDoc/SCDocRenderer.sc
@@ -51,6 +51,9 @@ SCDocHTMLRenderer {
 		^str.replace(" ", "%20")
 	}
 
+	// argument link: the raw link text from the schelp document
+	// argument escape: whether or not to escape special characters in the link text itself
+	// returns: the <a> tag HTML representation of the original `link`
 	*htmlForLink { |link, escape = true|
 		var n, linkAnchor, linkText, c, doc;
 		// FIXME: how slow is this? can we optimize

--- a/SCClassLibrary/SCDoc/SCDocRenderer.sc
+++ b/SCClassLibrary/SCDoc/SCDocRenderer.sc
@@ -141,10 +141,10 @@ SCDocHTMLRenderer {
 			// Process a link that goes to a URL outside the help system
 
 			// If there was no link text, set it to be the same as the original link
-			if(linkText.isEmpty) {linkText = link};
+			if(linkText.isEmpty) { linkText = link };
 
 			// Set the link target to be the link base plus its anchor, if there was one
-			linkTarget = if(spaceEscapedAnchor.isEmpty) {linkBase} {linkBase ++ "#" ++ spaceEscapedAnchor};
+			linkTarget = if(spaceEscapedAnchor.isEmpty) { linkBase } { linkBase ++ "#" ++ spaceEscapedAnchor };
 		} {
 		    // Process a link that goes to a URL within the help system
 

--- a/SCClassLibrary/SCDoc/SCDocRenderer.sc
+++ b/SCClassLibrary/SCDoc/SCDocRenderer.sc
@@ -55,34 +55,34 @@ SCDocHTMLRenderer {
 	// argument escape: whether or not to escape special characters in the link text itself
 	// returns: the <a> tag HTML representation of the original `link`
 	*htmlForLink { |link, escape = true|
-		var n, linkAnchor, linkText, c, doc;
+		var linkBase, linkAnchor, linkText, c, doc;
 		// FIXME: how slow is this? can we optimize
-		#n, linkAnchor, linkText = link.split($#); // link, anchor, label
+		#linkBase, linkAnchor, linkText = link.split($#); // link, anchor, label
 		if(linkAnchor.size > 0) {
 			linkAnchor = this.escapeSpacesInAnchor(linkAnchor);
 		};
 
 		^if("^[a-zA-Z]+://.+".matchRegexp(link) or: (link.first == $/)) {
 			if(linkText.size < 1) {linkText = link};
-			c = if(linkAnchor.size > 0) {n ++ "#" ++ linkAnchor} {n};
+			c = if(linkAnchor.size > 0) {linkBase ++ "#" ++ linkAnchor} {linkBase};
 			if(escape) { linkText = this.escapeSpecialChars(linkText) };
 
 			"<a href=\"" ++ c ++ "\">" ++ linkText ++ "</a>";
 		} {
-			if(n.size>0) {
-				c = baseDir +/+ n;
-				doc = SCDoc.documents[n];
+			if(linkBase.size>0) {
+				c = baseDir +/+ linkBase;
+				doc = SCDoc.documents[linkBase];
 
 				// link to other doc (might not be rendered yet)
 				if(doc.notNil) {
 					c = c ++ ".html";
 				} {
 					// link to ready-made html (Search, Browse, etc)
-					if(File.exists(SCDoc.helpTargetDir +/+ n ++ ".html")) {
+					if(File.exists(SCDoc.helpTargetDir +/+ linkBase ++ ".html")) {
 						c = c ++ ".html";
 					} {
 						// link to other file?
-						if(File.exists(SCDoc.helpTargetDir +/+ n).not) {
+						if(File.exists(SCDoc.helpTargetDir +/+ linkBase).not) {
 							"SCDoc: In %\n"
 							"  Broken link: '%'"
 							.format(currDoc.fullPath, link).warn;
@@ -95,8 +95,8 @@ SCDocHTMLRenderer {
 
 			if(linkAnchor.size > 0) { c = c ++ "#" ++ linkAnchor }; // add #anchor
 			if(linkText.size < 1) { // no label
-				if(n.size > 0) {
-					linkText = if(doc.notNil) {doc.title} {n.basename};
+				if(linkBase.size > 0) {
+					linkText = if(doc.notNil) {doc.title} {linkBase.basename};
 					if(linkAnchor.size > 0) {
 						linkText = linkText ++ ": " ++ linkAnchor;
 					}

--- a/SCClassLibrary/SCDoc/SCDocRenderer.sc
+++ b/SCClassLibrary/SCDoc/SCDocRenderer.sc
@@ -51,7 +51,7 @@ SCDocHTMLRenderer {
 		^str.replace(" ", "%20")
 	}
 
-	*htmlForLink {|link,escape=true|
+	*htmlForLink { |link, escape = true|
 		var n, linkAnchor, linkText, c, doc;
 		// FIXME: how slow is this? can we optimize
 		#n, linkAnchor, linkText = link.split($#); // link, anchor, label

--- a/SCClassLibrary/SCDoc/SCDocRenderer.sc
+++ b/SCClassLibrary/SCDoc/SCDocRenderer.sc
@@ -86,7 +86,7 @@ SCDocHTMLRenderer {
 			if(linkText.isEmpty) {linkText = link};
 
 			// Set the link target to be the link base plus its anchor, if there was one
-			linkTarget = if(spaceEscapedAnchor.isEmpty.not) {linkBase ++ "#" ++ spaceEscapedAnchor} {linkBase};
+			linkTarget = if(spaceEscapedAnchor.isEmpty) {linkBase} {linkBase ++ "#" ++ spaceEscapedAnchor};
 		} {
 		    // Process a link that goes to a URL within the help system
 
@@ -141,7 +141,7 @@ SCDocHTMLRenderer {
 						linkText = linkText ++ ": " ++ linkAnchor;
 					}
 				} {
-					linkText = if(linkAnchor.isEmpty.not) {linkAnchor} {"(empty link)"};
+					linkText = if(linkAnchor.isEmpty) {"(empty link)"} {linkAnchor};
 				};
 			};
 		};

--- a/SCClassLibrary/SCDoc/SCDocRenderer.sc
+++ b/SCClassLibrary/SCDoc/SCDocRenderer.sc
@@ -61,15 +61,18 @@ SCDocHTMLRenderer {
 		if(linkAnchor.size > 0) {
 			linkAnchor = this.escapeSpacesInAnchor(linkAnchor);
 		};
+
 		^if("^[a-zA-Z]+://.+".matchRegexp(link) or: (link.first == $/)) {
 			if(linkText.size < 1) {linkText = link};
 			c = if(linkAnchor.size > 0) {n ++ "#" ++ linkAnchor} {n};
 			if(escape) { linkText = this.escapeSpecialChars(linkText) };
+
 			"<a href=\"" ++ c ++ "\">" ++ linkText ++ "</a>";
 		} {
 			if(n.size>0) {
 				c = baseDir +/+ n;
 				doc = SCDoc.documents[n];
+
 				// link to other doc (might not be rendered yet)
 				if(doc.notNil) {
 					c = c ++ ".html";
@@ -89,6 +92,7 @@ SCDocHTMLRenderer {
 			} {
 				c = ""; // link inside same document
 			};
+
 			if(linkAnchor.size > 0) { c = c ++ "#" ++ linkAnchor }; // add #anchor
 			if(linkText.size < 1) { // no label
 				if(n.size > 0) {

--- a/SCClassLibrary/SCDoc/SCDocRenderer.sc
+++ b/SCClassLibrary/SCDoc/SCDocRenderer.sc
@@ -109,7 +109,7 @@ SCDocHTMLRenderer {
 					if(File.exists(SCDoc.helpTargetDir +/+ linkBase ++ ".html")) {
 						linkTarget = linkTarget ++ ".html";
 					} {
-					    // If the link target doesn't exist as an HTML file, check to see if the
+						// If the link target doesn't exist as an HTML file, check to see if the
 						// raw filepath exists. If it does, do nothing with it -- we're done. If
 						// it doesn't, then consider this a broken link.
 						if(File.exists(SCDoc.helpTargetDir +/+ linkBase).not) {

--- a/SCClassLibrary/SCDoc/SCDocRenderer.sc
+++ b/SCClassLibrary/SCDoc/SCDocRenderer.sc
@@ -51,7 +51,8 @@ SCDocHTMLRenderer {
 		^str.replace(" ", "%20")
 	}
 
-	*linkTargetForLink { |linkBase, originalLink|
+	// Find the target (what goes after href=) for the given link.
+	*prLinkTargetForLink { |linkBase, originalLink|
 		if(linkBase.isEmpty) {
 			^""
 		} {
@@ -82,7 +83,8 @@ SCDocHTMLRenderer {
 		}
 	}
 
-	*linkTextForLink { |linkBase, linkAnchor|
+	// Find the text label for the given link.
+	*prLinkTextForLink { |linkBase, linkAnchor|
 		// If the base was non-empty, generate it by combining the filename and the anchor.
 		// Otherwise, if there was an anchor, use that. Otherwise, use "(empty link)"
 		var result;
@@ -142,13 +144,12 @@ SCDocHTMLRenderer {
 		} {
 		    // Process a link that goes to a URL within the help system
 
-			linkTarget = linkTargetForLink(linkBase, link);
+			linkTarget = this.prLinkTargetForLink(linkBase, link);
 
-			// If there was an anchor, add it to the link target
 			if(spaceEscapedAnchor.isEmpty.not) { linkTarget = linkTarget ++ "#" ++ spaceEscapedAnchor };
 
 			if(linkText.isEmpty) {
-				linkText = linkTextForLink(linkBase, linkAnchor);
+				linkText = this.prLinkTextForLink(linkBase, linkAnchor);
 			}
 		};
 

--- a/SCClassLibrary/SCDoc/SCDocRenderer.sc
+++ b/SCClassLibrary/SCDoc/SCDocRenderer.sc
@@ -58,25 +58,25 @@ SCDocHTMLRenderer {
 		if(linkAnchor.size > 0) {
 			linkAnchor = this.escapeSpacesInAnchor(linkAnchor);
 		};
-		^if ("^[a-zA-Z]+://.+".matchRegexp(link) or: (link.first==$/)) {
-			if(linkText.size<1) {linkText=link};
-			c = if(linkAnchor.size>0) {n++"#"++linkAnchor} {n};
+		^if("^[a-zA-Z]+://.+".matchRegexp(link) or: (link.first == $/)) {
+			if(linkText.size < 1) {linkText = link};
+			c = if(linkAnchor.size > 0) {n ++ "#" ++ linkAnchor} {n};
 			if(escape) { linkText = this.escapeSpecialChars(linkText) };
-			"<a href=\""++c++"\">"++linkText++"</a>";
+			"<a href=\"" ++ c ++ "\">" ++ linkText ++ "</a>";
 		} {
 			if(n.size>0) {
-				c = baseDir+/+n;
+				c = baseDir +/+ n;
 				doc = SCDoc.documents[n];
 				// link to other doc (might not be rendered yet)
 				if(doc.notNil) {
 					c = c ++ ".html";
 				} {
 					// link to ready-made html (Search, Browse, etc)
-					if(File.exists(SCDoc.helpTargetDir+/+n++".html")) {
+					if(File.exists(SCDoc.helpTargetDir +/+ n ++ ".html")) {
 						c = c ++ ".html";
 					} {
 						// link to other file?
-						if(File.exists(SCDoc.helpTargetDir+/+n).not) {
+						if(File.exists(SCDoc.helpTargetDir +/+ n).not) {
 							"SCDoc: In %\n"
 							"  Broken link: '%'"
 							.format(currDoc.fullPath, link).warn;
@@ -86,19 +86,19 @@ SCDocHTMLRenderer {
 			} {
 				c = ""; // link inside same document
 			};
-			if(linkAnchor.size>0) { c = c ++ "#" ++ linkAnchor }; // add #anchor
-			if(linkText.size<1) { // no label
-				if(n.size>0) {
+			if(linkAnchor.size > 0) { c = c ++ "#" ++ linkAnchor }; // add #anchor
+			if(linkText.size < 1) { // no label
+				if(n.size > 0) {
 					linkText = if(doc.notNil) {doc.title} {n.basename};
-					if(linkAnchor.size>0) {
-						linkText = linkText++": "++linkAnchor;
+					if(linkAnchor.size > 0) {
+						linkText = linkText ++ ": " ++ linkAnchor;
 					}
 				} {
-					linkText = if(linkAnchor.size>0) {linkAnchor} {"(empty link)"};
+					linkText = if(linkAnchor.size > 0) {linkAnchor} {"(empty link)"};
 				};
 			};
 			if(escape) { linkText = this.escapeSpecialChars(linkText) };
-			"<a href=\""++c++"\">"++linkText++"</a>";
+			"<a href=\"" ++ c ++ "\">" ++ linkText ++ "</a>";
 		};
 	}
 

--- a/SCClassLibrary/SCDoc/SCDocRenderer.sc
+++ b/SCClassLibrary/SCDoc/SCDocRenderer.sc
@@ -128,7 +128,7 @@ SCDocHTMLRenderer {
 			// If there was an anchor, add it to the link target
 			if(linkAnchor.size > 0) { linkTarget = linkTarget ++ "#" ++ linkAnchor };
 
-			// If there was no label, generate one from the anchor.
+			// If there was no label, generate one from the base and/or anchor.
 			// FIXME: the anchor's spaces have already been escaped here, which causes issue #2337.
 			if(linkText.size < 1) {
 

--- a/SCClassLibrary/SCDoc/SCDocRenderer.sc
+++ b/SCClassLibrary/SCDoc/SCDocRenderer.sc
@@ -64,7 +64,7 @@ SCDocHTMLRenderer {
 	//   "#Key actions"
 	//   "http://qt-project.org/doc/qt-4.8/qt.html#Key-enum"
 	*htmlForLink { |link, escape = true|
-		var linkBase, linkAnchor, linkText, linkTarget;
+		var linkBase, spaceEscapedAnchor, linkAnchor, linkText, linkTarget;
 		// FIXME: how slow is this? can we optimize
 
 		// Get the link base, anchor, and text from the original string
@@ -74,9 +74,7 @@ SCDocHTMLRenderer {
 		linkAnchor = linkAnchor ? "";
 		linkText = linkText ? "";
 
-		if(linkAnchor.empty.not) {
-			linkAnchor = this.escapeSpacesInAnchor(linkAnchor);
-		};
+		spaceEscapedAnchor = this.escapeSpacesInAnchor(linkAnchor);
 
 		// Check whether the link is a URL or a relative path (starts with a `/`),
 		// NOTE: the second condition is not triggered by anything in the core library's
@@ -88,7 +86,7 @@ SCDocHTMLRenderer {
 			if(linkText.isEmpty) {linkText = link};
 
 			// Set the link target to be the link base plus its anchor, if there was one
-			linkTarget = if(linkAnchor.isEmpty.not) {linkBase ++ "#" ++ linkAnchor} {linkBase};
+			linkTarget = if(spaceEscapedAnchor.isEmpty.not) {linkBase ++ "#" ++ spaceEscapedAnchor} {linkBase};
 		} {
 		    // Process a link that goes to a URL within the help system
 
@@ -130,10 +128,9 @@ SCDocHTMLRenderer {
 			};
 
 			// If there was an anchor, add it to the link target
-			if(linkAnchor.isEmpty.not) { linkTarget = linkTarget ++ "#" ++ linkAnchor };
+			if(spaceEscapedAnchor.isEmpty.not) { linkTarget = linkTarget ++ "#" ++ spaceEscapedAnchor };
 
-			// If there was no label, generate one from the base and/or anchor.
-			// FIXME: the anchor's spaces have already been escaped here, which causes issue #2337.
+			// If there was no label, generate one from the base and/or unescaped anchor.
 			if(linkText.isEmpty) {
 
 				// If the base was non-empty, generate it by combining the filename and the anchor.

--- a/SCClassLibrary/SCDoc/SCDocRenderer.sc
+++ b/SCClassLibrary/SCDoc/SCDocRenderer.sc
@@ -55,7 +55,7 @@ SCDocHTMLRenderer {
 	// argument escape: whether or not to escape special characters in the link text itself
 	// returns: the <a> tag HTML representation of the original `link`
 	*htmlForLink { |link, escape = true|
-		var linkBase, linkAnchor, linkText, linkDestination, doc;
+		var linkBase, linkAnchor, linkText, linkTarget, doc;
 		// FIXME: how slow is this? can we optimize
 		#linkBase, linkAnchor, linkText = link.split($#); // link, anchor, label
 		if(linkAnchor.size > 0) {
@@ -64,22 +64,22 @@ SCDocHTMLRenderer {
 
 		^if("^[a-zA-Z]+://.+".matchRegexp(link) or: (link.first == $/)) {
 			if(linkText.size < 1) {linkText = link};
-			linkDestination = if(linkAnchor.size > 0) {linkBase ++ "#" ++ linkAnchor} {linkBase};
+			linkTarget = if(linkAnchor.size > 0) {linkBase ++ "#" ++ linkAnchor} {linkBase};
 			if(escape) { linkText = this.escapeSpecialChars(linkText) };
 
-			"<a href=\"" ++ linkDestination ++ "\">" ++ linkText ++ "</a>";
+			"<a href=\"" ++ linkTarget ++ "\">" ++ linkText ++ "</a>";
 		} {
 			if(linkBase.size>0) {
-				linkDestination = baseDir +/+ linkBase;
+				linkTarget = baseDir +/+ linkBase;
 				doc = SCDoc.documents[linkBase];
 
 				// link to other doc (might not be rendered yet)
 				if(doc.notNil) {
-					linkDestination = linkDestination ++ ".html";
+					linkTarget = linkTarget ++ ".html";
 				} {
 					// link to ready-made html (Search, Browse, etc)
 					if(File.exists(SCDoc.helpTargetDir +/+ linkBase ++ ".html")) {
-						linkDestination = linkDestination ++ ".html";
+						linkTarget = linkTarget ++ ".html";
 					} {
 						// link to other file?
 						if(File.exists(SCDoc.helpTargetDir +/+ linkBase).not) {
@@ -90,10 +90,10 @@ SCDocHTMLRenderer {
 					};
 				};
 			} {
-				linkDestination = ""; // link inside same document
+				linkTarget = ""; // link inside same document
 			};
 
-			if(linkAnchor.size > 0) { linkDestination = linkDestination ++ "#" ++ linkAnchor }; // add #anchor
+			if(linkAnchor.size > 0) { linkTarget = linkTarget ++ "#" ++ linkAnchor }; // add #anchor
 			if(linkText.size < 1) { // no label
 				if(linkBase.size > 0) {
 					linkText = if(doc.notNil) {doc.title} {linkBase.basename};
@@ -105,7 +105,7 @@ SCDocHTMLRenderer {
 				};
 			};
 			if(escape) { linkText = this.escapeSpecialChars(linkText) };
-			"<a href=\"" ++ linkDestination ++ "\">" ++ linkText ++ "</a>";
+			"<a href=\"" ++ linkTarget ++ "\">" ++ linkText ++ "</a>";
 		};
 	}
 

--- a/SCClassLibrary/SCDoc/SCDocRenderer.sc
+++ b/SCClassLibrary/SCDoc/SCDocRenderer.sc
@@ -63,12 +63,12 @@ SCDocHTMLRenderer {
 
 			// If this is an existing document, just add .html to get the target
 			if(doc.notNil) {
-				^result ++ ".html"
+				result = result ++ ".html"
 			} {
 				// If the document doesn't exist according to SCDoc, check the filesystem
 				// to see if the link target is present
 				if(File.exists(SCDoc.helpTargetDir +/+ linkBase ++ ".html")) {
-					^result ++ ".html"
+					result = result ++ ".html"
 				} {
 					// If the link target doesn't exist as an HTML file, check to see if the
 					// raw filepath exists. If it does, do nothing with it -- we're done. If

--- a/SCClassLibrary/SCDoc/SCDocRenderer.sc
+++ b/SCClassLibrary/SCDoc/SCDocRenderer.sc
@@ -52,17 +52,17 @@ SCDocHTMLRenderer {
 	}
 
 	*htmlForLink {|link,escape=true|
-		var n, linkAnchor, f, c, doc;
+		var n, linkAnchor, linkText, c, doc;
 		// FIXME: how slow is this? can we optimize
-		#n, linkAnchor, f = link.split($#); // link, anchor, label
+		#n, linkAnchor, linkText = link.split($#); // link, anchor, label
 		if(linkAnchor.size > 0) {
 			linkAnchor = this.escapeSpacesInAnchor(linkAnchor);
 		};
 		^if ("^[a-zA-Z]+://.+".matchRegexp(link) or: (link.first==$/)) {
-			if(f.size<1) {f=link};
+			if(linkText.size<1) {linkText=link};
 			c = if(linkAnchor.size>0) {n++"#"++linkAnchor} {n};
-			if(escape) { f = this.escapeSpecialChars(f) };
-			"<a href=\""++c++"\">"++f++"</a>";
+			if(escape) { linkText = this.escapeSpecialChars(linkText) };
+			"<a href=\""++c++"\">"++linkText++"</a>";
 		} {
 			if(n.size>0) {
 				c = baseDir+/+n;
@@ -87,18 +87,18 @@ SCDocHTMLRenderer {
 				c = ""; // link inside same document
 			};
 			if(linkAnchor.size>0) { c = c ++ "#" ++ linkAnchor }; // add #anchor
-			if(f.size<1) { // no label
+			if(linkText.size<1) { // no label
 				if(n.size>0) {
-					f = if(doc.notNil) {doc.title} {n.basename};
+					linkText = if(doc.notNil) {doc.title} {n.basename};
 					if(linkAnchor.size>0) {
-						f = f++": "++linkAnchor;
+						linkText = linkText++": "++linkAnchor;
 					}
 				} {
-					f = if(linkAnchor.size>0) {linkAnchor} {"(empty link)"};
+					linkText = if(linkAnchor.size>0) {linkAnchor} {"(empty link)"};
 				};
 			};
-			if(escape) { f = this.escapeSpecialChars(f) };
-			"<a href=\""++c++"\">"++f++"</a>";
+			if(escape) { linkText = this.escapeSpecialChars(linkText) };
+			"<a href=\""++c++"\">"++linkText++"</a>";
 		};
 	}
 

--- a/SCClassLibrary/SCDoc/SCDocRenderer.sc
+++ b/SCClassLibrary/SCDoc/SCDocRenderer.sc
@@ -64,7 +64,7 @@ SCDocHTMLRenderer {
 	//   "#Key actions"
 	//   "http://qt-project.org/doc/qt-4.8/qt.html#Key-enum"
 	*htmlForLink { |link, escape = true|
-		var linkBase, linkAnchor, linkText, linkTarget, doc;
+		var linkBase, linkAnchor, linkText, linkTarget;
 		// FIXME: how slow is this? can we optimize
 
 		// Get the link base, anchor, and text from the original string
@@ -88,14 +88,17 @@ SCDocHTMLRenderer {
 		} {
 		    // Process a link that goes to a URL within the help system
 
+			// The document referred to by this link
+			var doc = nil;
+
 			// If the link base is non-empty, it is a link to something in another document
 			if(linkBase.size>0) {
 
-				// Find the document referred to by this link
-				doc = SCDoc.documents[linkBase];
-
 				// Compose the target as being relative to the help system base directory
 				linkTarget = baseDir +/+ linkBase;
+
+				// Find the document referred to by this link
+				doc = SCDoc.documents[linkBase];
 
 				// If this is an existing document, just add .html to get the target
 				if(doc.notNil) {

--- a/SCClassLibrary/SCDoc/SCDocRenderer.sc
+++ b/SCClassLibrary/SCDoc/SCDocRenderer.sc
@@ -65,9 +65,6 @@ SCDocHTMLRenderer {
 		^if("^[a-zA-Z]+://.+".matchRegexp(link) or: (link.first == $/)) {
 			if(linkText.size < 1) {linkText = link};
 			linkTarget = if(linkAnchor.size > 0) {linkBase ++ "#" ++ linkAnchor} {linkBase};
-			if(escape) { linkText = this.escapeSpecialChars(linkText) };
-
-			"<a href=\"" ++ linkTarget ++ "\">" ++ linkText ++ "</a>";
 		} {
 			if(linkBase.size>0) {
 				linkTarget = baseDir +/+ linkBase;
@@ -104,9 +101,10 @@ SCDocHTMLRenderer {
 					linkText = if(linkAnchor.size > 0) {linkAnchor} {"(empty link)"};
 				};
 			};
-			if(escape) { linkText = this.escapeSpecialChars(linkText) };
-			"<a href=\"" ++ linkTarget ++ "\">" ++ linkText ++ "</a>";
 		};
+
+		if(escape) { linkText = this.escapeSpecialChars(linkText) };
+		^"<a href=\"" ++ linkTarget ++ "\">" ++ linkText ++ "</a>";
 	}
 
 	*makeArgString {|m, par=true|

--- a/SCClassLibrary/SCDoc/SCDocRenderer.sc
+++ b/SCClassLibrary/SCDoc/SCDocRenderer.sc
@@ -55,7 +55,7 @@ SCDocHTMLRenderer {
 	// argument escape: whether or not to escape special characters in the link text itself
 	// returns: the <a> tag HTML representation of the original `link`
 	*htmlForLink { |link, escape = true|
-		var linkBase, linkAnchor, linkText, c, doc;
+		var linkBase, linkAnchor, linkText, linkDestination, doc;
 		// FIXME: how slow is this? can we optimize
 		#linkBase, linkAnchor, linkText = link.split($#); // link, anchor, label
 		if(linkAnchor.size > 0) {
@@ -64,22 +64,22 @@ SCDocHTMLRenderer {
 
 		^if("^[a-zA-Z]+://.+".matchRegexp(link) or: (link.first == $/)) {
 			if(linkText.size < 1) {linkText = link};
-			c = if(linkAnchor.size > 0) {linkBase ++ "#" ++ linkAnchor} {linkBase};
+			linkDestination = if(linkAnchor.size > 0) {linkBase ++ "#" ++ linkAnchor} {linkBase};
 			if(escape) { linkText = this.escapeSpecialChars(linkText) };
 
-			"<a href=\"" ++ c ++ "\">" ++ linkText ++ "</a>";
+			"<a href=\"" ++ linkDestination ++ "\">" ++ linkText ++ "</a>";
 		} {
 			if(linkBase.size>0) {
-				c = baseDir +/+ linkBase;
+				linkDestination = baseDir +/+ linkBase;
 				doc = SCDoc.documents[linkBase];
 
 				// link to other doc (might not be rendered yet)
 				if(doc.notNil) {
-					c = c ++ ".html";
+					linkDestination = linkDestination ++ ".html";
 				} {
 					// link to ready-made html (Search, Browse, etc)
 					if(File.exists(SCDoc.helpTargetDir +/+ linkBase ++ ".html")) {
-						c = c ++ ".html";
+						linkDestination = linkDestination ++ ".html";
 					} {
 						// link to other file?
 						if(File.exists(SCDoc.helpTargetDir +/+ linkBase).not) {
@@ -90,10 +90,10 @@ SCDocHTMLRenderer {
 					};
 				};
 			} {
-				c = ""; // link inside same document
+				linkDestination = ""; // link inside same document
 			};
 
-			if(linkAnchor.size > 0) { c = c ++ "#" ++ linkAnchor }; // add #anchor
+			if(linkAnchor.size > 0) { linkDestination = linkDestination ++ "#" ++ linkAnchor }; // add #anchor
 			if(linkText.size < 1) { // no label
 				if(linkBase.size > 0) {
 					linkText = if(doc.notNil) {doc.title} {linkBase.basename};
@@ -105,7 +105,7 @@ SCDocHTMLRenderer {
 				};
 			};
 			if(escape) { linkText = this.escapeSpecialChars(linkText) };
-			"<a href=\"" ++ c ++ "\">" ++ linkText ++ "</a>";
+			"<a href=\"" ++ linkDestination ++ "\">" ++ linkText ++ "</a>";
 		};
 	}
 

--- a/SCClassLibrary/SCDoc/SCDocRenderer.sc
+++ b/SCClassLibrary/SCDoc/SCDocRenderer.sc
@@ -84,10 +84,14 @@ SCDocHTMLRenderer {
 	}
 
 	// Find the text label for the given link.
-	*prLinkTextForLink { |linkBase, linkAnchor|
+	*prLinkTextForLink { |linkBase, linkAnchor, linkText|
+		// Immediately return link text if available
+		if(linkText.isEmpty.not) {
+			^linkText
+		};
+
 		// If the base was non-empty, generate it by combining the filename and the anchor.
 		// Otherwise, if there was an anchor, use that. Otherwise, use "(empty link)"
-		var result;
 		if(linkBase.isEmpty) {
 			if(linkAnchor.isEmpty) {
 				^"(empty link)"
@@ -148,9 +152,7 @@ SCDocHTMLRenderer {
 
 			if(spaceEscapedAnchor.isEmpty.not) { linkTarget = linkTarget ++ "#" ++ spaceEscapedAnchor };
 
-			if(linkText.isEmpty) {
-				linkText = this.prLinkTextForLink(linkBase, linkAnchor);
-			}
+			linkText = this.prLinkTextForLink(linkBase, linkAnchor, linkText);
 		};
 
 		// Escape special characters in the link text if requested

--- a/SCClassLibrary/SCDoc/SCDocRenderer.sc
+++ b/SCClassLibrary/SCDoc/SCDocRenderer.sc
@@ -83,6 +83,15 @@ SCDocHTMLRenderer {
 		}
 	}
 
+	// Creates a link target for a link that points outside of the help system
+	*prLinkTargetForExternalLink { |linkBase, linkAnchor|
+		if(linkAnchor.isEmpty) {
+			^linkBase
+		} {
+			^linkBase ++ "#" ++ this.escapeSpacesInAnchor(linkAnchor);
+		}
+	}
+
 	// Find the text label for the given link.
 	*prLinkTextForLink { |linkBase, linkAnchor, linkText|
 		// Immediately return link text if available
@@ -143,8 +152,7 @@ SCDocHTMLRenderer {
 			// If there was no link text, set it to be the same as the original link
 			if(linkText.isEmpty) { linkText = link };
 
-			// Set the link target to be the link base plus its anchor, if there was one
-			linkTarget = if(spaceEscapedAnchor.isEmpty) { linkBase } { linkBase ++ "#" ++ spaceEscapedAnchor };
+			linkTarget = this.prLinkTargetForExternalLink(linkBase, linkAnchor);
 		} {
 		    // Process a link that goes to a URL within the help system
 

--- a/testsuite/classlibrary/TestSCDocHTMLRenderer.sc
+++ b/testsuite/classlibrary/TestSCDocHTMLRenderer.sc
@@ -80,4 +80,18 @@ TestSCDocHTMLRenderer : UnitTest {
 		this.assert(result == expected, "Got %, expected %".format(result, expected));
 	}
 
+	// empty link
+	test_htmlForLink_emptyLink {
+		var result = SCDocHTMLRenderer.htmlForLink("");
+		var expected = "<a href=\"\">(empty link)</a>";
+		this.assert(result == expected, "Got %, expected %".format(result, expected));
+	}
+
+	// empty link, with empty anchor and text
+	test_htmlForLink_emptyLinkWithAnchorAndText {
+		var result = SCDocHTMLRenderer.htmlForLink("##");
+		var expected = "<a href=\"\">(empty link)</a>";
+		this.assert(result == expected, "Got %, expected %".format(result, expected));
+	}
+
 }

--- a/testsuite/classlibrary/TestSCDocHTMLRenderer.sc
+++ b/testsuite/classlibrary/TestSCDocHTMLRenderer.sc
@@ -1,0 +1,83 @@
+// TestSCDocHTMLRenderer.sc
+// Brian Heim
+// 2017-07-12
+
+TestSCDocHTMLRenderer : UnitTest {
+
+	var didSetUp = false;
+
+	setUp {
+		if(didSetUp.not) {
+			"%: Performing one-time setup to simulate runtime conditions\n".postf(this.class);
+
+			if(SCDoc.didIndexDocuments.not) {
+				SCDoc.indexAllDocuments;
+			};
+
+			// setup: we need to get the renderer to calculate its 'baseDir' property
+			// so that we can safely call htmlForLink
+			SCDoc.parseAndRender(SCDoc.documents["Classes/View"]);
+
+			didSetUp = true;
+		}
+	}
+
+	/*******************************/
+	/**** tests for htmlForLink ****/
+	/*******************************/
+
+	// external link tests
+
+	test_htmlForLink_externalLink {
+		var result = SCDocHTMLRenderer.htmlForLink("http://example.org");
+		var expected = "<a href=\"http://example.org\">http://example.org</a>";
+		this.assert(result == expected, "Got %, expected %".format(result, expected));
+	}
+
+	test_htmlForLink_externalLinkWithLabel {
+		var result = SCDocHTMLRenderer.htmlForLink("http://example.org##Example Website");
+		var expected = "<a href=\"http://example.org\">Example Website</a>";
+		this.assert(result == expected, "Got %, expected %".format(result, expected));
+	}
+
+	test_htmlForLink_externalLinkWithAnchor {
+		var result = SCDocHTMLRenderer.htmlForLink("http://example.org#Anchor");
+		var expected = "<a href=\"http://example.org#Anchor\">http://example.org#Anchor</a>";
+		this.assert(result == expected, "Got %, expected %".format(result, expected));
+	}
+
+	test_htmlForLink_externalLinkWithAnchorAndLabel {
+		var result = SCDocHTMLRenderer.htmlForLink("http://example.org#Anchor#Anchored example");
+		var expected = "<a href=\"http://example.org#Anchor\">Anchored example</a>";
+		this.assert(result == expected, "Got %, expected %".format(result, expected));
+	}
+
+	// inernal link tests
+
+	test_htmlForLink_internalLink {
+		var result = SCDocHTMLRenderer.htmlForLink("Classes/View");
+		var expected = "<a href=\"./../Classes/View.html\">View</a>";
+		this.assert(result == expected, "Got %, expected %".format(result, expected));
+	}
+
+	test_htmlForLink_internalLinkWithLabel {
+		var result = SCDocHTMLRenderer.htmlForLink("Classes/View##view class");
+		var expected = "<a href=\"./../Classes/View.html\">view class</a>";
+		this.assert(result == expected, "Got %, expected %".format(result, expected));
+	}
+
+	// The link target should have escaped spaces, but the text should not
+	test_htmlForLink_internalLinkWithAnchor {
+		var result = SCDocHTMLRenderer.htmlForLink("Classes/View#Mouse actions");
+		var expected = "<a href=\"./../Classes/View.html#Mouse%20actions\">View: Mouse actions</a>";
+		this.assert(result == expected, "Got %, expected %".format(result, expected));
+	}
+
+	// The link target should have escaped spaces, but the text should not
+	test_htmlForLink_internalLinkWithAnchorAndLabel {
+		var result = SCDocHTMLRenderer.htmlForLink("Classes/View#Mouse actions#Hobbledy gobbledy");
+		var expected = "<a href=\"./../Classes/View.html#Mouse%20actions\">Hobbledy gobbledy</a>";
+		this.assert(result == expected, "Got %, expected %".format(result, expected));
+	}
+
+}


### PR DESCRIPTION
Fixes #2337.

## Problem

Some schelp links are rendered in text with `%20` in some cases and not in others. We don't want to see those.

## Solution

This PR rewrites the `htmlForLink` method so that it is more readable, and factors some complicated logic into encapsulated helper methods. It also adds in-source comments so that the behavior and expectations of each method is clear. The problem was that an escaped version of the anchor text was used to fill in a missing link label, but the method should have just used the original anchor. https://github.com/brianlheim/supercollider/commit/b34d80535e3e049d88bd744c9952551f1ed8632e shows where I made the fix.

## Other notes

I added tests for this method to target behavior under most conditions (internal and external links, with/out anchor and/or label). They all pass for this PR, and they all pass for the previous implementation, except for the one that targets #2337:

```
UNIT TEST.............
There were failures:
a TestSCDocHTMLRenderer:test_htmlForLink_internalLinkWithAnchor - Got <a href="./../Classes/View.html#Mouse%20actions">View: Mouse%20actions</a>, expected <a href="./../Classes/View.html#Mouse%20actions">View: Mouse actions</a>
```

I also updated the scdoc version number as requested by the turtle :)