### PR TITLE
class library: Psync now rounds up time

### DIFF
--- a/SCClassLibrary/Common/Streams/FilterPatterns.sc
+++ b/SCClassLibrary/Common/Streams/FilterPatterns.sc
@@ -452,7 +452,7 @@ Psync : FilterPattern {
 	storeArgs { ^[pattern, quant, maxdur, tolerance, mindur] }
 
 	embedInStream { arg event;
-		var item, stream, delta, elapsed = 0.0, nextElapsed, clock, inevent;
+		var item, stream, delta, elapsed = 0.0, nextElapsed, inevent;
 		var	localquant = quant.value(event), localmaxdur = maxdur.value(event);
 		var cleanup = EventStreamCleanup.new;
 

--- a/SCClassLibrary/Common/Streams/FilterPatterns.sc
+++ b/SCClassLibrary/Common/Streams/FilterPatterns.sc
@@ -472,7 +472,7 @@ Psync : FilterPattern {
 			delta = inevent.delta;
 			nextElapsed = elapsed + delta;
 
-			if (localmaxdur.notNil and: { nextElapsed.round(tolerance) >= localmaxdur }) {
+			if (localmaxdur.notNil and: { nextElapsed.roundUp(tolerance) >= localmaxdur }) {
 				inevent = inevent.copy;
 				inevent.put(\delta, localmaxdur - elapsed);
 				event = inevent.yield;


### PR DESCRIPTION
In cases of overshooting by tolerance, the simple round would result in
wrong results. This fixes #4767. (well it might!)

## Purpose and Motivation

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

This slightly changes the behaviour of `Psync` near quantisation boundary, guaranteeing a roundUp by tolerance. This now follows the model of `Pfindur`.

<!-- Delete lines that don't apply -->

- Bug fix
- Breaking change (might break behaviour, but probably not, because Pfindur uses roundUp)

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [ ] Code is tested
- [ ] All tests are passing
- [ ] This PR is ready for review
