### PR TITLE
Server: create separate default groups for multiple clients

### DIFF
--- a/HelpSource/Classes/ContiguousBlockAllocator.schelp
+++ b/HelpSource/Classes/ContiguousBlockAllocator.schelp
@@ -1,17 +1,11 @@
 class:: ContiguousBlockAllocator
 summary:: for better handling of dynamic allocation
-related:: Classes/Server, Classes/PowerOfTwoAllocator
+related:: Classes/Server, Classes/PowerOfTwoAllocator, Guides/MultiClient_Setups
 categories:: Control
 
 description::
 
-A more robust replacement for the default server block allocator, link::Classes/PowerOfTwoAllocator::. May be used in the link::Classes/Server:: class to allocate audio/control bus numbers and buffer numbers.
-
-To configure a server to use ContiguousBlockAllocator, execute the following:
-code::
-aServer.options.blockAllocClass = ContiguousBlockAllocator;
-::
-Normally you will not need to address the allocators directly. However, ContiguousBlockAllocator adds one feature not present in PowerOfTwoAllocator, namely the emphasis::reserve:: method.
+The default allocator used in servers to allocate bus numbers and buffer numbers. Compared to its predecessor, link::Classes/PowerOfTwoAllocator::, it can reserve a block of numbers at the beginning of its range, and it can offset its entire range of numbers to support multiple clientIDs.
 
 ClassMethods::
 
@@ -20,7 +14,16 @@ Create a new allocator with emphasis::size:: slots. You may block off the first 
 
 InstanceMethods::
 
-private::prReserve, prSplit
+private::prReserve, prSplit, addToFreed, blocks, findAvailable, findNext, findPrevious, removeFromFreed
+
+method::size
+	the number of id numbers it can allocate
+
+method::pos
+	the allocator's offset for a reserved block (e.g. for hardware input and output buses).
+
+method::addrOffset
+	the offset of the allocator's address range, which is used to accomodate multiple clientIDs.
 
 method::alloc
 Return the starting index of a free block that is emphasis::n:: slots wide. The default is 1 slot.
@@ -31,4 +34,6 @@ Free a previously allocated block starting at emphasis::address::.
 method::reserve
 Mark a specific range of addresses as used so that the alloc method will not return any addresses within that range.
 
+method::debug
+	post internal state of allocator for debugging.
 

--- a/HelpSource/Classes/Group.schelp
+++ b/HelpSource/Classes/Group.schelp
@@ -11,12 +11,19 @@ For more on the crucial distinction between client objects and server nodes, see
 
 N.B. Group is a subclass of Node, and thus many of its most useful and important methods are documented in the link::Classes/Node:: help file. Please refer to it for more information.
 
-subsection:: RootNode and the default group
+subsection:: RootNode and the default groups
 
-When a Server is booted there is a top level group with an ID of zero that defines the root of the tree. This is represented by a subclass of Group: link::Classes/RootNode::.
-If the Server was booted from within SCLang (as opposed to from the command line) then a default_group with an ID of 1 will be automatically created. This group is the default enclosing group for all Nodes, i.e. it's what you get if you don't specify.
-In general you should create new Nodes within the default group of a Server rather than in its RootNode.
-See link::Classes/Server::, link::Reference/default_group:: and link::Classes/RootNode:: for more detail.
+When a Server is booted, there is a top level group with an ID of 0 that
+defines the root of the tree. This is represented by a subclass of Group:
+link::Classes/RootNode::.
+
+sclang has the notion of a "default group," which is automatically created when
+the server is booted. This group is the default enclosing group for all Nodes,
+i.e. it's what you get if you don't specify. In general you should create new
+Nodes within the default group of a Server rather than in its RootNode.
+Multiclient setups may have different default groups for each client. See
+link::Reference/default_group::, link::Classes/Server::, and
+link::Classes/RootNode:: for more detail.
 
 subsection:: Bundling
 

--- a/HelpSource/Classes/ReadableNodeIDAllocator.schelp
+++ b/HelpSource/Classes/ReadableNodeIDAllocator.schelp
@@ -1,0 +1,86 @@
+TITLE:: ReadableNodeIDAllocator
+summary:: an allocator for nodeIDs with human-readable ownership
+categories:: Control
+related:: Classes/Server, Guides/MultiClient_Setups
+
+DESCRIPTION::
+In multi-client setups, it is useful to know which client created which nodeIDs on a shared server. ReadableNodeIDAllocator provides that facility by using a decimal prefix based on the clientID.
+
+
+code::
+// default server uses a ReadableNodeIDAllocator
+s.nodeAllocator;
+s.nodeAllocator.userID; // its userID is
+s.clientID
+
+// which creates this defaultGroup 1
+s.defaultGroup;
+s.defaultGroupID;
+// and temp nodes begin with 1000 ...
+3.do { s.nextNodeID.postln };
+
+
+// make a dummy server with different clientID
+r = Server(\remote4, s.addr, s.options, clientID: 4);
+// defaultGroup begins with 400000 ... prefix and ends with 1
+r.defaultGroup;
+r.defaultGroupID;
+// and temp nodes begin with 400001000 ...
+3.do { r.nextNodeID.postln };
+::
+
+CLASSMETHODS::
+
+METHOD:: new
+make a new instance for given clientID, offset for lowest temporary id, and
+argument:: clientID
+the clientID for which to create an offset/prefix
+argument:: lowestTempID
+the offset for the lowest temporary id
+argument:: numClients
+the number of clients for which to split the number range
+
+code::
+// make an allocator with id 11
+a = ReadableNodeIDAllocator(11, 1000, 12);
+// begins with 1100000 ... prefix
+3.do { a.alloc.postln };
+::
+
+INSTANCEMETHODS::
+
+METHOD:: clientID
+the clientID for which to create an offset/prefix
+
+METHOD:: numClients
+the number of clients for which to split the number range
+
+METHOD:: lowestTempID
+the offset from where temporary nodeID begin
+
+METHOD:: idOffset
+the offset from where nodeID range begins
+
+METHOD:: maxPermID
+the highest permanent nodeID
+
+METHOD:: numIDs
+the number of IDs before the allocator will wrap
+
+METHOD:: alloc
+allocate next temporary nodeID
+
+METHOD:: allocPerm
+allocate next permanent nodeID
+
+METHOD:: freePerm
+free a permanent nodeID
+argument:: id
+
+METHOD:: isPerm
+test whether num is in the allocator's range of permanent numbers
+argument:: num
+
+METHOD:: reset
+reset allocator to initial state
+

--- a/HelpSource/Classes/Server.schelp
+++ b/HelpSource/Classes/Server.schelp
@@ -262,7 +262,12 @@ method:: options
 Get or set this Server's link::Classes/ServerOptions:: object. Changes to options only take effect when the server is rebooted.
 
 method:: defaultGroup
-returns:: this Server's default group.
+Return the default group on this Server for this client ID. This will be the
+same object as code::server.defaultGroups[server.clientID]::.
+
+method:: defaultGroups
+Return an array mapping client IDs to their associated default groups as
+link::Classes/Group:: objects.
 
 method:: volume
 Get an instance of Volume that runs after the default group, or sets the Volume of the Server's output to level. Level is in db.

--- a/HelpSource/Guides/MultiClient_Setups.schelp
+++ b/HelpSource/Guides/MultiClient_Setups.schelp
@@ -1,4 +1,4 @@
-TITLE:: MultiClient_Setups
+TITLE:: Multi-client Setups
 SUMMARY:: How to set up and shared servers for multiple clients in SuperCollider
 CATEGORIES:: Guides
 related:: Classes/ServerOptions, Classes/Server
@@ -315,6 +315,7 @@ CmdPeriod.remove(~freeMyGroupS); // cleanup
 s.freeAll;
 ::
 strong::More power to all::
+
 In a less polite symmetrical setup, CmdPeriod stops all sounds on all clients, but keeps all defaultGroups running.
 code::
 ~myserver = s; // s on home machine, remote client on others

