### PR TITLE
Topic/impulse rewrite

### DIFF
--- a/HelpSource/Classes/Impulse.schelp
+++ b/HelpSource/Classes/Impulse.schelp
@@ -28,15 +28,12 @@ The output will be multiplied by this value.
 argument::add
 This value will be added to the output.
 
-discussion::
+Discussion::
 code::Impulse:: will output an impulse on the first sample (assuming no phase
-offset). code::Impulse:: with strong::freq:: code::0:: outputs a single impulse,
-followed by silence until the frequency changes.
+offset).
 
-Supported rate combinations for code::(freq, phase):: are
-code::(a,a)::, code::(a,k)::, code::(a,i)::,
-code::(k,k)::, code::(k,i)::,
-code::(i,k)::, code::(i,i)::.
+When the initial code::freq = 0::, a single impulse is output on first sample,
+followed by silence until the frequency changes.
 
 Discussion::
 code::Impulse:: will output a code::1.0:: on the first sample (assuming no

--- a/HelpSource/Classes/Impulse.schelp
+++ b/HelpSource/Classes/Impulse.schelp
@@ -5,7 +5,6 @@ categories::  UGens>Generators>Deterministic
 
 
 Description::
-
 Outputs non-bandlimited single sample impulses.
 
 
@@ -14,26 +13,25 @@ classmethods::
 method::ar, kr
 
 argument::freq
-
-Frequency in Hertz.
+Frequency in Hertz. strong::freq:: may be negative.
 
 
 argument::phase
-
-Phase offset in cycles (0..1).
-
+Phase offset in cycles (0..1). Staying in this range offers a slight efficiency
+advantage, though phase offsets outside this range are supported and wrapped
+internally.
 
 argument::mul
-
 The output will be multiplied by this value.
 
 
 argument::add
-
 This value will be added to the output.
 
 discussion::
-An Impulse with frequency 0 returns a single impulse.
+code::Impulse:: will output an impulse on the first sample (assuming no phase
+offset). code::Impulse:: with strong::freq:: code::0:: outputs a single impulse,
+followed by silence until the frequency changes.
 
 Examples::
 

--- a/HelpSource/Classes/Impulse.schelp
+++ b/HelpSource/Classes/Impulse.schelp
@@ -33,6 +33,38 @@ code::Impulse:: will output an impulse on the first sample (assuming no phase
 offset). code::Impulse:: with strong::freq:: code::0:: outputs a single impulse,
 followed by silence until the frequency changes.
 
+Supported rate combinations for code::(freq, phase):: are
+code::(a,a)::, code::(a,k)::, code::(a,i)::,
+code::(k,k)::, code::(k,i)::,
+code::(i,k)::, code::(i,i)::.
+
+Discussion::
+code::Impulse:: will output a code::1.0:: on the first sample (assuming no
+phase offset).
+
+If the initial code::freq = 0::, a single impulse is output on first sample,
+followed by silence until the frequency changes.
+
+Supported rate combinations for code::(freq, phase):: are
+code::(a,a)::, code::(a,k)::, code::(a,i)::,
+code::(k,k)::, code::(k,i)::,
+code::(i,k)::, code::(i,i)::.
+
+
+Internally, code::Impulse:: is based on a wrapping phasor: when the phase wraps,
+an impulse is output. Any strong::phase:: offset is added and wrapped before
+the phase increment (determined by strong::freq::) is applied. Therefore, it is
+the phase increment (freq) that triggers an impulse, not the phase offset. For
+example, if you wanted to drive and impulse train directly by the phase,
+code::Impulse:: would not support that. However, a small UGen network could
+achieve this result:
+code::
+({ var f = 1000;
+    HPZ1.ar(HPZ1.ar(Phasor.ar(rate: f * SampleDur.ir))) > 1e-5
+}.plot(0.005)
+);
+::
+
 Examples::
 
 code::

--- a/server/plugins/LFUGens.cpp
+++ b/server/plugins/LFUGens.cpp
@@ -67,7 +67,7 @@ struct LFGauss : public Unit {
 };
 
 struct Impulse : public Unit {
-    double mPhase, mPhaseOffset;
+    double mPhase, mPhaseOffset, mPhaseIncrement;
     float mFreqMul;
 };
 
@@ -202,9 +202,15 @@ void VarSaw_next_a(VarSaw* unit, int inNumSamples);
 void VarSaw_next_k(VarSaw* unit, int inNumSamples);
 void VarSaw_Ctor(VarSaw* unit);
 
-void Impulse_next_a(Impulse* unit, int inNumSamples);
+void Impulse_next_aa(Impulse* unit, int inNumSamples);
+void Impulse_next_ak(Impulse* unit, int inNumSamples);
+void Impulse_next_ai(Impulse* unit, int inNumSamples);
+void Impulse_next_ka(Impulse* unit, int inNumSamples);
 void Impulse_next_kk(Impulse* unit, int inNumSamples);
-void Impulse_next_k(Impulse* unit, int inNumSamples);
+void Impulse_next_ki(Impulse* unit, int inNumSamples);
+void Impulse_next_ia(Impulse* unit, int inNumSamples);
+void Impulse_next_ik(Impulse* unit, int inNumSamples);
+void Impulse_next_ii(Impulse* unit, int inNumSamples);
 void Impulse_Ctor(Impulse* unit);
 
 void SyncSaw_next_aa(SyncSaw* unit, int inNumSamples);
@@ -793,109 +799,281 @@ void LFGauss_Ctor(LFGauss* unit) {
 
 //////////////////////////////////////////////////////////////////////////////////////////////////
 
-void Impulse_next_a(Impulse* unit, int inNumSamples) {
-    float* out = ZOUT(0);
-    float* freq = ZIN(0);
-
-    float freqmul = unit->mFreqMul;
-    double phase = unit->mPhase;
-    LOOP1(
-        inNumSamples, float z; if (phase >= 1.f) {
+// detect if phasor is out-of-bounds, trigger and wrap [0, 1]
+static inline float Impulse_testWrapPhase(double prev_phasInc, double& phase) {
+    if (prev_phasInc < 0.f) { // negative freqs
+        if (phase <= 0.f) {
+            phase += 1.f;
+            if (phase <= 0.f) { // catch large phase jumps
+                phase -= sc_ceil(phase);
+            }
+            return 1.f;
+        } else {
+            return 0.f;
+        }
+    } else { // positive freqs
+        if (phase >= 1.f) {
             phase -= 1.f;
-            z = 1.f;
-        } else { z = 0.f; } phase += ZXP(freq) * freqmul;
-        ZXP(out) = z;);
+            if (phase >= 1.f) {
+                phase -= sc_floor(phase);
+            }
+            return 1.f;
+        } else {
+            return 0.f;
+        }
+    }
+}
+
+void Impulse_next_ii(Impulse* unit, int inNumSamples) {
+    float* out = ZOUT(0);
+    double phase = unit->mPhase;
+    double phaseInc = unit->mPhaseIncrement;
+
+    LOOP1(inNumSamples, ZXP(out) = Impulse_testWrapPhase(phaseInc, phase); phase += phaseInc;);
 
     unit->mPhase = phase;
 }
 
-/* phase mod - jrh 03 */
-
-void Impulse_next_ak(Impulse* unit, int inNumSamples) {
+void Impulse_next_ik(Impulse* unit, int inNumSamples) {
     float* out = ZOUT(0);
-    float* freq = ZIN(0);
-    double phaseOffset = ZIN0(1);
-
-    float freqmul = unit->mFreqMul;
     double phase = unit->mPhase;
-    double prev_phaseOffset = unit->mPhaseOffset;
-    double phaseSlope = CALCSLOPE(phaseOffset, prev_phaseOffset);
-    phase += prev_phaseOffset;
+
+    double phaseInc = unit->mPhaseIncrement;
+
+    double prev_phaseOff = unit->mPhaseOffset;
+    double phaseOff = ZIN0(1);
+    double phaseSlope = CALCSLOPE(phaseOff, prev_phaseOff);
+    bool phOffChanged = phaseSlope != 0.f;
 
     LOOP1(
-        inNumSamples, float z; phase += phaseSlope; if (phase >= 1.f) {
-            phase -= 1.f;
-            z = 1.f;
-        } else { z = 0.f; } phase += ZXP(freq) * freqmul;
-        ZXP(out) = z;);
+        inNumSamples, ZXP(out) = Impulse_testWrapPhase(phaseInc, phase);
 
-    unit->mPhase = phase - phaseOffset;
-    unit->mPhaseOffset = phaseOffset;
+        if (phOffChanged) {
+            phase += phaseSlope;
+            Impulse_testWrapPhase(phaseInc, phase);
+        } phase += phaseInc;);
+
+    unit->mPhase = phase;
+    unit->mPhaseOffset = phaseOff;
+}
+
+void Impulse_next_ia(Impulse* unit, int inNumSamples) {
+    float* out = ZOUT(0);
+    double phase = unit->mPhase;
+    float phaseInc = unit->mPhaseIncrement;
+
+    double prev_phaseOff = unit->mPhaseOffset;
+    float* phaseOffIn = ZIN(1);
+
+    LOOP1(inNumSamples, float z = Impulse_testWrapPhase(phaseInc, phase); float phaseOff = ZXP(phaseOffIn);
+          ZXP(out) = z;
+
+          float pOffsetInc = phaseOff - prev_phaseOff; phase += pOffsetInc; Impulse_testWrapPhase(phaseInc, phase);
+          phase += phaseInc; prev_phaseOff = phaseOff;);
+
+    unit->mPhase = phase;
+    unit->mPhaseOffset = prev_phaseOff;
+}
+
+void Impulse_next_ki(Impulse* unit, int inNumSamples) {
+    float* out = ZOUT(0);
+    double phase = unit->mPhase;
+
+    double prev_phaseInc = unit->mPhaseIncrement;
+    double phaseInc = ZIN0(0) * unit->mFreqMul;
+    double phaseIncSlope = CALCSLOPE(phaseInc, prev_phaseInc);
+
+    LOOP1(inNumSamples, ZXP(out) = Impulse_testWrapPhase(prev_phaseInc, phase);
+
+          prev_phaseInc += phaseIncSlope; phase += prev_phaseInc;);
+
+    unit->mPhase = phase;
+    unit->mPhaseIncrement = phaseInc;
 }
 
 void Impulse_next_kk(Impulse* unit, int inNumSamples) {
     float* out = ZOUT(0);
-    float freq = ZIN0(0) * unit->mFreqMul;
-    double phaseOffset = ZIN0(1);
-
     double phase = unit->mPhase;
-    double prev_phaseOffset = unit->mPhaseOffset;
-    double phaseSlope = CALCSLOPE(phaseOffset, prev_phaseOffset);
-    phase += prev_phaseOffset;
+
+    double prev_phaseInc = unit->mPhaseIncrement;
+    double phaseInc = ZIN0(0) * unit->mFreqMul;
+    double phaseIncSlope = CALCSLOPE(phaseInc, prev_phaseInc);
+
+    double prev_phaseOff = unit->mPhaseOffset;
+    double phaseOff = ZIN0(1);
+    double phaseSlope = CALCSLOPE(phaseOff, prev_phaseOff);
+    bool phOffChanged = phaseSlope != 0.f;
 
     LOOP1(
-        inNumSamples, float z; phase += phaseSlope; if (phase >= 1.f) {
-            phase -= 1.f;
-            z = 1.f;
-        } else { z = 0.f; } phase += freq;
-        ZXP(out) = z;);
+        inNumSamples, ZXP(out) = Impulse_testWrapPhase(prev_phaseInc, phase);
 
-    unit->mPhase = phase - phaseOffset;
-    unit->mPhaseOffset = phaseOffset;
-}
-
-
-void Impulse_next_k(Impulse* unit, int inNumSamples) {
-    float* out = ZOUT(0);
-    float freq = ZIN0(0) * unit->mFreqMul;
-
-    double phase = unit->mPhase;
-    LOOP1(
-        inNumSamples, float z; if (phase >= 1.f) {
-            phase -= 1.f;
-            z = 1.f;
-        } else { z = 0.f; } phase += freq;
-        ZXP(out) = z;);
+        if (phOffChanged) {
+            phase += phaseSlope;
+            Impulse_testWrapPhase(prev_phaseInc, phase);
+        } prev_phaseInc += phaseIncSlope;
+        phase += prev_phaseInc;);
 
     unit->mPhase = phase;
+    unit->mPhaseOffset = phaseOff;
+    unit->mPhaseIncrement = phaseInc;
 }
 
-void Impulse_Ctor(Impulse* unit) {
-    unit->mPhase = ZIN0(1);
+void Impulse_next_ka(Impulse* unit, int inNumSamples) {
+    float* out = ZOUT(0);
+    double phase = unit->mPhase;
 
-    if (INRATE(0) == calc_FullRate) {
-        if (INRATE(1) != calc_ScalarRate) {
-            SETCALC(Impulse_next_ak);
-            unit->mPhase = 1.f;
-        } else {
-            SETCALC(Impulse_next_a);
+    double prev_phaseInc = unit->mPhaseIncrement;
+    double phaseInc = ZIN0(0) * unit->mFreqMul;
+    double phaseIncSlope = CALCSLOPE(phaseInc, prev_phaseInc);
+
+    double prev_phaseOff = unit->mPhaseOffset;
+    float* phaseOffIn = ZIN(1);
+
+    LOOP1(inNumSamples, float z = Impulse_testWrapPhase(prev_phaseInc, phase); float phaseOff = ZXP(phaseOffIn);
+          ZXP(out) = z;
+
+          double phaseOffInc = phaseOff - prev_phaseOff; phase += phaseOffInc;
+          Impulse_testWrapPhase(prev_phaseInc, phase); prev_phaseInc += phaseIncSlope; phase += prev_phaseInc;
+          prev_phaseOff = phaseOff;);
+
+    unit->mPhase = phase;
+    unit->mPhaseOffset = prev_phaseOff;
+    unit->mPhaseIncrement = phaseInc;
+}
+
+void Impulse_next_ak(Impulse* unit, int inNumSamples) {
+    float* out = ZOUT(0);
+    double phase = unit->mPhase;
+
+    double prev_phaseInc = unit->mPhaseIncrement;
+    float* freqIn = ZIN(0);
+    float freqMul = unit->mFreqMul;
+
+    double prev_phaseOff = unit->mPhaseOffset;
+    double phaseOff = ZIN0(1);
+    double phaseOffSlope = CALCSLOPE(phaseOff, prev_phaseOff);
+    bool phaseOffChanged = phaseOffSlope != 0.f;
+
+    LOOP1(
+        inNumSamples, float z = Impulse_testWrapPhase(prev_phaseInc, phase); if (phaseOffChanged) {
+            phase += phaseOffSlope;
+            Impulse_testWrapPhase(prev_phaseInc, phase);
+        } double phaseInc = ZXP(freqIn) * freqMul;
+        ZXP(out) = z;
+
+        phase += phaseInc; prev_phaseInc = phaseInc;);
+
+    unit->mPhase = phase;
+    unit->mPhaseOffset = phaseOff;
+    unit->mPhaseIncrement = prev_phaseInc;
+}
+
+void Impulse_next_aa(Impulse* unit, int inNumSamples) {
+    float* out = ZOUT(0);
+    double phase = unit->mPhase;
+
+    double phaseInc = unit->mPhaseIncrement;
+    float* freqin = ZIN(0);
+    float freqmul = unit->mFreqMul;
+
+    double prev_phaseOff = unit->mPhaseOffset;
+    float* phaseOffIn = ZIN(1);
+
+    LOOP1(inNumSamples, float z = Impulse_testWrapPhase(phaseInc, phase); float phaseOff = ZXP(phaseOffIn);
+          float phaseOffInc = phaseOff - prev_phaseOff; phase += phaseOffInc; Impulse_testWrapPhase(phaseInc, phase);
+          phaseInc = ZXP(freqin) * freqmul; ZXP(out) = z;
+
+          phase += phaseInc; prev_phaseOff = phaseOff;);
+
+    unit->mPhase = phase;
+    unit->mPhaseOffset = prev_phaseOff;
+    unit->mPhaseIncrement = phaseInc;
+}
+
+void Impulse_next_ai(Impulse* unit, int inNumSamples) {
+    float* out = ZOUT(0);
+    double phase = unit->mPhase;
+
+    double phaseInc = unit->mPhaseIncrement;
+    float* freqin = ZIN(0);
+    float freqmul = unit->mFreqMul;
+
+    LOOP1(inNumSamples, float z = Impulse_testWrapPhase(phaseInc, phase); phaseInc = ZXP(freqin) * freqmul;
+          ZXP(out) = z; phase += phaseInc;);
+
+    unit->mPhase = phase;
+    unit->mPhaseIncrement = phaseInc;
+}
+
+// Note: In calc functions,
+// phase offset change is added to phase, then phase is wrapped into range,
+// followed by phase increment (freq), then tested for triggering an impulse.
+// So a freq increment will trigger an impulse, but not a phase offset.
+void Impulse_Ctor(Impulse* unit) {
+    unit->mPhaseOffset = ZIN0(1);
+    unit->mFreqMul = unit->mRate->mSampleDur;
+    unit->mPhaseIncrement = ZIN0(0) * unit->mFreqMul;
+
+    double initphaseOff = unit->mPhaseOffset;
+    double initPhaseInc = unit->mPhaseIncrement;
+    double initPhase = sc_wrap(initphaseOff, 0.0, 1.0);
+
+    // Initial phase offset of 0 means output of 1 on first sample.
+    // Set phase to wrap point to trigger impulse on first sample
+    if (initPhase == 0.0 && initPhaseInc >= 0.0) {
+        initPhase = 1.0; // positive frequency trigger/wrap position
+    }
+    unit->mPhase = initPhase;
+
+    UnitCalcFunc func;
+    switch (INRATE(0)) {
+    case calc_FullRate:
+        switch (INRATE(1)) {
+        case calc_FullRate:
+            func = (UnitCalcFunc)Impulse_next_aa;
+            break;
+        case calc_BufRate:
+            func = (UnitCalcFunc)Impulse_next_ak;
+            break;
+        case calc_ScalarRate:
+            func = (UnitCalcFunc)Impulse_next_ai;
+            break;
         }
-    } else {
-        if (INRATE(1) != calc_ScalarRate) {
-            SETCALC(Impulse_next_kk);
-            unit->mPhase = 1.f;
-        } else {
-            SETCALC(Impulse_next_k);
+        break;
+    case calc_BufRate:
+        switch (INRATE(1)) {
+        case calc_FullRate:
+            func = (UnitCalcFunc)Impulse_next_ka;
+            break;
+        case calc_BufRate:
+            func = (UnitCalcFunc)Impulse_next_kk;
+            break;
+        case calc_ScalarRate:
+            func = (UnitCalcFunc)Impulse_next_ki;
+            break;
         }
+        break;
+    case calc_ScalarRate:
+        switch (INRATE(1)) {
+        case calc_FullRate:
+            func = (UnitCalcFunc)Impulse_next_ia;
+            break;
+        case calc_BufRate:
+            func = (UnitCalcFunc)Impulse_next_ik;
+            break;
+        case calc_ScalarRate:
+            func = (UnitCalcFunc)Impulse_next_ii;
+            break;
+        }
+        break;
     }
 
+    unit->mCalcFunc = func;
+    func(unit, 1);
 
-    unit->mPhaseOffset = 0.f;
-    unit->mFreqMul = unit->mRate->mSampleDur;
-    if (unit->mPhase == 0.f)
-        unit->mPhase = 1.f;
-
-    ZOUT0(0) = 0.f;
+    unit->mPhase = initPhase;
+    unit->mPhaseOffset = initphaseOff;
+    unit->mPhaseIncrement = initPhaseInc;
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////

--- a/server/plugins/LFUGens.cpp
+++ b/server/plugins/LFUGens.cpp
@@ -960,10 +960,16 @@ void Impulse_next_ai(Impulse* unit, int inNumSamples) {
     unit->mPhaseIncrement = inc;
 }
 
-// Note: In calc functions,
-// phase offset change is added to phase, then phase is wrapped into range,
-// followed by phase increment (freq), then tested for triggering an impulse.
-// So a freq increment will trigger an impulse, but not a phase offset.
+// Impulse is based on a wrapping phasor. When the phase wraps, an impulse is
+// output. Phase _increments_ according to its frequency and an additional phase
+// _offset_ is applied.
+// Order of operations:
+// 1. Phase _offset_ is applied to the current phase (if offset has changed).
+// 2. Phase is wrapped into range.
+// 3. Phase _increment_ is added (according to the frequency).
+// 4. Phase is checked for being out of range, in which case a trigger is fired
+//    and the phase is again wrapped.
+// Therefore, phase increment (freq) triggers an impulse, but not phase offset.
 void Impulse_Ctor(Impulse* unit) {
     unit->mPhaseOffset = ZIN0(1);
     unit->mFreqMul = unit->mRate->mSampleDur;
@@ -984,15 +990,15 @@ void Impulse_Ctor(Impulse* unit) {
     switch (INRATE(0)) {
     case calc_FullRate:
         switch (INRATE(1)) {
-            case calc_ScalarRate:
-                func = (UnitCalcFunc)Impulse_next_ai;
-                break;
+        case calc_ScalarRate:
+            func = (UnitCalcFunc)Impulse_next_ai;
+            break;
         case calc_BufRate:
             func = (UnitCalcFunc)Impulse_next_ak;
             break;
-            case calc_FullRate:
-                func = (UnitCalcFunc)Impulse_next_aa;
-                break;
+        case calc_FullRate:
+            func = (UnitCalcFunc)Impulse_next_aa;
+            break;
         }
         break;
     case calc_BufRate:


### PR DESCRIPTION
Purpose and Motivation
----------------------
This PR addresses a number of longstanding issues with `Impulse` that I've aggregated from issues, comments, etc. which are highlighted below.

The primary goal was to initialize the UGen properly and support new frequency and phase argument ranges.

Part fo the [initialization sample fix project](https://github.com/supercollider/rfcs/pull/19), specifically in the LFUGens subset.

Types of changes
----------------

### Added features
- Supports positive and negative frequencies.
- Phase is wrapped internally, so any phase offset is valid.
- Correctly sets the initialization sample and first output sample.

### Fixes
#4752, #4075, likely more trigger-related issues

### Implementation notes to review

1. Added a wrapping function.
I chose to use a function to wrap the phase, taking advantage of the fact that the range is [0,1].
This could be useful for other UGens with a phasor in this range.
https://github.com/mtmccrea/supercollider/blob/36cadad0eef499a8122a9136fe2f17acace566ca/server/plugins/LFUGens.cpp#L915-L937

2. Trigger logic: `freq` drives impulse triggering, not phase offset.
Phase offset is applied, then phase is wrapped, then phase increment (freq) is applied, then the condition is checked for whether an impulse fires. In this way, phase changes are "instantaneous" and always in-range internally. So phase increment (the frequency control) primarily determines when impulses fire.

In other words, if you advance the phase offset by 3 periods, it's a relative phase offset of 0, so that won't cause an impulse to fire.

3. Argument input rates aren't limited.
You can read in audio rate arguments even if the UGen running at control rate.  
If it's advisable to limit kr ugens to kr arguments, that can be added to the class.

4. A k-rate frequency argument is now interpolated when running  at a-rate.
This wasn't the case before. My understanding is that all k-rate args should be interpolated when used at a-rate, unless there's a particular reason not to.

5. `phOffChanged` flag added to `Impulse_next_ak`.
This flag checks if k-rate `phase` offset input changes, and if not, skips adding a slope increment of `0` in the sample loop.  
Are these kind of optimizations worth it?... benchmarks seem to indicate yes. 
https://github.com/mtmccrea/supercollider/blob/36cadad0eef499a8122a9136fe2f17acace566ca/server/plugins/LFUGens.cpp#L963-L973
Aside: we might consider adding support for this kind of optimization in `SCUnit::SlopeSignal`

6. Variable names are changed
To more precisely reflect what they are. E.g. `unit->mFreq` wasn't actually a frequency, but rather a phase increment (`unit->mPhaseIncrement`).


### Bug fixes <a href="#user-content-bug-fixes" id="bug-fixes">#</a>

1. One of the primary issues resolved is the Ctor set the initialization sample to 0, incorrectly setting the initial state of downstream UGens. This bug is expressed in the initial state of, e.g., `ToggleFF`, `RLPF`, etc.

2. Phase offset isn't wrapped - fixed.
Ex: Phase is out of range for 3 k-periods, so erroneously outputs 1s for those 3 control samples.
https://github.com/supercollider/supercollider/pull/2864#issuecomment-299860789
```supercollider
{Impulse.kr(10, 3.8)}.plot(duration:0.03).plotMode_(\points);
```

3. Negative phase offset isn't handle properly - fixed.
Ex: A phase offset of -1 is equivalent to phase offset of 1, which should trigger an impulse (should output 1 on first sample).
```supercollider
{Impulse.kr(10, -1)}.plot(duration:0.3);
```

4. First output sample set incorrectly - fixed.
See #4075
```supercollider
( // envelope triggers one control period late
{
  var sig1 = EnvGen.kr(Env.perc(0.01, 0.04), 1) * SinOsc.ar(440);
  var sig2 = EnvGen.kr(Env.perc(0.01, 0.04), Impulse.kr(0)) * SinOsc.ar(440);
  [sig1,sig2]
}.plot
)
```

5. Negative frequencies aren't supported - fixed.
Ex: There's no impulse after first sample:
```supercollider
{Impulse.kr(-10, 0)}.plot(duration:0.3);
```

6. Inconsistent behavior with Lag - resolved.
See: https://github.com/supercollider/supercollider/pull/2864#issuecomment-299850572
This behaves properly now.
```supercollider
{Lag.ar(Impulse.ar(1, [0, 0.995]), 0.003)}.plot;
```

7. Interaction with RLPF - resolved
https://github.com/supercollider/supercollider/pull/2864#issuecomment-300040825
```supercollider
(
s.waitForBoot({
b = Buffer.alloc(s, 256, 1);
0.3.wait;
a = {
  var sig = RLPF.ar(Impulse.ar(0), 1200, 0.1);
  RecordBuf.ar(sig, b, loop: 0, doneAction: 2);
  sig
}.play;
0.3.wait;
// to inspect the IR
b.getToFloatArray(wait: -1, action: { |data| d = data.postln });
})
)
// before (note impulse is broken also in this signal chain):
// -> FloatArray[ 0.0072281970642507, 0.028581265360117, 0.055974174290895, 0.081284336745739, 0.10381526499987, 0.12296265363693, 0.1382302492857, 0.14924238622189, ...
// after this change, with corrected Impulse:
// -> FloatArray[ 0.035809461027384, 0.084555439651012, 0.13725851476192, 0.18509960174561, 0.22677791118622, 0.26119288802147, 0.28747263550758, 0.30499523878098, ...
// after this change AND after fixing RLPF Ctor:
// -> FloatArray[ 0.0072281970642507, 0.028581265360117, 0.055974174290895, 0.081284336745739, 0.10381526499987, 0.12296265363693, 0.1382302492857, 0.14924238622189...

// see first 100 samples of the result
d[0..99].plot
```
Note, the original IR in the above comment is "erroneously correct".
This correction to `Impulse` appeared to "break" this RLPF case, but the problem is to do with an initialization bug in `RLPF` (#4127), causing the appearance of an impulse double in size and off in phase (coefficients are improperly initialized in `RLPF`).  Once this is corrected, it works again, which coincidentally matches the erroneous IR. 

### Tests
UPDATE: Newly added unit tests will confirm the above issues are fixed as well as the rate-equivalence tests below.
```
UnitTest.runTest("TestCoreUGens:test_impulse")
```

I made numerous tests for the above changes, though here's a basic test comparing the output from all variations of argument rates and output rates:
```supercollider
// test for equal output at different input rates
// Note, this doesn't test modulated parameters, as
// results will vary because of k>a interpolation
(
var funcs;
{
	var frq = -32.9327;
	var phs = -0;
	var rate = \ar; // \ar or \kr

	funcs = [
		{Impulse.perform(rate, DC.ar(frq), DC.ar(phs))},
		{Impulse.perform(rate, DC.ar(frq), DC.kr(phs))},
		{Impulse.perform(rate, DC.ar(frq), phs)},
		{Impulse.perform(rate, DC.kr(frq), DC.ar(phs))},
		{Impulse.perform(rate, DC.kr(frq), DC.kr(phs))},
		{Impulse.perform(rate, DC.kr(frq), phs)},
		{Impulse.perform(rate, frq, DC.ar(phs))},
		{Impulse.perform(rate, frq, DC.kr(phs))},
		{Impulse.perform(rate, frq, phs)},
	];
}.value;

~res = Array.newClear(funcs.size);

fork{
	var cond = Condition();
	funcs.postln;
	funcs.do{ |f, i|
		f.loadToFloatArray(duration: 0.15, action: { |arr| ~res[i] = arr; i.post; " done".postln; cond.test_(true).signal; });
		cond.wait;
		cond.test_(false)
	};
	postf("result: %\n", ~res.every(_ == ~res[0]));
}
)
// inspect one
~res[0].plot.plotMode_(\plines);
```

Checklist
---------

<!--- Complete an item by checking it: [x] -->

- [x] All previous tests are passing
  - 3 tests fail which previously did not (in `TestCoreUGens:test_ugen_generator_equivalences`), all relating to `Trig` and `Trig1`. After applying init sample bug fixes to both UGens, the tests pass.
  - A change was made to `TestFilterUGens:test_time_invariance` to accommodate initialization sample bugs that pervade _FilterUGens_
- [x] Tests were updated or created to address changes in this PR, and tests are passing
- [x] Updated documentation, if necessary
- [x] This PR is ready for review

<!--- See DEVELOPING.md for instructions on running and writing tests. -->


<!--- Thanks for contributing! -->