### PR TITLE
Update Knob help to better showcase mouse modes

### DIFF
--- a/HelpSource/Classes/Knob.schelp
+++ b/HelpSource/Classes/Knob.schelp
@@ -201,11 +201,13 @@ subsection:: Compare Mouse Modes
 
 code::
 (
-var view = View().layout_(HLayout(
-    VLayout(Knob().mode_(\round), StaticText().string_("round")),
-    VLayout(Knob().mode_(\vert), StaticText().string_("vert")),
-    VLayout(Knob().mode_(\horiz), StaticText().string_("horiz"))
-));
+var view = View().layout_(
+    HLayout(
+        VLayout(Knob().mode_(\round), StaticText().string_("round")),
+        VLayout(Knob().mode_(\vert), StaticText().string_("vert")),
+        VLayout(Knob().mode_(\horiz), StaticText().string_("horiz"))
+    )
+);
 view.front;
 )
 ::

--- a/HelpSource/Classes/Knob.schelp
+++ b/HelpSource/Classes/Knob.schelp
@@ -197,6 +197,18 @@ k.canFocus = false
 k.canFocus = true
 ::
 
+subsection:: Compare Mouse Modes
+
+code::
+(
+var view = View().layout_(HLayout(
+    VLayout(Knob().mode_(\round), StaticText().string_("round")),
+    VLayout(Knob().mode_(\vert), StaticText().string_("vert")),
+    VLayout(Knob().mode_(\horiz), StaticText().string_("horiz"))
+));
+view.front;
+)
+::
 
 subsection:: Centered Mode
 


### PR DESCRIPTION
Purpose and Motivation
----------------------

Mouse modes for the Knob control deserve emphasis as the the \vert and \horiz modes are probably more user-friendly than the default \round mode.

Types of changes
----------------

Update help file to include an additional example showcasing the different modes.

