### PR TITLE
adding key repeat detection in QT views

### DIFF
--- a/QtCollider/QWidgetProxy.cpp
+++ b/QtCollider/QWidgetProxy.cpp
@@ -398,7 +398,7 @@ bool QWidgetProxy::interpretKeyEvent( QObject *o, QEvent *e, QList<QVariant> &ar
 
   QKeyEvent *ke = static_cast<QKeyEvent*>( e );
 
-  int key = ke->isAutoRepeat();
+  int key = ke->key();
 
   int mods = ke->modifiers();
 
@@ -437,6 +437,7 @@ bool QWidgetProxy::interpretKeyEvent( QObject *o, QEvent *e, QList<QVariant> &ar
   args << keycode;
   args << key;
   args << ke->spontaneous();
+  args << ke->isAutoRepeat();
 
   return true;
 }

--- a/QtCollider/QWidgetProxy.cpp
+++ b/QtCollider/QWidgetProxy.cpp
@@ -398,7 +398,7 @@ bool QWidgetProxy::interpretKeyEvent( QObject *o, QEvent *e, QList<QVariant> &ar
 
   QKeyEvent *ke = static_cast<QKeyEvent*>( e );
 
-  int key = ke->key();
+  int key = ke->isAutoRepeat();
 
   int mods = ke->modifiers();
 

--- a/SCClassLibrary/Common/GUI/Base/QView.sc
+++ b/SCClassLibrary/Common/GUI/Base/QView.sc
@@ -499,11 +499,11 @@ View : QObject {
 
 	defaultKeyUpAction { arg char, modifiers, unicode, keycode, key; }
 
-	keyDown { arg char, modifiers, unicode, keycode, key;
+	keyDown { arg char, modifiers, unicode, keycode, key, repeat;
 		if( keyDownAction.notNil ) {
-			^keyDownAction.value( this, char, modifiers, unicode, keycode, key );
+			^keyDownAction.value( this, char, modifiers, unicode, keycode, key, repeat);
 		} {
-			^this.defaultKeyDownAction( char, modifiers, unicode, keycode, key );
+			^this.defaultKeyDownAction( char, modifiers, unicode, keycode, key, repeat);
 		};
 	}
 
@@ -624,19 +624,19 @@ View : QObject {
 	moveEvent { onMove.value(this) }
 	resizeEvent { onResize.value(this) }
 
-	keyDownEvent { arg char, modifiers, unicode, keycode, key, spontaneous;
+  keyDownEvent { arg char, modifiers, unicode, keycode, key, spontaneous, repeat;
 		modifiers = QKeyModifiers.toCocoa(modifiers);
 
 		if( spontaneous ) {
 			// this event has never been propagated to parent yet
-			View.globalKeyDownAction.value( this, char, modifiers, unicode, keycode, key );
+			View.globalKeyDownAction.value( this, char, modifiers, unicode, keycode, key, repeat);
 		};
 
 		if( (key == 16r1000020) || (key == 16r1000021) ||
 			(key == 16r1000022) || (key == 16r1000023 ) )
 		{ this.keyModifiersChanged( modifiers ) };
 
-		^this.keyDown( char, modifiers, unicode, keycode, key );
+		^this.keyDown( char, modifiers, unicode, keycode, key, repeat);
 	}
 
 	keyUpEvent { arg char, modifiers, unicode, keycode, key, spontaneous;

--- a/SCClassLibrary/Common/GUI/Base/QView.sc
+++ b/SCClassLibrary/Common/GUI/Base/QView.sc
@@ -507,12 +507,12 @@ View : QObject {
 		};
 	}
 
-	keyUp { arg char, modifiers, unicode, keycode, key;
+	keyUp { arg char, modifiers, unicode, keycode, key, repeat;
 		keyTyped = char;
 		if( keyUpAction.notNil ) {
-			^keyUpAction.value( this, char, modifiers, unicode, keycode, key );
+			^keyUpAction.value( this, char, modifiers, unicode, keycode, key, repeat );
 		} {
-			^this.defaultKeyUpAction( char, modifiers, unicode, keycode, key );
+			^this.defaultKeyUpAction( char, modifiers, unicode, keycode, key, repeat );
 		};
 	}
 
@@ -639,19 +639,19 @@ View : QObject {
 		^this.keyDown( char, modifiers, unicode, keycode, key, repeat);
 	}
 
-	keyUpEvent { arg char, modifiers, unicode, keycode, key, spontaneous;
+	keyUpEvent { arg char, modifiers, unicode, keycode, key, spontaneous, repeat;
 		modifiers = QKeyModifiers.toCocoa(modifiers);
 
 		if( spontaneous ) {
 			// this event has never been propagated to parent yet
-			View.globalKeyUpAction.value( this, char, modifiers, unicode, keycode, key );
+			View.globalKeyUpAction.value( this, char, modifiers, unicode, keycode, key, repeat );
 		};
 
 		if( (key == 16r1000020) || (key == 16r1000021) ||
 			(key == 16r1000022) || (key == 16r1000023 ) )
 		{ this.keyModifiersChanged( modifiers ) };
 
-		^this.keyUp( char, modifiers, unicode, keycode, key );
+		^this.keyUp( char, modifiers, unicode, keycode, key, repeat );
 	}
 
 	mouseDownEvent { arg x, y, modifiers, buttonNumber, clickCount;


### PR DESCRIPTION
It seems to me that have a real key "down" and "up" is a crucial feature if we want to really create a GUI with SuperCollider.

QT allows natively to catch repeated event. So, why not adding this information in the hook ?
I have just added the flag at the end of the arguments passed to the keyDownAction hook.