### PR TITLE
class library: plot relative to target synth

### DIFF
--- a/HelpSource/Classes/Buffer.schelp
+++ b/HelpSource/Classes/Buffer.schelp
@@ -719,7 +719,7 @@ code::
 s.boot;
 b = Buffer.read(s, Platform.resourceDir +/+ "sounds/a11wlk01.wav");
 // same as Buffer.plot
-b.loadToFloatArray(action: { arg array; a = array; {a.plot;}.defer; "done".postln;});
+b.loadToFloatArray(action: { arg array; a = array; { a.plot }.defer; "done".postln });
 b.free;
 ::
 
@@ -741,7 +741,7 @@ code::
 s.boot;
 b = Buffer.read(s, Platform.resourceDir +/+ "sounds/a11wlk01.wav");
 // like Buffer.plot
-b.getToFloatArray(wait:0.01,action:{arg array; a = array; {a.plot;}.defer;"done".postln;});
+b.getToFloatArray(wait:0.01,action:{arg array; a = array; { a.plot }.defer; "done".postln });
 b.free;
 ::
 

--- a/HelpSource/Classes/Function.schelp
+++ b/HelpSource/Classes/Function.schelp
@@ -440,10 +440,13 @@ code::
 
 argument::duration
 The duration of the function to plot in seconds. The default is 0.01.
