### PR TITLE
Classlib: Handle `langPort` startup error descriptively

### DIFF
--- a/SCClassLibrary/DefaultLibrary/Main.sc
+++ b/SCClassLibrary/DefaultLibrary/Main.sc
@@ -19,7 +19,21 @@ Main : Process {
 		// set the 's' interpreter variable to the default server.
 		interpreter.s = Server.default;
 
-		openPorts = Set[NetAddr.langPort];
+		// 'langPort' may fail if no UDP port was available
+		// this wreaks several manners of havoc, so, inform the user
+		// also allow the rest of init to proceed
+		try {
+			openPorts = Set[NetAddr.langPort];
+		} { |error|
+			openPorts = Set.new;  // don't crash elsewhere
+			"\n\nWARNING: An error occurred related to network initialization.".postln;
+			"The error is '%'.\n".postf(error.errorString);
+			"There may be an error message earlier in the sclang startup log.".postln;
+			"Please look backward in the post window and report the error on the mailing list or user forum.".postln;
+			"You may be able to resolve the problem by killing 'sclang%' processes in your system's task manager.\n\n"
+			.postf(if(this.platform.name == \windows) { ".exe" } { "" });
+		};
+
 		this.platform.startup;
 		StartUp.run;
 


### PR DESCRIPTION
## Purpose and Motivation

Per forum thread: https://scsynth.org/t/win10-primitive-netaddr-sendmsg-failed-and-primitive-getlangport-failed/2085 -- it's possible for sclang to fail to get a UDP port at startup.

The rest of the startup sequence is omitted, which could cause any number of other problems.

Also, the error reported to the user is confusing -- a couple of users encountering this problem thought that they needed to kill servers, but it looks like it may be more relevant to kill language clients that didn't shut down.

So this PR provides more descriptive output.

## Types of changes

- Bug fix

## To-do list

- [x] Code is tested
- [x] All tests are passing
- [x] This PR is ready for review
