### PR TITLE
Help: fix incorrect LocalBuf arguments

### DIFF
--- a/HelpSource/Classes/BeatTrack.schelp
+++ b/HelpSource/Classes/BeatTrack.schelp
@@ -53,7 +53,7 @@ a = SynthDef(\help_beattrack, { |out, vol=1.0, beepvol=1.0, lock=0|
 	in = PlayBuf.ar(1,d, BufRateScale.kr(d),1,0,1);
 	//in = SoundIn.ar(0);
 
-	fft = FFT(LocalBuf(1, 1024), in); // for sampling rates 44100 and 48000
+	fft = FFT(LocalBuf(1024), in); // for sampling rates 44100 and 48000
 
 	#trackb, trackh, trackq, tempo = BeatTrack.kr(fft, lock);
 
@@ -85,7 +85,7 @@ SynthDef(\help_beattrack2, { |out|
 
 	source = SoundIn.ar(0);
 
-	#trackb, trackh, trackq, tempo = BeatTrack.kr(FFT(LocalBuf(1, 1024, source)));
+	#trackb, trackh, trackq, tempo = BeatTrack.kr(FFT(LocalBuf(1024)));
 
 	bsound = Pan2.ar(LPF.ar(WhiteNoise.ar * Decay.kr(trackb, 0.05), 1000), 0.0);
 

--- a/HelpSource/Classes/BeatTrack2.schelp
+++ b/HelpSource/Classes/BeatTrack2.schelp
@@ -64,8 +64,8 @@ SynthDef(\help_beattrack2_1, { |out, vol=1.0, beepvol=1.0, lock=0, bufnum|
 	//in = SoundIn.ar(0);
 
 	//Create some features
-	fft = FFT(LocalBuf(1, 1024), in); //for sampling rates 44100 and 48000
-	//fft = FFT(LocalBuf(1, 2048), in); //for sampling rates 88200 and 96000
+	fft = FFT(LocalBuf(1024), in); //for sampling rates 44100 and 48000
+	//fft = FFT(LocalBuf(2048), in); //for sampling rates 88200 and 96000
 
 	feature1 = RunningSum.rms(in, 64);
 	feature2 = MFCC.kr(fft,2); //two coefficients
@@ -109,8 +109,8 @@ a= SynthDef(\help_beattrack2_1, { |out, vol=1.0, beepvol=1.0, lock=0, bufnum|
 	//in = SoundIn.ar(0);
 
 	//Create some features
-	fft = FFT(LocalBuf(1, 1024), in); // for sampling rates 44100 and 48000
-	//fft = FFT(LocalBuf(1, 2048), in); // for sampling rates 88200 and 96000
+	fft = FFT(LocalBuf(1024), in); // for sampling rates 44100 and 48000
+	//fft = FFT(LocalBuf(2048), in); // for sampling rates 88200 and 96000
 
 	feature1 = Onsets.kr(fft, odftype:\mkl, rawodf:1);
 

--- a/HelpSource/Classes/FFTTrigger.schelp
+++ b/HelpSource/Classes/FFTTrigger.schelp
@@ -28,7 +28,7 @@ x = {
 	mags = mags * { LFPulse.kr(2 ** IRand(-3, 5)).range(0, 1) }.dup(100);
 	// Let's ignore phase for now
 	phases = 0.dup(100);
-	chain = FFTTrigger(LocalBuf(1, 512), 0.5);
+	chain = FFTTrigger(LocalBuf(512), 0.5);
 	// Now we can do the packing
 	chain = PackFFT(chain, 512, [mags, phases].flop.flatten, 0, 99, 1);
 	sig = IFFT(chain);

--- a/HelpSource/Classes/KeyTrack.schelp
+++ b/HelpSource/Classes/KeyTrack.schelp
@@ -44,8 +44,8 @@ d = Buffer.read(s, "/Users/nickcollins/Desktop/ML/training_wav/78.wav")
 	in = PlayBuf.ar(1, d, BufRateScale.kr(d), 1, 0, 1);
 
 	// With standard hop of half FFT size = 2048 samples
-	fft = FFT(LocalBuf(1, 4096), in);  // for sampling rates 44100 and 48000
-	fft = FFT(LocalBuf(1, 8192), in);   // for sampling rates 88200 and 96000
+	fft = FFT(LocalBuf(4096), in);  // for sampling rates 44100 and 48000
+	fft = FFT(LocalBuf(8192), in);   // for sampling rates 88200 and 96000
 
 	key = KeyTrack.kr(fft, 2.0, 0.5);
 
@@ -70,7 +70,7 @@ code::
 	// major dom 7 and minor 7; major keys preferred here
 	//in = Mix(SinOsc.ar((60 + (MouseY.kr(0, 11).round(1.0)) + [0, MouseX.kr(3, 4).round(1), 7, 10]).midicps, 0, 0.1));
 
-	fft = FFT(LocalBuf(1, 4096), in);  // for sampling rates 44100 and 48000
+	fft = FFT(LocalBuf(4096), in);  // for sampling rates 44100 and 48000
 
 	key = KeyTrack.kr(fft);
 
@@ -95,7 +95,7 @@ d = Buffer.read(s, "/Users/nickcollins/Desktop/ML/training_wav/78.wav")
 
 	in = PlayBuf.ar(1, d, BufRateScale.kr(d), 1, 0, 1);
 
-	fft = FFT(LocalBuf(1, 4096), in);  // for sampling rates 44100 and 48000
+	fft = FFT(LocalBuf(4096), in);  // for sampling rates 44100 and 48000
 
 	key = KeyTrack.kr(fft, 2.0, 0.5);
 	key.poll;

--- a/HelpSource/Classes/Loudness.schelp
+++ b/HelpSource/Classes/Loudness.schelp
@@ -30,8 +30,8 @@ d = Buffer.read(s, Platform.resourceDir +/+ "sounds/a11wlk01.wav");
 (
 {
 	var in = PlayBuf.ar(1, d, BufRateScale.kr(d), 1, 0, 1);
-	var chain = FFT(LocalBuf(1, 1024), in);  // for sampling rates 44100 and 48000
-	//var chain = FFT(LocalBuf(1, 2048), in);  // for sampling rates 88200 and 96000
+	var chain = FFT(LocalBuf(1024), in);  // for sampling rates 44100 and 48000
+	//var chain = FFT(LocalBuf(2048), in);  // for sampling rates 88200 and 96000
 	var loudness = Loudness.kr(chain).poll(50);
 	Pan2.ar(in)
 }.play
@@ -65,8 +65,8 @@ d = Buffer.read(s, Platform.resourceDir +/+ "sounds/a11wlk01.wav");
 	//in = WhiteNoise.ar(Line.kr(0, 1, 2));
 	//in = PlayBuf.ar(1, d, BufRateScale.kr(d), 1, 0, 1);
 
-	chain = FFT(LocalBuf(1, 1024), in);  // for sampling rates 44100 and 48000
-	//chain = FFT(LocalBuf(1, 2048), in);  // for sampling rates 88200 and 96000
+	chain = FFT(LocalBuf(1024), in);  // for sampling rates 44100 and 48000
+	//chain = FFT(LocalBuf(2048), in);  // for sampling rates 88200 and 96000
 
 	loudness = Loudness.kr(chain, 0.25, 6).poll(50);
 

--- a/HelpSource/Classes/MFCC.schelp
+++ b/HelpSource/Classes/MFCC.schelp
@@ -38,8 +38,8 @@ x = {
 	//in = PlayBuf.ar(1, d, BufRateScale.kr(d), 1, 0, 1);
 
 	in = SoundIn.ar(0);
-	fft = FFT(LocalBuf(1, 1024), in);  // for sampling rates 44100 and 48000
-	//fft = FFT(LocalBuf(1, 2048), in);  // for sampling rates 88200 and 96000
+	fft = FFT(LocalBuf(1024), in);  // for sampling rates 44100 and 48000
+	//fft = FFT(LocalBuf(2048), in);  // for sampling rates 88200 and 96000
 
 	array = MFCC.kr(fft);
 

--- a/HelpSource/Classes/Onsets.schelp
+++ b/HelpSource/Classes/Onsets.schelp
@@ -81,7 +81,7 @@ x = {
 	// or, uncomment this line if you want to play the buffer in
 	//sig = PlayBuf.ar(1, d, BufRateScale.kr(d), loop: 1);
 
-	chain = FFT(LocalBuf(1, 512), sig);
+	chain = FFT(LocalBuf(512), sig);
 
 	onsets = Onsets.kr(chain, MouseX.kr(0,1), \rcomplex);
 
@@ -109,7 +109,7 @@ x = {
 	// or, uncomment this line if you want to play the buffer in
 	//sig = PlayBuf.ar(1, d, BufRateScale.kr(d), loop: 1);
 
-	chain = FFT(LocalBuf(1, 512), sig);
+	chain = FFT(LocalBuf(512), sig);
 
 	onsets = Onsets.kr(chain, threshes, \rcomplex);
 

--- a/HelpSource/Classes/SpecFlatness.schelp
+++ b/HelpSource/Classes/SpecFlatness.schelp
@@ -24,7 +24,7 @@ s.boot;
 	var in, chain, flat, flatdb, flatdbsquish;
 
 	in = XFade2.ar(WhiteNoise.ar, SinOsc.ar, MouseX.kr(-1,1));
-	chain = FFT(LocalBuf(1, 2048), in);
+	chain = FFT(LocalBuf(2048), in);
 	Out.ar(0, in * 0.1);
 
 	flat = SpecFlatness.kr(chain);
@@ -43,7 +43,7 @@ s.boot;
 { // Now try with your own voice
 	var in, chain;
 	in = SoundIn.ar([0,1]).mean;
-	chain = FFT(LocalBuf(1, 2048), in);
+	chain = FFT(LocalBuf(2048), in);
 	Out.kr(0, [in, SpecFlatness.kr(chain).poll(1, "flatness: ")]);
 }.scope;
 )

--- a/HelpSource/Classes/SpecPcile.schelp
+++ b/HelpSource/Classes/SpecPcile.schelp
@@ -29,7 +29,7 @@ code::
 	var in, chain, realcutoff, estcutoff;
 	realcutoff = MouseX.kr(0.00001,22050);
 	in = LPF.ar(WhiteNoise.ar, realcutoff);
-	chain = FFT(LocalBuf(1, 2048), in);
+	chain = FFT(LocalBuf(2048), in);
 	estcutoff = Lag.kr(SpecPcile.kr(chain, 0.9), 1);
 	realcutoff.poll(Impulse.kr(1), "real cutoff");
 	estcutoff.poll(Impulse.kr(1), "estimated cutoff");
@@ -44,7 +44,7 @@ code::
 {
 	var in, chain, perc;
 	in = SoundIn.ar([0,1]).mean;
-	chain = FFT(LocalBuf(1, 2048), in);
+	chain = FFT(LocalBuf(2048), in);
 	//Out.ar(0, in * 0.1);
 	perc = SpecPcile.kr(chain, 0.5);
 	Out.kr(0, perc * 22050.0.reciprocal);

--- a/HelpSource/Classes/UnpackFFT.schelp
+++ b/HelpSource/Classes/UnpackFFT.schelp
@@ -41,7 +41,7 @@ x = {
 	var sig, chain, unp;
 	//sig = SinOsc.ar;
 	sig = PlayBuf.ar(1, c, BufRateScale.kr(c), loop: 1);
-	chain = FFT(LocalBuf(1, 1024), sig);
+	chain = FFT(LocalBuf(1024), sig);
 
 	// Using the frombin & tobin args makes it much more efficient, limiting analysis to the bins of interest
 	unp = UnpackFFT(chain, b.numFrames, frombin: 0, tobin: 4);
@@ -62,7 +62,7 @@ x.free;
 (
 x = {
 	var sig, chain, magsphases, b;
-	b = LocalBuf(1, 1024);
+	b = LocalBuf(1024);
 	sig = PlayBuf.ar(1, c, BufRateScale.kr(c), loop: 1);
 	chain = FFT(b, sig);
 	magsphases = UnpackFFT(chain, b.numFrames);


### PR DESCRIPTION
Some Help file examples use LocalBuf's arguments incorrectly. With these changes, `LocalBuf(1, 1024)` becomes `LocalBuf(1024)`.