### PR TITLE
Letting TestNode_Server:test_getn time out and fail

### DIFF
--- a/testsuite/classlibrary/TestNode_Server.sc
+++ b/testsuite/classlibrary/TestNode_Server.sc
@@ -32,8 +32,9 @@ TestNode_Server : UnitTest {
 		node.free;
 	}
 
+	// this one currently fails with supernova (3.9.3)
 	test_getn {
-		var setnValues, getnValues, node;
+		var setnValues, getnValues, node, timeout = 1;
 		var condition = Condition.new;
 
 		SynthDef(\test_getn, { |control1 = 2, control2 = 22.2, control3 = 222| }).add;
@@ -49,9 +50,10 @@ TestNode_Server : UnitTest {
 		getnValues = 0;
 		node.getn(0, 3, { |values|
 			getnValues = values;
-			condition.unhang;
+			condition.test = true;
 		});
-		condition.hang;
+
+		this.wait({ condition.test }, "getn response timed out after % seconds.".format(timeout), timeout);
 
 		this.assertArrayFloatEquals(getnValues, setnValues, "Node:getn works", 0.001);
 		node.free;


### PR DESCRIPTION
Node:getn is broken in supernova, which makes this test hangs forever.
Adding a timeout makes the test fail correctly. 
(Working towards making all server tests work with supernova...) 