### PR TITLE
scide: don't change indentation of commented regions

### DIFF
--- a/editors/sc-ide/widgets/code_editor/sc_editor.cpp
+++ b/editors/sc-ide/widgets/code_editor/sc_editor.cpp
@@ -917,8 +917,6 @@ void ScCodeEditor::toggleCommentSelection() {
         QString selectionText = cursor.selectedText();
         QTextCursor selectionCursor(cursor);
         if (isSelectionComment(selectionText)) {
-            selectionText = selectionText.trimmed().remove(0, 2);
-            selectionText.chop(2);
             selectionCursor.insertText(selectionText);
         } else {
             selectionText = QStringLiteral("/*") + selectionText + QStringLiteral("*/");


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

Currently:
- commented regions affect the behaviour of the indentation
- when indenting a whole file, commented code is "flattened" to the left

It can be sometimes very destructive if you are commenting out parts of the code - it would be much better of the indentation would _ignore_ commented text.

Fixes #1240

## Types of changes

<!-- Delete lines that don't apply -->

- New feature

Instead, the commented region is just left as it was.

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [ ] Code is tested
- [ ] All tests are passing
- [ ] Updated documentation
- [ ] This PR is ready for review

