### PR TITLE
TestEvent - remove added eventType after test

### DIFF
--- a/testsuite/classlibrary/TestEvent.sc
+++ b/testsuite/classlibrary/TestEvent.sc
@@ -110,6 +110,8 @@ TestEvent : UnitTest {
 		// must play to attach parent event
 		event = (type: \testType).play;
 		this.assert(event[\calculated] == 1, "parentType values should be accessible during event play");
+		// cleanup eventTypes:
+		Event.addEventType(\testType, nil);
 	}
 
 	test_server_message_head_type_grain {


### PR DESCRIPTION
Generally, UnitTests should reset global state after finishing. 
TestEvent:test_event_addParentType does not : 
It adds an eventType which stays there, and creates a cyclic reference loop. 
This causes TestPattern, which runs after TestEvent in .runAll, hang - see #3938.
Short reproducer: 
```
 // TestPattern alone passes fine
TestPattern.run
(
// TestPattern hangs when TestEvent ran first
UnitTest.forkIfNeeded {
	UnitTest.reset;
	[ TestEvent, TestPattern ].do ({ |testClass|
		testClass.run(false,false);
		0.1.wait;
	});
	UnitTest.report;
}
)
```
This PR resets the global state of event types after the test, 
and thus TestPattern does not hang when running after TestEvent.

- [x ] All tests are passing
- [ ] This PR is ready for review

<!--- Remaining Work -->
fix hangs by cyclic references in implementations of  ==, as discussed in #3938.