### PR TITLE
help: fix broken links in multiple helpfiles

### DIFF
--- a/HelpSource/Classes/AbstractResponderFunc.schelp
+++ b/HelpSource/Classes/AbstractResponderFunc.schelp
@@ -87,7 +87,7 @@ METHOD:: oneShot
 Indicate that this object should execute only once and then free itself.
 
 METHOD:: fix
-A synonym for link::#permanent::
+A synonym for link::#-permanent::
 
 METHOD:: free
 Disable this object and remove it from the global lists. This should be done when you are finished using this object.

--- a/HelpSource/Classes/BusPlug.schelp
+++ b/HelpSource/Classes/BusPlug.schelp
@@ -37,7 +37,7 @@ method::defaultNumControl
 Default number of channels when initializing in control rate and no specific number is given (default: 1).
 
 method::defaultReshaping
-default reshaping behaviour for BusPlug and its sublass NodeProxy. See: link::#reshaping::
+default reshaping behaviour for BusPlug and its sublass NodeProxy. See: link::#-reshaping::
 
 InstanceMethods::
 
@@ -53,7 +53,7 @@ Free the bus, end the monitor
 subsection::Making copies
 
 method::copy
-copies the hidden internal state to make the new BusPlug independent of the old, running on a new link::Classes/Bus::. By design, the link::Classes/Monitor:: is copied, but is not running (use play to start it in the same configuration). If needed, you can also copy the link::Classes/Monitor:: only (see: link::Classes/NodeProxy#copy::).
+copies the hidden internal state to make the new BusPlug independent of the old, running on a new link::Classes/Bus::. By design, the link::Classes/Monitor:: is copied, but is not running (use play to start it in the same configuration). If needed, you can also copy the link::Classes/Monitor:: only (see: link::Classes/NodeProxy#-copy::).
 
 method::copyState
 Copy the internal settings of one proxy into another. Old state is cleared, the bus is freed.
@@ -63,7 +63,7 @@ The object whose internal state is being copied.
 
 
 method::reshaping
-Determines how to behave when link::#initBus:: is called.
+Determines how to behave when link::#-initBus:: is called.
 Current options:
 list::
 ## teletype::nil:: Once initialized, keep the same bus - this is the default

--- a/HelpSource/Classes/Env.schelp
+++ b/HelpSource/Classes/Env.schelp
@@ -633,10 +633,10 @@ method::asSignal
 Returns a link::Classes/Signal:: of size strong::length:: created by sampling this Env at strong::length:: number of intervals. If the envelope has multiple channels (see link::#Multichannel expansion::), this method returns an array of signals.
 
 method::asArray
-Converts the Env to an link::Classes/Array:: in a specially ordered format. This allows for Env parameters to be settable arguments in a SynthDef. See example below under link::#-newClear::.
+Converts the Env to an link::Classes/Array:: in a specially ordered format. This allows for Env parameters to be settable arguments in a SynthDef. See example under link::#*newClear::.
 
 method::asMultichannelArray
-Converts the Env to an link::Classes/Array:: in a specially ordered format, like link::#asArray::, however it always returns an array of these data sets, corresponding to the number of channels of the envelope.
+Converts the Env to an link::Classes/Array:: in a specially ordered format, like link::#-asArray::, however it always returns an array of these data sets, corresponding to the number of channels of the envelope.
 
 method::isSustained
 Returns true if this is a sustaining envelope, false otherwise.

--- a/HelpSource/Classes/Environment.schelp
+++ b/HelpSource/Classes/Environment.schelp
@@ -17,10 +17,10 @@ method::use
 Creates a new Environment and sends use message.
 
 method::push
-Saves link::#.currentEnvironment:: on the stack.
+Saves link::#currentEnvironment:: on the stack.
 
 method::pop
-Restores link::#.currentEnvironment:: from the stack.
+Restores link::#currentEnvironment:: from the stack.
 
 INSTANCEMETHODS::
 
@@ -34,17 +34,17 @@ method::push
 Saves the receiver on the stack.
 
 method::pop
-Restores link::#.currentEnvironment:: from the stack.
+Restores link::#currentEnvironment:: from the stack.
 
 method::linkDoc
-Links the environment to the current document, so that it is the currentEnvironment only when one document is in focus. See:link::Classes/Document#envir::
+Links the environment to the current document, so that it is the currentEnvironment only when one document is in focus. See: link::Classes/Document#-envir::
 argument::doc
-The document to link to, defaults to the current document (link::Classes/Document#current::). If the document has focus or no document is given, the environment is pushed immediately.
+The document to link to, defaults to the current document (link::Classes/Document#*current::). If the document has focus or no document is given, the environment is pushed immediately.
 
 method::unlinkDoc
-Uninks the environment to the current document, so that it is the currentEnvironment only when one document is in focus. See:link::Classes/Document#envir::
+Uninks the environment to the current document, so that it is the currentEnvironment only when one document is in focus. See: link::Classes/Document#-envir::
 argument::doc
-The document to unlink from, defaults to the current document (link::Classes/Document#current::). If the document has focus or no document is given, the environment is popped immediately.
+The document to unlink from, defaults to the current document (link::Classes/Document#*current::). If the document has focus or no document is given, the environment is popped immediately.
 
 
 SECTION::PseudoVariables (global variables)
@@ -53,10 +53,10 @@ These are not methods, but global variables.
 warning::In general, you should not manipulate these variables directly. Instead, use the link::#-use::, link::#-push:: and link::#*pop:: methods.::
 
 method:: currentEnvironment
-determines environment used by "~" syntax, link::#.valueEnvir::, and link::#.valueArrayEnvir::
+determines environment used by "~" syntax, link::#valueEnvir::, and link::#valueArrayEnvir::
 
 method:: topEnvironment
-initial value of link::#.currentEnvironment::. code::~environmentVariables:: placed here can be used as "global variables," as long as the topEnvironment remains the currentEnvironment.
+initial value of link::#currentEnvironment::. code::~environmentVariables:: placed here can be used as "global variables," as long as the topEnvironment remains the currentEnvironment.
 
 code::
 ~abc = 10;  // Environment variable (acting like a global var)
@@ -87,22 +87,22 @@ Thus, ~abc is not truly a global variable because it is inaccessible if its envi
 SECTION::Related Messages
 
 method:: valueEnvir (arg1, arg2...)
-evaluates a function, looking up unspecified arguments in link::#.currentEnvironment::
+evaluates a function, looking up unspecified arguments in link::#currentEnvironment::
 
 method:: valueArrayEnvir (argArray)
-same as link::#.valueEnvir::, but with arguments in an array
+same as link::#valueEnvir::, but with arguments in an array
 
 
 SECTION::Overview
 
 subsection::topEnvironment, currentEnvironment, make and use
 
-When SuperCollider starts, it creates an Environment that it stores in the pseudovariables link::#.topEnvironment:: and link::#.currentEnvironment::. The link::#.topEnvironment:: provides a universally accessible collection of named values similar to the link::Classes/Interpreter:: variables a, b, c, ....
+When SuperCollider starts, it creates an Environment that it stores in the pseudovariables link::#topEnvironment:: and link::#currentEnvironment::. The link::#topEnvironment:: provides a universally accessible collection of named values similar to the link::Classes/Interpreter:: variables a, b, c, ....
 
-The compiler provides a shortcut syntax where ~ is a placeholder for link::#.currentEnvironment::.
+The compiler provides a shortcut syntax where ~ is a placeholder for link::#currentEnvironment::.
 This makes the expression code::~myvariable;:: equivalent to code::currentEnvironment.at(\myvariable);:: and the expression code::~myvariable = 888;:: equivalent to code::currentEnvironment.put(\myvariable, 888);::
 
-The messages link::#*make::(function) and link::#*use::(function) replace link::#.currentEnvironment:: with the receiver. The message link::#*make:: is intended to be used when initializing an Environment, so it returns the Environment. The message link::#*use:: is for evaluating a functions within an Environment, so it returns the return value of the function.
+The messages link::#*make::(function) and link::#*use::(function) replace link::#currentEnvironment:: with the receiver. The message link::#*make:: is intended to be used when initializing an Environment, so it returns the Environment. The message link::#*use:: is for evaluating a functions within an Environment, so it returns the return value of the function.
 
 For example
 code::
@@ -125,7 +125,7 @@ evaluates the function within that environment.
 
 subsection::valueEnvir and valueArrayEnvir
 
-When Functions are evaluated with link::#.valueEnvir:: and link::#.valueArrayEnvir:: unspecified arguments are looked up in the current Environment.
+When Functions are evaluated with link::#valueEnvir:: and link::#valueArrayEnvir:: unspecified arguments are looked up in the current Environment.
 If the argument is not found in the Environment its default value is used.
 code::
 (
@@ -147,7 +147,7 @@ Environment.use({
 });
 )
 ::
-Now here is how this can be used with an instrument function. Environments allow you to define instruments without having to worry about argument ordering conflicts. Even though the three functions below have the freq, amp and pan args declared in different orders it does not matter, because link::#.valueEnvir:: looks them up in the environment.
+Now here is how this can be used with an instrument function. Environments allow you to define instruments without having to worry about argument ordering conflicts. Even though the three functions below have the freq, amp and pan args declared in different orders it does not matter, because link::#valueEnvir:: looks them up in the environment.
 code::
 s.boot;
 
@@ -201,7 +201,7 @@ code::
 e = (a: "got it", f: { { ~a.postln }.defer(0.5) });
 e.use { e.f };
 ::
-link::Classes/Function#inEnvir#Function's inEnvir:: method attaches a function to a specific environment. If no environment is given, the current environment at the time of executing inEnvir is the default.
+link::Classes/Function#-inEnvir#Function's inEnvir:: method attaches a function to a specific environment. If no environment is given, the current environment at the time of executing inEnvir is the default.
 code::
 e = (a: "got it", f: { { ~a.postln }.inEnvir.defer(0.5) });
 e.use { e.f };
@@ -252,7 +252,7 @@ code::
 e.mul2 = { |z| z.someVariable * 2 };
 e.mul2;
 ::
-Environment variables inside a function will refer to the currently active environment -- not to the Environment being addressed. This is to allow the object prototype to interact with the link::#.currentEnvironment::.
+Environment variables inside a function will refer to the currently active environment -- not to the Environment being addressed. This is to allow the object prototype to interact with the link::#currentEnvironment::.
 code::
 e.mul2 = { |z| ~someVariable * 2 };
 // this will throw an error because ~someVariable is nil in the currentEnvironment

--- a/HelpSource/Classes/Event.schelp
+++ b/HelpSource/Classes/Event.schelp
@@ -45,7 +45,7 @@ argument::know
 If strong::know:: is set to link::Classes/True::, the event will respond to appropriate message calls. See link::Classes/Environment:: for more details.
 
 method::default
-Returns an empty event with link::#.defaultParentEvent:: as parent.
+Returns an empty event with link::#defaultParentEvent:: as parent.
 
 method::silent
 Returns an event that describes a pause of strong::dur:: duration.
@@ -231,13 +231,13 @@ q.y;			// [ 100, 200, 300 ]
 
 subsection::Event for specifying different things to happen
 
-Event provides a link::#.defaultParentEvent:: that defines a variety of different event types and provides a complete set of default key/value pairs for each type. The type is determined by the value of the key strong::\type:: which defaults to strong::\note::. Note events create synths on the server.
+Event provides a link::#defaultParentEvent:: that defines a variety of different event types and provides a complete set of default key/value pairs for each type. The type is determined by the value of the key strong::\type:: which defaults to strong::\note::. Note events create synths on the server.
 code::
 ( ).play;			// the default note
 (freq: 500, pan: -1) .play;	// 500 Hz, panned left
 (play: { ~what.postln }, what: "hello happening").play;	// something else
 ::
-Per default, the play message derives its behaviour from the link::#.defaultParentEvent::, which provides many default values, such as default instrument (\default), note (0), legato (0.8) and so on. Depending on the event type, these may differ completely and need not even represent a sound.
+Per default, the play message derives its behaviour from the link::#defaultParentEvent::, which provides many default values, such as default instrument (\default), note (0), legato (0.8) and so on. Depending on the event type, these may differ completely and need not even represent a sound.
 
 subsection::Events and SynthDefs
 
@@ -349,7 +349,7 @@ Pbind(
 )
 ::
 
-Here is an example that illustrates some more of the keys defined by the link::#.defaultParentEvent::. Note that it is equivalent to write code::Pbind(\key, val, ...):: and code::Pbind(*[key: val, ...])::.
+Here is an example that illustrates some more of the keys defined by the link::#defaultParentEvent::. Note that it is equivalent to write code::Pbind(\key, val, ...):: and code::Pbind(*[key: val, ...])::.
 code::
 (
 Pbind(*[
@@ -380,7 +380,7 @@ play {
 	this.use { ~play.value };
 }
 ::
-Thus we can see that the link::#.defaultParentEvent:: is used unless otherwise specified and the function stored in code::~play:: is executed in the context of the Event. It can be replaced in a given event for different behavior:
+Thus we can see that the link::#defaultParentEvent:: is used unless otherwise specified and the function stored in code::~play:: is executed in the context of the Event. It can be replaced in a given event for different behavior:
 code::
 (a: 6, b: 7, play: { (~a * ~b).postln }).play;
 ::

--- a/HelpSource/Classes/LID.schelp
+++ b/HelpSource/Classes/LID.schelp
@@ -118,7 +118,7 @@ LID.findBy( 2, 10, "/dev/input/event4", 0x0000, 'synaptics-pt/serio0/input0' )
 SUBSECTION:: Opening devices
 
 METHOD:: open
-Open a device with a given vendorID and product ID. For arguments description see link::#findBy::.
+Open a device with a given vendorID and product ID. For arguments description see link::#*findBy::.
 The method will call the method code::findBy:: and use the first available result as the device to open.
 
 returns:: The LID device - an instance of code::LID::.
@@ -243,7 +243,7 @@ LID.register('Logitech WingMan RumblePad', (
 
 
 METHOD:: register
-This will register the spec for the specified device. If the device was opened and did not use the spec before, it will use this spec. See also link::Classes/LID#spec::.
+This will register the spec for the specified device. If the device was opened and did not use the spec before, it will use this spec. See also link::Classes/LID#*specs::.
 
 ARGUMENT:: name
 The name of the device to register it for.

--- a/HelpSource/Classes/MIDIFunc.schelp
+++ b/HelpSource/Classes/MIDIFunc.schelp
@@ -93,7 +93,7 @@ A convenience method to create a new MIDIFunc which responds to MIDI smpte messa
 returns:: A new instance of MIDIFunc which responds to MIDI smpte messages.
 
 METHOD:: mtcQuarterFrame
-A convenience method to create a new MIDIFunc which responds to MIDI Time Code Quarter Frame messages. Note that the link::#smpte:: method above automatically assembles quarter frames into time code. See link::#*new:: for argument descriptions. The responding code::func:: will be passed the arguments data, srcID, and pieceNumber. You will need to manually assemble each 8 messages into smpte.
+A convenience method to create a new MIDIFunc which responds to MIDI Time Code Quarter Frame messages. Note that the link::#*smpte:: method above automatically assembles quarter frames into time code. See link::#*new:: for argument descriptions. The responding code::func:: will be passed the arguments data, srcID, and pieceNumber. You will need to manually assemble each 8 messages into smpte.
 
 returns:: A new instance of MIDIFunc which responds to MIDI Time Code Quarter Frame messages.
 

--- a/HelpSource/Classes/MIDIdef.schelp
+++ b/HelpSource/Classes/MIDIdef.schelp
@@ -99,7 +99,7 @@ A convenience method to create a new MIDIdef which responds to MIDI smpte messag
 returns:: A new instance of MIDIdef which responds to MIDI smpte messages.
 
 METHOD:: mtcQuarterFrame
-A convenience method to create a new MIDIdef which responds to MIDI Time Code Quarter Frame messages. Note that the link::#smpte:: method above automatically assembles quarter frames into time code. See link::#*new:: for argument descriptions. The responding code::func:: will be passed the arguments data, srcID, and pieceNumber. You will need to manually assemble each 8 messages into smpte.
+A convenience method to create a new MIDIdef which responds to MIDI Time Code Quarter Frame messages. Note that the link::#*smpte:: method above automatically assembles quarter frames into time code. See link::#*new:: for argument descriptions. The responding code::func:: will be passed the arguments data, srcID, and pieceNumber. You will need to manually assemble each 8 messages into smpte.
 
 returns:: A new instance of MIDIdef which responds to MIDI Time Code Quarter Frame messages.
 

--- a/HelpSource/Classes/Monitor.schelp
+++ b/HelpSource/Classes/Monitor.schelp
@@ -4,7 +4,7 @@ categories:: JITLib>NodeProxy, Live Coding
 related:: Reference/playN, Classes/NodeProxy, Classes/Bus
 
 description::
-A general purpose class for monitoring or crosslinking between busses. It supports multichannel expansion and crossfading between settings. It provides optimizations for playing contiguous channels to other contiguous busses (link::#play::) and for more complex routings, such as splitting, spreading etc to multiple channels (link::#playN::). Monitor uses the existing set of  link::Classes/SystemSynthDefs:: to do this.
+A general purpose class for monitoring or crosslinking between busses. It supports multichannel expansion and crossfading between settings. It provides optimizations for playing contiguous channels to other contiguous busses (link::#-play::) and for more complex routings, such as splitting, spreading etc to multiple channels (link::#-playN::). Monitor uses the existing set of link::Classes/SystemSynthDefs:: to do this.
 
 code::
 { Out.ar(87, SinOsc.ar(MouseX.kr(240, 1000, 1) * [1, 2, 3], 0, 0.2)) }.play; // play three sine tone on channels 87, 88, and 89
@@ -185,7 +185,7 @@ method::numChannels
 Return the number of input channels.
 
 method::copy
-Return a copy of the receiver, with the same channel setting, but not running. You can run it with the settings by sending it the link::#play:: message, and pass in any modifications you want to make.
+Return a copy of the receiver, with the same channel setting, but not running. You can run it with the settings by sending it the link::#-play:: message, and pass in any modifications you want to make.
 
 
 method::playToBundle

--- a/HelpSource/Classes/Pair.schelp
+++ b/HelpSource/Classes/Pair.schelp
@@ -35,10 +35,10 @@ Traverse
 Same like: link::#-depthFirstPreOrderTraversal::
 
 method::depthFirstPreOrderTraversal
-Traverse the data structure first link down, then across (see link::#Examples::).
+Traverse the data structure first link down, then across (see link::#examples::).
 
 method::depthFirstPostOrderTraversal
-Traverse the data structure from bottom up (see link::#Examples::).
+Traverse the data structure from bottom up (see link::#examples::).
 
 EXAMPLES::
 

--- a/HelpSource/Classes/Pspawn.schelp
+++ b/HelpSource/Classes/Pspawn.schelp
@@ -20,7 +20,7 @@ definitionList::
 ::
 ::
 
-Of these, only the child events are returned to the event stream player during play. The parent events are used strictly internally to control spawning behavior. The parent and child event streams do not mix together. Thus pattern composition ( link::Classes/Pchain:: ) and parallelization ( link::Classes/Ppar:: ) may be used without special handling. It is up to the user to be aware of whether the parent or child stream should be subject to further manipulation, and put that manipulation in the right place. If it is to affect the child stream, it should enclose the entire Pspawn; for the parent stream, it should be inside Pspawn. (See the link::#Examples:: below.)
+Of these, only the child events are returned to the event stream player during play. The parent events are used strictly internally to control spawning behavior. The parent and child event streams do not mix together. Thus pattern composition ( link::Classes/Pchain:: ) and parallelization ( link::Classes/Ppar:: ) may be used without special handling. It is up to the user to be aware of whether the parent or child stream should be subject to further manipulation, and put that manipulation in the right place. If it is to affect the child stream, it should enclose the entire Pspawn; for the parent stream, it should be inside Pspawn. (See the link::#examples:: below.)
 
 Pspawn uses the following items in the parent pattern:
 definitionList::

--- a/HelpSource/Classes/SCImageKernel.schelp
+++ b/HelpSource/Classes/SCImageKernel.schelp
@@ -42,7 +42,7 @@ METHOD::shader
 get or set the shader string.
 
 METHOD::values
-get or set the values array. When setting the object indexes in the values Array must match the argument declaration order as defined in the main emphasis::kernel vec4 routine::. See link::#Examples:: for more info.
+get or set the values array. When setting the object indexes in the values Array must match the argument declaration order as defined in the main emphasis::kernel vec4 routine::. See link::#examples:: for more info.
 
 METHOD::isValid
 very basic verification to tell if all arguments of the shader are set.

--- a/HelpSource/Classes/Thread.schelp
+++ b/HelpSource/Classes/Thread.schelp
@@ -25,7 +25,7 @@ When code on a Thread starts or resumes another Thread (Routine), the former Thr
 becomes the latter's strong::parent::, and the latter its strong::child::. The parent
 Thread's execution is strong::blocked:: until the child Thread finishes or is suspended,
 at which point the parent Thread continues execution. The strong::current:: Thread may be
-accessed using link::#.thisThread#thisThread::, while a Thread's parent may be accessed
+accessed using link::#thisThread::, while a Thread's parent may be accessed
 using link::#-parent::.
 
 A Thread has

--- a/HelpSource/Classes/UserView.schelp
+++ b/HelpSource/Classes/UserView.schelp
@@ -10,7 +10,7 @@ This view displays and does nothing by itself, but allows you to define how it w
 
 To define how the view is drawn you set the link::#-drawFunc:: variable to a link::Classes/Function:: within which you can use the link::Classes/Pen:: class to draw graphical primitives, such as lines, rectangles, ellipses, curves, and also text.
 
-This class offers convenient mechanisms for creating animations, that is, to automatically redraw itself in regular time intervals. See the link::#animation#Animation:: section of this document.
+This class offers convenient mechanisms for creating animations, that is, to automatically redraw itself in regular time intervals. See the link::#Animation:: section of this document.
 
 For a guide to using this view, see link::Guides/GUI-Introduction#Custom views::.
 
@@ -105,7 +105,7 @@ METHOD:: frame
 
 SUBSECTION:: Actions
 
-	The UserView by itself does not respond to any interaction by the user. You can define the modes of interaction entirely on your own using mouse and keyboard actions. See link::Guides/GUI-Introduction#Actions and hooks: make that button do something!#Actions and Hooks:: for detailed explanation.
+	The UserView by itself does not respond to any interaction by the user. You can define the modes of interaction entirely on your own using mouse and keyboard actions. See link::Guides/GUI-Introduction#Actions and hooks: Make that button do something!#Actions and Hooks:: for detailed explanation.
 
 	Note that there is no default mode of interaction with the UserView, so link::Classes/View#-action:: will never be triggered, if you don't implement that yourself.
 

--- a/HelpSource/Classes/View.schelp
+++ b/HelpSource/Classes/View.schelp
@@ -259,7 +259,7 @@ METHOD:: resizeToBounds
 
 METHOD:: resizeToHint
 
-	Resizes view to the bounds returned by link::#sizeHint::.
+	Resizes view to the bounds returned by link::#-sizeHint::.
 
 METHOD:: resize
 	Determines what happens with the view's position and size when its parent is resized. See link::Guides/GUI-Introduction#view:: for further explanation.

--- a/HelpSource/Overviews/Operators.schelp
+++ b/HelpSource/Overviews/Operators.schelp
@@ -521,12 +521,12 @@ abs(x) + abs(y) - ((sqrt(2) - 1) * min(abs(x), abs(y)))
 hypotApx is used to implement Complex method magnitudeApx.
 This should not be used for simulating a doppler shift because it is discontinuous. Use hypot.
 
-See also link::#.hypot::, link::#.atan2::.
+See also link::#hypot::, link::#atan2::.
 
 method:: atan2
 Returns the arctangent of y/x.
 discussion::
-OK, now we can add a pan to the link::#.hypot:: doppler examples by using atan2 to find the azimuth,
+OK, now we can add a pan to the link::#hypot:: doppler examples by using atan2 to find the azimuth,
 or direction angle, of the sound source.
 Assume speakers at +/- 45 degrees and clip the direction to between those.
 code::
@@ -569,7 +569,7 @@ discussion::
 Return the value of  ((a*b) + a). This is more efficient than using
 separate unit generators for the multiply and add.
 
-See also link::#.*::, link::#.ring1::, link::#.ring2::, link::#.ring3::, link::#.ring4::.
+See also link::#*::, link::#ring1::, link::#ring2::, link::#ring3::, link::#ring4::.
 code::
 { (FSinOsc.ar(800) ring1: FSinOsc.ar(XLine.kr(200,500,5))) * 0.125 }.play;
 ::

--- a/HelpSource/Tutorials/Mark_Polishook_tutorial/17_Delays_reverbs.schelp
+++ b/HelpSource/Tutorials/Mark_Polishook_tutorial/17_Delays_reverbs.schelp
@@ -131,7 +131,7 @@ code::
 
 section::Reverberation
 
-The next example is by James McCartney. It comes from the link::#Why Supercollider 2.0?#01 Why SuperCollider:: document that was part of the SuperCollider2 distribution.
+The next example is by James McCartney. It comes from the emphasis::Why Supercollider 2.0?:: document that was part of the SuperCollider2 distribution.
 
 The example is more or less a Schroeder reverb - a signal passed through a parallel bank of comb filters which then pass through a series of allpass filters.
 


### PR DESCRIPTION
2nd try. restarted from scratch. previous PR https://github.com/supercollider/supercollider/pull/4227 lost trying to rebase onto 3.10

Purpose and Motivation
----------------------

used a regexp script and found many helpfiles that had broken links - mainly for instance methods but also a few class methods and section links.
all changes tested manually and confirmed to work.

```supercollider
.findAllRegexp(" link::#[^-*]*::");
```