### PR TITLE
Clean build: remove some compiler warnings

### DIFF
--- a/common/SC_Apple.mm
+++ b/common/SC_Apple.mm
@@ -38,7 +38,7 @@ void disableAppNap ( )
 		uint64_t options = (0x00FFFFFFULL | (1ULL << 20)) | 0xFF00000000ULL;
 
 		// NSActivityLatencyCritical | NSActivityUserInitiated
-	    id activity = [[NSProcessInfo processInfo] beginActivityWithOptions: options reason:@"avoiding audio hiccups and reducing latency"];
+	    [[NSProcessInfo processInfo] beginActivityWithOptions: options reason:@"avoiding audio hiccups and reducing latency"];
 	}	
 }
 

--- a/common/SC_OscUtils.hpp
+++ b/common/SC_OscUtils.hpp
@@ -200,7 +200,7 @@ static void dumpOSC(int mode, int size, char* inData)
 	if (mode & 2) hexdump(size, inData);
 }
 
-
+#if 0 // debugging code
 static void DumpReplyAddress(ReplyAddress *inReplyAddress)
 {
 	scprintf("mAddress %s\n", inReplyAddress->mAddress.to_string().c_str());
@@ -214,5 +214,6 @@ static void DumpReplyAddress(ReplyAddress *inReplyAddress)
 
 	scprintf("mReplyFunc %p\n", (void*)inReplyAddress->mReplyFunc);
 }
+#endif
 
 #endif // SC_OSCUTILS_HPP

--- a/common/SC_fftlib.cpp
+++ b/common/SC_fftlib.cpp
@@ -300,7 +300,9 @@ scfft * scfft_create(size_t fullsize, size_t winsize, SCFFT_WindowFunction winty
 void scfft_ensurewindow(unsigned short log2_fullsize, unsigned short log2_winsize, short wintype)
 {
 	// Ensure we have enough space to do our calcs
+#if SC_FFT_FFTW
 	int old_log2n = largest_log2n;
+#endif
 	if(log2_fullsize > largest_log2n){
 		largest_log2n = log2_fullsize;
 		largest_fftsize = 1 << largest_log2n;

--- a/editors/sc-ide/core/sc_process.cpp
+++ b/editors/sc-ide/core/sc_process.cpp
@@ -399,7 +399,7 @@ void ScProcess::updateTextMirrorForDocument ( Document * doc, int position, int 
     if (!mIpcSocket)
         return;
 
-    if (mIpcSocket->state() != QAbstractSocket::ConnectedState)
+    if (mIpcSocket->state() != QLocalSocket::ConnectedState)
         return;
 
     QVariantList argList;
@@ -424,7 +424,7 @@ void ScProcess::updateSelectionMirrorForDocument ( Document * doc, int start, in
     if (!mIpcSocket)
         return;
 
-    if (mIpcSocket->state() != QAbstractSocket::ConnectedState)
+    if (mIpcSocket->state() != QLocalSocket::ConnectedState)
         return;
 
     QVariantList argList;


### PR DESCRIPTION
Toward #2927.

- use correct enum for comparison between values in IDE
- remove assignment to an unused variable
- deactivate a good but unused debugging function via `#if 0`
- move a variable inside a preprocessor guard that would otherwise be unused

This eliminates 5 clang warnings.