### PR TITLE
supernova: support unicode in argv on windows

### DIFF
--- a/server/supernova/server/main.cpp
+++ b/server/supernova/server/main.cpp
@@ -375,7 +375,7 @@ int wmain(int argc, wchar_t** wargv) {
     // set codepage to UTF-8 and remember the old codepage
     auto oldCodePage = GetConsoleOutputCP();
     if (!SetConsoleOutputCP(65001))
-        scprintf("WARNING: could not set codepage to UTF-8\n");
+        cout << "WARNING: could not set codepage to UTF-8" << endl;
 
     // run main
     int result = supernova_main(argv.size(), argv.data());

--- a/server/supernova/server/main.cpp
+++ b/server/supernova/server/main.cpp
@@ -308,7 +308,7 @@ void lock_memory(server_arguments const& args) {
 
 } /* namespace */
 
-int main(int argc, char* argv[]) {
+int supernova_main(int argc, char* argv[]) {
     drop_rt_scheduling(); // when being called from sclang, we inherit a low rt-scheduling priority. but we don't want
                           // it!
     enable_core_dumps();
@@ -360,3 +360,35 @@ int main(int argc, char* argv[]) {
 
     return 0;
 }
+
+#ifdef _WIN32
+
+int wmain(int argc, wchar_t** wargv) {
+    // convert args to utf-8
+    std::vector<char*> argv;
+    for (int i = 0; i < argc; i++) {
+        auto argSize = WideCharToMultiByte(CP_UTF8, 0, wargv[i], -1, nullptr, 0, nullptr, nullptr);
+        argv.push_back(new char[argSize]);
+        WideCharToMultiByte(CP_UTF8, 0, wargv[i], -1, argv[i], argSize, nullptr, nullptr);
+    }
+
+    // set codepage to UTF-8 and remember the old codepage
+    auto oldCodePage = GetConsoleOutputCP();
+    if (!SetConsoleOutputCP(65001))
+        scprintf("WARNING: could not set codepage to UTF-8\n");
+
+    // run main
+    int result = supernova_main(argv.size(), argv.data());
+
+    // clear vector with converted args
+    for (auto* arg : argv)
+        delete[] arg;
+
+    return result;
+}
+
+#else
+
+int main(int argc, char** argv) { return supernova_main(argc, argv); };
+
+#endif

--- a/server/supernova/server/main.cpp
+++ b/server/supernova/server/main.cpp
@@ -380,6 +380,8 @@ int wmain(int argc, wchar_t** wargv) {
     // run main
     int result = supernova_main(argv.size(), argv.data());
 
+    // reset codepage from UTF-8
+    SetConsoleOutputCP(oldCodePage);
     // clear vector with converted args
     for (auto* arg : argv)
         delete[] arg;


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

Support unicode characters in argv (primarily for setting device name) on Windows.
Companion supernova PR for scsynth's #4479. Implementation is pretty much identical.

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] This PR is ready for review
