### PR TITLE
JITLib: fix a duplicate node ID error in NodeProxy:xset

### DIFF
--- a/SCClassLibrary/JITLib/ProxySpace/ProxyInterfaces.sc
+++ b/SCClassLibrary/JITLib/ProxySpace/ProxyInterfaces.sc
@@ -253,11 +253,17 @@ SynthControl : AbstractPlayControl {
 				// otherwise it is self freeing by some inner mechanism.
 			};
 			nodeID = nil;
-		}
+			this.cancelPrevBundle;
+		};
+	}
+
+	cancelPrevBundle {
+		prevBundle !? { prevBundle.cancel };
+		prevBundle = nil;
 	}
 
 	freeToBundle {
-		prevBundle !? { prevBundle.cancel };
+		this.cancelPrevBundle
 	}
 
 	set { | ... args |
@@ -371,7 +377,7 @@ SynthDefControl : SynthControl {
 		if(synthDef.notNil) { bundle.addPrepare([53, synthDef.name]) }; // "/d_free"
 		parents.do { |x| x.removeChild(proxy) };
 		bytes = parents = nil;
-		prevBundle !? { prevBundle.cancel };
+		this.cancelPrevBundle;
 	}
 
 	writeSynthDefFile { | path, bytes |

--- a/SCClassLibrary/JITLib/ProxySpace/ProxyInterfaces.sc
+++ b/SCClassLibrary/JITLib/ProxySpace/ProxyInterfaces.sc
@@ -253,17 +253,12 @@ SynthControl : AbstractPlayControl {
 				// otherwise it is self freeing by some inner mechanism.
 			};
 			nodeID = nil;
-			this.cancelPrevBundle;
+			this.prCancelPrevBundle;
 		};
 	}
 
-	cancelPrevBundle {
-		prevBundle !? { prevBundle.cancel };
-		prevBundle = nil;
-	}
-
 	freeToBundle {
-		this.cancelPrevBundle
+		this.prCancelPrevBundle
 	}
 
 	set { | ... args |
@@ -307,6 +302,13 @@ SynthControl : AbstractPlayControl {
 		server = control.server;
 		canReleaseSynth = control.canReleaseSynth;
 		canFreeSynth = control.canFreeSynth;
+	}
+
+	// private
+
+	prCancelPrevBundle {
+		prevBundle !? { prevBundle.cancel };
+		prevBundle = nil;
 	}
 
 }
@@ -377,7 +379,7 @@ SynthDefControl : SynthControl {
 		if(synthDef.notNil) { bundle.addPrepare([53, synthDef.name]) }; // "/d_free"
 		parents.do { |x| x.removeChild(proxy) };
 		bytes = parents = nil;
-		this.cancelPrevBundle;
+		this.prCancelPrevBundle;
 	}
 
 	writeSynthDefFile { | path, bytes |

--- a/testsuite/classlibrary/TestNodeProxy_Server.sc
+++ b/testsuite/classlibrary/TestNodeProxy_Server.sc
@@ -153,4 +153,12 @@ TestNodeProxy_Server : UnitTest {
 		this.assertEquals(result, proxy.source, "After the crossfade from a ugen function to a value, the bus should have the correct value");
 	}
 
+	test_stop_object_should_cancel_old_bundle {
+		var container;
+		proxy.source = { Silent.ar };
+		container = proxy.objects.first;
+		proxy.free;
+		this.assert(container.instVarAt(\prevBundle).isNil, "Pending OSC message should be canceled when proxy synth is freed");
+	}
+
 }

--- a/testsuite/classlibrary/TestNodeProxy_Server.sc
+++ b/testsuite/classlibrary/TestNodeProxy_Server.sc
@@ -11,6 +11,7 @@ TestNodeProxy_Server : UnitTest {
 
 	tearDown {
 		proxy.clear;
+		server.sync;
 		server.quit;
 		server.remove;
 	}


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

Fixes  #4506

```supercollider
// test, shouldn't post " FAILURE IN SERVER /s_new duplicate node ID "
Ndef(\y, { |zz| Blip.ar(zz * 5) }).xset(\zz, 2).play;
Ndef(\y, { |zz| Blip.ar(zz * 5) }).xset(\zz, 4).play;
```

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix


## To-do list

- [x] Code is tested
- [x] All tests are passing
- [x] This PR is ready for review
