### PR TITLE
Topic fix client id alloc

### DIFF
--- a/HelpSource/Classes/ContiguousBlockAllocator.schelp
+++ b/HelpSource/Classes/ContiguousBlockAllocator.schelp
@@ -1,17 +1,11 @@
 class:: ContiguousBlockAllocator
 summary:: for better handling of dynamic allocation
-related:: Classes/Server, Classes/PowerOfTwoAllocator
+related:: Classes/Server, Classes/PowerOfTwoAllocator, Guides/MultiClient_Setups
 categories:: Control
 
 description::
 
-A more robust replacement for the default server block allocator, link::Classes/PowerOfTwoAllocator::. May be used in the link::Classes/Server:: class to allocate audio/control bus numbers and buffer numbers.
-
-To configure a server to use ContiguousBlockAllocator, execute the following:
-code::
-aServer.options.blockAllocClass = ContiguousBlockAllocator;
-::
-Normally you will not need to address the allocators directly. However, ContiguousBlockAllocator adds one feature not present in PowerOfTwoAllocator, namely the emphasis::reserve:: method.
+The default allocator used in servers to allocate bus numbers and buffer numbers. Compared to its predecessor, link::Classes/PowerOfTwoAllocator::, it can reserve a block of numbers at the beginning of its range, and it can offset its entire range of numbers to support multiple clientIDs.
 
 ClassMethods::
 
@@ -20,7 +14,16 @@ Create a new allocator with emphasis::size:: slots. You may block off the first 
 
 InstanceMethods::
 
-private::prReserve, prSplit
+private::prReserve, prSplit, addToFreed, blocks, findAvailable, findNext, findPrevious, removeFromFreed
+
+method::size
+	the number of id numbers it can allocate
+
+method::pos
+	the allocator's offset for a reserved block (e.g. for hardware input and output buses).
+
+method::addrOffset
+	the offset of the allocator's address range, which is used to accomodate multiple clientIDs.
 
 method::alloc
 Return the starting index of a free block that is emphasis::n:: slots wide. The default is 1 slot.
@@ -31,4 +34,6 @@ Free a previously allocated block starting at emphasis::address::.
 method::reserve
 Mark a specific range of addresses as used so that the alloc method will not return any addresses within that range.
 
+method::debug
+	post internal state of allocator for debugging.
 

