### PR TITLE
SC_JACK repair

### DIFF
--- a/server/scsynth/SC_Jack.cpp
+++ b/server/scsynth/SC_Jack.cpp
@@ -422,9 +422,8 @@ void SC_JackDriver::Run() {
         }
 
         // main loop
-        int64 oscTime = mOSCbuftime = (uint64)((mDLL.PeriodTime() + mMaxOutputLatency) * kSecondsToOSCunits + .5);
-        // 		int64 oscInc = mOSCincrement = (int64)(mOSCincrementNumerator / mDLL.SampleRate());
-        int64 oscInc = mOSCincrement = (uint64)((mDLL.Period() / numBufs) * kSecondsToOSCunits + .5);
+        int64 oscTime = mOSCbuftime = (mDLL.PeriodTime() + mMaxOutputLatency) * kSecondsToOSCunits + .5;
+        int64 oscInc = mOSCincrement = (mDLL.Period() / numBufs) * kSecondsToOSCunits + .5;
         mSmoothSampleRate = mDLL.SampleRate();
         double oscToSamples = mOSCtoSamples = mSmoothSampleRate * kOSCtoSecs /* 1/pow(2,32) */;
 

--- a/server/scsynth/SC_Jack.cpp
+++ b/server/scsynth/SC_Jack.cpp
@@ -307,7 +307,6 @@ void SC_JackDriver::ConnectClientOutputs(const char* pattern) {
 }
 
 
