### PR TITLE
[Help] make TOC's state persistent

### DIFF
--- a/HelpSource/scdoc.js
+++ b/HelpSource/scdoc.js
@@ -513,7 +513,7 @@ function fixTOC() {
         }, false);
         toc.insertBefore(close_link,toc.firstChild);
         resize_handler();
-        if(storage.tocOpen == "yes") {
+        if (storage.tocOpen === "yes") {
             show_toc();
         }
     }
@@ -531,7 +531,7 @@ function hide_toc() {
 }
 
 function toggle_toc() {
-    if (storage.tocOpen == "yes") {
+    if (storage.tocOpen === "yes") {
         hide_toc();
         storage.tocOpen = "no";
     } else {

--- a/HelpSource/scdoc.js
+++ b/HelpSource/scdoc.js
@@ -513,6 +513,9 @@ function fixTOC() {
         }, false);
         toc.insertBefore(close_link,toc.firstChild);
         resize_handler();
+        if(storage.tocOpen == "yes") {
+            show_toc();
+        }
     }
     window.onresize = resize_handler;
 }
@@ -527,14 +530,13 @@ function hide_toc() {
     document.querySelector(".contents").style.marginLeft = "0";
 }
 
-var toc_popped_out = false;
 function toggle_toc() {
-    if (toc_popped_out) {
+    if (storage.tocOpen == "yes") {
         hide_toc();
-        toc_popped_out = false;
+        storage.tocOpen = "no";
     } else {
         show_toc();
-        toc_popped_out = true;
+        storage.tocOpen = "yes";
     }
     resize_handler();
 }


### PR DESCRIPTION
Proposed fix for #3375. My apologies in advance for creating a PR which might not be complete. It fixes the issue to the best of my knowledge. Please review and suggest a better implementation if necessary.

From what I can see from [doc.sccode.org,](http://doc.sccode.org/) issue #3375 is a regression. The TOC used to be persistent when popped out. This PR is based on the previous use of  `storage` to keep the state of the popped out TOC in `HelpSource/scdoc.js`.

 