### PR TITLE
cmake: run macdeployqt on qtwebengineprocess binary as well

### DIFF
--- a/editors/sc-ide/CMakeLists.txt
+++ b/editors/sc-ide/CMakeLists.txt
@@ -412,11 +412,13 @@ if(APPLE OR WIN32)
     if(APPLE)
         find_program(DEPLOY_PROG macdeployqt PATHS ${CMAKE_PREFIX_PATH} PATH_SUFFIXES bin)
         # only the IDE executable is scanned normally, so force scanning of sclang as well
-        # to get QtWebEngine, libsndfile, and other libs
+        # to get QtWebEngine, libsndfile, and other libs. also force scanning of QtWebEngineProcess
+        # because macdeployqt is a fickle beast.
         set(DEPLOY_CMD "\"${DEPLOY_PROG}\"
                 \"${CMAKE_INSTALL_PREFIX}/SuperCollider/SuperCollider.app\"
                 -verbose=1
                 -executable=${CMAKE_INSTALL_PREFIX}/SuperCollider/SuperCollider.app/Contents/MacOS/sclang
+                -executable=${CMAKE_INSTALL_PREFIX}/SuperCollider/SuperCollider.app/Contents/Frameworks/QtWebEngineCore.framework/Versions/5/Helpers/QtWebEngineProcess.app/Contents/MacOS/QtWebEngineProcess
             ")
     else() # WIN32
         find_program(DEPLOY_PROG windeployqt PATHS ${CMAKE_PREFIX_PATH})


### PR DESCRIPTION
Purpose and Motivation
----------------------

Fixes #3971 by making sure macdeployqt is run on the QtWebEngineProcess binary.

I am not sure if a similar change needs to be applied on Windows.

For the record, a way to reproduce #3971 is by simply renaming the directory containing the Qt libs found by CMake after the build is complete.

Types of changes
----------------

- Bug fix (non-breaking change which fixes an issue)

Checklist
---------

- [x] This PR is ready for review

<!--- Remaining Work -->
<!--- ------------- -->

<!--- If any work remains to be done, please give a brief description here. -->
<!--- Consider providing a todo-list so we can easily track completion progress. -->

<!--- Thanks again! -->
