### PR TITLE
Fix sc_ide.svg when used with Qt SVG renderer, clean up sc_ide_svg.scd

### DIFF
--- a/icons/sc_ide.svg
+++ b/icons/sc_ide.svg
@@ -1,49 +1,42 @@
 <?xml version="1.0" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="1024" height="1024" viewBox="0 0 1024 1024" version="1.1">
-	<desc>SuperCollider Icon SVG - Batuhan Bozkurt 2012</desc>
-	<defs>
-		<circle id="circ0" cx="50%" cy="50%" r="45%" transform="rotate(0 512 512)"/>
-		<circle id="circ1" cx="50%" cy="50%" r="38.25%" transform="rotate(54 512 512)"/>
-		<circle id="circ2" cx="50%" cy="50%" r="31.5%" transform="rotate(108 512 512)"/>
-		<circle id="circ3" cx="50%" cy="50%" r="24.75%" transform="rotate(162 512 512)"/>
-		<circle id="circ4" cx="50%" cy="50%" r="18%" transform="rotate(216 512 512)"/>
-		<circle id="circ5" cx="50%" cy="50%" r="11.25%" transform="rotate(270 512 512)"/>
-		<circle id="circ6" cx="50%" cy="50%" r="4.5%" transform="rotate(324 512 512)"/>
-		<linearGradient id="fcirc0" x1="50%" y1="0%" x2="50%" y2="100%">
-			<stop stop-color="rgb(0,0,0)" offset="0%"/>
-			<stop stop-color="rgb(255,255,255)" offset="100%"/>
-		</linearGradient>
-		<linearGradient id="fcirc1" x1="50%" y1="0%" x2="50%" y2="100%">
-			<stop stop-color="rgb(13,13,13)" offset="0%"/>
-			<stop stop-color="rgb(255,255,255)" offset="100%"/>
-		</linearGradient>
-		<linearGradient id="fcirc2" x1="50%" y1="0%" x2="50%" y2="100%">
-			<stop stop-color="rgb(25,25,25)" offset="0%"/>
-			<stop stop-color="rgb(255,255,255)" offset="100%"/>
-		</linearGradient>
-		<linearGradient id="fcirc3" x1="50%" y1="0%" x2="50%" y2="100%">
-			<stop stop-color="rgb(38,38,38)" offset="0%"/>
-			<stop stop-color="rgb(255,255,255)" offset="100%"/>
-		</linearGradient>
-		<linearGradient id="fcirc4" x1="50%" y1="0%" x2="50%" y2="100%">
-			<stop stop-color="rgb(51,51,51)" offset="0%"/>
-			<stop stop-color="rgb(255,255,255)" offset="100%"/>
-		</linearGradient>
-		<linearGradient id="fcirc5" x1="50%" y1="0%" x2="50%" y2="100%">
-			<stop stop-color="rgb(64,64,64)" offset="0%"/>
-			<stop stop-color="rgb(255,255,255)" offset="100%"/>
-		</linearGradient>
-		<linearGradient id="fcirc6" x1="50%" y1="0%" x2="50%" y2="100%">
-			<stop stop-color="rgb(77,77,77)" offset="0%"/>
-			<stop stop-color="rgb(255,255,255)" offset="100%"/>
-		</linearGradient>
-	</defs>
-	<use xlink:href="#circ0" fill="url(#fcirc0)"/>
-	<use xlink:href="#circ1" fill="url(#fcirc1)"/>
-	<use xlink:href="#circ2" fill="url(#fcirc2)"/>
-	<use xlink:href="#circ3" fill="url(#fcirc3)"/>
-	<use xlink:href="#circ4" fill="url(#fcirc4)"/>
-	<use xlink:href="#circ5" fill="url(#fcirc5)"/>
-	<use xlink:href="#circ6" fill="url(#fcirc6)"/>
+<svg viewBox="0 0 1024 1024" version = "1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <desc>SuperCollider Icon SVG - Batuhan Bozkurt 2012</desc>
+    <linearGradient id="fcirc0" x1="50%" y1="0%" x2="50%" y2="100%">
+        <stop stop-color="rgb(0,0,0)" offset="0%"/>
+        <stop stop-color="rgb(255,255,255)" offset="100%"/>
+    </linearGradient>
+    <linearGradient id="fcirc1" x1="50%" y1="0%" x2="50%" y2="100%">
+        <stop stop-color="rgb(13,13,13)" offset="0%"/>
+        <stop stop-color="rgb(255,255,255)" offset="100%"/>
+    </linearGradient>
+    <linearGradient id="fcirc2" x1="50%" y1="0%" x2="50%" y2="100%">
+        <stop stop-color="rgb(25,25,25)" offset="0%"/>
+        <stop stop-color="rgb(255,255,255)" offset="100%"/>
+    </linearGradient>
+    <linearGradient id="fcirc3" x1="50%" y1="0%" x2="50%" y2="100%">
+        <stop stop-color="rgb(38,38,38)" offset="0%"/>
+        <stop stop-color="rgb(255,255,255)" offset="100%"/>
+    </linearGradient>
+    <linearGradient id="fcirc4" x1="50%" y1="0%" x2="50%" y2="100%">
+        <stop stop-color="rgb(51,51,51)" offset="0%"/>
+        <stop stop-color="rgb(255,255,255)" offset="100%"/>
+    </linearGradient>
+    <linearGradient id="fcirc5" x1="50%" y1="0%" x2="50%" y2="100%">
+        <stop stop-color="rgb(64,64,64)" offset="0%"/>
+        <stop stop-color="rgb(255,255,255)" offset="100%"/>
+    </linearGradient>
+    <linearGradient id="fcirc6" x1="50%" y1="0%" x2="50%" y2="100%">
+        <stop stop-color="rgb(77,77,77)" offset="0%"/>
+        <stop stop-color="rgb(255,255,255)" offset="100%"/>
+    </linearGradient>
+    <g transform="translate(512,512)">
+        <circle id="circ0" cx="0" cy ="0" r="460.8" fill="url(#fcirc0)" transform="rotate(0)"/>
+        <circle id="circ1" cx="0" cy ="0" r="391.68" fill="url(#fcirc1)" transform="rotate(54)"/>
+        <circle id="circ2" cx="0" cy ="0" r="322.56" fill="url(#fcirc2)" transform="rotate(108)"/>
+        <circle id="circ3" cx="0" cy ="0" r="253.44" fill="url(#fcirc3)" transform="rotate(162)"/>
+        <circle id="circ4" cx="0" cy ="0" r="184.32" fill="url(#fcirc4)" transform="rotate(216)"/>
+        <circle id="circ5" cx="0" cy ="0" r="115.2" fill="url(#fcirc5)" transform="rotate(270)"/>
+        <circle id="circ6" cx="0" cy ="0" r="46.08" fill="url(#fcirc6)" transform="rotate(324)"/>
+    </g>
 </svg>

