### PR TITLE
both servers have 8 default in/out channels

### DIFF
--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -130,10 +130,12 @@ ServerOptions {
 			numControlBusChannels = numControlBusChannels.asInteger;
 			o = o ++ " -c " ++ numControlBusChannels;
 		});
-		if (numInputBusChannels != defaultValues[\numInputBusChannels], {
+		// scsynth and supernova default to 8 input channels
+		if (numInputBusChannels != 8, {
 			o = o ++ " -i " ++ numInputBusChannels;
 		});
-		if (numOutputBusChannels != defaultValues[\numOutputBusChannels], {
+		// scsynth and supernova default to 8 output channels
+		if (numOutputBusChannels != 8, {
 			o = o ++ " -o " ++ numOutputBusChannels;
 		});
 		if (numBuffers !== defaultValues[\numBuffers], {


### PR DESCRIPTION
<!--- Hi, and thanks for contributing! -->
<!--- Make sure to provide a general summary of your changes in the title above. -->
<!--- For example: "[scsynth] Fix crash when encountering cute kittens" -->

Purpose and Motivation
----------------------

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to it here by writing "Fixes #555". -->

Fixes #4250 

Some changes made in #4110 need to be reverted. We have two competing default in/out channel numbers. ServerOptions says 2, but in reality scsynth and supernova default to 8. We need to check `ServerOptions.numOutpuBusChannel` (and the equivalent for In) against 8, not 2.

Types of changes
----------------

<!--- What types of changes does your pull request introduce? -->
<!--- Some examples are below (you can delete the lines that don't apply): -->

- Bug fix (non-breaking change which fixes an issue)

Checklist
---------

<!--- Complete an item by checking it: [x] -->

- [ ] All previous tests are passing
- [ ] Tests were updated or created to address changes in this PR, and tests are passing
- [ ] Updated documentation, if necessary
- [X] This PR is ready for review

<!--- See DEVELOPING.md for instructions on running and writing tests. -->

Remaining Work
--------------

<!--- If any work remains to be done, please give a brief description here. -->
<!--- Consider providing a todo-list so we can easily track completion progress. -->

<!--- Thanks for contributing! -->
