### PR TITLE
classlib: EventStreamCleanup "auto-deduplicates" cleanups 

### DIFF
--- a/HelpSource/Classes/CleanupThunk.schelp
+++ b/HelpSource/Classes/CleanupThunk.schelp
@@ -1,0 +1,95 @@
+TITLE:: CleanupThunk
+summary:: execute a function (at most) once
+categories::Streams-Patterns-Events
+related:: Classes/EventStreamCleanup
+
+DESCRIPTION::
+Unlike a link::Classes/Thunk::, which takes no arguments, a CleanupThunk does allow arguments to be passed to the function it wraps, but the function is executed at most once. CleanupThunks can also be "cancelled" with a code::clear:: call, without ever executing the wrapped function, even if CleanupThunk's code::value:: is called later.
+
+The general contract for CleanupThunk is that any calls into the function after the first would do the same or less (cleanup) work as the first call did. Thus, subsequent calls are completely redundant and can be answered with the result from the first call, even if the arguments change on subsequent calls. Prototypical use case: if a cleanup is called with a code::releaseResource: false:: argument, e.g. because the resource was already released by link::Classes/CmdPeriod::, it is assumed that the cleanup will not be called later with a code::releaseResource: true:: argument.
+
+Since it executes its function (at most) once, CleanupThunk is not a general-purpose function memoization facility for functions with arguments.
+
+Basic example (see end of page for more):
+
+code::
+c = CleanupThunk { |flag| if(flag) { "woking...".postln; "done:" + flag } };
+c.value(true);  // -> done: true (and posts "woking...")
+c.value(false); // -> done: true (nothing posted)
+::
+
+CLASSMETHODS::
+
+method::new
+
+argument::function
+a function that typically executes some cleanup and may return a desired value. The function is wrapped in the CleanupThunk for later execution.
+
+INSTANCEMETHODS::
+
+METHOD:: clear
+Cancels the CleanupThunk, meaning that subsequent calls to code::value:: will have not execute the wrapped function at all.
+returns:: the CleanupThunk.
+
+METHOD:: didEvaluate
+Report if the CleanupThunk is considered already evaluated.
+returns:: code::false:: if neither code::clear:: nor code::value:: were called previously; code::true:: otherwise.
+
+METHOD:: value
+If code::clear:: was called previously, the code::value:: call has no side-effect. Otherwise, on the first call to code::value:: the function wrapped by the CleanupThunk is evaluated with the arguments provided to code::value:: and the result of this evaluation is stored as the CleanupThunk's result, used to answer all subsequent calls to code::value::.
+
+argument::  ... args
+Arguments to use in the call to the wrapped function, if it happens. If code::didEvaluate:: already returns code::true:: (before the current call to code::value::) then the current code::args:: are irrelevant.
+
+returns::
+list::
+## code::nil:: if code::clear:: was called on the CleanupThunk before any calls to code::value::, otherwise
+## the value that was computed by the function (wrapped by the CleanupThunk) on the first call to CleanupThunk's code::value::
+::
+EXAMPLES::
+
+code::
+r = 1; // some resource
+c = CleanupThunk {  r = r - 1; postln("Resource is now released:" + r); r };
+c.didEvaluate; // -> false
+c.value;       // -> 0 (and posts "Resource is now released: 0")
+c.didEvaluate; // -> true
+c.value;       // -> 0 (but posts nothing)
+c.clear;       // even if is "cancelled" now
+c.value;       // -> 0; the computed value is preserved
+
+c = CleanupThunk { "not called".postln }
+c.didEvaluate; // -> false
+c.clear;       // "cancels" the cleanup
+c.didEvaluate; // -> true
+c.value;       // -> nil
+
+// use with an argument
+(
+r = 1; // some resource
+c = CleanupThunk { |releaseResource|
+	if(releaseResource) {
+		r = r - 1; "Resource is now released:" + r
+	} {
+		"nothing to do"
+	}
+};
+)
+d = c.copy // saved for later, separate execution state
+
+// correct use sequence (non-increasing cleanup-work sequence):
+c.value(true);
+c.value(true);
+c.value(false);
+r; // -> 0
+
+d.didEvaluate; // -> false (copy didn't evaluate yet)
+
+// semantically incorrect (contract breaking) use sequence
+d.value(false) // -> nothing to do
+d.value(true)  // -> nothing to do
+::
+
+
+
+

