### PR TITLE
GridLines improvements: fix exponential grids and add spacing control

### DIFF
--- a/HelpSource/Classes/AbstractGridLines.schelp
+++ b/HelpSource/Classes/AbstractGridLines.schelp
@@ -1,0 +1,134 @@
+CLASS:: AbstractGridLines
+summary:: given a spec and the actual data's min and max values, calculates the ideal spacing and labelling of grid lines for plotting
+categories:: GUI>Accessories
+related:: Classes/GridLines, Reference/plot, Classes/Plotter, Classes/DrawGrid
+
+DESCRIPTION::
+code::AbstractGridLines:: and its subclasses are strategy objects that implements a general strategy for finding a suitable min max range for graphing and suitable intervals for grid lines and labelling.
+
+Neither code::AbstractGridLines:: nor its subclasses are to be instantiated directly. Instead, link::Classes/GridLines:: factory class should be used to return the code::AbstractGridLines:: subclass appropriate for the given link::Classes/ControlSpec::.
+
+The object that does the actual drawing on a view is link::Classes/DrawGrid::.
+
+An code::AbstractGridLines:: object uses a link::Classes/ControlSpec:: to define the minimum and maximum possible values.  Given a data set's actual minimum and maximum values, the code::AbstractGridLines:: object can choose a logical range for graphing that encompasses the data that will be plotted.
+
+Subclasses of code::AbstractGridLines:: bind more tightly with the data they are representing. E.g. code::LinearGridLines:: represents data on linear scale, while code::ExponentialGridLines:: represents data on exponential scale. Future development work could add other subclasses like e.g. DegreeGridLines to be used to draw pitch degree GridLines behind a frequency plot.
+
+link::Classes/Spec:: has a .grid variable that points to its preferred code::AbstractGridLines:: subclass that should be used for graphing.
+
+code::
+\freq.asSpec.grid
+::
+
+This default implementation does not know anything about the data is displaying:
+
+code::
+DrawGrid.test(nil, \midinote.asSpec.grid);
+::
+
+A MidinoteGridLines could be written that labels these correctly, shows octaves and individual notes depending on the current zoom.
+
+Note that the code::AbstractGridLines:: does not know which axis it is to be used on and could also be used in polar plots or in 3D rendering.
+
+CLASSMETHODS::
+
+METHOD:: new
+
+argument:: spec
+The ControlSpec that defines the minimum and maximum values, warp and step.
+
+returns:: a AbstractGridLines
+
+
+INSTANCEMETHODS::
+
+METHOD:: spec
+get/set the spec
+
+returns:: a ControlSpec
+
+METHOD:: asGrid
+return self.  nil.asGrid would return a BlankGridLines which is a subclass of AbstractGridLines.  So when plotting if you specify a grid of nil then you will get no lines at all.
+
+returns:: self
+
+METHOD:: niceNum
+Based on: http://books.google.de/books?id=fvA7zLEFWZgC&pg=PA61&lpg=PA61
+
+This rounds a value to a logical nice number.  It is mostly used to support internal calculation, though it may be useful for other applications.
+
+argument:: val
+The value.
+
+argument:: round
+Boolean. Rounding uses a specific algorithm.  This is not simple rounding to an integer value.
+
+returns:: the nice number
+
+METHOD:: ideals
+for internal use
+
+argument:: min
+(describe argument here)
+
+argument:: max
+(describe argument here)
+
+argument:: ntick
+(describe argument here)
+
+returns:: (returnvalue)
+
+METHOD:: looseRange
+Returns the logical minimum and maximum that will contain the data.
+
+argument:: min
+minimum value
+
+argument:: max
+maximum value.
+
+argument:: ntick
+the number of lines you would like (which usually varies by how much screen space you have and what you consider cluttered)
+
+returns:: [ideal min, ideal max]
+
+METHOD:: getParams
+Specifically for use by DrawGrid. This returns a dictionary filled with:
+'lines': an array of values where lines should be drawn
+'labels': [value, formatted label] for each line
+
+argument:: valueMin
+minimum value of the data to be plotted
+
+argument:: valueMax
+maximum value of the data to be plotted
+
+argument:: pixelMin
+If numTicks is nil: used to guess the ideal numTicks based on the graph size.
+
+argument:: pixelMax
+If numTicks is nil: used to guess the ideal numTicks based on the graph size.
+
+argument:: numTicks
+Explicit number of ticks you would like to see on the graph.
+
+argument:: tickSpacing
+Approximate distance between ticks (in pixels). This value is only used when code::numTicks:: is code::nil::.
+
+returns:: A dictionary
+
+METHOD:: formatLabel
+Round the value and append the spec's units
+
+argument:: val
+The value
+
+argument:: numDecimalPlaces
+Number of decimal places
+
+returns:: a string
+
+private:: prCheckWarp
+
+

