### PR TITLE
tests: cleanup TestUnitTest.sc

### DIFF
--- a/testsuite/classlibrary/TestUnitTest.sc
+++ b/testsuite/classlibrary/TestUnitTest.sc
@@ -1,28 +1,13 @@
 TestUnitTest : UnitTest {
 
-	var someVar, toreDown, count=0;
+	var someVar;
 
 	setUp {
 		someVar = \setUp;
-		count = count + 1;
-	}
-	tearDown {
-		someVar = \tearDown;
-		toreDown = true;
 	}
 
 	test_setUp {
-		this.assertEquals(count, 1, "count should be on 1");
 		this.assertEquals(someVar, \setUp, "someVar be set in setUp");
-	}
-
-	test_toreDown{
-		this.assertEquals(toreDown, true, "toreDown should be set at the end of the last test");
-		this.assertEquals(count, 2, "count should be on 2");
-	}
-
-	test_setUp2 {
-		this.assertEquals(count, 3, "count should be on 3");
 	}
 
 	test_bootServer {
@@ -35,21 +20,6 @@ TestUnitTest : UnitTest {
 	test_assert {
 		this.assert(true, "assert(true) should certainly work");
 	}
-
-	/*
-	test_failure {
-		this.assert( false, "should fail")
-	}
-	*/
-
-	/*
-	test_assertAsynch {
-		Server.default.boot;
-		this.assertAsynch( Server.default.serverRunning, {
-			this.assert( Server.default.serverRunning,"server is indeed running");
-			}, "assert asynch should have triggered the server to boot and then run the test block");
-	}
-	*/
 
 	test_findTestedClass {
 		this.assertEquals(TestMixedBundleTester.findTestedClass, MixedBundleTester)
@@ -73,11 +43,4 @@ TestUnitTest : UnitTest {
 	test_assertNoException_nonThrowingFunction {
 		this.assertNoException({ try { 1789.monarchy } }, "assertNoThrow should return true for not an error")
 	}
-
-	/*** IF YOU ADD MORE TESTS, UPDATE THE numTestMethods var ***/
-	// test_findTestMethods {
-	// 	var numTestMethods = 7;
-	// 	this.assert( this.findTestMethods.size == numTestMethods, "should be " + numTestMethods + " test methods");
-	// }
 }
-


### PR DESCRIPTION
Purpose and Motivation
----------------------

remove tests that rely on faulty assumptions. in particular, tests
should not assume that anything other than `setUp` should run before the
test, and `tearDown` after the test.

remove commented out tests.

Types of changes
----------------

- Bug fix (non-breaking change which fixes an issue)

Checklist
---------

- [x] All tests are passing - tests pass locally
- [x] If necessary, new tests were created to address changes in PR, and tests are passing
- [x] Updated documentation, if necessary
- [x] This PR is ready for review