### PR TITLE
class library: Improve post output on server quit

### DIFF
--- a/HelpSource/Classes/Server.schelp
+++ b/HelpSource/Classes/Server.schelp
@@ -140,7 +140,7 @@ Switches the server program to scsynth. This is the default server.
 
 InstanceMethods::
 
-private:: doSend, prHandleClientLoginInfoFromServer, prHandleNotifyFailString, prPingApp
+private:: doSend, prHandleClientLoginInfoFromServer, prHandleNotifyFailString, prPingApp, prOnServerProcessExit
 
 method:: sendMsg
 send an OSC-message to the server.

--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -993,9 +993,9 @@ Server {
 
 		if(inProcess) {
 			this.quitInProcess;
-			"quit done\n".postln;
+			"quit done".postln;
 		} {
-			"'/quit' sent\n".postln;
+			"'/quit' message sent to server '%'.".format(name).postln;
 		};
 
 		pid = nil;

--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -912,7 +912,7 @@ Server {
 
 	bootServerApp { |onComplete|
 		if(inProcess) {
-			"booting internal".postln;
+			"Booting internal server.".postln;
 			this.bootInProcess;
 			pid = thisProcess.pid;
 			onComplete.value;
@@ -921,7 +921,7 @@ Server {
 			pid = unixCmd(program ++ options.asOptionsString(addr.port), { |exitCode|
 				this.prOnServerProcessExit(exitCode);
 			});
-			("booting server '%' on address: %:%").format(this.name, addr.hostname, addr.port.asString).postln;
+			("Booting server '%' on address %:%.").format(this.name, addr.hostname, addr.port.asString).postln;
 			if(options.protocol == \tcp, { addr.tryConnectTCP(onComplete) }, onComplete);
 		}
 	}
@@ -993,7 +993,7 @@ Server {
 
 		if(inProcess) {
 			this.quitInProcess;
-			"quit done".postln;
+			"Internal server has quit.".postln;
 		} {
 			"'/quit' message sent to server '%'.".format(name).postln;
 		};

--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -903,7 +903,7 @@ Server {
 		this.connectSharedMemory;
 	}
 
-	onServerProcessExit { |exitCode|
+	prOnServerProcessExit { |exitCode|
 		"Server '%' exited with exit code %."
 			.format(this.name, exitCode)
 			.postln;
@@ -919,7 +919,7 @@ Server {
 		} {
 			this.disconnectSharedMemory;
 			pid = unixCmd(program ++ options.asOptionsString(addr.port), { |exitCode|
-				this.onServerProcessExit(exitCode);
+				this.prOnServerProcessExit(exitCode);
 			});
 			("booting server '%' on address: %:%").format(this.name, addr.hostname, addr.port.asString).postln;
 			if(options.protocol == \tcp, { addr.tryConnectTCP(onComplete) }, onComplete);

--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -903,6 +903,13 @@ Server {
 		this.connectSharedMemory;
 	}
 
+	onServerProcessExit { |exitCode|
+		"Server '%' exited with exit code %."
+			.format(this.name, exitCode)
+			.postln;
+		statusWatcher.quit(watchShutDown: false);
+	}
+
 	bootServerApp { |onComplete|
 		if(inProcess) {
 			"booting internal".postln;
@@ -911,7 +918,9 @@ Server {
 			onComplete.value;
 		} {
 			this.disconnectSharedMemory;
-			pid = unixCmd(program ++ options.asOptionsString(addr.port), { statusWatcher.quit(watchShutDown:false) });
+			pid = unixCmd(program ++ options.asOptionsString(addr.port), { |exitCode|
+				this.onServerProcessExit(exitCode);
+			});
 			("booting server '%' on address: %:%").format(this.name, addr.hostname, addr.port.asString).postln;
 			if(options.protocol == \tcp, { addr.tryConnectTCP(onComplete) }, onComplete);
 		}


### PR DESCRIPTION
This commit adds a new message when the server process quits:

    Server ___ exited with return code ___.

This is much less cryptic than `RESULT = 0`.

It also improves the "'/quit' sent" message.