### PR TITLE
ide: only allow one preferences window open at a time

### DIFF
--- a/editors/sc-ide/widgets/main_window.cpp
+++ b/editors/sc-ide/widgets/main_window.cpp
@@ -1558,11 +1558,22 @@ void MainWindow::hideToolBox()
 
 void MainWindow::showSettings()
 {
-    Settings::Dialog dialog(mMain->settings());
-    dialog.resize(700,400);
-    int result = dialog.exec();
-    if( result == QDialog::Accepted )
-        mMain->applySettings();
+    static std::atomic<bool> showingSettings{false};
+
+    if ( showingSettings.load() )
+        return;
+
+    showingSettings = true;
+    try {
+        Settings::Dialog dialog(mMain->settings());
+        dialog.resize(700,400);
+        int result = dialog.exec();
+        if( result == QDialog::Accepted )
+            mMain->applySettings();
+    } catch (std::exception const& e) {
+        qWarning() << "Error while executing settings dialog:" << e.what();
+    }
+    showingSettings = false;
 }
 
 


### PR DESCRIPTION
Purpose and Motivation
----------------------

Fixes #3975.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to it here by writing "Fixes #555". -->

Types of changes
----------------

<!--- What types of changes does your pull request introduce? -->
<!--- Some examples are below (you can delete the lines that don't apply): -->

Added a function-static atomic to determine whether or not a settings
window is already open. Since I'm sure some of our stuff and the Qt
stuff is not noexcept, I added a try-catch to avoid the atomic becoming
stuck at true.

- Bug fix (non-breaking change which fixes an issue)

Checklist
---------

<!--- Complete an item by checking it: [x] -->

- [x] All tests are passing
- [x] If necessary, new tests were created to address changes in PR, and tests are passing
- [x] Updated documentation, if necessary
- [x] This PR is ready for review

<!--- See DEVELOPING.md for instructions on running and writing tests. -->

Remaining Work
--------------

<!--- If any work remains to be done, please give a brief description here. -->
<!--- Consider providing a todo-list so we can easily track completion progress. -->

<!--- Thanks for contributing! -->