### PR TITLE
remove Server-initTree from bootInit

### DIFF
--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -375,7 +375,7 @@ Server {
 	}
 
 	initTree {
-		this.newNodeAllocators;
+	//	this.newNodeAllocators;
 		this.sendDefaultGroups;
 		tree.value(this);
 		ServerTree.run(this);

--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -375,7 +375,7 @@ Server {
 	}
 
 	initTree {
-	//	this.newNodeAllocators;
+		this.newNodeAllocators;
 		this.sendDefaultGroups;
 		tree.value(this);
 		ServerTree.run(this);

--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -376,7 +376,7 @@ Server {
 
 	initTree {
 		this.newNodeAllocators;
-		this.sendMsg("/g_new", defaultGroup.nodeID, 0, 0);
+		this.sendDefaultGroups;
 		tree.value(this);
 		ServerTree.run(this);
 	}
@@ -406,7 +406,7 @@ Server {
 		clientID = val;
 		this.newAllocators;
 		if (statusWatcher.notNil and: { this.serverRunning }) {
-			this.sendDefaultGroups;
+			this.initTree;
 		};
 	}
 

--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -850,7 +850,6 @@ Server {
 			sendQuit = this.inProcess or: { this.isLocal };
 		};
 		this.connectSharedMemory;
-		this.initTree;
 	}
 
 	bootServerApp { |onComplete|

--- a/testsuite/classlibrary/TestServer_clientIDBooted.sc
+++ b/testsuite/classlibrary/TestServer_clientIDBooted.sc
@@ -27,6 +27,23 @@ TestServer_clientID_booted : UnitTest {
 		s.sync;
 		1.wait;
 		this.assert(s.clientID == 3, "User-defined clientID should be left as is by the server.");
+		s.quit;
+		s.remove;
+	}
+
+	test_nodeIDAlloc_ServerTree {
+		var s = Server(\testserv3, NetAddr("localhost", 57111));
+		var synth1, synth2;
+
+		ServerTree.add( { synth1 = Synth("default"); });
+		this.bootServer(s);
+
+		1.wait;
+
+		synth2 = Synth("default", [\freq, 330]);
+		this.assert(synth1.nodeID != synth2.nodeID,
+			"first nodeID after booting should not repeat nodeID created in ServerTree.");
+		s.quit;
 		s.remove;
 	}
 }


### PR DESCRIPTION
initTree should only happen after server received the login response,
because clientID and maxLogins may still change there. 
this fixes #3262.