### PR TITLE
Simplify UnitTest.wait and update test suite accordingly

### DIFF
--- a/HelpSource/Classes/Condition.schelp
+++ b/HelpSource/Classes/Condition.schelp
@@ -27,10 +27,10 @@ c = Condition.new; fork { 0.5.wait; "started ...".postln; c.hang;  "... and fini
 c.unhang;
 ::
 
-method::setTimeout
+method::timeoutAfter
 Prepares a time limit for this thread to be re-awakened after waiting or hanging on a Condition. If a timeout is set, there are two possible outcomes: A. The condition will signal successfully (or unhang) emphasis::before:: the timeout expires, and the thread will resume (without firing a timeout action); or B. The timeout will expire, and the thread will resume after that number of beats. The code::action:: function can set a flag so that the calling thread knows it's resuming due to a timeout. (If no timeout is set, then the thread may hang indefinitely if the condition fails to be met.)
 
-Call code::setTimeout:: immediately before calling code::wait:: or code::hang::.
+Call code::timeoutAfter:: immediately before calling code::wait:: or code::hang::. The timeout period begins at the moment of calling code::timeoutAfter::.
 
 argument::timeout
 Number of clock beats to wait before timing out.
@@ -126,8 +126,8 @@ s.waitForBoot {
 		cond.unhang;
 	}, '/n_end', s.addr, argTemplate: [node.nodeID]);
 
