### PR TITLE
[scsynth] Use snprintf, add constants for buffer sizes

### DIFF
--- a/server/scsynth/SC_GraphDef.cpp
+++ b/server/scsynth/SC_GraphDef.cpp
@@ -143,7 +143,7 @@ void UnitSpec_Read(UnitSpec* inUnitSpec, char*& buffer)
 	inUnitSpec->mUnitDef = GetUnitDef(name);
 	if (!inUnitSpec->mUnitDef) {
 		char str[256];
-		sprintf(str, "UGen '%s' not installed.", (char*)name);
+		snprintf(str, 256, "UGen '%s' not installed.", (char*)name);
 		throw std::runtime_error(str);
 		return;
 	}
@@ -173,7 +173,7 @@ void UnitSpec_ReadVer1(UnitSpec* inUnitSpec, char*& buffer)
 	inUnitSpec->mUnitDef = GetUnitDef(name);
 	if (!inUnitSpec->mUnitDef) {
 		char str[256];
-		sprintf(str, "UGen '%s' not installed.", (char*)name);
+		snprintf(str, 256, "UGen '%s' not installed.", (char*)name);
 		throw std::runtime_error(str);
 		return;
 	}

--- a/server/scsynth/SC_GraphDef.cpp
+++ b/server/scsynth/SC_GraphDef.cpp
@@ -52,6 +52,8 @@ namespace bfs = boost::filesystem;
 
 extern Malloc gMalloc;
 
