### PR TITLE
class library: envelopes behave like patterns in a pattern proxy

### DIFF
--- a/HelpSource/Classes/Env.schelp
+++ b/HelpSource/Classes/Env.schelp
@@ -16,8 +16,8 @@ Env.new(levels: [0, 1, 0.9, 0], times: [0.1, 0.5, 1], curve: [-5, 0, -5]).plot;
 
 In this envelope, there are four emphasis::nodes:: :
 
-list:: 
-## the first emphasis::node:: is the initial level of the envelope : 0 
+list::
+## the first emphasis::node:: is the initial level of the envelope : 0
 ## the second emphasis::node:: has level 1 and is reached in 0.1 second
 ## the third emphasis::nodes:: has level 0.9 and is reached in 0.5 second
 ## the fourth emphasis::nodes:: has level 0 and is reached in 1 second
@@ -30,7 +30,7 @@ code::
 {
 	EnvGen.kr(
 		Env(
-			levels: [0, 0.1, 0.2, 0.3], 
+			levels: [0, 0.1, 0.2, 0.3],
 			times: [0.1, 0.1, 0.1],
 			curve: 8
 		),
@@ -102,10 +102,10 @@ code::
 {
 	EnvGen.kr(
 		Env.new(
-			levels: [0, 1, 0.5, 0], 
+			levels: [0, 1, 0.5, 0],
 			times: [0.01, 0.01, 0.01],
 			releaseNode: 2 // sustains at level 0.5 until gate is closed
-		), 
+		),
 		gate: Trig.kr(Impulse.kr(3), dur: 0.3)
 	);
 }.plot(duration: 1);
@@ -830,7 +830,8 @@ There is an extra level at the beginning of the envelope to set the initial leve
 The loop jumps back to the loop node. The endpoint of that segment is the goal level for that segment and the duration of that segment will be the time over which the level changed from the current level to the goal level.
 ::
 
-
+method::streamArg
+Returns the same output as code::asStream::.
 
 
 subsection::blend

--- a/SCClassLibrary/Common/Audio/Env.sc
+++ b/SCClassLibrary/Common/Audio/Env.sc
@@ -286,6 +286,10 @@ Env {
 		^Routine({ arg inval; this.embedInStream(inval) })
 	}
 
+	streamArg {
+		^this.asStream
+	}
+
 	asPseg {
 		var c = if(curves.isSequenceableCollection.not) { curves } { Pseq(curves, inf) };
 		^Pseg(Pseq(levels), Pseq(times ++ [1.0]), c) // last time is a dummy

--- a/testsuite/classlibrary/TestPatternStreamArg.sc
+++ b/testsuite/classlibrary/TestPatternStreamArg.sc
@@ -1,0 +1,38 @@
+
+TestPatternStreamArg : UnitTest {
+
+	test_streamArg_Env {
+		var obj, embed, stream;
+		obj = Env([80, 300], [0]);
+		stream = obj.streamArg;
+		this.assertEquals(stream.next, 300, "streamArg should return stream of envelope levels");
+	}
+
+	test_streamArg_Env_in_Pcollect {
+		var pat, coll, stream;
+		pat = Env([80, 300], [0]);
+		coll = Pcollect({ |x| x * 2 }, pat);
+		stream = coll.asStream;
+		this.assertEquals(stream.next, 300 * 2, "Pcollect(env) should return envelope level");
+	}
+
+	test_streamArg_Env_in_PatternProxy {
+		var pat, coll, stream, proxy;
+		proxy = PatternProxy.new;
+		pat = Env([80, 300], [0]);
+		proxy.source = pat;
+		stream = proxy.asStream;
+		this.assertEquals(stream.next, 300, "PatternProxy of an Env should return envelope level");
+	}
+
+	test_streamArg_Env_in_Pbindef {
+		var pat, coll, stream, proxy, event;
+		pat = Env([80, 300], [0]);
+		proxy = Pbindef(\x, \dummy, pat);
+		stream = Pbindef(\x).asStream;
+		event = stream.next(Event.default);
+		Pdef.clear;
+		this.assertEquals(event[\dummy], 300, "Pbindef key of an Env should return envelope level");
+	}
+
+}


### PR DESCRIPTION


<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

To work as expected in PatternProxy (and in Pbindef and Pdefn), a class that does not simply return itself when embedded in a stream should implement streamArg. This fixes #5285.

```supercollider
a = PbindProxy.new;
a.set(\midinote, Env([60, 70, 60], [2, 2]));
a.asStream.next(Event.default); // => ( 'midinote': 60.0 )
```

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review
