### PR TITLE
class library: wetamp should not affect output of \filterIn function

### DIFF
--- a/HelpSource/Reference/NodeProxy_roles.schelp
+++ b/HelpSource/Reference/NodeProxy_roles.schelp
@@ -131,26 +131,32 @@ a.clear(3);
 ::
 
 ## \filter -> function
-|| Filter the audio on the proxy's own bus, using the first argument to pass in the sound. The function is any valid UGen function, which may be control or audio rate. Default controls are wet++index, where strong::index:: is the slot of the proxy (default 0), in the example below, the control is code::\wet1::.
+|| Filter the audio on the proxy's own bus, using the first argument to pass in the sound. The function is any valid UGen function, which may be control or audio rate. Default controls are wet++index, where strong::index:: is the slot of the proxy (default 0), in the example below, the control is code::\wet1::, and it crossfades between the incoming sound source and the effect (wet) signal output.
 
 code::
-a = NodeProxy(s);
-a[0] = { PinkNoise.ar(0.1.dup) };
-a.play;
-a[1] = \filter -> { |in| RLPF.ar(in, LFNoise2.kr(1).exprange(300, 1000), 0.1) };
-a.set(\wet1, 0.2);
+a = NodeProxy(s).play;
+a[0] = { RLPF.ar(Dust2.ar(5!2), LFNoise2.kr(2!2).exprange(200, 5000), 0.05) };
+a[1] = \filter -> { |in| CombL.ar(in, 0.2, LFNoise2.kr(0.5!2).exprange(0.01, 0.2), 3) };
+
+a.set(\wet1, 0.2); // set dry/wet mix level to less combs
+a.set(\wet1, 0.0); // wet 0 is all dry - cuts combs instantly.
+
 a.clear(3);
 ::
 
 ## \filterIn -> function
-|| Like code::\filter::, only that the input is controled by the code::\wet:: control, not the output.
+|| Like code::\filter::, but the code::\wet:: control now sets the filter strong::input:: level, rather than its output. This lets time-based effects like delays, combs, filters with long ringtimes continue to sound even when the input is already turned off.
 
 code::
-a = NodeProxy(s);
-a[0] = { PinkNoise.ar(0.1.dup) };
-a.play;
-a[1] = \filterIn -> { |in| RLPF.ar(in, LFNoise2.kr(1).exprange(300, 1000), 0.1) };
-a.set(\wet1, 0.2);
+a = NodeProxy(s).play;
+a[0] = { RLPF.ar(Dust2.ar(5!2), LFNoise2.kr(2!2).exprange(200, 5000), 0.05) };
+a[1] = \filterIn -> { |in| CombL.ar(in, 0.2, LFNoise2.kr(0.5!2).exprange(0.01, 0.2), 3) };
+
+
+a.set(\wet1, 0.5); // set mix level to less effect signal
+// wet 0 is all dry - input is off, but comb decay still sounds.
+a.set(\wet1, 0.0);
+
 a.clear(3);
 ::
 

--- a/SCClassLibrary/JITLib/ProxySpace/wrapForNodeProxy.sc
+++ b/SCClassLibrary/JITLib/ProxySpace/wrapForNodeProxy.sc
@@ -307,7 +307,8 @@
 						XOut.ar(out, env, SynthDef.wrap(func, nil, [In.ar(out, proxy.numChannels)]))
 					} {
 						env = ctl * EnvGate(i_level: 0, doneAction:2, curve:\lin);
-						XOut.kr(out, env, SynthDef.wrap(func, nil, [In.kr(out, proxy.numChannels)]))				};
+						XOut.kr(out, env, SynthDef.wrap(func, nil, [In.kr(out, proxy.numChannels)]))
+                    };
 				}.buildForProxy( proxy, channelOffset, index )
 
 			},
@@ -368,11 +369,11 @@
 
 					if(proxy.rate === 'audio') {
 						in = In.ar(out, proxy.numChannels);
-						env = wetamp * EnvGate(i_level: 0, doneAction:2, curve:\sin);
+						env = EnvGate(i_level: 0, doneAction:2, curve:\sin);
 						XOut.ar(out, env, sig.(in))
 					} {
 						in = In.kr(out, proxy.numChannels);
-						env = wetamp * EnvGate(i_level: 0, doneAction:2, curve:\lin);
+						env = EnvGate(i_level: 0, doneAction:2, curve:\lin);
 						XOut.kr(out, env, sig.(in))
 					};
 				}.buildForProxy( proxy, channelOffset, index )


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

Fixes #5291 

Following a conversation with @adcxyz here are some tests and the proposed fix:

```supercollider
// tests for filter vs filterIn roles: 

(
// test sig at full level
Ndef(\x)[5] = { 
	LFPulse.kr(3, 0, 0.2)
	* SinOsc.ar(LFNoise0.kr(3!2).exprange(200, 2000))
};
// comb filter as simplest ringing FX - use \filter here:
Ndef(\x)[10] = \filter -> { |in| CombL.ar(in, 0.03, 0.03, 2) };

Ndef(\x).play;
s.scope;
)

Ndef(\x).set(\wet10, 1); // full wet, just comb signal
Ndef(\x).set(\wet10, 0.5); // 50/50 mix
Ndef(\x).set(\wet10, 0); // just dry signal - ringing comb is cut off


///// same tests with filterIn: 
// comb filter as simplest ringing FX:
Ndef(\x)[10] = \filterIn -> { |in| CombL.ar(in, 0.03, 0.03, 2) };

Ndef(\x).set(\wet10, 1); // full wet, just comb signal
Ndef(\x).set(\wet10, 0.5); // 50/50 mix 
Ndef(\x).set(\wet10, 0); // just the dry signal - comb should ring out freely now!

// open and  close again by hand: 
// only source going into comb is gated, combt decay should be untouched
Ndef(\x).set(\wet10, 0.5);
Ndef(\x).set(\wet10, 0);


// replace comb filter with Silent to see we stil get dry signal as intended 
Ndef(\x)[10] = \filterIn -> { |in, decaytime = 5| Silent.ar(in.size) };

Ndef(\x).set(\wet10, 1); // full wet, now silent
Ndef(\x).set(\wet10, 0.5); // 50/50 mix, now only dry at 50%
Ndef(\x).set(\wet10, 0); // dry signal only at full level 

// temp fix it in the dictionary:
(
AbstractPlayControl.buildMethods[\filterIn] = #{ | func, proxy, channelOffset = 0, index |
	var ok, ugen;
	if(proxy.isNeutral) {
		ugen = func.value(Silent.ar);
		ok = proxy.initBus(ugen.rate, ugen.numChannels + channelOffset);
		if(ok.not) { Error("NodeProxy input: wrong rate/numChannels").throw }
	};
	
	{ | out |
		var in, env;
		var wetamp = Control.names(["wet"++(index ? 0)]).kr(1.0);
		var dryamp = 1 - wetamp;
		var sig = { |in| SynthDef.wrap(func, nil, [in * wetamp]) + (dryamp * in) };
		
		if(proxy.rate === 'audio') {
			in =  In.ar(out, proxy.numChannels);
			env = EnvGate(i_level: 0, doneAction: 2, curve: \sin);
			XOut.ar(out, env, sig.(in))
		} {
			in = In.kr(out, proxy.numChannels);
			env = EnvGate(i_level: 0, doneAction: 2, curve: \lin);
			XOut.kr(out, env, sig.(in))
		};
	}.buildForProxy( proxy, channelOffset, index )
};
)
```

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [X] Code is tested
- [x] All tests are passing
- [X] This PR is ready for review
