### PR TITLE
cmake: link libsclang against ncurses

### DIFF
--- a/lang/CMakeLists.txt
+++ b/lang/CMakeLists.txt
@@ -260,10 +260,18 @@ endif()
 
 ## external libraries
 if(READLINE_FOUND)
-	message(STATUS "Compiling with Readline support")
-	target_compile_definitions(libsclang PUBLIC HAVE_READLINE)
-	target_include_directories(libsclang PUBLIC ${READLINE_INCLUDE_DIR})
-	target_link_libraries(libsclang ${READLINE_LIBRARY})
+    message(STATUS "Compiling with Readline support")
+    # Some Linuxes require linking against ncurses as well as libreadline, because libtermcap provides
+    # the same API and so could be used instead. Since ncurses is widely available and usually installed
+    # already, we simply require it on all Linuxes. See #4899.
+    if(CMAKE_SYSTEM_NAME MATCHES "Linux")
+        set(CURSES_NEED_NCURSES 1)
+        find_package(Curses REQUIRED)
+        target_link_libraries(libsclang ${CURSES_LIBRARIES})
+    endif()
+    target_compile_definitions(libsclang PUBLIC HAVE_READLINE)
+    target_include_directories(libsclang PUBLIC ${READLINE_INCLUDE_DIR})
+    target_link_libraries(libsclang ${READLINE_LIBRARY})
 endif(READLINE_FOUND)
 mark_as_advanced(READLINE_INCLUDE_DIR READLINE_LIBRARY)
 


### PR DESCRIPTION
## Purpose and Motivation

Fixes #4899

On some systems readline is not linked against ncurses; developers must
choose to link with it against either ncurses or termcap. since ncurses
is widely available, we simply find and link against it directly on Linux.

This also appears to be the same problem as https://scsynth.org/t/installation-issue-in-ubuntu-19-10/1952

## Types of changes

- Bug fix

## To-do list

- [ ] Code is tested - this works on my machine, but @bjadel you should give this a try if you have the time!
- [x] All tests are passing
- [ ] Updated documentation - perhaps we should update documentation on necessary packages?
- [x] This PR is ready for review