### PR TITLE
Add freeSelfResumeNext done action

### DIFF
--- a/HelpSource/Classes/Done.schelp
+++ b/HelpSource/Classes/Done.schelp
@@ -44,6 +44,8 @@ table::
 ## freeSelfAndDeepFreeNext || 12 || free this synth and if the following node is a group then do g_deepFree on it, else free it
 ## freeAllInGroup || 13 || free this synth and all other nodes in this group (before and after)
 ## freeGroup || 14 || free the enclosing group and all nodes within it (including this synth)
+## freeSelfResumeNext || 15 ||  free this synth and resume the following node
+
 ::
 
 For information on code::freeAll:: and code::deepFree::, see link::Classes/Group:: and link::Reference/Server-Command-Reference::.

--- a/SCClassLibrary/Common/Audio/EnvGen.sc
+++ b/SCClassLibrary/Common/Audio/EnvGen.sc
@@ -15,6 +15,7 @@ Done : UGen {
 	const <freeSelfAndDeepFreeNext = 12;
 	const <freeAllInGroup = 13;
 	const <freeGroup = 14;
+	const <freeSelfResumeNext = 15;
 
 	*kr { arg src;
 		^this.multiNew('control', src)

--- a/server/scsynth/SC_Node.cpp
+++ b/server/scsynth/SC_Node.cpp
@@ -471,5 +471,11 @@ void Unit_DoneAction(int doneAction, Unit *unit)
 		case 14 :
 			Node_End(&unit->mParent->mNode.mParent->mNode);
 			break;
+		case 15 :
+		{
+			Node_End(&unit->mParent->mNode);
+			Node* next = unit->mParent->mNode.mNext;
+			if (next) Node_SetRun(next, 1);
+		} break;
 	}
 }

--- a/server/supernova/sc/sc_plugin_interface.cpp
+++ b/server/supernova/sc/sc_plugin_interface.cpp
@@ -213,6 +213,22 @@ void free_node_and_pause_following(Unit * unit)
         sc_factory->add_pause_node(next);
 }
 
+void free_node_and_resume_following(Unit * unit)
+{
+	server_node * node = static_cast<sc_synth*>(unit->mParent);
+	sc_factory->add_done_node(node);
+
+	if (node->get_parent()->is_parallel()) {
+		spin_lock::scoped_lock lock(log_guard);
+		log("parallel groups have no notion of following nodes\n");
+		return;
+	}
+	
+	server_node * next = node->next_node();
+	if (next)
+		sc_factory->add_resume_node(next);
+}
+	
 void free_node_and_following_children(Unit * unit)
 {
     server_node * node = static_cast<sc_synth*>(unit->mParent);
@@ -550,6 +566,11 @@ void done_action(int done_action, struct Unit *unit)
         // free the enclosing group and all nodes within it (including this synth)
         nova::free_parent_group(unit);
         return;
+	
+	case 15:
+		// free this synth and resume the following node
+		nova::free_node_and_resume_following(unit);
+		return;
 
     default:
         return;

--- a/testsuite/classlibrary/TestDoneActions.sc
+++ b/testsuite/classlibrary/TestDoneActions.sc
@@ -45,21 +45,3 @@ TestDoneActions : UnitTest {
 	}
 
 }
-
-TestDoneActionsSupernova : TestDoneActions {
-
-	setUp {
-		Server.supernova;
-		super.setUp;
-	}
-
-	tearDown {
-		super.tearDown;
-		Server.scsynth;
-	}
-
-	// this is needed so that the UnitTest run  method can find the method selector
-	test_freeSelfAndResumeNext {
-		super.test_freeSelfAndResumeNext
-	}
-}

--- a/testsuite/classlibrary/TestDoneActions.sc
+++ b/testsuite/classlibrary/TestDoneActions.sc
@@ -1,0 +1,50 @@
+TestDoneActions : UnitTest {
+	var server;
+
+	setUp {
+
+		server = Server(this.class.name);
+		this.bootServer(server);
+		server.notify;
+		server.sync;
+
+		SynthDef(this.class.name, { |doneAction|
+			Line.kr(0, 0, 0.01, doneAction:doneAction)
+		}).send(server);
+
+		server.sync;
+	}
+
+	tearDown {
+
+		server.quit.remove;
+
+	}
+
+	test_freeSelfAndResumeNext {
+		var synths, allPlaying, allEnded;
+
+		synths = Array.fill(4, {
+			Synth.newPaused(
+				this.class.name,
+				[\doneAction, Done.freeSelfResumeNext],
+				server,
+				addAction:\addToTail
+			).register
+		});
+
+		0.2.wait;
+		allPlaying = synths.every { |x| x.isPlaying };
+
+		synths.first.run(true);
+
+		0.2.wait;
+		allEnded = synths.every { |x| x.isPlaying.not };
+
+		this.assert(allPlaying, "the chain of synths should first be playing");
+		this.assert(allEnded, "the chain of synths should have freed itself");
+	}
+
+}
+
+

--- a/testsuite/classlibrary/TestDoneActions.sc
+++ b/testsuite/classlibrary/TestDoneActions.sc
@@ -2,7 +2,6 @@ TestDoneActions : UnitTest {
 	var server;
 
 	setUp {
-
 		server = Server(this.class.name);
 		this.bootServer(server);
 		server.notify;
@@ -47,4 +46,20 @@ TestDoneActions : UnitTest {
 
 }
 
+TestDoneActionsSupernova : TestDoneActions {
 
+	setUp {
+		Server.supernova;
+		super.setUp;
+	}
+
+	tearDown {
+		super.tearDown;
+		Server.scsynth;
+	}
+
+	// this is needed so that the UnitTest run  method can find the method selector
+	test_freeSelfAndResumeNext {
+		super.test_freeSelfAndResumeNext
+	}
+}


### PR DESCRIPTION
This PR adds a new `doneAction`, namely `Done.freeSelfResumeNext` (number 15). It is analogous to `freeSelfPauseNext` (number 10).

This PR is motivated by the lack of sample based scheduling in sclang. The done action allows us to build a  queue of paused synths that resume each other in a series, while new paused synths can be added. 

Here is an example that streams sclang generated values to scsynth:

```supercollider
(
var n = 2048;
SynthDef(\seq, { |out = 0|
	var array, signal;
	array = \array.ir(0 ! n);
	signal = Duty.ar(SampleDur.ir, 0, Dseq(array, 1), doneAction:Done.freeSelfResumeNext);
	ReplaceOut.ar(out, signal)
}).add
)


(
var block = 2048;
var dt = 1/s.sampleRate;
var dur = dt * block;
var synths;


var nextN = value {
	var c = 0;
	var freq = 64.midicps;
	var r = 2pi * freq * dt;
	{ |n|
		{
			var z = sin(c * r) * 0.1;
			c = c + 1;
			z
		} ! n
	}
};

var addSynth = { |array|
		synths = synths.add(
			Synth.newPaused(\seq, [array: array], addAction:\addToTail);
		)
};

var nextSynth = {
	synths.removeAt(0)//.run(1);
};

var initSynths = { |n|
	n.do {
		addSynth.(nextN.(block))
	}
};


fork {
	initSynths.(3);
	0.1.wait;
	synths.first.run(true);
	inf.do {
		addSynth.(nextN.(block));
		nextSynth.();
		dur.wait;
	}
};
)


```

Feel free to discuss. 

I'd prefer to have a synced server clock (or soundcard clock) in sclang -- I just don't know if the work to get it done will keep it on the hold forever.