### PR TITLE
Fix supernova reboot bug, add reboot tests

### DIFF
--- a/HelpSource/Classes/Server.schelp
+++ b/HelpSource/Classes/Server.schelp
@@ -140,7 +140,7 @@ Switches the server program to scsynth. This is the default server.
 
 InstanceMethods::
 
-private:: doSend, prHandleClientLoginInfoFromServer, prHandleNotifyFailString, prPingApp, prOnServerProcessExit
+private:: doSend, prHandleClientLoginInfoFromServer, prHandleNotifyFailString, prPingApp, prOnServerProcessExit, prWaitForPidRelease
 
 method:: sendMsg
 send an OSC-message to the server.

--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -527,15 +527,16 @@ Server {
 				.postf(this, newMaxLogins);
 			};
 		};
-
-		if (newClientID == clientID) {
-			"%: keeping clientID (%) as confirmed by server process.\n"
-			.postf(this, newClientID);
-		} {
-			"%: setting clientID to %, as obtained from server process.\n"
-			.postf(this, newClientID);
+		if (newClientID.notNil) {
+			if (newClientID == clientID) {
+				"%: keeping clientID (%) as confirmed by server process.\n"
+				.postf(this, newClientID);
+			} {
+				"%: setting clientID to %, as obtained from server process.\n"
+				.postf(this, newClientID);
+			};
+			this.clientID = newClientID;
 		};
-		this.clientID = newClientID;
 	}
 
 	prHandleNotifyFailString {|failString, msg|

--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -885,7 +885,7 @@ Server {
 				this.quit;
 				this.boot;
 			}, {
-				this.waitForPidRelease {
+				this.prWaitForPidRelease {
 					this.bootServerApp({
 						if(startAliveThread) { statusWatcher.startAliveThread }
 					})
@@ -894,13 +894,13 @@ Server {
 		}
 	}
 
-	waitForPidRelease { |onComplete, onFailure, timeout = 1|
+	prWaitForPidRelease { |onComplete, onFailure, timeout = 1|
 		var bootStart;
 		if (this.inProcess or: { this.isLocal.not }) {
 			onComplete.value;
 			^this
 		};
-		// FIXME: quick and dirty fix for supernova reboot hang on osx:
+		// FIXME: quick and dirty fix for supernova reboot hang on macOS:
 		// if we have just quit before running server.boot,
 		// we wait until server process really ends and sets its pid to nil
 		forkIfNeeded {
@@ -931,6 +931,7 @@ Server {
 	}
 
 	prOnServerProcessExit { |exitCode|
+		pid = nil;
 		"Server '%' exited with exit code %."
 			.format(this.name, exitCode)
 			.postln;
@@ -946,7 +947,6 @@ Server {
 		} {
 			this.disconnectSharedMemory;
 			pid = unixCmd(program ++ options.asOptionsString(addr.port), { |exitCode|
-				pid = nil;
 				this.prOnServerProcessExit(exitCode);
 			});
 			("Booting server '%' on address %:%.").format(this.name, addr.hostname, addr.port.asString).postln;

--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -923,6 +923,7 @@ Server {
 		} {
 			this.disconnectSharedMemory;
 			pid = unixCmd(program ++ options.asOptionsString(addr.port), { |exitCode|
+				pid = nil;
 				this.prOnServerProcessExit(exitCode);
 			});
 			("Booting server '%' on address %:%.").format(this.name, addr.hostname, addr.port.asString).postln;
@@ -1002,7 +1003,8 @@ Server {
 			"'/quit' message sent to server '%'.".format(name).postln;
 		};
 
-		pid = nil;
+		// let server process reset pid to nil!
+		// pid = nil;
 		sendQuit = nil;
 		maxNumClients = nil;
 

--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -280,7 +280,7 @@ Server {
 	var <window, <>scopeWindow, <emacsbuf;
 	var <volume, <recorder, <statusWatcher;
 	var <pid, serverInterface;
-	var <pidReleaseCondition;
+	var pidReleaseCondition;
 
 	*initClass {
 		Class.initClassTree(ServerOptions);

--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -894,10 +894,10 @@ Server {
 		}
 	}
 
-	waitForPidRelease { |onDone, onFailure, timeout = 1|
+	waitForPidRelease { |onComplete, onFailure, timeout = 1|
 		var bootStart;
 		if (this.inProcess or: { this.isLocal.not }) {
-			onDone.value;
+			onComplete.value;
 			^this
 		};
 		// FIXME: quick and dirty fix for supernova reboot hang on osx:
@@ -912,7 +912,7 @@ Server {
 			} {
 				0.05.wait
 			};
-			if (pid.isNil) { onDone.value } { onFailure.value };
+			if (pid.isNil, onComplete, onFailure);
 		}
 	}
 

--- a/SCClassLibrary/Common/Control/ServerStatus.sc
+++ b/SCClassLibrary/Common/Control/ServerStatus.sc
@@ -244,20 +244,26 @@ ServerStatusWatcher {
 	prHandleLoginWhenAlreadyRegistered { |clientIDFromProcess|
 		"% - handling login request though already registered - \n".postf(server);
 
-		// by default, only reset clientID if changed, to leave allocators untouched:
-		if (clientIDFromProcess != server.clientID) {
-			// make sure we can set the clientID, and set it
-			notified = false;
-			server.clientID_(clientIDFromProcess);
-			"*** This seems to be a login after a crash, or from a new server object,\n"
-			"*** so you may want to release currently running synths by hand:".postln;
-			"%.defaultGroup.release;\n".postf(server.cs);
-			"*** and you may want to redo server boot finalization by hand:".postln;
-			"%.statusWatcher.prFinalizeBoot;\n\n".postf(server.cs);
+		if (clientIDFromProcess.isNil) {
+			"% - notify response did not contain already-registered clientID from server process.\n"
+			"Assuming all is well.\n".postf(server);
 		} {
-			// same clientID, so leave all server resources in the state they were in!
-			"This seems to be a login after a loss of network contact - \n"
-			"- reconnected with the same clientID as before, so probably all is well.\n".postln;
+
+			// by default, only reset clientID if changed, to leave allocators untouched:
+			if (clientIDFromProcess != server.clientID) {
+				// make sure we can set the clientID, and set it
+				notified = false;
+				server.clientID_(clientIDFromProcess);
+				"*** This seems to be a login after a crash, or from a new server object,\n"
+				"*** so you may want to release currently running synths by hand:".postln;
+				"%.defaultGroup.release;\n".postf(server.cs);
+				"*** and you may want to redo server boot finalization by hand:".postln;
+				"%.statusWatcher.prFinalizeBoot;\n\n".postf(server.cs);
+			} {
+				// same clientID, so leave all server resources in the state they were in!
+				"This seems to be a login after a loss of network contact - \n"
+				"- reconnected with the same clientID as before, so probably all is well.\n".postln;
+			};
 		};
 
 		// ensure that statuswatcher is in the correct state immediately.

--- a/testsuite/classlibrary/TestNodeProxy.sc
+++ b/testsuite/classlibrary/TestNodeProxy.sc
@@ -8,6 +8,9 @@ TestNodeProxy : UnitTest {
 		s = Server.default;
 		s.quit;
 
+		// fail safe for large inits - must be Integer for supernova
+		s.options.numWireBufs = (64 * (2**7)).asInteger;
+
 		Ndef.clear;
 		x = nil;
 		Ndef(\x, { x = "rebuilt"; SinOsc.ar([661.1, 877.1, 551.1]) });
@@ -82,9 +85,6 @@ TestNodeProxy : UnitTest {
 		this.assert(Ndef(\x).loaded != true,
 			"after server quit: send should not assume server resources loaded");
 		*/
-
-		// fail safe for large inits
-		s.options.numWireBufs = 64 * (2**7);
 
 		// CLEAR
 		Ndef.clear;

--- a/testsuite/classlibrary/TestServer_boot.sc
+++ b/testsuite/classlibrary/TestServer_boot.sc
@@ -12,10 +12,11 @@ TestServer_boot : UnitTest {
 
 	cycleNotify { |server|
 		// XXX: no efficient way to wait
+		// FIXME: supernova hangs here unless we resend notify in the while loop
 		server.notify_(false);
-		while { server.notified } { 0.1.wait };
+		while { server.notified } { server.notify_(false); 0.1.wait };
 		server.notify_(true);
-		while { server.notified.not } { 0.1.wait };
+		while { server.notified.not } { server.notify_(false); 0.1.wait };
 	}
 
 	test_waitForBoot {

--- a/testsuite/classlibrary/TestServer_boot.sc
+++ b/testsuite/classlibrary/TestServer_boot.sc
@@ -14,9 +14,15 @@ TestServer_boot : UnitTest {
 		// XXX: no efficient way to wait
 		// FIXME: supernova hangs here unless we resend notify in the while loop
 		server.notify_(false);
-		while { server.notified } { server.notify_(false); 0.1.wait };
+		while { server.notified } {
+			server.statusWatcher.sendNotifyRequest(false);
+			0.1.wait
+		};
 		server.notify_(true);
-		while { server.notified.not } { server.notify_(false); 0.1.wait };
+		while { server.notified.not } {
+			server.statusWatcher.sendNotifyRequest(true);
+			0.1.wait
+		};
 	}
 
 	test_waitForBoot {

--- a/testsuite/classlibrary/TestServer_boot.sc
+++ b/testsuite/classlibrary/TestServer_boot.sc
@@ -62,40 +62,30 @@ TestServer_boot : UnitTest {
 	}
 
 	test_rebootOffServer {
-		var cond = Condition();
-		var timeout = 5;
-
-		s.doWhenBooted({ cond.unhang });
 		s.reboot;
-
-		fork { timeout.wait; cond.unhang };
-		cond.hang;
+		this.wait({ s.serverRunning }, "server reboot failed.", 5);
 
 		this.assert(s.serverRunning,
 			"A turned-off server should be running after reboot."
 		);
 		s.quit;
-
 	}
 
 	test_rebootRunningServer {
-		var cond = Condition();
-		var timeout = 5;
+		var rebooted = false;
 
+		s.quit;
 		s.doWhenBooted {
 			// first boot OK, starting reboot from here
 			s.reboot {
-				s.doWhenBooted({
-					// only unhang after second reboot worked
-					cond.unhang
-
-				})
+				s.doWhenBooted {
+					rebooted = true
+				}
 			};
 		};
 		s.boot;
 
-		fork { timeout.wait; cond.unhang };
-		cond.hang;
+		this.wait({ rebooted }, "server reboot failed.", 5);
 
 		this.assert(s.serverRunning,
 			"A running server should be running again after reboot."


### PR DESCRIPTION
currently supernova servers tends to hang on reboot (macOS 10.13.4):
```
Server.supernova; 
s.reboot; // first time usually works
s.reboot; // second time usually hangs, because notify does not happen.
```
this is a timing issue: supernova sends back the quit message early, but the supernova process still lives long enough to interfere with the boot messaging traffic with the rebooted instance. 
Thus, this PR adds waiting for release of the (previous) process PID when booting, which fixes the hang condition.
This PR includes
* waiting for quitting process to release server.pid
* safer testing for notify clientID info from server (supernova messages are not identical yet)
* new unit tests for reboot method 
* fix to cycleNotify which tends to hang up TestServer_boot methods

Result: All tests invoving booted servers now run with supernova!
They all pass, except test_getn still fails because of a bug in supernova handle_s_getn #3841 

I believe supernova will be part of the 3.10 release, yes? 
If so, I would be happy if this bug fix went into 3.10, so supernova supported as fully as possible.

