### PR TITLE
classlib: Make EnvironmentRedirect work as EnvirGui's object

### DIFF
--- a/SCClassLibrary/Common/Collections/EnvironmentRedirect.sc
+++ b/SCClassLibrary/Common/Collections/EnvironmentRedirect.sc
@@ -128,6 +128,14 @@ EnvironmentRedirect {
 
 	clear { envir.clear }
 
+	keys { arg species(Set);
+		^envir.keys(species)
+	}
+
+	values {
+		^envir.values
+	}
+
 	know_ { arg flag; envir.know = flag }
 	know { ^envir.know }
 

--- a/SCClassLibrary/JITLib/GUI/EnvirGui.sc
+++ b/SCClassLibrary/JITLib/GUI/EnvirGui.sc
@@ -140,7 +140,7 @@ EnvirGui : JITGui {
 	}
 
 	accepts { |obj|
-		^(obj.isNil or: { obj.isKindOf(Dictionary) })
+		^(obj.isNil or: { obj.isKindOf(Dictionary) or: {obj.isKindOf(EnvironmentRedirect)} })
 	}
 
 		// backwards compatibility


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

Fixes #4831 by making 

1. `EnvironmentRedirect` implement `keys` and `values` method for it to be more alike `Environment`, which inherits these two methods from `Dictionary`. Strictly speaking, only the `keys` method suffices to make `EnvirGui` happy.

2. Change `EnvirGui`'s `accepts` method to accept an `EnvironmentRedirect` as its `object` explicitly, since the latter don't derive from `Environment` (probably due to some intricate VM reasons; e.g. see #4829). **Style alert:**  for now this a quick fix using the maligned `isKindOf` check, which `EnvirGui` was already doing. I'm (very) open to suggestions to doing this differently, but I'd rather not change many files with this simple feature/fix. A rework by adding `isLookup` or `isDictionary` to `Dictionary` and its subclasses has been floated as an idea in prior discussions. I think it would be better if the core devs do that kind of more sweeping change (once agreed upon).

## Types of changes

<!-- Delete lines that don't apply -->

<!-- - Documentation -->
- Bug fix (or maybe)
- New feature
<!-- - Breaking change -->

I'm (also) not sure if this needs explicit documentation, or it can be reasonably expected that EnvironmentRedirect would "just work" in EnvirGui.

I see that neither `EnvironmentRedirect` nor `EnvirGui` have any units tests in the test suite...  so (just) adding a compability unit test between them seemed a bit pointless/premature. I've manually tested that they work together with code like

```
e = EnvironmentRedirect((foo: 33));
EnvirGui(e);
// moved the slider around
e[\foo] // tracked changes ok
```

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

<!-- - [ ] Updated documentation -->
- [x] Code is tested
- [x] All tests are passing
- [x] This PR is ready for review
