### PR TITLE
add legacy build temporarily

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,10 +18,23 @@ matrix:
           - DO_LINT=true # only lint on fastest build
       group: edge
     - os: osx
-      osx_image: xcode9.4
+      osx_image: xcode10.1
       env:
+          - JOB_NAME="macos legacy"
+          - IS_LEGACY_BUILD=true
           - QT=true
           - DO_LINT=false
+          - S3_DEPLOY_PREFIX="SC-legacy-" # turn on S3 deployment
+          - GITHUB_DEPLOY_SUFFIX="-macOS-legacy" # turn on Github deployment
+    - os: osx
+      osx_image: xcode9.4
+      env:
+          - JOB_NAME="macos"
+          - IS_LEGACY_BUILD=false
+          - QT=true
+          - DO_LINT=false
+          - S3_DEPLOY_PREFIX="SC-" # turn on S3 deployment
+          - GITHUB_DEPLOY_SUFFIX="-macOS" # turn on Github deployment
 
 # use ccache to speed up build times. on osx,
 # we install it during the the before_install step
@@ -47,13 +60,15 @@ before_script:
 script:
  - $TRAVIS_BUILD_DIR/.travis/script-$TRAVIS_OS_NAME.sh
  - $TRAVIS_BUILD_DIR/.travis/test.sh
+ - export S3_ARTIFACT_NAME=${S3_DEPLOY_PREFIX}${TRAVIS_COMMIT}
+ - export GITHUB_ARTIFACT_NAME=SuperCollider-${VERSION_TO_BUILD}${GITHUB_DEPLOY_SUFFIX}
  - if [[ $TRAVIS_OS_NAME == osx ]]; then $TRAVIS_BUILD_DIR/.travis/package-osx.sh; fi
 
 before_deploy:
  # required for github releases
  - export BUILD_PREFIX=$TRAVIS_REPO_SLUG/$TRAVIS_OS_NAME
  - export S3_BUILDS_LOCATION=builds/$BUILD_PREFIX
- - export S3_URL=https://supercollider.s3.amazonaws.com/$S3_BUILDS_LOCATION/SC-$TRAVIS_COMMIT.zip
+ - export S3_URL=https://supercollider.s3.amazonaws.com/$S3_BUILDS_LOCATION/$S3_ARTIFACT_NAME.zip
  - export FWD_HTML='<html><head><meta http-equiv="refresh" content="0; url='$S3_URL'" /></head></html>'
  # put everything to be archived in artifacts/
  - mkdir -p "$HOME/artifacts/${TRAVIS_BRANCH%/*}"
@@ -79,7 +94,7 @@ deploy:
  # github releases - only tags
  - provider: releases
    api_key: $GITHUB_KEY
-   file: $HOME/SuperCollider-$VERSION_TO_BUILD-macOS.zip
+   file: $HOME/$GITHUB_ARTIFACT_NAME.zip
    prerelease: true
    skip_cleanup: true
    on:

--- a/.travis/before-install-osx.sh
+++ b/.travis/before-install-osx.sh
@@ -1,13 +1,23 @@
 #!/bin/sh
 
 export HOMEBREW_NO_ANALYTICS=1
+export HOMEBREW_NO_AUTO_UPDATE=1
+export HOMEBREW_NO_INSTALL_CLEANUP=1
+
+if ! $IS_LEGACY_BUILD; then
+    #run update first so that possible update errors won't hold up package installation
+    brew update --preinstall
+fi
 
 brew install libsndfile || brew install libsndfile || exit 1
 brew install portaudio || exit 2
 brew install ccache || exit 3
-brew install qt5 || exit 4
-brew link qt5 --force || exit 5
-brew install fftw --verbose # temp allow
+if $IS_LEGACY_BUILD; then
+    brew install supercollider/formulae/qt@5.9.3 --force || exit 4
+else
+    brew upgrade qt5 || exit 4
+fi
+brew install fftw # temp allow
 
 # according to https://docs.travis-ci.com/user/caching#ccache-cache
 export PATH="/usr/local/opt/ccache/libexec:$PATH"

--- a/.travis/package-osx.sh
+++ b/.travis/package-osx.sh
@@ -3,5 +3,5 @@
 mkdir -p $HOME/artifacts
 
 cd $TRAVIS_BUILD_DIR/BUILD/Install
-zip -q -r --symlinks $HOME/artifacts/SC-$TRAVIS_COMMIT.zip SuperCollider
-cp $HOME/artifacts/SC-$TRAVIS_COMMIT.zip $HOME/SuperCollider-$VERSION_TO_BUILD-macOS.zip
+zip -q -r --symlinks $HOME/artifacts/$S3_ARTIFACT_NAME.zip SuperCollider
+cp $HOME/artifacts/$S3_ARTIFACT_NAME.zip $HOME/$GITHUB_ARTIFACT_NAME.zip

--- a/editors/sc-ide/CMakeLists.txt
+++ b/editors/sc-ide/CMakeLists.txt
@@ -498,7 +498,7 @@ if(APPLE OR WIN32)
                 # but libfftw3f is not fixed up automatically when supernova is deployed.
                 string(APPEND VERIFY_CMD "
                 message(STATUS \"Fixing up bad path in libfftw3f.3.dylib manually due to faulty logic in macdeployqt\")
-                execute_process(COMMAND install_name_tool -change /usr/local/lib/gcc/0/libgcc_s.1.dylib
+                execute_process(COMMAND install_name_tool -change /usr/local/lib/gcc/9/libgcc_s.1.dylib
                     @loader_path/libgcc_s.1.dylib ${CONTENTS_DIR}/Frameworks/libfftw3f.3.dylib)
                 execute_process(COMMAND install_name_tool -change /usr/local/lib/gcc/10/libgcc_s.1.dylib
                     @loader_path/libgcc_s.1.dylib ${CONTENTS_DIR}/Frameworks/libfftw3f.3.dylib)


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

Add legacy build for the 3.11 branch, as discussed in https://github.com/supercollider/supercollider/issues/5188#issuecomment-703364684

This PR focuses on a minimal amount of changes, copied from #5174 
As the implementation is incomplete (e.g. macos deployment is active for all builds, instead of conditional on specified prefix/suffix), these changes should be discarded when merging 3.11 back to develop 

The deployment itself was tested:
https://github.com/supercollider/supercollider/releases/tag/3.11-legacy-test-01
see also [s3 legacy build](https://supercollider.s3.amazonaws.com/builds/supercollider/supercollider/osx/SC-legacy-79035341eda52146bc6142420f0b35deac1c87fd.zip) and [s3 regular build](https://supercollider.s3.amazonaws.com/builds/supercollider/supercollider/osx/SC-79035341eda52146bc6142420f0b35deac1c87fd.zip)


## Types of changes

<!-- Delete lines that don't apply -->

- New feature

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] This PR is ready for review
