### PR TITLE
class library: don't warn by default when sending SynthDef

### DIFF
--- a/HelpSource/Classes/SynthDef.schelp
+++ b/HelpSource/Classes/SynthDef.schelp
@@ -133,6 +133,10 @@ warning:: code::SynthDef.writeOnce:: is a legacy method. Its main use was to imp
 
 The exception is very large SynthDefs, where you have a choice between link::#-writeDefFile:: and this method. Even then, the efficiency savings of code::writeOnce:: are only in disk I/O -- both methods build the SynthDef every time they run. ::
 
+
+method::warnAboutLargeSynthDefs
+When a SynthDef is too large to be sent to a local server in a standard OSC message, it is written to disk and the server loads it from there instead. If code::warnAboutLargeSynthDefs:: is set to true, it will warn that this is happening. There will always be a warning for remote servers.
+
 InstanceMethods::
 
 method:: add
@@ -245,7 +249,7 @@ y.set(\t_trig, 1, \freq, 220); // hear how the freq lags
 y.free;
 
 // Pbind with the default \note event type, and Pmono, use an automatically-generated
-// function to look up argument values. This function translates \trig in the 
+// function to look up argument values. This function translates \trig in the
 // event to \t_trig in the synth.
 (
 Pmono(\trigTest1, *[
@@ -255,7 +259,7 @@ Pmono(\trigTest1, *[
 ]).play;
 )
 
-// Note that With event type \set, there is no automatic translation so you 
+// Note that With event type \set, there is no automatic translation so you
 // should use t_trig in that case.
 y = Synth(\trigTest1);
 (
@@ -267,7 +271,7 @@ Pbind(*[
 ]).play;
 )
 y.free;
-	
+
 // This second version makes trig a \tr arg by specifying it in the rates array.
 (
 SynthDef(\trigTest2, { |out, trig=0, freq=440|

--- a/SCClassLibrary/Common/Audio/SynthDef.sc
+++ b/SCClassLibrary/Common/Audio/SynthDef.sc
@@ -591,8 +591,8 @@ SynthDef {
 		var resp, syncID;
 
 		if (bytes.size < (65535 div: 4)) {
- 			server.sendMsg("/d_recv", bytes, completionMsg)
- 		} {
+			server.sendMsg("/d_recv", bytes, completionMsg)
+		} {
 			if (server.isLocal) {
 				if(warnAboutLargeSynthDefs) {
 					"SynthDef % too big for sending. Retrying via synthdef file".format(name).warn;

--- a/SCClassLibrary/Common/Audio/SynthDef.sc
+++ b/SCClassLibrary/Common/Audio/SynthDef.sc
@@ -589,24 +589,25 @@ SynthDef {
 		var bytes = this.asBytes;
 		var path;
 		var resp, syncID;
+
 		if (bytes.size < (65535 div: 4)) {
-			path = synthDefDir +/+ name ++ ".scsyndef";
-			syncID = UniqueID.next;
-			resp = OSCFunc({
-				resp.remove;
-				File.delete(path);
-			}, '/synced', srcID: server.addr, argTemplate: [syncID]);
-			server.sendBundle(nil,
-				["/d_load", path, completionMsg],
-				["/sync", syncID]
-			);
-		} {
+ 			server.sendMsg("/d_recv", bytes, completionMsg)
+ 		} {
 			if (server.isLocal) {
 				if(warnAboutLargeSynthDefs) {
 					"SynthDef % too big for sending. Retrying via synthdef file".format(name).warn;
 				};
 				this.writeDefFile(synthDefDir);
-				server.sendMsg("/d_load", synthDefDir ++ name ++ ".scsyndef", completionMsg)
+				path = synthDefDir +/+ name ++ ".scsyndef";
+				syncID = UniqueID.next;
+				resp = OSCFunc({
+					resp.remove;
+					File.delete(path);
+				}, '/synced', srcID: server.addr, argTemplate: [syncID]);
+				server.sendBundle(nil,
+					["/d_load", path, completionMsg],
+					["/sync", syncID]
+				);
 			} {
 				"SynthDef % too big for sending.".format(name).warn;
 			}

--- a/SCClassLibrary/Common/Audio/SynthDef.sc
+++ b/SCClassLibrary/Common/Audio/SynthDef.sc
@@ -19,6 +19,7 @@ SynthDef {
 	var <>desc, <>metadata;
 
 	classvar <synthDefDir;
+	classvar <>warnAboutLargeSynthDefs = false;
 
 	*synthDefDir_ { arg dir;
 		if (dir.last.isPathSeparator.not )
@@ -590,7 +591,9 @@ SynthDef {
 			server.sendMsg("/d_recv", bytes, completionMsg)
 		} {
 			if (server.isLocal) {
-				"SynthDef % too big for sending. Retrying via synthdef file".format(name).warn;
+				if(warnAboutLargeSynthDefs) {
+					"SynthDef % too big for sending. Retrying via synthdef file".format(name).warn;
+				};
 				this.writeDefFile(synthDefDir);
 				server.sendMsg("/d_load", synthDefDir ++ name ++ ".scsyndef", completionMsg)
 			} {

--- a/SCClassLibrary/Common/Audio/SynthDef.sc
+++ b/SCClassLibrary/Common/Audio/SynthDef.sc
@@ -587,8 +587,19 @@ SynthDef {
 
 	doSend { |server, completionMsg|
 		var bytes = this.asBytes;
+		var path;
+		var resp, syncID;
 		if (bytes.size < (65535 div: 4)) {
-			server.sendMsg("/d_recv", bytes, completionMsg)
+			path = synthDefDir +/+ name ++ ".scsyndef";
+			syncID = UniqueID.next;
+			resp = OSCFunc({
+				resp.remove;
+				File.delete(path);
+			}, '/synced', srcID: server.addr, argTemplate: [syncID]);
+			server.sendBundle(nil,
+				["/d_load", path, completionMsg],
+				["/sync", syncID]
+			);
 		} {
 			if (server.isLocal) {
 				if(warnAboutLargeSynthDefs) {


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

supersedes the broken PR: #5236

## Purpose and Motivation

Currently, the warning:

```
WARNING:  SynthDef lalala too big for sending. Retrying via synthdef file
```

is more irritating than useful. This patch removes it in the default case.

An option is left to switch it on for debugging purposes.


## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review
