### PR TITLE
classlib: fix helpfile examples for Image class

### DIFF
--- a/HelpSource/Classes/Image.schelp
+++ b/HelpSource/Classes/Image.schelp
@@ -21,17 +21,17 @@ list::
 ## link::Classes/Number:: to create an strong::empty:: image of size multiple as width and height
 code::
 i = Image.new(400);		// Create a 400x400 pixel Image.
-i.dump;
+i.bounds;
 i.free;
 
 i = Image.new(400, 200);	// Create a 400x200 pixel Image.
-i.dump;
+i.bounds;
 i.free;
 ::
 ## link::Classes/Point:: to create an strong::empty:: image of size multiple.x as width and multiple.y as height
 code::
 i = Image.new(400@200);	// Create a 400x200 pixel Image.
-i.dump;
+i.bounds;
 i.free;
 ::
 ## link::Classes/String:: to create an image from a strong::local file::
@@ -39,6 +39,7 @@ code::
 //	Path string
 i = Image.new(SCDoc.helpSourceDir +/+ "images/Swamp.png"); // add a path to your image
 [i.width, i.height].postln;
+i.bounds;
 i.plot;
 i.free;
 ::
@@ -86,7 +87,7 @@ A link::Classes/Size::. SVG contents will be drawn into an image of this size. I
 
 
 METHOD::openURL
-// NOT IMPLEMENTED YET
+NOTE::Not implemented yet.::
 Creates a new Image instance from a valid image at the specified URL strong::path::.
 code::
 i = Image.openURL(SCDoc.helpSourceDir +/+ "images/Swamp.png");
@@ -162,6 +163,19 @@ the Window object.
 ARGUMENT::rect
 optional. the constrained rect to capture inside the Window. By default, it is the window size.
 
+METHOD::closeAllPlotWindows
+Close all the Image plot windows currently opened.
+
+METHOD::colorToPixel
+Convert a link::Classes/Color:: into a pixel datatype suitable for setting pixel data in the Image class.
+RETURNS:: A 32bit packed Integer in the RGBA format.
+
+METHOD::pixelToColor
+Convert a 32bit packed Integer in the RGBA format into a link::Classes/Color::
+RETURNS:: A link::Classes/Color::
+
+PRIVATE::newEmpty, prFormats
+
 SUBSECTION::Class variables and attributes
 
 METHOD::formats
@@ -182,12 +196,22 @@ code::
 Image.interpolations;
 ::
 
-METHOD::closeAllPlotWindows
-close all the Image plot windows currently opened.
+METHOD::resizeModes
+returns an link::Classes/Array:: of the different resize modes you can specify when changing the size of an Image.
+code::
+Image.resizeModes;
+::
+
+METHOD::allPlotWindows
+Returns an array of all the Image plot windows currently opened.
+code::
+Image.allPlotWindows
+::
+
 
 INSTANCEMETHODS::
 
-PRIVATE::prLockFocus, prDrawAtPoint, prSync, prApplyFilters, prTileInRect, prUpdatePixelsInRect, prGetPixel, prInit, prSetInterpolation, prFree, prSetPixel, prLoadPixels, prSetBackground, prApplyKernel, prUpdatePixels, prWriteToFile, prUnlockFocus, prInitFromURL, prSetColor, prGetColor, prSetName, prGetInterpolation, prDrawInRect
+PRIVATE::prLockFocus, prDrawAtPoint, prSync, prApplyFilters, prTileInRect, prUpdatePixelsInRect, prGetPixel, prInit, prSetInterpolation, prFree, prSetPixel, prLoadPixels, prSetBackground, prApplyKernel, prUpdatePixels, prWriteToFile, prUnlockFocus, prInitFromURL, prSetColor, prGetColor, prSetName, prGetInterpolation, prDrawInRect, prNewEmpty, prNewFromWindow, prNewPath, prNewSVG, prNewURL, prSetPainter, prSetSize, prTransferPixels, prUnsetPainter
 
 SUBSECTION::commons / general attributes
 
@@ -205,28 +229,23 @@ returns the bounds of the receiver.
 
 METHOD::free
 deallocate the receiver. this method is useful if you want to manage and reclaim yourself resources. otherwise you do not need to call this method since each object is automatically garbage collected.
-code::
-i = Image.new(SCDoc.helpSourceDir +/+ "images/Swamp.png");
-Image.all;
-i.free;
-Image.all;
-::
 
 METHOD::scalesWhenResized
 flag to tell or set if the receiver should update its bitmap representation to scale when a resize operation if performed
 code::
 (
-	i = Image.new(SCDoc.helpSourceDir +/+ "images/Swamp.png");
-	i.bounds.postln; // getting the dimensions
-	w =i.plot;
+i = Image.new(SCDoc.helpSourceDir +/+ "images/Swamp.png");
+i.bounds.postln; // getting the dimensions
+w =i.plot;
 )
 
 // changing the size of an image
 (
-	i.scalesWhenResized_(true);
-	i.setSize(400, 400 / (i.width / i.height));
-	a =i.plot;
+i.scalesWhenResized_(true);
+i.setSize(400, (400 / (i.width / i.height)).asInteger);
+a =i.plot;
 )
