### PR TITLE
sclang: SC_LanguageClient::SC_LanguageClient

### DIFF
--- a/lang/LangSource/SC_LanguageClient.cpp
+++ b/lang/LangSource/SC_LanguageClient.cpp
@@ -106,7 +106,8 @@ SC_LanguageClient::SC_LanguageClient(const char* name)
 SC_LanguageClient::~SC_LanguageClient()
 {
 	lockInstance();
-	gInstance = 0;
+	gInstance = nullptr;
+	delete mHiddenClient;
 	unlockInstance();
 }
 


### PR DESCRIPTION
valgrind detected a memory leak in the constructor of SC_LanguageClient. This commits fixes it by calling delete in the destructor.

With this fix I can boot sclang and quit it without any memory leak being detected.

Speaking of Valgrind, wouldn't it be a nice idea to run sclang's unit testes in Travis and AppVeyour using valgrind ? That way we can detect memory leaks... It might make them much slower though...