### PR TITLE
plugins: deprecate PSinGrain

### DIFF
--- a/HelpSource/Classes/PSinGrain.schelp
+++ b/HelpSource/Classes/PSinGrain.schelp
@@ -7,6 +7,7 @@ Description::
 
 Very fast sine grain with a parabolic envelope.
 
+note:: This UGen is deprecated and will be removed in a future version of SC. ::
 
 classmethods::
 private:: categories

--- a/SCClassLibrary/deprecated/3.10/PSinGrain.sc
+++ b/SCClassLibrary/deprecated/3.10/PSinGrain.sc
@@ -11,6 +11,7 @@
 
 PSinGrain : UGen {
 	*ar { arg freq = 440.0, dur = 0.2, amp = 1.0;
+		this.deprecated(thisMethod, SinOsc.class.findMethod(\ar));
 		^this.multiNew('audio', freq, dur, amp)
 	}
 }


### PR DESCRIPTION
PSinGrain is a fast way of generating a sine wave grain with a parabolic envelope. it performs its intended purpose, but after the grain finishes, it starts increasing in amplitude again and never stops, which is pretty useless. it might be salvageable, but it's not worth the trouble in my view. this commit deprecates it.

closes #3292.