### PR TITLE
sclang: print floats with at least 1 decimal place

### DIFF
--- a/lang/LangSource/DumpParseNode.cpp
+++ b/lang/LangSource/DumpParseNode.cpp
@@ -417,6 +417,22 @@ static void printObject(PyrSlot * slot, PyrObject * obj, char *str)
 	}
 }
 
+// Assumed: str has enough space to hold the representation of d
+static void prettyFormatFloat(char* str, double d)
+{
+	sprintf(str, "%.14g", d);
+
+	// append a trailing '.0' if the number would look like an integer.
+	for ( ; *str; ++str) {
+		if ((*str < '0' || *str > '9') && *str != '-')
+			return;
+	}
+
+	str[0] = '.';
+	str[1] = '0';
+	str[2] = '\0';
+}
+
 void slotOneWord(PyrSlot *slot, char *str)
 {
 	str[0] = 0;
@@ -459,7 +475,7 @@ void slotOneWord(PyrSlot *slot, char *str)
 			sprintf(str, "ptr%p", slotRawPtr(slot));
 			break;
 		default :
-			sprintf(str, "%.14g", slotRawFloat(slot));
+			prettyFormatFloat(str, slotRawFloat(slot));
 			break;
 	}
 }
@@ -507,7 +523,7 @@ bool postString(PyrSlot *slot, char *str)
 			sprintf(str, "%p", slotRawPtr(slot));
 			break;
 		default :
-			sprintf(str, "%.14g", slotRawFloat(slot));
+			prettyFormatFloat(str, slotRawFloat(slot));
 			break;
 	}
 	return res;

--- a/testsuite/classlibrary/TestFloat.sc
+++ b/testsuite/classlibrary/TestFloat.sc
@@ -1,6 +1,5 @@
-
 TestFloat : UnitTest {
-	
+
 	test_storeOn {
 		var stored;
 		stored = String.streamContents({ arg stream; stream <<< 1e-05});
@@ -14,6 +13,42 @@ TestFloat : UnitTest {
 		this.assertEquals(stored ,  "2", "2 should be stored as 2");
 
 	}
-	
+
+	test_asString_zero {
+		this.assertEquals(0.0.asString, "0.0")
+	}
+
+	test_asString_one {
+		this.assertEquals(1.0.asString, "1.0")
+	}
+
+	test_asString_minusOne {
+		this.assertEquals(-1.0.asString, "-1.0")
+	}
+
+	test_asString_almostTwo_isTwoPointZero {
+		this.assertEquals(1.9999999999999999.asString, "2.0")
+	}
+
+	test_asString_onePointFifteen {
+		this.assertEquals(1.15.asString, "1.15")
+	}
+
+	test_asString_inf {
+		this.assertEquals(inf.asString, "inf")
+	}
+
+	test_asString_minusInf {
+		this.assertEquals(-inf.asString, "-inf")
+	}
+
+	test_asString_nan {
+		this.assertEquals((0/0).asString, "nan")
+	}
+
+	test_asString_largeNumberUsesExp {
+		this.assertEquals((1e26).asString, "1e+26")
+	}
+
 }
 


### PR DESCRIPTION
Fixes #3573

Floats that are equal to an integer are printed with .0

I couldn't find a way to do this without actually scanning the string to
see if '.0' needs to be appended. "%.9f" will print extra significant
digits; and "%#.14g" will do the same. I think _possibly_ switching on
the point where numbers change to scientific notation (1e14) and then
using "%#.14f" would work, but I'm not sure if that's a portable
solution and this seems a bit cleaner.

---

Before:

```
sc3> 3.0
-> 3
```

After:

```
sc3> 3.0
-> 3.0
sc3> 3.0000
-> 3.0
sc3> 3 - 0.0000000000000001
-> 3.0
```