### PR TITLE
class library: fix bug in score multichannel-expansion

### DIFF
--- a/SCClassLibrary/Common/Control/asScore/ScoreStreamPlayer.sc
+++ b/SCClassLibrary/Common/Control/asScore/ScoreStreamPlayer.sc
@@ -38,8 +38,8 @@ ScoreStreamPlayer : Server {
 	add { | beats, args|
 		beats = beats min: maxTime;
 		if(beats.isArray) {
-			beats.flop.collect { |each|
-				bundleList = bundleList.add([each] ++ args)
+			beats.do { |each, i|
+				bundleList = bundleList.add([each, args.wrapAt(i)])
 			}
 		} {
 			bundleList = bundleList.add([beats] ++ args)

--- a/SCClassLibrary/Common/Control/asScore/ScoreStreamPlayer.sc
+++ b/SCClassLibrary/Common/Control/asScore/ScoreStreamPlayer.sc
@@ -39,7 +39,7 @@ ScoreStreamPlayer : Server {
 		beats = beats min: maxTime;
 		if(beats.isArray) {
 			beats.flop.collect { |each|
-				bundleList = bundleList.add([beats] ++ args)
+				bundleList = bundleList.add([each] ++ args)
 			}
 		} {
 			bundleList = bundleList.add([beats] ++ args)

--- a/SCClassLibrary/Common/Control/asScore/ScoreStreamPlayer.sc
+++ b/SCClassLibrary/Common/Control/asScore/ScoreStreamPlayer.sc
@@ -36,16 +36,23 @@ ScoreStreamPlayer : Server {
 	secs2beats { | beats | ^beats }
 
 	add { | beats, args|
-		bundleList = bundleList.add([beats min: maxTime] ++ args)
+		beats = beats min: maxTime;
+		if(beats.isArray) {
+			beats.flop.collect { |each|
+				bundleList = bundleList.add([beats] ++ args)
+			}
+		} {
+			bundleList = bundleList.add([beats] ++ args)
+		}
 	}
 
 	prepareEvent { | event |
 		event = event.copy;
 		event.use({
-			~schedBundle = flop { | lag, offset, server ... bundle |
+			~schedBundle = { | lag, offset, server ... bundle |
 				this.add(offset * tempo + lag + beats, bundle)
 			};
-			~schedBundleArray = flop { | lag, offset, server, bundle |
+			~schedBundleArray = { | lag, offset, server, bundle |
 				this.add(offset * tempo + lag + beats, bundle)
 			};
 		});
@@ -57,10 +64,10 @@ ScoreStreamPlayer : Server {
 		proto = (
 			server: this,
 
-			schedBundle: flop { | lag, offset, server ...bundle |
+			schedBundle: { | lag, offset, server ... bundle |
 				this.add(offset * tempo + lag + beats, bundle)
 			},
-			schedBundleArray: flop { | lag, offset, server, bundle |
+			schedBundleArray: { | lag, offset, server, bundle |
 				this.add(offset * tempo + lag + beats, bundle)
 			}
 		);

--- a/SCClassLibrary/Common/Control/asScore/ScoreStreamPlayer.sc
+++ b/SCClassLibrary/Common/Control/asScore/ScoreStreamPlayer.sc
@@ -1,4 +1,5 @@
 /*
+
 ScoreStreamPlayer collects OSC commands from an EventStream into a Score. It is derived from server to provide allocation of nodeIDs, bufums, etc.
 
 It implements the functionality of a TempoClock, to support tempo changes and time based patterns.
@@ -20,25 +21,32 @@ arrayOfScores = arrayOfServers.collect { | server |
 }
 
 */
+
+
 ScoreStreamPlayer : Server {
+
 	var <>beats, <>tempo;
 	var <>bundleList, <>maxTime;
 
-	*new { ^super.new("record").initScoreStreamPlayer }
+	*new {
+		^super.new("record").initScoreStreamPlayer
+	}
 
 	initScoreStreamPlayer {
 		this.latency_(0);
 		Server.all.remove(this); // we do not want to be part of the server list
-		^this
 	}
 
 	beats2secs { | beats | ^beats }
 	secs2beats { | beats | ^beats }
 
-	add { | beats, args|
+	add { | beats, args |
 		beats = beats min: maxTime;
 		if(beats.isArray) {
 			beats.do { |each, i|
+				// because of the way events multichannel expand their values
+				// before calling ~schedBundle, the args are already flopped.
+				// so in this case we just select one for each beat value
 				bundleList = bundleList.add([each, args.wrapAt(i)])
 			}
 		} {
@@ -56,10 +64,10 @@ ScoreStreamPlayer : Server {
 				this.add(offset * tempo + lag + beats, bundle)
 			};
 		});
-		^event;
+		^event
 	}
 
-	makeScore { | stream, duration = 1, event, timeOffset = 0|
+	makeScore { | stream, duration = 1, event, timeOffset = 0 |
 		var ev, startTime, proto;
 		proto = (
 			server: this,
@@ -78,25 +86,30 @@ ScoreStreamPlayer : Server {
 		tempo = 1;
 		bundleList = [];
 		maxTime = timeOffset + duration;
+
+		// call from a routine so that the stream has this as clock
 		Routine {
 			thisThread.clock = this;
-			while ({
+			while {
 				thisThread.beats = beats;
 				ev = stream.next(event.copy);
-				(maxTime >= beats) && ev.notNil
-			},{
+				(maxTime >= beats) and: { ev.notNil }
+			} {
 				ev.putAll(proto);
 				ev.play;
 				beats = ev.delta * tempo + beats
-			})
+			}
 		}.next;
-		bundleList = bundleList.sort({ | a, b | b[0] >= a[0] });
-		if ((startTime = bundleList[0][0]) < 0 ) {
+
+		bundleList = bundleList.sort { | a, b | b[0] >= a[0] };
+
+		if((startTime = bundleList[0][0]) < 0) {
 			timeOffset = timeOffset - startTime;
 		};
+
 //		bundleList.do { | b | b[0] = b[0] + timeOffset }
 
-		^Score(bundleList.add([duration+timeOffset, [\c_set, 0, 0]]) );
+		^Score(bundleList.add([duration + timeOffset, [\c_set, 0, 0]]))
 	}
 
 }

--- a/SCClassLibrary/Common/Control/asScore/asScore.sc
+++ b/SCClassLibrary/Common/Control/asScore/asScore.sc
@@ -1,8 +1,7 @@
 + Pattern {
 
-	asScore{|duration=1.0, timeOffset=0.0, protoEvent|
-		var player;
-		^ScoreStreamPlayer.new.makeScore(this.asStream, duration, protoEvent, timeOffset);
+	asScore{ | duration = 1.0, timeOffset = 0.0, protoEvent |
+		^ScoreStreamPlayer.new.makeScore(this.asStream, duration, protoEvent, timeOffset)
 	}
 
 }
@@ -10,8 +9,8 @@
 
 + Object {
 
-	render { arg path, maxTime=60, sampleRate = 44100,
-			headerFormat = "AIFF", sampleFormat = "int16", options, inputFilePath, action;
+	render { | path, maxTime=60, sampleRate = 44100,
+			headerFormat = "AIFF", sampleFormat = "int16", options, inputFilePath, action |
 
 		var file, oscFilePath, score;
 		oscFilePath = PathName.tmp +/+ "temp_oscscore" ++ UniqueID.next;
@@ -26,8 +25,7 @@
 
 + Event {
 	asOSC {
-		var score;
-		score = Pseq([this]).asScore.score;
-		^score.copyRange(1, score.size - 2);
+		var score = Pseq([this]).asScore.score;
+		^score.copyRange(1, score.size - 2)
 	}
 }

--- a/testsuite/classlibrary/TestScore.sc
+++ b/testsuite/classlibrary/TestScore.sc
@@ -4,7 +4,7 @@ TestScore : UnitTest {
 		var events, score, s_new_messages, onsetTimes;
 		events = [(x: 0, lag: 0.5), (x: 1, dur: 0.5), (x: 2, lag: 0.5)];
 		score = Pseq(events).asScore(3);
-		s_new_messages = score.score.drop(1).select { |x| x[2] == \default };
+		s_new_messages = score.score.drop(1).select { |x| x[1][1] == \default };
 		onsetTimes = s_new_messages.collect { |x| x.first };
 		this.assertEquals(onsetTimes, [0.5, 1, 2], "onsets should be correctly derived from lag and dur");
 	}
@@ -13,7 +13,7 @@ TestScore : UnitTest {
 		var events, score, s_new_messages, onsetTimes;
 		events = [(x: 0, timingOffset: 0.5), (x: 1, dur: 0.5), (x: 2, timingOffset: 0.5)];
 		score = Pseq(events).asScore(3);
-		s_new_messages = score.score.drop(1).select { |x| x[2] == \default };
+		s_new_messages = score.score.drop(1).select { |x| x[1][1] == \default };
 		onsetTimes = s_new_messages.collect { |x| x.first };
 		this.assertEquals(onsetTimes, [0.5, 1, 2], "onsets should be correctly derived from timingOffset and dur");
 	}
@@ -22,7 +22,7 @@ TestScore : UnitTest {
 		var events, score, s_new_messages, onsetTimes;
 		events = [(x: 0, lag: [0.5, 1, 2])];
 		score = Pseq(events).asScore(3);
-		s_new_messages = score.score.drop(1).select { |x| x[2] == \default };
+		s_new_messages = score.score.drop(1).select { |x| x[1][1] == \default };
 		onsetTimes = s_new_messages.collect { |x| x.first };
 		this.assertEquals(onsetTimes, [0.5, 1, 2], "onsets should be correctly derived from lag in multichannel expanding");
 	}
@@ -31,7 +31,7 @@ TestScore : UnitTest {
 		var events, score, s_new_messages, onsetTimes;
 		events = [(x: 0, timingOffset: [0.5, 1, 2])];
 		score = Pseq(events).asScore(3);
-		s_new_messages = score.score.drop(1).select { |x| x[2] == \default };
+		s_new_messages = score.score.drop(1).select { |x| x[1][1] == \default };
 		onsetTimes = s_new_messages.collect { |x| x.first };
 		this.assertEquals(onsetTimes, [0.5, 1, 2], "onsets should be correctly derived from timingOffset in multichannel expanding");
 	}
@@ -40,7 +40,7 @@ TestScore : UnitTest {
 		var events, score, s_new_messages, onsetTimes;
 		events = [(x: 0, timingOffset: [0.5, 1, 2], lag: [0.3, 0.7, 1])];
 		score = Pseq(events).asScore(4);
-		s_new_messages = score.score.drop(1).select { |x| x[2] == \default };
+		s_new_messages = score.score.drop(1).select { |x| x[1][1] == \default };
 		onsetTimes = s_new_messages.collect { |x| x.first };
 		this.assertEquals(onsetTimes, [0.5, 1, 2] + [0.3, 0.7, 1], "onsets should be correctly derived from lag and timingOffset in multichannel expanding");
 	}

--- a/testsuite/classlibrary/TestScore.sc
+++ b/testsuite/classlibrary/TestScore.sc
@@ -1,5 +1,17 @@
 TestScore : UnitTest {
 
+	test_pattern_asScore_plain {
+		var pattern, score, s_new_messages, onsetTimes;
+		pattern = Pbind(
+			\dur, Pseq([0.5], inf),
+			\freq, Prand([200, 300, 500], inf)
+		);
+		score = pattern.asScore(4.0);
+		s_new_messages = score.score.drop(1).select { |x| x[1][1] == \default };
+		onsetTimes = s_new_messages.collect { |x| x.first };
+		this.assertEquals(onsetTimes, (0, 0.5..4), "onsets should be correctly derived from dur");
+	}
+
 	test_pattern_asScore_lag {
 		var events, score, s_new_messages, onsetTimes;
 		events = [(x: 0, lag: 0.5), (x: 1, dur: 0.5), (x: 2, lag: 0.5)];


### PR DESCRIPTION
The `flop` was problematic for `schedBundleArray`. While `schedBundle`
takes the bundle in the form of an ellipsis argument, the former takes
it as an array. Then, the function multichannel expands on the bundle.