### PR TITLE
servers: allow building with FFT_GREEN on macOS

### DIFF
--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -16,7 +16,12 @@ include_directories(${boost_include_dirs})
 
 # here we choose who provides us with the FFT lib
 if (APPLE)
-	add_definitions("-DSC_FFT_VDSP")
+	if (FFT_GREEN)
+		message(STATUS "Using green fft")
+		add_definitions("-DSC_FFT_GREEN")
+	else()
+		add_definitions("-DSC_FFT_VDSP")
+	endif()
 else()
 	find_package(FFTW3f 3.3)
 


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

Previously, CMake option `FFT_GREEN` did not work on macOS (regardless of its value, one would always build against the `vDSP` library). This PR allows using this built-in FFT library on macOS.

The default value stays the same (`FFT_GREEN=OFF`) since it is not recommended.

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] This PR is ready for review
