### PR TITLE
[classlib] add fuzzy array comparisons

### DIFF
--- a/HelpSource/Classes/SequenceableCollection.schelp
+++ b/HelpSource/Classes/SequenceableCollection.schelp
@@ -631,10 +631,83 @@ method::hammingDistance
 Returns the count of array elements that are not equal in identical positions. http://en.wikipedia.org/wiki/Hamming_distance
 
 The collections are not wrapped - if one array is shorter than the other, the difference in size should be included in the count.
+
 code::
 [0, 0, 0, 1, 1, 1, 0, 1, 0, 0].hammingDistance([0, 0, 1, 1, 0, 0, 0, 0, 1, 1]);
 "SuperMan".hammingDistance("SuperCollider");
 ::
+
+subsection:: Fuzzy comparisons
+With fuzzy comparisons, the arrays do not need to match exactly. We can check how similar they are, and make decisions based on that. This is the magic behind autocorrection.
+
+method::editDistance
+Returns the mininum number of changes to modify this teletype::SequenceableCollection:: into the other teletype::SequenceableCollection::.
+A change can be: an addition, a deletion, or a substitution.
+This is known as the Levenshtein Distance and is implemented in SuperCollider using the Wagner–Fischer algorithm.
+
+The default comparison uses strong::identity:: - see link::Classes/Object#-==:: and link::Classes/Object#-===::
+
+Where both arrays are raw arrays (String, Int16Array, Int32Array, FloatArray etc., or any derived classes), like comparing two strings, a faster primitive will be used to calculate the distance.
+
+code::
+"hello".editDistance("hallo"); // 1 (substitution)
+"hello".editDistance("hell"); // 1 (deletion)
+"hello".editDistance("helloo"); // 1 (addition)
+"hello".editDistance("hllo"); // 1 (removal)
+"hello".editDistance("haldo"); // 2 (substitutions)
+::
+
+In cases where the arrays are of different types, it will fall back to a slower, non-primitive implementation.
+
+code::
+// String vs Array
+"hello".editDistance([$h, $e, $l, $l, $o]);
+::
+
+For cases that require comparisons other than identity, the optional teletype::compareFunc:: can be given to compare elements. This function will be passed two arguments, representing a single element from each array to compare, and this function must return a boolean as to whether or not the elements are equal.
+
+code::
+// Using compareFunc for case insensitive comparisons
+"HeLLO".editDistance("HELLO", { |a, b|
+	a.toLower == b.toLower;
+});
+::
+
+note::
+Specifying a teletype::compareFunc:: will bypass the primitive and may take significantly longer to execute for larger arrays.
+::
+
+argument::other
+The teletype::SequenceableCollection:: to compare against
+
+argument::compareFunc
+An optional comparison function to use for each element. It will be provided two arguments, and the function must return a boolean as to whether or not they are the same. Default value is teletype::nil::, which will use strong::identity:: (not equality) to compare elements.
+
+code::
+[1,2,3,4].editDistance([2,3,4,5], { | a, b |
+	a == b;
+});
+::
+
+method::similarity
+Returns a value between 0 and 1 representing the percentage similarity between this teletype::SequenceableCollection:: and the other teletype::SequenceableCollection::.
+
+A value of 1 means they are exactly the same, a value of 0 means they are completely different.
+This is calculated based on the link::#-editDistance::
+code::
+"hello".similarity("hello"); // 1
+"hello".similarity("asdf"); // 0
+"word".similarity("wodr"); // 0.5
+::
+
+argument::other
+The code::SequenceableCollection:: to compare against
+
+argument::compareFunc
+An optional compareFunc to be used to calculate the edit distance (see link::#-editDistance::)
+
+private::prEditDistance
+private::prLevenshteinDistance
 
 subsection::Math Support - Unary Messages
 

--- a/HelpSource/Classes/String.schelp
+++ b/HelpSource/Classes/String.schelp
@@ -135,6 +135,17 @@ code::
 "same" != "Same";
 ::
 
+subsection:: Fuzzy string comparison
+With fuzzy comparison, the strings don't need to match exactly - we can work out how similar they are, and make decisions based on that.
+This behaviour is inherited from the link::Classes/SequenceableCollection#-editDistance::, and is documented fully there, but to provide an example:
+code::
+"hello".editDistance("hallo"); // 1 (substitution)
+"hello".editDistance("hell"); // 1 (deletion)
+"hello".editDistance("helloo"); // 1 (addition)
+"hello".editDistance("hllo"); // 1 (removal)
+"hello".editDistance("haldo"); // 2 (substitutions)
+::
+
 subsection:: Posting strings
 
 method::post

--- a/lang/LangPrimSource/SC_Levenshtein.h
+++ b/lang/LangPrimSource/SC_Levenshtein.h
@@ -1,0 +1,82 @@
+/*
+    SC_Levenshtein.h
+    Copyright (c) 2019 James Surgenor
+
+    This is a header-only, templated functor to compute the Levenshtein distance between two arrays.
+
+    It uses the reduced memory footprint version, based on Martin Ettl's implementation, and is written as a functor
+    to facilitate even greater memory savings if a single instance is used (although only one comparison can be made
+    at a time). It is self-contained, so could easily be multithreaded.
+
+    Thanks to Brian Heim
+
+    ====================================================================
+
+    SuperCollider real time audio synthesis system
+    Copyright (c) 2002 James McCartney. All rights reserved.
+    http://www.audiosynth.com
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
+*/
+
+#pragma once
+
+#include <vector>
+#include <functional>
+#include <numeric>
+
+template <typename T> struct levenshteinDistance {
+    size_t operator()(
+        const T* dataA, size_t sizeA, const T* dataB, size_t sizeB,
+        std::function<bool(const T&, const T&)> compareFunc = [](const T& a, const T& b) { return a == b; }) {
+        // reduce memory by comparing against the smallest array
+        if (sizeA < sizeB) {
+            std::swap(dataA, dataB);
+            std::swap(sizeA, sizeB);
+        }
+
+        // empty array optimisation
+        if (sizeA == 0 || sizeB == 0) {
+            return sizeA;
+        }
+
+        matrix.resize(sizeB + 1);
+
+        // initialise matrix
+        std::iota(matrix.begin(), matrix.end(), 0);
+
+        // calculate the distances
+        for (size_t indX = 0; indX < sizeA; ++indX) {
+            matrix[0] = indX + 1;
+            size_t corner = indX;
+
+            for (size_t indY = 0; indY < sizeB; ++indY) {
+                size_t upper = matrix[indY + 1];
+
+                if (compareFunc(dataA[indX], dataB[indY]))
+                    matrix[indY + 1] = corner;
+                else
+                    matrix[indY + 1] = std::min({ upper, corner, matrix[indY] }) + 1;
+
+                corner = upper;
+            }
+        }
+
+        return matrix[sizeB];
+    }
+
+private:
+    std::vector<size_t> matrix;
+};

--- a/lang/LangSource/PyrSlot32.h
+++ b/lang/LangSource/PyrSlot32.h
@@ -210,7 +210,7 @@ inline bool NotNil(const PyrSlot* slot) { return ((slot)->utag != tagNil); }
 inline bool IsFalse(const PyrSlot* slot) { return ((slot)->utag == tagFalse); }
 inline bool IsTrue(const PyrSlot* slot) { return ((slot)->utag == tagTrue); }
 
-inline bool SlotEq(PyrSlot* a, PyrSlot* b) { return ((a)->ui == (b)->ui && (a)->utag == (b)->utag); }
+inline bool SlotEq(const PyrSlot* a, const PyrSlot* b) { return ((a)->ui == (b)->ui && (a)->utag == (b)->utag); }
 
 inline bool IsSym(const PyrSlot* slot) { return ((slot)->utag == tagSym); }
 inline bool NotSym(const PyrSlot* slot) { return ((slot)->utag != tagSym); }

--- a/lang/LangSource/PyrSlot64.h
+++ b/lang/LangSource/PyrSlot64.h
@@ -189,7 +189,7 @@ inline void SetRaw(PyrSlot* slot, double val) {
 inline void SetTagRaw(PyrSlot* slot, int tag) { slot->tag = tag; }
 
 /* slot comparison */
-inline bool SlotEq(PyrSlot* a, PyrSlot* b) { return (a->tag == b->tag) && (a->u.i == b->u.i); }
+inline bool SlotEq(const PyrSlot* a, const PyrSlot* b) { return (a->tag == b->tag) && (a->u.i == b->u.i); }
 
 /* extract numeric value */
 template <typename numeric_type> inline int slotVal(PyrSlot* slot, numeric_type* value) {

--- a/testsuite/classlibrary/TestArray.sc
+++ b/testsuite/classlibrary/TestArray.sc
@@ -235,6 +235,57 @@ TestArray : UnitTest {
 		this.assertEquals(result, expected);
 	}
 
+	test_editDistance_rawIntArraysSameType {
+		var result = Int8Array[0, 1].editDistance(Int8Array[0, 1]);
+		this.assertEquals(result, 0);
+	}
+
+	test_editDistance_rawIntArraysDifferentTypes {
+		var result = Int8Array[0, 1].editDistance(Int16Array[0, 1]);
+		this.assertEquals(result, 0);
+	}
+
+	test_editDistance_rawIntArrayAndArray {
+		var result = Int8Array[0, 1].editDistance(Array[0, 1]);
+		this.assertEquals(result, 0);
+	}
+
+	test_editDistance_arrayAndLinkedList {
+		var result = Array[0, 1].editDistance(LinkedList[0, 1]);
+		this.assertEquals(result, 0);
+	}
+
+	test_editDistance_listAndLinkedList {
+		var result = List[0, 1].editDistance(LinkedList[0, 1]);
+		this.assertEquals(result, 0);
+	}
+
+	test_editDistance_rawArrayAndPolymorphicArray {
+		var result = Int8Array[0, 1].editDistance(Array[0, \x]);
+		this.assertEquals(result, 1);
+	}
+
+	test_editDistance_nilCompareFunc_testsIdentityForRawArrays {
+		this.assertEquals(Array["a", "b"].editDistance(Array["a", "b"]), 2);
+		this.assertEquals(Array[\a, \b].editDistance(Array[\a, \b]), 0);
+	}
+
+	test_editDistance_nilCompareFunc_testsIdentityForLists {
+		// we also want to check that non-raw arrays use identity comparison by default
+		this.assertEquals(List["a", "b"].editDistance(List["a", "b"]), 2);
+		this.assertEquals(List[\a, \b].editDistance(List[\a, \b]), 0);
+	}
+
+	test_editDistance_usesCompareFuncForRawArrays {
+		var result = Array["a", "b"].editDistance(Array["a", "c"], _ == _);
+		this.assertEquals(result, 1);
+	}
+
+	test_editDistance_usesCompareFuncForLists {
+		var result = List["a", "b"].editDistance(List["a", "c"], _ == _);
+		this.assertEquals(result, 1);
+	}
+
 	test_similarity_emptyThis_emptyThat_isOne {
 		var result = [].similarity([]);
 		var expected = 1; // they're the same, even though they're empty

--- a/testsuite/classlibrary/TestArray.sc
+++ b/testsuite/classlibrary/TestArray.sc
@@ -186,6 +186,72 @@ TestArray : UnitTest {
 		}
 	}
 
+	// ----- editDistance and similarity --------------------------------------------
+
+	test_editDistance_emptyThis_isSizeThat {
+		var result = [].editDistance([0,1,2,3]);
+		this.assertEquals(result, 4);
+	}
+
+	test_editDistance_emptyThat_isSizeThis {
+		var result = [0,1,2,3].editDistance([]);
+		this.assertEquals(result, 4);
+	}
+
+	test_editDistance_emptyThis_emptyThat_isZero {
+		var result = [].editDistance([]);
+		this.assertEquals(result, 0);
+	}
+
+	test_editDistance_differentTypes_isOk {
+		var result = [0,1,2,3].editDistance([\a,\b,\c,\d]);
+		this.assertEquals(result, 4);
+	}
+
+	test_editDistance_mixedTypes_isOk {
+		var result = [0,1,2,3].editDistance([0,"hello",2,3]);
+		this.assertEquals(result, 1);
+	}
+
+	test_editDistance_countsSubstitution {
+		var result = [0,1,2,3].editDistance([0,1,0,3]);
+		this.assertEquals(result, 1);
+	}
+
+	test_editDistance_countsAddition {
+		var result = [0,1,2,3].editDistance([0,1,2,3,4]);
+		this.assertEquals(result, 1);
+	}
+
+	test_editDistance_countsRemoval {
+		var result = [0,1,2,3].editDistance([0,1,2]);
+		this.assertEquals(result, 1);
+	}
+
+	test_editDistance_countsChanges {
+		var result = [0,1,2,3].editDistance([4,5,6,7,8]);
+		var expected = 5; // 0:4, 1:5, 2:6, 3:8, addition:8
+
+		this.assertEquals(result, expected);
+	}
+
+	test_similarity_emptyThis_emptyThat_isOne {
+		var result = [].similarity([]);
+		var expected = 1; // they're the same, even though they're empty
+
+		this.assertEquals(result, expected);
+	}
+
+	test_similarity_same_isOne {
+		var result = [0,1,2,3].similarity([0,1,2,3]);
+		this.assertEquals(result, 1);
+	}
+
+	test_similarity_different_isZero {
+		var result = [0,1,2,3].similarity([4,5,6,7]);
+		this.assertEquals(result, 0);
+	}
+
 } // End class
 
 TestArrayLace : UnitTest {
@@ -355,6 +421,4 @@ TestArrayLace : UnitTest {
 		this.assertEquals(result, [1, 4, 7, 2, 5, 8, 3, 6, 9],
 			"lace: sublists should lace just like arrays do");
 	}
-
-
 } // End class

--- a/testsuite/classlibrary/TestString.sc
+++ b/testsuite/classlibrary/TestString.sc
@@ -152,5 +152,4 @@ TestString : UnitTest {
 		var result = "the quick brown fox".findRegexp("moo");
 		this.assertEquals(result, Array.new, "Non-matching findRegexp should return empty array");
 	}
-
 }


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

To add fuzzy string comparisons.

__EDIT__: this PR has changed focus to providing more general, fuzzy Array comparisons

Initial motivation came from the work on choosing an audio device for Windows, I started thinking if we could work out the most similar string for a device name to make guessing a little smarter, accounting for typos etc.

The core of this is fuzzy string comparison.

It's very easy to take these new methods, and write a quick check for nearest string, comparing each word to find the most relevant match (or if agreed, add the methods below for this).

Fuzzy comparison would prove useful to the language, including within the interpreter itself.

This PR adds the following instance methods to the SequenceableCollection class:

- `editDistance`
Alternatively known as Levenshtein Distance, this is the minimum amount of changes required to convert one string into another.
- `similarity`
This uses the `editDistance` to calculate the percentage similarity (scaled between 0-1) of the two strings (0 is completely different, 1 is exactly the same)

It also adds a primitive to sclang for faster execution, using  `SC_LevenshteinDistance.h`

### Examples

```supercollider
"hello".editDistance("hallo"); // 1
"word".similarity("wodr"); // 0.5
```

## Types of changes

<!-- Delete lines that don't apply -->

- Documentation
- New feature

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [ ] This PR is ready for review