### PR TITLE
Topic/fix macos linking

### DIFF
--- a/editors/sc-ide/CMakeLists.txt
+++ b/editors/sc-ide/CMakeLists.txt
@@ -436,6 +436,10 @@ if(APPLE OR WIN32)
                 \"${CMAKE_INSTALL_PREFIX}/SuperCollider/SuperCollider.app\"
                 -verbose=1
                 -executable=${CMAKE_INSTALL_PREFIX}/SuperCollider/SuperCollider.app/Contents/MacOS/sclang
+                -executable=${CMAKE_INSTALL_PREFIX}/SuperCollider/SuperCollider.app/Contents/Resources/scsynth
+                -executable=${CMAKE_INSTALL_PREFIX}/SuperCollider/SuperCollider.app/Contents/Resources/supernova
+                -executable=${CMAKE_INSTALL_PREFIX}/SuperCollider/SuperCollider.app/Contents/Resources/plugins/DiskIO_UGens.scx
+                -executable=${CMAKE_INSTALL_PREFIX}/SuperCollider/SuperCollider.app/Contents/Resources/plugins/DiskIO_UGens_supernova.scx
                 -executable=${CMAKE_INSTALL_PREFIX}/SuperCollider/SuperCollider.app/Contents/Frameworks/QtWebEngineCore.framework/Versions/5/Helpers/QtWebEngineProcess.app/Contents/MacOS/QtWebEngineProcess
             ")
     else() # WIN32

--- a/editors/sc-ide/CMakeLists.txt
+++ b/editors/sc-ide/CMakeLists.txt
@@ -442,12 +442,17 @@ if(APPLE OR WIN32)
                 -executable=${CMAKE_INSTALL_PREFIX}/SuperCollider/SuperCollider.app/Contents/Resources/plugins/DiskIO_UGens_supernova.scx
                 -executable=${CMAKE_INSTALL_PREFIX}/SuperCollider/SuperCollider.app/Contents/Frameworks/QtWebEngineCore.framework/Versions/5/Helpers/QtWebEngineProcess.app/Contents/MacOS/QtWebEngineProcess
             ")
+        set(VERIFY_CMD "include(BundleUtilities)
+            message(STATUS \"Verifying app\")
+            verify_app(\"${CMAKE_INSTALL_PREFIX}/SuperCollider/SuperCollider.app\")
+            ")
     else() # WIN32
         find_program(DEPLOY_PROG windeployqt PATHS ${CMAKE_PREFIX_PATH})
         set(DEPLOY_CMD "\"${DEPLOY_PROG}\"
                 --verbose 1 --no-compiler-runtime
                 \"${CMAKE_INSTALL_PREFIX}/${SC_WIN_BUNDLE_NAME}/sclang.exe\"
             ")
+        set(VERIFY_CMD "")
     endif()
 
     if(NOT DEPLOY_PROG)
@@ -469,6 +474,7 @@ if(APPLE OR WIN32)
             if(RES)
                 message(FATAL_ERROR \"Deploy failed with error: \${ERR}\")
             endif()
+            ${VERIFY_CMD}
         "
     )
 endif()


### PR DESCRIPTION
Purpose and Motivation
----------------------

Adds 4 files to check when running the macdeployqt command on MacOS: scsynth, supernova,
and DiskIO plugins. This is a quick-fix for #4007.

Types of changes
----------------
- Bug fix (non-breaking change which fixes an issue)

Checklist
---------

<!--- Complete an item by checking it: [x] -->

- [ ] All tests are passing
- [ ] If necessary, new tests were created to address changes in PR, and tests are passing
- [ ] Updated documentation, if necessary
- [ ] This PR is ready for review

I have confirmed that the bundling works both with and without supernova, using this command (run inside the app bundle) which doesn't echo any linked libraries in /opt/local:

```sh 
for file in **/scsynth **/sclang **/supernova **/*.scx; do otool -L $file|egrep "/opt/local"; done
```

Remaining Work
--------------

- Paths to executables and DiskIO plugins are currently hardcoded, which means macdeployqt tries to check supernova even if it isn't built. It works on my machine (Qt 5.10.1), but I guess the behaviour can change in future qt versions. 
- It might be a better long-term solution to use fixup_bundle to resolve the non-qt dependencies. I tried that briefly but got a lot of errors, and decided to finish this version instead.
- I don't know if verify_app would be good to run on the windows bundle as well? Currently it's only MacOS only.   
