### PR TITLE
sclang: LevelIndicatorStyle bugfix

### DIFF
--- a/SCClassLibrary/Common/GUI/Base/enums.sc
+++ b/SCClassLibrary/Common/GUI/Base/enums.sc
@@ -142,5 +142,7 @@ QLevelIndicatorStyle {
 	<continuous = 0,
 	<led = 1;
 
-	*new { arg style; style.isInteger.if(style, { this.perform(style) }) }
+	*new { arg style;
+		^ this.perform( style.isInteger.if({ #[\continuous, \led][style] }, style) );
+	}
 }


### PR DESCRIPTION
fixes Qt: WARNING: Do not know how to use an instance of class 'Meta_QLevelIndicatorStyle'