### PR TITLE
Remove outdated info about nested bundles

### DIFF
--- a/HelpSource/Reference/Server-Architecture.schelp
+++ b/HelpSource/Reference/Server-Architecture.schelp
@@ -140,7 +140,7 @@ scsynth -N score.osc _ out.aiff 48000 AIFF int24
 
 section:: Binary Format of Messages
 
-Messages are similar in format to Open Sound Control messages, except that OSC #bundles may not be nested, and pattern matching of the command name is not performed. When streamed via TCP, Messages are each preceded by a 32 bit integer giving the length in bytes of the message. UDP datagrams contain this length information already.
+Messages are similar in format to Open Sound Control messages, except that pattern matching of the command name is not performed. When streamed via TCP, messages are each preceded by a 32 bit integer giving the length in bytes of the message. UDP datagrams contain this length information already.
 
 subsection:: Types
 All values are in network byte order.


### PR DESCRIPTION
This apparently is outdated, according to this closed issue:

https://github.com/supercollider/supercollider/issues/776

I see the scsynth code here:

https://github.com/supercollider/supercollider/commit/f3ac02119e214789582609e8116012fb4e308252

Does anyone know where the supernova code for this is?

