### PR TITLE
comp: allocReadChannel no longer requires last argument in supernova

### DIFF
--- a/HelpSource/Classes/Buffer.schelp
+++ b/HelpSource/Classes/Buffer.schelp
@@ -483,7 +483,7 @@ The first frame of the soundfile to read. The default is 0, which is the beginni
 argument:: numFrames
 The number of frames to read. The default is -1, which will read the whole file.
 argument:: channels
-An Array of channels to be read from the soundfile. Indices start from zero. These will be read in the order provided.
+An Array of channels to be read from the soundfile. Indices start from zero. These will be read in the order provided. If absent or an empty array all channels will be read from soundfile in order.
 argument:: completionMessage
 A valid OSC message or a Function which will return one. A Function will be passed this Buffer as an argument when evaluated.
 discussion::

--- a/HelpSource/Reference/Server-Command-Reference.schelp
+++ b/HelpSource/Reference/Server-Command-Reference.schelp
@@ -589,7 +589,7 @@ table::
 ## strong::bytes:: || an OSC message to execute upon completion. (optional)
 ::
 
-As b_allocRead, but reads individual channels into the allocated buffer in the order specified.
+As b_allocRead, but reads individual channels into the allocated buffer in the order specified. If the channels argument is absent or empty all channels are read in the order they appear in the file.
 definitionlist::
 ## Asynchronous. || Replies to sender with strong::/done /b_allocReadChannel bufNum:: when complete.
 ::

--- a/SCClassLibrary/Common/Control/Buffer.sc
+++ b/SCClassLibrary/Common/Control/Buffer.sc
@@ -74,7 +74,8 @@ Buffer {
 		this.cache;
 		path = argpath;
 		this.startFrame = startFrame;
-		^["/b_allocReadChannel", bufnum, path, startFrame, (numFrames ? -1).asInt] ++ channels ++ [completionMessage.value(this)]
+		completionMessage !? { completionMessage = [completionMessage.value(this)] };
+		^["/b_allocReadChannel", bufnum, path, startFrame, (numFrames ? -1).asInt] ++ channels ++ completionMessage
 	}
 
 	// read whole file into memory for PlayBuf etc.

--- a/SCClassLibrary/Common/Control/Buffer.sc
+++ b/SCClassLibrary/Common/Control/Buffer.sc
@@ -51,7 +51,7 @@ Buffer {
 		server.listSendMsg(this.allocReadMsg( argpath, startFrame, numFrames, completionMessage))
 	}
 
