### PR TITLE
Moved definition of LinkClock into hpp, use static methods for init

### DIFF
--- a/lang/LangPrimSource/PyrSched.cpp
+++ b/lang/LangPrimSource/PyrSched.cpp
@@ -50,6 +50,7 @@
 #include "SC_Lock.h"
 
 #include "SC_Clock.hpp"
+#include "SC_Ableton_Link.hpp"
 
 #include <boost/sync/semaphore.hpp>
 #include <boost/sync/support/std_chrono.hpp>
@@ -233,15 +234,12 @@ using monotonic_clock = std::conditional<std::chrono::high_resolution_clock::is_
 
 static std::chrono::high_resolution_clock::time_point hrTimeOfInitialization;
 
-#ifdef SC_ABLETON_LINK
-	void initLink();
-#endif
 SCLANG_DLLEXPORT_C void schedInit()
 {
 	using namespace std::chrono;
 	hrTimeOfInitialization     = high_resolution_clock::now();
 #ifdef SC_ABLETON_LINK
-	initLink();
+  LinkClock::Init();
 #endif
 
 	syncOSCOffsetWithTimeOfDay();

--- a/lang/LangPrimSource/SC_Ableton_Link.hpp
+++ b/lang/LangPrimSource/SC_Ableton_Link.hpp
@@ -1,0 +1,97 @@
+#pragma once
+
+#ifdef SC_ABLETON_LINK
+
+#include "PyrKernel.h"
+#include "PyrSched.h"
+#include "GC.h"
+#include "PyrPrimitive.h"
+#include "PyrSymbol.h"
+
+#include "SCBase.h"
+#include "SC_Clock.hpp"
+
+#include <ableton/Link.hpp>
+
+class LinkClock : public TempoClock
+{
+public:
+    LinkClock(VMGlobals *vmGlobals, PyrObject* tempoClockObj,
+                double tempo, double baseBeats, double baseSeconds);
+
+    ~LinkClock() {}
+
+    static void Init();
+    static std::chrono::microseconds GetInitTime() { return LinkClock::mInitTime; }
+
+    void SetTempoAtBeat(double tempo, double inBeats);
+    void SetTempoAtTime(double tempo, double inSeconds);
+    void SetAll(double tempo, double inBeats, double inSeconds);
+    double BeatsToSecs(double beats) const override;
+    double SecsToBeats(double secs) const override;
+
+    void SetQuantum(double quantum)
+    {
+        mQuantum = quantum;
+        mCondition.notify_one();
+    }
+
+    double GetLatency() const
+    {
+        return mLatency;
+    }
+
+    void SetLatency(double latency)
+    {
+        mLatency = latency;
+    }
+
+    void OnTempoChanged(double bpm);
+
+    void OnStartStop(bool isPlaying)
+    {
+        //call sclang callback
+        gLangMutex.lock();
+        g->canCallOS = false;
+        ++g->sp;
+        SetObject(g->sp, mTempoClockObj);
+        ++g->sp;
+        SetBool(g->sp, isPlaying);
+        runInterpreter(g, getsym("prStartStopSync"), 2);
+        g->canCallOS = false;
+        gLangMutex.unlock();
+    }
+
+    void OnNumPeersChanged(std::size_t numPeers)
+    {
+        //call sclang callback
+        gLangMutex.lock();
+        g->canCallOS = false;
+        ++g->sp;
+        SetObject(g->sp, mTempoClockObj);
+        ++g->sp;
+        SetInt(g->sp, numPeers);
+        runInterpreter(g, getsym("prNumPeersChanged"), 2);
+        g->canCallOS = false;
+        gLangMutex.unlock();
+    }
+
+    std::size_t NumPeers() const { return mLink.numPeers(); }
+
+    void CommitTempo(ableton::Link::SessionState sessionState, double tempo)
+    {
+        mTempo = tempo;
+        mBeatDur = 1. / tempo;
+
+        mLink.commitAppSessionState(sessionState);
+        mCondition.notify_one();
+    }
+
+private:
+    ableton::Link mLink;
+    double mQuantum;
+    double mLatency;
+    static std::chrono::microseconds mInitTime;
+};
+
+#endif // SC_ABLETON_LINK


### PR DESCRIPTION
## Purpose and Motivation

Addresses review concerns on the ongoing Ableton Link PR #4331 .  Moves init routines of LinkClock into a static member of the LinkClock class.  This requires a bunch of re-ordering and thus makes most sense to have LinkClock defined in a header file.

## Types of changes

- New feature

## To-do list

- [x] Code is tested
- [x] All tests are passing
- [ ] Updated documentation
- [x] This PR is ready for review

FYI @jamshark70 
