### PR TITLE
[classlib] Plotter: fix domain and superpose behavior.

### DIFF
--- a/HelpSource/Classes/Plotter.schelp
+++ b/HelpSource/Classes/Plotter.schelp
@@ -274,9 +274,10 @@ link::Classes/Array:: of rank 1.
 
 If a new link::#-value:: is set, you will need to update your link::#-domain::.
 
-method:: plotColor
-Set or get the link::Classes/Color:: of your plot. An link::Classes/Array:: of colors will be mapped
-across multichannel plot data, including when link::#-superpose:: is code::true::.
+method:: plotColors
+Set or get the link::Classes/Color::(s) of your plot. An link::Classes/Array::
+of colors will be mapped across multichannel plot data, including
+when link::#-superpose:: is code::true::.
 
 method:: editFunc
 Supply a function which is evaluated when editing data. The function is called with the arguments: code::plotter::, code::plotIndex::, code::index::, code::val::, code::x::, code::y::.

--- a/HelpSource/Classes/Plotter.schelp
+++ b/HelpSource/Classes/Plotter.schelp
@@ -256,6 +256,8 @@ code::maxval:: of the domainSpecs.
 
 If a new link::#-value:: is set, you will need to update your domainSpecs.
 
+For examples, see link::#-domain:: and link::#examples::.
+
 method:: domain
 Set or get the x-axis positions of your data points. The size of the
 code::domainArray:: must equal the size of your value array, i.e. a domain
@@ -274,10 +276,24 @@ link::Classes/Array:: of rank 1.
 
 If a new link::#-value:: is set, you will need to update your link::#-domain::.
 
+Example:
+code::
+(
+var data, domain, plot;
+domain = 25.collect({rrand(0, 50)}).sort;
+data = domain.linlin(0, 50, 0, 1);
+
+plot = data.plot.plotMode_(\points);
+plot.domainSpecs_([0, 50].asSpec);
+plot.domain_(domain);
+)
+::
+A more elaborate example can be found in the link::#examples::.
+
 method:: plotColors
-Set or get the link::Classes/Color::(s) of your plot. An link::Classes/Array::
-of colors will be mapped across multichannel plot data, including
-when link::#-superpose:: is code::true::.
+Set or get the link::Classes/Color::(s) of your plot. An
+link::Classes/Array:: of colors will be mapped across multichannel plot
+data, including when link::#-superpose:: is code::true::.
 
 method:: editFunc
 Supply a function which is evaluated when editing data. The function is called with the arguments: code::plotter::, code::plotIndex::, code::index::, code::val::, code::x::, code::y::.
@@ -418,5 +434,45 @@ b = Buffer.read(s, Platform.resourceDir +/+ "sounds/SinedPink.aiff");
 		// Platform.resourceDir +/+ "sounds/SinedPink.aiff" contains SinOsc on left, PinkNoise on right
 b.plot;
 b.free;
+
+// Setting the domain, run the full block:
+(
+var ys, xs; // ys: data, xs: domain positions
+var rs = 0, plt2;
+
+// xs are the sample points over a 2pi range
+
+// sample locations, normalized
+xs = 50.collect({rrand(0.05, 1)}).normalizeSum;
+xs.do{ |me, i| xs[i] = me + rs; rs = rs + me; };
+
+// force beginning/end to land on 0/2pi
+xs[0] = 0;
+xs[xs.size-1] = 1;
+
+// scale these points to a 2pi range
+xs = xs * 2pi;
+
+// ys are the values of the sinusoid at the sampled points
+ys = sin(xs);
+
+// the uneven sampling is apparent when
+// displayed as uniformly sampled
+ys.plot("original data plot, uniform domain", [100, 100, 385, 285].asRect);
+
+// generate a second plot whose domainSpec is specified:
+// we see a smooth sinusoid cycle beginning
+// at 0 and ending at 2pi
+plt2 = ys.plot("resampled domain", [100+400, 100, 385, 285].asRect);
+
+// domain values place plotted points where they
+// actually sampled the sinusoid, thus visually
+// reconstructing it.
+plt2.domain = xs;
+
+// these values are placed within the domainSpec
+// so we can pad the plot on either side.
+plt2.domainSpecs_(([-0.5pi, 2.5pi]).asSpec);
+)
 ::
 

