### PR TITLE
sclang: fix signal_thresh_xf typo

### DIFF
--- a/HelpSource/Classes/Signal.schelp
+++ b/HelpSource/Classes/Signal.schelp
@@ -401,6 +401,11 @@ y = Signal.fill(512, { |i| (i * pi / 64).sin });
 	.plot(numChannels: 6);
 )
 ::
+method::thresh
+Thresholding replaces every value < threshold with 0.
+note::
+Before SuperCollider 3.13 this function was implemented incorrectly, evaluating the square of provided threshold. This behavior is now fixed, but note that older code might give different results.
+::
 method::+, -, *, /, div, pow, mod, min, max, ring1, ring2, ring3, ring4, difsqr, sumsqr, sqrdif, absdif, amclip, scaleneg, clip2, wrap2, excess
 method:: %, **
 method:: <!

--- a/lang/LangSource/PyrSignal.cpp
+++ b/lang/LangSource/PyrSignal.cpp
@@ -213,8 +213,7 @@ PyrObject* signal_thresh_xf(VMGlobals* g, PyrObject* ina, float inb) {
     PyrObject* outc = newPyrSignal(g, ina->size);
     float* a = (float*)(ina->slots) - 1;
     float* c = (float*)(outc->slots) - 1;
-    float inb2 = inb * inb;
-    UNROLL_CODE(outc->size, c, ++a; *++c = *a < inb2 ? 0.f : *a;)
+    UNROLL_CODE(outc->size, c, ++a; *++c = *a < inb ? 0.f : *a;)
     return outc;
 }
 


### PR DESCRIPTION
## Purpose and Motivation
When calling `.thresh` on a Signal, the supplied threshold is squared:
```supercollider
Signal.sineFill(1024, [1]).thresh(0.5).reject(_==0).minItem
// -> ~0.25
// Signal.thresh zeroes out everything below threshold.squared?

// as expected SimpleNumber.thresh zeroes out everything below a threshold
({1.0.rand2}!1024).thresh(0.5).reject(_==0).minItem
// -> ~0.5
```
I would expect `thresh` to do the same operation on SimpleNumbers and Signals. Am I missing something?
The threshold gets squared only for signal_thresh_fx, in `lang/LangSource/PyrSignal.cpp`:
https://github.com/supercollider/supercollider/blob/6de068ba83587d33d06d1b21f99b7a73ef5d8997/lang/LangSource/PyrSignal.cpp#L216
It looks like a copy-paste leftover from signal_ring4_xf, which is just above. Removing this line produces the expected behavior. 

## Types of changes

<!-- Delete lines that don't apply -->
- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [ ] Updated documentation
- [x] This PR is ready for review
