### PR TITLE
Fix bug where sclang hangs forever when exiting

### DIFF
--- a/lang/LangPrimSource/PyrSched.cpp
+++ b/lang/LangPrimSource/PyrSched.cpp
@@ -381,12 +381,16 @@ extern bool gTraceInterpreter;
 static void schedRunFunc() {
     using namespace std::chrono;
     unique_lock<timed_mutex> lock(gLangMutex);
+    // The scheduler may have already been stopped by the time we acquire this
+    // lock, so we need to check the condition now.
+    if (!gRunSched) {
+        return;
+    }
 
     VMGlobals* g = gMainVMGlobals;
     PyrObject* inQueue = slotRawObject(&g->process->sysSchedulerQueue);
     // dumpObject(inQueue);
 
-    gRunSched = true;
     while (true) {
         assert(inQueue->size);
 
@@ -558,6 +562,9 @@ static void SC_LinuxSetRealtimePriority(pthread_t thread, int priority) {
 
 
 SCLANG_DLLEXPORT_C void schedRun() {
+    // gLangMutex must be locked
+    gRunSched = true;
+
     SC_Thread thread(schedRunFunc);
     gSchedThread = std::move(thread);
 


### PR DESCRIPTION
# Purpose and Motivation

The `sclang` command sometimes hangs when exiting when run with a file that exits. This PR makes a small adjustment to how the scheduler thread in `PyrSched.cpp` coordinates with the main thread to eliminate this race condition.

## Types of changes

- Bug fix

## To-do list

- [x] Code is tested
- [x] All tests are passing
- [ ] Updated documentation
- [x] This PR is ready for review

# Issue

The `sclang` command sometimes hangs when exiting when run with a file that exits. This PR makes a small adjustment to how the scheduler thread in `PyrSched.cpp` coordinates with the main thread to eliminate this race condition.

## What I Did

I'm building SuperCollider to run on Linux without QT or X11 present so that I can run `sclang` in a an automated test suite in a container on GitLab CI for a project I'm working on. I'm using nix to build SuperCollider with the following command and derivation (`.nix` file). I've included a patch to add logging statements to demonstrate the race condition in this derivation, which is explained in detail later.

```bash
$ nix-build -E 'with import <nixpkgs> {}; enableDebugging (callPackage ./supercollider.nix { fftw = fftwSinglePrec; })'
```

```nix
# supercollider.nix
{ lib, stdenv, fetchurl, cmake, pkg-config, alsaLib
, libjack2, libsndfile, fftw, curl, gcc, libudev
, readline, useSCEL ? false, emacs
}:

let optional = lib.optional;
in

stdenv.mkDerivation rec {
  pname = "supercollider";
  version = "3.11.2";

  src = fetchurl {
    url = "https://github.com/supercollider/supercollider/releases/download/Version-${version}/SuperCollider-${version}-Source.tar.bz2";
    sha256 = "wiwyxrxIJnHU+49RZy33Etl6amJ3I1xNojEpEDA6BQY=";
  };

  hardeningDisable = [ "stackprotector" ];

  cmakeFlags = [
    "-DSC_EL=${if useSCEL then "ON" else "OFF"}"
    "-DNO_X11=ON"
    "-DSC_QT=OFF"
    "-DSUPERNOVA=OFF"
  ];

  patches = [ ./supercollider-add-logging.patch ];

  nativeBuildInputs = [ cmake pkg-config ];

  buildInputs = [
    gcc libjack2 libsndfile fftw curl readline libudev ]
      ++ optional (!stdenv.isDarwin) alsaLib
      ++ optional useSCEL emacs;

  meta = with lib; {
    description = "Programming language for real time audio synthesis";
    homepage = "https://supercollider.github.io";
    maintainers = with maintainers; [ mrmebelman ];
    license = licenses.gpl3;
    platforms = [ "x686-linux" "x86_64-linux" ];
  };
}
```

```patch
# supercollider-add-logging.patch
diff --git a/lang/LangPrimSource/PyrSched.cpp b/lang/LangPrimSource/PyrSched.cpp
index bf00322..2904ba0 100644
--- a/lang/LangPrimSource/PyrSched.cpp
+++ b/lang/LangPrimSource/PyrSched.cpp
@@ -333,13 +333,17 @@ void schedAdd(VMGlobals* g, PyrObject* inQueue, double inSeconds, PyrSlot* inTas
 
 SCLANG_DLLEXPORT_C void schedStop() {
     // printf("->schedStop\n");
+    printf("[schedStop] acquiring gLangMutex...\n");
     gLangMutex.lock();
+    printf("[schedStop] acquiring gLangMutex...\n");
     if (gRunSched) {
+        printf("[schedStop] notifying and joining thread.\n");
         gRunSched = false;
         gLangMutex.unlock();
         gSchedCond.notify_all();
         gSchedThread.join();
     } else {
+        printf("[schedStop] SKIPPING notifying and joining thread\n");
         gLangMutex.unlock();
     }
     // printf("<-schedStop\n");
@@ -380,7 +384,9 @@ extern bool gTraceInterpreter;
 
 static void schedRunFunc() {
     using namespace std::chrono;
+    printf("[schedRunFunc] acquiring gLangMutex...\n");
     unique_lock<timed_mutex> lock(gLangMutex);
+    printf("[schedRunFunc] acquired gLangMutex.\n");
 
     VMGlobals* g = gMainVMGlobals;
     PyrObject* inQueue = slotRawObject(&g->process->sysSchedulerQueue);
@@ -394,7 +400,9 @@ static void schedRunFunc() {
         // wait until there is something in scheduler
         while (inQueue->size == 1) {
             // postfl("wait until there is something in scheduler\n");
+            printf("[schedRunFunc] waiting on gSchedCond...\n");
             gSchedCond.wait(lock);
+            printf("[schedRunFunc] done waiting on gSchedCond.\n");
             if (!gRunSched)
                 goto leave;
         }
```

After the build completed, I ran `sclang` with a simple program that says hello and immediately exits:

```
$ result/bin/sclang test.sc
compiling class library...
        Found 733 primitives.
        Compiling directory '/nix/store/jd3ip43rimpdihj9kc2hfml422sxdygk-supercollider-3.11.2/share/SuperCollider/SCClassLibrary'
        Compiling directory '/nix/store/jd3ip43rimpdihj9kc2hfml422sxdygk-supercollider-3.11.2/share/SuperCollider/Extensions'
        Compiling directory '/home/ooesili/.local/share/SuperCollider/Extensions'
        numentries = 664002 / 7140168 = 0.093
        3906 method selectors, 1828 classes
        method table size 9692536 bytes, big table size 57121344
        Number of Symbols 9119
        Byte Code Size 262116
        compiled 224 files in 0.09 seconds

Info: 4 methods are currently overwritten by extensions. To see which, execute:
MethodOverride.printAll

compile done
localhost : setting clientID to 0.
internal : setting clientID to 0.
Class tree inited in 0.01 seconds


*** Welcome to SuperCollider 3.11.2. *** For help type ctrl-c ctrl-h (Emacs) or :SChelp (vim) or ctrl-U (sced/gedit).
hello
main: quit request 0
cleaning up OSC
```

## What I Expected

I expected `sclang` to exit shortly after printing `main: quit request 0`.

## What I Saw

The program sometimes exited as expected, and sometimes hung indefinitely. I attached `gdb` to a hung `sclang` process and printed stack traces for all active threads:

```
(gdb) thread apply all backtrace

Thread 2 (LWP 27682):
#0  0x00007fabdb2ee15d in pthread_cond_wait@@GLIBC_2.3.2 () from /nix/store/gafigwfaimlziam6qhw1m8dz4h952g1n-glibc-2.32-35/lib/libpthread.so.0
#1  0x00007fabdad4d7cc in std::condition_variable::wait(std::unique_lock<std::mutex>&) () from /nix/store/sipmc4wnbcws4vahqlf5i06zz7xgnp23-gcc-10.2.0-lib/lib/libstdc++.so.6
#2  0x0000000000427cf2 in std::_V2::condition_variable_any::wait<std::unique_lock<std::timed_mutex> > (__lock=..., this=0x6931c0 <gSchedCond>) at /nix/store/9rmf9whh2m8fqlqp859d8pmsb63jarsp-gcc-10.2.0/include/c++/10.2.0/x86_64-unknown-linux-gnu/bits/gthr-default.h:779
#3  schedRunFunc () at /build/SuperCollider-3.11.2-Source/lang/LangPrimSource/PyrSched.cpp:397
#4  0x0000000000428be5 in std::__invoke_impl<void, void (*)()> (__f=<optimized out>) at /nix/store/9rmf9whh2m8fqlqp859d8pmsb63jarsp-gcc-10.2.0/include/c++/10.2.0/thread:215
#5  std::__invoke<void (*)()> (__fn=<optimized out>) at /nix/store/9rmf9whh2m8fqlqp859d8pmsb63jarsp-gcc-10.2.0/include/c++/10.2.0/bits/invoke.h:95
#6  std::thread::_Invoker<std::tuple<void (*)()> >::_M_invoke<0ul> (this=<optimized out>) at /nix/store/9rmf9whh2m8fqlqp859d8pmsb63jarsp-gcc-10.2.0/include/c++/10.2.0/thread:264
#7  std::thread::_Invoker<std::tuple<void (*)()> >::operator() (this=<optimized out>) at /nix/store/9rmf9whh2m8fqlqp859d8pmsb63jarsp-gcc-10.2.0/include/c++/10.2.0/thread:271
#8  std::thread::_State_impl<std::thread::_Invoker<std::tuple<void (*)()> > >::_M_run (this=<optimized out>) at /nix/store/9rmf9whh2m8fqlqp859d8pmsb63jarsp-gcc-10.2.0/include/c++/10.2.0/thread:215
#9  0x00007fabdad52c50 in ?? () from /nix/store/sipmc4wnbcws4vahqlf5i06zz7xgnp23-gcc-10.2.0-lib/lib/libstdc++.so.6
#10 0x00007fabdb2e7e9e in start_thread () from /nix/store/gafigwfaimlziam6qhw1m8dz4h952g1n-glibc-2.32-35/lib/libpthread.so.0
#11 0x00007fabdaa5949f in clone () from /nix/store/gafigwfaimlziam6qhw1m8dz4h952g1n-glibc-2.32-35/lib/libc.so.6

Thread 1 (LWP 27673):
#0  0x00007fabda9e0f7a in pthread_cond_destroy@@GLIBC_2.3.2 () from /nix/store/gafigwfaimlziam6qhw1m8dz4h952g1n-glibc-2.32-35/lib/libc.so.6
#1  0x0000000000429164 in std::_V2::condition_variable_any::~condition_variable_any (this=0x6931c0 <gSchedCond>, __in_chrg=<optimized out>) at /nix/store/9rmf9whh2m8fqlqp859d8pmsb63jarsp-gcc-10.2.0/include/c++/10.2.0/ext/atomicity.h:70
#2  0x00007fabda99c5e7 in __run_exit_handlers () from /nix/store/gafigwfaimlziam6qhw1m8dz4h952g1n-glibc-2.32-35/lib/libc.so.6
#3  0x00007fabda99c79a in exit () from /nix/store/gafigwfaimlziam6qhw1m8dz4h952g1n-glibc-2.32-35/lib/libc.so.6
#4  0x00007fabda985df4 in __libc_start_main () from /nix/store/gafigwfaimlziam6qhw1m8dz4h952g1n-glibc-2.32-35/lib/libc.so.6
#5  0x000000000041543a in _start () at ../sysdeps/x86_64/start.S:120
```

I identified the two threads as:

- *Thread 1* - the main thread.
- *Thread 2* - the scheduler thread, started in `lang/LangPrimSource/PyrSched.cpp`.

The main thread destroys the condition variable upon exiting while the scheduler thread is waiting on the condition. I believe is undefined behavior as noted here, which may explain the indefinite blocking.

> From https://man.archlinux.org/man/core/man-pages/pthread_cond_destroy.3p.en
>
> "Attempting to destroy a condition variable upon which other threads are currently blocked results in undefined behavior."

I added some print statements to see what was happning and noticed a race condition between the two threads.

When program exits successfully:

```
$ sclang test.sc
...
*** Welcome to SuperCollider 3.11.2. *** For help type ctrl-c ctrl-h (Emacs) or :SChelp (vim) or ctrl-U (sced/gedit).
[schedRunFunc] acquiring gLangMutex...
hello
main: quit request 0
[schedRunFunc] acquired gLangMutex.
[schedRunFunc] waiting on gSchedCond...
[schedStop] acquiring gLangMutex...
[schedStop] acquiring gLangMutex...
[schedStop] notifying and joining thread.
[schedRunFunc] done waiting on gSchedCond.
cleaning up OSC
```

When the program hangs forever:

```
$ sclang test.sc
...
*** Welcome to SuperCollider 3.11.2. *** For help type ctrl-c ctrl-h (Emacs) or :SChelp (vim) or ctrl-U (sced/gedit).
[schedRunFunc] acquiring gLangMutex...
hello
main: quit request 0
[schedStop] acquiring gLangMutex...
[schedStop] acquiring gLangMutex...
[schedStop] SKIPPING notifying and joining thread
[schedRunFunc] acquired gLangMutex.
[schedRunFunc] waiting on gSchedCond...
cleaning up OSC
# <---- [hangs forever here]
```

The execution of the `test.sc` file can complete quickly causing `schedStop()` to be called (on the main thread) _before_ `schedRunFunc()` (scheduler thread) acquires the `gLangMutex` lock for the first time. This causes two bugs:

1. The main thread uses a condition variable called `gSchedCond` and a boolean called `gRunSched` to tell to the scheduler thread to terminate itself when the `stopSched()` function is called. The `schedRunFunc()` does not check the condition immediately upon acquiring `gLangMutex` to know if `schedStop()` has been called yet. It instead begins waiting on `gSchedCond()` without checking the condition causing it blocks forever because nothing after `schedStop()` notifies the condition variable.

2. In `schedRunFunc()`, `gRunSched` is initially set to `true` _after_ `gLangMutex` is acquired for the first time. `schedStop()` checks `gRunSched` to determine if the scheduler thread is running and needs to be notified and joined. When `schedStop()` is called before `schedRunFunc()` sets `gRunSched` to `true` the notification and join operations are skipped, causing the main thread to exit without waiting on the scheduler thread to stop.

Together, these bugs cause the scheduler thread to be waiting for a condition that will never occur when the main thread exits. The main thread exiting causes the condition variable to be destroyed, which causes the undefined blocking behavior.

# Solution

The solution in this PR fixes each bug individually.

1. The `schedRunFunc()` has been changed to check the `gRunSched` immediately after acquiring `gLangMutex` for the first time to avoid the first bug.

2. The line that sets `gRunSched` to `true` initially has been moved from `schedRunFunc()` on scheduler thread to be in `schedRun()` on the main thread. The guarantees that `stopSched()` will observe `gRunSched` as true, because the same thread that calls `stopSched()` also sets `gRunSched` to true: the main thread.