### PR TITLE
Document:getText fixes

### DIFF
--- a/HelpSource/Classes/Document.schelp
+++ b/HelpSource/Classes/Document.schelp
@@ -320,7 +320,7 @@ Document.current.keyUpAction = { arg ...args; args.postln };
 Document.current.keyUpAction = nil;
 ::
 
-subsection:: Editing Content
+subsection:: Accessing and Editing Content
 
 method:: selectLine
 Select a line of the document by number.
@@ -418,6 +418,28 @@ Document.current.string_(": test test test test test ",
 )
 // Watch me change content
 ::
+
+method:: getText
+Get a range of text from the document. Synchronous. The text is directly returned.
+argument:: start
+An link::Classes/Integer:: for the starting position to access.
+argument:: range
+An link::Classes/Integer:: for the number of characters to retrieve. -1 retrieves to the end of the document.
+
+method:: getTextAsync
+Get a range of text from the document. Asynchronous. The text is passed to the code::action:: function as an argument.
+
+note:: Currently, in Windows, link::Classes/Document#-getText:: and link::Classes/Document#-string:: may be unreliable. Windows users are recommended to use link::Classes/Document#-getTextAsync:: for the time being.
+::
+
+argument:: action
+A function to evaluate after the request is complete. It is passed one argument, a link::Classes/String::, for the retrieved contents.
+argument:: start
+An link::Classes/Integer:: for the starting position to access.
+argument:: range
+An link::Classes/Integer:: for the number of characters to retrieve. -1 retrieves to the end of the document.
+
+
 
 subsection:: Subclassing and Internal Methods
 

--- a/SCClassLibrary/scide_scqt/ScIDE.sc
+++ b/SCClassLibrary/scide_scqt/ScIDE.sc
@@ -642,7 +642,7 @@ Document {
 		ScIDE.getTextByQUuid(quuid, funcID, start, range);
 	}
 
-	getText { |action, start = 0, range -1|
+	getText { |start = 0, range -1|
 		^this.prGetTextFromMirror(quuid, start, range);
 	}
 

--- a/SCClassLibrary/scide_scqt/ScIDE.sc
+++ b/SCClassLibrary/scide_scqt/ScIDE.sc
@@ -630,17 +630,20 @@ Document {
 
 	close { ScIDE.close(quuid); }
 
-	/*	// asynchronous get
+	// asynchronous get
 	// range -1 means to the end of the Document
-	getText {|action, start = 0, range -1|
+	// 'getText' tried to replace this approach,
+	// but text mirroring is unstable in Windows.
+	// so we need to keep a backup approach.
+	getTextAsync { |action, start = 0, range -1|
 		var funcID;
 		funcID = ScIDE.getQUuid; // a unique id for this function
 		asyncActions[funcID] = action; // pass the text
 		ScIDE.getTextByQUuid(quuid, funcID, start, range);
-	}*/
+	}
 
-	getText {|action, start = 0, range -1|
-		^prGetTextFromMirror(quuid, start, range);
+	getText { |action, start = 0, range -1|
+		^this.prGetTextFromMirror(quuid, start, range);
 	}
 
 	prGetTextFromMirror {|id, start=0, range = -1|

--- a/testsuite/classlibrary/TestDocument.sc
+++ b/testsuite/classlibrary/TestDocument.sc
@@ -52,4 +52,27 @@ TestDocument : UnitTest {
 			// TODO: skip
 		};
 	}
+
+	test_document_getText_retrievesText {
+		var doc, str;
+		this.assert(Platform.ideName == "scqt", "Document tests are valid only when run in the IDE");
+		doc = Document(string: "abc");
+		str = doc.getText;
+		doc.close;
+		this.assertEquals(str, "abc", "getText contents retrieved from document should match input contents");
+	}
+
+	test_document_getTextAsync_retrievesText {
+		var doc, str,
+		cond = Condition.new;
+		this.assert(Platform.ideName == "scqt", "Document tests are valid only when run in the IDE");
+		doc = Document(string: "abc");
+		doc.getTextAsync({ |text|
+			str = text;
+			cond.unhang;
+		}, 0, -1);
+		cond.hang;
+		doc.close;
+		this.assertEquals(str, "abc", "getTextAsync contents retrieved from document should match input contents");
+	}
 }


### PR DESCRIPTION
## Purpose and Motivation

1. `Document:getText` had a typo -- omitted `this.` -- so it could only throw an error.
   a. Also, remove `action` from its argument list.

2. Restore an asynchronous version of `getText` that had been commented out, under a new name `getTextAsync`.

Some history.

The asynchronous version was introduced in https://github.com/supercollider/supercollider/commit/977bd3a290ed70bbd399ea37899b763ebb098144 on July 18, 2013 (tagged Version-3.7.0-alpha0).

The synchronous version replacing it (https://github.com/supercollider/supercollider/commit/578ab14cf73d185ac90d90a12f99e49f22647704) dates to August 8, 2013, also tagged Version-3.7.0-alpha0.

So the asynchronous version existed for only about three weeks and was superseded before its alpha release. It's a safe bet, then, that no user code relies on the asynchronous version.

And, the synchronous version wasn't usable (edit). So it's a safe bet that no user code is relying on the current, synchronous version.

So I think my approach here is reasonable -- clean up `getText` (and remove the async response function `action` argument, which in fact is currently ignored).

Which leaves the question, why do we need `getTextAsync`? Because there is currently an undiagnosed and unfixed bug in document text mirroring in Windows. (I've raised this on sc-dev, but it's not getting much attention.) If you need the complete document contents, the only way to do this reliably in Windows at present is to ask the IDE process asynchronously for the contents.

I would suggest, until we are 100% sure that document text mirroring is reliable on all platforms, that we should keep the asynchronous approach around as a backup. User impact in my case is that I was accessing document contents in order to save them as part of a JIT patch (see https://github.com/jamshark70/JITModular/tree/topic/patch). In Windows, `aDocument.string` is frequently incomplete, meaning that students' code could be lost forever... not quite usable in the classroom.

## Types of changes

- Documentation
- Bug fix
- Breaking change (? maybe? explained above)

## To-do list

- [x] Code is tested
- [x] All tests are passing (added unit tests)
- [x] Updated documentation
- [x] This PR is ready for review
