### PR TITLE
Classlib: Pattern:record should sync recording synth to pattern synths

### DIFF
--- a/SCClassLibrary/Common/Streams/Patterns.sc
+++ b/SCClassLibrary/Common/Streams/Patterns.sc
@@ -95,33 +95,45 @@ Pattern : AbstractFunction {
 
 	record { |path, headerFormat, sampleFormat, numChannels = 2, dur = nil, fadeTime = 0.2, clock(TempoClock.default), protoEvent(Event.default), server(Server.default), out = 0, outNumChannels|
 
-		var recorder = Recorder(server);
+		var buffer, nodeID, defname;
 		var pattern = if(dur.notNil) { Pfindur(dur, this) } { this };
 
-		recorder.recHeaderFormat = headerFormat;
-		recorder.recSampleFormat = sampleFormat;
-
 		server.waitForBoot {
-			var group, bus, startTime, free, monitor;
+			var group, bus, free, monitor;
 
-			recorder.prepareForRecord(path, numChannels);
-			fadeTime = (fadeTime ? 0).roundUp(recorder.numFrames / server.sampleRate);
+			buffer = Buffer.alloc(server, 32768, numChannels);
+			buffer.write(path, headerFormat, sampleFormat, 0, leaveOpen: true);
+			defname = SystemSynthDefs.generateTempName;
+			SynthDef(defname, { |bufnum, bus|
+				var sig = In.ar(bus, numChannels);
+				DiskOut.ar(bufnum, sig);
+			}).add;
+
+			fadeTime = (fadeTime ? 0).roundUp(buffer.duration);
 
 			bus = Bus.audio(server, numChannels);
 			group = Group(server);
 			Monitor.new.play(bus.index, bus.numChannels, out, outNumChannels ? numChannels, group);
 			server.sync;
 
-			free = { recorder.stopRecording; bus.free; group.free };
+			free = {
+				(type: \off, id: nodeID, server: server, hasGate: false).play;
+				{
+					bus.free; group.free;
+					buffer.free;
+					server.sendMsg(\d_free, defname);
+				}.defer(server.latency);
+			};
 
 			Pprotect(
 				Pfset(nil,
 					Pseq([
-						Pfuncn {
-							startTime = thisThread.beats;
-							(type: \rest, delta: 0)
-						},
-						(play: { recorder.record(path, bus, numChannels, group) }, delta: 0),
+						(
+							type: \on, id: nodeID, instrument: defname,
+							bus: bus, group: group, addAction: \addAfter,
+							delta: 0,
+							callback: { nodeID = ~id }
+						),
 						pattern <> (out: bus),
 						(type: \rest, delta: fadeTime)
 					], 1),


### PR DESCRIPTION
## Purpose and Motivation

https://scsynth.org/t/calling-supercollider-script-from-windows-batch-file/2964/8 reports that an audio file produced by `pattern.record` begins with some silence, where a reasonable expectation would be that the recording begins exactly at the onset of the pattern's audio.

This is because `pattern.record` uses the convenience class Recorder, so it gives up control over the exact moment of launching the recording synth.

I posted an alternate version on the forum, and it was only a couple more minutes to turn it into a PR.

Tested with:

```supercollider
Pbind(\degree, Pseries(0, 1, 8), \dur, 0.5).record("~/tmp/testzzz.wav".standardizePath, "wav", "int16");
```

... and the file is produced correctly, with no gap at the beginning.

## Types of changes

- Bug fix

## To-do list

- [x] Code is tested
- [x] All tests are passing
- [ ] ~~Updated documentation~~
- [x] This PR is ready for review