### PR TITLE
Name of the default device in ServerOptions

### DIFF
--- a/HelpSource/Reference/Server-Architecture.schelp
+++ b/HelpSource/Reference/Server-Architecture.schelp
@@ -103,7 +103,11 @@ definitionlist::
 || When using TCP, the session password must be the first command sent. The default is no password. UDP ports never require passwords, so if password protection is desired, use TCP.
 
 ## -H device-name
+## -H input-device-name output-device-name
 || name of the hardware I/O device. If not provided, the default device is used. See link::Reference/AudioDeviceSelection:: for more details.
+note::
+To specify only input device and use default output, or only output device and use default input, use an empty string: code::'-H "" output-device-name':: or code::'-H input-device-name ""'::
+::
 
 ## -I input-streams-enable-string
 || Allows turning off input streams that you are not interested in on the device. If the string is 01100, for example, then only the second and third input streams on the device will be enabled. Turning off streams can reduce CPU load.

--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -189,7 +189,7 @@ ServerOptions {
 			});
 		}
 		{
-			o = o ++ " -H % %".format(inDevice.asString.quote, outDevice.asString.quote);
+			o = o ++ " -H % %".format((inDevice ? "").asString.quote, (outDevice ? "").asString.quote);
 		};
 		if (verbosity != defaultValues[\verbosity], {
 			o = o ++ " -V " ++ verbosity;


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

When specifying only input or only output device with `s.options.inDevice`/`s.options.outDevice`, the other device is set to `"nil"`. This has not been a problem so far since in the server if a device with a matching name is not found, a default device is used. This would theoretically result in incorrect behavior if we had a device called "nil" in the system :)

From what I understand looking at server implementation, an empty string is the correct value for "default device". This also was not documented anywhere AFAICT, so I added documentation in the help.

example of old behavior:

```supercollider
s.options.inDevice_("TestIn");
s.options.outDevice_(nil);
s.options.asOptionsString;
->  -u 57110 -a 1024 -i 2 -o 2 -H "TestIn" "nil" -R 0 -l 1

s.options.inDevice_(nil);
s.options.outDevice_("TestOut");
s.options.asOptionsString;
->  -u 57110 -a 1024 -i 2 -o 2 -H "nil" "TestOut" -R 0 -l 1
```
after this PR:
```supercollider
s.options.inDevice_("TestIn");
s.options.outDevice_(nil);
s.options.asOptionsString;
->  -u 57110 -a 1024 -i 2 -o 2 -H "TestIn" "" -R 0 -l 1

s.options.inDevice_(nil);
s.options.outDevice_("TestOut");
s.options.asOptionsString;
->  -u 57110 -a 1024 -i 2 -o 2 -H "" "TestOut" -R 0 -l 1
```

## Types of changes

<!-- Delete lines that don't apply -->

- Documentation
- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] Updated documentation
- [x] This PR is ready for review
