### PR TITLE
Add default values to some waveshaping methods

### DIFF
--- a/SCClassLibrary/Common/Collections/SequenceableCollection.sc
+++ b/SCClassLibrary/Common/Collections/SequenceableCollection.sc
@@ -822,9 +822,9 @@ SequenceableCollection : Collection {
 	amclip { arg aNumber, adverb; ^this.performBinaryOp('amclip', aNumber, adverb) }
 	scaleneg { arg aNumber, adverb; ^this.performBinaryOp('scaleneg', aNumber, adverb) }
 	clip2 { arg aNumber=1, adverb; ^this.performBinaryOp('clip2', aNumber, adverb) }
-	fold2 { arg aNumber, adverb; ^this.performBinaryOp('fold2', aNumber, adverb) }
-	wrap2 { arg aNumber, adverb; ^this.performBinaryOp('wrap2', aNumber, adverb) }
-	excess { arg aNumber, adverb; ^this.performBinaryOp('excess', aNumber, adverb) }
+	fold2 { arg aNumber=1, adverb; ^this.performBinaryOp('fold2', aNumber, adverb) }
+	wrap2 { arg aNumber=1, adverb; ^this.performBinaryOp('wrap2', aNumber, adverb) }
+	excess { arg aNumber=1, adverb; ^this.performBinaryOp('excess', aNumber, adverb) }
 	firstArg { arg aNumber, adverb; ^this.performBinaryOp('firstArg', aNumber, adverb) }
 	rrand { arg aNumber, adverb; ^this.performBinaryOp('rrand', aNumber, adverb) }
 	exprand { arg aNumber, adverb; ^this.performBinaryOp('exprand', aNumber, adverb) }

--- a/SCClassLibrary/Common/Math/Signal.sc
+++ b/SCClassLibrary/Common/Math/Signal.sc
@@ -277,9 +277,9 @@ Signal[float] : FloatArray {
 	amclip { arg aNumber; _AMClip; ^aNumber.performBinaryOpOnSignal('amclip', this) }
 	scaleneg { arg aNumber; _ScaleNeg; ^aNumber.performBinaryOpOnSignal('scaleneg', this) }
 	clip2 { arg aNumber=1; _Clip2; ^aNumber.performBinaryOpOnSignal('clip2', this) }
-	fold2 { arg aNumber; _Fold2; ^aNumber.performBinaryOpOnSignal('fold2', this) }
-	wrap2 { arg aNumber; _Wrap2; ^aNumber.performBinaryOpOnSignal('wrap2', this) }
-	excess { arg aNumber; _Excess; ^aNumber.performBinaryOpOnSignal('excess', this) }
+	fold2 { arg aNumber=1; _Fold2; ^aNumber.performBinaryOpOnSignal('fold2', this) }
+	wrap2 { arg aNumber=1; _Wrap2; ^aNumber.performBinaryOpOnSignal('wrap2', this) }
+	excess { arg aNumber=1; _Excess; ^aNumber.performBinaryOpOnSignal('excess', this) }
 	firstArg { arg aNumber; _FirstArg; ^aNumber.performBinaryOpOnSignal('firstArg', this) }
 
 	== { arg aNumber; _EQ; ^aNumber.performBinaryOpOnSignal('==', this) }

--- a/SCClassLibrary/Common/Math/SimpleNumber.sc
+++ b/SCClassLibrary/Common/Math/SimpleNumber.sc
@@ -103,11 +103,11 @@ SimpleNumber : Number {
 	thresh { |aNumber, adverb| _Thresh; ^aNumber.performBinaryOpOnSimpleNumber('thresh', this, adverb) }
 	amclip { |aNumber, adverb| _AMClip; ^aNumber.performBinaryOpOnSimpleNumber('amclip', this, adverb) }
 	scaleneg { |aNumber, adverb| _ScaleNeg; ^aNumber.performBinaryOpOnSimpleNumber('scaleneg', this, adverb) }
-	clip2 { |aNumber, adverb| _Clip2; ^aNumber.performBinaryOpOnSimpleNumber('clip2', this, adverb) }
-	fold2 { |aNumber, adverb| _Fold2; ^aNumber.performBinaryOpOnSimpleNumber('fold2', this, adverb) }
-	wrap2 { |aNumber, adverb| _Wrap2; ^aNumber.performBinaryOpOnSimpleNumber('wrap2', this, adverb) }
+	clip2 { |aNumber=1, adverb| _Clip2; ^aNumber.performBinaryOpOnSimpleNumber('clip2', this, adverb) }
+	fold2 { |aNumber=1, adverb| _Fold2; ^aNumber.performBinaryOpOnSimpleNumber('fold2', this, adverb) }
+	wrap2 { |aNumber=1, adverb| _Wrap2; ^aNumber.performBinaryOpOnSimpleNumber('wrap2', this, adverb) }
 
-	excess { |aNumber, adverb| _Excess; ^aNumber.performBinaryOpOnSimpleNumber('excess', this, adverb) }
+	excess { |aNumber=1, adverb| _Excess; ^aNumber.performBinaryOpOnSimpleNumber('excess', this, adverb) }
 	firstArg { |aNumber, adverb| _FirstArg; ^aNumber.performBinaryOpOnSimpleNumber('firstArg', this, adverb) }
 	rrand { |aNumber, adverb| _RandRange; ^aNumber.performBinaryOpOnSimpleNumber('rrand', this, adverb) }
 	exprand { |aNumber, adverb| _ExpRandRange; ^aNumber.performBinaryOpOnSimpleNumber('exprand', this, adverb) }


### PR DESCRIPTION
<!--- Hi, and thanks for contributing! -->
<!--- Make sure to provide a general summary of your changes in the title above. -->
<!--- For example: "[scsynth] Fix crash when encountering cute kittens" -->

Purpose and Motivation
----------------------

Some waveshaping methods (`fold2`, `warp2`, and `excess`) didn't have default values. Doing ```[0, 0].fold2``` caused an error while ```[0, 0].clip2``` worked. This PR gives a default value of `1` to these methods.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to it here by writing "Fixes #555". -->

Types of changes
----------------

<!--- What types of changes does your pull request introduce? -->
<!--- Some examples are below (you can delete the lines that don't apply): -->

- Bug fix (non-breaking change which fixes an issue)

Checklist
---------

<!--- Complete an item by checking it: [x] -->

- [ ] All tests are passing
- [ ] If necessary, new tests were created to address changes in PR, and tests are passing
- [ ] Updated documentation, if necessary
- [X] This PR is ready for review

<!--- See DEVELOPING.md for instructions on running and writing tests. -->

Remaining Work
--------------

<!--- If any work remains to be done, please give a brief description here. -->
<!--- Consider providing a todo-list so we can easily track completion progress. -->

<!--- Thanks for contributing! -->
