### PR TITLE
Fix pv copy help

### DIFF
--- a/HelpSource/Classes/PV_Copy.schelp
+++ b/HelpSource/Classes/PV_Copy.schelp
@@ -6,7 +6,9 @@ description::
 
 Copies the spectral frame in bufferA to bufferB at that point in the chain of PV UGens. This allows for parallel processing of spectral data without the need for multiple FFT UGens, and to copy out data at that point in the chain for other purposes. bufferA and bufferB must be the same size.
 
-note::As of SC 3.7 instances of PV_Copy are added automatically where necessary for parallel processing. This document is provided for legacy purposes only. (Existing code explicitly using PV_Copy should continue to work.)::
+note::As of SC 3.7 instances of PV_Copy are added automatically where necessary for parallel processing. Please see link::Guides/FFT-Overview:: for the current implementation. 
+
+This document is provided for legacy purposes only. (Existing code explicitly using PV_Copy should continue to work.)::
 
 classmethods::
 method:: new

--- a/HelpSource/Classes/PV_Copy.schelp
+++ b/HelpSource/Classes/PV_Copy.schelp
@@ -4,11 +4,11 @@ categories:: UGens>FFT
 
 description::
 
-Copies the spectral frame in bufferA to bufferB at that point in the chain of PV UGens. This allows for parallel processing of spectral data without the need for multiple FFT UGens, and to copy out data at that point in the chain for other purposes. bufferA and bufferB must be the same size.
+Copies the spectral frame in code::bufferA:: to code::bufferB::. This allows for parallel processing of spectral data without the need for multiple FFT UGens. Further it allows to extract data at a given point in the FFT chain e.g. for monitoring purposes. 
 
 note::As of SC 3.7 instances of PV_Copy are added automatically where necessary for parallel processing. Please see link::Guides/FFT-Overview:: for the current implementation. 
 
-This document is provided for legacy purposes only. (Existing code explicitly using PV_Copy should continue to work.)::
+This document is provided for legacy purposes only. Existing code explicitly using PV_Copy should continue to work.::
 
 classmethods::
 method:: new
@@ -17,43 +17,36 @@ source buffer.
 argument:: bufferB
 destination buffer.
 
+note:: 
+code::bufferA:: and code::bufferB:: must be the same size.
+::
+
 examples::
 code::
-(
-s.waitForBoot({
-	d = Buffer.read(s, Platform.resourceDir +/+ "sounds/a11wlk01.wav");
-})
-)
 
