### PR TITLE
Topic/simplenumber series

### DIFF
--- a/HelpSource/Classes/SimpleNumber.schelp
+++ b/HelpSource/Classes/SimpleNumber.schelp
@@ -487,6 +487,8 @@ l = [0, 1, 5, 9, 11]; // pentatonic scale
 
 method:: series
 return an arithmetic series from this over second to last.
+The last value may not be included in the result if the step size does not divide evenly into the range of the series.
+
 discussion::
 This is used in the shortcuts:
 code::

--- a/lang/LangPrimSource/PyrMathPrim.cpp
+++ b/lang/LangPrimSource/PyrMathPrim.cpp
@@ -862,8 +862,12 @@ int prSimpleNumberSeries(struct VMGlobals* g, int numArgsPushed) {
         }
 
         step = second - first;
-        size = (int)((last - first) / step) + 1;
-
+        if (step == 0.f) {
+            size = 1;
+        } else {
+            size = (int)((last - first) / step) + 1;
+        }
+        
         if ((size < 1) || ((step >= 0) && (last < first)) || ((step <= 0) && (last > first))) {
             post(
                 "prSimpleNumberSeries: arguments do not form an arithmetic progression:\n \tfirst: %f, step: %f, last %f\n",

--- a/lang/LangPrimSource/PyrMathPrim.cpp
+++ b/lang/LangPrimSource/PyrMathPrim.cpp
@@ -813,9 +813,9 @@ int prSimpleNumberSeries(struct VMGlobals* g, int numArgsPushed) {
             size = ((last - first) / step) + 1;
 
         if ((size < 1) || ((step >= 0) && (last < first)) || ((step <= 0) && (last > first))) {
-            post(
-                "prSimpleNumberSeries: arguments do not form an arithmetic progression:\n \tfirst: %i, step: %i, last %i\n",
-                first, step, last);
+            post("prSimpleNumberSeries: arguments do not form an arithmetic progression:\n\tfirst: %i, step: %i, last "
+                 "%i\n",
+                 first, step, last);
             return errFailed;
         }
         if (size > INT_MAX_BY_PyrSlot) {
@@ -869,9 +869,9 @@ int prSimpleNumberSeries(struct VMGlobals* g, int numArgsPushed) {
         }
         
         if ((size < 1) || ((step >= 0) && (last < first)) || ((step <= 0) && (last > first))) {
-            post(
-                "prSimpleNumberSeries: arguments do not form an arithmetic progression:\n \tfirst: %f, step: %f, last %f\n",
-                first, step, last);
+            post("prSimpleNumberSeries: arguments do not form an arithmetic progression:\n\tfirst: %f, step: %f, last "
+                 "%f\n",
+                 first, step, last);
             return errFailed;
         }
         if (size > INT_MAX_BY_PyrSlot) {

--- a/lang/LangPrimSource/PyrMathPrim.cpp
+++ b/lang/LangPrimSource/PyrMathPrim.cpp
@@ -814,7 +814,7 @@ int prSimpleNumberSeries(struct VMGlobals* g, int numArgsPushed) {
 
         if ((size < 1) || ((step >= 0) && (last < first)) || ((step <= 0) && (last > first))) {
             post(
-                "prSimpleNumberSeries: arguments do not form an arithmetic progression: first: %i, step: %i, last %i\n",
+                "prSimpleNumberSeries: arguments do not form an arithmetic progression:\n \tfirst: %i, step: %i, last %i\n",
                 first, step, last);
             return errFailed;
         }
@@ -866,7 +866,7 @@ int prSimpleNumberSeries(struct VMGlobals* g, int numArgsPushed) {
 
         if ((size < 1) || ((step >= 0) && (last < first)) || ((step <= 0) && (last > first))) {
             post(
-                "prSimpleNumberSeries: arguments do not form an arithmetic progression: first: %f, step: %f, last %f\n",
+                "prSimpleNumberSeries: arguments do not form an arithmetic progression:\n \tfirst: %f, step: %f, last %f\n",
                 first, step, last);
             return errFailed;
         }

--- a/lang/LangPrimSource/PyrMathPrim.cpp
+++ b/lang/LangPrimSource/PyrMathPrim.cpp
@@ -867,7 +867,7 @@ int prSimpleNumberSeries(struct VMGlobals* g, int numArgsPushed) {
         } else {
             size = (int)((last - first) / step) + 1;
         }
-        
+
         if ((size < 1) || ((step >= 0) && (last < first)) || ((step <= 0) && (last > first))) {
             post("prSimpleNumberSeries: arguments do not form an arithmetic progression:\n\tfirst: %f, step: %f, last "
                  "%f\n",

--- a/lang/LangPrimSource/PyrMathPrim.cpp
+++ b/lang/LangPrimSource/PyrMathPrim.cpp
@@ -862,7 +862,7 @@ int prSimpleNumberSeries(struct VMGlobals* g, int numArgsPushed) {
         }
 
         step = second - first;
-        size = (int)floor((last - first) / step + 0.001) + 1;
+        size = (int)((last - first) / step) + 1;
 
         if ((size < 1) || ((step >= 0) && (last < first)) || ((step <= 0) && (last > first))) {
             post(

--- a/testsuite/classlibrary/TestSimpleNumber.sc
+++ b/testsuite/classlibrary/TestSimpleNumber.sc
@@ -181,5 +181,13 @@ TestSimpleNumber : UnitTest {
 		var last = 8;
 		var arr = first.series(step, last);
 		this.assert(arr.last <= last, "SimpleNumber:series should not produce an array whose last value is greater than the specified 'last' argument.");
+
+		first = 1;
+		arr = first.series(first, first);
+		this.assert(arr.size == 1, "SimpleNumber:series Int types with first == last and step == 0 should return an array of [ first ]");
+
+		first = 1.1;
+		arr = first.series(first, first);
+		this.assert(arr.size == 1, "SimpleNumber:series Float types with first == last and step == 0 should return an array of [ first ]");
 	}
 }

--- a/testsuite/classlibrary/TestSimpleNumber.sc
+++ b/testsuite/classlibrary/TestSimpleNumber.sc
@@ -174,4 +174,12 @@ TestSimpleNumber : UnitTest {
 		this.assertEquals(testF.(val,1,0,1), val, "Test 10 (edge case): snap(1, 0, 1)");
 		this.assertEquals(testF.(val,1,2,1), [ -1, 0, 0, 1, 1, 1 ] , "Test 11 (edge case): snap(1, 2, 1)");
 	}
+
+	test_series {
+		var first = 0;
+		var step = 2.0001;
+		var last = 8;
+		var arr = first.series(step, last);
+		this.assert(arr.last <= last, "SimpleNumber:series should not produce an array whose last value is greater than the specified 'last' argument.");
+	}
 }


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

This fixes #4452, where `SimpleNumber:series` can overshoot its last value if the step is specified as a `float` and does not evenly divide into the range of the series.

The problem is illustrated here:
```supercollider
(0, 39952.0 .. 958845).last
// -> 958848.0 // overshoots 'last' value
(0, 39952   .. 958845).last
// -> 918896   // int type stops short of 'last', as expected
(0, 2.00001 .. 8).last
// -> 8.0004   // overshoots when step is near an even division
(0, 3.0 .. 8.0).last
// -> 6.0      // otherwise stops short
```

## Types of changes
- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review