### PR TITLE
Add a warning for Windows users that Windows Defender might delay the server boot

### DIFF
--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -1030,12 +1030,14 @@ Server {
 			// We should warn users.
 			Platform.case(
 				\windows, {
-					if (this.serverRunning.not) {
-						"Server: possible boot delay.".warn;
-						"On some Windows-based machines, Windows Defender sometimes delays server boot by one minute.".postln;
-						"You can add scsynth.exe process to Windows Defender exclusion list to disable this check. It's safe.".postln;						
-					}
-				}.defer(7);
+					{
+						if (this.serverRunning.not) {
+							"Server: possible boot delay.".warn;
+							"On some Windows-based machines, Windows Defender sometimes delays server boot by one minute.".postln;
+							"You can add scsynth.exe process to Windows Defender exclusion list to disable this check. It's safe.".postln;						
+						};
+					}.defer(7);
+				}
 			);
 
 			// in case the server takes more time to boot

--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -1024,6 +1024,19 @@ Server {
 				this.prOnServerProcessExit(exitCode);
 			});
 			("Booting server '%' on address %:%.").format(this.name, addr.hostname, addr.port.asString).postln;
+
+			// Windows Defender sometimes delays scsynth boot by 60+ seconds
+			// (see github issue #4368)
+			// We should warn users.
+			Platform.case(
+				\windows, {
+					"Warning : on some Windows-based machines, Windows Defender".postln;
+					"sometimes delays server boot by one minute.".postln;
+					"You can add scsynth.exe process to Windows Defender".postln;
+					"exclusion list to disable this check.".postln;
+				}
+			);
+
 			// in case the server takes more time to boot
 			// we increase the number of attempts for tcp connection
 			// in order to minimize the chance of timing out

--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -1030,11 +1030,12 @@ Server {
 			// We should warn users.
 			Platform.case(
 				\windows, {
-					"Warning : on some Windows-based machines, Windows Defender".postln;
-					"sometimes delays server boot by one minute.".postln;
-					"You can add scsynth.exe process to Windows Defender".postln;
-					"exclusion list to disable this check.".postln;
-				}
+					if (this.serverRunning.not) {
+						"Server: possible boot delay.".warn;
+						"On some Windows-based machines, Windows Defender sometimes delays server boot by one minute.".postln;
+						"You can add scsynth.exe process to Windows Defender exclusion list to disable this check. It's safe.".postln;						
+					}
+				}.defer(7);
 			);
 
 			// in case the server takes more time to boot


### PR DESCRIPTION
## Purpose and Motivation

cf. #4368 

I've spent a lot of time trying to figure out why Windows Defender might delay server boot but recent Windows Defender updates makes it more and more difficult to debug it as I can reproduce the problem only once a day approximately, whereas I could reproduce it after every boot a few months ago.
It means that I can only debug once per day...
I am not proud of that PR but I don't know what else to do to go ahead with this issue.

## Types of changes

Add a warning.
I split the warning into four lines so that you can read it in the post window.
Not sure about that one.

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [ ] Code is tested
- [ ] All tests are passing
- [ ] Updated documentation
- [X] This PR is ready for review
