### PR TITLE
supernova: fix msvc build

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -96,7 +96,7 @@ before_build:
 - cd build
 
 build_script:
-- cmake -G "%CMAKE_GENERATOR%" -A "%CMAKE_ARCH%" -D CMAKE_PREFIX_PATH=%QT_DIR% ..
+- cmake -G "%CMAKE_GENERATOR%" -A "%CMAKE_ARCH%" -D CMAKE_PREFIX_PATH=%QT_DIR% -D SUPERNOVA=ON ..
 - cmake --build . --target install --config %CMAKE_CONFIGURATION%
 
 # after_build instead of before_deploy so artifacts are collected at the right time

--- a/README_WINDOWS.md
+++ b/README_WINDOWS.md
@@ -722,8 +722,8 @@ run:
     $> cmake .. -L
 
 This will show us amongst other things, that an option to build plugin versions
-for the alternative audio server `supernova` is available (not availale in
-VS builds). To add them to the build, just run:
+for the alternative audio server `supernova` is available. To add them to the
+build, just run:
 
     $> cmake -DSUPERNOVA=ON ..
 
@@ -880,10 +880,9 @@ subsequent run regardless of whether the cache has been deleted or not. That can
 be helpful at times, and confusing in other situations.
 
 *Note*: resist the temptation to enable all options that seem promising. Some of
-them don't work in the Windows build. For example the supernova server can't be
-built with VS yet. Usually SuperCollider's default values are a considered
-choice that should only be changed for a good reason (see the walkthrough for
-"More CMake" for some options that do work).
+them don't work in the Windows build. Usually SuperCollider's default values are 
+a considered choice that should only be changed for a good reason (see the
+walkthrough for "More CMake" for some options that do work).
 
 CMake will generate a solution file in the build folder. Use it to start VS, and
 you are ready to develop and build in this feature rich IDE. If you started
@@ -1053,8 +1052,7 @@ Commonly used variables to modify the build configuration are:
 
   *Note*: When you build with supernova, an alternative server executable and
   a supernova version of each plugin is built. If you also use the 'sc3-plugins'
-  package, make sure to compile them with supernova support too. At the time
-  of this writing supernova could only be built with the MinGW toolchain.
+  package, make sure to compile them with supernova support too.
 
   Within SC you will be able to switch between scsynth and supernova by
   evaluating one of lines below and then booting the server as usual:
@@ -1071,13 +1069,6 @@ Commonly used variables to modify the build configuration are:
   anywhere in the Extensions folder (or in any "included" class folder), whereas
   the binary plugins should reside in a folder "plugins" (this mirrors the situation
   in the application directory)
-
-  *Note*: While there is no readily available 64-bit Qt version for the MinGW
-  build, supernova does not depend on Qt. Therefore a qt-less build could be
-  used to build a 64-bit version of SuperNova, and combine it with the 64-bit
-  VS build of the IDE and sclang (using MinGW runtimes for supernova). The
-  64-bit build of supernova currently breaks, but might be more easy to fix
-  than the VS build.
 
 * It is possible to build SuperCollider without the IDE, and even without Qt
   (and implicitly without the IDE). This is not controlled via build targets,
@@ -1236,8 +1227,6 @@ Known issues
 ============
 
 - READLINE/Command line-mode for sclang is not available.
-
-- Supernova is not available.
 
 - using shell commands from SC only works in a quite limited way (and always did).
   .unixCmd expects a unix shell, only for essential requirements workarounds

--- a/server/supernova/audio_backend/portaudio_backend.hpp
+++ b/server/supernova/audio_backend/portaudio_backend.hpp
@@ -270,12 +270,12 @@ private:
         if (statusFlags & (paInputOverflow | paInputUnderflow | paOutputOverflow | paOutputUnderflow))
             engine_functor::sync_clock();
 
-        const float* inputs[input_channels];
+        auto** inputs = static_cast<const float**>(alloca(sizeof(float*) * input_channels));
         float* const* in = static_cast<float* const*>(inputBuffer);
         for (uint16_t i = 0; i != input_channels; ++i)
             inputs[i] = in[i];
 
