### PR TITLE
synth: Prevent data from being freed twice in AsyncPlugInCmd

### DIFF
--- a/server/scsynth/SC_SequencedCommand.cpp
+++ b/server/scsynth/SC_SequencedCommand.cpp
@@ -1444,9 +1444,7 @@ AsyncPlugInCmd::AsyncPlugInCmd(
     }
 }
 
-AsyncPlugInCmd::~AsyncPlugInCmd() {
-    (mCleanup)(mWorld, mCmdData);
-}
+AsyncPlugInCmd::~AsyncPlugInCmd() { (mCleanup)(mWorld, mCmdData); }
 
 void AsyncPlugInCmd::CallDestructor() { this->~AsyncPlugInCmd(); }
 

--- a/server/scsynth/SC_SequencedCommand.cpp
+++ b/server/scsynth/SC_SequencedCommand.cpp
@@ -1446,8 +1446,6 @@ AsyncPlugInCmd::AsyncPlugInCmd(
 
 AsyncPlugInCmd::~AsyncPlugInCmd() {
     (mCleanup)(mWorld, mCmdData);
-    if (mMsgData)
-        World_Free(mWorld, mMsgData);
 }
 
 void AsyncPlugInCmd::CallDestructor() { this->~AsyncPlugInCmd(); }


### PR DESCRIPTION

<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

Without this, World_Free is called on the same memory twice, as SequencedCmd also frees this pointer. This then causes the FIFO queue on the thread to get into trouble and render the server unresponsive.

Fixes #4338

## Types of changes

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [ ] All tests are passing
- [n/a] Updated documentation
- [ ] This PR is ready for review
