### PR TITLE
Topic/condition timeout

### DIFF
--- a/HelpSource/Classes/Condition.schelp
+++ b/HelpSource/Classes/Condition.schelp
@@ -27,10 +27,10 @@ c = Condition.new; fork { 0.5.wait; "started ...".postln; c.hang;  "... and fini
 c.unhang;
 ::
 
-method::setTimeout
+method::timeoutAfter
 Prepares a time limit for this thread to be re-awakened after waiting or hanging on a Condition. If a timeout is set, there are two possible outcomes: A. The condition will signal successfully (or unhang) emphasis::before:: the timeout expires, and the thread will resume (without firing a timeout action); or B. The timeout will expire, and the thread will resume after that number of beats. The code::action:: function can set a flag so that the calling thread knows it's resuming due to a timeout. (If no timeout is set, then the thread may hang indefinitely if the condition fails to be met.)
 
-Call code::setTimeout:: immediately before calling code::wait:: or code::hang::.
+Call code::timeoutAfter:: immediately before calling code::wait:: or code::hang::. The timeout period begins at the moment of calling code::timeoutAfter::.
 
 argument::timeout
 Number of clock beats to wait before timing out.
@@ -126,8 +126,8 @@ s.waitForBoot {
 		cond.unhang;
 	}, '/n_end', s.addr, argTemplate: [node.nodeID]);
 
