### PR TITLE
sclang: fix string/symbol lexing

### DIFF
--- a/lang/LangSource/PyrLexer.cpp
+++ b/lang/LangSource/PyrLexer.cpp
@@ -1375,7 +1375,7 @@ symbol3 : {
 		do {
 			c = input0();
 			if (c == '\\') {
-				c = input0();
+				input0();
 			}
 		} while (c != endchar && c != 0);
 		if (c == 0) {
@@ -1394,7 +1394,7 @@ string1 : {
 		do  {
 			c = input0();
 			if (c == '\\') {
-				c = input0();
+				input0();
 			}
 		} while (c != endchar && c != 0);
 		if (c == 0) {


### PR DESCRIPTION
Purpose and Motivation
----------------------

fixes #3352; previously would cause bad behavior with escaped double quotes
inside strings and escaped single quotes inside symbols.

what is essentially happening is that there are two separate lexing
routines - one that lexes individual tokens, and one that performs a
fast look-ahead to find a closing bracket. this bug is in the latter.

when lexing a line like:

```supercollider
"\"".cs
```

the lookahead lexer routine starts at the first double quote, then
considers the second double quote (the escaped one) to be the end of the
string. then the third double quote is considered the opening of a new
string. however, the normal lexing routine doesn't have this bug, so it
can still succeed.

Types of changes
----------------

- Bug fix (non-breaking change which fixes an issue)

Checklist
---------

- [x] All tests are passing - there is really not a great way to test this at the moment. I can run
the regression test suite I wrote but it's not exhaustive, so probably
beta testing is the best way to get this tested.
- [x] This PR is ready for review

Remaining Work
--------------

- [x] run regression test suite