### PR TITLE
Create dmg for macOS artifacts

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -311,7 +311,10 @@ jobs:
         run: cmake --build $BUILD_PATH --config Release --target install
       - name: create archive
         if: matrix.artifact-suffix
-        run: cd $INSTALL_PATH && hdiutil create -srcfolder SuperCollider -format UDBZ $ARTIFACT_FILE # this assumes that we end up with the build in the folder SuperCollider
+        run: |
+          cd $INSTALL_PATH
+          ln -s /Applications SuperCollider/Applications
+          hdiutil create -srcfolder SuperCollider -format UDBZ $ARTIFACT_FILE # this assumes that we end up with the build in the folder SuperCollider
       - name: upload artifacts
         uses: actions/upload-artifact@v2
         if: matrix.artifact-suffix

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -239,7 +239,7 @@ jobs:
       HOMEBREW_NO_INSTALL_CLEANUP: 1
       USE_SYSLIBS: ${{ matrix.use-syslibs }}
       SHARED_LIBSCSYNTH: ${{ matrix.shared-libscsynth }}
-      ARTIFACT_FILE: 'SuperCollider-${{ needs.lint.outputs.sc-version }}-${{ matrix.artifact-suffix }}'
+      ARTIFACT_FILE: 'SuperCollider-${{ needs.lint.outputs.sc-version }}-${{ matrix.artifact-suffix }}.dmg'
     steps:
       - uses: actions/checkout@v2
         with:
@@ -311,13 +311,13 @@ jobs:
         run: cmake --build $BUILD_PATH --config Release --target install
       - name: create archive
         if: matrix.artifact-suffix
-        run: cd $INSTALL_PATH && zip --symlinks -r $ARTIFACT_FILE.zip SuperCollider # this assumes that we end up with the build in the folder SuperCollider
+        run: cd $INSTALL_PATH && hdiutil create -srcfolder SuperCollider -format UDBZ $ARTIFACT_FILE # this assumes that we end up with the build in the folder SuperCollider
       - name: upload artifacts
         uses: actions/upload-artifact@v2
         if: matrix.artifact-suffix
         with:
           name: ${{ env.ARTIFACT_FILE }}
-          path: ${{ env.INSTALL_PATH }}/${{ env.ARTIFACT_FILE }}.zip
+          path: ${{ env.INSTALL_PATH }}/${{ env.ARTIFACT_FILE }}
           retention-days: 7 # quickly remove test artifacts
 
   Windows:
@@ -490,6 +490,7 @@ jobs:
             runs-on: macos-10.15
             sclang: 'build/Install/SuperCollider/SuperCollider.app/Contents/MacOS/sclang'
             artifact-suffix: macOS
+            artifact-extension: '.dmg'
 
           - name: Linux
             runs-on: ubuntu-18.04
@@ -501,7 +502,7 @@ jobs:
     name: 'test on ${{ matrix.name }}'
     env:
       INSTALL_PATH: ${{ github.workspace }}/build/Install
-      ARTIFACT_FILE: 'SuperCollider-${{ needs.lint.outputs.sc-version }}-${{ matrix.artifact-suffix }}'
+      ARTIFACT_FILE: 'SuperCollider-${{ needs.lint.outputs.sc-version }}-${{ matrix.artifact-suffix }}${{ matrix.artifact-extension }}'
       QUARKS_PATH: ${{ github.workspace }}/build/Quarks
       TESTS_PATH: ${{ github.workspace }}/testsuite/classlibrary
       SCLANG: ${{ github.workspace }}/${{ matrix.sclang }}
@@ -520,9 +521,16 @@ jobs:
       - name: extract artifact
         run: |
           cd $INSTALL_PATH
-          echo `pwd`
-          echo `ls -s`
-          unzip $ARTIFACT_FILE.zip
+          echo Contents of `pwd`:
+          ls
+          if [[ ${{ runner.os }} == "macOS" ]]; then
+            hdiutil attach $ARTIFACT_FILE
+            echo "mkdir SuperCollider"
+            mkdir SuperCollider
+            cp -R /Volumes/SuperCollider/* SuperCollider/
+          else
+            unzip $ARTIFACT_FILE.zip
+          fi
       - name: setup Linux environment
         if: runner.os == 'Linux'
         run: |
@@ -574,7 +582,7 @@ jobs:
           - artifact-suffix: macOS
             s3-os-name: osx
             s3-artifact-suffx: ''
-            artifact-extension: 'zip'
+            artifact-extension: 'dmg'
             s3-create-latest-link: true # create link to pointing to the "latest" build; activate only one per branch per s3-os-name
 
           - artifact-suffix: win32


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation
Fixes #5278 (to some extent at least)
This is a basic version of idea from https://github.com/supercollider/supercollider/issues/5278#issuecomment-742248040
While currently created DMG does not have a custom background and instructions to drag SuperCollider to `/Applications`, it still prevents the user from dragging whole folder, as the folder is replaced by disk image.
<img width="838" alt="Screen Shot 2021-04-03 at 13 31 40" src="https://user-images.githubusercontent.com/1589177/113490924-0d9d3d00-9482-11eb-8493-f96d236454e2.png">



I've also chosen `bzip2` compression for the archive, as this has resulted in the file size most closely resembling the previously used `.zip` (it's larger by just a couple of MB).

~~The fix will be "operational" once we fully migrate to github actions for macOS deployment.~~

EDIT: I've added a link to `/Applications`, as requested

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] This PR is ready for review
