### PR TITLE
Fix typo in Env help file

### DIFF
--- a/HelpSource/Classes/Env.schelp
+++ b/HelpSource/Classes/Env.schelp
@@ -17,7 +17,7 @@ Env.new(levels: [0, 1, 0.9, 0], times: [0.1, 0.5, 1], curve: [-5, 0, -5]).plot;
 In this envelope, there are four emphasis::nodes:: :
 
 list:: 
-## the first emphasis::node:: is the initial level of the enveloppe : 0 
+## the first emphasis::node:: is the initial level of the envelope : 0 
 ## the second emphasis::node:: has level 1 and is reached in 0.1 second
 ## the third emphasis::nodes:: has level 0.9 and is reached in 0.5 second
 ## the fourth emphasis::nodes:: has level 0 and is reached in 1 second


### PR DESCRIPTION
Removed an extra `p` in `envelope`.

<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

This is a cherry-pick of #4566 for `3.10`

## Types of changes

<!-- Delete lines that don't apply -->

- Cherry-pick

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [ ] Code is tested
- [ ] All tests are passing
- [ ] Updated documentation
- [X] This PR is ready for review
