### PR TITLE
Isolate unit tests

### DIFF
--- a/SCClassLibrary/Common/UnitTesting/UnitTest.sc
+++ b/SCClassLibrary/Common/UnitTesting/UnitTest.sc
@@ -142,15 +142,16 @@ UnitTest {
 				a[startFrom..],
 				if(b.isArray) { b[startFrom..] } { b }
 			);
-			this.failed(currentMethod,message, report);
+			this.failed(currentMethod, message, report);
+
 			if(onFailure.notNil) {
 				{ onFailure.value }.defer;
 				Error("UnitTest halted with onFailure handler.").throw;
 			};
 		} {
-			this.passed(currentMethod,message, report)
+			this.passed(currentMethod, message, report)
 		}
-		^someHaveFailed
+		^someHaveFailed.not
 	}
 
 	// make a further assertion only if it passed, or only if it failed

--- a/SCClassLibrary/Common/UnitTesting/UnitTest.sc
+++ b/SCClassLibrary/Common/UnitTesting/UnitTest.sc
@@ -31,15 +31,13 @@ UnitTest {
 	tearDown {}
 
 	*run { | reset = true, report = true|
-
-		if(reset) { this.class.reset };
+		var function;
+		if(reset) { this.reset };
 		if(report) { ("RUNNING UNIT TEST" + this).inform };
-
 		this.forkIfNeeded {
 			this.runAllTestMethods;
 			if(report) { this.report };
-			nil
-		}
+		};
 	}
 
 	// run all UnitTest subclasses
@@ -65,7 +63,7 @@ UnitTest {
 		class.new.runTestMethod(method);
 	}
 
