### PR TITLE
remove remaining unsafe usage of sf_open

### DIFF
--- a/QtCollider/widgets/soundfileview/view.cpp
+++ b/QtCollider/widgets/soundfileview/view.cpp
@@ -98,12 +98,12 @@ void QcWaveform::load( const QString& filename, int beg, int dur )
 static SNDFILE* sndfileOpenQString( const QString& filename, int mode, SF_INFO* info)
 {
 #ifdef _WIN32
-    auto name = filename.toStdWString().c_str();
+    auto name = filename.toStdWString();
 #else
-    auto name = filename.toStdString().c_str();
+    auto name = filename.toStdString();
 #endif // _WIN32
 
-    return sndfileOpen(name, mode, info);
+    return sndfileOpen(name.c_str(), mode, info);
 }
 
 // Negative dur is considered a failure, otherwise we could use dur == -1 to mean "load the whole file."

--- a/QtCollider/widgets/soundfileview/view.cpp
+++ b/QtCollider/widgets/soundfileview/view.cpp
@@ -101,7 +101,12 @@ void QcWaveform::load( const QString& filename, int beg, int dur, bool allFrames
   SF_INFO new_info;
   memset( &new_info, 0, sizeof(SF_INFO) );
 
+#ifdef _WIN32
+  SNDFILE *new_sf = sf_wchar_open( filename.toStdWString().c_str(), SFM_READ, &new_info );
+#else
   SNDFILE *new_sf = sf_open( filename.toStdString().c_str(), SFM_READ, &new_info );
+#endif // _WIN32
+
 
   if( !new_sf ) {
     qcErrorMsg(QStringLiteral("Could not open soundfile: ") + filename);

--- a/QtCollider/widgets/soundfileview/view.cpp
+++ b/QtCollider/widgets/soundfileview/view.cpp
@@ -95,18 +95,24 @@ void QcWaveform::load( const QString& filename, int beg, int dur )
   load( filename, beg, dur, false );
 }
 
+static SNDFILE* sndfileOpenQString( const QString& filename, int mode, SF_INFO* info)
+{
+#ifdef _WIN32
+    auto name = filename.toStdWString().c_str();
+#else
+    auto name = filename.toStdString().c_str();
+#endif // _WIN32
+
+    return sndfileOpen(name, mode, info);
+}
+
 // Negative dur is considered a failure, otherwise we could use dur == -1 to mean "load the whole file."
 void QcWaveform::load( const QString& filename, int beg, int dur, bool allFrames )
 {
   SF_INFO new_info;
   memset( &new_info, 0, sizeof(SF_INFO) );
 
-#ifdef _WIN32
-  SNDFILE *new_sf = sf_wchar_open( filename.toStdWString().c_str(), SFM_READ, &new_info );
-#else
-  SNDFILE *new_sf = sf_open( filename.toStdString().c_str(), SFM_READ, &new_info );
-#endif // _WIN32
-
+  SNDFILE *new_sf = sndfileOpenQString( filename, SFM_READ, &new_info );
 
   if( !new_sf ) {
     qcErrorMsg(QStringLiteral("Could not open soundfile: ") + filename);

--- a/QtCollider/widgets/soundfileview/view.cpp
+++ b/QtCollider/widgets/soundfileview/view.cpp
@@ -86,24 +86,18 @@ QcWaveform::~QcWaveform()
 void QcWaveform::load( const QString& filename )
 {
   qcDebugMsg( 1, "QcWaveform::load( filename )" );
-
-  SF_INFO new_info;
-  memset( &new_info, 0, sizeof(SF_INFO) );
-
-  SNDFILE *new_sf = sf_open( filename.toStdString().c_str(), SFM_READ, &new_info );
-
-  if( !new_sf ) {
-    qcErrorMsg(QStringLiteral("Could not open soundfile: ") + filename);
-    return;
-  }
-
-  doLoad( new_sf, new_info, 0, new_info.frames );
+  load( filename, 0, 0, true );
 }
 
 void QcWaveform::load( const QString& filename, int beg, int dur )
 {
   qcDebugMsg( 1, "QcWaveform::load( filename, beg, dur )" );
+  load( filename, beg, dur, false );
+}
 
+// Negative dur is considered a failure, otherwise we could use dur == -1 to mean "load the whole file."
+void QcWaveform::load( const QString& filename, int beg, int dur, bool allFrames )
+{
   SF_INFO new_info;
   memset( &new_info, 0, sizeof(SF_INFO) );
 
@@ -114,8 +108,10 @@ void QcWaveform::load( const QString& filename, int beg, int dur )
     return;
   }
 
+  dur = allFrames ? new_info.frames : dur;
   doLoad( new_sf, new_info, beg, dur );
 }
+
 
 void QcWaveform::load( const QVector<double> & data, int offset, int ch, int sr )
 {

--- a/QtCollider/widgets/soundfileview/view.hpp
+++ b/QtCollider/widgets/soundfileview/view.hpp
@@ -25,6 +25,12 @@
 #include "../../Common.h"
 #include "../../QcHelper.h"
 
+// on Windows, enable Windows libsndfile prototypes in order to access sf_wchar_open.
+// See sndfile.h, lines 739-752. Note that order matters: this has to be the first include of sndfile.h
+#ifdef _WIN32
+#  include <windows.h>
+#  define ENABLE_SNDFILE_WINDOWS_PROTOTYPES 1
+#endif // _WIN32
 #include <sndfile.h>
 
 #include <QVBoxLayout>

--- a/QtCollider/widgets/soundfileview/view.hpp
+++ b/QtCollider/widgets/soundfileview/view.hpp
@@ -215,6 +215,9 @@ protected:
 
 private:
 
+  /// \param allFrames If true, all frames are loaded and duration is ignored.
+  void load( const QString& filename, int beginning, int duration, bool allFrames );
+
   void doLoad( SNDFILE *new_sf, const SF_INFO &new_info, sf_count_t beginning, sf_count_t duration );
   inline void updateFPP() { _fpp = width() ? (double) _dur / width() : 0.0; }
   void rebuildCache ( int maxFramesPerCache, int maxRawFrames );

--- a/QtCollider/widgets/soundfileview/view.hpp
+++ b/QtCollider/widgets/soundfileview/view.hpp
@@ -25,14 +25,7 @@
 #include "../../Common.h"
 #include "../../QcHelper.h"
 
-// on Windows, enable Windows libsndfile prototypes in order to access sf_wchar_open.
-// See sndfile.h, lines 739-752. Note that order matters: this has to be the first include of sndfile.h
-#ifdef _WIN32
-#  include <windows.h>
-#  define ENABLE_SNDFILE_WINDOWS_PROTOTYPES 1
-#endif // _WIN32
-#include <sndfile.h>
-
+#include "SC_SndFileHelpers.hpp"
 #include <QVBoxLayout>
 #include <QScrollBar>
 #include <QSlider>

--- a/common/SC_SndFileHelpers.hpp
+++ b/common/SC_SndFileHelpers.hpp
@@ -29,6 +29,7 @@
 // on Windows, enable Windows libsndfile prototypes in order to access sf_wchar_open.
 // See sndfile.h, lines 739-752. Note that order matters: this has to be the first include of sndfile.h
 #ifdef _WIN32
+#  include "SC_Codecvt.hpp" // utf8_cstr_to_utf16_wstring
 #  include <windows.h>
 #  define ENABLE_SNDFILE_WINDOWS_PROTOTYPES 1
 #endif // _WIN32
@@ -125,11 +126,25 @@ inline SNDFILE* sndfileOpen(LPCWSTR wpath, int mode, SF_INFO *sfinfo)
 	return sf_wchar_open(wpath, mode, sfinfo);
 }
 
+// This safely opens a sound file using a raw cstring on any platform
+inline SNDFILE* sndfileOpenFromCStr(const char *path, int mode, SF_INFO *sfinfo)
+{
+	// convert to wchar first
+	const std::wstring path_w = SC_Codecvt::utf8_cstr_to_utf16_wstring(path);
+	return sndfileOpen(path_w.c_str(), mode, sfinfo);
+}
+
 #else // not _WIN32
 
 inline SNDFILE* sndfileOpen(const char *path, int mode, SF_INFO *sfinfo)
 {
 	return sf_open(path, mode, sfinfo);
+}
+
+// simple forward
+inline SNDFILE* sndfileOpenFromCStr(const char *path, int mode, SF_INFO *sfinfo)
+{
+	return sndfileOpen(path, mode, sfinfo);
 }
 
 #endif // _WIN32

--- a/common/SC_SndFileHelpers.hpp
+++ b/common/SC_SndFileHelpers.hpp
@@ -137,7 +137,7 @@ inline SNDFILE* sndfileOpenFromCStr(const char *path, int mode, SF_INFO *sfinfo)
 
 // Safely creates a handle using a raw cstring on any platform
 inline SndfileHandle makeSndfileHandle(
-	const char *path, int mode, int format = 0, int channels = 0, int samplerate = 0)
+	const char *path, int mode = SFM_READ, int format = 0, int channels = 0, int samplerate = 0)
 {
 	const std::wstring path_w = SC_Codecvt::utf8_cstr_to_utf16_wstring(path);
 	return SndfileHandle(path_w.c_str(), mode, format, channels, samplerate);
@@ -158,7 +158,7 @@ inline SNDFILE* sndfileOpenFromCStr(const char *path, int mode, SF_INFO *sfinfo)
 
 // simple forward
 inline SndfileHandle makeSndfileHandle(
-	const char *path, int mode, int format = 0, int channels = 0, int samplerate = 0)
+	const char *path, int mode = SFM_READ, int format = 0, int channels = 0, int samplerate = 0)
 {
 	return SndfileHandle(path, mode, format, channels, samplerate);
 }

--- a/common/SC_SndFileHelpers.hpp
+++ b/common/SC_SndFileHelpers.hpp
@@ -34,6 +34,7 @@
 #  define ENABLE_SNDFILE_WINDOWS_PROTOTYPES 1
 #endif // _WIN32
 #include <sndfile.h>
+#include <sndfile.hh>
 
 #include "string.h"
 
@@ -134,6 +135,14 @@ inline SNDFILE* sndfileOpenFromCStr(const char *path, int mode, SF_INFO *sfinfo)
 	return sndfileOpen(path_w.c_str(), mode, sfinfo);
 }
 
