### PR TITLE
SCDoc: use vector for recursive function

### DIFF
--- a/SCDoc/SCDoc.h
+++ b/SCDoc/SCDoc.h
@@ -35,6 +35,7 @@ void doc_node_free_tree(DocNode* n);
  */
 DocNode* scdoc_parse_file(const std::string& fn, int mode);
 
+/// Dumps a DocNode to stdout as a human-readable tree.
 void doc_node_dump(DocNode* n);
 
 extern const char* scdoc_current_file;


### PR DESCRIPTION
## Purpose and Motivation

otherwise may end up segfaulting on deep trees

this function is only used in `SCDoc/main.cpp`, which is just a test driver for the SCDoc parser. that file is not even compiled normally when building. so this has no impact on anything user facing.

## Types of changes

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested - old code segfaults on a deeply nested tree, this code doesn't
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review
