### PR TITLE
Classlib: Default event prototype uses ~clock instead of thisThread.clock

### DIFF
--- a/SCClassLibrary/Common/Collections/Event.sc
+++ b/SCClassLibrary/Common/Collections/Event.sc
@@ -311,11 +311,11 @@ Event : Environment {
 				// we keep these for compatibility.
 
 				schedBundle: #{ |lag, offset, server ... bundle |
-					schedBundleArrayOnClock(offset, thisThread.clock, bundle, lag, server);
+					schedBundleArrayOnClock(offset, ~clock, bundle, lag, server);
 				},
 
 				schedBundleArray: #{ | lag, offset, server, bundleArray, latency |
-					schedBundleArrayOnClock(offset, thisThread.clock, bundleArray, lag, server, latency);
+					schedBundleArrayOnClock(offset, ~clock, bundleArray, lag, server, latency);
 				},
 
 				schedStrummedNote: {| lag, strumTime, sustain, server, msg, sendGate |
@@ -436,11 +436,12 @@ Event : Environment {
 					parentType !? { currentEnvironment.parent = parentType };
 
 					server = ~server = ~server ? Server.default;
+					~clock ?? { ~clock = thisThread.clock };
 
 					~finish.value(currentEnvironment);
 
 					tempo = ~tempo;
-					tempo !? { thisThread.clock.tempo = tempo };
+					tempo !? { ~clock.tempo = tempo };
 
 
 					if(currentEnvironment.isRest.not) {
@@ -805,12 +806,12 @@ Event : Environment {
 							if(latency == 0.0) {
 								midiout.performList(midicmd, msgArgs)
 							} {
-								thisThread.clock.sched(latency, {
+								~clock.sched(latency, {
 									midiout.performList(midicmd, msgArgs);
 								})
 							};
 							if(hasGate and: { midicmd === \noteOn }) {
-								thisThread.clock.sched(sustain + latency, {
+								~clock.sched(sustain + latency, {
 									midiout.noteOff(*msgArgs)
 								});
 							};


### PR DESCRIPTION
Purpose and Motivation
----------------------

`Event` currently makes it unreliable to use objects, such as MIDISyncClock, that pretend to be clocks.

When the default event prototype needs to address the clock, it uses `thisThread.clock`. This may be only `SystemClock`, `AppClock`, or an instance of `TempoClock`.

While `MIDISyncClock` (ddwMIDI quark) is not really a beautiful class, it turns out that I might need it today, and I fixed a couple of bugs[1] so that it actually kinda works now. *But* it will not work currently with Event. If you play a pattern on MIDISyncClock, within the event, `thisThread.clock` is `SystemClock`. Scheduled note releases will then treat `~sustain` in *seconds*, rather than beats, ignoring the tempo coming in from the MIDI clock source.

To solve this, I suggest to make it possible to override `thisThread.clock` within the event by setting a `~clock` key (currently unused). If `~clock` is empty, the play function should fill it in with `thisThread.clock`.

Notes:

- I'm still taking a break from active SC development. I'm looking at this only because some local friends are calling for an impromptu jam session and, because LinkClock is delayed, this might be the only way to play with them, so I had to fix the really obvious bugs. Submitting this PR does *not* mean I have time to spend several extra hours to support it.

- I freely admit that this might not be the best solution (I don't like that you have to write `\clock, myClock` in the pattern or event), and it might be questionable to touch core functionality in order to support an extension class (which I, as the author, have disparaged in the past! -- but, until LinkClock lands, MIDISyncClock is the only way I can think of offhand to sync with external equipment). It's fine with me if this is closed after discussion.

- *But* I would like the basic issue to be considered: that we are inadvertently closing off users' options to roll their own schedulers by forcing clocks to be specific classes. If this is a bad solution, I might then open an enhancement request for future consideration.

- I thought about how to write a unit test. AFAICS we don't have a way for a unit test to monitor messages being sent to the server. I had thought of creating a "spoof" server, sending messages to sclang, and using OSCFunc to read their times, but this won't work because Event sends numeric commands and OSCFunc will convert OSC path `9` into `'/9'` (a symbol) [2], so you will never match it. I'm not prepared to go further with that. Probably the unit test suite should provide a fake server that records a list of commands it receives. Then it would be easy to test this.

[1] https://github.com/jamshark70/ddwMIDI/commit/7cf12a4e0c62e23b818987ab900f17ca72b81d1d
[2] https://github.com/supercollider/supercollider/blob/develop/SCClassLibrary/Common/Control/ResponseDefs.sc#L277-L279

Types of changes
----------------

- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change) -- highly unlikely but it is possible that someone somewhere is using `~clock` in events for some other purpose. We could change the key name.

Checklist
---------

- [x] All previous tests are passing -- regression tested with a simple pattern, it's OK.
- [ ] Tests were updated or created to address changes in this PR, and tests are passing -- UnitTest may be missing some features to test this.
- [ ] Updated documentation, if necessary -- not yet
- [ ] This PR is ready for review

Remaining Work
--------------

- Documentation