### PR TITLE
[scide] [scdoc] Add syntax highlighting for scale degree literals

### DIFF
--- a/HelpSource/editor.js
+++ b/HelpSource/editor.js
@@ -6,6 +6,7 @@ const init = () => {
             { regex: /^(?:arg|classvar|const|super|this|var)\b/, token: 'keyword' },
             { regex: /^(?:false|inf|nil|true|thisFunction|thisFunctionDef|thisMethod|thisProcess|thisThread|currentEnvironment|topEnvironment)\b/, token: 'built-in' },
             { regex: /^\b\d+r[0-9a-zA-Z]*(\.[0-9A-Z]*)?/, token: 'number radix-float' },
+            { regex: /^\b\d+(s+|b+|[sb]\d+)\b/, token: 'number scale-degree' },
             { regex: /^\b((\d+(\.\d+)?([eE][-+]?\d+)?(pi)?)|pi)\b/, token: 'number float' },
             { regex: /^\b0(x|X)(\d|[a-f]|[A-F])+/, token: 'number hex-int' },
             { regex: /^\b[A-Za-z_]\w*\:/, token: 'symbol symbol-arg' },
@@ -36,7 +37,7 @@ const init = () => {
             value: code,
             lineWrapping: true,
             viewportMargin: Infinity,
-            extraKeys: { 
+            extraKeys: {
                 'Shift-Enter': evalLine
             }
         })
@@ -118,7 +119,7 @@ const selectRegion = (options = { flash: true }) => {
     /* no parens found */
     if (parenPairs.length === 0)
         return selectLine(options)
-    
+
     let pair = parenPairs.pop()
     leftCursor = pair[0]
     rightCursor = pair[1]

--- a/editors/sc-ide/core/sc_lexer.cpp
+++ b/editors/sc-ide/core/sc_lexer.cpp
@@ -45,6 +45,9 @@ void ScLexer::initLexicalRules()
 
     mLexicalRules << LexicalRule( Token::RadixFloat, "^\\b\\d+r[0-9a-zA-Z]*(\\.[0-9A-Z]*)?" );
 
+    // Never heard of this one? Check the "Literals" help file :)
+    mLexicalRules << LexicalRule( Token::ScaleDegreeFloat, "^\\b\\d+(s+|b+|[sb]\\d+)\\b" );
+
     // do not include leading "-" in Float, as left-to-right algorithm does
     // not know whether it is not rather a binary operator
     mLexicalRules << LexicalRule( Token::Float, "^\\b((\\d+(\\.\\d+)?([eE][-+]?\\d+)?(pi)?)|pi)\\b" );

--- a/editors/sc-ide/widgets/code_editor/highlighter.cpp
+++ b/editors/sc-ide/widgets/code_editor/highlighter.cpp
@@ -130,6 +130,7 @@ void SyntaxHighlighter::highlightBlockInCode(ScLexer & lexer)
 
         case Token::Float:
         case Token::HexInt:
+        case Token::ScaleDegreeFloat:
         case Token::RadixFloat:
             setFormat(tokenPosition, tokenLength, formats[NumberFormat]);
             break;

--- a/editors/sc-ide/widgets/code_editor/tokens.hpp
+++ b/editors/sc-ide/widgets/code_editor/tokens.hpp
@@ -44,6 +44,7 @@ struct Token
         StringMark,
         Char,
         RadixFloat,
+        ScaleDegreeFloat,
         Float,
         HexInt,
         EnvVar,


### PR DESCRIPTION
Purpose and Motivation
----------------------

fix #2545. scide and scdoc now correctly highlight scale degree literals.

Types of changes
----------------

<!--- What types of changes does your pull request introduce? -->
<!--- Some examples are below (you can delete the lines that don't apply): -->

- Bug fix (non-breaking change which fixes an issue)

Checklist
---------

- [x] All tests are passing
- [x] If necessary, new tests were created to address changes in PR, and tests are passing
- [x] Updated documentation, if necessary
- [x] This PR is ready for review
