### PR TITLE
Supernova: use LIB_SUFFIX for plugin loading

### DIFF
--- a/server/supernova/CMakeLists.txt
+++ b/server/supernova/CMakeLists.txt
@@ -234,3 +234,11 @@ endif()
 if(${JACK_USE_METADATA_API})
     target_compile_definitions(libsupernova PUBLIC "-DSC_JACK_USE_METADATA_API")
 endif()
+
+
+
+if(${LIB_SUFFIX})
+    add_definitions(-DLIB_SUFFIX="${LIB_SUFFIX}")
+else()
+    add_definitions(-DLIB_SUFFIX="")
+endif()

--- a/server/supernova/server/main.cpp
+++ b/server/supernova/server/main.cpp
@@ -245,8 +245,7 @@ void set_plugin_paths(server_arguments const & args, nova::sc_ugen_factory * fac
 #ifdef __linux__
         const path home = resolve_home();
         std::vector<path> folders = { "/usr/local/lib/SuperCollider/plugins",
-                                      "/usr/lib/SuperCollider/plugins",
-                                      "/usr/lib64/SuperCollider/plugins",
+                                      "/usr/lib" LIB_SUFFIX "/SuperCollider/plugins",
                                       home / "/.local/share/SuperCollider/Extensions",
                                       home / "share/SuperCollider/plugins" };
 


### PR DESCRIPTION
Commit 547a18c introduced the CMake variable LIB_SUFFIX to determine the
system library folder, and made supernova load plugins in both /usr/lib
and /usr/lib64.
On some systems (eg archlinux64) lib64 is symlinked to lib, supernova then
tries to load the plugins twice and crashes.
We want supernova to load only the folder in which the plugins have been
installed.