### PR TITLE
test: add test for audio rate controls

### DIFF
--- a/testsuite/classlibrary/TestSynthMapping.sc
+++ b/testsuite/classlibrary/TestSynthMapping.sc
@@ -1,0 +1,83 @@
+/*
+
+make sure audio rate mapping doesn't require ordered nodes
+
+*/
+
+TestSynthAudioMapping : UnitTest {
+
+	var server, mapBus = 120, synth;
+
+	setUp {
+		server = Server(this.class.name);
+		this.bootServer(server);
+		server.sync;
+		this.sendSynthDef;
+		server.sync;
+
+	}
+
+	tearDown {
+		server.quit.remove;
+	}
+
+	sendSynthDef {
+
+		SynthDef(\testNode, {
+			var input = \input.ar(0);
+			var trig = T2A.ar(\trig.tr(0));
+			SendTrig.ar(trig, 0, input);
+		}).add;
+
+		SynthDef(\valueNode, {
+			var input = \input.ar(-1);
+			var out = \out.kr(0);
+			Out.ar(out, input);
+		}).add;
+
+	}
+
+	waitForOSCReply { |callback, timeout = 4|
+		var oscRecv = OSCFunc({ |msg| callback.(msg.drop(1)); }, "/tr").oneShot;
+		SystemClock.sched(timeout, { oscRecv.free });
+	}
+
+	test_noop {
+		synth = Synth(\testNode);
+		server.latency.wait;
+		synth.set(\trig, 1);
+		this.waitForOSCReply { |args|
+			var val = args.first;
+			this.assertEqualValue(val, -1, "default value of synth before mapping should be -1");
+		};
+	}
+
+	test_map_normal_order {
+		var controlSynth, value;
+		value = 6561;
+		synth = Synth(\testNode);
+		controlSynth = Synth.before(synth, \valueNode, [\out, mapBus, \input, value]);
+		synth.map(\input, mapBus);
+		server.latency.wait;
+		synth.set(\trig, 1);
+		this.waitForOSCReply { |args|
+			var val = args.first;
+			this.assertEqualValue(val, value, "value of synth after mapping should match");
+		};
+	}
+
+	test_map_reverse_order {
+		var controlSynth, value;
+		value = 6561;
+		synth = Synth(\testNode);
+		controlSynth = Synth.after(synth, \valueNode, [\out, mapBus, \input, value]);
+		synth.map(\input, mapBus);
+		server.latency.wait;
+		synth.set(\trig, 1);
+		this.waitForOSCReply { |args|
+			var val = args.first;
+			this.assertEqualValue(val, value, "value of synth after mapping should match");
+		};
+	}
+
+}

--- a/testsuite/classlibrary/TestSynthMapping.sc
+++ b/testsuite/classlibrary/TestSynthMapping.sc
@@ -110,4 +110,23 @@ TestSynthAudioMapping : UnitTest {
 		};
 	}
 
+	test_map_with_control_rate {
+		var controlSynth, value, ctlNumChannels, synthNumChannels, krBus;
+		ctlNumChannels = 2;
+		synthNumChannels = 5;
+		this.sendSynthDef(synthNumChannels, ctlNumChannels);
+		krBus = Bus.control(server, ctlNumChannels);
+		value = { 6561.0.rand.trunc } ! ctlNumChannels;
+		krBus.setn(value);
+		server.sync;
+		synth = Synth(\testNode);
+		synth.set(\input, ctlNumChannels.collect { |i| "c" ++ (krBus.index + i) });
+		server.latency.wait;
+		synth.set(\trig, 1);
+		this.waitForOSCReply { |args|
+			var synthVal = args;
+			this.assertEquals(synthVal.keep(ctlNumChannels), value, "fewer channels than available should be still mapped");
+		};
+	}
+
 }

--- a/testsuite/classlibrary/TestSynthMapping.sc
+++ b/testsuite/classlibrary/TestSynthMapping.sc
@@ -53,7 +53,7 @@ TestSynthAudioMapping : UnitTest {
 		server.latency.wait;
 		synth.set(\trig, 1);
 		this.waitForOSCReply { |args|
-			var val = args.first.asInteger;
+			var val = args.first.round.asInteger;
 			this.assertEquals(val, value, "value of synth after mapping should match");
 		};
 	}
@@ -69,7 +69,7 @@ TestSynthAudioMapping : UnitTest {
 		server.latency.wait;
 		synth.set(\trig, 1);
 		this.waitForOSCReply { |args|
-			var val = args.first.asInteger;
+			var val = args.first.round.asInteger;
 			this.assertEquals(val, value, "value of synth after mapping should match");
 		};
 	}
@@ -87,7 +87,7 @@ TestSynthAudioMapping : UnitTest {
 		server.latency.wait;
 		synth.set(\trig, 1);
 		this.waitForOSCReply { |args|
-			var synthVal = args.asInteger;
+			var synthVal = args.round.asInteger;
 			this.assertEquals(synthVal, value.keep(synthNumChannels), "more channels than available should be still mapped");
 		};
 	}
