### PR TITLE
classlib: provide suggested fixes for method name typos

### DIFF
--- a/HelpSource/Classes/DoesNotUnderstandError.schelp
+++ b/HelpSource/Classes/DoesNotUnderstandError.schelp
@@ -1,0 +1,45 @@
+title:: DoesNotUnderstandError
+summary:: Error thrown when calling an unknown method name
+categories::Core
+related:: Classes/Error
+
+description::
+
+This error is typically generated when a method that doesn't exist on the receiver is called. Users typically do not
+construct this object themselves. The object has a few getters to learn more about the call that caused the error.
+
+This method reports a backtrace as well as a best-guess suggested replacement based on edit distance.
+
+classmethods::
+
+method:: new
+Construct a new DoesNotUnderstandError, and choose a possible suggested replacement based on the class of the
+receiver and contents of the selector.
+
+argument:: receiver
+The object on which the method was called.
+
+argument:: selector
+The method name that was not understood.
+
+argument:: args
+Arguments passed to the unknown method.
+
+instancemethods::
+
+method:: selector
+returns:: The selector passed to new. Typically, the method name that was not understood.
+
+method:: args
+returns:: The args passed to new. Typically, an array of arguments passed to the unknown method.
+
+method:: suggestedCorrection
+returns:: If there is a method that the receiver would understand that looks similar to the unknown method name, the
+the link::Classes/Method:: object that corresponds to it. Otherwise, code::nil::.
+
+method:: errorString
+returns:: Short-form representation of the error as a link::Classes/String::, with a suggested replacement if one was
+found.
+
+method:: reportError
+Print a long-form explanation of the error including backtrace and suggested replacement if one was found.

--- a/testsuite/classlibrary/TestDoesNotUnderstandError.sc
+++ b/testsuite/classlibrary/TestDoesNotUnderstandError.sc
@@ -1,0 +1,18 @@
+TestDoesNotUnderstandError : UnitTest {
+	test_construction {
+		var error;
+		try { 3.bogusTestMethodNameXyz(4, 5) } { |e| error = e };
+
+		this.assertEquals(error.receiver, 3);
+		this.assertEquals(error.selector, 'bogusTestMethodNameXyz');
+		this.assertEquals(error.args, [4, 5]);
+		this.assertEquals(error.suggestedCorrection, nil);
+	}
+
+	test_suggestedCorrection {
+		var error;
+		try { Object().szie } { |e| error = e };
+
+		this.assertEquals(error.suggestedCorrection, Object.findMethod(\size));
+	}
+}


### PR DESCRIPTION
## Purpose and Motivation

huge thanks to @jrsurge for laying the groundwork for this. now that we have an easy way to calculate edit distance,
we can automatically provide suggested corrections for typos made in method names. For example:

```supercollider
sc3> [].isnil
ERROR: Message 'isnil' not understood. Did you mean 'isNil'?
RECEIVER:
Instance of Array {    (0x55eb540e9a68, gc=74, fmt=01, flg=00, set=00)
  indexed slots [0]
}
ARGS:
CALL STACK:
	DoesNotUnderstandError:reportError
		arg this = <instance of DoesNotUnderstandError>
	Nil:handleError
		arg this = nil
		arg error = <instance of DoesNotUnderstandError>
	Thread:handleError
		arg this = <instance of Thread>
		arg error = <instance of DoesNotUnderstandError>
	Object:throw
		arg this = <instance of DoesNotUnderstandError>
	Object:doesNotUnderstand
		arg this = [*0]
		arg selector = 'isnil'
		arg args = [*0]
	Interpreter:interpretPrintCmdLine
		arg this = <instance of Interpreter>
		var res = nil
		var func = <instance of Function>
		var code = "[].isnil"
		var doc = nil
		var ideClass = nil
	Process:interpretPrintCmdLine
		arg this = <instance of Main>
^^ The preceding error dump is for ERROR: Message 'isnil' not understood. Did you mean 'isNil'?
RECEIVER: [  ]
```

this should help improve quality of life :)

open to suggestions on ways we could improve this. i actually think there are a couple of additional heuristics we
could use instead of plain edit distance, in the case of ties. for instance, character swaps and bad capitalizations
are a frequent source of typos, so perhaps prioritizing replacements whose size and set of case-insensitive
characters are the same. what i mean is that ties should be broken the following ways:

```
"szie" : "size" vs "sin" => choose "size" because it is the same length
"szie" : "size" vs "side" => choose "size" because the set of characters is the same
"somemethodname" : "someMethodName" vs "somemethodna" => choose "someMethodName" because it's the same modulo caps
```

## Types of changes

- Documentation
- New feature

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested - added tests for this functionality and basic ctor
- [x] All tests are passing - tests pass locally
- [x] Updated documentation - added documentation for DoesNotUnderstandError since none existed
- [x] This PR is ready for review