### PR TITLE
Topic/gc fixes post 3.10

### DIFF
--- a/HelpSource/Guides/WritingPrimitives.schelp
+++ b/HelpSource/Guides/WritingPrimitives.schelp
@@ -35,9 +35,9 @@ enum { // primitive errors
 	errOutOfMemory,
 	errCantCallOS,
 	errException,
-	
+
 	errPropertyNotFound = 6000,
-	
+
 	errLastError
 };
 ::
@@ -176,7 +176,18 @@ PyrObject *array2 = newPyrArray(g->gc, 2, 0, false);
 ...
 ::
 ::
-Care must be taken when writing utility functions which themselves create new objects, since this may happen somewhat opaquely and the calling context may not be known. Functions which may call themselves recursively also need special attention. In such cases setting teletype::runGC:: to false may be the safest option, or including a teletype::runGC:: arg so that GC behaviour is explicit. teletype::MsgToInt8Array:: is one example of such a function.
+One caveat: When making a new object reachable by storing it on the stack, you must ensure that you are not overwriting the receiver if it is still needed in the primitive and you will need to do further allocations. If this is done the receiver may be collected on any future allocations. One solution is to strong::push:: the object onto the stack, and then pop it when finished, e.g.:
+teletype::
+PyrSlot* rec = g->sp; // get the receiver
+PyrObject *result = newPyrArray(g->gc, 2, 0, true); // create the result
+++g->sp; SetObject(g->sp, result); // push the result array on the stack, so both it and rec are reachable
+... // further allocations which make use of the receiver to populate result
+g->sp -= 1; // pop
+SetObject(rec, result); // now set the receiver
+::
+teletype::prArrayMultiChanExpand:: gives an example of this approach. Setting teletype::runGC:: to false is another possible solution.
+
+Similarly, care must be taken when writing utility functions which themselves create new objects, since this may happen somewhat opaquely and the calling context may not be known. Functions which may call themselves recursively also need special attention. In such cases setting teletype::runGC:: to false may be the safest option, or including a teletype::runGC:: arg so that GC behaviour is explicit. teletype::MsgToInt8Array:: is one example of such a function.
 
 teletype::
 static PyrInt8Array* MsgToInt8Array ( sc_msg_iter& msg, bool runGC )
@@ -267,7 +278,7 @@ To summarize, before calling any function that might allocate (like teletype::ne
 numberedlist::
 ## All objects previously created must be reachable, which means they must exist
     list::
-    ## on the teletype::g->sp:: stack
+    ## on the teletype::g->sp:: stack (taking care not to overwrite the receiver if it is still needed)
     ## or, in a lang-side variable or class variable.
     ## or, in a slot of another object that fulfils these criteria.
     ::

--- a/lang/LangPrimSource/PyrListPrim.cpp
+++ b/lang/LangPrimSource/PyrListPrim.cpp
@@ -80,7 +80,9 @@ int prArrayMultiChanExpand(struct VMGlobals *g, int numArgsPushed)
 	}
 
 	obj2 = newPyrArray(g->gc, maxlen, 0, true);
-	SetObject(a, obj2);
+	// push obj2 onto the stack so it's not collected
+	// we can't just set in a here as we still need obj1's slots below, so we need to ensure it isn't collected
+	++g->sp; SetObject(g->sp, obj2);
 	slots2 = obj2->slots;
 	for (i=0; i<maxlen; ++i) {
 		obj3 = newPyrArray(g->gc, size, 0, true);
@@ -110,6 +112,8 @@ int prArrayMultiChanExpand(struct VMGlobals *g, int numArgsPushed)
 		}
 	}
 
+	g->sp -= 1; // pop the stack
+	SetObject(a, obj2); // now set the result in a
 	return errNone;
 }
 

--- a/lang/LangPrimSource/PyrPrimitive.cpp
+++ b/lang/LangPrimSource/PyrPrimitive.cpp
@@ -3533,7 +3533,7 @@ static int prLanguageConfig_getLibraryPaths(struct VMGlobals * g, int numArgsPus
 
 	size_t numberOfPaths = dirVector.size();
 	PyrObject * resultArray = newPyrArray(g->gc, numberOfPaths, 0, true);
-	SetObject(result, resultArray);
+	SetObject(result, resultArray); // this is okay here as we don't use the receiver
 
 	for (size_t i = 0; i != numberOfPaths; ++i) {
 		const std::string& utf8_path = SC_Codecvt::path_to_utf8_str(dirVector[i]);

--- a/lang/LangPrimSource/PyrStringPrim.cpp
+++ b/lang/LangPrimSource/PyrStringPrim.cpp
@@ -573,7 +573,7 @@ int prString_PathMatch(struct VMGlobals *g, int numArgsPushed)
 
 	// create array with appropriate reserved size
 	PyrObject* array = newPyrArray(g->gc, paths.size(), 0, true);
-	SetObject(a, array);
+	SetObject(a, array); // we don't need the receiver any more so this is okay
 
 	// convert paths and copy into sclang array.
 	for (int i = 0; i < paths.size(); ++i) {

--- a/lang/LangPrimSource/PyrStringPrim.cpp
+++ b/lang/LangPrimSource/PyrStringPrim.cpp
@@ -410,7 +410,7 @@ static int prString_FindRegexp(struct VMGlobals *g, int numArgsPushed)
 	int match_count = matches.size();
 
 	PyrObject *result_array = newPyrArray(g->gc, match_count, 0, true);
-	SetObject(a, result_array);
+	++g->sp; SetObject(g->sp, result_array); // push result to make reachable
 
 	if( !match_count ) return errNone;
 
@@ -430,8 +430,11 @@ static int prString_FindRegexp(struct VMGlobals *g, int numArgsPushed)
 		array->size = 2;
 		SetInt(array->slots, pos + offset);
 		SetObject(array->slots+1, matched_string);
-		g->gc->GCWrite(array, matched_string); // we know matched_string is white so we can use GCWriteNew
+		g->gc->GCWriteNew(array, matched_string); // we know matched_string is white so we can use GCWriteNew
 	};
+	
+	g->sp -= 1; //pop
+	SetObject(a, result_array); // now store result
 
 	return errNone;
 }

--- a/lang/LangPrimSource/PyrStringPrim.cpp
+++ b/lang/LangPrimSource/PyrStringPrim.cpp
@@ -486,7 +486,7 @@ static int prString_FindRegexpAt(struct VMGlobals *g, int numArgsPushed)
 	}
 
 	PyrObject *array = newPyrArray(g->gc, 2, 0, true);
