### PR TITLE
Help: Fix incorrect variable name

### DIFF
--- a/HelpSource/Classes/HPZ2.schelp
+++ b/HelpSource/Classes/HPZ2.schelp
@@ -46,8 +46,8 @@ code::
 (
 {
 	var changingSignal = LFNoise0.ar(1000);
-	var hpz1 = HPZ2.ar(changingSignal);
-	[hpz1, hpz1 > 0]
+	var hpz2 = HPZ2.ar(changingSignal);
+	[hpz2, hpz2 > 0]
 }.plot
 );
 ::


### PR DESCRIPTION
The example at the end of this Help file is a copy of the example from the HPZ1 Help file. The variable name used for the filtered signal needed to be updated.