### PR TITLE
SimpleNumber.asTimeString: fix formatting

### DIFF
--- a/SCClassLibrary/Common/Math/SimpleNumber.sc
+++ b/SCClassLibrary/Common/Math/SimpleNumber.sc
@@ -711,7 +711,7 @@ SimpleNumber : Number {
 		// formatted string.
 		precision = max(precision, 0.001);
 		mseconds = this.frac.round(precision) * 1000;
-		mseconds = mseconds.round.asString.padLeft(3, "0");
+		mseconds = mseconds.round.asInteger.asString.padLeft(3, "0");
 		^days ++ hours ++ minutes ++ seconds ++ mseconds
 	}
 


### PR DESCRIPTION
<!--- Hi, and thanks for contributing! -->
<!--- Make sure to provide a general summary of your changes in the title above. -->
<!--- For example: "[scsynth] Fix crash when encountering cute kittens" -->

Purpose and Motivation
----------------------

millis was not being converted to integer correctly,
TestSimpleNumber failed as a result.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to it here by writing "Fixes #555". -->

Types of changes
----------------

<!--- What types of changes does your pull request introduce? -->
<!--- Some examples are below (you can delete the lines that don't apply): -->

- Bug fix

Checklist
---------

<!--- Complete an item by checking it: [x] -->

- [x] All tests are passing
- [x] If necessary, new tests were created to address changes in PR, and tests are passing
- [x] Updated documentation, if necessary
- [x] This PR is ready for review