+
 (
 a.close; w.close; i.free;
 )
@@ -251,33 +270,12 @@ i.interpolation;			// get the image currrent interpolation mode
 )
 
 (
-i.interpolation = 'none';		// experiment with interpolation modes
+i.interpolation = 'fast';		// experiment with interpolation modes
 w.refresh;
 )
 
 (
-i.interpolation = 'low';
-w.refresh;
-)
-
-(
-i.interpolation = 1;			// same as 'low'
-w.refresh;
-)
-
-(
-i.interpolation = 'high';
-w.refresh;
-)
-
-(
-i.interpolation = 'default';
-w.refresh;
-)
-
-(
-i.accelerated_(true);
-i.interpolation = 'none'; // does not work on coreimage accelerated image
+i.interpolation = 'smooth';
 w.refresh;
 )
 
@@ -296,6 +294,7 @@ i.free;
 
 //	storeOn / asCompileString
 i = Image.new(SCDoc.helpSourceDir +/+ "images/Swamp.png");
+
 i.url;
 i.asCompileString;
 i.writeArchive("~/Desktop/my_image.scd".standardizePath);
@@ -509,16 +508,16 @@ METHOD::tileInRect
 tile the image or a portion of it in a specified rectangle of the current graphic context. This may stretch the image depending on the destination rect.
 code::
 (
-	i = Image.new(
-		// "http://supercollider.sourceforge.net/theme/sc01/icon.supercollider.gif"
-		SCDoc.helpSourceDir +/+ "images/icon.supercollider.png"
-	);
+i = Image.new(
+	// "http://supercollider.sourceforge.net/theme/sc01/icon.supercollider.gif"
+	SCDoc.helpSourceDir +/+ "images/icon.supercollider.png"
+);
 
-	w = Window.new("Image", Rect(120, 400, 360, 180)).front;
-	w.onClose_({ i.free }); // free the image when the window is closed
-	w.drawHook_({
-		i.tileInRect(w.view.bounds, nil, 2, 1.0); // all image contents
-	});
+w = Window.new("Image", Rect(120, 400, 360, 180)).front;
+w.onClose_({ i.free }); // free the image when the window is closed
+w.drawFunc_({
+	i.tileInRect(w.view.bounds, nil, 2, 1.0); // all image contents
+});
 )
 ::
 
@@ -544,9 +543,9 @@ fill a pixel located at x @ y.
 code::
 i = Image.color(60, 60, Color.blue(0.1,0.1));
 w = i.plot;
-i.setPixel([255,0,0,255].asRGBA, 0, 0); // setting red
+i.setPixel(Image.colorToPixel(Color.new(1,0,0,1)), 0, 0); // setting red
 w.refresh;
-("pixel at 0 @ 0:"+i.getPixel(0,0).rgbaArray).postln;
+("pixel at 0 @ 0:"+Image.pixelToColor(i.getPixel(0,0)).asArray).postln;
 i.free;
 ::
 
@@ -561,42 +560,44 @@ METHOD::getPixel
 retrieve the pixel value at x @ y as a RGBA integer
 code::
 // A simple example on how to manipulate pixels with Image
+(
 b = Int32Array[
-	Integer.fromRGBA(255,0,0,255), // red
-	Integer.fromRGBA(0,255,0,255), // green
-	Integer.fromRGBA(0,0,255,255), // blue
-	Integer.fromRGBA(255,0,255,255) // purple
+	Image.colorToPixel(Color.new255(255,0,0,255)), // red
+	Image.colorToPixel(Color.new255(0,255,0,255)), // green
+	Image.colorToPixel(Color.new255(0,0,255,255)), // blue
+	Image.colorToPixel(Color.new255(255,0,255,255)) // purple
 ];
+)
 
-b[0].red; // 255 see Integer.red
-b[0].green; // 0 see Integer.green
-b[0].blue; // 0 see Integer.blue
-b[0].alpha; // 255 see Integer.alpha
+Image.pixelToColor(b[0]).red; // 1.0 see Color -red
+Image.pixelToColor(b[0]).green; // 0.0 see Color -green
+Image.pixelToColor(b[0]).blue; // 0.0 see Color -blue
+Image.pixelToColor(b[0]).alpha; // 1.0 see Color -alpha
 
-a = Image.new(b.size@1).pixels_(b).interpolation_(\none);
+a = Image.new(b.size@1).pixels_(b).interpolation_(\fast);
 a.plot;
 
 
 // Set + Get
-a.setPixel([255, 0, 255, 128].asRGBA /* create an Integer from 0-255 integer rgba value */, 0, 0).plot;
+a.setPixel(Image.colorToPixel(Color.new255(255, 0, 255, 128)) /* create an Integer from 0-255 integer rgba value */, 0, 0).plot;
 p = a.getPixel(0,0);
 
