### PR TITLE
Plugins: Convolution2_Ctor: Remove incorrect prevtrig init line

### DIFF
--- a/server/plugins/Convolution.cpp
+++ b/server/plugins/Convolution.cpp
@@ -336,7 +336,6 @@ void Convolution2_Ctor(Convolution2 *unit)
 		unit->m_pos = 0;
 
 		unit->m_prevtrig = 0.f;
-		unit->m_prevtrig = ZIN0(2);
 
 		if ( unit->m_framesize >= world->mFullRate.mBufLength ) {
 			SETCALC(Convolution2_next);


### PR DESCRIPTION
## Purpose and Motivation

You can actually find this bit of code in `Convolution2_Ctor` (https://github.com/supercollider/supercollider/blob/master/server/plugins/Convolution.cpp#L338):

```
		unit->m_prevtrig = 0.f;
		unit->m_prevtrig = ZIN0(2);
```

1. That's funny. Really, really funny.

2. It also initializes the plug-in to an incorrect state. Everywhere else in the core plug-ins, the Ctor does `unit->m_prevtrig = 0.f;`. No exceptions. There is no reason to break the rule here (esp. when it's obviously an editing mistake).

Simple, no-brainer fix: just delete the second line.

## Types of changes

- Bug fix

## To-do list

- [x] Code is tested -- I tested manually using code that I will paste below. But, we don't have an established testing procedure to verify UGens' output over time, and it's in the nature of Convolution2 that you would need at least a few thousand samples to be sure it's working. I don't think it's in the scope of this PR to develop that.
- [x] All tests are passing -- no audible difference in the test (so this change does not break init).
- [x] This PR is ready for review

Test code:

```supercollider
(
s.waitForBoot {
	var bufs = Buffer.allocConsecutive(2, s, 2048, 1),
	synthsCompleted = 0,
	cond = Condition({ synthsCompleted == 2 });
	s.sync;
	bufs.do { |buf, i|
		{
			RecordBuf.ar(
				RLPF.ar(Impulse.ar(0), 400 * (i+1), 0.1),
				buf,
				loop: 0,
				doneAction: 2
			);
		}.play.onFree {
			synthsCompleted = synthsCompleted + 1;
			cond.signal;
		};
	};
	cond.wait;
	
	// Should sound like alternating between RLPFs at 400 and 800 Hz
	a = {
		var trig = Impulse.kr(1),
		bufnum = Demand.kr(trig, 0, Dseq(b, inf));
		Convolution2.ar(PinkNoise.ar(0.1), bufnum, trig, BufFrames.ir(bufnum)).dup
	}.play.onFree { bufs.do(_.free) };
};
)

a.free;
```