### PR TITLE
scide: Fix dropped file path on Windows

### DIFF
--- a/editors/sc-ide/widgets/code_editor/sc_editor.cpp
+++ b/editors/sc-ide/widgets/code_editor/sc_editor.cpp
@@ -260,9 +260,13 @@ void ScCodeEditor::insertFromMimeData(const QMimeData* data) {
         for (int i = 0; i < urls.size(); ++i) {
             QUrl url = urls[i];
             cursor.insertText("\"");
-            if (QURL_IS_LOCAL_FILE(url))
-                cursor.insertText(url.toLocalFile());
-            else
+            if (QURL_IS_LOCAL_FILE(url)) {
+                QString path = url.toLocalFile();
+#ifdef Q_OS_WIN
+                path.replace('/', "\\");
+#endif
+                cursor.insertText(path);
+            } else
                 cursor.insertText(url.toString());
             cursor.insertText("\"");
             if (i < urls.size() - 1) {


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

When dragging & dropping a file on the ScIDE on Windows, the path has forward slashes, i.e. `"C:/foo/bar.txt"` instead of `"C:\\foo\\bar.txt"`.

The real problem comes later, when trying to interact with this path: all SC functions expect `\` as separator, e.g. `PathName("C:/foo/bar.txt").isAbsolutePath` yields `false`.

The problem comes from the use of QUrl to handle dropped files, and [QUrl::toLocalFile](https://doc.qt.io/qt-5/qurl.html#toLocalFile)'s behavior:

> The path returned will use forward slashes, even if it was originally created from one with backslashes.

## Types of changes

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [ ] Code is tested
- [ ] All tests are passing
- [ ] Updated documentation
- [X] This PR is ready for review
