### PR TITLE
Classlib: PmonoStreams must create a new node after being paused

### DIFF
--- a/SCClassLibrary/Common/Streams/PmonoStreams.sc
+++ b/SCClassLibrary/Common/Streams/PmonoStreams.sc
@@ -75,6 +75,7 @@ PmonoStream : Stream {
 							schedBundle: schedBundle).play
 						};
 						currentCleanupFunc = nil;
+						id = nil;
 					});
 				};
 			};
@@ -122,7 +123,7 @@ PmonoArticStream : PmonoStream {
 
 		loop {
 			if(this.prDoStreams) {
-				if(rearticulating and: { event.isRest.not }) {
+				if(rearticulating or: { event[\id].isNil } and: { event.isRest.not }) {
 					event[\id] = nil;
 					this.prInitNode;
 					rearticulating = false;

--- a/testsuite/classlibrary/TestPmono.sc
+++ b/testsuite/classlibrary/TestPmono.sc
@@ -1,0 +1,45 @@
+
+TestPmono : UnitTest {
+	var server;
+
+	setUp {
+		server = Server(this.class.name);
+	}
+
+	tearDown {
+		server.quit;
+		server.remove;
+	}
+
+	test_Pmono_makes_node_after_pause {
+		var player, event;
+		this.bootServer;
+		player = Pmono(
+			\default,
+			\degree, Pseries(-7, 1, inf),
+			\dur, 0.01
+		).play;
+		// we are simulating the user action of
+		// stopping an EventStreamPlayer while it's running
+		// there is really no way to do that except a hardcoded wait
+		0.05.wait;
+		player.stop;
+		event = player.originalStream.next(Event.default);
+		this.assertEquals(event[\type], \monoNote, "After stop, Pmono's next event should be monoNote");
+	}
+
+	test_PmonoArtic_makes_node_after_pause {
+		var player, event;
+		this.bootServer;
+		player = PmonoArtic(
+			\default,
+			\degree, Pseries(-7, 1, inf),
+			\dur, 0.01,
+			\sustain, 0.011,
+		).play;
+		0.05.wait;
+		player.stop;
+		event = player.originalStream.next(Event.default);
+		this.assertEquals(event[\type], \monoNote, "After stop, PmonoArtic's next event should be monoNote");
+	}
+}

--- a/testsuite/classlibrary/TestPmono.sc
+++ b/testsuite/classlibrary/TestPmono.sc
@@ -1,19 +1,8 @@
 
 TestPmono : UnitTest {
-	var server;
-
-	setUp {
-		server = Server(this.class.name);
-	}
-
-	tearDown {
-		server.quit;
-		server.remove;
-	}
 
 	test_Pmono_makes_node_after_pause {
 		var player, event;
-		this.bootServer;
 		player = Pmono(
 			\default,
 			\degree, Pseries(-7, 1, inf),
@@ -22,7 +11,9 @@ TestPmono : UnitTest {
 		// we are simulating the user action of
 		// stopping an EventStreamPlayer while it's running
 		// there is really no way to do that except a hardcoded wait
-		0.05.wait;
+		// also the test is not valid unless at least one event
+		// plays *before* stop. Nonzero wait time guarantees that.
+		0.001.wait;
 		player.stop;
 		event = player.originalStream.next(Event.default);
 		this.assertEquals(event[\type], \monoNote, "After stop, Pmono's next event should be monoNote");
@@ -30,14 +21,13 @@ TestPmono : UnitTest {
 
 	test_PmonoArtic_makes_node_after_pause {
 		var player, event;
-		this.bootServer;
 		player = PmonoArtic(
 			\default,
 			\degree, Pseries(-7, 1, inf),
 			\dur, 0.01,
 			\sustain, 0.011,
 		).play;
-		0.05.wait;
+		0.001.wait;
 		player.stop;
 		event = player.originalStream.next(Event.default);
 		this.assertEquals(event[\type], \monoNote, "After stop, PmonoArtic's next event should be monoNote");


### PR DESCRIPTION
## Purpose and Motivation

It was reported on the user forum that Pmono and PmonoArtic do not recover from being stopped and resumed.

```
(
p = Pmono(
	\default,
	\freq, Pexprand(200, 800, inf),
	\dur, 0.5
).play;
)

p.stop;

p.play;

FAILURE IN SERVER /n_set Node 1000 not found
FAILURE IN SERVER /n_set Node 1000 not found

p.stop;
```

This is because the EventStreamCleanup did not clear the old node ID. (PmonoArtic needed an additional check for the ID being nil.)

While I have, for health reasons, been cutting back on PR authoring, this is an easy fix in code that I wrote -- took me about five minutes to figure it out, where it would probably be longer for someone else.

The UnitTest does use a hardcoded wait time. Normally this is not recommended. But, the sequence of user actions that triggers the problem is to start playing a pattern and then manually stop it. So we are not waiting for an asynchronous result -- the best way to simulate that sequence is simply to wait for amount of time. 50 ms is not too much, I think.

## Types of changes

- Documentation: n/a
- Bug fix: yes
- New feature: no
- Breaking change: no

## To-do list

- [x] Code is tested
- [x] All tests are passing
- [ ] Updated documentation: n/a
- [x] This PR is ready for review

PS Submitting for develop because we are already in beta for 3.11. I believe the risk to backport it is basically 0 but best not to mess with the beta process.