-
-//// crossfade between original and magmul-ed whitenoise
+//proof of concept - PV_Copy creates a duplicate
 (
-x = { var in, in2, chain, chainB, chainC;
-	in = PlayBuf.ar(1, d, BufRateScale.kr(d), loop: 1) * 2;
-	in2 = WhiteNoise.ar;
-	chain = FFT(LocalBuf(2048), in);
-	chainB = FFT(LocalBuf(2048), in2);
-	chainC = PV_Copy(chain, LocalBuf(2048));
-	chainB = PV_MagMul(chainB, chainC);
-	XFade2.ar(IFFT(chain), IFFT(chainB) * 0.1, SinOsc.kr(0.1, 1.5pi));
+x = { var inA, chainA, inB, chainB, chain;
+	inA = LFClipNoise.ar(100);
+	chainA = FFT(LocalBuf(1024), inA);
+	chainB = PV_Copy(chainA, LocalBuf(1024));
+
+	IFFT(chainA) - IFFT(chainB); // cancels to zero so silent!
 }.play(s);
 )
 x.free;
 
 
-
-
-//// as previous but with Blip for 'vocoder' cross synthesis effect
 (
-x = { var in, in2, chain, chainB, chainC;
-	in = PlayBuf.ar(1, d, BufRateScale.kr(d), loop: 1) * 2;
-	in2 = Blip.ar(100, 50);
+x = { var in, chain, chainB;
+	in = WhiteNoise.ar(0.8);
 	chain = FFT(LocalBuf(2048), in);
-	chainB = FFT(LocalBuf(2048), in2);
-	chainC = PV_Copy(chain, LocalBuf(2048));
-	chainB = PV_MagMul(chainB, chainC);
-	XFade2.ar(IFFT(chain), IFFT(chainB) * 0.1, SinOsc.ar(0.1));
-}.play(s);
+	chainB = PV_Copy(chain,LocalBuf(2048));  //copies the FFT analysis into a new buffer
+	chain = PV_RandComb(chain, 0.95, Impulse.kr(0.4));
+	chainB = PV_BrickWall(chainB, SinOsc.kr(0.2));
+
+	[IFFT(chain), IFFT(chainB)*0.1];
+}.play;
 )
 x.free;
 
@@ -61,85 +54,16 @@ x.free;
 //// Spectral 'pan'
 (
 x = { var in, chain, chainB, pan;
-	in = PlayBuf.ar(1, d, BufRateScale.kr(d), loop: 1);
+	in = BrownNoise.ar;
 	chain = FFT(LocalBuf(2048), in);
 	chainB = PV_Copy(chain, LocalBuf(2048));
 	pan = MouseX.kr(0.001, 1.001, 'exponential') - 0.001;
 	chain = PV_BrickWall(chain, pan);
 	chainB = PV_BrickWall(chainB, -1 + pan);
-	0.5 * IFFT([chain, chainB]);
+
+	0.1 * IFFT([chain, chainB]);
 }.play(s);
 )
 x.free;
-
-
-(
-s.waitForBoot({
-	b = Buffer.alloc(s,2048,1);
-	c = Buffer.alloc(s,2048,1);
-	d = Buffer.read(s, Platform.resourceDir +/+ "sounds/a11wlk01.wav");
-	e = Buffer.alloc(s,2048,1);
-	f = Buffer.alloc(s,2048,1);
-})
-)
-
-
-//// proof of concept
-(
-x = { var inA, chainA, inB, chainB, chain;
-	inA = LFClipNoise.ar(100);
-	chainA = FFT(b, inA);
-	chainB = PV_Copy(chainA, c);
-	IFFT(chainA) - IFFT(chainB); // cancels to zero so silent!
-}.play(s);
-)
-x.free;
-// IFFTed frames contain the same windowed output data
-b.plot(\b, Rect(200, 430, 700, 300)); c.plot(\c, Rect(200, 100, 700, 300));
-
-
-
-//// Multiple Magnitude plots
-(
-x = { var in, chain, chainB, chainC;
-	in = WhiteNoise.ar;
-	chain = FFT(b, in);
-	PV_Copy(chain, LocalBuf(2048)); // initial spectrum
-	chain = PV_RectComb(chain, 20, 0, 0.2);
-	PV_Copy(chain, LocalBuf(2048)); // after comb
-	2.do({chain = PV_MagSquared(chain)});
-	PV_Copy(chain, LocalBuf(2048)); // after magsquared
-	0.00001 * Pan2.ar(IFFT(chain));
-}.play(s);
-)
-x.free;
-
-(
-c.getToFloatArray(action: { arg array;
-	var z, x;
-	z = array.clump(2).flop;
-	// Initially data is in complex form
-	z = [Signal.newFrom(z[0]), Signal.newFrom(z[1])];
-	x = Complex(z[0], z[1]);
-	{x.magnitude.plot('Initial', Rect(200, 560, 700, 200))}.defer
-});
-e.getToFloatArray(action: { arg array;
-	var z, x;
-	z = array.clump(2).flop;
-	// RectComb doesn't convert, so it's still complex
-	z = [Signal.newFrom(z[0]), Signal.newFrom(z[1])];
-	x = Complex(z[0], z[1]);
-	{x.magnitude.plot('After RectComb', Rect(200, 330, 700, 200))}.defer
-});
-f.getToFloatArray(action: { arg array;
-	var z, x;
-	z = array.clump(2).flop;
-	// MagSquared converts to Polar
-	x = Signal.newFrom(z[0]); // magnitude first
-	{x.plot('After MagSquared', Rect(200, 100, 700, 200))}.defer
-})
-)
-
-[b, c, d, e, f].do(_.free); // free the buffers
 ::
 

--- a/HelpSource/Guides/FFT-Overview.schelp
+++ b/HelpSource/Guides/FFT-Overview.schelp
@@ -80,27 +80,37 @@ d = Buffer.read(s, Platform.resourceDir +/+ "sounds/a11wlk01.wav");
 d.free;
 ::
 
-Because each PV UGen overwrites the output of the previous one, it is necessary to copy the data to an additional buffer at the desired point in the chain in order to do parallel processing of input without using multiple FFT UGens. link::Classes/PV_Copy:: allows for this.
+As seen below, SuperCollider can create chains of PV processes, which alter the same FFT buffer in series. The PV Ugen writes the output of its process in place, and the effect of one process feeds into the next:
+
 code::
 (
-b = Buffer.alloc(s,2048,1); // use global buffers for plotting the data
-c = Buffer.alloc(s,2048,1);
-)
-
-//// proof of concept
-(
-x = { var inA, chainA, chainB;
-    inA = LFClipNoise.ar(100);
-    chainA = FFT(b, inA);
-    chainB = PV_Copy(chainA, c);
-    IFFT(chainA) - IFFT(chainB); // cancels to zero so silent!
+{ var in, chain;
+    in = WhiteNoise.ar(0.8);
+    chain = FFT(LocalBuf(2048), in);
+    chain = PV_RandComb(chain, 0.95, Impulse.kr(0.4));
+	chain = PV_BrickWall(chain, SinOsc.kr(0.2));
+    IFFT(chain);
 }.play;
 )
-x.free;
-// IFFTed frames contain the same windowed output data
-b.plot(\b, Rect(200, 430, 700, 300), nil, nil); c.plot(\c, Rect(200, 100, 700, 300), nil, nil);
-[b, c].do(_.free);
 ::
+
+PV processes can also share a single FFT ugen to process a signal in parallel. In the following example, 'chain0' and 'chain1' share the same FFT ugen. SuperCollider automatically copies the FFT data from 'chain' into hidden LocalBufs inside the Synth. The processes thus operate independently on the original FFT analysis:
+
+code::
+
+(
+{ var in, chain, chain0, chain1;
+    in = WhiteNoise.ar(0.8);
+    chain = FFT(LocalBuf(2048), in);
+    chain0 = PV_RandComb(chain, 0.95, Impulse.kr(0.4));
+	chain1 = PV_BrickWall(chain, SinOsc.kr(0.2));
+	[IFFT(chain0), IFFT(chain1)*0.1];
+}.play;
+)
+::
+
+note::Parallel processing was previously acheived using PV_Copy. PV_Copy code should continue to work, but new code should be written as it appears above.::
+
 
 Note that PV UGens convert as needed between cartesian (complex) and polar representations, therefore when using multiple PV UGens it may be impossible to know in which form the values will be at any given time. FFT produces complex output (see above), so while the following produces a reliable magnitude plot:
 code::
@@ -201,7 +211,6 @@ definitionlist::
 ## link::Classes/PV_BinWipe:: || combine low and high bins from two inputs
 ## link::Classes/PV_BrickWall:: || zero bins
 ## link::Classes/PV_ConformalMap:: || complex plane attack
-## link::Classes/PV_Copy:: || copy an FFT buffer
 ## link::Classes/PV_CopyPhase:: || copy magnitudes and phases
 ## link::Classes/PV_Diffuser:: || random phase shifting
 ## link::Classes/PV_HainsworthFoote:: || onset detection

--- a/HelpSource/Guides/FFT-Overview.schelp
+++ b/HelpSource/Guides/FFT-Overview.schelp
@@ -115,27 +115,45 @@ code::
 )
 ::
 
-note::Parallel processing was previously acheived using PV_Copy. PV_Copy code should continue to work, but new code should be written as it appears above.::
+note::Parallel processing was previously achieved using PV_Copy. PV_Copy code should continue to work, but new code should be written as it appears above.::
 
+section:: Accessing Frame Data
 
-Note that PV UGens convert as needed between cartesian (complex) and polar representations, therefore when using multiple PV UGens it may be impossible to know in which form the values will be at any given time. FFT produces complex output (see above), so while the following produces a reliable magnitude plot:
+FFT produces complex output, which can be accessed on each frame of the analysis. The following example plots the magnitude data on an analysis of WhiteNoise for three frames that are 0.1 seconds apart:
 code::
-b = Buffer.alloc(s,1024); // use global buffers for plotting the data
-a = { FFT(b, LFSaw.ar(4000)); 0.0 }.play;
-(
-b.getn(0, 1024, { arg buf;
-	var z, x;
-	z = buf.clump(2).flop;
-	z = [Signal.newFrom(z[0]), Signal.newFrom(z[1])];
-	x = Complex(z[0], z[1]);
-	{x.magnitude.plot}.defer
-})
-)
-a.free; b.free;
-::
-any Synth using PV UGens might not.
+c = Buffer.alloc(s,2048,1);
 
-It is possible to manipulate the FFT data directly within a synth graph (if there doesn't already exist a PV UGen which will do what you want), using the methods pvcalc, pvcalc2, pvcollect. Here's an example which uses the link::Classes/SequenceableCollection:: methods clump and flop to rearrange the order of the spectral bins:
+(
+x = { var in, chain, chainB, chainC;
+	in = WhiteNoise.ar;
+	chain = FFT(c, in);
+	0.01 * Pan2.ar(IFFT(chain));
+}.play(s);
+)
+
+(
+Routine({
+	3.do{arg i;
+		c.getToFloatArray(action: { arg array;
+			var z, x;
+			z = array.clump(2).flop;
+			// Initially data is in complex form
+			z = [Signal.newFrom(z[0]), Signal.newFrom(z[1])];
+			x = Complex(z[0], z[1]);
+			
+			{ x.magnitude.plot('Initial', Rect(200, 600-(200*i), 700, 200)) }.defer
+		});
+		0.1.wait;
+}}).play
+)
+
+x.free;
+::
+Note that PV UGens convert as needed between cartesian (complex) and polar representations, therefore when using multiple PV UGens it may be impossible to know in which form the values will be at any given time. So while the example above produces reliable amplitude plots, any Synth using PV UGens might not.
+
+section:: Manipulating FFT Data Directly (PV_ChainUGens)
+
+It is possible to manipulate the FFT data directly within a synth graph (if there doesn't already exist a PV UGen which will do what you want), using the methods pvcalc, pvcalc2, pvcollect (see link::Classes/PV_ChainUGen:: for more examples). Here's an example which uses the link::Classes/SequenceableCollection:: methods clump and flop to rearrange the order of the spectral bins:
 code::
 c = Buffer.read(s, Platform.resourceDir +/+ "sounds/a11wlk01.wav");
 

--- a/HelpSource/Guides/FFT-Overview.schelp
+++ b/HelpSource/Guides/FFT-Overview.schelp
@@ -25,6 +25,7 @@ code::
 	in = WhiteNoise.ar(0.8);
 	chain = FFT(LocalBuf(2048), in);
 	chain = PV_RandComb(chain, 0.95, Impulse.kr(0.4));
+
 	IFFT(chain);
 }.play;
 )
@@ -38,6 +39,7 @@ code::
 	in = Ringz.ar(Impulse.ar([2, 3]), [700, 800], 0.1) * 5;
 	chain = FFT({ LocalBuf(2048) } ! 2, in);
 	chain = PV_RandComb(chain, 0.95, Impulse.kr(0.4));
+
 	IFFT(chain);
 }.play;
 )
