### PR TITLE
[classlib] increase maxAttempts for tcp connection to the server

### DIFF
--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -1018,7 +1018,10 @@ Server {
 				this.prOnServerProcessExit(exitCode);
 			});
 			("Booting server '%' on address %:%.").format(this.name, addr.hostname, addr.port.asString).postln;
-			if(options.protocol == \tcp, { addr.tryConnectTCP(onComplete) }, onComplete);
+			// in case the server takes more time to boot
+			// we increase the number of attempts for tcp connection
+			// in order to minimize the chance of timing out
+			if(options.protocol == \tcp, { addr.tryConnectTCP(onComplete, nil, 20) }, onComplete);
 		}
 	}
 


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

Tested on macOS 10.13.

In the process of testing #4435, I realized that supernova takes considerably more time to boot than scsynth, which is a problem with we wait for the tcp connection to be established.

`NetAddr -tryConnectTCP`, called by `Server -boot` by default makes a maximum of 10 attempts every 0.2s, and then says that the connection failed. That means that the server needs to respond within 2 seconds. 
On my system supernova takes about 1.8s to respond to the tcp connection (~8 connection attempts) when the system is idle. When I stress my system, the server often boots after we run out of connection attempts (supernova responds after more than 2 seconds). 

This PR increases number of connection attempts to 20, in practice giving server 4 seconds to respond. It is a workaround (not a fix) for https://github.com/supercollider/supercollider/issues/4483.

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] This PR is ready for review
