### PR TITLE
whitespace fixes when posting and converting to compile string

### DIFF
--- a/SCClassLibrary/Common/Collections/Array.sc
+++ b/SCClassLibrary/Common/Collections/Array.sc
@@ -287,15 +287,15 @@ Array[slot] : ArrayedCollection {
 
 	printOn { arg stream;
 		if (stream.atLimit, { ^this });
-		stream << "[ " ;
+		stream << "[" ;
 		this.printItemsOn(stream);
-		stream << " ]" ;
+		stream << "]" ;
 	}
 	storeOn { arg stream;
 		if (stream.atLimit, { ^this });
-		stream << "[ " ;
+		stream << "[" ;
 		this.storeItemsOn(stream);
-		stream << " ]" ;
+		stream << "]" ;
 	}
 	prUnarchive { arg slotArray;
 		slotArray.pairsDo {|index, slots| this[index].setSlots(slots) };

--- a/SCClassLibrary/Common/Collections/Collection.sc
+++ b/SCClassLibrary/Common/Collections/Collection.sc
@@ -679,15 +679,15 @@ Collection {
 
 	printOn { | stream |
 		if (stream.atLimit) { ^this };
-		stream << this.class.name << "[ " ;
+		stream << this.class.name << "[" ;
 		this.printItemsOn(stream);
-		stream << " ]" ;
+		stream << "]" ;
 	}
 	storeOn { | stream |
 		if (stream.atLimit) { ^this };
-		stream << this.class.name << "[ " ;
+		stream << this.class.name << "[" ;
 		this.storeItemsOn(stream);
-		stream << " ]" ;
+		stream << "]" ;
 	}
 	storeItemsOn { | stream |
 		var addComma = false;

--- a/SCClassLibrary/Common/Collections/Event.sc
+++ b/SCClassLibrary/Common/Collections/Event.sc
@@ -117,28 +117,30 @@ Event : Environment {
 		var max, itemsPerLinem1, i=0;
 		itemsPerLinem1 = itemsPerLine - 1;
 		max = this.size;
-		stream << "( ";
+		stream << "(";
 		this.keysValuesDo({ arg key, val;
-			stream <<< key << ": " << val;
+			if(key.isIdentifier) { stream << key } { stream <<< key };
+			stream << ": " << val;
 			if ((i=i+1) < max, { stream.comma.space;
 				if (i % itemsPerLine == itemsPerLinem1, { stream.nl.space.space });
 			});
 		});
-		stream << " )";
+		stream << ")";
 	}
 
 	storeOn { arg stream, itemsPerLine = 5;
 		var max, itemsPerLinem1, i=0;
 		itemsPerLinem1 = itemsPerLine - 1;
 		max = this.size;
-		stream << "( ";
+		stream << "(";
 		this.keysValuesDo({ arg key, val;
-			stream <<< key << ": " <<< val;
+			if(key.isIdentifier) { stream << key } { stream <<< key };
+			stream << ": " << val;
 			if ((i=i+1) < max, { stream.comma.space;
 				if (i % itemsPerLine == itemsPerLinem1, { stream.nl.space.space });
 			});
 		});
-		stream << " )";
+		stream << ")";
 		if(proto.notNil) { stream << "\n.proto_(" <<< proto << ")" };
 		if(parent.notNil) { stream << "\n.parent_(" <<< parent << ")" };
 	}

--- a/SCClassLibrary/Common/Core/Object.sc
+++ b/SCClassLibrary/Common/Core/Object.sc
@@ -290,6 +290,7 @@ Object  {
 	isCollection { ^false }
 	isArray { ^false }
 	isString { ^false }
+	isIdentifier { ^false }
 	containsSeqColl { ^false }
 	isValidUGenInput { ^false }
 	isException { ^false }


### PR DESCRIPTION
Following the agreement on #2931, this PR adjusts the `printOn` and `storeOn` methods of collections.

For example, it will post like the following:

```supercollider
[1, 2, 3]
List[1, 2, 3]
(a: 8, b:9)
// but still as usual:
([1, 2, 3]: 8, b:9)
('a b c': 8, b:9)
```

For this, it completes the interface `isIdentifier`, which now extends to any object.