### PR TITLE
docs: mouse(Up|Down)Action

### DIFF
--- a/HelpSource/Classes/Document.schelp
+++ b/HelpSource/Classes/Document.schelp
@@ -264,13 +264,13 @@ method:: mouseDownAction
 Get/set the action to be performed on link::Classes/Document#mouseDown::.
 
 argument:: action
-An instance of link::Classes/Function:: or link::Classes/FunctionList::. The arguments passed to the function are: code::document::, code::x::, code::y::, code::modifiers::, code::buttonNumber::, code::clickCount::, code::clickPos::.
+An instance of link::Classes/Function:: or link::Classes/FunctionList::. The arguments passed to the function are: code::document::, code::x::, code::y::, code::modifiers::, code::buttonNumber::, code::clickCount::.
 
 
 method:: mouseUpAction
 Get/set the action to be performed on link::Classes/Document#mouseUp::.
 argument:: action
-An instance of link::Classes/Function:: or link::Classes/FunctionList::. The arguments passed to the function are: code::document::, code::x::, code::y::, code::modifiers::, code::buttonNumber::, code::clickCount::, code::clickPos::.
+An instance of link::Classes/Function:: or link::Classes/FunctionList::. The arguments passed to the function are: code::document::, code::x::, code::y::, code::modifiers::, code::buttonNumber::.
 discussion::
 code::
 (

--- a/HelpSource/Classes/TextView.schelp
+++ b/HelpSource/Classes/TextView.schelp
@@ -269,7 +269,7 @@ t = TextView(w.asView,Rect(10,10, 500,200))
 )
 
 // Using the Window you just created, try these in succession, and test how the text view responds
-t.mouseUpAction_{|it, x, y, modifiers, buttonNumber, clickCount, pos| [pos].postln};
+t.mouseUpAction_{|it, x, y, modifiers, buttonNumber| [x, y].postln};
 t.autohidesScrollers_(false);
 t.hasVerticalScroller_(false);
 t.hasVerticalScroller_(true);

--- a/HelpSource/Classes/View.schelp
+++ b/HelpSource/Classes/View.schelp
@@ -525,7 +525,7 @@ METHOD:: mouseDownAction
 METHOD:: mouseUpAction
     The object to be evaluated when a mouse button is released after it was pressed on the view.
 
-    The following arguments are passed at evaluation: strong::view, x, y, modifiers::. See link::#Mouse actions:: for explanation of arguments.
+    The following arguments are passed at evaluation: strong::view, x, y, modifiers, buttonNumber::. See link::#Mouse actions:: for explanation of arguments.
 
     The return value of evaluation controls the event propagation to parent view. See link::#Key and mouse event processing:: for details.
 


### PR DESCRIPTION
these functions were incorrectly documented on both Document and View

quick test script showing that the arguments passed to the function are in fact the ones I've documented:

```supercollider
w = Window.new.front
w.view.mouseDownAction_ { |...args| args.postln; };
w.view.mouseUpAction_ { |...args| args.postln; };
Document.current.mouseDownAction_ { |...args| args.postln; };
Document.current.mouseUpAction_ { |...args| args.postln; };

// mouse down actions are passed 6 args, mouse up actions are passed 5
```