### PR TITLE
plugin intf: fix compile error, change type of arg to bool

### DIFF
--- a/include/plugin_interface/SC_PlugIn.hpp
+++ b/include/plugin_interface/SC_PlugIn.hpp
@@ -244,9 +244,9 @@ template <class UGenClass> void destroyClass(Unit* unit) { static_cast<UGenClass
 
 }
 
-template <class Unit> void registerUnit(InterfaceTable* ft, const char* name, int disableBufferAliasing = 0) {
+template <class Unit> void registerUnit(InterfaceTable* ft, const char* name, bool disableBufferAliasing = false) {
     UnitCtorFunc ctor = detail::constructClass<Unit>;
     UnitDtorFunc dtor = std::is_trivially_destructible<Unit>::value ? nullptr : detail::destroyClass<Unit>;
 
-    (*ft->fDefineUnit)(name, sizeof(Unit), ctor, dtor, disableBufferAliasing);
+    (*ft->fDefineUnit)(name, sizeof(Unit), ctor, dtor, uint32(disableBufferAliasing ? 1 : 0));
 }


### PR DESCRIPTION
## Purpose and Motivation

this is an addendum to #4356

msvc complains about signed to unsigned conversion ( see
https://github.com/supercollider/cookiecutter-supercollider-plugin/pull/21)

i also changed this argument to a boolean since there are really only
two possible values. it made sense to use `int` in the C interface since
bool is not a fundamental C type

## Types of changes

- Bug fix
- Breaking change (technically, but the change just went into develop
last week and no releases have occurred from it in the meantime)

## To-do list

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review