### PR TITLE
Make Help Browser open external links in desktop browser

### DIFF
--- a/QtCollider/widgets/web_page.cpp
+++ b/QtCollider/widgets/web_page.cpp
@@ -23,6 +23,8 @@
 
 #include <QApplication>
 #include <QClipboard>
+#include <QDesktopServices>
+#include <QNetworkRequest>
 
 namespace QtCollider {
 
@@ -46,6 +48,22 @@ void WebPage::triggerAction ( WebAction action, bool checked )
 void WebPage::javaScriptConsoleMessage ( const QString & msg, int line, const QString & src )
 {
   Q_EMIT( jsConsoleMsg(msg,line,src) );
+}
+
+/**
+ * \brief Override of QWebPage::acceptNavigationRequest that can open external links in the OS
+ * browser.
+ */
+bool WebPage::acceptNavigationRequest (
+        QWebFrame * frame,
+        const QNetworkRequest& request,
+        NavigationType type
+        )
+{
+  if ( frame == nullptr && _usingDesktopBrowser )
+    return QDesktopServices::openUrl( request.url() );
+  else
+    return QWebPage::acceptNavigationRequest( frame, request, type );
 }
 
 } // namespace QtCollider

--- a/QtCollider/widgets/web_page.hpp
+++ b/QtCollider/widgets/web_page.hpp
@@ -32,11 +32,23 @@ class WebPage : public QWebPage
 
 public:
 
-  WebPage( QObject *parent ) : QWebPage( parent ), _delegateReload(false) {}
+  WebPage( QObject *parent ) :
+    QWebPage( parent ),
+    _delegateReload(false),
+    _usingDesktopBrowser(false)
+  {}
+
   virtual void triggerAction ( WebAction action, bool checked = false );
   virtual void javaScriptConsoleMessage ( const QString &, int, const QString & );
   bool delegateReload() const { return _delegateReload; }
   void setDelegateReload( bool flag ) { _delegateReload = flag; }
+
+  bool usingDesktopBrowser() const { return _usingDesktopBrowser; }
+  void setUsingDesktopBrowser( bool flag ) { _usingDesktopBrowser = flag; }
+
+protected:
+  // from QWebPage::acceptNavigationRequest
+  virtual bool acceptNavigationRequest( QWebFrame*, const QNetworkRequest&, NavigationType );
 
 Q_SIGNALS:
   void jsConsoleMsg( const QString &, int, const QString & );
@@ -44,6 +56,7 @@ Q_SIGNALS:
 private:
 
   bool _delegateReload;
+  bool _usingDesktopBrowser; ///< If true, external links will open in the default desktop browser.
 };
 
 } // namespace QtCollider

--- a/editors/sc-ide/widgets/help_browser.cpp
+++ b/editors/sc-ide/widgets/help_browser.cpp
@@ -58,6 +58,9 @@ HelpBrowser::HelpBrowser( QWidget * parent ):
     webPage->setDelegateReload(true);
     webPage->setLinkDelegationPolicy( QWebPage::DelegateAllLinks );
 
+    // Tell the web page to open external links in the desktop browser
+    webPage->setUsingDesktopBrowser(true);
+
     mWebView = new QWebView;
     mWebView->setPage( webPage );
     mWebView->settings()->setAttribute( QWebSettings::LocalStorageEnabled, true );


### PR DESCRIPTION
This is toward #2897.

We realized at the dev meeting today that it's impossible to have the help browser open an external link in the user's default desktop browser. This PR adds an option to our extension of QWebPage for doing so, and then turns it on when the webpage is inside the help browser.

To test, you'll need to go to a web page that has a link with `taget="_blank"`. The first link I found that does this is:

`HelpBrowser.goTo("https://www.github.com")`

and then click on the "terms of service" link.

This works flawlessly on macOS (10.13 beta).

The next step after this PR is adding links that say "Submit a change to this file"/"Submit documentation for this file" in relevant help files.