### PR TITLE
[CI] use repo test suite on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,7 @@ before_script:
 
 script:
  - $TRAVIS_BUILD_DIR/.travis/script-$TRAVIS_OS_NAME.sh
+ - export PATH=$TRAVIS_BUILD_DIR/BUILD/Install/bin:$PATH
  - $TRAVIS_BUILD_DIR/.travis/test.sh
  - if [[ $TRAVIS_OS_NAME == osx ]]; then $TRAVIS_BUILD_DIR/.travis/package-osx.sh; fi
 

--- a/.travis/before-install-linux.sh
+++ b/.travis/before-install-linux.sh
@@ -28,3 +28,6 @@ if [[ -n "$1" && "$1" == "--qt=true" ]]; then
 fi
 sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.9 60 --slave /usr/bin/g++ g++ /usr/bin/g++-4.9
 sudo update-alternatives --auto gcc
+
+# start JACK
+jackd --no-realtime -d dummy &

--- a/.travis/before-install-linux.sh
+++ b/.travis/before-install-linux.sh
@@ -21,7 +21,8 @@ npm install -g lintspaces-cli
 sudo add-apt-repository --yes ppa:ubuntu-toolchain-r/test
 sudo add-apt-repository --yes ppa:beineri/opt-qt591-trusty
 sudo apt-get update
-sudo apt-get install --yes build-essential gcc-4.9 g++-4.9 cmake pkg-config libjack-jackd2-dev libsndfile1-dev libasound2-dev libavahi-client-dev libreadline6-dev libfftw3-dev libicu-dev libxt-dev libudev-dev
+sudo apt-get install --yes build-essential gcc-4.9 g++-4.9 cmake pkg-config libsndfile1-dev libasound2-dev libavahi-client-dev libreadline6-dev libfftw3-dev libicu-dev libxt-dev libudev-dev
+sudo apt-get install --yes --no-install-recommends libjack-dev jackd1
 if [[ -n "$1" && "$1" == "--qt=true" ]]; then
 	sudo apt-get install --yes libgl1-mesa-dev qt59base qt59location qt59declarative qt59tools qt59webengine qt59webchannel qt59xmlpatterns qt59svg qt59websockets
 fi

--- a/.travis/qpm-prep.sh
+++ b/.travis/qpm-prep.sh
@@ -5,8 +5,6 @@ sudo pip2 install git+https://github.com/supercollider/qpm.git
 
 mkdir $HOME/Quarks && cd $HOME/Quarks
 git clone --depth=1 https://github.com/supercollider-quarks/API
-git clone --depth=1 https://github.com/supercollider-quarks/CommonTests
-git clone --depth=1 https://github.com/supercollider-quarks/CommonTestsGUI
 cd $TRAVIS_BUILD_DIR/BUILD
 
 cp ../travis_test_run_proto.json ./travis_test_run.json

--- a/.travis/qpm-prep.sh
+++ b/.travis/qpm-prep.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 cd $TRAVIS_BUILD_DIR/BUILD
-sudo pip2 install git+https://github.com/supercollider/qpm.git
+sudo pip2 install git+https://github.com/patrickdupuis/qpm.git@topic/fix2
 
 mkdir $HOME/Quarks && cd $HOME/Quarks
 git clone --depth=1 https://github.com/supercollider-quarks/API

--- a/.travis/qpm-prep.sh
+++ b/.travis/qpm-prep.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 cd $TRAVIS_BUILD_DIR/BUILD
-sudo pip2 install git+https://github.com/patrickdupuis/qpm.git@topic/fix2
+sudo pip2 install git+https://github.com/supercollider/qpm.git
 
 mkdir $HOME/Quarks && cd $HOME/Quarks
 git clone --depth=1 https://github.com/supercollider-quarks/API

--- a/.travis/qpm-test.sh
+++ b/.travis/qpm-test.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-qpm test.run -l $TRAVIS_BUILD_DIR/BUILD/travis_test_run.json --path $SCLANG --include $HOME/Quarks
+qpm test.run -l $TRAVIS_BUILD_DIR/BUILD/travis_test_run.json --path $SCLANG --include $HOME/Quarks $TRAVIS_BUILD_DIR/testsuite/classlibrary

--- a/.travis/qpm-test.sh
+++ b/.travis/qpm-test.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-qpm test.run -l $TRAVIS_BUILD_DIR/BUILD/travis_test_run.json --path $SCLANG --include $HOME/Quarks $TRAVIS_BUILD_DIR/testsuite/classlibrary
+QPM_DEBUG=1 qpm test.run -l $TRAVIS_BUILD_DIR/BUILD/travis_test_run.json --path $SCLANG --include $HOME/Quarks $TRAVIS_BUILD_DIR/testsuite/classlibrary

