### PR TITLE
Help: [skip ci] Getting Started should model correct use of 'out' arg

### DIFF
--- a/HelpSource/Tutorials/Getting-Started/10-SynthDefs-and-Synths.schelp
+++ b/HelpSource/Tutorials/Getting-Started/10-SynthDefs-and-Synths.schelp
@@ -32,10 +32,12 @@ code::
 { SinOsc.ar(440, 0, 0.2) }.play;
 
 // now here's an equivalent SynthDef
-SynthDef.new("tutorial-SinOsc", { Out.ar(0, SinOsc.ar(440, 0, 0.2)) }).play;
+SynthDef.new("tutorial-SinOsc", { |out| Out.ar(out, SinOsc.ar(440, 0, 0.2)) }).play;
 ::
 
 SynthDef-new takes a number of arguments. The first is a name, usually in the form of a String as above. The second is in fact a Function. This argument is called a UGen Graph Function, as it tells the server how to connect together its various UGens.
+
+note:: Within the function braces, the code::|out|:: argument defines a SynthDef emphasis::control input::, which is then used as the first input to code::Out.ar::. It is a good habit to provide an code::out:: control in every SynthDef. Review link::Tutorials/Getting-Started/04-Functions-and-Other-Functionality:: for more about function arguments. ::
 
 section::SynthDefs vs. Functions
 
@@ -43,13 +45,14 @@ This UGen Graph Function we used in the second example above is similar to the F
 
 Out takes two arguments: The first is the index number of the bus to write out on. These start from 0, which on a stereo setup is usually the left output channel. The second is either a UGen or an Array of UGens. If you provide an array (i.e. a multichannel output) then the first channel will be played out on the bus with the indicated index, the second channel on the bus with the indicated index + 1, and so on.
 