-argument::server
-The Server on which to calculate the plot. This must be running on your local machine, but does not need to be the internal server. If nil the default server will be used. This argument can also be a group or synth, it then is used as a target (see link::Reference/asTarget::):
+argument::target
+The target node on which to calculate the plot. See link::Reference/asTarget::. If it is a link::Classes/Server::, it must be running on your local machine, but does not need to be the internal server (see link::Classes/Buffer#-loadToFloatArray:: for details).
 code::
-var synth = { Out.ar(99, SinOsc.ar([300, 700])) }.play; { In.ar(99, 2) }.plot(0.02, synth);
+(
+var synth = { Out.ar(99, SinOsc.ar([300, 700])) }.play;
+{ In.ar(99, 2) }.plot(0.02, synth);
+)
 ::
 
 argument::bounds

--- a/HelpSource/Classes/Function.schelp
+++ b/HelpSource/Classes/Function.schelp
@@ -452,9 +452,9 @@ var synth = { Out.ar(99, SinOsc.ar([300, 700])) }.play;
 argument::bounds
 An instance of Rect or Point indicating the bounds of the plot window.
 argument::minval
-the minimum value in the plot. If not specified, the signal's maximum is used.
+the minimum value in the plot. If not specified, the signal's minimum is used.
 argument::maxval
-the maximum value in the plot. If not specified, the signal's minimum is used.
+the maximum value in the plot. If not specified, the signal's maximum is used.
 argument:: separately
 If set to code::true::, for multichannel signals use separate value display ranges, unless minval or maxval is specified already.
 

--- a/HelpSource/Classes/Function.schelp
+++ b/HelpSource/Classes/Function.schelp
@@ -484,6 +484,61 @@ b.plot; // after 3 seconds, you can see it.
 ::
 
 
+method:: loadToFloatArray
+Write a UGen function to a file and then load it into a FloatArray.
+
+argument:: duration
+Amount of data to record in seconds
+
+argument::target
+A server, synth, or group where to place the synth that plays the function
+
+argument::action
+A function to call when writing is finished.
+
+code::
+// get some data from the synth audio
+{ SinOsc.ar + GrayNoise.ar(0.1) }.loadToFloatArray(0.01, action: { arg array; a = array });
+a.postln;
+a.plot;
+
+// place it after some other node:
+z = { WhiteNoise.ar * 0.1 }.play; // play some noise
+{ BPF.ar(In.ar(0), 7000, 0.01) * 10 }.loadToFloatArray(0.01, z, action: { arg array; a = array });
+a.postln;
+::
+
+method:: getToFloatArray
+Stream the function audio values to the client using a series of getn messages and put the results into a FloatArray.
+
+argument:: duration
+Amount of data to record in seconds
+
+argument::target
+A server, synth, or group where to place the synth that plays the function
+
+argument::action
+A function to call when writing is finished.
+
+argument:: wait
+The amount of time in seconds to wait between sending getn messages. Longer times are safer. The default is 0.01 seconds which seems reliable under normal circumstances. A setting of 0 is not recommended.
+
+argument:: timeout
+The amount of time in seconds after which to post a warning if all replies have not yet been received. the default is 3.
+
+discussion::
+For a discussion of the difference between getToFloatArray and loadToFloatArray, see link::Classes/Buffer#-getToFloatArray:: and link::Classes/Buffer#-loadToFloatArray::.
+
+
+code::
+// get some data from the synth audio
+
+{ SinOsc.ar + GrayNoise.ar(0.1) }.getToFloatArray(0.01, action: { arg array; a = array });
+a.postln;
+a.plot;
+::
+
+
 subsection::Conversion
 
 method::asSynthDef

--- a/HelpSource/Classes/Function.schelp
+++ b/HelpSource/Classes/Function.schelp
@@ -425,6 +425,9 @@ A zoom value for the scope's X axis. Larger values show more. The default is 1.
 
 method::plot
 
+note::See link::Reference/plot:: for a general reference on plotting::
+
+
 Calculates duration in seconds worth of the output of this function asynchronously, and plots it in a GUI window. Unlike play and scope it will not work with explicit Out Ugens, so your function should return a UGen or an Array of them. The plot will be calculated in realtime.
 
 code::
@@ -434,10 +437,15 @@ code::
 ::
 
 
+
 argument::duration
 The duration of the function to plot in seconds. The default is 0.01.
 argument::server
-The Server on which to calculate the plot. This must be running on your local machine, but does not need to be the internal server. If nil the default server will be used.
+The Server on which to calculate the plot. This must be running on your local machine, but does not need to be the internal server. If nil the default server will be used. This argument can also be a group or synth, it then is used as a target (see link::Reference/asTarget::):
+code::
+var synth = { Out.ar(99, SinOsc.ar([300, 700])) }.play; { In.ar(99, 2) }.plot(0.02, synth);
+::
+
 argument::bounds
 An instance of Rect or Point indicating the bounds of the plot window.
 argument::minval
@@ -445,8 +453,7 @@ the minimum value in the plot. Defaults to -1.0.
 argument::maxval
 the maximum value in the plot. Defaults to 1.0.
 argument:: separately
-For multi channel signals, set whether to use separate value display ranges or not.
-a window to place the plot in. If nil, one will be created for you.
+If set to code::true::, for multichannel signals use separate value display ranges.
 
 
 method::asBuffer
@@ -455,8 +462,8 @@ Calculates duration in seconds worth of the output of this function asynchronous
 argument::duration
 The duration of the function to plot in seconds. The default is 0.01.
 
-argument::server
-The server on which the function is calculated. The default is code::Server.default::.
+argument::target
+The synth or group after which the synth runs (see link::Reference/asTarget::). The default is the default group of code::Server.default::.
 
 argument::action
 A function that is called when the buffer is filled. It is passed the buffer as argument.

--- a/HelpSource/Classes/Function.schelp
+++ b/HelpSource/Classes/Function.schelp
@@ -452,11 +452,11 @@ var synth = { Out.ar(99, SinOsc.ar([300, 700])) }.play;
 argument::bounds
 An instance of Rect or Point indicating the bounds of the plot window.
 argument::minval
-the minimum value in the plot. Defaults to -1.0.
+the minimum value in the plot. If not specified, the signal's maximum is used.
 argument::maxval
-the maximum value in the plot. Defaults to 1.0.
+the maximum value in the plot. If not specified, the signal's minimum is used.
 argument:: separately
-If set to code::true::, for multichannel signals use separate value display ranges.
+If set to code::true::, for multichannel signals use separate value display ranges, unless minval or maxval is specified already.
 
 
 method::asBuffer

--- a/HelpSource/Classes/Function.schelp
+++ b/HelpSource/Classes/Function.schelp
@@ -441,7 +441,7 @@ code::
 argument::duration
 The duration of the function to plot in seconds. The default is 0.01.
 argument::target
-The target node on which to calculate the plot. See link::Reference/asTarget::.
+The server, synth or group where the signal is picked up. See link::Reference/asTarget::.
 code::
 (
 var synth = { Out.ar(99, SinOsc.ar([300, 700])) }.play;

--- a/HelpSource/Classes/Function.schelp
+++ b/HelpSource/Classes/Function.schelp
@@ -441,7 +441,7 @@ code::
 argument::duration
 The duration of the function to plot in seconds. The default is 0.01.
 argument::target
-The target node on which to calculate the plot. See link::Reference/asTarget::. If it is a link::Classes/Server::, it must be running on your local machine, but does not need to be the internal server (see link::Classes/Buffer#-loadToFloatArray:: for details).
+The target node on which to calculate the plot. See link::Reference/asTarget::.
 code::
 (
 var synth = { Out.ar(99, SinOsc.ar([300, 700])) }.play;

--- a/SCClassLibrary/Common/Core/Function.sc
+++ b/SCClassLibrary/Common/Core/Function.sc
@@ -322,6 +322,15 @@ Function : AbstractFunction {
 		})
 	}
 
+	getToFloatArray { |duration = 0.01, target, action, wait = 0.01, timeout = 3|
+		this.asBuffer(duration, target, { |buffer|
+			buffer.getToFloatArray(0, wait: wait, action: { |array|
+				action.value(array, buffer);
+				buffer.free
+			})
+		})
+	}
+
 }
 
 Thunk : AbstractFunction {

--- a/SCClassLibrary/Common/Core/Function.sc
+++ b/SCClassLibrary/Common/Core/Function.sc
@@ -263,9 +263,11 @@ Function : AbstractFunction {
 		^{ |... args| envir.use({ this.valueArray(args) }) }
 	}
 
-	asBuffer { |duration = 0.01, server, action, fadeTime = (0)|
-		var buffer, def, synth, name, numChannels, rate;
-		server = server ? Server.default;
+	asBuffer { |duration = 0.01, target, action, fadeTime = (0)|
+		var buffer, def, synth, name, numChannels, rate, server;
+		target = target.asTarget;
+		server = target.server;
+
 
 		name = this.hash.asString;
 		def = SynthDef(name, { |bufnum|
@@ -301,7 +303,7 @@ Function : AbstractFunction {
 			server.sync;
 			def.send(server);
 			server.sync;
-			synth = Synth(name, [\bufnum, buffer], server);
+			synth = Synth(name, [\bufnum, buffer], target, \addAfter);
 			OSCFunc({
 				action.value(buffer);
 				server.sendMsg("/d_free", name);

--- a/SCClassLibrary/Common/Core/Function.sc
+++ b/SCClassLibrary/Common/Core/Function.sc
@@ -313,8 +313,8 @@ Function : AbstractFunction {
 		^buffer
 	}
 
-	loadToFloatArray { |duration = 0.01, server, action|
-		this.asBuffer(duration, server, { |buffer|
+	loadToFloatArray { |duration = 0.01, target, action|
+		this.asBuffer(duration, target, { |buffer|
 			buffer.loadToFloatArray(action: { |array|
 				action.value(array, buffer);
 				buffer.free

--- a/SCClassLibrary/Common/Core/Function.sc
+++ b/SCClassLibrary/Common/Core/Function.sc
@@ -274,7 +274,7 @@ Function : AbstractFunction {
 			var	val = this.value;
 			if(val.isValidUGenInput.not) {
 				val.dump;
-				Error("loadToFloatArray failed: % is no valid UGen input".format(val)).throw
+				Error("reading signal failed: % is no valid UGen input".format(val)).throw
 			};
 			val = UGen.replaceZeroesWithSilence(val.asArray);
 			rate = val.rate;

--- a/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
+++ b/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
@@ -775,7 +775,7 @@ Plotter {
 		plotter = Plotter(name, bounds);
 		plotter.value = [0.0];
 
-		this.loadToFloatArray(duration, target, { |array, buf|
+		this.getToFloatArray(duration, target, { |array, buf|
 			var numChan = buf.numChannels;
 			{
 				plotter.setValue(

--- a/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
+++ b/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
@@ -769,14 +769,13 @@ Plotter {
 
 
 + Function {
-	plot { |duration = 0.01, server, bounds, minval, maxval, separately = false|
-
+	plot { |duration = 0.01, target, bounds, minval, maxval, separately = false|
 		var name = this.asCompileString, plotter;
 		if(name.size > 50 or: { name.includes(Char.nl) }) { name = "function plot" };
 		plotter = Plotter(name, bounds);
 		plotter.value = [0.0];
 
-		this.loadToFloatArray(duration, server, { |array, buf|
+		this.loadToFloatArray(duration, target, { |array, buf|
 			var numChan = buf.numChannels;
 			{
 				plotter.setValue(


### PR DESCRIPTION
Sometimes, one needs to plot values from a synth that depends on node
order. E.g. a synth that reads from a bus. This patch allows us to
determine the point at which the plotting synth is inserted in the node
order. It is inserted _after_ the target node. By default, this is the
default group of the default server. This follows the `asTarget`
interface, as documented in scdoc.