@@ -105,7 +105,7 @@ TestSynthAudioMapping : UnitTest {
 		server.latency.wait;
 		synth.set(\trig, 1);
 		this.waitForOSCReply { |args|
-			var synthVal = args.asInteger;
+			var synthVal = args.round.asInteger;
 			this.assertEquals(synthVal.keep(ctlNumChannels), value, "fewer channels than available should be still mapped");
 		};
 	}
@@ -124,7 +124,7 @@ TestSynthAudioMapping : UnitTest {
 		server.latency.wait;
 		synth.set(\trig, 1);
 		this.waitForOSCReply { |args|
-			var synthVal = args.asInteger;
+			var synthVal = args.round.asInteger;
 			this.assertEquals(synthVal.keep(ctlNumChannels), value, "fewer channels than available should be still mapped");
 		};
 	}

--- a/testsuite/classlibrary/TestSynthMapping.sc
+++ b/testsuite/classlibrary/TestSynthMapping.sc
@@ -46,14 +46,14 @@ TestSynthAudioMapping : UnitTest {
 		var controlSynth, value;
 		this.sendSynthDef(1, 1);
 		server.sync;
-		value = 6561.0;
+		value = 6561;
 		synth = Synth(\testNode);
 		controlSynth = Synth.before(synth, \valueNode, [\out, mapBus, \input, value]);
 		synth.set(\input, "a" ++ mapBus);
 		server.latency.wait;
 		synth.set(\trig, 1);
 		this.waitForOSCReply { |args|
-			var val = args.first;
+			var val = args.first.asInteger;
 			this.assertEquals(val, value, "value of synth after mapping should match");
 		};
 	}
@@ -62,14 +62,14 @@ TestSynthAudioMapping : UnitTest {
 		var controlSynth, value;
 		this.sendSynthDef(1, 1);
 		server.sync;
-		value = 6561.0;
+		value = 6561;
 		synth = Synth(\testNode);
 		controlSynth = Synth.after(synth, \valueNode, [\out, mapBus, \input, value]);
 		synth.set(\input, "a" ++ mapBus);
 		server.latency.wait;
 		synth.set(\trig, 1);
 		this.waitForOSCReply { |args|
-			var val = args.first;
+			var val = args.first.asInteger;
 			this.assertEquals(val, value, "value of synth after mapping should match");
 		};
 	}
@@ -80,14 +80,14 @@ TestSynthAudioMapping : UnitTest {
 		synthNumChannels = 2;
 		this.sendSynthDef(synthNumChannels, ctlNumChannels);
 		server.sync;
-		value = { 6561.0.rand.trunc } ! ctlNumChannels;
+		value = { 6561.rand } ! ctlNumChannels;
 		synth = Synth(\testNode);
 		controlSynth = Synth.after(synth, \valueNode, [\out, mapBus, \input, value]);
 		synth.set(\input, ctlNumChannels.collect { |i| "a" ++ (mapBus + i) });
 		server.latency.wait;
 		synth.set(\trig, 1);
 		this.waitForOSCReply { |args|
-			var synthVal = args;
+			var synthVal = args.asInteger;
 			this.assertEquals(synthVal, value.keep(synthNumChannels), "more channels than available should be still mapped");
 		};
 	}
@@ -98,14 +98,14 @@ TestSynthAudioMapping : UnitTest {
 		synthNumChannels = 5;
 		this.sendSynthDef(synthNumChannels, ctlNumChannels);
 		server.sync;
-		value = { 6561.0.rand.trunc } ! ctlNumChannels;
+		value = { 6561.rand } ! ctlNumChannels;
 		synth = Synth(\testNode);
 		controlSynth = Synth.after(synth, \valueNode, [\out, mapBus, \input, value]);
 		synth.set(\input, ctlNumChannels.collect { |i| "a" ++ (mapBus + i) });
 		server.latency.wait;
 		synth.set(\trig, 1);
 		this.waitForOSCReply { |args|
-			var synthVal = args;
+			var synthVal = args.asInteger;
 			this.assertEquals(synthVal.keep(ctlNumChannels), value, "fewer channels than available should be still mapped");
 		};
 	}
