### PR TITLE
scsynth: PanAz: fix leaks and imprecisions

### DIFF
--- a/server/plugins/PanUGens.cpp
+++ b/server/plugins/PanUGens.cpp
@@ -1310,9 +1310,9 @@ void PanAz_next_ak(PanAz* unit, int inNumSamples) {
     float orientation = ZIN0(4);
 
     int numOutputs = unit->mNumOutputs;
-    float rwidth = sc_reciprocal(width);
+    float rwidth = static_cast<float>(sc_reciprocal(static_cast<double>(width)));
     float range = numOutputs * rwidth;
-    float rrange = sc_reciprocal(range);
+    float rrange = static_cast<float>(sc_reciprocal(static_cast<double>(range)));
 
     pos = pos * 0.5f * numOutputs + width * 0.5f + orientation;
 
@@ -1324,7 +1324,7 @@ void PanAz_next_ak(PanAz* unit, int inNumSamples) {
         float chanpos = pos - i;
         chanpos *= rwidth;
         chanpos = chanpos - range * sc_floor(rrange * chanpos);
-        if (chanpos > 1.f) {
+        if (chanpos >= 1.f) {
             nextchanamp = 0.f;
         } else {
             nextchanamp = level * ft->mSine[(long)(4096.f * chanpos)];
@@ -1355,9 +1355,9 @@ FLATTEN void PanAz_next_ak_nova(PanAz* unit, int inNumSamples) {
     float orientation = ZIN0(4);
 
     int numOutputs = unit->mNumOutputs;
-    float rwidth = sc_reciprocal(width);
+    float rwidth = static_cast<float>(sc_reciprocal(static_cast<double>(width)));
     float range = numOutputs * rwidth;
-    float rrange = sc_reciprocal(range);
+    float rrange = static_cast<float>(sc_reciprocal(static_cast<double>(range)));
 
     pos = pos * 0.5f * numOutputs + width * 0.5f + orientation;
 
@@ -1370,7 +1370,7 @@ FLATTEN void PanAz_next_ak_nova(PanAz* unit, int inNumSamples) {
         float chanpos = pos - i;
         chanpos *= rwidth;
         chanpos = chanpos - range * sc_floor(rrange * chanpos);
-        if (chanpos > 1.f) {
+        if (chanpos >= 1.f) {
             nextchanamp = 0.f;
         } else {
             nextchanamp = level * ft->mSine[(long)(4096.f * chanpos)];
@@ -1397,9 +1397,9 @@ void PanAz_next_aa(PanAz* unit, int inNumSamples) {
     float orientation = ZIN0(4);
 
     int numOutputs = unit->mNumOutputs;
-    float rwidth = sc_reciprocal(width);
+    float rwidth = static_cast<float>(sc_reciprocal(static_cast<double>(width)));
     float range = numOutputs * rwidth;
-    float rrange = sc_reciprocal(range);
+    float rrange = static_cast<float>(sc_reciprocal(static_cast<double>(range)));
 
 
     // compute constant parts with which the pos has to be multiplied/added to respect numOutputs, width and orientation
@@ -1422,7 +1422,7 @@ void PanAz_next_aa(PanAz* unit, int inNumSamples) {
             chanpos = chanpos - range * sc_floor(rrange * chanpos);
 
             float chanamp;
-            if (chanpos > 1.f) { chanamp = 0.f; } else { chanamp = level * ft->mSine[(long)(4096.f * chanpos)]; }
+            if (chanpos >= 1.f) { chanamp = 0.f; } else { chanamp = level * ft->mSine[(long)(4096.f * chanpos)]; }
 
             ZXP(out) = ZXP(in) * chanamp;
 

--- a/testsuite/classlibrary/TestPanAz.sc
+++ b/testsuite/classlibrary/TestPanAz.sc
@@ -41,4 +41,38 @@ TestPanAz : UnitTest {
 		this.assertEquals(firstSample, 1.0, "Initial amplitude should match signals' amp");
 	}
 
+	test_PanAz_crosstalk {
+		var passed;
+		var cond = Condition.new;
+		var expected = [0.0, 1.0, 0.0, 0.0];
+
+		server.bootSync;
+
+		{ PanAz.ar(4, DC.ar(1), DC.ar(0.25), orientation: 0.5) }
+		.loadToFloatArray( 1 / server.sampleRate, server, { |output|
+			passed = output.detect{|v,n| expected[n] != v}.isNil;
+			cond.unhang;
+		});
+
+		cond.hang;
+
+		this.assert(passed, "Panning to one channel should not result in crosstalk");
+	}
+
+	test_PanAz_equalPowerBetweenTwoAdjacentChannels {
+		var result;
+		var cond = Condition.new;
+
+		server.bootSync;
+
+		{ PanAz.ar(4, DC.ar(1), DC.ar(0), orientation: 0.5) }
+		.loadToFloatArray( 1 / server.sampleRate, server, { |output|
+			result = output;
+			cond.unhang;
+		});
+
+		cond.hang;
+
+		this.assertEquals(result[1],result[0], "Panning halfways between two channels should produce same power in both channels");
+	}
 }


### PR DESCRIPTION
PanAz was having a small leak into adjacent-to-focused channels, due to
both an imprecision in sc_reciprocal and in ft->mSine. This fixes it
without touching either of the two.

## Purpose and Motivation

Fixes #4970

https://github.com/supercollider/supercollider/blob/f806ace7bd8565dd174e7d47a1b32aaa4175a46e/server/plugins/PanUGens.cpp#L1325
Changing this to` >= 1.f` should fix it.  `ft->mSine[4096]` should be zero (even if it is a very small number instead), so it makes sense to shortcut to 0 IMO.
However, due to an imprecision in `float32 sc_reciprocal()`, `chanpos` ends up not being `== 1.f` and so this fix doesn't work.
https://github.com/supercollider/supercollider/blob/f806ace7bd8565dd174e7d47a1b32aaa4175a46e/include/plugin_interface/SC_InlineUnaryOp.h#L210
It works however if the float64 version of sc_reciprocal is used.

I've checked other UGens usage of sc_reciprocal, I think this small imprecision causes problems only when it gets into an equality comparison, and PanAz is the only UGen doing that.

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix
- Breaking Change?
Is this a breaking change? e.g I have several past projects where I adjusted panning positions by a small amount to account for this error.

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] This PR is ready for review
