### PR TITLE
appveyor: use symlink to current qt version

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -28,7 +28,7 @@ environment:
           # https://www.appveyor.com/docs/lang/cpp/
           VCVARS_SCRIPT: "C:/Program Files (x86)/Microsoft Visual Studio/2017/Community/VC/Auxiliary/Build/vcvars32.bat"
 
-        - QT_DIR: "C:/Qt/5.11.0/msvc2017_64"
+        - QT_DIR: "C:/Qt/5.11/msvc2017_64"
           CMAKE_GENERATOR: "Visual Studio 15 2017 Win64"
           FFTW_URL: ftp://ftp.fftw.org/pub/fftw/fftw-3.3.5-dll64.zip
           ARCH: "x64"


### PR DESCRIPTION
Current appveyor builds are failing because I was pointing at 5.11.0 directly. It looks like Appveyor have now removed that in favor of 5.11.1.