### PR TITLE
Lang: Add event[\isRest] == true test to Event_IsRest primitive

### DIFF
--- a/lang/LangPrimSource/PyrListPrim.cpp
+++ b/lang/LangPrimSource/PyrListPrim.cpp
@@ -46,7 +46,7 @@ PyrSymbol *s_proto, *s_parent;
 PyrSymbol *s_delta, *s_dur, *s_stretch;
 
 // used in prEvent_IsRest
-PyrSymbol *s_type, *s_rest, *s_empty, *s_r;
+PyrSymbol *s_type, *s_rest, *s_empty, *s_r, *s_isRest;
 PyrClass *class_rest, *class_metarest;
 
 #define HASHSYMBOL(sym) (sym >> 5)
@@ -568,14 +568,21 @@ int prEvent_IsRest(struct VMGlobals *g, int numArgsPushed)
 	if (isKindOfSlot(arraySlot, class_array)) {
 		PyrSlot key, typeSlot;
 		PyrSymbol *typeSym;
-		// easy test first: 'this[\type] == \rest'
+		// easy tests first: 'this[\type] == \rest'
 		SetSymbol(&key, s_type);
 		identDict_lookup(slotRawObject(g->sp), &key, calcHash(&key), &typeSlot);
 		if(!slotSymbolVal(&typeSlot, &typeSym) && typeSym == s_rest) {
 			SetBool(g->sp, 1);
 			return errNone;
 		};
-		// failing that, scan slot values for a Rest instance or \ or \r
+		// and, 'this[\isRest] == true'
+		SetSymbol(&key, s_isRest);
+		identDict_lookup(slotRawObject(g->sp), &key, calcHash(&key), &typeSlot);
+		if(IsTrue(&typeSlot)) {
+			SetBool(g->sp, 1);
+			return errNone;
+		};
+		// failing those, scan slot values for a Rest instance or \ or \r
 		PyrObject *array = slotRawObject(arraySlot);
 		PyrSymbol *slotSym;
 		PyrSlot *slot;
@@ -851,6 +858,7 @@ void initPatterns()
 	s_rest = getsym("rest");
 	s_empty = getsym("");
 	s_r = getsym("r");
+	s_isRest = getsym("isRest");
 
 	class_rest = getsym("Rest")->u.classobj;
 	class_metarest = getsym("Meta_Rest")->u.classobj;

--- a/lang/LangPrimSource/PyrListPrim.cpp
+++ b/lang/LangPrimSource/PyrListPrim.cpp
@@ -611,10 +611,9 @@ int prEvent_IsRest(struct VMGlobals *g, int numArgsPushed)
 		SetSymbol(&key, s_isRest);
 		identDict_lookup(slotRawObject(g->sp), &key, calcHash(&key), &typeSlot);
 		if(IsTrue(&typeSlot)) {
-			if(++isRestCount == 1)
+			if (isRestCount == 0)
 				post("\nWARNING: Setting isRest to true in an event is deprecated. See the Rest helpfile for supported ways to specify rests.\n\n");
-			if(isRestCount == 100)
-				isRestCount = 0;
+			isRestCount = (isRestCount + 1) % 100;
 			SetBool(g->sp, 1);
 			return errNone;
 		};

--- a/lang/LangPrimSource/PyrListPrim.cpp
+++ b/lang/LangPrimSource/PyrListPrim.cpp
@@ -564,6 +564,7 @@ int prEvent_IsRest(struct VMGlobals *g, int numArgsPushed)
 {
 	PyrSlot *dictslots = slotRawObject(g->sp)->slots;
 	PyrSlot *arraySlot = dictslots + ivxIdentDict_array;
+	static int isRestCount = 0;
 
 	if (isKindOfSlot(arraySlot, class_array)) {
 		PyrSlot key, typeSlot;
@@ -579,6 +580,10 @@ int prEvent_IsRest(struct VMGlobals *g, int numArgsPushed)
 		SetSymbol(&key, s_isRest);
 		identDict_lookup(slotRawObject(g->sp), &key, calcHash(&key), &typeSlot);
 		if(IsTrue(&typeSlot)) {
+			if(++isRestCount == 1)
+				post("\nWARNING: Setting isRest to true in an event is deprecated. See the Rest helpfile for supported ways to specify rests.\n\n");
+			if(isRestCount == 100)
+				isRestCount = 0;
 			SetBool(g->sp, 1);
 			return errNone;
 		};

--- a/lang/LangPrimSource/PyrListPrim.cpp
+++ b/lang/LangPrimSource/PyrListPrim.cpp
@@ -597,38 +597,34 @@ int prEvent_IsRest(struct VMGlobals *g, int numArgsPushed)
 	PyrSlot *arraySlot = dictslots + ivxIdentDict_array;
 	static int isRestCount = 0;
 
-	if (isKindOfSlot(arraySlot, class_array)) {
-		PyrSlot key, typeSlot;
-		PyrSymbol *typeSym;
-		// easy tests first: 'this[\type] == \rest'
-		SetSymbol(&key, s_type);
-		identDict_lookup(slotRawObject(g->sp), &key, calcHash(&key), &typeSlot);
-		if(!slotSymbolVal(&typeSlot, &typeSym) && typeSym == s_rest) {
-			SetBool(g->sp, 1);
-			return errNone;
-		};
-		// and, 'this[\isRest] == true'
-		SetSymbol(&key, s_isRest);
-		identDict_lookup(slotRawObject(g->sp), &key, calcHash(&key), &typeSlot);
-		if(IsTrue(&typeSlot)) {
-			if (isRestCount == 0)
-				post("\nWARNING: Setting isRest to true in an event is deprecated. See the Rest helpfile for supported ways to specify rests.\n\n");
-			isRestCount = (isRestCount + 1) % 100;
-			SetBool(g->sp, 1);
-			return errNone;
-		};
-
-		// failing those, scan slot values for something rest-like
-		PyrObject *array = slotRawObject(arraySlot);
-		if (dictHasRestlikeValue(array)) {
-			SetBool(g->sp, 1);
-			return errNone;
-		}
-	} else {
+	if (!isKindOfSlot(arraySlot, class_array)) {
 		return errWrongType;
 	}
 
-	SetBool(g->sp, 0);
+	PyrSlot key, typeSlot;
+	PyrSymbol *typeSym;
+	// easy tests first: 'this[\type] == \rest'
+	SetSymbol(&key, s_type);
+	identDict_lookup(slotRawObject(g->sp), &key, calcHash(&key), &typeSlot);
+	if(!slotSymbolVal(&typeSlot, &typeSym) && typeSym == s_rest) {
+		SetBool(g->sp, 1);
+		return errNone;
+	}
+
+	// and, 'this[\isRest] == true'
+	SetSymbol(&key, s_isRest);
+	identDict_lookup(slotRawObject(g->sp), &key, calcHash(&key), &typeSlot);
+	if(IsTrue(&typeSlot)) {
+		if (isRestCount == 0)
+			post("\nWARNING: Setting isRest to true in an event is deprecated. See the Rest helpfile for supported ways to specify rests.\n\n");
+		isRestCount = (isRestCount + 1) % 100;
+		SetBool(g->sp, 1);
+		return errNone;
+	}
+
+	// failing those, scan slot values for something rest-like
+	PyrObject *array = slotRawObject(arraySlot);
+	SetBool(g->sp, dictHasRestlikeValue(array) ? 1 : 0);
 	return errNone;
 }
 

--- a/testsuite/classlibrary/TestAbstractFunction.sc
+++ b/testsuite/classlibrary/TestAbstractFunction.sc
@@ -148,6 +148,10 @@ TestAbstractFunction : UnitTest {
 
 		this.assertEquals((x: \rest).isRest, true, "event with an 'rest' symbol in arbitrary key should return true for isRest");
 
+		this.assertEquals((isRest: true).isRest, true, "event[\\isRest] == true is detected as a rest");
+
+		this.assertEquals((isRest: false, dur: Rest(1)).isRest, true, "event[\\isRest] == false does not cancel other entries' Rest status");
+
 		#[\dur, \degree, \paraplui, \type].do { |key|
 			var a, b, c, f;
 


### PR DESCRIPTION
http://new-supercollider-mailing-lists-forums-use-these.2681727.n2.nabble.com/3-9-1-and-isRest-tp7638027.html

A user made the unfortunate inference that `\isRest, true` in a Pbind was a supported way to mark an event as a rest, not realizing that it was a private implementation detail that was subject to change. Unfortunately, his private code base now contains some 20,000 occurrences of \isRest.

I could make a strong case that this is *de facto* a legacy way to write rests, and we shouldn't burn users who got the wrong idea. (It is, in fact, not the users' fault that sclang does nothing to prevent public use of private entities.) Hence, this PR.

One could also make a case that `\` and `\r` were previously legitimately supported, but `\isRest, true` was not.

I think on balance, the maintenance burden for adding legacy `\isRest` support is extremely low and the benefit to users much greater. So I'm suggesting this for 3.9.2 or .3. (I'm aware that we shouldn't take this as precedent to keep adding to the primitive in the future because of misunderstandings. I'd like this to be a one-off.)

Two commits. The first removes a layer of `else` structure -- `if(cond) { return ... } else { ... }` does not actually need the `else`. The second uses the simplified structure to add another test. I've also updated the event unit tests.

All `TestAbstractFunction` unit tests pass.