### PR TITLE
Eliminate a compiler warning in SC_CoreMIDI.cpp

### DIFF
--- a/lang/LangPrimSource/SC_CoreMIDI.cpp
+++ b/lang/LangPrimSource/SC_CoreMIDI.cpp
@@ -562,23 +562,26 @@ int prListMIDIEndpoints(struct VMGlobals *g, int numArgsPushed)
 int prConnectMIDIIn(struct VMGlobals *g, int numArgsPushed);
 int prConnectMIDIIn(struct VMGlobals *g, int numArgsPushed)
 {
-	//PyrSlot *a = g->sp - 2;
-	PyrSlot *b = g->sp - 1;
-	PyrSlot *c = g->sp;
+	PyrSlot *inputIndexSlot = g->sp - 1;
+	PyrSlot *uidSlot = g->sp;
 
 	int err, inputIndex, uid;
-	err = slotIntVal(b, &inputIndex);
-	if (err) return errWrongType;
-	if (inputIndex < 0 || inputIndex >= gNumMIDIInPorts) return errIndexOutOfRange;
 
-	err = slotIntVal(c, &uid);
-	if (err) return errWrongType;
+	err = slotIntVal(inputIndexSlot, &inputIndex);
+	if (err)
+		return errWrongType;
+	if (inputIndex < 0 || inputIndex >= gNumMIDIInPorts)
+		return errIndexOutOfRange;
 
+	err = slotIntVal(uidSlot, &uid);
+	if (err)
+		return errWrongType;
 
-	MIDIEndpointRef src=0;
+	MIDIEndpointRef src = 0;
 	MIDIObjectType mtype;
 	MIDIObjectFindByUniqueID(uid, &src, &mtype);
-	if (mtype != kMIDIObjectType_Source) return errFailed;
+	if (mtype != kMIDIObjectType_Source)
+		return errFailed;
 
 	// MIDIPortConnectSource's third parameter is just a unique value used to help
 	// identify the source. It expects a void*, so we reinterpret_cast from uid to
@@ -588,6 +591,7 @@ int prConnectMIDIIn(struct VMGlobals *g, int numArgsPushed)
 
 	return errNone;
 }
+
 int prDisconnectMIDIIn(struct VMGlobals *g, int numArgsPushed);
 int prDisconnectMIDIIn(struct VMGlobals *g, int numArgsPushed)
 {

--- a/lang/LangPrimSource/SC_CoreMIDI.cpp
+++ b/lang/LangPrimSource/SC_CoreMIDI.cpp
@@ -580,9 +580,11 @@ int prConnectMIDIIn(struct VMGlobals *g, int numArgsPushed)
 	MIDIObjectFindByUniqueID(uid, &src, &mtype);
 	if (mtype != kMIDIObjectType_Source) return errFailed;
 
-	//pass the uid to the midiReadProc to identify the src
-
-	MIDIPortConnectSource(gMIDIInPort[inputIndex], src, (void*)uid);
+	// MIDIPortConnectSource's third parameter is just a unique value used to help
+	// identify the source. It expects a void*, so we reinterpret_cast from uid to
+	// avoid a compiler warning.
+	// See: https://stackoverflow.com/questions/9051292/midireadproc-using-srcconnrefcon-to-listen-to-only-one-source
+	MIDIPortConnectSource(gMIDIInPort[inputIndex], src, reinterpret_cast<void*>(uid));
 
 	return errNone;
 }


### PR DESCRIPTION
The warning was on casting from `int` to `void*`, which is a wider type on 64-bit systems.

Also renotated the method body for clarity.

Honestly not very familiar with the C++-style casts, so I'm not sure if I used the right tool here, but in any case I wanted to leave an explanatory comment based on my research.