### PR TITLE
Testsuite: Correct Psetpre typo in TestPatternProxy

### DIFF
--- a/testsuite/classlibrary/TestPatternProxy.sc
+++ b/testsuite/classlibrary/TestPatternProxy.sc
@@ -89,7 +89,7 @@ TestPatternProxy : UnitTest {
 			//{ |x| Pselect({ |event| event[\zz].notNil }, x) },
 			{ |x| Pcollect({ |event| event[\zz] = 100 }, x) },
 			{ |x| Pfset({ ~gg = 8; ~zz = 9; }, x) },
-			{ |x| Psetpre({ ~gg = 8; ~zz = 9; }, x) },
+			{ |x| Psetpre(\gg, 8, x) },
 			{ |x| Ppar([x, x]) },
 			{ |x| Pfin(3, x) },
 			{ |x| Pfin(6, x) },


### PR DESCRIPTION
## Purpose and Motivation

Psetpre's constructor method signature is `Psetpre(name, value, pattern)`. But line 92 inappropriately copies the arguments from the Pfset test on the previous line: `Psetpre({ ~gg = 8; ~zz = 9; }, x)` -- since `pattern` is empty, this won't produce any values.

This PR only fixes this typo.

The test passed before, and after, the fix. So there might be something missing in the test logic: if events were expected but not produced at all, this test doesn't detect that. But I think that should be out of scope for this PR.

## Types of changes

- Bug fix

## To-do list

- [x] Code is tested
- [x] All tests are passing
- [ ] This PR is ready for review
