### PR TITLE
Fix Server volume and mute after reboot

### DIFF
--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -867,7 +867,7 @@ Server {
 		sendQuit = nil;
 
 		if(scopeWindow.notNil) { scopeWindow.quit };
-		volume.free;
+		volume.freeSynth;
 		RootNode(this).freeAll;
 		this.newAllocators;
 	}

--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -867,7 +867,7 @@ Server {
 		sendQuit = nil;
 
 		if(scopeWindow.notNil) { scopeWindow.quit };
-		if(volume.isPlaying) { volume.free };
+		volume.free;
 		RootNode(this).freeAll;
 		this.newAllocators;
 	}

--- a/SCClassLibrary/Common/Control/Volume.sc
+++ b/SCClassLibrary/Common/Control/Volume.sc
@@ -85,6 +85,10 @@ Volume {
 		}
 	}
 
+	free {
+		ampSynth.free;
+	}
+
 	// sets volume back to 1 - removes the synth
 	reset {
 		isMuted = false;

--- a/SCClassLibrary/Common/Control/Volume.sc
+++ b/SCClassLibrary/Common/Control/Volume.sc
@@ -23,9 +23,8 @@ Volume {
 	}
 
 	sendSynthDef {
-		forkIfNeeded {
+		server.doWhenBooted({
 			var synthNumChans = this.numChannels;
-			server.sync;
 			defName = (\volumeAmpControl ++ synthNumChans).asSymbol;
 			SynthDef(defName, { | volumeAmp = 1, volumeLag = 0.1, gate=1, bus |
 				XOut.ar(bus,
@@ -44,7 +43,7 @@ Volume {
 			ServerTree.add(updateFunc);
 
 			this.updateSynth
-		}
+		})
 	}
 
 	numChannels { ^numChannels ? server.options.numOutputBusChannels }

--- a/SCClassLibrary/Common/Control/Volume.sc
+++ b/SCClassLibrary/Common/Control/Volume.sc
@@ -4,7 +4,7 @@ Volume {
 
 	var <volume = 0.0, <lag = 0.1, <isMuted = false;
 
-	var <ampSynth, defName, updateFunc, initFunc;
+	var <ampSynth, <numOutputChannels, defName, updateFunc, initFunc;
 	var <>window;
 
 	*new { | server, startBus = 0, numChannels, min = -90, max = 6, persist = false |
@@ -24,12 +24,12 @@ Volume {
 
 	sendSynthDef {
 		server.doWhenBooted({
-			var synthNumChans = this.numChannels;
-			defName = (\volumeAmpControl ++ synthNumChans).asSymbol;
+			numOutputChannels = this.numChannels;
+			defName = (\volumeAmpControl ++ numOutputChannels).asSymbol;
 			SynthDef(defName, { | volumeAmp = 1, volumeLag = 0.1, gate=1, bus |
 				XOut.ar(bus,
 					Linen.kr(gate, releaseTime: 0.05, doneAction:2),
-					In.ar(bus, synthNumChans) * Lag.kr(volumeAmp, volumeLag)
+					In.ar(bus, numOutputChannels) * Lag.kr(volumeAmp, volumeLag)
 				);
 			}).send(server);
 

--- a/SCClassLibrary/Common/Control/Volume.sc
+++ b/SCClassLibrary/Common/Control/Volume.sc
@@ -13,12 +13,13 @@ Volume {
 
 	init {
 		if(server.serverRunning) { this.sendSynthDef };
-		if(initFunc.isNil) {
-			ServerBoot.add(initFunc = {
-				ampSynth = nil;
-				this.sendSynthDef;
-			}, server)
-		}
+
+		initFunc = {
+			ampSynth = nil;
+			this.sendSynthDef
+		};
+
+		ServerBoot.add(initFunc)
 	}
 
 	sendSynthDef {
@@ -34,14 +35,14 @@ Volume {
 
 			server.sync;
 
-			this.updateSynth;
+			updateFunc = {
+				ampSynth = nil;
+				if(persist) { this.updateSynth }
+			};
 
-			if(updateFunc.isNil) {
-				ServerTree.add(updateFunc = {
-					ampSynth = nil;
-					if(persist) { this.updateSynth }
-				})
-			}
+			ServerTree.add(updateFunc);
+
+			this.updateSynth
 		}
 	}
 
@@ -118,7 +119,6 @@ Volume {
 		clippedVolume = volume.clip(min, max);
 		if(clippedVolume != volume) { this.volume_(clippedVolume) }
 	}
-
 
 	gui { | window, bounds |
 		^VolumeGui(this, window, bounds)

--- a/SCClassLibrary/Common/Control/Volume.sc
+++ b/SCClassLibrary/Common/Control/Volume.sc
@@ -22,27 +22,26 @@ Volume {
 	}
 
 	sendSynthDef {
-
 		forkIfNeeded {
 			var synthNumChans = this.numChannels;
 			defName = (\volumeAmpControl ++ synthNumChans).asSymbol;
 			SynthDef(defName, { | volumeAmp = 1, volumeLag = 0.1, gate=1, bus |
-					XOut.ar(bus,
-						Linen.kr(gate, releaseTime: 0.05, doneAction:2),
-						In.ar(bus, synthNumChans) * Lag.kr(volumeAmp, volumeLag)
-					);
+				XOut.ar(bus,
+					Linen.kr(gate, releaseTime: 0.05, doneAction:2),
+					In.ar(bus, synthNumChans) * Lag.kr(volumeAmp, volumeLag)
+				);
 			}).send(server);
 
 			server.sync;
+
+			this.updateSynth;
 
 			if(updateFunc.isNil) {
 				ServerTree.add(updateFunc = {
 					ampSynth = nil;
 					if(persist) { this.updateSynth }
 				})
-			};
-
-			this.updateSynth
+			}
 		}
 	}
 
@@ -87,7 +86,7 @@ Volume {
 		}
 	}
 
-	free {
+	freeSynth {
 		ServerTree.remove(updateFunc);
 		updateFunc = nil;
 		ampSynth.release;

--- a/SCClassLibrary/Common/Control/Volume.sc
+++ b/SCClassLibrary/Common/Control/Volume.sc
@@ -4,7 +4,7 @@ Volume {
 
 	var <volume = 0.0, <lag = 0.1, <isMuted = false;
 
-	var ampSynth, defName, updateFunc, initFunc;
+	var <ampSynth, defName, updateFunc, initFunc;
 	var <>window;
 
 	*new { | server, startBus = 0, numChannels, min = -90, max = 6, persist = false |

--- a/SCClassLibrary/Common/Control/Volume.sc
+++ b/SCClassLibrary/Common/Control/Volume.sc
@@ -41,7 +41,9 @@ Volume {
 					if(persist) { this.updateSynth }
 				})
 			}
-		}
+		};
+
+		this.updateSynth
 	}
 
 	numChannels { ^numChannels ? server.options.numOutputBusChannels }
@@ -86,7 +88,10 @@ Volume {
 	}
 
 	free {
-		ampSynth.free;
+		ServerTree.remove(updateFunc);
+		updateFunc = nil;
+		ampSynth.release;
+		ampSynth = nil
 	}
 
 	// sets volume back to 1 - removes the synth

--- a/SCClassLibrary/Common/Control/Volume.sc
+++ b/SCClassLibrary/Common/Control/Volume.sc
@@ -40,10 +40,10 @@ Volume {
 					ampSynth = nil;
 					if(persist) { this.updateSynth }
 				})
-			}
-		};
+			};
 
-		this.updateSynth
+			this.updateSynth
+		}
 	}
 
 	numChannels { ^numChannels ? server.options.numOutputBusChannels }

--- a/SCClassLibrary/Common/Control/Volume.sc
+++ b/SCClassLibrary/Common/Control/Volume.sc
@@ -25,6 +25,7 @@ Volume {
 	sendSynthDef {
 		forkIfNeeded {
 			var synthNumChans = this.numChannels;
+			server.sync;
 			defName = (\volumeAmpControl ++ synthNumChans).asSymbol;
 			SynthDef(defName, { | volumeAmp = 1, volumeLag = 0.1, gate=1, bus |
 				XOut.ar(bus,

--- a/testsuite/classlibrary/TestVolume.sc
+++ b/testsuite/classlibrary/TestVolume.sc
@@ -1,40 +1,41 @@
 TestVolume : UnitTest {
 
-	var server = Server.default;
-
 	test_setVolume {
 
-		var serverVolume = server.volume.volume;
-		var ampSynthVolume;
+		var s, ampSynthVolume;
+		s = Server.default;
 
 		this.bootServer;
+		s.sync;
 
-		this.assert(serverVolume == 0, "initial volume is 0 db");
+		this.assert(s.volume.volume == 0, "initial volume is 0 db");
 
-		serverVolume = -36;
-		server.sync;
+		s.volume.volume = -36; // creates volume synth
+		this.assert(s.volume.ampSynth.notNil, "Server volume synth exists");
 
-		this.assert(server.volume.ampSynth.notNil, "Server volume synth exists");
+		s.volume.ampSynth.get(\volumeAmp, { |level| ampSynthVolume = level });
+		s.sync;
+		this.assertFloatEquals(ampSynthVolume, s.volume.volume.dbamp, "volume level correctly set", 0.0001);
 
-		server.volume.ampSynth.get(\volumeAmp, { |level| ampSynthVolume = level });
-		this.assertFloatEquals(ampSynthVolume == serverVolume, "volume level correctly set");
-
-		server.volume.reset;
-		server.quit;
+		s.volume.reset;
+		s.quit;
 	}
 
 	test_numOutputs {
 
-		var default_numChannels = server.options.numOutputBusChannels;
+		var s, default_numChannels;
+		s = Server.default;
+		default_numChannels = s.options.numOutputBusChannels;
 
-		server.options.numOutputBusChannels = 8;
+		s.options.numOutputBusChannels = 8;
 
 		this.bootServer;
+		s.sync;
 
-		this.assert(server.outputBus.numChannels == server.volume.numOutputChannels, "volume synth has correct number of channels");
+		this.assert(s.outputBus.numChannels == s.volume.numOutputChannels, "volume synth has correct number of channels");
 
-		server.quit;
-		server.options.numOutputBusChannels = default_numChannels;
+		s.quit;
+		s.options.numOutputBusChannels = default_numChannels;
 	}
 
 }

--- a/testsuite/classlibrary/TestVolume.sc
+++ b/testsuite/classlibrary/TestVolume.sc
@@ -31,7 +31,7 @@ TestVolume : UnitTest {
 
 		this.bootServer;
 
-		this.assert(server.outputBus.numChannels == server.volume.numChannels, "volume synth has correct number of channels");
+		this.assert(server.outputBus.numChannels == server.volume.numOutputChannels, "volume synth has correct number of channels");
 
 		server.quit;
 		server.options.numOutputBusChannels = default_numChannels;

--- a/testsuite/classlibrary/TestVolume.sc
+++ b/testsuite/classlibrary/TestVolume.sc
@@ -1,24 +1,49 @@
 TestVolume : UnitTest {
 
-	test_setVolume {
-		var server, volume, level, temp;
+	var server = Server.default;
+	var volume = Server.default.volume;
+	var level = Server.default.volume.volume;
+	var temp;
 
-		server = Server.default;
-		volume = server.volume;
-		level = volume.volume;
+	test_setVolume {
 
 		this.bootServer;
 
 		this.assert(level == 0, "initial volume is 0 db");
-		volume = -36;
+		level = -36;
 
 		server.sync;
 
 		this.assert(volume.ampSynth.notNil, "Server volume synth exists");
 		volume.ampSynth.get(\volumeAmp, { |val| temp = val});
-		this.assertFloatEquals(temp == level, "Volume level correctly set");
+		this.assertFloatEquals(temp == level, "volume level correctly set");
 
 		volume.reset;
 		server.quit;
+		temp = nil;
 	}
+
+	test_numOutputs {
+
+		temp = server.options.numOutputBusChannels;
+
+		this.bootServer;
+
+		server.mute;
+		server.sync;
+
+		this.assert(server.outputBus.numChannels == volume.numChannels, "volume synth has correct number of channels");
+
+		server.quit;
+		server.options.numOutputBusChannels = 8;
+
+		this.bootServer;
+
+		this.assert(server.outputBus.numChannels == volume.numChannels, "volume synth numChannels properly set");
+
+		server.quit;
+		server.options.numOutputBusChannels = temp;
+		temp = nil;
+	}
+
 }

--- a/testsuite/classlibrary/TestVolume.sc
+++ b/testsuite/classlibrary/TestVolume.sc
@@ -1,0 +1,24 @@
+TestVolume : UnitTest {
+
+	test_setVolume {
+		var server, volume, level, temp;
+
+		server = Server.default;
+		volume = server.volume;
+		level = volume.volume;
+
+		this.bootServer;
+
+		this.assert(level == 0, "initial volume is 0 db");
+		volume = -36;
+
+		server.sync;
+
+		this.assert(volume.ampSynth.notNil, "Server volume synth exists");
+		volume.ampSynth.get(\volumeAmp, { |val| temp = val});
+		this.assertFloatEquals(temp == level, "Volume level correctly set");
+
+		volume.reset;
+		server.quit;
+	}
+}

--- a/testsuite/classlibrary/TestVolume.sc
+++ b/testsuite/classlibrary/TestVolume.sc
@@ -1,49 +1,40 @@
 TestVolume : UnitTest {
 
 	var server = Server.default;
-	var volume = Server.default.volume;
-	var level = Server.default.volume.volume;
-	var temp;
 
 	test_setVolume {
 
+		var serverVolume = server.volume.volume;
+		var ampSynthVolume;
+
 		this.bootServer;
 
-		this.assert(level == 0, "initial volume is 0 db");
-		level = -36;
+		this.assert(serverVolume == 0, "initial volume is 0 db");
 
+		serverVolume = -36;
 		server.sync;
 
-		this.assert(volume.ampSynth.notNil, "Server volume synth exists");
-		volume.ampSynth.get(\volumeAmp, { |val| temp = val});
-		this.assertFloatEquals(temp == level, "volume level correctly set");
+		this.assert(server.volume.ampSynth.notNil, "Server volume synth exists");
 
-		volume.reset;
+		server.volume.ampSynth.get(\volumeAmp, { |level| ampSynthVolume = level });
+		this.assertFloatEquals(ampSynthVolume == serverVolume, "volume level correctly set");
+
+		server.volume.reset;
 		server.quit;
-		temp = nil;
 	}
 
 	test_numOutputs {
 
-		temp = server.options.numOutputBusChannels;
+		var default_numChannels = server.options.numOutputBusChannels;
 
-		this.bootServer;
-
-		server.mute;
-		server.sync;
-
-		this.assert(server.outputBus.numChannels == volume.numChannels, "volume synth has correct number of channels");
-
-		server.quit;
 		server.options.numOutputBusChannels = 8;
 
 		this.bootServer;
 
-		this.assert(server.outputBus.numChannels == volume.numChannels, "volume synth numChannels properly set");
+		this.assert(server.outputBus.numChannels == server.volume.numChannels, "volume synth has correct number of channels");
 
 		server.quit;
-		server.options.numOutputBusChannels = temp;
-		temp = nil;
+		server.options.numOutputBusChannels = default_numChannels;
 	}
 
 }


### PR DESCRIPTION
This PR is an attempt to fix #3105 & #3110.
### Description

The problem is that, on reboot, ServerTree calls its updateFunc (it was added the first time the server booted) before ServerBoot's initFunc is done sending the SynthDef. This causes the "SynthDef not found" error.
### Changes proposed

The fix removes the updateFunc from ServerTree when the server quits. That way, on reboot, ServerTree has nothing to call. When initFunc is finished sending the SynthDef, updateFunc gets added to ServerTree.

Also, this.updateSynth needs to be called at the end of sendSynthDef so that the volume synth gets created, if necessary.

This change also makes Server.quit call Volume.freeSynth.

### Result
The Server's volume and mute status persist across reboots. No more SynthDef not found errors posted after reboot.

### Test
```supercollider
s.volume.volume = -36;
s.boot;
s.queryAllNodes;
/* should see this (if you have 2 outputs)
NODE TREE Group 0
   1 group
   1000 volumeAmpControl2
*/

s.quit;
s.boot;
s.queryAllNodes;
/* should see this (if you have 2 outputs)
NODE TREE Group 0
   1 group
   1000 volumeAmpControl2
*/
a = {SinOsc.ar}.play; // should play at -36db 
a.free;

s.mute;
s.quit;
s.boot;
a = {SinOsc.ar}.play; // no sound, server muted 
s.unmute; // should play at -36db
a.free;

s.quit;
s.options.numOutputBusChannels = 4;
s.boot;
s.queryAllNodes;
/* should see:
NODE TREE Group 0
   1 group
   1000 volumeAmpControl4
*/
```