### PR TITLE
sc class library: PauseStream: allow clock change while playing

### DIFF
--- a/SCClassLibrary/Common/Streams/Stream.sc
+++ b/SCClassLibrary/Common/Streams/Stream.sc
@@ -327,7 +327,7 @@ CleanupStream : Stream {
 // PauseStream is a stream wrapper that can be started and stopped.
 
 PauseStream : Stream {
-	var <stream, <originalStream, <clock, <nextBeat, <>streamHasEnded=false;
+	var <stream, <originalStream, <>clock, <nextBeat, <>streamHasEnded=false;
 	var isWaiting = false, era=0;
 
 	*new { arg argStream, clock;
@@ -415,8 +415,14 @@ PauseStream : Stream {
 		^nextTime
 	}
 	awake { arg beats, seconds, inClock;
-		clock = inClock;
-		^this.next(beats)
+		if(this.clock == inClock){
+			clock = inClock; // is this needed at all?
+			^this.next(beats)
+		}{
+			this.clock.sched(0, this);
+    	^nil
+		}
+
 	}
 	threadPlayer { ^this }
 }

--- a/SCClassLibrary/JITLib/Patterns/Pdef.sc
+++ b/SCClassLibrary/JITLib/Patterns/Pdef.sc
@@ -301,6 +301,13 @@ TaskProxy : PatternProxy {
 
 	storeArgs { ^[source] }
 
+	clock_ { arg newClock;
+		clock = newClock;
+		if (this.isPlaying) {
+			this.player.clock = clock
+		}
+	}
+
 	source_ { arg obj;
 		pattern = if(obj.isKindOf(Function)) { this.convertFunction(obj) }{ obj };
 		if (obj.isNil) { pattern = this.class.default; source = obj; };


### PR DESCRIPTION
# Purpose and Motivation
Allows to change clock while playing for PauseStream and subclasses like Task and EventStreamPlayer. Discussion started at #4803, and continued at #4903.
TaskProxy and subclasses (like Pdef) gain the capability to change their player's clock while playing:
```supercollider
(
c = TempoClock(1.5, 10);
Pdef(\a).clock_(c).quant_(8).play;
Pdef(\a).source = Pbind(\dummy, Pfunc{ thisThread.clock.beats.debug("beats") }, \dur, 1);
)
// then, while playing
Pdef(\a).clock = TempoClock(10)
```

Would this be a breaking change? Could there be people out there changing a Pdef's clock while it's playing and relying on the fact that it wouldn't affect the current playing cycle?

## Types of changes

- New feature
- Breaking Change ?

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [ ] Code is tested
- [ ] All tests are passing
- [ ] Updated documentation
- [ ] This PR is ready for review
