### PR TITLE
Fix segfault in prMatchLangIP on Linux

### DIFF
--- a/lang/LangPrimSource/OSCData.cpp
+++ b/lang/LangPrimSource/OSCData.cpp
@@ -911,24 +911,22 @@ int prMatchLangIP(VMGlobals* g, int numArgsPushed) {
 #else
 
     struct ifaddrs *ifap, *ifa;
-    struct sockaddr_in* sa;
-    char* addr;
-
-    int result = getifaddrs(&ifap);
-    if (result) {
+    if (getifaddrs(&ifap) != 0) {
         error(strerror(errno));
         return errFailed;
     }
 
     for (ifa = ifap; ifa; ifa = ifa->ifa_next) {
-        int family = ifa->ifa_addr->sa_family;
-        if (family == AF_INET || family == AF_INET6) {
-            sa = (struct sockaddr_in*)ifa->ifa_addr;
-            addr = inet_ntoa(sa->sin_addr);
-            if (strcmp(ipstring, addr) == 0) {
-                SetTrue(g->sp - 1);
-                freeifaddrs(ifap);
-                return errNone;
+        if (ifa->ifa_addr) {
+            int family = ifa->ifa_addr->sa_family;
+            if (family == AF_INET || family == AF_INET6) {
+                struct sockaddr_in* sa = (struct sockaddr_in*)ifa->ifa_addr;
+                char *addr = inet_ntoa(sa->sin_addr);
+                if (strcmp(ipstring, addr) == 0) {
+                    SetTrue(g->sp - 1);
+                    freeifaddrs(ifap);
+                    return errNone;
+                }
             }
         }
     }

--- a/lang/LangPrimSource/OSCData.cpp
+++ b/lang/LangPrimSource/OSCData.cpp
@@ -921,7 +921,7 @@ int prMatchLangIP(VMGlobals* g, int numArgsPushed) {
             int family = ifa->ifa_addr->sa_family;
             if (family == AF_INET || family == AF_INET6) {
                 struct sockaddr_in* sa = (struct sockaddr_in*)ifa->ifa_addr;
-                char *addr = inet_ntoa(sa->sin_addr);
+                char* addr = inet_ntoa(sa->sin_addr);
                 if (strcmp(ipstring, addr) == 0) {
                     SetTrue(g->sp - 1);
                     freeifaddrs(ifap);


### PR DESCRIPTION
When I tried to initialize a remote scsynth with

  Server.remote(\salt, NetAddr("192.168.7.2", 57110),
ServerOptions.new.maxLogins = 4);

sclang answered by crashing with a segmentation fault.

gdb revealed that the crash happens in prMatchLangIP.  And this got me 
thinking: "Maybe I should stop my VPN?"  And indeed, that fixed the symptom.

Reading getifaddrs(3) explains it:

  The ifa_addr field points to a structure containing the interface address.
 (The sa_family subfield should be consulted to determine the format of the
 address structure.)  This field may contain a null pointer.

So fix prMatchLangIP by checking that ifa->ifa_addr is not NULL.