### PR TITLE
[scide] ui colors now reflect editor colors in settings

### DIFF
--- a/editors/sc-ide/core/main.cpp
+++ b/editors/sc-ide/core/main.cpp
@@ -26,7 +26,6 @@
 #include "../widgets/help_browser.hpp"
 #include "../widgets/lookup_dialog.hpp"
 #include "../widgets/code_editor/highlighter.hpp"
-#include "../widgets/style/style.hpp"
 #include "../../../QtCollider/hacks/hacks_mac.hpp"
 #include "../primitives/localsocket_utils.hpp"
 
@@ -80,17 +79,37 @@ int main( int argc, char *argv[] )
     scideTranslator.load( ideTranslationFile, ideTranslationPath );
     app.installTranslator(&scideTranslator);
 
+    // Load settings so that we can copy editor color values into the UI colors,
+    // which must be set before window is created.
+    Main *main = Main::instance();
+    Settings::Manager *settings = main->settings();
+
+    const QTextCharFormat *format = &settings->getThemeVal("text");
+    QBrush text_background = format->background();
+    QBrush text_foreground = format->foreground();
+
+    // Palette must be set before style, for consistent application.
+    app.setPalette(QPalette(
+        text_foreground,    // windowText
+        text_background,    // button
+        text_background,    // light
+        text_background,    // dark
+        text_background,    // mid
+        text_foreground,    // text
+        text_foreground,    // bright_text
+        text_background,    // base
+        text_background     // window
+    ));
+
     // Set up style
     app.setStyle( new ScIDE::Style(app.style()) );
 
     // Go...
-    Main * main = Main::instance();
     MainWindow *win = new MainWindow(main);
 
     app.setWindowIcon(QIcon("qrc:///icons/sc-ide-svg"));
 
     // NOTE: load session after GUI is created, so that GUI can respond
-    Settings::Manager *settings = main->settings();
     SessionManager *sessions = main->sessionManager();
 
     // NOTE: window has to be shown before restoring its geometry,

--- a/editors/sc-ide/core/main.cpp
+++ b/editors/sc-ide/core/main.cpp
@@ -297,6 +297,7 @@ void Main::setAppPaletteFromSettings() {
     }
 
     QBrush clamp_fg = text_fg;
+    QBrush clamp_highlight = active_bg;
 
 #ifdef Q_OS_MACOS
     // On OS X Qt uses Cocoa-style native buttons, which are currently rendered
@@ -308,6 +309,15 @@ void Main::setAppPaletteFromSettings() {
         clamp_fg = QColor::fromHsv(clamp_fg.color().hue(),
                                    clamp_fg.color().saturation(),
                                    127);
+    }
+    
+    // We must also do the same for the highlight color, which renders against
+    // some hard-coded white backgrounds like in the theme option picker.
+    if (clamp_highlight.color().value() > 127) {
+        clamp_highlight = QColor::fromHsv(clamp_highlight.color().hue(),
+                                          clamp_highlight.color().saturation(),
+                                          127);
+        
     }
 #endif
 
@@ -332,8 +342,8 @@ void Main::setAppPaletteFromSettings() {
     // Set a few other colors, namely the foreground color of disabled text
     // and the selection background color.
     palette.setBrush(QPalette::Disabled, QPalette::Text, disabled_fg);
-    palette.setBrush(QPalette::Normal, QPalette::Highlight, active_bg);
-    palette.setBrush(QPalette::Normal, QPalette::HighlightedText, text_fg);
+    palette.setBrush(QPalette::Normal, QPalette::Highlight, clamp_highlight);
+    palette.setBrush(QPalette::Normal, QPalette::HighlightedText, clamp_fg);
 
     qApp->setPalette(palette);
 }

