### PR TITLE
classlib: add number of decimal places to SimpleNumber -asTimeString

### DIFF
--- a/HelpSource/Classes/SimpleNumber.schelp
+++ b/HelpSource/Classes/SimpleNumber.schelp
@@ -368,16 +368,16 @@ method:: asAudioRateInput
 Converts this into an audiorate input.
 
 method:: asTimeString
-Produces a time string in the format code::ddd:hh:mm:ss.sss::, interpreting the receiver as time in
-seconds. See link::Classes/String#-asSecs:: for the inverse function.
+Produces a time string in the clock format inspired by ISO 8601 time interval display (truncated representation) code::(ddd:)hh:mm:ss(.z)::, interpreting the receiver as time in seconds. See link::Classes/String#-asSecs:: for the inverse function.
 argument:: precision
-accuracy of the millisecond format; the string will always be formatted with 3 decimal places for
-milliseconds. Minimum value: 0.001.
+accuracy of the fraction of seconds; since the number of decimal places is also an argument, code::precision:: is clamped to code::10.pow(decimalPlaces.neg)::, i.e. code::0.001:: for code::decimalPlaces = 3::
 argument::maxDays
 maximum number of days
 argument::dropDaysIfPossible
 a link::Classes/Boolean::. If set to code::true::, and the number of days in the formatted string
