### PR TITLE
Rewrite NRT guide

### DIFF
--- a/HelpSource/Guides/Non-Realtime-Synthesis.schelp
+++ b/HelpSource/Guides/Non-Realtime-Synthesis.schelp
@@ -3,112 +3,393 @@ summary:: Non-realtime synthesis with binary files of OSC commands
 categories:: Server>NRT, External Control>OSC
 related:: Classes/Score
 
-section:: Non-Realtime Synthesis
+SECTION:: Realtime vs. Non-Realtime Synthesis
 
-SuperCollider 3 supports non-realtime synthesis through the use of binary files of OSC commands.
+When you boot a SuperCollider server (scsynth, or supernova on supported systems) normally, it runs in emphasis::real-time:: mode:
 
-First create an OSC command file (i.e. a score)
-code::
-f = File("Cmds.osc","w");
-
-// start a sine oscillator at 0.2 seconds.
-c = [ 0.2, [\s_new, \NRTsine, 1001, 0, 0]].asRawOSC;
-f.write(c.size); // each bundle is preceded by a 32 bit size.
-f.write(c); // write the bundle data.
-
-// stop sine oscillator at 3.0 seconds.
-c = [ 3.0, [\n_free, 1001]].asRawOSC;
-f.write(c.size);
-f.write(c);
-
-// scsynth stops processing immediately after the last command, so here is
-// a do-nothing command to mark the end of the command stream.
-c = [ 3.2, [0]].asRawOSC;
-f.write(c.size);
-f.write(c);
-
-f.close;
-
-// the 'NRTsine' SynthDef
-(
-SynthDef("NRTsine", { |out, freq = 440|
-	Out.ar(out,
-		 SinOsc.ar(freq, 0, 0.2)
-	)
-}).writeDefFile;
-)
+list::
+## The server is constantly processing audio, at a rate determined by the hardware sample rate.
+## The server receives OSC commands over a network interface, and processes them either at the next available opportunity, or at a time specified by a timestamp.
+## The server can also send OSC messages back to the client.
 ::
-then on the command line (i.e. in Terminal):
-code::
-./scsynth -N Cmds.osc _ NRTout.aiff 44100 AIFF int16
-::
-The command line arguments are:
-code::
-    -N <cmd-filename> <input-filename> <output-filename> <sample-rate> <header-format> <sample-format> 	<...other scsynth arguments>
-::
-If you do not need an input sound file, then put "_" for the file name as in the example above.
 
-For details on other valid arguments to the scsynth app see Server-Architecture.
+If the server starts with the -N switch, it runs in emphasis::non-realtime:: (NRT) mode:
 
-This could be executed in SC as:
-code::
-"./scsynth -N Cmds.osc _ NRTout.aiff 44100 AIFF int16 -o 1".unixCmd; // -o 1 is mono output
+list::
+## The server processes audio as fast as possible, or as slow as necessary, depending only on workload. There is no attempt to synchronize with any other time reference.
+## The server takes commands only from a file of OSC commands (a "score"), prepared in advance.
+## There is no network connection and no interaction with the process while it is running.
 ::
