### PR TITLE
[tools] Cmake gen: fix caching of SC_PATH

### DIFF
--- a/tools/cmake_gen/CMakeLists_header.template
+++ b/tools/cmake_gen/CMakeLists_header.template
@@ -29,7 +29,7 @@ include(InstallRequiredSystemLibraries)
 sc_check_sc_path("${SC_PATH}")
 message(STATUS "Found SuperCollider: ${SC_PATH}")
 set(SC_PATH "${SC_PATH}" CACHE PATH
-    "Path to SuperCollider source. Relative paths are treated as relative to this script")
+    "Path to SuperCollider source. Relative paths are treated as relative to this script" FORCE)
 
 include("${SC_PATH}/SCVersion.txt")
 set(SC_VERSION "${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}${PROJECT_VERSION_PATCH}")


### PR DESCRIPTION
Purpose and motivation
-------------------------

This fixes
https://github.com/supercollider/cookiecutter-supercollider-plugin/issues/17

having a non-cache var with the same name as a cache var leads to
problems. also use FORCE so users can change it with ease.

Types of changes
----------------

- Bug fix (non-breaking change which fixes an issue)

Checklist
---------

<!--- Complete an item by checking it: [x] -->

- [x] All tests are passing - i have tested this locally and am very
certain this fixes the issue
- [x] If necessary, new tests were created to address changes in PR, and tests are passing
- [x] Updated documentation, if necessary
- [x] This PR is ready for review