### PR TITLE
Fix nodeproxy release shape

### DIFF
--- a/HelpSource/Classes/Ndef.schelp
+++ b/HelpSource/Classes/Ndef.schelp
@@ -33,6 +33,7 @@ Ndef(\b, { Impulse.ar([5, 7]/2, [0, 0.5], 0.15) });
 Ndef.clear(3); // clear all after 3 seconds
 ::
 
+
 ClassMethods::
 
 private::initClass
@@ -134,6 +135,25 @@ Ndef(\sound).map(\numHarm, Ndef(\lfo));
 Ndef(\sound).set(\numHarm, nil); // unmap.
 Ndef(\sound).stop;
 ::
+
+
+subsection::Reserved parameters
+Three parameters are automatically specified if they don't exist in a given UGen function. You can override their use: code::[\out, \gate, \fadeTime]::
+
+subsection::Specifying your own envelope
+
+If a UGen function that is passed to the proxy has its own envelope, and if this envelope can free the synth, the node proxy uses this envelope instead of making its own. If you provide a code::fadeTime:: argument, the proxy's fadeTime will be used.
+
+code::
+Ndef(\sound).fadeTime = 3;
+(
+Ndef(\sound, { |fadeTime = 1, gate = 1|
+	var e = Env.adsr(fadeTime, 0.01, 0.4, fadeTime).ar(2, gate);
+	SinOsc.ar(100 + (e * 700), SinOsc.ar(208) * (1 - e) * 6) * e * 0.1
+}).play
+)
+::
+
 
 
 subsection::Simple audio routing with the <<> operator

--- a/HelpSource/Classes/NodeProxy.schelp
+++ b/HelpSource/Classes/NodeProxy.schelp
@@ -189,6 +189,23 @@ Ndef(\maus, { LFNoise0.kr(1 ! 8) + 1 }); // now 8 parallel channels of audio are
 
 
 
+subsection::Reserved parameters
+Three parameters are automatically specified if they don't exist in a given UGen function. You can override their use: code::[\out, \gate, \fadeTime]::
+
+subsection::Specifying your own envelope
+
+If a UGen function that is passed to the proxy has its own envelope, and if this envelope can free the synth, the node proxy uses this envelope instead of making its own. If you provide a code::fadeTime:: argument, the proxy's fadeTime will be used.
+
+code::
+Ndef(\sound).fadeTime = 3;
+(
+Ndef(\sound, { |fadeTime = 1, gate = 1|
+	var e = Env.adsr(fadeTime, 0.01, 0.4, fadeTime).ar(2, gate);
+	SinOsc.ar(100 + (e * 700), SinOsc.ar(208) * (1 - e) * 6) * e * 0.1
+}).play
+)
+::
+
 
 subsection::Making copies
 

--- a/HelpSource/Tutorials/JITLib/jitlib_fading.schelp
+++ b/HelpSource/Tutorials/JITLib/jitlib_fading.schelp
@@ -76,10 +76,16 @@ section::c) custom fade envelope
 code::
 // when a gate arg is provided, and the env can free the synth, this envelope
 // is supposed to be the fade envelope for the synth: no extra fade env is created.
-(
+
 ~out = { arg gate=1; EnvGen.kr(Env.asr, gate, doneAction: Done.freeSelf) * 0.2 * SinOsc.ar([1,1]*Rand(440,550)) };
-)
+
+
+// if you want to use the proxy's fadeTime, you should provide a fadeTime argument:
+
+~out = { arg gate=1, fadeTime = 0.1; EnvGen.kr(Env.asr(fadeTime, 1, fadeTime), gate, doneAction: Done.freeSelf) * 0.2 * SinOsc.ar([1,1] * Rand(440, 550)) };
 ::
+
+
 
 section::d) SynthDef name assignment
 
@@ -97,7 +103,7 @@ SynthDef("test", { arg gate=1, out;
 }).send(s);
 )
 
