### PR TITLE
CMake: fix linking with makefiles+supernova+macos

### DIFF
--- a/testsuite/server/supernova/CMakeLists.txt
+++ b/testsuite/server/supernova/CMakeLists.txt
@@ -27,7 +27,7 @@ foreach(test ${simple_tests})
   string(REPLACE .cpp "" test_name ${test} )
   add_executable(${test_name} ${test})
 
-  target_link_libraries(${test_name} libsupernova boost_test boost_thread_lib)
+  target_link_libraries(${test_name} boost_test libsupernova boost_thread_lib)
 
   add_test(${test_name}_run ${EXECUTABLE_OUTPUT_PATH}/${test_name})
 endforeach(test)


### PR DESCRIPTION
## Purpose and Motivation

without this ordering, libsupernova is used to resolve symbols first and results
in undefined reference linker errors on supernova tests

## Types of changes

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review