### PR TITLE
class library: Deprecate String.scDir

### DIFF
--- a/HelpSource/Classes/String.schelp
+++ b/HelpSource/Classes/String.schelp
@@ -49,11 +49,7 @@ method::readNew
 Read the entire contents of a link::Classes/File:: and return them as a new String.
 
 method::scDir
-Provided for backwards compatibility.
-returns::
-the value of code::Platform.resourceDir::, which is the base resource directory of SuperCollider.
-discussion::
-Please use link::Classes/Platform#*resourceDir:: instead.
+Deprecated alias for code::Platform.resourceDir::. Please use link::Classes/Platform#*resourceDir:: instead.
 
 INSTANCEMETHODS::
 

--- a/HelpSource/Guides/standalones.schelp
+++ b/HelpSource/Guides/standalones.schelp
@@ -104,7 +104,7 @@ code::
 };
 
 // make some needed paths and folders
-~pathToThisApp = String.scDir.dirname.dirname;
+~pathToThisApp = Platform.resourceDir.dirname.dirname;
 ~thisAppName = ~pathToThisApp.basename.splitext.first;
 ~pathToNewApp = ~newAppLocation +/+ ~newAppName ++ ".app";
 ~newAppResDir = ~pathToNewApp +/+ "Contents/Resources";
@@ -185,13 +185,13 @@ list::
 code::
 (
 // 4. write a class extension file to look for the startupFile
-// in the app, in String.scDir for self-containment.
+// in the app, in Platform.resourceDir for self-containment.
 ~overDir = ~newAppResDir +/+ "SCClassLibrary/SystemOverwrites";
 File.mkdir(~overDir);
 ~writeText.value(~overDir +/+ "extModStartupFile.sc",
 	"+ OSXPlatform {
 	startupFiles {
-		^[String.scDir +/+ \"startup.scd\"];
+		^[Platform.resourceDir +/+ \"startup.scd\"];
 	}
 }
 "
@@ -314,7 +314,7 @@ unixCmd("open" + ~pathToNewApp);
 // AND IN THE NEW APP, run this to create a self-contained startup config file:
 (
 // use the internal extensions - repeat this when you move the app!
-LanguageConfig.addIncludePath(String.scDir +/+ "InternalExtensions");
+LanguageConfig.addIncludePath(Platform.resourceDir +/+ "InternalExtensions");
 // exclude the default
 LanguageConfig.addExcludePath(Platform.userExtensionDir);
 LanguageConfig.addExcludePath(Platform.systemExtensionDir);

--- a/SCClassLibrary/Common/Collections/String.sc
+++ b/SCClassLibrary/Common/Collections/String.sc
@@ -63,10 +63,6 @@ String[char] : RawArray {
 		^this.primitiveFailed
 	}
 
-	*scDir {
-		^Platform.resourceDir
-	}
-
 	compare { arg aString, ignoreCase=false;
 		_StringCompare
 		this.primitiveFailed;

--- a/SCClassLibrary/Platform/osx/OSXPlatform.sc
+++ b/SCClassLibrary/Platform/osx/OSXPlatform.sc
@@ -18,7 +18,7 @@ OSXPlatform : UnixPlatform {
 	}
 
 	startup {
-		Server.program = "exec %/scsynth".format((String.scDir +/+ "../Resources").shellQuote);
+		Server.program = "exec %/scsynth".format((Platform.resourceDir +/+ "../Resources").shellQuote);
 
 		Score.program = Server.program;
 

--- a/SCClassLibrary/deprecated/3.11/deprecated-3.11.sc
+++ b/SCClassLibrary/deprecated/3.11/deprecated-3.11.sc
@@ -11,3 +11,10 @@
 		^this.asInteger;
 	}
 }
+
++ String {
+    *scDir {
+        this.deprecated(thisMethod, Platform.class.findMethod(\resourceDir));
+        ^Platform.resourceDir
+    }
+}

--- a/platform/mac/Standalone Resources/SCClassLibrary/modifyStartup.sc
+++ b/platform/mac/Standalone Resources/SCClassLibrary/modifyStartup.sc
@@ -5,7 +5,7 @@
 //		^[this.systemAppSupportDir +/+ filename, this.userAppSupportDir +/+ filename];
 			// look for startup files inside the app Contents directory
 		var filename = "startup.*";
-		^(String.scDir +/+ filename).pathMatch;
+		^(Platform.resourceDir +/+ filename).pathMatch;
 	}
 
 	startup {
@@ -39,8 +39,8 @@
 		interpreter.s = Server.default;
 
 			// some folder paths that should point inside the app's Contents folder
-		SynthDef.synthDefDir = String.scDir +/+ "synthdefs/";
-		Archive.archiveDir = String.scDir;
+		SynthDef.synthDefDir = Platform.resourceDir +/+ "synthdefs/";
+		Archive.archiveDir = Platform.resourceDir;
 
 		this.platform.startup;
 
@@ -57,7 +57,7 @@
 
 		Server.default.waitForBoot({
 			SCSA_Demo.new("The Cheese Stands Alone", Rect(400, 400, 300, 200), interpreter.s).front;
-//			(String.scDir.dirname ++ "/MFBSD.rtf").load;
+//			(Platform.resourceDir.dirname ++ "/MFBSD.rtf").load;
 		});
 		// close post window if user should not have it
 //		Document.listener.close


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

`String.scDir` is an old alias for `Platform.resourceDir`. this PR fixes all erroneous uses of it in the SC code base and causes the method to emit a deprecation warning.

## Types of changes

<!-- Delete lines that don't apply -->

- Documentation
- Breaking change

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [ ] Code is tested
- [ ] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review
