### PR TITLE
\u_cmd: make sure to print correct node ID in case of an error

### DIFF
--- a/server/scsynth/SC_UnitDef.cpp
+++ b/server/scsynth/SC_UnitDef.cpp
@@ -32,6 +32,7 @@
 #include "SC_World.h"
 #include "sc_msg_iter.h"
 
+extern int gMissingNodeID;
 
 bool UnitDef_Create(const char* inName, size_t inAllocSize, UnitCtorFunc inCtor, UnitDtorFunc inDtor, uint32 inFlags) {
     if (strlen(inName) >= kSCNameByteLen)
@@ -106,6 +107,7 @@ bool PlugIn_DefineCmd(const char* inCmdName, PlugInCmdFunc inFunc, void* inUserD
 int Unit_DoCmd(World* inWorld, int inSize, char* inData) {
     sc_msg_iter msg(inSize, inData);
     int nodeID = msg.geti();
+    gMissingNodeID = nodeID;
     Graph* graph = World_GetGraph(inWorld, nodeID);
     if (!graph)
         return kSCErr_NodeNotFound;


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

`Unit_DoCmd` didn't set `gMissingNodeID`, so when we try to run a unit command on a non-existent node, the error message would contain a wrong node ID.

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review
