### PR TITLE
assertThrow

### DIFF
--- a/SCClassLibrary/Common/Core/Function.sc
+++ b/SCClassLibrary/Common/Core/Function.sc
@@ -189,11 +189,18 @@ Function : AbstractFunction {
 		};
 	}
 
+	catch { arg handler;
+		var result = this.prTry;
+		if (result.notNil) { ^handler.value(result); }
+		{ ^result }
+	}
+
 	try { arg handler;
 		var result = this.prTry;
 		if (result.isException) { ^handler.value(result); }
 		{ ^result }
 	}
+
 	prTry {
 		var result, thread = thisThread;
 		var next = thread.exceptionHandler,

--- a/SCClassLibrary/Common/UnitTesting/UnitTest.sc
+++ b/SCClassLibrary/Common/UnitTesting/UnitTest.sc
@@ -189,6 +189,22 @@ UnitTest {
 		}
 	}
 
+	testForException { |func, errorClass|
+		var test = if(errorClass.isNil) { _.isException } { _.isKindOf(errorClass.asClass) };
+		var result = false;
+		func.try { |error| result = test.(error) };
+		^result
+	}
+
+	assertThrow { | func, message, errorClass, report = true, details |
+		this.assert(this.testForException(func, errorClass), message, report, details: details)
+	}
+
+	assertNoThrow { | func, message, errorClass, report = true, onFailure, details |
+		this.assert(not(this.testForException(func, errorClass)), message, report, details: details)
+	}
+
+
 	// make a further assertion only if it passed, or only if it failed
 	ifAsserts { | boolean, message, ifPassedFunc, ifFailedFunc, report = true|
 		if(boolean.not,{

--- a/SCClassLibrary/Common/UnitTesting/UnitTest.sc
+++ b/SCClassLibrary/Common/UnitTesting/UnitTest.sc
@@ -189,19 +189,19 @@ UnitTest {
 		}
 	}
 
-	testForException { |func, errorClass|
-		var test = if(errorClass.isNil) { _.isException } { _.isKindOf(errorClass.asClass) };
+	testForThrow { |func, errorClass|
+		var test = if(errorClass.isNil) { _.notNil } { _.isKindOf(errorClass.asClass) };
 		var result = false;
-		func.try { |error| result = test.(error) };
+		func.catch { |error| result = test.(error) };
 		^result
 	}
 
 	assertThrow { | func, message, errorClass, report = true, details |
-		this.assert(this.testForException(func, errorClass), message, report, details: details)
+		this.assert(this.testForThrow(func, errorClass), message, report, details: details)
 	}
 
 	assertNoThrow { | func, message, errorClass, report = true, onFailure, details |
-		this.assert(not(this.testForException(func, errorClass)), message, report, details: details)
+		this.assert(not(this.testForThrow(func, errorClass)), message, report, details: details)
 	}
 
 

--- a/testsuite/classlibrary/TestFunction.sc
+++ b/testsuite/classlibrary/TestFunction.sc
@@ -36,6 +36,33 @@ TestFunction : UnitTest {
 		this.assert(obj.b == 42, "function should be able to set instance variable that has no setter");
 	}
 
+	test_try_with_error {
+		var result = false;
+		try { 7.snooze_error_away } { result = true };
+		this.assert(result, "try should call handler on error");
+	}
+
+	test_try_without_error {
+		var result = true;
+		try { 7.throw } { result = false };
+		this.assert(result, "try should not call handler on throw");
+	}
+
+
+	test_catch_with_throw {
+		var result = false;
+		catch { 7.throw } { |thrown| result = (thrown == 7) };
+		this.assert(result, "catch should call handler on throw and pass object that is thrown");
+	}
+
+	test_catch_without_throw {
+		var result = true;
+		try { 5 + 7 } { result = false };
+		this.assert(result, "catch should not call handler when nothing is thrown");
+	}
+
+
+
 
 }
 

--- a/testsuite/classlibrary/TestUnitTest.sc
+++ b/testsuite/classlibrary/TestUnitTest.sc
@@ -44,7 +44,24 @@ TestUnitTest : UnitTest {
 		this.assertEquals( TestMixedBundleTester.findTestedClass, MixedBundleTester)
 	}
 
+	test_assertThrow {
+		this.assertThrow({ 1789.monarchy }, "assertThrow should return true for any error")
+	}
 
+	test_assertThrow_for_throw {
+		this.assertThrow({ \stone.throw }, "assertThrow should return true for thrown object")
+	}
+
+	test_assertThrow_with_specific_error {
+		this.assertThrow({ BinaryOpFailureError.new.throw },
+			"assertThrow should return true for specific error",
+			BinaryOpFailureError
+		)
+	}
+
+	test_assertNoThrow {
+		this.assertNoThrow({ try { 1789.monarchy } }, "assertNoThrow should return true for not an error")
+	}
 
 
 	/*** IF YOU ADD MORE TESTS, UPDATE THE numTestMethods var ***/


### PR DESCRIPTION
This is a first draft of a UnitTest `assertThrow` and `assertNoThrow` method. 

Because it is needed, it also adds a `catch` method to function. If agreed on, this will be documented and can be made into a separate PR.