### PR TITLE
Versioning reform

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,7 @@
-project (SuperCollider)
+cmake_minimum_required(VERSION 3.5)
+include(SCVersion.txt)
+# CMake versions can only consist of digits and periods, so don't use _TWEAK
+project(SuperCollider VERSION ${SC_VERSION_MAJOR}.${SC_VERSION_MINOR}.${SC_VERSION_PATCH})
 
 if (CMAKE_SYSTEM_NAME MATCHES "Linux")
 	set(LINUX 1)
@@ -8,11 +11,7 @@ if(CMAKE_SYSTEM_NAME MATCHES "Linux|FreeBSD|DragonFly|OpenBSD|NetBSD")
     set(LINUX_OR_BSD 1)
 endif()
 
-cmake_minimum_required (VERSION 3.5)
-
-include("SCVersion.txt")
-set(PROJECT_VERSION "${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}${PROJECT_VERSION_PATCH}")
-message(STATUS "SuperCollider Version: ${PROJECT_VERSION}")
+message(STATUS "SuperCollider Version: ${SC_VERSION}")
 message(STATUS "Building from branch ${GIT_BRANCH}, commit hash is ${GIT_COMMIT_HASH}")
 include(CTest)
 enable_testing()
@@ -593,16 +592,17 @@ endif()
 #############################################
 # CPack support
 
