### PR TITLE
GitHub Actions: add macOS legacy build

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -203,13 +203,13 @@ jobs:
             shared-libscsynth: false
             artifact-suffix: 'macOS' # set if needed - will trigger artifact upload
 
-          # - job-name: 'legacy'
-          #   os-version: '10.15'
-          #   xcode-version: '10.3'
-          #   qt-version: '5.9' # will use qt not from homebrew
-          #   use-syslibs: false
-          #   shared-libscsynth: false
-          #   artifact-suffix: 'macOS-legacy' # set if needed - will trigger artifact upload
+          - job-name: 'legacy'
+            os-version: '10.15'
+            xcode-version: '10.3'
+            qt-version: '5.9.9' # will use qt from aqtinstall
+            use-syslibs: false
+            shared-libscsynth: false
+            artifact-suffix: 'macOS-legacy' # set if needed - will trigger artifact upload
 
           - job-name: 'use system libraries'
             os-version: '10.15'
@@ -261,13 +261,6 @@ jobs:
         with:
           path: ../Qt
           key: ${{ runner.os }}-v1-${{ matrix.os-version }}-${{ matrix.xcode-version }}-${{ matrix.use-syslibs }}-${{ matrix.shared-libscsynth }}-qt${{ matrix.qt-version }}
-      - name: install qt using aqtinstall
-        uses: jurplel/install-qt-action@v2
-        if: matrix.qt-version
-        with:
-          modules: 'qtwebengine'
-          version: ${{ matrix.qt-version }}
-          cached: ${{ steps.cache-qt.outputs.cache-hit }}
       - name: cleanup homebrew downloads # make sure we store only relevant downloads in cache
         if: '!steps.cache-homebrew.outputs.cache-hit'
         run: rm -rf $(brew --cache)
@@ -282,6 +275,13 @@ jobs:
       - name: install qt from homebrew
         if: '!matrix.qt-version'
         run: brew install qt5
+      - name: install qt using aqtinstall
+        uses: jurplel/install-qt-action@v2
+        if: matrix.qt-version
+        with:
+          modules: 'qtwebengine'
+          version: ${{ matrix.qt-version }}
+          cached: ${{ steps.cache-qt.outputs.cache-hit }}
 
       - name: configure
         env:
@@ -671,7 +671,7 @@ jobs:
         with:
           files: |
             ${{ env.INSTALL_PATH }}/${{ env.ARTIFACT_FILE_PREFIX }}-macOS/*
-            # ${{ env.INSTALL_PATH }}/${{ env.ARTIFACT_FILE_PREFIX }}-macOS-legacy/*
+            ${{ env.INSTALL_PATH }}/${{ env.ARTIFACT_FILE_PREFIX }}-macOS-legacy/*
             ${{ env.INSTALL_PATH }}/${{ env.ARTIFACT_FILE_PREFIX }}-win32-installer/*
             ${{ env.INSTALL_PATH }}/${{ env.ARTIFACT_FILE_PREFIX }}-win64-installer/*
             ${{ env.INSTALL_PATH }}/${{ env.ARTIFACT_FILE_PREFIX }}-win32/*

--- a/editors/sc-ide/CMakeLists.txt
+++ b/editors/sc-ide/CMakeLists.txt
@@ -344,7 +344,7 @@ target_link_libraries( libscide PUBLIC boost_system_lib boost_filesystem_lib)
 include_directories(${boost_include_dirs})
 
 # This makes sclang/scide work with a Qt installation at a fixed location.
-set_property(TARGET libscide PROPERTY INSTALL_RPATH_USE_LINK_PATH TRUE)
+set_property(TARGET libscide SuperCollider PROPERTY INSTALL_RPATH_USE_LINK_PATH TRUE)
 
 if(APPLE)
     target_link_libraries( libscide PUBLIC "-framework CoreServices -framework Foundation")
@@ -365,7 +365,7 @@ if(CMAKE_SYSTEM_NAME MATCHES "Linux")
     target_link_libraries(libscide PUBLIC ${X11_X11_LIB})
 
     # This makes sclang/scide work with a Qt installation at a fixed location.
-    set_property(TARGET libscide PROPERTY INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
+    set_property(TARGET libscide SuperCollider PROPERTY INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
 endif()
 
 if(PTHREADS_FOUND)


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->
#5294 was a roadblock in offering macOS legacy build in GitHub Actions. Now that that issue is resolved, it's possible to offer legacy build again. Legacy build uses "official" Qt distribution, since there's no easy way to add Qt 5.9 from homebrew to GH runners, which run macOS 10.15.

Deployment should work, though it was not explicitly tested for this addition.

I've also moved the position of the `aqtinstall` step to match the structure on Linux.

~~EDIT:
I guess it does not work, something is indeed wrong with the `rpath`. When trying to run the legacy build downloaded from Actions, I am getting~~

<details>

```sh
dyld: Library not loaded: @rpath/QtConcurrent.framework/Versions/5/QtConcurrent
  Referenced from: /path/to/SuperCollider.app/Contents/MacOS/SuperCollider
  Reason: image not found
```
</details>

~~Locally, I can build SC with official Qt and move it to another machine and it works...~~
## Types of changes

<!-- Delete lines that don't apply -->

- New feature (?)

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested (except for deployment)
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review
