### PR TITLE
Remove a compiler warning and add documentation

### DIFF
--- a/HelpSource/Classes/EnvelopeView.schelp
+++ b/HelpSource/Classes/EnvelopeView.schelp
@@ -254,7 +254,7 @@ METHOD:: index
 		An Integer.
 
 METHOD:: lastIndex
-    The last node selected, regardless of the current state of selection.
+    The last node selected, regardless of the current state of selection, or -1 if no node has yet been selected.
 
 
 METHOD:: selectIndex

--- a/QtCollider/widgets/QcGraph.cpp
+++ b/QtCollider/widgets/QcGraph.cpp
@@ -444,19 +444,25 @@ void QcGraph::setIndexSelected( int index, bool select )
 {
   Q_ASSERT( index >= 0 && index < _model.elementCount() );
 
+  // exit early if the element's selection status is already correct
   QcGraphElement *e = _model.elementAt( index );
-  if( e->selected == select ) return;
+  if( e->selected == select )
+    return;
 
   if( select ) {
     e->selected = true;
-    int c = _model.elementCount();
-    int si = 0;
-    int i = 0;
-    while( i < index ) {
-      if( _model.elementAt(i)->selected ) ++si;
-      ++i;
+
+    // insert this node into the list of selected elements to the right
+    // of any already selected nodes
+    int numSelectedNodes = 0;
+    for ( int i = 0; i < index; ++i ) {
+      if( _model.elementAt(i)->selected )
+        ++numSelectedNodes;
     }
-    _selection.elems.insert( si, SelectedElement(e) );
+
+    _selection.elems.insert( numSelectedNodes, SelectedElement(e) );
+
+    // mark this as the last index selected
     _lastIndex = index;
   }
   else {

--- a/QtCollider/widgets/QcGraph.cpp
+++ b/QtCollider/widgets/QcGraph.cpp
@@ -452,8 +452,8 @@ void QcGraph::setIndexSelected( int index, bool select )
   if( select ) {
     e->selected = true;
 
-    // insert this node into the list of selected elements to the right
-    // of any already selected nodes
+    // insert this node into the list of selected elements after selected
+    // nodes with lower indices. Maintains that the list is sorted.
     int numSelectedNodes = 0;
     for ( int i = 0; i < index; ++i ) {
       if( _model.elementAt(i)->selected )

--- a/QtCollider/widgets/QcGraph.h
+++ b/QtCollider/widgets/QcGraph.h
@@ -196,6 +196,11 @@ class QcGraph : public QWidget, QcHelper, QtCollider::Style::Client
     QVariantList value() const;
     QcGraphElement *currentElement() const;
     int index() const;
+
+    /** \brief The last node selected, regardless of current selection status.
+     *
+     * If no nodes have been selected yet, defaults to -1.
+     */
     int lastIndex() const { return _lastIndex; }
     QVariantList selectionIndexes() const;
     float currentX() const;
@@ -332,7 +337,7 @@ class QcGraph : public QWidget, QcHelper, QtCollider::Style::Client
       QPointF moveOrigin; // in data domain
     } _selection;
 
-    int _lastIndex;
+    int _lastIndex; ///< The last node selected, regardless of the current state of selection
 };
 
 #endif

--- a/QtCollider/widgets/QcGraph.h
+++ b/QtCollider/widgets/QcGraph.h
@@ -276,7 +276,17 @@ class QcGraph : public QWidget, QcHelper, QtCollider::Style::Client
 
   private:
     void setAllDeselected();
+
+    /** \brief Sets a node as being either selected or unselected.
+     *
+     * \c update() is called at the end of the function.
+     *
+     * \param index the index of the node to update
+     * \param selected whether to mark it as selected or not
+     * \post \c lastIndex() returns \c index if the node was newly selected.
+     */
     void setIndexSelected( int index, bool selected );
+
     void restrictValue( QPointF & );
     void orderRestrictValue( QcGraphElement *, QPointF &, bool selected );
     void setValue( QcGraphElement *, const QPointF & );


### PR DESCRIPTION
This removes a compiler warning ("c") from `QcGraph::setSelectedIndex`, and documents related methods.

Toward #2927.