### PR TITLE
Classlib: Quarks: Correct the user feedback in GUI "Check for updates"

### DIFF
--- a/HelpSource/Classes/Quarks.schelp
+++ b/HelpSource/Classes/Quarks.schelp
@@ -97,6 +97,15 @@ METHOD:: folder
 Path of the downloaded-quarks folder where Quarks are cloned to before installing.
 returns:: path
 
+METHOD:: checkForUpdates
+Scan through all downloaded, git-repository quarks and download any updates. This uses teletype::git fetch::; updates will be retrieved but not applied to the working copy (i.e., no visible change to the environment). After this, repositories will be aware of new branches and version tags.
+
+This will take several seconds per quark. The SC interpreter will be unresponsive during each individual quark update.
+ARGUMENT:: done
+(Optional) A function to evaluate after all quarks have been checked.
+ARGUMENT:: quarkAction
+(Optional) A function to evaluate emphasis::before:: checking each individual quark. This function receives the Quark object as an argument, so you can use it, for instance, to print the quark name and have a running status update in the post window: code::Quarks.checkForUpdates(quarkAction: { |quark| "Updating %\n".postf(quark.name) });::.
+
 METHOD:: fetchDirectory
 Private.
 Fetches the directory listing into downloaded-quarks/quarks

--- a/HelpSource/Classes/Quarks.schelp
+++ b/HelpSource/Classes/Quarks.schelp
@@ -74,7 +74,7 @@ METHOD:: load
 Clear all installed quarks and load a list from a file.
 Relative paths in the file are resolved relative to the file itself.
 eg. ./classes/my-quark
-Unix style tildas (~/supercollider/quarks/my-quark) resolve to the user's home directory, even on Windows.
+Unix style tildes (~/supercollider/quarks/my-quark) resolve to the user's home directory, even on Windows.
 By convention the file is called quarks.txt
 ARGUMENT:: path
 path of file to load. May contain ~ or relative paths (root is current working directory)

--- a/SCClassLibrary/Common/Quarks/Quarks.sc
+++ b/SCClassLibrary/Common/Quarks/Quarks.sc
@@ -66,7 +66,7 @@ Quarks {
 			^("Quark set file does not exist:" + path).error;
 		});
 		this.clear();
-		Routine.run({
+		forkIfNeeded({
 			file = File.open(path, "r");
 			while({
 				line = file.getLine();
@@ -334,16 +334,17 @@ Quarks {
 			});
 		});
 	}
-	*checkForUpdates { |done|
-		Routine.run({
+	*checkForUpdates { |done, quarkAction|
+		forkIfNeeded({
 			this.all.do { arg quark;
 				if(quark.isGit, {
+					quarkAction.value(quark);
 					quark.checkForUpdates();
 				});
 				0.05.wait;
 			};
 			done.value();
-		});
+		}, AppClock);
 	}
 	*prReadDirectoryFile { |dirTxtPath|
 		var file;

--- a/SCClassLibrary/Common/Quarks/QuarksGui.sc
+++ b/SCClassLibrary/Common/Quarks/QuarksGui.sc
@@ -196,7 +196,9 @@ QuarksGui {
 			model.fetchDirectory(true);
 			this.setMsg("Checking for updates to Quarks...", \info);
 			0.1.wait;
-			model.checkForUpdates();
+			model.checkForUpdates(nil, { |quark|
+				this.setMsg("Checking for updates to Quarks (%)...".format(quark.name), \info);
+			});
 		}, onComplete, onCancel)
 	}
 	installFolder {


### PR DESCRIPTION
Purpose and Motivation
----------------------

In `Quarks.gui`, if the user clicks the "Check for updates" button, the feedback to the user is misleading -- even up to the point of making the user think that SC is stuck in an infinite loop.

Checking updates involves two steps: 1/ fetching the directory listing and 2/ iterating over all quarks and, for each downloaded quark, `git fetch`-ing updates.

Upon reviewing the code, I found that it was always intended to provide a status update to the user for both steps. But, when I tried it just now, I saw the status for the first step but not the second. Meanwhile, the second step was running in the background, launching synchronous system processes (`Pipe.callSync`) that block the interpreter until each one is finished.

So the GUI tells the user that it's finished and the system is ready to use, while in fact the interpreter may be blocked for the next several minutes, and the user receives exactly zero feedback about this. :confounded: (If even an experienced user such as myself gets confused by this interface, what is a new user going to think?)

This PR fixes a glaring error that pushed step 2 into a background routine -- `Quarks` should use `forkIfNeeded` instead of `Routine.run`. Also it adds a hook so that Quarks.gui can display the name of the quark currently being updated (so that the user can see something is happening).

Types of changes
----------------

- Bug fix (non-breaking change which fixes an issue) - because the feedback to the user is different from the code's intent.

- API change (adds an argument to Quarks `*checkForUpdates` -- non-breaking change, however)

Checklist
---------

- [ ] All tests are passing - *I can't think of how to write a unit test for this*

- [ ] Updated documentation, if necessary - *not necessary*

- [x] This PR is ready for review
