### PR TITLE
Classlib: Correct grammar in a Dictionary warning [skip ci]

### DIFF
--- a/SCClassLibrary/Common/Collections/Dictionary.sc
+++ b/SCClassLibrary/Common/Collections/Dictionary.sc
@@ -546,7 +546,7 @@ IdentityDictionary : Dictionary {
 				selector = selector.asGetter;
 				if(this.respondsTo(selector)) {
 					warn(selector.asCompileString
-						+ "exists a method name, so you can't use it as pseudo-method.")
+						+ "exists as a method name, so you can't use it as a pseudo-method.")
 				};
 				^this[selector] = args[0];
 			};


### PR DESCRIPTION
## Purpose and Motivation

The `doesNotUnderstand` warning in Dictionary about pre-existing methods contained two grammatical errors:

- At the beginning, `as a` omitted the preposition.
- At the end, `as a` omitted the indefinite article.

No other changes -- just make the warning not sound awkward.

## Types of changes

- Bug fix

## To-do list

- [x] This PR is ready for review
