### PR TITLE
fix link doc to envir

### DIFF
--- a/SCClassLibrary/Common/Collections/EnvironmentRedirect.sc
+++ b/SCClassLibrary/Common/Collections/EnvironmentRedirect.sc
@@ -160,16 +160,14 @@ EnvironmentRedirect {
 		stream << " ]" ;
 	}
 
-	linkDoc { arg doc, pushNow=true;
+	linkDoc { arg doc;
 		doc = doc ? Document.current;
 		doc.envir_(this);
-		if(pushNow and: { currentEnvironment !== this }) { this.push };
 	}
 
-	unlinkDoc { arg doc, popNow = false;
+	unlinkDoc { arg doc;
 		doc = doc ? Document.current;
 		if(doc.envir === this) { doc.envir_(nil) };
-		if(popNow and:  { currentEnvironment === this }) { this.pop };
 	}
 
 	// networking

--- a/SCClassLibrary/scide_scqt/ScIDE.sc
+++ b/SCClassLibrary/scide_scqt/ScIDE.sc
@@ -794,7 +794,6 @@ Document {
 				this.text.interpret;
 			}
 		};
-		current = this;
 		initAction.value(this);
 	}
 

--- a/SCClassLibrary/scide_scqt/ScIDE.sc
+++ b/SCClassLibrary/scide_scqt/ScIDE.sc
@@ -454,7 +454,7 @@ Document {
 	var <keyDownAction, <keyUpAction, <mouseUpAction, <mouseDownAction;
 	var <>toFrontAction, <>endFrontAction, <>onClose, <textChangedAction;
 
-	var <envir, savedEnvir;
+	var <envir, <savedEnvir;
 	var <editable = true, <promptToSave = true;
 
 	*initClass{
@@ -584,7 +584,7 @@ Document {
 
 	closed {
 		onClose.value(this); // call user function
-		this.restoreCurrentEnvironment;
+		this.restorePreviousEnvironment;
 		allDocuments.remove(this);
 	}
 
@@ -698,13 +698,13 @@ Document {
 
 	didBecomeKey {
 		this.class.current = this;
-		this.saveCurrentEnvironment;
+		this.pushLinkedEnvironment;
 		toFrontAction.value(this);
 	}
 
 	didResignKey {
 		endFrontAction.value(this);
-		this.restoreCurrentEnvironment;
+		this.restorePreviousEnvironment;
 	}
 
 	keyDown { | modifiers, unicode, keycode, key |
@@ -881,27 +881,35 @@ Document {
 
 	// envir stuff
 
-	envir_ { | ev |
-		envir = ev;
-		if (this.class.current == this) {
-			if(envir.isNil) {
-				this.restoreCurrentEnvironment
-			} {
-				if (savedEnvir.isNil) {
-					this.saveCurrentEnvironment
-				}
-			}
-		}
+	hasSavedPreviousEnvironment {
+		^savedEnvir.notNil
 	}
 
-	restoreCurrentEnvironment {
+	envir_ { | newEnvir |
+
+		envir = newEnvir;
+
+		if(this.isFront) {
+			if(newEnvir.isNil) {
+				this.restorePreviousEnvironment
+			} {
+				if(this.hasSavedPreviousEnvironment.not) {
+					savedEnvir = currentEnvironment;
+				};
+				currentEnvironment = envir;
+			}
+		}
+
+	}
+
+	restorePreviousEnvironment { // happens on leaving focus
 		if (savedEnvir.notNil) {
 			currentEnvironment = savedEnvir;
 			savedEnvir = nil;
 		}
 	}
 
-	saveCurrentEnvironment {
+	pushLinkedEnvironment { // happens on focus
 		if (envir.notNil) {
 			savedEnvir = currentEnvironment;
 			currentEnvironment = envir;

--- a/testsuite/classlibrary/TestDocument.sc
+++ b/testsuite/classlibrary/TestDocument.sc
@@ -1,73 +1,125 @@
-TestDocument : UnitTest {
+TestDocumentEnvir : UnitTest {
 
+	var doc, envir1, envir2, envir0;
 
-	test_document_envir {
-
-		var doc, envir1, envir2, envir0;
-		var closeCount = 0, closeCounter, endFrontCount = 0, endFrontCounter;
-
+	setUp {
 		envir0 = (a: 0);
 		envir1 = (a: 27);
 		envir2 = (a: 29);
 
 		currentEnvironment = envir0;
 		doc = Document(envir: envir1);
+	}
 
-		// check base state
+	tearDown {
+		doc.close;
+		currentEnvironment = topEnvironment;
+	}
+
+	test_new_document_in_background {
 		this.assert(doc.isFront.not,
 			"new document should be created in the background by default");
+	}
 
-		this.assert(currentEnvironment === envir0,
+	test_new_document_in_background_neutral {
+		this.assertEquals(currentEnvironment, envir0,
 			"background document linked with envir on creation should not change currentEnvironment");
+	}
+
+	test_set_envir_in_background {
 
 		doc.envir = envir2;
 
-		this.assert(currentEnvironment === envir0,
+		this.assertEquals(currentEnvironment, envir0,
 			"background document linked with envir interactively should not change currentEnvironment");
 
+	}
+
+	test_document_to_front {
+
+		doc.envir = envir2;
 
 		doc.front;
 
-		this.assert(currentEnvironment === envir2,
+		this.assertEquals(currentEnvironment, envir2,
 			"focused document linked with envir should push its environment");
+	}
 
-		this.assert(doc.savedEnvir === envir0,
+	test_document_to_front_save_old_envir {
+
+		doc.envir = envir2;
+
+		doc.front;
+
+		this.assertEquals(doc.savedEnvir, envir0,
 			"focused document linked with envir should save its old environment");
+	}
+
+	test_set_envir_in_foreground {
+
+		doc.envir = envir2;
+
+		doc.front;
 
 		doc.envir = envir1;
 
-		this.assert(currentEnvironment === envir1,
+		this.assertEquals(currentEnvironment, envir1,
 			"focused document linked with envir should push envir when envir is changed");
 
-		this.assert(doc.savedEnvir === envir0,
+	}
+
+	test_set_envir_in_foreground_keep_old_envir {
+
+		doc.envir = envir2;
+
+		doc.front;
+
+		doc.envir = envir1;
+
+		this.assertEquals(doc.savedEnvir, envir0,
 			"focused document linked with envir should keep its old saved environment when envir is changed");
 
-		closeCounter = { closeCount = closeCount + 1 };
-		endFrontCounter = { endFrontCount = endFrontCount + 1 };
-		doc.onClose = closeCounter;
-		doc.endFrontAction = endFrontCounter;
+	}
+
+	test_onClose {
+		var test = { this.assertEquals(count, 1, "onClose should be called not more than once") };
+		var count = 0;
+		var counter = { count = count + 1; test.value; };
+		doc.onClose = counter;
+		doc.close;
+
+	}
+
+	test_endFront_on_close {
+
+		var test = { this.assertEquals(count, 1, "endFrontAction should be called not more than once") };
+		var count = 0;
+		var counter = { count = count + 1; test.value; };
+		doc.endFrontAction = counter;
+		doc.close;
+	}
+
+	test_close_restore_old_envir {
+
+		var test = {
+			this.assertEquals(currentEnvironment, envir0,
+				"closing document linked with envir should restore original currentEnvironment"
+			)
+		};
+
+		doc.envir = envir2;
+
+		doc.front;
+
+		doc.onClose = test;
 
 		doc.close;
 
-		/*
-
-		0.3.wait;
-
-		this.assertEquals(closeCount, 1, "onClose should be called once");
-		this.assertEquals(endFrontCount, 1, "endFrontAction should be called once");
-
-
-
-		// this fails, has envir1 (a: 27) as current.
-		// the test works when done by hand, it just fails in the test environment
-
-		this.assertEquals(currentEnvironment, envir0,
-			"closing document linked with envir should restore original currentEnvironment");
-		*/
-
-
 
 	}
+
+
+
 
 }
 

--- a/testsuite/classlibrary/TestDocument.sc
+++ b/testsuite/classlibrary/TestDocument.sc
@@ -1,0 +1,73 @@
+TestDocument : UnitTest {
+
+
+	test_document_envir {
+
+		var doc, envir1, envir2, envir0;
+		var closeCount = 0, closeCounter, endFrontCount = 0, endFrontCounter;
+
+		envir0 = (a: 0);
+		envir1 = (a: 27);
+		envir2 = (a: 29);
+
+		currentEnvironment = envir0;
+		doc = Document(envir: envir1);
+
+		// check base state
+		this.assert(doc.isFront.not,
+			"new document should be created in the background by default");
+
+		this.assert(currentEnvironment === envir0,
+			"background document linked with envir on creation should not change currentEnvironment");
+
+		doc.envir = envir2;
+
+		this.assert(currentEnvironment === envir0,
+			"background document linked with envir interactively should not change currentEnvironment");
+
+
+		doc.front;
+
+		this.assert(currentEnvironment === envir2,
+			"focused document linked with envir should push its environment");
+
+		this.assert(doc.savedEnvir === envir0,
+			"focused document linked with envir should save its old environment");
+
+		doc.envir = envir1;
+
+		this.assert(currentEnvironment === envir1,
+			"focused document linked with envir should push envir when envir is changed");
+
+		this.assert(doc.savedEnvir === envir0,
+			"focused document linked with envir should keep its old saved environment when envir is changed");
+
+		closeCounter = { closeCount = closeCount + 1 };
+		endFrontCounter = { endFrontCount = endFrontCount + 1 };
+		doc.onClose = closeCounter;
+		doc.endFrontAction = endFrontCounter;
+
+		doc.close;
+
+		/*
+
+		0.3.wait;
+
+		this.assertEquals(closeCount, 1, "onClose should be called once");
+		this.assertEquals(endFrontCount, 1, "endFrontAction should be called once");
+
+
+
+		// this fails, has envir1 (a: 27) as current.
+		// the test works when done by hand, it just fails in the test environment
+
+		this.assertEquals(currentEnvironment, envir0,
+			"closing document linked with envir should restore original currentEnvironment");
+		*/
+
+
+
+	}
+
+}
+

--- a/testsuite/classlibrary/TestDocumentEnvir.sc
+++ b/testsuite/classlibrary/TestDocumentEnvir.sc
@@ -1,4 +1,4 @@
-TestDocumentEnvir : UnitTest {
+TestDocumentEnvironment : UnitTest {
 
 	var doc, envir1, envir2, envir0;
 

--- a/testsuite/classlibrary/TestDocumentEnvir.sc
+++ b/testsuite/classlibrary/TestDocumentEnvir.sc
@@ -123,3 +123,37 @@ TestDocumentEnvir : UnitTest {
 
 }
 
+
+TestEnvironmentDocument : UnitTest {
+	var doc;
+
+	setUp {
+		currentEnvironment = topEnvironment;
+		doc = Document();
+	}
+
+	tearDown {
+		doc.close;
+	}
+
+	test_linkDoc {
+		var envir = (a: 9);
+		doc.front;
+		envir.linkDoc(doc);
+		this.assertEquals(currentEnvironment, envir, "a linked environment should be current when document has focus");
+	}
+
+	test_unlinkDoc {
+		var envir = (a: 9);
+		var oldCurrent = currentEnvironment;
+		doc.front;
+
+		envir.linkDoc(doc);
+		envir.unlinkDoc(doc);
+		this.assertEquals(currentEnvironment, oldCurrent, "a linked environment restore original envir when unlinked");
+
+	}
+
+}
+
+


### PR DESCRIPTION
This fixes #3717.

The basic assumption is that only one document can be in focus.

1. when a document comes to focus that has an envir bound to it, it should make that envir the `currentEnvironment`. Whatever envir that was current at that time should be saved.
2. when a document loses focus (either by closing or because one moves to another one), it should restore the envir that was currentEnvironment before.
3. when we set the envir of a document that has no focus, it should not do anything but store the envir for the moment it comes to focus.
4. when we set the envir of a document that has focus, the envir should by default become `currentEnvironment`, so that it is in a consistent state.
