### PR TITLE
GitHub Actions: add Windows builds

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -581,7 +581,7 @@ jobs:
             artifact-extension: 'zip'
             s3-create-latest-link: true # create link to pointing to the "latest" build
 
-    if: github.repository_owner == 'supercollider' # run in the main repo
+    if: github.repository_owner == 'supercollider' && github.event_name != 'pull_request' # run in the main repo, but not on pull requests
     needs: [lint, macOS, Windows]
     runs-on: ubuntu-18.04
     name: 'deploy ${{ matrix.artifact-suffix }} to s3'

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -567,47 +567,32 @@ jobs:
         include:
 
           - artifact-suffix: macOS
-            upload-to-github: true
-            upload-to-s3: true
             s3-os-name: osx
             s3-artifact-suffx: ''
             artifact-extension: 'zip'
             s3-create-latest-link: true # create link to pointing to the "latest" build; activate only one per branch per s3-os-name
 
           - artifact-suffix: win32
-            upload-to-github: true
-            upload-to-s3: true
             s3-os-name: win32
             s3-artifact-suffx: ''
             artifact-extension: 'zip'
             s3-create-latest-link: true # create link to pointing to the "latest" build
 
-          - artifact-suffix: win32-installer
-            upload-to-github: true
-            upload-to-s3: false
-
           - artifact-suffix: win64
-            upload-to-github: true
-            upload-to-s3: true
             s3-os-name: win64
             s3-artifact-suffx: ''
             artifact-extension: 'zip'
             s3-create-latest-link: true # create link to pointing to the "latest" build
 
-          - artifact-suffix: win64-installer
-            upload-to-github: true
-            upload-to-s3: false
-
-    if: github.repository_owner == 'supercollider' || startsWith(github.ref, 'refs/tags/') # run in the main repo and everywhere on tagged commits
+    if: github.repository_owner == 'supercollider' # run in the main repo
     needs: [lint, macOS, Windows]
     runs-on: ubuntu-18.04
-    name: 'deploy ${{ matrix.artifact-suffix }} build'
+    name: 'deploy ${{ matrix.artifact-suffix }} to s3'
     env:
       INSTALL_PATH: ${{ github.workspace }}/build/Install
       ARTIFACT_FILE: 'SuperCollider-${{ needs.lint.outputs.sc-version }}-${{ matrix.artifact-suffix }}'
-      UPLOAD_TO_GH_RELEASE: ${{ matrix.upload-to-github && startsWith(github.ref, 'refs/tags/') }}
-      UPLOAD_TO_S3: ${{ matrix.upload-to-s3 && (secrets.S3_ACCESS_KEY_ID != 0) && !startsWith(github.ref, 'refs/tags/') }}
-      S3_CREATE_LATEST_LINK: ${{ matrix.s3-create-latest-link && matrix.upload-to-s3 && (secrets.S3_ACCESS_KEY_ID != 0) && startsWith(github.ref, 'refs/heads/') }}
+      UPLOAD_TO_S3: ${{ (secrets.S3_ACCESS_KEY_ID != 0) && !startsWith(github.ref, 'refs/tags/') }}
+      S3_CREATE_LATEST_LINK: ${{ matrix.s3-create-latest-link && (secrets.S3_ACCESS_KEY_ID != 0) && startsWith(github.ref, 'refs/heads/') }}
       S3_ARTIFACT_PATH: ${{ github.workspace }}/build/s3-upload
       S3_ARTIFACT_NAME: SC-${{ github.sha }}${{ matrix.s3-artifact-suffx }}.${{ matrix.artifact-extension }}
       S3_BUILD_LOCATION: builds/supercollider/supercollider/${{ matrix.s3-os-name }}
@@ -615,20 +600,10 @@ jobs:
     steps:
       - name: download artifacts
         uses: actions/download-artifact@v2
-        if: (env.UPLOAD_TO_GH_RELEASE == 'true') || (env.UPLOAD_TO_S3 == 'true')
         with:
           name: ${{ env.ARTIFACT_FILE }}
           path: ${{ env.INSTALL_PATH }}
