### PR TITLE
Make Jack Startup environment variables usable.

### DIFF
--- a/HelpSource/Classes/LinuxPlatform.schelp
+++ b/HelpSource/Classes/LinuxPlatform.schelp
@@ -6,16 +6,9 @@ description::
 This class is available only on Linux, and implements Linux platform-specific methods.
 
 subsection:: Environment variables for Jack
-It is possible to set some environment variables in your operating system to automate connecting the Jack Audio Server on startup.
+Among other things, this class makes it possible to set some environment variables in your Linux operating system to automate connecting the Jack Audio Server on startup.
 
-If these are not set, SuperCollider will default to connecting SuperCollider's inputs and outputs to your system's inputs and outputs.
-
-This may be changed by setting the following environment variables in your STRONG::.bash_profile::, STRONG::.zsh_profile:: or similar startup file for your shell.
-
-code::
-export SC_JACK_DEFAULT_INPUTS = "system"
-export SC_JACK_DEFAULT_OUTPUTS = "system"
-::
+See link::Reference/AudioDeviceSelection#Linux:: for more information on this.
 
 classmethods::
 

--- a/HelpSource/Classes/LinuxPlatform.schelp
+++ b/HelpSource/Classes/LinuxPlatform.schelp
@@ -5,6 +5,18 @@ categories:: Platform
 description::
 This class is available only on Linux, and implements Linux platform-specific methods.
 
+subsection:: Environment variables for Jack
+It is possible to set some environment variables in your operating system to automate connecting the Jack Audio Server on startup.
+
+If these are not set, SuperCollider will default to connecting SuperCollider's inputs and outputs to your system's inputs and outputs.
+
+This may be changed by setting the following environment variables in your STRONG::.bash_profile::, STRONG::.zsh_profile:: or similar startup file for your shell.
+
+code::
+export SC_JACK_DEFAULT_INPUTS = "system"
+export SC_JACK_DEFAULT_OUTPUTS = "system"
+::
+
 classmethods::
 
 subsection:: Setting or finding a terminal emulator
@@ -23,3 +35,5 @@ The first code::"%":: is a placeholder for the window title, and the second is a
 method:: getTerminalEmulatorCmd
 scans the system for a supported terminal emulator. This method runs synchronously, and could block other scheduled operations while searching. If you rely on link::Classes/String#-runInTerminal::, it is recommended to run this method before you start scheduling Patterns or Routines, or to set link::#*runInTerminalCmd:: manually.
 returns:: command to invoke a terminal emulator, to be used as link::Classes/LinuxPlatform#*runInTerminalCmd::
+
+KEYWORD:: jack,linux

--- a/HelpSource/Reference/AudioDeviceSelection.schelp
+++ b/HelpSource/Reference/AudioDeviceSelection.schelp
@@ -72,18 +72,16 @@ section:: Linux
 By default, SuperCollider on Linux uses JACK, and the audio device selection is managed by the JACK server. teletype::ServerOptions:: cannot override JACK's selection of audio hardware.
 
 subsection:: Setup with JACK server
-note::The SuperCollider server is considered a JACK emphasis::client::. In the following section, the term emphasis::client:: will refer to the SuperCollider server, from the perspective of JACK. ::
+The SuperCollider server is considered a JACK emphasis::client::. In the following section, the term emphasis::client:: will refer to the SuperCollider server, from the perspective of JACK.
 
 When the server is compiled to use JACK as the audio backend, the code::ServerOption::'s teletype::device:: can be used in two ways:
-list::
-## to set the client name to register with JACK:
+to set the client name to register with JACK:
 code::
 Server.default.options.device = "my_synth";
 ::
-## to use a specific JACK server, as well as set the client name:
+to use a specific JACK server, as well as set the client name:
 code::
 Server.default.options.device = "JACKServerName:scsynthName";
-::
 ::
 A code::nil:: device is equivalent to code::Server.default.options.device = "default:SuperCollider";::
 

--- a/HelpSource/Reference/AudioDeviceSelection.schelp
+++ b/HelpSource/Reference/AudioDeviceSelection.schelp
@@ -92,16 +92,7 @@ teletype::SC_JACK_DEFAULT_OUTPUTS::. These allow SuperCollider to detect system 
 
 These variables are written as a string that specifies another jack client or a comma-separated list of jack ports formatted as a string.
 
