### PR TITLE
Give server volume control permanent nodeID

### DIFF
--- a/SCClassLibrary/Common/Control/Volume.sc
+++ b/SCClassLibrary/Common/Control/Volume.sc
@@ -25,8 +25,14 @@ Volume {
 			// only create synth now if it won't be created by ServerTree
 			if (persist.not) { this.updateSynth };
 		};
+		ServerBoot.add(initFunc, server);
 
-		ServerBoot.add(initFunc, server)
+		updateFunc = {
+			ampSynth = nil;
+			if(persist) { this.updateSynth }
+		};
+		ServerTree.add(updateFunc, server);
+
 	}
 
 	sendSynthDef {
@@ -43,12 +49,6 @@ Volume {
 
 				server.sync;
 
-				updateFunc = {
-					ampSynth = nil;
-					if(persist) { this.updateSynth }
-				};
-
-				ServerTree.add(updateFunc, server);
 			}
 		};
 	}


### PR DESCRIPTION
## Purpose and Motivation
Setting volume on the server can be made more robust and easier to reason about:
By giving it a known permanent nodeID, and creating a permanent synth object for it, 
there are much fewer possibilities for the volume state to get out of sync. 
A second advantage is with remote servers (as used in network music): with permanent nodeID, it becomes trivial to get and set volume values from a remote client if desired. 
This PR is the first infrastructural step toward this. 

## Types of changes
- New feature

## To-do list

- [x] Code is tested
- [x] All tests are passing
- [ ] Updated documentation
- [x] This PR is ready for review
