### PR TITLE
fix suffix + prefix generation

### DIFF
--- a/tools/cmake_gen/SuperColliderServerPlugin.cmake
+++ b/tools/cmake_gen/SuperColliderServerPlugin.cmake
@@ -29,15 +29,15 @@ function(sc_check_sc_path path)
     set(SC_PATH ${full_path} PARENT_SCOPE)
 endfunction()
 
-function(sc_set_shared_module_prefix)
-    if(APPLE OR WIN32)
-        set(CMAKE_SHARED_MODULE_SUFFIX ".scx" PARENT_SCOPE)
-    endif()
-    set(CMAKE_SHARED_MODULE_PREFIX "" PARENT_SCOPE)
-endfunction()
-
 function(sc_add_server_plugin_properties target is_supernova)
-    set_target_properties(${target} PROPERTIES CXX_VISIBILITY_PRESET hidden)
+    set_target_properties(${target} PROPERTIES
+        CXX_VISIBILITY_PRESET hidden
+        PREFIX ""
+    )
+
+    if(APPLE OR WIN32)
+        set_target_properties(${target} PROPERTIES SUFFIX ".scx")
+    endif()
 
     target_include_directories(${target} PUBLIC
         ${SC_PATH}/include/plugin_interface
@@ -79,7 +79,5 @@ function(sc_add_server_plugin dest_dir name cpp sc schelp)
         install(FILES "${schelp}" DESTINATION ${dest_dir}/Help)
     endif()
 endfunction()
-
-sc_set_shared_module_prefix()
 
 set(all_sc_server_plugins)


### PR DESCRIPTION
I've spent some time trying the cookiecutter plugin in creating sc plugins https://github.com/supercollider/cookiecutter-supercollider-plugin.

I noticed that on mac OS, libraries are not renamed to .scx but kept their .so suffix.

This PR addresses this by moving the suffix and prefix setting into target properties rather then global cmake properties.

see https://github.com/supercollider/supercollider/pull/4194

<!--- Hi, and thanks for contributing! -->
<!--- Make sure to provide a general summary of your changes in the title above. -->
<!--- For example: "[scsynth] Fix crash when encountering cute kittens" -->

Purpose and Motivation
----------------------

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to it here by writing "Fixes #555". -->

Types of changes
----------------

<!--- What types of changes does your pull request introduce? -->
<!--- Some examples are below (you can delete the lines that don't apply): -->

- Documentation (non-code change which corrects or adds documentation for existing features)
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)

Checklist
---------

<!--- Complete an item by checking it: [x] -->

- [ ] All previous tests are passing
- [ ] Tests were updated or created to address changes in this PR, and tests are passing
- [ ] Updated documentation, if necessary
- [x] This PR is ready for review

<!--- See DEVELOPING.md for instructions on running and writing tests. -->

Remaining Work
--------------

<!--- If any work remains to be done, please give a brief description here. -->
<!--- Consider providing a todo-list so we can easily track completion progress. -->

<!--- Thanks for contributing! -->
