### PR TITLE
Topic/pdef clear fixes

### DIFF
--- a/SCClassLibrary/JITLib/Patterns/Pdef.sc
+++ b/SCClassLibrary/JITLib/Patterns/Pdef.sc
@@ -174,7 +174,8 @@ PatternProxy : Pattern {
 	}
 
 	*clear {
-		this.all.do { arg pat; pat.clear }
+		this.all.do { arg pat; pat.clear };
+		this.all.clear;
 	}
 
 	clear {


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

Where the old source pattern is shorter than the quant value, Pdef /
EventPatternProxy would start the new pattern too early. This is
because Pfindur only cuts and doesn’t extend. This change checks if the
stream has ended and adds a silent event that holds the time until the
new pattern comes in.

fixes #4767.

Also Pdef.clear didn't empty the dictionary as expected, this is fixed, too.

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

Internal changes to embedInStream and constrainStream in EventPatternProxy

<!-- Delete lines that don't apply -->

- Bug fix

Possible breakage:
If someone would use a Pdef to stream a pattern that sometimes returns `nil` and then values again, this would change behaviour now (it would stop). But all other patterns behave like this, so it is an edge case. Opinions welcome. 

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [ ] Code is tested
- [x] All tests are passing
- [ ] This PR is ready for review
