### PR TITLE
NodeProxy set can be used with arbitrary objects

### DIFF
--- a/SCClassLibrary/JITLib/ProxySpace/NodeMap.sc
+++ b/SCClassLibrary/JITLib/ProxySpace/NodeMap.sc
@@ -137,7 +137,9 @@ ProxyNodeMap : NodeMap {
 	controlNames {
 		var res = Array.new;
 		this.keysValuesDo { |key, value|
-			var rate = if(value.rate == \audio) { \audio } { \control };
+			var rate;
+			value = value.asControlInput;
+			rate = if(value.rate == \audio) { \audio } { \control };
 			res = res.add(ControlName(key, nil, rate, value))
 		};
 		^res
@@ -146,7 +148,7 @@ ProxyNodeMap : NodeMap {
 	settingKeys {
 		var res;
 		this.keysValuesDo { |key, val|
-			if(val.isNumber or: { val.isSequenceableCollection }) { res = res.add(key) }
+			if(val.nodeMapMapsToControl.not) { res = res.add(key) }
 		}
 		^res
 	}
@@ -154,7 +156,7 @@ ProxyNodeMap : NodeMap {
 	mappingKeys {
 		var res;
 		this.keysValuesDo { |key, val|
-			if(val.isNumber.not and: { val.isSequenceableCollection.not }) { res = res.add(key) }
+			if(val.nodeMapMapsToControl) { res = res.add(key) }
 		}
 		^res
 	}

--- a/SCClassLibrary/JITLib/ProxySpace/wrapForNodeProxy.sc
+++ b/SCClassLibrary/JITLib/ProxySpace/wrapForNodeProxy.sc
@@ -47,6 +47,8 @@
 	defaultArgs { ^nil }
 	argNames { ^nil }
 
+	nodeMapMapsToControl { ^false }
+
 	// support for unop / binop proxy
 	isNeutral { ^true }
 	initBus { ^true }
@@ -120,6 +122,8 @@
 		proxy.initBus(this.rate, this.numChannels);
 		^{ this.value(proxy) }
 	}
+
+	nodeMapMapsToControl { ^true }
 
 }
 

--- a/testsuite/classlibrary/TestNodeMap.sc
+++ b/testsuite/classlibrary/TestNodeMap.sc
@@ -1,0 +1,33 @@
+TestProxyNodeMap : UnitTest {
+
+
+	test_nodeMap_whenSetWithProxy_maps {
+		var proxy = NodeProxy.new;
+		var otherProxy = NodeProxy.new;
+		var map = proxy.nodeMap;
+		map.set(\x, otherProxy);
+		this.assert(map.mappingKeys.includes(\x));
+		proxy.clear;
+		otherProxy.clear;
+	}
+
+	test_nodeMap_whenSetWithObject_sets {
+		var proxy = NodeProxy.new;
+		var object = [1, 2, 3];
+		var map = proxy.nodeMap;
+		map.set(\x, object);
+		this.assert(map.settingKeys.includes(\x));
+		proxy.clear;
+	}
+
+	test_nodeMap_controlNamesConvertsObjectToControlInput {
+		var proxy = NodeProxy.new;
+		var map = proxy.nodeMap;
+		var buffer = Buffer.alloc(numFrames:1);
+		map.set(\x, buffer);
+		this.assert(map.controlNames.first.defaultValue == buffer.bufnum);
+		buffer.free;
+		proxy.clear;
+	}
+}
+


### PR DESCRIPTION
<!--- Hi, and thanks for contributing! -->
<!--- Make sure to provide a general summary of your changes in the title above. -->
<!--- For example: "[scsynth] Fix crash when encountering cute kittens" -->

Purpose and Motivation
----------------------

<!--- Why is this change required? What problem does it solve? -->
NodeProxy interprets `set` as a mapping when the argument is another NodeProxy or BusPlug. Other objects are converted using `asControlInput` and passed as `/n_set`. The implementation assumed that other objects would only be numbers or arrays. Now it is possible to use any object that would also work with `Synth`.

<!--- If it fixes an open issue, please link to it here by writing "Fixes #555". -->
Fixes #4087.

Types of changes
----------------

<!--- What types of changes does your pull request introduce? -->
<!--- Some examples are below (you can delete the lines that don't apply): -->

Bug Fix and tests

```
// this works now
(
b = Buffer.alloc(s, 128, 1);
p = NodeProxy(s);
p.set(\buffer, b);
p.controlNames
)
```

Checklist
---------

<!--- Complete an item by checking it: [x] -->

- [x] All previous tests are passing
- [x] Tests were updated or created to address changes in this PR, and tests are passing
- [x] Updated documentation, if necessary
- [x] This PR is ready for review

<!--- See DEVELOPING.md for instructions on running and writing tests. -->

Remaining Work
--------------

<!--- If any work remains to be done, please give a brief description here. -->
<!--- Consider providing a todo-list so we can easily track completion progress. -->

<!--- Thanks for contributing! -->
