### PR TITLE
qtcollider: QcSignalSpy prevent creating QVariant<QVariant>

### DIFF
--- a/QtCollider/QcSignalSpy.h
+++ b/QtCollider/QcSignalSpy.h
@@ -91,7 +91,12 @@ public:
 
             for (int i = 0; i < _argTypes.count(); ++i) {
                 QMetaType::Type type = static_cast<QMetaType::Type>(_argTypes.at(i));
-                args << QVariant(type, argData[i + 1]);
+                if (type == QMetaType::QVariant) {
+                    // avoid creating a QVariant<QVariant>
+                    args << QVariant(type, argData[i + 1]).value<QVariant>();
+                } else {
+                    args << QVariant(type, argData[i + 1]);
+                }
             }
 
             react(args);

--- a/QtCollider/widgets/QcWebView.cpp
+++ b/QtCollider/widgets/QcWebView.cpp
@@ -153,8 +153,7 @@ void WebView::toPlainText(QcCallback* cb) const {
 void WebView::runJavaScript(const QString& script, QcCallback* cb) {
     if (page()) {
         if (cb) {
-            // convert QVariant to string until we deal with QVariants
-            page()->runJavaScript(script, [cb](const QVariant& t) { cb->call(t.toString()); });
+            page()->runJavaScript(script, cb->asFunctor());
         } else {
             page()->runJavaScript(script, [](const QVariant&) {});
         }


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation
I encountered a problem while working on #4883 : when sclang calls `WebView::runJavascript`, it would fail to get back return values. I digged into it and this is how it works:
- A Function (the callback) is connected to a Qt signal (the onCalled signal of QcCallback)
- A QcSignalSpy is connected to the signal
- When the signal fires, QcSignalSpy gets its arguments, and converts them to a QList<QVariant> to be passed to QtCollider::runLang and from there back to sclang. Since QcSignalSpy receives arguments as a (void**) and their types as a separate argument, it wraps each of them into a QVariant and pushes it to the list.

The problem is that the callback for runJavascript returns a QVariant already, that when wrapped becomes a QVariant<QVariant>, which QtCollider::runLang doesn't know how to translate into an object sclang can use.

So, in this PR, I'm just checking in QcSignalSpy if an argument is already a QVariant, preventing it then to being made into a QVariant<QVariant>
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->
- Bug fix

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [ ] Code is tested
- [ ] All tests are passing
- [ ] Updated documentation
- [ ] This PR is ready for review