-
 bool SC_JackDriver::DriverStart() {
     if (!mClient)
         return false;
@@ -377,14 +376,14 @@ void SC_JackDriver::Run() {
     World* world = mWorld;
 
     mDLL.Update(jackOscTimeSeconds());
-#    if SC_JACK_DEBUG_DLL
+#if SC_JACK_DEBUG_DLL
     static int tick = 0;
     if (++tick >= 10) {
         tick = 0;
         scprintf("DLL: t %.6f p %.9f sr %.6f e %.9f avg(e) %.9f inc %.9f\n", mDLL.PeriodTime(), mDLL.Period(),
                  mDLL.SampleRate(), mDLL.Error(), mDLL.AvgError(), mOSCincrement * kOSCtoSecs);
     }
-#    endif
+#endif
 
 
     try {

--- a/server/scsynth/SC_Jack.cpp
+++ b/server/scsynth/SC_Jack.cpp
@@ -54,6 +54,7 @@ int32 server_timeseed() { return timeSeed(); }
 
 int64 oscTimeNow() { return OSCTime(getTime()); }
 
+static double jackOscTimeSeconds() { return OSCTime(getTime()) * kOSCtoSecs; }
 
 void initializeScheduler() {}
 
@@ -306,8 +307,7 @@ void SC_JackDriver::ConnectClientOutputs(const char* pattern) {
 }
 
 
-static inline double sc_JACKOSCTimeSeconds() { return (uint64)OSCTime(getTime()) * kOSCtoSecs; }
-#define SC_JACK_USE_DLL
+
 bool SC_JackDriver::DriverStart() {
     if (!mClient)
         return false;
@@ -357,9 +357,8 @@ bool SC_JackDriver::DriverStart() {
         if (thisPortName && thatPortName)
             ConnectPorts(thisPortName, thatPortName);
     }
-#ifdef SC_JACK_USE_DLL
-    mDLL.Reset(mSampleRate, mNumSamplesPerCallback, SC_TIME_DLL_BW, sc_JACKOSCTimeSeconds());
-#endif
+    mDLL.Reset(mSampleRate, mNumSamplesPerCallback, SC_TIME_DLL_BW, jackOscTimeSeconds());
+
     return true;
 }
 
@@ -377,8 +376,7 @@ void SC_JackDriver::Run() {
     jack_client_t* client = mClient;
     World* world = mWorld;
 
-#ifdef SC_JACK_USE_DLL
-    mDLL.Update(sc_JACKOSCTimeSeconds());
+    mDLL.Update(jackOscTimeSeconds());
 #    if SC_JACK_DEBUG_DLL
     static int tick = 0;
     if (++tick >= 10) {
@@ -387,34 +385,7 @@ void SC_JackDriver::Run() {
                  mDLL.SampleRate(), mDLL.Error(), mDLL.AvgError(), mOSCincrement * kOSCtoSecs);
     }
 #    endif
-#else
-    HostTime hostTime = getTime();
 
-    double hostSecs = sc_JACKOSCTimeSeconds();
-    double sampleTime = (double)(jack_frame_time(client) + jack_frames_since_cycle_start(client));
-
-    if (mStartHostSecs == 0) {
-        mStartHostSecs = hostSecs;
-        mStartSampleTime = sampleTime;
-    } else {
-        double instSampleRate = (sampleTime - mPrevSampleTime) / (hostSecs - mPrevHostSecs);
-        double smoothSampleRate = mSmoothSampleRate;
-        smoothSampleRate = smoothSampleRate + 0.002 * (instSampleRate - smoothSampleRate);
-        if (fabs(smoothSampleRate - mSampleRate) > 10.) {
-            smoothSampleRate = mSampleRate;
-        }
-        mOSCincrement = (int64)(mOSCincrementNumerator / smoothSampleRate);
-        mSmoothSampleRate = smoothSampleRate;
-#    if 0
-		double avgSampleRate = (sampleTime - mStartSampleTime)/(hostSecs - mStartHostSecs);
-		double jitter = (smoothSampleRate * (hostSecs - mPrevHostSecs)) - (sampleTime - mPrevSampleTime);
-		double drift = (smoothSampleRate - mSampleRate) * (hostSecs - mStartHostSecs);
-#    endif
-    }
-
-    mPrevHostSecs = hostSecs;
-    mPrevSampleTime = sampleTime;
-#endif
 
     try {
         mFromEngine.Free();
@@ -452,17 +423,11 @@ void SC_JackDriver::Run() {
         }
 
         // main loop
-#ifdef SC_JACK_USE_DLL
         int64 oscTime = mOSCbuftime = (uint64)((mDLL.PeriodTime() + mMaxOutputLatency) * kSecondsToOSCunits + .5);
         // 		int64 oscInc = mOSCincrement = (int64)(mOSCincrementNumerator / mDLL.SampleRate());
         int64 oscInc = mOSCincrement = (uint64)((mDLL.Period() / numBufs) * kSecondsToOSCunits + .5);
         mSmoothSampleRate = mDLL.SampleRate();
         double oscToSamples = mOSCtoSamples = mSmoothSampleRate * kOSCtoSecs /* 1/pow(2,32) */;
-#else
-        int64 oscTime = mOSCbuftime = OSCTime(hostTime) + (int64)(mMaxOutputLatency * kSecondsToOSCunits + .5);
-        int64 oscInc = mOSCincrement;
-        double oscToSamples = mOSCtoSamples;
-#endif
 
         for (int i = 0; i < numBufs; ++i, mWorld->mBufCounter++, bufFramePos += bufFrames) {
             int32 bufCounter = mWorld->mBufCounter;
@@ -546,9 +511,7 @@ void SC_JackDriver::Reset(double sampleRate, int bufferSize) {
     mMaxPeakCounter = (int)mBuffersPerSecond;
     mOSCincrement = (int64)(mOSCincrementNumerator / mSampleRate);
 
-#ifdef SC_JACK_USE_DLL
-    mDLL.Reset(mSampleRate, mNumSamplesPerCallback, SC_TIME_DLL_BW, sc_JACKOSCTimeSeconds());
-#endif
+    mDLL.Reset(mSampleRate, mNumSamplesPerCallback, SC_TIME_DLL_BW, jackOscTimeSeconds());
 }
 
 bool SC_JackDriver::BufferSizeChanged(int numSamples) {


### PR DESCRIPTION
## Purpose and Motivation

Fixes #4596

Which basically consist on a lot of jitter in scsynth clock when uses Jack on windows or linux
Causes are:
TimeDLL was not used because SC_JACK_USE_DLL was not defined
TimeDLL.Reset was not called on DriverStart
time provided by secondsSinceEpoch(getTime()) was not correct

## Types of changes

- Bug fix
Let JACK use TimeDLLby defining SC_JACK_USE_DLL
sc_JACKOSCTimeSeconds (mimics portaudio for scsynth) instead of secondsSinceEpoch(getTime()) 
calling mDLL.Reset on DriverStart
cast with uint64 (as done in portaudio) instead of int64

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [X] Code is tested
- [X] All tests are passing
- [x] This PR is ready for review
