### PR TITLE
Topic/fix pdef clear

### DIFF
--- a/HelpSource/Classes/Pfindur.schelp
+++ b/HelpSource/Classes/Pfindur.schelp
@@ -8,12 +8,34 @@ ClassMethods::
 method::new
 Embeds elements of the strong::pattern:: into the stream until the duration comes close enough to strong::dur::.
 
+argument::dur
+The duration in beats after which the straem should end, derived from the event keys code::dur:: or code::delta::. The delta of the last event is adjusted so that the total duration fits this value. If the stream is shorter than dur, a code::filler:: (see below) can be used to fill the gap.
+
+argument::pattern
+The pattern to cut short. This should be an event pattern (returning a stream of events).
+
+argument::tolerance
+measuring tolerance for the total duration to avoid jitter
+
+argument::filling
+A function or event that can be used to provide the last event with which to fill the gap after a stream has ended before the code::dur:: is reached.
+
+
+
 Examples::
 
 code::
 (
 var a, b;
 a = Pfindur(5, Pbind(\dur, Prand([1, 2, 0.5, 0.1], inf)));
+x = a.asStream;
+9.do({ x.next(Event.default).postln; });
+)
+
+
+(
+var a, b;
+a = Pfindur(5, Pbind(\dur, Prand([1, 2, 0.5, 0.1], 4)), filling: (note: 1920));
 x = a.asStream;
 9.do({ x.next(Event.default).postln; });
 )

--- a/HelpSource/Classes/Pfindur.schelp
+++ b/HelpSource/Classes/Pfindur.schelp
@@ -41,15 +41,14 @@ x = a.asStream;
 )
 
 
