### PR TITLE
scide: set default font backup to Monaco

### DIFF
--- a/editors/sc-ide/core/settings/manager.cpp
+++ b/editors/sc-ide/core/settings/manager.cpp
@@ -74,7 +74,11 @@ void Manager::initDefaults()
 
     setDefault("blinkDuration", 600);
 
-    setDefault("font/family", "monospace");
+    // Issue #2389 - register a substitute so that macOS default won't be Helvetica.
+    // But, don't add substitutes for monospace, because this is a global registry.
+    setDefault("font/family", "scide_monospace");
+    QFont::insertSubstitutions("scide_monospace", { "monospace", "Monaco" });
+
     setDefault("font/antialias", true);
 
     setDefault("theme", "default");


### PR DESCRIPTION
This fixes issue #2389 by adding a backup for the default IDE font. It
keeps the "monospace" family that currently works for Linux & Windows.
Monaco is the default font for macOS's terminal, so it's safe to assume
this will be installed for almost all users.