### PR TITLE
[docs] - supercollider/supercollider/helpsource/classes/sinosc.schelp - adding a small example

### DIFF
--- a/HelpSource/Classes/SinOsc.schelp
+++ b/HelpSource/Classes/SinOsc.schelp
@@ -75,7 +75,7 @@ code::
         ]
     });
 
-    Out.ar(0, GVerb.ar(mix * Blip.kr(rrand(0.01, 0.1)), rrand(1, 300), rrand(1, 30), 0.55, 0.51, 15, -24, -46, -40, mul:0.03));
+    Out.ar(0, GVerb.ar(mix * Blip.kr(rrand(0.01, 0.1)), rrand(1, 300), rrand(1, 30), 0.55, 0.51, 15, -24, -46, -40, mul:0.006));
 }.scope;
 )
 

--- a/HelpSource/Classes/SinOsc.schelp
+++ b/HelpSource/Classes/SinOsc.schelp
@@ -60,22 +60,22 @@ code::
 
 (
 {
-    var freqs, mix;
+    var freqs, mix, reverbChain;
     freqs = [34, 46, 52, 56, 59, 63, 64, 72, 86, 98].midicps;
 
-    mix = 0.25 * Mix.arFill(freqs.size, {|i|
-        var freq;
-        freq = freqs[i];
+    mix = 0.125 * 0.25 * Mix(freqs.collect { |freq|
         [
             SinOsc.ar(freq, rrand(0,1.5), SinOsc.kr(rrand(0.01, 0.333)))
-            + Pulse.ar(freq,                    width:rrand(0, 1.5), mul:SinOsc.kr(rrand(0.01, 0.333)))
+            + Pulse.ar(freq, width:rrand(0, 1.5), mul:SinOsc.kr(rrand(0.01, 0.333)))
         ,
             SinOsc.ar(freq, rrand(0,1.5), SinOsc.kr(rrand(0.01, 0.333)))
             + Pulse.ar(freq + rrand(-1.0, 1.0), width:rrand(0, 1.5), mul:SinOsc.kr(rrand(0.01, 0.333)))
         ]
     });
 
-    Out.ar(0, GVerb.ar(mix * Blip.kr(rrand(0.01, 0.1)), rrand(1, 300), rrand(1, 30), 0.55, 0.51, 15, -24, -46, -40, mul:0.006));
+    reverbChain = GVerb.ar(mix * Blip.kr(rrand(0.01, 0.1)), rrand(1, 300), rrand(1, 30), 0.55, 0.51, 15, -24, -46, -40, mul:0.06);
+	
+	Limiter.ar(LeakDC.ar(reverbChain));	
 }.scope;
 )
 

--- a/HelpSource/Classes/SinOsc.schelp
+++ b/HelpSource/Classes/SinOsc.schelp
@@ -3,7 +3,6 @@ summary:: Interpolating sine wavetable oscillator.
 related:: Classes/Osc, Classes/FSinOsc, Classes/SinOscFB, Classes/PMOsc, Classes/Klang
 categories::  UGens>Generators>Deterministic
 
-
 Description::
 
 Generates a sine wave.
@@ -20,7 +19,6 @@ LIST::
 ## link::Classes/Klang:: – bank of sinewave oscillators
 ## link::Classes/DynKlang:: – modulable bank of sinewave oscillators
 ::
-
 
 classmethods::
 
@@ -41,7 +39,6 @@ Output will be multiplied by this value.
 argument::add
 This value will be added to the output.
 
-
 Examples::
 
 code::
@@ -59,5 +56,27 @@ code::
 // phase modulation (see also PMOsc)
 { SinOsc.ar(800, SinOsc.ar(XLine.kr(1, 1000, 9), 0, 2pi), 0.25) }.play;
 
-::
+// more complex example
 
+(
+{
+    var freqs, mix;
+    freqs = [56, 59, 63, 64, 72, 84].midicps;
+
+    mix = 0.25 * Mix.arFill(freqs.size, {|i|
+        var freq;
+        freq = freqs[i];
+        [
+            SinOsc.ar(freq, rrand(0,1.5), SinOsc.kr(rrand(0.01, 0.333)))
+            + Pulse.ar(freq,                    width:rrand(0, 1.5), mul:SinOsc.kr(rrand(0.01, 0.333)))
+        ,
+            SinOsc.ar(freq, rrand(0,1.5), SinOsc.kr(rrand(0.01, 0.333)))
+            + Pulse.ar(freq + rrand(-1.0, 1.0), width:rrand(0, 1.5), mul:SinOsc.kr(rrand(0.01, 0.333)))
+        ]
+    });
+
+    Out.ar(0, GVerb.ar(mix * Blip.kr(rrand(0.01, 0.1)), rrand(1, 300), rrand(1, 30), 0.55, 0.51, 15, -24, -46, -40, mul:0.03));
+}.scope;
+)
+
+::

--- a/HelpSource/Classes/SinOsc.schelp
+++ b/HelpSource/Classes/SinOsc.schelp
@@ -61,7 +61,7 @@ code::
 (
 {
     var freqs, mix;
-    freqs = [56, 59, 63, 64, 72, 84].midicps;
+    freqs = [34, 46, 52, 56, 59, 63, 64, 72, 86, 98].midicps;
 
     mix = 0.25 * Mix.arFill(freqs.size, {|i|
         var freq;


### PR DESCRIPTION
[docs] - supercollider/supercollider/helpsource/classes/sinosc.schelp - adding a small example

I've been most recently avoiding: 

- adding up examples of mine on supercollider documentation

the main reason fo that:

- supercollider documentation has been stabilized for already some time
- it's more worthy to improve it's overall quality, by adding in grammar checks, etc.

even though:

- I wrote this code example yesterday
- someone took the effort of reviewing it (lfnoise reddit user)
- i decided it could be a good pick to commit it

thank you so much