### PR TITLE
sclang: create config dir on startup, report errors from LanguageConfig.store

### DIFF
--- a/HelpSource/Classes/LanguageConfig.schelp
+++ b/HelpSource/Classes/LanguageConfig.schelp
@@ -19,7 +19,8 @@ definitionList::
 CLASSMETHODS::
 
 METHOD:: store
-Store the current configuration to file.
+Store the current configuration to file. Throws an error if the config file cannot be opened or if
+writing fails.
 
 argument:: file
 Path to the configuration file to store. If the value is code::nil:: it defaults to code::Platform.userConfigDir +/+ "sclang_conf.yaml"::

--- a/SCClassLibrary/Common/Core/LanguageConfig.sc
+++ b/SCClassLibrary/Common/Core/LanguageConfig.sc
@@ -1,7 +1,7 @@
 LanguageConfig {
 	*store {|file|
 		_LanguageConfig_writeConfigFile
-		^this.primitiveFailed
+		^MethodError("Could not write to file %".format(file.asCompileString), this).throw
 	}
 
 	*currentPath {

--- a/lang/LangPrimSource/PyrPrimitive.cpp
+++ b/lang/LangPrimSource/PyrPrimitive.cpp
@@ -3594,6 +3594,7 @@ static int prLanguageConfig_getCurrentConfigPath(struct VMGlobals * g, int numAr
 static int prLanguageConfig_writeConfigFile(struct VMGlobals * g, int numArgsPushed)
 {
 	PyrSlot *fileString = g->sp;
+	bfs::path config_path;
 
 	if (NotNil(fileString)) {
 		char path[MAXPATHLEN];
@@ -3601,16 +3602,18 @@ static int prLanguageConfig_writeConfigFile(struct VMGlobals * g, int numArgsPus
 		if (error)
 			return errWrongType;
 
-		const bfs::path& config_path = SC_Codecvt::utf8_str_to_path(path);
+		config_path = SC_Codecvt::utf8_str_to_path(path);
 		gLanguageConfig->writeLibraryConfigYAML(config_path);
 	} else {
-		const bfs::path& config_path =
+		config_path =
 			SC_Filesystem::instance().getDirectory(SC_Filesystem::DirName::UserConfig)
 			/ "sclang_conf.yaml";
-		gLanguageConfig->writeLibraryConfigYAML(config_path);
 	}
 
-	return errNone;
+	if (!gLanguageConfig->writeLibraryConfigYAML(config_path))
+		return errFailed;
+	else
+		return errNone;
 }
 
 static int prLanguageConfig_getPostInlineWarnings(struct VMGlobals * g, int numArgsPushed)

--- a/lang/LangSource/SC_LanguageConfig.cpp
+++ b/lang/LangSource/SC_LanguageConfig.cpp
@@ -164,6 +164,9 @@ bool SC_LanguageConfig::readLibraryConfigYAML(const Path& fileName, bool standal
 
 bool SC_LanguageConfig::writeLibraryConfigYAML(const Path& fileName)
 {
+	if (!bfs::exists(fileName.parent_path()))
+		return false;
+
 	using namespace YAML;
 	Emitter out;
 	out.SetIndent(4);
@@ -192,7 +195,7 @@ bool SC_LanguageConfig::writeLibraryConfigYAML(const Path& fileName)
 
 	bfs::ofstream fout(fileName);
 	fout << out.c_str();
-	return true;
+	return fout.good();
 }
 
 bool SC_LanguageConfig::defaultLibraryConfig(bool standalone)

--- a/lang/LangSource/SC_TerminalClient.cpp
+++ b/lang/LangSource/SC_TerminalClient.cpp
@@ -61,6 +61,8 @@
 #include "SC_LanguageConfig.hpp"
 #include "SC_Version.hpp"
 
+#include <boost/filesystem/operations.hpp>
+
 static FILE* gPostDest = stdout;
 
 #ifdef _WIN32
@@ -260,6 +262,11 @@ int SC_TerminalClient::run(int argc, char** argv)
 
 	// initialize runtime
 	initRuntime(opt);
+
+	// Create config directory so that it can be used by Quarks, etc. See #2919.
+	if (!opt.mStandalone && !opt.mLibraryConfigFile)
+		boost::filesystem::create_directories(
+			SC_Filesystem::instance().getDirectory(SC_Filesystem::DirName::UserConfig));
 
 	// startup library
 	compileLibrary(opt.mStandalone);


### PR DESCRIPTION
Fixes \#2919.

- Create the language config dir on startup. This step is skipped if run in standalone mode or a non-standard config file is specified with `-l`. This addresses issues raised by @jamshark70.
- Modify `SC_LanguageConfig::writeLibraryConfigYAMLFile` (C++) to return false if writing fails
- Modify `LanguageConfig.store` (SC) to throw a descriptive error on failure

Open to discussing alternate approaches. This doesn't feel perfect to me but I can't really put my finger on why. Either way, tested on macOS and works fine.