### PR TITLE
kill unresponsive servers on quit

### DIFF
--- a/HelpSource/Classes/Server.schelp
+++ b/HelpSource/Classes/Server.schelp
@@ -230,6 +230,8 @@ You cannot boot a server app on a remote machine, but you can initialize the all
 method:: quit
 quit the server application
 
+note:: If the server is unresponsive at the time of calling this method, it will be forced to quit immediately.::
+
 argument::onComplete
 A function that is called when quit has completed.
 

--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -1090,7 +1090,9 @@ Server {
 				"Server '%' was unresponsive. Killing forcefully.".format(name).postln;
 				thisProcess.platform.killProcessByID(pid);
 			} {
-				"Server '%' was unresponsive. Quitting anyway.".format(name).postln;
+				if(watchShutDown) {
+					"Server '%' was unresponsive. Quitting anyway.".format(name).postln;
+				};
 			};
 			watchShutDown = false;
 		};

--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -1087,7 +1087,7 @@ Server {
 
 		if(this.unresponsive) {
 			if(pid.notNil) {
-				"Server '%' was unresponsive. Killing forcefully.".format(name).postln;
+				"Server '%' is currently unresponsive. Forcing process to stop via system command.".format(name).postln;
 				thisProcess.platform.killProcessByID(pid);
 			} {
 				if(watchShutDown) {

--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -1085,8 +1085,13 @@ Server {
 
 		addr.sendMsg("/quit");
 
-		if(watchShutDown and: { this.unresponsive }) {
-			"Server '%' was unresponsive. Quitting anyway.".format(name).postln;
+		if(this.unresponsive) {
+			if(pid.notNil) {
+				"Server '%' was unresponsive. Killing forcefully.".format(name).postln;
+				thisProcess.platform.killProcessByID(pid);
+			} {
+				"Server '%' was unresponsive. Quitting anyway.".format(name).postln;
+			};
 			watchShutDown = false;
 		};
 
@@ -1103,8 +1108,6 @@ Server {
 			"'/quit' message sent to server '%'.".format(name).postln;
 		};
 
-		// let server process reset pid to nil!
-		// pid = nil;
 		sendQuit = nil;
 		maxNumClients = nil;
 


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

`Server -quit` does not quit unresponsive servers. This PR adds `kill` command to the server quit process if the given server is unresponsive.

IMO this should prevent majority of issues with hanging servers, since we'd be killing them e.g. on exit and recompile. However, I realize that this is also quite a strong measure and I'd like to hear if anyone feels like this has any major drawbacks.

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix
- New feature

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
~~- [ ] All tests are passing~~
- [x] Updated documentation
- [x] This PR is ready for review
