### PR TITLE
Supernova OSC message ordering

### DIFF
--- a/server/supernova/sc/sc_osc_handler.cpp
+++ b/server/supernova/sc/sc_osc_handler.cpp
@@ -863,7 +863,7 @@ int first_arg_as_int(ReceivedMessage const& message) {
 
 template <bool realtime> void handle_quit(endpoint_ptr endpoint) {
     instance->quit_received = true;
-    cmd_dispatcher<realtime>::fire_system_callback([=]() {
+    cmd_dispatcher<realtime>::fire_io_callback([=]() {
         instance->prepare_to_terminate();
         send_done_message(endpoint, "/quit");
         instance->terminate();
@@ -873,7 +873,7 @@ template <bool realtime> void handle_quit(endpoint_ptr endpoint) {
 template <bool realtime> void handle_notify(ReceivedMessage const& message, endpoint_ptr const& endpoint) {
     int enable = first_arg_as_int(message);
 
-    cmd_dispatcher<realtime>::fire_system_callback([=, endpoint = endpoint_ptr(endpoint)]() {
+    cmd_dispatcher<realtime>::fire_io_callback([=, endpoint = endpoint_ptr(endpoint)]() {
         int observer = 0;
 
         if (enable) {
@@ -1949,7 +1949,7 @@ template <bool realtime> void handle_b_alloc(ReceivedMessage const& msg, endpoin
                 sc_factory->buffer_sync(bufferIndex);
                 handle_completion_message(std::move(message), endpoint);
 
-                cmd_dispatcher<realtime>::fire_system_callback([=] {
+                cmd_dispatcher<realtime>::fire_io_callback([=] {
                     free_aligned(free_buf);
                     send_done_message(endpoint, "/b_alloc", bufferIndex);
                 });
@@ -1980,7 +1980,7 @@ template <bool realtime> void handle_b_free(ReceivedMessage const& msg, endpoint
 
             handle_completion_message(std::move(message), endpoint);
 
-            cmd_dispatcher<realtime>::fire_system_callback([=] {
+            cmd_dispatcher<realtime>::fire_io_callback([=] {
                 free_aligned(free_buf);
                 send_done_message(endpoint, "/b_free", index);
             });
@@ -2023,7 +2023,7 @@ template <bool realtime> void handle_b_allocRead(ReceivedMessage const& msg, end
                         handle_completion_message(std::move(message), endpoint);
                         consume(std::move(filename));
 
-                        cmd_dispatcher<realtime>::fire_system_callback([=] {
+                        cmd_dispatcher<realtime>::fire_io_callback([=] {
                             free_aligned(free_buf);
                             send_done_message(endpoint, "/b_allocRead", bufferIndex);
                         });
@@ -2089,7 +2089,7 @@ template <bool realtime> void handle_b_allocReadChannel(ReceivedMessage const& m
                 consume(std::move(filename));
                 handle_completion_message(std::move(message), endpoint);
 
-                cmd_dispatcher<realtime>::fire_system_callback([=] {
+                cmd_dispatcher<realtime>::fire_io_callback([=] {
                     free_aligned(free_buf);
                     send_done_message(endpoint, "/b_allocReadChannel", bufnum);
                 });
@@ -2635,7 +2635,7 @@ template <bool realtime> void handle_b_gen(ReceivedMessage const& msg, size_t ms
             consume(std::move(message));
             sc_factory->buffer_sync(index);
 
-            cmd_dispatcher<realtime>::fire_system_callback([=] {
+            cmd_dispatcher<realtime>::fire_io_callback([=] {
                 free_aligned(free_buf);
                 send_done_message(endpoint, "/b_gen", index);
             });
@@ -2777,7 +2777,7 @@ template <bool realtime> void handle_d_recv(ReceivedMessage const& msg, endpoint
             handle_completion_message(std::move(message), endpoint);
             consume(std::move(def));
 
-            cmd_dispatcher<realtime>::fire_system_callback([=, wrappedSynthdefs = std::move(wrappedSynthdefs)] {
+            cmd_dispatcher<realtime>::fire_io_callback([=, wrappedSynthdefs = std::move(wrappedSynthdefs)] {
                 consume(std::move(wrappedSynthdefs));
                 send_done_message(endpoint, "/d_recv");
             });
@@ -2808,7 +2808,7 @@ template <bool realtime> void handle_d_load(ReceivedMessage const& msg, endpoint
                 handle_completion_message(std::move(message), endpoint);
                 consume(std::move(path_string));
 
-                cmd_dispatcher<realtime>::fire_system_callback([=, wrappedSynthdefs = std::move(wrappedSynthdefs)] {
+                cmd_dispatcher<realtime>::fire_io_callback([=, wrappedSynthdefs = std::move(wrappedSynthdefs)] {
                     consume(std::move(wrappedSynthdefs));
                     send_done_message(endpoint, "/d_load");
                 });
@@ -2839,7 +2839,7 @@ template <bool realtime> void handle_d_loadDir(ReceivedMessage const& msg, endpo
                 handle_completion_message(std::move(message), endpoint);
                 consume(std::move(path_string));
 
-                cmd_dispatcher<realtime>::fire_system_callback([=, wrappedSynthdefs = std::move(wrappedSynthdefs)] {
+                cmd_dispatcher<realtime>::fire_io_callback([=, wrappedSynthdefs = std::move(wrappedSynthdefs)] {
                     consume(std::move(wrappedSynthdefs));
                     send_done_message(endpoint, "/d_loadDir");
                 });
@@ -3581,7 +3581,7 @@ void handle_asynchronous_command(World* world, const char* cmdName, void* cmdDat
                     }
                     consume(std::move(message));
 
-                    cmd_dispatcher<realtime>::fire_system_callback([=, endpoint = std::move(endpoint)] {
+                    cmd_dispatcher<realtime>::fire_io_callback([=, endpoint = std::move(endpoint)] {
                         if (stage4)
                             (stage4)(world, cmdData);
 

--- a/server/supernova/sc/sc_plugin_interface.cpp
+++ b/server/supernova/sc/sc_plugin_interface.cpp
@@ -934,15 +934,15 @@ void sc_plugin_interface::buffer_alloc_read_channels(uint32_t index, const char*
 }
 
 
-int sc_plugin_interface::buffer_write(uint32_t index, const char* filename, const char* header_format,
-                                      const char* sample_format, uint32_t start, uint32_t frames, bool leave_open) {
+void sc_plugin_interface::buffer_write(uint32_t index, const char* filename, const char* header_format,
+                                       const char* sample_format, uint32_t start, uint32_t frames, bool leave_open) {
     SndBuf* buf = World_GetNRTBuf(&world, index);
     int format = headerFormatFromString(header_format) | sampleFormatFromString(sample_format);
 
     auto sf = makeSndfileHandle(filename, SFM_WRITE, format, buf->channels, buf->samplerate);
 
-    if (!sf)
-        return -1;
+    if (sf.rawHandle() == nullptr)
+        throw std::runtime_error(sf.strError());
 
     if (frames == 0xffffffff)
         frames = buf->frames;
@@ -955,8 +955,6 @@ int sc_plugin_interface::buffer_write(uint32_t index, const char* filename, cons
 
     if (leave_open && !buf->sndfile)
         buf->sndfile = sf.takeOwnership();
-
-    return 0;
 }
 
 static void buffer_read_verify(SndfileHandle& sf, size_t min_length, size_t samplerate, bool check_samplerate) {

--- a/server/supernova/sc/sc_plugin_interface.hpp
+++ b/server/supernova/sc/sc_plugin_interface.hpp
@@ -115,8 +115,8 @@ public:
 
     SndBuf* get_buffer_struct(uint32_t index) { return world.mSndBufs + index; }
 
-    int buffer_write(uint32_t index, const char* filename, const char* header_format, const char* sample_format,
-                     uint32_t start, uint32_t frames, bool leave_open);
+    void buffer_write(uint32_t index, const char* filename, const char* header_format, const char* sample_format,
+                      uint32_t start, uint32_t frames, bool leave_open);
 
     void buffer_zero(uint32_t index);
     void buffer_close(uint32_t index);


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

This PR tries to achieve deterministic message ordering for asynchronous commands on Supernova. For more background, see: https://github.com/supercollider/supercollider/issues/4424

It makes sure that `/done` messages are *always* sent to the `io_interpreter` so that
a) `/synced` will always arrive *after* `/done` and 
b) replies from synchronous completion messages will always arrive *before* `/done`.

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] This PR is ready for review
