### PR TITLE
Xcode 11 support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -253,8 +253,8 @@ if (NOT WIN32)
 endif()
 
 if(SYSTEM_BOOST)
-  set(Boost_USE_MULTITHREADED      ON)
-  find_package( Boost 1.50.0 COMPONENTS  thread system filesystem program_options regex test_exec_monitor )
+    set(Boost_USE_MULTITHREADED ON)
+    find_package(Boost 1.66.0 COMPONENTS thread system filesystem program_options regex test_exec_monitor)
 endif()
 
 if (Boost_FOUND)

--- a/common/server_shm.hpp
+++ b/common/server_shm.hpp
@@ -95,10 +95,6 @@ public:
     server_shared_memory_creator(unsigned int port_number, unsigned int control_busses):
         shmem_name(detail_server_shm::make_shmem_name(port_number)),
         segment(bi::open_or_create, shmem_name.c_str(), 8192 * 1024) {
-#if (BOOST_VERSION < 105100)
-        segment.flush();
-#endif
-
         const int num_scope_buffers = 128;
         size_t scope_pool_size = num_scope_buffers * sizeof(float) * 8192; // pessimize, about 4 MB
         void* memory_for_scope_pool = segment.allocate(scope_pool_size);

--- a/server/supernova/sc/sc_osc_handler.cpp
+++ b/server/supernova/sc/sc_osc_handler.cpp
@@ -18,6 +18,11 @@
 
 #include <iostream>
 
+// AppleClang workaround
+#if defined(__apple_build_version__) && __apple_build_version__ > 11000000
+#    define BOOST_ASIO_HAS_STD_STRING_VIEW 1
+#endif
+
 #include <boost/asio/placeholders.hpp>
 #include <boost/asio/read.hpp>
 #include <boost/bind.hpp>

--- a/server/supernova/sc/sc_osc_handler.hpp
+++ b/server/supernova/sc/sc_osc_handler.hpp
@@ -28,6 +28,11 @@
 #    endif
 #endif
 
+// AppleClang workaround
+#if defined(__apple_build_version__) && __apple_build_version__ > 11000000
+#    define BOOST_ASIO_HAS_STD_STRING_VIEW 1
+#endif
+
 #include <boost/asio/ip/tcp.hpp>
 
 #include <boost/enable_shared_from_this.hpp>

--- a/server/supernova/utilities/osc_server.hpp
+++ b/server/supernova/utilities/osc_server.hpp
@@ -20,6 +20,11 @@
 
 #include <thread>
 
+// AppleClang workaround
+#if defined(__apple_build_version__) && __apple_build_version__ > 11000000
+#    define BOOST_ASIO_HAS_STD_STRING_VIEW 1
+#endif
+
 #include <boost/asio/io_service.hpp>
 #include <boost/asio/ip/udp.hpp>
 


### PR DESCRIPTION
## Purpose and Motivation

See commit messages for details

## Types of changes

- Bug fix
- Breaking change  -- boost >= 1.66 is now strictly required by the build system. Technically, this is not true as you don't absolutely need to build sclang to use the project. However, Boost is easy to obtain and this saves headaches later in the common case.

## To-do list

- [x] Code is tested -- I can now build Boost locally
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review
