### PR TITLE
Make ServerStatusWatcher return sampleRate as Integer

### DIFF
--- a/SCClassLibrary/Common/Control/ServerStatus.sc
+++ b/SCClassLibrary/Common/Control/ServerStatus.sc
@@ -9,7 +9,7 @@ ServerStatusWatcher {
 
 	var <numUGens=0, <numSynths=0, <numGroups=0, <numSynthDefs=0;
 	var <avgCPU, <peakCPU;
-	var <sampleRate, <actualSampleRate;
+	var sampleRate, <actualSampleRate;
 
 	var reallyDeadCount = 0, bootNotifyFirst = true;
 
@@ -173,6 +173,8 @@ ServerStatusWatcher {
 			this.startAliveThread;
 		}
 	}
+
+	sampleRate{ ^sampleRate.asInteger; }
 
 	serverRunning { ^hasBooted and: notified }
 


### PR DESCRIPTION

Purpose and Motivation
----------------------
Fixes #4107 

Types of changes
----------------
This PR ensures that ServerStatusWatcher returns sampleRate as Integer. Please see issue #4107 for more information about this change.

Checklist
---------

Remaining Work
--------------
Should I make a test for this?