### PR TITLE
gha testsuite: remove environment variable

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -567,7 +567,6 @@ jobs:
         env:
           PYCHARM_HOSTED: 1 # enable color output
           QPM_DEBUG: 1
-          QT_PLATFORM_PLUGIN: 'offscreen'
         run: xvfb-run --server-args="-screen 0, 1280x720x24" -a qpm test.run -l $SCRIPT_RUN --path $SCLANG --include $QUARKS_PATH $TESTS_PATH
       - name: run tests on macOS
         if: runner.os == 'macOS'


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->
It seems that we don't need the `QT_PLATFORM_PLUGIN` environment variable when running tests in GHA, for two reasons:
- it is meant to be used when there's no X display, however we do run a virtual X display with `xvfb`
- looking online it seems that it should've been `QT_QPA_PLATFORM` instead anyway... `QT_QPA_PLATFORM` seems to be the variable to set if one wants to use the "offscreen" plugin. If I set `QT_QPA_PLATFORM=offscreen`, I can run `sclang` in terminal without X (on Linux)

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review
