### PR TITLE
classlib-unittest: fix/clarify runAll for UnitTest subclasses

### DIFF
--- a/HelpSource/Classes/UnitTest.schelp
+++ b/HelpSource/Classes/UnitTest.schelp
@@ -78,7 +78,7 @@ within it, e.g. code::"TestPolyPlayerPool:test_prepareChildrenToBundle"::.
 
 
 METHOD:: runAll
-runs all subclasses of UnitTest
+Run the entire test suite. As this method addresses the entire test suite, it should be called only on code::UnitTest::. Calling it on any of its subclasses will result in throwing an code::Error::.
 
 code::
 UnitTest.reset;

--- a/SCClassLibrary/Common/UnitTesting/UnitTest.sc
+++ b/SCClassLibrary/Common/UnitTesting/UnitTest.sc
@@ -52,14 +52,18 @@ UnitTest {
 
 	// run all UnitTest subclasses
 	*runAll {
-		^this.forkIfNeeded {
-			this.reset;
-			this.allSubclasses.do { |testClass|
-				testClass.run(false, false);
-				0.1.wait;
-			};
-			this.report
-		}
+		if(this === UnitTest, {
+			^this.forkIfNeeded {
+				this.reset;
+				this.allSubclasses.do { |testClass|
+					testClass.run(false, false);
+					0.1.wait;
+				};
+				this.report
+			}
+		}, {
+			^this.shouldNotImplement(thisMethod)
+		});
 	}
 
 	// run a single test method of this class


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

This PR prevents individual unit tests from inheriting the `*runAll` class method.

Fixes #4720.

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix
- Breaking change (not sure?)

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] Tests seem to work as before
- [x] This PR is ready for review
