### PR TITLE
[IDE] fix shift-enter behavior in IDE

### DIFF
--- a/.travis/before-install-linux.sh
+++ b/.travis/before-install-linux.sh
@@ -6,7 +6,7 @@ sudo add-apt-repository --yes ppa:beineri/opt-qt591-trusty
 sudo apt-get update
 sudo apt-get install --yes build-essential gcc-4.9 g++-4.9 cmake pkg-config libjack-jackd2-dev libsndfile1-dev libasound2-dev libavahi-client-dev libreadline6-dev libfftw3-dev libicu-dev libxt-dev libudev-dev
 if [[ -n "$1" && "$1" == "--qt=true" ]]; then
-	sudo apt-get install --yes libgl1-mesa-dev qt59base qt59location qt59declarative qt59tools qt59webengine qt59webchannel qt59xmlpatterns qt59svg
+	sudo apt-get install --yes libgl1-mesa-dev qt59base qt59location qt59declarative qt59tools qt59webengine qt59webchannel qt59xmlpatterns qt59svg qt59websockets
 fi
 sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.9 60 --slave /usr/bin/g++ g++ /usr/bin/g++-4.9
 sudo update-alternatives --auto gcc

--- a/HelpSource/editor.js
+++ b/HelpSource/editor.js
@@ -30,7 +30,7 @@ const init = () => {
             viewportMargin: Infinity,
             extraKeys: { 
                 'Cmd-Enter': () => selectRegion(),
-                'Shift-Enter': () => selectLine()
+                'Shift-Enter': () => evalLine()
             }
         })
 
@@ -129,7 +129,12 @@ const selectRegion = (options = { flash: true }) => {
     }
 }
 
-/* returns the code selection or line */
+const evalLine = () => {
+    // Ask IDE to eval line. Calls back to `selectLine()`
+    window.IDE.evaluateLine();
+}
+
+// Returns the code selection or line
 const selectLine = (options = { flash: true }) => {
     let range = window.getSelection().getRangeAt(0)
     let textarea = range.startContainer.parentNode.previousSibling

--- a/HelpSource/scdoc.js
+++ b/HelpSource/scdoc.js
@@ -193,3 +193,35 @@ function fixTOC() {
         set_up_toc();
     }
 }
+
+// Set up a QWebChannel for communicating with C++ IDE objects. The main app publishes a handle
+// to IDE functionality at "IDE" which is made globally available here after the page and
+// WebSocket have loaded.
+function setUpWebChannel() {
+    if (location.search != "")
+        var baseUrl = (/[?&]webChannelBaseUrl=([A-Za-z0-9\-:/\.]+)/.exec(location.search)[1]);
+    else
+        var baseUrl = "ws://localhost:12344";
+
+    var socket = new WebSocket(baseUrl);
+    socket.onclose = function() { };
+    socket.onerror = function(error) {
+        console.error("WebChannel error: " + error);
+    };
+    socket.onopen = function() {
+        new QWebChannel(socket, function(channel) {
+            // make help browser globally accessible
+            window.IDE = channel.objects.IDE;
+        });
+    }
+}
+
+// Fixes the TOC and sets up the QWebChannel for communicating back to C++ code
+function didLoadRenderedWindow() {
+    fixTOC();
+
+    // Check that webchannel.js was loaded
+    if(typeof QWebChannel !== "undefined") {
+        setUpWebChannel();
+    }
+}

--- a/HelpSource/scdoc.js
+++ b/HelpSource/scdoc.js
@@ -212,12 +212,9 @@ function setUpWebChannel() {
     }
 }
 
-// Fixes the TOC and sets up the QWebChannel for communicating back to C++ code
-function didLoadRenderedWindow() {
-    fixTOC();
-
+$(function () {
     // Check that webchannel.js was loaded
     if(typeof QWebChannel !== "undefined") {
         setUpWebChannel();
     }
-}
+});

