### PR TITLE
Fix event parent type regression

### DIFF
--- a/SCClassLibrary/Common/Collections/Event.sc
+++ b/SCClassLibrary/Common/Collections/Event.sc
@@ -27,7 +27,7 @@ Event : Environment {
 
 	*addEventType { arg type, func, parentEvent;
 		partialEvents.playerEvent.eventTypes.put(type, func);
-		this.addParentType(parentEvent)
+		this.addParentType(type, parentEvent)
 	}
 
 	*addParentType { arg type, parentEvent;

--- a/testsuite/classlibrary/TestEvent.sc
+++ b/testsuite/classlibrary/TestEvent.sc
@@ -102,6 +102,16 @@ TestEvent : UnitTest {
 
 	}
 
+	test_event_addParentType {
+		var event, noError = true;
+		Event.addEventType(\testType, {
+			~calculated = ~given;
+		}, (given: 1));
+		// must play to attach parent event
+		event = (type: \testType).play;
+		this.assert(event[\calculated] == 1, "parentType values should be accessible during event play");
+	}
+
 	test_server_message_head_type_grain {
 		this.assertEqualServerMessage(\grain, [9, \default, -1, 0,  this.defaultGroupID])
 	}


### PR DESCRIPTION
OK, this is a howler.

https://github.com/supercollider/supercollider/commit/f570219ac1b320639fab944e695c2900de35b7a6#diff-d6dd1b5f66b384ff6c730a82fb0710aaR25

Before the change, we correctly `put` into the parentTypes dictionary `(type, protoEvent)`.

After the change, the `put` moved into a new method `addParentType` with method signature `type, parentEvent` (reasonable) but *the call to this method omits the `type` argument*. So, where it used to work, now it's attempting to put into the parentTypes dictionary where the protoEvent is the key, and nil is the value. So the parentTypes dictionary is always empty, and user-supplied default values are never accessible.

Which means the author of this change committed, pushed, and pull-requested without running even the most rudimentary test. That's a process problem. Nobody should ever be submitting PRs for untested changes. Not ever, not under any circumstances.

As the present case is evidence in favor of even spot-checking by unit tests, I'm also submitting a unit test for it.