### PR TITLE
main menu: remove Ctrl+B shortcut when server is running

### DIFF
--- a/SCClassLibrary/Common/GUI/Base/Menu.sc
+++ b/SCClassLibrary/Common/GUI/Base/Menu.sc
@@ -312,8 +312,8 @@ MainMenu {
 			actionsList[\name].string = defaultString + s.name + runningString;
 
 			actionsList[\running].string = startString;
-			if ((s == Server.default) && s.serverRunning.not) {
-				actionsList[\running].shortcut = "Ctrl+B";
+			if(s == Server.default) {
+				actionsList[\running].shortcut = if(s.serverRunning, "", "Ctrl+B");
 			};
 
 			actionsList[\kill].enabled = (s.serverRunning);


### PR DESCRIPTION
Purpose and Motivation
----------------------

"Ctrl-B" appears as a shortcut in the menu regardless of whether or not
the server is running. this PR sets the shortcut to "" when the server
is running.

Types of changes
----------------

- Bug fix (non-breaking change which fixes an issue)

Checklist
---------

- [x] All tests are passing
- [x] If necessary, new tests were created to address changes in PR, and tests are passing
- [x] Updated documentation, if necessary
- [x] This PR is ready for review