### PR TITLE
Server: add optional ReadableNodeIDAllocator

### DIFF
--- a/HelpSource/Classes/ContiguousBlockAllocator.schelp
+++ b/HelpSource/Classes/ContiguousBlockAllocator.schelp
@@ -1,17 +1,11 @@
 class:: ContiguousBlockAllocator
 summary:: for better handling of dynamic allocation
-related:: Classes/Server, Classes/PowerOfTwoAllocator
+related:: Classes/Server, Classes/PowerOfTwoAllocator, Guides/MultiClient_Setups
 categories:: Control
 
 description::
 
-A more robust replacement for the default server block allocator, link::Classes/PowerOfTwoAllocator::. May be used in the link::Classes/Server:: class to allocate audio/control bus numbers and buffer numbers.
-
-To configure a server to use ContiguousBlockAllocator, execute the following:
-code::
-aServer.options.blockAllocClass = ContiguousBlockAllocator;
-::
-Normally you will not need to address the allocators directly. However, ContiguousBlockAllocator adds one feature not present in PowerOfTwoAllocator, namely the emphasis::reserve:: method.
+The default allocator used in servers to allocate bus numbers and buffer numbers. Compared to its predecessor, link::Classes/PowerOfTwoAllocator::, it can reserve a block of numbers at the beginning of its range, and it can offset its entire range of numbers to support multiple clientIDs.
 
 ClassMethods::
 
@@ -20,7 +14,16 @@ Create a new allocator with emphasis::size:: slots. You may block off the first 
 
 InstanceMethods::
 
-private::prReserve, prSplit
+private::prReserve, prSplit, addToFreed, blocks, findAvailable, findNext, findPrevious, removeFromFreed
+
+method::size
+	the number of id numbers it can allocate
+
+method::pos
+	the allocator's offset for a reserved block (e.g. for hardware input and output buses).
+
+method::addrOffset
+	the offset of the allocator's address range, which is used to accomodate multiple clientIDs.
 
 method::alloc
 Return the starting index of a free block that is emphasis::n:: slots wide. The default is 1 slot.
@@ -31,4 +34,6 @@ Free a previously allocated block starting at emphasis::address::.
 method::reserve
 Mark a specific range of addresses as used so that the alloc method will not return any addresses within that range.
 
+method::debug
+	post internal state of allocator for debugging.
 

--- a/HelpSource/Classes/ReadableNodeIDAllocator.schelp
+++ b/HelpSource/Classes/ReadableNodeIDAllocator.schelp
@@ -1,0 +1,86 @@
+TITLE:: ReadableNodeIDAllocator
+summary:: an allocator for nodeIDs with human-readable ownership
+categories:: Control
+related:: Classes/Server, Guides/MultiClient_Setups
+
+DESCRIPTION::
+In multi-client setups, it is useful to know which client created which nodeIDs on a shared server. ReadableNodeIDAllocator provides that facility by using a decimal prefix based on the clientID.
+
+
+code::
+// default server uses a ReadableNodeIDAllocator
+s.nodeAllocator;
+s.nodeAllocator.userID; // its userID is
+s.clientID
+
+// which creates this defaultGroup 1
+s.defaultGroup;
+s.defaultGroupID;
+// and temp nodes begin with 1000 ...
+3.do { s.nextNodeID.postln };
+
+
+// make a dummy server with different clientID
+r = Server(\remote4, s.addr, s.options, clientID: 4);
+// defaultGroup begins with 400000 ... prefix and ends with 1
+r.defaultGroup;
+r.defaultGroupID;
+// and temp nodes begin with 400001000 ...
+3.do { r.nextNodeID.postln };
+::
+
+CLASSMETHODS::
+
+METHOD:: new
+make a new instance for given clientID, offset for lowest temporary id, and
+argument:: clientID
+the clientID for which to create an offset/prefix
+argument:: lowestTempID
+the offset for the lowest temporary id
+argument:: numClients
+the number of clients for which to split the number range
+
+code::
+// make an allocator with id 11
+a = ReadableNodeIDAllocator(11, 1000, 12);
+// begins with 1100000 ... prefix
+3.do { a.alloc.postln };
+::
+
+INSTANCEMETHODS::
+
+METHOD:: clientID
+the clientID for which to create an offset/prefix
+
+METHOD:: numClients
+the number of clients for which to split the number range
+
+METHOD:: lowestTempID
+the offset from where temporary nodeID begin
+
+METHOD:: idOffset
+the offset from where nodeID range begins
+
+METHOD:: maxPermID
+the highest permanent nodeID
+
+METHOD:: numIDs
+the number of IDs before the allocator will wrap
+
+METHOD:: alloc
+allocate next temporary nodeID
+
+METHOD:: allocPerm
+allocate next permanent nodeID
+
+METHOD:: freePerm
+free a permanent nodeID
+argument:: id
+
+METHOD:: isPerm
+test whether num is in the allocator's range of permanent numbers
+argument:: num
+
+METHOD:: reset
+reset allocator to initial state
+

