### PR TITLE
View:font_, change to set 'font' variable

### DIFF
--- a/SCClassLibrary/Common/GUI/Base/QView.sc
+++ b/SCClassLibrary/Common/GUI/Base/QView.sc
@@ -66,8 +66,9 @@ View : QObject {
 	}
 
 	// ----------------- properties --------------------------
-	font_ { arg font;
-		this.setProperty( \font, font );
+	font_ { arg aFont;
+		font = aFont;
+		this.setProperty( \font, aFont );
 	}
 
 	toolTip { ^this.getProperty(\toolTip) }

--- a/testsuite/classlibrary/TestView.sc
+++ b/testsuite/classlibrary/TestView.sc
@@ -1,0 +1,9 @@
+TestView : UnitTest {
+	test_View_settingFontUpdatesVariable {
+		var view = View(nil, Rect(100, 100, 100, 100));
+		var font = Font.default.pixelSize_(48);
+		view.font = font;
+		this.assertEquals(view.font, font, "aView.font should answer with the last set font");
+		view.close;
+	}
+}


### PR DESCRIPTION
## Purpose and Motivation

Fixes #5105.

Without this change, `View:font` (getter) fails with nil.

I checked other `font_` methods; they seem to be fine.

## Types of changes

- Bug fix

## To-do list

- [x] Code is tested
- [x] All tests are passing
- [ ] ~~Updated documentation~~
- [x] This PR is ready for review
