### PR TITLE
supernova: reserve enough size for synthdefs

### DIFF
--- a/server/scsynth/SC_GraphDef.cpp
+++ b/server/scsynth/SC_GraphDef.cpp
@@ -353,6 +353,8 @@ inline static void calcParamSpecs1(GraphDef* graphDef, char*& buffer)
 }
 
 // ver 2
+/** \note Relevant supernova code: `sc_synthdef::prepare(void)`
+ */
 GraphDef* GraphDef_Read(World *inWorld, char*& buffer, GraphDef* inList, int32 inVersion)
 {
 	int32 name[kSCNodeDefNameLen];

--- a/server/scsynth/SC_GraphDef.h
+++ b/server/scsynth/SC_GraphDef.h
@@ -36,6 +36,9 @@ struct ParamSpec
 
 typedef HashTable<ParamSpec, Malloc> ParamSpecTable;
 
+/** \note Relevant scsynth code: `GraphDef_Read(World *, char*&, GraphDef*, int32)`
+ *  \note Relevant supernova code: `sc_synthdef::prepare(void)`
+ */
 struct GraphDef
 {
 	NodeDef mNodeDef;

--- a/server/supernova/sc/sc_synthdef.cpp
+++ b/server/supernova/sc/sc_synthdef.cpp
@@ -381,8 +381,12 @@ void sc_synthdef::prepare(void)
     memory_requirement_ += (graph.size() + calc_unit_indices.size() + 1) * sizeof(Unit*); // reserves space for units (one more to allor prefetching)
 
     // memory that is required to fill the sc_synth data structure
-    const size_t ctor_alloc_size = parameter_count() * (sizeof(float) + sizeof(int) + sizeof(float*))
-                                 + constants.size() * sizeof(Wire);
+    // see SC_Graph.h for corresponding data structure
+    // mControls, mControlRates, mAudioBusOffset, mMapControls
+    const size_t param_alloc_size = parameter_count() * (sizeof(float) + sizeof(int) + sizeof(int32) + sizeof(float*));
+    // mWire
+    const size_t constant_alloc_size = constants.size() * sizeof(Wire);
+    const size_t ctor_alloc_size = param_alloc_size + constant_alloc_size;
 
     memory_requirement_ += ctor_alloc_size;
 


### PR DESCRIPTION
In `sc_synthdef::prepare(void)`, the memory requirement for a sc_synth structure was underreported because it did not change with #3063. As a result, there was memory corruption. This commit both fixes the issue and adds clarifying comments to the calculations.

Fixes #3196, and helps #3266 as it applies to supernova. Tested on macOS 10.13.

cc @dyfer, @samaaron. Definitely doesn't change anything on sonic pi w/ scsynth.