### PR TITLE
Update readmes for 3.9

### DIFF
--- a/README_LINUX.md
+++ b/README_LINUX.md
@@ -1,5 +1,5 @@
-Supercollider 3 for linux
-=========================
+Welcome to SuperCollider for Linux!
+===================================
 
 Intro
 -----

--- a/README_MACOS.md
+++ b/README_MACOS.md
@@ -1,5 +1,5 @@
-SuperCollider 3.8 for macOS (OS X)
-==================================
+Welcome to SuperCollider for macOS!
+===================================
 
 These are installation and build instructions for the macOS version of James McCartney's SuperCollider synthesis engine (scsynth) and programming language (sclang).
 

--- a/README_WINDOWS.md
+++ b/README_WINDOWS.md
@@ -198,12 +198,12 @@ Configuration- and support files
 An important folder containing application related user data (for example
 extensions, quarks, Help files, plugins, configuration files, synthdefs) is
 located in the Windows 'local application data' folder. In SC-speak this folder
-is called the userAppSupportDir. This location is a bit tricky to find when not
-using SC-IDE because its grandparent `AppData` is hidden by default. You
-can see it in the environment variable LOCALAPPDATA. Type this on a command
-line:
+is called the `userAppSupportDir`. This location is a bit tricky to find when
+not using SC-IDE because its grandparent `AppData` is hidden by default. You
+can see it in the environment variable LOCALAPPDATA. In a command prompt,
+execute:
 
-    $> echo %LOCALAPPDATA%
+    echo %LOCALAPPDATA%
 
 You will likely see (the grandpa referred to earlier):
 
@@ -213,10 +213,10 @@ The userAppSupportDir is in the subfolder `Local\SuperCollider`:
 
     C:\Users\<USERNAME>\AppData\Local\SuperCollider
 
-This folder is user writable and *not* deleted by uninstall. Therefore your
-settings, quarks, plugins etc persist through SC-updates. This is usually good,
+This folder is user writable and *not* deleted by uninstalling. Therefore your
+settings, quarks, and plugins persist through updates. This is usually good,
 but if you have binary "plugins" and update a minor version, e.g. 3.6 to 3.7,
-the plugins will not work any more, and cause errors during SC start-up. There
+the plugins may not work any more, and cause errors during SC start-up. There
 are more files in the `userAppSupportDir` that can cause trouble after updates,
 so you want to be aware of the possibility. In the IDE it is very easy to access
 the folder. There is a menu entry -> `Open user support directory`). You can

--- a/README_WINDOWS.md
+++ b/README_WINDOWS.md
@@ -383,6 +383,15 @@ SuperCollider repository.
     cmake -G "Visual Studio 12 2013 Win64" ..
     cmake --build . --config Release
 
+For a 32-bit build, you will use a different generator and Qt directory:
+
+    SET PATH=C:\Qt\5.5\msvc2013\bin;%PATH%
+    SET CMAKE_PREFIX_PATH=C:\Qt\5.5\msvc2013
+    mkdir build
+    cd build
+    cmake -G "Visual Studio 12 2013" ..
+    cmake --build . --config Release
+
 For the final step, you can also build from within Visual Studio:
 
     start SuperCollider.sln

--- a/README_WINDOWS.md
+++ b/README_WINDOWS.md
@@ -30,6 +30,7 @@ Table of contents
     - SuperNova
     - Other targets (install, installer)
     - PortAudio
+    - FLAC support
   - Common build problems
     - Dirty build states
     - Wrong libraries found
@@ -275,7 +276,9 @@ Required components:
   Studio Team Services (for free) in order to download this older version
 - **[Qt][Qt]** 5.5.1. Use the package `msvc2013_64` for a 64-bit build,
   `msvc2013` for 32-bit.
-- **[libsndfile][libsndfile]** >= 1.0.25
+- **[libsndfile][libsndfile]** >= 1.0.25. The binary distribution for Windows
+  does not have FLAC support. For building with FLAC support, see "FLAC
+  Support".
 - The **[Windows SDK][Windows 10 SDK]** for your edition of Windows
 
 Optional, but highly recommended:
@@ -498,6 +501,18 @@ like to tweak the PortAudio build you can single it out from the SC build with:
 DSound support out of the box. If you want ASIO or WDM-KS, you need to build
 PortAudio within MSYS2. Users have experienced issues using the WASAPI backend
 to build in MinGW-based environments. Use Visual Studio if you need WASAPI.
