### PR TITLE
Fix incorrect paths in README_LINUX

### DIFF
--- a/README_LINUX.md
+++ b/README_LINUX.md
@@ -134,7 +134,8 @@ If you are installing sclang with GUI features and the IDE, and you installed Qt
 The location of `/path/to/qt5` will depend on how you installed Qt:
 
 - If you downloaded Qt from the Qt website, the path is two directories down from the top-level unpacked Qt directory, in a folder called `gcc`: `Qt/5.11.0/gcc_64/` (64-bit Linux) or `Qt/5.11.0/gcc/` (32-bit). By default, the Qt installer places `Qt/` in your home directory.
-- If you used the Trusty/Xenial PPA's described above, the path is `/opt/qt511` or `/opt/qt510` (depending on which version you installed).
+- If you used the Xenial 3.11 PPA's described above, the path is `/opt/qt511/gcc_64` (64-bit) or `/opt/qt511/gcc` (32-bit).
+- If you used the Trusty 3.10 PPA's described above, the path is `/opt/qt510/gcc_64` (64-bit) or `/opt/qt510/gcc` (32-bit).
 
 If you want to build without Qt entirely, run
 


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

see discussion: https://www.listarc.bham.ac.uk/lists/sc-users/msg65059.html

forgot the `gcc_64` subdirectory

## Types of changes

<!-- Delete lines that don't apply -->

- Documentation

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Updated documentation
