### PR TITLE
Devendor ableton link

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -228,6 +228,7 @@ endif()
 
 option(SC_SYMLINK_CLASSLIB "Place a symlink of SCCLassLibrary instead of copying" OFF)
 
+option(SYSTEM_ABLETON_LINK "Use link from system" OFF)
 option(SYSTEM_BOOST   "Use boost libraries from system" OFF)
 option(SYSTEM_YAMLCPP "Use yaml-cpp library from system" OFF)
 

--- a/lang/CMakeLists.txt
+++ b/lang/CMakeLists.txt
@@ -252,7 +252,12 @@ endif()
 
 if (SC_ABLETON_LINK)
 	message(STATUS "Compiling with Ableton Link support")
-	include(../external_libraries/link/AbletonLinkConfig.cmake)
+	if(SYSTEM_ABLETON_LINK)
+		find_package(AbletonLink NAMES AbletonLink ableton-link link REQUIRED)
+	else()
+		include(../external_libraries/link/AbletonLinkConfig.cmake)
+	endif()
+
 	target_link_libraries(libsclang Ableton::Link)
 
 	add_definitions(-DSC_ABLETON_LINK)


### PR DESCRIPTION
## Purpose and Motivation

This enables package maintainers to use a system version of Ableton Link by specifying `-DSYSTEM_ABLETON_LINK=ON` when running cmake.

This fixes #4818 in a packaging context (because a system version of Ableton Link is preferred over the vendored version).

## Types of changes

- New feature

## To-do list

- [x] Code is tested
- [x] All tests are passing
- [ ] Updated documentation
- [x] This PR is ready for review
