### PR TITLE
travis: use git clone instead of qpm

### DIFF
--- a/.travis/qpm-prep.sh
+++ b/.travis/qpm-prep.sh
@@ -2,5 +2,11 @@
 
 cd $TRAVIS_BUILD_DIR/BUILD
 sudo pip install git+https://github.com/scztt/qpm.git@qpm-unit
-qpm quark checkout CommonTests CommonTestsGUI API --location $HOME/Quarks
+
+mkdir $HOME/Quarks && cd $HOME/Quarks
+git clone --depth=1 https://github.com/supercollider-quarks/API
+git clone --depth=1 https://github.com/supercollider-quarks/CommonTests
+git clone --depth=1 https://github.com/supercollider-quarks/CommonTestsGUI
+cd $TRAVIS_BUILD_DIR/BUILD
+
 cp ../travis_test_run_proto.json ./travis_test_run.json


### PR DESCRIPTION
qpm currently fails to download quarks with `qpm quark checkout`.
This commit replaces that command with simple git clones to achieve the
same result.