### PR TITLE
UnitTest - remove debug posts and inline warnings

### DIFF
--- a/testsuite/classlibrary/TestPattern.sc
+++ b/testsuite/classlibrary/TestPattern.sc
@@ -33,7 +33,7 @@ TestPattern : UnitTest {
 			Pbind(\x, 7).collect { |event| event.put(\y, 8) },
 		];
 
-		[identical, identical].allTuples.postln.do { |pair|
+		[identical, identical].allTuples.do { |pair|
 			assertUnfolded.(*pair)
 		};
 

--- a/testsuite/classlibrary/TestReadableNodeIDAllocator.sc
+++ b/testsuite/classlibrary/TestReadableNodeIDAllocator.sc
@@ -48,7 +48,7 @@ TestReadableNodeIDAllocator : UnitTest {
 			permIDs.add(nextPermID);
 		};
 		this.assert(
-			permIDs.size.postln == (alloc.lowestTempID - 2),
+			permIDs.size == (alloc.lowestTempID - 2),
 			"ReadableNodeIDAllocator should hand out all permanent IDs in mixed alloc/free use."
 		);
 

--- a/testsuite/classlibrary/TestServer_boot.sc
+++ b/testsuite/classlibrary/TestServer_boot.sc
@@ -212,7 +212,6 @@ TestServer_boot : UnitTest {
 		};
 
 		100.do {
-			".".post;
 			nodeID = s.nextNodeID;
 			if(nodeID <= prevNodeID) {
 				failed = true;
@@ -221,8 +220,6 @@ TestServer_boot : UnitTest {
 			};
 			prevNodeID = nodeID;
 		};
-
-		"Done.".postln;
 
 		this.assert(failed.not,
 			"allocating nodeIDs while booting should not produce duplicate nodeIDs."

--- a/testsuite/sclang/lpc/AbstractLPCBrutalTest.sc
+++ b/testsuite/sclang/lpc/AbstractLPCBrutalTest.sc
@@ -71,6 +71,7 @@ AbstractLPCBrutalTest : UnitTest {
 
 		stringLengthsPerAlphabet[alphabetName].do {
 			arg len;
+			var diffs;
 			var filename = "%_%_%".format(alphabetName, len, testMode);
 
 			LPCTestUtils.evaluateAllStrings(
@@ -84,7 +85,7 @@ AbstractLPCBrutalTest : UnitTest {
 			);
 
 			if(this.performingValidation) {
-				var diffs = LPCTestUtils.compareFiles(
+				diffs = LPCTestUtils.compareFiles(
 					this.getActualDir +/+ filename,
 					this.getExpectedDir +/+ filename
 				);

--- a/testsuite/sclang/lpc/LPCTestUtils.sc
+++ b/testsuite/sclang/lpc/LPCTestUtils.sc
@@ -269,18 +269,22 @@ LPCTestUtils {
 		var diffs = [];
 		var areAlphabetsEqual = alph1 == alph2; // Can optimize if equal
 
+		var inputs, inputM, min;
+
 		// alphM.postln;
 
 		// Stop when the master alphabet has been exhausted.
 		while { hasNext } {
-			var inputs = alphs.collect({ |alph, i| alph[ctrs[i]] });
-			var inputM = alphM[ctrM];
+
+			inputs = alphs.collect({ |alph, i| alph[ctrs[i]] });
+			inputM = alphM[ctrM];
 
 			// Get each file's output for the current master input. If a file's alphabet doesn't
 			// include the string, use `nil`. Since alphabets are sorted in lexicographical order,
 			// component alphabets can only skip ahead of the master alphabet's order.
 			inputs.do({
 				arg input, i;
+				var line;
 
 				// postf("here: % %\n", input, inputM);
 				if(inputM == input) {
@@ -292,7 +296,7 @@ LPCTestUtils {
 					if(reps[i] > 0) {
 						reps[i] = reps[i]-1;
 					} {
-						var line = files[i].getLine(this.maxline);
+						line = files[i].getLine(this.maxline);
 
 						if(line.size >= (this.maxline-1)) {
 							this.debug("compareData: maxline characters read; increase maxline in LPCTestUtils.\n"
@@ -318,7 +322,7 @@ LPCTestUtils {
 				// "match".postln;
 				if(areAlphabetsEqual) {
 					// Eat up extra repetitions when possible.
-					var min = reps.minItem;
+					min = reps.minItem;
 					reps = reps - min;
 					min.do {
 						this.incrementAlphabetCount(ctrs[0], strlen, alphSizes[0]);
@@ -535,6 +539,7 @@ LPCTestUtils {
 
 	*doFloatOutputsMatch {
 		arg input, a, b; // assumed: a and b are hex strings of floats
+		var a_f, b_f;
 
 		// If both nan of some sort, return true. `endsWith` because some systems
 		// may print NaN as `-nan`.
@@ -575,8 +580,8 @@ LPCTestUtils {
 
 			^true;
 		} {
-			var a_f = this.stringFromHexString(a).asFloat;
-			var b_f = this.stringFromHexString(b).asFloat;
+			a_f = this.stringFromHexString(a).asFloat;
+			b_f = this.stringFromHexString(b).asFloat;
 
 			// Note: `equalWithPrecision` returns false when comparing infinities. Use
 			// relative precision because we're only trying to catch rounding errors.


### PR DESCRIPTION

## Purpose and Motivation
Some UnitTest subclasses post unnecessary debug info,
some have var declarations that post compiler inline warnings.
This PR removes both, so unit tests run as quietly as possible.

## Types of changes
- cleanup for UnitTests.

- [x] Code is tested
- [x] All tests are passing *
- [x] No documentation update needed
- [x] This PR is ready for review

*That is, TestPattern, TestServer_boot, TestReadableNodeIDAllocator run fine.
On my setup, I cannot get the LPCtests to run properly, 
with or without the changes proposed here...
