### PR TITLE
Travis: use travis_retry and force correct installation of dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,9 +31,7 @@ cache:
  - ccache
 
 before_install:
-# Retry installation on OSX because Homebrew can be unreliable
- - if [[ $TRAVIS_OS_NAME == osx ]]; then travis_retry $TRAVIS_BUILD_DIR/.travis/before-install-osx.sh --qt=$QT
- - if [[ $TRAVIS_OS_NAME == linux ]]; then $TRAVIS_BUILD_DIR/.travis/before-install-linux.sh --qt=$QT
+ - $TRAVIS_BUILD_DIR/.travis/before-install-$TRAVIS_OS_NAME.sh --qt=$QT
 
 before_script:
  - mkdir BUILD && cd BUILD

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,9 @@ cache:
  - ccache
 
 before_install:
- - $TRAVIS_BUILD_DIR/.travis/before-install-$TRAVIS_OS_NAME.sh --qt=$QT
+# Retry installation on OSX because Homebrew can be unreliable
+ - if [[ $TRAVIS_OS_NAME == osx ]]; then travis_retry $TRAVIS_BUILD_DIR/.travis/before-install-osx.sh --qt=$QT
+ - if [[ $TRAVIS_OS_NAME == linux ]]; then $TRAVIS_BUILD_DIR/.travis/before-install-linux.sh --qt=$QT
 
 before_script:
  - mkdir BUILD && cd BUILD

--- a/.travis/before-install-osx.sh
+++ b/.travis/before-install-osx.sh
@@ -2,11 +2,11 @@
 
 export HOMEBREW_NO_ANALYTICS=1
 
-brew install libsndfile || true
-brew install portaudio || true
-brew install ccache || true
-brew install qt5 || true
-brew link qt5 --force
+travis_retry brew install libsndfile || exit 1
+travis_retry brew install portaudio || exit 2
+travis_retry brew install ccache || exit 3
+travis_retry brew install qt5 || exit 4
+travis_retry brew link qt5 --force || exit 5
 
 # according to https://docs.travis-ci.com/user/caching#ccache-cache
 export PATH="/usr/local/opt/ccache/libexec:$PATH"

--- a/.travis/before-install-osx.sh
+++ b/.travis/before-install-osx.sh
@@ -2,7 +2,7 @@
 
 export HOMEBREW_NO_ANALYTICS=1
 
-brew install libsndfile || exit 1
+brew install libsndfile || brew install libsndfile || exit 1
 brew install portaudio || exit 2
 brew install ccache || exit 3
 brew install qt5 || exit 4

--- a/.travis/before-install-osx.sh
+++ b/.travis/before-install-osx.sh
@@ -2,11 +2,11 @@
 
 export HOMEBREW_NO_ANALYTICS=1
 
-travis_retry brew install libsndfile || exit 1
-travis_retry brew install portaudio || exit 2
-travis_retry brew install ccache || exit 3
-travis_retry brew install qt5 || exit 4
-travis_retry brew link qt5 --force || exit 5
+brew install libsndfile || exit 1
+brew install portaudio || exit 2
+brew install ccache || exit 3
+brew install qt5 || exit 4
+brew link qt5 --force || exit 5
 
 # according to https://docs.travis-ci.com/user/caching#ccache-cache
 export PATH="/usr/local/opt/ccache/libexec:$PATH"


### PR DESCRIPTION
Purpose and Motivation
----------------------

may fix an issue discussed on sc-users. we always want to be using the libsndfile
from homebrew. if it's not installed, CMake will still find the system
installed one which does not have FLAC support among other things.

Types of changes
----------------

- Bug fix (non-breaking change which fixes an issue)

Checklist
---------

- [x] All tests are passing
- [x] If necessary, new tests were created to address changes in PR, and tests are passing
- [x] Updated documentation, if necessary
- [x] This PR is ready for review