### PR TITLE
docs: operators: UGens pow of negative value [skip ci]

### DIFF
--- a/HelpSource/Overviews/Operators.schelp
+++ b/HelpSource/Overviews/Operators.schelp
@@ -310,6 +310,7 @@ Exponentiation. Same as pow.
 
 method:: pow
 Exponentiation.
+NOTE:: When used with UGens which produce a negative signal this function extends the usual definition of exponentiation and returns code::neg(neg(a) ** b)::. This allows exponentiation of negative signal values by noninteger exponents.::
 
 method:: lcm
 Least common multiple. This definition extends the usual definition and returns a negative number if strong::any of the operands:: is negative. This makes it consistent with the lattice-theoretical interpretation and its idempotency, commutative, associative, absorption laws.


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->
Re-closes #3621

Re-introduces a clarification about the behavior of pow with UGens producing negative output.
Since this behavior contradicts basic math, I thought it would be mindful to write this as a NOTE::

## Types of changes

<!-- Delete lines that don't apply -->

- Documentation

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Updated documentation
- [x] This PR is ready for review
