### PR TITLE
[scide] Fix classname highlighting before introspection available

### DIFF
--- a/editors/sc-ide/widgets/code_editor/highlighter.cpp
+++ b/editors/sc-ide/widgets/code_editor/highlighter.cpp
@@ -208,6 +208,10 @@ void SyntaxHighlighter::highlightBlockInComment(ScLexer& lexer) {
 }
 
 void SyntaxHighlighter::highlightBlock(const QString& text) {
+    // if we don't have introspection yet don't format anything
+    if (!Main::scProcess()->introspection().introspectionAvailable())
+        return;
+
     TextBlockData* blockData = static_cast<TextBlockData*>(currentBlockUserData());
     if (!blockData) {
         blockData = new TextBlockData;

--- a/editors/sc-ide/widgets/code_editor/highlighter.cpp
+++ b/editors/sc-ide/widgets/code_editor/highlighter.cpp
@@ -68,6 +68,8 @@ SyntaxHighlighter::SyntaxHighlighter(QTextDocument* parent): QSyntaxHighlighter(
     mGlobals = SyntaxHighlighterGlobals::instance();
 
     connect(mGlobals, SIGNAL(syntaxFormatsChanged()), this, SLOT(rehighlight()));
+
+    connect(Main::scProcess(), &ScProcess::introspectionChanged, this, &SyntaxHighlighter::rehighlight);
 }
 
 void SyntaxHighlighter::highlightBlockInCode(ScLexer& lexer) {
@@ -88,6 +90,7 @@ void SyntaxHighlighter::highlightBlockInCode(ScLexer& lexer) {
 
         case Token::Class: {
             auto className = QString(lexer.text().begin() + tokenPosition, tokenLength);
+
             auto* classInstance = Main::scProcess()->introspection().findClass(className);
 
             if (classInstance != nullptr)

--- a/editors/sc-ide/widgets/code_editor/highlighter.hpp
+++ b/editors/sc-ide/widgets/code_editor/highlighter.hpp
@@ -89,7 +89,7 @@ public:
     SyntaxHighlighter(QTextDocument* parent = 0);
 
 private:
-    void highlightBlock(const QString& text);
+    void highlightBlock(const QString& text) override;
     void highlightBlockInCode(ScLexer& lexer);
     void highlightBlockInString(ScLexer& lexer);
     void highlightBlockInSymbol(ScLexer& lexer);


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

This aims to fix issue #5434.

Introduced in #4890 on develop, classnames would not highlight correctly if a file was opened before introspection was available.

This PR prevents highlighting until introspection is available, and triggers highlighting when introspection changes.

### Why did this break?
The classname highlighting was broken and formatted everything beginning with an uppercase letter.

The changes in #4890 mean that  classnames now have to exist before being highlighted, which means we need to wait for introspection before highlighting them.

### Why not use the old behaviour until introspection is available?
It would highlight things incorrectly and then magically correct itself, which could be confusing.

### Why not highlight everything else and only highlight classnames when introspection becomes available?
Ultimately, I think it would be more confusing to have a file partially highlight and then have things magically appear.

### Old behaviour
* A file would have different highlighting depending on when you opened it and the state of introspection.

### New behaviour
* No highlighting will occur until introspection is available.
* When introspection becomes available, all highlighting will be applied.

## Types of changes
- Bug fix

## To-do list
- [x] This PR is ready for review