--- a/HelpSource/Classes/CleanupThunk.schelp
+++ b/HelpSource/Classes/CleanupThunk.schelp
@@ -28,7 +28,7 @@ a function that typically executes some cleanup and may return a desired value. 
 INSTANCEMETHODS::
 
 METHOD:: clear
-Cancels the CleanupThunk, meaning that subsequent calls to code::value:: will have not execute the wrapped function at all.
+Cancels the CleanupThunk, meaning that subsequent calls to code::value:: will not execute the wrapped function at all.
 returns:: the CleanupThunk.
 
 METHOD:: didEvaluate
@@ -39,7 +39,7 @@ METHOD:: value
 If code::clear:: was called previously, the code::value:: call has no side-effect. Otherwise, on the first call to code::value:: the function wrapped by the CleanupThunk is evaluated with the arguments provided to code::value:: and the result of this evaluation is stored as the CleanupThunk's result, used to answer all subsequent calls to code::value::.
 
 argument::  ... args
-Arguments to use in the call to the wrapped function, if it happens. If code::didEvaluate:: already returns code::true:: (before the current call to code::value::) then the current code::args:: are irrelevant.
+Arguments to use in the call to the wrapped function, if the call happens. If code::didEvaluate:: already returns code::true:: (before the current call to code::value::) then the current code::args:: are irrelevant because the wrapped function is not called anymore.
 
 returns::
 list::

--- a/HelpSource/Classes/EventStreamCleanup.schelp
+++ b/HelpSource/Classes/EventStreamCleanup.schelp
@@ -68,6 +68,8 @@ The outevent that is passed on downstreams and which communicates to any stream-
 ARGUMENT:: function
 The function that is called for cleanup. E.g. code::{ group.free }::.
 
+RETURNS:: a link::Classes/CleanupThunk:: that executes the cleanup code::function:: at most once. Should it be necessary to execute the cleanup outside of the control of code::EventStreamCleanup::, the CleanupThunk returned should be used instead of the original code::function::, so that other referents are informed of the execution of the cleanup.
+
 METHOD:: update
 For every new event, the cleanup must be updated to receive information from any input stream further up. This method is called from all streams that may stop early (e.g. link::Classes/Pmono:: or link::Classes/Pfindur::).
 

--- a/SCClassLibrary/Common/Streams/EventStreamCleanup.sc
+++ b/SCClassLibrary/Common/Streams/EventStreamCleanup.sc
@@ -1,12 +1,49 @@
+// The "new" cleanup framework: built-in mechanism to avoid duplicate
+// execution of cleanups, difficult to avoid otherwise due to their
+// replicated nature in a stream graph. Instead of storing bare Functions,
+// they are now stored in CleanupThunks.
+
+// Unlike Thunks which take no arguments, CleanupThunks do allow arguments
+// to be passed to the function, but the CleanupThunk contract is that any
+// subsequent calls into the function would monotonically do the same or
+// less (cleanup) work, so that the first call does the maximal amount of
+// relevant work, making subsequent calls completely redundant.
+// Prototypical example: if a cleanup is called with a "flag: false",
+// it is assumed it will *not* be called later again with "flag: true",
+// if the latter means that the function would have to do "extra" work
+// that was skipped/excluded by "flag: false".
+// CleanupThunk is not a general-purpose function memoization class for
+// functions with arguments.
+CleanupThunk : Thunk {
+
+	value { |... args| ^this.prEvaluate(\valueArray, args) }
+	valueArray { |... args| ^this.prEvaluate(\valueArray, *args) }
+	valueEnvir { |... args| ^this.prEvaluate(\valueArrayEnvir, args) }
+	valueArrayEnvir { |... args| ^this.prEvaluate(\valueArrayEnvir, *args) }
+
+	prEvaluate { |selector, args|
+		^value ?? {
+			value = function.performList(selector, args);
+			function = nil;
+			value
+		}
+	}
+	didEvaluate { ^function.isNil }
+	clear { function = nil }
+}
+
+
 // Cleanup functions are passed a flag.
 // The flag is set false if nodes have already been freed by CmdPeriod