-would be 0, that section is instead ommitted and the string is formatted as code::hh:mm:ss.sss::.
+would be 0, that section of the resulting string is omitted
+argument::decimalPlaces
+number of decimal places representing fraction of seconds, clamped to code::0::; if code::0::, the string is formatted as code::(ddd:)hh:mm:ss::
 discussion::
 code::
 (

--- a/HelpSource/Classes/String.schelp
+++ b/HelpSource/Classes/String.schelp
@@ -255,18 +255,21 @@ code::
 ::
 
 method::asSecs
-Return a link::Classes/Float:: based on converting a time string in format (ddd):hh:mm:ss.sss. This is the inverse method to link::Classes/SimpleNumber#-asTimeString::.
+Return a link::Classes/Float:: based on converting a time string in format code::(ddd:)hh:mm:ss(.z)::, where code::z:: is any sequence of digits. This is the inverse method to link::Classes/SimpleNumber#-asTimeString::.
 code::
-(45296.asTimeString).asSecs;
+"00:00:59.900".asSecs; // hh:mm:ss.zzz
+"1:1:1.1".asSecs; // h:m:s.z
+"001:00:00:00.001".asSecs; // ddd:hh:mm:ss.zzz
 "32.1".asSecs;
-"62.1".asSecs;		// warns
-"0:0:59.9".asSecs;
-"1:1:1.1".asSecs;
-"-1".asSecs;		// neg sign supported
-"-12:34:56".asSecs;
-"12:-34:56".asSecs;	// warns
-"-23:12.3456".asSecs;	//
-"-1:00:00:00".asSecs;	// days too.
+"32.".asSecs; // trailing period
+"32.12345678".asSecs; // any number of decimal places
+"62.1".asSecs; // warns
+"-1".asSecs; // neg sign supported
+"-12:34:56".asSecs; // neg sign always at the beginning
+"-23:12.346".asSecs;
+"-1:00:00:00".asSecs; // neg with days
+"12:-34:56".asSecs; // warns
+(45296.789.asTimeString).asSecs; // inverse of aNumber.asTimeString
 ::
 
 subsection:: Concatenate strings

--- a/SCClassLibrary/Common/Math/SimpleNumber.sc
+++ b/SCClassLibrary/Common/Math/SimpleNumber.sc
@@ -701,14 +701,15 @@ SimpleNumber : Number {
 	// receiver is a time in seconds, returns string "ddd:hh:mm:ss.sss"
 	// see String:asSecs for complement
 
-	asTimeString { |precision = 0.001, maxDays = 365, dropDaysIfPossible = true|
-		var number, decimal, days, hours, minutes, seconds, mseconds, isNegative;
+	asTimeString { |precision = 0.001, maxDays = 365, dropDaysIfPossible = true, decimalPlaces = 3|
+		var number, decimal, days, hours, minutes, seconds, mseconds, msecstr, splitstr, isNegative;
 
-		// min value of precision is 0.001; this ensures that we stick to 3 decimal places in the
-		// formatted string.
-		precision = max(precision, 0.001);
+		// min value of precision depends on decimalPlaces
+		decimalPlaces = decimalPlaces.asInteger.max(0);
+		precision = max(precision, 10.pow(decimalPlaces.neg));
 
 		number = this.round(precision);
+		if(number == inf) {number = this}; //revert rounding if it produces inf
 		isNegative = number < 0;
 		number = number.abs;
 		decimal = number.asInteger;
@@ -721,9 +722,21 @@ SimpleNumber : Number {
 		if(isNegative) {days = "-" ++ days};
 		hours = (decimal.div(3600) % 24).asString.padLeft(2, "0").add($:);
 		minutes = (decimal.div(60) % 60).asString.padLeft(2, "0").add($:);
-		seconds = (decimal % 60).asString.padLeft(2, "0").add($.);
-		mseconds = number.frac * 1000;
-		mseconds = mseconds.round.asInteger.asString.padLeft(3, "0");
+		seconds = (decimal % 60).asString.padLeft(2, "0");
+		mseconds = if(decimalPlaces > 0) {
+			// this could be simplified once sclang gains sprintf functionality, see issue #3570
+			msecstr = number.asString;
+			"." ++ if(msecstr.includes($e)) {
+				splitstr = msecstr.split($e);
+				if(msecstr.includes($.)) {
+					("".catArgs(*(splitstr.last.asInteger.neg - splitstr.first.split($.).first.size).collect({"0"})) ++ splitstr.first.replace(".", "")).padRight(decimalPlaces, "0")
+				} {
+					("".catArgs(*(splitstr.last.asInteger.neg - 1).collect({"0"})) ++ splitstr.first).padRight(decimalPlaces, "0")
+				}
+			} {
+				msecstr.split($.).last.padRight(decimalPlaces, "0")
+			};
+		} { "" };
 		^days ++ hours ++ minutes ++ seconds ++ mseconds
 	}
 

--- a/testsuite/classlibrary/TestSimpleNumber.sc
+++ b/testsuite/classlibrary/TestSimpleNumber.sc
@@ -133,6 +133,34 @@ TestSimpleNumber : UnitTest {
 		this.assertEquals(actual, expected, "-1.asTimeString(dropDaysIfPossible: false) (negative value)");
 	}
 
+	test_asTimeString_precisionLargerThanDecimalPlaces {
+		var expected = "00:00:00.0200";
+		var totalTime = 0.015;
+		var actual = totalTime.asTimeString(precision: 0.01, decimalPlaces: 4);
+		this.assertEquals(actual, expected, "%.asTimeString(precision: 0.01, decimalPlaces: 4)".format(totalTime));
+	}
+
+	test_asTimeString_smallNumberScientificNotation {
+		var expected = "00:00:00.0000001";
+		var totalTime = 1e-7;
+		var actual = totalTime.asTimeString(precision: 1e-7, decimalPlaces: 7);
+		this.assertEquals(actual, expected, "%.asTimeString(precision: 1e-7, decimalPlaces: 7)".format(totalTime));
+	}
+
+	test_asTimeString_smallNumberScientificNotationMultipleDigits {
+		var expected = "00:00:00.000012300000";
+		var totalTime = 1.23e-5;
+		var actual = totalTime.asTimeString(precision: 0, decimalPlaces: 12);
+		this.assertEquals(actual, expected, "%.asTimeString(precision: 0, decimalPlaces: 12)".format(totalTime));
+	}
+
+	test_asTimeString_lotsaZeroes {
+		var expected = "00:00:00.1000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000";
+		var totalTime = 0.1;
+		var actual = totalTime.asTimeString(decimalPlaces: 100);
+		this.assertEquals(actual, expected, "%.asTimeString(decimalPlaces: 100)".format(totalTime));
+	}
+
 	test_softRound {
 		var val;
 		var testF = {|vals, g, t, s| vals.collect({|num| num.softRound(g, t, s)})};


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->
After discussion in #4661, I'd like to propose adding an argument to control number of decimal places for ```aNumber.AsTimeString```.

Before I write tests for this, I wanted to see if others think this is a worthwhile addition.

## Types of changes

<!-- Delete lines that don't apply -->

- (Documentation)
- New feature

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
  - [x] new tests were added and passing
- [x] Updated documentation
- [x] This PR is ready for review
- [x] cleanup commit history
