### PR TITLE
qtcollider: swallow events

### DIFF
--- a/QtCollider/QcApplication.cpp
+++ b/QtCollider/QcApplication.cpp
@@ -168,5 +168,16 @@ bool QcApplication::notify( QObject * object, QEvent * event )
         break;
     }
 
-    return QApplication::notify( object, event );
+    bool result = QApplication::notify( object, event );
+
+#ifdef Q_OS_MAC
+    // XXX Explicitly accept all handled events so they don't propagate outside the application.
+    // This is a hack; for a not-fully-understood reason Qt past 5.7 sends these events to the
+    // native window if they aren't accepted here. This caused issue #4058. Accepting them here
+    // seems to solve the problem, but might cause other issues since it is a heavy-handed way
+    // of doing this. TODO - solve more elegantly
+    if (result)
+        event->accept();
+#endif
+    return result;
 }

--- a/QtCollider/interface.cpp
+++ b/QtCollider/interface.cpp
@@ -63,7 +63,8 @@ void QtCollider::init() {
 #endif
 
 #ifdef Q_OS_MAC
-    QApplication::setAttribute( Qt::AA_MacPluginApplication, true );
+    // TODO: this should not be necessary
+    QApplication::setAttribute( Qt::AA_PluginApplication, true );
 #endif
 
     static int qcArgc = 1;


### PR DESCRIPTION
In QtCollider::notify(), explicitly accept all handled events so they
don't propagate outside the application.  This is a hack; for a
not-fully-understood reason Qt past 5.7 sends these events to the native
window if they aren't accepted here. This caused issue #4058. Accepting
them here seems to solve the problem, but might cause other issues since
it is a heavy-handed way of doing this.

Based on looking at Qt's source code I have a strong guess this happens
because we set AA_MacPluginApplication on the QtCollider application.
See https://code.qt.io/cgit/qt/qtbase.git/tree/src/plugins/platforms/cocoa/qnsview.mm?h=5.11#n1472

AFAICT we shouldn't be setting that flag because it is meant for Qt
_plugins_ only, and QtCollider is an application, not a plugin using the
Qt QPluginLoader system. But, removing that setting causes QtCollider to
take focus after starting up, an undesirable side effect. There might be
a way to fix that, I don't know.

At any rate AA_MacPluginApplication is deprecated in favor of
AA_PluginApplication, so I have swapped it out with that and left a
TODO.

Simple tests show that this works; at least, it lets events propagate up
the widget hierarchy within a window while still blocking e.g. Cmd-B
from booting the server.

Fixes #4058 (?)

Types of changes
----------------

- Bug fix (non-breaking change which fixes an issue)

Checklist
---------

- [x] All tests are passing
- [x] If necessary, new tests were created to address changes in PR, and tests are passing
- [x] Updated documentation, if necessary
- [x] This PR is ready for review

Remaining Work
--------------

Please test

<!--- If any work remains to be done, please give a brief description here. -->
<!--- Consider providing a todo-list so we can easily track completion progress. -->

<!--- Thanks for contributing! -->