### PR TITLE
class library: LocalOut correctly checks input size

### DIFF
--- a/SCClassLibrary/Common/Audio/InOut.sc
+++ b/SCClassLibrary/Common/Audio/InOut.sc
@@ -217,7 +217,7 @@ AbstractOut : UGen {
 				});
 			});
 		}, {
-			if(inputs.size <= 1, {
+			if(inputs.size <= this.class.numFixedArgs, {
 				^"missing input at index 1"
 			})
 		});


### PR DESCRIPTION
In current 3.8, the following fails:

```
SynthDef(\x, { LocalOut.kr(DC.kr(0)) }).add
```

... because the check for LocalOut's inputs mistakenly assumes that LocalOut, like Out, will provide a bus number, so the input check demands at least two inputs.

There is a maintenance release of 3.8 coming up. I can't think of any compelling reason to leave this (frankly ridiculous) bug in place.