### PR TITLE
Make verify_app optional, improve rpath setting

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -295,7 +295,7 @@ jobs:
 
           if $SHARED_LIBSCSYNTH; then EXTRA_CMAKE_FLAGS="-DLIBSCSYNTH=ON $EXTRA_CMAKE_FLAGS"; fi
 
-          if [[ -z "${{ matrix.qt-version }}" ]]; then EXTRA_CMAKE_FLAGS="-DCMAKE_PREFIX_PATH=`brew --prefix qt5` $EXTRA_CMAKE_FLAGS"; fi
+          if [[ -z "${{ matrix.qt-version }}" ]]; then EXTRA_CMAKE_FLAGS="-DCMAKE_PREFIX_PATH=`brew --prefix qt5` -DSC_VERIFY_APP=ON $EXTRA_CMAKE_FLAGS"; fi
 
           echo "EXTRA_CMAKE_FLAGS:" $EXTRA_CMAKE_FLAGS
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -246,6 +246,8 @@ option(SC_ABLETON_LINK "Build with Ableton Link support" ON)
 if(APPLE)
     # codesigning breaks increamental builds in Xcode 11+
     option(SC_DISABLE_XCODE_CODESIGNING "Disable codesigning in XCode" ON)
+    # verify_app fails with official Qt; we'll still use it for Qt from homebrew
+    option(SC_VERIFY_APP "Run verify_app on the app bundle" OFF)
 endif()
 
 #############################################

--- a/editors/sc-ide/CMakeLists.txt
+++ b/editors/sc-ide/CMakeLists.txt
@@ -553,6 +553,10 @@ if(APPLE OR WIN32)
         string(APPEND VERIFY_CMD "
             message(STATUS \"Verifying app\")
             verify_app(\"${CMAKE_INSTALL_PREFIX}/SuperCollider/SuperCollider.app\")")
+
+        if(NOT SC_VERIFY_APP)
+            set(VERIFY_CMD "")
+        endif()
     else() # WIN32
         find_program(DEPLOY_PROG windeployqt PATHS ${CMAKE_PREFIX_PATH})
         set(DEPLOY_CMD "\"${DEPLOY_PROG}\"

--- a/editors/sc-ide/CMakeLists.txt
+++ b/editors/sc-ide/CMakeLists.txt
@@ -1,7 +1,3 @@
-# This makes sclang/scide work with a Qt installation at a fixed, non-system location.
-SET(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
-SET(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
-
 set(QT_IDE_COMPONENTS
     Concurrent
     Core
@@ -347,6 +343,9 @@ target_link_libraries( SuperCollider libscide)
 target_link_libraries( libscide PUBLIC boost_system_lib boost_filesystem_lib)
 include_directories(${boost_include_dirs})
 
+# This makes sclang/scide work with a Qt installation at a fixed location.
+set_property(TARGET libscide PROPERTY INSTALL_RPATH_USE_LINK_PATH TRUE)
+
 if(APPLE)
     target_link_libraries( libscide PUBLIC "-framework CoreServices -framework Foundation")
     target_link_libraries( libscide PUBLIC "-framework Cocoa" )
@@ -364,6 +363,9 @@ if(CMAKE_SYSTEM_NAME MATCHES "Linux")
 
     include_directories(${X11_INCLUDE_DIR})
     target_link_libraries(libscide PUBLIC ${X11_X11_LIB})
+
+    # This makes sclang/scide work with a Qt installation at a fixed location.
+    set_property(TARGET libscide PROPERTY INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
 endif()
 
 if(PTHREADS_FOUND)

--- a/lang/CMakeLists.txt
+++ b/lang/CMakeLists.txt
@@ -1,6 +1,3 @@
-# This makes sclang/scide work with a Qt installation at a fixed location.
-SET(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
-SET(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 
 include_directories(${CMAKE_SOURCE_DIR}/include/common
                     ${CMAKE_SOURCE_DIR}/include/lang
@@ -219,6 +216,12 @@ if(SC_QT OR SC_IDE)
         target_compile_definitions(libsclang PUBLIC SC_USE_QTWEBENGINE)
     endif()
     target_link_libraries(libsclang ${QT_COLLIDER_LIBS})
+
+    # This makes sclang/scide work with a Qt installation at a fixed location.
+    if(CMAKE_SYSTEM_NAME MATCHES "Linux")
+        set_property(TARGET libsclang PROPERTY INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
+    endif()
+    set_property(TARGET libsclang PROPERTY INSTALL_RPATH_USE_LINK_PATH TRUE)
 endif()
 
 if(FALSE) # libsclang is a shared library


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->
Fixes #5294

Because `verify_app` fails for builds done with the official Qt (as opposed to the one from homebrew), we disable it by default and add a cmake switch to turn it back on.
See https://github.com/supercollider/supercollider/issues/5294#issuecomment-791988719 for more details

In this PR:
- `SC_VERIFY_APP` cmake flag is added on macOS, defaulting to OFF
  - the implementation of that flag is not the most elegant, I'm open to suggestions
- `SC_VERIFY_APP`is turned ON in CI
- `rpath` settings in cmake are defined specifically for the `libscide` and `libsclang` targets


## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review
