### PR TITLE
Quick fix for Pmono (and PmonoArtic) turning everything off in the default group

### DIFF
--- a/SCClassLibrary/Common/Streams/PmonoStreams.sc
+++ b/SCClassLibrary/Common/Streams/PmonoStreams.sc
@@ -69,7 +69,7 @@ PmonoStream : Stream {
 					~type = \monoNote;
 					~instrument = pattern.synthName;
 					cleanup.addFunction(event, currentCleanupFunc = { | flag |
-						if (flag) { (id: id, server: server, type: \off,
+						if (flag && id.notNil) { (id: id, server: server, type: \off,
 							hasGate: hasGate,
 							schedBundleArray: schedBundleArray,
 							schedBundle: schedBundle).play

--- a/SCClassLibrary/Common/Streams/PmonoStreams.sc
+++ b/SCClassLibrary/Common/Streams/PmonoStreams.sc
@@ -69,7 +69,7 @@ PmonoStream : Stream {
 					~type = \monoNote;
 					~instrument = pattern.synthName;
 					cleanup.addFunction(event, currentCleanupFunc = { | flag |
-						if (flag && id.notNil) { (id: id, server: server, type: \off,
+						if (flag and: { id.notNil }) { (id: id, server: server, type: \off,
 							hasGate: hasGate,
 							schedBundleArray: schedBundleArray,
 							schedBundle: schedBundle).play


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

Fixes #5024 

Commit 83e4607cd merged in PR #4787 exposed an underlying problem in Pmono's two-part cleanup setup, which can (now at least) fire a `type: off` event with no `id` set, turning everything off in the default group, e.g. as in:

```
Synth(\default);
PfadeOut(Pmono(\default, \dur, 0.4), 0.3).play;
```

This is an "emergency fix" that prevents Pmono's cleanup from firing that `off` event if `id` is still not set by the time the
cleanup is executed. (The mechanism is also inherited by PmonoArtic.)

A better solution would be to rewrite Pmono so that it doesn't register an incompletely specified cleanup at all, but that is somewhat involved given the number of variables it would need to capture in a closure.

Also this PR will very likely cause a merge conflict with the solution currently envisaged for #4806 which needs to change the previous line in that Pmono cleanup setup code (to conform to the new API for cleanups), so please merge this PR as soon as practically possible.

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] This PR is ready for review
