### PR TITLE
SoundFile: add basic UnitTest, and small OSCFunc fix

### DIFF
--- a/SCClassLibrary/Common/Files/SoundFile.sc
+++ b/SCClassLibrary/Common/Files/SoundFile.sc
@@ -437,7 +437,7 @@ SoundFile {
 					OSCFunc({
 						server.sendBundle(server.latency, ["/b_close", ev[\bufnum]],
 							["/b_read", ev[\bufnum], path, ev[\firstFrame], ev[\bufferSize], 0, 1]);
-					}, "/n_end", server.addr, nil, ev[\id][0]).oneShot;
+					}, "/n_end", server.addr, nil, ev[\id]).oneShot;
 				};
 				if (playNow) {
 					packet = server.makeBundle(false, {ev.play})[0];

--- a/testsuite/classlibrary/TestSoundFile.sc
+++ b/testsuite/classlibrary/TestSoundFile.sc
@@ -13,18 +13,13 @@ TestSoundFile : UnitTest {
 			(\sampleFormat -> "int16"),
 			(\headerFormat -> "WAV")
 		];
-
-		server = Server(this.class.name);
-		this.bootServer(server);
-
 		soundFile = SoundFile(path);
 
 	}
 
 	tearDown {
 
-		if (soundFile.isOpen) { soundFile.close };
-		server.quit.remove;
+		soundFile.close;
 
 	}
 

--- a/testsuite/classlibrary/TestSoundFile.sc
+++ b/testsuite/classlibrary/TestSoundFile.sc
@@ -1,0 +1,63 @@
+TestSoundFile : UnitTest {
+
+	var server, soundFile, path, info;
+
+	setUp {
+
+		path = Platform.resourceDir +/+ "sounds/a11wlk01.wav";
+		info = IdentityDictionary[
+			(\numFrames -> 188893),
+			(\numChannels -> 1),
+			(\path -> path),
+			(\sampleRate -> 44100),
+			(\sampleFormat -> "int16"),
+			(\headerFormat -> "WAV")
+		];
+
+		server = Server(this.class.name);
+		this.bootServer(server);
+		
+		soundFile = SoundFile(path);
+		server.sync;
+		
+	}
+
+	tearDown {
+
+		if (soundFile.isOpen) { soundFile.close };
+		server.quit.remove;
+
+	}
+
+	test_isOpen {
+
+		soundFile.openRead;
+		server.sync;
+
+		this.assert(soundFile.isOpen, "SoundFile should now be opened");
+
+		soundFile.close;
+		server.sync;
+
+		this.assert(soundFile.isOpen.not, "SoundFile should now be closed");
+
+	}
+
+	test_instVars {
+
+		var instVars;
+
+		soundFile.openRead;
+		server.sync;
+
+		this.assert(soundFile.fileptr.notNil, "SoundFile pointer should not be Nil after opening");
+
+		// collect all instance variables into a Dictionary, remove problematic 'fileptr'
+		instVars = soundFile.getSlots.asDict;
+		instVars.removeAt(\fileptr);
+		
+		this.assertEquals(instVars, info, "SoundFile information should match that of actual sound file");
+
+	}
+
+}

