### PR TITLE
various fixes to support cookiecutter repo

### DIFF
--- a/include/common/SC_fftlib.h
+++ b/include/common/SC_fftlib.h
@@ -42,6 +42,7 @@ class SCFFT_Allocator
 public:
 	virtual void* alloc(size_t size) = 0;
 	virtual void free(void* ptr) = 0;
+	virtual ~SCFFT_Allocator() {}
 };
 
 enum SCFFT_Direction

--- a/include/plugin_interface/Hash.h
+++ b/include/plugin_interface/Hash.h
@@ -126,9 +126,9 @@ inline int32 Hash(const int32 *inKey, int32 inLength)
 }
 
 #if BYTE_ORDER == LITTLE_ENDIAN
-static const int32 kLASTCHAR = 0xFF000000;
+const int32 kLASTCHAR = (int32)0xFF000000;
 #else
-static const int32 kLASTCHAR = 0x000000FF;
+const int32 kLASTCHAR = (int32)0x000000FF;
 #endif
 
 inline int32 Hash(const int32 *inKey)

--- a/include/plugin_interface/Hash.h
+++ b/include/plugin_interface/Hash.h
@@ -62,7 +62,7 @@ inline int32 Hash(const char *inKey, size_t *outLength)
     hash += hash << 3;
     hash ^= hash >> 11;
     hash += hash << 15;
-    *outLength = inKey - origKey;
+    *outLength = (size_t)(inKey - origKey);
     return hash;
 }
 

--- a/include/plugin_interface/Hash.h
+++ b/include/plugin_interface/Hash.h
@@ -125,13 +125,10 @@ inline int32 Hash(const int32 *inKey, int32 inLength)
     return hash;
 }
 
-#ifndef _LASTCHAR_
-#define _LASTCHAR_
 #if BYTE_ORDER == LITTLE_ENDIAN
-const int32 kLASTCHAR = 0xFF000000;
+static const int32 kLASTCHAR = 0xFF000000;
 #else
-const int32 kLASTCHAR = 0x000000FF;
-#endif
+static const int32 kLASTCHAR = 0x000000FF;
 #endif
 
 inline int32 Hash(const int32 *inKey)

--- a/include/plugin_interface/SC_InlineBinaryOp.h
+++ b/include/plugin_interface/SC_InlineBinaryOp.h
@@ -477,7 +477,7 @@ inline int sc_rightShift(int a, int b)
 
 inline int sc_unsignedRightShift(int a, int b)
 {
-	return (uint32)a >> b;
+	return (int)((uint32)a >> b);
 }
 
 inline int sc_round(int x, int quant)

--- a/include/plugin_interface/SC_InterfaceTable.h
+++ b/include/plugin_interface/SC_InterfaceTable.h
@@ -20,6 +20,7 @@
 
 #pragma once
 
+// TODO next time this is updated, change SC_PlugIn.hpp `in`, `zin`, etc. to take uint32s
 static const int sc_api_version = 3;
 
 #include "SC_Types.h"

--- a/include/plugin_interface/SC_InterfaceTable.h
+++ b/include/plugin_interface/SC_InterfaceTable.h
@@ -21,6 +21,8 @@
 #pragma once
 
 // TODO next time this is updated, change SC_PlugIn.hpp `in`, `zin`, etc. to take uint32s
+// TODO next time this is updated, change SC_PlugIn.hpp `numInputs`, `numOutputs` to have correct
+// return type
 static const int sc_api_version = 3;
 
 #include "SC_Types.h"

--- a/include/plugin_interface/SC_PlugIn.hpp
+++ b/include/plugin_interface/SC_PlugIn.hpp
@@ -159,13 +159,13 @@ public:
 	/// get number of inputs
 	int numInputs() const
 	{
-		return mNumInputs;
+		return int(mNumInputs);
 	}
 
 	/// get number of outputs
 	int numOutputs() const
 	{
-		return mNumOutputs;
+		return int(mNumOutputs);
 	}
 
 	/// test if input signal at index is scalar rate

--- a/include/plugin_interface/SC_PlugIn.hpp
+++ b/include/plugin_interface/SC_PlugIn.hpp
@@ -103,7 +103,7 @@ public:
 	/// get input signal at index
 	const float * in(int index) const
 	{
-		assert( index < mNumInputs );
+		assert( uint32(index) < mNumInputs );
 		const Unit * unit = this;
 		return IN(index);
 	}
