### PR TITLE
classlib: WebView.runJavaScript() return types: add tests and docs

### DIFF
--- a/HelpSource/Classes/WebView.schelp
+++ b/HelpSource/Classes/WebView.schelp
@@ -235,6 +235,11 @@ METHOD:: runJavaScript
         A String.
     Argument::
         A function to be called when execution is complete, with the result as first argument.
+        NOTE:: javascript code can correctly return Numbers, Strings and Arrays, but it can't currently pass javascript Objects to sclang. It is possible however to use JSON serialization to acheive this: ::
+        CODE::
+// passing a nested object from javascript to sclang:
+WebView().runJavaScript("JSON.stringify({a: [1,2,3], b: {ba: 1, bb: 'yeah'}})"){ |res| res.parseJSON.postln }
+::
 
 EXAMPLES::
 CODE::

--- a/testsuite/classlibrary/TestWebView.sc
+++ b/testsuite/classlibrary/TestWebView.sc
@@ -55,4 +55,32 @@ TestWebView : UnitTest {
 			this.assert(wasFound.not, "findText should not find");
 		}
 	}
+
+	test_runJavaScript_returnTypes {
+		(
+			"1 + 1": 2 -> Integer,
+			"1 + 0.1": 1.1 -> Float,
+			"'hello'": "hello" -> String,
+			"[1, 2, 'hello']": [1, 2, "hello"] -> Array
+		).keysValuesDo { |jsCode, expected|
+			var expectedClass = expected.value, expectedResult = expected.key;
+			var condition = Condition(), returnedResult;
+
+			WebView().runJavaScript(jsCode){ |res|
+				returnedResult = res;
+				condition.test_(true).signal
+			};
+
+			this.wait(condition, "runJavaScript() callback was not called before timeout", 0.5);
+			this.assertEquals(returnedResult, expectedResult,
+				"runJavaScript(\"%\") should return the expected result %"
+				.format(jsCode, expectedResult)
+			);
+			this.assert(returnedResult.class == expectedClass,
+				"runJavaScript(\"%\") should return an instance of %. Returned: %"
+				.format(jsCode, expectedClass, returnedResult.class)
+			);
+			condition.test = false;
+		};
+	}
 }


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation
Completing #5216, adding tests for WebView:-runJavaScript return types, and a note in the docs.
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->
- Documentation
- Tests
## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review
