### PR TITLE
SuperCollider projects V2

### DIFF
--- a/SCClassLibrary/Common/Core/LanguageConfig.sc
+++ b/SCClassLibrary/Common/Core/LanguageConfig.sc
@@ -9,9 +9,33 @@ LanguageConfig {
 		^this.primitiveFailed
 	}
 
+	*currentDirectory {
+		_LanguageConfig_getCurrentConfigDirectory
+		^this.primitiveFailed
+	}
+
+	*prMakeAbsoluteToProjectRoot { |paths|
+		var root;
+		^if( LanguageConfig.projectOpen ) {
+			root = this.currentDirectory;
+			paths.collect{ |p|
+				if( PathName(p).isRelativePath ) {
+					root +/+ p
+				} {
+					p
+				}
+			}
+		} {
+			paths
+		}
+	}
+
 	*includePaths {
 		_LanguageConfig_getIncludePaths
 		^this.primitiveFailed
+	}
+	*includePathsAbsolute {
+		^this.prMakeAbsoluteToProjectRoot(this.includePaths)
 	}
 	*addIncludePath {|aPath|
 		_LanguageConfig_addIncludePath
@@ -25,6 +49,9 @@ LanguageConfig {
 	*excludePaths {
 		_LanguageConfig_getExcludePaths
 		^this.primitiveFailed
+	}
+	*excludePathsAbsolute {
+		^this.prMakeAbsoluteToProjectRoot(this.excludePaths)
 	}
 	*addExcludePath {|aPath|
 		_LanguageConfig_addExcludePath
@@ -41,6 +68,16 @@ LanguageConfig {
 	}
 	*postInlineWarnings_ {|aBoolean|
 		_LanguageConfig_setPostInlineWarnings
+		^this.primitiveFailed
+	}
+
+	*projectOpen {
+		_LanguageConfig_getProjectOpen
+		^this.primitiveFailed
+	}
+
+	*defaultPathsExcluded {
+		_LanguageConfig_getExcludeDefaultPaths
 		^this.primitiveFailed
 	}
 }

--- a/SCClassLibrary/Platform/Platform.sc
+++ b/SCClassLibrary/Platform/Platform.sc
@@ -120,9 +120,17 @@ Platform {
 		}
 	}
 
-	loadStartupFiles { this.startupFiles.do{|afile|
-		afile = afile.standardizePath;
-		if(File.exists(afile), {afile.load})
+	loadStartupFiles {
+		var file;
+		if (LanguageConfig.defaultPathsExcluded.not && LanguageConfig.projectOpen.not) {
+			this.startupFiles.do{|afile|
+				afile = afile.standardizePath;
+				if(File.exists(afile), {afile.load})
+			}
+		};
+		if (LanguageConfig.projectOpen) {
+			file = LanguageConfig.currentDirectory ++ "/startup.scd";
+			if(File.exists(file), {file.load})
 		}
 	}
 

--- a/editors/sc-ide/CMakeLists.txt
+++ b/editors/sc-ide/CMakeLists.txt
@@ -64,6 +64,7 @@ set ( ide_moc_hdr
     core/session_manager.hpp
     widgets/cmd_line.hpp
     widgets/doc_list.hpp
+    widgets/file_tree.hpp
     widgets/documents_dialog.hpp
     widgets/editor_box.hpp
     widgets/find_replace_tool.hpp
@@ -89,6 +90,7 @@ set ( ide_moc_hdr
     widgets/settings/dialog.hpp
     widgets/settings/general_page.hpp
     widgets/settings/sclang_page.hpp
+    widgets/settings/sclang_project_page.hpp
     widgets/settings/editor_page.hpp
     widgets/settings/shortcuts_page.hpp
     widgets/util/path_chooser_widget.hpp
@@ -120,6 +122,7 @@ set ( ide_src
     core/util/scdoc_log.cpp
     widgets/cmd_line.cpp
     widgets/doc_list.cpp
+    widgets/file_tree.cpp
     widgets/documents_dialog.cpp
     widgets/editor_box.cpp
     widgets/find_replace_tool.cpp
@@ -141,6 +144,7 @@ set ( ide_src
     widgets/settings/dialog.cpp
     widgets/settings/general_page.cpp
     widgets/settings/sclang_page.cpp
+    widgets/settings/sclang_project_page.cpp
     widgets/settings/editor_page.cpp
     widgets/settings/shortcuts_page.cpp
     widgets/util/gui_utilities.cpp
@@ -171,6 +175,7 @@ set( ide_forms
     forms/settings_dialog.ui
     forms/settings_general.ui
     forms/settings_sclang.ui
+    forms/settings_sclang_project.ui
     forms/settings_editor.ui
     forms/settings_shortcuts.ui
 )

--- a/editors/sc-ide/core/main.cpp
+++ b/editors/sc-ide/core/main.cpp
@@ -30,9 +30,6 @@
 #include "../../../QtCollider/hacks/hacks_mac.hpp"
 #include "../primitives/localsocket_utils.hpp"
 
-#include <yaml-cpp/node/node.h>
-#include <yaml-cpp/parser.h>
-
 #include <QAction>
 #include <QApplication>
 #include <QBuffer>
@@ -327,3 +324,18 @@ void Main::findReferences(const QString &string, QWidget * parent)
     dialog.exec();
 }
 
+bool Main::useLanguageConfigFromSession() {
+    return settings()->value("IDE/useLanguageConfigFromSession").toBool() && (sessionManager()->currentSession() != nullptr);
+}
+
+SettingsInterface *Main::settingsForLanguageConfig(){
+    if( useLanguageConfigFromSession() )
+        return sessionManager()->currentSession();
+    else
+        return settings();
+}
+
+QString Main::getConfigFile()
+{
+    return settingsForLanguageConfig()->getConfigFile();
+}

--- a/editors/sc-ide/core/main.hpp
+++ b/editors/sc-ide/core/main.hpp
@@ -100,6 +100,11 @@ public:
     static void openCommandLine(const QString &string);
     static void findReferences(const QString &string, QWidget * parent);
 
+    static bool useLanguageConfigFromSession();
+    static SettingsInterface *settingsForLanguageConfig();
+    static QString getConfigFile();
+
+
 public Q_SLOTS:
     void storeSettings() {
         Q_EMIT(storeSettingsRequest(mSettings));

--- a/editors/sc-ide/core/sc_process.cpp
+++ b/editors/sc-ide/core/sc_process.cpp
@@ -115,6 +115,11 @@ void ScProcess::updateToggleRunningAction()
     mActions[ToggleRunning]->setShortcut( targetAction->shortcut() );
 }
 
+bool ScProcess::running()
+{
+    return state() == QProcess::Running;
+}
+
 void ScProcess::toggleRunning()
 {
     switch(state()) {
@@ -134,13 +139,10 @@ void ScProcess::startLanguage (void)
     }
 
     Settings::Manager *settings = Main::settings();
-    settings->beginGroup("IDE/interpreter");
 
-    QString workingDirectory = settings->value("runtimeDir").toString();
-    QString configFile = settings->value("configFile").toString();
-    bool standalone = settings->value("standalone").toBool();
+    QString workingDirectory = settings->value("IDE/interpreter/runtimeDir").toString();
 
-    settings->endGroup();
+    QString configFile = Main::instance()->getConfigFile();
 
     QString sclangCommand;
 #ifdef Q_OS_MAC
@@ -153,8 +155,6 @@ void ScProcess::startLanguage (void)
     if(!configFile.isEmpty())
         sclangArguments << "-l" << configFile;
     sclangArguments << "-i" << "scqt";
-    if(standalone)
-        sclangArguments << "-a";
 
     if(!workingDirectory.isEmpty())
         setWorkingDirectory(workingDirectory);

--- a/editors/sc-ide/core/sc_process.hpp
+++ b/editors/sc-ide/core/sc_process.hpp
@@ -82,6 +82,7 @@ public:
     void updateSelectionMirrorForDocument ( class Document * doc, int start, int range);
 
 public slots:
+    bool running();
     void toggleRunning();
     void startLanguage (void);
     void stopLanguage (void);

--- a/editors/sc-ide/core/session_manager.hpp
+++ b/editors/sc-ide/core/session_manager.hpp
@@ -26,11 +26,13 @@
 #include <QStringList>
 #include <QSettings>
 
+#include "settings_interface.hpp"
+
 namespace ScIDE {
 
 class DocumentManager;
 
-struct Session : public QSettings
+struct Session : public QSettings, public SettingsInterface
 {
     Session( const QString & file, const QString & name, Format format, QObject * parent = 0 ):
         QSettings(file, format, parent),
@@ -39,6 +41,11 @@ struct Session : public QSettings
 
     const QString & name() const { return mName; }
 
+    void beginGroup ( const QString & prefix ) override { QSettings::beginGroup(prefix); }
+    void endGroup () override { QSettings::endGroup(); }
+
+    QVariant value ( const QString & key ) const override { return QSettings::value(key); }
+    void setValue ( const QString & key, const QVariant & value ) override { QSettings::setValue(key, value); }
 private:
     QString mName;
 };

--- a/editors/sc-ide/core/settings/manager.hpp
+++ b/editors/sc-ide/core/settings/manager.hpp
@@ -29,11 +29,13 @@
 #include <QAction>
 #include <QTextCharFormat>
 
+#include "../settings_interface.hpp"
+
 namespace ScIDE { namespace Settings {
 
 class Theme;
 
-class Manager : public QObject
+class Manager : public QObject, public SettingsInterface
 {
     Q_OBJECT
 

--- a/editors/sc-ide/core/settings_interface.hpp
+++ b/editors/sc-ide/core/settings_interface.hpp
@@ -1,0 +1,29 @@
+#ifndef SCIDE_SETTINGS_INTERFACE_HPP_INCLUDED
+#define SCIDE_SETTINGS_INTERFACE_HPP_INCLUDED
+
+#include <QVariant>
+
+namespace ScIDE {
+
+class SettingsInterface
+{
+public:
+    virtual void beginGroup ( const QString & prefix ) = 0;
+    virtual void endGroup () = 0;
+
+    virtual QVariant value ( const QString & key ) const = 0;
+    virtual void setValue ( const QString & key, const QVariant & value ) = 0;
+
+    QString getConfigFile()
+    {
+        return value("IDE/interpreter/configFile").toString();
+    }
+
+    void setConfigFile(QString path)
+    {
+        setValue("IDE/interpreter/configFile", path);
+    }
+};
+
+}
+#endif // SCIDE_SETTINGS_INTERFACE_HPP_INCLUDED

--- a/editors/sc-ide/forms/settings_general.ui
+++ b/editors/sc-ide/forms/settings_general.ui
@@ -59,6 +59,42 @@
     </layout>
    </item>
    <item>
+    <widget class="QCheckBox" name="useLanguageConfigFromSession">
+     <property name="text">
+      <string>Save different language configuration per session.</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <layout class="QFormLayout" name="formLayout">
+     <property name="fieldGrowthPolicy">
+      <enum>QFormLayout::ExpandingFieldsGrow</enum>
+     </property>
+     <property name="leftMargin">
+      <number>9</number>
+     </property>
+     <property name="topMargin">
+      <number>9</number>
+     </property>
+     <property name="rightMargin">
+      <number>9</number>
+     </property>
+     <property name="bottomMargin">
+      <number>9</number>
+     </property>
+     <item row="0" column="0">
+      <widget class="QLabel" name="label_2">
+       <property name="text">
+        <string>FileTree Root:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="ScIDE::PathChooserWidget" name="fileTreeRootDir"/>
+     </item>
+    </layout>
+   </item>
+   <item>
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -73,6 +109,13 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>ScIDE::PathChooserWidget</class>
+   <extends>QLineEdit</extends>
+   <header>path_chooser_widget.hpp</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
  <buttongroups>

--- a/editors/sc-ide/forms/settings_sclang_project.ui
+++ b/editors/sc-ide/forms/settings_sclang_project.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
- <class>SclangConfigPage</class>
- <widget class="QWidget" name="SclangConfigPage">
+ <class>SclangProjectConfigPage</class>
+ <widget class="QWidget" name="SclangProjectConfigPage">
   <property name="geometry">
    <rect>
     <x>0</x>
@@ -37,55 +37,12 @@
       <item row="1" column="1">
        <widget class="ScIDE::PathChooserWidget" name="runtimeDir"/>
       </item>
-      <item row="2" column="0">
+      <item row="2" column="0" colspan="2">
        <widget class="QLabel" name="activeConfigFileLabel">
         <property name="text">
-         <string>Active config file:</string>
+         <string>Current Project:</string>
         </property>
        </widget>
-      </item>
-      <item row="2" column="1">
-       <layout class="QHBoxLayout" name="horizontalLayout">
-        <item>
-         <widget class="QComboBox" name="activeConfigFileComboBox">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QToolButton" name="sclang_add_configfile">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="toolTip">
-           <string>Save a new config file</string>
-          </property>
-          <property name="text">
-           <string>+</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QToolButton" name="sclang_remove_configfile">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="text">
-           <string>-</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
       </item>
      </layout>
     </widget>
@@ -102,7 +59,7 @@
       </sizepolicy>
      </property>
      <property name="title">
-      <string>Interpreter Options (stored in current active config file)</string>
+      <string>Interpreter Options (stored in current project file)</string>
      </property>
      <property name="flat">
       <bool>false</bool>
@@ -213,7 +170,7 @@
        </widget>
       </item>
       <item row="4" column="1">
-       <layout class="QHBoxLayout" name="interpreter_options">
+       <layout class="QHBoxLayout" name="horizontalLayout_2">
         <item>
          <widget class="QCheckBox" name="sclang_post_inline_warnings">
           <property name="text">

--- a/editors/sc-ide/widgets/file_tree.cpp
+++ b/editors/sc-ide/widgets/file_tree.cpp
@@ -1,0 +1,75 @@
+/*
+    SuperCollider Qt IDE
+    Copyright (c) 2012 Jakob Leben & Tim Blechmann & Miguel Negrão
+    http://www.audiosynth.com
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
+*/
+
+#include "file_tree.hpp"
+#include "../core/doc_manager.hpp"
+
+#include <QApplication>
+#include <QFileSystemModel>
+#include <QDebug>
+
+namespace ScIDE {
+
+FileTreeWidget::FileTreeWidget(QWidget * parent):
+    QTreeView(parent)
+{
+    setFrameShape( QFrame::NoFrame );
+    mModel.setRootPath(QDir::currentPath());
+    setModel(&mModel);
+    hideColumn(1);
+    hideColumn(2);
+    hideColumn(3);
+    setProperty("headerHidden", true);
+
+    connect(this, SIGNAL(doubleClicked(QModelIndex)),
+        this, SLOT(onItemDoubleClicked(QModelIndex)));
+}
+
+void FileTreeWidget::onItemDoubleClicked(const QModelIndex& index)
+{
+  QString path = mModel.filePath(index);
+  qDebug() << path;
+  QFileInfo info(path);
+  QString ext = info.suffix();
+  if (ext == "sc" || ext == "scd" || ext == "schelp" || ext == "txt" || ext == "yaml")
+    Q_EMIT( clicked(path) );
+}
+
+void FileTreeWidget::setRoot(const QString& path)
+{
+    mModel.setRootPath(path);
+    setRootIndex(mModel.index(path));
+}
+
+FileTreeDocklet::FileTreeDocklet(QWidget* parent):
+    Docklet(tr("File Tree"), parent),
+    mFileTree(new FileTreeWidget())
+{
+    setAllowedAreas(Qt::LeftDockWidgetArea | Qt::RightDockWidgetArea);
+    setWidget(mFileTree);
+}
+
+void FileTreeDocklet::setRoot(const QString &dir, const QString &title)
+{
+    tree()->setRoot(dir);
+    toolBar()->setTitle(title);
+}
+
+} // namespace ScIDE

--- a/editors/sc-ide/widgets/file_tree.hpp
+++ b/editors/sc-ide/widgets/file_tree.hpp
@@ -34,7 +34,7 @@ class FileTreeWidget : public QTreeView
     Q_OBJECT
 
 public:
-    FileTreeWidget(QWidget * parent = 0);
+    explicit FileTreeWidget(QWidget * parent = 0);
     void setRoot(const QString& path);
 
 public Q_SLOTS:
@@ -54,7 +54,7 @@ class FileTreeDocklet : public Docklet
 {
     Q_OBJECT
 public:
-    FileTreeDocklet(QWidget* parent = 0);
+    explicit FileTreeDocklet(QWidget* parent = 0);
     FileTreeWidget *tree() { return mFileTree; }
     void setRoot(const QString &dir, const QString &title);
 

--- a/editors/sc-ide/widgets/file_tree.hpp
+++ b/editors/sc-ide/widgets/file_tree.hpp
@@ -1,0 +1,67 @@
+/*
+    SuperCollider Qt IDE
+    Copyright (c) 2012 Jakob Leben & Tim Blechmann & Miguel Negrão
+    http://www.audiosynth.com
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
+*/
+
+#ifndef SCIDE_WIDGETS_FILE_TREE_HPP_INCLUDED
+#define SCIDE_WIDGETS_FILE_TREE_HPP_INCLUDED
+
+#include "util/docklet.hpp"
+
+#include <QTreeView>
+#include <QSignalMapper>
+#include <QFileSystemModel>
+
+namespace ScIDE {
+
+class FileTreeWidget : public QTreeView
+{
+    Q_OBJECT
+
+public:
+    FileTreeWidget(QWidget * parent = 0);
+    void setRoot(const QString& path);
+
+public Q_SLOTS:
+    void onItemDoubleClicked(const QModelIndex& index);
+
+Q_SIGNALS:
+    void clicked( const QString & path );
+
+protected:
+    virtual QSize sizeHint() const { return QSize(200,200); }
+
+private:
+    QFileSystemModel mModel;
+};
+
+class FileTreeDocklet : public Docklet
+{
+    Q_OBJECT
+public:
+    FileTreeDocklet(QWidget* parent = 0);
+    FileTreeWidget *tree() { return mFileTree; }
+    void setRoot(const QString &dir, const QString &title);
+
+private:
+    FileTreeWidget *mFileTree;
+};
+
+} // namespace ScIDE
+
+#endif // SCIDE_WIDGETS_FILE_TREE_HPP_INCLUDED

--- a/editors/sc-ide/widgets/main_window.cpp
+++ b/editors/sc-ide/widgets/main_window.cpp
@@ -580,7 +580,6 @@ void MainWindow::createMenus()
     QMenuBar *menuBar;
     QMenu *menu;
     QMenu *submenu;
-    QAction *action;
 
     // On Mac, create a parent-less menu bar to be shared by all windows:
 #ifdef Q_OS_MAC

--- a/editors/sc-ide/widgets/settings/dialog.hpp
+++ b/editors/sc-ide/widgets/settings/dialog.hpp
@@ -27,9 +27,14 @@ namespace Ui {
     class ConfigDialog;
 }
 
-namespace ScIDE { namespace Settings {
+namespace ScIDE {
+
+struct Session;
+
+namespace Settings {
 
 class Manager;
+class GeneralPage;
 
 class Dialog : public QDialog
 {
@@ -37,7 +42,7 @@ class Dialog : public QDialog
 
 public:
 
-    Dialog( Manager *settings, QWidget * parent = 0 );
+    Dialog(Manager *settings, ScIDE::Session *session, bool projectOpenFromSession = false, bool projectOpenFromSettings = false, QWidget * parent = 0);
     ~Dialog();
 
 public Q_SLOTS:
@@ -48,11 +53,19 @@ public Q_SLOTS:
     void apply();
 
 Q_SIGNALS:
-    void storeRequest( Manager * );
-    void loadRequest( Manager * );
+    void storeRequest( Manager *, Session *, bool );
+    void loadRequest( Manager *, Session * );
+
+private slots:
+    void switchSclangPage(bool);
 
 private:
     Manager *mManager;
+    ScIDE::Session *mSession;
+    QWidget *sclangPage;
+    GeneralPage *generalPage;
+    bool projectOpenFromSession = false;
+    bool projectOpenFromSettings = false;
     Ui::ConfigDialog *ui;
 };
 

--- a/editors/sc-ide/widgets/settings/editor_page.cpp
+++ b/editors/sc-ide/widgets/settings/editor_page.cpp
@@ -21,6 +21,7 @@
 #include "editor_page.hpp"
 #include "ui_settings_editor.h"
 #include "../code_editor/highlighter.hpp"
+#include "../../core/session_manager.hpp"
 #include "../../core/settings/manager.hpp"
 #include "../../core/settings/theme.hpp"
 #include "../../core/main.hpp"
@@ -80,7 +81,7 @@ EditorPage::~EditorPage()
     qDeleteAll(mThemes);
 }
 
-void EditorPage::load( Manager *s )
+void EditorPage::load(Manager *s, Session *session)
 {
     s->beginGroup("IDE/editor");
 
@@ -242,7 +243,7 @@ void EditorPage::populateThemeList(const QString & sel)
              this, SLOT(updateTheme(QString)) );
 }
 
-void EditorPage::store( Manager *s )
+void EditorPage::store( Manager *s,  Session *session, bool useLanguageConfigFromSession)
 {
     s->beginGroup("IDE/editor");
 

--- a/editors/sc-ide/widgets/settings/editor_page.hpp
+++ b/editors/sc-ide/widgets/settings/editor_page.hpp
@@ -34,7 +34,11 @@ namespace Ui {
     class EditorConfigPage;
 }
 
-namespace ScIDE { namespace Settings {
+namespace ScIDE {
+
+struct Session;
+
+namespace Settings {
 
 class Manager;
 
@@ -47,8 +51,8 @@ public:
     ~EditorPage();
 
 public Q_SLOTS:
-    void load( Manager * );
-    void store( Manager * );
+    void load( Manager *, Session *);
+    void store( Manager *, Session *, bool);
 
 private Q_SLOTS:
     void onCurrentTabChanged(int);

--- a/editors/sc-ide/widgets/settings/general_page.cpp
+++ b/editors/sc-ide/widgets/settings/general_page.cpp
@@ -20,6 +20,7 @@
 
 #include "general_page.hpp"
 #include "ui_settings_general.h"
+#include "../../core/session_manager.hpp"
 #include "../../core/settings/manager.hpp"
 
 Q_DECLARE_METATYPE(QAction*)
@@ -33,8 +34,14 @@ GeneralPage::GeneralPage(QWidget *parent) :
 {
     ui->setupUi(this);
 
+    ui->fileTreeRootDir->setFileMode(QFileDialog::Directory);
+
     connect( ui->startSessionName, SIGNAL(textChanged(QString)),
              this, SLOT(onStartSessionNameChanged(QString)) );
+
+    connect( ui->useLanguageConfigFromSession, SIGNAL(clicked(bool)),
+             this, SLOT(emitUseLanguageConfigFromSessionChanged(bool)) );
+
 }
 
 GeneralPage::~GeneralPage()
@@ -42,7 +49,7 @@ GeneralPage::~GeneralPage()
     delete ui;
 }
 
-void GeneralPage::load( Manager *settings )
+void GeneralPage::load( Manager *settings, Session *session)
 {
     QString startSessionName = settings->value("IDE/startWithSession").toString();
     if (startSessionName.isEmpty())
@@ -53,9 +60,11 @@ void GeneralPage::load( Manager *settings )
         ui->startNamedSessionOption->setChecked(true);
         ui->startSessionName->setText(startSessionName);
     }
+    ui->useLanguageConfigFromSession->setChecked(settings->value("IDE/useLanguageConfigFromSession").toBool());
+    ui->fileTreeRootDir->setText(settings->value("IDE/fileTreeRoot").toString());
 }
 
-void GeneralPage::store( Manager *settings )
+void GeneralPage::store( Manager *settings, Session *session, bool useLanguageConfigFromSession)
 {
     settings->beginGroup("IDE");
 
@@ -73,6 +82,10 @@ void GeneralPage::store( Manager *settings )
         settings->setValue("startWithSession", "");
     }
 
+    settings->setValue("useLanguageConfigFromSession", ui->useLanguageConfigFromSession->isChecked() );
+
+    settings->setValue("fileTreeRoot", ui->fileTreeRootDir->text());
+
     settings->endGroup();
 }
 
@@ -81,5 +94,16 @@ void GeneralPage::onStartSessionNameChanged( const QString & text )
     if (!text.isEmpty())
         ui->startNamedSessionOption->setChecked(true);
 }
+
+void GeneralPage::emitUseLanguageConfigFromSessionChanged(bool selected)
+{
+    Q_EMIT( useLanguageConfigFromSessionChanged(selected) );
+}
+
+bool GeneralPage::useLanguageConfigFromSessionChecked()
+{
+    return ui->useLanguageConfigFromSession->isChecked();
+}
+
 
 }} // namespace ScIDE::Settings

--- a/editors/sc-ide/widgets/settings/general_page.hpp
+++ b/editors/sc-ide/widgets/settings/general_page.hpp
@@ -27,7 +27,11 @@ namespace Ui {
     class GeneralConfigPage;
 }
 
-namespace ScIDE { namespace Settings {
+namespace ScIDE {
+
+struct Session;
+
+namespace Settings {
 
 class Manager;
 
@@ -38,13 +42,18 @@ class GeneralPage : public QWidget
 public:
     GeneralPage(QWidget *parent = 0);
     ~GeneralPage();
+    bool useLanguageConfigFromSessionChecked();
 
 public slots:
-    void load( Manager * );
-    void store( Manager * );
+    void load( Manager *, Session *);
+    void store( Manager *, Session *, bool);
+
+Q_SIGNALS:
+    void useLanguageConfigFromSessionChanged(bool);
 
 private slots:
     void onStartSessionNameChanged( const QString & text );
+    void emitUseLanguageConfigFromSessionChanged(bool);
 
 private:
     Ui::GeneralConfigPage *ui;

--- a/editors/sc-ide/widgets/settings/sclang_page.cpp
+++ b/editors/sc-ide/widgets/settings/sclang_page.cpp
@@ -27,30 +27,20 @@
 
 #include "sclang_page.hpp"
 #include "ui_settings_sclang.h"
+#include "../../core/session_manager.hpp"
 #include "../../core/settings/manager.hpp"
 #include "../../core/util/standard_dirs.hpp"
+#include "../core/main.hpp"
 
 #include <yaml-cpp/yaml.h>
 
 
 namespace ScIDE { namespace Settings {
 
-SclangPage::SclangPage(QWidget *parent) :
-    QWidget(parent),
-    ui( new Ui::SclangConfigPage )
+SclangPage::SclangPage(QWidget *parent) : SclangPageGeneric::SclangPageGeneric(parent)
 {
-    ui->setupUi(this);
-
     ui->sclang_add_configfile->setIcon( QIcon::fromTheme("list-add") );
     ui->sclang_remove_configfile->setIcon( QIcon::fromTheme("list-remove") );
-
-    ui->sclang_add_include->setIcon( QIcon::fromTheme("list-add") );
-    ui->sclang_remove_include->setIcon( QIcon::fromTheme("list-remove") );
-
-    ui->sclang_add_exclude->setIcon( QIcon::fromTheme("list-add") );
-    ui->sclang_remove_exclude->setIcon( QIcon::fromTheme("list-remove") );
-
-    ui->runtimeDir->setFileMode(QFileDialog::Directory);
 
     connect(ui->activeConfigFileComboBox, SIGNAL(currentIndexChanged(const QString &)), this, SLOT(changeSelectedLanguageConfig(const QString &)));
     connect(ui->sclang_add_configfile, SIGNAL(clicked()), this, SLOT(dialogCreateNewConfigFile()));
@@ -63,23 +53,16 @@ SclangPage::SclangPage(QWidget *parent) :
     connect(ui->sclang_remove_exclude, SIGNAL(clicked()), this, SLOT(removeExcludePath()));
 
     connect(ui->sclang_post_inline_warnings, SIGNAL(stateChanged(int)), this, SLOT(markSclangConfigDirty()));
+    connect(ui->sclang_exclude_default_paths, SIGNAL(stateChanged(int)), this, SLOT(markSclangConfigDirty()));
+
 }
 
-SclangPage::~SclangPage()
+void SclangPage::loadLocal(Manager *s, Session *session, bool useLanguageConfigFromSession)
 {
-    delete ui;
-}
-
-void SclangPage::load( Manager *s )
-{
-    s->beginGroup("IDE/interpreter");
-
-    ui->autoStart->setChecked( s->value("autoStart").toBool() );
-    ui->runtimeDir->setText( s->value("runtimeDir").toString() );
-    ui->sclang_standalone_mode->setChecked(s->value("standalone").toBool());
+    SclangPageGeneric::loadLocal(s);
 
     QStringList availConfigFiles = availableLanguageConfigFiles();
-    QString configSelectedLanguageConfigFile = s->value("configFile").toString();
+    QString configSelectedLanguageConfigFile = ((useLanguageConfigFromSession && session != nullptr) ? (SettingsInterface *) session : (SettingsInterface *) s)->getConfigFile();
 
     ui->activeConfigFileComboBox->clear();
     ui->activeConfigFileComboBox->addItems(availConfigFiles);
@@ -88,19 +71,40 @@ void SclangPage::load( Manager *s )
         ui->activeConfigFileComboBox->setCurrentIndex(index);
     selectedLanguageConfigFile = configSelectedLanguageConfigFile; // Happens after setting the combobox entries, since the code triggers stateChanged event.
 
+    readLanguageConfig();
+}
+
+void SclangPage::load(Manager *s, Session *session)
+{
+    s->beginGroup("IDE/interpreter");
+    ui->autoStart->setChecked( s->value("autoStart").toBool() );
+    ui->runtimeDir->setText( s->value("runtimeDir").toString() );
     s->endGroup();
+
+    QStringList availConfigFiles = availableLanguageConfigFiles();
+    QString configSelectedLanguageConfigFile = Main::instance()->getConfigFile();
+
+    ui->activeConfigFileComboBox->clear();
+    ui->activeConfigFileComboBox->addItems(availConfigFiles);
+    int index = availConfigFiles.indexOf(configSelectedLanguageConfigFile);
+    if (index != -1)
+        ui->activeConfigFileComboBox->setCurrentIndex(index);
+    selectedLanguageConfigFile = configSelectedLanguageConfigFile; // Happens after setting the combobox entries, since the code triggers stateChanged event.
 
     readLanguageConfig();
 }
 
-void SclangPage::store( Manager *s )
+void SclangPage::store( Manager *s, Session *session, bool useLanguageConfigFromSession)
 {
     s->beginGroup("IDE/interpreter");
     s->setValue("autoStart", ui->autoStart->isChecked());
     s->setValue("runtimeDir", ui->runtimeDir->text());
-    s->setValue("configFile", ui->activeConfigFileComboBox->currentText());
-    s->setValue("standalone", ui->sclang_standalone_mode->isChecked());
+    s->setValue("project", false);
     s->endGroup();
+
+    //NOTE: need to know in which settings to save, information which is not yet
+    // saved in the settings, so value passed directly via useLanguageConfigFromSession.
+    ((useLanguageConfigFromSession && session != nullptr) ? (SettingsInterface *) session : (SettingsInterface *) s)->setConfigFile(ui->activeConfigFileComboBox->currentText());
 
     writeLanguageConfig();
 }
@@ -142,115 +146,6 @@ void SclangPage::removeExcludePath()
 void SclangPage::changeSelectedLanguageConfig(const QString & configPath) {
     selectedLanguageConfigFile = configPath;
     readLanguageConfig();
-}
-
-void SclangPage::readLanguageConfig()
-{
-    // LATER: watch for changes
-
-    QString configFile = languageConfigFile();
-
-    QFileInfo configFileInfo(configFile);
-    const bool configFileExists = configFileInfo.exists();
-
-    if (!configFileExists)
-        return;
-
-    using namespace YAML;
-    try {
-        std::ifstream fin(configFile.toStdString());
-        Node doc = YAML::Load( fin );
-        if( doc ) {
-            const Node & includePaths = doc[ "includePaths" ];
-            if (includePaths && includePaths.IsSequence()) {
-                ui->sclang_include_directories->clear();
-                for( Node const & pathNode : includePaths ) {
-                    if (!pathNode.IsScalar())
-                        continue;
-                    std::string path = pathNode.as<std::string>();
-                    if( !path.empty() )
-                        ui->sclang_include_directories->addItem(QString(path.c_str()));
-                }
-            }
-
-            const Node & excludePaths = doc[ "excludePaths" ];
-            if (excludePaths && excludePaths.IsSequence()) {
-                ui->sclang_exclude_directories->clear();
-                for( Node const & pathNode : excludePaths ) {
-                    if (!pathNode.IsScalar())
-                        continue;
-                    std::string path = pathNode.as<std::string>();
-                    if( !path.empty() )
-                        ui->sclang_exclude_directories->addItem(QString(path.c_str()));
-                }
-            }
-
-            const Node & inlineWarnings = doc[ "postInlineWarnings" ];
-            if (inlineWarnings) {
-                try {
-                    bool postInlineWarnings = inlineWarnings.as<bool>();
-                    ui->sclang_post_inline_warnings->setChecked(postInlineWarnings);
-                } catch(...) {
-                    qDebug() << "Warning: Cannot parse config file entry \"postInlineWarnings\"";
-                }
-            }
-        }
-    } catch (std::exception &) {
-    }
-
-    sclangConfigDirty = false;
-}
-
-void SclangPage::writeLanguageConfig()
-{
-    if (!sclangConfigDirty)
-        return;
-
-    using namespace YAML; using std::ofstream;
-    Emitter out;
-    out.SetIndent(4);
-    out.SetMapFormat(Block);
-    out.SetSeqFormat(Block);
-    out.SetBoolFormat(TrueFalseBool);
-
-    out << BeginMap;
-
-    out << Key << "includePaths";
-    out << Value << BeginSeq;
-
-    for (int i = 0; i != ui->sclang_include_directories->count(); ++i)
-        out << ui->sclang_include_directories->item(i)->text().toStdString();
-    out << EndSeq;
-
-    out << Key << "excludePaths";
-    out << Value << BeginSeq;
-    for (int i = 0; i != ui->sclang_exclude_directories->count(); ++i)
-        out << ui->sclang_exclude_directories->item(i)->text().toStdString();
-    out << EndSeq;
-
-    out << Key << "postInlineWarnings";
-    out << Value << (ui->sclang_post_inline_warnings->checkState() == Qt::Checked);
-
-    out << EndMap;
-    ofstream fout(languageConfigFile().toStdString().c_str());
-    fout << out.c_str();
-
-    QMessageBox::information(this, tr("Sclang configuration file updated"),
-                             tr("The SuperCollider language configuration has been updated. "
-                                "Reboot the interpreter to apply the changes."));
-
-    sclangConfigDirty = false;
-}
-
-QString SclangPage::languageConfigFile()
-{
-    if (selectedLanguageConfigFile.isEmpty())
-    {
-        selectedLanguageConfigFile =
-                standardDirectory(ScConfigUserDir)
-                + "/" + QStringLiteral("sclang_conf.yaml");
-    }
-    return selectedLanguageConfigFile;
 }
 
 QStringList SclangPage::availableLanguageConfigFiles()
@@ -316,4 +211,5 @@ void SclangPage::dialogDeleteCurrentConfigFile()
         }
     }
 }
+
 }} // namespace ScIDE::Settings

--- a/editors/sc-ide/widgets/settings/sclang_page.cpp
+++ b/editors/sc-ide/widgets/settings/sclang_page.cpp
@@ -37,7 +37,7 @@
 
 namespace ScIDE { namespace Settings {
 
-SclangPage::SclangPage(QWidget *parent) : SclangPageGeneric::SclangPageGeneric(parent)
+SclangPage::SclangPage(QWidget *parent) : SclangPageGeneric(parent)
 {
     ui->sclang_add_configfile->setIcon( QIcon::fromTheme("list-add") );
     ui->sclang_remove_configfile->setIcon( QIcon::fromTheme("list-remove") );
@@ -62,7 +62,7 @@ void SclangPage::loadLocal(Manager *s, Session *session, bool useLanguageConfigF
     SclangPageGeneric::loadLocal(s);
 
     QStringList availConfigFiles = availableLanguageConfigFiles();
-    QString configSelectedLanguageConfigFile = ((useLanguageConfigFromSession && session != nullptr) ? (SettingsInterface *) session : (SettingsInterface *) s)->getConfigFile();
+    QString configSelectedLanguageConfigFile = ((useLanguageConfigFromSession && session != nullptr) ? static_cast<SettingsInterface *>(session) : static_cast<SettingsInterface *>(s))->getConfigFile();
 
     ui->activeConfigFileComboBox->clear();
     ui->activeConfigFileComboBox->addItems(availConfigFiles);
@@ -104,7 +104,7 @@ void SclangPage::store( Manager *s, Session *session, bool useLanguageConfigFrom
 
     //NOTE: need to know in which settings to save, information which is not yet
     // saved in the settings, so value passed directly via useLanguageConfigFromSession.
-    ((useLanguageConfigFromSession && session != nullptr) ? (SettingsInterface *) session : (SettingsInterface *) s)->setConfigFile(ui->activeConfigFileComboBox->currentText());
+    ((useLanguageConfigFromSession && session != nullptr) ? static_cast<SettingsInterface *>(session) : static_cast<SettingsInterface *>(s))->setConfigFile(ui->activeConfigFileComboBox->currentText());
 
     writeLanguageConfig();
 }

--- a/editors/sc-ide/widgets/settings/sclang_page.hpp
+++ b/editors/sc-ide/widgets/settings/sclang_page.hpp
@@ -40,7 +40,7 @@ class SclangPage : public SclangPageGeneric<Ui::SclangConfigPage>
     Q_OBJECT
 
 public:
-    SclangPage(QWidget *parent = 0);
+    explicit SclangPage(QWidget *parent = 0);
     void loadLocal(Manager *, Session *, bool);
 
 public Q_SLOTS:

--- a/editors/sc-ide/widgets/settings/sclang_page_generic.hpp
+++ b/editors/sc-ide/widgets/settings/sclang_page_generic.hpp
@@ -49,7 +49,7 @@ class SclangPageGeneric : public QWidget
 
 public:
 
-    SclangPageGeneric(QWidget *parent = 0) :
+    explicit SclangPageGeneric(QWidget *parent = 0) :
         QWidget(parent),
         ui( new ui_type )
     {

--- a/editors/sc-ide/widgets/settings/sclang_page_generic.hpp
+++ b/editors/sc-ide/widgets/settings/sclang_page_generic.hpp
@@ -1,0 +1,223 @@
+/*
+    SuperCollider Qt IDE
+    Copyright (c) 2012 Jakob Leben & Tim Blechmann
+    http://www.audiosynth.com
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
+*/
+
+#ifndef SCIDE_WIDGETS_SETTINGS_SCLANG_PAGE_GENERIC_HPP_INCLUDED
+#define SCIDE_WIDGETS_SETTINGS_SCLANG_PAGE_GENERIC_HPP_INCLUDED
+
+#include <QWidget>
+#include <QMessageBox>
+#include <QFileDialog>
+
+#include <fstream>
+
+#include <yaml-cpp/yaml.h>
+
+#include "sclang_page_generic.hpp"
+#include "../../core/session_manager.hpp"
+#include "../../core/settings/manager.hpp"
+#include "../../core/util/standard_dirs.hpp"
+#include "../core/main.hpp"
+
+namespace ScIDE {
+
+struct Session;
+
+namespace Settings {
+
+class Manager;
+
+template <class ui_type>
+class SclangPageGeneric : public QWidget
+{
+
+public:
+
+    SclangPageGeneric(QWidget *parent = 0) :
+        QWidget(parent),
+        ui( new ui_type )
+    {
+        ui->setupUi(this);
+
+        ui->sclang_add_include->setIcon( QIcon::fromTheme("list-add") );
+        ui->sclang_remove_include->setIcon( QIcon::fromTheme("list-remove") );
+
+        ui->sclang_add_exclude->setIcon( QIcon::fromTheme("list-add") );
+        ui->sclang_remove_exclude->setIcon( QIcon::fromTheme("list-remove") );
+
+        ui->runtimeDir->setFileMode(QFileDialog::Directory);
+    }
+
+    ~SclangPageGeneric()
+    {
+        delete ui;
+    }
+
+protected:
+
+    void loadLocal(Manager *s) {
+        s->beginGroup("IDE/interpreter");
+        ui->autoStart->setChecked( s->value("autoStart").toBool() );
+        ui->runtimeDir->setText( s->value("runtimeDir").toString() );
+        s->endGroup();
+    }
+
+    void load(Manager *s)
+    {
+        s->beginGroup("IDE/interpreter");
+        ui->autoStart->setChecked( s->value("autoStart").toBool() );
+        ui->runtimeDir->setText( s->value("runtimeDir").toString() );
+        s->endGroup();
+    }
+
+    void readLanguageConfig()
+    {
+        // LATER: watch for changes
+
+        QString configFile = languageConfigFile();
+
+        QFileInfo configFileInfo(configFile);
+        const bool configFileExists = configFileInfo.exists();
+
+        if (!configFileExists)
+            return;
+
+        using namespace YAML;
+        try {
+            std::ifstream fin(configFile.toStdString());
+            Node doc = YAML::Load( fin );
+            if ( doc ) {
+                const Node & includePaths = doc[ "includePaths" ];
+                if (includePaths && includePaths.IsSequence()) {
+                    ui->sclang_include_directories->clear();
+                    for( Node const & pathNode : includePaths ) {
+                        if (!pathNode.IsScalar())
+                            continue;
+                        std::string path = pathNode.as<std::string>();
+                        if ( !path.empty() )
+                            ui->sclang_include_directories->addItem(QString(path.c_str()));
+                    }
+                }
+
+                const Node & excludePaths = doc[ "excludePaths" ];
+                if (excludePaths && excludePaths.IsSequence()) {
+                    ui->sclang_exclude_directories->clear();
+                    for( Node const & pathNode : excludePaths ) {
+                        if (!pathNode.IsScalar())
+                            continue;
+                        std::string path = pathNode.as<std::string>();
+                        if ( !path.empty() )
+                            ui->sclang_exclude_directories->addItem(QString(path.c_str()));
+                    }
+                }
+
+                const Node & inlineWarnings = doc[ "postInlineWarnings" ];
+                if (inlineWarnings) {
+                    try {
+                        bool postInlineWarnings = inlineWarnings.as<bool>();
+                        ui->sclang_post_inline_warnings->setChecked(postInlineWarnings);
+                    } catch(...) {
+                        qDebug() << "Warning: Cannot parse config file entry \"postInlineWarnings\"";
+                    }
+                }
+
+                const Node & excludeDefaultPaths = doc["excludeDefaultPaths" ];
+                if (excludeDefaultPaths) {
+                    try {
+                        bool excludeDefaultPathsBool = excludeDefaultPaths.as<bool>();
+                        ui->sclang_exclude_default_paths->setChecked(excludeDefaultPathsBool);
+                    } catch(...) {
+                        qDebug() << "Warning: Cannot parse config file entry \"excludeDefaultPaths\"";
+                    }
+                }
+            }
+        } catch (std::exception &) {
+        }
+
+        sclangConfigDirty = false;
+    }
+
+    void writeLanguageConfig()
+    {
+        if (!sclangConfigDirty)
+            return;
+
+        using namespace YAML; using std::ofstream;
+        Emitter out;
+        out.SetIndent(4);
+        out.SetMapFormat(Block);
+        out.SetSeqFormat(Block);
+        out.SetBoolFormat(TrueFalseBool);
+
+        out << BeginMap;
+
+        out << Key << "includePaths";
+        out << Value << BeginSeq;
+
+        for (int i = 0; i != ui->sclang_include_directories->count(); ++i)
+            out << ui->sclang_include_directories->item(i)->text().toStdString();
+        out << EndSeq;
+
+        out << Key << "excludePaths";
+        out << Value << BeginSeq;
+        for (int i = 0; i != ui->sclang_exclude_directories->count(); ++i)
+            out << ui->sclang_exclude_directories->item(i)->text().toStdString();
+        out << EndSeq;
+
+        out << Key << "postInlineWarnings";
+        out << Value << (ui->sclang_post_inline_warnings->checkState() == Qt::Checked);
+
+        out << Key << "excludeDefaultPaths";
+        out << Value << (ui->sclang_exclude_default_paths->checkState() == Qt::Checked);
+
+        writeAddExtraFields(out);
+
+        out << EndMap;
+        ofstream fout(languageConfigFile().toStdString().c_str());
+        fout << out.c_str();
+
+        QMessageBox::information(this, tr("Sclang configuration file updated"),
+                                 tr("The SuperCollider language configuration has been updated. "
+                                    "Reboot the interpreter to apply the changes."));
+
+        sclangConfigDirty = false;
+    }
+
+    virtual void writeAddExtraFields(YAML::Emitter &out) = 0;
+
+    QString languageConfigFile()
+    {
+        if (selectedLanguageConfigFile.isEmpty())
+        {
+            selectedLanguageConfigFile =
+                    standardDirectory(ScConfigUserDir)
+                    + "/" + QStringLiteral("sclang_conf.yaml");
+        }
+        return selectedLanguageConfigFile;
+    }
+
+    ui_type *ui;
+
+    bool sclangConfigDirty;
+    QString selectedLanguageConfigFile;
+};
+
+}} // namespace ScIDE::Settings
+
+#endif // SCIDE_WIDGETS_SETTINGS_SCLANG_PAGE_GENERIC_HPP_INCLUDED

--- a/editors/sc-ide/widgets/settings/sclang_project_page.cpp
+++ b/editors/sc-ide/widgets/settings/sclang_project_page.cpp
@@ -38,7 +38,7 @@
 
 namespace ScIDE { namespace Settings {
 
-SclangProjectPage::SclangProjectPage(QWidget *parent) : SclangPageGeneric<Ui::SclangProjectConfigPage>::SclangPageGeneric(parent)
+SclangProjectPage::SclangProjectPage(QWidget *parent) : SclangPageGeneric(parent)
 {
     connect(ui->sclang_add_include, SIGNAL(clicked()), this, SLOT(addIncludePath()));
     connect(ui->sclang_add_exclude, SIGNAL(clicked()), this, SLOT(addExcludePath()));
@@ -57,7 +57,9 @@ void SclangProjectPage::loadLocal( Manager *s, Session *session, bool useLanguag
 {
     SclangPageGeneric::loadLocal(s);
 
-    selectedLanguageConfigFile = ((useLanguageConfigFromSession && session != nullptr) ? (SettingsInterface *) session : (SettingsInterface *) s)->getConfigFile();
+    selectedLanguageConfigFile = ((useLanguageConfigFromSession && session != nullptr) ?
+                                      static_cast<SettingsInterface *>(session)
+                                    : static_cast<SettingsInterface *>(s))->getConfigFile();
     QString tempLanguageConfigFileDir = QFileInfo(selectedLanguageConfigFile).canonicalPath();
     qSelectedLanguageConfigFileDir = QDir(tempLanguageConfigFileDir);
     selectedLanguageConfigFileDir = tempLanguageConfigFileDir.toStdString();

--- a/editors/sc-ide/widgets/settings/sclang_project_page.cpp
+++ b/editors/sc-ide/widgets/settings/sclang_project_page.cpp
@@ -1,0 +1,146 @@
+/*
+    SuperCollider Qt IDE
+    Copyright (c) 2012 Jakob Leben & Tim Blechmann
+    http://www.audiosynth.com
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
+*/
+
+#include <QDebug>
+#include <QMessageBox>
+#include <QInputDialog>
+#include <QFile>
+#include <QDir>
+
+#include <fstream>
+
+#include "sclang_project_page.hpp"
+#include "ui_settings_sclang_project.h"
+#include "../../core/session_manager.hpp"
+#include "../../core/settings/manager.hpp"
+#include "../../core/util/standard_dirs.hpp"
+#include "../core/main.hpp"
+
+#include "yaml-cpp/yaml.h"
+
+
+namespace ScIDE { namespace Settings {
+
+SclangProjectPage::SclangProjectPage(QWidget *parent) : SclangPageGeneric<Ui::SclangProjectConfigPage>::SclangPageGeneric(parent)
+{
+    connect(ui->sclang_add_include, SIGNAL(clicked()), this, SLOT(addIncludePath()));
+    connect(ui->sclang_add_exclude, SIGNAL(clicked()), this, SLOT(addExcludePath()));
+
+    connect(ui->sclang_remove_include, SIGNAL(clicked()), this, SLOT(removeIncludePath()));
+    connect(ui->sclang_remove_exclude, SIGNAL(clicked()), this, SLOT(removeExcludePath()));
+
+    connect(ui->sclang_post_inline_warnings, SIGNAL(stateChanged(int)), this, SLOT(markSclangConfigDirty()));
+    connect(ui->sclang_exclude_default_paths, SIGNAL(stateChanged(int)), this, SLOT(markSclangConfigDirty()));
+
+}
+
+//NOTE: need to know in which settings to save, information which is not yet
+// saved in the settings, so value passed directly via useLanguageConfigFromSession.
+void SclangProjectPage::loadLocal( Manager *s, Session *session, bool useLanguageConfigFromSession)
+{
+    SclangPageGeneric::loadLocal(s);
+
+    selectedLanguageConfigFile = ((useLanguageConfigFromSession && session != nullptr) ? (SettingsInterface *) session : (SettingsInterface *) s)->getConfigFile();
+    QString tempLanguageConfigFileDir = QFileInfo(selectedLanguageConfigFile).canonicalPath();
+    qSelectedLanguageConfigFileDir = QDir(tempLanguageConfigFileDir);
+    selectedLanguageConfigFileDir = tempLanguageConfigFileDir.toStdString();
+
+    ui->activeConfigFileLabel->setText(QString("Current project file: ").append(selectedLanguageConfigFile));
+
+    readLanguageConfig();
+
+}
+
+void SclangProjectPage::load( Manager *s, Session *session)
+{
+    SclangPageGeneric::load(s);
+
+    selectedLanguageConfigFile = Main::instance()->getConfigFile();
+    QString tempLanguageConfigFileDir = QFileInfo(selectedLanguageConfigFile).canonicalPath();
+    qSelectedLanguageConfigFileDir = QDir(tempLanguageConfigFileDir);
+    selectedLanguageConfigFileDir = tempLanguageConfigFileDir.toStdString();
+    ui->activeConfigFileLabel->setText(QString("Current project file: ").append(selectedLanguageConfigFile));
+
+    readLanguageConfig();
+
+}
+
+void SclangProjectPage::store( Manager *s, Session *session, bool useLanguageConfigFromSession)
+{
+    s->beginGroup("IDE/interpreter");
+    s->setValue("autoStart", ui->autoStart->isChecked());
+    s->setValue("runtimeDir", ui->runtimeDir->text());
+    s->endGroup();
+
+    writeLanguageConfig();
+}
+
+void SclangProjectPage::doRelativeProject(std::function<void(QString)> func, QString path) {
+    if (path.size()) {
+        if ( path.size() >= selectedLanguageConfigFileDir.size() &&
+             std::equal( selectedLanguageConfigFileDir.begin(), selectedLanguageConfigFileDir.end(), path.begin() ) ) {
+            func(qSelectedLanguageConfigFileDir.relativeFilePath(path));
+        } else {
+            func(path);
+        }
+    }
+}
+
+void SclangProjectPage::addIncludePath()
+{
+    QString projectDir = QFileInfo(Main::instance()->getConfigFile()).dir().absolutePath();
+    QString path = QFileDialog::getExistingDirectory(this, tr("ScLang include directories"), projectDir);
+    doRelativeProject([this](QString p){ ui->sclang_include_directories->addItem(p); }, path);
+    sclangConfigDirty = true;
+}
+
+void SclangProjectPage::removeIncludePath()
+{
+    foreach (QListWidgetItem * item, ui->sclang_include_directories->selectedItems() ) {
+        ui->sclang_include_directories->removeItemWidget(item);
+        delete item;
+    }
+    sclangConfigDirty = true;
+}
+
+void SclangProjectPage::addExcludePath()
+{
+    QString projectDir = QFileInfo(Main::instance()->getConfigFile()).dir().absolutePath();
+    QString path = QFileDialog::getExistingDirectory(this, tr("ScLang exclude directories"), projectDir);
+    doRelativeProject([this](QString p){ ui->sclang_exclude_directories->addItem(p); }, path);
+    sclangConfigDirty = true;
+}
+
+void SclangProjectPage::removeExcludePath()
+{
+    foreach (QListWidgetItem * item, ui->sclang_exclude_directories->selectedItems() ) {
+        ui->sclang_exclude_directories->removeItemWidget(item);
+        delete item;
+    }
+    sclangConfigDirty = true;
+}
+
+void SclangProjectPage::writeAddExtraFields(YAML::Emitter &out)
+{
+    out << YAML::Key << "project";
+    out << YAML::Value << true;
+}
+
+}} // namespace ScIDE::Settings

--- a/editors/sc-ide/widgets/settings/sclang_project_page.hpp
+++ b/editors/sc-ide/widgets/settings/sclang_project_page.hpp
@@ -18,14 +18,16 @@
     Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
 */
 
-#ifndef SCIDE_WIDGETS_SETTINGS_SCLANG_PAGE_HPP_INCLUDED
-#define SCIDE_WIDGETS_SETTINGS_SCLANG_PAGE_HPP_INCLUDED
+#ifndef SCIDE_WIDGETS_SETTINGS_SCLANG_PROJECT_PAGE_HPP_INCLUDED
+#define SCIDE_WIDGETS_SETTINGS_SCLANG_PROJECT_PAGE_HPP_INCLUDED
 
-#include "sclang_page_generic.hpp"
+#include <QDir>
+#include <functional>
+
 #include <yaml-cpp/yaml.h>
 
 #include "sclang_page_generic.hpp"
-#include "ui_settings_sclang.h"
+#include "ui_settings_sclang_project.h"
 
 namespace ScIDE {
 
@@ -35,17 +37,17 @@ namespace Settings {
 
 class Manager;
 
-class SclangPage : public SclangPageGeneric<Ui::SclangConfigPage>
+class SclangProjectPage : public SclangPageGeneric<Ui::SclangProjectConfigPage>
 {
     Q_OBJECT
 
 public:
-    SclangPage(QWidget *parent = 0);
-    void loadLocal(Manager *, Session *, bool);
+    SclangProjectPage(QWidget *parent = 0);
+    void loadLocal( Manager *, Session *, bool);
 
 public Q_SLOTS:
-    void load(Manager *, Session *);
-    void store(Manager *, Session *, bool);
+    void load( Manager *, Session *);
+    void store( Manager *, Session *, bool);
 
 private Q_SLOTS:
     void addIncludePath();
@@ -53,14 +55,13 @@ private Q_SLOTS:
     void addExcludePath();
     void removeExcludePath();
     void markSclangConfigDirty() { sclangConfigDirty = true; }
-    void changeSelectedLanguageConfig(const QString & configPath);
-    void dialogCreateNewConfigFile();
-    void dialogDeleteCurrentConfigFile();
 
 private:
-    void writeAddExtraFields(YAML::Emitter &) override {}
-    QStringList availableLanguageConfigFiles();
+    void writeAddExtraFields(YAML::Emitter &) override;
+    void doRelativeProject(std::function<void(QString)> func, QString path);
 
+    std::string selectedLanguageConfigFileDir;
+    QDir qSelectedLanguageConfigFileDir;
 };
 
 }} // namespace ScIDE::Settings

--- a/editors/sc-ide/widgets/settings/sclang_project_page.hpp
+++ b/editors/sc-ide/widgets/settings/sclang_project_page.hpp
@@ -42,7 +42,7 @@ class SclangProjectPage : public SclangPageGeneric<Ui::SclangProjectConfigPage>
     Q_OBJECT
 
 public:
-    SclangProjectPage(QWidget *parent = 0);
+    explicit SclangProjectPage(QWidget *parent = 0);
     void loadLocal( Manager *, Session *, bool);
 
 public Q_SLOTS:

--- a/editors/sc-ide/widgets/settings/shortcuts_page.cpp
+++ b/editors/sc-ide/widgets/settings/shortcuts_page.cpp
@@ -20,6 +20,7 @@
 
 #include "shortcuts_page.hpp"
 #include "ui_settings_shortcuts.h"
+#include "../../core/session_manager.hpp"
 #include "../../core/settings/manager.hpp"
 #include "../../core/main.hpp"
 
@@ -64,7 +65,7 @@ ShortcutsPage::~ShortcutsPage()
     delete ui;
 }
 
-void ShortcutsPage::load( Manager *s )
+void ShortcutsPage::load( Manager *s, Session *session )
 {
     ui->actionTree->clear();
 
@@ -80,7 +81,7 @@ void ShortcutsPage::load( Manager *s )
     ui->actionTree->header()->resizeSections(QHeaderView::ResizeToContents);
 }
 
-void ShortcutsPage::store( Manager *s )
+void ShortcutsPage::store( Manager *s, Session *session, bool useLanguageConfigFromSession)
 {
     s->beginGroup("IDE/shortcuts");
 

--- a/editors/sc-ide/widgets/settings/shortcuts_page.hpp
+++ b/editors/sc-ide/widgets/settings/shortcuts_page.hpp
@@ -31,7 +31,11 @@ namespace Ui {
     class ShortcutConfigPage;
 }
 
-namespace ScIDE { namespace Settings {
+namespace ScIDE {
+
+struct Session;
+
+namespace Settings {
 
 class Manager;
 
@@ -44,8 +48,8 @@ public:
     ~ShortcutsPage();
 
 public Q_SLOTS:
-    void load( Manager * );
-    void store( Manager * );
+    void load( Manager *, Session *);
+    void store( Manager *, Session *, bool);
     void filterBy( const QString & );
 
 private Q_SLOTS:

--- a/editors/sc-ide/widgets/util/docklet.cpp
+++ b/editors/sc-ide/widgets/util/docklet.cpp
@@ -60,6 +60,7 @@ void DocketToolButton::mousePressEvent(QMouseEvent *event)
 
 
 DockletToolBar::DockletToolBar(const QString &title)
+    :titleLabel(new QLabel(title))
 {
     setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
 
@@ -73,7 +74,6 @@ DockletToolBar::DockletToolBar(const QString &title)
     optionsBtn->setToolButtonStyle( Qt::ToolButtonIconOnly );
     optionsBtn->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Minimum);
 
-    QLabel *titleLabel = new QLabel(title);
     titleLabel->setMargin(5);
     titleLabel->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
 

--- a/editors/sc-ide/widgets/util/docklet.hpp
+++ b/editors/sc-ide/widgets/util/docklet.hpp
@@ -26,6 +26,7 @@
 #include <QMouseEvent>
 #include <QToolButton>
 #include <QWidget>
+#include <QLabel>
 
 namespace ScIDE {
 
@@ -51,10 +52,13 @@ public:
     void addAction (QAction *action);
     void addWidget (QWidget *widget, int stretch = 0 );
     QMenu *optionsMenu () { return mOptionsMenu; }
+    void setTitle(const QString& title) { titleLabel->setText(title); }
 
 protected:
     virtual void paintEvent( QPaintEvent *event );
     QMenu *mOptionsMenu;
+private:
+    QLabel *titleLabel;
 };
 
 class Docklet : public QObject

--- a/include/lang/SC_LanguageClient.h
+++ b/include/lang/SC_LanguageClient.h
@@ -80,9 +80,9 @@ public:
 
 	// library startup/shutdown
 	bool isLibraryCompiled();
-	void compileLibrary(bool standalone);
+	void compileLibrary();
 	void shutdownLibrary();
-	void recompileLibrary(bool standalone);
+	void recompileLibrary();
 
 	// interpreter access
 	void lock();

--- a/lang/LangPrimSource/PyrPrimitive.cpp
+++ b/lang/LangPrimSource/PyrPrimitive.cpp
@@ -3591,6 +3591,25 @@ static int prLanguageConfig_getCurrentConfigPath(struct VMGlobals * g, int numAr
 	return errNone;
 }
 
+static int prLanguageConfig_getCurrentConfigDirectory(struct VMGlobals * g, int numArgsPushed)
+{
+	PyrSlot *a = g->sp;
+	//return nil if no lang file was used.
+	if(gLanguageConfig->getConfigPath().empty()) {
+		SetNil(a);
+	} else {
+		const std::string& config_path_parent = SC_Codecvt::path_to_utf8_str(SC_LanguageConfig::getConfigFileDirectory());
+		PyrString* config_path_parent_pyrs = newPyrString(g->gc, config_path_parent.c_str(), 0, false);
+		if(config_path_parent_pyrs->size == 0) {
+			SetNil(a);
+		} else {
+			SetObject(a, config_path_parent_pyrs);
+		}
+	}
+
+	return errNone;
+}
+
 static int prLanguageConfig_writeConfigFile(struct VMGlobals * g, int numArgsPushed)
 {
 	PyrSlot *fileString = g->sp;
@@ -3634,6 +3653,19 @@ static int prLanguageConfig_setPostInlineWarnings(struct VMGlobals * g, int numA
 	return errNone;
 }
 
+static int prLanguageConfig_getExcludeDefaultPaths(struct VMGlobals * g, int numArgsPushed)
+{
+	PyrSlot *result = g->sp;
+	SetBool(result, gLanguageConfig->getExcludeDefaultPaths());
+	return errNone;
+}
+
+static int prLanguageConfig_getProjectOpen(struct VMGlobals * g, int numArgsPushed)
+{
+	PyrSlot *result = g->sp;
+	SetBool(result, gLanguageConfig->getProject());
+	return errNone;
+}
 
 static int prVersionMajor(struct VMGlobals * g, int numArgsPushed)
 {
@@ -4209,6 +4241,7 @@ void initPrimitives()
 
 	definePrimitive(base, index++, "_AppClock_SchedNotify", prAppClockSchedNotify, 1, 0);
 	definePrimitive(base, index++, "_LanguageConfig_getCurrentConfigPath", prLanguageConfig_getCurrentConfigPath, 1, 0);
+	definePrimitive(base, index++, "_LanguageConfig_getCurrentConfigDirectory", prLanguageConfig_getCurrentConfigDirectory, 1, 0);
 	definePrimitive(base, index++, "_LanguageConfig_getIncludePaths", prLanguageConfig_getIncludePaths, 1, 0);
 	definePrimitive(base, index++, "_LanguageConfig_getExcludePaths", prLanguageConfig_getExcludePaths, 1, 0);
 	definePrimitive(base, index++, "_LanguageConfig_addIncludePath", prLanguageConfig_addIncludePath, 2, 0);
@@ -4218,6 +4251,8 @@ void initPrimitives()
 	definePrimitive(base, index++, "_LanguageConfig_writeConfigFile", prLanguageConfig_writeConfigFile, 2, 0);
 	definePrimitive(base, index++, "_LanguageConfig_getPostInlineWarnings", prLanguageConfig_getPostInlineWarnings, 1, 0);
 	definePrimitive(base, index++, "_LanguageConfig_setPostInlineWarnings", prLanguageConfig_setPostInlineWarnings, 2, 0);
+	definePrimitive(base, index++, "_LanguageConfig_getExcludeDefaultPaths", prLanguageConfig_getExcludeDefaultPaths, 1, 0);
+	definePrimitive(base, index++, "_LanguageConfig_getProjectOpen", prLanguageConfig_getProjectOpen, 1, 0);
 
 	definePrimitive(base, index++, "_SC_VersionMajor", prVersionMajor, 1, 0);
 	definePrimitive(base, index++, "_SC_VersionMinor", prVersionMinor, 1, 0);

--- a/lang/LangSource/SCBase.h
+++ b/lang/LangSource/SCBase.h
@@ -57,7 +57,7 @@ SCLANG_DLLEXPORT_C void schedRun();
 SCLANG_DLLEXPORT_C void schedStop();
 SCLANG_DLLEXPORT_C void schedClear();
 
-SCLANG_DLLEXPORT_C bool compileLibrary(bool standalone);
+SCLANG_DLLEXPORT_C bool compileLibrary();
 SCLANG_DLLEXPORT_C void runLibrary(struct PyrSymbol* selector);
 SCLANG_DLLEXPORT_C void runInterpreter(struct VMGlobals *g, struct PyrSymbol *selector, int numArgsPushed);
 

--- a/lang/LangSource/SC_LanguageClient.cpp
+++ b/lang/LangSource/SC_LanguageClient.cpp
@@ -150,9 +150,9 @@ void SC_LanguageClient::shutdownRuntime()
 	cleanup_OSC();
 }
 
-void SC_LanguageClient::compileLibrary(bool standalone)
+void SC_LanguageClient::compileLibrary()
 {
-	::compileLibrary(standalone);
+	::compileLibrary();
 }
 
 extern void shutdownLibrary();
@@ -162,9 +162,9 @@ void SC_LanguageClient::shutdownLibrary()
 	flush();
 }
 
-void SC_LanguageClient::recompileLibrary(bool standalone)
+void SC_LanguageClient::recompileLibrary()
 {
-	compileLibrary(standalone);
+	compileLibrary();
 }
 
 void SC_LanguageClient::setCmdLine(const char* buf, size_t size)

--- a/lang/LangSource/SC_TerminalClient.cpp
+++ b/lang/LangSource/SC_TerminalClient.cpp
@@ -129,8 +129,7 @@ void SC_TerminalClient::printUsage()
 			"   -r                             Call Main.run on startup\n"
 			"   -s                             Call Main.stop on shutdown\n"
 			"   -u <network-port-number>       Set UDP listening port (default %d)\n"
-			"   -i <ide-name>                  Specify IDE name (for enabling IDE-specific class code, default \"%s\")\n"
-			"   -a                             Standalone mode (exclude SCClassLibrary and user and system Extensions folders from search path)\n",
+			"   -i <ide-name>                  Specify IDE name (for enabling IDE-specific class code, default \"%s\")\n",
 			memGrowBuf,
 			memSpaceBuf,
 			opt.mPort,
@@ -140,7 +139,7 @@ void SC_TerminalClient::printUsage()
 
 bool SC_TerminalClient::parseOptions(int& argc, char**& argv, Options& opt)
 {
-	const char* optstr = ":d:Dg:hl:m:rsu:i:av";
+	const char* optstr = ":d:Dg:hl:m:rsu:i:va";
 	int c;
 
 	// inhibit error reporting
@@ -197,8 +196,9 @@ bool SC_TerminalClient::parseOptions(int& argc, char**& argv, Options& opt)
 			case 'i':
 				SC_Filesystem::instance().setIdeName(optarg);
 				break;
+			//remove in version after version where this code is released ?
 			case 'a':
-				opt.mStandalone = true;
+				fprintf(stdout, "Warning: the standalone mode command line option (-a) has been deprecated. This functionality is available through the 'excludeDefaultPaths' key of the language config file.\n\n");
 				break;
 			default:
 				::post("%s: unknown error (getopt)\n", getName());
@@ -256,13 +256,13 @@ int SC_TerminalClient::run(int argc, char** argv)
 	// read library configuration file
 	if (opt.mLibraryConfigFile)
 		SC_LanguageConfig::setConfigPath(opt.mLibraryConfigFile);
-	SC_LanguageConfig::readLibraryConfig(opt.mStandalone);
+	SC_LanguageConfig::readLibraryConfig();
 
 	// initialize runtime
 	initRuntime(opt);
 
 	// startup library
-	compileLibrary(opt.mStandalone);
+	compileLibrary();
 
 	// enter main loop
 	if (codeFile) executeFile(codeFile);
@@ -292,7 +292,7 @@ int SC_TerminalClient::run(int argc, char** argv)
 
 void SC_TerminalClient::recompileLibrary()
 {
-    SC_LanguageClient::recompileLibrary(mOptions.mStandalone);
+	SC_LanguageClient::recompileLibrary();
 }
 
 void SC_TerminalClient::quit(int code)

--- a/lang/LangSource/SC_TerminalClient.h
+++ b/lang/LangSource/SC_TerminalClient.h
@@ -65,7 +65,6 @@ public:
 			  mDaemon(false),
 			  mCallRun(false),
 			  mCallStop(false),
-			  mStandalone(false),
 			  mArgc(0),
 			  mArgv(0)
 		{ }
@@ -74,7 +73,6 @@ public:
 		bool			mDaemon;
 		bool			mCallRun;
 		bool			mCallStop;
-		bool			mStandalone;
 		int				mArgc;
 		char**			mArgv;
 	};


### PR DESCRIPTION
This is a revised version of PR #1978. I've updated the code taking into account the changes added in #2861. The code has also been substantially changed with some features added.

## Overview
A supercollider project is an sclang config file which has an extra field "project: true". When this field is present sclang behaves differently:

- Relative paths in the config file are resolved relative to the directory containing the config file.
- Quarks download to the directory containing the config file.
- If present in the same directory as the config file a startup.scd is run at startup. The global startup.scd is not run.

This allows:
- Having self-contained projects which can be shared with other users by just sharing the directory containing the project file.
- Creating sclang standalones, that is, applications based on on supercollider and with a sclang Qt gui which can be installed and shared. (Currently the part of doing a system install or having a MacOS bundle is not implemented).




## Implementation notes:

### general

- It is recommended that when using a project to also activate the exclude default paths option, but this was not hardcoded for flexibility.
- The extension for project config files is by default .scproj

### sclang

- excluding default paths was removed from sclang command line options and moved to the config file. This introduces a change in the command line options of sclang, removing the -a option. The rationale is that with -a a lang file has to be used anyhow otherwise the class library will not compile as it doesn't find an SCClassLibrary, therefore might as well make that an option which is settable in the language config file which also makes it easier to manage. This also changes the header API to the state it was in before pull-request #1021, it is unfortunate going back and forth, but I do think it is better as it is in this pull-request.
- readLibraryConfigYAML: code was simplified abstracting repeated code using lambdas. In the future more simplification could be achieved by sharing this code between the ide and sclang, although there are issues when templated code interacts with lambdas in C++11.
- PyrLexer: gResourceDirectory, gSystemExtensionDirectory, gUserExtensionDirectory are initialized once in initPassOne(). In passOne_ProcessDir the corresponding strings are substituted by the actual paths and relative paths are converted to absolute (using the path of the language config file).
- Platform.sc: in project mode, if a start.scd file is present in the same directory as the config file it is used at startup instead of global start.scd file (which in any case is not used if exclude default paths is activated).

### IDE

- An option was added to store the language config in the sessions (disabled by default). This can be changed in the settings dialog. It allows having a different project or config file associated with each session.
- Changing from storing lang in session or settings will update dialog and guis while still in the dialog (without doing apply). The method void Dialog::switchSclangPage(bool useLanguageConfigFromSession) is used in the preference panes because that choice is still not commited to the QSettings object.
- Settings wraps a QSettings and session inherits from QSettings, but they both follow the same interface. This was formalized using an abstract class SettingsInterface from which both inherit. This contributes to very significant simplification of code dealing with fetching and writting the langauge config in either settings or session. This also allowed removing some templates from a couple of methods.
- A filesystem tree view was added to show the contents of the project directory.
- sclang_page_generic.hpp: both project and non project pages are very similar, therefore a class was created which includes common functionality. This class is templated on the type of the UI class which corresponds to the ui form.
- verifyProjectStatusMatchesConfigFile(): At startup and when changing sessions the config files (in the global config or in the session, depending on the current option) are checked to see detect if they of project type.
- When a project is open this is reflected in the title bar, sclang dialog page, Quarks gui and project file tree.
- When closing a project the selected config file goes back to the previous non-project config file (which is saved in the settings).

### Quarks

- In Quarks.sc relative paths are converted to absolute paths, in sclang c++ code they are converted from absolute to relative paths when part of a project. When adding a quark in project mode the absolute path will be passed to sclang, it is then converted to a relative path. This ensures that when a project directory is moved to a different path, the included and excluded folders which are part of the project are still found.

### Standalone

An sclang standalone consists of
- A project file.
- sclang and scsynth binaries
- plugins
- synthdefs
- class files
- quarks
- start.scd: for startup code
- start: a start script just calls 'sclang -l configfile.yaml'.

There is a template (without binaries) available at https://github.com/miguel-negrao/scStandalone.

## Testing

- There is test project available at https://github.com/miguel-negrao/TestSCProject

How to test this PR:
- create a new project, add paths in settings, install quarks.
- close project
- activate in the settings dialog the option for saving config file in sessions.
- create different sessions, open a project in some sessions and use a different config file in others. Change sessions.
- open project, close ide. Change project to false in the text file. Open ide again, confirm that it doesn't open as project and the current config file is last non-project config file.
