### PR TITLE
classlib: fix String -runInTerminal

### DIFF
--- a/SCClassLibrary/Common/Collections/osx/extString_osx.sc
+++ b/SCClassLibrary/Common/Collections/osx/extString_osx.sc
@@ -12,9 +12,10 @@
 		file = File(fpath, "w");
 
 		if(file.isOpen.not) {"String:runInTerminal was unable to create the script file".error} {
+			fpath = fpath.shellQuote;
 			file.write("#!"++shell++"\n"
 					++this++"\n"
-					++"rm"+fpath.quote+"\n");
+					++"rm"+fpath+"\n");
 			file.close;
 			("/bin/chmod +x" + fpath).systemCmd;
 			("/usr/bin/open -a Terminal" + fpath).systemCmd;


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->
Fixes #4878 

It seems that `String -runInTerminal` got broken in 3.11 since we changed `PathName.tmp` from `/tmp/` to `~/Library/Application Support/SuperCollider/tmp/` (note the addition of space in the path).

I decided to go for quoting the path, but alternatively, as suggested in the linked issue, it could instead have its spaces escaped:
```supercollider
fpath = fpath.escapeChar($ );
```

I'm not sure whether one is better than the other. I'm happy to change this as requested.

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [ ] All tests are passing 
  - I don't know if there's a way to test this
- [x] This PR is ready for review
