### PR TITLE
On macOS, register cmd+q on sclang interpreter main menu, solves #3824

### DIFF
--- a/QtCollider/QcApplication.cpp
+++ b/QtCollider/QcApplication.cpp
@@ -123,8 +123,8 @@ void QcApplication::createMenu() {
 }
 
 void QcApplication::onQuit() {
-    printf("[QcApplication::onQuit] CMD+Q was caught on the interpreter. This is weird, it should not happen. \
-    Please fill an issue on https://github.com/supercollider/supercollider/issues");
+    printf("[QcApplication::onQuit] CMD+Q was caught by the interpreter. This is weird, it should not happen. \
+    Please file an issue at https://github.com/supercollider/supercollider/issues");
 }
 
 bool QcApplication::compareThread() { return gMainVMGlobals->canCallOS; }

--- a/QtCollider/QcApplication.cpp
+++ b/QtCollider/QcApplication.cpp
@@ -105,26 +105,25 @@ QcApplication::~QcApplication() {
 }
 
 void QcApplication::createMenu() {
-    _mainMenu = QSharedPointer<QMenuBar>(new QMenuBar(0));
+    _mainMenu = QSharedPointer<QMenuBar>::create();
 
 #ifdef Q_OS_MAC
     // macOS registers cmd+q on menu bars by default. Here we register a handler for cmd+q that does nothing
     // and we disable the Quit menu by default
-    QMenu* menu;
-    QAction* action;
-    action = new QAction(tr("Catch CMD+Q on MacOS X"));
+    auto* action = new QAction("");
     action->setMenuRole(QAction::QuitRole);
+    action->setEnabled(false);
     QObject::connect(action, SIGNAL(triggered()), this, SLOT(onQuit()));
-    menu = new QMenu(tr("&File"));
+    auto* menu = new QMenu(tr("&File"));
     menu->addAction(action);
     _mainMenu->addMenu(menu);
-    action->setEnabled(false);
 #endif
 }
 
 void QcApplication::onQuit() {
-    printf("[QcApplication::onQuit] CMD+Q was caught by the interpreter. This is weird, it should not happen. \
-    Please file an issue at https://github.com/supercollider/supercollider/issues");
+    qWarning("[QcApplication::onQuit] CMD+Q was caught by the interpreter. "
+    "This is weird, it should not happen. "
+    "Please file an issue at https://github.com/supercollider/supercollider/issues");
 }
 
 bool QcApplication::compareThread() { return gMainVMGlobals->canCallOS; }

--- a/QtCollider/QcApplication.cpp
+++ b/QtCollider/QcApplication.cpp
@@ -87,7 +87,7 @@ QcApplication::QcApplication(int& argc, char** argv): QApplication(argc, argv, Q
         icon.addFile(":/icons/sc-cube-32");
         icon.addFile(":/icons/sc-cube-16");
         setWindowIcon(icon);
-        _mainMenu = QSharedPointer<QMenuBar>(new QMenuBar(0));
+        createMenu();
     }
 
 #ifdef Q_OS_MAC
@@ -102,6 +102,29 @@ QcApplication::~QcApplication() {
     _mutex.lock();
     _instance = 0;
     _mutex.unlock();
+}
+
+void QcApplication::createMenu() {
+    _mainMenu = QSharedPointer<QMenuBar>(new QMenuBar(0));
+
+#ifdef Q_OS_MAC
+    // macOS registers cmd+q on menu bars by default. Here we register a handler for cmd+q that does nothing
+    // and we disable the Quit menu by default
+    QMenu* menu;
+    QAction* action;
+    action = new QAction(tr("Catch CMD+Q on MacOS X"));
+    action->setMenuRole(QAction::QuitRole);
+    QObject::connect(action, SIGNAL(triggered()), this, SLOT(onQuit()));
+    menu = new QMenu(tr("&File"));
+    menu->addAction(action);
+    _mainMenu->addMenu(menu);
+    action->setEnabled(false);
+#endif
+}
+
+void QcApplication::onQuit() {
+    printf("[QcApplication::onQuit] CMD+Q was caught on the interpreter. This is weird, it should not happen. \
+    Please fill an issue on https://github.com/supercollider/supercollider/issues");
 }
 
 bool QcApplication::compareThread() { return gMainVMGlobals->canCallOS; }

--- a/QtCollider/QcApplication.cpp
+++ b/QtCollider/QcApplication.cpp
@@ -122,8 +122,8 @@ void QcApplication::createMenu() {
 
 void QcApplication::onQuit() {
     qWarning("[QcApplication::onQuit] CMD+Q was caught by the interpreter. "
-    "This is weird, it should not happen. "
-    "Please file an issue at https://github.com/supercollider/supercollider/issues");
+             "This is weird, it should not happen. "
+             "Please file an issue at https://github.com/supercollider/supercollider/issues");
 }
 
 bool QcApplication::compareThread() { return gMainVMGlobals->canCallOS; }

--- a/QtCollider/QcApplication.h
+++ b/QtCollider/QcApplication.h
@@ -60,6 +60,7 @@ public:
 
 public Q_SLOTS:
     void interpret(const QString& code, bool printResult = true);
+    void onQuit();
 
 protected:
     virtual bool event(QEvent*);
@@ -67,6 +68,7 @@ protected:
 
 private:
     QSharedPointer<QMenuBar> _mainMenu;
+    void createMenu();
 
     QtCollider::EventProcessor _eventProc;
 


### PR DESCRIPTION
## Purpose and Motivation

Fixes #3824 

Like in PR #4500 the fix consists in adding an `Action` with `QAction::QuitRole` so that this action registers cmd+q on macOS.
I disable this menu action so that Quit menu item is greyed out in the interpreter window.

MainMenu is not affected, it still works, I checked.

## Types of changes

- Bug fix

## To-do list

- [ ] Code is tested
- [ ] All tests are passing
- [ ] Updated documentation
- [X] This PR is ready for review
