### PR TITLE
[sclang] Fixes wrong bus plotting with control rate signals

### DIFF
--- a/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
+++ b/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
@@ -849,8 +849,13 @@ Plotter {
 
 + Bus {
 	plot { |duration = 0.01, bounds, minval, maxval, separately = false|
-		^{ InFeedback.ar(this.index, this.numChannels) }.plot(duration, this.server, bounds, minval, maxval, separately)
+		if (this.rate == \audio, {
+			^{ InFeedback.ar(this.index, this.numChannels) }.plot(duration, this.server, bounds, minval, maxval, separately);
+		},{
+			^{ In.kr(this.index, this.numChannels) }.plot(duration, this.server, bounds, minval, maxval, separately);
+		});
 	}
+	
 	plotAudio { |duration = 0.01, minval = -1, maxval = 1, bounds|
 		^this.plot(duration, bounds, minval, maxval)
 	}


### PR DESCRIPTION
Purpose and Motivation
----------------------

It was not possible to plot control rate signals in a bus.

For instance, in SC 3.10 beta 2

```supercollider
(
(
~debugBus = Bus.control(s, 1);
SynthDef(\test2, { |out, debug|
    var pulse = LFPulse.kr(1);
    Out.kr(debug, pulse);
    Out.ar(out, SinOsc.ar(440) * Lag.kr(pulse,1));
}).add;
)
Synth(\test2, [out: 0, debug: ~debugBus.index]);
~debugBus.plot(3);
```

plots an audio signal or nothing, but not the signal from the control rate bus.

![capture d ecran 8](https://user-images.githubusercontent.com/352910/45598943-a878bd80-b9e3-11e8-9de4-8ffe5d418ca3.png)

This PR solves that and you get the right signal plotted.

![capture d ecran 9](https://user-images.githubusercontent.com/352910/45598946-b1698f00-b9e3-11e8-81a8-91dca090ce88.png)

Types of changes
----------------

Bus.plot was assuming the signal was audio rate.
Now we check if the signal is control rate or audio rate and use In.kr or InFeedback.ar accordingly.

Checklist
---------

- [X] All previous tests are passing
- [ ] Tests were updated or created to address changes in this PR, and tests are passing
- [ ] Updated documentation, if necessary
- [X] This PR is ready for review

Remaining Work
--------------
I don't know how to unit test that.