### PR TITLE
include unittest into common

### DIFF
--- a/HelpSource/Classes/UnitTest.schelp
+++ b/HelpSource/Classes/UnitTest.schelp
@@ -1,0 +1,259 @@
+TITLE:: UnitTest
+summary:: a class for programmatic testing of classes
+categories:: Testing
+related:: Classes/UnitTestResult, Classes/UnitTestScript
+
+DESCRIPTION::
+In order to make sure a method works correctly, a test can be implemented that assures the correct behavior.
+
+It is a common practice to write tests to clarify how an object should respond, and it may avoid inconsistencies on the long run. A test is always a subclass of code::UnitTest::, implementing at least one method starting with code::test_::.
+
+note::
+UnitTests for the Common library classes are kept in the code::testsuite/classlibrary:: directory of the SuperCollider sources.
+
+To install, link::https://github.com/supercollider/supercollider##download the sources:: and add the directory to your code::sclang_conf.yaml::, either by editing it or via the ScIDE preferences.
+::
+
+
+CLASSMETHODS::
+
+PRIVATE:: allTestClasses, classesWithTests, classesWithoutTests, failures, findTestClass, findTestClasses, findTestMethods, findTestedClass, forkIfNeeded, listUntestedMethods, passes, report, reportPasses, reset, run, untestedMethods
+
+METHOD:: gui
+A graphical interface to run and browse all tests
+
+code::
+UnitTest.gui
+::
+
+METHOD:: runTest
+Run a single test for methodName.
+
+ARGUMENT:: methodName
+Should have the format code::"TestPolyPlayerPool:test_prepareChildrenToBundle"::
+
+code::
+UnitTest.reset;
+UnitTest.runTest("TestUnitTest:test_assert");
+::
+
+
+METHOD:: runAll
+runs all subclasses of UnitTest
+
+code::
+UnitTest.reset;
+UnitTest.runAll;
+::
+
+
+METHOD:: runTestClassForClass
+runs testclass for a class
+
+ARGUMENT:: class
+the class
+
+ARGUMENT:: reset
+reset UnitTest environment
+
+ARGUMENT:: report
+report on pass/fail
+
+
+
+
+
+
+INSTANCEMETHODS::
+
+METHOD:: run
+All method names that start with test_ are invoked.
+
+ARGUMENT:: reset
+(describe argument here)
+
+ARGUMENT:: report
+(describe argument here)
+
+returns:: (describe returnvalue here)
+
+code::
+TestUnitTest.new.run;
+::
+
+
+
+
+
+METHOD:: runTestMethod
+Run a single test method of this class
+
+ARGUMENT:: method
+the method to run
+
+code::
+TestUnitTest.new.runTestMethod(TestUnitTest.findMethod(\test_assert));
+::
+
+returns:: (describe returnvalue here)
+
+PRIVATE:: assert, assertArrayFloatEquals, asynchAssert, tearDown, setUp, assertEquals, failed, passed, assertFloatEquals, s, ifAsserts, findTestMethods, wait, bootServer
+
+
+SECTION:: Writing tests by subclassing UnitTest
+
+code::
+YourClass.test
+::
+Runs the test class for code::YourClass::, which is assumed to be named code::TestYourClass::.
+
+If no test class if found it politely declines.
+
+note::
+UnitTests for the Common library classes are kept in the CommonTests quark. 	This enables you to easily install and uninstall these tests.
+::
+
+
+Make sure to implement the methods code::setUp:: and code::tearDown::. They will be called before and after the test.
+
+METHOD:: assert
+
+argument:: test
+Make sure that this returns a boolean, where code::true:: means that the test is passed.
+
+argument:: message
+posted if report is true.
+
+argument:: onFailure
+If not code::nil::, a failure stops the tests and evaluates this function.
+
+code::
+UnitTest.new.assert(2 == 2, "Two does equal two.");
+UnitTest.new.assert(2 == 2.00001, "Two does equal two.");
+::
+
+METHOD:: assertFloatEquals
+
+Make sure that the two floats code::a:: and code::b:: equal within a given range (code::within::).
+
+
+argument:: a
+a float
+
+argument:: b
+a float
+
+argument:: message
+posted if report is true.
+
+argument:: onFailure
+If not code::nil::, a failure stops the tests and evaluates this function.
+
+
+
+code::
+UnitTest.new.assertFloatEquals(2, 2.00001, "Two does equal two.", 0.00001);
+UnitTest.new.assertFloatEquals(2, 2.001, "Two does equal two.", 0.0001);
+::
+
+method:: assertArrayFloatEquals
+Make sure that the two arrays of floats code::a:: and code::b:: equal within a given range (code::within::).
+
+argument:: a
+an code::Array:: of floats
+
+argument:: b
+an code::Array:: of floats
+
+argument:: message
+posted if report is true.
+
+argument:: onFailure
+If not code::nil::, a failure stops the tests and evaluates this function.
+
+code::
+UnitTest.new.assertArrayFloatEquals([2, 3], [2, 3] + 0.00001, "Same Floats", 0.000001);
+::
+
+METHOD:: ifAsserts
+Make a further assertion only if it passed, or only if it failed.
+
+code::
+(
+a = UnitTest.new;
+a.ifAsserts(2 == 3, "yes", { a.assert(2 == 4) }, { a.assert(1 == 1, "but this is correct") });
+)
+::
+
+method::wait
+Wait for a condition, consider failed after maxTime. Only valid within a test (or a routine).
+
+code::
+(
+{
+	s.reboot;
+	UnitTest.new.wait(s.serverRunning, "server failed to boot in time", 2);
+}.fork
+)
+::
+
+METHOD:: bootServer
+Wait for server boot until continued. Only valid within a test (or a routine).
+
+If already booted, then freeAll and create new allocators.
+
+code::
+(
+{
+	UnitTest.new.bootServer(s);
+}.fork
+)
+::
+
+METHOD:: failed
+call failure directly.
+
+code::
+UnitTest.new.passed(message: "this passed");
+::
+
+SUBSECTION:: UnitTest (sub)class  example.
+
+code::
+TestYourClass : UnitTest {
+	setUp {
+		// this will be called before each test
+	}
+	tearDown {
+		// this will be called after each test
+	}
+
+	test_yourMethod {
+
+		// every method named test_
+		// will be run
+
+		this.assert( 6 == 6, "6 should equal 6");
+
+		this.assertEquals( 9, 9, "9 should equal 9");
+
+		this.assertFloatEquals( 4.0 , 1.0 * 4.0 / 4.0  4.0,
+			"floating point math should be close to equal");
+
+		// we are inside a Routine, you may wait
+		1.0.wait;
+
+		// this will wait until the server is booted
+		this.bootServer;
+
+		// if the server is already booted it will free all nodes
+		// and create new allocators, giving you a clean slate
+		p = { SinOsc.ar };
+		p.play;
+		p.register;
+		// will wait until the condition is true
+		// will be considered a failure after 10 seconds
+		this.wait( { p.isPlaying }, "waiting for synth to play", 10);
+	}
+}
+::

