### PR TITLE
classlib: optimise and remove some .interpret

### DIFF
--- a/SCClassLibrary/Common/Core/Color.sc
+++ b/SCClassLibrary/Common/Core/Color.sc
@@ -183,9 +183,9 @@ Color {
 		var red, green, blue;
 		if(string[0] == $#, {string = string.copyToEnd(1)});
 		if(string.size == 3, {string = string[0] ++ string[0] ++ string[1] ++ string[1] ++ string[2] ++ string[2]});
-		red = ("0x" ++ string.copyRange(0, 1)).interpret;
-		green = ("0x" ++ string.copyRange(2, 3)).interpret;
-		blue = ("0x" ++ string.copyRange(4, 5)).interpret;
+		red = (string[0].digit*16)+string[1].digit;
+		green = (string[2].digit*16)+string[3].digit;
+		blue = (string[4].digit*16)+string[5].digit;
 		^this.new255(red, green, blue, 255);
 	}
 }

--- a/SCClassLibrary/Common/Core/Color.sc
+++ b/SCClassLibrary/Common/Core/Color.sc
@@ -180,12 +180,17 @@ Color {
 	}
 
 	*fromHexString {|string|
-		var red, green, blue;
+		var digits, red, green, blue;
 		if(string[0] == $#, {string = string.copyToEnd(1)});
-		if(string.size == 3, {string = string[0] ++ string[0] ++ string[1] ++ string[1] ++ string[2] ++ string[2]});
-		red = (string[0].digit*16)+string[1].digit;
-		green = (string[2].digit*16)+string[3].digit;
-		blue = (string[4].digit*16)+string[5].digit;
+		digits = string.collectAs({|chr|
+			var val = chr.digit;
+			if(val>15, { "hex value 0x% out of bounds - clipping to 0xF".format(chr).warn });
+			val.min(15);
+		}, Array);
+		if(digits.size == 3, { digits = digits.stutter(2) });
+		red = digits[0] * 16 + digits[1];
+		green = digits[2] * 16 + digits[3];
+		blue = digits[4] * 16 + digits[5];
 		^this.new255(red, green, blue, 255);
 	}
 }

--- a/SCClassLibrary/Common/Streams/History.sc
+++ b/SCClassLibrary/Common/Streams/History.sc
@@ -296,7 +296,7 @@ History { 		// adc 2006, Birmingham; rewrite 2007.
 	}
 	*unformatTime { |str|
 		var h, m, s;
-		#h, m, s = str.split($:).collect(_.interpret);
+		#h, m, s = str.split($:).asInteger;
 		^h * 60 + m * 60 + s
 	}
 


### PR DESCRIPTION
this PR optimise Color.fromHexString and History.unformatTime. both these were using .interpret and here they are replaced with much faster variants.

one caveat though that these methods now break differently...
```supercollider
Color.fromHexString("#ggg")  //deliberate user error
```

with the original .interpret method we get this cryptic error...
```
ERROR: syntax error, unexpected NAME, expecting $end
  in interpreted text
  line 1 char 4:

  0xgg
    ^^
```

and while with the variant in this PR it doesn't fail but rather overflow...
```supercollider
-> Color(1.0666666666667, 1.0666666666667, 1.0666666666667)
```

and similar for History.unformatTime...

```supercollider
History.unformatTime("01:XY:03")  //deliberate user error
```

with original method...
```
ERROR: Class not defined.
  in interpreted text
  line 1 char 2:

  XY 
```

and with this PR...
```
-> 3603
```

i think this 'soft landing' is better but people might have other opinions.
