### PR TITLE
build: renderAllHelp: exclude extensions

### DIFF
--- a/platform/renderAllHelp.scd
+++ b/platform/renderAllHelp.scd
@@ -1,5 +1,4 @@
 SCDoc.helpSourceDir = thisProcess.argv[0];
 SCDoc.helpTargetDir = thisProcess.argv[1];
-SCDoc.renderAll;
+SCDoc.renderAll(includeExtensions: false);
 0.exit;
-


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

SCDoc.renderAll needs to be told explicitly to exclude extension dirs, even if sclang is run in standalone (-a) mode. renderAllHelp.scd is already meant to exclude them since its purpose is to compile Help files after building sc, using only the class library from the source tree and disabling extensions (-a flag to sclang) and startup files. 
Unfortunately for this case, SCDoc.indexAllFiles will automatically include extensions' HelpSource dirs anyway, regardless of -a (which can be better fixed after #3733 is merged). 
However, IMO it doesn't hurt to be explicit about excluding extensions in this script, which otherwise would cause errors in SCDoc.renderAll.

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review