-A more powerful option is to use the link::Classes/Score:: object, which has convenience methods to create OSC command files and do nrt synthesis.
+
+Strong::When to use NRT mode: :: If the audio processing can be arranged fully in advance, and you need "faster-than-light" processing (or the processing is too heavy to complete in real time), NRT may be appropriate.
+
+Strong::When not to use NRT mode: :: If you need to interact with the server process at specific times, NRT is not appropriate. For instance, if your code makes decisions about upcoming events based on data received from link::Classes/SendReply::, link::Classes/Bus#-get:: (teletype::/c_get::) or link::Classes/Buffer#-get:: (teletype::/b_get::), or node notification messages, these data will not be available in NRT mode.
+
+
+SECTION:: Basic usage of Score
+
+It is recommended to use a link::Classes/Score:: object to run NRT processes. A Score object:
+
+list::
+## prepares the binary OSC file for you, in the correct format;
+## manages NRT server processes;
+## can optionally play the Score, or portions of it, in real time for testing.
+::
+
 code::
 (
-x = [
+var s = Server(\nrt,
+	options: ServerOptions.new
+	.numOutputBusChannels_(2)
+	.numInputBusChannels_(2)
+);
 
-[0.0, [ \s_new, \NRTsine, 1000, 0, 0,  \freq, 1413 ]],
-[0.1, [ \s_new, \NRTsine, 1001, 0, 0,  \freq, 712 ]],
-[0.2, [ \s_new, \NRTsine, 1002, 0, 0,  \freq, 417 ]],
-[0.3, [ \s_new, \NRTsine, 1003, 0, 0,  \freq, 1238 ]],
-[0.4, [ \s_new, \NRTsine, 1004, 0, 0,  \freq, 996 ]],
-[0.5, [ \s_new, \NRTsine, 1005, 0, 0,  \freq, 1320 ]],
-[0.6, [ \s_new, \NRTsine, 1006, 0, 0,  \freq, 864 ]],
-[0.7, [ \s_new, \NRTsine, 1007, 0, 0,  \freq, 1033 ]],
-[0.8, [ \s_new, \NRTsine, 1008, 0, 0,  \freq, 1693 ]],
-[0.9, [ \s_new, \NRTsine, 1009, 0, 0,  \freq, 410 ]],
-[1.0, [ \s_new, \NRTsine, 1010, 0, 0,  \freq, 1349 ]],
-[1.1, [ \s_new, \NRTsine, 1011, 0, 0,  \freq, 1449 ]],
-[1.2, [ \s_new, \NRTsine, 1012, 0, 0,  \freq, 1603 ]],
-[1.3, [ \s_new, \NRTsine, 1013, 0, 0,  \freq, 333 ]],
-[1.4, [ \s_new, \NRTsine, 1014, 0, 0,  \freq, 678 ]],
-[1.5, [ \s_new, \NRTsine, 1015, 0, 0,  \freq, 503 ]],
-[1.6, [ \s_new, \NRTsine, 1016, 0, 0,  \freq, 820 ]],
-[1.7, [ \s_new, \NRTsine, 1017, 0, 0,  \freq, 1599 ]],
-[1.8, [ \s_new, \NRTsine, 1018, 0, 0,  \freq, 968 ]],
-[1.9, [ \s_new, \NRTsine, 1019, 0, 0,  \freq, 1347 ]],
+a = Score([
+	[0.0, ['/d_recv',
+		SynthDef(\NRTsine, { |out, freq = 440|
+			Out.ar(out, SinOsc.ar(freq, 0, 0.2).dup)
+		}).asBytes
+	]],
+	[0.0, (x = Synth.basicNew(\NRTsine, s)).newMsg(args: [freq: 400])],
+	[1.0, x.freeMsg]
+]);
 
-[3.0, [\c_set, 0, 0]]
-];
-)
-::
-You can then use code::Score.write:: to convert the above to the OSC command file as follows:
-code::
-Score.write(x, "score-test.osc");
-"./scsynth -N score-test.osc _ score-test.aiff 44100 AIFF int16 -o 1".unixCmd;
-::
-Score also provides methods to do nrt synthesis directly:
-code::
-(
-var f, o;
-g = [
-	[0.1, [\s_new, \NRTsine, 1000, 0, 0, \freq, 440]],
-	[0.2, [\s_new, \NRTsine, 1001, 0, 0, \freq, 660]],
-	[0.3, [\s_new, \NRTsine, 1002, 0, 0, \freq, 220]],
-	[1, [\c_set, 0, 0]]
-	];
-o = ServerOptions.new.numOutputBusChannels = 1; // mono output
-Score.recordNRT(g, "help-oscFile.osc", "helpNRT.aiff", options: o); // synthesize
+a.recordNRT(
+	outputFilePath: "~/nrt-help.wav".standardizePath,
+	headerFormat: "wav",
+	sampleFormat: "int16",
+	options: s.options,
+	duration: 1,
+	action: { "done".postln }
+);
+
+s.remove;
 )
 ::
 
