### PR TITLE
Help Browser code execution

### DIFF
--- a/HelpSource/editor.js
+++ b/HelpSource/editor.js
@@ -38,7 +38,8 @@ const init = () => {
             lineWrapping: true,
             viewportMargin: Infinity,
             extraKeys: {
-                'Shift-Enter': evalLine
+                'Shift-Enter': ()=>false,
+                'Ctrl-D': false
             }
         })
 
@@ -59,6 +60,7 @@ const init = () => {
 
 }
 
+// UNUSED
 const evalLine = () => {
     // If we are not running in the SC IDE, do nothing.
     if (!window.IDE) {

--- a/HelpSource/editor.js
+++ b/HelpSource/editor.js
@@ -38,6 +38,9 @@ const init = () => {
             lineWrapping: true,
             viewportMargin: Infinity,
             extraKeys: {
+                // noop: prevent both codemirror and the browser to handle Shift-Enter
+                'Shift-Enter': ()=>{}, 
+                // prevent only codemirror to handle Ctrl+D
                 'Ctrl-D': false
             }
         })

--- a/HelpSource/editor.js
+++ b/HelpSource/editor.js
@@ -38,7 +38,6 @@ const init = () => {
             lineWrapping: true,
             viewportMargin: Infinity,
             extraKeys: {
-                'Shift-Enter': ()=>false,
                 'Ctrl-D': false
             }
         })
@@ -58,16 +57,6 @@ const init = () => {
         })
     })
 
-}
-
-// UNUSED
-const evalLine = () => {
-    // If we are not running in the SC IDE, do nothing.
-    if (!window.IDE) {
-        return;
-    }
-    // Ask IDE to eval line. Calls back to `selectLine()`
-    window.IDE.evaluateLine();
 }
 
 /* returns the code selection, line or region */

--- a/QtCollider/factories.cpp
+++ b/QtCollider/factories.cpp
@@ -27,8 +27,8 @@
 QC_DECLARE_QWIDGET_FACTORY(QLabel);
 
 #ifdef SC_USE_QTWEBENGINE