+const size_t ERR_BUF_SIZE(256);
+
 int32 GetHash(ParamSpec* inParamSpec)
 {
 	return inParamSpec->mHash;
@@ -142,8 +144,8 @@ void UnitSpec_Read(UnitSpec* inUnitSpec, char*& buffer)
 
 	inUnitSpec->mUnitDef = GetUnitDef(name);
 	if (!inUnitSpec->mUnitDef) {
-		char str[256];
-		snprintf(str, 256, "UGen '%s' not installed.", (char*)name);
+		char str[ERR_BUF_SIZE];
+		snprintf(str, ERR_BUF_SIZE, "UGen '%s' not installed.", (char*)name);
 		throw std::runtime_error(str);
 		return;
 	}
@@ -172,8 +174,8 @@ void UnitSpec_ReadVer1(UnitSpec* inUnitSpec, char*& buffer)
 
 	inUnitSpec->mUnitDef = GetUnitDef(name);
 	if (!inUnitSpec->mUnitDef) {
-		char str[256];
-		snprintf(str, 256, "UGen '%s' not installed.", (char*)name);
+		char str[ERR_BUF_SIZE];
+		snprintf(str, ERR_BUF_SIZE, "UGen '%s' not installed.", (char*)name);
 		throw std::runtime_error(str);
 		return;
 	}

--- a/server/scsynth/SC_Group.cpp
+++ b/server/scsynth/SC_Group.cpp
@@ -343,14 +343,15 @@ void Group_QueryTreeAndControls(Group* inGroup, big_scpacket *packet)
 				if((childGraph->mMapControls[i]) != ptr){
 					// it's mapped
 					int bus;
-					char buf[10]; //should be long enough
+          const size_t BUF_SIZE(10);
+					char buf[BUF_SIZE];
 					if (childGraph->mControlRates[i] == 2) {
-					bus = (childGraph->mMapControls[i]) - (child->mWorld->mAudioBus);
-					bus = (int)((float)bus / child->mWorld->mBufLength);
-					snprintf(buf, 10, "%c%d", 'a', bus);
+            bus = (childGraph->mMapControls[i]) - (child->mWorld->mAudioBus);
+            bus = (int)((float)bus / child->mWorld->mBufLength);
+            snprintf(buf, BUF_SIZE, "%c%d", 'a', bus);
 					} else {
 						bus = (childGraph->mMapControls[i]) - (child->mWorld->mControlBus);
-						snprintf(buf, 10, "%c%d", 'c', bus);
+						snprintf(buf, BUF_SIZE, "%c%d", 'c', bus);
 					}
 					//scprintf("bus: %d\n", bus);
 					packet->addtag('s');

--- a/server/scsynth/SC_Group.cpp
+++ b/server/scsynth/SC_Group.cpp
@@ -347,10 +347,10 @@ void Group_QueryTreeAndControls(Group* inGroup, big_scpacket *packet)
 					if (childGraph->mControlRates[i] == 2) {
 					bus = (childGraph->mMapControls[i]) - (child->mWorld->mAudioBus);
 					bus = (int)((float)bus / child->mWorld->mBufLength);
-					sprintf(buf, "%c%d", 'a', bus);
+					snprintf(buf, 10, "%c%d", 'a', bus);
 					} else {
 						bus = (childGraph->mMapControls[i]) - (child->mWorld->mControlBus);
-						sprintf(buf, "%c%d", 'c', bus);
+						snprintf(buf, 10, "%c%d", 'c', bus);
 					}
 					//scprintf("bus: %d\n", bus);
 					packet->addtag('s');

--- a/server/scsynth/SC_Group.cpp
+++ b/server/scsynth/SC_Group.cpp
@@ -343,12 +343,12 @@ void Group_QueryTreeAndControls(Group* inGroup, big_scpacket *packet)
 				if((childGraph->mMapControls[i]) != ptr){
 					// it's mapped
 					int bus;
-          const size_t BUF_SIZE(10);
+					const size_t BUF_SIZE(10);
 					char buf[BUF_SIZE];
 					if (childGraph->mControlRates[i] == 2) {
-            bus = (childGraph->mMapControls[i]) - (child->mWorld->mAudioBus);
-            bus = (int)((float)bus / child->mWorld->mBufLength);
-            snprintf(buf, BUF_SIZE, "%c%d", 'a', bus);
+						bus = (childGraph->mMapControls[i]) - (child->mWorld->mAudioBus);
+						bus = (int)((float)bus / child->mWorld->mBufLength);
+						snprintf(buf, BUF_SIZE, "%c%d", 'a', bus);
 					} else {
 						bus = (childGraph->mMapControls[i]) - (child->mWorld->mControlBus);
 						snprintf(buf, BUF_SIZE, "%c%d", 'c', bus);

--- a/server/scsynth/SC_Lib.cpp
+++ b/server/scsynth/SC_Lib.cpp
@@ -221,7 +221,7 @@ SCErr SC_LibCmd::Perform(struct World *inWorld, int inSize, char *inData, ReplyA
 SCErr NewCommand(const char *inPath, uint32 inCommandNumber, SC_CommandFunc inFunc)
 {
 	char path[256];
-	sprintf(path, "/%s", inPath);
+	snprintf(path, 256, "/%s", inPath);
 
 	SC_LibCmd *cmd = new SC_LibCmd(inFunc);
 	cmd->SetName(path);

--- a/server/scsynth/SC_Lib.cpp
+++ b/server/scsynth/SC_Lib.cpp
@@ -29,6 +29,7 @@
 #include "SC_Str4.h"
 #include "SC_WorldOptions.h"
 
+const size_t PATH_BUF_SIZE(256);
 
 void SendDone(ReplyAddress *inReply, const char *inCommandName)
 {
@@ -220,8 +221,8 @@ SCErr SC_LibCmd::Perform(struct World *inWorld, int inSize, char *inData, ReplyA
 
 SCErr NewCommand(const char *inPath, uint32 inCommandNumber, SC_CommandFunc inFunc)
 {
-	char path[256];
-	snprintf(path, 256, "/%s", inPath);
+	char path[PATH_BUF_SIZE];
+	snprintf(path, PATH_BUF_SIZE, "/%s", inPath);
 
 	SC_LibCmd *cmd = new SC_LibCmd(inFunc);
 	cmd->SetName(path);

--- a/server/scsynth/SC_SequencedCommand.cpp
+++ b/server/scsynth/SC_SequencedCommand.cpp
@@ -30,6 +30,8 @@
 #include "../../common/SC_SndFileHelpers.hpp"
 #include "SC_WorldOptions.h"
 
+const size_t ERR_BUF_SIZE(512);
+
 #define GET_COMPLETION_MSG(msg) \
 	mMsgSize = msg.getbsize(); \
 	if (mMsgSize) { \
@@ -539,8 +541,8 @@ bool BufAllocReadCmd::Stage2()
 	memset(&fileinfo, 0, sizeof(fileinfo));
 	SNDFILE* sf = sndfileOpenFromCStr(mFilename, SFM_READ, &fileinfo);
 	if (!sf) {
-		char str[512];
-		snprintf(str, 512, "File '%s' could not be opened: %s\n", mFilename, sf_strerror(NULL));
+		char str[ERR_BUF_SIZE];
+		snprintf(str, ERR_BUF_SIZE, "File '%s' could not be opened: %s\n", mFilename, sf_strerror(NULL));
 		SendFailureWithIntValue(&mReplyAddress, "/b_allocRead", str, mBufIndex);	//SendFailure(&mReplyAddress, "/b_allocRead", str);
 		scprintf(str);
 		return false;
@@ -640,16 +642,16 @@ bool BufReadCmd::Stage2()
 
 	SNDFILE* sf = sndfileOpenFromCStr(mFilename, SFM_READ, &fileinfo);
 	if (!sf) {
-		char str[512];
-		snprintf(str, 512, "File '%s' could not be opened: %s\n", mFilename, sf_strerror(NULL));
+		char str[ERR_BUF_SIZE];
+		snprintf(str, ERR_BUF_SIZE, "File '%s' could not be opened: %s\n", mFilename, sf_strerror(NULL));
 		SendFailureWithIntValue(&mReplyAddress, "/b_read", str, mBufIndex); //SendFailure(&mReplyAddress, "/b_read", str);
 		scprintf(str);
 		return false;
 	}
 	if (fileinfo.channels != buf->channels) {
-		char str[512];
+		char str[ERR_BUF_SIZE];
 		sf_close(sf);
-		snprintf(str, 512, "Channel mismatch. File '%s' has %d channels. Buffer has %d channels.\n", mFilename, fileinfo.channels, buf->channels);
+		snprintf(str, ERR_BUF_SIZE, "Channel mismatch. File '%s' has %d channels. Buffer has %d channels.\n", mFilename, fileinfo.channels, buf->channels);
 		SendFailureWithIntValue(&mReplyAddress, "/b_read", str, mBufIndex); //SendFailure(&mReplyAddress, "/b_read", str);
 		scprintf(str);
 		return false;
@@ -803,8 +805,8 @@ bool BufAllocReadChannelCmd::Stage2()
 	memset(&fileinfo, 0, sizeof(fileinfo));
 	SNDFILE* sf = sndfileOpenFromCStr(mFilename, SFM_READ, &fileinfo);
 	if (!sf) {
-		char str[512];
-		snprintf(str, 512, "File '%s' could not be opened: %s\n", mFilename, sf_strerror(NULL));
+		char str[ERR_BUF_SIZE];
+		snprintf(str, ERR_BUF_SIZE, "File '%s' could not be opened: %s\n", mFilename, sf_strerror(NULL));
 		SendFailureWithIntValue(&mReplyAddress, "/b_allocReadChannel", str, mBufIndex); //SendFailure(&mReplyAddress, "/b_allocRead", str);
 		scprintf(str);
 		return false;
@@ -930,8 +932,8 @@ bool BufReadChannelCmd::Stage2()
 
 	SNDFILE* sf = sndfileOpenFromCStr(mFilename, SFM_READ, &fileinfo);
 	if (!sf) {
-		char str[512];
-		snprintf(str, 512, "File '%s' could not be opened: %s\n", mFilename, sf_strerror(NULL));
+		char str[ERR_BUF_SIZE];
+		snprintf(str, ERR_BUF_SIZE, "File '%s' could not be opened: %s\n", mFilename, sf_strerror(NULL));
 		SendFailureWithIntValue(&mReplyAddress, "/b_readChannel", str, mBufIndex); //SendFailure(&mReplyAddress, "/b_read", str);
 		scprintf(str);
 		return false;
@@ -1081,8 +1083,8 @@ bool BufWriteCmd::Stage2()
 
 	SNDFILE* sf = sndfileOpenFromCStr(mFilename, SFM_WRITE, &mFileInfo);
 	if (!sf) {
-		char str[512];
-		snprintf(str, 512, "File '%s' could not be opened: %s\n", mFilename, sf_strerror(NULL));
+		char str[ERR_BUF_SIZE];
+		snprintf(str, ERR_BUF_SIZE, "File '%s' could not be opened: %s\n", mFilename, sf_strerror(NULL));
 		SendFailureWithIntValue(&mReplyAddress, "/b_write", str, mBufIndex); //SendFailure(&mReplyAddress, "/b_write", str);
 		scprintf(str);
 		return false;

--- a/server/scsynth/SC_SequencedCommand.cpp
+++ b/server/scsynth/SC_SequencedCommand.cpp
@@ -540,7 +540,7 @@ bool BufAllocReadCmd::Stage2()
 	SNDFILE* sf = sndfileOpenFromCStr(mFilename, SFM_READ, &fileinfo);
 	if (!sf) {
 		char str[512];
-		sprintf(str, "File '%s' could not be opened: %s\n", mFilename, sf_strerror(NULL));
+		snprintf(str, 512, "File '%s' could not be opened: %s\n", mFilename, sf_strerror(NULL));
 		SendFailureWithIntValue(&mReplyAddress, "/b_allocRead", str, mBufIndex);	//SendFailure(&mReplyAddress, "/b_allocRead", str);
 		scprintf(str);
 		return false;
@@ -641,7 +641,7 @@ bool BufReadCmd::Stage2()
 	SNDFILE* sf = sndfileOpenFromCStr(mFilename, SFM_READ, &fileinfo);
 	if (!sf) {
 		char str[512];
-		sprintf(str, "File '%s' could not be opened: %s\n", mFilename, sf_strerror(NULL));
+		snprintf(str, 512, "File '%s' could not be opened: %s\n", mFilename, sf_strerror(NULL));
 		SendFailureWithIntValue(&mReplyAddress, "/b_read", str, mBufIndex); //SendFailure(&mReplyAddress, "/b_read", str);
 		scprintf(str);
 		return false;
@@ -649,7 +649,7 @@ bool BufReadCmd::Stage2()
 	if (fileinfo.channels != buf->channels) {
 		char str[512];
 		sf_close(sf);
-		sprintf(str, "Channel mismatch. File '%s' has %d channels. Buffer has %d channels.\n", mFilename, fileinfo.channels, buf->channels);
+		snprintf(str, 512, "Channel mismatch. File '%s' has %d channels. Buffer has %d channels.\n", mFilename, fileinfo.channels, buf->channels);
 		SendFailureWithIntValue(&mReplyAddress, "/b_read", str, mBufIndex); //SendFailure(&mReplyAddress, "/b_read", str);
 		scprintf(str);
 		return false;
@@ -804,7 +804,7 @@ bool BufAllocReadChannelCmd::Stage2()
 	SNDFILE* sf = sndfileOpenFromCStr(mFilename, SFM_READ, &fileinfo);
 	if (!sf) {
 		char str[512];
-		sprintf(str, "File '%s' could not be opened: %s\n", mFilename, sf_strerror(NULL));
+		snprintf(str, 512, "File '%s' could not be opened: %s\n", mFilename, sf_strerror(NULL));
 		SendFailureWithIntValue(&mReplyAddress, "/b_allocReadChannel", str, mBufIndex); //SendFailure(&mReplyAddress, "/b_allocRead", str);
 		scprintf(str);
 		return false;
@@ -931,7 +931,7 @@ bool BufReadChannelCmd::Stage2()
 	SNDFILE* sf = sndfileOpenFromCStr(mFilename, SFM_READ, &fileinfo);
 	if (!sf) {
 		char str[512];
-		sprintf(str, "File '%s' could not be opened: %s\n", mFilename, sf_strerror(NULL));
+		snprintf(str, 512, "File '%s' could not be opened: %s\n", mFilename, sf_strerror(NULL));
 		SendFailureWithIntValue(&mReplyAddress, "/b_readChannel", str, mBufIndex); //SendFailure(&mReplyAddress, "/b_read", str);
 		scprintf(str);
 		return false;
@@ -1082,7 +1082,7 @@ bool BufWriteCmd::Stage2()
 	SNDFILE* sf = sndfileOpenFromCStr(mFilename, SFM_WRITE, &mFileInfo);
 	if (!sf) {
 		char str[512];
-		sprintf(str, "File '%s' could not be opened: %s\n", mFilename, sf_strerror(NULL));
+		snprintf(str, 512, "File '%s' could not be opened: %s\n", mFilename, sf_strerror(NULL));
 		SendFailureWithIntValue(&mReplyAddress, "/b_write", str, mBufIndex); //SendFailure(&mReplyAddress, "/b_write", str);
 		scprintf(str);
 		return false;


### PR DESCRIPTION
<!--- Hi, and thanks for contributing! -->
<!--- Make sure to provide a general summary of your changes in the title above. -->
<!--- For example: "[scsynth] Fix crash when encountering cute kittens" -->

Purpose and Motivation
----------------------

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to it here by writing "Fixes #555". -->
Use `snprintf` for mitigation against possible buffer overflows.
This seems especially important when dealing with filenames provided by a client.

Clarified buffer sizes with constants.
I did not create a constant for the change in SC_Group.cpp, though it may benefit from one in the future.

Have yet to run the test suite, though these are fairly minimal changes.

Types of changes
----------------

<!--- What types of changes does your pull request introduce? -->
<!--- Some examples are below (you can delete the lines that don't apply): -->

- Bug fix (non-breaking change which fixes an issue)

Checklist
---------

<!--- Complete an item by checking it: [x] -->

- [ ] All previous tests are passing
- [ ] Tests were updated or created to address changes in this PR, and tests are passing
- [ ] Updated documentation, if necessary
- [x] This PR is ready for review

<!--- See DEVELOPING.md for instructions on running and writing tests. -->

Remaining Work
--------------

<!--- If any work remains to be done, please give a brief description here. -->
<!--- Consider providing a todo-list so we can easily track completion progress. -->

<!--- Thanks for contributing! -->
