### PR TITLE
cmake/travis: use ccache, add support for Xcode+ccache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
-compiler:
- - gcc
+language: cpp
 
 matrix:
   fast_finish: true
@@ -19,8 +18,7 @@ matrix:
       env: QT=true
 
 cache:
- - apt
- - bundler
+ - ccache
 
 before_install:
  - $TRAVIS_BUILD_DIR/.travis/before-install-$TRAVIS_OS_NAME.sh --qt=$QT

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,6 @@ before_install:
 
 before_script:
  - mkdir BUILD && cd BUILD
- - if [[ $QT == true ]]; then export QT_PREFIX=$HOME/qt/gcc_64; fi
- - if [[ $QT == true ]]; then export QT_PLUGIN_PATH=$QT_PREFIX/plugins; fi
 
  - $TRAVIS_BUILD_DIR/.travis/before-script-$TRAVIS_OS_NAME.sh --qt=$QT
 # prep for testing

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,8 @@ matrix:
 
 # use ccache to speed up build times. on osx,
 # we install it during the the before_install step
+# with xcode, this requires an additional flag passed during the configuration phase.
+# see README_MACOS.md for details.
 cache:
  - ccache
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,8 @@ matrix:
       osx_image: xcode7.3
       env: QT=true
 
+# use ccache to speed up build times. on osx,
+# we install it during the the before_install step
 cache:
  - ccache
 

--- a/.travis/before-install-osx.sh
+++ b/.travis/before-install-osx.sh
@@ -3,6 +3,11 @@
 brew update
 brew tap homebrew/versions
 brew outdated cmake || brew upgrade cmake
-brew install libsndfile python || true
+
+# according to https://docs.travis-ci.com/user/caching#ccache-cache
+brew install ccache
+export PATH="/usr/local/opt/ccache/libexec:$PATH"
+
+brew install libsndfile || true
 brew install qt55 || true
 brew link qt55 --force

--- a/.travis/before-script-osx.sh
+++ b/.travis/before-script-osx.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-cmake -G"Xcode" -DCMAKE_PREFIX_PATH=`brew --prefix qt55` -DCMAKE_OSX_DEPLOYMENT_TARGET=10.7 $TRAVIS_BUILD_DIR --debug-output
+cmake -G"Xcode" -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_PREFIX_PATH=`brew --prefix qt55` -DCMAKE_OSX_DEPLOYMENT_TARGET=10.7 $TRAVIS_BUILD_DIR --debug-output

--- a/.travis/before-script-osx.sh
+++ b/.travis/before-script-osx.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-cmake -G"Xcode" -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_PREFIX_PATH=`brew --prefix qt55` -DCMAKE_OSX_DEPLOYMENT_TARGET=10.7 $TRAVIS_BUILD_DIR --debug-output
+cmake -G"Xcode" -DRULE_LAUNCH_COMPILE=ccache -DCMAKE_PREFIX_PATH=`brew --prefix qt55` -DCMAKE_OSX_DEPLOYMENT_TARGET=10.7 $TRAVIS_BUILD_DIR --debug-output

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,32 @@ CONFIGURE_FILE(
   "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake"
   IMMEDIATE @ONLY)
 
+# workaround for using ccache with Xcode generator
+# thanks to Craig Scott: https://crascit.com/2016/04/09/using-ccache-with-cmake/
+get_property(RULE_LAUNCH_COMPILE GLOBAL PROPERTY RULE_LAUNCH_COMPILE)
+if(RULE_LAUNCH_COMPILE AND CMAKE_GENERATOR STREQUAL "Xcode")
+
+    # find ccache
+    find_program(CCACHE_PROGRAM ccache)
+
+    message(STATUS "Xcode and ccache detected: using ccache to speed up build process")
+
+    # Set up wrapper scripts
+    set(SC_LAUNCH_C_SCRIPT   "${CMAKE_BINARY_DIR}/launch-c")
+    set(SC_LAUNCH_CXX_SCRIPT "${CMAKE_BINARY_DIR}/launch-cxx")
+
+    configure_file("cmake_modules/launch-c.in"   launch-c)
+    configure_file("cmake_modules/launch-cxx.in" launch-cxx)
+    execute_process(COMMAND chmod a+rx "${SC_LAUNCH_C_SCRIPT}" "${SC_LAUNCH_CXX_SCRIPT}")
+
+    # Set Xcode project attributes to route compilation and linking
+    # through our scripts
+    set(CMAKE_XCODE_ATTRIBUTE_CC         "${SC_LAUNCH_C_SCRIPT}")
+    set(CMAKE_XCODE_ATTRIBUTE_CXX        "${SC_LAUNCH_CXX_SCRIPT}")
+    set(CMAKE_XCODE_ATTRIBUTE_LD         "${SC_LAUNCH_C_SCRIPT}")
+    set(CMAKE_XCODE_ATTRIBUTE_LDPLUSPLUS "${SC_LAUNCH_CXX_SCRIPT}")
+endif()
+
 ADD_CUSTOM_TARGET(uninstall
   "${CMAKE_COMMAND}" -P "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake")
 

