### PR TITLE
Unit tests for "EnvGen not started" pull request

### DIFF
--- a/server/plugins/LFUGens.cpp
+++ b/server/plugins/LFUGens.cpp
@@ -2817,7 +2817,7 @@ static inline bool check_gate_ar(EnvGen * unit, int i, float & prevGate, float *
 
 static inline bool EnvGen_nextSegment(EnvGen * unit, int & counter, double & level)
 {
-	//if (unit->m_stage == ENVGEN_NOT_STARTED) { return true; } // this fixes doneAction 14, but breaks with EnvGen_next_aa
+	if (unit->m_stage == ENVGEN_NOT_STARTED) { counter = INT_MAX; return true; } 
 
 	//Print("stage %d rel %d\n", unit->m_stage, (int)ZIN0(kEnvGen_releaseNode));
 	int numstages = (int)ZIN0(kEnvGen_numStages);

--- a/testsuite/classlibrary/TestEnv.sc
+++ b/testsuite/classlibrary/TestEnv.sc
@@ -3,6 +3,7 @@ Env.test
 UnitTest.gui
 */
 TestEnv : UnitTest {
+	var server;
 
 	test_equality {
 		var a,b,c;
@@ -24,6 +25,93 @@ TestEnv : UnitTest {
 			Env.cutoff(1, 1, 'exp').asSignal(20).as(Array),
 			Env.cutoff(1, 1, 'lin').asSignal(20).asArray.linexp(0,1,-100.dbamp,1),
 			"Exponential Env.cutoff should be same as linear Env.cutoff.linexp");
+	}
+
+	setUp {
+		server = Server(this.class.name);
+	}
+
+	tearDown {
+		server.remove;
+	}
+
+	test_noff_bug334 {
+		var synth, n_off_resp, n_end_resp, passed,
+		cond = Condition.new,
+		cleanup = {
+			n_off_resp.free;
+			n_end_resp.free;
+			server.quit;
+		};
+		this.bootServer(server);
+		synth = {
+			// doneAction: 1 should reach end *after* doneAction: 2 envelope ends
+			// correct behavior is that '/n_off' is never sent
+			EnvGen.kr(Env([0, 1], [0.2]), gate: 0, doneAction: 1);
+			EnvGen.kr(Env([0, 1], [0.1]), doneAction: 2);
+		}.play(server);
+		n_off_resp = OSCFunc({
+			cleanup.value;
+			passed = false;
+			cond.unhang;
+		}, '/n_off', server.addr, argTemplate: [synth.nodeID]);
+		// responsible for cleaning up this test
+		// n_off_resp should NOT fire! so we need another for the stop condition
+		n_end_resp = OSCFunc({
+			cleanup.value;
+			passed = true;
+			cond.unhang;
+		}, '/n_end', server.addr, argTemplate: [synth.nodeID]);
+		cond.hang;
+		this.assert(passed, "EnvGen: Initial gate == 0 with doneAction == 1 should not send /n_off");
+	}
+
+	// has failed in supernova
+	// methodology: synth should play for 0.1 sec if it's working
+	// so we will send a trigger just before the envelope ends
+	// if the bug occurs, the synth will end almost immediately -- no trigger
+	test_nongated_bug3094 {
+		var n_end_resp, tr_resp, synth,
+		program = [\scsynth], failure,
+		cleanup = {
+			tr_resp.free;
+			n_end_resp.free;
+			server.quit;
+			Server.scsynth;
+		},
+		cond = Condition.new;
+		// we need to test supernova.
+		// In unixy systems, we can try to get the executable path
+		// Windows, I don't know
+		if(thisProcess.platform.name != "windows" and: {
+			"which supernova".unixCmdGetStdOut.size > 0
+		}) {
+			program = program ++ [\supernova];
+		};
+		program.do { |p|
+			var gotTrigger = false;
+			Server.perform(p);
+			this.bootServer(server);
+			synth = {
+				var gate = Impulse.kr(0);
+				SendTrig.kr(TDelay.kr(gate, 0.09), 0, 1);
+				EnvGen.kr(Env([0, 1], [0.1]), gate, doneAction: 2);
+			}.play(server);
+			tr_resp = OSCFunc({ |msg|
+				gotTrigger = true;
+			}, '/tr', server.addr, argTemplate: [synth.nodeID]);
+			n_end_resp = OSCFunc({ |msg|
+				cleanup.value;
+				cond.unhang;
+			}, '/n_end', server.addr, argTemplate: [synth.nodeID]);
+			cond.hang;
+			if(gotTrigger.not) { failure = failure.add(p) };
+		};
+		this.assert(failure.size == 0, "EnvGen: Closing gate should not affect non-gated envelope %".format(
+			if(failure.size == 0) { "" } {
+				"(failed in %)".format(failure)
+			}
+		));
 	}
 
 	/*


### PR DESCRIPTION
Here are unit tests for bugs #334 and #3094 (fixed by #3671) -- this PR also includes the changes from 3671. I think if you merge 3671 first, the commit history should be clean. (I had to do it this way because my develop branch is newer than the one in sonoro's fork.)

One question about unit test protocol -- #3094 was not a bug in scsynth, only in supernova. So, to test it properly, I have to use a supernova executable, which assumes that the user has installed supernova. I ended up with this, but I'm not sure it's the best way:

- Windows: No time today to figure out how to check the existence of an executable. Run for scsynth only.

- Unixy platforms: `"which supernova".unixCmdGetStdOut.size > 0` -- if the executable doesn't exist, then stdout returns an empty string.

If it finds supernova, it will try both executables, and the result of the test is `&&`. If it doesn't, then it will try only scsynth.

BTW is there any way to make UnitTest authoring easier? This was literally ~1h 30m~ 1h 40m for 2 tests... I won't have time to do this again for awhile.