### PR TITLE
sclang: fix spurious out-of-range error

### DIFF
--- a/lang/LangPrimSource/SC_CoreMIDI.cpp
+++ b/lang/LangPrimSource/SC_CoreMIDI.cpp
@@ -762,7 +762,7 @@ int prSendMIDIOut(struct VMGlobals* g, int numArgsPushed) {
     err = slotIntVal(p, &outputIndex);
     if (err)
         return err;
-    if (outputIndex < 0 || outputIndex >= gNumMIDIInPorts)
+    if (outputIndex < 0 || outputIndex >= gNumMIDIOutPorts)
         return errIndexOutOfRange;
 
     err = slotIntVal(u, &uid);


### PR DESCRIPTION
## Purpose and Motivation

CoreMIDI backend checked num in ports instead of out ports by mistake

fixes #4652

i am making this PR against 3.11 because it seems like a really obvious and simple fix to me, but i would appreciate
if someone on macOS could test it.

## Types of changes

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested - i haven't tested this, although it seems straightforward
- [x] All tests are passing
- [x] Updated documentation - no update needed
- [x] This PR is ready for review