### PR TITLE
Help: Correct the 'pvcollect' example function

### DIFF
--- a/HelpSource/Classes/PV_ChainUGen.schelp
+++ b/HelpSource/Classes/PV_ChainUGen.schelp
@@ -115,7 +115,8 @@ The function that processes each bin. It should be a function that takes code:: 
 code::
 // example function
 { | magnitude, phase, bin, index |
-	[mags.reverse, phases.reverse] // e.g. upside-down spectrum
+	// randomize magnitudes somewhat (noisier signal)
+	[magnitude * (5.0.rand2.dbamp), phase]
 }
 ::
 


### PR DESCRIPTION
Purpose and Motivation
----------------------

b4b70b4f43 introduces a copy/paste error into the documentation for `pvcollect`.

The function for this method should take the magnitude and phase for a single bin, and return either a new magnitude or a magnitude/phase pair for this bin only.

The revision adds an "example function" that takes `| magnitude, phase, bin, index |` as arguments but then returns `[mags.reverse, phases.reverse]`. `mags` and `phases` are undeclared, so this will never work. Also, it's conceptually inconsistent. `pvcollect` operate on individual bins, not on all of them at once: `reverse` doesn't make sense in this context. But it does make sense for `pvcalc`.

The PR replaces the return with a simple per-bin randomizer.

Types of changes
----------------

- Documentation

Checklist
---------

- [n/a] All tests are passing
- [n/a] If necessary, new tests were created to address changes in PR, and tests are passing
- [x] Updated documentation, if necessary
- [x] This PR is ready for review

(It's a correction for a typo. The checklist is basically superfluous.)