### PR TITLE
fix closing TCP connections in sclang on recompile

### DIFF
--- a/HelpSource/Classes/NetAddr.schelp
+++ b/HelpSource/Classes/NetAddr.schelp
@@ -40,6 +40,10 @@ A link::Classes/String:: to test containing an IP number in dot decimal notation
 
 returns::A link::Classes/Boolean:: indicating whether a match was found.
 
+method::connections
+
+returns::A copy of the link::Classes/IdentityDictionary:: with all open TCP connections.
+
 InstanceMethods::
 
 private::prConnect, prDisconnect, prConnectionClosed, recover

--- a/SCClassLibrary/Common/Control/NetAddr.sc
+++ b/SCClassLibrary/Common/Control/NetAddr.sc
@@ -140,7 +140,7 @@ NetAddr {
 	connect { | disconnectHandler |
 		if (this.isConnected.not) {
 			this.prConnect;
-			connections.put(this, disconnectHandler);
+			connections.put(this, disconnectHandler ? {});
 		}
 	}
 

--- a/SCClassLibrary/Common/Control/NetAddr.sc
+++ b/SCClassLibrary/Common/Control/NetAddr.sc
@@ -56,6 +56,10 @@ NetAddr {
 			}
 		}
 	}
+	
+	*connections {
+		^connections.copy;
+	}
 
 	hostname_ { arg inHostname;
 		hostname = inHostname;


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->
Fixes #4482 
 
It turns out that we were [failing to store a list of TCP connections](https://github.com/supercollider/supercollider/blob/develop/SCClassLibrary/Common/Control/NetAddr.sc#L143) when the `disconnectHandler` was `nil`, which prevented the connection from being added to the `IdentityDictionary`.

My fix replaces `nil` for the `disconnectHandler` with an empty function `{}`. I'm not sure if there's a better object to use here and I'm open to suggestions.

In the process of debugging this, I temporarily exposed `NetAddr *connections`. ~~I think it would be beneficial to keep it available, so I added a getter to it (as well as an entry in the docs) in a separate commit. It this is not desirable here, I'm happy to take this out. On one hand, it would be useful to have this information, but on the other, the user should not make changes to this dictionary...~~ I kept this class method and added documentation, but modified it to return a copy of the original dictionary, so the original can't be modified.

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix
- Documentation


## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
~~- [ ] All tests are passing~~ there are no tests for this...
- [x] Updated documentation
- [x] This PR is ready for review
