### PR TITLE
Topic/nodeproxy bundling queue

### DIFF
--- a/SCClassLibrary/JITLib/ProxySpace/ProxyInterfaces.sc
+++ b/SCClassLibrary/JITLib/ProxySpace/ProxyInterfaces.sc
@@ -254,7 +254,7 @@ SynthControl : AbstractPlayControl {
 			};
 			nodeID = nil;
 			this.prCancelPrevBundle;
-		};
+		}
 	}
 
 	freeToBundle {
@@ -354,7 +354,8 @@ SynthDefControl : SynthControl {
 		var size, path;
 
 		// cache rendered synth def, so it can be copied if necessary (see: copyData)
-		// We need to keep the bytes here, because some other instance may have deleted it from the server (see: freeToBundle)
+		// We need to keep the bytes here, because some other instance may have deleted it from the server
+		// (see: freeToBundle)
 		// the resulting synthDef will have the same name, because the name is encoded in the data (bytes).
 		bytes = bytes ?? { synthDef.asBytes }; // here the work for sclang is done.
 		size = bytes.size;
@@ -376,7 +377,7 @@ SynthDefControl : SynthControl {
 	}
 
 	freeToBundle { | bundle, proxy |
-		if(synthDef.notNil) { bundle.addPrepare([53, synthDef.name]) }; // "/d_free"
+		if(synthDef.notNil) { bundle.add([53, synthDef.name]) }; // "/d_free"
 		parents.do { |x| x.removeChild(proxy) };
 		bytes = parents = nil;
 		this.prCancelPrevBundle;

--- a/SCClassLibrary/JITLib/ProxySpace/wrapForNodeProxy.sc
+++ b/SCClassLibrary/JITLib/ProxySpace/wrapForNodeProxy.sc
@@ -24,7 +24,7 @@
 
 
 	// this method is called from within the Control
-	buildForProxy { | proxy, channelOffset = 0, index |
+	buildForProxy { | proxy, channelOffset = 0 |
 		var channelConstraint, rateConstraint;
 		var argNames = this.argNames;
 		if(proxy.fixedBus) {
@@ -32,7 +32,7 @@
 			rateConstraint = proxy.rate;
 		};
 		^ProxySynthDef(
-			SystemSynthDefs.tempNamePrefix ++ proxy.generateUniqueName ++ index,
+			SystemSynthDefs.tempNamePrefix ++ proxy.generateUniqueName ++ UniqueID.next,
 			this.prepareForProxySynthDef(proxy, channelOffset),
 			proxy.nodeMap.ratesFor(argNames),
 			nil,

--- a/testsuite/classlibrary/TestNodeProxy_Server.sc
+++ b/testsuite/classlibrary/TestNodeProxy_Server.sc
@@ -54,6 +54,19 @@ TestNodeProxy_Server : UnitTest {
 		this.assertEquals(build, false, "SynthDef should not be rebuilt when calling send");
 	}
 
+	test_synthDef_isReleased_afterFree {
+		var numBefore, numAfter;
+		numBefore = server.statusWatcher.numSynthDefs;
+		proxy.source = { Silent.ar };
+		server.sync;
+		proxy.source = nil;
+		server.sendStatusMsg.sync;
+		numAfter = server.statusWatcher.numSynthDefs;
+		this.assertEquals(numBefore, numAfter,
+			"Removing the  NodeProxy source function should remove SynthDef from server"
+		);
+	}
+
 	test_loaded_after_quit {
 		proxy.send;
 		server.quit;

--- a/testsuite/classlibrary/TestNodeProxy_Server.sc
+++ b/testsuite/classlibrary/TestNodeProxy_Server.sc
@@ -56,11 +56,14 @@ TestNodeProxy_Server : UnitTest {
 
 	test_synthDef_isReleased_afterFree {
 		var numBefore, numAfter;
+		server.sendStatusMsg;
+		server.sync;
 		numBefore = server.statusWatcher.numSynthDefs;
 		proxy.source = { Silent.ar };
 		server.sync;
 		proxy.source = nil;
-		server.sendStatusMsg.sync;
+		server.sendStatusMsg;
+		server.sync;
 		numAfter = server.statusWatcher.numSynthDefs;
 		this.assertEquals(numBefore, numAfter,
 			"Removing the  NodeProxy source function should remove SynthDef from server"

--- a/testsuite/classlibrary/TestNodeProxy_Server.sc
+++ b/testsuite/classlibrary/TestNodeProxy_Server.sc
@@ -56,15 +56,23 @@ TestNodeProxy_Server : UnitTest {
 
 	test_synthDef_isReleased_afterFree {
 		var numBefore, numAfter;
+
+		// here we have to make sure that the statusWatcher.numSynthDefs is correct
+		// before the experiment, so we force the otherwise regular update ...
 		server.sendStatusMsg;
 		server.sync;
 		numBefore = server.statusWatcher.numSynthDefs;
+
+		// ... then set the proxy source and remove it again ...
 		proxy.source = { Silent.ar };
 		server.sync;
 		proxy.source = nil;
+
+		// ... and also afterwards, we force an update
 		server.sendStatusMsg;
 		server.sync;
 		numAfter = server.statusWatcher.numSynthDefs;
+
 		this.assertEquals(numBefore, numAfter,
 			"Removing the  NodeProxy source function should remove SynthDef from server"
 		);


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

This fixes #3344.

It makes sure that:
a) SynthDefs have a unique name instead of a channel id
b) SynthDefs are freed even when the bundle is canceled

Not setting the nodeID to nil is ok, nothing substantial depends on it.

For some reason, `addPrepare` needs to be replaced by a direct adding.
I would have thought that either way should be OK, but `addPrepare`
will cause SynthDef not found errors under load (when bundles are
canceled). This may need further checking, including the server
behaviour.

## Types of changes

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [ ] This PR is ready for review
