### PR TITLE
SoundFile: fix SynthDef and Helpfile to match

### DIFF
--- a/HelpSource/Classes/SoundFile.schelp
+++ b/HelpSource/Classes/SoundFile.schelp
@@ -100,9 +100,9 @@ Where strong::bufferSize::, strong::firstFrame::, strong::lastFrame:: are for bu
 code::
 SynthDef(\diskIn2, { |out, amp=1, bufnum, sustainTime, atk=0, rel=0, gate=1|
 	var sig = VDiskIn.ar(2, bufnum, BufRateScale.kr(bufnum));
-	var env = EnvGen.kr(Env.linen(atk, (sustainTime-atk-rel).max(0), rel), 1, doneAction: Done.freeSelf);
-	var earlyGate = Linen.kr(gate, 0, 1, rel, Done.freeSelf);
-	Out.ar(out, sig * env * earlyGate * amp)
+	var gateEnv = EnvGen.kr(Env([1, 1, 0], [sustainTime-rel, 0]));
+	var env = EnvGen.kr(Env.asr(atk, 1, rel), gate * gateEnv, doneAction: Done.freeSelf);
+	Out.ar(out, sig * env * amp)
 });
 ::
 The control strong::sustainTime:: determines playback duration based on the firstFrame and lastFrame. The control strong::gate:: allows early termination of the playback

--- a/HelpSource/Classes/SoundFile.schelp
+++ b/HelpSource/Classes/SoundFile.schelp
@@ -98,7 +98,7 @@ table::
 ::
 Where strong::bufferSize::, strong::firstFrame::, strong::lastFrame:: are for buffer and playback position, and strong::out::, strong::server::, strong::group::, strong::addAction::, strong::amp:: are synth parameters. Here is the default SynthDef used for stereo files:
 code::
