### PR TITLE
Shorten pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,12 +1,10 @@
 <!-- Please see CONTRIBUTING.md for guidelines. -->
 
-Purpose and Motivation
-----------------------
+## Purpose and Motivation
 
-Fixes #
+<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->
 
-Type of change
---------------
+## Types of changes
 
 <!-- Delete lines that don't apply -->
 
@@ -15,11 +13,9 @@ Type of change
 - New feature
 - Breaking change
 
-To-do list
-----------
+## To-do list
 
-<!-- Complete an item by checking it: [x] -->
-<!-- Delete lines that don't apply, add new entries to track your progress -->
+<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->
 
 - [ ] Code is tested
 - [ ] All tests are passing

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,40 +1,27 @@
-<!--- Hi, and thanks for contributing! -->
-<!--- Make sure to provide a general summary of your changes in the title above. -->
-<!--- For example: "[scsynth] Fix crash when encountering cute kittens" -->
+<!-- Please see CONTRIBUTING.md for guidelines. -->
 
 Purpose and Motivation
 ----------------------
 
-<!--- Why is this change required? What problem does it solve? -->
-<!--- If it fixes an open issue, please link to it here by writing "Fixes #555". -->
+Fixes #
 
-Types of changes
-----------------
-
-<!--- What types of changes does your pull request introduce? -->
-<!--- Some examples are below (you can delete the lines that don't apply): -->
-
-- Documentation (non-code change which corrects or adds documentation for existing features)
-- Bug fix (non-breaking change which fixes an issue)
-- New feature (non-breaking change which adds functionality)
-- Breaking change (fix or feature that would cause existing functionality to change)
-
-Checklist
----------
-
-<!--- Complete an item by checking it: [x] -->
-
-- [ ] All previous tests are passing
-- [ ] Tests were updated or created to address changes in this PR, and tests are passing
-- [ ] Updated documentation, if necessary
-- [ ] This PR is ready for review
-
-<!--- See DEVELOPING.md for instructions on running and writing tests. -->
-
-Remaining Work
+Type of change
 --------------
 
-<!--- If any work remains to be done, please give a brief description here. -->
-<!--- Consider providing a todo-list so we can easily track completion progress. -->
+<!-- Delete lines that don't apply -->
 
-<!--- Thanks for contributing! -->
+- Documentation
+- Bug fix
+- New feature
+- Breaking change
+
+To-do list
+----------
+
+<!-- Complete an item by checking it: [x] -->
+<!-- Delete lines that don't apply, add new entries to track your progress -->
+
+- [ ] Code is tested
+- [ ] All tests are passing
+- [ ] Updated documentation
+- [ ] This PR is ready for review


### PR DESCRIPTION
i've found that the PR template, while made with great intentions, is pretty awkward to use on a daily basis. there's too much text, and it's just kinda cluttered and overwhelming. i feel that it can be made way shorter, reducing it to just the gist of the process, and still provide most of the necessary slots for a newcomer to fill out. any ambiguities or missing details can be easily worked out through regular conversation.

i'm aware some might object to the amount of detail i'm removing. my answer is that i think it's better to err on the side of brevity when it comes to these templates.