### PR TITLE
[scide] fix classname highlighting

### DIFF
--- a/editors/sc-ide/core/sc_introspection.cpp
+++ b/editors/sc-ide/core/sc_introspection.cpp
@@ -249,23 +249,6 @@ std::vector<const Method*> Introspection::findMethodPartial(const QString& parti
     return matchingMethods;
 }
 
-Introspection::ClassMethodMap Introspection::constructMethodMap(const Class* klass) const {
-    ClassMethodMap methodMap;
-    if (!klass)
-        return methodMap;
-
-    foreach (Method* method, klass->metaClass->methods) {
-        QList<Method*>& list = methodMap[method->definition.path];
-        list.append(method);
-    }
-
-    foreach (Method* method, klass->methods) {
-        QList<Method*>& list = methodMap[method->definition.path];
-        list.append(method);
-    }
-    return methodMap;
-}
-
 bool Method::matches(const QString& toMatch) const {
     return toMatch.isEmpty() ? true : name.get().startsWith(toMatch, Qt::CaseInsensitive);
 }

--- a/editors/sc-ide/core/sc_introspection.cpp
+++ b/editors/sc-ide/core/sc_introspection.cpp
@@ -200,18 +200,27 @@ bool Introspection::ensureIntrospectionData() const {
         return true;
 }
 
