### PR TITLE
sclang: SequenceableCollection:unixCmd respects PATH

### DIFF
--- a/common/sc_popen.cpp
+++ b/common/sc_popen.cpp
@@ -23,14 +23,6 @@
 #include <array>
 #include <string>
 
-// allows for linking into a dylib on darwin
-#if defined(__APPLE__) && !defined(SC_IPHONE)
-	#include <crt_externs.h>
-	#define environ (*_NSGetEnviron())
-#else
-	extern char **environ;
-#endif
-
 FILE *
 sc_popen(const char *command, pid_t *pidp, const char *type)
 {
@@ -104,7 +96,7 @@ sc_popen_argv(const char *filename, char *const argv[], pid_t *pidp, const char 
 			(void)close(pdes[1]);
 		}
 
-		execve(filename, argv, environ);
+		execvp(filename, argv);
 		exit(127);
 		/* NOTREACHED */
 	}


### PR DESCRIPTION
fix #2317

This commit changes a call to execve to execvpe in SequenceableCollection:unixCmd, so that PATH is now respected.

This only affects *nix systems. SequenceableCollection:unixCmd is not currently supported on Windows, or so I hear.

test case:

    ["which", "scsynth"].unixCmd

once this method is working on Windows, i suggest that we refactor all calls to String:unixCmd to use this method. it is much better to call actual command line arguments as an array rather than formatting shell strings, which is vulnerable to injections.