### PR TITLE
supernova: include argument names in queryTree

### DIFF
--- a/server/supernova/sc/sc_osc_handler.cpp
+++ b/server/supernova/sc/sc_osc_handler.cpp
@@ -1588,6 +1588,7 @@ void dump_controls(rt_string_stream & stream, abstract_synth const & synth, int 
     const size_t number_of_slots = synth.number_of_slots();
 
     bool eol_pending = false;
+    char str[10];
 
     for (size_t control_index = 0; control_index != number_of_slots; ++control_index) {
         const char * name_of_slot = synth.name_of_slot(control_index);
@@ -1604,7 +1605,10 @@ void dump_controls(rt_string_stream & stream, abstract_synth const & synth, int 
         } else
             stream << ", ";
 
-        stream << synth.get(control_index); /*FIXME: this seems not to check for mapped controls*/
+        if (synth.getMappedSymbol(control_index, str))
+            stream << str;
+        else
+            stream << synth.get(control_index);
     }
     if (eol_pending)
         stream << endl;

--- a/server/supernova/sc/sc_osc_handler.cpp
+++ b/server/supernova/sc/sc_osc_handler.cpp
@@ -1480,10 +1480,8 @@ void g_query_tree_fill_node(osc::OutboundPacketStream & p, bool flag, server_nod
         if (flag) {
             osc::int32 controls = scsynth.mNumControls;
             p << controls;
-            // log_printf("controls: %i\n", controls);
-            // log_printf("number_of_slots: %i\n", scsynth.number_of_slots());
 
-            for (int i = 0; i < controls; ++i) {
+            for (int i = 0; i != controls; ++i) {
                 const char * name_of_slot = scsynth.name_of_slot(i);
                 if(name_of_slot)
                     p << name_of_slot;
@@ -1494,10 +1492,9 @@ void g_query_tree_fill_node(osc::OutboundPacketStream & p, bool flag, server_nod
                 if (scsynth.mMapControls[i] != (scsynth.mControls+i)) {
                     /* we use a bus mapping */
                     int bus;
-                    // bus = (scsynth.mMapControls[i]) - (scsynth.mNode.mWorld->mControlBus);
                     char str[10];
-                    // sprintf(str, "%c%d", 'c', bus);
-                    if (*scsynth.mMapControls[i] == 2) { //this doesn't work yet! always goes to control bus
+
+                    if (scsynth.mControlRates[i] == 2) {
                         bus = (scsynth.mMapControls[i]) - (scsynth.mNode.mWorld->mAudioBus);
                         bus = (int)((float)bus / scsynth.mNode.mWorld->mBufLength);
                         sprintf(str, "%c%d", 'a', bus);
@@ -1607,7 +1604,7 @@ void dump_controls(rt_string_stream & stream, abstract_synth const & synth, int 
         } else
             stream << ", ";
 
-        stream << synth.get(control_index);
+        stream << synth.get(control_index); /*FIXME: this seems not to check for mapped controls*/
     }
     if (eol_pending)
         stream << endl;

--- a/server/supernova/sc/sc_osc_handler.cpp
+++ b/server/supernova/sc/sc_osc_handler.cpp
@@ -1480,15 +1480,31 @@ void g_query_tree_fill_node(osc::OutboundPacketStream & p, bool flag, server_nod
         if (flag) {
             osc::int32 controls = scsynth.mNumControls;
             p << controls;
+            // log_printf("controls: %i\n", controls);
+            // log_printf("number_of_slots: %i\n", scsynth.number_of_slots());
 
-            for (int i = 0; i != controls; ++i) {
-                p << osc::int32(i); /** \todo later we can return symbols */
+            for (int i = 0; i < controls; ++i) {
+                const char * name_of_slot = scsynth.name_of_slot(i);
+                if(name_of_slot)
+                    p << name_of_slot;
+                else
+                    p << osc::int32(i);
 
+                // analogous place in scsynth: SC_Group.cpp: void Group_QueryTreeAndControls(Group* inGroup, big_scpacket *packet)
                 if (scsynth.mMapControls[i] != (scsynth.mControls+i)) {
                     /* we use a bus mapping */
-                    int bus = (scsynth.mMapControls[i]) - (scsynth.mNode.mWorld->mControlBus);
+                    int bus;
+                    // bus = (scsynth.mMapControls[i]) - (scsynth.mNode.mWorld->mControlBus);
                     char str[10];
-                    sprintf(str, "s%d", bus);
+                    // sprintf(str, "%c%d", 'c', bus);
+                    if (*scsynth.mMapControls[i] == 2) { //this doesn't work yet! always goes to control bus
+                        bus = (scsynth.mMapControls[i]) - (scsynth.mNode.mWorld->mAudioBus);
+                        bus = (int)((float)bus / scsynth.mNode.mWorld->mBufLength);
+                        sprintf(str, "%c%d", 'a', bus);
+                    } else {
+                        bus = (scsynth.mMapControls[i]) - (scsynth.mNode.mWorld->mControlBus);
+                        sprintf(str, "%c%d", 'c', bus);
+                    };
                     p << str;
                 }
                 else

--- a/server/supernova/sc/sc_osc_handler.cpp
+++ b/server/supernova/sc/sc_osc_handler.cpp
@@ -200,7 +200,7 @@ struct movable_array
         data_   = rhs.data_;
 
         rhs.data_ = nullptr;
-        
+
         return *this;
     }
 
@@ -1488,22 +1488,9 @@ void g_query_tree_fill_node(osc::OutboundPacketStream & p, bool flag, server_nod
                 else
                     p << osc::int32(i);
 
-                // analogous place in scsynth: SC_Group.cpp: void Group_QueryTreeAndControls(Group* inGroup, big_scpacket *packet)
-                if (scsynth.mMapControls[i] != (scsynth.mControls+i)) {
-                    /* we use a bus mapping */
-                    int bus;
-                    char str[10];
-
-                    if (scsynth.mControlRates[i] == 2) {
-                        bus = (scsynth.mMapControls[i]) - (scsynth.mNode.mWorld->mAudioBus);
-                        bus = (int)((float)bus / scsynth.mNode.mWorld->mBufLength);
-                        sprintf(str, "%c%d", 'a', bus);
-                    } else {
-                        bus = (scsynth.mMapControls[i]) - (scsynth.mNode.mWorld->mControlBus);
-                        sprintf(str, "%c%d", 'c', bus);
-                    };
+                char str[10];
+                if (scsynth.getMappedSymbol(i, str))
                     p << str;
-                }
                 else
                     p << scsynth.mControls[i];
             }
@@ -1588,7 +1575,6 @@ void dump_controls(rt_string_stream & stream, abstract_synth const & synth, int 
     const size_t number_of_slots = synth.number_of_slots();
 
     bool eol_pending = false;
-    char str[10];
 
     for (size_t control_index = 0; control_index != number_of_slots; ++control_index) {
         const char * name_of_slot = synth.name_of_slot(control_index);
@@ -1605,6 +1591,7 @@ void dump_controls(rt_string_stream & stream, abstract_synth const & synth, int 
         } else
             stream << ", ";
 
+        char str[10];
         if (synth.getMappedSymbol(control_index, str))
             stream << str;
         else

--- a/server/supernova/sc/sc_synth.cpp
+++ b/server/supernova/sc/sc_synth.cpp
@@ -182,6 +182,23 @@ float sc_synth::get(slot_index_t slot_index) const
     return mControls[slot_index];
 }
 
+bool sc_synth::getMappedSymbol(slot_index_t slot_index, char * str) const
+{
+    bool isMapped = mMapControls[slot_index] != mControls+slot_index;
+    if (isMapped) {
+      int bus;
+      if (mControlRates[slot_index] == 2) {
+          bus = mMapControls[slot_index] - mNode.mWorld->mAudioBus;
+          bus = (int)((float)bus / mNode.mWorld->mBufLength);
+          sprintf(str, "%c%d", 'a', bus);
+      } else {
+          bus = mMapControls[slot_index] - mNode.mWorld->mControlBus;
+          sprintf(str, "%c%d", 'c', bus);
+      };
+    }
+    return isMapped;
+}
+
 void sc_synth::map_control_bus_control (unsigned int slot_index, int control_bus_index)
 {
     if (slot_index >= mNumControls)

--- a/server/supernova/sc/sc_synth.cpp
+++ b/server/supernova/sc/sc_synth.cpp
@@ -184,17 +184,17 @@ float sc_synth::get(slot_index_t slot_index) const
 
 bool sc_synth::getMappedSymbol(slot_index_t slot_index, char * str) const
 {
+    // analogous place in scsynth: SC_Group.cpp: void Group_QueryTreeAndControls(Group* inGroup, big_scpacket *packet)
     bool isMapped = mMapControls[slot_index] != mControls+slot_index;
     if (isMapped) {
-      int bus;
-      if (mControlRates[slot_index] == 2) {
-          bus = mMapControls[slot_index] - mNode.mWorld->mAudioBus;
-          bus = (int)((float)bus / mNode.mWorld->mBufLength);
-          sprintf(str, "%c%d", 'a', bus);
-      } else {
-          bus = mMapControls[slot_index] - mNode.mWorld->mControlBus;
-          sprintf(str, "%c%d", 'c', bus);
-      };
+        if (mControlRates[slot_index] == 2) {
+            int bus = mMapControls[slot_index] - mNode.mWorld->mAudioBus;
+            bus = bus / mNode.mWorld->mBufLength;
+            sprintf(str, "a%d", bus);
+        } else {
+            int bus = mMapControls[slot_index] - mNode.mWorld->mControlBus;
+            sprintf(str, "c%d", bus);
+        }
     }
     return isMapped;
 }

--- a/server/supernova/sc/sc_synth.hpp
+++ b/server/supernova/sc/sc_synth.hpp
@@ -135,6 +135,7 @@ public:
 
     void set(slot_index_t slot_index, sample val) override;
     float get(slot_index_t slot_index) const override;
+    bool getMappedSymbol(slot_index_t slot_index, char * str) const override;
     void set_control_array(slot_index_t slot_index, size_t count, sample * val) override;
 
     sample get(slot_index_t slot_index)

--- a/server/supernova/server/synth.hpp
+++ b/server/supernova/server/synth.hpp
@@ -100,6 +100,8 @@ public:
 
     virtual float get(slot_index_t slot_id) const = 0;
 
+    virtual bool getMappedSymbol(slot_index_t slot_id, char * str) const = 0;
+
     /** set a slot */
     /* @{ */
     virtual void set(slot_index_t slot_id, float val) override = 0;

--- a/server/supernova/server/synth.hpp
+++ b/server/supernova/server/synth.hpp
@@ -100,6 +100,7 @@ public:
 
     virtual float get(slot_index_t slot_id) const = 0;
 
+    /** returns true (and writes characters to *str) if the control at slot_id is indeed mapped, otherwise returns false */
     virtual bool getMappedSymbol(slot_index_t slot_id, char * str) const = 0;
 
     /** set a slot */

--- a/testsuite/server/supernova/test_synth.hpp
+++ b/testsuite/server/supernova/test_synth.hpp
@@ -18,6 +18,11 @@ public:
         return 0.f;
     }
 
+    virtual bool getMappedSymbol(slot_index_t slot_id, char * str) const
+    {
+        return false;
+    }
+
     virtual void set(slot_index_t slot_id, sample val)
     {}
 


### PR DESCRIPTION
As noted in https://github.com/supercollider/supercollider/issues/3210, scsynth and supernova respond differently to the the queryTree request. This changes the behavior of supernova to match the behavior of scsynth - controls's names are being reported in the reply message.
```
(
Server.supernova;
// Server.scsynth;
s.waitForBoot({
	SynthDef(\prTest, {arg amp = #[0.1, 0.12], freq = 300, out = 0;
		Out.ar(out, SinOsc.ar(freq, 0, amp))
	}).add;
	s.sync;
	x = Synth(\prTest);
	OSCFunc({arg msg;
		msg.postln;
		x.free;
	}, '/g_queryTree.reply').oneShot;
	s.sendMsg("/g_queryTree", 0, 1);
})
)
//supernova - no patch
// [ /g_queryTree.reply, 1, 0, 1, 1, 1, 1000, -1, prTest, 4, 0, 0.10000000149012, 1, 0.11999999731779, 2, 300, 3, 0 ]

//supernova - with patch
//[ /g_queryTree.reply, 1, 0, 1, 1, 1, 1000, -1, prTest, 4, amp, 0.10000000149012, 1, 0.11999999731779, freq, 300, out, 0 ]

//scsynth
//[ /g_queryTree.reply, 1, 0, 1, 1, 1, 1000, -1, prTest, 4, amp, 0.10000000149012, 1, 0.11999999731779, freq, 300, out, 0 ]
```