### PR TITLE
scsynth: use CoreAudio host time to calculate time of day offset

### DIFF
--- a/server/scsynth/SC_CoreAudio.cpp
+++ b/server/scsynth/SC_CoreAudio.cpp
@@ -76,26 +76,26 @@ static void syncOSCOffsetWithTimeOfDay() {
     // Then if this machine is synced via NTP, we are synced with the world.
     // more accurate way to do this??
 
-    using namespace std::chrono;
     struct timeval tv;
 
-    nanoseconds systemTimeBefore, systemTimeAfter;
+    int64 systemTimeBefore, systemTimeAfter;
     int64 diff, minDiff = 0x7fffFFFFffffFFFFLL;
 
     // take best of several tries
     const int numberOfTries = 5;
     int64 newOffset = gOSCoffset;
     for (int i = 0; i < numberOfTries; ++i) {
-        systemTimeBefore = high_resolution_clock::now().time_since_epoch();
+        systemTimeBefore = AudioGetCurrentHostTime();
         gettimeofday(&tv, 0);
-        systemTimeAfter = high_resolution_clock::now().time_since_epoch();
+        systemTimeAfter = AudioGetCurrentHostTime();
 
-        diff = (systemTimeAfter - systemTimeBefore).count();
+        diff = systemTimeAfter - systemTimeBefore;
         if (diff < minDiff) {
             minDiff = diff;
-            // assume that gettimeofday happens halfway between high_resolution_clock::now() calls
-            int64 systemTimeBetween = systemTimeBefore.count() + diff / 2;
-            int64 systemTimeInOSCunits = (int64)((double)systemTimeBetween * kNanosToOSCunits);
+            // assume that gettimeofday happens halfway between AudioGetCurrentHostTime() calls
+            int64 systemTimeBetween = systemTimeBefore + diff / 2;
+            int64 systemTimeInOSCunits =
+                (int64)((double)AudioConvertHostTimeToNanos(systemTimeBetween) * kNanosToOSCunits);
             int64 timeOfDayInOSCunits =
                 ((int64)(tv.tv_sec + kSECONDS_FROM_1900_to_1970) << 32) + (int64)(tv.tv_usec * kMicrosToOSCunits);
             newOffset = timeOfDayInOSCunits - systemTimeInOSCunits;


### PR DESCRIPTION
## Purpose and Motivation

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

See discussion in #5168

In macOS Big Sur, the clock provided by `high_resolution_clock` (using `mach_absolute_time`) drifts apart from the host time reported by CoreAudio. This is most apparent after a computer running Big Sur is in sleep mode for a bit, causing sounds from SuperCollider to be played after their scheduled time roughly by the amount of time the computer slept.

This change makes it so that the time of day offset is calculated against the CoreAudio host time (instead of `high_resolution_clock` time) since that offset is later used against the CoreAudio host time to get OSC time.

This commit effectively reverts the changes in 95a6604.

I read through the [wiki page](https://github.com/supercollider/supercollider/wiki/Creating-pull-requests) for making pull requests (and didn't know what I could make in terms of a regression test for this change) but let me know if there is anything else I should do!

I know there was still discussion in #5168 on clocks and timing in regards to this change and I will defer to the maintainers on whether this is a proper solution or not.

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing (running on macOS)
- [ ] Updated documentation
- [x] This PR is ready for review
