### PR TITLE
Classlib: Correct 'a+b.neg' ugen optimization, and fix descendants

### DIFF
--- a/testsuite/classlibrary/TestSynthDefOptimizations.sc
+++ b/testsuite/classlibrary/TestSynthDefOptimizations.sc
@@ -1,0 +1,123 @@
+TestSynthDefOptimizations : UnitTest {
+	test_optimizeAddNeg {
+		var def = SynthDef(\addneg, {
+			var a = DC.kr(0), b = DC.kr(1);
+			Out.kr(0, a + b.neg)
+		}),
+		op = def.children.detect(_.isKindOf(BinaryOpUGen));
+		this.assert(
+			def.children.any(_.isKindOf(UnaryOpUGen)).not and: {
+				op.notNil and: { op.operator == '-' }
+			},
+			"UGens a + b.neg should optimize to a - b"
+		);
+		def = SynthDef(\addneg, {
+			var a = DC.kr(0), b = DC.kr(1).neg;
+			Out.kr(0, a + b);
+			Out.kr(2, b);
+		});
+		op = def.children.detect(_.isKindOf(BinaryOpUGen));
+		this.assert(
+			op.notNil and: { op.operator == '+' },
+			"a + b.neg, b.neg should be kept if it has multiple descendants"
+		);
+	}
+	test_optimizeSub {
+		var def = SynthDef(\sub, {
+			var a = DC.kr(0), b = DC.kr(1);
+			Out.kr(0, a - b.neg)
+		}),
+		op = def.children.detect(_.isKindOf(BinaryOpUGen));
+		this.assert(
+			def.children.any(_.isKindOf(UnaryOpUGen)).not and: {
+				op.notNil and: { op.operator == '+' }
+			},
+			"UGens a - b.neg should optimize to a + b"
+		);
+		def = SynthDef(\addneg, {
+			var a = DC.kr(0), b = DC.kr(1).neg;
+			Out.kr(0, a - b);
+			Out.kr(2, b);
+		});
+		op = def.children.detect(_.isKindOf(BinaryOpUGen));
+		this.assert(
+			op.notNil and: { op.operator == '-' },
+			"a - b.neg, b.neg should be kept if it has multiple descendants"
+		);
+	}
+	test_optimizeToMulAdd {
+		var def;
+		[
+			"ugen * 2 + 1" -> { SinOsc.ar * 2 + 1 },
+			"2 * ugen + 1" -> { 2 * SinOsc.ar + 1 },
+			"1 + (ugen * 2)" -> { 1 + (SinOsc.ar * 2) },
+			"1 + (2 * ugen)" -> { 1 + (2 * SinOsc.ar) }
+		].do { |assn|
+			def = SynthDef(\test, {
+				Out.ar(0, assn.value.value)
+			});
+			this.assert(
+				def.children.any(_.isKindOf(BinaryOpUGen)).not and: {
+					def.children.count(_.isKindOf(MulAdd)) == 1
+				},
+				"Operator sequence '%' should optimize to MulAdd".format(assn.key)
+			)
+		};
+		def = SynthDef(\test, {
+			var osc = SinOsc.ar(440, 0, 0.1);
+			Out.ar(0, osc);
+			Out.ar(2, osc + 1);
+		});
+		this.assert(
+			def.children.any(_.isKindOf(MulAdd)).not,
+			"ugen * 0.1 + 1, reuse of '*' result prevents optimization"
+		);
+	}
+	test_optimizeToSum3 {
+		var def = SynthDef(\sum3, {
+			var ugens = DC.kr((0..2));
+			Out.kr(0, ugens.sum)
+		});
+		this.assert(
+			def.children.any(_.isKindOf(BinaryOpUGen)).not
+			and: { def.children.count(_.isKindOf(Sum3)) == 1 },
+			"UGens a + b + c, both '+' should be replaced by one Sum3"
+		);
+		def = SynthDef(\sum3, {
+			var ugens = DC.kr((0..2)),
+			aplusb = ugens[0] + ugens[1];
+			Out.kr(0, aplusb + ugens[2]);
+			Out.kr(2, aplusb)
+		});
+		this.assert(
+			def.children.count(_.isKindOf(BinaryOpUGen)) == 2
+			and: { def.children.any(_.isKindOf(Sum3)).not },
+			"UGens a + b + c, reuse of a + b prevents optimization"
+		);
+	}
+	test_optimizeToSum4 {
+		var def = SynthDef(\sum4, {
+			var ugens = DC.kr((0..3));
+			Out.kr(0, ugens.sum)
+		});
+		this.assert(
+			def.children.any(_.isKindOf(BinaryOpUGen)).not
+			and: { def.children.count(_.isKindOf(Sum4)) == 1 },
+			"UGens a + b + c + d, all '+' should be replaced by one Sum4"
+		);
+		def = SynthDef(\sum4, {
+			var ugens = DC.kr((0..3)),
+			abc = ugens[0..2].sum;
+			Out.kr(0, abc + ugens.last);
+			Out.kr(2, abc);
+		});
+		this.assert(
+			def.children.count(_.isKindOf(Sum3)) == 1 and: {
+				def.children.count(_.isKindOf(BinaryOpUGen)) == 1 and: {
+					def.children.any(_.isKindOf(Sum4)).not
+				}
+			},
+			"UGens a + b + c + d, reuse of a + b + c prevents optimization"
+		);
+	}
+}


### PR DESCRIPTION
This PR addresses the issues raised in #972.

- `a + b.neg` should optimize to `a - b` *only* if `b.neg` has only one descendant. But the prior logic was to perform some sort of optimization, no matter how many descendants needed the `b.neg` result. This caused required UGens to be lost to dead code optimization.

- Scott C. correctly pointed out that the "optimize" methods use `descendants` to decide whether the optimization is legitimate, but they do not update the descendants sets belonging to inputs of the replaced or deleted units. This PR introduces a method to update the descendants of all relevant input UGens.

- It also adds some preliminary unit tests for SynthDef optimizations. Currently testing each binary-op optimization method for the correct types of remaining operators. The tests don't currently check inputs or descendant sets.

Test case from #972.

```
(
d = SynthDef(\spreaderBroke, {
	var a, b, c, d, e;
	a = DC.kr(0.3);
	b = a + 1.1;
	c = b.neg;
	Poll.kr(1, c);
	
	d = 1.2 - c;
	e = d.abs;
}).add;

d.children
)
```

Without the fix, Poll gets lost because its source (`b.neg`) got folded into `optimizeSub`, and then the optimized UGen got removed as dead code.

```
-> [ a DC, a Sum3, an Impulse ]
```

With the fix, d and e are correctly dropped (dead code elimination) but the use of `b.neg` in Poll prevents optimization (correctly), and Poll remains intact.

```
-> [ a DC, a BinaryOpUGen, an UnaryOpUGen, an Impulse, a Poll ]
```

Suggesting 3.9.1 as it is a bugfix (of a subtle issue that is hard to explain), not a new feature.