### PR TITLE
Use asInteger instead of asInt. Fix #4015

### DIFF
--- a/HelpSource/Classes/AbstractFunction.schelp
+++ b/HelpSource/Classes/AbstractFunction.schelp
@@ -58,6 +58,8 @@ method::asFloat
 code::
 a = { "123.471".scramble }; b = a.asFloat; b.value;
 ::
+method::asInt
+Deprecated. Use code::asInteger:: instead.
 method::asInteger
 code::
 a = { "123471".scramble }; b = a.asInteger; b.value;

--- a/HelpSource/Classes/AbstractFunction.schelp
+++ b/HelpSource/Classes/AbstractFunction.schelp
@@ -58,9 +58,9 @@ method::asFloat
 code::
 a = { "123.471".scramble }; b = a.asFloat; b.value;
 ::
-method::asInt
+method::asInteger
 code::
-a = { "123471".scramble }; b = a.asInt; b.value;
+a = { "123471".scramble }; b = a.asInteger; b.value;
 ::
 method::ceil, floor, frac
 code::

--- a/HelpSource/Classes/Object.schelp
+++ b/HelpSource/Classes/Object.schelp
@@ -162,6 +162,10 @@ a.asCompileString.postcs;
 a.postcs;
 ::
 
+method::asInt
+
+Deprecated. Use code::asInteger:: instead.
+
 method::cs
 
 Shorthand for link::#-asCompileString::.

--- a/HelpSource/Classes/SequenceableCollection.schelp
+++ b/HelpSource/Classes/SequenceableCollection.schelp
@@ -640,7 +640,7 @@ subsection::Math Support - Unary Messages
 
 All of the following messages send the message link::#-performUnaryOp:: to the receiver with the unary message selector as an argument.
 
-method::neg, reciprocal, bitNot, abs, asFloat, asInt, ceil, floor, frac, sign, squared, cubed, sqrt, exp, midicps, cpsmidi, midiratio, ratiomidi, ampdb, dbamp, octcps, cpsoct, log, log2, log10, sin, cos, tan, asin, acos, atan, sinh, cosh, tanh, rand, rand2, linrand, bilinrand, sum3rand, distort, softclip, coin, even, odd, isPositive, isNegative, isStrictlyPositive, real, imag, magnitude, magnitudeApx, phase, angle, rho, theta, asFloat, asInteger
+method::neg, reciprocal, bitNot, abs, asFloat, ceil, floor, frac, sign, squared, cubed, sqrt, exp, midicps, cpsmidi, midiratio, ratiomidi, ampdb, dbamp, octcps, cpsoct, log, log2, log10, sin, cos, tan, asin, acos, atan, sinh, cosh, tanh, rand, rand2, linrand, bilinrand, sum3rand, distort, softclip, coin, even, odd, isPositive, isNegative, isStrictlyPositive, real, imag, magnitude, magnitudeApx, phase, angle, rho, theta, asFloat, asInteger
 
 method::performUnaryOp
 Creates a new collection of the results of applying the selector to all elements in the receiver.

