### PR TITLE
Topic/synthdef specs improvements

### DIFF
--- a/HelpSource/Classes/ControlName.schelp
+++ b/HelpSource/Classes/ControlName.schelp
@@ -37,12 +37,18 @@ returns:: an link::Classes/Integer::
 
 method:: spec
 The link::Classes/ControlSpec:: for this control. If set, it will be added to the specs metadata for the current SynthDef.at
+
 code::
-d = SynthDef(\tone, {
-	|freq=200|
+(
+d = SynthDef(\tone, { |out = 0, freq = 200|
+	var sig;
+
 	freq.spec = ControlSpec(20, 20000);
 	sig = SinOsc.ar(freq);
-	Out.ar(0, sig);
+
+	Out.ar(out, sig);
 }).add;
+)
+
 d.specs.freq.postln;
 ::

--- a/HelpSource/Classes/ControlName.schelp
+++ b/HelpSource/Classes/ControlName.schelp
@@ -35,3 +35,14 @@ method::numChannels
 The number of channels.
 returns:: an link::Classes/Integer::
 
+method:: spec
+The link::Classes/ControlSpec:: for this control. If set, it will be added to the specs metadata for the current SynthDef.at
+code::
+d = SynthDef(\tone, {
+	|freq=200|
+	freq.spec = ControlSpec(20, 20000);
+	sig = SinOsc.ar(freq);
+	Out.ar(0, sig);
+}).add;
+d.specs.freq.postln;
+::

--- a/HelpSource/Classes/NamedControl.schelp
+++ b/HelpSource/Classes/NamedControl.schelp
@@ -9,10 +9,10 @@ A NamedControl directly combines a ControlName and a Control UGen conveniently. 
 
 There are syntax shortcuts that generate NamedControls from the name:
 code::
-\name.ar(values, lags)
-\name.kr(values, lags, fixedLag)
-\name.ir(values, lags)
-\name.tr(values, lags)
+\name.ar(values, lags, spec)
+\name.kr(values, lags, fixedLag, spec)
+\name.ir(values, lags, spec)
+\name.tr(values, lags, spec)
 ::
 
 ClassMethods::
@@ -20,26 +20,26 @@ method:: ar
 add a new instance of link::Classes/AudioControl:: with given name and default values.
 If lags are given, apply a Lag UGen to it.
 discussion::
-code::\symbol.ar(values, lags):: is a synonym.
+code::\symbol.ar(values, lags, spec):: is a synonym.
 
 method:: kr
 add a new instance of link::Classes/Control:: (kr) with given name and default values.
 If lags are given, apply a link::Classes/Lag:: UGen to it. If fixedLag is set to true, create a link::Classes/LagControl::
 (lags cannot be modulated then, but fewer UGens are required).
 discussion::
-code::\symbol.kr(values, lags, fixedLag):: is a synonym.
+code::\symbol.kr(values, lags, fixedLag, spec):: is a synonym.
 
 method:: ir
 add a new instance of link::Classes/Control:: (ir) with given name and default values.
 If lags are given, apply a link::Classes/Lag:: UGen to it.
 discussion::
-code::\symbol.ir(values, lags):: is a synonym.
+code::\symbol.ir(values, lags, spec):: is a synonym.
 
 method:: tr
 add a new instance of link::Classes/TrigControl:: with given name and default values.
 If lags are given, apply a link::Classes/Lag:: UGen to it.
 discussion::
-code::\symbol.tr(values, lags):: is a synonym.
+code::\symbol.tr(values, lags, spec):: is a synonym.
 
 method:: new
 add a new instance with the given rate, name and default values.

--- a/HelpSource/Classes/NodeProxy.schelp
+++ b/HelpSource/Classes/NodeProxy.schelp
@@ -491,7 +491,7 @@ method::controlKeysValues
 Get all key value pairs from default arguments.
 
 method::specs
-Get the specs array from SynthDef metadata.Note that, for a NodeProxy with multiple sources, result will be a dictionary containing specs of ALL source SynthDefs.
+Get the specs array from SynthDef metadata. Note that, for a NodeProxy with multiple sources, result will be a dictionary containing specs of ALL source SynthDefs.
 code::
 ~p = NodeProxy.audio(Server.default, 2);
 ~p.put(0, { SinOsc.ar(\freq.kr(100, spec:[50, 400])) });

--- a/HelpSource/Classes/NodeProxy.schelp
+++ b/HelpSource/Classes/NodeProxy.schelp
@@ -490,6 +490,15 @@ Get all key value pairs from both link::Classes/NodeMap:: (the settings) and def
 method::controlKeysValues
 Get all key value pairs from default arguments.
 
+method::specs
+Get the specs array from SynthDef metadata.Note that, for a NodeProxy with multiple sources, result will be a dictionary containing specs of ALL source SynthDefs.
+code::
+~p = NodeProxy.audio(Server.default, 2);
+~p.put(0, { SinOsc.ar(\freq.kr(100, spec:[50, 400])) });
+~p.put(1, { WhiteNoise.ar(\noiseAmp.kr(0.1, spec:[0, 1])) });
+~p.specs.postln;
+::
+
 subsection::Sending synths to server explicitly
 
 Normally, processes (usually synths) are started when their respective source is added to the proxy. The processes can also be restarted, however, or the proxy can be used while asleep and the processes can then be started explicitly.

--- a/HelpSource/Classes/Symbol.schelp
+++ b/HelpSource/Classes/Symbol.schelp
@@ -168,6 +168,8 @@ Inside SynthDefs and UGen functions, symbols can be used to conveniently specify
 method::kr
 
 Return a control rate NamedControl input with a default value (val), and if supplied, with a lag. If val is an array, the control will be multichannel.
+A link::Classes/ControlSpec:: provided to the code::spec:: parameter will be written into the spec metadata for the current synth.
+
 discussion::
 code::
 a = { SinOsc.ar(\freq.kr(440, 1.2)) }.play;

--- a/HelpSource/Classes/SynthDef.schelp
+++ b/HelpSource/Classes/SynthDef.schelp
@@ -485,7 +485,7 @@ Pbind(
 
 
 subsection:: Inline ControlSpec definitions
-Sometimes, it can be clearer to specify a link::Classes/ControlSpec:: for a parameter at the point of its usage in a SynthDef, rather than elsewhere.
+Sometimes, it can be clearer to specify a link::Classes/ControlSpec:: for a parameter at the point of it's usage in a SynthDef, rather than elsewhere.
 Specs can be set either when contructing a link::Classes/NamedControl:: or as a property of a SynthDef argument.
 code::
 (

--- a/HelpSource/Classes/SynthDef.schelp
+++ b/HelpSource/Classes/SynthDef.schelp
@@ -485,7 +485,7 @@ Pbind(
 
 
 subsection:: Inline ControlSpec definitions
-Sometimes, it can be clearer to specify a link::Classes/ControlSpec:: for a parameter at the point of it's usage in a SynthDef, rather than elsewhere.
+Sometimes, it can be clearer to specify a link::Classes/ControlSpec:: for a parameter at the point of its usage in a SynthDef, rather than elsewhere.
 Specs can be set either when contructing a link::Classes/NamedControl:: or as a property of a SynthDef argument.
 code::
 (

--- a/HelpSource/Classes/SynthDef.schelp
+++ b/HelpSource/Classes/SynthDef.schelp
@@ -167,6 +167,9 @@ Return an Event containing this def's variants.
 method:: allControlNames
 An array of link::Classes/ControlName::'s for the controls.
 
+method:: specs
+A link::Classes/Dictionary:: of link::Classes/ControlSpec::s for a SynthDef. Equivalent to: code::d.metadata[\specs]::
+
 subsection:: Special purpose methods
 (for most purposes, the method add is recommended)
 
@@ -480,3 +483,35 @@ Pbind(
 )
 ::
 
+
+subsection:: Inline ControlSpec definitions
+Sometimes, it can be clearer to specify a link::Classes/ControlSpec:: for a parameter at the point of it's usage in a SynthDef, rather than elsewhere.
+Specs can be set either when contructing a link::Classes/NamedControl:: or as a property of a SynthDef argument.
+code::
+(
+~def = SynthDef(\argumentExample, {
+	|freq, amp|
+	var sig;
+	freq.spec = ControlSpec(20, 20000, \exp);
+	amp.spec = ControlSpec(0, 1);
+	sig = SinOsc.ar(freq, 0, amp);
+	Out.ar(0, sig);
+});
+~def.specs.freq.postln;
+~def.specs.amp.postln;
+)
+
+(
+~def = SynthDef(\argumentExample, {
+	var sig;
+	sig = SinOsc.ar(
+		\freq.kr(spec:ControlSpec(20, 20000)),
+		0,
+		\amp.kr(spec:ControlSpec(0, 1));
+	);
+	Out.ar(0, sig);
+});
+~def.specs.freq.postln;
+~def.specs.amp.postln;
+)
+::

--- a/HelpSource/Classes/SynthDef.schelp
+++ b/HelpSource/Classes/SynthDef.schelp
@@ -485,12 +485,11 @@ Pbind(
 
 
 subsection:: Inline ControlSpec definitions
-Sometimes, it can be clearer to specify a link::Classes/ControlSpec:: for a parameter at the point of it's usage in a SynthDef, rather than elsewhere.
+Sometimes, it can be clearer to specify a link::Classes/ControlSpec:: for a parameter at the point of its usage in a SynthDef, rather than elsewhere.
 Specs can be set either when contructing a link::Classes/NamedControl:: or as a property of a SynthDef argument.
 code::
 (
-~def = SynthDef(\argumentExample, {
-	|freq, amp|
+~def = SynthDef(\argumentExample, { |freq, amp|
 	var sig;
 	freq.spec = ControlSpec(20, 20000, \exp);
 	amp.spec = ControlSpec(0, 1);

--- a/HelpSource/Classes/SynthDesc.schelp
+++ b/HelpSource/Classes/SynthDesc.schelp
@@ -162,6 +162,8 @@ returns:: an array of link::Classes/IODesc:: that describes the available output
 method:: inputs
 returns:: an array of link::Classes/IODesc:: that describes the available inputs.
 
+copymethod:: SynthDef -specs
+
 method:: hasGate
 is true if the Synthdef has a gate input
 

--- a/SCClassLibrary/Common/Audio/InOut.sc
+++ b/SCClassLibrary/Common/Audio/InOut.sc
@@ -21,8 +21,7 @@ ControlName {
 		^UGen.buildSynthDef.specs[name]
 	}
 
-	spec_{
-		|spec|
+	spec_{ arg spec;
 		if (spec.notNil) {
 			spec = spec.asSpec;
 

--- a/SCClassLibrary/Common/Audio/InOut.sc
+++ b/SCClassLibrary/Common/Audio/InOut.sc
@@ -27,11 +27,11 @@ ControlName {
 			spec = spec.asSpec;
 
 			defaultValue ?? {
-				defaultValue = spec.default
+				defaultValue = spec.default;
 			};
 
 			UGen.buildSynthDef.specs[name] !? _.setFrom(spec) ?? {
-				UGen.buildSynthDef.specs[name] = spec
+				UGen.buildSynthDef.specs[name] = spec;
 			};
 		}
 	}

--- a/SCClassLibrary/Common/Audio/InOut.sc
+++ b/SCClassLibrary/Common/Audio/InOut.sc
@@ -17,6 +17,25 @@ ControlName {
 		//stream << "\n"
 	}
 
+	spec {
+		^UGen.buildSynthDef.specs[name]
+	}
+
+	spec_{
+		|spec|
+		if (spec.notNil) {
+			spec = spec.asSpec;
+
+			defaultValue ?? {
+				defaultValue = spec.default;
+			};
+
+			UGen.buildSynthDef.specs[name] !? _.setFrom(spec) ?? {
+				UGen.buildSynthDef.specs[name] = spec;
+			};
+		}
+	}
+
 }
 
 Control : MultiOutUGen {

--- a/SCClassLibrary/Common/Audio/InOut.sc
+++ b/SCClassLibrary/Common/Audio/InOut.sc
@@ -27,11 +27,11 @@ ControlName {
 			spec = spec.asSpec;
 
 			defaultValue ?? {
-				defaultValue = spec.default;
+				defaultValue = spec.default
 			};
 
 			UGen.buildSynthDef.specs[name] !? _.setFrom(spec) ?? {
-				UGen.buildSynthDef.specs[name] = spec;
+				UGen.buildSynthDef.specs[name] = spec
 			};
 		}
 	}

--- a/SCClassLibrary/Common/Audio/SynthDef.sc
+++ b/SCClassLibrary/Common/Audio/SynthDef.sc
@@ -33,7 +33,7 @@ SynthDef {
 	}
 
 	*new { arg name, ugenGraphFunc, rates, prependArgs, variants, metadata;
-		^super.newCopyArgs(name.asSymbol).variants_(variants).metadata_(metadata).children_(Array.new(64))
+		^super.newCopyArgs(name.asSymbol).variants_(variants).metadata_(metadata ?? {()}).children_(Array.new(64))
 			.build(ugenGraphFunc, rates, prependArgs)
 	}
 
@@ -648,6 +648,15 @@ SynthDef {
 		lib = SynthDescLib.getLib(libname);
 		desc = lib.readDescFromDef(stream, keepDef, this, metadata);
 		^desc
+	}
+
+	specs {
+		^(metadata[\specs] ?? {
+			var d;
+			d = ();
+			metadata[\specs] = d;
+			d
+		})
 	}
 
 	// this method warns and does not halt

--- a/SCClassLibrary/Common/Audio/SynthDesc.sc
+++ b/SCClassLibrary/Common/Audio/SynthDesc.sc
@@ -460,7 +460,7 @@ Use of this synth in Patterns will not detect argument names automatically becau
 	}
 
 	writeMetadata { arg path, mdPlugin;
-		if(metadata.isNil || (metadata.size == 0)) { AbstractMDPlugin.clearMetadata(path); ^this };
+		if (metadata.size == 0) { AbstractMDPlugin.clearMetadata(path); ^this };
 		(mdPlugin ?? { this.class.mdPlugin }).writeMetadata(metadata, def, path);
 	}
 

--- a/SCClassLibrary/Common/Audio/SynthDesc.sc
+++ b/SCClassLibrary/Common/Audio/SynthDesc.sc
@@ -460,7 +460,7 @@ Use of this synth in Patterns will not detect argument names automatically becau
 	}
 
 	writeMetadata { arg path, mdPlugin;
-		if(metadata.isNil) { AbstractMDPlugin.clearMetadata(path); ^this };
+		if(metadata.isNil || (metadata.size == 0)) { AbstractMDPlugin.clearMetadata(path); ^this };
 		(mdPlugin ?? { this.class.mdPlugin }).writeMetadata(metadata, def, path);
 	}
 

--- a/SCClassLibrary/Common/Audio/SynthDesc.sc
+++ b/SCClassLibrary/Common/Audio/SynthDesc.sc
@@ -488,7 +488,11 @@ Use of this synth in Patterns will not detect argument names automatically becau
 		}
 	}
 
-
+	specs {
+		metadata ?? { metadata = () };
+		metadata[\specs] ?? { metadata[\specs] = () };
+		^metadata[\specs]
+	}
 }
 
 SynthDescLib {

--- a/SCClassLibrary/Common/Audio/UGen.sc
+++ b/SCClassLibrary/Common/Audio/UGen.sc
@@ -602,4 +602,30 @@ OutputProxy : UGen {
 	dumpName {
 		^this.source.dumpName ++ "[" ++ outputIndex ++ "]"
 	}
+
+	controlName {
+		var counter = 0, index = 0;
+
+		this.synthDef.children.do({
+			arg ugen;
+			if(this.source.synthIndex == ugen.synthIndex,
+				{ index = counter + this.outputIndex; });
+			if(ugen.isKindOf(Control),
+				{ counter = counter + ugen.channels.size; });
+		});
+
+		^synthDef.controlNames.detect({ |c| c.index == index });
+	}
+
+	spec_{
+		|spec|
+		var controlName, name;
+		controlName = this.controlName;
+		if (this.controlName.notNil) {
+			controlName.spec = spec;
+		} {
+			"Cannot set spec on a non-Control".error;
+		}
+	}
+
 }

--- a/SCClassLibrary/Common/Audio/UGen.sc
+++ b/SCClassLibrary/Common/Audio/UGen.sc
@@ -617,8 +617,7 @@ OutputProxy : UGen {
 		^synthDef.controlNames.detect({ |c| c.index == index });
 	}
 
-	spec_{
-		|spec|
+	spec_{ arg spec;
 		var controlName, name;
 		controlName = this.controlName;
 		if (this.controlName.notNil) {

--- a/SCClassLibrary/Common/Control/GraphBuilder.sc
+++ b/SCClassLibrary/Common/Control/GraphBuilder.sc
@@ -84,10 +84,6 @@ NamedControl {
 			if (values.isNil) {
 				values = spec.default;
 			};
-
-			UGen.buildSynthDef.specs[name] !? _.setFrom(spec) ?? {
-				UGen.buildSynthDef.specs[name] = spec;
-			};
 		};
 
 		res = currentControls.at(name);
@@ -125,6 +121,8 @@ NamedControl {
 				^res.control;
 			}
 		};
+
+		res.spec = spec; // Set after we've finished without error.
 
 		^if(lags.notNil) {
 			res.control.lag(lags).unbubble
@@ -172,13 +170,22 @@ NamedControl {
 		control = control.asArray.reshapeLike(values).unbubble;
 	}
 
-
-
-
 	*initDict {
 		if(UGen.buildSynthDef !== buildSynthDef or: currentControls.isNil) {
 			buildSynthDef = UGen.buildSynthDef;
 			currentControls = IdentityDictionary.new;
+		};
+	}
+
+	spec {
+		^UGen.buildSynthDef.specs[name]
+	}
+
+	spec_{
+		|spec|
+		spec = spec.asSpec;
+		this.spec !? _.setFrom(spec) ?? {
+			UGen.buildSynthDef.specs[name] = spec
 		};
 	}
 }

--- a/SCClassLibrary/Common/Control/GraphBuilder.sc
+++ b/SCClassLibrary/Common/Control/GraphBuilder.sc
@@ -56,19 +56,19 @@ NamedControl {
 	var <control;
 
 	*ar { arg  name, values, lags, spec;
-		^this.new(name, values, \audio, lags, false, spec)
+		^this.newSpec(name, values, \audio, lags, false, spec)
 	}
 
 	*kr { arg  name, values, lags, fixedLag = false, spec;
-		^this.new(name, values, \control, lags, fixedLag, spec)
+		^this.newSpec(name, values, \control, lags, fixedLag, spec)
 	}
 
 	*ir { arg  name, values, lags, spec;
-		^this.new(name, values, \scalar, lags, false, spec)
+		^this.newSpec(name, values, \scalar, lags, false, spec)
 	}
 
 	*tr { arg  name, values, lags, spec;
-		^this.new(name, values, \trigger, lags, false, spec)
+		^this.newSpec(name, values, \trigger, lags, false, spec)
 	}
 
 	*new { arg name, values, rate, lags, fixedLag = false, spec;
@@ -131,6 +131,11 @@ NamedControl {
 		} {
 			res.control
 		}
+	}
+
+	*newSpec { arg name, values, rate, lags, fixedLag = false, spec;
+		this.initDict;
+
 	}
 
 	init {

--- a/SCClassLibrary/Common/Control/GraphBuilder.sc
+++ b/SCClassLibrary/Common/Control/GraphBuilder.sc
@@ -55,28 +55,41 @@ NamedControl {
 	var <name, <values, <lags, <rate, <fixedLag;
 	var <control;
 
-	*ar { arg  name, values, lags;
-		^this.new(name, values, \audio, lags, false)
+	*ar { arg  name, values, lags, spec;
+		^this.newSpec(name, values, \audio, lags, false, spec)
 	}
 
-	*kr { arg  name, values, lags, fixedLag = false;
-		^this.new(name, values, \control, lags, fixedLag)
+	*kr { arg  name, values, lags, fixedLag = false, spec;
+		^this.newSpec(name, values, \control, lags, fixedLag, spec)
 	}
 
-	*ir { arg  name, values, lags;
-		^this.new(name, values, \scalar, lags, false)
+	*ir { arg  name, values, lags, spec;
+		^this.newSpec(name, values, \scalar, lags, false, spec)
 	}
 
-	*tr { arg  name, values, lags;
-		^this.new(name, values, \trigger, lags, false)
+	*tr { arg  name, values, lags, spec;
+		^this.newSpec(name, values, \trigger, lags, false, spec)
 	}
 
-	*new { arg name, values, rate, lags, fixedLag = false;
+	*new { arg name, values, rate, lags, fixedLag = false, spec;
 		var res;
+
+		this.initDict;
 
 		name = name.asSymbol;
 
-		this.initDict;
+		if (spec.notNil) {
+			spec = spec.asSpec;
+
+			if (values.isNil) {
+				values = spec.default;
+			};
+
+			UGen.buildSynthDef.specs[name] !? _.setFrom(spec) ?? {
+				UGen.buildSynthDef.specs[name] = spec;
+			};
+		};
+
 		res = currentControls.at(name);
 
 		lags = lags.deepCollect(inf, {|elem|
@@ -120,6 +133,11 @@ NamedControl {
 		}
 	}
 
+	*newSpec { arg name, values, rate, lags, fixedLag = false, spec;
+		this.initDict;
+
+	}
+
 	init {
 		var prefix, ctlName, ctl, selector;
 
@@ -158,6 +176,9 @@ NamedControl {
 
 		control = control.asArray.reshapeLike(values).unbubble;
 	}
+
+
+
 
 	*initDict {
 		if(UGen.buildSynthDef !== buildSynthDef or: currentControls.isNil) {

--- a/SCClassLibrary/Common/Control/GraphBuilder.sc
+++ b/SCClassLibrary/Common/Control/GraphBuilder.sc
@@ -56,19 +56,19 @@ NamedControl {
 	var <control;
 
 	*ar { arg  name, values, lags, spec;
-		^this.newSpec(name, values, \audio, lags, false, spec)
+		^this.new(name, values, \audio, lags, false, spec)
 	}
 
 	*kr { arg  name, values, lags, fixedLag = false, spec;
-		^this.newSpec(name, values, \control, lags, fixedLag, spec)
+		^this.new(name, values, \control, lags, fixedLag, spec)
 	}
 
 	*ir { arg  name, values, lags, spec;
-		^this.newSpec(name, values, \scalar, lags, false, spec)
+		^this.new(name, values, \scalar, lags, false, spec)
 	}
 
 	*tr { arg  name, values, lags, spec;
-		^this.newSpec(name, values, \trigger, lags, false, spec)
+		^this.new(name, values, \trigger, lags, false, spec)
 	}
 
 	*new { arg name, values, rate, lags, fixedLag = false, spec;
@@ -131,11 +131,6 @@ NamedControl {
 		} {
 			res.control
 		}
-	}
-
-	*newSpec { arg name, values, rate, lags, fixedLag = false, spec;
-		this.initDict;
-
 	}
 
 	init {

--- a/SCClassLibrary/Common/Control/Spec.sc
+++ b/SCClassLibrary/Common/Control/Spec.sc
@@ -234,8 +234,7 @@ Warp {
 
 	*asWarp { arg spec; ^this.new(spec) }
 
-	asWarp {
-		|inSpec|
+	asWarp { arg inSpec;
 		^this.copy.spec_(inSpec)
 	}
 

--- a/SCClassLibrary/Common/Control/Spec.sc
+++ b/SCClassLibrary/Common/Control/Spec.sc
@@ -162,6 +162,19 @@ ControlSpec : Spec {
 		^minval.sign != maxval.sign
 	}
 
+	setFrom {
+		|otherSpec|
+
+		// Note that ownership with grid and warp are weird - they point back to
+		// the owning spec, so these need to be copied and re-setup in this case.
+		this.minval 	= otherSpec.minval;
+		this.maxval 	= otherSpec.maxval;
+		this.warp 		= otherSpec.warp.asWarp(this);
+		this.step 		= otherSpec.step;
+		this.default 	= otherSpec.default;
+		this.units 		= otherSpec.units;
+		this.grid 		= otherSpec.grid.copy.spec_(this);
+	}
 
 	*initClass {
 		Class.initClassTree(Spec);
@@ -220,7 +233,12 @@ Warp {
 	unmap { arg value; ^value }
 
 	*asWarp { arg spec; ^this.new(spec) }
-	asWarp { ^this }
+
+	asWarp {
+		|inSpec|
+		^this.copy.spec_(inSpec)
+	}
+
 	*initClass {
 		// support Symbol-asWarp
 		warps = IdentityDictionary[

--- a/SCClassLibrary/Common/Core/Symbol.sc
+++ b/SCClassLibrary/Common/Core/Symbol.sc
@@ -231,20 +231,20 @@ Symbol {
 
 	archiveAsCompileString { ^true }
 
-	kr { | val, lag, fixedLag = false |
-		^NamedControl.kr(this, val, lag, fixedLag)
+	kr { | val, lag, fixedLag = false, spec |
+		^NamedControl.kr(this, val, lag, fixedLag, spec)
 	}
 
-	ir { | val |
-		^NamedControl.ir(this, val)
+	ir { | val, spec |
+		^NamedControl.ir(this, val, spec:spec)
 	}
 
-	tr { | val |
-		^NamedControl.tr(this, val)
+	tr { | val, spec |
+		^NamedControl.tr(this, val, spec:spec)
 	}
 
-	ar { | val, lag |
-		^NamedControl.ar(this, val, lag)
+	ar { | val, lag, spec |
+		^NamedControl.ar(this, val, lag, spec:spec)
 	}
 
 	matchOSCAddressPattern { arg addressPattern;

--- a/SCClassLibrary/Common/Core/Symbol.sc
+++ b/SCClassLibrary/Common/Core/Symbol.sc
@@ -244,7 +244,7 @@ Symbol {
 	}
 
 	ar { | val, lag, spec |
-		^NamedControl.ar(this, val, lag, spec:spec)
+		^NamedControl.ar(this, val, lag, spec)
 	}
 
 	matchOSCAddressPattern { arg addressPattern;

--- a/SCClassLibrary/JITLib/ProxySpace/NodeProxy.sc
+++ b/SCClassLibrary/JITLib/ProxySpace/NodeProxy.sc
@@ -990,6 +990,21 @@ NodeProxy : BusPlug {
 		};
 		^SynthDef(name, func);
 	}
+
+	specs {
+		var specs = ();
+		this.objects.do {
+			|obj|
+			if (obj.respondsTo(\specs)) {
+				specs = specs.merge(obj.specs, {
+					|a, b, key|
+					"Duplicate specs for key: % - only one will be used.".format(key).warn;
+					a;
+				});
+			}
+		};
+		^specs
+	}
 }
 
 

--- a/SCClassLibrary/JITLib/ProxySpace/ProxyInterfaces.sc
+++ b/SCClassLibrary/JITLib/ProxySpace/ProxyInterfaces.sc
@@ -413,5 +413,8 @@ SynthDefControl : SynthControl {
 		bytes = control.bytes; // copy cached data
 	}
 
+	specs {
+		^synthDef.specs
+	}
 
 }

--- a/testsuite/classlibrary/TestControlSpec.sc
+++ b/testsuite/classlibrary/TestControlSpec.sc
@@ -1,22 +1,22 @@
 
 TestControlSpec : UnitTest {
-	
+
 	test_equals {
 		var a,b,c;
 		a = ControlSpec(0, 1, 'linear', 0, 0.0, "");
 		b = ControlSpec(0, 1, 'linear', 0, 0.0, "");
 		c = ControlSpec(0, 2, 'linear', 0, 0.0, "");
-		
+
 		// no really, this failed !
 		this.assert( a == b, "2 identical control specs should be equal");
 		this.assert( a != c, "2 different control specs should not be equal");
-		
+
 		this.assert( a == a, "control spec should equal itself");
 
 	}
 	test_copy {
 		var z,w;
-		
+
 		z = ControlSpec(50,100);
 		this.assert(z.warp.spec === z,"the spec's warp's spec should be the spec");
 
@@ -28,22 +28,112 @@ TestControlSpec : UnitTest {
 		this.assert(z.minval == 70,"setting minval on spec should work");
 
 		this.assert( w.minval != 70,"setting minval on spec should not affect its copy");
-		
+
 		// and here is the bug itself
 		this.assert( w.map(0.0) == 50,"mapping using the copied spec should result in the original mapping behavior of the original spec.");
 	}
 
+	test_setFrom {
+		var a, b;
+
+		a = ControlSpec(1, 2, \lin, 0.1, 1.5, "test units");
+		b = ControlSpec().setFrom(a);
+
+		this.assertEquals(b.minval, 1);
+		this.assertEquals(b.maxval, 2);
+		this.assert(b.warp.isKindOf(LinearWarp));
+		this.assertEquals(b.warp.spec, b);
+		this.assertEquals(b.step, 0.1);
+		this.assertEquals(b.default, 1.5);
+		this.assertEquals(b.units, "test units");
+		this.assertEquals(b.grid.spec, b);
+	}
+
+	test_defcontrols_args {
+		var def, spec;
+
+		spec = ControlSpec(100, 1000, \exp, 1, 440);
+
+		def = SynthDef(\__unittest_controlspec_namedcontrols, {
+			|freq=123|
+			freq.spec = spec;
+			Out.ar(0, SinOsc.ar(freq));
+		}).add;
+
+		this.assertEquals(spec, def.specs[\freq]);
+	}
+
+	test_defcontrols_symbols {
+		var def, spec;
+
+		spec = ControlSpec(100, 1000, \exp, 1, 440);
+
+		def = SynthDef(\__unittest_controlspec_namedcontrols, {
+			var freq, input, gate, dur;
+
+			dur = \dur.ir(spec:spec);
+			freq = \freq.kr(spec:spec);
+			input = \input.ar(spec:spec);
+			gate = \gate.tr(spec:spec);
+
+			Out.ar(0, SinOsc.ar(freq));
+		}).add;
+
+		this.assertEquals(spec, def.specs[\dur]);
+		this.assertEquals(spec, def.specs[\freq]);
+		this.assertEquals(spec, def.specs[\input]);
+		this.assertEquals(spec, def.specs[\gate]);
+	}
+
+	test_defcontrols_metadata {
+		var def, spec;
+
+		spec = ControlSpec(100, 1000, \exp, 1, 440);
+
+		def = SynthDef(\__unittest_controlspec_namedcontrols, {
+			|freq|
+			Out.ar(0, SinOsc.ar(freq));
+		}, metadata: ( specs: ( freq: spec ))).add;
+
+		this.assertEquals(spec, def.specs[\freq]);
+	}
+
+	test_defcontrols_nodeproxy {
+		var proxy, spec;
+
+		spec = ControlSpec(100, 1000, \exp, 1, 440);
+
+		proxy = NodeProxy.audio(Server.default, 2);
+		proxy.source = {
+			SinOsc.ar(\freq.kr(spec:spec));
+		};
+
+		this.assertEquals(spec, proxy.specs[\freq]);
+	}
+
+	test_def_defaults {
+		var def;
+
+		def = SynthDef(\__unittest_controlspec_namedcontrols_c, {
+			var freq;
+			freq = \freq.kr(spec:ControlSpec(0, 10000, default:123));
+		}).add;
+
+		this.assertEquals(def.desc.controls[0].defaultValue, 123);
+	}
+
+
 }
 
 TestCurveWarp :UnitTest {
-	
+
 	test_equals {
 		var s,c,d,e;
 		s = ControlSpec(0.3,10.0);
 		c = CurveWarp(s,-2);
 		d = CurveWarp(s,-2);
 		e = CurveWarp(s,-3);
-		
+
 		this.assert( c == d, "CurveWarp should be equal");
 		this.assert( c != e, "CurveWarp should not be equal");
 		this.assert( c == c, "identical CurveWarp should be equal");

--- a/testsuite/classlibrary/TestControlSpec.sc
+++ b/testsuite/classlibrary/TestControlSpec.sc
@@ -39,14 +39,14 @@ TestControlSpec : UnitTest {
 		a = ControlSpec(1, 2, \lin, 0.1, 1.5, "test units");
 		b = ControlSpec().setFrom(a);
 
-		this.assertEquals(b.minval, 1);
-		this.assertEquals(b.maxval, 2);
-		this.assert(b.warp.isKindOf(LinearWarp));
-		this.assertEquals(b.warp.spec, b);
-		this.assertEquals(b.step, 0.1);
-		this.assertEquals(b.default, 1.5);
-		this.assertEquals(b.units, "test units");
-		this.assertEquals(b.grid.spec, b);
+		this.assertEquals(b.minval, 1, "set minval");
+		this.assertEquals(b.maxval, 2, "set maxval");
+		this.assert(b.warp.isKindOf(LinearWarp), "set warp");
+		this.assertEquals(b.warp.spec, b, "set warp:spec");
+		this.assertEquals(b.step, 0.1, "set step");
+		this.assertEquals(b.default, 1.5, "set default");
+		this.assertEquals(b.units, "test units", "set units");
+		this.assertEquals(b.grid.spec, b, "set grid");
 	}
 
 	test_defcontrols_args {
@@ -60,7 +60,7 @@ TestControlSpec : UnitTest {
 			Out.ar(0, SinOsc.ar(freq));
 		}).add;
 
-		this.assertEquals(spec, def.specs[\freq]);
+		this.assertEquals(spec, def.specs[\freq], "spec set correctly on synth argument");
 	}
 
 	test_defcontrols_symbols {
@@ -79,10 +79,10 @@ TestControlSpec : UnitTest {
 			Out.ar(0, SinOsc.ar(freq));
 		}).add;
 
-		this.assertEquals(spec, def.specs[\dur]);
-		this.assertEquals(spec, def.specs[\freq]);
-		this.assertEquals(spec, def.specs[\input]);
-		this.assertEquals(spec, def.specs[\gate]);
+		this.assertEquals(spec, def.specs[\dur], "set correctly with named ir control");
+		this.assertEquals(spec, def.specs[\freq], "set correctly with named kr control");
+		this.assertEquals(spec, def.specs[\input], "set correctly with named ar control");
+		this.assertEquals(spec, def.specs[\gate], "set correctly with named tr control");
 	}
 
 	test_defcontrols_metadata {
@@ -95,7 +95,7 @@ TestControlSpec : UnitTest {
 			Out.ar(0, SinOsc.ar(freq));
 		}, metadata: ( specs: ( freq: spec ))).add;
 
-		this.assertEquals(spec, def.specs[\freq]);
+		this.assertEquals(spec, def.specs[\freq], "set correctly in metadata blob");
 	}
 
 	test_defcontrols_nodeproxy {
@@ -108,7 +108,7 @@ TestControlSpec : UnitTest {
 			SinOsc.ar(\freq.kr(spec:spec));
 		};
 
-		this.assertEquals(spec, proxy.specs[\freq]);
+		this.assertEquals(spec, proxy.specs[\freq], "set correctly in NodeProxy");
 	}
 
 	test_def_defaults {
@@ -119,7 +119,7 @@ TestControlSpec : UnitTest {
 			freq = \freq.kr(spec:ControlSpec(0, 10000, default:123));
 		}).add;
 
-		this.assertEquals(def.desc.controls[0].defaultValue, 123);
+		this.assertEquals(def.desc.controls[0].defaultValue, 123, "set default correctly from SynthDef");
 	}
 
 


### PR DESCRIPTION
This PR adds some more flexible ways of modifying ControlSpecs related to SynthDef args.
For settings specs:

    SynthDef(\foo, { |freq| freq.spec = ControlSpec(20, 20000) });
    SynthDef(\foo, { SinOsc.ar(\freq.kr(spec:ContolSpec(20, 20000)) });

For finding specs:

    def.specs[\freq];
    Ndef(\foo).specs[\freq];

Where ever possible, reasonable SynthDef-like objects respond to `.specs`. Also, where it's reasonable existing specs are set using `setFrom` rather that obliterating them in the specs dictionary itself, to preserve identity of those specs in case they are linked to UI or have dependents.