### PR TITLE
Windows: fix for #4412 - extra SuperCollider directory in Platform.recordingsDir

### DIFF
--- a/SCClassLibrary/Platform/windows/WindowsPlatform.sc
+++ b/SCClassLibrary/Platform/windows/WindowsPlatform.sc
@@ -8,7 +8,7 @@ WindowsPlatform : Platform {
 
 	initPlatform {
 		super.initPlatform;
-		recordingsDir = this.myDocumentsDir +/+ "SuperCollider" +/+ "Recordings";
+		recordingsDir = this.myDocumentsDir +/+ "Recordings";
 	}
 
 	startup {


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

fixes issue #4412.

Changes Platform.recordingsDir on Windows to return:

`C:\Users\<username>\Documents\SuperCollider\Recordings`

Before this commit - `C:\Users\<username>\Documents\SuperCollider\SuperCollider\Recordings`

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] This PR is ready for review
