### PR TITLE
Ndef as code fix fadetime

### DIFF
--- a/SCClassLibrary/JITLib/ProxySpace/extStoreOn.sc
+++ b/SCClassLibrary/JITLib/ProxySpace/extStoreOn.sc
@@ -359,6 +359,10 @@
 				map.removeAt(\i_out);
 			} { map = this };
 
+			if (map[\fadeTime] == NodeProxy.defaultFadeTime) {
+				map.removeAt(\fadeTime)
+			};
+
 			if(map.notEmpty) {
 				stream << namestring << ".set(" <<<* map.asKeyValuePairs << ");" << Char.nl;
 			};

--- a/testsuite/classlibrary/TestNodeProxy.sc
+++ b/testsuite/classlibrary/TestNodeProxy.sc
@@ -216,7 +216,7 @@ TestNodeProxy : UnitTest {
 	}
 
 	test_copy_pauseIsCopied {
-		var oldProxy = proxy.paused_(true);
+		var oldProxy = proxy.pause;
 		var newProxy = oldProxy.copy;
 
 		this.assertEquals(oldProxy.paused, newProxy.paused);

--- a/testsuite/classlibrary/TestNodeProxy.sc
+++ b/testsuite/classlibrary/TestNodeProxy.sc
@@ -101,8 +101,7 @@ TestNodeProxy : UnitTest {
 		server.sync; // avoids "FAILURE IN SERVER /g_new Group 1 not found"
 
 		this.assertEquals(proxy.asCode, codeString,
-			"asCode-posting nodeproxy with settings should post these correctly.",
-			onFailure: { server.quit }
+			"asCode-posting nodeproxy with settings should post these correctly."
 		);
 
 		server.quit;


### PR DESCRIPTION
## Purpose and Motivation

Fix a bug in NodeProxy.asCode, where default fadeTime is posted as code.
(even though it should be suppressed). this is an update on #4717.
This also fixes the currently failing TestNodeProxy asCode-related tests.

## Types of changes

- Bug fix

## To-do list

- [x] Code is tested
- [x] All tests are passing
- [x] No need for updating documentation
- [x] This PR is ready for review
