### PR TITLE
sclang: Fix scaling of canvas painting

### DIFF
--- a/QtCollider/widgets/QcCanvas.cpp
+++ b/QtCollider/widgets/QcCanvas.cpp
@@ -135,8 +135,8 @@ void QcCanvas::paintEvent( QPaintEvent *e )
 {
   if( _paint && _repaintNeeded ) {
     if( _resize ) {
-      int pixelRatio = round(backingStore()->window()->devicePixelRatio());
-      _pixmap = QPixmap( size() * pixelRatio );
+      qreal pixelRatio = backingStore()->window()->devicePixelRatio();
+      _pixmap = QPixmap(size() * pixelRatio);
       _pixmap.setDevicePixelRatio(pixelRatio);
       _resize = false;
       _clearOnce = true;
@@ -170,7 +170,12 @@ void QcCanvas::paintEvent( QPaintEvent *e )
   if (_bkg_image.isValid())
       _bkg_image.paint( &painter, rect() );
 
-  if( _paint ) painter.drawPixmap( e->rect(), _pixmap );
+  if ( _paint ) {
+    qreal pixelRatio = round(backingStore()->window()->devicePixelRatio());
+    auto sourceRect = e->rect().intersected(QRect(0, 0, size().width(), size().height()));
+    sourceRect = QRect(sourceRect.topLeft() * pixelRatio, sourceRect.size() * pixelRatio);
+    painter.drawPixmap( e->rect(), _pixmap, sourceRect);
+  }
 }
 
 void QcCanvas::timerEvent( QTimerEvent *e )

--- a/QtCollider/widgets/QcScopeShm.cpp
+++ b/QtCollider/widgets/QcScopeShm.cpp
@@ -165,7 +165,7 @@ void QcScopeShm::paintEvent ( QPaintEvent * event )
     int chanCount = _shm->reader.channels();
     int maxFrames = _shm->reader.max_frames();
     QRect area (_pixmap.rect());
-    area.setSize(area.size() / (int)_pixmap.devicePixelRatio());
+    area.setSize(area.size() / _pixmap.devicePixelRatio());
     
     p.begin(&_pixmap);
 


### PR DESCRIPTION
The QPainter::drawPixmap we were using does scaling. We need to use the version that clips, in case the thing we're painting extends beyond the surface of the canvas.
Also, fix two places where we demote float pixelRatio to int - this would have broken fractional pixelRatios.

Fixes #3822 