### PR TITLE
docs: improve syntax highlighter

### DIFF
--- a/HelpSource/editor.css
+++ b/HelpSource/editor.css
@@ -43,28 +43,28 @@ textarea.editor {
 }
 
 /* syntax hightlighting */
-.cm-s-default .cm-string { color: rgb(95, 95, 95) }
-.cm-s-default .cm-atom { color: rgb(0, 0, 230) }
-.cm-s-default .cm-comment { color: rgb(192, 0, 0) }
-.cm-s-default .cm-type { color: rgb(0, 0, 210) }
-.cm-s-default .cm-literal { color: rgb(152, 0, 153) }
-.cm-s-default .cm-punctuation { color: rgb(85, 85, 85) }
-.cm-s-default .cm-plain { color: rgb(0, 0, 0) }
-.cm-s-default .cm-keyword { color: rgb(51, 51, 191) }
-.cm-s-default .cm-declaration { color: rgb(0, 0, 230); font-weight: bold; }
-.cm-s-default .cm-attribute-name { color: rgb(0, 115, 0) }
-.cm-s-default .cm-env-var { color: rgb(140, 70, 20) }
+.cm-s-default .cm-keyword { color: #0000e6; font-weight: bold; }
+.cm-s-default .cm-built-in { color: #3333bf; }
+.cm-s-default .cm-number { color: #980099; }
+.cm-s-default .cm-symbol { color: #007300; }
+.cm-s-default .cm-class { color: #0000d2; }
+.cm-s-default .cm-primitive { color: #0000d2; }
+.cm-s-default .cm-char { color: #007300; }
+.cm-s-default .cm-env-var { color: #8c4614; }
+.cm-s-default .cm-comment { color: #bf0000; }
+.cm-s-default .cm-string { color: #5f5f5f; }
+.cm-s-default .cm-text { color: #000000; }
 
 @media print {
-    .cm-s-default .cm-string { color: rgb(95, 95, 95) }
-    .cm-s-default .cm-atom { color: rgb(0, 0, 230); font-weight: bold; }
-    .cm-s-default .cm-comment { color: rgb(192, 0, 0); font-style: italic; }
-    .cm-s-default .cm-type { color: rgb(0, 0, 210); font-weight: bold; }
-    .cm-s-default .cm-literal { color: rgb(152, 0, 153) }
-    .cm-s-default .cm-punctuationn { color: rgb(85, 85, 85) }
-    .cm-s-default .cm-plain { color: rgb(0, 0, 0) }
-    .cm-s-default .cm-keyword { color: rgb(51, 51, 191); font-weight: bold; }
-    .cm-s-default .cm-declaration { color: rgb(0, 0, 230); font-weight: bold; }
-    .cm-s-default .cm-attribute-name { color: rgb(0, 115, 0) }
-    .cm-s-default .cm-env-var { color: rgb(140, 70, 20) }
+    .cm-s-default .cm-keyword { color: #0000e6; font-weight: bold; }
+    .cm-s-default .cm-built-in { color: #3333bf; font-weight: bold; }
+    .cm-s-default .cm-number { color: #980099; }
+    .cm-s-default .cm-symbol { color: #007300; }
+    .cm-s-default .cm-class { color: #0000d2; font-weight: bold; }
+    .cm-s-default .cm-primitive { color: #0000d2; }
+    .cm-s-default .cm-char { color: #007300; }
+    .cm-s-default .cm-env-var { color: #8c4614; }
+    .cm-s-default .cm-comment { color: #bf0000; font-style: italic; }
+    .cm-s-default .cm-string { color: #5f5f5f; }
+    .cm-s-default .cm-text { color: #000000; }
 }

--- a/HelpSource/editor.js
+++ b/HelpSource/editor.js
@@ -1,24 +1,30 @@
 const init = () => {
     CodeMirror.defineSimpleMode('scd', {
         start: [
-            {regex: /"(?:[^\\]|\\.)*?(?:"|$)/, token: 'string'},
-            {regex: /^[\t\n\r \xA0]+/, token: 'whitespace'},
-            {regex: /^\\\w+/, token: 'attribute-name'},
-            {regex: /^'[^']+'/, token: 'attribute-name'},
-            {regex: /^\w+\:/, token: 'attribute-name'},
-            {regex: /^\$(\\)?./, token: 'attribute-name'},
-            {regex: /^~\w+/, token: 'env-var'},
-            {regex: /^(?:super|thisFunctionDef|thisFunction|thisMethod|thisProcess|thisThread|this)\b/, token: 'keyword'},
-            {regex: /^(?:true|false|nil|inf)\b/, token: 'atom'},
-            {regex: /^(?:var|classvar|const|arg)\b/, token: 'declaration'},
-            {regex: /^\b([A-Z][A-Za-z_0-9]+)\b/, token: 'type'},
-            {regex: /^\/(?:\/.*|\*(?:\/|\**[^*/])*(?:\*+\/?)?)/, token: 'comment'},
-            {regex: /^-?\d+r[\da-zA-Z]+(\.[\da-zA-Z]+)?/, token: 'literal'},
-            {regex: /^-?(?:(?:\d+(\.\d+)?)(?:e[+\-]?\d+)?(pi)?)|(?:pi\b)/, token: 'literal'},
-            {regex: /^[a-z_]\w*/i, token: 'plain'},
-            {regex: /^[-.,;#()\[\]{}]/, token: 'punctuation'}
+            { regex: /^\s+/, token: 'whitespace' },
+            { regex: /^(?:arg|classvar|const|super|this|var)\b/, token: 'keyword' },
+            { regex: /^(?:false|inf|nil|true|thisFunction|thisFunctionDef|thisMethod|thisProcess|thisThread|currentEnvironment|topEnvironment)\b/, token: 'built-in' },
+            { regex: /^\b\d+r[0-9a-zA-Z]*(\.[0-9A-Z]*)?/, token: 'number radix-float' },
+            { regex: /^\b((\d+(\.\d+)?([eE][-+]?\d+)?(pi)?)|pi)\b/, token: 'number float' },
+            { regex: /^\b0(x|X)(\d|[a-f]|[A-F])+/, token: 'number hex-int' },
+            { regex: /^\b[A-Za-z_]\w*\:/, token: 'symbol symbol-arg' },
+            { regex: /^[a-z]\w*/, token: 'text name' },
+            { regex: /^\b[A-Z]\w*/, token: 'class' },
+            { regex: /^\b_\w+/, token: 'primitive' },
+            { regex: /^\\\w*/, token: 'symbol' },
+            { regex: /^\$\\\?./, token: 'char' },
+            { regex: /^~\w+/, token: 'env-var' },
+            { regex: /^\/\/[^\r\n]*/, token: 'comment single-line-comment' },
+            { regex: /"(?:[^\\]|\\.)*?(?:"|$)/, token: 'string' },
+            { regex: /^[-.,;#()\[\]{}]/, token: 'text punctuation' },
+            { regex: /\/\*/, push: 'comment', token: 'comment multi-line-comment' },
+            { regex: /^[\+-\\*/&\\|\\^%<>=]+/, token: 'text operator' },
+        ],
+        comment: [
+            { regex: /\*\//, pop: true, token: 'comment multi-line-comment' },
+            { regex: /./, token: 'comment multi-line-comment' }
         ]
-    });
+    })
 
     let textareas = Array.from(document.querySelectorAll('textarea'))
     textareas.forEach(textarea => {

--- a/HelpSource/editor.js
+++ b/HelpSource/editor.js
@@ -1,4 +1,5 @@
 const init = () => {
+    /* based on editors/sc-ide/core/sc_lexer.cpp */
     CodeMirror.defineSimpleMode('scd', {
         start: [
             { regex: /^\s+/, token: 'whitespace' },
@@ -12,13 +13,14 @@ const init = () => {
             { regex: /^\b[A-Z]\w*/, token: 'class' },
             { regex: /^\b_\w+/, token: 'primitive' },
             { regex: /^\\\w*/, token: 'symbol' },
-            { regex: /^\$\\\?./, token: 'char' },
+            { regex: /^'[^']+'/, token: 'symbol' },
+            { regex: /^\$\\?./, token: 'char' },
             { regex: /^~\w+/, token: 'env-var' },
             { regex: /^\/\/[^\r\n]*/, token: 'comment single-line-comment' },
             { regex: /"(?:[^\\]|\\.)*?(?:"|$)/, token: 'string' },
             { regex: /^[-.,;#()\[\]{}]/, token: 'text punctuation' },
             { regex: /\/\*/, push: 'comment', token: 'comment multi-line-comment' },
-            { regex: /^[\+-\\*/&\\|\\^%<>=]+/, token: 'text operator' },
+            { regex: /^[+\-*/&\|\^%<>=]+/, token: 'text operator' },
         ],
         comment: [
             { regex: /\*\//, pop: true, token: 'comment multi-line-comment' },

--- a/HelpSource/editor.js
+++ b/HelpSource/editor.js
@@ -13,7 +13,7 @@ const init = () => {
             { regex: /^\b[A-Z]\w*/, token: 'class' },
             { regex: /^\b_\w+/, token: 'primitive' },
             { regex: /^\\\w*/, token: 'symbol' },
-            { regex: /^'[^']+'/, token: 'symbol' },
+            { regex: /'(?:[^\\]|\\.)*?(?:'|$)/, token: 'symbol' },
             { regex: /^\$\\?./, token: 'char' },
             { regex: /^~\w+/, token: 'env-var' },
             { regex: /^\/\/[^\r\n]*/, token: 'comment single-line-comment' },

--- a/HelpSource/editor.js
+++ b/HelpSource/editor.js
@@ -20,7 +20,7 @@ const init = () => {
             { regex: /"(?:[^\\]|\\.)*?(?:"|$)/, token: 'string' },
             { regex: /^[-.,;#()\[\]{}]/, token: 'text punctuation' },
             { regex: /\/\*/, push: 'comment', token: 'comment multi-line-comment' },
-            { regex: /^[+\-*/&\|\^%<>=]+/, token: 'text operator' },
+            { regex: /^[+\-*/&\|\^%<>=!?]+/, token: 'text operator' },
         ],
         comment: [
             { regex: /\*\//, pop: true, token: 'comment multi-line-comment' },


### PR DESCRIPTION
Purpose and Motivation
----------------------

the syntax highlighter in the docs doesn't correctly handle primitives, doesn't highlight `currentEnvironment` or `topEnvironment`, and also misses hex ints. colors for tokens are not matching the ide theme either.

this pr fixes the syntax highlighter to correctly match the above tokens, and adjusts the color theme to match the default color theme in the settings file `sc_ide_conf.yaml`. i've used the [main ide lexer](https://github.com/supercollider/supercollider/blob/develop/editors/sc-ide/core/sc_lexer.cpp#L41) as the reference for the syntax and token names. 

note that css class names are adjusted to the names used in `sc_ide_conf.yaml` so they can easily be set in js later when we have access to the theme from settings, by using the css class `.cm-<name>`.

Types of changes
----------------

- Bug fix (non-breaking change which fixes an issue)

Checklist
---------

<!--- See DEVELOPING.md for instructions on running tests. -->
- [x] All tests are passing
- [x] This PR is ready for review

<!--- Remaining Work -->
<!--- ------------- -->

<!--- If any work remains to be done, please give a brief description here. -->
<!--- Consider providing a todo-list so we can easily track completion progress. -->

<!--- Thanks again! -->
