### PR TITLE
Fix getToFloatArray 'count' argument

### DIFF
--- a/SCClassLibrary/Common/Control/Buffer.sc
+++ b/SCClassLibrary/Common/Control/Buffer.sc
@@ -297,11 +297,14 @@ Buffer {
 	}
 
 	// risky without wait
-	getToFloatArray { arg index = 0, count, wait = 0.01, timeout = 3, action;
+	getToFloatArray { arg index = 0, count = -1, wait = 0.01, timeout = 3, action;
 		var refcount, array, pos, getsize, resp, done = false;
 
 		pos = index = index.asInteger;
-		count = (count ??  { numFrames * numChannels }).asInteger;
+		// treat -1 and nil the same
+		if(count == -1 || count.isNil) {
+			count = (numFrames * numChannels).asInteger - index;
+		};
 		array = FloatArray.newClear(count);
 		refcount = (count / 1633).roundUp;
 		count = count + pos;

--- a/testsuite/classlibrary/TestBuffer_Server.sc
+++ b/testsuite/classlibrary/TestBuffer_Server.sc
@@ -243,4 +243,38 @@ TestBuffer_Server : UnitTest {
 		this.assertArrayFloatEquals(floats, collection, "Buffer:getToFloatArray should get the buffer's values");
 	}
 
+	test_getToFloatArray_index_count {
+		var collection = Array.iota(8).asFloat;
+		var buffer = Buffer.sendCollection(server, collection);
+		var ranges = [
+			[0, nil],
+			[0, -1],
+			[2, nil],
+			[2, -1],
+			[2, 2],
+		];
+
+		ranges.do { |range|
+			var floats;
+			var slice = if(range[1] == -1 || range[1].isNil) {
+				collection.copyToEnd(range[0]);
+			} {
+				collection.copyRange(range[0], (range[0] + range[1]) - 1);
+			};
+
+			buffer.getToFloatArray(
+				index: range[0],
+				count: range[1],
+				action: { |array| floats = array }
+			);
+			server.sync;
+
+			this.assertArrayFloatEquals(
+				floats,
+				slice,
+				"getToFloatArray should get count number of values starting at index"
+			);
+		};
+	}
+
 }


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

This PR fixes `Buffer.getToFloarArray` by checking to see if its `count` argument is equal to `-1`.

The documentation for `Buffer.getToFloatArray` states that `count` can take a value of `-1` and treat it as "from index until the end of the buffer". This doesn't work because 1) count's value is checked for `nil`, not `-1`, 2) count's default value is `nil`.

Since it's well established that `-1` means "the entire buffer", rather that document count as implemented, I've chosen to add a check for `-1` alongside the check for `nil`. I've also changed the default value of count to `-1`. This PR shouldn't break any user code that relied on `nil`.`getToFloatArray` now reflects its documentation and better matches other Buffer method implementations.

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [X] Code is tested
- [ ] All tests are passing
- [ ] Updated documentation
- [X] This PR is ready for review
