### PR TITLE
make_release.py: add some automation for opening webpages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,10 @@ package/*.asc
 .idea
 cmake-build-*
 
+# Python/PyCharm files
+venv
+__pycache__
+
 #build directories
 /build*
 

--- a/tools/release/git_utilities.py
+++ b/tools/release/git_utilities.py
@@ -1,0 +1,62 @@
+import os
+
+from git import Repo
+from utilities import assert_step, use_directory, run
+
+class GitUtilities:
+    @staticmethod
+    def check_no_uncommitted_changes(repo: Repo) -> None:
+        assert_step(not repo.bare, "There are uncommitted changes in git")
+
+        # From https://stackoverflow.com/questions/31959425/how-to-get-staged-files-using-gitpython
+        repo_name = GitUtilities.get_repo_name(repo)
+        assert_step(len(repo.index.diff(None)) == 0, f"there are un-committed changes to {repo_name}")  # Modified
+        assert_step(len(repo.index.diff("HEAD")) == 0, f"there are staged changes to {repo_name}")  # Staged
+
+    @staticmethod
+    def check_branch_name(repo: Repo, branch_name: str) -> None:
+        repo_name = GitUtilities.get_repo_name(repo)
+        assert_step((repo.active_branch.name == branch_name), f"the {repo_name} repo is not on branch {branch_name}")
+
+    @staticmethod
+    def get_repo_name(repo: Repo) -> str:
+        repo_location = repo.working_dir
+        repo_name = os.path.basename(repo_location)
+        return repo_name
+
+    @staticmethod
+    def reset_and_clean_working_directory(project_dir: str) -> None:
+        with use_directory(project_dir):
+            # Delete untracked files:
+            # - does not delete ignored files
+            # - does not delete untracked files in new, untracked directories
+            run(["git", "clean", "-f"])
+
+            run(["git", "reset", "--hard"])
+
+    @staticmethod
+    def add_everything(directory: str) -> None:
+        with use_directory(directory):
+            run(["git", "add", "."])
+
+    @staticmethod
+    def commit_everything(directory: str, message: str) -> None:
+        with use_directory(directory):
+            run(["git", "commit", "-m", F"'{message}'"])
+
+    @staticmethod
+    def add_and_commit_everything(directory: str, message: str) -> None:
+        GitUtilities.add_everything(directory)
+        GitUtilities.commit_everything(directory, message)
+
+    @staticmethod
+    def push_active_branch_origin(directory: str) -> None:
+        repo = Repo(directory)
+        branch = repo.active_branch.name
+        repo.remote('origin').push(branch)
+
+    @staticmethod
+    def pull_active_branch_origin(directory: str) -> None:
+        repo = Repo(directory)
+        branch = repo.active_branch.name
+        repo.remote('origin').pull(branch)

--- a/tools/release/make_release.py
+++ b/tools/release/make_release.py
@@ -55,9 +55,11 @@ def main():
         "If this is a minor release, have you made the release branch?",
         "Is the repo on the current release branch?",
         ["Have all the discussions in the pinned 'x.y.z discussions' ticket been resolved?", "https://github.com/supercollider/supercollider/issues"],
-        "If this is a patch release, have all the PRs in the cherry-pick GitHub project been added to the release branch?",
+        ["If this is a patch release, have all the PRs in the cherry-pick GitHub project been added to the release branch?", "https://github.com/supercollider/supercollider/projects/"],
         "Have all the deprecations been either removed or deferred to a later release?\n      Deprecations are removed on a case-by-case basis with each minor (3.x) release.\n      Corresponding UGen and primitive code should also be removed.\n      Be careful when deprecating UGens and be considerate of alternate clients!",
         "Have all the removed deprecations been documented in the changelog?",
+        # depends on branch name
+        # https://github.com/supercollider/supercollider/blob/Version-3.11.1-rc1/README.md#platform-support
         "Have you reviewed the platform support information in the main README.md for accuracy?",
 
         "Have you updated SCVersion.txt?",
@@ -70,33 +72,46 @@ def main():
         "If this is a proper release, have you merged the current release branch into master with git merge --no-ff?",
         "Have you tagged the release?",
         "Did you create the release announcement text?",
-        "Have you created a release on GitHub?",
+        ["Have you created a release on GitHub?", "https://github.com/supercollider/supercollider/releases/new"],
         "Have you run ./package/create_source_tarball.sh -v <version> (where version is the version tag, e.g. Version-3.11.0) to create a source tarball (including submodules)?",
         "Have you optionally run the script with -s <email-or-keyid> (where email-or-keyid is a valid PGP key id of the release manager) to also create a detached PGP signature for the source tarball?",
+        # depends on release tag
+        # https://github.com/supercollider/supercollider/releases/edit/Version-3.11.1-rc1
         "Have you uploaded source tarball (and optionally detached PGP signature)?",
+        # depends on release tag
+        # https://github.com/supercollider/supercollider/releases/tag/Version-3.11.1-rc1
         "Are builds for macOS, Linux, and Windows uploaded from CI?",
         "Have you codesigned and notarized a macOS app bundle?",
+        # depends on release tag
+        # https://github.com/supercollider/supercollider/releases/edit/Version-3.11.1-rc1
         "Have you uploaded the signed macOS app bundle?",
+        # depends on release tag
+        # https://github.com/supercollider/supercollider/releases/tag/Version-3.11.1-rc1
         "Have you made sure to note known-to-work platform versions and any changes in platform support on the Github release page?",
-        "If it is a full release, did you update the website download page?",
+        ["If it is a full release, did you update the website download page?", "https://supercollider.github.io/download"],
 
         "Did you do the same for sc3-plugins?", # XXX review what does this mean
 
-        "Did you update the sc3-plugins page (the one at https://github.com/supercollider/sc3-plugins/tree/master/website)?",
-        "If it's a proper release, did you update the Wikipedia page?",
+        ["Did you update the sc3-plugins page?", "https://github.com/supercollider/sc3-plugins/tree/master/website"],
+        ["If it's a proper release, did you update the Wikipedia page?", "https://en.wikipedia.org/wiki/SuperCollider"],
 
         "Have you created the text with an abbreviated changelog for announcing?", # XXX review what does this mean
-        "Did you announce on GitHub website?",
+        ["If this is a proper release, did you announce on GitHub website?", "https://supercollider.github.io/archive"],
         "Did you announce on sc-users mailing list?",
         "Did you announce on sc-dev mailing list?",
-        "Did you announce on scsynth.org?",
+        ["Did you announce on scsynth.org?", "https://scsynth.org"],
+        # open slack client?
         "Did you announce on Slack #general?",
+        # maybe remove? or indicate optional?
         "Did you announce on Facebook group?",
+        # maybe remove? or indicate optional?
         "Did you announce on Reddit (/r/supercollider)?",
 
+        # depends on current branch
+        # https://github.com/supercollider/supercollider/compare/develop...3.11
         "If it's a beta release, did you merge the current release branch into develop? Do not merge the release branch into master yet!",
-        "If it's a proper release, did you merge master into develop?",
-            ];
+        ["If it's a proper release, did you merge master into develop?", "https://github.com/supercollider/supercollider/compare/develop...master"]
+            ]
 
     stack = deque()
     for prompt in prompts:

--- a/tools/release/make_release.py
+++ b/tools/release/make_release.py
@@ -4,6 +4,8 @@
 
 from collections import deque
 import sys
+import semantic_version
+from semantic_version import Version
 
 import utilities
 
@@ -50,7 +52,7 @@ class YesNoStageWithUrl(YesNoStage):
         return super().do()
 
 
-def main(version: str):
+def main(version: Version):
     prompts = [
         "Is the repo clean?",
         "If this is a minor release, have you made the release branch?",
@@ -128,4 +130,8 @@ if __name__ == "__main__":
         print("Usage: make_release.py <version>")
         sys.exit(1)
 
-    main(sys.argv[1])
+    if not semantic_version.validate(sys.argv[1]):
+        print("The supplied version does not comply with SemVer rules. It should be in the form x.y.z[-prerelease]")
+        sys.exit(2)
+
+    main(Version(sys.argv[1]))

--- a/tools/release/make_release.py
+++ b/tools/release/make_release.py
@@ -4,6 +4,8 @@
 
 from collections import deque
 
+import utilities
+
 def check_step(step: str) -> bool:
     print("\nCHECK: ", step)
     response = input("  Press Y OR y to continue; Anything else to Quit: ")
@@ -37,12 +39,22 @@ class YesNoStage(Stage):
         print("UNDOING:", self.prompt)
 
 
+class YesNoStageWithUrl(YesNoStage):
+    def __init__(self, prompt, url):
+        super().__init__(prompt)
+        self.url = url
+
+    def do(self) -> bool:
+        utilities.open_url(self.url)
+        return super().do()
+
+
 def main():
     prompts = [
         "Is the repo clean?",
         "If this is a minor release, have you made the release branch?",
         "Is the repo on the current release branch?",
-        "Have all the discussions in the 'x.y.z discussions' ticket been resolved?",
+        ["https://github.com/supercollider/supercollider/issues", "Have all the discussions in the 'x.y.z discussions' ticket been resolved?"],
         "If this is a patch release, have all the PRs in the cherry-pick GitHub project been added to the release branch?",
         "Have all the deprecations been either removed or deferred to a later release?\n      Deprecations are removed on a case-by-case basis with each minor (3.x) release.\n      Corresponding UGen and primitive code should also be removed.\n      Be careful when deprecating UGens and be considerate of alternate clients!",
         "Have all the removed deprecations been documented in the changelog?",
@@ -88,7 +100,11 @@ def main():
 
     stack = deque()
     for prompt in prompts:
-        stage = YesNoStage(prompt)
+        if type(prompt) == str:
+            stage = YesNoStage(prompt)
+        else:
+            stage = YesNoStageWithUrl(prompt[1], prompt[0])
+
         if stage.do():
             stack.append(stage)
         else:

--- a/tools/release/make_release.py
+++ b/tools/release/make_release.py
@@ -53,38 +53,39 @@ class YesNoStageWithUrl(YesNoStage):
 
 
 def main(version: Version):
+    release_branch_name = f'{version.major}.{version.minor}'
+    discussions_issue_title = f'{version.major}.{version.minor}.{version.patch} discussions'
+    version_tag = f'Version-{version}'
+    schelp_news_page_title = f'News in {version.major}.{version.minor}'
+
     prompts = [
         "Is the repo clean?",
         "If this is a minor release, have you made the release branch?",
         "Is the repo on the current release branch?",
-        ["Have all the discussions in the pinned 'x.y.z discussions' ticket been resolved?", "https://github.com/supercollider/supercollider/issues"],
+        [f"Have all the discussions in the pinned '{discussions_issue_title}' ticket been resolved?", "https://github.com/supercollider/supercollider/issues"],
         ["If this is a patch release, have all the PRs in the cherry-pick GitHub project been added to the release branch?", "https://github.com/supercollider/supercollider/projects/"],
         "Have all the deprecations been either removed or deferred to a later release?\n      Deprecations are removed on a case-by-case basis with each minor (3.x) release.\n      Corresponding UGen and primitive code should also be removed.\n      Be careful when deprecating UGens and be considerate of alternate clients!",
         "Have all the removed deprecations been documented in the changelog?",
-        # depends on branch name
-        # https://github.com/supercollider/supercollider/blob/3.11/README.md#platform-support
-        "Have you reviewed the platform support information in the main README.md for accuracy?",
+        ["Have you reviewed the platform support information in the main README.md for accuracy?", f"https://github.com/supercollider/supercollider/blob/{release_branch_name}/README.md#platform-support"],
 
         "Have you updated SCVersion.txt?",
         "Have you updated CHANGELOG.md with information about merged PRs?",
         "Have you updated CHANGELOG.md with information about platform support changes?",
 
-        "Have you made sure the schelp file 'News in 3.x' is up to date with the changelog by running the conversion script?", # XXX where is the script?
-        "Have you made sure HelpSource/Help.schelp points to the latest 'News in 3.x' schelp file?",
-        # depends on branch name
-        # https://github.com/supercollider/supercollider/blob/develop/CHANGELOG.md#change-log
-        "If this is a proper release, have you updated the release history in README.md?",
+        f"Have you made sure the schelp file '{schelp_news_page_title}' is up to date with the changelog by running the conversion script?", # XXX where is the script?
+        f"Have you made sure HelpSource/Help.schelp points to the latest '{schelp_news_page_title}' schelp file?",
+        ["If this is a proper release, have you updated the release history in CHANGELOG.md?", f"https://github.com/supercollider/supercollider/blob/{release_branch_name}/CHANGELOG.md#change-log"],
         "If this is a proper release, have you merged the current release branch into master with git merge --no-ff?",
         "Have you tagged the release?",
         "Did you create the release announcement text?",
         ["Have you created a release on GitHub?", "https://github.com/supercollider/supercollider/releases/new"],
-        "Have you run ./package/create_source_tarball.sh -v <version> (where version is the version tag, e.g. Version-3.11.0) to create a source tarball (including submodules)?",
+        f"Have you run ./package/create_source_tarball.sh -v {version_tag} to create a source tarball?",
         "Have you optionally run the script with -s <email-or-keyid> (where email-or-keyid is a valid PGP key id of the release manager) to also create a detached PGP signature for the source tarball?",
-        ["Have you uploaded source tarball (and optionally detached PGP signature)?", f"https://github.com/supercollider/supercollider/releases/edit/Version-{version}"],
-        ["Are builds for macOS, Linux, and Windows uploaded from CI?",f"https://github.com/supercollider/supercollider/releases/tag/Version-{version}"],
+        ["Have you uploaded source tarball (and optionally detached PGP signature)?", f"https://github.com/supercollider/supercollider/releases/edit/{version_tag}"],
+        ["Are builds for macOS, Linux, and Windows uploaded from CI?",f"https://github.com/supercollider/supercollider/releases/tag/{version_tag}"],
         "Have you codesigned and notarized a macOS app bundle?",
-        ["Have you uploaded the signed macOS app bundle?", f"https://github.com/supercollider/supercollider/releases/edit/Version-{version}"],
-        ["Have you made sure to note known-to-work platform versions and any changes in platform support on the Github release page?", f"https://github.com/supercollider/supercollider/releases/tag/Version-{version}"],
+        ["Have you uploaded the signed macOS app bundle?", f"https://github.com/supercollider/supercollider/releases/edit/{version_tag}"],
+        ["Have you made sure to note known-to-work platform versions and any changes in platform support on the Github release page?", f"https://github.com/supercollider/supercollider/releases/tag/{version_tag}"],
         ["If it is a full release, did you update the website download page?", "https://supercollider.github.io/download"],
 
         "Did you do the same for sc3-plugins?", # XXX review what does this mean
@@ -104,9 +105,7 @@ def main(version: Version):
         # maybe remove? or indicate optional?
         "Did you announce on Reddit (/r/supercollider)?",
 
-        # depends on current branch
-        # https://github.com/supercollider/supercollider/compare/develop...3.11
-        "If it's a beta release, did you merge the current release branch into develop? Do not merge the release branch into master yet!",
+        ["If it's a beta release, did you merge the current release branch into develop? Do not merge the release branch into master yet!", f"https://github.com/supercollider/supercollider/compare/develop...{release_branch_name}"],
         ["If it's a proper release, did you merge master into develop?", "https://github.com/supercollider/supercollider/compare/develop...master"]
             ]
 

--- a/tools/release/make_release.py
+++ b/tools/release/make_release.py
@@ -54,7 +54,7 @@ def main():
         "Is the repo clean?",
         "If this is a minor release, have you made the release branch?",
         "Is the repo on the current release branch?",
-        ["https://github.com/supercollider/supercollider/issues", "Have all the discussions in the 'x.y.z discussions' ticket been resolved?"],
+        ["https://github.com/supercollider/supercollider/issues", "Have all the discussions in the pinned 'x.y.z discussions' ticket been resolved?"],
         "If this is a patch release, have all the PRs in the cherry-pick GitHub project been added to the release branch?",
         "Have all the deprecations been either removed or deferred to a later release?\n      Deprecations are removed on a case-by-case basis with each minor (3.x) release.\n      Corresponding UGen and primitive code should also be removed.\n      Be careful when deprecating UGens and be considerate of alternate clients!",
         "Have all the removed deprecations been documented in the changelog?",

--- a/tools/release/make_release.py
+++ b/tools/release/make_release.py
@@ -54,7 +54,7 @@ def main():
         "Is the repo clean?",
         "If this is a minor release, have you made the release branch?",
         "Is the repo on the current release branch?",
-        ["https://github.com/supercollider/supercollider/issues", "Have all the discussions in the pinned 'x.y.z discussions' ticket been resolved?"],
+        ["Have all the discussions in the pinned 'x.y.z discussions' ticket been resolved?", "https://github.com/supercollider/supercollider/issues"],
         "If this is a patch release, have all the PRs in the cherry-pick GitHub project been added to the release branch?",
         "Have all the deprecations been either removed or deferred to a later release?\n      Deprecations are removed on a case-by-case basis with each minor (3.x) release.\n      Corresponding UGen and primitive code should also be removed.\n      Be careful when deprecating UGens and be considerate of alternate clients!",
         "Have all the removed deprecations been documented in the changelog?",
@@ -103,7 +103,7 @@ def main():
         if type(prompt) == str:
             stage = YesNoStage(prompt)
         else:
-            stage = YesNoStageWithUrl(prompt[1], prompt[0])
+            stage = YesNoStageWithUrl(prompt[0], prompt[1])
 
         if stage.do():
             stack.append(stage)

--- a/tools/release/make_release.py
+++ b/tools/release/make_release.py
@@ -63,6 +63,8 @@ def main():
         "Have you optionally run the script with -s <email-or-keyid> (where email-or-keyid is a valid PGP key id of the release manager) to also create a detached PGP signature for the source tarball?",
         "Have you uploaded source tarball (and optionally detached PGP signature)?",
         "Are builds for macOS, Linux, and Windows uploaded from CI?",
+        "Have you codesigned and notarized a macOS app bundle?",
+        "Have you uploaded the signed macOS app bundle?",
         "Have you made sure to note known-to-work platform versions and any changes in platform support on the Github release page?",
         "If it is a full release, did you update the website download page?",
 

--- a/tools/release/make_release.py
+++ b/tools/release/make_release.py
@@ -3,6 +3,7 @@
 # This script provides an automated checklist for running through all the steps required for a release.
 
 from collections import deque
+import sys
 
 import utilities
 
@@ -49,7 +50,7 @@ class YesNoStageWithUrl(YesNoStage):
         return super().do()
 
 
-def main():
+def main(version: str):
     prompts = [
         "Is the repo clean?",
         "If this is a minor release, have you made the release branch?",
@@ -59,7 +60,7 @@ def main():
         "Have all the deprecations been either removed or deferred to a later release?\n      Deprecations are removed on a case-by-case basis with each minor (3.x) release.\n      Corresponding UGen and primitive code should also be removed.\n      Be careful when deprecating UGens and be considerate of alternate clients!",
         "Have all the removed deprecations been documented in the changelog?",
         # depends on branch name
-        # https://github.com/supercollider/supercollider/blob/Version-3.11.1-rc1/README.md#platform-support
+        # https://github.com/supercollider/supercollider/blob/3.11/README.md#platform-support
         "Have you reviewed the platform support information in the main README.md for accuracy?",
 
         "Have you updated SCVersion.txt?",
@@ -68,6 +69,8 @@ def main():
 
         "Have you made sure the schelp file 'News in 3.x' is up to date with the changelog by running the conversion script?", # XXX where is the script?
         "Have you made sure HelpSource/Help.schelp points to the latest 'News in 3.x' schelp file?",
+        # depends on branch name
+        # https://github.com/supercollider/supercollider/blob/develop/CHANGELOG.md#change-log
         "If this is a proper release, have you updated the release history in README.md?",
         "If this is a proper release, have you merged the current release branch into master with git merge --no-ff?",
         "Have you tagged the release?",
@@ -75,24 +78,16 @@ def main():
         ["Have you created a release on GitHub?", "https://github.com/supercollider/supercollider/releases/new"],
         "Have you run ./package/create_source_tarball.sh -v <version> (where version is the version tag, e.g. Version-3.11.0) to create a source tarball (including submodules)?",
         "Have you optionally run the script with -s <email-or-keyid> (where email-or-keyid is a valid PGP key id of the release manager) to also create a detached PGP signature for the source tarball?",
-        # depends on release tag
-        # https://github.com/supercollider/supercollider/releases/edit/Version-3.11.1-rc1
-        "Have you uploaded source tarball (and optionally detached PGP signature)?",
-        # depends on release tag
-        # https://github.com/supercollider/supercollider/releases/tag/Version-3.11.1-rc1
-        "Are builds for macOS, Linux, and Windows uploaded from CI?",
+        ["Have you uploaded source tarball (and optionally detached PGP signature)?", f"https://github.com/supercollider/supercollider/releases/edit/Version-{version}"],
+        ["Are builds for macOS, Linux, and Windows uploaded from CI?",f"https://github.com/supercollider/supercollider/releases/tag/Version-{version}"],
         "Have you codesigned and notarized a macOS app bundle?",
-        # depends on release tag
-        # https://github.com/supercollider/supercollider/releases/edit/Version-3.11.1-rc1
-        "Have you uploaded the signed macOS app bundle?",
-        # depends on release tag
-        # https://github.com/supercollider/supercollider/releases/tag/Version-3.11.1-rc1
-        "Have you made sure to note known-to-work platform versions and any changes in platform support on the Github release page?",
+        ["Have you uploaded the signed macOS app bundle?", f"https://github.com/supercollider/supercollider/releases/edit/Version-{version}"],
+        ["Have you made sure to note known-to-work platform versions and any changes in platform support on the Github release page?", f"https://github.com/supercollider/supercollider/releases/tag/Version-{version}"],
         ["If it is a full release, did you update the website download page?", "https://supercollider.github.io/download"],
 
         "Did you do the same for sc3-plugins?", # XXX review what does this mean
 
-        ["Did you update the sc3-plugins page?", "https://github.com/supercollider/sc3-plugins/tree/master/website"],
+        ["Did you update the sc3-plugins page?", "https://supercollider.github.io/sc3-plugins/"],
         ["If it's a proper release, did you update the Wikipedia page?", "https://en.wikipedia.org/wiki/SuperCollider"],
 
         "Have you created the text with an abbreviated changelog for announcing?", # XXX review what does this mean
@@ -103,7 +98,7 @@ def main():
         # open slack client?
         "Did you announce on Slack #general?",
         # maybe remove? or indicate optional?
-        "Did you announce on Facebook group?",
+        ["Did you announce on Facebook group?", "https://www.facebook.com/groups/2222754532"],
         # maybe remove? or indicate optional?
         "Did you announce on Reddit (/r/supercollider)?",
 
@@ -129,4 +124,8 @@ def main():
             break
 
 if __name__ == "__main__":
-    main()
+    if len(sys.argv) != 2:
+        print("Usage: make_release.py <version>")
+        sys.exit(1)
+
+    main(sys.argv[1])

--- a/tools/release/requirements.txt
+++ b/tools/release/requirements.txt
@@ -1,0 +1,2 @@
+GitPython
+PyGithub

--- a/tools/release/requirements.txt
+++ b/tools/release/requirements.txt
@@ -1,2 +1,3 @@
 GitPython
 PyGithub
+semantic_version

--- a/tools/release/utilities.py
+++ b/tools/release/utilities.py
@@ -22,6 +22,10 @@ def read_file(file_name: str) -> str:
     return text
 
 
+def open_url(url: str) -> None:
+    run(['open', url])
+
+
 def read_url(url: str) -> str:
     file = urllib.request.urlopen(url)
     text = ''

--- a/tools/release/utilities.py
+++ b/tools/release/utilities.py
@@ -1,0 +1,109 @@
+import os
+import subprocess
+import hashlib
+import urllib.request, urllib.error
+
+from typing import Callable, List, Any
+
+
+def run(command: List[str]) -> None:
+    print(command)
+    subprocess.run(" ".join(command), shell=True, check=True)
+
+
+def write_file(file_name: str, text: str) -> None:
+    with open(file_name, 'w') as output:
+        output.write(text)
+
+
+def read_file(file_name: str) -> str:
+    with open(file_name) as input:
+        text = input.read()
+    return text
+
+
+def read_url(url: str) -> str:
+    file = urllib.request.urlopen(url)
+    text = ''
+    for line in file:
+        decoded_line = line.decode("utf-8")
+        text += decoded_line
+    return text
+
+
+def check_url_exists(url: str) -> bool:
+    try:
+        conn = urllib.request.urlopen(url)
+    except urllib.error.HTTPError as e:
+        # Return code error (e.g. 404, 501, ...)
+        return False
+    except urllib.error.URLError as e:
+        # Not an HTTP-specific error (e.g. connection refused)
+        return False
+    else:
+        # 200
+        return True
+
+
+def get_file_name(path: str) -> str:
+    return os.path.split(path)[1]
+
+pushstack = list()
+
+
+def pushdir(dirname: str) -> None:
+    global pushstack
+    pushstack.append(os.getcwd())
+    os.chdir(dirname)
+
+
+def popdir() -> None:
+    global pushstack
+    os.chdir(pushstack.pop())
+
+
+def use_directory(dir: str) -> Any: # work around for nested class
+    class PushPopDirectory:
+        def __init__(self, dir: str) -> None:
+            self.dir = dir
+
+        def __enter__(self) -> None:
+            pushdir(dir)
+
+        def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+            popdir()
+    return PushPopDirectory(dir)
+
+
+def replace_text_in_file(file_name: str, old_text: str, new_text: str) -> None:
+    text = read_file(file_name)
+    text = text.replace(old_text, new_text)
+    write_file(file_name, text)
+
+
+def calculate_sha256(file_name: str) -> str:
+    with open(file_name, "rb") as f:
+        bytes = f.read()  # read entire file as bytes
+        readable_hash = hashlib.sha256(bytes).hexdigest()
+        # print(readable_hash)
+        return readable_hash
+
+
+# condition should be an Expression
+def assert_step(condition: bool, message:str = "") -> None:
+    assert condition, message
+
+
+def check_step(step: str) -> None:
+    def do_nothing() -> None:
+        pass
+    check_step_with_revert(step, do_nothing)
+
+
+def check_step_with_revert(step: str, revert_function: Callable) -> None:
+    print("\nCHECK: ", step)
+    response = input("  Press Y OR y to continue; Anything else to Quit: ")
+    if response not in ['Y', 'y']:
+        revert_function()
+        exit(0)
+    print('---------------------------------------------------------------')


### PR DESCRIPTION
## Purpose and Motivation

working toward #4974. this is the result of working with @claremacrae  this morning, thanks Clare!

added the following:
- `YesNoStageWithUrl`: same as `YesNoStage`, but opens a URL in a web browser
- copied over some helpful utility files from ApprovalTests.cpp's automation scripting
- added a requirements file with 3 packages
- added command-line option for the new version number
- add some stages and reword some stages based on experience with last release
- we're git-ignoring 'venv' and '__pycache__' directories now since those were generated by pycharm while working on this

Clare, for handling versioning logic i found and used the semantic_version package. it seems to work well with the
kind of version strings we use, and it's less code we need to test, what do you think?

## Types of changes

- New feature

## To-do list

- [x] Code is tested - ran and tested locally
- [x] All tests are passing
- [x] Updated documentation - updated wiki documentation. once this code becomes more stable i would like to add a
  readme
- [x] This PR is ready for review