### PR TITLE
Clean build: avoid overload of virtual function

### DIFF
--- a/QtCollider/QcWidgetFactory.h
+++ b/QtCollider/QcWidgetFactory.h
@@ -124,6 +124,9 @@ protected:
     return prox;
   }
 
+  // avoid overload of virtual initialize( QObjectProxy *, QWIDGET * )
+  using QcObjectFactory<QWIDGET>::initialize;
+
   virtual void initialize( QWidgetProxy *proxy, QWIDGET *obj ) {};
 };
 


### PR DESCRIPTION
Toward #2927.

This eliminates 27 warnings of `-Woverloaded-virtual`