### PR TITLE
README_LINUX.md: add note about headless operation

### DIFF
--- a/README_LINUX.md
+++ b/README_LINUX.md
@@ -288,6 +288,13 @@ to put Extensions to the class library, in a folder called Extensions.
 The runtime directory is either the current working directory or the
 path specified with the `-d` option.
 
+#### Headless operation
+
+Even though the standard distribution of SuperCollider is built with the Qt framework, `sclang` can still be run in terminal without the X server. In order to do that, the `QT_QPA_PLATFORM` environment variable needs to be set to `offscreen`:
+```shell
+$> export QT_QPA_PLATFORM=offscreen
+$> sclang
+```
 
 Environment
 -----------


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->
Document that `sclang` can be run without X server when `QT_QPA_PLATFORM` env variable is set.
This is meant to "fix" #5420


## Types of changes

<!-- Delete lines that don't apply -->

- Documentation

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review
