### PR TITLE
Escape quotes in strings sent from SCIDE to lang

### DIFF
--- a/editors/sc-ide/widgets/help_browser.cpp
+++ b/editors/sc-ide/widgets/help_browser.cpp
@@ -182,13 +182,22 @@ void HelpBrowser::closeDocument()
 
 void HelpBrowser::gotoHelpFor( const QString & symbol )
 {
-    QString code = QStringLiteral("HelpBrowser.openHelpFor(\"%1\")").arg(symbol);
+    QString escaped{symbol};
+    escaped.replace('\"', "\\\"");
+
+    QString code = QStringLiteral("HelpBrowser.openHelpFor(\"%1\")").arg(escaped);
     sendRequest(code);
 }
 
 void HelpBrowser::gotoHelpForMethod( const QString & className, const QString & methodName )
 {
-    QString code = QStringLiteral("HelpBrowser.openHelpForMethod( %1.findMethod(\\%2) )").arg(className, methodName);
+    QString escapedClass{className};
+    QString escapedMethod{methodName};
+    escapedClass.replace('\"', "\\\"");
+    escapedMethod.replace('\"', "\\\"");
+
+    QString code = QStringLiteral("HelpBrowser.openHelpForMethod( %1.findMethod(\\%2) )")
+        .arg(escapedClass, escapedMethod);
     sendRequest(code);
 }
 
@@ -211,6 +220,7 @@ void HelpBrowser::onLinkClicked( const QUrl & url )
         }
     }
 
+    urlString.replace("\"", "\\\"");
     sendRequest( QStringLiteral("HelpBrowser.goTo(\"%1\")").arg( urlString ) );
 }
 

--- a/editors/sc-ide/widgets/help_browser.cpp
+++ b/editors/sc-ide/widgets/help_browser.cpp
@@ -180,21 +180,23 @@ void HelpBrowser::closeDocument()
     MainWindow::instance()->helpBrowserDocklet()->close();
 }
 
+/// Escapes double quotes; used for strings sent to interpreter.
+static inline QString escapeDoubleQuotes( const QString & s )
+{
+    return QString{s}.replace('\"', "\\\"");
+}
+
 void HelpBrowser::gotoHelpFor( const QString & symbol )
 {
-    QString escaped{symbol};
-    escaped.replace('\"', "\\\"");
-
+    QString escaped = escapeDoubleQuotes(symbol);
     QString code = QStringLiteral("HelpBrowser.openHelpFor(\"%1\")").arg(escaped);
     sendRequest(code);
 }
 
 void HelpBrowser::gotoHelpForMethod( const QString & className, const QString & methodName )
 {
-    QString escapedClass{className};
-    QString escapedMethod{methodName};
-    escapedClass.replace('\"', "\\\"");
-    escapedMethod.replace('\"', "\\\"");
+    QString escapedClass = escapeDoubleQuotes(className);
+    QString escapedMethod = escapeDoubleQuotes(methodName);
 
     QString code = QStringLiteral("HelpBrowser.openHelpForMethod( %1.findMethod(\\%2) )")
         .arg(escapedClass, escapedMethod);
@@ -208,7 +210,7 @@ void HelpBrowser::onLinkClicked( const QUrl & url )
     static const QStringList nonHelpFileExtensions = QStringList() << ".sc" << ".scd" << ".schelp" << ".txt" << ".rtf";
     static const QString fileScheme("file");
 
-    QString urlString = url.toString();
+    QString urlString = escapeDoubleQuotes(url.toString());
 
     foreach ( const QString & extension, nonHelpFileExtensions ) {
         if (urlString.endsWith( extension )) {
@@ -220,7 +222,6 @@ void HelpBrowser::onLinkClicked( const QUrl & url )
         }
     }
 
-    urlString.replace("\"", "\\\"");
     sendRequest( QStringLiteral("HelpBrowser.goTo(\"%1\")").arg( urlString ) );
 }
 

--- a/editors/sc-ide/widgets/lookup_dialog.cpp
+++ b/editors/sc-ide/widgets/lookup_dialog.cpp
@@ -511,10 +511,10 @@ void ReferencesDialog::performQuery()
 
     if (queryString.isEmpty()) {
         setModel(NULL);
-        return;
+    } else {
+        queryString.replace('\"', "\\\"");
+        mRequest->sendRequest(queryString);
     }
