### PR TITLE
Make volume synth's envelope use lag time 

### DIFF
--- a/SCClassLibrary/Common/Control/Volume.sc
+++ b/SCClassLibrary/Common/Control/Volume.sc
@@ -28,7 +28,7 @@ Volume {
 			defName = (\volumeAmpControl ++ numOutputChannels).asSymbol;
 			SynthDef(defName, { | volumeAmp = 1, volumeLag = 0.1, gate=1, bus |
 				XOut.ar(bus,
-					Linen.kr(gate, releaseTime: 0.05, doneAction:2),
+					Linen.kr(gate, attackTime: volumeLag, releaseTime: volumeLag, doneAction:2),
 					In.ar(bus, numOutputChannels) * Lag.kr(volumeAmp, volumeLag)
 				);
 			}).send(server);

--- a/SCClassLibrary/Common/Control/Volume.sc
+++ b/SCClassLibrary/Common/Control/Volume.sc
@@ -28,7 +28,7 @@ Volume {
 			defName = (\volumeAmpControl ++ numOutputChannels).asSymbol;
 			SynthDef(defName, { | volumeAmp = 1, volumeLag = 0.1, gate=1, bus |
 				XOut.ar(bus,
-					Linen.kr(gate, attackTime: volumeLag, releaseTime: volumeLag, doneAction:2),
+					EnvGen.kr(Env.asr(attackTime: volumeLag, releaseTime: volumeLag, curve:-4), gate, doneAction:2),
 					In.ar(bus, numOutputChannels) * Lag.kr(volumeAmp, volumeLag)
 				);
 			}).send(server);

--- a/SCClassLibrary/Common/Control/Volume.sc
+++ b/SCClassLibrary/Common/Control/Volume.sc
@@ -28,7 +28,7 @@ Volume {
 			defName = (\volumeAmpControl ++ numOutputChannels).asSymbol;
 			SynthDef(defName, { | volumeAmp = 1, volumeLag = 0.1, gate=1, bus |
 				XOut.ar(bus,
-					EnvGen.kr(Env.asr(attackTime: volumeLag, releaseTime: volumeLag, curve:-4), gate, doneAction:2),
+					EnvGen.kr(Env.asr(attackTime: volumeLag, releaseTime: volumeLag, curve:\sine), gate, doneAction:2),
 					In.ar(bus, numOutputChannels) * Lag.kr(volumeAmp, volumeLag)
 				);
 			}).send(server);


### PR DESCRIPTION
Fixes #3326.

The envelope used by the server's `VolumeAmpControl` synth needs to have it's attack and release times set equal to the lag time. This way, the server's volume will not suddenly jump to the new value when setting the volume to/from 0Db.

I think this is safe for `3.9`, but I am OK with this being in `3.9.1`.