### PR TITLE
SoundFile: fix cue method

### DIFF
--- a/HelpSource/Classes/SoundFile.schelp
+++ b/HelpSource/Classes/SoundFile.schelp
@@ -118,7 +118,7 @@ e = f[1].cue( (addAction: 2, group: 1) );	// synth will play ahead of the defaul
 
 argument:: closeWhenDone
 
-A flag to indicate wether the code::SoundFile:: and buffer will be closed after playback is finished. Default is False.
+A flag to indicate whether the code::SoundFile:: and buffer will be closed after playback is finished. Default is False.
 
 subsection::Read/Write
 

--- a/HelpSource/Classes/SoundFile.schelp
+++ b/HelpSource/Classes/SoundFile.schelp
@@ -80,7 +80,7 @@ private::prOpenRead, prOpenWrite
 subsection::Playback
 
 method::cue
-Allocates a buffer and cues the SoundFile for playback. Returns an event parameterized to play that buffer. (See link::Reference/NodeEvent:: for a description of how events can be used to control running synths.) The event responds to strong::play::, strong::stop::, strong::pause::, strong::resume::, keeping both the file and buffer open. The file is closed and the buffer is freed when the event is sent a strong::close:: message.
+Allocates a buffer and cues the SoundFile for playback. Returns an event parameterized to play that buffer. (See link::Reference/NodeEvent:: for a description of how events can be used to control running synths.) The event responds to strong::play::, strong::stop::, strong::pause::, strong::resume::, keeping the buffer open. The buffer is closed when the event is sent a strong::close:: message.
 
 argument::ev
 An link::Classes/Event:: can passed as an argument allowing playback to be customized using the following keys:
@@ -118,7 +118,7 @@ e = f[1].cue( (addAction: 2, group: 1) );	// synth will play ahead of the defaul
 
 argument:: closeWhenDone
 
-A flag to indicate whether the code::SoundFile:: and buffer will be closed after playback is finished. Default is False.
+A flag to indicate whether the buffer will be closed after playback is finished. Default is False.
 
 subsection::Read/Write
 

--- a/HelpSource/Classes/SoundFile.schelp
+++ b/HelpSource/Classes/SoundFile.schelp
@@ -86,7 +86,7 @@ argument::ev
 An link::Classes/Event:: can passed as an argument allowing playback to be customized using the following keys:
 table::
 ## strong::key:: || strong::default value:: || strong::what it does::
-## bufferSize || 65536 ||
+## bufferSize || 65536 || Must be a power of two (65536, 131072 or 262144 recommended)
 ## firstFrame || 0 || first frame to play
 ## lastFrame || nil || last frame to play (nil plays to end of file)
 ## out: || 0 || sets output bus
@@ -118,7 +118,7 @@ e = f[1].cue( (addAction: 2, group: 1) );	// synth will play ahead of the defaul
 
 argument:: closeWhenDone
 
-A flag to indicate wether the code::SoundFile:: will be closed after it's done playing. Default is False.
+A flag to indicate wether the code::SoundFile:: and buffer will be closed after playback is finished. Default is False.
 
 subsection::Read/Write
 

--- a/SCClassLibrary/Common/Files/SoundFile.sc
+++ b/SCClassLibrary/Common/Files/SoundFile.sc
@@ -435,7 +435,7 @@ SoundFile {
 				};
 				if (closeWhenDone) {
 					OSCFunc({
-						ev.close;
+						ev[\close].value(ev);
 						this.close;
 					}, "/n_end", server.addr, nil, ev[\id]).oneShot;
 				};

--- a/SCClassLibrary/Common/Files/SoundFile.sc
+++ b/SCClassLibrary/Common/Files/SoundFile.sc
@@ -425,7 +425,7 @@ SoundFile {
 				};
 				ev.synth;	// set up as a synth event (see Event)
 				~bufnum =  server.bufferAllocator.alloc(1);
-				~bufferSize = 0x10000;
+				~bufferSize = ~bufferSize ? 0x10000;
 				~firstFrame = ~firstFrame ? 0;
 				~lastFrame = ~lastFrame ? numFrames;
 				~sustainTime = (~lastFrame - ~firstFrame)/(sampleRate ?? {server.sampleRate ? 44100});

