### PR TITLE
[scsynth][supernova] fix boost_simd preprocessor directives

### DIFF
--- a/server/scsynth/SC_World.cpp
+++ b/server/scsynth/SC_World.cpp
@@ -57,7 +57,7 @@
 
 #include <boost/predef/hardware.h>
 
-#ifdef BOOST_HW_SIMD_AVAILABLE >= BOOST_HW_SIMD_X86_SSE_VERSION
+#if BOOST_HW_SIMD_X86 >= BOOST_HW_SIMD_X86_SSE_VERSION
 #    include <xmmintrin.h>
 #endif
 

--- a/server/supernova/server/server.cpp
+++ b/server/supernova/server/server.cpp
@@ -209,7 +209,7 @@ static void name_current_thread(int thread_index) {
 }
 
 static void set_daz_ftz(void) {
-#if BOOST_HW_SIMD_X86 >= BOOST_X86_SSE_VERSION
+#if BOOST_HW_SIMD_X86 >= BOOST_HW_SIMD_X86_SSE_VERSION
     /* denormal handling */
     _MM_SET_FLUSH_ZERO_MODE(_MM_FLUSH_ZERO_ON);
     _mm_setcsr(_mm_getcsr() | 0x40);


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

As reported here:
https://scsynth.org/t/error-building-sc-on-raspberry-pi3/1799

PR #4046 added some incorrect preprocessor directives for BOOST_SIMD

This PR fixes those directives.

## Types of changes

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
  Still resolves the denormal issues of 4046
  supernova untested
- [x] This PR is ready for review
