### PR TITLE
fix #3807 FileDialog hangup in KDE

### DIFF
--- a/QtCollider/LanguageClient.cpp
+++ b/QtCollider/LanguageClient.cpp
@@ -83,10 +83,13 @@ void LangClient::customEvent(QEvent* e) {
 }
 
 void LangClient::tick() {
-    double secs;
-    lock();
-    bool haveNext = tickLocked(&secs);
-    unlock();
+    double secs = 0.0;
+    bool haveNext = false;
+
+    if (trylock()) {
+        haveNext = tickLocked(&secs);
+        unlock();
+    }
 
     flush();
 

--- a/QtCollider/LanguageClient.cpp
+++ b/QtCollider/LanguageClient.cpp
@@ -89,18 +89,18 @@ void LangClient::tick() {
     if (trylock()) {
         haveNext = tickLocked(&secs);
         unlock();
+
+        flush();
+
+        if (haveNext) {
+            secs -= elapsedTime();
+            secs *= 1000;
+            int ti = qMax(0, qCeil(secs));
+            qcDebugMsg(2, QStringLiteral("next at %1").arg(ti));
+            appClockTimer.start(ti, this);
+        } else
+            appClockTimer.stop();
     }
-
-    flush();
-
-    if (haveNext) {
-        secs -= elapsedTime();
-        secs *= 1000;
-        int ti = qMax(0, qCeil(secs));
-        qcDebugMsg(2, QStringLiteral("next at %1").arg(ti));
-        appClockTimer.start(ti, this);
-    } else
-        appClockTimer.stop();
 }
 
 void LangClient::timerEvent(QTimerEvent* e) {


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

fixes #3807 FileDialog hangup in KDE

Occasional deadlock was observed when opening a FileDialog and while I do not really understand the control flow, the following objects/methods appeared to be involved:

TempoClock::Run was waiting on a condition variable parameterized by gLangMutex (in multiple threads, apparently), and at the same time LangClient::tick was locking this same gLangMutex

Before the fix, I can reproduce the hangup in at most 40x opening/closing a FileDialog (often mucb less). After the fix, I can open/close it 200+ times without hangup.

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [ x] Code is tested
- [ ] All tests are passing 
**(NOTE: not all tests pass, but to the best of my understanding those that don't pass are not related to my change)**
- [ ] Updated documentation
- [ x] Sleepless nights
- [ x] This PR is ready for review 
(I think so, no idea how to unit test this, as it's a multi-threading/timing type of bug)
