### PR TITLE
Use fftw in supernova on macos

### DIFF
--- a/.travis/before-install-osx.sh
+++ b/.travis/before-install-osx.sh
@@ -7,6 +7,7 @@ brew install portaudio || exit 2
 brew install ccache || exit 3
 brew install qt5 || exit 4
 brew link qt5 --force || exit 5
+brew install fftw || exit 6
 
 # according to https://docs.travis-ci.com/user/caching#ccache-cache
 export PATH="/usr/local/opt/ccache/libexec:$PATH"

--- a/README_MACOS.md
+++ b/README_MACOS.md
@@ -50,8 +50,8 @@ Prerequisites:
   QtWebEngine](https://doc.qt.io/qt-5/qtwebengine-platform-notes.html#macos), specifically macOS
   10.9 and the macOS SDK for 10.10 or later.
 
-- If you want to build with the *supernova* server, you need **portaudio** package, which can also be installed via homebrew:
-  `brew install portaudio`
+- If you want to build with the *supernova* server, you need **portaudio** and **fftw** packages, which can also be installed via homebrew:
+  `brew install portaudio fftw`
 
 Obtaining the source code
 -------------------------
@@ -73,6 +73,7 @@ Build instructions
     cmake -G Xcode -DCMAKE_PREFIX_PATH=`brew --prefix qt5`  ..
     # or, if you want to build with supernova:
     cmake -G Xcode -DCMAKE_PREFIX_PATH=`brew --prefix qt5` -DSUPERNOVA=ON ..
+    # then start the build
     cmake --build . --target install --config RelWithDebInfo
 
 If successful this will build the application into `build/Install/SuperCollider/`

--- a/common/SC_fftlib.cpp
+++ b/common/SC_fftlib.cpp
@@ -217,6 +217,7 @@ static bool scfft_global_initialization(void) {
     }
     fftwf_free(buffer1);
     fftwf_free(buffer2);
+    // printf("SC FFT global init: FFTW initialised.\n");
 #endif
     return false;
 }

--- a/editors/sc-ide/CMakeLists.txt
+++ b/editors/sc-ide/CMakeLists.txt
@@ -476,20 +476,33 @@ if(APPLE OR WIN32)
         # only the IDE executable is scanned normally, so force scanning of sclang as well
         # to get QtWebEngine, libsndfile, and other libs. also force scanning of QtWebEngineProcess
         # because macdeployqt is a fickle beast.
