### PR TITLE
Release tarball script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,10 @@ common/Packager/LinuxExclusions.txt
 common/Packager/SuperCollider*.tar.gz
 common/Packager/SuperCollider*.dmg
 
+# source tarball
+package/*.bz2
+package/*.asc
+
 # CLion files
 .idea
 cmake-build-*

--- a/package/create_source_tarball.sh
+++ b/package/create_source_tarball.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+#
+# Creates source tarballs for SuperCollider in the form of
+# 'SuperCollider-x.x.x-Source.tar.bz2' and optionally detached PGP signatures
+# for the created file of the form 'SuperCollider-x.x.x-Source.tar.bz2.asc'.
+# If the environment variable BUILD_DIR is provided, the files will be moved to
+# $BUILD_DIR/package, else to the location of this script (the repository's
+# package folder).
+#
+# Requirements:
+# - git
+# - tar
+# - a writable (user) /tmp folder for mktemp
+# - gnupg >= 2.0.0 (if source tarball signing is requested)
+# - a valid PGP signing key in the keyring (if source tarball signing is
+# requested)
+
+set -euo pipefail
+
+get_absolute_path() {
+    cd "$(dirname "$1")" && pwd -P
+}
+
+validate_project_tag() {
+    if ! git ls-remote -t "${upstream}"| grep -e "${version}$" > /dev/null; then
+        echo "The tag '$version' could not be found in upstream repository (${upstream})."
+        exit 1
+    fi
+}
+
+checkout_project() {
+    echo "Cloning project below working directory ${working_dir}"
+    cd "$working_dir"
+    git clone "$upstream" --branch "$version" \
+                          --single-branch \
+                          --depth=1 \
+                          --recurse-submodules \
+                          "${output_name}"
+}
+
+clean_sources() {
+    cd "${working_dir}/${output_name}"
+    echo "Removing unneeded files and folders..."
+    rm -rfv .clang* \
+            .editor* \
+            .git* \
+            .travis* \
+            .github* \
+            .appveyor* \
+            travis* \
+            package
+}
+
+compress_sources() {
+    cd "${working_dir}"
+    tar -cvjSf "${output_name}.tar.bz2" "${output_name}"
+}
+
+move_sources() {
+    cd "${working_dir}"
+    mv -v "${output_name}.tar.bz2" "${output_dir}/"
+}
+
+sign_sources() {
+    cd "${output_dir}"
+    gpg --detach-sign \
+        -u "${signer}" \
+        -o "${output_name}.tar.bz2.asc" \
+        "${output_name}.tar.bz2"
+}
+
+cleanup_working_dir() {
+    echo "Removing working directory: ${working_dir}"
+    rm -rf "${working_dir}"
+}
+
+print_help() {
+    echo "Usage: $0 -v <version tag> -s <signature email or key ID>"
+    exit 1
+}
+
+if [ -n "${BUILD_DIR:-}" ]; then
+    echo "Build dir provided: ${BUILD_DIR}"
+    output_dir="${BUILD_DIR}/package"
+    mkdir -p "${output_dir}"
+else
+    output_dir="$(get_absolute_path "$0")"
+fi
+
+upstream="https://github.com/supercollider/supercollider"
+package_name="SuperCollider"
+working_dir="$(mktemp -d)"
+version="$(date '+%Y-%m-%d')"
+output_version=""
+output_name=""
+signer=""
+signature=0
+
+# remove the working directory, no matter what
+trap cleanup_working_dir EXIT
+
+if [ ${#@} -gt 0 ]; then
+    while getopts 'hv:s:' flag; do
+        case "${flag}" in
+            h) print_help
+                ;;
+            s) signer=$OPTARG
+                signature=1
+                ;;
+            v) version=$OPTARG
+                output_version="${version//Version-}"
+                ;;
+            *)
+                echo "Error! Try '${0} -h'."
+                exit 1
+                ;;
+        esac
+    done
+else
+    print_help
+fi
+
+output_name="${package_name}-${output_version}-Source"
+validate_project_tag
+checkout_project
+clean_sources
+compress_sources
+move_sources
+if [ $signature -eq 1 ]; then
+    sign_sources
+fi
+
+exit 0
+
+# vim:set ts=4 sw=4 et:


### PR DESCRIPTION
## Purpose and Motivation

This script creates a source tarball from a valid tag in this repository by checking out the SuperCollider sources recursively in a temporary working directory. Optionally, this script can also provide a detached PGP signature. The naming scheme of the tarball and the contained directory follows the current naming scheme.
The script automatically removes its working directory on exit or fail and is tested on Linux and macOS.

Eventually I think this should run in CI, but it can also be done manually by whoever is in charge of the release process (to be able to provide a detached PGP signature).

To create a source tarball:

```
./package/create_source_tarball.sh -v Version-3.11.0
```

To create a source tarball with detached PGP signature:

```
./package/create_source_tarball.sh -v Version-3.11.0 -s my-pgp-keyid-or-mail-address
```

Fixes #4545 #4818.

## Types of changes

- Bug fix
- New feature

## To-do list

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review