+// Safely creates a handle using a raw cstring on any platform
+inline SndfileHandle makeSndfileHandle(
+	const char *path, int mode, int format = 0, int channels = 0, int samplerate = 0)
+{
+	const std::wstring path_w = SC_Codecvt::utf8_cstr_to_utf16_wstring(path);
+	return SndfileHandle(path_w.c_str(), mode, format, channels, samplerate);
+}
+
 #else // not _WIN32
 
 inline SNDFILE* sndfileOpen(const char *path, int mode, SF_INFO *sfinfo)
@@ -145,6 +154,13 @@ inline SNDFILE* sndfileOpen(const char *path, int mode, SF_INFO *sfinfo)
 inline SNDFILE* sndfileOpenFromCStr(const char *path, int mode, SF_INFO *sfinfo)
 {
 	return sndfileOpen(path, mode, sfinfo);
+}
+
+// simple forward
+inline SndfileHandle makeSndfileHandle(
+	const char *path, int mode, int format = 0, int channels = 0, int samplerate = 0)
+{
+	return SndfileHandle(path, mode, format, channels, samplerate);
 }
 
 #endif // _WIN32

--- a/lang/LangPrimSource/PyrFilePrim.cpp
+++ b/lang/LangPrimSource/PyrFilePrim.cpp
@@ -33,16 +33,6 @@ Primitives for File i/o.
 #include "SCBase.h"
 #include "sc_popen.h"
 
