### PR TITLE
Fix task stop

### DIFF
--- a/SCClassLibrary/Common/Streams/Stream.sc
+++ b/SCClassLibrary/Common/Streams/Stream.sc
@@ -359,8 +359,12 @@ PauseStream : Stream {
 	}
 	reset { originalStream.reset }
 	stop {
+		var saveStream = this.stream;
 		this.prStop;
-		this.changed(\userStopped);
+ 		this.changed(\userStopped);
+		if(saveStream === thisThread) {
+			nil.alwaysYield
+		}
 	}
 	prStop {
 		stream = nil;

--- a/testsuite/classlibrary/TestTask.sc
+++ b/testsuite/classlibrary/TestTask.sc
@@ -1,0 +1,26 @@
+TestTask : UnitTest {
+
+	test_stop_internally {
+		var running, stopped;
+		var task = Task {
+			running = true;
+			0.001.wait;
+			stopped = true;
+			task.stop;
+			stopped = false;
+		};
+		task.play;
+		0.002.wait;
+		this.assert(stopped, "Task should stop itself immediately from within using the stop message");
+
+	}
+
+	test_stop_without_running {
+		var task = Task { 0.001.wait; task.stop; };
+		task.play;
+		0.002.wait;
+		task.stop;
+		this.assert(task.isPlaying.not, "Task be stoppable even if not running");
+	}
+
+}


### PR DESCRIPTION
Routines can’t stop in between yields. Nevertheless, `Routine`
implements a trick in `stop`: it checks if it is in the current thread
and if it is, it will yield nil, breaking calculation right where it is.

Because a `Task` has a routine and is not a routine, it needs to do
this check as well, but this time for its stream.

This fixes #3184.