### PR TITLE
Unittest:run add class info to post, remove debug posts

### DIFF
--- a/HelpSource/Classes/UnitTest.schelp
+++ b/HelpSource/Classes/UnitTest.schelp
@@ -53,9 +53,10 @@ Should be code::UnitTest.full:: or code::UnitTest.brief::.
 
 METHOD:: run
 Run all methods whose names begin with code::test_::.
+Redirects to code::UnitTest.new.run(args)::.
 
 code::
-TestUnitTest.new.run;
+TestUnitTest.run;
 ::
 
 ARGUMENT:: reset
@@ -63,6 +64,10 @@ If code::true::, first runs link::#*reset:: on the class.
 
 ARGUMENT:: report
 If code::true::, outputs the test results.
+
+ARGUMENT:: postHeader
+If code::true::, posts a header line before test results.
+
 
 METHOD:: runTest
 Run a single test method.
@@ -87,6 +92,22 @@ UnitTest.runAll;
 
 
 INSTANCEMETHODS::
+
+METHOD:: run
+Run all methods whose names begin with code::test_::.
+
+code::
+TestUnitTest.new.run;
+::
+
+ARGUMENT:: reset
+If code::true::, first runs link::#*reset:: on the class.
+
+ARGUMENT:: report
+If code::true::, outputs the test results.
+
+ARGUMENT:: postHeader
+If code::true::, posts a header line before test results.
 
 METHOD:: runTestMethod
 Run a single test method of this class

--- a/SCClassLibrary/Common/UnitTesting/UnitTest.sc
+++ b/SCClassLibrary/Common/UnitTesting/UnitTest.sc
@@ -24,69 +24,105 @@ UnitTest {
 
 	}
 
-	// run a single test in the name format "TestPolyPlayerPool:test_prepareChildrenToBundle"
-	*runTest { | methodName |
-		var class, method, unitTest;
-		# class, method = methodName.split($:);
-		class = class.asSymbol.asClass;
-		method = class.findMethod(method.asSymbol);
-		if(method.isNil) {
-			Error("Test method not found " + methodName).throw
-		};
-		class.new.runTestMethod(method);
-	}
-
-
 	// called before each test
 	setUp {}
 
 	// called after each test
 	tearDown {}
 
