### PR TITLE
Deprecate -plotColors

### DIFF
--- a/HelpSource/Classes/Plotter.schelp
+++ b/HelpSource/Classes/Plotter.schelp
@@ -290,7 +290,7 @@ plot.domain_(domain);
 ::
 A more elaborate example can be found in the link::#examples::.
 
-method:: plotColors
+method:: plotColor
 Set or get the link::Classes/Color::(s) of your plot. An
 link::Classes/Array:: of colors will be mapped across multichannel plot
 data, including when link::#-superpose:: is code::true::.
@@ -333,6 +333,8 @@ a.editFunc = { |plotter, plotIndex, i, val|
 a.parent.onClose = { x.release };
 );
 ::
+
+private:: plotColors
 
 examples::
 

--- a/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
+++ b/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
@@ -424,7 +424,7 @@ Plotter {
 
 	var <>name, <>bounds, <>parent;
 	var <value, <data, <domain;
-	var <plots, <specs, <domainSpecs, <plotColors;
+	var <plots, <specs, <domainSpecs, <plotColor;
 	var <cursorPos, <>plotMode = \linear, <>editMode = false, <>normalized = false;
 	var <>resolution = 1, <>findSpecs = true, <superpose = false;
 	var modes, <interactionView;
@@ -690,7 +690,7 @@ Plotter {
 		plots !? { plots = plots.keep(data.size.neg) };
 		plots = plots ++ template.dup(data.size - plots.size);
 		plots.do { |plot, i| plot.value = data.at(i) };
-		plotColors !? { this.plotColors_(plotColors) };
+		plotColor !? { this.plotColor_(plotColor) };
 		this.updatePlotSpecs;
 		this.updatePlotBounds;
 	}
@@ -744,11 +744,11 @@ Plotter {
 		}
 	}
 
-	plotColors_ { |argColors|
-		plotColors = argColors.as(Array);
+	plotColor_ { |colors|
+		plotColor = colors.as(Array);
 		plots.do { |plt, i|
 			// rotate colors to ensure proper behavior with superpose
-			plt.plotColor_(plotColors.rotate(i.neg))
+			plt.plotColor_(plotColor.rotate(i.neg))
 		}
 	}
 
@@ -947,7 +947,7 @@ Plotter {
 			^{ In.kr(this.index, this.numChannels) }.plot(duration, this.server, bounds, minval, maxval, separately);
 		});
 	}
-	
+
 	plotAudio { |duration = 0.01, minval = -1, maxval = 1, bounds|
 		^this.plot(duration, bounds, minval, maxval)
 	}

--- a/SCClassLibrary/deprecated/3.10/Plotter.sc
+++ b/SCClassLibrary/deprecated/3.10/Plotter.sc
@@ -1,0 +1,11 @@
++ Plotter {
+	plotColors {
+		this.deprecated(thisMethod, this.class.findMethod(\plotColor));
+		^this.plotColor;
+	}
+
+	plotColors_ { |argColors|
+		this.deprecated(thisMethod, this.class.findMethod(\plotColor_));
+		^this.plotColor_(argColors);
+	}
+}

--- a/testsuite/classlibrary/TestPlotter.sc
+++ b/testsuite/classlibrary/TestPlotter.sc
@@ -1,13 +1,13 @@
 TestPlotter : UnitTest {
 
-	test_set_plotColors_and_superpose {
+	test_set_plotColor_and_superpose {
 		var data, cols, plot;
 
 		data = 3.collect{15.collect{rrand(0.0, 3.0)}};
 		cols = 3.collect{Color.rand};
 
 		// set each plot to unique color, then superpose
-		plot = data.plot.plotColors_(cols);
+		plot = data.plot.plotColor_(cols);
 		plot.superpose_(true);
 
 		this.assertEquals(
@@ -15,7 +15,7 @@ TestPlotter : UnitTest {
 			cols,
 			format(
 				"The color of the superposed plot:\n\t[%]\n"
-				"\tshould match Plotter's plotColors (in order) when superpose = true.:\n\t[%]\n",
+				"\tshould match Plotter's plotColor (in order) when superpose = true.:\n\t[%]\n",
 				plot.plots[0].plotColor,
 				cols,
 			), report: false
@@ -29,7 +29,7 @@ TestPlotter : UnitTest {
 			cols,
 			format(
 				"The first color of each individual plot:\n\t[%]\n"
-				"\tshould match Plotter's plotColors (in order) when superpose = false.:\n\t[%]\n",
+				"\tshould match Plotter's plotColor (in order) when superpose = false.:\n\t[%]\n",
 				plot.plots.collect({|plt, i| plt.plotColor[0]}),
 				cols,
 			), report: false


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

As indicated in https://github.com/supercollider/supercollider/pull/4510#issuecomment-515826646, #4082 introduced `Plotter -plotColors` and it got into 3.10.3. PRs related to #4510, particularly #4459, are still in the process of being reviewed. This was a larger rework of `Plotter` and the latter PR plans to rename the method in question to singular `-plotColor` for consistency (see https://github.com/supercollider/supercollider/pull/4459#issuecomment-507089578).

Since it seems like the singular form was preferred, AFAIU from the review of #4459, I propose to deprecate the plural method name ASAP to discourage its use. 

@mtmccrea since `-plotColors` got into 3.10.3 and the PR reverting it did not, it seems that we need to deprecate the method before removing it. Is that OK with you?

## Types of changes

<!-- Delete lines that don't apply -->

- Documentation
- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review
