### PR TITLE
fix function plot when called with unspecified arguments

### DIFF
--- a/SCClassLibrary/Common/Core/Function.sc
+++ b/SCClassLibrary/Common/Core/Function.sc
@@ -271,7 +271,7 @@ Function : AbstractFunction {
 
 		name = this.hash.asString;
 		def = SynthDef(name, { |bufnum|
-			var	val = this.value;
+			var	val = SynthDef.wrap(this);
 			if(val.isValidUGenInput.not) {
 				val.dump;
 				Error("reading signal failed: % is no valid UGen input".format(val)).throw

--- a/testsuite/classlibrary/TestFunction.sc
+++ b/testsuite/classlibrary/TestFunction.sc
@@ -36,6 +36,15 @@ TestFunction : UnitTest {
 		this.assert(obj.b == 42, "function should be able to set instance variable that has no setter");
 	}
 
+	test_plot {
+		{ |x| DC.ar(x) }.asBuffer(duration: 0.01, action: { |b|
+			b.get(3, { |val|
+				this.assertEquals(val, 0, "unspecified function arguments should pass as 0 when function is written to a buffer");
+				b.free;
+			})
+		})
+	}
+
 
 }
 


### PR DESCRIPTION
when calling a UGen function from within a SynthDef, the arguments should be converted to controls with default values. For this, we have to use `SynthDef.wrap`

<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

Fixes #5435 

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] This PR is ready for review
