### PR TITLE
class library: fix linkDoc

### DIFF
--- a/SCClassLibrary/Common/Collections/EnvironmentRedirect.sc
+++ b/SCClassLibrary/Common/Collections/EnvironmentRedirect.sc
@@ -160,20 +160,14 @@ EnvironmentRedirect {
 		stream << " ]" ;
 	}
 
-	linkDoc { arg doc, pushNow = true;
+	linkDoc { arg doc;
 		doc = doc ? Document.current;
 		doc.envir_(this);
-		if(pushNow and: { doc != Document.current } and: { currentEnvironment !== this })  {
-			this.push // otherwise this is done by doc.envir_(this)
-		};
 	}
 
-	unlinkDoc { arg doc, popNow = false;
+	unlinkDoc { arg doc;
 		doc = doc ? Document.current;
 		if(doc.envir === this) { doc.envir_(nil) };
-		if(popNow and: { doc != Document.current } and: { currentEnvironment === this })  {
-			this.pop // otherwise this is done by doc.envir_(nil)
-		};
 	}
 
 	// networking

--- a/SCClassLibrary/Common/Collections/EnvironmentRedirect.sc
+++ b/SCClassLibrary/Common/Collections/EnvironmentRedirect.sc
@@ -160,16 +160,20 @@ EnvironmentRedirect {
 		stream << " ]" ;
 	}
 
-	linkDoc { arg doc, pushNow=true;
+	linkDoc { arg doc, pushNow = true;
 		doc = doc ? Document.current;
 		doc.envir_(this);
-		if(pushNow and: { currentEnvironment !== this }) { this.push };
+		if(pushNow and: { doc != Document.current } and: { currentEnvironment !== this })  {
+			this.push // otherwise this is done by doc.envir_(this)
+		};
 	}
 
 	unlinkDoc { arg doc, popNow = false;
 		doc = doc ? Document.current;
 		if(doc.envir === this) { doc.envir_(nil) };
-		if(popNow and:  { currentEnvironment === this }) { this.pop };
+		if(popNow and: { doc != Document.current } and: { currentEnvironment === this })  {
+			this.pop // otherwise this is done by doc.envir_(nil)
+		};
 	}
 
 	// networking

--- a/SCClassLibrary/scide_scqt/ScIDE.sc
+++ b/SCClassLibrary/scide_scqt/ScIDE.sc
@@ -794,7 +794,6 @@ Document {
 				this.text.interpret;
 			}
 		};
-		current = this;
 		initAction.value(this);
 	}
 

--- a/SCClassLibrary/scide_scqt/ScIDE.sc
+++ b/SCClassLibrary/scide_scqt/ScIDE.sc
@@ -584,7 +584,7 @@ Document {
 
 	closed {
 		onClose.value(this); // call user function
-		this.restoreCurrentEnvironment;
+		this.restorePreviousEnvironment;
 		allDocuments.remove(this);
 	}
 
@@ -698,13 +698,13 @@ Document {
 
 	didBecomeKey {
 		this.class.current = this;
-		this.saveCurrentEnvironment;
+		this.pushLinkedEnvironment;
 		toFrontAction.value(this);
 	}
 
 	didResignKey {
 		endFrontAction.value(this);
-		this.restoreCurrentEnvironment;
+		this.restorePreviousEnvironment;
 	}
 
 	keyDown { | modifiers, unicode, keycode, key |
@@ -891,7 +891,7 @@ Document {
 
 		if(this.isFront) {
 			if(newEnvir.isNil) {
-				this.restoreCurrentEnvironment
+				this.restorePreviousEnvironment
 			} {
 				if(this.hasSavedPreviousEnvironment.not) {
 					savedEnvir = currentEnvironment;
@@ -902,14 +902,14 @@ Document {
 
 	}
 
-	restoreCurrentEnvironment {
+	restorePreviousEnvironment { // happens on leaving focus
 		if (savedEnvir.notNil) {
 			currentEnvironment = savedEnvir;
 			savedEnvir = nil;
 		}
 	}
 
-	saveCurrentEnvironment {
+	pushLinkedEnvironment { // happens on focus
 		if (envir.notNil) {
 			savedEnvir = currentEnvironment;
 			currentEnvironment = envir;

--- a/SCClassLibrary/scide_scqt/ScIDE.sc
+++ b/SCClassLibrary/scide_scqt/ScIDE.sc
@@ -881,17 +881,25 @@ Document {
 
 	// envir stuff
 
-	envir_ { | ev |
-		envir = ev;
-		if (this.class.current == this) {
-			if(envir.isNil) {
+	hasSavedPreviousEnvironment {
+		^savedEnvir.notNil
+	}
+
+	envir_ { | newEnvir |
+
+		envir = newEnvir;
+
+		if(this.isFront) {
+			if(newEnvir.isNil) {
 				this.restoreCurrentEnvironment
 			} {
-				if (savedEnvir.isNil) {
-					this.saveCurrentEnvironment
-				}
+				if(this.hasSavedPreviousEnvironment.not) {
+					savedEnvir = currentEnvironment;
+				};
+				currentEnvironment = envir;
 			}
 		}
+
 	}
 
 	restoreCurrentEnvironment {

--- a/SCClassLibrary/scide_scqt/ScIDE.sc
+++ b/SCClassLibrary/scide_scqt/ScIDE.sc
@@ -454,7 +454,7 @@ Document {
 	var <keyDownAction, <keyUpAction, <mouseUpAction, <mouseDownAction;
 	var <>toFrontAction, <>endFrontAction, <>onClose, <textChangedAction;
 
-	var <envir, savedEnvir;
+	var <envir, <savedEnvir;
 	var <editable = true, <promptToSave = true;
 
 	*initClass{

--- a/testsuite/classlibrary/TestDocument.sc
+++ b/testsuite/classlibrary/TestDocument.sc
@@ -1,0 +1,71 @@
+TestDocument : UnitTest {
+
+
+	test_document_envir {
+
+		var doc, envir1, envir2, envir0;
+		var closeCount = 0, closeCounter, endFrontCount = 0, endFrontCounter;
+
+		envir0 = (a: 0);
+		envir1 = (a: 27);
+		envir2 = (a: 29);
+
+		currentEnvironment = envir0;
+		doc = Document(envir: envir1);
+
+		// check base state
+		this.assert(doc.isFront.not,
+			"new document should be created in the background by default");
+
+		this.assert(currentEnvironment === envir0,
+			"background document linked with envir on creation should not change currentEnvironment");
+
+		doc.envir = envir2;
+
+		this.assert(currentEnvironment === envir0,
+			"background document linked with envir interactively should not change currentEnvironment");
+
+
+		doc.front;
+
+		this.assert(currentEnvironment === envir2,
+			"focused document linked with envir should push its environment");
+
+		this.assert(doc.savedEnvir === envir0,
+			"focused document linked with envir should save its old environment");
+
+		doc.envir = envir1;
+
+		this.assert(currentEnvironment === envir1,
+			"focused document linked with envir should push envir when envir is changed");
+
+		this.assert(doc.savedEnvir === envir0,
+			"focused document linked with envir should keep its old saved environment when envir is changed");
+
+		closeCounter = { closeCount = closeCount + 1 };
+		endFrontCounter = { endFrontCount = endFrontCount + 1 };
+		doc.onClose = closeCounter;
+		doc.endFrontAction = endFrontCounter;
+
+		doc.close;
+
+		/*
+
+		0.3.wait;
+
+		this.assertEquals(closeCount, 1, "onClose should be called once");
+		this.assertEquals(endFrontCount, 1, "endFrontAction should be called once");
+
+
+
+		// this fails, has envir1 (a: 27) as current.
+		this.assertEquals(currentEnvironment, envir0,
+			"closing document linked with envir should restore original currentEnvironment");
+		*/
+
+
+
+	}
+
+}
+


### PR DESCRIPTION
This fixes #3717. The push should not happen twice (.doc_(envir) also
pushes when appropriate).

This fix checks if the condition is correct.

Needs discussion, maybe a refactoring is better.