### PR TITLE
Fix nil test in SynthDescLib.init

### DIFF
--- a/SCClassLibrary/Common/Audio/SynthDesc.sc
+++ b/SCClassLibrary/Common/Audio/SynthDesc.sc
@@ -506,7 +506,7 @@ SynthDescLib {
 	init { |inServers|
 		all.put(name.asSymbol, this);
 		synthDescs = IdentityDictionary.new;
-		servers = IdentitySet.with(*inServers ? { Server.default })
+		servers = IdentitySet.with(*inServers ?? { Server.default })
 	}
 	*initClass {
 		Class.initClassTree(Server);


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

This PR fixes an issue in `SynthDescLib.init`. The IdentitySet should contain `Server.default` but instead contains a Function. In order to fix it, I replaced `?` with `??`. 

I'm having a hard time understanding how it worked before, or if this change breaks anything. Please review carefully.

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix


## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [ ] Code is tested
- [ ] All tests are passing
- [ ] Updated documentation
- [X] This PR is ready for review
