### PR TITLE
Prepare for 3.11.2-rc1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,56 @@ Release dates of 3.x versions:
 - 3.10: 2018-11-24
 - 3.11: 2020-03-08
 
+3.11.2 (TBD)
+============
+
+We are now providing a "legacy macOS" binary that supports macOS 10.10 and above. It can be found where you normally
+download SuperCollider ([#5190](https://github.com/supercollider/supercollider/pull/5190)).
+
+### General: Fixed
+
+In the help browser, Shift-Enter now evaluates code again! ([#4883](https://github.com/supercollider/supercollider/pull/4883))
+
+Fixed faulty deployment of macOS app bundle due to bug in Qt utility
+([#5187](https://github.com/supercollider/supercollider/pull/5187)).
+
+Fixed support for Portaudio in build system with CMake 3.18
+([#5206](https://github.com/supercollider/supercollider/pull/5206)).
+
+Fixed support for building shared libscsynth on macOS and Linux
+([#5215](https://github.com/supercollider/supercollider/pull/5215)).
+
+General documentation improvements ([#5131](https://github.com/supercollider/supercollider/pull/5131), [#5136](https://github.com/supercollider/supercollider/pull/5136), [#5137](https://github.com/supercollider/supercollider/pull/5137), [#5141](https://github.com/supercollider/supercollider/pull/5141), [#5142](https://github.com/supercollider/supercollider/pull/5142), [#5173](https://github.com/supercollider/supercollider/pull/5173), [#5203](https://github.com/supercollider/supercollider/pull/5203)).
+
+### General: Removed
+
+Removed some unused code for old Android support ([#4975](https://github.com/supercollider/supercollider/pull/4975)).
+
+### Class library: Fixed
+
+Fixed a bug in Pfindur where the last event of the pattern could become "Rest-less"
+([#5113](https://github.com/supercollider/supercollider/pull/5113)).
+
+SynthDesc and SynthDescLib now restore metadata for SynthDefs
+([#5122](https://github.com/supercollider/supercollider/pull/5122)).
+
+Fixed an issue in output formatting for UnitTest:assertFloatEquals
+([#5135](https://github.com/supercollider/supercollider/pull/5135)).
+
+Pattern:record no longer ignores header and sample formats provided as arguments
+([#5031](https://github.com/supercollider/supercollider/pull/5031)).
+
+Pseg:embedInStream now returns 'inval' to match other patterns
+([#5145](https://github.com/supercollider/supercollider/pull/5145)).
+
+ProxySpace:copy also rebuilds the ProxySpace to copy referenced objects
+([#5192](https://github.com/supercollider/supercollider/pull/5192)).
+
+### Servers: Fixed
+
+Supernova now correctly handles `/s_getn` with a control name instead of index
+([#5182](https://github.com/supercollider/supercollider/pull/5182)).
+
 3.11.1 (2020-08-19)
 ===================
 

--- a/README.md
+++ b/README.md
@@ -27,13 +27,15 @@ See the [Raspberry Pi](README_RASPBERRY_PI.md) and [BeagleBone Black](README_BEA
 
 SuperCollider is tested with:
 - Windows 10 (32- and 64-bit) and MSVC 2017
-- macOS 10.13 and Xcode 9.4
+- macOS 10.13 with Xcode 9.4 and Xcode 10.1
 - Ubuntu 14.04 and gcc 4.9
 
 SuperCollider is known to support these platforms:
 - Windows Vista, 7, 8, and 10
 - macOS 10.13-10.15
 - Ubuntu 14.04-18.04
+
+We also provide a legacy macOS binary for macOS 10.10 and above using Qt 5.9.
 
 SuperCollider has guaranteed support for:
 - Windows 10

--- a/SCVersion.txt
+++ b/SCVersion.txt
@@ -3,8 +3,8 @@
 
 set(SC_VERSION_MAJOR 3)
 set(SC_VERSION_MINOR 11)
-set(SC_VERSION_PATCH 1)
-set(SC_VERSION_TWEAK "")
+set(SC_VERSION_PATCH 2)
+set(SC_VERSION_TWEAK "-rc1")
 set(SC_VERSION ${SC_VERSION_MAJOR}.${SC_VERSION_MINOR}.${SC_VERSION_PATCH}${SC_VERSION_TWEAK})
 
 # Note: these are provided for backwards compatibility only. In the main project, PROJECT_VERSION_PATCH


### PR DESCRIPTION
## Purpose and Motivation

This updates the changelog, readme, and main version number in the repo to prepare for the 3.11.2-rc1 release.

## Types of changes

- New feature

## To-do list

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review