### PR TITLE
class library: Check message is >= template size in OSCArgsMatcher

### DIFF
--- a/SCClassLibrary/Common/Control/ResponseDefs.sc
+++ b/SCClassLibrary/Common/Control/ResponseDefs.sc
@@ -393,8 +393,9 @@ OSCArgsMatcher : AbstractMessageMatcher {
 	init {|argArgTemplate, argFunc| argTemplate = argArgTemplate.asArray; func = argFunc; }
 
 	value {|testMsg, time, addr, recvPort|
-		testMsg[1..].do({|item, i|
-			if(argTemplate[i].matchItem(item).not, {^this});
+		var msgArgs = testMsg[1..];
+		argTemplate.do({|item, i|
+			if(item.matchItem(msgArgs[i]).not, {^this});
 		});
 		func.value(testMsg, time, addr, recvPort)
 	}

--- a/testsuite/classlibrary/TestOSCFunc.sc
+++ b/testsuite/classlibrary/TestOSCFunc.sc
@@ -1,0 +1,32 @@
+TestOSCFunc : UnitTest {
+
+	test_argSizeMatchingSucceeds {
+		var cond = Condition();
+		var oscfunc;
+		var result = 0;
+
+		oscfunc = OSCFunc({ result = 1; cond.unhang; }, "/test_argSizeMatchingSucceeds", argTemplate: [2, 3]);
+
+		NetAddr.localAddr.sendMsg( "/test_argSizeMatchingSucceeds", 2, 3); // this should match
+		fork { 0.1.wait; cond.unhang };
+
+		cond.hang;
+
+		this.assertEquals(result, 1);
+	}
+
+	test_argSizeMatchingFails {
+		var cond = Condition();
+		var oscfunc;
+		var result = 0;
+
+		oscfunc = OSCFunc({ result = 1; cond.unhang; }, "/test_argSizeMatchingFails", argTemplate: [2, 3]);
+
+		NetAddr.localAddr.sendMsg( "/test_argSizeMatchingFails", 2); // we need at least the same numArgs in the template
+		fork { 0.1.wait; cond.unhang };
+
+		cond.hang;
+
+		this.assertEquals(result, 0);
+	}
+}

--- a/testsuite/classlibrary/TestOSCFunc.sc
+++ b/testsuite/classlibrary/TestOSCFunc.sc
@@ -1,6 +1,6 @@
 TestOSCFunc : UnitTest {
 
-	test_argSizeMatchingSucceeds {
+	test_argSizeMatching_Succeeds {
 		var cond = Condition();
 		var oscfunc;
 		var result = 0;
@@ -15,7 +15,7 @@ TestOSCFunc : UnitTest {
 		this.assertEquals(result, 1);
 	}
 
-	test_argSizeMatchingFails {
+	test_argSizeMatching_Fails {
 		var cond = Condition();
 		var oscfunc;
 		var result = 0;


### PR DESCRIPTION
Purpose and Motivation
----------------------

Fix bug noted in issue #1482 in which OSCArgsMatcher would show a match with fewer args than the template.

Types of changes
----------------

- Bug fix (non-breaking change which fixes an issue)

Checklist
---------

- [x] All tests are passing
- [x] If necessary, new tests were created to address changes in PR, and tests are passing
(There's no new functionality, so I've not added a test for this, though I can if needed)
- [x] Updated documentation, if necessary
- [x] This PR is ready for review
