### PR TITLE
cmake: fix verify_app switch

### DIFF
--- a/editors/sc-ide/CMakeLists.txt
+++ b/editors/sc-ide/CMakeLists.txt
@@ -552,12 +552,10 @@ if(APPLE OR WIN32)
                 ")
         endif()
 
-        string(APPEND VERIFY_CMD "
-            message(STATUS \"Verifying app\")
-            verify_app(\"${CMAKE_INSTALL_PREFIX}/SuperCollider/SuperCollider.app\")")
-
-        if(NOT SC_VERIFY_APP)
-            set(VERIFY_CMD "")
+        if(SC_VERIFY_APP)
+            string(APPEND VERIFY_CMD "
+                message(STATUS \"Verifying app\")
+                verify_app(\"${CMAKE_INSTALL_PREFIX}/SuperCollider/SuperCollider.app\")")
         endif()
     else() # WIN32
         find_program(DEPLOY_PROG windeployqt PATHS ${CMAKE_PREFIX_PATH})


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->
Addendum to #5388

Since we are adding various ["fixup" steps](https://github.com/supercollider/supercollider/blob/develop/editors/sc-ide/CMakeLists.txt#L505) to `VERIFY_CMD`, I shouldn't have completely removed it when skipping verification. This PR fixes this issue, so that only `verify_app` is conditionally included/excluded.

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review