--- a/HelpSource/Classes/Plotter.schelp
+++ b/HelpSource/Classes/Plotter.schelp
@@ -226,6 +226,35 @@ code::
 a = { (40..300).scramble }.dup(2).plot;
 a.domainSpecs = \freq.asSpec; a.refresh;
 ::
+discussion::
+The default domainSpec when setting your Plotter link::#-value:: is a linear
+spec in the range code::[0, value.size-1]::. Unless you set link::#-domain::,
+your values are displayed as evenly sampled between the code::minval:: and
+code::maxval:: of the domainSpecs.
+
+If a new link::#-value:: is set, you will need to update your domainSpecs.
+
+method:: domain
+Set or get the x-axis positions of your data points. The size of the
+code::domainArray:: must equal the size of your value array, i.e. a domain
+value specified for each data point.
+
+discussion::
+Domain values are mapped into the range of the link::#-domainSpecs::, so need
+not be evenly distributed. If link::#-domain:: is set to code::nil::, your
+values are displayed as evenly sampled between the code::minval:: and
+code::maxval:: of the link::#-domainSpecs::.
+
+Currently, for multichannel data plots, it's assumed that all channels of data
+share a single link::#-domain::. I.e. code::domainArray:: must be an
+link::Classes/Array:: of rank 1.
+
+
+If a new link::#-value:: is set, you will need to update your link::#-domain::.
+
+method:: plotColor
+Set or get the link::Classes/Color:: of your plot. An link::Classes/Array:: of colors will be mapped
+across multichannel plot data, including when link::#-superpose:: is code::true::.
 
 method:: editFunc
 Supply a function which is evaluated when editing data. The function is called with the arguments: code::plotter::, code::plotIndex::, code::index::, code::val::, code::x::, code::y::.

--- a/HelpSource/Classes/Plotter.schelp
+++ b/HelpSource/Classes/Plotter.schelp
@@ -203,6 +203,28 @@ a = [1, 4, 2, 7, 4].dup(2).plot;
 a.value;
 ::
 
+method::setValue
+Set the data values, with additional arguments determining how the plot is updated.
+argument:: arrays
+Arrays of data to plot. Data may be numerical arrays of up to 3 dimensions.
+argument:: findSpecs
+A code::Boolean::. If code::true:: (default), bounds of the plot(s) are determined automatically.
+If code::false::, previous bounds will persist.
+argument:: refresh
+A code::Boolean::. If code::true:: (default), refresh the view immediately.
+argument:: separately
+A code::Boolean::. If code::true:: (default), min and max of each set of data will be calculated
+and displayed separately for each plot. If code::false::, each plot's range on the
+y-axis will be the same.
+argument::minval
+(Optional) The minimum value displayed on the y-axis.
+argument::maxval
+(Optional) The maximum value displayed on the y-axis.
+argument:: defaultRange
+(Optional) A default range for the y-axis in the case
+that the max and min values of the data are identical.
+
+
 method:: data
 Reference to the current internal data.
 

