### PR TITLE
travis: update osx to xcode9.4 [3.10]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ matrix:
           - DO_LINT=true # only lint on fastest build
       group: edge
     - os: osx
-      osx_image: xcode8.3
+      osx_image: xcode9.4
       env:
           - QT=true
           - DO_LINT=false

--- a/.travis/before-install-osx.sh
+++ b/.travis/before-install-osx.sh
@@ -2,14 +2,14 @@
 
 export HOMEBREW_NO_ANALYTICS=1
 
-# according to https://docs.travis-ci.com/user/caching#ccache-cache
-brew install ccache
-export PATH="/usr/local/opt/ccache/libexec:$PATH"
-
 brew install libsndfile || true
 brew install portaudio || true
+brew install ccache || true
 brew install qt5 || true
 brew link qt5 --force
+
+# according to https://docs.travis-ci.com/user/caching#ccache-cache
+export PATH="/usr/local/opt/ccache/libexec:$PATH"
 
 # To get less noise in xcode output
 gem install xcpretty

--- a/.travis/qpm-prep.sh
+++ b/.travis/qpm-prep.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 cd $TRAVIS_BUILD_DIR/BUILD
-sudo pip2 install git+https://github.com/scztt/qpm.git@qpm-unit
+sudo pip2 install git+https://github.com/brianlheim/qpm.git@pip-setup
 
 mkdir $HOME/Quarks && cd $HOME/Quarks
 git clone --depth=1 https://github.com/supercollider-quarks/API


### PR DESCRIPTION
## Purpose and Motivation

to fix build failures with Homebrew

also reorder homebrew installation steps, otherwise ccache isn't
installed properly, not sure why. possibly needs further testing.

Fixes #4621

## Types of changes

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review

I'm not sure what will be affected by switching over to a 10.13 macOS image, but since it seems fairly impossible to use homebrew on macOS 10.12 anymore, I'm not sure we have a choice. 
