### PR TITLE
class library: function plot uses loadToFloatArray

### DIFF
--- a/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
+++ b/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
@@ -816,7 +816,7 @@ Plotter {
 		plotter = Plotter(name, bounds);
 		plotter.value = [0.0];
 
-		this.getToFloatArray(duration, target, { |array, buf|
+		this.loadToFloatArray(duration, target, { |array, buf|
 			var numChan = buf.numChannels;
 			{
 				plotter.setValue(


### PR DESCRIPTION
Because getToFloatArray is broken in some specific boundary case, for
now we just use loadToFloatArray instead. This used to be the case in
previous versions of the method, so this change doesn’t break expected
functionality.

Note that for now this again limits plotting to local servers.

By curing the symptom, this fixes #3873.

getToFloatArray still needs to be fixed.