### PR TITLE
Supernova: Add missing \n to buffer command error messages

### DIFF
--- a/server/supernova/sc/sc_osc_handler.cpp
+++ b/server/supernova/sc/sc_osc_handler.cpp
@@ -2688,7 +2688,7 @@ void handle_b_set(ReceivedMessage const & msg)
 
     buffer_wrapper::sample_t * data = sc_factory->get_buffer(buffer_index);
     if( !data ) {
-        log_printf("/b_set called on unallocated buffer");
+        log_printf("/b_set called on unallocated buffer\n");
         return;
     }
 
@@ -2709,7 +2709,7 @@ void handle_b_setn(ReceivedMessage const & msg)
 
     buffer_wrapper::sample_t * data = sc_factory->get_buffer(buffer_index);
     if( !data ) {
-        log_printf("/b_setn called on unallocated buffer");
+        log_printf("/b_setn called on unallocated buffer\n");
         return;
     }
 
@@ -2735,7 +2735,7 @@ void handle_b_fill(ReceivedMessage const & msg)
 
     buffer_wrapper::sample_t * data = sc_factory->get_buffer(buffer_index);
     if( !data ) {
-        log_printf("/b_fill called on unallocated buffer");
+        log_printf("/b_fill called on unallocated buffer\n");
         return;
     }
 
@@ -2818,7 +2818,7 @@ void handle_b_get(ReceivedMessage const & msg, endpoint_ptr endpoint)
     const SndBuf * buf = sc_factory->get_buffer_struct(buffer_index);
     const sample * data = buf->data;
     if( !data ) {
-        log_printf("/b_get called on unallocated buffer");
+        log_printf("/b_get called on unallocated buffer\n");
         return;
     }
 
@@ -2875,7 +2875,7 @@ void handle_b_getn(ReceivedMessage const & msg, endpoint_ptr endpoint)
     const SndBuf * buf = sc_factory->get_buffer_struct(buffer_index);
     const sample * data = buf->data;
     if( !data ) {
-        log_printf("/b_getn called on unallocated buffer");
+        log_printf("/b_getn called on unallocated buffer\n");
         return;
     }
     const int max_sample = buf->frames * buf->channels;


### PR DESCRIPTION
TL;DR It's a typo. No risk to include in 3.10.

Supernova currently omits newline for "unallocated buffer" error messages.

Supernova also flushes log output to the post window only when it prints `\n`.

This means posting these particular error messages is delayed until the next log post from supernova. This may be anywhere from seconds to minutes later, making it impossible to troubleshoot (if you don't know when the error really happened, you can't narrow it down in the code).

Easily corrected.

```
Server.supernova;
s.boot;

// unallocated buffer but no posting
s.sendMsg(\b_setn, 0, 0, 3, 1, 2, 3);

a = { PlayBuf.ar(1, 0) }.play;

-> /b_setn called on unallocated bufferBuffer UGen: no buffer data

a.free;
```