--- a/testsuite/classlibrary/TestAbstractFunction.sc
+++ b/testsuite/classlibrary/TestAbstractFunction.sc
@@ -138,7 +138,7 @@ TestAbstractFunction : UnitTest {
 
 		this.assertEquals((dur: Rest(1)).isRest, true, "event with dur = Rest(1) should return true for isRest");
 
-		this.assertEquals((type: \rest).isRest, true, "event with dur = \rest should return true for isRest");
+		this.assertEquals((type: \rest).isRest, true, "event with dur = \\rest should return true for isRest");
 
 		this.assertEquals((degree: \).isRest, true, "event with an empty symbol as dur should return true for isRest");
 

--- a/travis_test_run_proto.json
+++ b/travis_test_run_proto.json
@@ -170,10 +170,6 @@
     },
     {
       "test": "*",
-      "suite": "TestSerialPort"
-    },
-    {
-      "test": "*",
       "suite": "TestServer"
     },
     {

--- a/travis_test_run_proto.json
+++ b/travis_test_run_proto.json
@@ -10,10 +10,6 @@
     },
     {
       "test": "*",
-      "suite": "TestBuffer"
-    },
-    {
-      "test": "*",
       "suite": "TestClockScheduling"
     },
     {

--- a/travis_test_run_proto.json
+++ b/travis_test_run_proto.json
@@ -46,10 +46,6 @@
     },
     {
       "test": "*",
-      "suite": "TestDocumentEnvironment"
-    },
-    {
-      "test": "*",
       "suite": "TestDoneActions"
     },
     {
@@ -59,10 +55,6 @@
     {
       "test": "*",
       "suite": "TestEnvGate"
-    },
-    {
-      "test": "*",
-      "suite": "TestEnvironmentDocument"
     },
     {
       "test": "*",

--- a/travis_test_run_proto.json
+++ b/travis_test_run_proto.json
@@ -14,12 +14,6 @@
     },
     {
       "test": "*",
-      "suite": "TestBus",
-      "skip": true,
-      "skipReason": "Test leaves server running (FIXME)"
-    },
-    {
-      "test": "*",
       "suite": "TestClockScheduling"
     },
     {
@@ -45,16 +39,6 @@
     {
       "test": "*",
       "suite": "TestControlSpec"
-    },
-    {
-      "test": "*",
-      "suite": "TestCoreUGens"
-    },
-    {
-      "test": "test_ugen_generator_equivalences",
-      "suite": "TestCoreUGens",
-      "skip": true,
-      "skipReason": "Test has failures (FIXME)"
     },
     {
       "test": "*",
@@ -134,16 +118,6 @@
     },
     {
       "test": "*",
-      "suite": "TestNoOps"
-    },
-    {
-      "test": "test_arithmetics",
-      "suite": "TestNoOps",
-      "skip": true,
-      "skipReason": "Too many asserts in test causes issues (FIXME)"
-    },
-    {
-      "test": "*",
       "suite": "TestNode"
     },
     {
@@ -153,12 +127,6 @@
     {
       "test": "*",
       "suite": "TestNodeProxyRoles"
-    },
-    {
-      "test": "*",
-      "suite": "TestNodeProxy_Server",
-      "skip": true,
-      "skipReason": "Test hangs for unknown reason (FIXME)"
     },
     {
       "test": "*",
@@ -174,25 +142,7 @@
     },
     {
       "test": "*",
-      "suite": "TestPV_ChainUGen",
-      "skip": true,
-      "skipReason": "Test leaves the server running (FIXME)"
-    },
-    {
-      "test": "*",
       "suite": "TestParser"
-    },
-    {
-      "test": "*",
-      "suite": "TestPattern",
-      "skip": true,
-      "skipReason": "reason unknown (FIXME)"
-    },
-    {
-      "test": "*",
-      "suite": "TestPatternProxy",
-      "skip": true,
-      "skipReason": "reason unknown (FIXME)"
     },
     {
       "test": "*",

--- a/travis_test_run_proto.json
+++ b/travis_test_run_proto.json
@@ -247,10 +247,6 @@
     {
       "test": "*",
       "suite": "TestUnitTest"
-    },
-    {
-      "test": "*",
-      "suite": "TestVolume"
     }
   ]
 }

--- a/travis_test_run_proto.json
+++ b/travis_test_run_proto.json
@@ -242,10 +242,6 @@
     },
     {
       "test": "*",
-      "suite": "TestTempoClock"
-    },
-    {
-      "test": "*",
       "suite": "TestUGen_Duty"
     },
     {

--- a/travis_test_run_proto.json
+++ b/travis_test_run_proto.json
@@ -1,104 +1,326 @@
 {
   "tests": [
     {
-      "test": "*", 
-      "suite": "TestPlotter"
-    }, 
+      "test": "*",
+      "suite": "TestAbstractFunction"
+    },
     {
-      "test": "*", 
-      "suite": "TestUnitTest",
-      "skip": true,
-      "skipReason": "Unidentified UnitTest bug (FIXME)"
-    }, 
-    {
-      "test": "*", 
-      "suite": "TestEnv"
-    }, 
-    {
-      "test": "*", 
+      "test": "*",
       "suite": "TestArray"
-    }, 
+    },
     {
-      "test": "*", 
-      "suite": "TestEvent"
-    }, 
+      "test": "*",
+      "suite": "TestBuffer"
+    },
     {
-      "test": "*", 
-      "suite": "TestOSCBundle"
-    }, 
-    {
-      "test": "*", 
-      "suite": "TestNoOps"
-    }, 
-    {
-      "test": "*", 
-      "suite": "TestMixedBundleTester",
+      "test": "*",
+      "suite": "TestBus",
       "skip": true,
-      "skipReason": "Unidentified UnitTest bug (FIXME)"
-    }, 
+      "skipReason": "Test leaves server running (FIXME)"
+    },
     {
-      "test": "*", 
-      "suite": "TestFloat"
-    }, 
+      "test": "*",
+      "suite": "TestClockScheduling"
+    },
     {
-      "test": "*", 
-      "suite": "TestNetAddr"
-    }, 
+      "test": "*",
+      "suite": "TestCollection"
+    },
     {
-      "test": "*", 
+      "test": "*",
+      "suite": "TestCollectionConversions"
+    },
+    {
+      "test": "*",
+      "suite": "TestCollectionEquality"
+    },
+    {
+      "test": "*",
+      "suite": "TestComplex"
+    },
+    {
+      "test": "*",
+      "suite": "TestContiguousBlockAllocator"
+    },
+    {
+      "test": "*",
+      "suite": "TestControlSpec"
+    },
+    {
+      "test": "*",
+      "suite": "TestCoreUGens"
+    },
+    {
+      "test": "test_ugen_generator_equivalences",
+      "suite": "TestCoreUGens",
+      "skip": true,
+      "skipReason": "Test has failures (FIXME)"
+    },
+    {
+      "test": "*",
       "suite": "TestCurveWarp"
-    }, 
+    },
     {
-      "test": "*", 
-      "suite": "UnitTestScript"
-    }, 
+      "test": "*",
+      "suite": "TestDictionary"
+    },
     {
-      "test": "*", 
+      "test": "*",
+      "suite": "TestDocumentEnvironment"
+    },
+    {
+      "test": "*",
+      "suite": "TestDoneActions"
+    },
+    {
+      "test": "*",
+      "suite": "TestEnv"
+    },
+    {
+      "test": "*",
+      "suite": "TestEnvGate"
+    },
+    {
+      "test": "*",
+      "suite": "TestEnvironmentDocument"
+    },
+    {
+      "test": "*",
+      "suite": "TestEvent"
+    },
+    {
+      "test": "*",
+      "suite": "TestFilterUGens"
+    },
+    {
+      "test": "*",
+      "suite": "TestFloat"
+    },
+    {
+      "test": "*",
+      "suite": "TestFunction"
+    },
+    {
+      "test": "*",
+      "suite": "TestIndexUGenRates"
+    },
+    {
+      "test": "*",
+      "suite": "TestInteger"
+    },
+    {
+      "test": "*",
+      "suite": "TestLcmGcd"
+    },
+    {
+      "test": "*",
+      "suite": "TestMethod"
+    },
+    {
+      "test": "*",
+      "suite": "TestMixedBundleTester"
+    },
+    {
+      "test": "*",
+      "suite": "TestMixedBundle_Server"
+    },
+    {
+      "test": "*",
+      "suite": "TestNamedControl"
+    },
+    {
+      "test": "*",
+      "suite": "TestNetAddr"
+    },
+    {
+      "test": "*",
+      "suite": "TestNoOps"
+    },
+    {
+      "test": "test_arithmetics",
+      "suite": "TestNoOps",
+      "skip": true,
+      "skipReason": "Too many asserts in test causes issues (FIXME)"
+    },
+    {
+      "test": "*",
+      "suite": "TestNode"
+    },
+    {
+      "test": "*",
+      "suite": "TestNodeProxy"
+    },
+    {
+      "test": "*",
+      "suite": "TestNodeProxyRoles"
+    },
+    {
+      "test": "*",
+      "suite": "TestNodeProxy_Server",
+      "skip": true,
+      "skipReason": "Test hangs for unknown reason (FIXME)"
+    },
+    {
+      "test": "*",
+      "suite": "TestNode_Server"
+    },
+    {
+      "test": "*",
+      "suite": "TestOSCBundle"
+    },
+    {
+      "test": "*",
+      "suite": "TestOSCFunc"
+    },
+    {
+      "test": "*",
+      "suite": "TestPV_ChainUGen",
+      "skip": true,
+      "skipReason": "Test leaves the server running (FIXME)"
+    },
+    {
+      "test": "*",
+      "suite": "TestParser"
+    },
+    {
+      "test": "*",
+      "suite": "TestPattern",
+      "skip": true,
+      "skipReason": "reason unknown (FIXME)"
+    },
+    {
+      "test": "*",
+      "suite": "TestPatternProxy",
+      "skip": true,
+      "skipReason": "reason unknown (FIXME)"
+    },
+    {
+      "test": "*",
+      "suite": "TestPlotter"
+    },
+    {
+      "test": "*",
+      "suite": "TestPprotect"
+    },
+    {
+      "test": "*",
+      "suite": "TestQuery"
+    },
+    {
+      "test": "*",
+      "suite": "TestRangeSlider"
+    },
+    {
+      "test": "*",
+      "suite": "TestReadableNodeIDAllocator"
+    },
+    {
+      "test": "*",
+      "suite": "TestRecorder"
+    },
+    {
+      "test": "*",
+      "suite": "TestSCDocHTMLRenderer"
+    },
+    {
+      "test": "*",
+      "suite": "TestSanitize"
+    },
+    {
+      "test": "*",
+      "suite": "TestScore"
+    },
+    {
+      "test": "*",
+      "suite": "TestSerialPort"
+    },
+    {
+      "test": "*",
+      "suite": "TestServer"
+    },
+    {
+      "test": "*",
+      "suite": "TestServerOptions"
+    },
+    {
+      "test": "*",
+      "suite": "TestServer_GUI"
+    },
+    {
+      "test": "*",
+      "suite": "TestServer_ServerGUI"
+    },
+    {
+      "test": "*",
+      "suite": "TestServer_SynthDefVersion1"
+    },
+    {
+      "test": "*",
+      "suite": "TestServer_boot"
+    },
+    {
+      "test": "*",
+      "suite": "TestServer_clientID"
+    },
+    {
+      "test": "*",
+      "suite": "TestServer_clientID_booted"
+    },
+    {
+      "test": "*",
       "suite": "TestSignal"
-    }, 
-    {
-      "suite": "TestUnitTest", "test": "test_toreDown", 
-      "skip": true, "skipReason": "UnitTest bug"
-    }, 
-    {
-      "suite": "TestUnitTest", "test": "test_setUp2", 
-      "skip": true, "skipReason": "UnitTest bug"
-    }, 
-    {
-      "suite": "TestUnitTest", "test": "test_findTestedClass",
-      "skip": true, "skipReason": "Unidentified UnitTest bug"
     },
     {
-      "suite": "TestUnitTest", "test": "test_bootServer", 
-      "skip": true, "skipReason": "No server support on travis"
-    }, 
-    {
-      "test": "test_sendBundle50", 
-      "suite": "TestNetAddr", 
-      "skipReason": "No server support on travis", 
-      "skip": true
-    }, 
-    {
-      "test": "test_send", 
-      "suite": "TestMixedBundleTester", 
-      "skipReason": "No server support on travis", 
-      "skip": true
-    }, 
-    {
-      "test": "test_findPreparationMessage", 
-      "suite": "TestMixedBundleTester", 
-      "skipReason": "No server support on travis", 
-      "skip": true
-    }, 
-    {
-      "suite": "TestMixedBundleTester", "test": "test_defNames",
-      "skip": true, "skipReason": "Unidentified UnitTest bug"
+      "test": "*",
+      "suite": "TestSimpleNumber"
     },
     {
-      "test": "test_prepare", 
-      "suite": "TestOSCBundle", 
-      "skipReason": "No server support on travis", 
-      "skip": true
+      "test": "*",
+      "suite": "TestSoundFile"
+    },
+    {
+      "test": "*",
+      "suite": "TestSoundFile_Normalize"
+    },
+    {
+      "test": "*",
+      "suite": "TestSoundFile_Server"
+    },
+    {
+      "test": "*",
+      "suite": "TestStream"
+    },
+    {
+      "test": "*",
+      "suite": "TestString"
+    },
+    {
+      "test": "*",
+      "suite": "TestSymbol"
+    },
+    {
+      "test": "*",
+      "suite": "TestSynthDefOptimizations"
+    },
+    {
+      "test": "*",
+      "suite": "TestTask"
+    },
+    {
+      "test": "*",
+      "suite": "TestTempoClock"
+    },
+    {
+      "test": "*",
+      "suite": "TestUGen_Duty"
+    },
+    {
+      "test": "*",
+      "suite": "TestUnitTest"
+    },
+    {
+      "test": "*",
+      "suite": "TestVolume"
     }
   ]
 }


