### PR TITLE
CI: use qt 5.14 in builds, switch to VS 2019

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -9,7 +9,7 @@ version: '{build}' # incremented with each build
 clone_depth: 10
 
 # https://www.appveyor.com/docs/build-environment/#build-worker-images
-image: Visual Studio 2017
+image: Visual Studio 2019
 
 # disable automatic tests
 test: off
@@ -27,17 +27,19 @@ environment:
 
     matrix:
         - QT_DIR: "C:/Qt/5.9/msvc2015"
-          CMAKE_GENERATOR: "Visual Studio 15 2017"
+          CMAKE_GENERATOR: "Visual Studio 16 2019"
           FFTW_URL: ftp://ftp.fftw.org/pub/fftw/fftw-3.3.5-dll32.zip
           ARCH: "x86"
+          CMAKE_ARCH: "Win32"
           S3_BUILDS_LOCATION: "builds/supercollider/supercollider/win32"
           # https://www.appveyor.com/docs/lang/cpp/
           VCVARS_SCRIPT: "C:/Program Files (x86)/Microsoft Visual Studio/2017/Community/VC/Auxiliary/Build/vcvars32.bat"
 
         - QT_DIR: "C:/Qt/5.14/msvc2017_64"
-          CMAKE_GENERATOR: "Visual Studio 15 2017 Win64"
+          CMAKE_GENERATOR: "Visual Studio 16 2019"
           FFTW_URL: ftp://ftp.fftw.org/pub/fftw/fftw-3.3.5-dll64.zip
           ARCH: "x64"
+          CMAKE_ARCH: "x64"
           S3_BUILDS_LOCATION: "builds/supercollider/supercollider/win64"
           VCVARS_SCRIPT: "C:/Program Files (x86)/Microsoft Visual Studio/2017/Community/VC/Auxiliary/Build/vcvars64.bat"
 
@@ -47,7 +49,7 @@ install:
 - ps: $env:PROGFILES = if ($env:ARCH -eq "x64") { 'Program Files' } else { 'Program Files (x86)' }
 
 # Load command-line tools (lib.exe)
-- cmd: call "%VCVARS_SCRIPT%"
+# - cmd: call "%VCVARS_SCRIPT%"
 
 - cmd: echo "Get submodules"
 - cmd: git submodule update --init --recursive
@@ -94,7 +96,7 @@ before_build:
 - cd build
 
 build_script:
-- cmake -G "%CMAKE_GENERATOR%" -D CMAKE_PREFIX_PATH=%QT_DIR% ..
+- cmake -G "%CMAKE_GENERATOR%" -A "%CMAKE_ARCH%" -D CMAKE_PREFIX_PATH=%QT_DIR% ..
 - cmake --build . --target install --config %CMAKE_CONFIGURATION%
 
 # after_build instead of before_deploy so artifacts are collected at the right time

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -34,7 +34,7 @@ environment:
           # https://www.appveyor.com/docs/lang/cpp/
           VCVARS_SCRIPT: "C:/Program Files (x86)/Microsoft Visual Studio/2017/Community/VC/Auxiliary/Build/vcvars32.bat"
 
-        - QT_DIR: "C:/Qt/5.11/msvc2017_64"
+        - QT_DIR: "C:/Qt/5.14/msvc2017_64"
           CMAKE_GENERATOR: "Visual Studio 15 2017 Win64"
           FFTW_URL: ftp://ftp.fftw.org/pub/fftw/fftw-3.3.5-dll64.zip
           ARCH: "x64"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -33,7 +33,7 @@ environment:
           CMAKE_ARCH: "Win32"
           S3_BUILDS_LOCATION: "builds/supercollider/supercollider/win32"
           # https://www.appveyor.com/docs/lang/cpp/
-          VCVARS_SCRIPT: "C:/Program Files (x86)/Microsoft Visual Studio/2017/Community/VC/Auxiliary/Build/vcvars32.bat"
+          VCVARS_SCRIPT: "C:/Program Files (x86)/Microsoft Visual Studio/2019/Community/VC/Auxiliary/Build/vcvars32.bat"
 
         - QT_DIR: "C:/Qt/5.14/msvc2017_64"
           CMAKE_GENERATOR: "Visual Studio 16 2019"
@@ -41,7 +41,7 @@ environment:
           ARCH: "x64"
           CMAKE_ARCH: "x64"
           S3_BUILDS_LOCATION: "builds/supercollider/supercollider/win64"
-          VCVARS_SCRIPT: "C:/Program Files (x86)/Microsoft Visual Studio/2017/Community/VC/Auxiliary/Build/vcvars64.bat"
+          VCVARS_SCRIPT: "C:/Program Files (x86)/Microsoft Visual Studio/2019/Community/VC/Auxiliary/Build/vcvars64.bat"
 
 install:
 - ps: echo "Install phase start"
@@ -49,7 +49,7 @@ install:
 - ps: $env:PROGFILES = if ($env:ARCH -eq "x64") { 'Program Files' } else { 'Program Files (x86)' }
 
 # Load command-line tools (lib.exe)
-# - cmd: call "%VCVARS_SCRIPT%"
+- cmd: call "%VCVARS_SCRIPT%"
 
 - cmd: echo "Get submodules"
 - cmd: git submodule update --init --recursive

--- a/.travis/before-install-osx.sh
+++ b/.travis/before-install-osx.sh
@@ -5,7 +5,7 @@ export HOMEBREW_NO_ANALYTICS=1
 brew install libsndfile || brew install libsndfile || exit 1
 brew install portaudio || exit 2
 brew install ccache || exit 3
-brew install qt5 || exit 4
+brew upgrade qt5 || exit 4
 brew link qt5 --force || exit 5
 brew install fftw || exit 6
 


### PR DESCRIPTION
appveyor 32-bit build kept at 5.9 because it's the last version to have qtwebengine

<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

Motivated by #4850 , but we should be using latest versions anyway.

## Types of changes

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [ ] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review
