### PR TITLE
Help: VarLag: Explicitly note the kr input limitation [skip ci]

### DIFF
--- a/HelpSource/Classes/VarLag.schelp
+++ b/HelpSource/Classes/VarLag.schelp
@@ -7,7 +7,9 @@ categories::  UGens>Filters>Linear
 Description::
 Similar to link::Classes/Lag:: but with other curve shapes than exponential.
 A change on the input will take the specified time to reach the new value.
-Useful for smoothing out control signals.
+Useful for smoothing out control (not audio) signals.
+
+warning:: code::VarLag.ar:: currently accepts audio-rate input, but the underlying implementation treats the input as control rate. Effectively, then, the "sampling rate" of VarLag's input is code::ControlRate.ir:: or code::server.sampleRate / server.options.blockSize::, and the maximum safe frequency to feed into VarLag is half of this. VarLag does not currently yield correct results for full-bandwidth audio-rate signals. Use code::VarLag.ar:: at your own risk.::
 
 classmethods::
 


### PR DESCRIPTION
Purpose and Motivation
----------------------

Per bug #3958, `VarLag.ar` is currently unsafe unless you're sure all frequencies in the input are below the control rate Nyquist frequency `s.sampleRate / s.options.blockSize * 0.5`.

The help file states only that VarLag is "Useful for smoothing out control signals." But, the existence of an audio-rate implementation suggests that this is not a serious warning.

The finding in the bug report is that the fix goes pretty deep into EnvGen internals. I don't believe this will happen quickly. At the very least, then, the help file should advise users not to expect true audio-rate behavior.

Types of changes
----------------

- Documentation (non-code change which corrects or adds documentation for existing features)

Checklist
---------

- [x] Updated documentation, if necessary
- [x] This PR is ready for review
