### PR TITLE
appveyor: don't push PR artifacts to S3 storage

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -128,9 +128,11 @@ after_build:
 # XXX vvv TEMPORARY WORKAROUND DUE TO APPVEYOR ARTIFACT STORAGE LIMIT
 - ps: >-
     If ($env:APPVEYOR_REPO_NAME -eq "supercollider/supercollider") {
-        echo "Pushing artifact to S3"
-        aws s3 cp --region us-west-2 --acl public-read --recursive --include "*" $env:APPVEYOR_BUILD_FOLDER/artifacts/ s3://supercollider/$env:S3_BUILDS_LOCATION
-        echo "S3 Build Location = $env:S3_URL"
+        If ([string]::IsNullOrEmpty($env:APPVEYOR_PULL_REQUEST_NUMBER)) {
+            echo "Pushing artifact to S3"
+            aws s3 cp --region us-west-2 --acl public-read --recursive --include "*" $env:APPVEYOR_BUILD_FOLDER/artifacts/ s3://supercollider/$env:S3_BUILDS_LOCATION
+            echo "S3 Build Location = $env:S3_URL"
+        }
     }
 # XXX ^^^ TEMPORARY WORKAROUND DUE TO APPVEYOR ARTIFACT STORAGE LIMIT
 


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

This prevents AppVeyor from trying (and failing) to push artifacts from PRs to S3 storage. This is just a cosmetic change - it tidies up the log, the failure to upload was not treated as CI failure anyway.
Solution copied from https://github.com/supercollider/sc3-plugins/pull/283

## Types of changes

<!-- Delete lines that don't apply -->

- Cosmetic change

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] This PR is ready for review
