### PR TITLE
readme: use master branch for travis badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Welcome to SuperCollider!
 =========================
 
-[![Build Status](https://img.shields.io/travis/supercollider/supercollider.svg)](https://travis-ci.org/supercollider/supercollider) [![Slack](https://slackin-apxbmqnfui.now.sh/badge.svg)](https://slackin-apxbmqnfui.now.sh)
+[![Build Status](https://travis-ci.org/supercollider/supercollider.svg?branch=master)](https://travis-ci.org/supercollider/supercollider) [![Slack](https://slackin-apxbmqnfui.now.sh/badge.svg)](https://slackin-apxbmqnfui.now.sh)
 
 **SuperCollider** is a platform for audio synthesis and algorithmic composition, used by musicians, artists, and researchers working with sound. It is free and open source software available for Windows, macOS, and Linux.
 


### PR DESCRIPTION
without this, the badge shows the build status of whatever branch was built last within the repo, even if it isn't the default branch (master)