### PR TITLE
sclang: Ugen: composeBinaryOp add missing ^

### DIFF
--- a/SCClassLibrary/Common/Audio/UGen.sc
+++ b/SCClassLibrary/Common/Audio/UGen.sc
@@ -419,7 +419,7 @@ UGen : AbstractFunction {
 		if (anInput.isValidUGenInput, {
 			^BinaryOpUGen.new(aSelector, this, anInput)
 		},{
-			anInput.performBinaryOpOnUGen(aSelector, this);
+			^anInput.performBinaryOpOnUGen(aSelector, this);
 		});
 	}
 	reverseComposeBinaryOp { arg aSelector, aUGen;

--- a/testsuite/classlibrary/TestComplex.sc
+++ b/testsuite/classlibrary/TestComplex.sc
@@ -24,4 +24,10 @@ TestComplex : UnitTest {
 
 	}
 
+	// regression test for #5000: UGen:performBinaryOpOnUGen should return even if operand's isValidUGenInput is false
+	test_performBinaryOpOnUGen {
+		var complex = Complex(1,1), ugen = DC.kr(1);
+		this.assertEquals( (ugen * complex).class, (complex * ugen).class, "(UGen * Complex) should return same class as (Complex * UGen)")
+	}
+
 }


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation
UGen:composeBinaryOp checks if the other operand isValidUGenInput, and if not, calls `otherOperand.performBinaryOpOnUgen(this)` (pseudo). However, it doesn't return the latter's return value, making it ineffective. 

This has been like that since the dawn of time (+18 years?), however, all implementations of `performBinaryOpOnUgen` seem to expect their value to be returned:

https://github.com/supercollider/supercollider/blob/f65a1ef7bfb100f4ccb7dcab3a6dff6826be4344/SCClassLibrary/Common/Math/Complex.sc#L78
https://github.com/supercollider/supercollider/blob/f65a1ef7bfb100f4ccb7dcab3a6dff6826be4344/SCClassLibrary/Common/Math/Polar.sc#L50
https://github.com/supercollider/supercollider/blob/9be3fe2b6e2250b6ed5cb0f4e02d4c4246ebef69/SCClassLibrary/Common/Core/Object.sc#L683

EDIT: another impementation found in Quarks
https://github.com/supercollider-quarks/downloaded-quarks/blob/3b0d2f1e405587613e3e5f43103184f231552c42/MathLib/classes/SpherCoords/Spherical.sc#L115

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix


## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [ ] Code is tested
- [ ] All tests are passing
- [x] This PR is ready for review
