### PR TITLE
travis: use latest packages on osx

### DIFF
--- a/.travis/before-install-osx.sh
+++ b/.travis/before-install-osx.sh
@@ -1,6 +1,5 @@
 #!/bin/sh
 
-export HOMEBREW_NO_AUTO_UPDATE=1
 export HOMEBREW_NO_ANALYTICS=1
 
 # according to https://docs.travis-ci.com/user/caching#ccache-cache


### PR DESCRIPTION
##  Purpose and Motivation

Mea culpa -- I had formerly added this to avoid a really long wait time while homebrew updated on macOS Travis builds, but as pointed out by Christophe and present-day me, we probably want to use the latest version to get any bugfixes. Note however that homebrew auto-update does take a really long time, something like 5 minutes. Would love any info on how to avoid that, since we only ever need these few formulas.

Open to discussion -- it is not a great look to upgrade a major dependency like this between release candidates, but Qt has seemed pretty stable so I'm fine doing this.

## Types of changes

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested - i use 5.13 when i build locally, works fine for me
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review
