### PR TITLE
scide: Improve line number margins

### DIFF
--- a/editors/sc-ide/widgets/code_editor/editor.cpp
+++ b/editors/sc-ide/widgets/code_editor/editor.cpp
@@ -876,7 +876,12 @@ void GenericCodeEditor::onDocumentFontChanged()
 
 void GenericCodeEditor::updateLayout()
 {
-    setViewportMargins( mLineIndicator->width(), 0, 0, 0 );
+    // Left margin equal to the width of one digit. If line numbers are
+    // present, this is the spacing between the line numbers and the code. If
+    // line numbers are not present, this is the margin to the left of the
+    // code.
+    int leftMargin = fontMetrics().width('9') * 0.8f;
+    setViewportMargins( mLineIndicator->width() + leftMargin, 0, 0, 0 );
     mOverlayWidget->setGeometry( viewport()->geometry() );
 }
 

--- a/editors/sc-ide/widgets/code_editor/line_indicator.cpp
+++ b/editors/sc-ide/widgets/code_editor/line_indicator.cpp
@@ -93,7 +93,10 @@ int LineIndicator::widthForLineCount( int lineCount )
         ++digits;
     }
 
-    return 6 + fontMetrics().width('9') * digits;
+    // +6 pixels width because GenericCodeEditor::paintLineIndicator adds 4
+    // pixels right padding.
+    // +0.75 digits width for less cramped left margin.
+    return 6 + fontMetrics().width('9') * (digits + 0.75);
 }
 
 void LineIndicator::setHideLineIndicator( bool hide )


### PR DESCRIPTION
+0.8 digit-width of spacing between code and line numbers (or code and left edge if line numbers are disabled)

+0.75 digit-widths of left padding to line numbers for a less cramped look.

before:

![untitled](https://user-images.githubusercontent.com/1211064/50649954-077f2580-0f34-11e9-810a-a6a9fb4572d4.png)

after:

![untitled](https://user-images.githubusercontent.com/1211064/50649892-def72b80-0f33-11e9-85cf-6136884a408d.png)

![untitled](https://user-images.githubusercontent.com/1211064/50651487-5f1f9000-0f38-11e9-82b1-64fd99ec99fc.png)
