### PR TITLE
docs/travis: note that macOS >= 10.10 is required

### DIFF
--- a/.travis/before-script-osx.sh
+++ b/.travis/before-script-osx.sh
@@ -3,6 +3,6 @@
 cmake -G"Xcode" \
     -DRULE_LAUNCH_COMPILE=ccache \
     -DCMAKE_PREFIX_PATH=`brew --prefix qt5` \
-    -DCMAKE_OSX_DEPLOYMENT_TARGET=10.8 \
+    -DCMAKE_OSX_DEPLOYMENT_TARGET=10.10 \
     -DSUPERNOVA=ON \
     $TRAVIS_BUILD_DIR --debug-output

--- a/README.md
+++ b/README.md
@@ -21,6 +21,11 @@ To get the latest stable version, Linux users will need to build SuperCollider t
 
 [downloads page]: https://supercollider.github.io/download
 
+### Platform requirements
+
+The minimum supported version of macOS is 10.10 Yosemite; the minimum supported version of Windows
+is Windows Vista.
+
 Learn
 -----
 

--- a/README_MACOS.md
+++ b/README_MACOS.md
@@ -45,6 +45,9 @@ Prerequisites:
   See http://brew.sh for installation instructions.
 - **git, cmake >= 3.5, libsndfile, readline, and qt5 >= 5.7**, installed via homebrew:
   `brew install git cmake libsndfile readline qt5`
+- If you are building with Qt libraries, you will also need the [requirements for
+  QtWebEngine](https://doc.qt.io/qt-5/qtwebengine-platform-notes.html#macos), specifically macOS
+  10.9 and the macOS SDK for 10.10 or later.
 
 - If you want to build with the *supernova* server, you need **portaudio** package, which can also be installed via homebrew:
   `brew install portaudio`

--- a/README_MACOS.md
+++ b/README_MACOS.md
@@ -233,19 +233,9 @@ Common arguments to control the build configuration are:
 
     Check sc help for `ParGroup` to see how to make use of multi-core hardware.
 
-  * Build a 32-bit version (sc 3.6 only):
-
-    `-DCMAKE_OSX_ARCHITECTURES='i386'`
-
-    or combine a 32- and 64-bit version into a bundle (i.e. build a universal binary).
-    This is only possible up until macOS 10.6 and requires the dependencies (Qtlibs &
-    readline) to be universal builds too:
-
-    `-DCMAKE_OSX_ARCHITECTURES='i386;x86_64'`
-
-  * By default the build will only be compatible with the macOS / OS X version (and
+  * By default the build will only be compatible with the macOS (and
     subsequent versions) on which the compiler was run. To build with compatibility
-    for previous versions of macOS / OS X, you can use e.g.:
+    for previous versions of macOS, you can use e.g.:
 
     `-DCMAKE_OSX_DEPLOYMENT_TARGET=10.10`
 


### PR DESCRIPTION
<!--- Hi, and thanks for contributing! -->
<!--- Make sure to provide a general summary of your changes in the title above. -->
<!--- For example: "[scsynth] Fix crash when encountering cute kittens" -->

Purpose and Motivation
----------------------

We discovered during the beta that our min required version for a full build with QtWebEngine is 10.10 (noted https://doc.qt.io/qt-5/qtwebengine-platform-notes.html#macos). This PR updates documentation and also the min deploy target used in Travis builds.

Also took out a bit of the readme that was related to macOS <= 10.6.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to it here by writing "Fixes #555". -->

Types of changes
----------------

<!--- What types of changes does your pull request introduce? -->
<!--- Some examples are below (you can delete the lines that don't apply): -->

- Documentation (non-code change which corrects or adds documentation for existing features)
- CI change

Checklist
---------

<!--- Complete an item by checking it: [x] -->

- [x] All previous tests are passing
- [x] Tests were updated or created to address changes in this PR, and tests are passing
- [x] Updated documentation, if necessary
- [x] This PR is ready for review

<!--- See DEVELOPING.md for instructions on running and writing tests. -->

Remaining Work
--------------

<!--- If any work remains to be done, please give a brief description here. -->
<!--- Consider providing a todo-list so we can easily track completion progress. -->

<!--- Thanks for contributing! -->
