### PR TITLE
help browser: ignore certain tokens when matching parens

### DIFF
--- a/HelpSource/editor.js
+++ b/HelpSource/editor.js
@@ -80,10 +80,14 @@ const selectRegion = (options = { flash: true }) => {
 
     const findLeftParen = cursor => {
         let cursorLeft = editor.findPosH(cursor, -1, 'char')
+        let token = editor.getTokenTypeAt(cursor) || ''
         if (cursorLeft.hitSide)
             return cursorLeft
         let ch = editor.getLine(cursorLeft.line)
             .slice(cursorLeft.ch, cursorLeft.ch+1)
+        if (token.startsWith('comment') || token.startsWith('string') ||
+            token.startsWith('symbol') || token.startsWith('char'))
+            return findLeftParen(cursorLeft)
         if (ch === ')')
             return findLeftParen(findLeftParen(cursorLeft))
         if (ch === '(')
@@ -93,10 +97,14 @@ const selectRegion = (options = { flash: true }) => {
 
     const findRightParen = cursor => {
         let cursorRight = editor.findPosH(cursor, 1, 'char')
+        let token = editor.getTokenTypeAt(cursor) || ''
         if (cursorRight.hitSide)
             return cursorRight
         let ch = editor.getLine(cursorRight.line)
             .slice(cursorRight.ch-1, cursorRight.ch)
+        if (token.startsWith('comment') || token.startsWith('string') ||
+            token.startsWith('symbol') || token.startsWith('char'))
+            return findRightParen(cursorRight)
         if (ch === '(')
             return findRightParen(findRightParen(cursorRight))
         if (ch === ')')

--- a/HelpSource/editor.js
+++ b/HelpSource/editor.js
@@ -85,8 +85,7 @@ const selectRegion = (options = { flash: true }) => {
             return cursorLeft
         let ch = editor.getLine(cursorLeft.line)
             .slice(cursorLeft.ch, cursorLeft.ch+1)
-        if (token.startsWith('comment') || token.startsWith('string') ||
-            token.startsWith('symbol') || token.startsWith('char'))
+        if (token.match(/^(comment|string|symbol|char)/))
             return findLeftParen(cursorLeft)
         if (ch === ')')
             return findLeftParen(findLeftParen(cursorLeft))
@@ -102,8 +101,7 @@ const selectRegion = (options = { flash: true }) => {
             return cursorRight
         let ch = editor.getLine(cursorRight.line)
             .slice(cursorRight.ch-1, cursorRight.ch)
-        if (token.startsWith('comment') || token.startsWith('string') ||
-            token.startsWith('symbol') || token.startsWith('char'))
+        if (token.match(/^(comment|string|symbol|char)/))
             return findRightParen(cursorRight)
         if (ch === '(')
             return findRightParen(findRightParen(cursorRight))


### PR DESCRIPTION
## Purpose and Motivation

fixes: #4536. also, strings, symbols and chars containing `(` or `)` will now be correctly ignored by the paren matcher. 

side note: i really wish that it was possible to hook into the sc-ide 's code parser/evaluator instead of duplicating the logic just for the help browser. maybe possible with that webchannel/socket thingy?

## Types of changes

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review
