### PR TITLE
Plugins: Choose Index.ar calc function based on phase arg

### DIFF
--- a/server/plugins/OscUGens.cpp
+++ b/server/plugins/OscUGens.cpp
@@ -675,7 +675,7 @@ void Index_Ctor(Index *unit)
 	unit->m_fbufnum = std::numeric_limits<float>::quiet_NaN();
 	if (BUFLENGTH == 1) {
 		SETCALC(Index_next_1);
-	} else if (INRATE(0) == calc_FullRate) {
+	} else if (INRATE(1) == calc_FullRate) {
 		SETCALC(Index_next_a);
 	} else {
 		SETCALC(Index_next_k);
@@ -739,7 +739,7 @@ void IndexL_Ctor(IndexL *unit)
 	unit->m_fbufnum = std::numeric_limits<float>::quiet_NaN();
 	if (BUFLENGTH == 1) {
 		SETCALC(IndexL_next_1);
-	} else if (INRATE(0) == calc_FullRate) {
+	} else if (INRATE(1) == calc_FullRate) {
 		SETCALC(IndexL_next_a);
 	} else {
 		SETCALC(IndexL_next_k);
@@ -822,7 +822,7 @@ void FoldIndex_Ctor(FoldIndex *unit)
 	unit->m_fbufnum = std::numeric_limits<float>::quiet_NaN();
 	if (BUFLENGTH == 1) {
 		SETCALC(FoldIndex_next_1);
-	} else if (INRATE(0) == calc_FullRate) {
+	} else if (INRATE(1) == calc_FullRate) {
 		SETCALC(FoldIndex_next_a);
 	} else {
 		SETCALC(FoldIndex_next_k);
@@ -885,7 +885,7 @@ void WrapIndex_Ctor(WrapIndex *unit)
 	unit->m_fbufnum = std::numeric_limits<float>::quiet_NaN();
 	if (BUFLENGTH == 1) {
 		SETCALC(WrapIndex_next_1);
-	} else if (INRATE(0) == calc_FullRate) {
+	} else if (INRATE(1) == calc_FullRate) {
 		SETCALC(WrapIndex_next_a);
 	} else {
 		SETCALC(WrapIndex_next_k);
@@ -961,7 +961,7 @@ void IndexInBetween_Ctor(IndexInBetween *unit)
 	unit->m_fbufnum = std::numeric_limits<float>::quiet_NaN();
 	if (BUFLENGTH == 1) {
 		SETCALC(IndexInBetween_next_1);
-	} else if (INRATE(0) == calc_FullRate) {
+	} else if (INRATE(1) == calc_FullRate) {
 		SETCALC(IndexInBetween_next_a);
 	} else {
 		SETCALC(IndexInBetween_next_k);
@@ -1031,7 +1031,7 @@ void DetectIndex_Ctor(DetectIndex *unit)
 	unit->m_fbufnum = std::numeric_limits<float>::quiet_NaN();
 	if (BUFLENGTH == 1) {
 		SETCALC(DetectIndex_next_1);
-	} else if (INRATE(0) == calc_FullRate) {
+	} else if (INRATE(1) == calc_FullRate) {
 		SETCALC(DetectIndex_next_a);
 	} else {
 		SETCALC(DetectIndex_next_k);

--- a/testsuite/classlibrary/TestIndexUGenRates.sc
+++ b/testsuite/classlibrary/TestIndexUGenRates.sc
@@ -1,0 +1,130 @@
+TestIndexUGenRates : UnitTest {
+
+	var server, numFrames, floats;
+
+	setUp {
+
+		server = Server.default;
+		this.bootServer(server);
+	}
+
+	tearDown {
+
+		Buffer.freeAll;
+		server.quit;
+	}
+
+	addSynthDefs {
+
+		SynthDef(\indexArPhaseAr, { |buf|
+			var phase = Phasor.ar(0, 1, 0, numFrames);
+			BufWr.ar(
+				Index.ar(
+					floats,
+					phase
+				),
+				buf,
+				phase,
+				loop:0
+			);
+			Line.kr(0, 1, 0.01, doneAction: Done.freeSelf);
+			Out.ar(0, Silent.ar);
+		}).add;
+
+		SynthDef(\indexKrPhaseAr, { |buf|
+			var phase = Phasor.ar(0, 1, 0, numFrames);
+			BufWr.ar(
+				K2A.ar(
+					Index.kr(
+						floats,
+						phase
+					)
+				),
+				buf,
+				phase,
+				loop:0
+			);
+			Line.kr(0, 1, 0.01, doneAction: Done.freeSelf);
+			Out.ar(0, Silent.ar);
+		}).add;
+
+		SynthDef(\indexArPhaseKr, { |buf|
+			var phase = Phasor.kr(0, 1, 0, 1);
+			BufWr.ar(
+				Index.ar(
+					floats,
+					K2A.ar(phase)
+				),
+				buf,
+				Phasor.ar(0, 1, 0, numFrames),
+				loop:0
+			);
+			Line.kr(0, 1, 0.01, doneAction: Done.freeSelf);
+			Out.ar(0, Silent.ar);
+		}).add;
+
+		SynthDef(\indexKrPhaseKr, { |buf|
+			var phase = Phasor.kr(0, 1, 0, 1);
+			BufWr.ar(
+				K2A.ar(
+					Index.kr(
+						floats,
+						phase
+					)
+				),
+				buf,
+				Phasor.ar(0, 1, 0, numFrames),
+				loop:0
+			);
+			Line.kr(0, 1, 0.01, doneAction: Done.freeSelf);
+			Out.ar(0, Silent.ar);
+		}).add;
+
+	}
+
+	test_indexRates {
+
+		var index, writeBuf, value, synth;
+
+		numFrames = server.options.blockSize;
+		index = (numFrames/2).asInteger;
+		floats = Array.fill(numFrames, { |i| (numFrames-i)/numFrames });
+		floats = Buffer.loadCollection(server, floats);
+		writeBuf = Buffer.alloc(server, numFrames);
+
+		this.addSynthDefs;
+		server.sync;
+
+		synth = Synth(\indexArPhaseAr, [\buf, writeBuf]);
+		synth.waitForFree;
+		writeBuf.get(index, { |i| value = i});
+		server.sync;
+		this.assertFloatEquals(value, 0.5, "Index.ar with audio rate input should output 0.5");
+		writeBuf.zero;
+		server.sync;
+
+		synth = Synth(\indexKrPhaseAr, [\buf, writeBuf]);
+		synth.waitForFree;
+		writeBuf.get(index, { |i| value = i});
+		server.sync;
+		this.assertFloatEquals(value, 1.0, "Index.kr with audio rate input should output 1.0");
+		writeBuf.zero;
+		server.sync;
+
+		synth = Synth(\indexArPhaseKr, [\buf, writeBuf]);
+		synth.waitForFree;
+		writeBuf.get(index, { |i| value = i});
+		server.sync;
+		this.assertFloatEquals(value, 1.0, "Index.ar with control rate input should output 1.0");
+		writeBuf.zero;
+		server.sync;
+
+		synth = Synth(\indexKrPhaseKr, [\buf, writeBuf]);
+		synth.waitForFree;
+		writeBuf.get(index, { |i| value = i});
+		server.sync;
+		this.assertFloatEquals(value, 1.0, "Index.kr with control rate input should output 1.0");
+
+	}
+
+}


### PR DESCRIPTION
- `Index_next_k()` accesses index `ZIN0(1)` once per control cycle -- i.e., assumes a kr index.
- `Index_next_a()` accesses index `ZIN0(1)` `inNumSamples` times per control cycle -- ar index.

Both calculation functions do `GET_TABLE` only once per control cycle -- so the bufnum input does not support ar under any circumstances.

But, the Ctor chooses next_k for a control-rate *bufnum*, regardless of the rate of the input that matters (index). So this PR changes `INRATE(0)` to `INRATE(1)`.

Five other UGens follow the same pattern: IndexL, FoldIndex, WrapIndex, IndexInBetween and DetectIndex.

Test: without the fix, the following displays an obvious sample-and-hold. With the fix, Index.ar is correctly equivalent to BufRd.ar without interpolation.

```
(
s.waitForBoot {
	b = Buffer.alloc(s, 512, 1, completionMessage: { |buf|
		buf.sine3Msg([4], [1], [0.25pi], asWavetable: false)
	});
	s.sync;
	{
		var phase = Phasor.ar(0, 1, 0, 1000);
		[Index.ar(b, phase), BufRd.ar(1, b, phase, interpolation: 1)]
	}.plot(duration: b.duration); 
};
)
```

I'll suggest 3.9.1 for this as it's a small bugfix.