-section:: Analysis using a Non-Realtime server
+subsection:: Timed messages
+
+A new Score object needs a list of commands, with times.
+
+Each command is an array, e.g. code::['/n_set', 1000, 'gate', 0]::.
+
+Each command is bound to a time by placing it in another array, with the time (a floating point number, in beats) first:
+
+code::
+[143.2647423, ['/n_set', 1000, 'gate', 0]]
+::
+
+NOTE:: Times are adjusted for the clock's tempo. link::Classes/Score#*new:: allows you to specify a link::Classes/TempoClock::; if you don't, then code::TempoClock.default:: will be used. ::
+
+Server abstraction objects (Synth, Group, Buffer etc.) include methods to give you the OSC message. So, a Score may frequently include idioms such as:
+
+list::
+## Create a group: code::[time, Group.basicNew(s).newMsg]::
+## Create a synth: code::[time, Synth.basicNew(\defname, s).newMsg(target, args: [...])]::
+## Read a buffer from disk: code::[time, Buffer(s).allocReadMsg(path)]::
+::
+
+NOTE:: Normal usage of link::Classes/Synth:: or link::Classes/Buffer:: communicates immediately with the server: code::Synth.new(...):: transmits teletype::/s_new::; code::Buffer.alloc(s, ...):: sends teletype::/b_alloc::. To build a NRT score, create the object as a placeholder (no immediate communication) and then ask a placeholder for the message: link::Classes/Synth#*basicNew:: and link::Classes/Synth#-newMsg::, or link::Classes/Buffer#*new:: and link::Classes/Buffer#-allocMsg:: or link::Classes/Buffer#-allocReadMsg::. If you have only used real-time synthesis, this code style is unfamiliar, but it's worth practicing. ::
+
+Note:: The result of, e.g., teletype::newMsg:: is already the array representing the message. So it is sufficient for each Score item to be an array containing the time and method call. The subarray should be explicit only when writing the message by hand. ::
+
+Consult help files for the server abstraction classes for additional "...Msg" methods.
+
+If you save the code::Synth.basicNew(...):: instance in a variable, then you can free it later using either link::Classes/Node#-freeMsg:: or link::Classes/Node#-releaseMsg::, e.g.:
+
+code::
+[1.0, (x = Synth.basicNew(\default, s)).newMsg(args: [freq: 200])],
+[2.0, x.releaseMsg]
+::
+
+For link::Classes/SynthDef::, there is no 'addMsg' or 'recvMsg' method. The simplest form is:
+
+code::
+[0.0, ['/d_recv', SynthDef(...).asBytes]]
+::
+
+subsection:: recordNRT
+
+To render the Score, use the link::Classes/Score#-recordNRT:: method.
+
+code::
+(
+a = Score(...);
+
+a.recordNRT(
+	oscFilePath: ,
+	outputFilePath: ,
+	inputFilePath: ,
+	sampleRate: ,
+	headerFormat: ,
+	sampleFormat: ,
+	options: ,
+	completionString: ,
+	duration: ,
+	action: 
+);
+)
+::
+
+definitionlist::
+## oscFilePath || Recommended to omit (leave as teletype::nil::). Score will generate a temporary filename  for you.
+## outputFilePath || The output audio file that you want (full path).
+## inputFilePath || Optional. If you provide an existing audio file, its contents will stream to the NRT server's hardware input buses.
+## sampleRate || Output file sample rate.
+## headerFormat || See link::Classes/SoundFile#-headerFormat::.
+## sampleFormat || See link::Classes/SoundFile#-sampleFormat::.
+## options || An instance of link::Classes/ServerOptions::. In particular, this is important to set the desired number of output channels, e.g. code::ServerOptions.new.numOutputBusChannels_(2)::.
+## completionString || Undocumented. No apparent purpose.
+## duration || The desired total length of the output file, in seconds.
+## action || A function to evaluate when rendering is complete.
+::
+
+Of these, teletype::outputFilePath::, teletype::options:: and teletype::duration:: are particularly important. Make sure you specify at least these.
+
+NOTE:: NRT processing continues until the last timestamp in the score file. If you specify a teletype::duration:: for recordNRT, Score will automatically append a dummy command at the end of the score, with the given timestamp, ensuring that the output file will be at least this long. ::
+
+If you are repeatedly rendering NRT scores, you can set code::Score.options = ServerOptions.new...:: and teletype::recordNRT:: will use this set of server options by default.
+
+subsection:: Server instance
+
+If you want to use server abstraction objects (e.g. Synth, Group, Buffer), you might also want them to allocate node IDs or buffer and bus numbers for you. link::Classes/Synth#*basicNew:: and link::Classes/Buffer#*new:: use the server's allocators if you don't supply an ID (leave it nil). However, if you accidentally use the default server, any IDs you allocate for NRT will be marked as "used" in the default, real-time server. To avoid this, you can create a separate Server instance, just for producing the Score, and then remove the instance after rendering. This is a client-only object; you don't need to boot it.
+
+The Examples section demonstrates.
+
+subsection:: Server resources
+
+A NRT server is emphasis::a separate server process:: from any other. Every time you run a Score, it launches a brand-new server process. Each new server starts with a blank slate. In particular, any SynthDefs you have added or Buffers you have loaded are not automatically available to the new server.
+
+Therefore, emphasis::your Score must include instructions to prepare these resources::.
+
+It is a very common mistake to load a buffer into a real-time server, and then run a non-realtime server, and find that resources are not available. For instance, this example adds a SynthDef in the normal way (added in memory only), and the SynthDef is not automatically transferred to the NRT server.
+
+code::
+// INCORRECT
+(
+SynthDef(\NRTsine, { |out, freq = 440|
+	Out.ar(out, SinOsc.ar(freq, 0, 0.2).dup)
+}).add;
+)
+
+(
+var s = Server(\nrt,
+	options: ServerOptions.new
+	.numOutputBusChannels_(2)
+	.numInputBusChannels_(2)
+);
+
+a = Score([
+	[0.0, (x = Synth.basicNew(\NRTsine, s, 1000)).newMsg(args: [freq: 400])],
+	[1.0, x.freeMsg]
+]);
+
+a.recordNRT(
+	outputFilePath: PathName.tmp +/+ "nrt-help-fail.wav",
+	headerFormat: "wav",
+	sampleFormat: "int16",
+	options: s.options,
+	duration: 1,
+	action: { "done".postln }
+);
+
+s.remove;
+)
+::
+
+teletype::
+->
+nextOSCPacket 0
+*** ERROR: SynthDef NRTsine not found
+FAILURE IN SERVER /s_new SynthDef not found
+::
+
+code::
+File.delete(PathName.tmp +/+ "nrt-help-fail.wav");
+::
+
+NOTE:: Some other tutorials about NRT synthesis use link::Classes/SynthDef#-writeDefFile:: to avoid this problem. This works by writing the SynthDef into the default SynthDef directory; then, the NRT server reads SynthDefs from the default location when it starts up. This approach is perfectly valid, but has the disadvantage of leaving teletype::.scsyndef:: files on disk that you might not need later. For that reason, this document demonstrates how to make SynthDefs available to NRT servers without using disk files. ::
+
+The good news is that a NRT server does not have to wait for "heavy" operations like receiving SynthDefs or loading buffers. Commands that are considered "asynchronous" in a real-time server behave as synchronous commands in NRT. So, you can simply front-load your Score with all the SynthDefs and Buffers, at time 0.0, and then start the audio processing also at time 0.0. The following examples demonstrate.
+
+section:: Examples
+
+subsection:: Algorithmic generation of Synth messages
+
+The preceding example, for simplicity, adds only one synth. Another approach is to create the initial Score with "setup" messages, and add further Synth messages for notes.
+
+code::
+(
+var s = Server(\nrt,
+	options: ServerOptions.new
+	.numOutputBusChannels_(2)
+	.numInputBusChannels_(2)
+),
+defaultGroup = Group.basicNew(s);
+
+var time = 0;
+
+x = Score([
+	[0.0, ['/d_recv',
+		SynthDef(\singrain, { |out, freq = 440, time = 0.1, amp = 0.1|
+			var eg = EnvGen.kr(Env.perc(0.01, time), doneAction: 2),
+			sig = SinOsc.ar(freq) * amp;
+			Out.ar(out, (sig * eg).dup);
+		}).asBytes
+	]],
+	[0.0, defaultGroup.newMsg]
+]);
+
+100.do {
+	x.add([time, Synth.basicNew(\singrain, s)
+		.newMsg(g, [freq: exprand(200, 800), time: exprand(0.1, 1.0)])
+	]);
+	time = time + exprand(0.02, 0.25)
+};
+
+x.recordNRT(
+	outputFilePath: "~/nrt.aiff".standardizePath,
+	sampleRate: 44100,
+	headerFormat: "AIFF",
+	sampleFormat: "int16",
+	options: s.options,
+	duration: x.endTime + 1
+);
+
+s.remove;
+)
+::
+
+subsection:: NRT processing of an audio file
+
+Applying a custom effect to a very long audio file is an especially good use of NRT: create a Score that defines an effect SynthDef and runs it for the duration of of the input file. You can use teletype::recordNRT::'s input file parameter to pipe the source audio to the NRT server's hardware inputs, and read it with link::Classes/SoundIn::.
+
+The example audio file is not very long, but processing here is almost instantaneous.
+
+code::
+(
+var s,
+inputFile = SoundFile.openRead(Platform.resourceDir +/+ "sounds/a11wlk01.wav");
+
+inputFile.close;  // doesn't need to stay open; we just need the stats
+
+s = Server(\nrt,
+	options: ServerOptions.new
+	.numOutputBusChannels_(2)
+	.numInputBusChannels_(inputFile.numChannels)
+);
+
+x = Score([
+	[0.0, ['/d_recv',
+		SynthDef(\fft, {
+			var in = SoundIn.ar([0]),
+			fft = FFT(LocalBuf(1024, 1), in);
+			fft = PV_Freeze(fft, ToggleFF.kr(Dust.kr(12)));
+			Out.ar(0, IFFT(fft).dup)
+		}).asBytes
+	]],
+	[0.0, Synth.basicNew(\fft, s).newMsg]
+]);
+
+x.recordNRT(
+	outputFilePath: "~/nrt.aiff".standardizePath,
+	inputFilePath: inputFile.path,
+	sampleRate: 44100,
+	headerFormat: "AIFF",
+	sampleFormat: "int16",
+	options: s.options,
+	duration: inputFile.duration
+);
+
+s.remove;
+)
+::
+
+subsection:: Generating NRT scores from patterns
+
+Event patterns can be converted into Scores by teletype::asScore::.
+
+First, a simple example using the default SynthDef. This example does not require any extra resources.
+
+code::
+(
+var s = Server(\nrt,
+	options: ServerOptions.new
+	.numOutputBusChannels_(2)
+	.numInputBusChannels_(2)
+);
+
+x = Pbind(
+	\freq, Pexprand(200, 800, inf),
+	\dur, Pexprand(0.8, 1.25, inf) * Pgeom(0.01, 1.0143978590819, 400),
+	\legato, 3,
+).asScore(120);
+
+x.recordNRT(
+	outputFilePath: "~/nrt.aiff".standardizePath,
+	sampleRate: 44100,
+	headerFormat: "AIFF",
+	sampleFormat: "int16",
+	options: s.options,
+	duration: 120
+);
+
+s.remove;
+)
+::
+
+It is somewhat trickier to use Buffers and custom SynthDefs with pattern-generated Scores. It's possible to build the Score by teletype::asScore::, add setup instructions at time 0.0, and sort the commands in time order. But if the events also begin at time 0.0, sorting the score is not guaranteed to put the setup commands first. As a workaround, you can specify a short time offset in teletype::asScore::.
+
+code::
+(
+var s = Server(\nrt,
+	options: ServerOptions.new
+	.numOutputBusChannels_(2)
+	.numInputBusChannels_(2)
+),
+def = SynthDef(\buf1, { |out, bufnum, rate = 1, time = 0.1, start = 0, amp = 0.1|
+	var eg = EnvGen.kr(Env.perc(0.01, time), doneAction: 2),
+	sig = PlayBuf.ar(1, bufnum, rate, startPos: start);
+	Out.ar(out, (sig * (eg * amp)).dup);
+}),
+// the pattern needs a placeholder for the buffer
+buf = Buffer.new(s, 0, 1);
+
+def.add;  // the pattern needs the def in the SynthDescLib
+
+x = Pbind(
+	\instrument, \buf1,
+	\bufnum, buf,
+	\rate, Pexprand(0.5, 2, inf),
+	\start, Pwhite(0, 50000, inf),
+	\time, 0.1,
+	\dur, Pexprand(0.05, 0.5, inf),
+	\legato, 3,
+).asScore(duration: 20, timeOffset: 0.001);
+
+// the score also needs the def and buffer
+x.add([0.0, [\d_recv, def.asBytes]]);
+x.add([0.0, buf.allocReadMsg(Platform.resourceDir +/+ "sounds/a11wlk01.wav")]);
+x.sort;
+
+x.recordNRT(
+	outputFilePath: "~/nrt.aiff".standardizePath,
+	sampleRate: 44100,
+	headerFormat: "AIFF",
+	sampleFormat: "int16",
+	options: s.options,
+	duration: 20
+);
+
+s.remove;
+)
+::
+
+subsection:: Analysis using a Non-Realtime server
 
 An NRT server may also be used to extract analytical data from a sound file. The main issues are:
 
