### PR TITLE
Plotter: update default colors to valid colors.

### DIFF
--- a/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
+++ b/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
@@ -14,14 +14,14 @@ Plot {
 
 		StartUp.add {
 			GUI.skin.put(\plot, (
-				gridColorX: QtGUI.palette.highlight,
-				gridColorY: QtGUI.palette.highlight,
-				fontColor: QtGUI.palette.windowText,
-				plotColor: [QtGUI.palette.windowText, Color.blue.valueBlend(QtGUI.palette.windowText), Color.red.valueBlend(QtGUI.palette.windowText), Color.green(0.7).valueBlend(QtGUI.palette.windowText)],
-				// gridColorX: QtGUI.palette.highlight.sat_(0.8).alpha_(0.6),
-				// gridColorY: QtGUI.palette.highlight.sat_(0.8).alpha_(0.6),
-				// fontColor: Color(0.5 ! 3),
-				// plotColor: [ QtGUI.palette.highlight.val_(0.5) ],
+				// gridColorX: QtGUI.palette.highlight,
+				// gridColorY: QtGUI.palette.highlight,
+				// fontColor: QtGUI.palette.windowText,
+				// plotColor: [QtGUI.palette.windowText, Color.blue.valueBlend(QtGUI.palette.windowText), Color.red.valueBlend(QtGUI.palette.windowText), Color.green(0.7).valueBlend(QtGUI.palette.windowText)],
+				gridColorX: QtGUI.palette.highlight.sat_(0.8).alpha_(0.6),
+				gridColorY: QtGUI.palette.highlight.sat_(0.8).alpha_(0.6),
+				fontColor: Color(0.5 ! 3),
+				plotColor: [ QtGUI.palette.highlight.val_(0.5) ],
 				background: QtGUI.palette.base,
 				gridLinePattern: nil,
 				gridLineSmoothing: false,

--- a/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
+++ b/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
@@ -497,7 +497,7 @@ Plotter {
 		};
 		modes = [\points, \levels, \linear, \plines, \steps, \bars].iter.loop;
 		this.plotMode = \linear;
-		// this.plotColor = Color.black;
+		this.plotColor = GUI.skins.plot.plotColor;
 
 		interactionView
 		.background_(Color.clear)
@@ -732,7 +732,7 @@ Plotter {
 		plots !? { plots = plots.keep(data.size.neg) };
 		plots = plots ++ template.dup(data.size - plots.size);
 		plots.do { |plot, i| plot.value = data.at(i) };
-		// this.plotColor_(plotColor);
+		this.plotColor_(plotColor);
 		this.plotMode_(plotMode);
 		this.updatePlotSpecs;
 		this.updatePlotBounds;

--- a/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
+++ b/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
@@ -14,14 +14,10 @@ Plot {
 
 		StartUp.add {
 			GUI.skin.put(\plot, (
-				// gridColorX: QtGUI.palette.highlight,
-				// gridColorY: QtGUI.palette.highlight,
-				// fontColor: QtGUI.palette.windowText,
-				// plotColor: [QtGUI.palette.windowText, Color.blue.valueBlend(QtGUI.palette.windowText), Color.red.valueBlend(QtGUI.palette.windowText), Color.green(0.7).valueBlend(QtGUI.palette.windowText)],
-				gridColorX: QtGUI.palette.highlight.sat_(0.8).alpha_(0.6),
-				gridColorY: QtGUI.palette.highlight.sat_(0.8).alpha_(0.6),
-				fontColor: Color(0.5 ! 3),
-				plotColor: [ QtGUI.palette.highlight.val_(0.5) ],
+				gridColorX: QtGUI.palette.highlight.sat_(0.2).val_(0.9),
+				gridColorY: QtGUI.palette.highlight.sat_(0.2).val_(0.9),
+				fontColor: Color(*(0.3 ! 3)),
+				plotColor: [ QtGUI.palette.highlight.val_(0.4) ],
 				background: QtGUI.palette.base,
 				gridLinePattern: nil,
 				gridLineSmoothing: false,

--- a/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
+++ b/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
@@ -14,10 +14,10 @@ Plot {
 
 		StartUp.add {
 			GUI.skin.put(\plot, (
-				gridColorX: QtGUI.palette.highlight,
-				gridColorY: QtGUI.palette.highlight,
-				fontColor: QtGUI.palette.windowText,
-				plotColor: [QtGUI.palette.windowText, Color.blue.valueBlend(QtGUI.palette.windowText), Color.red.valueBlend(QtGUI.palette.windowText), Color.green(0.7).valueBlend(QtGUI.palette.windowText)],
+				gridColorX: QtGUI.palette.highlight.sat_(0.8).alpha_(0.6),
+				gridColorY: QtGUI.palette.highlight.sat_(0.8).alpha_(0.6),
+				fontColor: Color(0.5 ! 3),
+				plotColor: [ QtGUI.palette.highlight.val_(0.5) ],
 				background: QtGUI.palette.base,
 				gridLinePattern: nil,
 				gridLineSmoothing: false,

--- a/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
+++ b/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
@@ -14,10 +14,14 @@ Plot {
 
 		StartUp.add {
 			GUI.skin.put(\plot, (
-				gridColorX: QtGUI.palette.highlight.sat_(0.8).alpha_(0.6),
-				gridColorY: QtGUI.palette.highlight.sat_(0.8).alpha_(0.6),
-				fontColor: Color(0.5 ! 3),
-				plotColor: [ QtGUI.palette.highlight.val_(0.5) ],
+				gridColorX: QtGUI.palette.highlight,
+				gridColorY: QtGUI.palette.highlight,
+				fontColor: QtGUI.palette.windowText,
+				plotColor: [QtGUI.palette.windowText, Color.blue.valueBlend(QtGUI.palette.windowText), Color.red.valueBlend(QtGUI.palette.windowText), Color.green(0.7).valueBlend(QtGUI.palette.windowText)],
+				// gridColorX: QtGUI.palette.highlight.sat_(0.8).alpha_(0.6),
+				// gridColorY: QtGUI.palette.highlight.sat_(0.8).alpha_(0.6),
+				// fontColor: Color(0.5 ! 3),
+				// plotColor: [ QtGUI.palette.highlight.val_(0.5) ],
 				background: QtGUI.palette.base,
 				gridLinePattern: nil,
 				gridLineSmoothing: false,

--- a/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
+++ b/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
@@ -13,10 +13,6 @@ Plot {
 	*initClass {
 		if(Platform.hasQt.not) { ^nil; };	// skip init on Qt-less builds
 
-		// prevent accumulating in StartUp by multiple calls to *initClass
-		// TODO: review removing this
-		// initGuiSkin !? { StartUp.remove(initGuiSkin) };
-
 		initGuiSkin = {
 			var palette = QtGUI.palette;
 			var hl = palette.highlight;
@@ -26,7 +22,7 @@ Plot {
 			var gridCol = butt.blend(baseText, 0.2);
 			var labelCol = butt.blend(baseText, 0.7);
 
-			GUI.skin.put(\plot, (
+			GUI.skins.put(\plot, (
 				gridColorX: gridCol,
 				gridColorY: gridCol,
 				fontColor: labelCol,
@@ -54,7 +50,7 @@ Plot {
 
 	init {
 		var fontName;
-		var skin = GUI.skin.at(\plot);
+		var skin = GUI.skins.at(\plot);
 
 		drawGrid = DrawGrid(bounds ? Rect(0,0,1,1),nil,nil);
 		drawGrid.x.labelOffset = Point(0,4);

--- a/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
+++ b/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
@@ -13,11 +13,13 @@ Plot {
 		if(Platform.hasQt.not) { ^nil; };	// skip init on Qt-less builds
 
 		StartUp.add {
+			var hlHSV = QtGUI.palette.highlight.asHSV;
+
 			GUI.skin.put(\plot, (
-				gridColorX: QtGUI.palette.highlight.sat_(0.2).val_(0.9),
-				gridColorY: QtGUI.palette.highlight.sat_(0.2).val_(0.9),
+				gridColorX: Color.hsv(*hlHSV.put(1, 0.2).put(2, 0.9)),
+				gridColorY: Color.hsv(*hlHSV.put(1, 0.2).put(2, 0.9)),
 				fontColor: Color(*(0.3 ! 3)),
-				plotColor: [ QtGUI.palette.highlight.val_(0.4) ],
+				plotColor: [Color.hsv(*hlHSV.put(2, 0.4))],
 				background: QtGUI.palette.base,
 				gridLinePattern: nil,
 				gridLineSmoothing: false,

--- a/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
+++ b/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
@@ -19,8 +19,8 @@ Plot {
 			var base = palette.base;
 			var baseText = palette.baseText;
 			var butt = palette.button;
-			var gridCol = butt.blend(baseText, 0.2);
-			var labelCol = butt.blend(baseText, 0.7);
+			var gridCol = palette.window;
+			var labelCol = butt.blend(baseText, 0.6);
 
 			GUI.skins.put(\plot, (
 				gridColorX: gridCol,
@@ -483,6 +483,7 @@ Plotter {
 		if(parent.isNil) {
 			parent = Window.new(name ? "Plot", bounds ? Rect(100, 200, 400, 300));
 			bounds = parent.view.bounds.insetBy(8);
+			parent.background_(QtGUI.palette.window);
 			interactionView = UserView.new(parent, bounds);
 
 			interactionView.drawFunc = { this.draw };


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

Revealed in fa67b746fa6cf9cd29eb42d4fba3f63133e3bf8d, `Plotter` never really handled default colors correctly. When accessing `QtGUI.palettle` colors, it would return unset colors, which would "gracefully" fail by defaulting to black. It seems that correcting the behavior of `-asHSV` made these calls break...ungracefully.

The problem is seen by running 
```supercollider
7.collect({ 15.collect({ rrand(0,1.0) }) }).plot.superpose_(true)
```
The proposed defaults access `QtGUI.palette.highlight`, which returns a valid color, whereas `QtGUI.palette.windowText`, used before, didn't.

I've also reduced the default `plotColor` down to one color. Four colors was a rather random number of colors to default to, and in any case the user can set them explicitly in `Plot` (more easily through `Plotter` in a pending PR merge — #4459).

## Types of changes

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
~~- [ ] Updated documentation~~
- [x] This PR is ready for review
