### PR TITLE
server: EnvGen: set endValue for shape \hold

### DIFF
--- a/server/plugins/LFUGens.cpp
+++ b/server/plugins/LFUGens.cpp
@@ -2398,6 +2398,8 @@ static bool EnvGen_initSegment(EnvGen* unit, int& counter, double& level, double
     }
 
     float previousEndLevel = unit->m_endLevel;
+    if (unit->m_shape == shape_Hold)
+        level = previousEndLevel;
     float** envPtr = unit->mInBuf + stageOffset;
     double endLevel = *envPtr[0] * ZIN0(kEnvGen_levelScale) + ZIN0(kEnvGen_levelBias); // scale levels
     if (dur < 0)

--- a/testsuite/classlibrary/TestEnvGen_server.sc
+++ b/testsuite/classlibrary/TestEnvGen_server.sc
@@ -167,4 +167,18 @@ TestEnvGen_server : UnitTest {
 		this.assert(passed, "gate < 0 should respect env's last node curve");
 	}
 
+	// issue #5104
+	test_shapeHold_setEndValue {
+		var env = Env(curves: [\hold, \lin]);
+		var condition = Condition();
+		var result = [];
+		server.bootSync;
+		{ EnvGen.kr(env, timeScale: 0.01, doneAction:2) }.loadToFloatArray(0.01, server){ |values|
+			result = values;
+			condition.test_(true).signal;
+		};
+		this.wait(condition, "timeout when waiting for EnvGen results from server", 0.1);
+		this.assert(result.any { |v| v > 0 }, "Env(curves: [\hold, \lin]) should not be rendered as silent");
+	}
+
 }


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

Fixes #5104.

in EnvGen UGen, \hold shaped segments never set their level to their end value. They hold the previous segment's value, and are supposed to switch "instantly" to their endValue at the end of the segment, but that actually never happens in UGen code.

While this PR doesn't make EnvGen output that endValue, it sets it internally before calculating the next segment, to avoid problems with shapes which rely on the the previousEndValue, like linear shapes using it to calculate their grow factor. For example, with:

```Env([0,1,0], curve:[\hold,\lin])```

the linear segment does nothing because it has an endValue of 0 and also a previousEndValue of 0, since \hold didn't ever set it to 1, resulting in a grow factor of 0 for the linear segment, a.k.a noop. Thus, this envelope is completely silent, while a `.plot` shows a spike and a decay corresponding to the linear segment.

## Types of changes

<!-- Delete lines that don't apply -->
- Bug fix

## To-do list
Can't figure out a test for this. I tried to compare a FloatArray array got from Env.discretize with another from Function.loadToFloatArray, but they differ, as they do for many Envelopes shapes anyway.
A simple test could be just checking that the test Env from this PR is not silent, let me know if that feels like a meaningful addition to our testsuite.

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [ ] Updated documentation
- [x] This PR is ready for review
