### PR TITLE
classlib: String:openOS escaping

### DIFF
--- a/SCClassLibrary/Common/Collections/linux/extString_linux.sc
+++ b/SCClassLibrary/Common/Collections/linux/extString_linux.sc
@@ -23,6 +23,6 @@
 	}
 
 	openOS {
-		("xdg-open " ++ this.escapeChar($ )).systemCmd
+		["xdg-open", this].unixCmd;
 	}
 }

--- a/SCClassLibrary/Common/Collections/osx/extString_osx.sc
+++ b/SCClassLibrary/Common/Collections/osx/extString_osx.sc
@@ -23,6 +23,6 @@
 	}
 
 	openOS {
-		("open " ++ this.escapeChar($ )).systemCmd
+		["open", this].unixCmd;
 	}
 }

--- a/SCClassLibrary/Common/Collections/windows/extString_windows.sc
+++ b/SCClassLibrary/Common/Collections/windows/extString_windows.sc
@@ -3,8 +3,8 @@
 		format("start \"SuperCollider runInTerminal\" cmd.exe /k %", this.quote).unixCmd;
 	}
 
-	openOS {|aPath|
+	openOS {
 		// start "title" "command"
-		("start" + "\"SuperCollider\"" + this.quote).systemCmd
+		["start", "SuperCollider".quote, this.quote].unixCmd;
 	}
 }


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->
Fixes #2297.
String:openOS calls systemCmd, resulting in:
- sclang being blocked until the executed command exits (e.g. when the file browser window is closed)
- only spaces are escaped, and not ampersands and other characters as described in #2297

This PR switches to SequenceableCollection:unixCmd, as suggested by @nhthn, fixing both problems at once.
I've changed implementations for Linux and macOS, but not for Windows, which I don't understand and can't test. 

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix
- New feature
- Breaking change?
could anyone rely on openOS being blocking? I don't see it very likely, as openOS is not a file-chooser and doesn't return anything.

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [ ] Code is tested
- [ ] All tests are passing
- [ ] Updated documentation
- [x] This PR is ready for review
