### PR TITLE
Servers: workaround for boost interprocess

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -134,8 +134,8 @@ if(WIN32)
     #avoid unnecesary autolink
     add_definitions(-DBOOST_DATE_TIME_NO_LIB -DBOOST_ALL_NO_LIB)
 
-    # define the location of shared memory ourselves, see issue 2409
-    add_definitions(-DBOOST_INTERPROCESS_SHARED_DIR_FUNC)
+    # use session manager to set shared memory locaation, see issue 2409
+    add_definitions(-DBOOST_INTERPROCESS_BOOTSTAMP_IS_SESSION_MANAGER_BASED)
 endif()
 
 add_definitions(-DBOOST_CHRONO_HEADER_ONLY -DBOOST_NO_AUTO_PTR -DBOOST_CONFIG_SUPPRESS_OUTDATED_MESSAGE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -134,6 +134,8 @@ if(WIN32)
     #avoid unnecesary autolink
     add_definitions(-DBOOST_DATE_TIME_NO_LIB -DBOOST_ALL_NO_LIB)
 
+    # define the location of shared memory ourselves, see issue 2409
+    add_definitions(-DBOOST_INTERPROCESS_SHARED_DIR_FUNC)
 endif()
 
 add_definitions(-DBOOST_CHRONO_HEADER_ONLY -DBOOST_NO_AUTO_PTR -DBOOST_CONFIG_SUPPRESS_OUTDATED_MESSAGE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -134,7 +134,7 @@ if(WIN32)
     #avoid unnecesary autolink
     add_definitions(-DBOOST_DATE_TIME_NO_LIB -DBOOST_ALL_NO_LIB)
 
-    # use session manager to set shared memory locaation, see issue 2409
+    # use session manager to set shared memory location, see issue 2409
     add_definitions(-DBOOST_INTERPROCESS_BOOTSTAMP_IS_SESSION_MANAGER_BASED)
 endif()
 

--- a/common/server_shm.hpp
+++ b/common/server_shm.hpp
@@ -32,6 +32,7 @@
 // this overrides the location of boost's shared memory, fixing an issue where missing logs
 // prevented the server from booting, see https://github.com/supercollider/supercollider/issues/2409
 #    include "SC_Filesystem.hpp"
+#    include <boost/filesystem/operations.hpp>
 namespace boost { namespace interprocess { namespace ipcdetail {
 inline void get_shared_dir(std::string& shared_dir) {
     shared_dir = SC_Filesystem::instance().getDirectory(SC_Filesystem::DirName::UserConfig).string()

--- a/common/server_shm.hpp
+++ b/common/server_shm.hpp
@@ -35,7 +35,8 @@
 #ifdef _WIN32
 namespace boost { namespace interprocess { namespace ipcdetail {
 inline void get_shared_dir(std::string& shared_dir) {
-    shared_dir = SC_Filesystem::instance().getDirectory(SC_Filesystem::DirName::Resource) + "/shm";
+    shared_dir = SC_Filesystem::instance().getDirectory(SC_Filesystem::DirName::Resource);
+    shared_dir += "/shm";
 }
 }}}
 #endif

--- a/common/server_shm.hpp
+++ b/common/server_shm.hpp
@@ -35,7 +35,9 @@
 #    include <boost/filesystem/operations.hpp>
 namespace boost { namespace interprocess { namespace ipcdetail {
 inline void get_shared_dir(std::string& shared_dir) {
-    shared_dir = (SC_Filesystem::instance().getDirectory(SC_Filesystem::DirName::UserConfig) / "boost_interprocess_shared_memory").string();
+    shared_dir =
+        (SC_Filesystem::instance().getDirectory(SC_Filesystem::DirName::UserConfig) / "BoostInterprocessSharedMemory")
+            .string();
     bool result = boost::filesystem::create_directories(shared_dir);
     if (!result) {
         throw std::runtime_error("Cannot create a directory for shared memory at " + shared_dir);

--- a/common/server_shm.hpp
+++ b/common/server_shm.hpp
@@ -35,8 +35,7 @@
 #    include <boost/filesystem/operations.hpp>
 namespace boost { namespace interprocess { namespace ipcdetail {
 inline void get_shared_dir(std::string& shared_dir) {
-    shared_dir = SC_Filesystem::instance().getDirectory(SC_Filesystem::DirName::UserConfig).string()
-        + "/boost_interprocess_shared_memory";
+    shared_dir = (SC_Filesystem::instance().getDirectory(SC_Filesystem::DirName::UserConfig) / "boost_interprocess_shared_memory").string();
     bool result = boost::filesystem::create_directories(shared_dir);
     if (!result) {
         throw std::runtime_error("Cannot create a directory for shared memory at " + shared_dir);

--- a/common/server_shm.hpp
+++ b/common/server_shm.hpp
@@ -25,13 +25,17 @@
 #include <boost/foreach.hpp>
 #include <boost/ref.hpp>
 #include <boost/lexical_cast.hpp>
+#ifdef _WIN32
+#    include "SC_Filesystem.hpp"
+#    define BOOST_INTERPROCESS_SHARED_DIR_FUNC
+#endif
 #include <boost/interprocess/managed_shared_memory.hpp>
 #include <boost/interprocess/containers/vector.hpp>
 
 #ifdef _WIN32
-#    include "SC_Filesystem.hpp"
-#    define BOOST_INTERPROCESS_SHARED_DIR_FUNC                                                                         \
-        void get_shared_dir(std::string& shared_dir) { shared_dir = SC_Filesystem::defaultResourceDirectory + "/shm" }
+namespace boost { namespace interprocess { namespace ipcdetail {
+inline void get_shared_dir(std::string& shared_dir) { shared_dir = SC_Filesystem::defaultResourceDirectory + "/shm" }
+}}}
 #endif
 
 namespace detail_server_shm {

--- a/common/server_shm.hpp
+++ b/common/server_shm.hpp
@@ -26,6 +26,8 @@
 #include <boost/ref.hpp>
 #include <boost/lexical_cast.hpp>
 #ifdef _WIN32
+// this overrides the location of boost's shared memory, fixing an issue where missing logs
+// prevented the server from booting, see https://github.com/supercollider/supercollider/issues/2409
 #    include "SC_Filesystem.hpp"
 #    define BOOST_INTERPROCESS_SHARED_DIR_FUNC
 #endif
@@ -35,7 +37,7 @@
 #ifdef _WIN32
 namespace boost { namespace interprocess { namespace ipcdetail {
 inline void get_shared_dir(std::string& shared_dir) {
-    shared_dir = SC_Filesystem::instance().getDirectory(SC_Filesystem::DirName::Resource).string() / "shm";
+    shared_dir = SC_Filesystem::instance().getDirectory(SC_Filesystem::DirName::Resource).string() + "/shm";
 }
 }}}
 #endif

--- a/common/server_shm.hpp
+++ b/common/server_shm.hpp
@@ -34,7 +34,10 @@
 
 #ifdef _WIN32
 namespace boost { namespace interprocess { namespace ipcdetail {
-inline void get_shared_dir(std::string& shared_dir) { shared_dir = SC_Filesystem::defaultResourceDirectory + "/shm" }
+inline void get_shared_dir(std::string& shared_dir) {
+    shared_dir = SC_Filesystem::defaultResourceDirectory;
+    shared_dir /= "shm";
+}
 }}}
 #endif
 

--- a/common/server_shm.hpp
+++ b/common/server_shm.hpp
@@ -28,40 +28,6 @@
 #include <boost/interprocess/managed_shared_memory.hpp>
 #include <boost/interprocess/containers/vector.hpp>
 
-// this overrides the location of boost's shared memory, fixing an issue where missing logs
-// prevented the server from booting, see https://github.com/supercollider/supercollider/issues/2409
-#ifdef BOOST_INTERPROCESS_SHARED_DIR_FUNC
-#    include "SC_Filesystem.hpp"
-#    include <boost/filesystem/operations.hpp>
-#    include <iostream>
-#    include "SC_Codecvt.hpp"
-namespace boost { namespace interprocess { namespace ipcdetail {
-inline void get_shared_dir(std::string& shared_dir) {
-    // this solution still fails if the shm file already exists and sc has no permissions to overwrite it - e.g. if it
-    // was created by another user
-    // the shm file is deleted after scsynth exits when run from scide, but NOT when
-    // run in the command prompt and stopped with ctrl+c
-    // I don't know what's the reason for not cleaning up that file in
-    // the latter situation
-    get_shared_dir_root(shared_dir); // this is C:\ProgramData\boost_interprocess
-    shared_dir += "/SuperCollider";
-
-    // user location alternative - doesn't work for users with non-ascii characters
-    // auto dir = (SC_Filesystem::instance().getDirectory(SC_Filesystem::DirName::UserConfig) /
-    // "BoostInterprocessSharedMemory"); shared_dir = SC_Codecvt::path_to_utf8_str(dir);
-    // boost::filesystem::create_directories(dir); // note boost path here - this works for non-ascii path
-    // however, shared_dir is still incorrect and while directory creation succeedes, shm creations fails later on
-
-    std::cout << shared_dir << std::endl; // debug
-    try {
-        boost::filesystem::create_directories(shared_dir);
-    } catch (const boost::filesystem::filesystem_error& error) {
-        throw std::runtime_error("Cannot create a directory for shared memory at " + shared_dir
-                                 + "\nReason: " + error.what());
-    }
-}
-}}}
-#endif
 
 namespace detail_server_shm {
 

--- a/common/server_shm.hpp
+++ b/common/server_shm.hpp
@@ -28,6 +28,12 @@
 #include <boost/interprocess/managed_shared_memory.hpp>
 #include <boost/interprocess/containers/vector.hpp>
 
+#ifdef _WIN32
+#    include "SC_Filesystem.hpp"
+#    define BOOST_INTERPROCESS_SHARED_DIR_FUNC                                                                         \
+        void get_shared_dir(std::string& shared_dir) { shared_dir = SC_Filesystem::defaultResourceDirectory + "/shm" }
+#endif
+
 namespace detail_server_shm {
 
 using std::pair;

--- a/common/server_shm.hpp
+++ b/common/server_shm.hpp
@@ -35,7 +35,7 @@
 #ifdef _WIN32
 namespace boost { namespace interprocess { namespace ipcdetail {
 inline void get_shared_dir(std::string& shared_dir) {
-    shared_dir = SC_Filesystem::instance().getDirectory(SC_Filesystem::DirName::Resource) / "shm";
+    shared_dir = SC_Filesystem::instance().getDirectory(SC_Filesystem::DirName::Resource).string() / "shm";
 }
 }}}
 #endif

--- a/common/server_shm.hpp
+++ b/common/server_shm.hpp
@@ -35,8 +35,7 @@
 #ifdef _WIN32
 namespace boost { namespace interprocess { namespace ipcdetail {
 inline void get_shared_dir(std::string& shared_dir) {
-    shared_dir = SC_Filesystem::instance().getDirectory(SC_Filesystem::DirName::Resource);
-    shared_dir += "/shm";
+    shared_dir = SC_Filesystem::instance().getDirectory(SC_Filesystem::DirName::Resource) / "shm";
 }
 }}}
 #endif

--- a/common/server_shm.hpp
+++ b/common/server_shm.hpp
@@ -35,8 +35,7 @@
 #ifdef _WIN32
 namespace boost { namespace interprocess { namespace ipcdetail {
 inline void get_shared_dir(std::string& shared_dir) {
-    shared_dir = SC_Filesystem::defaultResourceDirectory;
-    shared_dir /= "shm";
+    shared_dir = SC_Filesystem::instance().getDirectory(SC_Filesystem::DirName::Resource) + "/shm";
 }
 }}}
 #endif

--- a/common/server_shm.hpp
+++ b/common/server_shm.hpp
@@ -28,7 +28,6 @@
 #include <boost/interprocess/managed_shared_memory.hpp>
 #include <boost/interprocess/containers/vector.hpp>
 
-
 namespace detail_server_shm {
 
 using std::pair;

--- a/common/server_shm.hpp
+++ b/common/server_shm.hpp
@@ -28,18 +28,18 @@
 #include <boost/interprocess/managed_shared_memory.hpp>
 #include <boost/interprocess/containers/vector.hpp>
 
-#ifdef BOOST_INTERPROCESS_SHARED_DIR_FUNC
 // this overrides the location of boost's shared memory, fixing an issue where missing logs
 // prevented the server from booting, see https://github.com/supercollider/supercollider/issues/2409
+#ifdef BOOST_INTERPROCESS_SHARED_DIR_FUNC
 #    include "SC_Filesystem.hpp"
 #    include <boost/filesystem/operations.hpp>
 namespace boost { namespace interprocess { namespace ipcdetail {
 inline void get_shared_dir(std::string& shared_dir) {
     shared_dir = SC_Filesystem::instance().getDirectory(SC_Filesystem::DirName::UserConfig).string()
         + "/boost_interprocess_shared_memory";
-    auto result = boost::filesystem::create_directories(shared_dir);
+    bool result = boost::filesystem::create_directories(shared_dir);
     if (!result) {
-        throw std::runtime_error("Cannot create a directory for shared memory at" + shared_dir);
+        throw std::runtime_error("Cannot create a directory for shared memory at " + shared_dir);
     }
 }
 }}}

--- a/common/server_shm.hpp
+++ b/common/server_shm.hpp
@@ -37,7 +37,7 @@
 #ifdef _WIN32
 namespace boost { namespace interprocess { namespace ipcdetail {
 inline void get_shared_dir(std::string& shared_dir) {
-    shared_dir = SC_Filesystem::instance().getDirectory(SC_Filesystem::DirName::Resource).string() + "/shm";
+    shared_dir = SC_Filesystem::instance().getDirectory(SC_Filesystem::DirName::Resource).string();
 }
 }}}
 #endif


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->
It's an attempt to fix #2409
It seems that on Windows server's shared memory interface can be broken (way too easily IMO) by missing logs.
~~This PR overrides boost's shared memory creation function and uses a fixed location in SC Resource Directory.
**I'm not sure if this is the correct fix**, however I was able to reproduce the bug from #2409 (*) and I can confirm that this PR fixes it. The fix was adopted from https://stackoverflow.com/questions/39742630/boost-shared-memory-cant-be-initialized~~

EDIT: after lengthy tests and back-and-forth with @brianlheim it looks like boost also provides another method for obtaining the stamp for the shm location, enabled by defining `BOOST_INTERPROCESS_BOOTSTAMP_IS_SESSION_MANAGER_BASED`. This seems to fix the issue on my system and seems like the cleanest solution.


(*) I reproduced the bug by going to Event Viewer -> System -> Filter entries by id 6005 -> Clear Log...
## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review
