### PR TITLE
Build fixes for Qt 5.15

### DIFF
--- a/QtCollider/primitives/prim_QPen.cpp
+++ b/QtCollider/primitives/prim_QPen.cpp
@@ -27,6 +27,7 @@
 #include "PyrKernel.h"
 
 #include <QPainter>
+#include <QPainterPath>
 #include <QVector2D>
 #include <QVector3D>
 #include <cmath>

--- a/QtCollider/widgets/QcGraph.cpp
+++ b/QtCollider/widgets/QcGraph.cpp
@@ -24,6 +24,7 @@
 #include "../style/routines.hpp"
 
 #include <QPainter>
+#include <QPainterPath>
 #include <QMouseEvent>
 #include <QApplication>
 #include <QtCore/qmath.h>

--- a/QtCollider/widgets/QcLevelIndicator.cpp
+++ b/QtCollider/widgets/QcLevelIndicator.cpp
@@ -23,6 +23,7 @@
 #include "../QcWidgetFactory.h"
 
 #include <QPainter>
+#include <QPainterPath>
 
 QC_DECLARE_QWIDGET_FACTORY(QcLevelIndicator);
 

--- a/QtCollider/widgets/QcMultiSlider.cpp
+++ b/QtCollider/widgets/QcMultiSlider.cpp
@@ -26,6 +26,7 @@
 #include <QApplication>
 #include <QMouseEvent>
 #include <QPainter>
+#include <QPainterPath>
 
 #include <cmath>
 

--- a/QtCollider/widgets/QcScopeShm.cpp
+++ b/QtCollider/widgets/QcScopeShm.cpp
@@ -25,6 +25,7 @@
 #include "../debug.h"
 
 #include <QPainter>
+#include <QPainterPath>
 #include <QTimer>
 #include <QResizeEvent>
 #include <QWindow>

--- a/QtCollider/widgets/soundfileview/view.cpp
+++ b/QtCollider/widgets/soundfileview/view.cpp
@@ -24,6 +24,7 @@
 
 #include <QGridLayout>
 #include <QPainter>
+#include <QPainterPath>
 #include <QApplication>
 #include <QPaintEvent>
 #include <QCursor>


### PR DESCRIPTION
## Purpose and Motivation

This fixes the build when using Qt 5.15 ~and system boost 1.72.0~. Tested using GCC 10.1.0.

I don't think these changes should break things on older versions (~the built-in Boost also has `boost/predef/other/endian.h`, and~ the Qt change was always a missed include, it just happened to work on older versions).

## Types of changes

- Bug fix (build fix)

## To-do list

- [x] Code is tested (basic compile/run test)
- [x] This PR is ready for review
