### PR TITLE
Topic/plotter fix resample

### DIFF
--- a/HelpSource/Classes/Plotter.schelp
+++ b/HelpSource/Classes/Plotter.schelp
@@ -179,11 +179,14 @@ a.value; // the value
 ::
 
 method:: resolution
-Set the number of data points displayed maximally per pixel (default: 1)
+Set the minimum number of pixels between data points (default: 1)
 code::
-a = (0..200).scramble.plot;
-a.resolution = 8; a.refresh; // resizing the window shows interpolation
-a.resolution = 1; a.refresh;
+// Changing plot resolution (x-axis)
+p = 5000.collect({ |i| sinPi(i * 0.0025) }).plot;
+p.resolution_(5).refresh;  // 5px
+p.resolution_(10).refresh;
+p.resolution_(50).refresh; // undersampled
+p.resolution_(1).refresh;  // default
 ::
 
 method:: findSpecs
@@ -241,6 +244,7 @@ code::
 a = { (40..3000).scramble }.dup(2).plot;
 a.specs = \freq.asSpec; a.refresh;
 ::
+See also link::#examples::.
 
 method:: domainSpecs
 Set or get the spec for the x-axis (domain).
@@ -248,6 +252,7 @@ code::
 a = { (40..300).scramble }.dup(2).plot;
 a.domainSpecs = \freq.asSpec; a.refresh;
 ::
+
 discussion::
 The default domainSpec when setting your Plotter link::#-value:: is a linear
 spec in the range code::[0, value.size-1]::. Unless you set link::#-domain::,
@@ -474,5 +479,12 @@ plt2.domain = xs;
 // so we can pad the plot on either side.
 plt2.domainSpecs_(([-0.5pi, 2.5pi]).asSpec);
 )
-::
 
+// Non-linear scaling of axes.
+// plot 1000 values, linearly distributed on X and Y
+p = (1, 2 .. 1000).plot.domainSpecs_([1, 1000, \lin].asSpec).refresh;
+// scale y axis exponentially
+p.specs_([[1, 1000, \exp].asSpec]).refresh;
+// then scale x axis exponentially
+p.domainSpecs_([1, 1000, \exp].asSpec).refresh;
+::

--- a/SCClassLibrary/Common/GUI/Base/Grid.sc
+++ b/SCClassLibrary/Common/GUI/Base/Grid.sc
@@ -107,7 +107,7 @@ DrawGridX {
 				// value, [color]
 				var x;
 				val = val.asArray;
-				x = val[0].linlin(range[0],range[1],bounds.left,bounds.right);
+				x = grid.spec.unmap(val[0]).linlin(0, 1, bounds.left, bounds.right);
 				commands = commands.add( ['strokeColor_',val[1] ? gridColor] );
 				commands = commands.add( ['line', Point( x, bounds.top), Point(x,bounds.bottom) ] );
 				commands = commands.add( ['stroke' ] );
@@ -124,7 +124,7 @@ DrawGridX {
 					if(val[3].notNil,{
 						commands = commands.add( ['font_',val[3] ] );
 					});
-					x = val[0].linlin(range[0],range[1],bounds.left,bounds.right);
+					x = grid.spec.unmap(val[0]).linlin(0, 1 ,bounds.left, bounds.right);
 					commands = commands.add( ['stringAtPoint', val[1].asString, Point(x, bounds.bottom) + labelOffset ] );
 				}
 			});
