### PR TITLE
[portaudio:macos] avoid resampling when talking to audio hardware

### DIFF
--- a/common/SC_PaUtils.cpp
+++ b/common/SC_PaUtils.cpp
@@ -4,6 +4,10 @@
 #include <cstring>
 #include <cstdio>
 
+#ifdef __APPLE__
+#    include <pa_mac_core.h>
+#endif
+
 using PaSupportCheckFunc = PaError (*)(PaStreamParameters&, double);
 PaError CheckDeviceSampleRateOrGetDefault(int* device, double sampleRate, int maxChannels, int defaultDevice,
                                           const char* deviceType, PaSupportCheckFunc isSupportedFunc) {
@@ -156,6 +160,12 @@ PaStreamParameters MakePaStreamParameters(int device, int channelCount, double s
     streamParams.channelCount = channelCount;
     streamParams.sampleFormat = fmt;
     streamParams.suggestedLatency = suggestedLatency;
+#ifdef __APPLE__
+    static PaMacCoreStreamInfo macInfo;
+    PaMacCore_SetupStreamInfo(&macInfo, paMacCorePro);
+    streamParams.hostApiSpecificStreamInfo = &macInfo;
+#else
     streamParams.hostApiSpecificStreamInfo = nullptr;
+#endif
     return streamParams;
 }


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

In the process of working on #4009, I discovered CoreAudio-specific flags in PortAudio, that make it run on macOS with settings tuned for pro-audio applications. What it means in practice is that now PortAudio will ask the audio device to run at the requested sample rate, instead of allowing CoreAudio to resample. This matches scsynth's behavior with the native CoreAudio driver.

By default it will only benefit supernova on macOS (which uses PortAudio), however it is possible to build scsynth with PortAudio as well. ~~so the changes were applied for both scsynth and supernova.~~ The changes are applied to a common file that can be used by both scsynth and supernova.

~~EDIT: this will be re-worked after #4614 is merged.~~ This is ready for review.

## Types of changes

<!-- Delete lines that don't apply -->

- New feature

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing (audio is running)
- [x] This PR is ready for review
