### PR TITLE
SC_Plugin.hpp: registerUnit, add no buffer aliasing flag.

### DIFF
--- a/include/plugin_interface/SC_PlugIn.hpp
+++ b/include/plugin_interface/SC_PlugIn.hpp
@@ -244,9 +244,9 @@ template <class UGenClass> void destroyClass(Unit* unit) { static_cast<UGenClass
 
 }
 
-template <class Unit> void registerUnit(InterfaceTable* ft, const char* name) {
+template <class Unit> void registerUnit(InterfaceTable* ft, const char* name, int disableBufferAliasing = 0) {
     UnitCtorFunc ctor = detail::constructClass<Unit>;
     UnitDtorFunc dtor = std::is_trivially_destructible<Unit>::value ? nullptr : detail::destroyClass<Unit>;
 
-    (*ft->fDefineUnit)(name, sizeof(Unit), ctor, dtor, 0);
+    (*ft->fDefineUnit)(name, sizeof(Unit), ctor, dtor, disableBufferAliasing);
 }


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

The `registerUnit` function conveniently combines registering constructors and destructors, but hard codes the flag that prevents buffer aliasing. Many UGens require non-aliased buffers. The [older defines](https://github.com/supercollider/supercollider/blob/63783aeca007c1e1d2a7cf73b3f3da056913f077/include/plugin_interface/SC_InterfaceTable.h#L213-L218) allowed this. This omission is noted in the [example-plugins](https://github.com/supercollider/example-plugins/blob/d0622ac6a4919bc7db134561d292d71337a9823d/02b-MySaw/MySaw2.cpp#L134).

## Types of changes

<!-- Delete lines that don't apply -->

- New feature
This flag simply allows preventing buffer aliasing. The default value of `0` should be a good choice because it's more common, and ensures backwards compatibility.


## To-do list

Questions for review:

- Does anyone know if this was an oversight or if it was intentionally hard coded?
- The argument name ins't great, so other suggestions are welcome. I'd also considered `cantAliasBufs`. Though I think it's better than the the corresponding [enum](https://github.com/supercollider/supercollider/blob/63783aeca007c1e1d2a7cf73b3f3da056913f077/include/plugin_interface/SC_Unit.h#L57-L59), `kUnitDef_CantAliasInputsToOutputs`.

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
  - tested on a multi input/output, non-aligned ugen
- [x] All tests are passing
  - building showed no problems (macOS)
- [ ] Updated documentation
  - after merging, `example-plugins` examples can be updated.
- [x] This PR is ready for review