### PR TITLE
classlib: implement String -runInTerminal on Windows

### DIFF
--- a/SCClassLibrary/Common/Collections/windows/extString_windows.sc
+++ b/SCClassLibrary/Common/Collections/windows/extString_windows.sc
@@ -1,6 +1,6 @@
 + String {
 	runInTerminal {
-		"String:runInTerminal - sorry this method has not yet been implemented for windows.".error;
+		format("start \"SuperCollider runInTerminal\" cmd.exe /k %", this.quote).unixCmd;
 	}
 
 	openOS {|aPath|


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

Implement `String -runInTerminal` on Windows.
This seems to work fine, but I'm open to suggestions.

## Types of changes

<!-- Delete lines that don't apply -->

- New feature

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
  - I tested on Windows 10 only
- [ ] All tests are passing
  - no tests were added...
- [x] This PR is ready for review