+
+### FLAC support
+
+The binaries distrubted by the libsndfile website do not come with FLAC support,
+which means that your SuperCollider build won't have it, either.  Unfortunately,
+there does not seem to be an easy way to get such a binary.  Instructions for
+building libsndfile with FLAC support can be found in the [libsndfile
+readme][libsndfile readme], but it's probably easiest to drop in the
+FLAC-enabled DLL that comes with our Windows releases.
+
+If you are interested in building it yourself, please check out ["Building
+libsndfile with FLAC support"][libsndfileFLAC] on the project wiki.
 
 Common build problems
 ---------------------
@@ -1356,3 +1371,5 @@ software publicly and freely available.
 [VS2013]: https://www.visualstudio.com/vs/older-downloads/ (you need to create a free developer account to download Visual Studio 2013, community edition)
 [Windows 8 SDK]: https://developer.microsoft.com/en-us/windows/downloads/windows-8-1-sdk (Windows 8.1 SDK including debugger used by Qt Creator)
 [Windows 10 SDK]: https://developer.microsoft.com/en-us/windows/downloads/windows-10-sdk  (Windows 10 SDK including debugger used by Qt Creator)
+[libsndfileFLAC]: https://github.com/supercollider/supercollider/wiki/Building-libsndfile-with-FLAC-support-(Windows,-VS-2017) (Building libsndfile with FLAC support)
+[libsndfile readme]: https://github.com/erikd/libsndfile/blob/master/README.md (libsndfile readme)

--- a/README_WINDOWS.md
+++ b/README_WINDOWS.md
@@ -43,7 +43,7 @@ Table of contents
     - More `cmake`: building supernova, qt-less, verbosity and more
     - Recalling environment- and build settings on the command line
 - Description of SC 3.9 release build
-- Known problems
+- Known issues
 - Outro
 
 Introduction
@@ -1280,8 +1280,8 @@ The following libraries and tools were used to build the Windows installers
 - DirectX v9 (June 2010)
 - NSIS 3.02.1
 
-Known problems
-==============
+Known issues
+============
 
 - READLINE/Command line-mode is not available.
 

--- a/README_WINDOWS.md
+++ b/README_WINDOWS.md
@@ -3,13 +3,13 @@ Welcome to SuperCollider for Windows!
 
 This Readme has two sections: "Installing SuperCollider", and "Building
 SuperCollider for Windows". The first section provides basic information to get
-going, and also introduces some common SuperCollider terminology. The second section
-is subdivided into two sections, "Quick Steps" and "Walkthroughs". Quick Steps
-contains the essentials for a successful build, the "Walkthroughs" are more
-tutorial-like and written for less experienced developers. They are not required
-reading to build the Windows version of SC. Furthermore the individual chapters
-in "Walkthroughs" are not expected to be read consecutively; they might appear
-quite repetitive if done so.
+going, and also introduces some common SuperCollider terminology. The second
+section is subdivided into two sections: direct build instructions, and
+"Walkthroughs". The first part contains the essentials for a successful build,
+while the walkthroughs are more tutorial-like and written for less experienced
+developers. They are not required reading to build the Windows version of SC.
+Furthermore, the individual chapters in "Walkthroughs" are not expected to be
+read consecutively; they might appear quite repetitive if done so.
 
 Table of contents
 -----------------

--- a/README_WINDOWS.md
+++ b/README_WINDOWS.md
@@ -288,7 +288,7 @@ Optional components:
 - **[readline][readline]** for command-line support. However, this is currently
   non-functional.
 - **DirectX SDK** [v.9][dx9sdk] for Direct Sound support in Portaudio
-- **[NSIS][nsis]** to create an installation execuatable. Make sure to add
+- **[NSIS][nsis]** to create an installation executable. Make sure to add
   `makensis` to your `PATH`!
 
 Other development tools:
@@ -358,8 +358,7 @@ For a **32-bit** build:
 
     lib /def:libfftw3f-3.def
 
-The SC build only uses the single precision version of the fftw library
-(fftw3f).
+The SC build only uses the single precision FFTW library (fftw3f).
 
 *Note*: if you compile FFTW yourself, all files must end up in the root fftw
 directory.
@@ -404,7 +403,7 @@ building or in the build command given to CMake:
 
     cmake --build . --config <config>
 
-The four options are:
+The four options for \<config\> are:
 
 - `Debug`: no optimization, debugging code enabled
 - `Release`: full optimization, no debugging code
@@ -488,8 +487,8 @@ like to tweak the PortAudio build you can single it out from the SC build with:
 
 *Note:* MSYS2 provides a portaudio package, but it only comes with MME and
 DSound support out of the box. If you want ASIO or WDM-KS, you need to build
-PortAudio within MSYS2. Users have experienced issues using WASAPI backend to
-build in MinGW-based environments. Use Visual Studio if you need WASAPI.
+PortAudio within MSYS2. Users have experienced issues using the WASAPI backend
+to build in MinGW-based environments. Use Visual Studio if you need WASAPI.
 
 Common build problems
 ---------------------

--- a/README_WINDOWS.md
+++ b/README_WINDOWS.md
@@ -1,8 +1,6 @@
 Welcome to Supercollider 3.8 for Windows!
 =========================================
 
-**IMPORTANT NOTE**:
-
 This Readme has two sections: "Installing SuperCollider", and "Building
 SuperCollider for Windows". The first section provides basic information to get
 going, and also introduces some common SuperCollider terminology. The second section

--- a/README_WINDOWS.md
+++ b/README_WINDOWS.md
@@ -156,8 +156,7 @@ Help Browser'.
 Using SuperCollider in command line mode
 ----------------------------------------
 
-**This is currently unsupported, but will be fixed in a future release. Stay
-tuned for updates!**
+**This is currently unsupported.**
 
 1. Open a Windows command line window (the cmd.exe program).
 

--- a/README_WINDOWS.md
+++ b/README_WINDOWS.md
@@ -531,8 +531,8 @@ for libraries that do not depend on MinGW runtimes or make sure all components
 in the build can use the same runtimes.
 - Architecture mismatches. This does not only concern target system architecture
 (32- or 64-bit) but also the toolchain used to compile SC and Qt. They have to
-match as closely as possible. SC built with VS requires the msvc2013_64
-package; the MinGW 4.8.2 build requires mingw492_32.
+match as closely as possible. SC built with VS requires the msvc2013_64 or
+msvc2013 package.
 - Dirty states in your build folder (usually resulting from changes in the build
 configuration). See below for how to fix this.
 - cmake finds and uses different libraries on your system than the ones intended

--- a/README_WINDOWS.md
+++ b/README_WINDOWS.md
@@ -22,7 +22,7 @@ Table of contents
   - Configuration- and support files
   - Extensions and Quarks
 - **Building SuperCollider for Windows**
-  - Components
+  - Required and Optional Components
   - Preparing to build
   - Configuration and building
   - Additional build settings

--- a/README_WINDOWS.md
+++ b/README_WINDOWS.md
@@ -42,7 +42,7 @@ Table of contents
     - Using Qt Creator
     - More `cmake`: building supernova, qt-less, verbosity and more
     - Recalling environment- and build settings on the command line
-- Description of SC 3.8 release build
+- Description of SC 3.9 release build
 - Known problems
 - Outro
 
@@ -1264,44 +1264,21 @@ Another way of storing CMake command line arguments is creating a "toolchain"
 file. This is the CMake suggested method. Please look up the CMake documentation
 if you require an advanced configuration, and are interested in this approach.
 
-Description of the SC 3.8 release build
+Description of the SC 3.9 release build
 ---------------------------------------
 
-All dependencies not contained in the SC source (external_libraries) were
-downloaded from the original providers (see links at the end). For both VS and
-QT the free community editions were used.
+The following libraries and tools were used to build the Windows installers
+"Windows-x86-VS" and "Windows-x64-VS":
 
-SCWin64 3.8 was built with Visual Studio 12/2013
-
-- Qt5.5.1 (flavour msvc2013_64)
-- libsndfile 1.0.27
+- Visual Studio 12.0 2013, compiler version 18.00.40629
+- Qt5.5.1
+  - for Windows-x86-VS: distribution `msvc2013`
+  - for Windows-x64-VS: distribution `msvc2013_64`
+- libsndfile 1.0.28, compiled by Brian Heim for FLAC support
 - FFTW 3.3.5
-
-SCWin32 3.8 was built using Qt Creator, combining MinGW 4.8.2 and Qt 5.5.1
-mingw492_32 into a kit. The MinGW distribution provided by Qt was used.
-
-- linsndfile 1.0.27
-- FFTW 3.3.5
-- Readline 5.0.1 (as provided by gnuwin32)
-
-For both builds all other external libraries (including portaudio) were compiled
-as part of the SC build, using the sources embedded in the SC source tree (in
-the folder external libraries) and the settings defined there.
-
-The portaudio build was extended for ASIO support by adding the ASIO-SDK:
-
 - ASIO SDK 2.3
-
-For DSound support different DirectX versions had to be used in the VS and MinGW
-build. For VS:
-
 - DirectX v9 (June 2010)
-
-The MinGW build uses the libraries coming with MinGW.
-
-The tools used were Git for Windows v2.10.2.windows.1, cmake v3.52, and NSIS v3.0b1
-to create the binary installer.
-
+- NSIS 3.02.1
 
 Known problems
 ==============

--- a/README_WINDOWS.md
+++ b/README_WINDOWS.md
@@ -61,7 +61,7 @@ This is the Windows version of James McCartney's SuperCollider synthesis engine
 (`scsynth`) and programming language (`sclang`), distributed together with a
 dedicated IDE (`scide`).
 
-SuperCollider's central website is on Github:
+SuperCollider's homepage is:
 
     http://supercollider.github.io/
 
@@ -81,7 +81,7 @@ from Sourceforge:
 
     http://sourceforge.net/projects/supercollider/files/?source=navbar
 
-There is an online version of SuperCollider Help, the site SCDOC:
+There is an online version of SuperCollider Help:
 
     http://doc.sccode.org/Help.html
 
@@ -164,11 +164,8 @@ Help Browser'.
 Using SuperCollider in command line mode
 ----------------------------------------
 
-*Note*: this is currently broken (Nov 2016, SC3.8). If you are using the 32-bit
-version, you can get output in emergency situations: either keep your finger on
-the key for about half a second or type each keystroke twice for it to
-register. You can also send text files to sclang by passing the filename as
-argument to `sclang`.
+**This is currently unsupported, but will be fixed in a future release. Stay
+tuned for updates!**
 
 1. Open a Windows command line window (the cmd.exe program).
 

--- a/README_WINDOWS.md
+++ b/README_WINDOWS.md
@@ -24,24 +24,25 @@ Table of contents
   - Configuration- and support files
   - Extensions and Quarks
 - **Building SuperCollider for Windows**
-  - Build Basics
-  - Quick Steps
-    - Required software
-      - Getting packages with MSYS2
-      - Getting the SuperCollider source code
-    - Arranging the components (non-MSYS2 builds only)
-    - Configuring and executing a build
-      - MinGW (non-MSYS2)
-      - Visual Studio 2013
-      - MSYS2
+  - Components
+    - Required components
+    - Optional components
+    - Other development tools
+  - Preparing to build
+    - Obtaining the source code
+    - Arranging the components
+    - Creating VS libs for FFTW
+    - ASIO support
+  - Configuration and building
+    - Basic build
     - Additional build settings
-      - `cmake` configuration options
-      - Build options
-      - Portaudio
-      - HIDAPI with native MinGW builds
-  - Diagnosing build problems
-      - Dirty build states
-      - Wrong libraries found
+      - Build type
+      - SuperNova
+      - Other targets (install, installer)
+      - PortAudio
+  - Common build problems
+    - Dirty build states
+    - Wrong libraries found
   - Walkthroughs
     - The trial-error approach: building sc3-plugins and aggregating
       build settings to pass to `cmake`

--- a/README_WINDOWS.md
+++ b/README_WINDOWS.md
@@ -1,5 +1,5 @@
-Welcome to Supercollider 3.8 for Windows!
-=========================================
+Welcome to SuperCollider for Windows!
+=====================================
 
 This Readme has two sections: "Installing SuperCollider", and "Building
 SuperCollider for Windows". The first section provides basic information to get

--- a/README_WINDOWS.md
+++ b/README_WINDOWS.md
@@ -263,148 +263,57 @@ Enjoy SuperCollider!
 Building SuperCollider for Windows
 ==================================
 
-Build Basics
-------------
+SuperCollider uses [CMake][cmake] as its build system. The main toolchain
+supported by the development team is Visual Studio - Microsoft's IDE for C++ -
+which also includes Visual C++, the official Microsoft C++ compiler. Use other
+build environments and toolchains (such as MinGW, gcc, and Cygwin) at your own
+risk.
 
-If you can't be bothered and have to get building immediately,
-then the quickest path through this material is:
+Components
+----------
 
-1. Pick a build tool: VS 2013, native MinGW, or MSYS2
-2. Download libraries as listed in "Required software"
-3. If you're not using MSYS2, follow the instructions in
-    "Arranging the components"
-4. Jump to the section on your build tool under "Configuring and executing a
-    build"
+### Required components
 
-Otherwise, read on.
-
-SuperCollider uses the cross platform build system [CMake][cmake], which works
-well for many OS and toolchain combinations. While CMake is command-line
-oriented, it can also be controlled from a GUI (`cmake-gui`) and is very well
-integrated into Qt Creator.
-
-There are three main ways you can build SuperCollider on Windows:
-- Visual Studio 2013
-- Native MinGW
-- MSYS2 + MinGW
-
-Of these, MSYS2 will be the most familiar for Unix developers.
-
-Some approaches are limited in certain respects:
-- Visual Studio cannot build libreadline or supernova (a multithreading version
-   of scsynth)
-- Native MinGW can only build a 32-bit executable
-- Visual Studio and native MinGW are limited to Qt 5.5.1
-
-The Windows port of SC is in a stage of transition. Native MinGW is the oldest
-method; Visual Studio 2013 is newer; and MSYS2 support was only made available
-while developing SuperCollider 3.9. Keeping these options open will make it
-easier for those who already do Windows development to get started with
-SuperCollider, without having to be limited by toolchain or IDE.
-
-Quick Steps
------------
-
-### Required software
-
-To build with Visual Studio or native MinGW, you will have to download and
-install these packages manually. When you are given the option, make sure to
-choose the 32-bit or 64-bit version of each library as appropriate. For MSYS2,
-see the instructions below.
+You will need to install these packages manually if you do not already have
+them. When you are given the option, make sure to choose the 32-bit or 64-bit
+version of each library as appropriate.
 
 - **[Git][Git]** for Windows
-- **[CMake][cmake]**: 3.5.2 with native minGW; otherwise, latest version
-- The SuperCollider source code
-- Build tools: one of
-    - MinGW as bundled with **[Qt 5.5.1][Qt55]** (distribution 'mingw492')
-    - **[MSYS2+MinGW][MSYS2]**
-    - **[Visual Studio 12 2013][VS2013]**: note that you will need to join Visual
-        Studio Team Services (for free) in order to download this older version
-- Required Libraries
-    - **[Qt][Qt]** >= 5.5.1. The current version, 5.8, works with MSYS2. For
-        Visual Studio and native MinGW, you must use 5.5.1 as the WebKit
-        component of Qt, which SuperCollider's IDE requires, was dropped in 5.6.
+- **[CMake][cmake]**
+- **[Visual Studio 12 2013][VS2013]**: note that you will need to join Visual
+  Studio Team Services (for free) in order to download this older version
+- **[Qt][Qt]** 5.5.1. Use the package `msvc2013_64` for a 64-bit build,
+  `msvc2013` for 32-bit.
+- **[libsndfile][libsndfile]** >= 1.0.25
+- The **[Windows SDK][Windows 10 SDK]** for your edition of Windows
 
-        If you're not using MSYS2, use the official archived download, and
-        choose from the following packages:
-            - msvc2013_64, for a 64-bit Visual Studio build
-            - msvc2013, for a 32-bit Visual Studio build
-            - mingw492 (32-bit), for a MinGW build
+These libraries are not strictly required, but highly recommended:
 
-    - **[libsndfile][libsndfile]** >= 1.0.25
-    - The **[Windows SDK][Windows 10 SDK]** for your edition of Windows
-- Recommended Libraries
-    - **[fftw][fftw]** >= 3.3.4. See the instructions below on arranging the
-        libraries if you are making a Visual Studio or native MinGW build.
-    - **[Asio SDK][asiosdk]** >= 2.3, for Asio support in PortAudio
-- Optional Libraries
-    - **[readline][readline]** = 5.0.1. More recent versions found in MinGW
-        distributions do *not* currently work in *native* MinGW builds. In MSYS
-        builds more recent (and 64-bit) versions cann be used, see however the
-        restrictions mentioned in the introductory note of "Using SC on the
-        command line". Readline cannot be used at all in Visual Studio builds.
-    - **DirectX SDK** [v.9][dx9sdk] for VS build. (Direct Sound support in Portaudio)
-    - **[NSIS][nsis]**, if you want to create a binary SC installer (add the
-        binary `makensis` to PATH)
-- Convenience
-    - a Unix line-ending friendly text editor like **[Atom][atomeditor]** or
-        **[Notepad++][notepad++]**. There are SuperCollider packages available
-        for Atom; we recommend using that.
-    - **[7-zip][7-zip]** to extract .tar and .gz format archives
+- **[fftw][fftw]** >= 3.3.4
+- **[Asio SDK][asiosdk]** >= 2.3, for Asio support in PortAudio
 
-#### Getting packages with MSYS2
+### Optional components
 
-If this is your first time using MSYS2, here are some things to know.
-People who grew up with Windows hate MSYS2, people with a Unix background
-think it is God sent. Make your choice. As a build system it is as close
-as it can get to an Arch Linux clone running within Windows.
+- **[readline][readline]** for command-line support. However, this is currently
+  non-functional.
+- **DirectX SDK** [v.9][dx9sdk] for Direct Sound support in Portaudio
+- **[NSIS][nsis]** to create an installation execuatable. Make sure to add
+  `makensis` to your `PATH`!
 
-MSYS2 offers very up-to-date 32- and 64-bit versions of every package, and
-provides a full set of libraries built with the same toolchain, so compatibility
-considerations are a thing of the past. If you haven't downloaded it yet,
-[do that now][MSYS2] and consider reading over the wiki before continuing:
+### Other development tools
 
-    https://github.com/msys2/msys2/wiki
+- a Unix line-ending friendly text editor like **[Atom][atomeditor]** or
+  **[Notepad++][notepad++]**. There are SuperCollider packages available
+  for Atom.
+- **[7-zip][7-zip]** to extract .tar and .gz format archives
 
-The prefix `mingw-w64-` distinguishes a package as being used outside the
-enviroment of MSYS2—in other words, things you'll use to build SuperCollider!
-`x86_64` bit identifies a package as being 64-bit, and `i686` means 32-bit.
+Preparing to build
+------------------
 
-MSYS2 uses a clone of the Arch Linux package manager, `pacman`. After opening
-the MinGW64 shell installed with MSYS2, run the following command repeatedly
-until MSYS2 is fully updated:
+### Obtaining the source code
 
-    pacman -Syuu
-
-Get some basic packages:
-
-    pacman -S base-devel git mingw-w64-x86_64-toolchain
-
-Some other, completely optional tools (not used for building SuperCollider):
-
-    pacman -S subversion p7zip perl ruby python2 nano vim emacs
-
-Now get the remaining packages needed for SuperCollider. If you want to be
-able to do both 32-bit and 64-bit builds, use `{x86_64,i686}` in place of
-`x86_64`:
-
-    pacman -S mingw-w64-x86_64-{qt5,clang,cmake,portaudio,libsndfile,fftw}
-
-A free IDE with good Qt and Cmake integration is:
-
-    - `mingw_w64-x86_64-qt-creator` for Qt Creator.
-
-If you plan to build supernova, you will also need:
-
-    - `mingw-w64-x86_64-dlfcn`
-
-If you are not sure what a package is called you can search:
-
-    pacman -Ss libsndfile
-
-#### Getting the SuperCollider source code
-
-`cd` to wherever you'd like to build SuperCollider, then:
+`cd` to wherever you'd like to build SuperCollider, then checkout the repository
+with:
 
     git clone --recursive https://github.com/supercollider/supercollider.git
 
@@ -413,28 +322,18 @@ switching to different stages of submodules might be required. In this case use:
 
     git submodule update
 
-`git submodule sync` is useful if the address of a submodule has changed; Git
-will usually tell if a resynchronization/update is required.
+Note that a slightly patched version of PortAudio source is provided as
+submodule. PortAudio can support up to five different backends: MME, DSound,
+WDM-KS, ASIO and WASAPI. For ASIO support, you will need to install the ASIO
+SDK; for DSound, install the DirectX SDK (see the preceding section).
 
-*Fine print*: the PortAudio library is not available as binary download. A
-slightly patched version of its source is provided as submodule. Portaudio can
-support up to five different backends: MME, DSound, WDM-KS, ASIO and WASAPI.
+### Arranging the components
 
-- For ASIO support the (gratis) ASIO-SDK from Steinberg has to be added to the
-  source tree in any build environment.
-- For DSound support the *Visual Studio* build requires to install the DirectX
-  SDK Version 9. (MinGW (and implicitly MSYS2) provide the required libraries)
-
-The MSYS2 SC-build uses the binary portaudio package provided by MSYS2. By
-default this only comes with MME and DSound support. If you want additional
-backends (ASIO and/or WDM-KS strongly recommended) you need to rebuild the
-portaudio package within the MSYS2 environment (very easy).
-
-
-### Arranging the components (non-MSYS2 builds only)
-
-*Note:* creating the folder structure *exactly as given here* will save you
-from likely frustration when CMake cannot find dependencies.
+*Note:* If you are only building 64-bit SuperCollider, you will likely not even
+have to bother with this step, as CMake will find the libraries where they are
+installed by default. However, creating the folder structure *exactly as given
+here* could save you from headaches if CMake cannot find them for whatever
+reason.
 
 Create a new folder next to where you cloned SuperCollider. If you're making a
 32-bit build, call it `x86`; use `x64` for 64-bit. Move the installed files of
@@ -453,20 +352,25 @@ the following folder structure *exactly*:
             lib
         fftw
 
-If you are making a Visual Studio build, you must create library files by
-`cd`ing to the fftw directory and executing the following command:
+### Creating VS libs for FFTW
 
-    lib /def:libfftw3f-3.def
-
-Note: the SC build only uses the single precision version of the fftw library
-(fftw3f).
-
-For 64-bit, add `/machine:x64`:
+FFTW does not provide build files for Visual Studio. In the **Developer Command
+Prompt for VS2013** (note that this this is not `cmd.exe`), `cd` to the
+directory where FFTW is installed and, for a **64-bit** build:
 
     lib /machine:x64 /def:libfftw3f-3.def
 
+For a **32-bit** build:
+
+    lib /def:libfftw3f-3.def
+
+The SC build only uses the single precision version of the fftw library
+(fftw3f).
+
 *Note*: if you compile FFTW yourself, all files must end up in the root fftw
 directory.
+
+### ASIO support
 
 In order to get support for ASIO drivers, follow this directory structure:
 
@@ -479,112 +383,31 @@ In order to get support for ASIO drivers, follow this directory structure:
                 ...
             ...
 
-For DSound support in Visual Studio, you have to download the DirectX SDK
-[version 9][dx9sdk] and install it.
+Configuration and Building
+--------------------------
 
-*Fine print*: If you install the DirectX SDK and try to build using MinGW, the
-PortAudio build will likely break. Try to avoid the DXSDK detection in that
-case; for example, by editing CMakeLists.txt in the PortAudio root folder.
-DSound support will nevertheless be built when using MinGW libraries. If
-you want to avoid adding in DS-support, set `PA_USE_DS` in the same file to
-`OFF`.
+*Note:* This section assumes familiarity with the command line. The section below titled
+"Avoiding the command line" may be helpful if that doesn't describe you.
 
-### Configuring and executing the build
+*Note:* You should always use forward slashes for paths passed to CMake.
 
-The sections below assume that you are comfortable with the command line. If
-not, see the walkthrough below, "Avoiding the command line".
+### Basic build
 
-Once everything has been arranged properly, `cmake` must be told:
+**Confirm the location of your Qt install before executing these commands.** You
+may need to modify them if you installed Qt somewhere else. The following
+commands should be executed starting from the root directory of the
+SuperCollider repository.
 
-    - which "generator" to use
-    - the location of the compiler
-    - the location of Qt
-    - the location of SuperCollider's source code
-
-If you're all set, jump to the section below specific to your build tool.
-
-*Note:* You should always use forward slashes for path statements when using
-CMake commands. When creating/modifying environment variables, or interacting
-otherwise directly with Windows command line functionality (`cd`, `rmdir`, ...),
-you should use the proper Windows syntax with backslashes as directory
-delimiters.
-
-*Note:* The SC source given as the last parameter of the `cmake` command. The
-pointer to the source directory is the only element of the cmake command that
-has to be repeated each time cmake is run to configure the build. The other
-options are stored in "CMakeCache.txt" in the build folder for subsequent runs.
-
-#### MinGW (non-MSYS2)
-
-The following steps build SuperCollider in a subdirectory of the SC source
-directory called 'build'. You may want to check the path where you installed
-Qt—if it's not `C:\Qt\`, then change these commands accordingly. You should
-`cd` into the SuperCollider source folder to begin.
-
-    SET PATH=C:\Qt\5.5\mingw492_32\bin;C:\Qt\Tools\mingw492_32\bin;%PATH%
-    SET CMAKE_PREFIX_PATH=C:\Qt\5.5\mingw492_32
-    mkdir build
-    cd build
-    cmake -G "MinGW Makefiles" ..
-    cmake --build .
-
-This is the bare-bones, dead-simple way to build SuperCollider with MinGW!
-
-A line-by-line explanation:
-
-    SET PATH=C:\Qt\5.5\mingw492_32\bin;C:\Qt\Tools\mingw492_32\bin;%PATH%
-    SET CMAKE_PREFIX_PATH=C:\Qt\5.5\mingw492_32
-
-Tell `cmake` where to look for the Qt files and MinGW.
-
-    mkdir build
-    cd build
-
-Create the build directory and move into it.
-
-    cmake -G "MinGW Makefiles" ..
-
-Configure the makefiles to prepare for building.
-
-    cmake --build .
-
-Mind the dot after `build`. It refers to the folder where the cmake build
-configuration files are located.
-
-Build SuperCollider.
-
-#### Visual Studio 2013
-
-You may want to check the path where you installed Qt—if it's not `C:\Qt\`, then
-change these commands accordingly. You should `cd` into the SuperCollider source
-folder to begin.
-
-    SET PATH=C:\Qt\5.5\msvc2013_64\bin;C:\Qt\Tools\msvc2013_64\bin;%PATH%
+    SET PATH=C:\Qt\5.5\msvc2013_64\bin;%PATH%
     SET CMAKE_PREFIX_PATH=C:\Qt\5.5\msvc2013_64
     mkdir build
     cd build
     cmake -G "Visual Studio 12 2013 Win64" ..
+    cmake --build . --config Release
 
-For the final step, you can either build within the Visual Studio IDE:
+For the final step, you can also build from within Visual Studio:
 
     start SuperCollider.sln
-
-Or build using `cmake` as usual:
-
-    cmake --build .
-
-The preceding MinGW section contains an explanation of this command sequence.
-
-#### MSYS2
-
-    mkdir build
-    cd build
-    cmake -G "MSYS Makefiles" ..
-    cmake --build . -- -j4
-
-The preceding MinGW section contains an explanation of this command sequence.
-`-- -j4` passes the argument -j4 (use 4 processor threads) to the makefile.
-Adjust the number to your processor ;)
 
 ### Additional build settings
 