--- a/HelpSource/Guides/MultiClient_Setups.schelp
+++ b/HelpSource/Guides/MultiClient_Setups.schelp
@@ -1,0 +1,211 @@
+TITLE:: MultiClient_Setups
+SUMMARY:: How to handle clientIDs and id allocation in multi-client/server setups
+CATEGORIES:: Guides
+related:: Classes/ServerOptions, Classes/Server
+KEYWORD:: server, multi-client
+
+section:: Multi client-server setups - discussion and tests
+
+OSC communication between SC and its sound server offers many options for network music: Multiple computers can run both supercollider and associated sound servers.
+For clarity, the "server process" refers to a running scsynth or supernova process. The "server object" AKA "client" is the server's representation in sclang, such as code::Server.local, s, Server(\elsewhere, NetAddr("163.234.56.78"))::.
+
+subsection:: What are clientIDs, and how do servers get them?
+
+When more than one user plays on a given server,
+some resources need to be shared between users/clients:
+list::
+## permanent and temporary nodeIDs (handled by Server:nodeAllocator),
+## private control and audio bus channels (handled by Server:audioBusAllocator, Server:controlBusAllocator)
+## buffer numbers (handled by Server:bufferAllocator).
+::
+
+This sharing is handled by declaring how many clients/users are expected to login (Server:numUsers), and giving a different clientID to each of them when the login happens.
+
+The most common case is that there is only a single user/client, who always gets clientID 0, and control of all available resources (i.e. the full number range of every allocator).
+
+When multiple clients log in, this is what happens:
+list::
+## On startup, scsynth (the server process) gets a fixed limit of maxLogins.
+## When a local or remote server object/client has no user-specified clientID,
+scsynth sends back the next free clientID, and the client uses it.
+## When a local or remote server object/client was created with a specific clientID,
+scsynth sends back that number if it was free, or the next free clientID if not; the client should use the free number, as the other may clash with a client already logged in.
+## [After the corresponding pull request is accepted,] scsynth also sends back the maxLogins value it was started with, so clients can adjust their internal allocator settings to it.
+::
+
+subsection:: Code examples and tests
+
+Recommended usage for multiple clients on the same server is to use identical options settings for all clients, and logging into the scsynth process from different sclang instances, which are typically on different laptops.
+
+code::
+// on the machine where scsynth runs, it can be the default server.
+// set the maximum number of client logins expected:
+s.options.maxLogins = 16;
+// now boot the server:
+s.boot;
+
+// from another sclang instance, log into scsynth:
+s.options.maxLogins = 16;
+// example NetAddr of the machine that runs scsynth on standard port
+s.addr = NetAddr("168.192.1.20", 57110);
+::
+
+When fixed clientIDs for multiclient setups are desired, the recommended usage is to set every clientID on creation.
+
+code::
+s.options.maxLogins = 16;
+
+r = Server(
+	\remote4,
+	// example NetAddr of the machine that runs scsynth on standard port
+	NetAddr("168.192.1.2", 57110),
+	s.options,		// make sure all remote servers use the same options
+	4				// and when desired, set fixed client by hand
+);
+
+// now s knows it can change clientID from server login response
+// (because userSpecifiedClientID is false)
+s.userSpecifiedClientID;
+// and z knows to keep its clientID
+r.userSpecifiedClientID;
+
+::
+
+subsection:: Separate defaultGroups and easy-to-trace nodeIDs
+
+Every client registering with a server has its own defaultGroup. All nodes belonging to one client are in its defaultGroup and can be specifically addressed, so e.g. freeAll can release only one's own nodes, and not those of other clients on this server.
+For details, see NodeIDAllocator and ReadableNodeIDAllocator class and help files.
+
+code::
+
+// NodeIDAllocator uses a fixed binary prefix of (2 ** 26) * clientID:
+Server.nodeAllocClass = NodeIDAllocator;
+s.newAllocators; r.newAllocators;  // remake allocators
+// clientID 0 has group 1:
+s.clientID;
+s.defaultGroup;
+s.defaultGroupID;
+
+// for server r:
+r.clientID; 		// 4
+r.nodeAllocator.idOffset; // lookup the offset: (2 ** 26 * 4)
+r.defaultGroup;		// Group(268435457) : idOffset + 1
+
+r.defaultGroupID; 	// 268435457
+r.options.maxLogins	// 16
+
+
+r.defaultGroupID mod: (2 ** 26); // 1 is the nodeID relative to idOffset relative ID
+r.defaultGroupID >> 26;
+r.nextNodeID ;   // begin at defaultGroupID + 1000
+r.nextNodeID >> 26; // get clientID from a long nodeID
+
+
+// ReadableNodeIDAllocator uses a decimal prefix - to demonstrate:
+Server.nodeAllocClass = ReadableNodeIDAllocator;
+s.newAllocators; r.newAllocators;  // remake allocators
+
+// for clientID 0, nothing changes:
+s.clientID;
+s.defaultGroup;
+s.defaultGroupID;
+
+// for server r:
+r.clientID; 		// 4
+r.nodeAllocator.idOffset;  // offset if decimal
+r.defaultGroupID; 	// 400000001 - easy to identify nodeID source
+r.defaultGroup;		// Group(400000001)
+r.options.maxLogins	// 16
+
+
+// s.defaultGroup is used often, and can be looked up in many ways:
+r.defaultGroup;
+r.defaultGroupID;
+r.asGroup;
+r.asTarget;
+
+// temp nodeIDs readably belong to clientID 4, starting with 4...1000
+5.do { r.nextNodeID.postln };
+5.do { s.nextNodeID.postln };
+
+
+// For demonstration, switch addr of r to point to local scsynth,
+// so we can test the allocator numbers on a single machine:
+r.addr = s.addr;
+// whenever an accessible sound process is created, it gets a nodeID;
+// here are four different ways to create sounds, and see their nodeIDs:
+r.boot;
+r.plotTree;
+Server.default = r;
+
+// Synth
+x = Synth(\default, nil);
+x.release;
+
+x = { Dust.ar(10!2).lag(0.002) }.play(r);
+x.release(2);
+
+(dur: 4, server: r).play;
+
+// JITLib nodeproxies
+Ndef(\x, { Dust.ar(10 ! 2) });
+Ndef(\x).play;
+Ndef(\x).filter(10, { |in| Ringz.ar(in, [600, 800], 0.03) }).play;
+Ndef(\x).end(3);
+
+// more nodeID examples needed here?
+
+::
+
+subsection:: Bus channel and buffer numbers
+The allocators for audio and control busses and for buffers split the full number range of scsynth evenly for the number of clients expected.
+
+code::
+// default value for clientID is 0 and maxLogins is 1
+Server.default = Server.local;
+s.clientID;   // should be 0
+s.options.maxLogins; // default 1
+
+// you can set maxLogins_ by hand - not recommended, only for testing here:
+s.options.maxLogins_(1); // default 1
+
+s.options.numAudioBusChannels;
+// use newAllocators method to create allocator ranges accordingly
+s.newBusAllocators;
+s.audioBusAllocator.size;
+
+// 1024 buses to allocate
+Bus.audio(s, 2);
+
+//  set maxLogins_ to 16 by hand - not recommended, only for demonstration here:
+s.options.maxLogins_(16);
+s.newBusAllocators; // 64 = 1024 / 16 buses to allocate per client.
+s.audioBusAllocator.size;
+3.collect { Bus.audio(s, 2) };
+// 1024 control buses to allocate, starting at 0
+s.controlBusAllocator.size;
+3.collect { Bus.control(s, 2) };
+
+r.newBusAllocators;
+// audio bus range starts at 256
+3.collect { Bus.audio(r, 2) }; //
+// control bus range starts at 4096: 1365 * 4
+3.collect { Bus.control(r, 2) };
+
+// more bus alloc examples desirable here?
+::
+
+
+Buffer allocation uses the same class, ContiguousBlockAllocator, and thus works the same way.
+
+code::
+// show buffer allocation
+Server.default = Server.local;
+s.bufferAllocator.size;
+3.collect { Buffer(s) }; // starts at 0
+
+r.bufferAllocator.size;
+3.collect { Buffer(r) }; // starts at 256
+
+// more buffer alloc examples desirable here?
+::

--- a/HelpSource/Guides/MultiClient_Setups.schelp
+++ b/HelpSource/Guides/MultiClient_Setups.schelp
@@ -72,6 +72,8 @@ r.userSpecifiedClientID;
 
 subsection:: Separate defaultGroups
 
+For info on what a default group is, see link::Reference/default_group::.
+
 Every client registering with a server has its own defaultGroup. All nodes belonging to one client are in its defaultGroup and can be specifically addressed, so that a client can release only one's own nodes, and leave those of other clients on this server untouched.
 
 A client also knows the defaultGroups of all other clients that may login, so it can reason about other clients, and be as sharing-friendly as desired, see below in subsection CmdPeriod behavior.

--- a/HelpSource/Guides/MultiClient_Setups.schelp
+++ b/HelpSource/Guides/MultiClient_Setups.schelp
@@ -1,5 +1,5 @@
 TITLE:: MultiClient_Setups
-SUMMARY:: How to handle clientIDs and id allocation in multi-client/server setups
+SUMMARY:: How to set up and shared servers for multiple clients in SuperCollider
 CATEGORIES:: Guides
 related:: Classes/ServerOptions, Classes/Server
 KEYWORD:: server, multi-client