+        set(CONTENTS_DIR ${CMAKE_INSTALL_PREFIX}/SuperCollider/SuperCollider.app/Contents)
         set(DEPLOY_CMD "\"${DEPLOY_PROG}\"
                 \"${CMAKE_INSTALL_PREFIX}/SuperCollider/SuperCollider.app\"
                 -verbose=1
-                -executable=${CMAKE_INSTALL_PREFIX}/SuperCollider/SuperCollider.app/Contents/MacOS/sclang
-                -executable=${CMAKE_INSTALL_PREFIX}/SuperCollider/SuperCollider.app/Contents/Resources/scsynth
-                -executable=${CMAKE_INSTALL_PREFIX}/SuperCollider/SuperCollider.app/Contents/Resources/supernova
-                -executable=${CMAKE_INSTALL_PREFIX}/SuperCollider/SuperCollider.app/Contents/Resources/plugins/DiskIO_UGens.scx
-                -executable=${CMAKE_INSTALL_PREFIX}/SuperCollider/SuperCollider.app/Contents/Resources/plugins/DiskIO_UGens_supernova.scx
-                -executable=${CMAKE_INSTALL_PREFIX}/SuperCollider/SuperCollider.app/Contents/Frameworks/QtWebEngineCore.framework/Versions/5/Helpers/QtWebEngineProcess.app/Contents/MacOS/QtWebEngineProcess
+                -executable=${CONTENTS_DIR}/MacOS/sclang
+                -executable=${CONTENTS_DIR}/Resources/scsynth
+                -executable=${CONTENTS_DIR}/Resources/supernova
+                -executable=${CONTENTS_DIR}/Resources/plugins/DiskIO_UGens.scx
+                -executable=${CONTENTS_DIR}/Resources/plugins/DiskIO_UGens_supernova.scx
+                -executable=${CONTENTS_DIR}/Frameworks/QtWebEngineCore.framework/Versions/5/Helpers/QtWebEngineProcess.app/Contents/MacOS/QtWebEngineProcess
             ")
-        set(VERIFY_CMD "include(BundleUtilities)
+        set(VERIFY_CMD "include(BundleUtilities)")
+        if(SUPERNOVA)
+            get_target_property(LINK_FFTW libsupernova SUPERNOVA_FFTW)
+            if(LINK_FFTW)
+                message(STATUS "macdeployqt: will fix linking FFTW for supernova")
+                # For supernova, libfftw3f.3.dylib has a further dependency (libgcc_s) which is copied in,
+                # but libfftw3f is not fixed up automatically when supernova is deployed.
+                string(APPEND VERIFY_CMD "
+                message(STATUS \"Fixing up bad path in libfftw3f.3.dylib manually due to faulty logic in macdeployqt\")
+                execute_process(COMMAND install_name_tool -change /usr/local/lib/gcc/9/libgcc_s.1.dylib
+                    @loader_path/libgcc_s.1.dylib ${CONTENTS_DIR}/Frameworks/libfftw3f.3.dylib)")
+            endif()
+        endif()
+        string(APPEND VERIFY_CMD "
             message(STATUS \"Verifying app\")
-            verify_app(\"${CMAKE_INSTALL_PREFIX}/SuperCollider/SuperCollider.app\")
-            ")
+            verify_app(\"${CMAKE_INSTALL_PREFIX}/SuperCollider/SuperCollider.app\")")
     else() # WIN32
         find_program(DEPLOY_PROG windeployqt PATHS ${CMAKE_PREFIX_PATH})
         set(DEPLOY_CMD "\"${DEPLOY_PROG}\"

--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -14,26 +14,6 @@ include_directories(${CMAKE_SOURCE_DIR}/external_libraries
 
 include_directories(${boost_include_dirs})
 
-# here we choose who provides us with the FFT lib
-if (APPLE)
-	add_definitions("-DSC_FFT_VDSP")
-else()
-	find_package(FFTW3f 3.3)
-
-	if (NOT FFTW3F_FOUND OR FFT_GREEN)
-		message(STATUS "Using green fft")
-		set(FFT_GREEN 1)
-		add_definitions("-DSC_FFT_GREEN")
-	else()
-		if(WIN32)
-			message(STATUS "Found fftw3f: ${FFTW3F_LIBRARY}")
-		else(WIN32)
-			message(STATUS "Using fftw3f")
-		endif(WIN32)
-		add_definitions("-DSC_FFT_FFTW")
-	endif()
-endif()
-
 add_subdirectory(plugins)
 add_subdirectory(scsynth)
 

--- a/server/scsynth/CMakeLists.txt
+++ b/server/scsynth/CMakeLists.txt
@@ -1,5 +1,27 @@
 find_package(Sndfile)
 
+# here we choose who provides us with the FFT lib
+# this is done independently for scsynth and supernova
+# on macOS scsynth uses vDSP implementation for FFT
+# which is not thread-safe
+
+if (APPLE)
+    add_definitions("-DSC_FFT_VDSP")
+    message(STATUS "FFT library (scsynth): vDSP")
+else()
+    find_package(FFTW3f 3.3)
+
+    if (NOT FFTW3F_FOUND OR FFT_GREEN)
+        message(STATUS "FFT library (scsynth): Green")
+        set(FFT_GREEN 1)
+        add_definitions("-DSC_FFT_GREEN")
+    else()
+        message(STATUS "Found fftw3f: ${FFTW3F_LIBRARY}")
+        message(STATUS "FFT library (scsynth): FFTW")
+        add_definitions("-DSC_FFT_FFTW")
+    endif()
+endif()
+
 # Here we work out which audio API to use, from system type and/or user option.
 if(AUDIOAPI STREQUAL "default")
 	if(APPLE)

--- a/server/supernova/CMakeLists.txt
+++ b/server/supernova/CMakeLists.txt
@@ -15,6 +15,26 @@ if(APPLE)
     include_directories(${CMAKE_SOURCE_DIR}/external_libraries/libsndfile)
 endif()
 
+# here we choose who provides us with the FFT lib
+# this is done independently for scsynth and supernova
+# scsynth uses vDSP implementation for FFT on macOS
+# however current implementation of vDSP is not thread-safe
+# so we use FFTW with supernova on macOS
+# once vDSP implementation becomes thread-safe
+# this logic can be reworked to use vDSP on macOS
+
+find_package(FFTW3f 3.3)
+
+if (NOT FFTW3F_FOUND OR FFT_GREEN)
+    message(STATUS "FFT library (supernova): Green")
+    set(FFT_GREEN 1)
+    add_definitions("-DSC_FFT_GREEN")
+else()
+    message(STATUS "Found fftw3f: ${FFTW3F_LIBRARY}")
+    message(STATUS "FFT library (supernova): FFTW")
+    add_definitions("-DSC_FFT_FFTW")
+endif()
+
 set(libsupernova_src
     sc/sc_synth_definition.cpp
     sc/sc_osc_handler.cpp
@@ -140,6 +160,7 @@ endif()
 if (FFTW3F_FOUND)
     target_include_directories(libsupernova PUBLIC ${FFTW3F_INCLUDE_DIR})
     target_link_libraries(libsupernova ${FFTW3F_LIBRARY})
+    set_property(TARGET libsupernova PROPERTY SUPERNOVA_FFTW ON) # for fixing linking in macdeployqt
 endif()
 
 if(CMAKE_SYSTEM_NAME MATCHES "Linux")


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->
In the process of trying to find solutions to #4289, it was suggested to use the `FFTW` library on macOS for supernova.

This PR adds build instructions for including FFTW in supercollider built on macOS (for supernova only; scsynth still uses vDSP). 

~~In order to provide static FFTW I am using a custom homebrew formula. This formula is temporarily hosted on my [github](https://github.com/dyfer/homebrew-fftw-sc), but if we decide to accept this PR, it should be moved to a more permanent place (and appropriate portions of this PR should be updated).~~

EDIT: This uses a regular FFTW from homebrew. Thanks to @brianlheim for figuring out how to fix linking with it.

## Types of changes

<!-- Delete lines that don't apply -->

- Documentation
- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] Updated documentation
- [x] This PR is ready for review
- [x] commit history is cleaned up
