### PR TITLE
add crossplatform kill method

### DIFF
--- a/HelpSource/Classes/Platform.schelp
+++ b/HelpSource/Classes/Platform.schelp
@@ -144,6 +144,25 @@ files to be loaded on startup
 method:: loadStartupFiles
 (re)load startup files
 
+subsection:: Crossplatform system commands
+
+method:: killAll
+kill all processes as defined by cmdLineArgs.
+Typically, this is a process name or a list of names.
+code::
+// kill all possibly running servers (scsynth or supernova)
+thisProcess.platform.killAll("scsynth supernova");
+::
+
+method:: killProcessByID
+kill all processes as identified by pid argument.
+code::
+// start server program from cmdLine for testing
+~pid = unixCmd(Server.program + s.options.asOptionsString);
+// kill just that server program by its pid:
+thisProcess.platform.killProcessByID(~pid);
+::
+
 subsection:: Features
 
 Features are abstract symbols that can be declared by extension authors and be checked during runtime in user code. Apart from explicitly declared features, class and primitive names are implicitly declared.

--- a/HelpSource/Classes/Platform.schelp
+++ b/HelpSource/Classes/Platform.schelp
@@ -144,21 +144,24 @@ files to be loaded on startup
 method:: loadStartupFiles
 (re)load startup files
 
-subsection:: Crossplatform system commands
+subsection:: System commands
 
 method:: killAll
 kill all processes as defined by cmdLineArgs.
-Typically, this is a process name or a list of names.
+argument:: cmdLineArgs
+a string containing one or several process names.
 code::
-// kill all possibly running servers (scsynth or supernova)
+// e.g. kill all possibly running servers (scsynth or supernova)
 thisProcess.platform.killAll("scsynth supernova");
 ::
 
 method:: killProcessByID
-kill all processes as identified by pid argument.
+kill a single process as identified by its process ID.
+argument:: pid
+an Integer which is the pid of the process to kill.
 code::
-// start server program from cmdLine for testing
-~pid = unixCmd(Server.program + s.options.asOptionsString);
+// start a server program from the cmdLine for testing
+~pid = unixCmd(Server.program + s.options.asOptionsString(57100));
 // kill just that server program by its pid:
 thisProcess.platform.killProcessByID(~pid);
 ::

--- a/SCClassLibrary/Platform/Platform.sc
+++ b/SCClassLibrary/Platform/Platform.sc
@@ -173,7 +173,7 @@ Platform {
 	writeClientCSS {}
 
 	killProcessByID { |cmdLineArgs|
-		^this.subclassResponsibility(\kill)
+		^this.subclassResponsibility(\killProcessByID)
 	}
 
 	killAll { |cmdLineArgs|

--- a/SCClassLibrary/Platform/Platform.sc
+++ b/SCClassLibrary/Platform/Platform.sc
@@ -172,7 +172,7 @@ Platform {
 	// hook for clients to write frontend.css
 	writeClientCSS {}
 
-	kill { |cmdLineArgs|
+	killProcessByID { |cmdLineArgs|
 		^this.subclassResponsibility(\kill)
 	}
 
@@ -200,7 +200,7 @@ UnixPlatform : Platform {
 		^arch.asSymbol;
 	}
 
-	kill { |pid|
+	killProcessByID { |pid|
 		("kill -9 " ++ pid).unixCmd;
 	}
 

--- a/SCClassLibrary/Platform/Platform.sc
+++ b/SCClassLibrary/Platform/Platform.sc
@@ -172,6 +172,10 @@ Platform {
 	// hook for clients to write frontend.css
 	writeClientCSS {}
 
+	kill { |cmdLineArgs|
+		^this.subclassResponsibility(\kill)
+	}
+
 	killAll { |cmdLineArgs|
 		^this.subclassResponsibility(\killAll)
 	}
@@ -194,6 +198,10 @@ UnixPlatform : Platform {
 		arch = pipe.getLine;
 		pipe.close;
 		^arch.asSymbol;
+	}
+
+	kill { |pid|
+		("kill -9 " ++ pid).unixCmd;
 	}
 
 	killAll { |cmdLineArgs|

--- a/SCClassLibrary/Platform/Platform.sc
+++ b/SCClassLibrary/Platform/Platform.sc
@@ -172,7 +172,7 @@ Platform {
 	// hook for clients to write frontend.css
 	writeClientCSS {}
 
-	killProcessByID { |cmdLineArgs|
+	killProcessByID { |pid|
 		^this.subclassResponsibility(\killProcessByID)
 	}
 

--- a/SCClassLibrary/Platform/windows/WindowsPlatform.sc
+++ b/SCClassLibrary/Platform/windows/WindowsPlatform.sc
@@ -31,7 +31,7 @@ WindowsPlatform : Platform {
 		"del %%.*meta%".format(34.asAscii, path, 34.asAscii).systemCmd;
 	}
 
-	kill { |pid|
+	killProcessByID { |pid|
 		("taskkill /F /pid " ++ pid).unixCmd;
 	}
 

--- a/SCClassLibrary/Platform/windows/WindowsPlatform.sc
+++ b/SCClassLibrary/Platform/windows/WindowsPlatform.sc
@@ -31,6 +31,10 @@ WindowsPlatform : Platform {
 		"del %%.*meta%".format(34.asAscii, path, 34.asAscii).systemCmd;
 	}
 
+	kill { |pid|
+		("taskkill /F /pid " ++ pid).unixCmd;
+	}
+
 	killAll { |cmdLineArgs|
 		("taskkill /F /IM " ++ cmdLineArgs).unixCmd;
 	}


### PR DESCRIPTION
this PR adds a crossplatform kill method to allow killing specific process ids (in addition to killAll).
this is useful for ending specific cmdline programs from within SC. E.g. in a current UnitTest where a server program is started by hand, #3486, this is useful to make that test run crossplatform.
not tested on windows yet - windows devs please check :-)