### PR TITLE
IDE: add space after colon in autocompletion

### DIFF
--- a/editors/sc-ide/widgets/code_editor/autocompleter.cpp
+++ b/editors/sc-ide/widgets/code_editor/autocompleter.cpp
@@ -1125,13 +1125,13 @@ bool AutoCompleter::trySwitchMethodCallArgument(bool backwards)
         argNum = 0;
 
     QString text = call.method->arguments[argNum].name;
-    text.append(":");
+    text.append(": ");
 
     // insert argument name
     if (argNameToken.isValid() && cursorAtArgName) {
         int pos = argNameToken.position();
         cursor.setPosition(pos);
-        cursor.setPosition(pos + argNameToken->length, QTextCursor::KeepAnchor);
+        cursor.setPosition(pos + argNameToken->length + 1, QTextCursor::KeepAnchor);
     }
     cursor.insertText(text);
 


### PR DESCRIPTION
This causes the autocompleter to add a space between colon and insertion
point when autocompleting keyword arguments to a function.

ex. "Array.fill(size: <CURSOR>"

Fixes #831

Thanks to @patrickdupuis for finding the solution in #831!

To test:

Open the IDE, wait for introspection to load, and type `Array.fill(`. Then cycle through the options with tab.

Another good test case is trying it with text to the right of the cursor: inserting `Array.fill)` first, then placing the cursor to the left of the `)`, typing `(`, and cycling through the options.