@@ -111,15 +111,15 @@ public:
 	/// get input signal at index (to be used with ZXP)
 	const float * zin(int index) const
 	{
-		assert( index < mNumInputs );
+		assert( uint32(index) < mNumInputs );
 		const Unit * unit = this;
 		return ZIN(index);
 	}
 
 	/// get first sample of input signal
-	const float in0(int index) const
+	float in0(int index) const
 	{
-		assert( index < mNumInputs );
+		assert( uint32(index) < mNumInputs );
 		const Unit * unit = this;
 		return IN0(index);
 	}
@@ -127,7 +127,7 @@ public:
 	/// get output signal at index
 	float * out(int index) const
 	{
-		assert( index < mNumOutputs );
+		assert( uint32(index) < mNumOutputs );
 		const Unit * unit = this;
 		return OUT(index);
 	}
@@ -135,7 +135,7 @@ public:
 	/// get output signal at index (to be used with ZXP)
 	float * zout(int index) const
 	{
-		assert( index < mNumOutputs );
+		assert( uint32(index) < mNumOutputs );
 		const Unit * unit = this;
 		return ZOUT(index);
 	}
@@ -143,7 +143,7 @@ public:
 	/// get reference to first sample of output signal
 	float & out0(int index) const
 	{
-		assert( index < mNumOutputs );
+		assert( uint32(index) < mNumOutputs );
 		const Unit * unit = this;
 		return OUT0(index);
 	}
@@ -151,7 +151,7 @@ public:
 	/// get rate of input signal
 	int inRate(int index) const
 	{
-		assert( index < mNumInputs );
+		assert( uint32(index) < mNumInputs );
 		const Unit * unit = this;
 		return INRATE(index);
 	}
@@ -171,35 +171,35 @@ public:
 	/// test if input signal at index is scalar rate
 	bool isScalarRateIn(int index) const
 	{
-		assert( index < mNumInputs );
+		assert( uint32(index) < mNumInputs );
 		return inRate(index) == calc_ScalarRate;
 	}
 
 	/// test if input signal at index is demand rate
 	bool isDemandRateIn(int index) const
 	{
-		assert( index < mNumInputs );
+		assert( uint32(index) < mNumInputs );
 		return inRate(index) == calc_DemandRate;
 	}
 
 	/// test if input signal at index is control rate
 	bool isControlRateIn(int index) const
 	{
-		assert( index < mNumInputs );
+		assert( uint32(index) < mNumInputs );
 		return inRate(index) == calc_BufRate;
 	}
 
 	/// test if input signal at index is audio rate
 	bool isAudioRateIn(int index) const
 	{
-		assert( index < mNumInputs );
+		assert( uint32(index) < mNumInputs );
 		return inRate(index) == calc_FullRate;
 	}
 
 	/// get the blocksize of the input
 	int inBufferSize(int index) const
 	{
-		assert( index < mNumInputs );
+		assert( uint32(index) < mNumInputs );
 		const Unit * unit = this;
 		return INBUFLENGTH(index);
 	}

