### PR TITLE
Extend UnitTest runAll with arguments for items and posting 

### DIFF
--- a/HelpSource/Classes/UnitTest.schelp
+++ b/HelpSource/Classes/UnitTest.schelp
@@ -53,9 +53,23 @@ within it, e.g. code::"TestPolyPlayerPool:test_prepareChildrenToBundle"::.
 
 
 METHOD:: runAll
-runs all subclasses of UnitTest
+runs all subclasses of UnitTest by default.
+The optional testItems argument is a list of unittest classnames or Strings with <TestClassName>:<testclassmethod>.
+The postTimes argument sets whether to post individual run times for each test.
 
 code::
+// test only a specific subset of all unittests,
+// e.g. the tests for the area one is working on
+UnitTest.runAll(
+	[
+		TestBuffer,
+		"TestArray:test_array_nonmutating"
+	],
+	// post individual times for each test item,
+	// e.g. to see which ones could use speedups
+	true
+);
+// run all UnitTest subclasses:
 UnitTest.reset;
 UnitTest.runAll;
 ::

--- a/SCClassLibrary/Common/UnitTesting/UnitTest.sc
+++ b/SCClassLibrary/Common/UnitTesting/UnitTest.sc
@@ -30,13 +30,37 @@ UnitTest {
 	}
 
 	// run all UnitTest subclasses
-	*runAll {
+	*runAll { |testItems, postTimes = false|
 		^this.forkIfNeeded {
+			var startTime = Main.elapsedTime;
 			this.reset;
-			this.allSubclasses.do ({ |testClass|
-				testClass.run(false,false);
+			testItems = testItems ?? { this.allSubclasses };
+			testItems.do ({ |testItem|
+				var myStartTime = Main.elapsedTime;
+				var myTestTime;
+				if (testItem.isKindOf(Class)) {
+					// assume this is a UnitTest:
+					if (testItem.superclasses.includes(UnitTest)) {
+						testItem.run(false,false);
+					} {
+						"%: testItem % is not a unit test subclass."
+							.format(testItem.cs).warn;
+					}
+				} {
+					if (testItem.isKindOf(String)) {
+						try { UnitTest.runTest(testItem) } {
+							"%: testItem % is not a unit test method string."
+							.format(testItem.cs).warn;
+						}
+					}
+				};
+				myTestTime = Main.elapsedTime - myStartTime;
+				if (postTimes) {
+					"*** % took % seconds to run.\n".postf(testItem, myTestTime);
+				};
 				0.1.wait;
 			});
+			"*** % took % seconds to run.\n".postf(thisMethod, Main.elapsedTime - startTime);
 			this.report;
 		}
 	}


### PR DESCRIPTION
While working on a specific area of SC, it is useful to test the most relevant subset of unit tests in one go, and the arguments added to runAll allow just that. E.g. for #3486, I kept running combinations of tests like this:
```
fork {
	Server.killAll;
	0.1.wait;
	TestServer_boot.new.test_notifyAndServerBootActions;
	0.1.wait;
	TestServer_clientID.new.run;
	0.1.wait;
	TestServer_clientID_booted.new.run;
};
```
which with this PR becomes 
```
Server.killAll;
UnitTest.runAll([
	"TestServer_boot:test_notifyAndServerBootActions",
	TestServer_clientID, 
	TestServer_clientID_booted
]);
```