### PR TITLE
lang: reword "NumPrimitives =" post

### DIFF
--- a/lang/LangPrimSource/PyrPrimitive.cpp
+++ b/lang/LangPrimSource/PyrPrimitive.cpp
@@ -4336,7 +4336,7 @@ void initOpenGLPrimitives();
 	initSCDocPrimitives();
 
 	s_recvmsg = getsym("receiveMsg");
-	post("\tNumPrimitives = %d\n", nextPrimitiveIndex());
+	post("\tFound %d primitives.\n", nextPrimitiveIndex());
 }
 
 void deinitPrimitives()


### PR DESCRIPTION
this commit changes the startup message

	NumPrimitives = #

to

	Found # primitives.

[supercollider.js does not appear to parse it.](https://github.com/crucialfelix/supercolliderjs/blob/c95740ac398b4cf50d1536289d2e8244707dfbe1/src/lang/internals/sclang-io.js#L380)