### PR TITLE
scsynth: macOS: clip values on hw out busses

### DIFF
--- a/HelpSource/Classes/ServerOptions.schelp
+++ b/HelpSource/Classes/ServerOptions.schelp
@@ -144,7 +144,8 @@ An Integer indicating the maximum number of clients which can simultaneously rec
 
 method:: safetyClipThreshold
 note:: MacOS only::
-A Float indicating a safety threshold for output values to be clipped. This is necessary on MacOSX because setting a low system volume doesn't prevent output values greater than +- 1 (which can happen by mistake, e.g. when sending a negative coefficient to a filter) to sound absolutely loud, since CoreAudio applies only a relative attenuation. Defaults to a threshold of 2.0, to save some ears and still allow some headroom. Values are clipped only before being written to hardware output busses, so although this affects inter-app routing as well (since it would use those same busses), it doesn't affect recording, which still benefits from the full 32bit float range without any clipping.
+A Float indicating a safety threshold for output values to be clipped to. This is necessary on macOS because setting a low system volume doesn't prevent output values greater than +/- 1 from sounding extremely loud, which can happen by mistake, e.g. when sending a negative coefficient to a filter. With this threshold, values are clipped just before being written to hardware output busses, which does not affect the recording. However, the signal will be affected if it's above the threshold and the sound is routed to other apps using 3rd-party software.
+Defaults to a threshold of 1.26 (ca. 2 dB), to save some ears and still allow some headroom. Setting safetyClipThreshold to code::inf::, code::0::, or a negative value, disables clipping altogether.
 
 subsection:: Other Instance Methods
 method:: asOptionsString

--- a/HelpSource/Classes/ServerOptions.schelp
+++ b/HelpSource/Classes/ServerOptions.schelp
@@ -142,6 +142,9 @@ A Boolean indicating whether the server should try to lock its memory into physi
 method:: maxLogins
 An Integer indicating the maximum number of clients which can simultaneously receive notifications from the server. When using TCP this is also the maximum number of simultaneous connections. This is also used by the language to split ranges of link::Classes/Node##Nodes::, link::Classes/Buffer##Buffers::, or link::Classes/Bus##Busses::. In multi-client situations you will need to set this to at least the number of clients you wish to allow. This must be the same in the Server instances on every client. The default is 1.
 
+method:: safetyClipThreshold
+note:: MacOS only::
+A Float indicating a safety threshold for output values to be clipped. This is necessary on MacOSX because setting a low system volume doesn't prevent output values greater than +- 1 (which can happen by mistake, e.g. when sending a negative coefficient to a filter) to sound absolutely loud, since CoreAudio applies only a relative attenuation. Defaults to a threshold of 2.0, to save some ears and still allow some headroom. Values are clipped only before being written to hardware output busses, so although this affects inter-app routing as well (since it would use those same busses), it doesn't affect recording, which still benefits from the full 32bit float range without any clipping.
 
 subsection:: Other Instance Methods
 method:: asOptionsString

--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -100,7 +100,7 @@ ServerOptions {
 				recChannels: 2,
 				recBufSize: nil,
 				bindAddress: "127.0.0.1",
-				safetyClipThreshold: 2.0,
+				safetyClipThreshold: 1.26 // ca. 2 dB
 			)
 		)
 	}
