### PR TITLE
return early after first path separator in splitext

### DIFF
--- a/SCClassLibrary/Common/Collections/String.sc
+++ b/SCClassLibrary/Common/Collections/String.sc
@@ -429,11 +429,16 @@ String[char] : RawArray {
 		^this.primitiveFailed
 	}
 	splitext {
+		var sep = thisProcess.platform.pathSeparator;
 		this.reverseDo({ arg char, i;
+			// Return early after the first path separator
+			if ((char == sep), {^[this, nil]});
+
 			if (char == $\., {
 				^[this.copyFromStart(this.size - 2 - i), this.copyToEnd(this.size - i)]
 			});
 		});
+
 		^[this, nil]
 	}
 

--- a/SCClassLibrary/Common/Collections/String.sc
+++ b/SCClassLibrary/Common/Collections/String.sc
@@ -429,10 +429,9 @@ String[char] : RawArray {
 		^this.primitiveFailed
 	}
 	splitext {
-		var sep = thisProcess.platform.pathSeparator;
 		this.reverseDo({ arg char, i;
 			// Return early after the first path separator
-			if ((char == sep), {^[this, nil]});
+			if (Platform.isPathSeparator(char), {^[this, nil]});
 
 			if (char == $\., {
 				^[this.copyFromStart(this.size - 2 - i), this.copyToEnd(this.size - i)]

--- a/testsuite/classlibrary/TestString.sc
+++ b/testsuite/classlibrary/TestString.sc
@@ -122,7 +122,7 @@ TestString : UnitTest {
 	test_splitext_platform_path {
 		var p = Platform.pathSeparator;
 		var result = (p ++ "foo" ++ p ++ "bar" ++ p ++ "baz.xyz").splitext;
-		var expected = ["/foo/bar/baz", "xyz"];
+		var expected = [p ++ "foo" ++ p ++ "bar" ++ p ++ "baz", "xyz"];
 		this.assertEquals(result, expected);
 	}
 
@@ -135,7 +135,7 @@ TestString : UnitTest {
 	test_splitext_no_extension_platform_path {
 		var p = Platform.pathSeparator;
 		var result = (p ++ "foo" ++ p ++ "bar" ++ p ++ "baz").splitext;
-		var expected = ["/foo/bar/baz", nil];
+		var expected = [p ++ "foo" ++ p ++ "bar" ++ p ++ "baz", nil];
 		this.assertEquals(result, expected);
 	}
 
@@ -148,7 +148,7 @@ TestString : UnitTest {
 	test_splitext_early_return_platform_path {
 		var p = Platform.pathSeparator;
 		var result = (p ++ "foo.bar" ++ p ++ "baz.xyz").splitext;
-		var expected = ["/foo.bar/baz", "xyz"];
+		var expected = [p ++ "foo.bar" ++ p ++ "baz", "xyz"];
 		this.assertEquals(result, expected);
 	}
 
@@ -161,7 +161,7 @@ TestString : UnitTest {
 	test_splitext_no_extension_early_return_platform_path {
 		var p = Platform.pathSeparator;
 		var result = (p ++ "foo.bar" ++ p ++ "baz").splitext;
-		var expected = ["/foo.bar/baz", nil];
+		var expected = [p ++ "foo.bar" ++ p ++ "baz", nil];
 		this.assertEquals(result, expected);
 	}
 

--- a/testsuite/classlibrary/TestString.sc
+++ b/testsuite/classlibrary/TestString.sc
@@ -113,6 +113,58 @@ TestString : UnitTest {
 		this.assertEquals(result, expected);
 	}
 
+	test_splitext {
+		var result = "/foo/bar/baz.xyz".splitext;
+		var expected = ["/foo/bar/baz", "xyz"];
+		this.assertEquals(result, expected);
+	}
+
+	test_splitext_platform_path {
+		var p = Platform.pathSeparator;
+		var result = (p ++ "foo" ++ p ++ "bar" ++ p ++ "baz.xyz").splitext;
+		var expected = ["/foo/bar/baz", "xyz"];
+		this.assertEquals(result, expected);
+	}
+
+	test_splitext_no_extension {
+		var result = "/foo/bar/baz".splitext;
+		var expected = ["/foo/bar/baz", nil];
+		this.assertEquals(result, expected);
+	}
+
+	test_splitext_no_extension_platform_path {
+		var p = Platform.pathSeparator;
+		var result = (p ++ "foo" ++ p ++ "bar" ++ p ++ "baz").splitext;
+		var expected = ["/foo/bar/baz", nil];
+		this.assertEquals(result, expected);
+	}
+
+	test_splitext_early_return {
+		var result = "/foo.bar/baz.xyz".splitext;
+		var expected = ["/foo.bar/baz", "xyz"];
+		this.assertEquals(result, expected);
+	}
+
+	test_splitext_early_return_platform_path {
+		var p = Platform.pathSeparator;
+		var result = (p ++ "foo.bar" ++ p ++ "baz.xyz").splitext;
+		var expected = ["/foo.bar/baz", "xyz"];
+		this.assertEquals(result, expected);
+	}
+
+	test_splitext_no_extension_early_return {
+		var result = "/foo.bar/baz".splitext;
+		var expected = ["/foo.bar/baz", nil];
+		this.assertEquals(result, expected);
+	}
+
+	test_splitext_no_extension_early_return_platform_path {
+		var p = Platform.pathSeparator;
+		var result = (p ++ "foo.bar" ++ p ++ "baz").splitext;
+		var expected = ["/foo.bar/baz", nil];
+		this.assertEquals(result, expected);
+	}
+
 	// ------- time-related operations -----------------------------------------------
 
 	test_asSecs_stringDddHhMmSsSss_convertsToSeconds {


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->
Fixes #4944 

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list
 Note: I verified the fix manually. I think it warrants some unit tests, especially because the method in question doesn't currently have any. But I'm new to hacking on this project so it will take a bit to get my dev environment set up.

Update: Added tests and everything is passing locally now.

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [ ] Updated documentation
- [x] This PR is ready for review
