### PR TITLE
sclang: fix resolveIfAlias [skip appveyor]

### DIFF
--- a/testsuite/classlibrary/TestSerialPort.sc
+++ b/testsuite/classlibrary/TestSerialPort.sc
@@ -33,11 +33,11 @@ TestSerialPort : UnitTest {
 		};
 		skipSerialTests = false;
 		if(thisProcess.platform.name == \windows) {
-			"Skipping SerialPort tests because platform is Windows.".warn;
+			"Skipping most SerialPort tests because platform is Windows.".warn;
 			skipSerialTests = true;
 		};
 		if("which socat".systemCmd != 0) {
-			"Skipping SerialPort tests because socat is not installed.".warn;
+			"Skipping most SerialPort tests because socat is not installed.".warn;
 			skipSerialTests = true;
 		};
 		^skipSerialTests;
@@ -84,6 +84,11 @@ TestSerialPort : UnitTest {
 	}
 
 	// ----------- tests -----------------------------------------------------------------------------------------
+
+	test_devices {
+		// used to hang forever on macOS (#4131)
+		SerialPort.devices;
+	}
 
 	test_open_onExistingDevice_defaultArgs {
 		var port;


### PR DESCRIPTION
Purpose and Motivation
----------------------

fixes an infinite hang in SC_Filesystem::resolveIfAlias on certain input
files (unknown cause).

also add regression test, update message in TestSerialPort

fixes #4131

Types of changes
----------------

- Bug fix (non-breaking change which fixes an issue)
- *Note: this affects macOS only*

Checklist
---------

- [x] All tests are passing - *See notes below*
- [x] If necessary, new tests were created to address changes in PR, and tests are passing
- [x] Updated documentation, if necessary
- [x] This PR is ready for review

Notes on testing
--------------

This affects all places `standardizePath` is used, and class library
compilation. I don't know for certain whether the old behavior is
maintained under all cases. Here are the cases that do stay the same:

- normal files
- directories
- devices/pipes
- valid alias
- broken alias

I'm not enough of a macOS filesystem expert to know if there are corner
cases this misses. It's really unfortunate that this code now has to do a full
string compare when we previously had a bool; if anyone can find a
better way please let me know!

If this goes into 3.10.1 (which i would expect it to) I would say this
change alone warrants a beta release so any obvious failings can be
caught.