### PR TITLE
class library: some NodeProxy roles fade in and out correctly again

### DIFF
--- a/SCClassLibrary/JITLib/ProxySpace/wrapForNodeProxy.sc
+++ b/SCClassLibrary/JITLib/ProxySpace/wrapForNodeProxy.sc
@@ -296,7 +296,6 @@
 				};
 
 				{ | out |
-
 					var env, ctl = Control.names(["wet"++(index ? 0)]).kr(1.0);
 					if(proxy.rate === 'audio') {
 						env = ctl * EnvGate(i_level: 0, doneAction:2, curve:\sin);

--- a/SCClassLibrary/JITLib/ProxySpace/wrapForNodeProxy.sc
+++ b/SCClassLibrary/JITLib/ProxySpace/wrapForNodeProxy.sc
@@ -296,10 +296,13 @@
 				};
 
 				{ | out |
-					var e = EnvGate.new * Control.names(["wet"++(index ? 0)]).kr(1.0);
+
+					var e, ctl = Control.names(["wet"++(index ? 0)]).kr(1.0);
 					if(proxy.rate === 'audio') {
+						e = ctl * EnvGate(i_level: 0, doneAction:2, curve:\sin);
 						XOut.ar(out, e, SynthDef.wrap(func, nil, [In.ar(out, proxy.numChannels)]))
 					} {
+						e = ctl * EnvGate(i_level: 0, doneAction:2, curve:\lin);
 						XOut.kr(out, e, SynthDef.wrap(func, nil, [In.kr(out, proxy.numChannels)]))				};
 				}.buildForProxy( proxy, channelOffset, index )
 
@@ -354,17 +357,18 @@
 				};
 
 				{ | out |
-					var in;
-					var egate = EnvGate.new;
+					var in, e;
 					var wetamp = Control.names(["wet"++(index ? 0)]).kr(1.0);
 					var dryamp = 1 - wetamp;
 					if(proxy.rate === 'audio') {
 						in = In.ar(out, proxy.numChannels);
-						XOut.ar(out, egate, SynthDef.wrap(func, nil,
+						e = wetamp * EnvGate(i_level: 0, doneAction:2, curve:\sin);
+						XOut.ar(out, e, SynthDef.wrap(func, nil,
 							[in * wetamp]) + (dryamp * in))
 					} {
 						in = In.kr(out, proxy.numChannels);
-						XOut.kr(out, egate, SynthDef.wrap(func, nil,
+						e = wetamp * EnvGate(i_level: 0, doneAction:2, curve:\lin);
+						XOut.kr(out, e, SynthDef.wrap(func, nil,
 							[in * wetamp]) + (dryamp * in))
 					};
 				}.buildForProxy( proxy, channelOffset, index )
@@ -372,8 +376,15 @@
 
 			mix: #{ | func, proxy, channelOffset = 0, index |
 
-				{ var e = EnvGate.new * Control.names(["mix"++(index ? 0)]).kr(1.0);
-					e * SynthDef.wrap(func);
+				{
+					var e = Control.names(["mix" ++ (index ? 0)]).kr(1.0);
+					var sig = SynthDef.wrap(func);
+					var ctl = if(sig.rate == \audio) {
+						EnvGate(i_level: 0, doneAction:2, curve:\sin);
+					} {
+						EnvGate(i_level: 0, doneAction:2, curve:\lin);
+					};
+					e * ctl * sig
 				}.buildForProxy( proxy, channelOffset, index )
 			};
 

--- a/SCClassLibrary/JITLib/ProxySpace/wrapForNodeProxy.sc
+++ b/SCClassLibrary/JITLib/ProxySpace/wrapForNodeProxy.sc
@@ -297,13 +297,13 @@
 
 				{ | out |
 
-					var e, ctl = Control.names(["wet"++(index ? 0)]).kr(1.0);
+					var env, ctl = Control.names(["wet"++(index ? 0)]).kr(1.0);
 					if(proxy.rate === 'audio') {
-						e = ctl * EnvGate(i_level: 0, doneAction:2, curve:\sin);
-						XOut.ar(out, e, SynthDef.wrap(func, nil, [In.ar(out, proxy.numChannels)]))
+						env = ctl * EnvGate(i_level: 0, doneAction:2, curve:\sin);
+						XOut.ar(out, env, SynthDef.wrap(func, nil, [In.ar(out, proxy.numChannels)]))
 					} {
-						e = ctl * EnvGate(i_level: 0, doneAction:2, curve:\lin);
-						XOut.kr(out, e, SynthDef.wrap(func, nil, [In.kr(out, proxy.numChannels)]))				};
+						env = ctl * EnvGate(i_level: 0, doneAction:2, curve:\lin);
+						XOut.kr(out, env, SynthDef.wrap(func, nil, [In.kr(out, proxy.numChannels)]))				};
 				}.buildForProxy( proxy, channelOffset, index )
 
 			},
@@ -357,19 +357,19 @@
 				};
 
 				{ | out |
-					var in, e;
+					var in, env;
 					var wetamp = Control.names(["wet"++(index ? 0)]).kr(1.0);
 					var dryamp = 1 - wetamp;
 					var sig = { |in| SynthDef.wrap(func, nil, [in * wetamp]) + (dryamp * in) };
 
 					if(proxy.rate === 'audio') {
 						in = In.ar(out, proxy.numChannels);
-						e = wetamp * EnvGate(i_level: 0, doneAction:2, curve:\sin);
-						XOut.ar(out, e, sig.(in))
+						env = wetamp * EnvGate(i_level: 0, doneAction:2, curve:\sin);
+						XOut.ar(out, env, sig.(in))
 					} {
 						in = In.kr(out, proxy.numChannels);
-						e = wetamp * EnvGate(i_level: 0, doneAction:2, curve:\lin);
-						XOut.kr(out, e, sig.(in))
+						env = wetamp * EnvGate(i_level: 0, doneAction:2, curve:\lin);
+						XOut.kr(out, env, sig.(in))
 					};
 				}.buildForProxy( proxy, channelOffset, index )
 			},

