### PR TITLE
Quarks Doc: remove suggestion to use @refspec in git URL

### DIFF
--- a/HelpSource/Guides/UsingQuarks.schelp
+++ b/HelpSource/Guides/UsingQuarks.schelp
@@ -177,22 +177,18 @@ Hard drives die, backups fail, people make mistakes. If you keep a copy on bitbu
 
 section:: Publishing a Quark
 
-Make a git repository and push it to github, bitbucket or any publicly accessible git host.
+Make a git repository and push it to github, gitlab, bitbucket or any publicly accessible git host.
 
-tag your releases. The name of the tag is the name of the release version. Using semver (eg "1.0.1") is recommended. This provides the Quarks system with a way to list versions in the interface and to checkout a version and for people to pin dependencies to a stable release. it also provides a downloadable version on your github releases page.
+Be sure to strong::tag your releases::. The name of a tag should be the release version to which it corresponds. Using link::https://semver.org##Semantic Versioning:: (eg "v1.0.1") is strongly recommended. This provides the Quarks system with the ability to list available versions and allow the user to choose which version to checkout. Version tags also allow other quark developpers to pin their dependencies to specific release versions.
 
-If its on github then anybody can install your quark.
-
-You can also add your quark to the community directory:
+You can add your quark to the Community Quark Directory by adding its name and git URL to the following file:
 
 https://github.com/supercollider-quarks/quarks/blob/master/directory.txt
 
-Simply click teletype::edit::, make any changes and submit a pull request.
-
-You specify the name, the git url and optionally the most recent version as @tags/{version-name}
+Simply click teletype::edit::, add in your quark's info, and submit a pull request. Here's an example of what an entry should look like in the Quark Directory:
 
 code::
-quarkname=git://github.com/author/quarkname@tags/4.1.4
+quarkname=https://github.com/author/quarkname
 ::
 
 subsection::Migrated Quarks from SVN


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

Updates Quarks documentation and removes the suggestion to add @refspec's to the git URL.

## Types of changes

<!-- Delete lines that don't apply -->

- Documentation

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [ ] All tests are passing
- [X] Updated documentation
- [X] This PR is ready for review
