### PR TITLE
Disable 128bit float constants.

### DIFF
--- a/lang/LangPrimSource/PyrMathPrim.cpp
+++ b/lang/LangPrimSource/PyrMathPrim.cpp
@@ -34,6 +34,7 @@
 #include "SC_Endian.h"
 #include "SCBase.h"
 
+#define BOOST_MATH_DISABLE_FLOAT128 1
 #include "boost/math/special_functions.hpp"
 
 const int INT_MAX_BY_PyrSlot = INT_MAX / sizeof(PyrSlot);


### PR DESCRIPTION
They conflict with --std=c++11 (additional compiler flags are required),
but are not used, so just skip using them.

This comes from the downstream debian package. I figure it could be useful upstream too.