### PR TITLE
cmake: correctly include yaml-cpp

### DIFF
--- a/editors/sc-ide/CMakeLists.txt
+++ b/editors/sc-ide/CMakeLists.txt
@@ -199,6 +199,7 @@ include_directories(${CMAKE_SOURCE_DIR}/include/common)
 include_directories(${CMAKE_SOURCE_DIR}/common)
 include_directories(${CMAKE_SOURCE_DIR}/include/plugin_interface)
 include_directories(${CMAKE_SOURCE_DIR}/external_libraries/boost)
+include_directories(${YAMLCPP_INCLUDE_DIR})
 # For QtCollider headers:
 include_directories(${CMAKE_SOURCE_DIR})
 # Needed for auto-generated forms headers:
@@ -273,7 +274,7 @@ endif()
 
 target_link_libraries( SuperCollider
     ${QT_IDE_LIBRARIES}
-    yaml
+    ${YAMLCPP_LIBRARY}
     oscpack
 )
 

--- a/external_libraries/CMakeLists.txt
+++ b/external_libraries/CMakeLists.txt
@@ -106,6 +106,8 @@ if(NOT YAMLCPP_FOUND)
   add_library(yaml STATIC EXCLUDE_FROM_ALL ${CMAKE_CURRENT_BINARY_DIR}/libyamlcpp.cpp)
   target_include_directories(yaml PUBLIC ${CMAKE_SOURCE_DIR}/external_libraries/yaml-cpp/include boost)
   set_property( TARGET yaml PROPERTY FOLDER 3rdparty )
+  set(YAMLCPP_LIBRARY yaml)
+  set(YAMLCPP_INCLUDE_DIR ${CMAKE_SOURCE_DIR}/external_libraries/yaml-cpp/include)
 
   if(CMAKE_COMPILER_IS_GNUCXX)
     target_compile_options(yaml PRIVATE -Wno-deprecated-declarations)

--- a/lang/CMakeLists.txt
+++ b/lang/CMakeLists.txt
@@ -10,8 +10,6 @@ include_directories(${CMAKE_SOURCE_DIR}/include/common
                     ${CMAKE_SOURCE_DIR}/include/server
                     ${CMAKE_SOURCE_DIR}/common
 
-                    ${YAMLCPP_INCLUDE_DIR}
-
                     ${CMAKE_SOURCE_DIR}/external_libraries/boost_sync/include
 
                     LangSource
@@ -19,6 +17,8 @@ include_directories(${CMAKE_SOURCE_DIR}/include/common
 
                     ${CMAKE_SOURCE_DIR}/external_libraries/nova-tt
                     LangSource/Bison
+
+                    ${YAMLCPP_INCLUDE_DIR}
 )
 
 


### PR DESCRIPTION
Include its dirs last for libsclang, and use the YAMLCPP_LIBRARY variable for linking.

Fixes #3557.

cc @Apteryks. This works for me on macOS, using v0.6.1 of yaml-cpp.

Edit - oops, think I broke linking when SYSTEM_YAMLCPP=OFF. will keep investigating.