### PR TITLE
class library: throw proper error when plotting an array with nil (edited)

### DIFF
--- a/HelpSource/Classes/ArrayedCollection.schelp
+++ b/HelpSource/Classes/ArrayedCollection.schelp
@@ -88,7 +88,7 @@ y.foldAt(5).postln; // this returns the value at index 1
 ::
 
 method::plot
-Plot data in a GUI window. See link::Reference/plot:: for more details.
+Plot values in a GUI window.  See link::Reference/plot:: for more details. When the receiver contains code::nil:: items, the plot fails with an error.
 
 method::swap
 Swap the values at indices i and j.

--- a/HelpSource/Reference/plot.schelp
+++ b/HelpSource/Reference/plot.schelp
@@ -40,7 +40,7 @@ By default labels appear at the top left of the plot giving a data readout based
 
 
 discussion::
-If code::minval:: and/or code::maxval:: are set to code::nil:: (this is default, except for link::Classes/Buffer::s), they will be automatically calculated from the dataset minimum and/or maximum. For multi-channel data, code::minval:: and code::maxval:: may be arrays, specifying the range independently for each channel (including use of code::nil::, in which case the min/max will be calculated for the specific channel rather than for the overall dataset).
+If code::minval:: and/or code::maxval:: are set to code::nil:: (this is default, except for link::Classes/Buffer::s), they will be automatically calculated from the dataset minimum and/or maximum. For multi-channel data, code::minval:: and code::maxval:: may be arrays, specifying the range independently for each channel (including use of code::nil::, in which case the min/max will be calculated for the specific channel rather than for the overall dataset). When the receiver contains code::nil:: items, the plot fails with an error.
 
 Hitting the strong::E-key:: on the keyboard when the window is focussed toggles the lock, and the window can be used to edit the data.
 

--- a/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
+++ b/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
@@ -724,7 +724,7 @@ Plotter {
 
 
 + ArrayedCollection {
-	plot { |name, bounds, discrete=false, numChannels, minval, maxval, separately = true|
+	plot { |name, bounds, discrete = false, numChannels, minval, maxval, separately = true|
 		var array, plotter;
 		array = this.as(Array);
 
@@ -736,13 +736,17 @@ Plotter {
 		if(discrete) { plotter.plotMode = \points };
 
 		numChannels !? { array = array.unlace(numChannels) };
-		array = array.collect {|elem|
+		array = array.collect {|elem, i|
 			if (elem.isKindOf(Env)) {
 				elem.asMultichannelSignal.flop
 			} {
+				if(elem.isNil) {
+					Error("cannot plot array: non-numeric value at index %".format(i)).throw
+				};
 				elem
 			}
 		};
+
 		plotter.setValue(
 			array,
 			findSpecs: true,


### PR DESCRIPTION
ArrayedCollection plot used to throw hard to understand errors when it
contained a nil value. ~~Now it warns and plots anyway, replacing the
value by zero.~~ edit: now it throws a better error

This fixes #3725.