@@ -153,7 +153,7 @@ DrawGridY : DrawGridX {
 				// value, [color]
 				var y;
 				val = val.asArray;
-				y = val[0].linlin(range[0],range[1],bounds.bottom,bounds.top);
+				y = grid.spec.unmap(val[0]).linlin(0, 1 ,bounds.bottom, bounds.top);
 				commands = commands.add( ['strokeColor_',val[1] ? gridColor] );
 				commands = commands.add( ['line', Point( bounds.left,y), Point(bounds.right,y) ] );
 				commands = commands.add( ['stroke' ] );
@@ -163,7 +163,7 @@ DrawGridY : DrawGridX {
 				commands = commands.add(['color_',fontColor ] );
 				p['labels'].do { arg val,i;
 					var y;
-					y = val[0].linlin(range[0],range[1],bounds.bottom,bounds.top);
+					y = grid.spec.unmap(val[0]).linlin(0, 1 ,bounds.bottom, bounds.top);
 					if(val[2].notNil,{
 						commands = commands.add( ['color_',val[2] ] );
 					});

--- a/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
+++ b/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
@@ -413,8 +413,12 @@ Plot {
 	}
 
 	prResampValues {
+		var dataRes, numSpecSteps, specStep, sizem1;
+
+		dataRes = plotBounds.width / max((value.size - 1), 1);
+
 		^if (
-			value.size <= (plotBounds.width / plotter.resolution) or:
+			(dataRes >= plotter.resolution) or:
 			{ plotter.domain.notNil } // don't resample if domain is specified
 		) {
 			value
@@ -422,8 +426,15 @@ Plot {
 			// resample
 			if (valueCache.isNil or: { resolution != plotter.resolution }) {
 				resolution = plotter.resolution;
+
 				// domain is nil, so data fills full domain/view width
-				valueCache = value.resamp1(plotBounds.width / resolution)
+				numSpecSteps = (plotBounds.width / resolution).floor.asInt;
+				specStep = numSpecSteps.reciprocal;
+				sizem1 = value.size - 1;
+
+				valueCache = (numSpecSteps + 1).collect{ |i|
+					value.blendAt((specStep * i) * sizem1)  // float index of new value
+				}
 			} {
 				valueCache
 			}
@@ -960,7 +971,7 @@ Plotter {
 			^{ In.kr(this.index, this.numChannels) }.plot(duration, this.server, bounds, minval, maxval, separately);
 		});
 	}
-	
+
 	plotAudio { |duration = 0.01, minval = -1, maxval = 1, bounds|
 		^this.plot(duration, bounds, minval, maxval)
 	}

--- a/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
+++ b/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
@@ -428,7 +428,7 @@ Plot {
 				resolution = plotter.resolution;
 
 				// domain is nil, so data fills full domain/view width
-				numSpecSteps = (plotBounds.width / resolution).floor.asInt;
+				numSpecSteps = (plotBounds.width / resolution).floor.asInteger;
 				specStep = numSpecSteps.reciprocal;
 				sizem1 = value.size - 1;
 


### PR DESCRIPTION
<!--- Hi, and thanks for contributing! -->
<!--- Make sure to provide a general summary of your changes in the title above. -->
<!--- For example: "[scsynth] Fix crash when encountering cute kittens" -->

Purpose and Motivation
----------------------

This PR brings more support to specifying specs in `Plotter`, and related issues regarding GridLines and `resolution`.


Types of changes
----------------

This fixes a few issues regarding plotting:
- `Grid` now follows the warping of its spec. Before the warp was assumed to be linear, so if, e.g. you assigned an exponential spec to the domain (`domainSpecs_`) or codomain (`specs_`) in `Plotter`, the gridlines wouldn't be at the correct locations.
- `Plotter` resamples values if the number of values exceeded the plot width (or specified resolution). However setting the domain requires one domain value for every data point, so domain locations aren't correct when resampling. So now if the domain is set, the values won't be resampled.
  - This means that if the domain is set and the plotted data set is large, refresh can be slow, but at least the values are now correct. Resampling assigned domain values is a harder problem (especially for non-linear domain specs) for a future fix.
- The `prResampValues` method, which enforces the `resolution`, now also catches a change in resolution, which before wouldn't be caught unless the window was resized (wouldn't be caught on refresh either).
- The `prResampValues` method now resamples differently. The previous approach used `SequenceableCollection : resamp1`, which allows floating-point resample argument resulting in a last value which isn’t the last in the array, but rather one just short of it. In plotting, this means that resampled data may appear to not reach the final value. This new approach ensures correct start and end values, and has evenly spaced (re)sampling that is at least `resolution` pixels.
- docs were updated to provide examples and clarification on the `resolution` setter method.

An example of improper resampling:
```supercollider
//  notice the endpoint drifts when shrinking window width
p = (1, 2 .. 1000).plot.plotMode_(\linear).domainSpecs_([1, 1000, \exp].asSpec).refresh;
p.domain_((1, 2 .. 1000)/2).refresh;
// note it's a bit hard to see without gridlines working properly! (this PR fixes that too)
```

An example of resolution not updating:
```supercollider
// Changing plot resolution (x-axis)
p = 5000.collect({ |i| sinPi(i * 0.0025) }).plot;
// after setting resolution, note strange resampling,
// then resize the window and plot snaps back to original, resampled
p.resolution_(10).refresh;
p.resolution_(20).refresh;
p.resolution_(50).refresh; // undersampled
p.resolution_(1).refresh;  // default
```

Checklist
---------

<!--- Complete an item by checking it: [x] -->

- [ ] All previous tests are passing
  - The current TestPlotter unit test only tests color setters ...
- [ ] Tests were updated or created to address changes in this PR, and tests are passing
  - Not sure how to make a test for this kind of (QT) thing, when changes result in display differences!
- [x] Updated documentation, if necessary
- [x] This PR is ready for review