### PR TITLE
Add action argument to Node.query

### DIFF
--- a/HelpSource/Classes/Node.schelp
+++ b/HelpSource/Classes/Node.schelp
@@ -193,6 +193,8 @@ x.release(5); // override the Env's specified 1 second release time
 
 method:: query
 Sends an n_query message to the server, which will reply with a message containing information about this node and its place in the server's node tree.
+argument:: action
+An optional Function to be called. If the node is a code::Synth::, the function will take the arguments code::serverCmd, nodeID, parent, prev, next, isGroup::. If the node is a code::Group::, the function will take the arguments code::serverCmd, nodeID, parent, prev, next, isGroup, head, tail::. Providing a function here will bypass code::query::'s normal behaviour, i.e., the usual node information will not be posted.
 discussion::
 This information will be printed to the post window. (See also the queryAllNodes method of Server.) "parent" indicates the Node's enclosing group. If "prev" or "next" are equal to -1 that indicates that there are no other nodes in the enclosing group before or after this one, respectively.
 code::

--- a/SCClassLibrary/Common/Control/Node.sc
+++ b/SCClassLibrary/Common/Control/Node.sc
@@ -141,23 +141,21 @@ Node {
 		server.sendMsg(10, nodeID);//"/n_trace"
 	}
 
-	query {
-		OSCFunc({ arg msg;
-			var cmd, argnodeID, parent, prev, next, isGroup, head, tail;
-			# cmd, argnodeID, parent, prev, next, isGroup, head, tail = msg;
-			// assuming its me ... if(nodeID == argnodeID)
-			Post
-				<< if(isGroup == 1, "Group:\t" , "Synth:\t") << nodeID << Char.nl
-				<< "parent:\t" << parent << Char.nl
-				<< "prev:\t" << prev << Char.nl
-				<< "next:\t" << next << Char.nl;
-			if(isGroup == 1) {
-				Post
-					<< "head:\t" << head << Char.nl
-					<< "tail:\t" << tail << Char.nl << Char.nl;
-			};
-		}, '/n_info', server.addr).oneShot;
-		server.sendMsg(46, nodeID) //"/n_query"
+	query { |action|
+		action = action ?? {
+			{ |cmd, argnodeID, parent, prev, next, isGroup, head, tail|
+				var group = isGroup == 1;
+				(
+					if(group, "Group: ", "Synth: ") ++ "%\nParent: %\nPrev: %\nNext: %\n" ++ if(group, "Head: %\nTail: %\n\n", "\n")
+				).format(
+					argnodeID, parent, prev, next, head, tail
+				).postln
+			}
+		};
+		OSCFunc({ |msg|
+			action.valueArray(msg)
+		}, '/n_info', server.addr, nil, [nodeID]).oneShot;
+		server.sendMsg('/n_query', nodeID)
 	}
 
 	register { arg assumePlaying = false;

--- a/testsuite/classlibrary/TestQuery.sc
+++ b/testsuite/classlibrary/TestQuery.sc
@@ -78,7 +78,7 @@ TestQuery : UnitTest {
 		nodes.do { |node| node.query({ |...args| responses.add(args[1]) }) };
 		server.sync;
 
-		this.assertEquals(responses, nodeIDs, "All requested buffers must be queried");
+		this.assertEquals(responses, nodeIDs, "All requested nodes must be queried");
 
 	}
 

--- a/testsuite/classlibrary/TestQuery.sc
+++ b/testsuite/classlibrary/TestQuery.sc
@@ -43,4 +43,43 @@ TestQuery : UnitTest {
 
 	}
 
+	test_synthQuery {
+
+		var response, synth = Synth(\default, target:server);
+		server.sync;
+
+		synth.query({ |...args| response = args });
+		server.sync;
+
+		this.assertEquals(response, ['/n_info', synth.nodeID, server.defaultGroupID, -1, -1, 0], "Synth.query should post correct info");
+
+	}
+
+	test_groupQuery {
+
+		var response, group = Group(server);
+		server.sync;
+
+		group.query({ |...args| response = args });
+		server.sync;
+
+		this.assertEquals(response, ['/n_info', group.nodeID, server.defaultGroupID, -1, -1, 1, -1, -1], "Group.query should post correct info");
+
+	}
+
+	test_multiNodeQuery {
+
+		var responses = Array(4);
+		var nodes = 4.collect { |i| if (i%2 == 0) { Synth(\default, target:server) } { Group(server) } };
+		var nodeIDs;
+		server.sync;
+
+		nodeIDs = nodes.collect { |node| node.nodeID };
+		nodes.do { |node| node.query({ |...args| responses.add(args[1]) }) };
+		server.sync;
+
+		this.assertEquals(responses, nodeIDs, "All requested buffers must be queried");
+
+	}
+
 }


### PR DESCRIPTION
This PR is a companion to #3645. `Node.query` now takes an action function as argument. It's OSCFunc also filters requests based on `nodeID`.

The UnitTests were added to `TestQuery`. There's a lot of duplication in the tests. I'm not certain whether it is best to write them in this way, or to combine some of them into fewer test methods.