### PR TITLE
PureUGen reform

### DIFF
--- a/SCClassLibrary/Common/Audio/BasicOpsUGen.sc
+++ b/SCClassLibrary/Common/Audio/BasicOpsUGen.sc
@@ -3,6 +3,8 @@
 BasicOpUGen : UGen {
 	var <operator;
 
+	isPureUGen { ^true }
+
 //	writeName { arg file;
 //		var name, opname;
 //		name = this.class.name.asString;

--- a/SCClassLibrary/Common/Audio/BasicOpsUGen.sc
+++ b/SCClassLibrary/Common/Audio/BasicOpsUGen.sc
@@ -3,7 +3,7 @@
 BasicOpUGen : UGen {
 	var <operator;
 
-	isPureUGen { ^true }
+	*isPureUGen { ^true }
 
 //	writeName { arg file;
 //		var name, opname;

--- a/SCClassLibrary/Common/Audio/Delays.sc
+++ b/SCClassLibrary/Common/Audio/Delays.sc
@@ -1,4 +1,5 @@
 Delay1 : PureUGen {
+	isPureUGen { ^true }
 
 	*ar { arg in = 0.0, mul = 1.0, add = 0.0;
 		^this.multiNew('audio', in).madd(mul, add)
@@ -15,6 +16,7 @@ Delay2 : Delay1 { }
 // these delays use real time allocated memory.
 
 DelayN : PureUGen {
+	isPureUGen { ^true }
 
 	*ar { arg in = 0.0, maxdelaytime = 0.2, delaytime = 0.2, mul = 1.0, add = 0.0;
 		^this.multiNew('audio', in.asAudioRateInput, maxdelaytime, delaytime).madd(mul, add)
@@ -29,6 +31,7 @@ DelayC : DelayN { }
 
 
 CombN : PureUGen {
+	isPureUGen { ^true }
 
 	*ar { arg in = 0.0, maxdelaytime = 0.2, delaytime = 0.2, decaytime = 1.0, mul = 1.0, add = 0.0;
 		^this.multiNew('audio', in.asAudioRateInput(this), maxdelaytime, delaytime, decaytime).madd(mul, add)

--- a/SCClassLibrary/Common/Audio/Delays.sc
+++ b/SCClassLibrary/Common/Audio/Delays.sc
@@ -1,5 +1,5 @@
 Delay1 : UGen {
-	isPureUGen { ^true }
+	*isPureUGen { ^true }
 
 	*ar { arg in = 0.0, mul = 1.0, add = 0.0;
 		^this.multiNew('audio', in).madd(mul, add)
@@ -16,7 +16,7 @@ Delay2 : Delay1 { }
 // these delays use real time allocated memory.
 
 DelayN : UGen {
-	isPureUGen { ^true }
+	*isPureUGen { ^true }
 
 	*ar { arg in = 0.0, maxdelaytime = 0.2, delaytime = 0.2, mul = 1.0, add = 0.0;
 		^this.multiNew('audio', in.asAudioRateInput, maxdelaytime, delaytime).madd(mul, add)
@@ -31,7 +31,7 @@ DelayC : DelayN { }
 
 
 CombN : UGen {
-	isPureUGen { ^true }
+	*isPureUGen { ^true }
 
 	*ar { arg in = 0.0, maxdelaytime = 0.2, delaytime = 0.2, decaytime = 1.0, mul = 1.0, add = 0.0;
 		^this.multiNew('audio', in.asAudioRateInput(this), maxdelaytime, delaytime, decaytime).madd(mul, add)

--- a/SCClassLibrary/Common/Audio/Delays.sc
+++ b/SCClassLibrary/Common/Audio/Delays.sc
@@ -1,4 +1,4 @@
-Delay1 : PureUGen {
+Delay1 : UGen {
 	isPureUGen { ^true }
 
 	*ar { arg in = 0.0, mul = 1.0, add = 0.0;
@@ -15,7 +15,7 @@ Delay2 : Delay1 { }
 
 // these delays use real time allocated memory.
 
-DelayN : PureUGen {
+DelayN : UGen {
 	isPureUGen { ^true }
 
 	*ar { arg in = 0.0, maxdelaytime = 0.2, delaytime = 0.2, mul = 1.0, add = 0.0;
@@ -30,7 +30,7 @@ DelayL : DelayN { }
 DelayC : DelayN { }
 
 
-CombN : PureUGen {
+CombN : UGen {
 	isPureUGen { ^true }
 
 	*ar { arg in = 0.0, maxdelaytime = 0.2, delaytime = 0.2, decaytime = 1.0, mul = 1.0, add = 0.0;

--- a/SCClassLibrary/Common/Audio/Filter.sc
+++ b/SCClassLibrary/Common/Audio/Filter.sc
@@ -1,5 +1,5 @@
 Filter : UGen {
-	isPureUGen { ^true }
+	*isPureUGen { ^true }
 	checkInputs { ^this.checkSameRateAsFirstInput }
 }
 

--- a/SCClassLibrary/Common/Audio/Filter.sc
+++ b/SCClassLibrary/Common/Audio/Filter.sc
@@ -1,4 +1,5 @@
 Filter : PureUGen {
+	isPureUGen { ^true }
 	checkInputs { ^this.checkSameRateAsFirstInput }
 }
 

--- a/SCClassLibrary/Common/Audio/Filter.sc
+++ b/SCClassLibrary/Common/Audio/Filter.sc
@@ -1,4 +1,4 @@
-Filter : PureUGen {
+Filter : UGen {
 	isPureUGen { ^true }
 	checkInputs { ^this.checkSameRateAsFirstInput }
 }

--- a/SCClassLibrary/Common/Audio/Line.sc
+++ b/SCClassLibrary/Common/Audio/Line.sc
@@ -17,6 +17,7 @@ XLine : UGen {
 }
 
 LinExp : PureUGen {
+	isPureUGen { ^true }
 	checkInputs { ^this.checkSameRateAsFirstInput }
 	*ar { arg in=0.0, srclo = 0.0, srchi = 1.0, dstlo = 1.0, dsthi = 2.0;
 		^this.multiNew('audio', in, srclo, srchi, dstlo, dsthi)
@@ -42,6 +43,7 @@ LinLin {
 }
 
 AmpComp : PureUGen {
+	isPureUGen { ^true }
 	*ir { arg freq = 60.midicps, root = 60.midicps, exp = 0.3333;
 		^this.multiNew('scalar', freq, root, exp)
 	}
@@ -67,12 +69,14 @@ AmpCompA : AmpComp {
 }
 
 K2A : PureUGen { // control rate to audio rate converter
+	isPureUGen { ^true }
 	*ar { arg in = 0.0;
 		^this.multiNew('audio', in)
 	}
 }
 
 A2K : PureUGen { // audio rate to control rate converter. only needed in specific cases
+	isPureUGen { ^true }
 	*kr { arg in = 0.0;
 		^this.multiNew('control', in)
 	}
@@ -94,6 +98,7 @@ T2A : K2A { // control rate to audio rate trigger converter.
 }
 
 DC : PureMultiOutUGen {
+	isPureUGen { ^true }
 	*ar { arg in=0.0;
 		^this.multiNew('audio', in)
 	}

--- a/SCClassLibrary/Common/Audio/Line.sc
+++ b/SCClassLibrary/Common/Audio/Line.sc
@@ -17,7 +17,7 @@ XLine : UGen {
 }
 
 LinExp : UGen {
-	isPureUGen { ^true }
+	*isPureUGen { ^true }
 	checkInputs { ^this.checkSameRateAsFirstInput }
 	*ar { arg in=0.0, srclo = 0.0, srchi = 1.0, dstlo = 1.0, dsthi = 2.0;
 		^this.multiNew('audio', in, srclo, srchi, dstlo, dsthi)
@@ -43,7 +43,7 @@ LinLin {
 }
 
 AmpComp : UGen {
-	isPureUGen { ^true }
+	*isPureUGen { ^true }
 	*ir { arg freq = 60.midicps, root = 60.midicps, exp = 0.3333;
 		^this.multiNew('scalar', freq, root, exp)
 	}
@@ -69,14 +69,14 @@ AmpCompA : AmpComp {
 }
 
 K2A : UGen { // control rate to audio rate converter
-	isPureUGen { ^true }
+	*isPureUGen { ^true }
 	*ar { arg in = 0.0;
 		^this.multiNew('audio', in)
 	}
 }
 
 A2K : UGen { // audio rate to control rate converter. only needed in specific cases
-	isPureUGen { ^true }
+	*isPureUGen { ^true }
 	*kr { arg in = 0.0;
 		^this.multiNew('control', in)
 	}
@@ -98,7 +98,7 @@ T2A : K2A { // control rate to audio rate trigger converter.
 }
 
 DC : MultiOutUGen {
-	isPureUGen { ^true }
+	*isPureUGen { ^true }
 	*ar { arg in=0.0;
 		^this.multiNew('audio', in)
 	}

--- a/SCClassLibrary/Common/Audio/Line.sc
+++ b/SCClassLibrary/Common/Audio/Line.sc
@@ -16,7 +16,7 @@ XLine : UGen {
 	}
 }
 
-LinExp : PureUGen {
+LinExp : UGen {
 	isPureUGen { ^true }
 	checkInputs { ^this.checkSameRateAsFirstInput }
 	*ar { arg in=0.0, srclo = 0.0, srchi = 1.0, dstlo = 1.0, dsthi = 2.0;
@@ -42,7 +42,7 @@ LinLin {
 	}
 }
 
-AmpComp : PureUGen {
+AmpComp : UGen {
 	isPureUGen { ^true }
 	*ir { arg freq = 60.midicps, root = 60.midicps, exp = 0.3333;
 		^this.multiNew('scalar', freq, root, exp)
@@ -68,14 +68,14 @@ AmpCompA : AmpComp {
 	}
 }
 
-K2A : PureUGen { // control rate to audio rate converter
+K2A : UGen { // control rate to audio rate converter
 	isPureUGen { ^true }
 	*ar { arg in = 0.0;
 		^this.multiNew('audio', in)
 	}
 }
 
-A2K : PureUGen { // audio rate to control rate converter. only needed in specific cases
+A2K : UGen { // audio rate to control rate converter. only needed in specific cases
 	isPureUGen { ^true }
 	*kr { arg in = 0.0;
 		^this.multiNew('control', in)
@@ -97,7 +97,7 @@ T2A : K2A { // control rate to audio rate trigger converter.
 	}
 }
 
-DC : PureMultiOutUGen {
+DC : MultiOutUGen {
 	isPureUGen { ^true }
 	*ar { arg in=0.0;
 		^this.multiNew('audio', in)

--- a/SCClassLibrary/Common/Audio/Osc.sc
+++ b/SCClassLibrary/Common/Audio/Osc.sc
@@ -9,6 +9,7 @@
 */
 
 Osc : PureUGen {
+	isPureUGen { ^true }
 	*ar {
 		arg bufnum, freq=440.0, phase=0.0, mul=1.0, add=0.0;
 		^this.multiNew('audio', bufnum, freq, phase).madd(mul, add)
@@ -20,6 +21,7 @@ Osc : PureUGen {
 }
 
 SinOsc : PureUGen {
+	isPureUGen { ^true }
 	*ar {
 		arg freq=440.0, phase=0.0, mul=1.0, add=0.0;
 		^this.multiNew('audio', freq, phase).madd(mul, add)
@@ -31,6 +33,7 @@ SinOsc : PureUGen {
 }
 
 SinOscFB : PureUGen {
+	isPureUGen { ^true }
 	*ar {
 		arg freq=440.0, feedback=0.0, mul=1.0, add=0.0;
 		^this.multiNew('audio', freq, feedback).madd(mul, add)
@@ -42,6 +45,7 @@ SinOscFB : PureUGen {
 }
 
 OscN : PureUGen {
+	isPureUGen { ^true }
 	*ar {
 		arg bufnum, freq=440.0, phase=0.0, mul=1.0, add=0.0;
 		^this.multiNew('audio', bufnum, freq, phase).madd(mul, add)
@@ -54,6 +58,7 @@ OscN : PureUGen {
 
 
 VOsc : PureUGen {
+	isPureUGen { ^true }
 	*ar {
 		arg bufpos, freq=440.0, phase=0.0, mul=1.0, add=0.0;
 		^this.multiNew('audio', bufpos, freq, phase).madd(mul, add)
@@ -65,6 +70,7 @@ VOsc : PureUGen {
 }
 
 VOsc3 : PureUGen {
+	isPureUGen { ^true }
 	*ar {
 		arg bufpos, freq1=110.0, freq2=220.0, freq3=440.0, mul=1.0, add=0.0;
 		^this.multiNew('audio', bufpos, freq1, freq2, freq3).madd(mul, add)
@@ -76,6 +82,7 @@ VOsc3 : PureUGen {
 }
 
 COsc : PureUGen {
+	isPureUGen { ^true }
 	*ar {
 		arg bufnum, freq=440.0, beats=0.5, mul=1.0, add=0.0;
 		^this.multiNew('audio', bufnum, freq, beats).madd(mul, add)
@@ -87,6 +94,7 @@ COsc : PureUGen {
 }
 
 Formant : PureUGen {
+	isPureUGen { ^true }
 	*ar {
 		arg fundfreq = 440.0, formfreq = 1760.0, bwfreq = 880.0, mul = 1.0, add = 0.0;
 		^this.multiNew('audio', fundfreq, formfreq, bwfreq).madd(mul, add)
@@ -94,6 +102,7 @@ Formant : PureUGen {
 }
 
 LFSaw : PureUGen {
+	isPureUGen { ^true }
 	*ar {
 		arg freq = 440.0, iphase = 0.0, mul = 1.0, add = 0.0;
 		^this.multiNew('audio', freq, iphase).madd(mul, add)
@@ -133,6 +142,7 @@ LFGauss : UGen {
 }
 
 LFPulse : PureUGen {
+	isPureUGen { ^true }
 	*ar {
 		arg freq = 440.0, iphase = 0.0, width = 0.5, mul = 1.0, add = 0.0;
 		^this.multiNew('audio', freq, iphase, width).madd(mul, add)
@@ -145,6 +155,7 @@ LFPulse : PureUGen {
 }
 
 VarSaw : PureUGen {
+	isPureUGen { ^true }
 	*ar {
 		arg freq = 440.0, iphase = 0.0, width = 0.5, mul = 1.0, add = 0.0;
 		^this.multiNew('audio', freq, iphase, width).madd(mul, add)
@@ -156,6 +167,7 @@ VarSaw : PureUGen {
 }
 
 Impulse : PureUGen {
+	isPureUGen { ^true }
 	*ar {
 		arg freq = 440.0, phase = 0.0, mul = 1.0, add = 0.0;
 		^this.multiNew('audio', freq, phase).madd(mul, add)
@@ -169,6 +181,7 @@ Impulse : PureUGen {
 
 
 SyncSaw : PureUGen {
+	isPureUGen { ^true }
 	*ar {
 		arg syncFreq = 440.0, sawFreq = 440.0, mul = 1.0, add = 0.0;
 		^this.multiNew('audio', syncFreq, sawFreq).madd(mul, add)
@@ -193,6 +206,7 @@ SyncSaw : PureUGen {
 //}
 
 Index : PureUGen {
+	isPureUGen { ^true }
 	*ar {
 		arg bufnum, in = 0.0, mul = 1.0, add = 0.0;
 		^this.multiNew('audio', bufnum, in).madd(mul, add)
@@ -219,6 +233,7 @@ IndexL : Index {
 }
 
 DegreeToKey : PureUGen {
+	isPureUGen { ^true }
 	*ar {
 		arg bufnum, in = 0.0, octave = 12.0, mul = 1.0, add = 0.0;
 		^this.multiNew('audio', bufnum, in, octave).madd(mul, add)
@@ -230,6 +245,7 @@ DegreeToKey : PureUGen {
 }
 
 Select : PureUGen {
+	isPureUGen { ^true }
 	*ar {
 		arg which, array;
 		^this.multiNewList(['audio', which] ++ array)
@@ -298,6 +314,7 @@ SelectXFocus {
 }
 
 Vibrato : PureUGen {
+	isPureUGen { ^true }
 	*ar {
 		arg freq = 440.0, rate = 6, depth = 0.02, delay = 0.0, onset = 0.0,
 				rateVariation = 0.04, depthVariation = 0.1, iphase = 0.0, trig = 0.0;

--- a/SCClassLibrary/Common/Audio/Osc.sc
+++ b/SCClassLibrary/Common/Audio/Osc.sc
@@ -9,7 +9,7 @@
 */
 
 Osc : UGen {
-	isPureUGen { ^true }
+	*isPureUGen { ^true }
 	*ar {
 		arg bufnum, freq=440.0, phase=0.0, mul=1.0, add=0.0;
 		^this.multiNew('audio', bufnum, freq, phase).madd(mul, add)
@@ -21,7 +21,7 @@ Osc : UGen {
 }
 
 SinOsc : UGen {
-	isPureUGen { ^true }
+	*isPureUGen { ^true }
 	*ar {
 		arg freq=440.0, phase=0.0, mul=1.0, add=0.0;
 		^this.multiNew('audio', freq, phase).madd(mul, add)
@@ -33,7 +33,7 @@ SinOsc : UGen {
 }
 
 SinOscFB : UGen {
-	isPureUGen { ^true }
+	*isPureUGen { ^true }
 	*ar {
 		arg freq=440.0, feedback=0.0, mul=1.0, add=0.0;
 		^this.multiNew('audio', freq, feedback).madd(mul, add)
@@ -45,7 +45,7 @@ SinOscFB : UGen {
 }
 
 OscN : UGen {
-	isPureUGen { ^true }
+	*isPureUGen { ^true }
 	*ar {
 		arg bufnum, freq=440.0, phase=0.0, mul=1.0, add=0.0;
 		^this.multiNew('audio', bufnum, freq, phase).madd(mul, add)
@@ -58,7 +58,7 @@ OscN : UGen {
 
 
 VOsc : UGen {
-	isPureUGen { ^true }
+	*isPureUGen { ^true }
 	*ar {
 		arg bufpos, freq=440.0, phase=0.0, mul=1.0, add=0.0;
 		^this.multiNew('audio', bufpos, freq, phase).madd(mul, add)
@@ -70,7 +70,7 @@ VOsc : UGen {
 }
 
 VOsc3 : UGen {
-	isPureUGen { ^true }
+	*isPureUGen { ^true }
 	*ar {
 		arg bufpos, freq1=110.0, freq2=220.0, freq3=440.0, mul=1.0, add=0.0;
 		^this.multiNew('audio', bufpos, freq1, freq2, freq3).madd(mul, add)
@@ -82,7 +82,7 @@ VOsc3 : UGen {
 }
 
 COsc : UGen {
-	isPureUGen { ^true }
+	*isPureUGen { ^true }
 	*ar {
 		arg bufnum, freq=440.0, beats=0.5, mul=1.0, add=0.0;
 		^this.multiNew('audio', bufnum, freq, beats).madd(mul, add)
@@ -94,7 +94,7 @@ COsc : UGen {
 }
 
 Formant : UGen {
-	isPureUGen { ^true }
+	*isPureUGen { ^true }
 	*ar {
 		arg fundfreq = 440.0, formfreq = 1760.0, bwfreq = 880.0, mul = 1.0, add = 0.0;
 		^this.multiNew('audio', fundfreq, formfreq, bwfreq).madd(mul, add)
@@ -102,7 +102,7 @@ Formant : UGen {
 }
 
 LFSaw : UGen {
-	isPureUGen { ^true }
+	*isPureUGen { ^true }
 	*ar {
 		arg freq = 440.0, iphase = 0.0, mul = 1.0, add = 0.0;
 		^this.multiNew('audio', freq, iphase).madd(mul, add)
@@ -142,7 +142,7 @@ LFGauss : UGen {
 }
 
 LFPulse : UGen {
-	isPureUGen { ^true }
+	*isPureUGen { ^true }
 	*ar {
 		arg freq = 440.0, iphase = 0.0, width = 0.5, mul = 1.0, add = 0.0;
 		^this.multiNew('audio', freq, iphase, width).madd(mul, add)
@@ -155,7 +155,7 @@ LFPulse : UGen {
 }
 
 VarSaw : UGen {
-	isPureUGen { ^true }
+	*isPureUGen { ^true }
 	*ar {
 		arg freq = 440.0, iphase = 0.0, width = 0.5, mul = 1.0, add = 0.0;
 		^this.multiNew('audio', freq, iphase, width).madd(mul, add)
@@ -167,7 +167,7 @@ VarSaw : UGen {
 }
 
 Impulse : UGen {
-	isPureUGen { ^true }
+	*isPureUGen { ^true }
 	*ar {
 		arg freq = 440.0, phase = 0.0, mul = 1.0, add = 0.0;
 		^this.multiNew('audio', freq, phase).madd(mul, add)
@@ -181,7 +181,7 @@ Impulse : UGen {
 
 
 SyncSaw : UGen {
-	isPureUGen { ^true }
+	*isPureUGen { ^true }
 	*ar {
 		arg syncFreq = 440.0, sawFreq = 440.0, mul = 1.0, add = 0.0;
 		^this.multiNew('audio', syncFreq, sawFreq).madd(mul, add)
@@ -206,7 +206,7 @@ SyncSaw : UGen {
 //}
 
 Index : UGen {
-	isPureUGen { ^true }
+	*isPureUGen { ^true }
 	*ar {
 		arg bufnum, in = 0.0, mul = 1.0, add = 0.0;
 		^this.multiNew('audio', bufnum, in).madd(mul, add)
@@ -233,7 +233,7 @@ IndexL : Index {
 }
 
 DegreeToKey : UGen {
-	isPureUGen { ^true }
+	*isPureUGen { ^true }
 	*ar {
 		arg bufnum, in = 0.0, octave = 12.0, mul = 1.0, add = 0.0;
 		^this.multiNew('audio', bufnum, in, octave).madd(mul, add)
@@ -245,7 +245,7 @@ DegreeToKey : UGen {
 }
 
 Select : UGen {
-	isPureUGen { ^true }
+	*isPureUGen { ^true }
 	*ar {
 		arg which, array;
 		^this.multiNewList(['audio', which] ++ array)
@@ -314,7 +314,7 @@ SelectXFocus {
 }
 
 Vibrato : UGen {
-	isPureUGen { ^true }
+	*isPureUGen { ^true }
 	*ar {
 		arg freq = 440.0, rate = 6, depth = 0.02, delay = 0.0, onset = 0.0,
 				rateVariation = 0.04, depthVariation = 0.1, iphase = 0.0, trig = 0.0;

--- a/SCClassLibrary/Common/Audio/Osc.sc
+++ b/SCClassLibrary/Common/Audio/Osc.sc
@@ -8,7 +8,7 @@
 		add - add to signal or scalar
 */
 
-Osc : PureUGen {
+Osc : UGen {
 	isPureUGen { ^true }
 	*ar {
 		arg bufnum, freq=440.0, phase=0.0, mul=1.0, add=0.0;
@@ -20,7 +20,7 @@ Osc : PureUGen {
 	}
 }
 
-SinOsc : PureUGen {
+SinOsc : UGen {
 	isPureUGen { ^true }
 	*ar {
 		arg freq=440.0, phase=0.0, mul=1.0, add=0.0;
@@ -32,7 +32,7 @@ SinOsc : PureUGen {
 	}
 }
 
-SinOscFB : PureUGen {
+SinOscFB : UGen {
 	isPureUGen { ^true }
 	*ar {
 		arg freq=440.0, feedback=0.0, mul=1.0, add=0.0;
@@ -44,7 +44,7 @@ SinOscFB : PureUGen {
 	}
 }
 
-OscN : PureUGen {
+OscN : UGen {
 	isPureUGen { ^true }
 	*ar {
 		arg bufnum, freq=440.0, phase=0.0, mul=1.0, add=0.0;
@@ -57,7 +57,7 @@ OscN : PureUGen {
 }
 
 
-VOsc : PureUGen {
+VOsc : UGen {
 	isPureUGen { ^true }
 	*ar {
 		arg bufpos, freq=440.0, phase=0.0, mul=1.0, add=0.0;
@@ -69,7 +69,7 @@ VOsc : PureUGen {
 	}
 }
 
-VOsc3 : PureUGen {
+VOsc3 : UGen {
 	isPureUGen { ^true }
 	*ar {
 		arg bufpos, freq1=110.0, freq2=220.0, freq3=440.0, mul=1.0, add=0.0;
@@ -81,7 +81,7 @@ VOsc3 : PureUGen {
 	}
 }
 
-COsc : PureUGen {
+COsc : UGen {
 	isPureUGen { ^true }
 	*ar {
 		arg bufnum, freq=440.0, beats=0.5, mul=1.0, add=0.0;
@@ -93,7 +93,7 @@ COsc : PureUGen {
 	}
 }
 
-Formant : PureUGen {
+Formant : UGen {
 	isPureUGen { ^true }
 	*ar {
 		arg fundfreq = 440.0, formfreq = 1760.0, bwfreq = 880.0, mul = 1.0, add = 0.0;
@@ -101,7 +101,7 @@ Formant : PureUGen {
 	}
 }
 
-LFSaw : PureUGen {
+LFSaw : UGen {
 	isPureUGen { ^true }
 	*ar {
 		arg freq = 440.0, iphase = 0.0, mul = 1.0, add = 0.0;
@@ -141,7 +141,7 @@ LFGauss : UGen {
 
 }
 
-LFPulse : PureUGen {
+LFPulse : UGen {
 	isPureUGen { ^true }
 	*ar {
 		arg freq = 440.0, iphase = 0.0, width = 0.5, mul = 1.0, add = 0.0;
@@ -154,7 +154,7 @@ LFPulse : PureUGen {
 	signalRange { ^\unipolar }
 }
 
-VarSaw : PureUGen {
+VarSaw : UGen {
 	isPureUGen { ^true }
 	*ar {
 		arg freq = 440.0, iphase = 0.0, width = 0.5, mul = 1.0, add = 0.0;
@@ -166,7 +166,7 @@ VarSaw : PureUGen {
 	}
 }
 
-Impulse : PureUGen {
+Impulse : UGen {
 	isPureUGen { ^true }
 	*ar {
 		arg freq = 440.0, phase = 0.0, mul = 1.0, add = 0.0;
@@ -180,7 +180,7 @@ Impulse : PureUGen {
 }
 
 
-SyncSaw : PureUGen {
+SyncSaw : UGen {
 	isPureUGen { ^true }
 	*ar {
 		arg syncFreq = 440.0, sawFreq = 440.0, mul = 1.0, add = 0.0;
@@ -205,7 +205,7 @@ SyncSaw : PureUGen {
 //	signalRange { ^\unipolar }
 //}
 
-Index : PureUGen {
+Index : UGen {
 	isPureUGen { ^true }
 	*ar {
 		arg bufnum, in = 0.0, mul = 1.0, add = 0.0;
@@ -232,7 +232,7 @@ Shaper : Index {
 IndexL : Index {
 }
 
-DegreeToKey : PureUGen {
+DegreeToKey : UGen {
 	isPureUGen { ^true }
 	*ar {
 		arg bufnum, in = 0.0, octave = 12.0, mul = 1.0, add = 0.0;
@@ -244,7 +244,7 @@ DegreeToKey : PureUGen {
 	}
 }
 
-Select : PureUGen {
+Select : UGen {
 	isPureUGen { ^true }
 	*ar {
 		arg which, array;
@@ -313,7 +313,7 @@ SelectXFocus {
 	}
 }
 
-Vibrato : PureUGen {
+Vibrato : UGen {
 	isPureUGen { ^true }
 	*ar {
 		arg freq = 440.0, rate = 6, depth = 0.02, delay = 0.0, onset = 0.0,

--- a/SCClassLibrary/Common/Audio/UGen.sc
+++ b/SCClassLibrary/Common/Audio/UGen.sc
@@ -512,10 +512,11 @@ UGen : AbstractFunction {
 	// read access to buffers/busses are allowed
 
 	// UGens are assumed to be non-pure unless they contradict this
-	isPureUGen { ^false }
+	*isPureUGen { ^false }
+	isPureUGen { ^this.class.isPureUGen }
 
 	performDeadCodeElimination {
-		if (this.isPureUGen and: { descendants.size == 0 }) {
+		if (this.class.isPureUGen and: { descendants.size == 0 }) {
 			this.inputs.do {|a|
 				if (a.isKindOf(UGen)) {
 					a.descendants.remove(this);

--- a/SCClassLibrary/Common/Audio/UGen.sc
+++ b/SCClassLibrary/Common/Audio/UGen.sc
@@ -499,14 +499,17 @@ UGen : AbstractFunction {
 		^outStack.add(this);
 	}
 
-	optimizeGraph {}
+	optimizeGraph { ^this.performDeadCodeElimination }
 
 	dumpName {
 		^synthIndex.asString ++ "_" ++ this.class.name.asString
 	}
 
+	// UGens are assumed to be non-pure unless they contradict this
+	isPureUGen { ^false }
+
 	performDeadCodeElimination {
-		if (descendants.size == 0) {
+		if (this.isPureUGen and: { descendants.size == 0 }) {
 			this.inputs.do {|a|
 				if (a.isKindOf(UGen)) {
 					a.descendants.remove(this);

--- a/SCClassLibrary/Common/Audio/UGen.sc
+++ b/SCClassLibrary/Common/Audio/UGen.sc
@@ -505,6 +505,12 @@ UGen : AbstractFunction {
 		^synthIndex.asString ++ "_" ++ this.class.name.asString
 	}
 
+	// a pure ugen is one which has no side effect
+	// side effect = bus or buffer writing, doneAction, sending OSC or posting
+	// pure ugens may be considered for dead code elimination
+	// non-pure ugens must stay in place because you might need the side effect
+	// read access to buffers/busses are allowed
+
 	// UGens are assumed to be non-pure unless they contradict this
 	isPureUGen { ^false }
 
@@ -520,15 +526,6 @@ UGen : AbstractFunction {
 			^true;
 		};
 		^false
-	}
-}
-
-// ugen which has no side effect and can therefore be considered for a dead code elimination
-// read access to buffers/busses are allowed
-
-PureUGen : UGen {
-	optimizeGraph {
-		super.performDeadCodeElimination
 	}
 }
 
@@ -562,12 +559,6 @@ MultiOutUGen : UGen {
 		channels.do({ arg output; output.synthIndex_(index); });
 	}
 
-}
-
-PureMultiOutUGen : MultiOutUGen {
-	optimizeGraph {
-		super.performDeadCodeElimination
-	}
 }
 
 OutputProxy : UGen {

--- a/SCClassLibrary/deprecated/3.10/PureUGen.sc
+++ b/SCClassLibrary/deprecated/3.10/PureUGen.sc
@@ -1,0 +1,99 @@
+// Something unusual: Deprecating an abstract class
+// The fix is not to replace a method call, but to:
+// 1. MyClass : UGen instead of MyClass : PureUGen
+// 2. Add 'isPureUGen { ^true }' to the class definition.
+// BOTH are needed.
+
+PureUGen : UGen {
+	*new1 { arg rate ... args;
+		var superclass = this;
+		while { superclass.superclass != PureUGen } {
+			superclass = superclass.superclass;
+		};
+		"The abstract class PureUGen is deprecated. The UGen class '%'% needs to be updated to inherit from UGen, and implement isPureUGen { ^true }. Please contact the UGen author."
+		.format(
+			this.name,
+			if(superclass !== this) {
+				", or its superclass '%',".format(superclass.name)
+			} {
+				""
+			}
+		).warn;
+		^super.new1(rate, *args);
+	}
+	*multiNewList { arg args;
+		var superclass = this;
+		while { superclass.superclass != PureUGen } {
+			superclass = superclass.superclass;
+		};
+		"The abstract class PureUGen is deprecated. The UGen class '%'% needs to be updated to inherit from UGen, and implement isPureUGen { ^true }. Please contact the UGen author."
+		.format(
+			this.name,
+			if(superclass !== this) {
+				", or its superclass '%',".format(superclass.name)
+			} {
+				""
+			}
+		).warn;
+		^super.multiNewList(args);
+	}
+
+	// An unwitting user might have written:
+	// MyPseudoUGen : PureUGen { ... }
+	// This is wrong -- pseudo-ugens should not inherit from UGen at all.
+	// The above deprecation warnings will not catch that case.
+	// So, at startup, check the class tree.
+	*initClass {
+		var children = this.subclasses;
+		if(children.size > 0) {
+			children = children.collect(_.name).sort;
+			("The following classes inherit from PureUGen, which is now deprecated. Contact the UGen author(s) to update.\n" ++ children).warn;
+		}
+	}
+}
+
+// Multiple-inheritance problem:
+// PureMultiOutUGen still needs to act like a MultiOutUGen
+
+PureMultiOutUGen : MultiOutUGen {
+	*new1 { arg rate ... args;
+		var superclass = this;
+		while { superclass.superclass != PureMultiOutUGen } {
+			superclass = superclass.superclass;
+		};
+		"The abstract class PureMultiOutUGen is deprecated. The UGen class '%'% needs to be updated to inherit from MultiOutUGen, and implement isPureUGen { ^true }. Please contact the UGen author."
+		.format(
+			this.name,
+			if(superclass !== this) {
+				", or its superclass '%',".format(superclass.name)
+			} {
+				""
+			}
+		).warn;
+		^super.new1(rate, *args);
+	}
+	*multiNewList { arg args;
+		var superclass = this;
+		while { superclass.superclass != PureUGen } {
+			superclass = superclass.superclass;
+		};
+		"The abstract class PureMultiOutUGen is deprecated. The UGen class '%'% needs to be updated to inherit from MultiOutUGen, and implement isPureUGen { ^true }. Please contact the UGen author."
+		.format(
+			this.name,
+			if(superclass !== this) {
+				", or its superclass '%',".format(superclass.name)
+			} {
+				""
+			}
+		).warn;
+		^super.multiNewList(args);
+	}
+
+	*initClass {
+		var children = this.subclasses;
+		if(children.size > 0) {
+			children = children.collect(_.name).sort;
+			("The following classes inherit from PureMultiOutUGen, which is now deprecated. Contact the UGen author(s) to update.\n" ++ children).warn;
+		}
+	}
+}

--- a/SCClassLibrary/deprecated/3.10/PureUGen.sc
+++ b/SCClassLibrary/deprecated/3.10/PureUGen.sc
@@ -1,7 +1,7 @@
 // Something unusual: Deprecating an abstract class
 // The fix is not to replace a method call, but to:
 // 1. MyClass : UGen instead of MyClass : PureUGen
-// 2. Add 'isPureUGen { ^true }' to the class definition.
+// 2. Add '*isPureUGen { ^true }' to the class definition.
 // BOTH are needed.
 
 PureUGen : UGen {
@@ -10,7 +10,7 @@ PureUGen : UGen {
 		while { superclass.superclass != PureUGen } {
 			superclass = superclass.superclass;
 		};
-		"The abstract class PureUGen is deprecated. The UGen class '%'% needs to be updated to inherit from UGen, and implement isPureUGen { ^true }. Please contact the UGen author."
+		"The abstract class PureUGen is deprecated. The UGen class '%'% needs to be updated to inherit from UGen, and implement *isPureUGen { ^true }. Please contact the UGen author."
 		.format(
 			this.name,
 			if(superclass !== this) {
@@ -26,7 +26,7 @@ PureUGen : UGen {
 		while { superclass.superclass != PureUGen } {
 			superclass = superclass.superclass;
 		};
-		"The abstract class PureUGen is deprecated. The UGen class '%'% needs to be updated to inherit from UGen, and implement isPureUGen { ^true }. Please contact the UGen author."
+		"The abstract class PureUGen is deprecated. The UGen class '%'% needs to be updated to inherit from UGen, and implement *isPureUGen { ^true }. Please contact the UGen author."
 		.format(
 			this.name,
 			if(superclass !== this) {
@@ -61,7 +61,7 @@ PureMultiOutUGen : MultiOutUGen {
 		while { superclass.superclass != PureMultiOutUGen } {
 			superclass = superclass.superclass;
 		};
-		"The abstract class PureMultiOutUGen is deprecated. The UGen class '%'% needs to be updated to inherit from MultiOutUGen, and implement isPureUGen { ^true }. Please contact the UGen author."
+		"The abstract class PureMultiOutUGen is deprecated. The UGen class '%'% needs to be updated to inherit from MultiOutUGen, and implement *isPureUGen { ^true }. Please contact the UGen author."
 		.format(
 			this.name,
 			if(superclass !== this) {
@@ -77,7 +77,7 @@ PureMultiOutUGen : MultiOutUGen {
 		while { superclass.superclass != PureUGen } {
 			superclass = superclass.superclass;
 		};
-		"The abstract class PureMultiOutUGen is deprecated. The UGen class '%'% needs to be updated to inherit from MultiOutUGen, and implement isPureUGen { ^true }. Please contact the UGen author."
+		"The abstract class PureMultiOutUGen is deprecated. The UGen class '%'% needs to be updated to inherit from MultiOutUGen, and implement *isPureUGen { ^true }. Please contact the UGen author."
 		.format(
 			this.name,
 			if(superclass !== this) {


### PR DESCRIPTION
Continuing with leftover tasks... here's a start on the PureUGen refactor.

- First commit: Add `isPureUGen { ^false }` to UGen, and `isPureUGen { ^true }` to every direct subclass of PureUGen. (At first, I thought I should add the "true" definition to every member of `PureUGen.allSubclasses`, but then I realized, for instance, if I add it to Filter, then every subclass of Filter automatically picks it up. So it's enough to hit the first-generation children.)

- Second commit: Remove PureUGen and PureMultiOutUGen.

- Next step (not done): Add "true" for the remaining units that should be pure, but currently aren't.

I did a couple of quick, basic tests, and in those simple cases, dead code elimination behaved exactly the same. I want to do some more tests before going further -- it seems wise to pause at a point where the behavior should be unchanged.

But I'd like to submit the WIP, to have more pairs of eyes looking it over.

Not a bugfix, so this is based on the develop branch.