--- a/include/plugin_interface/SC_SndBuf.h
+++ b/include/plugin_interface/SC_SndBuf.h
@@ -218,7 +218,7 @@ inline float lookupi2(const float *table, uint32_t phase, uint32_t mask)
 inline float lookupi1(const float* table0, const float* table1, uint32_t pphase, int32_t lomask)
 {
 	float pfrac = PhaseFrac1(pphase);
-	uint32_t index = ((pphase >> xlobits1) & lomask);
+	uint32_t index = ((pphase >> xlobits1) & (uint32_t)lomask);
 	float val1 = *(const float*)((const char*)table0 + index);
 	float val2 = *(const float*)((const char*)table1 + index);
 	return val1 + val2 * pfrac;

--- a/include/plugin_interface/SC_SndBuf.h
+++ b/include/plugin_interface/SC_SndBuf.h
@@ -71,7 +71,6 @@ public:
 	rw_spinlock(rw_spinlock const & rhs)             = delete;
 	rw_spinlock & operator=(rw_spinlock const & rhs) = delete;
 	rw_spinlock(rw_spinlock && rhs)                  = delete;
-	rw_spinlock & operator=(rw_spinlock & rhs)       = delete;
 
 	~rw_spinlock() { assert(state == unlocked_state); }
 

--- a/include/plugin_interface/Unroll.h
+++ b/include/plugin_interface/Unroll.h
@@ -139,19 +139,19 @@ meanings of the indexing macros:
 inline void Clear(int numSamples, float *out)
 {
 	// The memset approach is valid on any system using IEEE floating-point. On other systems, please check...
-	memset(out, 0, numSamples * sizeof(float));
+	memset(out, 0, (unsigned int)numSamples * sizeof(float));
 }
 
 inline void Clear(int numSamples, double *out)
 {
 	// The memset approach is valid on any system using IEEE floating-point. On other systems, please check...
-	memset(out, 0, numSamples * sizeof(double));
+	memset(out, 0, (unsigned int)numSamples * sizeof(double));
 }
 
 
 inline void Copy(int numSamples, float *out, float *in)
 {
-	memcpy(out, in, numSamples * sizeof(float));
+	memcpy(out, in, (unsigned int)numSamples * sizeof(float));
 }
 
 inline void Fill(int numSamples, float *out, float level)
@@ -218,7 +218,7 @@ inline void ZCopy(int numSamples, float *out, const float *in)
 	if ((numSamples & 1) == 0) {
 		// copying doubles is faster on powerpc.
 		double *outd = (double*)(out + ZOFF) - ZOFF;
-		double *ind = (double*)(in + ZOFF) - ZOFF;
+		const double *ind = (const double*)(in + ZOFF) - ZOFF;
 		LOOP(numSamples >> 1, ZXP(outd) = ZXP(ind); );
 	} else {
 		LOOP(numSamples, ZXP(out) = ZXP(in); );

--- a/include/plugin_interface/sc_msg_iter.h
+++ b/include/plugin_interface/sc_msg_iter.h
@@ -37,7 +37,7 @@ inline const char* OSCstrskip(const char *str)
 // returns the number of bytes (including padding) for an OSC string.
 inline size_t OSCstrlen(const char *strin)
 {
-	return OSCstrskip(strin) - strin;
+	return (size_t)(OSCstrskip(strin) - strin);
 }
 
 // returns a float, converting an int if necessary
@@ -82,7 +82,7 @@ struct sc_msg_iter
 	size_t getbsize();
 	void getb(char* outData, size_t inSize);
 	void skipb();
-	size_t remain() { return endpos - rdpos; }
+	size_t remain() { return (size_t)(endpos - rdpos); }
 
     char nextTag(char defaultTag = 'f') { return tags ? tags[count] : defaultTag; }
 };
@@ -280,26 +280,26 @@ inline size_t sc_msg_iter::getbsize()
 	if (remain() <= 0) return 0;
 	if (tags) {
 		if (tags[count] == 'b')
-			len = OSCint(rdpos);
+			len = (size_t)OSCint(rdpos);
 		else if (tags[count] == 'm')
 			len = 4;
 	}
 	return len;
 }
 
-inline void sc_msg_iter::getb(char* outArray, size_t size)
+inline void sc_msg_iter::getb(char* outArray, size_t arraySize)
 {
 	size_t len = 0;
 	if (tags[count] == 'b') {
-		len = OSCint(rdpos);
-		if (size < len) return;
+		len = (size_t)OSCint(rdpos);
+		if (arraySize < len) return;
 		rdpos += sizeof(int32);
 	}	else if (tags[count] == 'm') {
 		len = 4;
-		if (size < len) return;
+		if (arraySize < len) return;
 	}
 	size_t len4 = (len + 3) & (size_t)-4;
-	memcpy(outArray, rdpos, size);
+	memcpy(outArray, rdpos, arraySize);
 	rdpos += len4;
 	count ++;
 }
@@ -309,7 +309,7 @@ inline void sc_msg_iter::skipb()
 	size_t len = 0;
 	if (tags[count] == 'b')
 	{
-		len = OSCint(rdpos);
+		len = (size_t)OSCint(rdpos);
 		rdpos += sizeof(int32);
 	} else if (tags[count] == 'm')
 		len = 4;

--- a/server/scsynth/SC_Str4.h
+++ b/server/scsynth/SC_Str4.h
@@ -26,16 +26,6 @@
 #include <stdio.h>
 #include <limits.h>
 
-#ifndef _LASTCHAR_
-#define _LASTCHAR_
-#if BYTE_ORDER == LITTLE_ENDIAN
-const int32 kLASTCHAR = 0xFF000000;
-#else
-const int32 kLASTCHAR = 0x000000FF;
-#endif
-#endif
-
-
 void str4cpy(int32 *dst, const char *src);
 void mem4cpy(int32 *dst, const char *src, int charlen);
 

