### PR TITLE
Cmake: force set install prefix on macos

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,7 +130,7 @@ endif()
 
 if(APPLE)
 	if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
-		set(CMAKE_INSTALL_PREFIX "${CMAKE_BINARY_DIR}/Install" CACHE STRING "Cmake install path")
+		set(CMAKE_INSTALL_PREFIX "${CMAKE_BINARY_DIR}/Install" CACHE STRING "Cmake install path" FORCE)
 	endif()
 elseif(UNIX)
 	add_definitions(-DSC_DATA_DIR="${CMAKE_INSTALL_PREFIX}/share/SuperCollider")


### PR DESCRIPTION

<!--- Hi, and thanks for contributing! -->
<!--- Make sure to provide a general summary of your changes in the title above. -->
<!--- For example: "[scsynth] Fix crash when encountering cute kittens" -->

Purpose and Motivation
----------------------

this fixes an issue where experiencing a cmake config-step error would leave install prefix set to /usr/local

Seen in https://github.com/supercollider/supercollider/issues/3931 and elsewhere.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to it here by writing "Fixes #555". -->

Types of changes
----------------

- Bug fix (non-breaking change which fixes an issue)

Checklist
---------

<!--- Complete an item by checking it: [x] -->

- [x] All tests are passing
- [x] If necessary, new tests were created to address changes in PR, and tests are passing
- [x] Updated documentation, if necessary
- [x] This PR is ready for review

You can test this issue this way:

Before this PR (off 3.10 or develop):

1. `git submodule deinit --all`
2. starting from a fresh build directory, run the cmake configure step
3. configuring will fail because certain files are not found in external_libraries
4. at this point, run `cmake -L` to see that `CMAKE_PREFIX_PATH` is set to /usr/local
5. if you want to recreate #3931, re-initialize submodules and build the `install` target

After this PR:

1. `git submodule deinit --all`
2. starting from a fresh build directory, run the cmake configure step
3. configuring will fail because certain files are not found in external_libraries
4. at this point, run `cmake -L` to see that `CMAKE_PREFIX_PATH` is now set to the reasonable default

<!--- See DEVELOPING.md for instructions on running and writing tests. -->

Remaining Work
--------------

<!--- If any work remains to be done, please give a brief description here. -->
<!--- Consider providing a todo-list so we can easily track completion progress. -->

<!--- Thanks for contributing! -->
