### PR TITLE
[develop] travis: fix CI error

### DIFF
--- a/editors/sc-ide/CMakeLists.txt
+++ b/editors/sc-ide/CMakeLists.txt
@@ -496,8 +496,11 @@ if(APPLE OR WIN32)
                 # but libfftw3f is not fixed up automatically when supernova is deployed.
                 string(APPEND VERIFY_CMD "
                 message(STATUS \"Fixing up bad path in libfftw3f.3.dylib manually due to faulty logic in macdeployqt\")
-                execute_process(COMMAND install_name_tool -change /usr/local/lib/gcc/9/libgcc_s.1.dylib
-                    @loader_path/libgcc_s.1.dylib ${CONTENTS_DIR}/Frameworks/libfftw3f.3.dylib)")
+                execute_process(COMMAND install_name_tool -change /usr/local/lib/gcc/0/libgcc_s.1.dylib
+                    @loader_path/libgcc_s.1.dylib ${CONTENTS_DIR}/Frameworks/libfftw3f.3.dylib)
+                execute_process(COMMAND install_name_tool -change /usr/local/lib/gcc/10/libgcc_s.1.dylib
+                    @loader_path/libgcc_s.1.dylib ${CONTENTS_DIR}/Frameworks/libfftw3f.3.dylib)
+                    ")
             endif()
         endif()
         string(APPEND VERIFY_CMD "


### PR DESCRIPTION
## Purpose and Motivation

there is a better way to do this -- parse the output of otool and use that to fixup bad paths, but since install_name_tool doesn't consider it an error if the path doesn't exist, this works for now

that more complex solution is worth implementing, but i don't have time to do it at the moment and want to keep CI running

## Types of changes

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [ ] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review