### PR TITLE
server: added binout to SpecPcile

### DIFF
--- a/HelpSource/Classes/SpecPcile.schelp
+++ b/HelpSource/Classes/SpecPcile.schelp
@@ -10,6 +10,8 @@ For example, to find the frequency at which 90% of the spectral energy lies belo
 
 The optional third argument strong::interpolate:: specifies whether interpolation should be used to try and make the percentile frequency estimate more accurate, at the cost of a little higher CPU usage. Set it to 1 to enable this.
 
+Optional fourth argument is strong::binout:: specifies whether to output the bin number instead of the frequency (set to 1). If interpolate is enabled, parabolic interpolation on the bin number is performed.
+
 classmethods::
 method:: kr
 
@@ -17,6 +19,7 @@ argument:: buffer
 an link::Classes/FFT:: chain.
 argument:: fraction
 argument:: interpolate
+argument:: binout
 
 examples::
 

--- a/HelpSource/Classes/SpecPcile.schelp
+++ b/HelpSource/Classes/SpecPcile.schelp
@@ -8,9 +8,9 @@ Given an link::Classes/FFT:: chain this calculates the cumulative distribution o
 
 For example, to find the frequency at which 90% of the spectral energy lies below that frequency, you want the 90-percentile, which means the value of emphasis::fraction:: should be 0.9. The 90-percentile or 95-percentile is often used as a measure of strong::spectral roll-off::.
 
-The optional third argument strong::interpolate:: specifies whether interpolation should be used to try and make the percentile frequency estimate more accurate, at the cost of a little higher CPU usage. Set it to 1 to enable this.
+The optional third argument strong::interpolate:: (code::ir::) specifies whether interpolation should be used to try and make the percentile frequency estimate more accurate, at the cost of a little higher CPU usage. Set it to 1 to enable this.
 
-Optional fourth argument is strong::binout:: specifies whether to output the bin number instead of the frequency (set to 1). If interpolate is enabled, parabolic interpolation on the bin number is performed.
+Optional fourth argument is strong::binout:: (code::ir::) specifies whether to output the bin number instead of the frequency (default 0, set to 1 to enable). If interpolate is enabled, linear interpolation on the bin number is performed.
 
 classmethods::
 method:: kr

--- a/SCClassLibrary/Common/Audio/MachineListening.sc
+++ b/SCClassLibrary/Common/Audio/MachineListening.sc
@@ -88,8 +88,8 @@ SpecFlatness : UGen {
 	}
 }
 SpecPcile : UGen {
-	*kr { | buffer, fraction = 0.5, interpolate = 0 |
-		^this.multiNew('control', buffer, fraction, interpolate)
+	*kr { | buffer, fraction = 0.5, interpolate = 0 , binout = 0|
+		^this.multiNew('control', buffer, fraction, interpolate, binout)
 	}
 }
 SpecCentroid : UGen {

--- a/server/plugins/ML.h
+++ b/server/plugins/ML.h
@@ -118,6 +118,7 @@ struct SpecFlatness : FFTAnalyser_Unit {
 
 struct SpecPcile : FFTAnalyser_OutOfPlace {
     bool m_interpolate;
+    bool m_binout;
 };
 
 struct SpecCentroid : FFTAnalyser_Unit {};

--- a/server/plugins/ML_SpecStats.cpp
+++ b/server/plugins/ML_SpecStats.cpp
@@ -197,6 +197,7 @@ void SpecPcile_Ctor(SpecPcile* unit) {
     SETCALC(SpecPcile_next);
 
     unit->m_interpolate = ZIN0(2) > 0.f;
+    unit->m_binouot = ZIN0(3) > 0.f;
 
     ZOUT0(0) = unit->outval = 0.;
     unit->m_tempbuf = 0;
@@ -215,7 +216,7 @@ void SpecPcile_next(SpecPcile* unit, int inNumSamples) {
 
     // Percentile value as a fraction. eg: 0.5 == 50-percentile (median).
     float fraction = ZIN0(1);
-    bool binout = ZIN0(3); // if true, output the bin number instead of freq
+    bool binout = unit->m_binouot; // if true, output the bin number instead of freq
     bool interpolate = unit->m_interpolate;
 
     // The magnitudes in *p will be converted to cumulative sum values and stored in *q temporarily

--- a/server/plugins/ML_SpecStats.cpp
+++ b/server/plugins/ML_SpecStats.cpp
@@ -197,7 +197,7 @@ void SpecPcile_Ctor(SpecPcile* unit) {
     SETCALC(SpecPcile_next);
 
     unit->m_interpolate = ZIN0(2) > 0.f;
-    unit->m_binouot = ZIN0(3) > 0.f;
+    unit->m_binout = ZIN0(3) > 0.f;
 
     ZOUT0(0) = unit->outval = 0.;
     unit->m_tempbuf = 0;
@@ -216,7 +216,7 @@ void SpecPcile_next(SpecPcile* unit, int inNumSamples) {
 
     // Percentile value as a fraction. eg: 0.5 == 50-percentile (median).
     float fraction = ZIN0(1);
-    bool binout = unit->m_binouot; // if true, output the bin number instead of freq
+    bool binout = unit->m_binout; // if true, output the bin number instead of freq
     bool interpolate = unit->m_interpolate;
 
     // The magnitudes in *p will be converted to cumulative sum values and stored in *q temporarily


### PR DESCRIPTION
If enabled, outputs the bin number directly instead the calculated 
frequency. If interpolate is true, performs linear interpolation and 
outputs a fractional bin as a float.

<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

I needed the functionality of SpecPcile UGen but needed the bin number as opposed to the frequency. Works as expected.

## Types of changes

- Documentation
- New feature

## To-do list

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review
