### PR TITLE
classlib: Pattern.record correctly set header and sample formats

### DIFF
--- a/HelpSource/Classes/Pattern.schelp
+++ b/HelpSource/Classes/Pattern.schelp
@@ -153,10 +153,10 @@ argument::path
 Disk location for the recorded file. If not given, a filename is generated for you and placed in the default recording directory: code::thisProcess.platform.recordingsDir::.
 
 argument::headerFormat
-File format, default "AIFF" - see link::Classes/SoundFile:: for supported header and sample formats.
+File format, defaults to link::Classes/Server#-recHeaderFormat##server.recHeaderFormat:: - see link::Classes/SoundFile:: for supported header and sample formats.
 
 argument::sampleFormat
-Sample format, default "float".
+Sample format, defaults to link::Classes/Server#-recSampleFormat##server.recSampleFormat::.
 
 argument::numChannels
 Number of channels to record, default 2.

--- a/SCClassLibrary/Common/Streams/Patterns.sc
+++ b/SCClassLibrary/Common/Streams/Patterns.sc
@@ -93,10 +93,13 @@ Pattern : AbstractFunction {
 	// dur: if nil, record until pattern stops or is stopped externally
 	// fadeTime: allow extra time after last Event for nodes to become silent
 
-	record { |path, headerFormat = "AIFF", sampleFormat = "float", numChannels = 2, dur = nil, fadeTime = 0.2, clock(TempoClock.default), protoEvent(Event.default), server(Server.default), out = 0, outNumChannels|
+	record { |path, headerFormat, sampleFormat, numChannels = 2, dur = nil, fadeTime = 0.2, clock(TempoClock.default), protoEvent(Event.default), server(Server.default), out = 0, outNumChannels|
 
 		var recorder = Recorder(server);
 		var pattern = if(dur.notNil) { Pfindur(dur, this) } { this };
+
+		recorder.recHeaderFormat = headerFormat;
+		recorder.recSampleFormat = sampleFormat;
 
 		server.waitForBoot {
 			var group, bus, startTime, free, monitor;


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->
Pattern.record used to simply ignore header and sample formats provided 
as arguments.

Issue reproducer:
```supercollider
Pbind().record("test","wav")
// CmdPeriod to stop rec
SoundFile.use("test"){|f| f.headerFormat.postln} // -> "AIFF"
```

## Types of changes

<!-- Delete lines that don't apply -->

- Documentation
- Bug fix
- Breaking change? I can't say if anyone relied on Patterns ignoring settings provided as arguments... sounds unlikely to me

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [ ] Code is tested
- [ ] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review
