### PR TITLE
GitHub Actions: use qt5 on macOS

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -281,7 +281,7 @@ jobs:
         run: brew install yaml-cpp boost
       - name: install qt from homebrew
         if: '!matrix.qt-version'
-        run: brew install qt
+        run: brew install qt5
 
       - name: configure
         env:


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->
It seems that GHA runners [updated homebrew qt to version 6](https://github.com/dyfer/supercollider/runs/2033649718?check_suite_focus=true#step:11:49). This PR fixes our builds, specifying `qt5` for homebrew.

## Types of changes

<!-- Delete lines that don't apply -->


- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review
