### PR TITLE
fix re-login behavior of remote clients to a server

### DIFF
--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -544,7 +544,8 @@ Server {
 		case
 		{ failString.asString.contains("already registered") } {
 			"% - already registered with clientID %.\n".postf(this, msg[3]);
-			statusWatcher.notified = true;
+			statusWatcher.prRecoverRemoteLogin(msg[3]);
+
 		} { failString.asString.contains("not registered") } {
 			// unregister when already not registered:
 			"% - not registered.\n".postf(this);

--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -543,8 +543,10 @@ Server {
 		// post info on some known error cases
 		case
 		{ failString.asString.contains("already registered") } {
+			// when already registered, msg[3] is the clientID by which
+			// the requesting client was registered previously
 			"% - already registered with clientID %.\n".postf(this, msg[3]);
-			statusWatcher.prRecoverRemoteLogin(msg[3]);
+			statusWatcher.prHandleLoginWhenAlreadyRegistered(msg[3]);
 
 		} { failString.asString.contains("not registered") } {
 			// unregister when already not registered:

--- a/SCClassLibrary/Common/Control/ServerStatus.sc
+++ b/SCClassLibrary/Common/Control/ServerStatus.sc
@@ -249,15 +249,15 @@ ServerStatusWatcher {
 			// make sure we can set the clientID, and set it
 			notified = false;
 			server.clientID_(clientIDFromProcess);
-			"// This seems to be a login after a crash, or from a new server object,\n"
-			"// so you may want to release currently running synths by hand:\n".postln;
+			"*** This seems to be a login after a crash, or from a new server object,\n"
+			"*** so you may want to release currently running synths by hand:".postln;
 			"%.defaultGroup.release;\n".postf(server.cs);
-			"// and you may want to redo server boot finalization by hand:\n".postln;
-			"%.statusWatcher.prFinalizeBoot;\n".postf(server.cs);
+			"*** and you may want to redo server boot finalization by hand:".postln;
+			"%.statusWatcher.prFinalizeBoot;\n\n".postf(server.cs);
 		} {
 			// same clientID, so leave all server resources in the state they were in!
-			"// This seems to be a login after a loss of network contact - \n"
-			"// - reconnected with the same clientID as before, so probably all is well.\n".postln;
+			"This seems to be a login after a loss of network contact - \n"
+			"- reconnected with the same clientID as before, so probably all is well.\n".postln;
 		};
 
 		// ensure that statuswatcher is in the correct state immediately.

--- a/SCClassLibrary/Common/Control/ServerStatus.sc
+++ b/SCClassLibrary/Common/Control/ServerStatus.sc
@@ -237,12 +237,33 @@ ServerStatusWatcher {
 		}, AppClock)
 	}
 
-	prRecoverRemoteLogin { |clientID|
-		"% - recovering by adapting clientID %.\n".postf(server, clientID);
-		// make sure we can set the clientID
-		notified = false;
-		server.clientID_(clientID);
-		this.prFinalizeBoot;
+	// This method attempts to recover from a loss of client-server contact,
+	// which is a serious emergency in live shows. So it posts a lot of info
+	// on the recovered state, and possibly helpful next user actions.
+
+	prHandleLoginWhenAlreadyRegistered { |clientIDFromProcess|
+		"% - handling login request though already registered - \n".postf(server);
+
+		// by default, only reset clientID if changed, to leave allocators untouched:
+		if (clientIDFromProcess != server.clientID) {
+			// make sure we can set the clientID, and set it
+			notified = false;
+			server.clientID_(clientIDFromProcess);
+			"// This seems to be a login after a crash, or from a new server object,\n"
+			"// so you may want to release currently running synths by hand:\n".postln;
+			"%.defaultGroup.release;\n".postf(server.cs);
+			"// and you may want to redo server boot finalization by hand:\n".postln;
+			"%.statusWatcher.prFinalizeBoot;\n".postf(server.cs);
+		} {
+			// same clientID, so leave all server resources in the state they were in!
+			"// This seems to be a login after a loss of network contact - \n"
+			"// - reconnected with the same clientID as before, so probably all is well.\n".postln;
+		};
+
+		// ensure that statuswatcher is in the correct state immediately.
+		this.notified = true;
+		unresponsive = false;
+		server.changed(\serverRunning);
 	}
 
 	prSendNotifyRequest { |flag = true, addingStatusWatcher|

--- a/testsuite/classlibrary/TestServer_clientID_booted.sc
+++ b/testsuite/classlibrary/TestServer_clientID_booted.sc
@@ -139,8 +139,6 @@ TestServer_clientID_booted : UnitTest {
 		// simulate a remote server process by starting a server process independently of SC
 		serverPid = unixCmd(Server.program + options.asOptionsString);
 
-		1.wait;
-
 		// login with standard Server.remote method to test for
 		remote1 = Server.remote(\remoteLogin1, options: options, clientID: 3);
 		cond = Condition.new;

--- a/testsuite/classlibrary/TestServer_clientID_booted.sc
+++ b/testsuite/classlibrary/TestServer_clientID_booted.sc
@@ -127,6 +127,14 @@ TestServer_clientID_booted : UnitTest {
 
 	}
 
+	// temp replacement for Platform:killProcessByID
+	killProcessByID { |pid|
+		Platform.case(
+			\windows, { ("taskkill /F /pid " ++ pid).unixCmd },
+			{ ("kill -9 " ++ pid).unixCmd }
+		)
+	}
+
 	// test that logins to a (pseudo-) remote server process work as intended
 	// first login initializes fully,
 	// second login from same address gets the same clientID, and sets running state.
@@ -160,10 +168,9 @@ TestServer_clientID_booted : UnitTest {
 		);
 
 		remote1.remove;
-		// temp macOS only for now
-		unixCmd("kill -9" + serverPid);
-		// crossplatform when addKillMethod PR is in
-		// thisProcess.platform.kill(serverPid);
+		// FIXME: when addKillMethod PR is in, replace with
+		// thisProcess.platform.killProcessByID(serverPid);
+		this.killProcessByID(serverPid);
 	}
 
 	test_repeatedRemoteLogin {
@@ -219,9 +226,8 @@ TestServer_clientID_booted : UnitTest {
 		// cleanup
 		remote1.remove;
 		remote2.remove;
-		// temp macOS only for now
-		unixCmd("kill -9" + serverPid);
-		// crossplatform when addKillMethod PR is in
-		// thisProcess.platform.kill(serverPid);
+		// FIXME: when addKillMethod PR is in, replace with
+		// thisProcess.platform.killProcessByID(serverPid);
+		this.killProcessByID(serverPid);
 	}
 }

--- a/testsuite/classlibrary/TestServer_clientID_booted.sc
+++ b/testsuite/classlibrary/TestServer_clientID_booted.sc
@@ -71,47 +71,127 @@ TestServer_clientID_booted : UnitTest {
 		s.remove;
 	}
 
-	test_recoverRemoteReLogin {
-		var options, homeServer, remote, dt = 0.1, timeout = 5;
+	// test that repeated login from the same server object to a running server process
+	// ends with correct server status, and keeps clientID and allocators  as is.
+	test_repeatedLogin {
+		var server, cond, timer, lastNodeID;
+
+		server = Server(thisMethod.name.asSymbol);
+		server.options.maxLogins = 4;
+		server.clientID = 3;
+		this.bootServer(server);
+
+		// use some nodeIDs so we know whether nodeID allocator is reset
+		10.do { server.nextNodeID };
+		lastNodeID = server.nextNodeID;
+
+		// simulate losing network contact by turning off watcher,
+		// but actually leave the server process running
+		server.statusWatcher
+			.stopStatusWatcher
+			.stopAliveThread
+			.notified_(false)
+			.serverRunning_(false);
+
+//		1.wait;
+
+		// now login again from the same server object
+		// should get "This seems to be a login after loss of network ... all is well" post.
+		server.startAliveThread;
+
+		cond = Condition.new;
+
+		timer = fork { 3.wait; cond.unhang };
+		server.doWhenBooted {
+			"% - server login timed out.\n".postf(thisMethod);
+			timer.stop;
+			cond.unhang;
+		};
+
+		cond.hang;
+
+		this.assert(server.serverRunning,
+			"after repeated login, server should be known to be fully running."
+		);
+
+		this.assert(server.clientID == 3,
+			"after repeated login, remote client should get the same clientID from server process."
+		);
+
+		this.assert(server.nextNodeID > lastNodeID,
+			"after repeated login, nodeID allocator should not be reset."
+		);
+
+		server.quit;
+		server.remove;
+
+	}
+
+	// test that logins to a (pseudo-) remote server process work as intended
+	// first login initializes fully,
+	// second login from same address gets the same clientID, and sets running state.
+	test_remoteLogins {
+		var options, serverPid, remote1, remote2, cond, timer;
 
 		options = ServerOptions.new;
 		options.maxLogins = 4;
-		options.sampleRate = 48000;
 
-		homeServer = Server(\pseudoHome, options: options);
+		// simulate a remote server process by starting a server process independently of SC
+		serverPid = unixCmd(Server.program + options.asOptionsString);
 
-		homeServer.clientID = 3;
-		this.bootServer(homeServer);
+		1.wait;
 
-		this.assert(homeServer.clientID == 3,
-			"homeServer gets requested clientID back from server process."
+		// login with standard Server.remote method to test for
+		remote1 = Server.remote(\remoteLogin1, options: options, clientID: 3);
+		cond = Condition.new;
+		timer = fork { 3.wait; cond.unhang };
+
+		remote1.doWhenBooted {
+			"% - server first login timed out.\n".postf(thisMethod);
+			timer.stop;
+			cond.unhang;
+		};
+		cond.hang;
+
+		this.assert(remote1.serverRunning,
+			"after first login, remote client should be known to be fully running."
 		);
 
-		// make s play dead now, but leave the process running
-		homeServer.statusWatcher.stopStatusWatcher.stopAliveThread.serverRunning_(false);
-		// homeServer.serverRunning.postln; // client thinks it is dead
+		this.assert(remote1.clientID == 3,
+			"after first login, remote client should have its requested clientID."
+		);
 
-		// now login again from different server object, but same client address
-		// -> this client netaddr is already registered, and should say so!
-		// -> so the response should go thru prHandleNotifyFailString
+		// now login again from a different server object,
+		// but from the same client address (in the test, local, in reality, it would be remote).
+		// This simulates a crashed remote client which gets restarted,
+		// and logs in with its old setup data.
 
-		remote = Server.remote(\remTest, homeServer.addr, homeServer.options);
-		// Server.default = remote; // to test IDE server display
+		// Because client netaddr is already registered in the server process,
+		// the response goes thru prHandleNotifyFailString, and prHandleLoginWhenAlreadyRegistered
 
-		while {
-			remote.serverRunning.not and: { timeout > 0 }
-		} {
-			timeout = timeout - dt;
-			dt.wait;
+		remote2 = Server.remote(\remoteLogin2, options: options);
+		cond = Condition.new;
+		timer = fork { 3.wait; cond.unhang };
+
+		remote2.doWhenBooted {
+			"% - server repeated login timed out.\n".postf(thisMethod);
+			timer.stop;
+			cond.unhang;
 		};
 
-		this.assert(remote.serverRunning,
-			"after recovering, remote client is known to be fully running."
+		cond.hang;
+
+		this.assert(remote2.serverRunning,
+			"after re-login from a new server object, remote client should be known to be fully running."
 		);
 
-		this.assert(remote.clientID == 3,
-			"after recovering, remote client gets same clientID from server process."
+		this.assert(remote2.clientID == 3,
+			"after re-login from a new server object, remote client should have its requested clientID."
 		);
 
+		// cleanup
+		remote1.remove;
+		remote2.remove;
+		unixCmd("kill -9" + serverPid);
 	}
 }

--- a/testsuite/classlibrary/TestServer_clientID_booted.sc
+++ b/testsuite/classlibrary/TestServer_clientID_booted.sc
@@ -72,7 +72,7 @@ TestServer_clientID_booted : UnitTest {
 	}
 
 	test_recoverRemoteReLogin {
-		var options, homeServer, remote;
+		var options, homeServer, remote, dt = 0.1, timeout = 5;
 
 		options = ServerOptions.new;
 		options.maxLogins = 4;
@@ -98,7 +98,16 @@ TestServer_clientID_booted : UnitTest {
 		remote = Server.remote(\remTest, homeServer.addr, homeServer.options);
 		// Server.default = remote; // to test IDE server display
 
-		while { remote.serverRunning.not } { 0.1.wait };
+		while {
+			remote.serverRunning.not and: { timeout > 0 }
+		} {
+			timeout = timeout - dt;
+			dt.wait;
+		};
+
+		this.assert(remote.serverRunning,
+			"after recovering, remote client is known to be fully running."
+		);
 
 		this.assert(remote.clientID == 3,
 			"after recovering, remote client gets same clientID from server process."

--- a/testsuite/classlibrary/TestServer_clientID_booted.sc
+++ b/testsuite/classlibrary/TestServer_clientID_booted.sc
@@ -93,8 +93,6 @@ TestServer_clientID_booted : UnitTest {
 		.notified_(false)
 		.serverRunning_(false);
 
-		//		1.wait;
-
 		// now login again from the same server object
 		// should get "This seems to be a login after loss of network ... all is well" post.
 		server.startAliveThread;

--- a/testsuite/classlibrary/TestServer_clientID_booted.sc
+++ b/testsuite/classlibrary/TestServer_clientID_booted.sc
@@ -127,14 +127,6 @@ TestServer_clientID_booted : UnitTest {
 
 	}
 
-	// temp replacement for Platform:killProcessByID
-	killProcessByID { |pid|
-		Platform.case(
-			\windows, { ("taskkill /F /pid " ++ pid).unixCmd },
-			{ ("kill -9 " ++ pid).unixCmd }
-		)
-	}
-
 	// test that logins to a (pseudo-) remote server process work as intended
 	// first login initializes fully,
 	// second login from same address gets the same clientID, and sets running state.
@@ -168,9 +160,7 @@ TestServer_clientID_booted : UnitTest {
 		);
 
 		remote1.remove;
-		// FIXME: when addKillMethod PR is in, replace with
-		// thisProcess.platform.killProcessByID(serverPid);
-		this.killProcessByID(serverPid);
+		thisProcess.platform.killProcessByID(serverPid);
 	}
 
 	test_repeatedRemoteLogin {
@@ -226,8 +216,6 @@ TestServer_clientID_booted : UnitTest {
 		// cleanup
 		remote1.remove;
 		remote2.remove;
-		// FIXME: when addKillMethod PR is in, replace with
-		// thisProcess.platform.killProcessByID(serverPid);
-		this.killProcessByID(serverPid);
+		thisProcess.platform.killProcessByID(serverPid);
 	}
 }


### PR DESCRIPTION
*** PR Info text completely redone ***
Thanks to questions by @muellmusik and @brianlheim,
the cases covered in this PR became much clearer to me.
The general issue is handling repeated logins in network performance situations,
to recover as gracefully as possible from loss of connection between client and server,
whether by network glicht or client crash.
(server crash is outside the scope of this PR, but should be fully thought through elsewhere.)

Case 1: network connection is lost,
and the same client, same client-side server object logs in again.
* the server program remembers the client, and sends its previous clientID back
* then the client knows it is connected again,
* and it can keep all its known buffers, nodes, synths as they are.
-> so, just post that connection is back, and all is well.

Case 2: client crashes, and is restarted;
then the new client logs in again from the same network address:
* the client-side server object is new, but the server program knows the address,
so the server program sends its previous clientID back to the new client.
* because the new server object may not know its previous clientID,
the server program response may trigger new allocators - which is correct
* there may be buffers and running nodes and synths on the server program
that the new server object does not know about:
depending on the specific setup used,
- it may make sense to get rid of these by hand ( server.defaultGroup.release )
- and reinit the server by running server.statusWatcher.prFinalizeBoot by hand.
-> so, post about successful reconnect, and advice about release/reinit code.

(Note for later: maybe develop functionality to retrieve these resources
from the server program in the client.)

Case 3: loss of connection and login from a different network address:
This will look like a new login to the server, so the old defaultGroup
and everything in it keeps going, and the new client gets a new clientID.

In the future, this case could be handled better by releasing the previous notify registration,
and then asking for the same clientID it had earlier, to continue seamlessly from there.
This would need some more effort to work.

The tests provided also cover cases 1 and 2:
TestServer_clientID_booted:test_repeatedLogin tests case 1
TestServer_clientID_booted:test_remoteLogins tests a first login by the Server:remote method,
and a repeated login from a new server object after a simulated crash.
```
fork {
	Server.killAll;
	0.1.wait;
	TestServer_clientID_booted.new.test_repeatedLogin;
	0.1.wait;
	TestServer_clientID_booted.new.test_remoteLogins;
};
```
