### PR TITLE
Add new slack join link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Welcome to SuperCollider!
 =========================
 
-[![Build Status](https://travis-ci.org/supercollider/supercollider.svg?branch=master)](https://travis-ci.org/supercollider/supercollider) [![Appveyor](https://ci.appveyor.com/api/projects/status/github/gruntjs/grunt?branch=develop&svg=true)](https://ci.appveyor.com/project/brianlheim/supercollider-mu8dk) [![Slack](https://slackin-apxbmqnfui.now.sh/badge.svg)](https://slackin-apxbmqnfui.now.sh)
+[![Build Status](https://travis-ci.org/supercollider/supercollider.svg?branch=master)](https://travis-ci.org/supercollider/supercollider) [![Appveyor](https://ci.appveyor.com/api/projects/status/github/gruntjs/grunt?branch=develop&svg=true)](https://ci.appveyor.com/project/brianlheim/supercollider-mu8dk) | [Join us on Slack](https://join.slack.com/t/scsynth/shared_invite/enQtMjk0MzA0NzgyOTkyLTYwNjdmYjFmNWY4NGIyZWM2YWY1NzZhMjM3MWQ0MmEwZTZkZDExOTRjMWI2NjBiMGQ1NTg1NDQyZjExNWFjZGM)
 
 **SuperCollider** is a platform for audio synthesis and algorithmic composition, used by musicians, artists, and researchers working with sound. It is free and open source software available for Windows, macOS, and Linux.
 


### PR DESCRIPTION
Slack auto-invite is now directly supported by slack. No badge, but this is more reliable long-term.