### PR TITLE
lang: make "Byte Code Size" and "Number of Symbols" posts only in debug mode

### DIFF
--- a/lang/LangSource/PyrLexer.cpp
+++ b/lang/LangSource/PyrLexer.cpp
@@ -1672,11 +1672,11 @@ void traverseFullDepTree2()
 		} else {
 			double elapsed;
 			buildBigMethodMatrix();
+#ifndef NDEBUG
 			SymbolTable* symbolTable = gMainVMGlobals->symbolTable;
-			post("\tNumber of Symbols %d\n", symbolTable->NumItems());
-			post("\tByte Code Size %d\n", totalByteCodes);
-			//elapsed = TickCount() - compileStartTime;
-			//elapsed = 0;
+			post("\tSymbol table has %d items.\n", symbolTable->NumItems());
+			post("\tCompiled %d byte code elements.\n", totalByteCodes);
+#endif
 			elapsed = elapsedTime() - compileStartTime;
 			post("\tcompiled %d files in %.2f seconds\n",
 				 gNumCompiledFiles, elapsed );


### PR DESCRIPTION
does anyone know what these mean? are they useful information at all? we
already have post messages for the size of the method table.