### PR DESCRIPTION
:sparkles: :sparkles: :sparkles:  ***WIP - do not merge*** :sparkles: :sparkles: :sparkles:

This PR relates to #3132 and makes use of supercollider/qpm/pull/10

#### List of changes so far:

- Remove cloning `CommonTests` and `CommonTestGUI`
- Install JACK1 instead of JACK2
- Boot JACK using the dummy backend
- Export SC's `bin/` directory to $PATH
- Run `qpm` including the path to `testsuite/classlibrary`
- List all tests in `travis_test_run_proto.json` that are able to run in the CI without causing issue (including tests that boot the serve)

#### Discussion

I learned a lot and also ran into some strange issues while trying to get this to work. I'm going to try and explain some of my choice here so that you can better understand what I've done.

Not installing `CommonTests` means that `qpm` will no longer find UnitTests in the quarks directory. We now need to include the path to `testsuite/classlibrary` when running `qpm`. In order to include multiple paths, `--include` and its paths need to be positioned at the end of the `qpm` command.

The `API` quark is still needed because it contains the class `JSON` which is used by `qpm`.

I've had better luck getting JACK running inside a Docker container on Ubuntu when JACK1 is being used. I don't really know why. Maybe it related to D-BUS? In any case, JACK1 works fine using its `-d dummy` backend.