--- a/tools/cmake_gen/CMakeLists_header.template
+++ b/tools/cmake_gen/CMakeLists_header.template
@@ -37,6 +37,7 @@ message(STATUS "Building plugins for SuperCollider version: ${SC_VERSION}")
 
 # set project here to avoid SCVersion.txt clobbering our version info
 project(${project_name})
+sc_do_initial_compiler_config() # do after setting project so compiler ID is available
 
 if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT OR NOT CMAKE_INSTALL_PREFIX)
     message(WARNING "No install prefix provided, defaulting to $BUILD_DIR/install")

--- a/tools/cmake_gen/SuperColliderCompilerConfig.cmake
+++ b/tools/cmake_gen/SuperColliderCompilerConfig.cmake
@@ -48,7 +48,7 @@ function(sc_config_compiler_flags target)
             message(WARNING "-DNATIVE is not supported with MSVC")
         endif()
         target_compile_options(${target} PUBLIC
-            $<$<BOOL:${STRICT}>:"/Wall /WX">
+            $<$<BOOL:${STRICT}>:-Wall -WX>
             )
     else()
         message(WARNING "Unknown compiler: ${CMAKE_CXX_COMPILER_ID}. You may want to modify SuperColliderCompilerConfig.cmake to add checks for SIMD flags and other optimizations.")

--- a/tools/cmake_gen/SuperColliderCompilerConfig.cmake
+++ b/tools/cmake_gen/SuperColliderCompilerConfig.cmake
@@ -47,8 +47,14 @@ function(sc_config_compiler_flags target)
         if(NATIVE)
             message(WARNING "-DNATIVE is not supported with MSVC")
         endif()
+        # C4514: inline function not used
+        # C4625: copy ctor implicitly deleted
+        # C4626: copy assign implicitly deleted
+        # C4820: padding added after member
+        # C5026: move ctor implicitly deleted
+        # C5027: move assign implicitly deleted
         target_compile_options(${target} PUBLIC
-            $<$<BOOL:${STRICT}>:-Wall -WX>
+            $<$<BOOL:${STRICT}>:-Wall -WX -wd4820 -wd4514 -wd5026 -wd5027 -wd4626 -wd4625>
             )
     else()
         message(WARNING "Unknown compiler: ${CMAKE_CXX_COMPILER_ID}. You may want to modify SuperColliderCompilerConfig.cmake to add checks for SIMD flags and other optimizations.")

--- a/tools/cmake_gen/SuperColliderCompilerConfig.cmake
+++ b/tools/cmake_gen/SuperColliderCompilerConfig.cmake
@@ -3,26 +3,28 @@
 #
 # Compiler configuration help for server plugins
 
