### PR TITLE
Supernova fix s_getn bug

### DIFF
--- a/HelpSource/Classes/Function.schelp
+++ b/HelpSource/Classes/Function.schelp
@@ -253,11 +253,12 @@ code::
 (
 a = nil;
 { a == 2 }.whenTrueWithin(2, { "did it on time!".postln }, { "too late ...".postln });
-fork { 1.99.wait; a = 2 };
+fork { 1.999.wait; a = 2 };
 )
-// can be used for branching when preparation may fail:
+
+// can be used for branching when some preparation may fail:
 (
-{ s.serverRunning }.whenTrueWithin(3,
+{ s.serverRunning }.whenTrueWithin(4,
 	{ "YES! doWhenBooted...".postln; ().play },
 	{ "NO! boot timed out - quitting again.".postln; s.quit }
 );

--- a/HelpSource/Classes/Function.schelp
+++ b/HelpSource/Classes/Function.schelp
@@ -245,6 +245,26 @@ f.forkIfNeeded;
 { "we are now in a routine".postln; 1.wait; f.forkIfNeeded }.fork;
 ::
 
+method::whenTrueWithin
+
+When func.value becomes true within timeout, then do thenFunc, else to elseFunc.
+
+code::
+(
+a = nil;
+{ a == 2 }.whenTrueWithin(2, { "did it on time!".postln }, { "too late ...".postln });
+fork { 1.99.wait; a = 2 };
+)
+// can be used for branching when preparation may fail:
+(
+{ s.serverRunning }.whenTrueWithin(3,
+	{ "YES! doWhenBooted...".postln; ().play },
+	{ "NO! boot timed out - quitting again.".postln; s.quit }
+);
+fork { s.quit; 1.wait; s.boot };
+)
+::
+
 method::block
 
 Break from a loop. Calls the receiver with an argument which is a function that returns from the method block. To exit the loop, call .value on the function passed in. You can pass a value to this function and that value will be returned from the block method.

--- a/SCClassLibrary/Common/Core/Function.sc
+++ b/SCClassLibrary/Common/Core/Function.sc
@@ -159,6 +159,18 @@ Function : AbstractFunction {
 		^thisThread;
 	}
 
+	whenTrueWithin { |timeout = 3, thenFunc, elseFunc, dt = (1/16)|
+		var remaining = timeout;
+		^Routine {
+			while {
+				remaining = remaining - dt;
+				this.value.not and: { remaining >= 0 }
+			} {
+				dt.wait;
+			};
+			if (this.value, thenFunc, elseFunc)
+		}.play(AppClock)
+	}
 
 	awake { arg beats, seconds, clock;
 		var time = seconds; // prevent optimization

--- a/server/supernova/sc/sc_osc_handler.cpp
+++ b/server/supernova/sc/sc_osc_handler.cpp
@@ -2087,7 +2087,7 @@ void handle_s_getn(ReceivedMessage const & msg, size_t msg_size, endpoint_ptr co
             break;
         if (!it->IsInt32())
             throw std::runtime_error("invalid count");
-        argument_count += it->AsInt32Unchecked(); ++it;
+        argument_count += it->AsInt32Unchecked();
     }
 
     size_t alloc_size = msg_size + sizeof(float) * (argument_count) + 128;
@@ -2109,6 +2109,7 @@ void handle_s_getn(ReceivedMessage const & msg, size_t msg_size, endpoint_ptr co
         if (control_count < 0)
             break;
 
+        p << control_count;
         for (int i = 0; i != control_count; ++i)
             p << s->get(control + i);
     }


### PR DESCRIPTION
This PR fixes #3839: 
supernova now returns correct responses to correct s_getn calls, 
which fixes the failing test in TestNode_Server.

```
Server.supernova;
TestNode_Server.run; // no failures now
```

Explicit testing raises a followup question: scsynth and supernova handle \s_getn calls with odd arg numbers (which are wrong) differently: scsynth sends back wrong values, supernova does not answer. 
Which behavior should that be unified to? 

```
// longer tests:
OSCFunc.trace(true, true); s.dumpOSC;

// switch to supernova
Server.killAll; Server.supernova; s.waitForBoot { x = Synth(\default, [\out, 0, \freq, 234, \amp, 0.125, \pan, 0.5]) };

//  multi-getn is now correct in both: 
s.sendMsg(\s_getn, x.nodeID, 1, 1, 2, 3);
	// OK: [ /n_setn, 1000, 1, 1, 234.0, 2, 3, 0.125, 0.5, 1.0 ]

// responses to faulty getn messags with odd arg numbers differ:
s.sendMsg(\s_getn, x.nodeID, 1); 
	// scsynth: [ /n_setn, 0, 0, 0 ] - misleading answer, index, size and value are wrong
	// supernova: no answer, posts error: exception in handle_message: integer argument expected
s.sendMsg(\s_getn, x.nodeID, 1, 1, 2); 
	// scsynth: [ /n_setn, 1000, 1, 1, 234.0, 2, 0 ] // wrong value 0 in second pair
	// supernova: no answer, posts error: exception in handle_message: integer argument expected
```
