### PR TITLE
Classlib: Add 'composite' event type to default Event prototype

### DIFF
--- a/HelpSource/Classes/Event.schelp
+++ b/HelpSource/Classes/Event.schelp
@@ -138,6 +138,17 @@ Pbind(\degree, Pseq([0, 1, 2, 3, 4, 4, 5, 5, 5, 5, 4, 2, 3, 2, 3, 1], inf), \dur
 
 ::
 
+method::removeEventType
+Remove an event type function from the collection. If there is an associated event type parent, this will be removed also.
+
+argument::type
+A name (usually a symbol) for the event type.
+
+method::removeParentType
+Remove a parent event associated with an event type.
+
+argument::type
+A name (usually a symbol) for the event type.
 
 
 method::makeDefaultSynthDef

--- a/HelpSource/Overviews/Event_types.schelp
+++ b/HelpSource/Overviews/Event_types.schelp
@@ -80,6 +80,15 @@ table::
 
 ## rest || do nothing for a specified amount of time
 
+## composite || perform any number of event types, given as ~types
+code::
+MIDIClient.init;
+m = MIDIOut(0);
+
+// should play a synth *and* an external MIDI note simultaneously
+(type: \composite, types: [\note, \midi], midiout: m, degree: 0, dur: 3).play;
+::
+
 ## bus || write ~array to control buses starting at ~out
 ## audioBus || allocate ~channels consecutive audio buses
 ## controlBus || allocate ~channels consecutive control buses

--- a/HelpSource/Tutorials/A-Practical-Guide/PG_08_Event_Types_and_Parameters.schelp
+++ b/HelpSource/Tutorials/A-Practical-Guide/PG_08_Event_Types_and_Parameters.schelp
@@ -428,7 +428,7 @@ Very important: Arrays normally multi-channel expand in patterns. So, you must w
 subsection::Miscellaneous
 
 definitionList::
-## composite || Perform any number of event types, given as ~types. Users should ensure that parameters are compatible. It is possible, using code::\composite::, to play a synth and send MIDI for the same pitches. It is not possible to use one frequency for the synth and a different one for MIDI, in the same event (you would need two different events for that case).
+## composite || Perform any number of event types, given as ~types. You should ensure that parameters are compatible. It is possible, using code::\composite::, to play a synth and send MIDI for the same pitches. It is not possible to use one frequency for the synth and a different one for MIDI, in the same event (you would need two different events for that case).
 
 definitionList::
 ## types || An array of Symbols, listing the Event types to be performed.

--- a/HelpSource/Tutorials/A-Practical-Guide/PG_08_Event_Types_and_Parameters.schelp
+++ b/HelpSource/Tutorials/A-Practical-Guide/PG_08_Event_Types_and_Parameters.schelp
@@ -428,6 +428,20 @@ Very important: Arrays normally multi-channel expand in patterns. So, you must w
 subsection::Miscellaneous
 
 definitionList::
+## composite || Perform any number of event types, given as ~types. Users should ensure that parameters are compatible. It is possible, using code::\composite::, to play a synth and send MIDI for the same pitches. It is not possible to use one frequency for the synth and a different one for MIDI, in the same event (you would need two different events for that case).
+
+definitionList::
+## types || An array of Symbols, listing the Event types to be performed.
+::
+
+code::
+MIDIClient.init;
+m = MIDIOut(0);
+
+// should play a synth *and* an external MIDI note simultaneously
+(type: \composite, types: [\note, \midi], midiout: m, degree: 0, dur: 3).play;
+::
+
 ## phrase || See link::Tutorials/JITLib/recursive_phrasing::.
 
 ## setProperties || Set variables belonging to a given object. One possible use is to control a GUI using a pattern.

--- a/SCClassLibrary/Common/Collections/Event.sc
+++ b/SCClassLibrary/Common/Collections/Event.sc
@@ -971,8 +971,10 @@ Event : Environment {
 					},
 
 					composite: { |server|
-						~types.do { |type|
-							~eventTypes[type].value(server);
+						~resultEvents = ~types.collect { |type|
+							if(type != \composite) {
+								currentEnvironment.copy.put(\type, type).play;
+							};
 						};
 					}
 				)

--- a/SCClassLibrary/Common/Collections/Event.sc
+++ b/SCClassLibrary/Common/Collections/Event.sc
@@ -968,6 +968,12 @@ Event : Environment {
 							server.sendBundle(server.latency, *~bundle);
 						};
 						~bundle = nil;
+					},
+
+					composite: { |server|
+						~types.do { |type|
+							~eventTypes[type].value(server);
+						};
 					}
 				)
 			)

