### PR TITLE
Classlib: Fix Pfindur bug where the last event could lose its Rest status

### DIFF
--- a/SCClassLibrary/Common/Streams/FilterPatterns.sc
+++ b/SCClassLibrary/Common/Streams/FilterPatterns.sc
@@ -435,7 +435,7 @@ Pfindur : FilterPattern {
 				// must always copy an event before altering it.
 				// fix delta time and yield to play the event.
 				remaining = localdur - elapsed;
-				if(inevent.isRest) { remaining = Rest(remaining) };
+				if(inevent[\delta].isRest) { remaining = Rest(remaining) };
 				inevent = inevent.copy.put(\delta, remaining).yield;
 				^cleanup.exit(inevent);
 			};

--- a/SCClassLibrary/Common/Streams/FilterPatterns.sc
+++ b/SCClassLibrary/Common/Streams/FilterPatterns.sc
@@ -425,6 +425,7 @@ Pfindur : FilterPattern {
 		var localdur = dur.value(event);
 		var stream = pattern.asStream;
 		var cleanup = EventStreamCleanup.new;
+		var remaining;
 		loop {
 			inevent = stream.next(event).asEvent ?? { ^event };
 			cleanup.update(inevent);
@@ -433,7 +434,9 @@ Pfindur : FilterPattern {
 			if (nextElapsed.roundUp(tolerance) >= localdur) {
 				// must always copy an event before altering it.
 				// fix delta time and yield to play the event.
-				inevent = inevent.copy.put(\delta, localdur - elapsed).yield;
+				remaining = localdur - elapsed;
+				if(inevent.isRest) { remaining = Rest(remaining) };
+				inevent = inevent.copy.put(\delta, remaining).yield;
 				^cleanup.exit(inevent);
 			};
 

--- a/testsuite/classlibrary/TestPattern.sc
+++ b/testsuite/classlibrary/TestPattern.sc
@@ -170,6 +170,12 @@ TestPattern : UnitTest {
 		this.assert(cleanup.functions.size == 0, "Pfset on nil stream should have no effect on a cleanup-functions set");
 	}
 
+	test_Pfindur_maintains_final_rest {
+		var stream = Pfindur(4, Pbind(\delta, Rest(4))).asStream;
+		var event = stream.next(Event.new);
+		this.assert(event.isRest, "The final event of a Pfindur, if it was originally a rest, should still be a rest");
+	}
+
 
 /*
 	test_storeArgs {


### PR DESCRIPTION
## Purpose and Motivation

When Pfindur reaches the end of its duration, it replaces the original event with a copy, where `delta` has been shortened so that the total duration matches the `Pfindur` limit.

*But* if `event[\delta]` is a Rest, then `localdur - elapsed` is not a rest -- so the event loses its `isRest` status and may play sound, even though the user pattern specified a Rest.

```supercollider
Pfindur(1, Pbind(\dur, Rest(1))).trace.play;
( 'dur': Rest(1), 'delta': 1.0 )   -- does not make sound

Pfindur(1, Pbind(\delta, Rest(1))).trace.play;
( 'delta': 1.0 )   -- does make sound
```

(It *is* valid for a pattern to specify timing using `\delta`, and it's valid for rests to be specified in a `\delta` stream -- so, Pfindur should respect that.)

## Types of changes

- Bug fix

## To-do list

- [x] Code is tested
- [x] All tests are passing
- [x] This PR is ready for review
