### PR TITLE
servers: print "(default)" when booting with default devices

### DIFF
--- a/server/scsynth/SC_PortAudio.cpp
+++ b/server/scsynth/SC_PortAudio.cpp
@@ -278,18 +278,28 @@ bool SC_PortAudioDriver::DriverSetup(int* outNumSamples, double* outSampleRate) 
                 pdi->maxInputChannels, pdi->maxOutputChannels);
     }
 
-    mDeviceInOut[0] = GetPaDeviceFromName(mWorld->hw->mInDeviceName, true);
-    mDeviceInOut[1] = GetPaDeviceFromName(mWorld->hw->mOutDeviceName, false);
+    auto m_inDeviceName = mWorld->hw->mInDeviceName;
+    auto m_outDeviceName = mWorld->hw->mOutDeviceName;
+    mDeviceInOut[0] = GetPaDeviceFromName(m_inDeviceName, true);
+    mDeviceInOut[1] = GetPaDeviceFromName(m_outDeviceName, false);
 
     // report requested devices
     fprintf(stdout, "\nRequested devices:\n");
     if (mWorld->mNumInputs) {
-        fprintf(stdout, "  In (matching device %sfound):\n  - %s\n", (mDeviceInOut[0] == paNoDevice ? "NOT " : ""),
-                mWorld->hw->mInDeviceName);
+        auto nameIsEmpty = (m_inDeviceName && !m_inDeviceName[0]) || (m_inDeviceName == nullptr);
+        fprintf(stdout, "  In%s:\n  - %s\n",
+                nameIsEmpty
+                    ? ""
+                    : (mDeviceInOut[0] == paNoDevice ? " (matching device NOT found)" : " (matching device found)"),
+                (nameIsEmpty ? "(default)" : m_inDeviceName));
     }
     if (mWorld->mNumOutputs) {
-        fprintf(stdout, "  Out (matching device %sfound):\n  - %s\n", (mDeviceInOut[1] == paNoDevice ? "NOT " : ""),
-                mWorld->hw->mOutDeviceName);
+        auto nameIsEmpty = (m_outDeviceName && !m_outDeviceName[0]) || (m_outDeviceName == nullptr);
+        fprintf(stdout, "  Out%s:\n  - %s\n",
+                nameIsEmpty
+                    ? ""
+                    : (mDeviceInOut[1] == paNoDevice ? " (matching device NOT found)" : " (matching device found)"),
+                (nameIsEmpty ? "(default)" : m_outDeviceName));
     }
 
     fprintf(stdout, "\n");

--- a/server/scsynth/SC_PortAudio.cpp
+++ b/server/scsynth/SC_PortAudio.cpp
@@ -278,28 +278,28 @@ bool SC_PortAudioDriver::DriverSetup(int* outNumSamples, double* outSampleRate) 
                 pdi->maxInputChannels, pdi->maxOutputChannels);
     }
 
-    auto m_inDeviceName = mWorld->hw->mInDeviceName;
-    auto m_outDeviceName = mWorld->hw->mOutDeviceName;
-    mDeviceInOut[0] = GetPaDeviceFromName(m_inDeviceName, true);
-    mDeviceInOut[1] = GetPaDeviceFromName(m_outDeviceName, false);
+    auto* inDeviceName = mWorld->hw->mInDeviceName;
+    auto* outDeviceName = mWorld->hw->mOutDeviceName;
+    mDeviceInOut[0] = GetPaDeviceFromName(inDeviceName, true);
+    mDeviceInOut[1] = GetPaDeviceFromName(outDeviceName, false);
 
     // report requested devices
     fprintf(stdout, "\nRequested devices:\n");
     if (mWorld->mNumInputs) {
-        auto nameIsEmpty = (m_inDeviceName && !m_inDeviceName[0]) || (m_inDeviceName == nullptr);
+        auto nameIsEmpty = (inDeviceName && !inDeviceName[0]) || (inDeviceName == nullptr);
         fprintf(stdout, "  In%s:\n  - %s\n",
                 nameIsEmpty
                     ? ""
                     : (mDeviceInOut[0] == paNoDevice ? " (matching device NOT found)" : " (matching device found)"),
-                (nameIsEmpty ? "(default)" : m_inDeviceName));
+                (nameIsEmpty ? "(default)" : inDeviceName));
     }
     if (mWorld->mNumOutputs) {
-        auto nameIsEmpty = (m_outDeviceName && !m_outDeviceName[0]) || (m_outDeviceName == nullptr);
+        auto nameIsEmpty = (outDeviceName && !outDeviceName[0]) || (outDeviceName == nullptr);
         fprintf(stdout, "  Out%s:\n  - %s\n",
                 nameIsEmpty
                     ? ""
                     : (mDeviceInOut[1] == paNoDevice ? " (matching device NOT found)" : " (matching device found)"),
-                (nameIsEmpty ? "(default)" : m_outDeviceName));
+                (nameIsEmpty ? "(default)" : outDeviceName));
     }
 
     fprintf(stdout, "\n");

--- a/server/supernova/server/main.cpp
+++ b/server/supernova/server/main.cpp
@@ -172,9 +172,11 @@ void start_audio_backend(server_arguments const& args) {
     if (output_channels == 0)
         output_device.clear();
 
-    std::cout << "Requested audio devices:\n";
-    std::cout << "  In: " << input_device << "\n";
-    std::cout << "  Out: " << output_device << std::endl;
+    std::cout << "Requested audio devices:" << std::endl;
+    if (input_channels)
+        std::cout << "  In: " << (input_device.empty() ? "(default)" : input_device) << std::endl;
+    if (output_channels)
+        std::cout << "  Out: " << (output_device.empty() ? "(default)" : output_device) << std::endl;
 
     bool success = instance->open_stream(input_device, input_channels, output_device, output_channels, args.samplerate,
                                          args.blocksize, args.hardware_buffer_size);


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

A follow up to first sentence in https://github.com/supercollider/supercollider/pull/4476#issuecomment-623772589

Print `(default)` when server is requested to use a default input/output device. Applies to PortAudio backend only. Examples:

scsynth:
```
Requested devices:
  In:
  - (default)
  Out:
  - (default)
```
supernova:
```
Requested audio devices:
  In: (default)
  Out: (default)
```


Additionally, scsynth will not print `(matching device NOT found)` when selecting default device.

Tested with following code:
```supercollider
// all tests run for scsynth and supernova
Server.supernova;
Server.scsynth;

// note that PortAudio backend does partial matching for device name

(
// default input and output
s.options.inDevice_(nil);
s.options.outDevice_(nil);
s.reboot;
)

(
// non-existing input
s.options.inDevice_("test");
s.options.outDevice_(nil);
s.reboot;
)

(
// non-existing output
s.options.inDevice_(nil);
s.options.outDevice_("test");
s.reboot;
)


(
// existing input (on apple macbook)
s.options.inDevice_("Built");
s.options.outDevice_(nil);
s.reboot;
)

(
// existing output (on apple macbook)
s.options.inDevice_(nil);
s.options.outDevice_("Built");
s.reboot;
)
```

## Types of changes

<!-- Delete lines that don't apply -->

- (Bug fix?)

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] This PR is ready for review