-//Pfindur used as a sequence of pitches
+// Pfindur used as a sequence of pitches
 
 (
-SynthDef(\help_sinegrain,
-	{ arg out=0, freq=440, sustain=0.05;
-		var env;
-		env = EnvGen.kr(Env.perc(0.01, sustain, 0.2), doneAction: Done.freeSelf);
-		Out.ar(out, SinOsc.ar(freq, 0, env))
-	}).add;
+SynthDef(\help_sinegrain, { | out=0, freq=440, sustain=0.05 |
+	var env;
+	env = EnvGen.kr(Env.perc(0.01, sustain, 0.2), doneAction: Done.freeSelf);
+	Out.ar(out, SinOsc.ar(freq, 0, env))
+}).add;
 )
 
 (
@@ -63,6 +62,21 @@ c = Pbind(
 
 Pn(
 	Pfindur(1, c)
+).play;
+)
+
+// using a filling:
+(
+var c;
+c = Pbind(
+	\dur, Prand([1, 0.02, 0.2], 3),
+	\instrument, \help_sinegrain,
+	\degree, Pseries(0, 1, inf),
+	\octave, 6
+);
+
+Pn(
+	Pfindur(1.5, c, filling: Event.silent)
 ).play;
 )
 ::

--- a/SCClassLibrary/Common/Streams/FilterPatterns.sc
+++ b/SCClassLibrary/Common/Streams/FilterPatterns.sc
@@ -414,9 +414,9 @@ Pfinval : Pfin {
 }
 
 Pfindur : FilterPattern {
-	var <>dur, <>tolerance;
-	*new { arg dur, pattern, tolerance = 0.001;
-		^super.new(pattern).dur_(dur).tolerance_(tolerance)
+	var <>dur, <>tolerance, <>filling;
+	*new { arg dur, pattern, tolerance = 0.001, filling;
+		^super.new(pattern).dur_(dur).tolerance_(tolerance).filling_(filling)
 	}
 	storeArgs { ^[dur,pattern,tolerance] }
 
@@ -426,7 +426,12 @@ Pfindur : FilterPattern {
 		var stream = pattern.asStream;
 		var cleanup = EventStreamCleanup.new;
 		loop {
-			inevent = stream.next(event).asEvent ?? { ^event };
+			inevent = stream.next(event).asEvent ?? {
+				if(filling.notNil) {
+					filling.value(event).put(\delta, localdur - elapsed).yield
+				};
+				^event
+			};
 			cleanup.update(inevent);
 			delta = inevent.delta;
 			nextElapsed = elapsed + delta;

--- a/SCClassLibrary/Common/Streams/FilterPatterns.sc
+++ b/SCClassLibrary/Common/Streams/FilterPatterns.sc
@@ -418,7 +418,8 @@ Pfindur : FilterPattern {
 	*new { arg dur, pattern, tolerance = 0.001, filling;
 		^super.new(pattern).dur_(dur).tolerance_(tolerance).filling_(filling)
 	}
-	storeArgs { ^[dur,pattern,tolerance] }
+
+	storeArgs { ^[dur, pattern, tolerance, filling] }
 
 	embedInStream { arg event;
 		var item, delta, elapsed = 0.0, nextElapsed, inevent;

--- a/SCClassLibrary/JITLib/Patterns/Pdef.sc
+++ b/SCClassLibrary/JITLib/Patterns/Pdef.sc
@@ -174,7 +174,8 @@ PatternProxy : Pattern {
 	}
 
 	*clear {
-		this.all.do { arg pat; pat.clear }
+		this.all.do { arg pat; pat.clear };
+		this.all.clear;
 	}
 
 	clear {

--- a/SCClassLibrary/JITLib/Patterns/Pdef.sc
+++ b/SCClassLibrary/JITLib/Patterns/Pdef.sc
@@ -524,7 +524,7 @@ EventPatternProxy : TaskProxy {
 				} {
 					Pseq([
 						EmbedOnce(
-							Pfindur(delta, stream, tolerance).asStream,
+							Pfindur(delta, stream, tolerance, Event.silent).asStream,
 							cleanup
 						),
 						newStream

--- a/SCClassLibrary/JITLib/Patterns/Pxfade.sc
+++ b/SCClassLibrary/JITLib/Patterns/Pxfade.sc
@@ -61,10 +61,10 @@ PfadeOut : PfadeIn {
 }
 
 PfinQuant : FilterPattern {
-	var <>quant, <>clock;
+	var <>quant, <>clock, <>filling;
 
-	*new { arg pattern, quant, clock;
-		^super.new(pattern).quant_(quant).clock_(clock)
+	*new { arg pattern, quant, clock, filling;
+		^super.new(pattern).quant_(quant).clock_(clock).filling_(filling)
 	}
 
 	embedInStream { arg inval;
@@ -72,11 +72,13 @@ PfinQuant : FilterPattern {
 		var referenceClock = clock ? thisThread.clock;
 		var endAt = quant.nextTimeOnGrid(referenceClock);
 		while {
-			value = stream.next(inval);
+			value = stream.next(inval) ?? { filling.value(inval) };
 			value.notNil and: { referenceClock.beats < endAt }
 		} {
 			inval = value.yield;
 		};
 		^inval
 	}
+
+	storeArgs { ^[pattern, quant, clock, filling] }
 }

--- a/testsuite/classlibrary/TestPattern.sc
+++ b/testsuite/classlibrary/TestPattern.sc
@@ -128,6 +128,27 @@ TestPattern : UnitTest {
 		);
 	}
 
+
+	test_Pfindur_endsInTime {
+		var p, q, x;
+		p = Pbind(\dur, 1, \count, Pseries());
+		q = Pfindur(3.5, p);
+		x = Pevent(q).asStream.all;
+		this.assert(x.last[\count] == 3, "Pfindur should end inner pattern after dur");
+		this.assert(x.sum { |x| x.delta } == 3.5, "Pfindur with filler should end no sooner than after dur");
+	}
+
+	test_Pfindur_fillsRemainingTime {
+		var p, q, x;
+		p = Pbind(\dur, 1, \count, Pseries(0, 1, 3));
+		q = Pfindur(4.5, p, filling: (test:true));
+		x = Pevent(q).asStream.all;
+		this.assert(x.last[\test] == true, "Pfindur with filler should extend short pattern using filler");
+		this.assert(x.sum { |x| x.delta } == 4.5, "Pfindur with filler should end no earlier than after dur");
+	}
+
+
+
 /*
 	test_storeArgs {
 		Pattern.allSubclasses.do({ |class|


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

Where the old source pattern is shorter than the quant value, `Pdef` / `EventPatternProxy` would start the new pattern too early. This is because Pfindur only cuts and doesn’t extend.  ~~This change checks if the stream has ended and adds a silent event that holds the time until the new pattern comes in.~~ This change introduces a `filling` argument to `Pfindur`, which allows us to extend the stream until `dur` has been reached.

fixes #4767.

Also Pdef.clear didn't empty the dictionary as expected, this is fixed, too.

This supersedes #4072 which was an incomplete fix.

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

Internal changes to embedInStream and constrainStream in EventPatternProxy

<!-- Delete lines that don't apply -->

- Bug fix
- New Feature (as side effect)

New feature:
An extra argument to `Pfindur` was added. This was the least intrusive fix and it makes the solution available to other uses.

Possible inconsistency:
If someone would use a Pdef to stream a pattern that sometimes returns `nil` and then values again, this would change behaviour now (it would stop). But all other patterns behave like this, so it is an edge case. Opinions welcome. 

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] This PR is ready for review
