### PR TITLE
Isolate unit tests

### DIFF
--- a/SCClassLibrary/Common/UnitTesting/UnitTest.sc
+++ b/SCClassLibrary/Common/UnitTesting/UnitTest.sc
@@ -45,9 +45,8 @@ UnitTest {
 
 	*run { | reset = true, report = true |
 		if(reset) { this.reset };
-		if(report) { ("RUNNING UNIT TEST" + this).inform };
 		this.forkIfNeeded {
-			this.runAllTestMethods;
+			this.runAllTestMethods(report);
 			if(report) { this.report };
 		};
 	}
@@ -64,23 +63,25 @@ UnitTest {
 		}
 	}
 
-	*runAllTestMethods {
+	*runAllTestMethods { |report = true|
 		this.forkIfNeeded {
 			this.findTestMethods.do { |method|
-				this.new.runTestMethod(method)
+				this.new.runTestMethod(method, report)
 			}
 		}
 	}
 
 	// run a single test method of this class
-	runTestMethod { | method |
-		("RUNNING UNIT TEST" + this.class.name ++ ":" ++ method.name).inform;
+	runTestMethod { | method, report = true |
+		if(report) {
+			"\nRUNNING UNIT TEST -- %: %\n".format(this.class.name, method.name).inform
+		};
 		this.class.forkIfNeeded {
 			this.setUp;
 			currentMethod = method;
 			this.perform(method.name);
 			this.tearDown;
-			this.class.report;
+			if(report) { this.class.report };
 		}
 	}
 
@@ -263,7 +264,7 @@ UnitTest {
 
 	*report {
 		Post.nl;
-		"UNIT TEST.............".inform;
+		"UNIT TESTS FOR '%' COMPLETED".format(this.class.name).inform;
 		if(failures.size > 0) {
 			"There were failures:".inform;
 			failures.do { arg results;

--- a/SCClassLibrary/Common/UnitTesting/UnitTest.sc
+++ b/SCClassLibrary/Common/UnitTesting/UnitTest.sc
@@ -24,42 +24,56 @@ UnitTest {
 
 	}
 
+	// run a single test in the name format "TestPolyPlayerPool:test_prepareChildrenToBundle"
+	*runTest { | methodName |
+		var class, method, unitTest;
+		# class, method = methodName.split($:);
+		class = class.asSymbol.asClass;
+		method = class.findMethod(method.asSymbol);
+		if(method.isNil) {
+			Error("Test method not found " + methodName).throw
+		};
+		class.new.runTestMethod(method);
+	}
+
+
 	// called before each test
 	setUp {}
 
 	// called after each test
 	tearDown {}
 
-	*run { | reset = true, report = true|
-		this.new.run(reset, report);
+	*run { | reset = true, report = true |
+		if(reset) { this.reset };
+		if(report) { ("RUNNING UNIT TEST" + this).inform };
+		this.forkIfNeeded {
+			this.runAllTestMethods;
+			if(report) { this.report };
+		};
 	}
 
 	// run all UnitTest subclasses
 	*runAll {
 		^this.forkIfNeeded {
 			this.reset;
-			this.allSubclasses.do ({ |testClass|
-				testClass.run(false,false);
+			this.allSubclasses.do { |testClass|
+				testClass.run(false, false);
 				0.1.wait;
-			});
-			this.report;
+			};
+			this.report
 		}
 	}
 
-	// run a single test in the name format "TestPolyPlayerPool:test_prepareChildrenToBundle"
-	*runTest { | methodName |
-		var class, method, unitTest;
-		# class, method = methodName.split($:);
-		class = class.asSymbol.asClass;
-		method.asSymbol;
-		method = class.findMethod(method.asSymbol);
-		if(method.isNil) { Error("Test method not found "+methodName).throw };
-		class.new.runTestMethod(method);
+	*runAllTestMethods {
+		this.forkIfNeeded {
+			this.findTestMethods.do { |method|
+				this.new.runTestMethod(method)
+			}
+		}
 	}
 
 	// run a single test method of this class
 	runTestMethod { | method |
-		var function;
 		("RUNNING UNIT TEST" + this.class.name ++ ":" ++ method.name).inform;
 		this.class.forkIfNeeded {
 			this.setUp;
@@ -67,62 +81,12 @@ UnitTest {
 			this.perform(method.name);
 			this.tearDown;
 			this.class.report;
-			nil
 		}
 	}
 
 	*gui {
-
-		// UnitTest GUI written by Dan Stowell 2009.
-		var w, classlist, methodlist, lookUp;
-
 		this.findTestClasses;
-
-		w = Window.new("[UnitTest GUI]", Rect(100, 100, 415, 615), resizable: false);
-		w.addFlowLayout;
-
-		StaticText(w, Rect(0,0, 400, 40))
-		.string_("Select a category, then a test method, and press Enter\nHit 'i' to jump to the code file")
-		.align_(\center);
-
-		classlist = ListView(w, Rect(0,0, 200, 600-40))
-		.items_(allTestClasses.asSortedArray.collect(_[0]))
-		.action_{|widg|
-			methodlist.items_(
-				allTestClasses.asSortedArray[widg.value][1].asSortedArray.collect(_[0])
-			)
-		};
-
-		methodlist = ListView(w, Rect(200,40, 200, 600-40));
-		methodlist.enterKeyAction_ {|widg|
-			allTestClasses.asSortedArray[classlist.value][1].asSortedArray[widg.value][1].value
-		};
-
-		lookUp = {|widg, char, mod|
-			var class, selector, method;
-			class = ("Test" ++ classlist.items[classlist.value]).asSymbol.asClass;
-			class !? {
-				selector = methodlist.items[methodlist.value].asSymbol;
-				method = class.findMethod(selector);
-				if(char == $i) {
-					if(method.notNil) { method.openCodeFile } { class.openCodeFile };
-				}
-			};
-
-		};
-
-		methodlist.keyDownAction = lookUp;
-		classlist.keyDownAction = lookUp;
-
-		classlist.enterKeyAction_{|widg|
-			// mimic behaviour of pressing enter in methodlist
-			methodlist.enterKey;
-		};
-
-		classlist.value_(0);
-		classlist.doAction; // fills in the right-hand column
-		^w.front;
-
+		^UnitTestGUI.new(this.allTestClasses)
 	}
 
 	///////////////////////////////////////////////////////////////////////
@@ -148,22 +112,21 @@ UnitTest {
 
 	assertFloatEquals { |a, b, message = "", within = 0.0001, report = true, onFailure|
 		var details =
-			"Is:\n\t" + a +
-			"\nShould equal (within range" + within ++ "):\n\t" + b;
+		"Is:\n\t" + a +
+		"\nShould equal (within range" + within ++ "):\n\t" + b;
 		this.assert((a - b).abs <= within, message, report, onFailure, details);
 	}
 
 	assertArrayFloatEquals { |a, b, message = "", within = 0.0001, report = true, onFailure|
-		// Check whether all in array meet the condition.
-		var results, startFrom;
-		a = a.asArray;
-		results = if(b.isArray) {
-			a.collect {|item, index| (item - b[index]).abs <= within }
-		}{
-			a.collect {|item, index| (item - b).abs <= within }
-		};
 
-		if(results.any(_ == false)) {
+		var results, startFrom, someHaveFailed;
+		a = a.asArray;
+
+		// Check whether all in array meet the condition.
+		results = (a - b).abs <= within;
+		someHaveFailed = results.includes(false);
+
+		if(someHaveFailed) {
 			startFrom = results.indexOf(false);
 			// Add failure details:
 			message = message ++
@@ -177,56 +140,60 @@ UnitTest {
 				a[startFrom..],
 				if(b.isArray) { b[startFrom..] } { b }
 			);
-			this.failed(currentMethod,message, report);
+			this.failed(currentMethod, message, report);
+
 			if(onFailure.notNil) {
 				{ onFailure.value }.defer;
 				Error("UnitTest halted with onFailure handler.").throw;
 			};
-			^false
-		}{
-			this.passed(currentMethod,message, report)
-			^true
+		} {
+			this.passed(currentMethod, message, report)
 		}
+		^someHaveFailed.not
 	}
 
 	// make a further assertion only if it passed, or only if it failed
 	ifAsserts { | boolean, message, ifPassedFunc, ifFailedFunc, report = true|
-		if(boolean.not,{
-			this.failed(currentMethod,message, report);
+		if(boolean.not) {
+			this.failed(currentMethod, message, report);
 			ifFailedFunc.value;
-		},{
+		} {
 			this.passed(currentMethod,message, report);
 			ifPassedFunc.value;
-		});
+		};
 		^boolean
 	}
 
 	// waits for condition with a maxTime limit
 	// if time expires, the test is a failure
 	wait { |condition, failureMessage, maxTime = 10.0|
-		var limit;
-		limit = maxTime / 0.05;
-		while({
+
+		var limit = maxTime / 0.05;
+
+		while {
 			condition.value.not and:
 			{(limit = limit - 1) > 0}
-		},{
+		} {
 			0.05.wait;
-		});
-		if(limit == 0 and: failureMessage.notNil,{
+		};
+
+		if(limit == 0 and: failureMessage.notNil) {
 			this.failed(currentMethod,failureMessage)
-		})
+		}
 	}
 
 	// wait is better
 	asynchAssert { |waitConditionBlock, testBlock, timeoutMessage = "", timeout = 10|
-		var limit;
-		limit = timeout / 0.1;
+
+		var limit = timeout / 0.1;
+
 		while {
 			waitConditionBlock.value.not and:
 			{ (limit = limit - 1) > 0 }
 		} {
 			0.1.wait;
 		};
+
 		if(limit == 0) {
 			this.failed(currentMethod,"Timeout:" + timeoutMessage)
 		} {
@@ -249,10 +216,11 @@ UnitTest {
 
 	// call failure directly
 	failed { | method, message, report = true, details |
-		var r;
-		r = UnitTestResult(this, method, message, details);
+
+		var r = UnitTestResult(this, method, message, details);
 		failures = failures.add(r);
-		if(report){
+
+		if(report) {
 			Post << Char.nl << "FAIL: ";
 			r.report;
 			Post << Char.nl;
@@ -261,10 +229,11 @@ UnitTest {
 
 	// call pass directly
 	passed { | method, message, report = true, details |
-		var r;
-		r = UnitTestResult(this, method, message, details);
+
+		var r = UnitTestResult(this, method, message, details);
 		passes = passes.add(r);
-		if(report && reportPasses) {
+
+		if(report and: { reportPasses }) {
 			Post << "PASS: ";
 			r.report(passVerbosity == brief);
 		};
@@ -313,90 +282,80 @@ UnitTest {
 	// private - use TestYourClass.run
 
 	run { | reset = true, report = true|
-		var function;
-		if(reset) { this.class.reset };
-		if(report) { ("RUNNING UNIT TEST" + this).inform };
-		this.class.forkIfNeeded {
-			this.findTestMethods.do { |method|
-				this.setUp;
-				currentMethod = method;
-				//{
-				this.perform(method.name);
-				// unfortunately this removes the interesting part of the call stack
-				//}.try({ |err|
-				//	("ERROR during test"+method).postln;
-				//	err.throw;
-				//});
-
-				this.tearDown;
-			};
-			if(report) { this.class.report };
-			nil
-		};
-
+		this.class.run
 	}
 
 	*forkIfNeeded { |function|
-		^if(thisThread.isKindOf(Routine)) {
-			// we are inside the Routine already
-			function.value
-		} {
-			Routine(function).play(AppClock)
-		}
+		function.forkIfNeeded(AppClock)
 	}
 
 	// returns the methods named test_
 	findTestMethods {
 		^this.class.findTestMethods
 	}
+
 	*findTestMethods {
-		^methods.select({ arg m;
-			m.name.asString.copyRange(0,4) == "test_"
-		})
+		^methods.select { |m|
+			m.name.asString.beginsWith("test_")
+		}
 	}
+
 	*classesWithTests { | package = 'Common'|
-		^Quarks.classesInPackage(package).select({ |c| UnitTest.findTestClass(c).notNil })
+		^Quarks.classesInPackage(package).select { |c|
+			UnitTest.findTestClass(c).notNil
+		}
 	}
+
 	*classesWithoutTests { |package = 'Common'|
-		^Quarks.classesInPackage(package).difference( UnitTest.classesWithTests(package) );
+		^Quarks.classesInPackage(package).difference(UnitTest.classesWithTests(package))
 	}
 
 	// whom I am testing
+	// removing "Test" by copyToEnd(4)
 	*findTestedClass {
 		^this.name.asString.copyToEnd(4).asSymbol.asClass
 	}
+
 	// methods in the tested class that do not have test_ methods written
 	*untestedMethods {
 		var testedClass,testMethods,testedMethods,untestedMethods;
 		testedClass = this.findTestedClass;
 		// what methods in the target class do not have tests written for them ?
 		testMethods = this.findTestMethods;
-		testedMethods = testMethods.collect({ |meth|
+		testedMethods = testMethods.collect { |meth|
 			testedClass.findMethod(meth.name.asString.copyToEnd(5).asSymbol)
-		}).reject(_.isNil);
-		if(testedMethods.isNil or: {testedMethods.isEmpty},{
-			untestedMethods = testedClass.methods;
-		},{
-			untestedMethods =
-			testedClass.methods.select({ |meth| testedMethods.includes(meth).not });
-		});
+		}.reject(_.isNil);
+
+		if(testedMethods.isNil or: { testedMethods.isEmpty }) {
+			untestedMethods = testedClass.methods
+		} {
+			untestedMethods = testedClass.methods.select { |meth|
+				testedMethods.includes(meth).not
+			}
+		};
+
 		// reject getters,setters, empty methods
-		untestedMethods = untestedMethods.reject({ |meth| meth.code.isNil });
+		untestedMethods = untestedMethods.reject { |meth| meth.code.isNil };
 		^untestedMethods
 	}
-	*listUntestedMethods { arg forClass;
-		this.findTestClass(forClass).untestedMethods.do({|m| m.name.postln })
+
+	*listUntestedMethods { | forClass |
+		this.findTestClass(forClass).untestedMethods.do {|m| m.name.postln }
 	}
+
 	// private
 	*reset {
 		failures = [];
 		passes = [];
 		routine.stop;
 	}
+
 	s {
 		^Server.default; // for convenient translation to/from example code
 	}
+
 }
+
 
 UnitTestResult {
 
@@ -501,7 +460,6 @@ UnitTestScript : UnitTest {
 			currentMethod = this;
 			path.load.value(this);
 			this.class.report;
-			nil
 		}
 	}
 

--- a/SCClassLibrary/Common/UnitTesting/UnitTest.sc
+++ b/SCClassLibrary/Common/UnitTesting/UnitTest.sc
@@ -106,19 +106,17 @@ UnitTest {
 	}
 
 	assertEquals { |a, b, message = "", report = true, onFailure |
-		var details = "Is:\n\t" + a + "\nShould be:\n\t" + b;
+		var details = "Is:\n\t % \nShould be:\n\t %".format(a, b);
 		this.assert(a == b, message, report, onFailure, details);
 	}
 
 	assertFloatEquals { |a, b, message = "", within = 0.0001, report = true, onFailure|
 		var details =
-		"Is:\n\t" + a +
-		"\nShould equal (within range" + within ++ "):\n\t" + b;
+		"Is:\n\t % \nShould equal (within range" + within ++ "):\n\t %".format(a, b);
 		this.assert((a - b).abs <= within, message, report, onFailure, details);
 	}
 
 	assertArrayFloatEquals { |a, b, message = "", within = 0.0001, report = true, onFailure|
-
 		var results, startFrom, someHaveFailed;
 		a = a.asArray;
 
@@ -167,7 +165,6 @@ UnitTest {
 	// waits for condition with a maxTime limit
 	// if time expires, the test is a failure
 	wait { |condition, failureMessage, maxTime = 10.0|
-
 		var limit = maxTime / 0.05;
 
 		while {
@@ -184,7 +181,6 @@ UnitTest {
 
 	// wait is better
 	asynchAssert { |waitConditionBlock, testBlock, timeoutMessage = "", timeout = 10|
-
 		var limit = timeout / 0.1;
 
 		while {
@@ -229,7 +225,6 @@ UnitTest {
 
 	// call pass directly
 	passed { | method, message, report = true, details |
-
 		var r = UnitTestResult(this, method, message, details);
 		passes = passes.add(r);
 

--- a/SCClassLibrary/Common/UnitTesting/UnitTest.sc
+++ b/SCClassLibrary/Common/UnitTesting/UnitTest.sc
@@ -277,7 +277,7 @@ UnitTest {
 	// private - use TestYourClass.run
 
 	run { | reset = true, report = true|
-		this.class.run
+		this.deprecated(thisMethod, this.class.findRespondingMethodFor(\run))
 	}
 
 	*forkIfNeeded { |function|

--- a/SCClassLibrary/Common/UnitTesting/UnitTestGUI.sc
+++ b/SCClassLibrary/Common/UnitTesting/UnitTestGUI.sc
@@ -1,0 +1,56 @@
+UnitTestGUI {
+
+
+	*new { |allTestClasses|
+
+		// UnitTest GUI written by Dan Stowell 2009.
+		var w, classlist, methodlist, lookUp;
+
+		w = Window.new("[UnitTest GUI]", Rect(100, 100, 415, 615), resizable: false);
+		w.addFlowLayout;
+
+		StaticText(w, Rect(0,0, 400, 40))
+		.string_("Select a category, then a test method, and press Enter\nHit 'i' to jump to the code file")
+		.align_(\center);
+
+		classlist = ListView(w, Rect(0,0, 200, 600-40))
+		.items_(allTestClasses.asSortedArray.collect(_[0]))
+		.action_{|widg|
+			methodlist.items_(
+				allTestClasses.asSortedArray[widg.value][1].asSortedArray.collect(_[0])
+			)
+		};
+
+		methodlist = ListView(w, Rect(200,40, 200, 600-40));
+		methodlist.enterKeyAction_ {|widg|
+			allTestClasses.asSortedArray[classlist.value][1].asSortedArray[widg.value][1].value
+		};
+
+		lookUp = {|widg, char, mod|
+			var class, selector, method;
+			class = ("Test" ++ classlist.items[classlist.value]).asSymbol.asClass;
+			class !? {
+				selector = methodlist.items[methodlist.value].asSymbol;
+				method = class.findMethod(selector);
+				if(char == $i) {
+					if(method.notNil) { method.openCodeFile } { class.openCodeFile };
+				}
+			};
+
+		};
+
+		methodlist.keyDownAction = lookUp;
+		classlist.keyDownAction = lookUp;
+
+		classlist.enterKeyAction_{|widg|
+			// mimic behaviour of pressing enter in methodlist
+			methodlist.enterKey;
+		};
+
+		classlist.value_(0);
+		classlist.doAction; // fills in the right-hand column
+		^w.front;
+
+	}
+
+}

--- a/testsuite/classlibrary/TestUnitTest.sc
+++ b/testsuite/classlibrary/TestUnitTest.sc
@@ -1,31 +1,40 @@
 
 TestUnitTest : UnitTest {
 
-	var someVar,toreDown,count = 0;
+	var someVar, setUp = false, toreDown = false;
 
 	setUp {
-		someVar = "setUp";
-		count = count + 1;
+		setUp = true;
 	}
+
 	tearDown {
-		someVar = "tearDown";
 		toreDown = true;
 	}
 
 	test_setUp {
-		this.assert( count == 1, "count should be on 1");
-		this.assert( someVar == "setUp", "someVar be set in setUp" );
+		this.assert( setUp, "setUp should have happened" )
 	}
-	test_toreDown{
+
+	/*test_toreDown {
 		this.assert( toreDown, "toreDown should be set at the end of the last test" );
 		this.assert( count == 2, "count should be on 2");
-	}
-	test_setUp2 {
-		this.assert( count == 3, "count should be on 3");
-	}
+	}*/
+
+
 	test_assert {
 		this.assert(true, "assert(true) should certainly work");
 	}
+
+	test_isolation_first {
+		this.assertEquals(someVar, nil, "methods in UnitTests should be isolated");
+		someVar = 2;
+	}
+
+	test_isolation_second {
+		this.assertEquals(someVar, nil, "methods in UnitTests should be isolated");
+		someVar = 2;
+	}
+
 /*
 	test_failure {
 		this.assert( false, "should fail")

--- a/testsuite/classlibrary/TestUnitTest.sc
+++ b/testsuite/classlibrary/TestUnitTest.sc
@@ -15,12 +15,6 @@ TestUnitTest : UnitTest {
 		this.assert( setUp, "setUp should have happened" )
 	}
 
-	/*test_toreDown {
-		this.assert( toreDown, "toreDown should be set at the end of the last test" );
-		this.assert( count == 2, "count should be on 2");
-	}*/
-
-
 	test_assert {
 		this.assert(true, "assert(true) should certainly work");
 	}
@@ -35,31 +29,9 @@ TestUnitTest : UnitTest {
 		someVar = 2;
 	}
 
-/*
-	test_failure {
-		this.assert( false, "should fail")
-	}
-*/
-
-/*	test_assertAsynch {
-		Server.default.boot;
-		this.assertAsynch( Server.default.serverRunning, {
-			this.assert( Server.default.serverRunning,"server is indeed running");
-			}, "assert asynch should have triggered the server to boot and then run the test block");
-	}
-*/
-
 	test_findTestedClass {
 		this.assertEquals( TestMixedBundleTester.findTestedClass, MixedBundleTester)
 	}
 
-
-
-
-	/*** IF YOU ADD MORE TESTS, UPDATE THE numTestMethods var ***/
-	// test_findTestMethods {
-	// 	var numTestMethods = 7;
-	// 	this.assert( this.findTestMethods.size == numTestMethods, "should be " + numTestMethods + " test methods");
-	// }
 }
 


### PR DESCRIPTION
This cleans up the `UnitTest` class and isolates the test methods by making an instance each.

This fixes #3572.