### PR TITLE
UnitTest: add runTests method

### DIFF
--- a/HelpSource/Classes/UnitTest.schelp
+++ b/HelpSource/Classes/UnitTest.schelp
@@ -83,6 +83,46 @@ UnitTest.reset;
 UnitTest.runAll;
 ::
 
+METHOD:: runTests
+run a list of testItems and optionally post how long they take.
+
+code::
+// same as TestServer_clientID.run;
+UnitTest.runTests(TestServer_clientID, false)
+
+// an example list of classes and methods "<TestClass:testMethod>"
+(
+UnitTest.runTests([
+	TestServer_clientID,
+	"TestServer_boot:test_bootSync"
+]);
+)
+
+// make a subgroup of server tests:
+(
+~serverTestClasses = UnitTest.allSubclasses.select { |cl|
+	var namestr = cl.name.asString;
+	namestr.contains("Server") and: { namestr.contains("GUI").not };
+};
+)
+// test that they all work with scsynth ...
+Server.scsynth;
+UnitTest.runTests(~serverTestClasses);
+
+// and supernova as well
+Server.supernova;
+UnitTest.runTests(~serverTestClasses);
+::
+
+ARGUMENT:: testItems
+a list of testItems given as classes and method names
+in the format of code::"<TestClass:testMethod>" ::
+
+ARGUMENT:: postTimes
+flag whether to post individual and total test times or not.
+
+
+
 
 INSTANCEMETHODS::
 

--- a/HelpSource/Classes/UnitTest.schelp
+++ b/HelpSource/Classes/UnitTest.schelp
@@ -50,7 +50,7 @@ ARGUMENT:: value
 Should be code::UnitTest.full:: or code::UnitTest.brief::.
 
 METHOD:: run
-Run all methods whose names begin with code::test_::.
+Run all methods (of a UnitTest subclass) whose names begin with code::test_::.
 
 code::
 TestUnitTest.new.run;
@@ -62,19 +62,6 @@ If code::true::, first runs link::#*reset:: on the class.
 ARGUMENT:: report
 If code::true::, outputs the test results.
 
-METHOD:: runTest
-Run a single test method.
-
-code::
-UnitTest.reset;
-UnitTest.runTest("TestUnitTest:test_assert");
-::
-
-ARGUMENT:: methodName
-A link::Classes/String:: referring to the class and test method
-within it, e.g. code::"TestPolyPlayerPool:test_prepareChildrenToBundle"::.
-
-
 METHOD:: runAll
 runs all subclasses of UnitTest
 
@@ -82,6 +69,21 @@ code::
 UnitTest.reset;
 UnitTest.runAll;
 ::
+
+METHOD:: runTest
+Run a single test method or class
+
+code::
+UnitTest.reset;
+UnitTest.runTest("TestUnitTest:test_assert");
+UnitTest.runTest(TestUnitTest);
+::
+
+ARGUMENT:: testItem
+can be a link::Classes/String:: referring to a class and a test method
+within it, e.g. code::"TestUnitTest:test_assert"::, then this single method runs;
+
+when a subclass of UnitTest, all tests in that class run.
 
 METHOD:: runTests
 run a list of testItems and optionally post how long they take.

--- a/SCClassLibrary/Common/UnitTesting/UnitTest.sc
+++ b/SCClassLibrary/Common/UnitTesting/UnitTest.sc
@@ -119,14 +119,13 @@ UnitTest {
 		^method
 	}
 
-	// could be moved to e.g. Method.isTest
+	// specific for UnitTest:
 	*isTestMethod { |method|
-		^method.ownerClass.superclasses.includes(UnitTest) and: {
+		^method.ownerClass.isKindOf(Meta_UnitTest) and: {
 			method.name.asString.beginsWith("test_")
 		}
 	}
 
-	// specific for UnitTest:
 	*findTestMethodFor { |methodString|
 		var method = this.findMethodFor(methodString);
 		if (method.notNil and: { this.isTestMethod(method) }) {

--- a/SCClassLibrary/Common/UnitTesting/UnitTest.sc
+++ b/SCClassLibrary/Common/UnitTesting/UnitTest.sc
@@ -83,7 +83,7 @@ UnitTest {
 			testItems.do ({ |testItem|
 				if (testItem.isKindOf(Class)) {
 					// assume this is a UnitTest:
-					if (testItem.superclasses.includes(UnitTest)) {
+					if (testItem.isKindOf(Meta_UnitTest)) {
 						testItem.run(false,false);
 					} {
 						"%: testItem % is not a unit test subclass."

--- a/SCClassLibrary/Common/UnitTesting/UnitTest.sc
+++ b/SCClassLibrary/Common/UnitTesting/UnitTest.sc
@@ -71,6 +71,50 @@ UnitTest {
 		}
 	}
 
+	// run a list of testItems which can be UnitTest classes or method names
+	// in the format "TestPolyPlayerPool:test_prepareChildrenToBundle"
+
+	*runTests { |testItems, postTimes = false|
+		^this.forkIfNeeded {
+			var startTime = Main.elapsedTime;
+			this.reset;
+			testItems = testItems ?? { this.allSubclasses };
+			testItems.do ({ |testItem|
+				var myStartTime = Main.elapsedTime;
+				var myTestTime;
+				if (testItem.isKindOf(Class)) {
+					// assume this is a UnitTest:
+					if (testItem.superclasses.includes(UnitTest)) {
+						testItem.run(false,false);
+					} {
+						"%: testItem % is not a unit test subclass."
+						.format(testItem.cs).warn;
+					}
+				} {
+					if (testItem.isKindOf(String)) {
+						try { UnitTest.runTest(testItem) } {
+							"%: testItem % is not a unit test method string."
+							.format(testItem.cs).warn;
+						}
+					}
+				};
+				myTestTime = Main.elapsedTime - myStartTime;
+				if (postTimes) {
+					"*** % took % seconds to run.\n".postf(testItem, myTestTime);
+				};
+				0.1.wait;
+			});
+			if (postTimes) {
+				"*** % for items: % took % seconds to run.\n".postf(
+					thisMethod,
+					testItems,
+					Main.elapsedTime - startTime
+				);
+			};
+			this.report;
+		}
+	}
+
 	*gui {
 
 		// UnitTest GUI written by Dan Stowell 2009.


### PR DESCRIPTION
runTests is a convenience method for running groups of UnitTests.
It allows testing the most-likely affected areas first when working on core SC classes.
It can optionally measure runtimes of individual tests, 
so one can see see which tests would benefit from speed tweaks.

E.g. it makes running all server tests for scsynth and supernova very easy:
```
// make a subgroup of server tests:
~serverTestClasses = UnitTest.allSubclasses.select { |cl| 
	var namestr = cl.name.asString; 
	namestr.contains("Server") and: { namestr.contains("GUI").not };
};
// test that they all work with scsynth ...
Server.scsynth;
UnitTest.runTests(~serverTestClasses);

// and supernova as well
Server.supernova;
UnitTest.runTests(~serverTestClasses);
```