### PR TITLE
Topic/midi out use logical time

### DIFF
--- a/lang/LangPrimSource/SC_CoreMIDI.cpp
+++ b/lang/LangPrimSource/SC_CoreMIDI.cpp
@@ -638,9 +638,7 @@ int prDisconnectMIDIIn(struct VMGlobals* g, int numArgsPushed) {
     return errNone;
 }
 
-UInt64 logicalTimeToNanos(struct VMGlobals* g) {
-    return slotRawFloat(&g->thread->seconds) * 1000000000;
-}
+UInt64 logicalTimeToNanos(struct VMGlobals* g) { return slotRawFloat(&g->thread->seconds) * 1000000000; }
 
 int prInitMIDI(struct VMGlobals* g, int numArgsPushed);
 int prInitMIDI(struct VMGlobals* g, int numArgsPushed) {
@@ -670,7 +668,6 @@ int prInitMIDI(struct VMGlobals* g, int numArgsPushed) {
 #endif
 
     return err;
-
 }
 int prDisposeMIDIClient(VMGlobals* g, int numArgsPushed);
 int prDisposeMIDIClient(VMGlobals* g, int numArgsPushed) { return midiCleanUp(); }
@@ -747,13 +744,15 @@ static MIDITimeStamp midiTime(float latencySeconds, UInt64 time) {
          gLogicalInitTime, gCoreAudioInitTime,
          AudioGetCurrentHostTime(), AudioGetCurrentHostTime() - gCoreAudioInitTime,
          time, timeElapsed, schedTime); */
-    return (MIDITimeStamp) schedTime + AudioConvertNanosToHostTime(latencyNanos);
+    return (MIDITimeStamp)schedTime + AudioConvertNanosToHostTime(latencyNanos);
 }
 
 #endif
 
-void sendmidi(int port, MIDIEndpointRef dest, int length, int hiStatus, int loStatus, int aval, int bval, float late, UInt64 time);
-void sendmidi(int port, MIDIEndpointRef dest, int length, int hiStatus, int loStatus, int aval, int bval, float late, UInt64 time) {
+void sendmidi(int port, MIDIEndpointRef dest, int length, int hiStatus, int loStatus, int aval, int bval, float late,
+              UInt64 time);
+void sendmidi(int port, MIDIEndpointRef dest, int length, int hiStatus, int loStatus, int aval, int bval, float late,
+              UInt64 time) {
     MIDIPacketList mpktlist;
     MIDIPacketList* pktlist = &mpktlist;
     MIDIPacket* pk = MIDIPacketListInit(pktlist);

--- a/lang/LangPrimSource/SC_CoreMIDI.cpp
+++ b/lang/LangPrimSource/SC_CoreMIDI.cpp
@@ -784,7 +784,7 @@ int prSendMIDIOut(struct VMGlobals* g, int numArgsPushed) {
 
     int err, outputIndex, uid, length, hiStatus, loStatus, aval, bval;
     float late;
-    double time;
+    UInt64 time;
 
     err = slotIntVal(p, &outputIndex);
     if (err)


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

Improve `MIDIOut` jitter by using logical time to schedule MIDI events.

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->

- New feature
  - really a performance improvement, doesn't change any functionality

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [ ] Updated documentation
- [ ] This PR is ready for review

Caveats:
- this improvement only targets CoreMIDI on OSX. Since it doesn't harm the other implementations (IOS, PortMidi) it is conceivable that this change can be it's own PR.
- Tested on my machine with noticable, if subjective, improvement in scheduling reliability. 