### PR TITLE
Topic/fix node proxy free bus timing

### DIFF
--- a/HelpSource/Classes/NodeProxy.schelp
+++ b/HelpSource/Classes/NodeProxy.schelp
@@ -368,7 +368,7 @@ if a fadeTime is given, first fade out, then clear.
 
 method::schedAfterFade
 
-Calls a function after the fadeTime and server latency has passed. If the proxy specifies a code::quant:: value, this is adjusted to it.
+Calls a function after the fadeTime and server latency have passed. If the proxy specifies a code::quant:: value, this call happens relative to the specified beat.
 
 argument::func
 a function to be called at the appropriate time

--- a/HelpSource/Classes/NodeProxy.schelp
+++ b/HelpSource/Classes/NodeProxy.schelp
@@ -366,6 +366,14 @@ reset everything to nil, neutralizes rate/numChannels
 argument::fadeTime
 if a fadeTime is given, first fade out, then clear.
 
+method::schedAfterFade
+
+Calls a function after the fadeTime and server latency has passed. If the proxy specifies a code::quant:: value, this is adjusted to it.
+
+argument::func
+a function to be called at the appropriate time
+
+
 subsection::Accessing Instance Variables
 
 method::sources

--- a/HelpSource/Classes/NodeProxy.schelp
+++ b/HelpSource/Classes/NodeProxy.schelp
@@ -368,7 +368,7 @@ if a fadeTime is given, first fade out, then clear.
 
 method::schedAfterFade
 
-Calls a function after the fadeTime and server latency have passed. If the proxy specifies a code::quant:: value, this call happens relative to the specified beat.
+Calls a function after the fadeTime and server latency have passed. If the proxy specifies a code::quant:: value, the function is evaluated code::fadeTime + latency:: seconds after the next timepoint on the quant grid; otherwise, the fade delay begins immediately.
 
 argument::func
 a function to be called at the appropriate time

--- a/SCClassLibrary/JITLib/ProxySpace/NodeProxy.sc
+++ b/SCClassLibrary/JITLib/ProxySpace/NodeProxy.sc
@@ -911,7 +911,7 @@ NodeProxy : BusPlug {
 			usedClock = (clock ? TempoClock.default);
 			delta = server.latency ? 0.01 + this.fadeTime;
 			if(quant.notNil) { delta = delta + quant.nextTimeOnGrid(usedClock) };
-			usedClock.schedAbs(delta, { CmdPeriod.remove(func); func.value; nil });
+			usedClock.schedAbs(delta, { func.value; func = nil });
 			CmdPeriod.doOnce { func.value; func = nil; };
 		}, func)
 	}

