### PR TITLE
Topic/pipe call sync error code

### DIFF
--- a/HelpSource/Classes/Pipe.schelp
+++ b/HelpSource/Classes/Pipe.schelp
@@ -24,6 +24,32 @@ A link::Classes/SequenceableCollection:: containining strings where the first st
 argument::mode
 A link::Classes/String:: representing the mode. Valid modes are "w" (pipe to stdin) and "r" (pipe from stdout).
 
+method::callSync
+
+Opens a pipe for reading, and retrieves either the command's results as a string or the exit code.
+
+list::
+## If the command is successful and there is output to report, the code::onSuccess:: function will be called with two arguments: code::contents, exitCode::. code::exitCode:: should be 0, but is passed just in case something goes wrong.
+## If the command is successful and the output is empty, the code::onError:: function will be called with a single argument, code::exitCode::. The exit code will be 0 in this case.
+## If the command failed, the code::onError:: function will be called with the error code as the single argument.
+::
+
+(That is, this method assumes the command will produce output. If it didn't, it calls the error function, where you can use the exitCode argument to distinguish success or failure.)
+
+argument::command
+A string containing the commandline to evaluate.
+
+argument::onSuccess
+A function with two arguments: code::contents, exitCode::. code::exitCode:: should be 0 and may normally be ignored.
+
+argument::onError
+A function with one argument: code::exitCode::. If 0, it means the command did not encounter any errors but that the output was empty.
+
+argument::maxLineLength
+An Integer, for the maximum expected line size.
+
+returns:: Normally returns nil. Command results should be handled in code::onSuccess:: and code::onError::. If the method's return is non-nil, then it is a function to close the pipe.
+
 InstanceMethods::
 
 private::prClose, prOpen, prOpenArgv

--- a/testsuite/classlibrary/TestPipe.sc
+++ b/testsuite/classlibrary/TestPipe.sc
@@ -1,0 +1,61 @@
+TestPipe : UnitTest {
+	var path, command;
+
+	setUp {
+		path = PathName.tmp +/+ "sc_testfile.txt";
+		command = (linux: "cat", osx: "cat", windows: "type").at(thisProcess.platform.name);
+	}
+
+	tearDown {
+		File.delete(path);
+	}
+
+	test_callSync_normal {
+		var file, lines, exitCode;
+
+		file = File(path, "w");
+		file << "one line\ntwo lines\n";
+		file.close;
+
+		Pipe.callSync(command + path,
+			onSuccess: { |contents| lines = contents.postcs },
+			onError: { |exit| exitCode = exit }
+		);
+
+		// note: if onError is called inappropriately, then 'lines' will be nil
+		// and the test fails. So we don't really have to *test* exitCode.
+		// we report it for troubleshooting.
+		this.assert(lines == "one line\ntwo lines",
+			"Pipe.callSync should retrieve the command results exactly, minus trailing newline (exit code was %)".format(exitCode)
+		);
+	}
+
+	test_callSync_empty {
+		var file, lines, exitCode;
+
+		file = File(path, "w");
+		file.close;
+
+		Pipe.callSync(command + path,
+			onSuccess: { |contents| lines = contents },
+			onError: { |exit| exitCode = exit }
+		);
+
+		this.assert(exitCode == 0,
+			"Pipe.callSync should call onError with exit code 0 for empty results (exit code was %)".format(exitCode)
+		);
+	}
+
+	test_callSync_error {
+		var file, lines, exitCode;
+
+		Pipe.callSync("flibble",
+			onSuccess: { |contents| lines = contents },
+			onError: { |exit| exitCode = exit }
+		);
+
+		this.assert(exitCode != 0,
+			"Pipe.callSync with error should give the exit code to the onError function (exit code was %)".format(exitCode)
+		);
+	}
+}


### PR DESCRIPTION
Purpose and Motivation
----------------------

Cleaning up some old e-mails, I found a discussion about Pipe.callSync.

Suggesting this for 'develop' because it isn't really urgent.

Previously, the exit code was discarded. Now, we get the exit code when closing the pipe, and pass it into `onSuccess` or `onError` (whichever is called).

Old behavior: if the command completes without error but there is no output, `onError` was called. Per mailing list discussion, we keep the current behavior for empty output (only now, the user can check the error code).

Unit testing: Three tests for callSync:
- Success, with output (check for the result string to be correct).
- Success, with empty output (check for exit == 0).
- Failure (invalid command) -- exit != 0.

Along the way, if `File` writing functionality breaks, these tests will fail too.

Documentation: `callSync` had been undocumented. There is a related method `call`, which appears to be intended for asynchronous use -- but Pipe is synchronous (always blocks the interpreter) so I don't see much purpose for it. I haven't documented `Pipe.call` -- actually I would suggest deprecating it. It isn't used anywhere in the class library and it seems to me to have no legitimate purpose.

Types of changes
----------------

- Documentation
- New feature (non-breaking change which adds functionality) -- well, it passes additional arguments to user-supplied functions called from within the class library, so technically, API change. It doesn't change the meaning of any existing arguments or change the circumstances under which the functions are called.

Checklist
---------

- [x] All previous tests are passing
- [x] Tests were updated or created to address changes in this PR, and tests are passing
- [x] Updated documentation, if necessary
- [x] This PR is ready for review

Remaining Work
--------------

Possibly deprecate `Pipe.call`.