### PR TITLE
Classlib: SynthDesc should produce a valid rate symbol for DUGens

### DIFF
--- a/SCClassLibrary/Common/Audio/SynthDesc.sc
+++ b/SCClassLibrary/Common/Audio/SynthDesc.sc
@@ -272,7 +272,7 @@ SynthDesc {
 			ugenInputs = ugenInputs.add(input);
 		};
 
-		rate = #[\scalar,\control,\audio][rateIndex];
+		rate = #[\scalar, \control, \audio, \demand][rateIndex];
 		ugen = ugenClass.newFromDesc(rate, numOutputs, ugenInputs, specialIndex).source;
 		ugen.addToSynth(ugen);
 
@@ -346,7 +346,7 @@ SynthDesc {
 			ugenInputs = ugenInputs.add(input);
 		};
 
-		rate = #[\scalar,\control,\audio][rateIndex];
+		rate = #[\scalar, \control, \audio, \demand][rateIndex];
 		ugen = ugenClass.newFromDesc(rate, numOutputs, ugenInputs, specialIndex).source;
 		ugen.addToSynth(ugen);
 


### PR DESCRIPTION
## Purpose and Motivation

Fixes #5276.

It turns out that SynthDesc, when building a UGen object from a binary graphdef stream, has always been creating demand units with rate = `nil`.

By chance, this never threw an error -- but the error was exposed by the first multi-out demand unit to be added into sc3-plugins.

Simple fix: Just provide `\demand` in the table that converts a rate index to a symbol.

## Types of changes

- Bug fix

## To-do list

- [x] Code is tested
- [x] All tests are passing
- [ ] ~~Updated documentation~~
- [x] This PR is ready for review
