### PR TITLE
travis: add legacy macos build and custom Qt version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,59 @@ matrix:
     #    clang {4, 5, 6, 7, 8, 9, 10}
     # gcc 6, clang 4 are on xenial, all others on bionic
     #
-    # macOS jobs: xcode 10.3, xcode 11.3, xcode 11.3-using-syslibs, xcode 11.3-shared-libscsynth
-    # both on Mojave 10.14
+    # macOS jobs: xcode 10.1, xcode 11.3, xcode 11.3-using-syslibs, xcode 11.3-shared-libscsynth
+    # xcode 10 is on High Sierra 10.13, xcode 11 are on Mojave 10.14
     #
     # macOS is deployed from the plain xcode 11.3 job
+    # macOS jobs (taking longer time to finish) run first to decrease overall build time
+
+    # macOS 10.13 xcode10 legacy build with qt 5.9
+    - os: osx
+      osx_image: xcode10.1
+      env:
+        - JOB_NAME="macos xcode10.1 legacy build with qt 5.9"
+        - IS_LEGACY_BUILD=true
+        - QT=true
+        - DO_LINT=false
+        - USE_SYSLIBS=false
+        - SHARED_LIBSCSYNTH=false
+        - S3_DEPLOY_PREFIX="SC-legacy-" # turn on S3 deployment
+        - GITHUB_DEPLOY_SUFFIX="-macOS-legacy" # turn on Github deployment
+
+    # macOS 10.14 xcode11
+    - os: osx
+      osx_image: xcode11.3
+      env:
+        - JOB_NAME="macos xcode11.3"
+        - IS_LEGACY_BUILD=false
+        - QT=true
+        - DO_LINT=false
+        - USE_SYSLIBS=false
+        - SHARED_LIBSCSYNTH=false
+        - S3_DEPLOY_PREFIX="SC-" # turn on S3 deployment
+        - GITHUB_DEPLOY_SUFFIX="-macOS" # turn on Github deployment
+
+    # macOS 10.14 xcode11 use_syslibs
+    - os: osx
+      osx_image: xcode11.3
+      env:
+        - JOB_NAME="macos xcode11.3 with syslibs"
+        - IS_LEGACY_BUILD=false
+        - QT=true
+        - DO_LINT=false
+        - USE_SYSLIBS=true
+        - SHARED_LIBSCSYNTH=false
+
+    # macOS 10.14 xcode11 shared_scsynth (LIBSCSYNTH)
+    - os: osx
+      osx_image: xcode11.3
+      env:
+        - JOB_NAME="macos xcode11.3 with shared libscsynth"
+        - IS_LEGACY_BUILD=false
+        - QT=true
+        - DO_LINT=false
+        - USE_SYSLIBS=false
+        - SHARED_LIBSCSYNTH=true
 
     # Ubuntu 16.04 gcc6
     - os: linux
@@ -235,47 +284,6 @@ matrix:
         - USE_SYSLIBS=false
         - SHARED_LIBSCSYNTH=false
 
-    # macOS 10.14 xcode10
-    - os: osx
-      osx_image: xcode10.3
-      env:
-        - JOB_NAME="macos xcode10.3"
-        - QT=true
-        - DO_LINT=false
-        - USE_SYSLIBS=false
-        - SHARED_LIBSCSYNTH=false
-
-    # macOS 10.14 xcode11
-    - os: osx
-      osx_image: xcode11.3
-      env:
-        - JOB_NAME="macos xcode11.3"
-        - QT=true
-        - DO_LINT=false
-        - USE_SYSLIBS=false
-        - SHARED_LIBSCSYNTH=false
-        - DO_DEPLOY=YES # presence option
-
-    # macOS 10.14 xcode11 use_syslibs
-    - os: osx
-      osx_image: xcode11.3
-      env:
-        - JOB_NAME="macos xcode11.3 with syslibs"
-        - QT=true
-        - DO_LINT=false
-        - USE_SYSLIBS=true
-        - SHARED_LIBSCSYNTH=false
-
-    # macOS 10.14 xcode11 shared_scsynth (LIBSCSYNTH)
-    - os: osx
-      osx_image: xcode11.3
-      env:
-        - JOB_NAME="macos xcode11.3 with shared libscsynth"
-        - QT=true
-        - DO_LINT=false
-        - USE_SYSLIBS=false
-        - SHARED_LIBSCSYNTH=true
-
 # use ccache to speed up build times. on osx,
 # we install it during the the before_install step
 # with xcode, this requires an additional flag passed during the configuration phase.