@@ -19,18 +19,17 @@ list::
 ## buffer numbers (handled by Server:bufferAllocator).
 ::
 
-This sharing is handled by declaring how many clients/users are expected to login (Server:numUsers), and giving a different clientID to each of them when the login happens.
+This sharing is handled by declaring how many clients/users are expected to login - code::server.options.maxLogins:: - and scsynth will automatically give a different clientID to each client when it logs in.
 
 The most common case is that there is only a single user/client, who always gets clientID 0, and control of all available resources (i.e. the full number range of every allocator).
 
 When multiple clients log in, this is what happens:
 list::
-## On startup, scsynth (the server process) gets a fixed limit of maxLogins.
-## When a local or remote server object/client has no user-specified clientID,
-scsynth sends back the next free clientID, and the client uses it.
-## When a local or remote server object/client was created with a specific clientID,
-scsynth sends back that number if it was free, or the next free clientID if not; the client should use the free number, as the other may clash with a client already logged in.
-## [After the corresponding pull request is accepted,] scsynth also sends back the maxLogins value it was started with, so clients can adjust their internal allocator settings to it.
+## On startup, scsynth (the server process) is started with a fixed limit of maxLogins.
+## When a local or remote server object/client has no user-specified clientID, scsynth sends back the next free clientID, and the client uses that clientID.
+## When a local or remote server object/client was created with specific clientID, scsynth sends back that number if it was free, or the next free clientID if not; the client should use the free number in any case, as the other may clash with a client already logged in.
+## In case the client was already registered and tries to register again (after a reboot or network problem), scsynth sends back a failed message AND the clientID this client had earlier, and the client will use that clientID.
+## [After pull request #3181] scsynth also sends back the maxLogins value it was started with, so clients can also adjust their internal allocator settings to it.
 ::
 
 subsection:: Code examples and tests
@@ -40,12 +39,12 @@ Recommended usage for multiple clients on the same server is to use identical op
 code::
 // on the machine where scsynth runs, it can be the default server.
 // set the maximum number of client logins expected:
-s.options.maxLogins = 16;
-// now boot the server:
-s.boot;
+s.options.maxLogins = 8;
+// now reboot the server, so that it will have maxLogins
+s.reboot;
 
 // from another sclang instance, log into scsynth:
-s.options.maxLogins = 16;
+s.options.maxLogins = 8;
 // example NetAddr of the machine that runs scsynth on standard port
 s.addr = NetAddr("168.192.1.20", 57110);
 ::
@@ -53,7 +52,7 @@ s.addr = NetAddr("168.192.1.20", 57110);
 When fixed clientIDs for multiclient setups are desired, the recommended usage is to set every clientID on creation.
 
 code::
