### PR TITLE
node fixes: correct a call and improve variable names

### DIFF
--- a/SCClassLibrary/Common/Control/Node.sc
+++ b/SCClassLibrary/Common/Control/Node.sc
@@ -13,7 +13,7 @@ Node {
 			addReplace: 4,
 			h: 0,
 			t: 1,
-				// valid action numbers should stay the same
+			// valid action numbers should stay the same
 			0: 0, 1: 1, 2: 2, 3: 3, 4: 4
 		);
 	}
@@ -25,7 +25,7 @@ Node {
 
 	*actionNumberFor { |addAction = (\addToHead)| ^addActions[addAction] }
 
-	free { arg sendFlag=true;
+	free { arg sendFlag = true;
 		if(sendFlag, {
 			server.sendMsg(11, nodeID); //"/n_free"
 		});
@@ -36,7 +36,7 @@ Node {
 
 	freeMsg { ^[11, nodeID] }
 
-	run { arg flag=true;
+	run { arg flag = true;
 		server.sendMsg(12, nodeID, flag.binaryValue); //"/n_run"
 	}
 
@@ -61,13 +61,13 @@ Node {
 		args.pairsDo({ arg control, bus;
 			bus = bus.asBus;
 			switch(bus.rate)
-				{ \control } {
-					krVals.addAll([control.asControlInput, bus.index, bus.numChannels])
-				}
-				{ \audio } {
-					arVals.addAll([control.asControlInput, bus.index, bus.numChannels])
-				};
-				// no default case, ignore others
+			{ \control } {
+				krVals.addAll([control.asControlInput, bus.index, bus.numChannels])
+			}
+			{ \audio } {
+				arVals.addAll([control.asControlInput, bus.index, bus.numChannels])
+			};
+			// no default case, ignore others
 		});
 		if(krVals.size > 0, { result = result.add(["/n_mapn", nodeID] ++ krVals) });
 		if(arVals.size > 0, { result = result.add(["/n_mapan", nodeID] ++ arVals) });
@@ -96,7 +96,7 @@ Node {
 	}
 
 	*setnMsgArgs{ arg ... args;
-		var nargs=List.new;
+		var nargs = List.new;
 		args = args.asControlInput;
 		args.pairsDo { arg control, moreVals;
 			if(moreVals.isArray, {
@@ -105,7 +105,7 @@ Node {
 				nargs.addAll([control, 1, moreVals]);
 			});
 		};
-		^nargs;
+		^nargs
 	}
 
 	setnMsg { arg ... args;
@@ -145,18 +145,18 @@ Node {
 			# cmd, argnodeID, parent, prev, next, isGroup, head, tail = msg;
 			// assuming its me ... if(nodeID == argnodeID)
 			Post << if(isGroup == 1, "Group:" , "Synth:") << nodeID << Char.nl
-				<< "parent  : " << parent << Char.nl
-				<< "prev : " << prev << Char.nl
-				<< "next :" << next << Char.nl;
+			<< "parent  : " << parent << Char.nl
+			<< "prev : " << prev << Char.nl
+			<< "next :" << next << Char.nl;
 			if(isGroup==1, {
 				Post << "head :" << head << Char.nl
-					<< "tail :" << tail << Char.nl << Char.nl;
+				<< "tail :" << tail << Char.nl << Char.nl;
 			});
 		}, '/n_info', server.addr).oneShot;
 		server.sendMsg(46, nodeID) //"/n_query"
 	}
 
-	register { arg assumePlaying=false;
+	register { arg assumePlaying = false;
 		NodeWatcher.register(this, assumePlaying)
 	}
 
@@ -246,23 +246,23 @@ AbstractGroup : Node {
 
 	/** immediately sends **/
 	*new { arg target, addAction=\addToHead;
-		var group, server, addNum, inTarget;
-		inTarget = target.asTarget;
-		server = inTarget.server;
+		var group, server, addActionID;
+		target = target.asTarget;
+		server = target.server;
 		group = this.basicNew(server);
-		addNum = addActions[addAction];
-		if((addNum < 2), { group.group = inTarget; }, { group.group = inTarget.group; });
-		server.sendMsg(this.creationCmd, group.nodeID, addNum, inTarget.nodeID);
+		addActionID = addActions[addAction];
+		group.group = if(addActionID < 2) { target } { target.group };
+		server.sendMsg(this.creationCmd, group.nodeID, addActionID, target.nodeID);
 		^group
 	}
 
 	newMsg { arg target, addAction = \addToHead;
-		var addNum, inTarget;
+		var addActionID;
 		// if target is nil set to default group of server specified when basicNew was called
-		inTarget = (target ? server.defaultGroup).asTarget;
-		addNum = addActions[addAction];
-		(addNum < 2).if({ group = inTarget; }, { group = inTarget.group; });
-		^[this.class.creationCmd, nodeID, addNum, inTarget.nodeID]
+		target = (target ? server.defaultGroup).asTarget;
+		addActionID = addActions[addAction];
+		group = if(addActionID < 2) { target } { target.group };
+		^[this.class.creationCmd, nodeID, addActionID, target.nodeID]
 	}
 
 	// for bundling
@@ -362,25 +362,25 @@ AbstractGroup : Node {
 						if(msg[i + 1] >= 0, {
 							" group".postln;
 							if(msg[i + 1] > 0, { dumpFunc.value(msg[i + 1]) });
-							}, {
-								(" " ++ msg[i + 2]).postln; // defname
-								if(printControls, {
-									if(msg[i + 3] > 0, {
-										" ".post;
-										tabs.do({ "  ".post });
-									});
-									j = 0;
-									msg[i + 3].do({
-										" ".post;
-										if(msg[i + 4 + j].isMemberOf(Symbol), {
-											(msg[i + 4 + j] ++ ": ").post;
-										});
-										msg[i + 5 + j].post;
-										j = j + 2;
-									});
-									"\n".post;
+						}, {
+							(" " ++ msg[i + 2]).postln; // defname
+							if(printControls, {
+								if(msg[i + 3] > 0, {
+									" ".post;
+									tabs.do({ "  ".post });
 								});
+								j = 0;
+								msg[i + 3].do({
+									" ".post;
+									if(msg[i + 4 + j].isMemberOf(Symbol), {
+										(msg[i + 4 + j] ++ ": ").post;
+									});
+									msg[i + 5 + j].post;
+									j = j + 2;
+								});
+								"\n".post;
 							});
+						});
 					});
 					tabs = tabs - 1;
 				};
@@ -390,7 +390,9 @@ AbstractGroup : Node {
 			//				action.value(msg);
 			done = true;
 		}, '/g_queryTree.reply', server.addr).oneShot;
+
 		server.sendMsg("/g_queryTree", nodeID);
+
 		SystemClock.sched(3, {
 			if(done.not, {
 				resp.free;
@@ -417,35 +419,35 @@ Synth : Node {
 
 	/** immediately sends **/
 	*new { arg defName, args, target, addAction=\addToHead;
-		var synth, server, addNum, inTarget;
-		inTarget = target.asTarget;
-		server = inTarget.server;
-		addNum = addActions[addAction];
+		var synth, server, addActionID;
+		target = target.asTarget;
+		server = target.server;
+		addActionID = addActions[addAction];
 		synth = this.basicNew(defName, server);
 
-		if((addNum < 2), { synth.group = inTarget; }, { synth.group = inTarget.group; });
+		synth.group = if(addActionID < 2) { target } { target.group };
 		server.sendMsg(9, //"s_new"
-			defName, synth.nodeID, addNum, inTarget.nodeID,
+			defName, synth.nodeID, addActionID, target.nodeID,
 			*(args.asOSCArgArray)
 		);
 		^synth
 	}
 
 	*newPaused { arg defName, args, target, addAction=\addToHead;
-		var synth, server, addNum, inTarget;
-		inTarget = target.asTarget;
+		var synth, server, addActionID, inTarget;
+		target = target.asTarget;
 		server = inTarget.server;
-		addNum = addActions[addAction];
+		addActionID = addActions[addAction];
 		synth = this.basicNew(defName, server);
-		if((addNum < 2), { synth.group = inTarget; }, { synth.group = inTarget.group; });
-		server.sendBundle(nil, [9, defName, synth.nodeID, addNum, inTarget.nodeID] ++
+		synth.group = if(addActionID < 2) { inTarget } { target.group };
+		server.sendBundle(nil, [9, defName, synth.nodeID, addActionID, inTarget.nodeID] ++
 			args.asOSCArgArray, [12, synth.nodeID, 0]); // "s_new" + "/n_run"
 		^synth
 	}
 
 	*replace { arg nodeToReplace, defName, args, sameID=false;
-		var synth, server, addNum, inTarget, newNodeID;
-		if (sameID) { newNodeID = nodeToReplace.nodeID };
+		var synth, server, newNodeID;
+		if(sameID) { newNodeID = nodeToReplace.nodeID };
 		server = nodeToReplace.server;
 		synth = this.basicNew(defName, server, newNodeID);
 
@@ -465,12 +467,12 @@ Synth : Node {
 	}
 
 	newMsg { arg target, args, addAction = \addToHead;
-		var addNum, inTarget;
-		addNum = addActions[addAction];
+		var addActionID, inTarget;
+		addActionID = addActions[addAction];
 		// if target is nil set to default group of server specified when basicNew was called
-		inTarget = (target ? server.defaultGroup).asTarget;
-		(addNum < 2).if({ group = inTarget; }, { group = inTarget.group; });
-		^[9, defName, nodeID, addNum, inTarget.nodeID] ++ args.asOSCArgArray //"/s_new"
+		target = target.asTarget;
+		group = if(addActionID < 2) { inTarget } { target.group };
+		^[9, defName, nodeID, addActionID, inTarget.nodeID] ++ args.asOSCArgArray //"/s_new"
 	}
 
 	*after { arg aNode, defName, args;

--- a/SCClassLibrary/Common/Control/Node.sc
+++ b/SCClassLibrary/Common/Control/Node.sc
@@ -261,7 +261,7 @@ AbstractGroup : Node {
 	newMsg { arg target, addAction = \addToHead;
 		var addActionID;
 		// if target is nil set to default group of server specified when basicNew was called
-		target = (target ? server.defaultGroup).asTarget;
+		target = target.asTarget;
 		addActionID = addActions[addAction];
 		group = if(addActionID < 2) { target } { target.group };
 		^[this.class.creationCmd, nodeID, addActionID, target.nodeID]
@@ -436,13 +436,13 @@ Synth : Node {
 	}
 
 	*newPaused { arg defName, args, target, addAction=\addToHead;
-		var synth, server, addActionID, inTarget;
+		var synth, server, addActionID;
 		target = target.asTarget;
-		server = inTarget.server;
+		server = target.server;
 		addActionID = addActions[addAction];
 		synth = this.basicNew(defName, server);
-		synth.group = if(addActionID < 2) { inTarget } { target.group };
-		server.sendBundle(nil, [9, defName, synth.nodeID, addActionID, inTarget.nodeID] ++
+		synth.group = if(addActionID < 2) { target } { target.group };
+		server.sendBundle(nil, [9, defName, synth.nodeID, addActionID, target.nodeID] ++
 			args.asOSCArgArray, [12, synth.nodeID, 0]); // "s_new" + "/n_run"
 		^synth
 	}
@@ -469,12 +469,10 @@ Synth : Node {
 	}
 
 	newMsg { arg target, args, addAction = \addToHead;
-		var addActionID, inTarget;
-		addActionID = addActions[addAction];
-		// if target is nil set to default group of server specified when basicNew was called
+		var addActionID = addActions[addAction];
 		target = target.asTarget;
-		group = if(addActionID < 2) { inTarget } { target.group };
-		^[9, defName, nodeID, addActionID, inTarget.nodeID] ++ args.asOSCArgArray //"/s_new"
+		group = if(addActionID < 2) { target } { target.group };
+		^[9, defName, nodeID, addActionID, target.nodeID] ++ args.asOSCArgArray //"/s_new"
 	}
 
 	*after { arg aNode, defName, args;

--- a/SCClassLibrary/Common/Control/Node.sc
+++ b/SCClassLibrary/Common/Control/Node.sc
@@ -23,7 +23,9 @@ Node {
 		^super.newCopyArgs(nodeID ?? { server.nextNodeID }, server)
 	}
 
-	*actionNumberFor { |addAction = (\addToHead)| ^addActions[addAction] }
+	*actionNumberFor { arg addAction = (\addToHead);
+		^addActions[addAction]
+	}
 
 	free { arg sendFlag = true;
 		if(sendFlag, {

--- a/SCClassLibrary/Common/Control/Node.sc
+++ b/SCClassLibrary/Common/Control/Node.sc
@@ -153,8 +153,8 @@ Node {
 				<< "next:\t" << next << Char.nl;
 			if(isGroup == 1) {
 				Post
-				<< "head:\t" << head << Char.nl
-				<< "tail:\t" << tail << Char.nl << Char.nl;
+					<< "head:\t" << head << Char.nl
+					<< "tail:\t" << tail << Char.nl << Char.nl;
 			};
 		}, '/n_info', server.addr).oneShot;
 		server.sendMsg(46, nodeID) //"/n_query"

--- a/SCClassLibrary/Common/Control/Node.sc
+++ b/SCClassLibrary/Common/Control/Node.sc
@@ -399,7 +399,9 @@ AbstractGroup : Node {
 		})
 	}
 
-	*creationCmd { ^this.subclassMustImplementThisMethod }
+	*creationCmd {
+		^this.subclassResponsibility(thisMethod)
+	}
 
 }
 

--- a/SCClassLibrary/Common/Control/Node.sc
+++ b/SCClassLibrary/Common/Control/Node.sc
@@ -146,14 +146,16 @@ Node {
 			var cmd, argnodeID, parent, prev, next, isGroup, head, tail;
 			# cmd, argnodeID, parent, prev, next, isGroup, head, tail = msg;
 			// assuming its me ... if(nodeID == argnodeID)
-			Post << if(isGroup == 1, "Group:" , "Synth:") << nodeID << Char.nl
-			<< "parent  : " << parent << Char.nl
-			<< "prev : " << prev << Char.nl
-			<< "next :" << next << Char.nl;
-			if(isGroup==1, {
-				Post << "head :" << head << Char.nl
-				<< "tail :" << tail << Char.nl << Char.nl;
-			});
+			Post
+				<< if(isGroup == 1, "Group:\t" , "Synth:\t") << nodeID << Char.nl
+				<< "parent:\t" << parent << Char.nl
+				<< "prev:\t" << prev << Char.nl
+				<< "next:\t" << next << Char.nl;
+			if(isGroup == 1) {
+				Post
+				<< "head:\t" << head << Char.nl
+				<< "tail:\t" << tail << Char.nl << Char.nl;
+			};
 		}, '/n_info', server.addr).oneShot;
 		server.sendMsg(46, nodeID) //"/n_query"
 	}


### PR DESCRIPTION
- The method “subclassMustImplementThisMethod” has never existed.
- Renamed `addNum` to `addActionID` and replaced `inTarget` by a direct
conversion.
- brought code to a more standard form.