### PR TITLE
Fix Document.initAction to fire when opening from the IDE

### DIFF
--- a/HelpSource/Classes/Document.schelp
+++ b/HelpSource/Classes/Document.schelp
@@ -97,7 +97,7 @@ argument:: action
 An instance of link::Classes/Function:: or link::Classes/FunctionList::.
 
 method:: autoRun
-If a document begins with the comment, code::/*RUN*/::, then the code following it in the file will be executed on opening the file, if autorun is set to true.
+If autoRun is set to true, documents beginning with the comment code::/*RUN*/:: will be executed immediately after being opened, and also when the class library is recompiled with the document already open in the IDE.
 argument:: value
 An instance of link::Classes/Boolean::. Default value is code::true::.
 

--- a/SCClassLibrary/scide_scqt/ScIDE.sc
+++ b/SCClassLibrary/scide_scqt/ScIDE.sc
@@ -496,7 +496,7 @@ Document {
 		};
 		if((doc = this.findByQUuid(quuid)).isNil, {
 			doc = super.new.initFromIDE(quuid, title, chars, isEdited, path, selStart, selSize);
-			allDocuments = allDocuments.add(doc);
+			doc.prAdd;
 		}, {doc.initFromIDE(quuid, title, chars, isEdited, path, selStart, selSize)});
 	}
 

--- a/testsuite/classlibrary/TestDocument.sc
+++ b/testsuite/classlibrary/TestDocument.sc
@@ -24,7 +24,7 @@ TestDocument : UnitTest {
 	}
 
 	test_open_autorun_document_runs_code {
-		var path = PathName.tmp +/+ "autoRunTest%.scd".format(UniqueID.next),
+		var path = Platform.defaultTempDir +/+ "autoRunTest%.scd".format(UniqueID.next),
 		file, doc;
 		if(Platform.ideName == "scqt") {
 			if(File.exists(path)) {

--- a/testsuite/classlibrary/TestDocument.sc
+++ b/testsuite/classlibrary/TestDocument.sc
@@ -24,7 +24,7 @@ TestDocument : UnitTest {
 	}
 
 	test_open_autorun_document_runs_code {
-		var path = Platform.defaultTempDir +/+ "autoRunTest%.scd".format(UniqueID.next),
+		var path = Platform.defaultTempDir +/+ "autoRunTest.scd",
 		file, doc;
 		if(Platform.ideName == "scqt") {
 			if(File.exists(path)) {

--- a/testsuite/classlibrary/TestDocument.sc
+++ b/testsuite/classlibrary/TestDocument.sc
@@ -1,0 +1,53 @@
+TestDocument : UnitTest {
+	// autorun doesn't have access to this object's scope
+	// need a public place to communicate the result
+	classvar <>success;
+
+	test_new_document_runs_initAction {
+		var success = false, doc, save;
+		if(Platform.ideName == "scqt") {
+			save = Document.initAction;
+			protect {
+				Document.initAction = { success = true };
+				doc = Document.new;
+				0.1.wait;
+				doc.close;
+			} {
+				Document.initAction = save;
+			};
+			this.assert(success, "Document.new should fire Document.initAction function");
+		} {
+			this.assert(false, "Cannot test Document.new behavior in a non-ScIDE session");
+		};
+	}
+
+	test_open_autorun_document_runs_code {
+		var path = PathName.tmp +/+ "autoRunTest%.scd".format(UniqueID.next),
+		file, doc;
+		if(Platform.ideName == "scqt") {
+			if(File.exists(path)) {
+				this.assert(false, "Document autoRun test file path should not exist: '%'".format(path));
+			} {
+				file = File(path, "w");
+				if(file.isOpen) {
+					protect {
+						file << "/*RUN*/\nTestDocument.success = true\n";
+						file.close;
+						success = false;
+						doc = Document.open(path);
+						0.1.wait;
+						doc.close;
+						this.assert(success, "Document.open should run autoRun /*RUN*/ documents");
+					} {
+						file.close;
+						File.delete(path);
+					};
+				} {
+					this.assert(false, "Document autoRun test could not open '%' for writing".format(path));
+				};
+			}
+		} {
+			this.assert(false, "Cannot test Document.open behavior in a non-ScIDE session");
+		};
+	}
+}

--- a/testsuite/classlibrary/TestDocument.sc
+++ b/testsuite/classlibrary/TestDocument.sc
@@ -10,14 +10,16 @@ TestDocument : UnitTest {
 			protect {
 				Document.initAction = { success = true };
 				doc = Document.new;
-				0.1.wait;
+				// failureMessage is deliberately nil
+				// we will assert below, we don't need `wait` to call `failed` itself
+				this.wait({ success }, failureMessage: nil, maxTime: 0.2);
 				doc.close;
 			} {
 				Document.initAction = save;
 			};
 			this.assert(success, "Document.new should fire Document.initAction function");
 		} {
-			this.assert(false, "Cannot test Document.new behavior in a non-ScIDE session");
+			// TODO: skip
 		};
 	}
 
@@ -47,7 +49,7 @@ TestDocument : UnitTest {
 				};
 			}
 		} {
-			this.assert(false, "Cannot test Document.open behavior in a non-ScIDE session");
+			// TODO: skip
 		};
 	}
 }


### PR DESCRIPTION
## Purpose and Motivation

Fixes #4549.

Previously, `Document.initAction = { ... }` or autorun documents took effect only when opening the document programmatically (`Document.open` or `Document.new`), but these were ignored when opening the document using IDE menu commands.

The simplest fix also means that autoRun documents will execute whenever recompiling the class library (if they are open). Per discussion under #4549, this seems to match the original autoRun behavior under Cocoa, and it's justifiable as an easy way to write "soft" startup code. However, the documentation inaccurately claimed that autoRun fires only when opening the document. So I updated the help file as well.

This PR touches two behaviors that are impossible to test automatically:

- User action in the IDE.
- Startup behavior after recompiling the library (as this would halt the entire test suite).

I've added tests for initAction and autoRun when opening a document programmatically. That's about all I think I can do.

## Types of changes

- Documentation
- Bug fix

## To-do list

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review
