### PR TITLE
Return plotter in AbstractFunction:plotGraph

### DIFF
--- a/HelpSource/Classes/AbstractFunction.schelp
+++ b/HelpSource/Classes/AbstractFunction.schelp
@@ -516,6 +516,44 @@ g.plotGraph(from:0,to:1);
 { 200.collect{ g.(rand(0.0,1.0)) } }.bench;
 ::
 
+method::plotGraph
+Sample the function with n points, in the range [from, to], and plot it in a Plotter.
+Returns a link::Classes/Plotter::.
+
+argument:: n
+Number of values displayed in the plot window (500 by default).
+argument:: from
+Minimum value passed to the function.
+argument:: to
+Maximum value passed to the function.
+
+argument:: name
+See link::Reference/plot::
+argument:: bounds
+See link::Reference/plot::
+argument:: discrete
+See link::Reference/plot::
+argument:: numChannels
+See link::Reference/plot::
+argument:: minval
+See link::Reference/plot::
+argument:: maxval
+See link::Reference/plot::
+argument:: separately
+See link::Reference/plot::
+
+returns:: a link::Classes/Plotter::
+
+discussion::
+code::
+// plot x.squared transfer function with x between -1 and 1.
+// here the x-axis shows n, the number of points 
+{ |x| x.squared }.plotGraph(n: 200, from: -1, to: 1);
+
+// as plotGraph returns a Plotter, you can apply a domain spec to show x value on the x-axis
+{ |x| x.squared }.plotGraph(n: 200, from: -1, to: 1).domainSpecs_([-1, 1, \lin].asSpec).refresh;
+::
+
 subsection::Function Composition
 
 When unary, binary or n-ary operators are applied to an abstract function, it returns an object that represents
@@ -582,4 +620,3 @@ a.value(0.5);
 
 a.value((0, 0.06..1)); // creates a range of values..
 ::
-

--- a/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
+++ b/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
@@ -1067,6 +1067,6 @@ Plotter {
 		numChannels, minval, maxval, separately = true;
 		var array = Array.interpolation(n, from, to);
 		var res = array.collect { |x| this.value(x) };
-		res.plot(name, bounds, discrete, numChannels, minval, maxval, separately)
+		^res.plot(name, bounds, discrete, numChannels, minval, maxval, separately)
 	}
 }


### PR DESCRIPTION
## Purpose and Motivation

As discussed on [scsynth.org](https://scsynth.org/t/how-to-plot-a-transfer-function/1911/4), it seems the ^ was forgotten at the end of AbstractFunction:plotGraph, and this function does not return the Plotter like plot does.

## Types of changes

- Breaking change

## To-do list

- [ ] Code is tested
- [ ] All tests are passing
- [ ] Updated documentation
- [X] This PR is ready for review
