### PR TITLE
sclang: Defer showing of dialog

### DIFF
--- a/QtCollider/widgets/QcFileDialog.h
+++ b/QtCollider/widgets/QcFileDialog.h
@@ -56,6 +56,14 @@ Q_SIGNALS:
 private Q_SLOTS:
 
   void show() {
+    // If we show the dialog in the middle of an Interpret call, and the idle
+    // loop of the dialog tries to process SuperCollider events, we hang since
+    // we're already mid-interpret. We need to launch the dialog without SC
+    // on the stack, so we defer.
+
+    // QTimer doesn't actually defer things with 'msec' equal to 0, so we use
+    // a 1-millisecond delay.
+
     auto thisDialog = dialog;
     QTimer::singleShot(1, [thisDialog]() {
       thisDialog->exec();

--- a/QtCollider/widgets/QcFileDialog.h
+++ b/QtCollider/widgets/QcFileDialog.h
@@ -25,6 +25,7 @@
 
 #include <QFileDialog>
 #include <QPointer>
+#include <QTimer>
 
 class QcFileDialog : public QObject
 {
@@ -55,8 +56,11 @@ Q_SIGNALS:
 private Q_SLOTS:
 
   void show() {
-    dialog->exec();
-    dialog->deleteLater();
+    auto thisDialog = dialog;
+    QTimer::singleShot(1, [thisDialog]() {
+      thisDialog->exec();
+      thisDialog->deleteLater();
+    });
   }
 
   void onFinished( int res ) {


### PR DESCRIPTION
Purpose and Motivation
----------------------
Fixes #3807 

Types of changes
----------------

If we show dialog while we're in the middle of an Interpret call (as can be the case now), and the idle loop of the dialog tries to process SuperCollider timer events, we hang (since we're already mid-interpret). We need to launch the dialog without SC on the stack, so we defer. QTimer doesn't actually defer things with time==0, so we have to do 1ms.

Checklist
---------

- [x] All tests are passing
- [x] Updated documentation, if necessary
- [x] This PR is ready for review

<!--- Remaining Work -->
- [ ] If necessary, new tests were created to address changes in PR (and tests are passing)