### PR TITLE
Help: [skip ci] Using MIDI guide: Explain MIDIFunc/MIDIdef filtering

### DIFF
--- a/HelpSource/Classes/MIDIFunc.schelp
+++ b/HelpSource/Classes/MIDIFunc.schelp
@@ -33,7 +33,7 @@ argument:: msgType
 A link::Classes/Symbol:: indicating which kind of MIDI message this MIDIFunc should respond to. One of code::\noteOn::, code::\noteOff::, code::\control::, code::\touch::, code::\polytouch::, code::\bend::, code::\program::, code::\sysex::, code::\mtcQF::, code::\smpte::, code::\songPosition::, code::\songSelect::, code::\tuneRequest::, code::\midiClock::, code::\sysrt::, code::\tick::, code::\start::, code::\continue::, code::\stop::, code::\activeSense::, or code::\reset::.
 
 argument:: srcID
-An link::Classes/Integer:: corresponding to the uid of the MIDI input. (See link::Classes/MIDIClient::.) If nil, the MIDIFunc will respond to messages received from all sources.
+An link::Classes/Integer:: corresponding to the uid of the MIDI input. (See link::Guides/UsingMIDI#MIDIFunc and MIDIdef: Filtering based on device or message data::.) If nil, the MIDIFunc will respond to messages received from all sources.
 
 argument:: argTemplate
 An optional link::Classes/Integer:: or link::Classes/Function:: (or object which responds to the method link::Overviews/Methods#matchItem::) used to match the value of an incoming MIDI message. (e.g. velocity, control value, program number, etc.). If a Function, it will be evaluated with the message value as an argument, and should return a link::Classes/Boolean:: indicating whether the message matches and this MIDIFunc should respond.

--- a/HelpSource/Classes/MIDIdef.schelp
+++ b/HelpSource/Classes/MIDIdef.schelp
@@ -36,7 +36,7 @@ argument:: msgType
 A link::Classes/Symbol:: indicating which kind of MIDI message this MIDIdef should respond to. One of code::\noteOn::, code::\noteOff::, code::\control::, code::\touch::, code::\polytouch::, code::\bend::, code::\program::, code::\sysex::, code::\mtcQF::, code::\smpte::, code::\songPosition::, code::\songSelect::, code::\tuneRequest::, code::\midiClock::, code::\sysrt::, code::\tick::, code::\start::, code::\continue::, code::\stop::, code::\activeSense::, or code::\reset::.
 
 argument:: srcID
-An link::Classes/Integer:: corresponding to the uid of the MIDI input. (See link::Classes/MIDIClient::.) If nil, the MIDIdef will respond to messages received from all sources.
+An link::Classes/Integer:: corresponding to the uid of the MIDI input. (See link::Guides/UsingMIDI#MIDIFunc and MIDIdef: Filtering based on device or message data::.) If nil, the MIDIdef will respond to messages received from all sources.
 
 argument:: argTemplate
 An optional link::Classes/Integer:: or link::Classes/Function:: (or object which responds to the method link::Overviews/Methods#matchItem::) used to match the value of an incoming MIDI message. (e.g. velocity, control value, program number, etc.). If a Function, it will be evaluated with the message value as an argument, and should return a link::Classes/Boolean:: indicating whether the message matches and this MIDIdef should respond.

--- a/HelpSource/Guides/UsingMIDI.schelp
+++ b/HelpSource/Guides/UsingMIDI.schelp
@@ -34,7 +34,7 @@ subsection:: MIDIFunc and MIDIdef: Filtering based on device or message data
 
 MIDIFunc and MIDIdef can filter incoming messages, responding to specific devices, MIDI channels or data values. For example, you may want one MIDIFunc to handle controller 1, while a different MIDIFunc handles controller 7.
 
-Filters are set by the argument immediately following the response function: code::MIDIFunc.incomingType({ ... function ... }, msgNum, chan, srcID):: where the meaning of msgNum depends on the message type.
+Filters are set by the argument immediately following the response function: code::MIDIFunc.incomingType({ /* function */ }, msgNum, chan, srcID):: where the meaning of msgNum depends on the message type.
 
 definitionlist::
 ## msgNum || The first data byte of the message. Note on/off messages send code::note_number velocity::; code::msgNum:: is the note number. Continuous controllers send code::cc_number value::; code::msgNum:: is the CC number. Check the specific message type for details.

--- a/HelpSource/Guides/UsingMIDI.schelp
+++ b/HelpSource/Guides/UsingMIDI.schelp
@@ -30,6 +30,20 @@ link::Classes/MIDIFunc:: has a number of convenience methods allowing you to reg
 
 See link::#Playing notes on your MIDI keyboard:: below for a simple example using the note-on and note-off MIDIFuncs.
 
+subsection:: MIDIFunc and MIDIdef: Filtering based on device or message data
+
+MIDIFunc and MIDIdef can filter incoming messages, responding to specific devices, MIDI channels or data values. For example, you may want one MIDIFunc to handle controller 1, while a different MIDIFunc handles controller 7.
+
+Filters are set by the argument immediately following the response function: code::MIDIFunc.incomingType({ ... function ... }, msgNum, chan, srcID):: where the meaning of msgNum depends on the message type.
+
+definitionlist::
+## msgNum || The first data byte of the message. Note on/off messages send code::note_number velocity::; code::msgNum:: is the note number. Continuous controllers send code::cc_number value::; code::msgNum:: is the CC number. Check the specific message type for details.
+## chan || The channel number. Most MIDI devices and software refer to channels 1-16. SuperCollider uses channels 0-15. In SuperCollider, you usually have to subtract 1 from the channel number set in the sending device.
+## srcID || The UID (unique identifier) of the MIDI port. This is set by the system, and is available through the link::Classes/MIDIEndPoint:: objects in the array code::MIDIClient.sources::. (For MIDI input, use code::MIDIClient.sources::, not code::destinations::.) If you know the device's array index, you can set code::srcID: MIDIClient.sources[index].uid::. If you know the device's name, you can search the array for a matching MIDIEndPoint first: code::srcID: MIDIClient.sources.detect { |e| e.device.containsi("searchstring") }.uid::.
+::
+
+Any filters that are omitted will match all values -- e.g., for an omni-channel responder, simply leave out a code::chan:: filter.
+
 subsection:: MIDIIn
 
 MIDIIn has a number of class variables holding functions to be evaluated when a MIDI event comes in. Technical details on each function can be found in the link::Classes/MIDIIn:: help file.


### PR DESCRIPTION
## Purpose and Motivation

MIDIFunc help for srcID directs the user to the `MIDIClient` help file, which... doesn't explain MIDIEndPoints or UIDs at all.

Just had a thread on the user forum where it was not clear how to use this parameter.

## Types of changes

- Documentation

## To-do list

- [x] Updated documentation
- [x] This PR is ready for review