--- a/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
+++ b/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
@@ -585,8 +585,8 @@ Plotter {
 		value = arrays;
 		data = this.prReshape(arrays);
 		if(findSpecs) {
-			this.calcSpecs(separately, minval, maxval, defaultRange);
 			this.calcDomainSpecs;
+			this.calcSpecs(separately, minval, maxval, defaultRange);
 		};
 		this.updatePlots;
 		if(refresh) { this.refresh };

--- a/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
+++ b/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
@@ -430,6 +430,7 @@ Plotter {
 	var <>resolution = 1, <>findSpecs = true, <superpose = false;
 	var modes, <interactionView;
 	var <editPlotIndex, <editPos;
+	var <plotColor;
 
 	var <>drawFunc, <>editFunc;
 	var <gui;
@@ -659,7 +660,7 @@ Plotter {
 		plots !? { plots = plots.keep(data.size.neg) };
 		plots = plots ++ template.dup(data.size - plots.size);
 		plots.do { |plot, i| plot.value = data.at(i) };
-
+		plotColor !? { this.plotColor_(plotColor) };
 		this.updatePlotSpecs;
 		this.updatePlotBounds;
 	}
@@ -691,6 +692,15 @@ Plotter {
 		pairs.pairsDo { |selector, value|
 			selector = selector.asSetter;
 			plots.do { |x| x.perform(selector, value) }
+		}
+	}
+
+	plotColor_ { |color|
+		var col = color.as(Array);
+		plotColor = col;
+		plots.do { |plt, i|
+			// rotate colors to ensure proper behavior with superpose
+			plt.plotColor_(col.rotate(i.neg))
 		}
 	}
 

--- a/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
+++ b/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
@@ -152,8 +152,9 @@ Plot {
 	// }
 
 	domainCoordinates { |size|
-		var step, val, resamps;
-		step = domainSpec.range / (size-1);
+		var range, step, val, resamps;
+		range = domainSpec.range;
+		step =  if (range == 0) { 0 } { range / (size-1) };
 		resamps = plotter.domain ?? {
 			// if no domain values specified, uniformly sample the domainSpec
 			(domainSpec.minval, domainSpec.minval + step .. domainSpec.maxval)
@@ -591,11 +592,17 @@ Plotter {
 		if(refresh) { this.refresh };
 	}
 
-	// domain values are within the domainSpec
+	// domain values are (un)mapped within the domainSpec
 	// TODO: currently domain assumed to be identical across all channels
 	domain_ { |domainArray|
 		var dataSize;
-		dataSize = if (this.value.rank > 1) { this.value[0].size } { this.value.size };
+
+		dataSize = if (this.value.rank > 1) {
+			this.value[0].size
+		} {
+			this.value.size
+		};
+
 		if (domainArray.size != dataSize) {
 			Error(format("[Plotter:-domain_] Domain array size [%] does not match data array size [%]", domainArray.size, dataSize)).throw;
 		} {

--- a/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
+++ b/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
@@ -147,16 +147,22 @@ Plot {
 	}
 
 	domainCoordinates { |size|
-		var range, step, val, resamps;
-		range = domainSpec.range;
-		step =  if (range == 0) { 0 } { range / (size-1) };
-		resamps = plotter.domain ?? {
-			// if no domain values specified, uniformly sample the domainSpec
-			(domainSpec.minval, domainSpec.minval + step .. domainSpec.maxval)
-		};
-		val = domainSpec.unmap(resamps);
+		var range, step, vals, resamps;
 
-		^plotBounds.left + (val * plotBounds.width);
+		vals = if (plotter.domain.notNil) {
+			domainSpec.unmap(plotter.domain);
+		} {
+			range = domainSpec.range;
+			if (range == 0.0 or: { size == 1 }) {
+				0.5.dup(size) // put the values in the middle of the plot
+			} {
+				domainSpec.unmap(
+					(domainSpec.minval, domainSpec.minval + (range / (size-1)) .. domainSpec.maxval)
+				);
+			}
+		};
+
+		^plotBounds.left + (vals * plotBounds.width);
 	}
 
 	dataCoordinates {

--- a/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
+++ b/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
@@ -600,10 +600,19 @@ Plotter {
 	}
 
 	superpose_ { |flag|
+		var dom, domSpecs;
+		dom = domain.copy;
+		domSpecs = domainSpecs.copy;
+
 		superpose = flag;
 		if ( value.notNil ){
-			this.setValue(value, findSpecs, true);
+			this.setValue(value, false, false);
 		};
+
+		// for individual plots, restore previous domain state
+		this.domain_(dom);
+		if (superpose.not) { this.domainSpecs_(domSpecs) };
+		this.refresh;
 	}
 
 	numChannels {

--- a/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
+++ b/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
@@ -358,7 +358,8 @@ Plot {
 	}
 
 	getRelativePositionX { |x|
-		^this.resampledDomainSpec.map((x - plotBounds.left) / plotBounds.width)
+		// ^this.resampledDomainSpec.map((x - plotBounds.left) / plotBounds.width)
+		^domainSpec.map((x - plotBounds.left) / plotBounds.width)
 	}
 
 	getRelativePositionY { |y|

--- a/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
+++ b/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
@@ -583,6 +583,7 @@ Plotter {
 
 	setValue { |arrays, findSpecs = true, refresh = true, separately = true, minval, maxval, defaultRange|
 		value = arrays;
+		domain = nil;  // for now require user to re-set domain after setting new value
 		data = this.prReshape(arrays);
 		if(findSpecs) {
 			this.calcDomainSpecs;

--- a/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
+++ b/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
@@ -698,14 +698,33 @@ Plotter {
 	}
 
 	updatePlotSpecs {
+		var template, smin, smax;
+
 		specs !? {
-			plots.do { |plot, i|
-				plot.spec = specs.clipAt(i)
+			if (superpose) {
+				// NOTE: for superpose, all spec properties except
+				// minval and maxval are inherited from first spec
+				template = specs[0].copy;
+				smin = specs.collect(_.minval).minItem;
+				smax = specs.collect(_.maxval).maxItem;
+				plots[0].spec = template.minval_(smin).maxval_(smax);
+			} {
+				plots.do { |plot, i|
+					plot.spec = specs.clipAt(i)
+				}
 			}
 		};
+
 		domainSpecs !? {
-			plots.do { |plot, i|
-				plot.domainSpec = domainSpecs.clipAt(i)
+			if (superpose) {
+				template = domainSpecs[0].copy;
+				smin = domainSpecs.collect(_.minval).minItem;
+				smax = domainSpecs.collect(_.maxval).maxItem;
+				plots[0].domainSpec = template.minval_(smin).maxval_(smax);
+			} {
+				plots.do { |plot, i|
+					plot.domainSpec = domainSpecs.clipAt(i)
+				}
 			}
 		}
 	}

--- a/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
+++ b/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
@@ -364,16 +364,24 @@ Plot {
 		var xcoord = this.domainCoordinates(ycoord.size);
 		var binwidth = 0;
 		var offset;
-		if (xcoord.size > 0) {
-			binwidth = (xcoord[1] ?? {plotBounds.right}) - xcoord[0]
-		};
-		offset = if(this.hasSteplikeDisplay) { binwidth/2.0 } { 0.0 };
 
 		if (plotter.domain.notNil) {
-			^(plotter.domain.indexIn(this.getRelativePositionX(x)) - offset).round.asInteger
+			if (this.hasSteplikeDisplay) {
+				// round down to index
+				^plotter.domain.indexInBetween(this.getRelativePositionX(x)).floor.asInteger
+			} {
+				// round to nearest index
+				^plotter.domain.indexIn(this.getRelativePositionX(x))
+			};
 		} {
-			// domain unspecified, values are evenly distributed between either side of the plot
-			^(((x - plotBounds.left) / plotBounds.width) * (value.size - 1) - offset).round.clip(0, value.size-1).asInteger
+			if (xcoord.size > 0) {
+				binwidth = (xcoord[1] ?? {plotBounds.right}) - xcoord[0]
+			};
+			offset = if(this.hasSteplikeDisplay) { binwidth * 0.5 } { 0.0 };
+
+			^(  // domain unspecified, values are evenly distributed between either side of the plot
+				((x - offset - plotBounds.left) / plotBounds.width) * (value.size - 1)
+			).round.clip(0, value.size-1).asInteger
 		}
 	}
 

--- a/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
+++ b/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
@@ -416,12 +416,11 @@ Plotter {
 
 	var <>name, <>bounds, <>parent;
 	var <value, <data, <domain;
-	var <plots, <specs, <domainSpecs;
+	var <plots, <specs, <domainSpecs, <plotColors;
 	var <cursorPos, <>plotMode = \linear, <>editMode = false, <>normalized = false;
 	var <>resolution = 1, <>findSpecs = true, <superpose = false;
 	var modes, <interactionView;
 	var <editPlotIndex, <editPos;
-	var <plotColor;
 
 	var <>drawFunc, <>editFunc;
 	var <gui;
@@ -658,7 +657,7 @@ Plotter {
 		plots !? { plots = plots.keep(data.size.neg) };
 		plots = plots ++ template.dup(data.size - plots.size);
 		plots.do { |plot, i| plot.value = data.at(i) };
-		plotColor !? { this.plotColor_(plotColor) };
+		plotColors !? { this.plotColors_(plotColors) };
 		this.updatePlotSpecs;
 		this.updatePlotBounds;
 	}
@@ -693,12 +692,11 @@ Plotter {
 		}
 	}
 
-	plotColor_ { |color|
-		var col = color.as(Array);
-		plotColor = col;
+	plotColors_ { |argColors|
+		plotColors = argColors.as(Array);
 		plots.do { |plt, i|
 			// rotate colors to ensure proper behavior with superpose
-			plt.plotColor_(col.rotate(i.neg))
+			plt.plotColor_(plotColors.rotate(i.neg))
 		}
 	}
 

--- a/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
+++ b/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
@@ -603,7 +603,7 @@ Plotter {
 	superpose_ { |flag|
 		superpose = flag;
 		if ( value.notNil ){
-			this.setValue(value, false, true);
+			this.setValue(value, findSpecs, true);
 		};
 	}
 

--- a/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
+++ b/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
@@ -146,11 +146,6 @@ Plot {
 		};
 	}
 
-	// domainCoordinates { |size|
-	// 	var val = this.resampledDomainSpec.unmap(plotter.domain ?? { (0..size-1) });
-	// 	^plotBounds.left + (val * plotBounds.width);
-	// }
-
 	domainCoordinates { |size|
 		var range, step, val, resamps;
 		range = domainSpec.range;
@@ -159,7 +154,6 @@ Plot {
 			// if no domain values specified, uniformly sample the domainSpec
 			(domainSpec.minval, domainSpec.minval + step .. domainSpec.maxval)
 		};
-		// val = this.resampledDomainSpec.unmap(resamps);
 		val = domainSpec.unmap(resamps);
 
 		^plotBounds.left + (val * plotBounds.width);
@@ -169,15 +163,6 @@ Plot {
 		var val = spec.warp.unmap(this.prResampValues);
 		^plotBounds.bottom - (val * plotBounds.height); // measures from top left (may be arrays)
 	}
-
-	// resampledSize {
-	// 	^min(value.size, plotBounds.width / plotter.resolution)
-	// }
-
-	// resampledDomainSpec {
-	// 	var offset = if(this.hasSteplikeDisplay) { 0 } { 1 };
-	// 	^domainSpec.copy.maxval_(this.resampledSize - offset)
-	// }
 
 	drawData {
 		var mode = plotter.plotMode;
@@ -359,7 +344,6 @@ Plot {
 	}
 
 	getRelativePositionX { |x|
-		// ^this.resampledDomainSpec.map((x - plotBounds.left) / plotBounds.width)
 		^domainSpec.map((x - plotBounds.left) / plotBounds.width)
 	}
 
@@ -385,9 +369,6 @@ Plot {
 		};
 		offset = if(this.hasSteplikeDisplay) { binwidth/2.0 } { 0.0 };
 
-		// ^this.getRelativePositionX(x - offset).round.asInteger
-
-		// mtm
 		if (plotter.domain.notNil) {
 			^(plotter.domain.indexIn(this.getRelativePositionX(x)) - offset).round.asInteger
 		} {
@@ -593,8 +574,8 @@ Plotter {
 		if(refresh) { this.refresh };
 	}
 
+	// TODO: currently domain is constrained to being identical across all channels
 	// domain values are (un)mapped within the domainSpec
-	// TODO: currently domain assumed to be identical across all channels
 	domain_ { |domainArray|
 		var dataSize;
 

--- a/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
+++ b/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
@@ -584,16 +584,32 @@ Plotter {
 	// TODO: currently domain is constrained to being identical across all channels
 	// domain values are (un)mapped within the domainSpec
 	domain_ { |domainArray|
-		var dataSize;
+		var dataSize, sizes;
+
+		domainArray ?? {
+			domain = nil;
+			^this
+		};
 
 		dataSize = if (this.value.rank > 1) {
-			this.value[0].size
+			sizes = this.value.collect(_.size);
+			if (sizes.any(_ != this.value[0].size)) {
+				Error(format(
+					"[Plotter:-domain_] Setting the domain values isn't supported "
+					"for multichannel data of different sizes %.", sizes
+				)).throw;
+			};
+			this.value[0].size;
 		} {
 			this.value.size
 		};
 
+
 		if (domainArray.size != dataSize) {
-			Error(format("[Plotter:-domain_] Domain array size [%] does not match data array size [%]", domainArray.size, dataSize)).throw;
+			Error(format(
+				"[Plotter:-domain_] Domain array size [%] does not "
+				"match data array size [%]", domainArray.size, dataSize
+			)).throw;
 		} {
 			domain = domainArray
 		}

--- a/testsuite/classlibrary/TestPlotter.sc
+++ b/testsuite/classlibrary/TestPlotter.sc
@@ -1,0 +1,41 @@
+TestPlotter : UnitTest {
+
+	test_set_plotColors_and_superpose {
+		var data, cols, plot;
+
+		data = 3.collect{15.collect{rrand(0.0, 3.0)}};
+		cols = 3.collect{Color.rand};
+
+		// set each plot to unique color, then superpose
+		plot = data.plot.plotColors_(cols);
+		plot.superpose_(true);
+
+		this.assertEquals(
+			plot.plots[0].plotColor,
+			cols,
+			format(
+				"The color of the superposed plot:\n\t[%]\n"
+				"\tshould match Plotter's plotColors (in order) when superpose = true.:\n\t[%]\n",
+				plot.plots[0].plotColor,
+				cols,
+			), report: false
+		);
+
+		// plot individually
+		plot.superpose_(false);
+
+		this.assertEquals(
+			plot.plots.collect({|plt, i| plt.plotColor[0]}),
+			cols,
+			format(
+				"The first color of each individual plot:\n\t[%]\n"
+				"\tshould match Plotter's plotColors (in order) when superpose = false.:\n\t[%]\n",
+				plot.plots.collect({|plt, i| plt.plotColor[0]}),
+				cols,
+			), report: false
+		);
+
+		plot.parent.close;
+	}
+
+}


### PR DESCRIPTION
Purpose and Motivation
----------------------
Under various conditions, the behavior of `Plotter` was either broken or not fully supported when `domain` values and `domainSpec` are set. 

In one such case, updating the `domainSpec` updates grid lines and domain labels correctly, but the internal umapping of domain values (which would default to `0->size-1`) is inconsistent with the updated `domainSpec`. The problem with examples will be provided later in this thread.

In addition to fixing this underlying issues, a couple other minor bugs are fixed, including the behavior of `plotColors` and `findSpecs` when toggling the `superpose` flag.

This fixes issues observed in the course of documenting #3672.

Types of changes
----------------
- Bug fix (non-breaking change which fixes an issue)
Methods were altered in Plotter to account for a variety of test cases which seemed were not fully considered/supported:
  - plot colors now remain constant when toggling `superpose`
  - `superpose_` setter uses instance variable `findSpecs` when internally calling `this.setValue`. Before this defaulted to `false`, which meant a multichannel plot toggled to an overlaid plot defaulted to the y spec of the first plot.
  - `Plotter:-setValue`: calculate the `domainSpecs` before `this.calcSpecs`, otherwise domain doesn't update until a second refresh is called.

- Documentation (non-code change which corrects or adds documentation for existing features)
  - All changes and additions are documented.
  - Add documentation for `Plotter:-setValue`.
  - Includes examples for `domain_`/`domainSpecs_`.

- New feature (non-breaking change which adds functionality)
A new method was added: 
  - plotColors_ : this allows plot colors to be set from the Plotter class, as opposed requiring the user to set the plot colors individually via the variable `plots` (though this can still be done).

- Breaking change (fix or feature that would cause existing functionality to change)
  - note: 719c0ca7e17bb99c98c557af4e323a758c4b03fe : default behavior of `superpose_` is made follow the instance variable `findSpecs` rather than default to `false`. However I consider this a bug fix.

Checklist
---------

<!--- Complete an item by checking it: [x] -->

- [ ] All previous tests are passing
  - ... I didn't find any preexisting unit tests for Plotter.
- [x] Tests were updated or created to address changes in this PR, and tests are passing
  - 7f5cb544973fae76fa58bb87e8fb6b056f1ec9b9
- [x] Updated documentation, if necessary
- [x] This PR is ready for review

<!--- See DEVELOPING.md for instructions on running and writing tests. -->

Remaining Work
--------------
A couple issues came up along the way that are beyond bug fixes, which would require some consensus to change. For example, right now if `value_` is set, `domainSpecs` are reset to their defaults, and `domain` is set to `nil`. It's an open question whether these states should persist when updating the values.  I'll open issues for this.

<!--- Thanks for contributing! -->