--- a/HelpSource/Classes/UnitTestScript.schelp
+++ b/HelpSource/Classes/UnitTestScript.schelp
@@ -1,0 +1,56 @@
+TITLE:: UnitTestScript
+summary:: run test scripts
+categories:: Testing
+related:: Classes/UnitTest, Classes/UnitTestResult
+
+DESCRIPTION::
+In order to make sure a method works correctly, a test can be implemented that assures the correct behavior.
+
+It is a common practice to write tests to clarify how an object should respond, and it may avoid inconsistencies on the long run.
+
+Test scripts are simply plain text files ending with TELETYPE::_unittest.scd::, which are interpreted.
+Scripts may be located next to a class in the classpath or one folder below.
+If they return a function, the code::UnitTestScript:: is passed in, allowing to call methods like assert etc. (see link::Classes/UnitTest::)
+
+code::UnitTestScript:: mimics some of the behavior of link::Classes/Method::, to be compatible with link::Classes/UnitTest::.
+
+
+
+
+
+
+CLASSMETHODS::
+PRIVATE:: initClass, findTestScripts, new, findTestMethods, allScripts, runTest
+
+INSTANCEMETHODS::
+
+PRIVATE:: name, path, init, runScript
+
+EXAMPLES::
+
+An example script
+
+NOTE::
+This should be in a file TELETYPE::myUnitTest_unittest.scd::
+::
+
+code::
+{ |test|
+	"Kant test".postln;
+	"5 + 7 = ".post;
+	(5 + 7).postln;
+	test.assertEquals(5 + 7, 12, "five plus seven should always be twelve");
+}
+::
+
+To run only the test scripts:
+
+code::
+UnitTestScript.run;
+::
+
+The scripts are to be found under the class UnitTestScript in the GUI:
+
+code::
+UnitTest.gui
+::

