### PR TITLE
QtCollider: fix method linking

### DIFF
--- a/HelpSource/Classes/WebView.schelp
+++ b/HelpSource/Classes/WebView.schelp
@@ -51,7 +51,7 @@ METHOD:: findText
     Argument::
         Whether to search in reverse direction; a Boolean.
     Argument::
-        A function to be called with the find result when the operation is finished.
+        A function, called when the operation is finished. If the text was found this function is passed code::true::, otherwise code::false::.
 
 METHOD:: triggerPageAction
     Trigger an action on the current page. Possible actions include: reload, select all, copy, undo, redo (see link::Classes/QWebPageAction::)

--- a/QtCollider/widgets/QcWebView.h
+++ b/QtCollider/widgets/QcWebView.h
@@ -46,18 +46,19 @@ public:
     Q_INVOKABLE QAction* pageAction(QWebEnginePage::WebAction) const;
 
     // QWebEnginePage forwards
+    // Note: need to use QtCollider:: namespace here due to limitations of Qt metatype system
     Q_INVOKABLE void setHtml(const QString& html, const QString& baseUrl);
     Q_INVOKABLE void setContent(const QVector<int>& data, const QString& mimeType, const QString& baseUrl);
-    Q_INVOKABLE void toHtml(QcCallback* cb) const;
-    Q_INVOKABLE void toPlainText(QcCallback* cb) const;
-    Q_INVOKABLE void runJavaScript(const QString& script, QcCallback* cb);
+    Q_INVOKABLE void toHtml(QtCollider::QcCallback* cb) const;
+    Q_INVOKABLE void toPlainText(QtCollider::QcCallback* cb) const;
+    Q_INVOKABLE void runJavaScript(const QString& script, QtCollider::QcCallback* cb);
     Q_INVOKABLE void setWebAttribute(int attr, bool on);
     Q_INVOKABLE bool testWebAttribute(int attr);
     Q_INVOKABLE void resetWebAttribute(int attr);
     Q_INVOKABLE void navigate(const QString& url);
 
 public Q_SLOTS:
-    void findText(const QString& searchText, bool reversed, QcCallback* cb);
+    void findText(const QString& searchText, bool reversed, QtCollider::QcCallback* cb);
 
 Q_SIGNALS:
     void linkActivated(const QString&, int, bool);

--- a/testsuite/classlibrary/TestWebView.sc
+++ b/testsuite/classlibrary/TestWebView.sc
@@ -1,0 +1,58 @@
+TestWebView : UnitTest {
+
+	test_findText_found {
+		var window = Window();
+		var webView = WebView(window, Rect(0, 0, 100, 100));
+		var cond = Condition.new;
+		var wasFound, timeout;
+
+		window.front; // FIXME findText doesn't work if the window isn't displayed
+		webView.setHtml("abc");
+		webView.onLoadFinished = {
+			webView.findText("abc", true, { |found|
+				cond.unhang;
+				wasFound = found;
+			});
+		};
+		timeout = fork {
+			2.wait;
+			cond.unhang;
+		};
+
+		cond.hang;
+		timeout.stop;
+		window.close;
+		this.assert(wasFound.notNil, "test timeout check");
+		if(wasFound.notNil) {
+			this.assert(wasFound, "findText should find")
+		}
+	}
+
+	test_findText_notFound {
+		var window = Window();
+		var webView = WebView(window, Rect(0, 0, 100, 100));
+		var cond = Condition.new;
+		var wasFound, timeout;
+
+		window.front; // FIXME findText doesn't work if the window isn't displayed
+		webView.setHtml("abc");
+		webView.onLoadFinished = {
+			webView.findText("def", true, { |found|
+				cond.unhang;
+				wasFound = found;
+			});
+		};
+		timeout = fork {
+			2.wait;
+			cond.unhang;
+		};
+
+		cond.hang;
+		timeout.stop;
+		window.close;
+		this.assert(wasFound.notNil, "test timeout check");
+		if(wasFound.notNil) {
+			this.assert(wasFound.not, "findText should not find");
+		}
+	}
+}


### PR DESCRIPTION
## Purpose and Motivation

Fixes #4933.

We need to use the fully qualified "QtCollider::QcCallback", otherwise the qt metatype system
doesn't find the function signature. this seems to be a deficiency in the way qt matches function
signatures, but solving it more cleverly might be difficult and introduce other bugs, so i'm just
doing the straightforward thing for now.

another problem (maybe?) raised by this is that findText on a web view that isn't visible will
lock up the interpreter. same with findText(""). i don't know why.

## Types of changes

- Documentation
- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review