--- a/HelpSource/Classes/ControlSpec.schelp
+++ b/HelpSource/Classes/ControlSpec.schelp
@@ -69,6 +69,9 @@ Returns code::maxval - minval::.
 method::guessNumberStep
 Used for EZ GUI classes for guessing a sensible strong::step:: if none is specified.
 
+method::gridClass
+Returns the link::Classes/AbstractGridLines:: subclass appropriate for the current spec.
+
 Examples::
 
 code::

--- a/HelpSource/Classes/DrawGrid.schelp
+++ b/HelpSource/Classes/DrawGrid.schelp
@@ -1,18 +1,18 @@
 CLASS:: DrawGrid
 summary:: Draws grid lines on a UserView for plotting
 categories:: GUI>Accessories
-related:: Reference/plot, Classes/GridLines, Classes/Plotter, Classes/UserView
+related:: Reference/plot, Classes/AbstractGridLines, Classes/GridLines, Classes/Plotter, Classes/UserView
 
 DESCRIPTION::
 DrawGrid is used by Plotter to draw the grid lines on a graph. It can however
-also be used to draw link::Classes/GridLines:: on any
+also be used to draw link::Classes/AbstractGridLines:: on any
 link::Classes/UserView:: and could even be used to add grid lines to UserViews
 behind sliders or in any GUI.
 
 Note that DrawGrid does not hold any reference to the UserView but is meant to
 have its .draw method called inside of the UserView's drawFunc.  It only needs
 to know what bounds the grid lines should be drawn within and what the
-horizontal and vertical GridLines are.
+horizontal and vertical AbstractGridLines are.
 
 
 CLASSMETHODS::
@@ -25,27 +25,25 @@ Multiple DrawGrid may be used to draw grids on a single
 link::Classes/UserView::.
 
 argument:: horzGrid
-A link::Classes/GridLines::, link::Classes/BlankGridLines:: or GridLines
-subclass.
+An link::Classes/AbstractGridLines:: subclass.
 
 argument:: vertGrid
-A link::Classes/GridLines::, link::Classes/BlankGridLines:: or GridLines
-subclass.
+An link::Classes/AbstractGridLines:: subclass.
 
 returns:: A DrawGrid.
 
 METHOD:: test
-For testing new link::Classes/GridLines:: objects.
+For testing new link::Classes/AbstractGridLines:: objects.
 code::
 DrawGrid.test(\freq.asSpec.grid, \amp.asSpec.grid);
 DrawGrid.test(nil, \lofreq.asSpec.grid);
 ::
 
 argument:: horzGrid
-A link::Classes/GridLines:: object or subclass.
+An link::Classes/AbstractGridLines:: subclass.
 
 argument:: vertGrid
-A link::Classes/GridLines:: object or subclass.
+An link::Classes/AbstractGridLines:: subclass.
 
 argument:: bounds
 Bounds describing the extents of the grid (not including any labels) within the
@@ -69,7 +67,7 @@ METHOD:: horzGrid
 Set the X axis grid lines.
 
 argument:: g
-A link::Classes/GridLines::.
+An link::Classes/AbstractGridLines:: subclass.
 
 returns:: Self.
 
@@ -78,7 +76,7 @@ METHOD:: vertGrid
 Set the Y axis grid lines.
 
 argument:: g
-A link::Classes/GridLines::.
+An link::Classes/AbstractGridLines:: subclass.
 
 returns:: Self.
 

--- a/HelpSource/Classes/GridLines.schelp
+++ b/HelpSource/Classes/GridLines.schelp
@@ -1,126 +1,17 @@
 CLASS:: GridLines
-summary:: given a spec and the actual data's min and max values, calculates the ideal spacing and labelling of grid lines for plotting
+summary:: A factory class for AbstractGridLines
 categories:: GUI>Accessories
