### PR TITLE
help: clarify Document.autoRun

### DIFF
--- a/HelpSource/Classes/Document.schelp
+++ b/HelpSource/Classes/Document.schelp
@@ -97,7 +97,7 @@ argument:: action
 An instance of link::Classes/Function:: or link::Classes/FunctionList::.
 
 method:: autoRun
-If a document begins with the link::Classes/String::, code::"/*RUN*/"::, then the code following it int he file will be executed on opening the file, if autorun is set to true.
+If a document begins with the comment, code::/*RUN*/::, then the code following it in the file will be executed on opening the file, if autorun is set to true.
 argument:: value
 An instance of link::Classes/Boolean::. Default value is code::true::.
 


### PR DESCRIPTION


<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

Automatic execution of the code in the ```Document``` expects ```/*RUN*/``` at the beginning of the file, and not ```"/*RUN*/"```, as the documentation suggested.

Also fixed a typo further down in the description.


## Types of changes

<!-- Delete lines that don't apply -->

- Documentation

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Updated documentation
- [x] This PR is ready for review
