### PR TITLE
Serveroptions/add ip option

### DIFF
--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -53,6 +53,7 @@ ServerOptions {
 	var <>recSampleFormat;
 	var <>recChannels;
 	var <>recBufSize;
+	var <>bindTo;
 
 	*initClass {
 		defaultValues = IdentityDictionary.newFrom(
@@ -95,6 +96,7 @@ ServerOptions {
 				recSampleFormat: "float",
 				recChannels: 2,
 				recBufSize: nil,
+				bindTo: "127.0.0.1",
 			)
 		)
 	}
@@ -124,6 +126,8 @@ ServerOptions {
 		o = if(protocol == \tcp, " -t ", " -u ");
 		o = o ++ port;
 
+		o = o ++ " -B " ++ bindTo;
+		
 		o = o ++ " -a " ++ (numPrivateAudioBusChannels + numInputBusChannels + numOutputBusChannels) ;
 		o = o ++ " -i " ++ numInputBusChannels;
 		o = o ++ " -o " ++ numOutputBusChannels;


### PR DESCRIPTION
## Purpose and Motivation

Fixes #4497 
ServerOptions should expose scsynth's -B option

## Types of changes

- Bug fix

Added bindTo instance variable to ServerOptions as suggested in #4497 .
Added corresponding line in ServerOptions::asOptionsString to
include this option in the scsynth command string.

## To-do list

- [x] Code is tested
- [ ] Updated documentation
- [x] This PR is ready for review

## Testing

Confirmed that the scsynth command string is built and used as intended, by
running ```ps -ef | grep scsynth``` and getting this result: 

```
18980 17459  1 10:36 ?        00:00:32 scsynth -u 57110 -B 127.0.0.1 -a 1024 -i 2 -o 2 -R 0 -l 1
```
 

