### PR TITLE
Update to non-expiring slack invite

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Welcome to SuperCollider!
 =========================
 
-[![Build Status](https://travis-ci.org/supercollider/supercollider.svg?branch=master)](https://travis-ci.org/supercollider/supercollider) [![Appveyor](https://ci.appveyor.com/api/projects/status/github/supercollider/supercollider?branch=develop&svg=true)](https://ci.appveyor.com/project/brianlheim/supercollider-mu8dk) | [Join us on Slack](https://join.slack.com/t/scsynth/shared_invite/enQtMzEwODExNDU3NzMzLWIyYjRmMzcwZjlhYmIwNjBjYzZjZDViZjI1ZGRkZWJlNzMwODA5ZTEwMGU5MTM2MDAxZDkyMzMxYzRkMTQ0YzE)
+[![Build Status](https://travis-ci.org/supercollider/supercollider.svg?branch=master)](https://travis-ci.org/supercollider/supercollider) [![Appveyor](https://ci.appveyor.com/api/projects/status/github/supercollider/supercollider?branch=develop&svg=true)](https://ci.appveyor.com/project/brianlheim/supercollider-mu8dk) | [Join us on Slack](https://slackin-apxbmqnfui.now.sh)
 
 **SuperCollider** is a platform for audio synthesis and algorithmic composition, used by musicians, artists, and researchers working with sound. It is free and open source software available for Windows, macOS, and Linux.
 


### PR DESCRIPTION
I see that there was recently (#3647) an update to the slack invite link. Perhaps changing to this link (that's been around for [8 months or so](http://new-supercollider-mailing-lists-forums-use-these.2681727.n2.nabble.com/switch-to-Slack-td7634241.html)) would help the churn. Downside is it is a 3rd party service, not an official Slack page.

cc @brianlheim