### PR TITLE
supernova - portaudio_backend macos: enable buffer size choice on macos

### DIFF
--- a/server/supernova/audio_backend/portaudio_backend.hpp
+++ b/server/supernova/audio_backend/portaudio_backend.hpp
@@ -129,7 +129,7 @@ public:
         const PaStreamInfo *psi = Pa_GetStreamInfo(stream);
         if (psi){
             fprintf(stdout,"  Sample rate: %.3f\n", psi->sampleRate);
-            fprintf(stdout,"  Latency (in/out): %.3f / %.3f sec\n", psi->inputLatency, psi->outputLatency); 
+            fprintf(stdout,"  Latency (in/out): %.3f / %.3f sec\n", psi->inputLatency, psi->outputLatency);
         }
     }
 
@@ -143,11 +143,6 @@ public:
 
         PaStreamParameters in_parameters, out_parameters;
         PaTime suggestedLatencyIn, suggestedLatencyOut;
-        
-#ifdef __APPLE__
-        suggestedLatencyIn = Pa_GetDeviceInfo(input_device_index)->defaultHighInputLatency;
-        suggestedLatencyOut = Pa_GetDeviceInfo(output_device_index)->defaultHighOutputLatency;
-#else
 
         if (h_blocksize == 0){
             if (inchans)
@@ -163,7 +158,6 @@ public:
             }else
                 suggestedLatencyIn = suggestedLatencyOut = (double)h_blocksize / (double)samplerate;
         }
-#endif
 
         if (inchans) {
             const PaDeviceInfo* device_info = Pa_GetDeviceInfo(input_device_index);


### PR DESCRIPTION
Enable choosing different buffer size (s.options.hardwareBufferSize in sclang) for supernova on macos. Previously on macos supernova was always using the largest available buffer size (the buffer size switch was ignored).
I understand this was in order to ensure glitch-free audio, however now with possibility of choosing buffer size (introduced in https://github.com/supercollider/supercollider/commit/0c3d4c999253204a288c18482eab0d432e33412a) one can make a conscious choice about it. And it still defaults to a large buffer size when hardwareBufferSize is nil.