### PR TITLE
scide: restoreDocuments dialog focuses Yes button

### DIFF
--- a/editors/sc-ide/widgets/main_window.cpp
+++ b/editors/sc-ide/widgets/main_window.cpp
@@ -1097,8 +1097,8 @@ void MainWindow::restoreDocuments() {
     if (docMng->needRestore()) {
         QString msg = tr("Supercollider didn't quit properly last time\n"
                          "Do you want to restore files saved as temporary backups?");
-        QMessageBox::StandardButton restore =
-            QMessageBox::warning(mInstance, tr("Restore files?"), msg, QMessageBox::Yes | QMessageBox::No);
+        QMessageBox::StandardButton restore = QMessageBox::warning(
+            mInstance, tr("Restore files?"), msg, QMessageBox::Yes | QMessageBox::No, QMessageBox::Yes);
         if (restore == QMessageBox::Yes)
             docMng->restore();
         else


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation
A small addition.
When the restoreDocuments dialog appears, it currently focuses on the "No" button, so that pressing Enter will discard backups. This feels counter-intuitive, since the dialog is asking if you want to restore those backups, and a positive answer like pressing Enter should be supposed to restore them.
With this PR, Yes is set as default, focused button, so that pressing Enter will restore backups, while Esc will discard them.

Additional note: if anyone wonders about the spacing in this PR, I did run clang-format :)


## Types of changes

<!-- Delete lines that don't apply -->
- New feature

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review
