### PR TITLE
CMake: always use current year for end date of copyright range

### DIFF
--- a/cmake_modules/MacOSXBundleInfo.plist.in
+++ b/cmake_modules/MacOSXBundleInfo.plist.in
@@ -144,7 +144,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}${PROJECT_VERSION_PATCH}</string>
 	<key>NSHumanReadableCopyright</key>
-	<string>(C) 2001-2018 James McCartney et al.</string>
+	<string>(C) 2001-${CURRENT_YEAR} James McCartney et al.</string>
 	<key>NSMainNibFile</key>
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>

--- a/editors/sc-ide/CMakeLists.txt
+++ b/editors/sc-ide/CMakeLists.txt
@@ -368,6 +368,8 @@ if(APPLE)
 
     # set how it shows up in the Info.plist file
     SET(MACOSX_BUNDLE_ICON_FILE ../../icons/sc_ide.icns)
+    # ensure copyright in plist file always says current year as end date
+    string(TIMESTAMP CURRENT_YEAR "%Y")
 
     install(TARGETS SuperCollider
           DESTINATION ${scappbundlename})


### PR DESCRIPTION
Purpose and Motivation
----------------------

reported by @redfrik.

the end of the copyright range should definitely always be the current
year for a release.

Types of changes
----------------

- Bug fix (non-breaking change which fixes an issue)

Checklist
---------

<!--- Complete an item by checking it: [x] -->

- [x] All tests are passing - tested this locally
- [x] If necessary, new tests were created to address changes in PR, and tests are passing
- [x] Updated documentation, if necessary
- [x] This PR is ready for review