### PR TITLE
help: writing classes corrections

### DIFF
--- a/HelpSource/Guides/Polymorphism.schelp
+++ b/HelpSource/Guides/Polymorphism.schelp
@@ -52,22 +52,20 @@ code::
 
 subsection:: Ref
 The link::Classes/Ref:: class provides a way to create an indirect reference to an object. It can be used to pass a value by reference. Ref objects have a single instance variable called code::value::.
-The code::value:: method returns the value of the instance variable code::value::. Here is the class definition for Ref:
+The code::value:: method returns the value of the instance variable code::value::. Here is a part of the class definition for Ref:
 code::
 Ref : AbstractFunction
 {
     var <>value;
-    *new { arg thing; ^super.new.value_(thing) }
+
+	*new { arg thing; ^super.new.value_(thing) }
     set { arg thing; value = thing }
     get { ^value }
     dereference { ^value }
     asRef { ^this }
 
-    //behave like a stream
+    // behave like a stream
     next { ^value }
-    embedInStream { arg inval;
-        ^this.value.embedInStream(inval)
-    }
 
     printOn { arg stream;
         stream << "`(" << value << ")";

--- a/HelpSource/Guides/WritingClasses.schelp
+++ b/HelpSource/Guides/WritingClasses.schelp
@@ -100,9 +100,10 @@ MyClass {
 
 subsection:: Class Methods
 
-An object's strong::class methods:: are defined together with the instance methods. Class methods are specified with the asterisk (teletype::*::). Within class methods, the keyword code::this:: refers to the class.
+An object's strong::class methods:: are defined together with its instance methods. They are specified with the asterisk (teletype::*::).
 
-A link::Classes/Class:: is itself an object. It is what all instances of it have in common.
+
+A link::Classes/Class:: is itself an object. It is what all instances of it have in common. Class methods are the instance methods of the object's class. That's why within class methods, the keyword code::this:: refers to the class.
 
 code::
 MyClass {
@@ -126,7 +127,7 @@ MyClass.classMethod // posts "hello class"
 
 subsection::Overriding methods (overloading)
 
-In order to change the behaviour of the superclass, often methods are overridden. Note that an object looks always for
+To change the behaviour of the superclass, methods can be overridden. Note that an object looks always for
 the method it has defined first and then looks in the superclass. Here code::MyClass.value(2):: will return 6, not 4:
 
 code::
@@ -174,7 +175,7 @@ MyClass {
 		^super.new.init(arga, argb, argc)
 	}
 
-	init { | arga, argb ,argc |
+	init { | arga, argb, argc |
 		// do initiation here
 	}
 }
@@ -239,7 +240,7 @@ MyClass {
 
 section::Alternatives to inheritance
 
-Overreliance on inheritance is usually a design flaw. Inheritance is mainly a way to organise code, and less a categorisation of objects. Two objects may respond to a message in different ways (polymorphism), and objects delegate control to ther objects they hold in their instance variables (object composition).
+Overreliance on inheritance is usually a design flaw. Inheritance is mainly a way to organise code, and shouldn't be mistaken for a categorisation of objects. Two objects may respond to a message in different ways (polymorphism), and objects delegate control to ther objects they hold in their instance variables (object composition).
 
 subsection::Polymorphism
 
@@ -523,6 +524,10 @@ MyTestPoint {
 code::
 MyTestPoint(2, 3).asCompileString;
 ::
+
+section::Private Methods
+
+Private methods are marked by a prefix code::pr::, e.g. code::prBundleSize::. This is just a strong::naming convention::, the message can still be called from anywhere. It is not recommended to do this.
 
 
 section:: Catching undefined method calls

--- a/HelpSource/Guides/WritingClasses.schelp
+++ b/HelpSource/Guides/WritingClasses.schelp
@@ -1,10 +1,14 @@
 title:: Writing Classes
 summary:: Writing SuperCollider Classes
 categories:: Language>OOP
-related:: Reference/Classes, Classes/Class
+related:: Reference/Classes, Classes/Class, Classes/Object
 
-For a basic tutorial on how standard object-orientated classes are composed, look elsewhere
-link::http://www.google.com/search?q=oop+class+tutorial::
+
+SuperCollider follows a pure object-oriented paradigm. It is not built on data types, but on objects, which respond to messages. A class is an object that holds information about how its objects (instances) respond to such messages. Writing a class gives a definition of this behavior.
+
+What follows is not a tutorial for how to write a class system. It gives an overview of some typical expressions. See also: link::Guides/Intro-to-Objects::, link::Reference/Messages::, and link::Reference/Classes::.
+
+There is also an overview of the current full link::Overviews/ClassTree::.
 
 note:: Class definitions are statically compiled when you launch SuperCollider or "recompile the library." This means
 that class definitions must be saved into a file with the extension .sc, in a disk location where SuperCollider looks
@@ -20,8 +24,9 @@ It is not possible to enter a class definition into an interpreter window and ex
 ::
 
 
-
 section:: Inheriting
+
+To avoid having to write the same code several times, classes can strong::inherit:: implementations from their strong::superclasses::.
 
 code::
 MyClass : SomeSuperclass {
@@ -32,27 +37,42 @@ MyClass : SomeSuperclass {
 Without specifying a superclass, link::Classes/Object:: is assumed as the default superclass.
 
 code::
-MyClass { // :Object is implied
+MyClass { // : Object is implied
 
 }
 ::
 
+This is why in the above example, the message code::new:: can be called without being explicitly defined in the class.
+
+
+
 section:: Methods
 
-class methods are specified with the asterisk within the class method, the keyword code::this:: refers to the class. A
-class in SuperCollider is itself an object.  It is an instance of link::Classes/Class::. Instance methods are specified
-within the instance method, the keyword code::this:: refers to the instance.
+subsection:: Instance Methods
+
+Each object instance responds to its strong::instance methods::.Within instance methods, the keyword code::this:: refers to the instance itself.
+
+An instance is independent of all the other instances, unless otherwise specified.
+
 
 code::
 MyClass {
-    *classMethod { arg argument;
 
-    }
+	instanceMethod { | argument |
+		this.anotherInstanceMethod(argument)
+	}
 
-    instanceMethod { arg argument;
-
-    }
+	anotherInstanceMethod { | argument |
+		"hello instance".postln
+	}
 }
+::
+
+This could then be used as follows:
+
+code::
+a = MyClass.new // returns a new instance
+a.instanceMethod // posts "hello instance"
 ::
 
 
@@ -62,42 +82,101 @@ such thing as returning void in SuperCollider.
 
 code::
 MyClass {
-    someMethod {
-        ^returnObject
-    }
+	someMethod {
+		^returnObject
+	}
 
-    someOtherMethod { arg aBoolean;
-        if(aBoolean,{
-            ^someObject
-        },{
-            ^someOtherObject
-        })
-    }
+	someOtherMethod { | aBoolean |
+		if(aBoolean) {
+			^someObject
+		} {
+			^someOtherObject
+		}
+	}
 
 }
 ::
 
 
-section:: New Instance creation
+subsection:: Class Methods
 
-code::Object.new:: will return to you a new object. When overriding the class method code::.new:: you must call the
+An object's strong::class methods:: are defined together with the instance methods. Class methods are specified with the asterisk (teletype::*::). Within class methods, the keyword code::this:: refers to the class.
+
+A link::Classes/Class:: is itself an object. It is what all instances of it have in common.
+
+code::
+MyClass {
+	*classMethod { | argument |
+		this.anotherClassMethod(argument)
+	}
+
+	*anotherClassMethod { | argument |
+		"hello class".postln
+	}
+
+}
+::
+
+This could then be used as follows:
+
+code::
+MyClass.classMethod // posts "hello class"
+::
+
+
+subsection::Overriding methods (overloading)
+
+In order to change the behaviour of the superclass, often methods are overridden. Note that an object looks always for
+the method it has defined first and then looks in the superclass. Here code::MyClass.value(2):: will return 6, not 4:
+
+code::
+SomeSuperclass {
+	calculate { |in| ^in * 2 }
+	value { |in| ^this.calculate(in) }
+}
+
+MyClass : SomeSuperclass {
+	calculate { |in| ^in * 3 }
+}
+::
+
+If the method of the superclass is needed, it can be called by super.
+
+code::
+SomeSuperclass {
+
+	value {
+		^100.rand
+	}
+}
+
+MyClass : SomeSuperclass {
+
+	value {
+		^super.value * 2
+	}
+}
+::
+
+
+
+section:: Instances
+
+code::Object.new:: will return a new object. When overriding the class method code::.new:: you must call the
 superclass, which in turn calls its superclass, up until code::Object.new:: is called and an object is actually created
 and its memory allocated.
 
 code::
 MyClass {
-    // this example adds no new functionality
-    *new {
-        ^super.new
-    }
 
-    // this is a normal constructor method
-    *new1 { arg arga,argb,argc;
-        ^super.new.init(arga,argb,argc)
-    }
-    init { arg arga,argb,argc;
-        // do initiation here
-    }
+	// this is a normal constructor method
+	*new { | arga, argb, argc |
+		^super.new.init(arga, argb, argc)
+	}
+
+	init { | arga, argb ,argc |
+		// do initiation here
+	}
 }
 ::
 
@@ -106,101 +185,176 @@ we are calling the code::.init:: method on that object, which is an instance met
 
 Warning:: If the superclass also happened to call super.new.init it will have expected to call the .init method defined
 in that class (the superclass), but instead the message .init will find the implementation of the class that the object
-actually is, which is our new subclass.  So you should use a unique method name like myclassinit if this is likely to be
-a problem.
+actually is, which is our new subclass. In such cases, a unique method name like myclassInit should be used.
 ::
 
-One easy way to copy the arguments passed to the instance variables when creating a class is to use newCopyArgs.  This
+One easy way to copy the arguments passed to the instance variables when creating a class is to use link::Classes/Object#*newCopyArgs::.  This
 method will copy the arguments to the instance variables in the order that the variables were defined in the class,
-starting the parent classes and working it's way down to the current class.
+starting from the parent classes and working it's way down to the current class.
 
 code::
 MyClass {
-    var <a,b,c;
+	var a,b,c;
 
-    *new { arg a,b,c;
-        ^super.newCopyArgs(a,b,c)
-    }
+	*new { | a, b, c |
+		^super.newCopyArgs(a, b, c)
+	}
 }
 
-MyChildClass : MyClass{
-    var <d;
+MyChildClass : MyClass {
+	var d;
 
-    *new { arg a,b,c,d;
-        ^super.newCopyArgs(a,b,c,d)
-    }
+	*new { | a, b, c, d |
+		^super.newCopyArgs(a, b, c, d)
+	}
 }
 ::
-
-Over reliance on inheritance is usually a design flaw.  Explore "object composition" rather than trying to obtain all
-your powers through inheritance. Is your "subclass" really some kind of "superclass" or are you just trying to swipe all
-of daddy's methods? Do a websearch for Design Patterns.
 
 Class variables are accessible within class methods and in any instance methods.
 
 code::
 MyClass {
-    classvar myClassvar;
-    var myInstanceVar;
+	classvar myClassvar;
+
+	instanceMethod {
+		^myClassvar
+	}
 }
 ::
 
 Initializations on class level (e.g. to set up code::classvar::s) can be implemented by overloading the link::Classes/Class#*initClass:: method.
 
-section:: Overriding Methods (Overloading)
-
-In order to change the behaviour of the superclass, often methods are overridden. Note that an object looks always for
-the method it has defined first and then looks in the superclass. Here code::MyClass.value(2):: will return 6, not 4:
-
 code::
-Superclass {
-    calculate { arg in; in * 2 }
-    value { arg in; ^this.calculate(in) }
-}
+MyClass {
+	classvar myClassvar;
 
-MyClass : Superclass {
-    calculate { arg in; in * 3 }
-}
-::
-
-If the method of the superclass is needed, it can be called by super.
-
-code::
-Superclass {
-    var x;
-
-    init {
-        x = 5;
-    }
-}
-
-MyClass : Superclass {
-    var y;
-    init {
-        super.init;
-        y = 6;
-    }
+	*initClass {
+		myClassvar = IdentityDictionary.new;
+	}
 }
 ::
 
 
 
-section:: Getter Setter
+
+section::Alternatives to inheritance
+
+Overreliance on inheritance is usually a design flaw. Inheritance is mainly a way to organise code, and less a categorisation of objects. Two objects may respond to a message in different ways (polymorphism), and objects delegate control to ther objects they hold in their instance variables (object composition).
+
+subsection::Polymorphism
+
+See also: link::Guides/Polymorphism::
+
+Two completely unrelated objects can respond to the same messages and therefore be used together in the same code. For example, link::Classes/Function:: and link::Classes/Event:: have no common superclass apart from the general class link::Classes/Object::. But both respond to the message code::play::. Instead of inheriting all methods, you can simply implement some of the same methods in your class.
+
+code::
+MyClass {
+	var count = 0;
+	value {
+		^count = count + 1
+	}
+}
+// objects of this class will respond to the message "value", just like a function.
+a = MyClass.new;
+a.value; // returns 1
+::
+
+
+subsection::Object Composition
+Often, an object passes control to one of the objects it has in its instance variables. Because these objects can be of any kind, this is a very flexible way to achieve a wide range of functionalities. For example, a link::Classes/Button:: has an code::action:: instance variable, which may hold anything that responds to the message code::value::.
+
+code::
+MyClass {
+	var action;
+	*new { |action|
+		^super.newCopyArgs(action)
+	}
+	value {
+		action.value;
+	}
+}
+
+// depending on what "action" is, objects of this class will behave differently
+a = MyClass({ "hello." });
+b = MyClass({ |i| log2(i) * sin(i * pi) });
+a.value(8);
+b.value(8);
+::
+
+Often, variables like code::action:: above are filled with custom objects that belong to code::MyClass::. Thus, one will write many small classes that can be well combined in such a way. This is called "pluggable behavior".
+
+
+section::Variables
+
+subsection:: Initializing variables directly
+
+In a variable declaration, variables can be directly initialized. This works for link::Reference/Literals:: only.
+
+code::
+MyClass {
+	classvar all = #[];
+	var x = 8;
+	var y = #[1, 2, 3];
+}
+::
+
+In class definitions, it is not possible to chain assignments (e.g. code:: var x = 9; var y = x + 1::).
+
+
+subsection:: Variable Scope
+
+An instance variable is accessible from all instance methods of this class and its subclasses. A class variable is accessible from all class and instance methods of this class and its subclasses. Instance variables of the same name as override the scope of class variables of the same name.
+
+code::
+MyClass {
+	classvar x = 0, y = 1;
+	var x = 1;
+
+	*returnX { ^x } // returns 0
+	returnX { ^x } // returns 1
+	returnXY { ^x + y } // returns 2
+}
+::
+
+Subclasses can override class variable declarations (but not instance variables). Then the class variables of the superclass are not accessible in the subclass anymore.
+
+code::
+SomeSuperclass {
+	classvar x = 0;
+
+	returnX { ^x }
+	returnXHere { ^x }
+}
+
+MyClass : SomeSuperclass {
+	classvar x = 1;
+
+	returnXHere { ^x }
+}
+
+// SomeSuperclass.returnXHere returns 0
+// MyClass.returnXHere returns 1
+// MyClass.returnX returns 0
+
+
+::
+
+subsection:: Getter and Setter
 
 SuperCollider demands that variables are not accessible outside of the class or instance. A method must be added to
 explicitly give access:
 
 code::
-MyClass : Superclass {
-    var myVariable;
+MyClass : SomeSuperclass {
+	var myVariable;
 
-    variable {
-        ^myVariable
-    }
+	variable {
+		^myVariable
+	}
 
-    variable_ { arg newValue;
-        myVariable = newValue;
-    }
+	variable_ { arg newValue;
+		myVariable = newValue;
+	}
 }
 ::
 
@@ -209,24 +363,24 @@ teletype::>::.
 
 code::
 MyClass {
-    var <getMe, >setMe, <>getMeOrSetMe;
+	var <getMe, >setMe, <>getMeOrSetMe;
 }
 ::
 
-you now have the methods:
+This provides the following methods:
 
 code::
 someObject.getMe;
 someObject.setMe_(value);
 ::
 
-this also allows us to say:
+And it also allows us to say:
 
 code::
 someObject.setMe = value;
 
 someObject.getMeOrSetMe_(5);
-someObject.getMeOrSetMe.postln;
+someObject.getMeOrSetMe;
 ::
 
 
@@ -235,92 +389,97 @@ methods should take only one argument to support both ways of expression consist
 
 code::
 MyClass {
-    variable_ { arg newValue;
-        variable = newValue.clip(minval,maxval);
-    }
+
+	variable_ { | newValue |
+		variable = newValue.clip(minval,maxval);
+	}
+
 }
 ::
 
-A setter method should always return the receiver. This is standard OOP practice (outside of SuperCollider as well). Do
-not return the new value from your setter.
+A setter method should always return the receiver. This is standard OOP practice. Never return the new value from your setter.
 
 code::
 MyClass {
-    variable_ { arg newValue;
-        myVariable = newValue;
-        ^newValue       // DO NOT DO THIS
-    }
+
+	variable_ { | newValue |
+		myVariable = newValue;
+		^newValue       // DO NOT DO THIS
+	}
+
 }
 ::
 
-section:: External Method Files
+subsection::Constants
+Constants are variables, that, well, don't vary. They can be assigned only initially.
+
+code::
+MyClass {
+	const <zero = 0;
+}
+
+MyClass.zero // returns 0
+::
+
+section:: External method files
 
 Methods may be added to Classes in separate files.  This is equivalent to Categories in Objective-C.  By convention, the
 file name starts with a lower case letter: the name of the method or feature that the methods are supporting.
 
 code::
 + Class {
-    newMethod {
-    }
 
-    *newClassMethod {
-    }
+	newMethod {
+
+	}
+
+	*newClassMethod {
+
+	}
+
 }
 ::
 
 
 section:: Slotted classes
 
-Classes defined with [slot] can use the syntax myClass[i] which will call myClass.at(i). This is useful when defining
-classes that inherit from a Collection type class.
+Classes defined with code::[slot]:: can use the syntax code::myClass[...]:: which will call code::myClass.new:: and then code::this.add(each):: for each item in the square brackets.
 
 code::
-MyClass[slot] {
-    *new {
-         ^super.new
-    }
-
-    at {|i|
-        ("Index "++i).postln
-    }
+MyClass[] {
+	var <allOfThem;
+	add { |item|
+		allOfThem = allOfThem.add(item)
+	}
 }
+
+a = MyClass[1, 2, 3];
+a.allOfThem; // [1, 2, 3]
 ::
 
-code::
-a = MyClass();
-a[3];
-::
+section:: Printing to string
 
-Defining a custom array of Points:
-
-code::
-MyPointArray[slot] : RawArray {
-    center { ^Point(*this.asArray.flop.collect{ |item| item.sum / item.size } ) }
-    asArray{ ^this.collect{ |elem| elem.asArray } }
-}
-::
-
-
-section:: Printing custom messages to post window
+subsection:: Printing custom messages to post window
 
 By default when postln is called on an class instance the name of the class is printed in a post window. When
-code::postln:: or code::asString:: is called on a class instance, the class then calls code::printOn:: which can be
-overridden to obtain more useful information.
+code::postln:: or code::asString:: is called on a class instance, the class then calls code::printOn:: which by default returns just the object's class name. This should be overridden to obtain more useful information.
 
 code::
 MyTestPoint {
-    var <x, <y;
+	var <x, <y;
 
-    *new{ |x,y| ^super.newCopyArgs(x,y) }
+	*new { |x, y|
+		^super.newCopyArgs(x, y)
+	}
 
-    printOn { arg stream;
-        stream << "MyTestPoint( " << x << ", " << y << " )";
-    }
+	printOn { | stream |
+		stream << "MyTestPoint( " << x << ", " << y << " )";
+	}
 }
 ::
 
 code::
-a = MyTestPoint(2,3);
+a = MyTestPoint(2, 3)
 ::
 
 subsection:: Defining custom asCompileString behaviour
@@ -334,46 +493,52 @@ method can be used instead of code::storeOn::.
 code::
 // either
 MyTestPoint {
-    var <x, <y;
+	var <x, <y;
 
-    *new{ |x,y| ^super.newCopyArgs(x,y) }
+	*new { |x, y|
+		^super.newCopyArgs(x,y)
+	}
 
-    storeOn { arg stream;
-        stream << "MyTestPoint.new(" << x << ", " << y << ")";
-    }
+	storeOn { | stream |
+		// note that <<< stands for storeOn, and << for printOn.
+		// we want x and y to be completely represented
+		stream << "MyTestPoint.new(" <<< x << ", " <<< y << ")"
+	}
 }
 
 // or
 MyTestPoint {
-    var <x, <y;
+	var <x, <y;
 
-    *new{ |x,y| ^super.newCopyArgs(x,y) }
+	*new { |x, y|
+		^super.newCopyArgs(x,y)
+	}
 
-    storeArgs { arg stream;
-        ^[x,y]
-    }
+	storeArgs { | stream |
+		^[x, y]
+	}
 }
 ::
 
 code::
-MyTestPoint(2,3).asCompileString;
+MyTestPoint(2, 3).asCompileString;
 ::
 
-section:: Catching methods that are not explicitly defined
 
-It is possible to catch calls to methods that are not explicitly defined in a Class by overriding code::doesNotUnderstand::.
+section:: Catching undefined method calls
+
+When a message is received that is undefined, the receiver calls the method code::doesNotUnderstand::. Normally this throws an error. By overriding code::doesNotUnderstand::, it is possible to catch those calls and use them (For an example, see the class definition of code::IdentityDictionary::).
 
 code::
 MyClass {
-    *new { ^super.new }
 
-    doesNotUnderstand { arg selector...args;
-        (this.class++" does not understand method "++selector);
+	doesNotUnderstand { | selector...args |
+		(this.class ++ " does not understand method " ++ selector);
 
-        If(UGen.findRespondingMethodFor(selector).notNil){
-            "But UGen understands this method".postln
-        };
-    }
+		if(UGen.findRespondingMethodFor(selector).notNil) {
+			"But UGen understands this method".postln
+		};
+	}
 }
 ::
 
@@ -382,16 +547,3 @@ a = MyClass();
 a.someMethodThatDoesNotExist
 ::
 
-section:: Tricks and Traps
-
-definitionList::
-
-## "Superclass not found..."
-
-|| In one given code file, you can only put classes that inherit from each Object, each other, and one external class.
-In other words, you can't inherit from two separate classes that are defined in separate files.
-
-If you should happen to declare a variable in a subclass and use the same name as a variable declared in a superclass,
-you will find that both variables exist, but only the one in the object's actual class is accessible.  You should not do
-that. This will at some point become an error worthy of compilation failure.
-::

--- a/HelpSource/Guides/WritingClasses.schelp
+++ b/HelpSource/Guides/WritingClasses.schelp
@@ -6,7 +6,7 @@ related:: Reference/Classes, Classes/Class, Classes/Object
 
 SuperCollider follows a pure object-oriented paradigm. It is not built on data types, but on objects, which respond to messages. A class is an object that holds information about how its objects (instances) respond to such messages. Writing a class gives a definition of this behavior.
 
-What follows is not a tutorial for how to write a class system. It gives an overview of some typical expressions. See also: link::Guides/Intro-to-Objects::, link::Reference/Messages::, and link::Reference/Classes::.
+This is an overview of idioms used in writing classes. It is not a tutorial on writing a system of interrelated classes. It gives an overview of some typical expressions. See also: link::Guides/Intro-to-Objects::, link::Reference/Messages::, and link::Reference/Classes::.
 
 There is also an overview of the current full link::Overviews/ClassTree::.
 
@@ -50,10 +50,7 @@ section:: Methods
 
 subsection:: Instance Methods
 
-Each object instance responds to its strong::instance methods::.Within instance methods, the keyword code::this:: refers to the instance itself.
-
-An instance is independent of all the other instances, unless otherwise specified.
-
+Each object instance responds to its strong::instance methods::. Instance methods are called in the local context of the object. Within instance methods, the keyword code::this:: refers to the instance itself.
 
 code::
 MyClass {
@@ -100,7 +97,8 @@ MyClass {
 
 subsection:: Class Methods
 
-An object's strong::class methods:: are defined together with its instance methods. They are specified with the asterisk (teletype::*::).
+
+An object's  strong::class methods:: are defined alongside its instance methods. They are specified with an asterisk (teletype::*::) before the method name.
 
 
 A link::Classes/Class:: is itself an object. It is what all instances of it have in common. Class methods are the instance methods of the object's class. That's why within class methods, the keyword code::this:: refers to the class.
@@ -127,7 +125,7 @@ MyClass.classMethod // posts "hello class"
 
 subsection::Overriding methods (overloading)
 
-To change the behaviour of the superclass, methods can be overridden. Note that an object looks always for
+To change the behaviour inherited from the superclass, methods can be overridden. Note that an object looks always for
 the method it has defined first and then looks in the superclass. Here code::MyClass.value(2):: will return 6, not 4:
 
 code::
@@ -141,7 +139,7 @@ MyClass : SomeSuperclass {
 }
 ::
 
-If the method of the superclass is needed, it can be called by super.
+The keyword code::super:: can be used to call methods on the superclass
 
 code::
 SomeSuperclass {
@@ -270,8 +268,8 @@ MyClass {
 	*new { |action|
 		^super.newCopyArgs(action)
 	}
-	value {
-		action.value;
+	value { |x|
+		action.value(x);
 	}
 }
 
@@ -289,7 +287,7 @@ section::Variables
 
 subsection:: Initializing variables directly
 
-In a variable declaration, variables can be directly initialized. This works for link::Reference/Literals:: only.
+In a variable declaration, variables can be directly initialized. Only link::Reference/Literals:: may be used to initialize variables this way. This means that it is not possible to chain assignments (e.g. code:: var x = 9; var y = x + 1::).
 
 code::
 MyClass {
@@ -299,12 +297,10 @@ MyClass {
 }
 ::
 
-In class definitions, it is not possible to chain assignments (e.g. code:: var x = 9; var y = x + 1::).
-
 
 subsection:: Variable Scope
 
-An instance variable is accessible from all instance methods of this class and its subclasses. A class variable is accessible from all class and instance methods of this class and its subclasses. Instance variables of the same name as override the scope of class variables of the same name.
+An instance variable is accessible strong::from all instance methods:: of this class and its subclasses. A class variable, by contrast, is accessible strong::from all class and instance methods:: of this class and its subclasses. Instance variables will shadow class variables of the same name.
 
 code::
 MyClass {
@@ -340,7 +336,7 @@ MyClass : SomeSuperclass {
 
 ::
 
-subsection:: Getter and Setter
+subsection:: Getters and Setters
 
 SuperCollider demands that variables are not accessible outside of the class or instance. A method must be added to
 explicitly give access:
@@ -353,7 +349,7 @@ MyClass : SomeSuperclass {
 		^myVariable
 	}
 
-	variable_ { arg newValue;
+	variable_ { | newValue |
 		myVariable = newValue;
 	}
 }
@@ -385,8 +381,7 @@ someObject.getMeOrSetMe;
 ::
 
 
-A getter or setter method created in this fashion may be overridden in a subclass by manually writing the method setter
-methods should take only one argument to support both ways of expression consistently.  eg.
+A getter or setter method created in this fashion may be overridden in a subclass by explicitly defining the method. Setter methods should take only one argument to support both ways of expression consistently.  eg.
 
 code::
 MyClass {
@@ -398,21 +393,11 @@ MyClass {
 }
 ::
 
-A setter method should always return the receiver. This is standard OOP practice. Never return the new value from your setter.
+A setter method should always return the receiver. This allows us to be sure that several setters can chained up.
 
-code::
-MyClass {
-
-	variable_ { | newValue |
-		myVariable = newValue;
-		^newValue       // DO NOT DO THIS
-	}
-
-}
-::
 
 subsection::Constants
-Constants are variables, that, well, don't vary. They can be assigned only initially.
+Constants are variables, that, well, don't vary. They can only be assigned initially.
 
 code::
 MyClass {
@@ -527,12 +512,12 @@ MyTestPoint(2, 3).asCompileString;
 
 section::Private Methods
 
-Private methods are marked by a prefix code::pr::, e.g. code::prBundleSize::. This is just a strong::naming convention::, the message can still be called from anywhere. It is not recommended to do this.
+Private methods are marked by a prefix code::pr::, e.g. code::prBundleSize::. This is just a strong::naming convention::; the message can still be called from anywhere. It is recommended to stick to convention and only call private methods from within the class that defines them.
 
 
 section:: Catching undefined method calls
 
-When a message is received that is undefined, the receiver calls the method code::doesNotUnderstand::. Normally this throws an error. By overriding code::doesNotUnderstand::, it is possible to catch those calls and use them (For an example, see the class definition of code::IdentityDictionary::).
+When a message is received that is undefined, the receiver calls the method code::doesNotUnderstand::. Normally this throws an error. By overriding code::doesNotUnderstand::, it is possible to catch those calls and use them. For an example, see the class definition of code::IdentityDictionary::.
 
 code::
 MyClass {

--- a/HelpSource/Reference/Assignment.schelp
+++ b/HelpSource/Reference/Assignment.schelp
@@ -14,35 +14,21 @@ x = [1, 2, 3, 4].rotate(1);
 c = a + b;
 ::
 
-section:: Assignment in Declaration
-
-When declaring a variable, a value can be assigned to it immediately:
+A variable can be assigned a value at any time, including during declaration.
 
 code::
 (
-var x = 1;
-var y = -1;
-x + y
+// assignment in declaration
+var one = 1;
+var two = 2;
+var four = two + 2;
+
+// reassign
+two = two + one;
+two = "and now for something completely different"
+two = nil;
+
 )
-::
-
-Such assignments can be chained up:
-code::
-(
-var x = 1;
-var y = x + 9;
-x + y
-)
-::
-
-section:: Reassignment
-
-A variable can be given a new value of any kind at any time.
-code::
-x = 7;
-x = [1, 6, 3, 4, 1];
-x = { rrand(1, 10) };
-x = nil;
 ::
 
 In some cases, chains of reassignment are useful:

--- a/HelpSource/Reference/Assignment.schelp
+++ b/HelpSource/Reference/Assignment.schelp
@@ -14,6 +14,50 @@ x = [1, 2, 3, 4].rotate(1);
 c = a + b;
 ::
 
+section:: Assignment in Declaration
+
+When declaring a variable, a value can be assigned to it immediately:
+
+code::
+(
+var x = 1;
+var y = -1;
+x + y
+)
+::
+
+Such assignments can be chained up:
+code::
+(
+var x = 1;
+var y = x + 9;
+x + y
+)
+::
+
+section:: Reassignment
+
+A variable can be given a new value of any kind at any time.
+code::
+x = 7;
+x = [1, 6, 3, 4, 1];
+x = { rrand(1, 10) };
+x = nil;
+::
+
+In some cases, chains of reassignment are useful:
+code::
+(
+{
+	var sig;
+	sig = SinOsc.ar(LFNoise0.kr(10).exprange(1, 1000));
+	sig = SinOsc.ar(310, sig * 3);
+	sig = SinOsc.ar(230, sig * 0.4);
+	sig * 0.2
+}.play
+)
+::
+
 section:: Multiple Assignment
 
 A multiple assignment statement assigns the elements of a link::Classes/Collection:: which is the result of an expression on the right hand side, to a list of variables on the left hand side.
@@ -51,6 +95,7 @@ code::
 point.x = 5;
 ::
 This type of assignment is translated to the first form by the compiler. The two syntaxes are equivalent.
+
 
 section:: Series Assignment to an ArrayedCollection or List
 


### PR DESCRIPTION
- improve helpfile wording
- remove confusing examples
- explain class variable initialisation and scope
- explain constants
- improve and simplify example code
- remove wrong explanation of "slottedÓ: this was completely wrong, so I rewrote it.

(this replaces #3583).