### PR TITLE
class library: Add bar graph mode to PlotView

### DIFF
--- a/HelpSource/Classes/Plotter.schelp
+++ b/HelpSource/Classes/Plotter.schelp
@@ -121,6 +121,7 @@ table::
 ## code::\plines:: || combination of lines and points
 ## code::\levels:: || horizontal lines
 ## code::\steps:: || connecting data points with step interpolation
+## code::\bars:: || bar graph with filled bars
 ::
 discussion::
 code::
@@ -130,6 +131,7 @@ a.plotMode = \plines; a.refresh;
 a.plotMode = \levels; a.refresh;
 a.plotMode = \steps; a.refresh;
 a.plotMode = \linear; a.refresh;
+a.plotMode = \bars; a.refresh;
 ::
 
 method:: setProperties
@@ -250,7 +252,7 @@ a.parent.onClose = { x.release };
 
 (
 a = { (0..10).scramble.normalize(300, 400) }.dup.plot;
-a.specs = \freq; a.plotMode = \levels;
+a.specs = \freq; a.plotMode = \bars;
 a.editMode = true;
 x = {
 	var phase = SinOsc.ar(\rate.kr(a.value[1]));

--- a/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
+++ b/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
@@ -361,8 +361,15 @@ Plot {
 	}
 
 	getIndex { |x|
-		var offset = if(this.hasSteplikeDisplay) { 0.5 } { 0.0 }; // needs to be fixed.
-		^(this.getRelativePositionX(x) - offset).round.asInteger
+		var ycoord = this.dataCoordinates;
+		var xcoord = this.domainCoordinates(ycoord.size);
+		var binwidth = 0;
+		var offset;
+		if (xcoord.size > 0) {
+			binwidth = (xcoord[1] ?? {plotBounds.right}) - xcoord[0];
+		};
+		offset = if(this.hasSteplikeDisplay) { binwidth/2.0 } { 0.0 };
+		^(this.getRelativePositionX(x - offset)).round.asInteger;
 	}
 
 	getDataPoint { |x|

--- a/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
+++ b/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
@@ -184,10 +184,10 @@ Plot {
 					this.perform(mode, xcoord, y);
 					if (this.needsPenFill(mode)) {
 						Pen.fillColor = plotColor.wrapAt(i);
-						Pen.fill;
+						Pen.fill
 					} {
 						Pen.strokeColor = plotColor.wrapAt(i);
-						Pen.stroke;
+						Pen.stroke
 					}
 				}
 			} {
@@ -196,10 +196,10 @@ Plot {
 				Pen.fillColor= plotColor.at(0);
 				this.perform(mode, xcoord, ycoord);
 				if (this.needsPenFill(mode)) {
-					Pen.fill;
+					Pen.fill
 				} {
-					Pen.stroke;
-				};
+					Pen.stroke
+				}
 			};
 			Pen.joinStyle = 0;
 		};
@@ -255,14 +255,14 @@ Plot {
 		Pen.smoothing_(false);
 		y.size.do { |i|
 			var p = x[i] @ y[i];
-			var nextx = x[i+1] ?? {plotBounds.right};
+			var nextx = x[i + 1] ?? {plotBounds.right};
 			var centery = 0.linlin(this.spec.minval, this.spec.maxval, plotBounds.bottom, plotBounds.top, clip:nil);
 			var rely = y[i] - centery;
-			var gap = (nextx-x[i])*0.1;
+			var gap = (nextx - x[i]) * 0.1;
 			if (rely < 0) {
-				Pen.addRect(Rect(x[i] + gap, centery + rely, nextx-x[i]-(2*gap), rely.abs));
+				Pen.addRect(Rect(x[i] + gap, centery + rely, nextx- x[i] - (2 * gap), rely.abs))
 			} {
-				Pen.addRect(Rect(x[i] + gap, centery, nextx-x[i]-(2*gap), rely));
+				Pen.addRect(Rect(x[i] + gap, centery, nextx - x[i] - ( 2 * gap), rely))
 			}
 		}
 	}
@@ -366,10 +366,10 @@ Plot {
 		var binwidth = 0;
 		var offset;
 		if (xcoord.size > 0) {
-			binwidth = (xcoord[1] ?? {plotBounds.right}) - xcoord[0];
+			binwidth = (xcoord[1] ?? {plotBounds.right}) - xcoord[0]
 		};
 		offset = if(this.hasSteplikeDisplay) { binwidth/2.0 } { 0.0 };
-		^(this.getRelativePositionX(x - offset)).round.asInteger;
+		^this.getRelativePositionX(x - offset).round.asInteger
 	}
 
 	getDataPoint { |x|


### PR DESCRIPTION
This adds a basic "bar graph" type to PlotView. It also fixes the wrong index returned during editing for step-like representations when the mouse cursor is in the right half of the "step" and it updates the Plotter documentation to include the new functionality.

