### PR TITLE
scdoc: remove reference to UnitTesting in the Quarks guide

### DIFF
--- a/HelpSource/Guides/UsingQuarks.schelp
+++ b/HelpSource/Guides/UsingQuarks.schelp
@@ -31,16 +31,16 @@ subsection::by name
 You can (un)install a Quark by name:
 
 code::
-Quarks.install("UnitTesting");
-Quarks.uninstall("UnitTesting");
+Quarks.install("MathLib");
+Quarks.uninstall("MathLib");
 ::
 
 subsection::by git URL
 
 code::
-Quarks.install("https://github.com/supercollider-quarks/UnitTesting.git");
+Quarks.install("https://github.com/supercollider-quarks/MathLib.git");
 // uninstall it
-Quarks.uninstall("https://github.com/supercollider-quarks/UnitTesting.git");
+Quarks.uninstall("https://github.com/supercollider-quarks/MathLib.git");
 ::
 
 subsection::from a local folder


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

`UnitTesting` quark won't install in SC version >3.9+. It would be beneficial to provide examples of a working quark in the help files.

I have chosen `MathLib` since it's fairly generic and doesn't seem to be abandoned. However, if you feel that another quark would be a better candidate for an example in the help file, I'd be happy to update this PR.

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->

- Documentation

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Updated documentation
- [x] This PR is ready for review
