### PR TITLE
sclang: fixes crash on call to Array::lace with empty subarrays

### DIFF
--- a/lang/LangPrimSource/PyrArrayPrimitives.cpp
+++ b/lang/LangPrimSource/PyrArrayPrimitives.cpp
@@ -2019,7 +2019,7 @@ int prArrayLace(struct VMGlobals *g, int numArgsPushed)
 		// the length of the shortest sub-array and the number of sub-arrays.
 		for (j=0; j<numLists; ++j) {
 			slot = slots + j;
-			if(isKindOfSlot(slot, class_array))	{
+			if(isKindOfSlot(slot, class_array)) {
 				len = slotRawObject(slot)->size;
 				if(j==0 || n>len) { n = len; }
 			} else {
@@ -2054,7 +2054,7 @@ int prArrayLace(struct VMGlobals *g, int numArgsPushed)
 						SetNil(&obj2->slots[i]);
 					}
 				} else {
-					slotCopy(&obj2->slots[i],&obj3->slots[k]);
+					slotCopy(&obj2->slots[i],&slots[k]);
 				}
 			} else {
 				slotCopy(&obj2->slots[i],&slots[k]);

--- a/lang/LangPrimSource/PyrArrayPrimitives.cpp
+++ b/lang/LangPrimSource/PyrArrayPrimitives.cpp
@@ -2050,7 +2050,7 @@ int prArrayLace(struct VMGlobals *g, int numArgsPushed)
 					m = j % obj3->size;
 					slotCopy(&obj2->slots[i],&obj3->slots[m]);
 				} else {
-					slotCopy(&obj2->slots[i],&slots[k]);
+					SetNil(&obj2->slots[i]);
 				}
 			} else {
 				slotCopy(&obj2->slots[i],&slots[k]);

--- a/lang/LangPrimSource/PyrArrayPrimitives.cpp
+++ b/lang/LangPrimSource/PyrArrayPrimitives.cpp
@@ -2046,11 +2046,13 @@ int prArrayLace(struct VMGlobals *g, int numArgsPushed)
 				if (isKindOf(obj3, class_list)) {
 					obj3 = slotRawObject(&obj3->slots[0]); // get the list's array
 				}
-				if (obj3 && isKindOf(obj3, class_array) && obj3->size>0) {
-					m = j % obj3->size;
-					slotCopy(&obj2->slots[i],&obj3->slots[m]);
-				} else {
-					SetNil(&obj2->slots[i]);
+				if (obj3 && isKindOf(obj3, class_array)) {
+					if (obj3->size>0) {
+						m = j % obj3->size;
+						slotCopy(&obj2->slots[i],&obj3->slots[m]);
+					} else {
+						SetNil(&obj2->slots[i]);
+					}
 				}
 			} else {
 				slotCopy(&obj2->slots[i],&slots[k]);

--- a/lang/LangPrimSource/PyrArrayPrimitives.cpp
+++ b/lang/LangPrimSource/PyrArrayPrimitives.cpp
@@ -2015,13 +2015,17 @@ int prArrayLace(struct VMGlobals *g, int numArgsPushed)
 	numLists = obj1->size;
 
 	if(IsNil(b)) {
+		// If length argument is unspecified, compute length as the multiple of
+		// the length of the shortest sub-array and the number of sub-arrays.
 		for (j=0; j<numLists; ++j) {
 			slot = slots + j;
 			if(isKindOfSlot(slot, class_array))	{
 				len = slotRawObject(slot)->size;
 				if(j==0 || n>len) { n = len; }
 			} else {
-				return errFailed; // this primitive only handles Arrays.
+				// If not an array we assume a max per-element length of one.
+				n = 1;
+				break;
 			}
 		}
 		n = n * numLists;
@@ -2042,7 +2046,7 @@ int prArrayLace(struct VMGlobals *g, int numArgsPushed)
 				if (isKindOf(obj3, class_list)) {
 					obj3 = slotRawObject(&obj3->slots[0]); // get the list's array
 				}
-				if (obj3 && isKindOf(obj3, class_array)) {
+				if (obj3 && isKindOf(obj3, class_array) && obj3->size>0) {
 					m = j % obj3->size;
 					slotCopy(&obj2->slots[i],&obj3->slots[m]);
 				} else {
@@ -2054,10 +2058,15 @@ int prArrayLace(struct VMGlobals *g, int numArgsPushed)
 			k = (k+1) % obj1->size;
 			if (k == 0) j++;
 		}
+		obj2->size = n;
 	} else {
-		obj2 = instantiateObject(g->gc, obj1->classptr, n, true, true);
+		if (isKindOf(obj1, class_array)) {
+			obj2 = newPyrArray(g->gc, 0, 0, true);
+		} else {
+			obj2 = instantiateObject(g->gc, obj1->classptr, n, true, true);
+			obj2->size = n;
+		}
 	}
-	obj2->size = n;
 	SetRaw(a, obj2);
 	return errNone;
 }

--- a/lang/LangPrimSource/PyrArrayPrimitives.cpp
+++ b/lang/LangPrimSource/PyrArrayPrimitives.cpp
@@ -2053,6 +2053,8 @@ int prArrayLace(struct VMGlobals *g, int numArgsPushed)
 					} else {
 						SetNil(&obj2->slots[i]);
 					}
+				} else {
+					slotCopy(&obj2->slots[i],&obj3->slots[k]);
 				}
 			} else {
 				slotCopy(&obj2->slots[i],&slots[k]);

--- a/lang/LangPrimSource/PyrArrayPrimitives.cpp
+++ b/lang/LangPrimSource/PyrArrayPrimitives.cpp
@@ -2019,6 +2019,10 @@ int prArrayLace(struct VMGlobals *g, int numArgsPushed)
 		// the length of the shortest sub-array and the number of sub-arrays.
 		for (j=0; j<numLists; ++j) {
 			slot = slots + j;
+			if(isKindOfSlot(slot, class_list)) {
+				obj2 = slotRawObject(slot);
+				slot = &obj2->slots[0];
+			}
 			if(isKindOfSlot(slot, class_array)) {
 				len = slotRawObject(slot)->size;
 				if(j==0 || n>len) { n = len; }

--- a/testsuite/classlibrary/TestArray.sc
+++ b/testsuite/classlibrary/TestArray.sc
@@ -242,6 +242,22 @@ TestArrayLace : UnitTest {
 			"lace: single-length items with no length argument should only be copied once");
 	}
 
+	test_list_with_sublists_without_length_arg {
+		var list, result;
+		list = List[List[1, 2, 3], List[4, 5, 6], List[7, 8]];
+		result = list.lace;
+		this.assertEquals(result, List[1, 4, 7, 2, 5, 8],
+			"lace: lists with sublists and no length argument should compute length using minimum length sublist");
+	}
+
+	test_subarray_and_sublist_mixture_without_length_arg {
+		var array, result;
+		array = [["z", "y"], List[9, 8, 7], [\a, \b, \c]];
+		result = array.lace;
+		this.assertEquals(result, ["z", 9, \a, "y", 8, \b],
+			"lace: arrays with mixture of sublists and subarrays should compute length using minimum length element");
+	}
+
 	test_subarrays_with_complete_length_arg {
 		var array, result;
 		array = [[1, 2, 3, 4], [5, 6, 7, 8], [-1, -2, -3, -4]];

--- a/testsuite/classlibrary/TestArray.sc
+++ b/testsuite/classlibrary/TestArray.sc
@@ -163,3 +163,98 @@ TestArray : UnitTest {
 	} // End test_arraystats
 
 } // End class
+
+TestArrayLace : UnitTest {
+	test_empty_returns_empty {
+		var array, result;
+		array = [];
+		result = array.lace;
+		this.assertEquals(result, [], "lace: empty array with no length argument should return empty array");
+	}
+
+	test_empty_with_length_argument_returns_empty {
+		var array, result;
+		array = [];
+		result = array.lace(8);
+		this.assertEquals(result, [], "lace: empty array with length argument should return empty array");
+	}
+
+	test_empty_subarray_returns_nil {
+		var array, result;
+		array = [[]];
+		result = array.lace;
+		this.assertEquals(result, [ nil ], "lace: empty subarray should return empty array");
+	}
+
+	test_flat_without_length_arg {
+		var array, result;
+		array = [1, 2, 3, 4, 5];
+		result = array.lace;
+		this.assertEquals(result, array, "lace: flat array should return a copy of itself");
+	}
+
+	test_flat_with_empty_subarray_substitutes_nil {
+		var array, result;
+		array = [1, 2, [], 4, 5];
+		result = array.lace;
+		this.assertEquals(result, [1, 2, nil, 4, 5], "lace: empty subarrays should be substituted for nil");
+	}
+
+	test_flat_with_length_arg_small {
+		var array, result, n;
+		n = 3;
+		array = [1, 2, 3, 4, 5];
+		result = array.lace(n);
+		this.assertEquals(result, array.keep(n),
+			"lace: flat array should return a copy of itself shortened to the length given in the argument");
+	}
+
+	test_flat_with_length_arg_large {
+		var array, result, n;
+		n = 18;
+		array = [1, 2, 3, 4, 5];
+		result = array.lace(n);
+		this.assertEquals(result, array.wrapExtend(n),
+			"lace: flat array should return itself extended to the length given in the argument");
+	}
+
+	test_subarrays_of_equal_length_without_length_arg {
+		var array, result;
+		array = [[1, 4, 7], [2, 5, 8], [3, 6, 9]];
+		result = array.lace;
+		this.assertEquals(result, [1, 2, 3, 4, 5, 6, 7, 8, 9],
+			"lace: subarrays of equal length should lace correctly without length arugment");
+	}
+
+	test_subarrays_of_unequal_length_without_length_arg {
+		var array, result;
+		array = [[1, 4], [2, 5, 7], [3, 6, 8, 9]];
+		result = array.lace;
+		this.assertEquals(result, [1, 2, 3, 4, 5, 6],
+			"lace: if not supplied, length should be computed using the minimum length subarray");
+	}
+
+	test_mixture_of_flat_and_arrays_without_length_arg {
+		var array, result;
+		array = [[10, 9], 8, [7, 6, 5], [4], [3, 2, 1, 0]];
+		result = array.lace;
+		this.assertEquals(result, [10, 8, 7, 4, 3],
+			"lace: single-length items with no length argument should only be copied once.");
+	}
+
+	test_subarrays_with_complete_length_arg {
+		var array, result;
+		array = [[1, 2, 3, 4], [5, 6, 7, 8], [-1, -2, -3, -4]];
+		result = array.lace(12);
+		this.assertEquals(result, [1, 5, -1, 2, 6, -2, 3, 7, -3, 4, 8, -4],
+			"lace: complete length argument should return completely laced array");
+	}
+
+	test_subarrays_with_length_arg_shorter_than_number_of_subarrays {
+		var array, result;
+		array = [["a", "b"], ["c", "d"], ["e", "f"], ["g", "h"]];
+		result = array.lace(3);
+		this.assertEquals(result, ["a", "c", "e"],
+			"lace: short length argument should return first members of first subarrays");
+	}
+} // End class

--- a/testsuite/classlibrary/TestArray.sc
+++ b/testsuite/classlibrary/TestArray.sc
@@ -195,9 +195,9 @@ TestArrayLace : UnitTest {
 
 	test_flat_with_empty_subarray_substitutes_nil {
 		var array, result;
-		array = [1, 2, [], 4, 5];
+		array = ["one", "two", [], "four", "five"];
 		result = array.lace;
-		this.assertEquals(result, [1, 2, nil, 4, 5], "lace: empty subarrays should be substituted for nil");
+		this.assertEquals(result, ["one", "two", nil, "four", "five"], "lace: empty subarrays should be substituted for nil");
 	}
 
 	test_flat_with_length_arg_small {
@@ -239,7 +239,7 @@ TestArrayLace : UnitTest {
 		array = [[10, 9], 8, [7, 6, 5], [4], [3, 2, 1, 0]];
 		result = array.lace;
 		this.assertEquals(result, [10, 8, 7, 4, 3],
-			"lace: single-length items with no length argument should only be copied once.");
+			"lace: single-length items with no length argument should only be copied once");
 	}
 
 	test_subarrays_with_complete_length_arg {
@@ -257,4 +257,64 @@ TestArrayLace : UnitTest {
 		this.assertEquals(result, ["a", "c", "e"],
 			"lace: short length argument should return first members of first subarrays");
 	}
+
+	test_subarrays_with_length_arg_equal_to_number_of_subarrays {
+		var array, result;
+		array = [[\tok1, \tok2, \tok3], [\tok4], [\tok5, \tok6], [\tok7, \tok8, \tok9, \tok10]];
+		result = array.lace(4);
+		this.assertEquals(result, [\tok1, \tok4, \tok5, \tok7],
+			"lace: equal length argument should return first members of all subarrays");
+	}
+
+	test_subarrays_with_length_arg_greater_than_number_of_subarrays {
+		var array, result;
+		array = [[1.0, -1.0, 2.0, -2.0, 3.0, -3.0], [4.0, -4.0, 5.0, -5.0]];
+		result = array.lace(5);
+		this.assertEquals(result, [1.0, 4.0, -1.0, -4.0, 2.0],
+			"lace: should iterate through each subarray until length argument elements copied");
+	}
+
+	test_subarrays_with_length_arg_equal_to_total_number_of_elements {
+		var array, result;
+		array = [[1], [2, 3], [4, 5, 6], [7, 8, 9, 10], [11, 12, 13, 14, 15]];
+		result = array.lace(15);
+		this.assertEquals(result, [1, 2, 4, 7, 11, 1, 3, 5, 8, 12, 1, 2, 6, 9, 13],
+			"lace: should advance through each array independently");
+	}
+
+	test_subarrays_with_length_arg_greater_than_total_number_of_elements {
+		var array, result;
+		array = [["one", "two", "three"], ["four", "five"], ["six"], "seven"];
+		result = array.lace(12);
+		this.assertEquals(result,
+			["one", "four", "six", "seven", "two", "five", "six", "seven", "three", "four", "six", "seven"],
+			"lace: should continue to fill from each array until reaching length argument");
+	}
+
+	test_subarrays_with_length_arg_equal_to_complete_lace {
+		var array, result;
+		array = [[3, 2, 1], 0, [5, 6], [10, 9, 8, 7], [12]];
+		result = array.lace(20);
+		this.assertEquals(result,
+			[3, 0, 5, 10, 12, 2, 0, 6, 9, 12, 1, 0, 5, 8, 12, 3, 0, 6, 7, 12],
+			"lace: should fill array with all interleaved values");
+	}
+
+	test_subarrays_with_length_arg_greater_than_complete_lace {
+		var array, result;
+		array = [[\a, \b], [\c, \d, \e], [\f]];
+		result = array.lace(12);
+		this.assertEquals(result, [\a, \c, \f, \b, \d, \f, \a, \e, \f, \b, \c, \f],
+			"lace: should start over once array is completely laced");
+	}
+
+	test_sublists_work_like_arrays {
+		var array, result;
+		array = [List[1, 2, 3], List[4, 5, 6], List[7, 8, 9]];
+		result = array.lace(9);
+		this.assertEquals(result, [1, 4, 7, 2, 5, 8, 3, 6, 9],
+			"lace: sublists should lace just like arrays do");
+	}
+
+
 } // End class


### PR DESCRIPTION
Regarding issue #3716, this fixes two bugs:

a) Calls to lace with no length argument would fail if any elements in the
array weren't subarrays. Now lace will assume the max length of each
subelement is one.

b) Calls to lace with empty subarrays would crash due to a divide-by-zero
error in running modulo to calculate the lace index on a subarray of length
zero. Now the code simply copies the empty subarray into place in the ouput
array.