### PR TITLE
classlib: fix for leaking routine in plotTree

### DIFF
--- a/SCClassLibrary/Common/GUI/PlusGUI/Control/ServerPlusGUI.sc
+++ b/SCClassLibrary/Common/GUI/PlusGUI/Control/ServerPlusGUI.sc
@@ -492,14 +492,14 @@
 		}, '/g_queryTree.reply', addr).fix;
 
 		updateFunc = {
-			fork {
+			updater = fork {
 				loop {
 					this.sendMsg("/g_queryTree", 0, 0);
 					interval.wait;
 				}
 			}
 		};
-		updater = updateFunc.value;
+		updateFunc.value;
 		CmdPeriod.add(updateFunc);
 		SystemClock.sched(3, {
 			if(done.not, {


### PR DESCRIPTION
fix for a minor problem that happens when pressing cmd+period while a plotTree window is open.

```supercollider
s.boot
s.dumpOSC  //to debug

s.plotTree
//now close the window - OK - g_queryTree messages are no longer being posted

s.plotTree
CmdPeriod.run  //or typing cmd+.
//again close the window - BAD - leaking routine - g_queryTree still being posted
```

with the suggested change the second example work as expected and the internal updater routine is stopped.