--- a/HelpSource/scdoc.js
+++ b/HelpSource/scdoc.js
@@ -198,11 +198,7 @@ function fixTOC() {
 // to IDE functionality at "IDE" which is made globally available here after the page and
 // WebSocket have loaded.
 function setUpWebChannel() {
-    if (location.search != "")
-        var baseUrl = (/[?&]webChannelBaseUrl=([A-Za-z0-9\-:/\.]+)/.exec(location.search)[1]);
-    else
-        var baseUrl = "ws://localhost:12344";
-
+    var baseUrl = "ws://localhost:12344";
     var socket = new WebSocket(baseUrl);
     socket.onclose = function() { };
     socket.onerror = function(error) {

--- a/README_LINUX.md
+++ b/README_LINUX.md
@@ -86,13 +86,13 @@ On Xenial:
 
     sudo apt-add-repository ppa:beineri/opt-qt-5.11.0-xenial
     sudo apt-get update
-    sudo apt-get install qt511base qt511location qt511declarative qt511tools qt511webchannel qt511xmlpatterns qt511svg qt511webengine
+    sudo apt-get install qt511base qt511location qt511declarative qt511tools qt511webchannel qt511xmlpatterns qt511svg qt511webengine qt511websockets
 
 On Trusty, only Qt 5.10 and below are available:
 
     sudo apt-add-repository ppa:beineri/opt-qt-5.10.1-trusty
     sudo apt-get update
-    sudo apt-get install qt510base qt510location qt510declarative qt510tools qt510webchannel qt510xmlpatterns qt510svg qt510webengine
+    sudo apt-get install qt510base qt510location qt510declarative qt510tools qt510webchannel qt510xmlpatterns qt510svg qt510webengine qt510websockets
 
 [Stephan Binner's Launchpad PPAs]: https://launchpad.net/~beineri
 

--- a/SCClassLibrary/SCDoc/SCDoc.sc
+++ b/SCClassLibrary/SCDoc/SCDoc.sc
@@ -384,7 +384,7 @@ SCDocNode {
 SCDoc {
 
 	// Increment this whenever we make a change to the SCDoc system so that all help-files should be processed again
-	classvar version = 70;
+	classvar version = 71;
 
 	classvar <helpTargetDir;
 	classvar <helpTargetUrl;

--- a/SCClassLibrary/SCDoc/SCDoc.sc
+++ b/SCClassLibrary/SCDoc/SCDoc.sc
@@ -384,7 +384,7 @@ SCDocNode {
 SCDoc {
 
 	// Increment this whenever we make a change to the SCDoc system so that all help-files should be processed again
-	classvar version = 69;
+	classvar version = 70;
 
 	classvar <helpTargetDir;
 	classvar <helpTargetUrl;

--- a/SCClassLibrary/SCDoc/SCDocRenderer.sc
+++ b/SCClassLibrary/SCDoc/SCDocRenderer.sc
@@ -249,7 +249,7 @@ SCDocHTMLRenderer {
 		// QWebChannel access
 		<< "<script src='qrc:///qtwebchannel/qwebchannel.js' type='text/javascript'></script>\n"
 		<< "</head>\n"
-		<< "<body onload='didLoadRenderedWindow()'>\n";
+		<< "<body onload='fixTOC()'>\n";
 
 
 		displayedTitle = if(

--- a/SCClassLibrary/SCDoc/SCDocRenderer.sc
+++ b/SCClassLibrary/SCDoc/SCDocRenderer.sc
@@ -226,6 +226,8 @@ SCDocHTMLRenderer {
 			stream << doc.title << " | SuperCollider " << Main.version << " Help";
 		};
 
+		// XXX if you make changes here, make sure to also update the static HTML files
+		// (Search.html, Browse.html, etc.) if necessary.
 		stream
 		<< "</title>\n"
 		<< "<link rel='stylesheet' href='" << baseDir << "/scdoc.css' type='text/css' />\n"
@@ -244,10 +246,10 @@ SCDocHTMLRenderer {
 		<< "</script>\n"
 		<< "<script src='" << baseDir << "/scdoc.js' type='text/javascript'></script>\n"
 		<< "<script src='" << baseDir << "/docmap.js' type='text/javascript'></script>\n" // FIXME: remove?
-		<< "</head>\n";
-
-		stream
-		<< "<body onload='fixTOC()'>\n";
+		// QWebChannel access
+		<< "<script src='qrc:///qtwebchannel/qwebchannel.js' type='text/javascript'></script>\n"
+		<< "</head>\n"
+		<< "<body onload='didLoadRenderedWindow()'>\n";
 
 
 		displayedTitle = if(

--- a/editors/sc-ide/CMakeLists.txt
+++ b/editors/sc-ide/CMakeLists.txt
@@ -112,7 +112,6 @@ set ( ide_moc_hdr
     widgets/util/color_widget.hpp
     widgets/util/docklet.hpp
     widgets/util/volume_widget.hpp
-    widgets/util/volume_widget.hpp
     widgets/util/WebSocketTransport.hpp
     widgets/util/WebSocketClientWrapper.hpp
     widgets/util/IDEWebChannelWrapper.hpp

--- a/editors/sc-ide/CMakeLists.txt
+++ b/editors/sc-ide/CMakeLists.txt
@@ -5,23 +5,34 @@ SET(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 find_package(
     Qt5 ${REQUIRED_QT_VERSION}
     COMPONENTS
-    Core
     Concurrent
+    Core
     LinguistTools
     # OpenGL
     PrintSupport
     Qml
     Quick
     Sql
+    WebChannel
     WebEngine
     WebEngineWidgets
+    WebSockets
     Widgets
     REQUIRED
 )
 
 set(QT_IDE_LIBRARIES
+    Qt5::Concurrent
+    Qt5::Core
     # Qt5::OpenGL
-    Qt5::Core Qt5::Concurrent Qt5::WebEngineWidgets Qt5::PrintSupport Qt5::Quick Qt5::Qml Qt5::Sql)
+    Qt5::PrintSupport
+    Qt5::Qml
+    Qt5::Quick
+    Qt5::Sql
+    Qt5::WebChannel
+    Qt5::WebEngineWidgets
+    Qt5::WebSockets
+)
 
 if(${CMAKE_COMPILER_IS_GNUCXX})
     add_definitions(-Wreorder)
@@ -101,6 +112,10 @@ set ( ide_moc_hdr
     widgets/util/color_widget.hpp
     widgets/util/docklet.hpp
     widgets/util/volume_widget.hpp
+    widgets/util/volume_widget.hpp
+    widgets/util/WebSocketTransport.hpp
+    widgets/util/WebSocketClientWrapper.hpp
+    widgets/util/IDEWebChannelWrapper.hpp
 
     ${CMAKE_SOURCE_DIR}/QtCollider/widgets/web_page.hpp
 )
@@ -152,6 +167,7 @@ set ( ide_src
     widgets/util/docklet.cpp
     widgets/util/volume_widget.cpp
     widgets/util/status_box.cpp
+    widgets/util/WebSocketTransport.cpp
     widgets/style/style.cpp
 
     ${CMAKE_SOURCE_DIR}/QtCollider/widgets/web_page.cpp

--- a/editors/sc-ide/core/main.cpp
+++ b/editors/sc-ide/core/main.cpp
@@ -27,6 +27,9 @@
 #include "../widgets/lookup_dialog.hpp"
 #include "../widgets/code_editor/highlighter.hpp"
 #include "../widgets/style/style.hpp"
+#include "../widgets/util/WebSocketClientWrapper.hpp"
+#include "../widgets/util/WebSocketTransport.hpp"
+#include "../widgets/util/IDEWebChannelWrapper.hpp"
 #include "../../../QtCollider/hacks/hacks_mac.hpp"
 #include "../primitives/localsocket_utils.hpp"
 
@@ -42,6 +45,7 @@
 #include <QLibraryInfo>
 #include <QTranslator>
 #include <QDebug>
+#include <QWebChannel>
 
 using namespace ScIDE;
 
@@ -123,6 +127,23 @@ int main( int argc, char *argv[] )
     bool startInterpreter = settings->value("IDE/interpreter/autoStart").toBool();
     if (startInterpreter)
         main->scProcess()->startLanguage();
+
+    // setup HelpBrowser server
+    QWebSocketServer server("SCIDE HelpBrowser Server", QWebSocketServer::NonSecureMode);
+    if (!server.listen(QHostAddress::LocalHost, 12344)) {
+        qFatal("Failed to open web socket server.");
+        return 1;
+    }
+
+    // setup comm channel
+    WebSocketClientWrapper clientWrapper(&server);
+    QWebChannel channel;
+    QObject::connect(&clientWrapper, &WebSocketClientWrapper::clientConnected,
+                     &channel, &QWebChannel::connectTo);
+
+    // publish IDE interface
+    IDEWebChannelWrapper ideWrapper{win->helpBrowserDocklet()->browser()};
+    channel.registerObject("IDE", &ideWrapper);
 
     return app.exec();
 }

--- a/editors/sc-ide/widgets/util/IDEWebChannelWrapper.hpp
+++ b/editors/sc-ide/widgets/util/IDEWebChannelWrapper.hpp
@@ -1,0 +1,48 @@
+/*
+    SuperCollider Qt IDE
+    http://www.audiosynth.com
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
+*/
+
+#pragma once
+
+#include "../help_browser.hpp"
+
+#include <QObject>
+
+namespace ScIDE {
+
+/// Exposes IDE functionality to JS in help browser widget via WebChannel
+class IDEWebChannelWrapper : public QObject {
+    Q_OBJECT
+
+public:
+    IDEWebChannelWrapper(HelpBrowser* browser):
+        m_browser{browser}
+    {}
+
+public slots:
+    void evaluateLine()
+    {
+        m_browser->evaluateSelection(false);
+    }
+
+private:
+    HelpBrowser * const m_browser;
+};
+
+} // namespace ScIDE
+

--- a/editors/sc-ide/widgets/util/WebSocketClientWrapper.hpp
+++ b/editors/sc-ide/widgets/util/WebSocketClientWrapper.hpp
@@ -1,0 +1,51 @@
+/*
+    SuperCollider Qt IDE
+    http://www.audiosynth.com
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
+*/
+
+#pragma once
+
+#include <QWebSocketServer>
+#include <QObject>
+
+#include "WebSocketTransport.hpp"
+
+namespace ScIDE {
+
+class WebSocketClientWrapper : public QObject
+{
+    Q_OBJECT
+public:
+    WebSocketClientWrapper(QWebSocketServer *server, QObject *parent = nullptr) :
+        QObject(parent),
+        m_server(server)
+    {
+        connect(server, &QWebSocketServer::newConnection,
+            this, &WebSocketClientWrapper::handleNewConnection);
+    }
+
+signals:
+    void clientConnected(WebSocketTransport *client);
+private slots:
+    void handleNewConnection() {
+        emit clientConnected(new WebSocketTransport(m_server->nextPendingConnection()));
+    }
+private:
+    QWebSocketServer *m_server;
+};
+
+} // namespace ScIDE

--- a/editors/sc-ide/widgets/util/WebSocketClientWrapper.hpp
+++ b/editors/sc-ide/widgets/util/WebSocketClientWrapper.hpp
@@ -15,6 +15,37 @@
     You should have received a copy of the GNU General Public License
     along with this program; if not, write to the Free Software
     Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
+
+    Adapted from Qt example, which is BSD-licensed:
+    https://doc.qt.io/qt-5/qtwebchannel-standalone-example.html
+
+    BSD License
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are
+    met:
+      * Redistributions of source code must retain the above copyright
+        notice, this list of conditions and the following disclaimer.
+      * Redistributions in binary form must reproduce the above copyright
+        notice, this list of conditions and the following disclaimer in
+        the documentation and/or other materials provided with the
+        distribution.
+      * Neither the name of The Qt Company Ltd nor the names of its
+        contributors may be used to endorse or promote products derived
+        from this software without specific prior written permission.
+
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+    A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+    OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+    SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+    LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+    DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+    THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #pragma once

--- a/editors/sc-ide/widgets/util/WebSocketTransport.cpp
+++ b/editors/sc-ide/widgets/util/WebSocketTransport.cpp
@@ -15,6 +15,37 @@
     You should have received a copy of the GNU General Public License
     along with this program; if not, write to the Free Software
     Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
+
+    Adapted from Qt example, which is BSD-licensed:
+    https://doc.qt.io/qt-5/qtwebchannel-standalone-example.html
+
+    BSD License
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are
+    met:
+      * Redistributions of source code must retain the above copyright
+        notice, this list of conditions and the following disclaimer.
+      * Redistributions in binary form must reproduce the above copyright
+        notice, this list of conditions and the following disclaimer in
+        the documentation and/or other materials provided with the
+        distribution.
+      * Neither the name of The Qt Company Ltd nor the names of its
+        contributors may be used to endorse or promote products derived
+        from this software without specific prior written permission.
+
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+    A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+    OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+    SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+    LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+    DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+    THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #include "WebSocketTransport.hpp"

--- a/editors/sc-ide/widgets/util/WebSocketTransport.cpp
+++ b/editors/sc-ide/widgets/util/WebSocketTransport.cpp
@@ -1,0 +1,56 @@
+/*
+    SuperCollider Qt IDE
+    http://www.audiosynth.com
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
+*/
+
+#include "WebSocketTransport.hpp"
+
+#include <QJsonDocument>
+#include <QWebSocket>
+
+namespace ScIDE {
+
+WebSocketTransport::WebSocketTransport(QWebSocket *socket)
+        : QWebChannelAbstractTransport(socket), m_socket(socket) {
+    connect(socket, &QWebSocket::textMessageReceived, this, &WebSocketTransport::textMessageReceived);
+    connect(socket, &QWebSocket::disconnected, this, &WebSocketTransport::deleteLater);
+}
+
+WebSocketTransport::~WebSocketTransport() {
+    m_socket->deleteLater();
+}
+
+void WebSocketTransport::sendMessage(const QJsonObject &message) {
+    QJsonDocument doc(message);
+    m_socket->sendTextMessage(QString::fromUtf8(doc.toJson(QJsonDocument::Compact)));
+}
+
+void WebSocketTransport::textMessageReceived(const QString &messageData) {
+    QJsonParseError error;
+    QJsonDocument message = QJsonDocument::fromJson(messageData.toUtf8(), &error);
+    if (error.error) {
+        qWarning() << "Failed to parse text message as JSON object:" << messageData
+                   << "Error is:" << error.errorString();
+        return;
+    } else if (!message.isObject()) {
+        qWarning() << "Received JSON message that is not an object: " << messageData;
+        return;
+    }
+    emit messageReceived(message.object(), this);
+}
+
+} // namespace ScIDE

--- a/editors/sc-ide/widgets/util/WebSocketTransport.hpp
+++ b/editors/sc-ide/widgets/util/WebSocketTransport.hpp
@@ -1,0 +1,46 @@
+/*
+    SuperCollider Qt IDE
+    http://www.audiosynth.com
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
+*/
+
+#pragma once
+
+#include <QWebChannelAbstractTransport>
+#include <QJsonObject>
+#include <QString>
+
+class QWebSocket;
+
+namespace ScIDE {
+
+class WebSocketTransport : public QWebChannelAbstractTransport
+{
+    Q_OBJECT
+
+public:
+    explicit WebSocketTransport(QWebSocket *socket);
+    virtual ~WebSocketTransport();
+    void sendMessage(const QJsonObject &message) override;
+
+private slots:
+    void textMessageReceived(const QString &message);
+
+private:
+    QWebSocket *m_socket;
+};
+
+} // namespace ScIDE

--- a/editors/sc-ide/widgets/util/WebSocketTransport.hpp
+++ b/editors/sc-ide/widgets/util/WebSocketTransport.hpp
@@ -15,6 +15,37 @@
     You should have received a copy of the GNU General Public License
     along with this program; if not, write to the Free Software
     Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
+
+    Adapted from Qt example, which is BSD-licensed:
+    https://doc.qt.io/qt-5/qtwebchannel-standalone-example.html
+
+    BSD License
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are
+    met:
+      * Redistributions of source code must retain the above copyright
+        notice, this list of conditions and the following disclaimer.
+      * Redistributions in binary form must reproduce the above copyright
+        notice, this list of conditions and the following disclaimer in
+        the documentation and/or other materials provided with the
+        distribution.
+      * Neither the name of The Qt Company Ltd nor the names of its
+        contributors may be used to endorse or promote products derived
+        from this software without specific prior written permission.
+
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+    A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+    OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+    SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+    LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+    DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+    THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #pragma once


### PR DESCRIPTION
Purpose and Motivation
----------------------

shift-enter needs to be intercepted at the JS level and call a slot on a
C++ object in order to evaluate a line. This shortcut isn't propagated
normally. This commit adds QWebChannel and QWebSockets to the dependencies
and uses them to allow JS to request the help browser C++ code to evaluate
a line.

Also some changes to JS code and SCDoc renderer code

Note that the WebChannel should only be loaded on pages with code to
execute.

The WebChannel is constructed in the IDE's main() and then the help browser
is published to it. On the JS side, evaluateSelection(false) is called
whenever shift-enter on a code snippet is detected.

Note that I based this off @htor's other branch, since that will be
merged soon and since I needed to interface with some of the codemirror code.

Comments on JS style/design welcome, I dunno what I'm doing there.

Fixes #3877.

Types of changes
----------------

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

Checklist
---------

- [x] All tests are passing

- [x] If necessary, new tests were created to address changes in PR (and tests are passing)

- [x] Updated documentation, if necessary

- [x] This PR is ready for review

Remaining Work
------------

- [x] ~May need to update guides since new libs are required (QWebChannel, QWebSockets).~ added qt5xxwebsockets to lists of dependencies in travis and readmes.
- [x] ~Need to check on other platforms (I don't anticipate any problems there, though)~ reportedly works fine on linux.
- [x] ~Update scdoc_version?~ updated
- [x] ~May need to credit code in the new files, which were taken with very minor edits from the Qt WebChannel Standalone Example (https://doc.qt.io/qt-5/qtwebchannel-standalone-example.html)~ included BSD license which is compatible with GPL3.

Also note that QWebChannel may open up an easy/convenient way for us to
translate configuration settings from the IDE to the browser via the
existing Qt signal/slot interface. I see no reason not to do this.