### PR TITLE
appveyor: make s3 artefacts readable

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -129,7 +129,7 @@ after_build:
 - ps: >-
     If ($env:APPVEYOR_REPO_NAME -eq "supercollider/supercollider") {
         echo "Pushing artifact to S3"
-        aws s3 cp --region us-west-2 --recursive --include "*" $env:APPVEYOR_BUILD_FOLDER/artifacts/ s3://supercollider/$env:S3_BUILDS_LOCATION
+        aws s3 cp --region us-west-2 --acl public-read --recursive --include "*" $env:APPVEYOR_BUILD_FOLDER/artifacts/ s3://supercollider/$env:S3_BUILDS_LOCATION
         echo "S3 Build Location = $env:S3_URL"
     }
 # XXX ^^^ TEMPORARY WORKAROUND DUE TO APPVEYOR ARTIFACT STORAGE LIMIT


### PR DESCRIPTION
## Purpose and Motivation

In the previous PR to fix this i neglected to mark the uploaded artefacts as publicly readable. Thanks to @dyfer for
noticing this; it was something i should have checked in the first place.

Fixed #4860

## Types of changes

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review