### PR TITLE
cmake: fix doc, sclang-test targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -525,18 +525,13 @@ endif()
 #
 # build scdoc help files
 #
-list(APPEND BUILD_CLASSLIBRARIES "${CMAKE_CURRENT_SOURCE_DIR}/SCClassLibrary/Common")
-list(APPEND BUILD_CLASSLIBRARIES "${CMAKE_CURRENT_SOURCE_DIR}/SCClassLibrary/Platform")
-list(APPEND BUILD_CLASSLIBRARIES "${CMAKE_CURRENT_SOURCE_DIR}/SCClassLibrary/SCDoc")
-list(APPEND BUILD_CLASSLIBRARIES "${CMAKE_CURRENT_SOURCE_DIR}/SCClassLibrary/DefaultLibrary")
-list(APPEND BUILD_CLASSLIBRARIES "${CMAKE_CURRENT_SOURCE_DIR}/SCClassLibrary/JITLib")
-list(APPEND BUILD_CLASSLIBRARIES "${CMAKE_CURRENT_SOURCE_DIR}/SCClassLibrary/backwards_compatibility")
+list(APPEND BUILD_CLASSLIBRARIES "${CMAKE_CURRENT_SOURCE_DIR}/SCClassLibrary")
 
 # this folder has an extension to Platform that disables the loadStartupFiles method
 list(APPEND BUILD_CLASSLIBRARIES "${CMAKE_CURRENT_SOURCE_DIR}/platform/disable_startup_files")
 
 foreach(arg ${BUILD_CLASSLIBRARIES})
-	set(BUILD_CLASSLIBRARYPATH "${BUILD_CLASSLIBRARYPATH}+${arg}\n")
+	set(BUILD_CLASSLIBRARYPATH "${BUILD_CLASSLIBRARYPATH}  - ${arg}\n")
 endforeach()
 
 configure_file(build_sclang.cfg.in ${CMAKE_CURRENT_BINARY_DIR}/build_sclang.cfg)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -541,8 +541,8 @@ if(SC_DOC_RENDER)
 	file(GLOB_RECURSE SCDocClasses RELATIVE SCClassLibrary/SCDoc *.sc)
 
 	add_custom_target(doc ALL
-		COMMAND $<TARGET_FILE_DIR:sclang>/sclang${CMAKE_EXECUTABLE_SUFFIX}
-			-l ${CMAKE_CURRENT_BINARY_DIR}/build_sclang.cfg
+		COMMAND sclang
+			-a -l ${CMAKE_CURRENT_BINARY_DIR}/build_sclang.cfg
 			platform/renderAllHelp.scd ${CMAKE_CURRENT_SOURCE_DIR}/HelpSource ${CMAKE_CURRENT_BINARY_DIR}/RenderedHelp
 		WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 		DEPENDS sclang ${SCDocSources} ${SCDocClasses})

--- a/build_sclang.cfg.in
+++ b/build_sclang.cfg.in
@@ -1,1 +1,2 @@
+includePaths:
 @BUILD_CLASSLIBRARYPATH@

--- a/testsuite/sclang/CMakeLists.txt
+++ b/testsuite/sclang/CMakeLists.txt
@@ -1,8 +1,7 @@
-set(SCLANG ${CMAKE_CURRENT_BINARY_DIR}/../../lang/sclang${CMAKE_EXECUTABLE_SUFFIX}
-							-l ${CMAKE_CURRENT_BINARY_DIR}/../../build_sclang.cfg)
-
 file(GLOB tests *.scd)
 
 foreach(test ${tests})
-	add_test(${test}_run ${SCLANG} ${test})
+    get_filename_component(test_name ${test} NAME_WE)
+    set(test_target ${test_name}_run)
+    add_test(NAME ${test_target} COMMAND sclang -a -l ${CMAKE_BINARY_DIR}/build_sclang.cfg ${test})
 endforeach()


### PR DESCRIPTION
Fixes #3555 (the part that isn't duplicated by #1717) by addressing a few intermingled issues.

Issue 1: We have targets in testsuite/sclang that are pretty broken - they use a full path as the test name, and also use a hacky approach to launch sclang.

- use [get_filename_component](https://cmake.org/cmake/help/latest/command/get_filename_component.html) to get simplified test names
- use the COMMAND form of [add_test](https://cmake.org/cmake/help/latest/command/add_test.html) to automatically launch the sclang executable
- note that this means you have to run the tests with `ctest -C <config>` if you're using a multi-config toolchain (i.e. VS, Xcode)
- launch with `-a` so that we only pull the class library from the repo (no extensions)

Issue 2: build_sclang.cfg doesn't end up being a yaml config file (possibly hasn't been touched since we moved to yaml)

- update configuration code in CMakeLists.txt so that it works (i.e. is valid yaml)

Issue 3: custom `doc` target launches sclang in a non-portable way (similar to issue 1)

- launch with `-a` (as in issue 1)
- use [add_custom_target](https://cmake.org/cmake/help/latest/command/add_custom_target.html)'s built-in behavior of finding the right executable:

> If COMMAND specifies an executable target name (created by the add_executable() command) it will automatically be replaced by the location of the executable created at build time.

This is tested and works on macOS with the Xcode generator. In theory this is only more portable than what it was before, but someone should test on another platform just to be sure.

It is a separate issue that the sclang tests seem to fail but don't, according to ctest.

This can go to 3.9.x because it only modifies non-packaged, non-essential targets.