@@ -54,6 +56,7 @@ code::
 	chainA = FFT(LocalBuf(2048), inA);
 	chainB = FFT(LocalBuf(2048), inB);
 	chain = PV_MagMul(chainA, chainB); // writes into bufferA
+
 	0.1 * IFFT(chain);
 }.play;
 )
@@ -73,6 +76,7 @@ d = Buffer.read(s, Platform.resourceDir +/+ "sounds/a11wlk01.wav");
 	chainA = FFT(LocalBuf(2048), inA);
 	chainB = FFT(LocalBuf(2048), inB);
 	chain = PV_MagMul(chainA, chainB); // writes into bufferA
+
 	0.1 * IFFT(chain);
 }.play;
 )
@@ -85,11 +89,12 @@ As seen below, SuperCollider can create chains of PV processes, which alter the 
 code::
 (
 { var in, chain;
-    in = WhiteNoise.ar(0.8);
-    chain = FFT(LocalBuf(2048), in);
-    chain = PV_RandComb(chain, 0.95, Impulse.kr(0.4));
-	chain = PV_BrickWall(chain, SinOsc.kr(0.2));
-    IFFT(chain);
+	in = WhiteNoise.ar(0.8);
+ 	chain = FFT(LocalBuf(2048), in);
+ 	chain = PV_RandComb(chain, 0.95, Impulse.kr(0.4));
+ 	chain = PV_BrickWall(chain, SinOsc.kr(0.2));
+
+	IFFT(chain);
 }.play;
 )
 ::
