### PR TITLE
Topic/minor help fixes mk

### DIFF
--- a/HelpSource/Classes/MIDIFunc.schelp
+++ b/HelpSource/Classes/MIDIFunc.schelp
@@ -6,8 +6,13 @@ related:: Guides/MIDI, Classes/MIDIdef
 DESCRIPTION::
 MIDIFunc (and its subclass link::Classes/MIDIdef::) registers one or more functions to respond to an incoming MIDI message. Many of its methods are inherited from its superclass link::Classes/AbstractResponderFunc::.
 
-note:: MIDIFunc and link::Classes/MIDIdef:: aim to improve upon the MIDIresponder classes by being faster, easier to use, and providing support for all MIDI message types. They were made with the intention of creating a more convenient, logical and consistent interface, which shares a common design with link::Classes/OSCFunc:: and link::Classes/OSCdef::. Note that unlike the older classes, MIDIFuncs are removed on Cmd-. by default. This can be overridden using either of the fix or permanent methods.::
+MIDIFunc and link::Classes/MIDIdef:: aim to improve upon the MIDIresponder classes by being faster, easier to use, and providing support for all MIDI message types. They were made with the intention of creating a more convenient, logical and consistent interface, which shares a common design with link::Classes/OSCFunc:: and link::Classes/OSCdef::. 
 
+subsection:: Important note on persistence
+
+MIDIFunc (and its subclass link::Classes/MIDIdef::) are by default removed when the user presses Cmd/ctrl-. to stop SuperCollider.
+
+This behaviour may be overwritten using link::Classes/AbstractResponderFunc#permanent#permanent:: or link::Classes/AbstractResponderFunc#fix#fix:: methods inherited from the link::Classes/AbstractResponderFunc:: superclass.
 
 CLASSMETHODS::
 private:: initClass, cmdPeriod

--- a/HelpSource/Classes/MIDIFunc.schelp
+++ b/HelpSource/Classes/MIDIFunc.schelp
@@ -6,13 +6,11 @@ related:: Guides/MIDI, Classes/MIDIdef
 DESCRIPTION::
 MIDIFunc (and its subclass link::Classes/MIDIdef::) registers one or more functions to respond to an incoming MIDI message. Many of its methods are inherited from its superclass link::Classes/AbstractResponderFunc::.
 
-MIDIFunc and link::Classes/MIDIdef:: aim to improve upon the MIDIresponder classes by being faster, easier to use, and providing support for all MIDI message types. They were made with the intention of creating a more convenient, logical and consistent interface, which shares a common design with link::Classes/OSCFunc:: and link::Classes/OSCdef::. 
-
 subsection:: Important note on persistence
 
 MIDIFunc (and its subclass link::Classes/MIDIdef::) are by default removed when the user presses Cmd/ctrl-. to stop SuperCollider.
 
-This behaviour may be overwritten using link::Classes/AbstractResponderFunc#permanent#permanent:: or link::Classes/AbstractResponderFunc#fix#fix:: methods inherited from the link::Classes/AbstractResponderFunc:: superclass.
+This behaviour may be overridden using link::Classes/AbstractResponderFunc#-permanent#permanent:: or link::Classes/AbstractResponderFunc#-fix#fix:: methods inherited from the link::Classes/AbstractResponderFunc:: superclass.
 
 CLASSMETHODS::
 private:: initClass, cmdPeriod

--- a/HelpSource/Classes/MIDIdef.schelp
+++ b/HelpSource/Classes/MIDIdef.schelp
@@ -6,8 +6,13 @@ related:: Guides/MIDI, Classes/MIDIFunc
 DESCRIPTION::
 MIDIdef provides a global reference to the functionality of its superclass link::Classes/MIDIFunc::. Essentially it stores itself at a key within a global dictionary, allowing replacement at any time. Most methods are inherited from its superclass.
 
-note:: MIDIdef and link::Classes/MIDIFunc:: aim to improve upon the MIDIresponder classes by being faster, easier to use, and providing support for all MIDI message types. They were made with the intention of creating a more convenient, logical and consistent interface, which shares a common design with link::Classes/OSCFunc:: and link::Classes/OSCdef::. Note that unlike the older classes, MIDIdefs are removed on Cmd-. by default. This can be overridden using either of the fix or permanent methods.::
+MIDIFunc and link::Classes/MIDIdef:: aim to improve upon the MIDIresponder classes by being faster, easier to use, and providing support for all MIDI message types. They were made with the intention of creating a more convenient, logical and consistent interface, which shares a common design with link::Classes/OSCFunc:: and link::Classes/OSCdef::. 
 
