### PR TITLE
GitHub Actions: add test suite

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -312,3 +312,87 @@ jobs:
           name: ${{ env.ARTIFACT_FILE }}
           path: ${{ env.INSTALL_PATH }}/${{ env.ARTIFACT_FILE }}
           retention-days: 7 # quickly remove test artifacts
+
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+
+          - name: macOS
+            runs-on: macos-10.15
+            sclang: 'build/Install/SuperCollider/SuperCollider.app/Contents/MacOS/sclang'
+            artifact-suffix: macOS
+
+          - name: Linux
+            runs-on: ubuntu-18.04
+            sclang: 'build/Install/bin/sclang'
+            artifact-suffix: linux-bionic-gcc10
+
+    needs: [lint, Linux, macOS] # unfortunately we can't use matrix expression here to make Linux test depend only on Linux build
+    runs-on: '${{ matrix.runs-on }}'
+    name: 'test on ${{ matrix.name }}'
+    env:
+      INSTALL_PATH: ${{ github.workspace }}/build/Install
+      ARTIFACT_FILE: 'SuperCollider-${{ needs.lint.outputs.sc-version }}-${{ matrix.artifact-suffix }}.zip'
+      QUARKS_PATH: ${{ github.workspace }}/build/Quarks
+      TESTS_PATH: ${{ github.workspace }}/testsuite/classlibrary
+      SCLANG: ${{ github.workspace }}/${{ matrix.sclang }}
+      SCRIPT_PROTO: ${{ github.workspace }}/testsuite/scripts/gha_test_run_proto.json
+      SCRIPT_RUN: ${{ github.workspace }}/testsuite/scripts/run/gha_test_run.json
+      QPM_URL: git+https://github.com/supercollider/qpm.git@topic/xvfb-off
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: false # don't need submodules for testing
+      - name: download artifacts
+        uses: actions/download-artifact@v2
+        with:
+          name: ${{ env.ARTIFACT_FILE }}
+          path: ${{ env.INSTALL_PATH }}
+      - name: extract artifact
+        run: |
+          cd $INSTALL_PATH
+          echo `pwd`
+          echo `ls -s`
+          unzip $ARTIFACT_FILE
+      - name: setup Linux environment
+        if: runner.os == 'Linux'
+        run: |
+          # install dependencies
+          sudo apt-get update
+          sudo apt-get install --yes libsndfile1 libavahi-client-dev libfftw3-dev libicu-dev libudev-dev qt5-default qtwebengine5-dev jackd1
+
+          # add bin to PATH so qpm can find scsynth
+          echo "$INSTALL_PATH/bin" >> $GITHUB_PATH
+
+          # start jack
+          jackd --no-realtime -d dummy &
+      - name: setup python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '2.x'
+      - name: prepare tests
+        run: |
+          echo `python --version` # check version
+          sudo pip install $QPM_URL
+
+          # install API quark
+          mkdir $QUARKS_PATH && cd $QUARKS_PATH
+          git clone --depth=1 https://github.com/supercollider-quarks/API
+
+          # make working copy of the script
+          cp $SCRIPT_PROTO $SCRIPT_RUN
+      - name: run tests on Linux
+        if: runner.os == 'Linux'
+        env:
+          PYCHARM_HOSTED: 1 # enable color output
+          QPM_DEBUG: 1
+          QT_PLATFORM_PLUGIN: 'offscreen'
+        run: xvfb-run --server-args="-screen 0, 1280x720x24" -a qpm test.run -l $SCRIPT_RUN --path $SCLANG --include $QUARKS_PATH $TESTS_PATH
+      - name: run tests on macOS
+        if: runner.os == 'macOS'
+        env:
+          PYCHARM_HOSTED: 1 # enable color output
+          QPM_DEBUG: 1
+        run: qpm test.run -l $SCRIPT_RUN --path $SCLANG --include $QUARKS_PATH $TESTS_PATH

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -1,9 +1,9 @@
 name: check, build, test
 on: [push, pull_request]
 jobs:
-  linter:
+  lint:
     runs-on: ubuntu-18.04
-    outputs: 
+    outputs:
       sc-version: ${{ steps.set-version.outputs.version }}
     steps:
       - uses: actions/checkout@v2
@@ -21,7 +21,7 @@ jobs:
       - name: set version string for artifacts
         id: set-version
         run: |