-	*run { | reset = true, report = true |
-		if(reset) { this.reset };
-		this.forkIfNeeded {
-			this.prRunAllTestMethods(report);
-		};
+	*run { | reset = true, report = true|
+		this.new.run(reset, report);
 	}
 
 	// run all UnitTest subclasses
 	*runAll {
 		^this.forkIfNeeded {
 			this.reset;
-			this.allSubclasses.do { |testClass|
-				testClass.run(false, false);
+			this.allSubclasses.do ({ |testClass|
+				testClass.run(false,false);
 				0.1.wait;
-			};
-			this.report
+			});
+			this.report;
 		}
 	}
 
+	// run a single test in the name format "TestPolyPlayerPool:test_prepareChildrenToBundle"
+	*runTest { | methodName |
+		var class, method, unitTest;
+		# class, method = methodName.split($:);
+		class = class.asSymbol.asClass;
+		method.asSymbol;
+		method = class.findMethod(method.asSymbol);
+		if(method.isNil) { Error("Test method not found "+methodName).throw };
+		class.new.runTestMethod(method);
+	}
+
 	// run a single test method of this class
-	runTestMethod { | method, report = true |
+	runTestMethod { | method |
+		var function;
+		("RUNNING UNIT TEST" + this.class.name ++ ":" ++ method.name).inform;
 		this.class.forkIfNeeded {
 			this.setUp;
 			currentMethod = method;
 			this.perform(method.name);
 			this.tearDown;
-			if(report) { this.class.report };
-		}
-	}
-
-
-	*prRunAllTestMethods { |report = true|
-		"RUNNING UNIT TEST '%'".format(this.name).inform;
-		this.forkIfNeeded {
-			this.findTestMethods.do { |method|
-				this.new.runTestMethod(method, false)
-			};
-			if(report) { this.report };
+			this.class.report;
+			nil
 		}
 	}
 
 	*gui {
+
+		// UnitTest GUI written by Dan Stowell 2009.
+		var w, classlist, methodlist, lookUp;
+
 		this.findTestClasses;
-		^UnitTestGUI.new(this.allTestClasses)
+
+		w = Window.new("[UnitTest GUI]", Rect(100, 100, 415, 615), resizable: false);
+		w.addFlowLayout;
+
+		StaticText(w, Rect(0,0, 400, 40))
+		.string_("Select a category, then a test method, and press Enter\nHit 'i' to jump to the code file")
+		.align_(\center);
+
+		classlist = ListView(w, Rect(0,0, 200, 600-40))
+		.items_(allTestClasses.asSortedArray.collect(_[0]))
+		.action_{|widg|
+			methodlist.items_(
+				allTestClasses.asSortedArray[widg.value][1].asSortedArray.collect(_[0])
+			)
+		};
+
+		methodlist = ListView(w, Rect(200,40, 200, 600-40));
+		methodlist.enterKeyAction_ {|widg|
+			allTestClasses.asSortedArray[classlist.value][1].asSortedArray[widg.value][1].value
+		};
+
+		lookUp = {|widg, char, mod|
+			var class, selector, method;
+			class = ("Test" ++ classlist.items[classlist.value]).asSymbol.asClass;
+			class !? {
+				selector = methodlist.items[methodlist.value].asSymbol;
+				method = class.findMethod(selector);
+				if(char == $i) {
+					if(method.notNil) { method.openCodeFile } { class.openCodeFile };
+				}
+			};
+
+		};
+
+		methodlist.keyDownAction = lookUp;
+		classlist.keyDownAction = lookUp;
+
+		classlist.enterKeyAction_{|widg|
+			// mimic behaviour of pressing enter in methodlist
+			methodlist.enterKey;
+		};
+
+		classlist.value_(0);
+		classlist.doAction; // fills in the right-hand column
+		^w.front;
+
 	}
 
 	///////////////////////////////////////////////////////////////////////
@@ -106,25 +142,28 @@ UnitTest {
 	}
 
 	assertEquals { |a, b, message = "", report = true, onFailure |
-		var details = "Is:\n\t % \nShould be:\n\t %".format(a, b);
+		var details = "Is:\n\t" + a + "\nShould be:\n\t" + b;
 		this.assert(a == b, message, report, onFailure, details);
 	}
 
 	assertFloatEquals { |a, b, message = "", within = 0.0001, report = true, onFailure|
 		var details =
-		"Is:\n\t % \nShould equal (within range" + within ++ "):\n\t %".format(a, b);
+			"Is:\n\t" + a +
+			"\nShould equal (within range" + within ++ "):\n\t" + b;
 		this.assert((a - b).abs <= within, message, report, onFailure, details);
 	}
 
 	assertArrayFloatEquals { |a, b, message = "", within = 0.0001, report = true, onFailure|
-		var results, startFrom, someHaveFailed;
-		a = a.asArray;
-
 		// Check whether all in array meet the condition.
-		results = (a - b).abs <= within;
-		someHaveFailed = results.includes(false);
+		var results, startFrom;
+		a = a.asArray;
+		results = if(b.isArray) {
+			a.collect {|item, index| (item - b[index]).abs <= within }
+		}{
+			a.collect {|item, index| (item - b).abs <= within }
+		};
 
-		if(someHaveFailed) {
+		if(results.any(_ == false)) {
 			startFrom = results.indexOf(false);
 			// Add failure details:
 			message = message ++
@@ -138,16 +177,16 @@ UnitTest {
 				a[startFrom..],
 				if(b.isArray) { b[startFrom..] } { b }
 			);
-			this.failed(currentMethod, message, report);
-
+			this.failed(currentMethod,message, report);
 			if(onFailure.notNil) {
 				{ onFailure.value }.defer;
 				Error("UnitTest halted with onFailure handler.").throw;
 			};
-		} {
-			this.passed(currentMethod, message, report)
+			^false
+		}{
+			this.passed(currentMethod,message, report)
+			^true
 		}
-		^someHaveFailed.not
 	}
 
 	assertException { | func, errorClass, message, report = true, onFailure, details |
@@ -195,44 +234,42 @@ UnitTest {
 
 	// make a further assertion only if it passed, or only if it failed
 	ifAsserts { | boolean, message, ifPassedFunc, ifFailedFunc, report = true|
-		if(boolean.not) {
-			this.failed(currentMethod, message, report);
+		if(boolean.not,{
+			this.failed(currentMethod,message, report);
 			ifFailedFunc.value;
-		} {
+		},{
 			this.passed(currentMethod,message, report);
 			ifPassedFunc.value;
-		};
+		});
 		^boolean
 	}
 
 	// waits for condition with a maxTime limit
 	// if time expires, the test is a failure
 	wait { |condition, failureMessage, maxTime = 10.0|
-		var limit = maxTime / 0.05;
-
-		while {
+		var limit;
+		limit = maxTime / 0.05;
+		while({
 			condition.value.not and:
 			{(limit = limit - 1) > 0}
-		} {
+		},{
 			0.05.wait;
-		};
-
-		if(limit == 0 and: failureMessage.notNil) {
+		});
+		if(limit == 0 and: failureMessage.notNil,{
 			this.failed(currentMethod,failureMessage)
-		}
+		})
 	}
 
 	// wait is better
 	asynchAssert { |waitConditionBlock, testBlock, timeoutMessage = "", timeout = 10|
-		var limit = timeout / 0.1;
-
+		var limit;
+		limit = timeout / 0.1;
 		while {
 			waitConditionBlock.value.not and:
 			{ (limit = limit - 1) > 0 }
 		} {
 			0.1.wait;
 		};
-
 		if(limit == 0) {
 			this.failed(currentMethod,"Timeout:" + timeoutMessage)
 		} {
@@ -255,11 +292,10 @@ UnitTest {
 
 	// call failure directly
 	failed { | method, message, report = true, details |
-
-		var r = UnitTestResult(this, method, message, details);
+		var r;
+		r = UnitTestResult(this, method, message, details);
 		failures = failures.add(r);
-
-		if(report) {
+		if(report){
 			Post << Char.nl << "FAIL: ";
 			r.report;
 			Post << Char.nl;
@@ -268,10 +304,10 @@ UnitTest {
 
 	// call pass directly
 	passed { | method, message, report = true, details |
-		var r = UnitTestResult(this, method, message, details);
+		var r;
+		r = UnitTestResult(this, method, message, details);
 		passes = passes.add(r);
-
-		if(report and: { reportPasses }) {
+		if(report && reportPasses) {
 			Post << "PASS: ";
 			r.report(passVerbosity == brief);
 		};
@@ -306,7 +342,7 @@ UnitTest {
 
 	*report {
 		Post.nl;
-		"UNIT TESTS FOR '%' COMPLETED".format(this.name).inform;
+		"UNIT TEST.............".inform;
 		if(failures.size > 0) {
 			"There were failures:".inform;
 			failures.do { arg results;
@@ -319,77 +355,93 @@ UnitTest {
 
 	// private - use TestYourClass.run
 
+	run { | reset = true, report = true, postHeader = true|
+		var function;
+		if(reset) { this.class.reset };
+		if(postHeader or: report) {
+			("\n*** RUNNING UNIT TESTS of:" + this.class).inform;
+		};
+		this.class.forkIfNeeded {
+			this.findTestMethods.do { |method|
+				this.setUp;
+				currentMethod = method;
+				//{
+				this.perform(method.name);
+				// unfortunately this removes the interesting part of the call stack
+				//}.try({ |err|
+				//	("ERROR during test"+method).postln;
+				//	err.throw;
+				//});
+
+				this.tearDown;
+			};
+			if(report) { this.class.report };
+			nil
+		};
+
+	}
+
 	*forkIfNeeded { |function|
-		function.forkIfNeeded(AppClock)
+		^if(thisThread.isKindOf(Routine)) {
+			// we are inside the Routine already
+			function.value
+		} {
+			Routine(function).play(AppClock)
+		}
 	}
 
 	// returns the methods named test_
 	findTestMethods {
 		^this.class.findTestMethods
 	}
-
 	*findTestMethods {
-		^methods.select { |m|
-			m.name.asString.beginsWith("test_")
-		}
+		^methods.select({ arg m;
+			m.name.asString.copyRange(0,4) == "test_"
+		})
 	}
-
 	*classesWithTests { | package = 'Common'|
-		^Quarks.classesInPackage(package).select { |c|
-			UnitTest.findTestClass(c).notNil
-		}
+		^Quarks.classesInPackage(package).select({ |c| UnitTest.findTestClass(c).notNil })
 	}
-
 	*classesWithoutTests { |package = 'Common'|
-		^Quarks.classesInPackage(package).difference(UnitTest.classesWithTests(package))
+		^Quarks.classesInPackage(package).difference( UnitTest.classesWithTests(package) );
 	}
 
 	// whom I am testing
-	// removing "Test" by copyToEnd(4)
 	*findTestedClass {
 		^this.name.asString.copyToEnd(4).asSymbol.asClass
 	}
-
 	// methods in the tested class that do not have test_ methods written
 	*untestedMethods {
 		var testedClass,testMethods,testedMethods,untestedMethods;
 		testedClass = this.findTestedClass;
 		// what methods in the target class do not have tests written for them ?
 		testMethods = this.findTestMethods;
-		testedMethods = testMethods.collect { |meth|
+		testedMethods = testMethods.collect({ |meth|
 			testedClass.findMethod(meth.name.asString.copyToEnd(5).asSymbol)
-		}.reject(_.isNil);
-
-		if(testedMethods.isNil or: { testedMethods.isEmpty }) {
-			untestedMethods = testedClass.methods
-		} {
-			untestedMethods = testedClass.methods.select { |meth|
-				testedMethods.includes(meth).not
-			}
-		};
-
+		}).reject(_.isNil);
+		if(testedMethods.isNil or: {testedMethods.isEmpty},{
+			untestedMethods = testedClass.methods;
+		},{
+			untestedMethods =
+			testedClass.methods.select({ |meth| testedMethods.includes(meth).not });
+		});
 		// reject getters,setters, empty methods
-		untestedMethods = untestedMethods.reject { |meth| meth.code.isNil };
+		untestedMethods = untestedMethods.reject({ |meth| meth.code.isNil });
 		^untestedMethods
 	}
-
-	*listUntestedMethods { | forClass |
-		this.findTestClass(forClass).untestedMethods.do {|m| m.name.postln }
+	*listUntestedMethods { arg forClass;
+		this.findTestClass(forClass).untestedMethods.do({|m| m.name.postln })
 	}
-
 	// private
 	*reset {
 		failures = [];
 		passes = [];
 		routine.stop;
 	}
-
 	s {
 		^Server.default; // for convenient translation to/from example code
 	}
-
 }
-
 
 UnitTestResult {
 
@@ -494,6 +546,7 @@ UnitTestScript : UnitTest {
 			currentMethod = this;
 			path.load.value(this);
 			this.class.report;
+			nil
 		}
 	}
 

--- a/SCClassLibrary/Common/UnitTesting/UnitTest.sc
+++ b/SCClassLibrary/Common/UnitTesting/UnitTest.sc
@@ -30,8 +30,8 @@ UnitTest {
 	// called after each test
 	tearDown {}
 
-	*run { | reset = true, report = true|
-		this.new.run(reset, report);
+	*run { | reset = true, report = true, postHeader = true|
+		this.new.run(reset, report, postHeader)
 	}
 
 	// run all UnitTest subclasses

--- a/testsuite/classlibrary/TestPattern.sc
+++ b/testsuite/classlibrary/TestPattern.sc
@@ -33,7 +33,7 @@ TestPattern : UnitTest {
 			Pbind(\x, 7).collect { |event| event.put(\y, 8) },
 		];
 
-		[identical, identical].allTuples.postln.do { |pair|
+		[identical, identical].allTuples.do { |pair|
 			assertUnfolded.(*pair)
 		};
 

--- a/testsuite/classlibrary/TestReadableNodeIDAllocator.sc
+++ b/testsuite/classlibrary/TestReadableNodeIDAllocator.sc
@@ -48,7 +48,7 @@ TestReadableNodeIDAllocator : UnitTest {
 			permIDs.add(nextPermID);
 		};
 		this.assert(
-			permIDs.size.postln == (alloc.lowestTempID - 2),
+			permIDs.size == (alloc.lowestTempID - 2),
 			"ReadableNodeIDAllocator should hand out all permanent IDs in mixed alloc/free use."
 		);
 

--- a/testsuite/classlibrary/TestServer_boot.sc
+++ b/testsuite/classlibrary/TestServer_boot.sc
@@ -212,7 +212,6 @@ TestServer_boot : UnitTest {
 		};
 
 		100.do {
-			".".post;
 			nodeID = s.nextNodeID;
 			if(nodeID <= prevNodeID) {
 				failed = true;
@@ -221,8 +220,6 @@ TestServer_boot : UnitTest {
 			};
 			prevNodeID = nodeID;
 		};
-
-		"Done.".postln;
 
 		this.assert(failed.not,
 			"allocating nodeIDs while booting should not produce duplicate nodeIDs."


### PR DESCRIPTION

UnitTest logs currently contain some stray debug postings, and do not show a clear structure where which Test class run begins. 

---------

This PR removes the few leftover debug post commands in the UnitTest subclasses.
New feature: 
It adds separate line that posts when a new UnitTest subclass begins to run.
This is intended to make UnitTest logs easier and quicker to read.
This header line can be suppressed with a flag if desired. 

---------
- [x] All tests are passing - except unrelated hang reported in #3938
- [x] Updated documentation
- [x] This PR is ready for review

OLD post example: 
```
...
PASS: a TestScore: test_pattern_asScore_timingValues_multichannel - onsets should be correctly derived from lag and timingOffset in multichannel expanding
Is:
	 [ 0.8, 1.7, 3.0 ] 
Should be:
	 [ 0.8, 1.7, 3 ]
'/quit' message sent to server 'localhost'.   //// <-- (... here next class test starts, hard to see ...)
PASS: a TestNodeProxy: test_load_init - when server isn't running, the SynthDef should be built
...
```
NEW post example: 
```
PASS: a TestScore: test_pattern_asScore_timingValues_multichannel - onsets should be correctly derived from lag and timingOffset in multichannel expanding
Is:
	 [ 0.8, 1.7, 3.0 ] 
Should be:
	 [ 0.8, 1.7, 3 ]

*** RUNNING UNIT TESTS of: TestNodeProxy   // <--- added newline and header line
'/quit' message sent to server 'localhost'.
PASS: a TestNodeProxy: test_load_init - when server isn't running, the SynthDef should be built
```