### PR TITLE
Remove misleading deprecation of old support directory

### DIFF
--- a/lang/LangSource/SC_LanguageClient.cpp
+++ b/lang/LangSource/SC_LanguageClient.cpp
@@ -24,7 +24,6 @@
 */
 
 #include "SC_LanguageClient.h"
-#include "SC_LanguageConfig.hpp"
 #include "SC_Lock.h"
 #include <cstring>
 #include <string>
@@ -47,15 +46,8 @@
 #include "PyrSched.h"
 #include "GC.h"
 #include "VMGlobals.h"
-#include "SC_Filesystem.hpp"
 #include "SCBase.h"
 #include "SC_StringBuffer.h"
-
-// only needed on linux to detect deprecated support directory (see initRuntime)
-#ifdef __linux__
-#    include <boost/filesystem/path.hpp>
-#    include <boost/filesystem/operations.hpp>
-#endif
 
 void closeAllGUIScreens();
 void initGUI();
@@ -115,23 +107,6 @@ void SC_LanguageClient::initRuntime(const Options& opt)
 {
 	// start virtual machine
 	if (!mHiddenClient->mRunning) {
-#ifdef __linux__
-		using DirName = SC_Filesystem::DirName;
-		namespace bfs = boost::filesystem;
-		bfs::path deprecatedSupportDirectory = SC_Filesystem::instance().getDirectory(DirName::UserHome);
-		deprecatedSupportDirectory /= "share/SuperCollider";
-
-		if (bfs::exists(deprecatedSupportDirectory)) {
-			bfs::path supportDirectory = SC_Filesystem::instance().getDirectory(DirName::UserAppSupport);
-			postfl("WARNING: Deprecated support directory detected: %s\n"
-				"Extensions and other contents in this directory will not be available until you move them to the new support directory:\n"
-				"%s\n"
-				"Quarks will need to be reinstalled due to broken symbolic links.\n\n",
-				deprecatedSupportDirectory.string().c_str(), // we can safely convert to c_str here because the POSIX filesystem uses UTF-8
-				supportDirectory.string().c_str());
-		}
-#endif
-
 		mHiddenClient->mRunning = true;
 		if (opt.mRuntimeDir) {
 			int err = chdir(opt.mRuntimeDir);


### PR DESCRIPTION
On UNIX-like systems, if SuperCollider is compiled from source into the user's home directory via:

    cmake -DCMAKE_INSTALL_PREFIX=$HOME
    make install

then `Platform.systemAppSupportDir` and `Platform.resourceDir` will be set to

    $HOME/share/SuperCollider

This is due to `CMakeLists.txt` containing the definition of `SC_DATA_DIR`:

    elseif(UNIX)
            add_definitions(-DSC_DATA_DIR="${CMAKE_INSTALL_PREFIX}/share/SuperCollider")
    endif()

which is then consumed by `common/SC_Filesystem_unix.cpp`.

Unfortunately, this resulting path is identical to the old location for the *user* support directory, so it triggers a misleading warning.  However this deprecation was introduced by 2b77ef67 in August 2011, so it should be safe to remove it by now.

Fixes #3367.