### PR TITLE
Fix args explanation SelectXFocus.schelp

### DIFF
--- a/HelpSource/Classes/SelectXFocus.schelp
+++ b/HelpSource/Classes/SelectXFocus.schelp
@@ -10,11 +10,11 @@ classmethods::
 method:: ar, kr
 
 argument:: which
-Index of the selected input, which is also the center of the selection for a focus < 1.
+Index of the selected input, which is also the center of the selection for a focus > 0.
 argument:: array
 A collection of inputs.
 argument:: focus
-The "fuzziness" of the selection: the larger the focus, the more adjacent inputs are mixed in.
+The "fuzziness" of the selection: the larger the focus, the less adjacent inputs are mixed in.
 argument:: wrap
 If set to true, index will wrap around the array of inputs (see also: link::Classes/Array#-wrapAt::).
 


### PR DESCRIPTION
'focus' arg was explained backwards.

<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

'focus' arg was explained backwards -- with focus approaching 1, less (not more) adjacent channels are mixed in.

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->

- Documentation

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x ] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review