-
-    mRequest->sendRequest(queryString);
 }
 
 void ReferencesDialog::requestCancelled()


### PR DESCRIPTION
Fixes #1036, tested and works (on macOS 10.13 high sierra).

## Reproducer

1. Start scide.
2. Type the line `"broken`
3. Select-all, and Cmd-D (to search documentation) or Cmd-U (to look up references).

## Old behavior

Errors:

```
ERROR: syntax error, unexpected NAME, expecting ')'
  in interpreted text
  line 1 char 32:

  HelpBrowser.openHelpFor(""broken") 
                            ^^^^^^
-----------------------------------
ERROR: Command line parse failed
ERROR: syntax error, unexpected NAME, expecting ')'
  in interpreted text
  line 1 char 88:

  ScIDE.request("{ec39ccb4-c981-43ac-a72e-a75439af6b6c}",'findReferencesToSymbol',""broken") 
                                                                                    ^^^^^^
-----------------------------------
ERROR: Command line parse failed
```

Also freezes the help browser.

## New behavior

Works without error/complaint.

## Addendum

I noticed similar opportunities for this issue to arise in other IDEs (search result at the end of this post), but I think this is more pressing/issue-worthy because (a) the IDE has widest usage and (b) this issue actually causes a major freeze. I am not sure if it does in other contexts. Since I'm not a user of any other SC environments, I haven't changed any of those files.

```
[brianheim@BrianMBP supercollider]$ rg openHelpFor
HelpSource/Classes/HelpBrowser.schelp
28:method:: openHelpFor
40:method:: openHelpForMethod

SCClassLibrary/DefaultLibrary/Main.sc
119:		HelpBrowser.openHelpFor(this.getCurrentSelection);

editors/scel/el/sclang-help.el
628:      (sclang-eval-string (sclang-format "HelpBrowser.openHelpFor(%o)" topic))

editors/sced/sced/WindowHelper.py
289:        self.__lang.evaluate("HelpBrowser.openHelpFor(\"" + text + "\");")

editors/sced/sced3/supercollider.py
527:        cmd = 'HelpBrowser.openHelpFor(\"' + text + '\");'

editors/sc-ide/widgets/help_browser.cpp
187:    QString code = QStringLiteral("HelpBrowser.openHelpFor(\"%1\")").arg(escaped);
193:    QString code = QStringLiteral("HelpBrowser.openHelpForMethod( %1.findMethod(\\%2) )").arg(className, methodName);

editors/scvim/ftplugin/supercollider.vim
244:  call SendToSCSilent('HelpBrowser.openHelpFor("' . a:subject . '");')

SCClassLibrary/Common/Core/Kernel.sc
517:		HelpBrowser.openHelpForMethod(this);

SCClassLibrary/Common/Quarks/Quark.sc
277:			^HelpBrowser.openHelpFor(p);

editors/sced/scedwin/py/WindowHelper.py
307:        self.__lang.evaluate("HelpBrowser.openHelpFor(\"" + text + "\");")

SCClassLibrary/Common/GUI/tools/HelpBrowser.sc
59:	*openHelpFor {|text|
66:	*openHelpForMethod {|method|

SCClassLibrary/Common/GUI/PlusGUI/Collections/StringPlusGUI.sc
94:			HelpBrowser.openHelpFor(this);
[brianheim@BrianMBP supercollider]$ rg gotoHelpFor
editors/sc-ide/core/main.cpp
292:    helpDock->browser()->gotoHelpFor(symbol);
300:    helpDock->browser()->gotoHelpForMethod(className, methodName);

editors/sc-ide/widgets/help_browser.cpp
183:void HelpBrowser::gotoHelpFor( const QString & symbol )
192:void HelpBrowser::gotoHelpForMethod( const QString & className, const QString & methodName )

editors/sc-ide/widgets/main_window.cpp
1612:    mHelpBrowserDocklet->browser()->gotoHelpFor("Guides/SCIde");

editors/sc-ide/widgets/help_browser.hpp
99:    void gotoHelpFor( const QString & );
100:    void gotoHelpForMethod( const QString & className, const QString & methodName );

editors/sc-ide/widgets/code_editor/autocompleter.cpp
1312:    helpDock->browser()->gotoHelpFor(symbol);
```