### PR TITLE
Add S3 deployment to appveyor setup

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -101,7 +101,6 @@ after_build:
 - ps: rmdir -Recurse -Force SuperCollider
 - ps: echo $env:APPVEYOR_REPO_TAG_NAME
 - ps: >-
-    # PS way to test if an env var is defined
     If (Test-Path env:APPVEYOR_REPO_TAG_NAME) {
         # required for github releases
         git fetch --tags

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -87,25 +87,25 @@ build_script:
 after_build:
 # required for github releases
 - git fetch --tags
-- ps: $S3_BUILDS_LOCATION="builds/supercollider/supercollider/win"
-- ps: $S3_URL="https://supercollider.s3.amazonaws.com/$S3_BUILDS_LOCATION/SC-$env:APPVEYOR_REPO_COMMIT.zip"
-- ps: $FWD_HTML="<html><head><meta http-equiv=""refresh"" content=""0; url='$S3_URL'"" /></head></html>"
-- ps: $BRANCH_ESC=$env:APPVEYOR_REPO_BRANCH -replace '/', ''
+- ps: $env:S3_BUILDS_LOCATION="builds/supercollider/supercollider/win"
+- ps: $env:S3_URL="https://supercollider.s3.amazonaws.com/$env:S3_BUILDS_LOCATION/SC-$env:APPVEYOR_REPO_COMMIT.zip"
+- ps: $env:FWD_HTML="<html><head><meta http-equiv=""refresh"" content=""0; url='$env:S3_URL'"" /></head></html>"
+- ps: $env:BRANCH_ESC=$env:APPVEYOR_REPO_BRANCH -replace '/', ''
 - ps: cd $env:APPVEYOR_BUILD_FOLDER
 - ps: mkdir artifacts/branch
-- ps: echo $FWD_HTML > artifacts/$BRANCH_ESC-latest.html
+- ps: echo $env:FWD_HTML > artifacts/$env:BRANCH_ESC-latest.html
 - ps: ls artifacts
 - ps: 7z a artifacts/SC-$env:APPVEYOR_REPO_COMMIT.zip -tzip -mx=9 build/Install/SuperCollider
 - ps: echo $env:APPVEYOR_REPO_TAG_NAME
 - ps: >-
     If ($env:APPVEYOR_REPO_TAG_NAME -ne "") {
-        $TAG_ESC=$env:APPVEYOR_REPO_TAG_NAME -replace '/', ''
+        $env:TAG_ESC=$env:APPVEYOR_REPO_TAG_NAME -replace '/', ''
         mkdir artifacts/tag
-        echo $FWD_HTML > artifacts/$TAG_ESC.html
+        echo $env:FWD_HTML > artifacts/$env:TAG_ESC.html
     }
 
 after_deploy:
-- cmd: echo S3 Build Location = %S3_URL%
+- ps: echo S3 Build Location = $env:S3_URL
 
 artifacts:
     - path: artifacts

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -103,15 +103,14 @@ after_build:
 - ps: >-
     If (Test-Path env:APPVEYOR_REPO_TAG_NAME) {
         # required for github releases
-        git fetch --tags https://github.com/supercollider/supercollider
+        # -q because otherwise PS reads output from stderr and thinks there's a problem
+        git fetch --tags -q
         $env:TAG_ESC=$env:APPVEYOR_REPO_TAG_NAME -replace '/', ''
         echo $env:FWD_HTML > $env:TAG_ESC.html
         cd ../build
-        which nsis
+        # to get NSIS in path for installer generation
         $env:PATH="C:\Program Files (x86)\NSIS;$env:PATH"
         cmake --build . --target installer --config Release
-        ls .
-        ls Install
     }
 - ps: cd ..
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -87,7 +87,7 @@ build_script:
 
 # after_build instead of before_deploy so artifacts are collected at the right time
 after_build:
-- ps: $env:ARCHIVE_NAME="SC-Windows-$env:ARCH$-$env:APPVEYOR_REPO_COMMIT.zip"
+- ps: $env:ARCHIVE_NAME="SC-Windows-$env:ARCH-$env:APPVEYOR_REPO_COMMIT.zip"
 - ps: $env:S3_URL="https://supercollider.s3.amazonaws.com/$env:S3_BUILDS_LOCATION/$env:ARCHIVE_NAME"
 - ps: $env:FWD_HTML="<html><head><meta http-equiv=""refresh"" content=""0; url='$env:S3_URL'"" /></head></html>"
 - ps: $env:BRANCH_ESC=$env:APPVEYOR_REPO_BRANCH -replace '/', ''

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -98,7 +98,7 @@ before_deploy:
     }
 
 after_deploy:
-- echo "S3 Build Location: %S3_URL%"
+- cmd: echo S3 Build Location: %S3_URL%
 
 artifacts:
     - path: %USERPROFILE%/artifacts

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -87,21 +87,22 @@ before_deploy:
 - ps: $S3_URL="https://supercollider.s3.amazonaws.com/$S3_BUILDS_LOCATION/SC-$env:APPVEYOR_REPO_COMMIT.zip"
 - ps: $FWD_HTML="<html><head><meta http-equiv=""refresh"" content=""0; url='$S3_URL'"" /></head></html>"
 - ps: $BRANCH_ESC=$env:APPVEYOR_REPO_BRANCH -replace '/', ''
-- ps: mkdir $env:USERPROFILE/artifacts/branch
-- ps: echo $FWD_HTML > $env:USERPROFILE/artifacts/$BRANCH_ESC-latest.html
-- ps: 7z a $env:USERPROFILE/artifacts/SC-$env:APPVEYOR_REPO_COMMIT.zip -tzip -mx=9 $env:APPVEYOR_BUILD_FOLDER/build/Install/SuperCollider
+- ps: cd $env:APPVEYOR_BUILD_FOLDER
+- ps: mkdir artifacts/branch
+- ps: echo $FWD_HTML > artifacts/$BRANCH_ESC-latest.html
+- ps: 7z a artifacts/SC-$env:APPVEYOR_REPO_COMMIT.zip -tzip -mx=9 build/Install/SuperCollider
 - ps: >-
     If ($env:APPVEYOR_REPO_TAG_NAME -ne "") {
         $TAG_ESC=$env:APPVEYOR_REPO_TAG_NAME -replace '/', ''
-        mkdir $env:USERPROFILE/artifacts/tag
-        echo $FWD_HTML > $env:USERPROFILE/artifacts/$TAG_ESC.html
+        mkdir artifacts/tag
+        echo $FWD_HTML > artifacts/$TAG_ESC.html
     }
 
 after_deploy:
 - cmd: echo S3 Build Location = %S3_URL%
 
 artifacts:
-    - path: %USERPROFILE%/artifacts
+    - path: artifacts
       name: art_folder
 
 deploy:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -94,7 +94,9 @@ after_build:
 - ps: cd $env:APPVEYOR_BUILD_FOLDER
 - ps: mkdir artifacts/branch
 - ps: echo $FWD_HTML > artifacts/$BRANCH_ESC-latest.html
+- ps: ls artifacts
 - ps: 7z a artifacts/SC-$env:APPVEYOR_REPO_COMMIT.zip -tzip -mx=9 build/Install/SuperCollider
