### PR TITLE
classlib: kill both scsynth and supernova with Server -killAll

### DIFF
--- a/HelpSource/Classes/Server.schelp
+++ b/HelpSource/Classes/Server.schelp
@@ -112,7 +112,7 @@ method:: quitAll
 quit all registered servers
 
 method:: killAll
-query the system for any sc-server apps and hard quit them
+kill all the processes called "scsynth" and "supernova" in the system
 
 method:: freeAll
 free all nodes in all registered servers

--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -1129,7 +1129,15 @@ Server {
 		// you can't cause them to quit via OSC (the boot button)
 
 		// this brutally kills them all off
-		thisProcess.platform.killAll(this.program.basename);
+		thisProcess.platform.name.switch(
+			\windows, {
+				thisProcess.platform.killAll("scsynth.exe");
+				thisProcess.platform.killAll("supernova.exe");
+			}, {
+				thisProcess.platform.killAll("scsynth");
+				thisProcess.platform.killAll("supernova");
+			}
+		);
 		this.quitAll(watchShutDown: false);
 	}
 


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->
This PR makes `Server -killAll` command kill both `scsynth` and `supernova`.
Fixes #3999

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## Notes

I think that handling `scsynth` vs `supernova` throughout the `Server.sc` should be revisited, possibly defining executable strings in one place only. I had some [initial thoughts](https://github.com/supercollider/supercollider/issues/3999#issuecomment-414836118) on this, but it would be for a separate PR anyway.


## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] Updated documentation
- [x] This PR is ready for review
