### PR TITLE
GHA: add github actions for linux and macos

### DIFF
--- a/.github/workflows/actions-test.yml
+++ b/.github/workflows/actions-test.yml
@@ -1,5 +1,5 @@
 name: check, build, test
-on: [push]
+on: [push, pull_request]
 jobs:
   linter:
     runs-on: ubuntu-18.04

--- a/.github/workflows/actions-test.yml
+++ b/.github/workflows/actions-test.yml
@@ -1,0 +1,300 @@
+name: check, build, test
+on: [push]
+jobs:
+  linter:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      - name: lint class library
+        run: |
+          sudo npm install -g lintspaces-cli
+          lintspaces -e .editorconfig SCClassLibrary/**/*.sc || true # ignore failure
+
+      - name: lint cpp files
+        run: |
+          echo "Running tools/clang-format.py lintall"
+          tools/clang-format.py -c clang-format-8 -d clang-format-diff-8 lintall || exit 1
+          echo "Lint successful"
+
+  Linux:
+    needs: linter
+    runs-on: ubuntu-${{ matrix.os-version }} 
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # - job-name: 'xenial gcc5' # disabled because of  https://github.com/jurplel/install-qt-action/issues/65
+          #   os-version: '16.04'
+          #   c-compiler: 'gcc-5'
+          #   cxx-compiler: 'g++-5'
+          #   use-syslibs: false
+          #   shared-libscsynth: false
+          #   qt-version: '5.9.3' # manually install requested version of qt
+          #   # artifact-suffix: 'linux-bionic-gcc9' # set if needed - will trigger artifact upload
+
+          - job-name: 'bionic gcc7'
+            os-version: '18.04'
+            c-compiler: 'gcc-7'
+            cxx-compiler: 'g++-7'
+            use-syslibs: false
+            shared-libscsynth: false
+
+          - job-name: 'bionic gcc8'
+            os-version: '18.04'
+            c-compiler: 'gcc-8'
+            cxx-compiler: 'g++-8'
+            use-syslibs: false
+            shared-libscsynth: false
+
+          - job-name: 'bionic gcc9'
+            os-version: '18.04'
+            c-compiler: 'gcc-9'
+            cxx-compiler: 'g++-9'
+            use-syslibs: false
+            shared-libscsynth: false
+
+          - job-name: 'bionic gcc9 shared libscsynth'
+            os-version: '18.04'
+            c-compiler: 'gcc-9'
+            cxx-compiler: 'g++-9'
+            use-syslibs: false
+            shared-libscsynth: true
+
+          - job-name: 'bionic gcc10'
+            os-version: '18.04'
+            c-compiler: 'gcc-10'
+            cxx-compiler: 'g++-10'
+            use-syslibs: false
+            shared-libscsynth: false
+            artifact-suffix: 'linux-bionic-gcc10' # set if needed - will trigger artifact upload
+
+          # - job-name: 'focal gcc10 use syslibs' # disabled - boost version incompatible
+          #   os-version: '20.04'
+          #   c-compiler: 'gcc-10'
+          #   cxx-compiler: 'g++-10'
+          #   use-syslibs: true
+          #   shared-libscsynth: false
+
+          - job-name: 'bionic clang6.0'
+            os-version: '18.04'
+            c-compiler: 'clang-6.0'
+            cxx-compiler: 'clang++-6.0'
+            use-syslibs: false
+            shared-libscsynth: false
+
+          - job-name: 'bionic clang8'
+            os-version: '18.04'
+            c-compiler: 'clang-8'
+            cxx-compiler: 'clang++-8'
+            use-syslibs: false
+            shared-libscsynth: false
+
+          - job-name: 'bionic clang9'
+            os-version: '18.04'
+            c-compiler: 'clang-9'
+            cxx-compiler: 'clang++-9'
+            use-syslibs: false
+            shared-libscsynth: false
+
+          - job-name: 'focal clang10'
+            os-version: '20.04'
+            c-compiler: 'clang-10'
+            cxx-compiler: 'clang++-10'
+            use-syslibs: false
+            shared-libscsynth: false
+
+    env: 
+      BUILD_PATH: ${{ github.workspace }}/build
+      INSTALL_PATH: ${{ github.workspace }}/build/Install
+      USE_SYSLIBS: ${{ matrix.use-syslibs }}
+      SHARED_LIBSCSYNTH: ${{ matrix.shared-libscsynth }}
+      CC: ${{ matrix.c-compiler }}
+      CXX: ${{ matrix.cxx-compiler }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      - name: set sc version and artifact filename
+        run: |
+          # set SC_VERSION to tag (if present) or to commit SHA
+          SC_VERSION=
+          if [[ "$GITHUB_REF" == refs/tags/* ]]; then 
+            FULL_TAG=${GITHUB_REF#refs/tags/}
+            TAG=${FULL_TAG##Version-}
+            SC_VERSION=$TAG
+          else
+            SC_VERSION=$GITHUB_SHA
+          fi
+          echo "ARTIFACT_FILE=SuperCollider-$SC_VERSION-${{ matrix.artifact-suffix }}.zip" >> $GITHUB_ENV
+      - name: cache ccache
+        uses: actions/cache@v2
+        with:
+          path: ~/.ccache
+          key: ${{ runner.os }}-v1-${{ matrix.os-version }}-${{ matrix.c-compiler }}-${{ matrix.use-syslibs }}-${{ matrix.shared-libscsynth }} # -v2- etc can be used for "clearing" the cache, it's not functionally connected to the version of the script
+      - name: install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes build-essential cmake pkg-config libjack-jackd2-dev libsndfile1-dev libasound2-dev libavahi-client-dev libreadline6-dev libfftw3-dev libicu-dev libxt-dev libudev-dev emacs ccache
+      - name: install system libraries
+        if: env.USE_SYSLIBS == 'true'
+        run: sudo apt-get install --yes libboost-thread-dev libboost-system-dev libboost-filesystem-dev libboost-regex-dev libboost-test-dev libboost-program-options-dev libyaml-cpp-dev
+      - name: install qt from apt
+        if: '!matrix.qt-version'
+        run: sudo apt-get install qt5-default qt5-qmake qttools5-dev qttools5-dev-tools qtdeclarative5-dev libqt5svg5-dev libqt5websockets5-dev qtwebengine5-dev
+      # custon Qt version doesn't work in ubuntu 16.04 - see https://github.com/jurplel/install-qt-action/issues/65
+      - name: install qt - specific version
+        uses: jurplel/install-qt-action@v2
+        if: matrix.qt-version
+        with:
+          modules: qtwebengine
+          version: ${{ matrix.qt-version }}
+      - name: configure
+        run: |
+          mkdir $BUILD_PATH && cd $BUILD_PATH
+          
+          EXTRA_CMAKE_FLAGS=
+
+          if $USE_SYSLIBS; then EXTRA_CMAKE_FLAGS="-DSYSTEM_BOOST=ON -DSYSTEM_YAMLCPP=ON"; fi
+
+          if $SHARED_LIBSCSYNTH; then EXTRA_CMAKE_FLAGS="-DLIBSCSYNTH=ON $EXTRA_CMAKE_FLAGS"; fi
+
+          cmake $EXTRA_CMAKE_FLAGS -DSC_EL=ON -DSC_VIM=ON -DSC_ED=ON -DSC_QT=ON -DSC_IDE=ON  -DCMAKE_INSTALL_PREFIX:PATH=$INSTALL_PATH -DCMAKE_BUILD_TYPE=Release .. # --debug-output
+      - name: build
+        run: |
+          cd $BUILD_PATH
+          make install -j2
+      - name: create archive
+        if: matrix.artifact-suffix
+        run: cd $INSTALL_PATH && zip --symlinks -r $ARTIFACT_FILE .
+      - name: upload artifacts
+        uses: actions/upload-artifact@v2
+        if: matrix.artifact-suffix
+        with:
+          name: ${{ env.ARTIFACT_FILE }}
+          path: ${{ env.INSTALL_PATH }}/${{ env.ARTIFACT_FILE }}
+          retention-days: 7 # quickly remove test artifacts
+
+  macOS:
+    needs: linter
+    runs-on: macos-${{ matrix.os-version }} 
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+
+          - job-name: 'macOS'
+            os-version: '10.15'
+            xcode-version: '11.7'
+            use-syslibs: false
+            shared-libscsynth: false
+            artifact-suffix: 'macOS' # set if needed - will trigger artifact upload
+
+          # - job-name: 'macOS legacy'
+          #   os-version: '10.15'
+          #   xcode-version: '10.3'
+          #   qt-version: '5.9' # will use qt not from homebrew
+          #   use-syslibs: false
+          #   shared-libscsynth: false
+          #   artifact-suffix: 'macOS-legacy' # set if needed - will trigger artifact upload
+
+          - job-name: 'macOS use syslibs'
+            os-version: '10.15'
+            xcode-version: '11.7'
+            use-syslibs: true
+            shared-libscsynth: false
+
+          - job-name: 'macOS shared libscsynth'
+            os-version: '10.15'
+            xcode-version: '11.7'
+            use-syslibs: false
+            shared-libscsynth: true
+
+    env: 
+      BUILD_PATH: ${{ github.workspace }}/build
+      INSTALL_PATH: ${{ github.workspace }}/build/Install
+      HOMEBREW_NO_ANALYTICS: 1
+      HOMEBREW_NO_AUTO_UPDATE: 1
+      HOMEBREW_NO_INSTALL_CLEANUP: 1
+      USE_SYSLIBS: ${{ matrix.use-syslibs }}
+      SHARED_LIBSCSYNTH: ${{ matrix.shared-libscsynth }}
+      DEVELOPER_DIR: '/Applications/Xcode_${{ matrix.xcode-version }}.app/Contents/Developer'
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      - name: set sc version and artifact filename
+        run: |
+          # set SC_VERSION to tag (if present) or to commit SHA
+          SC_VERSION=
+          if [[ "$GITHUB_REF" == refs/tags/* ]]; then 
+            FULL_TAG=${GITHUB_REF#refs/tags/}
+            TAG=${FULL_TAG##Version-}
+            SC_VERSION=$TAG
+          else
+            SC_VERSION=$GITHUB_SHA
+          fi
+          echo "ARTIFACT_FILE=SuperCollider-$SC_VERSION-${{ matrix.artifact-suffix }}.zip" >> $GITHUB_ENV
+      - name: cache ccache
+        uses: actions/cache@v2
+        with:
+          path: ~/Library/Caches/ccache
+          key: ${{ runner.os }}-v1-${{ matrix.os-version }}-${{ matrix.xcode-version }}-${{ matrix.use-syslibs }}-${{ matrix.shared-libscsynth }}-${{ matrix.qt-version }} # -v2- etc can be used for "clearing" the cache, it's not functionally connected to the version of the script
+      - name: cache qt
+        id: cache-qt
+        uses: actions/cache@v1
+        if: matrix.qt-version
+        with:
+          path: ../Qt
+          key: ${{ runner.os }}-v1-${{ matrix.os-version }}-${{ matrix.xcode-version }}-${{ matrix.use-syslibs }}-${{ matrix.shared-libscsynth }}-qt${{ matrix.qt-version }}
+      - name: install qt - specific version
+        uses: jurplel/install-qt-action@v2
+        if: matrix.qt-version
+        with:
+          modules: 'qtwebengine'
+          version: ${{ matrix.qt-version }}
+          cached: ${{ steps.cache-qt.outputs.cache-hit }}
+      - name: install dependencies
+        run: |
+          brew install libsndfile portaudio ccache fftw ninja # ninja added temporarily
+          # add ccamke to PATH - see https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions
+          echo "/usr/local/opt/ccache/libexec" >> $GITHUB_PATH
+          # To get less noise in xcode output
+          gem install xcpretty
+      - name: install syslibs
+        if: env.USE_SYSLIBS == 'true'
+        run: brew install yaml-cpp boost
+      - name: install qt from homebrew
+        if: '!matrix.qt-version'
+        run: brew install qt
+  
+      - name: configure
+        run: |
+          mkdir $BUILD_PATH && cd $BUILD_PATH
+          
+          EXTRA_CMAKE_FLAGS=
+          
+          if $USE_SYSLIBS; then EXTRA_CMAKE_FLAGS="-DSYSTEM_BOOST=ON -DSYSTEM_YAMLCPP=ON $EXTRA_CMAKE_FLAGS"; fi
+          
+          if $SHARED_LIBSCSYNTH; then EXTRA_CMAKE_FLAGS="-DLIBSCSYNTH=ON $EXTRA_CMAKE_FLAGS"; fi
+          
+          if [[ -z "${{ matrix.qt-version }}" ]]; then EXTRA_CMAKE_FLAGS="-DCMAKE_PREFIX_PATH=`brew --prefix qt5` $EXTRA_CMAKE_FLAGS"; fi
+
+          echo "EXTRA_CMAKE_FLAGS:" $EXTRA_CMAKE_FLAGS
+
+          # cmake -G"Xcode" -DRULE_LAUNCH_COMPILE=ccache -DCMAKE_OSX_DEPLOYMENT_TARGET=10.10 -DSUPERNOVA=ON $EXTRA_CMAKE_FLAGS $EXTRA_CMAKE_FLAGS .. # --debug-output
+
+          cmake -G"Ninja" -DRULE_LAUNCH_COMPILE=ccache -DCMAKE_OSX_DEPLOYMENT_TARGET=10.10 -DSUPERNOVA=ON -DCMAKE_BUILD_TYPE=Release $EXTRA_CMAKE_FLAGS .. --debug-output
+      - name: build
+        run: cmake --build $BUILD_PATH --config Release --target install
+      - name: create archive
+        if: matrix.artifact-suffix
+        run: cd $INSTALL_PATH && zip --symlinks -r $ARTIFACT_FILE SuperCollider # this assumes that we end up with the build in the folder SuperCollider
+      - name: upload artifacts
+        uses: actions/upload-artifact@v2
+        if: matrix.artifact-suffix
+        with:
+          name: ${{ env.ARTIFACT_FILE }}
+          path: ${{ env.INSTALL_PATH }}/${{ env.ARTIFACT_FILE }}
+          retention-days: 7 # quickly remove test artifacts


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

Add GitHub Actions CI for linux and macOS. See #5261 for prior discussion

Implemented:

- build matrix for both linux and macOS (mostly complete)
- ccache (cached between builds)
- linting
- artifact names use either tag or commit sha (if tag is not present)

todo:
- upload/publish nightly builds

not implemented / for later:
- run tests
- create windows builds
- fix macOS legacy builds
- automatic deployment

Notes:
- I think we need a new label. Should it be "GitHub Actions", "GHA", "Actions" or maybe just "CI"?
- Most names (like names of steps etc) are starting lowercase now. Is this OK or should they start with a capital letter?
- For nightly builds: we either need to upload them to S3, or maybe there's a way to use some external script with [GH API](https://docs.github.com/en/free-pro-team@latest/rest/reference/actions#artifacts)?
- I've set artifacts to expire quickly (7 days); I think that's fine for PRs, but I thought that maybe artifacts on the main repo/branches should expire longer; this should be easy to implement I think

## Types of changes

<!-- Delete lines that don't apply -->

- New feature

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [ ] All tests are passing
- [ ] Updated documentation
- [x] This PR is ready for review
