### PR TITLE
lang: Add warning sclang config file directory

### DIFF
--- a/lang/LangSource/SC_LanguageConfig.cpp
+++ b/lang/LangSource/SC_LanguageConfig.cpp
@@ -192,7 +192,7 @@ bool SC_LanguageConfig::writeLibraryConfigYAML(const Path& fileName)
 	
 	bfs::path dir(fileName.parent_path());
 	if(!(bfs::exists(dir)))
-		postfl("WARNING: Cannot create config file. First create the directory %s\n", dir.c_str());
+		postfl("WARNING: Cannot create config file. First create the directory '%s'\n", dir.c_str());
 
 	bfs::ofstream fout(fileName);
 	fout << out.c_str();

--- a/lang/LangSource/SC_LanguageConfig.cpp
+++ b/lang/LangSource/SC_LanguageConfig.cpp
@@ -189,6 +189,10 @@ bool SC_LanguageConfig::writeLibraryConfigYAML(const Path& fileName)
 	out << Value << gPostInlineWarnings;
 
 	out << EndMap;
+	
+	bfs::path dir(fileName.parent_path());
+	if(!(bfs::exists(dir)))
+		postfl("WARNING: Cannot create config file. First create the directory %s\n", dir.c_str());
 
 	bfs::ofstream fout(fileName);
 	fout << out.c_str();


### PR DESCRIPTION
the main reason for this is to warn users if a Quark didn't install correctly.
tested under osx and linux.