### PR TITLE
QT GUI: close window with cmd-w on macos

### DIFF
--- a/QtCollider/QcApplication.cpp
+++ b/QtCollider/QcApplication.cpp
@@ -198,9 +198,9 @@ bool QcApplication::notify(QObject* object, QEvent* event) {
     // native window if they aren't accepted here. This caused issue #4058. Accepting them here
     // seems to solve the problem, but might cause other issues since it is a heavy-handed way
     // of doing this.
-    // In order to still allow closing GUI windows with "cmd-w", we do not accept modifier keys
-    // alone, as well as the "cmd-w" combination itself, so that they propagate further
-    // (see isKeyEvent and isCloseEvent above).
+    // In order to still allow closing GUI windows with "cmd-w", we need to let this combination
+    // through, as well as modifier keys alone, since the "cmd" needs to passed through by itself
+    // first for the "cmd-w" to work (see isKeyEvent and isCloseEvent above).
     // TODO - solve more elegantly
     if (result && isKeyEvent && (!isCloseEvent))
         event->accept();

--- a/QtCollider/QcApplication.cpp
+++ b/QtCollider/QcApplication.cpp
@@ -181,28 +181,22 @@ bool QcApplication::notify(QObject* object, QEvent* event) {
     bool result = QApplication::notify(object, event);
 
 #ifdef Q_OS_MAC
-    bool isCloseEvent = false;
-    bool isKeyEvent = false;
-    if (event->type() == QEvent::KeyPress) {
-        QKeyEvent* kevent = static_cast<QKeyEvent*>(event);
-        if ((kevent->key() != Qt::Key_unknown)) {
-            isKeyEvent = true; // true for regular keys pressed, but not modifiers alone
-        }
-        if ((kevent->key() == Qt::Key_W) && (kevent->modifiers() == Qt::ControlModifier)) {
-            isCloseEvent = true;
-        }
-    }
     // XXX Explicitly accept all handled events so they don't propagate outside the application.
     // This is a hack; for a not-fully-understood reason Qt past 5.7 sends these events to the
     // native window if they aren't accepted here. This caused issue #4058. Accepting them here
     // seems to solve the problem, but might cause other issues since it is a heavy-handed way
     // of doing this.
-    // In order to still allow closing GUI windows with "cmd-w", we need to let this combination
-    // through, as well as modifier keys alone, since the "cmd" needs to be passed through
-    // by itself first for the "cmd-w" to work (see isKeyEvent and isCloseEvent above).
+    // In order to still allow closing GUI windows with "cmd-w", we need to let through both
+    // this key combination, as well as modifier keys alone, since the "cmd" needs to be passed
+    // through by itself first for the "cmd-w" to work.
     // TODO - solve more elegantly
-    if (result && isKeyEvent && (!isCloseEvent))
-        event->accept();
+    if (result && event->type() == QEvent::KeyPress) {
+        auto kevent = static_cast<QKeyEvent*>(event);
+        if (!((kevent->key() == Qt::Key_W) && (kevent->modifiers() == Qt::ControlModifier))
+            && (kevent->key() != Qt::Key_unknown)) {
+            event->accept();
+        }
+    }
 #endif
     return result;
 }

--- a/QtCollider/QcApplication.cpp
+++ b/QtCollider/QcApplication.cpp
@@ -161,10 +161,6 @@ bool QcApplication::event(QEvent* event) {
 }
 
 bool QcApplication::notify(QObject* object, QEvent* event) {
-#ifdef Q_OS_MAC
-    bool isCloseEvent = false;
-    bool isKeyEvent = false;
-#endif
     switch (event->type()) {
     case QEvent::KeyPress: {
         QKeyEvent* kevent = static_cast<QKeyEvent*>(event);
@@ -172,14 +168,6 @@ bool QcApplication::notify(QObject* object, QEvent* event) {
             static QString cmdPeriodCommand("CmdPeriod.run");
             interpret(cmdPeriodCommand, false);
         }
-#ifdef Q_OS_MAC
-        if ((kevent->key() != Qt::Key_unknown)) {
-            isKeyEvent = true; // true for regular keys pressed, but not modifiers alone
-        }
-        if ((kevent->key() == Qt::Key_W) && (kevent->modifiers() == Qt::ControlModifier)) {
-            isCloseEvent = true;
-        }
-#endif
         break;
     }
     case QEvent::Wheel: {
@@ -193,6 +181,17 @@ bool QcApplication::notify(QObject* object, QEvent* event) {
     bool result = QApplication::notify(object, event);
 
 #ifdef Q_OS_MAC
+    bool isCloseEvent = false;
+    bool isKeyEvent = false;
+    if (event->type() == QEvent::KeyPress) {
+        QKeyEvent* kevent = static_cast<QKeyEvent*>(event);
+        if ((kevent->key() != Qt::Key_unknown)) {
+            isKeyEvent = true; // true for regular keys pressed, but not modifiers alone
+        }
+        if ((kevent->key() == Qt::Key_W) && (kevent->modifiers() == Qt::ControlModifier)) {
+            isCloseEvent = true;
+        }
+    }
     // XXX Explicitly accept all handled events so they don't propagate outside the application.
     // This is a hack; for a not-fully-understood reason Qt past 5.7 sends these events to the
     // native window if they aren't accepted here. This caused issue #4058. Accepting them here

--- a/QtCollider/QcApplication.cpp
+++ b/QtCollider/QcApplication.cpp
@@ -198,8 +198,8 @@ bool QcApplication::notify(QObject* object, QEvent* event) {
     // seems to solve the problem, but might cause other issues since it is a heavy-handed way
     // of doing this.
     // In order to still allow closing GUI windows with "cmd-w", we need to let this combination
-    // through, as well as modifier keys alone, since the "cmd" needs to passed through by itself
-    // first for the "cmd-w" to work (see isKeyEvent and isCloseEvent above).
+    // through, as well as modifier keys alone, since the "cmd" needs to be passed through
+    // by itself first for the "cmd-w" to work (see isKeyEvent and isCloseEvent above).
     // TODO - solve more elegantly
     if (result && isKeyEvent && (!isCloseEvent))
         event->accept();


### PR DESCRIPTION

<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

This is a workaround for a workaround introduced in #4105 (which fixed #4058, but caused #4309). **This fixes #4309**.

It's not pretty, but it works. I hope that at some point someone looks into a proper fix that's hacked in #4105, but until then it would be great to have the ability to close windows from the keyboard again...

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] This PR is ready for review
