### PR TITLE
Bela: various fixes

### DIFF
--- a/README_BELA.md
+++ b/README_BELA.md
@@ -172,7 +172,7 @@ Building a Debian package for Bela
 
 - create a debian package to be installed on the board:
 ```
-cpack -G DEB -D CPACK_PACKAGE_CONTACT="Your Name <your.name@domain.com>" -D CPACK_DEBIAN_PACKAGE_ARCHITECTURE="armhf" -D CPACK_CMAKE_GENERATOR=Ninja
+cpack -G DEB -D CPACK_PACKAGE_CONTACT="Your Name <your.name@domain.com>" -D CPACK_DEBIAN_PACKAGE_ARCHITECTURE="armhf" -D CPACK_CMAKE_GENERATOR=Ninja -D CPACK_STRIP_FILES=true
 ```
 (the `CPACK_CMAKE_GENERATOR=Ninja` is a trick to prevent the `preinstall` target from rebuilding the whole thing slower (see [here](https://stackoverflow.com/a/57530945/2958741)).
 

--- a/README_LINUX.md
+++ b/README_LINUX.md
@@ -54,6 +54,7 @@ There are dedicated READMEs in this repository for building on particular embedd
 
 - Raspberry Pi: README_RASPBERRY_PI.md
 - BeagleBone Black: README_BEAGLEBONE_BLACK.md
+- Bela: README_BELA.md
 
 On Debian-like systems, the following command installs the minimal recommended dependencies for compiling scsynth and supernova:
 

--- a/server/plugins/BelaUGens.cpp
+++ b/server/plugins/BelaUGens.cpp
@@ -505,7 +505,7 @@ void DigitalIn_next_k(DigitalIn* unit, int inNumSamples) {
 void DigitalIn_Ctor(DigitalIn* unit) {
     BelaContext* context = unit->mWorld->mBelaContext;
 
-    unit->mDigitalPin = static_cast<int>(IN0(1)); // digital in pin -- cannot change after construction
+    unit->mDigitalPin = static_cast<int>(IN0(0)); // digital in pin -- cannot change after construction
     if ((unit->mDigitalPin < 0) || (unit->mDigitalPin >= context->digitalChannels)) {
         rt_fprintf(stderr, "DigitalIn error: digital pin must be between %i and %i, it is %i\n", 0,
                    context->digitalChannels, unit->mDigitalPin);


### PR DESCRIPTION
## Purpose and Motivation

Fixing some Bela related issues. The most pressing one was that `DigitalIn` was broken since a refactoring in d75aa123fa.
The others are in the docs.

## Types of changes

- Documentation: added mention of Bela to the Linux README; tell `cpack` to strip symbols.
- Bug fix: fixed `DigitalIn`

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review
