### PR TITLE
class library: fix TCP connection in Server.remote

### DIFF
--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -388,7 +388,11 @@ Server {
 	*remote { |name, addr, options, clientID|
 		var result;
 		result = this.new(name, addr, options, clientID);
-		result.startAliveThread;
+		if(options.protocol == \tcp) {
+			addr.tryConnectTCP({ result.startAliveThread }, nil, 20)
+		} {
+			result.startAliveThread;
+		};
 		^result;
 	}
 


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->
Previously `Server.remote` was not instantiating connection properly when using the TCP protocol. `Server.remote` is all that's needed to use a remote server when using UDP. My understanding is that it also should be the case for TCP.

This PR attempts to fix the issue with TCP. I'm not 100% sure this is the correct fix, but it does seem to work as expected.

Here's one way to test this locally by starting the server using `.unixCmd` and connecting to it as if it was a remote server:

```supercollider
// start the server
~serverPid = "/Applications/SuperCollider.app/Contents/Resources/scsynth -t 57110".unixCmd({"server command finished".postln}); // on macOS; NOTE we assume that SuperCollider.app is directly in /Applications - adjust the path if needed
// or
~serverPid = "scsynth -t 57110".unixCmd({"server command finished".postln}); // if scsynth is in the PATH, likely on Linux

// connect to the "remote" server, running locally
~server = Server.remote(\test, NetAddr("127.0.0.1", 57110), ServerOptions().protocol_(\tcp));
~server.makeGui; // with the fix, we can see server state updates in the gui window

// stop
~server.quit; // if the connection was successful, that should be all that's needed
// if not, we may need to stop the server manually:
thisProcess.platform.killProcessByID(~serverPid);
```

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [ ] All tests are passing
- [ ] Updated documentation
- [x] This PR is ready for review
