### PR TITLE
cmake: update audio API message

### DIFF
--- a/server/scsynth/CMakeLists.txt
+++ b/server/scsynth/CMakeLists.txt
@@ -48,7 +48,7 @@ elseif(AUDIOAPI STREQUAL portaudio AND ((NOT WIN32) OR MSYS)) # MSYS like Apple
       message(FATAL_ERROR "Portaudio selected as audio API, but development files not found")
     endif()
 endif()
-message(STATUS "scsynth audio API: ${AUDIOAPI}")
+message(STATUS "Audio API (scsynth): ${AUDIOAPI}")
 
 set(scsynth_sources
 	SC_BufGen.cpp

--- a/server/supernova/CMakeLists.txt
+++ b/server/supernova/CMakeLists.txt
@@ -148,7 +148,7 @@ if(AUDIOAPI STREQUAL jack)
 elseif(AUDIOAPI STREQUAL portaudio AND ((NOT WIN32) OR MSYS)) # MSYS like Apple
     find_package(Portaudio REQUIRED)
 endif()
-message(STATUS "supernova audio API: ${AUDIOAPI}")
+message(STATUS "Audio API (supernova): ${AUDIOAPI}")
 
 if(AUDIOAPI STREQUAL jack)
     find_library(JACK NAMES jack)


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

This PR changes `Audio API` message in CMake to match the `FFT library` message. IMO this improves readability.

This is example output of CMake on macOS after this PR:

```
...
-- FFT library (scsynth): vDSP
-- Audio API (scsynth): coreaudio
-- Found fftw3f: /usr/local/lib/libfftw3f.dylib
-- FFT library (supernova): FFTW
-- Audio API (supernova): portaudio
...
```

## Types of changes

<!-- Delete lines that don't apply -->

- Cosmetic change :)

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] This PR is ready for review
