### PR TITLE
supernova: change node_graph group_count_ to 1

### DIFF
--- a/server/supernova/server/node_graph.hpp
+++ b/server/supernova/server/node_graph.hpp
@@ -290,7 +290,7 @@ private:
                                              boost::intrusive::power_2_buckets<true>
                                            > node_set_type;
 
-    uint32_t synth_count_ = 0, group_count_ = 0;
+    uint32_t synth_count_ = 0, group_count_ = 1;
 
     node_set_type::bucket_type node_buckets[node_set_bucket_count];
     node_set_type node_set;


### PR DESCRIPTION
This is a partial fix for #1717.

I took the following nodes while fixing this:

## default group behavior of supernova & scsynth

```supercollider
Server.supernova
s.boot
s.numGroups // 1
s.queryAllNodes

//NODE TREE Group 0
//   0 group
//      1 group

s.quit
Server.scsynth
s.boot
s.numGroups // 2
s.queryAllNodes

//NODE TREE Group 0
//   1 group
```

Status querying is the only time supernova's group count is actually used for an external calculation (grep for group_count_ if you don't believe me), so it doesn't matter which
value it starts with. Also, it looks like this was accidentally changed during a refactor:
5cc4615dcd (`group_count_` was moved from constructor init list to private member definition,
and changed from 1 to 0 for no clear reason).

Since the tests pass with this at 1, and since this seems to conform to what's actually printed by
querying the server, and since it would conform to scsynth's behavior, I'm going to respect the
tests and change it to 1.


Output of server_node_graph_test after this change:
```
Running 19 test cases...

*** No errors detected
```