### PR TITLE
Exclude testsuite/ from Linux tarball

### DIFF
--- a/package/package
+++ b/package/package
@@ -71,7 +71,8 @@ SuperCollider-Source/platform/mac
 SuperCollider-Source/platform/iphone
 SuperCollider-Source/platform/windows
 SuperCollider-Source/lang/LangPrimSource/HID_Utilities
-SuperCollider-Source/lang/LangPrimSource/WiiMote_OSX' >> LinuxExclusions.txt
+SuperCollider-Source/lang/LangPrimSource/WiiMote_OSX
+SuperCollider-Source/testsuite/sclang/lpc' >> LinuxExclusions.txt
 
     tar cfj "$filename" SuperCollider-Source
     tar cfjX "$filenamelinux" LinuxExclusions.txt SuperCollider-Source


### PR DESCRIPTION
the regression tests add 5 MB to the tarball and are really only for developer use. the linux tarball should be kept as slim as possible, so it makes sense to exclude this.

i am ok with keeping them in the main source tarball since they are, after all, part of the source.