### PR TITLE
Help: Clarify Routine's "inheritance" of clocks, times and RNGs [skip ci]

### DIFF
--- a/HelpSource/Classes/Routine.schelp
+++ b/HelpSource/Classes/Routine.schelp
@@ -66,11 +66,12 @@ passing the code::inval:: argument as the return value of code::yield::.
 link::#-stop:: has been called).
 ::
 
-Since Routine inherits from link::Classes/Thread::, it will become the
+code::thisThread:: : Since Routine inherits from link::Classes/Thread::, it will become the
 emphasis::current thread:: when it is started or resumed; i.e.
 link::Classes/Thread#.thisThread#thisThread:: used in the Routine Function will return
-the Routine. It will inherit the parent thread's logical time and clock
-(see link::Classes/Thread#-parent::).
+the Routine.
+
+Time: Just before code::next:: is called, code::thisThread:: points either to another Routine, or the top-level Thread. During the code::next:: call, this becomes the "parent thread" (see link::Classes/Thread#-parent::). code::next:: then evaluates on the parent's clock, at the parent's logical time.
 
 Synonyms for code::next:: are link::#-value:: and link::#-resume::.
 
@@ -162,9 +163,7 @@ See also: link::Classes/Object#-yield::, link::Classes/Object#-alwaysYield::
 
 method::play
 
-In the SuperCollider application, a Routine can be played using a link::Classes/Clock::, as can any link::Classes/Stream::.
-every time the Routine yields, it should do so with a float, the clock will interpret that, usually
-pausing for that many seconds, and then resume the routine, passing it the clock's current time.
+Schedules the Routine on the given link::Classes/Clock::, at a time specified by code::quant::. At that time, the routine will "awake," setting the clock and time and evaluating the routine. If the routine yields a number, this number of beats will be added to the current time and the routine will be rescheduled. (This behavior is compatible with scheduling a link::Classes/Stream:: or a link::Classes/Function::.)
 
 argument::clock
 a Clock, TempoClock by default

--- a/HelpSource/Classes/Routine.schelp
+++ b/HelpSource/Classes/Routine.schelp
@@ -71,7 +71,7 @@ emphasis::current thread:: when it is started or resumed; i.e.
 link::Classes/Thread#.thisThread#thisThread:: used in the Routine Function will return
 the Routine.
 
-Time: Just before code::next:: is called, code::thisThread:: points either to another Routine, or the top-level Thread. During the code::next:: call, this becomes the "parent thread" (see link::Classes/Thread#-parent::). code::next:: then evaluates on the parent's clock, at the parent's logical time.
+Time: Just before code::next:: is called, code::thisThread:: points either to another Routine, or the top-level Thread. During the code::next:: call, this becomes the parent thread (see link::Classes/Thread#-parent::). code::next:: then evaluates on the parent's clock, at the parent's logical time.
 
 Synonyms for code::next:: are link::#-value:: and link::#-resume::.
 
@@ -163,7 +163,7 @@ See also: link::Classes/Object#-yield::, link::Classes/Object#-alwaysYield::
 
 method::play
 
-Schedules the Routine on the given link::Classes/Clock::, at a time specified by code::quant::. At that time, the routine will "awake," setting the clock and time and evaluating the routine. If the routine yields a number, this number of beats will be added to the current time and the routine will be rescheduled. (This behavior is compatible with scheduling a link::Classes/Stream:: or a link::Classes/Function::.)
+Schedules the Routine on the given link::Classes/Clock::, at a time specified by code::quant::. At that time, the Routine will wake up (by calling link::Classes/Routine#-awake::), setting the clock and time and evaluating the Routine. If the Routine yields a number, this number of beats will be added to the current time and the Routine will be rescheduled. (This behavior is compatible with scheduling a link::Classes/Stream:: or a link::Classes/Function::.)
 
 argument::clock
 a Clock, TempoClock by default

--- a/HelpSource/Reference/randomSeed.schelp
+++ b/HelpSource/Reference/randomSeed.schelp
@@ -32,8 +32,11 @@ Array.fill(7, r);
 
 subsection::Inheriting Seeds
 
-Also it is possible to set the seed of the running thread that
-all threads started within will inherit.
+When a routine is created, it "inherits" its random number generator from the parent thread (link::Classes/Thread#.thisThread#thisThread::). If no particular randSeed is set (the normal case), it will tap the same stream of random number generators used by the parent.
+
+The parent thread is whichever Routine is in force at the moment of creating a new Routine. If no Routine is evaluating at that moment, then the parent is the sclang process master link::Classes/Thread:: -- that is, the default from which all Routines inherit the random number generator.
+
+To set the master random seed for the entire application, then, evaluate code::thisThread.randSeed = yourSeed:: outside of the context of any routine, as in the example below.
 
 code::
 thisThread.randSeed = 1923;
@@ -51,6 +54,32 @@ thisThread.randSeed = 1923;
 
 Array.fill(7, r.value);
 ::
+
+When you set code::randSeed:: on a Routine, it switches to its own random number generator, independent of any other. Subsequently, routines created within the independent-RNG routine will inherit the separate random number generator.
+
+code::
+(
+thisThread.randSeed = 1000;
+TempoClock.sched(0, { 1000.rand.debug("master RNG"); 1 });
+
+fork {
+	2.1.wait;
+	thisThread.randSeed = 1000;
+	loop { 1000.rand.debug("routine RNG"); 1.wait }
+};
+)
+
+master RNG: 592 // sequence is 592, 876, 614, 236...
+master RNG: 876
+master RNG: 614
+routine RNG: 592 // sequence is 592, 876...
+master RNG: 236
+routine RNG: 876
+::
+
+Note that this "inheritance" takes place only at the moment of creating a new routine. Calling code::next:: or code::play:: on the child routine does not override that routine's random number generator.
+
+subsection:: Audio example
 
 code::
 // use the seed to completely reproduce a sound:

--- a/HelpSource/Reference/randomSeed.schelp
+++ b/HelpSource/Reference/randomSeed.schelp
@@ -32,16 +32,16 @@ Array.fill(7, r);
 
 subsection::Inheriting Seeds
 
-When a routine is created, it "inherits" its random number generator from the parent thread (link::Classes/Thread#.thisThread#thisThread::). If no particular randSeed is set (the normal case), it will tap the same stream of random number generators used by the parent.
+When a routine is created, it inherits its random number generator from the parent thread (link::Classes/Thread#.thisThread#thisThread::). If no particular randSeed is set (the normal case), then the same random number generator object provides numbers to both the parent and the child (one stream of random numbers, distributed between both).
 
-The parent thread is whichever Routine is in force at the moment of creating a new Routine. If no Routine is evaluating at that moment, then the parent is the sclang process master link::Classes/Thread:: -- that is, the default from which all Routines inherit the random number generator.
+The parent thread is whichever Routine is in force at the moment of creating a new Routine. If no Routine is evaluating at that moment, then the parent is the sclang process main link::Classes/Thread::. By default, all Routines inherit the random number generator from the main thread.
 
-To set the master random seed for the entire application, then, evaluate code::thisThread.randSeed = yourSeed:: outside of the context of any routine, as in the example below.
+To set the main random seed for the entire application, then, evaluate code::thisThread.randSeed = yourSeed:: outside of the context of any Routine, as in the example below.
 
 code::
 thisThread.randSeed = 1923;
 
-// create a function that returns a routine
+// create a function that returns a Routine
 
 r = { Routine({
 	loop({#[1,2,3,4,5].choose.yield })
@@ -55,12 +55,12 @@ thisThread.randSeed = 1923;
 Array.fill(7, r.value);
 ::
 
-When you set code::randSeed:: on a Routine, it switches to its own random number generator, independent of any other. Subsequently, routines created within the independent-RNG routine will inherit the separate random number generator.
+When you set code::randSeed:: on a Routine, the Routine switches to its own random number generator, independent of any other. Subsequently, Routines created within this Routine will inherit its unique random number generator.
 
 code::
 (
 thisThread.randSeed = 1000;
-TempoClock.sched(0, { 1000.rand.debug("master RNG"); 1 });
+TempoClock.sched(0, { 1000.rand.debug("main RNG"); 1 });
 
 fork {
 	2.1.wait;
@@ -69,15 +69,15 @@ fork {
 };
 )
 
-master RNG: 592 // sequence is 592, 876, 614, 236...
-master RNG: 876
-master RNG: 614
+main RNG: 592 // sequence is 592, 876, 614, 236...
+main RNG: 876
+main RNG: 614
 routine RNG: 592 // sequence is 592, 876...
-master RNG: 236
+main RNG: 236
 routine RNG: 876
 ::
 
-Note that this "inheritance" takes place only at the moment of creating a new routine. Calling code::next:: or code::play:: on the child routine does not override that routine's random number generator.
+Note that this inheritance takes place only at the moment of creating a new Routine. Calling code::next:: or code::play:: on the child Routine does not override that Routine's random number generator.
 
 subsection:: Audio example
 


### PR DESCRIPTION
## Purpose and Motivation

A mailing list discussion revealed that some of the documentation about routines "inheriting" state from the parent thread is unclear, and possibly misleading. This PR attempts to clarify a few points.

## Types of changes

- Documentation

## To-do list

- [x] This PR is ready for review
