### PR TITLE
sclang: LanguageConfig store fix

### DIFF
--- a/HelpSource/Classes/LanguageConfig.schelp
+++ b/HelpSource/Classes/LanguageConfig.schelp
@@ -23,7 +23,7 @@ Store the current configuration to file. Throws an error if the config file cann
 writing fails.
 
 argument:: file
-Path to the configuration file to store. If the value is code::nil:: it defaults to code::Platform.userConfigDir +/+ "sclang_conf.yaml"::
+Path to the configuration file to store. If the value is code::nil:: it defaults to currently used configuration file, as specified in the IDE preferences, or by the code::sclang -l "/path/to/sclang_conf.yaml":: argument. By default this is code::Platform.userConfigDir +/+ "sclang_conf.yaml"::
 
 subsection:: Library Path Handling
 

--- a/lang/LangPrimSource/PyrPrimitive.cpp
+++ b/lang/LangPrimSource/PyrPrimitive.cpp
@@ -3643,9 +3643,11 @@ static int prLanguageConfig_writeConfigFile(struct VMGlobals* g, int numArgsPush
             return errWrongType;
 
         config_path = SC_Codecvt::utf8_str_to_path(path);
-        gLanguageConfig->writeLibraryConfigYAML(config_path);
     } else {
-        config_path = SC_Filesystem::instance().getDirectory(SC_Filesystem::DirName::UserConfig) / "sclang_conf.yaml";
+        config_path = SC_Codecvt::path_to_utf8_str(gLanguageConfig->getConfigPath());
+        if (config_path.empty())
+            config_path = SC_Filesystem::instance().getDirectory(SC_Filesystem::DirName::UserConfig)
+                / SCLANG_YAML_CONFIG_FILENAME;
     }
 
     if (!gLanguageConfig->writeLibraryConfigYAML(config_path))

--- a/lang/LangSource/SC_LanguageConfig.cpp
+++ b/lang/LangSource/SC_LanguageConfig.cpp
@@ -41,7 +41,7 @@ static const char* INCLUDE_PATHS = "includePaths";
 static const char* EXCLUDE_PATHS = "excludePaths";
 static const char* POST_INLINE_WARNINGS = "postInlineWarnings";
 static const char* CLASS_LIB_DIR_NAME = "SCClassLibrary";
-static const char* SCLANG_YAML_CONFIG_FILENAME = "sclang_conf.yaml";
+const char* SCLANG_YAML_CONFIG_FILENAME = "sclang_conf.yaml";
 
 using DirName = SC_Filesystem::DirName;
 namespace bfs = boost::filesystem;

--- a/lang/LangSource/SC_LanguageConfig.hpp
+++ b/lang/LangSource/SC_LanguageConfig.hpp
@@ -29,6 +29,7 @@
 
 class SC_LanguageConfig;
 extern SC_LanguageConfig* gLanguageConfig;
+extern const char* SCLANG_YAML_CONFIG_FILENAME;
 
 /**
  * \brief Language configuration settings.


### PR DESCRIPTION
Use the currently specified config file when saving language configuration

<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->
Fixes #4595 

I couldn't get the [proposed fix](https://github.com/supercollider/supercollider/issues/4595#issuecomment-534786390) to work - adding anything in the language method before calling the sclang primitive causes errors - there doesn't seem to be a way to modify the argument in sclang before calling the primitive.

~~This seems like a proper fix, but there's one area for improvement, see below.~~
## Types of changes

<!-- Delete lines that don't apply -->

- Documentation
- Bug fix
- Breaking change

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [ ] ~~All tests are passing - does this need tests?~~
- [x] Updated documentation
- [x] This PR is ready for review
