### PR TITLE
class library: event.synth works without args

### DIFF
--- a/SCClassLibrary/Common/Collections/Event.sc
+++ b/SCClassLibrary/Common/Collections/Event.sc
@@ -1027,7 +1027,7 @@ Event : Environment {
 						msgFunc = ~defaultMsgFunc;
 					};
 
-					msgs = msgFunc.valueEnvir.flop;
+					msgs = msgFunc.valueEnvir.asArray.flop;
 					ids = Event.checkIDs(~id, server);
 					if (ids.isNil) { ids = msgs.collect { server.nextNodeID } };
 					bndl = ids.collect { |id, i|


### PR DESCRIPTION
This fixes #3742.

Note that in the other synth like events, the args are flopped after
the messages are composed with their “head”, and then their ids are
placed inside them.

This is supposed to be a minimal change, so just canceling out the bad
case.