### PR TITLE
[Release] appveyor: undo temporary storage limit workaround to prepare for release

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -18,12 +18,6 @@ environment:
     CMAKE_CONFIGURATION: Release
     ASIO_URL: "http://www.steinberg.net/sdk_downloads/asiosdk2.3.zip"
     ASIO_ZIP: asiosdk2.3.zip
-    # XXX vvv TEMPORARY WORKAROUND DUE TO APPVEYOR ARTIFACT STORAGE LIMIT
-    AWS_ACCESS_KEY_ID:
-        secure: cUwCIb/EtpG3uAP48WylcMNxAh3yEbPNcQGPZDnh6go=
-    AWS_SECRET_ACCESS_KEY:
-        secure: 9n0lOPh/3hpwSEf1l0QySYngrgWYqplZozQ9ZJMxtDARIV5DIBn/NXttTfkh1Z3k
-    # XXX ^^^ TEMPORARY WORKAROUND DUE TO APPVEYOR ARTIFACT STORAGE LIMIT
 
     matrix:
         - QT_DIR: "C:/Qt/5.9/msvc2015"
@@ -125,52 +119,38 @@ after_build:
     }
 - ps: cd ..
 
-# XXX vvv TEMPORARY WORKAROUND DUE TO APPVEYOR ARTIFACT STORAGE LIMIT
-- ps: >-
-    If ($env:APPVEYOR_REPO_NAME -eq "supercollider/supercollider") {
-        If ([string]::IsNullOrEmpty($env:APPVEYOR_PULL_REQUEST_NUMBER)) {
-            echo "Pushing artifact to S3"
-            aws s3 cp --region us-west-2 --acl public-read --recursive --include "*" $env:APPVEYOR_BUILD_FOLDER/artifacts/ s3://supercollider/$env:S3_BUILDS_LOCATION
-            echo "S3 Build Location = $env:S3_URL"
-        }
-    }
-# XXX ^^^ TEMPORARY WORKAROUND DUE TO APPVEYOR ARTIFACT STORAGE LIMIT
+after_deploy:
+- ps: echo "S3 Build Location = $env:S3_URL"
 
+artifacts:
+    - path: artifacts
+      name: art_folder
+    - path: build\Install\*.exe
+      name: installer
+      type: File
 
-# XXX vvv TEMPORARILY DISABLED DUE TO APPVEYOR ARTIFACT STORAGE LIMIT
-#after_deploy:
-#- ps: echo "S3 Build Location = $env:S3_URL"
-#
-#artifacts:
-#    - path: artifacts
-#      name: art_folder
-#    - path: build\Install\*.exe
-#      name: installer
-#      type: File
-#
-#deploy:
-## s3 upload - every commit
-#- provider: S3
-#  access_key_id:
-#    secure: cUwCIb/EtpG3uAP48WylcMNxAh3yEbPNcQGPZDnh6go=
-#  secret_access_key:
-#    secure: 9n0lOPh/3hpwSEf1l0QySYngrgWYqplZozQ9ZJMxtDARIV5DIBn/NXttTfkh1Z3k
-#  bucket: supercollider
-#  region: us-west-2
-#  folder: $(S3_BUILDS_LOCATION)
-#  artifact: art_folder
-#  unzip: true
-#  set_public: true
-#  on:
-#    appveyor_repo_name: supercollider/supercollider
-#
-## github releases - only tags
-#- provider: GitHub
-#  description: appveyor_$(APPVEYOR_REPO_TAG_NAME)
-#  artifact: installer
-#  auth_token:
-#    secure: 6m5+IiGj/pLhiUJvZPqs7yOlSe0ttH3pklaM7w1i8ca4YRUrIKddsGTZAZo86qLx
-#  prerelease: true
-#  on:
-#    appveyor_repo_tag: true
-# XXX ^^^ TEMPORARY WORKAROUND DUE TO APPVEYOR ARTIFACT STORAGE LIMIT
+deploy:
+# s3 upload - every commit
+- provider: S3
+  access_key_id:
+    secure: cUwCIb/EtpG3uAP48WylcMNxAh3yEbPNcQGPZDnh6go=
+  secret_access_key:
+    secure: 9n0lOPh/3hpwSEf1l0QySYngrgWYqplZozQ9ZJMxtDARIV5DIBn/NXttTfkh1Z3k
+  bucket: supercollider
+  region: us-west-2
+  folder: $(S3_BUILDS_LOCATION)
+  artifact: art_folder
+  unzip: true
+  set_public: true
+  on:
+    appveyor_repo_name: supercollider/supercollider
+
+# github releases - only tags
+- provider: GitHub
+  description: appveyor_$(APPVEYOR_REPO_TAG_NAME)
+  artifact: installer
+  auth_token:
+    secure: 6m5+IiGj/pLhiUJvZPqs7yOlSe0ttH3pklaM7w1i8ca4YRUrIKddsGTZAZo86qLx
+  prerelease: true
+  on:
+    appveyor_repo_tag: true


### PR DESCRIPTION
## Purpose and Motivation

this undoes PRs #4993, #4861, and #4847, which were nice in that they allowed us to have S3-published builds but did not
have support for github releases. hopefully, by now enough stored artifacts have expired that we won't hit the
storage limit for long enough to make the release; it's nice also to have the artifacts get stored on Appveyor anyway.

## Types of changes

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review