### PR TITLE
Fix bison args in make_parser.sh

### DIFF
--- a/lang/LangSource/Bison/make_parser.sh
+++ b/lang/LangSource/Bison/make_parser.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-bison -o lang11d_tab.cpp lang11d
+bison --defines=lang11d_tab.h --output=lang11d_tab.cpp lang11d
 


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

Fixes #2259

There was no actual compatibility issue, but the script arguments were wrong.

I would have preferred to commit a CMake rule instead of fixing this script that needs to be manually run, but it looks like [getting a working Bison rule in CMake is a bear](https://github.com/supercollider/supercollider/issues/5021#issuecomment-647004008).

Also, with bison 3.5.1, while the parser builds and runs ok, there's this warning:

```
LangSource/Bison/lang11d:36.1-14: warning: deprecated directive: ‘%error-verbose’, use ‘%define parse.error verbose’ [-Wdeprecated]
   36 | %error-verbose
      | ^~~~~~~~~~~~~~
      | %define parse.error verbose
LangSource/Bison/lang11d: warning: fix-its can be applied.  Rerun with option '--update'. [-Wother]
```

which I didn't fix because I don't know how far backwards the new directive is compatible... ([Apparently](https://lists.gnu.org/archive/html/info-gnu/2019-01/msg00016.html) since bison 3.0).

> The %error-verbose directive is deprecated in favor of '%define
  parse.error verbose' since Bison 3.0, but no warning was issued.

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] This PR is ready for review
