### PR TITLE
ci: use cache for clang-format

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,9 @@ matrix:
 # with xcode, this requires an additional flag passed during the configuration phase.
 # see README_MACOS.md for details.
 cache:
- - ccache
+ ccache: true
+ directories:
+   - ../downloads
 
 before_install:
  - $TRAVIS_BUILD_DIR/.travis/before-install-$TRAVIS_OS_NAME.sh --qt=$QT

--- a/.travis/before-install-linux.sh
+++ b/.travis/before-install-linux.sh
@@ -3,10 +3,20 @@
 if $DO_LINT; then
     pushd . >/dev/null
     cd ..
-    echo "Downloading and extracting Clang 8.0.0"
+    if ! [[ -d "downloads" ]]
+    then
+       mkdir downloads
+    fi
+    cd downloads
     RELEASE_NAME=clang+llvm-8.0.0-x86_64-linux-gnu-ubuntu-14.04
-    curl -o clang.tar.xz https://releases.llvm.org/8.0.0/$RELEASE_NAME.tar.xz
-    tar xf clang.tar.xz
+    if ! [[ -d "$RELEASE_NAME" ]]
+    then
+       echo "Downloading and extracting Clang 8.0.0"
+       curl -o clang.tar.xz https://releases.llvm.org/8.0.0/$RELEASE_NAME.tar.xz
+       tar xf clang.tar.xz
+    else
+       echo "Using Clang 8.0.0 from cache"
+    fi
     cd $RELEASE_NAME/bin
     export PATH=$(pwd):$PATH
     echo "Added clang-format in $(pwd) to PATH"


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

Store clang download in cache.

Prevents CI failures when download source is not available.

clang download and extracted archive is now stored in `$TRAVIS_BUILD_DIR/../downloads/`, (previously `$TRAVIS_BUILD_DIR/../`), I hope that's okay.

## Types of changes

<!-- Delete lines that don't apply -->

- (Bug fix)

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [ ] Feel free to restart the build to confirm that cache actually works
- [x] This PR is ready for review