-	SetObject(a, array);
+	++g->sp; SetObject(g->sp, array); // push on stack to make reachable
 
 	PyrString *matched_string = newPyrStringN(g->gc, matched_len, 0, true);
 	memcpy(matched_string->s, stringBegin, (size_t) matched_len);
@@ -495,6 +495,8 @@ static int prString_FindRegexpAt(struct VMGlobals *g, int numArgsPushed)
 	SetInt(array->slots+1, matched_len);
 	SetObject(array->slots, matched_string);
 	g->gc->GCWriteNew(array, matched_string); // we know matched_string is white so we can use GCWriteNew
+	g->sp -= 1; // pop
+	SetObject(a, array); // now store result
 
 	return errNone;
 }

--- a/lang/LangPrimSource/SC_CoreAudioPrim.cpp
+++ b/lang/LangPrimSource/SC_CoreAudioPrim.cpp
@@ -96,7 +96,7 @@ int listDevices(struct VMGlobals *g, int type)
 	else num = numDevices;
 
     PyrObject* devArray = newPyrArray(g->gc, num * sizeof(PyrObject), 0, true);
-	SetObject(a, devArray);
+	SetObject(a, devArray); // this is okay here as we do use the receiver
 
 	int j = 0;
 	for (i=0; i<numDevices; i++)

--- a/lang/LangPrimSource/SC_CoreMIDI.cpp
+++ b/lang/LangPrimSource/SC_CoreMIDI.cpp
@@ -431,7 +431,7 @@ int prListMIDIEndpoints(struct VMGlobals *g, int numArgsPushed)
 	int numDst = MIDIGetNumberOfDestinations();
 
 	PyrObject* idarray = newPyrArray(g->gc, 6 * sizeof(PyrObject), 0 , true);
-		SetObject(a, idarray);
+		SetObject(a, idarray); // this is okay here as we don't use the receiver
 
 	PyrObject* idarraySo = newPyrArray(g->gc, numSrc * sizeof(SInt32), 0 , true);
 		SetObject(idarray->slots+idarray->size++, idarraySo);

--- a/lang/LangPrimSource/SC_HID_api.cpp
+++ b/lang/LangPrimSource/SC_HID_api.cpp
@@ -492,7 +492,7 @@ int prHID_API_BuildDeviceList(VMGlobals* g, int numArgsPushed){
 	int result = SC_HID_APIManager::instance().build_devicelist();
 	if ( result > 0 ){
 		PyrObject* allDevsArray = newPyrArray(g->gc, result * sizeof(PyrObject), 0 , true);
-		SetObject( self, allDevsArray );
+		SetObject( self, allDevsArray ); // this is okay here as we don't use the receiver
 
 		struct hid_device_info *cur_dev = SC_HID_APIManager::instance().devinfos;
 		while( cur_dev ){

--- a/lang/LangSource/SC_TerminalClient.cpp
+++ b/lang/LangSource/SC_TerminalClient.cpp
@@ -713,7 +713,7 @@ int SC_TerminalClient::prArgv(struct VMGlobals* g, int)
 	PyrSlot* argvSlot = g->sp;
 
 	PyrObject* argvObj = newPyrArray(g->gc, argc * sizeof(PyrObject), 0, true);
-	SetObject(argvSlot, argvObj);
+	SetObject(argvSlot, argvObj); // this is okay here as we don't use the receiver
 
 	for (int i=0; i < argc; i++) {
 		PyrString* str = newPyrString(g->gc, argv[i], 0, true);


### PR DESCRIPTION
Purpose and Motivation
----------------------

This PR primarily addresses a class of GC issues previously not widely noted. The pattern is (within one primitive):
1. get the receiver from the stack
2. create a new result object
3. set the result object on the stack
4. create new objects while continuing to access the receiver

As the receiver is not on the stack anymore, it may be collected when new objects are created in 4., before we are finished using it, if it is not otherwise reachable.

This fixes #3454 and I think #4179.

In addition:

- I did a code review of and fixed two other primitives that could have been subject to this error
- I updated the Writing Primitives help file to explain this issue and how to avoid it
- I added comments in appropriate places in other primitives explaining why this was not a problem in those cases, in the hopes that this will avoid people reusing that code without understanding (this has been a problem in the past)
- I fixed one other GC related issue.

Types of changes
----------------

<!--- What types of changes does your pull request introduce? -->
- Documentation (non-code change which corrects or adds documentation for existing features)
- Bug fix (non-breaking change which fixes an issue)

Checklist
---------

<!--- Complete an item by checking it: [x] -->

- [x] All previous tests are passing
- [ ] Tests were updated or created to address changes in this PR, and tests are passing
- [x] Updated documentation, if necessary
- [x] This PR is ready for review

<!--- See DEVELOPING.md for instructions on running and writing tests. -->