--- a/SCClassLibrary/Common/Files/SoundFile.sc
+++ b/SCClassLibrary/Common/Files/SoundFile.sc
@@ -406,7 +406,7 @@ SoundFile {
 	}
 
 	cue { | ev, playNow = false, closeWhenDone = false |
-		var server, packet, defname = "diskIn" ++ numChannels, onClose;
+		var server, packet, defname = "diskIn" ++ numChannels;
 		ev = ev ? ();
 		if (this.numFrames == 0) { this.info };
 		fork {

--- a/SCClassLibrary/Common/Files/SoundFile.sc
+++ b/SCClassLibrary/Common/Files/SoundFile.sc
@@ -427,7 +427,7 @@ SoundFile {
 				~bufferSize = ~bufferSize ? 0x10000;
 				~firstFrame = ~firstFrame ? 0;
 				~lastFrame = ~lastFrame ? numFrames;
-				~sustainTime = (~lastFrame - ~firstFrame)/(sampleRate ?? {server.sampleRate ? 44100});
+				~sustainTime = (~lastFrame - ~firstFrame) / (sampleRate ?? { server.sampleRate ? 44100 });
 				~close = { | ev |
 						server.bufferAllocator.free(ev[\bufnum]);
 						server.sendBundle(server.latency, ["/b_close", ev[\bufnum]],

--- a/SCClassLibrary/Common/Files/SoundFile.sc
+++ b/SCClassLibrary/Common/Files/SoundFile.sc
@@ -406,7 +406,7 @@ SoundFile {
 	}
 
 	cue { | ev, playNow = false, closeWhenDone = false |
-		var server, packet, defname = "diskIn" ++ numChannels, condition, onClose;
+		var server, packet, defname = "diskIn" ++ numChannels, onClose;
 		ev = ev ? ();
 		if (this.numFrames == 0) { this.info };
 		fork {
@@ -420,8 +420,7 @@ SoundFile {
 						Out.ar(out, sig * env * amp)
 					}).add;
 					~instrument = defname;
-					condition = Condition.new;
-					server.sync(condition);
+					server.sync;
 				};
 				ev.synth;	// set up as a synth event (see Event)
 				~bufnum =  server.bufferAllocator.alloc(1);

--- a/SCClassLibrary/Common/Files/SoundFile.sc
+++ b/SCClassLibrary/Common/Files/SoundFile.sc
@@ -428,7 +428,7 @@ SoundFile {
 				~bufferSize = 0x10000;
 				~firstFrame = ~firstFrame ? 0;
 				~lastFrame = ~lastFrame ? numFrames;
-				~sustain = (~lastFrame - ~firstFrame)/(sampleRate ?? {server.options.sampleRate ? 44100});
+				~sustainTime = (~lastFrame - ~firstFrame)/(sampleRate ?? {server.options.sampleRate ? 44100});
 				~close = { | ev |
 						server.bufferAllocator.free(ev[\bufnum]);
 						server.sendBundle(server.latency, ["/b_close", ev[\bufnum]],

--- a/SCClassLibrary/Common/Files/SoundFile.sc
+++ b/SCClassLibrary/Common/Files/SoundFile.sc
@@ -441,9 +441,10 @@ SoundFile {
 					}, "/n_end", server.addr, nil, ev[\id]).oneShot;
 				};
 				if (closeWhenDone) {
+					ev.setwatchers;
 					onClose = SimpleController(ev).put(\n_end, {
-						ev.setwatchers;
 						ev.close;
+						this.close;
 						onClose.remove;
 					});
 					ev.addDependant(onClose)

--- a/SCClassLibrary/Common/Files/SoundFile.sc
+++ b/SCClassLibrary/Common/Files/SoundFile.sc
@@ -428,7 +428,7 @@ SoundFile {
 				~bufferSize = 0x10000;
 				~firstFrame = ~firstFrame ? 0;
 				~lastFrame = ~lastFrame ? numFrames;
-				~sustainTime = (~lastFrame - ~firstFrame)/(sampleRate ?? {server.options.sampleRate ? 44100});
+				~sustainTime = (~lastFrame - ~firstFrame)/(sampleRate ?? {server.sampleRate ? 44100});
 				~close = { | ev |
 						server.bufferAllocator.free(ev[\bufnum]);
 						server.sendBundle(server.latency, ["/b_close", ev[\bufnum]],

--- a/SCClassLibrary/Common/Files/SoundFile.sc
+++ b/SCClassLibrary/Common/Files/SoundFile.sc
@@ -436,7 +436,6 @@ SoundFile {
 				if (closeWhenDone) {
 					OSCFunc({
 						ev[\close].value(ev);
-						this.close;
 					}, "/n_end", server.addr, nil, ev[\id]).oneShot;
 				};
 				if (playNow) {

--- a/SCClassLibrary/Common/Files/SoundFile.sc
+++ b/SCClassLibrary/Common/Files/SoundFile.sc
@@ -433,20 +433,11 @@ SoundFile {
 						server.sendBundle(server.latency, ["/b_close", ev[\bufnum]],
 							["/b_free", ev[\bufnum] ]  )
 				};
-				~setwatchers = { |ev|
-					OSCFunc({
-						server.sendBundle(server.latency, ["/b_close", ev[\bufnum]],
-							["/b_read", ev[\bufnum], path, ev[\firstFrame], ev[\bufferSize], 0, 1]);
-					}, "/n_end", server.addr, nil, ev[\id]).oneShot;
-				};
 				if (closeWhenDone) {
-					ev.setwatchers;
-					onClose = SimpleController(ev).put(\n_end, {
+					OSCFunc({
 						ev.close;
 						this.close;
-						onClose.remove;
-					});
-					ev.addDependant(onClose)
+					}, "/n_end", server.addr, nil, ev[\id]).oneShot;
 				};
 				if (playNow) {
 					packet = server.makeBundle(false, {ev.play})[0];

--- a/SCClassLibrary/Common/Files/SoundFile.sc
+++ b/SCClassLibrary/Common/Files/SoundFile.sc
@@ -440,6 +440,14 @@ SoundFile {
 							["/b_read", ev[\bufnum], path, ev[\firstFrame], ev[\bufferSize], 0, 1]);
 					}, "/n_end", server.addr, nil, ev[\id]).oneShot;
 				};
+				if (closeWhenDone) {
+					onClose = SimpleController(ev).put(\n_end, {
+						ev.setwatchers;
+						ev.close;
+						onClose.remove;
+					});
+					ev.addDependant(onClose)
+				};
 				if (playNow) {
 					packet = server.makeBundle(false, {ev.play})[0];
 						// makeBundle creates an array of messages
@@ -451,13 +459,6 @@ SoundFile {
 							["/b_read", ~bufnum, path, ~firstFrame, ~bufferSize, 0, 1, packet]
 						]);
 			};
-		};
-		if (closeWhenDone) {
-			onClose = SimpleController(ev).put(\n_end, {
-				ev.close;
-				onClose.remove;
-			});
-			ev.addDependant(onClose)
 		};
 		^ev;
 	}

--- a/testsuite/classlibrary/TestSoundFile.sc
+++ b/testsuite/classlibrary/TestSoundFile.sc
@@ -55,34 +55,38 @@ TestSoundFile : UnitTest {
 
 	test_cue {
 
-		var cueEvent, testEvent, testGroup;
+		var cueEvent, testEvent, group;
 		var server = Server(this.class.name);
 		this.bootServer(server);
 
-		// Cue Event argument
+		// pass in Event
 		testEvent = (foo: true);
 		cueEvent = soundFile.cue(testEvent);
-		this.assert(cueEvent[\foo].notNil, "Cue should take an Event as first argument");
+		this.assert(cueEvent[\foo], "Cue should take an Event as first argument");
 
-		// Cue playNow argument
+		// playNow argument
 		cueEvent = soundFile.cue((), true);
 		0.5.wait;
 		this.assert(cueEvent.isRunning, "Event should play immediately after cueing");
 		cueEvent.stop;
 
 		// Test settable controls
-		testGroup = Group.new(server);
-		testEvent = (bufferSize: 262144, firstFrame: 100, lastFrame: 200, out: 20, server: server, group: testGroup, addAction: 1, amp: 0);
+		group = Group.new(server);
+		testEvent = (bufferSize: 262144, firstFrame: 100, lastFrame: 200, out: 20, server: server, group: group, addAction: 1, amp: 0);
 		cueEvent = soundFile.cue(testEvent);
 		testEvent.keysDo { |key|
 			this.assertEquals(cueEvent[key], testEvent[key], "Control '%' was correclty set".format(key))
 		};
 
-		// Cue closeWhenDone argument
+		// closeWhenDone argument
 		soundFile.openRead;
 		soundFile.cue((lastFrame: 10), true, true);
 		0.5.wait;
 		this.assert(soundFile.isOpen.not, "SoundFile should close when finished playing");
+
+		// test cleanup
+		Buffer.freeAll;
+		server.quit.remove;
 
 	}
 }

--- a/testsuite/classlibrary/TestSoundFile.sc
+++ b/testsuite/classlibrary/TestSoundFile.sc
@@ -53,4 +53,36 @@ TestSoundFile : UnitTest {
 
 	}
 
+	test_cue {
+
+		var cueEvent, testEvent, testGroup;
+		var server = Server(this.class.name);
+		this.bootServer(server);
+
+		// Cue Event argument
+		testEvent = (foo: true);
+		cueEvent = soundFile.cue(testEvent);
+		this.assert(cueEvent[\foo].notNil, "Cue should take an Event as first argument");
+
+		// Cue playNow argument
+		cueEvent = soundFile.cue((), true);
+		0.5.wait;
+		this.assert(cueEvent.isRunning, "Event should play immediately after cueing");
+		cueEvent.stop;
+
+		// Test settable controls
+		testGroup = Group.new(server);
+		testEvent = (bufferSize: 262144, firstFrame: 100, lastFrame: 200, out: 20, server: server, group: testGroup, addAction: 1, amp: 0);
+		cueEvent = soundFile.cue(testEvent);
+		testEvent.keysDo { |key|
+			this.assertEquals(cueEvent[key], testEvent[key], "Control '%' was correclty set".format(key))
+		};
+
+		// Cue closeWhenDone argument
+		soundFile.openRead;
+		soundFile.cue((lastFrame: 10), true, true);
+		0.5.wait;
+		this.assert(soundFile.isOpen.not, "SoundFile should close when finished playing");
+
+	}
 }

--- a/testsuite/classlibrary/TestSoundFile.sc
+++ b/testsuite/classlibrary/TestSoundFile.sc
@@ -3,35 +3,26 @@ TestSoundFile : UnitTest {
 	var soundFile, path;
 
 	setUp {
-
 		path = Platform.resourceDir +/+ "sounds/a11wlk01.wav";
 		soundFile = SoundFile(path);
-
 	}
 
 	tearDown {
-
 		soundFile.close;
-
 	}
 
 	test_isOpen {
-
 		soundFile.openRead;
 		this.assert(soundFile.isOpen, "SoundFile should be opened");
-
 	}
 
 	test_close {
-
 		soundFile.openRead;
 		soundFile.close;
 		this.assert(soundFile.isOpen.not, "SoundFile should be closed");
-
 	}
 
 	test_instVars {
-
 		var instVars;
 		var info = IdentityDictionary[
 			(\numFrames -> 188893),
@@ -50,43 +41,6 @@ TestSoundFile : UnitTest {
 		instVars.removeAt(\fileptr);
 		
 		this.assertEquals(instVars, info, "SoundFile information should match that of actual sound file");
-
 	}
 
-	test_cue {
-
-		var cueEvent, testEvent, group;
-		var server = Server(this.class.name);
-		this.bootServer(server);
-
-		// pass in Event
-		testEvent = (foo: true);
-		cueEvent = soundFile.cue(testEvent);
-		this.assert(cueEvent[\foo], "Cue should take an Event as first argument");
-
-		// playNow argument
-		cueEvent = soundFile.cue((), true);
-		0.5.wait;
-		this.assert(cueEvent.isRunning, "Event should play immediately after cueing");
-		cueEvent.stop;
-
-		// Test settable controls
-		group = Group.new(server);
-		testEvent = (bufferSize: 262144, firstFrame: 100, lastFrame: 200, out: 20, server: server, group: group, addAction: 1, amp: 0);
-		cueEvent = soundFile.cue(testEvent);
-		testEvent.keysDo { |key|
-			this.assertEquals(cueEvent[key], testEvent[key], "Control '%' was correclty set".format(key))
-		};
-
-		// closeWhenDone argument
-		soundFile.openRead;
-		soundFile.cue((lastFrame: 10), true, true);
-		0.5.wait;
-		this.assert(soundFile.isOpen.not, "SoundFile should close when finished playing");
-
-		// test cleanup
-		Buffer.freeAll;
-		server.quit.remove;
-
-	}
 }

--- a/testsuite/classlibrary/TestSoundFile_Server.sc
+++ b/testsuite/classlibrary/TestSoundFile_Server.sc
@@ -16,7 +16,7 @@ TestSoundFile_Server : UnitTest {
 	}
 
 	test_cue_passInEvent {
-		var cueEvent, testEvent, group, condition = Condition.new;
+		var cueEvent, testEvent, condition = Condition.new;
 
 		testEvent = (foo: true);
 		cueEvent = soundFile.cue(testEvent);

--- a/testsuite/classlibrary/TestSoundFile_Server.sc
+++ b/testsuite/classlibrary/TestSoundFile_Server.sc
@@ -1,0 +1,47 @@
+TestSoundFile_Server : UnitTest {
+
+	var server;
+
+	setUp {
+		server = Server(this.class.name);
+		this.bootServer(server);
+	}
+
+	tearDown {
+		server.quit.remove;
+	}
+
+	test_cue {
+		var cueEvent, testEvent, group;
+
+		// pass in Event
+		testEvent = (foo: true);
+		cueEvent = soundFile.cue(testEvent);
+		this.assert(cueEvent[\foo], "Cue should take an Event as first argument");
+
+		// playNow argument
+		cueEvent = soundFile.cue((), true);
+		0.5.wait;
+		this.assert(cueEvent.isRunning, "Event should play immediately after cueing");
+		cueEvent.stop;
+
+		// Test settable controls
+		group = Group.new(server);
+		testEvent = (bufferSize: 262144, firstFrame: 100, lastFrame: 200, out: 20, server: server, group: group, addAction: 1, amp: 0);
+		cueEvent = soundFile.cue(testEvent);
+		testEvent.keysDo { |key|
+			this.assertEquals(cueEvent[key], testEvent[key], "Control '%' was correclty set".format(key))
+		};
+
+		// closeWhenDone argument
+		soundFile.openRead;
+		soundFile.cue((lastFrame: 10), true, true);
+		0.5.wait;
+		this.assert(soundFile.isOpen.not, "SoundFile should close when finished playing");
+
+		// test cleanup
+		Buffer.freeAll;
+		server.quit.remove;
+	}
+
+}

--- a/testsuite/classlibrary/TestSoundFile_Server.sc
+++ b/testsuite/classlibrary/TestSoundFile_Server.sc
@@ -24,13 +24,15 @@ TestSoundFile_Server : UnitTest {
 	}
 
 	test_cue_playNow {
-		var cueEvent, condition = Condition.new;
+		var cueEvent, timeout, condition = Condition.new;
 
-		OSCFunc({ condition.unhang }, '/n_go', server.addr);
+		OSCdef(\isPlaying, { condition.unhang }, '/n_go', server.addr);
 		cueEvent = soundFile.cue((), true);
-		fork { 3.wait; condition.unhang };
+		timeout = fork { 3.wait; condition.unhang };
 		condition.hang;
 		this.assert(cueEvent.isRunning, "Event should play immediately after cueing");
+		timeout.stop;
+		OSCdef(\isPlaying).free;
 		cueEvent.stop;
 	}
 


### PR DESCRIPTION
This PR introduces a few fixes and documentation improvements to SoundFile's cue method.

- This PR fixes a mistake introduces in a previous PR (#3713) by correctly renaming the event key to `~sustainTime`
- The main fix here is related to the `closeWhenDone` argument. Previously, this arg had no effect. Now, the OSCFunc correctly fires which closes the buffer ~and SoundFile~.
- The documentation was improved to indicate the closing of the buffer by `closeWhenDone`.
- `bufferSize` used to be hardcoded to a value, even though the documentation suggested that it was settable. This control is now settable and the documentation has been improved.
- The sample rate is now obtained by `server.sampleRate` instead of looking it up in server.options.
- An unnecessary Condition was removed.
- A test for the cue method was added to ~TestSoundFile~ TestSoundFile_Server
