### PR TITLE
CMake: don't rebuild boost libs

### DIFF
--- a/external_libraries/CMakeLists.txt
+++ b/external_libraries/CMakeLists.txt
@@ -26,6 +26,10 @@ if(NOT Boost_FOUND) # we compile boost ourselves
 	add_library(boost_filesystem STATIC EXCLUDE_FROM_ALL ${boost_filesystem_src})
 	target_include_directories(boost_filesystem PUBLIC boost)
 
+	aux_source_directory(boost/libs/regex/src boost_regex_src)
+	add_library(boost_regex STATIC EXCLUDE_FROM_ALL ${boost_regex_src})
+	target_include_directories(boost_regex PUBLIC boost)
+
 	if(LTO)
 		set_property(TARGET boost_program_options boost_system boost_filesystem
 					 APPEND PROPERTY COMPILE_FLAGS "-flto -flto-report")
@@ -61,7 +65,14 @@ if(NOT Boost_FOUND) # we compile boost ourselves
 			APPEND PROPERTY LINK_FLAGS "-flto -flto-report")
 	endif()
 
-	set_property( TARGET boost_thread boost_program_options boost_system boost_filesystem PROPERTY FOLDER 3rdparty )
+	set_property( TARGET
+        boost_regex
+        boost_thread
+        boost_program_options
+        boost_system
+        boost_filesystem
+        PROPERTY FOLDER 3rdparty
+    )
 
 endif()
 

--- a/lang/CMakeLists.txt
+++ b/lang/CMakeLists.txt
@@ -99,13 +99,6 @@ if(APPLE)
 	set_source_files_properties(${CMAKE_SOURCE_DIR}/common/SC_Apple.mm PROPERTIES COMPILE_FLAGS "-x objective-c++ -fobjc-exceptions")
 endif()
 
-if (NOT Boost_FOUND)
-	file(GLOB boost_system_sources ../external_libraries/boost/libs/system/src/*cpp)
-	file(GLOB boost_fs_sources ../external_libraries/boost/libs/filesystem/src/*cpp)
-	file(GLOB boost_regex_sources ../external_libraries/boost/libs/regex/src/*cpp)
-	list(APPEND sclang_sources ${boost_fs_sources} ${boost_system_sources} ${boost_regex_sources})
-endif()
-
 file(GLOB_RECURSE headers ../include/*.h* )
 file(GLOB_RECURSE external_headers ../external_libraries/*.h* )
 list(APPEND sclang_sources ${headers} ${external_headers}) # make qt creator happy
@@ -253,7 +246,7 @@ if (Boost_FOUND)
 	target_link_libraries(libsclang ${Boost_THREAD_LIBRARY} ${Boost_SYSTEM_LIBRARY} ${Boost_REGEX_LIBRARY} ${Boost_FILESYSTEM_LIBRARY})
 else()
 	target_include_directories(libsclang PUBLIC ${CMAKE_SOURCE_DIR}/external_libraries/boost)
-	target_link_libraries(libsclang boost_thread)
+	target_link_libraries(libsclang boost_regex boost_thread boost_system boost_filesystem)
 endif()
 
 

--- a/server/scsynth/CMakeLists.txt
+++ b/server/scsynth/CMakeLists.txt
@@ -28,11 +28,6 @@ elseif(AUDIOAPI STREQUAL portaudio AND ((NOT WIN32) OR MSYS)) # MSYS like Apple
 endif()
 message(STATUS "Audio API: ${AUDIOAPI}")
 
-if (NOT Boost_FOUND)
-	file(GLOB boost_system_sources ../../external_libraries/boost/libs/system/src/*cpp)
-	file(GLOB boost_filesystem_sources ../../external_libraries/boost/libs/filesystem/src/*cpp)
-endif()
-
 set(scsynth_sources
 	SC_BufGen.cpp
 
@@ -67,9 +62,6 @@ set(scsynth_sources
 	${CMAKE_SOURCE_DIR}/common/SC_StringParser.cpp
 	${CMAKE_SOURCE_DIR}/common/Samp.cpp
 	${CMAKE_SOURCE_DIR}/common/sc_popen.cpp
-
-	${boost_system_sources}
-	${boost_filesystem_sources}
 )
 
 if(APPLE)


### PR DESCRIPTION
- add `boost_regex` lib as a separate target
- link `sclang` and `scsynth` against boost libs so they aren't built twice (filesystem is build 3 times right now)

- scsynth is already linked against necessary libs so its `target_link_libraries` call doesn't need to be modified

Fixes #2192.