-// This caused a minor change to TempoClock:clear and TempoClock:cmdPeriod
-
 EventStreamCleanup {
 
 	var <>functions;		// cleanup functions from child streams and parent stream
 
 	*new { ^super.new.clear }
+
+	copy {
+		^this.class.new.functions_(this.functions.copy)
+	}
 
 	clear {
 		functions = IdentitySet.new;
@@ -14,23 +51,28 @@ EventStreamCleanup {
 
 	addFunction { |event, function |
 		if(event.isKindOf(Dictionary)) {
+			function = CleanupThunk(function);
 			functions.add(function);
 			event[\addToCleanup] = event[\addToCleanup].add(function);
 		};
+		^function
 	}
 
 	addNodeCleanup { |event, function |
 		if(event.isKindOf(Dictionary)) {
+			function = CleanupThunk(function);
 			functions.add(function);
 			event[\addToNodeCleanup] = event[\addToNodeCleanup].add(function);
 		};
+		^function
 	}
 
 	update { | event |
 		if(event.isKindOf(Dictionary)) {
 			functions.addAll(event[\addToNodeCleanup]);
 			functions.addAll(event[\addToCleanup]);
-			functions.removeAll(event[\removeFromCleanup]);
+			functions.removeAll(event[\removeFromCleanup]); // backwards compat.
+			functions = functions.reject(_.didEvaluate);
 		};
 		^event
 	}
@@ -38,10 +80,7 @@ EventStreamCleanup {
 	exit { | event, freeNodes = true |
 		if(event.isKindOf(Dictionary)) {
 			this.update(event);
-			if(functions.notEmpty) {
-				functions.do(_.value(freeNodes) );
-				event[\removeFromCleanup] = event[\removeFromCleanup].addAll(functions);
-			};
+			functions.do(_.value(freeNodes));
 			this.clear;
 		};
 		^event

--- a/SCClassLibrary/Common/Streams/PmonoStreams.sc
+++ b/SCClassLibrary/Common/Streams/PmonoStreams.sc
@@ -69,7 +69,7 @@ PmonoStream : Stream {
 					~type = \monoNote;
 					~instrument = pattern.synthName;
 					cleanup.addFunction(event, currentCleanupFunc = { | flag |
-						if (flag) { (id: id, server: server, type: \off,
+						if (flag && id.notNil) { (id: id, server: server, type: \off,
 							hasGate: hasGate,
 							schedBundleArray: schedBundleArray,
 							schedBundle: schedBundle).play

--- a/SCClassLibrary/Common/Streams/PmonoStreams.sc
+++ b/SCClassLibrary/Common/Streams/PmonoStreams.sc
@@ -69,7 +69,7 @@ PmonoStream : Stream {
 					~type = \monoNote;
 					~instrument = pattern.synthName;
 					cleanup.addFunction(event, currentCleanupFunc = { | flag |
-						if (flag && id.notNil) { (id: id, server: server, type: \off,
+						if (flag and: { id.notNil }) { (id: id, server: server, type: \off,
 							hasGate: hasGate,
 							schedBundleArray: schedBundleArray,
 							schedBundle: schedBundle).play

--- a/SCClassLibrary/Common/Streams/PmonoStreams.sc
+++ b/SCClassLibrary/Common/Streams/PmonoStreams.sc
@@ -68,7 +68,7 @@ PmonoStream : Stream {
 				if(event.isRest.not) {
 					~type = \monoNote;
 					~instrument = pattern.synthName;
-					cleanup.addFunction(event, currentCleanupFunc = { | flag |
+					currentCleanupFunc = cleanup.addFunction(event, { | flag |
 						if (flag and: { id.notNil }) { (id: id, server: server, type: \off,
 							hasGate: hasGate,
 							schedBundleArray: schedBundleArray,
@@ -130,7 +130,7 @@ PmonoArticStream : PmonoStream {
 				};
 				sustain = event.use { ~sustain.value };
 				if(sustain.notNil and: { sustain < event.delta }) {
-					event[\removeFromCleanup] = event[\removeFromCleanup].add(currentCleanupFunc);
+					// no removal from cleanup now: faster stop behavior
 					thisThread.clock.sched(sustain, {
 						currentCleanupFunc.value(true);
 						rearticulating = true;

--- a/testsuite/classlibrary/TestEventStreamCleanup.sc
+++ b/testsuite/classlibrary/TestEventStreamCleanup.sc
@@ -1,0 +1,89 @@
+TestEventStreamCleanup : UnitTest {
+
+	test_cleanupsNotDuplicatedOrLost {
+
+		var tryExhaustPstream = { |pattern, inEvent = (())|
+			var cleanup = EventStreamCleanup.new, outEvent, stream = pattern.asStream;
+			var hist = List().add(cleanup.functions.size);
+			while {
+				outEvent = stream.next(inEvent);
+				cleanup.update(inEvent);
+				hist.add(cleanup.functions.size);
+				hist.size < 100 && outEvent.notNil // well, exhaust if it's not infinite
+			};
+			[hist, inEvent] // retval not used presently (except in manual debugging)
+		};
+		var injectAndCountCleanupsVsInits = { |patFunc, inEvent = (())|
+			var initCount = 0, cleanupCount = 0;
+			var injector = Pfset(
+				{ initCount = initCount + 1 },
+				p { |ev| ev.yield },
+				{ cleanupCount = cleanupCount + 1 });
+			tryExhaustPstream.(patFunc.(injector), inEvent);
+			[initCount, cleanupCount]
+		};
+		// pattern-generating functions, x substituted for cleanup injector
+		var patternGenFuncs = [
+			{ |x| Pn(x, 1) },
+			{ |x| Pn(x, 3) },
+			{ |x| Pn(x, 0) },
+			{ |x| Pchain(x) },
+			{ |x| Pchain(x, x) },
+			{ |x| Pcollect({ |ev| ev }, x) },
+			{ |x| Pcollect({ |ev| ev.copy }, x) },
+			{ |x| Pseq([x]) },
+			{ |x| Pseq([x, x]) },
+			{ |x| Pseq([x, (y: 10)]) },
+			{ |x| Psetpre(\gg, 8, x) },
+			// the following expected to fail until Psetpre is fixed
+			//{ |x| Psetpre(\hh, Pseq([nil]), x) },
+			//{ |x| Psetpre(\xx, x, Pseq([nil])) },
+			//{ |x| Psetpre(\zz, x, Pseq([ () ])) },
+		];
+		var patternGenFuncsDur = [ // these need a duration pre-set externally
+			{ |x| Ppar([x, Pseq([ () ])]) },
+			{ |x| Ppar([x, x]) },
+			{ |x| Ppar([x, Plazy { x }]) },
+		];
+
+		patternGenFuncs.do { |pgf|
+			var cntPairs = injectAndCountCleanupsVsInits.(pgf);
+			this.assertEquals(cntPairs[0], cntPairs[1], "Cleanup propagation" +
+				pgf.cs + "inits:" + cntPairs[0] ++ ", cleanups:" + cntPairs[1]);
+		};
+		patternGenFuncs.do { |pgf|
+			patternGenFuncs.do { |pgf2|
+				var cntPairs = injectAndCountCleanupsVsInits.(pgf <> pgf2);
+				this.assertEquals(cntPairs[0], cntPairs[1], "Cleanup propagation" +
+					// (pgf <> pgf2).cs doesn't print anything useful
+					pgf.cs + "<>" + pgf2.cs + "inits:" + cntPairs[0] ++ ", cleanups:" + cntPairs[1]);
+			};
+		};
+		patternGenFuncsDur.do { |pgf|
+			var cntPairs = injectAndCountCleanupsVsInits.(pgf, (dur: 0.2));
+			this.assertEquals(cntPairs[0], cntPairs[1], "Cleanup propagation" +
+				pgf.cs + "inits:" + cntPairs[0] ++ ", cleanups:" + cntPairs[1]);
+		};
+		patternGenFuncsDur.do { |pgf|
+			patternGenFuncs.do { |pgf2|
+				var cntPairs = injectAndCountCleanupsVsInits.(pgf <> pgf2, (dur: 0.2));
+				this.assertEquals(cntPairs[0], cntPairs[1], "Cleanup propagation" +
+					pgf.cs + "<>" + pgf2.cs + "inits:" + cntPairs[0] ++ ", cleanups:" + cntPairs[1]);
+			};
+		};
+		patternGenFuncs.do { |pgf|
+			patternGenFuncsDur.do { |pgf2|
+				var cntPairs = injectAndCountCleanupsVsInits.(pgf <> pgf2, (dur: 0.2));
+				this.assertEquals(cntPairs[0], cntPairs[1], "Cleanup propagation" +
+					pgf.cs + "<>" + pgf2.cs + "inits:" + cntPairs[0] ++ ", cleanups:" + cntPairs[1]);
+			};
+		};
+		patternGenFuncsDur.do { |pgf|
+			patternGenFuncsDur.do { |pgf2|
+				var cntPairs = injectAndCountCleanupsVsInits.(pgf <> pgf2, (dur: 0.2));
+				this.assertEquals(cntPairs[0], cntPairs[1], "Cleanup propagation" +
+					pgf.cs + "<>" + pgf2.cs + "inits:" + cntPairs[0] ++ ", cleanups:" + cntPairs[1]);
+			};
+		};
+	}
+}

--- a/testsuite/classlibrary/TestPattern.sc
+++ b/testsuite/classlibrary/TestPattern.sc
@@ -161,9 +161,6 @@ TestPattern : UnitTest {
 		this.assert(x == 1, "Pfset on nil stream should still call the initializer function");
 		this.assert(y == 2, "Pfset on nil stream should still call the cleanup function");
 		this.assert(outEvent.isNil, "Pfset on nil stream should return nil");
-		// inEvent.size is 2 if Pfset adds 'addToCleanup' and 'removeFromCleanup' in sequence (presently);
-		// inEvente.size could be 0 if this add-remove pair is "optimized out" in the future.
-		this.assert(inEvent.size.even, "Pfset on nil stream should add an even number of items to the input event");
 		// The present implementation of EventStreamCleanup.update first does the add(s) then the remove(s),
 		// so it "cancels out" matched add-remove pairs in the same event. But let's check that too...
 		cleanup.update(inEvent);


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

Fixes: #4806, #4808

This PR implements the new cleanup framework that "auto-deduplicates" cleanups by storing them in do-at-most-once thunks.

Unlike Thunks these CleanupThunks need accept (at least one) parameter, so a new class was need. Per previous discussion in #4806, although these CleanupThunks take parameters they aren't actually a general-purpose function memorization facility, hence the more specialized name. (The exact contract/invariant of CleanupThunk is spelled out in a comment in EventStreamCleanup, for now, probably to be added to the help-documentation.)

This PR Assumes #5027 merged/committed, although only one line would conflict if that were *not* applied first. If a more sophisticated solution were to be implemented instead of #5027 for the problem that PR solves, the merge conflicts with this PR could be more substantial.

## Types of changes

<!-- Delete lines that don't apply -->

- Documentation
- Bug fix
- New feature
- Breaking changes:

The API of the new framework has several "breaking changes":
- addFunction and addNodeCleanup return the CleanupThunk-packaged function,
  so that if the cleanup need be executed outside of EventStreamCleanup
  methods, such execution would still be detected by other referents
  of the cleanup. PmonoStreams was changed accordingly.
- \removeFromCleanup messages are no longer emitted by EventStreamCleanup
  although it still honors them for backward compatibility with user code that
  might be using them (to signal the removal of cleanups).  In classlib itself,
  PmonoStreams no longer relies on \removeFromCleanup.
- There is an automatic filtering process that removes executed cleanups
  from cleanup "functions" sets.
- EventStreamCleanup.copy now does a shallow copy of the functions set.
  Although no classlib class depends on this new functionality for correct
  operation, this is copy-behavior was discussed as more desirable in previous
  bug fix #4954, so I'm bundling it with the other breaking changes for
  EventStreamCleanup.
  
Also "breaking change" no strictly related to the cleanups API:
- PmonoArticStream implements new (faster) stop behavior
  that no longer removes nodes with legato<1 from cleanup. Consequently, 
  EventStreamPlayer.stop can release such legato<1 events as well now. This was
  discussed/agreed in #4806 and also [announced](https://www.listarc.bham.ac.uk/lists/sc-users/msg67708.html) on the mailing list where there
  was no opposition expressed. (It's possible to get the old behavior of PmonoArtic
  back in the new cleanup framework; I have even tested the code that would do
  that, but I see no reason to commit it.)

The amusing part is that the (help) documentation is still not incorrect because it never promised how many times a cleanup would be executed (which before this PR, it could have been many times). Nor did it say anything about the return value of addFunction. Nor did it document how to remove a cleanup (\removeFromCleanup).

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review
