### PR TITLE
Add warning when windows defender delays supernova boot

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -141,12 +141,12 @@ after_build:
 #after_deploy:
 #- ps: echo "S3 Build Location = $env:S3_URL"
 #
-#artifacts:
-#    - path: artifacts
-#      name: art_folder
-#    - path: build\Install\*.exe
-#      name: installer
-#      type: File
+artifacts:
+   - path: artifacts
+     name: art_folder
+   - path: build\Install\*.exe
+     name: installer
+     type: File
 #
 #deploy:
 ## s3 upload - every commit

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -141,12 +141,12 @@ after_build:
 #after_deploy:
 #- ps: echo "S3 Build Location = $env:S3_URL"
 #
-artifacts:
-   - path: artifacts
-     name: art_folder
-   - path: build\Install\*.exe
-     name: installer
-     type: File
+#artifacts:
+#    - path: artifacts
+#      name: art_folder
+#    - path: build\Install\*.exe
+#      name: installer
+#      type: File
 #
 #deploy:
 ## s3 upload - every commit

--- a/common/SC_ServerBootDelayWarning.cpp
+++ b/common/SC_ServerBootDelayWarning.cpp
@@ -19,10 +19,11 @@ static void displayWarningIfServerHasNotBooted() {
 
     if (!g_scsynthBootWarningConditionVariable.wait_for(lock, std::chrono::seconds(10),
                                                         [] { return g_isServerBooted; })) {
-        std::cout << "Server: possible boot delay.\n";
-        std::cout << "On some Windows-based machines, Windows Defender sometimes delays server boot by one minute.\n";
-        std::cout << "You can add scsynth.exe and/or supernova.exe *processes* to Windows Defender exclusion list ";
-        std::cout << "to disable this check. It's safe.\n";
+        std::cout << "Server: possible boot delay." << std::endl;
+        std::cout << "On some Windows-based machines, Windows Defender sometimes ";
+        std::cout << "delays server boot by one minute." << std::endl;
+        std::cout << "You can add scsynth.exe and/or supernova.exe *processes* to ";
+        std::cout << "Windows Defender exclusion list to disable this check. It's safe." << std::endl;
     }
 }
 #endif //_WIN32

--- a/common/SC_ServerBootDelayWarning.cpp
+++ b/common/SC_ServerBootDelayWarning.cpp
@@ -1,0 +1,46 @@
+// Add a warning when Windows Defender delays scsynth boot by 60+ seconds
+// cf. github issue #4368
+#include "SC_ServerBootDelayWarning.h"
+
+#ifdef _WIN32
+#    include <iostream>
+#    include <thread>
+#    include <mutex>
+#    include <chrono>
+#    include <condition_variable>
+
+static bool g_isServerBooted = false;
+static std::mutex g_scsynthBootWarningMutex;
+static std::condition_variable g_scsynthBootWarningConditionVariable;
+static std::thread* g_bootWarningThread;
+
+static void displayWarningIfServerHasNotBooted() {
+    std::unique_lock<std::mutex> lock(g_scsynthBootWarningMutex);
+
+    if (!g_scsynthBootWarningConditionVariable.wait_for(lock, std::chrono::seconds(10),
+                                                        [] { return g_isServerBooted; })) {
+        std::cout << "Server: possible boot delay.\n";
+        std::cout << "On some Windows-based machines, Windows Defender sometimes delays server boot by one minute.\n";
+        std::cout << "You can add scsynth.exe and/or supernova.exe *processes* to Windows Defender exclusion list ";
+        std::cout << "to disable this check. It's safe.\n";
+    }
+}
+#endif //_WIN32
+
+void startServerBootDelayWarningTimer() {
+#ifdef _WIN32
+    g_bootWarningThread = new std::thread(displayWarningIfServerHasNotBooted);
+#endif //_WIN32
+}
+
+void stopServerBootDelayWarningTimer() {
+#ifdef _WIN32
+    {
+        const std::lock_guard<std::mutex> lock(g_scsynthBootWarningMutex);
+        g_isServerBooted = true;
+    }
+    g_scsynthBootWarningConditionVariable.notify_all();
+    g_bootWarningThread->join();
+    delete g_bootWarningThread;
+#endif //_WIN32
+}

--- a/common/SC_ServerBootDelayWarning.cpp
+++ b/common/SC_ServerBootDelayWarning.cpp
@@ -1,5 +1,3 @@
-// Add a warning when Windows Defender delays scsynth boot by 60+ seconds
-// cf. github issue #4368
 #include "SC_ServerBootDelayWarning.h"
 
 #ifdef _WIN32
@@ -10,38 +8,37 @@
 #    include <condition_variable>
 
 static bool g_isServerBooted = false;
