### PR TITLE
Improve Env.schelp to explain nodes and looping envelopes

### DIFF
--- a/HelpSource/Classes/Env.schelp
+++ b/HelpSource/Classes/Env.schelp
@@ -8,11 +8,32 @@ An Env is a specification for a segmented envelope. Envs can be used both server
 
 An Env can have any number of segments which can stop at a particular value or loop several segments when sustaining. It can have several shapes for its segments.
 
+The envelope is conceived as a sequence of emphasis::nodes:: (not to be confused with a synthesis-Node) each of which has three parameters: a target level, a time duration from the previous node, and a shape. The three parameters for each node are kept in separate arrays as explained below.
+
 code::
-Env.new([0, 1, 0.9, 0], [0.1, 0.5, 1],[-5, 0, -5]).plot;
+Env.new(levels: [0, 1, 0.9, 0], times: [0.1, 0.5, 1], curve: [-5, 0, -5]).plot;
 ::
 
-The envelope is conceived as a sequence of emphasis::nodes:: (not to be confused with a synthesis-Node) each of which has three parameters: a target level, a time duration from the previous node, and a shape. The three parameters for each node are kept in separate arrays as explained below.
+In this envelope, there are three emphasis::nodes:: :
+
+list:: 
+## the first emphasis::node:: has level 1 and is reached in 0.1 beat or second depending on the link::Classes/Clock:: used to run the envelope
+## the second emphasis::nodes:: has level 0.9 and is reached in 0.5 beat / second
+## the third emphasis::nodes:: has level 0 and is reached in 1 beat / second
+::
+
+Pay attention that the first level (0) is the starting value of the envelope, but is not considered a emphasis::node:: per se. Which means that if you retrigger an envelope, the starting level of the envelope will not be used the second time, the transition will go from the current level of the envelope to the level of the first emphasis::node::.
+
+code::
+(
+var env = Env.new(levels: [0, 1, 2, 3], times: [0.1, 0.1, 0.1]);
+{
+	EnvGen.kr(envelope: env, gate: Impulse.kr(1));
+}.plot(duration: 2, minval: -0.1, maxval: 3.1);
+)
+::
+
+In this example, the starting level is 0, but the first node has a level of 1, so when the envelope is retriggered, it goes from the level of the current node at the time of the trigger (here, level = 3) to the level of the first node (level = 1).
 
 note::
 In some situations we deal with control points or breakpoints. If these control points have associated x positions (say in an envelope GUI, see link::Classes/EnvelopeView::) they must be converted to time differences between points to be used as nodes in a Env object. The methods link::#*xyc:: and link::#*pairs:: can be used to specify an envelope in terms of points.
@@ -43,7 +64,7 @@ method::new
 Create a new envelope specification.
 
 argument::levels
-an array of levels. The first level is the initial value of the envelope. When the envelope is used with an EnvGen, levels can be any UGen (new level values are updated only when the envelope has reached that point).
+an array of levels. The first value is the initial level of the envelope. When the envelope is used with an EnvGen, levels can be any UGen (new level values are updated only when the envelope has reached that point).
 When the array of levels contains itself an array, the envelope returns a multichannel output (for a discussion, see link::#Multichannel expansion::)
 
 argument::times
@@ -67,10 +88,47 @@ table::
 ::
 
 argument::releaseNode
-an link::Classes/Integer:: or nil. The envelope will sustain at the release node until released.
+an link::Classes/Integer:: or nil. The envelope will sustain at the node preceding the release node until released, therefore a gate signal (and not a trigger signal) should be used to control an envelope with a releaseNode.
+
+code::
+(
+var env = Env.new(levels: [0, 1, 2, 3], times: [0.5, 0.5, 0.25], releaseNode: 1);
+{
+	EnvGen.kr(envelope: env, gate: Trig.kr(in: 1, dur: 3));
+}.plot(duration: 4, minval: -0.1, maxval: 3.1);
+)
+::
+
+In this example, the release node is the second node (nodes[1]) which has a level of 2, so the envelope sustains at the level of 1, and when the gate is released, the envelope goes to the release node level (2) and continues until the end of the envelope.
 
 argument::loopNode
-an link::Classes/Integer:: or nil. If not nil the output will loop through those nodes starting at the loop node to the node immediately preceding the release node, before back to the loop node, and so on. Note that the envelope only transitions to the release node when released. Examples are below. The loop is escaped when a gate signal is sent, when the output transitions to the release node, as described below.
+an link::Classes/Integer:: or nil. If not nil the output will loop through those nodes starting at the loop node to the node immediately preceding the release node, before back to the loop node, and so on. Note that the envelope only transitions to the release node when released. The loop is escaped when a gate signal is sent, when the output transitions to the release node, as described below.
+You should specify the releaseNode and use a gate signal (and not a trigger signal) to use a looping envelope.
+
+code::
+(
+var env = Env.new(levels: [0, 1, 2, 3, 4, 0], times: [0.1, 0.2, 0.1, 0.1, 0.5], loopNode: 1, releaseNode: 4);
+env.plot;
+{
+    EnvGen.ar(envelope: env, gate: Trig.ar(1, 2.05), doneAction: 2);
+}.plot(duration: 3, minval: -0.1, maxval: 4.1);
+)
+::
+
+In this example, the levels array set values for :
+
+list::
+## the starting level of the envelope
+## then the level of the first node which is nodes[0]
+## the level of the second node which is nodes[1]
+## the level of the third node which is nodes[2]
+## etc.
+::
+
+Release node is nodes[4] (the fifth node) whose level is 0.
+Loop node is nodes[1] whose level is 2.
+The loop starts when the gate is not released, and the envelope reaches the fourth node (nodes[4-1]) whose level is 4, to the loop node (nodes[1], so the second node) whose level is 2.
+We can also see that when the envelope is released (at time 2.05), the envelope goes to the release node (level 0) in 0.5 beat/second.
 
 argument::offset
 an offset to all time values (only applies in link::Classes/IEnvGen::).
@@ -86,10 +144,7 @@ code::
 	) * envgen * 0.1
 }.play
 );
-
 ::
-
-
 
 method::newClear
 Creates a new envelope specification with strong::numSegments:: and strong::numChannels:: for filling in later.
@@ -807,4 +862,3 @@ SynthDef(\help_EnvBlend, { | out, factor = 0 |
 }.fork
 );
 ::
-


### PR DESCRIPTION
Purpose and Motivation
----------------------

There are often questions on SC mailing list about Env and especially the first value of the levels array.
I also had difficulties understanding it, as well as looping envelopes (see [this thread](https://scsynth.org/t/how-to-trigger-an-enveloppe-that-will-go-from-0-to-1-and-stay-at-1-until-next-trigger/608/6)) so I'm trying to improve Env documentation to make the concept of nodes clearer.

Types of changes
----------------

- Documentation (non-code change which corrects or adds documentation for existing features)

Checklist
---------

- [X] All previous tests are passing
- [ ] Tests were updated or created to address changes in this PR, and tests are passing
- [X] Updated documentation, if necessary
- [X] This PR is ready for review

Remaining Work
--------------
