### PR TITLE
[classlib] Plotter: correct resampling of domain given fixed Array:series method.

### DIFF
--- a/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
+++ b/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
@@ -159,7 +159,7 @@ Plot {
 				0.5.dup(size) // put the values in the middle of the plot
 			} {
 				domainSpec.unmap(
-					(domainSpec.minval, domainSpec.minval + (range / (size-1)) .. domainSpec.maxval)
+					Array.interpolation(size, domainSpec.minval, domainSpec.maxval)
 				);
 			}
 		};


### PR DESCRIPTION
## Purpose and Motivation

Fixes #4505, which came up as an issue after #4454 broke #4082.

The way the plot's domain values were previously calculated, accumulated resolution error meant that `Array:series` prevented the domain from reaching its upper boundary in some cases (before #4454, `Array:series` would overshoot its end value), which in turn meant the domain array would be one value less than the data coordinate array.

This fix replace Array:series with Array:interpolation to resample the domain, ensuring the domain hits the last value and its size matches exactly with the data coordinate array.

## Types of changes
- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
~~- [ ] Updated documentation~~
- [x] This PR is ready for review
