### PR TITLE
document distort formula in the Operators Overview

### DIFF
--- a/HelpSource/Overviews/Operators.schelp
+++ b/HelpSource/Overviews/Operators.schelp
@@ -231,6 +231,11 @@ Hyperbolic tangent.
 method:: distort
 Nonlinear distortion.
 discussion::
+The formula used is :
+code::
+x / (1 + abs(x))
+::
+Here is an example :
 code::
 (
 {


### PR DESCRIPTION
Following on the discussion from sc-users about documenting the distort formula.
I added this change to `/Applications/SuperCollider.app/Contents/Resources/HelpSource/Overviews/Operators.schelp` and reloaded the Operator Overview page in the IDE and it seemed to be doing what I thought it should do.
I'm on SuperCollider 3.7.2 FWIW