### PR TITLE
Git (class): add url composition

### DIFF
--- a/HelpSource/Classes/Git.schelp
+++ b/HelpSource/Classes/Git.schelp
@@ -56,6 +56,9 @@ returns:: hash of the given tag
 METHOD:: isDirty
 returns:: code::true:: if there are local changes
 
+METHOD:: openRemote, openLocalPath
+open the local respectively remote urls with the OS
+
 
 
 subsection:: perform actions on remote

--- a/HelpSource/Classes/Git.schelp
+++ b/HelpSource/Classes/Git.schelp
@@ -33,7 +33,23 @@ METHOD:: remote, url
 returns:: url of the first remote that it finds.
 
 METHOD:: remoteAsHttpUrl
-returns:: remote url formatted for code::https:: request
+Detects if the remote URI starts with code::"git@":: or code::"git:":: and remodels it to a valid code::"https":: URI. Otherwise, it returns the unaltered remote.
+
+code::
+// git-style remote URI's are transformed to https
+Git().url_("git@github.com:foo/bar.git").remoteAsHttpUrl;
+Git().url_("git://github.com/foo/bar").remoteAsHttpUrl;
+Git().url_("git@foo.net:foo/bar.git").remoteAsHttpUrl;
+
+// http and https are left untouched
+Git().url_("https://foo.org/bar").remoteAsHttpUrl;
+Git().url_("http://foo.org/bar").remoteAsHttpUrl;
+
+// unknown URI styles are left untouched
+Git().url_("fooBar").remoteAsHttpUrl;
+::
+
+returns:: remote URI formatted for code::http:: respectively code::https:: requests.
 
 METHOD:: remoteLatest
 returns:: hash of latest commit on the remote

--- a/HelpSource/Classes/Git.schelp
+++ b/HelpSource/Classes/Git.schelp
@@ -32,6 +32,9 @@ subsection:: info
 METHOD:: remote, url
 returns:: url of the first remote that it finds.
 
+METHOD:: httpsString
+returns:: remote url formatted for code::https:: request
+
 METHOD:: remoteLatest
 returns:: hash of latest commit on the remote
 
@@ -55,9 +58,6 @@ returns:: hash of the given tag
 
 METHOD:: isDirty
 returns:: code::true:: if there are local changes
-
-METHOD:: openRemote, openLocalPath
-open the local respectively remote urls with the OS
 
 
 

--- a/HelpSource/Classes/Git.schelp
+++ b/HelpSource/Classes/Git.schelp
@@ -32,7 +32,7 @@ subsection:: info
 METHOD:: remote, url
 returns:: url of the first remote that it finds.
 
-METHOD:: httpsString
+METHOD:: remoteAsHttpUrl
 returns:: remote url formatted for code::https:: request
 
 METHOD:: remoteLatest

--- a/SCClassLibrary/Common/Quarks/Git.sc
+++ b/SCClassLibrary/Common/Quarks/Git.sc
@@ -48,6 +48,21 @@ Git {
 		});
 		^nil
 	}
+	openRemote {
+		var url = this.url;
+		if(url.notNil, {
+			if(url.beginsWith("git@github.com:"), {
+				url = "https://github.com/" ++ url.copyToEnd(15)
+			});
+			if(url.beginsWith("git:"), {
+				url = "https:" ++ url.copyToEnd(4)
+			});
+			openOS(url);
+		})
+	}
+	openLocalPath {
+		localPath.openOS
+	}
 	refspec {
 		^this.tag ?? { this.sha }
 	}

--- a/SCClassLibrary/Common/Quarks/Git.sc
+++ b/SCClassLibrary/Common/Quarks/Git.sc
@@ -48,20 +48,21 @@ Git {
 		});
 		^nil
 	}
-	openRemote {
-		var url = this.url;
-		if(url.notNil, {
-			if(url.beginsWith("git@github.com:"), {
-				url = "https://github.com/" ++ url.copyToEnd(15)
+	httpsString {
+		var giturl = this.url;
+		var hosturl, path;
+
+		if(giturl.notNil, {
+			if(giturl.beginsWith("git@"), {
+				#hosturl, path = giturl.split($:);
+				^"https://%/%".format(hosturl.split($@).last, path)
 			});
-			if(url.beginsWith("git:"), {
-				url = "https:" ++ url.copyToEnd(4)
+			if(giturl.beginsWith("git:"), {
+				^("https:" ++ giturl.copyToEnd(4))
 			});
-			openOS(url);
-		})
-	}
-	openLocalPath {
-		localPath.openOS
+			^giturl;
+		});
+		^nil
 	}
 	refspec {
 		^this.tag ?? { this.sha }

--- a/SCClassLibrary/Common/Quarks/Git.sc
+++ b/SCClassLibrary/Common/Quarks/Git.sc
@@ -48,7 +48,7 @@ Git {
 		});
 		^nil
 	}
-	httpsString {
+	remoteAsHttpUrl {
 		var giturl = this.url;
 		var hosturl, path;
 

--- a/SCClassLibrary/Common/Quarks/QuarksGui.sc
+++ b/SCClassLibrary/Common/Quarks/QuarksGui.sc
@@ -296,7 +296,7 @@ QuarkDetailView {
 
 			if(url.notNil, {
 				this.pushRow("Repository", makeBtn.value(url, {
-					this.openGithub();
+					this.openGitRemote();
 				}));
 			});
 
@@ -377,11 +377,11 @@ QuarkDetailView {
 			openOS(url);
 		});
 	}
-	openGithub {
-		model.git.openRemote;
+	openGitRemote {
+		model.git.httpsString.openOS;
 	}
 	openLocalPath {
-		model.git.openLocalPath;
+		model.localPath.openOS;
 	}
 	showClasses {
 		var cls = model.definesClasses;

--- a/SCClassLibrary/Common/Quarks/QuarksGui.sc
+++ b/SCClassLibrary/Common/Quarks/QuarksGui.sc
@@ -380,6 +380,9 @@ QuarkDetailView {
 	openGithub {
 		var url = model.url;
 		if(url.notNil, {
+			if(url.beginsWith("git@github.com:"), {
+				url = "https://github.com/" ++ url.copyToEnd(15)
+			});
 			if(url.beginsWith("git:"), {
 				url = "https:" ++ url.copyToEnd(4)
 			});

--- a/SCClassLibrary/Common/Quarks/QuarksGui.sc
+++ b/SCClassLibrary/Common/Quarks/QuarksGui.sc
@@ -378,7 +378,7 @@ QuarkDetailView {
 		});
 	}
 	openGitRemote {
-		model.git.httpsString.openOS;
+		model.git.remoteAsHttpUrl.openOS;
 	}
 	openLocalPath {
 		model.localPath.openOS;

--- a/SCClassLibrary/Common/Quarks/QuarksGui.sc
+++ b/SCClassLibrary/Common/Quarks/QuarksGui.sc
@@ -378,19 +378,10 @@ QuarkDetailView {
 		});
 	}
 	openGithub {
-		var url = model.url;
-		if(url.notNil, {
-			if(url.beginsWith("git@github.com:"), {
-				url = "https://github.com/" ++ url.copyToEnd(15)
-			});
-			if(url.beginsWith("git:"), {
-				url = "https:" ++ url.copyToEnd(4)
-			});
-			openOS(url);
-		});
+		model.git.openRemote;
 	}
 	openLocalPath {
-		model.localPath.openOS;
+		model.git.openLocalPath;
 	}
 	showClasses {
 		var cls = model.definesClasses;


### PR DESCRIPTION
opening the gihub url silently failed if remote url is of form `git@github.com:<uri>`