### PR TITLE
Fix extension in path generated by Recorder

### DIFF
--- a/SCClassLibrary/Common/Control/Recorder.sc
+++ b/SCClassLibrary/Common/Control/Recorder.sc
@@ -173,7 +173,7 @@ Recorder {
 		var timestamp;
 		var dir = thisProcess.platform.recordingsDir;
 		timestamp = Date.localtime.stamp;
-		^dir +/+ filePrefix ++ timestamp ++ "." ++ server.recHeaderFormat;
+		^dir +/+ filePrefix ++ timestamp ++ "." ++ recHeaderFormat;
 	}
 
 	changedServer { | what ... moreArgs |

--- a/testsuite/classlibrary/TestRecorder.sc
+++ b/testsuite/classlibrary/TestRecorder.sc
@@ -1,0 +1,11 @@
+TestRecorder : UnitTest {
+
+	test_recorder_makePath_extension {
+		var ext, server = Server();
+		server.options.recHeaderFormat = "aiff";
+		server.recorder.recHeaderFormat = "wav";
+		ext = server.recorder.makePath.splitext[1];
+		this.assertEquals("wav", ext)
+	}
+
+}


### PR DESCRIPTION
## Purpose and Motivation

Before this fix, recorded file paths would always have extensions according to `s.options.recHeaderFormat`, even if recHeaderFormat of `s.recorder` was different, possibly creating files with wrong extension.

Use Recorder's own `recHeaderFormat` variable when generating the path, which should make sure header format and extension is in sync.

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [ ] Updated documentation
- [x] This PR is ready for review
