### PR TITLE
clang-format.py: don't consider empty output an error

### DIFF
--- a/tools/clang-format.py
+++ b/tools/clang-format.py
@@ -479,7 +479,7 @@ def do_lint(clang_format, clang_format_diff, commit):
     diff_text = prepare_diff_for_lint_format(clang_format, commit)
     lint_out = callo_with_input(['python', clang_format_diff, '-p1', '-binary', clang_format], diff_text)
     print(lint_out, end='')
-    if lint_out != '\n':
+    if lint_out != '\n' and lint_out != '':
         sys.exit(1)
 
 def do_format(clang_format, clang_format_diff, commit):


### PR DESCRIPTION
<!--- Hi, and thanks for contributing! -->
<!--- Make sure to provide a general summary of your changes in the title above. -->
<!--- For example: "[scsynth] Fix crash when encountering cute kittens" -->

Purpose and Motivation
----------------------


sometimes the output of clang-format's linting operation is an empty string instead of newline

Types of changes
----------------

- Bug fix (non-breaking change which fixes an issue)

Checklist
---------

<!--- Complete an item by checking it: [x] -->

- [x] All tests are passing
- [x] If necessary, new tests were created to address changes in PR, and tests are passing
- [x] Updated documentation, if necessary
- [x] This PR is ready for review