-	// here: cond.setTimeout().hang (or wait)
-	cond.setTimeout(1.0, {
+	// here: cond.timeoutAfter().hang (or wait)
+	cond.timeoutAfter(1.0, {
 		endResp.free;
 		"Reached timeout; synth hasn't ended".postln;
 	}).hang;

--- a/HelpSource/Classes/Condition.schelp
+++ b/HelpSource/Classes/Condition.schelp
@@ -27,6 +27,17 @@ c = Condition.new; fork { 0.5.wait; "started ...".postln; c.hang;  "... and fini
 c.unhang;
 ::
 
+method::setTimeout
+Prepares a time limit for this thread to be re-awakened after waiting or hanging on a Condition. If a timeout is set, there are two possible outcomes: A. The condition will signal successfully (or unhang) emphasis::before:: the timeout expires, and the thread will resume (without firing a timeout action); or B. The timeout will expire, and the thread will resume after that number of beats. The code::action:: function can set a flag so that the calling thread knows it's resuming due to a timeout. (If no timeout is set, then the thread may hang indefinitely if the condition fails to be met.)
+
+Call code::setTimeout:: immediately before calling code::wait:: or code::hang::.
+
+argument::timeout
+Number of clock beats to wait before timing out.
+
+argument::action
+A function to execute only in case the timeout expires. The function will not execute for a successful signal or unhang.
+
 method::signal
 If link::#-test:: is true, reschedule blocked threads.
 
@@ -97,12 +108,41 @@ Routine {
 c.unhang;
 ::
 
+Timeout limits: About half the time, the synth will run longer than 1.0 second and the condition will time out.
+
+code::
+(
+s.waitForBoot {
+	var cond = Condition.new;
+	
+	var node = {
+		var freq = XLine.kr(1, 2, rrand(0.5, 1.5), doneAction: 2);
+		SinOsc.ar(freq, 0, 0.1).dup
+	}.play;
+	
+	var endResp = OSCFunc({ |msg|
+		"Synth ended on time".postln;
+		endResp.free;
+		cond.unhang;
+	}, '/n_end', s.addr, argTemplate: [node.nodeID]);
+
+	// here: cond.setTimeout().hang (or wait)
+	cond.setTimeout(1.0, {
+		endResp.free;
+		"Reached timeout; synth hasn't ended".postln;
+	}).hang;
+	
+	"Resumed thread".postln;
+};
+)
+::
+
 Waiting for Synths to end (waitForFree) uses a Condition implicitly:
 code::
 (
 SynthDef(\help, { |out|
 	var mod = LFNoise2.kr(ExpRand(0.5, 2)) * 0.5;
-	var snd =  mod * Blip.ar(Rand(200, 800) * (mod + 1));
+	var snd = mod * Blip.ar(Rand(200, 800) * (mod + 1));
 	Out.ar(out, snd);
 	FreeSelf.kr(mod < 0); // free the synth when amplitude goes below 0.
 }).add;

--- a/SCClassLibrary/Common/Core/Condition.sc
+++ b/SCClassLibrary/Common/Core/Condition.sc
@@ -16,12 +16,13 @@ Condition {
 		value.yield;
 	}
 
-	setTimeout { |timeout|
+	setTimeout { |timeout, action|
 		var waitingThread = thisThread.threadPlayer;
 		var timeoutThread = Routine {
 			timeout.wait;
 			waitingThreads.remove(waitingThread);
 			waitingTimeouts.remove(timeoutThread);
+			action.value;
 			waitingThread.clock.sched(0, waitingThread);
 		};
 		waitingTimeouts = waitingTimeouts.add(timeoutThread);

--- a/SCClassLibrary/Common/Core/Condition.sc
+++ b/SCClassLibrary/Common/Core/Condition.sc
@@ -16,14 +16,17 @@ Condition {
 		value.yield;
 	}
 
-	setTimeout { |timeout, action|
+	timeoutAfter { |timeout, action|
 		var waitingThread = thisThread.threadPlayer;
 		var timeoutThread = Routine {
+			var resume;
 			timeout.wait;
-			waitingThreads.remove(waitingThread);
+			// sleight-of-hand: if waitingThreads does not contain my thread,
+			// then resume will be nil
+			resume = waitingThreads.remove(waitingThread);
 			waitingTimeouts.remove(timeoutThread);
 			action.value;
-			waitingThread.clock.sched(0, waitingThread);
+			waitingThread.clock.sched(0, resume);
 		};
 		waitingTimeouts = waitingTimeouts.add(timeoutThread);
 		timeoutThread.play(thisThread.clock);

--- a/SCClassLibrary/Common/Core/Condition.sc
+++ b/SCClassLibrary/Common/Core/Condition.sc
@@ -34,13 +34,12 @@ Condition {
 		};
 	}
 	unhang {
-		var tempWaitingThreads, time;
+		var tempWaitingThreads;
 		// ignore the test, just resume all waiting threads
 		waitingTimeouts.do { |thread|
 			thread.stop;
 		};
 		waitingTimeouts = nil;
-		time = thisThread.seconds;
 		tempWaitingThreads = waitingThreads;
 		waitingThreads = nil;
 		tempWaitingThreads.do({ arg thread;

--- a/SCClassLibrary/Common/Core/Condition.sc
+++ b/SCClassLibrary/Common/Core/Condition.sc
@@ -29,19 +29,9 @@ Condition {
 	}
 
 	signal {
-		var tempWaitingThreads, time;
-		if (test.value, {
-			waitingTimeouts.do { |thread|
-				thread.stop;
-			};
-			waitingTimeouts = nil;
-			time = thisThread.seconds;
-			tempWaitingThreads = waitingThreads;
-			waitingThreads = nil;
-			tempWaitingThreads.do({ arg thread;
-				thread.clock.sched(0, thread);
-			});
-		});
+		if(test.value) {
+			this.unhang;
+		};
 	}
 	unhang {
 		var tempWaitingThreads, time;

--- a/SCClassLibrary/Common/Core/Condition.sc
+++ b/SCClassLibrary/Common/Core/Condition.sc
@@ -30,9 +30,7 @@ Condition {
 	}
 
 	signal {
-		if(test.value) {
-			this.unhang;
-		};
+		if(test.value) { this.unhang }
 	}
 	unhang {
 		var tempWaitingThreads;

--- a/testsuite/classlibrary/TestCondition.sc
+++ b/testsuite/classlibrary/TestCondition.sc
@@ -33,7 +33,7 @@ TestCondition : UnitTest {
 			failed = true;
 			condition.unhang;
 		};
-		condition.setTimeout(1e-6).hang;
+		condition.timeoutAfter(1e-6).hang;
 		lateTask.stop;
 		this.assert(failed.not, "condition has timed out")
 	}
@@ -44,7 +44,7 @@ TestCondition : UnitTest {
 		cond = Condition({ value }),
 		thread = Routine {
 			var clock = thisThread.clock;
-			cond.setTimeout(0.001, { result = false }).wait;
+			cond.timeoutAfter(0.001, { result = false }).wait;
 		};
 		thread.play(thisThread.clock);
 		0.0005.wait;  // no, there is not any other way to do this
@@ -59,7 +59,7 @@ TestCondition : UnitTest {
 		cond = Condition.new,
 		thread = Routine {
 			var clock = thisThread.clock;
-			cond.setTimeout(0.001, { result = false }).hang;
+			cond.timeoutAfter(0.001, { result = false }).hang;
 		};
 		thread.play(thisThread.clock);
 		0.0005.wait;

--- a/testsuite/classlibrary/TestCondition.sc
+++ b/testsuite/classlibrary/TestCondition.sc
@@ -1,5 +1,30 @@
 TestCondition : UnitTest {
 
+	test_condition_awakesBySignal {
+		var value = false,
+		cond = Condition({ value });
+		// fairly sure that review will require this time to be 0
+		// but I'm not sure that actually makes sense
+		thisThread.clock.sched(0, {
+			value = true;
+			cond.signal;
+		});
+		// note, if Condition is ever broken, then we hang here forever
+		cond.wait;
+		this.assert(value, "Condition should wake up threads when a 'true' condition is signaled");
+	}
+
+	test_condition_awakesByUnhang {
+		var cond = Condition.new;
+		thisThread.clock.sched(0, {
+			cond.unhang;
+		});
+		// note, if Condition is ever broken, then we hang here forever
+		cond.hang;
+		// if you got this far, then we passed
+		this.assert(true, "Condition should wake up threads upon unhang");
+	}
+
 	test_timeout {
 		var condition = Condition.new;
 		var failed = false;
@@ -8,9 +33,38 @@ TestCondition : UnitTest {
 			failed = true;
 			condition.unhang;
 		};
-		condition.hang(1e-6);
+		condition.setTimeout(1e-6).hang;
 		lateTask.stop;
 		this.assert(failed.not, "condition has timed out")
 	}
 
+	test_condition_signalsAndBypassesTimeout {
+		var result = true,
+		value = false,
+		cond = Condition({ value }),
+		thread = Routine {
+			var clock = thisThread.clock;
+			cond.setTimeout(0.001, { result = false }).wait;
+		};
+		thread.play(thisThread.clock);
+		0.0005.wait;  // no, there is not any other way to do this
+		value = true;
+		cond.signal;
+		0.001.wait;
+		this.assert(result, "Successful signal before timeout should cancel the timeout");
+	}
+
+	test_condition_unhangsAndBypassesTimeout {
+		var result = true,
+		cond = Condition.new,
+		thread = Routine {
+			var clock = thisThread.clock;
+			cond.setTimeout(0.001, { result = false }).hang;
+		};
+		thread.play(thisThread.clock);
+		0.0005.wait;
+		cond.unhang;
+		0.001.wait;
+		this.assert(result, "Successful unhang before timeout should cancel the timeout");
+	}
 }


### PR DESCRIPTION
## Purpose and Motivation

Per discussion of UnitTest:wait, I realized today that Condition can handle timeouts gracefully by scheduling a timeout function that can be cancelled. Routine works well for this: if it is `stop`ped before awakening, then it never fires. This eliminates the need for periodic polling.

It's implemented as a method to call just before wait or hang (avoiding code duplication) -- semantics are: request timeout, then pause.

I also cleaned up some duplicate code, removed an unused variable, and fixed the old unit test for the prior, improperly implemented "timeout."

## Types of changes

- Documentation
- New feature

## To-do list

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review
