### PR TITLE
 Work around build errors on musl libc

### DIFF
--- a/common/SC_Filesystem_unix.cpp
+++ b/common/SC_Filesystem_unix.cpp
@@ -33,9 +33,9 @@
 #    include <glob.h> // ::glob, glob_t
 
 // workaround for musl not yet supporting GLOB_TILDE
-#ifndef GLOB_TILDE
-#    define GLOB_TILDE 0
-#endif
+#    ifndef GLOB_TILDE
+#        define GLOB_TILDE 0
+#    endif
 
 using Path = SC_Filesystem::Path;
 using DirName = SC_Filesystem::DirName;

--- a/common/SC_Filesystem_unix.cpp
+++ b/common/SC_Filesystem_unix.cpp
@@ -32,6 +32,11 @@
 // system
 #    include <glob.h> // ::glob, glob_t
 
+// workaround for musl not yet supporting GLOB_TILDE
+#ifndef GLOB_TILDE
+#    define GLOB_TILDE 0
+#endif
+
 using Path = SC_Filesystem::Path;
 using DirName = SC_Filesystem::DirName;
 using DirMap = SC_Filesystem::DirMap;

--- a/common/SC_StringBuffer.cpp
+++ b/common/SC_StringBuffer.cpp
@@ -61,11 +61,7 @@ void SC_StringBuffer::vappendf(const char* fmt, va_list ap) {
     size_t remaining = getRemaining();
 
     // Calling vsnprintf may invalidate vargs, so keep a copy
-#ifdef __va_copy
-    __va_copy(ap2, ap);
-#else
-    ap2 = ap;
-#endif
+    va_copy(ap2, ap);
 
     // NOTE: This only works since glibc 2.0.6!
     int size = vsnprintf(mPtr, remaining, fmt, ap);

--- a/common/sc_popen.cpp
+++ b/common/sc_popen.cpp
@@ -13,7 +13,6 @@
     (maintaining a global linked list of fds to pids and locking
     it is no longer necessary). */
 
-#    include <sys/cdefs.h>
 #    include <sys/param.h>
 #    include <sys/wait.h>
 #    include <signal.h>


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

This continues on from and replaces #4391.

> Currently musl does not support GLOB_TILDE but it is on their roadmap [1]. This
> patch is no fix and changes functionality for musl. A slightly changed
> functionality seems better than being unable to build.
> 
> For glibc and future versions of musl this change is a noop.
> 
> [1] [https://wiki.musl-libc.org/roadmap.html](https://wiki.musl-libc.org/roadmap.html)

Tests 10 (server_test_run) and 16 (perf_counter_test_run) from `make test` fail on my machine but they also fail without these changes.

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix
- New feature

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [ ] All tests are passing
- [ ] Updated documentation
- [x] This PR is ready for review
