### PR TITLE
Linux packaging: Install icons into share/icons/hicolor/*

### DIFF
--- a/platform/linux/CMakeLists.txt
+++ b/platform/linux/CMakeLists.txt
@@ -1,8 +1,11 @@
-install(FILES icons/supercollider.png icons/supercollider.xpm
-	DESTINATION ${CMAKE_INSTALL_PREFIX}/share/pixmaps )
+install(FILES icons/supercollider.xpm
+	DESTINATION ${CMAKE_INSTALL_PREFIX}/share/icons/hicolor/32x32/apps )
+
+install(FILES icons/supercollider.png
+	DESTINATION ${CMAKE_INSTALL_PREFIX}/share/icons/hicolor/48x48/apps )
 
 install(FILES ../../icons/sc_ide.svg
-	DESTINATION ${CMAKE_INSTALL_PREFIX}/share/pixmaps )
+	DESTINATION ${CMAKE_INSTALL_PREFIX}/share/icons/hicolor/scalable/apps )
 
 install(FILES supercollider.xml
     DESTINATION share/mime/packages )


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

I am working on a [flatpak manifest for SuperCollider](https://github.com/jmaibaum/flathub/tree/io.github.SuperCollider) (using the pipewire jack replacement libraries on the host). `flatpak-builder` doesn't like icons to be stored in `share/pixmaps/*`, but looks for them in `share/icons/hicolor/*` only. Freedesktop's specifications are a little bit unclear in this regard, but one can find relevant lines, for example https://specifications.freedesktop.org/icon-theme-spec/latest/ar01s07.html:

> ## Installing Application Icons
> 
> So, you're an application author, and want to install application icons so that they work in the KDE and Gnome menus. Minimally you should install a 48x48 icon in the hicolor theme. This means installing a PNG file in $prefix/share/icons/hicolor/48x48/apps. Optionally you can install icons in different sizes. For example, installing a svg icon in $prefix/share/icons/hicolor/scalable/apps means most desktops will have one icon that works for all sizes.

## Types of changes

- Bug fix: Change CMake script to install icons into `share/icons/hicolor/*`, instead of `share/pixmaps/*`.

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested: My flatpak manifest is able to package SuperCollider after this patch is applied
- [ ] All tests are passing
- [ ] Updated documentation
- [x] This PR is ready for review
