### PR TITLE
Topic fix setbus glitch

### DIFF
--- a/SCClassLibrary/Common/Audio/SystemSynthDefs.sc
+++ b/SCClassLibrary/Common/Audio/SystemSynthDefs.sc
@@ -63,8 +63,9 @@ SystemSynthDefs {
 
 				SynthDef("system_setbus_control_" ++ i, { arg out = 0, fadeTime = 0, curve = 0;
 					var values = NamedControl.ir(\values, 0 ! i);
-					var env = Env([In.kr(out, i), values], [1], curve);
-					var sig = EnvGen.kr(env, timeScale: fadeTime, doneAction: 2);
+					var holdTime = ControlDur.ir; // we need this to make sure value isn't overridded accidentally
+					var env = Env([In.kr(out, i), values, values], [fadeTime, holdTime], curve);
+					var sig = EnvGen.kr(env, doneAction: 2);
 					ReplaceOut.kr(out, sig);
 				}, [\ir, \kr, \ir]).add;
 			};

--- a/SCClassLibrary/JITLib/ProxySpace/wrapForNodeProxy.sc
+++ b/SCClassLibrary/JITLib/ProxySpace/wrapForNodeProxy.sc
@@ -94,9 +94,9 @@
 			array: this,
 			proxy: proxy,
 			channelOffset: channelOffset,
+			server: proxy.server,
 			finish: #{
 				var proxy = ~proxy;
-				~server = proxy.server;
 				~array = ~array.wrapExtend(proxy.numChannels);
 				~out = proxy.index + ~channelOffset;
 				~group = proxy.group;

--- a/SCClassLibrary/JITLib/ProxySpace/wrapForNodeProxy.sc
+++ b/SCClassLibrary/JITLib/ProxySpace/wrapForNodeProxy.sc
@@ -96,6 +96,7 @@
 			channelOffset: channelOffset,
 			finish: #{
 				var proxy = ~proxy;
+				~server = proxy.server;
 				~array = ~array.wrapExtend(proxy.numChannels);
 				~out = proxy.index + ~channelOffset;
 				~group = proxy.group;

--- a/testsuite/classlibrary/TestNodeProxy.sc
+++ b/testsuite/classlibrary/TestNodeProxy.sc
@@ -159,7 +159,7 @@ TestNodeProxy : UnitTest {
 
 	test_control_fade {
 		var server = Server(this.class.name);
-		var result, proxy;
+		var result, proxy, timeout;
 		var cond = Condition.new;
 		var fadeTime = 0.1;
 		var waitTime = (fadeTime + (server.latency * 2) + 1e-2);
@@ -170,13 +170,14 @@ TestNodeProxy : UnitTest {
 		proxy.source = { DC.kr(2000) };
 		proxy.fadeTime = fadeTime;
 
-		0.2.wait;
 		proxy.source = 440;
 		waitTime.wait;
 
 		OSCFunc({ cond.unhang }, '/c_set');
+		timeout = fork{ 1.wait; cond.unhang };
 		proxy.bus.get({ |val| result = val });
-		cond.hang(1); // timeout after one second
+		cond.hang;
+		timeout.stop;
 
 		this.assertEquals(result, proxy.source, "after the crossfade from a ugen function to a value the bus should have this value");
 

--- a/testsuite/classlibrary/TestNodeProxy.sc
+++ b/testsuite/classlibrary/TestNodeProxy.sc
@@ -159,7 +159,7 @@ TestNodeProxy : UnitTest {
 
 	test_control_fade {
 		var server = Server(this.class.name);
-		var result, synth, proxy;
+		var result, proxy;
 		var cond = Condition.new;
 		var fadeTime = 1;
 		var waitTime = (fadeTime + (server.latency * 2) + 1e-2);
@@ -179,7 +179,7 @@ TestNodeProxy : UnitTest {
 		cond.hang(1); // timeout after one second
 
 		this.assertEquals(result, proxy.source, "after the crossfade from a ugen function to a value the bus should have this value");
-		server.sync;
+
 		server.quit;
 		server.remove;
 	}

--- a/testsuite/classlibrary/TestNodeProxy.sc
+++ b/testsuite/classlibrary/TestNodeProxy.sc
@@ -7,7 +7,7 @@ TestNodeProxy : UnitTest {
 		var server = Server(this.class.name);
 
 		// fail safe for large inits - must be Integer for supernova
-		server.options.numWireBufs = (64 * (2**7)).asInteger;
+		server.options.numWireBufs = (64 * (2 ** 7)).asInteger;
 
 		proxy = NodeProxy(server);
 
@@ -174,7 +174,7 @@ TestNodeProxy : UnitTest {
 		waitTime.wait;
 
 		OSCFunc({ cond.unhang }, '/c_set');
-		timeout = fork{ 1.wait; cond.unhang };
+		timeout = fork { 1.wait; cond.unhang };
 		proxy.bus.get({ |val| result = val });
 		cond.hang;
 		timeout.stop;

--- a/testsuite/classlibrary/TestNodeProxy.sc
+++ b/testsuite/classlibrary/TestNodeProxy.sc
@@ -161,7 +161,7 @@ TestNodeProxy : UnitTest {
 		var server = Server(this.class.name);
 		var result, proxy;
 		var cond = Condition.new;
-		var fadeTime = 1;
+		var fadeTime = 0.1;
 		var waitTime = (fadeTime + (server.latency * 2) + 1e-2);
 
 		server.bootSync;


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

class library: fix `setbus_control` Event type 

The Event type `\setbus_control` is intended to be used for crossfading between values on a control bus. There are cases in which a previously
playing synth still writes on the bus after the `fadeTime` (this can happen due to a slightly later release of the other crossfade envelope). Then the target value that the control bus should have after
transition is lost.

Adding one control period to the envelope as a hold value is a way to
avoid this glitch.

This fixes  #4295.

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] This PR is ready for review