--- a/icons/sc_ide_svg.scd
+++ b/icons/sc_ide_svg.scd
@@ -3,32 +3,35 @@
 
 (
 var cids, fids;
-var circDefs, fillDefs, uses, wrapped;
-var incre, incre2, decre, phase;
+var circDefs, fillDefs, wrapped;
 var radFor;
-var w;
+var canvasSize = 1024, pos = (canvasSize / 2).asInt;
 
-~circle = {|id, cx, cy, r, rotate| "<circle id=\"%\" cx=\"%\\%\" cy =\"%\\%\" r=\"%\\%\" transform=\"rotate(% 512 512)\"/>".format(id, cx, cy, r, rotate) };
-~color = {|shade| "rgb(%,%,%)".format(*((shade * 255).round ! 3)); };
-~linGrad = {|id, xy1, xy2, c1, c2| "<linearGradient id=\"%\" x1=\"%\\%\" y1=\"%\\%\" x2=\"%\\%\" y2=\"%\\%\"><stop stop-color=\"%\" offset=\"0\\%\"/><stop stop-color=\"%\" offset=\"100\\%\"/></linearGradient>".format(id, xy1.x, xy1.y, xy2.x, xy2.y, ~color.(c1), ~color.(c2)); };
-~use = {|shape, fill| "<use xlink:href=\"#%\" fill=\"url(#%)\"/>".format(shape, fill); };
-~wrapAll = {|w, h, defs, draws| "<?xml version=\"1.0\" standalone=\"no\"?><!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\" \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\"><svg width=\"%\" height=\"%\" viewBox=\"0 0 % %\" version = \"1.1\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\"><desc>SuperCollider Icon SVG - Batuhan Bozkurt 2012</desc><defs>%</defs>%</svg>".format(w, h, w, h, defs, draws); };
+~color = {|shade| "rgb(%,%,%)".format(*((shade * 255).round.asInt ! 3)); };
 
+~linGrad = {|id, xy1, xy2, c1, c2| "
+    <linearGradient id=\"%\" x1=\"%\\%\" y1=\"%\\%\" x2=\"%\\%\" y2=\"%\\%\">
+        <stop stop-color=\"%\" offset=\"0\\%\"/>
+        <stop stop-color=\"%\" offset=\"100\\%\"/>
+    </linearGradient>".format(id, xy1.x, xy1.y, xy2.x, xy2.y, ~color.(c1), ~color.(c2)); };
 
-radFor = {|cnt| (90 - (13.5 * cnt)); };
-w = 100;
-phase = -pi;
+~circle = {|id, r, fill, rotate| "
+        <circle id=\"%\" cx=\"0\" cy =\"0\" r=\"%\" fill=\"url(#%)\" transform=\"rotate(%)\"/>".format(id, r, fill, rotate) };
 
-incre = -0.95;
-incre2 = 4.02;
-decre = 59;
+~wrapAll = {|w, h, defs, x, y, draws| "<?xml version=\"1.0\" standalone=\"no\"?>
+<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\" \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">
+<svg viewBox=\"0 0 % %\" version = \"1.1\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">
+    <desc>SuperCollider Icon SVG - Batuhan Bozkurt 2012</desc>%
+    <g transform=\"translate(%,%)\">%
+    </g>
+</svg>".format(w, h, defs, x, y, draws); };
 
 cids = 7.collect({|cnt| "circ" ++ cnt; });
 fids = 7.collect({|cnt| "fcirc" ++ cnt; });
+radFor = {|cnt| (90 - (13.5 * cnt)) / 100 * canvasSize / 2; };
 
-circDefs = 7.collect({|cnt| ~circle.(cids[cnt], 50, 50, radFor.(cnt) / 2, (54 * cnt) % 360); });
 fillDefs = 7.collect({|cnt| ~linGrad.(fids[cnt], 50@0, 50@100, cnt.linlin(0, 6, 0, 0.3), 1); });
-uses = 7.collect({|cnt| ~use.(cids[cnt], fids[cnt]); });
-wrapped = ~wrapAll.(1024, 1024, circDefs.join ++ fillDefs.join, uses.join);
+circDefs = 7.collect({|cnt| ~circle.(cids[cnt], radFor.(cnt), fids[cnt], (54 * cnt) % 360); });
+wrapped = ~wrapAll.(canvasSize, canvasSize, fillDefs.join, pos, pos, circDefs.join);
 wrapped.postln;
 )


### PR DESCRIPTION
## Purpose and Motivation

The icon was broken when displayed with the Qt SVG renderer. This patch fixes and cleans up the SVG code generated by `sc_ide_svg.scd` as well as the actual SVG (`sc_ide.svg`).

Fixes #2646 

## Types of changes

- Bug fix

## To-do list

- [x] Code is tested
- [x] This PR is ready for review
