### PR TITLE
Qt: AA_EnableHighDpiScaling flags

### DIFF
--- a/QtCollider/interface.cpp
+++ b/QtCollider/interface.cpp
@@ -75,6 +75,12 @@ void QtCollider::init() {
         static char* qcArgv[1] = { qcArg0 };
 
         QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+        // In order to scale the UI properly on Windows with display scaling like 125% or 150%
+        // we need to disable scale factor rounding
+        // This is only available in Qt >= 5.14
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+        QGuiApplication::setHighDpiScaleFactorRoundingPolicy(Qt::HighDpiScaleFactorRoundingPolicy::PassThrough);
+#endif // QT_VERSION
 
         QcApplication* qcApp = new QcApplication(qcArgc, qcArgv);
 

--- a/QtCollider/interface.cpp
+++ b/QtCollider/interface.cpp
@@ -74,6 +74,8 @@ void QtCollider::init() {
         static char qcArg0[] = "SuperCollider";
         static char* qcArgv[1] = { qcArg0 };
 
+        QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+
         QcApplication* qcApp = new QcApplication(qcArgc, qcArgv);
 
         qcApp->setQuitOnLastWindowClosed(false);

--- a/editors/sc-ide/core/main_function.cpp
+++ b/editors/sc-ide/core/main_function.cpp
@@ -34,6 +34,13 @@ using namespace ScIDE;
 
 int main(int argc, char* argv[]) {
     QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+    // In order to scale the UI properly on Windows with display scaling like 125% or 150%
+    // we need to disable scale factor rounding
+    // This is only available in Qt >= 5.14
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+    QGuiApplication::setHighDpiScaleFactorRoundingPolicy(Qt::HighDpiScaleFactorRoundingPolicy::PassThrough);
+#endif // QT_VERSION
+
     QApplication app(argc, argv);
 
     QStringList arguments(QApplication::arguments());

--- a/editors/sc-ide/core/main_function.cpp
+++ b/editors/sc-ide/core/main_function.cpp
@@ -33,6 +33,7 @@
 using namespace ScIDE;
 
 int main(int argc, char* argv[]) {
+    QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
     QApplication app(argc, argv);
 
     QStringList arguments(QApplication::arguments());


### PR DESCRIPTION
## Purpose and Motivation
Maybe helps with #2442, ~badly needs testing on Windows though.~ @dyfer tested it, and it works, with his addition (see below).

Enables Qt's auto-detection for devicePixelRatio (HiDPI scaling), for both sclang and scide.
Qt provides ways to override this feature by setting environment variables, if the user prefers so.
For example:

- it's possible to turn auto-detection off by setting QT_AUTO_SCREEN_SCALE_FACTOR or QT_ENABLE_HIGHDPI_SCALING to 0

- it's possible to combine auto-detection with a user-supplied scale factor, for either GUIs, fonts or both, by setting QT_SCALE_FACTOR and QT_FONT_DPI

What I've found on my system, is that without any env var set, scide's and sclang's GUIs look very small, especially the help browser text and sclang-generated GUIs ( this resembles the situation in #2442 ). By setting the env vars, OR just by setting the flags I'm setting in this PR, the automatic scaling renders GUIs and text of a reasonable size.

After a commit from @dyfer we are also setting [HighDpiScaleFactorRoundingPolicy](https://doc.qt.io/qt-5/qguiapplication.html#setHighDpiScaleFactorRoundingPolicy) to PassThrough, so that fractional scale factors are not rounded to the nearest integer. This flag is available and set only for Qt version >= 5.14.
Since in previous versions of Qt was not possible to change the default policy (Round), for fractional scaling to work out of the box on Windows it is required to build with at least Qt 5.14.

More general info at [doc.qt.io](https://doc.qt.io/qt-5/highdpi.html#high-dpi-support-in-qt)

## Types of changes

- New feature

## To-do list

- [x] Code is tested on Windows, Linux, and Mac
meaning that we tried different scaling settings, and both UIs and text scale appropriately
(for QcCanvas based UIs, see #4846)
- [x] All tests are passing
- [x] Updated documentation (not needed IMO)
- [x] This PR is ready for review
