### PR TITLE
supernova: use system clock by default

### DIFF
--- a/HelpSource/Classes/ServerOptions.schelp
+++ b/HelpSource/Classes/ServerOptions.schelp
@@ -125,13 +125,13 @@ uses the one thread per CPU. Default is code::nil::.
 
 method:: useSystemClock
 Tells supernova whether to sync to the driver's sample clock, or to the system clock.
-For scsynth this value is ignored.
+note:: scsynth always uses system clock and this value is ignored.::
 list::
-## code::false:: (default) -- Use the sample clock. This helps to
+## code::true:: (default) -- Use the system clock. Timestamped messages will maintain consistent
+latency over long sessions, but may not be perfectly sample-accurate.
+## code::false:: -- Use the sample clock. This helps to
 support sample-accurate scheduling; however, messaging latency from
 the SuperCollider language will drift over long periods of time.
-## code::true:: -- Use the system clock. Timestamped messages will maintain consistent
-latency over long sessions, but may not be perfectly sample-accurate.
 ::
 
 method:: memoryLocking

--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -86,7 +86,7 @@ ServerOptions {
 				remoteControlVolume: false,
 				memoryLocking: false,
 				threads: nil,
-				useSystemClock: false,
+				useSystemClock: true,
 				numPrivateAudioBusChannels: 1020, // see corresponding setter method below
 				reservedNumAudioBusChannels: 0,
 				reservedNumControlBusChannels: 0,
@@ -218,6 +218,8 @@ ServerOptions {
 		});
 		if (useSystemClock, {
 			o = o ++ " -C 1"
+		}, {
+			o = o ++ " -C 0"
 		});
 		if (maxLogins.notNil, {
 			o = o ++ " -l " ++ maxLogins;

--- a/server/supernova/server/server_args.cpp
+++ b/server/supernova/server/server_args.cpp
@@ -43,7 +43,7 @@ server_arguments::server_arguments(int argc, char* argv[]) {
         ("audio-busses,a", value<uint32_t>(&audio_busses)->default_value(1024), "number of audio busses")
         ("block-size,z", value<uint32_t>(&blocksize)->default_value(64), "audio block size")
         ("hardware-buffer-size,Z", value<int32_t>(&hardware_buffer_size)->default_value(0), "hardware buffer size")
-        ("use-system-clock,C", value<uint16_t>(&use_system_clock)->default_value(0), "type of clock sampleclock=0 systemclock=1")
+        ("use-system-clock,C", value<uint16_t>(&use_system_clock)->default_value(1), "type of clock sampleclock=0 systemclock=1")
         ("samplerate,S", value<uint32_t>(&samplerate)->default_value(0), "hardware sample rate")
         ("buffers,b", value<uint32_t>(&buffers)->default_value(1024), "number of sample buffers")
         ("max-nodes,n", value<uint32_t>(&max_nodes)->default_value(1024), "maximum number of server nodes")


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

Per discussion in #4729 I think it would be good to have supernova use system clock by default, to match scsynth's behavior.
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->

- Documentation
- Breaking change

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] Updated documentation
- [x] This PR is ready for review
