### PR TITLE
use getpwduid on unix to find user home directory

### DIFF
--- a/common/SC_Filesystem_unix.cpp
+++ b/common/SC_Filesystem_unix.cpp
@@ -31,6 +31,7 @@
 
 // system
 #include <glob.h> // ::glob, glob_t
+#include <pwd.h> // ::getpwuid
 
 using Path = SC_Filesystem::Path;
 using DirName = SC_Filesystem::DirName;
@@ -101,7 +102,8 @@ Path SC_Filesystem::defaultSystemAppSupportDirectory()
 
 Path SC_Filesystem::defaultUserHomeDirectory()
 {
-	const char *home = getenv("HOME");
+	struct passwd *pw = getpwuid(getuid());
+	const char *home = pw->pw_dir;
 	return Path(home ? home : "");
 }
 

--- a/lang/LangSource/SC_TerminalClient.cpp
+++ b/lang/LangSource/SC_TerminalClient.cpp
@@ -30,6 +30,7 @@
 #endif
 
 #include <boost/bind.hpp>
+#include <boost/filesystem/operations.hpp> // exists
 
 #ifdef _WIN32
 # define __GNU_LIBRARY__
@@ -64,6 +65,8 @@
 #include <boost/filesystem/operations.hpp>
 
 static FILE* gPostDest = stdout;
+
+namespace bfs = boost::filesystem;
 
 #ifdef _WIN32
 static UINT gOldCodePage; // for remembering the old codepage when we switch to UTF-8
@@ -264,9 +267,13 @@ int SC_TerminalClient::run(int argc, char** argv)
 	initRuntime(opt);
 
 	// Create config directory so that it can be used by Quarks, etc. See #2919.
-	if (!opt.mStandalone && !opt.mLibraryConfigFile)
-		boost::filesystem::create_directories(
-			SC_Filesystem::instance().getDirectory(SC_Filesystem::DirName::UserConfig));
+	if (!opt.mStandalone && !opt.mLibraryConfigFile) {
+		const bfs::path userConfigDir = SC_Filesystem::instance().getDirectory(
+				SC_Filesystem::DirName::UserConfig);
+
+		if (!userConfigDir.empty())
+			bfs::create_directories(userConfigDir);
+	}
 
 	// startup library
 	compileLibrary(opt.mStandalone);


### PR DESCRIPTION
Purpose and Motivation
----------------------

Currently on unix systems SC uses the HOME environment variable to find the user home directory. On systems using `systemd` for example if the user specifies a service to run `sclang` without declaring the User= configuration explicitly, the HOME variable is not set, thus failing to run sclang (see #4132).

The patch also adds a path validation before trying to create the directories to avoid sclang from crashing.

Types of changes
----------------

- Bug fix (non-breaking change which fixes an issue)

Checklist
---------

- [X] All previous tests are passing
- [X] This PR is ready for review