@@ -227,7 +227,7 @@ ServerOptions {
 		if (maxLogins.notNil, {
 			o = o ++ " -l " ++ maxLogins;
 		});
-		if (safetyClipThreshold.notNil, {
+		if (thisProcess.platform.name === \osx && Server.program.asString.endsWith("supernova").not && safetyClipThreshold.notNil, {
 			o = o ++ " -s " ++ safetyClipThreshold;
 		});
 		^o

--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -56,6 +56,8 @@ ServerOptions {
 
 	var <>bindAddress;
 
+	var <>safetyClipThreshold;
+
 	*initClass {
 		defaultValues = IdentityDictionary.newFrom(
 			(
@@ -98,6 +100,7 @@ ServerOptions {
 				recChannels: 2,
 				recBufSize: nil,
 				bindAddress: "127.0.0.1",
+				safetyClipThreshold: 2.0,
 			)
 		)
 	}
@@ -223,6 +226,9 @@ ServerOptions {
 		});
 		if (maxLogins.notNil, {
 			o = o ++ " -l " ++ maxLogins;
+		});
+		if (safetyClipThreshold.notNil, {
+			o = o ++ " -s " ++ safetyClipThreshold;
 		});
 		^o
 	}

--- a/include/server/ErrorMessage.hpp
+++ b/include/server/ErrorMessage.hpp
@@ -39,6 +39,11 @@
  *  02110-1301 USA
  */
 
+// PLEASE NOTE:
+// libscsynth API might change across minor versions.
+// Always make sure, when using libscsynth as a shared library, that binary and headers come from the same minor
+// version.
+
 #pragma once
 
 #include <string>

--- a/include/server/SC_OSC_Commands.h
+++ b/include/server/SC_OSC_Commands.h
@@ -18,6 +18,10 @@
     Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
 */
 
+// PLEASE NOTE:
+// libscsynth API might change across minor versions.
+// Always make sure, when using libscsynth as a shared library, that binary and headers come from the same minor
+// version.
 
 #pragma once
 

--- a/include/server/SC_WorldOptions.h
+++ b/include/server/SC_WorldOptions.h
@@ -18,6 +18,10 @@
     Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
 */
 
+// PLEASE NOTE:
+// libscsynth API might change across minor versions.
+// Always make sure, when using libscsynth as a shared library, that binary and headers come from the same minor
+// version.
 
 #pragma once
 
@@ -49,7 +53,7 @@ struct WorldOptions {
 
     bool mRealTime = true;
     bool mMemoryLocking = false;
-    float mSafetyClipThreshold = 2.0;
+    float mSafetyClipThreshold = 1.26; // ca. 2 dB
 
     const char* mNonRealTimeCmdFilename = nullptr;
     const char* mNonRealTimeInputFilename = nullptr;

--- a/include/server/SC_WorldOptions.h
+++ b/include/server/SC_WorldOptions.h
@@ -49,6 +49,7 @@ struct WorldOptions {
 
     bool mRealTime = true;
     bool mMemoryLocking = false;
+    float mSafetyClipThreshold = 2.0;
 
     const char* mNonRealTimeCmdFilename = nullptr;
     const char* mNonRealTimeInputFilename = nullptr;

--- a/server/scsynth/SC_CoreAudio.cpp
+++ b/server/scsynth/SC_CoreAudio.cpp
@@ -28,6 +28,7 @@
 #include "SC_Lib_Cintf.h"
 #include "SC_Lock.h"
 #include "SC_Time.hpp"
+#include "SC_InlineBinaryOp.h"
 #include <stdlib.h>
 #include <algorithm>
 
@@ -332,9 +333,8 @@ void Free_FromEngine_Msg(FifoMsg* inMsg) { World_Free(inMsg->mWorld, inMsg->mDat
 SC_AudioDriver::SC_AudioDriver(struct World* inWorld):
     mWorld(inWorld),
     mSampleTime(0),
-    mNumSamplesPerCallback(0)
-
-{}
+    mNumSamplesPerCallback(0),
+    mSafetyClipThreshold(2.f) {}
 
 SC_AudioDriver::~SC_AudioDriver() {
     mRunThreadFlag = false;
@@ -1375,7 +1375,7 @@ void SC_CoreAudioDriver::Run(const AudioBufferList* inInputData, AudioBufferList
                     if (nchan == 1) {
                         if (outputTouched[b] == bufCounter) {
                             for (int k = 0; k < bufFrames; ++k) {
-                                bufdata[k] = busdata[k];
+                                bufdata[k] = sc_clip2(busdata[k], mSafetyClipThreshold);
                             }
                         }
                     } else {
@@ -1383,7 +1383,7 @@ void SC_CoreAudioDriver::Run(const AudioBufferList* inInputData, AudioBufferList
                         for (int j = 0; j < minchan; ++j, busdata += bufFrames) {
                             if (outputTouched[b + j] == bufCounter) {
                                 for (int k = 0, m = j; k < bufFrames; ++k, m += nchan) {
-                                    bufdata[m] = busdata[k];
+                                    bufdata[m] = sc_clip2(busdata[k], mSafetyClipThreshold);
                                 }
                             }
                         }

--- a/server/scsynth/SC_CoreAudio.h
+++ b/server/scsynth/SC_CoreAudio.h
@@ -239,6 +239,7 @@ class SC_CoreAudioDriver : public SC_AudioDriver {
     AudioStreamBasicDescription inputStreamDesc; // info about the default device
     AudioStreamBasicDescription outputStreamDesc; // info about the default device
 
+    template <bool IsClipping>
     friend OSStatus appIOProc(AudioDeviceID inDevice, const AudioTimeStamp* inNow, const AudioBufferList* inInputData,
                               const AudioTimeStamp* inInputTime, AudioBufferList* outOutputData,
                               const AudioTimeStamp* inOutputTime, void* defptr);
@@ -247,6 +248,8 @@ class SC_CoreAudioDriver : public SC_AudioDriver {
                                         const AudioBufferList* inInputData, const AudioTimeStamp* inInputTime,
                                         AudioBufferList* outOutputData, const AudioTimeStamp* inOutputTime,
                                         void* defptr);
+
+    bool isClippingEnabled() const { return mSafetyClipThreshold > 0 && mSafetyClipThreshold < INFINITY; }
 
 protected:
     // Driver interface methods
@@ -265,6 +268,7 @@ public:
 
     bool StopStart();
 
+    template <bool IsClipping>
     void Run(const AudioBufferList* inInputData, AudioBufferList* outOutputData, int64 oscTime);
 
     bool UseInput() { return mInputDevice != kAudioDeviceUnknown; }

--- a/server/scsynth/SC_CoreAudio.h
+++ b/server/scsynth/SC_CoreAudio.h
@@ -145,6 +145,7 @@ protected:
     struct World* mWorld;
     double mOSCtoSamples;
     int mSampleTime;
+    float mSafetyClipThreshold;
 
     // Common members
     uint32 mHardwareBufferSize; // bufferSize returned by kAudioDevicePropertyBufferSize
@@ -210,6 +211,7 @@ public:
     int NumSamplesPerCallback() const { return mNumSamplesPerCallback; }
     void SetPreferredHardwareBufferFrameSize(int inSize) { mPreferredHardwareBufferFrameSize = inSize; }
     void SetPreferredSampleRate(int inRate) { mPreferredSampleRate = inRate; }
+    void SetSafetyClipThreshold(float thr) { mSafetyClipThreshold = thr; }
 
     bool SendMsgToEngine(FifoMsg& inMsg); // called by NRT thread
     bool SendMsgFromEngine(FifoMsg& inMsg);

--- a/server/scsynth/SC_World.cpp
+++ b/server/scsynth/SC_World.cpp
@@ -410,6 +410,9 @@ World* World_New(WorldOptions* inOptions) {
             hw->mAudioDriver = SC_NewAudioDriver(world);
             hw->mAudioDriver->SetPreferredHardwareBufferFrameSize(inOptions->mPreferredHardwareBufferFrameSize);
             hw->mAudioDriver->SetPreferredSampleRate(inOptions->mPreferredSampleRate);
+#ifdef __APPLE__
+            hw->mAudioDriver->SetSafetyClipThreshold(inOptions->mSafetyClipThreshold);
+#endif
 
             if (inOptions->mLoadGraphDefs) {
                 World_LoadGraphDefs(world);

--- a/server/scsynth/scsynth_main.cpp
+++ b/server/scsynth/scsynth_main.cpp
@@ -82,6 +82,8 @@ void Usage() {
              "   -N <cmd-filename> <input-filename> <output-filename> <sample-rate> <header-format> <sample-format>\n"
 #ifdef __APPLE__
              "   -s <safety-clip-threshold>          (default %d)\n"
+             "          absolute amplitude value output signals will be clipped to.\n"
+             "          Set to <= 0 or inf to completely disable output clipping.\n"
              "   -I <input-streams-enabled>\n"
              "   -O <output-streams-enabled>\n"
 #endif

--- a/server/scsynth/scsynth_main.cpp
+++ b/server/scsynth/scsynth_main.cpp
@@ -81,6 +81,7 @@ void Usage() {
              "          UDP ports never require passwords, so for security use TCP.\n"
              "   -N <cmd-filename> <input-filename> <output-filename> <sample-rate> <header-format> <sample-format>\n"
 #ifdef __APPLE__
+             "   -s <safety-clip-threshold>          (default %d)\n"
              "   -I <input-streams-enabled>\n"
              "   -O <output-streams-enabled>\n"
 #endif
@@ -111,7 +112,12 @@ void Usage() {
              defaultOptions.mPreferredHardwareBufferFrameSize, defaultOptions.mPreferredSampleRate,
              defaultOptions.mNumBuffers, defaultOptions.mMaxNodes, defaultOptions.mMaxGraphDefs,
              defaultOptions.mRealTimeMemorySize, defaultOptions.mMaxWireBufs, defaultOptions.mNumRGens,
-             defaultOptions.mRendezvous, defaultOptions.mLoadGraphDefs, defaultOptions.mMaxLogins);
+             defaultOptions.mRendezvous, defaultOptions.mLoadGraphDefs, defaultOptions.mMaxLogins
+#ifdef __APPLE__
+             ,
+             defaultOptions.mSafetyClipThreshold
+#endif
+    );
     exit(1);
 }
 
@@ -140,7 +146,8 @@ int scsynth_main(int argc, char** argv) {
     WorldOptions options;
 
     for (int i = 1; i < argc;) {
-        if (argv[i][0] != '-' || argv[i][1] == 0 || strchr("utBaioczblndpmwZrCNSDIOMHvVRUhPL", argv[i][1]) == nullptr) {
+        if (argv[i][0] != '-' || argv[i][1] == 0
+            || strchr("utBaioczblndpmwZrCNSDIOsMHvVRUhPL", argv[i][1]) == nullptr) {
             scprintf("ERROR: Invalid option %s\n", argv[i]);
             Usage();
         }
@@ -248,6 +255,10 @@ int scsynth_main(int argc, char** argv) {
             break;
         case 'M':
 #endif
+        case 's':
+            checkNumArgs(2);
+            options.mSafetyClipThreshold = atof(argv[j + 1]);
+            break;
         case 'H':
             checkNumArgs(2);
             options.mInDeviceName = argv[j + 1];


### PR DESCRIPTION
## Purpose and Motivation

Related to #4894.
Proposes a fix for CoreAudio handling of loud volumes. Since CoreAudio only applies a relative attenuation, setting a low system volume doesn't prevent output values > +- 1 from sounding absolutely loud, possibly leading to hear damage.
This PR attempts to fix it by:
- introducing a new ServerOption + cli switch: `-s safetyClipThreshold`
- clipping values between +-safetyClipThreshold when CoreAudioDriver writes out
- safetyClipThreshold defaults to 2.0 to allow some headroom and save some ears

Although clipping affects inter-app routing (as it happens through the same out busses), it doesn't affect recording.

Note: `s.options.safetyClipThreshold = inf` is valid (thx c++!) and makes clipping ineffective

## Needs discussion: cross-platform
This is initially macos only. Any consideration about making it general? I wouldn't like to have it on linux for instance, where it is not needed, but maybe it would be good to have the same behavior for all platforms?

## Types of changes

<!-- Delete lines that don't apply -->

- Documentation
- New feature
- Breaking change 
( doesn't change any interface, but introduces hard clipping on macos scsynth by default and adds a cli switch )
## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [ ] Code is tested
- [ ] All tests are passing
- [x] Updated documentation
- [ ] This PR is ready for review
