### PR TITLE
open git URL without fetch

### DIFF
--- a/SCClassLibrary/Common/Quarks/QuarksGui.sc
+++ b/SCClassLibrary/Common/Quarks/QuarksGui.sc
@@ -378,7 +378,9 @@ QuarkDetailView {
 		});
 	}
 	openGitRemote {
-		model.git.remoteAsHttpUrl.openOS;
+		if (model.git.notNil, {
+			model.git.remoteAsHttpUrl.openOS;
+		}, { model.url.openOS });
 	}
 	openLocalPath {
 		model.localPath.openOS;


### PR DESCRIPTION
Before:

- go to `Quarks.gui`
- click on the URL of any Quark that has not been checked out
- BOOM

With this patch:

- opening the URL goes by default to the `quark.url` without relying on
  a git repo