### PR TITLE
classlib: fix SimpleNumber asTimeString for negative values

### DIFF
--- a/SCClassLibrary/Common/Math/SimpleNumber.sc
+++ b/SCClassLibrary/Common/Math/SimpleNumber.sc
@@ -695,13 +695,16 @@ SimpleNumber : Number {
 	// see String:asSecs for complement
 
 	asTimeString { |precision = 0.001, maxDays = 365, dropDaysIfPossible = true|
-		var number, decimal, days, hours, minutes, seconds, mseconds;
+		var number, decimal, days, hours, minutes, seconds, mseconds, isNegative = false;
+		if(this < 0, {
+			isNegative = true;
+		});
 
 		// min value of precision is 0.001; this ensures that we stick to 3 decimal places in the
 		// formatted string.
 		precision = max(precision, 0.001);
 
-		number = this.round(precision);
+		number = this.abs.round(precision);
 		decimal = number.asInteger;
 		days = decimal.div(86400).min(maxDays);
 		days = if(dropDaysIfPossible and: { days == 0 }) {
@@ -709,6 +712,7 @@ SimpleNumber : Number {
 		} {
 			days.asString.padLeft(3, "0").add($:);
 		};
+		if(isNegative, {days = "-" ++ days});
 		hours = (decimal.div(3600) % 24).asString.padLeft(2, "0").add($:);
 		minutes = (decimal.div(60) % 60).asString.padLeft(2, "0").add($:);
 		seconds = (decimal % 60).asString.padLeft(2, "0").add($.);

--- a/SCClassLibrary/Common/Math/SimpleNumber.sc
+++ b/SCClassLibrary/Common/Math/SimpleNumber.sc
@@ -695,7 +695,7 @@ SimpleNumber : Number {
 	// see String:asSecs for complement
 
 	asTimeString { |precision = 0.001, maxDays = 365, dropDaysIfPossible = true|
-		var number, decimal, days, hours, minutes, seconds, mseconds, isNegative = this < 0;
+		var number, decimal, days, hours, minutes, seconds, mseconds, isNegative = (this < 0) || (this === -0.0);
 
 		// min value of precision is 0.001; this ensures that we stick to 3 decimal places in the
 		// formatted string.

--- a/SCClassLibrary/Common/Math/SimpleNumber.sc
+++ b/SCClassLibrary/Common/Math/SimpleNumber.sc
@@ -695,13 +695,15 @@ SimpleNumber : Number {
 	// see String:asSecs for complement
 
 	asTimeString { |precision = 0.001, maxDays = 365, dropDaysIfPossible = true|
-		var number, decimal, days, hours, minutes, seconds, mseconds, isNegative = this < 0;
+		var number, decimal, days, hours, minutes, seconds, mseconds, isNegative;
 
 		// min value of precision is 0.001; this ensures that we stick to 3 decimal places in the
 		// formatted string.
 		precision = max(precision, 0.001);
 
-		number = this.abs.round(precision);
+		number = this.round(precision);
+		isNegative = number < 0;
+		number = number.abs;
 		decimal = number.asInteger;
 		days = decimal.div(86400).min(maxDays);
 		days = if(dropDaysIfPossible and: { days == 0 }) {

--- a/SCClassLibrary/Common/Math/SimpleNumber.sc
+++ b/SCClassLibrary/Common/Math/SimpleNumber.sc
@@ -695,7 +695,7 @@ SimpleNumber : Number {
 	// see String:asSecs for complement
 
 	asTimeString { |precision = 0.001, maxDays = 365, dropDaysIfPossible = true|
-		var number, decimal, days, hours, minutes, seconds, mseconds, isNegative = (this < 0) || (this === -0.0);
+		var number, decimal, days, hours, minutes, seconds, mseconds, isNegative = this < 0;
 
 		// min value of precision is 0.001; this ensures that we stick to 3 decimal places in the
 		// formatted string.

--- a/SCClassLibrary/Common/Math/SimpleNumber.sc
+++ b/SCClassLibrary/Common/Math/SimpleNumber.sc
@@ -695,10 +695,7 @@ SimpleNumber : Number {
 	// see String:asSecs for complement
 
 	asTimeString { |precision = 0.001, maxDays = 365, dropDaysIfPossible = true|
-		var number, decimal, days, hours, minutes, seconds, mseconds, isNegative = false;
-		if(this < 0, {
-			isNegative = true;
-		});
+		var number, decimal, days, hours, minutes, seconds, mseconds, isNegative = this < 0;
 
 		// min value of precision is 0.001; this ensures that we stick to 3 decimal places in the
 		// formatted string.
@@ -712,7 +709,7 @@ SimpleNumber : Number {
 		} {
 			days.asString.padLeft(3, "0").add($:);
 		};
-		if(isNegative, {days = "-" ++ days});
+		if(isNegative) {days = "-" ++ days};
 		hours = (decimal.div(3600) % 24).asString.padLeft(2, "0").add($:);
 		minutes = (decimal.div(60) % 60).asString.padLeft(2, "0").add($:);
 		seconds = (decimal % 60).asString.padLeft(2, "0").add($.);

--- a/testsuite/classlibrary/TestSimpleNumber.sc
+++ b/testsuite/classlibrary/TestSimpleNumber.sc
@@ -115,6 +115,12 @@ TestSimpleNumber : UnitTest {
 		this.assertEquals(actual, expected, "-1.asTimeString (negative value)");
 	}
 
+	test_asTimeString_negativeOneDontDropDays {
+		var expected = "-000:00:00:01.000";
+		var actual = -1.asTimeString(dropDaysIfPossible: false);
+		this.assertEquals(actual, expected, "-1.asTimeString(dropDaysIfPossible: false) (negative value)");
+	}
+
 	test_softRound {
 		var val;
 		var testF = {|vals, g, t, s| vals.collect({|num| num.softRound(g, t, s)})};

--- a/testsuite/classlibrary/TestSimpleNumber.sc
+++ b/testsuite/classlibrary/TestSimpleNumber.sc
@@ -109,6 +109,12 @@ TestSimpleNumber : UnitTest {
 		this.assertEquals(actual, expected, "%.asTimeString (number of days > 365 and 10 seconds)".format(totalTime));
 	}
 
+	test_asTimeString_negativeOne {
+		var expected = "-00:00:01.000";
+		var actual = -1.asTimeString;
+		this.assertEquals(actual, expected, "-1.asTimeString (negative value)");
+	}
+
 	test_softRound {
 		var val;
 		var testF = {|vals, g, t, s| vals.collect({|num| num.softRound(g, t, s)})};

--- a/testsuite/classlibrary/TestSimpleNumber.sc
+++ b/testsuite/classlibrary/TestSimpleNumber.sc
@@ -109,10 +109,16 @@ TestSimpleNumber : UnitTest {
 		this.assertEquals(actual, expected, "%.asTimeString (number of days > 365 and 10 seconds)".format(totalTime));
 	}
 
+	test_asTimeString_negativeZero {
+		var expected = "-00:00:00.000";
+		var actual = -0.0.asTimeString;
+		this.assertEquals(actual, expected, "-0.0.asTimeString (negative zero)");
+	}
+
 	test_asTimeString_negativeOne {
 		var expected = "-00:00:01.000";
 		var actual = -1.asTimeString;
-		this.assertEquals(actual, expected, "-1.asTimeString (negative value)");
+		this.assertEquals(actual, expected, "-1.asTimeString (negative one)");
 	}
 
 	test_asTimeString_negativeOneDontDropDays {

--- a/testsuite/classlibrary/TestSimpleNumber.sc
+++ b/testsuite/classlibrary/TestSimpleNumber.sc
@@ -121,6 +121,12 @@ TestSimpleNumber : UnitTest {
 		this.assertEquals(actual, expected, "-1.asTimeString (negative one)");
 	}
 
+	test_asTimeString_negativeFraction {
+		var expected = "00:00:00.000";
+		var actual = -0.001.asTimeString(precision: 0.1);
+		this.assertEquals(actual, expected, "-0.001.asTimeString(precision: 0.1) (negative number smaller than precision)");
+	}
+
 	test_asTimeString_negativeOneDontDropDays {
 		var expected = "-000:00:00:01.000";
 		var actual = -1.asTimeString(dropDaysIfPossible: false);

--- a/testsuite/classlibrary/TestSimpleNumber.sc
+++ b/testsuite/classlibrary/TestSimpleNumber.sc
@@ -110,7 +110,7 @@ TestSimpleNumber : UnitTest {
 	}
 
 	test_asTimeString_negativeZero {
-		var expected = "-00:00:00.000";
+		var expected = "00:00:00.000";
 		var actual = -0.0.asTimeString;
 		this.assertEquals(actual, expected, "-0.0.asTimeString (negative zero)");
 	}


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation
Negative `SimpleNumber -asTimeString` returned incorrect string.
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->
Previously:
```supercollider
-1.asTimeString;
-> 0-1:23:59:59.000
```
Now:
```supercollider
-1.asTimeString;
-> -00:00:01.000
```

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] This PR is ready for review
