### PR TITLE
CMake plugin template (used by cookiecutter): add NOVA_SIMD build option and include boost.

### DIFF
--- a/tools/cmake_gen/CMakeLists_header.template
+++ b/tools/cmake_gen/CMakeLists_header.template
@@ -52,3 +52,13 @@ option(SUPERNOVA "Build plugins for supernova" ON)
 option(SCSYNTH "Build plugins for scsynth" ON)
 option(NATIVE "Optimize for native architecture" OFF)
 option(STRICT "Use strict warning flags" OFF)
+option(NOVA_SIMD "Build plugins with nova-simd support." ON)
+
+####################################################################################################
+# include libraries
+
+include_directories(${SC_PATH}/external_libraries/boost)
+if (NOVA_SIMD)
+	add_definitions(-DNOVA_SIMD)
+	include_directories(${SC_PATH}/external_libraries/nova-simd)
+endif()

--- a/tools/cmake_gen/CMakeLists_header.template
+++ b/tools/cmake_gen/CMakeLists_header.template
@@ -57,7 +57,6 @@ option(NOVA_SIMD "Build plugins with nova-simd support." ON)
 ####################################################################################################
 # include libraries
 
-include_directories(${SC_PATH}/external_libraries/boost)
 if (NOVA_SIMD)
 	add_definitions(-DNOVA_SIMD)
 	include_directories(${SC_PATH}/external_libraries/nova-simd)


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation
The cookiecutter plugin build workflow doesn't currently support nova-simd or include the boost library.

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->

- New feature
This adds the `NOVA_SIMD` build option ~~and includes the `boost` library~~ by default so it's available to the cookiecutter plugin build workflow.

**Note**: The default `DNOVA_SIMD` flag is `ON`.

This gets the job done for making these libraries available to plugins, but I'm open to other options for optionally including these.

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
  - plugin built using both libraries
- [x] All tests are passing 
  - SC built just fine
- [x] Updated documentation
  - I didn't see any build flag documentation in the cookiecutter repo to update.
- [x] This PR is ready for review