### PR TITLE
Refactor NodeProxy UnitTests

### DIFF
--- a/testsuite/classlibrary/TestNodeProxy.sc
+++ b/testsuite/classlibrary/TestNodeProxy.sc
@@ -1,189 +1,43 @@
 TestNodeProxy : UnitTest {
 
+	var server, proxy;
 
-	test_load_init {
-
-		var x, proxy;
-		var server = Server(this.class.name);
-
-		// fail safe for large inits - must be Integer for supernova
-		server.options.numWireBufs = (64 * (2 ** 7)).asInteger;
-
+	setUp {
+		// NOTE: these tests don't make use of a booted server
+		server = Server(this.class.name);
 		proxy = NodeProxy(server);
-
-		x = nil;
-		proxy.source = { x = "rebuilt"; SinOsc.ar([661.1, 877.1, 551.1]) };
-
-		this.assert(x == "rebuilt", "when server isn't running, the SynthDef should be built");
-
-		this.assert(
-			proxy.rate == \audio,
-			"when server isn't running, audio rate ugen graph should init neutral proxy in 'audio' rate",
-		);
-
-		this.assert(
-			proxy.numChannels == 3,
-			"when server isn't running, 3 channel ugen graph should init neutral proxy to 3 channels"
-		);
-
-		this.assert(
-			proxy.loaded == false,
-			"when server isn't running, nothing should be sent to it."
-		);
-		this.assert(
-			proxy.isPlaying == false,
-			"when server isn't running, NodeProxy shouldn't assume to be playing."
-		);
-
-		x = nil;
-
-		server.bootSync;
-
-		this.assert(
-			proxy.loaded == false,
-			"after server has started, NodeProxy shouldn't change by itself."
-		);
-
-		proxy.send;
-
-		this.assert(x == nil,
-			"by calling 'send', SynthDef shouldn't be rebuilt");
-
-		this.assert(proxy.isPlaying,
-			"after send: NodeProxy group should be playing");
-
-		this.assert(proxy.loaded == true,
-			"after send: NodeProxy should have sent resources to the server (loaded)");
-
-		proxy.rebuild;
-
-
-		this.assert(x == "rebuilt",
-			"after rebuilt: synth function should have been called");
-
-		this.assert(proxy.loaded == true,
-			"after rebuild and server running: resources should be on the server");
-
-		// QUIT
-		server.quit;
-		x = nil;
-		proxy.rebuild;
-
-		this.assert(x == "rebuilt",
-			"after server quit and rebuild: synth function should have been called");
-
-		this.assert(proxy.loaded == false,
-			"after server quit: no resources should be on the server");
-
-		/* will be fixed in master
-		proxy.send;
-		this.assert(proxy.loaded != true,
-		"after server quit: send should not assume server resources loaded");
-		*/
-
-		// CLEAR
-		proxy.clear;
-		try { proxy.ar(server.options.numAudioBusChannels * 2) };
-
-		this.assert(proxy.isNeutral,
-			"trying to allocate more bus channels than available should leave the node proxy untouched"
-		);
-
-		// ELASTIC
-
-		proxy.reshaping = \elastic;
-
-		try { Ndef(\x, { DC.ar(0 ! (server.options.numAudioBusChannels * 2)) }) };
-
-		this.assert(proxy.isNeutral,
-			"when elastic: trying to allocate more bus channels than available should leave the node proxy untouched"
-		);
-
-		proxy.ar(8);
-
-		this.assert(proxy.numChannels == 8,
-			"setting number of channels should change them"
-		);
-
-		try { Ndef(\x, { DC.ar(0 ! (server.options.numAudioBusChannels * 2)) }) };
-
-		this.assert(proxy.numChannels == 8,
-			"when elasic and initialised: trying to allocate more bus channels than available should leave the node proxy untouched"
-		);
-
-
-		proxy.clear;
-		server.quit;
-		server.remove;
-
 	}
 
-	test_fadeTime {
-
-		var server = Server(this.class.name);
-		var proxy;
-
-		server.bootSync;
-
-		proxy = NodeProxy(server);
-		proxy.fadeTime = 2;
-		proxy.reshaping = \elastic;
-		proxy.clear(1);
-		1.01.wait;
-
-		this.assert(proxy.isNeutral, "after fadeTime of clear, node proxy should be neutral again");
-
+	tearDown {
 		proxy.clear;
-		server.quit;
 		server.remove;
-
 	}
 
-	test_synthDefControl_build {
+	test_source_synthDef_build {
+		var x = nil;
 
-		var server = Server(this.class.name);
-		var proxy;
+		proxy.source = { x = true; Silent.ar };
+		this.assertEquals(x, true, "Setting a source should build the SynthDef");
+	}
 
-		server.bootSync;
+	test_source_rate {
+		proxy.source = { SinOsc.ar };
+		this.assertEquals(proxy.rate, \audio, "An audio rate ugen graph should init proxy to \audio rate");
+	}
 
-		proxy = NodeProxy(server);
+	test_source_numChannels {
+		proxy.source = { Silent.ar.dup(3) };
+		this.assertEquals(proxy.numChannels, 3, "A 3 channel ugen graph should init proxy to 3 channels");
+	}
+
+	test_source_proxy_loaded {
 		proxy.source = { Silent.ar };
-
-		this.assert(proxy.objects.first.hasFadeTimeControl, "functions should register their fadeTime control");
-
-		proxy.clear;
-		server.sync;
-		server.quit;
-		server.remove;
+		this.assertEquals(proxy.loaded, false, "Setting the proxy's source should not set loaded = true");
 	}
 
-	test_control_fade {
-		var server = Server(this.class.name);
-		var result, proxy, timeout;
-		var cond = Condition.new;
-		var fadeTime = 0.1;
-		var waitTime = (fadeTime + (server.latency * 2) + 1e-2);
-
-		server.bootSync;
-
-		proxy = NodeProxy(server);
-		proxy.source = { DC.kr(2000) };
-		proxy.fadeTime = fadeTime;
-
-		proxy.source = 440;
-		waitTime.wait;
-
-		OSCFunc({ cond.unhang }, '/c_set');
-		timeout = fork { 1.wait; cond.unhang };
-		proxy.bus.get({ |val| result = val });
-		cond.hang;
-		timeout.stop;
-
-		this.assertEquals(result, proxy.source, "after the crossfade from a ugen function to a value the bus should have this value");
-
-		server.quit;
-		server.remove;
+	test_source_proxy_isPlaying {
+		proxy.source = { Silent.ar };
+		this.assertEquals(proxy.isPlaying, false, "Setting the proxy's source should not set isPlaying = true");
 	}
 
 }
-

--- a/testsuite/classlibrary/TestNodeProxy_Server.sc
+++ b/testsuite/classlibrary/TestNodeProxy_Server.sc
@@ -1,0 +1,156 @@
+TestNodeProxy_Server : UnitTest {
+
+	var server, proxy;
+
+	setUp {
+		server = Server(this.class.name);
+		server.options.numWireBufs = 2048;
+		proxy = NodeProxy(server);
+		server.bootSync;
+	}
+
+	tearDown {
+		proxy.clear;
+		server.quit;
+		server.remove;
+	}
+
+	test_send_loaded {
+		proxy.source = { Silent.ar };
+		proxy.send;
+		this.assertEquals(proxy.loaded, true, "After sending, NodeProxy should be loaded");
+	}
+
+	test_send_isPlaying {
+		proxy.source = { Silent.ar };
+		proxy.send;
+		this.assertEquals(proxy.isPlaying, true, "After sending, NodeProxy should be playing");
+	}
+
+	test_rebuild {
+		var build;
+
+		proxy.source = { build = true; Silent.ar };
+		// set build to false in order to check that it gets set back to true after rebuild
+		build = false;
+		proxy.rebuild;
+		this.assertEquals(build, true, "Calling rebuild should build SynthDef again");
+	}
+
+	test_rebuild_loaded {
+		proxy.source = { Silent.ar };
+		proxy.rebuild;
+		this.assertEquals(proxy.loaded, true, "After rebuild, NodeProxy should be loaded");
+	}
+
+	test_send_synthDef_rebuild {
+		var build;
+
+		proxy.source = { build = true; Silent.ar };
+		// set build to false in order to check whether it stays false after calling send
+		build = false;
+		proxy.send;
+		this.assertEquals(build, false, "SynthDef should not be rebuilt when calling send");
+	}
+
+	test_loaded_after_quit {
+		proxy.send;
+		server.quit;
+		this.assertEquals(proxy.loaded, false, "NodeProxy should not be loaded after server quit");
+	}
+
+	test_send_after_quit {
+		proxy.send;
+		server.quit;
+		proxy.send;
+		this.assertEquals(proxy.loaded, false, "After server quit, sending should not set node as loaded");
+	}
+
+	test_rebuild_after_quit {
+		var build;
+
+		proxy.source = { build = true; Silent.ar };
+		server.quit;
+		proxy.rebuild;
+		this.assertEquals(build, true, "After server quit, rebuilding NodeProxy should rebuild SynthDef");
+	}
+
+	test_reshaping_nil_numChannels_expansion {
+		proxy.ar(2);
+		proxy.reshaping = nil;
+		proxy.source = { Silent.ar.dup(8) };
+		this.assertEquals(proxy.numChannels, 2, "When reshaping is nil, NodeProxy's number of channels should NOT be able to expand");
+	}
+
+	test_reshaping_nil_numChannels_contraction {
+		proxy.ar(8);
+		proxy.reshaping = nil;
+		proxy.source = { Silent.ar.dup(2) };
+		this.assertEquals(proxy.numChannels, 8, "When reshaping is nil, NodeProxy's number of channels should NOT be able to contract");
+	}
+
+	test_reshaping_elastic_numChannels_expansion {
+		proxy.ar(2);
+		proxy.reshaping = \elastic;
+		proxy.source = { Silent.ar.dup(8) };
+		this.assertEquals(proxy.numChannels, 8, "When reshaping is elastic, NodeProxy's number of channels should be able to expand");
+	}
+
+	test_reshaping_elastic_numChannels_contraction {
+		proxy.ar(8);
+		proxy.reshaping = \elastic;
+		proxy.source = { Silent.ar.dup(2) };
+		this.assertEquals(proxy.numChannels, 2, "When reshaping is elastic, NodeProxy's number of channels should be able to contract");
+	}
+
+	test_reshaping_expanding_numChannels_expansion {
+		proxy.ar(2);
+		proxy.reshaping = \expanding;
+		proxy.source = { Silent.ar.dup(8) };
+		this.assertEquals(proxy.numChannels, 8, "When reshaping is expanding, NodeProxy's number of channels should be able to expand");
+	}
+
+	test_reshaping_expanding_numChannels_contraction {
+		proxy.ar(8);
+		proxy.reshaping = \expanding;
+		proxy.source = { Silent.ar.dup(2) };
+		this.assertEquals(proxy.numChannels, 8, "When reshaping is expanding, NodeProxy's number of channels should NOT be able to contract");
+	}
+
+	test_clear_fadeTime {
+		var clearTime = 0.1;
+
+		proxy.fadeTime = 2;
+		proxy.reshaping = \elastic;
+		proxy.clear(clearTime);
+		clearTime.wait;
+
+		this.assertEquals(proxy.isNeutral, true, "After clearing with a fadeTime, NodeProxy should be neutral");
+	}
+
+	test_synthDefControl_build {
+		proxy.source = { Silent.ar };
+		this.assertEquals(proxy.objects.first.hasFadeTimeControl, true, "Functions should register their fadeTime control");
+	}
+
+	test_control_fade {
+		var result, timeout;
+		var cond = Condition.new;
+		var fadeTime = 0.2;
+		var waitTime = (fadeTime + (server.latency * 2) + 1e-2);
+
+		proxy.source = { DC.kr(2000) };
+		proxy.fadeTime = fadeTime;
+		proxy.source = 440;
+		waitTime.wait;
+
+		OSCFunc({ cond.unhang }, '/c_set');
+		timeout = fork{ 1.wait; cond.unhang };
+		proxy.bus.get({ |val| result = val });
+		cond.hang;
+		timeout.stop;
+
+		this.assertEquals(result, proxy.source, "After the crossfade from a ugen function to a value, the bus should have the correct value");
+	}
+
+}


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

This PR refactors UnitTests for NodeProxy. Tests that require a booted server have been moved to a new UnitTest called `TestNodeProxy_Server.sc`. Tests have been separated into individual test methods containing a single `assertEquals`.

## Types of changes

<!-- Delete lines that don't apply -->

- UnitTest refactoring

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [X] tests are passing
- [X] This PR is ready for review
