### PR TITLE
travis: fix latest develop link

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -324,7 +324,7 @@ before_deploy:
  # put everything to be archived in artifacts/
  - mkdir -p "$HOME/artifacts/${TRAVIS_BRANCH%/*}"
  - mkdir -p "$HOME/artifacts/${TRAVIS_TAG%/*}"
- - 'if [[ ! $IS_LEGACY_BUILD ]]; then echo $FWD_HTML > $HOME/artifacts/$TRAVIS_BRANCH-latest.html; fi;'
+ - 'if [[ $IS_LEGACY_BUILD != "true" ]]; then echo $FWD_HTML > $HOME/artifacts/$TRAVIS_BRANCH-latest.html; fi;'
  - 'if [[ $TRAVIS_TAG != "head" ]]; then echo $FWD_HTML > $HOME/artifacts/$TRAVIS_TAG.html; fi;'
 
 deploy:


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

It seems that #5234 was incorrect... sorry about that.
As a result, the [latest develop build](http://supercollider.s3.amazonaws.com/builds/supercollider/supercollider/osx/develop-latest.html) links to ba3cb869536ff11b623ef683644502b1e77d220f, which is just before https://github.com/supercollider/supercollider/commit/71ef241bf0ca0d945f1cec91e0578a30ca9555a8, or #5234; the latest develop link hasn't been updated since then...

This should fix it. The link from this branch works: http://supercollider.s3.amazonaws.com/builds/supercollider/supercollider/osx/topic/fix-latest-develop-build-link-latest.html

Sorry again for my previous mistake! :-)

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested (this time for real!)
- [ ] All tests are passing
- [ ] Updated documentation
- [x] This PR is ready for review
