### PR TITLE
Help browser: add shortcuts for back, forward

### DIFF
--- a/editors/sc-ide/widgets/help_browser.cpp
+++ b/editors/sc-ide/widgets/help_browser.cpp
@@ -145,6 +145,10 @@ void HelpBrowser::applySettings( Settings::Manager *settings )
 {
     settings->beginGroup("IDE/shortcuts");
 
+    mWebView->pageAction(QWebPage::Back)->setShortcut( QKeySequence(QKeySequence::Back) );
+
+    mWebView->pageAction(QWebPage::Forward)->setShortcut( QKeySequence(QKeySequence::Forward) );
+
     mActions[DocClose]->setShortcut( settings->shortcut("ide-document-close") );
 
     mActions[ZoomIn]->setShortcut( settings->shortcut("editor-enlarge-font") );

--- a/editors/sc-ide/widgets/help_browser.cpp
+++ b/editors/sc-ide/widgets/help_browser.cpp
@@ -145,9 +145,9 @@ void HelpBrowser::applySettings( Settings::Manager *settings )
 {
     settings->beginGroup("IDE/shortcuts");
 
-    mWebView->pageAction(QWebPage::Back)->setShortcut( QKeySequence(QKeySequence::Back) );
+    mWebView->pageAction(QWebPage::Back)->setShortcut( QKeySequence::Back );
 
-    mWebView->pageAction(QWebPage::Forward)->setShortcut( QKeySequence(QKeySequence::Forward) );
+    mWebView->pageAction(QWebPage::Forward)->setShortcut( QKeySequence::Forward );
 
     mActions[DocClose]->setShortcut( settings->shortcut("ide-document-close") );
 


### PR DESCRIPTION
Fixes #680, using the default QKeySequence::Back & Forward.

On macOS, these map to `Cmd-[` and `Cmd-]`.

You can see what these map to per OS here: http://doc.qt.io/qt-5.9/qkeysequence.html#standard-shortcuts.

These don't seem to collide with any existing shortcuts.