### PR TITLE
Collection:== : add early exit for identity, also in subclasses

### DIFF
--- a/SCClassLibrary/Common/Collections/Collection.sc
+++ b/SCClassLibrary/Common/Collections/Collection.sc
@@ -70,6 +70,7 @@ Collection {
 	@ { | index | ^this[index] }
 
 	== { | aCollection |
+		if (this === aCollection) { ^true };
 		if (aCollection.class != this.class) { ^false };
 		if (this.size != aCollection.size) { ^false };
 		this.do { | item, i |

--- a/SCClassLibrary/Common/Collections/Dictionary.sc
+++ b/SCClassLibrary/Common/Collections/Dictionary.sc
@@ -371,6 +371,7 @@ Dictionary : Set {
 	}
 
 	== { arg that;
+		if (that === this) { ^true };
 		if(that.isKindOf(this.class).not) { ^false };
 		if(that.size != this.size) { ^false };
 		that.keysValuesDo { |key, val|

--- a/SCClassLibrary/Common/Collections/SequenceableCollection.sc
+++ b/SCClassLibrary/Common/Collections/SequenceableCollection.sc
@@ -120,6 +120,7 @@ SequenceableCollection : Collection {
 	}
 
 	== { | aCollection |
+		if (this === aCollection) { ^true };
 		if (aCollection.class != this.class) { ^false };
 		if (this.size != aCollection.size) { ^false };
 		this.do { | item, i |

--- a/SCClassLibrary/Common/Collections/String.sc
+++ b/SCClassLibrary/Common/Collections/String.sc
@@ -88,6 +88,7 @@ String[char] : RawArray {
 		^this.compare(aString, false) >= 0
 	}
 	== { arg aString;
+		if (this === aString) { ^true };
 		if(aString.isString.not) { ^false };
 		^this.compare(aString, false) == 0
 	}


### PR DESCRIPTION
This PR adds an identity check-based early exit to the '==' methods of 
Collection, SequenceableCollection, String and Dictionary (and thus indirectly to IdentityDictionary).

Purpose and Motivation
----------------------
Collections that will be compared often may be identical, or may contain identical subcollections, and for these cases there aresignificant speedups. 
Given that identity testing is really fast, the potential add cost is minimal.

Types of changes
----------------
No changes in behavior except speedups when objects are identical or partially identical.
Examples for measured speedups:
```
a = (1..1000);
b = a.copy;
bench { 1000.do { a === b } }; // ca 0.00012
bench { 1000.do { a ==  b } }; // ca 0.234
b = a;
bench { 1000.do { a ==  b } }; // ca 0.0010 <- as fast as === when identical!


// Same test for contained collections
b = [1, 2, a];
c = [1, 2, a.copy];
bench { 1000.do { b === c } }; // 0.00013
bench { 1000.do { b ==  c } }; // 0.25
c = [1, 2, a];
bench { 1000.do { b ==  c } }; // 0.00590 <-speedup when identical


// for event parents, which often are identical:
p = ().play.parent; // get defaultParentEvent
d = ().parent_(p);
e = ().parent_(p);

bench { 1000.do { d === e } }; // 0.00012
bench { 1000.do { d ==  e } }; // 0.0090
e.parent_(p.copy);
bench { 1000.do { d ==  e } }; // 0.062
e.parent_(p.deepCopy);
bench { 1000.do { d ==  e } }; // 0.16

a = "asdfghjkl".wrapExtend(1000);
b = a.copy;
bench { 1000.do { a === b } }; // ca 0.00012
bench { 1000.do { a ==  b } }; // ca 0.00090
b = a;
bench { 1000.do { a ==  b } }; // ca 0.00050
```
Checklist
---------
- [x] All tests are passing
- [x] This PR is ready for review

Remaining work:
----------
When testing, it turned out that Signal:== is a random generator ;-) 
```
20.collect { Signal[1] == Signal[1] }; 
-> [ false, true, false, true, false, true, true, true, true, false, false, false, true, false, false, false, false, false, false, false ]
20.collect { Signal[1, 2] == Signal[1, 2] }; 
-> [ false, false, false, false, false, false, false, false, true, true, false, false, false, false, false, false, true, false, false, true ]
20.collect { Signal[1, 2, 3] == Signal[1, 2, 3] }// 
-> [ true, true, true, true, false, false, true, true, false, true, true, true, true, true, true, true, true, true, true, true ]
```