### PR TITLE
testsuite: remove long-running duplicate test

### DIFF
--- a/testsuite/classlibrary/TestArray.sc
+++ b/testsuite/classlibrary/TestArray.sc
@@ -93,8 +93,7 @@ TestArray : UnitTest {
 		#[
 			// arsize, clumpsize -- different sizes to test:
 			[100,     10],
-			[121,     11],
-			[100000, 100]
+			[121,     11]
 		].do{ |settings|
 
 			arsize    = settings[0];


### PR DESCRIPTION
In TestArray.

Testing this large an array really doesn't do much, and it adds about 5 seconds to the overall test time. I want to cut down on clutter like this so that it becomes more feasible to run the full test suite more regularly.