### PR TITLE
Help: FFT-Overview: Replace auto-pvcopy example, and explain

### DIFF
--- a/HelpSource/Guides/FFT-Overview.schelp
+++ b/HelpSource/Guides/FFT-Overview.schelp
@@ -58,7 +58,7 @@ See link::#PV and FFT UGens in the Standard Library:: for a list of UGens.
 
 code::
 (
-{ 
+{
   var in, chain;
 	in = WhiteNoise.ar(0.8);
 	chain = FFT(LocalBuf(2048), in); // encode to frequency domain
@@ -72,7 +72,7 @@ In order to expand PV UGens for a multichannel input signal, an appropriate arra
 
 code::
 (
-{ 
+{
   var in, chain;
 	in = Ringz.ar(Impulse.ar([2, 3]), [700, 800], 0.1) * 5; // stereo input
 	chain = FFT({ LocalBuf(2048) } ! 2, in); // array of two local buffers
@@ -90,7 +90,7 @@ PV Ugens write their output data emphasis:: in place ::, i.e. back into the same
 code::
 
 (
-{ 
+{
   var inA, chainA, inB, chainB, chain;
 	inA = LFSaw.ar(MouseY.kr(100, 1000, 1), 0, 0.2);
 	inB = Ringz.ar(Impulse.ar(MouseX.kr(1, 100, 1)), 700, 0.5);
@@ -112,7 +112,7 @@ code::
 d = Buffer.read(s, Platform.resourceDir +/+ "sounds/a11wlk01.wav");
 
 (
-{ 
+{
   var inA, chainA, inB, chainB, chain;
 	inA = LFSaw.ar(100, 0, 0.2);
 	inB = PlayBuf.ar(1, d, BufRateScale.kr(d), loop: 1);
@@ -153,27 +153,19 @@ code::
 )
 ::
 
-PV processes can also share a single FFT ugen to process a signal in parallel. In the following example, 'chain0' and 'chain1' share the same FFT ugen. SuperCollider automatically copies the FFT data from 'chain' into hidden LocalBufs inside the Synth. The processes thus operate independently on the original FFT analysis:
+PV processes can also share a single FFT ugen to process a signal in parallel. In the following example, 'chain0' and 'chain1' share the same FFT ugen. SuperCollider automatically copies the FFT data from 'chain' into hidden LocalBufs inside the Synth. In the following example, if the link::Classes/PV_PhaseShift:: UGen were operating directly on code::chainA::, then the two link::Classes/IFFT:: units would produce the same signal, which, when added together, would reinforce each other. Instead, the sound is nearly silent -- proving that code::chainB:: is in a different buffer, even though the function does not explicitly create it.
 
 code::
-
-// now, this can be written without the copy:
-
 (
-{
-	var in, in2, chainA, chainB;
-	var mod = LFNoise2.kr(2);
-	in = Blip.ar(mod.exprange(4000, 2), 231);
-	in2 = SinOsc.ar(mod.exprange(200, 4000));
-	chainA = FFT(LocalBuf(2048), in);
-	chainB = FFT(LocalBuf(2048), in2);
-	chainB = PV_MagMul(chainA, chainB);
-	XFade2.ar(
-		IFFT(chainA) * 0.4,
-		IFFT(chainB) * 0.1,
-		MouseX.kr(-1, 1)
-	);
-}.play
+x = { var inA, chainA, chainB;
+	inA = LFClipNoise.ar(100);
+	chainA = FFT(LocalBuf(2048, 1), inA);
+	chainB = PV_PhaseShift(chainA, pi);
+	// half-circle phase shift should result in an inverse signal
+	// in practice, ultra-low frequencies sneak through
+	// but you won't hear very much here
+	IFFT(chainA) + IFFT(chainB);
+}.play;
 )
 ::
 
@@ -202,7 +194,7 @@ Routine({
 			// Initially data is in complex form
 			z = [Signal.newFrom(z[0]), Signal.newFrom(z[1])];
 			x = Complex(z[0], z[1]);
-			
+
 			{ x.magnitude.plot('Initial', Rect(200, 600-(200*i), 700, 200)) }.defer
 		});
 		0.1.wait;


### PR DESCRIPTION
At some point, the PV_Copy example was incorrectly copy/pasted from another example. Here's a new example that demonstrates conclusively that PV_Copy is added automatically (and which would fail if PV_Copy weren't there).