### PR TITLE
remove use of asAscii in doc_manager.cpp

### DIFF
--- a/editors/sc-ide/core/doc_manager.cpp
+++ b/editors/sc-ide/core/doc_manager.cpp
@@ -769,8 +769,9 @@ void DocumentManager::handleGetDocTextScRequest(const QString& data) {
             if (document) {
                 QString docText = document->textAsSCArrayOfCharCodes(start, range);
 
-                QString command =
-                    QStringLiteral("Document.executeAsyncResponse(\'%1\', %2.asAscii)").arg(funcID.c_str(), docText);
+                QString command = QStringLiteral("Document.executeAsyncResponse(\'%1\', %2.collect({|x| "
+                                                 "{x.asInteger.asAscii}.try ? \"\" }).join)")
+                                      .arg(funcID.c_str(), docText);
                 Main::evaluateCode(command, true);
             }
         }


### PR DESCRIPTION
## Purpose and Motivation

Fixes #4380

## Types of changes

- Bug fix

I just replace the asAscii call with the definition of asAscii in wslib quark.

## To-do list

- [ ] Code is tested
- [ ] All tests are passing
- [ ] Updated documentation
- [X] This PR is ready for review
