### PR TITLE
Adds a warning if scsynth does not boot after 10 seconds on Windows to circumvent #4368

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -140,7 +140,7 @@ after_build:
 # XXX vvv TEMPORARILY DISABLED DUE TO APPVEYOR ARTIFACT STORAGE LIMIT
 #after_deploy:
 #- ps: echo "S3 Build Location = $env:S3_URL"
-
+#
 #artifacts:
 #    - path: artifacts
 #      name: art_folder

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -141,12 +141,12 @@ after_build:
 #after_deploy:
 #- ps: echo "S3 Build Location = $env:S3_URL"
 #
-#artifacts:
-#    - path: artifacts
-#      name: art_folder
-#    - path: build\Install\*.exe
-#      name: installer
-#      type: File
+artifacts:
+   - path: artifacts
+     name: art_folder
+   - path: build\Install\*.exe
+     name: installer
+     type: File
 #
 #deploy:
 ## s3 upload - every commit

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -138,15 +138,15 @@ after_build:
 
 
 # XXX vvv TEMPORARILY DISABLED DUE TO APPVEYOR ARTIFACT STORAGE LIMIT
-#after_deploy:
-#- ps: echo "S3 Build Location = $env:S3_URL"
-#
-#artifacts:
-#    - path: artifacts
-#      name: art_folder
-#    - path: build\Install\*.exe
-#      name: installer
-#      type: File
+after_deploy:
+- ps: echo "S3 Build Location = $env:S3_URL"
+
+artifacts:
+   - path: artifacts
+     name: art_folder
+   - path: build\Install\*.exe
+     name: installer
+     type: File
 #
 #deploy:
 ## s3 upload - every commit

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -141,12 +141,12 @@ after_build:
 #after_deploy:
 #- ps: echo "S3 Build Location = $env:S3_URL"
 #
-artifacts:
-   - path: artifacts
-     name: art_folder
-   - path: build\Install\*.exe
-     name: installer
-     type: File
+#artifacts:
+#    - path: artifacts
+#      name: art_folder
+#    - path: build\Install\*.exe
+#      name: installer
+#      type: File
 #
 #deploy:
 ## s3 upload - every commit

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -138,15 +138,15 @@ after_build:
 
 
 # XXX vvv TEMPORARILY DISABLED DUE TO APPVEYOR ARTIFACT STORAGE LIMIT
-after_deploy:
-- ps: echo "S3 Build Location = $env:S3_URL"
+# after_deploy:
+# - ps: echo "S3 Build Location = $env:S3_URL"
 
-artifacts:
-   - path: artifacts
-     name: art_folder
-   - path: build\Install\*.exe
-     name: installer
-     type: File
+# artifacts:
+#    - path: artifacts
+#      name: art_folder
+#    - path: build\Install\*.exe
+#      name: installer
+#      type: File
 #
 #deploy:
 ## s3 upload - every commit

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -138,10 +138,10 @@ after_build:
 
 
 # XXX vvv TEMPORARILY DISABLED DUE TO APPVEYOR ARTIFACT STORAGE LIMIT
-# after_deploy:
-# - ps: echo "S3 Build Location = $env:S3_URL"
+#after_deploy:
+#- ps: echo "S3 Build Location = $env:S3_URL"
 
-# artifacts:
+#artifacts:
 #    - path: artifacts
 #      name: art_folder
 #    - path: build\Install\*.exe

--- a/server/scsynth/scsynth_main.cpp
+++ b/server/scsynth/scsynth_main.cpp
@@ -47,10 +47,10 @@ inline int setlinebuf(FILE* stream) { return setvbuf(stream, (char*)0, _IONBF, 0
 #ifdef _WIN32
 // Add a warning when Windows Defender delays scsynth boot by 60+ seconds
 // cf. github issue #4368
-#include <iostream>
-#include <thread>
-#include <mutex>
-#include <chrono>
+#   include <iostream>
+#   include <thread>
+#   include <mutex>
+#   include <chrono>
 bool bScsynthHasBooted = false;
 std::mutex bScsynthHasBootedMutex;
 

--- a/server/scsynth/scsynth_main.cpp
+++ b/server/scsynth/scsynth_main.cpp
@@ -47,10 +47,10 @@ inline int setlinebuf(FILE* stream) { return setvbuf(stream, (char*)0, _IONBF, 0
 #ifdef _WIN32
 // Add a warning when Windows Defender delays scsynth boot by 60+ seconds
 // cf. github issue #4368
-#   include <iostream>
-#   include <thread>
-#   include <mutex>
-#   include <chrono>
+#    include <iostream>
+#    include <thread>
+#    include <mutex>
+#    include <chrono>
 bool bScsynthHasBooted = false;
 std::mutex bScsynthHasBootedMutex;
 

--- a/server/scsynth/scsynth_main.cpp
+++ b/server/scsynth/scsynth_main.cpp
@@ -66,7 +66,8 @@ void displayWarningIfScsynthHasNotBooted() {
     if (!bScsynthHasBooted) {
         std::cout << "Server: possible boot delay.\n";
         std::cout << "On some Windows-based machines, Windows Defender sometimes delays server boot by one minute.\n";
-        std::cout << "You can add scsynth.exe process to Windows Defender exclusion list to disable this check. It's safe.\n";
+        std::cout << "You can add scsynth.exe process to Windows Defender exclusion list ";
+        std::cout << "to disable this check. It's safe.\n";
     }
 }
 // end of additions for Windows Defender delay warning


### PR DESCRIPTION
## Purpose and Motivation

This is a workaround for #4368 

On some Windows 10 computers, Windows Defender delays scsynth.exe start for around one minute. Users can mark scsynth.exe as safe by adding the scsynth.exe process to Windows Defender exclusion list.
This PR adds a warning to scsynth output if it has not booted after 10 seconds.  

It may be difficult to get this delay at the first place, but having sc3-plugins and some quarks installed seem to increase the probability of getting it.

I tried the NRT example and it seems to work.

Please squash the commits if the PR is accepted (I could install the linter on my machine now 🙄).

## Types of changes

- New feature

## To-do list

- [ ] Code is tested
- [ ] All tests are passing
- [ ] Updated documentation
- [X] This PR is ready for review