--- a/README_MACOS.md
+++ b/README_MACOS.md
@@ -18,6 +18,7 @@ Table of contents
  * Diagnosing build problems
  * Frequently used cmake settings
  * Using cmake with Xcode or QtCreator
+ * Using ccache with Xcode
  * Building without Qt or the IDE
  * sclang and scynth executables
 
@@ -276,6 +277,12 @@ Qt Creator has very good `cmake` integration and can build `cmake` projects with
 
     brew linkapps qt5
 
+Using ccache with Xcode
+-----------------------
+
+Although cmake does not support using `ccache` with Xcode out of the box, this project is set up to
+allow it with the option `-DLAUNCH_RULE_COMPILE=ccache`. This can speed up build times
+significantly, even when the build directory has been cleared.
 
 Building without Qt or the IDE
 ------------------------------

--- a/cmake_modules/launch-c.in
+++ b/cmake_modules/launch-c.in
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+# thanks to Craig Scott: https://crascit.com/2016/04/09/using-ccache-with-cmake/
+export CCACHE_CPP2=true
+exec "${RULE_LAUNCH_COMPILE}" "${CMAKE_CXX_COMPILER}" "$@"

--- a/cmake_modules/launch-cxx.in
+++ b/cmake_modules/launch-cxx.in
@@ -1,0 +1,5 @@
+#!/bin/sh
+# Thanks to Craig Scott: https://crascit.com/2016/04/09/using-ccache-with-cmake/
+
+export CCACHE_CPP2=true
+exec "${RULE_LAUNCH_COMPILE}" "${CMAKE_CXX_COMPILER}" "$@"


### PR DESCRIPTION
Problem: builds take a long time on travis.
Solution: use [ccache](https://ccache.samba.org/).

Problem 2: ccache + cmake + xcode doesn't work out of the box
Solution 2: workaround thanks to Craig Scott: https://crascit.com/2016/04/09/using-ccache-with-cmake/

Other changes:
- set `language: cpp` in `.travis.yml`. According to travis's docs, this is needed to access ccache caching.
- remove `compiler: gcc`. this was redundant, and wasn't being used by any of the builds.
- new files in `cmake_modules/` according to Craig Scott's post. Minimal shell scripts that do the necessary dirty jobs.

Pros:
- cached between builds
- reduces overall build time by more than 50% (and more than 75% on linux).
- ccache reproduces compiler warnings on cached compilations
- macOS devs can also use ccache to speed up compilation time, even on fresh builds
- since many of our PRs only affect the class library or a few files, we will see time savings near this level a vast majority of the time
- easy to turn on and off in travis (just remove the key in the main `.travis.yml` file)
- the xcode workaround is actually supported back to Cmake 2.8, which is our minimum Cmake version according to CMakeLists.txt

Cons:
- ???: none that I can think of. possible, but very unlikely issues under pathological hash collision cases.

Compare:
before: https://travis-ci.org/brianlheim/supercollider/builds/266315015
after: https://travis-ci.org/brianlheim/supercollider/builds/266339318

```
environment  time-before-ccache  time-after-ccache  savings
linux+Qt     17.22               03.40              13.42
linux-Qt     08.50               02.27              06.23
osx+Qt       14.08               07.53              06.15
TOTAL        30.20               14.00              16.20
```

Note: you won't see the speedup until there has been at least one successful build on the master branch