-      - name: upload to the release page
-        uses: softprops/action-gh-release@v1
-        if: env.UPLOAD_TO_GH_RELEASE == 'true'
-        with:
-          files: ${{ env.INSTALL_PATH }}/*.*
-          draft: true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: preapre s3 upload
-        if: env.UPLOAD_TO_S3 == 'true'
         run: |
           mkdir $S3_ARTIFACT_PATH
           mv $INSTALL_PATH/*.* $S3_ARTIFACT_PATH/$S3_ARTIFACT_NAME
@@ -659,7 +634,6 @@ jobs:
           cat $LATEST_HTML_PATH
       - name: upload to S3
         uses: jakejarvis/s3-sync-action@master
-        if: env.UPLOAD_TO_S3 == 'true'
         with:
           args: --acl public-read
         env:
@@ -677,3 +651,31 @@ jobs:
           echo $S3_BUILD_URL
           if [[ -n "$LATEST_HTML_URL" ]]; then echo $LATEST_HTML_URL; fi
           echo "::endgroup::"
+
+  # release - list of files uploaded to GH release is specified in the *upload* step
+  deploy_gh:
+    if: startsWith(github.ref, 'refs/tags/') # run on tagged commits
+    needs: [lint, macOS, Windows]
+    runs-on: ubuntu-18.04
+    name: 'deploy release'
+    env:
+      INSTALL_PATH: ${{ github.workspace }}/Install
+      ARTIFACT_FILE_PREFIX: 'SuperCollider-${{ needs.lint.outputs.sc-version }}'
+    steps:
+      - name: download artifacts
+        uses: actions/download-artifact@v2
+        with:
+          path: ${{ env.INSTALL_PATH }} # no "name" paramter - download all artifacts
+      - name: upload to the release page
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            ${{ env.INSTALL_PATH }}/${{ env.ARTIFACT_FILE_PREFIX }}-macOS/*
+            # ${{ env.INSTALL_PATH }}/${{ env.ARTIFACT_FILE_PREFIX }}-macOS-legacy/*
+            ${{ env.INSTALL_PATH }}/${{ env.ARTIFACT_FILE_PREFIX }}-win32-installer/*
+            ${{ env.INSTALL_PATH }}/${{ env.ARTIFACT_FILE_PREFIX }}-win64-installer/*
+            ${{ env.INSTALL_PATH }}/${{ env.ARTIFACT_FILE_PREFIX }}-win32/*
+            ${{ env.INSTALL_PATH }}/${{ env.ARTIFACT_FILE_PREFIX }}-win64/*
+          draft: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -571,6 +571,7 @@ jobs:
             upload-to-s3: true
             s3-os-name: osx
             s3-artifact-suffx: ''
+            artifact-extension: 'zip'
             s3-create-latest-link: true # create link to pointing to the "latest" build; activate only one per branch per s3-os-name
 
           - artifact-suffix: win32
@@ -578,6 +579,7 @@ jobs:
             upload-to-s3: true
             s3-os-name: win32
             s3-artifact-suffx: ''
+            artifact-extension: 'zip'
             s3-create-latest-link: true # create link to pointing to the "latest" build
 
           - artifact-suffix: win32-installer
@@ -589,6 +591,7 @@ jobs:
             upload-to-s3: true
             s3-os-name: win64
             s3-artifact-suffx: ''
+            artifact-extension: 'zip'
             s3-create-latest-link: true # create link to pointing to the "latest" build
 
           - artifact-suffix: win64-installer
@@ -606,7 +609,7 @@ jobs:
       UPLOAD_TO_S3: ${{ matrix.upload-to-s3 && (secrets.S3_ACCESS_KEY_ID != 0) && !startsWith(github.ref, 'refs/tags/') }}
       S3_CREATE_LATEST_LINK: ${{ matrix.s3-create-latest-link && matrix.upload-to-s3 && (secrets.S3_ACCESS_KEY_ID != 0) && startsWith(github.ref, 'refs/heads/') }}
       S3_ARTIFACT_PATH: ${{ github.workspace }}/build/s3-upload
-      S3_ARTIFACT_NAME: SC-${{ github.sha }}${{ matrix.s3-artifact-suffx }}.zip
+      S3_ARTIFACT_NAME: SC-${{ github.sha }}${{ matrix.s3-artifact-suffx }}.${{ matrix.artifact-extension }}
       S3_BUILD_LOCATION: builds/supercollider/supercollider/${{ matrix.s3-os-name }}
       S3_ROOT_URL: 'https://supercollider.s3.amazonaws.com'
     steps:
@@ -620,7 +623,7 @@ jobs:
         uses: softprops/action-gh-release@v1
         if: env.UPLOAD_TO_GH_RELEASE == 'true'
         with:
-          files: ${{ env.INSTALL_PATH }}/${{ env.ARTIFACT_FILE }}.zip
+          files: ${{ env.INSTALL_PATH }}/*.*
           draft: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -435,22 +435,19 @@ jobs:
           mv ASIOSDK2.3 $GITHUB_WORKSPACE/external_libraries/portaudio/asiosdk
       - name: configure
         shell: bash
-        env:
-          CMAKE_GENERATOR: ${{ matrix.cmake-generator }}
-          CMAKE_ARCH: ${{ matrix.cmake-arch }}
-          USE_WEBENGINE: ${{ matrix.use-qtwebengine }}
-          ABLETON_LINK: ${{ matrix.ableton-link }}
         run: |
           export PATH=$Qt5_DIR/bin:$PATH
 
           mkdir $BUILD_PATH && cd $BUILD_PATH
 
-          cmake -G "$CMAKE_GENERATOR" -A "$CMAKE_ARCH" -D CMAKE_PREFIX_PATH="$Qt5_DIR" -D SUPERNOVA=ON -D SC_USE_QTWEBENGINE=$USE_WEBENGINE -D SC_ABLETON_LINK=$ABLETON_LINK -D CMAKE_BUILD_TYPE=Release .. # build type is specified here for MinGW build
+          cmake -G "${{ matrix.cmake-generator }}" -A "${{ matrix.cmake-arch }}" -D CMAKE_PREFIX_PATH="$Qt5_DIR" -D SUPERNOVA=ON -D SC_USE_QTWEBENGINE=${{ matrix.use-qtwebengine }} -D SC_ABLETON_LINK=${{ matrix.ableton-link }} -D CMAKE_BUILD_TYPE=Release .. # build type is specified here for MinGW build
 
       - name: build
         shell: bash
         run: |
-          cmake --build $BUILD_PATH --config Release --target install
+          BUILD_PARALLELISM=
+          if [[ ${{ startsWith(matrix.cmake-generator, 'MinGW') }} == true ]]; then BUILD_PARALLELISM="-- -j2"; fi
+          cmake --build $BUILD_PATH --config Release --target install $BUILD_PARALLELISM
       - name: create archive
         if: matrix.artifact-suffix
         shell: bash

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -600,10 +600,12 @@ jobs:
     steps:
       - name: download artifacts
         uses: actions/download-artifact@v2
+        if: env.UPLOAD_TO_S3 == 'true'
         with:
           name: ${{ env.ARTIFACT_FILE }}
           path: ${{ env.INSTALL_PATH }}
       - name: preapre s3 upload
+        if: env.UPLOAD_TO_S3 == 'true'
         run: |
           mkdir $S3_ARTIFACT_PATH
           mv $INSTALL_PATH/*.* $S3_ARTIFACT_PATH/$S3_ARTIFACT_NAME
@@ -634,6 +636,7 @@ jobs:
           cat $LATEST_HTML_PATH
       - name: upload to S3
         uses: jakejarvis/s3-sync-action@master
+        if: env.UPLOAD_TO_S3 == 'true'
         with:
           args: --acl public-read
         env:

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -313,6 +313,169 @@ jobs:
           path: ${{ env.INSTALL_PATH }}/${{ env.ARTIFACT_FILE }}
           retention-days: 7 # quickly remove test artifacts
 
+  Windows:
+    needs: lint
+    runs-on: windows-${{ matrix.os-version }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+
+          - job-name: '32-bit'
+            fftw-arch: 'x32'
+            cmake-arch: 'Win32'
+            os-version: '2019'
+            qt-version: '5.15.2'
+            qt-arch: 'win32_msvc2019'
+            fftw-url: 'ftp://ftp.fftw.org/pub/fftw/fftw-3.3.5-dll32.zip'
+            cmake-generator: 'Visual Studio 16 2019'
+            msvc-year: '2019'
+            vcvars-script: 'vcvars32.bat'
+            chocolatey-options: '--forcex86' # '--forcex86' for 32-bit build
+            use-qtwebengine: 'ON' # might need to be turned off for MinGW
+            ableton-link: 'ON' # might need to be turned off for MinGW
+            artifact-suffix: 'win32' # set if needed - will trigger artifact upload
+            create-installer: ${{ startsWith(github.ref, 'refs/tags/') }}
+            installer-suffix: 'win32-installer'
+
+          - job-name: '64-bit'
+            fftw-arch: 'x64'
+            cmake-arch: 'x64'
+            os-version: '2019'
+            qt-version: '5.15.2'
+            qt-arch: 'win64_msvc2019_64'
+            fftw-url: 'ftp://ftp.fftw.org/pub/fftw/fftw-3.3.5-dll64.zip'
+            cmake-generator: 'Visual Studio 16 2019'
+            msvc-year: '2019'
+            vcvars-script: 'vcvars64.bat'
+            chocolatey-options: '' # '--forcex86' for 32-bit build
+            use-qtwebengine: 'ON' # might need to be turned off for MinGW
+            ableton-link: 'ON' # might need to be turned off for MinGW
+            artifact-suffix: 'win64' # set if needed - will trigger artifact upload
+            create-installer: ${{ startsWith(github.ref, 'refs/tags/') }}
+            installer-suffix: 'win64-installer'
+
+          - job-name: '64-bit MinGW'
+            fftw-arch: 'x64'
+            os-version: '2019'
+            qt-version: '5.15.2'
+            qt-arch: 'win64_mingw81'
+            fftw-url: 'ftp://ftp.fftw.org/pub/fftw/fftw-3.3.5-dll64.zip'
+            cmake-generator: 'MinGW Makefiles'
+            chocolatey-options: '' # '--forcex86' for 32-bit build
+            use-qtwebengine: 'OFF' # might need to be turned off for MinGW
+            ableton-link: 'OFF' # might need to be turned off for MinGW
+            artifact-suffix: 'win64-mingw' # set if needed - will trigger artifact upload
+
+    name: Windows ${{ matrix.job-name }}
+    env:
+      BUILD_PATH: ${{ github.workspace }}/build
+      INSTALL_PATH: ${{ github.workspace }}/build/Install
+      LIBS_DOWNLOAD_PATH: ${{ github.workspace }}/../3rd-party
+      VCVARS_SCRIPT_PATH: 'C:/Program Files (x86)/Microsoft Visual Studio/${{ matrix.msvc-year }}/Enterprise/VC/Auxiliary/Build/${{ matrix.vcvars-script }}'
+      ARTIFACT_FILE: 'SuperCollider-${{ needs.lint.outputs.sc-version }}-${{ matrix.artifact-suffix }}'
+      INSTALLER_FILE: 'SuperCollider-${{ needs.lint.outputs.sc-version }}-${{ matrix.installer-suffix }}'
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      - name: prepare timestamp for cache
+        id: current-date
+        run: |
+          echo "::set-output name=stamp::$(date '+%Y-%m-%d')"
+          echo "::set-output name=week::$(date '+%V')"
+      - name: cache qt
+        id: cache-qt
+        uses: actions/cache@v1
+        with:
+          path: ../Qt
+          key: ${{ runner.os }}-v1-${{ matrix.os-version }}-${{ matrix.qt-version }}-qt${{ matrix.qt-arch }}
+      - name: install qt using aqtinstall
+        uses: jurplel/install-qt-action@v2
+        with:
+          modules: 'qtwebengine'
+          version: ${{ matrix.qt-version }}
+          arch: ${{ matrix.qt-arch }}
+          cached: ${{ steps.cache-qt.outputs.cache-hit }}
+      - name: install libsndfile
+        run: choco install libsndfile ${{ matrix.chocolatey-options }}
+      - name: download fftw
+        shell: bash
+        env:
+          FFTW_PATH: ${{ env.LIBS_DOWNLOAD_PATH }}/fftw
+        run: |
+          mkdir -p $FFTW_PATH && cd $FFTW_PATH
+          curl -L ${{ matrix.fftw-url }} -o fftw.zip
+          7z x fftw.zip -y
+          # add env var for subsequent steps
+          echo 'FFTW_PATH<<EOF' >> $GITHUB_ENV
+          echo $FFTW_PATH >> $GITHUB_ENV
+          echo 'EOF' >> $GITHUB_ENV
+      - name: create fftw msvc library
+        if: matrix.vcvars-script
+        shell: cmd
+        env:
+          FFTW_ARCH: ${{ matrix.fftw-arch }}
+        run: |
+          call "%VCVARS_SCRIPT_PATH%"
+          cd "%FFTW_PATH%"
+          lib.exe /machine:%FFTW_ARCH% /def:libfftw3f-3.def
+      - name: move fftw
+        shell: bash
+        run: |
+          mv $FFTW_PATH "C:/Program Files/fftw"
+      - name: install asio sdk
+        shell: bash
+        env:
+          ASIO_PATH: ${{ env.LIBS_DOWNLOAD_PATH }}/asio_sdk
+        run: |
+          mkdir -p $ASIO_PATH && cd $ASIO_PATH
+          curl -L https://www.steinberg.net/sdk_downloads/asiosdk2.3.zip -o asio.zip
+          7z x asio.zip -y
+          mv ASIOSDK2.3 $GITHUB_WORKSPACE/external_libraries/portaudio/asiosdk
+      - name: configure
+        shell: bash
+        env:
+          CMAKE_GENERATOR: ${{ matrix.cmake-generator }}
+          CMAKE_ARCH: ${{ matrix.cmake-arch }}
+          USE_WEBENGINE: ${{ matrix.use-qtwebengine }}
+          ABLETON_LINK: ${{ matrix.ableton-link }}
+        run: |
+          export PATH=$Qt5_DIR/bin:$PATH
+
+          mkdir $BUILD_PATH && cd $BUILD_PATH
+
+          cmake -G "$CMAKE_GENERATOR" -A "$CMAKE_ARCH" -D CMAKE_PREFIX_PATH="$Qt5_DIR" -D SUPERNOVA=ON -D SC_USE_QTWEBENGINE=$USE_WEBENGINE -D SC_ABLETON_LINK=$ABLETON_LINK -D CMAKE_BUILD_TYPE=Release .. # build type is specified here for MinGW build
+
+      - name: build
+        shell: bash
+        run: |
+          cmake --build $BUILD_PATH --config Release --target install
+      - name: create archive
+        if: matrix.artifact-suffix
+        shell: bash
+        run: cd $INSTALL_PATH && 7z a $ARTIFACT_FILE.zip -tzip SuperCollider # this assumes that we end up with the build in the folder SuperCollider
+      - name: upload artifacts
+        uses: actions/upload-artifact@v2
+        if: matrix.artifact-suffix
+        with:
+          name: ${{ env.ARTIFACT_FILE }}
+          path: ${{ env.INSTALL_PATH }}/${{ env.ARTIFACT_FILE }}.zip
+          retention-days: 7 # quickly remove test artifacts
+      - name: create installer
+        if: matrix.create-installer == 'true'
+        shell: bash
+        run: |
+          export PATH="C:\Program Files (x86)\NSIS":$PATH
+          cmake --build $BUILD_PATH --config Release --target installer
+      - name: upload installer
+        uses: actions/upload-artifact@v2
+        if: matrix.create-installer == 'true'
+        with:
+          name: ${{ env.INSTALLER_FILE }}
+          path: ${{ env.INSTALL_PATH }}/*.exe
+          retention-days: 7 # quickly remove test artifacts
+
   test:
     strategy:
       fail-fast: false
@@ -396,8 +559,8 @@ jobs:
           PYCHARM_HOSTED: 1 # enable color output
           QPM_DEBUG: 1
         run: qpm test.run -l $SCRIPT_RUN --path $SCLANG --include $QUARKS_PATH $TESTS_PATH
-        
-  deploy:
+
+  deploy_s3:
     strategy:
       fail-fast: false
       matrix:
@@ -410,8 +573,30 @@ jobs:
             s3-artifact-suffx: ''
             s3-create-latest-link: true # create link to pointing to the "latest" build; activate only one per branch per s3-os-name
 
+          - artifact-suffix: win32
+            upload-to-github: true
+            upload-to-s3: true
+            s3-os-name: win32
+            s3-artifact-suffx: ''
+            s3-create-latest-link: true # create link to pointing to the "latest" build
+
+          - artifact-suffix: win32-installer
+            upload-to-github: true
+            upload-to-s3: false
+
+          - artifact-suffix: win64
+            upload-to-github: true
+            upload-to-s3: true
+            s3-os-name: win64
+            s3-artifact-suffx: ''
+            s3-create-latest-link: true # create link to pointing to the "latest" build
+
+          - artifact-suffix: win64-installer
+            upload-to-github: true
+            upload-to-s3: false
+
     if: github.repository_owner == 'supercollider' || startsWith(github.ref, 'refs/tags/') # run in the main repo and everywhere on tagged commits
-    needs: [lint, macOS]
+    needs: [lint, macOS, Windows]
     runs-on: ubuntu-18.04
     name: 'deploy ${{ matrix.artifact-suffix }} build'
     env:
@@ -427,6 +612,7 @@ jobs:
     steps:
       - name: download artifacts
         uses: actions/download-artifact@v2
+        if: (env.UPLOAD_TO_GH_RELEASE == 'true') || (env.UPLOAD_TO_S3 == 'true')
         with:
           name: ${{ env.ARTIFACT_FILE }}
           path: ${{ env.INSTALL_PATH }}
@@ -442,13 +628,13 @@ jobs:
         if: env.UPLOAD_TO_S3 == 'true'
         run: |
           mkdir $S3_ARTIFACT_PATH
-          cp $INSTALL_PATH/$ARTIFACT_FILE $S3_ARTIFACT_PATH/$S3_ARTIFACT_NAME
-          
-          # set S3_BUILD_LOCATION 
+          mv $INSTALL_PATH/*.* $S3_ARTIFACT_PATH/$S3_ARTIFACT_NAME
+
+          # set S3_BUILD_LOCATION
           echo 'S3_BUILD_URL<<EOF' >> $GITHUB_ENV
           echo ${{ env.S3_ROOT_URL }}/${{ env.S3_BUILD_LOCATION }}/${{ env.S3_ARTIFACT_NAME }} >> $GITHUB_ENV
           echo 'EOF' >> $GITHUB_ENV
-          
+
           if [[ $S3_CREATE_LATEST_LINK == true ]]; then
             # set LATEST_HTML_PATH and LATEST_HTML_URL
             echo 'LATEST_HTML_PATH<<EOF' >> $GITHUB_ENV

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -124,7 +124,7 @@ jobs:
       SHARED_LIBSCSYNTH: ${{ matrix.shared-libscsynth }}
       CC: ${{ matrix.c-compiler }}
       CXX: ${{ matrix.cxx-compiler }}
-      ARTIFACT_FILE: 'SuperCollider-${{ needs.lint.outputs.sc-version }}-${{ matrix.artifact-suffix }}.zip'
+      ARTIFACT_FILE: 'SuperCollider-${{ needs.lint.outputs.sc-version }}-${{ matrix.artifact-suffix }}'
     steps:
       - uses: actions/checkout@v2
         with:
@@ -179,13 +179,13 @@ jobs:
           make install -j2
       - name: create archive
         if: matrix.artifact-suffix
-        run: cd $INSTALL_PATH && zip --symlinks -r $ARTIFACT_FILE .
+        run: cd $INSTALL_PATH && zip --symlinks -r $ARTIFACT_FILE.zip .
       - name: upload artifacts
         uses: actions/upload-artifact@v2
         if: matrix.artifact-suffix
         with:
           name: ${{ env.ARTIFACT_FILE }}
-          path: ${{ env.INSTALL_PATH }}/${{ env.ARTIFACT_FILE }}
+          path: ${{ env.INSTALL_PATH }}/${{ env.ARTIFACT_FILE }}.zip
           retention-days: 7 # quickly remove test artifacts
 
   macOS:
@@ -232,7 +232,7 @@ jobs:
       HOMEBREW_NO_INSTALL_CLEANUP: 1
       USE_SYSLIBS: ${{ matrix.use-syslibs }}
       SHARED_LIBSCSYNTH: ${{ matrix.shared-libscsynth }}
-      ARTIFACT_FILE: 'SuperCollider-${{ needs.lint.outputs.sc-version }}-${{ matrix.artifact-suffix }}.zip'
+      ARTIFACT_FILE: 'SuperCollider-${{ needs.lint.outputs.sc-version }}-${{ matrix.artifact-suffix }}'
     steps:
       - uses: actions/checkout@v2
         with:
@@ -304,13 +304,13 @@ jobs:
         run: cmake --build $BUILD_PATH --config Release --target install
       - name: create archive
         if: matrix.artifact-suffix
-        run: cd $INSTALL_PATH && zip --symlinks -r $ARTIFACT_FILE SuperCollider # this assumes that we end up with the build in the folder SuperCollider
+        run: cd $INSTALL_PATH && zip --symlinks -r $ARTIFACT_FILE.zip SuperCollider # this assumes that we end up with the build in the folder SuperCollider
       - name: upload artifacts
         uses: actions/upload-artifact@v2
         if: matrix.artifact-suffix
         with:
           name: ${{ env.ARTIFACT_FILE }}
-          path: ${{ env.INSTALL_PATH }}/${{ env.ARTIFACT_FILE }}
+          path: ${{ env.INSTALL_PATH }}/${{ env.ARTIFACT_FILE }}.zip
           retention-days: 7 # quickly remove test artifacts
 
   Windows:
@@ -497,7 +497,7 @@ jobs:
     name: 'test on ${{ matrix.name }}'
     env:
       INSTALL_PATH: ${{ github.workspace }}/build/Install
-      ARTIFACT_FILE: 'SuperCollider-${{ needs.lint.outputs.sc-version }}-${{ matrix.artifact-suffix }}.zip'
+      ARTIFACT_FILE: 'SuperCollider-${{ needs.lint.outputs.sc-version }}-${{ matrix.artifact-suffix }}'
       QUARKS_PATH: ${{ github.workspace }}/build/Quarks
       TESTS_PATH: ${{ github.workspace }}/testsuite/classlibrary
       SCLANG: ${{ github.workspace }}/${{ matrix.sclang }}
@@ -518,7 +518,7 @@ jobs:
           cd $INSTALL_PATH
           echo `pwd`
           echo `ls -s`
-          unzip $ARTIFACT_FILE
+          unzip $ARTIFACT_FILE.zip
       - name: setup Linux environment
         if: runner.os == 'Linux'
         run: |
@@ -601,7 +601,7 @@ jobs:
     name: 'deploy ${{ matrix.artifact-suffix }} build'
     env:
       INSTALL_PATH: ${{ github.workspace }}/build/Install
-      ARTIFACT_FILE: 'SuperCollider-${{ needs.lint.outputs.sc-version }}-${{ matrix.artifact-suffix }}.zip'
+      ARTIFACT_FILE: 'SuperCollider-${{ needs.lint.outputs.sc-version }}-${{ matrix.artifact-suffix }}'
       UPLOAD_TO_GH_RELEASE: ${{ matrix.upload-to-github && startsWith(github.ref, 'refs/tags/') }}
       UPLOAD_TO_S3: ${{ matrix.upload-to-s3 && (secrets.S3_ACCESS_KEY_ID != 0) && !startsWith(github.ref, 'refs/tags/') }}
       S3_CREATE_LATEST_LINK: ${{ matrix.s3-create-latest-link && matrix.upload-to-s3 && (secrets.S3_ACCESS_KEY_ID != 0) && startsWith(github.ref, 'refs/heads/') }}
@@ -620,7 +620,7 @@ jobs:
         uses: softprops/action-gh-release@v1
         if: env.UPLOAD_TO_GH_RELEASE == 'true'
         with:
-          files: ${{ env.INSTALL_PATH }}/${{ env.ARTIFACT_FILE }}
+          files: ${{ env.INSTALL_PATH }}/${{ env.ARTIFACT_FILE }}.zip
           draft: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -358,6 +358,7 @@ if(MSVC)
     set(${flag} "${${flag}} /wd4800") # forcing value to bool 'true' or 'false' (performance warning)
     set(${flag} "${${flag}} /wd4996") # The POSIX name for this item is deprecated.
   endforeach()
+  add_compile_options("/Zc:__cplusplus")
 
 # _ENABLE_ATOMIC_ALIGNMENT_FIX prevents the build from breaking when VS2015 update 2 upwards are used
 # see http://boost.2283326.n4.nabble.com/lockfree-ENABLE-ATOMIC-ALIGNMENT-FIX-for-VS-2015-Update-2-td4685955.html

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -358,6 +358,10 @@ if(MSVC)
     set(${flag} "${${flag}} /wd4800") # forcing value to bool 'true' or 'false' (performance warning)
     set(${flag} "${${flag}} /wd4996") # The POSIX name for this item is deprecated.
   endforeach()
+
+# this flag causes MSVC to correctly report __cplusplus, which prevents a compiler error 
+# caused by some versions of libsndfile's C++ header redefining nullptr as NULL. 
+# See https://devblogs.microsoft.com/cppblog/msvc-now-correctly-reports-__cplusplus/
   add_compile_options("/Zc:__cplusplus")
 
 # _ENABLE_ATOMIC_ALIGNMENT_FIX prevents the build from breaking when VS2015 update 2 upwards are used

--- a/cmake_modules/FindSndfile.cmake
+++ b/cmake_modules/FindSndfile.cmake
@@ -51,6 +51,8 @@ else()
       "${CMAKE_SOURCE_DIR}/../${CMAKE_LIBRARY_ARCHITECTURE}/libsndfile/include"
       "$ENV{ProgramW6432}/Mega-Nerd/libsndfile/include"
       "$ENV{ProgramFiles}/Mega-Nerd/libsndfile/include"
+      "$ENV{PROGRAMFILES\(X86\)}/libsndfile/include"
+      "$ENV{ProgramFiles}/libsndfile/include"
     PATHS /usr/local/include
       /usr/include
   )
@@ -64,6 +66,10 @@ else()
       "$ENV{ProgramW6432}/Mega-Nerd/libsndfile/bin"
       "$ENV{ProgramFiles}/Mega-Nerd/libsndfile/lib"
       "$ENV{ProgramFiles}/Mega-Nerd/libsndfile/bin"
+      "$ENV{PROGRAMFILES\(X86\)}/libsndfile/lib"
+      "$ENV{PROGRAMFILES\(X86\)}/libsndfile/bin"
+      "$ENV{ProgramFiles}/libsndfile/lib"
+      "$ENV{ProgramFiles}/libsndfile/bin"
     PATHS /usr/local/
       /usr/lib
   )
@@ -77,6 +83,10 @@ else()
       "$ENV{ProgramW6432}/Mega-Nerd/libsndfile/bin"
       "$ENV{ProgramFiles}/Mega-Nerd/libsndfile/lib"
       "$ENV{ProgramFiles}/Mega-Nerd/libsndfile/bin"
+      "$ENV{PROGRAMFILES\(X86\)}/libsndfile/lib"
+      "$ENV{PROGRAMFILES\(X86\)}/libsndfile/bin"
+      "$ENV{ProgramFiles}/libsndfile/lib"
+      "$ENV{ProgramFiles}/libsndfile/bin"
   )
 
   # Handle the QUIETLY and REQUIRED arguments and set SNDFILE_FOUND to TRUE if

--- a/cmake_modules/FindSndfile.cmake
+++ b/cmake_modules/FindSndfile.cmake
@@ -75,7 +75,7 @@ else()
   )
   # used by Windows only
   find_path(SNDFILE_LIBRARY_DIR
-    NAMES libsndfile.dll libsndfile-1.dll
+    NAMES libsndfile.dll libsndfile-1.dll sndfile.dll
     HINTS
       "${CMAKE_SOURCE_DIR}/../${CMAKE_LIBRARY_ARCHITECTURE}/libsndfile/lib"
       "${CMAKE_SOURCE_DIR}/../${CMAKE_LIBRARY_ARCHITECTURE}/libsndfile/bin"


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->
Further implementation of #5261

This PR adds Windows guilds to our GHA

Notes, particularly highlighting differences with our AppVeyor builds:
- we use [chocolatey](https://chocolatey.org/) to install `libsndfile`
  - `FindSndfile.cmake` needed to be updated to include different search paths
  - we are effectively using a newer version of the library, I think
  - this is arguably cleaner than the way we installed libsndfile in appveyor :)
- both 32- and 64-bit builds use Qt 5.15.2
- added `/Zc:__cplusplus` switch for MSVC (thanks @brianlheim and @jrsurge !)
- `fftw` and `ASIO` for portaudio are installed manually, as before
- installer creation is triggered for tagged builds only
- build artifacts (non-installer zip) are uploaded to s3
- both the installer and the non-installer zip is uploaded to GH release
  - I personally wanted to have this, in order to be able to try new release without installing it/replacing the currently installed version
  - this is easily configurable and I can change it if desired
- I added MinGW build 
  - I've made the matrix configurable so one can easily define builds using both MSVC and MinGW
  - We wouldn't use these builds for releases
    - this is just a proposition that would allow us to test if MinGW build works
    - MinGW version is built without `QtWebEngine` and `LinkClock` modules
  - ~~currently MinGW takes the longest time to build (approx 24 min, compared to approx 18 min for the regular Win64 build)~~
  - I guess we could add ccache to it? I haven't tried though
  - If we don't want it for now, I'd leave the entry commented out, so that it's clear how to set it up in the future
- s3 uploads are named differently from before for Windows, but consistently with macOS builds:
  - `https://.../supercollider/win32/SC-<SHA>.zip`
  - `https://.../supercollider/win64/SC-<SHA>.zip`
- I separated the release deployment job, since calling it multiple times created multiple releases sometimes. Also I think it makes the conditionals a little clearer.
- This is more of an observation - installer's name is specified in CMake, not in GHA. I haven't changed this, the installer is passed to the release with the name it is created with (`SuperCollider-<SCVersion>_<BuildType>-<arch>-VS-<ShortSHA>.exe`), i.e. tag name is _not_ used in the installer's name (SCVersion is taken from SCVersion.txt).

Here is the [action from the tagged commit](https://github.com/dyfer/supercollider/actions/runs/611461277) in this PR, and the accompanying [release](https://github.com/dyfer/supercollider/releases/tag/untagged-1612948dc6134f0497aa) with uploaded artifacts (the release is missing win64 zip but it was a simple typo that I've since corrected).

Since I've touched s3 deployment as well, here's the [action running on this branch pushed to the main repo](https://github.com/supercollider/supercollider/actions/runs/611646595) - s3 upload seems to work.

## Types of changes

<!-- Delete lines that don't apply -->

- New feature

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review