@@ -302,17 +310,16 @@ before_script:
 script:
  - $TRAVIS_BUILD_DIR/.travis/script-$TRAVIS_OS_NAME.sh
  - $TRAVIS_BUILD_DIR/.travis/test.sh
+ - export S3_ARTIFACT_NAME=${S3_DEPLOY_PREFIX}${TRAVIS_COMMIT}
+ - export GITHUB_ARTIFACT_NAME=SuperCollider-${VERSION_TO_BUILD}${GITHUB_DEPLOY_SUFFIX}
 # only on osx for now
- - echo $DO_DEPLOY
- - if [[ ! -z "$DO_DEPLOY" ]]; then echo hi; fi
- - if [[ -z "$DO_DEPLOY" ]]; then echo hi; fi
- - if [[ ! -z "$DO_DEPLOY" ]]; then $TRAVIS_BUILD_DIR/.travis/package-$TRAVIS_OS_NAME.sh; fi
+ - if [[ -n "$S3_DEPLOY_PREFIX" || -n "$GITHUB_DEPLOY_SUFFIX" ]]; then $TRAVIS_BUILD_DIR/.travis/package-$TRAVIS_OS_NAME.sh; fi
 
 before_deploy:
  # required for github releases
  - export BUILD_PREFIX=$TRAVIS_REPO_SLUG/$TRAVIS_OS_NAME
  - export S3_BUILDS_LOCATION=builds/$BUILD_PREFIX
- - export S3_URL=https://supercollider.s3.amazonaws.com/$S3_BUILDS_LOCATION/SC-$TRAVIS_COMMIT.zip
+ - export S3_URL=https://supercollider.s3.amazonaws.com/$S3_BUILDS_LOCATION/$S3_ARTIFACT_NAME.zip
  - export FWD_HTML='<html><head><meta http-equiv="refresh" content="0; url='$S3_URL'" /></head></html>'
  # put everything to be archived in artifacts/
  - mkdir -p "$HOME/artifacts/${TRAVIS_BRANCH%/*}"
@@ -333,21 +340,21 @@ deploy:
    endpoint: s3-us-west-2.amazonaws.com
    acl: public_read
    on:
-     condition: $TRAVIS_OS_NAME = osx && ! -z $AWS_KEY && ! -z $AWS_SECRET && ! -z $DO_DEPLOY
+     condition: $TRAVIS_OS_NAME = osx && -n $AWS_KEY && -n $AWS_SECRET && -n $S3_DEPLOY_PREFIX
      all_branches: true
  # github releases - only tags
  - provider: releases
    api_key: $GITHUB_KEY
-   file: $HOME/SuperCollider-$VERSION_TO_BUILD-macOS.zip
+   file: $HOME/$GITHUB_ARTIFACT_NAME.zip
    prerelease: true
    skip_cleanup: true
    on:
-     condition: $TRAVIS_OS_NAME = osx && ! -z $GITHUB_KEY && ! -z $DO_DEPLOY
+     condition: $TRAVIS_OS_NAME = osx && -n $GITHUB_KEY && -n $GITHUB_DEPLOY_SUFFIX
      tags: true
      all_branches: true
 
 after_deploy:
- - "echo S3 Build Location: $S3_URL"
+ - 'if [[ -n "$S3_DEPLOY_PREFIX" ]]; then echo S3 Build Location: $S3_URL; fi;'
 
 notifications:
   on_success: change

--- a/.travis/before-install-osx.sh
+++ b/.travis/before-install-osx.sh
@@ -1,13 +1,23 @@
 #!/bin/sh
 
 export HOMEBREW_NO_ANALYTICS=1
