### PR TITLE
List audio devices on Windows

### DIFF
--- a/HelpSource/Classes/ServerOptions.schelp
+++ b/HelpSource/Classes/ServerOptions.schelp
@@ -19,15 +19,15 @@ method:: new
 Create and return a new instance of ServerOptions.
 
 method:: devices
-macOS only. Return an Array of Strings listing the audio devices currently available on the system.
+Return an Array of Strings listing the audio devices currently available on the system.
 
 method:: inDevices
-macOS only. Return an Array of Strings listing the audio devices currently available on the system which have input channels.
+Return an Array of Strings listing the audio devices currently available on the system which have input channels.
 
 method:: outDevices
-macOS only. Return an Array of Strings listing the audio devices currently available on the system which have output channels.
+Return an Array of Strings listing the audio devices currently available on the system which have output channels.
 
-note::All platforms: list of available devices is printed in the post window when the server is booting. Also see link::Reference/AudioDeviceSelection:: for more information on selecting audio device.::
+note:: The above three methods are not available if SuperCollider is built with JACK backend (by default on Linux). Also see link::Reference/AudioDeviceSelection:: for more information on selecting audio device.::
 
 instancemethods::
 subsection:: The Options
@@ -199,4 +199,3 @@ t.makeWindow;
 t.boot;
 t.quit;
 ::
-

--- a/HelpSource/Reference/AudioDeviceSelection.schelp
+++ b/HelpSource/Reference/AudioDeviceSelection.schelp
@@ -24,11 +24,11 @@ code::
 Server.default.options.device_("MOTU 828");
 ::
 
-On macOS you can programmatically obtain a list of available audio devices without booting the server:
+On Windows and macOS you can programmatically obtain a list of available audio devices without booting the server:
 code::
-ServerOptions.devices; //all devices
-ServerOptions.inDevices; //input devices
-ServerOptions.outDevices; //output devices
+ServerOptions.devices; // all devices
+ServerOptions.inDevices; // input devices
+ServerOptions.outDevices; // output devices
 ::
 
 subsection:: Sample rate mismatch
@@ -109,7 +109,13 @@ o.inDevice_("Windows WASAPI : Microphone");
 o.outDevice_("Windows WASAPI : Speakers");
 Server.default.reboot;
 ::
-On Windows you strong::cannot:: programmatically obtain the list of available audio devices in sclang. However, all the devices are listed in the post window when the server is booting: code::Server.default.boot::. Partial device name matching is supported in Windows (though not in macOS).
+You can programmatically obtain a list of available audio devices without booting the server:
+code::
+ServerOptions.devices; // all devices
+ServerOptions.inDevices; // input devices
+ServerOptions.outDevices; // output devices
+::
+Partial device name matching is supported in Windows (though not in macOS).
 
 subsection:: Choosing the device and the API
 list::

