### PR TITLE
GHA: refresh ccache daily, add homebrew download cache

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -3,6 +3,8 @@ on: [push, pull_request]
 jobs:
   linter:
     runs-on: ubuntu-18.04
+    outputs: 
+      sc-version: ${{ steps.set-version.outputs.version }}
     steps:
       - uses: actions/checkout@v2
         with:
@@ -11,12 +13,21 @@ jobs:
         run: |
           sudo npm install -g lintspaces-cli
           lintspaces -e .editorconfig SCClassLibrary/**/*.sc || true # ignore failure
-
       - name: lint cpp files
         run: |
           echo "Running tools/clang-format.py lintall"
           tools/clang-format.py -c clang-format-8 -d clang-format-diff-8 lintall || exit 1
           echo "Lint successful"
+      - name: set version string for artifacts
+        id: set-version
+        run: |
+          if [[ "$GITHUB_REF" == refs/tags/* ]]; then 
+            FULL_TAG=${GITHUB_REF#refs/tags/}
+            SC_VERSION=${FULL_TAG##Version-}
+          else
+            SC_VERSION=$GITHUB_SHA
+          fi
+          echo "::set-output name=version::$SC_VERSION"
 
   Linux:
     needs: linter
@@ -113,6 +124,7 @@ jobs:
       SHARED_LIBSCSYNTH: ${{ matrix.shared-libscsynth }}
       CC: ${{ matrix.c-compiler }}
       CXX: ${{ matrix.cxx-compiler }}
+      ARTIFACT_FILE: 'SuperCollider-${{ needs.linter.outputs.sc-version }}-${{ matrix.artifact-suffix }}.zip'
     steps:
       - uses: actions/checkout@v2
         with:
@@ -165,19 +177,6 @@ jobs:
         run: |
           cd $BUILD_PATH
           make install -j2
-      - name: set artifact filename
-        if: matrix.artifact-suffix
-        run: |
-          # set SC_VERSION to tag (if present) or to commit SHA
-          SC_VERSION=
-          if [[ "$GITHUB_REF" == refs/tags/* ]]; then 
-            FULL_TAG=${GITHUB_REF#refs/tags/}
-            TAG=${FULL_TAG##Version-}
-            SC_VERSION=$TAG
-          else
-            SC_VERSION=$GITHUB_SHA
-          fi
-          echo "ARTIFACT_FILE=SuperCollider-$SC_VERSION-${{ matrix.artifact-suffix }}.zip" >> $GITHUB_ENV
       - name: create archive
         if: matrix.artifact-suffix
         run: cd $INSTALL_PATH && zip --symlinks -r $ARTIFACT_FILE .
@@ -234,6 +233,7 @@ jobs:
       USE_SYSLIBS: ${{ matrix.use-syslibs }}
       SHARED_LIBSCSYNTH: ${{ matrix.shared-libscsynth }}
       DEVELOPER_DIR: '/Applications/Xcode_${{ matrix.xcode-version }}.app/Contents/Developer'
+      ARTIFACT_FILE: 'SuperCollider-${{ needs.linter.outputs.sc-version }}-${{ matrix.artifact-suffix }}.zip'
     steps:
       - uses: actions/checkout@v2
         with:
@@ -304,19 +304,6 @@ jobs:
           cmake -G"Ninja" -DRULE_LAUNCH_COMPILE=ccache -DCMAKE_OSX_DEPLOYMENT_TARGET=10.10 -DSUPERNOVA=ON -DCMAKE_BUILD_TYPE=Release $EXTRA_CMAKE_FLAGS .. --debug-output
       - name: build
         run: cmake --build $BUILD_PATH --config Release --target install
-      - name: set artifact filename
-        if: matrix.artifact-suffix
-        run: |
-          # set SC_VERSION to tag (if present) or to commit SHA
-          SC_VERSION=
-          if [[ "$GITHUB_REF" == refs/tags/* ]]; then 
-            FULL_TAG=${GITHUB_REF#refs/tags/}
-            TAG=${FULL_TAG##Version-}
-            SC_VERSION=$TAG
-          else
-            SC_VERSION=$GITHUB_SHA
-          fi
-          echo "ARTIFACT_FILE=SuperCollider-$SC_VERSION-${{ matrix.artifact-suffix }}.zip" >> $GITHUB_ENV
       - name: create archive
         if: matrix.artifact-suffix
         run: cd $INSTALL_PATH && zip --symlinks -r $ARTIFACT_FILE SuperCollider # this assumes that we end up with the build in the folder SuperCollider

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -252,6 +252,7 @@ jobs:
           restore-keys: ${{ runner.os }}-${{ matrix.os-version }}-${{ matrix.xcode-version }}-${{ matrix.use-syslibs }}-${{ matrix.shared-libscsynth }}-${{ matrix.qt-version }}-
       - name: cache homebrew downloads
         uses: actions/cache@v2
+        id: cache-homebrew
         with:
           path: ~/Library/Caches/Homebrew/downloads
           key: ${{ runner.os }}-${{ matrix.os-version }}-${{ matrix.xcode-version }}-${{ matrix.use-syslibs }}-${{ matrix.shared-libscsynth }}-${{ matrix.qt-version }}-homebrew-${{ steps.current-month.outputs.stamp }}
@@ -269,6 +270,9 @@ jobs:
           modules: 'qtwebengine'
           version: ${{ matrix.qt-version }}
           cached: ${{ steps.cache-qt.outputs.cache-hit }}
+      - name: cleanup homebrew downloads # make sure we store only relevant downloads in cache
+        if: '!steps.cache-homebrew.outputs.cache-hit'
+        run: rm -rf $(brew --cache)
       - name: install dependencies
         run: |
           brew install libsndfile portaudio ccache fftw ninja # ninja added temporarily

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -119,12 +119,12 @@ jobs:
           submodules: recursive
       - name: prepare daily timestamp for cache
         id: current-date
-        run: echo "::set-output name=date::$(date '+%Y-%m-%d')"
+        run: echo "::set-output name=stamp::$(date '+%Y-%m-%d')"
       - name: cache ccache
         uses: actions/cache@v2
         with:
           path: ~/.ccache
-          key: ${{ runner.os }}-${{ matrix.os-version }}-${{ matrix.c-compiler }}-${{ matrix.use-syslibs }}-${{ matrix.shared-libscsynth }}-${{ steps.current-date.outputs.date }}
+          key: ${{ runner.os }}-${{ matrix.os-version }}-${{ matrix.c-compiler }}-${{ matrix.use-syslibs }}-${{ matrix.shared-libscsynth }}-${{ steps.current-date.outputs.stamp }}
           restore-keys: ${{ runner.os }}-${{ matrix.os-version }}-${{ matrix.c-compiler }}-${{ matrix.use-syslibs }}-${{ matrix.shared-libscsynth }}-
       - name: cache qt
         id: cache-qt
@@ -240,13 +240,22 @@ jobs:
           submodules: recursive
       - name: prepare daily timestamp for cache
         id: current-date
-        run: echo "::set-output name=date::$(date '+%Y-%m-%d')"
+        run: echo "::set-output name=stamp::$(date '+%Y-%m-%d')"
+      - name: prepare monthly timestamp for cache
+        id: current-month
+        run: echo "::set-output name=stamp::$(date '+%Y-%m')"
       - name: cache ccache
         uses: actions/cache@v2
         with:
           path: ~/Library/Caches/ccache
-          key: ${{ runner.os }}-${{ matrix.os-version }}-${{ matrix.xcode-version }}-${{ matrix.use-syslibs }}-${{ matrix.shared-libscsynth }}-${{ matrix.qt-version }}-${{ steps.current-date.outputs.date }}
+          key: ${{ runner.os }}-${{ matrix.os-version }}-${{ matrix.xcode-version }}-${{ matrix.use-syslibs }}-${{ matrix.shared-libscsynth }}-${{ matrix.qt-version }}-${{ steps.current-date.outputs.stamp }}
           restore-keys: ${{ runner.os }}-${{ matrix.os-version }}-${{ matrix.xcode-version }}-${{ matrix.use-syslibs }}-${{ matrix.shared-libscsynth }}-${{ matrix.qt-version }}-
+      - name: cache homebrew downloads
+        uses: actions/cache@v2
+        with:
+          path: ~/Library/Caches/Homebrew/downloads
+          key: ${{ runner.os }}-${{ matrix.os-version }}-${{ matrix.xcode-version }}-${{ matrix.use-syslibs }}-${{ matrix.shared-libscsynth }}-${{ matrix.qt-version }}-homebrew-${{ steps.current-month.outputs.stamp }}
+          restore-keys: ${{ runner.os }}-${{ matrix.os-version }}-${{ matrix.xcode-version }}-${{ matrix.use-syslibs }}-${{ matrix.shared-libscsynth }}-${{ matrix.qt-version }}-homebrew-
       - name: cache qt
         id: cache-qt
         uses: actions/cache@v1

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -117,19 +117,6 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: recursive
-      - name: set artifact filename
-        if: matrix.artifact-suffix
-        run: |
-          # set SC_VERSION to tag (if present) or to commit SHA
-          SC_VERSION=
-          if [[ "$GITHUB_REF" == refs/tags/* ]]; then 
-            FULL_TAG=${GITHUB_REF#refs/tags/}
-            TAG=${FULL_TAG##Version-}
-            SC_VERSION=$TAG
-          else
-            SC_VERSION=$GITHUB_SHA
-          fi
-          echo "ARTIFACT_FILE=SuperCollider-$SC_VERSION-${{ matrix.artifact-suffix }}.zip" >> $GITHUB_ENV
       - name: prepare daily timestamp for cache
         id: current-date
         run: echo "::set-output name=date::$(date '+%Y-%m-%d')"
@@ -178,6 +165,19 @@ jobs:
         run: |
           cd $BUILD_PATH
           make install -j2
+      - name: set artifact filename
+        if: matrix.artifact-suffix
+        run: |
+          # set SC_VERSION to tag (if present) or to commit SHA
+          SC_VERSION=
+          if [[ "$GITHUB_REF" == refs/tags/* ]]; then 
+            FULL_TAG=${GITHUB_REF#refs/tags/}
+            TAG=${FULL_TAG##Version-}
+            SC_VERSION=$TAG
+          else
+            SC_VERSION=$GITHUB_SHA
+          fi
+          echo "ARTIFACT_FILE=SuperCollider-$SC_VERSION-${{ matrix.artifact-suffix }}.zip" >> $GITHUB_ENV
       - name: create archive
         if: matrix.artifact-suffix
         run: cd $INSTALL_PATH && zip --symlinks -r $ARTIFACT_FILE .
@@ -238,19 +238,6 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: recursive
-      - name: set artifact filename
-        if: matrix.artifact-suffix
-        run: |
-          # set SC_VERSION to tag (if present) or to commit SHA
-          SC_VERSION=
-          if [[ "$GITHUB_REF" == refs/tags/* ]]; then 
-            FULL_TAG=${GITHUB_REF#refs/tags/}
-            TAG=${FULL_TAG##Version-}
-            SC_VERSION=$TAG
-          else
-            SC_VERSION=$GITHUB_SHA
-          fi
-          echo "ARTIFACT_FILE=SuperCollider-$SC_VERSION-${{ matrix.artifact-suffix }}.zip" >> $GITHUB_ENV
       - name: prepare daily timestamp for cache
         id: current-date
         run: echo "::set-output name=date::$(date '+%Y-%m-%d')"
@@ -305,6 +292,19 @@ jobs:
           cmake -G"Ninja" -DRULE_LAUNCH_COMPILE=ccache -DCMAKE_OSX_DEPLOYMENT_TARGET=10.10 -DSUPERNOVA=ON -DCMAKE_BUILD_TYPE=Release $EXTRA_CMAKE_FLAGS .. --debug-output
       - name: build
         run: cmake --build $BUILD_PATH --config Release --target install
+      - name: set artifact filename
+        if: matrix.artifact-suffix
+        run: |
+          # set SC_VERSION to tag (if present) or to commit SHA
+          SC_VERSION=
+          if [[ "$GITHUB_REF" == refs/tags/* ]]; then 
+            FULL_TAG=${GITHUB_REF#refs/tags/}
+            TAG=${FULL_TAG##Version-}
+            SC_VERSION=$TAG
+          else
+            SC_VERSION=$GITHUB_SHA
+          fi
+          echo "ARTIFACT_FILE=SuperCollider-$SC_VERSION-${{ matrix.artifact-suffix }}.zip" >> $GITHUB_ENV
       - name: create archive
         if: matrix.artifact-suffix
         run: cd $INSTALL_PATH && zip --symlinks -r $ARTIFACT_FILE SuperCollider # this assumes that we end up with the build in the folder SuperCollider

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -129,11 +129,15 @@ jobs:
             SC_VERSION=$GITHUB_SHA
           fi
           echo "ARTIFACT_FILE=SuperCollider-$SC_VERSION-${{ matrix.artifact-suffix }}.zip" >> $GITHUB_ENV
+      - name: prepare daily timestamp for cache
+        id: current-date
+        run: echo "::set-output name=date::$(date '+%Y-%m-%d')"
       - name: cache ccache
         uses: actions/cache@v2
         with:
           path: ~/.ccache
-          key: ${{ runner.os }}-v1-${{ matrix.os-version }}-${{ matrix.c-compiler }}-${{ matrix.use-syslibs }}-${{ matrix.shared-libscsynth }} # -v2- etc can be used for "clearing" the cache, it's not functionally connected to the version of the script
+          key: ${{ runner.os }}-${{ matrix.os-version }}-${{ matrix.c-compiler }}-${{ matrix.use-syslibs }}-${{ matrix.shared-libscsynth }}-${{ steps.current-date.outputs.date }}
+          restore-keys: ${{ runner.os }}-${{ matrix.os-version }}-${{ matrix.c-compiler }}-${{ matrix.use-syslibs }}-${{ matrix.shared-libscsynth }}-
       - name: cache qt
         id: cache-qt
         uses: actions/cache@v1
@@ -245,11 +249,15 @@ jobs:
             SC_VERSION=$GITHUB_SHA
           fi
           echo "ARTIFACT_FILE=SuperCollider-$SC_VERSION-${{ matrix.artifact-suffix }}.zip" >> $GITHUB_ENV
+      - name: prepare daily timestamp for cache
+        id: current-date
+        run: echo "::set-output name=date::$(date '+%Y-%m-%d')"
       - name: cache ccache
         uses: actions/cache@v2
         with:
           path: ~/Library/Caches/ccache
-          key: ${{ runner.os }}-v1-${{ matrix.os-version }}-${{ matrix.xcode-version }}-${{ matrix.use-syslibs }}-${{ matrix.shared-libscsynth }}-${{ matrix.qt-version }} # -v2- etc can be used for "clearing" the cache, it's not functionally connected to the version of the script
+          key: ${{ runner.os }}-${{ matrix.os-version }}-${{ matrix.xcode-version }}-${{ matrix.use-syslibs }}-${{ matrix.shared-libscsynth }}-${{ matrix.qt-version }}-${{ steps.current-date.outputs.date }}
+          restore-keys: ${{ runner.os }}-${{ matrix.os-version }}-${{ matrix.xcode-version }}-${{ matrix.use-syslibs }}-${{ matrix.shared-libscsynth }}-${{ matrix.qt-version }}-
       - name: cache qt
         id: cache-qt
         uses: actions/cache@v1

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -117,7 +117,8 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: recursive
-      - name: set sc version and artifact filename
+      - name: set artifact filename
+        if: matrix.artifact-suffix
         run: |
           # set SC_VERSION to tag (if present) or to commit SHA
           SC_VERSION=
@@ -237,7 +238,8 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: recursive
-      - name: set sc version and artifact filename
+      - name: set artifact filename
+        if: matrix.artifact-suffix
         run: |
           # set SC_VERSION to tag (if present) or to commit SHA
           SC_VERSION=

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -255,7 +255,6 @@ jobs:
         with:
           path: ~/Library/Caches/Homebrew/downloads
           key: ${{ runner.os }}-${{ matrix.os-version }}-${{ matrix.xcode-version }}-${{ matrix.use-syslibs }}-${{ matrix.shared-libscsynth }}-${{ matrix.qt-version }}-homebrew-${{ steps.current-month.outputs.stamp }}
-          restore-keys: ${{ runner.os }}-${{ matrix.os-version }}-${{ matrix.xcode-version }}-${{ matrix.use-syslibs }}-${{ matrix.shared-libscsynth }}-${{ matrix.qt-version }}-homebrew-
       - name: cache qt
         id: cache-qt
         uses: actions/cache@v1


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

Previously `ccache` cache would never be updated between builds, save for manually changing the cache file key. With this PR `ccache` cache will be updated daily.

I also added caching homebrew downloads. Some observations on that:
- homebrew downloads seem to take ~~>3.5GB (!)~~ EDIT: it seems there were previous downloads there; I added cleanup step before caching them, now it's ~250MB
~~- I _think_ most of that is `FFTW`'s dependencies, but haven't checked closely~~
~~- retrieving cache happens at varying speed, sometimes it seems to take longer than re-downloading the files from their original locations... but I think it's still better to use cache, right?~~
- I've set homebrew download cache to reset monthly, to cache possible package updates etc.
- I've also moved the archive name preparatory step closer to archive creation/upload, I think it makes more sense
- I factored out code to set SC version for the artifact (tag for tagged commits, sha for the rest)

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] This PR is ready for review
