### PR TITLE
fix for #4422: use mousewheel angleDelta if pixelDelta not available

### DIFF
--- a/QtCollider/QWidgetProxy.cpp
+++ b/QtCollider/QWidgetProxy.cpp
@@ -372,8 +372,9 @@ bool QWidgetProxy::interpretMouseWheelEvent(QObject* o, QEvent* e, QList<QVarian
     QWidget* w = widget();
     QPoint pt = _mouseEventWidget == w ? we->pos() : _mouseEventWidget->mapTo(w, we->pos());
 
-    QPointF delta = we->pixelDelta();
-    delta *= 0.25f; // This matches old scaling of delta
+    // only hi-res trackpads return pixelDelta everything else uses angleDelta..
+    QPointF delta = we->pixelDelta().isNull() ? we->angleDelta() / 8.f // scaled to return steps of 15
+                                              : we->pixelDelta() * 0.25f; // this matches old scaling of delta
 
     args << pt.x();
     args << pt.y();


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

Fixes #4422.

Previously, interpretMouseWheelEvent only used QWheelEvent::pixelDelta().
pixelDelta is only valid on systems with hi-res trackpads, whereas angleDelta() is always available.

https://doc.qt.io/qt-5/qwheelevent.html#details

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

Checks if pixelDelta().isNull(), uses QWheelEvent::angleDelta() instead.

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] This PR is ready for review