--- a/SCClassLibrary/JITLib/ProxySpace/NodeProxy.sc
+++ b/SCClassLibrary/JITLib/ProxySpace/NodeProxy.sc
@@ -910,11 +910,7 @@ NodeProxy : BusPlug {
 		if(this.isPlaying, {
 			usedClock = (clock ? TempoClock.default);
 			delta = server.latency ? 0.01 + this.fadeTime;
-			delta = delta + if(quant.notNil) {
-				quant.nextTimeOnGrid(usedClock)
-			} {
-				usedClock.beats
-			};
+			delta = delta + (quant ? 0).nextTimeOnGrid(usedClock);
 			usedClock.schedAbs(delta, { func.value; func = nil });
 			CmdPeriod.doOnce { func.value; func = nil; };
 		}, func)

--- a/SCClassLibrary/JITLib/ProxySpace/NodeProxy.sc
+++ b/SCClassLibrary/JITLib/ProxySpace/NodeProxy.sc
@@ -908,8 +908,8 @@ NodeProxy : BusPlug {
 	schedAfterFade { |func|
 		var delta, usedClock;
 		if(this.isPlaying, {
-			usedClock = (clock ? TempoClock.default);
-			delta = server.latency ? 0.01 + this.fadeTime;
+			usedClock = clock ? TempoClock.default;
+			delta = server.latency ? 0.01 + this.fadeTime; // 0.01 is reasonable for a local server
 			delta = delta + (quant ? 0).nextTimeOnGrid(usedClock);
 			usedClock.schedAbs(delta, { func.value; func = nil });
 			CmdPeriod.doOnce { func.value; func = nil; };

--- a/SCClassLibrary/JITLib/ProxySpace/NodeProxy.sc
+++ b/SCClassLibrary/JITLib/ProxySpace/NodeProxy.sc
@@ -906,13 +906,12 @@ NodeProxy : BusPlug {
 	}
 
 	schedAfterFade { |func|
-		var delta, usedClock;
+		var usedClock, time;
 		if(this.isPlaying, {
 			usedClock = clock ? TempoClock.default;
-			delta = server.latency ? 0.01 + this.fadeTime; // 0.01 is reasonable for a local server
-			delta = delta + (quant ? 0).nextTimeOnGrid(usedClock);
-			usedClock.schedAbs(delta, { func.value; func = nil });
-			CmdPeriod.doOnce { func.value; func = nil; };
+			time = this.fadeTime + (server.latency ? 0.01) + (quant ? 0).nextTimeOnGrid(usedClock);
+			usedClock.schedAbs(time, { func.value; func = nil });
+			CmdPeriod.doOnce { func.value; func = nil };
 		}, func)
 	}
 

--- a/SCClassLibrary/JITLib/ProxySpace/NodeProxy.sc
+++ b/SCClassLibrary/JITLib/ProxySpace/NodeProxy.sc
@@ -910,7 +910,11 @@ NodeProxy : BusPlug {
 		if(this.isPlaying, {
 			usedClock = (clock ? TempoClock.default);
 			delta = server.latency ? 0.01 + this.fadeTime;
-			if(quant.notNil) { delta = delta + quant.nextTimeOnGrid(usedClock) };
+			delta = delta + if(quant.notNil) {
+				quant.nextTimeOnGrid(usedClock)
+			} {
+				usedClock.beats
+			};
 			usedClock.schedAbs(delta, { func.value; func = nil });
 			CmdPeriod.doOnce { func.value; func = nil; };
 		}, func)

--- a/testsuite/classlibrary/TestNodeProxy.sc
+++ b/testsuite/classlibrary/TestNodeProxy.sc
@@ -40,4 +40,38 @@ TestNodeProxy : UnitTest {
 		this.assertEquals(proxy.isPlaying, false, "Setting the proxy's source should not set isPlaying = true");
 	}
 
+	test_schedAfterFade_notPlaying {
+		var ok = false;
+		proxy.fadeTime = 0.1;
+		proxy.schedAfterFade { ok = true };
+		this.assert(ok, "if not playing, schedAfterFade should happen immediately");
+	}
+	test_schedAfterFade_playing {
+		var ok = false;
+		proxy.fadeTime = 0.1;
+		proxy.source = { Silent.ar };
+		proxy.schedAfterFade { ok = true };
+		0.11.wait;
+		this.assert(ok, "if playing, schedAfterFade should have happened after fadeTime");
+	}
+	test_schedAfterFade_cmdPeriod {
+		var ok = false;
+		proxy.fadeTime = 0.1;
+		proxy.source = { Silent.ar };
+		proxy.schedAfterFade { ok = true };
+		CmdPeriod.run;
+		this.assert(ok, "scheduled function should be run at CmdPeriod");
+	}
+
+	test_schedAfterFade_cmdPeriod_removed {
+		var count = 0;
+		proxy.fadeTime = 0.1;
+		proxy.source = { Silent.ar };
+		proxy.schedAfterFade { count = count + 1 };
+		CmdPeriod.run;
+		0.11.wait;
+		this.assertEquals(count, 1, "scheduled function should be run at CmdPeriod, not twice");
+	}
+
+
 }

--- a/testsuite/classlibrary/TestNodeProxy.sc
+++ b/testsuite/classlibrary/TestNodeProxy.sc
@@ -53,7 +53,7 @@ TestNodeProxy : UnitTest {
 		proxy.source = { Silent.ar };
 		proxy.schedAfterFade { ok = true };
 		0.11.wait;
-		this.assert(ok, "if playing, schedAfterFade should have happened after fadeTime");
+		this.assert(ok, "if playing, schedAfterFade should happen right after fadeTime");
 	}
 
 

--- a/testsuite/classlibrary/TestNodeProxy.sc
+++ b/testsuite/classlibrary/TestNodeProxy.sc
@@ -46,31 +46,14 @@ TestNodeProxy : UnitTest {
 		proxy.schedAfterFade { ok = true };
 		this.assert(ok, "if not playing, schedAfterFade should happen immediately");
 	}
-	test_schedAfterFade_playing {
+
+	test_schedAfterFade {
 		var ok = false;
 		proxy.fadeTime = 0.1;
 		proxy.source = { Silent.ar };
 		proxy.schedAfterFade { ok = true };
 		0.11.wait;
 		this.assert(ok, "if playing, schedAfterFade should have happened after fadeTime");
-	}
-	test_schedAfterFade_cmdPeriod {
-		var ok = false;
-		proxy.fadeTime = 0.1;
-		proxy.source = { Silent.ar };
-		proxy.schedAfterFade { ok = true };
-		CmdPeriod.run;
-		this.assert(ok, "scheduled function should be run at CmdPeriod");
-	}
-
-	test_schedAfterFade_cmdPeriod_removed {
-		var count = 0;
-		proxy.fadeTime = 0.1;
-		proxy.source = { Silent.ar };
-		proxy.schedAfterFade { count = count + 1 };
-		CmdPeriod.run;
-		0.11.wait;
-		this.assertEquals(count, 1, "scheduled function should be run at CmdPeriod, not twice");
 	}
 
 

--- a/testsuite/classlibrary/TestNodeProxy_Server.sc
+++ b/testsuite/classlibrary/TestNodeProxy_Server.sc
@@ -127,7 +127,7 @@ TestNodeProxy_Server : UnitTest {
 		0.2.wait;
 		proxy.schedAfterFade { ok = true };
 		(proxy.fadeTime + 1.5 + proxy.server.latency - 0.2).wait;
-		this.assert(ok, "schedAfterFade should happen right after quant and fadeTime");
+		this.assert(ok, "schedAfterFade should happened right after quant and fadeTime");
 	}
 
 	test_schedAfterFade_notBeforeQuant {
@@ -139,7 +139,7 @@ TestNodeProxy_Server : UnitTest {
 		0.2.wait;
 		proxy.schedAfterFade { ok = false };
 		(proxy.fadeTime + proxy.server.latency + 1.0 - 0.2 - earlierThan).wait;
-		this.assert(ok, "schedAfterFade should not happen before quant and fadeTime");
+		this.assert(ok, "schedAfterFade should not happened before quant and fadeTime");
 	}
 
 	test_schedAfterFade_cmdPeriod {

--- a/testsuite/classlibrary/TestNodeProxy_Server.sc
+++ b/testsuite/classlibrary/TestNodeProxy_Server.sc
@@ -117,6 +117,20 @@ TestNodeProxy_Server : UnitTest {
 		this.assertEquals(proxy.numChannels, 8, "When reshaping is expanding, NodeProxy's number of channels should NOT be able to contract");
 	}
 
+	test_reshaping_freeOldBus_after_fadeTime {
+		var oldBus;
+		proxy.reshaping = \expanding;
+		proxy.source = { Silent.ar.dup(2) };
+		proxy.fadeTime = 0.1;
+		oldBus = proxy.bus;
+		proxy.source = { Silent.ar.dup(3) };
+		(proxy.fadeTime + server.latency).wait;
+		oldBus.postln;
+		this.assert(oldBus.index.isNil,
+			"When reshaping, the old bus should be free after fadeTime and server latency"
+		);
+	}
+
 	test_clear_fadeTime {
 		var clearTime = 0.1;
 

--- a/testsuite/classlibrary/TestNodeProxy_Server.sc
+++ b/testsuite/classlibrary/TestNodeProxy_Server.sc
@@ -180,13 +180,13 @@ TestNodeProxy_Server : UnitTest {
 		proxy.source = { Silent.ar.dup(2) };
 		proxy.fadeTime = 0.1;
 		proxy.clock = TempoClock.new(10);
-		proxy.quant = [1, 0.5];
+		proxy.quant = [1.0, 0.5];
 		oldBus = proxy.bus;
 		0.01.wait;
 		proxy.source = { Silent.ar.dup(3) };
-		(proxy.fadeTime + server.latency + 0).wait;
+		(proxy.fadeTime + server.latency + 0.5).wait;
 		this.assert(oldBus.index.isNil,
-			"When reshaping, the old bus should be free after fadeTime and server latency"
+			"When reshaping, the old bus should be free after fadeTime, quant and server latency"
 		);
 	}
 

--- a/testsuite/classlibrary/TestNodeProxy_Server.sc
+++ b/testsuite/classlibrary/TestNodeProxy_Server.sc
@@ -127,7 +127,7 @@ TestNodeProxy_Server : UnitTest {
 		0.2.wait;
 		proxy.schedAfterFade { ok = true };
 		(proxy.fadeTime + 1.5 + proxy.server.latency - 0.2).wait;
-		this.assert(ok, "schedAfterFade should have happen right after quant and fadeTime");
+		this.assert(ok, "schedAfterFade should happen right after quant and fadeTime");
 	}
 
 	test_schedAfterFade_notBeforeQuant {

--- a/testsuite/classlibrary/TestNodeProxy_Server.sc
+++ b/testsuite/classlibrary/TestNodeProxy_Server.sc
@@ -125,7 +125,6 @@ TestNodeProxy_Server : UnitTest {
 		oldBus = proxy.bus;
 		proxy.source = { Silent.ar.dup(3) };
 		(proxy.fadeTime + server.latency).wait;
-		oldBus.postln;
 		this.assert(oldBus.index.isNil,
 			"When reshaping, the old bus should be free after fadeTime and server latency"
 		);

--- a/testsuite/classlibrary/TestNodeProxy_Server.sc
+++ b/testsuite/classlibrary/TestNodeProxy_Server.sc
@@ -127,7 +127,7 @@ TestNodeProxy_Server : UnitTest {
 		0.2.wait;
 		proxy.schedAfterFade { ok = true };
 		(proxy.fadeTime + 1.5 + proxy.server.latency - 0.2).wait;
-		this.assert(ok, "schedAfterFade should have happened after quant and fadeTime");
+		this.assert(ok, "schedAfterFade should have happen right after quant and fadeTime");
 	}
 
 	test_schedAfterFade_notBeforeQuant {
@@ -170,7 +170,7 @@ TestNodeProxy_Server : UnitTest {
 		proxy.source = { Silent.ar.dup(3) };
 		(proxy.fadeTime + server.latency).wait;
 		this.assert(oldBus.index.isNil,
-			"When reshaping, the old bus should be free after fadeTime and server latency"
+			"When reshaping, the old bus should be free right after fadeTime and server latency"
 		);
 	}
 
@@ -186,7 +186,7 @@ TestNodeProxy_Server : UnitTest {
 		proxy.source = { Silent.ar.dup(3) };
 		(proxy.fadeTime + server.latency + 0.5).wait;
 		this.assert(oldBus.index.isNil,
-			"When reshaping, the old bus should be free after fadeTime, quant and server latency"
+			"When reshaping, the old bus should be free right after fadeTime, quant and server latency"
 		);
 	}
 

--- a/testsuite/classlibrary/TestNodeProxy_Server.sc
+++ b/testsuite/classlibrary/TestNodeProxy_Server.sc
@@ -117,6 +117,50 @@ TestNodeProxy_Server : UnitTest {
 		this.assertEquals(proxy.numChannels, 8, "When reshaping is expanding, NodeProxy's number of channels should NOT be able to contract");
 	}
 
+	test_schedAfterFade_afterQuant {
+		var ok = false;
+		proxy.source = { Silent.ar };
+		1.wait;
+		proxy.fadeTime = 0.1;
+		proxy.clock = TempoClock.new(1);
+		proxy.quant = [1, 0.5];
+		0.2.wait;
+		proxy.schedAfterFade { ok = true };
+		(proxy.fadeTime + 1.5 + proxy.server.latency - 0.2).wait;
+		this.assert(ok, "schedAfterFade should have happened after quant and fadeTime");
+	}
+
+	test_schedAfterFade_notBeforeQuant {
+		var ok = true, earlierThan = 0.01;
+		proxy.source = { Silent.ar };
+		proxy.fadeTime = 0.1;
+		proxy.clock = TempoClock.new(1);
+		proxy.quant = 1.0;
+		0.2.wait;
+		proxy.schedAfterFade { ok = false };
+		(proxy.fadeTime + proxy.server.latency + 1.0 - 0.2 - earlierThan).wait;
+		this.assert(ok, "schedAfterFade should not happen before quant and fadeTime");
+	}
+
+	test_schedAfterFade_cmdPeriod {
+		var ok = false;
+		proxy.fadeTime = 0.1;
+		proxy.source = { Silent.ar };
+		proxy.schedAfterFade { ok = true };
+		CmdPeriod.run;
+		this.assert(ok, "scheduled function should be run at CmdPeriod");
+	}
+
+	test_schedAfterFade_cmdPeriod_removed {
+		var count = 0;
+		proxy.fadeTime = 0.1;
+		proxy.source = { Silent.ar };
+		proxy.schedAfterFade { count = count + 1 };
+		CmdPeriod.run;
+		0.11.wait;
+		this.assertEquals(count, 1, "scheduled function should be run at CmdPeriod, not twice");
+	}
+
 	test_reshaping_freeOldBus_after_fadeTime {
 		var oldBus;
 		proxy.reshaping = \expanding;
@@ -125,6 +169,22 @@ TestNodeProxy_Server : UnitTest {
 		oldBus = proxy.bus;
 		proxy.source = { Silent.ar.dup(3) };
 		(proxy.fadeTime + server.latency).wait;
+		this.assert(oldBus.index.isNil,
+			"When reshaping, the old bus should be free after fadeTime and server latency"
+		);
+	}
+
+	test_reshaping_freeOldBus_after_fadeTime_quant {
+		var oldBus;
+		proxy.reshaping = \expanding;
+		proxy.source = { Silent.ar.dup(2) };
+		proxy.fadeTime = 0.1;
+		proxy.clock = TempoClock.new(10);
+		proxy.quant = [1, 0.5];
+		oldBus = proxy.bus;
+		0.01.wait;
+		proxy.source = { Silent.ar.dup(3) };
+		(proxy.fadeTime + server.latency + 0).wait;
 		this.assert(oldBus.index.isNil,
 			"When reshaping, the old bus should be free after fadeTime and server latency"
 		);


### PR DESCRIPTION

## Purpose and Motivation

As it turned out, when dynamically changing the number of channels and/or the rate of a NodeProxy, the old bus was freed too late. This occurred for those who use the `reshaping = \elastic` mode. After some time this memory leak would lead to a failure of bus allocation due to overrun.

The bug was due to a wrong use of `sched` instead of `schedAbs`.

Some refactoring improved readability and better overall behavior.

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

- Documentation
- Bug fix
- New feature
- Breaking change

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review