@@ -592,32 +415,36 @@ Listed here are common additional configurations you may want to use. For a
 more complete list, use `cmake --help` and/or see the section "More `cmake`:
 building supernova, qt-less, verbosity and more" below.
 
-#### `cmake` configuration options
+#### Build type
 
-There are a number of additional options you can use in the penultimate build
-step:
+The `CMAKE_BUILD_TYPE` controls optimization level and whether or not debugging
+code (asserts, info messages, and other similar code) is included in the
+executable. The configuration is specified either in Visual Studio before
+building or in the build command given to CMake:
 
-    cmake -G "Toolchain Name" [-D OPTION_NAME] ..
+    cmake --build . --config <config>
 
-When using native MinGW or MSYS2 you can specify the build configuration with
-`CMAKE_BUILD_TYPE`. The default is `RelWithDebInfo` ("Release build, with debug
-info"), but there are other possibilities:
+The four options are:
 
-    cmake -D CMAKE_BUILD_TYPE=Debug ..
-    cmake -D CMAKE_BUILD_TYPE=Release ..
-    cmake -D CMAKE_BUILD_TYPE=RelMinSize ..
+- `Debug`: no optimization, debugging code enabled
+- `Release`: full optimization, no debugging code
+- `RelWithDebInfo`: "release with debug info." Full optimization, debugging code
+  enabled.
+- `RelMinSize`: "release, minimal size." Like `Release`, but optimized for
+  minimal executable size.
 
-When using Visual Studio the build configuration can only be specified in the
-build step. Default here is `Debug`:
+The `Debug` configuration is used to develop the C++ codebase. For developing
+the SuperCollider core libraries, `Release` should be fine. Using a `Debug`
+build in production is strongly discouraged, as it will be many times slower
+than `Release`.
 
-    cmake --build . --config Release
-
+#### SuperNova
 
 If you want to build supernova, add `-D SUPERNOVA=ON`
 
     cmake -D SUPERNOVA=ON ..
 
-#### Build options
+#### Other targets (install, installer)
 
 If you used the basic instructions above, you will end up with three target
 folders (four if supernova is built). You can run these executables to develop
@@ -642,18 +469,17 @@ If you want to run SuperCollider independently of the build environment:
 
     cmake --build . --target install
 
-This "builds the target install", which means that the SC files proper are
-combined with all required external libraries to create a *portable* application
-folder.
+This will create a self-contained, portable application which bundles all the
+required libraries.
 
 If you want to create a binary installer, first build the target install, then
-make sure `makensis`, the command-line tool for NSIS, is in your PATH:
+make sure `makensis`, the command-line tool for NSIS, is in your PATH. Finally,
 
     cmake --build . --target installer
 
 The SuperCollider installer executable will be built in the directory path:
 
-    ...\build\Install\SuperCollider.exe
+    <...>\build\Install\SuperCollider.exe
 
 The exact name will vary depending on what architecture and build configuration
 you specified.
@@ -669,69 +495,24 @@ always loose the local customizations and additions stored in the
 userAppSupportDirectory. The new Quarks system provides means to make porting
 of extension/Quark groups easier.
 
-#### Portaudio
+#### PortAudio
 
-Portaudio is provided as submodule of SC and is built automatically as part
-of the SC-build. In order to add ASIO- and/or DSound support, the respective
-SDKs have to be added to the build.
-
-ASIO: download the SDK from [Steinberg][asiosdk], extract the zip and place
-the folder in a sibling folder of the portaudio folder in external_libraries.
-The folder name should not contain dots, start with `as`, and be the immediate
-parent of the library folders (asio, common, ...). You should end up with a
-folder tree like this:
-
-    sc-source
-        external_libraries
-            portaudio_sc_org
-            asiosdk
-                asio
-                common
-                driver
-                host
-
-DSound/DirectX: The VS-build requires DirectX. It should be installed as usual.
-[version 9 (June 2010)][dx9sdk].
-
-You can study the file `CMakeLists.txt` in the portaudio folder
-(external_libraries\portaudio_sc_org) to learn about the options that the build
-provides. With default settings, all APIs that *work out of the box* are enabled
-and only the library for static linking is built. In the VS-build all APIs are
-enabled, in the MinGW build WASAPI had to be omitted, and some features of full
-duplex mode in DSound had to be disabled. If you would like to tweak the PA-
-build you can single it out from the SC build like so:
+You can study the file `external_libraries\portaudio_sc_org\CMakeLists.txt` to
+learn about the options that the build provides. With default settings, all APIs
+that *work out of the box* are enabled and only the library for static linking
+is built. In the VS-build all APIs are enabled. For MinGW, WASAPI is ommitted
+and some features of DSound's full duplex mode are unavailable.  If you would
+like to tweak the PortAudio build you can single it out from the SC build with:
 
     cmake --build . --target portaudio
 
-MSYS2 provides a portaudio package, but it only comes with MME and DSound support
-out of the box. If you want ASIO or WDM-KS, you need to build portaudio within
-the MSYS2 framework. At the time of this writing the WASAPI backend could not be
-built in MinGW-based environments. Use VS, if you need WASAPI.
+*Note:* MSYS2 provides a portaudio package, but it only comes with MME and
+DSound support out of the box. If you want ASIO or WDM-KS, you need to build
+PortAudio within MSYS2. Users have experienced issues using WASAPI backend to
+build in MinGW-based environments. Use Visual Studio if you need WASAPI.
 
-#### HIDAPI with native MinGW builds
-
-Currently, HIDAPI is disabled by default for native MinGW builds using MinGW/GCC
-versions below 5.3. It can be enabled by manually altering the source code:
-
-In `/external-libraries/hidapi/hidapi_parser/hidapi_parser.c`, change the
-header includes as follows:
-
-    // #include <hidsdi.h>
-    #include "../windows/hidsdi.h"
-
-In `SC-source/external-libraries/hidapi/windows/hid.c`:
-
-    // #include <hidsdi.h>
-    #include "./hidsdi.h"
-
-Rerun the cmake configuration step and add the argument:
-
-    -D SC_HIDAPI=ON
-
-SuperCollider will now build with HIDAPI.
-
-Troubleshooting build problems
-------------------------------
+Common build problems
+---------------------
 
 These are likely the most common causes of build problems:
 

--- a/README_WINDOWS.md
+++ b/README_WINDOWS.md
@@ -25,21 +25,13 @@ Table of contents
   - Extensions and Quarks
 - **Building SuperCollider for Windows**
   - Components
-    - Required components
-    - Optional components
-    - Other development tools
   - Preparing to build
-    - Obtaining the source code
-    - Arranging the components
-    - Creating VS libs for FFTW
-    - ASIO support
   - Configuration and building
-    - Basic build
-    - Additional build settings
-      - Build type
-      - SuperNova
-      - Other targets (install, installer)
-      - PortAudio
+  - Additional build settings
+    - Build type
+    - SuperNova
+    - Other targets (install, installer)
+    - PortAudio
   - Common build problems
     - Dirty build states
     - Wrong libraries found
@@ -270,14 +262,14 @@ which also includes Visual C++, the official Microsoft C++ compiler. Use other
 build environments and toolchains (such as MinGW, gcc, and Cygwin) at your own
 risk.
 
-Components
-----------
-
-### Required components
+Required and Optional Components
+--------------------------------
 
 You will need to install these packages manually if you do not already have
 them. When you are given the option, make sure to choose the 32-bit or 64-bit
 version of each library as appropriate.
+
+Required components:
 
 - **[Git][Git]** for Windows
 - **[CMake][cmake]**
@@ -288,12 +280,12 @@ version of each library as appropriate.
 - **[libsndfile][libsndfile]** >= 1.0.25
 - The **[Windows SDK][Windows 10 SDK]** for your edition of Windows
 
-These libraries are not strictly required, but highly recommended:
+Optional, but highly recommended:
 
 - **[fftw][fftw]** >= 3.3.4
 - **[Asio SDK][asiosdk]** >= 2.3, for Asio support in PortAudio
 
-### Optional components
+Optional components:
 
 - **[readline][readline]** for command-line support. However, this is currently
   non-functional.
@@ -301,7 +293,7 @@ These libraries are not strictly required, but highly recommended:
 - **[NSIS][nsis]** to create an installation execuatable. Make sure to add
   `makensis` to your `PATH`!
 
-### Other development tools
+Other development tools:
 
 - a Unix line-ending friendly text editor like **[Atom][atomeditor]** or
   **[Notepad++][notepad++]**. There are SuperCollider packages available
@@ -311,10 +303,7 @@ These libraries are not strictly required, but highly recommended:
 Preparing to build
 ------------------
 
-### Obtaining the source code
-
-`cd` to wherever you'd like to build SuperCollider, then checkout the repository
-with:
+First obtain the source code by checking out the repository:
 
     git clone --recursive https://github.com/supercollider/supercollider.git
 
@@ -330,11 +319,8 @@ SDK; for DSound, install the DirectX SDK (see the preceding section).
 
 ### Arranging the components
 
-*Note:* If you are only building 64-bit SuperCollider, you will likely not even
-have to bother with this step, as CMake will find the libraries where they are
-installed by default. However, creating the folder structure *exactly as given
-here* could save you from headaches if CMake cannot find them for whatever
-reason.
+*Note:* creating the folder structure *exactly as given here* could save you
+from headaches if CMake cannot find them for whatever reason.
 
 Create a new folder next to where you cloned SuperCollider. If you're making a
 32-bit build, call it `x86`; use `x64` for 64-bit. Move the installed files of
@@ -353,7 +339,16 @@ the following folder structure *exactly*:
             lib
         fftw
 
-### Creating VS libs for FFTW
+In order to get support for ASIO drivers, follow this directory structure:
+
+    supercollider
+        external_libraries
+            portaudio_sc_org
+            asiosdk
+                asio
+                common
+                ...
+            ...
 
 FFTW does not provide build files for Visual Studio. In the **Developer Command
 Prompt for VS2013** (note that this this is not `cmd.exe`), `cd` to the
@@ -371,19 +366,6 @@ The SC build only uses the single precision version of the fftw library
 *Note*: if you compile FFTW yourself, all files must end up in the root fftw
 directory.
 
-### ASIO support
-
-In order to get support for ASIO drivers, follow this directory structure:
-
-    supercollider
-        external_libraries
-            portaudio_sc_org
-            asiosdk
-                asio
-                common
-                ...
-            ...
-
 Configuration and Building
 --------------------------
 
@@ -391,8 +373,6 @@ Configuration and Building
 "Avoiding the command line" may be helpful if that doesn't describe you.
 
 *Note:* You should always use forward slashes for paths passed to CMake.
-
-### Basic build
 
 **Confirm the location of your Qt install before executing these commands.** You
 may need to modify them if you installed Qt somewhere else. The following
@@ -410,13 +390,14 @@ For the final step, you can also build from within Visual Studio:
 
     start SuperCollider.sln
 
-### Additional build settings
+Additional build settings
+-------------------------
 
 Listed here are common additional configurations you may want to use. For a
 more complete list, use `cmake --help` and/or see the section "More `cmake`:
 building supernova, qt-less, verbosity and more" below.
 
-#### Build type
+### Build type
 
 The `CMAKE_BUILD_TYPE` controls optimization level and whether or not debugging
 code (asserts, info messages, and other similar code) is included in the
@@ -439,13 +420,13 @@ the SuperCollider core libraries, `Release` should be fine. Using a `Debug`
 build in production is strongly discouraged, as it will be many times slower
 than `Release`.
 
-#### SuperNova
+### SuperNova
 
 If you want to build supernova, add `-D SUPERNOVA=ON`
 
     cmake -D SUPERNOVA=ON ..
 
-#### Other targets (install, installer)
+### Other targets (install, installer)
 
 If you used the basic instructions above, you will end up with three target
 folders (four if supernova is built). You can run these executables to develop
@@ -496,7 +477,7 @@ always loose the local customizations and additions stored in the
 userAppSupportDirectory. The new Quarks system provides means to make porting
 of extension/Quark groups easier.
 
-#### PortAudio
+### PortAudio
 
 You can study the file `external_libraries\portaudio_sc_org\CMakeLists.txt` to
 learn about the options that the build provides. With default settings, all APIs

--- a/README_WINDOWS.md
+++ b/README_WINDOWS.md
@@ -1283,36 +1283,15 @@ The following libraries and tools were used to build the Windows installers
 Known problems
 ==============
 
-- READLINE/Command line-mode does not work properly.
-  You have to wait a short while with the key pressed to get it to register - if
-  you wait for too long, the key will repeat. It's kind of possible to get used
-  to it for a short while. Second problem: sclang will crash if you use ctrl-d.
-  Another problem shared with the IDE: You need to stop the server process
-  manually to avoid scsynth-zombies. Readline is initialized in
-  lang/LangSource/SC_TerminalClient.cpp (readlineInit()). This problem can only
-  be studied in the MinGW build for now, as the VS build (even 32-bit) cannot
-  link to the readline lib yet (and you can only use v. 5.0.1 which isn't
-  available as 64-bit binary).
+- READLINE/Command line-mode is not available.
+
+- Supernova is not available.
 
 - using shell commands from SC only works in a quite limited way (and always did).
   .unixCmd expects a unix shell, only for essential requirements workarounds
   are in place on Windows.
 
-- serial port communication does not work on Windows
-
-- your username should not contain spaces or non-ASCII characters
-
-A build issue that does not seem to create a problem:
-
-- during the MinGW build, when statically linking portaudio, we currently get
-  several dozen non-fatal errors (this is not due to the portaudio version,
-  it has been observed with several pa-builds. Similar errors are reported in
-  unrelated contexts and have to do with boost). These errors seem to have no
-  consequence:
-
-      CMakeFiles\SuperCollider.dir\objects.a(find_replace_tool.cpp.obj):-1: error: duplicate section `.data$_ZGVZN5ScIDE4Main8instanceEvE9singleton[__ZGVZN5ScIDE4Main8instanceEvE9singleton]' has different size
-      ...
-
+- Serial port communication is not available.
 
 Outro
 =====

--- a/README_WINDOWS.md
+++ b/README_WINDOWS.md
@@ -256,9 +256,9 @@ Building SuperCollider for Windows
 
 SuperCollider uses [CMake][cmake] as its build system. The main toolchain
 supported by the development team is Visual Studio - Microsoft's IDE for C++ -
-which also includes Visual C++, the official Microsoft C++ compiler. Use other
-build environments and toolchains (such as MinGW, gcc, and Cygwin) at your own
-risk.
+which also includes Visual C++, the official Microsoft C++ compiler. Use of
+other build environments and toolchains (such as MinGW, gcc, and Cygwin) is not
+currently supported.
 
 Required and Optional Components
 --------------------------------
@@ -276,8 +276,8 @@ Required components:
 - **[Qt][Qt]** 5.5.1. Use the package `msvc2013_64` for a 64-bit build,
   `msvc2013` for 32-bit.
 - **[libsndfile][libsndfile]** >= 1.0.25. The binary distribution for Windows
-  does not have FLAC support. For building with FLAC support, see "FLAC
-  Support".
+  does not have FLAC support. For building with FLAC support, see the "FLAC
+  Support" section below.
 - The **[Windows SDK][Windows 10 SDK]** for your edition of Windows
 
 Optional, but highly recommended:


### PR DESCRIPTION
* Unify readme headers to all have a friendly message + version number
* Update the Windows build instructions to reflect current support & build procedures
  * remove a lot of information about MinGW and MSYS2 and encourage use of VS
  * note that command line is not supported right now
  * add note about using VS dev prompt (not cmd.exe) to execute `lib` command (this has tripped up at least one other developer, plus myself)
  * remove very old info about hack for old version of MinGW + HIDAPI
* Simplify some verbosity
* Improve flow of build instructions and simplify the TOC

Reviews & suggestions welcome. I left in some info about mingw/msys2 because some of it is genuinely useful info if you're going to build with those toolchains.  However, I think for now the approach I would prefer is to keep this already very long readme as simple and as direct as possible, encourage people to use the tools that we know work, and not go overboard on tangential explanations.

I would like to also rework and possible cut out some of the sections toward the end; IMHO, most of it is unneeded and/or hopelessly out-of-date. It will always be there in source control if we need to refer back to it. I worry that the length of this readme could cause confusion/indimidation for newbies, and headaches for everyone if a new user tries to do something they found in this guide that we aren't actually sure will work. I could be mistaken, but that's my current impression.

Will probably not respond to this again until the New Year. Thanks everyone for the great work. :)

Edit: oh also TODO:
- [x] update the "description of the build" part at the end.