### PR TITLE
Remove spurious Qt dependencies

### DIFF
--- a/QtCollider/CMakeLists.txt
+++ b/QtCollider/CMakeLists.txt
@@ -7,19 +7,15 @@ option(SC_USE_QTWEBENGINE "Build with Qt WebEngine." ON)
 set(
   QT_COMPONENTS
   Core
-  Widgets
+  Gui
   Network
   PrintSupport
-  OpenGL
-  Quick
-  Qml
-  Sql
   Svg
+  Widgets
 )
 
 set (QT_COLLIDER_LIBS
-  Qt5::Core Qt5::Gui Qt5::Widgets Qt5::Network Qt5::PrintSupport
-  Qt5::Quick Qt5::Qml Qt5::Sql Qt5::OpenGL Qt5::Svg
+  Qt5::Core Qt5::Gui Qt5::Network Qt5::PrintSupport Qt5::Svg Qt5::Widgets
   ${MATH_LIBRARY})
 
 if(SC_USE_QTWEBENGINE)

--- a/QtCollider/widgets/QcCanvas.h
+++ b/QtCollider/widgets/QcCanvas.h
@@ -28,9 +28,7 @@
 #include <QBasicTimer>
 #include <QTime>
 #include <QPalette>
-#include <QGLWidget>
 
-// using QcCanvasBase = QGLWidget;
 using QcCanvasBase = QWidget;
 
 class QcCanvas : public QcCanvasBase {

--- a/README_LINUX.md
+++ b/README_LINUX.md
@@ -75,7 +75,7 @@ Depending on your Debian flavor and version, your distribution's PPA may be stuc
 
 If this displays version 5.7 or later, installing Qt is easy:
 
-    sudo apt-get install qt5-default qt5-qmake qttools5-dev qttools5-dev-tools qtdeclarative5-dev qtwebengine5-dev libqt5svg5-dev libqt5websockets5-dev
+    sudo apt-get install qt5-default qt5-qmake qttools5-dev qttools5-dev-tools qtwebengine5-dev libqt5svg5-dev libqt5websockets5-dev
 
 If you are on Ubuntu 14.04 (Trusty) or 16.04 (Xenial), check the next section. Otherwise, you will have to use the official Qt installer. Sorry.
 
@@ -87,13 +87,13 @@ On Xenial:
 
     sudo apt-add-repository ppa:beineri/opt-qt-5.11.0-xenial
     sudo apt-get update
-    sudo apt-get install qt511base qt511location qt511declarative qt511tools qt511webchannel qt511xmlpatterns qt511svg qt511webengine qt511websockets
+    sudo apt-get install qt511base qt511location qt511tools qt511webchannel qt511xmlpatterns qt511svg qt511webengine qt511websockets
 
 On Trusty, only Qt 5.10 and below are available:
 
     sudo apt-add-repository ppa:beineri/opt-qt-5.10.1-trusty
     sudo apt-get update
-    sudo apt-get install qt510base qt510location qt510declarative qt510tools qt510webchannel qt510xmlpatterns qt510svg qt510webengine qt510websockets
+    sudo apt-get install qt510base qt510location qt510tools qt510webchannel qt510xmlpatterns qt510svg qt510webengine qt510websockets
 
 [Stephan Binner's Launchpad PPAs]: https://launchpad.net/~beineri
 

--- a/README_RASPBERRY_PI.md
+++ b/README_RASPBERRY_PI.md
@@ -42,7 +42,7 @@ Install required libraries:
     # For GUI builds:
     sudo apt-get install libjack-jackd2-dev libsndfile1-dev libasound2-dev libavahi-client-dev \
         libreadline-dev libfftw3-dev libxt-dev libudev-dev cmake qttools5-dev qttools5-dev-tools \
-        qtdeclarative5-dev libqt5svg5-dev qjackctl
+        qtbase5-dev libqt5svg5-dev qjackctl
     # For GUI-less builds:
     sudo apt-get install libsamplerate0-dev libsndfile1-dev libasound2-dev libavahi-client-dev \
         libreadline-dev libfftw3-dev libudev-dev cmake git

--- a/editors/sc-ide/CMakeLists.txt
+++ b/editors/sc-ide/CMakeLists.txt
@@ -6,22 +6,15 @@ set(QT_IDE_COMPONENTS
     Concurrent
     Core
     LinguistTools
-    # OpenGL
-    PrintSupport
-    Qml
-    Quick
-    Sql
+    Network
     Widgets
 )
 
 set(QT_IDE_LIBRARIES
     Qt5::Concurrent
     Qt5::Core
-    # Qt5::OpenGL
-    Qt5::PrintSupport
-    Qt5::Qml
-    Qt5::Quick
-    Qt5::Sql
+    Qt5::Network
+    Qt5::Widgets
 )
 
 if(SC_USE_QTWEBENGINE)


### PR DESCRIPTION
## Purpose and Motivation

The buildsystem currently requests Qt libraries that are not actually in use. Remove these references, so users do not need to install them.

## Types of changes

- New feature (easier builds)

## To-do list

- [x] Code is tested
- [x] Updated documentation
- [x] This PR is ready for review

Tested both with and without QtWebengine support, and with the following Qt libs not installed:
- qtwebengine (for non-webengine build)
- qtdeclarative (for non-webengine build; webengine pulls this in)
- qtopengl
- qtsql