-        float* outputs[output_channels];
+        auto** outputs = static_cast<float**>(alloca(sizeof(float*) * output_channels));
         float** out = static_cast<float**>(outputBuffer);
         for (uint16_t i = 0; i != output_channels; ++i)
             outputs[i] = out[i];

--- a/server/supernova/dsp_thread_queue/dsp_thread_queue.hpp
+++ b/server/supernova/dsp_thread_queue/dsp_thread_queue.hpp
@@ -425,7 +425,7 @@ private:
         const int backoff_iterations = 100;
 
         vector<nanoseconds> measured_values;
-        generate_n(back_inserter(measured_values), 16, [] {
+        generate_n(back_inserter(measured_values), 16, [backoff_iterations] {
             backoff b(max_backup_loops, max_backup_loops);
             auto start = high_resolution_clock::now();
 

--- a/server/supernova/sc/sc_osc_handler.cpp
+++ b/server/supernova/sc/sc_osc_handler.cpp
@@ -634,7 +634,7 @@ void sc_osc_handler::handle_receive_udp(const boost::system::error_code& error, 
         return;
     }
 
-    handle_packet_async(recv_buffer_.begin(), bytes_transferred, make_shared<udp_endpoint>(udp_remote_endpoint_));
+    handle_packet_async(recv_buffer_.data(), bytes_transferred, make_shared<udp_endpoint>(udp_remote_endpoint_));
 
     start_receive_udp();
     return;

--- a/server/supernova/sc/sc_plugin_interface.cpp
+++ b/server/supernova/sc/sc_plugin_interface.cpp
@@ -19,6 +19,8 @@
 #include <cstdarg>
 #include <random>
 
+#include "SC_Win32Utils.h"
+
 #include "SC_SndFileHelpers.hpp"
 
 #include "sc_plugin_interface.hpp"

--- a/server/supernova/sc/sc_synth.cpp
+++ b/server/supernova/sc/sc_synth.cpp
@@ -18,6 +18,8 @@
 
 #include <cstdio>
 
+#include "SC_Win32Utils.h"
+
 #include <boost/align/align_up.hpp>
 
 #include "sc_synth.hpp"

--- a/server/supernova/sc/sc_synth.hpp
+++ b/server/supernova/sc/sc_synth.hpp
@@ -117,10 +117,13 @@ public:
 
         static const size_t cacheline_size = 64;
 
-        for (; ptr < end; ptr += cacheline_size)
+        for (; ptr < end; ptr += cacheline_size) {
 #ifdef __GNUC__
             __builtin_prefetch(ptr, 0, 0);
+#elif defined(_MSC_VER)
+            _mm_prefetch(ptr, 0);
 #endif
+        }
     }
 
     void run(void) override;

--- a/server/supernova/sc/sc_ugen_factory.cpp
+++ b/server/supernova/sc/sc_ugen_factory.cpp
@@ -22,7 +22,7 @@
 #ifdef DLOPEN
 #    include <dlfcn.h>
 #elif defined(_WIN32)
-#    include "Windows.h"
+#    include "SC_Win32Utils.h"
 #endif
 
 #include <boost/filesystem.hpp>

--- a/server/supernova/server/main.cpp
+++ b/server/supernova/server/main.cpp
@@ -22,6 +22,8 @@
 #include <string>
 #include <vector>
 
+#include "SC_Win32Utils.h"
+
 #include <boost/filesystem/path.hpp>
 #include <boost/algorithm/string.hpp>
 

--- a/server/supernova/server/node_graph.cpp
+++ b/server/supernova/server/node_graph.cpp
@@ -93,13 +93,13 @@ abstract_group::~abstract_group(void) {
 }
 
 void abstract_group::pause(void) {
-    for (server_node& node : child_nodes)
-        node.pause();
+    for (server_node& child_node : child_nodes)
+        child_node.pause();
 }
 
 void abstract_group::resume(void) {
-    for (server_node& node : child_nodes)
-        node.resume();
+    for (server_node& child_node : child_nodes)
+        child_node.resume();
 }
 
 void abstract_group::add_child(server_node* node) {

--- a/server/supernova/server/node_graph.cpp
+++ b/server/supernova/server/node_graph.cpp
@@ -59,7 +59,7 @@ void node_graph::synth_reassign_id(int32_t node_id) {
     int32_t hidden_id = -std::abs(node_id);
 
     while (!node_id_available(hidden_id))
-        hidden_id = -std::abs<int32_t>(hasher(node_id));
+        hidden_id = -std::abs(static_cast<int32_t>(hasher(node_id)));
 
     assert(hidden_id < 0);
 
@@ -72,7 +72,7 @@ int32_t node_graph::generate_node_id(void) {
     int32_t new_id;
     do {
         for (;;) {
-            new_id = -std::abs<int32_t>(server_node::hash(generated_id));
+            new_id = -std::abs(static_cast<int32_t>(server_node::hash(generated_id)));
             if (likely(new_id != generated_id))
                 break;
 
@@ -103,14 +103,14 @@ void abstract_group::resume(void) {
 }
 
 void abstract_group::add_child(server_node* node) {
-    assert(not has_child(node));
+    assert(!has_child(node));
 
     child_nodes.push_front(*node);
     node->set_parent(this);
 }
 
 void abstract_group::replace_child(server_node* node, server_node* node_to_replace) {
-    assert(not has_child(node));
+    assert(!has_child(node));
     assert(has_child(node_to_replace));
 
     server_node_list::iterator position_of_old_element = server_node_list::s_iterator_to(*node_to_replace);
@@ -195,7 +195,7 @@ int parallel_group::tail_nodes(void) const {
 }
 
 void group::add_child(server_node* node, node_position_constraint const& constraint) {
-    assert(not has_child(node));
+    assert(!has_child(node));
 
     server_node* ref = constraint.first;
     node_position position = constraint.second;
@@ -217,7 +217,7 @@ void parallel_group::add_child(server_node* node, node_position_constraint const
 }
 
 void group::add_child(server_node* node, node_position position) {
-    assert(not has_child(node));
+    assert(!has_child(node));
     assert((position == head) || (position == tail));
 
     if (position == head)

--- a/server/supernova/server/server.cpp
+++ b/server/supernova/server/server.cpp
@@ -18,6 +18,8 @@
 
 #include <stdexcept>
 
+#include "SC_Win32Utils.h"
+
 #include "nova-tt/thread_affinity.hpp"
 #include "nova-tt/thread_priority.hpp"
 #include "nova-tt/name_thread.hpp"

--- a/server/supernova/server/synth_definition.hpp
+++ b/server/supernova/server/synth_definition.hpp
@@ -67,7 +67,7 @@ protected:
     ~slot_resolver(void) { slot_resolver_map.clear_and_dispose(boost::checked_deleter<map_type>()); }
 
     void register_slot(symbol const& str, slot_index_t i, int number_of_values) {
-        assert(not exists(str.c_str()));
+        assert(!exists(str.c_str()));
         map_type* elem = new map_type(str, i, number_of_values);
         bool success = slot_resolver_map.insert(*elem).second;
         assert(success);

--- a/server/supernova/utilities/static_pool.hpp
+++ b/server/supernova/utilities/static_pool.hpp
@@ -53,7 +53,7 @@ public:
             lock_memory();
 
         data_.pool.fill(0);
-        std::size_t status = init_memory_pool(bytes, data_.pool.begin());
+        std::size_t status = init_memory_pool(bytes, data_.pool.data());
         assert(status > 0);
     }
 
@@ -61,17 +61,17 @@ public:
 
     ~static_pool() throw() {
         scoped_lock lock(data_);
-        destroy_memory_pool(data_.pool.begin());
+        destroy_memory_pool(data_.pool.data());
     }
 
     void* malloc(std::size_t size) {
         scoped_lock lock(data_);
-        return malloc_ex(size, data_.pool.begin());
+        return malloc_ex(size, data_.pool.data());
     }
 
     void free(void* p) {
         scoped_lock lock(data_);
-        free_ex(p, data_.pool.begin());
+        free_ex(p, data_.pool.data());
     }
 
     std::size_t get_max_size(void) { return ::get_max_size(data_.pool.begin()); }


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->
Fixes #3766.
This is an attempt to make `supernova` available on Windows with the supported toolchain (Visual Studio). I think I figured out _what_ to change, but I'm looking for advice _how_ to change it. More information below.

EDIT: In the interest of brevity, I've hidden parts of the description that have already been addressed.

<details>

EDIT: This builds and runs on my machine under VS 2017. CI fails because I'm using my own fork of nova-tt. Is this something to be solved temporarily, before changes to nova-tt are submitted upstream?
EDIT 2: I've temporarily changed the nova-tt submodule to use my fork for the CI to pass.
EDIT 3: nova-tt submodule is now updated upstream

</details>

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix
- (Documentation)

## Notes

### nova-tt
<details>

`nova-tt` generally has cross-platform implementation for the functionality we use, but it seems that the [rw_mutex.hpp](https://github.com/timblechmann/nova-tt/compare/103dd25bb9fd0a359fff685d6aefd8028822afcc...f04436f4e8c0b7a3e6d2896b2dd25013d82a6c69#diff-c4c4c2b9d7108b582bc4bc090a40ba13) had a bug and there were no proper guards around `pthread` code on windows. I believe that `boost::shared_mutex` is a non-recursive one, so I exposed it under `nova_tt::nonrecursive_rw_mutex` and I added guards around `pthread` code as well as `nova_tt::rw_mutex`  (which we don't use).
AFAIU this should be submitted upstream and I'm happy to do that once others take a look and give feedback whether this looks reasonable.

</details>

### casts
<details>

In [sc_osc_handler.hpp](https://github.com/supercollider/supercollider/compare/develop...dyfer:topic/supernova-msvc?expand=1#diff-10cb142c0aa41ab047740d1fd0f35c75) and [static_pool.hpp](https://github.com/supercollider/supercollider/compare/develop...dyfer:topic/supernova-msvc?expand=1#diff-e0b9fb964f25c2dc49c7b59acb2cd147) I was getting an error `cannot convert from std::_array_iterator_T(...) to (void *)` or `(const char*)`. The solution I came up with doesn't seem proper, but it works. I'd love to learn how to deal with this properly.
</details>

### winsock2.h

I was getting errors that suggested that Windows libraries are not properly referenced. Adding this header [here](https://github.com/supercollider/supercollider/compare/develop...dyfer:topic/supernova-msvc?expand=1#diff-fd06e22b7336ea70a06e9a594f831a43) and [here](https://github.com/supercollider/supercollider/compare/develop...dyfer:topic/supernova-msvc?expand=1#diff-81e90ee1041e463a9c9a424f4d95eb2a) solved it, but maybe there's a better place to include it.

EDIT: I replaced these includes with `SC_Win32Utils.h` which was not included before. I did this for every file that failed to build...

### capture mode
<details>

In [dsp_thread_queue.hpp](https://github.com/supercollider/supercollider/compare/develop...dyfer:topic/supernova-msvc?expand=1#diff-6bb5e8f41922489573d7414621b0f820) I was getting an error `"backoff_iterations" cannot be implicitly captured because no default capture mode has been specified`. I'm not sure if my solution is correct.
</details>

### cache prefetch

I added [prefetch function](https://github.com/supercollider/supercollider/pull/4763/files#diff-81e90ee1041e463a9c9a424f4d95eb2aR128) for MSVC. I'm not sure if it's better to have it or skip prefetching under MSVC. My (limited) testing of builds with and without this did not yield conclusive results.

Other changes seem more straightforward, like replacing `not` with `!`. There are also some other casts which were needed but I'm not sure why.

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] Updated documentation
- [x] This PR is ready for review

I think it would be best to squash merge this PR (?)