### PR TITLE
class library: fix String -asSecs

### DIFF
--- a/HelpSource/Classes/String.schelp
+++ b/HelpSource/Classes/String.schelp
@@ -248,7 +248,7 @@ code::
 ::
 
 method::asSecs
-Return a link::Classes/Float:: based on converting a time string in format (dd):hh:mm:ss.s. This is the inverse method to link::Classes/SimpleNumber#-asTimeString::.
+Return a link::Classes/Float:: based on converting a time string in format (ddd):hh:mm:ss.sss. This is the inverse method to link::Classes/SimpleNumber#-asTimeString::.
 code::
 (45296.asTimeString).asSecs;
 "32.1".asSecs;

--- a/SCClassLibrary/Common/Collections/String.sc
+++ b/SCClassLibrary/Common/Collections/String.sc
@@ -505,9 +505,9 @@ String[char] : RawArray {
 
 	asSecs { |maxDays = 365| // assume a timeString of ddd:hh:mm:ss.sss. see asTimeString.
 		var time = 0, sign = 1, str = this;
-		var limits = [inf, 60, 60, 24, maxDays];
-		var scaling = [0.001, 1.0, 60.0, 3600.0, 86400.0];
-		var padding = [3, 2, 2, 2, 3];
+		var limits = [60, 60, 24, maxDays];
+		var scaling = [1.0, 60.0, 3600.0, 86400.0];
+		var slotNames = [\seconds, \minutes, \hours, \days];
 
 		if (this.first == $-) {
 			str = this.drop(1);
@@ -515,14 +515,13 @@ String[char] : RawArray {
 		};
 
 		str.split($:).reverseDo { |num, i|
-			num = num.padRight(padding[i], "0").asInteger;
-			if (num > limits[i]) {
-				("asSecs: number greater than allowed:" + this).warn;
-				num = limits[i];
-			};
+			num = num.asFloat;
 			if (num < 0) {
-				("asSecs: negative numbers within slots not supported:" + this).warn;
-				num = 0;
+				format("%.asSecs: negative numbers within slots not supported, using absolute value", this).warn;
+				num = num.abs;
+			};
+			if (num > limits[i]) {
+				format("%.asSecs: number of % greater than %", this, slotNames[i], limits[i]).warn;
 			};
 			time = time + (num * scaling[i]);
 		};

--- a/SCClassLibrary/Common/Math/SimpleNumber.sc
+++ b/SCClassLibrary/Common/Math/SimpleNumber.sc
@@ -711,7 +711,7 @@ SimpleNumber : Number {
 		// formatted string.
 		precision = max(precision, 0.001);
 		mseconds = this.frac.round(precision) * 1000;
-		mseconds = mseconds.round.asString.padLeft(3, "0");
+		mseconds = mseconds.round.asInteger.asString.padLeft(3, "0");
 		^days ++ hours ++ minutes ++ seconds ++ mseconds
 	}
 

--- a/testsuite/classlibrary/TestString.sc
+++ b/testsuite/classlibrary/TestString.sc
@@ -94,5 +94,28 @@ TestString : UnitTest {
 		this.assertEquals("dir" +/+ 'file', "dir%file".format(sep));
 	}
 
-}
+	test_asSecs_stringDddHhMmSsSss_convertsToSeconds {
+		var result = "001:01:01:01.001".asSecs;
+		var expected = 90061.001;
+		this.assertEquals(result, expected);
+	}
 
+	test_asSecs_stringSsSss_convertsToSeconds {
+		var result = "01.001".asSecs;
+		var expected = 1.001;
+		this.assertEquals(result, expected);
+	}
+
+	test_asSecs_stringMmSs_convertsToSeconds {
+		var result = "01:01".asSecs;
+		var expected = 61.0;
+		this.assertEquals(result, expected);
+	}
+
+	test_asSecs_stringSs_convertsToSeconds {
+		var result = "01".asSecs;
+		var expected = 1.0;
+		this.assertEquals(result, expected);
+	}
+
+}


### PR DESCRIPTION
This corrects the behavior of ```String -asSecs``` to expect the format ```hh:mm:ss.sss```. This is consistent with the documentation and the reverse method ```SimpleNumber -asTimeString```.
Fixes https://github.com/supercollider/supercollider/issues/3818.

Before merging this, I have one question:
The original implementation warns when number of seconds/minutes/hours exceeds respectively 60/60/24, and _clips these values to their maximum_. IMO the clipping should not happen and I removed that in this PR. 
So previously
```"62:1".asSecs; //warns and returns 60.1```
and now
```"62.1".asSecs; //warns and returns 62.1```

What do you think should be the right behavior?