### PR TITLE
docs: match code syntax highlighting from the default theme

### DIFF
--- a/HelpSource/lang-sc.js
+++ b/HelpSource/lang-sc.js
@@ -7,11 +7,11 @@ PR.registerLangHandler(
         [PR.PR_STRING,      /^"(?:[^\\"]|\\.)*(?:"|$)/, null, '"'],
     ],
     [
-        /* char literal */
-        [PR.PR_LITERAL,     /^\$(\\)?./],
-        /* symbols */
+        /* symbols, char literals, env vars */
         [PR.PR_ATTRIB_NAME, /^\\\w+/],
         [PR.PR_ATTRIB_NAME, /^'[^']+'/],
+        [PR.PR_ATTRIB_NAME, /^\w+\:/],
+        [PR.PR_ATTRIB_NAME, /^\$(\\)?./],
         [PR.PR_ATTRIB_VALUE, /^~\w+/],
         /* special variables */
         [PR.PR_TAG,         /^(?:super|thisFunctionDef|thisFunction|thisMethod|thisProcess|thisThread|this)\b/],

--- a/HelpSource/scdoc.css
+++ b/HelpSource/scdoc.css
@@ -601,17 +601,31 @@ a.clslnk {
 
 /* Pretty printing styles. Used with prettify.js. */
 
-.str { color: #070; } /* strings */
-.kwd { color: #880; } /* special values like true, nil.. */
-.com { color: #822; } /* comments */
-.typ { color: #008; } /* class names */
-.lit { color: #066; } /* numbers and character literals */
-.pun { color: #555; } /* punctuation */
-.pln { color: #000; } /* plain text, methods and variable names */
-.tag { color: #059; } /* special variables like super, thisProcess... */
-.dec { color: #508; } /* declarations like var, const... */
-.atn { color: #285; } /* symbols */
-.atv { color: #750; } /* environment vars */
+.str { color: rgb(95, 95, 95) } /* strings */
+.kwd { color: rgb(0, 0, 230) } /* special values like true, nil.. */
+.com { color: rgb(192, 0, 0) } /* comments */
+.typ { color: rgb(0, 0, 210) } /* class names */
+.lit { color: rgb(152, 0, 153) } /* numbers and character literals */
+.pun { color: rgb(85, 85, 85) } /* punctuation */
+.pln { color: rgb(0, 0, 0) } /* plain text, methods and variable names */
+.tag { color: rgb(51, 51, 191) } /* special variables like super, thisProcess... */
+.dec { color: rgb(0, 0, 230); font-weight: bold; } /* declarations like var, const... */
+.atn { color: rgb(0, 115, 0) } /* symbols */
+.atv { color: rgb(140, 70, 20) } /* environment vars */
+
+@media print {
+    .str { color: rgb(95, 95, 95) } /* strings */
+    .kwd { color: rgb(0, 0, 230); font-weight: bold; } /* special values like true, nil.. */
+    .com { color: rgb(192, 0, 0); font-style: italic; } /* comments */
+    .typ { color: rgb(0, 0, 210); font-weight: bold; } /* class names */
+    .lit { color: rgb(152, 0, 153) } /* numbers and character literals */
+    .pun { color: rgb(85, 85, 85) } /* punctuation */
+    .pln { color: rgb(0, 0, 0) } /* plain text, methods and variable names */
+    .tag { color: rgb(51, 51, 191); font-weight: bold; } /* special variables like super, thisProcess... */
+    .dec { color: rgb(0, 0, 230); font-weight: bold; } /* declarations like var, const... */
+    .atn { color: rgb(0, 115, 0) } /* symbols */
+    .atv { color: rgb(140, 70, 20) } /* environment vars */
+}
 
 /* Specify class=linenums on a pre to get line numbering */
 ol.linenums { margin-top: 0; margin-bottom: 0 } /* IE indents via margin-left */
@@ -629,19 +643,6 @@ li.L3,
 li.L5,
 li.L7,
 li.L9 { background: #eee }
-
-@media print {
-  .str { color: #060; }
-  .kwd { color: #006; font-weight: bold; }
-  .com { color: #600; font-style: italic; }
-  .typ { color: #404; font-weight: bold; }
-  .lit { color: #044; }
-  .pun { color: #440; }
-  .pln { color: #000; }
-  .tag { color: #006; font-weight: bold; }
-  .atn { color: #404; }
-  .atv { color: #060; }
-}
 
 /* from HelpSource/Search.html */
 


### PR DESCRIPTION
syntax highlighting for code in the help/docs is different (but confusingly similar) from the default theme in the editor. for consistency, colors and font weights are adjusted to be the same.

before:

<img width="1392" alt="screen shot 2018-07-16 at 19 03 41" src="https://user-images.githubusercontent.com/1709263/42775890-d0b86b6c-8935-11e8-9d3c-86d892a572a4.png">

after:

<img width="1392" alt="screen shot 2018-07-16 at 19 56 02" src="https://user-images.githubusercontent.com/1709263/42775870-c1d0ca40-8935-11e8-905e-42e372100f89.png">

the careful eye will notice that the editor has slightly lighter tone than the docs. 
i wasn't able to translate that from qt into css, but if it's significant i might do it.

the default theme: https://github.com/supercollider/supercollider/blob/develop/editors/sc-ide/core/settings/theme.cpp#L101. testing the docs theme: https://github.com/supercollider/supercollider/blob/develop/HelpSource/syntax_colors.html 