### PR TITLE
Proxy mixer edit gui should use proxyspace

### DIFF
--- a/SCClassLibrary/JITLib/GUI/ProxyMixer.sc
+++ b/SCClassLibrary/JITLib/GUI/ProxyMixer.sc
@@ -187,20 +187,18 @@ ProxyMixer : JITGui {
 
 			.action_({ arg btn, mod;
 				this.proxyspace.use {
-					protect {
-						if (mod.notNil and: { mod.isAlt }) {
-							NdefGui(pxgui.object);
-						} {
-							this.switchSize(2, isSmall);
-							editGui.object_(pxgui.object);
-							arGuis.do { |gui| gui.edBut.value_(0) };
-							krGuis.do { |gui| gui.edBut.value_(0) };
-							btn.value_(1);
-						}
+					if (mod.notNil and: { mod.isAlt }) {
+						NdefGui(pxgui.object);
+					} {
+						this.switchSize(2, isSmall);
+						editGui.object_(pxgui.object);
+						arGuis.do { |gui| gui.edBut.value_(0) };
+						krGuis.do { |gui| gui.edBut.value_(0) };
+						btn.value_(1);
 					}
-				}
-			})
-		}
+				};
+			});
+		};
 	}
 
 	makeArZone { |isSmall = false|
@@ -305,80 +303,78 @@ ProxyMixer : JITGui {
 		};
 
 		this.proxyspace.use {
-			protect {
-				newState = this.getState;
+			newState = this.getState;
 
-				if (newState[\name] != prevState[\name]) {
-					this.name_(newState[\name])
+			if (newState[\name] != prevState[\name]) {
+				this.name_(newState[\name])
+			};
+
+			arNames = newState[\arNames];
+			prevArNames = prevState[\arNames];
+			fullSize = arNames.size;
+
+			if (newState[\arOverflow] > 0) {
+				arNames = arNames.drop(arKeysRotation).keep(numItems);
+				newState[\arNames] = arNames;
+			} {
+				arKeysRotation = 0;
+			};
+
+			arKeysRotation = min(arKeysRotation, newState[\arOverflow]);
+			arScroller.numItems_(fullSize).value_(arKeysRotation).visible_(newState[\arOverflow] > 0);
+
+
+			if (arNames != prevArNames) {
+				arGuis.do { |argui, i|
+					var newName = arNames[i];
+					var newPx = object.envir[newName];
+					argui.object_(newPx);
+					argui.name_(newName);
+					argui.zone.visible_(newPx.notNil);
 				};
+			};
+			arGuis.do { |gui|
+				var pxIsEdited = gui.object.notNil and: { gui.object == editGui.object };
+				gui.checkUpdate;
+				if(gui.hasName.not) { gui.name = this.proxyspace.findKeyForValue(gui.object) };
+				gui.edBut.value_(pxIsEdited.binaryValue);
+			};
 
-				arNames = newState[\arNames];
-				prevArNames = prevState[\arNames];
-				fullSize = arNames.size;
 
-				if (newState[\arOverflow] > 0) {
-					arNames = arNames.drop(arKeysRotation).keep(numItems);
-					newState[\arNames] = arNames;
-				} {
-					arKeysRotation = 0;
+			krNames = newState[\krNames];
+			prevKrNames = prevState[\krNames];
+			fullSize = krNames.size;
+
+			if (newState[\krOverflow] > 0) {
+				krNames = krNames.drop(krKeysRotation).keep(numItems);
+				newState[\krNames] = krNames;
+
+			} {
+				krKeysRotation = 0;
+			};
+			krKeysRotation = min(krKeysRotation, newState[\krOverflow]);
+			krScroller.numItems_(fullSize)
+			.value_(krKeysRotation).visible_(newState[\krOverflow] > 0);
+
+			if (krNames != prevKrNames) {
+				krGuis.do { |krgui, i|
+					var newName = krNames[i];
+					var newPx = object.envir[newName];
+					krgui.object_(newPx);
+					krgui.name_(newName);
+					krgui.zone.visible_(newPx.notNil);
 				};
+			};
 
-				arKeysRotation = min(arKeysRotation, newState[\arOverflow]);
-				arScroller.numItems_(fullSize).value_(arKeysRotation).visible_(newState[\arOverflow] > 0);
+			krGuis.do { |gui|
+				var pxIsEdited = gui.object.notNil and: { gui.object == editGui.object };
+				gui.checkUpdate;
+				if(gui.hasName.not) { gui.name = this.proxyspace.findKeyForValue(gui.object) };
+				gui.edBut.value_(pxIsEdited.binaryValue);
+			};
 
-
-				if (arNames != prevArNames) {
-					arGuis.do { |argui, i|
-						var newName = arNames[i];
-						var newPx = object.envir[newName];
-						argui.object_(newPx);
-						argui.name_(newName);
-						argui.zone.visible_(newPx.notNil);
-					};
-				};
-				arGuis.do { |gui|
-					var pxIsEdited = gui.object.notNil and: { gui.object == editGui.object };
-					gui.checkUpdate;
-					if(gui.hasName.not) { gui.name = this.proxyspace.findKeyForValue(gui.object) };
-					gui.edBut.value_(pxIsEdited.binaryValue);
-				};
-
-
-				krNames = newState[\krNames];
-				prevKrNames = prevState[\krNames];
-				fullSize = krNames.size;
-
-				if (newState[\krOverflow] > 0) {
-					krNames = krNames.drop(krKeysRotation).keep(numItems);
-					newState[\krNames] = krNames;
-
-				} {
-					krKeysRotation = 0;
-				};
-				krKeysRotation = min(krKeysRotation, newState[\krOverflow]);
-				krScroller.numItems_(fullSize)
-				.value_(krKeysRotation).visible_(newState[\krOverflow] > 0);
-
-				if (krNames != prevKrNames) {
-					krGuis.do { |krgui, i|
-						var newName = krNames[i];
-						var newPx = object.envir[newName];
-						krgui.object_(newPx);
-						krgui.name_(newName);
-						krgui.zone.visible_(newPx.notNil);
-					};
-				};
-
-				krGuis.do { |gui|
-					var pxIsEdited = gui.object.notNil and: { gui.object == editGui.object };
-					gui.checkUpdate;
-					if(gui.hasName.not) { gui.name = this.proxyspace.findKeyForValue(gui.object) };
-					gui.edBut.value_(pxIsEdited.binaryValue);
-				};
-
-				editGui.checkUpdate;
-				prevState = newState;
-			}
+			editGui.checkUpdate;
+			prevState = newState;
 		}
 	}
 }

--- a/SCClassLibrary/JITLib/GUI/ProxyMixer.sc
+++ b/SCClassLibrary/JITLib/GUI/ProxyMixer.sc
@@ -276,7 +276,7 @@ ProxyMixer : JITGui {
 				\name, object.asCode,
 				\arNames, arNames,
 				\krNames, krNames,
-				\editedName, editGui.object !? { editGui.object.key },
+				\editedName, editGui.object !? { editGui.object.key(proxyspace) },
 				\arOverflow, (arNames.size - numItems).max(0),
 				\krOverflow, (krNames.size - numItems).max(0)
 			]);
