### PR TITLE
classlib: Remove usage of deprecated method File.openDialog

### DIFF
--- a/SCClassLibrary/Common/Control/Buffer.sc
+++ b/SCClassLibrary/Common/Control/Buffer.sc
@@ -696,7 +696,7 @@ Buffer {
 		server = server ? Server.default;
 		bufnum ?? { bufnum = server.nextBufferNumber(1) };
 		buffer = super.newCopyArgs(server, bufnum).cache;
-		File.openDialog("Select a file...", { arg path;
+		Dialog.openPanel({ arg path;
 			buffer.doOnInfo_(action)
 				.allocRead(path, startFrame, numFrames, { ["/b_query", buffer.bufnum] })
 		});


### PR DESCRIPTION
## Purpose and Motivation

About a year ago, #3507 deprecated `File.openDialog`. However, one reference to this method remains in the core class library (`Buffer.loadDialog`).

This PR replaces that reference with `Dialog.openPanel`.

I would argue that `Buffer.loadDialog` itself should be deprecated, but that's a bigger discussion about which convenience methods should make the cut. In the meantime, it's a no-brainer to fix a deprecation warning.

Not done here: `Dialog.openPanel` supports a starting directory (!), but `Buffer.loadDialog` doesn't expose that as an argument. That would be an API change. Easy enough, I suppose, to add `, path` to the end of the argument list, but "just add an argument" has also caused other problems in the past -- so I'll raise it as a point for discussion but I won't unilaterally do that here.

## Types of changes

- Bug fix

## To-do list

- [x] Code is tested
- [x] All tests are passing (note, `Buffer.loadDialog` cannot be automatically tested as it requires user intervention)
- [x] This PR is ready for review
