### PR TITLE
Classlib: Recorder: Create user's recording directory if it doesn't exist

### DIFF
--- a/HelpSource/Classes/Recorder.schelp
+++ b/HelpSource/Classes/Recorder.schelp
@@ -58,7 +58,7 @@ method:: prepareForRecord
 Allocates the necessary buffer, etc. for recording the server's output. (See code::record:: below.)
 
 argument:: path
-a link::Classes/String:: representing the path and name of the output file.
+a link::Classes/String:: representing the path and name of the output file. If the directory does not exist, it will be created for you. (Note, however, that if this fails for any reason, recording will also fail.)
 
 argument::numChannels
 The number of output channels to record.

--- a/HelpSource/Classes/Server.schelp
+++ b/HelpSource/Classes/Server.schelp
@@ -626,7 +626,7 @@ Recording is done via an of link::Classes/Recorder:: - a server holds one instan
 method:: prepareForRecord
 Allocates the necessary buffer, etc. for recording the server's output. (See code::record:: below.)
 argument:: path
-a link::Classes/String:: representing the path and name of the output file.
+a link::Classes/String:: representing the path and name of the output file. If the directory does not exist, it will be created for you. (Note, however, that if this fails for any reason, recording will also fail.)
 argument:: numChannels
 a link::Classes/String:: the number of output channels to record.
 

--- a/SCClassLibrary/Common/Control/Recorder.sc
+++ b/SCClassLibrary/Common/Control/Recorder.sc
@@ -108,10 +108,7 @@ Recorder {
 
 		path = if(path.isNil) { this.makePath } { path.standardizePath };
 		dir = path.dirname;
-		if(File.exists(dir).not) {
-			dir.mkdir;
-			"created recordings directory: '%'\n".postf(dir)
-		};
+		if(File.exists(dir).not) { dir.mkdir };
 
 		recordBuf = Buffer.alloc(server,
 			bufSize,

--- a/SCClassLibrary/Common/Control/Recorder.sc
+++ b/SCClassLibrary/Common/Control/Recorder.sc
@@ -100,11 +100,19 @@ Recorder {
 
 	prepareForRecord { | path, numChannels |
 		var bufSize = recBufSize ? server.recBufSize ?? { server.sampleRate.nextPowerOfTwo };
+		var dir;
 
 		recHeaderFormat = recHeaderFormat ? server.recHeaderFormat;
 		recSampleFormat = recSampleFormat ? server.recSampleFormat;
 		numChannels = numChannels ? server.recChannels;
+
 		path = if(path.isNil) { this.makePath } { path.standardizePath };
+		dir = path.dirname;
+		if(File.exists(dir).not) {
+			dir.mkdir;
+			"created recordings directory: '%'\n".postf(dir)
+		};
+
 		recordBuf = Buffer.alloc(server,
 			bufSize,
 			numChannels,
@@ -167,13 +175,7 @@ Recorder {
 	makePath {
 		var timestamp;
 		var dir = thisProcess.platform.recordingsDir;
-		if(File.exists(dir).not) {
-			dir.mkdir;
-			"created recordings directory: '%'\n".postf(dir)
-		};
-
 		timestamp = Date.localtime.stamp;
-
 		^dir +/+ filePrefix ++ timestamp ++ "." ++ server.recHeaderFormat;
 	}
 


### PR DESCRIPTION
Recorder class should mkdir the user's chosen location in all cases

Yesterday, I gave some code that looks like this to a classroom full of students:

```
	if(view.value == 1) {
		Server.default.record(
			Platform.recordingsDir +/+ "%-%.wav".format(
				idField.string, groupField.string
			),
			numChannels: 2
		);
	}
```

When I ran it in the classroom, the server complained that it couldn't open the output file.

Then I found out why:

- If the default recording location doesn't exist, it is created for you in `Recorder:makePath`.
- `makePath` is called only if you don't specify a path.

Therefore, if the user wants to override the default filename but not the recording location, then the user has a gotcha -- "every other time I tried to record, there was no problem, but when I do it for the first time on a particular system in this way, it fails."

A reasonable solution is to ensure that the path exists in every case.