### PR TITLE
UnitTest: brief reporting for passing tests via passVerbosity = brief

### DIFF
--- a/HelpSource/Classes/UnitTest.schelp
+++ b/HelpSource/Classes/UnitTest.schelp
@@ -17,7 +17,7 @@ To install, link::https://github.com/supercollider/supercollider##download the s
 
 CLASSMETHODS::
 
-PRIVATE:: allTestClasses, classesWithTests, classesWithoutTests, failures, findTestClass, findTestClasses, findTestMethods, findTestedClass, forkIfNeeded, listUntestedMethods, passes, report, reportPasses, reset, run, untestedMethods
+PRIVATE:: allTestClasses, classesWithTests, classesWithoutTests, failures, findTestClass, findTestClasses, findTestMethods, findTestedClass, forkIfNeeded, listUntestedMethods, passes, report, reset, run, untestedMethods
 
 METHOD:: gui
 A graphical interface to run and browse all tests
@@ -25,6 +25,29 @@ A graphical interface to run and browse all tests
 code::
 UnitTest.gui
 ::
+
+METHOD:: reportPasses
+Accessor controlling whether passing tests should be reported.
+Defaults to code::true::.  See also link::#*passVerbosity:: which
+controls how much detail is reported from passing tests
+when this is set to true.
+
+ARGUMENT:: value
+Should be code::true:: or code::false::.
+
+METHOD:: passVerbosity
+Accessor controlling whether extra details should be reported for
+passing tests.
+
+Defaults to code::UnitTest.full:: so that all details are reported;
+however this behaviour may be too verbose for some, for whom it is
+sufficient to see that a test is passing without needing to see the
+detail.  If set to code::UnitTest.brief::, and link::#*reportPasses::
+is true, passes will be reported, but without any extra details which
+may be provided by assertions.
+
+ARGUMENT:: value
+Should be code::UnitTest.full:: or code::UnitTest.brief::.
 
 METHOD:: run
 Run all methods whose names begin with code::test_::.
@@ -101,11 +124,20 @@ Reports the result of the test if code::true::.
 argument:: onFailure
 If not code::nil::, a failure stops the tests and evaluates this function.
 
