### PR TITLE
class library: fix def proxy dup

### DIFF
--- a/SCClassLibrary/JITLib/Patterns/Pdef.sc
+++ b/SCClassLibrary/JITLib/Patterns/Pdef.sc
@@ -274,10 +274,13 @@ Pdefn : PatternProxy {
 	}
 
 	storeArgs { ^[key] } // assume it was created globally
+
 	copy { |toKey|
-		if(key == toKey) { Error("cannot copy to identical key").throw };
+		if(toKey.isNil or: { key == toKey }) { Error("cannot copy to identical key").throw };
 		^this.class.new(toKey).copyState(this)
 	}
+
+	dup { |n = 2| ^{ this }.dup(n) }
 
 	prAdd { arg argKey;
 		key = argKey;
@@ -416,9 +419,12 @@ Tdef : TaskProxy {
 	storeArgs { ^[key] }
 
 	copy { |toKey|
-		if(key == toKey) { Error("cannot copy to identical key").throw };
+		if(toKey.isNil or: { key == toKey }) { Error("cannot copy to identical key").throw };
 		^this.class.new(toKey).copyState(this)
 	}
+
+	dup { |n = 2| ^{ this }.dup(n) }
+
 
 	prAdd { arg argKey;
 		key = argKey;
@@ -608,9 +614,11 @@ Pdef : EventPatternProxy {
 	}
 
 	copy { |toKey|
-		if(key == toKey) { Error("cannot copy to identical key").throw };
+		if(toKey.isNil or: { key == toKey }) { Error("cannot copy to identical key").throw };
 		^this.class.new(toKey).copyState(this)
 	}
+
+	dup { |n = 2| ^{ this }.dup(n) }
 
 	*hasGlobalDictionary { ^true }
 

--- a/SCClassLibrary/JITLib/Patterns/Pdef.sc
+++ b/SCClassLibrary/JITLib/Patterns/Pdef.sc
@@ -276,7 +276,7 @@ Pdefn : PatternProxy {
 	storeArgs { ^[key] } // assume it was created globally
 
 	copy { |toKey|
-		if(toKey.isNil or: { key == toKey }) { Error("cannot copy to identical key").throw };
+		if(toKey.isNil or: { key == toKey }) { Error("can only copy to new key (key is %)".format(toKey)).throw };
 		^this.class.new(toKey).copyState(this)
 	}
 
@@ -419,7 +419,7 @@ Tdef : TaskProxy {
 	storeArgs { ^[key] }
 
 	copy { |toKey|
-		if(toKey.isNil or: { key == toKey }) { Error("cannot copy to identical key").throw };
+		if(toKey.isNil or: { key == toKey }) { Error("can only copy to new key (key is %)".format(toKey)).throw };
 		^this.class.new(toKey).copyState(this)
 	}
 
@@ -614,7 +614,7 @@ Pdef : EventPatternProxy {
 	}
 
 	copy { |toKey|
-		if(toKey.isNil or: { key == toKey }) { Error("cannot copy to identical key").throw };
+		if(toKey.isNil or: { key == toKey }) { Error("can only copy to new key (key is %)".format(toKey)).throw };
 		^this.class.new(toKey).copyState(this)
 	}
 

--- a/SCClassLibrary/JITLib/Patterns/Pdef.sc
+++ b/SCClassLibrary/JITLib/Patterns/Pdef.sc
@@ -425,7 +425,6 @@ Tdef : TaskProxy {
 
 	dup { |n = 2| ^{ this }.dup(n) } // avoid copy in Object::dup
 
-
 	prAdd { arg argKey;
 		key = argKey;
 		all.put(argKey, this);

--- a/SCClassLibrary/JITLib/Patterns/Pdef.sc
+++ b/SCClassLibrary/JITLib/Patterns/Pdef.sc
@@ -280,7 +280,7 @@ Pdefn : PatternProxy {
 		^this.class.new(toKey).copyState(this)
 	}
 
-	dup { |n = 2| ^{ this }.dup(n) }
+	dup { |n = 2| ^{ this }.dup(n) } // avoid copy in Object::dup
 
 	prAdd { arg argKey;
 		key = argKey;
@@ -423,7 +423,7 @@ Tdef : TaskProxy {
 		^this.class.new(toKey).copyState(this)
 	}
 
-	dup { |n = 2| ^{ this }.dup(n) }
+	dup { |n = 2| ^{ this }.dup(n) } // avoid copy in Object::dup
 
 
 	prAdd { arg argKey;
@@ -618,7 +618,7 @@ Pdef : EventPatternProxy {
 		^this.class.new(toKey).copyState(this)
 	}
 
-	dup { |n = 2| ^{ this }.dup(n) }
+	dup { |n = 2| ^{ this }.dup(n) } // avoid copy in Object::dup
 
 	*hasGlobalDictionary { ^true }
 

--- a/SCClassLibrary/JITLib/ProxySpace/NodeProxy.sc
+++ b/SCClassLibrary/JITLib/ProxySpace/NodeProxy.sc
@@ -1051,7 +1051,7 @@ Ndef : NodeProxy {
 	}
 
 	copy { |toKey|
-		if(toKey.isNil or: { key == toKey }) { Error("cannot copy to identical key").throw };
+		if(toKey.isNil or: { key == toKey }) { Error("can only copy to new key (key is %)".format(toKey)).throw };
 		^this.class.new(toKey).copyState(this)
 	}
 

--- a/SCClassLibrary/JITLib/ProxySpace/NodeProxy.sc
+++ b/SCClassLibrary/JITLib/ProxySpace/NodeProxy.sc
@@ -1055,7 +1055,7 @@ Ndef : NodeProxy {
 		^this.class.new(toKey).copyState(this)
 	}
 
-	dup { |n = 2| ^{ this }.dup(n) }
+	dup { |n = 2| ^{ this }.dup(n) } // avoid copy in Object::dup
 
 	proxyspace {
 		^this.class.dictFor(this.server)

--- a/SCClassLibrary/JITLib/ProxySpace/NodeProxy.sc
+++ b/SCClassLibrary/JITLib/ProxySpace/NodeProxy.sc
@@ -1051,9 +1051,11 @@ Ndef : NodeProxy {
 	}
 
 	copy { |toKey|
-		if(key == toKey) { Error("cannot copy to identical key").throw };
+		if(toKey.isNil or: { key == toKey }) { Error("cannot copy to identical key").throw };
 		^this.class.new(toKey).copyState(this)
 	}
+
+	dup { |n = 2| ^{ this }.dup(n) }
 
 	proxyspace {
 		^this.class.dictFor(this.server)

--- a/testsuite/classlibrary/TestNodeProxy.sc
+++ b/testsuite/classlibrary/TestNodeProxy.sc
@@ -235,4 +235,14 @@ TestNodeProxy : UnitTest {
 		this.assertEquals(oldProxy.nodeMap, newProxy.nodeMap);
 	}
 
+	test_copy_independent {
+		var copied;
+		proxy.source = 1967;
+		copied = proxy.copy;
+		copied.source = 1968;
+		this.assertEquals(proxy.source, 1967, "copying a proxy should return an independent object");
+	}
+
+
+
 }

--- a/testsuite/classlibrary/TestNodeProxy.sc
+++ b/testsuite/classlibrary/TestNodeProxy.sc
@@ -244,5 +244,4 @@ TestNodeProxy : UnitTest {
 	}
 
 
-
 }


### PR DESCRIPTION
When no key was passed into `copy` for an Ndef (and analogous classes),
it would fail obscurely. This happens easily, e.g. in `dup`. It is good
to throw an error, because usually one expects copy to return a
separate object. But in cases like `dup`, a copy isn’t needed.



## Purpose and Motivation

This fixes #4685.

## Types of changes

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] This PR is ready for review

Separate documentation isn't needed, because arguably it now just behaves as expected.