### PR TITLE
Topic/improve doc for remote servers

### DIFF
--- a/HelpSource/Classes/Server.schelp
+++ b/HelpSource/Classes/Server.schelp
@@ -1,7 +1,7 @@
 class:: Server
 summary:: Object representing a server application
 categories:: Server>Abstractions
-related:: Classes/ServerOptions, Reference/Server-Architecture, Reference/Server-Command-Reference, Classes/ServerStatusWatcher, Reference/AudioDeviceSelection
+related:: Guides/Server-Guide, Guides/MultiClient_Setups, Classes/ServerOptions, Reference/Server-Architecture, Reference/Server-Command-Reference, Classes/ServerStatusWatcher, Reference/AudioDeviceSelection
 
 description::
 
@@ -49,7 +49,7 @@ argument:: clientID
 an integer. In multi-client situations, every client can be given separate ranges for link::Classes/Node##Nodes::, link::Classes/Buffer##Buffers::, or link::Classes/Bus##Busses::. In normal usage, the server will supply an ID automatically when a client registers for the link::#-notify#notifications:: so you should not need to supply one here. N.B. In multi-client situations, you will need to set the link::Classes/ServerOptions#-maxLogins:: to at least the number of clients you wish to allow. This must be the same in the Server instances on every client.
 
 method:: remote
-Create a new Server instance corresponding to a server app running on a separate machine. This method assumes the remote app has been booted and starts listening immediately. You should not call link::#-boot:: on an instance created using this method.
+Create a new Server instance corresponding to a server app running on a separate machine. This method assumes the remote app has been booted and starts listening immediately. You should not call link::#-boot:: on an instance created using this method. link::Guides/Server-Guide:: and link::Guides/MultiClient_Setups:: contain further information on this and multiclient usage.
 
 argument:: name
 a symbol;  each Server object is stored in one global classvariable under its name.
@@ -58,10 +58,29 @@ argument:: addr
 an optional instance of link::Classes/NetAddr::, providing IP address of the remote machine and port the app is listening on.
 
 argument:: options
-an optional instance of link::Classes/ServerOptions::. If code::nil::, an instance of ServerOptions will be created, using the default values.
+an optional instance of link::Classes/ServerOptions::. If code::nil::, an instance of ServerOptions will be created, using the default values. note::To enable remote connections you will need to change the option link::Classes/ServerOptions#-bindAddress:: as the default value only allows connections from the local machine. code::s.options.bindAddress = "0.0.0.0":: will allow connections from any address.::
 
 argument:: clientID
 an integer. In multi-client situations, every client can be given separate ranges for link::Classes/Node##Nodes::, link::Classes/Buffer##Buffers::, or link::Classes/Bus##Busses::. In normal usage, the server will supply an ID automatically when a client registers for the link::#-notify#notifications:: so you should not need to supply one here. N.B. In multi-client situations, you will need to set the link::Classes/ServerOptions#-maxLogins:: to at least the number of clients you wish to allow. This must be the same in the Server instances on every client.
+
+code::
+// example usage:
+// on machine running the server
+(
+s.options.bindAddress = "0.0.0.0"; // allow connections from any address
+s.options.maxLogins = 2; // set to correct number of clients
+s.boot;
+)
+
+// on remote machine connecting to server
+(
+o = ServerOptions.new;
+o.options.maxLogins = 2;
+t = Server.remote(\remote, NetAddr("192.168.0.130", 57110), o); // set to correct address and port
+// info about returned client ID should be posted in the post window
+t.makeWindow; // make a window for monitoring
+)
+::
 
 
 method:: local

--- a/HelpSource/Guides/Server-Guide.schelp
+++ b/HelpSource/Guides/Server-Guide.schelp
@@ -1,7 +1,7 @@
 title:: Server Guide
-summary:: Using Server objecs in different situations
+summary:: Using Server objects in different situations
 categories:: Server>Abstractions
-related:: Classes/Server, Classes/ServerOptions, Reference/Server-Architecture, Reference/Server-Command-Reference
+related:: Classes/Server, Classes/ServerOptions, Reference/Server-Architecture, Reference/Server-Command-Reference, Guides/MultiClient_Setups
 
 description::
 
@@ -55,18 +55,32 @@ There is always a default Server, which is stored in the class variable code::de
 
 subsection:: Local vs. Remote Servers, Multi-client Configurations
 
-Most of the time users work with a server app running on the same machine as the SC language client. It is possible to use a server running on a different machine via a network, providing you know the IP address and port of that server. The link::#*remote:: method provides a convenient way to do this.
+Most of the time users work with a server app running on the same machine as the SC language client. It is possible to use a server running on a different machine via a network, providing you know the IP address and port of that server. The link::#*remote:: method provides a convenient way to do this. note::To enable remote connections you will need to change link::Classes/ServerOptions#-bindAddress:: in the server's link::Classes/ServerOptions:: as the default value only allows connections from the local machine. code::s.options.bindAddress = "0.0.0.0":: will allow connections from any address.::
 
-One common variant of this approach is multiple clients using the same server. If you wish to do this you will need to set the server's link::Classes/ServerOptions#-maxLogins:: to at least the number of clients you wish to allow.  When a client registers for link::#-notify#notifications:: the server will supply a client ID. This also configures the allocators to avoid conflicts when allocating link::Classes/Node##Nodes::, link::Classes/Buffer##Buffers::, or link::Classes/Bus##Busses::.
+One common variant of this approach is multiple clients using the same server. If you wish to do this you will need to set the server's link::Classes/ServerOptions#-maxLogins:: to at least the number of clients you wish to allow.  When a client registers for link::#-notify#notifications:: the server will supply a client ID. This also configures the allocators to avoid conflicts when allocating link::Classes/Node##Nodes::, link::Classes/Buffer##Buffers::, or link::Classes/Bus##Busses::. For more info see link::Guides/MultiClient_Setups::.
 
-In order to use a remote server with tcp one should first boot the remote server using the code::-t:: option and then run the following code:
+In order to use a remote server with tcp one should first boot the remote server using the code::-t:: option e.g. as follows:
+code::
+// on machine running the server
+(
+s.options.protocol = \tcp; // set to use tcp
+s.options.bindAddress = "0.0.0.0"; // allow connections from any address
+s.options.maxLogins = 2; // set to correct number of clients
+s.boot;
+)
+::
+
+then run the following code:
 
 code::
+// on remote machine connecting to server
 (
-s.options.protocol_(\tcp);
-s.addr.connect;
-s.startAliveThread( 0 );
-s.doWhenBooted({ "remote tcp server started".postln; s.notify; s.initTree });
+o = ServerOptions.new;
+o.protocol_(\tcp);
+t = Server.remote(\remote, NetAddr("192.168.0.130", 57110), o); // set to correct address and port
+t.addr.connect;
+t.startAliveThread( 0 );
+t.doWhenBooted({ "remote tcp server started".postln; t.notify; t.initTree });
 )
 ::
 


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

#4496 and #4516 added the bindAddress option to scsynth. This was documented in the ServerOptions help file and the change log. As a breaking change however (and just to generally make it easy to find and clear to users how to work with remote servers) this should be more prominently documented. This PR adds info and examples to the Server and ServerOptions help files to address this.

## Types of changes

<!-- Delete lines that don't apply -->

- Documentation


## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review
