### PR TITLE
Fix SimpleNumber.asTimeString

### DIFF
--- a/HelpSource/Classes/SimpleNumber.schelp
+++ b/HelpSource/Classes/SimpleNumber.schelp
@@ -307,20 +307,27 @@ method:: asAudioRateInput
 Converts this into an audiorate input.
 
 method:: asTimeString
-Compile a time string.
+Produces a time string in the format code::ddd:hh:mm:ss.sss::, interpreting the receiver as time in
+seconds. See link::String#-asSecs:: for the inverse function.
 argument:: precision
-how accurate
+accuracy of the millisecond format; the string will always be formatted with 3 decimal places for
+milliseconds. Minimum value: 0.001.
 argument::maxDays
-the maximum number of days
+maximum number of days
 argument::dropDaysIfPossible
-a link::Classes/Boolean::
-returns:: a string corresponding to the hours:minutes:seconds based on the receiver as number of seconds
+a link::Classes/Boolean::. If set to code::true::, and the number of days in the formatted string
+would be 0, that section is instead ommitted and the string is formatted as code::hh:mm:ss.sss::.
 discussion::
 code::
 (
 var start;
 start = Main.elapsedTime;
-{ loop({(Main.elapsedTime - start).asTimeString.postln; 0.05.wait}) }.fork;
+{
+	loop {
+		(Main.elapsedTime - start).asTimeString.postln;
+		0.05.wait
+	}
+}.fork;
 )
 ::
 

