### PR TITLE
classlib: SCDoc: include extensionDirs only if not excluded by LanguageConfig

### DIFF
--- a/HelpSource/Classes/SCDoc.schelp
+++ b/HelpSource/Classes/SCDoc.schelp
@@ -35,9 +35,10 @@ method:: helpSourceDir
 get/set the system-wide directory of help sourcefiles. Defaults to code::Platform.classLibraryDir.dirname +/+ "HelpSource":: and should typically not be changed by the user.
 
 method:: helpSourceDirs
-get the list of HelpSource folders, including extensions and quarks.
+get the list of HelpSource folders, including extensions and quarks (unless they are excluded from library compilation, e.g. by link::Classes/LanguageConfig#*excludeDefaultPaths::)
 discussion::
-This searches recursively for all folders named "HelpSource" under code::Platform.userExtensionDir:: and code::Platform.systemExtensionDir:: as well as including the system-wide code::helpSourceDir::
+This searches recursively for all folders named "HelpSource" under link::Classes/LanguageConfig#*includePaths::, as well as including the system-wide code::helpSourceDir::.
+Unless link::Classes/LanguageConfig#*excludeDefaultPaths:: is on, code::Platform.userExtensionDir:: and code::Platform.systemExtensionDir:: are searched too.
 
 method:: findHelpFile
 Find help for a given string. Tries to be smart.
@@ -233,4 +234,3 @@ tree::
         ::
     ::
 ::
-

--- a/SCClassLibrary/SCDoc/SCDoc.sc
+++ b/SCClassLibrary/SCDoc/SCDoc.sc
@@ -462,8 +462,7 @@ SCDoc {
 		this.checkVersion(clearCache);
 		this.postMsg("Indexing help-files...",0);
 		documents = Dictionary(); // or use IdDict and symbols as keys?
-		helpSourceDirs = nil; // force re-scan of HelpSource folders
-		this.helpSourceDirs.do {|dir|
+		this.prRescanHelpSourceDirs.do {|dir|
 			PathName(dir).filesDo {|f|
 				case
 				{f.fullPath.endsWith(".ext.schelp")} {
@@ -535,6 +534,11 @@ SCDoc {
 		^documents;
 	}
 
+	*prRescanHelpSourceDirs {
+		helpSourceDirs = nil;
+		^this.helpSourceDirs;
+	}
+
 	*helpSourceDirs {
 		var find, rootPaths;
 		if(helpSourceDirs.isNil) {
@@ -549,7 +553,11 @@ SCDoc {
 					};
 				}
 			};
-			rootPaths = [thisProcess.platform.userExtensionDir, thisProcess.platform.systemExtensionDir];
+			rootPaths = if(LanguageConfig.excludeDefaultPaths) {
+				[]
+			} {
+				[thisProcess.platform.userExtensionDir, thisProcess.platform.systemExtensionDir]
+			};
 			rootPaths = rootPaths.addAll(LanguageConfig.includePaths);
 			rootPaths.do {|dir|
 				find.(PathName(dir));

--- a/testsuite/classlibrary/TestSCDoc.sc
+++ b/testsuite/classlibrary/TestSCDoc.sc
@@ -1,0 +1,23 @@
+TestSCDoc : UnitTest {
+
+    test_helpSourceDirs_excludedExtensions {
+        var result;
+        var extensionPaths = [thisProcess.platform.systemExtensionDir, thisProcess.platform.userExtensionDir];
+        var prevSetting = LanguageConfig.excludeDefaultPaths;
+        LanguageConfig.excludeDefaultPaths = true;
+        result = SCDoc.prRescanHelpSourceDirs.any { |p| extensionPaths.any { |ep| ("^"++ep).matchRegexp(p) } };
+        LanguageConfig.excludeDefaultPaths = prevSetting;
+        this.assert(result.not, "should not search for extensions' HelpSource when LanguageConfig.excludeDefaultPaths = true");
+    }
+
+    test_helpSourceDirs_includedExtensions {
+        var result;
+        var extensionPaths = [thisProcess.platform.systemExtensionDir, thisProcess.platform.userExtensionDir];
+        var prevSetting = LanguageConfig.excludeDefaultPaths;
+        LanguageConfig.excludeDefaultPaths = false;
+        result = SCDoc.prRescanHelpSourceDirs.any { |p| extensionPaths.any { |ep| ("^"++ep).matchRegexp(p) } };
+        LanguageConfig.excludeDefaultPaths = prevSetting;
+        this.assert(result, "should search for extensions' HelpSource when LanguageConfig.excludeDefaultPaths = false");
+    }
+
+}


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

This is a more proper fix for an issue encountered in #5089 (which is meant for 3.11 before #3733 is ~cherry-picked~ included in a release).
Resume: SCDoc indexes userExtensionDir and systemExtensionDir regardless of them being included or not in class library compilation. This creates an issue when compiling Help Files from renderAllHelp script, which is meant to run in a standalone (-a) sclang, but will anyway try to build help for extensions and fail because they are not part of its class library.
With #3733, it is possible to check LanguageConfig for `excludeDefaultPaths`, and include extension dirs in SCDoc.helpSourceDirs only if default paths are not excluded from the class library.

## Types of changes

<!-- Delete lines that don't apply -->

- Documentation
- Bug fix
- New feature

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review