`qpm test.run` takes an argument `--path` to which we provide the path to `sclang`. Unfortunately, `qpm` is unable to find `scsynth` in this same directory. This would need to be implemented, but for now, exporting SC's `bin/` directory to $PATH solves the issue.

Now for the UnitTests themselves. Some tests wreak havoc when run on Travis: some cause the CI to hang until it eventually times out, others cause the CI to abort suddenly and report success. The problematic tests don't usually cause issue when run locally on your system which makes it hard to know what is actually going on with them. What I've done here is start with basically a full list of our UnitTests and gradually remove the troublesome ones. The current state of `travis_test_run_proto.json` contains a list of tests that appear to be able to run without issue on Travis (fingers still crossed). This isn't to say that they pass, just that they can run.

I've turned on `QPM_DEBUG` when running `qpm test.run`. This is not something we will want to keep once we get things running smoothly.

#### Work still to be done

Getting things to work on macOS is still a part of this PR that has yet to be done. Ideally, we would find a way to boot the server for tests on macOS. Worse case scenario, we'll be maintain two versions of `travis_test_run_proto.json`, one for linux and one for macOS.

There are still failing tests in the CI that don't necessarily fail when run locally.

This PR currently runs through its list of tests successfully (it seems). However, something is causing the CI to report failure immediately after `qpm/scscripts/test_runner.sc` finished. I haven't been able to find the cause. The Travis log looks like this:

```
    witing to file: /home/travis/build/supercollider/supercollider/BUILD/travis_test_run.json

    ******** DONE ********

    Server 'TestUnitTest' exited with exit code 0.

    main: waiting for input thread to join...

    main: quitting...

    cleaning up OSC

    2020-01-26 01:11:48,704 (DEBUG) qpm : Wait result: <_sre.SRE_Match object at 0x7fb39a0bf510>

    ERROR:

    Invalid control character at: line 1 column 8701 (char 8700)

    The command "$TRAVIS_BUILD_DIR/.travis/test.sh" exited with 1.
```

The line `... (DEBUG) qpm : Wait result ...` is something I see when running things on my system. However, the `<_sre.SRE_Match object at 0x7fb39a0bf510>` part is not something that I've seen. I haven't seen the `Invalid control character at: line 1 column xxxx (char xxxx)` line when testing locally either.


