### PR TITLE
Topic/thread reschedule

### DIFF
--- a/HelpSource/Classes/EventStreamPlayer.schelp
+++ b/HelpSource/Classes/EventStreamPlayer.schelp
@@ -49,3 +49,10 @@ Stop playing now. (Pause and stop have the same implementation.)
 
 method::reset
 Set the stream to restart from the beginning the next time it's played.
+
+method::reschedule
+
+Switch the Task to a different clock, or a different time, without stopping. See link::Classes/Routine#-reschedule:: for complete documentation.
+
+NOTE:: Rescheduling an EventStreamPlayer from within the pattern itself is currently not supported.
+::

--- a/HelpSource/Classes/Routine.schelp
+++ b/HelpSource/Classes/Routine.schelp
@@ -217,6 +217,87 @@ fork {
 );
 ::
 
+method:: reschedule
+
+If a Routine is currently scheduled on a clock, it will be expected to "awake" at a specific time, on a specific clock. code::reschedule:: allows you to change to a different clock or to a later time.
+
+argument:: argClock
+The new clock on which to run the Routine. If code::nil::, the routine's clock will not be changed. (Note: Currently incompatible with link::Classes/AppClock::; rescheduling depends upon the method code::schedAbs::, which AppClock does not implement.)
+
+argument:: quant
+A quantization specifier, identifying a time emphasis::later:: than the next-scheduled time. If code::nil::, the current value of code::nextBeat:: will be used.
+
+discussion::
+
+list::
+## Rescheduling to a different clock will be continuous in terms of seconds, but not necessarily continuous in terms of beats. Time-based patterns such as link::Classes/Pseg::, or the use of link::Classes/Env:: as a stream, are likely to break.
+
+When switching the clock, code::reschedule:: will first calculate the new "awake" time, in beats, based on the given code::quant::. Then it converts that code::beats:: value into the new clock's code::beats:: for the same instant in time. If the old clock's tempo is 1 and the Routine was waiting for 1 beat, the next "awake" should happen after one second. When rescheduling without a code::quant::, the next "awake" will emphasis::still:: happen after one second -- but the code::beats:: value will adjust for the new clock.
+
+## Currently code::quant:: will resolve to a time emphasis::later:: than the Routine's current code::nextBeat::. If you try to force it earlier, there is likely to be some discontinuity. This is because the Routine cannot reschedule until it wakes up normally. The workaround is to switch the Routine into a different link::Classes/Task:: wrapper.
+
+## Currently the routine must be playing (already scheduled on a clock). This is because the handoff to the new clock or time occurs during the thread's "awake" process. If the routine is not playing, then it will not awake, and nothing will happen.
+::
+
+code::
+// Rescheduling to a different clock, same time
+c = TempoClock.new;
+
+(
+t = Routine {
+	var lastSeconds = thisThread.seconds;
+	loop {
+		1.0.wait;
+		[thisThread.beats, thisThread.seconds - lastSeconds].postln;
+		lastSeconds = thisThread.seconds;
+	}
+}.play;
+)
+
+t.reschedule(c);  // seconds delta = 1.0 throughout
+
+t.stop;
+
+// Rescheduling to a later time, same clock
+(
+t = Routine {
+	var lastSeconds = thisThread.seconds;
+	loop {
+		1.0.wait;
+		[thisThread.beats, thisThread.seconds - lastSeconds].postln;
+		lastSeconds = thisThread.seconds;
+	}
+}.play;
+)
+
+t.reschedule(quant: 1);
+
+t.stop;
+
+// Rescheduling to an earlier time (workaround, only possible way)
+// Requires you to start with a PauseStream!
+// This does not work if 't' is a Routine initially.
+(
+t = PauseStream(Routine {
+	var lastSeconds = thisThread.seconds;
+	loop {
+		1.0.wait;
+		[thisThread.beats, thisThread.seconds - lastSeconds].postln;
+		lastSeconds = thisThread.seconds;
+	}
+}).play;
+)
+
+// shorter than 1 beat later
+(
+u = PauseStream(t.stream);
+TempoClock.schedAbs(t.nextBeat.trunc, u.refresh);
+t.stop;
+)
+
+u.stop;
+::
+
 method:: awake
 
 This method is called by a link::Classes/Clock:: on which the Routine was scheduled

