### PR TITLE
Add "lazy equality" |==| operator

### DIFF
--- a/HelpSource/Classes/AbstractFunction.schelp
+++ b/HelpSource/Classes/AbstractFunction.schelp
@@ -567,8 +567,32 @@ a.value;
 // compose a function from a that selects only odd values
 b = { |x| x.select(_.odd) } <> a;
 b.value;
+
+// operator composition
+// compose a function that multiplies a random integer by 2
+{ rrand(1, 5) } * 2
 ::
 
+note::
+The comparison operators code::<::, code::<=::, code::>:: and code::>=:: automatically perform function composition, as does code::*:: in the example above.
+
+Equality comparisons have two possible meanings: to compare the objects as they exist right now, or a composite operator that will evaluate the operands in the future and check the equality of those results. Both are needed at different times in the class library, and are supported by different operators: code::==:: for an immediate equality check (which always returns a Boolean result), or code::|==|:: for a "lazy" equality operator to be performed later.
+::
+
+code::
+f = { 2.rand };  // a function
+
+// eager (immediate) equality
+// false: the function as itself is not the same as '1'
+g = (f == 1);
+
+g.value;  // still false
+
+// lazy equality
+g = (f |==| 1);  // a BinaryOpFunction
+
+g.value;  // true or false, depending on f's result
+::
 
 examples::
 

--- a/HelpSource/Classes/AbstractFunction.schelp
+++ b/HelpSource/Classes/AbstractFunction.schelp
@@ -576,7 +576,7 @@ b.value;
 note::
 The comparison operators code::<::, code::<=::, code::>:: and code::>=:: automatically perform function composition, as does code::*:: in the example above.
 
-Equality comparisons have two possible meanings: to compare the objects as they exist right now, or a composite operator that will evaluate the operands in the future and check the equality of those results. Both are needed at different times in the class library, and are supported by different operators: code::==:: for an immediate equality check (which always returns a Boolean result), or code::|==|:: for a "lazy" equality operator to be performed later.
+Equality comparisons have two possible meanings: to compare the objects as they exist right now, or a composite operator that will evaluate the operands in the future and check the equality of those results. Both are needed at different times, and are supported by different operators: code::==:: for an immediate equality check (which always returns a Boolean result), or code::|==|:: for a "lazy" equality operator to be performed later.
 ::
 
 code::

--- a/HelpSource/Classes/Object.schelp
+++ b/HelpSource/Classes/Object.schelp
@@ -223,6 +223,18 @@ method::!==
 
 Answer whether the receiver is not identical to anotherObject.
 
+method::|==|
+
+A "lazy equality" operator. For typical object types, code::|==|:: behaves the same as link::Classes/Object#-==::. For link::Classes/AbstractFunction:: and its subclasses (including link::Classes/Pattern:: and link::Classes/UGen::), it does not perform the equality check immediately, but rather "composes" an equality operation to be performed at the time of evaluating the resulting function or stream.
+
+code::
+1 |==| 2  // false
+
+Pwhite(1, 3, inf) == 1  // false
+
+Pwhite(1, 3, inf) |==| 1  // a Pbinop
+::
+
 method::fuzzyEqual
 
 Returns the degree of equality between two objects with regard to a given precision. Objects to compare must support max, substraction, and division.

--- a/HelpSource/Classes/Object.schelp
+++ b/HelpSource/Classes/Object.schelp
@@ -225,7 +225,7 @@ Answer whether the receiver is not identical to anotherObject.
 
 method::|==|
 
-A "lazy equality" operator. For typical object types, code::|==|:: behaves the same as link::Classes/Object#-==::. For link::Classes/AbstractFunction:: and its subclasses (including link::Classes/Pattern:: and link::Classes/UGen::), it does not perform the equality check immediately, but rather "composes" an equality operation to be performed at the time of evaluating the resulting function or stream.
+A lazy equality operator. For typical object types, code::|==|:: behaves the same as link::Classes/Object#-==::. For link::Classes/AbstractFunction:: and its subclasses (including link::Classes/Pattern:: and link::Classes/UGen::), it does not perform the equality check immediately, but rather composes an equality operation to be performed at the time of evaluating the resulting function or stream.
 
 code::
 1 |==| 2  // false

--- a/HelpSource/Classes/Object.schelp
+++ b/HelpSource/Classes/Object.schelp
@@ -217,7 +217,11 @@ code::
 
 method::!=
 
-Answer whether the receiver does not equal anotherObject. The default implementation in Object is to answer if the two objects are not identical (see below).
+Answer whether the receiver does not equal anotherObject. The default implementation in Object is to determine '==' for the two operands and negate this result. (see below).
+
+method::!==
+
+Answer whether the receiver is not identical to anotherObject.
 
 method::fuzzyEqual
 

