### PR TITLE
Server.sc: Properly format g_new messages to server

### DIFF
--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -740,14 +740,14 @@ Server {
 	defaultGroupID { ^defaultGroup.nodeID }
 
 	sendDefaultGroups {
-		defaultGroups.do { |defGrp|
-			this.sendMsg("/g_new", defGrp.nodeID, 0, 0);
+		defaultGroups.do { |group|
+			this.sendMsg("/g_new", group.nodeID, 0, 0);
 		};
 	}
 
 	sendDefaultGroupsForClientIDs { |clientIDs|
-		defaultGroups[clientIDs].do { |defGrp|
-			this.sendMsg("/g_new", defGrp.nodeID, 0, 0);
+		defaultGroups[clientIDs].do { |group|
+			this.sendMsg("/g_new", group.nodeID, 0, 0);
 		}
 	}
 

--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -741,13 +741,13 @@ Server {
 
 	sendDefaultGroups {
 		defaultGroups.do { |defGrp|
-			this.sendMsg("/g_new", defGrp.nodeID);
+			this.sendMsg("/g_new", defGrp.nodeID, 0, 0);
 		};
 	}
 
 	sendDefaultGroupsForClientIDs { |clientIDs|
 		defaultGroups[clientIDs].do { |defGrp|
-			this.sendMsg("/g_new", defGrp.nodeID);
+			this.sendMsg("/g_new", defGrp.nodeID, 0, 0);
 		}
 	}
 


### PR DESCRIPTION
According to the server command reference, these messages take triples of ints (ID, action, target). Because of supernova's implementation of this command, it treats these as badly formed and throws an exception.

I just added the missing args according to the older version of this code: 

https://github.com/supercollider/supercollider/blob/0b0b85fdfabb04d7e31521cb74757152e440e855/SCClassLibrary/Common/Control/Server.sc#L350-L355

Without this change, supernova is basically unusable on my machine.