### PR TITLE
class library: fix node proxy cancel

### DIFF
--- a/SCClassLibrary/JITLib/ProxySpace/ProxyInterfaces.sc
+++ b/SCClassLibrary/JITLib/ProxySpace/ProxyInterfaces.sc
@@ -247,11 +247,12 @@ SynthControl : AbstractPlayControl {
 				// otherwise it is self freeing by some inner mechanism.
 			};
 			nodeID = nil;
-		}
+		};
+		prevBundle !? { prevBundle.cancel; prevBundle = nil };
 	}
 
 	freeToBundle {
-		prevBundle !? { prevBundle.cancel };
+		prevBundle !? { prevBundle.cancel; prevBundle = nil };
 	}
 
 	set { | ... args |


### PR DESCRIPTION
When a node proxy receives the instruction to send a new synth before
an old message has been sent off, it cancels the old one.