### PR TITLE
treeview: fix setItemWidget

### DIFF
--- a/QtCollider/widgets/QcTreeWidget.cpp
+++ b/QtCollider/widgets/QcTreeWidget.cpp
@@ -193,14 +193,14 @@ QWidget * QcTreeWidget::itemWidget( const QcTreeWidget::ItemPtr &item, int colum
   return item ? QTreeWidget::itemWidget( item, column ) : 0;
 }
 
-void QcTreeWidget::setItemWidget( const QcTreeWidget::ItemPtr &item, int column, QObjectProxy *o )
+void QcTreeWidget::setItemWidget( const QcTreeWidget::ItemPtr &item, int column, QWidget *o )
 {
   if( !item ) return;
 
-  QWidget *w = qobject_cast<QWidget*>(o->object());
-  if( !w ) return;
+  if( !o )
+    return;
 
-  QTreeWidget::setItemWidget( item, column, w );
+  QTreeWidget::setItemWidget( item, column, o );
 }
 
 void QcTreeWidget::removeItemWidget( const QcTreeWidget::ItemPtr &item, int column )

--- a/QtCollider/widgets/QcTreeWidget.h
+++ b/QtCollider/widgets/QcTreeWidget.h
@@ -82,7 +82,7 @@ public:
   Q_INVOKABLE void setTextColor( const QcTreeWidget::ItemPtr &, int column, const QColor & );
 
   Q_INVOKABLE QWidget * itemWidget( const QcTreeWidget::ItemPtr &, int column );
-  Q_INVOKABLE void setItemWidget( const QcTreeWidget::ItemPtr &, int column, QObjectProxy * );
+  Q_INVOKABLE void setItemWidget( const QcTreeWidget::ItemPtr &, int column, QWidget * );
   Q_INVOKABLE void removeItemWidget( const QcTreeWidget::ItemPtr &, int column );
 
   Q_INVOKABLE void sort( int column, bool descending );


### PR DESCRIPTION
In #2504, changes were introduced to the metatype system that made the type of this method inconsistent with what Qt GUI expected. this fixes a method-not-found error

Fixes #3828