### PR TITLE
cmake: Better help for users new to submodules.

### DIFF
--- a/external_libraries/CMakeLists.txt
+++ b/external_libraries/CMakeLists.txt
@@ -1,5 +1,9 @@
 if (NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/nova-simd/vec.hpp)
-    message(FATAL_ERROR "It appears you haven't cloned this project's git submodules: please run `git submodule update --init --recursive` from the root level of the repository")
+    message(FATAL_ERROR "It appears you haven't cloned this project's git submodules:"
+			" please run `git submodule update --init --recursive` from the root level of the repository.\n"
+			"For advice on setting up submodules, and also on keeping them updated over time, please see"
+			" this wiki page, and consider saving this link:"
+			" https://github.com/supercollider/supercollider/wiki/git-cheat-sheet#working-with-submodules")
 endif()
 
 if(NOT SYSTEM_BOOST) # we compile boost ourselves


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

This arose from discussion on the Slack recently, and improvements that @brianlheim made to the wiki...

The point when users will most benefit from this wiki is when they have cloned the repo but not the sub-modules...

For those who have just cloned or forked this repo, and not updated submodules, there is already a really helpful message printed as soon as they run cmake, with the command needed to clone submodules.

This commit extends that, to also point to the wealth of extra tips at:
https://github.com/supercollider/supercollider/wiki/git-cheat-sheet#working-with-submodules


## Types of changes

<!-- Delete lines that don't apply -->

- Build usability

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [ ] All tests are passing
- [ ] Updated documentation
- [x] This PR is ready for review

## Changes:

Old console output from cmake when submodules missing:

```
CMake Error at external_libraries/CMakeLists.txt:2 (message):
  It appears you haven't cloned this project's git submodules: please run
  `git submodule update --init --recursive` from the root level of the
  repository
```

New console output from cmake when submodules missing:

```
CMake Error at external_libraries/CMakeLists.txt:2 (message):
  It appears you haven't cloned this project's git submodules: please run
  `git submodule update --init --recursive` from the root level of the
  repository.

  For advice on setting up submodules, and also on keeping them updated over
  time, please see this wiki page, and consider saving this link:
  https://github.com/supercollider/supercollider/wiki/git-cheat-sheet#working-with-submodules
```
