### PR TITLE
help-browser: rm keybinding used for js debugging only

### DIFF
--- a/HelpSource/editor.js
+++ b/HelpSource/editor.js
@@ -79,9 +79,8 @@ const selectRegion = (options = { flash: true }) => {
             return cursorLeft
         let ch = editor.getLine(cursorLeft.line)
             .slice(cursorLeft.ch, cursorLeft.ch+1)
-        if (ch === ')') {
+        if (ch === ')')
             return findLeftParen(findLeftParen(cursorLeft))
-        }
         if (ch === '(')
             return cursorLeft
         return findLeftParen(cursorLeft)
@@ -93,9 +92,8 @@ const selectRegion = (options = { flash: true }) => {
             return cursorRight
         let ch = editor.getLine(cursorRight.line)
             .slice(cursorRight.ch-1, cursorRight.ch)
-        if (ch === '(') {
+        if (ch === '(')
             return findRightParen(findRightParen(cursorRight))
-        }
         if (ch === ')')
             return cursorRight
         return findRightParen(cursorRight)

--- a/HelpSource/editor.js
+++ b/HelpSource/editor.js
@@ -37,8 +37,7 @@ const init = () => {
             lineWrapping: true,
             viewportMargin: Infinity,
             extraKeys: { 
-                'Cmd-Enter': () => selectRegion(),
-                'Shift-Enter': () => evalLine()
+                'Shift-Enter': evalLine
             }
         })
 
@@ -59,6 +58,10 @@ const init = () => {
 
 }
 
+const evalLine = () => {
+    // Ask IDE to eval line. Calls back to `selectLine()`
+    window.IDE.evaluateLine();
+}
 
 /* returns the code selection, line or region */
 const selectRegion = (options = { flash: true }) => {
@@ -135,11 +138,6 @@ const selectRegion = (options = { flash: true }) => {
         setTimeout(() => marker.clear(), 300)
         return editor.getRange(leftCursor, rightCursor)
     }
-}
-
-const evalLine = () => {
-    // Ask IDE to eval line. Calls back to `selectLine()`
-    window.IDE.evaluateLine();
 }
 
 // Returns the code selection or line


### PR DESCRIPTION
Purpose and Motivation
----------------------

may fix #3924. needs to be tested, because i can't reproduce it here.
otherwise this should be merged anyway, since the keybinding isn't needed.
(only shift-enter keybinding is needed in javascript and cmd/ctrl-enter keybindings are already intercepted in c++)

Types of changes
----------------

- Bug fix (non-breaking change which fixes an issue)

Checklist
---------

- [x] This PR is ready for review

<!--- See DEVELOPING.md for instructions on running and writing tests. -->

Remaining Work
--------------

test this pull, those who can reproduce #3924

