### PR TITLE
[scide] Change default theme

### DIFF
--- a/editors/sc-ide/CMakeLists.txt
+++ b/editors/sc-ide/CMakeLists.txt
@@ -133,6 +133,7 @@ set ( ide_src
     core/settings/serialization.cpp
     core/settings/manager.cpp
     core/settings/theme.cpp
+    core/settings/default_themes.cpp
     core/session_manager.cpp
     core/util/color.cpp
     core/util/standard_dirs.cpp

--- a/editors/sc-ide/core/settings/default_themes.cpp
+++ b/editors/sc-ide/core/settings/default_themes.cpp
@@ -1,0 +1,307 @@
+/*
+    SuperCollider IDE
+    Copyright (c) 2018 SuperCollider Team
+    https://supercollider.github.io/
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
+*/
+
+#include "theme.hpp"
+#include <QPalette>
+#include <QApplication>
+
+namespace ScIDE { namespace Settings {
+
+/*
+    Kary Pro Colors
+    Copyright (c) 2018 Pouya Kary
+    modified and adaptated for SuperCollider by Nathan Ho
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
+*/
+void Theme::fillDefault()
+{
+    QColor background("#f7f7f7");
+    QColor current_line("#efefef");
+    QColor selection("#d6d6d6");
+    QColor foreground("#1a1a1a");
+    QColor line_number("#c7c4c2");
+    QColor comment("#848484");
+    QColor red("#cc3626");
+    QColor orange("#c07f00");
+    QColor yellow("#ada526");
+    QColor green("#3f831e");
+    QColor cyan("#3582bc");
+    QColor blue("#3951c9");
+    QColor purple("#af33a6");
+
+    addToTheme("text",               foreground, background);
+    addToTheme("currentLine",        foreground, current_line);
+    addToTheme("searchResult",       background, blue);
+    addToTheme("matchingBrackets",   foreground, background, true);
+    addToTheme("mismatchedBrackets", background, red);
+    addToTheme("evaluatedCode",      background, orange);
+    addToTheme("whitespace",         background);
+    addToTheme("keyword",            red);
+    addToTheme("built-in",           yellow);
+    addToTheme("env-var",            orange);
+    addToTheme("class",              cyan);
+    addToTheme("number",             purple);
+    addToTheme("symbol",             green);
+    addToTheme("string",             blue);
+    addToTheme("char",               green);
+    addToTheme("comment",            comment);
+    addToTheme("primitive",          orange);
+    addToTheme("lineNumbers",        line_number);
+    addToTheme("selection",          foreground, selection);
+    addToTheme("postwindowtext",     foreground);
+    addToTheme("postwindowerror",    red);
+    addToTheme("postwindowwarning",  orange);
+    addToTheme("postwindowsuccess",  green);
+    addToTheme("postwindowemphasis", foreground, Qt::transparent, true);
+}
+/* END Kary Pro Colors */
+
+void Theme::fillClassic()
+{
+    addToTheme("text", QColor(Qt::black), QColor(Qt::white));
+
+    QPalette appPlt(QApplication::palette());
+    QColor bkg = appPlt.color(QPalette::Base);
+    int value = bkg.value();
+    if (value > 40)
+        bkg.setHsv(bkg.hue(), bkg.saturation(), value - 11);
+    else
+        bkg.setHsv(bkg.hue(), bkg.saturation(), value + 20);
+    addToTheme("currentLine", QColor(Qt::black), bkg.toRgb());
+    addToTheme("searchResult",
+               appPlt.color(QPalette::HighlightedText).darker(200),
+               appPlt.color(QPalette::Highlight).darker(200));
+    addToTheme("matchingBrackets", QColor("#2bc93d"), Qt::yellow, true);
+    addToTheme("mismatchedBrackets", Qt::white, QColor(150,0,0));
+    addToTheme("evaluatedCode", Qt::black, QColor("#F8A200"));
+
+    QPalette plt(QApplication::palette());
+    QColor base = plt.color(QPalette::Base);
+    QColor text = plt.color(QPalette::Text);
+    int shade = (base.red() + base.green() + base.blue() < 380) ? 160 : 100;
+
+    QColor whitespace_color((base.red() + text.red()) / 2,
+                            (base.green() + text.green()) / 2,
+                            (base.blue() + text.blue()) / 2);
+
+    addToTheme("whitespace", whitespace_color);
+    addToTheme("keyword", QColor(0,0,230).lighter(shade),
+                                    QColor(Qt::transparent), true);
+    addToTheme("built-in", QColor(51,51,191).lighter(shade));
+    addToTheme("env-var", QColor(140,70,20).lighter(shade));
+    addToTheme("class", QColor(0,0,210).lighter(shade));
+    addToTheme("number", QColor(152,0,153).lighter(shade));
+    addToTheme("symbol", QColor(0,115,0).lighter(shade));
+    addToTheme("string", QColor(95,95,95).lighter(shade));
+    addToTheme("char", QColor(0,115,0).lighter(shade));
+    addToTheme("comment", QColor(191,0,0).lighter(shade));
+    addToTheme("primitive", QColor(51,51,191).lighter(shade));
+    addToTheme("lineNumbers", plt.color(QPalette::ButtonText),
+                                        plt.color(QPalette::Mid));
+    addToTheme("selection", plt.color(QPalette::HighlightedText),
+                                      plt.color(QPalette::Highlight));
+    addToTheme("postwindowtext", plt.color(QPalette::ButtonText));
+    addToTheme("postwindowerror", QColor(209, 28, 36));
+    addToTheme("postwindowwarning", QColor(165, 119, 6));
+    addToTheme("postwindowsuccess", QColor(115, 138, 5));
+    addToTheme("postwindowemphasis", Qt::black, Qt::transparent, true);
+}
+
+void Theme::fillDark()
+{
+    addToTheme("text",               QColor("#ffa4e2"), Qt::black);
+    addToTheme("currentLine",        QColor("#e4e4e4"), QColor("#393939"));
+    addToTheme("searchResult",       QColor("#e4e4e4"), QColor("#194c7f"));
+    addToTheme("matchingBrackets",   QColor("#ff5500"), QColor("#001d49"), true);
+    addToTheme("mismatchedBrackets", QColor("#ffaa00"), QColor("#980000"));
+    addToTheme("evaluatedCode",      QColor("#e4e4e4"), QColor("#636397"));
+    addToTheme("whitespace",         QColor("#e4e4e4"));
+    addToTheme("keyword",            QColor("#aaaaff"), Qt::transparent, true);
+    addToTheme("built-in",           QColor("#ffa4e2"));
+    addToTheme("env-var",            QColor("#73e7ad"));
+    addToTheme("class",              QColor("#00abff"), Qt::transparent, true);
+    addToTheme("number",             QColor("#4aff00"));
+    addToTheme("symbol",             QColor("#ddde00"));
+    addToTheme("string",             QColor("#d7d7d7"));
+    addToTheme("char",               QColor("#ff55ff"));
+    addToTheme("comment",            QColor("#d4b982"));
+    addToTheme("primitive",          QColor("#aaff7f"));
+    addToTheme("lineNumbers",        QColor("#cfcfcf"));
+    addToTheme("selection",          QColor("#ff5500"));
+    addToTheme("postwindowtext",     QColor("#e4e4e4"));
+    addToTheme("postwindowerror",    QColor("#ff1f2a"));
+    addToTheme("postwindowwarning",  QColor("#de7100"));
+    addToTheme("postwindowsuccess",  QColor("#b0d206"));
+    addToTheme("postwindowemphasis", QColor("#e4e4e4"), Qt::transparent, true);
+}
+
+/*
+The MIT License (MIT)
+
+Copyright (c) 2016 Dracula Theme
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+https://github.com/dracula/dracula-theme/
+*/
+
+void Theme::fillDracula()
+{
+    addToTheme("text",               QColor("#f7fdff"), QColor("#282a36"));
+    addToTheme("currentLine",        QColor("#909194"), QColor("#282a36"));
+    addToTheme("searchResult",       QColor("#e4e4e4"), QColor("#194c7f"));
+    addToTheme("matchingBrackets",   QColor("#ff5500"), QColor("#001d49"), true);
+    addToTheme("mismatchedBrackets", QColor("#ffaa00"), QColor("#980000"));
+    addToTheme("evaluatedCode",      QColor("#e4e4e4"), QColor("#636397"));
+    addToTheme("whitespace",         QColor("#e4e4e4"));
+    addToTheme("keyword",            QColor("#ff76c7"), Qt::transparent, true);
+    addToTheme("built-in",           QColor("#e2e37a"));
+    addToTheme("env-var",            QColor("#ffb965"));
+    addToTheme("class",              QColor("#65e5ff"), Qt::transparent, true);
+    addToTheme("number",             QColor("#be90fc"));
+    addToTheme("symbol",             QColor("#45fc75"));
+    addToTheme("string",             QColor("#5df884"));
+    addToTheme("char",               QColor("#ff55ff"));
+    addToTheme("comment",            QColor("#6071a6"));
+    addToTheme("primitive",          QColor("#aaff7f"));
+    addToTheme("lineNumbers",        QColor("#909194"));
+    addToTheme("selection",          QColor("#e0eeff"));
+    addToTheme("postwindowtext",     QColor("#dfe0fc"));
+    addToTheme("postwindowerror",    QColor("#ff1f2a"));
+    addToTheme("postwindowwarning",  QColor("#de7100"));
+    addToTheme("postwindowsuccess",  QColor("#b0d206"));
+    addToTheme("postwindowemphasis", QColor("#e4e4e4"), Qt::transparent, true);
+}
+/* END MIT LICENSED CODE */
+
+/*
+The MIT license (MIT)
+
+Copyright (c) 2011 Ethan Schoonover
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+https://github.com/altercation/solarized
+*/
+
+void Theme::fillSolarizedLight()
+{
+    addToTheme("text",               QColor("#657b83"), QColor("#fdf6e3"));
+    addToTheme("currentLine",        Qt::transparent, QColor("#eee8d5"));
+    addToTheme("searchResult",       QColor("#93a1a1"), QColor("#073642"));
+    addToTheme("matchingBrackets",   QColor("#002b36"), QColor("#eee8d5"), true);
+    addToTheme("mismatchedBrackets", QColor("#eee8d5"), QColor("#586e75"));
+    addToTheme("evaluatedCode",      QColor("#586e75"), QColor("#eee8d5"));
+    addToTheme("whitespace",         Qt::transparent);
+    addToTheme("keyword",            QColor("#dc322f"), Qt::transparent, true);
+    addToTheme("built-in",           QColor("#b58900"));
+    addToTheme("env-var",            QColor("#d33682"));
+    addToTheme("class",              QColor("#268bd2"));
+    addToTheme("number",             QColor("#6c71c4"));
+    addToTheme("symbol",             QColor("#b58900"));
+    addToTheme("string",             QColor("#93a1a1"));
+    addToTheme("char",               QColor("#cb4b16"));
+    addToTheme("comment",            QColor("#586e75"), Qt::transparent, false, true);
+    addToTheme("primitive",          QColor("#2aa198"));
+    addToTheme("lineNumbers",        QColor("#839496"), QColor("#eee8d5"));
+    addToTheme("selection",          QColor("#fdf6e3"), QColor("#657b83"));
+    addToTheme("postwindowtext",     QColor("#657b83"));
+    addToTheme("postwindowerror",    QColor("#dc322f"));
+    addToTheme("postwindowwarning",  QColor("#cb4b16"));
+    addToTheme("postwindowsuccess",  QColor("#859900"));
+    addToTheme("postwindowemphasis", QColor("#b58900"), Qt::transparent, true);
+}
+
+void Theme::fillSolarizedDark()
+{
+    addToTheme("text",               QColor("#839496"), QColor("#002b36"));
+    addToTheme("currentLine",        Qt::transparent, QColor("#073642"));
+    addToTheme("searchResult",       QColor("#586e75"), QColor("#eee8d5"));
+    addToTheme("matchingBrackets",   QColor("#fdf6e3"), QColor("#073642"), true);
+    addToTheme("mismatchedBrackets", QColor("#073642"), QColor("#93a1a1"));
+    addToTheme("evaluatedCode",      QColor("#93a1a1"), QColor("#073642"));
+    addToTheme("whitespace",         Qt::transparent);
+    addToTheme("keyword",            QColor("#dc322f"), Qt::transparent, true);
+    addToTheme("built-in",           QColor("#b58900"));
+    addToTheme("env-var",            QColor("#d33682"));
+    addToTheme("class",              QColor("#268bd2"));
+    addToTheme("number",             QColor("#6c71c4"));
+    addToTheme("symbol",             QColor("#b58900"));
+    addToTheme("string",             QColor("#586e75"));
+    addToTheme("char",               QColor("#cb4b16"));
+    addToTheme("comment",            QColor("#93a1a1"), Qt::transparent, false, true);
+    addToTheme("primitive",          QColor("#2aa198"));
+    addToTheme("lineNumbers",        QColor("#657b83"), QColor("#073642"));
+    addToTheme("selection",          QColor("#002b36"), QColor("#839496"));
+    addToTheme("postwindowtext",     QColor("#839496"));
+    addToTheme("postwindowerror",    QColor("#dc322f"));
+    addToTheme("postwindowwarning",  QColor("#cb4b16"));
+    addToTheme("postwindowsuccess",  QColor("#859900"));
+    addToTheme("postwindowemphasis", QColor("#b58900"), Qt::transparent, true);
+}
+
+/* END MIT LICENSED CODE */
+
+} } // namespace ScIDE

--- a/editors/sc-ide/core/settings/default_themes.cpp
+++ b/editors/sc-ide/core/settings/default_themes.cpp
@@ -53,7 +53,7 @@ void Theme::fillDefault()
     QColor comment("#848484");
     QColor red("#cc3626");
     QColor orange("#c07f00");
-    QColor yellow("#ada526");
+    // QColor yellow("#ada526"); // Not used currently.
     QColor green("#3f831e");
     QColor cyan("#3582bc");
     QColor blue("#3951c9");
@@ -67,13 +67,13 @@ void Theme::fillDefault()
     addToTheme("evaluatedCode",      background, orange);
     addToTheme("whitespace",         background);
     addToTheme("keyword",            red);
-    addToTheme("built-in",           yellow);
+    addToTheme("built-in",           purple);
     addToTheme("env-var",            orange);
     addToTheme("class",              cyan);
     addToTheme("number",             purple);
     addToTheme("symbol",             green);
     addToTheme("string",             blue);
-    addToTheme("char",               green);
+    addToTheme("char",               purple);
     addToTheme("comment",            comment);
     addToTheme("primitive",          orange);
     addToTheme("lineNumbers",        line_number);

--- a/editors/sc-ide/core/settings/default_themes.cpp
+++ b/editors/sc-ide/core/settings/default_themes.cpp
@@ -59,36 +59,36 @@ void Theme::fillDefault()
     QColor blue("#3f39c9");
     QColor purple("#af33a6");
 
-    addToTheme("text",               foreground, background);
-    addToTheme("currentLine",        foreground, current_line);
-    addToTheme("searchResult",       background, blue);
-    addToTheme("matchingBrackets",   foreground, background, true);
-    addToTheme("mismatchedBrackets", background, red);
-    addToTheme("evaluatedCode",      background, orange);
-    addToTheme("whitespace",         background);
-    addToTheme("keyword",            red);
-    addToTheme("built-in",           purple);
-    addToTheme("env-var",            orange);
-    addToTheme("class",              cyan);
-    addToTheme("number",             purple);
-    addToTheme("symbol",             green);
-    addToTheme("string",             blue);
-    addToTheme("char",               purple);
-    addToTheme("comment",            comment);
-    addToTheme("primitive",          orange);
-    addToTheme("lineNumbers",        line_number);
-    addToTheme("selection",          foreground, selection);
-    addToTheme("postwindowtext",     foreground);
-    addToTheme("postwindowerror",    red);
-    addToTheme("postwindowwarning",  orange);
-    addToTheme("postwindowsuccess",  green);
-    addToTheme("postwindowemphasis", foreground, Qt::transparent, true);
+    add("text",               foreground, background);
+    add("currentLine",        foreground, current_line);
+    add("searchResult",       background, blue);
+    add("matchingBrackets",   foreground, background, true);
+    add("mismatchedBrackets", background, red);
+    add("evaluatedCode",      background, orange);
+    add("whitespace",         background);
+    add("keyword",            red);
+    add("built-in",           purple);
+    add("env-var",            orange);
+    add("class",              cyan);
+    add("number",             purple);
+    add("symbol",             green);
+    add("string",             blue);
+    add("char",               purple);
+    add("comment",            comment);
+    add("primitive",          orange);
+    add("lineNumbers",        line_number);
+    add("selection",          foreground, selection);
+    add("postwindowtext",     foreground);
+    add("postwindowerror",    red);
+    add("postwindowwarning",  orange);
+    add("postwindowsuccess",  green);
+    add("postwindowemphasis", foreground, Qt::transparent, true);
 }
 /* END Kary Pro Colors */
 
 void Theme::fillClassic()
 {
-    addToTheme("text", QColor(Qt::black), QColor(Qt::white));
+    add("text", QColor(Qt::black), QColor(Qt::white));
 
     QPalette appPlt(QApplication::palette());
     QColor bkg = appPlt.color(QPalette::Base);
@@ -97,13 +97,13 @@ void Theme::fillClassic()
         bkg.setHsv(bkg.hue(), bkg.saturation(), value - 11);
     else
         bkg.setHsv(bkg.hue(), bkg.saturation(), value + 20);
-    addToTheme("currentLine", QColor(Qt::black), bkg.toRgb());
-    addToTheme("searchResult",
+    add("currentLine", QColor(Qt::black), bkg.toRgb());
+    add("searchResult",
                appPlt.color(QPalette::HighlightedText).darker(200),
                appPlt.color(QPalette::Highlight).darker(200));
-    addToTheme("matchingBrackets", QColor("#2bc93d"), Qt::yellow, true);
-    addToTheme("mismatchedBrackets", Qt::white, QColor(150,0,0));
-    addToTheme("evaluatedCode", Qt::black, QColor("#F8A200"));
+    add("matchingBrackets", QColor("#2bc93d"), Qt::yellow, true);
+    add("mismatchedBrackets", Qt::white, QColor(150,0,0));
+    add("evaluatedCode", Qt::black, QColor("#F8A200"));
 
     QPalette plt(QApplication::palette());
     QColor base = plt.color(QPalette::Base);
@@ -114,55 +114,55 @@ void Theme::fillClassic()
                             (base.green() + text.green()) / 2,
                             (base.blue() + text.blue()) / 2);
 
-    addToTheme("whitespace", whitespace_color);
-    addToTheme("keyword", QColor(0,0,230).lighter(shade),
+    add("whitespace", whitespace_color);
+    add("keyword", QColor(0,0,230).lighter(shade),
                                     QColor(Qt::transparent), true);
-    addToTheme("built-in", QColor(51,51,191).lighter(shade));
-    addToTheme("env-var", QColor(140,70,20).lighter(shade));
-    addToTheme("class", QColor(0,0,210).lighter(shade));
-    addToTheme("number", QColor(152,0,153).lighter(shade));
-    addToTheme("symbol", QColor(0,115,0).lighter(shade));
-    addToTheme("string", QColor(95,95,95).lighter(shade));
-    addToTheme("char", QColor(0,115,0).lighter(shade));
-    addToTheme("comment", QColor(191,0,0).lighter(shade));
-    addToTheme("primitive", QColor(51,51,191).lighter(shade));
-    addToTheme("lineNumbers", plt.color(QPalette::ButtonText),
+    add("built-in", QColor(51,51,191).lighter(shade));
+    add("env-var", QColor(140,70,20).lighter(shade));
+    add("class", QColor(0,0,210).lighter(shade));
+    add("number", QColor(152,0,153).lighter(shade));
+    add("symbol", QColor(0,115,0).lighter(shade));
+    add("string", QColor(95,95,95).lighter(shade));
+    add("char", QColor(0,115,0).lighter(shade));
+    add("comment", QColor(191,0,0).lighter(shade));
+    add("primitive", QColor(51,51,191).lighter(shade));
+    add("lineNumbers", plt.color(QPalette::ButtonText),
                                         plt.color(QPalette::Mid));
-    addToTheme("selection", plt.color(QPalette::HighlightedText),
+    add("selection", plt.color(QPalette::HighlightedText),
                                       plt.color(QPalette::Highlight));
-    addToTheme("postwindowtext", plt.color(QPalette::ButtonText));
-    addToTheme("postwindowerror", QColor(209, 28, 36));
-    addToTheme("postwindowwarning", QColor(165, 119, 6));
-    addToTheme("postwindowsuccess", QColor(115, 138, 5));
-    addToTheme("postwindowemphasis", Qt::black, Qt::transparent, true);
+    add("postwindowtext", plt.color(QPalette::ButtonText));
+    add("postwindowerror", QColor(209, 28, 36));
+    add("postwindowwarning", QColor(165, 119, 6));
+    add("postwindowsuccess", QColor(115, 138, 5));
+    add("postwindowemphasis", Qt::black, Qt::transparent, true);
 }
 
 void Theme::fillDark()
 {
-    addToTheme("text",               QColor("#ffa4e2"), Qt::black);
-    addToTheme("currentLine",        QColor("#e4e4e4"), QColor("#393939"));
-    addToTheme("searchResult",       QColor("#e4e4e4"), QColor("#194c7f"));
-    addToTheme("matchingBrackets",   QColor("#ff5500"), QColor("#001d49"), true);
-    addToTheme("mismatchedBrackets", QColor("#ffaa00"), QColor("#980000"));
-    addToTheme("evaluatedCode",      QColor("#e4e4e4"), QColor("#636397"));
-    addToTheme("whitespace",         QColor("#e4e4e4"));
-    addToTheme("keyword",            QColor("#aaaaff"), Qt::transparent, true);
-    addToTheme("built-in",           QColor("#ffa4e2"));
-    addToTheme("env-var",            QColor("#73e7ad"));
-    addToTheme("class",              QColor("#00abff"), Qt::transparent, true);
-    addToTheme("number",             QColor("#4aff00"));
-    addToTheme("symbol",             QColor("#ddde00"));
-    addToTheme("string",             QColor("#d7d7d7"));
-    addToTheme("char",               QColor("#ff55ff"));
-    addToTheme("comment",            QColor("#d4b982"));
-    addToTheme("primitive",          QColor("#aaff7f"));
-    addToTheme("lineNumbers",        QColor("#cfcfcf"));
-    addToTheme("selection",          QColor("#ff5500"));
-    addToTheme("postwindowtext",     QColor("#e4e4e4"));
-    addToTheme("postwindowerror",    QColor("#ff1f2a"));
-    addToTheme("postwindowwarning",  QColor("#de7100"));
-    addToTheme("postwindowsuccess",  QColor("#b0d206"));
-    addToTheme("postwindowemphasis", QColor("#e4e4e4"), Qt::transparent, true);
+    add("text",               QColor("#ffa4e2"), Qt::black);
+    add("currentLine",        QColor("#e4e4e4"), QColor("#393939"));
+    add("searchResult",       QColor("#e4e4e4"), QColor("#194c7f"));
+    add("matchingBrackets",   QColor("#ff5500"), QColor("#001d49"), true);
+    add("mismatchedBrackets", QColor("#ffaa00"), QColor("#980000"));
+    add("evaluatedCode",      QColor("#e4e4e4"), QColor("#636397"));
+    add("whitespace",         QColor("#e4e4e4"));
+    add("keyword",            QColor("#aaaaff"), Qt::transparent, true);
+    add("built-in",           QColor("#ffa4e2"));
+    add("env-var",            QColor("#73e7ad"));
+    add("class",              QColor("#00abff"), Qt::transparent, true);
+    add("number",             QColor("#4aff00"));
+    add("symbol",             QColor("#ddde00"));
+    add("string",             QColor("#d7d7d7"));
+    add("char",               QColor("#ff55ff"));
+    add("comment",            QColor("#d4b982"));
+    add("primitive",          QColor("#aaff7f"));
+    add("lineNumbers",        QColor("#cfcfcf"));
+    add("selection",          QColor("#ff5500"));
+    add("postwindowtext",     QColor("#e4e4e4"));
+    add("postwindowerror",    QColor("#ff1f2a"));
+    add("postwindowwarning",  QColor("#de7100"));
+    add("postwindowsuccess",  QColor("#b0d206"));
+    add("postwindowemphasis", QColor("#e4e4e4"), Qt::transparent, true);
 }
 
 /*
@@ -193,30 +193,30 @@ https://github.com/dracula/dracula-theme/
 
 void Theme::fillDracula()
 {
-    addToTheme("text",               QColor("#f7fdff"), QColor("#282a36"));
-    addToTheme("currentLine",        QColor("#909194"), QColor("#282a36"));
-    addToTheme("searchResult",       QColor("#e4e4e4"), QColor("#194c7f"));
-    addToTheme("matchingBrackets",   QColor("#ff5500"), QColor("#001d49"), true);
-    addToTheme("mismatchedBrackets", QColor("#ffaa00"), QColor("#980000"));
-    addToTheme("evaluatedCode",      QColor("#e4e4e4"), QColor("#636397"));
-    addToTheme("whitespace",         QColor("#e4e4e4"));
-    addToTheme("keyword",            QColor("#ff76c7"), Qt::transparent, true);
-    addToTheme("built-in",           QColor("#e2e37a"));
-    addToTheme("env-var",            QColor("#ffb965"));
-    addToTheme("class",              QColor("#65e5ff"), Qt::transparent, true);
-    addToTheme("number",             QColor("#be90fc"));
-    addToTheme("symbol",             QColor("#45fc75"));
-    addToTheme("string",             QColor("#5df884"));
-    addToTheme("char",               QColor("#ff55ff"));
-    addToTheme("comment",            QColor("#6071a6"));
-    addToTheme("primitive",          QColor("#aaff7f"));
-    addToTheme("lineNumbers",        QColor("#909194"));
-    addToTheme("selection",          QColor("#e0eeff"));
-    addToTheme("postwindowtext",     QColor("#dfe0fc"));
-    addToTheme("postwindowerror",    QColor("#ff1f2a"));
-    addToTheme("postwindowwarning",  QColor("#de7100"));
-    addToTheme("postwindowsuccess",  QColor("#b0d206"));
-    addToTheme("postwindowemphasis", QColor("#e4e4e4"), Qt::transparent, true);
+    add("text",               QColor("#f7fdff"), QColor("#282a36"));
+    add("currentLine",        QColor("#909194"), QColor("#282a36"));
+    add("searchResult",       QColor("#e4e4e4"), QColor("#194c7f"));
+    add("matchingBrackets",   QColor("#ff5500"), QColor("#001d49"), true);
+    add("mismatchedBrackets", QColor("#ffaa00"), QColor("#980000"));
+    add("evaluatedCode",      QColor("#e4e4e4"), QColor("#636397"));
+    add("whitespace",         QColor("#e4e4e4"));
+    add("keyword",            QColor("#ff76c7"), Qt::transparent, true);
+    add("built-in",           QColor("#e2e37a"));
+    add("env-var",            QColor("#ffb965"));
+    add("class",              QColor("#65e5ff"), Qt::transparent, true);
+    add("number",             QColor("#be90fc"));
+    add("symbol",             QColor("#45fc75"));
+    add("string",             QColor("#5df884"));
+    add("char",               QColor("#ff55ff"));
+    add("comment",            QColor("#6071a6"));
+    add("primitive",          QColor("#aaff7f"));
+    add("lineNumbers",        QColor("#909194"));
+    add("selection",          QColor("#e0eeff"));
+    add("postwindowtext",     QColor("#dfe0fc"));
+    add("postwindowerror",    QColor("#ff1f2a"));
+    add("postwindowwarning",  QColor("#de7100"));
+    add("postwindowsuccess",  QColor("#b0d206"));
+    add("postwindowemphasis", QColor("#e4e4e4"), Qt::transparent, true);
 }
 /* END MIT LICENSED CODE */
 
@@ -248,58 +248,58 @@ https://github.com/altercation/solarized
 
 void Theme::fillSolarizedLight()
 {
-    addToTheme("text",               QColor("#657b83"), QColor("#fdf6e3"));
-    addToTheme("currentLine",        Qt::transparent, QColor("#eee8d5"));
-    addToTheme("searchResult",       QColor("#93a1a1"), QColor("#073642"));
-    addToTheme("matchingBrackets",   QColor("#002b36"), QColor("#eee8d5"), true);
-    addToTheme("mismatchedBrackets", QColor("#eee8d5"), QColor("#586e75"));
-    addToTheme("evaluatedCode",      QColor("#586e75"), QColor("#eee8d5"));
-    addToTheme("whitespace",         Qt::transparent);
-    addToTheme("keyword",            QColor("#dc322f"), Qt::transparent, true);
-    addToTheme("built-in",           QColor("#b58900"));
-    addToTheme("env-var",            QColor("#d33682"));
-    addToTheme("class",              QColor("#268bd2"));
-    addToTheme("number",             QColor("#6c71c4"));
-    addToTheme("symbol",             QColor("#b58900"));
-    addToTheme("string",             QColor("#93a1a1"));
-    addToTheme("char",               QColor("#cb4b16"));
-    addToTheme("comment",            QColor("#586e75"), Qt::transparent, false, true);
-    addToTheme("primitive",          QColor("#2aa198"));
-    addToTheme("lineNumbers",        QColor("#839496"), QColor("#eee8d5"));
-    addToTheme("selection",          QColor("#fdf6e3"), QColor("#657b83"));
-    addToTheme("postwindowtext",     QColor("#657b83"));
-    addToTheme("postwindowerror",    QColor("#dc322f"));
-    addToTheme("postwindowwarning",  QColor("#cb4b16"));
-    addToTheme("postwindowsuccess",  QColor("#859900"));
-    addToTheme("postwindowemphasis", QColor("#b58900"), Qt::transparent, true);
+    add("text",               QColor("#657b83"), QColor("#fdf6e3"));
+    add("currentLine",        Qt::transparent, QColor("#eee8d5"));
+    add("searchResult",       QColor("#93a1a1"), QColor("#073642"));
+    add("matchingBrackets",   QColor("#002b36"), QColor("#eee8d5"), true);
+    add("mismatchedBrackets", QColor("#eee8d5"), QColor("#586e75"));
+    add("evaluatedCode",      QColor("#586e75"), QColor("#eee8d5"));
+    add("whitespace",         Qt::transparent);
+    add("keyword",            QColor("#dc322f"), Qt::transparent, true);
+    add("built-in",           QColor("#b58900"));
+    add("env-var",            QColor("#d33682"));
+    add("class",              QColor("#268bd2"));
+    add("number",             QColor("#6c71c4"));
+    add("symbol",             QColor("#b58900"));
+    add("string",             QColor("#93a1a1"));
+    add("char",               QColor("#cb4b16"));
+    add("comment",            QColor("#586e75"), Qt::transparent, false, true);
+    add("primitive",          QColor("#2aa198"));
+    add("lineNumbers",        QColor("#839496"), QColor("#eee8d5"));
+    add("selection",          QColor("#fdf6e3"), QColor("#657b83"));
+    add("postwindowtext",     QColor("#657b83"));
+    add("postwindowerror",    QColor("#dc322f"));
+    add("postwindowwarning",  QColor("#cb4b16"));
+    add("postwindowsuccess",  QColor("#859900"));
+    add("postwindowemphasis", QColor("#b58900"), Qt::transparent, true);
 }
 
 void Theme::fillSolarizedDark()
 {
-    addToTheme("text",               QColor("#839496"), QColor("#002b36"));
-    addToTheme("currentLine",        Qt::transparent, QColor("#073642"));
-    addToTheme("searchResult",       QColor("#586e75"), QColor("#eee8d5"));
-    addToTheme("matchingBrackets",   QColor("#fdf6e3"), QColor("#073642"), true);
-    addToTheme("mismatchedBrackets", QColor("#073642"), QColor("#93a1a1"));
-    addToTheme("evaluatedCode",      QColor("#93a1a1"), QColor("#073642"));
-    addToTheme("whitespace",         Qt::transparent);
-    addToTheme("keyword",            QColor("#dc322f"), Qt::transparent, true);
-    addToTheme("built-in",           QColor("#b58900"));
-    addToTheme("env-var",            QColor("#d33682"));
-    addToTheme("class",              QColor("#268bd2"));
-    addToTheme("number",             QColor("#6c71c4"));
-    addToTheme("symbol",             QColor("#b58900"));
-    addToTheme("string",             QColor("#586e75"));
-    addToTheme("char",               QColor("#cb4b16"));
-    addToTheme("comment",            QColor("#93a1a1"), Qt::transparent, false, true);
-    addToTheme("primitive",          QColor("#2aa198"));
-    addToTheme("lineNumbers",        QColor("#657b83"), QColor("#073642"));
-    addToTheme("selection",          QColor("#002b36"), QColor("#839496"));
-    addToTheme("postwindowtext",     QColor("#839496"));
-    addToTheme("postwindowerror",    QColor("#dc322f"));
-    addToTheme("postwindowwarning",  QColor("#cb4b16"));
-    addToTheme("postwindowsuccess",  QColor("#859900"));
-    addToTheme("postwindowemphasis", QColor("#b58900"), Qt::transparent, true);
+    add("text",               QColor("#839496"), QColor("#002b36"));
+    add("currentLine",        Qt::transparent, QColor("#073642"));
+    add("searchResult",       QColor("#586e75"), QColor("#eee8d5"));
+    add("matchingBrackets",   QColor("#fdf6e3"), QColor("#073642"), true);
+    add("mismatchedBrackets", QColor("#073642"), QColor("#93a1a1"));
+    add("evaluatedCode",      QColor("#93a1a1"), QColor("#073642"));
+    add("whitespace",         Qt::transparent);
+    add("keyword",            QColor("#dc322f"), Qt::transparent, true);
+    add("built-in",           QColor("#b58900"));
+    add("env-var",            QColor("#d33682"));
+    add("class",              QColor("#268bd2"));
+    add("number",             QColor("#6c71c4"));
+    add("symbol",             QColor("#b58900"));
+    add("string",             QColor("#586e75"));
+    add("char",               QColor("#cb4b16"));
+    add("comment",            QColor("#93a1a1"), Qt::transparent, false, true);
+    add("primitive",          QColor("#2aa198"));
+    add("lineNumbers",        QColor("#657b83"), QColor("#073642"));
+    add("selection",          QColor("#002b36"), QColor("#839496"));
+    add("postwindowtext",     QColor("#839496"));
+    add("postwindowerror",    QColor("#dc322f"));
+    add("postwindowwarning",  QColor("#cb4b16"));
+    add("postwindowsuccess",  QColor("#859900"));
+    add("postwindowemphasis", QColor("#b58900"), Qt::transparent, true);
 }
 
 /* END MIT LICENSED CODE */

--- a/editors/sc-ide/core/settings/default_themes.cpp
+++ b/editors/sc-ide/core/settings/default_themes.cpp
@@ -62,7 +62,7 @@ void Theme::fillDefault()
     add("text",               foreground, background);
     add("currentLine",        foreground, current_line);
     add("searchResult",       background, blue);
-    add("matchingBrackets",   foreground, background, true);
+    add("matchingBrackets",   foreground, current_line, true);
     add("mismatchedBrackets", background, red);
     add("evaluatedCode",      background, orange);
     add("whitespace",         background);

--- a/editors/sc-ide/core/settings/default_themes.cpp
+++ b/editors/sc-ide/core/settings/default_themes.cpp
@@ -46,7 +46,7 @@ namespace ScIDE { namespace Settings {
 void Theme::fillDefault()
 {
     QColor background("#f7f7f7");
-    QColor current_line("#efefef");
+    QColor current_line("#eaeaea");
     QColor selection("#d6d6d6");
     QColor foreground("#1a1a1a");
     QColor line_number("#c7c4c2");

--- a/editors/sc-ide/core/settings/default_themes.cpp
+++ b/editors/sc-ide/core/settings/default_themes.cpp
@@ -55,8 +55,8 @@ void Theme::fillDefault()
     QColor orange("#c07f00");
     // QColor yellow("#ada526"); // Not used currently.
     QColor green("#3f831e");
-    QColor cyan("#3582bc");
-    QColor blue("#3951c9");
+    QColor cyan("#3478bc");
+    QColor blue("#3f39c9");
     QColor purple("#af33a6");
 
     addToTheme("text",               foreground, background);

--- a/editors/sc-ide/core/settings/theme.cpp
+++ b/editors/sc-ide/core/settings/theme.cpp
@@ -79,7 +79,7 @@ int legacyTheme(Manager * settings)
     return 1;
 }
 
-void Theme::addToTheme(
+void Theme::add(
     const char *key,
     const QColor & fg,
     const QColor & bg, // = QColor(Qt::transparent)
@@ -202,7 +202,7 @@ void Theme::setFormat(const QString & key, const QTextCharFormat & newFormat)
     }
 
     mFormats.remove(key);
-    addToTheme(key.toStdString().c_str(), fg, bg, fontWeight, newFormat.fontItalic());
+    add(key.toStdString().c_str(), fg, bg, fontWeight, newFormat.fontItalic());
 }
 
 const QTextCharFormat & Theme::format(const QString & key)

--- a/editors/sc-ide/core/settings/theme.cpp
+++ b/editors/sc-ide/core/settings/theme.cpp
@@ -79,10 +79,13 @@ int legacyTheme(Manager * settings)
     return 1;
 }
 
-static void addToTheme(QMap<QString, QTextCharFormat *> & map, const char *key,
-                  const QColor & fg, const QColor & bg = QColor(Qt::transparent),
-                  bool bold = false, bool italic = false)
-{
+void Theme::addToTheme(
+    const char *key,
+    const QColor & fg,
+    const QColor & bg, // = QColor(Qt::transparent)
+    bool bold, // = false
+    bool italic // = false
+) {
     QTextCharFormat *format = new QTextCharFormat();
 
     if (bg != QColor(Qt::transparent))
@@ -95,268 +98,8 @@ static void addToTheme(QMap<QString, QTextCharFormat *> & map, const char *key,
         format->setFontWeight(QFont::Bold);
     format->setFontItalic(italic);
 
-    map.insert(key, format);
+    mFormats.insert(key, format);
 }
-
-void Theme::fillDefault()
-{
-    QColor background("#f7f7f7");
-    QColor current_line("#efefef");
-    QColor selection("#d6d6d6");
-    QColor foreground("#1a1a1a");
-    QColor line_number("#c7c4c2");
-    QColor comment("#848484");
-    QColor red("#cc3626");
-    QColor orange("#c07f00");
-    QColor yellow("#ada526");
-    QColor green("#3f831e");
-    QColor cyan("#3582bc");
-    QColor blue("#3951c9");
-    QColor purple("#af33a6");
-
-    addToTheme(mFormats, "text",               foreground, background);
-    addToTheme(mFormats, "currentLine",        foreground, current_line);
-    addToTheme(mFormats, "searchResult",       background, blue);
-    addToTheme(mFormats, "matchingBrackets",   foreground, background, true);
-    addToTheme(mFormats, "mismatchedBrackets", background, red);
-    addToTheme(mFormats, "evaluatedCode",      background, orange);
-    addToTheme(mFormats, "whitespace",         background);
-    addToTheme(mFormats, "keyword",            red);
-    addToTheme(mFormats, "built-in",           yellow);
-    addToTheme(mFormats, "env-var",            orange);
-    addToTheme(mFormats, "class",              cyan);
-    addToTheme(mFormats, "number",             purple);
-    addToTheme(mFormats, "symbol",             green);
-    addToTheme(mFormats, "string",             blue);
-    addToTheme(mFormats, "char",               green);
-    addToTheme(mFormats, "comment",            comment);
-    addToTheme(mFormats, "primitive",          orange);
-    addToTheme(mFormats, "lineNumbers",        line_number);
-    addToTheme(mFormats, "selection",          foreground, selection);
-    addToTheme(mFormats, "postwindowtext",     foreground);
-    addToTheme(mFormats, "postwindowerror",    red);
-    addToTheme(mFormats, "postwindowwarning",  orange);
-    addToTheme(mFormats, "postwindowsuccess",  green);
-    addToTheme(mFormats, "postwindowemphasis", foreground, Qt::transparent, true);
-}
-
-void Theme::fillClassic()
-{
-    addToTheme(mFormats, "text", QColor(Qt::black), QColor(Qt::white));
-
-    QPalette appPlt(QApplication::palette());
-    QColor bkg = appPlt.color(QPalette::Base);
-    int value = bkg.value();
-    if (value > 40)
-        bkg.setHsv(bkg.hue(), bkg.saturation(), value - 11);
-    else
-        bkg.setHsv(bkg.hue(), bkg.saturation(), value + 20);
-    addToTheme(mFormats, "currentLine", QColor(Qt::black), bkg.toRgb());
-    addToTheme(mFormats, "searchResult",
-               appPlt.color(QPalette::HighlightedText).darker(200),
-               appPlt.color(QPalette::Highlight).darker(200));
-    addToTheme(mFormats, "matchingBrackets", QColor("#2bc93d"), Qt::yellow, true);
-    addToTheme(mFormats, "mismatchedBrackets", Qt::white, QColor(150,0,0));
-    addToTheme(mFormats, "evaluatedCode", Qt::black, QColor("#F8A200"));
-
-    QPalette plt(QApplication::palette());
-    QColor base = plt.color(QPalette::Base);
-    QColor text = plt.color(QPalette::Text);
-    int shade = (base.red() + base.green() + base.blue() < 380) ? 160 : 100;
-
-    QColor whitespace_color((base.red() + text.red()) / 2,
-                            (base.green() + text.green()) / 2,
-                            (base.blue() + text.blue()) / 2);
-
-    addToTheme(mFormats, "whitespace", whitespace_color);
-    addToTheme(mFormats, "keyword", QColor(0,0,230).lighter(shade),
-                                    QColor(Qt::transparent), true);
-    addToTheme(mFormats, "built-in", QColor(51,51,191).lighter(shade));
-    addToTheme(mFormats, "env-var", QColor(140,70,20).lighter(shade));
-    addToTheme(mFormats, "class", QColor(0,0,210).lighter(shade));
-    addToTheme(mFormats, "number", QColor(152,0,153).lighter(shade));
-    addToTheme(mFormats, "symbol", QColor(0,115,0).lighter(shade));
-    addToTheme(mFormats, "string", QColor(95,95,95).lighter(shade));
-    addToTheme(mFormats, "char", QColor(0,115,0).lighter(shade));
-    addToTheme(mFormats, "comment", QColor(191,0,0).lighter(shade));
-    addToTheme(mFormats, "primitive", QColor(51,51,191).lighter(shade));
-    addToTheme(mFormats, "lineNumbers", plt.color(QPalette::ButtonText),
-                                        plt.color(QPalette::Mid));
-    addToTheme(mFormats, "selection", plt.color(QPalette::HighlightedText),
-                                      plt.color(QPalette::Highlight));
-    addToTheme(mFormats, "postwindowtext", plt.color(QPalette::ButtonText));
-    addToTheme(mFormats, "postwindowerror", QColor(209, 28, 36));
-    addToTheme(mFormats, "postwindowwarning", QColor(165, 119, 6));
-    addToTheme(mFormats, "postwindowsuccess", QColor(115, 138, 5));
-    addToTheme(mFormats, "postwindowemphasis", Qt::black, Qt::transparent, true);
-}
-
-void Theme::fillDark()
-{
-    addToTheme(mFormats, "text",               QColor("#ffa4e2"), Qt::black);
-    addToTheme(mFormats, "currentLine",        QColor("#e4e4e4"), QColor("#393939"));
-    addToTheme(mFormats, "searchResult",       QColor("#e4e4e4"), QColor("#194c7f"));
-    addToTheme(mFormats, "matchingBrackets",   QColor("#ff5500"), QColor("#001d49"), true);
-    addToTheme(mFormats, "mismatchedBrackets", QColor("#ffaa00"), QColor("#980000"));
-    addToTheme(mFormats, "evaluatedCode",      QColor("#e4e4e4"), QColor("#636397"));
-    addToTheme(mFormats, "whitespace",         QColor("#e4e4e4"));
-    addToTheme(mFormats, "keyword",            QColor("#aaaaff"), Qt::transparent, true);
-    addToTheme(mFormats, "built-in",           QColor("#ffa4e2"));
-    addToTheme(mFormats, "env-var",            QColor("#73e7ad"));
-    addToTheme(mFormats, "class",              QColor("#00abff"), Qt::transparent, true);
-    addToTheme(mFormats, "number",             QColor("#4aff00"));
-    addToTheme(mFormats, "symbol",             QColor("#ddde00"));
-    addToTheme(mFormats, "string",             QColor("#d7d7d7"));
-    addToTheme(mFormats, "char",               QColor("#ff55ff"));
-    addToTheme(mFormats, "comment",            QColor("#d4b982"));
-    addToTheme(mFormats, "primitive",          QColor("#aaff7f"));
-    addToTheme(mFormats, "lineNumbers",        QColor("#cfcfcf"));
-    addToTheme(mFormats, "selection",          QColor("#ff5500"));
-    addToTheme(mFormats, "postwindowtext",     QColor("#e4e4e4"));
-    addToTheme(mFormats, "postwindowerror",    QColor("#ff1f2a"));
-    addToTheme(mFormats, "postwindowwarning",  QColor("#de7100"));
-    addToTheme(mFormats, "postwindowsuccess",  QColor("#b0d206"));
-    addToTheme(mFormats, "postwindowemphasis", QColor("#e4e4e4"), Qt::transparent, true);
-}
-
-/*
-The MIT License (MIT)
-
-Copyright (c) 2016 Dracula Theme
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-https://github.com/dracula/dracula-theme/
-*/
-
-void Theme::fillDracula()
-{
-    addToTheme(mFormats, "text",               QColor("#f7fdff"), QColor("#282a36"));
-    addToTheme(mFormats, "currentLine",        QColor("#909194"), QColor("#282a36"));
-    addToTheme(mFormats, "searchResult",       QColor("#e4e4e4"), QColor("#194c7f"));
-    addToTheme(mFormats, "matchingBrackets",   QColor("#ff5500"), QColor("#001d49"), true);
-    addToTheme(mFormats, "mismatchedBrackets", QColor("#ffaa00"), QColor("#980000"));
-    addToTheme(mFormats, "evaluatedCode",      QColor("#e4e4e4"), QColor("#636397"));
-    addToTheme(mFormats, "whitespace",         QColor("#e4e4e4"));
-    addToTheme(mFormats, "keyword",            QColor("#ff76c7"), Qt::transparent, true);
-    addToTheme(mFormats, "built-in",           QColor("#e2e37a"));
-    addToTheme(mFormats, "env-var",            QColor("#ffb965"));
-    addToTheme(mFormats, "class",              QColor("#65e5ff"), Qt::transparent, true);
-    addToTheme(mFormats, "number",             QColor("#be90fc"));
-    addToTheme(mFormats, "symbol",             QColor("#45fc75"));
-    addToTheme(mFormats, "string",             QColor("#5df884"));
-    addToTheme(mFormats, "char",               QColor("#ff55ff"));
-    addToTheme(mFormats, "comment",            QColor("#6071a6"));
-    addToTheme(mFormats, "primitive",          QColor("#aaff7f"));
-    addToTheme(mFormats, "lineNumbers",        QColor("#909194"));
-    addToTheme(mFormats, "selection",          QColor("#e0eeff"));
-    addToTheme(mFormats, "postwindowtext",     QColor("#dfe0fc"));
-    addToTheme(mFormats, "postwindowerror",    QColor("#ff1f2a"));
-    addToTheme(mFormats, "postwindowwarning",  QColor("#de7100"));
-    addToTheme(mFormats, "postwindowsuccess",  QColor("#b0d206"));
-    addToTheme(mFormats, "postwindowemphasis", QColor("#e4e4e4"), Qt::transparent, true);
-}
-/* END MIT LICENSED CODE */
-
-/*
-The MIT license (MIT)
-
-Copyright (c) 2011 Ethan Schoonover
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-
-https://github.com/altercation/solarized
-*/
-
-void Theme::fillSolarizedLight()
-{
-    addToTheme(mFormats, "text",               QColor("#657b83"), QColor("#fdf6e3"));
-    addToTheme(mFormats, "currentLine",        Qt::transparent, QColor("#eee8d5"));
-    addToTheme(mFormats, "searchResult",       QColor("#93a1a1"), QColor("#073642"));
-    addToTheme(mFormats, "matchingBrackets",   QColor("#002b36"), QColor("#eee8d5"), true);
-    addToTheme(mFormats, "mismatchedBrackets", QColor("#eee8d5"), QColor("#586e75"));
-    addToTheme(mFormats, "evaluatedCode",      QColor("#586e75"), QColor("#eee8d5"));
-    addToTheme(mFormats, "whitespace",         Qt::transparent);
-    addToTheme(mFormats, "keyword",            QColor("#dc322f"), Qt::transparent, true);
-    addToTheme(mFormats, "built-in",           QColor("#b58900"));
-    addToTheme(mFormats, "env-var",            QColor("#d33682"));
-    addToTheme(mFormats, "class",              QColor("#268bd2"));
-    addToTheme(mFormats, "number",             QColor("#6c71c4"));
-    addToTheme(mFormats, "symbol",             QColor("#b58900"));
-    addToTheme(mFormats, "string",             QColor("#93a1a1"));
-    addToTheme(mFormats, "char",               QColor("#cb4b16"));
-    addToTheme(mFormats, "comment",            QColor("#586e75"), Qt::transparent, false, true);
-    addToTheme(mFormats, "primitive",          QColor("#2aa198"));
-    addToTheme(mFormats, "lineNumbers",        QColor("#839496"), QColor("#eee8d5"));
-    addToTheme(mFormats, "selection",          QColor("#fdf6e3"), QColor("#657b83"));
-    addToTheme(mFormats, "postwindowtext",     QColor("#657b83"));
-    addToTheme(mFormats, "postwindowerror",    QColor("#dc322f"));
-    addToTheme(mFormats, "postwindowwarning",  QColor("#cb4b16"));
-    addToTheme(mFormats, "postwindowsuccess",  QColor("#859900"));
-    addToTheme(mFormats, "postwindowemphasis", QColor("#b58900"), Qt::transparent, true);
-}
-
-void Theme::fillSolarizedDark()
-{
-    addToTheme(mFormats, "text",               QColor("#839496"), QColor("#002b36"));
-    addToTheme(mFormats, "currentLine",        Qt::transparent, QColor("#073642"));
-    addToTheme(mFormats, "searchResult",       QColor("#586e75"), QColor("#eee8d5"));
-    addToTheme(mFormats, "matchingBrackets",   QColor("#fdf6e3"), QColor("#073642"), true);
-    addToTheme(mFormats, "mismatchedBrackets", QColor("#073642"), QColor("#93a1a1"));
-    addToTheme(mFormats, "evaluatedCode",      QColor("#93a1a1"), QColor("#073642"));
-    addToTheme(mFormats, "whitespace",         Qt::transparent);
-    addToTheme(mFormats, "keyword",            QColor("#dc322f"), Qt::transparent, true);
-    addToTheme(mFormats, "built-in",           QColor("#b58900"));
-    addToTheme(mFormats, "env-var",            QColor("#d33682"));
-    addToTheme(mFormats, "class",              QColor("#268bd2"));
-    addToTheme(mFormats, "number",             QColor("#6c71c4"));
-    addToTheme(mFormats, "symbol",             QColor("#b58900"));
-    addToTheme(mFormats, "string",             QColor("#586e75"));
-    addToTheme(mFormats, "char",               QColor("#cb4b16"));
-    addToTheme(mFormats, "comment",            QColor("#93a1a1"), Qt::transparent, false, true);
-    addToTheme(mFormats, "primitive",          QColor("#2aa198"));
-    addToTheme(mFormats, "lineNumbers",        QColor("#657b83"), QColor("#073642"));
-    addToTheme(mFormats, "selection",          QColor("#002b36"), QColor("#839496"));
-    addToTheme(mFormats, "postwindowtext",     QColor("#839496"));
-    addToTheme(mFormats, "postwindowerror",    QColor("#dc322f"));
-    addToTheme(mFormats, "postwindowwarning",  QColor("#cb4b16"));
-    addToTheme(mFormats, "postwindowsuccess",  QColor("#859900"));
-    addToTheme(mFormats, "postwindowemphasis", QColor("#b58900"), Qt::transparent, true);
-}
-
-/* END MIT LICENSED COSE */
 
 void Theme::fillUser(const QString & name, const Manager *settings)
 {
@@ -454,8 +197,7 @@ void Theme::setFormat(const QString & key, const QTextCharFormat & newFormat)
     }
 
     mFormats.remove(key);
-    addToTheme(mFormats, key.toStdString().c_str(), fg, bg, fontWeight,
-                                                    newFormat.fontItalic());
+    addToTheme(key.toStdString().c_str(), fg, bg, fontWeight, newFormat.fontItalic());
 }
 
 const QTextCharFormat & Theme::format(const QString & key)

--- a/editors/sc-ide/core/settings/theme.cpp
+++ b/editors/sc-ide/core/settings/theme.cpp
@@ -135,6 +135,9 @@ Theme::Theme(const QString & _name, Manager * settings)
     if (mName == "default") {
         fillDefault();
         mLocked = true;
+    } else if (mName == "classic") {
+        fillClassic();
+        mLocked = true;
     } else if (mName == "dark") {
         fillDark();
         mLocked = true;
@@ -162,6 +165,8 @@ Theme::Theme(const QString & _name, const QString & _source, Manager * settings)
 
     if (_source == "default") {
         fillDefault();
+    } else if (_source == "classic") {
+        fillClassic();
     } else if (_source == "dark") {
         fillDark();
     } else if (_source == "dracula") {
@@ -220,6 +225,7 @@ QList<QString> Theme::availableThemes()
     QList<QString> themes;
 
     themes.append("default");
+    themes.append("classic");
     themes.append("dark");
     themes.append("dracula");
     themes.append("solarizedLight");

--- a/editors/sc-ide/core/settings/theme.cpp
+++ b/editors/sc-ide/core/settings/theme.cpp
@@ -100,6 +100,48 @@ static void addToTheme(QMap<QString, QTextCharFormat *> & map, const char *key,
 
 void Theme::fillDefault()
 {
+    QColor background("#f7f7f7");
+    QColor current_line("#efefef");
+    QColor selection("#d6d6d6");
+    QColor foreground("#1a1a1a");
+    QColor line_number("#c7c4c2");
+    QColor comment("#848484");
+    QColor red("#cc3626");
+    QColor orange("#c07f00");
+    QColor yellow("#ada526");
+    QColor green("#3f831e");
+    QColor cyan("#3582bc");
+    QColor blue("#3951c9");
+    QColor purple("#af33a6");
+
+    addToTheme(mFormats, "text",               foreground, background);
+    addToTheme(mFormats, "currentLine",        foreground, current_line);
+    addToTheme(mFormats, "searchResult",       background, blue);
+    addToTheme(mFormats, "matchingBrackets",   foreground, background, true);
+    addToTheme(mFormats, "mismatchedBrackets", background, red);
+    addToTheme(mFormats, "evaluatedCode",      background, orange);
+    addToTheme(mFormats, "whitespace",         background);
+    addToTheme(mFormats, "keyword",            red);
+    addToTheme(mFormats, "built-in",           yellow);
+    addToTheme(mFormats, "env-var",            orange);
+    addToTheme(mFormats, "class",              cyan);
+    addToTheme(mFormats, "number",             purple);
+    addToTheme(mFormats, "symbol",             green);
+    addToTheme(mFormats, "string",             blue);
+    addToTheme(mFormats, "char",               green);
+    addToTheme(mFormats, "comment",            comment);
+    addToTheme(mFormats, "primitive",          orange);
+    addToTheme(mFormats, "lineNumbers",        line_number);
+    addToTheme(mFormats, "selection",          foreground, selection);
+    addToTheme(mFormats, "postwindowtext",     foreground);
+    addToTheme(mFormats, "postwindowerror",    red);
+    addToTheme(mFormats, "postwindowwarning",  orange);
+    addToTheme(mFormats, "postwindowsuccess",  green);
+    addToTheme(mFormats, "postwindowemphasis", foreground, Qt::transparent, true);
+}
+
+void Theme::fillClassic()
+{
     addToTheme(mFormats, "text", QColor(Qt::black), QColor(Qt::white));
 
     QPalette appPlt(QApplication::palette());

--- a/editors/sc-ide/core/settings/theme.hpp
+++ b/editors/sc-ide/core/settings/theme.hpp
@@ -51,6 +51,7 @@ public:
 private:
     void fillUser(const QString & theme, const Manager *settings);
     void fillDefault();
+    void fillClassic();
     void fillDark();
     void fillDracula();
     void fillSolarizedLight();

--- a/editors/sc-ide/core/settings/theme.hpp
+++ b/editors/sc-ide/core/settings/theme.hpp
@@ -57,6 +57,14 @@ private:
     void fillSolarizedLight();
     void fillSolarizedDark();
 
+    void addToTheme(
+        const char *key,
+        const QColor & fg,
+        const QColor & bg = QColor(Qt::transparent),
+        bool bold = false,
+        bool italic = false
+    );
+
     bool mLocked;
     QMap<QString, QTextCharFormat *> mFormats;
     QString mName;

--- a/editors/sc-ide/core/settings/theme.hpp
+++ b/editors/sc-ide/core/settings/theme.hpp
@@ -57,7 +57,7 @@ private:
     void fillSolarizedLight();
     void fillSolarizedDark();
 
-    void addToTheme(
+    void add(
         const char *key,
         const QColor & fg,
         const QColor & bg = QColor(Qt::transparent),


### PR DESCRIPTION
Purpose and Motivation
----------------------

the default IDE theme is quite ugly. providing a professional looking default theme improves first impressions of SC. also if SC educators don't have to look at #ffffff white backgrounds when helping students, that's a plus.

this PR supplies a new default theme. here's what it looks like with some SynthDef code:

![untitled](https://user-images.githubusercontent.com/1211064/44705754-6c8db080-aa54-11e8-86c2-0556dcc7e13c.png)

here is the full gamut of code colors and the syntax elements they correspond to:

![untitled](https://user-images.githubusercontent.com/1211064/44747644-85cd4600-aac2-11e8-83ed-87b730a67a6a.png)

i wanted to keep it a light theme to avoid making the change too radical from 3.9. the colors are lifted from [Kary Pro Color](https://github.com/pmkary/kf-theme-vscode), but i switched them around considerably to keep an attractive balance of hues in typical SC code.

the background is light gray and not white like the old theme. however, it is still quite high contrast. it looks especially great with a beefy font choice like Source Code Pro Medium (above) or Meslo LG.

i avoided bold text. some themes can pull it off, but i think it looks pretty unprofessional in syntax highlighting. the most popular editor themes use bold very sparingly.

 too many inconsistent colors become hard to tweak, and just don't look very good. i reused some colors:  `~environmentVars` / `_Primitive` (both of which are very unlikely to occur in adjacent code), and numerics/characters/builtins (all of which are "atomic" literals).

old theme is renamed to "classic."

Types of changes
----------------

cosmetic change

Checklist
---------

<!--- Complete an item by checking it: [x] -->

- [x] All tests are passing
- [x] If necessary, new tests were created to address changes in PR, and tests are passing
- [x] Updated documentation, if necessary
- [x] This PR is ready for review

Remaining Work
------------

right now the help browser still has #fffff background, so it looks off from the default theme. we should change it, but i will leave that for another PR.