### PR TITLE
filter OSC response based on bufnum

### DIFF
--- a/HelpSource/Classes/Buffer.schelp
+++ b/HelpSource/Classes/Buffer.schelp
@@ -834,7 +834,7 @@ x.free; b.free;
 method:: query
 Sends a b_query message to the server, asking for a description of this buffer. The results are posted to the post window. Does not update instance vars.
 argument:: action
-An optional Function to be evaluated which will be passed the buffer's information as argument. Providing a function here will bypass this method's normal behaviour. A description of the buffer will not be posted.
+An optional Function to be called with the query reply as an argument (code::[/b_info, bufnum, numFrames, numChannels, sampleRate]::). Providing a function here will bypass this method's normal behaviour. A description of the buffer will not be posted.
 method:: updateInfo
 Sends a b_query message to the server, asking for a description of this buffer. Upon reply this Buffer's instance variables are automatically updated.
 argument:: action

--- a/HelpSource/Classes/Buffer.schelp
+++ b/HelpSource/Classes/Buffer.schelp
@@ -833,7 +833,8 @@ x.free; b.free;
 
 method:: query
 Sends a b_query message to the server, asking for a description of this buffer. The results are posted to the post window. Does not update instance vars.
-
+argument:: action
+An optional Function to be evaluated which will be passed the buffer's information as argument. Providing a function here will bypass this method's normal behaviour. A description of the buffer will not be posted.
 method:: updateInfo
 Sends a b_query message to the server, asking for a description of this buffer. Upon reply this Buffer's instance variables are automatically updated.
 argument:: action

--- a/HelpSource/Classes/Buffer.schelp
+++ b/HelpSource/Classes/Buffer.schelp
@@ -834,7 +834,7 @@ x.free; b.free;
 method:: query
 Sends a b_query message to the server, asking for a description of this buffer. The results are posted to the post window. Does not update instance vars.
 argument:: action
-An optional Function to be called with the query reply as an argument (code::[/b_info, bufnum, numFrames, numChannels, sampleRate]::). Providing a function here will bypass this method's normal behaviour. A description of the buffer will not be posted.
+An optional Function to be called which takes the arguments code::msgType, bufnum, numFrames, numChannels, sampleRate::. Providing a function here will bypass this method's normal behaviour. A description of the buffer will not be posted.
 method:: updateInfo
 Sends a b_query message to the server, asking for a description of this buffer. Upon reply this Buffer's instance variables are automatically updated.
 argument:: action

--- a/HelpSource/Classes/Buffer.schelp
+++ b/HelpSource/Classes/Buffer.schelp
@@ -834,7 +834,7 @@ x.free; b.free;
 method:: query
 Sends a b_query message to the server, asking for a description of this buffer. The results are posted to the post window. Does not update instance vars.
 argument:: action
-An optional Function to be called which takes the arguments code::msgType, bufnum, numFrames, numChannels, sampleRate::. Providing a function here will bypass this method's normal behaviour. A description of the buffer will not be posted.
+An optional Function to be called which takes the arguments code::msgType, bufnum, numFrames, numChannels, sampleRate::. Providing a function here will bypass code::query::'s normal behaviour, i.e., the usual buffer information will not be posted.
 method:: updateInfo
 Sends a b_query message to the server, asking for a description of this buffer. Upon reply this Buffer's instance variables are automatically updated.
 argument:: action

--- a/SCClassLibrary/Common/Control/Buffer.sc
+++ b/SCClassLibrary/Common/Control/Buffer.sc
@@ -585,13 +585,17 @@ Buffer {
 		^[\b_close, bufnum, completionMessage.value(this) ]
 	}
 
-	query {
+	query { |action|
 		if(bufnum.isNil) { Error("Cannot call % on a % that has been freed".format(thisMethod.name, this.class.name)).throw };
-		OSCFunc({ arg msg;
-			Post << "bufnum   : " << msg[1] << Char.nl
-				<< "numFrames  : " << msg[2] << Char.nl
-				<< "numChannels : " << msg[3] << Char.nl
-				<< "sampleRate : " << msg[4] << Char.nl << Char.nl;
+		action = action ?? {
+			{ |addr, bufnum, numFrames, numChannels, sampleRate|
+				"bufnum: %\nnumFrames: %\nnumChannels: %\nsampleRate: %\n".format(
+					bufnum, numFrames, numChannels, sampleRate
+				).postln;
+			}
+		};
+		OSCFunc({ |msg|
+			action.valueArray(msg)
 		}, \b_info, server.addr, nil, [bufnum]).oneShot;
 		server.listSendMsg([\b_query, bufnum])
 	}

--- a/SCClassLibrary/Common/Control/Buffer.sc
+++ b/SCClassLibrary/Common/Control/Buffer.sc
@@ -592,7 +592,7 @@ Buffer {
 				<< "numFrames  : " << msg[2] << Char.nl
 				<< "numChannels : " << msg[3] << Char.nl
 				<< "sampleRate : " << msg[4] << Char.nl << Char.nl;
-		}, \b_info, server.addr).oneShot;
+		}, \b_info, server.addr, nil, [bufnum]).oneShot;
 		server.listSendMsg([\b_query, bufnum])
 	}
 

