### PR TITLE
Properly manager Server in TestSanitize

### DIFF
--- a/testsuite/classlibrary/TestSanitize.sc
+++ b/testsuite/classlibrary/TestSanitize.sc
@@ -1,38 +1,49 @@
 TestSanitize : UnitTest {
 
-    test_sanitize {
-        var s, duration, expected;
-        var tests, testsIncomplete;
-        s = Server.default;
-        duration = 256 / s.sampleRate;
-        expected = 8888.0;
+	var server;
 
-        // Not using a Dictionary here to retain order
-        tests = [
-            "Sanitize.kr(8888)" -> { Sanitize.kr(expected, 0) },
-            "Sanitize.kr(inf)" -> { Sanitize.kr(inf, expected) },
-            "Sanitize.kr(-inf)" -> { Sanitize.kr(inf, expected) },
-            "Sanitize.kr(nan)" -> { Sanitize.kr(DC.kr(0) / 0, expected) },
+	setUp {
+		server = Server(this.class.name);
+		server.bootSync;
+	}
 
-            "Sanitize.ar(8888)" -> { Sanitize.ar(DC.ar(expected), 0) },
-            "Sanitize.ar(inf)" -> { Sanitize.ar(DC.ar(inf), expected) },
-            "Sanitize.ar(-inf)" -> { Sanitize.ar(DC.ar(-inf), expected) },
-            "Sanitize.ar(nan)" -> { Sanitize.ar(DC.ar(0) / 0, expected) }
-        ];
+	tearDown {
+		server.quit;
+		server.remove;
+	}
 
-        testsIncomplete = tests.size;
+	test_sanitize {
+		var duration, expected;
+		var tests, testsIncomplete;
+		duration = 256 / server.sampleRate;
+		expected = 8888.0;
 
-        tests.do { |test|
-            var text, ugenGraphFunc;
-            text = test.key;
-            ugenGraphFunc = test.value;
-            ugenGraphFunc.loadToFloatArray(duration, s, { |samples|
-                this.assertArrayFloatEquals(samples, expected, text);
-                testsIncomplete = testsIncomplete - 1;
-            });
-        };
+		// Not using a Dictionary here to retain order
+		tests = [
+			"Sanitize.kr(8888)" -> { Sanitize.kr(expected, 0) },
+			"Sanitize.kr(inf)" -> { Sanitize.kr(inf, expected) },
+			"Sanitize.kr(-inf)" -> { Sanitize.kr(inf, expected) },
+			"Sanitize.kr(nan)" -> { Sanitize.kr(DC.kr(0) / 0, expected) },
 
-        this.wait { testsIncomplete == 0 };
-    }
+			"Sanitize.ar(8888)" -> { Sanitize.ar(DC.ar(expected), 0) },
+			"Sanitize.ar(inf)" -> { Sanitize.ar(DC.ar(inf), expected) },
+			"Sanitize.ar(-inf)" -> { Sanitize.ar(DC.ar(-inf), expected) },
+			"Sanitize.ar(nan)" -> { Sanitize.ar(DC.ar(0) / 0, expected) }
+		];
+
+		testsIncomplete = tests.size;
+
+		tests.do { |test|
+			var text, ugenGraphFunc;
+			text = test.key;
+			ugenGraphFunc = test.value;
+			ugenGraphFunc.loadToFloatArray(duration, server, { |samples|
+				this.assertArrayFloatEquals(samples, expected, text);
+				testsIncomplete = testsIncomplete - 1;
+			});
+		};
+
+		this.wait { testsIncomplete == 0 };
+	}
 
 }


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

This PR fixes a bug in `TestSanitize` which caused it to fail. The failure happened when calling `256 / s.sampleRate`. Immediately after starting sclang, `s.sampleRate` is nil. To fix the error, I've made use of `setUp` and `tearDown` to manage booting/quitting the server.

I've also replaced the use of 4 spaces with tabs as per SC class library style.

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [X] tests are passing
- [ ] Updated documentation
- [X] This PR is ready for review
