### PR TITLE
Classlib: Remove pseudo-method calls from Pspawn:embedInStream

### DIFF
--- a/SCClassLibrary/Common/Streams/Pspawner.sc
+++ b/SCClassLibrary/Common/Streams/Pspawner.sc
@@ -100,29 +100,30 @@ Pspawn : FilterPattern {
 
 	embedInStream { |inevent|
 		^Spawner({ |sp|
-			var	event, stream = pattern.asStream, child;
+			var	event, stream = pattern.asStream, child, method;
 			while { (event = stream.next(spawnProtoEvent.copy.put(\spawner, sp))).notNil } {
+				method = event[\method];
 				case
-				{ event.method == \wait } {
-					event.spawner.wait(event.delta)
+				{ method == \wait } {
+					event[\spawner].wait(event.delta)
 				}
-				{ #[seq, par].includes(event.method) } {
+				{ #[seq, par].includes(method) } {
 					child = event[\pattern];
 					if(child.isKindOf(Symbol)) {
 						child = (event[\dict] ? Pdef).at(child);
 					};
-					event.spawner.perform(event.method, child.value(event));
+					event[\spawner].perform(event.method, child.value(event));
 					if(event.delta > 0) {
-						event.spawner.wait(event.delta)
+						event[\spawner].wait(event.delta)
 					}
 				}
 				// suspend requires access to the specific stream
 				// don't know how to get it... maybe implement later
-				{ event.method == \suspendAll } {
-					event.spawner.suspendAll
+				{ method == \suspendAll } {
+					event[\spawner].suspendAll
 				}
 				{ "Unrecognized method % in spawner event."
-					.format(event.method.asCompileString).warn;
+					.format(method.asCompileString).warn;
 				}
 			};
 		}).embedInStream(inevent)


### PR DESCRIPTION
Purpose and Motivation
----------------------

Fixes #1084.

Types of changes
----------------

- Bug fix (non-breaking change which fixes an issue)

Checklist
---------

- [x] All tests are passing
- [ ] If necessary, new tests were created to address changes in PR, and tests are passing (I don't believe additional tests are needed)
- [ ] Updated documentation, if necessary (no documentation changes needed)
- [x] This PR is ready for review

Note
----

As a sidenote -- in #1084, Julian said:

> To fix this, we can use a direct lookup event[\method] but in order to make it fully backward compatible, it would have to be:
> 
> ```
> method = event[\method];
> method !? { method = method.functionPerformList(\value, event) }
> ```

I don't think we have to be that fussy. Pspawn is not used very much, and `method` should be chosen algorithmically using patterns, and the other pseudo-method (`spawner`) must not be overridden or the whole thing breaks. I'd be content to say that putting functions there is incorrect usage.