### PR TITLE
NdefGui: re-enable typeView update

### DIFF
--- a/SCClassLibrary/JITLib/GUI/NdefGui.sc
+++ b/SCClassLibrary/JITLib/GUI/NdefGui.sc
@@ -386,7 +386,7 @@ NdefGui : JITGui {
 
 		if (typeView.notNil) {
 			if (newState[\type] != prevState[\type]) {
-				// typeView.string_(newState[\type].asString)
+				typeView.string_(newState[\type].asString)
 			}
 		};
 


### PR DESCRIPTION
in NdefGui:checkUpdate, the update to the typeView was accidentally commented out. 
this PR reenables it, so NdefGuis again display the rate (ar/kr) and numChannels of its proxy.

just a minimal bug fix, so it introduces no new features, and no need to add tests or documentation.
- [x] This PR is ready for review
