### PR TITLE
class library: Server handling same names in *new method

### DIFF
--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -308,7 +308,47 @@ Server {
 	}
 
 	*new { |name, addr, options, clientID|
+		var existing = this.checkExisting(name, addr, options, clientID);
+		if (existing.notNil) {
+			// posting can be dropped when the new behavior is established.
+			"returning existing Server(%).\n".postf(name.cs);
+			^existing
+		};
 		^super.new.init(name, addr, options, clientID)
+	}
+
+	*checkExisting { |name, addr, options, clientID|
+		var found = Server.all.detect { |sv| sv.name == name };
+		var addrStr = "", optionsStr = "", clientIDStr = "";
+		var diffStr;
+
+		if (found.isNil) { ^nil };
+
+		if (addr.notNil and: { addr != found.addr }) {
+			addrStr = "addr of existing: % - new: %\n".format(found.addr.cs, addr.cs);
+		};
+		if (clientID.notNil and: { clientID != found.clientID }) {
+			clientIDStr = "addr of existing: % - new: %\n"
+			.format(found.clientID, clientID);
+		};
+		// options are trickier to compare and stringify ...
+		if (options.notNil) {
+			optionsStr = "options may also be different...\n"
+		};
+
+		diffStr = addrStr ++ clientIDStr ++ optionsStr;
+
+		if (diffStr.size > 0) {
+			("Server(%) already exists with different parameters:\n"
+				++ diffStr
+				++ "Please use a different name, or change the existing server's settings!"
+			).format(name.cs).warn;
+		} {
+			// posting can be dropped when the new behavior is established.
+			"Server(%) already exists - ".postf(name.cs);
+		};
+
+		^found
 	}
 
 	*remote { |name, addr, options, clientID|


### PR DESCRIPTION
Currently, when making a server with a name that is already used by an existing server, the existing server is returned, a warning is posted, and by accident, a new server with the same name is generated which remains in Server.all.
  
```
3.do { Server(\xyz); };
Server.all;
-> Set[ localhost, xyz, internal, xyz, xyz ]
```
This patch fixes that. It was written relative to 3.9, thus the PR is towards 3.9, but it is quite independent of all else, so it could also go elsewhere easily.

The proposal here is to always return the existing server, and warn if the creation parameters are different from what the existing server has.
This is similar to access in the Xdef(<name>) pattern, except that for servers, dynamically setting new address, options and clientID seems too risky: thus there is only a warning that tells user to either make a server with a different name, or to change the existing servers internal settings if that was intended.

Here is the proposed behavior in code:
````
x = Server(\xyz);
Server(\xyz);
-> Server('xyz') already exists - returning existing Server('xyz').

x === Server(\x);
-> true

y = Server(\xyz, NetAddr("1.2.3.4", 57110)); // post more, true

WARNING: Server('xyz') already exists with different parameters:
addr of existing: NetAddr.new("127.0.0.1", 57110) - new: NetAddr.new("1.2.3.4", 57110)
Please use a different name, or change the existing server's settings!
returning existing Server('xyz').
-> xyz

z = Server(\xyz, NetAddr("1.2.3.4", 57110), s.options); // post more, true
WARNING: Server('xyz') already exists with different parameters:
addr of existing: NetAddr.new("127.0.0.1", 57110) - new: NetAddr.new("1.2.3.4", 57110)
options may also be different...
Please use a different name, or change the existing server's settings!
returning existing Server('xyz').
-> xyz

w = Server(\xyz, clientID: 1); // post more info
WARNING: Server('xyz') already exists with different parameters:
addr of existing: 0 - new: 1
Please use a different name, or change the existing server's settings!
returning existing Server('xyz').
-> xyz

// test whether they are all identical
[x, y, z, w].asSet.size == 1; // should be true
```