### PR TITLE
supernova: include header to get SC_PLUGIN_EXT

### DIFF
--- a/server/supernova/sc/sc_ugen_factory.cpp
+++ b/server/supernova/sc/sc_ugen_factory.cpp
@@ -32,6 +32,7 @@
 #include "SC_World.h"
 #include "SC_Wire.h"
 #include "ErrorMessage.hpp"
+#include "SC_Filesystem.hpp" // SC_PLUGIN_EXT
 
 namespace nova {
 


### PR DESCRIPTION
A previous PR broke supernova compilation on macOS; this allows Supernova to build when SC_PLUGIN_EXT has not been defined in compiler options.