-# assume we are not mixing C and C++ compiler vendors
-if(CMAKE_VERSION VERSION_LESS 3.10)
-    # slower/more complicated way
-    include(CheckCCompilerFlag)
-    include(CheckCXXCompilerFlag)
-    if(CMAKE_CXX_COMPILER_ID MATCHES "Clang|AppleClang|GNU")
-        CHECK_CXX_COMPILER_FLAG(-msse has_sse)
-        CHECK_CXX_COMPILER_FLAG(-msse2 has_sse2)
-        CHECK_CXX_COMPILER_FLAG(-mfpmath=sse has_sse_fp)
-    elseif(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
-        CHECK_CXX_COMPILER_FLAG(/arch:SSE has_sse)
-        CHECK_CXX_COMPILER_FLAG(/arch:SSE2 has_sse2)
+function(sc_do_initial_compiler_config)
+    # assume we are not mixing C and C++ compiler vendors
+    if(CMAKE_VERSION VERSION_LESS 3.10)
+        # slower/more complicated way
+        include(CheckCCompilerFlag)
+        include(CheckCXXCompilerFlag)
+        if(CMAKE_CXX_COMPILER_ID MATCHES "Clang|AppleClang|GNU")
+            CHECK_CXX_COMPILER_FLAG(-msse has_sse)
+            CHECK_CXX_COMPILER_FLAG(-msse2 has_sse2)
+            CHECK_CXX_COMPILER_FLAG(-mfpmath=sse has_sse_fp)
+        elseif(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
+            CHECK_CXX_COMPILER_FLAG(/arch:SSE has_sse)
+            CHECK_CXX_COMPILER_FLAG(/arch:SSE2 has_sse2)
+        else()
+            message(WARNING "Unknown compiler: ${CMAKE_CXX_COMPILER_ID}. You may want to modify SuperColliderCompilerConfig.cmake to add checks for SIMD flags and other optimizations.")
+        endif()
     else()
-        message(WARNING "Unknown compiler: ${CMAKE_CXX_COMPILER_ID}. You may want to modify SuperColliderCompilerConfig.cmake to add checks for SIMD flags and other optimizations.")
+        cmake_host_system_information(RESULT has_sse QUERY HAS_SSE)
+        cmake_host_system_information(RESULT has_sse2 QUERY HAS_SSE2)
+        cmake_host_system_information(RESULT has_sse_fp QUERY HAS_SSE_FP)
     endif()
-else()
-    cmake_host_system_information(RESULT has_sse QUERY HAS_SSE)
-    cmake_host_system_information(RESULT has_sse2 QUERY HAS_SSE2)
-    cmake_host_system_information(RESULT has_sse_fp QUERY HAS_SSE_FP)
-endif()
+endfunction()
 
 function(sc_config_compiler_flags target)
     if(CMAKE_CXX_COMPILER_ID MATCHES "Clang|AppleClang|GNU")

--- a/tools/cmake_gen/SuperColliderServerPlugin.cmake
+++ b/tools/cmake_gen/SuperColliderServerPlugin.cmake
@@ -29,15 +29,15 @@ function(sc_check_sc_path path)
     set(SC_PATH ${full_path} PARENT_SCOPE)
 endfunction()
 
-function(sc_set_shared_module_prefix)
-    if(APPLE OR WIN32)
-        set(CMAKE_SHARED_MODULE_SUFFIX ".scx" PARENT_SCOPE)
-    endif()
-    set(CMAKE_SHARED_MODULE_PREFIX "" PARENT_SCOPE)
-endfunction()
-
 function(sc_add_server_plugin_properties target is_supernova)
-    set_target_properties(${target} PROPERTIES CXX_VISIBILITY_PRESET hidden)
+    set_target_properties(${target} PROPERTIES
+        CXX_VISIBILITY_PRESET hidden
+        PREFIX ""
+    )
+
+    if(APPLE OR WIN32)
+        set_target_properties(${target} PROPERTIES SUFFIX ".scx")
+    endif()
 
     target_include_directories(${target} PUBLIC
         ${SC_PATH}/include/plugin_interface
@@ -79,7 +79,5 @@ function(sc_add_server_plugin dest_dir name cpp sc schelp)
         install(FILES "${schelp}" DESTINATION ${dest_dir}/Help)
     endif()
 endfunction()
-
-sc_set_shared_module_prefix()
 
 set(all_sc_server_plugins)

--- a/tools/cmake_gen/generate_server_plugin_cmake.py
+++ b/tools/cmake_gen/generate_server_plugin_cmake.py
@@ -246,7 +246,8 @@ class Generator:
     # helper
     def join_file_list(self, files):
         if files:
-            return ''.join(map(lambda x: '    ' + x + '\n', files))
+            # CMake generally likes / more than \
+            return ''.join(map(lambda x: '    ' + x.replace('\\', '/') + '\n', files))
         else:
             return ''
 


### PR DESCRIPTION
Purpose and Motivation
----------------------

There are a couple problems revealed by using CI in the cookiecutter
repo that can only be fixed in this repo. In no particular order:

- CMake warnings on Linux: https://github.com/supercollider/cookiecutter-supercollider-plugin/issues/8
- Building with all warnings on causes build error due to warnings in SC
repo headers: https://github.com/supercollider/cookiecutter-supercollider-plugin/issues/9
- Windows CI fails due to bad path separators in CMakeLists.txt: https://github.com/supercollider/cookiecutter-supercollider-plugin/issues/7
- Bad extension for built plugins due to broken target property logic:
https://github.com/supercollider/cookiecutter-supercollider-plugin/issues/1
(see also https://github.com/supercollider/supercollider/pull/4195)

Types of changes
----------------

- Bug fix (non-breaking change which fixes an issue)

The fix for signed/unsigned comparison in SC_PlugIn.hpp is not ideal.
Changing the type of those functions now wouldn't have any real impact
on binary compatibility but I think it's better we save outward facing
API changes for actual API versioning bumps, so I've left a TODO.

This PR includes @sbl's commit from #4195, so I am closing that in favor
of this which tackles all the little known issues at once.

Checklist
---------

<!--- Complete an item by checking it: [x] -->

- [x] All tests are passing
- [x] If necessary, new tests were created to address changes in PR, and tests are passing
- [x] Updated documentation, if necessary
- [x] This PR is ready for review

I've added extra checks in the cookiecutter repo CI to ensure all of
these things will not regress.