### PR TITLE
[scide] Fix tab overline

### DIFF
--- a/editors/sc-ide/widgets/style/style.cpp
+++ b/editors/sc-ide/widgets/style/style.cpp
@@ -260,8 +260,8 @@ void Style::drawControl
             painter->drawRect(
                 rect.left(),
                 rect.top(),
-                rect.right(),
-                rect.top() + 2
+                rect.width(),
+                2
             );
         }
 


### PR DESCRIPTION
Purpose and Motivation
----------------------

sometimes the tab overline gets drawn wrong for really dark themes:

![untitled](https://user-images.githubusercontent.com/1211064/44693234-8f4fa300-aa1b-11e8-958a-5a38d4c0f757.png)

because i forgot that `QRect`'s arguments are x-y-width-height, not x1-y1-x2-y2.

the overline only shows up when the theme has a really dark background, so use e.g. the default "dark" theme if you want to see the effects.

Types of changes
----------------

cosmetic bug fix

Checklist
---------

- [x] All tests are passing
- [x] If necessary, new tests were created to address changes in PR, and tests are passing
- [x] Updated documentation, if necessary
- [x] This PR is ready for review
