### PR TITLE
scsynth: use correct types for allocation sizes

### DIFF
--- a/server/scsynth/SC_GraphDef.cpp
+++ b/server/scsynth/SC_GraphDef.cpp
@@ -371,10 +371,10 @@ static void GraphDef_SetAllocSizes(GraphDef* graphDef)
 	graphDef->mMapControlsAllocSize = graphDef->mNumControls * sizeof(float*);
 	graphDef->mNodeDef.mAllocSize += graphDef->mMapControlsAllocSize;
 
-	graphDef->mMapControlRatesAllocSize = graphDef->mNumControls * sizeof(int*);
+	graphDef->mMapControlRatesAllocSize = graphDef->mNumControls * sizeof(int);
 	graphDef->mNodeDef.mAllocSize += graphDef->mMapControlRatesAllocSize;
 
-	graphDef->mAudioMapBusOffsetSize = graphDef->mNumControls * sizeof(int32*);
+	graphDef->mAudioMapBusOffsetSize = graphDef->mNumControls * sizeof(int32);
 	graphDef->mNodeDef.mAllocSize += graphDef->mAudioMapBusOffsetSize;
 }
 


### PR DESCRIPTION
In GraphDef_Read(), sizeof is applied to incorrect types - int* and
int32* instead of int and int32. This doesn't appear to have caused any
problems so far, but is a mistake and could cause issues on systems
where these sizes differ.