### PR TITLE
travis: build supernova for MacOS

### DIFF
--- a/.travis/before-install-osx.sh
+++ b/.travis/before-install-osx.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+export BREW_NO_AUTO_UPDATE=1
+export BREW_NO_ANALYTICS=1
+
 brew update
 brew tap homebrew/versions
 brew outdated cmake || brew upgrade cmake

--- a/.travis/before-install-osx.sh
+++ b/.travis/before-install-osx.sh
@@ -3,15 +3,12 @@
 export BREW_NO_AUTO_UPDATE=1
 export BREW_NO_ANALYTICS=1
 
-brew update
-brew tap homebrew/versions
-brew outdated cmake || brew upgrade cmake
-
 # according to https://docs.travis-ci.com/user/caching#ccache-cache
 brew install ccache
 export PATH="/usr/local/opt/ccache/libexec:$PATH"
 
 brew install libsndfile || true
+brew install portaudio || true
 brew install qt5 || true
 brew link qt5 --force
 

--- a/.travis/before-script-osx.sh
+++ b/.travis/before-script-osx.sh
@@ -1,3 +1,8 @@
 #!/bin/sh
 
-cmake -G"Xcode" -DRULE_LAUNCH_COMPILE=ccache -DCMAKE_PREFIX_PATH=`brew --prefix qt5` -DCMAKE_OSX_DEPLOYMENT_TARGET=10.8 $TRAVIS_BUILD_DIR --debug-output
+cmake -G"Xcode" \
+    -DRULE_LAUNCH_COMPILE=ccache \
+    -DCMAKE_PREFIX_PATH=`brew --prefix qt5` \
+    -DCMAKE_OSX_DEPLOYMENT_TARGET=10.8 \
+    -DSUPERNOVA=ON \
+    $TRAVIS_BUILD_DIR --debug-output


### PR DESCRIPTION
<!--- Hi, and thanks for contributing! -->
<!--- Make sure to provide a general summary of your changes in the title above. -->
<!--- For example: "[scsynth] Fix crash when encountering cute kittens" -->

Purpose and Motivation
----------------------

This turns on building SuperNova for macOS Travis builds, and makes two further changes:

- don't send analytics to homebrew (really? yes...)
- don't let brew auto-update, which takes forever when installing/upgrading

Types of changes
----------------

- CI change
- change to release assets

Note that _release builds will now include Supernova_. This is something we've discussed at dev meetings and on the ML, and nobody has opposed it, so I thought I should make this change now that we're close to releasing 3.10!

Checklist
---------

- [ ] maybe need a note in the readme?
- [x] This PR is ready for review
