### PR TITLE
QtCollider:LangClient - event loop deadlock fix - issue #1640

### DIFF
--- a/QtCollider/LanguageClient.cpp
+++ b/QtCollider/LanguageClient.cpp
@@ -84,7 +84,11 @@ void LangClient::customEvent(QEvent* e) {
 
 void LangClient::tick() {
     double secs;
+
     lock();
+    // deadlock here indicates behaviour which likely should be avoided.
+    // e.g. calling qt event loop from primitive.
+
     bool haveNext = tickLocked(&secs);
     unlock();
 


### PR DESCRIPTION
In qt tick event handler there's potential for language deadlock with a recursive event loop call.
This fix uses trylock to bail early from handler when unable to obtain language lock.

e.g. deadlock can happen when tick called during work event handling, which is rare but possible.

Solution seems not too radical as SuperCollider appears to have precedence of this approach:

[SC_LanguageClient::tick](https://github.com/supercollider/supercollider/blob/master/lang/LangSource/SC_LanguageClient.cpp#L266)
[SCApp AppClock handler](https://github.com/supercollider/supercollider/blob/96e56b57edb66ae538bf7360901f3f3b3b451571/editors/scapp/SCVirtualMachine.M#L182)

Tested with no apparent issues on MacOS 10.14.6.


<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

Document the cause of #1640

## Types of changes

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [ ] Code is tested
- [ ] All tests are passing
- [ ] Updated documentation
- [x] This PR is ready for review