+subsection:: Important note on persistence
+
+MIDIFunc (and its subclass link::Classes/MIDIdef::) are by default removed when the user presses Cmd/ctrl-. to stop SuperCollider.
+
+This behaviour may be overwritten using link::Classes/AbstractResponderFunc#permanent#permanent:: or link::Classes/AbstractResponderFunc#fix#fix:: methods inherited from the link::Classes/AbstractResponderFunc:: superclass.
 
 CLASSMETHODS::
 private:: initClass

--- a/HelpSource/Classes/MIDIdef.schelp
+++ b/HelpSource/Classes/MIDIdef.schelp
@@ -6,13 +6,12 @@ related:: Guides/MIDI, Classes/MIDIFunc
 DESCRIPTION::
 MIDIdef provides a global reference to the functionality of its superclass link::Classes/MIDIFunc::. Essentially it stores itself at a key within a global dictionary, allowing replacement at any time. Most methods are inherited from its superclass.
 
-MIDIFunc and link::Classes/MIDIdef:: aim to improve upon the MIDIresponder classes by being faster, easier to use, and providing support for all MIDI message types. They were made with the intention of creating a more convenient, logical and consistent interface, which shares a common design with link::Classes/OSCFunc:: and link::Classes/OSCdef::. 
 
 subsection:: Important note on persistence
 
 MIDIFunc (and its subclass link::Classes/MIDIdef::) are by default removed when the user presses Cmd/ctrl-. to stop SuperCollider.
 
-This behaviour may be overwritten using link::Classes/AbstractResponderFunc#permanent#permanent:: or link::Classes/AbstractResponderFunc#fix#fix:: methods inherited from the link::Classes/AbstractResponderFunc:: superclass.
+This behaviour may be overridden using link::Classes/AbstractResponderFunc#-permanent#permanent:: or link::Classes/AbstractResponderFunc#-fix#fix:: methods inherited from the link::Classes/AbstractResponderFunc:: superclass.
 
 CLASSMETHODS::
 private:: initClass

--- a/HelpSource/Guides/WritingHelp.schelp
+++ b/HelpSource/Guides/WritingHelp.schelp
@@ -6,64 +6,9 @@ related:: Reference/SCDocSyntax, Classes/SCDoc
 section:: Writing new help
 The simplest way is to look at an existing help file or class document, and read this document and link::Reference/SCDocSyntax::
 
