### PR TITLE
[lang] Color -asHSV: Achromatic colors return nan

### DIFF
--- a/SCClassLibrary/Common/Core/Color.sc
+++ b/SCClassLibrary/Common/Core/Color.sc
@@ -141,7 +141,9 @@ Color {
 		if (blue == max, {hue = (red - green) / delta + 4});
 		hue = hue/6;
 		if (hue < 0, {hue = hue + 1});
+		if (hue.isNaN, {hue = 0.0});
 		sat = delta / max;
+		if (sat.isNaN, {sat = 0.0});
 		val = max;
 		^[hue, sat, val, alpha]
 	}


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

Achromatic colors (black, white, grey) return `nan` from `Color -asHSV` method. That makes calculations problematic. Correct me if I'm wrong, but I believe that 0 is an appropriate value for hue and saturation in these cases.

```supercollider
//before fix
Color.black.asHSV
// -> [ nan, nan, 0.0, 1.0 ]
Color.white.asHSV
// -> [ nan, 0.0, 1.0, 1.0 ]
Color.grey.asHSV
// -> [ nan, 0.0, 0.5, 1.0 ]

//after fix
Color.black.asHSV
// -> [ 0.0, 0.0, 0.0, 1.0 ]
Color.white.asHSV
// -> [ 0.0, 0.0, 1.0, 1.0 ]
Color.grey.asHSV
// -> [ 0.0, 0.0, 0.5, 1.0 ]

//also:
Color.hsv(*Color.black.asHSV) == Color.black; //false before fix, true after fix
```

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix
- Breaking change (?)

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [ ] All tests are passing (does this need tests?)
- [x] Updated documentation (documentation for this change is not needed)
- [x] This PR is ready for review
