### PR TITLE
Help: Classes/FFT should highlight correct multichannel approach

### DIFF
--- a/HelpSource/Classes/FFT.schelp
+++ b/HelpSource/Classes/FFT.schelp
@@ -18,6 +18,10 @@ fft = FFT(LocalBuf(2048, 2), aStereoSignal);
 
 // YES: Use an array of two single-channel buffers
 fft = FFT(Array.fill(2, { LocalBuf(2048, 1) }), aStereoSignal);
+
+// Equivalent shortcut:
+// LocalBuf multichannel-expands, causing FFT to expand as well
+fft = FFT(LocalBuf(2048.dup(2), 1), aStereoSignal);
 ::
 
 See also link::Guides/FFT-Overview#Multichannel Expansion with FFT UGens::.

--- a/HelpSource/Classes/FFT.schelp
+++ b/HelpSource/Classes/FFT.schelp
@@ -7,6 +7,22 @@ Description::
 
 The fast fourier transform analyzes the frequency content of a signal, which can be useful for audio analysis or for frequency-domain sound processing (phase vocoder).
 
+note::
+FFT and link::Classes/IFFT:: UGens require a buffer to store the frequency-domain data. This buffer must have exactly one channel. emphasis::Multichannel buffers are never supported.::
+
+To do FFT processing on a multichannel signal, provide an array of mono buffers, one for each channel. Then, FFT/IFFT will perform link::Guides/Multichannel-Expansion::, to process each channel separately.
+
+code::
+// NO: The buffer has two channels -- this will not work
+fft = FFT(LocalBuf(2048, 2), aStereoSignal);
+
+// YES: Use an array of two single-channel buffers
+fft = FFT(Array.fill(2, { LocalBuf(2048, 1) }), aStereoSignal);
+::
+
+See also link::Guides/FFT-Overview#Multichannel Expansion with FFT UGens::.
+::
+
 classmethods::
 
 method::new


### PR DESCRIPTION
## Purpose and Motivation

Users very frequently overlook the requirement to use multiple single-channel buffers for n-channel FFT. This is documented in the FFT Overview, but a/ users read the FFT class help file and stop there, never making it over to the overview and b/ the multichannel section is quite far down in the overview, easy to miss.

So, I'd like to add a short note block to FFT class help explaining briefly how to handle multichannel signals ("don't do this -- do that instead"), so that it's almost the first thing users see.

## Types of changes

- Documentation

## To-do list

- [x] Updated documentation
- [x] This PR is ready for review