@@ -100,10 +105,11 @@ code::
 
 (
 { var in, chain, chain0, chain1;
-    in = WhiteNoise.ar(0.8);
-    chain = FFT(LocalBuf(2048), in);
-    chain0 = PV_RandComb(chain, 0.95, Impulse.kr(0.4));
+	in = WhiteNoise.ar(0.8);
+	chain = FFT(LocalBuf(2048), in);
+	chain0 = PV_RandComb(chain, 0.95, Impulse.kr(0.4));
 	chain1 = PV_BrickWall(chain, SinOsc.kr(0.2));
+
 	[IFFT(chain0), IFFT(chain1)*0.1];
 }.play;
 )
@@ -135,16 +141,16 @@ c = Buffer.read(s, Platform.resourceDir +/+ "sounds/a11wlk01.wav");
 
 (
 x = {
-  var in, numFrames=2048, chain, v;
-  in = PlayBuf.ar(1, c, loop: 1);
-  chain = FFT(LocalBuf(numFrames), in);
+	var in, numFrames=2048, chain, v;
+	in = PlayBuf.ar(1, c, loop: 1);
+	chain = FFT(LocalBuf(numFrames), in);
 
-  chain = chain.pvcalc(numFrames, {|mags, phases|
-      /* Play with the mags and phases, then return them */
-      [mags, phases].flop.clump(2).flop.flatten
-  }, tobin: 250);
+	chain = chain.pvcalc(numFrames, {|mags, phases|
+		/* Play with the mags and phases, then return them */
+		[mags, phases].flop.clump(2).flop.flatten
+	}, tobin: 250);
 
-  0.5 * IFFT(chain).dup
+	0.5 * IFFT(chain).dup
 }.play;
 )
 x.free; c.free;
@@ -168,6 +174,7 @@ SynthDef("help-multichannel FFT", { |out=0| // bufnum is an array
 	chain = FFT(LocalBuf([2048, 2048]), in); // each FFT has a different buffer
 	// now we can multichannel expand as normal
 	chain = PV_BrickWall(chain, SinOsc.kr(-0.1));
+
 	Out.ar(out, IFFT(chain));
 }).play;
 )
@@ -183,6 +190,7 @@ SynthDef("help-multichannel FFT", { |out=0, bufnum= #[0, 1]| // bufnum is an arr
 	chain = FFT(bufnum, in); // each FFT has a different buffer
 	// now we can multichannel expand as normal
 	chain = PV_BrickWall(chain, SinOsc.kr(-0.1));
+
 	Out.ar(out, IFFT(chain));
 }).play(s,[\bufnum, b]);
 )


### PR DESCRIPTION
Updated FFT Overview and PV_Copy help files to reflect the current syntax for automatically copying FFT data for parallel PV streams.