### PR TITLE
note about default sample rate on Windows

### DIFF
--- a/HelpSource/Classes/ServerOptions.schelp
+++ b/HelpSource/Classes/ServerOptions.schelp
@@ -107,6 +107,8 @@ A Boolean indicating whether this server should allow its volume to be set remot
 method:: sampleRate
 The preferred sample rate. If non-nil the server app will attempt to set the sample rate of the hardware. The hardware has to support the sample rate that you choose.
 
+note:: On Windows, leaving the code::sampleRate:: as code::nil:: for an code::ASIO:: device will likely result in setting the hardware to run at 44100 Hz.::
+
 method:: verbosity
 Controls the verbosity of server messages. A value of 0 is normal behaviour. -1 suppresses informational messages. -2 suppresses informational and many error messages, as well as messages from Poll. The default is 0.
 

--- a/HelpSource/Reference/AudioDeviceSelection.schelp
+++ b/HelpSource/Reference/AudioDeviceSelection.schelp
@@ -117,6 +117,8 @@ ServerOptions.outDevices; // output devices
 ::
 Partial device name matching is supported in Windows (though not in macOS).
 
+note:: Leaving the code::sampleRate:: (e.g. code::Server.default.options.sampleRate::) as code::nil:: for an code::ASIO:: device will likely result in setting the hardware to run at 44100 Hz.::
+
 subsection:: Choosing the device and the API
 list::
 ##If you need to specify the device, you will need to do so for both input and output (setting both code::.inDevice::, as well as code::.outDevice::), unless you use ASIO


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->
On Windows, setting `sampleRate` to `nil` for `ASIO` devices does not result in using hardware sample rate.

I believe other APIs default to a mix of 44100 or 48000 and use resampling if needed, but I might be wrong; I'm documenting only for ASIO here, as I'm sure this is the behavior with this API.
Suggested in https://www.listarc.bham.ac.uk/lists/sc-users/msg68893.html

EDIT: I manually cancelled builds since this is a help-only PR

## Types of changes

<!-- Delete lines that don't apply -->

- Documentation


## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review
