### PR TITLE
Fix OSC{Func,def}.newMatching by reversing arguments to lo_pattern_match

### DIFF
--- a/lang/LangPrimSource/PyrSymbolPrim.cpp
+++ b/lang/LangPrimSource/PyrSymbolPrim.cpp
@@ -535,7 +535,7 @@ int prSymbol_matchOSCPattern(struct VMGlobals* g, int numArgsPushed) {
     //	int32 alen = slotRawSymbol(a)->length;
     //	int32 blen = slotRawSymbol(b)->length;
     //	length = sc_min(alen, blen);
-    if (lo_pattern_match(slotRawSymbol(a)->name, slotRawSymbol(b)->name)) {
+    if (lo_pattern_match(slotRawSymbol(b)->name, slotRawSymbol(a)->name)) {
         SetTrue(a);
     } else {
         SetFalse(a);


### PR DESCRIPTION
Prompted by a recent question on sc-users, I tried to use
( OSCdef.newMatching(\match, {|...args| args.postln}, '/osc[1-3]') 
NetAddr("127.0.0.1", 57120).sendMsg('/osc1')
) and realized it doesn't work.

Digging deep, it turns out the arguments to lo_pattern_match are accidentally 
reversed.  lo_pattern_match takes the pattern as second argument.