### PR TITLE
Only the main window should received a signal when cmd+q is pressed o…

### DIFF
--- a/editors/sc-ide/core/sc_process.cpp
+++ b/editors/sc-ide/core/sc_process.cpp
@@ -63,8 +63,8 @@ void ScProcess::prepareActions(Settings::Manager* settings) {
     const QString interpreterCategory(tr("Interpreter"));
 
     mActions[ToggleRunning] = action = new QAction(tr("Boot or Quit Interpreter"), this);
-    action->setMenuRole(
-        QAction::NoRole); // the default QAction::TextHeuristicRole incorrectly detects a quit role on macOS
+    // the default QAction::TextHeuristicRole incorrectly detects a quit role on macOS
+    action->setMenuRole(QAction::NoRole);
     connect(action, SIGNAL(triggered()), this, SLOT(toggleRunning()));
     // settings->addAction( action, "interpreter-toggle-running", interpreterCategory);
 

--- a/editors/sc-ide/core/sc_process.cpp
+++ b/editors/sc-ide/core/sc_process.cpp
@@ -63,7 +63,8 @@ void ScProcess::prepareActions(Settings::Manager* settings) {
     const QString interpreterCategory(tr("Interpreter"));
 
     mActions[ToggleRunning] = action = new QAction(tr("Boot or Quit Interpreter"), this);
-    action->setMenuRole(QAction::NoRole); // the default QAction::TextHeuristicRole incorrectly detects a quit role on macOS
+    action->setMenuRole(
+        QAction::NoRole); // the default QAction::TextHeuristicRole incorrectly detects a quit role on macOS
     connect(action, SIGNAL(triggered()), this, SLOT(toggleRunning()));
     // settings->addAction( action, "interpreter-toggle-running", interpreterCategory);
 

--- a/editors/sc-ide/core/sc_process.cpp
+++ b/editors/sc-ide/core/sc_process.cpp
@@ -63,7 +63,7 @@ void ScProcess::prepareActions(Settings::Manager* settings) {
     const QString interpreterCategory(tr("Interpreter"));
 
     mActions[ToggleRunning] = action = new QAction(tr("Boot or Quit Interpreter"), this);
-    action->setMenuRole(QAction::NoRole); // to prevent the action from being fired with cmd+q on macosx
+    action->setMenuRole(QAction::NoRole); // the default QAction::TextHeuristicRole incorrectly detects a quit role on macOS
     connect(action, SIGNAL(triggered()), this, SLOT(toggleRunning()));
     // settings->addAction( action, "interpreter-toggle-running", interpreterCategory);
 

--- a/editors/sc-ide/core/sc_process.cpp
+++ b/editors/sc-ide/core/sc_process.cpp
@@ -63,6 +63,7 @@ void ScProcess::prepareActions(Settings::Manager* settings) {
     const QString interpreterCategory(tr("Interpreter"));
 
     mActions[ToggleRunning] = action = new QAction(tr("Boot or Quit Interpreter"), this);
+    action->setMenuRole(QAction::NoRole); // to prevent the action from being fired with cmd+q on macosx
     connect(action, SIGNAL(triggered()), this, SLOT(toggleRunning()));
     // settings->addAction( action, "interpreter-toggle-running", interpreterCategory);
 

--- a/editors/sc-ide/core/sc_server.cpp
+++ b/editors/sc-ide/core/sc_server.cpp
@@ -61,6 +61,7 @@ void ScServer::createActions(Settings::Manager* settings) {
     QWidgetAction* widgetAction;
 
     mActions[ToggleRunning] = action = new QAction(tr("Boot or quit default server"), this);
+    action->setMenuRole(QAction::NoRole); // to prevent the action from being fired with cmd+q on macosx
     connect(action, SIGNAL(triggered()), this, SLOT(toggleRunning()));
     // settings->addAction( action, "synth-server-toggle-running", synthServerCategory);
 

--- a/editors/sc-ide/core/sc_server.cpp
+++ b/editors/sc-ide/core/sc_server.cpp
@@ -61,7 +61,7 @@ void ScServer::createActions(Settings::Manager* settings) {
     QWidgetAction* widgetAction;
 
     mActions[ToggleRunning] = action = new QAction(tr("Boot or quit default server"), this);
-    action->setMenuRole(QAction::NoRole); // to prevent the action from being fired with cmd+q on macosx
+    action->setMenuRole(QAction::NoRole); // the default QAction::TextHeuristicRole incorrectly detects a quit role on macOS
     connect(action, SIGNAL(triggered()), this, SLOT(toggleRunning()));
     // settings->addAction( action, "synth-server-toggle-running", synthServerCategory);
 

--- a/editors/sc-ide/core/sc_server.cpp
+++ b/editors/sc-ide/core/sc_server.cpp
@@ -61,7 +61,8 @@ void ScServer::createActions(Settings::Manager* settings) {
     QWidgetAction* widgetAction;
 
     mActions[ToggleRunning] = action = new QAction(tr("Boot or quit default server"), this);
-    action->setMenuRole(QAction::NoRole); // the default QAction::TextHeuristicRole incorrectly detects a quit role on macOS
+    action->setMenuRole(
+        QAction::NoRole); // the default QAction::TextHeuristicRole incorrectly detects a quit role on macOS
     connect(action, SIGNAL(triggered()), this, SLOT(toggleRunning()));
     // settings->addAction( action, "synth-server-toggle-running", synthServerCategory);
 

--- a/editors/sc-ide/core/sc_server.cpp
+++ b/editors/sc-ide/core/sc_server.cpp
@@ -61,8 +61,8 @@ void ScServer::createActions(Settings::Manager* settings) {
     QWidgetAction* widgetAction;
 
     mActions[ToggleRunning] = action = new QAction(tr("Boot or quit default server"), this);
-    action->setMenuRole(
-        QAction::NoRole); // the default QAction::TextHeuristicRole incorrectly detects a quit role on macOS
+    // the default QAction::TextHeuristicRole incorrectly detects a quit role on macOS
+    action->setMenuRole(QAction::NoRole);
     connect(action, SIGNAL(triggered()), this, SLOT(toggleRunning()));
     // settings->addAction( action, "synth-server-toggle-running", synthServerCategory);
 

--- a/editors/sc-ide/widgets/main_window.cpp
+++ b/editors/sc-ide/widgets/main_window.cpp
@@ -237,6 +237,7 @@ void MainWindow::createActions() {
     mActions[Quit] = action = new QAction(QIcon::fromTheme("application-exit"), tr("&Quit..."), this);
     action->setShortcut(tr("Ctrl+Q", "Quit application"));
     action->setStatusTip(tr("Quit SuperCollider IDE"));
+    action->setMenuRole(QAction::QuitRole); // needed for mac os x
     QObject::connect(action, SIGNAL(triggered()), this, SLOT(onQuit()));
     settings->addAction(action, "ide-quit", ideCategory);
 

--- a/editors/sc-ide/widgets/main_window.cpp
+++ b/editors/sc-ide/widgets/main_window.cpp
@@ -237,7 +237,7 @@ void MainWindow::createActions() {
     mActions[Quit] = action = new QAction(QIcon::fromTheme("application-exit"), tr("&Quit..."), this);
     action->setShortcut(tr("Ctrl+Q", "Quit application"));
     action->setStatusTip(tr("Quit SuperCollider IDE"));
-    action->setMenuRole(QAction::QuitRole); // needed for mac os x
+    action->setMenuRole(QAction::QuitRole); // explicitely states that this action can be triggered by macOS QUIT events (such as cmd+q or window closing)
     QObject::connect(action, SIGNAL(triggered()), this, SLOT(onQuit()));
     settings->addAction(action, "ide-quit", ideCategory);
 

--- a/editors/sc-ide/widgets/main_window.cpp
+++ b/editors/sc-ide/widgets/main_window.cpp
@@ -237,7 +237,8 @@ void MainWindow::createActions() {
     mActions[Quit] = action = new QAction(QIcon::fromTheme("application-exit"), tr("&Quit..."), this);
     action->setShortcut(tr("Ctrl+Q", "Quit application"));
     action->setStatusTip(tr("Quit SuperCollider IDE"));
-    action->setMenuRole(QAction::QuitRole); // explicitely states that this action can be triggered by macOS QUIT events (such as cmd+q or window closing)
+    action->setMenuRole(QAction::QuitRole); // explicitely states that this action can be triggered by macOS QUIT events
+                                            // (such as cmd+q or window closing)
     QObject::connect(action, SIGNAL(triggered()), this, SLOT(onQuit()));
     settings->addAction(action, "ide-quit", ideCategory);
 

--- a/editors/sc-ide/widgets/main_window.cpp
+++ b/editors/sc-ide/widgets/main_window.cpp
@@ -237,8 +237,10 @@ void MainWindow::createActions() {
     mActions[Quit] = action = new QAction(QIcon::fromTheme("application-exit"), tr("&Quit..."), this);
     action->setShortcut(tr("Ctrl+Q", "Quit application"));
     action->setStatusTip(tr("Quit SuperCollider IDE"));
-    action->setMenuRole(QAction::QuitRole); // explicitely states that this action can be triggered by macOS QUIT events
-                                            // (such as cmd+q or window closing)
+    // explicitly states that this action can be triggered by macOS QUIT events
+    // (such as cmd+q or window closing)
+    action->setMenuRole(QAction::QuitRole);
+
     QObject::connect(action, SIGNAL(triggered()), this, SLOT(onQuit()));
     settings->addAction(action, "ide-quit", ideCategory);
 


### PR DESCRIPTION
## Purpose and Motivation

Fixes #4300.

## Types of changes
- Bug fix

## Description

Some users reported that in the develop branch, one could not quit the IDE with CMD+Q anymore (see #4300).
I could reproduce that on my local machine (Mac OS 10.12, QT 5.13).
I first thought it was due to a change in the code base since 3.10.2 as I could not reproduce the problem with the release.
I tried recompiling releases tags 3.10.2, then 3.10.1 and 3.10.0 and I could still reproduce the problem with the most recent version of QT installed with brew (5.13).
I put a lot of traces and I realized that when pressing cmd+q, `MainWindow::onQuit` was not called. Instead, `ScProcess::toggleRunning` was called.
I then remembered reading in [QT MacOS issues page](https://doc.qt.io/qt-5/macos-issues.html#) that Qt automagically handles certain actions by their texts. Basically, if you add an action with the word "Quit" or "Exit" in it, QT will register them to cmd+Q. I would have thought that it would be only for menu item actions, or at least for QWidgets, but it seems that, at least for recent QT versions, it also applies to `QProcess` or plain `QObject`.
QT doc recommends to action action roles to bypass the magical interpretation of the action based on its text.
So the solution was disable reacting to cmd+q by adding a `QAction::NoRole` to the `Boot or Quit Interpreter` and `Boot or Quit Server` actions, and adding a `QAction::QuitRole` to clearly define that the callback shall be called on MainWindow, whatever the translation of the `Quit` is, when pressing cmd+q.

## To-do list

- [X] All tests are passing
- [X] This PR is ready for review
- [X] Tested on Windows
- [X] Tested on Linux
