### PR TITLE
remove refs to TDuty_old

### DIFF
--- a/HelpSource/Classes/TDuty.schelp
+++ b/HelpSource/Classes/TDuty.schelp
@@ -46,7 +46,7 @@ link::Classes/Done::  for more detail.
 
 
 argument::gapFirst
-when 0 (default), the UGen does the first level poll immediately and then waits for the first durational value. When this is 1, the UGen initially polls the first durational value, waits for that duration, and then polls the first level (along with polling the next durational value). So gapFirst > 0 makes TDuty behave like link::Classes/TDuty_old::.
+when 0 (default), the UGen does the first level poll immediately and then waits for the first durational value. When this is 1, the UGen initially polls the first durational value, waits for that duration, and then polls the first level (along with polling the next durational value).
 
 Examples::
 

--- a/HelpSource/Classes/TDuty_old.schelp
+++ b/HelpSource/Classes/TDuty_old.schelp
@@ -1,8 +1,0 @@
-class:: TDuty_old
-summary:: Deprecated ugen
-related:: Classes/TDuty
-categories:: UGens>Deprecated
-
-description::
-This class is deprecated, use link::Classes/TDuty:: instead.
-


### PR DESCRIPTION
Purpose and Motivation
----------------------

Some docs were left around that referred to TDuty_old.

Types of changes
----------------

- Bug fix (non-breaking change which fixes an issue)

Checklist
---------

<!--- Complete an item by checking it: [x] -->

- [x] All tests are passing
- [x] If necessary, new tests were created to address changes in PR, and tests are passing
- [x] Updated documentation, if necessary
- [x] This PR is ready for review