### PR TITLE
sclang: fix resolveIfAlias [skip appveyor]

### DIFF
--- a/testsuite/classlibrary/TestString.sc
+++ b/testsuite/classlibrary/TestString.sc
@@ -94,6 +94,27 @@ TestString : UnitTest {
 		this.assertEquals("dir" +/+ 'file', "dir%file".format(sep));
 	}
 
+	// regression tests for #4252
+	test_standardizePath_withTrailingSlash_shouldNotRemove {
+		var result = "~/".standardizePath;
+		var expected = "~".standardizePath ++ "/";
+		this.assertEquals(result, expected);
+	}
+
+	test_standardizePath_withTwoTrailingSlashes_shouldNotRemove {
+		var result = "~//".standardizePath;
+		var expected = "~".standardizePath ++ "//";
+		this.assertEquals(result, expected);
+	}
+
+	test_standardizePath_tilde_expandsToHome {
+		var result = "~".standardizePath;
+		var expected = Platform.userHomeDir;
+		this.assertEquals(result, expected);
+	}
+
+	// ------- time-related operations -----------------------------------------------
+
 	test_asSecs_stringDddHhMmSsSss_convertsToSeconds {
 		var result = "001:01:01:01.001".asSecs;
 		var expected = 90061.001;


### PR DESCRIPTION
Purpose and Motivation
----------------------

Fixes #4252, and adds regression tests.

I'm really not happy with how complex this code has grown to be for
something that should be so trivial to check with macOS's filesystem.

Types of changes
----------------

- Bug fix (non-breaking change which fixes an issue)

Checklist
---------

- [x] All tests are passing
- [x] If necessary, new tests were created to address changes in PR, and tests are passing
- [x] Updated documentation, if necessary
- [x] This PR is ready for review

TestString passes on macOS.