### PR TITLE
ProxySpace:storeOn: Fix initialization of children

### DIFF
--- a/SCClassLibrary/JITLib/ProxySpace/extStoreOn.sc
+++ b/SCClassLibrary/JITLib/ProxySpace/extStoreOn.sc
@@ -333,7 +333,7 @@
 			if (Ndef.all.includes(this)) {
 				stream << ("// ( " + this.asCode + ") \n\n");
 			} {
-				stream << "// ( p = ProxySpace.new(s).push; ) \n\n";
+				stream << "// ( p = " << this.class.name << ".new(s).push; ) \n\n";
 			};
 			this.storeOn(stream, keys, includeSettings);
 			//			this.do { |px| if(px.monitorGroup.isPlaying) {

--- a/testsuite/classlibrary/TestProxySpace.sc
+++ b/testsuite/classlibrary/TestProxySpace.sc
@@ -1,0 +1,62 @@
+TestProxySpace : UnitTest {
+
+
+	test_storeOn_recoversState {
+		var psA, psB, stream, bValue, bNodeMap, failedKey;
+		var server = Server(\test, NetAddr("127.0.0.1", 57111));
+
+		this.bootServer(server);
+		server.initTree;
+
+		psA = ProxySpace(server).make {
+			~out = { \in.ar(0!2) };
+			~osc = { |freq = 440| SinOsc.ar(freq).dup };
+			~out.set(\in, ~osc);
+			~freqmod = { LFDNoise3.kr(14).exprange(200, 800) };
+			~osc.set(\freq, ~freqmod);
+
+			// must do this inside the ProxySpace environment
+			// otherwise it can't identify the ~keys
+			stream = CollStream.new;
+			currentEnvironment.storeOn(stream);
+		};
+
+		psB = ProxySpace(server).make {
+			stream.collection.interpret;
+		};
+
+		failedKey = block { |break|
+			psA.keysValuesDo { |key, value|
+				bValue = psB[key];
+				// basic checks
+				if(bValue.rate != value.rate or: {
+					bValue.numChannels != value.numChannels or: {
+						bValue.source.asCompileString != value.source.asCompileString
+					}
+				}) {
+					break.value(key);
+				};
+				// check nodemap
+				bNodeMap = bValue.nodeMap;
+				value.nodeMap.keysValuesDo { |parm, map|
+					// output bus indices will not match, skip them
+					if(#[out, i_out].includes(parm).not) {
+						if(map.asCompileString != bNodeMap[parm].asCompileString) {
+							break.value(key);
+						};
+					};
+				};
+			};
+			nil
+		};
+
+		psA.clear;
+		psB.clear;
+		server.quit;
+
+		this.assert(failedKey.isNil,
+			"ProxySpace document string should recover all proxies' sources, rates, numChannels and nodemaps %"
+			.format(if(failedKey.notNil) { "(% failed)".format(failedKey) } { "" })
+		);
+	}
+}

--- a/testsuite/classlibrary/TestProxySpace.sc
+++ b/testsuite/classlibrary/TestProxySpace.sc
@@ -3,7 +3,7 @@ TestProxySpace : UnitTest {
 
 	test_storeOn_recoversState {
 		var psA, psB, stream, bValue, bNodeMap, aMapString, bMapString;
-		var server = Server(\test, NetAddr("127.0.0.1", 57111));
+		var server = Server(this.class.name, NetAddr("127.0.0.1", 57111));
 
 		this.bootServer(server);
 		server.initTree;
@@ -22,7 +22,7 @@ TestProxySpace : UnitTest {
 		};
 
 		psB = ProxySpace(server).make {
-			stream.collection.debug("\n\n\n\nSTREAM:\n\n").interpret;
+			stream.collection.interpret;
 		};
 
 		psA.keysValuesDo { |key, value|


### PR DESCRIPTION
## Purpose and Motivation

There are a couple of weaknesses in `ProxySpace:storeOn`. Note that this is used to save the state of a ProxySpace into a document, so that the user can execute that document's contents and recover the state (assuming the user avoided open functions, Buffers etc.) -- so it's important to get as much of it right as possible.

- In `ProxySpace:document`, the header line hardcodes "ProxySpace" instead of using `this.class.name`. This disallows subclasses. I don't see a good reason to disallow subclasses.

- Proxies found in a ProxyNodeMap may be referenced without being initialized (for rate and number of channels). In my test case, this meant that a stereo `ar` proxy was restored as a mono `kr` proxy, corrupting the original state. So, this PR goes through the nodeMap and, for any NodeProxies found inside, issues a line such as `~osc.ar(2);` before reconstructing the nodeMap.

E.g.

```
s.boot; p = ProxySpace.new.push;

~out = { \in.ar(0!2) }; ~out.play(vol: 0.2);
~osc = { SinOsc.ar(440).dup };
~osc <>> ~out;

p.asCompileString;
->
(
(
~out = { \in.ar(0!2) };
~out.set('in', ~osc);  // <<-- here, ~osc is assumed to be `.kr(1)`, oops
~out.play(
	vol: 0.2

);
);

~osc = { SinOsc.ar(440).dup };

);
```

After this change, `p.asCompileString` produces:

```
(
(
~out = { \in.ar(0!2) };
~osc.ar(2);   // <<-- here, we make sure ~osc has the right specs
~out.set('in', ~osc);
~out.play(
	vol: 0.2

);
);

~osc = { SinOsc.ar(440).dup };

);
```

## Types of changes

- Bug fix

## To-do list

- [x] Code is tested (added `TestProxySpace` for this)
- [x] All tests are passing
- [ ] ~~Updated documentation~~ not needed
- [x] This PR is ready for review
