### PR TITLE
[3.8] Add missing includes to fix build errors with gcc7

### DIFF
--- a/lang/LangPrimSource/PyrSerialPrim.cpp
+++ b/lang/LangPrimSource/PyrSerialPrim.cpp
@@ -27,6 +27,7 @@
 
 #include <errno.h>
 #include <fcntl.h>
+#include <functional>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/server/plugins/DiskIO_UGens.cpp
+++ b/server/plugins/DiskIO_UGens.cpp
@@ -27,6 +27,7 @@
 #include <sndfile.h>
 
 #include <atomic>
+#include <functional>
 #include <new>
 #include <SC_Lock.h>
 


### PR DESCRIPTION
See PRs #3015, #3029. <functional> is needed in some files so that std::bind is found.


cc @dvzrv