-          if [[ "$GITHUB_REF" == refs/tags/* ]]; then 
+          if [[ "$GITHUB_REF" == refs/tags/* ]]; then
             FULL_TAG=${GITHUB_REF#refs/tags/}
             SC_VERSION=${FULL_TAG##Version-}
           else
@@ -30,8 +30,8 @@ jobs:
           echo "::set-output name=version::$SC_VERSION"
 
   Linux:
-    needs: linter
-    runs-on: ubuntu-${{ matrix.os-version }} 
+    needs: lint
+    runs-on: ubuntu-${{ matrix.os-version }}
     strategy:
       fail-fast: false
       matrix:
@@ -117,14 +117,14 @@ jobs:
             shared-libscsynth: false
 
     name: Linux ${{ matrix.job-name }}
-    env: 
+    env:
       BUILD_PATH: ${{ github.workspace }}/build
       INSTALL_PATH: ${{ github.workspace }}/build/Install
       USE_SYSLIBS: ${{ matrix.use-syslibs }}
       SHARED_LIBSCSYNTH: ${{ matrix.shared-libscsynth }}
       CC: ${{ matrix.c-compiler }}
       CXX: ${{ matrix.cxx-compiler }}
-      ARTIFACT_FILE: 'SuperCollider-${{ needs.linter.outputs.sc-version }}-${{ matrix.artifact-suffix }}.zip'
+      ARTIFACT_FILE: 'SuperCollider-${{ needs.lint.outputs.sc-version }}-${{ matrix.artifact-suffix }}.zip'
     steps:
       - uses: actions/checkout@v2
         with:
@@ -165,7 +165,7 @@ jobs:
       - name: configure
         run: |
           mkdir $BUILD_PATH && cd $BUILD_PATH
-          
+
           EXTRA_CMAKE_FLAGS=
 
           if $USE_SYSLIBS; then EXTRA_CMAKE_FLAGS="-DSYSTEM_BOOST=ON -DSYSTEM_YAMLCPP=ON"; fi
@@ -189,8 +189,8 @@ jobs:
           retention-days: 7 # quickly remove test artifacts
 
   macOS:
-    needs: linter
-    runs-on: macos-${{ matrix.os-version }} 
+    needs: lint
+    runs-on: macos-${{ matrix.os-version }}
     strategy:
       fail-fast: false
       matrix:
@@ -224,7 +224,7 @@ jobs:
             shared-libscsynth: true
 
     name: macOS ${{ matrix.job-name }}
-    env: 
+    env:
       BUILD_PATH: ${{ github.workspace }}/build
       INSTALL_PATH: ${{ github.workspace }}/build/Install
       HOMEBREW_NO_ANALYTICS: 1
@@ -232,17 +232,16 @@ jobs:
       HOMEBREW_NO_INSTALL_CLEANUP: 1
       USE_SYSLIBS: ${{ matrix.use-syslibs }}
       SHARED_LIBSCSYNTH: ${{ matrix.shared-libscsynth }}
-      ARTIFACT_FILE: 'SuperCollider-${{ needs.linter.outputs.sc-version }}-${{ matrix.artifact-suffix }}.zip'
+      ARTIFACT_FILE: 'SuperCollider-${{ needs.lint.outputs.sc-version }}-${{ matrix.artifact-suffix }}.zip'
     steps:
       - uses: actions/checkout@v2
         with:
           submodules: recursive
-      - name: prepare daily timestamp for cache
+      - name: prepare timestamp for cache
         id: current-date
-        run: echo "::set-output name=stamp::$(date '+%Y-%m-%d')"
-      - name: prepare monthly timestamp for cache
-        id: current-month
-        run: echo "::set-output name=stamp::$(date '+%Y-%m')"
+        run: |
+          echo "::set-output name=stamp::$(date '+%Y-%m-%d')"
+          echo "::set-output name=week::$(date '+%V')"
       - name: cache ccache
         uses: actions/cache@v2
         with:
@@ -254,7 +253,7 @@ jobs:
         id: cache-homebrew
         with:
           path: ~/Library/Caches/Homebrew/downloads
-          key: ${{ runner.os }}-${{ matrix.os-version }}-${{ matrix.xcode-version }}-${{ matrix.use-syslibs }}-${{ matrix.shared-libscsynth }}-${{ matrix.qt-version }}-homebrew-${{ steps.current-month.outputs.stamp }}
+          key: ${{ runner.os }}-${{ matrix.os-version }}-${{ matrix.xcode-version }}-${{ matrix.use-syslibs }}-${{ matrix.shared-libscsynth }}-${{ matrix.qt-version }}-homebrew-${{ steps.current-date.outputs.week }}
       - name: cache qt
         id: cache-qt
         uses: actions/cache@v1
@@ -283,19 +282,19 @@ jobs:
       - name: install qt from homebrew
         if: '!matrix.qt-version'
         run: brew install qt
-  
+
       - name: configure
         env:
           DEVELOPER_DIR: '/Applications/Xcode_${{ matrix.xcode-version }}.app/Contents/Developer'
         run: |
           mkdir $BUILD_PATH && cd $BUILD_PATH
-          
+
           EXTRA_CMAKE_FLAGS=
-          
+
           if $USE_SYSLIBS; then EXTRA_CMAKE_FLAGS="-DSYSTEM_BOOST=ON -DSYSTEM_YAMLCPP=ON $EXTRA_CMAKE_FLAGS"; fi
-          
+
           if $SHARED_LIBSCSYNTH; then EXTRA_CMAKE_FLAGS="-DLIBSCSYNTH=ON $EXTRA_CMAKE_FLAGS"; fi
-          
+
           if [[ -z "${{ matrix.qt-version }}" ]]; then EXTRA_CMAKE_FLAGS="-DCMAKE_PREFIX_PATH=`brew --prefix qt5` $EXTRA_CMAKE_FLAGS"; fi
 
           echo "EXTRA_CMAKE_FLAGS:" $EXTRA_CMAKE_FLAGS

--- a/testsuite/classlibrary/TestAbstractFunction.sc
+++ b/testsuite/classlibrary/TestAbstractFunction.sc
@@ -138,7 +138,7 @@ TestAbstractFunction : UnitTest {
 
 		this.assertEquals((dur: Rest(1)).isRest, true, "event with dur = Rest(1) should return true for isRest");
 
-		this.assertEquals((type: \rest).isRest, true, "event with dur = \rest should return true for isRest");
+		this.assertEquals((type: \rest).isRest, true, "event with dur = \\rest should return true for isRest");
 
 		this.assertEquals((degree: \).isRest, true, "event with an empty symbol as dur should return true for isRest");
 

--- a/testsuite/classlibrary/TestOSCBundle.sc
+++ b/testsuite/classlibrary/TestOSCBundle.sc
@@ -14,17 +14,17 @@ TestOSCBundle : UnitTest {
 
 	test_doPrepare {
 		var synthDef, bundle;
-		var completed = false;
+		var completed = Condition(false);
 
 		bundle = OSCBundle.new;
 		synthDef = Array.fill(100, { |i|
 			var def = SynthDef("TestOSCBundle" ++ i, { Silent.ar });
 			bundle.addPrepare(["/d_recv", def.asBytes])
 		});
-		bundle.doPrepare(server, { completed = true });
-		this.wait({ completed }, "% timed out waiting for bundle to be sent".format(thisMethod));
+		bundle.doPrepare(server, { completed.test = true });
+		this.wait(completed, "% timed out waiting for bundle to be sent".format(thisMethod));
 
-		this.assertEquals(completed, true, "'doPrepare' sent the prepare bundle to the server");
+		this.assertEquals(completed.test, true, "'doPrepare' sent the prepare bundle to the server");
 	}
 
 }

--- a/testsuite/classlibrary/TestSanitize.sc
+++ b/testsuite/classlibrary/TestSanitize.sc
@@ -14,7 +14,7 @@ TestSanitize : UnitTest {
 
 	test_sanitize {
 		var duration, expected;
-		var tests, testsIncomplete;
+		var tests, testsIncomplete, testCond = Condition(false);
 		duration = 256 / server.sampleRate;
 		expected = 8888.0;
 
@@ -40,10 +40,11 @@ TestSanitize : UnitTest {
 			ugenGraphFunc.loadToFloatArray(duration, server, { |samples|
 				this.assertArrayFloatEquals(samples, expected, text);
 				testsIncomplete = testsIncomplete - 1;
+				if(testsIncomplete == 0) { testCond.test = true };
 			});
 		};
 
-		this.wait { testsIncomplete == 0 };
+		this.wait(testCond);
 	}
 
 }

--- a/testsuite/classlibrary/TestServer.sc
+++ b/testsuite/classlibrary/TestServer.sc
@@ -12,7 +12,7 @@ TestServer : UnitTest {
 		server.sync(condition, f, server.latency);
 
 		// 60 seconds
-		this.wait({condition.test}, "waiting for server to finish sync", 60);
+		this.wait(condition, "waiting for server to finish sync", 60);
 		this.assert(true, "server synced bundle with " + f.size + "messages " + "bundleSize: " + bundleSize)
 	}
 

--- a/testsuite/scripts/gha_test_run_proto.json
+++ b/testsuite/scripts/gha_test_run_proto.json
@@ -1,0 +1,188 @@
+{
+    "tests":[
+        {
+            "suite":"*",
+            "test":"*"
+        },
+        {
+            "suite":"TestBus",
+            "test":"test_get",
+            "skip":true,
+            "skipReason":"UnitTest sometimes fails when run in qpm (FIXME)"
+        },
+        {
+            "suite":"TestCondition",
+            "test":"*",
+            "skip":true,
+            "skipReason":"UnitTest fails when run in qpm (FIXME)"
+        },
+        {
+            "suite":"TestCoreUGens",
+            "test":"*",
+            "skip":true,
+            "skipReason":"UnitTest has bugs (FIXME)"
+        },
+        {
+            "suite":"TestDocument",
+            "test":"*",
+            "skip":true,
+            "skipReason":"UnitTest has bugs (FIXME)"
+        },
+        {
+            "suite":"TestDocumentEnvironment",
+            "test":"*",
+            "skip":true,
+            "skipReason":"UnitTest creates issues when run in qpm (FIXME)"
+        },
+        {
+            "suite":"TestEnvironmentDocument",
+            "test":"*",
+            "skip":true,
+            "skipReason":"UnitTest fails when run in qpm (FIXME)"
+        },
+        {
+            "suite":"TestDoneActions",
+            "test":"test_freeSelfAndResumeNext",
+            "skip":true,
+            "skipReason":"UnitTest fails when run in qpm (FIXME)"
+        },
+        {
+            "suite":"TestEnvGen_server",
+            "test":"test_zero_gate_n_off_not_sent",
+            "skip":true,
+            "skipReason":"UnitTest has bugs (FIXME)"
+        },
+        {
+            "suite":"TestEnvGen_server",
+            "test":"test_trig_gate_nonsustain_env",
+            "skip":true,
+            "skipReason":"UnitTest fails on supernova in qpm on Linux (FIXME)"
+        },
+        {
+            "suite":"TestEnvGen_server",
+            "test":"test_shapeHold_setEndValue",
+            "skip":true,
+            "skipReason":"UnitTest fails on when run in qpm on Linux (FIXME)"
+        },
+        {
+            "suite":"TestFilterUGens",
+            "test":"*",
+            "skip":true,
+            "skipReason":"UnitTest has bugs (FIXME)"
+        },
+        {
+            "suite":"TestFilterUGens",
+            "test":"*",
+            "skip":true,
+            "skipReason":"UnitTest has bugs (FIXME)"
+        },
+        {
+            "suite":"TestLinkClock",
+            "test":"*",
+            "skip":true,
+            "skipReason":"UnitTest has unknown issues when run in qpm (FIXME)"
+        },
+        {
+            "suite":"TestMixedBundleTester",
+            "test":"*",
+            "skip":true,
+            "skipReason":"UnitTest has bugs (FIXME)"
+        },
+        {
+            "suite":"TestNodeProxy",
+            "test":"test_copy_nodeMapIsCopied",
+            "skip":true,
+            "skipReason":"UnitTest fails (FIXME)"
+        },
+        {
+            "suite":"TestNodeProxyBusMapping",
+            "test":"test_audiorate_mapping",
+            "skip":true,
+            "skipReason":"UnitTest fails (FIXME)"
+        },
+        {
+            "suite":"TestNodeProxyBusMapping",
+            "test":"test_audiorate_mapping_elasticity",
+            "skip":true,
+            "skipReason":"UnitTest fails (FIXME)"
+        },
+        {
+            "suite":"TestNodeProxyRoles",
+            "test":"test_proxyroles_xfade_smoothly",
+            "skip":true,
+            "skipReason":"UnitTest fails in qpm (FIXME)"
+        },
+        {
+            "suite":"TestNodeProxy_Server",
+            "test":"test_synthDef_isReleased_afterFree",
+            "skip":true,
+            "skipReason":"UnitTest fails (FIXME)"
+        },
+        {
+            "suite":"TestNodeProxy_Server",
+            "test":"test_schedAfterFade_notBeforeQuant",
+            "skip":true,
+            "skipReason":"UnitTest fails (FIXME)"
+        },
+        {
+            "suite":"TestNode_Server",
+            "test":"*",
+            "skip":true,
+            "skipReason":"UnitTest has bugs (FIXME)"
+        },
+        {
+            "suite":"TestOSCFunc",
+            "test":"test_argSizeMatching_Succeeds",
+            "skip":true,
+            "skipReason":"UnitTest fails when run in qpm on Linux (FIXME)"
+        },
+        {
+            "suite":"TestPanAz",
+            "test":"*",
+            "skip":true,
+            "skipReason":"UnitTest fails (FIXME)"
+        },
+        {
+            "suite":"TestProxyNodeMap",
+            "test":"*",
+            "skip":true,
+            "skipReason":"UnitTest has bugs (FIXME)"
+        },
+        {
+            "suite":"TestPV_ChainUGen",
+            "test":"*",
+            "skip":true,
+            "skipReason":"Server might hang after these tests when run in qpm (FIXME)"
+        },
+        {
+            "suite":"TestSCDoc",
+            "test":"test_helpSourceDirs_includedExtensions",
+            "skip":true,
+            "skipReason":"UnitTest fails (FIXME)"
+        },
+        {
+            "suite":"TestServer_boot",
+            "test":"*",
+            "skip":true,
+            "skipReason":"UnitTest has bugs (FIXME)"
+        },
+        {
+            "suite":"TestTempoClock",
+            "test":"test_nextTimeOnGrid_okAfterMeterChange",
+            "skip":true,
+            "skipReason":"UnitTest fails (FIXME)"
+        },
+        {
+            "suite":"TestUnitTest",
+            "test":"test_setUpClass_already_happened",
+            "skip":true,
+            "skipReason":"UnitTest fails (FIXME)"
+        },
+        {
+            "suite":"TestWebView",
+            "test":"*",
+            "skip":true,
+            "skipReason":"UnitTest sometimes fails when run in qpm on Linux (FIXME)"
+        }
+    ]
+}

--- a/testsuite/scripts/run/.gitignore
+++ b/testsuite/scripts/run/.gitignore
@@ -1,0 +1,4 @@
+# ignore all files in this directory
+*
+# except this file
+!.gitignore


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

This PR implements running our full test suite in GitHub Actions on Linux and macOS. It is another milestone in implementing #5261. Fixes #3132, supersedes #4749.

Result: `3036 TESTS PASSED`, as reported by the [GH runner](https://github.com/supercollider/supercollider/pull/5332/checks?check_run_id=1803991060#step:8:18085).

In the process on working on this, I have discovered numerous issues, some of them are fixed, while others are "patched" in this PR, yet others are still in place and documented below.

### qpm

We are using [qpm](https://github.com/supercollider/qpm) for running the test suite. @patrickdupuis's work on #4749 was a big help to understand how it works. 
Qpm uses the following [SuperCollider code](https://github.com/supercollider/qpm/blob/topic/xvfb-temp-fix/qpm/scscripts/test_runner.scd) to actually run the tests. This code reads a list of tests from a JSON file, expands * globs in test names updating the list in the JSON file, and writes the results of the tests to the same file. It needs the API Quark to work.
Qpm has some [system-specific code](https://github.com/supercollider/qpm/blob/master/qpm/sclang_process.py#L147) that needed to be changed to work with GHA runners. I'm not sure what is the canonical way of running xvfb, but this should be discussed on a separate issue in the qpm repo. In this PR I am using qpm with fixes I applied to a [new branch](https://github.com/supercollider/qpm/tree/topic/xvfb-temp-fix).
I've encountered mysterious errors ([example](https://github.com/dyfer/supercollider/runs/1759544804?check_suite_focus=true#step:8:392)) as I've started running larger chunks of the test suite. I _think_ there might be some issues in writing large dictionary to the file, and thus made some [changes to the SuperCollider code runnings the tests](https://github.com/supercollider/qpm/compare/master...supercollider:topic/xvfb-temp-fix#diff-fe8a427be8692275a981a92526eb607c62c6d2f0d7c9c3a8ca25e3ab691256e5). Particularly the hardcoded wait times are _not_ a proper solution, but allowed to avoid these errors.
I've placed the JSON file with the list of tests in `testsuite/scripts`.  I'd be happy to change that location if desired. Previously the list for Travis was stored in the root directory of the repo, which I wanted to avoid. I've also created a directory `testsuite/scripts/run` where a copy of the JSON file is made and qpm is operating on that copy.

### failing tests

There is a number of failing tests. Some have bugs and simply don't run, some run locally but fail, and some fail only when running as part of the test suite, sometimes when run locally, sometimes only when run in GHA. For some tests I excluded/listed specific methods, for others I excluded all tests for a given class. I also fixed some tests as part of this PR.
Here are the failing tests:
<details>

Tests with bugs:
```
TestCoreUGens
TestDocument
TestEnvGen_server.test_zero_gate_n_off_not_sent
TestFilterUGens
TestFilterUGens
TestMixedBundleTester
TestNode_Server
TestProxyNodeMap
TestServer_boot
```
Tests failing locally:
```
TestNodeProxy.test_copy_nodeMapIsCopied
TestNodeProxyBusMapping:test_audiorate_mapping
TestNodeProxyBusMapping:test_audiorate_mapping_elasticity
TestNodeProxy_Server.test_schedAfterFade_notBeforeQuant
TestNodeProxy_Server.test_synthDef_isReleased_afterFree
TestPanAz
TestSCDoc.test_helpSourceDirs_includedExtensions
TestTempoClock.test_nextTimeOnGrid_okAfterMeterChange
TestUnitTest.test_setUpClass_already_happened
```
Tests failing in qpm, with short descriptions:
```
TestBus.test_get: UnitTest sometimes fails when run in qpm
TestCondition.*: UnitTest fails when run in qpm
TestDocumentEnvironment.*: UnitTest creates issues when run in qpm
TestDoneActions.test_freeSelfAndResumeNext: UnitTest fails when run in qpm
TestEnvGen_server.test_shapeHold_setEndValue: UnitTest fails when run in qpm on Linux
TestEnvGen_server.test_trig_gate_nonsustain_env: UnitTest fails on supernova in qpm on Linux
TestEnvironmentDocument.*: UnitTest fails when run in qpm
TestLinkClock.*: UnitTest has unknown issues when run in qpm
TestNodeProxyRoles.test_proxyroles_xfade_smoothly: UnitTest fails in qpm
TestOSCFunc.test_argSizeMatching_Succeeds: UnitTest fails when run in qpm on Linux
TestPV_ChainUGen.*: Server might hang after these tests when run in qpm
TestWebView.*: UnitTest sometimes fails when run in qpm on Linux
```

</details>

### running tests locally

- To run the test suite in qpm locally, one needs to install qpm (note: it requires python 2)
`pip install git+https://github.com/supercollider/qpm.git@topic/xvfb-temp-fix`
- On Linux, add path with scscyth to the PATH, e.g.
`export PATH=/path/to/supercollider/build/Install/bin:$PATH`
- You might need to temporarily move the `Extensions` and `synthdefs` folders to avoid running non-built-in tests and introducing issues from 3rd-party server plugins
- Run qpm, providing the JSON file, the location of API quark and the test suite itself, for example
`cp /path/to/supercollider/testsuite/scripts/gha_test_run_proto.json /path/to/supercollider/testsuite/scripts/run/gha_test_run.json && qpm test.run -l /path/to//supercollider/testsuite/scripts/run/gha_test_run.json --path /path/to/supercollider/build/Install/SuperCollider/SuperCollider.app/Contents/MacOS/sclang --include ~/path/to/API/quark /path/to/supercollider/testsuite/classlibrary`

### GitHub Actions implementation
I implemented running tests in jobs separate from the building ones. That way it is presented more clearly when the tests pass/fail, as it is listed in the list of jobs. Unfortunately this makes it also a little slower, since the testing stage needs to wait for all build steps to finish.

EDIT: now the qpm output is in color

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix
- New feature

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] ~All~ most tests are passing (see details)
- [x] Updated documentation - [sort of](https://github.com/supercollider/supercollider/wiki/GitHub-Actions-migration-notes#test-suite)
- [x] This PR is ready for review
- [ ] Submit an issue listing failing tests (after merging this PR)