--- a/HelpSource/Guides/WritingTests.schelp
+++ b/HelpSource/Guides/WritingTests.schelp
@@ -1,0 +1,62 @@
+title:: Writing tests
+summary:: Get started with writing unit tests
+categories:: UnitTest
+related:: Reference/SCDocSyntax, Classes/SCDoc
+
+
+To write, use and develop UnitTests, you need to 
+
+list::
+## install a sourcecode version of SuperCollider
+## install the code::UnitTesting:: Quark
+## change your environment to include only core library functionality
+## run UnitTests
+::
+
+section:: install a sourcecode version of SuperCollider
+
+Download or clone SuperCollider from github: https://github.com/supercollider/supercollider.
+It is not needed to compile SuperCollider from its sources, you can instead use a pre-compiled binary and include the relevant folders (code::SCClassLibrary, HelpSource, testsuite/classlibrary:: in your environment. See below for an example.
+
+section:: install the code::UnitTesting:: Quark
+
+The code::UnitTest:: framework is not part of the core library but provided as a quark. 
+To install it,  run
+
+code::
+Quarks.install("UnitTesting");
+::
+
+and recompile the language.
+
+section:: Change your environment to include only core library functionality
+
+In order to mimick the standard SuperCollider installation, make sure that you have only the class library installed. 
+
+Best practise is to create a separate code::.yaml:: configuration file that resides parallel to the default one. You can do this either interactively from within the preferences of your IDE (code::Preferences>Interpreter::), or programatically
+
+code::
+~sclangConf = "SCLANG_CONF".getenv;
+LanguageConfig.addIncludePath(~travisBuildDir +/+ "testsuite/classlibrary");
++   LanguageConfig.addExcludePath(~travisBuildDir +/+ "testsuite/classlibrary/server");
++   LanguageConfig.addExcludePath(Quarks.folder +/+ "UnitTesting/tests");
++   postf("Writing configuration to %\n", ~sclangConf);
++   LanguageConfig.store(~sclangConf);
+:: 
+
+
+section:: Organisation
+
+Core class code::UnitTest::s are located in the directory
+1.  UnitTests go into parrallel directlry
+2.  server-related tests go into `server` subdir (travis)
+3.  UnitTests should use assert and assertFloat
+4.  look at existing UnitTests to understand what are good UnitTests
+5.  UnitTest setup
+8.  run UnitTests either automatically (UnitTest.runAll), interactively (UnitTEst.gui), or individually by class (MyClass.test / TestMyClass.run << synonyms)
+
+
+section:: Writing new tests
+The simplest way is to look at an existing help file or class document, and read this document and link::Reference/SCDocSyntax::
+
+

--- a/testsuite/classlibrary/TestUnitTest.sc
+++ b/testsuite/classlibrary/TestUnitTest.sc
@@ -1,0 +1,56 @@
+
+TestUnitTest : UnitTest {
+
+	var someVar,toreDown,count = 0;
+
+	setUp {
+		someVar = "setUp";
+		count = count + 1;
+	}
+	tearDown {
+		someVar = "tearDown";
+		toreDown = true;
+	}
+
+	test_setUp {
+		this.assert( count == 1, "count should be on 1");
+		this.assert( someVar == "setUp", "someVar be set in setUp" );
+	}
+	test_toreDown{
+		this.assert( toreDown, "toreDown should be set at the end of the last test" );
+		this.assert( count == 2, "count should be on 2");
+	}
+	test_setUp2 {
+		this.assert( count == 3, "count should be on 3");
+	}
+	test_assert {
+		this.assert(true, "assert(true) should certainly work");
+	}
+/*
+	test_failure {
+		this.assert( false, "should fail")
+	}
+*/
+
+/*	test_assertAsynch {
+		Server.default.boot;
+		this.assertAsynch( Server.default.serverRunning, {
+			this.assert( Server.default.serverRunning,"server is indeed running");
+			}, "assert asynch should have triggered the server to boot and then run the test block");
+	}
+*/
+
+	test_findTestedClass {
+		this.assertEquals( TestMixedBundleTester.findTestedClass, MixedBundleTester)
+	}
+
+
+
+
+	/*** IF YOU ADD MORE TESTS, UPDATE THE numTestMethods var ***/
+	// test_findTestMethods {
+	// 	var numTestMethods = 7;
+	// 	this.assert( this.findTestMethods.size == numTestMethods, "should be " + numTestMethods + " test methods");
+	// }
+}
+

--- a/testsuite/classlibrary/server/TestMixedBundleTester.sc
+++ b/testsuite/classlibrary/server/TestMixedBundleTester.sc
@@ -1,0 +1,104 @@
+
+TestMixedBundleTester : UnitTest {
+
+	var t;
+
+	setUp {
+		t = MixedBundleTester.new;
+		MixedBundleTester.reset;
+
+	}
+	test_findMessage {
+		t.add( [ "/n_free",1001]);
+
+		t.send(Server.default);
+		Server.default.latency.wait;
+		0.01.wait;
+		this.assert( MixedBundleTester.findMessage( [ "/n_free",1001]),
+		 		"should find the message in its sent messages");
+
+		this.assert( MixedBundleTester.findMessage( [ "/n_free"]),
+		 		"should match any /n_free message")
+	}
+
+	test_findPreparationMessage {
+		var d;
+
+		this.bootServer;
+
+		d = SynthDef("TestOSCBundle", { arg freq = 440;
+			Out.ar(0, SinOsc.ar(freq, 0, 0.1));
+		});
+
+		// bad.
+		// this is really testng UnitTest setUp
+		// and is assuming the implementation of MixedBundle
+		//this.assert( t.messages.isNil,"bundle should have no messages to start with");
+		//this.assert( t.preparationMessages.isNil,"bundle should have no preparationMessages to start with");
+		// anyway, they passed
+
+		t.addPrepare( ["/d_recv", d.asBytes]);
+		this.assert( t.preparationMessages.size == 1,"bundle should have 1 preparationMessages");
+
+		t.send(Server.default);
+
+		(Server.default.latency * 2).wait;
+
+		this.assert( MixedBundleTester.findPreparationMessage(  ["/d_recv", d.asBytes] ),
+		 		"should find the synth def message in its preparation messages" );
+
+		this.assert( MixedBundleTester.findPreparationMessage(  ["/d_recv"] ),
+		 		"should match any synth def /d_recv" );
+	}
+
+	// test that after sending that the bundle gets put in bundlesSent
+	test_send { arg numDefs = 100;
+		var functionFired = false, sent;
+
+		this.makeDefs(numDefs);
+		t.addFunction({ functionFired = true });
+
+		this.bootServer;
+
+		t.send(Server.default);
+		this.wait( { functionFired }, "wait for functionFired to be set by bundle.doFunction");
+
+		// should be 100 in preparationMessages
+		this.assert( MixedBundleTester.bundlesSent.size == 1, "should be 1 bundle sent");
+
+		sent = MixedBundleTester.bundlesSent.first;
+		this.assert( sent === t, "it should be our bundle");
+		this.assert( sent.preparationMessages.size == numDefs,"should be " + numDefs + " in preparationMessages");
+	}
+
+// crashes the language
+//	test_largePrepare {
+//		this.test_prepare(1000)
+//	}
+
+	makeDefs { |numDefs|
+		numDefs.do({ |i|
+			var d;
+			d = SynthDef( "TestOSCBundle" ++ i,{
+					SinOsc.ar([400,403] + i)
+			});
+
+			t.addPrepare( ["/d_recv", d.asBytes] )
+
+		});
+	}
+	test_defNames {
+		var d,names;
+		d = [ "/d_recv", Int8Array[ 83, 67, 103, 102, 0, 0, 0, 1, 0, 1, 7, 100, 105, 115, 107, 73, 110, 52, 0, 5, 0, 0, 0, 0, 63, -128, 0, 0, 64, 0, 0, 0, 64, 64, 0, 0, -62, -58, 0, 0, 0, 7, 0, 0, 0, 0, 63, -128, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 60, 35, -41, 10, 63, -128, 0, 0, 0, 7, 3, 111, 117, 116, 0, 0, 3, 97, 109, 112, 0, 1, 6, 98, 117, 102, 110, 117, 109, 0, 2, 7, 115, 117, 115, 116, 97, 105, 110, 0, 3, 2, 97, 114, 0, 4, 2, 100, 114, 0, 5, 4, 103, 97, 116, 101, 0, 6, 0, 20, 7, 67, 111, 110, 116, 114, 111, 108, 1, 0, 0, 0, 7, 0, 0, 1, 1, 1, 1, 1, 1, 1, 6, 68, 105, 115, 107, 73, 110, 2, 0, 2, 0, 4, 0, 0, 0, 0, 0, 2, -1, -1, 0, 0, 2, 2, 2, 2, 5, 76, 105, 110, 101, 110, 1, 0, 5, 0, 1, 0, 0, 0, 0, 0, 6, 0, 0, 0, 4, -1, -1, 0, 1, 0, 0, 0, 5, -1, -1, 0, 2, 1, 12, 66, 105, 110, 97, 114, 121, 79, 112, 85, 71, 101, 110, 2, 0, 2, 0, 1, 0, 2, 0, 1, 0, 0, 0, 2, 0, 0, 2, 12, 66, 105, 110, 97, 114, 121, 79, 112, 85, 71, 101, 110, 2, 0, 2, 0, 1, 0, 2, 0, 1, 0, 1, 0, 2, 0, 0, 2, 12, 66, 105, 110, 97, 114, 121, 79, 112, 85, 71, 101, 110, 2, 0, 2, 0, 1, 0, 2, 0, 1, 0, 2, 0, 2, 0, 0, 2, 12, 66, 105, 110, 97, 114, 121, 79, 112, 85, 71, 101, 110, 2, 0, 2, 0, 1, 0, 2, 0, 1, 0, 3, 0, 2, 0, 0, 2, 12, 66, 105, 110, 97, 114, 121, 79, 112, 85, 71, 101, 110, 1, 0, 2, 0, 1, 0, 1, 0, 0, 0, 3, 0, 0, 0, 4, 1, 12, 66, 105, 110, 97, 114, 121, 79, 112, 85, 71, 101, 110, 1, 0, 2, 0, 1, 0, 1, 0, 7, 0, 0, 0, 0, 0, 5, 1, 12, 66, 105, 110, 97, 114, 121, 79, 112, 85, 71, 101, 110, 1, 0, 2, 0, 1, 0, 13, 0, 8, 0, 0, -1, -1, 0, 0, 1, 6, 69, 110, 118, 71, 101, 110, 1, 0, 21, 0, 1, 0, 0, -1, -1, 0, 1, -1, -1, 0, 1, -1, -1, 0, 0, -1, -1, 0, 1, -1, -1, 0, 2, -1, -1, 0, 0, -1, -1, 0, 3, -1, -1, 0, 4, -1, -1, 0, 4, -1, -1, 0, 1, 0, 0, 0, 4, -1, -1, 0, 1, -1, -1, 0, 0, -1, -1, 0, 1, 0, 9, 0, 0, -1, -1, 0, 1, -1, -1, 0, 0, -1, -1, 0, 0, 0, 0, 0, 5, -1, -1, 0, 1, -1, -1, 0, 0, 1, 12, 66, 105, 110, 97, 114, 121, 79, 112, 85, 71, 101, 110, 2, 0, 2, 0, 1, 0, 2, 0, 3, 0, 0, 0, 10, 0, 0, 2, 12, 66, 105, 110, 97, 114, 121, 79, 112, 85, 71, 101, 110, 2, 0, 2, 0, 1, 0, 2, 0, 11, 0, 0, 0, 0, 0, 1, 2, 12, 66, 105, 110, 97, 114, 121, 79, 112, 85, 71, 101, 110, 2, 0, 2, 0, 1, 0, 2, 0, 4, 0, 0, 0, 10, 0, 0, 2, 12, 66, 105, 110, 97, 114, 121, 79, 112, 85, 71, 101, 110, 2, 0, 2, 0, 1, 0, 2, 0, 13, 0, 0, 0, 0, 0, 1, 2, 12, 66, 105, 110, 97, 114, 121, 79, 112, 85, 71, 101, 110, 2, 0, 2, 0, 1, 0, 2, 0, 5, 0, 0, 0, 10, 0, 0, 2, 12, 66, 105, 110, 97, 114, 121, 79, 112, 85, 71, 101, 110, 2, 0, 2, 0, 1, 0, 2, 0, 15, 0, 0, 0, 0, 0, 1, 2, 12, 66, 105, 110, 97, 114, 121, 79, 112, 85, 71, 101, 110, 2, 0, 2, 0, 1, 0, 2, 0, 6, 0, 0, 0, 10, 0, 0, 2, 12, 66, 105, 110, 97, 114, 121, 79, 112, 85, 71, 101, 110, 2, 0, 2, 0, 1, 0, 2, 0, 17, 0, 0, 0, 0, 0, 1, 2, 3, 79, 117, 116, 2, 0, 5, 0, 0, 0, 0, 0, 0, 0, 0, 0, 12, 0, 0, 0, 14, 0, 0, 0, 16, 0, 0, 0, 18, 0, 0, 0, 0 ] ];
+		
+		t.addPrepare(d);
+		
+		names = t.defNames;
+		
+		this.assertEquals( names[0],"diskIn4");
+
+		this.assert( t.includesDefName("diskIn4") );
+	}
+
+}
+

--- a/testsuite/classlibrary/server/TestUnitTest-test_bootServer.sc
+++ b/testsuite/classlibrary/server/TestUnitTest-test_bootServer.sc
@@ -1,0 +1,6 @@
++ TestUnitTest {
+	test_bootServer {
+		this.bootServer;
+		this.assert(Server.default.serverRunning, "Server.default should be booted while we waited");
+	}
+}


### PR DESCRIPTION
## Problem

Since a while, SuperCollider development increasingly relies on `UnitTest`s to secure code stability. 
Most prominently, they are part of the testing framework around  [travis](https://travis-ci.org/supercollider/supercollider).

Not having UnitTesting capabilities in the core library makes the development process rely on a Quark extension. This seems to place it out of sight of developers. 
 
## Changes

To ease the process of UnitTesting and to encourage people to write `UnitTest`s, I propose to include the UnitTest framework (`UnitTest, UnitTestResult, UnitTestScript`) into the main repository. This will also ensure that travis builds always use the right UnitTest framework for their tests.

I copied the classes defined in the UnitTesting quark to `SCClassLibrary/Common/UnitTesting` and added the tests to `testsuite/classlibrary` resp. `testsuite/classlibrary/server` (server-related tests, according to #3161 ). Help files went to `HelpSource`.

## To Do

+ [ ] clarify the use of `MixedBundleTester`. It is an extension that might be useful for testing Bundles, however, there is no helpfile available, sourcecode documentation is sparse. Maybe @crucialfelix can shed some light?

## Related

+ #3164 
+ #3075