### PR TITLE
[SCIDE] Fix duplicate icons in Gnome3 dock

### DIFF
--- a/editors/sc-ide/SuperColliderIDE.desktop
+++ b/editors/sc-ide/SuperColliderIDE.desktop
@@ -1,9 +1,11 @@
 [Desktop Entry]
 Name=SuperCollider IDE
 GenericName=SuperCollider IDE
+Comment=Audio synthesis and algorithmic musical creation
 Exec=scide %F
 Icon=sc_ide
 Type=Application
 Terminal=false
-Categories=AudioVideo;Audio;AudioVideoEditing;
+Categories=AudioVideo;Audio;Development;IDE;
 MimeType=text/x-sc;
+StartupWMClass=scide

--- a/editors/sc-ide/SuperColliderIDE.desktop
+++ b/editors/sc-ide/SuperColliderIDE.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Name=SuperCollider IDE
 GenericName=SuperCollider IDE
-Comment=Audio synthesis and algorithmic musical creation
+Comment=IDE for the SuperCollider audio synthesis language 
 Exec=scide %F
 Icon=sc_ide
 Type=Application


### PR DESCRIPTION
On Gnome3, we get duplicate SC-IDE icons in the left-hand side "Favorites" dock. This only happens when SCIDE is pinned to the dock and then launched. I found the solution here:
https://askubuntu.com/questions/403766/duplicate-icons-for-manually-created-gnome-launcher-items

Basically, the .desktop file needs to have a field called `StartupWMClass` with the value `scide`. For more info, see https://standards.freedesktop.org/desktop-entry-spec/latest/ar01s06.html

This seems to also fix #2646 as a side-effect.

I also made a few additions and changes to the .desktop file based on what I read on the freedesktop.org site.
