### PR TITLE
exclude a specific failing test in TestProxyNodeMap

### DIFF
--- a/testsuite/scripts/gha_test_run_proto.json
+++ b/testsuite/scripts/gha_test_run_proto.json
@@ -144,7 +144,7 @@
         },
         {
             "suite":"TestProxyNodeMap",
-            "test":"*",
+            "test":"test_nodeMap_controlNamesConvertsObjectToControlInput",
             "skip":true,
             "skipReason":"UnitTest has bugs (FIXME)"
         },


### PR DESCRIPTION

<!-- Please see CONTRIBUTING.md for guidelines. -->
Exclude only `test_nodeMap_controlNamesConvertsObjectToControlInput` from `TestProxyNodeMap`

See https://github.com/supercollider/supercollider/pull/5368#issuecomment-787510733

## Purpose and Motivation

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review
