### PR TITLE
CONTRIBUTING.md: correct URIs of `git remote -v` output

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -121,8 +121,8 @@ In order to keep your fork up-to-date, you need to point it to the main SuperCol
 
 			origin	https://github.com/your-name/supercollider.git (fetch)
 			origin	https://github.com/your-name/supercollider.git (push)
-			upstream	https://github.com/supercollider/supercollider (fetch)
-			upstream	https://github.com/supercollider/supercollider (push)
+			upstream	https://github.com/supercollider/supercollider.git (fetch)
+			upstream	https://github.com/supercollider/supercollider.git (push)
 
 	- You can now proceed to update your fork.
 - If you've already added the `upstream` remote, you can update your fork by doing the following:


### PR DESCRIPTION
Purpose and Motivation
----------------------
while `git clone ...` and `git remote add upstream ...` work both with and without the extension `.git`, the output of `git remote -v` reflects the state of the repo's originally given URI (w/ or w/o `.git`).
In this doc `git remote add upstream ...` was issued w/ `.git` at the end of the URI.

Types of changes
----------------
- Documentation (non-code change which corrects or adds documentation for existing features)
- [X] This PR is ready for review
