### PR TITLE
Classlib: Quarks: Print errorString if fetchDirectory failed

### DIFF
--- a/SCClassLibrary/Common/Quarks/Quarks.sc
+++ b/SCClassLibrary/Common/Quarks/Quarks.sc
@@ -325,7 +325,9 @@ Quarks {
 			if(fetch, { this.prFetchDirectory });
 			this.prReadDirectoryFile(dirTxtPath);
 		}.try({ arg err;
-			("Failed to read quarks directory listing: % %".format(if(fetch, directoryUrl, dirTxtPath), err)).error;
+			var text = err.tryPerform(\errorString);
+			if(text.isNil) { text = err.asString };
+			("Failed to read quarks directory listing: % %".format(if(fetch, directoryUrl, dirTxtPath), text)).error;
 			if(fetch, {
 				// if fetch failed, try read from cache
 				if(File.exists(dirTxtPath), {

--- a/SCClassLibrary/Common/Quarks/Quarks.sc
+++ b/SCClassLibrary/Common/Quarks/Quarks.sc
@@ -325,9 +325,12 @@ Quarks {
 			if(fetch, { this.prFetchDirectory });
 			this.prReadDirectoryFile(dirTxtPath);
 		}.try({ arg err;
-			var text = err.tryPerform(\errorString);
-			if(text.isNil) { text = err.asString };
-			("Failed to read quarks directory listing: % %".format(if(fetch, directoryUrl, dirTxtPath), text)).error;
+			// 'err' should, by definition, be an Exception
+			// and all Exceptions should respond to 'errorString'
+			// but "throw during error handling" is really really bad,
+			// so, be doubly sure it won't happen
+			var text = err.tryPerform(\errorString) ?? { text = err.asString };
+			("Failed to read quarks directory listing: %\n%".format(if(fetch, directoryUrl, dirTxtPath), text)).error;
 			if(fetch, {
 				// if fetch failed, try read from cache
 				if(File.exists(dirTxtPath), {


### PR DESCRIPTION
## Purpose and Motivation

We have received multiple reports of the following error message:

```
ERROR: Failed to read quarks directory listing:
https://github.com/supercollider-quarks/quarks.git
a PrimitiveFailedError
```

Troubleshooting this is deadlocked because the error message embeds the error object `asString`, which only prints the error's class name and omits the error string.

We should print a descriptive error message, if one is available.

## Types of changes

- Bug fix

## To-do list

- [x] Code is tested
- [x] All tests are passing
- [x] This PR is ready for review

As this is a class-library-only change, it does not need to wait for codebase reformatting.