### PR TITLE
class library: PanAz: initialize amps in Ctor

### DIFF
--- a/server/plugins/PanUGens.cpp
+++ b/server/plugins/PanUGens.cpp
@@ -1268,9 +1268,10 @@ void PanAz_next_ak_nova(PanAz* unit, int inNumSamples);
 #endif
 
 void PanAz_Ctor(PanAz* unit) {
+    unit->m_chanamp = nullptr;
     if (INRATE(1) == calc_FullRate) {
-        unit->m_chanamp = NULL;
         SETCALC(PanAz_next_aa);
+        PanAz_next_aa(unit, 1);
     } else {
         int numOutputs = unit->mNumOutputs;
         for (int i = 0; i < numOutputs; ++i)
@@ -1293,6 +1294,7 @@ void PanAz_Ctor(PanAz* unit) {
 #else
         SETCALC(PanAz_next_ak);
 #endif
+        PanAz_next_ak(unit, 1);
     }
 }
 

--- a/testsuite/classlibrary/TestPanAz.sc
+++ b/testsuite/classlibrary/TestPanAz.sc
@@ -1,0 +1,44 @@
+TestPanAz : UnitTest {
+
+	var server;
+
+	setUp {
+		server = Server(this.class.name);
+	}
+
+	tearDown {
+		if(server.serverRunning) { server.quit };
+		server.remove;
+	}
+
+	test_PanAz_ak_initializesAmps {
+		var firstSample;
+		var cond = Condition.new;
+
+		server.bootSync;
+
+		{ PanAz.ar(2, DC.ar(1), -0.5) }.loadToFloatArray( 1 / server.sampleRate, server, { |output|
+			firstSample = output[0];
+			cond.unhang;
+		});
+
+		cond.hang;
+		this.assertEquals(firstSample, 1.0, "Initial amplitude should match signals' amp");
+	}
+
+	test_PanAz_ar_initializesAmps {
+		var firstSample;
+		var cond = Condition.new;
+
+		server.bootSync;
+
+		{ PanAz.ar(2, DC.ar(1), DC.ar(-0.5)) }.loadToFloatArray( 1 / server.sampleRate, server, { |output|
+			firstSample = output[0];
+			cond.unhang;
+		});
+
+		cond.hang;
+		this.assertEquals(firstSample, 1.0, "Initial amplitude should match signals' amp");
+	}
+
+}


### PR DESCRIPTION
Fixes an hardcoded fade-in from 0 in ak/kr cases, due to missing initialization of amplitudes.

I've included suggestions from @mtmccrea https://github.com/supercollider/supercollider/issues/4387#issuecomment-483887517.
However, instead of creating a new PanAz_init function, I'm calling PanAz_calc_ak for 1 sample (as it seems to be a common practice throughout classlib)

<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->
Fixes #4387 
## Types of changes

<!-- Delete lines that don't apply -->
- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] This PR is ready for review
