### PR TITLE
Adding Missing Qt5 Dependency in README for Linux Builds

### DIFF
--- a/README_LINUX.md
+++ b/README_LINUX.md
@@ -75,7 +75,7 @@ Depending on your Debian flavor and version, your distribution's PPA may be stuc
 
 If this displays version 5.7 or later, installing Qt is easy:
 
-    sudo apt-get install qt5-default qt5-qmake qttools5-dev qttools5-dev-tools qtdeclarative5-dev qtwebengine5-dev libqt5svg5-dev
+    sudo apt-get install qt5-default qt5-qmake qttools5-dev qttools5-dev-tools qtdeclarative5-dev qtwebengine5-dev libqt5svg5-dev libqt5websockets5-dev
 
 If you are on Ubuntu 14.04 (Trusty) or 16.04 (Xenial), check the next section. Otherwise, you will have to use the official Qt installer. Sorry.
 


### PR DESCRIPTION
<!--- Hi, and thanks for contributing! -->
<!--- Make sure to provide a general summary of your changes in the title above. -->
<!--- For example: "[scsynth] Fix crash when encountering cute kittens" -->

Purpose and Motivation
----------------------
Qt5WebSockets is needed in order to build on Linux.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to it here by writing "Fixes #555". -->

Types of changes
----------------

<!--- What types of changes does your pull request introduce? -->
<!--- Some examples are below (you can delete the lines that don't apply): -->

- Documentation (non-code change which corrects or adds documentation for existing features)

Checklist
---------

<!--- Complete an item by checking it: [x] -->

- [ ] All previous tests are passing
- [ ] Tests were updated or created to address changes in this PR, and tests are passing
- [x] Updated documentation, if necessary
- [ ] This PR is ready for review

<!--- See DEVELOPING.md for instructions on running and writing tests. -->

Remaining Work
--------------

<!--- If any work remains to be done, please give a brief description here. -->
<!--- Consider providing a todo-list so we can easily track completion progress. -->

<!--- Thanks for contributing! -->
