### PR TITLE
Classlib: Pstretch(p): Correct bug resulting from variable name confusion

### DIFF
--- a/SCClassLibrary/Common/Streams/FilterPatterns.sc
+++ b/SCClassLibrary/Common/Streams/FilterPatterns.sc
@@ -271,26 +271,26 @@ Pstretch : FilterPattern {
 		^super.new(pattern).value_(value)
 	}
 	storeArgs { ^[value,pattern] }
-	embedInStream {  arg event;
+	embedInStream {  arg inevent;
 		var cleanup = EventStreamCleanup.new;
-		var inevent;
+		var event;
 		var val, delta;
 		var valStream = value.asStream;
 		var evtStream = pattern.asStream;
 
 		loop {
-			inevent = evtStream.next(event).asEvent;
-			if (inevent.isNil) { ^cleanup.exit(event) };
-			val = valStream.next(inevent);
-			if (val.isNil) { ^cleanup.exit(event) };
+			event = evtStream.next(inevent).asEvent;
+			if (event.isNil) { ^cleanup.exit(inevent) };
+			val = valStream.next(event);
+			if (val.isNil) { ^cleanup.exit(inevent) };
 
 			delta = event[\delta];
 			if (delta.notNil) {
-				inevent[\delta] = delta * val;
+				event[\delta] = delta * val;
 			};
-			inevent[\dur] = inevent[\dur] * val;
-			cleanup.update(inevent);
-			event = yield(inevent);
+			event[\dur] = event[\dur] * val;
+			cleanup.update(event);
+			inevent = yield(event);
 		}
 	}
 }
@@ -299,27 +299,27 @@ Pstretch : FilterPattern {
 
 Pstretchp : Pstretch {
 
-	embedInStream { arg event;
-		var evtStream, val, inevent, delta;
+	embedInStream { arg inevent;
+		var evtStream, val, event, delta;
 		var valStream = value.asStream;
 		while {
-			val = valStream.next(event);
+			val = valStream.next(inevent);
 			val.notNil
 		} {
 			evtStream = pattern.asStream;
 			while {
-				inevent = evtStream.next(event);
-				inevent.notNil
+				event = evtStream.next(inevent);
+				event.notNil
 			} {
-				delta = inevent[\delta];
+				delta = event[\delta];
 				if (delta.notNil) {
-					inevent[\delta] = delta * val;
+					event[\delta] = delta * val;
 				};
-				inevent[\dur] = inevent[\dur] * val;
-				event = inevent.yield;
+				event[\dur] = event[\dur] * val;
+				inevent = event.yield;
 			};
 		};
-		^event;
+		^inevent;
 	}
 }
 

--- a/testsuite/classlibrary/TestPattern.sc
+++ b/testsuite/classlibrary/TestPattern.sc
@@ -99,6 +99,34 @@ TestPattern : UnitTest {
 
 	}
 
+	// test bug #3851: Pstretch applied to Ppar should operate on deltas, not only dur
+	// bug: Ppar sets event deltas.
+	// Pstretch used to miss this and change only the output event's dur, not delta.
+	// After Pstretch, dur and delta should be the same.
+	test_PstretchDeltas {
+		var pattern = Pbind(\dur, Pn(1, 1)),
+		ppar = Ppar([pattern], 1),
+		pstretch = Pstretch(0.5, ppar),
+		event = pstretch.asStream.next(());
+
+		this.assert(
+			event.delta == event[\dur] and: { event.delta == 0.5 },
+			"Pstretch should stretch deltas of Ppar"
+		);
+	}
+
+	// the bug did not occur in Pstretchp, but let's test it anyway
+	test_PstretchpDeltas {
+		var pattern = Pbind(\dur, Pn(1, 1)),
+		ppar = Ppar([pattern], 1),
+		pstretch = Pstretchp(0.5, ppar),
+		event = pstretch.asStream.next(());
+
+		this.assert(
+			event.delta == event[\dur] and: { event.delta == 0.5 },
+			"Pstretchp should stretch deltas of Ppar"
+		);
+	}
 
 /*
 	test_storeArgs {


### PR DESCRIPTION
Pstretch did not correctly apply to events using \delta rather than \dur for rhythm -- including all Ppars.

The original code, when checking if the event has a delta, checked `event[\delta]` -- which seems reasonable, until you read it more closely and see that `event` is the event prototype that was passed in. The event-in-progress (including information from Pstretch's child pattern) is `inevent`, in a really bizarre reversal of semantics.

I don't have time to review all filter patterns today, but we really should make sure to be consistent: `inevent` should always be the event prototype (`arg inevent`; `inevent = blahblah.yield`) and `event` should always be the event being prepared for yield. That should avoid this sort of confusion in the future.

Simple tests, ensuring that basic `Pstretch` and `Pstretchp` functionality isn't broken:

```
(
p = Pstretch(
	Pseq([1, 1.5, 2], inf),
	Pbind(
		\degree, Pseries(0, 1, 8),
		\dur, 0.125
	)
).play;
)

(
p = Pstretchp(
	Pseq([1, 1.5, 2], inf),
	Pbind(
		\degree, Pseries(0, 1, 8),
		\dur, 0.125
	)
).play;
)
```

More complex test from SC help (this is the case that was broken, fixed by this PR):

```
(
// modal transposition
var pat1, pat2;

// define the basic pattern
pat1 = Pbind(
	\dur, 0.15,
	\degree, Pseq([ Pshuf(#[-7,-3,0,2,4,7], 4), Pseq([0,1,2,3,4,5,6,7]) ], 1)
);

pat2 = Paddp(
	\mtranspose,    // property to be modified
	Pseq([0,1,2]),    // a value pattern as a source of values for adding to mtranspose
	Ppar([
		pat1,
		Padd(\mtranspose, -3, pat1),    // down a 4th
		Padd(\mtranspose, 2, pat1)    // up a 3rd
	])
);

Pseq([
	pat1,    // unmodified pattern
	pat2,    // parallel sequence
	Pstretch(1.5, pat2)  // parallel sequence stretched by 3/2
], inf).play
)
```