--- a/SCClassLibrary/Common/Math/SimpleNumber.sc
+++ b/SCClassLibrary/Common/Math/SimpleNumber.sc
@@ -472,7 +472,7 @@ SimpleNumber : Number {
 	asQuant { ^Quant(this) }
 
 	// a clock format inspired by ISO 8601 time interval display (truncated representation)
-	// receiver is a time in seconds, returns string "ddd:hh:mm:ss:ttt" where t is milliseconds
+	// receiver is a time in seconds, returns string "ddd:hh:mm:ss.sss"
 	// see String:asSecs for complement
 
 	asTimeString { arg precision = 0.001, maxDays = 365, dropDaysIfPossible = true;
@@ -486,7 +486,7 @@ SimpleNumber : Number {
 		};
 		hours = (decimal.div(3600) % 24).asString.padLeft(2, "0").add($:);
 		minutes = (decimal.div(60) % 60).asString.padLeft(2, "0").add($:);
-		seconds = (decimal % 60).asString.padLeft(2, "0").add($:);
+		seconds = (decimal % 60).asString.padLeft(2, "0").add($.);
 		mseconds = (this.frac / precision).round(precision).asInteger.asString.padLeft(3, "0");
 		^days ++ hours ++ minutes ++ seconds ++ mseconds
 	}

--- a/SCClassLibrary/Common/Math/SimpleNumber.sc
+++ b/SCClassLibrary/Common/Math/SimpleNumber.sc
@@ -487,7 +487,11 @@ SimpleNumber : Number {
 		hours = (decimal.div(3600) % 24).asString.padLeft(2, "0").add($:);
 		minutes = (decimal.div(60) % 60).asString.padLeft(2, "0").add($:);
 		seconds = (decimal % 60).asString.padLeft(2, "0").add($.);
-		mseconds = (this.frac / precision).round(precision).asInteger.asString.padLeft(3, "0");
+
+		// min value of precision is 0.001; this ensures that we stick to 3 decimal places in the
+		// formatted string.
+		precision = max(precision, 0.001);
+		mseconds = (this.frac / precision).round(precision).asInteger.asString.padRight(3, "0");
 		^days ++ hours ++ minutes ++ seconds ++ mseconds
 	}
 

--- a/SCClassLibrary/Common/Math/SimpleNumber.sc
+++ b/SCClassLibrary/Common/Math/SimpleNumber.sc
@@ -491,7 +491,8 @@ SimpleNumber : Number {
 		// min value of precision is 0.001; this ensures that we stick to 3 decimal places in the
 		// formatted string.
 		precision = max(precision, 0.001);
-		mseconds = (this.frac / precision).round(precision).asInteger.asString.padRight(3, "0");
+		mseconds = this.frac.round(precision) * 1000;
+		mseconds = mseconds.round.asString.padLeft(3, "0");
 		^days ++ hours ++ minutes ++ seconds ++ mseconds
 	}
 

--- a/testsuite/classlibrary/TestSimpleNumber.sc
+++ b/testsuite/classlibrary/TestSimpleNumber.sc
@@ -1,0 +1,105 @@
+// TestSimpleNumber.sc
+// Tests for the SimpleNumber class
+TestSimpleNumber : UnitTest {
+
+	//////////////////////
+	// asTimeString tests
+	//////////////////////
+
+	test_asTimeString_zero {
+		var expected = "00:00:00.000";
+		var actual = 0.asTimeString;
+		this.assert(actual == expected, "expected %, got %".format(expected, actual));
+	}
+
+	test_asTimeString_zeroNotDroppingDays {
+		var expected = "000:00:00:00.000";
+		var actual = 0.asTimeString(dropDaysIfPossible: false);
+		this.assert(actual == expected, "expected %, got %".format(expected, actual));
+	}
+
+	test_asTimeString_nearZeroRoundDown {
+		var expected = "00:00:00.000";
+		var actual = 0.0001.asTimeString;
+		this.assert(actual == expected, "expected %, got %".format(expected, actual));
+	}
+
+	test_asTimeString_nearZeroRoundUp {
+		var expected = "00:00:00.001";
+		var actual = 0.0009.asTimeString;
+		this.assert(actual == expected, "expected %, got %".format(expected, actual));
+	}
+
+	test_asTimeString_milliseconds {
+		var expected = "00:00:00.015";
+		var actual = 0.015.asTimeString;
+		this.assert(actual == expected, "expected %, got %".format(expected, actual));
+	}
+
+	test_asTimeString_millisecondPrecisionTenths {
+		var expected = "00:00:05.500";
+		var actual = 5.478.asTimeString(precision: 0.1);
+		this.assert(actual == expected, "expected %, got %".format(expected, actual));
+	}
+
+	test_asTimeString_millisecondPrecisionHundredths {
+		var expected = "00:00:05.480";
+		var actual = 5.478.asTimeString(precision: 0.01);
+		this.assert(actual == expected, "expected %, got %".format(expected, actual));
+	}
+
+	test_asTimeString_millisecondPrecisionFiftieths {
+		var expected = "00:00:05.480";
+		var actual = 5.471.asTimeString(precision: 0.02);
+		this.assert(actual == expected, "expected %, got %".format(expected, actual));
+	}
+
+	test_asTimeString_seconds {
+		var expected = "00:00:07.015";
+		var actual = 7.015.asTimeString;
+		this.assert(actual == expected, "expected %, got %".format(expected, actual));
+	}
+
+	test_asTimeString_minutes {
+		var expected = "00:02:07.015";
+		var actual = 127.015.asTimeString;
+		this.assert(actual == expected, "expected %, got %".format(expected, actual));
+	}
+
+	test_asTimeString_hours {
+		var expected = "03:02:07.015";
+
+		var threeHoursInSeconds = 3600 * 3;
+		var totalTime = threeHoursInSeconds + 127.015;
+		var actual = totalTime.asTimeString;
+		this.assert(actual == expected, "expected %, got %".format(expected, actual));
+	}
+
+	test_asTimeString_days {
+		var expected = "002:03:02:07.015";
+
+		var twoDaysInSeconds = 24 * 3600 * 2;
+		var threeHoursInSeconds = 3600 * 3;
+		var totalTime = twoDaysInSeconds + threeHoursInSeconds + 127.015;
+		var actual = totalTime.asTimeString;
+		this.assert(actual == expected, "expected %, got %".format(expected, actual));
+	}
+
+	test_asTimeString_maxDays {
+		var expected = "365:00:00:00.000";
+
+		var numSecondsIn400Days = 400 * 24 * 3600;
+		var actual = numSecondsIn400Days.asTimeString;
+		this.assert(actual == expected, "expected %, got %".format(expected, actual));
+	}
+
+	test_asTimeString_maxDaysWithExtraSeconds {
+		var expected = "365:00:00:10.000";
+
+		var numSecondsIn400Days = 400 * 24 * 3600;
+		var totalTime = numSecondsIn400Days + 10;
+		var actual = totalTime.asTimeString;
+		this.assert(actual == expected, "expected %, got %".format(expected, actual));
+	}
+
+}


### PR DESCRIPTION
As reported by Andrea Valle on the mailing list:

---
54.678.asTimeString
-> 00:00:54:678 // OK

54.678.asTimeString(precision:0.01)
-> 00:00:54:067

54.678.asTimeString(precision:0.1)
00:00:54:006


I don’t get the padding. I was expecting 
00:00:54:670 or 00:00:54:680
and
00:00:54:600 or 00:00:54:700

---

This PR makes several changes:
- use a period instead of colon to separate seconds and milliseconds; this is the correct ISO 8601 format
- correctly pad zeros in the milliseconds field
- fix rounding in the milliseconds field in general
- add unit tests for the core functionality of this method