### PR TITLE
Topic/fix nodeproxy audio bus mapping num channels

### DIFF
--- a/HelpSource/Classes/NodeProxy.schelp
+++ b/HelpSource/Classes/NodeProxy.schelp
@@ -490,6 +490,9 @@ Get all key value pairs from both link::Classes/NodeMap:: (the settings) and def
 method::controlKeysValues
 Get all key value pairs from default arguments.
 
+method::findControlName
+Search the source objects for a given control name symbol
+
 method::specs
 Get the specs array from SynthDef metadata. Note that, for a NodeProxy with multiple sources, result will be a dictionary containing specs of ALL source SynthDefs.
 code::

--- a/HelpSource/Classes/NodeProxy.schelp
+++ b/HelpSource/Classes/NodeProxy.schelp
@@ -491,7 +491,7 @@ method::controlKeysValues
 Get all key value pairs from default arguments.
 
 method::findControlName
-Search the source objects for a given control name symbol
+Search the source objects for a given control name symbol and return the link::Classes/ControlName::.
 
 method::specs
 Get the specs array from SynthDef metadata. Note that, for a NodeProxy with multiple sources, result will be a dictionary containing specs of ALL source SynthDefs.

--- a/SCClassLibrary/JITLib/ProxySpace/NodeProxy.sc
+++ b/SCClassLibrary/JITLib/ProxySpace/NodeProxy.sc
@@ -424,13 +424,12 @@ NodeProxy : BusPlug {
 			}
 		};
 		numChannels = ctl !? { ctl.defaultValue.asArray.size };
-		canBeMapped = proxy.initBus(rate, numChannels); // warning: proxy should still have a fixed bus
-		if(canBeMapped) {
-			if(this.isNeutral) { this.defineBus(rate, numChannels) };
-			this.xmap(key, proxy);
-		} {
-			"Could not link node proxies, no matching input found.".warn
-		};
+
+		if(proxy.isNeutral) { proxy.defineBus(rate, numChannels) };
+		if(this.isNeutral) { this.defineBus(rate, numChannels) };
+
+		this.xmap(key, proxy);
+
 		^proxy // returns first argument for further chaining
 	}
 

--- a/SCClassLibrary/JITLib/ProxySpace/NodeProxy.sc
+++ b/SCClassLibrary/JITLib/ProxySpace/NodeProxy.sc
@@ -84,7 +84,7 @@ NodeProxy : BusPlug {
 	}
 
 	fadeTime_ { | dur |
-		this.set(\fadeTime, dur ? defaultFadeTime) // Use default if fadeTime set to nil 
+		this.set(\fadeTime, dur ? defaultFadeTime) // Use default if fadeTime set to nil
 	}
 
 	fadeTime {
@@ -415,7 +415,7 @@ NodeProxy : BusPlug {
 	<<> { | proxy, key = \in |
 		var ctl, rate, numChannels, canBeMapped;
 		if(proxy.isNil) { ^this.unmap(key) };
-		ctl = this.controlNames.detect { |x| x.name == key };
+		ctl = this.findControlName(key);
 		rate = ctl.rate ?? {
 			if(proxy.isNeutral) {
 				if(this.isNeutral) { \audio } { this.rate }
@@ -647,6 +647,16 @@ NodeProxy : BusPlug {
 			}
 		};
 		^objCtlNames
+	}
+
+
+	findControlName { | key |
+		objects.do { |el|
+			el.controlNames.do { |item|
+				if(key == item.name) { ^item }
+			};
+		};
+		^nil
 	}
 
 	resetNodeMap {

--- a/testsuite/classlibrary/TestNodeProxy.sc
+++ b/testsuite/classlibrary/TestNodeProxy.sc
@@ -329,7 +329,7 @@ TestNodeProxyBusMapping : UnitTest {
 
 		0.2.wait;
 
-		this.assert(proxy.rate == \control, "proxy should have initialized itself to a control rate proxy");
+		this.assert(proxy.rate == \control, "proxy should have initialized itself to control rate");
 
 		synthValues = server.getControlBusValues(proxy.bus.index, proxy.numChannels);
 
@@ -342,6 +342,49 @@ TestNodeProxyBusMapping : UnitTest {
 		synthValues = server.getControlBusValues(proxy.bus.index, proxy.numChannels);
 
 		this.assertEquals(synthValues, controlValues, "after mapping, synth should return mapped values");
+
+
+	}
+
+	test_audiorate_mapping_elasticity {
+		var proxy, controlProxy;
+		var synthValues, controlValues, defaultValues;
+
+		defaultValues = [-1.0, -2.0, -3.0];
+		controlValues = [162.0, 54.0, 45.0, 87.0];
+
+		proxy = NodeProxy(server, \audio, 7);
+		proxy.reshaping = \elastic;
+		proxy.fadeTime = 0.001;
+
+		proxy.source = {
+			var in = \in.ar(defaultValues);
+			A2K.kr(in);
+		};
+
+		controlProxy = NodeProxy(server, \audio, 2);
+		controlProxy.reshaping = \elastic;
+		controlProxy.fadeTime = 0.001;
+		controlProxy.source = {
+			DC.ar(controlValues)
+		};
+
+		0.2.wait;
+
+		this.assertEquals(proxy.rate, \control, "proxy should have initialized itself to control rate");
+		this.assertEquals(proxy.numChannels, defaultValues.size, "proxy should have initialized itself to the correct number of channels");
+
+		synthValues = server.getControlBusValues(proxy.bus.index, proxy.numChannels);
+
+		this.assertEquals(synthValues.round, defaultValues.round, "before mapping, synth values should be default values");
+
+		proxy <<>.in controlProxy;
+
+		0.2.wait;
+
+		synthValues = server.getControlBusValues(proxy.bus.index, proxy.numChannels);
+
+		this.assertEquals(synthValues.round, controlValues.keep(synthValues.size).round, "after mapping, synth should return mapped values");
 
 
 	}


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

This fixes #5303. The issue resulted from the fact that `ProxyNodeMap` intentionally returns instances of `ControlName` that have the mapped proxy as default values. In the case of the `<<>` operator, we are only interested in the objects' control names. It would have been enough to use the keyword argument switch `.controlNames(addNodeMap: false)`, but it is much more efficient and clear as it is solved here.

Another issue was that when mapping a control to an elastic proxy, this proxy was reshaped. This led to inconsistent behavior. This PR also makes sure that any proxy that is passed into `<<>` will only be initialized if neutral, but will retain its shape when already initialized.

## Types of changes

- Documentation
- Bug fix
- New feature

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review
