### PR TITLE
Fix menu inline warnings

### DIFF
--- a/SCClassLibrary/Common/GUI/Base/Menu.sc
+++ b/SCClassLibrary/Common/GUI/Base/Menu.sc
@@ -272,9 +272,10 @@ MainMenu {
 			var actionsList;
 			// var running, options, kill, default;
 			var startString, runningString, defaultString;
+			var actions, new;
 
 			actionsList = serversMenuActions[s] ?? {
-				var actions, new = ();
+				new = ();
 				serversMenuActions[s] = new;
 
 				new[\name] = MenuAction().font_(Font(italic:true)).action_({


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

`prUpdateServersMenu` would have non-inlineable variables, this moves
their definition up to allow inlining.

## Types of changes

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] This PR is ready for review