--- a/editors/sc-ide/core/main.cpp
+++ b/editors/sc-ide/core/main.cpp
@@ -250,24 +250,25 @@ void Main::setAppPaletteFromSettings() {
     QBrush text_bg = format->background();
     QBrush text_fg = format->foreground();
 
-    QBrush mid_bg, dark_bg;
-    // If the text is darker than the background we we create contrast colors
-    // that are darker in value than the background, otherwise we do the
-    // opposite.
+    QBrush active_bg, inactive_bg;
+    // If we are using a dark text on light background we use the light background
+    // color for active tabs, and darken it somewhat for inactive tabs.
     if (text_fg.color().value() < text_bg.color().value()) {
-        mid_bg = QBrush(text_bg.color().darker(200));
-        dark_bg = QBrush(text_bg.color().darker(300));
+        active_bg = text_bg;
+        inactive_bg = QBrush(text_bg.color().darker(125));
     } else {
+        // When using light text on a dark background the active tab pops more
+        // as a lighter version of the background color.
+        inactive_bg = text_bg;
+
         // QtColor::lighter() multiplies the value of the color by the provided
         // percentage factor, so if the value is zero it has no effect. In that
         // case we darken the foreground color, since hue information is lost
         // in maximum black.
         if (text_bg.color().value() > 0) {
-            mid_bg = QBrush(text_bg.color().lighter(200));
-            dark_bg = QBrush(text_bg.color().lighter(300));
+            active_bg = QBrush(text_bg.color().lighter(150));
         } else {
-            mid_bg = QBrush(text_fg.color().darker(500));
-            dark_bg = QBrush(text_fg.color().darker(1000));
+            active_bg = QBrush(text_fg.color().darker(300));
         }
     }
 
@@ -291,18 +292,18 @@ void Main::setAppPaletteFromSettings() {
                        //    bars, and most non-bold text in controls, including
                        //    the selector buttons at the top of the editor
                        //    settings tab.
-        text_bg,       // button - background color of active tab.
+        active_bg,     // button - background color of *active* tab.
         text_fg,       // light - no observed use in current ui.
-        dark_bg,       // dark - color for dividers around tabs, the background
+        inactive_bg,   // dark - color for dividers around tabs, the background
                        //     color around the Auto Scroll button, and selection
                        //     background color in the settings tab menu.
-        mid_bg,        // mid - background color for the help and log dock bars
-                       //     as well as inactive tabs.
+        inactive_bg,   // mid - background color for the help and log dock bars
+                       //     as well as *inactive* tabs.
         clamp_fg,      // text - text color for home and autoscroll dock bars,
                        //     tab selector names in settings, and most buttons.
         text_fg,       // bright_text - no observed use in current UI.
         text_bg,       // base - no observed use in current UI.
-        mid_bg         // window - background color of settings window and the color
+        text_bg        // window - background color of settings window and the color
                        //     of the frame drawn around the editor widgets.
     ));
 }

--- a/editors/sc-ide/core/main.cpp
+++ b/editors/sc-ide/core/main.cpp
@@ -79,11 +79,8 @@ int main( int argc, char *argv[] )
     scideTranslator.load( ideTranslationFile, ideTranslationPath );
     app.installTranslator(&scideTranslator);
 
-    // Load settings so that we can copy editor color values into the UI colors,
-    // which must be set before window is created.
-    Main *main = Main::instance();
-
     // Palette must be set before style, for consistent application.
+    Main *main = Main::instance();
     main->setAppPaletteFromSettings();
 
    // Set up style
@@ -95,6 +92,7 @@ int main( int argc, char *argv[] )
     app.setWindowIcon(QIcon("qrc:///icons/sc-ide-svg"));
 
     // NOTE: load session after GUI is created, so that GUI can respond
+    Settings::Manager *settings = main->settings();
     SessionManager *sessions = main->sessionManager();
 
     // NOTE: window has to be shown before restoring its geometry,
@@ -102,7 +100,6 @@ int main( int argc, char *argv[] )
     // been saved un-maximized.
     win->show();
 
