### PR TITLE
Fix the IPC message processing on scide

### DIFF
--- a/editors/sc-ide/core/sc_process.cpp
+++ b/editors/sc-ide/core/sc_process.cpp
@@ -306,8 +306,8 @@ void ScProcess::onIpcData() {
         if (mReadSize > 0 && avail >= mReadSize) {
             QByteArray baReceived(mIpcData.left(mReadSize));
             mIpcData.remove(0, mReadSize);
-            mReadSize = 0;
             avail -= mReadSize;
+            mReadSize = 0;
 
             QDataStream in(baReceived);
             in.setVersion(QDataStream::Qt_4_6);


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

Fixes: #4688 

This is a pretty nasty bug that causes all sorts of random failures. The message processor for the IPC between ide and lang will fail if it doesn't process a message in one go because it loses track of the remaining available data.

When this happens, it never recovers, causing all sort of problems in the IDE, anything that depends on ScIDE.send stops to work, include the HelpBrowser. The only way to recover is restarting the whole IDE.

Please see #4688 for an easy way to reproduce the problem. 
On Linux you might need a bigger value (60000 for example) and a few tries to trigger the bug, but it is pretty constant. I think other bugs reported are also caused by this, including in quarks that use a lot the interaction between the IDE and language such as @adcxyz 's  SyncText. @adcxyz helped me to track this down.

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review
