### PR TITLE
sc class library: TaskProxy: play on instances' clock if no argClock

### DIFF
--- a/HelpSource/Classes/EventPatternProxy.schelp
+++ b/HelpSource/Classes/EventPatternProxy.schelp
@@ -25,6 +25,9 @@ set the source (a pattern). If a quantization is given, schedule this change to 
 method::clear
 set the source to nil and stop playing
 
+method::clock
+get or set the instance's default clock, used by link::#-play:: if no other clock is specified. Defaults to TempoClock.default.
+
 method::quant
 get or set the quantization value. can be an array [quant, phase, offset, outset]
 
@@ -66,7 +69,7 @@ method::play
 starts the EventPatternProxy and creates a player. if you want to play multiple instances, use link::#-fork::.
 
 argument::argClock
-play on a certain clock, e.g. a link::Classes/TempoClock::.
+play on a certain clock, e.g. a link::Classes/TempoClock::. If nil uses this instance's link::#-clock::, which in turn defaults to TempoClock.default.
 
 argument::protoEvent
 an event to be used as a first input to the chain

--- a/HelpSource/Classes/Pdef.schelp
+++ b/HelpSource/Classes/Pdef.schelp
@@ -105,6 +105,9 @@ subsection::Changing the definition / setting the source
 
 One pattern may have many streams in different places. A change in the pattern definition Pdef propagates through all streams. The change does not have to be immediate - there is a scheme to schedule when the change becomes effective: a strong::quant:: and strong::clock:: (like elsewhere) and a strong::condition::.
 
+method::clock
+get or set the instance's default clock, used by link::#-play:: if no other clock is specified. Defaults to TempoClock.default.
+
 method::quant
 Set the quantisation time for beat accurate scheduling.
 

--- a/HelpSource/Classes/TaskProxy.schelp
+++ b/HelpSource/Classes/TaskProxy.schelp
@@ -25,6 +25,9 @@ set the source. If a quantization is given, schedule this change to the next bea
 method::clear
 set the source to nil
 
+method::clock
+get or set the instance's default clock, used by link::#-play:: if no other clock is specified. Defaults to TempoClock.default.
+
 method::quant
 get or set the quantization value. can be a pair [quant, offset]
 
@@ -57,7 +60,7 @@ method::play
 starts the TaskProxy and creates a player. if you want to play multiple instances, use strong::.playOnce(clock, protoEvent, quant)::
 
 argument::argClock
-which clock to use. if nil then the TempoClock.default is used.
+which clock to use. if nil then use this instance's link::#-clock::, which in turn defaults to TempoClock.default.
 
 argument::doReset
 A link::Classes/Boolean::

--- a/HelpSource/Classes/Tdef.schelp
+++ b/HelpSource/Classes/Tdef.schelp
@@ -72,6 +72,9 @@ One Tdef may have many tasks in different places. A change in the task definitio
 method::quant
 Set the quantisation time for beat accurate scheduling.
 
+method::clock
+get or set the instance's default clock, used by link::#-play:: if no other clock is specified. Defaults to TempoClock.default.
+
 argument::val
 can be an array strong::[quant, phase, timingOffset, outset] ::, or just strong::[quant, phase]:: etc.
 
@@ -126,7 +129,7 @@ method::play
 Starts the Tdef and creates a player.
 
 argument::argClock
-a clock on which to play the Tdef
+a clock on which to play the Tdef. If nil, uses the instance's link::#-clock::, which in turn defaults to TempoClock.default.
 argument::doReset
 a flag whether to reset the task if already playing
 argument::quant

--- a/SCClassLibrary/JITLib/Patterns/Pdef.sc
+++ b/SCClassLibrary/JITLib/Patterns/Pdef.sc
@@ -354,6 +354,7 @@ TaskProxy : PatternProxy {
 	}
 
 	play { arg argClock, doReset=false, quant;
+		argClock = argClock ? this.clock;
 		playQuant = quant ? this.quant;
 		if(player.isNil) {
 			player = this.playOnce(argClock, doReset, playQuant);
@@ -566,6 +567,7 @@ EventPatternProxy : TaskProxy {
 	////////// playing interface //////////
 
 	play { arg argClock, protoEvent, quant, doReset=false;
+		argClock = argClock ? this.clock;
 		playQuant = quant ? this.quant;
 		if(player.isNil) {
 			player = EventStreamPlayer(this.asProtected.asStream, protoEvent);

--- a/testsuite/classlibrary/TestEventPatternProxy.sc
+++ b/testsuite/classlibrary/TestEventPatternProxy.sc
@@ -1,0 +1,15 @@
+TestEventPatternProxy : UnitTest{
+
+    test_playOnInstanceClock {
+        var actualClock;
+        var clock = TempoClock(2);
+        var cond = Condition();
+        var proxy = EventPatternProxy(
+            Pbind(\dummy, Pfuncn{ actualClock = thisThread.clock; cond.unhang }, \dur, 0)
+        );
+        proxy.clock_(clock).play;
+        cond.hang;
+        this.assertEquals(actualClock, clock, "EventPatternProxy.play() should use instance's clock if no argClock is given");
+    }
+
+}

--- a/testsuite/classlibrary/TestTaskProxy.sc
+++ b/testsuite/classlibrary/TestTaskProxy.sc
@@ -1,0 +1,15 @@
+TestTaskProxy : UnitTest{
+
+    test_TaskProxy_playOnInstanceClock {
+        var actualClock;
+        var clock = TempoClock(2);
+        var cond = Condition();
+        var proxy = TaskProxy{ actualClock = thisThread.clock; cond.unhang };
+        proxy.play; // needs to play once before setting clock_, otherwise playOnce sets the player's clock for us
+        cond.hang;
+        proxy.clock_(clock).play;
+        cond.hang;
+        this.assertEquals(actualClock, clock, "TaskProxy.play() should use instance's clock if no argClock is given");
+    }
+
+}


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

Fixes #4803 

Both TaskProxy and EventPatternProxy were ignoring instances' clock in .play().
They should do what they do in .playOnce(): if a clock is not provided as an argument, fallback to instances' clock, which in turn falls back to TempoClock.default if unset

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review
