### PR TITLE
[skip ci] readmes: include ncurses in dependencies

### DIFF
--- a/README_BEAGLEBONE_BLACK.md
+++ b/README_BEAGLEBONE_BLACK.md
@@ -41,7 +41,7 @@ ssh from your laptop by opening a terminal and typing:
     sudo apt-get upgrade
     sudo apt-get dist-upgrade
     sudo apt-get install libsamplerate0-dev libsndfile1-dev libasound2-dev libavahi-client-dev libreadline-dev \
-        libfftw3-dev libudev-dev cmake git build-essential python-dev alsa-utils cpufrequtils
+        libncurses5-dev libfftw3-dev libudev-dev cmake git build-essential python-dev alsa-utils cpufrequtils
 
 ### Step 3: Compile, install and configure jackd (no d-bus)
 

--- a/README_LINUX.md
+++ b/README_LINUX.md
@@ -36,21 +36,23 @@ For sclang and scide:
 - [libudev][libudev]: Device manager library, required for HID support.
 - [Linux kernel][Linux kernel] >= 2.6: Required for LID support.
 - [libreadline][libreadline] >= 5: Required for sclang's CLI interface.
+- [ncurses][ncurses]: Required for sclang's CLI interface.
 
 [Qt]: http://qt-project.org
 [ALSA]: http://www.alsa-project.org
 [libudev]: http://www.freedesktop.org/software/systemd/man/libudev.html
 [libreadline]: http://savannah.gnu.org/projects/readline
+[ncurses]: https://invisible-island.net/ncurses/
 [Linux kernel]: http://www.kernel.org
 [git]: https://git-scm.com/
 
 Installing requirements on Debian
 ---------------------------------
 
-There are dedicated web pages for building on particular embedded Linux platforms:
+There are dedicated READMEs in this repository for building on particular embedded Linux platforms:
 
-- [Raspberry Pi](http://supercollider.github.io/development/building-raspberrypi)
-- [BeagleBone Black](https://supercollider.github.io/development/building-beagleboneblack)
+- Raspberry Pi: README_RASPBERRY_PI.md
+- BeagleBone Black: README_BEAGLEBONE_BLACK.md
 
 On Debian-like systems, the following command installs the minimal recommended dependencies for compiling scsynth and supernova:
 
@@ -60,7 +62,7 @@ If you need to use JACK1 replace libjack-jackd2-dev by libjack-dev.
 
 The following command installs all the recommended dependencies for sclang except for Qt:
 
-    sudo apt-get install git libasound2-dev libicu-dev libreadline6-dev libudev-dev pkg-config
+    sudo apt-get install git libasound2-dev libicu-dev libreadline6-dev libudev-dev pkg-config libncurses5-dev
 
 Installing Qt
 -------------

--- a/README_RASPBERRY_PI.md
+++ b/README_RASPBERRY_PI.md
@@ -41,11 +41,11 @@ Install required libraries:
 
     # For GUI builds:
     sudo apt-get install libjack-jackd2-dev libsndfile1-dev libasound2-dev libavahi-client-dev \
-        libreadline-dev libfftw3-dev libxt-dev libudev-dev cmake qttools5-dev qttools5-dev-tools \
+        libreadline-dev libfftw3-dev libxt-dev libudev-dev libncurses5-dev cmake git qttools5-dev qttools5-dev-tools \
         qtdeclarative5-dev libqt5svg5-dev qjackctl
     # For GUI-less builds:
     sudo apt-get install libsamplerate0-dev libsndfile1-dev libasound2-dev libavahi-client-dev \
-        libreadline-dev libfftw3-dev libudev-dev cmake git
+        libreadline-dev libfftw3-dev libudev-dev libncurses5-dev cmake git
 
 ### Step 3: GUI-less builds only: compile and install jackd (no d-bus)
 


### PR DESCRIPTION
## Purpose and Motivation

ncurses is now a dependency and apparently not installed by default on some flavors of linux, so document it.

these are the right package names in debian's repos as far as i can tell. would be nice if someone can confirm.

https://packages.debian.org/jessie/libncurses5-dev

## Types of changes

- Documentation

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review