### PR TITLE
lang: Fix system realtime message type codes

### DIFF
--- a/lang/LangPrimSource/SC_AlsaMIDI.cpp
+++ b/lang/LangPrimSource/SC_AlsaMIDI.cpp
@@ -278,14 +278,18 @@ void SC_AlsaMidiClient::processEvent(snd_seq_event_t* evt) {
             break;
         case SND_SEQ_EVENT_SONGPOS: // song ptr
             ++g->sp;
-            SetInt(g->sp, evt->data.control.channel);
+            SetInt(g->sp, 0x2);
             ++g->sp;
-            SetInt(g->sp, (evt->data.control.value << 7) | evt->data.control.param);
+            // note: this differs from the corresponding sections
+            // of SC_CoreMIDI.cpp and SC_PortMIDI.cpp.
+            // Empirically I found that data.control.value has already been
+            // decoded from the two 7-bit values -- the bitwise ops are not necessary here
+            SetInt(g->sp, evt->data.control.value);
             runInterpreter(g, s_midiSysrtAction, 4);
             break;
         case SND_SEQ_EVENT_SONGSEL: // song sel
             ++g->sp;
-            SetInt(g->sp, evt->data.control.channel);
+            SetInt(g->sp, 0x3);
             ++g->sp;
             SetInt(g->sp, evt->data.control.param);
             runInterpreter(g, s_midiSysrtAction, 4);


### PR DESCRIPTION
## Purpose and Motivation

Fixes #5198 (for Linux, not totally sure about Windows -- there is a pending PR to fix a related crash in Windows).

In Linux, song position pointer and song select messages were sent with an incorrect sysrt message type code. We thought we were getting the type code from `evt->data.control.channel` (and maybe that was actually the case a decade or two ago), but I found in testing that this is always 0.

SC_CoreMIDI.cpp and SC_PortMIDI.cpp simply pass the code byte as a constant. So, I'm updating SC_AlsaMIDI.cpp accordingly.

I also found that the song position data value (`(pkt->data[2] << 7) | pkt->data[1]` for Core MIDI) is a wrong calculation in Alsa. Through debugging posts, I found that `evt->data.control.value` is already the 14-bit value, and doing `evt->data.control.value << 7` means that the value passed into the language is 128 times the correct value. With this change, if I send MIDI bytes `242 101 2`, the expected song position is `101 | (2 << 7)` == 357, and 357 is in fact the value received in the language.

## Types of changes

- Bug fix

## To-do list

- [x] Code is tested
- [x] All tests are passing
- [x] This PR is ready for review
