### PR TITLE
Fix TWindex 'sum' initialization bug

### DIFF
--- a/HelpSource/Classes/TWindex.schelp
+++ b/HelpSource/Classes/TWindex.schelp
@@ -22,10 +22,10 @@ the signal changes from non-positive to positive.
 
 
 argument::array
-The list of probabilities.
+The list of probabilities. (Note: These should be control rate only.)
 
 argument::normalize
-Controls whether to normalize the probability values.
+Controls whether to normalize the probability values. (Control rate only.)
 
 Examples::
 

--- a/server/plugins/OscUGens.cpp
+++ b/server/plugins/OscUGens.cpp
@@ -189,7 +189,7 @@ void Select_next_a(Select* unit, int inNumSamples);
 
 void TWindex_Ctor(TWindex* unit);
 void TWindex_next_k(TWindex* unit, int inNumSamples);
-void TWindex_next_ak(TWindex* unit, int inNumSamples);
+void TWindex_next_a(TWindex* unit, int inNumSamples);
 
 void Index_Ctor(Index* unit);
 void Index_next_1(Index* unit, int inNumSamples);
@@ -529,7 +529,7 @@ void Select_next_a(Select* unit, int inNumSamples) {
 
 void TWindex_Ctor(TWindex* unit) {
     if (INRATE(0) == calc_FullRate) {
-        SETCALC(TWindex_next_ak); // todo : ar
+        SETCALC(TWindex_next_a);
     } else {
         SETCALC(TWindex_next_k);
     }
@@ -575,11 +575,10 @@ void TWindex_next_k(TWindex* unit, int inNumSamples) {
     unit->m_trig = trig;
 }
 
-void TWindex_next_ak(TWindex* unit, int inNumSamples) {
+void TWindex_next_a(TWindex* unit, int inNumSamples) {
     int maxindex = unit->mNumInputs;
     int32 index = maxindex;
 
-    float sum = 0.f;
     float maxSum = 0.f;
     float normalize = ZIN0(1); // switch normalisation on or off
     float* trig = ZIN(0);
@@ -596,6 +595,7 @@ void TWindex_next_ak(TWindex* unit, int inNumSamples) {
     LOOP1(
         inNumSamples, curtrig = ZXP(trig); if (curtrig > 0.f && unit->m_trig <= 0.f) {
             float max = maxSum * rgen.frand();
+            float sum = 0.f;
             for (int32 k = 2; k < maxindex; ++k) {
                 sum += ZIN0(k);
                 if (sum >= max) {

--- a/testsuite/classlibrary/TestCoreUGens.sc
+++ b/testsuite/classlibrary/TestCoreUGens.sc
@@ -512,5 +512,39 @@ TestCoreUGens : UnitTest {
 
 	}
 
+	test_TWindex_ar_skips_zero_probability {
+		var cond = Condition.new,
+		success = true,
+		node, failResp;
+
+		server.bootSync;
+
+		// testing a specific bug:
+		// TWindex should initialize its 'sum' variable per trigger
+		// older versions do not do that, so they may output an index
+		// for a zero probability
+		node = {
+			var trig = Impulse.ar(ControlRate.ir * 2),  // 2 triggers / control block
+			index = TWindex.ar(trig, [0, 1]);
+			SendReply.ar(trig * (index <= 0), '/badIndex');
+			Line.ar(0, 0, ControlDur.ir, doneAction: 2);
+			Silent.ar(1);
+		}.play(server);
+		node.onFree {
+			// success == true means the OSCFunc didn't unhang
+			// other case, unnecessary to re-unhang
+			if(success) { cond.unhang }
+		};
+
+		failResp = OSCFunc({
+			success = false;
+			cond.unhang;
+		}, '/badIndex', argTemplate: [node.nodeID]);
+
+		cond.hang;
+
+		this.assert(success.debug("assert"), "TWindex.ar should output only for nonzero probabilities");
+	}
+
 
 } // end TestCoreUGens class

--- a/testsuite/classlibrary/TestCoreUGens.sc
+++ b/testsuite/classlibrary/TestCoreUGens.sc
@@ -512,39 +512,5 @@ TestCoreUGens : UnitTest {
 
 	}
 
-	test_TWindex_ar_skips_zero_probability {
-		var cond = Condition.new,
-		success = true,
-		node, failResp;
-
-		server.bootSync;
-
-		// testing a specific bug:
-		// TWindex should initialize its 'sum' variable per trigger
-		// older versions do not do that, so they may output an index
-		// for a zero probability
-		node = {
-			var trig = Impulse.ar(ControlRate.ir * 2),  // 2 triggers / control block
-			index = TWindex.ar(trig, [0, 1]);
-			SendReply.ar(trig * (index <= 0), '/badIndex');
-			Line.ar(0, 0, ControlDur.ir, doneAction: 2);
-			Silent.ar(1);
-		}.play(server);
-		node.onFree {
-			// success == true means the OSCFunc didn't unhang
-			// other case, unnecessary to re-unhang
-			if(success) { cond.unhang }
-		};
-
-		failResp = OSCFunc({
-			success = false;
-			cond.unhang;
-		}, '/badIndex', argTemplate: [node.nodeID]);
-
-		cond.hang;
-
-		this.assert(success, "TWindex.ar should output only for nonzero probabilities");
-	}
-
 
 } // end TestCoreUGens class

--- a/testsuite/classlibrary/TestCoreUGens.sc
+++ b/testsuite/classlibrary/TestCoreUGens.sc
@@ -543,7 +543,7 @@ TestCoreUGens : UnitTest {
 
 		cond.hang;
 
-		this.assert(success.debug("assert"), "TWindex.ar should output only for nonzero probabilities");
+		this.assert(success, "TWindex.ar should output only for nonzero probabilities");
 	}
 
 

--- a/testsuite/classlibrary/TestTWindex.sc
+++ b/testsuite/classlibrary/TestTWindex.sc
@@ -1,0 +1,46 @@
+TestTWindex : UnitTest {
+	var server;
+
+	setUp {
+		server = Server(this.class.name);
+	}
+
+	tearDown {
+		server.quit;
+		server.remove;
+	}
+
+	test_TWindex_ar_skips_zero_probability {
+		var cond = Condition.new,
+		success = true,
+		node, failResp;
+
+		server.bootSync;
+
+		// testing a specific bug:
+		// TWindex should initialize its 'sum' variable per trigger
+		// older versions do not do that, so they may output an index
+		// for a zero probability
+		node = {
+			var trig = Impulse.ar(ControlRate.ir * 2),  // 2 triggers / control block
+			index = TWindex.ar(trig, [0, 1]);
+			SendReply.ar(trig * (index <= 0), '/badIndex');
+			Line.ar(0, 0, ControlDur.ir, doneAction: 2);
+			Silent.ar(1);
+		}.play(server);
+		node.onFree {
+			// success == true means the OSCFunc didn't unhang
+			// other case, unnecessary to re-unhang
+			if(success) { cond.unhang }
+		};
+
+		failResp = OSCFunc({
+			success = false;
+			cond.unhang;
+		}, '/badIndex', argTemplate: [node.nodeID]);
+
+		cond.hang;
+
+		this.assert(success, "TWindex.ar should output only for nonzero probabilities");
+	}
+}


### PR DESCRIPTION
## Purpose and Motivation

Reported at https://scsynth.org/t/strange-twchoose-ar-behavior/2277/5:

```
a = {
	var trig = Impulse.ar(ControlRate.ir * 4),
	index = TWindex.ar(trig, [0, 1]),
	sampleCount = Sweep.ar(0, SampleRate.ir);
	Poll.ar(trig * (index <= 0), sampleCount, "failed");
	Line.ar(0, 1, ControlDur.ir, doneAction: 2);
	Silent.ar(1)
}.play;
```

Four triggers are generated within one control block. The first one behaves correctly, skipping over the zero probability and returning an index == 1. The 2nd, 3rd and 4th return index == 0, which should be impossible according to the probability table.

The reason why is that TWindex initializes its `sum` variable only once per control block. It should initialize for every incoming trigger. That is, it currently assumes there will never be more than one trigger in a control block.

Easy fix, easy unit test.

Note that I changed `TWindex_next_ak` to `TWindex_next_a` because it now doesn't assume that the trigger will be control rate, so `_ak` as a rate suffix is now inaccurate.

I didn't make any changes to support changing probabilities in the middle of a control block. `ar` triggers would be a common use case; `ar` probabilities, much less so.

## Types of changes

- Documentation (small note)
- Bug fix

## To-do list

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review