### PR TITLE
classlib: Fix NamedControl spec arg (if nil, do not overwrite metadata)

### DIFF
--- a/SCClassLibrary/Common/Control/GraphBuilder.sc
+++ b/SCClassLibrary/Common/Control/GraphBuilder.sc
@@ -122,7 +122,9 @@ NamedControl {
 			}
 		};
 
-		res.spec = spec; // Set after we've finished without error.
+		if(spec.notNil) {
+			res.spec = spec; // Set after we've finished without error.
+		};
 
 		^if(lags.notNil) {
 			res.control.lag(lags).unbubble

--- a/testsuite/classlibrary/TestNamedControl.sc
+++ b/testsuite/classlibrary/TestNamedControl.sc
@@ -48,10 +48,46 @@ TestNamedControl : UnitTest {
 				defaultValues = a.source.values;
 			});
 		}, Error)
-
-
 	}
 
+	test_NamedControl_uses_constructor_spec {
+		var def;
+		var argSpec = [0, 2].asSpec, mdSpec = [0, 5].asSpec;
+		def = SynthDef(\test, {
+			var control = \name.kr(0, spec: argSpec);
+		}, metadata: (
+			specs: (
+				name: mdSpec
+			)
+		));
+		this.assertEquals(
+			def.metadata[\specs][\name].maxval,
+			argSpec.maxval,
+			"Spec passed into NamedControl.kr should override metadata (testing maxval)"
+		)
+	}
+
+	test_NamedControl_uses_metadata_spec {
+		var def;
+		var mdSpec = [0, 5].asSpec;
+		def = SynthDef(\test, {
+			var control = \name.kr(0);
+		}, metadata: (
+			specs: (
+				// old logic did not replace the ControlSpec object
+				// but actually corrupted the object given here!
+				// so, without copying, assertEquals passes but with
+				// the wrong value
+				// copy is necessary for a valid test
+				name: mdSpec.copy
+			)
+		));
+		this.assertEquals(
+			def.metadata[\specs][\name].maxval,
+			mdSpec.maxval,
+			"Nil spec in NamedControl.kr should not override metadata (testing maxval)"
+		)
+	}
 
 }
 


### PR DESCRIPTION
## Purpose and Motivation

Fixes #4816 .

Formerly, `res.spec = spec` at the bottom of NamedControl `*new` would overwrite a spec in metadata with the default ControlSpec.

(Note that the unit test can't use assertEquals on the spec objects -- I tried it but it fails spuriously. No time to debug that, so I just test same/different maxval.)

## Types of changes

- Bug fix

## To-do list

- [x] Code is tested
- [x] All tests are passing
- [ ] Updated documentation (n/a)
- [x] This PR is ready for review
