### PR TITLE
scide: Fix the finding of locale-specific translations (#4619)

### DIFF
--- a/editors/sc-ide/CMakeLists.txt
+++ b/editors/sc-ide/CMakeLists.txt
@@ -277,7 +277,7 @@ qt5_add_translation( translations ${translation_src} ${native_translation_src} )
 
 set(ide_sources ${ide_src} ${all_hdr} )
 
-set(ide_rc_sources ${ide_moc_src} ${ide_forms_src} ${ide_rcc} ${translations})
+set(ide_rc_sources ${ide_moc_src} ${ide_forms_src} ${ide_rcc})
 
 if(APPLE)
     foreach(file ${translations})
@@ -323,7 +323,7 @@ target_include_directories(libscide PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}/widgets/util
 )
 
-add_executable( SuperCollider MACOSX_BUNDLE core/main_function.cpp ${RES_FILES} ${AdditionalBundleSources})
+add_executable( SuperCollider MACOSX_BUNDLE core/main_function.cpp ${RES_FILES} ${AdditionalBundleSources} ${translations})
 
 set_target_properties(libscide PROPERTIES PREFIX "")
 

--- a/editors/sc-ide/core/main_function.cpp
+++ b/editors/sc-ide/core/main_function.cpp
@@ -61,9 +61,9 @@ int main(int argc, char* argv[]) {
         qWarning("scide warning: Failed to load fallback translation file.");
 
     // Load translator for locale
-    QString ideTranslationFile = "scide_" + QLocale::system().name();
+    const QLocale locale;
     QTranslator scideTranslator;
-    scideTranslator.load(ideTranslationFile, ideTranslationPath);
+    scideTranslator.load(locale, "scide", "_", ideTranslationPath);
     app.installTranslator(&scideTranslator);
 
     // Force Fusion style to appear consistently on all platforms.


### PR DESCRIPTION
The fix is to use the QTranslator::load() overload that takes a QLocale, instead of searching for the filename ourselves.

That way, Qt's documented logic takes care of finding scide_fr.qm when the locale contains fr_FR.

<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

- Fixes #4619
- Replaces the closed, unmerged #4620
- **Note** that this also depends on a change that is in PR #4810

Please see the detail about the fix, and how I tested it, in that ticket.

## Types of changes

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [ ] Code is tested - _tested on Mac only - it's hard to say how much effort should be tested on other platforms, given that all the translation files are effectively empty_
- [ ] All tests are passing - _as far as I understand, there are no tests for sc-ide, so this should not change any behaviour_
- [ ] Updated documentation - _nothing to document - no user-observable change_
- [x] This PR is ready for review