### PR TITLE
class library: improve suggestions in method not found error

### DIFF
--- a/SCClassLibrary/Common/Core/Error.sc
+++ b/SCClassLibrary/Common/Core/Error.sc
@@ -166,18 +166,18 @@ DoesNotUnderstandError : MethodError {
 			// to avoid unhelpful suggestions.
 			if(editDistances[minIndex] <= 3 and: { methodNames[minIndex].similarity(lowerCaseSelector) > 0 }) {
 				suggestedCorrection = methods[minIndex];
-				suggestion = "Did you mean '%'? Or should '%' have been called on another receiver?"
+				suggestion = "\nPerhaps you misspelled '%', or meant to call '%' on another receiver?"
 				.format(suggestedCorrection.name, selector);
 			}
 		}
 	}
 	errorString {
-		^"ERROR: Message '%' not understood by '%'".format(selector, receiver)
+		^"ERROR: Message '" ++ selector ++ "' not understood." ++ suggestion
 	}
 	reportError {
+		"\n".post;
 		this.errorString.postln;
-		suggestion.postln;
-		"RECEIVER:\n".post;
+		"\nRECEIVER:\n".post;
 		receiver.dump;
 		"ARGS:\n".post;
 		args.dumpAll;
@@ -185,7 +185,7 @@ DoesNotUnderstandError : MethodError {
 		if(protectedBacktrace.notNil, { this.postProtectedBacktrace });
 		this.dumpBackTrace;
 		// this.adviceLink.postln;
-		"^^ The preceding error dump is for %\nRECEIVER: %\n\n\n".postf(this.errorString, receiver);
+		"\n^^ %\nRECEIVER: %\n\n\n".postf(this.errorString, receiver);
 	}
 	adviceLinkPage {
 		^"%#%".format(this.class.name, selector)

--- a/SCClassLibrary/Common/Core/Error.sc
+++ b/SCClassLibrary/Common/Core/Error.sc
@@ -175,9 +175,8 @@ DoesNotUnderstandError : MethodError {
 		^"ERROR: Message '" ++ selector ++ "' not understood." ++ suggestion
 	}
 	reportError {
-		"\n".post;
 		this.errorString.postln;
-		"\nRECEIVER:\n".post;
+		"RECEIVER:\n".post;
 		receiver.dump;
 		"ARGS:\n".post;
 		args.dumpAll;
@@ -185,7 +184,7 @@ DoesNotUnderstandError : MethodError {
 		if(protectedBacktrace.notNil, { this.postProtectedBacktrace });
 		this.dumpBackTrace;
 		// this.adviceLink.postln;
-		"\n^^ %\nRECEIVER: %\n\n\n".postf(this.errorString, receiver);
+		"^^ %\nRECEIVER: %\n\n\n".postf(this.errorString, receiver);
 	}
 	adviceLinkPage {
 		^"%#%".format(this.class.name, selector)

--- a/SCClassLibrary/Common/Core/Error.sc
+++ b/SCClassLibrary/Common/Core/Error.sc
@@ -147,33 +147,36 @@ ShouldNotImplementError : MethodError {
 }
 
 DoesNotUnderstandError : MethodError {
-	var <>selector, <>args, <suggestedCorrection, suggestion;
+	var <>selector, <>args, <suggestedCorrection, suggestion = "";
 	*new { arg receiver, selector, args;
 		^super.new(nil, receiver).selector_(selector).args_(args).init
 	}
+
 	init {
 		var methods, methodNames, editDistances, minIndex, lowerCaseSelector;
-		methods = receiver.class.superclasses.add(receiver.class).collect(_.methods).reduce('++');
-		methodNames = methods.collect { |x| x.name.asString.toLower };
-		// we compare lower-case versions to prioritize capitalization mistakes
-		lowerCaseSelector = selector.asString.toLower;
-		editDistances = methodNames.collect(_.editDistance(lowerCaseSelector));
-		minIndex = editDistances.minIndex;
-		// Edit distance of 3 chosen arbitrarily; also, filter out completely dissimilar matches
-		// to avoid unhelpful suggestions.
-		if(editDistances[minIndex] <= 3 and: { methodNames[minIndex].similarity(lowerCaseSelector) > 0 }) {
-			suggestedCorrection = methods[minIndex];
-			suggestion = " Did you mean '%'?".format(suggestedCorrection.name);
-		} {
-			suggestedCorrection = nil;
-			suggestion = "";
+
+		if(receiver.notNil) {
+			methods = receiver.class.superclasses.add(receiver.class).collect(_.methods).reduce('++');
+			methodNames = methods.collect { |x| x.name.asString.toLower };
+			// we compare lower-case versions to prioritize capitalization mistakes
+			lowerCaseSelector = selector.asString.toLower;
+			editDistances = methodNames.collect(_.editDistance(lowerCaseSelector));
+			minIndex = editDistances.minIndex;
+			// Edit distance of 3 chosen arbitrarily; also, filter out completely dissimilar matches
+			// to avoid unhelpful suggestions.
+			if(editDistances[minIndex] <= 3 and: { methodNames[minIndex].similarity(lowerCaseSelector) > 0 }) {
+				suggestedCorrection = methods[minIndex];
+				suggestion = "Did you mean '%'? Or should '%' have been called on another receiver?"
+				.format(suggestedCorrection.name, selector);
+			}
 		}
 	}
 	errorString {
-		^"ERROR: Message '" ++ selector ++ "' not understood." ++ suggestion
+		^"ERROR: Message '%' not understood by '%'".format(selector, receiver)
 	}
 	reportError {
 		this.errorString.postln;
+		suggestion.postln;
 		"RECEIVER:\n".post;
 		receiver.dump;
 		"ARGS:\n".post;


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

The current error fixing suggestion can be misleading. Typically, the receiver is wrong, not the message. So when you call:

```
nil.flop
```

you get a suggestion that you mistyped `flop`, but it happens to be nil which doesn't understand flop:

```
ERROR: Message 'flop' not understood. Did you mean 'stop'?
RECEIVER:
   nil
ARGS:
```



This branch improves this situation.

If the receiver is nil, no suggestion is made - this seems like a reasonable thing not to do.

Otherwise, we post this:
```
"Did you mean '%'? Or should '%' have been called on another receiver?"
```

So that:
```supercollider
Set[1, 2, 3].flop 

// returns 

ERROR: Message 'flop' not understood by 'Set[ 1, 3, 2 ]'
Did you mean 'stop'? Or should 'flop' have been called on another receiver?
RECEIVER:
Instance of Set {    (0x11bbaff68, gc=78, fmt=00, flg=00, set=02)
  instance variables [2]
    array : instance of Array (0x11b705628, size=6, set=3)
    size : Integer 3
}
ARGS:
CALL STACK:
	DoesNotUnderstandError:reportError
		arg this = <instance of DoesNotUnderstandError>
	Nil:handleError
		arg 
[etc.]
```

This still isn't optimal in all cases, but catches most "misunderstandings".



<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->

- general improvement

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] This PR is ready for review
