### PR TITLE
travis: install and use xcpretty (macos builds)

### DIFF
--- a/.travis/before-install-osx.sh
+++ b/.travis/before-install-osx.sh
@@ -11,3 +11,6 @@ export PATH="/usr/local/opt/ccache/libexec:$PATH"
 brew install libsndfile || true
 brew install qt55 || true
 brew link qt55 --force
+
+# To get less noise in xcode output
+gem install xcpretty

--- a/.travis/script-osx.sh
+++ b/.travis/script-osx.sh
@@ -1,3 +1,18 @@
 #!/bin/sh
 
-cmake --build $TRAVIS_BUILD_DIR/BUILD --config Release --target install
+# Keep a raw log of cmake's output
+BUILD_LOG=$TRAVIS_BUILD_DIR/BUILD/raw_build.log
+XCPRETTY='xcpretty --simple --no-utf --no-color'
+
+# Make cmake failure an overall failure
+set -o pipefail
+cmake --build $TRAVIS_BUILD_DIR/BUILD --config Release --target install | tee $BUILD_LOG | $XCPRETTY
+CMAKE_EXIT=$?
+set +o pipefail
+
+if [[ $CMAKE_EXIT != 0 ]]; then
+    echo "Error while building. Printing raw log."
+    cat $BUILD_LOG
+fi
+
+exit $CMAKE_EXIT


### PR DESCRIPTION
Thanks to @scztt for this idea. 

xcpretty makes the build output from xcode much less verbose and much more readable. With this change, the log goes from being ~4 MB/16,000 lines to ~300 KB/7,000 lines. I have on occasion waited a full minute and a half to read the last few lines of the travis log, this is 

This also updates the build scripts so that if there's any failure while building the whole log is printed.

Example (passing) build: https://api.travis-ci.org/jobs/306987284/log.txt?deansi=true
Example (failing) build: https://travis-ci.org/brianlheim/supercollider/jobs/306996793

I hope nobody minds if we merge this right away. It's non-user-facing and seriously makes life easier when checking the Travis logs. 