### PR TITLE
Topic/tempo clock is running

### DIFF
--- a/HelpSource/Classes/TempoClock.schelp
+++ b/HelpSource/Classes/TempoClock.schelp
@@ -93,6 +93,7 @@ method:: bars2beats
 method:: bar
 method:: nextBar
 method:: beatInBar
+method:: isRunning
 
 INSTANCEMETHODS::
 
@@ -103,6 +104,9 @@ Destroys the scheduler and releases the OS thread running the scheduler.
 
 method::clear
 Removes all tasks from the scheduling queue.
+
+method::isRunning
+returns:: A Boolean, true if the clock is active or false if the clock has been stopped.
 
 method::tempo
 Sets or gets the current tempo in beats per second at the current strong::logical time::.

--- a/SCClassLibrary/Common/Core/Clock.sc
+++ b/SCClassLibrary/Common/Core/Clock.sc
@@ -330,7 +330,6 @@ elapsed time is whatever the system clock says it is right now. elapsed time is 
 	}
 
 	isRunning { ^ptr.notNil }
-	*isRunning { ^this.default.isRunning }
 
 	// PRIVATE
 	prStart { arg tempo, beats, seconds;
@@ -395,6 +394,8 @@ elapsed time is whatever the system clock says it is right now. elapsed time is 
 	*bar { ^TempoClock.default.bar  }
 	*nextBar { | beat | ^TempoClock.default.nextBar(beat)  }
 	*beatInBar { ^TempoClock.default.beatInBar  }
+
+	*isRunning { ^this.default.isRunning }
 
 	archiveAsCompileString { ^true }
 }

--- a/SCClassLibrary/Common/Core/Clock.sc
+++ b/SCClassLibrary/Common/Core/Clock.sc
@@ -329,6 +329,9 @@ elapsed time is whatever the system clock says it is right now. elapsed time is 
 		^this.beats - this.bars2beats(this.bar)
 	}
 
+	isRunning { ^ptr.notNil }
+	*isRunning { ^this.default.isRunning }
+
 	// PRIVATE
 	prStart { arg tempo, beats, seconds;
 		_TempoClock_New

--- a/testsuite/classlibrary/TestTempoClock.sc
+++ b/testsuite/classlibrary/TestTempoClock.sc
@@ -1,0 +1,94 @@
+TestTempoClock : UnitTest {
+	var clock;
+
+	setUp {
+		clock = TempoClock.new(1000);
+	}
+
+	// called after each test
+	tearDown {
+		clock.stop;
+	}
+
+	test_isRunning {
+		var beforeStop = clock.isRunning, afterStop;
+		clock.stop;
+		afterStop = clock.isRunning;
+		this.assert(beforeStop and: { afterStop.not }, "TempoClock:isRunning should be true before 'stop', and false afterward");
+	}
+
+	test_afterStop_isRemovedFromAll {
+		clock.stop;
+		this.assert(TempoClock.all.includes(clock).not, "TempoClock.all should not contain a stopped instance");
+	}
+
+	test_threadWait_advancesCorrectTime {
+		var now = SystemClock.seconds, then, cond = Condition.new;
+		{
+			1.wait;
+			then = SystemClock.seconds;
+			cond.unhang;
+		}.fork(clock);
+		cond.hang;
+		// note: floating point math, == is not safe
+		this.assert((then - now absdif: 0.001) < 1e-10, "TempoClock 1000 beats/sec, 1 beat should be 0.001 seconds");
+	}
+
+	test_beats2secs_validConversion {
+		this.assert(
+			clock.beats2secs(clock.beats + 1) - SystemClock.seconds absdif: 0.001 < 1e-10,
+			"TempoClock 1000 beats/sec, 'beats2secs' for now + 1 beat should be 0.001 seconds later"
+		)
+	}
+
+	test_secs2beats_validConversion {
+		this.assert(
+			clock.secs2beats(SystemClock.seconds + 1) - clock.beats absdif: 1000.0 < 1e-10,
+			"TempoClock 1000 beats/sec, 'secs2beats' for now + 1 second should be 1000 beats later"
+		)
+	}
+
+	test_defaultMeter_unchanged {
+		this.assert(
+			clock.beatsPerBar == 4,
+			"A new TempoClock should have 4 beats per bar by default"
+		)
+	}
+
+	test_nextTimeOnGrid_okAfterMeterChange {
+		// formally you should change meter only on a barline
+		// at 1000 bps that is 0.004 sec later, so... ok.
+		var cond = Condition.new;
+		{
+			clock.beatsPerBar.wait;
+			clock.beatsPerBar = 3;
+			0.1.wait;  // must tick past the barline
+			cond.unhang;
+		}.fork(clock);
+		cond.hang;
+		this.assertEquals(
+			clock.nextTimeOnGrid(-1), 7.0,
+			"Set meter to 3/4, at beat 4, next barline should be 7.0"
+		);
+	}
+
+	test_nextTimeOnGrid_addsPhaseCorrectly {
+		this.assertEquals(
+			clock.nextTimeOnGrid(1, 0.5), 0.5,
+			"nextTimeOnGrid(1, 0.5) at beat 0 should be 0.5"
+		)
+	}
+
+	test_nextTimeOnGrid_negativePhaseWraps {
+		var cond = Condition.new;
+		{
+			0.5.wait;
+			cond.unhang;
+		}.fork(clock);
+		cond.hang;
+		this.assertEquals(
+			clock.nextTimeOnGrid(1, -0.9), 1.1,
+			"nextTimeOnGrid(1, -0.9) at beat 0.5 should wrap up to 1.1"
+		)
+	}
+}


### PR DESCRIPTION
Purpose and Motivation
----------------------

It's kind of a no-brainer to be able to ask a TempoClock if it's still running -- it might have been stopped, but in the main class library as it is now, you have no way to know, except to try to schedule something on it and catch an error (!).

So I propose a very simple `isRunning` method. Actually, I've had this in my extensions for years. It works.

Plus documentation.

Plus a unit test... but then I thought, there are some other things about TempoClock (correct rate of advancing through time, handling of meter changes) that are probably not tested anywhere else. So I added a bunch of other useful tests.

Types of changes
----------------

- Documentation (non-code change which corrects or adds documentation for existing features)
- New feature (non-breaking change which adds functionality)

Checklist
---------

- [x] All previous tests are passing (well, I did try to run the entire test suite, but TestUGen_Duty locked up the system and forced me to hard reboot... so to be completely honest, I don't know, but I don't think that's the fault of this PR)
- [x] Tests were updated or created to address changes in this PR, and tests are passing
- [x] Updated documentation, if necessary
- [x] This PR is ready for review