-Here's a stereo example to make clear how this works. The SinOsc with the frequency argument of 440 Hz will be played out on bus 0 (the left channel), and the SinOsc with the frequency argument of 442 Hz will be played out on bus 1 (the right channel).
+Here's a stereo example to make clear how this works. The SinOsc with the frequency argument of 440 Hz will be played out on the first output bus (the left channel), and the SinOsc with the frequency argument of 442 Hz will be played out on the second bus (the right channel). By default, code::out:: assumes bus 0 as the first channel, so the two will play on buses 0 and 1 respectively.
 
 code::
 (
-SynthDef.new("tutorial-SinOsc-stereo", { var outArray;
+SynthDef.new("tutorial-SinOsc-stereo", { |out|
+	var outArray;
 	outArray = [SinOsc.ar(440, 0, 0.2), SinOsc.ar(442, 0, 0.2)];
-	Out.ar(0, outArray)
+	Out.ar(out, outArray)
 }).play;
 )
 ::
@@ -60,7 +63,7 @@ Both Function-play and SynthDef-play return another type of object, a Synth, whi
 
 code::
 x = { SinOsc.ar(660, 0, 0.2) }.play;
-y = SynthDef.new("tutorial-SinOsc", { Out.ar(0, SinOsc.ar(440, 0, 0.2)) }).play;
+y = SynthDef.new("tutorial-SinOsc", { |out| Out.ar(out, SinOsc.ar(440, 0, 0.2)) }).play;
 x.free;	// free just x
 y.free;	// free just y
 ::
@@ -71,7 +74,7 @@ More often, you will want to send the corresponding byte code to the server app 
 
 code::
 // execute first, by itself
-SynthDef.new("tutorial-PinkNoise", { Out.ar(0, PinkNoise.ar(0.3)) }).add;
+SynthDef.new("tutorial-PinkNoise", { |out| Out.ar(out, PinkNoise.ar(0.3)) }).add;
 
 // then:
 x = Synth.new("tutorial-PinkNoise");
@@ -92,7 +95,7 @@ z = f.play;
 x.free; y.free; z.free;
 
 // Now with a SynthDef. No randomness!
-SynthDef("tutorial-NoRand", { Out.ar(0, SinOsc.ar(440 + 200.rand, 0, 0.2)) }).add;
+SynthDef("tutorial-NoRand", { |out| Out.ar(out, SinOsc.ar(440 + 200.rand, 0, 0.2)) }).add;
 x = Synth("tutorial-NoRand");
 y = Synth("tutorial-NoRand");
 z = Synth("tutorial-NoRand");
@@ -107,7 +110,7 @@ There are numerous ways of getting variety out of SynthDefs, however. Some thing
 
 code::
 // With Rand, it works!
-SynthDef("tutorial-Rand", { Out.ar(0, SinOsc.ar(Rand(440, 660), 0, 0.2)) }).add;
+SynthDef("tutorial-Rand", { |out| Out.ar(out, SinOsc.ar(Rand(440, 660), 0, 0.2)) }).add;
 x = Synth("tutorial-Rand");
 y = Synth("tutorial-Rand");
 z = Synth("tutorial-Rand");

--- a/HelpSource/Tutorials/Getting-Started/11-Busses.schelp
+++ b/HelpSource/Tutorials/Getting-Started/11-Busses.schelp
@@ -32,10 +32,10 @@ In and Out also have 'kr' methods, which will read and write control rate signal
 
 code::
 // This throws an error. Can't write a control rate signal to an audio rate bus
-{Out.ar(0, SinOsc.kr)}.play;
+{ |out| Out.ar(out, SinOsc.kr) }.play;
 
 // This will work as the audio rate signal is downsampled to control rate
-{Out.kr(0, SinOsc.ar)}.scope;
+{ |out| Out.kr(out, SinOsc.ar) }.scope;
 ::
 
 (This limitation is not universal amongst audio rate UGens, however, and most will accept control rate signals for some or all of their arguments. Some will even convert control rate inputs to audio rate if needed, filling in the extra values through a process called interpolation.)
@@ -68,9 +68,10 @@ You may be wondering what a 'two channel' bus is, since we haven't mentioned the
 
 code::
 (
-SynthDef.new("tutorial-SinOsc-stereo", { var outArray;
+SynthDef.new("tutorial-SinOsc-stereo", { |out|
+	var outArray;
 	outArray = [SinOsc.ar(440, 0, 0.2), SinOsc.ar(442, 0, 0.2)];
-	Out.ar(0, outArray); // writes to busses 0 and 1
+	Out.ar(out, outArray); // writes to busses 0 and 1
 }).play;
 )
 ::
@@ -111,9 +112,9 @@ So here are two examples using busses. The first is with a control rate bus.
 
 code::
 (
-SynthDef("tutorial-Infreq", { arg bus, freqOffset = 0;
+SynthDef("tutorial-Infreq", { arg bus, freqOffset = 0, out;
 	// this will add freqOffset to whatever is read in from the bus
-	Out.ar(0, SinOsc.ar(In.kr(bus) + freqOffset, 0, 0.5));
+	Out.ar(out, SinOsc.ar(In.kr(bus) + freqOffset, 0, 0.5));
 }).add;
 
 SynthDef("tutorial-Outfreq", { arg freq = 400, bus;
@@ -202,8 +203,8 @@ code::
 b = Bus.control(s, 1); b.set(880);
 c = Bus.control(s, 1); c.set(884);
 // and make a synth with two frequency arguments
-x = SynthDef("tutorial-map", { arg freq1 = 440, freq2 = 440;
-	Out.ar(0, SinOsc.ar([freq1, freq2], 0, 0.1));
+x = SynthDef("tutorial-map", { arg freq1 = 440, freq2 = 440, out;
+	Out.ar(out, SinOsc.ar([freq1, freq2], 0, 0.1));
 }).play(s);
 )
 // Now map freq1 and freq2 to read from the two busses

--- a/HelpSource/Tutorials/Getting-Started/15-Sequencing-with-Routines-and-Tasks.schelp
+++ b/HelpSource/Tutorials/Getting-Started/15-Sequencing-with-Routines-and-Tasks.schelp
@@ -54,10 +54,10 @@ Now let's replace the posting statements with instructions to play a synth. Prep
 
 code::
 (
-SynthDef(\singrain, { |freq = 440, amp = 0.2, sustain = 1|
+SynthDef(\singrain, { |freq = 440, amp = 0.2, sustain = 1, out|
 	var sig;
 	sig = SinOsc.ar(freq, 0, amp) * EnvGen.kr(Env.perc(0.01, sustain), doneAction: Done.freeSelf);
-	Out.ar(0, sig ! 2);	// sig ! 2 is the same as [sig, sig]
+	Out.ar(out, sig ! 2);	// sig ! 2 is the same as [sig, sig]
 }).add;
 
 r = Routine({
@@ -172,10 +172,10 @@ dur = Routine({
 	[2, 2, 1, 0.5, 0.5, 1, 1, 2, 2, 3].do({ |dur| dur.yield });
 });
 
-SynthDef(\smooth, { |freq = 440, sustain = 1, amp = 0.5|
+SynthDef(\smooth, { |freq = 440, sustain = 1, amp = 0.5, out|
 	var sig;
 	sig = SinOsc.ar(freq, 0, amp) * EnvGen.kr(Env.linen(0.05, sustain, 0.1), doneAction: Done.freeSelf);
-	Out.ar(0, sig ! 2)
+	Out.ar(out, sig ! 2)
 }).add;
 
 r = Task({


### PR DESCRIPTION
## Purpose and Motivation

Just saw a question on Facebook where a new user had hardcoded bus 0 into a SynthDef, and then used a feature that assumes the bus will not be hardcoded.

Since the question was coming from a user who had just started, I wondered if our tutorial series was pointing in the right direction about bus usage.

It doesn't. The tutorials throughout write `Out.ar(0, ...)`.

This PR replaces all of those with `out` arguments (following the convention used throughout the class library).

I can understand why we wanted the tutorial series to start in the simplest possible place. But the question this morning reveals also that users extrapolate principles from our code examples. So I'm proposing this in the interest of improving the code models we give to beginning users.

## Types of changes

- Documentation

## To-do list

- [x] Updated documentation
- [x] This PR is ready for review