### PR TITLE
SimpleNumber.schelp: Fix link to "Classes/String#-asSecs"

### DIFF
--- a/HelpSource/Classes/SimpleNumber.schelp
+++ b/HelpSource/Classes/SimpleNumber.schelp
@@ -369,7 +369,7 @@ Converts this into an audiorate input.
 
 method:: asTimeString
 Produces a time string in the format code::ddd:hh:mm:ss.sss::, interpreting the receiver as time in
-seconds. See link::String#-asSecs:: for the inverse function.
+seconds. See link::Classes/String#-asSecs:: for the inverse function.
 argument:: precision
 accuracy of the millisecond format; the string will always be formatted with 3 decimal places for
 milliseconds. Minimum value: 0.001.


### PR DESCRIPTION
The link to "String#-asSecs" currently misses the reference to "Classes/".
Help browser throws
```
WARNING: SCDoc: In /Users/mz/dev/sc3.git/3.9/build/Install/SuperCollider/SuperCollider.app/Contents/Resources/HelpSource/Classes/SimpleNumber.schelp
  Broken link: 'String#-asSecs'
```
error.

Types of changes
----------------
inserted "Classes/" reference in link to "String#-asSecs".
