### PR TITLE
Clean build: remove unused variables

### DIFF
--- a/QtCollider/widgets/QcGraph.cpp
+++ b/QtCollider/widgets/QcGraph.cpp
@@ -749,7 +749,6 @@ void QcGraph::addCurve( QPainterPath &path, QcGraphElement *e1, QcGraphElement *
 
     path.moveTo( pt1 );
 
-    float dx = (pt2.x() - pt1.x());
     float dy = (pt2.y() - pt1.y());
 
     // prevent NaN, optimize

--- a/QtCollider/widgets/QcScopeShm.cpp
+++ b/QtCollider/widgets/QcScopeShm.cpp
@@ -236,7 +236,6 @@ void QcScopeShm::paint1D( bool overlapped, int chanCount, int maxFrames, int fra
   {
     int w = area.width();
     float fpp = frameCount / (float) w; // frames per x pixel
-    float ypix = yRatio != 0.f ? -1/yRatio : 0.f; // value per y pixel;
 
     for( int ch = 0; ch < chanCount; ch++ )
     {

--- a/lang/LangPrimSource/OSCData.cpp
+++ b/lang/LangPrimSource/OSCData.cpp
@@ -89,7 +89,7 @@ inline bool IsBundle(char* ptr)
 
 const int ivxNetAddr_Hostaddr = 0;
 const int ivxNetAddr_PortID = 1;
-const int ivxNetAddr_Hostname = 2;
+// const int ivxNetAddr_Hostname = 2; // unused
 const int ivxNetAddr_Socket = 3;
 
 static int makeSynthMsgWithTags(big_scpacket *packet, PyrSlot *slots, int size);

--- a/lang/LangPrimSource/PyrArrayPrimitives.cpp
+++ b/lang/LangPrimSource/PyrArrayPrimitives.cpp
@@ -895,7 +895,6 @@ int prArrayInsert(struct VMGlobals *g, int numArgsPushed)
 
 	array = slotRawObject(a);
 	const int format = slotRawObject(a)->obj_format;
-	const int tag = gFormatElemTag[format];
 
 	const int size = array->size;
 	int index = slotRawInt(b);

--- a/lang/LangPrimSource/PyrSched.cpp
+++ b/lang/LangPrimSource/PyrSched.cpp
@@ -228,7 +228,6 @@ int64 gHostStartNanos = 0;
 int64 gElapsedOSCoffset = 0;
 
 const int32 kSECONDS_FROM_1900_to_1970 = (int32)2208988800UL; /* 17 leap years */
-const double fSECONDS_FROM_1900_to_1970 = 2208988800.; /* 17 leap years */
 
 static void syncOSCOffsetWithTimeOfDay();
 void resyncThread();

--- a/lang/LangSource/GC.h
+++ b/lang/LangSource/GC.h
@@ -211,7 +211,6 @@ private:
 	int32 mPartialScanSlot;
 	int32 mNumToScan;
 	int32 mNumGrey;
-	int32 mCurSet;
 
 	int32 mFlips, mCollects, mAllocTotal, mScans, mNumAllocs, mStackScans, mNumPartialScans, mSlotsScanned, mUncollectedAllocations;
 

--- a/lang/LangSource/PyrInterpreter3.cpp
+++ b/lang/LangSource/PyrInterpreter3.cpp
@@ -1878,7 +1878,6 @@ HOT void Interpret(VMGlobals *g)
 				}
 				case 21 : {
 					-- sp ; // Drop
-					PyrSlot * vars = g->frame->vars;
 					SetRaw(&g->frame->vars[2], slotRawFloat(&g->frame->vars[2]) - 1.0); // dec i
 					SetRaw(&g->frame->vars[3], slotRawFloat(&g->frame->vars[3]) - 1.0); // inc j
 					ip -= 4;

--- a/lang/LangSource/PyrInterpreter3.cpp
+++ b/lang/LangSource/PyrInterpreter3.cpp
@@ -1878,8 +1878,9 @@ HOT void Interpret(VMGlobals *g)
 				}
 				case 21 : {
 					-- sp ; // Drop
-					SetRaw(&g->frame->vars[2], slotRawFloat(&g->frame->vars[2]) - 1.0); // dec i
-					SetRaw(&g->frame->vars[3], slotRawFloat(&g->frame->vars[3]) - 1.0); // inc j
+					PyrSlot * vars = g->frame->vars;
+					SetRaw(&vars[2], slotRawFloat(&vars[2]) - 1.0); // dec i
+					SetRaw(&vars[3], slotRawFloat(&vars[3]) - 1.0); // inc j
 					ip -= 4;
 					dispatch_opcode;
 				}


### PR DESCRIPTION
This PR removes 7 unused variables in libsclang, along with their compiler warnings.

Toward #2927.