-const Class* Introspection::findClass(const QString& className, bool silent) const {
+const Class* Introspection::findClass(const QString& className) const {
     if (!ensureIntrospectionData())
-        return NULL;
+        return nullptr;
 
-    ClassMap::const_iterator klass_it = mClassMap.find(className);
-    if (klass_it == mClassMap.end()) {
-        if (!silent) {
-            MainWindow::instance()->showStatusMessage(QObject::tr("Class not defined!"));
-        }
-        return NULL;
+    auto classIterator = mClassMap.find(className);
+
+    if (classIterator == mClassMap.end()) {
+        return nullptr;
     }
-    return klass_it->second.data();
+
+    return classIterator->second.data();
+}
+
+const Class* Introspection::findClassOrWarn(const QString& className) const {
+    auto* classInstance = findClass(className);
+
+    if (classInstance == nullptr) {
+        MainWindow::instance()->showStatusMessage(QObject::tr("Class not defined!"));
+    }
+
+    return classInstance;
 }
 
 std::vector<const Class*> Introspection::findClassPartial(const QString& partialClassName) const {

--- a/editors/sc-ide/core/sc_introspection.cpp
+++ b/editors/sc-ide/core/sc_introspection.cpp
@@ -200,13 +200,15 @@ bool Introspection::ensureIntrospectionData() const {
         return true;
 }
 
-const Class* Introspection::findClass(const QString& className) const {
+const Class* Introspection::findClass(const QString& className, bool silent) const {
     if (!ensureIntrospectionData())
         return NULL;
 
     ClassMap::const_iterator klass_it = mClassMap.find(className);
     if (klass_it == mClassMap.end()) {
-        MainWindow::instance()->showStatusMessage(QObject::tr("Class not defined!"));
+        if (!silent) {
+            MainWindow::instance()->showStatusMessage(QObject::tr("Class not defined!"));
+        }
         return NULL;
     }
     return klass_it->second.data();

--- a/editors/sc-ide/core/sc_introspection.hpp
+++ b/editors/sc-ide/core/sc_introspection.hpp
@@ -115,11 +115,6 @@ public:
     std::vector<const Class*> findClassPartial(const QString& partialClassName) const;
     std::vector<const Method*> findMethodPartial(const QString& partialMethodName) const;
 
-    ClassMethodMap constructMethodMap(const Class* klass) const;
-    ClassMethodMap constructMethodMap(QString const& className) const {
-        return constructMethodMap(findClass(className));
-    }
-
     QString const& classLibraryPath() const { return mClassLibraryPath; }
 
     // remove class library path, userExtensionDir and systemExtensionDir

--- a/editors/sc-ide/core/sc_introspection.hpp
+++ b/editors/sc-ide/core/sc_introspection.hpp
@@ -111,7 +111,8 @@ public:
     const ClassMap& classMap() const { return mClassMap; }
     const MethodMap& methodMap() const { return mMethodMap; }
 
-    const Class* findClass(QString const& className, bool silent = false) const;
+    const Class* findClass(const QString& className) const;
+    const Class* findClassOrWarn(const QString& className) const;
     std::vector<const Class*> findClassPartial(const QString& partialClassName) const;
     std::vector<const Method*> findMethodPartial(const QString& partialMethodName) const;
 

--- a/editors/sc-ide/core/sc_introspection.hpp
+++ b/editors/sc-ide/core/sc_introspection.hpp
@@ -111,7 +111,7 @@ public:
     const ClassMap& classMap() const { return mClassMap; }
     const MethodMap& methodMap() const { return mMethodMap; }
 
-    const Class* findClass(QString const& className) const;
+    const Class* findClass(QString const& className, bool silent = false) const;
     std::vector<const Class*> findClassPartial(const QString& partialClassName) const;
     std::vector<const Method*> findMethodPartial(const QString& partialMethodName) const;
 

--- a/editors/sc-ide/widgets/code_editor/autocompleter.cpp
+++ b/editors/sc-ide/widgets/code_editor/autocompleter.cpp
@@ -631,7 +631,7 @@ const ScLanguage::Class* AutoCompleter::classForToken(Token::Type tokenType, con
 
     switch (tokenType) {
     case Token::Class: {
-        const Class* klass = introspection.findClass(tokenString);
+        const Class* klass = introspection.findClassOrWarn(tokenString);
         if (klass)
             klass = klass->metaClass;
         return klass;

--- a/editors/sc-ide/widgets/code_editor/highlighter.cpp
+++ b/editors/sc-ide/widgets/code_editor/highlighter.cpp
@@ -86,10 +86,15 @@ void SyntaxHighlighter::highlightBlockInCode(ScLexer& lexer) {
             setFormat(tokenPosition, tokenLength, formats[WhitespaceFormat]);
             break;
 
-        case Token::Class:
-            setFormat(tokenPosition, tokenLength, formats[ClassFormat]);
-            break;
+        case Token::Class: {
+            auto className = QString(lexer.text().begin() + tokenPosition, tokenLength);
+            auto* classNameInst = Main::scProcess()->introspection().findClass(className, true);
 
+            if (classNameInst != nullptr)
+                setFormat(tokenPosition, tokenLength, formats[ClassFormat]);
+
+            break;
+        }
         case Token::Builtin:
             setFormat(tokenPosition, tokenLength, formats[BuiltinFormat]);
             break;

--- a/editors/sc-ide/widgets/code_editor/highlighter.cpp
+++ b/editors/sc-ide/widgets/code_editor/highlighter.cpp
@@ -88,9 +88,9 @@ void SyntaxHighlighter::highlightBlockInCode(ScLexer& lexer) {
 
         case Token::Class: {
             auto className = QString(lexer.text().begin() + tokenPosition, tokenLength);
-            auto* classNameInst = Main::scProcess()->introspection().findClass(className, true);
+            auto* classInstance = Main::scProcess()->introspection().findClass(className);
 
-            if (classNameInst != nullptr)
+            if (classInstance != nullptr)
                 setFormat(tokenPosition, tokenLength, formats[ClassFormat]);
 
             break;

--- a/editors/sc-ide/widgets/lookup_dialog.cpp
+++ b/editors/sc-ide/widgets/lookup_dialog.cpp
@@ -317,7 +317,7 @@ QList<QStandardItem*> GenericLookupDialog::makeDialogItem(QString const& display
 
 QStandardItemModel* LookupDialog::modelForClass(const QString& className, const QString& methodName) {
     const Introspection& introspection = Main::scProcess()->introspection();
-    const Class* klass = introspection.findClass(className);
+    const Class* klass = introspection.findClassOrWarn(className);
 
     if (!klass)
         return NULL;


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

Previously, scide would highlight any token beginning with an uppercase letter as a class.
This can be very confusing when learning SC.

This PR checks introspection to ensure the class exists before highlighting.

* Uses Introspection::findClass rather than findClassPartial
    * findClassPartial uses QString::contains, so produces false positives
    * ~~This required adding a bool to findClass to allow the suppression of the status message warning about not finding the class~~
    * This required removing the warning from `findClass` and adding `findClassOrWarn` to allow suppression of the warning message.

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix
  technically a bug fix? more a behaviour change

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] This PR is ready for review
