### PR TITLE
add Platform.architecture

### DIFF
--- a/HelpSource/Classes/Platform.schelp
+++ b/HelpSource/Classes/Platform.schelp
@@ -80,6 +80,11 @@ true if the Qt library is available, false otherwise
 method:: hasQtWebEngine
 true if the QtWebEngine library is available, false otherwise
 
+method:: architecture
+A link::Symbol:: naming the architecture for which this version of SuperCollider was built.
+Returns one of 'AArch32' (32-bit ARM), 'AArch64' (64-bit ARM, introduced in ARMv8), 'Itanium64', 'i386', 'x86_64',
+'PowerPC', or 'unknown' if the architecture is unidentifiable.
+
 subsection:: Features
 
 method:: when

--- a/SCClassLibrary/Platform/Platform.sc
+++ b/SCClassLibrary/Platform/Platform.sc
@@ -173,6 +173,12 @@ Platform {
 		^this.primitiveFailed
 	}
 
+	// Architecture for which this version of SuperCollider was built.
+	*architecture {
+		_Platform_architecture
+		^this.primitiveFailed
+	}
+
 	isSleeping { ^false } // unless defined otherwise
 
 	// used on systems to deduce a svn directory path, if system wide location is used for installed version. (tested on Linux).

--- a/lang/LangPrimSource/PyrPlatformPrim.cpp
+++ b/lang/LangPrimSource/PyrPlatformPrim.cpp
@@ -28,12 +28,14 @@ Primitives for platform dependent directories, constants etc.
 #include "SC_LanguageConfig.hpp" // getIdeName
 #include "PyrPrimitive.h"
 #include "PyrKernel.h"
+#include "SCBase.h" // getsym
 #ifdef _WIN32
 #    include "SC_Win32Utils.h"
 #    include "Shlobj.h"
 #endif
 
 #include <boost/filesystem/path.hpp> // path
+#include <boost/predef/architecture.h>
 
 namespace bfs = boost::filesystem;
 using DirName = SC_Filesystem::DirName;
@@ -107,6 +109,27 @@ int prPlatform_hasQtWebEngine(struct VMGlobals* g, int numArgsPushed) {
     return errNone;
 }
 
+int prPlatform_architecture(struct VMGlobals* g, int numArgsPushed) {
+    // See discussion at https://github.com/supercollider/supercollider/pull/4524
+#if defined(BOOST_ARCH_ARM) && defined(__aarch64__)
+    SetSymbol(g->sp, getsym("AArch64"));
+#elif BOOST_ARCH_ARM
+    SetSymbol(g->sp, getsym("AArch32"));
+#elif BOOST_ARCH_IA64
+    SetSymbol(g->sp, getsym("Itanium64"));
+#elif BOOST_ARCH_X86_32
+    SetSymbol(g->sp, getsym("i386"));
+#elif BOOST_ARCH_X86_64
+    SetSymbol(g->sp, getsym("x86_64"));
+#elif BOOST_ARCH_PPC
+    SetSymbol(g->sp, getsym("PowerPC"));
+#else
+#    warning "Unknown platform architecture: please submit a pull request to add yours!"
+    SetSymbol(g->sp, getsym("unknown"));
+#endif
+    return errNone;
+}
+
 void initPlatformPrimitives();
 void initPlatformPrimitives() {
     int base, index = 0;
@@ -123,6 +146,7 @@ void initPlatformPrimitives() {
     definePrimitive(base, index++, "_Platform_ideName", prPlatform_ideName, 1, 0);
     definePrimitive(base, index++, "_Platform_hasQt", prPlatform_hasQt, 1, 0);
     definePrimitive(base, index++, "_Platform_hasQtWebEngine", prPlatform_hasQtWebEngine, 1, 0);
+    definePrimitive(base, index++, "_Platform_architecture", prPlatform_architecture, 1, 0);
 #ifdef _WIN32
     definePrimitive(base, index++, "_WinPlatform_myDocumentsDir", prWinPlatform_myDocumentsDir, 1, 0);
 #endif


### PR DESCRIPTION
allows programmatically getting the platform architecture as a symbol

<!--- Hi, and thanks for contributing! -->
<!--- Make sure to provide a general summary of your changes in the title above. -->
<!--- For example: "[scsynth] Fix crash when encountering cute kittens" -->

Purpose and Motivation
----------------------

motivated by https://scsynth.org/t/how-do-i-tell-from-sclang-if-the-win-environment-is-32-bit-or-64-bit/1168

see for similar implementation https://docs.python.org/2/library/platform.html#platform.machine

Types of changes
----------------

- Documentation (non-code change which corrects or adds documentation for existing features)
- New feature (non-breaking change which adds functionality)

Checklist
---------

- [x] All tests are passing
- [x] If necessary, new tests were created to address changes in PR, and tests are passing
- [x] Updated documentation, if necessary
- [x] This PR is ready for review