### PR TITLE
README_LINUX: Fix typo about SC_ABLETON_LINK option

### DIFF
--- a/README_LINUX.md
+++ b/README_LINUX.md
@@ -112,7 +112,7 @@ Using clang
 -----------
 
 SuperCollider can be compiled with clang, with the following limitations:
-- for clang 4, pass `-DSC_ALBETON_LINK=OFF` when configuring the project
+- for clang 4, pass `-DSC_ABLETON_LINK=OFF` when configuring the project
 - by default clang will use libc++; you can pass `-DSC_CLANG_USES_LIBSTDCPP=ON` to use libstdc++ instead
 
 Building


### PR DESCRIPTION
## Purpose and Motivation

Nothing controversial -- old version says "for clang 4, pass `-DSC_ALBETON_LINK=OFF` when configuring the project" but that is unlikely to succeed.

## Types of changes

- Documentation

## To-do list

- [x] Updated documentation
