### PR TITLE
testsuite: Fix TestTempoClock:test_nextTimeOnGrid_negativePhaseWraps

### DIFF
--- a/testsuite/classlibrary/TestTempoClock.sc
+++ b/testsuite/classlibrary/TestTempoClock.sc
@@ -88,12 +88,9 @@ TestTempoClock : UnitTest {
 	}
 
 	test_nextTimeOnGrid_negativePhaseWraps {
-		var cond = Condition.new;
-		{
-			0.5.wait;
-			cond.unhang;
-		}.fork(clock);
-		cond.hang;
+		// when running the whole suite, 'beats' might be later
+		// so, ensure the right test value
+		clock.beats = 0.5;
 		this.assertEquals(
 			clock.nextTimeOnGrid(1, -0.9), 1.1,
 			"nextTimeOnGrid(1, -0.9) at beat 0.5 should wrap up to 1.1"


### PR DESCRIPTION
## Purpose and Motivation

`TestTempoClock:test_nextTimeOnGrid_negativePhaseWraps` is badly written:

- It uses a condition, hang and unhang where nothing is happening except a `wait`. Should remove the extra complexity.

- It fails when running the entire `TestTempoClock` because, in that case, the beats when entering the test are non-zero. It should set the beats explicitly.

## Types of changes

- Bug fix

## To-do list

- [x] Code is tested
- [x] All tests are passing
- [x] This PR is ready for review
