### PR TITLE
classlib: Fix MainMenu so that adding an item without initialising sy…

### DIFF
--- a/SCClassLibrary/Common/GUI/Base/Menu.sc
+++ b/SCClassLibrary/Common/GUI/Base/Menu.sc
@@ -106,7 +106,10 @@ MainMenu {
 	classvar systemMenus;
 	classvar <>buildAppMenusAction;
 
-	*initClass {}
+	*initClass {
+		registered = List();
+		systemMenus = [];
+	}
 
 	*initBuiltInMenus {
 		if(Platform.hasQt.not) { ^nil; };	// skip init on Qt-less builds
@@ -130,13 +133,10 @@ MainMenu {
 			{ this.prUpdateServersMenu() }.defer
 		}));
 
-		registered = List();
-
 		systemMenus = [\SuperCollider, \File, \Edit, \Server, \Quarks, \Help];
 		systemMenus.do({ |systemMenu| this.prGetMenu(systemMenu) });
 
 		this.prUpdateServersMenu();
-		this.clear();
 		this.prUpdate();
 	}
 


### PR DESCRIPTION
…stem menus doesn't throw an error

This fixes #4568

<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

This improves upon the workaround in 423a54e making it less disruptive when not using System Menus

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix


## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] This PR is ready for review
