### PR TITLE
Update 12-Groups.schelp

### DIFF
--- a/HelpSource/Tutorials/Getting-Started/12-Groups.schelp
+++ b/HelpSource/Tutorials/Getting-Started/12-Groups.schelp
@@ -46,7 +46,7 @@ SynthDef(\tutorial_Reverb2, { arg outBus = 0, inBus;
 
 // now synths in the groups. The default addAction is \addToHead
 (
-x = Synth(\tutorial_Reverb2, [\inBus, b], ~effects);
+x = Synth(\tutorial_Reverb2, [\inBus, ~bus], ~effects);
 y = Synth(\tutorial_DecaySin2, [\effectBus, ~bus, \outBus, 0], ~sources);
 z = Synth(\tutorial_DecaySin2, [\effectBus, ~bus, \outBus, 0, \freq, 660], ~sources);
 )


### PR DESCRIPTION
Here the effect bus should be passed. This might have been overlooked for a long time as the example sounds, but it doesn't work as it should with other parameters.

http://new-supercollider-mailing-lists-forums-use-these.2681727.n2.nabble.com/new-to-SC3-about-default-Buses-quot-b-c-quot-td7634676.html