-s.options.maxLogins = 16;
+s.options.maxLogins = 8;
 
 r = Server(
 	\remote4,
@@ -71,20 +70,30 @@ r.userSpecifiedClientID;
 
 ::
 
-subsection:: Separate defaultGroups and easy-to-trace nodeIDs
+subsection:: Separate defaultGroups
 
-Every client registering with a server has its own defaultGroup. All nodes belonging to one client are in its defaultGroup and can be specifically addressed, so e.g. freeAll can release only one's own nodes, and not those of other clients on this server.
-For details, see NodeIDAllocator and ReadableNodeIDAllocator class and help files.
+Every client registering with a server has its own defaultGroup. All nodes belonging to one client are in its defaultGroup and can be specifically addressed, so that a client can release only one's own nodes, and leave those of other clients on this server untouched.
+
+A client also knows the defaultGroups of all other clients that may login, so it can reason about other clients, and be as sharing-friendly as desired, see below in subsection CmdPeriod behavior.
+
+code::s.defaultGroups;::
+
+
+subsection:: Easy-to-trace nodeIDs
+
+For details on node allocation, see NodeIDAllocator and ReadableNodeIDAllocator class and help files.
+The scheme from NodeIDAllocator is also followed by many non-sclang clients allocation ranges; in networks with these, NodeIDAllocator will be the safe choice.
 
 code::
 
 // NodeIDAllocator uses a fixed binary prefix of (2 ** 26) * clientID:
 Server.nodeAllocClass = NodeIDAllocator;
-s.newAllocators; r.newAllocators;  // remake allocators
+s.newAllocators;
+r.newAllocators;  // remake allocators
 // clientID 0 has group 1:
-s.clientID;
-s.defaultGroup;
-s.defaultGroupID;
+s.clientID;		// 0
+s.defaultGroup;  // Group(1)
+s.defaultGroupID; // 1
 
 // for server r:
 r.clientID; 		// 4
@@ -92,9 +101,9 @@ r.nodeAllocator.idOffset; // lookup the offset: (2 ** 26 * 4)
 r.defaultGroup;		// Group(268435457) : idOffset + 1
 
 r.defaultGroupID; 	// 268435457
-r.options.maxLogins	// 16
+r.options.maxLogins	// 8
 
-
+// calculate backwards to which clientID a node belongs
 r.defaultGroupID mod: (2 ** 26); // 1 is the nodeID relative to idOffset relative ID
 r.defaultGroupID >> 26;
 r.nextNodeID ;   // begin at defaultGroupID + 1000
@@ -103,26 +112,27 @@ r.nextNodeID >> 26; // get clientID from a long nodeID
 
 // ReadableNodeIDAllocator uses a decimal prefix - to demonstrate:
 Server.nodeAllocClass = ReadableNodeIDAllocator;
-s.newAllocators; r.newAllocators;  // remake allocators
+s.newAllocators;
+r.newAllocators;  // remake allocators
 
 // for clientID 0, nothing changes:
-s.clientID;
-s.defaultGroup;
-s.defaultGroupID;
+s.clientID;       // 0
+s.defaultGroup;   // Group(1)
+s.defaultGroupID; // 1
 
 // for server r:
 r.clientID; 		// 4
-r.nodeAllocator.idOffset;  // offset if decimal
+r.nodeAllocator.idOffset;  // decimal offset so clientID is prefix
 r.defaultGroupID; 	// 400000001 - easy to identify nodeID source
 r.defaultGroup;		// Group(400000001)
-r.options.maxLogins	// 16
+r.options.maxLogins	// 8
 
+// s.defaultGroup can be looked up in many ways:
+r.defaultGroupID;  // 400000001
+r.defaultGroup;    // Group(400000001)
+r.asGroup;         // Group(400000001)
+r.asTarget;        // Group(400000001)
 
-// s.defaultGroup is used often, and can be looked up in many ways:
-r.defaultGroup;
-r.defaultGroupID;
-r.asGroup;
-r.asTarget;
 
 // temp nodeIDs readably belong to clientID 4, starting with 4...1000
 5.do { r.nextNodeID.postln };
@@ -134,7 +144,7 @@ r.asTarget;
 r.addr = s.addr;
 // whenever an accessible sound process is created, it gets a nodeID;
 // here are four different ways to create sounds, and see their nodeIDs:
-r.boot;
+r.reboot;
 r.plotTree;
 Server.default = r;
 
@@ -145,15 +155,13 @@ x.release;
 x = { Dust.ar(10!2).lag(0.002) }.play(r);
 x.release(2);
 
-(dur: 4, server: r).play;
+Pbind(\degree, Pseq((0..7).mirror), \dur, 0.15, \server, r).play;
 
 // JITLib nodeproxies
 Ndef(\x, { Dust.ar(10 ! 2) });
 Ndef(\x).play;
 Ndef(\x).filter(10, { |in| Ringz.ar(in, [600, 800], 0.03) }).play;
 Ndef(\x).end(3);
-
-// more nodeID examples needed here?
 
 ::
 
@@ -163,7 +171,7 @@ The allocators for audio and control busses and for buffers split the full numbe
 code::
 // default value for clientID is 0 and maxLogins is 1
 Server.default = Server.local;
-s.clientID;   // should be 0
+s.clientID;   // 0
 s.options.maxLogins; // default 1
 
 // you can set maxLogins_ by hand - not recommended, only for testing here:
@@ -174,27 +182,25 @@ s.options.numAudioBusChannels;
 s.newBusAllocators;
 s.audioBusAllocator.size;
 
-// 1024 buses to allocate
+// 1024 buses to allocate, starting past the hardware IO buses.
 Bus.audio(s, 2);
 
-//  set maxLogins_ to 16 by hand - not recommended, only for demonstration here:
-s.options.maxLogins_(16);
-s.newBusAllocators; // 64 = 1024 / 16 buses to allocate per client.
+//  set maxLogins_ to 8 by hand - not recommended, only for demonstration here:
+s.options.maxLogins_(8);
+s.newBusAllocators; // 128 = 1024 / 8 buses to allocate per client.
 s.audioBusAllocator.size;
 3.collect { Bus.audio(s, 2) };
 // 1024 control buses to allocate, starting at 0
 s.controlBusAllocator.size;
 3.collect { Bus.control(s, 2) };
 
+r.options.dump
 r.newBusAllocators;
-// audio bus range starts at 256
-3.collect { Bus.audio(r, 2) }; //
-// control bus range starts at 4096: 1365 * 4
+// audio bus range starts at 512 of 1024 total range
+3.collect { Bus.audio(r, 2) }; // 512, 514, 516
+// control bus range starts at 8192 of 16384 total range
 3.collect { Bus.control(r, 2) };
-
-// more bus alloc examples desirable here?
 ::
-
 
 Buffer allocation uses the same class, ContiguousBlockAllocator, and thus works the same way.
 
@@ -208,4 +214,117 @@ r.bufferAllocator.size;
 3.collect { Buffer(r) }; // starts at 256
 
 // more buffer alloc examples desirable here?
+::
+
+
+subsection:: Configuring CmdPeriod behavior
+
+In networked performances, it is useful that clients have well-chosen
+emergency access to 'their' sounds on a remote server; and it may make sense to give the local client more emergency power. Both can be configured easily.
+
+strong::Default behavior::
+
+By default, the local client will kill all sounds, and only reconstruct its defaultGroup; on remote clients, CmdPeriod does not affect remoter servers at all.
+
+code::
+// default - single client:
+s.options.maxLogins_(1);
+s.reboot;
+s.plotTree;		// watch to debug
+s.defaultGroup; // Group(1)
+s.defaultGroups; //  only one client, so this is [ Group(1) ]
+(dur: inf).play;  // play a test sound
+Group(0);   // make another group at root level
+s.freeAll;  // sound and added group die, only Group(1) remains
+
+// same with using CmdPeriod:
+(dur: inf).play;  // play a test sound
+Group(0);   // make another group at root level
+CmdPeriod.run; // simulate CmdPeriod key action
+
+
+// show behavior and support methods with a 4 client setup:
+s.options.maxLogins_(4);
+s.reboot;
+s.defaultGroups; // 4 default groups, 1 for every possible client.
+// send defaultGroups for specific clientIDs to scsynth : -> cf plotTree
+s.sendDefaultGroupsForIDs([0, 1]); // adds second defaultGroup
+
+// send all default groups
+s.sendDefaultGroups; // four groups in plotTree
+
+// s.tree gets evaluated after each CmdPeriod.
+// make sure we have nothing in s.tree:
+s.tree = nil;
+s.freeAll; // <- by default, frees other client's defaultGroups too.
+::
+
+strong::Remote-friendly local master setup::
+
+Now, all sounds on the server are gone, as desired.
+But the other clients cannot start new synths now,
+because their defaultGroups are gone too!
+
+Thus, the local client should reconstruct them,
+so the other clients can pick up playing again:
+code::
+// - easiest option:
+s.tree = { s.sendDefaultGroups; };
+(dur: inf).play;  // test sound
+Group(0);   // make second group at root level
+CmdPeriod.run; // simulate CmdPeriod key action
+// -> still stops all sounds, but then remakes all defaultGroups,
+// so the other clients can continue.
+::
+
+strong::Give remote clients control of their sounds::
+
+code::
+// create a fake remote server
+x = Server(\pseudoRem3, s.addr, s.options, 3);
+// method to
+~freeMyGroupX = { x.freeMyGroup };
+CmdPeriod.add(~freeMyGroupX);
+// fake playing a sound from it:
+(dur: 10, group: x.defaultGroup).play;
+(dur: 10, degree: 2).play; // and one on home client
+
+~freeMyGroupX.value; // only frees the one in \pseudoRem3
+
+CmdPeriod.remove(~freeMyGroupX);
+
+strong::Symmetrical / democratic setups::
+
+The home client on the machine where scsynth runs may want to be just like the others. It is simple to make the home client more polite:
+code::
+// first, disable general freeAll:
+CmdPeriod.freeServers = false;
+s.tree = nil;
+s.sendDefaultGroups;
+// and add a custom action to CmdPeriod:
+~freeMyGroupS = { s.freeMyGroup };
+CmdPeriod.add(~freeMyGroupS);
+(dur: inf).play;  // test sound
+// simulate second sound from a different client:
+(dur: inf, degree: 2, group: s.defaultGroups[3]).play;
+
+CmdPeriod.run; // simulate CmdPeriod key action
+// -> only stops s.defaultGroup, others continue untouched
+
+CmdPeriod.remove(~freeMyGroupS); // cleanup
+s.freeAll;
+::
+strong::More power to all::
+In a less polite symmetrical setup, CmdPeriod stops all sounds on all clients, but keeps all defaultGroups running.
+code::
+~myserver = s; // s on home machine, remote client on others
+~myserver.sendDefaultGroups;
+~freeDefaultGroups = { ~myserver.freeDefaultGroups };
+CmdPeriod.add(~freeDefaultGroups);
+(dur: inf).play;  // test sound
+// fake sound from  client 1:
+(dur: inf, degree: 2, group: s.defaultGroups[1].nodeID).play;
+
+CmdPeriod.run; // simulate CmdPeriod key action
+// -> all clients stop sound in all groups, groups remain.
 ::

--- a/HelpSource/Reference/default_group.schelp
+++ b/HelpSource/Reference/default_group.schelp
@@ -1,5 +1,5 @@
-title:: default_group
-summary:: The default Group
+title:: Default Group
+summary:: An automatically created Group in sclang
 categories:: Server>Nodes
 related:: Classes/Group, Classes/RootNode, Classes/Node, Guides/NodeMessaging, Guides/Order-of-execution
 
@@ -10,18 +10,37 @@ tree::
 ::
 ::
 
-When a Server is booted there is a top level group with an ID of 0 that defines the root of the node tree. (This is represented by a subclass of Group: link::Classes/RootNode::.)
-If the Server was booted from within SCLang (as opposed to from the command line) a default group with an ID of 1 will be automatically created. footnote::
+When a Server is booted, there is a top level group with an ID of 0 that
+defines the root of the tree. This is represented by a subclass of Group:
+link::Classes/RootNode::.
+
+Separate from the root group is sclang's notion of a "default group," which is
+automatically created when the server is booted. You can access it with the
+method link::Classes/Server#-defaultGroup::. This group is the default
+enclosing group for all Nodes, i.e. it's what you get if you don't specify. In
+general, you should create new Nodes within the default group of a Server
+rather than in its RootNode. In a single-client setup, the default group will
+have an ID of 1.
+
+Keep in mind that default groups are a client-side concept, and you are
+responsible for creating them if you're running scsynth from the command line
+or NRT mode, or developing an alternate client. footnote::
 When booting the server from the command line, you can create the default group manually with:
 code::
 s.initTree;
 ::
 ::
-This is the default target for all Nodes when using object style and is what you will get if you supply a link::Classes/Server:: as a target. If you don't specify a target or pass in nil, you will get the default group of the default Server.
+
+This is the default target for all Nodes when using object style and is what
+you will get if you supply a link::Classes/Server:: as a target. If you don't
+specify a target or pass in nil, you will get the default group of the default
+Server.
 code::
 s.boot;
 a = Synth.new(\default); // creates a synth in the default group of the default Server
 a.group; // note the Group ID
+a.group == Server.default.defaultGroup;
+// -> true
 ::
 The default group serves an important purpose: It provides a predictable basic Node tree so that methods such as Server-scope, Server-record, etc. can function without running into order of execution problems. In the example below the scoping node will come after the default group.
 code::
@@ -71,3 +90,16 @@ tree::
 ## recording synth
 ::
 
+section:: Default groups in multi-client setups
+
+See link::Guides/MultiClient_Setups:: for more info.
+
+The default group mechanism is also used to separate clients in a multi-client
+setup. Every client registering with a server has its own individual default
+group. All nodes belonging to one client are in its default group and can be
+specifically addressed.
+
+This keeps nodes cleanly separated by default, but a client also knows the
+default groups of all other clients. This is accessible via the method
+link::Classes/Server#-defaultGroups::, which is an array mapping client IDs
+to default groups.

--- a/SCClassLibrary/Common/Collections/Event.sc
+++ b/SCClassLibrary/Common/Collections/Event.sc
@@ -257,7 +257,7 @@ Event : Environment {
 
 				synthLib: nil,
 
-				group: 1,
+				group: { ~server.defaultGroupID },
 				out: 0,
 				addAction: 0,
 
@@ -373,7 +373,7 @@ Event : Environment {
 				delta: 0,
 
 				addAction: 0,
-				group: 1,
+				group: { ~server.defaultGroupID },
 				latency: 0.2,
 				instrument: \default,
 				hasGate: true,

--- a/SCClassLibrary/Common/Collections/Event.sc
+++ b/SCClassLibrary/Common/Collections/Event.sc
@@ -257,7 +257,7 @@ Event : Environment {
 
 				synthLib: nil,
 
-				group: { ~server.defaultGroupID },
+				group: { ~server.defaultGroup.nodeID },
 				out: 0,
 				addAction: 0,
 
@@ -373,7 +373,7 @@ Event : Environment {
 				delta: 0,
 
 				addAction: 0,
-				group: { ~server.defaultGroupID },
+				group: { ~server.defaultGroup.nodeID },
 				latency: 0.2,
 				instrument: \default,
 				hasGate: true,

--- a/SCClassLibrary/Common/Control/Engine.sc
+++ b/SCClassLibrary/Common/Control/Engine.sc
@@ -1,6 +1,7 @@
 
 NodeIDAllocator {
 	var <user, initTemp, temp, perm, mask, permFreed;
+	var <numIDs = 0x04000000; // 2 ** 26
 	// support 32 users
 
 	*new { arg user=0, initTemp = 1000;
@@ -196,7 +197,7 @@ ContiguousBlock {
 // pos is offset for reserved numbers,
 // addrOffset is offset for clientID * size
 ContiguousBlockAllocator {
-	var <size, array, freed, <pos, top, <addrOffset;
+	var <size, array, freed, <pos, <top, <addrOffset;
 	// pos is offset for reserved numbers,
 	// addrOffset is offset for clientID * size
 

--- a/SCClassLibrary/Common/Control/Engine.sc
+++ b/SCClassLibrary/Common/Control/Engine.sc
@@ -193,13 +193,18 @@ ContiguousBlock {
 	printOn { |stream| this.storeOn(stream) }
 }
 
-
+// pos is offset for reserved numbers,
+// addrOffset is offset for clientID * size
 ContiguousBlockAllocator {
-	var	size, array, freed, pos, top;
 
-	*new { |size, pos = 0|
-		^super.newCopyArgs(size, Array.newClear(size).put(pos, ContiguousBlock(pos, size-pos)),
-			IdentityDictionary.new, pos, pos);
+	var	<size, array, freed, <pos, top, <addrOffset;
+
+	*new { |size, pos = 0, addrOffset = 0|
+		var shiftedPos = pos + addrOffset;
+		^super.newCopyArgs(size,
+			Array.newClear(size).put(pos, ContiguousBlock(shiftedPos, size-pos)),
+			IdentityDictionary.new,
+			shiftedPos, shiftedPos, addrOffset);
 	}
 
 	alloc { |n = 1|
@@ -212,7 +217,7 @@ ContiguousBlockAllocator {
 	reserve { |address, size = 1, warn = true|
 		var	block, new;
 		((block = array[address] ?? { this.findNext(address) }).notNil and:
-				{ block.used and:
+			{ block.used and:
 				{ address + size > block.start } }).if({
 			warn.if({ "The block at (%, %) is already in use and cannot be reserved."
 				.format(address, size).warn; });
@@ -222,7 +227,7 @@ ContiguousBlockAllocator {
 				^new;
 			}, {
 				((block = this.findPrevious(address)).notNil and:
-						{ block.used and:
+					{ block.used and:
 						{ block.start + block.size > address } }).if({
 					warn.if({ "The block at (%, %) is already in use and cannot be reserved."
 						.format(address, size).warn; });
@@ -237,18 +242,18 @@ ContiguousBlockAllocator {
 
 	free { |address|
 		var	block,
-			prev, next, temp;
+		prev, next, temp;
 		// this 'if' prevents an error if a Buffer object is freed twice
 		if(address.isNil) { ^this };
-		((block = array[address]).notNil and: { block.used }).if({
+		((block = array[address - addrOffset]).notNil and: { block.used }).if({
 			block.used = false;
 			this.addToFreed(block);
 			((prev = this.findPrevious(address)).notNil and: { prev.used.not }).if({
 				(temp = prev.join(block)).notNil.if({
-						// if block is the last one, reduce the top
+					// if block is the last one, reduce the top
 					(block.start == top).if({ top = temp.start });
-					array[temp.start] = temp;
-					array[block.start] = nil;
+					array[temp.start - addrOffset] = temp;
+					array[block.start - addrOffset] = nil;
 					this.removeFromFreed(prev).removeFromFreed(block);
 					(top > temp.start).if({ this.addToFreed(temp); });
 					block = temp;
@@ -256,10 +261,10 @@ ContiguousBlockAllocator {
 			});
 			((next = this.findNext(block.start)).notNil and: { next.used.not }).if({
 				(temp = next.join(block)).notNil.if({
-						// if next is the last one, reduce the top
+					// if next is the last one, reduce the top
 					(next.start == top).if({ top = temp.start });
-					array[temp.start] = temp;
-					array[next.start] = nil;
+					array[temp.start - addrOffset] = temp;
+					array[next.start - addrOffset] = nil;
 					this.removeFromFreed(next).removeFromFreed(block);
 					(top > temp.start).if({ this.addToFreed(temp); });
 				});
@@ -280,8 +285,8 @@ ContiguousBlockAllocator {
 			});
 		});
 
-		(top + n > size or: { array[top].used }).if({ ^nil });
-		^array[top]
+		(top + n - addrOffset > size or: { array[top - addrOffset].used }).if({ ^nil });
+		^array[top - addrOffset]
 	}
 
 	addToFreed { |block|
@@ -291,26 +296,26 @@ ContiguousBlockAllocator {
 
 	removeFromFreed { |block|
 		freed[block.size].tryPerform(\remove, block);
-			// I tested without gc; performance is about half as efficient without it
+		// I tested without gc; performance is about half as efficient without it
 		(freed[block.size].size == 0).if({ freed.removeAt(block.size) });
 	}
 
 	findPrevious { |address|
 		forBy(address-1, pos, -1, { |i|
-			array[i].notNil.if({ ^array[i] });
+			array[i - addrOffset].notNil.if({ ^array[i - addrOffset] });
 		});
 		^nil
 	}
 
 	findNext { |address|
-		var	temp;
-		(temp = array[address]).notNil.if({
-			^array[temp.start + temp.size]
-		}, {
+		var	temp = array[address - addrOffset];
+		if (temp.notNil) {
+			^array[temp.start + temp.size - addrOffset]
+		} {
 			for(address+1, top, { |i|
-				array[i].notNil.if({ ^array[i] });
+				array[i - addrOffset].notNil.if({ ^array[i - addrOffset] });
 			});
-		});
+		};
 		^nil
 	}
 
@@ -333,9 +338,9 @@ ContiguousBlockAllocator {
 		new.used = used;
 		this.removeFromFreed(availBlock);
 		used.not.if({ this.addToFreed(new) });
-		array[new.start] = new;
+		array[new.start - addrOffset] = new;
 		leftover.notNil.if({
-			array[leftover.start] = leftover;
+			array[leftover.start - addrOffset] = leftover;
 			top = max(top, leftover.start);
 			(top > leftover.start).if({ this.addToFreed(leftover); });
 		});

--- a/SCClassLibrary/Common/Control/Engine.sc
+++ b/SCClassLibrary/Common/Control/Engine.sc
@@ -8,6 +8,9 @@ NodeIDAllocator {
 		if (user > 31) { "NodeIDAllocator user id > 31".error; ^nil };
 		^super.newCopyArgs(user, initTemp).reset
 	}
+
+	idOffset { ^numIDs * user }
+
 	reset {
 		mask = user << 26;
 		temp = initTemp;

--- a/SCClassLibrary/Common/Control/Engine.sc
+++ b/SCClassLibrary/Common/Control/Engine.sc
@@ -157,7 +157,7 @@ RingNumberAllocator {
 
 ContiguousBlock {
 
-	var     <start, <size, <>used = false;  // assume free; owner must say otherwise
+	var <start, <size, <>used = false;  // assume free; owner must say otherwise
 
 	*new { |start, size| ^super.newCopyArgs(start, size) }
 
@@ -196,8 +196,9 @@ ContiguousBlock {
 // pos is offset for reserved numbers,
 // addrOffset is offset for clientID * size
 ContiguousBlockAllocator {
-
-	var	<size, array, freed, <pos, top, <addrOffset;
+	var <size, array, freed, <pos, top, <addrOffset;
+	// pos is offset for reserved numbers,
+	// addrOffset is offset for clientID * size
 
 	*new { |size, pos = 0, addrOffset = 0|
 		var shiftedPos = pos + addrOffset;
@@ -208,14 +209,14 @@ ContiguousBlockAllocator {
 	}
 
 	alloc { |n = 1|
-		var	block;
+		var block;
 		(block = this.findAvailable(n)).notNil.if({
 			^this.prReserve(block.start, n, block).start
 		}, { ^nil });
 	}
 
 	reserve { |address, size = 1, warn = true|
-		var	block, new;
+		var block, new;
 		((block = array[address] ?? { this.findNext(address) }).notNil and:
 			{ block.used and:
 				{ address + size > block.start } }).if({
@@ -241,8 +242,7 @@ ContiguousBlockAllocator {
 	}
 
 	free { |address|
-		var	block,
-		prev, next, temp;
+		var block, prev, next, temp;
 		// this 'if' prevents an error if a Buffer object is freed twice
 		if(address.isNil) { ^this };
 		((block = array[address - addrOffset]).notNil and: { block.used }).if({
@@ -308,7 +308,7 @@ ContiguousBlockAllocator {
 	}
 
 	findNext { |address|
-		var	temp = array[address - addrOffset];
+		var temp = array[address - addrOffset];
 		if (temp.notNil) {
 			^array[temp.start + temp.size - addrOffset]
 		} {
@@ -320,7 +320,7 @@ ContiguousBlockAllocator {
 	}
 
 	prReserve { |address, size, availBlock, prevBlock|
-		var	new, leftover;
+		var new, leftover;
 		(availBlock.isNil and: { prevBlock.isNil }).if({
 			prevBlock = this.findPrevious(address);
 		});
@@ -333,7 +333,7 @@ ContiguousBlockAllocator {
 	}
 
 	prSplit { |availBlock, n, used = true|
-		var	new, leftover;
+		var new, leftover;
 		#new, leftover = availBlock.split(n);
 		new.used = used;
 		this.removeFromFreed(availBlock);

--- a/SCClassLibrary/Common/Control/ReadableNodeIDAllocator.sc
+++ b/SCClassLibrary/Common/Control/ReadableNodeIDAllocator.sc
@@ -1,0 +1,74 @@
+/* make nodeIDs more humanly readable:
+10 ** 8 ids for 1 user, 10 ** 7 for < 21, 10 ** 6 for < 210
+
+for example, with 20 Clients, clientIDs would be
+clientID  defaultGroup  tempIDs
+ 1         10000001      120001000, 10001001, etc
+ 2         10000001      120001000, 10001001, etc
+12        120000001      120001000, 10001001, etc
+
+In multi-client settings, this makes s.plotTree display
+or s.queryAllNodes posts much easier to understand.
+*/
+
+ReadableNodeIDAllocator {
+
+	var <clientID, <lowestTempID, <numClients;
+	var <numIDs, <idOffset, <maxPermID;
+	var tempCount = -1, permCount = 1, permFreed;
+
+	*new { |clientID = 0, lowestTempID = 1000, numClients = 32|
+		^super.newCopyArgs(clientID, lowestTempID, numClients).reset
+	}
+
+	reset {
+		var maxNumPerUser = (2 ** 31 / numClients).trunc;
+		// go to next lower power of 10:
+		numIDs = (10 ** maxNumPerUser.log10.trunc).asInteger;
+
+		idOffset = numIDs * clientID;
+
+		permFreed = IdentitySet.new;
+		maxPermID = idOffset + lowestTempID - 1;
+		tempCount = -1;
+		permCount = 1;
+	}
+
+	alloc {
+		tempCount = tempCount + 1;
+		// wraps after handing out (numIDs - lowestTempID) ids
+		^(lowestTempID + tempCount).wrap(lowestTempID, numIDs) + idOffset;
+	}
+
+	isPerm { |num|
+		// test whether num is a valid permanent nodeID for this client/allocator's range,
+		// which includes idOffset + 0 (for clientID 0, RootNode)
+		// and idOffset + 1, the defaultGroup for this allocator/client
+		^num.inclusivelyBetween(idOffset, maxPermID);
+	}
+
+	allocPerm {
+		var perm;
+		if(permFreed.size > 0) {
+			perm = permFreed.minItem;
+			permFreed.remove(perm);
+			^perm
+		};
+
+		permCount = (permCount + 1).min(lowestTempID);
+		perm = permCount;
+		if (perm >= lowestTempID) {
+			warn("%: cannot create more than % permanent ids."
+				"\nPlease free some permanent ids first,"
+				"or set lowestTempID higher."
+				.format(thisMethod, perm)
+			);
+			^nil
+		};
+		^perm + idOffset
+	}
+
+	freePerm { |id|
+		if (this.isPerm(id)) { permFreed.add(id) }
+	}
+}

--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -38,7 +38,7 @@ ServerOptions {
 	var <>threads = nil; // for supernova
 	var <>useSystemClock = false;  // for supernova
 
-	var <numPrivateAudioBusChannels=112;
+	var <numPrivateAudioBusChannels=1020;
 
 	var <>reservedNumAudioBusChannels = 0;
 	var <>reservedNumControlBusChannels = 0;

--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -417,7 +417,11 @@ Server {
 	}
 
 	newNodeAllocators {
-		nodeAllocator = NodeIDAllocator(clientID, options.initialNodeID)
+		nodeAllocator = nodeAllocClass.new(
+			clientID,
+			options.initialNodeID,
+			options.maxLogins
+		);
 	}
 
 	newBusAllocators {

--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -286,7 +286,8 @@ Server {
 		named = IdentityDictionary.new;
 		all = Set.new;
 
-		nodeAllocClass = ReadableNodeIDAllocator;
+		nodeAllocClass = NodeIDAllocator;
+		// nodeAllocClass = ReadableNodeIDAllocator;
 		bufferAllocClass = ContiguousBlockAllocator;
 		busAllocClass = ContiguousBlockAllocator;
 
@@ -370,7 +371,7 @@ Server {
 
 	initTree {
 		this.newNodeAllocators;
-		this.sendMsg("/g_new", this.defaultGroupID, 0, 0);
+		this.sendMsg("/g_new", this.defaultGroup.nodeID, 0, 0);
 		tree.value(this);
 		ServerTree.run(this);
 	}
@@ -408,14 +409,14 @@ Server {
 	}
 
 	newAllocators {
-		this.newNodeAllocator;
+		this.newNodeAllocators;
 		this.newBusAllocators;
 		this.newBufferAllocators;
 		this.newScopeBufferAllocators;
 		NotificationCenter.notify(this, \newAllocators);
 	}
 
-	newNodeAllocator {
+	newNodeAllocators {
 		nodeAllocator = NodeIDAllocator(clientID, options.initialNodeID)
 	}
 

--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -742,13 +742,13 @@ Server {
 
 	sendDefaultGroups {
 		defaultGroups.do { |defGrp|
-			this.sendMsg("/g_new", defGrp.nodeID.postln);
+			this.sendMsg("/g_new", defGrp.nodeID);
 		};
 	}
 
-	sendDefaultGroupsForIDs { |ids|
-		defaultGroups[ids].do { |defGrp|
-			this.sendMsg("/g_new", defGrp.nodeID.postln);
+	sendDefaultGroupsForClientIDs { |clientIDs|
+		defaultGroups[clientIDs].do { |defGrp|
+			this.sendMsg("/g_new", defGrp.nodeID);
 		}
 	}
 
@@ -973,7 +973,7 @@ Server {
 		this.initTree;
 	}
 
-	freeMyGroup {
+	freeMyDefaultGroup {
 		this.sendMsg("/g_freeAll", defaultGroup.nodeID);
 	}
 

--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -945,7 +945,11 @@ Server {
 	}
 
 	freeAll {
-		this.sendMsg("/g_freeAll", 0);
+		if (clientID == 0) {
+			this.sendMsg("/g_freeAll", 0);
+		} {
+			this.sendMsg("/g_freeAll", this.defaultGroupID);
+		};
 		this.sendMsg("/clearSched");
 		this.initTree;
 	}

--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -723,9 +723,11 @@ Server {
 		^Buffer.cachedBufferAt(this, bufnum)
 	}
 
-	defaultGroup {
-		^Group.basicNew(this, 1)
-	}
+	defaultGroupID { ^nodeAllocator.idOffset + 1 }
+
+ 	defaultGroup {
+		^Group.basicNew(this, nodeAllocator.idOffset + 1)
+ 	}
 
 	inputBus {
 		^Bus(\audio, this.options.numOutputBusChannels, this.options.numInputBusChannels, this)

--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -278,7 +278,7 @@ Server {
 	var <window, <>scopeWindow, <emacsbuf;
 	var <volume, <recorder, <statusWatcher;
 	var <pid, serverInterface;
-
+	var <>freeAllFreesRootNode = true;
 
 	*initClass {
 		Class.initClassTree(ServerOptions);
@@ -357,7 +357,8 @@ Server {
 		addr = netAddr ?? { NetAddr("127.0.0.1", 57110) };
 		inProcess = addr.addr == 0;
 		isLocal = inProcess || { addr.isLocal };
-		remoteControlled = isLocal;
+		remoteControlled = isLocal.not;
+		freeAllFreesRootNode = isLocal;
 	}
 
 	name_ { |argName|
@@ -723,6 +724,14 @@ Server {
 		^Buffer.cachedBufferAt(this, bufnum)
 	}
 
+	defaultGroupIDForClientID { |id| ^nodeAllocator.numIDs * id + 1 }
+
+	sendDefaultGroupsFor { |ids|
+		ids.do { |id|
+			this.sendMsg("g_new", this.defaultGroupIDForClientID(id));
+		}
+	}
+
 	defaultGroupID { ^nodeAllocator.idOffset + 1 }
 
  	defaultGroup {
@@ -807,7 +816,7 @@ Server {
 			this.bootInit(recover);
 		}, onFailure: onFailure ? false);
 
-		if(remoteControlled.not) {
+		if(remoteControlled) {
 			"You will have to manually boot remote server.".postln;
 		} {
 			this.prPingApp({
@@ -945,10 +954,9 @@ Server {
 	}
 
 	freeAll {
-		if (clientID == 0) {
+		this.sendMsg("/g_freeAll", this.defaultGroupID);
+		if (freeAllFreesRootNode) {
 			this.sendMsg("/g_freeAll", 0);
-		} {
-			this.sendMsg("/g_freeAll", this.defaultGroupID);
 		};
 		this.sendMsg("/clearSched");
 		this.initTree;

--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -391,30 +391,29 @@ Server {
 		controlBusOffset = numControl * offset + options.reservedNumControlBusChannels;
 		audioBusOffset = options.firstPrivateBus + (numAudio * offset) + options.reservedNumAudioBusChannels;
 
-		controlBusAllocator =
-		ContiguousBlockAllocator.new(numControl, controlBusOffset);
-
-		audioBusAllocator =
-		ContiguousBlockAllocator.new(numAudio, audioBusOffset);
+		controlBusAllocator = busAllocClass.new(
+			numControlPerUser,
+			controlReservedOffset,
+			controlBusClientOffset
+		);
+		audioBusAllocator = busAllocClass.new(
+			numAudioPerUser,
+			audioReservedOffset,
+			audioBusClientOffset
+		);
 	}
 
 
 	newBufferAllocators {
-		var bufferOffset;
-		var offset = this.calcOffset;
-		var n = options.maxLogins ? 1;
-		var numBuffers = options.numBuffers div: n;
-		bufferOffset = numBuffers * offset + options.reservedNumBuffers;
-		bufferAllocator =
-		ContiguousBlockAllocator.new(numBuffers, bufferOffset);
-	}
+		var numBuffersPerUser = options.numBuffers div: numUsers;
+		var numReservedBuffers = options.reservedNumBuffers;
+		var bufferClientOffset = numBuffersPerUser * clientID;
 
-	calcOffset {
-		if(options.maxLogins.isNil) { ^0 };
-		if(clientID > (options.maxLogins - 1)) {
-			"Client ID exceeds maxLogins. Some buses and buffers may overlap for remote server: %".format(this).warn;
-		};
-		^clientID % options.maxLogins
+		bufferAllocator = bufferAllocClass.new(
+			numBuffersPerUser,
+			numReservedBuffers,
+			bufferClientOffset
+		);
 	}
 
 	newScopeBufferAllocators {

--- a/SCClassLibrary/Common/Control/asGroup.sc
+++ b/SCClassLibrary/Common/Control/asGroup.sc
@@ -4,12 +4,12 @@
 
 + Nil {
 	asGroup {
-		^Group.basicNew(this, 1)
+		^Server.default.defaultGroup
 	}
 }
 + Server {
 	asGroup {
-		^Group.basicNew(this, 1)
+		^this.defaultGroup
 	}
 }
 + Synth {

--- a/SCClassLibrary/Common/Control/asTarget.sc
+++ b/SCClassLibrary/Common/Control/asTarget.sc
@@ -1,5 +1,5 @@
 +Server {
-	asTarget { ^Group.basicNew(this, 1) }
+	asTarget { ^this.defaultGroup }
 	asNodeID { ^0 }
 }
 

--- a/SCClassLibrary/JITLib/ProxySpace/NodeProxy.sc
+++ b/SCClassLibrary/JITLib/ProxySpace/NodeProxy.sc
@@ -95,12 +95,15 @@ NodeProxy : BusPlug {
 	asNodeID { ^group.asNodeID }
 	nodeID { ^group.nodeID }
 
-	parentGroup_ { | node |
-		if(node.isPlaying.not) { "node not playing and registered: % \n".postf(node); ^this };
-		parentGroup = node;
-		if(group.isPlaying) { group.moveToHead(parentGroup) };
-	}
-
+ 	parentGroup_ { | node |
+		if(node.isPlaying.not) {
+			"% : cannot make non-playing node parentGroup: % \n"
+			.postf(thisMethod, node);
+			^this
+		};
+ 		parentGroup = node;
+ 		if(group.isPlaying) { group.moveToHead(parentGroup) };
+ 	}
 
 	// setting the source
 

--- a/testsuite/classlibrary/TestContiguousBlockAllocator.sc
+++ b/testsuite/classlibrary/TestContiguousBlockAllocator.sc
@@ -1,0 +1,58 @@
+TestContiguousBlockAllocator : UnitTest {
+
+	test_CBAllocator {
+		var alloc = ContiguousBlockAllocator(1024, 0, 1024 * 8);
+		var remaining = alloc.size, lastID;
+		var allIDs = List[], newID, maxPos;
+		var sizes = (1024 * (0.5 ** (1.. 1024.log2))).asInteger;
+
+		// sizes.sum = 1023, + [1, 1] goes over max by 1
+		(sizes.scramble ++ [1, 1]).do { |size|
+			newID = alloc.alloc(size);
+			allIDs.add(newID);
+		};
+
+		this.assert(
+			allIDs.drop(-1).every(_.isNumber) and: allIDs.last.isNil,
+			"ContiguousBlockAllocator hands out its full range for variable block sizes."
+		);
+
+		allIDs.size.do { allIDs.remove(allIDs.choose); };
+
+		this.assert(
+			alloc.pos == alloc.addrOffset,
+			"ContiguousBlockAllocator should reclaim its full range after all blocks are removed."
+		);
+
+		while {
+			// try removing first
+			if (0.5.coin) { allIDs.remove(allIDs.choose) };
+			// try allocating random block size
+			newID = alloc.alloc([1, 2, 3, 5, 8].choose);
+			// if random block too big, try single id
+			if (newID.isNil) { newID = alloc.alloc; };
+			newID.notNil;
+		} {
+			allIDs.add(newID);
+		};
+		this.assert(
+			alloc.top == (alloc.addrOffset + alloc.size - 1),
+			"ContiguousBlockAllocator should hand out its full range in mixed allocation/removal."
+		);
+
+		while {
+			allIDs.remove(allIDs.choose);
+			allIDs.notEmpty;
+		} {
+			if (0.5.coin) {
+				newID = alloc.alloc([1, 2, 3, 5, 8].choose);
+				// if random block too big, try single id
+				if (newID.isNil) { newID = alloc.alloc; };
+				if (newID.notNil) { allIDs.add(newID) };
+			};
+		};
+		this.assert(
+			alloc.top == (alloc.addrOffset + alloc.size - 1),
+			"ContiguousBlockAllocator should reclaim its full range after mixed allocation/removal.")
+	}
+}

--- a/testsuite/classlibrary/TestEvent.sc
+++ b/testsuite/classlibrary/TestEvent.sc
@@ -153,6 +153,7 @@ TestEvent : UnitTest {
 
 	nextNodeID { ^-1 }
 	latency { ^0.2 }
+	defaultGroupID { ^1 }
 
 }
 

--- a/testsuite/classlibrary/TestEvent.sc
+++ b/testsuite/classlibrary/TestEvent.sc
@@ -154,6 +154,7 @@ TestEvent : UnitTest {
 	nextNodeID { ^-1 }
 	latency { ^0.2 }
 	defaultGroupID { ^1 }
+	defaultGroup { ^Group.basicNew(nil, 1) }
 
 }
 

--- a/testsuite/classlibrary/TestReadableNodeIDAllocator.sc
+++ b/testsuite/classlibrary/TestReadableNodeIDAllocator.sc
@@ -1,0 +1,85 @@
+TestReadableNodeIDAllocator : UnitTest {
+
+	// test proper creation from Server
+	test_readableNodeRange {
+		var s = Server(\testRNIA);
+		var prevClass = Server.nodeAllocClass;
+		Server.nodeAllocClass = ReadableNodeIDAllocator;
+		s.options.maxLogins = 1; s.newAllocators;
+		// this.assert(
+		// 	(s.nodeAllocator.numIDs == (10 ** 8)),
+		// 	"for a single client, (readable) nodeAllocator has maximum range."
+		// );
+		// this.assert(
+		// 	(s.nodeAllocator.numIDs == (10 ** 7)),
+		// 	"for 16 clients, (readable) nodeAllocator has divided range."
+		// );
+
+		// same for ReadableNodeIDAllocator
+		// Server.nodeAllocClass = ReadableNodeIDAllocator;
+		Server.named.removeAt(s.name); Server.all.remove(s);
+		Server.nodeAllocClass = prevClass;
+	}
+
+	test_permIDs {
+		var alloc = ReadableNodeIDAllocator(8191, 1000, 8191);
+		var nextPermID, permIDs = List[], permIDToFree;
+
+		this.assert(
+			alloc.isPerm(alloc.idOffset - 1).not
+			and: alloc.isPerm(alloc.idOffset)
+			and: alloc.isPerm(alloc.idOffset + alloc.lowestTempID - 1)
+			and: alloc.isPerm(alloc.idOffset + alloc.lowestTempID).not,
+			"ReadableNodeIDAllocator should identify its permanent IDs."
+		);
+		while {
+			if (0.5.coin and: { permIDs.size > 0 }) {
+				permIDToFree = permIDs.remove(permIDs.choose);
+				alloc.freePerm(permIDToFree);
+			};
+			nextPermID = alloc.allocPerm;
+			nextPermID.notNil;
+		} {
+			permIDs.add(nextPermID);
+		};
+		this.assert(
+			permIDs.size.postln == (alloc.lowestTempID - 2),
+			"ReadableNodeIDAllocator should hand out all permanent IDs in mixed alloc/free use."
+		);
+
+		while {
+			if (0.5.coin) {
+				nextPermID = alloc.allocPerm;
+				if (nextPermID.notNil) {
+					permIDs.add(nextPermID);
+				};
+			};
+			permIDs.size > 0;
+		} {
+			permIDToFree = permIDs.remove(permIDs.choose);
+			alloc.freePerm(permIDToFree);
+		};
+		this.assert(
+			alloc.allocPerm == (alloc.idOffset + 2),
+			"ReadableNodeIDAllocator should begin at first permID after freeing all permanent IDs in mixed alloc/free use."
+		);
+	}
+
+	test_fullRange {
+		var alloc = ReadableNodeIDAllocator(8191, 1000, 8191);
+		var tempID, prevID = -1, count = 0;
+
+		while {
+			tempID = alloc.alloc;
+			tempID > prevID
+		} {
+			count = count + 1;
+			prevID = tempID;
+		};
+		this.assert(
+			count == (alloc.numIDs - alloc.lowestTempID + 1)
+			and: tempID == (alloc.idOffset + alloc.lowestTempID),
+			"ReadableNodeIDAllocator should recycle tempIDs after its full range has been used."
+		);
+	}
+}

--- a/testsuite/classlibrary/TestServerClientID.sc
+++ b/testsuite/classlibrary/TestServerClientID.sc
@@ -1,0 +1,75 @@
+/*
+TestServerClientID.run;
+UnitTest.gui;
+
+Tests for clientID, maxLogins and allocator creation based on these.
+
+* clientID should be impossible to set to nonsense data,
+it should always be between 0 and maxLogins - 1.
+
+NOTE: All test cases currently have powerOfTwo numbers for maxLogins.
+This is because the server currently rounds up maxLogins to nextPowerOfTwo;
+so when the server IS NOT booted, odd numbers of maxLogins stay as they are;
+when the server IS booted, the rounded-up maxLogins come back to each client.
+If this server behavior changes to support non-powerOfTwo numbers of clients,
+the tests should also include irregular numbers for maxLogins, e.g. 1, 2, 3, 5, 8.
+
+*/
+
+TestServer_clientID : UnitTest {
+	// these while server is off
+	test_ClientIDChecks {
+		var s = Server(\testID);
+		this.assert(s.clientID == 0, "s.clientID should be 0 by default.");
+		// test checks for bad input
+		s.clientID = -1.sqrt;
+		this.assert(s.clientID == 0, "s.clientID should block non-Integers.");
+		s.clientID = -123;
+		this.assert(s.clientID == 0, "s.clientID should block negative numbers.");
+		s.options.maxLogins = 32;
+		s.clientID = s.options.maxLogins;
+		this.assert(s.clientID == 0, "s.clientID should block number >= maxLogins.");
+		s.clientID = s.options.maxLogins - 1;
+		this.assert(s.clientID == 31, "s.clientID should be settable if valid.");
+		Server.named.removeAt(s.name); Server.all.remove(s);
+	}
+
+	test_UserSetClientID {
+		var options = ServerOptions.new;
+		var s = Server(\testserv, NetAddr("localhost", 57111), options, 1);
+		this.assert(s == nil, "Making a server with invalid clientID should be blocked.");
+		options.maxLogins_(8);
+		s = Server(\testserv, NetAddr("localhost", 57111), options, 7);
+		this.assert(s.clientID == 7, "Making a server with valid nonzero clientID should work.");
+		Server.named.removeAt(s.name); Server.all.remove(s);
+	}
+
+	test_AllocRanges {
+		var s = Server(\testAlloc);
+		var prevClass = Server.nodeAllocClass;
+
+		Server.nodeAllocClass = NodeIDAllocator;
+		s.options.maxLogins = 1; s.newAllocators;
+
+		this.assert(
+			(s.nodeAllocator.numIDs == (2 ** 26)),
+			"nodeAllocator should have its normal range."
+		);
+
+		this.assert(
+			(s.audioBusAllocator.size == s.options.numAudioBusChannels) and:
+			(s.controlBusAllocator.size == s.options.numControlBusChannels) and:
+			(s.bufferAllocator.size == s.options.numBuffers),
+			"for a single client, bus and buffer allocators should have full range."
+		);
+		s.options.maxLogins = 16; s.newAllocators;
+		this.assert(
+			(s.audioBusAllocator.size == (s.options.numAudioBusChannels div: 16)) and:
+			(s.controlBusAllocator.size == (s.options.numControlBusChannels div: 16)) and:
+			(s.bufferAllocator.size == (s.options.numBuffers div: 16)),
+			"for 16 clients, all allocators should divide range evenly."
+		);
+
+		Server.nodeAllocClass = prevClass;
+	}
+}

--- a/testsuite/classlibrary/TestServer_clientIDBooted.sc
+++ b/testsuite/classlibrary/TestServer_clientIDBooted.sc
@@ -1,0 +1,27 @@
+// see also TestServer_clientID
+TestServer_clientID_booted : UnitTest {
+
+	// with running server
+	test_ClientIDResetByServer {
+		var options = ServerOptions.new;
+		var s;
+		s = Server(\testserv1, NetAddr("localhost", 57111), options);
+
+		s.options.maxLogins = 4; s.clientID = 3;
+		this.bootServer(s);
+		s.sync;
+		1.wait;
+		this.assert(s.clientID == 0, "Non-user-defined clientID should be reset by the server.");
+		Server.named.removeAt(s.name); Server.all.remove(s);
+		s.quit;
+		1.wait;
+
+		s = Server(\testserv2, NetAddr("localhost", 57112), options, 3);
+
+		this.bootServer(s);
+		s.sync;
+		1.wait;
+		this.assert(s.clientID == 3, "User-defined clientID should be left as is by the server.");
+		Server.named.removeAt(s.name); Server.all.remove(s);
+	}
+}


### PR DESCRIPTION
This is no. 3 of several smaller PR based on #3106, hopefully easier to review.
see just the difference to current 3.9: 
https://github.com/supercollider/supercollider/compare/3.9...topic-separateDefaultGroups
I also made a reduced version of this branch with clearer commit history here:
https://github.com/supercollider/supercollider/compare/3.9...adcxyz:reduced_separateDefaultGroups

It is based on PR #3179, to which it adds only the commit from 6c56b01 on:
- each client (Server object) gets a defaultGroup based on clientID
- It is used everywhere instead of hardcoded group 1
- each client also knows defaultGroups of all other clients that may login
- default behavior on CmdPeriod is unchanged: local client does freeAll, remote clients do not
- CmdPeriod behavior is easy to adapt (e.g. remotes free their defaultGroup, local remakes all defaultGroups etc)
- added guide file to provide recommended usage in MultiClient Setups.
