### PR TITLE
scide:  disables copy theme if theme is a new theme not yet saved

### DIFF
--- a/editors/sc-ide/core/settings/theme.cpp
+++ b/editors/sc-ide/core/settings/theme.cpp
@@ -107,6 +107,7 @@ void Theme::fillUser(const QString & name, const Manager *settings)
 
     if (!settings->contains(group + "whitespace")) {
         qDebug() << "Failed to find theme" << name << settings->group();
+        fillDefault(); // Fallback to default theme to avoid a broken Theme
         return;
     }
 

--- a/editors/sc-ide/widgets/settings/editor_page.cpp
+++ b/editors/sc-ide/widgets/settings/editor_page.cpp
@@ -283,6 +283,8 @@ void EditorPage::store( Manager *s )
         else
             theme->remove();
     }
+
+    ui->themeCopyBtn->setDisabled(false);
     s->updateTheme();
 }
 
@@ -484,6 +486,7 @@ void EditorPage::dialogCopyTheme()
             mThemes.insert(newThemeName, theme);
             ui->themeCombo->addItem(newThemeName);
             ui->themeCombo->setCurrentIndex(ui->themeCombo->findText(newThemeName));
+            ui->themeCopyBtn->setDisabled(true);
             updateTheme(newThemeName);
         }
     }


### PR DESCRIPTION
Purpose and Motivation
----------------------

Fixes #4033 

As noted on the issue above, scide crashes when you try to copy a theme that was just copied.

It happens because the newly copied theme is not stored until the changes are applied.

This patch disables the copy button when a new theme is created by copying an old one, until the changes are applied.

Also, internally, it falls back to the default theme if, somehow, we try to create a new Theme based on a theme that doesn't exist. I'm not 100% sure about that since errors should not be silenced, so an warning is still issued.


Types of changes
----------------

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

Checklist
---------

- [X] All previous tests are passing
- [X] This PR is ready for review