### PR TITLE
fix Pconst help file

### DIFF
--- a/HelpSource/Classes/Pconst.schelp
+++ b/HelpSource/Classes/Pconst.schelp
@@ -27,7 +27,7 @@ x = a.asStream;
 )
 
 
-//Pconst used as a sequence of pitches
+//Pconst used as a sequence of durations
 
 (
 SynthDef(\help_sinegrain,


### PR DESCRIPTION
The Pconst help file includes an example that shows how to use Pconst as a sequence of durations. However the comment just above the example indicates Pconst is used as a sequence of pitches. The text of the comment has been updated to:

"Pconst used as a sequence of durations"