### PR TITLE
class library: server single boot task

### DIFF
--- a/SCClassLibrary/Common/Audio/SynthDesc.sc
+++ b/SCClassLibrary/Common/Audio/SynthDesc.sc
@@ -532,6 +532,10 @@ SynthDescLib {
 	}
 
 	*send { |server, tryToLoadReconstructedDefs = true|
+		if (server.hasBooted.not) {
+			"server % not booted, % cannot send SynthDefs.\n".format(server, this).warn;
+			^this
+		};
 		global.send(server, tryToLoadReconstructedDefs);
 	}
 

--- a/SCClassLibrary/Common/Audio/SynthDesc.sc
+++ b/SCClassLibrary/Common/Audio/SynthDesc.sc
@@ -514,7 +514,10 @@ SynthDescLib {
 			// since this is done automatically, w/o user action,
 			// it should not try to do things that will cause warnings
 			// (or errors, if one of the servers is not local)
-			this.send(server, false)
+			if (Server.postingBootInfo) {
+				"ServerBoot doing SynthDescLib.send to %\n".postf(server);
+			};
+			SynthDescLib.send(server, false)
 		}
 	}
 

--- a/SCClassLibrary/Common/Control/NodeWatcher.sc
+++ b/SCClassLibrary/Common/Control/NodeWatcher.sc
@@ -105,7 +105,7 @@ NodeWatcher : BasicNodeWatcher {
 	*doOnServerBoot {|aServer|
 		var serverName = aServer.name;
 		var serverNodeWatchers = all.removeAt(serverName);
-
+		if (Server.postingBootInfo) { "% running %.".postf(aServer, thisMethod.name) };
 		if (serverNodeWatchers.notNil) {
 			serverNodeWatchers.clear
 		}

--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -526,18 +526,21 @@ Server {
 		// turn notified off to allow setting clientID
 		statusWatcher.notified = false;
 
-		if (newMaxLogins.notNil) {
-			if (newMaxLogins != options.maxLogins) {
-				"%: scsynth has maxLogins % - adjusting my options accordingly.\n"
-				.postf(this, newMaxLogins);
+		// only set maxLogins if not internal server
+		if (inProcess.not) {
+			if (newMaxLogins.notNil) {
+				if (newMaxLogins != options.maxLogins) {
+					"%: scsynth has maxLogins % - adjusting my options accordingly.\n"
+					.postf(this, newMaxLogins);
+				} {
+					"%: scsynth maxLogins % match with my options.\n"
+					.postf(this, newMaxLogins);
+				};
+				options.maxLogins = numClients = newMaxLogins;
 			} {
-				"%: scsynth maxLogins % match with my options.\n"
+				"%: no maxLogins info from scsynth.\n"
 				.postf(this, newMaxLogins);
 			};
-			options.maxLogins = numClients = newMaxLogins;
-		} {
-			"%: no maxLogins info from scsynth.\n"
-			.postf(this, newMaxLogins);
 		};
 
 		if (newClientID == clientID) {
@@ -925,6 +928,7 @@ Server {
 			"booting internal".postln;
 			this.bootInProcess;
 			pid = thisProcess.pid;
+			onComplete.value;
 		} {
 			this.disconnectSharedMemory;
 			pid = unixCmd(program ++ options.asOptionsString(addr.port), { statusWatcher.quit(watchShutDown:false) });

--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -766,32 +766,22 @@ Server {
 	}
 
 	waitForBoot { |onComplete, limit = 100, onFailure|
+		if (Server.postingBootInfo) {
+			"*** waitForBoot calls doWhenBooted: ".postln;
+			"% .% onComplete: %\n".postf(this, thisMethod.name, onComplete);
+		};
+
+		if(this.serverRunning) {
+			^forkIfNeeded({ onComplete.value(this) }, AppClock)
+		};
+
 		// onFailure.true: why is this necessary?
 		// this.boot also calls doWhenBooted.
 		// doWhenBooted prints the normal boot failure message.
 		// if the server fails to boot, the failure error gets posted TWICE.
 		// So, we suppress one of them.
-		if (Server.postingBootInfo) {
-			"*** waitForBoot calls doWhenBooted: ".postln;
-			"% .% onComplete: %\n".postf(this, thisMethod.name, onComplete);
-		};
-		this.doWhenBooted(onComplete, limit, onFailure);
-		if(this.serverRunning.not) { this.boot(onFailure: true) };
-	}
-
-	doSetupItems { |onComplete, limit=100, onFailure|
-		// what to do with onFailure functions?
-		// put in onFailureFuncs list and evaluate after a timeout?
-		if (Server.postingBootInfo) {
-			"% .% - onComplete: %\n"
-			.postf(this, thisMethod.name, onComplete.cs);
-		};
-		if (this.serverRunning) {
-			if (Server.postingBootInfo) { "running onComplete directly.".postln };
-			forkIfNeeded { onComplete.value }
-		} {
-			this.addSetupItem(onComplete);
-		}
+		this.boot(onFailure: true);
+		^this.doWhenBooted(onComplete, limit, onFailure);
 	}
 
 	ifRunning { |func, failFunc|

--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -520,24 +520,24 @@ Server {
 		if (inProcess.not) {
 			if (newMaxLogins.notNil) {
 				if (newMaxLogins != options.maxLogins) {
-					"%: scsynth has maxLogins % - adjusting my options accordingly.\n"
+					"%: server process has maxLogins % - adjusting my options accordingly.\n"
 					.postf(this, newMaxLogins);
 				} {
-					"%: scsynth maxLogins % match with my options.\n"
+					"%: server process's maxLogins (%) matches with my options.\n"
 					.postf(this, newMaxLogins);
 				};
 				options.maxLogins = maxNumClients = newMaxLogins;
 			} {
-				"%: no maxLogins info from scsynth.\n"
+				"%: no maxLogins info from server process.\n"
 				.postf(this, newMaxLogins);
 			};
 		};
 
 		if (newClientID == clientID) {
-			"%: keeping clientID % as confirmed from scsynth.\n"
+			"%: keeping clientID (%) as confirmed by server process.\n"
 			.postf(this, newClientID);
 		} {
-			"%: setting clientID to %, as obtained from scsynth.\n"
+			"%: setting clientID to %, as obtained from server process.\n"
 			.postf(this, newClientID);
 		};
 		this.clientID = newClientID;

--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -353,8 +353,8 @@ Server {
 	remove {
 		all.remove(this);
 		named.removeAt(this.name);
-		ServerTree.objects.removeAt(this);
-		ServerBoot.objects.removeAt(this);
+		ServerTree.objects !? { ServerTree.objects.removeAt(this) };
+		ServerBoot.objects !? { ServerBoot.objects.removeAt(this) };
 	}
 
 	addr_ { |netAddr|
@@ -402,13 +402,16 @@ Server {
 		Task {
 			if (Server.postingBootInfo) { "prRun: % - %\n".postf(this, "ServerBoot.run") };
 			ServerBoot.run(this);
+			0.2.wait;
 			this.sync;
 			if (Server.postingBootInfo) { "prRun: % .%\n".postf(this, "initTree") };
 			this.initTree;
+			0.2.wait;
 			this.sync;
 			if (Server.postingBootInfo) { "prRun: % .%\n".postf(this, "tempBootItems.do") };
 			tempBootItems.do(_.value);
 			tempBootItems.clear;
+			0.2.wait;
 			this.sync;
 		}.play(AppClock);
 	}

--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -755,6 +755,7 @@ Server {
 		// if the server fails to boot, the failure error gets posted TWICE.
 		// So, we suppress one of them.
 		if (Server.postingBootInfo) {
+			"*** waitForBoot calls doWhenBooted: ".postln;
 			"% .% onComplete: %\n".postf(this, thisMethod.name, onComplete);
 		};
 		this.doWhenBooted(onComplete, limit, onFailure);

--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -367,9 +367,13 @@ Server {
 	}
 
 	initTree {
-		this.sendDefaultGroups;
-		tree.value(this);
-		Routine { ServerTree.run(this) }.play(AppClock);
+		forkIfNeeded {
+			this.sendDefaultGroups;
+			tree.value(this);
+			this.sync;
+			ServerTree.run(this);
+			this.sync;
+		};
 	}
 
 	/* id allocators */
@@ -542,6 +546,12 @@ Server {
 		};
 		this.clientID = newClientID;
 		statusWatcher.notified = true; // and lock again
+
+		forkIfNeeded {
+			this.initTree;
+			this.sync;
+			statusWatcher.notified = true; // and lock again
+		};
 	}
 
 	prHandleNotifyFailString {|failString, msg|

--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -410,10 +410,12 @@ Server {
 			if (Server.postingBootInfo) { "prRun: % .%\n".postf(this, "initTree") };
 			this.initTree;
 			this.sync;
-			this.bootStatus_(\running); // or maybe 'running'
-			// also set server.statusWatcher.serverRunning_(true) here;
+			this.bootStatus_(\running);
+			statusWatcher.serverRunning_(true);
+			this.changed;
+
 			if (Server.postingBootInfo) { "prRun: % .%\n".postf(this, "tempBootItems.do") };
-			while { tempBootItems.notNil } {
+			while { tempBootItems.notEmpty } {
 				tempBootItems.removeAt(0).value;
 			};
 		}.play(AppClock);
@@ -970,6 +972,7 @@ Server {
 					if(startAliveThread) { statusWatcher.start };
 				};
 			} {
+				statusWatcher.serverBooting = false;
 				"%.boot - server process rebooting.\n".postf(this);
 				this.reboot;
 			}

--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -1064,6 +1064,9 @@ Server {
 			"'/quit' sent\n".postln;
 		};
 
+		statusWatcher.serverRunning_(false);
+		this.changed(\serverRunning);
+
 		pid = nil;
 		sendQuit = nil;
 		maxNumClients = nil;

--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -406,9 +406,6 @@ Server {
 		};
 		clientID = val;
 		this.newAllocators;
-		if (statusWatcher.notNil and: { this.serverRunning }) {
-			this.initTree;
-		};
 	}
 
 	newAllocators {
@@ -904,7 +901,9 @@ Server {
 	}
 
 	bootInit { | recover = false |
-		if(recover) { this.newNodeAllocators } { this.newAllocators };
+		// if(recover) { this.newNodeAllocators } {
+		// 	"% calls newAllocators\n".postf(thisMethod);
+		// this.newAllocators };
 		if(dumpMode != 0) { this.sendMsg(\dumpOSC, dumpMode) };
 		if(sendQuit.isNil) {
 			sendQuit = this.inProcess or: { this.isLocal };

--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -378,15 +378,11 @@ Server {
 
 	/* id allocators */
 
-	isFullyBooted { ^this.serverRunning and: { this.notified } }
-
-	// clientID can be set while server is off,
-	// and is called from prHandleClientLoginInfoFromServer once after booting,
-	// clientID is locked while the server is running
+	// clientID is settable while server is off, and locked while server is running
+	// called from prHandleClientLoginInfoFromServer once after booting.
 	clientID_ { |val|
 		var failstr = "Server % couldn't set clientID to: % - %. clientID is still %.";
-
-		if (this.isFullyBooted) {
+		if (this.serverRunning) {
 			"%: setting clientID is locked after server is fully booted."
 			.postf(thisMethod);
 			^this
@@ -718,7 +714,7 @@ Server {
 		// doWhenBooted prints the normal boot failure message.
 		// if the server fails to boot, the failure error gets posted TWICE.
 		// So, we suppress one of them.
-		if(this.isFullyBooted.not) { this.boot(onFailure: true) };
+		if(this.serverRunning.not) { this.boot(onFailure: true) };
 		this.doWhenBooted(onComplete, limit, onFailure);
 	}
 

--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -411,6 +411,7 @@ Server {
 
 	prRunBootTask {
 		this.state_(\isSettingUp);
+		statusWatcher.serverBooting = false;
 
 		if (Server.postingBootInfo) { "%.%\n".postf(this, thisMethod.name) };
 		forkIfNeeded( {

--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -264,7 +264,7 @@ Server {
 	classvar <>local, <>internal, <default;
 	classvar <>named, <>all, <>program, <>sync_s = true;
 	classvar <>nodeAllocClass, <>bufferAllocClass, <>busAllocClass;
-	classvar <>postingBootInfo = true;
+	classvar <>postingBootInfo = false;
 
 	var <name, <addr, <clientID;
 	var <isLocal, <inProcess, <>sendQuit, <>bootAndQuitDisabled = false;
@@ -390,7 +390,7 @@ Server {
 
 	addBootItem { |item|
 		if (Server.postingBootInfo) {
-			"% .% (%).".postf(this, thisMethod.name, item.cs);
+			"% .% (%).\n".postf(this, thisMethod.name, item.cs);
 		};
 
 		this.removeBootItem(item);
@@ -400,13 +400,13 @@ Server {
 	prRunBootTask {
 		if (Server.postingBootInfo) { "%.%\n".postf(this, thisMethod.name) };
 		Task {
-			if (Server.postingBootInfo) { "prRun: %.%\n".postf(this, "ServerBoot.run") };
+			if (Server.postingBootInfo) { "prRun: % - %\n".postf(this, "ServerBoot.run") };
 			ServerBoot.run(this);
 			this.sync;
-			if (Server.postingBootInfo) { "prRun: %.%\n".postf(this, "initTree") };
+			if (Server.postingBootInfo) { "prRun: % .%\n".postf(this, "initTree") };
 			this.initTree;
 			this.sync;
-			if (Server.postingBootInfo) { "prRun: %.%\n".postf(this, "tempBootItems.do") };
+			if (Server.postingBootInfo) { "prRun: % .%\n".postf(this, "tempBootItems.do") };
 			tempBootItems.do(_.value);
 			tempBootItems.clear;
 			this.sync;
@@ -757,8 +757,8 @@ Server {
 		if (Server.postingBootInfo) {
 			"% .% onComplete: %\n".postf(this, thisMethod.name, onComplete);
 		};
-		if(this.serverRunning.not) { this.boot(onFailure: true) };
 		this.doWhenBooted(onComplete, limit, onFailure);
+		if(this.serverRunning.not) { this.boot(onFailure: true) };
 	}
 
 	doWhenBooted { |onComplete, limit=100, onFailure|

--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -434,7 +434,7 @@ Server {
 				"%: scsynth maxLogins % match with my options.\n"
 				.postf(this, newMaxLogins);
 			};
-			numClients = options.maxLogins = newMaxLogins;
+			options.maxLogins = numClients = newMaxLogins;
 		} {
 			"%: no maxLogins info from scsynth.\n"
 			.postf(this, newMaxLogins);

--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -321,7 +321,7 @@ Server {
 
 	init { |argName, argAddr, argOptions, argClientID|
 		this.addr = argAddr;
-		options = argOptions ? ServerOptions.new;
+		options = argOptions ?? { ServerOptions.new };
 
 		// set name to get readable posts from clientID set
 		name = argName.asSymbol;
@@ -353,7 +353,7 @@ Server {
 
 	}
 
-	numClients { ^numClients ? options.maxLogins }
+	numClients { ^numClients ?? { options.maxLogins } }
 
 	remove {
 		all.remove(this);

--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -896,6 +896,7 @@ Server {
 	peakCPU { ^statusWatcher.peakCPU }
 	sampleRate { ^statusWatcher.sampleRate }
 	actualSampleRate { ^statusWatcher.actualSampleRate }
+	hasBooted { ^statusWatcher.hasBooted }
 	serverRunning { ^statusWatcher.serverRunning }
 	serverBooting { ^statusWatcher.serverBooting }
 	unresponsive { ^statusWatcher.unresponsive }

--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -384,7 +384,7 @@ Server {
 
 	/* id allocators */
 
-	clientIDLocked { ^this.serverRunning and: { this.notified } }
+	isFullyBooted { ^this.serverRunning and: { this.notified } }
 
 	// clientID can be set while server is off,
 	// and is called from prHandleClientLoginInfoFromServer once after booting,
@@ -392,8 +392,8 @@ Server {
 	clientID_ { |val|
 		var failstr = "Server % couldn't set clientID to: % - %. clientID is still %.";
 
-		if (this.clientIDLocked) {
-			"%: setting clientID is locked while server is running."
+		if (this.isFullyBooted) {
+			"%: setting clientID is locked after server is fully booted."
 			.postf(thisMethod);
 			^this
 		};
@@ -722,7 +722,7 @@ Server {
 		// doWhenBooted prints the normal boot failure message.
 		// if the server fails to boot, the failure error gets posted TWICE.
 		// So, we suppress one of them.
-		if(this.serverRunning.not) { this.boot(onFailure: true) };
+		if(this.isFullyBooted.not) { this.boot(onFailure: true) };
 		this.doWhenBooted(onComplete, limit, onFailure);
 	}
 

--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -774,7 +774,7 @@ Server {
 		};
 		if (this.serverRunning) {
 			if (Server.postingBootInfo) { "running onComplete directly.".postln };
-			onComplete.value
+			forkIfNeeded { onComplete.value }
 		} {
 			this.addBootItem(onComplete);
 		}
@@ -982,7 +982,7 @@ Server {
 			"booting internal".postln;
 			this.bootInProcess;
 			pid = thisProcess.pid;
-			onComplete.value;
+			forkIfNeeded { onComplete.value };
 		} {
 			this.disconnectSharedMemory;
 			pid = unixCmd(program ++ options.asOptionsString(addr.port), { statusWatcher.quit(watchShutDown:false) });

--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -267,7 +267,7 @@ Server {
 
 	var <name, <addr, <clientID, <userSpecifiedClientID = false;
 	var <isLocal, <inProcess, <>sendQuit, <>remoteControlled;
-	var numClients; // maxLogins as sent from booted scsynth
+	var maxNumClients; // maxLogins as sent from booted scsynth
 
 	var <>options, <>latency = 0.2, <dumpMode = 0;
 
@@ -331,7 +331,7 @@ Server {
 
 		if(argClientID.notNil) {
 			userSpecifiedClientID = true;
-			if (argClientID >= this.numClients) {
+			if (argClientID >= this.maxNumClients) {
 				warn("% : user-specified clientID % is greater than maxLogins!"
 					"\nPlease adjust clientID or options.maxLogins."
 					.format(name, argClientID));
@@ -353,7 +353,7 @@ Server {
 
 	}
 
-	numClients { ^numClients ?? { options.maxLogins } }
+	maxNumClients { ^maxNumClients ?? { options.maxLogins } }
 
 	remove {
 		all.remove(this);
@@ -402,10 +402,10 @@ Server {
 			failstr.format(name, val.cs, "not an Integer", clientID).warn;
 			^this
 		};
-		if (val < 0 or: { val >= this.numClients }) {
+		if (val < 0 or: { val >= this.maxNumClients }) {
 			failstr.format(name,
 				val.cs,
-				"outside of allowed server.numClients range of 0 - %".format(this.numClients),
+				"outside of allowed server.maxNumClients range of 0 - %".format(this.maxNumClients),
 				clientID
 			).warn;
 			^this
@@ -433,7 +433,7 @@ Server {
 		nodeAllocator = nodeAllocClass.new(
 			clientID,
 			options.initialNodeID,
-			this.numClients
+			this.maxNumClients
 		);
 		// defaultGroup and defaultGroups depend on allocator,
 		// so always make them here:
@@ -447,8 +447,8 @@ Server {
 
 		var audioBusIOOffset = options.firstPrivateBus;
 
-		numControlPerClient = options.numControlBusChannels div: this.numClients;
-		numAudioPerClient = options.numAudioBusChannels - audioBusIOOffset div: this.numClients;
+		numControlPerClient = options.numControlBusChannels div: this.maxNumClients;
+		numAudioPerClient = options.numAudioBusChannels - audioBusIOOffset div: this.maxNumClients;
 
 		controlReservedOffset = options.reservedNumControlBusChannels;
 		controlBusClientOffset = numControlPerClient * clientID;
@@ -469,7 +469,7 @@ Server {
 	}
 
 	newBufferAllocators {
-		var numBuffersPerClient = options.numBuffers div: this.numClients;
+		var numBuffersPerClient = options.numBuffers div: this.maxNumClients;
 		var numReservedBuffers = options.reservedNumBuffers;
 		var bufferClientOffset = numBuffersPerClient * clientID;
 
@@ -536,7 +536,7 @@ Server {
 					"%: scsynth maxLogins % match with my options.\n"
 					.postf(this, newMaxLogins);
 				};
-				options.maxLogins = numClients = newMaxLogins;
+				options.maxLogins = maxNumClients = newMaxLogins;
 			} {
 				"%: no maxLogins info from scsynth.\n"
 				.postf(this, newMaxLogins);
@@ -798,7 +798,7 @@ Server {
 
 	// defaultGroups for all clients on this server:
 
-	allClientIDs { ^(0..this.numClients-1) }
+	allClientIDs { ^(0..this.maxNumClients-1) }
 
 	// keep defaultGroups for all clients on this server:
 	makeDefaultGroups {
@@ -1011,7 +1011,7 @@ Server {
 
 		pid = nil;
 		sendQuit = nil;
-		numClients = nil;
+		maxNumClients = nil;
 
 		if(scopeWindow.notNil) { scopeWindow.quit };
 		volume.freeSynth;

--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -265,7 +265,7 @@ Server {
 	classvar <>named, <>all, <>program, <>sync_s = true;
 	classvar <>nodeAllocClass, <>bufferAllocClass, <>busAllocClass;
 
-	var <name, <addr, <clientID, <userSpecifiedClientID = false;
+	var <name, <addr, <clientID;
 	var <isLocal, <inProcess, <>sendQuit, <>remoteControlled;
 	var maxNumClients; // maxLogins as sent from booted scsynth
 
@@ -328,16 +328,6 @@ Server {
 
 		// make statusWatcher before clientID, so .serverRunning works
 		statusWatcher = ServerStatusWatcher(server: this);
-
-		if(argClientID.notNil) {
-			userSpecifiedClientID = true;
-			if (argClientID >= this.maxNumClients) {
-				warn("% : user-specified clientID % is greater than maxLogins!"
-					"\nPlease adjust clientID or options.maxLogins."
-					.format(name, argClientID));
-				^nil
-			};
-		};
 
 		// go thru setter to test validity
 		this.clientID = argClientID ? 0;
@@ -547,15 +537,8 @@ Server {
 			"%: keeping clientID % as confirmed from scsynth.\n"
 			.postf(this, newClientID);
 		} {
-			if (userSpecifiedClientID.not) {
-				"%: setting clientID to %, as obtained from scsynth.\n"
-				.postf(this, newClientID);
-			} {
-				("% - userSpecifiedClientID % is not free!\n"
-					" Switching to free clientID obtained from scsynth: %.\n"
-					"If that is problematic, please set clientID by hand before booting.")
-				.format(this, clientID, newClientID).warn;
-			};
+			"%: setting clientID to %, as obtained from scsynth.\n"
+			.postf(this, newClientID);
 		};
 		this.clientID = newClientID;
 		statusWatcher.notified = true; // and lock again

--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -910,7 +910,7 @@ Server {
 	isBooting { ^statusWatcher.isBooting }
 	isSettingUp { ^statusWatcher.isSettingUp }
 	isReady { ^statusWatcher.isReady }
-	isQitting { ^statusWatcher.isQitting }
+	isQuitting { ^statusWatcher.isQitting }
 
 	startAliveThread { | delay=0.0 | statusWatcher.startAliveThread(delay) }
 	stopAliveThread { statusWatcher.stopAliveThread }

--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -400,13 +400,13 @@ Server {
 	prRunBootTask {
 		if (Server.postingBootInfo) { "%.%\n".postf(this, thisMethod.name) };
 		Task {
-			if (Server.postingBootInfo) { "%.%\n".postf(this, "ServerBoot.run") };
+			if (Server.postingBootInfo) { "prRun: %.%\n".postf(this, "ServerBoot.run") };
 			ServerBoot.run(this);
 			this.sync;
-			if (Server.postingBootInfo) { "%.%\n".postf(this, "initTree") };
+			if (Server.postingBootInfo) { "prRun: %.%\n".postf(this, "initTree") };
 			this.initTree;
 			this.sync;
-			if (Server.postingBootInfo) { "%.%\n".postf(this, "tempBootItems.do") };
+			if (Server.postingBootInfo) { "prRun: %.%\n".postf(this, "tempBootItems.do") };
 			tempBootItems.do(_.value);
 			tempBootItems.clear;
 			this.sync;

--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -311,6 +311,12 @@ Server {
 	}
 
 	*new { |name, addr, options, clientID|
+		var existing = Server.all.detect { |sv| sv.name == name };
+		if (existing.notNil) {
+			"Server(%) already exists, returning existing.\n"
+			.format(name).warn;
+			^existing
+		};
 		^super.new.init(name, addr, options, clientID)
 	}
 
@@ -943,7 +949,7 @@ Server {
 
 	// TODO: re-enable  recover and onFailure;
 	// also add timeout arg here?
-	boot { | startAliveThread = true, recover = false, onFailure |
+	bootOld { | startAliveThread = true, recover = false, onFailure |
 		// temp to keep boot working after changes for bootAlt
 		var appBooted, timeout = 5;
 
@@ -1009,7 +1015,7 @@ Server {
 		}
 	}
 
-	bootAlt { | startAliveThread = true, recover = false, onFailure, onComplete, timeout = 5 |
+	boot { | startAliveThread = true, recover = false, onFailure, onComplete, timeout = 5 |
 		// measure time for all boot steps:
 		var t0 = thisThread.seconds, now = { thisThread.seconds - t0 };
 		var pt = { |str=""| "t %: %".format(now.().round(0.01), str).postln; };

--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -372,8 +372,8 @@ Server {
 		}
 	}
 
-	bootStatus { ^statusWatcher.bootStatus }
-	bootStatus_ { |newStatus| statusWatcher.bootStatus_(newStatus) }
+	state { ^statusWatcher.state }
+	state_ { |newStatus| statusWatcher.state_(newStatus) }
 
 	initTree {
 		if (Server.postingBootInfo) { "% .%\n".postf(this, thisMethod.name) };
@@ -399,7 +399,7 @@ Server {
 	}
 
 	prRunBootTask {
-		this.bootStatus_(\doingSetup);
+		this.state_(\isSettingUp);
 
 		if (Server.postingBootInfo) { "%.%\n".postf(this, thisMethod.name) };
 		Task {
@@ -410,9 +410,9 @@ Server {
 			if (Server.postingBootInfo) { "prRun: % .%\n".postf(this, "initTree") };
 			this.initTree;
 			this.sync;
-			this.bootStatus_(\running);
+			this.state_(\isReady);
 			statusWatcher.serverRunning_(true);
-			this.changed;
+			this.changed(\serverRunning);
 
 			if (Server.postingBootInfo) { "prRun: % .%\n".postf(this, "tempBootItems.do") };
 			while { tempBootItems.notEmpty } {
@@ -956,7 +956,7 @@ Server {
 		if(this.serverRunning) { "server '%' already running".format(this.name).postln; ^this };
 		if(this.serverBooting) { "server '%' already booting".format(this.name).postln; ^this };
 
-		this.bootStatus = \booting;
+		this.state = \isBooting;
 		statusWatcher.serverBooting = true;
 
 		// if there is a server at my address, reboot.
@@ -1074,7 +1074,7 @@ Server {
 			^this
 		};
 
-		this.bootStatus_(\quitting);
+		this.state_(\isQuitting);
 
 		addr.sendMsg("/quit");
 
@@ -1107,7 +1107,7 @@ Server {
 		volume.freeSynth;
 		RootNode(this).freeAll;
 		this.newAllocators;
-		this.bootStatus_(\off);
+		this.state_(\isOff);
 	}
 
 	*quitAll { |watchShutDown = true|

--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -380,9 +380,7 @@ Server {
 		forkIfNeeded({
 			this.sendDefaultGroups;
 			tree.value(this);
-			this.sync;
 			ServerTree.run(this);
-			this.sync;
 		}, AppClock);
 	}
 
@@ -408,18 +406,16 @@ Server {
 			this.bootInit;
 			if (Server.postingBootInfo) { "prRun: % - %\n".postf(this, "ServerBoot.run") };
 			ServerBoot.run(this);
-			0.2.wait;
 			this.sync;
 			if (Server.postingBootInfo) { "prRun: % .%\n".postf(this, "initTree") };
 			this.initTree;
-			0.2.wait;
 			this.sync;
+			this.bootStatus_(\running); // or maybe 'running'
+			// also set server.statusWatcher.serverRunning_(true) here;
 			if (Server.postingBootInfo) { "prRun: % .%\n".postf(this, "tempBootItems.do") };
-			tempBootItems.do(_.value);
-			tempBootItems.clear;
-			0.2.wait;
-			this.sync;
-			this.bootStatus_(\running);
+			while { tempBootItems.notNil } {
+				tempBootItems.removeAt(0).value;
+			};
 		}.play(AppClock);
 	}
 

--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -379,7 +379,7 @@ Server {
 	initTree {
 		this.sendDefaultGroups;
 		tree.value(this);
-		ServerTree.run(this);
+		Routine { ServerTree.run(this) }.play(AppClock);
 	}
 
 	/* id allocators */

--- a/SCClassLibrary/Common/Control/ServerStatus.sc
+++ b/SCClassLibrary/Common/Control/ServerStatus.sc
@@ -76,38 +76,8 @@ ServerStatusWatcher {
 	}
 
 	doWhenBooted { |onComplete, limit = 100, onFailure|
-		var mBootNotifyFirst = bootNotifyFirst, postError = true;
-		bootNotifyFirst = false;
-
-		^Routine {
-			while {
-				server.serverRunning.not
-				/*
-				// this is not yet implemented.
-				or: { serverBooting and: mBootNotifyFirst.not }
-				and: { (limit = limit - 1) > 0 }
-				and: { server.applicationRunning.not }
-				*/
-
-			} {
-				0.2.wait;
-			};
-
-			if(server.serverRunning.not, {
-				if(onFailure.notNil) {
-					postError = (onFailure.value(server) == false);
-				};
-				if(postError) {
-					"Server '%' on failed to start. You may need to kill all servers".format(server.name).error;
-				};
-				serverBooting = false;
-				server.changed(\serverRunning);
-			}, {
-				server.sync;
-				onComplete.value;
-			});
-
-		}.play(AppClock)
+		this.deprecated(thisMethod, Server.findMethod(\doWhenBooted));
+		server.doWhenBooted(onComplete, limit = 100, onFailure);
 	}
 
 
@@ -215,9 +185,8 @@ ServerStatusWatcher {
 			hasBooted = running;
 			this.unresponsive = false;
 
-			if (running) {
 				// serverBoot happens in prRunBootTask now
-			} {
+			if (running.not) {
 				ServerQuit.run(server);
 
 				server.disconnectSharedMemory;

--- a/SCClassLibrary/Common/Control/ServerStatus.sc
+++ b/SCClassLibrary/Common/Control/ServerStatus.sc
@@ -210,6 +210,7 @@ ServerStatusWatcher {
 
 	serverRunning_ { | running |
 
+		hasBooted = running;
 		if(running != server.serverRunning) {
 			hasBooted = running;
 			this.unresponsive = false;

--- a/SCClassLibrary/Common/Control/ServerStatus.sc
+++ b/SCClassLibrary/Common/Control/ServerStatus.sc
@@ -84,7 +84,7 @@ ServerStatusWatcher {
 
 		^Routine {
 			while {
-				serverRunning.not
+				server.isFullyBooted.not
 				/*
 				// this is not yet implemented.
 				or: { serverBooting and: mBootNotifyFirst.not }
@@ -95,7 +95,8 @@ ServerStatusWatcher {
 			} {
 				0.2.wait;
 			};
-			if(serverRunning.not, {
+
+			if(server.isFullyBooted.not, {
 				if(onFailure.notNil) {
 					postError = (onFailure.value(server) == false);
 				};

--- a/SCClassLibrary/Common/Control/ServerStatus.sc
+++ b/SCClassLibrary/Common/Control/ServerStatus.sc
@@ -103,7 +103,10 @@ ServerStatusWatcher {
 				};
 				serverBooting = false;
 				server.changed(\serverRunning);
-			}, onComplete);
+			}, {
+				server.sync;
+				onComplete.value;
+			});
 
 		}.play(AppClock)
 	}

--- a/SCClassLibrary/Common/Control/ServerStatus.sc
+++ b/SCClassLibrary/Common/Control/ServerStatus.sc
@@ -1,13 +1,13 @@
 ServerStatusWatcher {
 
-	classvar bootStatuses = #[\off, \booting, \doingSetup, \running, \quitting];
+	classvar states = #[\isOff, \isBooting, \isSettingUp, \isReady, \isQuitting];
 
 	var server;
 
 	var <>notified = false, <notify = true;
 	var alive = false, <aliveThread, <>aliveThreadPeriod = 0.7, statusWatcher;
 
-	var <bootStatus = \off;
+	var <state = \isOff;
 	var <hasBooted = false, <>serverBooting = false, <unresponsive = false;
 
 	var <numUGens=0, <numSynths=0, <numGroups=0, <numSynthDefs=0;
@@ -20,21 +20,21 @@ ServerStatusWatcher {
 		^super.newCopyArgs(server)
 	}
 
-	bootStatus_ { |newStatus|
-		if (bootStatuses.includes(newStatus)) {
-			bootStatus = newStatus;
-			"%: bootStatus is now %.\n".postf(server, newStatus.cs);
+	state_ { |newState|
+		if (states.includes(newState)) {
+			state = newState;
+			"%: boot state is now %.\n".postf(server, newState.cs);
 		} {
 			warn(
-				"%:% - % is not a valid status."
-				.format(this, thisMethod.name, newStatus)
+				"%:% - % is not a valid boot state."
+				.format(this, thisMethod.name, newState)
 			);
 		}
 	}
-	running { ^bootStatus == \running }
-	doingSetup { ^bootStatus == \doingSetup }
-	booting { ^bootStatus == \running }
-	quitting { ^bootStatus == \quitting }
+	isBooting { ^state == \isBooting }
+	isReady { ^state == \isReady }
+	isSettingUp { ^state == \isSettingUp }
+	isQitting { ^state == \isQuitting }
 
 	quit { |onComplete, onFailure, watchShutDown = true|
 		if(watchShutDown) {
@@ -210,7 +210,7 @@ ServerStatusWatcher {
 
 				// serverBoot happens in prRunBootTask now
 			if (running) {
-				server.bootStatus_(\doingSetup)
+				server.state_(\isSettingUp)
 			} {
 				ServerQuit.run(server);
 

--- a/SCClassLibrary/Common/Control/ServerStatus.sc
+++ b/SCClassLibrary/Common/Control/ServerStatus.sc
@@ -216,9 +216,7 @@ ServerStatusWatcher {
 			this.unresponsive = false;
 
 			if (running) {
-				server.doWhenBooted {
-					ServerBoot.run(server);
-				};
+				// serverBoot happens in prRunBootTask now
 			} {
 				ServerQuit.run(server);
 

--- a/SCClassLibrary/Common/Control/ServerStatus.sc
+++ b/SCClassLibrary/Common/Control/ServerStatus.sc
@@ -156,7 +156,7 @@ ServerStatusWatcher {
 	}
 
 	stopStatusWatcher { this.stop }
-	startAliveThread { this.start }
+	startAliveThread { |delay=0.0| this.start(delay) }
 
 	start { | delay = 0.0 |
 		if (Server.postingBootInfo) {

--- a/SCClassLibrary/Common/Control/ServerStatus.sc
+++ b/SCClassLibrary/Common/Control/ServerStatus.sc
@@ -67,9 +67,7 @@ ServerStatusWatcher {
 
 		}, '/fail', server.addr, argTemplate:['/notify', nil, nil]).oneShot;
 
-		// send the notify request - on or off, userSpecifiedClientID or not
-		desiredClientID = if(server.userSpecifiedClientID, { server.clientID }, {-1});
-		server.sendMsg("/notify", flag.binaryValue, desiredClientID);
+		server.sendMsg("/notify", flag.binaryValue, server.clientID);
 
 		if(flag){
 			"Requested notification messages from server '%'\n".postf(server.name)

--- a/SCClassLibrary/Common/Control/ServerStatus.sc
+++ b/SCClassLibrary/Common/Control/ServerStatus.sc
@@ -231,7 +231,6 @@ ServerStatusWatcher {
 					notified = false;
 				};
 			};
-			{ server.changed(\serverRunning) }.defer;
 		}
 
 	}

--- a/SCClassLibrary/Common/Control/ServerStatus.sc
+++ b/SCClassLibrary/Common/Control/ServerStatus.sc
@@ -167,6 +167,9 @@ ServerStatusWatcher {
 	}
 
 	startAliveThread { | delay = 0.0 |
+		if (Server.postingBootInfo) {
+			"%.% with delay %.\n".postf(server, thisMethod.name, delay);
+		};
 		this.addStatusWatcher;
 		^aliveThread ?? {
 			aliveThread = Routine {
@@ -174,6 +177,9 @@ ServerStatusWatcher {
 				delay.wait;
 				loop {
 					alive = false;
+					if (Server.postingBootInfo) {
+						"% . sendStatusMsg...\n".postf(server);
+					};
 					server.sendStatusMsg;
 					aliveThreadPeriod.wait;
 					this.updateRunningState(alive);

--- a/SCClassLibrary/Common/Control/SystemActions.sc
+++ b/SCClassLibrary/Common/Control/SystemActions.sc
@@ -151,6 +151,9 @@ AbstractServerAction : AbstractSystemAction {
 	*add { arg object, server;
 		var list;
 		if (server.isNil)  { server = \all };
+		if (Server.postingBootInfo) {
+			"ServerBoot adds to server %: \n    %\n".postf(server, object.cs);
+		};
 		if (this.objects.isNil) { this.init };
 		list = this.objects.at(server);
 		if (list.isNil) { list = List.new; this.objects.put(server, list) };

--- a/SCClassLibrary/Common/Control/SystemActions.sc
+++ b/SCClassLibrary/Common/Control/SystemActions.sc
@@ -140,7 +140,7 @@ AbstractServerAction : AbstractSystemAction {
 
 	*run { arg server;
 		var selector = this.functionSelector;
-		// selector.postln;
+		if (Server.postingBootInfo) { "%: ServerTree.run\n".postf(server) };
 		this.performFunction(server, { arg obj; obj.perform(selector, server) });
 	}
 

--- a/SCClassLibrary/Common/Control/Volume.sc
+++ b/SCClassLibrary/Common/Control/Volume.sc
@@ -15,10 +15,15 @@ Volume {
 		if(server.serverRunning) { this.sendSynthDef };
 
 		initFunc = {
+			if (Server.postingBootInfo) {
+				"%.volume.initFunc runs.\n".postf(server);
+			};
 			ampSynth = nil;
 			this.sendSynthDef
 		};
-
+		if (Server.postingBootInfo) {
+			"% - ServerBoot.adds volume initFunc.\n".postf(server);
+		};
 		ServerBoot.add(initFunc, server)
 	}
 

--- a/SCClassLibrary/Common/Control/Volume.sc
+++ b/SCClassLibrary/Common/Control/Volume.sc
@@ -19,7 +19,7 @@ Volume {
 			this.sendSynthDef
 		};
 
-		ServerBoot.add(initFunc)
+		ServerBoot.add(initFunc, server)
 	}
 
 	sendSynthDef {

--- a/SCClassLibrary/scide_scqt/ScIDE.sc
+++ b/SCClassLibrary/scide_scqt/ScIDE.sc
@@ -41,7 +41,7 @@ ScIDE {
 		serverController = SimpleController(server)
 		.put(\serverRunning, { | server, what, extraArg |
 			this.send(\defaultServerRunningChanged, [
-				server.serverRunning, server.addr.hostname, server.addr.port, server.unresponsive]);
+				server.hasBooted, server.addr.hostname, server.addr.port, server.unresponsive]);
 		})
 		.put(\default, { | server, what, newServer |
 			("changed default server to:" + newServer.name).postln;

--- a/SCClassLibrary/scide_scqt/ScIDE.sc
+++ b/SCClassLibrary/scide_scqt/ScIDE.sc
@@ -33,6 +33,10 @@ ScIDE {
 	}
 
 	*defaultServer_ {|server|
+		if (Server.postingBootInfo) {
+			"% .% %\n".postf(this, thisMethod.name, server)
+		};
+
 		serverController.remove;
 		serverController = SimpleController(server)
 		.put(\serverRunning, { | server, what, extraArg |

--- a/testsuite/classlibrary/TestServerClientID.sc
+++ b/testsuite/classlibrary/TestServerClientID.sc
@@ -37,7 +37,7 @@ TestServer_clientID : UnitTest {
 	test_userSpecifiedClientID {
 		var options = ServerOptions.new;
 		var s = Server(\testserv, NetAddr("localhost", 57111), options, 1);
-		this.assert(s == nil, "Making a server with invalid clientID should be blocked.");
+		this.assert(s.clientID.isNil, "Making a server with invalid clientID should return a server with clientID nil.");
 		options.maxLogins_(8);
 		s = Server(\testserv, NetAddr("localhost", 57111), options, 7);
 		this.assert(s.clientID == 7, "Making a server with valid nonzero clientID should work.");

--- a/testsuite/classlibrary/TestServerClientID.sc
+++ b/testsuite/classlibrary/TestServerClientID.sc
@@ -36,10 +36,11 @@ TestServer_clientID : UnitTest {
 
 	test_userSpecifiedClientID {
 		var options = ServerOptions.new;
-		var s = Server(\testserv, NetAddr("localhost", 57111), options, 1);
+		var s = Server(\testUServ1, NetAddr("localhost", 57111), options, 1);
 		this.assert(s.clientID.isNil, "Making a server with invalid clientID should return a server with clientID nil.");
 		options.maxLogins_(8);
-		s = Server(\testserv, NetAddr("localhost", 57111), options, 7);
+		s.remove;
+		s = Server(\testUServ2, NetAddr("localhost", 57111), options, 7);
 		this.assert(s.clientID == 7, "Making a server with valid nonzero clientID should work.");
 		s.remove;
 	}

--- a/testsuite/classlibrary/TestServer_boot.sc
+++ b/testsuite/classlibrary/TestServer_boot.sc
@@ -76,8 +76,7 @@ TestServer_boot : UnitTest {
 	}
 
 	test_fourWaysToPlaySound {
-		var options = ServerOptions.new;
-		var s = Server(\testserv1, NetAddr("localhost", 57111), options);
+		var s = Server(\testserv1, NetAddr("localhost", 57111));
 		var amps, flags;
 		var o = OSCFunc({ |msg| amps = msg.drop(3) }, '/the8Amps');
 		var cond = Condition();
@@ -90,9 +89,9 @@ TestServer_boot : UnitTest {
 			// 1.wait;
 
 			// 4 ways to make sounds on the first 8 chans
-			Pbind(\legato, 1.1, \server, s).play;
+			Pbind(\legato, 2, \amp, 0.2, \dur, 0.25, \server, s).play;
 			{ Saw.ar([220, 330], 0.1) }.play(s, 2);
-			Synth(\default, [\out, 4], s);
+			Synth(\default, [\out, 4, \amp, 0.2], s);
 			Ndef(\testX -> s.name, { PinkNoise.ar(0.1) ! 2 }).play(6);
 			// get 8 sound levels
 			{
@@ -110,7 +109,8 @@ TestServer_boot : UnitTest {
 
 		cond.hang;
 
-		flags = amps.clump(2).collect(_.every(_ > 0.01)).postln;
+		flags = amps.clump(2).postln.collect(_.every(_ > 0.03)).postln;
+
 		this.assert(flags[0],
 			"Server: Pbind should play right after booting."
 		);
@@ -128,5 +128,51 @@ TestServer_boot : UnitTest {
 		s.quit;
 		s.remove;
 		o.free;
+	}
+
+	test_bootSequence {
+		var a, cond, b1, b2, t1, t2, oldTFunc;
+		var s = Server.default;
+		var numBootFuncs = ServerBoot.objects !? { ServerBoot.objects[s].size } ? 0;
+		var numTreeFuncs = ServerTree.objects !? { ServerTree.objects[s].size } ? 0;
+		var expectedList = List[ '1_Bt', '2_Bt', '3_tr', '4_Tr', '5_Tr', '6_wt', '7_do' ];
+
+		// list of function names to check
+		a = List[];
+		// add functions to run at all boot stages
+		ServerBoot.add (b1 = { |sv| (sv.name + ": ").post; 0.1.wait; a.add('1_Bt'.postln); }, s);
+		ServerBoot.add (b2 = { |sv|  (sv.name + ": ").post; 0.1.wait; a.add('2_Bt'.postln); }, s);
+		oldTFunc = s.tree;
+		s.tree =        { (s.name + ": ").post; 0.1.wait; a.add('3_tr'.postln); };
+		ServerTree.add (t1 = { |sv| (sv.name + ": ").post; 0.1.wait; a.add('4_Tr'.postln); }, s);
+		ServerTree.add (t2 = { |sv| (sv.name + ": ").post; 0.1.wait; a.add('5_Tr'.postln); }, s);
+
+		s.quit;
+		a = List[];
+		s.waitForBoot  { 0.1.wait; s.post; a.add('6_wt'.postln); };
+		s.doWhenBooted { 0.1.wait; s.post; a.add('7_do'.postln); };
+		s.doWhenBooted { 2.wait; cond.unhang; };
+
+		cond = Condition.new;
+		cond.hang;
+
+		0.1.wait;
+
+		// "*** expected: ".postln;
+		// expectedList.postcs;
+		// "*** result:".postln;
+		// a.postcs;
+
+		UnitTest.new.assert(a.size == expectedList.size, "each func in boot sequence should happen exactly once.");
+		UnitTest().assert(expectedList == a.copy.sort, "all funcs in boot sequence should happen in the correct order.");
+
+		// cleanup
+		ServerBoot.remove(b1, s);
+		ServerBoot.remove(b2, s);
+		ServerTree.remove(t1, s);
+		ServerTree.remove(t2, s);
+		s.tree = oldTFunc;
+
+		s.quit;
 	}
 }

--- a/testsuite/classlibrary/TestServer_boot.sc
+++ b/testsuite/classlibrary/TestServer_boot.sc
@@ -156,15 +156,11 @@ TestServer_boot : UnitTest {
 		cond = Condition.new;
 		cond.hang;
 
-		0.1.wait;
+		// wait for slow late tasks, just in case
+		2.wait;
 
-		// "*** expected: ".postln;
-		// expectedList.postcs;
-		// "*** result:".postln;
-		// a.postcs;
-
-		UnitTest.new.assert(a.size == expectedList.size, "each func in boot sequence should happen exactly once.");
-		UnitTest().assert(expectedList == a.copy.sort, "all funcs in boot sequence should happen in the correct order.");
+		this.assert(a.size == expectedList.size, "each func in boot sequence should happen exactly once.");
+		this.assert(expectedList == a.copy.sort, "all funcs in boot sequence should happen in the correct order.");
 
 		// cleanup
 		ServerBoot.remove(b1, s);

--- a/testsuite/classlibrary/TestServer_boot.sc
+++ b/testsuite/classlibrary/TestServer_boot.sc
@@ -92,7 +92,7 @@ TestServer_boot : UnitTest {
 			// 4 ways to make sounds on the first 8 chans
 			Pbind(\legato, 2, \amp, 0.3, \dur, 0.25, \server, s).play;
 			{ Saw.ar([220, 330], 0.1) }.play(s, 2);
-			Synth(\default, [\out, 4, \amp, 0.2], s);
+			Synth(\default, [\out, 4, \amp, 0.3], s);
 			Ndef(\testX -> s.name, { PinkNoise.ar(0.2) ! 2 }).play(6);
 
 			s.sync;

--- a/testsuite/classlibrary/TestServer_boot.sc
+++ b/testsuite/classlibrary/TestServer_boot.sc
@@ -56,7 +56,7 @@ TestServer_boot : UnitTest {
 		while {
 			done.not and: { failed.not }
 		} {
-			if(s.isFullyBooted) {
+			if(s.serverRunning) {
 				count = count + 1;
 				nodeID = s.nextNodeID;
 				if(nodeID <= prevNodeID) {

--- a/testsuite/classlibrary/TestServer_boot.sc
+++ b/testsuite/classlibrary/TestServer_boot.sc
@@ -1,0 +1,51 @@
+TestServer_boot : UnitTest {
+
+	test_waitForBoot {
+		var options = ServerOptions.new;
+		var s = Server(\testserv1, NetAddr("localhost", 57111), options);
+		var vals = List[];
+		var of = OSCFunc({ |msg| vals.add(msg[3]) }, \tr, s.addr);
+		var cond = Condition();
+
+		// waitForBoot tests doWhenBooted implicitly
+		s.waitForBoot({
+
+			var synth = { SendTrig.ar(Impulse.ar(10), 4711, 1) }.play(s);
+			1.wait;
+			synth.free;
+			cond.unhang;
+		});
+
+		cond.hang;
+		this.assert((vals.size > 8 and: vals.every(_ == 1)),
+			"waitForBoot should allow starting a synth."
+		);
+
+		s.quit;
+		s.remove;
+		of.free;
+	}
+
+	test_bootSync {
+		var options = ServerOptions.new;
+		var s = Server(\testserv1, NetAddr("localhost", 57111), options);
+		var vals = List[];
+		var of = OSCFunc({ |msg| vals.add(msg[3]) }, \tr, s.addr);
+		var synth;
+
+		s.bootSync;
+
+		synth = { SendTrig.ar(Impulse.ar(10), 4711, 1) }.play(s);
+		1.wait;
+		synth.free;
+
+		this.assert((vals.size > 8 and: vals.every(_ == 1)),
+			"bootSync should allow starting a synth right after continuing."
+		);
+
+		s.quit;
+		s.remove;
+		of.free;
+	}
+
+}

--- a/testsuite/classlibrary/TestServer_boot.sc
+++ b/testsuite/classlibrary/TestServer_boot.sc
@@ -76,7 +76,7 @@ TestServer_boot : UnitTest {
 	}
 
 	test_fourWaysToPlaySound {
-		var s = Server(\testserv1, NetAddr("localhost", 57111));
+		var s = Server(\test4w, NetAddr("localhost", 57111));
 		var amps, flags;
 		var o = OSCFunc({ |msg| amps = msg.drop(3) }, '/the8Amps');
 		var cond = Condition();
@@ -89,10 +89,13 @@ TestServer_boot : UnitTest {
 			// 1.wait;
 
 			// 4 ways to make sounds on the first 8 chans
-			Pbind(\legato, 2, \amp, 0.2, \dur, 0.25, \server, s).play;
+			Pbind(\legato, 2, \amp, 0.3, \dur, 0.25, \server, s).play;
 			{ Saw.ar([220, 330], 0.1) }.play(s, 2);
 			Synth(\default, [\out, 4, \amp, 0.2], s);
-			Ndef(\testX -> s.name, { PinkNoise.ar(0.1) ! 2 }).play(6);
+			Ndef(\testX -> s.name, { PinkNoise.ar(0.2) ! 2 }).play(6);
+
+			s.sync;
+
 			// get 8 sound levels
 			{
 				SendReply.kr(
@@ -103,7 +106,6 @@ TestServer_boot : UnitTest {
 
 			2.wait;
 
-			s.quit;
 			cond.unhang;
 		});
 
@@ -123,6 +125,8 @@ TestServer_boot : UnitTest {
 		this.assert(flags[3],
 			"Server: Ndef should play right after booting."
 		);
+
+		1.wait;
 
 		Ndef.dictFor(s).clear;
 		s.quit;

--- a/testsuite/classlibrary/TestServer_boot.sc
+++ b/testsuite/classlibrary/TestServer_boot.sc
@@ -48,4 +48,30 @@ TestServer_boot : UnitTest {
 		of.free;
 	}
 
+	test_allocWhileBooting {
+		var s = Server(\test), done = false, count = 0;
+		var prevNodeID = -1, nodeID = 0, failed = false;
+
+		s.boot;
+		while {
+			done.not and: { failed.not }
+		} {
+			if(s.isFullyBooted) {
+				count = count + 1;
+				nodeID = s.nextNodeID;
+				if(nodeID <= prevNodeID) {
+					failed = true;
+					"failed: prevNodeID % and nodeID = % "
+					.format(prevNodeID, nodeID).warn;
+				};
+
+				prevNodeID = nodeID;
+				done = count > 1000;
+			};
+			0.001.wait;
+		};
+		this.assert(failed.not,
+			"allocating nodeIDs while booting should not produce duplicate nodeIDs."
+		);
+	}
 }

--- a/testsuite/classlibrary/TestServer_boot.sc
+++ b/testsuite/classlibrary/TestServer_boot.sc
@@ -93,7 +93,7 @@ TestServer_boot : UnitTest {
 			"*** test_fourWaysToPlaySound - waitForBoot action runs!".postln;
 
 			// 4 ways to make sounds on the first 8 chans
-			Pbind(\legato, 2, \amp, 0.3, \dur, 0.25, \server, s).play(quant: 0);
+			Pbind(\legato, 2, \amp, 0.3, \dur, Pn(0.25, 4), \server, s).play(quant: 0);
 			{ Saw.ar([220, 330], 0.1) }.play(s, 2);
 			Synth(\def2, [\out, 4, \amp, 0.3], s);
 			NodeProxy.audio(s).source_({ PinkNoise.ar(0.2) ! 2 }).play(6);

--- a/testsuite/classlibrary/TestServer_boot.sc
+++ b/testsuite/classlibrary/TestServer_boot.sc
@@ -73,6 +73,7 @@ TestServer_boot : UnitTest {
 		this.assert(failed.not,
 			"allocating nodeIDs while booting should not produce duplicate nodeIDs."
 		);
+		s.quit.remove;
 	}
 
 	test_fourWaysToPlaySound {
@@ -161,7 +162,7 @@ TestServer_boot : UnitTest {
 		cond.hang;
 
 		// wait for slow late tasks, just in case
-		2.wait;
+		1.wait;
 
 		this.assert(a.size == expectedList.size, "each func in boot sequence should happen exactly once.");
 		this.assert(expectedList == a.copy.sort, "all funcs in boot sequence should happen in the correct order.");

--- a/testsuite/classlibrary/TestServer_clientIDBooted.sc
+++ b/testsuite/classlibrary/TestServer_clientIDBooted.sc
@@ -34,8 +34,9 @@ TestServer_clientID_booted : UnitTest {
 	test_nodeIDAlloc_ServerTree {
 		var s = Server(\testserv3, NetAddr("localhost", 57111));
 		var synth1, synth2;
+		var func = { synth1 = Synth("default"); };
 
-		ServerTree.add( { synth1 = Synth("default"); });
+		ServerTree.add( func, s );
 		this.bootServer(s);
 
 		1.wait;
@@ -45,5 +46,6 @@ TestServer_clientID_booted : UnitTest {
 			"first nodeID after booting should not repeat nodeID created in ServerTree.");
 		s.quit;
 		s.remove;
+		ServerTree.remove( func, s );
 	}
 }

--- a/testsuite/classlibrary/TestServer_clientIDBooted.sc
+++ b/testsuite/classlibrary/TestServer_clientIDBooted.sc
@@ -39,14 +39,28 @@ TestServer_clientID_booted : UnitTest {
 		ServerTree.add( func, s );
 		this.bootServer(s);
 
-		1.wait;
-
 		synth2 = Synth("default", [\freq, 330]);
 		this.assert(synth1.nodeID != synth2.nodeID,
 			"first nodeID after booting should not repeat nodeID created in ServerTree.");
 
 		0.5.wait;
 		ServerTree.remove( func, s );
+		s.quit;
+		s.remove;
+	}
+
+	test_clientIDLockedWhileRunning {
+		var options = ServerOptions.new.maxLogins_(4);
+		var s = Server(\testserv4, NetAddr("localhost", 57111), options, clientID: 1);
+		var lockedID;
+
+		this.bootServer(s);
+		lockedID = s.clientID;
+
+		s.clientID = 3;
+		this.assert(s.clientID == lockedID,
+			"clientID should be locked while server is running.");
+
 		s.quit;
 		s.remove;
 	}

--- a/testsuite/classlibrary/TestServer_clientIDBooted.sc
+++ b/testsuite/classlibrary/TestServer_clientIDBooted.sc
@@ -15,7 +15,7 @@ TestServer_clientID_booted : UnitTest {
 		this.bootServer(s);
 		s.sync;
 		1.wait;
-		this.assert(s.clientID == 0, "Non-user-defined clientID should be reset by the server.");
+		this.assert(s.clientID == 3, "clientID should be settable before booting.");
 		s.quit;
 		s.remove;
 
@@ -26,7 +26,7 @@ TestServer_clientID_booted : UnitTest {
 		this.bootServer(s);
 		s.sync;
 		1.wait;
-		this.assert(s.clientID == 3, "User-defined clientID should be left as is by the server.");
+		this.assert(s.clientID == 3, "clientID should remain as is when booting a server.");
 		s.quit;
 		s.remove;
 	}

--- a/testsuite/classlibrary/TestServer_clientIDBooted.sc
+++ b/testsuite/classlibrary/TestServer_clientIDBooted.sc
@@ -8,31 +8,27 @@ TestServer_clientID_booted : UnitTest {
 	// with running server
 	test_clientIDResetByServer {
 		var options = ServerOptions.new;
-		var s = Server(\testserv1, NetAddr("localhost", 57111), options);
+		var s = Server(\test_clientIDResetByServer, NetAddr("localhost", 57111), options);
 
 		s.options.maxLogins = 4;
 		s.clientID = 3;
 		this.bootServer(s);
 		s.sync;
-		1.wait;
 		this.assert(s.clientID == 3, "clientID should be settable before booting.");
 		s.quit;
 		s.remove;
-
-		1.wait;
 
 		s = Server(\testserv2, NetAddr("localhost", 57112), options, 3);
 
 		this.bootServer(s);
 		s.sync;
-		1.wait;
 		this.assert(s.clientID == 3, "clientID should remain as is when booting a server.");
 		s.quit;
 		s.remove;
 	}
 
 	test_nodeIDAlloc_ServerTree {
-		var s = Server(\testserv3, NetAddr("localhost", 57113));
+		var s = Server(\test_nodeIDAlloc_ServerTree, NetAddr("localhost", 57113));
 		var synth1, synth2;
 		var func = { synth1 = Synth("default"); };
 
@@ -43,7 +39,6 @@ TestServer_clientID_booted : UnitTest {
 		this.assert(synth1.nodeID != synth2.nodeID,
 			"first nodeID after booting should not repeat nodeID created in ServerTree.");
 
-		0.5.wait;
 		synth1.free;
 		synth2.free;
 		s.quit;
@@ -53,7 +48,7 @@ TestServer_clientID_booted : UnitTest {
 
 	test_clientIDLockedWhileRunning {
 		var options = ServerOptions.new.maxLogins_(4);
-		var s = Server(\testserv4, NetAddr("localhost", 57114), options, clientID: 1);
+		var s = Server(\test_clientIDLockedWhileRunning, NetAddr("localhost", 57114), options, clientID: 1);
 		var lockedID;
 
 		this.bootServer(s);

--- a/testsuite/classlibrary/TestServer_clientIDBooted.sc
+++ b/testsuite/classlibrary/TestServer_clientIDBooted.sc
@@ -44,8 +44,10 @@ TestServer_clientID_booted : UnitTest {
 			"first nodeID after booting should not repeat nodeID created in ServerTree.");
 
 		0.5.wait;
-		ServerTree.remove( func, s );
+		synth1.free;
+		synth2.free;
 		s.quit;
+		ServerTree.remove( func, s );
 		s.remove;
 	}
 

--- a/testsuite/classlibrary/TestServer_clientIDBooted.sc
+++ b/testsuite/classlibrary/TestServer_clientIDBooted.sc
@@ -44,8 +44,10 @@ TestServer_clientID_booted : UnitTest {
 		synth2 = Synth("default", [\freq, 330]);
 		this.assert(synth1.nodeID != synth2.nodeID,
 			"first nodeID after booting should not repeat nodeID created in ServerTree.");
+
+		0.5.wait;
+		ServerTree.remove( func, s );
 		s.quit;
 		s.remove;
-		ServerTree.remove( func, s );
 	}
 }

--- a/testsuite/classlibrary/TestServer_clientIDBooted.sc
+++ b/testsuite/classlibrary/TestServer_clientIDBooted.sc
@@ -32,7 +32,7 @@ TestServer_clientID_booted : UnitTest {
 	}
 
 	test_nodeIDAlloc_ServerTree {
-		var s = Server(\testserv3, NetAddr("localhost", 57111));
+		var s = Server(\testserv3, NetAddr("localhost", 57113));
 		var synth1, synth2;
 		var func = { synth1 = Synth("default"); };
 
@@ -53,7 +53,7 @@ TestServer_clientID_booted : UnitTest {
 
 	test_clientIDLockedWhileRunning {
 		var options = ServerOptions.new.maxLogins_(4);
-		var s = Server(\testserv4, NetAddr("localhost", 57111), options, clientID: 1);
+		var s = Server(\testserv4, NetAddr("localhost", 57114), options, clientID: 1);
 		var lockedID;
 
 		this.bootServer(s);

--- a/testsuite/sclang/sclang_bootAltDemo_Tests.scd
+++ b/testsuite/sclang/sclang_bootAltDemo_Tests.scd
@@ -1,0 +1,82 @@
+/*
+*** Demonstration and tests of bootAlt, an alternative for Server:boot ***
+
+bootAlt features :
+* all boot steps happen in a single task
+* running scsynths can be recovered or rebooted
+* posts info on all steps and the times they take
+* adds arguments for onComplete and timeout for more flexibility
+
+* assumes startAliveThread is always true (which it probably should be)
+* manual test suite below
+
+*/
+
+// test all branches in bootAlt:
+// turn posting on and off for debugging
+Server.postingBootInfo = true;
+Server.postingBootInfo = false;
+Server.killAll;
+
+// get boot time for s.boot for comparison:
+(
+s.quit;
+~t0 = thisThread.seconds;
+s.waitForBoot { "booted in % secs.\n".postf(thisThread.seconds - ~t0) };
+)
+
+// test basic bootAlt
+s.quit;
+s.bootAlt; // boots
+
+// make s a remote server
+s.addr = NetAddr("123.234.56.78", 123);
+s.bootAlt;  // cant boot and quit
+s.quit;
+
+// test bootAndQuitDisabled on local
+s.addr = NetAddr.localAddr.port_(57110);  // local again
+s.quit; // can quit now
+s.bootAndQuitDisabled = true;
+s.bootAlt; // no boot and quit
+s.quit;
+s.bootAndQuitDisabled = false;
+
+
+// test unresposive reboot
+s.bootAlt; // boot first
+
+// then pretend unresponsive
+(
+s.statusWatcher.stop;
+s.statusWatcher.unresponsive_(true).serverRunning_(false).serverBooting_(false);
+s.state_(\isOff);
+)
+s.bootAlt; // -> this reboots
+
+// test unresposive reboot 2 - recover
+s.bootAlt; // boot first, then pretend unresponsive
+(
+s.statusWatcher.stop;
+s.statusWatcher.unresponsive_(true).serverRunning_(false).serverBooting_(false);
+s.state_(\isOff);
+)
+// recovers the server and runs prRunBootTask
+s.bootAlt(recover: true);
+
+// test boot timeout:
+s.quit;
+p = Server.program;  // rename server program so it does not start
+Server.program = "nonono";
+s.bootAlt(onFailure: { "TEST TIMEOUT".postln; }); // onFailure after 5 sec
+s.bootAlt(onFailure: { "fast TIMEOUT.".postln; }, timeout: 1);
+p !? { Server.program = p }; // restore
+
+
+
+// test onComplete argument:
+// Synthdef is there, nodetree inited, etc etc
+s.bootAlt(onComplete: { ().play; });
+// is already running, runs directly
+s.bootAlt(onComplete: { ().play; });
+


### PR DESCRIPTION
This PR is based on the lockClientID PR #3275, and implements a simple deterministic order for all Server-boot-related items, as proposed in  #3286.
 Compare what is new relative to #3275:
https://github.com/adcxyz/supercollider/compare/lockClientIDWhileRunning...adcxyz:server_singleBootTask?expand=1

(Partly copied from my post in #3286, rework server boot logic):
The order proposed here follows james' sketch, and all actions run in a single Task.
This makes the boot process deterministic and easy to reason about.

The PR is relative to 3.9 because this is what I based it on - 
it need not go into 3.9 if devs prefer to release it as is + PR #3275. 
IMO, it does solidify the boot process, and makes a step towards #3286, 
which could be desirable and useful to have quickly. 

The order proposed and implemented here is:
* boot the server process -> server.hasBooted is true
* notify, get clientID, make allocators -> serverRunning is true
* do ServerBoot.run: everything that can or must happen before server tree:
   SynthDescLib, NodeWatcher, etc.
 sync 
* do server.initTree:
  create defaultGroups
  all user setup actions that needs server tree go into:
  s.tree 
  ServerTree.run 
  sync when done
* do all tempBootItems 
  user actions added by doWhenBooted, in the order they were added in.

All of them allow waiting and conditions within the functions.

```
// Here is a variant of test_bootSequence that works as a test on 3.8.0: 
fork {
	var a, cond, b1, b2, t1, t2, oldTFunc;
	var numBootFuncs = ServerBoot.objects !? { ServerBoot.objects[s].size } ? 0;
	var numTreeFuncs = ServerTree.objects !? { ServerTree.objects[s].size } ? 0;
	var expectedList = List[ '1_Bt', '2_Bt', '3_tr', '4_Tr', '5_Tr', '6_wt', '7_do' ];
		
	// list of function names to check
	a = List[];
	// add functions to run at all boot stages
	ServerBoot.add (b1 = { |sv1| (sv1.name + ": ").post; a.add('1_Bt'.postln); }, s);
	ServerBoot.add (b2 = { |sv2| (sv2.name + ": ").post; a.add('2_Bt'.postln); }, s);
	s.tree =        { (s.name + ": ").post; 0.1.wait; a.add('3_tr'.postln); };
	ServerTree.add (t1 = { |sv| (sv.name + ": ").post; 0.1.wait; a.add('4_Tr'.postln); }, s);
	ServerTree.add (t2 = { |sv| (sv.name + ": ").post; 0.1.wait; a.add('5_Tr'.postln); }, s);
		
	s.quit;
	a = List[];
	s.waitForBoot  { ().play; s.post; a.add('6_wt'.postln); };
	s.doWhenBooted { 0.1.wait; s.post; a.add('7_do'.postln); };
	s.doWhenBooted { 2.wait; cond.unhang; };
	s.boot;
	
	cond = Condition.new;
	cond.hang;
		
	// wait for slow late tasks, just in case
	5.wait;
	
	a.postln; 
	if (a == expectedList) { 
		"*** YES, BOOT ORDER IS CORRECT. *** ".postln;
	} { 
		"*** NO, BOOT ORDER IS not correct. *** ".postln;
	};
	
	// cleanup
	ServerBoot.remove(b1, s);
	ServerBoot.remove(b2, s);
	ServerTree.remove(t1, s);
	ServerTree.remove(t2, s);
	s.quit;
}
```