--- a/SCClassLibrary/Common/Collections/Event.sc
+++ b/SCClassLibrary/Common/Collections/Event.sc
@@ -25,14 +25,23 @@ Event : Environment {
 
 	// event types
 
-	*addEventType { arg type, func, parentEvent;
+	*addEventType { |type, func, parentEvent|
 		partialEvents.playerEvent.eventTypes.put(type, func);
 		this.addParentType(type, parentEvent)
 	}
 
-	*addParentType { arg type, parentEvent;
+	*addParentType { |type, parentEvent|
 		if(parentEvent.notNil and: { parentEvent.parent.isNil }) { parentEvent.parent = defaultParentEvent };
 		partialEvents.playerEvent.parentTypes.put(type, parentEvent)
+	}
+
+	*removeEventType { |type|
+		Event.removeParentType(type);
+		partialEvents.playerEvent.eventTypes.removeAt(type);
+	}
+
+	*removeParentType { |type|
+		partialEvents.playerEvent.parentTypes.removeAt(type)
 	}
 
 	*parentTypes {

--- a/testsuite/classlibrary/TestEvent.sc
+++ b/testsuite/classlibrary/TestEvent.sc
@@ -256,8 +256,8 @@ TestEvent : UnitTest {
 		Event.addEventType(\composite2, { test2 = true });
 		(type: \composite, types: #[composite1, composite2]).play;
 		this.assert(test1 && test2, "Composite event type should call all listed event type functions");
-		Event.eventTypes.removeAt(\composite1);
-		Event.eventTypes.removeAt(\composite2);
+		Event.removeEventType(\composite1);
+		Event.removeEventType(\composite2);
 	}
 
 	test_composite_event_type_ignores_composite {

--- a/testsuite/classlibrary/TestEvent.sc
+++ b/testsuite/classlibrary/TestEvent.sc
@@ -250,6 +250,16 @@ TestEvent : UnitTest {
 		this.cleanUpMessages;
 	}
 
+	test_composite_event_type_calls_all_listed_types {
+		var test1 = false, test2 = false;
+		Event.addEventType(\composite1, { test1 = true });
+		Event.addEventType(\composite2, { test2 = true });
+		(type: \composite, types: #[composite1, composite2]).play;
+		this.assert(test1 && test2, "Composite event type should call all listed event type functions");
+		Event.eventTypes.removeAt(\composite1);
+		Event.eventTypes.removeAt(\composite2);
+	}
+
 	cleanUpMessages {
 		prevMsg = nil;
 		prevLatency = nil;

--- a/testsuite/classlibrary/TestEvent.sc
+++ b/testsuite/classlibrary/TestEvent.sc
@@ -260,6 +260,18 @@ TestEvent : UnitTest {
 		Event.eventTypes.removeAt(\composite2);
 	}
 
+	test_composite_event_type_ignores_composite {
+		var event = (type: \composite, types: #[note, composite]).play;
+		this.assert(event[\resultEvents][1].isNil, "Composite event type should not try to call itself")
+	}
+
+	test_composite_event_type_generates_unique_node_IDs {
+		var event = (type: \composite, types: #[note, note]).play;
+		this.assert(event[\resultEvents][0][\id] != event[\resultEvents][1][\id],
+			"Composite event subtypes should not have node ID clashes"
+		);
+	}
+
 	cleanUpMessages {
 		prevMsg = nil;
 		prevLatency = nil;


### PR DESCRIPTION
## Purpose and Motivation

Within the last month or so, I've seen 4 or 5 separate questions (on the mailing list, the forum, and today on Facebook) asking how to make one event take multiple actions.

I propose to add a `composite` event type to handle this.

Example -- `types: [\note, \midi]` sends a synth message and MIDI.

```
MIDIClient.init;
MIDIIn.connectAll;

// Linux MIDIOut usage, change this for Mac/Windows
// it's only to print the MIDI, not critical
m = MIDIOut(0);
m.connect(2);

MIDIFunc.trace(true);
s.waitForBoot { s.dumpOSC(1) };

(type: \composite, types: [\note, \midi], midiout: m, degree: 0, dur: 3).play;

->

[ "#bundle", 16187144061062032979, 
  [ 9, "default", 1001, 0, 1, "out", 0, "freq", 261.626, "amp", 0.1, "pan", 0 ]
]

MIDI Message Received:
	type: noteOn
	src: 8454148
	chan: 0
	num: 60
	val: 12

// note off follows, omitted here
```

### To discuss

Many event types modify the event. This implementation does not protect against that -- each event type incrementally modifies the same event object. This is debatable.

- On the one hand, it is not the same as producing two events with the same contents (except `type`) and playing them separately. I think the risk is low, but it's not risk-free.

- On the other hand, currently, when you `play` an event, you have access to the event that has been modified by the event type action. If `composite` were to copy the event for each subtype, you would get better encapsulation but the user would not be able to see the result (e.g., no access to node IDs).

I'm about 50-50 on this. Encapsulation is important, but so is not breaking the public interface of access to the event's intermediate values.

If consensus is that encapsulation is more important, I'm happy to change it.

## Types of changes

- Documentation
- New feature

## To-do list

- [x] Code is tested (added `TestEvent` method)
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review