-#   include "widgets/QcWebView.h"   
-    QC_DECLARE_QWIDGET_FACTORY(WebView);
+#    include "widgets/QcWebView.h"
+QC_DECLARE_QWIDGET_FACTORY(WebView);
 #endif
 
 static void doLoadFactories() {

--- a/QtCollider/factories.cpp
+++ b/QtCollider/factories.cpp
@@ -26,6 +26,11 @@
 
 QC_DECLARE_QWIDGET_FACTORY(QLabel);
 
+#ifdef SC_USE_QTWEBENGINE
+#   include "widgets/QcWebView.h"   
+    QC_DECLARE_QWIDGET_FACTORY(WebView);
+#endif
+
 static void doLoadFactories() {
     QC_ADD_FACTORY(QcDefaultWidget);
     QC_ADD_FACTORY(QcHLayoutWidget);

--- a/QtCollider/widgets/QcWebView.cpp
+++ b/QtCollider/widgets/QcWebView.cpp
@@ -23,7 +23,6 @@
 
 #    include "QcWebView.h"
 #    include "../widgets/web_page.hpp"
-#    include "../QcWidgetFactory.h"
 #    include <QWebEnginePage>
 #    include <QWebEngineSettings>
 #    include <QWebEngineContextMenuData>
@@ -35,7 +34,10 @@
 #    include <QStyle>
 #    include <QWebEngineCallback>
 
+#    ifndef SCIDE_NO_QWIDGETFACTORY
+#        include "../QcWidgetFactory.h"
 QC_DECLARE_QWIDGET_FACTORY(WebView);
+#    endif
 
 namespace QtCollider {
 

--- a/QtCollider/widgets/QcWebView.cpp
+++ b/QtCollider/widgets/QcWebView.cpp
@@ -227,11 +227,8 @@ void WebView::contextMenuEvent(QContextMenuEvent* event) {
 // duplicate them
 bool WebView::eventFilter(QObject* obj, QEvent* event) {
     if (event->type() == QEvent::KeyPress) {
-        QKeyEvent* keyEvent = static_cast<QKeyEvent*>(event);
-        QKeyEvent* newEvent =
-            new QKeyEvent(QEvent::KeyPress, keyEvent->key(), keyEvent->modifiers(), keyEvent->nativeScanCode(),
-                          keyEvent->nativeVirtualKey(), keyEvent->nativeModifiers(), keyEvent->text());
-        QApplication::postEvent(this, newEvent);
+        // takes ownership of newEvent
+        QApplication::postEvent(this, new QKeyEvent(*static_cast<QKeyEvent*>(event)));
     }
 
     event->ignore();
@@ -248,7 +245,8 @@ bool WebView::event(QEvent* ev) {
 
 void WebView::pageLoaded(bool ok) { this->focusProxy()->installEventFilter(this); }
 
-void WebView::updateEditable() {
+void WebView::setEditable(bool b) {
+    _editable = b;
     if (_editable) {
         page()->runJavaScript("document.documentElement.contentEditable = true");
     } else {

--- a/QtCollider/widgets/QcWebView.cpp
+++ b/QtCollider/widgets/QcWebView.cpp
@@ -34,11 +34,6 @@
 #    include <QStyle>
 #    include <QWebEngineCallback>
 
-#    ifndef SCIDE_NO_QWIDGETFACTORY
-#        include "../QcWidgetFactory.h"
-QC_DECLARE_QWIDGET_FACTORY(WebView);
-#    endif
-
 namespace QtCollider {
 
 WebView::WebView(QWidget* parent): QWebEngineView(parent), _editable(false) {

--- a/QtCollider/widgets/QcWebView.h
+++ b/QtCollider/widgets/QcWebView.h
@@ -58,7 +58,7 @@ public:
     Q_INVOKABLE void navigate(const QString& url);
 
 public Q_SLOTS:
-    void findText(const QString& searchText, bool reversed, QcCallback* cb = nullptr);
+    void findText(const QString& searchText, bool reversed, QtCollider::QcCallback* cb = nullptr);
 
 Q_SIGNALS:
     void linkActivated(const QString&, int, bool);

--- a/QtCollider/widgets/QcWebView.h
+++ b/QtCollider/widgets/QcWebView.h
@@ -100,10 +100,7 @@ public:
 
     Q_PROPERTY(bool editable READ editable WRITE setEditable);
     bool editable() const { return _editable; }
-    void setEditable(bool b) {
-        _editable = b;
-        updateEditable();
-    }
+    void setEditable(bool b);
 
     // QWebEnginePage properties
     Q_PROPERTY(QString requestedUrl READ requestedUrl)
@@ -135,15 +132,14 @@ public:
     inline static QUrl urlFromString(const QString& str) { return QUrl::fromUserInput(str); }
 
 protected:
-    virtual void contextMenuEvent(QContextMenuEvent*);
-    virtual bool event(QEvent* ev);
-    virtual bool eventFilter(QObject* obj, QEvent* event);
+    void contextMenuEvent(QContextMenuEvent*) override;
+    bool event(QEvent* ev) override;
+    bool eventFilter(QObject* obj, QEvent* event) override;
 
 public Q_SLOTS:
     void onPageReload();
     void onRenderProcessTerminated(QWebEnginePage::RenderProcessTerminationStatus, int);
     void onLinkClicked(const QUrl&, QWebEnginePage::NavigationType, bool);
-    void updateEditable();
     void pageLoaded(bool);
 
 private:

--- a/QtCollider/widgets/QcWebView.h
+++ b/QtCollider/widgets/QcWebView.h
@@ -42,7 +42,7 @@ class WebView : public QWebEngineView {
 
 public:
     Q_INVOKABLE void setFontFamily(int genericFontFamily, const QString& fontFamily);
-    Q_INVOKABLE void triggerPageAction(int action, bool checked);
+    Q_INVOKABLE void triggerPageAction(int action, bool checked = false);
     Q_INVOKABLE QAction* pageAction(QWebEnginePage::WebAction) const;
 
     // QWebEnginePage forwards
@@ -58,13 +58,12 @@ public:
     Q_INVOKABLE void navigate(const QString& url);
 
 public Q_SLOTS:
-    void findText(const QString& searchText, bool reversed, QtCollider::QcCallback* cb);
+    void findText(const QString& searchText, bool reversed, QcCallback* cb = nullptr);
 
 Q_SIGNALS:
     void linkActivated(const QString&, int, bool);
     void jsConsoleMsg(const QString&, int, const QString&);
     void reloadTriggered(const QString&);
-    void interpret(const QString& code);
 
     // QWebEnginePage forwards
     void linkHovered(const QString& url);
@@ -99,15 +98,11 @@ public:
     bool delegateReload() const;
     void setDelegateReload(bool);
 
-    Q_PROPERTY(bool enterInterpretsSelection READ interpretSelection WRITE setInterpretSelection);
-    bool interpretSelection() const { return _interpretSelection; }
-    void setInterpretSelection(bool b) { _interpretSelection = b; }
-
     Q_PROPERTY(bool editable READ editable WRITE setEditable);
     bool editable() const { return _editable; }
     void setEditable(bool b) {
         _editable = b;
-        updateEditable(true);
+        updateEditable();
     }
 
     // QWebEnginePage properties
@@ -140,19 +135,20 @@ public:
     inline static QUrl urlFromString(const QString& str) { return QUrl::fromUserInput(str); }
 
 protected:
-    virtual void keyPressEvent(QKeyEvent*);
     virtual void contextMenuEvent(QContextMenuEvent*);
+    virtual bool event(QEvent* ev);
+    virtual bool eventFilter(QObject* obj, QEvent* event);
 
 public Q_SLOTS:
     void onPageReload();
     void onRenderProcessTerminated(QWebEnginePage::RenderProcessTerminationStatus, int);
     void onLinkClicked(const QUrl&, QWebEnginePage::NavigationType, bool);
-    void updateEditable(bool);
+    void updateEditable();
+    void pageLoaded(bool);
 
 private:
     void connectPage(QtCollider::WebPage* page);
 
-    bool _interpretSelection;
     bool _editable;
 };
 

--- a/SCClassLibrary/Common/GUI/Base/QWebView.sc
+++ b/SCClassLibrary/Common/GUI/Base/QWebView.sc
@@ -3,7 +3,7 @@ WebView : View {
 
 	var <onLoadFinished, <onLoadFailed, <onLoadProgress, <onLoadStarted, <onLinkActivated, <onLinkHovered, <onReloadTriggered, <onJavaScriptMsg,
 		<onSelectionChanged, <onTitleChanged, <onUrlChanged, <onScrollPositionChanged, <onContentsSizeChanged, <onAudioMutedChanged,
-		<onRecentlyAudibleChanged;
+		<onRecentlyAudibleChanged, <enterInterpretsSelection;
 
 	*qtClass { ^'QtCollider::WebView'; }
 
@@ -107,6 +107,7 @@ WebView : View {
 		onReloadTriggered = func;
 	}
 
+	// this function is called by a javascript callback: see enterInterpretsSelection below
 	onInterpret {
 		|code|
 		code.interpret();
@@ -223,9 +224,25 @@ WebView : View {
 	url { ^this.getProperty('url') }
 	url_ { |url| this.setProperty('url', url) }
 
-	enterInterpretsSelection { ^this.getProperty('enterInterpretsSelection') }
-	enterInterpretsSelection_ { |b| this.setProperty('enterInterpretsSelection', b) }
-
+	enterInterpretsSelection_ { |b|
+		enterInterpretsSelection = b;
+		if(enterInterpretsSelection){
+			this.keyDownAction = { arg view, char, mods, u, keycode, key;
+				// 01000004 is Qt's keycode for Enter, needed on Mac
+				if((char.ascii==13).or(key.asHexString == "01000004")){
+					if(mods.isShift){
+						view.runJavaScript("selectLine()",this.onInterpret(_));
+					}{
+						if(mods.isCtrl || mods.isCmd) {
+							view.runJavaScript("selectRegion()",this.onInterpret(_));
+						};
+					}
+				}
+			};
+		}{
+			this.keyDownAction = {}
+		}
+	}
 	editable { ^this.getProperty('editable') }
 	editable_ { |b| this.setProperty('editable', b) }
 

--- a/SCClassLibrary/Common/GUI/Base/QWebView.sc
+++ b/SCClassLibrary/Common/GUI/Base/QWebView.sc
@@ -3,7 +3,7 @@ WebView : View {
 
 	var <onLoadFinished, <onLoadFailed, <onLoadProgress, <onLoadStarted, <onLinkActivated, <onLinkHovered, <onReloadTriggered, <onJavaScriptMsg,
 		<onSelectionChanged, <onTitleChanged, <onUrlChanged, <onScrollPositionChanged, <onContentsSizeChanged, <onAudioMutedChanged,
-		<onRecentlyAudibleChanged, <enterInterpretsSelection;
+		<onRecentlyAudibleChanged, <enterInterpretsSelection = false;
 
 	*qtClass { ^'QtCollider::WebView'; }
 
@@ -226,16 +226,16 @@ WebView : View {
 
 	enterInterpretsSelection_ { |b|
 		enterInterpretsSelection = b;
-		if(enterInterpretsSelection){
-			this.keyDownAction = { arg view, char, mods, u, keycode, key;
+		if(enterInterpretsSelection) {
+			this.keyDownAction = { |view, char, mods, u, keycode, key|
 				// 01000004 is Qt's keycode for Enter, needed on Mac
-				if((char.ascii==13).or(key.asHexString == "01000004")){
-					if(mods.isShift){
-						view.runJavaScript("selectLine()",this.onInterpret(_));
-					}{
-						if(mods.isCtrl || mods.isCmd) {
-							view.runJavaScript("selectRegion()",this.onInterpret(_));
-						};
+				if((char == Char.ret).or(key == 0x01000004)){
+					case
+					{ mods.isShift } {
+						view.runJavaScript("selectLine()", this.onInterpret(_));
+					}
+					{ mods.isCtrl || mods.isCmd }{
+						view.runJavaScript("selectRegion()", this.onInterpret(_));
 					}
 				}
 			};
@@ -243,6 +243,7 @@ WebView : View {
 			this.keyDownAction = {}
 		}
 	}
+
 	editable { ^this.getProperty('editable') }
 	editable_ { |b| this.setProperty('editable', b) }
 

--- a/SCClassLibrary/Common/GUI/tools/HelpBrowser.sc
+++ b/SCClassLibrary/Common/GUI/tools/HelpBrowser.sc
@@ -184,7 +184,7 @@ HelpBrowser {
 				.resize_(1)
 				.string_(str)
 				.value_(openNewWin)
-				.action_({ |b| openNewWin = b.value; webView.overrideNavigation = openNewWin; });
+				.action_({ |b| openNewWin = b.value; });
 		} {
 			str = "Open links in same window";
 			w = str.bounds.width + 5;
@@ -192,7 +192,7 @@ HelpBrowser {
 				.resize_(1)
 				.states_([[str],["Open links in new window"]])
 				.value_(openNewWin.asInteger)
-				.action_({ |b| openNewWin = b.value.asBoolean; webView.overrideNavigation = openNewWin; });
+				.action_({ |b| openNewWin = b.value.asBoolean; });
 		};
 
 		x = 0;
@@ -223,6 +223,8 @@ HelpBrowser {
 			{ "Monospace" }
 		));
 
+		webView.overrideNavigation = true;
+
 		webView.onLoadFinished = {
 			this.stopAnim;
 			window.name = "SuperCollider Help: %".format(webView.title);
@@ -233,16 +235,13 @@ HelpBrowser {
 		webView.onLinkActivated = {|wv, url|
 			var redirected, newPath, oldPath;
 			redirected = this.redirectTextFile(url);
-
 			if (not(redirected)) {
-				if(openNewWin) {
-					#newPath, oldPath = [url,webView.url].collect {|x|
-						if(x.notEmpty) {x.findRegexp("(^\\w+://)?([^#]+)(#.*)?")[1..].flop[1][1]}
-					};
-
+				#newPath, oldPath = [url,webView.url].collect {|x|
+					if(x.notEmpty) {x.findRegexp("(^\\w+://)?([^#]+)(#.*)?")[1..].flop[1][1]}
 				};
-				if(newPath!=oldPath) {
-					HelpBrowser.new(newWin:true).goTo(url);
+
+				if(newPath!=oldPath && openNewWin) {
+						HelpBrowser.new(newWin:openNewWin).goTo(url);
 				} {
 					this.goTo(url);
 				};
@@ -272,11 +271,7 @@ HelpBrowser {
 		};
 
 		webView.enterInterpretsSelection = true;
-		webView.keyDownAction = { arg view, char, mods;
-			if( (char.ascii == 13) && (mods.isCtrl || mods.isCmd || mods.isShift) ) {
-				view.tryPerform(\evaluateJavaScript,"selectLine()");
-			};
-		};
+
 		window.view.keyDownAction = { arg view, char, mods, uni, kcode, key;
 			var keyPlus, keyZero, keyMinus, keyEquals, keyF;
 			var modifier, zoomIn;

--- a/SCClassLibrary/Common/GUI/tools/HelpBrowser.sc
+++ b/SCClassLibrary/Common/GUI/tools/HelpBrowser.sc
@@ -240,7 +240,7 @@ HelpBrowser {
 					if(x.notEmpty) {x.findRegexp("(^\\w+://)?([^#]+)(#.*)?")[1..].flop[1][1]}
 				};
 
-				if(newPath!=oldPath && openNewWin) {
+				if(newPath != oldPath && openNewWin) {
 						HelpBrowser.new(newWin:openNewWin).goTo(url);
 				} {
 					this.goTo(url);

--- a/editors/sc-ide/CMakeLists.txt
+++ b/editors/sc-ide/CMakeLists.txt
@@ -193,11 +193,14 @@ set(ide_webengine_moc_hdrs
     widgets/util/WebSocketClientWrapper.hpp
     widgets/util/IDEWebChannelWrapper.hpp
     ${CMAKE_SOURCE_DIR}/QtCollider/widgets/web_page.hpp
+    ${CMAKE_SOURCE_DIR}/QtCollider/widgets/QcWebView.h
+    ${CMAKE_SOURCE_DIR}/QtCollider/QcCallback.hpp
 )
 set(ide_webengine_src
     widgets/help_browser.cpp
     widgets/util/WebSocketTransport.cpp
     ${CMAKE_SOURCE_DIR}/QtCollider/widgets/web_page.cpp
+    ${CMAKE_SOURCE_DIR}/QtCollider/widgets/QcWebView.cpp
 )
 
 if(SC_USE_QTWEBENGINE)
@@ -377,7 +380,7 @@ endif()
 
 if(SC_USE_QTWEBENGINE)
     message(STATUS "IDE: Building with QtWebEngine")
-    target_compile_definitions(libscide PUBLIC SC_USE_QTWEBENGINE)
+    target_compile_definitions(libscide PUBLIC SC_USE_QTWEBENGINE SCIDE_NO_QWIDGETFACTORY)
 endif()
 
 # Installation

--- a/editors/sc-ide/CMakeLists.txt
+++ b/editors/sc-ide/CMakeLists.txt
@@ -380,7 +380,7 @@ endif()
 
 if(SC_USE_QTWEBENGINE)
     message(STATUS "IDE: Building with QtWebEngine")
-    target_compile_definitions(libscide PUBLIC SC_USE_QTWEBENGINE SCIDE_NO_QWIDGETFACTORY)
+    target_compile_definitions(libscide PUBLIC SC_USE_QTWEBENGINE)
 endif()
 
 # Installation

--- a/editors/sc-ide/widgets/help_browser.hpp
+++ b/editors/sc-ide/widgets/help_browser.hpp
@@ -22,6 +22,7 @@
 
 #include "util/docklet.hpp"
 #include "QtCollider/widgets/web_page.hpp"
+#include "QtCollider/widgets/QcWebView.h"
 
 #include <QWebEngineView>
 #include <QLabel>
@@ -75,15 +76,6 @@ private:
     int mDotCount;
 };
 
-class HelpWebPage : public QtCollider::WebPage {
-    Q_OBJECT
-
-public:
-    HelpWebPage(HelpBrowser* browser);
-
-private:
-    HelpBrowser* mBrowser;
-};
 
 class HelpBrowser : public QWidget {
     Q_OBJECT
@@ -96,6 +88,7 @@ public:
         ZoomOut,
         ResetZoom,
         Evaluate,
+        EvaluateRegion,
 
         ActionCount
     };
@@ -148,7 +141,7 @@ private:
     void sendRequest(const QString& code);
     QString symbolUnderCursor();
 
-    QWebEngineView* mWebView;
+    QtCollider::WebView* mWebView;
     LoadProgressIndicator* mLoadProgressIndicator;
 
     QSize mSizeHint;


### PR DESCRIPTION
## Purpose and Motivation

Fixes #4542 and #4000

Explained more in detail in an RFC and open for discussion. Please let's discuss it, I don't want to push this in any way. I also would really benefit from some other pairs of eyes on it. And it needs testing on Windows.
RFC: https://github.com/elgiano/rfcs/blob/helpbrowser/rfcs/0009-helpbrowser-code-evaluation.md

- fixed code execution in both HelpBrowser class and Widget + in WebView, if the rendered webpage has selectLine()/selectRegion() javascript functions. It works with selected text/line, and with selected text/region.
- code execution in webviews is more consistently delegated to javascript, calling a function to get selected text, receiving it in a callback and then sending it to the interpreter
- a workaround WebView's "funny" keypress behavior, now keyDownAction works on WebView only when an url is set. It gets all events (including the ones swallowed by the renderer) without duplication. WebView parent widgets also get all keystrokes, except the ones swallowed by the web renderer when focusing an input field (like Shift+Enter).
- Using QcWebView in ScIDE Help Browser Widget

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
It works on Linux and Mac.~~Missing testing on Windows~~. Also on Windows, thanks @dyfer
- [x] All tests are passing
- [ ] Updated documentation
- [x] This PR is ready for review
