### PR TITLE
[classlib] Plotter: add multiple concurrent modes

### DIFF
--- a/HelpSource/Classes/Plotter.schelp
+++ b/HelpSource/Classes/Plotter.schelp
@@ -134,6 +134,25 @@ a.plotMode = \linear; a.refresh;
 a.plotMode = \bars; a.refresh;
 ::
 
+method:: plotModes
+Get/Set the style of data display. This can be an array of different styles for
+multichannel data. See link::#-plotMode:: for a list of possible modes.
+argument:: modes
+A link::Classes/Symbol:: or an link::Classes/Array:: of link::Classes/Symbol::s.
+If code::modes.size < numChannels::, the plots will strong::wrap:: around the
+array of modes.
+
+code::
+/* mixed modes */
+(
+c = [Color.red, Color.cyan, Color.green, Color.blue];
+d = 4.collect({ |i| 100.collect({|j| sinPi(1+i.squared*j * 50.reciprocal) })});
+p = d.plot;
+p.plotColors_(c).plotModes_([\steps, \linear, \plines, \points]).superpose_(true);
+{ p.refresh }.defer(0.4);
+)
+::
+
 method:: setProperties
 Set properties of all plot views. Defaults are taken from code::GUI.skin.at(\plot);::
 argument:: ... pairs

--- a/HelpSource/Classes/Plotter.schelp
+++ b/HelpSource/Classes/Plotter.schelp
@@ -112,8 +112,18 @@ argument:: argBounds
 The window bounds (a link::Classes/Rect::).
 
 method:: plotMode
-Set the style of data display.
-argument:: symbol
+Get/Set the style of data display. This can be an array of different modes for
+multi-channel data.
+argument:: modes
+A link::Classes/Symbol:: or an link::Classes/Array:: of link::Classes/Symbol::s.
+
+If code::modes.size < numChannels::, the plots will emphasis::wrap:: around the
+array of modes.
+returns::
+An link::Classes/Array:: of link::Classes/Symbol::s,
+unless there is only one mode specified or if all modes of a multi-channel plot
+are the same, in which case a link::Classes/Symbol:: is returned.
+
 Available modes:
 table::
 ## code::\linear:: || connecting data points with linear interpolation
@@ -132,24 +142,16 @@ a.plotMode = \levels; a.refresh;
 a.plotMode = \steps; a.refresh;
 a.plotMode = \linear; a.refresh;
 a.plotMode = \bars; a.refresh;
-::
 
-method:: plotModes
-Get/Set the style of data display. This can be an array of different styles for
-multichannel data. See link::#-plotMode:: for a list of possible modes.
-argument:: modes
-A link::Classes/Symbol:: or an link::Classes/Array:: of link::Classes/Symbol::s.
-If code::modes.size < numChannels::, the plots will strong::wrap:: around the
-array of modes.
-
-code::
 /* mixed modes */
 (
 c = [Color.red, Color.cyan, Color.green, Color.blue];
-d = 4.collect({ |i| 100.collect({|j| sinPi(1+i.squared*j * 50.reciprocal) })});
+d = 4.collect({ |i| 100.collect({ |j| sinPi(1+i.squared*j * 50.reciprocal) })});
 p = d.plot;
-p.plotColors_(c).plotModes_([\steps, \linear, \plines, \points]).superpose_(true);
-{ p.refresh }.defer(0.4);
+p.plotColor_(c);
+p.plotMode_([\steps, \linear, \plines, \points]);
+// superpose will trigger a refresh to update colors/modes
+p.superpose_(true);
 )
 ::
 
@@ -315,9 +317,18 @@ plot.domain_(domain);
 A more elaborate example can be found in the link::#examples::.
 
 method:: plotColor
-Set or get the link::Classes/Color::(s) of your plot. An
-link::Classes/Array:: of colors will be mapped across multichannel plot
-data, including when link::#-superpose:: is code::true::.
+Set or get the colors of your data plot.
+
+argument:: colors
+This can be an link::Classes/Array:: of link::Classes/Color::s for
+multichannel data, or a single link::Classes/Color:: to map to all channels.
+
+If code::colors.size < numChannels::, the plots will emphasis::wrap:: around the
+array of colors.
+returns::
+An link::Classes/Array:: of link::Classes/Color::s, unless there is only one
+color specified or if all colors of a multi-channel plot are the same, in which
+case a link::Classes/Color:: is returned.
 
 method:: editFunc
 Supply a function which is evaluated when editing data. The function is called with the arguments: code::plotter::, code::plotIndex::, code::index::, code::val::, code::x::, code::y::.

