### PR TITLE
Fix some instances of broken spacing

### DIFF
--- a/HelpSource/Classes/EnvGen.schelp
+++ b/HelpSource/Classes/EnvGen.schelp
@@ -7,10 +7,9 @@ categories::  UGens>Envelopes
 Description::
 
 Plays back break point envelopes. The envelopes are instances of the
-link::Classes/Env:: class. The envelope and the arguments for  code::levelScale:: ,
-code::levelBias:: , and  code::timeScale::
-are polled when the EnvGen is triggered and remain constant for the
-duration of the envelope.
+link::Classes/Env:: class. The envelope and the arguments for  code::levelScale::,
+code::levelBias::, and  code::timeScale:: are polled when the EnvGen is
+triggered and remain constant for the duration of the envelope.
 
 code::
 { PinkNoise.ar(EnvGen.kr(Env.perc, doneAction: Done.freeSelf)) }.play

--- a/HelpSource/Classes/LFDNoise1.schelp
+++ b/HelpSource/Classes/LFDNoise1.schelp
@@ -6,9 +6,8 @@ categories::  UGens>Generators>Stochastic
 
 Description::
 
-Like  link::Classes/LFNoise1:: , it generates linearly interpolated
-random values at a rate given by the  code::freq::
-argument, with two differences:
+Like link::Classes/LFNoise1::, it generates linearly interpolated random
+values at a rate given by the code::freq:: argument, with two differences:
 list::
 ## no time quantization
 ## fast recovery from low freq values footnote::


### PR DESCRIPTION
There seems to be a corner-case in PROSE handling which leads to missing 
spaces.  In particular, if there is a code::word::
followed by normal text on a new line, HTML omits a space between
the closing tag and the text of the new line.
I can't tell how other browsers react, but here is how Lynx currently 
renders Classes/EnvGen. My in-development Emacs SCDoc renderer exposes the
same problem. Note the "word" "timeScaleare". Also note the extra spaces in
"levelScale , levelBias ,".

Description

    Plays back break point envelopes. The envelopes are instances of the
    Env class. The envelope and the arguments for levelScale , levelBias ,
    and timeScaleare polled when the EnvGen is triggered and remain
    constant for the duration of the envelope.