### PR TITLE
UnitTest: add debug method

### DIFF
--- a/HelpSource/Classes/UnitTest.schelp
+++ b/HelpSource/Classes/UnitTest.schelp
@@ -295,6 +295,35 @@ code::
 )
 ::
 
+METHOD:: debug
+Supply some debugging information relevant to the currently running
+test case.  This will be displayed immediately preceding any details
+which may be displayed through use of the code::details:: argument of
+link::#-passed:: and link::#-failed::.
+
+ARGUMENT:: text
+The debugging text.
+
+DISCUSSION::
+code::
+test_myMethod {
+    var obj = MyClass.new;
+    this.debug("obj has color" + obj.color);
+    this.assert(2 + 2, 5);
+}
+::
+
+will result in:
+
+code::
+FAIL: a TestMyClass: test_myMethod
+obj has color red
+Is:
+         4
+Should be:
+         5
+::
+
 METHOD:: passed
 Register a passed test.
 

--- a/SCClassLibrary/Common/UnitTesting/UnitTest.sc
+++ b/SCClassLibrary/Common/UnitTesting/UnitTest.sc
@@ -1,6 +1,6 @@
 UnitTest {
 
-	var currentMethod;
+	var currentMethod, debug = "";
 	const <brief = 1, <full = 2;
 	classvar <failures, <passes, routine, <>reportPasses = true, <>passVerbosity;
 	classvar <allTestClasses;
@@ -253,10 +253,13 @@ UnitTest {
 		server.newAllocators; // new nodes, busses regardless
 	}
 
+	debug { |text|
+		debug = debug ++ text;
+	}
+
 	// call failure directly
 	failed { | method, message, report = true, details |
-
-		var r = UnitTestResult(this, method, message, details);
+		var r = UnitTestResult(this, method, message, details, debug);
 		failures = failures.add(r);
 
 		if(report) {
@@ -268,7 +271,7 @@ UnitTest {
 
 	// call pass directly
 	passed { | method, message, report = true, details |
-		var r = UnitTestResult(this, method, message, details);
+		var r = UnitTestResult(this, method, message, details, debug);
 		passes = passes.add(r);
 
 		if(report and: { reportPasses }) {
@@ -393,10 +396,10 @@ UnitTest {
 
 UnitTestResult {
 
-	var <testClass, <testMethod, <message, <details;
+	var <testClass, <testMethod, <message, <details, <debug;
 
-	*new { |testClass, testMethod, message = "", details|
-		^super.newCopyArgs(testClass ? this, testMethod ? thisMethod, message, details)
+	*new { |testClass, testMethod, message = "", details, debug|
+		^super.newCopyArgs(testClass ? this, testMethod ? thisMethod, message, details, debug)
 	}
 
 	report { |brief=false|
@@ -405,8 +408,13 @@ UnitTestResult {
 		if (message.size > 0) {
 			Post << " - " << message;
 		};
-		if (brief.not && details.notNil) {
-			Post << Char.nl << details;
+		if (brief.not) {
+			if (debug.size > 0) {
+				Post << Char.nl << debug;
+			};
+			if (details.notNil) {
+				Post << Char.nl << details;
+			};
 		};
 		Post << Char.nl;
 	}


### PR DESCRIPTION
This allows TestCases to provide debug which will be displayed in the results report along with any details from assertions, except for passing tests where brief reporting has been requested via

    UnitTest.passVerbosity = UnitTest.brief;

This is very similar to [the `addDetail` method in Python's testtools](https://testtools.readthedocs.io/en/latest/for-test-authors.html#details).

Unfortunately UnitTest doesn't provide isolation between test cases as per https://github.com/supercollider/supercollider/issues/3572, so we have to reset the debug state after each test method, otherwise debug from one test method can bleed into the next if brief reporting is enabled and all the tests in the first one pass.

Partially addresses #3365.