### PR TITLE
scsynth: refactor SC_WorldOptions.h for readability

### DIFF
--- a/include/server/SC_WorldOptions.h
+++ b/include/server/SC_WorldOptions.h
@@ -29,74 +29,62 @@
 
 typedef int (*PrintFunc)(const char *format, va_list ap);
 
-struct WorldOptions
+const struct WorldOptions
 {
-	const char* mPassword;
-	uint32 mNumBuffers;
-	uint32 mMaxLogins;
-	uint32 mMaxNodes;
-	uint32 mMaxGraphDefs;
-	uint32 mMaxWireBufs;
-	uint32 mNumAudioBusChannels;
-	uint32 mNumInputBusChannels;
-	uint32 mNumOutputBusChannels;
-	uint32 mNumControlBusChannels;
-	uint32 mBufLength;
-	uint32 mRealTimeMemorySize;
+	const char* mPassword = nullptr;
+	uint32 mNumBuffers = 1024;
+	uint32 mMaxLogins = 64;
+	uint32 mMaxNodes = 1024;
+	uint32 mMaxGraphDefs = 1024;
+	uint32 mMaxWireBufs = 64;
+	uint32 mNumAudioBusChannels = 1024;
+	uint32 mNumInputBusChannels = 8;
+	uint32 mNumOutputBusChannels = 8;
+	uint32 mNumControlBusChannels = 16384;
+	uint32 mBufLength = 64;
+	uint32 mRealTimeMemorySize = 8192; // in kilobytes
 
-	int mNumSharedControls;
-	float *mSharedControls;
+	int mNumSharedControls = 0;
+	float *mSharedControls = 0;
 
-	bool mRealTime;
-	bool mMemoryLocking;
+	bool mRealTime = true;
+	bool mMemoryLocking = false;
 
-	const char *mNonRealTimeCmdFilename;
-	const char *mNonRealTimeInputFilename;
-	const char *mNonRealTimeOutputFilename;
-	const char *mNonRealTimeOutputHeaderFormat;
-	const char *mNonRealTimeOutputSampleFormat;
+	const char *mNonRealTimeCmdFilename = nullptr;
+	const char *mNonRealTimeInputFilename = nullptr;
+	const char *mNonRealTimeOutputFilename = nullptr;
+	const char *mNonRealTimeOutputHeaderFormat = nullptr;
+	const char *mNonRealTimeOutputSampleFormat = nullptr;
 
-	uint32 mPreferredSampleRate;
-	uint32 mNumRGens;
-
-	uint32 mPreferredHardwareBufferFrameSize;
-
-	uint32 mLoadGraphDefs;
-
-	const char *mInputStreamsEnabled;
-	const char *mOutputStreamsEnabled;
-	const char *mInDeviceName;
-
-	int mVerbosity;
-
-	bool mRendezvous;
-
-	const char *mUGensPluginPath;
-
-	const char *mOutDeviceName;
-
-	const char *mRestrictedPath;
-
-	int mSharedMemoryID;
-};
-
-const struct WorldOptions kDefaultWorldOptions =
-{
-	0,1024,64,1024,1024,64,1024,8,8,16384,64,8192, 0,0, 1, 0, 0,0,0,0,0
 #if defined(_WIN32)
-	,44100
+#	define DEFAULT_PREFERRED_SAMPLE_RATE 44100
 #else
-	,0
+#	define DEFAULT_PREFERRED_SAMPLE_RATE 0
 #endif
-	,64, 0, 1
-	,0, 0, 0
-	,0
-	,1
-	,0
-	,0
-	,0
-	,0
-};
+
+	uint32 mPreferredSampleRate = DEFAULT_PREFERRED_SAMPLE_RATE;
+	uint32 mNumRGens = 64;
+
+	uint32 mPreferredHardwareBufferFrameSize = 0;
+
+	uint32 mLoadGraphDefs = 1;
+
+	const char *mInputStreamsEnabled = nullptr;
+	const char *mOutputStreamsEnabled = nullptr;
+	const char *mInDeviceName = nullptr;
+
+	int mVerbosity = 0;
+
+	bool mRendezvous = true;
+
+	const char *mUGensPluginPath = nullptr;
+
+	const char *mOutDeviceName = nullptr;
+
+	const char *mRestrictedPath = nullptr;
+
+	int mSharedMemoryID = 0;
+} kDefaultWorldOptions;
 
 struct SndBuf;
 

