### PR TITLE
Env xyc: use default curve

### DIFF
--- a/HelpSource/Classes/Env.schelp
+++ b/HelpSource/Classes/Env.schelp
@@ -305,6 +305,7 @@ code::
 Env.xyc([[0, 1, \sin], [2.1, 0.5, \lin],  [3, 1.4, \lin]]).plot;
 Env.xyc([[2.1, 0.5, \lin], [0, 1, \sin], [3, 1.4, \lin]]).plot; // *if possible*, pairs are sorted according to time
 Env.xyc({ [1.0.rand, 10.0.rand, -4.rand2] } ! 16, \exp).plot;
+Env.xyc([[0, 1], [2.1, 0.5],  [3, 1.4]]).plot; // if not specified, curve defaults to \lin
 ::
 
 

--- a/SCClassLibrary/Common/Audio/Env.sc
+++ b/SCClassLibrary/Common/Audio/Env.sc
@@ -139,6 +139,7 @@ Env {
 
 	*xyc { arg xyc;
 		var times, levels, curves, offset, order;
+		xyc = xyc.collect({|arr| arr[0..1] ++ (arr[2] ? \lin)});
 		#times, levels, curves = xyc.flop;
 		if(times.every(_.isKindOf(Magnitude))) { // sort triplets, if possible.
 			order = times.order;


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

When specifying envelope as control points, one needs to specify curve for each point. With this PR, curve parameter can be omitted, in which case `\lin`ear curve will be used.

## Types of changes

<!-- Delete lines that don't apply -->

- New feature

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [ ] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review
