### PR TITLE
doc: clarify syntactic shortcuts in Pbind documentation

### DIFF
--- a/HelpSource/Classes/Pbind.schelp
+++ b/HelpSource/Classes/Pbind.schelp
@@ -67,7 +67,12 @@ Pbind(
 )
 ::
 
-It is possible to specify a Pbind with an link::Classes/Array:: preceded by *. Arrays treat identifiers ending with a colon as link::Classes/Symbol::s, making the syntax of the Pbind specification a bit more concise:
+It is possible to specify a Pbind with an link::Classes/Array:: preceded by *. This takes advantage of a special
+syntactic shortcut in SC where using * expands an Array into a list of method arguments. You can see more information
+about this and other syntactic shortcuts in link::Reference/Syntax-Shortcuts:: and
+link::Overviews/SymbolicNotations::.  Another useful shortcut is that Arrays treat identifiers ending with a colon as
+link::Classes/Symbol::s. Both of these shortcuts together help make the syntax of the Pbind specification a bit more
+concise:
 
 code::
 (


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

this responds to a couple threads on forums [here](https://llllllll.co/t/supercollider-tips-q-a/3185/416) and [here](https://scsynth.org/t/in-pbind-alternative-syntax/3262) where it seems the wording in Pbind documentation is confusing to readers. this PR attempts to clarify the wording and also adds links to relevant documentation.

## Types of changes

- Documentation

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review