### PR TITLE
server/supernova/utilities/time_tag.hpp: Adding static_cast to long f…

### DIFF
--- a/server/supernova/utilities/time_tag.hpp
+++ b/server/supernova/utilities/time_tag.hpp
@@ -229,7 +229,7 @@ public:
 #ifdef BOOST_DATE_TIME_POSIX_TIME_STD_CONFIG
         time_duration offset = seconds(get_secs() - ntp_offset) + nanoseconds(get_nanoseconds());
 #else
-        time_duration offset = seconds(get_secs() - ntp_offset) + microseconds(get_nanoseconds()/1000);
+        time_duration offset = seconds(get_secs() - ntp_offset) + microseconds(static_cast<long>(get_nanoseconds()/1000));
 #endif
         return ptime(base, offset);
     }


### PR DESCRIPTION
…or time_duration offset in microseconds to satisfy boost >= 1.67.0.

Purpose and Motivation
----------------------

Fixes #3981 

Types of changes
----------------

- Bug fix (non-breaking change which fixes an issue)

Checklist
---------

- [x] All previous tests are passing
- [ ] Tests were updated or created to address changes in this PR, and tests are passing
- [ ] Updated documentation, if necessary
- [x] This PR is ready for review

Remaining Work
--------------

Hopefully none!