### PR TITLE
sclang: fix return value for [x].mirror1

### DIFF
--- a/HelpSource/Classes/Array.schelp
+++ b/HelpSource/Classes/Array.schelp
@@ -153,6 +153,7 @@ method::mirror1
 Return a new Array which is the receiver made into a palindrome with the last element removed.
 This is useful if the list will be repeated cyclically, the first element will not get played twice.
 The receiver is unchanged.
+If the receiver is a single-element array, a copy is returned.
 code::
 [1, 2, 3, 4].mirror1.postln;
 ::

--- a/lang/LangPrimSource/PyrArrayPrimitives.cpp
+++ b/lang/LangPrimSource/PyrArrayPrimitives.cpp
@@ -1650,12 +1650,10 @@ int prArrayMirror1(struct VMGlobals* g, int numArgsPushed) {
 
     obj1 = slotRawObject(a);
     slots = obj1->slots;
-    size = std::max(obj1->size * 2 - 2, 0);
+    size = std::max(obj1->size * 2 - 2, obj1->size);
     obj2 = instantiateObject(g->gc, obj1->classptr, size, false, true);
     obj2->size = size;
-    // Special-case length-1 arrays
-    auto memcpySize = obj1->size == 1 ? 0 : obj1->size;
-    memcpy(obj2->slots, slots, memcpySize * sizeof(PyrSlot));
+    memcpy(obj2->slots, slots, obj1->size * sizeof(PyrSlot));
     // copy second part
     k = size / 2;
     for (i = 1, j = size - 1; i < k; ++i, --j) {

--- a/testsuite/classlibrary/TestArray.sc
+++ b/testsuite/classlibrary/TestArray.sc
@@ -325,11 +325,11 @@ TestArray : UnitTest {
 	}
 
 	test_mirror_oneElementArray_result { this.assertEquals([1].mirror, [1]); }
-	test_mirror1_oneElementArray_result { this.assertEquals([1].mirror1, []); }
+	test_mirror1_oneElementArray_result { this.assertEquals([1].mirror1, [1]); }
 	test_mirror2_oneElementArray_result { this.assertEquals([1].mirror2, [1, 1]); }
 
 	test_mirror_oneElementArray_size { this.assertEquals([1].mirror.size, 1); }
-	test_mirror1_oneElementArray_size { this.assertEquals([1].mirror1.size, 0); }
+	test_mirror1_oneElementArray_size { this.assertEquals([1].mirror1.size, 1); }
 	test_mirror2_oneElementArray_size { this.assertEquals([1].mirror2.size, 2); }
 
 	test_mirror_twoElementArray_result { this.assertEquals([1, 2].mirror, [1, 2, 1]); }


### PR DESCRIPTION
## Purpose and Motivation

Fixes #4930.

this pr contains the commits from #4935, that should be merged first and then 3.11 into develop

since this is technically a breaking change i put it in develop instead of 3.11

## Types of changes

- Documentation
- Bug fix
- Breaking change

## To-do list

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review