--- a/SCClassLibrary/Common/Control/Engine.sc
+++ b/SCClassLibrary/Common/Control/Engine.sc
@@ -1,6 +1,7 @@
 
 NodeIDAllocator {
 	var <user, initTemp, temp, perm, mask, permFreed;
+	var <numIDs = 0x04000000; // 2 ** 26
 	// support 32 users
 
 	*new { arg user=0, initTemp = 1000;
@@ -196,7 +197,7 @@ ContiguousBlock {
 // pos is offset for reserved numbers,
 // addrOffset is offset for clientID * size
 ContiguousBlockAllocator {
-	var <size, array, freed, <pos, top, <addrOffset;
+	var <size, array, freed, <pos, <top, <addrOffset;
 	// pos is offset for reserved numbers,
 	// addrOffset is offset for clientID * size
 

--- a/SCClassLibrary/Common/Control/Engine.sc
+++ b/SCClassLibrary/Common/Control/Engine.sc
@@ -193,13 +193,18 @@ ContiguousBlock {
 	printOn { |stream| this.storeOn(stream) }
 }
 
-
+// pos is offset for reserved numbers,
+// addrOffset is offset for clientID * size
 ContiguousBlockAllocator {
-	var	size, array, freed, pos, top;
 
-	*new { |size, pos = 0|
-		^super.newCopyArgs(size, Array.newClear(size).put(pos, ContiguousBlock(pos, size-pos)),
-			IdentityDictionary.new, pos, pos);
+	var	<size, array, freed, <pos, top, <addrOffset;
+
+	*new { |size, pos = 0, addrOffset = 0|
+		var shiftedPos = pos + addrOffset;
+		^super.newCopyArgs(size,
+			Array.newClear(size).put(pos, ContiguousBlock(shiftedPos, size-pos)),
+			IdentityDictionary.new,
+			shiftedPos, shiftedPos, addrOffset);
 	}
 
 	alloc { |n = 1|
@@ -212,7 +217,7 @@ ContiguousBlockAllocator {
 	reserve { |address, size = 1, warn = true|
 		var	block, new;
 		((block = array[address] ?? { this.findNext(address) }).notNil and:
-				{ block.used and:
+			{ block.used and:
 				{ address + size > block.start } }).if({
 			warn.if({ "The block at (%, %) is already in use and cannot be reserved."
 				.format(address, size).warn; });
@@ -222,7 +227,7 @@ ContiguousBlockAllocator {
 				^new;
 			}, {
 				((block = this.findPrevious(address)).notNil and:
-						{ block.used and:
+					{ block.used and:
 						{ block.start + block.size > address } }).if({
 					warn.if({ "The block at (%, %) is already in use and cannot be reserved."
 						.format(address, size).warn; });
@@ -237,18 +242,18 @@ ContiguousBlockAllocator {
 
 	free { |address|
 		var	block,
-			prev, next, temp;
+		prev, next, temp;
 		// this 'if' prevents an error if a Buffer object is freed twice
 		if(address.isNil) { ^this };
-		((block = array[address]).notNil and: { block.used }).if({
+		((block = array[address - addrOffset]).notNil and: { block.used }).if({
 			block.used = false;
 			this.addToFreed(block);
 			((prev = this.findPrevious(address)).notNil and: { prev.used.not }).if({
 				(temp = prev.join(block)).notNil.if({
-						// if block is the last one, reduce the top
+					// if block is the last one, reduce the top
 					(block.start == top).if({ top = temp.start });
-					array[temp.start] = temp;
-					array[block.start] = nil;
+					array[temp.start - addrOffset] = temp;
+					array[block.start - addrOffset] = nil;
 					this.removeFromFreed(prev).removeFromFreed(block);
 					(top > temp.start).if({ this.addToFreed(temp); });
 					block = temp;
@@ -256,10 +261,10 @@ ContiguousBlockAllocator {
 			});
 			((next = this.findNext(block.start)).notNil and: { next.used.not }).if({
 				(temp = next.join(block)).notNil.if({
-						// if next is the last one, reduce the top
+					// if next is the last one, reduce the top
 					(next.start == top).if({ top = temp.start });
-					array[temp.start] = temp;
-					array[next.start] = nil;
+					array[temp.start - addrOffset] = temp;
+					array[next.start - addrOffset] = nil;
 					this.removeFromFreed(next).removeFromFreed(block);
 					(top > temp.start).if({ this.addToFreed(temp); });
 				});
@@ -280,8 +285,8 @@ ContiguousBlockAllocator {
 			});
 		});
 
-		(top + n > size or: { array[top].used }).if({ ^nil });
-		^array[top]
+		(top + n - addrOffset > size or: { array[top - addrOffset].used }).if({ ^nil });
+		^array[top - addrOffset]
 	}
 
 	addToFreed { |block|
@@ -291,26 +296,26 @@ ContiguousBlockAllocator {
 
 	removeFromFreed { |block|
 		freed[block.size].tryPerform(\remove, block);
-			// I tested without gc; performance is about half as efficient without it
+		// I tested without gc; performance is about half as efficient without it
 		(freed[block.size].size == 0).if({ freed.removeAt(block.size) });
 	}
 
 	findPrevious { |address|
 		forBy(address-1, pos, -1, { |i|
-			array[i].notNil.if({ ^array[i] });
+			array[i - addrOffset].notNil.if({ ^array[i - addrOffset] });
 		});
 		^nil
 	}
 
 	findNext { |address|
-		var	temp;
-		(temp = array[address]).notNil.if({
-			^array[temp.start + temp.size]
-		}, {
+		var	temp = array[address - addrOffset];
+		if (temp.notNil) {
+			^array[temp.start + temp.size - addrOffset]
+		} {
 			for(address+1, top, { |i|
-				array[i].notNil.if({ ^array[i] });
+				array[i - addrOffset].notNil.if({ ^array[i - addrOffset] });
 			});
-		});
+		};
 		^nil
 	}
 
@@ -333,9 +338,9 @@ ContiguousBlockAllocator {
 		new.used = used;
 		this.removeFromFreed(availBlock);
 		used.not.if({ this.addToFreed(new) });
-		array[new.start] = new;
+		array[new.start - addrOffset] = new;
 		leftover.notNil.if({
-			array[leftover.start] = leftover;
+			array[leftover.start - addrOffset] = leftover;
 			top = max(top, leftover.start);
 			(top > leftover.start).if({ this.addToFreed(leftover); });
 		});

--- a/SCClassLibrary/Common/Control/Engine.sc
+++ b/SCClassLibrary/Common/Control/Engine.sc
@@ -157,7 +157,7 @@ RingNumberAllocator {
 
 ContiguousBlock {
 
-	var     <start, <size, <>used = false;  // assume free; owner must say otherwise
+	var <start, <size, <>used = false;  // assume free; owner must say otherwise
 
 	*new { |start, size| ^super.newCopyArgs(start, size) }
 
@@ -196,8 +196,9 @@ ContiguousBlock {
 // pos is offset for reserved numbers,
 // addrOffset is offset for clientID * size
 ContiguousBlockAllocator {
-
-	var	<size, array, freed, <pos, top, <addrOffset;
+	var <size, array, freed, <pos, top, <addrOffset;
+	// pos is offset for reserved numbers,
+	// addrOffset is offset for clientID * size
 
 	*new { |size, pos = 0, addrOffset = 0|
 		var shiftedPos = pos + addrOffset;
@@ -208,14 +209,14 @@ ContiguousBlockAllocator {
 	}
 
 	alloc { |n = 1|
-		var	block;
+		var block;
 		(block = this.findAvailable(n)).notNil.if({
 			^this.prReserve(block.start, n, block).start
 		}, { ^nil });
 	}
 
 	reserve { |address, size = 1, warn = true|
-		var	block, new;
+		var block, new;
 		((block = array[address] ?? { this.findNext(address) }).notNil and:
 			{ block.used and:
 				{ address + size > block.start } }).if({
@@ -241,8 +242,7 @@ ContiguousBlockAllocator {
 	}
 
 	free { |address|
-		var	block,
-		prev, next, temp;
+		var block, prev, next, temp;
 		// this 'if' prevents an error if a Buffer object is freed twice
 		if(address.isNil) { ^this };
 		((block = array[address - addrOffset]).notNil and: { block.used }).if({
@@ -308,7 +308,7 @@ ContiguousBlockAllocator {
 	}
 
 	findNext { |address|
-		var	temp = array[address - addrOffset];
+		var temp = array[address - addrOffset];
 		if (temp.notNil) {
 			^array[temp.start + temp.size - addrOffset]
 		} {
@@ -320,7 +320,7 @@ ContiguousBlockAllocator {
 	}
 
 	prReserve { |address, size, availBlock, prevBlock|
-		var	new, leftover;
+		var new, leftover;
 		(availBlock.isNil and: { prevBlock.isNil }).if({
 			prevBlock = this.findPrevious(address);
 		});
@@ -333,7 +333,7 @@ ContiguousBlockAllocator {
 	}
 
 	prSplit { |availBlock, n, used = true|
-		var	new, leftover;
+		var new, leftover;
 		#new, leftover = availBlock.split(n);
 		new.used = used;
 		this.removeFromFreed(availBlock);

--- a/SCClassLibrary/Common/Control/ReadableNodeIDAllocator.sc
+++ b/SCClassLibrary/Common/Control/ReadableNodeIDAllocator.sc
@@ -3,8 +3,8 @@
 
 for example, with 20 Clients, clientIDs would be
 clientID  defaultGroup  tempIDs
- 1         10000001      120001000, 10001001, etc
- 2         10000001      120001000, 10001001, etc
+1         10000001      120001000, 10001001, etc
+2         10000001      120001000, 10001001, etc
 12        120000001      120001000, 10001001, etc
 
 In multi-client settings, this makes s.plotTree display
@@ -69,6 +69,18 @@ ReadableNodeIDAllocator {
 	}
 
 	freePerm { |id|
-		if (this.isPerm(id)) { permFreed.add(id) }
+		var topFreed;
+		if (this.isPerm(id).not) { ^this };
+
+		permFreed.add(id);
+		while {
+			permFreed.notEmpty and: {
+				topFreed = permFreed.maxItem;
+				topFreed == permCount;
+			}
+		} {
+			permFreed.remove(topFreed);
+			permCount = permCount - 1;
+		}
 	}
 }

--- a/SCClassLibrary/Common/Control/ReadableNodeIDAllocator.sc
+++ b/SCClassLibrary/Common/Control/ReadableNodeIDAllocator.sc
@@ -1,0 +1,74 @@
+/* make nodeIDs more humanly readable:
+10 ** 8 ids for 1 user, 10 ** 7 for < 21, 10 ** 6 for < 210
+
+for example, with 20 Clients, clientIDs would be
+clientID  defaultGroup  tempIDs
+ 1         10000001      120001000, 10001001, etc
+ 2         10000001      120001000, 10001001, etc
+12        120000001      120001000, 10001001, etc
+
+In multi-client settings, this makes s.plotTree display
+or s.queryAllNodes posts much easier to understand.
+*/
+
+ReadableNodeIDAllocator {
+
+	var <clientID, <lowestTempID, <numClients;
+	var <numIDs, <idOffset, <maxPermID;
+	var tempCount = -1, permCount = 1, permFreed;
+
+	*new { |clientID = 0, lowestTempID = 1000, numClients = 32|
+		^super.newCopyArgs(clientID, lowestTempID, numClients).reset
+	}
+
+	reset {
+		var maxNumPerUser = (2 ** 31 / numClients).trunc;
+		// go to next lower power of 10:
+		numIDs = (10 ** maxNumPerUser.log10.trunc).asInteger;
+
+		idOffset = numIDs * clientID;
+
+		permFreed = IdentitySet.new;
+		maxPermID = idOffset + lowestTempID - 1;
+		tempCount = -1;
+		permCount = 1;
+	}
+
+	alloc {
+		tempCount = tempCount + 1;
+		// wraps after handing out (numIDs - lowestTempID) ids
+		^(lowestTempID + tempCount).wrap(lowestTempID, numIDs) + idOffset;
+	}
+
+	isPerm { |num|
+		// test whether num is a valid permanent nodeID for this client/allocator's range,
+		// which includes idOffset + 0 (for clientID 0, RootNode)
+		// and idOffset + 1, the defaultGroup for this allocator/client
+		^num.inclusivelyBetween(idOffset, maxPermID);
+	}
+
+	allocPerm {
+		var perm;
+		if(permFreed.size > 0) {
+			perm = permFreed.minItem;
+			permFreed.remove(perm);
+			^perm
+		};
+
+		permCount = (permCount + 1).min(lowestTempID);
+		perm = permCount;
+		if (perm >= lowestTempID) {
+			warn("%: cannot create more than % permanent ids."
+				"\nPlease free some permanent ids first,"
+				"or set lowestTempID higher."
+				.format(thisMethod, perm)
+			);
+			^nil
+		};
+		^perm + idOffset
+	}
+
+	freePerm { |id|
+		if (this.isPerm(id)) { permFreed.add(id) }
+	}
+}

--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -38,7 +38,7 @@ ServerOptions {
 	var <>threads = nil; // for supernova
 	var <>useSystemClock = false;  // for supernova
 
-	var <numPrivateAudioBusChannels=112;
+	var <numPrivateAudioBusChannels=1020;
 
 	var <>reservedNumAudioBusChannels = 0;
 	var <>reservedNumControlBusChannels = 0;

--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -417,7 +417,11 @@ Server {
 	}
 
 	newNodeAllocators {
-		nodeAllocator = NodeIDAllocator(clientID, options.initialNodeID)
+		nodeAllocator = nodeAllocClass.new(
+			clientID,
+			options.initialNodeID,
+			options.maxLogins
+		);
 	}
 
 	newBusAllocators {

--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -286,7 +286,8 @@ Server {
 		named = IdentityDictionary.new;
 		all = Set.new;
 
-		nodeAllocClass = ReadableNodeIDAllocator;
+		nodeAllocClass = NodeIDAllocator;
+		// nodeAllocClass = ReadableNodeIDAllocator;
 		bufferAllocClass = ContiguousBlockAllocator;
 		busAllocClass = ContiguousBlockAllocator;
 
@@ -370,7 +371,7 @@ Server {
 
 	initTree {
 		this.newNodeAllocators;
-		this.sendMsg("/g_new", this.defaultGroupID, 0, 0);
+		this.sendMsg("/g_new", this.defaultGroup.nodeID, 0, 0);
 		tree.value(this);
 		ServerTree.run(this);
 	}
@@ -408,14 +409,14 @@ Server {
 	}
 
 	newAllocators {
-		this.newNodeAllocator;
+		this.newNodeAllocators;
 		this.newBusAllocators;
 		this.newBufferAllocators;
 		this.newScopeBufferAllocators;
 		NotificationCenter.notify(this, \newAllocators);
 	}
 
-	newNodeAllocator {
+	newNodeAllocators {
 		nodeAllocator = NodeIDAllocator(clientID, options.initialNodeID)
 	}
 

--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -351,6 +351,11 @@ Server {
 
 	}
 
+	remove {
+		all.remove(this);
+		named.removeAt(this.name);
+	}
+
 	numClients { ^options.maxLogins }
 
 	addr_ { |netAddr|

--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -391,30 +391,29 @@ Server {
 		controlBusOffset = numControl * offset + options.reservedNumControlBusChannels;
 		audioBusOffset = options.firstPrivateBus + (numAudio * offset) + options.reservedNumAudioBusChannels;
 
-		controlBusAllocator =
-		ContiguousBlockAllocator.new(numControl, controlBusOffset);
-
-		audioBusAllocator =
-		ContiguousBlockAllocator.new(numAudio, audioBusOffset);
+		controlBusAllocator = busAllocClass.new(
+			numControlPerUser,
+			controlReservedOffset,
+			controlBusClientOffset
+		);
+		audioBusAllocator = busAllocClass.new(
+			numAudioPerUser,
+			audioReservedOffset,
+			audioBusClientOffset
+		);
 	}
 
 
 	newBufferAllocators {
-		var bufferOffset;
-		var offset = this.calcOffset;
-		var n = options.maxLogins ? 1;
-		var numBuffers = options.numBuffers div: n;
-		bufferOffset = numBuffers * offset + options.reservedNumBuffers;
-		bufferAllocator =
-		ContiguousBlockAllocator.new(numBuffers, bufferOffset);
-	}
+		var numBuffersPerUser = options.numBuffers div: numUsers;
+		var numReservedBuffers = options.reservedNumBuffers;
+		var bufferClientOffset = numBuffersPerUser * clientID;
 
-	calcOffset {
-		if(options.maxLogins.isNil) { ^0 };
-		if(clientID > (options.maxLogins - 1)) {
-			"Client ID exceeds maxLogins. Some buses and buffers may overlap for remote server: %".format(this).warn;
-		};
-		^clientID % options.maxLogins
+		bufferAllocator = bufferAllocClass.new(
+			numBuffersPerUser,
+			numReservedBuffers,
+			bufferClientOffset
+		);
 	}
 
 	newScopeBufferAllocators {

--- a/testsuite/classlibrary/TestContiguousBlockAllocator.sc
+++ b/testsuite/classlibrary/TestContiguousBlockAllocator.sc
@@ -1,0 +1,58 @@
+TestContiguousBlockAllocator : UnitTest {
+
+	test_CBAllocator {
+		var alloc = ContiguousBlockAllocator(1024, 0, 1024 * 8);
+		var remaining = alloc.size, lastID;
+		var allIDs = List[], newID, maxPos;
+		var sizes = (1024 * (0.5 ** (1.. 1024.log2))).asInteger;
+
+		// sizes.sum = 1023, + [1, 1] goes over max by 1
+		(sizes.scramble ++ [1, 1]).do { |size|
+			newID = alloc.alloc(size);
+			allIDs.add(newID);
+		};
+
+		this.assert(
+			allIDs.drop(-1).every(_.isNumber) and: allIDs.last.isNil,
+			"ContiguousBlockAllocator hands out its full range for variable block sizes."
+		);
+
+		allIDs.size.do { allIDs.remove(allIDs.choose); };
+
+		this.assert(
+			alloc.pos == alloc.addrOffset,
+			"ContiguousBlockAllocator should reclaim its full range after all blocks are removed."
+		);
+
+		while {
+			// try removing first
+			if (0.5.coin) { allIDs.remove(allIDs.choose) };
+			// try allocating random block size
+			newID = alloc.alloc([1, 2, 3, 5, 8].choose);
+			// if random block too big, try single id
+			if (newID.isNil) { newID = alloc.alloc; };
+			newID.notNil;
+		} {
+			allIDs.add(newID);
+		};
+		this.assert(
+			alloc.top == (alloc.addrOffset + alloc.size - 1),
+			"ContiguousBlockAllocator should hand out its full range in mixed allocation/removal."
+		);
+
+		while {
+			allIDs.remove(allIDs.choose);
+			allIDs.notEmpty;
+		} {
+			if (0.5.coin) {
+				newID = alloc.alloc([1, 2, 3, 5, 8].choose);
+				// if random block too big, try single id
+				if (newID.isNil) { newID = alloc.alloc; };
+				if (newID.notNil) { allIDs.add(newID) };
+			};
+		};
+		this.assert(
+			alloc.top == (alloc.addrOffset + alloc.size - 1),
+			"ContiguousBlockAllocator should reclaim its full range after mixed allocation/removal.")
+	}
+}

--- a/testsuite/classlibrary/TestReadableNodeIDAllocator.sc
+++ b/testsuite/classlibrary/TestReadableNodeIDAllocator.sc
@@ -1,0 +1,85 @@
+TestReadableNodeIDAllocator : UnitTest {
+
+	// test proper creation from Server
+	test_readableNodeRange {
+		var s = Server(\testRNIA);
+		var prevClass = Server.nodeAllocClass;
+		Server.nodeAllocClass = ReadableNodeIDAllocator;
+		s.options.maxLogins = 1; s.newAllocators;
+		// this.assert(
+		// 	(s.nodeAllocator.numIDs == (10 ** 8)),
+		// 	"for a single client, (readable) nodeAllocator has maximum range."
+		// );
+		// this.assert(
+		// 	(s.nodeAllocator.numIDs == (10 ** 7)),
+		// 	"for 16 clients, (readable) nodeAllocator has divided range."
+		// );
+
+		// same for ReadableNodeIDAllocator
+		// Server.nodeAllocClass = ReadableNodeIDAllocator;
+		Server.named.removeAt(s.name); Server.all.remove(s);
+		Server.nodeAllocClass = prevClass;
+	}
+
+	test_permIDs {
+		var alloc = ReadableNodeIDAllocator(8191, 1000, 8191);
+		var nextPermID, permIDs = List[], permIDToFree;
+
+		this.assert(
+			alloc.isPerm(alloc.idOffset - 1).not
+			and: alloc.isPerm(alloc.idOffset)
+			and: alloc.isPerm(alloc.idOffset + alloc.lowestTempID - 1)
+			and: alloc.isPerm(alloc.idOffset + alloc.lowestTempID).not,
+			"ReadableNodeIDAllocator should identify its permanent IDs."
+		);
+		while {
+			if (0.5.coin and: { permIDs.size > 0 }) {
+				permIDToFree = permIDs.remove(permIDs.choose);
+				alloc.freePerm(permIDToFree);
+			};
+			nextPermID = alloc.allocPerm;
+			nextPermID.notNil;
+		} {
+			permIDs.add(nextPermID);
+		};
+		this.assert(
+			permIDs.size.postln == (alloc.lowestTempID - 2),
+			"ReadableNodeIDAllocator should hand out all permanent IDs in mixed alloc/free use."
+		);
+
+		while {
+			if (0.5.coin) {
+				nextPermID = alloc.allocPerm;
+				if (nextPermID.notNil) {
+					permIDs.add(nextPermID);
+				};
+			};
+			permIDs.size > 0;
+		} {
+			permIDToFree = permIDs.remove(permIDs.choose);
+			alloc.freePerm(permIDToFree);
+		};
+		this.assert(
+			alloc.allocPerm == (alloc.idOffset + 2),
+			"ReadableNodeIDAllocator should begin at first permID after freeing all permanent IDs in mixed alloc/free use."
+		);
+	}
+
+	test_fullRange {
+		var alloc = ReadableNodeIDAllocator(8191, 1000, 8191);
+		var tempID, prevID = -1, count = 0;
+
+		while {
+			tempID = alloc.alloc;
+			tempID > prevID
+		} {
+			count = count + 1;
+			prevID = tempID;
+		};
+		this.assert(
+			count == (alloc.numIDs - alloc.lowestTempID + 1)
+			and: tempID == (alloc.idOffset + alloc.lowestTempID),
+			"ReadableNodeIDAllocator should recycle tempIDs after its full range has been used."
+		);
+	}
+}

--- a/testsuite/classlibrary/TestReadableNodeIDAllocator.sc
+++ b/testsuite/classlibrary/TestReadableNodeIDAllocator.sc
@@ -5,25 +5,30 @@ TestReadableNodeIDAllocator : UnitTest {
 		var s = Server(\testRNIA);
 		var prevClass = Server.nodeAllocClass;
 		Server.nodeAllocClass = ReadableNodeIDAllocator;
-		s.options.maxLogins = 1; s.newAllocators;
-		// this.assert(
-		// 	(s.nodeAllocator.numIDs == (10 ** 8)),
-		// 	"for a single client, (readable) nodeAllocator has maximum range."
-		// );
-		// this.assert(
-		// 	(s.nodeAllocator.numIDs == (10 ** 7)),
-		// 	"for 16 clients, (readable) nodeAllocator has divided range."
-		// );
 
-		// same for ReadableNodeIDAllocator
-		// Server.nodeAllocClass = ReadableNodeIDAllocator;
-		Server.named.removeAt(s.name); Server.all.remove(s);
+		s.options.maxLogins = 1;
+		s.newAllocators;
+		this.assert(
+			(s.nodeAllocator.numIDs == (10 ** 9)),
+			"for a single client, (readable) nodeAllocator has maximum range."
+		);
+
+		s.options.maxLogins = 16;
+		s.newAllocators;
+		this.assert(
+			(s.nodeAllocator.numIDs == (10 ** 8)),
+			"for 16 clients, (readable) nodeAllocator has equally divided range."
+		);
+
+		s.remove;
 		Server.nodeAllocClass = prevClass;
 	}
 
 	test_permIDs {
 		var alloc = ReadableNodeIDAllocator(8191, 1000, 8191);
 		var nextPermID, permIDs = List[], permIDToFree;
+
+		thisThread.randSeed_(4711);
 
 		this.assert(
 			alloc.isPerm(alloc.idOffset - 1).not

--- a/testsuite/classlibrary/TestServerClientID.sc
+++ b/testsuite/classlibrary/TestServerClientID.sc
@@ -1,0 +1,75 @@
+/*
+TestServerClientID.run;
+UnitTest.gui;
+
+Tests for clientID, maxLogins and allocator creation based on these.
+
+* clientID should be impossible to set to nonsense data,
+it should always be between 0 and maxLogins - 1.
+
+NOTE: All test cases currently have powerOfTwo numbers for maxLogins.
+This is because the server currently rounds up maxLogins to nextPowerOfTwo;
+so when the server IS NOT booted, odd numbers of maxLogins stay as they are;
+when the server IS booted, the rounded-up maxLogins come back to each client.
+If this server behavior changes to support non-powerOfTwo numbers of clients,
+the tests should also include irregular numbers for maxLogins, e.g. 1, 2, 3, 5, 8.
+
+*/
+
+TestServer_clientID : UnitTest {
+	// these while server is off
+	test_ClientIDChecks {
+		var s = Server(\testID);
+		this.assert(s.clientID == 0, "s.clientID should be 0 by default.");
+		// test checks for bad input
+		s.clientID = -1.sqrt;
+		this.assert(s.clientID == 0, "s.clientID should block non-Integers.");
+		s.clientID = -123;
+		this.assert(s.clientID == 0, "s.clientID should block negative numbers.");
+		s.options.maxLogins = 32;
+		s.clientID = s.options.maxLogins;
+		this.assert(s.clientID == 0, "s.clientID should block number >= maxLogins.");
+		s.clientID = s.options.maxLogins - 1;
+		this.assert(s.clientID == 31, "s.clientID should be settable if valid.");
+		Server.named.removeAt(s.name); Server.all.remove(s);
+	}
+
+	test_UserSetClientID {
+		var options = ServerOptions.new;
+		var s = Server(\testserv, NetAddr("localhost", 57111), options, 1);
+		this.assert(s == nil, "Making a server with invalid clientID should be blocked.");
+		options.maxLogins_(8);
+		s = Server(\testserv, NetAddr("localhost", 57111), options, 7);
+		this.assert(s.clientID == 7, "Making a server with valid nonzero clientID should work.");
+		Server.named.removeAt(s.name); Server.all.remove(s);
+	}
+
+	test_AllocRanges {
+		var s = Server(\testAlloc);
+		var prevClass = Server.nodeAllocClass;
+
+		Server.nodeAllocClass = NodeIDAllocator;
+		s.options.maxLogins = 1; s.newAllocators;
+
+		this.assert(
+			(s.nodeAllocator.numIDs == (2 ** 26)),
+			"nodeAllocator should have its normal range."
+		);
+
+		this.assert(
+			(s.audioBusAllocator.size == s.options.numAudioBusChannels) and:
+			(s.controlBusAllocator.size == s.options.numControlBusChannels) and:
+			(s.bufferAllocator.size == s.options.numBuffers),
+			"for a single client, bus and buffer allocators should have full range."
+		);
+		s.options.maxLogins = 16; s.newAllocators;
+		this.assert(
+			(s.audioBusAllocator.size == (s.options.numAudioBusChannels div: 16)) and:
+			(s.controlBusAllocator.size == (s.options.numControlBusChannels div: 16)) and:
+			(s.bufferAllocator.size == (s.options.numBuffers div: 16)),
+			"for 16 clients, all allocators should divide range evenly."
+		);
+
+		Server.nodeAllocClass = prevClass;
+	}
+}

--- a/testsuite/classlibrary/TestServer_clientIDBooted.sc
+++ b/testsuite/classlibrary/TestServer_clientIDBooted.sc
@@ -1,0 +1,27 @@
+// see also TestServer_clientID
+TestServer_clientID_booted : UnitTest {
+
+	// with running server
+	test_ClientIDResetByServer {
+		var options = ServerOptions.new;
+		var s;
+		s = Server(\testserv1, NetAddr("localhost", 57111), options);
+
+		s.options.maxLogins = 4; s.clientID = 3;
+		this.bootServer(s);
+		s.sync;
+		1.wait;
+		this.assert(s.clientID == 0, "Non-user-defined clientID should be reset by the server.");
+		Server.named.removeAt(s.name); Server.all.remove(s);
+		s.quit;
+		1.wait;
+
+		s = Server(\testserv2, NetAddr("localhost", 57112), options, 3);
+
+		this.bootServer(s);
+		s.sync;
+		1.wait;
+		this.assert(s.clientID == 3, "User-defined clientID should be left as is by the server.");
+		Server.named.removeAt(s.name); Server.all.remove(s);
+	}
+}


### PR DESCRIPTION
This is no. 2 of several smaller PR based on #3106, hopefully easier to review.

It is based on PR #3178, to which it adds only the last 2 commits:
ReadableNodeIDAllocator, an alternative to NodeIDAllocator, 
class file, help file and unittest, and allowing its use in Server.