--- a/SCClassLibrary/Common/Collections/SequenceableCollection.sc
+++ b/SCClassLibrary/Common/Collections/SequenceableCollection.sc
@@ -908,7 +908,7 @@ SequenceableCollection : Collection {
 	//  "https://en.wikipedia.org/wiki/Chebyshev_polynomials#Roots_and_extrema"
 	//  "http://mathworld.wolfram.com/ChebyshevPolynomialoftheFirstKind.html"
 	chebyshevTZeros {
-		var n = this.asInt;
+		var n = this.asInteger;
 		^(1..n).collect({ arg k;
 			cos(pi* ((2*k) - 1) / (2*n))
 		});

--- a/SCClassLibrary/Common/Core/Object.sc
+++ b/SCClassLibrary/Common/Core/Object.sc
@@ -611,8 +611,6 @@ Object  {
 	+>> { arg that; ^unsignedRightShift(this, that) }
 	<! { arg that; ^firstArg(this, that) }
 
-	asInt { ^this.asInteger }
-
 	blend { arg that, blendFrac = 0.5;
 		// blendFrac should be from zero to one
 		^this + (blendFrac * (that - this));

--- a/SCClassLibrary/Common/Math/Signal.sc
+++ b/SCClassLibrary/Common/Math/Signal.sc
@@ -292,7 +292,7 @@ Signal[float] : FloatArray {
 		^this + (blendFrac * (that - this));
 	}
 
-	asInteger { _AsInt; ^this.primitiveFailed }
+	asInteger { _AsInteger; ^this.primitiveFailed }
 	asFloat { _AsFloat; ^this.primitiveFailed }
 	asComplex { ^Complex.new(this, 0.0) }
 	asSignal { ^this }

--- a/SCClassLibrary/Common/Math/SimpleNumber.sc
+++ b/SCClassLibrary/Common/Math/SimpleNumber.sc
@@ -129,7 +129,7 @@ SimpleNumber : Number {
 
 	hash { _ObjectHash; ^this.primitiveFailed }
 
-	asInteger { _AsInt; ^this.primitiveFailed }
+	asInteger { _AsInteger; ^this.primitiveFailed }
 	asFloat { _AsFloat; ^this.primitiveFailed }
 	asComplex { ^Complex.new(this, 0.0) }
 	asRect { ^Rect(this, this, this, this) }

--- a/SCClassLibrary/deprecated/3.11/deprecated-3.11.sc
+++ b/SCClassLibrary/deprecated/3.11/deprecated-3.11.sc
@@ -1,0 +1,13 @@
++ AbstractFunction {
+	asInt {
+		this.deprecated(thisMethod, this.class.findMethod(\asInteger));
+		^this.composeUnaryOp('asInteger');
+	}
+}
+
++ Object {
+	asInt {
+		this.deprecated(thisMethod, this.class.findMethod(\asInteger));
+		^this.asInteger;
+	}
+}

--- a/lang/LangPrimSource/PyrPrimitive.cpp
+++ b/lang/LangPrimSource/PyrPrimitive.cpp
@@ -4011,7 +4011,7 @@ void initPrimitives()
 	definePrimitive(base, opBitNot, "_BitNot", doSpecialUnaryArithMsg, 1, 0);
 	definePrimitive(base, opAbs, "_Abs", doSpecialUnaryArithMsg, 1, 0);
 	definePrimitive(base, opAsFloat, "_AsFloat", doSpecialUnaryArithMsg, 1, 0);
-	definePrimitive(base, opAsInt, "_AsInt", doSpecialUnaryArithMsg, 1, 0);
+	definePrimitive(base, opAsInteger, "_AsInteger", doSpecialUnaryArithMsg, 1, 0);
 	definePrimitive(base, opCeil, "_Ceil", doSpecialUnaryArithMsg, 1, 0);			// 5
 	definePrimitive(base, opFloor, "_Floor", doSpecialUnaryArithMsg, 1, 0);
 	definePrimitive(base, opFrac, "_Frac", doSpecialUnaryArithMsg, 1, 0);

--- a/lang/LangSource/Opcodes.h
+++ b/lang/LangSource/Opcodes.h
@@ -85,7 +85,7 @@ enum {
 	opBitNot,
 	opAbs,
 	opAsFloat,
-	opAsInt,
+	opAsInteger,
 	opCeil,			//5
 	opFloor,
 	opFrac,

--- a/lang/LangSource/PyrMathOps.cpp
+++ b/lang/LangSource/PyrMathOps.cpp
@@ -62,7 +62,7 @@ int doSpecialUnaryArithMsg(VMGlobals *g, int numArgsPushed)
 				case opBitNot : SetRaw(a, ~slotRawInt(a)); break;
 				case opAbs : SetRaw(a, sc_abs(slotRawInt(a))); break;
 				case opAsFloat : SetFloat(a, (double)slotRawInt(a)); break;
-				case opAsInt : SetRaw(a, (int)slotRawInt(a)); break;
+				case opAsInteger : SetRaw(a, (int)slotRawInt(a)); break;
 				case opCeil : SetRaw(a, slotRawInt(a)); break;
 				case opFloor : SetRaw(a, slotRawInt(a)); break;
 				case opFrac : SetRaw(a, 0); break;
@@ -122,7 +122,7 @@ int doSpecialUnaryArithMsg(VMGlobals *g, int numArgsPushed)
 				//case opNot : goto send_normal_1;
 				case opIsNil : SetFalse(a); break;
 				case opNotNil : SetTrue(a); break;
-				case opAsInt : SetTagRaw(a, tagInt); break;
+				case opAsInteger : SetTagRaw(a, tagInt); break;
 				case opDigitValue :
 					if (slotRawInt(a) >= '0' && slotRawInt(a) <= '9') SetInt(a, slotRawInt(a) - '0');
 					else if (slotRawInt(a) >= 'A' && slotRawInt(a) <= 'Z') SetInt(a, slotRawInt(a) - 'A');
@@ -165,7 +165,7 @@ int doSpecialUnaryArithMsg(VMGlobals *g, int numArgsPushed)
 		case tagSym :
 			switch (opcode) {
 				case opAsFloat :
-				case opAsInt :
+				case opAsInteger :
 					goto send_normal_1;
 				case opIsNil : SetFalse(a); break;
 				case opNotNil : SetTrue(a); break;
@@ -214,7 +214,7 @@ int doSpecialUnaryArithMsg(VMGlobals *g, int numArgsPushed)
 				case opBitNot : SetRaw(a, ~(int)slotRawFloat(a)); break;
 				case opAbs : SetRaw(a, sc_abs(slotRawFloat(a))); break;
 				case opAsFloat : SetRaw(a, (double)slotRawFloat(a)); break;
-				case opAsInt :
+				case opAsInteger :
 				{
 					double val = slotRawFloat(a);
 					if (val == std::numeric_limits<double>::infinity())

--- a/lang/LangSource/PyrParseNode.cpp
+++ b/lang/LangSource/PyrParseNode.cpp
@@ -4502,7 +4502,7 @@ void initSpecialSelectors()
 	sel[opBitNot] = getsym("bitNot");
 	sel[opAbs] = getsym("abs");
 	sel[opAsFloat] = getsym("asFloat");
-	sel[opAsInt] = getsym("asInt");
+	sel[opAsInt] = getsym("asInteger");
 	sel[opCeil] = getsym("ceil");			//5
 	sel[opFloor] = getsym("floor");
 	sel[opFrac] = getsym("frac");

--- a/lang/LangSource/PyrParseNode.cpp
+++ b/lang/LangSource/PyrParseNode.cpp
@@ -4502,7 +4502,7 @@ void initSpecialSelectors()
 	sel[opBitNot] = getsym("bitNot");
 	sel[opAbs] = getsym("abs");
 	sel[opAsFloat] = getsym("asFloat");
-	sel[opAsInt] = getsym("asInteger");
+	sel[opAsInteger] = getsym("asInteger");
 	sel[opCeil] = getsym("ceil");			//5
 	sel[opFloor] = getsym("floor");
 	sel[opFrac] = getsym("frac");

--- a/server/plugins/UnaryOpUGens.cpp
+++ b/server/plugins/UnaryOpUGens.cpp
@@ -141,7 +141,7 @@ enum {
 	opBitNot,
 	opAbs,
 	opAsFloat,
-	opAsInt,
+	opAsInteger,
 	opCeil,
 	opFloor,
 	opFrac,

--- a/testsuite/sclang/lpc/TestCompilerBrutal.sc
+++ b/testsuite/sclang/lpc/TestCompilerBrutal.sc
@@ -24,7 +24,7 @@ TestCompilerBrutal : AbstractLPCBrutalTest {
 			"bitNot",
 			"abs",
 			"asFloat",
-			"asInt",
+			"asInteger",
 			"ceil",
 			"floor",
 			"frac",


### PR DESCRIPTION
<!--- Hi, and thanks for contributing! -->
<!--- Make sure to provide a general summary of your changes in the title above. -->
<!--- For example: "[scsynth] Fix crash when encountering cute kittens" -->

Purpose and Motivation
----------------------

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to it here by writing "Fixes #555". -->
Fixes #4015 

Types of changes
----------------

<!--- What types of changes does your pull request introduce? -->
<!--- Some examples are below (you can delete the lines that don't apply): -->

- Documentation (non-code change which corrects or adds documentation for existing features)
- Bug fix (non-breaking change which fixes an issue)

Checklist
---------

<!--- Complete an item by checking it: [x] -->

- [x] All previous tests are passing
- [x] Tests were updated or created to address changes in this PR, and tests are passing
- [x] Updated documentation, if necessary
- [x] This PR is ready for review

<!--- See DEVELOPING.md for instructions on running and writing tests. -->

Remaining Work
--------------

<!--- If any work remains to be done, please give a brief description here. -->
<!--- Consider providing a todo-list so we can easily track completion progress. -->

I added an entry in the `Object` help file with a note that `asInt` is deprecated. There was no previous documentation of `asInt` so maybe I shouldn't have added this? The method is still available in Object though.

Also, I'm not sure I did optimization for the sclang compiler correctly, so this would need to be reviewed by someone who knows more about this. My tests after building from this branch shows no performance improvements after my change, so most likely I did not manage to get this right. Code snippet for reference:

```supercollider
bench { 10000000.do { "1234567890".asInt; } } // time to run: 0.92768638500002 seconds.
bench { 10000000.do { "1234567890".asInteger; } } // time to run: 0.98579284500002 seconds.
```


<!--- Thanks for contributing! -->
