### PR TITLE
fix for issue #3924 (Help Browser executing selected code twice)

### DIFF
--- a/editors/sc-ide/widgets/help_browser.cpp
+++ b/editors/sc-ide/widgets/help_browser.cpp
@@ -333,8 +333,7 @@ void HelpBrowser::evaluateSelection(bool evaluateRegion) {
     QString selected = mWebView->selectedText();
     if (!selected.isEmpty()) {
         Main::scProcess()->evaluateCode(selected);
-    }
-    {
+    } else {
         mWebView->page()->runJavaScript(evaluateRegion ? jsSelectRegion : jsSelectLine, [this](QVariant res) {
             QString selectionResult = res.toString();
             if (!selectionResult.isEmpty()) {


### PR DESCRIPTION
missing else in if-else in HelpBrowser::evaluateSelection()

## Purpose and Motivation

Fixes  #3924

## Types of changes
- Bug fix

## To-do list
- [x] Code is tested
- [x] This PR is ready for review
