### PR TITLE
ServerOptions:asOptionsString: fix to use correct concatenation

### DIFF
--- a/HelpSource/Classes/Platform.schelp
+++ b/HelpSource/Classes/Platform.schelp
@@ -134,6 +134,9 @@ platform specific directory for class files (see link::Guides/UsingExtensions::)
 method:: pathSeparator
 platform specific path separator
 
+method:: pathDelimiter
+platform specific path delimiter
+
 method:: recordingsDir
 platform recordings directory
 

--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -141,7 +141,7 @@ ServerOptions {
 			o = o ++ " -U " ++ if(ugenPluginsPath.isString) {
 				ugenPluginsPath
 			} {
-				ugenPluginsPath.join("; ");
+				ugenPluginsPath.join(":");
 			};
 		});
 		if (memoryLocking, {

--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -141,7 +141,7 @@ ServerOptions {
 			o = o ++ " -U " ++ if(ugenPluginsPath.isString) {
 				ugenPluginsPath
 			} {
-				ugenPluginsPath.join(":");
+				ugenPluginsPath.join(Platform.pathDelimiter);
 			};
 		});
 		if (memoryLocking, {

--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -138,11 +138,12 @@ ServerOptions {
 			o = o ++ " -P " ++ restrictedPath;
 		});
 		if (ugenPluginsPath.notNil, {
-			o = o ++ " -U " ++ if(ugenPluginsPath.isString) {
-				ugenPluginsPath
-			} {
-				ugenPluginsPath.join(Platform.pathDelimiter);
-			};
+			if(ugenPluginsPath.isString, {
+				ugenPluginsPath = ugenPluginsPath.bubble;
+			});
+			o = o ++ " -U " ++ ugenPluginsPath.collect{|p|
+				thisProcess.platform.formatPathForCmdLine(p)
+			}.join(Platform.pathDelimiter);
 		});
 		if (memoryLocking, {
 			o = o ++ " -L";

--- a/SCClassLibrary/Platform/Platform.sc
+++ b/SCClassLibrary/Platform/Platform.sc
@@ -93,6 +93,9 @@ Platform {
 	pathSeparator { ^this.subclassResponsibility }
 	*pathSeparator { ^thisProcess.platform.pathSeparator }
 
+	pathDelimiter{ ^this.subclassResponsibility }
+	*pathDelimiter { ^thisProcess.platform.pathDelimiter }
+
 	isPathSeparator { |char| ^this.subclassResponsibility }
 	*isPathSeparator { |char| ^thisProcess.platform.isPathSeparator(char) }
 
@@ -190,6 +193,7 @@ Platform {
 
 UnixPlatform : Platform {
 	pathSeparator { ^$/ }
+    pathDelimiter { ^$: }
 
 	isPathSeparator { |char|
 		^(char === this.pathSeparator)

--- a/SCClassLibrary/Platform/windows/WindowsPlatform.sc
+++ b/SCClassLibrary/Platform/windows/WindowsPlatform.sc
@@ -23,6 +23,8 @@ WindowsPlatform : Platform {
 	}
 
 	pathSeparator { ^$\\ }
+    pathDelimiter { ^$; }
+
 	isPathSeparator { |char|
 		^#[$\\, $/].includes(char)
 	}

--- a/server/scsynth/scsynth_main.cpp
+++ b/server/scsynth/scsynth_main.cpp
@@ -94,8 +94,14 @@ void Usage()
 		"          -2 suppresses informational and many error messages, as well as\n"
 		"             messages from Poll.\n"
 		"          The default is 0.\n"
-		"   -U <ugen-plugins-path>    a colon-separated list of paths\n"
-		"          if -U is specified, the standard paths are NOT searched for plugins.\n"
+#ifdef _WIN32
+		"   -U <ugen-plugins-path>\n"    
+		"          A list of paths seperated by `;`.\n"
+#else
+		"   -U <ugen-plugins-path>\n"
+		"          A list of paths seperated by `:`.\n"
+#endif
+		"          If specified, standard paths are NOT searched for plugins.\n"
 		"   -P <restricted-path>    \n"
 		"          if specified, prevents file-accessing OSC commands from\n"
 		"          accessing files outside <restricted-path>.\n"

--- a/server/supernova/server/server_args.cpp
+++ b/server/supernova/server/server_args.cpp
@@ -65,8 +65,13 @@ server_arguments::server_arguments(int argc, char * argv[])
         ("verbose,V", value<int16_t>(&verbosity)->default_value(0), "verbosity: 0 is normal behaviour\n-1 suppresses informational messages\n"
                                                             "-2 suppresses informational and many error messages, as well as\n"
                                                             "messages from Poll.")
-        ("ugen-search-path,U", value<vector<string> >(&ugen_paths), "a colon-separated list of paths\n"
-                                                                    "if -U is specified, the standard paths are NOT searched for plugins.")
+#ifdef _WIN32
+        ("ugen-search-path,U", value<vector<string> >(&ugen_paths), "A list of paths seperated by `;`.\n"
+                                                            "If specified, standard paths are NOT searched for plugins.\nMay be specified several times.")
+#else
+        ("ugen-search-path,U", value<vector<string> >(&ugen_paths), "A list of paths seperated by `:`.\n"
+                                                            "If specified, standard paths are NOT searched for plugins.\nMay be specified several times.")
+#endif
         ("restricted-path,P", value<vector<string> >(&restrict_paths), "if specified, prevents file-accessing OSC commands from accessing files outside <restricted-path>")
         ("threads,T", value<uint16_t>(&threads)->default_value(boost::thread::physical_concurrency()), "number of audio threads")
         ;


### PR DESCRIPTION
This PR fixes `asOptionsString` to use correct concatenation (as described in `scsynth -h`) for `ugenPluginPath` (`scsynth -U <path>[:<path>[:<path>]]`) (`":"` instead of `"; "`).


## Test

Like most developers, I have built SC and sc3-plugins from source. This means I have two valid paths.


Test that pluginpath works

```
(
// plugin paths without plugins
s.options.ugenPluginsPath = thisProcess.platform.helpDir

)

s.options.asOptionsString;

s.reboot
```

results in (anticipated) errors

```
-> Booting server 'localhost' on address 127.0.0.1:57110.
*** ERROR: open directory failed '/localvol/sound/src/supercollider/Help': No such file or directory
exception in GraphDef_Load: UGen 'Control' not installed.
[...]
```

Test general plugin paths
```
(
// fill your own plugin paths here
s.options.ugenPluginsPath = [
	"/localvol/sound/src/sc3-plugins/build/build_osx/SC3plugins/",
	"/localvol/sound/src/supercollider/build/Install/SuperCollider/SuperCollider.app/Contents/Resources/plugins"
];
)

// escaped options string
s.options.asOptionsString;

s.reboot;
```

You should see something like this:

```
[...]
Found 98 LADSPA plugins
[...]
SuperCollider 3 server ready.
Requested notification messages from server 'localhost'
localhost: server process's maxLogins (1) matches with my options.
localhost: keeping clientID (0) as confirmed by server process.
Shared memory server interface initialized
```

This means sc3-plugins are found.

There should _not_ be anything like

```
exception in GraphDef_Load: UGen 'Control' not installed.
while reading file: '/home/dlm/.local/share/SuperCollider/synthdefs/system_line_audio.scsyndef'
```

This'd mean that the standard plugin library is _not_ loaded.

Alternatively, and particularly to test path escaping, make a hardcopy of the plugins to a temp directory that has spaces in its path and run

```
(
s.options.ugenPluginsPath = [
	"/Users/tboverma/tmp/pluginpath with space/SC3plugins/",
	"/Users/tboverma/tmp/pluginpath with space/plugins/"
];
)
```

Results should be similar as in the previous case.