### PR TITLE
help: Pfunc: remove erroneous mention of argument being passed to resetFunc

### DIFF
--- a/HelpSource/Classes/Pfunc.schelp
+++ b/HelpSource/Classes/Pfunc.schelp
@@ -83,5 +83,3 @@ p.trace.play;
 p = Pbind(\freq, nil, \degree, 6) <> q;
 p.trace.play; // silent because it outputs no events
 ::
-
-

--- a/HelpSource/Classes/Pfunc.schelp
+++ b/HelpSource/Classes/Pfunc.schelp
@@ -11,12 +11,15 @@ classmethods::
 
 method:: new
 argument:: nextFunc
-Stream function. In an event stream receives the current link::Classes/Event:: as argument.
+Stream function. In an event stream code::nextFunc:: receives the current link::Classes/Event:: as argument, and more generally the argument passed to the stream's code::next:: call.
 argument:: resetFunc
-Function that is called when the stream is reset. In an event stream receives the current link::Classes/Event:: as argument.
+Function that is called when the stream is reset. code::resetFunc:: receives no arguments.
 
 
 examples::
+
+Numeric stream examples
+
 code::
 (
 var a, x;
@@ -25,9 +28,17 @@ x = a.asStream;
 x.nextN(20).postln;
 x.reset;
 )
+
+// with argument passed to nextFunc
+(
+x = Pfunc({ |inval| (10 ** inval.value) * rrand(1, 9) }).asStream;
+[2, 3, 2].do { |i| x.next(i).postln };
+x.nextN(5, (:0..)).postln;
+)
 ::
 
-Sound example
+Event stream (sound) examples:
+
 code::
 (
 SynthDef(\help_sinegrain,
@@ -49,3 +60,28 @@ a = Pfunc({ exprand(0.1, 0.3) + #[1, 2, 3, 6, 7].choose }).asStream;
 }.fork;
 )
 ::
+
+When an Event is played, if code::\freq:: is set then code::\degree:: is ignored (due to the code::Event.default:: machinery). In a chain of Patterns, a code::Pfunc:: can be used to delete a key from the Event stream; this can even be done inside a Pbind.
+
+code::
+q = Pbind(\freq, 300, \dur, Pn(0.3, 2));
+q.trace.play;
+
+// Sound-wise ineffective modification of the incoming stream
+p = Pbind(\degree, 6) <> q;
+p.trace.play;
+
+// Instead
+p = Pbind(\degree, 6) <> Pfunc { |ev| ev.freq = nil } <> q;
+p.trace.play;
+
+// Alternatively
+p = Pbind(\degree, Pfunc { |ev| ev.freq = nil; 6 } ) <> q;
+p.trace.play;
+
+// Just setting a key to nil from a Pbind pair will end the stream
+p = Pbind(\freq, nil, \degree, 6) <> q;
+p.trace.play; // silent because it outputs no events
+::
+
+


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

Fixes #5009 i.e. there's no argument passed to `reset` in the classlib code, so I've removed the claiam that that happens from the Pfunc documentation.

Also, I've add examples of using the argument in nextFunc, including one on how to delete keys from event streams, which is a bit of a newbie gotcha if done from a Pbind "directly", by setting a key to nil.

Alas, it might not be easy to find this example from the most relevant context, i.e. the Pbind help page ... but since it exists now in a help file, it could linked/mentioned from there, although I've not included that in this PR. (If you think that's a good idea, I'll push another commit on Pbind's help page.)

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->

- Documentation

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [ ] All tests are passing
- [x] This PR is ready for review
