### PR TITLE
Disallow maxLogins > 32

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,8 @@ Release dates of 3.x versions:
 - 3.10: 2018-11-24
 - 3.11: 2020-03-08
 
-3.11.1 (TBA)
-============
+3.11.1 (2020-08-19)
+===================
 
 This version of SuperCollider now supports Fedora 32 and Ubuntu 20.04. See README.md or
 [the wiki](https://github.com/supercollider/supercollider/wiki/Platform-Support) for more information on the full set of

--- a/HelpSource/Classes/ServerOptions.schelp
+++ b/HelpSource/Classes/ServerOptions.schelp
@@ -138,7 +138,7 @@ method:: memoryLocking
 A Boolean indicating whether the server should try to lock its memory into physical RAM. Default is code::false::.
 
 method:: maxLogins
-An Integer indicating the maximum number of clients which can simultaneously receive notifications from the server. When using TCP this is also the maximum number of simultaneous connections. This is also used by the language to split ranges of link::Classes/Node##Nodes::, link::Classes/Buffer##Buffers::, or link::Classes/Bus##Busses::. In multi-client situations you will need to set this to at least the number of clients you wish to allow. This must be the same in the Server instances on every client. The default is 1.
+An Integer indicating the maximum number of clients which can simultaneously receive notifications from the server. When using TCP this is also the maximum number of simultaneous connections. This is also used by the language to split ranges of link::Classes/Node##Nodes::, link::Classes/Buffer##Buffers::, or link::Classes/Bus##Busses::. In multi-client situations you will need to set this to at least the number of clients you wish to allow. This must be the same in the Server instances on every client. The default is 1. The maximum is 32.
 
 
 subsection:: Other Instance Methods

--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -47,7 +47,7 @@ ServerOptions {
 	var <>reservedNumBuffers;
 	var <>pingsBeforeConsideredDead;
 
-	var <>maxLogins;
+	var <maxLogins;
 
 	var <>recHeaderFormat;
 	var <>recSampleFormat;
@@ -258,6 +258,13 @@ ServerOptions {
 
 	recalcChannels {
 		numAudioBusChannels = numPrivateAudioBusChannels + numInputBusChannels + numOutputBusChannels;
+	}
+
+	maxLogins_ { |logins|
+		if(logins > 32) {
+			Error("maxLogins should be <= 32, tried to set to " ++ logins).throw;
+		};
+		maxLogins = logins;
 	}
 
 	*prListDevices {

--- a/SCVersion.txt
+++ b/SCVersion.txt
@@ -4,7 +4,7 @@
 set(SC_VERSION_MAJOR 3)
 set(SC_VERSION_MINOR 11)
 set(SC_VERSION_PATCH 1)
-set(SC_VERSION_TWEAK "-rc1")
+set(SC_VERSION_TWEAK "")
 set(SC_VERSION ${SC_VERSION_MAJOR}.${SC_VERSION_MINOR}.${SC_VERSION_PATCH}${SC_VERSION_TWEAK})
 
 # Note: these are provided for backwards compatibility only. In the main project, PROJECT_VERSION_PATCH


### PR DESCRIPTION
## Purpose and Motivation

Seen in a sc-forum thread (https://scsynth.org/t/how-do-i-connect-sclang-to-an-already-running-server/2498):

```supercollider
o = ServerOptions.new;
o.maxLogins = 100;
```

Currently ServerOptions allows this to be set. But, NodeIDAllocator doesn't allow a clientID >= 32 (https://github.com/supercollider/supercollider/blob/develop/SCClassLibrary/Common/Control/Engine.sc#L8) -- clientID may be 0-31. So maxLogins should never exceed 32.

We should validate this in ServerOptions.

I also added a short sentence to ServerOptions help.

## Types of changes

- Bug fix

## To-do list

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review
