### PR TITLE
Corrected Signal.hammingWindow implementation. 

### DIFF
--- a/HelpSource/Classes/Signal.schelp
+++ b/HelpSource/Classes/Signal.schelp
@@ -92,6 +92,11 @@ the number of samples of the size that is zero padding.
 
 method::hammingWindow
 Fill a Signal of the given size with a Hamming window.
+
+warning::
+In versions of SuperCollider before 3.11, the implementation of code:: Signal.hammingWindow :: had incorrect coefficients. To get the old behavior back, use code:: Signal.hammingWindow_old ::.
+::
+
 code::
 Signal.hammingWindow(1024).plot;
 Signal.hammingWindow(1024, 512).plot;
@@ -128,6 +133,10 @@ Fourier Transform: Fill a Signal with the cosine table needed by the FFT methods
 code::
 Signal.fftCosTable(512).plot;
 ::
+
+method::hammingWindow_old
+
+This used to be code:: Signal.hammingWindow ::, but the coefficients were incorrect (making it a different window in the generalized Hamming window family). It is provided to assist in porting code to 3.11 and later.
 
 INSTANCEMETHODS::
 

--- a/SCClassLibrary/Common/Math/Signal.sc
+++ b/SCClassLibrary/Common/Math/Signal.sc
@@ -6,11 +6,18 @@ Signal[float] : FloatArray {
 	*chebyFill { arg size, amplitudes, normalize=true, zeroOffset=false;
 		^Signal.newClear(size).chebyFill(amplitudes, normalize, zeroOffset);
 	}
-	*hammingWindow { arg size, pad=0;
+	*hammingWindow_old { arg size, pad=0;
 		if (pad == 0, {
 			^this.newClear(size).fill(0.5).addSine(1, 0.39, -0.5pi);
 		},{
 			^this.newClear(size-pad).fill(0.5).addSine(1, 0.39, -0.5pi) ++ this.newClear(pad);
+		});
+	}
+	*hammingWindow { arg size, pad=0;
+		if (pad == 0, {
+			^this.newClear(size).fill(0.53836).addSine(1, 0.46164, -0.5pi);
+		},{
+			^this.newClear(size).fill(0.53836).addSine(1, 0.46164, -0.5pi) ++ this.newClear(pad);
 		});
 	}
 	*hanningWindow { arg size, pad=0;

--- a/testsuite/classlibrary/TestSignal.sc
+++ b/testsuite/classlibrary/TestSignal.sc
@@ -20,6 +20,26 @@ TestSignal : UnitTest {
 
 	}
 
+	test_hanningWindow_max1 {
+		var window = Signal.hanningWindow(1024);
+		this.assertFloatEquals(window.maxItem, 1.0, "Signal.hanningWindow has maximum of 1.0 for even window size");
+	}
+
+	test_hammingWindow_max1 {
+		var window = Signal.hammingWindow(1024);
+		this.assertFloatEquals(window.maxItem, 1.0, "Signal.hammingWindow has maximum of 1.0 for even window size");
+	}
+
+	test_rectWindow_max1 {
+		var window = Signal.rectWindow(1024);
+		this.assertFloatEquals(window.maxItem, 1.0, "Signal.rectWindow has maximum of 1.0");
+	}
+
+	test_welchWindow_max1 {
+		var window = Signal.welchWindow(1024);
+		this.assertFloatEquals(window.maxItem, 1.0, "Signal.welchWindow has maximum of 1.0 for even window size");
+	}
+
 	// This is just a helper method
 	getSignalMidValue { arg sig;
 		var midIndex = sig.size >> 1;


### PR DESCRIPTION
Corrected Signal.hammingWindow implementation. 

Old method moved to Signal.hammingWindow_old. 

See https://github.com/supercollider/supercollider/issues/4323