### PR TITLE
Remove sclang debug posts on startup: "init_OSC", "initPassOne", "pass 1 done"

### DIFF
--- a/lang/LangPrimSource/OSCData.cpp
+++ b/lang/LangPrimSource/OSCData.cpp
@@ -763,7 +763,6 @@ void stopAsioThread();
 
 void init_OSC(int port)
 {
-	postfl("init_OSC\n");
 
 #ifdef _WIN32
 	WSAData wsaData;

--- a/lang/LangSource/PyrLexer.cpp
+++ b/lang/LangSource/PyrLexer.cpp
@@ -2098,8 +2098,6 @@ SCLANG_DLLEXPORT_C bool compileLibrary(bool standalone)
 	bool res = passOne();
 	if (res) {
 
-		postfl("\tpass 1 done\n");
-
 		if (!compileErrors) {
 			buildDepTree();
 			traverseFullDepTree();

--- a/lang/LangSource/PyrLexer.cpp
+++ b/lang/LangSource/PyrLexer.cpp
@@ -1775,8 +1775,6 @@ bool parseOneClass(PyrSymbol *fileSym)
 
 void initPassOne()
 {
-	post("initPassOne started\n");
-
 	//dump_pool_histo(pyr_pool_runtime);
 	pyr_pool_runtime->FreeAllInternal();
 	//dump_pool_histo(pyr_pool_runtime);
@@ -1803,8 +1801,6 @@ void initPassOne()
 
 	// main class library folder: only used for relative path resolution
 	gCompileDir = SC_Filesystem::instance().getDirectory(DirName::Resource) / "SCClassLibrary";
-
-	post("initPassOne done\n");
 }
 
 void finiPassOne()
@@ -1974,7 +1970,7 @@ bool isValidSourceFileName(const bfs::path& path)
 bool passOne_ProcessOneFile(const bfs::path& path)
 {
 	bool success = true;
-	
+
 	const std::string path_str = SC_Codecvt::path_to_utf8_str(path);
 	const char* path_c_str = path_str.c_str();
 	if (gLanguageConfig && gLanguageConfig->pathIsExcluded(path)) {


### PR DESCRIPTION
this cherrypicks the most conservative commits out of #2431. this removes the following startup posts, which are not useful at all and were probably mistakenly left in:

    init_OSC
    initPassOne started
    initPassOne done
    pass 1 done