### PR TITLE
[Help] Fix broken Help browser navigation

### DIFF
--- a/SCClassLibrary/Common/GUI/tools/HelpBrowser.sc
+++ b/SCClassLibrary/Common/GUI/tools/HelpBrowser.sc
@@ -96,6 +96,8 @@ HelpBrowser {
 				url = SCDoc.prepareHelpForURL(url) ?? { brokenAction.(urlString) };
 				newPath = url.path;
 				oldPath = URI(webView.url).path;
+				// deferring is needed to fix broken navigation in the HelpBrowser on some systems
+				// a hack solution for an issue that needs more investigation
 				{ webView.url = url.asString }.defer(0.05);
 				// needed since onLoadFinished is not called if the path did not change:
 				if(newPath == oldPath) {webView.onLoadFinished.value};

--- a/SCClassLibrary/Common/GUI/tools/HelpBrowser.sc
+++ b/SCClassLibrary/Common/GUI/tools/HelpBrowser.sc
@@ -96,7 +96,7 @@ HelpBrowser {
 				url = SCDoc.prepareHelpForURL(url) ?? { brokenAction.(urlString) };
 				newPath = url.path;
 				oldPath = URI(webView.url).path;
-				// deferring is needed to fix broken navigation in the HelpBrowser on some systems
+				// FIXME: deferring is needed to fix broken navigation in the HelpBrowser on some systems
 				// a hack solution for an issue that needs more investigation
 				{ webView.url = url.asString }.defer(0.05);
 				// needed since onLoadFinished is not called if the path did not change:

--- a/SCClassLibrary/Common/GUI/tools/HelpBrowser.sc
+++ b/SCClassLibrary/Common/GUI/tools/HelpBrowser.sc
@@ -96,7 +96,7 @@ HelpBrowser {
 				url = SCDoc.prepareHelpForURL(url) ?? { brokenAction.(urlString) };
 				newPath = url.path;
 				oldPath = URI(webView.url).path;
-				webView.url = url.asString;
+				{ webView.url = url.asString }.defer(0.05);
 				// needed since onLoadFinished is not called if the path did not change:
 				if(newPath == oldPath) {webView.onLoadFinished.value};
 				webView.focus;

--- a/SCClassLibrary/scide_scqt/ScIDE.sc
+++ b/SCClassLibrary/scide_scqt/ScIDE.sc
@@ -426,9 +426,7 @@ ScIDE {
 	}
 
 	*send { |id, data|
-		defer {
-			this.prSend(id, data)
-		}
+		{ this.prSend(id, data) }.defer(0.05)
 	}
 
 

--- a/SCClassLibrary/scide_scqt/ScIDE.sc
+++ b/SCClassLibrary/scide_scqt/ScIDE.sc
@@ -426,7 +426,7 @@ ScIDE {
 	}
 
 	*send { |id, data|
-		// deferring is needed to fix broken navigation in the help browser on some systems
+		// FIXME: deferring is needed to fix broken navigation in the help browser on some systems
 		// a hack solution for an issue that needs more investigation
 		{ this.prSend(id, data) }.defer(0.05)
 	}

--- a/SCClassLibrary/scide_scqt/ScIDE.sc
+++ b/SCClassLibrary/scide_scqt/ScIDE.sc
@@ -426,6 +426,8 @@ ScIDE {
 	}
 
 	*send { |id, data|
+		// deferring is needed to fix broken navigation in the help browser on some systems
+		// a hack solution for an issue that needs more investigation
 		{ this.prSend(id, data) }.defer(0.05)
 	}
 


### PR DESCRIPTION
<!--- Hi, and thanks for contributing! -->
<!--- Make sure to provide a general summary of your changes in the title above. -->
<!--- For example: "[scsynth] Fix crash when encountering cute kittens" -->

Purpose and Motivation
----------------------

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to it here by writing "Fixes #555". -->

This PR fixes broken navigation inside the IDE's help browser, as well as in the language HelpBrowser. On my system at least, navigating help files when using `HelpBrowser` was entirely broken. Clicking on a link never worked. The situation was more or less the same for the IDE's help browser. Links worked 1 out of 4 times approximately.

This PR add a small deferral time to `ScIDE.prSend` and `HelpBrowser.goTo` in order to correct the issue. Simply deferring is not enough. There needs to be a small delta time.

Types of changes
----------------

<!--- What types of changes does your pull request introduce? -->
<!--- Some examples are below (you can delete the lines that don't apply): -->

- Bug fix (non-breaking change which fixes an issue)

Checklist
---------

<!--- Complete an item by checking it: [x] -->

- [ ] All tests are passing
- [ ] If necessary, new tests were created to address changes in PR, and tests are passing
- [ ] Updated documentation, if necessary
- [X] This PR is ready for review

<!--- See DEVELOPING.md for instructions on running and writing tests. -->

Remaining Work
--------------

<!--- If any work remains to be done, please give a brief description here. -->
<!--- Consider providing a todo-list so we can easily track completion progress. -->

<!--- Thanks for contributing! -->
