### PR TITLE
class library: Condition hangWithTimeout

### DIFF
--- a/SCClassLibrary/Common/Core/Condition.sc
+++ b/SCClassLibrary/Common/Core/Condition.sc
@@ -16,6 +16,19 @@ Condition {
 		value.yield;
 	}
 
+	hangWithTimeout { arg value = \hang, timeout, timeoutFunction;
+		var func;
+		func = {
+			this.test = true;
+			this.signal;
+			timeoutFunction.value(this);
+			func = nil;
+		};
+		thisThread.clock.sched(timeout, { func.value; nil });
+		this.hang(value);
+		func = nil;
+	}
+
 	signal {
 		var tempWaitingThreads, time;
 		if (test.value, {

--- a/testsuite/classlibrary/TestCondition.sc
+++ b/testsuite/classlibrary/TestCondition.sc
@@ -1,0 +1,37 @@
+
+
+TestCondition : UnitTest {
+
+
+	test_hangWithTimeout {
+
+		var dt = 0.1;
+		var hasContinued = false;
+		var timeoutFunctionWasCalled = false;
+		Routine.run {
+			var condition;
+
+			condition = Condition.new;
+			condition.test = false;
+			condition.hangWithTimeout(\hang, dt, { timeoutFunctionWasCalled = true });
+			hasContinued = true;
+
+		};
+
+		SystemClock.sched(0.001, {
+			this.assert(hasContinued.not, "hangWithTimeout should hang");
+		});
+
+		SystemClock.sched(0.001, {
+			this.assert(timeoutFunctionWasCalled.not, "hangWithTimeout should not call timeout Function while hanging");
+		});
+
+		SystemClock.sched(dt + 0.001, {
+			this.assert(hasContinued, "hangWithTimeout should time out");
+			this.assert(timeoutFunctionWasCalled, "hangWithTimeout should call timeout Function after time out");
+		})
+
+	}
+
+
+}

--- a/testsuite/classlibrary/TestCondition.sc
+++ b/testsuite/classlibrary/TestCondition.sc
@@ -5,7 +5,7 @@ TestCondition : UnitTest {
 
 	test_hangWithTimeout {
 
-		var dt = 0.1;
+		var hangTime = 0.1;
 		var hasContinued = false;
 		var timeoutFunctionWasCalled = false;
 		Routine.run {
@@ -13,7 +13,7 @@ TestCondition : UnitTest {
 
 			condition = Condition.new;
 			condition.test = false;
-			condition.hangWithTimeout(\hang, dt, { timeoutFunctionWasCalled = true });
+			condition.hangWithTimeout(\hang, hangTime, { timeoutFunctionWasCalled = true });
 			hasContinued = true;
 
 		};
@@ -26,10 +26,38 @@ TestCondition : UnitTest {
 			this.assert(timeoutFunctionWasCalled.not, "hangWithTimeout should not call timeout Function while hanging");
 		});
 
-		SystemClock.sched(dt + 0.001, {
+		SystemClock.sched(hangTime + 0.001, {
 			this.assert(hasContinued, "hangWithTimeout should time out");
 			this.assert(timeoutFunctionWasCalled, "hangWithTimeout should call timeout Function after time out");
-		})
+		});
+
+	}
+
+	test_hangWithTimeout_unhang {
+
+		var hangTime = 0.1;
+		var hasContinued = false;
+		var timeoutFunctionWasCalled = false;
+		var condition = Condition.new;
+
+		Routine.run {
+			condition.test = false;
+			condition.hangWithTimeout(\hang, hangTime, { timeoutFunctionWasCalled = true });
+			hasContinued = true;
+		};
+
+		SystemClock.sched(0.001, {
+			this.assert(hasContinued.not, "hangWithTimeout should hang");
+		});
+
+		SystemClock.sched(0.001 + (hangTime / 2), {
+			condition.test = true;
+			condition.signal;
+		});
+
+		SystemClock.sched(0.1 + hangTime, {
+			this.assert(timeoutFunctionWasCalled.not, "hangWithTimeout should not call timeout Function when unhung externally");
+		});
 
 	}
 


### PR DESCRIPTION
As a contribution to the refactorings and fixes to the Server booting process, I've added this. It makes it much simpler to organize time outs. Server `sync` could then take `timeout` and `timeoutFunction` arguments.