-p.red; // 255
-p.green; // 0
-p.blue; // 255
-p.alpha; // 128
+Image.pixelToColor(p).red;// 1.0
+Image.pixelToColor(p).green; // 0.0
+Image.pixelToColor(p).blue; // 1.0
+Image.pixelToColor(p).alpha; // ~0.5
 
 // now another important example
-a.setPixel([255, 0, 255, 0].asRGBA, 1, 0).plot; // clear color -> alpha is 0
+a.setPixel(Image.colorToPixel(Color.new255(255, 0, 255, 0)), 1, 0).plot; // clear color -> alpha is 0
 p = a.getPixel(1,0);
 
-p.red; // you expect 255 but you get 0 ??? Why = because Image uses premultiplied color component value internally
+Image.pixelToColor(p).red; // you expect 1.0 but you get 0.0 ??? Why = because Image uses premultiplied color component value internally
 // meaning all Red, Green, and Blue component are premultiplied by the alpha
 // if alpha is 0 you get 0 back for all components.
 
-p.green; // 0
-p.blue; // 0
-p.alpha; // 0
+Image.pixelToColor(p).green; // 0
+Image.pixelToColor(p).blue; // 0
+Image.pixelToColor(p).alpha; // 0
 
 p = a.getColor(1,0); // more explicit - but same here
 ::
@@ -610,7 +611,7 @@ retrieve the pixel value at x @ y as a link::Classes/Color::.
 METHOD::pixels
 retrieve or set all the pixels of the receiver.
 NOTE::
-Careful: the returned Array is a link::Classes/Int32Array:: of size receiver.width * receiver.height containing all pixel values as 32bit Integer
+Careful: the returned Array is a link::Classes/Int32Array:: of size receiver.width * receiver.height containing all pixel values as 32bit Integer. See link::#*colorToPixel:: and link::#*pixelToColor::.
 ::
 
 ARGUMENT::array
@@ -620,16 +621,18 @@ METHOD::loadPixels
 load all the pixels of the receiver in an array. it is better and faster to call this function instead of link::#-pixels:: if you plan to retrieve frequently the pixel data (since it won't allocate a new array everytime !)
 code::
 // exec one line at a time
+(
 i = Image.new(
 	// "http://supercollider.sourceforge.net/theme/sc01/icon.supercollider.gif"
 	SCDoc.helpSourceDir +/+ "images/icon.supercollider.png"
 );
+)
 
 // first grab the pixels
 p = i.pixels;
 
 // do some mods - here invert
-i.invert;
+// i.invert; // not implemented yet
 
 // reload directly in my array - do not need to call i.pixels again
 i.loadPixels(p);
@@ -649,27 +652,28 @@ the start index of the array.
 METHOD::setPixels
 set the pixels in a specific portion of the receiver.
 code::
+
 (
-	i = Image.new(20@20);
-	i.pixels_(
-		Int32Array.fill(i.width * i.height, {
-			Integer.fromRGBA(255.rand,127.rand,255.rand,255)
-		})
-	);
-	//i.interpolation_(\none); // uncomment to see the difference
-	w = i.plot(freeOnClose:true);
-	i.pixels.postln;
+i = Image.new(20@20);
+i.pixels_(
+	Int32Array.fill(i.width * i.height, {
+		Image.colorToPixel(Color.new255(255.rand,127.rand,255.rand,255))
+	})
+);
+//i.interpolation_(\fast); // uncomment to see the difference
+w = i.plot(freeOnClose:true);
+i.pixels.postln;
 )
 
 (
-	i = Image.color(50@50, Color.white);
-	i.setPixels(
-		Int32Array.fill(20*20,{Integer.fromRGBA(255.rand, 127.rand, 255.rand, 255)}),
-		Rect(10,10,20,20)
-	);
-	i.interpolation_(\none); // uncomment to see the difference
-	w = i.plot(freeOnClose:true);
-	i.pixels.postln;
+i = Image.color(50@50, Color.white);
+i.setPixels(
+	Int32Array.fill(20*20,{Image.colorToPixel(Color.new255(255.rand,127.rand,255.rand,255))}),
+	Rect(10,10,20,20)
+);
+i.interpolation_(\fast); // uncomment to see the difference
+w = i.plot(freeOnClose:true);
+i.pixels.postln;
 )
 ::
 


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->
A number of examples in the `Image` helpfile did not run, due to using some obsolete methods (`Integer .fromRGBA`, `Array .asRGBA`, `Integer .red` etc.) This corrects the examples so they at least run.

Some examples are a little awkward now, as `Color` returns values `0.0 - 1.0`, while the examples are generally using 8-bit integers. I'm open to suggestions if more changes should be made.

## Types of changes

<!-- Delete lines that don't apply -->

- Documentation

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] Updated documentation
- [x] This PR is ready for review
