### PR TITLE
travis macos: don't update brew, fix build error

### DIFF
--- a/.travis/before-install-osx.sh
+++ b/.travis/before-install-osx.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-export BREW_NO_AUTO_UPDATE=1
-export BREW_NO_ANALYTICS=1
+export HOMEBREW_NO_AUTO_UPDATE=1
+export HOMEBREW_NO_ANALYTICS=1
 
 # according to https://docs.travis-ci.com/user/caching#ccache-cache
 brew install ccache

--- a/.travis/script-osx.sh
+++ b/.travis/script-osx.sh
@@ -10,4 +10,9 @@ cmake --build $TRAVIS_BUILD_DIR/BUILD --config Release --target install | tee $B
 CMAKE_EXIT=$?
 set +o pipefail
 
+if [[ $CMAKE_EXIT != 0 ]]; then
+    echo "Build failed. Log:"
+    cat $BUILD_LOG
+fi
+
 exit $CMAKE_EXIT


### PR DESCRIPTION
Purpose and Motivation
----------------------

latest version of travis seems to be barfing when trying to install
ccache. dunno why, but either way forcing homebrew not to update seems
to fix it. we intended to do this anyway but mistyped the environment
variable names! this shaves quite a bit of time off the build.

also cat the un-xcpretty'd build log when there's a failure, which in this case would
have helped to diagnose the problem more quickly.