### PR TITLE
Topic: Help: NodeProxy: fix pset typo [skip ci]

### DIFF
--- a/HelpSource/Reference/NodeProxy_roles.schelp
+++ b/HelpSource/Reference/NodeProxy_roles.schelp
@@ -54,7 +54,7 @@ a[0] = { |freq = 440, dt=0.1, rate=2| Ringz.ar(Impulse.ar(rate * [1, 1.2]), freq
 a.play;
 
 (
-a[1] = \xset -> Pbind(
+a[1] = \pset -> Pbind(
 	\dur, Prand([1, 0.5], inf),
 	\freq, Pwhite(200.0, 1000, inf).round(30),
 	\rate, Pstutter(4, Prand([1, 3, 6, 10], inf)),


### PR DESCRIPTION
## Purpose and Motivation

Fixes a typo in the `NodeProxy_roles` help file.

## Types of changes

- Documentation

## To-do list

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review
