### PR TITLE
[IDE] Fix detached docklet visibility bug

### DIFF
--- a/editors/sc-ide/widgets/util/docklet.hpp
+++ b/editors/sc-ide/widgets/util/docklet.hpp
@@ -74,7 +74,7 @@ public:
         return const_cast<Docklet*>(this)->currentContainer() != mDockWidget;
     }
 
-    void setDetached( bool detached );
+    void setDetachedAndVisible( bool detached, bool visible );
 
     bool isVisible() const
     {


### PR DESCRIPTION
Fix #3287 

This fixes what seems to be a weird race condition: when starting the IDE, a detached (and closed) docklet container can be raised just after it has been hidden, leading into a *ghost* unresponsive window (see linked issue).

I'm not sure this is the most elegant fix so I'm open to any hint if this needs to be done differently.

cc @jamshark70 