### PR TITLE
Update DEVELOPING.md

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -120,7 +120,9 @@ Independently from Amazon S3 hosting service, AppVeyor stores its Windows builds
 
 `https://ci.appveyor.com/api/buildjobs/76sh4cu20rh50bp1/artifacts/art_folder.zip`
 
-In order to access these builds, go to the desired pull request page. At the bottom of the page, in the section `All checks have passed`, toggle `Show all checks` and choose `Details` next to the AppVeyor entry. On the page that opens, choose the desired job from the list, and then `artifacts` on the right. This will reveal a link to `art_folder.zip` which contains the build.
+These builds may be accessed either from [AppVeyor's build history](https://ci.appveyor.com/project/supercollider/supercollider/history), or from individual pull request's page. For the latter, find section `All checks have passed` at the bottom of the page, toggle `Show all checks` and choose `Details` next to the AppVeyor entry.
+
+On the page with the selected build, choose the desired job from the list (32bit vs 64bit), and then `artifacts` on the right. This will reveal a link to `art_folder.zip` which contains the build.
 
 Boost Update Script
 -------------------

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -118,7 +118,7 @@ AppVeyor builds
 ---------------
 Independently from Amazon S3 hosting service, AppVeyor stores its Windows builds temporarily for 6 months. In contrast to the Amazon S3 hosting, these builds are available for _all_ pull requests. The URL to these builds includes AppVeyor's job number and is unrelated to commit SHA, e.g.
 
-* https://ci.appveyor.com/api/buildjobs/76sh4cu20rh50bp1/artifacts/art_folder.zip
+`https://ci.appveyor.com/api/buildjobs/76sh4cu20rh50bp1/artifacts/art_folder.zip`
 
 In order to access these builds, go to the desired pull request page. At the bottom of the page, in the section `All checks have passed`, toggle `Show all checks` and choose `Details` next to the AppVeyor entry. On the page that opens, choose the desired job from the list, and then `artifacts` on the right. This will reveal a link to `art_folder.zip` which contains the build.
 

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -114,6 +114,14 @@ are at:
 A build for a specific commit may not always be available: for instance, if the build was cancelled early or failed to
 complete.
 
+AppVeyor builds
+---------------
+Independently from Amazon S3 hosting service, AppVeyor stores its Windows builds temporarily for 6 months. In contrast to the Amazon S3 hosting, these builds are available for _all_ pull requests. The URL to these builds includes AppVeyor's job number and is unrelated to commit SHA, e.g.
+
+* https://ci.appveyor.com/api/buildjobs/76sh4cu20rh50bp1/artifacts/art_folder.zip
+
+In order to access these builds, go to the desired pull request page. At the bottom of the page, in the section `All checks have passed`, toggle `Show all checks` and choose `Details` next to the AppVeyor entry. On the page that opens, choose the desired job from the list, and then `artifacts` on the right. This will reveal a link to `art_folder.zip` which contains the build.
+
 Boost Update Script
 -------------------
 


### PR DESCRIPTION
Add information about accessing AppVeyor builds

<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

AppVeyor builds are stpored independently from Travis builds uploaded to Amazon S3. This PR adds instructions how to access these builds, either from a PR page, or from AppVeyor's history.

## Types of changes

<!-- Delete lines that don't apply -->

- Documentation
## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Updated documentation
- [x] This PR is ready for review
