### PR TITLE
class library: function plot switches method

### DIFF
--- a/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
+++ b/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
@@ -811,12 +811,15 @@ Plotter {
 
 + Function {
 	plot { |duration = 0.01, target, bounds, minval, maxval, separately = false|
-		var name = this.asCompileString, plotter;
+
+		var name = this.asCompileString, plotter, selector;
 		if(name.size > 50 or: { name.includes(Char.nl) }) { name = "function plot" };
 		plotter = Plotter(name, bounds);
 		plotter.value = [0.0];
+		target = target.asTarget;
+		selector = if(target.server.isLocal) { \loadToFloatArray } { \getToFloatArray };
 
-		this.getToFloatArray(duration, target, { |array, buf|
+		this.perform(selector, duration, target, action: { |array, buf|
 			var numChan = buf.numChannels;
 			{
 				plotter.setValue(

--- a/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
+++ b/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
@@ -860,14 +860,17 @@ Plotter {
 
 + Buffer {
 	plot { |name, bounds, minval, maxval, separately = false|
-		var plotter;
+		var plotter, selector;
 		if(server.serverRunning.not) { "Server % not running".format(server).warn; ^nil };
 		if(numFrames.isNil) { "Buffer not allocated, can't plot data".warn; ^nil };
+		selector = if(server.isLocal) { \loadToFloatArray } { \getToFloatArray };
+
 		plotter = [0].plot(
 			name ? "Buffer plot (bufnum: %)".format(this.bufnum),
 			bounds, minval: minval, maxval: maxval
 		);
-		this.loadToFloatArray(action: { |array, buf|
+
+		this.perform(selector, action: { |array, buf|
 			{
 				plotter.setValue(
 					array.unlace(buf.numChannels),


### PR DESCRIPTION
This PR recovers the implementation of `plot` before it was changed to use OSC messages instead of writing files. We now only use OSC when the server is remote so that plot wouldn't work otherwise.

This is a temporary fix, in a later version we agreed on cleaning up the interface involving methods like `loadToFloatArray` and `getToFloatArray`.