@@ -116,7 +116,7 @@ TestSynthAudioMapping : UnitTest {
 		synthNumChannels = 5;
 		this.sendSynthDef(synthNumChannels, ctlNumChannels);
 		krBus = Bus.control(server, ctlNumChannels);
-		value = { 6561.0.rand.trunc } ! ctlNumChannels;
+		value = { 6561.rand } ! ctlNumChannels;
 		krBus.setn(value);
 		server.sync;
 		synth = Synth(\testNode);
@@ -124,7 +124,7 @@ TestSynthAudioMapping : UnitTest {
 		server.latency.wait;
 		synth.set(\trig, 1);
 		this.waitForOSCReply { |args|
-			var synthVal = args;
+			var synthVal = args.asInteger;
 			this.assertEquals(synthVal.keep(ctlNumChannels), value, "fewer channels than available should be still mapped");
 		};
 	}

--- a/testsuite/classlibrary/TestSynthMapping.sc
+++ b/testsuite/classlibrary/TestSynthMapping.sc
@@ -12,25 +12,22 @@ TestSynthAudioMapping : UnitTest {
 		server = Server(this.class.name);
 		this.bootServer(server);
 		server.sync;
-		this.sendSynthDef;
-		server.sync;
-
 	}
 
 	tearDown {
 		server.quit.remove;
 	}
 
-	sendSynthDef {
+	sendSynthDef { |n1, n2|
 
 		SynthDef(\testNode, {
-			var input = \input.ar(0);
+			var input = \input.ar(0 ! n1);
 			var trig = T2A.ar(\trig.tr(0));
-			SendTrig.ar(trig, 0, input);
+			SendReply.ar(trig, "/tr", input);
 		}).add;
 
 		SynthDef(\valueNode, {
-			var input = \input.ar(-1);
+			var input = \input.ar(-1 ! n2);
 			var out = \out.kr(0);
 			Out.ar(out, input);
 		}).add;
@@ -38,45 +35,78 @@ TestSynthAudioMapping : UnitTest {
 	}
 
 	waitForOSCReply { |callback, timeout = 4|
-		var oscRecv = OSCFunc({ |msg| callback.(msg.drop(1)); }, "/tr").oneShot;
-		SystemClock.sched(timeout, { oscRecv.free });
+		var cond = Condition.new;
+		var oscRecv = OSCFunc({ |msg| msg.postcs; "----".postln; callback.(msg.drop(3)); cond.unhang; }, "/tr").oneShot;
+		SystemClock.sched(timeout, { oscRecv.free; cond.unhang; });
+		cond.hang;
 	}
 
-	test_noop {
-		synth = Synth(\testNode);
-		server.latency.wait;
-		synth.set(\trig, 1);
-		this.waitForOSCReply { |args|
-			var val = args.first;
-			this.assertEqualValue(val, -1, "default value of synth before mapping should be -1");
-		};
-	}
 
 	test_map_normal_order {
 		var controlSynth, value;
-		value = 6561;
+		this.sendSynthDef(1, 1);
+		server.sync;
+		value = 6561.0;
 		synth = Synth(\testNode);
 		controlSynth = Synth.before(synth, \valueNode, [\out, mapBus, \input, value]);
-		synth.map(\input, mapBus);
+		synth.set(\input, "a" ++ mapBus);
 		server.latency.wait;
 		synth.set(\trig, 1);
 		this.waitForOSCReply { |args|
 			var val = args.first;
-			this.assertEqualValue(val, value, "value of synth after mapping should match");
+			this.assertEquals(val, value, "value of synth after mapping should match");
 		};
 	}
 
 	test_map_reverse_order {
 		var controlSynth, value;
-		value = 6561;
+		this.sendSynthDef(1, 1);
+		server.sync;
+		value = 6561.0;
 		synth = Synth(\testNode);
 		controlSynth = Synth.after(synth, \valueNode, [\out, mapBus, \input, value]);
-		synth.map(\input, mapBus);
+		synth.set(\input, "a" ++ mapBus);
 		server.latency.wait;
 		synth.set(\trig, 1);
 		this.waitForOSCReply { |args|
 			var val = args.first;
-			this.assertEqualValue(val, value, "value of synth after mapping should match");
+			this.assertEquals(val, value, "value of synth after mapping should match");
+		};
+	}
+
+	test_map_with_too_many_channels {
+		var controlSynth, value, ctlNumChannels, synthNumChannels;
+		ctlNumChannels = 5;
+		synthNumChannels = 2;
+		this.sendSynthDef(synthNumChannels, ctlNumChannels);
+		server.sync;
+		value = { 6561.0.rand.trunc } ! ctlNumChannels;
+		synth = Synth(\testNode);
+		controlSynth = Synth.after(synth, \valueNode, [\out, mapBus, \input, value]);
+		synth.set(\input, ctlNumChannels.collect { |i| "a" ++ (mapBus + i) });
+		server.latency.wait;
+		synth.set(\trig, 1);
+		this.waitForOSCReply { |args|
+			var synthVal = args;
+			this.assertEquals(synthVal, value.keep(synthNumChannels), "more channels than available should be still mapped");
+		};
+	}
+
+	test_map_with_too_few_channels {
+		var controlSynth, value, ctlNumChannels, synthNumChannels;
+		ctlNumChannels = 2;
+		synthNumChannels = 5;
+		this.sendSynthDef(synthNumChannels, ctlNumChannels);
+		server.sync;
+		value = { 6561.0.rand.trunc } ! ctlNumChannels;
+		synth = Synth(\testNode);
+		controlSynth = Synth.after(synth, \valueNode, [\out, mapBus, \input, value]);
+		synth.set(\input, ctlNumChannels.collect { |i| "a" ++ (mapBus + i) });
+		server.latency.wait;
+		synth.set(\trig, 1);
+		this.waitForOSCReply { |args|
+			var synthVal = args;
+			this.assertEquals(synthVal.keep(ctlNumChannels), value, "fewer channels than available should be still mapped");
 		};
 	}
 


### PR DESCRIPTION

## Purpose and Motivation

This makes sure that node order doesn't matter for audio rate mapping, up to block delay.


## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] This PR is ready for review