-DEFINITIONlIST::
+definitionlist::
 ## Suppressing audio file output
 || In macOS and Linux environments, use teletype::/dev/null:: for the output file path. In Windows, use teletype::NUL::.
 ## Retrieving analytical data.
@@ -174,4 +455,44 @@ fork {
 	data.postln;  // these are your onsets!
 };
 )
+::
+
+section:: OSC file format
+
+If, for some reason, you need to write the OSC command file yourself without using Score, the general method is:
+
+numberedlist::
+## Open a file for writing: code::File(path, "w")::.
+## For each OSC command:
+numberedlist::
+## Create the command as an array, and save it in a variable such as teletype::cmd::.
+## Convert to binary: code::cmd = cmd.asRawOSC;::
+## Write the byte size as an integer: code::file.write(cmd.size);::
+## Write the binary command: code::file.write(cmd);::
+::
+::
+
+code::
+f = File(PathName.tmp +/+ "Cmds.osc", "w");
+
+// start a sine oscillator at 0.2 seconds.
+c = [0.2, [\s_new, \default, 1001, 0, 0]].asRawOSC;
+f.write(c.size); // each bundle is preceded by a 32 bit size.
+f.write(c); // write the bundle data.
+
+// stop sine oscillator at 3.0 seconds.
+c = [3.0, [\n_free, 1001]].asRawOSC;
+f.write(c.size);
+f.write(c);
+
+// scsynth stops processing immediately after the last command, so here is
+// a do-nothing command to mark the end of the command stream.
+c = [3.2, [0]].asRawOSC;
+f.write(c.size);
+f.write(c);
+
+f.close;
+
+// after rendering, always remember to clean up your mess:
+File.delete(PathName.tmp +/+ "Cmds.osc");
 ::