--- a/include/server/SC_WorldOptions.h
+++ b/include/server/SC_WorldOptions.h
@@ -87,8 +87,6 @@ struct WorldOptions
 	int mSharedMemoryID = 0;
 };
 
-const struct WorldOptions kDefaultWorldOptions;
-
 struct SndBuf;
 
 SCSYNTH_DLLEXPORT_C void SetPrintFunc(PrintFunc func);

--- a/include/server/SC_WorldOptions.h
+++ b/include/server/SC_WorldOptions.h
@@ -1,21 +1,21 @@
 /*
 	SuperCollider real time audio synthesis system
-    Copyright (c) 2002 James McCartney. All rights reserved.
+	Copyright (c) 2002 James McCartney. All rights reserved.
 	http://www.audiosynth.com
 
-    This program is free software; you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
-    the Free Software Foundation; either version 2 of the License, or
-    (at your option) any later version.
+	This program is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
 
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
 
-    You should have received a copy of the GNU General Public License
-    along with this program; if not, write to the Free Software
-    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
+	You should have received a copy of the GNU General Public License
+	along with this program; if not, write to the Free Software
+	Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
 */
 
 
@@ -29,8 +29,10 @@
 
 typedef int (*PrintFunc)(const char *format, va_list ap);
 
-const struct WorldOptions
+struct WorldOptions
 {
+	WorldOptions() { }
+
 	const char* mPassword = nullptr;
 	uint32 mNumBuffers = 1024;
 	uint32 mMaxLogins = 64;
@@ -45,7 +47,7 @@ const struct WorldOptions
 	uint32 mRealTimeMemorySize = 8192; // in kilobytes
 
 	int mNumSharedControls = 0;
-	float *mSharedControls = 0;
+	float *mSharedControls = nullptr;
 
 	bool mRealTime = true;
 	bool mMemoryLocking = false;
@@ -57,12 +59,11 @@ const struct WorldOptions
 	const char *mNonRealTimeOutputSampleFormat = nullptr;
 
 #if defined(_WIN32)
-#	define DEFAULT_PREFERRED_SAMPLE_RATE 44100
+	uint32 mPreferredSampleRate = 44100;
 #else
-#	define DEFAULT_PREFERRED_SAMPLE_RATE 0
+	uint32 mPreferredSampleRate = 0;
 #endif
 
-	uint32 mPreferredSampleRate = DEFAULT_PREFERRED_SAMPLE_RATE;
 	uint32 mNumRGens = 64;
 
 	uint32 mPreferredHardwareBufferFrameSize = 0;
@@ -84,7 +85,9 @@ const struct WorldOptions
 	const char *mRestrictedPath = nullptr;
 
 	int mSharedMemoryID = 0;
-} kDefaultWorldOptions;
+};
+
+const struct WorldOptions kDefaultWorldOptions;
 
 struct SndBuf;
 

