### PR TITLE
class library: do not convert value before rate check

### DIFF
--- a/SCClassLibrary/JITLib/ProxySpace/NodeMap.sc
+++ b/SCClassLibrary/JITLib/ProxySpace/NodeMap.sc
@@ -132,9 +132,7 @@ ProxyNodeMap : NodeMap {
 	controlNames {
 		var res = Array.new;
 		this.keysValuesDo { |key, value|
-			var rate;
-			value = value.asControlInput;
-			rate = if(value.rate == \audio) { \audio } { \control };
+			var rate = if(value.rate == \audio) { \audio } { \control };
 			res = res.add(ControlName(key, nil, rate, value))
 		};
 		^res

--- a/testsuite/classlibrary/TestNodeProxy.sc
+++ b/testsuite/classlibrary/TestNodeProxy.sc
@@ -290,5 +290,3 @@ TestNodeProxy : UnitTest {
 	}
 
 }
-
-}

--- a/testsuite/classlibrary/TestNodeProxy.sc
+++ b/testsuite/classlibrary/TestNodeProxy.sc
@@ -269,6 +269,7 @@ TestNodeProxy : UnitTest {
 
 		server.quit;
 		server.remove;
+	}
 
 	test_map_rates {
 

--- a/testsuite/classlibrary/TestNodeProxy.sc
+++ b/testsuite/classlibrary/TestNodeProxy.sc
@@ -243,5 +243,49 @@ TestNodeProxy : UnitTest {
 		this.assertEquals(proxy.source, 1967, "copying a proxy should return an independent object");
 	}
 
+	test_control_fade {
+		var server = Server(this.class.name);
+		var result, proxy, timeout;
+		var cond = Condition.new;
+		var fadeTime = 0.1;
+		var waitTime = (fadeTime + (server.latency * 2) + 1e-2);
+
+		server.bootSync;
+
+		proxy = NodeProxy(server);
+		proxy.source = { DC.kr(2000) };
+		proxy.fadeTime = fadeTime;
+
+		proxy.source = 440;
+		waitTime.wait;
+
+		OSCFunc({ cond.unhang }, '/c_set');
+		timeout = fork { 1.wait; cond.unhang };
+		proxy.bus.get({ |val| result = val });
+		cond.hang;
+		timeout.stop;
+
+		this.assertEquals(result, proxy.source, "after the crossfade from a ugen function to a value the bus should have this value");
+
+		server.quit;
+		server.remove;
+
+	test_map_rates {
+
+		var p = ProxySpace.new.use {
+
+			~out = { \in.ar(0 ! 2) };
+			~osc = { |freq = 440| Saw.ar(freq).dup };
+			~osc <>> ~out;
+			this.assertEquals(~out.controlNames.detect { |cn| cn.name == \in }.rate, \audio,
+				"report the correct controlNames rates for audio rate proxies"
+			);
+		};
+
+		p.clear;
+
+	}
+
+}
 
 }

--- a/testsuite/classlibrary/TestNodeProxy.sc
+++ b/testsuite/classlibrary/TestNodeProxy.sc
@@ -249,6 +249,7 @@ TestNodeProxy : UnitTest {
 		var cond = Condition.new;
 		var fadeTime = 0.1;
 		var waitTime = (fadeTime + (server.latency * 2) + 1e-2);
+		var resp;
 
 		server.bootSync;
 
@@ -259,11 +260,12 @@ TestNodeProxy : UnitTest {
 		proxy.source = 440;
 		waitTime.wait;
 
-		OSCFunc({ cond.unhang }, '/c_set');
+		resp = OSCFunc({ cond.unhang; resp.free; }, '/c_set');
 		timeout = fork { 1.wait; cond.unhang };
 		proxy.bus.get({ |val| result = val });
 		cond.hang;
 		timeout.stop;
+		resp.free;
 
 		this.assertEquals(result, proxy.source, "after the crossfade from a ugen function to a value the bus should have this value");
 


### PR DESCRIPTION
For deriving the controls of a `ProxyNodeMap`’s values, we cannot convert
them to control inputs before rate checking, because this will return
symbols for busses that have no explicit rate information (like `[\a1,
\a2]`).

This was introduced in 1b88d80c7dd761170fbf970f813466feac9cddcf.

Thanks to James Harkins for analysis (see #4311).

