### PR TITLE
Add keydown actions to resize the HelpBrowser

### DIFF
--- a/SCClassLibrary/Common/GUI/tools/HelpBrowser.sc
+++ b/SCClassLibrary/Common/GUI/tools/HelpBrowser.sc
@@ -278,20 +278,25 @@ HelpBrowser {
 			};
 		};
 		window.view.keyDownAction = { arg view, char, mods, uni, kcode, key;
-			if( ((key == 70) && (mods.isCtrl || mods.isCmd)) ) {
-				toggleFind.value;
-			};
-			if(char.ascii==27) {
-				if(findView.visible) {toggleFind.value};
-			};
-			if(((key == 61) && (mods.isCtrl || mods.isCmd)) || (key == 43 && mods.isCtrl)) {
+			var keyPlus, keyZero, keyMinus, keyEquals, keyF;
+			var modifier = Platform.case(\osx, { mods.isCmd }, { mods.isCtrl });
+			#keyPlus, keyZero, keyMinus, keyEquals, keyF = [43, 48, 45, 61, 70];
+
+			// +/= has the same value when pressed with <Cmd>
+			if (((key == keyEquals) || (key == keyPlus)) && modifier) {
 				webView.zoom = min(webView.zoom + 0.1, 2.0);
 			};
-			if(key == 45 && (mods.isCtrl || mods.isCmd)) {
+			if ((key == keyMinus) && modifier) {
 				webView.zoom = max(webView.zoom - 0.1, 0.1);
 			};
-			if(key == 48 && (mods.isCtrl || mods.isCmd)) {
+			if ((key == keyZero) && modifier) {
 				webView.zoom = 1.0;
+			};
+			if ((key == keyF) && modifier) {
+				toggleFind.value;
+			};
+			if (char.ascii == 27) { // Esc
+				if (findView.visible) { toggleFind.value };
 			};
 		};
 

--- a/SCClassLibrary/Common/GUI/tools/HelpBrowser.sc
+++ b/SCClassLibrary/Common/GUI/tools/HelpBrowser.sc
@@ -279,22 +279,39 @@ HelpBrowser {
 		};
 		window.view.keyDownAction = { arg view, char, mods, uni, kcode, key;
 			var keyPlus, keyZero, keyMinus, keyEquals, keyF;
-			var modifier = Platform.case(\osx, { mods.isCmd }, { mods.isCtrl });
+			var modifier, zoomIn;
+
+			modifier = Platform.case(\osx, {
+				mods.isCmd && mods.isCtrl.not && mods.isAlt.not;
+			}, {
+				mods.isCtrl && mods.isCmd.not && mods.isAlt.not;
+			});
+
 			#keyPlus, keyZero, keyMinus, keyEquals, keyF = [43, 48, 45, 61, 70];
 
-			// +/= has the same value when pressed with <Cmd>
-			if (((key == keyEquals) || (key == keyPlus)) && modifier) {
+			// +/= has the same value on macOS when pressed with <Cmd>
+			zoomIn = Platform.case(\osx, {
+				(key == keyEquals) && modifier;
+			}, {
+				(key == keyPlus) && modifier;
+			});
+
+			if (zoomIn) {
 				webView.zoom = min(webView.zoom + 0.1, 2.0);
 			};
+
 			if ((key == keyMinus) && modifier) {
 				webView.zoom = max(webView.zoom - 0.1, 0.1);
 			};
+
 			if ((key == keyZero) && modifier) {
 				webView.zoom = 1.0;
 			};
+
 			if ((key == keyF) && modifier) {
 				toggleFind.value;
 			};
+
 			if (char.ascii == 27) { // Esc
 				if (findView.visible) { toggleFind.value };
 			};

--- a/SCClassLibrary/Common/GUI/tools/HelpBrowser.sc
+++ b/SCClassLibrary/Common/GUI/tools/HelpBrowser.sc
@@ -278,7 +278,7 @@ HelpBrowser {
 			};
 		};
 		window.view.keyDownAction = { arg view, char, mods, uni, kcode, key;
-			if( ((key == 70) && mods.isCtrl) || (char == $f && mods.isCmd) ) {
+			if( ((key == 70) && (mods.isCtrl || mods.isCmd)) ) {
 				toggleFind.value;
 			};
 			if(char.ascii==27) {

--- a/SCClassLibrary/Common/GUI/tools/HelpBrowser.sc
+++ b/SCClassLibrary/Common/GUI/tools/HelpBrowser.sc
@@ -283,7 +283,16 @@ HelpBrowser {
 			};
 			if(char.ascii==27) {
 				if(findView.visible) {toggleFind.value};
-			}
+			};
+			if(((key == 61) && (mods.isCtrl || mods.isCmd)) || (key == 43 && mods.isCtrl)) {
+				webView.zoom = min(webView.zoom + 0.1, 2.0);
+			};
+			if(key == 45 && (mods.isCtrl || mods.isCmd)) {
+				webView.zoom = max(webView.zoom - 0.1, 0.1);
+			};
+			if(key == 48 && (mods.isCtrl || mods.isCmd)) {
+				webView.zoom = 1.0;
+			};
 		};
 
 		toolbar[\Back].action = { this.goBack };


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

There is no way to resize the (WebView based) HelpBrowser dynamically. This PR adds key down actions to be able to resize the content similar to the way the built-in HelpBrowsers docklet works in the IDE. It also fixes the key down action (Cmd-f on macOS) to toggle the "Find text" utility.

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix
- New feature

## To-do list

- [x] Code is tested
- [x] All tests are passing
- [ ] Updated documentation
- [x] This PR is ready for review
