### PR TITLE
Fix NamedControl 'name' String convertion

### DIFF
--- a/SCClassLibrary/Common/Control/GraphBuilder.sc
+++ b/SCClassLibrary/Common/Control/GraphBuilder.sc
@@ -121,11 +121,11 @@ NamedControl {
 	}
 
 	init {
-		var prefix, ctlName, ctl, selector;
+		var prefix, str;
 
 		name !? {
-			name = name.asString;
-			if(name[1] == $_) { prefix = name[0]; ctlName = name[2..] } { ctlName = name };
+			str = name.asString;
+			if(str[1] == $_) { prefix = str[0] };
 		};
 
 		if(fixedLag && lags.notNil && prefix.isNil) {


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

A NamedControl's `name` is converted from a Symbol to a String in cases where the `.init` function is called (when `res == nil`). I stumbled upon this while testing #3814. This issue should be fixed before that PR gets merged. 

I'm not sure how to demonstrate the issue using current `develop`, but it may be simple enough to understand just by looking at the changes. Some unused variables were removed (`ctlName`, `ctl`, & `selector`), and `name` stays a Symbol throughout the `.init` function.

## Types of changes

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [ ] Code is tested
- [ ] All tests are passing
- [ ] Updated documentation
- [X] This PR is ready for review
