### PR TITLE
scsynth: set SC_ServerBootDelayWarning as source to scsynth

### DIFF
--- a/server/scsynth/CMakeLists.txt
+++ b/server/scsynth/CMakeLists.txt
@@ -84,7 +84,6 @@ set(scsynth_sources
 	${CMAKE_SOURCE_DIR}/common/SC_StringParser.cpp
 	${CMAKE_SOURCE_DIR}/common/Samp.cpp
 	${CMAKE_SOURCE_DIR}/common/sc_popen.cpp
-	${CMAKE_SOURCE_DIR}/common/SC_ServerBootDelayWarning.cpp
 )
 
 if(APPLE)
@@ -230,7 +229,7 @@ if(CMAKE_SYSTEM_NAME MATCHES "Linux")
 	target_link_libraries(libscsynth rt)
 endif()
 
-add_executable(scsynth scsynth_main.cpp)
+add_executable(scsynth scsynth_main.cpp ${CMAKE_SOURCE_DIR}/common/SC_ServerBootDelayWarning.cpp)
 target_link_libraries(scsynth libscsynth)
 
 if (PTHREADS_FOUND)

--- a/server/supernova/CMakeLists.txt
+++ b/server/supernova/CMakeLists.txt
@@ -51,7 +51,6 @@ set(libsupernova_src
     ${CMAKE_SOURCE_DIR}/common/Samp.cpp
     ${CMAKE_SOURCE_DIR}/common/SC_fftlib.cpp
     ${CMAKE_SOURCE_DIR}/common/SC_StringParser.cpp
-    ${CMAKE_SOURCE_DIR}/common/SC_ServerBootDelayWarning.cpp
     server/buffer_manager.cpp
     server/memory_pool.cpp
     server/node_graph.cpp
@@ -202,7 +201,7 @@ if(WIN32)
 endif()
 
 
-add_executable(supernova server/main.cpp ${supernova_headers})
+add_executable(supernova server/main.cpp ${supernova_headers} ${CMAKE_SOURCE_DIR}/common/SC_ServerBootDelayWarning.cpp)
 target_link_libraries(supernova libsupernova)
 
 if(WIN32)


### PR DESCRIPTION
scsynth: set SC_ServerBootDelayWarning as source to scsynth not to libscsynth solves #4992
