### PR TITLE
supernova portaudio: fix for requesting number of I/O channels exceeding hardware capabilities

### DIFF
--- a/server/supernova/server/server.hpp
+++ b/server/supernova/server/server.hpp
@@ -226,7 +226,9 @@ private:
 
 inline void run_scheduler_tick(void) {
     const int blocksize = sc_factory->world.mBufLength;
-    const int input_channels = sc_factory->world.mNumInputs;
+    // FIXME/TODO
+    // server may have fewer input channels than sc_factory
+    const int input_channels = instance->audio_backend::get_input_count();
     const int output_channels = sc_factory->world.mNumOutputs;
     const int buf_counter = ++sc_factory->world.mBufCounter;
 


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

Fixes #4029 

~~This is WIP - it works as expected, but the implementation is hack-y.~~

The gist of the issue was that in ```void nova_server::prepare_backend(void)```, as well as in ```inline void run_scheduler_tick(void)``` (in `server.hpp`/`server.cpp`) we needed to use number of input channels clipped to the number of available ins in the hardware, but number of output channels as requested by the user (_not_ clipped to what HW provides).

After modifications to `server.cpp` and `server.hpp` and making `input_channels`/`output_channels` variables available globally to fix this, I have also tested JACK and non-real-time (soundfile) backends; both seem to work as expected. (Soundfile needed a fix, which is now included).

**I'm open to suggestions if there's a better way to fix this :)**

BTW original issue was reported only for number of output channels, but it actually applies to exceeding both input and output HW channels. This PR contains fixes both. To test:

```supercollider
(
Server.supernova;
s.options.numOutputBusChannels_(4); //choose number larger than the soundcard provides
s.options.numInputBusChannels_(4); //choose number larger than the soundcard provides
s.reboot;
)
s.meter; 

x.free; x = {PinkNoise.ar(-12.dbamp)}.play(outbus: 4, target: 0, addAction: \addToHead); //play on the first input channel

x.free; x = {PinkNoise.ar(-12.dbamp)}.play(outbus: 6, target: 0, addAction: \addToHead); //play on the input channel above what hardware provides

x.free;
```

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
  - [x] PortAudio input/output is tested
  - [x] JACK input/output is tested
  - [x] non-real-time (soundfile) input/output is tested
- [x] Code structure/logic is improved
- [ ] Commit history is cleaned up (after review)
- [x] This PR is ready for review
