### PR TITLE
add missing SIGNAL renderProcessTerminated

### DIFF
--- a/QtCollider/widgets/QcWebView.cpp
+++ b/QtCollider/widgets/QcWebView.cpp
@@ -82,8 +82,7 @@ void WebView::connectPage(QtCollider::WebPage* page) {
 
     connect(page->action(QWebEnginePage::Reload), SIGNAL(triggered(bool)), this, SLOT(onPageReload()));
 
-    connect(page, SIGNAL(renderProcessTerminated(RenderProcessTerminationStatus, int)), this,
-            SLOT(onRenderProcessTerminated(RenderProcessTerminationStatus, int)));
+    connect(page, &WebPage::renderProcessTerminated, this, &WebView::onRenderProcessTerminated);
 }
 
 void WebView::onRenderProcessTerminated(QWebEnginePage::RenderProcessTerminationStatus status, int code) {


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

This PR fixes an error message that is posted when opening `HelpBrowser.instance` in command line sclang.
```
QObject::connect: No such slot QtCollider::WebView::onRenderProcessTerminated(RenderProcessTerminationStatus, int)
```
~Adding a new SLOT called `onRenderProcessTerminated` to the  `WebPage` class seems to fix this. I've also specified that this SIGNAL and corresponding SLOT take a `QWebEnginePage::RenderProcessTerminationStatus` as first argument.~

@jrsurge posted a proper fix in his [comment](https://github.com/supercollider/supercollider/pull/4488#pullrequestreview-267479404). I've updated the PR accordingly.

~Possibly related to some behaviour mentioned in #4256~ This PR isn't a fix for any specific issue.

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [X] Code is tested
- [ ] All tests are passing
- [ ] Updated documentation
- [X] This PR is ready for review