+- ps: echo $env:APPVEYOR_REPO_TAG_NAME
 - ps: >-
     If ($env:APPVEYOR_REPO_TAG_NAME -ne "") {
         $TAG_ESC=$env:APPVEYOR_REPO_TAG_NAME -replace '/', ''
@@ -115,6 +117,7 @@ deploy:
   access_key_id: $(AWS_KEY)
   secret_access_key: $(AWS_SECRET)
   bucket: supercollider
+  region: us-west-2
   folder: $(S3_BUILDS_LOCATION)
   artifact: art_folder
   unzip: true

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -100,14 +100,15 @@ after_build:
 - ps: Copy-Item -Path $env:APPVEYOR_BUILD_FOLDER/build/Install/SuperCollider . -Recurse
 - ps: 7z a $env:ARCHIVE_NAME -tzip SuperCollider
 - ps: rmdir -Recurse -Force SuperCollider
-- ps: echo $env:APPVEYOR_REPO_TAG_NAME
 - ps: >-
     If (Test-Path env:APPVEYOR_REPO_TAG_NAME) {
         # required for github releases
-        git fetch --tags
+        git fetch --tags https://github.com/supercollider/supercollider
         $env:TAG_ESC=$env:APPVEYOR_REPO_TAG_NAME -replace '/', ''
         echo $env:FWD_HTML > $env:TAG_ESC.html
         cd ../build
+        which nsis
+        $env:PATH="C:\Program Files (x86)\NSIS;$env:PATH"
         cmake --build . --target installer --config Release
         ls .
         ls Install

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -11,6 +11,9 @@ clone_depth: 10
 # https://www.appveyor.com/docs/build-environment/#build-worker-images
 image: Visual Studio 2013
 
+# disable automatic tests
+test: off
+
 environment:
     CMAKE_CONFIGURATION: Release
     ASIO_URL: "http://www.steinberg.net/sdk_downloads/asiosdk2.3.zip"
@@ -80,7 +83,8 @@ build_script:
 - cmake -G "%CMAKE_GENERATOR%" -D CMAKE_PREFIX_PATH=%QT_DIR% ..
 - cmake --build . --target install --config %CMAKE_CONFIGURATION%
 
-before_deploy:
+# after_build instead of before_deploy so artifacts are collected at the right time
+after_build:
 # required for github releases
 - git fetch --tags
 - ps: $S3_BUILDS_LOCATION="builds/supercollider/supercollider/win"
@@ -115,8 +119,6 @@ deploy:
   artifact: art_folder
   unzip: true
   set_public: true
-  on:
-    all_branches: true
 
 notifications:
     - provider: Webhook

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -80,6 +80,43 @@ build_script:
 - cmake -G "%CMAKE_GENERATOR%" -D CMAKE_PREFIX_PATH=%QT_DIR% ..
 - cmake --build . --target install --config %CMAKE_CONFIGURATION%
 
+before_deploy:
+# required for github releases
+- git fetch --tags
+- ps: $S3_BUILDS_LOCATION="builds/supercollider/supercollider/win"
+- ps: $S3_URL="https://supercollider.s3.amazonaws.com/$S3_BUILDS_LOCATION/SC-$env:APPVEYOR_REPO_COMMIT.zip"
+- ps: $FWD_HTML="<html><head><meta http-equiv=""refresh"" content=""0; url='$S3_URL'"" /></head></html>"
+- ps: $BRANCH_ESC=$env:APPVEYOR_REPO_BRANCH -replace '/', ''
+- ps: mkdir $env:USERPROFILE/artifacts/branch
+- ps: echo $FWD_HTML > $env:USERPROFILE/artifacts/$BRANCH_ESC-latest.html
+- ps: 7z a $env:USERPROFILE/artifacts/SC-$env:APPVEYOR_REPO_COMMIT.zip -tzip -mx=9 $env:APPVEYOR_BUILD_FOLDER/build/Install/SuperCollider
+- ps: >-
+    If ($env:APPVEYOR_REPO_TAG_NAME -ne "") {
+        $TAG_ESC=$env:APPVEYOR_REPO_TAG_NAME -replace '/', ''
+        mkdir $env:USERPROFILE/artifacts/tag
+        echo $FWD_HTML > $env:USERPROFILE/artifacts/$TAG_ESC.html
+    }
+
+after_deploy:
+- echo "S3 Build Location: %S3_URL%"
+
+artifacts:
+    - path: %USERPROFILE%/artifacts
+      name: art_folder
+
+deploy:
+# s3 upload - every commit
+- provider: S3
+  access_key_id: %AWS_KEY%
+  secret_access_key: %AWS_SECRET%
+  bucket: supercollider
+  folder: %S3_BUILDS_LOCATION%
+  artifact: art_folder
+  unzip: true
+  set_public: true
+  on:
+    all_branches: true
+
 notifications:
     - provider: Webhook
       url: https://webhooks.gitter.im/e/0f811b8a74efd99f4a4e

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -98,7 +98,7 @@ before_deploy:
     }
 
 after_deploy:
-- cmd: echo S3 Build Location\: %S3_URL%
+- cmd: echo S3 Build Location = %S3_URL%
 
 artifacts:
     - path: %USERPROFILE%/artifacts

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -24,11 +24,13 @@ environment:
           CMAKE_GENERATOR: "Visual Studio 12 2013"
           FFTW_URL: ftp://ftp.fftw.org/pub/fftw/fftw-3.3.5-dll32.zip
           ARCH: "x86"
+          S3_BUILDS_LOCATION: "builds/supercollider/supercollider/win32"
 
         - QT_DIR: "C:/Qt/5.5/msvc2013_64"
           CMAKE_GENERATOR: "Visual Studio 12 2013 Win64"
           FFTW_URL: ftp://ftp.fftw.org/pub/fftw/fftw-3.3.5-dll64.zip
           ARCH: "x64"
+          S3_BUILDS_LOCATION: "builds/supercollider/supercollider/win64"
 
 install:
 - ps: echo "Install phase start"
@@ -85,27 +87,31 @@ build_script:
 
 # after_build instead of before_deploy so artifacts are collected at the right time
 after_build:
-# required for github releases
-- git fetch --tags
-- ps: $env:S3_BUILDS_LOCATION="builds/supercollider/supercollider/win"
 - ps: $env:S3_URL="https://supercollider.s3.amazonaws.com/$env:S3_BUILDS_LOCATION/SC-$env:APPVEYOR_REPO_COMMIT.zip"
 - ps: $env:FWD_HTML="<html><head><meta http-equiv=""refresh"" content=""0; url='$env:S3_URL'"" /></head></html>"
 - ps: $env:BRANCH_ESC=$env:APPVEYOR_REPO_BRANCH -replace '/', ''
 - ps: cd $env:APPVEYOR_BUILD_FOLDER
-- ps: mkdir artifacts/branch
-- ps: echo $env:FWD_HTML > artifacts/$env:BRANCH_ESC-latest.html
-- ps: ls artifacts
-- ps: 7z a artifacts/SC-$env:APPVEYOR_REPO_COMMIT.zip -tzip -mx=9 build/Install/SuperCollider
+
+- echo "Making artifacts"
+- ps: mkdir artifacts
+- ps: cd artifacts
+- ps: echo $env:FWD_HTML > $env:BRANCH_ESC-latest.html
+- ps: Copy-Item -Path $env:APPVEYOR_BUILD_FOLDER/build/Install/SuperCollider . -Recurse
+- ps: 7z a SC-$env:APPVEYOR_REPO_COMMIT.zip -tzip -mx=9 SuperCollider
+- ps: rmdir -Recurse -Force SuperCollider
 - ps: echo $env:APPVEYOR_REPO_TAG_NAME
 - ps: >-
-    If ($env:APPVEYOR_REPO_TAG_NAME -ne "") {
+    # PS way to test if an env var is defined
+    If (Test-Path env:APPVEYOR_REPO_TAG_NAME) {
+        # required for github releases
+        git fetch --tags
         $env:TAG_ESC=$env:APPVEYOR_REPO_TAG_NAME -replace '/', ''
-        mkdir artifacts/tag
-        echo $env:FWD_HTML > artifacts/$env:TAG_ESC.html
+        echo $env:FWD_HTML > $env:TAG_ESC.html
     }
+- ps: cd ..
 
 after_deploy:
-- ps: echo S3 Build Location = $env:S3_URL
+- ps: echo "S3 Build Location = $env:S3_URL"
 
 artifacts:
     - path: artifacts

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -106,7 +106,7 @@ after_build:
         git fetch --tags
         $env:TAG_ESC=$env:APPVEYOR_REPO_TAG_NAME -replace '/', ''
         echo $env:FWD_HTML > $env:TAG_ESC.html
-        cd build
+        cd ../build
         cmake --build . --target installer --config Release
     }
 - ps: cd ..

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -98,7 +98,7 @@ before_deploy:
     }
 
 after_deploy:
