### PR TITLE
supernova: Unify scsynth/supernova plugin loading

### DIFF
--- a/common/SC_Filesystem.hpp
+++ b/common/SC_Filesystem.hpp
@@ -65,6 +65,14 @@
 /// Default IDE name.
 #define SC_DEFAULT_IDE_NAME "none"
 
+/// Name of the plugins subdirectory of the Resources dir
+#define SC_PLUGIN_DIR_NAME "plugins"
+
+/// Extension for server plugins.
+#ifndef SC_PLUGIN_EXT
+#   define SC_PLUGIN_EXT ".scx"
+#endif
+
 #include <map> // map
 #include <algorithm> // std::transform
 #include <string> // std::string
@@ -192,7 +200,7 @@ public:
 	  * \param p a path to resolve
 	  * \param isAlias set to true if p is an alias
 	  * \return An empty path if resolution failed; otherwise, the resolved path.
-	  * 
+	  *
 	  * If the path was not an alias, a copy is returned. */
 	// Could possibly be split into `isAlias` and `resolveAlias` to avoid
 	// unnecessary copying - bh

--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -3,6 +3,10 @@ if (NOT APPLE AND NOT WIN32)
 	add_definitions("-DSC_PLUGIN_EXT=\".so\"")
 endif()
 
+if(UNIX AND NOT APPLE)
+	set(LINUX_SC_PLUGIN_DIR ${CMAKE_INSTALL_PREFIX}/lib${LIB_SUFFIX}/SuperCollider/plugins)
+endif()
+
 include_directories(${CMAKE_SOURCE_DIR}/external_libraries
 					${CMAKE_SOURCE_DIR}/external_libraries/nova-simd
 					${CMAKE_SOURCE_DIR}/external_libraries/nova-tt

--- a/server/scsynth/CMakeLists.txt
+++ b/server/scsynth/CMakeLists.txt
@@ -147,9 +147,8 @@ elseif(NOT NO_LIBSNDFILE)
 endif(SNDFILE_FOUND)
 
 if(UNIX AND NOT APPLE)
-	target_compile_definitions(libscsynth PUBLIC "SC_PLUGIN_DIR=\"${CMAKE_INSTALL_PREFIX}/lib${LIB_SUFFIX}/SuperCollider/plugins\"")
+	target_compile_definitions(libscsynth PUBLIC "SC_PLUGIN_DIR=\"${LINUX_SC_PLUGIN_DIR}\"")
 endif()
-
 
 if(NOT NO_AVAHI)
 	if(APPLE)

--- a/server/scsynth/SC_Lib_Cintf.cpp
+++ b/server/scsynth/SC_Lib_Cintf.cpp
@@ -45,14 +45,6 @@
 # include <sys/param.h>
 #endif // _WIN32
 
-// Plugin directory in resource directory
-#define SC_PLUGIN_DIR_NAME "plugins"
-
-// Extension for binary plugins
-#ifndef SC_PLUGIN_EXT
-#  define SC_PLUGIN_EXT ".scx"
-#endif
-
 #include <boost/filesystem/path.hpp> // path
 #include <boost/filesystem/operations.hpp> // is_directory
 

--- a/server/supernova/CMakeLists.txt
+++ b/server/supernova/CMakeLists.txt
@@ -244,3 +244,7 @@ if(${LIB_SUFFIX})
 else()
     add_definitions(-DLIB_SUFFIX="")
 endif()
+
+if(UNIX AND NOT APPLE)
+    target_compile_definitions(libsupernova PUBLIC "SC_PLUGIN_DIR=\"${LINUX_SC_PLUGIN_DIR}\"")
+endif()

--- a/server/supernova/sc/sc_ugen_factory.cpp
+++ b/server/supernova/sc/sc_ugen_factory.cpp
@@ -260,6 +260,11 @@ void sc_ugen_factory::load_plugin ( boost::filesystem::path const & path )
 {
     using namespace std;
 
+    // Ignore files that don't have the extension of an SC plugin
+    if (path.extension() != SC_PLUGIN_EXT) {
+        return;
+    }
+
     void * handle = dlopen(path.string().c_str(), RTLD_NOW | RTLD_LOCAL);
     if (handle == nullptr)
         return;
@@ -312,6 +317,11 @@ void sc_ugen_factory::close_handles(void)
 
 void sc_ugen_factory::load_plugin ( boost::filesystem::path const & path )
 {
+    // Ignore files that don't have the extension of an SC plugin
+    if (path.extension() != SC_PLUGIN_EXT) {
+        return;
+    }
+
     //std::cout << "try open plugin: " << path << std::endl;
     const char * filename = path.string().c_str();
     HINSTANCE hinstance = LoadLibrary( path.string().c_str() );

--- a/server/supernova/server/main.cpp
+++ b/server/supernova/server/main.cpp
@@ -248,9 +248,9 @@ void set_plugin_paths(server_arguments const & args, nova::sc_ugen_factory * fac
         factory->load_plugin_folder(SC_Filesystem::instance().getDirectory(DirName::Resource) / SC_PLUGIN_DIR_NAME);
         factory->load_plugin_folder(SC_Filesystem::instance().getDirectory(DirName::SystemExtension));
         factory->load_plugin_folder(SC_Filesystem::instance().getDirectory(DirName::UserExtension));
-        vector<std::string> directories;
         const char * env_plugin_path = getenv("SC_PLUGIN_PATH");
         if (env_plugin_path) {
+            vector<std::string> directories;
             boost::split(directories, env_plugin_path, boost::is_any_of(pathSeparator));
             for (string const & path : directories) {
                 factory->load_plugin_folder(path);

--- a/server/supernova/server/main.cpp
+++ b/server/supernova/server/main.cpp
@@ -242,20 +242,20 @@ void set_plugin_paths(server_arguments const & args, nova::sc_ugen_factory * fac
             }
         }
     } else {
-#ifdef __linux__
-        const path home = resolve_home();
-        std::vector<path> folders = { "/usr/local/lib/SuperCollider/plugins",
-                                      "/usr/lib" LIB_SUFFIX "/SuperCollider/plugins",
-                                      home / "/.local/share/SuperCollider/Extensions",
-                                      home / "share/SuperCollider/plugins" };
-
-        for (path const & folder : folders)
-            factory->load_plugin_folder(folder);
-#else
-        factory->load_plugin_folder(SC_Filesystem::instance().getDirectory(DirName::Resource) / "plugins");
-        factory->load_plugin_folder(SC_Filesystem::instance().getDirectory(DirName::SystemExtension) );
-        factory->load_plugin_folder(SC_Filesystem::instance().getDirectory(DirName::UserExtension) );
+#ifdef SC_PLUGIN_DIR
+        factory->load_plugin_folder(SC_PLUGIN_DIR);
 #endif
+        factory->load_plugin_folder(SC_Filesystem::instance().getDirectory(DirName::Resource) / "plugins");
+        factory->load_plugin_folder(SC_Filesystem::instance().getDirectory(DirName::SystemExtension));
+        factory->load_plugin_folder(SC_Filesystem::instance().getDirectory(DirName::UserExtension));
+        vector<std::string> directories;
+        const char * env_plugin_path = getenv("SC_PLUGIN_PATH");
+        if (env_plugin_path) {
+            boost::split(directories, env_plugin_path, boost::is_any_of(pathSeparator));
+            for (string const & path : directories) {
+                factory->load_plugin_folder(path);
+            }
+        }
     }
 
 #ifndef NDEBUG

--- a/server/supernova/server/main.cpp
+++ b/server/supernova/server/main.cpp
@@ -245,7 +245,7 @@ void set_plugin_paths(server_arguments const & args, nova::sc_ugen_factory * fac
 #ifdef SC_PLUGIN_DIR
         factory->load_plugin_folder(SC_PLUGIN_DIR);
 #endif
-        factory->load_plugin_folder(SC_Filesystem::instance().getDirectory(DirName::Resource) / "plugins");
+        factory->load_plugin_folder(SC_Filesystem::instance().getDirectory(DirName::Resource) / SC_PLUGIN_DIR_NAME);
         factory->load_plugin_folder(SC_Filesystem::instance().getDirectory(DirName::SystemExtension));
         factory->load_plugin_folder(SC_Filesystem::instance().getDirectory(DirName::UserExtension));
         vector<std::string> directories;


### PR DESCRIPTION
this fixes #2290 and #3446. here are the supernova plugin path problems:

- the `SC_PLUGIN_PATH` environment variable is not respected
- on linux systems, a fixed set of hardcoded paths are tested, and that's it
- tries *all* files, not just ones with the correct extension

now supernova should have identical behavior in plugin path loading compared to scsynth. #2290 in particular was barring me from using supernova.

some variables had to be moved from scsynth to avoid code duplication.