### PR TITLE
class library: fix issues with asPairs, asAssociations, asDict

### DIFF
--- a/SCClassLibrary/Common/Collections/Collection.sc
+++ b/SCClassLibrary/Common/Collections/Collection.sc
@@ -565,7 +565,7 @@ Collection {
 			^if(class == this.class) { this } { this.as(class) }
 		};
 		res = class.new(this.size div: 2);
-		this.pairsDo { |key, val| res.add(key -> val) }
+		this.pairsDo { |key, val| res = res.add(key -> val) }
 		^res
 	}
 
@@ -575,8 +575,8 @@ Collection {
 		if(this.isAssociationArray.not) {
 			^if(class == this.class) { this } { this.as(class) }
 		};
-		res = class.new(this.size div: 2);
-		this.do { |assoc| res.add(assoc.key).add(assoc.value) }
+		res = class.new(this.size * 2);
+		this.do { |assoc| res = res.add(assoc.key).add(assoc.value) }
 		^res
 	}
 

--- a/testsuite/classlibrary/TestCollection.sc
+++ b/testsuite/classlibrary/TestCollection.sc
@@ -1,0 +1,10 @@
+TestCollection : UnitTest {
+
+	test_asPairs {
+
+		this.assert([2,10,100,1000].collect{ |size| size.collect{ |i| i -> i }.asPairs.size >= (size * 2) }.reduce('&&')
+, "asPairs on an array of associations should create an array with size higher or equal to twice the number of elements in the original array");
+
+	}
+
+}

--- a/testsuite/classlibrary/TestDictionary.sc
+++ b/testsuite/classlibrary/TestDictionary.sc
@@ -13,4 +13,16 @@ TestDictionary : UnitTest {
 
 	}
 
+	test_asAssociations {
+
+		this.assert(
+			[2,10,100,1000].collect{ |size|
+				var dict = Dictionary.new(size);
+				size.do{ |i| dict.put(i,i) };
+				dict.asAssociations.size >= size
+			}.reduce('&&')
+			, "asAssociations on a dictionary should create array of associations with size higher or equal to the number of elements in the original dictionary");
+
+	}
+
 }


### PR DESCRIPTION
I was getting strange results with asPairs and asAssociations and I think I found some bugs. Some elements were missing after doing asPairs or asAssociations. 

When going from a dictionary to an array of associations the size should stay the same. the method in Collection was being called which was halving the size:
```
(
x = Dictionary.new;
100.do{ |i| x.put(i,i) };
x.asAssociations.size;
)
//got 64 should be at least 100

```

When going from an array of associations to an array of pairs the size should double, and the code in Collection was halving it.
```
(
x = Array.new;
100.do{ |i| x = x.add(i -> i) };
x.asPairs.size;
)
//got 64 should be at least 200

```

