### PR TITLE
[scide][qtcollider] Fix Qt deprecations

### DIFF
--- a/QtCollider/primitives/prim_QImage.cpp
+++ b/QtCollider/primitives/prim_QImage.cpp
@@ -197,7 +197,7 @@ QC_LANG_PRIMITIVE(QImage_NewFromWindow, 2, PyrSlot* r, PyrSlot* a, VMGlobals* g)
     else if (NotNil(a + 1))
         return errWrongType;
 
-    QPixmap pixmap = QPixmap::grabWidget(widget, rect);
+    QPixmap pixmap = widget->grab(rect);
     if (pixmap.isNull())
         return errFailed;
 

--- a/QtCollider/primitives/prim_misc.cpp
+++ b/QtCollider/primitives/prim_misc.cpp
@@ -42,6 +42,7 @@
 #include <QDesktopWidget>
 #include <QStyleFactory>
 #include <QCursor>
+#include <QScreen>
 
 namespace QtCollider {
 
@@ -59,7 +60,7 @@ QC_LANG_PRIMITIVE(QWindow_ScreenBounds, 0, PyrSlot* r, PyrSlot* a, VMGlobals* g)
     if (!QcApplication::compareThread())
         return QtCollider::wrongThreadError();
 
-    QRect screenGeometry = QApplication::desktop()->screenGeometry();
+    QRect screenGeometry = QApplication::primaryScreen()->geometry();
     QtCollider::set(r, screenGeometry);
     return errNone;
 }
@@ -68,7 +69,7 @@ QC_LANG_PRIMITIVE(QWindow_AvailableGeometry, 0, PyrSlot* r, PyrSlot* a, VMGlobal
     if (!QcApplication::compareThread())
         return QtCollider::wrongThreadError();
 
-    QRect rect = QApplication::desktop()->availableGeometry();
+    QRect rect = QApplication::primaryScreen()->availableGeometry();
     QtCollider::set(r, rect);
     return errNone;
 }

--- a/QtCollider/widgets/QcWindow.cpp
+++ b/QtCollider/widgets/QcWindow.cpp
@@ -26,6 +26,7 @@
 #include <QShortcut>
 #include <QApplication>
 #include <QDesktopWidget>
+#include <QScreen>
 
 class QcWindowFactory : public QcObjectFactory<QcWindow> {
     // NOTE: use basic object contruction, but return widget proxy
@@ -57,7 +58,7 @@ static void qcInitWindow(QWidget* window, const QString& title, const QRectF& ge
     QRect geom(geom_.toRect());
 
     if (geom.isEmpty()) {
-        geom = QApplication::desktop()->availableGeometry();
+        geom = QApplication::primaryScreen()->availableGeometry();
         geom.setSize(window->sizeHint());
     }
 

--- a/editors/sc-ide/core/doc_manager.cpp
+++ b/editors/sc-ide/core/doc_manager.cpp
@@ -129,7 +129,13 @@ void Document::setIndentWidth(int numSpaces) {
     qreal tabStop = fontMetrics.width(' ') * numSpaces;
 
     QTextOption options = mDoc->defaultTextOption();
+
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 10, 0))
+    options.setTabStopDistance(tabStop);
+#else
     options.setTabStop(tabStop);
+#endif
+
     mDoc->setDefaultTextOption(options);
 }
 

--- a/editors/sc-ide/core/sc_introspection.cpp
+++ b/editors/sc-ide/core/sc_introspection.cpp
@@ -25,6 +25,7 @@
 #include <yaml-cpp/yaml.h>
 
 #include <cassert>
+#include <algorithm> // std::sort
 
 #include <QDebug>
 #include <QHash>
@@ -153,8 +154,8 @@ bool Introspection::parse(const QString& yamlString) {
             mMethodMap.insert(make_pair(method->name, QSharedPointer<Method>(method)));
         }
 
-        qSort(klass->methods.begin(), klass->methods.end(),
-              [](Method* lhs, Method* rhs) { return lhs->name.get() < rhs->name.get(); });
+        std::sort(klass->methods.begin(), klass->methods.end(),
+                  [](Method* lhs, Method* rhs) { return lhs->name.get() < rhs->name.get(); });
     }
 
     inferClassLibraryPath();

--- a/editors/sc-ide/widgets/code_editor/line_indicator.cpp
+++ b/editors/sc-ide/widgets/code_editor/line_indicator.cpp
@@ -81,7 +81,11 @@ int LineIndicator::widthForLineCount(int lineCount) {
         ++digits;
     }
 
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 11, 0))
+    return 6 + fontMetrics().horizontalAdvance('9') * digits;
+#else
     return 6 + fontMetrics().width('9') * digits;
