### PR TITLE
clean build: remove unused variables and functions

### DIFF
--- a/editors/sc-ide/core/session_manager.cpp
+++ b/editors/sc-ide/core/session_manager.cpp
@@ -30,20 +30,6 @@
 
 namespace ScIDE {
 
-static QString sessionFilePath( const QString & name )
-{
-    QDir dir(standardDirectory(ScConfigUserDir));
-
-    if (!dir.mkpath("sessions")) {
-        qWarning("The path to sessions does not exist and could not be created!");
-        return QString();
-    }
-
-    dir.cd("sessions");
-
-    return dir.filePath(name + ".yaml");
-}
-
 SessionManager::SessionManager( DocumentManager *docMng, QObject * parent ) :
     QObject(parent),
     mDocMng(docMng),

--- a/editors/sc-ide/widgets/code_editor/autocompleter.cpp
+++ b/editors/sc-ide/widgets/code_editor/autocompleter.cpp
@@ -559,7 +559,6 @@ CompletionMenu * AutoCompleter::menuForClassMethodCompletion(CompletionDescripti
                                                              ScCodeEditor * editor)
 {
     using namespace ScLanguage;
-    const Introspection & introspection = Main::scProcess()->introspection();
 
     const Class *klass = NULL;
 
@@ -826,7 +825,6 @@ void AutoCompleter::updateCompletionMenuInfo()
 void AutoCompleter::triggerMethodCallAid( bool explicitTrigger )
 {
     using namespace ScLanguage;
-    const Introspection & introspection = Main::scProcess()->introspection();
 
     if (!mMethodCall.menu.isNull()) {
         qDebug("Method call: disambiguation menu already shown. Aborting.");

--- a/editors/sc-ide/widgets/code_editor/completion_menu.cpp
+++ b/editors/sc-ide/widgets/code_editor/completion_menu.cpp
@@ -131,7 +131,6 @@ bool CompletionMenu::eventFilter(QObject * obj, QEvent * ev)
 {
     if (isVisible() && obj == parentWidget() && ev->type() == QEvent::KeyPress)
     {
-        bool filtered = false;
         static int oldIndex = 0;
 
         QKeyEvent *kev = static_cast<QKeyEvent*>(ev);

--- a/editors/sc-ide/widgets/code_editor/sc_editor.cpp
+++ b/editors/sc-ide/widgets/code_editor/sc_editor.cpp
@@ -36,8 +36,6 @@
 
 namespace ScIDE {
 
-static void matchBracket( const TokenIterator & bracket, BracketPair & match );
-
 ScCodeEditor::ScCodeEditor( Document *doc, QWidget *parent ) :
     GenericCodeEditor( doc, parent ),
     mSpaceIndent(true),

--- a/editors/sc-ide/widgets/code_editor/sc_editor.cpp
+++ b/editors/sc-ide/widgets/code_editor/sc_editor.cpp
@@ -1092,15 +1092,6 @@ void ScCodeEditor::nextBracketPair( const TokenIterator & startIt, BracketPair &
     bracketPair = BracketPair();
 }
 
-inline static bool bracketPairContainsPosition( const BracketPair & bracketPair, int position )
-{
-    bool result =
-            bracketPair.first.isValid() && bracketPair.second.isValid()
-            && bracketPair.first.position() < position
-            && bracketPair.second.position() >= position;
-    return result;
-}
-
 void ScCodeEditor::gotoNextBlock()
 {
     QTextCursor cursor = textCursor();

--- a/editors/sc-ide/widgets/style/style.cpp
+++ b/editors/sc-ide/widgets/style/style.cpp
@@ -284,9 +284,6 @@ void Style::drawPrimitive
     case QStyle::PE_FrameTabBarBase: {
         const QTabBar *tabBar = qobject_cast<const QTabBar*>(widget);
 
-        const QStyleOptionTabBarBase *tabBarBaseOption =
-                static_cast<const QStyleOptionTabBarBase*>(option);
-
         painter->save();
 
         painter->setPen(Qt::NoPen);


### PR DESCRIPTION
Toward #2927.

I did my best to inspect the blame/log for anything that might hint at a better use for these variables, but couldn't spot anything. I think it's better to just remove them. One function is basically duplicated by another function below (fd1d2eb), the other is almost trivial to write if it's ever needed again (c9cd6f2).