### PR TITLE
[WIP] Calculate Duty first sample output

### DIFF
--- a/server/plugins/DemandUGens.cpp
+++ b/server/plugins/DemandUGens.cpp
@@ -589,6 +589,8 @@ void Duty_Ctor(Duty* unit) {
     unit->m_count = DEMANDINPUT(duty_dur) * SAMPLERATE;
     unit->m_prevout = DEMANDINPUT(duty_level);
     OUT0(0) = unit->m_prevout;
+    // calculate one sample of output.
+    unit->mCalcFunc(unit, 1);
 }
 
 

--- a/testsuite/classlibrary/TestCoreUGens.sc
+++ b/testsuite/classlibrary/TestCoreUGens.sc
@@ -16,6 +16,20 @@ TestCoreUGens : UnitTest {
 		server.remove;
 	}
 
+	test_duty_first_sample {
+		var func;
+		var testComplete = false;
+
+		func = { var n = EnvGen.ar(Env.new([0.66, 0.8, -0.4, 0],[0, SampleDur.ir, SampleDur.ir])); (n - Duty.ar(SampleDur.ir, 0, n)) };
+
+		server.bootSync;
+		func.loadToFloatArray(server.sampleRate.reciprocal * 2, server, { |data|
+			this.assertArrayFloatEquals(data, 0, "Duty first sample should be properly initialized", within: 0.0, report: true);
+			testComplete = true;
+		});
+		this.wait{testComplete == true};
+	}
+
 	test_ugen_generator_equivalences {
 		var n, v;
 


### PR DESCRIPTION
## Purpose and Motivation

When running `UnitTest.runAll` I got the following failed tests

```
FAIL: a TestCoreUGens: test_ugen_generator_equivalences - "Duty.ar(SampleDur.ir, 0, x) == x"
1 of 44100 items in array failed to match. Displaying arrays from index of first failure (0) onwards:
FloatArray[ -0.61635398864746, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0...etc...

FAIL: a TestCoreUGens: test_ugen_generator_equivalences - "Duty.ar(SampleDur.ir, 0, Drand([x],inf)) == x"
1 of 44100 items in array failed to match. Displaying arrays from index of first failure (0) onwards:
FloatArray[ 1.3432414531708, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0...etc...
```

I wanted to fix that first sample output problem.

## Types of changes

Bug fix.
I added a specific test for comparing the first samples with a known input.

This PR fixes the two aforementioned bugs, but breaks TestUGen_Duty

```
a TestUGen_Duty: test_ar_1_frame - Duty should output exact values at audio rate. Tested with 1 frames per value
5 of 6 items in array failed to match. Displaying arrays from index of first failure (0) onwards:
FloatArray[ 0.15000000596046, 1.1000000238419, 0.25, 2.0, 0.5, 0.5 ]
! = 
[ 1, 0.15, 1.1, 0.25, 2, 0.5 ]

a TestUGen_Duty: test_ar_16_frames - Duty should output exact values at audio rate. Tested with 16 frames per value
5 of 96 items in array failed to match. Displaying arrays from index of first failure (15) onwards:
FloatArray[ 0.15000000596046, 0.15000000596046, 0.15000000596046, 0.15000000596046, 0.15000000596046, 0.15000000596046, 0.15000000596046, 0.15000000596046, 0.15000000596046, 0.15000000596046, 0.15000000596046, 0.15000000596046, 0.15000000596046, 0.15000000596046, 0.15000000596046, 0.15000000596046, 1.1000000238419, 1.1000000238419, 1.1000000238419, 1.1000000238419, 1.1000000238419, 1.1000000238419, 1.1000000238419, 1.1000000238419, 1.1000000238419, 1.1000000238419, 1.1000000238419, 1.1000000238419, 1.100000...etc...
! = 
[ 1, 0.15, 0.15, 0.15, 0.15, 0.15, 0.15, 0.15, 0.15, 0.15, 0.15, 0.15, 0.15, 0.15, 0.15, 0.15, 0.15, 1.1, 1.1, 1.1, 1.1, 1.1, 1.1, 1.1, 1.1, 1.1, 1.1, 1.1, 1.1, 1.1, 1.1, 1.1, 1.1, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5 ]

a TestUGen_Duty: test_ar_256_frames - Duty should output exact values at audio rate. Tested with 256 frames per value
5 of 1536 items in array failed to match. Displaying arrays from index of first failure (255) onwards:
FloatArray[ 0.15000000596046, 0.15000000596046, 0.15000000596046, 0.15000000596046, 0.15000000596046, 0.15000000596046, 0.15000000596046, 0.15000000596046, 0.15000000596046, 0.15000000596046, 0.15000000596046, 0.15000000596046, 0.15000000596046, 0.15000000596046, 0.15000000596046, 0.15000000596046, 0.15000000596046, 0.15000000596046, 0.15000000596046, 0.15000000596046, 0.15000000596046, 0.15000000596046, 0.15000000596046, 0.15000000596046, 0.15000000596046, 0.15000000596046, 0.15000000596046, 0.150000005960...etc...
! = 
[ 1, 0.15, 0.15, 0.15, 0.15, 0.15, 0.15, 0.15, 0.15, 0.15, 0.15, 0.15, 0.15, 0.15, 0.15, 0.15, 0.15, 0.15, 0.15, 0.15, 0.15, 0.15, 0.15, 0.15, 0.15, 0.15, 0.15, 0.15, 0.15, 0.15, 0.15, 0.15, 0.15, 0.15, 0.15, 0.15, 0.15, 0.15, 0.15, 0.15, 0.15, 0.15, 0.15, 0.15, 0.15, 0.1a TestUGen_Duty: test_ar_1_frame_audiorate_reset - Duty should output exact values at audio rate. Tested with 1 frames per value
5 of 6 items in array failed to match. Displaying arrays from index of first failure (0) onwards:
FloatArray[ 0.15000000596046, 1.1000000238419, 0.25, 2.0, 0.5, 0.5 ]
! = 
[ 1, 0.15, 1.1, 0.25, 2, 0.5 ]

a TestUGen_Duty: test_ar_1_frame_demandrate_reset - Duty should output exact values at audio rate. Tested with 1 frames per value
5 of 6 items in array failed to match. Displaying arrays from index of first failure (0) onwards:
FloatArray[ 0.15000000596046, 1.1000000238419, 0.25, 2.0, 0.5, 0.5 ]
! = 
[ 1, 0.15, 1.1, 0.25, 2, 0.5 ]

```

so it's obviously not ready to merge...

## To-do list

- [X] Code is tested
- [ ] All tests are passing
- [ ] Updated documentation
- [ ] This PR is ready for review
