### PR TITLE
PyrListPrim: correctly initialize symbols

### DIFF
--- a/lang/LangPrimSource/PyrListPrim.cpp
+++ b/lang/LangPrimSource/PyrListPrim.cpp
@@ -45,6 +45,10 @@ PyrClass *class_identdict;
 PyrSymbol *s_proto, *s_parent;
 PyrSymbol *s_delta, *s_dur, *s_stretch;
 
+// used in prEvent_IsRest
+PyrSymbol *s_type, *s_rest, *s_empty, *s_r;
+PyrClass *class_rest, *class_metarest;
+
 #define HASHSYMBOL(sym) (sym >> 5)
 
 #define ISKINDOF(obj, lo, hi)  (\
@@ -563,8 +567,6 @@ int prEvent_IsRest(struct VMGlobals *g, int numArgsPushed)
 
 	if (isKindOfSlot(arraySlot, class_array)) {
 		PyrSlot key, typeSlot;
-		static PyrSymbol *s_type = getsym("type");
-		static PyrSymbol *s_rest = getsym("rest");
 		PyrSymbol *typeSym;
 		// test 'this[\type] == \rest' first
 		SetSymbol(&key, s_type);
@@ -575,10 +577,6 @@ int prEvent_IsRest(struct VMGlobals *g, int numArgsPushed)
 		} else {
 			PyrObject *array = slotRawObject(arraySlot);
 			PyrSymbol *slotSym;
-			static PyrSymbol *s_empty = getsym("");
-			static PyrSymbol *s_r = getsym("r");
-			static PyrClass *class_rest = getsym("Rest")->u.classobj;
-			static PyrClass *class_metarest = getsym("Meta_Rest")->u.classobj;
 			PyrSlot *slot;
 			int32 size = array->size;
 			int32 i;
@@ -847,4 +845,13 @@ void initPatterns()
 	s_delta = getsym("delta");
 	s_dur = getsym("dur");
 	s_stretch = getsym("stretch");
+
+	// used in prEvent_IsRest
+	s_type = getsym("type");
+	s_rest = getsym("rest");
+	s_empty = getsym("");
+	s_r = getsym("r");
+
+	class_rest = getsym("Rest")->u.classobj;
+	class_metarest = getsym("Meta_Rest")->u.classobj;
 }


### PR DESCRIPTION
This fixes a bug in prEvent_IsRest.

Initializing in static storage results in invalid pointers when symbol table is rebuilt during interpreter init. Then, during execution of `isRest`, these stagnant `PyrClass*`s cause an assert to be thrown in `isKindOf` because the symbol is no longer recognized as pointing to a valid class.

I saw this interpreter crash sporadically (first reported in https://github.com/supercollider/supercollider/pull/3275#issuecomment-350594973). I believe that's because memory allocation would occasionally allocate a class symbol in the symbol table at the same address as the pointer.

This is a pretty big mea culpa. Sorry for asking you to write it that other way, @jamshark70. :/

My errors were not realizing that (1) you can recompile the class library while keeping sclang alive and (2) the symbol table is fully rebuilt during that recompilation.

This may have been responsible for that 'phantom' error seen on the mailing list a few weeks ago. In a release build, asserts are no-ops, so this bug would result in garbage values being passed around without warning.