### PR TITLE
Classlib/Help: Raise maximum number of Buffer:getn/setn values

### DIFF
--- a/HelpSource/Classes/Buffer.schelp
+++ b/HelpSource/Classes/Buffer.schelp
@@ -614,7 +614,7 @@ Set a contiguous range of values in the buffer starting at the index startAt to 
 discussion::
 Note that multichannel buffers interleave their sample data, therefore the actual number of available values is equal to code::numFrames * numChannels::. You are responsible for interleaving the data in values if needed. Multi-dimensional arrays will not work. Indices start at 0.
 
-N.B. The maximum number of values that you can set with a single setn message is 1633 when the server is using UDP as its communication protocol. Use link::#-loadCollection:: and link::#-sendCollection:: to set larger ranges of values.
+N.B. The maximum number of values that you can set with a single setn message is 13098 when the server is using UDP as its communication protocol. Use link::#-loadCollection:: and link::#-sendCollection:: to set larger ranges of values.
 code::
 s.boot;
 b = Buffer.alloc(s,16);
@@ -705,7 +705,7 @@ b.free;
 method:: getn, getnMsg
 Send a message requesting the a contiguous range of values of size count starting from index. action is a Function which will be passed the values in an Array as an argument and evaluated when a reply is received. (Floating-point values for index and count are truncated to integer.)
 discussion::
-N.B. The maximum number of values that you can get with a single getn message is 1633 when the server is using UDP as its communication protocol. Use link::#-loadToFloatArray:: and link::#-getToFloatArray:: to get larger ranges of values.
+N.B. The maximum number of values that you can get with a single getn message is 13095 when the server is using UDP as its communication protocol. (For an unknown reason, the SuperCollider language can send a code::/b_setn:: message containing 13098 values, while the server can send 13095 values.) Use link::#-loadToFloatArray:: and link::#-getToFloatArray:: to get larger ranges of values.
 
 method:: loadToFloatArray
 Write the buffer to a file and then load it into a FloatArray.

--- a/HelpSource/Tutorials/Getting-Started/13-Buffers.schelp
+++ b/HelpSource/Tutorials/Getting-Started/13-Buffers.schelp
@@ -180,7 +180,7 @@ b.getn(0, b.numFrames, {|msg| msg.postln});	// get them
 b.free;
 ::
 
-There is an upper limit on the number of values you can get or set at a time (usually 1633 when using UDP, the default). This is because of a limit on network packet size. To overcome this Buffer has two methods, 'loadCollection' and 'loadToFloatArray' which allow you to set or get large amounts of data by writing it to disk and then loading to client or server as appropriate.
+There is an upper limit on the number of values you can get or set at a time (13095 to get and 13098 to set when using UDP, the default). This is because of a limit on network packet size. To overcome this Buffer has two methods, 'loadCollection' and 'loadToFloatArray' which allow you to set or get large amounts of data by writing it to disk and then loading to client or server as appropriate.
 
 code::
 (

--- a/SCClassLibrary/Common/Control/Buffer.sc
+++ b/SCClassLibrary/Common/Control/Buffer.sc
@@ -299,6 +299,8 @@ Buffer {
 	// risky without wait
 	getToFloatArray { arg index = 0, count = -1, wait = 0.01, timeout = 3, action;
 		var refcount, array, pos, getsize, resp, done = false;
+		// empirically determined: largest b_setn that scsynth/supernova can send back
+		var chunkSize = 13095;
 
 		pos = index = index.asInteger;
 		// treat -1 and nil the same
@@ -306,7 +308,7 @@ Buffer {
 			count = (numFrames * numChannels).asInteger - index;
 		};
 		array = FloatArray.newClear(count);
-		refcount = (count / 1633).roundUp;
+		refcount = (count / chunkSize).roundUp;
 		count = count + pos;
 
 		resp = OSCFunc({ arg msg;
@@ -319,8 +321,7 @@ Buffer {
 
 		{
 			while { pos < count } {
-				// 1633 max size for getn under udp
-				getsize = min(1633, count - pos);
+				getsize = min(chunkSize, count - pos);
 				server.listSendMsg(this.getnMsg(pos, getsize));
 				pos = pos + getsize;
 				if(wait >= 0) { wait.wait } { server.sync };


### PR DESCRIPTION
## Purpose and Motivation

This one has been nagging at me for a while.

Years ago, the maximum UDP packet size was raised from 8192 to 65516.

Documentation, and `Buffer:getToFloatArray`, refer to a maximum getn/setn array size of 1633, which is based on the old packet size.

Empirically, I determined:

- sclang can send a `/b_setn` message containing up to 13098 values.
- scsynth can respond to a `/b_getn` request with a `/b_setn` message containing up to 13095 values. (I don't know the reason for this discrepancy, but I don't think it's a serious problem.)

So this PR changes `Buffer:getToFloatArray` and three places in the documentation.

The performance improvement seems to be roughly linear btw.

(PS I tried `const chunkSize = 13095;` too but `const` is not allowed at the top of a method declaration.)

## Types of changes

- Bug fix

## To-do list

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review