-note:: The help files should use UTF-8 encoding! ::
-
-subsection:: News in SC 3.5.2
-SCDoc has been rewritten and the parser is now implemented in C++ for speed and stability.
-The syntax has gotten stricter, and it will throw errors or warnings if there are faults in the documentation.
-
-Some important changes to keep in mind:
-list::
-## Linking to sections does no longer use lower_case_and_underscored anchors, but the exact section title as it is. Example: teletype::link\::#Language-side news\:::: renders: link::#Language-side news::
-## Run code::SCDoc.indexAllDocuments:: if you add a new document or other file and want to see the change reflected in the help. If you just changed a document and want to see the changes, just press Reload in the browser and SCDoc will detect and re-index automatically.
-## The teletype::CLASS\:::: tag is deprecated, just use teletype::TITLE\:::: instead also for class reference docs.
-## The argument name given to the teletype::ARGUMENT\:::: tag is now optional. If not given, SCDoc will auto-fill the real argument name.
-::
-
-subsection:: Documenting new classes
-When you navigate to an undocumented class, it will contain an schelp template that can be filled in and saved to HelpSource/Classes/ClassName.schelp.
-
-section:: Converting old helpfiles
-There is no automated process for this, but for most help files it's really simple to do it manually:
-
-numberedlist::
-## open the old helpfile in your web browser
-## copy the text and insert it in a new textfile: FileName.schelp
-## add the appropriate tags, like title, sections, etc.. (see below)
-## save the file to the right subdirectory under HelpSource, depending on the document kind (see link::#Directory layout:: below)
-## strong:: check that it rendered OK ::.
-You can run code::SCDoc.indexAllDocuments:: (link to method documentation: link::Classes/SCDoc#*indexAllDocuments::) to make SCDoc detect the new file and add it to the document index.
-
-If the file already existed and you want to see the changes, just press Reload in the help browser and SCDoc will re-render it.
-::
-
-A list of all undocumented classes can be seen here: link::Browse#Undocumented classes:: (auto-generated).
-
-section:: Directory layout
-The help system uses different folders under HelpSource depending on document kind:
-definitionlist::
-## HelpSource ||
-definitionlist::
-## Classes || class reference, file must be named as the class.
-## Reference || other reference documentation.
-## Tutorials || yes, tutorials.
-## Guides || guides that explain stuff but without being a real tutorial.
-## Overviews || overviews of other documents, these are mostly auto-generated.
-## Other || stuff that don't fit in any other directory.
-::
-::
-
-note:: It's important that the document is put in the right folder. For Classes, it's a must! ::
-
-All .schelp files will be parsed and rendered to an equal directory layout in the help target directory. Any other files, like images or ready-made HTML files, will just be copied.
-
-section:: Document header
-
 All tags that are used for document metadata should be entered at the top of the document source file, before any section or other text. See link::Reference/SCDocSyntax#Header tags::
 
-note:: You should always specify title, summary and categories. ::
-
-section:: Normal documents
+In the header, you should must specify the title, summary and categories parts of the header.
 
 Example header:
 teletype::
@@ -85,6 +30,32 @@ subsection:: Details
 
 Some details..
 ::
+
+
+
+subsection:: Documenting new classes
+When you navigate to an undocumented class, it will contain an schelp template that can be filled in and saved to HelpSource/Classes/ClassName.schelp.
+
+
+A list of all undocumented classes can be seen here: link::Browse#Undocumented classes:: (auto-generated).
+
+section:: Directory layout
+The help system uses different folders under HelpSource depending on document kind:
+definitionlist::
+## HelpSource ||
+definitionlist::
+## Classes || class reference, file must be named as the class.
+## Reference || other reference documentation.
+## Tutorials || yes, tutorials.
+## Guides || guides that explain stuff but without being a real tutorial.
+## Overviews || overviews of other documents, these are mostly auto-generated.
+## Other || stuff that don't fit in any other directory.
+::
+::
+
+note:: It's important that the document is put in the right folder. For Classes, it's a must! ::
+
+All .schelp files will be parsed and rendered to an equal directory layout in the help target directory. Any other files, like images or ready-made HTML files, will just be copied.
 
 section:: Class reference
 Class reference has some special tags and a more strict structure. Normal text should be written inside the special top-level sections DESCRIPTION, CLASSMETHODS, INSTANCEMETHODS and EXAMPLES.
@@ -321,11 +292,12 @@ For more filters, see link::Browse#UGens>Filters::
 ::
 Renders as: For more filters, see link::Browse#UGens>Filters::
 
-section:: Contributing with the documentation
+section:: Contributing with documentation
 
 The easiest way to contribute to the documentation is:
 
     1. Fork the SuperCollider repository https://github.com/supercollider/supercollider
+
     2. Clone your repository
     code::
     git clone --recursive git://github.com/{your_username}/supercollider.git
@@ -338,4 +310,40 @@ The easiest way to contribute to the documentation is:
     code::
     git push origin -u doc_updates
     ::
+<<<<<<< HEAD
     5. Submit your pull request through github, from your branch doc_updates to SuperCollider develop
+=======
+    5. Submit your pull request through github, from your branch doc_updates to SuperCollider master
+
+section::Working with legacy documentation
+
+Here is some information for working with documentation that is written in legacy format or syntax.
+
+subsection:: News in SC 3.5.2
+SCDoc was rewritten and the parser implemented in C++ for speed and stability in 3.5.2.
+The syntax got more strict, and the parser now throws errors or warnings if there are faults in the documentation.
+
+Some important changes to keep in mind:
+
+list::
+## Linking to sections does no longer use lower_case_and_underscored anchors, but the exact section title as it is. Example: teletype::link\::#Language-side news\:::: renders: link::#Language-side news::
+## Run code::SCDoc.indexAllDocuments:: if you add a new document or other file and want to see the change reflected in the help. If you just changed a document and want to see the changes, just press Reload in the browser and SCDoc will detect and re-index automatically.
+## The teletype::CLASS\:::: tag is deprecated, just use teletype::TITLE\:::: instead also for class reference docs.
+## The argument name given to the teletype::ARGUMENT\:::: tag is now optional. If not given, SCDoc will auto-fill the real argument name.
+::
+
+subsection:: Converting old helpfiles
+There is no automated process for this, but for most help files it's really simple to do it manually:
+
+numberedlist::
+## open the old helpfile in your web browser
+## copy the text and insert it in a new textfile: FileName.schelp
+## add the appropriate tags, like title, sections, etc.. (see below)
+## save the file to the right subdirectory under HelpSource, depending on the document kind (see link::#Directory layout:: below)
+## strong:: check that it rendered OK ::.
+You can run code::SCDoc.indexAllDocuments:: (link to method documentation: link::Classes/SCDoc#*indexAllDocuments::) to make SCDoc detect the new file and add it to the document index.
+
+If the file already existed and you want to see the changes, just press Reload in the help browser and SCDoc will re-render it.
+::
+
+>>>>>>> 3e9cac82c (Restructure Writing Help guide)

--- a/HelpSource/Guides/WritingHelp.schelp
+++ b/HelpSource/Guides/WritingHelp.schelp
@@ -308,7 +308,7 @@ The easiest way to contribute to the documentation is:
     code::
     git push origin -u doc_updates
     ::
-    5. Submit your pull request through github, from your branch doc_updates to SuperCollider main
+    5. Submit your pull request through github, from your branch doc_updates to SuperCollider develop
 
 section::Working with legacy documentation
 

--- a/HelpSource/Guides/WritingHelp.schelp
+++ b/HelpSource/Guides/WritingHelp.schelp
@@ -312,12 +312,16 @@ The easiest way to contribute to the documentation is:
     ::
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
     5. Submit your pull request through github, from your branch doc_updates to SuperCollider develop
 =======
     5. Submit your pull request through github, from your branch doc_updates to SuperCollider master
 =======
     5. Submit your pull request through github, from your branch doc_updates to SuperCollider develop
 >>>>>>> a1efea155 (mege conflict)
+=======
+    5. Submit your pull request through github, from your branch doc_updates to SuperCollider main
+>>>>>>> 728dbfd13 (main)
 
 section::Working with legacy documentation
 

--- a/HelpSource/Guides/WritingHelp.schelp
+++ b/HelpSource/Guides/WritingHelp.schelp
@@ -311,9 +311,13 @@ The easiest way to contribute to the documentation is:
     git push origin -u doc_updates
     ::
 <<<<<<< HEAD
+<<<<<<< HEAD
     5. Submit your pull request through github, from your branch doc_updates to SuperCollider develop
 =======
     5. Submit your pull request through github, from your branch doc_updates to SuperCollider master
+=======
+    5. Submit your pull request through github, from your branch doc_updates to SuperCollider develop
+>>>>>>> a1efea155 (mege conflict)
 
 section::Working with legacy documentation
 

--- a/HelpSource/Guides/WritingHelp.schelp
+++ b/HelpSource/Guides/WritingHelp.schelp
@@ -6,6 +6,8 @@ related:: Reference/SCDocSyntax, Classes/SCDoc
 section:: Writing new help
 The simplest way is to look at an existing help file or class document, and read this document and link::Reference/SCDocSyntax::
 
+note:: The help files should use UTF-8 encoding! ::
+
 All tags that are used for document metadata should be entered at the top of the document source file, before any section or other text. See link::Reference/SCDocSyntax#Header tags::
 
 In the header, you should must specify the title, summary and categories parts of the header.

--- a/HelpSource/Guides/WritingHelp.schelp
+++ b/HelpSource/Guides/WritingHelp.schelp
@@ -243,10 +243,6 @@ returns:: the stripped string
 The contents are inserted into the right spot (section, subsection, etc).
 It works for all kind of sections, for example one can add a subsection to code::DESCRIPTION\:::: with additional information, or add another top-level section, etc.
 
-
-
-
-
 section:: Links
 
 URL's are automagically converted to links.
@@ -310,18 +306,7 @@ The easiest way to contribute to the documentation is:
     code::
     git push origin -u doc_updates
     ::
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-    5. Submit your pull request through github, from your branch doc_updates to SuperCollider develop
-=======
-    5. Submit your pull request through github, from your branch doc_updates to SuperCollider master
-=======
-    5. Submit your pull request through github, from your branch doc_updates to SuperCollider develop
->>>>>>> a1efea155 (mege conflict)
-=======
     5. Submit your pull request through github, from your branch doc_updates to SuperCollider main
->>>>>>> 728dbfd13 (main)
 
 section::Working with legacy documentation
 
@@ -353,5 +338,3 @@ You can run code::SCDoc.indexAllDocuments:: (link to method documentation: link:
 
 If the file already existed and you want to see the changes, just press Reload in the help browser and SCDoc will re-render it.
 ::
-
->>>>>>> 3e9cac82c (Restructure Writing Help guide)


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

This fixes two small documentation issues:
https://github.com/supercollider/supercollider/issues/5301

and 

https://github.com/supercollider/supercollider/issues/5290

The writing help helpfile was restructured as to not have legacy information be the first thing a user sees but rather how to write help. Some `note` tags were removed as well to make it easier to read.

MIDIFunc and MIDIdef help files were rewritten to make it even clearer that cmd-. kills them by default and where to find information about how to fix that.

## Types of changes

- Documentation

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [ ] Code is tested
- [ ] All tests are passing
- [x] Updated documentation
- [ ] This PR is ready for review