-	allocReadChannel { arg argpath, startFrame, numFrames = 0, channels = -1, completionMessage;
+	allocReadChannel { arg argpath, startFrame = 0, numFrames = -1, channels, completionMessage;
 		path = argpath;
 		this.startFrame = startFrame;
 		server.listSendMsg(this.allocReadChannelMsg( argpath, startFrame, numFrames, channels,

--- a/server/scsynth/SC_SequencedCommand.cpp
+++ b/server/scsynth/SC_SequencedCommand.cpp
@@ -813,7 +813,7 @@ bool BufAllocReadChannelCmd::Stage2()
 	else if (mFileOffset > fileinfo.frames) mFileOffset = fileinfo.frames;
 	if (mNumFrames <= 0 || mNumFrames + mFileOffset > fileinfo.frames) mNumFrames = fileinfo.frames - mFileOffset;
 
-    if (mNumChannels > 0){
+    if (mNumChannels > 0) {
 		// verify channel indexes
 		if (!CheckChannels(fileinfo.channels)) {
 			const char* str = "Channel index out of range.\n";

--- a/server/scsynth/SC_SequencedCommand.cpp
+++ b/server/scsynth/SC_SequencedCommand.cpp
@@ -813,7 +813,15 @@ bool BufAllocReadChannelCmd::Stage2()
 	else if (mFileOffset > fileinfo.frames) mFileOffset = fileinfo.frames;
 	if (mNumFrames <= 0 || mNumFrames + mFileOffset > fileinfo.frames) mNumFrames = fileinfo.frames - mFileOffset;
 
-    if (mNumChannels > 0) {
+	if (mNumChannels == 0) {
+		// alloc data size
+		mFreeData = buf->data;
+		SCErr err = bufAlloc(buf, fileinfo.channels, mNumFrames, fileinfo.samplerate);
+		if (err) goto leave;
+		// read all channels
+		sf_seek(sf, mFileOffset, SEEK_SET);
+		sf_readf_float(sf, buf->data, mNumFrames);
+	} else {
 		// verify channel indexes
 		if (!CheckChannels(fileinfo.channels)) {
 			const char* str = "Channel index out of range.\n";

--- a/server/scsynth/SC_SequencedCommand.cpp
+++ b/server/scsynth/SC_SequencedCommand.cpp
@@ -813,15 +813,7 @@ bool BufAllocReadChannelCmd::Stage2()
 	else if (mFileOffset > fileinfo.frames) mFileOffset = fileinfo.frames;
 	if (mNumFrames <= 0 || mNumFrames + mFileOffset > fileinfo.frames) mNumFrames = fileinfo.frames - mFileOffset;
 
-	if (mNumChannels == 0) {
-		// alloc data size
-		mFreeData = buf->data;
-		SCErr err = bufAlloc(buf, fileinfo.channels, mNumFrames, fileinfo.samplerate);
-		if (err) goto leave;
-		// read all channels
-		sf_seek(sf, mFileOffset, SEEK_SET);
-		sf_readf_float(sf, buf->data, mNumFrames);
-	} else {
+    if (mNumChannels > 0){
 		// verify channel indexes
 		if (!CheckChannels(fileinfo.channels)) {
 			const char* str = "Channel index out of range.\n";

--- a/server/supernova/sc/sc_osc_handler.cpp
+++ b/server/supernova/sc/sc_osc_handler.cpp
@@ -2357,8 +2357,9 @@ void handle_b_allocReadChannel(ReceivedMessage const & msg, endpoint_ptr endpoin
     size_t channel_count = 0;
     sized_array<uint, rt_pool_allocator<uint> > channels(channel_args);
 
-    // sclang formats the last completion message as int, so we skip the last element
-    for (uint i = 0; i != channel_args - 1; ++i)  {
+    // Any remaining Int arguments are channels, followed by an optional
+    // completion message.
+    for (uint i = 0; i < channel_args; ++i)  {
         if (arg->IsInt32()) {
             channels[i] = arg->AsInt32Unchecked(); arg++;
             ++channel_count;

--- a/server/supernova/sc/sc_plugin_interface.cpp
+++ b/server/supernova/sc/sc_plugin_interface.cpp
@@ -966,10 +966,16 @@ void sc_plugin_interface::buffer_alloc_read_channels(uint32_t index, const char 
                                                      uint32_t frames, uint32_t channel_count,
                                                      const uint32_t * channel_data)
 {
+    // If no channel argument provided we read all channels.
+    if (channel_count == 0) {
+        buffer_read_alloc(index, filename, start, frames);
+        return;
+    }
+
     auto f = makeSndfileHandle(filename);
     if (f.rawHandle() == nullptr)
         throw std::runtime_error(f.strError());
-
+    
     uint32_t sf_channels = uint32_t(f.channels());
     const uint32_t * max_chan = std::max_element(channel_data, channel_data + channel_count);
     if (*max_chan >= sf_channels)

--- a/server/supernova/sc/sc_plugin_interface.cpp
+++ b/server/supernova/sc/sc_plugin_interface.cpp
@@ -975,7 +975,7 @@ void sc_plugin_interface::buffer_alloc_read_channels(uint32_t index, const char 
     auto f = makeSndfileHandle(filename);
     if (f.rawHandle() == nullptr)
         throw std::runtime_error(f.strError());
-    
+
     uint32_t sf_channels = uint32_t(f.channels());
     const uint32_t * max_chan = std::max_element(channel_data, channel_data + channel_count);
     if (*max_chan >= sf_channels)

--- a/testsuite/classlibrary/TestBuffer.sc
+++ b/testsuite/classlibrary/TestBuffer.sc
@@ -213,4 +213,36 @@ TestBuffer : UnitTest {
 		buffer.free;
 	}
 
+	test_allocReadChannelMsg_missingChannelsAndCompletionMessage {
+		var buffer, msg;
+		buffer = Buffer.new;
+		msg = buffer.allocReadChannelMsg("test_path", 0, -1);
+		this.assertEquals(msg, ["/b_allocReadChannel", buffer.bufnum, "test_path", 0, -1]);
+		buffer.free;
+	}
+
+	test_allocReadChannelMsg_emptyChannelsWithCompletionMessage {
+		var buffer, msg;
+		buffer = Buffer.new;
+		msg = buffer.allocReadChannelMsg("test_path", 0, 25, [], ["test_message", 1, 2, 3]);
+		this.assertEquals(msg, ["/b_allocReadChannel", buffer.bufnum, "test_path", 0, 25, ["test_message", 1, 2, 3]]);
+		buffer.free;
+	}
+
+	test_allocReadChannelMsg_validChannelsNoCompletionMessage {
+		var buffer, msg;
+		buffer = Buffer.new;
+		msg = buffer.allocReadChannelMsg("test_path", 0, -1, [7, 0, 1]);
+		this.assertEquals(msg, ["/b_allocReadChannel", buffer.bufnum, "test_path", 0, -1, 7, 0, 1]);
+		buffer.free;
+	}
+
+	test_allocReadChannelMsg_allArgumentsProvided {
+		var buffer, msg;
+		buffer = Buffer.new;
+		msg = buffer.allocReadChannelMsg("test_path", 0, -1, [1, 0], ["complete", "xx"]);
+		this.assertEquals(msg, ["/b_allocReadChannel", buffer.bufnum, "test_path", 0, -1, 1, 0, ["complete", "xx"]]);
+		buffer.free;
+	}
+
 }


### PR DESCRIPTION
Regarding #3631, implements @jamshark70 suggestion to correctly append
completion argument in array. Also fixes supernova so it doesn't
hardlock when channel and completion arguments absent.