### PR TITLE
[sclang][win] Fix hang on Windows - read from stdin synchronously before starting

### DIFF
--- a/lang/LangSource/SC_TerminalClient.cpp
+++ b/lang/LangSource/SC_TerminalClient.cpp
@@ -590,6 +590,17 @@ void SC_TerminalClient::inputThreadFn() {
         readlineInit();
 #endif
 
+#ifdef _WIN32
+    // make sure there's nothing on stdin before we launch the service
+    // this fixes #4214
+    DWORD bytesRead = 0;
+    auto success = ReadFile(GetStdHandle(STD_INPUT_HANDLE), inputBuffer.data(), inputBuffer.size(), &bytesRead, NULL);
+
+    if (success) {
+        pushCmdLine(inputBuffer.data(), bytesRead);
+    }
+#endif
+
     startInputRead();
 
     boost::asio::io_service::work work(mInputService);


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

Fixes #4214 - "IDE can't run code on Windows, stuck at Sending Request....".

Under certain circumstances, the initial read of stdin appeared to be lost while starting the async io service - this left the interpreter unresponsive as it stopped listening to scide and failed to setup the IPC.

This PR reads from stdin once synchronously, just before starting the service to ensure all stdin is read - which appears to resolve the issue, but will need testing.

## Reasoning

### Is it an IPC breakdown?

It initially presented as an IPC breakdown. 
The IPC has two parts:
- ScProcess::mIpcServer (QLocalSocket)
- ScIpcClient

When the IDE launches sclang (ScProcess) it writes to STDIN:
```_ScIDE_Connect(<socketID>)```
passing in the QLocalSocket address of the IPC server.

sclang executes the primitive, which creates the IPC client.

The IPC client was never being created - so it was a breakdown, but not really.
## Does scide write to sclang STDIN?

The question became whether or not scide was writing to STDIN correctly. I wrote a logger that dumped error messages to a log file. As far as scide was concerned, it was writing ok - no errors from anything.

Something along these lines:

```cpp
std::ofstream jrs_log_file("log_file.txt");
std::mutex jrs_log_mutex;
#define JRS_DEBUG(what) {                               \
    std::lock_guard<std::mutex> lock(jrs_log_mutex);    \
    jrs_log_file << what << std::endl;                  \
}
```

## Does sclang read from STDIN?

The question then became whether or not sclang was reading from STDIN.
I moved the logger across to sclang and started dumping everything. Nothing was in the logs, the 

I added a separate thread that manually read STDIN and logged it.
Once I kick started reading from STDIN, sclang's normal reading took place (and they eventually started competing for reads, with some commands skipping).

I looked into why this was happening, and I noticed that the boost::asio service was being started after the initial `ScIDE_Connect` command was being sent, so it appeared as though it was being lost.

Why it was being lost I don't know - I don't fully understand the boost side of things. I suspect that it's something to do with the work queue running out of jobs and shutting down.

Subsequent writes to sclang's STDIN weren't being triggered because they relied on the IPC, which wasn't set up.

The solution was then to ensure there was nothing on STDIN before we started the async service.

This PR adds that - all communication is still async, apart from the first command (which sets up the IPC).

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix


## To-do list

This will need some serious testing to ensure nothing else broke in the process.

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [ ] Code is tested
- [ ] All tests are passing
- [ ] This PR is ready for review
