### PR TITLE
QTreeView: add setColumnWidth

### DIFF
--- a/HelpSource/Classes/TreeView.schelp
+++ b/HelpSource/Classes/TreeView.schelp
@@ -96,6 +96,13 @@ METHOD:: sort
 	ARGUMENT:: descending
 		Whether to sort in descending or ascending fashion. The default is ascending.
 
+METHOD:: setColumnWidth
+
+	ARGUMENT:: column
+		The integer index of the column to modify
+	ARGUMENT:: width
+		Integer width in pixels
+
 PRIVATE:: background
 
 

--- a/HelpSource/Classes/TreeView.schelp
+++ b/HelpSource/Classes/TreeView.schelp
@@ -96,6 +96,14 @@ METHOD:: sort
 	ARGUMENT:: descending
 		Whether to sort in descending or ascending fashion. The default is ascending.
 
+METHOD:: columnWidth
+
+	ARGUMENT:: column
+		The integer index of a column
+	RETURNS::
+		Integer width of column in pixels. If code::column:: is not in the range
+		code::0..(numColumns-1)::, returns code::-1::.
+
 METHOD:: setColumnWidth
 
 	ARGUMENT:: column

--- a/HelpSource/Classes/TreeView.schelp
+++ b/HelpSource/Classes/TreeView.schelp
@@ -106,6 +106,9 @@ METHOD:: columnWidth
 
 METHOD:: setColumnWidth
 
+Sets the width of a column. The rightmost column must extend at least to the right bound of the
+TreeView.
+
 	ARGUMENT:: column
 		The integer index of the column to modify
 	ARGUMENT:: width

--- a/QtCollider/widgets/QcTreeWidget.cpp
+++ b/QtCollider/widgets/QcTreeWidget.cpp
@@ -199,6 +199,11 @@ void QcTreeWidget::sort( int column, bool descending )
   sortItems( column, descending ? Qt::DescendingOrder : Qt::AscendingOrder );
 }
 
+void QcTreeWidget::setColumnWidth( int column, int width )
+{
+  QTreeWidget::setColumnWidth( column, width );
+}
+
 void QcTreeWidget::keyPressEvent( QKeyEvent *e )
 {
   QTreeWidget::keyPressEvent( e );

--- a/QtCollider/widgets/QcTreeWidget.cpp
+++ b/QtCollider/widgets/QcTreeWidget.cpp
@@ -199,6 +199,14 @@ void QcTreeWidget::sort( int column, bool descending )
   sortItems( column, descending ? Qt::DescendingOrder : Qt::AscendingOrder );
 }
 
+int QcTreeWidget::columnWidth( int column )
+{
+  if ( column < 0 || column >= columnCount() )
+      return -1;
+  else
+      return QTreeWidget::columnWidth( column );
+}
+
 void QcTreeWidget::setColumnWidth( int column, int width )
 {
   QTreeWidget::setColumnWidth( column, width );

--- a/QtCollider/widgets/QcTreeWidget.h
+++ b/QtCollider/widgets/QcTreeWidget.h
@@ -88,6 +88,7 @@ public:
 
   Q_INVOKABLE void sort( int column, bool descending );
 
+  Q_INVOKABLE int columnWidth( int column );
   Q_INVOKABLE void setColumnWidth( int column, int width );
 
 Q_SIGNALS:

--- a/QtCollider/widgets/QcTreeWidget.h
+++ b/QtCollider/widgets/QcTreeWidget.h
@@ -88,6 +88,8 @@ public:
 
   Q_INVOKABLE void sort( int column, bool descending );
 
+  Q_INVOKABLE void setColumnWidth( int column, int width );
+
 Q_SIGNALS:
 
   void action();

--- a/SCClassLibrary/Common/GUI/Base/QTreeView.sc
+++ b/SCClassLibrary/Common/GUI/Base/QTreeView.sc
@@ -41,6 +41,10 @@ TreeView : View {
 		this.invokeMethod( \sort, [column, descending] )
 	}
 
+	setColumnWidth { arg column, width;
+		this.invokeMethod( \setColumnWidth, [column, width] )
+	}
+
 	itemPressedAction_ { arg action;
 		if(itemPressedAction.notNil) {
 			this.disconnectFunction( 'itemPressedAction()', itemPressedAction );

--- a/SCClassLibrary/Common/GUI/Base/QTreeView.sc
+++ b/SCClassLibrary/Common/GUI/Base/QTreeView.sc
@@ -41,6 +41,10 @@ TreeView : View {
 		this.invokeMethod( \sort, [column, descending] )
 	}
 
+	columnWidth { arg column;
+		^this.invokeMethod( \columnWidth, [column] )
+	}
+
 	setColumnWidth { arg column, width;
 		this.invokeMethod( \setColumnWidth, [column, width] )
 	}


### PR DESCRIPTION
This adds the `setColumnWidth` method to TreeView. This was requested by a user on the mailing list (Stefano Franchi) and I see no reason not to add it.