### PR TITLE
help browser: fix crash on exit with qt 5.9.3 build

### DIFF
--- a/editors/sc-ide/widgets/help_browser.cpp
+++ b/editors/sc-ide/widgets/help_browser.cpp
@@ -96,9 +96,12 @@ HelpBrowser::HelpBrowser(QWidget* parent): QWidget(parent) {
     // FIXME: should actually respond to class library shutdown, but we don't have that signal
     connect(scProcess, SIGNAL(classLibraryRecompiled()), mLoadProgressIndicator, SLOT(stop()));
 
+    // Legacy mac build support -- with Qt 5.9.3 this causes a segfault on application exit.
+#    if QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)
     // Delete the help browser's page to avoid an assert/crash during shutdown. See QTBUG-56441, QTBUG-50160.
     // Note that putting this in the destructor doesn't work.
     connect(QApplication::instance(), &QApplication::aboutToQuit, [this]() { delete mWebView->page(); });
+#    endif
 
     createActions();
 


### PR DESCRIPTION
## Purpose and Motivation

fixes #5229

tested here: https://github.com/supercollider/supercollider/issues/5229#issuecomment-720119452

since this only affects the legacy build, which uses a version of Qt we no longer support, it is a harmless change.

## Types of changes

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review