+#endif
 }
 
 void LineIndicator::setHideLineIndicator(bool hide) { hideLineIndicator = hide; }

--- a/editors/sc-ide/widgets/doc_list.cpp
+++ b/editors/sc-ide/widgets/doc_list.cpp
@@ -34,7 +34,6 @@ DocumentListWidget::DocumentListWidget(DocumentManager* manager, QWidget* parent
     connect(manager, SIGNAL(opened(Document*, int, int)), this, SLOT(onOpen(Document*, int, int)));
     connect(manager, SIGNAL(closed(Document*)), this, SLOT(onClose(Document*)));
     connect(manager, SIGNAL(saved(Document*)), this, SLOT(onSaved(Document*)));
-    connect(&mModificationMapper, SIGNAL(mapped(QObject*)), this, SLOT(onModificationChanged(QObject*)));
     connect(this, SIGNAL(itemPressed(QListWidgetItem*)), this, SLOT(onItemClicked(QListWidgetItem*)));
 
     setDragDropMode(QAbstractItemView::InternalMove);
@@ -87,8 +86,7 @@ void DocumentListWidget::onSaved(Document* doc) {
         item->setText(doc->title());
 }
 
-void DocumentListWidget::onModificationChanged(QObject* obj) {
-    Document* doc = qobject_cast<Document*>(obj);
+void DocumentListWidget::onModificationChanged(Document* doc) {
     Item* item = itemFor(doc);
     if (item)
         item->setIcon(doc->textDocument()->isModified() ? mDocModifiedIcon : QIcon());
@@ -109,8 +107,7 @@ DocumentListWidget::Item* DocumentListWidget::addItemFor(Document* doc) {
     if (tdoc->isModified())
         item->setIcon(mDocModifiedIcon);
 
-    mModificationMapper.setMapping(tdoc, doc);
-    connect(tdoc, SIGNAL(modificationChanged(bool)), &mModificationMapper, SLOT(map()));
+    connect(tdoc, &QTextDocument::modificationChanged, [this, doc](bool) { onModificationChanged(doc); });
 
     return item;
 }

--- a/editors/sc-ide/widgets/doc_list.hpp
+++ b/editors/sc-ide/widgets/doc_list.hpp
@@ -24,7 +24,6 @@
 #include "../core/doc_manager.hpp"
 
 #include <QListWidget>
-#include <QSignalMapper>
 
 namespace ScIDE {
 
@@ -52,7 +51,7 @@ private Q_SLOTS:
     void onOpen(Document*, int, int);
     void onClose(Document*);
     void onSaved(Document*);
-    void onModificationChanged(QObject*);
+    void onModificationChanged(Document*);
     void onItemClicked(QListWidgetItem*);
 
 protected:
@@ -73,7 +72,6 @@ private:
     Item* addItemFor(Document*);
     Item* itemFor(Document*);
     Item* itemFor(QListWidgetItem*);
-    QSignalMapper mModificationMapper;
     QIcon mDocModifiedIcon;
     QList<Document*> dockletOrder;
 };

--- a/editors/sc-ide/widgets/main_window.cpp
+++ b/editors/sc-ide/widgets/main_window.cpp
@@ -164,7 +164,6 @@ MainWindow::MainWindow(Main* main): mMain(main), mClockLabel(0), mDocDialog(0) {
     connect(main->sessionManager(), SIGNAL(switchSessionRequest(Session*)), this, SLOT(switchSession(Session*)));
     connect(main->sessionManager(), SIGNAL(currentSessionNameChanged()), this, SLOT(updateWindowTitle()));
     // A system for easy evaluation of pre-defined code:
-    connect(&mCodeEvalMapper, SIGNAL(mapped(QString)), this, SIGNAL(evaluateCode(QString)));
     connect(this, SIGNAL(evaluateCode(QString, bool)), main->scProcess(), SLOT(evaluateCode(QString, bool)));
     // Interpreter: post output
     connect(main->scProcess(), SIGNAL(scPost(QString)), mPostDocklet->mPostWindow, SLOT(post(QString)));

--- a/editors/sc-ide/widgets/main_window.hpp
+++ b/editors/sc-ide/widgets/main_window.hpp
@@ -23,7 +23,6 @@
 #include <QLabel>
 #include <QMainWindow>
 #include <QProcess>
-#include <QSignalMapper>
 #include <QStatusBar>
 
 #include "util/status_box.hpp"
@@ -249,8 +248,6 @@ private:
 #ifdef SC_USE_QTWEBENGINE
     HelpBrowserDocklet* mHelpBrowserDocklet;
 #endif
-
-    QSignalMapper mCodeEvalMapper;
     DocumentsDialog* mDocDialog;
 
     QString mLastDocumentSavePath;

--- a/editors/sc-ide/widgets/multi_editor.cpp
+++ b/editors/sc-ide/widgets/multi_editor.cpp
@@ -293,8 +293,6 @@ MultiEditor::MultiEditor(Main* main, QWidget* parent):
 
     makeSignalConnections();
 
-    connect(&mDocModifiedSigMap, SIGNAL(mapped(QObject*)), this, SLOT(onDocModified(QObject*)));
-
     connect(main, SIGNAL(applySettingsRequest(Settings::Manager*)), this, SLOT(applySettings(Settings::Manager*)));
 
     createActions();
@@ -950,8 +948,7 @@ int MultiEditor::insertTab(Document* doc, int insertIndex) {
     tabIdx = mTabs->insertTab(insertIndex, icon, doc->title());
     mTabs->setTabData(tabIdx, QVariant::fromValue<Document*>(doc));
 
-    mDocModifiedSigMap.setMapping(tdoc, doc);
-    connect(tdoc, SIGNAL(modificationChanged(bool)), &mDocModifiedSigMap, SLOT(map()));
+    connect(tdoc, &QTextDocument::modificationChanged, [this, doc](bool) { onDocModified(doc); });
 
     return tabIdx;
 }
@@ -1014,8 +1011,7 @@ void MultiEditor::onClose(Document* doc) {
     // TODO: each box should switch document according to their own history
 }
 
-void MultiEditor::onDocModified(QObject* object) {
-    Document* doc = qobject_cast<Document*>(object);
+void MultiEditor::onDocModified(Document* doc) {
     if (!doc)
         return;
 

--- a/editors/sc-ide/widgets/multi_editor.hpp
+++ b/editors/sc-ide/widgets/multi_editor.hpp
@@ -31,7 +31,6 @@
 #include <QGridLayout>
 #include <QTextDocument>
 #include <QSplitter>
-#include <QSignalMapper>
 
 namespace ScIDE {
 
@@ -180,7 +179,7 @@ private slots:
     void onCurrentTabChanged(int index);
     void onCurrentEditorChanged(GenericCodeEditor*);
     void onBoxActivated(CodeEditorBox*);
-    void onDocModified(QObject*);
+    void onDocModified(Document*);
     void updateDocOrder(int, int);
 
 private:
@@ -210,7 +209,6 @@ private:
 
     SignalMultiplexer* mEditorSigMux;
     SignalMultiplexer* mBoxSigMux;
-    QSignalMapper mDocModifiedSigMap;
 
     // gui
     QTabBar* mTabs;

--- a/editors/sc-ide/widgets/post_window.cpp
+++ b/editors/sc-ide/widgets/post_window.cpp
@@ -163,7 +163,12 @@ void PostWindow::applySettings(Settings::Manager* settings) {
 
     QFontMetrics metrics(font);
     QString stringOfSpaces(settings->value("IDE/editor/indentWidth").toInt(), QChar(' '));
+
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 11, 0))
+    setTabStopDistance(metrics.horizontalAdvance(stringOfSpaces));
+#else
     setTabStopWidth(metrics.width(stringOfSpaces));
+#endif
 
     updateActionShortcuts(settings);
 }

--- a/editors/sc-ide/widgets/util/icon_list_widget.hpp
+++ b/editors/sc-ide/widgets/util/icon_list_widget.hpp
@@ -39,7 +39,11 @@ public:
             QString text = index.data(Qt::DisplayRole).toString();
             QFontMetrics fm(option.font);
 
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 11, 0))
+            int fontWidth = fm.horizontalAdvance(text);
+#else
             int fontWidth = fm.width(text);
+#endif
 
             QSize requiredSize(qMax(fontWidth, iconSize.width()), fm.height() + iconSize.height());
 


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

Qt has started issuing deprecation warnings - this PR addresses as many of them as possible while maintaining compatibility.

These aren't particularly high priority, but just to get ahead of it where possible.

~~Everything here uses 5.0 compatible fixes.~~

~~For those that need a more recent Qt version, I've added TODO notes with the code to uncomment when the time comes - some things need 5.10, etc. and I wasn't sure we were ready to enforce that.~~

EDIT: Compile-time checks of Qt versions switch in newer code where required.

Commit history outlines the details - most of them relate the use of QSignalMapper, which hasn't been necessary since 5.0 with C++11.

Features affected/to test:
- [x] Document modifications still update the icon in QTabWidget (Windows doesn't have an icon for this, so Mac and Linux need checking).
- [x] Document modifications still update the icons in split view
- [x] Window reporting geometry:
```supercollider
Window.availableBounds; // should be screen size - a bit for toolbars etc
Window.screenBounds; // should be screen size
```

## Types of changes

- Bug fix (?)

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] This PR is ready for review
