### PR TITLE
Plugins: Integrator Ctor passes through the first sample only

### DIFF
--- a/server/plugins/FilterUGens.cpp
+++ b/server/plugins/FilterUGens.cpp
@@ -1053,7 +1053,15 @@ void Integrator_Ctor(Integrator* unit) {
         SETCALC(Integrator_next);
     unit->m_b1 = ZIN0(1);
     unit->m_y1 = 0.f;
-    Integrator_next(unit, 1);
+    // Note: Here, we deliberately do NOT want to call Integrator_next(unit, 1).
+    // That would initialize the presample AND update m_y1.
+    // Then this initial value will be added in *again* by the normal calc loop.
+    // So the integral would be corrupted for its lifetime.
+    // The formula is input + (coef * output[-1]).
+    // But output[-1] is 0 initially, so we just drop that term.
+    float* out = ZOUT(0);
+    float* in = ZIN(0);
+    ZXP(out) = ZXP(in);
 }
 
 void Integrator_next_i(Integrator* unit, int inNumSamples) {

--- a/server/plugins/FilterUGens.cpp
+++ b/server/plugins/FilterUGens.cpp
@@ -1053,15 +1053,7 @@ void Integrator_Ctor(Integrator* unit) {
         SETCALC(Integrator_next);
     unit->m_b1 = ZIN0(1);
     unit->m_y1 = 0.f;
-    // Note: Here, we deliberately do NOT want to call Integrator_next(unit, 1).
-    // That would initialize the presample AND update m_y1.
-    // Then this initial value will be added in *again* by the normal calc loop.
-    // So the integral would be corrupted for its lifetime.
-    // The formula is input + (coef * output[-1]).
-    // But output[-1] is 0 initially, so we just drop that term.
-    float* out = ZOUT(0);
-    float* in = ZIN(0);
-    ZXP(out) = ZXP(in);
+    ZOUT0(0) = ZIN0(0); // out = in + (coef * out[-1]); out[-1] = 0
 }
 
 void Integrator_next_i(Integrator* unit, int inNumSamples) {

--- a/testsuite/classlibrary/TestFilterUGens.sc
+++ b/testsuite/classlibrary/TestFilterUGens.sc
@@ -117,4 +117,41 @@ TestFilterUGens : UnitTest {
 
 	}
 
+	test_Integrator_add_presample_once_only {
+		var buffer;  // use a buffer to guarantee exactly 1 input value of 1
+		var synth;
+		var testResp;
+		var result;
+		var cond = Condition.new;
+		var server = Server.default;
+
+		this.bootServer(server);
+		server.sync;
+		buffer = Buffer.alloc(server, 500, 1, { |buf| buf.zeroMsg });
+		server.sync;
+		buffer.set(0, 1);
+		server.sync;
+
+		synth = {
+			var phasor = Phasor.ar(0, 1, 0, buffer.numFrames);
+			// don't allow to loop
+			var stop = Line.kr(0, 1, 0.01, doneAction: 2);
+			var sig = Integrator.ar(BufRd.ar(1, buffer, phasor, loop: 0, interpolation: 1));
+			SendReply.kr(Done.kr(stop), '/testIntegrator', A2K.kr(sig));
+			Silent.ar(1)
+		}.play;
+
+		testResp = OSCFunc({ |msg|
+			result = msg[3];
+			cond.unhang;
+		}, '/testIntegrator', server.addr, argTemplate: [synth.nodeID]);
+
+		synth.onFree { cond.unhang };
+
+		cond.hang;
+		buffer.free;
+
+		this.assertEquals(result, 1, "Integral of a single 1 should be 1");
+	}
+
 }


### PR DESCRIPTION
## Purpose and Motivation

Integrator double-counts the initial value, because of calling `next` in the Ctor.

See the added unit test: Without this fix, the integral of a single 1 followed by endless 0s ends up being 2. With the fix, it's 1 as expected.

(This is related to #2343 but it's only a spot fix of one UGen.)

## Types of changes

- Bug fix

## To-do list

- [x] Code is tested
- [x] All tests are passing
- ~~[ ] Updated documentation~~
- [x] This PR is ready for review
