### PR TITLE
appveyor: use more restricted s3 credentials

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -128,9 +128,9 @@ deploy:
 # s3 upload - every commit
 - provider: S3
   access_key_id:
-    secure: DkLynQIGT6YN1PM45y9iIPTd2pdM4worHlbS5mXNtFI=
+    secure: Imi70fjxyMWt9kwV9RfVT7qV8OaxA40iGlR1hO12SK4=
   secret_access_key:
-    secure: qD/tbccsTj6FefmdbotjKPtSlvseXhIXsy84DDhuojOxPKz/e5unqeip6onNCI4X
+    secure: 3K2MRfkIb7BJk4kCCakxcGAjkc1LCYZHpD32I52mYd//2WHE63xVJl/qd3Q1IBhI
   bucket: supercollider
   region: us-west-2
   folder: $(S3_BUILDS_LOCATION)


### PR DESCRIPTION
This replaces the credentials in appveyor.yml with credentials that are more restricted than what we were using previously. This is good because now appveyor will only be able to do the bare minimum of what it needs to do.