### PR TITLE
Server's 'wait' method reimplemented using Condition.

### DIFF
--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -761,10 +761,13 @@ Server {
 	/* scheduling */
 
 	wait { |responseName|
-		var routine = thisThread;
+		var condition = Condition.new;
 		OSCFunc({
-			routine.resume(true)
+			condition.test = true;
+			condition.signal
 		}, responseName, addr).oneShot;
+
+		condition.wait
 	}
 
 	waitForBoot { |onComplete, limit = 100, onFailure|


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation
`Server`'s `wait` method is defined as
```supercollider
wait { |responseName|
		var routine = thisThread;
		OSCFunc({
			routine.resume(true)
		}, responseName, addr).oneShot;
}
```
Currently, `wait` doesn't pause the running thread. This PR proposes
a fix using a `Condition` to pause and resume the thread. It is based on the discussion for #4942.

It follows a similar pattern found in `Server`'s `sendMsgSync` and `bootSync` methods. Specifically, we have
```supercollider
wait { |responseName|
	var condition = Condition.new;
	OSCFunc({
		condition.test = true;
		condition.signal
	}, responseName, addr).oneShot;

	condition.wait
}
```
Fixes #4942.
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review
