### PR TITLE
Help: NRT Guide: Replace Platform.defaultTempDir with PathName.tmp

### DIFF
--- a/HelpSource/Guides/Non-Realtime-Synthesis.schelp
+++ b/HelpSource/Guides/Non-Realtime-Synthesis.schelp
@@ -174,7 +174,7 @@ teletype::recordNRT:: allows you optionally to specify the path to the binary OS
 If you do not give a path, teletype::recordNRT:: will generate one for you in the system's temporary file location. These files are not automatically deleted after rendering. Some systems may automatically clean up old temporary files after some time. Otherwise, you can take it into your own hands:
 
 code::
-var oscPath = Platform.defaultTempDir +/+ "mytempscore";
+var oscPath = PathName.tmp +/+ "mytempscore";
 
 x = Score([ ... ]);
 


### PR DESCRIPTION
## Purpose and Motivation

#5093 fixed a typo in the NRT guide (`Platform.tmp` did need to be fixed).

But, I believe the correction in that PR was not the right one. It should be `PathName.tmp` and not `Platform.defaultTempDir`.

1. `PathName.tmp` appears in six other places (lines 221, 241, 446, 447, 513, 534). The occurrence that was fixed should be consistent with these (or, change all of them).

2. `Platform.defaultTempDir` is not user-configurable, while `PathName.tmp` is. I don't see a good reason here to enforce a system default. Let's use the one that the user could override if needed.

#5093 was merged almost immediately, so there was no chance for comment from people living outside the Western hemisphere.

## Types of changes

- Documentation

## To-do list

- [x] Updated documentation
- [x] This PR is ready for review
