### PR TITLE
supernova: load plugins from correct directories

### DIFF
--- a/server/supernova/server/main.cpp
+++ b/server/supernova/server/main.cpp
@@ -253,8 +253,8 @@ void set_plugin_paths(server_arguments const & args, nova::sc_ugen_factory * fac
             factory->load_plugin_folder(folder);
 #else
         factory->load_plugin_folder(SC_Filesystem::instance().getDirectory(DirName::Resource) / "plugins");
-        factory->load_plugin_folder(SC_Filesystem::instance().getDirectory(DirName::SystemExtension) / "plugins");
-        factory->load_plugin_folder(SC_Filesystem::instance().getDirectory(DirName::UserExtension) / "plugins");
+        factory->load_plugin_folder(SC_Filesystem::instance().getDirectory(DirName::SystemExtension) );
+        factory->load_plugin_folder(SC_Filesystem::instance().getDirectory(DirName::UserExtension) );
 #endif
     }
 


### PR DESCRIPTION
previously, plugins were loaded from /plugins within extension directories

Fixes #3391

Thanks to @florian-grond for the patch!