### PR TITLE
fix bfill handler for supernova

### DIFF
--- a/server/supernova/sc/sc_osc_handler.cpp
+++ b/server/supernova/sc/sc_osc_handler.cpp
@@ -2756,9 +2756,9 @@ void handle_b_fill(ReceivedMessage const & msg)
 
         for (int i = 0; i != samples; ++i) {
             data[index] = value;
-	    ++index;
+            ++index;
             if (index >= bufSamples) {
-	        break;
+                break;
             }
         }
     }

--- a/server/supernova/sc/sc_osc_handler.cpp
+++ b/server/supernova/sc/sc_osc_handler.cpp
@@ -2740,10 +2740,12 @@ void handle_b_fill(ReceivedMessage const & msg)
     osc::int32 buffer_index = it->AsInt32(); ++it;
 
     buffer_wrapper::sample_t * data = sc_factory->get_buffer(buffer_index);
-    if( !data ) {
+    if (!data) {
         log_printf("/b_fill called on unallocated buffer\n");
         return;
     }
+
+    int bufSamples = sc_factory->get_buffer_struct(buffer_index)->samples;
 
     while (it != end) {
         osc::int32 index = it->AsInt32(); ++it;
@@ -2752,8 +2754,13 @@ void handle_b_fill(ReceivedMessage const & msg)
         verify_argument(it, end);
         float value = extract_float_argument(it++);
 
-        for (int i = 0; i != samples; ++i)
+        for (int i = 0; i != samples; ++i) {
             data[index] = value;
+	    ++index;
+            if (index >= bufSamples) {
+	        break;
+            }
+        }
     }
 }
 


### PR DESCRIPTION
(new version of PR #4137, based on 3.10 branch)

Purpose and Motivation
----------------------

noticed that `/b_fill` commands didn't seem to be doing anything in supernova. 

checking the source revealed that the sample index into the buffer data wasn't being incremented, so i added this.

i additionally added a bounds check for the index. surprisingly this doesn't happen in other command handlers like `/b_set`. it is possible to smash memory and crash supernova using these OSC commands.

Types of changes
----------------

- Bug fix (non-breaking change which fixes an issue)

Checklist
---------

<!--- Complete an item by checking it: [x] -->

- [x] All previous tests are passing
- [x] This PR is ready for review

i haven't added any unit tests, but of course would be happy to do so with a little more guidance.

<!--- See DEVELOPING.md for instructions on running and writing tests. -->
