### PR TITLE
class library: rebuild proxyspace after copy

### DIFF
--- a/SCClassLibrary/JITLib/ProxySpace/ProxySpace.sc
+++ b/SCClassLibrary/JITLib/ProxySpace/ProxySpace.sc
@@ -151,6 +151,17 @@ ProxySpace : LazyEnvir {
 		});
 	}
 
+	rebuild {
+		var bundle = MixedBundle.new;
+		var checkedAlready = IdentitySet.new;
+		this.use {
+			envir.do { arg proxy;
+				proxy.rebuildDeepToBundle(bundle, false, checkedAlready)
+			}
+		};
+		bundle.schedSend(server, clock ? TempoClock.default, quant);
+	}
+
 	// maintaining bus state
 
 
@@ -249,7 +260,7 @@ ProxySpace : LazyEnvir {
 	// making copies
 
 	copy {
-		^super.copy.copyState(this)
+		^super.copy.copyState(this).rebuild
 	}
 
 	copyState { |proxySpace|

--- a/testsuite/classlibrary/TestProxySpace.sc
+++ b/testsuite/classlibrary/TestProxySpace.sc
@@ -3,18 +3,16 @@ TestProxySpace : UnitTest {
 
 	setUp {
 		server = Server(this.class.name);
+		this.bootServer(server);
 	}
 
 	tearDown {
+		server.quit;
 		server.remove;
 	}
 
-
 	test_storeOn_recoversState {
 		var psA, psB, stream, bValue, bNodeMap, aMapString, bMapString;
-
-		this.bootServer(server);
-		server.initTree;
 
 		psA = ProxySpace(server).make {
 			~out = { \in.ar(0!2) };
@@ -57,8 +55,8 @@ TestProxySpace : UnitTest {
 
 		psA.clear;
 		psB.clear;
-		server.quit;
-		server.remove;
+
+		server.sync; // we quit only after clear, avoiding unnecessary warnings
 	}
 
 	test_copy_as_currentEnvironment {

--- a/testsuite/classlibrary/TestProxySpace.sc
+++ b/testsuite/classlibrary/TestProxySpace.sc
@@ -1,9 +1,17 @@
 TestProxySpace : UnitTest {
+	var server;
+
+	setUp {
+		server = Server(this.class.name);
+	}
+
+	tearDown {
+		server.remove;
+	}
 
 
 	test_storeOn_recoversState {
 		var psA, psB, stream, bValue, bNodeMap, aMapString, bMapString;
-		var server = Server(this.class.name, NetAddr("127.0.0.1", 57111));
 
 		this.bootServer(server);
 		server.initTree;
@@ -52,4 +60,42 @@ TestProxySpace : UnitTest {
 		server.quit;
 		server.remove;
 	}
+
+	test_copy_as_currentEnvironment {
+
+		var environment = currentEnvironment;
+		var proxySpace = ProxySpace(server);
+		var copySpace;
+		var family = IdentitySet.new;
+		var commonProxies;
+
+		this.bootServer(server);
+
+		proxySpace.push;
+
+		~freq = 80;
+		~hpf = { HPF.ar(WhiteNoise.ar(0.1), ~freq.kr) };
+
+		0.1.wait;
+
+		copySpace = proxySpace.copy;
+
+		proxySpace.pop;
+		proxySpace.end;
+
+
+		copySpace[\hpf].getFamily(family);
+		this.assert(family.size == 2, "there should be one parent in this case", report: true); // sanity check
+
+		commonProxies = proxySpace.envir.values.as(IdentitySet) sect: family;
+		this.assert(commonProxies.isEmpty, "proxyspace copying should refresh local environment crossreferences");
+
+		proxySpace.clear;
+		copySpace.clear;
+
+		currentEnvironment = environment;
+
+	}
+
+
 }


### PR DESCRIPTION
This fixes  #5180


## Purpose and Motivation

When used within a `ProxySpace`, a NodeProxy's function may contain dynamically scoped references to the local environment. When the `ProxySpace` is copied, the proxies are copied, but they still point to the original sources. This patch updates the references  by rebuilding every proxy from within the new environment. It avoids double rebuilding by keeping a set of those which have been touched already (`checkedAlready`);

## Types of changes

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] This PR is ready for review

