### PR TITLE
travis: don't print raw build log on failure

### DIFF
--- a/.travis/script-osx.sh
+++ b/.travis/script-osx.sh
@@ -10,9 +10,4 @@ cmake --build $TRAVIS_BUILD_DIR/BUILD --config Release --target install | tee $B
 CMAKE_EXIT=$?
 set +o pipefail
 
-if [[ $CMAKE_EXIT != 0 ]]; then
-    echo "Error while building. Printing raw log."
-    cat $BUILD_LOG
-fi
-
 exit $CMAKE_EXIT


### PR DESCRIPTION
in my experience so far this is unnecessary, as xcpretty doesn't seem to hide any part of the build message.

in addition, the previous configuration has the drawback that it makes build logs very hard to navigate if there is a failure.