### PR TITLE
SC-IDE: Display the right-click tab menu in the right spot.

### DIFF
--- a/editors/sc-ide/widgets/multi_editor.cpp
+++ b/editors/sc-ide/widgets/multi_editor.cpp
@@ -254,7 +254,7 @@ void EditorTabBar::showContextMenu(QMouseEvent * event)
         menu->addAction(tr("Close Tabs to the Right"), this, SLOT(onCloseTabsToTheRight()));
     }
 
-    menu->popup(event->pos());
+    menu->popup(event->screenPos().toPoint());
 }
 
 void EditorTabBar::onCloseTab()


### PR DESCRIPTION
event->pos() is relative to the widget, but menu->popup() takes an
absolute position. Using event->screenPos() displays the menu in the
correct location.

Fixes #3042