### PR TITLE
sclang: Fix excessive calls to SC_TerminalClient::tick when SC_QT is off

### DIFF
--- a/lang/LangSource/SC_TerminalClient.cpp
+++ b/lang/LangSource/SC_TerminalClient.cpp
@@ -410,7 +410,11 @@ extern void ElapsedTimeToChrono(double elapsed, std::chrono::system_clock::time_
 
 void SC_TerminalClient::tick( const boost::system::error_code& error )
 {
-	mTimer.cancel();
+	if (error == boost::system::errc::success) {
+		mTimer.cancel();
+	} else {
+		return;
+	}
 
 	double secs;
 	lock();

--- a/lang/LangSource/SC_TerminalClient.cpp
+++ b/lang/LangSource/SC_TerminalClient.cpp
@@ -408,8 +408,47 @@ void SC_TerminalClient::onQuit( int exitCode )
 
 extern void ElapsedTimeToChrono(double elapsed, std::chrono::system_clock::time_point & out_time_point);
 
+/**
+ * \brief Repeatedly calls the main AppClock loop.
+ *
+ * This method does the following:
+ *
+ * - Wraps \c tickLocked (locking \c gLangMutex before and after), which in
+ *   turn calls \c runLibrary.
+ * - Schedules to call itself again using a \c boost::asio::basic_waitable_timer
+ *   (\c mTimer).
+ *
+ * Since it calls itself, a single call to \c tick will cause the method to
+ * keep calling itself autonomously.
+ *
+ * If \c tick is called again externally while a timer is running, any
+ * previously scheduled \c tick call is canceled. This forces a premature \c
+ * tick, which will schedule itself again, and so on.
+ *
+ * The timed calls to \c tick are used for events scheduled on the AppClock.
+ * The interruption feature is used when sclang receives unanticipated events
+ * such as inbound OSC messages.
+ */
 void SC_TerminalClient::tick( const boost::system::error_code& error )
 {
+	/*
+	Even if the timeout is canceled, this callback will always fire (see docs
+	for boost::asio::basic_waitable_timer).
+
+	Distinguishing between a canceled and successful callback is done by
+	inspecting the error. If it turns out this method was called because of a
+	cancelled timer, we need to bail out and let the tick call that
+	interrupted us take over.
+
+	If we aren't the result of a canceled timer call, we're either the result
+	of a scheduled timer expiry, or we *are* the interruption and we need to
+	cancel any scheduled tick calls. Calling mTimer.cancel() if the error is
+	a success error code handles both cases.
+
+	Previously, instead of this if/else block, this was just a call to
+	mTimer.cancel(). This was causing this method to rapidly call itself
+	excessively, hogging the CPU. See discussion at #2144.
+	*/
 	if (error == boost::system::errc::success) {
 		mTimer.cancel();
 	} else {
@@ -651,7 +690,7 @@ void SC_TerminalClient::endInput()
 	mInputService.stop();
 	mStdIn.cancel();
 #ifdef _WIN32
-	// Note this breaks Windows XP compatibility, since this function is only defined in Vista and later 
+	// Note this breaks Windows XP compatibility, since this function is only defined in Vista and later
 	::CancelIoEx(GetStdHandle(STD_INPUT_HANDLE), nullptr);
 #endif
 	postfl("main: waiting for input thread to join...\n");


### PR DESCRIPTION
this cherrypicks @giuliomoro's fix for #2144, the infamous "CPU hog when built without Qt" issue. this fix has been used for a long time in the bela fork of SC. see his comment here for explanation: https://github.com/supercollider/supercollider/issues/2144#issuecomment-320401926.

the fix seems quite logical to me, and i've tested and verified that it corrects the behavior. ~~what is mysterious is not the bug itself, but the fact that it *doesn't* happen when sclang is built *with* Qt.~~ **EDIT:** it's actually hilariously simple, there's an `#ifdef SC_QT` which redirects `SC_TerminalClient` to the completely separate `LanguageClient` code in QtCollider. so this is symptomatic of a larger problem: fragmentation of code depending on whether SC_QT is on or off, which is most likely a historical artifact of QtCollider's origins. this patch does seem fine to me though.

thanks so much to @giuliomoro, and sincere apologies to the alternate-client and embedded SC crowds for delaying on this for so long.

## Test case

build SC with `cmake -DSC_QT=OFF`. create a file called `foo.scd` with the following:

```
Server.default.waitForBoot {
   Routine {
      x = play { SinOsc.ar };
      "thing happening".postln;
      1.wait;
      x.free;
   }.play
}
```

run `sclang foo.scd` (makes sound). after this patch, sclang no longer uses a ludicrous amount of CPU.