### PR TITLE
classlib: patch String:+/+

### DIFF
--- a/HelpSource/Classes/String.schelp
+++ b/HelpSource/Classes/String.schelp
@@ -283,16 +283,18 @@ system. The strings are joined to avoid duplicate path separators.
 If code::this:: ends with a path separator and code::path:: begins with one, then the separator
 in code::path:: is dropped. If there is a path separator on either side, this has the same effect as
 using code::++::. If neither side has a path separator, the platform's preferred separator
-(code::\\:: on Windows, code::/:: otherwise) is added.
+('\' on Windows, '/' otherwise) is added.
 
-If code::path:: is a link::Classes/PathName::, the result will be a PathName.
+Returns code::this:: and code::path:: concatenated. If code::path:: was a PathName, the result is a
+PathName; otherwise, it is a String.
 
 argument::path
 
-Either a String or link::Classes/PathName::.
+Any object that can be converted to a string. Typically, either a String, link::Classes/Symbol::, or
+link::Classes/PathName::.
 
 code::
-// On Windows, this produces "foo\\\\bar"; on other platforms, "foo/bar"
+// On Windows, this produces "foo\\bar"; on other platforms, "foo/bar"
 "foo" +/+ "bar"
 
 // On all platforms, this produces "foo/bar": +/+ prefers using an existing separator
@@ -300,8 +302,11 @@ code::
 "foo" +/+ "/bar"
 "foo/" +/+ "/bar"
 
-// On Windows, this produces "foo\\\\bar"; on other platforms, "foo/\\\\bar"
-"foo" +/+ "\\\\bar"
+// On Windows, this produces "foo\\bar"; on other platforms, "foo/\\bar"
+"foo" +/+ "\\bar"
+
+// Concatenating a symbol is also OK
+"foo" +/+ 'bar'
 ::
 
 method::catArgs

--- a/SCClassLibrary/Common/Collections/String.sc
+++ b/SCClassLibrary/Common/Collections/String.sc
@@ -449,6 +449,8 @@ String[char] : RawArray {
 			^PathName(this +/+ path.fullPath)
 		};
 
+		// convert to string before concatenation.
+		path = path.asString;
 		hasLeftSep = this.notEmpty and: { this.last.isPathSeparator };
 		hasRightSep = path.notEmpty and: { path.first.isPathSeparator };
 		if(hasLeftSep && hasRightSep) {

--- a/testsuite/classlibrary/TestString.sc
+++ b/testsuite/classlibrary/TestString.sc
@@ -88,5 +88,11 @@ TestString : UnitTest {
 		this.assertEquals(result.fullPath, expected.fullPath);
 	}
 
+	// should work with symbols too for backward compatibility
+	test_appendPathSep_stringWithSymbol_producesString {
+		var sep = thisProcess.platform.pathSeparator.asString;
+		this.assertEquals("dir" +/+ 'file', "dir%file".format(sep));
+	}
+
 }
 


### PR DESCRIPTION
after #3634, +/+ would fail if the RHS was a symbol.

+/+ now converts the RHS to a string (unless it was a PathName) before
attempting to concatenate it.

Fixes #3699.