### PR TITLE
Classlib: Patterns: Pkey embedInStream must provide a default repeats

### DIFF
--- a/SCClassLibrary/Common/Streams/Patterns.sc
+++ b/SCClassLibrary/Common/Streams/Patterns.sc
@@ -673,7 +673,7 @@ Pkey : Pattern {
 
 	embedInStream { |inval|
 		var outval, keystream = key.asStream;
-		repeats.value(inval).do {
+		(repeats.value(inval) ?? { inf }).do {
 			outval = inval[keystream.next(inval)];
 			if(outval.isNil) { ^inval };
 			inval = outval.yield;


### PR DESCRIPTION
Without the fix:

```
(
p = Pbind(
	\stuff, Pwhite(30, 36, inf),
	\midinote, Pseq([Pkey(\stuff), 62, 64, 65], inf)
).asStream;
)

4.do { p.next(()).postln };
( 'stuff': 34, 'midinote': 62 )
( 'stuff': 35, 'midinote': 64 )
( 'stuff': 36, 'midinote': 65 )
( 'stuff': 31, 'midinote': 62 )
```

Pkey is skipped because: `repeats.value(inval).do` but the default `repeats` is nil :man_facepalming:

We should substitute `inf` repeats -- Pkey with no repeats specified should be infinite-length. In fact, I had suggested this at one point, but then somebody removed the nil check.

I think we shouldn't assign a default in the class. Currently we're using `nil` as an optimization, to avoid checking the stream length if it's going to be infinite anyway.