--- a/lang/LangPrimSource/OSCData.cpp
+++ b/lang/LangPrimSource/OSCData.cpp
@@ -985,7 +985,7 @@ int prBootInProcessServer(VMGlobals *g, int numArgsPushed)
 
 	if (!gInternalSynthServer.mWorld) {
 		SetPrintFunc(&vpost);
-		WorldOptions options = kDefaultWorldOptions;
+		WorldOptions options;
 
 		PyrObject *optionsObj = slotRawObject(a);
 		PyrSlot *optionsSlots = optionsObj->slots;

--- a/platform/mac/SuperColliderAU/Source/SuperColliderAU.cpp
+++ b/platform/mac/SuperColliderAU/Source/SuperColliderAU.cpp
@@ -129,7 +129,7 @@ ComponentResult		SuperColliderAU::GetProperty(	AudioUnitPropertyID inID,
 ComponentResult SuperColliderAU::Initialize()
 {
 
-    WorldOptions options = kDefaultWorldOptions;
+    WorldOptions options;
     options.mPreferredSampleRate=GetSampleRate();
     options.mBufLength=kDefaultBlockSize;
     options.mPreferredHardwareBufferFrameSize = GetMaxFramesPerSlice();

--- a/server/scsynth/iPhone/iSCSynthController.mm
+++ b/server/scsynth/iPhone/iSCSynthController.mm
@@ -36,7 +36,6 @@ int vpost(const char *fmt, va_list ap)
 {
 	if (!theController && (self=[super init]))
 	{
-		options = kDefaultWorldOptions;
 		options.mBufLength = 1024;
 		timer = 0;
 		world = 0;

--- a/server/scsynth/scsynth_main.cpp
+++ b/server/scsynth/scsynth_main.cpp
@@ -146,7 +146,7 @@ int main(int argc, char* argv[])
 	int tcpPortNum = -1;
 	std::string bindTo("0.0.0.0");
 
-	WorldOptions options = kDefaultWorldOptions;
+	WorldOptions options;
 
 	for (int i=1; i<argc;) {
 		if (argv[i][0] != '-' || argv[i][1] == 0 || strchr("utBaioczblndpmwZrCNSDIOMHvVRUhPL", argv[i][1]) == 0) {

--- a/server/scsynth/scsynth_main.cpp
+++ b/server/scsynth/scsynth_main.cpp
@@ -49,6 +49,8 @@ inline int setlinebuf(FILE *stream)
 void Usage();
 void Usage()
 {
+	WorldOptions defaultOptions;
+
 	scprintf(
 		"supercollider_synth  options:\n"
 		"   -v print the supercollider version and exit\n"
@@ -98,22 +100,22 @@ void Usage()
 		"          if specified, prevents file-accessing OSC commands from\n"
 		"          accessing files outside <restricted-path>.\n"
 		"\nTo quit, send a 'quit' command via UDP or TCP, or press ctrl-C.\n\n",
-		kDefaultWorldOptions.mNumControlBusChannels,
-		kDefaultWorldOptions.mNumAudioBusChannels,
-		kDefaultWorldOptions.mNumInputBusChannels,
-		kDefaultWorldOptions.mNumOutputBusChannels,
-		kDefaultWorldOptions.mBufLength,
-		kDefaultWorldOptions.mPreferredHardwareBufferFrameSize,
-		kDefaultWorldOptions.mPreferredSampleRate,
-		kDefaultWorldOptions.mNumBuffers,
-		kDefaultWorldOptions.mMaxNodes,
-		kDefaultWorldOptions.mMaxGraphDefs,
-		kDefaultWorldOptions.mRealTimeMemorySize,
-		kDefaultWorldOptions.mMaxWireBufs,
-		kDefaultWorldOptions.mNumRGens,
-		kDefaultWorldOptions.mRendezvous,
-		kDefaultWorldOptions.mLoadGraphDefs,
-		kDefaultWorldOptions.mMaxLogins
+		defaultOptions.mNumControlBusChannels,
+		defaultOptions.mNumAudioBusChannels,
+		defaultOptions.mNumInputBusChannels,
+		defaultOptions.mNumOutputBusChannels,
+		defaultOptions.mBufLength,
+		defaultOptions.mPreferredHardwareBufferFrameSize,
+		defaultOptions.mPreferredSampleRate,
+		defaultOptions.mNumBuffers,
+		defaultOptions.mMaxNodes,
+		defaultOptions.mMaxGraphDefs,
+		defaultOptions.mRealTimeMemorySize,
+		defaultOptions.mMaxWireBufs,
+		defaultOptions.mNumRGens,
+		defaultOptions.mRendezvous,
+		defaultOptions.mLoadGraphDefs,
+		defaultOptions.mMaxLogins
 	);
 	exit(1);
 }


### PR DESCRIPTION
cleaning up some scsynth code for fun. with c++11 (currently required to build anyway) we have support for structs with default arguments, so the definition of default arguments in `WorldOptions` can be expressed much more readably.