### PR TITLE
Update SpecPcile.schelp

### DIFF
--- a/HelpSource/Classes/SpecPcile.schelp
+++ b/HelpSource/Classes/SpecPcile.schelp
@@ -29,7 +29,7 @@ code::
 	var in, chain, realcutoff, estcutoff;
 	realcutoff = MouseX.kr(0.00001,22050);
 	in = LPF.ar(WhiteNoise.ar, realcutoff);
-	chain = FFT(LocalBuf(1, 2048), in);
+	chain = FFT(LocalBuf(2048), in);
 	estcutoff = Lag.kr(SpecPcile.kr(chain, 0.9), 1);
 	realcutoff.poll(Impulse.kr(1), "real cutoff");
 	estcutoff.poll(Impulse.kr(1), "estimated cutoff");
@@ -44,7 +44,7 @@ code::
 {
 	var in, chain, perc;
 	in = SoundIn.ar([0,1]).mean;
-	chain = FFT(LocalBuf(1, 2048), in);
+	chain = FFT(LocalBuf(2048), in);
 	//Out.ar(0, in * 0.1);
 	perc = SpecPcile.kr(chain, 0.5);
 	Out.kr(0, perc * 22050.0.reciprocal);


### PR DESCRIPTION
Corrected example code in the SpecPcile helpfile, now using LocalBuf(size) instead of (incorrect) LocalBuf(numChannels, size). The original still worked, likely because the total size of the buffer was the same.