### PR TITLE
class library: DeprecatedError posts method path

### DIFF
--- a/SCClassLibrary/Common/Core/Error.sc
+++ b/SCClassLibrary/Common/Core/Error.sc
@@ -237,7 +237,7 @@ DeprecatedError : MethodError {
 			};
 			if(backtrace.notNil) { backtrace.tryPerform(\functionDef) };
 		};
-		var caller, string, path;
+		var caller, string;
 		if(protectedBacktrace.notNil) {
 			caller = searchForCaller.value(protectedBacktrace, method);
 		};
@@ -257,13 +257,13 @@ DeprecatedError : MethodError {
 			caller,
 			methodSignature.value(method)
 		);
-		if(alternateMethod.notNil, {
+		if(alternateMethod.notNil) {
 			string = string + "Use" + methodSignature.value(alternateMethod) + "instead.";
-		});
+		};
 
 		string = string ++ "\nThe definition of '%' is to be found here: '%'".format(method, method.filenameSymbol);
 
-		^string;
+		^string
 	}
 
 	reportError {

--- a/SCClassLibrary/Common/Core/Error.sc
+++ b/SCClassLibrary/Common/Core/Error.sc
@@ -237,7 +237,7 @@ DeprecatedError : MethodError {
 			};
 			if(backtrace.notNil) { backtrace.tryPerform(\functionDef) };
 		};
-		var caller, string;
+		var caller, string, path;
 		if(protectedBacktrace.notNil) {
 			caller = searchForCaller.value(protectedBacktrace, method);
 		};
@@ -260,6 +260,9 @@ DeprecatedError : MethodError {
 		if(alternateMethod.notNil, {
 			string = string + "Use" + methodSignature.value(alternateMethod) + "instead.";
 		});
+
+		string = string ++ "\nThe definition of '%' is to be found here: '%'".format(method, method.filenameSymbol);
+
 		^string;
 	}
 


### PR DESCRIPTION
This makes it easier to find where the error comes from.

For a typical case, see #3038.