--- a/SCClassLibrary/Common/Control/Engine.sc
+++ b/SCClassLibrary/Common/Control/Engine.sc
@@ -1,6 +1,7 @@
 
 NodeIDAllocator {
 	var <user, initTemp, temp, perm, mask, permFreed;
+	var <numIDs = 0x04000000; // 2 ** 26
 	// support 32 users
 
 	*new { arg user=0, initTemp = 1000;
@@ -196,7 +197,7 @@ ContiguousBlock {
 // pos is offset for reserved numbers,
 // addrOffset is offset for clientID * size
 ContiguousBlockAllocator {
-	var <size, array, freed, <pos, top, <addrOffset;
+	var <size, array, freed, <pos, <top, <addrOffset;
 	// pos is offset for reserved numbers,
 	// addrOffset is offset for clientID * size
 

--- a/SCClassLibrary/Common/Control/Engine.sc
+++ b/SCClassLibrary/Common/Control/Engine.sc
@@ -193,13 +193,18 @@ ContiguousBlock {
 	printOn { |stream| this.storeOn(stream) }
 }
 
-
+// pos is offset for reserved numbers,
+// addrOffset is offset for clientID * size
 ContiguousBlockAllocator {
-	var	size, array, freed, pos, top;
 
-	*new { |size, pos = 0|
-		^super.newCopyArgs(size, Array.newClear(size).put(pos, ContiguousBlock(pos, size-pos)),
-			IdentityDictionary.new, pos, pos);
+	var	<size, array, freed, <pos, top, <addrOffset;
+
+	*new { |size, pos = 0, addrOffset = 0|
+		var shiftedPos = pos + addrOffset;
+		^super.newCopyArgs(size,
+			Array.newClear(size).put(pos, ContiguousBlock(shiftedPos, size-pos)),
+			IdentityDictionary.new,
+			shiftedPos, shiftedPos, addrOffset);
 	}
 
 	alloc { |n = 1|
@@ -212,7 +217,7 @@ ContiguousBlockAllocator {
 	reserve { |address, size = 1, warn = true|
 		var	block, new;
 		((block = array[address] ?? { this.findNext(address) }).notNil and:
-				{ block.used and:
+			{ block.used and:
 				{ address + size > block.start } }).if({
 			warn.if({ "The block at (%, %) is already in use and cannot be reserved."
 				.format(address, size).warn; });
@@ -222,7 +227,7 @@ ContiguousBlockAllocator {
 				^new;
 			}, {
 				((block = this.findPrevious(address)).notNil and:
-						{ block.used and:
+					{ block.used and:
 						{ block.start + block.size > address } }).if({
 					warn.if({ "The block at (%, %) is already in use and cannot be reserved."
 						.format(address, size).warn; });
@@ -237,18 +242,18 @@ ContiguousBlockAllocator {
 
 	free { |address|
 		var	block,
-			prev, next, temp;
+		prev, next, temp;
 		// this 'if' prevents an error if a Buffer object is freed twice
 		if(address.isNil) { ^this };
-		((block = array[address]).notNil and: { block.used }).if({
+		((block = array[address - addrOffset]).notNil and: { block.used }).if({
 			block.used = false;
 			this.addToFreed(block);
 			((prev = this.findPrevious(address)).notNil and: { prev.used.not }).if({
 				(temp = prev.join(block)).notNil.if({
-						// if block is the last one, reduce the top
+					// if block is the last one, reduce the top
 					(block.start == top).if({ top = temp.start });
-					array[temp.start] = temp;
-					array[block.start] = nil;
+					array[temp.start - addrOffset] = temp;
+					array[block.start - addrOffset] = nil;
 					this.removeFromFreed(prev).removeFromFreed(block);
 					(top > temp.start).if({ this.addToFreed(temp); });
 					block = temp;
@@ -256,10 +261,10 @@ ContiguousBlockAllocator {
 			});
 			((next = this.findNext(block.start)).notNil and: { next.used.not }).if({
 				(temp = next.join(block)).notNil.if({
-						// if next is the last one, reduce the top
+					// if next is the last one, reduce the top
 					(next.start == top).if({ top = temp.start });
-					array[temp.start] = temp;
-					array[next.start] = nil;
+					array[temp.start - addrOffset] = temp;
+					array[next.start - addrOffset] = nil;
 					this.removeFromFreed(next).removeFromFreed(block);
 					(top > temp.start).if({ this.addToFreed(temp); });
 				});
@@ -280,8 +285,8 @@ ContiguousBlockAllocator {
 			});
 		});
 
-		(top + n > size or: { array[top].used }).if({ ^nil });
-		^array[top]
+		(top + n - addrOffset > size or: { array[top - addrOffset].used }).if({ ^nil });
+		^array[top - addrOffset]
 	}
 
 	addToFreed { |block|
@@ -291,26 +296,26 @@ ContiguousBlockAllocator {
 
 	removeFromFreed { |block|
 		freed[block.size].tryPerform(\remove, block);
-			// I tested without gc; performance is about half as efficient without it
+		// I tested without gc; performance is about half as efficient without it
 		(freed[block.size].size == 0).if({ freed.removeAt(block.size) });
 	}
 
 	findPrevious { |address|
 		forBy(address-1, pos, -1, { |i|
-			array[i].notNil.if({ ^array[i] });
+			array[i - addrOffset].notNil.if({ ^array[i - addrOffset] });
 		});
 		^nil
 	}
 
 	findNext { |address|
-		var	temp;
-		(temp = array[address]).notNil.if({
-			^array[temp.start + temp.size]
-		}, {
+		var	temp = array[address - addrOffset];
+		if (temp.notNil) {
+			^array[temp.start + temp.size - addrOffset]
+		} {
 			for(address+1, top, { |i|
-				array[i].notNil.if({ ^array[i] });
+				array[i - addrOffset].notNil.if({ ^array[i - addrOffset] });
 			});
-		});
+		};
 		^nil
 	}
 
@@ -333,9 +338,9 @@ ContiguousBlockAllocator {
 		new.used = used;
 		this.removeFromFreed(availBlock);
 		used.not.if({ this.addToFreed(new) });
-		array[new.start] = new;
+		array[new.start - addrOffset] = new;
 		leftover.notNil.if({
-			array[leftover.start] = leftover;
+			array[leftover.start - addrOffset] = leftover;
 			top = max(top, leftover.start);
 			(top > leftover.start).if({ this.addToFreed(leftover); });
 		});

--- a/SCClassLibrary/Common/Control/Engine.sc
+++ b/SCClassLibrary/Common/Control/Engine.sc
@@ -157,7 +157,7 @@ RingNumberAllocator {
 
 ContiguousBlock {
 
-	var     <start, <size, <>used = false;  // assume free; owner must say otherwise
+	var <start, <size, <>used = false;  // assume free; owner must say otherwise
 
 	*new { |start, size| ^super.newCopyArgs(start, size) }
 
@@ -196,8 +196,9 @@ ContiguousBlock {
 // pos is offset for reserved numbers,
 // addrOffset is offset for clientID * size
 ContiguousBlockAllocator {
-
-	var	<size, array, freed, <pos, top, <addrOffset;
+	var <size, array, freed, <pos, top, <addrOffset;
+	// pos is offset for reserved numbers,
+	// addrOffset is offset for clientID * size
 
 	*new { |size, pos = 0, addrOffset = 0|
 		var shiftedPos = pos + addrOffset;
@@ -208,14 +209,14 @@ ContiguousBlockAllocator {
 	}
 
 	alloc { |n = 1|
-		var	block;
+		var block;
 		(block = this.findAvailable(n)).notNil.if({
 			^this.prReserve(block.start, n, block).start
 		}, { ^nil });
 	}
 
 	reserve { |address, size = 1, warn = true|
-		var	block, new;
+		var block, new;
 		((block = array[address] ?? { this.findNext(address) }).notNil and:
 			{ block.used and:
 				{ address + size > block.start } }).if({
@@ -241,8 +242,7 @@ ContiguousBlockAllocator {
 	}
 
 	free { |address|
-		var	block,
-		prev, next, temp;
+		var block, prev, next, temp;
 		// this 'if' prevents an error if a Buffer object is freed twice
 		if(address.isNil) { ^this };
 		((block = array[address - addrOffset]).notNil and: { block.used }).if({
@@ -308,7 +308,7 @@ ContiguousBlockAllocator {
 	}
 
 	findNext { |address|
-		var	temp = array[address - addrOffset];
+		var temp = array[address - addrOffset];
 		if (temp.notNil) {
 			^array[temp.start + temp.size - addrOffset]
 		} {
@@ -320,7 +320,7 @@ ContiguousBlockAllocator {
 	}
 
 	prReserve { |address, size, availBlock, prevBlock|
-		var	new, leftover;
+		var new, leftover;
 		(availBlock.isNil and: { prevBlock.isNil }).if({
 			prevBlock = this.findPrevious(address);
 		});
@@ -333,7 +333,7 @@ ContiguousBlockAllocator {
 	}
 
 	prSplit { |availBlock, n, used = true|
-		var	new, leftover;
+		var new, leftover;
 		#new, leftover = availBlock.split(n);
 		new.used = used;
 		this.removeFromFreed(availBlock);

--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -38,7 +38,7 @@ ServerOptions {
 	var <>threads = nil; // for supernova
 	var <>useSystemClock = false;  // for supernova
 
-	var <numPrivateAudioBusChannels=112;
+	var <numPrivateAudioBusChannels=1020;
 
 	var <>reservedNumAudioBusChannels = 0;
 	var <>reservedNumControlBusChannels = 0;

--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -286,7 +286,8 @@ Server {
 		named = IdentityDictionary.new;
 		all = Set.new;
 
-		nodeAllocClass = ReadableNodeIDAllocator;
+		nodeAllocClass = NodeIDAllocator;
+		// nodeAllocClass = ReadableNodeIDAllocator;
 		bufferAllocClass = ContiguousBlockAllocator;
 		busAllocClass = ContiguousBlockAllocator;
 
@@ -370,7 +371,7 @@ Server {
 
 	initTree {
 		this.newNodeAllocators;
-		this.sendMsg("/g_new", this.defaultGroupID, 0, 0);
+		this.sendMsg("/g_new", this.defaultGroup.nodeID, 0, 0);
 		tree.value(this);
 		ServerTree.run(this);
 	}
@@ -408,14 +409,14 @@ Server {
 	}
 
 	newAllocators {
-		this.newNodeAllocator;
+		this.newNodeAllocators;
 		this.newBusAllocators;
 		this.newBufferAllocators;
 		this.newScopeBufferAllocators;
 		NotificationCenter.notify(this, \newAllocators);
 	}
 
-	newNodeAllocator {
+	newNodeAllocators {
 		nodeAllocator = NodeIDAllocator(clientID, options.initialNodeID)
 	}
 

--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -390,14 +390,10 @@ Server {
 			failstr.format(name, val.cs, "not an Integer", clientID).warn;
 			^this
 		};
-		if (val < 0) {
-			failstr.format(name, val.cs, "less than minimum 0", clientID).warn;
-			^this
-		};
-		if (val >= this.numClients) {
+		if (val < 0 or: { val >= this.numClients }) {
 			failstr.format(name,
 				val.cs,
-				"greater than server.numClients % minus 1 allows".format(this.numClients),
+				"outside of allowed server.numClients range of 0 - %".format(this.numClients),
 				clientID
 			).warn;
 			^this

--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -423,20 +423,17 @@ Server {
 	newBusAllocators {
 		var numControlPerClient, numAudioPerClient;
 		var controlReservedOffset, controlBusClientOffset;
-		var audioReservedOffset = 0, audioBusClientOffset;
+		var audioReservedOffset, audioBusClientOffset;
+
+		var audioBusIOOffset = options.firstPrivateBus;
 
 		numControlPerClient = options.numControlBusChannels div: this.numClients;
-		numAudioPerClient = options.numAudioBusChannels div: this.numClients;
+		numAudioPerClient = options.numAudioBusChannels - audioBusIOOffset div: this.numClients;
 
 		controlReservedOffset = options.reservedNumControlBusChannels;
 		controlBusClientOffset = numControlPerClient * clientID;
 
-		// only reserve hardware output chans on clientID 0
-		if (clientID == 0) {
-			audioReservedOffset = audioReservedOffset + options.firstPrivateBus;
-		};
-		audioReservedOffset = audioReservedOffset +
-			options.reservedNumAudioBusChannels;
+		audioReservedOffset = options.reservedNumAudioBusChannels;
 		audioBusClientOffset = numAudioPerClient * clientID;
 
 		controlBusAllocator = busAllocClass.new(
@@ -447,7 +444,7 @@ Server {
 		audioBusAllocator = busAllocClass.new(
 			numAudioPerClient,
 			audioReservedOffset,
-			audioBusClientOffset
+			audioBusClientOffset + audioBusIOOffset
 		);
 	}
 

--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -380,7 +380,7 @@ Server {
 
 	// private, called from server notify response with next free clientID
 	clientID_ { |val|
-		var failstr = "Server % couldn't set client id to: % - %. clientID is still %.";
+		var failstr = "Server % couldn't set clientID to: % - %. clientID is still %.";
 
 		if(val == clientID) {
 			// no need to change

--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -391,30 +391,29 @@ Server {
 		controlBusOffset = numControl * offset + options.reservedNumControlBusChannels;
 		audioBusOffset = options.firstPrivateBus + (numAudio * offset) + options.reservedNumAudioBusChannels;
 
-		controlBusAllocator =
-		ContiguousBlockAllocator.new(numControl, controlBusOffset);
-
-		audioBusAllocator =
-		ContiguousBlockAllocator.new(numAudio, audioBusOffset);
+		controlBusAllocator = busAllocClass.new(
+			numControlPerUser,
+			controlReservedOffset,
+			controlBusClientOffset
+		);
+		audioBusAllocator = busAllocClass.new(
+			numAudioPerUser,
+			audioReservedOffset,
+			audioBusClientOffset
+		);
 	}
 
 
 	newBufferAllocators {
-		var bufferOffset;
-		var offset = this.calcOffset;
-		var n = options.maxLogins ? 1;
-		var numBuffers = options.numBuffers div: n;
-		bufferOffset = numBuffers * offset + options.reservedNumBuffers;
-		bufferAllocator =
-		ContiguousBlockAllocator.new(numBuffers, bufferOffset);
-	}
+		var numBuffersPerUser = options.numBuffers div: numUsers;
+		var numReservedBuffers = options.reservedNumBuffers;
+		var bufferClientOffset = numBuffersPerUser * clientID;
 
-	calcOffset {
-		if(options.maxLogins.isNil) { ^0 };
-		if(clientID > (options.maxLogins - 1)) {
-			"Client ID exceeds maxLogins. Some buses and buffers may overlap for remote server: %".format(this).warn;
-		};
-		^clientID % options.maxLogins
+		bufferAllocator = bufferAllocClass.new(
+			numBuffersPerUser,
+			numReservedBuffers,
+			bufferClientOffset
+		);
 	}
 
 	newScopeBufferAllocators {

--- a/SCClassLibrary/Common/Control/ServerStatus.sc
+++ b/SCClassLibrary/Common/Control/ServerStatus.sc
@@ -38,29 +38,93 @@ ServerStatusWatcher {
 
 	sendNotifyRequest { |flag = true|
 		var doneOSCFunc, failOSCFunc;
+		var desiredClientID;
+
 		if(serverRunning.not) { ^this };
+
+		// flag true requests notification, false turns it off
 		notified = flag;
-		if(server.userSpecifiedClientID.not) {
-			doneOSCFunc = OSCFunc({|msg|
-				if(flag) { server.clientID = msg[2] };
-				failOSCFunc.free;
-			}, '/done', server.addr, argTemplate:['/notify', nil]).oneShot;
 
-			failOSCFunc = OSCFunc({|msg|
-				doneOSCFunc.free;
-				Error(
-					"Failed to register with server '%' for notifications: %\n"
-					"To recover, please reboot the server.".format(server.name, msg)).throw;
-			}, '/fail', server.addr, argTemplate:['/notify', nil, nil]).oneShot;
+		// set up oscfuncs for possible server responses, \done or \failed
+		doneOSCFunc = OSCFunc({|msg|
+			var newClientID = msg[2], newMaxLogins = msg[3];
+			failOSCFunc.free;
 
-		};
+			if(flag) {
+				// on registering scsynth sends back a free clientID and its maxLogins,
+				// which usually adjust the server object's settings:
+				this.prHandleClientLoginInfoFromServer(newClientID, newMaxLogins);
+			};
+
+		}, '/done', server.addr, argTemplate:['/notify', nil]).oneShot;
+
+		failOSCFunc = OSCFunc({|msg|
+
+			doneOSCFunc.free;
+			this.prHandleNotifyFailString(msg[2], msg);
+
+		}, '/fail', server.addr, argTemplate:['/notify', nil, nil]).oneShot;
+
+		// send the notify request - on or off, userSpecifiedClientID or not
+		desiredClientID = if(server.userSpecifiedClientID, { server.clientID }, {-1});
+		server.sendMsg("/notify", flag.binaryValue, desiredClientID);
 
 		if(flag){
-			"Receiving notification messages from server '%'\n".postf(server.name)
+			"Requested notification messages from server '%'\n".postf(server.name)
 		} {
 			"Switched off notification messages from server '%'\n".postf(server.name);
 		};
-		server.sendMsg("/notify", flag.binaryValue);
+	}
+
+	prHandleClientLoginInfoFromServer { |newClientID, newMaxLogins|
+		if (newMaxLogins.notNil) {
+			if (newMaxLogins != server.options.maxLogins) {
+				"%: scsynth has maxLogins % - adjusting my options accordingly.\n"
+				.postf(server, newMaxLogins);
+				server.options.maxLogins = newMaxLogins;
+			} {
+				"%: scsynth maxLogins % match with my options.\n".postf(server, newMaxLogins);
+			};
+		} {
+			"%: no maxLogins info from scsynth.\n".postf(server, newMaxLogins);
+		};
+
+		if (newClientID == server.clientID) {
+			"%: keeping clientID % as confirmed from scsynth.\n"
+			.postf(server, newClientID);
+			server.clientID = newClientID;
+		} {
+			if (server.userSpecifiedClientID.not) {
+				"%: setting clientID to %, as obtained from scsynth.\n"
+				.postf(server, newClientID);
+				server.clientID = newClientID;
+			} {
+				("% - userSpecifiedClientID % is not free!\n"
+					" Switching to free clientID obtained from scsynth: %.\n"
+					"If that is problematic, please set clientID by hand before booting.")
+				.format(server, server.clientID, newClientID).warn;
+				server.clientID = newClientID;
+			};
+		}
+	}
+
+	prHandleNotifyFailString {|failString, msg|
+
+		// post info on some known error cases
+		case
+		{ failString.asString.contains("already registered") } {
+			"% - already registered with clientID %.\n".postf(server, msg[3])
+		} { failString.asString.contains("not registered") } {
+			// unregister when already not registered:
+			"% - not registered.\n".postf(server)
+		} { failString.asString.contains("too many users") } {
+			"% - could not register, too many users.\n".postf(server)
+		} {
+			// throw error if unknown failure
+			Error(
+				"Failed to register with server '%' for notifications: %\n"
+				"To recover, please reboot the server.".format(server.name, msg)).throw;
+		};
 	}
 
 	doWhenBooted { |onComplete, limit = 100, onFailure|
@@ -135,7 +199,7 @@ ServerStatusWatcher {
 				if(notify and: { notified.not }) { this.sendNotifyRequest };
 				alive = true;
 				#cmd, one, numUGens, numSynths, numGroups, numSynthDefs,
-						avgCPU, peakCPU, sampleRate, actualSampleRate = msg;
+				avgCPU, peakCPU, sampleRate, actualSampleRate = msg;
 				{
 					this.updateRunningState(true);
 					server.changed(\counts);

--- a/SCClassLibrary/Common/Control/ServerStatus.sc
+++ b/SCClassLibrary/Common/Control/ServerStatus.sc
@@ -92,20 +92,18 @@ ServerStatusWatcher {
 		if (newClientID == server.clientID) {
 			"%: keeping clientID % as confirmed from scsynth.\n"
 			.postf(server, newClientID);
-			server.clientID = newClientID;
 		} {
 			if (server.userSpecifiedClientID.not) {
 				"%: setting clientID to %, as obtained from scsynth.\n"
 				.postf(server, newClientID);
-				server.clientID = newClientID;
 			} {
 				("% - userSpecifiedClientID % is not free!\n"
 					" Switching to free clientID obtained from scsynth: %.\n"
 					"If that is problematic, please set clientID by hand before booting.")
 				.format(server, server.clientID, newClientID).warn;
-				server.clientID = newClientID;
 			};
-		}
+		};
+		server.clientID = newClientID;
 	}
 
 	prHandleNotifyFailString {|failString, msg|

--- a/testsuite/classlibrary/TestContiguousBlockAllocator.sc
+++ b/testsuite/classlibrary/TestContiguousBlockAllocator.sc
@@ -1,0 +1,58 @@
+TestContiguousBlockAllocator : UnitTest {
+
+	test_CBAllocator {
+		var alloc = ContiguousBlockAllocator(1024, 0, 1024 * 8);
+		var remaining = alloc.size, lastID;
+		var allIDs = List[], newID, maxPos;
+		var sizes = (1024 * (0.5 ** (1.. 1024.log2))).asInteger;
+
+		// sizes.sum = 1023, + [1, 1] goes over max by 1
+		(sizes.scramble ++ [1, 1]).do { |size|
+			newID = alloc.alloc(size);
+			allIDs.add(newID);
+		};
+
+		this.assert(
+			allIDs.drop(-1).every(_.isNumber) and: allIDs.last.isNil,
+			"ContiguousBlockAllocator hands out its full range for variable block sizes."
+		);
+
+		allIDs.size.do { allIDs.remove(allIDs.choose); };
+
+		this.assert(
+			alloc.pos == alloc.addrOffset,
+			"ContiguousBlockAllocator should reclaim its full range after all blocks are removed."
+		);
+
+		while {
+			// try removing first
+			if (0.5.coin) { allIDs.remove(allIDs.choose) };
+			// try allocating random block size
+			newID = alloc.alloc([1, 2, 3, 5, 8].choose);
+			// if random block too big, try single id
+			if (newID.isNil) { newID = alloc.alloc; };
+			newID.notNil;
+		} {
+			allIDs.add(newID);
+		};
+		this.assert(
+			alloc.top == (alloc.addrOffset + alloc.size - 1),
+			"ContiguousBlockAllocator should hand out its full range in mixed allocation/removal."
+		);
+
+		while {
+			allIDs.remove(allIDs.choose);
+			allIDs.notEmpty;
+		} {
+			if (0.5.coin) {
+				newID = alloc.alloc([1, 2, 3, 5, 8].choose);
+				// if random block too big, try single id
+				if (newID.isNil) { newID = alloc.alloc; };
+				if (newID.notNil) { allIDs.add(newID) };
+			};
+		};
+		this.assert(
+			alloc.top == (alloc.addrOffset + alloc.size - 1),
+			"ContiguousBlockAllocator should reclaim its full range after mixed allocation/removal.")
+	}
+}

--- a/testsuite/classlibrary/TestServerClientID.sc
+++ b/testsuite/classlibrary/TestServerClientID.sc
@@ -31,7 +31,8 @@ TestServer_clientID : UnitTest {
 		this.assert(s.clientID == 0, "s.clientID should block number >= maxLogins.");
 		s.clientID = s.options.maxLogins - 1;
 		this.assert(s.clientID == 31, "s.clientID should be settable if valid.");
-		Server.named.removeAt(s.name); Server.all.remove(s);
+		Server.named.removeAt(s.name);
+		Server.all.remove(s);
 	}
 
 	test_userSpecifiedClientID {
@@ -41,7 +42,8 @@ TestServer_clientID : UnitTest {
 		options.maxLogins_(8);
 		s = Server(\testserv, NetAddr("localhost", 57111), options, 7);
 		this.assert(s.clientID == 7, "Making a server with valid nonzero clientID should work.");
-		Server.named.removeAt(s.name); Server.all.remove(s);
+		Server.named.removeAt(s.name);
+		Server.all.remove(s);
 	}
 
 	test_allocatorRanges {
@@ -49,7 +51,8 @@ TestServer_clientID : UnitTest {
 		var prevClass = Server.nodeAllocClass;
 
 		Server.nodeAllocClass = NodeIDAllocator;
-		s.options.maxLogins = 1; s.newAllocators;
+		s.options.maxLogins = 1;
+		s.newAllocators;
 
 		this.assert(
 			s.nodeAllocator.numIDs == (2 ** 26),

--- a/testsuite/classlibrary/TestServerClientID.sc
+++ b/testsuite/classlibrary/TestServerClientID.sc
@@ -1,0 +1,75 @@
+/*
+TestServerClientID.run;
+UnitTest.gui;
+
+Tests for clientID, maxLogins and allocator creation based on these.
+
+* clientID should be impossible to set to nonsense data,
+it should always be between 0 and maxLogins - 1.
+
+NOTE: All test cases currently have powerOfTwo numbers for maxLogins.
+This is because the server currently rounds up maxLogins to nextPowerOfTwo;
+so when the server IS NOT booted, odd numbers of maxLogins stay as they are;
+when the server IS booted, the rounded-up maxLogins come back to each client.
+If this server behavior changes to support non-powerOfTwo numbers of clients,
+the tests should also include irregular numbers for maxLogins, e.g. 1, 2, 3, 5, 8.
+
+*/
+
+TestServer_clientID : UnitTest {
+	// these while server is off
+	test_ClientIDChecks {
+		var s = Server(\testID);
+		this.assert(s.clientID == 0, "s.clientID should be 0 by default.");
+		// test checks for bad input
+		s.clientID = -1.sqrt;
+		this.assert(s.clientID == 0, "s.clientID should block non-Integers.");
+		s.clientID = -123;
+		this.assert(s.clientID == 0, "s.clientID should block negative numbers.");
+		s.options.maxLogins = 32;
+		s.clientID = s.options.maxLogins;
+		this.assert(s.clientID == 0, "s.clientID should block number >= maxLogins.");
+		s.clientID = s.options.maxLogins - 1;
+		this.assert(s.clientID == 31, "s.clientID should be settable if valid.");
+		Server.named.removeAt(s.name); Server.all.remove(s);
+	}
+
+	test_UserSetClientID {
+		var options = ServerOptions.new;
+		var s = Server(\testserv, NetAddr("localhost", 57111), options, 1);
+		this.assert(s == nil, "Making a server with invalid clientID should be blocked.");
+		options.maxLogins_(8);
+		s = Server(\testserv, NetAddr("localhost", 57111), options, 7);
+		this.assert(s.clientID == 7, "Making a server with valid nonzero clientID should work.");
+		Server.named.removeAt(s.name); Server.all.remove(s);
+	}
+
+	test_AllocRanges {
+		var s = Server(\testAlloc);
+		var prevClass = Server.nodeAllocClass;
+
+		Server.nodeAllocClass = NodeIDAllocator;
+		s.options.maxLogins = 1; s.newAllocators;
+
+		this.assert(
+			(s.nodeAllocator.numIDs == (2 ** 26)),
+			"nodeAllocator should have its normal range."
+		);
+
+		this.assert(
+			(s.audioBusAllocator.size == s.options.numAudioBusChannels) and:
+			(s.controlBusAllocator.size == s.options.numControlBusChannels) and:
+			(s.bufferAllocator.size == s.options.numBuffers),
+			"for a single client, bus and buffer allocators should have full range."
+		);
+		s.options.maxLogins = 16; s.newAllocators;
+		this.assert(
+			(s.audioBusAllocator.size == (s.options.numAudioBusChannels div: 16)) and:
+			(s.controlBusAllocator.size == (s.options.numControlBusChannels div: 16)) and:
+			(s.bufferAllocator.size == (s.options.numBuffers div: 16)),
+			"for 16 clients, all allocators should divide range evenly."
+		);
+
+		Server.nodeAllocClass = prevClass;
+	}
+}

--- a/testsuite/classlibrary/TestServerClientID.sc
+++ b/testsuite/classlibrary/TestServerClientID.sc
@@ -69,7 +69,8 @@ TestServer_clientID : UnitTest {
 			"for a single client, bufferAllocator should have full range."
 		);
 
-		s.options.maxLogins = 16; s.newAllocators;
+		s.options.maxLogins = 16;
+		s.newAllocators;
 
 		this.assert(
 			s.audioBusAllocator.size ==

--- a/testsuite/classlibrary/TestServer_clientIDBooted.sc
+++ b/testsuite/classlibrary/TestServer_clientIDBooted.sc
@@ -1,8 +1,12 @@
 // see also TestServer_clientID
+/*
+TestServer_clientID_booted.run;
+*/
+
 TestServer_clientID_booted : UnitTest {
 
 	// with running server
-	test_ClientIDResetByServer {
+	test_clientIDResetByServer {
 		var options = ServerOptions.new;
 		var s;
 		s = Server(\testserv1, NetAddr("localhost", 57111), options);
@@ -12,7 +16,8 @@ TestServer_clientID_booted : UnitTest {
 		s.sync;
 		1.wait;
 		this.assert(s.clientID == 0, "Non-user-defined clientID should be reset by the server.");
-		Server.named.removeAt(s.name); Server.all.remove(s);
+		Server.named.removeAt(s.name);
+		Server.all.remove(s);
 		s.quit;
 		1.wait;
 
@@ -22,6 +27,7 @@ TestServer_clientID_booted : UnitTest {
 		s.sync;
 		1.wait;
 		this.assert(s.clientID == 3, "User-defined clientID should be left as is by the server.");
-		Server.named.removeAt(s.name); Server.all.remove(s);
+		Server.named.removeAt(s.name);
+		Server.all.remove(s);
 	}
 }

--- a/testsuite/classlibrary/TestServer_clientIDBooted.sc
+++ b/testsuite/classlibrary/TestServer_clientIDBooted.sc
@@ -1,0 +1,27 @@
+// see also TestServer_clientID
+TestServer_clientID_booted : UnitTest {
+
+	// with running server
+	test_ClientIDResetByServer {
+		var options = ServerOptions.new;
+		var s;
+		s = Server(\testserv1, NetAddr("localhost", 57111), options);
+
+		s.options.maxLogins = 4; s.clientID = 3;
+		this.bootServer(s);
+		s.sync;
+		1.wait;
+		this.assert(s.clientID == 0, "Non-user-defined clientID should be reset by the server.");
+		Server.named.removeAt(s.name); Server.all.remove(s);
+		s.quit;
+		1.wait;
+
+		s = Server(\testserv2, NetAddr("localhost", 57112), options, 3);
+
+		this.bootServer(s);
+		s.sync;
+		1.wait;
+		this.assert(s.clientID == 3, "User-defined clientID should be left as is by the server.");
+		Server.named.removeAt(s.name); Server.all.remove(s);
+	}
+}

--- a/testsuite/classlibrary/TestServer_clientIDBooted.sc
+++ b/testsuite/classlibrary/TestServer_clientIDBooted.sc
@@ -11,7 +11,8 @@ TestServer_clientID_booted : UnitTest {
 		var s;
 		s = Server(\testserv1, NetAddr("localhost", 57111), options);
 
-		s.options.maxLogins = 4; s.clientID = 3;
+		s.options.maxLogins = 4;
+		s.clientID = 3;
 		this.bootServer(s);
 		s.sync;
 		1.wait;


### PR DESCRIPTION
This is one of several smaller PR based on #3106, hopefully easier to review. 
It fixes #2940 and includes
-  ContiguousBlockAllocator adaptation for multiclients
-  safeguards to clientID_ setting
- redone calculations for Server allocator ranges  and allocator creation 
- updated help files 
- updated responses in sendNotifyRequest
-  Unittests for Allocators and clientID.
