### PR TITLE
class library: Pfset - do cleanup on nil stream

### DIFF
--- a/SCClassLibrary/Common/Streams/FilterPatterns.sc
+++ b/SCClassLibrary/Common/Streams/FilterPatterns.sc
@@ -125,7 +125,7 @@ Pfset : FuncFilterPattern {
 			inevent.putAll(envir);
 			event = stream.next(inevent);
 			if(once) {
-				cleanup.addFunction(event, { |flag|
+				cleanup.addFunction(event ? inevent, { |flag|
 					envir.use({ cleanupFunc.value(flag) });
 				});
 				once = false;

--- a/testsuite/classlibrary/TestPattern.sc
+++ b/testsuite/classlibrary/TestPattern.sc
@@ -156,8 +156,8 @@ TestPattern : UnitTest {
 	}
 
 	test_Pfset_evaluates_init_and_cleanup_on_empty_stream {
-		var x = 0, y = 0, outEvent = (), inEvent = (), cleanup = EventStreamCleanup.new;
-		outEvent = Pfset({ x = 1 }, p{}, { y = 2 }).asStream.next(inEvent);
+		var x = 0, y = 0, inEvent = (), cleanup = EventStreamCleanup.new;
+		var outEvent = Pfset({ x = 1 }, p{}, { y = 2 }).asStream.next(inEvent);
 		this.assert(x == 1, "Pfset on nil stream should still call the initializer function");
 		this.assert(y == 2, "Pfset on nil stream should still call the cleanup function");
 		this.assert(outEvent.isNil, "Pfset on nil stream should return nil");

--- a/testsuite/classlibrary/TestPattern.sc
+++ b/testsuite/classlibrary/TestPattern.sc
@@ -155,6 +155,21 @@ TestPattern : UnitTest {
 		this.assert(x.sum { |x| x.delta } == 4.5, "Psync with maxdur = quant should end no earlier than after dur");
 	}
 
+	test_Pfset_nilStream {
+		var x = 0, y = 0, oe = (), ie = (), clup = EventStreamCleanup.new;
+		oe = Pfset({ x = 1 }, p{}, { y = 2 }).asStream.next(ie);
+		this.assert(x == 1, "Pfset on nil stream should still call the initializer function");
+		this.assert(y == 2, "Pfset on nil stream should still call the cleanup function");
+		this.assert(oe.isNil, "Pfset on nil stream should return nil");
+		this.assert(ie.size.even, "Pfset on nil stream should add an even number of items to the input event");
+		// ie.size is 2 if Pfset adds 'addToCleanup' and 'removeFromCleanup' in sequence (presently);
+		// ie.size could be 0 if this add-remove pair is "optimized out" in the future.
+		// The present implementation of EventStreamCleanup.update first does the add(s) then the remove(s),
+		// so it "cancels out" matched add-remove pairs in the same event. But let's check that too...
+		clup.update(ie);
+		this.assert(clup.functions.size == 0, "Pfset on nil stream should have no effect on a cleanup-functions set");
+	}
+
 
 /*
 	test_storeArgs {

--- a/testsuite/classlibrary/TestPattern.sc
+++ b/testsuite/classlibrary/TestPattern.sc
@@ -155,19 +155,19 @@ TestPattern : UnitTest {
 		this.assert(x.sum { |x| x.delta } == 4.5, "Psync with maxdur = quant should end no earlier than after dur");
 	}
 
-	test_Pfset_nilStream {
-		var x = 0, y = 0, oe = (), ie = (), clup = EventStreamCleanup.new;
-		oe = Pfset({ x = 1 }, p{}, { y = 2 }).asStream.next(ie);
+	test_Pfset_evaluates_init_and_cleanup_on_empty_stream {
+		var x = 0, y = 0, outEvent = (), inEvent = (), cleanup = EventStreamCleanup.new;
+		outEvent = Pfset({ x = 1 }, p{}, { y = 2 }).asStream.next(inEvent);
 		this.assert(x == 1, "Pfset on nil stream should still call the initializer function");
 		this.assert(y == 2, "Pfset on nil stream should still call the cleanup function");
-		this.assert(oe.isNil, "Pfset on nil stream should return nil");
-		this.assert(ie.size.even, "Pfset on nil stream should add an even number of items to the input event");
-		// ie.size is 2 if Pfset adds 'addToCleanup' and 'removeFromCleanup' in sequence (presently);
-		// ie.size could be 0 if this add-remove pair is "optimized out" in the future.
+		this.assert(outEvent.isNil, "Pfset on nil stream should return nil");
+		// inEvent.size is 2 if Pfset adds 'addToCleanup' and 'removeFromCleanup' in sequence (presently);
+		// inEvente.size could be 0 if this add-remove pair is "optimized out" in the future.
+		this.assert(inEvent.size.even, "Pfset on nil stream should add an even number of items to the input event");
 		// The present implementation of EventStreamCleanup.update first does the add(s) then the remove(s),
 		// so it "cancels out" matched add-remove pairs in the same event. But let's check that too...
-		clup.update(ie);
-		this.assert(clup.functions.size == 0, "Pfset on nil stream should have no effect on a cleanup-functions set");
+		cleanup.update(inEvent);
+		this.assert(cleanup.functions.size == 0, "Pfset on nil stream should have no effect on a cleanup-functions set");
 	}
 
 


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

Fixes #4807 Pfset doesn't do cleanup if its sub-pattern yields nil immediately.

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review
