### PR TITLE
Fix small bugs in CI scripts

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -33,7 +33,7 @@ install:
 - ps: $env:PROGFILES = if ($env:ARCH -eq "x64") { 'Program Files' } else { 'Program Files (x86)' }
 
 - cmd: echo "Get submodules"
-- cmd: git submodule update --init
+- cmd: git submodule update --init --recursive
 
 # Install libsndfile, FFTW, and ASIO SDK. Note that DirectX SDK, Windows SDK are already installed.
 - cmd: echo "Install 3rd-party tools"

--- a/.travis.yml
+++ b/.travis.yml
@@ -77,9 +77,9 @@ deploy:
      condition: $TRAVIS_OS_NAME = osx && ! -z $GITHUB_KEY
      tags: true
      all_branches: true
-after-deploy:
- - "echo S3 Build Location: $S3_URL"
 
+after_deploy:
+ - "echo S3 Build Location: $S3_URL"
 
 notifications:
   on_success: change


### PR DESCRIPTION
Appveyor breaks when Ableton link is added as a submodule because the script isn't using --recursive

.travis.yml has a typo - "after-deploy" instead of "after_deploy" (https://docs.travis-ci.com/user/customizing-the-build/#The-Build-Lifecycle)