-static std::mutex g_scsynthBootWarningMutex;
-static std::condition_variable g_scsynthBootWarningConditionVariable;
-static std::thread* g_bootWarningThread;
+static std::mutex g_serverBootWarningMutex;
+static std::condition_variable g_serverBootWarningConditionVariable;
+static std::thread g_bootWarningThread;
 
 static void displayWarningIfServerHasNotBooted() {
-    std::unique_lock<std::mutex> lock(g_scsynthBootWarningMutex);
+    std::unique_lock<std::mutex> lock(g_serverBootWarningMutex);
 
-    if (!g_scsynthBootWarningConditionVariable.wait_for(lock, std::chrono::seconds(10),
-                                                        [] { return g_isServerBooted; })) {
+    if (!g_serverBootWarningConditionVariable.wait_for(lock, std::chrono::seconds(10),
+                                                       [] { return g_isServerBooted; })) {
         std::cout << "Server: possible boot delay." << std::endl;
         std::cout << "On some Windows-based machines, Windows Defender sometimes ";
         std::cout << "delays server boot by one minute." << std::endl;
         std::cout << "You can add scsynth.exe and/or supernova.exe *processes* to ";
-        std::cout << "Windows Defender exclusion list to disable this check. It's safe." << std::endl;
+        std::cout << "Windows Defender exclusion list to avoid this delay. It's safe." << std::endl;
     }
 }
 #endif //_WIN32
 
 void startServerBootDelayWarningTimer() {
 #ifdef _WIN32
-    g_bootWarningThread = new std::thread(displayWarningIfServerHasNotBooted);
+    g_bootWarningThread = std::thread(displayWarningIfServerHasNotBooted);
 #endif //_WIN32
 }
 
 void stopServerBootDelayWarningTimer() {
 #ifdef _WIN32
     {
-        const std::lock_guard<std::mutex> lock(g_scsynthBootWarningMutex);
+        const std::lock_guard<std::mutex> lock(g_serverBootWarningMutex);
         g_isServerBooted = true;
     }
-    g_scsynthBootWarningConditionVariable.notify_all();
-    g_bootWarningThread->join();
-    delete g_bootWarningThread;
+    g_serverBootWarningConditionVariable.notify_all();
+    g_bootWarningThread.join();
 #endif //_WIN32
 }

--- a/common/SC_ServerBootDelayWarning.h
+++ b/common/SC_ServerBootDelayWarning.h
@@ -1,0 +1,2 @@
+void startServerBootDelayWarningTimer();
+void stopServerBootDelayWarningTimer();

--- a/common/SC_ServerBootDelayWarning.h
+++ b/common/SC_ServerBootDelayWarning.h
@@ -1,2 +1,14 @@
+// Add a warning when Windows Defender delays scsynth boot by 60+ seconds
+// cf. github issue #4368
+
+#pragma once
+
+// On Windows, starts a timer that will display a warning message
+// after 10 seconds if the server has not booted,
+// which may be due to Windows Defender.
+// On other platforms, it does not do anything.
+// Must be called at the start of the server boot sequence.
 void startServerBootDelayWarningTimer();
+
+// Must be called at the end of the server boot sequence.
 void stopServerBootDelayWarningTimer();

--- a/server/scsynth/CMakeLists.txt
+++ b/server/scsynth/CMakeLists.txt
@@ -84,6 +84,7 @@ set(scsynth_sources
 	${CMAKE_SOURCE_DIR}/common/SC_StringParser.cpp
 	${CMAKE_SOURCE_DIR}/common/Samp.cpp
 	${CMAKE_SOURCE_DIR}/common/sc_popen.cpp
+	${CMAKE_SOURCE_DIR}/common/SC_ServerBootDelayWarning.cpp
 )
 
 if(APPLE)

--- a/server/supernova/CMakeLists.txt
+++ b/server/supernova/CMakeLists.txt
@@ -51,6 +51,7 @@ set(libsupernova_src
     ${CMAKE_SOURCE_DIR}/common/Samp.cpp
     ${CMAKE_SOURCE_DIR}/common/SC_fftlib.cpp
     ${CMAKE_SOURCE_DIR}/common/SC_StringParser.cpp
+    ${CMAKE_SOURCE_DIR}/common/SC_ServerBootDelayWarning.cpp
     server/buffer_manager.cpp
     server/memory_pool.cpp
     server/node_graph.cpp

--- a/server/supernova/server/main.cpp
+++ b/server/supernova/server/main.cpp
@@ -23,6 +23,7 @@
 #include <vector>
 
 #include "SC_Win32Utils.h"
+#include "SC_ServerBootDelayWarning.h"
 
 #include <boost/filesystem/path.hpp>
 #include <boost/algorithm/string.hpp>
@@ -343,6 +344,8 @@ int supernova_main(int argc, char* argv[]) {
     cout << "compiled for debugging" << endl;
 #endif
 
+    startServerBootDelayWarningTimer();
+
     // FIXME should have more granular error handling
     try {
         server_shared_memory_creator::cleanup(args.port());
@@ -351,6 +354,8 @@ int supernova_main(int argc, char* argv[]) {
 
         set_plugin_paths(args, sc_factory.get());
         load_synthdefs(server, args);
+
+        stopServerBootDelayWarningTimer();
 
         if (!args.non_rt) {
             try {


### PR DESCRIPTION
## Purpose and Motivation

This is the followup to #4941 (thanks for guiding me @brianlheim).

It displays a warning message for Windows users when supernova takes longer than 10 seconds to boot, which may come from Windows Defender scanning all the UGens.

Manually tested :
[X] Message is displayed if supernova takes more than 10 seconds to boot
[X] Message is not displayed if supernova takes less than 10 seconds to boot
[X] Message is displayed if scsynth takes more than 10 seconds to boot
[X] Message is not displayed if scsynth takes less than 10 seconds to boot

## Types of changes

- New feature

## To-do list

- [ ] Code is tested
- [ ] All tests are passing
- [ ] Updated documentation
- [X] This PR is ready for review

Please squash the commits if you merge this PR !
