### PR TITLE
appveyor: use previous images

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -9,7 +9,7 @@ version: '{build}' # incremented with each build
 clone_depth: 10
 
 # https://www.appveyor.com/docs/build-environment/#build-worker-images
-image: Visual Studio 2017
+image: Previous Visual Studio 2017
 
 # disable automatic tests
 test: off


### PR DESCRIPTION
Purpose and Motivation
----------------------

Appveyor builds are currently failing because of an update to VS 15.8
which breaks lots of things.

Types of changes
----------------

As documented on Appveyor's site, use the previous (working) VS 2017
image.

- Bug fix (non-breaking change which fixes an issue)