### PR TITLE
IDE: Use AlternateBase, not Mid, for unselected document tabs

### DIFF
--- a/editors/sc-ide/widgets/style/style.cpp
+++ b/editors/sc-ide/widgets/style/style.cpp
@@ -125,7 +125,7 @@ void Style::drawComplexControl
 
             if (qobject_cast<QTabBar*>(toolBtn->parent())) {
                 if (!highlight) {
-                    QColor fill = option->palette.color(QPalette::Mid);
+                    QColor fill = option->palette.color(QPalette::AlternateBase);  // was ::Mid
                     painter->setBrush(fill);
                     painter->setPen(Qt::NoPen);
                     painter->drawRect(r.adjusted(0,0,0,-1));
@@ -289,7 +289,7 @@ void Style::drawPrimitive
         painter->setPen(Qt::NoPen);
 
         if (tabBar) {
-            painter->setBrush( option->palette.color(QPalette::Mid) );
+            painter->setBrush( option->palette.color(QPalette::AlternateBase) );
             painter->drawRect( tabBar->rect() );
         }
 


### PR DESCRIPTION
This has driven me nuts for years.

Without patching the IDE, this is what I see with multiple tabs. That's absurd.

![bad-tab-colors](https://user-images.githubusercontent.com/318301/34556830-fbb6349e-f172-11e7-8995-6a455d3588e1.png)

Can someone try on a light screen theme?

Not urgent, but not nice either.