### PR TITLE
Fix typo in LFSaw.schelp

### DIFF
--- a/HelpSource/Classes/LFSaw.schelp
+++ b/HelpSource/Classes/LFSaw.schelp
@@ -20,8 +20,8 @@ argument::iphase
 
 Initial phase offset. For efficiency reasons this is a value
 ranging from 0 to 2.
-Note:: enter "1" for an initial phase of 0 radiants.
-A value of 0 would start the cycle at pi radiants. See the example below.::
+Note:: enter "1" for an initial phase of 0 radians.
+A value of 0 would start the cycle at pi radians. See the example below.::
 
 argument::mul
 Output will be multiplied by this value.


### PR DESCRIPTION
"radians" not "radiants"

<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->

- Documentation
- Bug fix
- New feature
- Breaking change

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [ ] Code is tested
- [ ] All tests are passing
- [ ] Updated documentation
- [ ] This PR is ready for review
