### PR TITLE
Latency compensation in scsynth & supernova

### DIFF
--- a/server/scsynth/SC_Jack.cpp
+++ b/server/scsynth/SC_Jack.cpp
@@ -481,13 +481,13 @@ void SC_JackDriver::Run()
 
 		// main loop
 #ifdef SC_JACK_USE_DLL
-		int64 oscTime = mOSCbuftime = (int64)((mDLL.PeriodTime() - mMaxOutputLatency) * kSecondsToOSCunits + .5);
+		int64 oscTime = mOSCbuftime = (int64)((mDLL.PeriodTime() + mMaxOutputLatency) * kSecondsToOSCunits + .5);
 // 		int64 oscInc = mOSCincrement = (int64)(mOSCincrementNumerator / mDLL.SampleRate());
 		int64 oscInc = mOSCincrement = (int64)((mDLL.Period() / numBufs) * kSecondsToOSCunits + .5);
 		mSmoothSampleRate = mDLL.SampleRate();
 		double oscToSamples = mOSCtoSamples = mSmoothSampleRate * kOSCtoSecs /* 1/pow(2,32) */;
 #else
-		int64 oscTime = mOSCbuftime = OSCTime(hostTime) - (int64)(mMaxOutputLatency * kSecondsToOSCunits + .5);
+		int64 oscTime = mOSCbuftime = OSCTime(hostTime) + (int64)(mMaxOutputLatency * kSecondsToOSCunits + .5);
 		int64 oscInc = mOSCincrement;
 		double oscToSamples = mOSCtoSamples;
 #endif

--- a/server/supernova/audio_backend/jack_backend.hpp
+++ b/server/supernova/audio_backend/jack_backend.hpp
@@ -71,6 +71,11 @@ public:
         return blocksize_;
     }
 
+    uint32_t get_latency(void) const
+    {
+        return latency_;
+    }
+
 public:
     void open_client(std::string const & server_name, std::string const & name, uint32_t input_port_count,
                      uint32_t output_port_count, uint32_t blocksize)
@@ -95,6 +100,7 @@ public:
         jack_set_thread_init_callback (client, jack_thread_init_callback, this);
         jack_set_process_callback (client, jack_process_callback, this);
         jack_set_xrun_callback(client, jack_xrun_callback, this);
+        jack_set_graph_order_callback(client, jack_graph_order_callback, this);
         jack_on_info_shutdown(client, (JackInfoShutdownCallback)jack_on_info_shutdown_callback, nullptr);
 
         /* register ports */
@@ -292,11 +298,39 @@ private:
         return static_cast<jack_backend*>(arg)->handle_xrun();
     }
 
+    static int jack_graph_order_callback(void* arg)
+    {
+        return static_cast<jack_backend*>(arg)->graph_order_changed();
+    }
+
     int handle_xrun(void)
     {
         time_is_synced = false;
         engine_functor::log_("Jack: xrun detected - resyncing clock\n");
         return 0;
+    }
+
+    int graph_order_changed()
+    {
+        time_is_synced = false;
+
+        jack_nframes_t lat = 0;
+        for(auto const& port: output_ports) {
+            jack_latency_range_t range;
+            jack_port_get_latency_range( port, JackPlaybackLatency, &range );
+            jack_nframes_t portLat = range.max;
+            if(portLat > lat) lat = portLat;
+        }
+
+        uint32_t latency = (uint32_t) lat;
+
+        if(latency != latency_) {
+            latency_ = latency;
+            double latms = lat / samplerate_ * 1e3;
+            engine_functor::log_printf_("JackDriver: max output latency %.1f ms\n", latms);
+        }
+
+        return true;
     }
 
     int perform(jack_nframes_t frames)
@@ -352,6 +386,8 @@ private:
     std::vector<jack_port_t*> input_ports, output_ports;
     jack_nframes_t jack_frames;
     cpu_time_info cpu_time_accumulator;
+
+    uint32_t latency_;
 };
 
 } /* namespace nova */

--- a/server/supernova/audio_backend/portaudio_backend.hpp
+++ b/server/supernova/audio_backend/portaudio_backend.hpp
@@ -75,6 +75,11 @@ public:
         return blocksize_;
     }
 
+	uint32_t get_latency(void) const
+	{
+		return latency_;
+	}
+
 private:
     static void report_error(int err, bool throw_exception = false)
     {
@@ -201,6 +206,12 @@ public:
 
         if (opened != paNoError)
             return false;
+		else {
+			const PaStreamInfo *psi = Pa_GetStreamInfo(stream);
+			if (psi)
+				latency_ = (uint32_t) (psi->outputLatency * psi->sampleRate);
+            fprintf(stdout,"  latency: %d\n", latency_);
+		}
 
         input_channels = inchans;
         super::input_samples.resize(inchans);
@@ -324,6 +335,8 @@ private:
     uint32_t blocksize_    = 0;
     bool engine_initalised = false;
     cpu_time_info cpu_time_accumulator;
+
+	uint32_t latency_      = 0;
 };
 
 } /* namespace nova */

--- a/server/supernova/sc/sc_osc_handler.hpp
+++ b/server/supernova/sc/sc_osc_handler.hpp
@@ -385,6 +385,12 @@ public:
         last = lasts;
     }
 
+	void add_last_now(time_tag const & add)
+	{
+		now += add;
+		last += add;
+	}
+
     void update_time_from_system(void)
     {
         now = time_tag::from_ptime(boost::date_time::microsec_clock<boost::posix_time::ptime>::universal_time());

--- a/server/supernova/server/server.hpp
+++ b/server/supernova/server/server.hpp
@@ -231,6 +231,16 @@ public:
         sc_osc_handler::set_last_now(lasts, nows);
     }
 
+	void compensate_latency(void)
+	{
+		sc_osc_handler::add_last_now(
+				time_tag::from_samples(
+					audio_backend::get_latency(),
+					audio_backend::get_samplerate()
+				)
+			);
+	}
+
 public:
     HOT void tick()
     {
@@ -310,6 +320,8 @@ inline void realtime_engine_functor::sync_clock(void)
         instance->set_last_now(oscTime,oscTime + oscInc);
     }else
         instance->update_time_from_system();
+
+	instance->compensate_latency();
 }
 
 


### PR DESCRIPTION
There is currently a ~~heated~~ debate on the [Ableton Link PR](https://github.com/supercollider/supercollider/pull/3351) on how to implement accurate ~~sample-level~~ synchronization between instances. While doing some tests I noticed some inconsistencies regarding latency compensation in scsynth and supercollider for timestamped events:

* scsynth with jack audio backend has a sign error when computing true output time, which leads into a doubling of the latency ! (I can't believed that I never noticed this).
* supernova has no mechanism for latency compensation.  I implemented it similarly to how it's done in scsynth.