### PR TITLE
scsynth: use correct types for allocation sizes

### DIFF
--- a/server/scsynth/SC_GraphDef.cpp
+++ b/server/scsynth/SC_GraphDef.cpp
@@ -431,10 +431,10 @@ GraphDef* GraphDef_Read(World *inWorld, char*& buffer, GraphDef* inList, int32 i
 	graphDef->mMapControlsAllocSize = graphDef->mNumControls * sizeof(float*);
 	graphDef->mNodeDef.mAllocSize += graphDef->mMapControlsAllocSize;
 
-	graphDef->mMapControlRatesAllocSize = graphDef->mNumControls * sizeof(int*);
+	graphDef->mMapControlRatesAllocSize = graphDef->mNumControls * sizeof(int);
 	graphDef->mNodeDef.mAllocSize += graphDef->mMapControlRatesAllocSize;
 
-	graphDef->mAudioMapBusOffsetSize = graphDef->mNumControls * sizeof(int32*);
+	graphDef->mAudioMapBusOffsetSize = graphDef->mNumControls * sizeof(int32);
 	graphDef->mNodeDef.mAllocSize += graphDef->mAudioMapBusOffsetSize;
 
 	graphDef->mNext = inList;


### PR DESCRIPTION
In GraphDef_Read(), sizeof(int*) and sizeof(int32*) are used when the
sizes of int and int32 are meant instead. This doesn't appear to have
caused any real problems so far, but is a typo, and may be related to
 #3266.

@samaaron - can you test this out and see if it solves anything? Just a hunch.