### PR TITLE
macOS: fix IDE-less build

### DIFF
--- a/lang/CMakeLists.txt
+++ b/lang/CMakeLists.txt
@@ -295,9 +295,11 @@ if(LTO)
 endif()
 
 if(APPLE)
-    add_custom_command(TARGET sclang POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E make_directory $<TARGET_FILE_DIR:SuperCollider>/../MacOS/
-        COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_FILE:sclang> $<TARGET_FILE_DIR:SuperCollider>/../MacOS)
+    if(SC_IDE)
+        add_custom_command(TARGET sclang POST_BUILD
+            COMMAND ${CMAKE_COMMAND} -E make_directory $<TARGET_FILE_DIR:SuperCollider>/../MacOS/
+            COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_FILE:sclang> $<TARGET_FILE_DIR:SuperCollider>/../MacOS)
+    endif()
 elseif(WIN32)
     if(NOT MSVC)
         set_target_properties(sclang PROPERTIES RUNTIME_OUTPUT_DIRECTORY "$<CONFIG>")

--- a/server/plugins/CMakeLists.txt
+++ b/server/plugins/CMakeLists.txt
@@ -306,12 +306,13 @@ if (WIN32)
 	)
 
 elseif(APPLE)
-	foreach(plugin ${plugins} ${supernova_plugins})
-		add_custom_command(TARGET ${plugin} POST_BUILD
-			COMMAND ${CMAKE_COMMAND} -E make_directory $<TARGET_FILE_DIR:SuperCollider>/../Resources/plugins/
-			COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_FILE:${plugin}> $<TARGET_FILE_DIR:SuperCollider>/../Resources/plugins/)
-	endforeach()
-
+    if(SC_IDE)
+        foreach(plugin ${plugins} ${supernova_plugins})
+            add_custom_command(TARGET ${plugin} POST_BUILD
+                COMMAND ${CMAKE_COMMAND} -E make_directory $<TARGET_FILE_DIR:SuperCollider>/../Resources/plugins/
+                COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_FILE:${plugin}> $<TARGET_FILE_DIR:SuperCollider>/../Resources/plugins/)
+        endforeach()
+    endif()
 else()
 	install(TARGETS ${plugins} ${supernova_plugins}
 			DESTINATION "lib${LIB_SUFFIX}/SuperCollider/plugins"

--- a/server/scsynth/CMakeLists.txt
+++ b/server/scsynth/CMakeLists.txt
@@ -232,9 +232,11 @@ else()
 endif()
 
 if(APPLE)
-	add_custom_command(TARGET scsynth POST_BUILD
-		COMMAND ${CMAKE_COMMAND} -E make_directory $<TARGET_FILE_DIR:SuperCollider>/../Resources/
-		COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_FILE:scsynth> $<TARGET_FILE_DIR:SuperCollider>/../Resources)
+    if(SC_IDE)
+        add_custom_command(TARGET scsynth POST_BUILD
+            COMMAND ${CMAKE_COMMAND} -E make_directory $<TARGET_FILE_DIR:SuperCollider>/../Resources/
+            COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_FILE:scsynth> $<TARGET_FILE_DIR:SuperCollider>/../Resources)
+    endif()
 elseif(WIN32)
     if(NOT MSVC)
       set_target_properties(scsynth libscsynth PROPERTIES RUNTIME_OUTPUT_DIRECTORY "$<CONFIG>")

--- a/server/supernova/CMakeLists.txt
+++ b/server/supernova/CMakeLists.txt
@@ -205,9 +205,11 @@ if(WIN32)
     )
 
 elseif(APPLE)
-    add_custom_command(TARGET supernova POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E make_directory $<TARGET_FILE_DIR:SuperCollider>/../Resources/
-        COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_FILE:supernova> $<TARGET_FILE_DIR:SuperCollider>/../Resources)
+    if(SC_IDE)
+        add_custom_command(TARGET supernova POST_BUILD
+            COMMAND ${CMAKE_COMMAND} -E make_directory $<TARGET_FILE_DIR:SuperCollider>/../Resources/
+            COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_FILE:supernova> $<TARGET_FILE_DIR:SuperCollider>/../Resources)
+    endif()
 else()
   install(TARGETS supernova
           DESTINATION "bin"


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

This allows for configuration and generation of the build system on macOS using -DSC_IDE and -DSC_QT, and thus allows users to build subsets of SC (sclang, scsynth) without having Qt libraries installed.

however, this does NOT support the `install` target, and i have no idea what would happen if you tried to run it. obviously, creating an app bundle with just sclang and scsynth wouldn't make much sense anyway. some major changes would need to happen to make that possible. if anyone thinks that is something worth warning users about, let's think of a way to do so cleanly and clearly. i personally think it is fine the way it is.

this is the _bare minimum needed_ to support https://github.com/VCVRack/VCV-Prototype/pull/24

## Types of changes

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review