--- a/HelpSource/Classes/Object.schelp
+++ b/HelpSource/Classes/Object.schelp
@@ -228,12 +228,18 @@ method::|==|
 A lazy equality operator. For typical object types, code::|==|:: behaves the same as link::Classes/Object#-==::. For link::Classes/AbstractFunction:: and its subclasses (including link::Classes/Pattern:: and link::Classes/UGen::), it does not perform the equality check immediately, but rather composes an equality operation to be performed at the time of evaluating the resulting function or stream.
 
 code::
-1 |==| 2  // false
+1 |==| 1  // true
 
-Pwhite(1, 3, inf) == 1  // false
+Pseq([1], inf) == 1  // false (because "a Pseq" is not 1)
 
-Pwhite(1, 3, inf) |==| 1  // a Pbinop
+Pseq([1], inf) |==| 1  // a Pbinop
+
+(Pseq([1], inf) |==| 1).asStream.next  // Pbinop evaluates to true
 ::
+
+method::|!=|
+
+A lazy inequality operator, defined as code::not(this |==| that)::. See link::Classes/Object#-|==|::.
 
 method::fuzzyEqual
 

--- a/HelpSource/Classes/Pkey.schelp
+++ b/HelpSource/Classes/Pkey.schelp
@@ -35,7 +35,7 @@ p.next(())	// for Pbind, must pass in a default event even if empty
 // note: to check if a Pkey's result /equals/ another value,
 // be sure to use |==|
 p = Pbind(
-	\a, Pwhite(1, 3, inf),
+	\a, Pseries(1, 1, inf),
 	\b, Pif(
 		Pkey(\a) == 2,
 		"equals 2",
@@ -46,7 +46,7 @@ p = Pbind(
 p.next(());  // 'b' is always "nope"
 
 p = Pbind(
-	\a, Pwhite(1, 3, inf),
+	\a, Pseries(1, 1, inf),
 	\b, Pif(
 		Pkey(\a) |==| 2,
 		"equals 2",

--- a/HelpSource/Classes/Pkey.schelp
+++ b/HelpSource/Classes/Pkey.schelp
@@ -31,4 +31,28 @@ p.next(())	// for Pbind, must pass in a default event even if empty
 ( 'a': 5, 'b': 10 )
 ( 'a': 4, 'b': 8 )
 ( 'a': 2, 'b': 4 )
+
+// note: to check if a Pkey's result /equals/ another value,
+// be sure to use |==|
+p = Pbind(
+	\a, Pwhite(1, 3, inf),
+	\b, Pif(
+		Pkey(\a) == 2,
+		"equals 2",
+		"nope"
+	)
+).asStream;
+
+p.next(());  // 'b' is always "nope"
+
+p = Pbind(
+	\a, Pwhite(1, 3, inf),
+	\b, Pif(
+		Pkey(\a) |==| 2,
+		"equals 2",
+		"nope"
+	)
+).asStream;
+
+p.next(());  // 'b' is as expected
 ::

--- a/HelpSource/Overviews/Operators.schelp
+++ b/HelpSource/Overviews/Operators.schelp
@@ -428,6 +428,9 @@ Equal.
 method:: !=
 Not equal.
 
+method:: |==|
+"Lazy equality." See link::Classes/Object#-|==|::.
+
 subsection:: Other
 
 method:: <!

--- a/SCClassLibrary/Common/Audio/UGen.sc
+++ b/SCClassLibrary/Common/Audio/UGen.sc
@@ -283,8 +283,12 @@ UGen : AbstractFunction {
 		^ModDif.multiNew(this.rate, this, that, mod)
 	}
 
-	// |==| for other AbstractFunctions should compose the |==| operator itself
-	// |==| is not supported in scsynth, so, compose it to == which is supported
+	// Note that this differs from |==| for other AbstractFunctions
+	// Other AbstractFunctions write '|==|' into the compound function
+	// for the sake of their 'storeOn' (compile string) representation.
+	// For UGens, scsynth does not support |==| (same handling --> error).
+	// So here, we use '==' which scsynth does understand.
+	// Also, BinaryOpUGen doesn't write a compile string.
 	|==| { |that|
 		^this.composeBinaryOp('==', that)
 	}

--- a/SCClassLibrary/Common/Audio/UGen.sc
+++ b/SCClassLibrary/Common/Audio/UGen.sc
@@ -283,6 +283,16 @@ UGen : AbstractFunction {
 		^ModDif.multiNew(this.rate, this, that, mod)
 	}
 
+	// |==| for other AbstractFunctions should compose the |==| operator itself
+	// |==| is not supported in scsynth, so, compose it to == which is supported
+	|==| { |that|
+		^this.composeBinaryOp('==', that)
+	}
+	prReverseLazyEquals { |that|
+		// commutative, so it's OK to flip the operands
+		^this.composeBinaryOp('==', that)
+	}
+
 	sanitize {
 		^Sanitize.perform(this.methodSelectorForRate, this);
 	}

--- a/SCClassLibrary/Common/Core/AbstractFunction.sc
+++ b/SCClassLibrary/Common/Core/AbstractFunction.sc
@@ -108,6 +108,14 @@ AbstractFunction {
 	>  { arg function, adverb; ^this.composeBinaryOp('>',  function, adverb) }
 	>= { arg function, adverb; ^this.composeBinaryOp('>=', function, adverb) }
 
+	|==| { |that|
+		^this.composeBinaryOp('|==|', that)
+	}
+	prReverseLazyEquals { |that|
+		// commutative, so it's OK to flip the operands
+		^this.composeBinaryOp('|==|', that)
+	}
+
 	bitAnd { arg function, adverb; ^this.composeBinaryOp('bitAnd', function, adverb) }
 	bitOr { arg function, adverb; ^this.composeBinaryOp('bitOr', function, adverb) }
 	bitXor { arg function, adverb; ^this.composeBinaryOp('bitXor', function, adverb) }

--- a/SCClassLibrary/Common/Core/Object.sc
+++ b/SCClassLibrary/Common/Core/Object.sc
@@ -222,6 +222,9 @@ Object  {
 	|==| { |that|
 		^that.prReverseLazyEquals(this)
 	}
+	|!=| { |that|
+		^not(this |==| that)
+	}
 	// a user might write `something |==| aPattern`
 	// so we need to support reverse dispatch
 	prReverseLazyEquals { |that|

--- a/SCClassLibrary/Common/Core/Object.sc
+++ b/SCClassLibrary/Common/Core/Object.sc
@@ -217,6 +217,17 @@ Object  {
 	hash { _ObjectHash; ^this.primitiveFailed }
 	identityHash { _ObjectHash; ^this.primitiveFailed }
 
+	// lazy equality: same as == for objects
+	// "composed" for lazy operands (patterns, UGens)
+	|==| { |that|
+		^that.prReverseLazyEquals(this)
+	}
+	// a user might write `something |==| aPattern`
+	// so we need to support reverse dispatch
+	prReverseLazyEquals { |that|
+		^(this == that)
+	}
+
 	// create an association
 	-> { arg obj; ^Association.new(this, obj) }
 

--- a/testsuite/classlibrary/TestAbstractFunction.sc
+++ b/testsuite/classlibrary/TestAbstractFunction.sc
@@ -168,5 +168,24 @@ TestAbstractFunction : UnitTest {
 
 	}
 
+	test_lazy_equals_operator_returns_right_class {
+		[
+			Pwhite(1, 10, inf) -> Pbinop,
+			// 1 |==| Pwhite(1, 10, inf) -> Pbinop,
+			SinOsc.ar -> BinaryOpUGen
+			// 1 |==| SinOsc.ar -> BinaryOpUGen
+		].do { |assn|
+			this.assertEquals(
+				(assn.key |==| 1).class,
+				assn.value,
+				"'% |==| 1' should return a composed operator".format(assn.key.asCompileString)
+			);
+			this.assertEquals(
+				(1 |==| assn.key).class,
+				assn.value,
+				"'1 |==| %' should return a composed operator".format(assn.key.asCompileString)
+			)
+		};
+	}
 }
 

--- a/testsuite/classlibrary/TestAbstractFunction.sc
+++ b/testsuite/classlibrary/TestAbstractFunction.sc
@@ -171,9 +171,7 @@ TestAbstractFunction : UnitTest {
 	test_lazy_equals_operator_returns_right_class {
 		[
 			Pwhite(1, 10, inf) -> Pbinop,
-			// 1 |==| Pwhite(1, 10, inf) -> Pbinop,
 			SinOsc.ar -> BinaryOpUGen
-			// 1 |==| SinOsc.ar -> BinaryOpUGen
 		].do { |assn|
 			this.assertEquals(
 				(assn.key |==| 1).class,


### PR DESCRIPTION
## Purpose and Motivation

Fixes #5179.

Confusion about `aPattern == something` or `aUGen == something` has been a two-decade annoyance.

This PR introduces a new operator such that:

```supercollider
(
p = Pbind(
	\a, Pwhite(1, 3, inf),
	\b, Pif(
		Pkey(\a) == 2,
		"equals 2",
		"nope"
	)
).asStream;

p.nextN(20, ()).any { |event| event[\b] == "equals 2" };
)

// ^^ false, but, the probability of
// Pwhite(1, 3) *never* returning 2, in 20 tries, is (2/3) ** 20 == 0.03%

(
p = Pbind(
	\a, Pwhite(1, 3, inf),
	\b, Pif(
		Pkey(\a) |==| 2,
		"equals 2",
		"nope"
	)
).asStream;

p.nextN(20, ()).any { |event| event[\b] == "equals 2" };
)

// ^^ true
```

If both operands are regular objects, `|==|` returns the Boolean result immediately.

If either operand is some kind of abstract function, `|==|` returns a composite operator -- `2 |==| Pkey(\a)` would work just as well.

I've tested only patterns and UGens (which are the primary use cases).

## Types of changes

- Documentation
- New feature

## To-do list

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review
