### PR TITLE
Fix condition eval in UnitTest.wait

### DIFF
--- a/HelpSource/Classes/UnitTest.schelp
+++ b/HelpSource/Classes/UnitTest.schelp
@@ -274,7 +274,7 @@ method::wait
 Wait for a condition, consider failed after maxTime. Only valid within a test (or a routine).
 
 argument:: condition
-A Boolean or a Function that returns a Boolean.
+A Function that returns a Boolean.
 
 argument:: failureMessage
 A message that will be posted if waiting fails due to timeout.

--- a/HelpSource/Classes/UnitTest.schelp
+++ b/HelpSource/Classes/UnitTest.schelp
@@ -273,6 +273,15 @@ For arguments, see link::#-assertException::.
 method::wait
 Wait for a condition, consider failed after maxTime. Only valid within a test (or a routine).
 
+argument:: condition
+A Boolean or a Function that returns a Boolean.
+
+argument:: failureMessage
+A message that will be posted if waiting fails due to timeout.
+
+argument:: maxTime
+A timeout duration in seconds.
+
 code::
 (
 {

--- a/SCClassLibrary/Common/UnitTesting/UnitTest.sc
+++ b/SCClassLibrary/Common/UnitTesting/UnitTest.sc
@@ -233,7 +233,7 @@ UnitTest {
 	}
 
 	// waits for condition with a maxTime limit
-	// condition is a Boolean or a Function that returns a Boolean
+	// condition is a Function that returns a Boolean
 	// if time expires, the test is a failure
 	wait { |condition, failureMessage, maxTime = 10.0|
 		var dt = 0.05;

--- a/SCClassLibrary/Common/UnitTesting/UnitTest.sc
+++ b/SCClassLibrary/Common/UnitTesting/UnitTest.sc
@@ -233,6 +233,7 @@ UnitTest {
 	}
 
 	// waits for condition with a maxTime limit
+	// condition is a Boolean or a Function that returns a Boolean
 	// if time expires, the test is a failure
 	wait { |condition, failureMessage, maxTime = 10.0|
 		var dt = 0.05;

--- a/SCClassLibrary/Common/UnitTesting/UnitTest.sc
+++ b/SCClassLibrary/Common/UnitTesting/UnitTest.sc
@@ -239,7 +239,7 @@ UnitTest {
 		var limit = max(1, maxTime / dt);
 
 		while {
-			condition.test.not and: { limit >= 0 }
+			condition.value.not and: { limit >= 0 }
 		} {
 			limit = limit - 1;
 			dt.wait;

--- a/testsuite/classlibrary/TestEnvGen_server.sc
+++ b/testsuite/classlibrary/TestEnvGen_server.sc
@@ -170,14 +170,14 @@ TestEnvGen_server : UnitTest {
 	// issue #5104
 	test_shapeHold_setEndValue {
 		var env = Env(curves: [\hold, \lin]);
-		var condition = Condition();
+		var condition = false;
 		var result = [];
 		server.bootSync;
 		{ EnvGen.kr(env, timeScale: 0.01, doneAction:2) }.loadToFloatArray(0.01, server){ |values|
 			result = values;
-			condition.test_(true).signal;
+			condition = true;
 		};
-		this.wait(condition, "timeout when waiting for EnvGen results from server", 0.1);
+		this.wait({ condition }, "timeout when waiting for EnvGen results from server", 0.1);
 		this.assert(result.any { |v| v > 0 }, "Env(curves: [\hold, \lin]) should not be rendered as silent");
 	}
 

--- a/testsuite/classlibrary/TestOSCBundle.sc
+++ b/testsuite/classlibrary/TestOSCBundle.sc
@@ -14,17 +14,17 @@ TestOSCBundle : UnitTest {
 
 	test_doPrepare {
 		var synthDef, bundle;
-		var completed = Condition(false);
+		var completed = false;
 
 		bundle = OSCBundle.new;
 		synthDef = Array.fill(100, { |i|
 			var def = SynthDef("TestOSCBundle" ++ i, { Silent.ar });
 			bundle.addPrepare(["/d_recv", def.asBytes])
 		});
-		bundle.doPrepare(server, { completed.test = true });
-		this.wait(completed, "% timed out waiting for bundle to be sent".format(thisMethod));
+		bundle.doPrepare(server, { completed = true });
+		this.wait({ completed }, "% timed out waiting for bundle to be sent".format(thisMethod));
 
-		this.assertEquals(completed.test, true, "'doPrepare' sent the prepare bundle to the server");
+		this.assertEquals(completed, true, "'doPrepare' sent the prepare bundle to the server");
 	}
 
 }

--- a/testsuite/classlibrary/TestPprotect.sc
+++ b/testsuite/classlibrary/TestPprotect.sc
@@ -1,7 +1,7 @@
 TestPprotect : UnitTest {
 
 	test_resetExceptionHandler_onError {
-		var routine, stream, success = false, condition = Condition.new;
+		var routine, stream, success = false, condition = false;
 		// Note that this must be a Stream, not a Pattern (x.asStream --> x).
 		// If it's a pattern, then we don't have access to the routine
 		// to check its exceptionHandler below.
@@ -10,7 +10,7 @@ TestPprotect : UnitTest {
 			routine,
 			{
 				success = routine.exceptionHandler.isNil;
-				condition.test = true;
+				condition = true;
 			}
 		).asStream;
 		// Note that it is necessary to do this asynchronously!
@@ -23,12 +23,12 @@ TestPprotect : UnitTest {
 
 	test_stream_can_be_restarted_after_error {
 		var pat, stream;
-		var condition = Condition.new;
+		var condition = false;
 
 		pat = Pprotect(
 			Prout {
 				0.01.yield;
-				condition.test = true;
+				condition = true;
 				Error("dummy error").throw
 			},
 			{ stream.streamError }
@@ -37,17 +37,17 @@ TestPprotect : UnitTest {
 		stream = pat.play;
 		this.wait(condition, maxTime: 0.1);
 
-		condition.test = false;
+		condition = false;
 		stream.reset;
 		stream.play;
 		this.wait(condition, maxTime: 0.1);
 
-		this.assert(condition.test, "stream should be resettable after an error");
+		this.assert(condition, "stream should be resettable after an error");
 	}
 
 	test_task_proxy_play_after_error {
 		var proxy, redefine, hasRun;
-		var condition = Condition.new;
+		var condition = false;
 
 		proxy = TaskProxy.new;
 		proxy.quant = 0;
@@ -56,25 +56,25 @@ TestPprotect : UnitTest {
 		redefine = {
 			proxy.source = {
 				0.01.wait;
-				condition.test = true;
+				condition = true;
 				Error("dummy error").throw
 			}
 		};
 
-		condition.test = false;
+		condition = false;
 		redefine.value;
 		this.wait(condition, maxTime: 0.1);
 
-		condition.test = false;
+		condition = false;
 		redefine.value;
 		this.wait(condition, maxTime: 0.1);
 
-		this.assert(condition.test, "task proxy should play again after an error");
+		this.assert(condition, "task proxy should play again after an error");
 	}
 
 	test_nested_instances {
 		var innerHasBeenCalled = false, outerHasBeenCalled = false;
-		var condition = Condition.new;
+		var condition = false;
 
 		fork {
 			var stream;
@@ -83,12 +83,12 @@ TestPprotect : UnitTest {
 					Prout {
 						Error("dummy error").throw
 					}, {
-						condition.test = true;
+						condition = true;
 						innerHasBeenCalled = true
 					}
 				),
 				{
-					condition.test = true;
+					condition = true;
 					outerHasBeenCalled = true
 				}
 			).asStream;

--- a/testsuite/classlibrary/TestPprotect.sc
+++ b/testsuite/classlibrary/TestPprotect.sc
@@ -16,7 +16,7 @@ TestPprotect : UnitTest {
 		// Note that it is necessary to do this asynchronously!
 		// Otherwise "routine"'s error will halt the entire test suite.
 		stream.play;
-		this.wait(condition, maxTime: 0.1);
+		this.wait({ condition }, maxTime: 0.1);
 
 		this.assert(success, "Pprotect should clear the stream's exceptionHandler");
 	}
@@ -35,12 +35,12 @@ TestPprotect : UnitTest {
 		);
 
 		stream = pat.play;
-		this.wait(condition, maxTime: 0.1);
+		this.wait({ condition }, maxTime: 0.1);
 
 		condition = false;
 		stream.reset;
 		stream.play;
-		this.wait(condition, maxTime: 0.1);
+		this.wait({ condition }, maxTime: 0.1);
 
 		this.assert(condition, "stream should be resettable after an error");
 	}
@@ -63,11 +63,11 @@ TestPprotect : UnitTest {
 
 		condition = false;
 		redefine.value;
-		this.wait(condition, maxTime: 0.1);
+		this.wait({ condition }, maxTime: 0.1);
 
 		condition = false;
 		redefine.value;
-		this.wait(condition, maxTime: 0.1);
+		this.wait({ condition }, maxTime: 0.1);
 
 		this.assert(condition, "task proxy should play again after an error");
 	}
@@ -97,7 +97,7 @@ TestPprotect : UnitTest {
 
 		};
 
-		this.wait(condition, maxTime: 0.1);
+		this.wait({ condition }, maxTime: 0.1);
 
 		this.assert(innerHasBeenCalled, "When nesting Pprotect, inner functions should be called");
 		this.assert(outerHasBeenCalled, "When nesting Pprotect, outer functions should be called");

--- a/testsuite/classlibrary/TestSanitize.sc
+++ b/testsuite/classlibrary/TestSanitize.sc
@@ -14,7 +14,7 @@ TestSanitize : UnitTest {
 
 	test_sanitize {
 		var duration, expected;
-		var tests, testsIncomplete, testCond = Condition(false);
+		var tests, testsIncomplete;
 		duration = 256 / server.sampleRate;
 		expected = 8888.0;
 
@@ -40,11 +40,10 @@ TestSanitize : UnitTest {
 			ugenGraphFunc.loadToFloatArray(duration, server, { |samples|
 				this.assertArrayFloatEquals(samples, expected, text);
 				testsIncomplete = testsIncomplete - 1;
-				if(testsIncomplete == 0) { testCond.test = true };
 			});
 		};
 
-		this.wait(testCond);
+		this.wait({ testsIncomplete == 0 });
 	}
 
 }

--- a/testsuite/classlibrary/TestServer.sc
+++ b/testsuite/classlibrary/TestServer.sc
@@ -12,7 +12,7 @@ TestServer : UnitTest {
 		server.sync(condition, f, server.latency);
 
 		// 60 seconds
-		this.wait(condition, "waiting for server to finish sync", 60);
+		this.wait({ condition.test }, "waiting for server to finish sync", 60);
 		this.assert(true, "server synced bundle with " + f.size + "messages " + "bundleSize: " + bundleSize)
 	}
 

--- a/testsuite/classlibrary/TestUnitTest.sc
+++ b/testsuite/classlibrary/TestUnitTest.sc
@@ -76,16 +76,13 @@ TestUnitTest : UnitTest {
 	}
 
 	test_wait {
-		var condition = Condition.new;
-		var r = Routine {
+		var condition = false;
+		Routine({
 			0.01.yield;
-			condition.test = true;
-		};
-		r.play;
-		this.wait(condition, maxTime:0.02);
-		this.assert(condition.test, "UnitTest.wait should continue when test is true");
+			condition = true;
+		}).play;
+		this.wait(condition, maxTime: 0.02);
+		this.assert(condition, "UnitTest.wait should proceed when its condition becomes true");
 	}
-
-
 
 }

--- a/testsuite/classlibrary/TestUnitTest.sc
+++ b/testsuite/classlibrary/TestUnitTest.sc
@@ -81,7 +81,7 @@ TestUnitTest : UnitTest {
 			0.01.yield;
 			condition = true;
 		}).play;
-		this.wait(condition, maxTime: 0.02);
+		this.wait({ condition }, maxTime: 0.02);
 		this.assert(condition, "UnitTest.wait should proceed when its condition becomes true");
 	}
 

--- a/testsuite/classlibrary/TestWebView.sc
+++ b/testsuite/classlibrary/TestWebView.sc
@@ -64,14 +64,15 @@ TestWebView : UnitTest {
 			"[1, 2, 'hello']": [1, 2, "hello"] -> Array
 		).keysValuesDo { |jsCode, expected|
 			var expectedClass = expected.value, expectedResult = expected.key;
-			var condition = Condition(), returnedResult;
+			var condition, returnedResult;
 
+			condition = false;
 			WebView().runJavaScript(jsCode){ |res|
 				returnedResult = res;
-				condition.test_(true).signal
+				condition = true;
 			};
 
-			this.wait(condition, "runJavaScript() callback was not called before timeout", 0.5);
+			this.wait({ condition }, "runJavaScript() callback was not called before timeout", 0.5);
 			this.assertEquals(returnedResult, expectedResult,
 				"runJavaScript(\"%\") should return the expected result %"
 				.format(jsCode, expectedResult)
@@ -80,7 +81,6 @@ TestWebView : UnitTest {
 				"runJavaScript(\"%\") should return an instance of %. Returned: %"
 				.format(jsCode, expectedClass, returnedResult.class)
 			);
-			condition.test = false;
 		};
 	}
 }


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

This PR fixes a breakage that occured in https://github.com/supercollider/supercollider/commit/2aa3374e1e52b7db3f7708498810dc6032a1d082

`UnitTest.wait` has a parameter named `condition` that is either a Boolean or a Function that returned a Boolean. We must call `value` on it, not `test`. This mistake is causing a few of our UnitTests to fail.

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [X] Code is tested
- [ ] All tests are passing
- [ ] Updated documentation
- [X] This PR is ready for review
