### PR TITLE
Appveyor: workaround for storage limit

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -126,8 +126,11 @@ after_build:
 - ps: cd ..
 
 # XXX vvv TEMPORARY WORKAROUND DUE TO APPVEYOR ARTIFACT STORAGE LIMIT
-- echo "Pushing artifact to S3"
-- ps: aws s3 cp --region us-west-2 --recursive --include "*" $env:APPVEYOR_BUILD_FOLDER/artifacts/ s3://supercollider/$env:S3_BUILDS_LOCATION
+- ps: >-
+    If ($env:APPVEYOR_REPO_NAME -eq "supercollider/supercollider") {
+        echo "Pushing artifact to S3"
+        aws s3 cp --region us-west-2 --recursive --include "*" $env:APPVEYOR_BUILD_FOLDER/artifacts/ s3://supercollider/$env:S3_BUILDS_LOCATION
+    }
 # XXX ^^^ TEMPORARY WORKAROUND DUE TO APPVEYOR ARTIFACT STORAGE LIMIT
 
 after_deploy:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -130,13 +130,15 @@ after_build:
     If ($env:APPVEYOR_REPO_NAME -eq "supercollider/supercollider") {
         echo "Pushing artifact to S3"
         aws s3 cp --region us-west-2 --recursive --include "*" $env:APPVEYOR_BUILD_FOLDER/artifacts/ s3://supercollider/$env:S3_BUILDS_LOCATION
+        echo "S3 Build Location = $env:S3_URL"
     }
 # XXX ^^^ TEMPORARY WORKAROUND DUE TO APPVEYOR ARTIFACT STORAGE LIMIT
 
-after_deploy:
-- ps: echo "S3 Build Location = $env:S3_URL"
 
 # XXX vvv TEMPORARILY DISABLED DUE TO APPVEYOR ARTIFACT STORAGE LIMIT
+#after_deploy:
+#- ps: echo "S3 Build Location = $env:S3_URL"
+#
 #artifacts:
 #    - path: artifacts
 #      name: art_folder

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -18,6 +18,12 @@ environment:
     CMAKE_CONFIGURATION: Release
     ASIO_URL: "http://www.steinberg.net/sdk_downloads/asiosdk2.3.zip"
     ASIO_ZIP: asiosdk2.3.zip
+    # XXX vvv TEMPORARY WORKAROUND DUE TO APPVEYOR ARTIFACT STORAGE LIMIT
+    AWS_ACCESS_KEY_ID:
+        secure: cUwCIb/EtpG3uAP48WylcMNxAh3yEbPNcQGPZDnh6go=
+    AWS_SECRET_ACCESS_KEY:
+        secure: 9n0lOPh/3hpwSEf1l0QySYngrgWYqplZozQ9ZJMxtDARIV5DIBn/NXttTfkh1Z3k
+    # XXX ^^^ TEMPORARY WORKAROUND DUE TO APPVEYOR ARTIFACT STORAGE LIMIT
 
     matrix:
         - QT_DIR: "C:/Qt/5.9/msvc2015"
@@ -119,38 +125,45 @@ after_build:
     }
 - ps: cd ..
 
+# XXX vvv TEMPORARY WORKAROUND DUE TO APPVEYOR ARTIFACT STORAGE LIMIT
+- echo "Pushing artifact to S3"
+- ps: aws s3 cp --region us-west-2 --recursive --include "*" $env:APPVEYOR_BUILD_FOLDER/artifacts/ s3://supercollider/$env:S3_BUILDS_LOCATION
+# XXX ^^^ TEMPORARY WORKAROUND DUE TO APPVEYOR ARTIFACT STORAGE LIMIT
+
 after_deploy:
 - ps: echo "S3 Build Location = $env:S3_URL"
 
-artifacts:
-    - path: artifacts
-      name: art_folder
-    - path: build\Install\*.exe
-      name: installer
-      type: File
-
-deploy:
-# s3 upload - every commit
-- provider: S3
-  access_key_id:
-    secure: cUwCIb/EtpG3uAP48WylcMNxAh3yEbPNcQGPZDnh6go=
-  secret_access_key:
-    secure: 9n0lOPh/3hpwSEf1l0QySYngrgWYqplZozQ9ZJMxtDARIV5DIBn/NXttTfkh1Z3k
-  bucket: supercollider
-  region: us-west-2
-  folder: $(S3_BUILDS_LOCATION)
-  artifact: art_folder
-  unzip: true
-  set_public: true
-  on:
-    appveyor_repo_name: supercollider/supercollider
-
-# github releases - only tags
-- provider: GitHub
-  description: appveyor_$(APPVEYOR_REPO_TAG_NAME)
-  artifact: installer
-  auth_token:
-    secure: 6m5+IiGj/pLhiUJvZPqs7yOlSe0ttH3pklaM7w1i8ca4YRUrIKddsGTZAZo86qLx
-  prerelease: true
-  on:
-    appveyor_repo_tag: true
+# XXX vvv TEMPORARILY DISABLED DUE TO APPVEYOR ARTIFACT STORAGE LIMIT
+#artifacts:
+#    - path: artifacts
+#      name: art_folder
+#    - path: build\Install\*.exe
+#      name: installer
+#      type: File
+#
+#deploy:
+## s3 upload - every commit
+#- provider: S3
+#  access_key_id:
+#    secure: cUwCIb/EtpG3uAP48WylcMNxAh3yEbPNcQGPZDnh6go=
+#  secret_access_key:
+#    secure: 9n0lOPh/3hpwSEf1l0QySYngrgWYqplZozQ9ZJMxtDARIV5DIBn/NXttTfkh1Z3k
+#  bucket: supercollider
+#  region: us-west-2
+#  folder: $(S3_BUILDS_LOCATION)
+#  artifact: art_folder
+#  unzip: true
+#  set_public: true
+#  on:
+#    appveyor_repo_name: supercollider/supercollider
+#
+## github releases - only tags
+#- provider: GitHub
+#  description: appveyor_$(APPVEYOR_REPO_TAG_NAME)
+#  artifact: installer
+#  auth_token:
+#    secure: 6m5+IiGj/pLhiUJvZPqs7yOlSe0ttH3pklaM7w1i8ca4YRUrIKddsGTZAZo86qLx
+#  prerelease: true
+#  on:
+#    appveyor_repo_tag: true
+# XXX ^^^ TEMPORARY WORKAROUND DUE TO APPVEYOR ARTIFACT STORAGE LIMIT


### PR DESCRIPTION
it seems like it might take appveyor some time to address us hitting our storage limit due to the COVID pandemic, so in the meantime i propose we use this method to manually push to S3. by not listing the ZIP and html file we push to S3 as an "appveyor artifact", we avoid having them also store it, which would count toward our Appveyor storage limit.

that storage behavior and retention policy is currently an [unconfigurable aspect](https://www.appveyor.com/docs/packaging-artifacts/#artifacts-retention-policy) of appveyor. i've asked their support about this in the past and been told manually deploying like in this PR is the only way to avoid it.

this is a temporary workaround. we will need to revert this (or augment it) before a release, since it does not handle github deployments. it may be useful again in the future if we ever hit this limit again at an inopportune moment.