--- a/testsuite/classlibrary/TestQuery.sc
+++ b/testsuite/classlibrary/TestQuery.sc
@@ -4,7 +4,7 @@ TestQuery : UnitTest {
 
 	setUp {
 
-		server = Server.default;
+		server = Server(this.class.name);
 		this.bootServer(server);
 
 	}
@@ -12,7 +12,7 @@ TestQuery : UnitTest {
 	tearDown {
 
 		Buffer.freeAll;
-		server.quit;
+		server.quit.remove;
 
 	}
 

--- a/testsuite/classlibrary/TestQuery.sc
+++ b/testsuite/classlibrary/TestQuery.sc
@@ -24,20 +24,22 @@ TestQuery : UnitTest {
 		buffer.query({ |...args| responce = args });
 		server.sync;
 
-		this.assertEquals(responce, ['/b_info', 0, 512, 1, server.sampleRate], "Buffer.query should post correct info");
+		this.assertEquals(responce, ['/b_info', buffer.bufnum, 512, 1, server.sampleRate], "Buffer.query should post correct info");
 
 	}
 
 	test_multiBufferQuery {
 
-		var bufnums = Array(3);
+		var responces = Array(3);
 		var buffers = 3.collect { Buffer.alloc(server, 512) };
+		var bufnums;
 		server.sync;
 
-		buffers.do { |buf| buf.query({ |...args| bufnums.add(args[1]) }) };
+		bufnums = buffers.collect { |buf| buf.bufnum };
+		buffers.do { |buf| buf.query({ |...args| responces.add(args[1]) }) };
 		server.sync;
 
-		this.assertEquals(bufnums, [0, 1, 2], "All buffers must be queried");
+		this.assertEquals(responces, bufnums, "All buffers must be queried");
 
 	}
 

--- a/testsuite/classlibrary/TestQuery.sc
+++ b/testsuite/classlibrary/TestQuery.sc
@@ -39,7 +39,7 @@ TestQuery : UnitTest {
 		buffers.do { |buf| buf.query({ |...args| responces.add(args[1]) }) };
 		server.sync;
 
-		this.assertEquals(responces, bufnums, "All buffers must be queried");
+		this.assertEquals(responces, bufnums, "All requested buffers must be queried");
 
 	}
 

--- a/testsuite/classlibrary/TestQuery.sc
+++ b/testsuite/classlibrary/TestQuery.sc
@@ -1,0 +1,44 @@
+TestQuery : UnitTest {
+
+	var server;
+
+	setUp {
+
+		server = Server.default;
+		this.bootServer(server);
+
+	}
+
+	tearDown {
+
+		Buffer.freeAll;
+		server.quit;
+
+	}
+
+	test_bufferQuery {
+
+		var responce, buffer = Buffer.alloc(server, 512);
+		server.sync;
+
+		buffer.query({ |...args| responce = args });
+		server.sync;
+
+		this.assertEquals(responce, ['/b_info', 0, 512, 1, server.sampleRate], "Buffer.query should post correct info");
+
+	}
+
+	test_multiBufferQuery {
+
+		var bufnums = Array(3);
+		var buffers = 3.collect { Buffer.alloc(server, 512) };
+		server.sync;
+
+		buffers.do { |buf| buf.query({ |...args| bufnums.add(args[1]) }) };
+		server.sync;
+
+		this.assertEquals(bufnums, [0, 1, 2], "All buffers must be queried");
+
+	}
+
+}

--- a/testsuite/classlibrary/TestQuery.sc
+++ b/testsuite/classlibrary/TestQuery.sc
@@ -18,28 +18,28 @@ TestQuery : UnitTest {
 
 	test_bufferQuery {
 
-		var responce, buffer = Buffer.alloc(server, 512);
+		var response, buffer = Buffer.alloc(server, 512);
 		server.sync;
 
-		buffer.query({ |...args| responce = args });
+		buffer.query({ |...args| response = args });
 		server.sync;
 
-		this.assertEquals(responce, ['/b_info', buffer.bufnum, 512, 1, server.sampleRate], "Buffer.query should post correct info");
+		this.assertEquals(response, ['/b_info', buffer.bufnum, 512, 1, server.sampleRate], "Buffer.query should post correct info");
 
 	}
 
 	test_multiBufferQuery {
 
-		var responces = Array(3);
+		var responses = Array(3);
 		var buffers = 3.collect { Buffer.alloc(server, 512) };
 		var bufnums;
 		server.sync;
 
 		bufnums = buffers.collect { |buf| buf.bufnum };
-		buffers.do { |buf| buf.query({ |...args| responces.add(args[1]) }) };
+		buffers.do { |buf| buf.query({ |...args| responses.add(args[1]) }) };
 		server.sync;
 
-		this.assertEquals(responces, bufnums, "All requested buffers must be queried");
+		this.assertEquals(responses, bufnums, "All requested buffers must be queried");
 
 	}
 


### PR DESCRIPTION
Fixes #3611 

Use **argTemplate** to filter query responses based on the Buffer's bufnum. This needs a UnitTest. I can write try and write one later. I've opted to based this on `develop` since `3.9.3` is set for tomorrow. We can always cherry-pick this into `3.9` if we want.