-// you can also provide a fadeTime arg, whic is set by the proxy:
+// you can also provide a fadeTime arg, which is set by the proxy:
 (
 SynthDef("test", { arg gate=1, out, fadeTime=1;
 	Out.ar(out,
@@ -116,8 +122,7 @@ the strong::number of channels:: is your own responsibility when using symbols, 
 ::
 
 code::
-// if the synthdef has a fixed duration envelope, there is a FAILURE /n_set Node not found message.
-// with no further significance
+// if the synthdef has a fixed duration envelope, it won't use the proxy's fadeTime
 (
 SynthDef("test", { arg gate=1, out;
 	Out.ar(out,

--- a/HelpSource/Tutorials/JITLib/proxyspace_examples.schelp
+++ b/HelpSource/Tutorials/JITLib/proxyspace_examples.schelp
@@ -323,10 +323,10 @@ code::
 
 // if you supply a gate it fades in and out. evaluate this several times
 (
-~out = SynthDef("w", { arg out=0, gate=1.0;
+~out = SynthDef("w", { arg out=0, gate=1.0, fadeTime = 0.1;
 	Out.ar(out,
 		SinOsc.ar([Rand(430, 800), Rand(430, 800)], 0, 0.2)
-			* EnvGen.kr(Env.asr(1,1,1), gate, doneAction: Done.freeSelf)
+			* EnvGen.kr(Env.asr(fadeTime, 1, fadeTime), gate, doneAction: Done.freeSelf)
 	)
 	});
 )
@@ -339,10 +339,10 @@ code::
 // if the synth def is in the synthdesc lib (.add) its gate is detected.
 
 (
-SynthDef("staub", { arg out, gate=1;
+SynthDef("staub", { arg out, gate=1, fadeTime = 0.1;
 	Out.ar(out,
 		Ringz.ar(Dust.ar(15), Rand(1, 3) * 3000*[1,1], 0.001)
-			* EnvGen.kr(Env.asr, gate, doneAction: Done.freeSelf)
+		* EnvGen.kr(Env.asr(fadeTime, 1, fadeTime), gate, doneAction: Done.freeSelf)
 	)
 }).add;
 )

--- a/SCClassLibrary/JITLib/ProxySpace/ProxyInterfaces.sc
+++ b/SCClassLibrary/JITLib/ProxySpace/ProxyInterfaces.sc
@@ -239,7 +239,7 @@ SynthControl : AbstractPlayControl {
 	stopToBundle { | bundle, fadeTime |
 		if(nodeID.notNil) {
 			if(canReleaseSynth) {
-				bundle.addAll([['/error', -1], [15, nodeID, \gate, -1.0 - fadeTime, \fadeTime, fadeTime], ['/error', -2]]);
+				bundle.addAll([['/error', -1], [15, nodeID, \fadeTime, fadeTime, \gate, 0], ['/error', -2]]);
 			} {
 				if(canFreeSynth.not) { //"/n_free"
 					bundle.addAll([['/error', -1], [11, nodeID], ['/error', -2]]);

--- a/SCClassLibrary/JITLib/ProxySpace/ProxyInterfaces.sc
+++ b/SCClassLibrary/JITLib/ProxySpace/ProxyInterfaces.sc
@@ -199,7 +199,7 @@ PatternControl : StreamControl {
 SynthControl : AbstractPlayControl {
 
 	var <server, <>nodeID;
-	var <canReleaseSynth=false, <canFreeSynth=false;
+	var <canReleaseSynth=false, <canFreeSynth=false, <hasFadeTimeControl=false;
 	var prevBundle;
 
 
@@ -215,6 +215,7 @@ SynthControl : AbstractPlayControl {
 		if(desc.notNil) {
 			canFreeSynth = desc.canFreeSynth;
 			canReleaseSynth = desc.hasGate && canFreeSynth;
+			hasFadeTimeControl = desc.controls.any { |x| x.name === \fadeTime };
 		};
 		if(proxy.isNeutral) { rate = \audio };
 		^proxy.initBus(rate)
@@ -238,12 +239,17 @@ SynthControl : AbstractPlayControl {
 
 	stopToBundle { | bundle, fadeTime |
 		if(nodeID.notNil) {
+
 			if(canReleaseSynth) {
-				bundle.addAll([['/error', -1], [15, nodeID, \fadeTime, fadeTime, \gate, 0], ['/error', -2]]);
+				if(hasFadeTimeControl) {
+					bundle.addAll([['/error', -1], [15, nodeID, \fadeTime, fadeTime, \gate, 0], ['/error', -2]])
+				} {
+					bundle.addAll([['/error', -1], [15, nodeID, \gate, -1.0 - fadeTime.abs], ['/error', -2]])
+				}
 			} {
 				if(canFreeSynth.not) { //"/n_free"
 					bundle.addAll([['/error', -1], [11, nodeID], ['/error', -2]]);
-				};
+				}
 				// otherwise it is self freeing by some inner mechanism.
 			};
 			nodeID = nil;


### PR DESCRIPTION
Setting the gate of an envelope to a negative value makes a forced release. What remained unnoticed here was that the forced release shape is always linear, regardless of the envelope’s shape. This commit replaces the forced release by a normal release. The fadeTime is set,
so forcing wasn’t necessary.

This fixes #3775.

It changes how crossfading sounds.

testing:
- test how node object replacement and freeing sounds.
- this may change the behaviour of SynthDefs that are separately made
and which *do not use the `fadeTime` parameter to specify the release
time*.

 