+argument:: details
+Some optional extra details which will be passed to the reporting framework
+for display unless brief reporting is requested (see link::#*passVerbosity::).
+
 METHOD:: assertEquals
 
 Asserts that an expression code::a:: is equal to the value code::b::,
 where equality is determined according to code::a::'s implementation
 of code::==::.
+
+Automatically passes details of the equality check to the reporting
+framework, which will be displayed if the assertion fails, and also if
+it passes and link::#*reportPasses:: is code::true:: and
+link::#*passVerbosity:: is not set to code::UnitTest.brief::.
 
 code::
 this.assertEquals(2 + 2, 4, "passes");
@@ -133,6 +165,11 @@ METHOD:: assertFloatEquals
 
 Asserts that an expression code::a:: returning a float is within a
 given range (code::within::) of being equal to code::b::.
+
+Automatically passes details of the equality check to the reporting
+framework, which will be displayed if the assertion fails, and also if
+it passes and link::#*reportPasses:: is code::true:: and
+link::#*passVerbosity:: is not set to code::UnitTest.brief::.
 
 code::
 this.assertFloatEquals(2, 2.0001, "Pass since 2 is close enough to 2.0001.", 0.001);
@@ -229,6 +266,23 @@ code::
 METHOD:: passed
 Register a passed test.
 
+ARGUMENT:: method
+Name of the method in which the test is passing.
+
+ARGUMENT:: message
+A message describing the purpose of the assertion, e.g. code::"foo
+should be less than bar"::.
+Posted if neither code::report:: nor link::#*reportPasses:: are false.
+
+argument:: report
+Reports the result of the test if true and link::#*reportPasses:: is true.
+
+argument:: details
+Some optional extra details which will be displayed if
+link::#*reportPasses:: is true and link::#*passVerbosity:: is
+not set to code::UnitTest.brief::.
+
+DISCUSSION::
 code::
 this.passed(message: "this passed");
 ::
@@ -236,6 +290,22 @@ this.passed(message: "this passed");
 METHOD:: failed
 Register a test failure.
 
+ARGUMENT:: method
+Name of the method in which the test is failing.
+
+ARGUMENT:: message
+A message describing the purpose of the assertion, e.g. code::"foo
+should be less than bar"::.
+Posted if code::report:: is true.
+
+argument:: report
+Reports the result of the test if true.
+
+argument:: details
+Some optional extra details which will be displayed if code::report::
+is true.
+
+DISCUSSION::
 code::
 this.failed(message: "this failed");
 ::

--- a/SCClassLibrary/Common/UnitTesting/UnitTest.sc
+++ b/SCClassLibrary/Common/UnitTesting/UnitTest.sc
@@ -244,7 +244,7 @@ UnitTest {
 		var r = UnitTestResult(this, method, message);
 		failures = failures.add(r);
 		if(report){
-			Post << Char.nl << "FAIL:";
+			Post << Char.nl << "FAIL: ";
 			r.report;
 			Post << Char.nl;
 		};
@@ -255,7 +255,7 @@ UnitTest {
 		var r = UnitTestResult(this, method, message);
 		passes = passes.add(r);
 		if(report and: reportPasses) {
-			Post << "PASS:";
+			Post << "PASS: ";
 			r.report;
 		};
 	}

--- a/SCClassLibrary/Common/UnitTesting/UnitTest.sc
+++ b/SCClassLibrary/Common/UnitTesting/UnitTest.sc
@@ -1,8 +1,13 @@
 UnitTest {
 
 	var currentMethod;
-	classvar <failures, <passes, routine, <>reportPasses = true;
+	const <brief = 1, <full = 2;
+	classvar <failures, <passes, routine, <>reportPasses = true, <>passVerbosity;
 	classvar <allTestClasses;
+
+	*initClass {
+		passVerbosity = full;
+	}
 
 	*findTestClasses {
 		allTestClasses = UnitTest.allSubclasses.collectAs({ |c|
@@ -123,26 +128,29 @@ UnitTest {
 	///////////////////////////////////////////////////////////////////////
 	// call these in your test_ methods to check conditions and pass or fail
 
-	assert { | boolean, message, report = true, onFailure |
+	assert { | boolean, message, report = true, onFailure, details |
 		if(boolean.not) {
-			this.failed(currentMethod, message, report);
+			this.failed(currentMethod, message, report, details);
 			if(onFailure.notNil) {
 				{ onFailure.value }.defer;
 				Error("UnitTest halted with onFailure handler.").throw;
 			};
 		} {
-			this.passed(currentMethod, message, report)
+			this.passed(currentMethod, message, report, details)
 		};
 		^boolean
 	}
 
 	assertEquals { |a, b, message = "", report = true, onFailure |
-		this.assert( a == b, message + "\nIs:\n\t" + a + "\nShould be:\n\t" + b + "\n", report, onFailure)
+		var details = "Is:\n\t" + a + "\nShould be:\n\t" + b;
+		this.assert(a == b, message, report, onFailure, details);
 	}
 
 	assertFloatEquals { |a, b, message = "", within = 0.0001, report = true, onFailure|
-		this.assert( (a - b).abs <= within,
-			message + "\nIs:\n\t" + a + "\nShould equal (within range" + within ++ "):\n\t" + b + "\n", report, onFailure);
+		var details =
+			"Is:\n\t" + a +
+			"\nShould equal (within range" + within ++ "):\n\t" + b;
+		this.assert((a - b).abs <= within, message, report, onFailure, details);
 	}
 
 	assertArrayFloatEquals { |a, b, message = "", within = 0.0001, report = true, onFailure|
@@ -240,8 +248,9 @@ UnitTest {
 	}
 
 	// call failure directly
-	failed { | method, message, report = true |
-		var r = UnitTestResult(this, method, message);
+	failed { | method, message, report = true, details |
+		var r;
+		r = UnitTestResult(this, method, message, details);
 		failures = failures.add(r);
 		if(report){
 			Post << Char.nl << "FAIL: ";
@@ -251,12 +260,13 @@ UnitTest {
 	}
 
 	// call pass directly
-	passed { | method, message, report = true |
-		var r = UnitTestResult(this, method, message);
+	passed { | method, message, report = true, details |
+		var r;
+		r = UnitTestResult(this, method, message, details);
 		passes = passes.add(r);
-		if(report and: reportPasses) {
+		if(report && reportPasses) {
 			Post << "PASS: ";
-			r.report;
+			r.report(passVerbosity == brief);
 		};
 	}
 
@@ -293,8 +303,7 @@ UnitTest {
 		if(failures.size > 0) {
 			"There were failures:".inform;
 			failures.do { arg results;
-
-				results.report
+				results.report(true);
 			};
 		} {
 			"There were no failures".inform;
@@ -391,17 +400,20 @@ UnitTest {
 
 UnitTestResult {
 
-	var <testClass, <testMethod, <message;
+	var <testClass, <testMethod, <message, <details;
 
-	*new { |testClass, testMethod, message = ""|
-		^super.newCopyArgs(testClass ? this, testMethod ? thisMethod, message)
+	*new { |testClass, testMethod, message = "", details|
+		^super.newCopyArgs(testClass ? this, testMethod ? thisMethod, message, details)
 	}
 
-	report {
+	report { |brief=false|
 		var name = if(testMethod.notNil) { testMethod.name } { "unit test result" };
 		Post << testClass.asString << ": " << name;
 		if (message.size > 0) {
 			Post << " - " << message;
+		};
+		if (brief.not && details.notNil) {
+			Post << Char.nl << details;
 		};
 		Post << Char.nl;
 	}

--- a/SCClassLibrary/Common/UnitTesting/UnitTest.sc
+++ b/SCClassLibrary/Common/UnitTesting/UnitTest.sc
@@ -399,7 +399,11 @@ UnitTestResult {
 
 	report {
 		var name = if(testMethod.notNil) { testMethod.name } { "unit test result" };
-		Post << testClass.asString << ":" << name << " - " << message << Char.nl;
+		Post << testClass.asString << ": " << name;
+		if (message.size > 0) {
+			Post << " - " << message;
+		};
+		Post << Char.nl;
 	}
 }
 


### PR DESCRIPTION
Supersedes #3569.

When assertions succeed, we don't usually need to see the details; they just clutter up the output and make it harder to see the details of the failures.  So extend `UnitTest` and `UnitTestResult` in a backwards-compatible manner:

- Default behaviour does not change.
- Output from anything other than passing assertions does not change.
- If `UnitTest.passVerbosity` is set to the constant `UnitTest.brief`, passing assertions only output the summary, not the details.

In a future release it may be considered acceptable to switch the default for `passVerbosity` to `brief`.

Additionally perform some other cosmetic cleanups on the test framework output.

Partially addresses #3365.