### PR TITLE
Fix scaleneg for floats

### DIFF
--- a/include/plugin_interface/SC_InlineBinaryOp.h
+++ b/include/plugin_interface/SC_InlineBinaryOp.h
@@ -495,13 +495,13 @@ template <typename T> inline T sc_scaleneg(T a, T b) {
 }
 
 template <> inline float sc_scaleneg<float>(float a, float b) {
-    b = 0.5f * b + 0.5f;
-    return (std::abs(a) - a) * b + a;
+    float absValue = std::abs(a);
+    return 0.5 * ((a - absValue) * b + a + absValue);
 }
 
 template <> inline double sc_scaleneg<double>(double a, double b) {
-    b = 0.5 * b + 0.5;
-    return (std::abs(a) - a) * b + a;
+    double absValue = std::abs(a);
+    return 0.5 * ((a - absValue) * b + a + absValue);
 }
 
 template <typename T> inline T sc_amclip(T a, T b) {

--- a/testsuite/classlibrary/TestSimpleNumber.sc
+++ b/testsuite/classlibrary/TestSimpleNumber.sc
@@ -221,4 +221,79 @@ TestSimpleNumber : UnitTest {
 		arr = first.series(first, first);
 		this.assert(arr.size == 1, "SimpleNumber:series Float types with first == last and step == 0 should return an array of [ first ]");
 	}
+
+	//////////////////////
+	// scaleneg tests
+	//////////////////////	
+	test_scaleneg {
+		var a, b, result;
+
+		// ////////// Test Integers
+		// Test scaleneg(a, b) with Integer a, b >= 0.
+		a = 2;
+		b = 3;
+		result = a;
+		this.assertEquals(scaleneg(a, b), result, "SimpleNumber:scaleneg with Integer arguments a >= 0, b >= 0 returns a.");
+
+		// Test scaleneg(a, b) with Integer a >= 0, b < 0.
+		a = 2;
+		b = -3;
+		result = a;
+		this.assertEquals(scaleneg(a, b), result, "SimpleNumber:scaleneg with Integer  arguments a >= 0, b < 0 returns a.");
+
+		// Test scaleneg(a, b) with Integer a < 0, b >= 0.
+		a = -2;
+		b = 3;
+		result = a * b;
+		this.assertEquals(scaleneg(a, b), result, "SimpleNumber:scaleneg with Integer  arguments a < 0, b >= 0 returns a * b.");
+
+		// Test scaleneg(a, b) with Integer a < 0, b < 0.
+		a = -2;
+		b = -3;
+		result = a * b;
+		this.assertEquals(scaleneg(a, b), result, "SimpleNumber:scaleneg with Integer  arguments a < 0, b < 0 returns a * b.");
+
+		// ////////// Test Floats
+		// Test scaleneg(a, b) with Float a, b >= 0.
+		a = 2.0;
+		b = 3.0;
+		result = a;
+		this.assertEquals(scaleneg(a, b), result, "SimpleNumber:scaleneg with Float arguments a >= 0, b >= 0 returns a.");
+
+		// Test scaleneg(a, b) with Float a >= 0, b < 0.
+		a = 2.0;
+		b = -3.0;
+		result = a;
+		this.assertEquals(scaleneg(a, b), result, "SimpleNumber:scaleneg with Float  arguments a >= 0, b < 0 returns a.");
+
+		// Test scaleneg(a, b) with Float a < 0, b >= 0.
+		a = -2.0;
+		b = 3.0;
+		result = a * b;
+		this.assertEquals(scaleneg(a, b), result, "SimpleNumber:scaleneg with Float  arguments a < 0, b >= 0 returns a * b.");
+
+		// Test scaleneg(a, b) with Float a < 0, b < 0.
+		a = -2.0;
+		b = -3.0;
+		result = a * b;
+		this.assertEquals(scaleneg(a, b), result, "SimpleNumber:scaleneg with Float  arguments a < 0, b < 0 returns a * b.");
+
+		// ////////// Test inf as argument
+		a = inf;
+		b = 3;
+		this.assert(scaleneg(a, b).isNaN, "SimpleNumber:scaleneg with a = inf, returns nan.");
+
+		a = -2.0;
+		b = inf;
+		result = a * b;
+		this.assertEquals(scaleneg(a, b), result, "SimpleNumber:scaleneg with b = inf, returns a * b.");
+
+		a = inf;
+		b = inf;
+		this.assert(scaleneg(a, b).isNaN, "SimpleNumber:scaleneg with a = inf, b = inf, returns nan.");
+
+		a = 0;
+		b = inf;
+		this.assert(scaleneg(a, b).isNaN, "SimpleNumber:scaleneg with a = 0, b = inf, returns nan.");
+	}
 }


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation
In `include/plugin_interface/SC_InlineBinaryOp.h` the function `scaleneg(a, b)` is defined for `floats` as (line 557)
```
0.5 * (|a| - a) * (b + 1) + a
```
which gives `a` for `a >= 0` and `- a * b` for `a < 0`.

On the other hand, the documentation for `SimpleNumber.scaleneg`  asserts that the result should be `a` for `a >= 0` and `a * b` for `a < 0`.

We can redefine `scaleneg` by making use of the formula
```
min(a, 0) * b + max(a, 0)
```
Since `min(a, 0) = 0.5 * ( a - |a|)` and `max(a, 0) = 0.5 * (a + |a|)`, the above expression reduces to
```
0.5 * ((a - |a|) * b + a + |a|) 
```

So, we could define `scaleneg` as
https://github.com/tsmtzs/supercollider/blob/188e922d55631e075cab5398dc33c97445eae306/include/plugin_interface/SC_InlineBinaryOp.h#L497-L505


<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->
Fixes #3708
## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Documentation doesn't need an update
- [x] This PR is ready for review
