### PR TITLE
classlib: fix EventPatternProxy premature cleanup of faded-in stream

### DIFF
--- a/SCClassLibrary/JITLib/Patterns/Pdef.sc
+++ b/SCClassLibrary/JITLib/Patterns/Pdef.sc
@@ -506,7 +506,7 @@ EventPatternProxy : TaskProxy {
 	}
 
 	constrainStream { arg stream, newStream, inval, cleanup;
-		var delta, tolerance;
+		var delta, tolerance, fadeOutCleanup;
 		var quantBeat, catchUp, deltaTillCatchUp, forwardTime, quant = this.quant;
 
 		^if(this.quant.isNil) {
@@ -539,10 +539,12 @@ EventPatternProxy : TaskProxy {
 					]).asStream
 				}
 			}{
+				fadeOutCleanup = cleanup.copy;
+				cleanup.clear; // change need be seen by caller function, i.e. embedInStream
 				Ppar([
 					EmbedOnce(
 						PfadeOut(stream, fadeTime, delta, tolerance),
-						cleanup
+						fadeOutCleanup
 					),
 					PfadeIn(newStream, fadeTime, delta, tolerance)
 				]).asStream

--- a/testsuite/classlibrary/TestEventPatternProxy.sc
+++ b/testsuite/classlibrary/TestEventPatternProxy.sc
@@ -12,4 +12,30 @@ TestEventPatternProxy : UnitTest{
         this.assertEquals(actualClock, clock, "EventPatternProxy.play() should use instance's clock if no argClock is given");
     }
 
+	test_EventPatternProxy_xfade_cleanupNotPremature {
+
+		var stream2CleanupCalled = false, p = EventPatternProxy.new.fadeTime_(2), r;
+		p.source = Pbind(\dur, 1.1, \degree, 3, \amp, 0.1);
+		r = p.asStream;
+		// pulling one event is necessary to prime the old stream
+		this.assertEquals(r.next(())[\degree], 3,
+			"EventPatternProxy xfade 1st source 1st pull shold be executed transparently.");
+		p.source = Pfset({},
+			Pbind(\dur, 1.3, \freq, 440, \amp, 0.4),
+			{ stream2CleanupCalled = true });
+		// Pull enough events to exhaust the xfade.
+		// There should NOT be a cleanup of the 2nd stream executed,
+		// since it's an infinite stream (of the same event).
+		// Three more events should be enough to pull here to
+		// end the cross-fade, but "just in case" we pull 6.
+		6 do: { r.next(()) };
+		this.assert(stream2CleanupCalled.not,
+			"EventPatternProxy xfade 2nd source cleanup should be not called prematurely.");
+		// todo: might also wanna check that the cleanup was sent downstream (addToCleanup seen)
+	}
+
+	// todo: TestPatternProxy.test_transparency_withEvents could be moved here
+	// without any changes to that method. test_update_withEvents
+	// from (the same) TestPatternProxy would need more refactoring though
+	// to separate global JITlib lookups (Pdef, Pdefn) from source updating.
 }


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

#Fixes #4954

I have checked that fix this works with both the present cleanup system and the one proposed in #4806. 

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] This PR is ready for review
