### PR TITLE
macOS info.plist: add microphone access prompt

### DIFF
--- a/cmake_modules/MacOSXBundleInfo.plist.in
+++ b/cmake_modules/MacOSXBundleInfo.plist.in
@@ -149,6 +149,8 @@
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>SuperCollider wants to use your microphone or sound input.</string>
 	<key>NSServices</key>
 	<array>
 		<dict>


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->
On macOS, builds with Qt 5.15.2 were not triggering the "Microphone permissions" dialog in Catalina and Big Sur, and thus did not have access to audio input.

Adding the appropriate field to the `info.plist` file seems to fix this issue. In my testing with this fix SC asks for correct permissions whether the build is signed or not.

Thanks @brianlheim for suggesting this!

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review
