### PR TITLE
QtGUI: Remove scroll wheel check for scrollbars in Windows and Linux

### DIFF
--- a/QtCollider/style/ProxyStyle.cpp
+++ b/QtCollider/style/ProxyStyle.cpp
@@ -18,13 +18,13 @@ static bool AlwaysShowScrollbars() {
   return QtCollider::Mac::AlwaysShowScrollbars();
 
 #elif defined(Q_OS_X11)
-  return !QcApplication::SystemHasMouseWheel();
+  return true;
 
 #elif defined(Q_OS_WIN)
-  return !QcApplication::SystemHasMouseWheel();
+  return true;
 
 #else
-  return !QcApplication::SystemHasMouseWheel();
+  return true;
 #endif
 };
 


### PR DESCRIPTION
Temporary workaround for issue #3552.

Automatically-faded scroll bars do not work well in Linux or Windows. Unfortunately, if the user touches the scroll wheel, then scroll bars start to fade out and become unreachable.

Under issue #3552, we were discussing research into Linux and Windows system preferences for fading scrollbars, and per-view control. That's an extensive enhancement request.

In the meantime, I was recently in the position of trying to explain to a classroom of students why the scrollbars disappear if you touch the scroll wheel, but not before. Let's just say that the rationale for the current behavior was met with universal incomprehension.

Currently, we have a situation that simply doesn't make sense to typical users in Windows and Linux. So, at the very least, for 3.10, it would be a measurable improvement just to get rid of that logic. It doesn't close the other issue, but at least it would change the behavior to something explainable.