### PR TITLE
[scsynth] provide better error message when failing to open socket

### DIFF
--- a/HelpSource/Guides/Understanding-Errors.schelp
+++ b/HelpSource/Guides/Understanding-Errors.schelp
@@ -250,19 +250,6 @@ a.put(3, 1);
 [ nil, nil, nil, 1 ]
 ::
 
-section:: A common network error
-
-code::
-Exception in World_OpenUDP: unable to bind udp socket
-::
-This is because you have multiple servers running, left over from crashes, unexpected quits etc.
-One can't cause them to quit via OSC (the boot button).
-
-use this to remove them:
-code::
-Server.killAll
-::
-
 section:: A common warning
 code::
 WARNING: FunctionDef contains variable declarations and so will not be inlined.

--- a/server/supernova/server/main.cpp
+++ b/server/supernova/server/main.cpp
@@ -337,24 +337,33 @@ int main(int argc, char* argv[]) {
     cout << "compiled for debugging" << endl;
 #endif
 
-    server_shared_memory_creator::cleanup(args.port());
-    nova_server server(args);
-    register_signal_handler();
+    // FIXME should have more granular error handling
+    try {
+        server_shared_memory_creator::cleanup(args.port());
+        nova_server server(args);
+        register_signal_handler();
 
     set_plugin_paths(args, sc_factory.get());
     load_synthdefs(server, args);
 
-    if (!args.non_rt) {
-        try {
-            start_audio_backend(args);
-            cout << "Supernova ready" << endl;
-        } catch (exception const& e) {
-            cout << "Error: " << e.what() << endl;
-            exit(1);
-        }
-        EventLoop::run([&server]() { server.run(); });
-    } else
-        server.run_nonrt_synthesis(args);
+        if (!args.non_rt) {
+            try {
+                start_audio_backend(args);
+                cout << "Supernova ready" << endl;
+            } catch (exception const& e) {
+                cout << "\n*** ERROR: could not start audio backend: " << e.what() << endl;
+                exit(1);
+            }
+            EventLoop::run([&server]() { server.run(); });
+        } else
+            server.run_nonrt_synthesis(args);
+    } catch (const std::exception& exc) {
+        cout << "\n*** ERROR: in main(): " << exc.what() << endl;
+        exit(1);
+    } catch (...) {
+        cout << "\n*** ERROR: unknown error in main()" << endl;
+        exit(1);
+    }
 
     return 0;
 }

--- a/server/supernova/server/server.cpp
+++ b/server/supernova/server/server.cpp
@@ -321,9 +321,17 @@ void realtime_engine_functor::init_thread(void) {
     name_current_thread(0);
 }
 
-void realtime_engine_functor::log_(const char* str) { instance->log_printf(str); }
+void realtime_engine_functor::log_(const char* str) {
+    // Silently drop messages; if instance is null it means something failed while constructing nova_server
+    if (instance)
+        instance->log_printf(str);
+}
 
 void realtime_engine_functor::log_printf_(const char* fmt, ...) {
+    // Silently drop messages; if instance is null it means something failed while constructing nova_server
+    if (instance == nullptr)
+        return;
+
     va_list vargs;
     va_start(vargs, fmt);
     instance->log_printf(fmt, vargs);


### PR DESCRIPTION
## Purpose and Motivation

Fixes #3969, also refactor code so both UDP and TCP creation are treated similarly. the new function effectively acts as a glorified `make_unique`

i am testing it by just opening two terminals and running `scsynth -u 57110` and `scsynth -u 57110` in both.

similar fix for supernova coming soon

also remove a section of a help file that effectively re-explained this in a less effective way

## Types of changes

- Documentation
- Bug fix

## To-do list

- [x] add similar handling for supernova
- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review
