### PR TITLE
class library: checks if quarks local path is a dir before installing

### DIFF
--- a/SCClassLibrary/Common/Quarks/Quarks.sc
+++ b/SCClassLibrary/Common/Quarks/Quarks.sc
@@ -24,6 +24,10 @@ Quarks {
 				("Quarks-install: path does not exist" + path).error;
 				^nil
 			});
+			if(File.type(path) != \directory, {
+				("Quarks-install: path is not a directory" + path).error;
+				^nil
+			});
 			quark = Quark.fromLocalPath(path);
 			this.installQuark(quark);
 			^quark


### PR DESCRIPTION
Purpose and Motivation
----------------------

Fixes #4109 

This will check when trying to install a quarks from local path if it is a directory, otherwise fails. 

Without the patch, it will add bad paths (any files) to the configuration and then always fail when compiling the class library.

Types of changes
----------------

- New feature (non-breaking change which adds functionality)

Checklist
---------

- [X] All previous tests are passing
- [X] This PR is ready for review
