### PR TITLE
readmes: fix path to plugins

### DIFF
--- a/README_MACOS.md
+++ b/README_MACOS.md
@@ -342,7 +342,7 @@ And for `scsynth`:
 
     #!/bin/sh
     cd /full/path/to/SuperCollider.app/Contents/Resources
-    export SC_PLUGIN_PATH="/full/path/to/SuperCollider.app/Resources/plugins/";
+    export SC_PLUGIN_PATH="/full/path/to/SuperCollider.app/Contents/Resources/plugins/";
     exec ./scsynth $*
 
 ###### Why not just symlink them ?


### PR DESCRIPTION
Hi there,
This is my first contribution in this repo, and one of my first OS contrib... My apologies for everything I'm doing wrong!

This PR is to fix a typo in a path in README_MACOS.md. In the part about accessing sclang and scsynth from the Terminal, the path for SC_PLUGIN_PATH is incorrect (missing "Contents/").

Looking forward to more substantial PRs!