### PR TITLE
Workaround build errors on musl libc

### DIFF
--- a/common/SC_Filesystem_unix.cpp
+++ b/common/SC_Filesystem_unix.cpp
@@ -32,6 +32,11 @@
 // system
 #include <glob.h> // ::glob, glob_t
 
+// workaround for musl not yet supporting GLOB_TILDE
+#ifndef GLOB_TILDE
+#define GLOB_TILDE 0
+#endif
+
 using Path = SC_Filesystem::Path;
 using DirName = SC_Filesystem::DirName;
 using DirMap = SC_Filesystem::DirMap;


### PR DESCRIPTION
Currently musl does not support GLOB_TILDE but it is on their roadmap [1]. This
patch is no fix and changes functionality for musl. A slightly changed
functionality seems better than being unable to build.

For glibc and future versions of musl this change is a noop.

[1] https://wiki.musl-libc.org/roadmap.html

Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>

<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->

- Documentation
- Bug fix
- New feature
- Breaking change

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [ ] Code is tested
- [ ] All tests are passing
- [ ] Updated documentation
- [ ] This PR is ready for review
