### PR TITLE
Fix buffer getToFloatArray

### DIFF
--- a/SCClassLibrary/Common/Control/Buffer.sc
+++ b/SCClassLibrary/Common/Control/Buffer.sc
@@ -295,37 +295,39 @@ Buffer {
 	// risky without wait
 	getToFloatArray { arg index = 0, count, wait = 0.01, timeout = 3, action;
 		var refcount, array, pos, getsize, resp, done = false;
+
 		pos = index = index.asInteger;
-		count = (count ? (numFrames * numChannels)).asInteger;
+		count = (count ??  { numFrames * numChannels }).asInteger;
 		array = FloatArray.newClear(count);
 		refcount = (count / 1633).roundUp;
 		count = count + pos;
-		//("refcount" + refcount).postln;
+
 		resp = OSCFunc({ arg msg;
 			if(msg[1] == bufnum, {
-				//("received" + msg).postln;
 				array = array.overWrite(FloatArray.newFrom(msg.copyToEnd(4)), msg[2] - index);
 				refcount = refcount - 1;
-				//("countDown" + refcount).postln;
-				if(refcount <= 0, {done = true; resp.clear; action.value(array, this); });
+				if(refcount <= 0, { done = true; resp.clear; action.value(array, this) });
 			});
 		}, '/b_setn', server.addr);
+
 		{
-			while({ pos < count }, {
+			while { pos < count } {
 				// 1633 max size for getn under udp
 				getsize = min(1633, count - pos);
-				//("sending from" + pos).postln;
 				server.listSendMsg(this.getnMsg(pos, getsize));
 				pos = pos + getsize;
 				if(wait >= 0) { wait.wait } { server.sync };
-			});
+			};
 
 		}.forkIfNeeded;
+
 		// lose the responder if the network choked
 		SystemClock.sched(timeout, {
-			if(done.not, { resp.free; "Buffer-streamToFloatArray failed!".warn;
+			if(done.not) {
+				resp.free;
+				"Buffer-streamToFloatArray failed!".warn;
 				"Try increasing wait time".postln
-			})
+			}
 		})
 	}
 

--- a/SCClassLibrary/Common/Core/Function.sc
+++ b/SCClassLibrary/Common/Core/Function.sc
@@ -297,7 +297,7 @@ Function : AbstractFunction {
 			if(running.not) { server.bootSync; 1.wait };
 			numFrames = duration * server.sampleRate;
 			if(rate == \control) { numFrames = numFrames / server.options.blockSize };
-			buffer.numFrames = numFrames;
+			buffer.numFrames = numFrames.asInteger;
 			buffer.numChannels = numChannels;
 			buffer = buffer.alloc(numFrames, numChannels);
 			server.sync;


### PR DESCRIPTION
We need to make sure that the `numFrames` variable of the buffer is an integer.

This fixes #3873.

Test will be added in a separate subsequent PR.

quick test:

```supercollider
b = { SinOsc.ar([234, 562]) }.asBuffer(2 * 1633 + 69 / s.sampleRate);
b.getToFloatArray(0, b.numFrames * b.numChannels, action: _.postln)
```