### PR TITLE
Topic/refactor dict embed in stream

### DIFF
--- a/HelpSource/Classes/Dictionary.schelp
+++ b/HelpSource/Classes/Dictionary.schelp
@@ -329,7 +329,7 @@ method::embedInStream
 argument::event
 The inval, usually in an event stream. See also link::Classes/Event::.
 
-If the event is not nil, yields a copy, adding all the elements of the receiver event (this leaves the receiver unchanged). If it is nil, return the receiver.
+If the event is not nil, yields a copy, adding all the elements of the receiver event (this leaves the receiver unchanged). If it is not a dictionary (e.g. nil), return a copy of the receiver.
 
 code::
 a = (note: 2);
@@ -378,6 +378,25 @@ d = (
 d.rout.((z:999));
 d.rout.((z:1, a:0));
 d.rout.(());
+::
+
+method::overwritePairs
+Use the argument dictionary to partly overwrite a copy of the receiver.
+
+code::
+a = (x: 1871, y: 1920);
+b = (y: 1968, z: 2020);
+a.overwritePairs(b); // (x: 1871, y: 1969, z: 2020)
+
+// key value pairs
+a.overwritePairs([\y, -10]);  // (x: 1871, y: -10)
+
+// this interface works with any object, including nil
+nil.overwritePairs(b); // (y: 1969, z: 2020)
+
+// this is analogous to ".add"
+nil.add(5).add(7); // [5, 7]
+nil.overwritePairs(a).overwritePairs(b) // ( x: 1871, y: 1969, z: 2020 )
 ::
 
 SECTION::Overview

--- a/HelpSource/Classes/SequenceableCollection.schelp
+++ b/HelpSource/Classes/SequenceableCollection.schelp
@@ -556,6 +556,14 @@ code::
 [1, 2, 3, 4, 5].doAdjacentPairs({ arg a, b; [a, b].postln; });
 ::
 
+method::overwritePairs
+Given a list of key value pairs, use the collection from the argument to replace values and add those that do not yet exist. This keeps the order intact, new keys are added to the end. This method always returns a copy and leaves receiver and argument unchanged.
+
+code::
+x = [a:3, b:4];
+x.overwritePairs([a:9, c:10]);
+::
+
 method::separate
 Separates the collection into sub-collections by calling the function for each adjacent pair of elements. If the function returns true, then a separation is made between the elements.
 code::

--- a/SCClassLibrary/Common/Collections/Dictionary.sc
+++ b/SCClassLibrary/Common/Collections/Dictionary.sc
@@ -272,10 +272,15 @@ Dictionary : Set {
 	transformEvent { arg event;
 		^event.putAll(this);
 	}
+
 	embedInStream { arg event;
 		var func = this.at(\embedInStream);
 		if(func.notNil) { ^func.value(this, event) };
-		^if(event.isNil) { this } { event.copy.putAll(this) }.yield
+		^event.overwritePairs(this).yield
+	}
+
+	overwritePairs { arg dict;
+		^this.copy.putPairs(dict)
 	}
 
 	asSortedArray {

--- a/SCClassLibrary/Common/Collections/SequenceableCollection.sc
+++ b/SCClassLibrary/Common/Collections/SequenceableCollection.sc
@@ -345,6 +345,21 @@ SequenceableCollection : Collection {
 			function.value(this.at(i), this.at(i+1), i);
 		})
 	}
+
+	overwritePairs { arg pairs;
+		var res = this.copy;
+		pairs = pairs.copy.asPairs;
+		forBy(0, this.size-1, 2, { |i|
+			var key = this[i];
+			var argIndex = pairs.detectIndex { |x| x == key };
+			if(argIndex.notNil) {
+				res[i+1] = pairs[argIndex+1];
+				2.do { pairs.removeAt(argIndex) };
+			}
+		});
+		^res ++ pairs
+	}
+
 	separate { arg function = true;
 		var list = Array.new;
 		var sublist = this.species.new;

--- a/SCClassLibrary/Common/Core/Object.sc
+++ b/SCClassLibrary/Common/Core/Object.sc
@@ -231,6 +231,7 @@ Object  {
 	removedFromScheduler { ^this }
 	isPlaying { ^false }
 	embedInStream { ^this.yield; }
+	overwritePairs { arg dict; ^dict.copy }
 	cyc { arg n = inf;
 		^r {|inval|
 			n.do {

--- a/testsuite/classlibrary/TestArray.sc
+++ b/testsuite/classlibrary/TestArray.sc
@@ -76,7 +76,7 @@ TestArray : UnitTest {
 		var deepArray = { |depth|
 			if(depth == 0) {
 				1000.rand
-		} {
+			} {
 				{ deepArray.value(depth - 1) } ! rrand(1, maxLength) }
 		};
 		20.do {
@@ -186,7 +186,16 @@ TestArray : UnitTest {
 		}
 	}
 
+	test_overwritePairs {
+		var pairs, newPairs;
+		pairs = [a:3, b:4];
+		newPairs = pairs.overwritePairs([a:9, c:10, d:11]);
+		this.assertEquals(newPairs, [a:9, b:4, c:10, d:11], "overwritePairs should replace key value pairs correctly");
+
+	}
+
 } // End class
+
 
 TestArrayLace : UnitTest {
 	test_empty_returns_empty {

--- a/testsuite/classlibrary/TestDictionary.sc
+++ b/testsuite/classlibrary/TestDictionary.sc
@@ -38,7 +38,15 @@ TestDictionary : UnitTest {
 		var dict = (a:9);
 		var argument = (b:10, a:11);
 		var res = dict.embedInStream(argument);
-		this.assertEquals(res, (b:10, a:9), "embedInStream should ovrwrite the keys in the argument")
+		this.assertEquals(res, (b:10, a:9), "embedInStream should overwrite the keys in the argument")
+	}
+
+	test_overwritePairs {
+		var a = (x: 1871, y: 1920);
+		var b = (y: 1968, z: 2020);
+		var c = a.overwritePairs(b);
+
+		this.assertEquals(c, ( x: 1871, y: 1969, z: 2020 ), "in a.overwritePairs(b), b should overwrite keys of a");
 	}
 
 

--- a/testsuite/classlibrary/TestDictionary.sc
+++ b/testsuite/classlibrary/TestDictionary.sc
@@ -27,4 +27,19 @@ TestDictionary : UnitTest {
 
 	}
 
+	test_embedInStream_withNonEventArgument {
+		var dict = (a:9);
+		var argument = 0; // not an event
+		var res = dict.embedInStream(argument);
+		this.assertEquals(res, dict, "embedInStream should return the receiver if the argument is a number")
+	}
+
+	test_embedInStream_withEventArgument {
+		var dict = (a:9);
+		var argument = (b:10, a:11);
+		var res = dict.embedInStream(argument);
+		this.assertEquals(res, (b:10, a:9), "embedInStream should ovrwrite the keys in the argument")
+	}
+
+
 }


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

This fixes #4735 by refactoring embedInStream. At the same time, it introduces a clearer interface for overwriting key value pairs.

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->

- Documentation
- Bug fix
- New feature

There is a potential for breaking code that should be discussed here. This change makes sure that also if nothing is passed in, the embedded event is copied. Something that relies on `event.embedInStream(nil) === event` would break.

The reson for ths change is uniformity and reliability. Note that `event.embedInStream(x) !== event` is currently always true for any x that is an event, in particular this is done when playing event patterns like Pbind.

It would be easy to change this, so that `nil` would not copy the event.

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review
