### PR TITLE
supernova_getn: fix getn response

### DIFF
--- a/server/supernova/sc/sc_osc_handler.cpp
+++ b/server/supernova/sc/sc_osc_handler.cpp
@@ -2087,7 +2087,7 @@ void handle_s_getn(ReceivedMessage const & msg, size_t msg_size, endpoint_ptr co
             break;
         if (!it->IsInt32())
             throw std::runtime_error("invalid count");
-        argument_count += it->AsInt32Unchecked(); ++it;
+        argument_count += it->AsInt32Unchecked();
     }
 
     size_t alloc_size = msg_size + sizeof(float) * (argument_count) + 128;
@@ -2109,6 +2109,8 @@ void handle_s_getn(ReceivedMessage const & msg, size_t msg_size, endpoint_ptr co
         if (control_count < 0)
             break;
 
+        p << control_count;
+        
         for (int i = 0; i != control_count; ++i)
             p << s->get(control + i);
     }


### PR DESCRIPTION
This PR fixes #3839: 
supernova now returns correct responses to correct s_getn calls, 
which fixes the failing test in TestNode_Server.

```
Server.supernova;
TestNode_Server.run; // no failures now
```

Explicit testing raises a followup question: scsynth and supernova handle \s_getn calls with odd arg numbers (which are wrong) differently: scsynth sends back wrong values, supernova does not answer. 
Which behavior should that be unified to? 

```
// longer tests:
OSCFunc.trace(true, true); s.dumpOSC;

// switch to supernova
Server.killAll; Server.supernova; s.waitForBoot { x = Synth(\default, [\out, 0, \freq, 234, \amp, 0.125, \pan, 0.5]) };

//  multi-getn is now correct in both: 
s.sendMsg(\s_getn, x.nodeID, 1, 1, 2, 3);
	// OK: [ /n_setn, 1000, 1, 1, 234.0, 2, 3, 0.125, 0.5, 1.0 ]

// responses to faulty getn messags with odd arg numbers differ:
s.sendMsg(\s_getn, x.nodeID, 1); 
	// scsynth: [ /n_setn, 0, 0, 0 ] - misleading answer, index, size and value are wrong
	// supernova: no answer, posts error: exception in handle_message: integer argument expected
s.sendMsg(\s_getn, x.nodeID, 1, 1, 2); 
	// scsynth: [ /n_setn, 1000, 1, 1, 234.0, 2, 0 ] // wrong value 0 in second pair
	// supernova: no answer, posts error: exception in handle_message: integer argument expected
```