-SynthDef(\diskIn2, { |out, amp = 1, bufnum, sustain, ar=0, dr=0.01, gate=1|
+SynthDef(\diskIn2, { |out, amp=1, bufnum, sustain, ar=0, dr=0.01, gate=1|
 	var sig = VDiskIn.ar(2, bufnum, BufRateScale.kr(bufnum));
 	var env = EnvGen.kr(Env.linen(ar, (sustain - ar - dr).max(0), dr), gate, doneAction: Done.freeSelf);
 	Out.ar(out, sig * env * amp)

--- a/HelpSource/Classes/SoundFile.schelp
+++ b/HelpSource/Classes/SoundFile.schelp
@@ -98,10 +98,10 @@ table::
 ::
 Where strong::bufferSize::, strong::firstFrame::, strong::lastFrame:: are for buffer and playback position, and strong::out::, strong::server::, strong::group::, strong::addAction::, strong::amp:: are synth parameters. Here is the default SynthDef used for stereo files:
 code::
-SynthDef(\diskIn2, { | bufnum, out, gate = 1, sustain, amp = 1, ar = 0, dr = 0.01 |
-	Out.ar(out, DiskIn.ar(2, bufnum)
-	* Linen.kr(gate, ar, 1, dr, 2)
-	* EnvGen.kr(Env.linen(0, sustain - ar - dr max: 0 ,dr),1, doneAction: Done.freeSelf) * amp)
+SynthDef(\diskIn2, { |out, amp = 1, bufnum, sustain, ar=0, dr=0.01, gate=1|
+	var sig = VDiskIn.ar(2, bufnum, BufRateScale.kr(bufnum));
+	var env = EnvGen.kr(Env.linen(ar, (sustain - ar - dr).max(0), dr), gate, doneAction: Done.freeSelf);
+	Out.ar(out, sig * env * amp)
 });
 ::
 The control strong::sustain:: determines playback duration based on the firstFrame and lastFrame. The control strong::gate:: allows early termination of the playback

--- a/HelpSource/Classes/SoundFile.schelp
+++ b/HelpSource/Classes/SoundFile.schelp
@@ -101,7 +101,7 @@ code::
 SynthDef(\diskIn2, { |out, amp=1, bufnum, sustainTime, atk=0, rel=0, gate=1|
 	var sig = VDiskIn.ar(2, bufnum, BufRateScale.kr(bufnum));
 	var env = EnvGen.kr(Env.linen(atk, (sustainTime-atk-rel).max(0), rel), 1, doneAction: Done.freeSelf);
-	var earlyGate = Linen.kr(gate, atk, 1, rel, Done.freeSelf);
+	var earlyGate = Linen.kr(gate, 0, 1, rel, Done.freeSelf);
 	Out.ar(out, sig * env * earlyGate * amp)
 });
 ::

--- a/HelpSource/Classes/SoundFile.schelp
+++ b/HelpSource/Classes/SoundFile.schelp
@@ -98,13 +98,14 @@ table::
 ::
 Where strong::bufferSize::, strong::firstFrame::, strong::lastFrame:: are for buffer and playback position, and strong::out::, strong::server::, strong::group::, strong::addAction::, strong::amp:: are synth parameters. Here is the default SynthDef used for stereo files:
 code::
-SynthDef(\diskIn2, { |out, amp=1, bufnum, sustain, ar=0, dr=0.01, gate=1|
+SynthDef(\diskIn2, { |out, amp=1, bufnum, sustainTime, atk=0, rel=0, gate=1|
 	var sig = VDiskIn.ar(2, bufnum, BufRateScale.kr(bufnum));
-	var env = EnvGen.kr(Env.linen(ar, (sustain - ar - dr).max(0), dr), gate, doneAction: Done.freeSelf);
-	Out.ar(out, sig * env * amp)
+	var env = EnvGen.kr(Env.linen(atk, (sustainTime-atk-rel).max(0), rel), 1, doneAction: Done.freeSelf);
+	var earlyGate = Linen.kr(gate, atk, 1, rel, Done.freeSelf);
+	Out.ar(out, sig * env * earlyGate * amp)
 });
 ::
-The control strong::sustain:: determines playback duration based on the firstFrame and lastFrame. The control strong::gate:: allows early termination of the playback
+The control strong::sustainTime:: determines playback duration based on the firstFrame and lastFrame. The control strong::gate:: allows early termination of the playback
 
 argument::playNow
 This is a link::Classes/Boolean:: that determines whether the file is to be played immediately after cueing.

--- a/SCClassLibrary/Common/Files/SoundFile.sc
+++ b/SCClassLibrary/Common/Files/SoundFile.sc
@@ -415,9 +415,9 @@ SoundFile {
 				if(~instrument.isNil) {
 					SynthDef(defname, { |out, amp=1, bufnum, sustainTime, atk=0, rel=0, gate=1|
 						var sig = VDiskIn.ar(numChannels, bufnum, BufRateScale.kr(bufnum));
-						var env = EnvGen.kr(Env.linen(atk, (sustainTime-atk-rel).max(0), rel), 1, doneAction: Done.freeSelf); 
-						var earlyGate = Linen.kr(gate, 0, 1, rel, Done.freeSelf);
-						Out.ar(out, sig * env * earlyGate * amp)
+						var gateEnv = EnvGen.kr(Env([1, 1, 0], [sustainTime-rel, 0]));
+						var env = EnvGen.kr(Env.asr(atk, 1, rel), gate * gateEnv, doneAction: Done.freeSelf);
+						Out.ar(out, sig * env * amp)
 					}).add;
 					~instrument = defname;
 					condition = Condition.new;

--- a/SCClassLibrary/Common/Files/SoundFile.sc
+++ b/SCClassLibrary/Common/Files/SoundFile.sc
@@ -413,10 +413,10 @@ SoundFile {
 			ev.use {
 				server = ~server ?? { Server.default};
 				if(~instrument.isNil) {
-					SynthDef(defname, { | out, amp = 1, bufnum, sustain, ar = 0, dr = 0.01 gate = 1 |
-						Out.ar(out, VDiskIn.ar(numChannels, bufnum, BufRateScale.kr(bufnum) )
-						* Linen.kr(gate, ar, 1, dr, 2)
-						* EnvGen.kr(Env.linen(ar, sustain - ar - dr max: 0 ,dr),1, doneAction: 2) * amp)
+					SynthDef(defname, { |out, amp=1, bufnum, sustain, ar=0, dr=0.01, gate=1|
+						var sig = VDiskIn.ar(numChannels, bufnum, BufRateScale.kr(bufnum));
+						var env = EnvGen.kr(Env.linen(ar, (sustain - ar - dr).max(0), dr), gate, doneAction: Done.freeSelf); 
+						Out.ar(out, sig * env * amp)
 					}).add;
 					~instrument = defname;
 					condition = Condition.new;

--- a/SCClassLibrary/Common/Files/SoundFile.sc
+++ b/SCClassLibrary/Common/Files/SoundFile.sc
@@ -413,10 +413,11 @@ SoundFile {
 			ev.use {
 				server = ~server ?? { Server.default};
 				if(~instrument.isNil) {
-					SynthDef(defname, { |out, amp=1, bufnum, sustain, ar=0, dr=0.01, gate=1|
+					SynthDef(defname, { |out, amp=1, bufnum, sustainTime, atk=0, rel=0, gate=1|
 						var sig = VDiskIn.ar(numChannels, bufnum, BufRateScale.kr(bufnum));
-						var env = EnvGen.kr(Env.linen(ar, (sustain - ar - dr).max(0), dr), gate, doneAction: Done.freeSelf); 
-						Out.ar(out, sig * env * amp)
+						var env = EnvGen.kr(Env.linen(atk, (sustainTime-atk-rel).max(0), rel), 1, doneAction: Done.freeSelf); 
+						var earlyGate = Linen.kr(gate, atk, 1, rel, Done.freeSelf);
+						Out.ar(out, sig * env * earlyGate * amp)
 					}).add;
 					~instrument = defname;
 					condition = Condition.new;

--- a/SCClassLibrary/Common/Files/SoundFile.sc
+++ b/SCClassLibrary/Common/Files/SoundFile.sc
@@ -416,7 +416,7 @@ SoundFile {
 					SynthDef(defname, { |out, amp=1, bufnum, sustainTime, atk=0, rel=0, gate=1|
 						var sig = VDiskIn.ar(numChannels, bufnum, BufRateScale.kr(bufnum));
 						var env = EnvGen.kr(Env.linen(atk, (sustainTime-atk-rel).max(0), rel), 1, doneAction: Done.freeSelf); 
-						var earlyGate = Linen.kr(gate, atk, 1, rel, Done.freeSelf);
+						var earlyGate = Linen.kr(gate, 0, 1, rel, Done.freeSelf);
 						Out.ar(out, sig * env * earlyGate * amp)
 					}).add;
 					~instrument = defname;


### PR DESCRIPTION
I initially wanted to update SoundFile's `cue` method documentation to correctly indicate the use of VDiskIn inside it's SynthDef. What I ended up doing is rewriting the SynthDef in the class file and in the documentation. The major difference is the removal of the redundant `Linen`. I couldn't understand why there needed to be two envelopes (one sustaining with gate, the other fixed duration without gate, both set to `doneAction:2`). Maybe I'm misunderstanding...? The rest of the changes are mostly cosmetic.