-set(CPACK_PACKAGE_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
-set(CPACK_PACKAGE_VERSION_MINOR ${PROJECT_VERSION_MINOR})
-set(CPACK_PACKAGE_VERSION_PATCH ${PROJECT_VERSION_PATCH})
+set(CPACK_PACKAGE_VERSION_MAJOR ${SC_VERSION_MAJOR})
+set(CPACK_PACKAGE_VERSION_MINOR ${SC_VERSION_MINOR})
+# No restriction on version strings unlike for project()
+set(CPACK_PACKAGE_VERSION_PATCH ${SC_VERSION_PATCH}${SC_VERSION_TWEAK})
 
 if(APPLE)
 	set(CPACK_GENERATOR "DragNDrop")
 	set(CPACK_DMG_FORMAT "UDBZ")
 	set(CPACK_DMG_VOLUME_NAME "${scappbundlename}")
 	set(CPACK_SYSTEM_NAME "OSX")
-#	set(CPACK_PACKAGE_FILE_NAME "${scappbundlename}-${PROJECT_VERSION}")
+#	set(CPACK_PACKAGE_FILE_NAME "${scappbundlename}-${SC_VERSION}")
 	set(CPACK_DMG_DS_STORE "${CMAKE_SOURCE_DIR}/package/ds_store")
 	set(CPACK_DMG_BACKGROUND_IMAGE "${CMAKE_SOURCE_DIR}/package/background.png")
     set(CPACK_PACKAGE_ICON "${CMAKE_SOURCE_DIR}/icons/sc_ide.icns")

--- a/HelpSource/Classes/Main.schelp
+++ b/HelpSource/Classes/Main.schelp
@@ -27,18 +27,63 @@ method::version
 returns:: the current version as a human readable string
 
 method::versionAtLeast
-check if we are running at least version maj.min
+
+Returns code::true:: if we are running version maj.min.patch or newer, false otherwise. If code::min:: and/or
+code::patch:: are code::nil::, they will be treated as wildcards. The tweak part of the version is completely ignored.
+
+argument::maj
+Major version number as Integer.
+
+argument::min
+Minor version number as Integer, or code::nil::.
+
+argument::patch
+Patch version number as Integer, or code::nil::.
+
 code::
-Main.versionAtLeast( 3, 1 );
+Main.versionAtLeast(3, 10, 4);
 ::
-returns:: true or false
 
 method::versionAtMost
-check if we are running version maj.min or older
+
+Returns code::true:: if we are running version maj.min.patch or older, false otherwise. If code::min:: and/or
+code::patch:: are code::nil::, they will be treated as wildcards. The tweak part of the version is completely ignored.
+
+argument::maj
+Major version number as Integer.
+
+argument::min
+Minor version number as Integer, or code::nil::.
+
+argument::patch
+Patch version number as Integer, or code::nil::.
+
 code::
-Main.versionAtMost( 3, 1 );
+Main.versionAtMost(3, 13, 9);
 ::
-returns:: true or false
+
+method::scVersionMajor
+
+returns:: major version number as Integer
+
+method::scVersionMinor
+
+returns:: minor version number as Integer
+
+method::scVersionPatch
+
+returns:: patch version number as Integer
+
+method::scVersionTweak
+
+The "tweak" version is typically only used to distinguish pre-release versions of SC from proper releases. It may be
+empty.
+
+returns:: tweak version as a String
+
+method::scVersionPostfix
+
+Deprecated. Use code::scVersionPatch:: and code::scVersionTweak:: instead.
 
 instanceMethods::
 

--- a/HelpSource/Reference/Server-Command-Reference.schelp
+++ b/HelpSource/Reference/Server-Command-Reference.schelp
@@ -124,7 +124,7 @@ definitionlist::
 ## string || Program name. May be "scsynth" or "supernova".
 ## int || Major version number. Equivalent to sclang's code::Main.scVersionMajor::.
 ## int || Minor version number. Equivalent to sclang's code::Main.scVersionMinor::.
-## string || Patch version name. Equivalent to sclang's code::Main.scVersionPostfix::.
+## string || Patch version name. Equivalent to the sclang code code::"." ++ Main.scVersionPatch ++ Main.scVersionTweak::.
 ## string || Git branch name.
 ## string || First seven hex digits of the commit hash.
 ::

--- a/SCClassLibrary/DefaultLibrary/Main.sc
+++ b/SCClassLibrary/DefaultLibrary/Main.sc
@@ -131,34 +131,35 @@ Main : Process {
 		(class ? Object).browse;
 	}
 
-	*version {^[this.scVersionMajor, ".", this.scVersionMinor, this.scVersionPostfix].join}
+	*version { ^"%.%.%%".format(this.scVersionMajor, this.scVersionMinor, this.scVersionPatch, this.scVersionTweak) }
 
-	*scVersionMajor   {
-		_SC_VersionMajor
-		^this.primitiveFailed
-	}
-	*scVersionMinor   {
-		_SC_VersionMinor
-		^this.primitiveFailed
-	}
-	*scVersionPostfix {
-		_SC_VersionPatch
-		^this.primitiveFailed
-	}
-	*versionAtLeast { |maj, min|
-		^if((maj==this.scVersionMajor) and:{min.notNil}){
-			this.scVersionMinor >= min
-		}{
+	*scVersionMajor { _SC_VersionMajor ^this.primitiveFailed }
+	*scVersionMinor { _SC_VersionMinor ^this.primitiveFailed }
+	*scVersionPatch { _SC_VersionPatch ^this.primitiveFailed }
+	*scVersionTweak { _SC_VersionTweak ^this.primitiveFailed }
+
+	*versionAtLeast { |maj, min, patch|
+		^if((maj == this.scVersionMajor) and: { min.notNil }) {
+			if((min == this.scVersionMinor) and: { patch.notNil }) {
+				this.scVersionPatch >= patch
+			} {
+				this.scVersionMinor >= min
+			}
+		} {
 			this.scVersionMajor >= maj
-		};
+		}
 	}
 
-	*versionAtMost { |maj, min|
-		^if((maj==this.scVersionMajor) and:{min.notNil}){
-			this.scVersionMinor <= min
-		}{
+	*versionAtMost { |maj, min, patch|
+		^if((maj == this.scVersionMajor) and: { min.notNil }) {
+			if((min == this.scVersionMinor) and: { patch.notNil }) {
+				this.scVersionPatch <= patch
+			} {
+				this.scVersionMinor <= min
+			}
+		} {
 			this.scVersionMajor <= maj
-		};
+		}
 	}
 
 	pid {

--- a/SCClassLibrary/deprecated/3.10/Main.sc
+++ b/SCClassLibrary/deprecated/3.10/Main.sc
@@ -1,0 +1,6 @@
++ Main {
+	*scVersionPostfix {
+		this.deprecated(thisMethod, this.class.findMethod(\scVersionPatch));
+		^"." ++ this.scVersionPatch ++ this.scVersionTweak;
+	}
+}

--- a/SCVersion.txt
+++ b/SCVersion.txt
@@ -1,9 +1,19 @@
 # This file is included by CMakeLists.txt and is the single place where SC version should be updated.
 # Note that you need to "make install" for this information to be copied into all places.
 
-set(PROJECT_VERSION_MAJOR 3)
-set(PROJECT_VERSION_MINOR 10)
-set(PROJECT_VERSION_PATCH .4-rc1)
+set(SC_VERSION_MAJOR 3)
+set(SC_VERSION_MINOR 10)
+set(SC_VERSION_PATCH 4)
+set(SC_VERSION_TWEAK "-rc1")
+set(SC_VERSION ${SC_VERSION_MAJOR}.${SC_VERSION_MINOR}.${SC_VERSION_PATCH}${SC_VERSION_TWEAK})
+
+# Note: these are provided for backwards compatibility only. In the main project, PROJECT_VERSION_PATCH
+# will be stripped of anything after the patch number (e.g., "-beta1", "-rc2" will be removed).
+# Historically, the _PATCH version also included a leading period. New code and project should use the
+# SC_ variables above instead of these.
+set(PROJECT_VERSION_MAJOR ${SC_VERSION_MAJOR})
+set(PROJECT_VERSION_MINOR ${SC_VERSION_MINOR})
+set(PROJECT_VERSION_PATCH .${SC_VERSION_PATCH}${SC_VERSION_TWEAK})
 
 if(EXISTS "${CMAKE_SOURCE_DIR}/.git")
 

--- a/cmake_modules/MacOSXBundleInfo.plist.in
+++ b/cmake_modules/MacOSXBundleInfo.plist.in
@@ -140,9 +140,9 @@
 	<key>CFBundleSignature</key>
 	<string>SCjm</string>
 	<key>CFBundleVersion</key>
-	<string>${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}${PROJECT_VERSION_PATCH}</string>
+	<string>${SC_VERSION}</string>
 	<key>CFBundleShortVersionString</key>
-	<string>${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}${PROJECT_VERSION_PATCH}</string>
+	<string>${SC_VERSION}</string>
 	<key>NSHumanReadableCopyright</key>
 	<string>(C) 2001-${CURRENT_YEAR} James McCartney et al.</string>
 	<key>NSMainNibFile</key>

--- a/common/SC_Version.hpp.in
+++ b/common/SC_Version.hpp.in
@@ -21,18 +21,20 @@
 #include <string>
 #include <sstream>
 
-static const int SC_VersionMajor    = @PROJECT_VERSION_MAJOR@;
-static const int SC_VersionMinor    = @PROJECT_VERSION_MINOR@;
-static const char SC_VersionPatch[] = "@PROJECT_VERSION_PATCH@";
+static const int SC_VersionMajor = @SC_VERSION_MAJOR@;
+static const int SC_VersionMinor = @SC_VERSION_MINOR@;
+static const int SC_VersionPatch = @SC_VERSION_PATCH@;
+static const char SC_VersionTweak[] = "@SC_VERSION_TWEAK@";
 static const char SC_Branch[] = "@GIT_BRANCH@";
 static const char SC_CommitHash[] = "@GIT_COMMIT_HASH@";
+
+// For backward compatibility in scsynth and supernova only.
+static const char SC_VersionPostfix[] = ".@SC_VERSION_PATCH@@SC_VERSION_TWEAK@";
 
 static inline std::string SC_VersionString()
 {
 	std::stringstream out;
-	out << SC_VersionMajor << "."
-		<< SC_VersionMinor
-		<< SC_VersionPatch;
+	out << SC_VersionMajor << "." << SC_VersionMinor << "." << SC_VersionPatch << SC_VersionTweak;
 	return out.str();
 }
 

--- a/editors/sced/sced3/supercollider.plugin.in
+++ b/editors/sced/sced3/supercollider.plugin.in
@@ -7,4 +7,4 @@ Description=SuperCollider interaction plugin for gedit.
 Authors=Artem Popov <artfwo@gmail.com>;Eckard Riedenklau <eriedenk@techfak.uni-bielefeld.de>;Marije Baalman <nescivi AT gmail DOT com>;Jonatan Liljedahl <lijon@kymatica.com>
 Copyright=Copyright © 2006-2011 Artem Popov <artfwo@gmail.com>
 Website=http://supercollider.sourceforge.net
-Version=@PROJECT_VERSION@
+Version=@SC_VERSION@

--- a/lang/LangPrimSource/PyrPrimitive.cpp
+++ b/lang/LangPrimSource/PyrPrimitive.cpp
@@ -3690,7 +3690,13 @@ static int prVersionMinor(struct VMGlobals* g, int numArgsPushed) {
 
 static int prVersionPatch(struct VMGlobals* g, int numArgsPushed) {
     PyrSlot* result = g->sp;
-    SetObject(result, newPyrString(g->gc, SC_VersionPatch, 0, 1));
+    SetInt(result, SC_VersionPatch);
+    return errNone;
+}
+
+static int prVersionTweak(struct VMGlobals* g, int numArgsPushed) {
+    PyrSlot* result = g->sp;
+    SetObject(result, newPyrString(g->gc, SC_VersionTweak, 0, 1));
     return errNone;
 }
 
@@ -4258,6 +4264,7 @@ void initPrimitives() {
     definePrimitive(base, index++, "_SC_VersionMajor", prVersionMajor, 1, 0);
     definePrimitive(base, index++, "_SC_VersionMinor", prVersionMinor, 1, 0);
     definePrimitive(base, index++, "_SC_VersionPatch", prVersionPatch, 1, 0);
+    definePrimitive(base, index++, "_SC_VersionTweak", prVersionTweak, 1, 0);
 
     // void initOscilPrimitives();
     // void initControllerPrimitives();

--- a/platform/windows/CMakeLists.txt
+++ b/platform/windows/CMakeLists.txt
@@ -35,7 +35,7 @@ endif(MSVC)
 
 add_custom_target( installer
     COMMAND ${CMAKE_COMMAND}
-        "-DSC_VERSION=${PROJECT_VERSION}"
+        "-DSC_VERSION=${SC_VERSION}"
         "-DSC_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}"
         "-DNSIS_SCRIPT=${CMAKE_CURRENT_SOURCE_DIR}/supercollider.nsi"
         "-DSC_CUBE_PATH=${CMAKE_CURRENT_SOURCE_DIR}/Resources/sc_cube.ico"

--- a/server/scsynth/SC_MiscCmds.cpp
+++ b/server/scsynth/SC_MiscCmds.cpp
@@ -1345,7 +1345,7 @@ SCErr meth_version(World* inWorld, int inSize, char* inData, ReplyAddress* inRep
     packet.addtag('i');
     packet.addi(SC_VersionMinor);
     packet.addtag('s');
-    packet.adds(SC_VersionPatch);
+    packet.adds(SC_VersionPostfix);
     packet.addtag('s');
     packet.adds(SC_Branch);
     packet.addtag('s');

--- a/server/supernova/sc/sc_osc_handler.cpp
+++ b/server/supernova/sc/sc_osc_handler.cpp
@@ -974,7 +974,7 @@ template <bool realtime> void handle_version(endpoint_ptr const& endpoint_ref) {
 
         osc::OutboundPacketStream p(buffer, 4096);
         p << osc::BeginMessage("/version.reply") << "supernova" << (i32)SC_VersionMajor << (i32)SC_VersionMinor
-          << SC_VersionPatch << SC_Branch << SC_CommitHash << osc::EndMessage;
+          << SC_VersionPostfix << SC_Branch << SC_CommitHash << osc::EndMessage;
         endpoint->send(p.Data(), p.Size());
     });
 }

--- a/testsuite/classlibrary/TestMain.sc
+++ b/testsuite/classlibrary/TestMain.sc
@@ -1,0 +1,57 @@
+TestMain : UnitTest {
+	test_versionAtMost_equal_returnsTrue {
+		this.assert(Main.versionAtMost(Main.scVersionMajor, Main.scVersionMinor, Main.scVersionPatch))
+	}
+
+	test_versionAtMost_equalWithNilPatch_returnsTrue {
+		this.assert(Main.versionAtMost(Main.scVersionMajor, Main.scVersionMinor, nil))
+	}
+
+	test_versionAtMost_equalWithNilMinorAndPatch_returnsTrue {
+		this.assert(Main.versionAtMost(Main.scVersionMajor, nil, nil))
+	}
+
+	test_versionAtMost_majorGreater_returnsTrue {
+		this.assert(Main.versionAtMost(Main.scVersionMajor + 1, nil, nil))
+	}
+
+	test_versionAtMost_majorLess_returnsFalse {
+		this.assert(Main.versionAtMost(Main.scVersionMajor - 1, nil, nil).not)
+	}
+
+	test_versionAtMost_patchGreater_returnsTrue {
+		this.assert(Main.versionAtMost(Main.scVersionMajor, Main.scVersionMinor, Main.scVersionPatch + 1))
+	}
+
+	test_versionAtMost_patchLess_returnsFalse {
+		this.assert(Main.versionAtMost(Main.scVersionMajor, Main.scVersionMinor, Main.scVersionPatch - 1).not)
+	}
+
+	test_versionAtLeast_equal_returnsTrue {
+		this.assert(Main.versionAtLeast(Main.scVersionMajor, Main.scVersionMinor, Main.scVersionPatch))
+	}
+
+	test_versionAtLeast_equalWithNilPatch_returnsTrue {
+		this.assert(Main.versionAtLeast(Main.scVersionMajor, Main.scVersionMinor, nil))
+	}
+
+	test_versionAtLeast_equalWithNilMinorAndPatch_returnsTrue {
+		this.assert(Main.versionAtLeast(Main.scVersionMajor, nil, nil))
+	}
+
+	test_versionAtLeast_majorGreater_returnsFalse {
+		this.assert(Main.versionAtLeast(Main.scVersionMajor + 1, nil, nil).not)
+	}
+
+	test_versionAtLeast_majorLess_returnsTrue {
+		this.assert(Main.versionAtLeast(Main.scVersionMajor - 1, nil, nil))
+	}
+
+	test_versionAtLeast_patchGreater_returnsFalse {
+		this.assert(Main.versionAtLeast(Main.scVersionMajor, Main.scVersionMinor, Main.scVersionPatch + 1).not)
+	}
+
+	test_versionAtLeast_patchLess_returnsTrue {
+		this.assert(Main.versionAtLeast(Main.scVersionMajor, Main.scVersionMinor, Main.scVersionPatch - 1))
+	}
+}

--- a/tools/cmake_gen/CMakeLists_header.template
+++ b/tools/cmake_gen/CMakeLists_header.template
@@ -32,7 +32,6 @@ set(SC_PATH "${SC_PATH}" CACHE PATH
     "Path to SuperCollider source. Relative paths are treated as relative to this script" FORCE)
 
 include("${SC_PATH}/SCVersion.txt")
-set(SC_VERSION "${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}${PROJECT_VERSION_PATCH}")
 message(STATUS "Building plugins for SuperCollider version: ${SC_VERSION}")
 
 # set project here to avoid SCVersion.txt clobbering our version info


### PR DESCRIPTION
## Purpose and Motivation

this commit updates how versioning is communicated across the codebase.
the most important change is that SCVersion.txt now separates the
'patch' and 'tweak' version components in new CMake variables called
SC_VERSION_[MAJOR,MINOR,PATCH,TWEAK]. 'patch' is always numeric, while
'tweak' is the optional component used for '-beta1', '-rc2'. the old
variables are kept for backwards compatibility.

we use these to set the VERSION in the CMake call to project(), which
fixes #4648. however, this requires that we strip the 'tweak' component
since only digits and periods are allowed in version strings. so, we
replace references to PROJECT_VERSION with SC_VERSION where appropriate.

this also allows us to be more precise with versioning in the class
library. previously, we only had a method that would return the
".4-beta1" part of the version string, Main.scVersionPostfix. this
commit deprecates that method and replaces it with Main.scVersionPatch
and Main.scVersionTweak. now, we can also update Main.versionAtMost and
Main.versionAtLeast to check the patch version as well.

scsynth and supernova's `/version.reply` contents are kept the same for
backwards compatibility.

documentation added/updated for all affected methods.

testing checklist:
- try re-configuring cmake multiple times to confirm #4648 is fixed
- check that outputs of Main.version, Main.scVersionFoo commands are
unchanged
- check that scsynth and supernova replies to /version are unchanged

i have tested the above points and found no issues.

## Types of changes

- Documentation
- Bug fix
- New feature

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested - new tests for versionAtMost and versionAtLeast, but i can't think of any way to test scVersionMajor etc.
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review