-- cmd: echo S3 Build Location: %S3_URL%
+- cmd: echo S3 Build Location\: %S3_URL%
 
 artifacts:
     - path: %USERPROFILE%/artifacts

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -106,6 +106,8 @@ after_build:
         git fetch --tags
         $env:TAG_ESC=$env:APPVEYOR_REPO_TAG_NAME -replace '/', ''
         echo $env:FWD_HTML > $env:TAG_ESC.html
+        cd build
+        cmake --build . --target installer --config Release
     }
 - ps: cd ..
 
@@ -115,18 +117,33 @@ after_deploy:
 artifacts:
     - path: artifacts
       name: art_folder
+    - path: build/Install/*.exe
+      name: installer
+      type: File
 
 deploy:
 # s3 upload - every commit
 - provider: S3
-  access_key_id: $(AWS_KEY)
-  secret_access_key: $(AWS_SECRET)
+  access_key_id:
+    secure: DkLynQIGT6YN1PM45y9iIPTd2pdM4worHlbS5mXNtFI=
+  secret_access_key:
+    secure: qD/tbccsTj6FefmdbotjKPtSlvseXhIXsy84DDhuojOxPKz/e5unqeip6onNCI4X
   bucket: supercollider
   region: us-west-2
   folder: $(S3_BUILDS_LOCATION)
   artifact: art_folder
   unzip: true
   set_public: true
+
+# github releases - only tags
+- provider: GitHub
+  description: appveyor_$(APPVEYOR_REPO_TAG_NAME)
+  artifact: installer
+  auth_token:
+    secure: rxXJNY+6n25Th9R4+7qI+AcnTj0wCAMSnBGH2+5s7DlVLrAGsSY6+EEDbeHWGGeI
+  prerelease: true
+  on:
+    appveyor_repo_tag: true
 
 notifications:
     - provider: Webhook

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -108,10 +108,10 @@ artifacts:
 deploy:
 # s3 upload - every commit
 - provider: S3
-  access_key_id: %AWS_KEY%
-  secret_access_key: %AWS_SECRET%
+  access_key_id: $(AWS_KEY)
+  secret_access_key: $(AWS_SECRET)
   bucket: supercollider
-  folder: %S3_BUILDS_LOCATION%
+  folder: $(S3_BUILDS_LOCATION)
   artifact: art_folder
   unzip: true
   set_public: true

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -87,7 +87,8 @@ build_script:
 
 # after_build instead of before_deploy so artifacts are collected at the right time
 after_build:
-- ps: $env:S3_URL="https://supercollider.s3.amazonaws.com/$env:S3_BUILDS_LOCATION/SC-$env:APPVEYOR_REPO_COMMIT.zip"
+- ps: $env:ARCHIVE_NAME="SC-Windows-$env:ARCH$-$env:APPVEYOR_REPO_COMMIT.zip"
+- ps: $env:S3_URL="https://supercollider.s3.amazonaws.com/$env:S3_BUILDS_LOCATION/$env:ARCHIVE_NAME"
 - ps: $env:FWD_HTML="<html><head><meta http-equiv=""refresh"" content=""0; url='$env:S3_URL'"" /></head></html>"
 - ps: $env:BRANCH_ESC=$env:APPVEYOR_REPO_BRANCH -replace '/', ''
 - ps: cd $env:APPVEYOR_BUILD_FOLDER
@@ -97,7 +98,7 @@ after_build:
 - ps: cd artifacts
 - ps: echo $env:FWD_HTML > $env:BRANCH_ESC-latest.html
 - ps: Copy-Item -Path $env:APPVEYOR_BUILD_FOLDER/build/Install/SuperCollider . -Recurse
-- ps: 7z a SC-$env:APPVEYOR_REPO_COMMIT.zip -tzip -mx=9 SuperCollider
+- ps: 7z a $env:ARCHIVE_NAME -tzip SuperCollider
 - ps: rmdir -Recurse -Force SuperCollider
 - ps: echo $env:APPVEYOR_REPO_TAG_NAME
 - ps: >-
@@ -108,6 +109,8 @@ after_build:
         echo $env:FWD_HTML > $env:TAG_ESC.html
         cd ../build
         cmake --build . --target installer --config Release
+        ls .
+        ls Install
     }
 - ps: cd ..
 
@@ -117,7 +120,7 @@ after_deploy:
 artifacts:
     - path: artifacts
       name: art_folder
-    - path: build/Install/*.exe
+    - path: build\Install\*.exe
       name: installer
       type: File
 

--- a/README_MACOS.md
+++ b/README_MACOS.md
@@ -7,7 +7,8 @@ Pre-compiled releases are available for download at:
 
 https://github.com/SuperCollider/SuperCollider/releases
 
-
+You can also download a bleeding-edge build of the latest development branch
+[here](http://supercollider.s3.amazonaws.com/builds/supercollider/supercollider/osx/develop-latest.html).
 
 Table of contents
 -----------------

--- a/README_WINDOWS.md
+++ b/README_WINDOWS.md
@@ -62,6 +62,10 @@ GitHub releases now:
 
     https://github.com/supercollider/supercollider/releases
 
+You can also download a bleeding-edge build of the latest development branch!
+Builds are available for [32-bit][bleeding edge 32 bit] and
+[64-bit][bleeding edge 64 bit] Windows.
+
 This page also provides snapshots of the source version used for the release.
 Note though, that this automated Github service misses out on the submodules.
 For actual development work you should always use SuperCollider's Github repo:
@@ -1303,6 +1307,8 @@ software publicly and freely available.
 [asio4all]: http://www.asio4all.com/ (ASIO4ALL, generic ASIO driver)
 [asiosdk]: http://www.steinberg.net/en/company/developers.html (ASIO SDK v2.3)
 [atomeditor]: https://atom.io/ (free unixy text editor with SuperCollider package)
+[bleeding edge 32 bit]: http://supercollider.s3.amazonaws.com/builds/supercollider/supercollider/win32/develop-latest.html
+[bleeding edge 64 bit]: http://supercollider.s3.amazonaws.com/builds/supercollider/supercollider/win64/develop-latest.html
 [cmake]: http://www.cmake.org/download/
 [conemu]: https://conemu.github.io/ (free console emulator)
 [dependency walker]: http://www.dependencywalker.com/ (inspect missing library errors)


### PR DESCRIPTION
This PR adds S3 deployment to our Appveyor setup so that "bleeding-edge" builds can be downloaded and tested by interested users and developers. Most of this was copied/adapted from `.travis.yml`. Thanks to @scztt for helping with S3 access and general usage.

This should be accompanied by an appropriate PR to the website making these builds available.

With the current config, builds are uploaded both for 32-bit and 64-bit builds.

I haven't tackled the automatic release asset uploading part of the script. If it isn't too hard to add that in, we can merge both at once. Might take some testing with temp tags created on this branch, if you're ok with that @snappizz.