-    Settings::Manager *settings = main->settings();
     QString startSessionName = settings->value("IDE/startWithSession").toString();
     if (startSessionName == "last") {
         QString lastSession = sessions->lastSession();

--- a/editors/sc-ide/core/main.cpp
+++ b/editors/sc-ide/core/main.cpp
@@ -41,6 +41,7 @@
 #include <QLibraryInfo>
 #include <QTranslator>
 #include <QDebug>
+#include <QStyleFactory>
 
 using namespace ScIDE;
 
@@ -79,11 +80,14 @@ int main( int argc, char *argv[] )
     scideTranslator.load( ideTranslationFile, ideTranslationPath );
     app.installTranslator(&scideTranslator);
 
+    // Force Fusion style to appear consistently on all platforms.
+    app.setStyle(QStyleFactory::create("Fusion"));
+
     // Palette must be set before style, for consistent application.
     Main *main = Main::instance();
     main->setAppPaletteFromSettings();
 
-   // Set up style
+    // Install style proxy.
     app.setStyle( new ScIDE::Style(app.style()) );
 
     // Go...
@@ -249,15 +253,13 @@ void Main::setAppPaletteFromSettings() {
 
     int value_difference = text_bg.color().value() - text_fg.color().value();
     if (std::abs(value_difference) < 32) {
-        // If we are on the darker end of the spectrum we lighten the background,
-        // to avoid interfering with color clamping of foreground text on OS X.
+        // If we are on the darker end of the spectrum we lighten the background.
         if (text_bg.color().value() < 127) {
             text_bg = QColor::fromHsv(text_bg.color().hue(),
                                       text_bg.color().saturation(),
                                       text_bg.color().value() + 32 - value_difference);
         } else {
-            // Otherwise we can darken the foreground color, once gain in keeping
-            // with the idea we don't want to overly lighten foreground text colors.
+            // Otherwise we can darken the foreground color.
             text_fg = QColor::fromHsv(text_fg.color().hue(),
                                       text_fg.color().saturation(),
                                       text_fg.color().value() - (32 - value_difference));
@@ -298,28 +300,6 @@ void Main::setAppPaletteFromSettings() {
 
     QBrush clamp_fg = text_fg;
     QBrush clamp_highlight = active_bg;
-
-#ifdef Q_OS_MACOS
-    // On OS X Qt uses Cocoa-style native buttons, which are currently rendered
-    // with a hard-coded white background. If we are using a light text on dark
-    // background themes this means the text can be washed out and not readable
-    // on the controls. For this platform we therefore clamp the text color to
-    // be at most half value.
-    if (clamp_fg.color().value() > 127) {
-        clamp_fg = QColor::fromHsv(clamp_fg.color().hue(),
-                                   clamp_fg.color().saturation(),
-                                   127);
-    }
-    
-    // We must also do the same for the highlight color, which renders against
-    // some hard-coded white backgrounds like in the theme option picker.
-    if (clamp_highlight.color().value() > 127) {
-        clamp_highlight = QColor::fromHsv(clamp_highlight.color().hue(),
-                                          clamp_highlight.color().saturation(),
-                                          127);
-        
-    }
-#endif
 
     QPalette palette(
         clamp_fg,         // windowText - text color for active and inactive tab

--- a/editors/sc-ide/core/main.cpp
+++ b/editors/sc-ide/core/main.cpp
@@ -247,7 +247,7 @@ void Main::setAppPaletteFromSettings() {
     QBrush text_bg = format->background();
     QBrush text_fg = format->foreground();
 
-    int value_difference = text_bg.color().value - text_fg.color().value();
+    int value_difference = text_bg.color().value() - text_fg.color().value();
     if (std::abs(value_difference) < 32) {
         // If we are on the darker end of the spectrum we lighten the background,
         // to avoid interfering with color clamping of foreground text on OS X.
@@ -305,7 +305,7 @@ void Main::setAppPaletteFromSettings() {
     // on the controls. For this platform we therefore clamp the text color to
     // be at most half value.
     if (clamp_fg.color().value() > 127) {
-        clamp_fg = QColor::fromHsv(clamp_fg.color().hue()
+        clamp_fg = QColor::fromHsv(clamp_fg.color().hue(),
                                    clamp_fg.color().saturation(),
                                    127);
     }

--- a/editors/sc-ide/core/main.cpp
+++ b/editors/sc-ide/core/main.cpp
@@ -250,19 +250,20 @@ void Main::setAppPaletteFromSettings() {
     QBrush text_bg = format->background();
     QBrush text_fg = format->foreground();
 
-    if (std::abs(text_bg.color().value() - text_fg.color().value()) < 16) {
+    int value_difference = text_bg.color().value - text_fg.color().value();
+    if (std::abs(value_difference) < 32) {
         // If we are on the darker end of the spectrum we lighten the background,
         // to avoid interfering with color clamping of foreground text on OS X.
         if (text_bg.color().value() < 127) {
             text_bg = QColor::fromHsv(text_bg.color().hue(),
                                       text_bg.color().saturation(),
-                                      text_bg.color().value() + 32);
+                                      text_bg.color().value() + 32 - value_difference);
         } else {
             // Otherwise we can darken the foreground color, once gain in keeping
             // with the idea we don't want to overly lighten foreground text colors.
             text_fg = QColor::fromHsv(text_fg.color().hue(),
                                       text_fg.color().saturation(),
-                                      text_fg.color().value() - 32);
+                                      text_fg.color().value() - (32 - value_difference));
         }
     }
 

--- a/editors/sc-ide/core/main.hpp
+++ b/editors/sc-ide/core/main.hpp
@@ -87,7 +87,7 @@ public:
     {
         instance()->scProcess()->evaluateCode(text, silent);
     }
-    
+
     static void evaluateCodeIfCompiled(QString const & text, bool silent = false)
     {
         if(instance()->scProcess()->compiled())
@@ -108,27 +108,12 @@ public Q_SLOTS:
 
     void applySettings() {
         Q_EMIT(applySettingsRequest(mSettings));
-
-        const QTextCharFormat *format = &mSettings->getThemeVal("text");
-        QBrush text_background = format->background();
-        QBrush text_foreground = format->foreground();
-
-        qApp->setPalette(QPalette(
-            text_foreground,    // windowText
-            text_background,    // button
-            text_background,    // light
-            text_background,    // dark
-            text_background,    // mid
-            text_foreground,    // text
-            text_foreground,    // bright_text
-            text_background,    // base
-            text_background     // window
-        ));
-
+        setAppPaletteFromSettings();
         qApp->setStyle(qApp->style());
     }
 
     void quit();
+    void setAppPaletteFromSettings();
 
 Q_SIGNALS:
     void storeSettingsRequest(Settings::Manager *);
@@ -138,7 +123,7 @@ private:
     Main(void);
     bool eventFilter(QObject *obj, QEvent *event);
     bool nativeEventFilter(const QByteArray&, void* message, long*);
-    
+
     Settings::Manager *mSettings;
     ScProcess * mScProcess;
     ScServer * mScServer;

--- a/editors/sc-ide/core/main.hpp
+++ b/editors/sc-ide/core/main.hpp
@@ -31,6 +31,7 @@
 #include "sc_server.hpp"
 #include "doc_manager.hpp"
 #include "settings/manager.hpp"
+#include "../widgets/style/style.hpp"
 
 namespace ScIDE {
 
@@ -107,6 +108,24 @@ public Q_SLOTS:
 
     void applySettings() {
         Q_EMIT(applySettingsRequest(mSettings));
+
+        const QTextCharFormat *format = &mSettings->getThemeVal("text");
+        QBrush text_background = format->background();
+        QBrush text_foreground = format->foreground();
+
+        qApp->setPalette(QPalette(
+            text_foreground,    // windowText
+            text_background,    // button
+            text_background,    // light
+            text_background,    // dark
+            text_background,    // mid
+            text_foreground,    // text
+            text_foreground,    // bright_text
+            text_background,    // base
+            text_background     // window
+        ));
+
+        qApp->setStyle(qApp->style());
     }
 
     void quit();


### PR DESCRIPTION
Purpose and Motivation
----------------------
Fixes #3792, this forces the UI colors to track the changes to the colors
in the settings menu. We set the colors on startup as well as update the colors
each time the settings are applied.

Types of changes
----------------
- New feature (non-breaking change which adds functionality) 

Checklist
---------

- [X] All tests are passing
- [ ] Updated documentation, if necessary
- [x] This PR is ready for review

Remaining Work
-------------
None known.
