### PR TITLE
Eliminate a magic number

### DIFF
--- a/server/scsynth/SC_Time.hpp
+++ b/server/scsynth/SC_Time.hpp
@@ -33,10 +33,10 @@ const double kNanosToOSCunits = 4.294967296; // pow(2,32)/1e9
 
 typedef std::chrono::system_clock::time_point HostTime;
 
-static inline std::chrono::system_clock::time_point getTime() { return std::chrono::system_clock::now(); }
+static inline HostTime getTime() { return std::chrono::system_clock::now(); }
 
 template <typename TimePoint> static inline double secondsSinceEpoch(TimePoint const& tp) {
-    return std::chrono::duration_cast<std::chrono::nanoseconds>(tp.time_since_epoch()).count() * 1e-9;
+    return std::chrono::duration_cast<std::chrono::duration<double>>(tp.time_since_epoch()).count();
 }
 
 template <typename TimePoint> static inline int64 OSCTime(TimePoint const& tp) {


### PR DESCRIPTION
By default, std::chrono::duration measures time in seconds (std::ratio<1, 1>). 
The correct way to convert to fractional seconds is to use duration_cast with
std::chrono::duration<T> where T is some kind of floating point type.