### PR TITLE
scide: Fix the finding of locale-specific translations (#4619)

### DIFF
--- a/editors/sc-ide/core/main.cpp
+++ b/editors/sc-ide/core/main.cpp
@@ -60,8 +60,10 @@ int main(int argc, char* argv[]) {
         return 0;
 
     // Set up translations
+    const QLocale locale;
+
     QTranslator qtTranslator;
-    qtTranslator.load("qt_" + QLocale::system().name(), QLibraryInfo::location(QLibraryInfo::TranslationsPath));
+    qtTranslator.load(locale, "qt", "_", QLibraryInfo::location(QLibraryInfo::TranslationsPath));
     app.installTranslator(&qtTranslator);
 
     QString ideTranslationPath = standardDirectory(ScResourceDir) + "/translations";
@@ -76,9 +78,8 @@ int main(int argc, char* argv[]) {
         qWarning("scide warning: Failed to load fallback translation file.");
 
     // Load translator for locale
-    QString ideTranslationFile = "scide_" + QLocale::system().name();
     QTranslator scideTranslator;
-    scideTranslator.load(ideTranslationFile, ideTranslationPath);
+    scideTranslator.load(locale, "scide", "_", ideTranslationPath);
     app.installTranslator(&scideTranslator);
 
     // Force Fusion style to appear consistently on all platforms.


### PR DESCRIPTION
The fix is to use the QTranslator::load() overload that takes a
QLocale, instead of searching for the filename ourselves.
That way, Qt's documented logic takes care of finding
scide_fr.qm when the locale contains fr_FR.

<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

Fixes #4619.

Please see the detail about the fix, and how I tested it, in that ticket.

## Types of changes

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [ ] Code is tested - _tested on Mac only - it's hard to say how much effort should be tested on other platforms, given that all the translation files are effectively empty_
- [ ] All tests are passing - _as far as I understand, there are no tests for sc-ide, so this should not change any behaviour_
- [ ] Updated documentation - _nothing to document - no user-observable change_
- [x] This PR is ready for review