### PR TITLE
EnvirGui: fix accidental overwrite of flag, SkipJack: fix stop method.

### DIFF
--- a/SCClassLibrary/Common/Control/SkipJack.sc
+++ b/SCClassLibrary/Common/Control/SkipJack.sc
@@ -45,9 +45,9 @@ SkipJack {
 	play { this.start }
 
 	stop {
-		task.stop;
 		all.remove(this);
 		CmdPeriod.remove(this);
 		if( verbose ) { ("SkipJack" + name + "stopped.").postcln };
+		task.stop;
 	}
 }

--- a/SCClassLibrary/Common/Control/SkipJack.sc
+++ b/SCClassLibrary/Common/Control/SkipJack.sc
@@ -47,7 +47,7 @@ SkipJack {
 	stop {
 		all.remove(this);
 		CmdPeriod.remove(this);
-		if( verbose ) { ("SkipJack" + name + "stopped.").postcln };
+		if( verbose ) { ("SkipJack" + name + "stopping.").postcln };
 		task.stop;
 	}
 }

--- a/SCClassLibrary/JITLib/GUI/EnvirGui.sc
+++ b/SCClassLibrary/JITLib/GUI/EnvirGui.sc
@@ -25,7 +25,7 @@ EnvirGui : JITGui {
 	}
 
 	*new { |object, numItems = 8, parent, bounds, makeSkip = true, options = #[]|
-		^super.new(object, numItems, parent, bounds, makeSkip = true, options);
+		^super.new(object, numItems, parent, bounds, makeSkip, options);
 	}
 
 	setDefaults {


### PR DESCRIPTION
## Purpose and Motivation

This fixes two related bugs: 
- EnvirGui:new always created a skipjack (accidental overwrite of the makeSkip flag)
- When a SkipJack stopped by its stopTest, it would not remove itself properly. 
 
- [x] Code is tested
- [x] All tests are passing
- [x] This PR is ready for review

```
///// Tests:

z = SkipJack({ "..".postln }, 1, { a == 0 }, \test);

// test stop with .stop method:
z.stop;
SkipJack.all.includes(z).not;  // true is OK
CmdPeriod.objects.includes(z).not; // true is OK


z.start;
// test stopping with stoptest
a = 0; // stoptest becomes true
SkipJack.all.includes(z).not;  // true is OK
CmdPeriod.objects.includes(z).not; // true is OK
```