### PR TITLE
Function: add method 'whenTrueWithin' for branching with timeout.

### DIFF
--- a/HelpSource/Classes/Function.schelp
+++ b/HelpSource/Classes/Function.schelp
@@ -253,11 +253,12 @@ code::
 (
 a = nil;
 { a == 2 }.whenTrueWithin(2, { "did it on time!".postln }, { "too late ...".postln });
-fork { 1.99.wait; a = 2 };
+fork { 1.999.wait; a = 2 };
 )
-// can be used for branching when preparation may fail:
+
+// can be used for branching when some preparation may fail:
 (
-{ s.serverRunning }.whenTrueWithin(3,
+{ s.serverRunning }.whenTrueWithin(4,
 	{ "YES! doWhenBooted...".postln; ().play },
 	{ "NO! boot timed out - quitting again.".postln; s.quit }
 );

--- a/HelpSource/Classes/Function.schelp
+++ b/HelpSource/Classes/Function.schelp
@@ -245,6 +245,26 @@ f.forkIfNeeded;
 { "we are now in a routine".postln; 1.wait; f.forkIfNeeded }.fork;
 ::
 
+method::whenTrueWithin
+
+When func.value becomes true within timeout, then do thenFunc, else to elseFunc.
+
+code::
+(
+a = nil;
+{ a == 2 }.whenTrueWithin(2, { "did it on time!".postln }, { "too late ...".postln });
+fork { 1.99.wait; a = 2 };
+)
+// can be used for branching when preparation may fail:
+(
+{ s.serverRunning }.whenTrueWithin(3,
+	{ "YES! doWhenBooted...".postln; ().play },
+	{ "NO! boot timed out - quitting again.".postln; s.quit }
+);
+fork { s.quit; 1.wait; s.boot };
+)
+::
+
 method::block
 
 Break from a loop. Calls the receiver with an argument which is a function that returns from the method block. To exit the loop, call .value on the function passed in. You can pass a value to this function and that value will be returned from the block method.

--- a/HelpSource/Classes/Function.schelp
+++ b/HelpSource/Classes/Function.schelp
@@ -255,14 +255,23 @@ a = nil;
 { a == 2 }.whenTrueWithin(2, { "did it on time!".postln }, { "too late ...".postln });
 fork { 1.999.wait; a = 2 };
 )
-
-// can be used for branching when some preparation may fail:
+::
+This is useful when the state of interest is to be observed from a distance only,
+and the processes that change the state should remain as decoupled as possible.
+(When coupling is not a problem, using Condition is the cleaner solution.)
+code::
 (
-{ s.serverRunning }.whenTrueWithin(4,
-	{ "YES! doWhenBooted...".postln; ().play },
-	{ "NO! boot timed out - quitting again.".postln; s.quit }
+// multiple processes change a state over time:
+a = List[];
+fork { 32.do { 0.5.rand.wait; a.add(32.rand) }; "done 1".postln  };
+fork { 32.do { 1.0.rand.wait; a.add(32.rand) }; "done 2".postln  };
+
+// to keep them decoupled, we poll the state of interest,
+// rather than attaching a condition.signal construction to each of them
+{ a.size > 32 }.whenTrueWithin(4,
+	{ "YES! list size sufficient.".postln;},
+	{ "NO ...".postln; }
 );
-fork { s.quit; 1.wait; s.boot };
 )
 ::
 

--- a/SCClassLibrary/Common/Core/Function.sc
+++ b/SCClassLibrary/Common/Core/Function.sc
@@ -159,6 +159,18 @@ Function : AbstractFunction {
 		^thisThread;
 	}
 
+	whenTrueWithin { |timeout = 3, thenFunc, elseFunc, dt = (1/16)|
+		var remaining = timeout;
+		^Routine {
+			while {
+				remaining = remaining - dt;
+				this.value.not and: { remaining >= 0 }
+			} {
+				dt.wait;
+			};
+			if (this.value, thenFunc, elseFunc)
+		}.play(AppClock)
+	}
 
 	awake { arg beats, seconds, clock;
 		var time = seconds; // prevent optimization


### PR DESCRIPTION
[ Edited header after discussion: ]
When waiting for a specific state to come true within a certain time, a useful pattern is to poll the state of interest within a timeout limit, and to branch between success or failure cases.
Function:whenTrueWithin aims to solve that generally and conveniently. 
```
(
a = nil;
{ a == 2 }.whenTrueWithin(2, { "did it on time!".postln }, { "sorry, too late ...".postln });
fork { 1.99.wait; a = 2 };
)
```
[ORIGINAL top comment which led to discussion was:]
When expecting an async process to finish which may fail (e.g. booting a server), the pattern is to wait for it to finish within a timeout limit, and to branch between success or failure cases.
Function:whenTrueWithin aims to solve that generally and conveniently. 
It could be used to rewrite e.g. waitForBoot / doWhenBooted much more clearly than now,
and likely other cases in the class lib that timeout when things dont work as expected.

```
(
a = nil;
{ a == 2 }.whenTrueWithin(2, { "did it on time!".postln }, { "sorry, too late ...".postln });
fork { 1.99.wait; a = 2 };
)

// waitForBoot could work like this: 
(
{ s.serverRunning }.whenTrueWithin(3,
	{ "YES! - waitForBoot...".postln; ().play },
	{ "NO! boot timed out - quitting again.".postln; s.quit }
);
fork { s.quit; 1.wait; s.boot };
)
```
