### PR TITLE
Fix assertFloatEquals string formatting

### DIFF
--- a/SCClassLibrary/Common/UnitTesting/UnitTest.sc
+++ b/SCClassLibrary/Common/UnitTesting/UnitTest.sc
@@ -115,8 +115,7 @@ UnitTest {
 	}
 
 	assertFloatEquals { |a, b, message = "", within = 0.0001, report = true, onFailure|
-		var details =
-		"Is:\n\t % \nShould equal (within range" + within ++ "):\n\t %".format(a, b);
+		var details = ("Is:\n\t % \nShould equal (within range " ++ within ++ "):\n\t %").format(a, b);
 		this.assert((a - b).abs <= within, message, report, onFailure, details);
 	}
 


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

Fixes the message that's posted when using `assertFloatEquals`. Currently, the formatting is done only on the last bit of the String:

```
PASS: a TestFoo: test_foo1 - foo this is true
Is:
	 % 
Should equal (within range 0.0001):
	 1.0
```

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [X] Code is tested
- [ ] All tests are passing
- [ ] Updated documentation
- [X] This PR is ready for review
