### PR TITLE
class library: don't warn by default when sending SynthDef

### DIFF
--- a/SCClassLibrary/Common/Audio/SynthDef.sc
+++ b/SCClassLibrary/Common/Audio/SynthDef.sc
@@ -19,6 +19,7 @@ SynthDef {
 	var <>desc, <>metadata;
 
 	classvar <synthDefDir;
+	classvar <>warnAboutLargeSynthDefs = false;
 
 	*synthDefDir_ { arg dir;
 		if (dir.last.isPathSeparator.not )
@@ -590,7 +591,9 @@ SynthDef {
 			server.sendMsg("/d_recv", bytes, completionMsg)
 		} {
 			if (server.isLocal) {
-				"SynthDef % too big for sending. Retrying via synthdef file".format(name).warn;
+				if(warnAboutLargeSynthDefs) {
+					"SynthDef % too big for sending. Retrying via synthdef file".format(name).warn;
+				};
 				this.writeDefFile(synthDefDir);
 				server.sendMsg("/d_load", synthDefDir ++ name ++ ".scsyndef", completionMsg)
 			} {


### PR DESCRIPTION

<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

Currently, the warning:

```
WARNING:  SynthDef lalala too big for sending. Retrying via synthdef file
```

is more irritating than useful. This patch removes it in the default case.

An option is left to switch it on for debugging purposes.


## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [ ] Updated documentation
- [ ] This PR is ready for review
