### PR TITLE
Fix a typo in description of Pbindf help file

### DIFF
--- a/HelpSource/Classes/Pbindf.schelp
+++ b/HelpSource/Classes/Pbindf.schelp
@@ -1,5 +1,5 @@
 class:: Pbindf
-summary:: bind several value patterns to one existing event stream by binding keys to valueskeys to values
+summary:: bind several value patterns to one existing event stream by binding keys to values
 related:: Classes/Pattern, Classes/Event, Classes/Pbind, Classes/Pchain
 categories:: Streams-Patterns-Events>Patterns>Composition
 


### PR DESCRIPTION
was: "keys to valueskeys to values"

<!-- Please see CONTRIBUTING.md for guidelines. -->



<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->

- Documentation