### PR DESCRIPTION
Purpose and Motivation
----------------------

sc-users discussion turned up that the current NRT guide document is not really informative, maybe even misleading, for users new to NRT processing.

This is a draft at an almost complete rewrite.

Fixes #3916.

Types of changes
----------------

- Documentation (non-code change which corrects or adds documentation for existing features)

Checklist
---------

- [x] Updated documentation, if necessary
- [x] This PR is ready for review (maybe?)

Remaining Work
-------------

I have not extensively proofread.

Possibly some of the contents might be reordered.

I encourage revisions from other authors. Brian suggested that I push the branch directly to supercollider/supercollider so that other authors could contribute.

At first glance, the code style in the examples might seem a little fussy. But I think it's useful to write them this way. NRT poses a relatively high number of hidden "gotchas" and I've written these examples specifically to avoid those traps (such as, accidentally using allocators from the default real-time server, or leaving stray .scsyndef files around, or explicitly writing an OSC command file and not cleaning it up). I'm trying to suggest some best practices which, if users new to NRT copy/paste and modify, might help them avoid pitfalls. If this seems unusual or maybe presumptuous, it might be because we have never (in the 16 years I've been involved) discussed any NRT best practices! I wouldn't be surprised if there's some disagreement.

It might be worth mentioning the Ctk quark... I'm not sure.