### PR TITLE
[travis] disable builds if no source files are touched

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,12 @@ cache:
  - ccache
 
 before_install:
+ - |
+  MODIFIED_FILES=$(git diff --name-only $TRAVIS_COMMIT_RANGE)
+  if ! echo ${MODIFIED_FILES} | grep -qvE '(\.md$)|(^(examples|HelpSource|package|sounds|tools))/'; then
+    echo "No source files were changed, stopping build process."
+    exit 0
+  fi
  - $TRAVIS_BUILD_DIR/.travis/before-install-$TRAVIS_OS_NAME.sh --qt=$QT
 
 before_script:


### PR DESCRIPTION
After seeing the work done in #4039 to be able to skip travis builds with a commit message, I thought it could be a good idea to do this automatically when no source files are touched.
Some advantages to this approach might be:
- no commit message "pollution"
- contributors do not need to worry too much about adding `[skip XXX]` as the check is done automatically
- we do not "promote" the use of `[skip XXX]` too much, which could be a good idea ;)

In a PR, if the modified files are **only** either `.md` files, either from `examples`, `HelpSource`, `package`, `sounds` and/or `tools` folders, travis builds will exit early.

Please note that I have no idea about how AppVeyor works, but I would be willing to have a look into it.

I have tested this on my fork:
https://github.com/gusano/supercollider/pull/25
- first commit only touched a markdown file: [builds exited early](https://travis-ci.org/gusano/supercollider/builds/426151139?utm_source=github_status&utm_medium=notification)
- second commit touched a cpp file: [builds ran normally](https://travis-ci.org/gusano/supercollider/builds/426152097?utm_source=github_status&utm_medium=notification)