### PR TITLE
quarks: Display current branch name in Quarks.gui

### DIFF
--- a/HelpSource/Classes/Git.schelp
+++ b/HelpSource/Classes/Git.schelp
@@ -29,6 +29,9 @@ INSTANCEMETHODS::
 
 subsection:: info
 
+METHOD:: branch
+returns:: current branch name.
+
 METHOD:: remote, url
 returns:: url of the first remote that it finds.
 

--- a/HelpSource/Classes/Quark.schelp
+++ b/HelpSource/Classes/Quark.schelp
@@ -110,6 +110,10 @@ returns:: this
 METHOD:: version
 returns:: String
 
+METHOD:: branch
+returns the current branch name.
+returns:: String or nil, if failed
+
 METHOD:: tags
 returns:: Array of Strings
 

--- a/SCClassLibrary/Common/Quarks/Git.sc
+++ b/SCClassLibrary/Common/Quarks/Git.sc
@@ -34,6 +34,10 @@ Git {
 			url = this.remote;
 		}
 	}
+	branch {
+		var out = this.git(["rev-parse --abbrev-ref HEAD"]);
+		^if(out.size > 0) { out } { nil }
+	}
 	remote {
 		// detect origin of repo or nil
 		// origin	git://github.com/supercollider-quarks/MathLib (fetch)

--- a/SCClassLibrary/Common/Quarks/Quark.sc
+++ b/SCClassLibrary/Common/Quarks/Quark.sc
@@ -1,6 +1,6 @@
 
 Quark {
-	var <name, url, >refspec, data, <localPath;
+	var <name, url, >refspec, data, <localPath, branch;
 	var <changed = false, <git;
 
 	*new { |name, refspec, url, localPath|
@@ -53,6 +53,9 @@ Quark {
 	}
 	tags {
 		^git !? { git.tags }
+	}
+	branch {
+		^git !? { git.branch }
 	}
 	isDownloaded {
 		^File.exists(this.localPath)

--- a/SCClassLibrary/Common/Quarks/QuarksGui.sc
+++ b/SCClassLibrary/Common/Quarks/QuarksGui.sc
@@ -468,7 +468,7 @@ QuarkDetailView {
 		if(tags.size == 0 or: {
 			remoteLatest != model.git.shaForTag(tags.first);
 		}, {
-			versions.add([remoteLatest, "LATEST"]);
+			versions.add([remoteLatest, "Latest master"]);
 		});
 
 		// working copy

--- a/SCClassLibrary/Common/Quarks/QuarksGui.sc
+++ b/SCClassLibrary/Common/Quarks/QuarksGui.sc
@@ -289,6 +289,10 @@ QuarkDetailView {
 			if(model.data['version'].notNil, {
 				this.pushRow("Version", model.data['version'].asString);
 			});
+			// branch
+			if(model.branch.notNil, {
+				this.pushRow("Current branch", model.branch.asString);
+			});
 
 			if(webpage != url and: webpage.notNil, {
 				this.pushRow("Webpage", makeBtn.value(webpage, {
@@ -348,6 +352,7 @@ QuarkDetailView {
 					this.pushRow(k.asString, v.value().asString);
 				}
 			});
+
 
 			// versions
 			if(isDownloaded and: {model.git.notNil}, {


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

The current branch was never mentioned in the Quarks gui, which can be confusing. This adds the quark name to:

1. the LATEST in the versions tree (there, at the moment, latest always means master)
2. an extra field that displays the current branch

## Types of changes

<!-- Delete lines that don't apply -->

- Documentation
- Bug fix
- New feature

This fixes #4321.

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] Updated documentation
- [x] This PR is ready for review