--- a/HelpSource/Classes/Task.schelp
+++ b/HelpSource/Classes/Task.schelp
@@ -6,12 +6,7 @@ related::Classes/Routine
 DESCRIPTION::
 Task is a pauseable process. It is implemented by wrapping a link::Classes/PauseStream:: around a link::Classes/Routine::. Most of its methods (start, stop, reset) are inherited from PauseStream.
 
-Tasks are not 100% interchangeable with Routines.
-
-list::
-## Condition does not work properly inside of a Task.
-## Stopping a task and restarting it quickly may yield surprising results (see example below), but this is necessary to prevent tasks from becoming unstable if they are started and/or stopped in rapid succession.
-::
+Stopping a task and restarting it quickly may yield surprising results (see example below), but this is necessary to prevent tasks from becoming unstable if they are started and/or stopped in rapid succession.
 
 CLASSMETHODS::
 

--- a/HelpSource/Classes/Task.schelp
+++ b/HelpSource/Classes/Task.schelp
@@ -44,6 +44,13 @@ Stop playing now. (Pause and stop have the same implementation.)
 method::reset
 Set the stream to restart from the beginning the next time it's played.
 
+method::reschedule
+
+Switch the Task to a different clock, or a different time, without stopping. See link::Classes/Routine#-reschedule:: for complete documentation.
+
+NOTE:: If you want to reschedule a Task from within the Task itself, code::thisThread.reschedule(...):: will not work (as it does in a Routine). You must write code::thisThread.threadPlayer.reschedule(...):: instead.
+::
+
 subsection::Notifications
 
 Other objects might need to be aware of changes in the state of a task. The following notifications are broadcast to dependents registered with the Task object.

--- a/HelpSource/Classes/TempoClock.schelp
+++ b/HelpSource/Classes/TempoClock.schelp
@@ -262,6 +262,8 @@ t.nextTimeOnGrid(t.beatsPerBar) == t.nextBar // => true
 ::
 Together strong::quant:: and strong::phase:: are useful for finding the next n beat in a bar, e.g. code::nextTimeOnGrid(4, 2):: will return the next 3rd beat of a bar (of 4 beats), whereas code::nextBar-2:: may return an elapsed beat.
 
+code::referenceBeat:: may be used to evaluate the quant and phase relative to an arbitrary beat. Normally, no reference beat will be specified (code::nil::) and the clock's current beats will be used.
+
 method::elapsedBeats
 Returns the current elapsed time in beats. This is equivalent to code::tempoClock.secs2beats(Main.elapsedTime)::. It is often preferable to use link::#-beats:: instead of elapsedBeats because beats uses a thread's logical time.
 

--- a/SCClassLibrary/Common/Core/Clock.sc
+++ b/SCClassLibrary/Common/Core/Clock.sc
@@ -298,11 +298,12 @@ elapsed time is whatever the system clock says it is right now. elapsed time is 
 		^this.primitiveFailed
 	}
 
