### PR TITLE
Cleanup - get max logins from scsynth

### DIFF
--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -387,10 +387,6 @@ Server {
 	clientID_ { |val|
 		var failstr = "Server % couldn't set clientID to: % - %. clientID is still %.";
 
-		if(val == clientID) {
-			// no need to change
-			^this
-		};
 		if(val.isInteger.not) {
 			failstr.format(name, val.cs, "not an Integer", clientID).warn;
 			^this
@@ -404,9 +400,14 @@ Server {
 			^this
 		};
 
-		"% : setting clientID to %.\n".postf(this, val);
+		if (clientID != val) {
+			"% : setting clientID to %.\n".postf(this, val);
+		};
 		clientID = val;
 		this.newAllocators;
+		if (statusWatcher.notNil and: { this.serverRunning }) {
+			this.sendDefaultGroups;
+		};
 	}
 
 	newAllocators {

--- a/server/scsynth/SC_GraphDef.cpp
+++ b/server/scsynth/SC_GraphDef.cpp
@@ -610,10 +610,10 @@ SCErr GraphDef_DeleteMsg(World *inWorld, GraphDef *inDef)
 	packet.addtag('s');
 	packet.adds((char*)inDef->mNodeDef.mName);
 
-	ReplyAddress *users = inWorld->hw->mUsers;
-	int numUsers = inWorld->hw->mNumUsers;
-	for (int i=0; i<numUsers; ++i) {
-		SCErr err = SendReplyCmd_d_removed(inWorld, packet.size(), packet.data(), users+i);
+	Clients::iterator it;
+	for (it = inWorld->hw->mUsers->begin(); it != inWorld->hw->mUsers->end(); ++it){
+		ReplyAddress addr = *it;
+		SCErr err = SendReplyCmd_d_removed(inWorld, packet.size(), packet.data(), &addr);
 		if(err!=kSCErr_None)
 			return err;
 	}

--- a/server/scsynth/SC_GraphDef.cpp
+++ b/server/scsynth/SC_GraphDef.cpp
@@ -610,13 +610,12 @@ SCErr GraphDef_DeleteMsg(World *inWorld, GraphDef *inDef)
 	packet.addtag('s');
 	packet.adds((char*)inDef->mNodeDef.mName);
 
-	Clients::iterator it;
-	for (it = inWorld->hw->mUsers->begin(); it != inWorld->hw->mUsers->end(); ++it){
-		ReplyAddress addr = *it;
-		SCErr err = SendReplyCmd_d_removed(inWorld, packet.size(), packet.data(), &addr);
-		if(err!=kSCErr_None)
+	for (auto addr : *inWorld->hw->mUsers) {
+		SCErr const err = SendReplyCmd_d_removed(inWorld, packet.size(), packet.data(), &addr);
+		if (err != kSCErr_None)
 			return err;
 	}
+
 	return kSCErr_None;
 }
 

--- a/server/scsynth/SC_HiddenWorld.h
+++ b/server/scsynth/SC_HiddenWorld.h
@@ -31,6 +31,8 @@
 #include "SC_Reply.h"
 #include "MsgFifo.h"
 #include <map>
+#include <deque>
+#include <set>
 
 #include "boost/sync/semaphore.hpp"
 
@@ -90,15 +92,17 @@ typedef MsgFifoNoFree<DeleteGraphDefMsg, 512> DeleteGraphDefsFifo;
 typedef HashTable<struct GraphDef, Malloc> GrafDefTable;
 
 typedef std::map<struct ReplyAddress, uint32> ClientIDDict;
+typedef std::deque<int> ClientIDs;
+typedef std::set<ReplyAddress> Clients;
 
 struct HiddenWorld
 {
 	class AllocPool *mAllocPool;
 	IntHashTable<struct Node, AllocPool> *mNodeLib;
 	GrafDefTable *mGraphDefLib;
-	uint32 mNumUsers, mMaxUsers;
-	ReplyAddress *mUsers;
-	uint32 *mClientIDs, mClientIDTop;
+	uint32 mMaxUsers;
+	Clients *mUsers;
+	ClientIDs *mAvailableClientIDs;
 	ClientIDDict *mClientIDdict;
 
 	class SC_AudioDriver *mAudioDriver;

--- a/server/scsynth/SC_Lib.cpp
+++ b/server/scsynth/SC_Lib.cpp
@@ -54,6 +54,57 @@ void SendDoneWithIntValue(ReplyAddress *inReply, const char *inCommandName, int 
 	SendReply(inReply, packet.data(), packet.size());
 }
 
+void SendDoneWithVarArgs(struct ReplyAddress *inReply, const char *inCommandName, const char *oscFormat, ...)
+{
+	small_scpacket packet;
+	int numArgs = strlen(oscFormat);
+	packet.adds("/done");
+	packet.maketags(2 + numArgs);
+	packet.addtag(',');
+	packet.addtag('s');
+	packet.adds(inCommandName);
+	
+	va_list args;
+	va_start(args, oscFormat);
+ 
+	// support all the types the server currently does
+	while (*oscFormat != '\0') {
+		if (*oscFormat == 'i') {
+			int32 i = va_arg(args, int32);
+			packet.addtag('i');
+			packet.addi(i);
+		} else if(*oscFormat == 'h') {
+			int64 h = va_arg(args, int64);
+			packet.addtag('h');
+			packet.addii(h);
+		} else if (*oscFormat == 'f') {
+			float32 f = (float32)va_arg(args, double);
+			packet.addtag('f');
+			packet.addf(f);
+		} else if (*oscFormat == 'd') {
+			double d = va_arg(args, double);
+			packet.addtag('d');
+			packet.addd(d);
+		} else if (*oscFormat == 's') {
+			const char *s = va_arg(args, char*);
+			packet.addtag('s');
+			packet.adds(s);
+		} else if (*oscFormat == 'b') {
+			size_t len = va_arg(args, size_t);
+			++oscFormat;
+			uint8 *b = va_arg(args, uint8*);
+			packet.addtag('b');
+			packet.addb(b, len);
+		}
+		
+		++oscFormat;
+	}
+ 
+	va_end(args);
+	
+	SendReply(inReply, packet.data(), packet.size());
+}
+
 void SendFailure(ReplyAddress *inReply, const char *inCommandName, const char *errString)
 {
 	small_scpacket packet;
@@ -79,6 +130,59 @@ void SendFailureWithIntValue(ReplyAddress *inReply, const char *inCommandName, c
 	packet.adds(errString);
 	packet.addtag('i');
 	packet.addi((int)index);
+	SendReply(inReply, packet.data(), packet.size());
+}
+
+void SendFailureWithVarArgs(struct ReplyAddress *inReply, const char *inCommandName, const char *errString, const char *oscFormat, ...)
+{
+	small_scpacket packet;
+	int numArgs = strlen(oscFormat);
+	packet.adds("/fail");
+	packet.maketags(3 + numArgs);
+	packet.addtag(',');
+	packet.addtag('s');
+	packet.addtag('s');
+	packet.adds(inCommandName);
+	packet.adds(errString);
+	
+	va_list args;
+	va_start(args, oscFormat);
+ 
+	// support all the types the server currently does
+	while (*oscFormat != '\0') {
+		if (*oscFormat == 'i') {
+			int32 i = va_arg(args, int32);
+			packet.addtag('i');
+			packet.addi(i);
+		} else if(*oscFormat == 'h') {
+			int64 h = va_arg(args, int64);
+			packet.addtag('h');
+			packet.addii(h);
+		} else if (*oscFormat == 'f') {
+			float32 f = (float32)va_arg(args, double);
+			packet.addtag('f');
+			packet.addf(f);
+		} else if (*oscFormat == 'd') {
+			double d = va_arg(args, double);
+			packet.addtag('d');
+			packet.addd(d);
+		} else if (*oscFormat == 's') {
+			const char *s = va_arg(args, char*);
+			packet.addtag('s');
+			packet.adds(s);
+		} else if (*oscFormat == 'b') {
+			size_t len = va_arg(args, size_t);
+			++oscFormat;
+			uint8 *b = va_arg(args, uint8*);
+			packet.addtag('b');
+			packet.addb(b, len);
+		}
+		
+		++oscFormat;
+	}
+ 
+	va_end(args);
+	
 	SendReply(inReply, packet.data(), packet.size());
 }
 

--- a/server/scsynth/SC_Lib.cpp
+++ b/server/scsynth/SC_Lib.cpp
@@ -54,19 +54,8 @@ void SendDoneWithIntValue(ReplyAddress *inReply, const char *inCommandName, int 
 	SendReply(inReply, packet.data(), packet.size());
 }
 
-void SendDoneWithVarArgs(struct ReplyAddress *inReply, const char *inCommandName, const char *oscFormat, ...)
+static void appendVarArgs(small_scpacket& packet, const char *oscFormat, va_list args)
 {
-	small_scpacket packet;
-	int numArgs = strlen(oscFormat);
-	packet.adds("/done");
-	packet.maketags(2 + numArgs);
-	packet.addtag(',');
-	packet.addtag('s');
-	packet.adds(inCommandName);
-	
-	va_list args;
-	va_start(args, oscFormat);
- 
 	// support all the types the server currently does
 	while (*oscFormat != '\0') {
 		if (*oscFormat == 'i') {
@@ -96,12 +85,26 @@ void SendDoneWithVarArgs(struct ReplyAddress *inReply, const char *inCommandName
 			packet.addtag('b');
 			packet.addb(b, len);
 		}
-		
+
 		++oscFormat;
 	}
- 
+}
+
+void SendDoneWithVarArgs(struct ReplyAddress *inReply, const char *inCommandName, const char *oscFormat, ...)
+{
+	small_scpacket packet;
+	int numArgs = strlen(oscFormat);
+	packet.adds("/done");
+	packet.maketags(2 + numArgs);
+	packet.addtag(',');
+	packet.addtag('s');
+	packet.adds(inCommandName);
+
+	va_list args;
+	va_start(args, oscFormat);
+	appendVarArgs(packet, oscFormat, args);
 	va_end(args);
-	
+
 	SendReply(inReply, packet.data(), packet.size());
 }
 
@@ -144,45 +147,12 @@ void SendFailureWithVarArgs(struct ReplyAddress *inReply, const char *inCommandN
 	packet.addtag('s');
 	packet.adds(inCommandName);
 	packet.adds(errString);
-	
+
 	va_list args;
 	va_start(args, oscFormat);
- 
-	// support all the types the server currently does
-	while (*oscFormat != '\0') {
-		if (*oscFormat == 'i') {
-			int32 i = va_arg(args, int32);
-			packet.addtag('i');
-			packet.addi(i);
-		} else if(*oscFormat == 'h') {
-			int64 h = va_arg(args, int64);
-			packet.addtag('h');
-			packet.addii(h);
-		} else if (*oscFormat == 'f') {
-			float32 f = (float32)va_arg(args, double);
-			packet.addtag('f');
-			packet.addf(f);
-		} else if (*oscFormat == 'd') {
-			double d = va_arg(args, double);
-			packet.addtag('d');
-			packet.addd(d);
-		} else if (*oscFormat == 's') {
-			const char *s = va_arg(args, char*);
-			packet.addtag('s');
-			packet.adds(s);
-		} else if (*oscFormat == 'b') {
-			size_t len = va_arg(args, size_t);
-			++oscFormat;
-			uint8 *b = va_arg(args, uint8*);
-			packet.addtag('b');
-			packet.addb(b, len);
-		}
-		
-		++oscFormat;
-	}
- 
+	appendVarArgs(packet, oscFormat, args);
 	va_end(args);
-	
+
 	SendReply(inReply, packet.data(), packet.size());
 }
 

--- a/server/scsynth/SC_Prototypes.h
+++ b/server/scsynth/SC_Prototypes.h
@@ -192,8 +192,10 @@ void Unit_ZeroOutputs(struct Unit *inUnit, int inNumSamples);
 
 void SendDone(struct ReplyAddress *inReply, const char *inCommandName);
 void SendDoneWithIntValue(struct ReplyAddress *inReply, const char *inCommandName, int value);
+void SendDoneWithVarArgs(struct ReplyAddress *inReply, const char *inCommandName, const char *oscFormat, ...);
 void SendFailure(struct ReplyAddress *inReply, const char *inCommandName, const char *errString);
 void SendFailureWithIntValue(struct ReplyAddress *inReply, const char *inCommandName, const char *errString, uint32 index);
+void SendFailureWithVarArgs(struct ReplyAddress *inReply, const char *inCommandName, const char *errString, const char *oscFormat, ...);
 void ReportLateness(struct ReplyAddress *inReply, float32 seconds);
 int32 Hash(struct ReplyAddress *inReplyAddress);
 

--- a/server/scsynth/SC_SequencedCommand.cpp
+++ b/server/scsynth/SC_SequencedCommand.cpp
@@ -1283,9 +1283,7 @@ bool NotifyCmd::Stage2()
 	HiddenWorld *hw = mWorld->hw;
 
 	if (mOnOff) {
-		Clients::iterator it;
-		for (it = mWorld->hw->mUsers->begin(); it != mWorld->hw->mUsers->end(); ++it){
-			ReplyAddress addr = *it;
+		for (auto addr : *hw->mUsers) {
 			if (mReplyAddress == addr) {
 				// already in table - don't fail though..
 				SendFailureWithIntValue(&mReplyAddress, "/notify", "notify: already registered\n", hw->mClientIDdict->at(mReplyAddress));
@@ -1320,19 +1318,15 @@ bool NotifyCmd::Stage2()
 		hw->mUsers->insert(mReplyAddress);
 		SendDoneWithVarArgs(&mReplyAddress, "/notify", "ii", clientID, (int)hw->mMaxUsers);
 		
-
-    } else {
-		Clients::iterator it;
-		for (it = mWorld->hw->mUsers->begin(); it != mWorld->hw->mUsers->end(); ++it){
-			ReplyAddress addr = *it;
-			if (mReplyAddress == addr) {
-				// remove from list
-				hw->mAvailableClientIDs->push_back(hw->mClientIDdict->at(mReplyAddress)); // push the freed ID
-				hw->mClientIDdict->erase(mReplyAddress);
-				hw->mUsers->erase(it);
-				SendDone("/notify");
-				return false;
-			}
+	} else {
+		auto const it = std::find(hw->mUsers->begin(), hw->mUsers->end(), mReplyAddress);
+		if (it != hw->mUsers->end()) {
+			// remove from list
+			hw->mAvailableClientIDs->push_back(hw->mClientIDdict->at(mReplyAddress)); // push the freed ID
+			hw->mClientIDdict->erase(mReplyAddress);
+			hw->mUsers->erase(it);
+			SendDone("/notify");
+			return false;
 		}
 
 		SendFailure(&mReplyAddress, "/notify", "not registered\n");

--- a/server/scsynth/SC_SequencedCommand.cpp
+++ b/server/scsynth/SC_SequencedCommand.cpp
@@ -1331,9 +1331,10 @@ bool NotifyCmd::Stage2()
 		hw->mClientIDdict->insert(std::make_pair(mReplyAddress,clientID));
 		hw->mUsers->insert(mReplyAddress);
 		SendDoneWithVarArgs(&mReplyAddress, "/notify", "ii", clientID, (int)hw->mMaxUsers);
+		
+	} else {
 
-    } else {
-		auto const it = std::find(hw->mUsers->begin(), hw->mUsers->end(), mReplyAddress);
+        auto const it = std::find(hw->mUsers->begin(), hw->mUsers->end(), mReplyAddress);
 		if (it != hw->mUsers->end()) {
 			// remove from list
 			hw->mAvailableClientIDs->push_back(hw->mClientIDdict->at(mReplyAddress)); // push the freed ID

--- a/server/scsynth/SC_SequencedCommand.cpp
+++ b/server/scsynth/SC_SequencedCommand.cpp
@@ -1268,6 +1268,7 @@ int NotifyCmd::Init(char *inData, int inSize)
 {
 	sc_msg_iter msg(inSize, inData);
 	mOnOff = msg.geti();
+	mID = msg.geti(-1);
 
 	return kSCErr_None;
 }
@@ -1282,8 +1283,10 @@ bool NotifyCmd::Stage2()
 	HiddenWorld *hw = mWorld->hw;
 
 	if (mOnOff) {
-		for (uint32 i=0; i<hw->mNumUsers; ++i) {
-			if (mReplyAddress == hw->mUsers[i]) {
+		Clients::iterator it;
+		for (it = mWorld->hw->mUsers->begin(); it != mWorld->hw->mUsers->end(); ++it){
+			ReplyAddress addr = *it;
+			if (mReplyAddress == addr) {
 				// already in table - don't fail though..
 				SendFailureWithIntValue(&mReplyAddress, "/notify", "notify: already registered\n", hw->mClientIDdict->at(mReplyAddress));
 				scprintf("/notify : already registered\n");
@@ -1291,25 +1294,42 @@ bool NotifyCmd::Stage2()
 			}
 		}
 
-		// add reply address to user table
-		if (hw->mNumUsers >= hw->mMaxUsers) {
+		if (hw->mUsers->size() >= hw->mMaxUsers) {
 			SendFailure(&mReplyAddress, "/notify", "too many users\n");
 			scprintf("too many users\n");
 			return false;
 		}
-
-		uint32 clientID = hw->mClientIDs[hw->mClientIDTop++]; // pop an ID
+		
+		int clientID;
+		
+		if(mID == -1) { // no requested clientID
+			clientID = hw->mAvailableClientIDs->front(); // pop an ID
+			hw->mAvailableClientIDs->pop_front();
+		} else { // user ID requested
+			ClientIDs::iterator it = std::find(hw->mAvailableClientIDs->begin(), hw->mAvailableClientIDs->end(), mID);
+			if (it != hw->mAvailableClientIDs->end()) { // return the requested ID if available
+				clientID = mID;
+				hw->mAvailableClientIDs->erase(it);
+			} else { // otherwise return the first free one
+				clientID = hw->mAvailableClientIDs->front();
+				hw->mAvailableClientIDs->pop_front();
+			}
+		}
+		
 		hw->mClientIDdict->insert(std::pair<ReplyAddress, uint32>(mReplyAddress,clientID));
-		hw->mUsers[hw->mNumUsers++] = mReplyAddress;
+		hw->mUsers->insert(mReplyAddress);
+		SendDoneWithVarArgs(&mReplyAddress, "/notify", "ii", clientID, (int)hw->mMaxUsers);
+		
 
-		SendDoneWithIntValue("/notify", clientID);
-	} else {
-		for (uint32 i=0; i<hw->mNumUsers; ++i) {
-			if (mReplyAddress == hw->mUsers[i]) {
+    } else {
+		Clients::iterator it;
+		for (it = mWorld->hw->mUsers->begin(); it != mWorld->hw->mUsers->end(); ++it){
+			ReplyAddress addr = *it;
+			if (mReplyAddress == addr) {
 				// remove from list
-				hw->mClientIDs[--hw->mClientIDTop] = hw->mClientIDdict->at(mReplyAddress); // push the freed ID
+				hw->mAvailableClientIDs->push_back(hw->mClientIDdict->at(mReplyAddress)); // push the freed ID
 				hw->mClientIDdict->erase(mReplyAddress);
-				hw->mUsers[i] = hw->mUsers[--hw->mNumUsers];
+				hw->mUsers->erase(it);
 				SendDone("/notify");
 				return false;
 			}

--- a/server/scsynth/SC_SequencedCommand.cpp
+++ b/server/scsynth/SC_SequencedCommand.cpp
@@ -1328,7 +1328,7 @@ bool NotifyCmd::Stage2()
 
 		int const clientID = popAvailableClientID(mID, *hw->mAvailableClientIDs);
 
-		hw->mClientIDdict->insert(std::pair<ReplyAddress, uint32>(mReplyAddress,clientID));
+		hw->mClientIDdict->insert(std::make_pair(mReplyAddress,clientID));
 		hw->mUsers->insert(mReplyAddress);
 		SendDoneWithVarArgs(&mReplyAddress, "/notify", "ii", clientID, (int)hw->mMaxUsers);
 

--- a/server/scsynth/SC_World.cpp
+++ b/server/scsynth/SC_World.cpp
@@ -1157,11 +1157,8 @@ void TriggerMsg::Perform()
 	packet.addi(mTriggerID);
 	packet.addf(mValue);
 
-	Clients::iterator it;
-	for (it = mWorld->hw->mUsers->begin(); it != mWorld->hw->mUsers->end(); ++it){
-		ReplyAddress addr = *it;
+	for (auto addr : *mWorld->hw->mUsers)
 		SendReply(&addr, packet.data(), packet.size());
-	}
 }
 
 static void NodeReplyMsg_RTFree(FifoMsg* msg)
@@ -1185,11 +1182,8 @@ void NodeReplyMsg::Perform()
 		packet.addf(mValues[i]);
 	}
 
-	Clients::iterator it;
-	for (it = mWorld->hw->mUsers->begin(); it != mWorld->hw->mUsers->end(); ++it){
-		ReplyAddress addr = *it;
+	for (auto addr : *mWorld->hw->mUsers)
 		SendReply(&addr, packet.data(), packet.size());
-	}
 
 	// Free memory in realtime thread
 	FifoMsg msg;
@@ -1253,11 +1247,8 @@ void NodeEndMsg::Perform()
 		packet.addi(mIsGroup);
 	}
 
-	Clients::iterator it;
-	for (it = mWorld->hw->mUsers->begin(); it != mWorld->hw->mUsers->end(); ++it){
-		ReplyAddress addr = *it;
+	for (auto addr : *mWorld->hw->mUsers)
 		SendReply(&addr, packet.data(), packet.size());
-	}
 }
 
 void DeleteGraphDefMsg::Perform()
@@ -1271,11 +1262,8 @@ void NotifyNoArgs(World *inWorld, char *inString)
 	small_scpacket packet;
 	packet.adds(inString);
 
-	Clients::iterator it;
-	for (it = inWorld->hw->mUsers->begin(); it != inWorld->hw->mUsers->end(); ++it){
-		ReplyAddress addr = *it;
+	for (auto addr : *inWorld->hw->mUsers)
 		SendReply(&addr, packet.data(), packet.size());
-	}
 }
 
 

--- a/server/scsynth/SC_World.cpp
+++ b/server/scsynth/SC_World.cpp
@@ -350,14 +350,12 @@ World* World_New(WorldOptions *inOptions)
 		HiddenWorld *hw = world->hw;
 		hw->mGraphDefLib = new HashTable<struct GraphDef, Malloc>(&gMalloc, inOptions->mMaxGraphDefs, false);
 		hw->mNodeLib = new IntHashTable<Node, AllocPool>(hw->mAllocPool, inOptions->mMaxNodes, false);
-		hw->mUsers = (ReplyAddress*)zalloc(inOptions->mMaxLogins, sizeof(ReplyAddress));
-		hw->mNumUsers = 0;
+		hw->mUsers = new Clients();
 		hw->mMaxUsers = inOptions->mMaxLogins;
-		hw->mClientIDs = (uint32*)zalloc(inOptions->mMaxLogins, sizeof(uint32));
+		hw->mAvailableClientIDs = new ClientIDs();
 		for (int i = 0; i<hw->mMaxUsers; i++) {
-			hw->mClientIDs[i] = i;
+			hw->mAvailableClientIDs->push_back(i);
 		}
-		hw->mClientIDTop = 0;
 		hw->mClientIDdict = new ClientIDDict();
 		hw->mHiddenID = -8;
 		hw->mRecentID = -8;
@@ -1060,8 +1058,8 @@ void World_Cleanup(World *world, bool unload_plugins)
 		if (hw->mNRTOutputFile) sf_close(hw->mNRTOutputFile);
 		if (hw->mNRTCmdFile) fclose(hw->mNRTCmdFile);
 #endif
-		free_alig(hw->mUsers);
-		free_alig(hw->mClientIDs);
+		delete hw->mUsers;
+		delete hw->mAvailableClientIDs;
 		delete hw->mClientIDdict;
 		delete hw->mNodeLib;
 		delete hw->mGraphDefLib;
@@ -1159,10 +1157,10 @@ void TriggerMsg::Perform()
 	packet.addi(mTriggerID);
 	packet.addf(mValue);
 
-	ReplyAddress *users = mWorld->hw->mUsers;
-	int numUsers = mWorld->hw->mNumUsers;
-	for (int i=0; i<numUsers; ++i) {
-		SendReply(users+i, packet.data(), packet.size());
+	Clients::iterator it;
+	for (it = mWorld->hw->mUsers->begin(); it != mWorld->hw->mUsers->end(); ++it){
+		ReplyAddress addr = *it;
+		SendReply(&addr, packet.data(), packet.size());
 	}
 }
 
@@ -1187,10 +1185,10 @@ void NodeReplyMsg::Perform()
 		packet.addf(mValues[i]);
 	}
 
-	ReplyAddress *users = mWorld->hw->mUsers;
-	int numUsers = mWorld->hw->mNumUsers;
-	for (int i=0; i<numUsers; ++i) {
-		SendReply(users+i, packet.data(), packet.size());
+	Clients::iterator it;
+	for (it = mWorld->hw->mUsers->begin(); it != mWorld->hw->mUsers->end(); ++it){
+		ReplyAddress addr = *it;
+		SendReply(&addr, packet.data(), packet.size());
 	}
 
 	// Free memory in realtime thread
@@ -1255,10 +1253,10 @@ void NodeEndMsg::Perform()
 		packet.addi(mIsGroup);
 	}
 
-	ReplyAddress *users = mWorld->hw->mUsers;
-	int numUsers = mWorld->hw->mNumUsers;
-	for (int i=0; i<numUsers; ++i) {
-		SendReply(users+i, packet.data(), packet.size());
+	Clients::iterator it;
+	for (it = mWorld->hw->mUsers->begin(); it != mWorld->hw->mUsers->end(); ++it){
+		ReplyAddress addr = *it;
+		SendReply(&addr, packet.data(), packet.size());
 	}
 }
 
@@ -1273,10 +1271,10 @@ void NotifyNoArgs(World *inWorld, char *inString)
 	small_scpacket packet;
 	packet.adds(inString);
 
-	ReplyAddress *users = inWorld->hw->mUsers;
-	int numUsers = inWorld->hw->mNumUsers;
-	for (int i=0; i<numUsers; ++i) {
-		SendReply(users+i, packet.data(), packet.size());
+	Clients::iterator it;
+	for (it = inWorld->hw->mUsers->begin(); it != inWorld->hw->mUsers->end(); ++it){
+		ReplyAddress addr = *it;
+		SendReply(&addr, packet.data(), packet.size());
 	}
 }
 

--- a/testsuite/classlibrary/TestDictionary.sc
+++ b/testsuite/classlibrary/TestDictionary.sc
@@ -1,13 +1,15 @@
 TestDictionary : UnitTest {
 
 	test_keysValuesArrayDo {
+		var failedAsIntended = false;
 
 		this.assert(Dictionary[].keysValuesArrayDo([]) == Dictionary[], "keysValuesArrayDo on an empty dictionary should do nothing");
 
+		try { Dictionary[].keysValuesArrayDo(nil) } { |err|
+			failedAsIntended = err.isKindOf(PrimitiveFailedError)
+		};
 		this.assert(
-			try { Dictionary[].keysValuesArrayDo(nil) } { |err|
-				err.isKindOf(PrimitiveFailedError)
-			},
+			failedAsIntended,
 			"calling keysValuesArrayDo on nil should throw a PrimitiveFailedError"
 		)
 

--- a/testsuite/classlibrary/TestServerClientID.sc
+++ b/testsuite/classlibrary/TestServerClientID.sc
@@ -31,8 +31,7 @@ TestServer_clientID : UnitTest {
 		this.assert(s.clientID == 0, "s.clientID should block number >= maxLogins.");
 		s.clientID = s.options.maxLogins - 1;
 		this.assert(s.clientID == 31, "s.clientID should be settable if valid.");
-		Server.named.removeAt(s.name);
-		Server.all.remove(s);
+		s.remove;
 	}
 
 	test_userSpecifiedClientID {
@@ -42,8 +41,7 @@ TestServer_clientID : UnitTest {
 		options.maxLogins_(8);
 		s = Server(\testserv, NetAddr("localhost", 57111), options, 7);
 		this.assert(s.clientID == 7, "Making a server with valid nonzero clientID should work.");
-		Server.named.removeAt(s.name);
-		Server.all.remove(s);
+		s.remove;
 	}
 
 	test_allocatorRanges {
@@ -91,5 +89,7 @@ TestServer_clientID : UnitTest {
 		);
 
 		Server.nodeAllocClass = prevClass;
+		s.remove;
+
 	}
 }

--- a/testsuite/classlibrary/TestServer_clientIDBooted.sc
+++ b/testsuite/classlibrary/TestServer_clientIDBooted.sc
@@ -8,8 +8,7 @@ TestServer_clientID_booted : UnitTest {
 	// with running server
 	test_clientIDResetByServer {
 		var options = ServerOptions.new;
-		var s;
-		s = Server(\testserv1, NetAddr("localhost", 57111), options);
+		var s = Server(\testserv1, NetAddr("localhost", 57111), options);
 
 		s.options.maxLogins = 4;
 		s.clientID = 3;
@@ -17,9 +16,9 @@ TestServer_clientID_booted : UnitTest {
 		s.sync;
 		1.wait;
 		this.assert(s.clientID == 0, "Non-user-defined clientID should be reset by the server.");
-		Server.named.removeAt(s.name);
-		Server.all.remove(s);
 		s.quit;
+		s.remove;
+
 		1.wait;
 
 		s = Server(\testserv2, NetAddr("localhost", 57112), options, 3);
@@ -28,7 +27,6 @@ TestServer_clientID_booted : UnitTest {
 		s.sync;
 		1.wait;
 		this.assert(s.clientID == 3, "User-defined clientID should be left as is by the server.");
-		Server.named.removeAt(s.name);
-		Server.all.remove(s);
+		s.remove;
 	}
 }


### PR DESCRIPTION
This is a cleaned-up replacement PR for PR #3181. 
It contains 
* cherry-picked  changes to scsynth by @muellmusik and @brianlheim,
* a fix to failing unrelated UnitTest ```TestDictionary:test_keysValuesArrayDo```
  which apparently got lost 
* a minimal fix to clientID_ for a bug that showed up while testing 
multiple combinations of clients and server with this script: 
https://gist.github.com/adcxyz/57c89fe1faed045e77b09a2ec1d23b34
