### PR TITLE
Use the correct message number for n_after message in orderNodesMsg

### DIFF
--- a/SCClassLibrary/Common/Control/Node.sc
+++ b/SCClassLibrary/Common/Control/Node.sc
@@ -226,7 +226,7 @@ Node {
 	}
 
 	*orderNodesMsg { arg nodes;
-		var msg = [18]; // "/n_after"
+		var msg = [19]; // "/n_after"
 		nodes.doAdjacentPairs { |first, toMoveAfter|
 			msg = msg.add(toMoveAfter.nodeID);
 			msg = msg.add(first.nodeID);


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

The `Node.orderNodesMsg` method is supposed to order nodes from first to last (one after the other) but is sending the wrong server message which causes the node order to be reversed. It should be sending `n_after` (number 19) instead of `n_before` (number 18).

## Types of changes

- Bug fix
- Breaking change

## To-do list

- [X] Code is tested
- [X] All tests are passing
- [X] This PR is ready for review
