### PR TITLE
[scsynth:windows] support unicode in argv

### DIFF
--- a/server/scsynth/scsynth_main.cpp
+++ b/server/scsynth/scsynth_main.cpp
@@ -387,7 +387,9 @@ int wmain(int argc, wchar_t** wargv) {
     // reset codepage from UTF-8
     SetConsoleOutputCP(oldCodePage);
     // clear vector with converted args
-    argv.clear();
+    for (int i = 0; i < argv.size(); i++) {
+        delete[] argv[i];
+    }
 
     return result;
 }

--- a/server/scsynth/scsynth_main.cpp
+++ b/server/scsynth/scsynth_main.cpp
@@ -374,8 +374,8 @@ int wmain(int argc, wchar_t** wargv) {
     }
 
     // set codepage to UTF-8
-    static UINT gOldCodePage; // for remembering the old codepage when we switch to UTF-8
-    gOldCodePage = GetConsoleOutputCP();
+    static UINT oldCodePage; // for remembering the old codepage when we switch to UTF-8
+    oldCodePage = GetConsoleOutputCP();
     if (!SetConsoleOutputCP(65001))
         scprintf("WARNING: could not set codepage to UTF-8\n");
 
@@ -385,7 +385,7 @@ int wmain(int argc, wchar_t** wargv) {
     // clean up winsock
     WSACleanup();
     // reset codepage from UTF-8
-    SetConsoleOutputCP(gOldCodePage);
+    SetConsoleOutputCP(oldCodePage);
     // clear vector with converted args
     argv.clear();
 

--- a/server/scsynth/scsynth_main.cpp
+++ b/server/scsynth/scsynth_main.cpp
@@ -357,6 +357,14 @@ int scsynth_main(int argc, char** argv) {
 #ifdef _WIN32
 
 int wmain(int argc, wchar_t** wargv) {
+    // initialize winsock
+    WSAData wsaData;
+    int nCode;
+    if ((nCode = WSAStartup(MAKEWORD(1, 1), &wsaData)) != 0) {
+        scprintf("WSAStartup() failed with error code %d.\n", nCode);
+        return 1;
+    }
+
     // convert args to utf-8
     std::vector<char*> argv;
     for (int i = 0; i < argc; i++) {
@@ -370,14 +378,6 @@ int wmain(int argc, wchar_t** wargv) {
     gOldCodePage = GetConsoleOutputCP();
     if (!SetConsoleOutputCP(65001))
         scprintf("WARNING: could not set codepage to UTF-8\n");
-
-    // initialize winsock
-    WSAData wsaData;
-    int nCode;
-    if ((nCode = WSAStartup(MAKEWORD(1, 1), &wsaData)) != 0) {
-        scprintf("WSAStartup() failed with error code %d.\n", nCode);
-        return 1;
-    }
 
     // run main
     int result = scsynth_main(argv.size(), argv.data());

--- a/server/scsynth/scsynth_main.cpp
+++ b/server/scsynth/scsynth_main.cpp
@@ -125,8 +125,6 @@ void Usage() {
     i += n;
 
 
-// int main(int argc, char* argv[]);
-// int scsynth_main(int argc, char* argv[]) {
 int scsynth_main(int argc, char** argv) {
     setlinebuf(stdout);
 
@@ -396,7 +394,6 @@ int wmain(int argc, wchar_t** wargv) {
 
 #else
 
-// int main(int argc, char* argv[]) { return scsynth_main(argc, argv) };
 int main(int argc, char** argv) { return scsynth_main(argc, argv); };
 
 #endif //_WIN32

--- a/server/scsynth/scsynth_main.cpp
+++ b/server/scsynth/scsynth_main.cpp
@@ -373,9 +373,8 @@ int wmain(int argc, wchar_t** wargv) {
         WideCharToMultiByte(CP_UTF8, 0, wargv[i], -1, argv[i], argSize, nullptr, nullptr);
     }
 
-    // set codepage to UTF-8
-    static UINT oldCodePage; // for remembering the old codepage when we switch to UTF-8
-    oldCodePage = GetConsoleOutputCP();
+    // set codepage to UTF-8 and remember the old codepage
+    auto oldCodePage = GetConsoleOutputCP();
     if (!SetConsoleOutputCP(65001))
         scprintf("WARNING: could not set codepage to UTF-8\n");
 
@@ -387,9 +386,8 @@ int wmain(int argc, wchar_t** wargv) {
     // reset codepage from UTF-8
     SetConsoleOutputCP(oldCodePage);
     // clear vector with converted args
-    for (int i = 0; i < argv.size(); i++) {
-        delete[] argv[i];
-    }
+    for (auto* arg : argv)
+        delete[] arg;
 
     return result;
 }


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

In the process of working on #4009, it turned out that device names with unicode characters are not handled properly on Windows. AFAICT they need to be encoded in UTF-16 (AKA "wide characters") on the stdio level on Windows.

EDIT: This PR is now updated according to https://github.com/supercollider/supercollider/pull/4479#pullrequestreview-262017862. Scsynth on Windows reads command line arguments in UTF-16 and converts them to UTF-8; it also sets the terminal to UTF-8, similarly to what sclang does. This should allow selecting devices with non-ASCII characters in their name. 

Please note, while the requested (non-ASCII) device name is properly displayed in the the terminal when scsynth boots, **I'm not able to test if the device selection works properly for devices with non-ASCII names**, as no devices on my system have non-ASCII characters in their name.

I'm hiding outdated information below

<details>
I started working on this issue, but it seems to be larger than just reading unicode characters in the arguments of scsynth. See relevant discussion: https://github.com/supercollider/supercollider/pull/4009#issuecomment-509001234, https://github.com/supercollider/supercollider/pull/4009#issuecomment-509016396

It seems that this PR solves the issue of passing unicode characters to scsynth on command line, having the scsynth properly handle UTF-16 encoding on the input. However, they are still not printed correctly outside of SC IDE, as they are still printed in UTF-8, which makes them display incorrectly in the console. However, in SCIDE they _are_ displayed correctly, as the IDE's post window seems to interpret characters in UTF-8.

With this in mind, it seems that we still need to fix:
- printing scsynth's unicode characters on Windows in the console (in UTF-16)
- reading these characters in scide (converting UTF-16 to UTF-8)
- eventually bringing scsynth's changes to supernova

Please note, the current implementation has a memory leak, as pointed out by @Spacechild1: https://github.com/supercollider/supercollider/pull/4009#issuecomment-509025111

My intention for this PR is to have it for reference for the work on fixing the unicode pipeline on Windows. As this seems to be a larger project, I don't think I'll be able to continue work on this.

</details>

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] This PR is ready for review
