### PR TITLE
[scsynth][supernova] fix Windows not guarding denormals

### DIFF
--- a/server/scsynth/SC_World.cpp
+++ b/server/scsynth/SC_World.cpp
@@ -55,6 +55,12 @@
 
 #include "malloc_aligned.hpp"
 
+#include <boost/predef/hardware.h>
+
+#ifdef BOOST_HW_SIMD_AVAILABLE >= BOOST_HW_SIMD_X86_SSE_VERSION
+#    include <xmmintrin.h>
+#endif
+
 // undefine the shadowed scfft functions
 #undef scfft_create
 #undef scfft_dofft
@@ -148,26 +154,12 @@ void zfree(void* ptr) { return free_alig(ptr); }
 ////////////////////////////////////////////////////////////////////////////////
 
 // Set denormal FTZ mode on CPUs that need/support it.
-void sc_SetDenormalFlags();
-
-#ifdef __SSE2__
-#    include <xmmintrin.h>
-
 void sc_SetDenormalFlags() {
+#if BOOST_HW_SIMD_X86 >= BOOST_HW_SIMD_X86_SSE_VERSION
     _MM_SET_FLUSH_ZERO_MODE(_MM_FLUSH_ZERO_ON);
     _mm_setcsr(_mm_getcsr() | 0x40); // DAZ
-}
-
-#elif defined(__SSE__)
-#    include <xmmintrin.h>
-
-void sc_SetDenormalFlags() { _MM_SET_FLUSH_ZERO_MODE(_MM_FLUSH_ZERO_ON); }
-
-#else
-
-void sc_SetDenormalFlags() {}
-
 #endif
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/server/supernova/server/server.cpp
+++ b/server/supernova/server/server.cpp
@@ -36,6 +36,8 @@
 #    include <CoreAudio/CoreAudioTypes.h>
 #endif
 
+#include <boost/predef/hardware.h>
+
 namespace nova {
 
 class nova_server* instance = nullptr;
@@ -207,7 +209,7 @@ static void name_current_thread(int thread_index) {
 }
 
 static void set_daz_ftz(void) {
-#ifdef __SSE__
+#if BOOST_HW_SIMD_X86 >= BOOST_X86_SSE_VERSION
     /* denormal handling */
     _MM_SET_FLUSH_ZERO_MODE(_MM_FLUSH_ZERO_ON);
     _mm_setcsr(_mm_getcsr() | 0x40);


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

[Edit] Updated in line with https://github.com/supercollider/supercollider/pull/4504#issuecomment-517965808

This fixes #4046 - Windows not guarding denormals.

MSVC doesn't set the usual `__SSE__` and `__SSE2__` etc definitions, so denormals aren't properly handled on Windows.

This PR uses boost.predef to check for requested SIMD instructions.


## Types of changes

- Bug fix
Fixes #4046
- Breaking changes (?)
This changes how every platform works, so may have unintended consequences

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [ ] Code is tested
scsynth, yes. supernova doesn't compile on msvc
- [x] All tests are passing
~~- [ ] Updated documentation~~
- [x] This PR is ready for review
