### PR TITLE
scide: Find an open port for WebSocket communication with SCDoc rather than hardcoding port 12344

### DIFF
--- a/HelpSource/editor.js
+++ b/HelpSource/editor.js
@@ -60,6 +60,10 @@ const init = () => {
 }
 
 const evalLine = () => {
+    // If we are not running in the SC IDE, do nothing.
+    if (!window.IDE) {
+        return;
+    }
     // Ask IDE to eval line. Calls back to `selectLine()`
     window.IDE.evaluateLine();
 }

--- a/HelpSource/scdoc.js
+++ b/HelpSource/scdoc.js
@@ -198,8 +198,13 @@ function fixTOC() {
 // Set up a QWebChannel for communicating with C++ IDE objects. The main app publishes a handle
 // to IDE functionality at "IDE" which is made globally available here after the page and
 // WebSocket have loaded.
-function setUpWebChannel() {
-    var baseUrl = "ws://localhost:12344";
+
+// This function is called by the IDE, and will not be called otherwise.
+function setUpWebChannel(port) {
+    if (typeof QWebChannel === "undefined") {
+        return;
+    }
+    var baseUrl = `ws://localhost:${port}`;
     var socket = new WebSocket(baseUrl);
     socket.onclose = function() { };
     socket.onerror = function(error) {
@@ -212,10 +217,3 @@ function setUpWebChannel() {
         });
     }
 }
-
-$(function () {
-    // Check that webchannel.js was loaded
-    if(typeof QWebChannel !== "undefined") {
-        setUpWebChannel();
-    }
-});

--- a/editors/sc-ide/core/main.cpp
+++ b/editors/sc-ide/core/main.cpp
@@ -43,12 +43,7 @@
 #include <QDebug>
 #include <QStyleFactory>
 
-#ifdef SC_USE_QTWEBENGINE
-#    include <QWebChannel>
-#    include "../widgets/util/WebSocketClientWrapper.hpp"
-#    include "../widgets/util/WebSocketTransport.hpp"
-#    include "../widgets/util/IDEWebChannelWrapper.hpp"
-#endif // SC_USE_QTWEBENGINE
+#include "util/HelpBrowserWebSocketServices.hpp"
 
 using namespace ScIDE;
 
@@ -132,26 +127,10 @@ int main(int argc, char* argv[]) {
         main->scProcess()->startLanguage();
 
 #ifdef SC_USE_QTWEBENGINE
-    // setup HelpBrowser server
-    QWebSocketServer server("SCIDE HelpBrowser Server", QWebSocketServer::NonSecureMode);
-    if (!server.listen(QHostAddress::LocalHost, 12344)) {
-        qFatal("Failed to open web socket server.");
-        return 1;
-    }
-
-    // setup comm channel
-    WebSocketClientWrapper clientWrapper(&server);
-    QWebChannel channel;
-    QObject::connect(&clientWrapper, &WebSocketClientWrapper::clientConnected, &channel, &QWebChannel::connectTo);
-
-    // publish IDE interface
-    IDEWebChannelWrapper ideWrapper { win->helpBrowserDocklet()->browser() };
-    channel.registerObject("IDE", &ideWrapper);
-#endif // SC_USE_QTWEBENGINE
-
-    return app.exec();
+    HelpBrowserWebSocketServices hbServices(win->helpBrowserDocklet()->browser());
+#endif
+    app.exec();
 }
-
 
 bool SingleInstanceGuard::tryConnect(QStringList const& arguments) {
     const int maxNumberOfInstances = 128;

--- a/editors/sc-ide/core/util/HelpBrowserWebSocketServices.hpp
+++ b/editors/sc-ide/core/util/HelpBrowserWebSocketServices.hpp
@@ -1,0 +1,53 @@
+#pragma once
+
+#ifdef SC_USE_QTWEBENGINE
+#    include <QWebChannel>
+#    include "../../widgets/util/WebSocketClientWrapper.hpp"
+#    include "../../widgets/util/WebSocketTransport.hpp"
+#    include "../../widgets/util/IDEWebChannelWrapper.hpp"
+
+namespace ScIDE {
+
+/** RAII class to encapsulate websocket services needed by the help browser.
+ */
+class HelpBrowserWebSocketServices {
+public:
+    HelpBrowserWebSocketServices(HelpBrowser* browser) {
+        m_server = new QWebSocketServer("SCIDE HelpBrowser Server", QWebSocketServer::NonSecureMode);
+        if (m_server->listen(QHostAddress::LocalHost)) {
+            browser->setServerPort(m_server->serverPort());
+
+            // setup comm channel
+            m_clientWrapper = new WebSocketClientWrapper(m_server);
+            m_channel = new QWebChannel();
+            QObject::connect(m_clientWrapper, &WebSocketClientWrapper::clientConnected, m_channel,
+                             &QWebChannel::connectTo);
+
+            // publish IDE interface
+            m_ideWrapper = new IDEWebChannelWrapper(browser);
+            m_channel->registerObject("IDE", m_ideWrapper);
+        } else {
+            qWarning("Failed to set up help browser web socket.");
+            // [don't take up heap space with a useless object]
+            delete m_server;
+            m_server = nullptr;
+        }
+    }
+
+    ~HelpBrowserWebSocketServices() {
+        delete m_server;
+        delete m_clientWrapper;
+        delete m_channel;
+        delete m_ideWrapper;
+    }
+
+private:
+    QWebSocketServer* m_server; // non-null only if server listens successfully
+    WebSocketClientWrapper* m_clientWrapper;
+    QWebChannel* m_channel;
+    IDEWebChannelWrapper* m_ideWrapper;
+};
+
+} // namespace ScIDE
+
+#endif // SC_USE_QTWEBENGINE

--- a/editors/sc-ide/widgets/help_browser.cpp
+++ b/editors/sc-ide/widgets/help_browser.cpp
@@ -113,6 +113,12 @@ HelpBrowser::HelpBrowser(QWidget* parent): QWidget(parent) {
     setFocusProxy(mWebView);
 }
 
+void HelpBrowser::onPageLoad() {
+    if (mServerPort) {
+        mWebView->page()->runJavaScript(QString("setUpWebChannel(%1)").arg(mServerPort));
+    }
+}
+
 void HelpBrowser::createActions() {
     QAction* action;
     OverridingAction* ovrAction;

--- a/editors/sc-ide/widgets/help_browser.hpp
+++ b/editors/sc-ide/widgets/help_browser.hpp
@@ -113,6 +113,8 @@ public:
 
     bool helpBrowserHasFocus() const;
 
+    void setServerPort(int serverPort) { mServerPort = serverPort; };
+
 public slots:
     void applySettings(Settings::Manager*);
     void goHome();
@@ -127,6 +129,7 @@ public slots:
     void openCommandLine();
     void findReferences();
     void onLinkClicked(const QUrl&, QWebEnginePage::NavigationType type, bool isMainFrame);
+    void onPageLoad();
 
 signals:
     void urlChanged();
@@ -151,6 +154,8 @@ private:
     QSize mSizeHint;
 
     QAction* mActions[ActionCount];
+
+    int mServerPort = 0; // if 0, server is not running
 };
 
 class HelpBrowserFindBox : public QLineEdit {


### PR DESCRIPTION
Purpose and Motivation
----------------------

fix #4177 and #4256 with the following changes:

- the web socket server finds an open port rather than hardcoding port 12344.
- if the web socket server setup fails, SCIDE still starts. i'm not sure it's good to allow multiple IDE's running, but the regression in 3.10 shouldn't have happened. there's no need for a failed web socket connection to be a fatal error!
- scdoc.js is smarter about recognizing whether it's in the IDE, and doesn't print errors.

Testing
-----

- if there is already an instance of SCIDE open, you should be able to open another SCIDE without the latter crashing at start.
- you should be able to run code from the help browser in any open instance of SCIDE.
- if you have SCIDE open and you fire up a command-line sclang and run `HelpBrowser()` at it, there should be no error about websockets in the command line. (a weird `QObject::connect` error will appear, which is a different bug unrelated to this PR.)
- SCIDE should compile and run fine even if SC_USE_QTWEBENGINE is off (`cmake -DSC_USE_QTWEBENGINE=OFF ..`).

Types of changes
----------------

- Bug fix (non-breaking change which fixes an issue)

Checklist
---------

<!--- Complete an item by checking it: [x] -->

- [x] Updated documentation, if necessary
- [x] This PR is ready for review

<!--- See DEVELOPING.md for instructions on running and writing tests. -->