+export HOMEBREW_NO_AUTO_UPDATE=1
+export HOMEBREW_NO_INSTALL_CLEANUP=1
 
-brew install libsndfile || brew install libsndfile || exit 1
+if ! $IS_LEGACY_BUILD; then
+    #run update first so that possible update errors won't hold up package installation
+    brew update --preinstall
+fi
+
+brew install libsndfile || exit 1
 brew install portaudio || exit 2
 brew install ccache || exit 3
-brew upgrade qt5 || exit 4
-brew link qt5 --force || exit 5
-brew install fftw --verbose # temp allow
+if $IS_LEGACY_BUILD; then
+    brew install supercollider/formulae/qt@5.9.3 --force || exit 4
+else
+    brew upgrade qt5 || exit 4
+fi
+brew install fftw # do not abort in this step - fftw dependency install may fail, but this is not fatal
 
 if $USE_SYSLIBS; then
     # boost is already installed

--- a/.travis/package-osx.sh
+++ b/.travis/package-osx.sh
@@ -3,5 +3,5 @@
 mkdir -p $HOME/artifacts
 
 cd $TRAVIS_BUILD_DIR/BUILD/Install
-zip -q -r --symlinks $HOME/artifacts/SC-$TRAVIS_COMMIT.zip SuperCollider
-cp $HOME/artifacts/SC-$TRAVIS_COMMIT.zip $HOME/SuperCollider-$VERSION_TO_BUILD-macOS.zip
+zip -q -r --symlinks $HOME/artifacts/$S3_ARTIFACT_NAME.zip SuperCollider
+cp $HOME/artifacts/$S3_ARTIFACT_NAME.zip $HOME/$GITHUB_ARTIFACT_NAME.zip

--- a/editors/sc-ide/CMakeLists.txt
+++ b/editors/sc-ide/CMakeLists.txt
@@ -498,7 +498,7 @@ if(APPLE OR WIN32)
                 # but libfftw3f is not fixed up automatically when supernova is deployed.
                 string(APPEND VERIFY_CMD "
                 message(STATUS \"Fixing up bad path in libfftw3f.3.dylib manually due to faulty logic in macdeployqt\")
-                execute_process(COMMAND install_name_tool -change /usr/local/lib/gcc/0/libgcc_s.1.dylib
+                execute_process(COMMAND install_name_tool -change /usr/local/lib/gcc/9/libgcc_s.1.dylib
                     @loader_path/libgcc_s.1.dylib ${CONTENTS_DIR}/Frameworks/libfftw3f.3.dylib)
                 execute_process(COMMAND install_name_tool -change /usr/local/lib/gcc/10/libgcc_s.1.dylib
                     @loader_path/libgcc_s.1.dylib ${CONTENTS_DIR}/Frameworks/libfftw3f.3.dylib)


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

~~EDIT: this PR will include using custom Qt version in regular builds to fix #5167 and #5175~~

Inspired by [this comment](https://github.com/supercollider/supercollider/issues/5033#issuecomment-696100369) and following conversation, I wanted to see if adding a "legacy" build to our build matrix would be an option.

In this PR I propose to add one more macOS build to our travis build matrix, based on XCode 10 running on macOS 13 and using Qt 5.9. IIUC, this build should run on systems as old as 10.10 (untested). 

I propose this build to be an **unsupported** legacy build, as a courtesy to users running older systems. Once maintaining this becomes a burden, we'd just drop it. But for now it seems to build just fine. 

~~As far as implementation goes, I ended up using a modified QT formula on my own github, I don't see a better way. I understand this might be too hacky of an approach for an addition to this codebase.~~ Now using formula in `supercollider/formulae` repo.

~~TODO: add uploading of the build to AWS~~ Added deployment to Github and AWS


## Types of changes

<!-- Delete lines that don't apply -->

- New feature (?)

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Deployment to Github/AWS is added
- [x] Code is tested
- [x] This PR is ready for review