--- a/testsuite/classlibrary/TestSoundFile.sc
+++ b/testsuite/classlibrary/TestSoundFile.sc
@@ -5,14 +5,6 @@ TestSoundFile : UnitTest {
 	setUp {
 
 		path = Platform.resourceDir +/+ "sounds/a11wlk01.wav";
-		info = IdentityDictionary[
-			(\numFrames -> 188893),
-			(\numChannels -> 1),
-			(\path -> path),
-			(\sampleRate -> 44100),
-			(\sampleFormat -> "int16"),
-			(\headerFormat -> "WAV")
-		];
 		soundFile = SoundFile(path);
 
 	}
@@ -36,6 +28,14 @@ TestSoundFile : UnitTest {
 	test_instVars {
 
 		var instVars;
+		var info = IdentityDictionary[
+			(\numFrames -> 188893),
+			(\numChannels -> 1),
+			(\path -> path),
+			(\sampleRate -> 44100),
+			(\sampleFormat -> "int16"),
+			(\headerFormat -> "WAV")
+		];
 
 		soundFile.openRead;
 		this.assert(soundFile.fileptr.notNil, "SoundFile pointer should not be Nil after opening");

--- a/testsuite/classlibrary/TestSoundFile.sc
+++ b/testsuite/classlibrary/TestSoundFile.sc
@@ -16,10 +16,9 @@ TestSoundFile : UnitTest {
 
 		server = Server(this.class.name);
 		this.bootServer(server);
-		
+
 		soundFile = SoundFile(path);
-		server.sync;
-		
+
 	}
 
 	tearDown {
@@ -32,13 +31,9 @@ TestSoundFile : UnitTest {
 	test_isOpen {
 
 		soundFile.openRead;
-		server.sync;
-
 		this.assert(soundFile.isOpen, "SoundFile should now be opened");
 
 		soundFile.close;
-		server.sync;
-
 		this.assert(soundFile.isOpen.not, "SoundFile should now be closed");
 
 	}
@@ -48,8 +43,6 @@ TestSoundFile : UnitTest {
 		var instVars;
 
 		soundFile.openRead;
-		server.sync;
-
 		this.assert(soundFile.fileptr.notNil, "SoundFile pointer should not be Nil after opening");
 
 		// collect all instance variables into a Dictionary, remove problematic 'fileptr'

--- a/testsuite/classlibrary/TestSoundFile.sc
+++ b/testsuite/classlibrary/TestSoundFile.sc
@@ -1,6 +1,6 @@
 TestSoundFile : UnitTest {
 
-	var soundFile, path, info;
+	var soundFile, path;
 
 	setUp {
 
@@ -18,10 +18,15 @@ TestSoundFile : UnitTest {
 	test_isOpen {
 
 		soundFile.openRead;
-		this.assert(soundFile.isOpen, "SoundFile should now be opened");
+		this.assert(soundFile.isOpen, "SoundFile should be opened");
 
+	}
+
+	test_close {
+
+		soundFile.openRead;
 		soundFile.close;
-		this.assert(soundFile.isOpen.not, "SoundFile should now be closed");
+		this.assert(soundFile.isOpen.not, "SoundFile should be closed");
 
 	}
 

--- a/testsuite/classlibrary/TestSoundFile.sc
+++ b/testsuite/classlibrary/TestSoundFile.sc
@@ -1,6 +1,6 @@
 TestSoundFile : UnitTest {
 
-	var server, soundFile, path, info;
+	var soundFile, path, info;
 
 	setUp {
 


### PR DESCRIPTION
__Update:__ This PR adds a basic UnitTest for SoundFile. It also fixes a small error in an OSCFunc found inside this class.

OSCFunc's `argTemplate` can either be `nil`/`0` or an Array of intergers and/or functions. The SoundFile class contains an OSCFunc who's `argTemplate` is set to an Integer. For this reason, the OSCFunc will never fire. The following fixes the OSCFunc by making it's `argTemplate` into an _Array_ containing an Integer.

Consider the following:
```supercollider
e = (dur:0.01).play
e[\id] // Array containing Integer
e[\id][0] // Integer

(
n = NetAddr.localAddr;
a = OSCFunc({ |...args| "A fires".postln }, '/test', n, argTemplate: e[\id]).oneShot;
b = OSCFunc({ |...args| "B never fires".postln }, '/test', n, argTemplate: e[\id][0]).oneShot;
)
n.sendMsg("/test", e[\id][0])
```
This shows that the OSCFunc found inside `SoundFile.cue` should have it's `argTemplate` set to `ev[\id]` and not `ev[\id][0]`.

~~I can try and come up with a UnitTest in the coming days.~~ done!