-related:: Reference/plot, Classes/Plotter, Classes/DrawGrid
+related:: Classes/AbstractGridLines
 
 DESCRIPTION::
-GridLines is a strategy object that implements a general strategy for finding a suitable min max range for graphing and suitable intervals for grid lines and labelling.
+code::GridLines:: is a factory class that returns the appropriate subclass of link::Classes/AbstractGridLines:: for a given code::ControlSpec::.
 
-The object that does the actual drawing on a view is DrawGrid.
-
-A GridLines object uses a ControlSpec to define the minimum and maximum possible values.  Given a data set's actual minimum and maximum values, the GridLines object can choose a logical range for graphing that encompasses the data that will be plotted.  
-
-Future development work will add subclasses of GridLines that can bind more tightly with the data they are representing.  For instance a FreqGridLines (not yet implemented) could apply stronger lines to octave divisions.  A DegreeGridLines could be used to draw pitch degree gridlines behind a frequency plot.
-
-Spec has a .grid variable that points to its preferred GridLines object that should be used for graphing.
-
-code::
-\freq.asSpec.grid
-::
-
-This default implementation does not know anything about the data is displaying:
-
-code::
-DrawGrid.test( nil, \midinote.asSpec.grid );
-::
-
-A MidinoteGrid could be written that labels these correctly, shows octaves and individual notes depending on the current zoom.
-
-Note that the GridLines does not know which axis it is to be used on and could also be used in polar plots or in 3D rendering.
 
 CLASSMETHODS::
 
 METHOD:: new
 
 argument:: spec
-The ControlSpec that defines the minimum and maximum values, warn and step.
+The ControlSpec that defines the minimum and maximum values, warp and step.
 
-returns:: a GridLines
-
-
-INSTANCEMETHODS::
-
-METHOD:: spec
-get/set the spec
-
-returns:: a ControlSpec
-
-METHOD:: asGrid
-return self.  nil.asGrid would return a BlankGridLines which is a subclass of GridLines.  So when plotting if you specify a grid of nil then you will get no lines at all.
-
-returns:: self
-
-METHOD:: niceNum
-Based on: http://books.google.de/books?id=fvA7zLEFWZgC&pg=PA61&lpg=PA61
-This rounds a value to a logical nice number.  It is mostly used to support internal calculation, though it may be useful for other applications.
-
-argument:: val
-The value.
-
-argument:: round
-Boolean. Rounding uses a specific algorithm.  This is not simple rounding to an integer value.
-
-returns:: the nice number
-
-METHOD:: ideals
-for internal use
-
-argument:: min
-(describe argument here)
-
-argument:: max
-(describe argument here)
-
-argument:: ntick
-(describe argument here)
-
-returns:: (returnvalue)
-
-METHOD:: looseRange
-Returns the logical minimum and maximum that will contain the data.
-
-argument:: min
-minimum value
-
-argument:: max
-maximum value.
-
-argument:: ntick
-the number of lines you would like (which usually varies by how much screen space you have and what you consider cluttered)
-
-returns:: [ideal min, ideal max]
-
-METHOD:: getParams
-Specifically for use by DrawGrid. This returns a dictionary filled with:
-'lines': an array of values where lines should be drawn
-'labels': [value, formatted label] for each line 
-
-argument:: valueMin
-minimum value of the data to be plotted
-
-argument:: valueMax
-maximum value of the data to be plotted
-
-argument:: pixelMin
-If numTicks is nil: used to guess the ideal numTicks based on the graph size.
-
-argument:: pixelMax
-If numTicks is nil: used to guess the ideal numTicks based on the graph size.
-
-argument:: numTicks
-Explicit number of ticks you would like to see on the graph.
-
-returns:: A dictionary
-
-METHOD:: formatLabel
-Round the value and append the spec's units
-
-argument:: val
-The value
-
-argument:: numDecimalPlaces
-Number of decimal places
-
-returns:: a string
-
-
+returns:: a subclass of link::Classes/AbstractGridLines::

--- a/SCClassLibrary/Common/Control/Spec.sc
+++ b/SCClassLibrary/Common/Control/Spec.sc
@@ -11,6 +11,9 @@ Spec {
 		^spec
 	}
 	asSpec { ^this }
