### PR TITLE
Ableton Link synchronization

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -17,3 +17,6 @@
 [submodule "external_libraries/yaml-cpp"]
 	path = external_libraries/yaml-cpp
 	url = https://github.com/supercollider/yaml-cpp.git
+[submodule "external_libraries/link"]
+	path = external_libraries/link
+	url = https://github.com/Ableton/link

--- a/SCClassLibrary/Common/Core/Clock.sc
+++ b/SCClassLibrary/Common/Core/Clock.sc
@@ -334,6 +334,11 @@ elapsed time is whatever the system clock says it is right now. elapsed time is 
 		enable.if({this.prLinkEnable}, {this.prLinkDisable});
 	}
 
+	numPeers {
+		_TempoClock_NumPeers
+		^this.primitiveFailed
+	}
+
 	// PRIVATE
 	prStart { arg tempo, beats, seconds;
 		_TempoClock_New

--- a/SCClassLibrary/Common/Core/Clock.sc
+++ b/SCClassLibrary/Common/Core/Clock.sc
@@ -162,6 +162,7 @@ TempoClock : Clock {
 	var <beatsPerBar=4.0, barsPerBeat=0.25;
 	var <baseBarBeat=0.0, <baseBar=0.0;
 	var <>permanent=false;
+	var <>linkTempoChanged;
 
 /*
 You should only change the tempo 'now'. You can't set the tempo at some beat in the future or past, even though you might think so from the methods.
@@ -369,6 +370,12 @@ elapsed time is whatever the system clock says it is right now. elapsed time is 
 		_TempoClock_LinkDisable
 		^this.primitiveFailed
 	}
+
+	//throw tempo changed callback
+	prLinkTempoChanged { arg tempo, beats, secs, clock;
+		linkTempoChanged.value(tempo, beats, secs, clock);
+	}
+
 
 	// meter should only be changed in the TempoClock's thread.
 	setMeterAtBeat { arg newBeatsPerBar, beats;

--- a/SCClassLibrary/Common/Core/Clock.sc
+++ b/SCClassLibrary/Common/Core/Clock.sc
@@ -329,6 +329,11 @@ elapsed time is whatever the system clock says it is right now. elapsed time is 
 		^this.beats - this.bars2beats(this.bar)
 	}
 
+	//Ableton Link
+	link { arg enable = true;
+		enable.if({this.prLinkEnable}, {this.prLinkDisable});
+	}
+
 	// PRIVATE
 	prStart { arg tempo, beats, seconds;
 		_TempoClock_New
@@ -350,6 +355,16 @@ elapsed time is whatever the system clock says it is right now. elapsed time is 
 		_TempoClock_SetTempoAtTime
 		^this.primitiveFailed
 	}
+
+	prLinkEnable {
+		_TempoClock_LinkEnable
+		^this.primitiveFailed
+	}
+	prLinkDisable {
+		_TempoClock_LinkDisable
+		^this.primitiveFailed
+	}
+
 	// meter should only be changed in the TempoClock's thread.
 	setMeterAtBeat { arg newBeatsPerBar, beats;
 		// bar must be integer valued when meter changes or confusion results later.

--- a/lang/CMakeLists.txt
+++ b/lang/CMakeLists.txt
@@ -320,11 +320,16 @@ endif()
 
 target_link_libraries(libsclang ${YAMLCPP_LIBRARY})
 
+include(../external_libraries/link/AbletonLinkConfig.cmake)
+target_link_libraries(libsclang Ableton::Link)
+
 add_executable(sclang LangSource/cmdLineFuncs.cpp ${RES_FILES})
 target_link_libraries(sclang libsclang)
 target_link_libraries(sclang ${ICU_LIBRARIES})
 
 target_compile_definitions(sclang PUBLIC USE_SC_TERMINAL_CLIENT)
+
+
 
 if(LTO)
   target_compile_definitions(libsclang PUBLIC -flto -flto-report)

--- a/lang/LangPrimSource/PyrSched.cpp
+++ b/lang/LangPrimSource/PyrSched.cpp
@@ -1459,6 +1459,20 @@ int prTempoClock_LinkDisable(struct VMGlobals *g, int numArgsPushed)
     return errNone;
 }
 
+int prTempoClock_NumPeers(struct VMGlobals *g, int numArgsPushed);
+int prTempoClock_NumPeers(struct VMGlobals *g, int numArgsPushed)
+{
+    PyrSlot *a = g->sp;
+    TempoClock *clock = (TempoClock*)slotRawPtr(&slotRawObject(a)->slots[1]);
+
+    if(clock->mLink)
+        SetInt(a, clock->mLink->numPeers());
+    else
+        SetNil(a);
+
+    return errNone;
+}
+
 
 int prSystemClock_Clear(struct VMGlobals *g, int numArgsPushed);
 int prSystemClock_Clear(struct VMGlobals *g, int numArgsPushed)
@@ -1545,6 +1559,7 @@ void initSchedPrimitives()
 
 	definePrimitive(base, index++, "_TempoClock_LinkEnable", prTempoClock_LinkEnable, 1, 0);
 	definePrimitive(base, index++, "_TempoClock_LinkDisable", prTempoClock_LinkDisable, 1, 0);
+	definePrimitive(base, index++, "_TempoClock_NumPeers", prTempoClock_NumPeers, 1, 0);
 
 	definePrimitive(base, index++, "_SystemClock_Clear", prSystemClock_Clear, 1, 0);
 	definePrimitive(base, index++, "_SystemClock_Sched", prSystemClock_Sched, 3, 0);

--- a/lang/LangPrimSource/PyrSched.cpp
+++ b/lang/LangPrimSource/PyrSched.cpp
@@ -1057,6 +1057,7 @@ void TempoClock::LinkEnable(double seconds, double beatsPerBar)
         auto timeline = mLink->captureAppTimeline();
         timeline.requestBeatAtTime(beat, hrToLinkTime(seconds), beatsPerBar);
         mLink->commitAppTimeline(timeline);
+        mCondition.notify_one();
     }
 }
 


### PR DESCRIPTION
This is a follow up of #3347. This branch adds [Ableton Link](https://github.com/Ableton/link) synchronization to `TempoClock` beats and tempo.

### Testing
I only have tested it in Linux as I write this.
You can test it with any SuperCollider object that uses `TempoClock` for scheduling, such as `Pbind` or `Routine`. A quant value must set to ensure proper phase synchronization of beats, and server latency must be set to zero when working with audio. For example
```
t = TempoClock(90/60).link;
Pbind(\degree, Pseq([0,1,2,3],inf), \latency, 0).play(t, quant:4);
```
Any other [program that implements Link](https://www.ableton.com/en/link/apps/) can be used to test synchronization, although [LinkHut](https://github.com/Ableton/link/tree/master/examples/linkhut) which is available in link's sources examples is simple and good enough for that purpose.

### Interface & Design
The methods added to `TempoClock` are:
- `link(state=true)` - (des)activates link synchronization
- `numPeers` - gives the number of other client connected in the session
- `linkTempoChanged` - can be set to a callback function called when the session's tempo change.

On the C++ side, a `mLink` variable is added to the `TempoClock` class, and is instantiated to a [Link object](https://github.com/Ableton/link/blob/master/include/ableton/Link.hpp) with corresponding time, beat and tempo value when link state is set to true. Every time, beat or tempo related method  then checks whether link is up and delegates to `mLink` if so.
When link is turned off, mLink calls its destructor and set TempoClock's `mBaseBeats`, `mBaseSeconds` and `mTempo` to ensure continuity between link and SuperCollider native clock.

### Further changes
A few improvements can be made:
- Time signature (`beatsPerBar` in SC or `quantum` in Link) changes during a link session isn't handled well right now and will result in phase shifts.
- Add class methods for link in `TempoClock` that forward to the default instance
- Add documentation
- Add a CMake option to enable/disabled Link functionality at build time
