### PR TITLE
Add example to mismatched sample rate error

### DIFF
--- a/server/scsynth/SC_CoreAudio.cpp
+++ b/server/scsynth/SC_CoreAudio.cpp
@@ -896,7 +896,9 @@ bool SC_CoreAudioDriver::DriverSetup(int* outNumSamplesPerCallback, double* outS
             && inputStreamDesc.mSampleRate != outputStreamDesc.mSampleRate) {
             scprintf("ERROR: Input sample rate is %g, but output is %g. "
                      "Mismatched sample rates are not supported. "
-                     "To disable input, set the number of input channels to 0.\n",
+                     "To disable input, set the number of input channels to 0.\n"
+                     "For Example:\n"
+                     "  s.options.numInputBusChannels = 0\n",
                      inputStreamDesc.mSampleRate, outputStreamDesc.mSampleRate);
             return false;
         }


### PR DESCRIPTION
## Purpose and Motivation

As someone familiar to code, but not SC, it took me quite a while to figure out how set the number of input channels to 0 like the existing error message suggests. Figured this example might help someone else.

It assumes the `s` server variable, which I could imagine might not be applicable in a more advanced set-up, but I also imagine that someone working on a more advanced set-up probably would be familiar with `ServerOptions` to the point where they wouldn't need this example, or would know how to apply it to whatever `Server` scheme they had.

## Types of changes

<!-- Delete lines that don't apply -->

- Documentation
- Bug fix
- New feature
