### PR TITLE
classlib: remove old workaround code in Recorder.makePath

### DIFF
--- a/SCClassLibrary/Common/Control/Recorder.sc
+++ b/SCClassLibrary/Common/Control/Recorder.sc
@@ -172,12 +172,7 @@ Recorder {
 			"created recordings directory: '%'\n".postf(dir)
 		};
 
-		// temporary kludge to fix Date's brokenness on windows
-		timestamp = if(thisProcess.platform.name == \windows) {
-			Main.elapsedTime.round(0.01)
-		} {
-			Date.localtime.stamp
-		};
+		timestamp = Date.localtime.stamp;
 
 		^dir +/+ filePrefix ++ timestamp ++ "." ++ server.recHeaderFormat;
 	}


### PR DESCRIPTION
Fixes #3307.

Please don't merge until 3.9.1. This code is probably fine, but for stability's sake I don't want to risk it.