### PR TITLE
Classlib: Fix displaying labels in Plotter

### DIFF
--- a/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
+++ b/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
@@ -140,18 +140,18 @@ Plot {
 		var sbounds;
 		if(gridOnX and: { labelX.notNil }) {
 			sbounds = try { labelX.bounds(font) } ? 0;
-			Pen.font = font;
-			Pen.strokeColor = fontColor;
 			Pen.stringAtPoint(labelX,
-				plotBounds.right - sbounds.width @ plotBounds.bottom
+				plotBounds.right - sbounds.width @ plotBounds.bottom,
+				font,
+				fontColor
 			)
 		};
 		if(gridOnY and: { labelY.notNil }) {
 			sbounds = try { labelY.bounds(font) } ? 0;
-			Pen.font = font;
-			Pen.strokeColor = fontColor;
 			Pen.stringAtPoint(labelY,
-				plotBounds.left - sbounds.width - 3 @ plotBounds.top
+				plotBounds.left - sbounds.width - 3 @ plotBounds.top,
+				font,
+				fontColor
 			)
 		};
 	}


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

There was an issue with displaying labels in plots. 
An example code from ```Plotter```  help file in ```.setProperties``` method now does exactly what was inteded.
This PR fixes displaying the labels, in this case the "Humidity" string on X axis.

```
(
a = { (0..30).scramble }.dup(2).plot;
a.setProperties(
    \fontColor, Color.red,
    \plotColor, Color.blue,
    \backgroundColor, Color.black,
    \gridColorX, Color.white,
    \labelX, "Humidity"
);
a.refresh;
);

```

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix


## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [ X] Code is tested
- [X ] All tests are passing
- [X ] This PR is ready for review