--- a/testsuite/classlibrary/TestNodeProxyRoles.sc
+++ b/testsuite/classlibrary/TestNodeProxyRoles.sc
@@ -1,0 +1,58 @@
+TestNodeProxyRoles : UnitTest {
+
+	var server, proxy;
+
+	setUp {
+		server = Server(this.class.name);
+		server.bootSync;
+		proxy = NodeProxy(server);
+		server.sync;
+	}
+
+	tearDown {
+		proxy.clear;
+		server.quit;
+		server.remove;
+	}
+
+	test_proxyroles_xfade_smoothly {
+		var result = Array.new(8);
+		var cond = Condition.new;
+		var numSegments = 4;
+		var buffer = Buffer.alloc(server, server.sampleRate.asInteger);
+		var fadeTime = buffer.duration / numSegments;
+
+		server.sync;
+
+		proxy[3] = \filter -> { |in| RecordBuf.ar(in, buffer, loop: 0) };
+		proxy.fadeTime = fadeTime;
+
+		proxy[0] = { DC.ar(0.1) };
+		fadeTime.wait;
+		proxy[1] = \filter -> { DC.ar(0.2) };
+		fadeTime.wait;
+		proxy[1] = nil;
+		fadeTime.wait;
+		proxy[0] = nil;
+		fadeTime.wait;
+
+		fork {
+			forBy(0, (buffer.numFrames - 1), (buffer.numFrames / (numSegments*2)).asInteger, { |index|
+				buffer.get(index, { |val| result.add(val) });
+				server.sync;
+			});
+			cond.unhang;
+			buffer.free;
+		};
+
+		cond.hang;
+
+		this.assertArrayFloatEquals(
+			result,
+			[0.0, 0.05, 0.1, 0.15, 0.2, 0.15, 0.1, 0.05],
+			"Signal should fade smoothly over 'fadeTime' duration when adding/removing roles.",
+			within: 0.02
+		);
+	}
+
+}


### PR DESCRIPTION



<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

A change in `EnvGen` (#4060) wasn’t completely fixed in #4114.
This commit fixes #4266.
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

```supercollider
// some tests
a = NodeProxy.new.play;
a.fadeTime = 4;

a[1] = { Saw.ar ! 2 * 0.1 };
a[2] = \filterIn-> {|sig| Resonz.ar(sig, LFDNoise1.kr(30).range(200, 1900), 0.99) };
a[2] = \filter-> {|sig| Resonz.ar(sig, LFDNoise1.kr(30).range(400, 900), 0.99) };
a[2] = \mix -> {|sig| SinOsc.ar(1230) * 0.02 };
a[2] = nil;
a[1] = nil;
```


## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested with basic examples (see above)
- [ ] Code is tested in heavy use
- [ ] All tests are passing
- [x] This PR is ready for review