-// on Windows, enable Windows libsndfile prototypes in order to access sf_wchar_open.
-// See sndfile.h, lines 739-752. Note that order matters: this has to be the first include of sndfile.h
-#ifndef NO_LIBSNDFILE
-#  ifdef _WIN32
-#    include <windows.h>
-#    define ENABLE_SNDFILE_WINDOWS_PROTOTYPES 1
-#  endif // _WIN32
-#  include <sndfile.h>
-#endif // NO_LIBSNDFILE
-
 /* SuperCollider newer headers*/
 #include "SC_SndFileHelpers.hpp"
 #include "SC_Filesystem.hpp" // resolveIfAlias
@@ -1516,12 +1506,7 @@ int prSFOpenRead(struct VMGlobals *g, int numArgsPushed)
 	filename[slotRawString(b)->size] = 0;
 
 	info.format = 0;
-#ifdef _WIN32
-	const std::wstring filename_w = SC_Codecvt::utf8_cstr_to_utf16_wstring(filename);
-	file = sf_wchar_open(filename_w.c_str(), SFM_READ, &info);
-#else
-	file = sf_open(filename, SFM_READ, &info);
-#endif // _WIN32
+	file = sndfileOpenFromCStr(filename, SFM_READ, &info);
 
 	if (file) {
 		SetPtr(obj1->slots + 0, file);
@@ -1603,12 +1588,7 @@ int prSFOpenWrite(struct VMGlobals *g, int numArgsPushed)
 	slotIntVal(slotRawObject(a)->slots + 4, &info.channels);
 	slotIntVal(slotRawObject(a)->slots + 5, &info.samplerate);
 
-#ifdef _WIN32
-	const std::wstring filename_w = SC_Codecvt::utf8_cstr_to_utf16_wstring(filename);
-	file = sf_wchar_open(filename_w.c_str(), SFM_WRITE, &info);
-#else
-	file = sf_open(filename, SFM_WRITE, &info);
-#endif // _WIN32
+	file = sndfileOpenFromCStr(filename, SFM_WRITE, &info);
 
 	sf_command(file, SFC_SET_CLIPPING, NULL, SF_TRUE);
 

--- a/server/scsynth/SC_SequencedCommand.cpp
+++ b/server/scsynth/SC_SequencedCommand.cpp
@@ -537,7 +537,7 @@ bool BufAllocReadCmd::Stage2()
 	SndBuf *buf = World_GetNRTBuf(mWorld, mBufIndex);
 	SF_INFO fileinfo;
 	memset(&fileinfo, 0, sizeof(fileinfo));
-	SNDFILE* sf = sf_open(mFilename, SFM_READ, &fileinfo);
+	SNDFILE* sf = sndfileOpenFromCStr(mFilename, SFM_READ, &fileinfo);
 	if (!sf) {
 		char str[512];
 		sprintf(str, "File '%s' could not be opened: %s\n", mFilename, sf_strerror(NULL));
@@ -638,7 +638,7 @@ bool BufReadCmd::Stage2()
 	int framesToEnd = buf->frames - mBufOffset;
 	if (framesToEnd <= 0) return true;
 
-	SNDFILE* sf = sf_open(mFilename, SFM_READ, &fileinfo);
+	SNDFILE* sf = sndfileOpenFromCStr(mFilename, SFM_READ, &fileinfo);
 	if (!sf) {
 		char str[512];
 		sprintf(str, "File '%s' could not be opened: %s\n", mFilename, sf_strerror(NULL));
@@ -801,7 +801,7 @@ bool BufAllocReadChannelCmd::Stage2()
 
 	SF_INFO fileinfo;
 	memset(&fileinfo, 0, sizeof(fileinfo));
-	SNDFILE* sf = sf_open(mFilename, SFM_READ, &fileinfo);
+	SNDFILE* sf = sndfileOpenFromCStr(mFilename, SFM_READ, &fileinfo);
 	if (!sf) {
 		char str[512];
 		sprintf(str, "File '%s' could not be opened: %s\n", mFilename, sf_strerror(NULL));
@@ -928,7 +928,7 @@ bool BufReadChannelCmd::Stage2()
 	int framesToEnd = buf->frames - mBufOffset;
 	if (framesToEnd <= 0) return true;
 
-	SNDFILE* sf = sf_open(mFilename, SFM_READ, &fileinfo);
+	SNDFILE* sf = sndfileOpenFromCStr(mFilename, SFM_READ, &fileinfo);
 	if (!sf) {
 		char str[512];
 		sprintf(str, "File '%s' could not be opened: %s\n", mFilename, sf_strerror(NULL));
@@ -1079,7 +1079,7 @@ bool BufWriteCmd::Stage2()
 	mFileInfo.samplerate = (int)buf->samplerate;
 	mFileInfo.channels = buf->channels;
 
-	SNDFILE* sf = sf_open(mFilename, SFM_WRITE, &mFileInfo);
+	SNDFILE* sf = sndfileOpenFromCStr(mFilename, SFM_WRITE, &mFileInfo);
 	if (!sf) {
 		char str[512];
 		sprintf(str, "File '%s' could not be opened: %s\n", mFilename, sf_strerror(NULL));

--- a/server/scsynth/SC_SequencedCommand.h
+++ b/server/scsynth/SC_SequencedCommand.h
@@ -33,9 +33,7 @@
 #include "SC_World.h"
 #include "SC_BufGen.h"
 #include "sc_msg_iter.h"
-#ifndef NO_LIBSNDFILE
-#include <sndfile.h>
-#endif
+#include "SC_SndFileHelpers.hpp"
 #include <new>
 
 #define CallSequencedCommand(T, inWorld, inSize, inData, inReply)	\

--- a/server/scsynth/SC_World.cpp
+++ b/server/scsynth/SC_World.cpp
@@ -596,7 +596,8 @@ void World_NonRealTimeSynthesis(struct World *world, WorldOptions *inOptions)
 	sndfileFormatInfoFromStrings(&outputFileInfo,
 		inOptions->mNonRealTimeOutputHeaderFormat, inOptions->mNonRealTimeOutputSampleFormat);
 
-	world->hw->mNRTOutputFile = sf_open(inOptions->mNonRealTimeOutputFilename, SFM_WRITE, &outputFileInfo);
+	world->hw->mNRTOutputFile = sndfileOpenFromCStr(
+		inOptions->mNonRealTimeOutputFilename, SFM_WRITE, &outputFileInfo);
 	sf_command(world->hw->mNRTOutputFile, SFC_SET_CLIPPING, NULL, SF_TRUE);
 
 	if (!world->hw->mNRTOutputFile)
@@ -605,7 +606,8 @@ void World_NonRealTimeSynthesis(struct World *world, WorldOptions *inOptions)
 	outputFileBuf = (float*)calloc(1, world->mNumOutputs * fileBufFrames * sizeof(float));
 
 	if (inOptions->mNonRealTimeInputFilename) {
-		world->hw->mNRTInputFile = sf_open(inOptions->mNonRealTimeInputFilename, SFM_READ, &inputFileInfo);
+		world->hw->mNRTInputFile = sndfileOpenFromCStr(
+			inOptions->mNonRealTimeInputFilename, SFM_READ, &inputFileInfo);
 		if (!world->hw->mNRTInputFile)
 			throw std::runtime_error("Couldn't open non real time input file.\n");
 

--- a/server/supernova/audio_backend/sndfile_backend.hpp
+++ b/server/supernova/audio_backend/sndfile_backend.hpp
@@ -31,7 +31,7 @@
 #include <boost/lockfree/spsc_queue.hpp>
 #include <boost/sync/semaphore.hpp>
 
-#include <sndfile.hh>
+#include "SC_SndFileHelpers.hpp"
 
 #include "nova-tt/name_thread.hpp"
 #include "utilities/branch_hints.hpp"
@@ -84,7 +84,7 @@ public:
         block_size_ = block_size;
 
         if (!input_file_name.empty()) {
-            input_file = SndfileHandle(input_file_name.c_str(), SFM_READ);
+            input_file = makeSndfileHandle(input_file_name.c_str(), SFM_READ);
             if (!input_file)
                 throw std::runtime_error("cannot open input file");
 
@@ -98,7 +98,8 @@ public:
             input_channels = 0;
         read_position = 0;
 
-        output_file = SndfileHandle(output_file_name.c_str(), SFM_WRITE, format, output_channel_count, samplerate);
+        output_file = makeSndfileHandle(
+            output_file_name.c_str(), SFM_WRITE, format, output_channel_count, samplerate);
         if (!output_file)
             throw std::runtime_error("cannot open output file");
 

--- a/server/supernova/sc/sc_plugin_interface.cpp
+++ b/server/supernova/sc/sc_plugin_interface.cpp
@@ -19,7 +19,7 @@
 #include <cstdarg>
 #include <random>
 
-#include "sndfile.hh"
+#include "SC_SndFileHelpers.hpp"
 
 #include "sc_plugin_interface.hpp"
 #include "sc_ugen_factory.hpp"
@@ -942,7 +942,7 @@ SndBuf * sc_plugin_interface::allocate_buffer(uint32_t index, uint32_t frames, u
 
 void sc_plugin_interface::buffer_read_alloc(uint32_t index, const char * filename, uint32_t start, uint32_t frames)
 {
-    SndfileHandle f(filename);
+    auto f = makeSndfileHandle(filename);
     if (f.rawHandle() == nullptr)
         throw std::runtime_error(f.strError());
 
@@ -966,7 +966,7 @@ void sc_plugin_interface::buffer_alloc_read_channels(uint32_t index, const char 
                                                      uint32_t frames, uint32_t channel_count,
                                                      const uint32_t * channel_data)
 {
-    SndfileHandle f(filename);
+    auto f = makeSndfileHandle(filename);
     if (f.rawHandle() == nullptr)
         throw std::runtime_error(f.strError());
 
@@ -997,7 +997,7 @@ int sc_plugin_interface::buffer_write(uint32_t index, const char * filename, con
     SndBuf * buf = World_GetNRTBuf(&world, index);
     int format = headerFormatFromString(header_format) | sampleFormatFromString(sample_format);
 
-    SndfileHandle sf(filename, SFM_WRITE, format, buf->channels, buf->samplerate);
+    auto sf = makeSndfileHandle(filename, SFM_WRITE, format, buf->channels, buf->samplerate);
 
     if (!sf)
         return -1;
@@ -1036,7 +1036,7 @@ void sc_plugin_interface::buffer_read(uint32_t index, const char * filename, uin
     if (uint32_t(buf->frames) < start_buffer)
         throw std::runtime_error("buffer already full");
 
-    SndfileHandle sf(filename, SFM_READ);
+    auto sf = makeSndfileHandle(filename, SFM_READ);
     buffer_read_verify(sf, start_file, buf->samplerate, !leave_open);
 
     if (sf.channels() != buf->channels)
@@ -1065,7 +1065,7 @@ void sc_plugin_interface::buffer_read_channel(uint32_t index, const char * filen
     if (uint32_t(buf->frames) >= start_buffer)
         throw std::runtime_error("buffer already full");
 
-    SndfileHandle sf(filename, SFM_READ);
+    auto sf = makeSndfileHandle(filename, SFM_READ);
     buffer_read_verify(sf, start_file, buf->samplerate, !leave_open);
 
     uint32_t sf_channels = uint32_t(sf.channels());

--- a/server/supernova/server/buffer_manager.cpp
+++ b/server/supernova/server/buffer_manager.cpp
@@ -42,7 +42,7 @@ namespace
 
 SndfileHandle open_file(const char * file, std::size_t start_frame)
 {
-    SndfileHandle sndfile(file);
+    auto sndfile = makeSndfileHandle(file);
     if (!sndfile)
         throw std::runtime_error(std::string("could not open file: ") + std::string(file));
 
@@ -119,7 +119,7 @@ void buffer_wrapper::write_file(const char * file, const char * header_format, c
 
     format |= sample_format_tag;
 
-    SndfileHandle sndfile(file, SFM_WRITE, format, channels_, sample_rate_);
+    auto sndfile = makeSndfileHandle(file, SFM_WRITE, format, channels_, sample_rate_);
     if (!sndfile)
         throw std::runtime_error(std::string("could not open file: ") + std::string(file));
 


### PR DESCRIPTION
See prev work in #3683 

Fixes #3673, fixes #3719.

After the big PR awhile ago there were still some uses of libsndfile's sf_open function that didn't handle Unicode strings for the Windows FS API. This cleans that up.

Moved common logic to the SC_SndFileHelpers header so there are fewer ifdefs everywhere.

Fixed spots are:
- supernova's sndfile backend, buffer manager, and plugin interface
- scsynth's NRT and b_read-related commands
- Qt soundfileview's soundfile loading

some of the refactoring also touched the sclang soundfile primitives