### PR TITLE
qt gui: add "path" option to FileDialog and Dialog

### DIFF
--- a/HelpSource/Classes/Dialog.schelp
+++ b/HelpSource/Classes/Dialog.schelp
@@ -18,6 +18,9 @@ METHOD:: openPanel
 		An object to be evaluated when Cancel is pressed.
 	ARGUMENT:: multipleSelection
 		A Boolean indicating whether multiple files can be selected.
+	ARGUMENT:: path
+		A string. The dialog will initially display the contents of this path. The default is the current
+		user's home directory.
 	DISCUSSION::
 	Example:
 code::
@@ -37,6 +40,9 @@ METHOD:: savePanel
 		An object to be evaluated when OK is pressed. The chosen filename (as an absolute path) is passed as a String as argument. If the file already exists, the user will be asked to confirm.
 	ARGUMENT:: cancelFunc
 		An object to be evaluated when Cancel is pressed.
+	ARGUMENT:: path
+		A string. The dialog will initially display the contents of this path. The default is the current
+		user's home directory.
 	DISCUSSION::
 	Example:
 code::

--- a/HelpSource/Classes/Dialog.schelp
+++ b/HelpSource/Classes/Dialog.schelp
@@ -1,10 +1,12 @@
 CLASS:: Dialog
 summary:: Shows various system dialogs
 categories:: GUI>Accessories
+related:: Classes/FileDialog, Classes/File
 
 DESCRIPTION::
 This class allows to show various system dialogs. link::#*openPanel:: will show a dialog for selecting a file to open, and link::#*savePanel:: will show a dialog for selecting or creating a file to save to.
 
+The methods here are convenience functions built on top of link::Classes/FileDialog::.
 
 CLASSMETHODS::
 PRIVATE:: key

--- a/HelpSource/Classes/FileDialog.schelp
+++ b/HelpSource/Classes/FileDialog.schelp
@@ -67,9 +67,32 @@ returns:: a FileDialog
 EXAMPLES::
 
 code::
+// By default, the selected paths are passed to okFunc as an array.
+FileDialog({ |paths|
+	postln("Selected path:" + paths[0]);
+	}, {
+	postln("Dialog was cancelled. Try again.");
+	});
+
+// You can change this by passing `stripResult: true`
 FileDialog({ |path|
+	postln("Selected path:" + path);
+	}, {
+	postln("Dialog was cancelled. Try again.");
+	}, stripResult: true);
 
-}, {
+// Passing `fileMode: 3` makes it possible to select multiple files.
+FileDialog({ |paths|
+	postln("Selected paths:);
+	paths.do(_.postln);
+	}, fileMode: 3);
 
-});
+// Passing `fileMode: 0` allows selecting any kind of file.
+// You can start the dialog in a directory other than home by passing `path: "/some/path/"`
+FileDialog({ |path|
+	postln("Selected file:" + path);
+	postln("File type is:" + File.type(path)); },
+	fileMode: 0,
+	stripResult: true,
+	path: Platform.userAppSupportDir);
 ::

--- a/HelpSource/Classes/FileDialog.schelp
+++ b/HelpSource/Classes/FileDialog.schelp
@@ -12,6 +12,8 @@ At the moment selecting a directory is only possible with FileDialog.
 
 CLASSMETHODS::
 
+PRIVATE:: qtClass
+
 METHOD:: new
 Open a modal dialog
 
@@ -56,11 +58,11 @@ list::
 ## false: okFunc(paths)
 ::
 
+ARGUMENT:: path
+A string. The dialog will initially display the contents of this path. The default is the current
+user's home directory.
+
 returns:: a FileDialog
-
-METHOD:: qtClass
-private
-
 
 EXAMPLES::
 

--- a/HelpSource/Classes/FileDialog.schelp
+++ b/HelpSource/Classes/FileDialog.schelp
@@ -70,31 +70,39 @@ EXAMPLES::
 
 code::
 // By default, the selected paths are passed to okFunc as an array.
+(
 FileDialog({ |paths|
 	postln("Selected path:" + paths[0]);
 	}, {
 	postln("Dialog was cancelled. Try again.");
 	});
+)
 
 // You can change this by passing `stripResult: true`
+(
 FileDialog({ |path|
 	postln("Selected path:" + path);
 	}, {
 	postln("Dialog was cancelled. Try again.");
 	}, stripResult: true);
+)
 
 // Passing `fileMode: 3` makes it possible to select multiple files.
