### PR TITLE
docs: clarify that EnvGen samples args per segment

### DIFF
--- a/HelpSource/Classes/EnvGen.schelp
+++ b/HelpSource/Classes/EnvGen.schelp
@@ -9,7 +9,8 @@ Description::
 Plays back break point envelopes. The envelopes are instances of the
 link::Classes/Env:: class. The envelope and the arguments for  code::levelScale::,
 code::levelBias::, and  code::timeScale:: are polled when the EnvGen is
-triggered and remain constant for the duration of the envelope.
+triggered, and at the start of a new envelope segment. All values remain constant
+for the duration of each segment.
 
 code::
 { PinkNoise.ar(EnvGen.kr(Env.perc, doneAction: Done.freeSelf)) }.play
@@ -27,7 +28,7 @@ An link::Classes/Env:: instance, or an Array of Controls.
 (See link::Classes/Control::  and the example below for how to use
 this.)
 
-The envelope is polled when the EnvGen is triggered. The Env inputs can be other UGens.
+The envelope is polled when the EnvGen is triggered, and at the start of a new envelope segment. The Env inputs can be other UGens.
 
 
 argument::gate


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

Clarify when EnvGen samples its inputs. The observed behavior, and inspection of [EnvGen code in LFUGens.cpp](https://github.com/supercollider/supercollider/blob/develop/server/plugins/LFUGens.cpp#L2386) reveals that EnvGen arguments and the associated envelope are sampled at the start of each segment. The existing documentation is clear about this in the descriptions of the `levelScale`, `levelBias`, and `timeScale` arguments, but the main description and the description for the `envelope` parameter are less clear.

## Types of changes

- Documentation

## To-do list

- [ ] Code is tested
- [ ] All tests are passing
- [X] Updated documentation
- [X] This PR is ready for review
