### PR TITLE
clang-format.py: accept any 8.y.z version

### DIFF
--- a/tools/clang-format.py
+++ b/tools/clang-format.py
@@ -118,7 +118,8 @@ except ImportError:  # Forced testing
 # Constants
 #
 
-CLANG_FORMAT_ACCEPTED_VERSION = "8.0.0"
+CLANG_FORMAT_ACCEPTED_VERSION_REGEX = re.compile("8\\.\\d+\\.\\d+")
+CLANG_FORMAT_ACCEPTED_VERSION_STRING = "8.y.z"
 
 # all the extensions we format with clang-format in SC (no JS!)
 CLANG_FORMAT_FILES_REGEX = re.compile('\\.(cpp|hpp|h|c|m|mm)$')
@@ -235,13 +236,13 @@ class ClangFormat(object):
     def _validate_version(self):
         cf_version = callo([self.cf_cmd, "--version"])
 
-        if CLANG_FORMAT_ACCEPTED_VERSION in cf_version:
+        if CLANG_FORMAT_ACCEPTED_VERSION_REGEX.search(cf_version):
             return
 
         # TODO add instructions to check docs when docs are written
         raise ValueError("clang-format found, but incorrect version at " +
-                self.cf_cmd + " with version: " + cf_version + "\nAccepted version: " +
-                CLANG_FORMAT_ACCEPTED_VERSION)
+                self.cf_cmd + " with version: " + cf_version + "\nAccepted versions: " +
+                CLANG_FORMAT_ACCEPTED_VERSION_STRING)
         sys.exit(5)
 
     def lint(self, file_name, print_diff):


### PR DESCRIPTION
Purpose and Motivation
----------------------

see https://github.com/supercollider/supercollider/pull/4379#issuecomment-551161971

also encountered with with @ClareMacrae -- it's probably better in this
situation to be permissive, and restrict later if problems arise.

Types of changes
----------------

- Bug fix (non-breaking change which fixes an issue)

Checklist
---------

- [x] All tests are passing - tested this, the regex works for me for positive and negative matches
- [x] If necessary, new tests were created to address changes in PR, and tests are passing
- [x] Updated documentation, if necessary - will update the wiki instructions if this is merged
- [x] This PR is ready for review