### PR TITLE
servers: include unistd.h when using _POSIX_MEMLOCK macro

### DIFF
--- a/server/scsynth/SC_World.cpp
+++ b/server/scsynth/SC_World.cpp
@@ -51,6 +51,7 @@
 #    include <direct.h>
 #else
 #    include <sys/param.h>
+#    include <unistd.h> // for _POSIX_MEMLOCK
 #endif
 
 #include "malloc_aligned.hpp"

--- a/server/scsynth/scsynth_main.cpp
+++ b/server/scsynth/scsynth_main.cpp
@@ -34,6 +34,7 @@
 #    include <winsock2.h>
 #    include <vector>
 #else
+#    include <unistd.h> // for _POSIX_MEMLOCK
 #    include <sys/wait.h>
 #endif
 

--- a/server/supernova/server/main.cpp
+++ b/server/supernova/server/main.cpp
@@ -48,6 +48,9 @@
 #    include <SC_Apple.hpp>
 #endif
 
+#ifndef _WIN32
+#    include <unistd.h> // for _POSIX_MEMLOCK
+#endif
 
 #if (_POSIX_MEMLOCK - 0) >= 200112L
 #    include <sys/resource.h>


### PR DESCRIPTION
## Purpose and Motivation

fixes #5210

thanks @giuliomoro for the report

tested on Arch Linux, the option appears and is used

## Types of changes

- Bug fix
- New feature (kind of a new feature since it wasn't available for a while)

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review