-	runAllTestMethods {
+	*runAllTestMethods {
 		this.forkIfNeeded {
 			this.findTestMethods.do { |method|
 				this.new.runTestMethod(method)
@@ -83,7 +81,6 @@ UnitTest {
 			this.perform(method.name);
 			this.tearDown;
 			this.class.report;
-			nil
 		}
 	}
 
@@ -329,27 +326,7 @@ UnitTest {
 	// private - use TestYourClass.run
 
 	run { | reset = true, report = true|
-		var function;
-		if(reset) { this.class.reset };
-		if(report) { ("RUNNING UNIT TEST" + this).inform };
-		this.class.forkIfNeeded {
-			this.findTestMethods.do { |method|
-				this.setUp;
-				currentMethod = method;
-				//{
-				this.perform(method.name);
-				// unfortunately this removes the interesting part of the call stack
-				//}.try({ |err|
-				//	("ERROR during test"+method).postln;
-				//	err.throw;
-				//});
-
-				this.tearDown;
-			};
-			if(report) { this.class.report };
-			nil
-		};
-
+		this.class.run
 	}
 
 	*forkIfNeeded { |function|
@@ -517,7 +494,6 @@ UnitTestScript : UnitTest {
 			currentMethod = this;
 			path.load.value(this);
 			this.class.report;
-			nil
 		}
 	}
 

--- a/SCClassLibrary/Common/UnitTesting/UnitTest.sc
+++ b/SCClassLibrary/Common/UnitTesting/UnitTest.sc
@@ -86,57 +86,8 @@ UnitTest {
 	}
 
 	*gui {
-
-		// UnitTest GUI written by Dan Stowell 2009.
-		var w, classlist, methodlist, lookUp;
-
 		this.findTestClasses;
-
-		w = Window.new("[UnitTest GUI]", Rect(100, 100, 415, 615), resizable: false);
-		w.addFlowLayout;
-
-		StaticText(w, Rect(0,0, 400, 40))
-		.string_("Select a category, then a test method, and press Enter\nHit 'i' to jump to the code file")
-		.align_(\center);
-
-		classlist = ListView(w, Rect(0,0, 200, 600-40))
-		.items_(allTestClasses.asSortedArray.collect(_[0]))
-		.action_{|widg|
-			methodlist.items_(
-				allTestClasses.asSortedArray[widg.value][1].asSortedArray.collect(_[0])
-			)
-		};
-
-		methodlist = ListView(w, Rect(200,40, 200, 600-40));
-		methodlist.enterKeyAction_ {|widg|
-			allTestClasses.asSortedArray[classlist.value][1].asSortedArray[widg.value][1].value
-		};
-
-		lookUp = {|widg, char, mod|
-			var class, selector, method;
-			class = ("Test" ++ classlist.items[classlist.value]).asSymbol.asClass;
-			class !? {
-				selector = methodlist.items[methodlist.value].asSymbol;
-				method = class.findMethod(selector);
-				if(char == $i) {
-					if(method.notNil) { method.openCodeFile } { class.openCodeFile };
-				}
-			};
-
-		};
-
-		methodlist.keyDownAction = lookUp;
-		classlist.keyDownAction = lookUp;
-
-		classlist.enterKeyAction_{|widg|
-			// mimic behaviour of pressing enter in methodlist
-			methodlist.enterKey;
-		};
-
-		classlist.value_(0);
-		classlist.doAction; // fills in the right-hand column
-		^w.front;
-
+		^UnitTestGUI.new(this.allTestClasses)
 	}
 
 	///////////////////////////////////////////////////////////////////////

--- a/SCClassLibrary/Common/UnitTesting/UnitTest.sc
+++ b/SCClassLibrary/Common/UnitTesting/UnitTest.sc
@@ -31,18 +31,26 @@ UnitTest {
 	tearDown {}
 
 	*run { | reset = true, report = true|
-		this.new.run(reset, report);
+
+		if(reset) { this.class.reset };
+		if(report) { ("RUNNING UNIT TEST" + this).inform };
+
+		this.forkIfNeeded {
+			this.runAllTestMethods;
+			if(report) { this.report };
+			nil
+		}
 	}
 
 	// run all UnitTest subclasses
 	*runAll {
 		^this.forkIfNeeded {
 			this.reset;
-			this.allSubclasses.do ({ |testClass|
-				testClass.run(false,false);
+			this.allSubclasses.do { |testClass|
+				testClass.run(false, false);
 				0.1.wait;
-			});
-			this.report;
+			};
+			this.report
 		}
 	}
 
@@ -55,6 +63,14 @@ UnitTest {
 		method = class.findMethod(method.asSymbol);
 		if(method.isNil) { Error("Test method not found "+methodName).throw };
 		class.new.runTestMethod(method);
+	}
+
+	runAllTestMethods {
+		this.forkIfNeeded {
+			this.findTestMethods.do { |method|
+				this.new.runTestMethod(method)
+			}
+		}
 	}
 
 	// run a single test method of this class
@@ -148,8 +164,8 @@ UnitTest {
 
 	assertFloatEquals { |a, b, message = "", within = 0.0001, report = true, onFailure|
 		var details =
-			"Is:\n\t" + a +
-			"\nShould equal (within range" + within ++ "):\n\t" + b;
+		"Is:\n\t" + a +
+		"\nShould equal (within range" + within ++ "):\n\t" + b;
 		this.assert((a - b).abs <= within, message, report, onFailure, details);
 	}
 

--- a/SCClassLibrary/Common/UnitTesting/UnitTest.sc
+++ b/SCClassLibrary/Common/UnitTesting/UnitTest.sc
@@ -118,14 +118,12 @@ UnitTest {
 	}
 
 	assertArrayFloatEquals { |a, b, message = "", within = 0.0001, report = true, onFailure|
-		// Check whether all in array meet the condition.
+
 		var results, startFrom, someHaveFailed;
 		a = a.asArray;
-		results = if(b.isArray) {
-			a.collect {|item, index| (item - b[index]).abs <= within }
-		}{
-			a.collect {|item, index| (item - b).abs <= within }
-		};
+
+		// Check whether all in array meet the condition.
+		results = (a - b).abs <= within;
 		someHaveFailed = results.includes(false);
 
 		if(someHaveFailed) {

--- a/SCClassLibrary/Common/UnitTesting/UnitTest.sc
+++ b/SCClassLibrary/Common/UnitTesting/UnitTest.sc
@@ -330,12 +330,7 @@ UnitTest {
 	}
 
 	*forkIfNeeded { |function|
-		^if(thisThread.isKindOf(Routine)) {
-			// we are inside the Routine already
-			function.value
-		} {
-			Routine(function).play(AppClock)
-		}
+		function.forkIfNeeded(AppClock)
 	}
 
 	// returns the methods named test_

--- a/SCClassLibrary/Common/UnitTesting/UnitTest.sc
+++ b/SCClassLibrary/Common/UnitTesting/UnitTest.sc
@@ -29,9 +29,10 @@ UnitTest {
 		var class, method, unitTest;
 		# class, method = methodName.split($:);
 		class = class.asSymbol.asClass;
-		method.asSymbol;
 		method = class.findMethod(method.asSymbol);
-		if(method.isNil) { Error("Test method not found "+methodName).throw };
+		if(method.isNil) {
+			Error("Test method not found " + methodName).throw
+		};
 		class.new.runTestMethod(method);
 	}
 
@@ -42,8 +43,7 @@ UnitTest {
 	// called after each test
 	tearDown {}
 
-	*run { | reset = true, report = true|
-		var function;
+	*run { | reset = true, report = true |
 		if(reset) { this.reset };
 		if(report) { ("RUNNING UNIT TEST" + this).inform };
 		this.forkIfNeeded {
@@ -74,7 +74,6 @@ UnitTest {
 
 	// run a single test method of this class
 	runTestMethod { | method |
-		var function;
 		("RUNNING UNIT TEST" + this.class.name ++ ":" ++ method.name).inform;
 		this.class.forkIfNeeded {
 			this.setUp;
@@ -120,15 +119,16 @@ UnitTest {
 
 	assertArrayFloatEquals { |a, b, message = "", within = 0.0001, report = true, onFailure|
 		// Check whether all in array meet the condition.
-		var results, startFrom;
+		var results, startFrom, someHaveFailed;
 		a = a.asArray;
 		results = if(b.isArray) {
 			a.collect {|item, index| (item - b[index]).abs <= within }
 		}{
 			a.collect {|item, index| (item - b).abs <= within }
 		};
+		someHaveFailed = results.includes(false);
 
-		if(results.any(_ == false)) {
+		if(someHaveFailed) {
 			startFrom = results.indexOf(false);
 			// Add failure details:
 			message = message ++
@@ -147,11 +147,10 @@ UnitTest {
 				{ onFailure.value }.defer;
 				Error("UnitTest halted with onFailure handler.").throw;
 			};
-			^false
-		}{
+		} {
 			this.passed(currentMethod,message, report)
-			^true
 		}
+		^someHaveFailed
 	}
 
 	// make a further assertion only if it passed, or only if it failed
@@ -298,7 +297,7 @@ UnitTest {
 
 	*findTestMethods {
 		^methods.select { |m|
-			m.name.asString.copyRange(0,4) == "test_"
+			m.name.asString.beginsWith("test_")
 		}
 	}
 
@@ -313,6 +312,7 @@ UnitTest {
 	}
 
 	// whom I am testing
+	// removing "Test" by copyToEnd(4)
 	*findTestedClass {
 		^this.name.asString.copyToEnd(4).asSymbol.asClass
 	}

--- a/SCClassLibrary/Common/UnitTesting/UnitTestGUI.sc
+++ b/SCClassLibrary/Common/UnitTesting/UnitTestGUI.sc
@@ -1,0 +1,56 @@
+UnitTestGUI {
+
+
+	*new { |allTestClasses|
+
+		// UnitTest GUI written by Dan Stowell 2009.
+		var w, classlist, methodlist, lookUp;
+
+		w = Window.new("[UnitTest GUI]", Rect(100, 100, 415, 615), resizable: false);
+		w.addFlowLayout;
+
+		StaticText(w, Rect(0,0, 400, 40))
+		.string_("Select a category, then a test method, and press Enter\nHit 'i' to jump to the code file")
+		.align_(\center);
+
+		classlist = ListView(w, Rect(0,0, 200, 600-40))
+		.items_(allTestClasses.asSortedArray.collect(_[0]))
+		.action_{|widg|
+			methodlist.items_(
+				allTestClasses.asSortedArray[widg.value][1].asSortedArray.collect(_[0])
+			)
+		};
+
+		methodlist = ListView(w, Rect(200,40, 200, 600-40));
+		methodlist.enterKeyAction_ {|widg|
+			allTestClasses.asSortedArray[classlist.value][1].asSortedArray[widg.value][1].value
+		};
+
+		lookUp = {|widg, char, mod|
+			var class, selector, method;
+			class = ("Test" ++ classlist.items[classlist.value]).asSymbol.asClass;
+			class !? {
+				selector = methodlist.items[methodlist.value].asSymbol;
+				method = class.findMethod(selector);
+				if(char == $i) {
+					if(method.notNil) { method.openCodeFile } { class.openCodeFile };
+				}
+			};
+
+		};
+
+		methodlist.keyDownAction = lookUp;
+		classlist.keyDownAction = lookUp;
+
+		classlist.enterKeyAction_{|widg|
+			// mimic behaviour of pressing enter in methodlist
+			methodlist.enterKey;
+		};
+
+		classlist.value_(0);
+		classlist.doAction; // fills in the right-hand column
+		^w.front;
+
+	}
+
+}

--- a/testsuite/classlibrary/TestUnitTest.sc
+++ b/testsuite/classlibrary/TestUnitTest.sc
@@ -1,31 +1,40 @@
 
 TestUnitTest : UnitTest {
 
-	var someVar,toreDown,count = 0;
+	var someVar, setUp = false, toreDown = false;
 
 	setUp {
-		someVar = "setUp";
-		count = count + 1;
+		setUp = true;
 	}
+
 	tearDown {
-		someVar = "tearDown";
 		toreDown = true;
 	}
 
 	test_setUp {
-		this.assert( count == 1, "count should be on 1");
-		this.assert( someVar == "setUp", "someVar be set in setUp" );
+		this.assert( setUp, "setUp should have happened" )
 	}
-	test_toreDown{
+
+	/*test_toreDown {
 		this.assert( toreDown, "toreDown should be set at the end of the last test" );
 		this.assert( count == 2, "count should be on 2");
-	}
-	test_setUp2 {
-		this.assert( count == 3, "count should be on 3");
-	}
+	}*/
+
+
 	test_assert {
 		this.assert(true, "assert(true) should certainly work");
 	}
+
+	test_isolation_first {
+		this.assertEquals(someVar, nil, "methods in UnitTests should be isolated");
+		someVar = 2;
+	}
+
+	test_isolation_second {
+		this.assertEquals(someVar, nil, "methods in UnitTests should be isolated");
+		someVar = 2;
+	}
+
 /*
 	test_failure {
 		this.assert( false, "should fail")


### PR DESCRIPTION
This cleans up the `UnitTest` class and isolates the test methods by making an instance each.

This fixes #3572.