-If these are not set, SuperCollider will default to connecting SuperCollider's inputs and outputs to your system's inputs and outputs.
-
-This may be changed by setting the following environment variables in your STRONG::.bash_profile::, STRONG::.zsh_profile:: or similar startup file for your shell:
-
-code::
-export SC_JACK_DEFAULT_INPUTS = "system"
-export SC_JACK_DEFAULT_OUTPUTS = "system"
-::
-
-Alternatively, you can also set these from SuperCollider:
+If these are not set, SuperCollider will default to connecting SuperCollider's inputs and outputs to your system's inputs and outputs. This is the recommended way of changing the Jack environment variables for SuperCollider from within a SuperCollider script:
 
 code::
 // connect first to input channels with system
@@ -111,6 +102,12 @@ code::
 "SC_JACK_DEFAULT_OUTPUTS".setenv("system");
 ::
 
+As an alternative, these may be also be changed by setting the following environment variables in your STRONG::.bash_profile::, STRONG::.zsh_profile:: or similar startup file for your shell:
+
+code::
+export SC_JACK_DEFAULT_INPUTS = "system"
+export SC_JACK_DEFAULT_OUTPUTS = "system"
+::
 
 section:: Windows
 

--- a/HelpSource/Reference/AudioDeviceSelection.schelp
+++ b/HelpSource/Reference/AudioDeviceSelection.schelp
@@ -87,8 +87,23 @@ Server.default.options.device = "JACKServerName:scsynthName";
 ::
 A code::nil:: device is equivalent to code::Server.default.options.device = "default:SuperCollider";::
 
+subsection:: Jack Environment variables
+
 The JACK connections can be configured via the environment variables teletype::SC_JACK_DEFAULT_INPUTS:: and
-teletype::SC_JACK_DEFAULT_OUTPUTS::. The format is either a string that specifies another jack client or a comma-separated list of jack ports.
+teletype::SC_JACK_DEFAULT_OUTPUTS::. These allow SuperCollider to detect system preferences for Jack inputs and outputs to/from the scsynth server. 
+
+These variables are written as a string that specifies another jack client or a comma-separated list of jack ports formatted as a string.
+
+If these are not set, SuperCollider will default to connecting SuperCollider's inputs and outputs to your system's inputs and outputs.
+
+This may be changed by setting the following environment variables in your STRONG::.bash_profile::, STRONG::.zsh_profile:: or similar startup file for your shell:
+
+code::
+export SC_JACK_DEFAULT_INPUTS = "system"
+export SC_JACK_DEFAULT_OUTPUTS = "system"
+::
+
+Alternatively, you can also set these from SuperCollider:
 
 code::
 // connect first to input channels with system
@@ -97,6 +112,7 @@ code::
 // connect all output channels with system
 "SC_JACK_DEFAULT_OUTPUTS".setenv("system");
 ::
+
 
 section:: Windows
 

--- a/SCClassLibrary/Platform/linux/LinuxPlatform.sc
+++ b/SCClassLibrary/Platform/linux/LinuxPlatform.sc
@@ -19,8 +19,14 @@ LinuxPlatform : UnixPlatform {
 		Score.program = Server.program;
 
 		// default jack port hookup
-		"SC_JACK_DEFAULT_INPUTS".setenv("system");
-		"SC_JACK_DEFAULT_OUTPUTS".setenv("system");
+		// use "system" as default when env vars haven't been set by user
+		if("SC_JACK_DEFAULT_INPUTS".getenv.isNil, {
+			"SC_JACK_DEFAULT_INPUTS".setenv("system")
+		});
+
+		if("SC_JACK_DEFAULT_OUTPUTS".getenv.isNil, {
+			"SC_JACK_DEFAULT_OUTPUTS".setenv("system")
+		});
 
 		// automatically start jack when booting the server
 		// can still be overridden with JACK_NO_START_SERVER


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation
Fixes https://github.com/supercollider/supercollider/issues/5260

This PR makes it possible to set the Jack environment variables on Linux to let SC automatically connect it's inputs and outputs to other jack nodes on startup. These were hardcoded to be "system" by default and were never checked by the system but they are with this PR.

The usage of these has been documented as well in the LinuxPlatform help file. 


## Types of changes

<!-- Delete lines that don't apply -->

- Documentation
- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [ ] Code is tested
- [ ] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review
