### PR TITLE
scide: Fix missing icon

### DIFF
--- a/editors/sc-ide/core/main.cpp
+++ b/editors/sc-ide/core/main.cpp
@@ -98,8 +98,6 @@ int main( int argc, char *argv[] )
     // Go...
     MainWindow *win = new MainWindow(main);
 
-    app.setWindowIcon(QIcon("qrc:///icons/sc-ide-svg"));
-
     // NOTE: load session after GUI is created, so that GUI can respond
     Settings::Manager *settings = main->settings();
     SessionManager *sessions = main->sessionManager();

--- a/editors/sc-ide/widgets/main_window.cpp
+++ b/editors/sc-ide/widgets/main_window.cpp
@@ -227,16 +227,18 @@ MainWindow::MainWindow(Main * main) :
     updateRecentDocsMenu();
 
     QIcon icon;
-    icon.addFile(":/icons/sc-ide-svg");
-    icon.addFile(":/icons/sc-ide-16");
-    icon.addFile(":/icons/sc-ide-24");
-    icon.addFile(":/icons/sc-ide-32");
-    icon.addFile(":/icons/sc-ide-48");
-    icon.addFile(":/icons/sc-ide-64");
-    icon.addFile(":/icons/sc-ide-128");
-    icon.addFile(":/icons/sc-ide-256");
-    icon.addFile(":/icons/sc-ide-512");
-    icon.addFile(":/icons/sc-ide-1024");
+    // Unfortunately, the SVG icon shows up as a tiny dot on some Linux window
+    // managers (see #3905, #2646). Best we can do here is PNGs.
+    // icon.addFile(":icons/sc-ide-svg");
+    icon.addFile(":icons/sc-ide-16");
+    icon.addFile(":icons/sc-ide-24");
+    icon.addFile(":icons/sc-ide-32");
+    icon.addFile(":icons/sc-ide-48");
+    icon.addFile(":icons/sc-ide-64");
+    icon.addFile(":icons/sc-ide-128");
+    icon.addFile(":icons/sc-ide-256");
+    icon.addFile(":icons/sc-ide-512");
+    icon.addFile(":icons/sc-ide-1024");
     QApplication::setWindowIcon(icon);
 
     updateWindowTitle();


### PR DESCRIPTION
Purpose and Motivation
----------------------

fixes #3905 -- SCIDE is missing an icon. turns out it was something silly, the `QIcon` path should be `:icons/blah` rather than `:/icons/blah`.

unfortunately we can't use the svg icon because of #2646 (icon appears tiny on some linux DEs), so i just used the PNGs.

Types of changes
----------------
- Bug fix (non-breaking change which fixes an issue)

Checklist
---------

- [x] This PR is ready for review
