### PR TITLE
String:prFlat Do not break string into characters

### DIFF
--- a/SCClassLibrary/Common/Collections/String.sc
+++ b/SCClassLibrary/Common/Collections/String.sc
@@ -331,6 +331,10 @@ String[char] : RawArray {
 	}
 	prCat { arg aString; _ArrayCat; ^this.primitiveFailed; }
 
+	prFlat { | list | // avoid breaking string up into characters
+		^list add: this
+	}
+
 	printOn { arg stream;
 		stream.putAll(this);
 	}


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Fix string behavior so that ["hello" ["there"]].flat returns a flat array of strings - not characters

See also #2538

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation (no need to update - there is no change, just a fix
- [x] This PR is ready for review