@@ -367,7 +367,9 @@ ProxyMixer : JITGui {
 			gui.edBut.value_(pxIsEdited.binaryValue);
 		};
 
-		editGui.checkUpdate;
+		this.proxyspace.use {
+			protect { editGui.checkUpdate }
+		};
 
 		prevState = newState;
 	}


### PR DESCRIPTION

## Purpose and Motivation
 Bug fix, Fixes #4335.

A ProxyMixer has a proxyspace that it shows, so all named it displays are within that proxyspace.
The editGui in the mixer did not use the proxyspace, but relied on either using Ndefs, or the 
mixer's proxyspace being the currentEnvironment. 
Thus, when the mixer's proxyspace is not current, proxy names would be displayed as anonymous.


This PR ensures that the editGui shows all names as found within the mixer's proxyspace. 

- [x] Code is tested (see below)
- [x] This PR is ready for discussion

Tests for correct functioning: 

```
p = ProxySpace.new.push(s.boot);
// make some proxies
~out = { \in.ar(0!2) };
~osc = { SinOsc.ar(440).dup };
// map a proxy to an ar input
~osc <>> ~out;

// make p != currentEnvironment
p.pop;

// make a mixer: should show names of proxies within p
g = p.gui;

// send ~out to editGui: editGui name should show "out", 
// and editGui's first paramView should show "~osc" as mapped input
g.arGuis[1].edBut.valueAction_(1);

// add an ar proxy: name should be shown correctly in arGuis on the left
p[\test].ar; 

// add a control proxy: show show name in krGuis in the middle
p[\lfo] = { SinOsc.kr(3) }

// send p[\test] to editGui: name "test" should get shown correctly in editGui on the right
g.arGuis[2].edBut.valueAction_(1);

// p[\out] to editGui: paramGui should show param "in" as mapped "~osc"
g.arGuis[1].edBut.valueAction_(1);

// add second source osc2: name "osc2" should get shown in arGuis
p[\osc2] = { Pulse.ar(440).dup };

// map ~out param in to osc2: name "osc2" should get shown in editGui.paramViews
p[\osc2] <>> p[\out];
```
