### PR TITLE
add tests for PR 4436

### DIFF
--- a/testsuite/classlibrary/TestEnv.sc
+++ b/testsuite/classlibrary/TestEnv.sc
@@ -3,6 +3,7 @@ Env.test
 UnitTest.gui
 */
 TestEnv : UnitTest {
+	var server;
 
 	test_equality {
 		var a,b,c;
@@ -24,6 +25,93 @@ TestEnv : UnitTest {
 			Env.cutoff(1, 1, 'exp').asSignal(20).as(Array),
 			Env.cutoff(1, 1, 'lin').asSignal(20).asArray.linexp(0,1,-100.dbamp,1),
 			"Exponential Env.cutoff should be same as linear Env.cutoff.linexp");
+	}
+
+	setUp {
+		server = Server(this.class.name);
+	}
+
+	tearDown {
+		server.remove;
+	}
+
+	test_noff_bug334 {
+		var synth, n_off_resp, n_end_resp, passed,
+		cond = Condition.new,
+		cleanup = {
+			n_off_resp.free;
+			n_end_resp.free;
+			server.quit;
+		};
+		this.bootServer(server);
+		synth = {
+			// doneAction: 1 should reach end *after* doneAction: 2 envelope ends
+			// correct behavior is that '/n_off' is never sent
+			EnvGen.kr(Env([0, 1], [0.2]), gate: 0, doneAction: 1);
+			EnvGen.kr(Env([0, 1], [0.1]), doneAction: 2);
+		}.play(server);
+		n_off_resp = OSCFunc({
+			cleanup.value;
+			passed = false;
+			cond.unhang;
+		}, '/n_off', server.addr, argTemplate: [synth.nodeID]);
+		// responsible for cleaning up this test
+		// n_off_resp should NOT fire! so we need another for the stop condition
+		n_end_resp = OSCFunc({
+			cleanup.value;
+			passed = true;
+			cond.unhang;
+		}, '/n_end', server.addr, argTemplate: [synth.nodeID]);
+		cond.hang;
+		this.assert(passed, "EnvGen: Initial gate == 0 with doneAction == 1 should not send /n_off");
+	}
+
+	// has failed in supernova
+	// methodology: synth should play for 0.1 sec if it's working
+	// so we will send a trigger just before the envelope ends
+	// if the bug occurs, the synth will end almost immediately -- no trigger
+	test_nongated_bug3094 {
+		var n_end_resp, tr_resp, synth,
+		program = [\scsynth], failure,
+		cleanup = {
+			tr_resp.free;
+			n_end_resp.free;
+			server.quit;
+			Server.scsynth;
+		},
+		cond = Condition.new;
+		// we need to test supernova.
+		// In unixy systems, we can try to get the executable path
+		// Windows, I don't know
+		if(thisProcess.platform.name != "windows" and: {
+			"which supernova".unixCmdGetStdOut.size > 0
+		}) {
+			program = program ++ [\supernova];
+		};
+		program.do { |p|
+			var gotTrigger = false;
+			Server.perform(p);
+			this.bootServer(server);
+			synth = {
+				var gate = Impulse.kr(0);
+				SendTrig.kr(TDelay.kr(gate, 0.09), 0, 1);
+				EnvGen.kr(Env([0, 1], [0.1]), gate, doneAction: 2);
+			}.play(server);
+			tr_resp = OSCFunc({ |msg|
+				gotTrigger = true;
+			}, '/tr', server.addr, argTemplate: [synth.nodeID]);
+			n_end_resp = OSCFunc({ |msg|
+				cleanup.value;
+				cond.unhang;
+			}, '/n_end', server.addr, argTemplate: [synth.nodeID]);
+			cond.hang;
+			if(gotTrigger.not) { failure = failure.add(p) };
+		};
+		this.assert(failure.size == 0, "EnvGen: Closing gate should not affect non-gated envelope %".format(
+			if(failure.size == 0) { "" } {
+				"(failed in %)".format(failure)
+			}
+		));
 	}
 
 	/*

--- a/testsuite/classlibrary/TestEnv.sc
+++ b/testsuite/classlibrary/TestEnv.sc
@@ -3,7 +3,6 @@ Env.test
 UnitTest.gui
 */
 TestEnv : UnitTest {
-	var server;
 
 	test_equality {
 		var a,b,c;
@@ -25,93 +24,6 @@ TestEnv : UnitTest {
 			Env.cutoff(1, 1, 'exp').asSignal(20).as(Array),
 			Env.cutoff(1, 1, 'lin').asSignal(20).asArray.linexp(0,1,-100.dbamp,1),
 			"Exponential Env.cutoff should be same as linear Env.cutoff.linexp");
-	}
-
-	setUp {
-		server = Server(this.class.name);
-	}
-
-	tearDown {
-		server.remove;
-	}
-
-	test_noff_bug334 {
-		var synth, n_off_resp, n_end_resp, passed,
-		cond = Condition.new,
-		cleanup = {
-			n_off_resp.free;
-			n_end_resp.free;
-			server.quit;
-		};
-		this.bootServer(server);
-		synth = {
-			// doneAction: 1 should reach end *after* doneAction: 2 envelope ends
-			// correct behavior is that '/n_off' is never sent
-			EnvGen.kr(Env([0, 1], [0.2]), gate: 0, doneAction: 1);
-			EnvGen.kr(Env([0, 1], [0.1]), doneAction: 2);
-		}.play(server);
-		n_off_resp = OSCFunc({
-			cleanup.value;
-			passed = false;
-			cond.unhang;
-		}, '/n_off', server.addr, argTemplate: [synth.nodeID]);
-		// responsible for cleaning up this test
-		// n_off_resp should NOT fire! so we need another for the stop condition
-		n_end_resp = OSCFunc({
-			cleanup.value;
-			passed = true;
-			cond.unhang;
-		}, '/n_end', server.addr, argTemplate: [synth.nodeID]);
-		cond.hang;
-		this.assert(passed, "EnvGen: Initial gate == 0 with doneAction == 1 should not send /n_off");
-	}
-
-	// has failed in supernova
-	// methodology: synth should play for 0.1 sec if it's working
-	// so we will send a trigger just before the envelope ends
-	// if the bug occurs, the synth will end almost immediately -- no trigger
-	test_nongated_bug3094 {
-		var n_end_resp, tr_resp, synth,
-		program = [\scsynth], failure,
-		cleanup = {
-			tr_resp.free;
-			n_end_resp.free;
-			server.quit;
-			Server.scsynth;
-		},
-		cond = Condition.new;
-		// we need to test supernova.
-		// In unixy systems, we can try to get the executable path
-		// Windows, I don't know
-		if(thisProcess.platform.name != "windows" and: {
-			"which supernova".unixCmdGetStdOut.size > 0
-		}) {
-			program = program ++ [\supernova];
-		};
-		program.do { |p|
-			var gotTrigger = false;
-			Server.perform(p);
-			this.bootServer(server);
-			synth = {
-				var gate = Impulse.kr(0);
-				SendTrig.kr(TDelay.kr(gate, 0.09), 0, 1);
-				EnvGen.kr(Env([0, 1], [0.1]), gate, doneAction: 2);
-			}.play(server);
-			tr_resp = OSCFunc({ |msg|
-				gotTrigger = true;
-			}, '/tr', server.addr, argTemplate: [synth.nodeID]);
-			n_end_resp = OSCFunc({ |msg|
-				cleanup.value;
-				cond.unhang;
-			}, '/n_end', server.addr, argTemplate: [synth.nodeID]);
-			cond.hang;
-			if(gotTrigger.not) { failure = failure.add(p) };
-		};
-		this.assert(failure.size == 0, "EnvGen: Closing gate should not affect non-gated envelope %".format(
-			if(failure.size == 0) { "" } {
-				"(failed in %)".format(failure)
-			}
-		));
 	}
 
 	/*

--- a/testsuite/classlibrary/TestEnvGen_server.sc
+++ b/testsuite/classlibrary/TestEnvGen_server.sc
@@ -1,0 +1,100 @@
+TestEnvGen_server : UnitTest {
+
+	var server;
+
+	setUp {
+		server = Server(this.class.name);
+	}
+
+	tearDown {
+		if(server.serverRunning) { server.quit };
+		server.remove;
+	}
+
+	test_zero_gate_n_off_not_sent {
+		var synth, n_off_resp, n_end_resp, passed;
+		var cond = Condition.new;
+		var cleanup = {
+			n_off_resp.free;
+			n_end_resp.free;
+		};
+
+		server.bootSync;
+		synth = {
+			// doneAction: 1 should reach end *after* doneAction: 2 envelope ends
+			// correct behavior is that '/n_off' is never sent
+			EnvGen.kr(Env([0, 1], [0.2]), gate: 0, doneAction: 1);
+			EnvGen.kr(Env([0, 1], [0.1]), doneAction: 2);
+		}.play(server);
+
+		n_off_resp = OSCFunc({
+			cleanup.value;
+			passed = false;
+			cond.unhang;
+		}, '/n_off', server.addr, argTemplate: [synth.nodeID]);
+
+		// responsible for cleaning up this test
+		// n_off_resp should NOT fire! so we need this to unhang the condition
+		n_end_resp = OSCFunc({
+			cleanup.value;
+			passed = true;
+			cond.unhang;
+		}, '/n_end', server.addr, argTemplate: [synth.nodeID]);
+
+		cond.hang;
+		this.assert(passed, "Initial gate == 0 with doneAction == 1 should not send /n_off");
+	}
+
+	// has failed in supernova
+	// methodology: synth should play for 0.1 sec if it's working
+	// so we will send a trigger just before the envelope ends
+	// if the bug occurs, the synth will end almost immediately -- no trigger
+	test_trig_gate_nonsustain_env {
+		var n_end_resp, tr_resp, synth;
+		var program = [\scsynth];
+		var cond = Condition.new;
+		var cleanup = {
+			tr_resp.free;
+			n_end_resp.free;
+			server.quit;
+			Server.scsynth;
+		};
+
+		// we need to test supernova.
+		// In unixy systems, we can try to get the executable path
+		// Windows, I don't know
+		if(
+			thisProcess.platform.name != "windows"
+			and: { "which supernova".unixCmdGetStdOut.size > 0 }
+		) {
+			program = program ++ [\supernova];
+		};
+
+		program.do { |p|
+			var gotTrigger = false;
+
+			Server.perform(p);
+			server.bootSync;
+
+			synth = {
+				var gate = Impulse.kr(0);
+				SendTrig.kr(TDelay.kr(gate, 0.09), 0, 1);
+				EnvGen.kr(Env([0, 1], [0.1]), gate, doneAction: 2);
+			}.play(server);
+
+			tr_resp = OSCFunc({ |msg|
+				gotTrigger = true;
+			}, '/tr', server.addr, argTemplate: [synth.nodeID]);
+
+			n_end_resp = OSCFunc({ |msg|
+				cleanup.value;
+				cond.unhang;
+			}, '/n_end', server.addr, argTemplate: [synth.nodeID]);
+
+			cond.hang;
+			this.assert(gotTrigger, "Closing gate should not affect non-sustaining envelopes when using %".format(p));
+		};
+	}
+
+}
+


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

This PR is a redo of #3684, keeping only its UnitTest and not the other changes. The history around #3684 is a bit complicated. The new tests introduced here pass on current `develop`. I believe this is because #4436 was merged.

Thanks to @jamshark70 for twritting these tests. I made the changes to `setUp` and `tearDown` that @brianlheim requested.

## Types of changes

<!-- Delete lines that don't apply -->

- UnitTests

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [X] Code is tested
- [X] All tests are passing
- [ ] Updated documentation
- [X] This PR is ready for review