-	// here: cond.setTimeout().hang (or wait)
-	cond.setTimeout(1.0, {
+	// here: cond.timeoutAfter().hang (or wait)
+	cond.timeoutAfter(1.0, {
 		endResp.free;
 		"Reached timeout; synth hasn't ended".postln;
 	}).hang;

--- a/HelpSource/Classes/Condition.schelp
+++ b/HelpSource/Classes/Condition.schelp
@@ -27,6 +27,17 @@ c = Condition.new; fork { 0.5.wait; "started ...".postln; c.hang;  "... and fini
 c.unhang;
 ::
 
+method::setTimeout
+Prepares a time limit for this thread to be re-awakened after waiting or hanging on a Condition. If a timeout is set, there are two possible outcomes: A. The condition will signal successfully (or unhang) emphasis::before:: the timeout expires, and the thread will resume (without firing a timeout action); or B. The timeout will expire, and the thread will resume after that number of beats. The code::action:: function can set a flag so that the calling thread knows it's resuming due to a timeout. (If no timeout is set, then the thread may hang indefinitely if the condition fails to be met.)
+
+Call code::setTimeout:: immediately before calling code::wait:: or code::hang::.
+
+argument::timeout
+Number of clock beats to wait before timing out.
+
+argument::action
+A function to execute only in case the timeout expires. The function will not execute for a successful signal or unhang.
+
 method::signal
 If link::#-test:: is true, reschedule blocked threads.
 
@@ -97,12 +108,41 @@ Routine {
 c.unhang;
 ::
 
+Timeout limits: About half the time, the synth will run longer than 1.0 second and the condition will time out.
+
+code::
+(
+s.waitForBoot {
+	var cond = Condition.new;
+	
+	var node = {
+		var freq = XLine.kr(1, 2, rrand(0.5, 1.5), doneAction: 2);
+		SinOsc.ar(freq, 0, 0.1).dup
+	}.play;
+	
+	var endResp = OSCFunc({ |msg|
+		"Synth ended on time".postln;
+		endResp.free;
+		cond.unhang;
+	}, '/n_end', s.addr, argTemplate: [node.nodeID]);
+
+	// here: cond.setTimeout().hang (or wait)
+	cond.setTimeout(1.0, {
+		endResp.free;
+		"Reached timeout; synth hasn't ended".postln;
+	}).hang;
+	
+	"Resumed thread".postln;
+};
+)
+::
+
 Waiting for Synths to end (waitForFree) uses a Condition implicitly:
 code::
 (
 SynthDef(\help, { |out|
 	var mod = LFNoise2.kr(ExpRand(0.5, 2)) * 0.5;
-	var snd =  mod * Blip.ar(Rand(200, 800) * (mod + 1));
+	var snd = mod * Blip.ar(Rand(200, 800) * (mod + 1));
 	Out.ar(out, snd);
 	FreeSelf.kr(mod < 0); // free the synth when amplitude goes below 0.
 }).add;

--- a/SCClassLibrary/Common/Core/Condition.sc
+++ b/SCClassLibrary/Common/Core/Condition.sc
@@ -16,12 +16,13 @@ Condition {
 		value.yield;
 	}
 
-	setTimeout { |timeout|
+	setTimeout { |timeout, action|
 		var waitingThread = thisThread.threadPlayer;
 		var timeoutThread = Routine {
 			timeout.wait;
 			waitingThreads.remove(waitingThread);
 			waitingTimeouts.remove(timeoutThread);
+			action.value;
 			waitingThread.clock.sched(0, waitingThread);
 		};
 		waitingTimeouts = waitingTimeouts.add(timeoutThread);

--- a/SCClassLibrary/Common/Core/Condition.sc
+++ b/SCClassLibrary/Common/Core/Condition.sc
@@ -16,6 +16,17 @@ Condition {
 		value.yield;
 	}
 
+	waitWithTimeout { |timeout, action|
+		if(test.value.not) {
+			this.timeoutAfter(timeout, action);
+			this.wait
+		}
+	}
+	hangWithTimeout { |timeout, action|
+		this.timeoutAfter(timeout, action);
+		this.hang
+	}
+
 	timeoutAfter { |timeout, action|
 		var waitingThread = thisThread.threadPlayer;
 		var timeoutThread = Routine {

--- a/SCClassLibrary/Common/Core/Condition.sc
+++ b/SCClassLibrary/Common/Core/Condition.sc
@@ -16,14 +16,17 @@ Condition {
 		value.yield;
 	}
 
-	setTimeout { |timeout, action|
+	timeoutAfter { |timeout, action|
 		var waitingThread = thisThread.threadPlayer;
 		var timeoutThread = Routine {
+			var resume;
 			timeout.wait;
-			waitingThreads.remove(waitingThread);
+			// sleight-of-hand: if waitingThreads does not contain my thread,
+			// then resume will be nil
+			resume = waitingThreads.remove(waitingThread);
 			waitingTimeouts.remove(timeoutThread);
 			action.value;
-			waitingThread.clock.sched(0, waitingThread);
+			waitingThread.clock.sched(0, resume);
 		};
 		waitingTimeouts = waitingTimeouts.add(timeoutThread);
 		timeoutThread.play(thisThread.clock);

--- a/SCClassLibrary/Common/Core/Condition.sc
+++ b/SCClassLibrary/Common/Core/Condition.sc
@@ -34,13 +34,12 @@ Condition {
 		};
 	}
 	unhang {
-		var tempWaitingThreads, time;
+		var tempWaitingThreads;
 		// ignore the test, just resume all waiting threads
 		waitingTimeouts.do { |thread|
 			thread.stop;
 		};
 		waitingTimeouts = nil;
-		time = thisThread.seconds;
 		tempWaitingThreads = waitingThreads;
 		waitingThreads = nil;
 		tempWaitingThreads.do({ arg thread;

--- a/SCClassLibrary/Common/Core/Condition.sc
+++ b/SCClassLibrary/Common/Core/Condition.sc
@@ -29,19 +29,9 @@ Condition {
 	}
 
 	signal {
-		var tempWaitingThreads, time;
-		if (test.value, {
-			waitingTimeouts.do { |thread|
-				thread.stop;
-			};
-			waitingTimeouts = nil;
-			time = thisThread.seconds;
-			tempWaitingThreads = waitingThreads;
-			waitingThreads = nil;
-			tempWaitingThreads.do({ arg thread;
-				thread.clock.sched(0, thread);
-			});
-		});
+		if(test.value) {
+			this.unhang;
+		};
 	}
 	unhang {
 		var tempWaitingThreads, time;

--- a/SCClassLibrary/Common/Core/Condition.sc
+++ b/SCClassLibrary/Common/Core/Condition.sc
@@ -30,9 +30,7 @@ Condition {
 	}
 
 	signal {
-		if(test.value) {
-			this.unhang;
-		};
+		if(test.value) { this.unhang }
 	}
 	unhang {
 		var tempWaitingThreads;

--- a/SCClassLibrary/Common/UnitTesting/UnitTest.sc
+++ b/SCClassLibrary/Common/UnitTesting/UnitTest.sc
@@ -235,11 +235,11 @@ UnitTest {
 	// waits for condition with a maxTime limit
 	// if time expires, the test is a failure
 	wait { |condition, failureMessage, maxTime = 10.0|
-		condition.timeoutAfter(maxTime, {
+		condition.waitWithTimeout(maxTime, {
 			if(failureMessage.notNil) {
 				this.failed(currentMethod, failureMessage)
 			}
-		}).wait;
+		})
 	}
 
 	// wait is better

--- a/SCClassLibrary/Common/UnitTesting/UnitTest.sc
+++ b/SCClassLibrary/Common/UnitTesting/UnitTest.sc
@@ -235,19 +235,9 @@ UnitTest {
 	// waits for condition with a maxTime limit
 	// if time expires, the test is a failure
 	wait { |condition, failureMessage, maxTime = 10.0|
-		var dt = 0.05;
-		var limit = max(1, maxTime / dt);
-
-		while {
-			condition.test.not and: { limit >= 0 }
-		} {
-			limit = limit - 1;
-			dt.wait;
-		};
-
-		if(limit < 0 and: failureMessage.notNil) {
-			this.failed(currentMethod,failureMessage)
-		}
+		condition.timeoutAfter(maxTime, {
+			this.failed(currentMethod, failureMessage)
+		}).wait;
 	}
 
 	// wait is better

--- a/SCClassLibrary/Common/UnitTesting/UnitTest.sc
+++ b/SCClassLibrary/Common/UnitTesting/UnitTest.sc
@@ -236,7 +236,9 @@ UnitTest {
 	// if time expires, the test is a failure
 	wait { |condition, failureMessage, maxTime = 10.0|
 		condition.timeoutAfter(maxTime, {
-			this.failed(currentMethod, failureMessage)
+			if(failureMessage.notNil) {
+				this.failed(currentMethod, failureMessage)
+			}
 		}).wait;
 	}
 

--- a/testsuite/classlibrary/TestCondition.sc
+++ b/testsuite/classlibrary/TestCondition.sc
@@ -33,7 +33,7 @@ TestCondition : UnitTest {
 			failed = true;
 			condition.unhang;
 		};
-		condition.setTimeout(1e-6).hang;
+		condition.timeoutAfter(1e-6).hang;
 		lateTask.stop;
 		this.assert(failed.not, "condition has timed out")
 	}
@@ -44,7 +44,7 @@ TestCondition : UnitTest {
 		cond = Condition({ value }),
 		thread = Routine {
 			var clock = thisThread.clock;
-			cond.setTimeout(0.001, { result = false }).wait;
+			cond.timeoutAfter(0.001, { result = false }).wait;
 		};
 		thread.play(thisThread.clock);
 		0.0005.wait;  // no, there is not any other way to do this
@@ -59,7 +59,7 @@ TestCondition : UnitTest {
 		cond = Condition.new,
 		thread = Routine {
 			var clock = thisThread.clock;
-			cond.setTimeout(0.001, { result = false }).hang;
+			cond.timeoutAfter(0.001, { result = false }).hang;
 		};
 		thread.play(thisThread.clock);
 		0.0005.wait;

--- a/testsuite/classlibrary/TestCondition.sc
+++ b/testsuite/classlibrary/TestCondition.sc
@@ -1,5 +1,30 @@
 TestCondition : UnitTest {
 
+	test_condition_awakesBySignal {
+		var value = false,
+		cond = Condition({ value });
+		// fairly sure that review will require this time to be 0
+		// but I'm not sure that actually makes sense
+		thisThread.clock.sched(0, {
+			value = true;
+			cond.signal;
+		});
+		// note, if Condition is ever broken, then we hang here forever
+		cond.wait;
+		this.assert(value, "Condition should wake up threads when a 'true' condition is signaled");
+	}
+
+	test_condition_awakesByUnhang {
+		var cond = Condition.new;
+		thisThread.clock.sched(0, {
+			cond.unhang;
+		});
+		// note, if Condition is ever broken, then we hang here forever
+		cond.hang;
+		// if you got this far, then we passed
+		this.assert(true, "Condition should wake up threads upon unhang");
+	}
+
 	test_timeout {
 		var condition = Condition.new;
 		var failed = false;
@@ -8,9 +33,38 @@ TestCondition : UnitTest {
 			failed = true;
 			condition.unhang;
 		};
-		condition.hang(1e-6);
+		condition.setTimeout(1e-6).hang;
 		lateTask.stop;
 		this.assert(failed.not, "condition has timed out")
 	}
 
+	test_condition_signalsAndBypassesTimeout {
+		var result = true,
+		value = false,
+		cond = Condition({ value }),
+		thread = Routine {
+			var clock = thisThread.clock;
+			cond.setTimeout(0.001, { result = false }).wait;
+		};
+		thread.play(thisThread.clock);
+		0.0005.wait;  // no, there is not any other way to do this
+		value = true;
+		cond.signal;
+		0.001.wait;
+		this.assert(result, "Successful signal before timeout should cancel the timeout");
+	}
+
+	test_condition_unhangsAndBypassesTimeout {
+		var result = true,
+		cond = Condition.new,
+		thread = Routine {
+			var clock = thisThread.clock;
+			cond.setTimeout(0.001, { result = false }).hang;
+		};
+		thread.play(thisThread.clock);
+		0.0005.wait;
+		cond.unhang;
+		0.001.wait;
+		this.assert(result, "Successful unhang before timeout should cancel the timeout");
+	}
 }

--- a/testsuite/classlibrary/TestCoreUGens.sc
+++ b/testsuite/classlibrary/TestCoreUGens.sc
@@ -211,7 +211,7 @@ TestCoreUGens : UnitTest {
 
 		];
 		var testsIncomplete = tests.size;
-
+		var condition = Condition { testsIncomplete == 0 };
 
 		//////////////////////////////////////////
 		// reversible unary ops:
@@ -279,12 +279,13 @@ TestCoreUGens : UnitTest {
 			func.loadToFloatArray(1, server, { |data|
 				this.assertArrayFloatEquals(data, 0, name.quote, within: 0.001, report: true);
 				testsIncomplete = testsIncomplete - 1;
+				condition.signal
 			});
 			rrand(0.12, 0.35).wait;
 		};
 
 
-		this.wait{testsIncomplete==0};
+		this.wait(condition, "timed out");
 	}
 
 	test_exact_convergence {
@@ -298,20 +299,23 @@ TestCoreUGens : UnitTest {
 
 		];
 		var testsIncomplete = tests.size;
+		var condition = Condition { testsIncomplete == 0 };
 		server.bootSync;
 		tests.keysValuesDo{|name, func|
 			func.loadToFloatArray(1, server, { |data|
 				this.assertArrayFloatEquals(data, 0, name.quote, within: 0.0, report: true);
 				testsIncomplete = testsIncomplete - 1;
+				condition.signal
 			});
 			rrand(0.05, 0.1).wait;
 		};
-		this.wait{testsIncomplete==0};
+		this.wait(condition, "timed out")
 	}
 
 	test_muladd {
 		var n, v;
 		var testsIncomplete;
+		var condition = Condition { testsIncomplete == 0 };
 
 		var tests = Dictionary[
 		];
@@ -330,13 +334,14 @@ TestCoreUGens : UnitTest {
 			});
 			rrand(0.06, 0.15).wait;
 		};
-		this.wait{testsIncomplete==0};
+		this.wait(condition, "timed out")
 	}
 
 
 	test_bufugens{
 		var d, b, c;
 		var testsIncomplete = 6;
+		var condition = Condition { testsIncomplete == 0 };
 		server.bootSync;
 
 		// channel sizes for test:
@@ -364,11 +369,12 @@ TestCoreUGens : UnitTest {
 				b.free;
 				c.free;
 				testsIncomplete = testsIncomplete - 1;
+				condition.signal
 			});
 			0.32.wait;
 			server.sync;
 		};
-		this.wait{testsIncomplete==0};
+		this.wait(condition, "timed out")
 	}
 
 	test_demand {
@@ -429,6 +435,7 @@ TestCoreUGens : UnitTest {
 				dev * 0.1 /* rescaled cos Pitch more variable than ZCR */ },
 		];
 		var testsIncomplete = tests.size;
+		var condition = Condition { testsIncomplete == 0 };
 		server.bootSync;
 		tests.keysValuesDo{|text, func|
 			func.loadToFloatArray(10, server, { |data|
@@ -439,7 +446,7 @@ TestCoreUGens : UnitTest {
 		};
 
 		// Wait for async tests
-		this.wait{testsIncomplete==0};
+		this.wait(condition, "timed out")
 	} // test_pitchtrackers
 
 	test_out_ugens {

--- a/testsuite/classlibrary/TestCoreUGens.sc
+++ b/testsuite/classlibrary/TestCoreUGens.sc
@@ -210,7 +210,7 @@ TestCoreUGens : UnitTest {
 			},
 
 		];
-		var testsIncomplete = tests.size;
+		var testsIncomplete;
 		var condition = Condition { testsIncomplete == 0 };
 
 		//////////////////////////////////////////
@@ -273,6 +273,7 @@ TestCoreUGens : UnitTest {
 			);
 		};
 
+		testsIncomplete = tests.size;
 
 		server.bootSync;
 		tests.keysValuesDo{|name, func|
@@ -334,7 +335,7 @@ TestCoreUGens : UnitTest {
 			});
 			rrand(0.06, 0.15).wait;
 		};
-		this.wait(condition, "timed out")
+		this.wait(condition, "timed out", 30)
 	}
 
 

--- a/testsuite/classlibrary/TestDocument.sc
+++ b/testsuite/classlibrary/TestDocument.sc
@@ -5,14 +5,15 @@ TestDocument : UnitTest {
 
 	test_new_document_runs_initAction {
 		var success = false, doc, save;
+		var condition = Condition.new;
 		if(Platform.ideName == "scqt") {
 			save = Document.initAction;
 			protect {
-				Document.initAction = { success = true };
+				Document.initAction = { condition.test_(true).signal };
 				doc = Document.new;
 				// failureMessage is deliberately nil
 				// we will assert below, we don't need `wait` to call `failed` itself
-				this.wait({ success }, failureMessage: nil, maxTime: 0.2);
+				this.wait(condition, failureMessage: nil, maxTime: 0.2);
 				doc.close;
 			} {
 				Document.initAction = save;

--- a/testsuite/classlibrary/TestDocument.sc
+++ b/testsuite/classlibrary/TestDocument.sc
@@ -4,7 +4,7 @@ TestDocument : UnitTest {
 	classvar <>success;
 
 	test_new_document_runs_initAction {
-		var success = false, doc, save;
+		var doc, save;
 		var condition = Condition.new;
 		if(Platform.ideName == "scqt") {
 			save = Document.initAction;
@@ -18,7 +18,7 @@ TestDocument : UnitTest {
 			} {
 				Document.initAction = save;
 			};
-			this.assert(success, "Document.new should fire Document.initAction function");
+			this.assert(condition.test, "Document.new should fire Document.initAction function");
 		} {
 			// TODO: skip
 		};

--- a/testsuite/classlibrary/TestFilterUGens.sc
+++ b/testsuite/classlibrary/TestFilterUGens.sc
@@ -76,6 +76,7 @@ TestFilterUGens : UnitTest {
 		var delay_times = [1,64]; // in samples
 
 		var testsIncomplete = delay_times.size * filters.size;
+		var condition = Condition({ testsIncomplete == 0 });
 
 		this.bootServer;
 		filters.do {
@@ -95,13 +96,14 @@ TestFilterUGens : UnitTest {
 					arg data;
 					this.assertArrayFloatEquals(data, 0, message, within:1e-10, report:true);
 					testsIncomplete = testsIncomplete - 1;
+					condition.signal;
 				});
 
 				rrand(0.012,0.035).wait;
 			}
 		};
 
-		this.wait(testsIncomplete == 0);
+		this.wait(condition);
 
 		"".postln;
 		postln("Please note: the following subclasses of Filter are not included in TestFilterUgens.");

--- a/testsuite/classlibrary/TestNode_Server.sc
+++ b/testsuite/classlibrary/TestNode_Server.sc
@@ -50,10 +50,10 @@ TestNode_Server : UnitTest {
 		getnValues = 0;
 		node.getn(0, 3, { |values|
 			getnValues = values;
-			condition.test = true;
+			condition.test_(true).signal;
 		});
 
-		this.wait({ condition.test }, "getn response timed out after % seconds.".format(timeout), timeout);
+		this.wait(condition, "getn response timed out after % seconds.".format(timeout), timeout);
 
 		this.assertArrayFloatEquals(getnValues, setnValues, "Node:getn works", 0.001);
 		node.free;

--- a/testsuite/classlibrary/TestOSCBundle.sc
+++ b/testsuite/classlibrary/TestOSCBundle.sc
@@ -21,7 +21,7 @@ TestOSCBundle : UnitTest {
 			var def = SynthDef("TestOSCBundle" ++ i, { Silent.ar });
 			bundle.addPrepare(["/d_recv", def.asBytes])
 		});
-		bundle.doPrepare(server, { completed.test = true });
+		bundle.doPrepare(server, { completed.test_(true).signal });
 		this.wait(completed, "% timed out waiting for bundle to be sent".format(thisMethod));
 
 		this.assertEquals(completed.test, true, "'doPrepare' sent the prepare bundle to the server");

--- a/testsuite/classlibrary/TestPprotect.sc
+++ b/testsuite/classlibrary/TestPprotect.sc
@@ -10,7 +10,7 @@ TestPprotect : UnitTest {
 			routine,
 			{
 				success = routine.exceptionHandler.isNil;
-				condition.test = true;
+				condition.test_(true).signal;
 			}
 		).asStream;
 		// Note that it is necessary to do this asynchronously!
@@ -28,7 +28,7 @@ TestPprotect : UnitTest {
 		pat = Pprotect(
 			Prout {
 				0.01.yield;
-				condition.test = true;
+				{ condition.test_(true).signal }.defer(0.001);
 				Error("dummy error").throw
 			},
 			{ stream.streamError }
@@ -56,7 +56,7 @@ TestPprotect : UnitTest {
 		redefine = {
 			proxy.source = {
 				0.01.wait;
-				condition.test = true;
+				{ condition.test_(true).signal }.defer(0.001);
 				Error("dummy error").throw
 			}
 		};
@@ -83,12 +83,12 @@ TestPprotect : UnitTest {
 					Prout {
 						Error("dummy error").throw
 					}, {
-						condition.test = true;
+						{ condition.test_(true).signal }.defer(0.001);
 						innerHasBeenCalled = true
 					}
 				),
 				{
-					condition.test = true;
+					{ condition.test_(true).signal }.defer(0.001);
 					outerHasBeenCalled = true
 				}
 			).asStream;

--- a/testsuite/classlibrary/TestSanitize.sc
+++ b/testsuite/classlibrary/TestSanitize.sc
@@ -40,7 +40,7 @@ TestSanitize : UnitTest {
 			ugenGraphFunc.loadToFloatArray(duration, server, { |samples|
 				this.assertArrayFloatEquals(samples, expected, text);
 				testsIncomplete = testsIncomplete - 1;
-				if(testsIncomplete == 0) { testCond.test = true };
+				if(testsIncomplete == 0) { testCond.test_(true).signal };
 			});
 		};
 

--- a/testsuite/classlibrary/TestUnitTest.sc
+++ b/testsuite/classlibrary/TestUnitTest.sc
@@ -79,7 +79,7 @@ TestUnitTest : UnitTest {
 		var condition = Condition.new;
 		var r = Routine {
 			0.01.yield;
-			condition.test = true;
+			condition.test_(true).signal
 		};
 		r.play;
 		this.wait(condition, maxTime:0.02);

--- a/testsuite/classlibrary/server/TestMixedBundleTester.sc
+++ b/testsuite/classlibrary/server/TestMixedBundleTester.sc
@@ -53,13 +53,13 @@ TestMixedBundleTester : UnitTest {
 	test_send {
 		var sent;
 		var numDefs = 100;
-		var functionFired = false;
+		var condition = Condition.new;
 
 		this.makeDefs(numDefs);
-		tester.addFunction({ functionFired = true });
+		tester.addFunction({ condition.test_(true).signal });
 
 		tester.send(server);
-		this.wait({ functionFired }, "% timed out while waiting".format(thisMethod));
+		this.wait(condition, "% timed out while waiting".format(thisMethod));
 
 		// should be 100 in preparationMessages
 		this.assertEquals(MixedBundleTester.bundlesSent.size, 1, "should be 1 bundle sent");


### PR DESCRIPTION
## Purpose and Motivation

Fixes #5366.

After merging #5364, we can simplify `UnitTest:wait` by simply passing the timeout along to the Condition.

This requires all unit tests that had previously passed a function or Boolean now to use a Condition. I've done that here.

It also requires all tests to `.signal` their conditions consistently (which is correct Condition usage anyway). I've updated that.

I reran all of the modified unit tests. All of them except TestCoreUGens pass. I fixed a couple of things in TestCoreUGens but it's still not completely working... after about an hour and a half working on this PR, I'd better put it aside for now.

## Types of changes

- Bug fix
- Breaking change

## To-do list

- [x] Code is tested
- [ ] All tests are passing  -- almost
- [ ] Updated documentation  -- need to?
- [ ] This PR is ready for review  -- almost