+(
 FileDialog({ |paths|
 	postln("Selected paths:);
 	paths.do(_.postln);
 	}, fileMode: 3);
+)
 
 // Passing `fileMode: 0` allows selecting any kind of file.
 // You can start the dialog in a directory other than home by passing `path: "/some/path/"`
+(
 FileDialog({ |path|
 	postln("Selected file:" + path);
 	postln("File type is:" + File.type(path)); },
 	fileMode: 0,
 	stripResult: true,
 	path: Platform.userAppSupportDir);
+)
 ::

--- a/HelpSource/Classes/FileDialog.schelp
+++ b/HelpSource/Classes/FileDialog.schelp
@@ -6,56 +6,58 @@ related:: Classes/Dialog, Classes/File
 DESCRIPTION::
 This is the interface for your standard operating system modal file dialogs to open files, save files and select directories.
 
-See also Dialog which makes it a bit simpler without the need to set fileMode and acceptMode manually.
-
-At the moment selecting a directory is only possible with FileDialog.
+link::Classes/Dialog:: has functions built on top of FileDialog that may be more convenient to use.
+However, selecting a directory is only possible with FileDialog.
 
 CLASSMETHODS::
 
 PRIVATE:: qtClass
 
 METHOD:: new
-Open a modal dialog
+Create and display a dialog.
 
 ARGUMENT:: okFunc
-handler function for: user selected a file and clicked ok.
-Argument to the function is either a single path, an array of paths, or multiple paths passed in as separate arguments.
-This depends on what fileMode and stripResult were specified.
+Handler function evaluated when the user clicks "Open" or "Save".
+This function receives different arguments depending on the value of code::stripResult::. By default
+(code::stripResult: false::), code::okFunc:: is passed an array of selected paths. Otherwise, the
+paths are passed as separate arguments, one for each path.
 
 ARGUMENT:: cancelFunc
-handler function for: user cancelled
+Handler function evaluated when the user clicks "Cancel". Receives no arguments.
 
 ARGUMENT:: fileMode
-Integer
+An integer that determines the type of dialog.
 
-Determines the type of dialog.
+These values correspond directly to values of QFileDialog\::FileMode in the Qt class.
 
 list::
-## 0			QFileDialog AnyFile		     The name of a file, whether it exists or not.
-## 1			QFileDialog ExistingFile	   The name of a single existing file.
-## 2			QFileDialog Directory		   The name of a directory. Both files and directories are displayed.
-## 3			QFileDialog ExistingFiles	 The names of zero or more existing files.
+## 0 The name of a file, whether it exists or not.
+## 1 The name of a single existing file.
+## 2 The name of a directory. Both files and directories are displayed.
+## 3 The names of zero or more existing files.
 ::
 
 0 or 3 implies that the user can type in a new file name.
 
 ARGUMENT:: acceptMode
-Integer
-This determines what the accept button says: "Open" or "Save"
+An integer that determines whether the dialog is for opening or saving files. Note that this doesn't
+actually open or save a file; you'll need to do that in your code::okFunc::. This only affects
+appearance of the dialog.
+
+These values correspond directly to values of QFileDialog\::AcceptMode in the Qt class.
 
 list::
-## 0			QFileDialog AcceptOpen
-## 1			QFileDialog AcceptSave
+## 0 Opening
+## 1 Saving
 ::
 
 ARGUMENT:: stripResult
-If selecting multiple files (using fileMode 3) then you have the choice of having your okFunc called with a list or with each of the paths as separate items.
-
-If you want to select only one item then use stripResult = true so that your okFunc will be passed the item instead of a list.
+A boolean. If code::true::, selected paths are passed individually as arguments to code::okFunc::.
+Otherwise, they are passed as an array in a single argument (the default).
 
 list::
-## true: okFunc(path1, path2, path3)
 ## false: okFunc(paths)
+## true: okFunc(path1, path2, path3)
 ::
 
 ARGUMENT:: path

--- a/QtCollider/widgets/QcFileDialog.cpp
+++ b/QtCollider/widgets/QcFileDialog.cpp
@@ -24,10 +24,10 @@
 
 QC_DECLARE_QOBJECT_FACTORY(QcFileDialog);
 
-QcFileDialog::QcFileDialog( int fileMode, int acceptMode ) {
+QcFileDialog::QcFileDialog( int fileMode, int acceptMode, const QString& startDir ) {
   dialog = new QFileDialog();
 
-  dialog->setDirectory( QDir::home() );
+  dialog->setDirectory(QDir{startDir});
 
   switch(fileMode) {
     case QFileDialog::AnyFile:

--- a/QtCollider/widgets/QcFileDialog.h
+++ b/QtCollider/widgets/QcFileDialog.h
@@ -33,8 +33,14 @@ class QcFileDialog : public QObject
 
 public:
 
+  /**
+   * \param fileMode What the user may select in the dialog
+   * \param acceptMode Whether for opening or saving files
+   * \param startDir What location the directory will open at
+   */
   Q_INVOKABLE QcFileDialog( int fileMode = QFileDialog::ExistingFile,
-                            int acceptMode = QFileDialog::AcceptOpen );
+                            int acceptMode = QFileDialog::AcceptOpen,
+                            const QString& startDir = QDir::home().path());
 
   ~QcFileDialog() {
     if (dialog) { dialog->deleteLater(); };

--- a/SCClassLibrary/Common/GUI/Base/QDialog.sc
+++ b/SCClassLibrary/Common/GUI/Base/QDialog.sc
@@ -1,7 +1,7 @@
 FileDialog : QObject {
 	*qtClass { ^'QcFileDialog' }
 
-	*new { arg okFunc, cancelFunc, fileMode, acceptMode, stripResult = false, path;
+	*new { arg okFunc, cancelFunc, fileMode = 1, acceptMode = 0, stripResult = false, path;
 		/**
 		fileMode:
 			QFileDialog::AnyFile		0	The name of a file, whether it exists or not.

--- a/SCClassLibrary/Common/GUI/Base/QDialog.sc
+++ b/SCClassLibrary/Common/GUI/Base/QDialog.sc
@@ -1,7 +1,7 @@
 FileDialog : QObject {
 	*qtClass { ^'QcFileDialog' }
 
-	*new { arg okFunc, cancelFunc, fileMode, acceptMode, stripResult = false;
+	*new { arg okFunc, cancelFunc, fileMode, acceptMode, stripResult = false, path;
 		/**
 		fileMode:
 			QFileDialog::AnyFile		0	The name of a file, whether it exists or not.
@@ -17,7 +17,7 @@ FileDialog : QObject {
 			false: okFunc(paths)
 		**/
 
-		var me = super.new( [fileMode, acceptMode] );
+		var me = super.new( [fileMode, acceptMode, path] );
 
 		if( okFunc.notNil ) {
 			me.connectFunction( 'accepted(QVariantList)', {

--- a/SCClassLibrary/Common/GUI/Base/QDialog.sc
+++ b/SCClassLibrary/Common/GUI/Base/QDialog.sc
@@ -40,13 +40,13 @@ FileDialog : QObject {
 
 Dialog {
 
-	*openPanel { arg okFunc, cancelFunc, multipleSelection=false;
+	*openPanel { arg okFunc, cancelFunc, multipleSelection = false, path;
 		var fileMode;
 		if( multipleSelection ) { fileMode = 3 } { fileMode = 1 };
-		^FileDialog.new( okFunc, cancelFunc, fileMode, 0, stripResult:multipleSelection.not );
+		^FileDialog.new( okFunc, cancelFunc, fileMode, 0, multipleSelection.not, path );
 	}
 
-	*savePanel { arg okFunc, cancelFunc;
-		^FileDialog.new( okFunc, cancelFunc, 0, 1, stripResult:true );
+	*savePanel { arg okFunc, cancelFunc, path;
+		^FileDialog.new( okFunc, cancelFunc, 0, 1, true, path );
 	}
 }

--- a/SCClassLibrary/Common/GUI/Base/QDialog.sc
+++ b/SCClassLibrary/Common/GUI/Base/QDialog.sc
@@ -17,7 +17,7 @@ FileDialog : QObject {
 			false: okFunc(paths)
 		**/
 
-		var me = super.new( [fileMode, acceptMode, path] );
+		var me = super.new([fileMode, acceptMode, path]);
 
 		if( okFunc.notNil ) {
 			me.connectFunction( 'accepted(QVariantList)', {


### PR DESCRIPTION
Fixes \#874.

See also \#3505, unfortunately @snappizz and I started working on this at the same time without knowing :/

This branch has extra documentations so I thought it might be preferable (also Nathan said in PM that he was OK with it).