--- a/common/SC_PaUtils.cpp
+++ b/common/SC_PaUtils.cpp
@@ -49,6 +49,10 @@ void TryMatchDeviceSameAPI(int* matchingDevice, const int* knownDevice, bool isI
 
 std::string GetPaDeviceName(PaDeviceIndex index) {
     auto* pdi = Pa_GetDeviceInfo(index);
+    return GetPaDeviceName(pdi);
+}
+
+std::string GetPaDeviceName(const PaDeviceInfo* pdi) {
     std::string name;
 #ifndef __APPLE__
     name += Pa_GetHostApiInfo(pdi->hostApi)->name;

--- a/common/SC_PaUtils.hpp
+++ b/common/SC_PaUtils.hpp
@@ -5,8 +5,9 @@
 #include "portaudio.h"
 #include <string>
 
-// get device name from PaDeviceIndex
+// get device name from PaDeviceIndex or PaDeviceInfo
 std::string GetPaDeviceName(PaDeviceIndex index);
+std::string GetPaDeviceName(const PaDeviceInfo* pdi);
 
 // get PaDeviceIndex from device name
 PaDeviceIndex GetPaDeviceFromName(const char* device, bool isInput);

--- a/lang/CMakeLists.txt
+++ b/lang/CMakeLists.txt
@@ -36,6 +36,7 @@ endif ()
 
 set(sclang_sources
     LangPrimSource/SC_LinkClock.cpp
+    LangPrimSource/SC_AudioDevicePrim.cpp
 	LangPrimSource/PyrSignalPrim.cpp
 	LangPrimSource/PyrSched.cpp
 	LangPrimSource/PyrPrimitive.cpp
@@ -104,11 +105,39 @@ list(APPEND sclang_sources ${headers} ${external_headers}) # make qt creator hap
 
 set(sclang_parser_source LangSource/Bison/lang11d_tab.cpp)
 
+# audio API for listing devices, selected the same way as in the server
+if(AUDIOAPI STREQUAL "default")
+    if(APPLE)
+        set(AUDIOAPI coreaudio)
+    elseif(WIN32)
+        set(AUDIOAPI portaudio)
+    else()
+        set(AUDIOAPI jack)
+    endif(APPLE)
+endif()
+
+if(NOT AUDIOAPI MATCHES "^(jack|coreaudio|portaudio)$")
+    message(FATAL_ERROR "Unrecognised audio API: ${AUDIOAPI}")
+endif()
+
+if (AUDIOAPI STREQUAL coreaudio)
+    add_definitions("-DSC_AUDIO_API_COREAUDIO")
+elseif (AUDIOAPI STREQUAL portaudio)
+    if ((NOT WIN32) OR MSYS)
+        find_package(Portaudio)
+        if(NOT PORTAUDIO_FOUND)
+            message(FATAL_ERROR "Portaudio selected as audio API, but development files not found")
+        endif() #NOT PORTAUDIO_FOUND
+    endif() #(NOT WIN32) OR MSYS
+    add_definitions("-DSC_AUDIO_API_PORTAUDIO")
+    list(APPEND sclang_sources ${CMAKE_SOURCE_DIR}/common/SC_PaUtils.cpp)
+    include_directories(${PORTAUDIO_INCLUDE_DIRS})
+endif()
+
 if(UNIX)
 	if(APPLE)
 		list(APPEND sclang_sources
 			LangPrimSource/SC_CoreMIDI.cpp
-			LangPrimSource/SC_CoreAudioPrim.cpp
 			)
 	else(APPLE)
 		if(ALSA_FOUND)
@@ -252,6 +281,14 @@ if(ALSA_FOUND)
 	target_compile_definitions(libsclang PUBLIC HAVE_ALSA=1)
 	target_link_libraries(libsclang ${ALSA_LIBRARY})
 endif(ALSA_FOUND)
+
+if (AUDIOAPI STREQUAL portaudio)
+    if(WIN32 AND NOT MSYS)
+        target_link_libraries(libsclang portaudio)
+    else()
+        target_link_libraries(libsclang ${PORTAUDIO_LIBRARIES})
+    endif()
+endif()
 
 if(SNDFILE_FOUND)
 	target_include_directories(libsclang PUBLIC ${SNDFILE_INCLUDE_DIR})

--- a/lang/LangPrimSource/PyrPrimitive.cpp
+++ b/lang/LangPrimSource/PyrPrimitive.cpp
@@ -45,6 +45,7 @@
 #include "PyrDeepFreezer.h"
 //#include "Wacom.h"
 #include "InitAlloc.h"
+#include "SC_AudioDevicePrim.hpp"
 #include "SC_LanguageConfig.hpp"
 #include "SC_Filesystem.hpp"
 #include "SC_Version.hpp"
@@ -4274,6 +4275,7 @@ void initPrimitives() {
     initMathPrimitives();
     initSignalPrimitives();
     initArrayPrimitives();
+    initAudioDevicePrimitives();
 
     void initSymbolPrimitives();
     initSymbolPrimitives();
@@ -4347,11 +4349,6 @@ void initPrimitives() {
 
     void initSerialPrimitives();
     initSerialPrimitives();
-
-#ifdef __APPLE__
-    void initCoreAudioPrimitives();
-    initCoreAudioPrimitives();
-#endif
 
 #ifdef SCOGL_COMPILE
     void initOpenGLPrimitives();

--- a/lang/LangPrimSource/SC_AudioDevicePrim.cpp
+++ b/lang/LangPrimSource/SC_AudioDevicePrim.cpp
@@ -18,7 +18,12 @@
     Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
 */
 
-#include <CoreAudio/AudioHardware.h>
+#if defined(SC_AUDIO_API_COREAUDIO)
+#    include <CoreAudio/AudioHardware.h>
+#elif defined(SC_AUDIO_API_PORTAUDIO)
+#    include "portaudio.h"
+#    include "SC_PaUtils.hpp"
+#endif
 
 #include "SCBase.h"
 #include "VMGlobals.h"
@@ -28,7 +33,8 @@
 
 enum { OUT = 0, IN, BOTH };
 
-int listDevices(struct VMGlobals* g, int type) {
+#if defined(SC_AUDIO_API_COREAUDIO)
+int listDevices(VMGlobals* g, int type) {
     int numDevices, num = 0;
     PyrSlot* a = g->sp - 2;
     AudioObjectPropertyAddress propertyAddress;
@@ -125,7 +131,53 @@ int listDevices(struct VMGlobals* g, int type) {
     return 1;
 }
 
-int prListAudioDevices(struct VMGlobals* g, int numArgsPushed) {
+#elif defined(SC_AUDIO_API_PORTAUDIO)
+int listDevices(VMGlobals* g, int type) {
+    if (Pa_Initialize() != paNoError)
+        return 0;
+
+    auto numDevices = Pa_GetDeviceCount();
+    if (numDevices < 0) {
+        Pa_Terminate();
+        return 0;
+    }
+
+    std::vector<const PaDeviceInfo*> deviceInfos;
+    for (PaDeviceIndex i = 0; i < numDevices; i++) {
+        auto* pdi = Pa_GetDeviceInfo(i);
+        if (type == IN) {
+            if (pdi->maxInputChannels > 0)
+                deviceInfos.push_back(pdi);
+        } else if (type == OUT) {
+            if (pdi->maxOutputChannels > 0)
+                deviceInfos.push_back(pdi);
+        } else
+            deviceInfos.push_back(pdi);
+    }
+
+    PyrObject* devArray = newPyrArray(g->gc, deviceInfos.size() * sizeof(PyrObject), 0, true);
+    SetObject(g->sp - 2, devArray); // this is okay here as we don't use the receiver below
+    devArray->size = deviceInfos.size();
+
+    for (int i = 0; i < deviceInfos.size(); i++) {
+        PyrString* string = newPyrString(g->gc, GetPaDeviceName(deviceInfos[i]).c_str(), 0, true);
+        SetObject(devArray->slots + i, string);
+        g->gc->GCWriteNew(devArray,
+                          reinterpret_cast<PyrObject*>(string)); // we know array is white so we can use GCWriteNew
+    }
+
+    Pa_Terminate();
+    return 1;
+}
+
+#else
+int listDevices(VMGlobals* g, int type) {
+    return 0; // listing devices fails when using neither CoreAudio nor PortAudio
+}
+#endif
+
+
+int prListAudioDevices(VMGlobals* g, int numArgsPushed) {
     int in = 0;
     int out = 0;
     slotIntVal(g->sp, &out);
@@ -144,6 +196,6 @@ int prListAudioDevices(struct VMGlobals* g, int numArgsPushed) {
     return errFailed;
 }
 
-void initCoreAudioPrimitives() {
+void initAudioDevicePrimitives() {
     definePrimitive(nextPrimitiveIndex(), 0, "_ListAudioDevices", prListAudioDevices, 3, 0);
 }

--- a/lang/LangPrimSource/SC_AudioDevicePrim.hpp
+++ b/lang/LangPrimSource/SC_AudioDevicePrim.hpp
@@ -1,0 +1,3 @@
+#pragma once
+
+void initAudioDevicePrimitives();


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

Add listing devices with PortAudio backend (by default on Windows). With this PR following commands will work on Windows:
```supercollider
ServerOptions.inDevices;
ServerOptions.outDevices;
ServerOptions.devices;
```

Fixes #1557.

RE #1557 - the issue mentions listing devices not working on Linux as well, but since we use JACK on Linux there's [no point implementing listing devices](https://github.com/supercollider/supercollider/issues/1557#issuecomment-114677077). (Maybe at some point we could consider implementing available JACK server names... but this PR is really for Windows users and PortAudio).

## Types of changes

<!-- Delete lines that don't apply -->

- Documentation
- New feature

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- ~~All tests are passing~~
  - there are no tests
- [x] Updated documentation
- [x] This PR is ready for review
- [x] Cleanup commit history
