### PR TITLE
Fix FunctionDef:argumentString

### DIFF
--- a/SCClassLibrary/Common/Core/Kernel.sc
+++ b/SCClassLibrary/Common/Core/Kernel.sc
@@ -474,16 +474,22 @@ FunctionDef {
 
 	argumentString { arg withDefaultValues=true;
 		var res = "", pairs = this.keyValuePairsFromArgs;
-		var last;
+		var last, noVarArgs;
 		if(pairs.isEmpty) { ^nil };
 		last = pairs.lastIndex;
+		noVarArgs = this.varArgs.not;
 		pairs.pairsDo { |name, defaultValue, i|
-			var value;
-			res = res ++ name;
-			if(withDefaultValues and: { defaultValue.notNil }) {
-				res = res ++ " = " ++ defaultValue.asCompileString
+			var value, notLast;
+			notLast = i + 1 != last;
+			if(notLast or: noVarArgs) {
+				res = res ++ name;
+				if(withDefaultValues and: { defaultValue.notNil }) {
+					res = res ++ " = " ++ defaultValue.asCompileString;
+				};
+			} {
+				res = res ++ "... " ++ name;
 			};
-			if(i + 1 != last) { res = res ++ ", " };
+			if(notLast) { res = res ++ ", " };
 		}
 		^res
 	}


### PR DESCRIPTION
Purpose and Motivation
----------------------

```argumentString``` did not handle varArgs correctly, adding a default of ```[ ]```. varArgs cannot have defaults.

One side effect of this is that archives containing open Functions would be uninterpretable. The correct behaviour is that the open function is archived with args but does nothing. (This is what happens without varArgs. In that case it is readable.)

For example:

```
(
var f, g;

f = {arg ... args; g };

f.writeTextArchive("/tmp/testarch")
)

Object.readTextArchive("/tmp/testarch")
```

ERROR: syntax error, unexpected ‘[’
 in interpreted text
 line 1 char 12:

 { | args = [  ] | “open Function” }
            ^

-----------------------------------
ERROR: Command line parse failed

With this change the archived func is correctly rendered:

{ | ... args | "open Function" }

I think this is correct and straightforward, but it touches (lightly) core stuff, so some eyes would be good.

Types of changes
----------------

- Bug fix (non-breaking change which fixes an issue)

Checklist
---------

<!--- Complete an item by checking it: [x] -->

- [x] All previous tests are passing
- [ ] Tests were updated or created to address changes in this PR, and tests are passing
- [x] This PR is ready for review

<!--- See DEVELOPING.md for instructions on running and writing tests. -->

Remaining Work
--------------

- [ ] create tests to avoid regression (will do once we have agreement on this)