### PR TITLE
scide: Reinstate translations files in distributions.

### DIFF
--- a/editors/sc-ide/CMakeLists.txt
+++ b/editors/sc-ide/CMakeLists.txt
@@ -277,7 +277,7 @@ qt5_add_translation( translations ${translation_src} ${native_translation_src} )
 
 set(ide_sources ${ide_src} ${all_hdr} )
 
-set(ide_rc_sources ${ide_moc_src} ${ide_forms_src} ${ide_rcc} ${translations})
+set(ide_rc_sources ${ide_moc_src} ${ide_forms_src} ${ide_rcc})
 
 if(APPLE)
     foreach(file ${translations})
@@ -323,7 +323,7 @@ target_include_directories(libscide PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}/widgets/util
 )
 
-add_executable( SuperCollider MACOSX_BUNDLE core/main_function.cpp ${RES_FILES} ${AdditionalBundleSources})
+add_executable( SuperCollider MACOSX_BUNDLE core/main_function.cpp ${RES_FILES} ${AdditionalBundleSources} ${translations})
 
 set_target_properties(libscide PROPERTIES PREFIX "")
 


### PR DESCRIPTION

<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->
This fixes #4809 - which is that a change I made previously had stopped the translations/scide_*.qm files from being added to distributions.

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

The fix was to make the sc-ide exe depend on the translation files, instead of the libscide library...

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested - tested by creating a distribution on Mac and checking it had the translations folder
- [x] All tests are passing - based on the belief that there are no tests for this issue (as it hasn't been reported)
- [x] Updated documentation - not sure that there is any documentation to change?
- [x] This PR is ready for review
