### PR TITLE
QWebView is able to set scrollPosition of QcWebView

### DIFF
--- a/QtCollider/widgets/QcWebView.h
+++ b/QtCollider/widgets/QcWebView.h
@@ -116,8 +116,12 @@ public:
     Q_PROPERTY(QSizeF contentsSize READ contentsSize)
     QSizeF contentsSize() const { return page() ? page()->contentsSize() : QSizeF(0, 0); }
 
-    Q_PROPERTY(QPointF scrollPosition READ scrollPosition)
+    Q_PROPERTY(QPointF scrollPosition READ scrollPosition WRITE setScrollPosition)
     QPointF scrollPosition() const { return page() ? page()->scrollPosition() : QPointF(0, 0); }
+    void setScrollPosition(QPointF p) {
+        if (page())
+            page()->runJavaScript(QString("window.scrollTo(%1, %2);").arg(p.rx()).arg(p.ry()));
+    }
 
     Q_PROPERTY(bool audioMuted READ isAudioMuted WRITE setAudioMuted)
     bool isAudioMuted() const { return page() ? page()->isAudioMuted() : false; }

--- a/SCClassLibrary/Common/GUI/Base/QWebView.sc
+++ b/SCClassLibrary/Common/GUI/Base/QWebView.sc
@@ -253,6 +253,7 @@ WebView : View {
 	contentsSize { ^this.getProperty('contentsSize') }
 
 	scrollPosition { ^this.getProperty('scrollPosition') }
+	scrollPosition_ { |point| ^this.setProperty('scrollPosition',point) }
 
 	audioMuted { ^this.getProperty('audioMuted') }
 	audioMuted_ { |muted| this.setProperty('audioMuted', muted) }


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation
WebView scrollPosition setter was not working even it is in documentation. Maybe due some changes in Qt. I don't know.
This fixes it. it should work. I  hope a did not mess anything.
This pull request is preparation for adding 'vim keys' into WebView class. Soon.



## Types of changes
GUI/Base/QWebView.sc
- added  method: 	`scrollPosition_ { |point| ^this.setProperty('scrollPosition',point) }`

QtCollider/widgets/QcWebView.h
- changed and updated this part:

    `Q_PROPERTY(QPointF scrollPosition READ scrollPosition WRITE setScrollPosition)
    QPointF scrollPosition() const { return page() ? page()->scrollPosition() : QPointF(0, 0); }
    void setScrollPosition(QPointF p) {
        if (page())
            page()->runJavaScript(QString("window.scrollTo(%1, %2);").arg(p.rx()).arg(p.ry()));
    }`






<!-- Delete lines that don't apply -->


- Bug fix



## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [ x] Code is tested
- [ x] All tests are passing
- [x ] This PR is ready for review
