### PR TITLE
TestFloat: handle "-nan" in test

### DIFF
--- a/testsuite/classlibrary/TestFloat.sc
+++ b/testsuite/classlibrary/TestFloat.sc
@@ -43,7 +43,12 @@ TestFloat : UnitTest {
 	}
 
 	test_asString_nan {
-		this.assertEquals((0/0).asString, "nan")
+		var zeroDivString = (0/0).asString;
+		if(zeroDivString == "-nan") {
+			this.assertEquals(zeroDivString, "-nan")
+		} {
+			this.assertEquals(zeroDivString, "nan")
+		}
 	}
 
 	test_asString_largeNumberUsesExp {


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

This PR improves `TestFloat.test_asString_nan` to allow it to handle the case on some platforms where zero division equals `-nan`.

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [X] tests are passing
- [ ] Updated documentation
- [X] This PR is ready for review
