### PR TITLE
scsynth: use boost::program_options

### DIFF
--- a/server/scsynth/CMakeLists.txt
+++ b/server/scsynth/CMakeLists.txt
@@ -230,7 +230,7 @@ if(CMAKE_SYSTEM_NAME MATCHES "Linux")
 endif()
 
 add_executable(scsynth scsynth_main.cpp)
-target_link_libraries(scsynth libscsynth)
+target_link_libraries(scsynth libscsynth boost_program_options_lib)
 
 if (PTHREADS_FOUND)
     target_link_libraries(scsynth ${PTHREADS_LIBRARIES})

--- a/server/scsynth/scsynth_main.cpp
+++ b/server/scsynth/scsynth_main.cpp
@@ -108,7 +108,7 @@ static bpo::options_description makeScsynthOptionsDesc(ScsynthOptions& opts) {
                                                             "The default is no password.\n"
                                                             "UDP ports never require passwords, so for security use TCP.")
         ("nrt,N", bpo::value<std::vector<std::string>>()->multitoken(), "nrt synthesis <cmd-filename> <input-filename> <output-filename> <sample-rate> <header-format> <sample-format>")
-        ("memory-locking,L", "enable memory locking")
+        ("memory-locking,L", bpo::bool_switch(&opts.mMemoryLocking), "enable memory locking")
         ("version,v", "print version information and exit")
         ("hardware-device-name,H", bpo::value<std::vector<std::string>>()->multitoken(), "hardware device name")
         ("verbose,V", bpo::value<int>(&opts.mVerbosity)->default_value(defaultOpts.mVerbosity),
@@ -224,9 +224,8 @@ static ScsynthOptions parseScsynthArgs(int argc, char** argv) {
     options.mMaxGraphDefs = NEXTPOWEROFTWO(options.mMaxGraphDefs);
     options.mMaxLogins = NEXTPOWEROFTWO(options.mMaxLogins);
 
-    // Set boolean options manually
+    // Do int->boolean conversion manually
     options.mRendezvous = vm["rendezvous"].as<uint16_t>() > 0;
-    options.mMemoryLocking = vm.count("memory-locking") > 0;
 
     // Manually populate const char* fields from the corresponding string option
     // Use a macro to avoid typos and for readability

--- a/server/scsynth/scsynth_main.cpp
+++ b/server/scsynth/scsynth_main.cpp
@@ -161,6 +161,7 @@ static ScsynthOptions parseScsynthArgs(int argc, char** argv) {
     try {
         // If successful, populates `options`
         store(bpo::command_line_parser(argc, argv).options(optionsDesc).run(), vm);
+        notify(vm);
     } catch (bpo::error const& e) {
         fatalError(e.what());
     }


### PR DESCRIPTION
## Purpose and Motivation

fixes #3117

this gets rid of the old fragile option parsing in favor of
boost::program_options. i tried to keep everything as consistent as
possible, but the result was not as clean as i was hoping.

a difficulty is that WorldOptions is in the public API, so the
names and types of arguments cannot be changed to help integrate with
boost::program_options. probably the best thing to do would be use
server_args in supernova for both, and have a function that converts
directly from server_args to WorldOptions

some more notable changes:

added long options (#4028) identical to supernova's

udp & tcp port defaults changed from -1 to 0
- impact low, not good practice to begin with (0-1023 are system ports)

-U can be specified multiple times, accumulating each time
- low-impact, previous invocations that used it multiple times and assumed the last option would be the only one to take effect will break

now an error if -L passed but memory locking not available
- this is good, because users should know if they are not getting the options they request

## Types of changes

- Bug fix
- New feature
- Breaking change - outlined above

## To-do list

- [ ] Code is tested - i haven't tested this very much yet. i'd be grateful if someone could give it a try, i will also
  be testing it myself
- [ ] All tests are passing
- [ ] Updated documentation - i think there is an schelp document that should be updated too
- [ ] This PR is ready for review