### PR TITLE
sclang: Print init/quit messages to stderr

### DIFF
--- a/lang/LangSource/SC_TerminalClient.cpp
+++ b/lang/LangSource/SC_TerminalClient.cpp
@@ -254,6 +254,7 @@ int SC_TerminalClient::run(int argc, char** argv)
 
 	opt.mArgc = argc;
 	opt.mArgv = argv;
+	gPostDest = stderr;
 
 	// read library configuration file
 	if (opt.mLibraryConfigFile)
@@ -270,6 +271,7 @@ int SC_TerminalClient::run(int argc, char** argv)
 
 	// startup library
 	compileLibrary(opt.mStandalone);
+	gPostDest = stdout;
 
 	// enter main loop
 	if (codeFile) executeFile(codeFile);
@@ -286,6 +288,7 @@ int SC_TerminalClient::run(int argc, char** argv)
 		cleanupInput();
 	}
 
+	gPostDest = stderr;
 	if (opt.mCallStop) stopMain();
 
 	// shutdown library


### PR DESCRIPTION
This is a hacky implementation of https://github.com/supercollider/supercollider/issues/3625#issuecomment-377962942. Instead of tracking down all instances of messages printed at init/quit time and replacing their calls to an equivalent printing to stderr, I just rebound the current destination with the same effect.

Hints how to do better are appreciated. There doesn't seem to be one way of printing information, otherwise I'd have created a variation of that printing to stderr and used it consistently.