### PR TITLE
[scsynth:portaudio] add option for defaultHighLatency

### DIFF
--- a/include/server/SC_WorldOptions.h
+++ b/include/server/SC_WorldOptions.h
@@ -64,7 +64,7 @@ struct WorldOptions {
 
     uint32 mNumRGens = 64;
 
-    uint32 mPreferredHardwareBufferFrameSize = 0;
+    int32 mPreferredHardwareBufferFrameSize = 0;
 
     uint32 mLoadGraphDefs = 1;
 

--- a/server/scsynth/SC_CoreAudio.h
+++ b/server/scsynth/SC_CoreAudio.h
@@ -161,7 +161,7 @@ protected:
     uint32 mSafetyOffset;
     PriorityQueueT<SC_ScheduledEvent, 2048> mScheduler;
     int mNumSamplesPerCallback;
-    uint32 mPreferredHardwareBufferFrameSize;
+    int32 mPreferredHardwareBufferFrameSize;
     uint32 mPreferredSampleRate;
     boost::optional<uint32> mExplicitSampleRate;
     double mBuffersPerSecond;

--- a/server/scsynth/SC_PortAudio.cpp
+++ b/server/scsynth/SC_PortAudio.cpp
@@ -325,10 +325,15 @@ bool SC_PortAudioDriver::DriverSetup(int* outNumSamples, double* outSampleRate) 
 
 
     if (mDeviceInOut[0] != paNoDevice || mDeviceInOut[1] != paNoDevice) {
-        if (mPreferredHardwareBufferFrameSize)
+        if (mPreferredHardwareBufferFrameSize > 0)
             // controls the suggested latency by hardwareBufferSize switch -Z
             suggestedLatencyIn = suggestedLatencyOut = mPreferredHardwareBufferFrameSize / (*outSampleRate);
-        else {
+        else if (mPreferredHardwareBufferFrameSize < 0) {
+            if (mDeviceInOut[0] != paNoDevice)
+                suggestedLatencyIn = Pa_GetDeviceInfo(mDeviceInOut[0])->defaultHighInputLatency;
+            if (mDeviceInOut[1] != paNoDevice)
+                suggestedLatencyOut = Pa_GetDeviceInfo(mDeviceInOut[1])->defaultHighInputLatency;
+        } else {
             if (mDeviceInOut[0] != paNoDevice)
                 suggestedLatencyIn = Pa_GetDeviceInfo(mDeviceInOut[0])->defaultLowInputLatency;
             if (mDeviceInOut[1] != paNoDevice)

--- a/server/scsynth/scsynth_main.cpp
+++ b/server/scsynth/scsynth_main.cpp
@@ -182,7 +182,9 @@ int main(int argc, char* argv[]) {
             break;
         case 'Z':
             checkNumArgs(2);
-            options.mPreferredHardwareBufferFrameSize = NEXTPOWEROFTWO(atoi(argv[j + 1]));
+            options.mPreferredHardwareBufferFrameSize = atoi(argv[j + 1]);
+            if (options.mPreferredHardwareBufferFrameSize > 0)
+                options.mPreferredHardwareBufferFrameSize = NEXTPOWEROFTWO(options.mPreferredHardwareBufferFrameSize);
             break;
         case 'b':
             checkNumArgs(2);


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

In process of working on #4009 @sonoro1234 suggested to add the option to request `defaultHighLatency` from the PortAudio driver in scsynth. When setting buffer size `-Z -1`, PortAudio will select `defaultHighLatency` for a given device. Previous behavior is maintained: not setting `-Z` results in choosing `defaultLowLatency`.

Please note, this is opposite to the current behavior in supernova. Supernova will choose `defaultHighLatency` for `-Z 0` and `defaultLowLatency` for `-Z -1`. It was suggested to change the behavior of supernova to match the scsynth. Supernova's change is not included in this PR.

This behavior is not documented in SC helpfiles, as far as I know.

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->

- New feature

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [ ] Updated documentation
- [x] This PR is ready for review
