### PR TITLE
sclang: create default compilation directories automatically

### DIFF
--- a/lang/LangSource/PyrLexer.cpp
+++ b/lang/LangSource/PyrLexer.cpp
@@ -1810,6 +1810,36 @@ void finiPassOne()
 	//postfl("<-finiPassOne\n");
 }
 
+/**
+ * \brief \c true if \c dir is one of the language config's default classlib directories
+ */
+static bool isDefaultClassLibraryDirectory(const bfs::path& dir)
+{
+	auto const& defaultDirs = gLanguageConfig->defaultClassLibraryDirectories();
+	auto const iter = std::find(defaultDirs.begin(), defaultDirs.end(), dir);
+	return iter != defaultDirs.end();
+}
+
+/**
+ * \brief Handles a missing directory encountered during compilation.
+ *
+ * If the directory is one of the default directories traversed during compilation,
+ * try to create it, silently ignoring failure (most likely from permissions failure).
+ * Otherwise, warn the user to help catch mistyped/missing directory names. See #3468.
+ */
+static void passOne_HandleMissingDirectory(const bfs::path& dir)
+{
+	if (isDefaultClassLibraryDirectory(dir)) {
+		boost::system::error_code ec{};
+		bfs::create_directories(dir, ec);
+	} else {
+		post("WARNING: Could not open directory: '%s'\n"
+			 "\tTo resolve this, either create the directory or remove it from your compilation paths.\n\n",
+			 SC_Codecvt::path_to_utf8_str(dir).c_str()
+		);
+	}
+}
+
 bfs::path relativeToCompileDir(const bfs::path& p)
 {
 	return bfs::relative(p, gCompileDir);
@@ -1867,12 +1897,7 @@ static bool passOne_ProcessDir(const bfs::path& dir)
 		// If we got an error, post a warning if it was because the target wasn't found, and return success.
 		// Otherwise, post the error and fail.
 		if (ec.default_error_condition().value() == boost::system::errc::no_such_file_or_directory) {
-			post("WARNING: Could not open directory: '%s'\n"
-				"\tTo resolve this, either create the directory or remove it from your compilation paths.\n\n",
-				SC_Codecvt::path_to_utf8_str(dir).c_str(),
-				ec.message().c_str()
-			);
-
+			passOne_HandleMissingDirectory(dir);
 			return true;
 		} else {
 			error("Could not open directory '%s': (%d) %s\n",

--- a/lang/LangSource/SC_LanguageConfig.hpp
+++ b/lang/LangSource/SC_LanguageConfig.hpp
@@ -31,6 +31,15 @@
 class SC_LanguageConfig;
 extern SC_LanguageConfig* gLanguageConfig;
 
+/**
+ * \brief Language configuration settings.
+ *
+ * \c sclang uses a global instance of this class to manage knowledge of
+ * compilation paths.
+ *
+ * \c SC_LanguageConfig also provides services for the global language
+ * configuration file and the option for warning on function inlining.
+ */
 class SC_LanguageConfig
 {
 public:

--- a/lang/LangSource/SC_LanguageConfig.hpp
+++ b/lang/LangSource/SC_LanguageConfig.hpp
@@ -50,6 +50,8 @@ public:
 
 	const DirVector& includedDirectories() const { return mIncludedDirectories; }
 	const DirVector& excludedDirectories() const { return mExcludedDirectories; }
+	const DirVector& defaultClassLibraryDirectories() const
+	{ return mDefaultClassLibraryDirectories; }
 
 	void postExcludedDirectories(void) const;
 


### PR DESCRIPTION
Fixes \#3468.
During library compilation, try to create any missing default directories

And, don't warn if these don't exist or can't be created

Solves much user confusion and annoyance

Also added some doc comments