### PR TITLE
File.mkdir now throws an error

### DIFF
--- a/HelpSource/Classes/File.schelp
+++ b/HelpSource/Classes/File.schelp
@@ -86,6 +86,12 @@ Answers if the filesystem is case sensitive or not.
 method::mkdir
 Create directory at path, including any missing parent directories.
 
+returns:: a link::Classes/Boolean::, as follows:
+list::
+## code::true:: -- A new directory was created at code::path::.
+## code::false:: -- A directory already existed at code::path::; a new one was not created.
+::
+
 method::delete
 Deletes the file at that path. Use only for good, never for evil.
 

--- a/HelpSource/Classes/File.schelp
+++ b/HelpSource/Classes/File.schelp
@@ -111,6 +111,27 @@ method::mtime
 Get last modification time in seconds since the Epoch.
 returns:: an link::Classes/Integer::
 
+subsection:: Error handling in filesystem utilities
+
+If one of the above file system primitives fails, in most cases, a PrimitiveFailedError object will be thrown:
+
+code::
+File.mkdir("/usr/oh-no-you-cant");
+
+ERROR: Primitive '_FileMkDir' failed.
+caught exception 'boost::filesystem::create_directory: Permission denied: "/usr/oh-no-you-cant"' in primitive in method Meta_File:mkdir
+::
+
+The methods link::Classes/Function#-try:: and link::Classes/Function#-protect:: can detect and handle these errors. See link::Guides/Understanding-Errors:: for details.
+
+Currently, link::Classes/File#*copy::, link::Classes/File#*fileSize::, link::Classes/File#*mkdir::, link::Classes/File#*mtime::, and link::Classes/File#*type:: throw errors upon failure.
+
+link::Classes/File#*delete:: does not throw an error, but instead returns a Boolean:
+
+list::
+## code::true:: -- You can assume that the path no longer exists. (Either it existed and was deleted, or it didn't exist and it still doesn't exist.)
+## code::false:: -- The file could not be deleted (probably a permissions error). Your code should assume that the path still exists.
+::
 
 InstanceMethods::
 

--- a/HelpSource/Classes/File.schelp
+++ b/HelpSource/Classes/File.schelp
@@ -89,6 +89,12 @@ Create directory at path, including any missing parent directories.
 method::delete
 Deletes the file at that path. Use only for good, never for evil.
 
+returns:: a link::Classes/Boolean::, as follows:
+list::
+## code::true:: -- You can assume that the path no longer exists. (Either it existed and was deleted, or it didn't exist and it still doesn't exist.)
+## code::false:: -- The file could not be deleted (probably a permissions error). Your code should assume that the path still exists.
+::
+
 method::realpath
 Follow symbolic links (and aliases on macOS) and any parent directory references (like "..") and return the true absolute path.
 
@@ -113,25 +119,20 @@ returns:: an link::Classes/Integer::
 
 subsection:: Error handling in filesystem utilities
 
-If one of the above file system primitives fails, in most cases, a PrimitiveFailedError object will be thrown:
+If one of the above filesystem primitives fails, in most cases, a PrimitiveFailedError object will be thrown:
 
 code::
 File.mkdir("/usr/oh-no-you-cant");
+::
 
+teletype::
 ERROR: Primitive '_FileMkDir' failed.
 caught exception 'boost::filesystem::create_directory: Permission denied: "/usr/oh-no-you-cant"' in primitive in method Meta_File:mkdir
 ::
 
 The methods link::Classes/Function#-try:: and link::Classes/Function#-protect:: can detect and handle these errors. See link::Guides/Understanding-Errors:: for details.
 
-Currently, link::Classes/File#*copy::, link::Classes/File#*fileSize::, link::Classes/File#*mkdir::, link::Classes/File#*mtime::, and link::Classes/File#*type:: throw errors upon failure.
-
-link::Classes/File#*delete:: does not throw an error, but instead returns a Boolean:
-
-list::
-## code::true:: -- You can assume that the path no longer exists. (Either it existed and was deleted, or it didn't exist and it still doesn't exist.)
-## code::false:: -- The file could not be deleted (probably a permissions error). Your code should assume that the path still exists.
-::
+Currently, link::Classes/File#*copy::, link::Classes/File#*fileSize::, link::Classes/File#*mkdir::, link::Classes/File#*mtime::, and link::Classes/File#*type:: throw errors upon failure. (link::Classes/File#*delete:: does not throw an error, but instead returns a Boolean.)
 
 InstanceMethods::
 

--- a/lang/LangPrimSource/PyrFilePrim.cpp
+++ b/lang/LangPrimSource/PyrFilePrim.cpp
@@ -162,11 +162,8 @@ int prFileMkDir(struct VMGlobals * g, int numArgsPushed)
 	if (error != errNone)
 		return error;
 
-	boost::system::error_code error_code;
 	const bfs::path& p = SC_Codecvt::utf8_str_to_path(filename);
-	bfs::create_directories(p, error_code);
-	if (error_code)
-		postfl("Warning: %s (\"%s\")\n", error_code.message().c_str(), p.c_str());
+	bfs::create_directories(p);
 
 	return errNone;
 }

--- a/lang/LangPrimSource/PyrFilePrim.cpp
+++ b/lang/LangPrimSource/PyrFilePrim.cpp
@@ -155,7 +155,7 @@ int prFileRealPath(struct VMGlobals* g, int numArgsPushed )
 
 int prFileMkDir(struct VMGlobals * g, int numArgsPushed)
 {
-	PyrSlot *b = g->sp;
+	PyrSlot *a = g->sp - 1, *b = g->sp;
 	char filename[PATH_MAX];
 
 	int error = slotStrVal(b, filename, PATH_MAX);
@@ -163,8 +163,9 @@ int prFileMkDir(struct VMGlobals * g, int numArgsPushed)
 		return error;
 
 	const bfs::path& p = SC_Codecvt::utf8_str_to_path(filename);
-	bfs::create_directories(p);
+	bool result = bfs::create_directories(p);
 
+	SetBool(a, result);
 	return errNone;
 }
 


### PR DESCRIPTION
Fixes #3635.

Per https://www.boost.org/doc/libs/1_49_0/libs/filesystem/v3/doc/reference.html#Error-reporting, all that is necessary to get an error to be thrown is to remove the error_code argument from the call to `bfs::create_directories()`. On success, it drops through to `return errNone`; on failure, a C++ exception is raised, caught, and passed along to a sclang PrimitiveFailedError.

Test:

```
File.mkdir("/usr/oh-no-you-cant");

ERROR: Primitive '_FileMkDir' failed.
caught exception 'boost::filesystem::create_directory: Permission denied: "/usr/oh-no-you-cant"' in primitive in method Meta_File:mkdir
```

Also, I added a short section to the File documentation about error handling for the boost functions.