### PR TITLE
scide: fix hex int highlighting

### DIFF
--- a/HelpSource/editor.js
+++ b/HelpSource/editor.js
@@ -8,7 +8,7 @@ const init = () => {
             { regex: /^\b\d+r[0-9a-zA-Z]*(\.[0-9A-Z]*)?/, token: 'number radix-float' },
             { regex: /^\b\d+(s+|b+|[sb]\d+)\b/, token: 'number scale-degree' },
             { regex: /^\b((\d+(\.\d+)?([eE][-+]?\d+)?(pi)?)|pi)\b/, token: 'number float' },
-            { regex: /^\b0(x|X)(\d|[a-f]|[A-F])+/, token: 'number hex-int' },
+            { regex: /^\b0x(\d|[a-f]|[A-F])+/, token: 'number hex-int' },
             { regex: /^\b[A-Za-z_]\w*\:/, token: 'symbol symbol-arg' },
             { regex: /^[a-z]\w*/, token: 'text name' },
             { regex: /^\b[A-Z]\w*/, token: 'class' },

--- a/editors/sc-ide/core/sc_lexer.cpp
+++ b/editors/sc-ide/core/sc_lexer.cpp
@@ -52,7 +52,7 @@ void ScLexer::initLexicalRules()
     // not know whether it is not rather a binary operator
     mLexicalRules << LexicalRule( Token::Float, "^\\b((\\d+(\\.\\d+)?([eE][-+]?\\d+)?(pi)?)|pi)\\b" );
 
-    mLexicalRules << LexicalRule( Token::HexInt, "^\\b0(x|X)(\\d|[a-f]|[A-F])+" );
+    mLexicalRules << LexicalRule( Token::HexInt, "^\\b0x(\\d|[a-f]|[A-F])+" );
 
     mLexicalRules << LexicalRule( Token::SymbolArg, "^\\b[A-Za-z_]\\w*\\:" );
 


### PR DESCRIPTION
<!--- Hi, and thanks for contributing! -->
<!--- Make sure to provide a general summary of your changes in the title above. -->
<!--- For example: "[scsynth] Fix crash when encountering cute kittens" -->

Purpose and Motivation
----------------------

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to it here by writing "Fixes #555". -->

hex numbers starting with 0X are actually not allowed, so don't highlight them

Types of changes
----------------

<!--- What types of changes does your pull request introduce? -->
<!--- Some examples are below (you can delete the lines that don't apply): -->

- Bug fix (non-breaking change which fixes an issue)

Checklist
---------

<!--- Complete an item by checking it: [x] -->

- [x] All tests are passing
- [x] If necessary, new tests were created to address changes in PR, and tests are passing
- [x] Updated documentation, if necessary
- [x] This PR is ready for review

<!--- See DEVELOPING.md for instructions on running and writing tests. -->