--- a/HelpSource/Guides/Tour-of-Special-Functions.schelp
+++ b/HelpSource/Guides/Tour-of-Special-Functions.schelp
@@ -59,12 +59,17 @@ getPlotLay = { |plot, text|
 		bundle.collect(func.applyTo(*_)).select(_.notNil)
 	});
 
-	pltr = res.plot( txt, minval: min, maxval: max).superpose_(true);
+	pltr = res.plot( txt, minval: min, maxval: max)
+	.superpose_(true)
+	.domainSpecs_([samps.minItem, samps.maxItem].asSpec)
+	.plotColor_(
+		genCol.(params !? params.size ?? 1, rrand(0,1.0))
+	)
+	;
 
 	pltr.plots[0]
-	.plotColor_(genCol.(params !? params.size ?? 1, rrand(0,1.0)))
-	.domainSpec_([samps.minItem, samps.maxItem].asSpec)
-	.gridColorX_(gridcol).gridColorY_(gridcol)
+	.gridColorX_(gridcol)
+	.gridColorY_(gridcol)
 	;
 
 	pltr

--- a/testsuite/classlibrary/TestPlotter.sc
+++ b/testsuite/classlibrary/TestPlotter.sc
@@ -15,7 +15,7 @@ TestPlotter : UnitTest {
 			cols,
 			format(
 				"The color of the superposed plot:\n\t[%]\n"
-				"\tshould match Plotter's plotColor (in order) when superpose = true.:\n\t[%]\n",
+				"\tshould match Plotter's plotColor(s) (in order) when superpose = true.:\n\t[%]\n",
 				plot.plots[0].plotColor,
 				cols,
 			), report: false
@@ -29,7 +29,7 @@ TestPlotter : UnitTest {
 			cols,
 			format(
 				"The first color of each individual plot:\n\t[%]\n"
-				"\tshould match Plotter's plotColor (in order) when superpose = false.:\n\t[%]\n",
+				"\tshould match Plotter's plotColor(s) (in order) when superpose = false.:\n\t[%]\n",
 				plot.plots.collect({|plt, i| plt.plotColor[0]}),
 				cols,
 			), report: false


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation
This PR adds the ability to specify multiple plot modes, as you can with plot colors.
It follows the same implementation as `plotColors` for consistency. This includes making a `plotMode` variable local to `Plot`, and settable through `Plotter` via `-plotModes_`. 

### Implementation Notes to review

- `-plotMode` (singular) getter and setter methods are left for backwards compatibility. This also offers syntax that suit the common case of a single plot (`-plotMode` calls `-plotModes` internally).
- In the same way that with `plotColors` stores all the plot colors internally in an array, `plotModes` an array of modes, even when it's a single mode. The getter method will return this array, _unless there is only one mode or all modes of a multi-channel plot are identical_, in which case it just returns the `Symbol` of the mode. This mirrors the way all modes can be **set** by a single mode `Symbol`.
#### Open questions (**Update: resolved**):
- As there are both `-plotModes` and `-plotMode` (singular) getters and setters, should this also be the case for `-plotColors`? Should a `-plotColor` (singular) getter and setter be added to `Plotter`?
  - If so, the same question stands for `-specs` and `-domainSpecs` get/setters—should their singular counterparts (synonyms essentially) be added?
  - The rationale is that despite supporting multiple specs, colors, modes, etc within a `Plotter`, a common case is a `Plotter` that just contains one `Plot`, for which it makes more semantic sense to say, e.g.  `myPlotter.domainSpec_([33, 45].asSpec)`
- The argument to `-plotColors_` was changed from `argColors` to `colors`, which is technically a breaking change, but this method was only recently introduced in  #4082, merged into 3.10, but has the 3.10.3 milestone, so isn't yet in the main distribution.
  - I used the name `argColors` originally because the the nearby `argSpecs` argument name, but after a closer look I see that's because there is an instance variable `specs` so `argSpecs` was to differentiate it from that variable name. This is not the case with `argColors`, so I decided to go with the cleaner name.

## Types of changes

<!-- Delete lines that don't apply -->

- Documentation
- New feature

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review