### PR TITLE
Help fix: assign PackFFT to var chain in example

### DIFF
--- a/HelpSource/Classes/UnpackFFT.schelp
+++ b/HelpSource/Classes/UnpackFFT.schelp
@@ -67,7 +67,7 @@ x = {
 	chain = FFT(b, sig);
 	magsphases = UnpackFFT(chain, b.numFrames);
 	magsphases = magsphases.collect(_.sqrt);
-	PackFFT(chain, b.numFrames, magsphases);
+	chain = PackFFT(chain, b.numFrames, magsphases);
 	Out.ar(0, 0.25 * IFFT(chain).dup);
 }.play
 )


### PR DESCRIPTION
The ouput of `PackFFT` should be assigned to the variable `chain` in this example. See discussion in #3212.