### PR TITLE
Add pseudo-ugen implementation of snap and softRound

### DIFF
--- a/HelpSource/Classes/UGen.schelp
+++ b/HelpSource/Classes/UGen.schelp
@@ -210,6 +210,20 @@ method:: minNyquist
 
 Wraps the receiver in a code::min:: link::Classes/BinaryOpUGen::, such that the lesser of the receiver's output and the Nyquist frequency is output. This can be useful to prevent aliasing.
 
+method:: snap
+
+Wraps the receiver so that its values are rounded within code::margin:: distance from a multiple of code::resolution:: to a multiple of resolution. By using code::margin:: and code::strength:: you can control when values will be rounded, and by how much. See link::Classes/SimpleNumber#-snap:: for more details.
+
+This can be used to make control signals (e.g. from sensors) "snap" to defined resolution. Example:
+code::
+s.boot;
+x = {SinOsc.ar((Line.kr(0, 10, 10).snap(1, 0.3, 1) + 60).poll.midicps, 0, -24.dbamp)}.play
+::
+
+method:: softRound
+
+Wraps the receiver so that its values are rounded outside of code::margin:: distance from a multiple of code::resolution:: to a multiple of resolution. By using code::margin:: and code::strength:: you can control when values will be rounded, and by how much. See link::Classes/SimpleNumber#-softRound:: for more details.
+
 method:: linlin
 Wraps the receiver so that a linear input range is mapped to a linear output range.
 
@@ -403,4 +417,3 @@ method:: init
 By default, this method stores the inputs (e.g. the arguments to code::*ar:: and code::*kr::) in the UGen.
 discussion::
 This may be overridden to do other initialisations, as long as the inputs are set correctly.
-

--- a/SCClassLibrary/Common/Audio/UGen.sc
+++ b/SCClassLibrary/Common/Audio/UGen.sc
@@ -182,6 +182,19 @@ UGen : AbstractFunction {
 		);
 		^this
 	}
+
+	snap { arg resolution = 1.0, margin = 0.05, strength = 1.0;
+		var round = round(this, resolution);
+		var diff = round - this;
+		^Select.multiNew(this.rate, abs(diff) < margin, this, this + (strength * diff));
+	}
+
+	softRound { arg resolution = 1.0, margin = 0.05, strength = 1.0;
+		var round = round(this, resolution);
+		var diff = round - this;
+		^Select.multiNew(this.rate, abs(diff) > margin, this, this + (strength * diff));
+	}
+
 	linlin { arg inMin, inMax, outMin, outMax, clip = \minmax;
 		if (this.rate == \audio) {
 			^LinLin.ar(this.prune(inMin, inMax, clip), inMin, inMax, outMin, outMax)


### PR DESCRIPTION
A while ago I created a pseudo-ugen version of SimpleNumber.quantize method, which I used for processing sensor data. In the meantime, the .quantize method became obsoleted and replaced by .snap (https://github.com/supercollider/supercollider/pull/3160).
This creates a pseudo-ugen version for both .snap and .softRound (I'm not sure if the latter is useful as a pseudo-ugen, but I added it for the sake of completeness).
I added brief entry in the help as well. Does this need anything else to be merged?

also, here's a rough test of the language vs ugen version
(the values won't be exact due to timing, but the plots should look similar)
```
s.boot;

//snap test
(
Routine.run({
	~time = 5; //seconds
	~numSamples = 1000;
	~maxValue = 10;
	~bus = Bus.control(s, 1);
	~bus.setSynchronous(0);
	~list = List.new;
	~currentValue = 0;
	~synth = {Out.kr(~bus, Line.kr(0, ~maxValue, ~time).snap(1, 0.4, 1))}.play;
	"starting data collection".postln;
	s.sync;
	while({~currentValue < ~maxValue}, {
		~currentValue = ~bus.getSynchronous;
		// ~currentValue.postln;
		~list.add(~currentValue);
		".".post;
		(~time / ~numSamples).wait;
	});
	~synth.free;
	~bus.free;
	"\ndata collected".postln;
	{~list.asArray.plot}.defer;
})
)
//lang version
(
~numSamples = 1000;
~maxValue = 10;
~numSamples.collect({|inc| var val = inc.linlin(0, ~numSamples, 0, ~maxValue); val.snap(1, 0.4, 1)}).plot
)

//softRound test
(
Routine.run({
	~time = 5; //seconds
	~numSamples = 1000;
	~maxValue = 10;
	~bus = Bus.control(s, 1);
	~bus.setSynchronous(0);
	~list = List.new;
	~currentValue = 0;
	~synth = {Out.kr(~bus, Line.kr(0, ~maxValue, ~time).softRound(1, 0.25, 1))}.play;
	"starting data collection".postln;
	s.sync;
	while({~currentValue < ~maxValue}, {
		~currentValue = ~bus.getSynchronous;
		// ~currentValue.postln;
		~list.add(~currentValue);
		".".post;
		(~time / ~numSamples).wait;
	});
	~synth.free;
	~bus.free;
	"\ndata collected".postln;
	{~list.asArray.plot}.defer;
})
)
//lang version
(
~numSamples = 1000;
~maxValue = 10;
~numSamples.collect({|inc| var val = inc.linlin(0, ~numSamples, 0, ~maxValue); val.softRound(1, 0.25, 1)}).plot
)
```
 