+	gridClass {
+		^this.subclassResponsibility(thisMethod)
+	}
 	defaultControl {
 		^this.subclassResponsibility(thisMethod)
 	}
@@ -100,7 +103,9 @@ ControlSpec : Spec {
 		^numStep
 	}
 
-	grid { ^grid ?? {GridLines(this)} }
+	gridClass { ^this.warp.gridClass }
+
+	grid { ^grid ?? { GridLines(this) } }
 
 	looseRange { |data, defaultRange, minval, maxval|
 		var newMin, newMax;
@@ -238,6 +243,8 @@ Warp {
 		^this.copy.spec_(inSpec)
 	}
 
+	gridClass { ^LinearGridLines }
+
 	*initClass {
 		// support Symbol-asWarp
 		warps = IdentityDictionary[
@@ -279,6 +286,7 @@ LinearWarp : Warp {
 }
 
 ExponentialWarp : Warp {
+	gridClass { ^ExponentialGridLines }
 	// minval and maxval must both be non zero and have the same sign.
 	map { arg value;
 		// maps a value from [0..1] to spec range


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

This PR fixes exponential GridLines, which previously were not drawn cleanly. Fixes #5156

In detail this PR:
- fixes drawing exponential gridlines, based on solution by @sternsc 
  - both positive and negative ranges are supported
- adds control over grid density through ~`DrawGrid -pixDensity`~ `DrawGridX -tickSpacing`
- ~~adds option to not draw individual labels if they'd overlap, through `DrawGrid -dropLabelIfTooNarrow `~~
- labels are now dropped within the exponential gridlines generation for the X axis, based on line spacing and label width
- ~~removes `.0` from integer labels~~ this was addressed in #5827
- I realized that the original design [intended to create separate GridLines objects for various Warps](https://github.com/supercollider/supercollider/blob/develop/HelpSource/Classes/GridLines.schelp#L13). This PR now implements exponential grids as a `ExponentialGridLines` class, instead of [using switch statements when generating grids](https://github.com/dyfer/supercollider/commit/4b2ff1d4a0af6e35a9ad109b2573728c32bff730#diff-1d5b6087b26a5651c9a746f81acf4e906a45ed083d3e95b12322ab9442979426R367).

Other considerations
- ~~the mechanism to control grid spacing and density is implemented mostly in `GridLines -getParam`, but some of it is in `DrawGrid`; I have not changed this but this design could be reconsidered~~
- There are some minor drive-by formatting changes to the code; they were in the vicinity of the code I was changing but I'd be happy to remove those if they're not desired
- There is quite a bit of magic numbers that I came up with when tuning the grids
- ~~The documentation still needs updating~~ Basic documentation updates are now included in this PR

Examples:

```supercollider
(
c = ControlSpec.new(20,20000, \exp, units:"Hz");
g = c.grid;
d = DrawGrid.test(g, nil, 500@100);
)
```
<img width="612" alt="Screen Shot 2022-09-07 at 11 43 59" src="https://user-images.githubusercontent.com/1589177/188954646-abc041ba-ca07-46a8-805a-41de5306e2a3.png">

```supercollider
(
c = ControlSpec.new(20,20000, \exp, units:"Hz");
g = c.grid;
d = DrawGrid.test(g, nil, 1000@100);
)
```
<img width="1112" alt="Screen Shot 2022-09-07 at 11 44 13" src="https://user-images.githubusercontent.com/1589177/188954682-3d4f2f2d-d4c3-41b8-b299-0e8c6777d228.png">

```supercollider
(
c = ControlSpec.new(0.1, 100, \exp, units:"Hz");
g = c.asSpec.grid;
d = DrawGrid.test(g, nil, 500@100);
)
```
<img width="612" alt="Screen Shot 2022-09-07 at 12 00 40" src="https://user-images.githubusercontent.com/1589177/188956915-4992bf93-ea9d-48be-b216-8ff00cfd3ab5.png">

```supercollider
DrawGrid.test(\freq.asSpec.grid, \freq.asSpec.grid, 1000@600);
```
<img width="1112" alt="Screen Shot 2022-09-07 at 11 45 11" src="https://user-images.githubusercontent.com/1589177/188954700-e13c7e5c-8ef0-4d09-93d2-dd1830440a04.png">
(note how x-axis labels get dynamically dropped as the view is resized)

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->

- Documentation
- Bug fix
- New feature

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review
