### PR TITLE
cmake: turn off -ffast-math for gcc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,7 +107,7 @@ if (${CMAKE_COMPILER_IS_GNUCXX})
 		message(FATAL_ERROR "SuperCollider requires at least gcc-4.8 when compiled with gcc.")
 	endif()
 
-	add_definitions("-ffast-math -fsigned-zeros -fno-associative-math")
+	add_definitions("-fno-math-errno -fno-signaling-nans -fsigned-zeros -fno-associative-math")
 
 	if(APPLE)
 		exec_program(${CMAKE_CXX_COMPILER} ARGS --version OUTPUT_VARIABLE _gcc_version_info)


### PR DESCRIPTION
Purpose and Motivation
----------------------

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to it here by writing "Fixes #555". -->

This causes fp math to behave incorrectly
Instead, enable optimizations for the worst offenders (no signaling nan, no math errno)

Fixes #4116

Types of changes
----------------

<!--- What types of changes does your pull request introduce? -->
<!--- Some examples are below (you can delete the lines that don't apply): -->

- Bug fix (non-breaking change which fixes an issue)
- Breaking change (possibly, needs evaluation)

Checklist
---------

<!--- Complete an item by checking it: [x] -->

- [x] All tests are passing
- [x] If necessary, new tests were created to address changes in PR, and tests are passing
- [x] Updated documentation, if necessary
- [x] This PR is ready for review

<!--- See DEVELOPING.md for instructions on running and writing tests. -->

Remaining Work
--------------

Tests should be run after building with this change to ensure nothing
else in the main language test suite has broken as a result of this
change.
<!--- If any work remains to be done, please give a brief description here. -->
<!--- Consider providing a todo-list so we can easily track completion progress. -->

<!--- Thanks for contributing! -->