### PR TITLE
SCDoc: Escape single-quotes in generated javascript

### DIFF
--- a/SCClassLibrary/SCDoc/SCDoc.sc
+++ b/SCClassLibrary/SCDoc/SCDoc.sc
@@ -384,7 +384,7 @@ SCDocNode {
 SCDoc {
 
 	// Increment this whenever we make a change to the SCDoc system so that all help-files should be processed again
-	classvar version = 61;
+	classvar version = 62;
 
 	classvar <helpTargetDir;
 	classvar <helpTargetUrl;

--- a/SCClassLibrary/SCDoc/SCDocRenderer.sc
+++ b/SCClassLibrary/SCDoc/SCDocRenderer.sc
@@ -233,7 +233,7 @@ SCDocHTMLRenderer {
 		<< "<meta http-equiv='Content-Type' content='text/html; charset=UTF-8' />\n"
 		<< "<script>\n"
 		<< "var helpRoot = '" << baseDir << "';\n"
-		<< "var scdoc_title = '" << doc.title << "';\n"
+		<< "var scdoc_title = '" << doc.title.escapeChar($') << "';\n"
 		<< "var scdoc_sc_version = '" << Main.version << "';\n"
 		<< "</script>\n"
 		<< "<script src='" << baseDir << "/scdoc.js' type='text/javascript'></script>\n"


### PR DESCRIPTION
Fixes issue #3298.

Tested on macOS 10.13 (not that OS should make a difference).

I am milestoning this as 3.9.1, but if people think it's safe it could go in 3.9.0. I would say that since the issue/workaround is known, it would be safer to wait for now.