### PR TITLE
cmake: unquote lists (SuperColliderServerPlugin) [skip ci]

### DIFF
--- a/tools/cmake_gen/SuperColliderServerPlugin.cmake
+++ b/tools/cmake_gen/SuperColliderServerPlugin.cmake
@@ -73,10 +73,10 @@ function(sc_add_server_plugin dest_dir name cpp sc schelp)
     endif()
 
     if(sc)
-        install(FILES "${sc}" DESTINATION ${dest_dir}/Classes)
+        install(FILES ${sc} DESTINATION ${dest_dir}/Classes)
     endif()
     if(schelp)
-        install(FILES "${schelp}" DESTINATION ${dest_dir}/Help)
+        install(FILES ${schelp} DESTINATION ${dest_dir}/Help)
     endif()
 endfunction()
 


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->
Removing quotes to allow correct expansion of lists, for plugins with more than one schelp or sc file. Previous behavior caused errors on `make install`.
## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->
- [x] This PR is ready for review
