### PR TITLE
Always set server's number of In/Out channels

### DIFF
--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -125,18 +125,12 @@ ServerOptions {
 		o = o ++ port;
 
 		o = o ++ " -a " ++ (numPrivateAudioBusChannels + numInputBusChannels + numOutputBusChannels) ;
+		o = o ++ " -i " ++ numInputBusChannels;
+		o = o ++ " -o " ++ numOutputBusChannels;
 
 		if (numControlBusChannels !== defaultValues[\numControlBusChannels], {
 			numControlBusChannels = numControlBusChannels.asInteger;
 			o = o ++ " -c " ++ numControlBusChannels;
-		});
-		// scsynth and supernova default to 8 input channels
-		if (numInputBusChannels != 8, {
-			o = o ++ " -i " ++ numInputBusChannels;
-		});
-		// scsynth and supernova default to 8 output channels
-		if (numOutputBusChannels != 8, {
-			o = o ++ " -o " ++ numOutputBusChannels;
 		});
 		if (numBuffers !== defaultValues[\numBuffers], {
 			numBuffers = numBuffers.asInteger;


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->
This is a small enhancement to `ServerOptions.asOptionsString`. The number of In/Out channels should always be set, even when using the default values.

## Types of changes

<!-- Delete lines that don't apply -->

- Enhancement

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [ ] All tests are passing
- [ ] Updated documentation
- [x] This PR is ready for review
