### PR TITLE
portaudio: test ASIO default samplerate

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -12,7 +12,7 @@
 	url = https://github.com/supercollider/scvim.git
 [submodule "external_libraries/portaudio_sc_org"]
 	path = external_libraries/portaudio_sc_org
-	url = https://github.com/supercollider/portaudio.git
+	url = https://github.com/dyfer/portaudio.git
 	branch = supercollider
 [submodule "external_libraries/yaml-cpp"]
 	path = external_libraries/yaml-cpp


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

I modified PortAudio ASIO implementation to use soundcard's current sample rate as the default samplerate. I'm putting this as a PR to get AppVeyor build and allow testing with larger community.

The old behavior is to test ASIO driver whether it supports a given samplerate against a known list of samplerates, and the first match becomes the default samplerate (that's usually 44100). This does not take into account the device's current samplerate AFAICT.

Direct link to AppVeyor builds: [32bit](https://ci.appveyor.com/api/buildjobs/p2brvvx4ucv2afcn/artifacts/art_folder.zip) [64bit](https://ci.appveyor.com/api/buildjobs/u7xdh4072u3k8y04/artifacts/art_folder.zip)

## Types of changes

<!-- Delete lines that don't apply -->

- New feature
- Breaking change (I guess the default behavior does change)

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [ ] Code is tested
- [ ] All tests are passing
- [ ] Updated documentation
- [ ] This PR is ready for review
