### PR TITLE
CONTRIBUTING.md: update instructions reflecting develop branch, add fork syncing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,7 +55,7 @@ Please be as descriptive as possible when creating an issue. Give us the informa
 
 - Create a fork of the SuperCollider repository.
 - Clone the repo and its submodules locally: `git clone --recursive https://github.com/your-name/supercollider.git`.
-	- If you have created the fork before, bring it up-to-date with the SuperCollider repository. See [Updating your fork](#updating-your-fork) below for details.
+	- If you have created the fork before, bring it up-to-date with the SuperCollider repository. See [updating your fork](#updating-your-fork) below for details.
 - Create a topic branch from where you want to base your work.
 	- This is the `develop` branch.
 	- Our branch naming convention is `topic/branch-description`: for example, `topic/fix-sinosc` or `topic/document-object`.
@@ -92,7 +92,8 @@ Please be as descriptive as possible when creating an issue. Give us the informa
 - You may receive feedback and requests for changes. We expect changes to be made in a timely manner. We may close the pull request if it isn't showing any activity.
 
 ### Updating your fork
-- In order to keep your fork up-to-date, you need to create another *remote*, usually called *upstream*, pointing to the main SuperCollider repository. Please note, *this needs to be done only once.*
+In order to keep your fork up-to-date, you need to point it to the main SuperCollider repository. This is done by adding the main repository as another *remote*, usually called *upstream*. **Please note:** naming the main repository *upstream* is just a convention, not a requirement. If you already have a differently named remote pointing to the main SuperCollider repository, you can use that name instead of *upstream*.
+- If you have **not** yet created the *upstream* remote, create if first:
 	- Check the list of remotes: `git remote -v`. The output should look like this:
 
 			origin	https://github.com/your-name/supercollider.git (fetch)
@@ -106,13 +107,16 @@ Please be as descriptive as possible when creating an issue. Give us the informa
 			origin	https://github.com/your-name/supercollider.git (push)
 			upstream	https://github.com/supercollider/supercollider (fetch)
 			upstream	https://github.com/supercollider/supercollider (push)
+	- Now you can proceed to updating your fork (see below).
+- If you have already created the *upstream* remote, update your fork:
+	- **Be sure to have all local changes committed before doing this!**
+	- Checkout the `develop` branch:	`git checkout develop`
+	- Pull changes from *upstream*:	`git pull --rebase`
+	- If you have already created your topic branch:
+		- Update your branch with the changes in the `develop`:
+		`git rebase develop topic/branch-description`
+	- If you have **not** yet created your topic branch, proceed to creating it as described in the [Pull Requests section](#before-making-changes)
 
-- Update your fork:
-	- Be sure to have all local changes committed before doing this.
-	- Pull changes from *upstream*:	`git fetch upstream`
-	- Checkout your local `develop` branch:	`git checkout develop`
-	- If you have already created your topic branch, update it with the changes in the `develop`:
-	`git rebase develop topic/branch-description`
 
 
 ### Additional resources

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,7 +109,7 @@ In order to keep your fork up-to-date, you need to point it to the main SuperCol
 	- **Be sure to have all local changes committed before doing this!**
 	- Update from the *upstream* repository: `git fetch upstream`
 	- Checkout the `develop` branch: `git checkout develop`
-	- Pull changes into the `develop` branch: `git pull`
+	- Pull changes into the `develop` branch: `git pull --rebase`
 	- If you have already created your topic branch:
 		- Update it with the changes in the `develop`: `git rebase develop topic/branch-description`
 	- If you have **not** yet created your topic branch, proceed to creating it as described in the [Pull Requests section](#before-making-changes)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,15 +95,19 @@ Please be as descriptive as possible when creating an issue. Give us the informa
 In order to keep your fork up-to-date, you need to point it to the main SuperCollider repository. This is done by adding the main repository as another `remote`, usually called `upstream`. **Please note:** naming the main repository `upstream` is just a convention, not a requirement. If you already have a differently named `remote` pointing to the main SuperCollider repository, you can use that name instead of `upstream`.
 - If you have not yet created the `upstream` `remote`, create it first:
 	- Check the list of remotes: `git remote -v`. The output should look like this:
+
 			origin	https://github.com/your-name/supercollider.git (fetch)
 			origin	https://github.com/your-name/supercollider.git (push)
+
 	- Add a new remote called `upstream`, pointing to the SuperCollider repository:
 	`git remote add upstream https://github.com/your-name/supercollider.git`
 	- Check the list of remotes again: `git remote -v`. Now the output should look like this:
+
 			origin	https://github.com/your-name/supercollider.git (fetch)
 			origin	https://github.com/your-name/supercollider.git (push)
 			upstream	https://github.com/supercollider/supercollider (fetch)
 			upstream	https://github.com/supercollider/supercollider (push)
+			
 	- Now you can proceed to updating your fork (see below).
 - If you have already created the `upstream` `remote`, update your fork:
 	- Be sure to have all local changes committed before doing this!

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,11 +55,13 @@ Please be as descriptive as possible when creating an issue. Give us the informa
 
 - Create a fork of the SuperCollider repository.
 - Clone the repo and its submodules locally: `git clone --recursive https://github.com/your-name/supercollider.git`.
+	- If you have created the fork before, bring it up-to-date with the SuperCollider repository. See [Updating your fork](#updating-your-fork) below for details.
 - Create a topic branch from where you want to base your work.
-	- This is usually the `master` branch.
+	- This is the `develop` branch.
 	- Our branch naming convention is `topic/branch-description`: for example, `topic/fix-sinosc` or `topic/document-object`.
-	- To quickly create a topic branch based on master: `git checkout -b topic/my-fix master`.
-	- Please avoid working directly on the `master` branch.
+	- To quickly create a topic branch based on develop: `git checkout -b topic/my-fix develop`.
+	- Please avoid working directly on the `develop` branch.
+	- Please do not work off of the `master` branch, which is stable and only includes releases.
 
 ### Making changes
 
@@ -82,12 +84,41 @@ Please be as descriptive as possible when creating an issue. Give us the informa
 - Make sure you have added the necessary tests for your changes.
 - Make sure you have documented your changes, if necessary.
 
-### Submitting changes as pull Requests
+### Submitting changes as Pull Requests
 
 - Push your changes to a topic branch in the fork of your repository. If you are working locally, do this with `git push -u my-gh-repo topic/my-fix`. `my-gh-repo` is typically `origin`; check with `git remote -v`.
 - Submit a pull request to the SuperCollider repository.
 - The core team looks at pull requests on a regular basis in a weekly meeting that we hold in a public meeting. The hangout is announced in the weekly status updates that are sent to the sc-dev list.
 - You may receive feedback and requests for changes. We expect changes to be made in a timely manner. We may close the pull request if it isn't showing any activity.
+
+### Updating your fork
+- In order to keep your fork up-to-date, you need to create another *remote*, usually called *upstream*, pointing to the main SuperCollider repository. Please note, *this needs to be done only once.*
+	- Check the list of remotes: `git remote -v`. The output should look like this:
+
+			origin	https://github.com/your-name/supercollider.git (fetch)
+			origin	https://github.com/your-name/supercollider.git (push)
+
+	- Add a new remote called *upstream*, pointing to the SuperCollider repository:
+	`git remote add upstream https://github.com/your-name/supercollider.git`
+	- Check the list of remotes again: `git remote -v`. Now the output should look like this:
+
+			origin	https://github.com/your-name/supercollider.git (fetch)
+			origin	https://github.com/your-name/supercollider.git (push)
+			upstream	https://github.com/supercollider/supercollider (fetch)
+			upstream	https://github.com/supercollider/supercollider (push)
+
+- Update your fork:
+	- Be sure to have all local changes committed before doing this.
+	- Pull changes from *upstream*:	`git fetch upstream`
+	- Checkout your local `develop` branch:	`git checkout develop`
+	- If you have already created your topic branch, update it with the changes in the `develop`:
+	`git rebase develop topic/branch-description`
+
+
+### Additional resources
+More information can be found on the [git workflow wiki page](https://github.com/supercollider/supercollider/wiki/git-workflow-and-guidelines).
+
+You can also refer to Github's guide to [forking a repository](https://help.github.com/articles/fork-a-repo/) and [syncing a fork](https://help.github.com/articles/syncing-a-fork/).
 
 ## Above and beyond
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -114,8 +114,6 @@ In order to keep your fork up-to-date, you need to point it to the main SuperCol
 		- Update it with the changes in the `develop`: `git rebase develop topic/branch-description`
 	- If you have **not** yet created your topic branch, proceed to creating it as described in the [Pull Requests section](#before-making-changes)
 
-
-
 ### Additional resources
 More information can be found on the [git workflow wiki page](https://github.com/supercollider/supercollider/wiki/git-workflow-and-guidelines).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,12 +92,12 @@ Please be as descriptive as possible when creating an issue. Give us the informa
 - You may receive feedback and requests for changes. We expect changes to be made in a timely manner. We may close the pull request if it isn't showing any activity.
 
 ### Updating your fork
-In order to keep your fork up-to-date, you need to point it to the main SuperCollider repository. This is done by adding the main repository as another *remote*, usually called *upstream*. **Please note:** naming the main repository *upstream* is just a convention, not a requirement. If you already have a differently named remote pointing to the main SuperCollider repository, you can use that name instead of *upstream*.
-- If you have **not** yet created the *upstream* remote, create if first:
+In order to keep your fork up-to-date, you need to point it to the main SuperCollider repository. This is done by adding the main repository as another `remote`, usually called `upstream`. **Please note:** naming the main repository `upstream` is just a convention, not a requirement. If you already have a differently named `remote` pointing to the main SuperCollider repository, you can use that name instead of `upstream`.
+- If you have not yet created the `upstream` `remote`, create it first:
 	- Check the list of remotes: `git remote -v`. The output should look like this:
 			origin	https://github.com/your-name/supercollider.git (fetch)
 			origin	https://github.com/your-name/supercollider.git (push)
-	- Add a new remote called *upstream*, pointing to the SuperCollider repository:
+	- Add a new remote called `upstream`, pointing to the SuperCollider repository:
 	`git remote add upstream https://github.com/your-name/supercollider.git`
 	- Check the list of remotes again: `git remote -v`. Now the output should look like this:
 			origin	https://github.com/your-name/supercollider.git (fetch)
@@ -105,14 +105,14 @@ In order to keep your fork up-to-date, you need to point it to the main SuperCol
 			upstream	https://github.com/supercollider/supercollider (fetch)
 			upstream	https://github.com/supercollider/supercollider (push)
 	- Now you can proceed to updating your fork (see below).
-- If you have already created the *upstream* remote, update your fork:
-	- **Be sure to have all local changes committed before doing this!**
-	- Update from the *upstream* repository: `git fetch upstream`
+- If you have already created the `upstream` `remote`, update your fork:
+	- Be sure to have all local changes committed before doing this!
+	- Update from the `upstream` repository: `git fetch upstream`
 	- Checkout the `develop` branch: `git checkout develop`
 	- Pull changes into the `develop` branch: `git pull --rebase`
 	- If you have already created your topic branch:
 		- Update it with the changes in the `develop`: `git rebase develop topic/branch-description`
-	- If you have **not** yet created your topic branch, proceed to creating it as described in the [Pull Requests section](#before-making-changes)
+	- If you have not yet created your topic branch, proceed to creating it as described in the [Pull Requests section](#before-making-changes)
 
 ### Additional resources
 More information can be found on the [git workflow wiki page](https://github.com/supercollider/supercollider/wiki/git-workflow-and-guidelines).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,14 +95,11 @@ Please be as descriptive as possible when creating an issue. Give us the informa
 In order to keep your fork up-to-date, you need to point it to the main SuperCollider repository. This is done by adding the main repository as another *remote*, usually called *upstream*. **Please note:** naming the main repository *upstream* is just a convention, not a requirement. If you already have a differently named remote pointing to the main SuperCollider repository, you can use that name instead of *upstream*.
 - If you have **not** yet created the *upstream* remote, create if first:
 	- Check the list of remotes: `git remote -v`. The output should look like this:
-
 			origin	https://github.com/your-name/supercollider.git (fetch)
 			origin	https://github.com/your-name/supercollider.git (push)
-
 	- Add a new remote called *upstream*, pointing to the SuperCollider repository:
 	`git remote add upstream https://github.com/your-name/supercollider.git`
 	- Check the list of remotes again: `git remote -v`. Now the output should look like this:
-
 			origin	https://github.com/your-name/supercollider.git (fetch)
 			origin	https://github.com/your-name/supercollider.git (push)
 			upstream	https://github.com/supercollider/supercollider (fetch)
@@ -110,11 +107,11 @@ In order to keep your fork up-to-date, you need to point it to the main SuperCol
 	- Now you can proceed to updating your fork (see below).
 - If you have already created the *upstream* remote, update your fork:
 	- **Be sure to have all local changes committed before doing this!**
-	- Checkout the `develop` branch:	`git checkout develop`
-	- Pull changes from *upstream*:	`git pull --rebase`
+	- Update from the *upstream* repository: `git fetch upstream`
+	- Checkout the `develop` branch: `git checkout develop`
+	- Pull changes into the `develop` branch: `git pull`
 	- If you have already created your topic branch:
-		- Update your branch with the changes in the `develop`:
-		`git rebase develop topic/branch-description`
+		- Update it with the changes in the `develop`: `git rebase develop topic/branch-description`
 	- If you have **not** yet created your topic branch, proceed to creating it as described in the [Pull Requests section](#before-making-changes)
 
 


### PR DESCRIPTION
I updated CONTRIBUTING.md to reflect the recent change to use the develop branch for development (also discussed in https://github.com/supercollider/supercollider/issues/3205). I also added a section about syncing the fork with the upstream, as well as links to git workflow wiki and Github's guide to forking/syncing.

I intended my additions to be both comprehensive and straightforward for a newcomer, as I myself am new to contributing to SC. I believe it is desirable to have such section to help people familiarize with the workflow.

I would appreciate if someone could take a look at the section about syncing the fork to make sure it reflects current workflow correctly, thanks.