### PR TITLE
scide: Fix a dangling pointer when removing splits

### DIFF
--- a/editors/sc-ide/widgets/code_editor/editor.cpp
+++ b/editors/sc-ide/widgets/code_editor/editor.cpp
@@ -104,6 +104,12 @@ GenericCodeEditor::GenericCodeEditor(Document* doc, QWidget* parent):
     applySettings(Main::settings());
 }
 
+GenericCodeEditor::~GenericCodeEditor() {
+    if (mDoc->lastActiveEditor() == this) {
+        mDoc->setLastActiveEditor(nullptr);
+    }
+}
+
 void GenericCodeEditor::applySettings(Settings::Manager* settings) {
     settings->beginGroup("IDE/editor");
 

--- a/editors/sc-ide/widgets/code_editor/editor.cpp
+++ b/editors/sc-ide/widgets/code_editor/editor.cpp
@@ -105,6 +105,7 @@ GenericCodeEditor::GenericCodeEditor(Document* doc, QWidget* parent):
 }
 
 GenericCodeEditor::~GenericCodeEditor() {
+    // Prevent a dangling pointer.
     if (mDoc->lastActiveEditor() == this) {
         mDoc->setLastActiveEditor(nullptr);
     }

--- a/editors/sc-ide/widgets/code_editor/editor.hpp
+++ b/editors/sc-ide/widgets/code_editor/editor.hpp
@@ -41,6 +41,7 @@ class GenericCodeEditor : public QPlainTextEdit {
 
 public:
     GenericCodeEditor(Document*, QWidget* parent = NULL);
+    ~GenericCodeEditor();
 
     Document* document() { return mDoc; }
     QTextDocument* textDocument() { return QPlainTextEdit::document(); }

--- a/editors/sc-ide/widgets/code_editor/editor.hpp
+++ b/editors/sc-ide/widgets/code_editor/editor.hpp
@@ -54,7 +54,6 @@ public:
 
     Document* document() { return mDoc; }
     QTextDocument* textDocument() { return QPlainTextEdit::document(); }
-    void setDocument(Document*);
     bool showWhitespace();
     bool showLinenumber();
     bool find(const QRegExp& expr, QTextDocument::FindFlags options = 0);

--- a/editors/sc-ide/widgets/code_editor/editor.hpp
+++ b/editors/sc-ide/widgets/code_editor/editor.hpp
@@ -43,13 +43,13 @@ public:
     GenericCodeEditor(Document*, QWidget* parent = NULL);
     ~GenericCodeEditor();
 
-    // Rule of 5 -- with an explicit dtor, make sure that copy ctor, move ctor,
-    // copy assign, and move assign are deleted.
+    // Rule of 5 -- with an explicit dtor, make sure that copy ctor/assign and move
+    // ctor/assign are deleted.
     // If these must be implemented in the future, make sure they take care of
     // mDoc->lastActiveEditor() appropriately. See source of dtor method.
     GenericCodeEditor(const GenericCodeEditor& other) = delete;
-    GenericCodeEditor(GenericCodeEditor&& other) = delete;
     GenericCodeEditor& operator=(const GenericCodeEditor& other) = delete;
+    GenericCodeEditor(GenericCodeEditor&& other) = delete;
     GenericCodeEditor& operator=(GenericCodeEditor&& other) = delete;
 
     Document* document() { return mDoc; }

--- a/editors/sc-ide/widgets/code_editor/editor.hpp
+++ b/editors/sc-ide/widgets/code_editor/editor.hpp
@@ -130,7 +130,9 @@ protected:
     QWidget* mOverlayWidget;
     OverlayAnimator* mOverlayAnimator;
 
-    Document* mDoc;
+    // If this "const" is removed in the future, make sure to handle mDoc->lastActiveEditor()
+    // correctly (see source of dtor method for this class).
+    Document* const mDoc;
 
     bool mHighlightCurrentLine;
     bool mEditorBoxIsActive;

--- a/editors/sc-ide/widgets/code_editor/editor.hpp
+++ b/editors/sc-ide/widgets/code_editor/editor.hpp
@@ -43,6 +43,15 @@ public:
     GenericCodeEditor(Document*, QWidget* parent = NULL);
     ~GenericCodeEditor();
 
+    // Rule of 5 -- with an explicit dtor, make sure that copy ctor, move ctor,
+    // copy assign, and move assign are deleted.
+    // If these must be implemented in the future, make sure they take care of
+    // mDoc->lastActiveEditor() appropriately. See source of dtor method.
+    GenericCodeEditor(const GenericCodeEditor& other) = delete;
+    GenericCodeEditor(GenericCodeEditor&& other) = delete;
+    GenericCodeEditor& operator=(const GenericCodeEditor& other) = delete;
+    GenericCodeEditor& operator=(GenericCodeEditor&& other) = delete;
+
     Document* document() { return mDoc; }
     QTextDocument* textDocument() { return QPlainTextEdit::document(); }
     void setDocument(Document*);


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

Fixes #4133, supersedes #4363. When a GenericCodeEditor is destroyed but a Document refers to it via
mLastActiveEditor, said pointer is dangling and can cause a crash. For
example, creating a split, removing all splits, and then recompiling the
class library can cause a crash.

This commit is a quick bandage, simply setting mLastActiveEditor to a
null pointer in the GenericCodeEditor's destructor. A more thorough
solution would be a stack of the most recently active editors, but the
point is to just prevent an IDE crash right now.

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] This PR is ready for review