-	nextTimeOnGrid { arg quant = 1, phase = 0;
-		if (quant == 0) { ^this.beats + phase };
-		if (quant < 0) { quant = beatsPerBar * quant.neg };
-		if (phase < 0) { phase = phase % quant };
-		^roundUp(this.beats - baseBarBeat - (phase % quant), quant) + baseBarBeat + phase
+	nextTimeOnGrid { arg quant = 1, phase = 0, referenceBeat;
+		if(referenceBeat.isNil) { referenceBeat = this.beats };
+		if(quant == 0) { ^referenceBeat + phase };
+		if(quant < 0) { quant = beatsPerBar * quant.neg };
+		if(phase < 0) { phase = phase % quant };
+		^roundUp(referenceBeat - baseBarBeat - (phase % quant), quant) + baseBarBeat + phase
 	}
 
 	timeToNextBeat { arg quant=1.0; // logical time to next beat

--- a/SCClassLibrary/Common/Core/Thread.sc
+++ b/SCClassLibrary/Common/Core/Thread.sc
@@ -16,6 +16,7 @@ Thread : Stream {
 	var environment;
 	var <>exceptionHandler, >threadPlayer;
 	var <executingPath, <oldExecutingPath;
+	var rescheduledTime;
 
 	*new { arg func, stackSize = (512);
 		^super.new.init(func, stackSize)
@@ -110,6 +111,20 @@ Routine : Thread {
 		_RoutineResume
 		^this.primitiveFailed
 	}
+	reschedule { arg argClock, quant;
+		// Thread:isPlaying only answers if the thread is waiting
+		// It *doesn't* confirm that it is actually scheduled on a clock
+		if(this.nextBeat.isNil) {
+			Error("% can't be rescheduled when idle; use 'play' instead".format(this.class.name)).throw;
+		};
+		rescheduledTime = quant.asQuant.nextTimeOnGrid(clock, this.nextBeat);
+		if(argClock.isNil) { argClock = clock };
+		if(argClock !== clock) {
+			// convert to new clock's time
+			rescheduledTime = argClock.secs2beats(clock.beats2secs(rescheduledTime));
+		};
+		clock = argClock;
+	}
 	run { arg inval;
 		_RoutineResume
 		^this.primitiveFailed
@@ -145,9 +160,15 @@ Routine : Thread {
 
 	// PRIVATE
 	awake { arg inBeats, inSeconds, inClock;
-		var temp = inBeats; // prevent optimization
-
-		^this.next(inBeats)
+		if(rescheduledTime.isNil) {
+			clock = inClock;
+			^this.next(inBeats)
+		} {
+			// rescheduling, possibly on a new clock
+			clock.schedAbs(rescheduledTime, this);
+			rescheduledTime = nil;
+			^nil
+		}
 	}
 	prStart { arg inval;
 		func.value(inval);

--- a/SCClassLibrary/Common/Streams/Quant.sc
+++ b/SCClassLibrary/Common/Streams/Quant.sc
@@ -11,8 +11,8 @@ Quant {
 
 	*new { |quant = 0, phase, timingOffset| ^super.newCopyArgs(quant, phase, timingOffset) }
 
-	nextTimeOnGrid { | clock |
-		^clock.nextTimeOnGrid(quant, (phase ? 0) - (timingOffset ? 0));
+	nextTimeOnGrid { |clock, referenceBeat|
+		^clock.nextTimeOnGrid(quant, (phase ? 0) - (timingOffset ? 0), referenceBeat)
 	}
 
 	asQuant { ^this.copy }

--- a/SCClassLibrary/Common/Streams/Stream.sc
+++ b/SCClassLibrary/Common/Streams/Stream.sc
@@ -392,16 +392,23 @@ PauseStream : Stream {
 		^this.play(clock ? argClock, false, quant)
 	}
 	reschedule { arg argClock, quant;
-		if(this.isPlaying.not) {
-			Error("% can't be rescheduled when idle; use 'play' instead".format(this.class.name)).throw;
+		var doResched = {
+			if(this.isPlaying.not) {
+				Error("% can't be rescheduled when idle; use 'play' instead".format(this.class.name)).throw;
+			};
+			rescheduledTime = quant.asQuant.nextTimeOnGrid(clock, this.nextBeat);
+			if(argClock.isNil) { argClock = clock };
+			if(argClock !== clock) {
+				// convert to new clock's time
+				rescheduledTime = argClock.secs2beats(clock.beats2secs(rescheduledTime));
+			};
+			clock = argClock;
 		};
-		rescheduledTime = quant.asQuant.nextTimeOnGrid(clock, this.nextBeat);
-		if(argClock.isNil) { argClock = clock };
-		if(argClock !== clock) {
-			// convert to new clock's time
-			rescheduledTime = argClock.secs2beats(clock.beats2secs(rescheduledTime));
-		};
-		clock = argClock;
+		if(thisThread === this.stream) {
+			doResched.defer
+		} {
+			doResched.value
+		}
 	}
 
 	refresh {

--- a/SCClassLibrary/Common/Streams/Stream.sc
+++ b/SCClassLibrary/Common/Streams/Stream.sc
@@ -329,6 +329,7 @@ CleanupStream : Stream {
 PauseStream : Stream {
 	var <stream, <originalStream, <clock, <nextBeat, <>streamHasEnded=false;
 	var isWaiting = false, era=0;
+	var rescheduledTime;  // normally nil
 
 	*new { arg argStream, clock;
 		^super.newCopyArgs(nil, argStream, clock ? TempoClock.default)
@@ -368,6 +369,7 @@ PauseStream : Stream {
 	}
 	prStop {
 		stream = nil;
+		rescheduledTime = nil;
 		isWaiting = false;
 	}
 	removedFromScheduler {
@@ -388,6 +390,18 @@ PauseStream : Stream {
 	}
 	resume { arg argClock, quant;
 		^this.play(clock ? argClock, false, quant)
+	}
+	reschedule { arg argClock, quant;
+		if(this.isPlaying.not) {
+			Error("% can't be rescheduled when idle; use 'play' instead".format(this.class.name)).throw;
+		};
+		rescheduledTime = quant.asQuant.nextTimeOnGrid(clock, this.nextBeat);
+		if(argClock.isNil) { argClock = clock };
+		if(argClock !== clock) {
+			// convert to new clock's time
+			rescheduledTime = argClock.secs2beats(clock.beats2secs(rescheduledTime));
+		};
+		clock = argClock;
 	}
 
 	refresh {
@@ -415,8 +429,15 @@ PauseStream : Stream {
 		^nextTime
 	}
 	awake { arg beats, seconds, inClock;
-		clock = inClock;
-		^this.next(beats)
+		if(rescheduledTime.isNil) {
+			clock = inClock;
+			^this.next(beats)
+		} {
+			// rescheduling, possibly on a new clock
+			clock.schedAbs(rescheduledTime, this);
+			rescheduledTime = nil;
+			^nil
+		}
 	}
 	threadPlayer { ^this }
 }

--- a/lang/LangSource/PyrKernel.h
+++ b/lang/LangSource/PyrKernel.h
@@ -110,6 +110,7 @@ struct PyrThread : public PyrObjectHdr {
     PyrSlot threadPlayer;
     PyrSlot executingPath;
     PyrSlot oldExecutingPath;
+    PyrSlot rescheduledTime;
     PyrSlot stackSize;
 };
 

--- a/lang/LangSource/PyrObject.cpp
+++ b/lang/LangSource/PyrObject.cpp
@@ -1710,6 +1710,8 @@ void initClasses() {
     addIntrinsicVar(class_thread, "executingPath", &o_nil);
     addIntrinsicVar(class_thread, "oldExecutingPath", &o_nil);
 
+    addIntrinsicVar(class_thread, "rescheduledTime", &o_nil);
+
     class_finalizer = makeIntrinsicClass(s_finalizer, s_object, 2, 0);
     addIntrinsicVar(class_finalizer, "cFunction", &o_nil);
     addIntrinsicVar(class_finalizer, "object", &o_nil);

--- a/testsuite/classlibrary/TestThreadReschedule.sc
+++ b/testsuite/classlibrary/TestThreadReschedule.sc
@@ -1,0 +1,69 @@
+TestThreadReschedule : UnitTest {
+	test_Threads_rescheduleToOtherClock {
+		var cond = Condition.new,
+		// please make sure 'tempo' is a power of two
+		// to avoid floating-point rounding errors
+		tempo = 1024,
+		// different tempi to be sure time conversion is working
+		// 0.75's denominator is also a power of two -- important for same reason
+		tempoRatio = 0.75,
+		clock1 = TempoClock.new(tempo),
+		clock2 = TempoClock.new(tempo * tempoRatio),
+		expectedBeats = [0.0, 1.0, 1.5, 2.5],
+		expectedDeltaSeconds = [tempo, tempo, tempo * tempoRatio].reciprocal,
+		threadTimes = Array(6), taskTimes = Array(6),
+		thread = Routine {
+			4.do {
+				threadTimes.add([thisThread.beats, thisThread.seconds]);
+				1.0.wait;
+			};
+		}.play(clock1),
+		task = Task {
+			4.do {
+				taskTimes.add([thisThread.clock.beats, thisThread.clock.seconds]);
+				1.0.wait;
+			};
+		}.play(clock1),
+		controlThread = Routine {
+			// For some completely bizarre and unknown reason,
+			// this first wait must be slightly longer than 1.0 beat.
+			// Without it, the order of execution is:
+			// thread, controlThread, task.
+			// ControlThread is added into the queue LAST
+			// but without this extra wait, it runs before the Task.
+			// Then the thread and the task wake up at different times
+			// relative to rescheduling.
+			// That is probably a bug in itself but outside the scope
+			// of this test.
+			1.0001.wait;  // remember 1 beat < 1 ms here
+			thread.reschedule(clock2);
+			task.reschedule(clock2);
+			// The test requires 4 data points (to measure tempo after rescheduling).
+			// So, all 3 beats are necessary. 3 beats < 3 ms.
+			3.wait;
+			cond.unhang;
+		}.play(clock1);
+		cond.hang;
+		thread.stop;
+		clock1.stop;
+		clock2.stop;
+		this.assertEquals(
+			threadTimes.flop[0], expectedBeats,
+			"Rescheduling a Routine should adjust beats for continuous seconds"
+		);
+		this.assert(
+			threadTimes.flop[1].differentiate.drop(1)
+			.fuzzyEqual(expectedDeltaSeconds, 0.00001).every(_ > 0),
+			"Tempo should be maintained before rescheduling a Routine, and change after rescheduling"
+		);
+		this.assertEquals(
+			taskTimes.flop[0], expectedBeats,
+			"Rescheduling a Task should adjust beats for continuous seconds"
+		);
+		this.assert(
+			taskTimes.flop[1].differentiate.drop(1)
+			.fuzzyEqual(expectedDeltaSeconds, 0.00001).every(_ > 0),
+			"Tempo should be maintained before rescheduling a Task, and change after rescheduling"
+		);
+	}
+}

--- a/testsuite/classlibrary/TestThreadReschedule.sc
+++ b/testsuite/classlibrary/TestThreadReschedule.sc
@@ -66,4 +66,59 @@ TestThreadReschedule : UnitTest {
 			"Tempo should be maintained before rescheduling a Task, and change after rescheduling"
 		);
 	}
+
+	test_Threads_rescheduleToOtherTime {
+		var cond = Condition.new,
+		// please make sure 'tempo' is a power of two
+		// to avoid floating-point rounding errors
+		tempo = 1024,
+		clock1 = TempoClock.new(tempo),
+		expectedBeats = [0.0, 1.0, 3.0, 4.0],
+		expectedDeltaSeconds = [1.0, 2.0, 1.0] / tempo,
+		threadTimes = Array(6), taskTimes = Array(6),
+		thread = Routine {
+			4.do {
+				threadTimes.add([thisThread.beats, thisThread.seconds]);
+				1.0.wait;
+			};
+		}.play(clock1),
+		task = Task {
+			4.do {
+				taskTimes.add([thisThread.clock.beats, thisThread.clock.seconds]);
+				1.0.wait;
+			};
+		}.play(clock1),
+		controlThread = Routine {
+			// same issue as above
+			1.0001.wait;  // remember 1 beat < 1 ms here
+			// one beat later than normal
+			thread.reschedule(quant: thisThread.beats.roundUp(1) + 1);
+			task.reschedule(quant: thisThread.beats.roundUp(1) + 1);
+			// The test requires 4 data points (to measure tempo after rescheduling).
+			// So, all 3 beats are necessary. 3 beats < 3 ms.
+			3.wait;
+			cond.unhang;
+		}.play(clock1);
+		cond.hang;
+		thread.stop;
+		clock1.stop;
+		this.assertEquals(
+			threadTimes.flop[0], expectedBeats,
+			"Rescheduling a Routine at another beat should affect wake-up times"
+		);
+		this.assert(
+			threadTimes.flop[1].differentiate.drop(1)
+			.fuzzyEqual(expectedDeltaSeconds, 0.00001).every(_ > 0),
+			"Rescheduling a Routine, delta in seconds should match beats"
+		);
+		this.assertEquals(
+			taskTimes.flop[0], expectedBeats,
+			"Rescheduling a Task at another beat should affect wake-up times"
+		);
+		this.assert(
+			taskTimes.flop[1].differentiate.drop(1)
+			.fuzzyEqual(expectedDeltaSeconds, 0.00001).every(_ > 0),
+			"Rescheduling a Task, delta in seconds should match beats"
+		);
+	}
 }


### PR DESCRIPTION
## Purpose and Motivation

New feature suggested in #4903: Make it possible to reschedule a Routine, Task or EventStreamPlayer transparently onto a different clock or to a different (later) time.

Along the way, I found out that our documentation for `nextTimeOnGrid` is quite poor. I haven't updated it yet. It's tangentially related to this PR, so I'm not sure if I should just fold it in here or make another PR. (`nextTimeOnGrid` doesn't change substantially here, except for a new `referenceBeat` argument. Default behavior is unchanged.)

(There is one unrelated documentation cleanup: Task help said that Condition could not be used within a Task. That hasn't been true for some years, so I took the liberty of removing that remark.)

## Types of changes

- Documentation
- New feature

(The `nextTimeOnGrid` third argument could be a breaking change if someone has created an extension with additional arguments for this method selector. AFAICS within the main class library, there is no breaking change.)

## To-do list

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review
