### PR TITLE
GHA: run hdiutil again if it fails

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -290,7 +290,10 @@ jobs:
         run: |
           cd $INSTALL_PATH
           ln -s /Applications SuperCollider/Applications
-          hdiutil create -srcfolder SuperCollider -format UDBZ $ARTIFACT_FILE # this assumes that we end up with the build in the folder SuperCollider
+           # the following assumes that we end up with the build in the folder SuperCollider
+           # hdiutil sometimes fails with "create failed - Resource busy"
+           # when that happens, we run it again
+          hdiutil create -srcfolder SuperCollider -format UDBZ $ARTIFACT_FILE || hdiutil create -srcfolder SuperCollider -format UDBZ $ARTIFACT_FILE
       - name: upload artifacts
         uses: actions/upload-artifact@v2
         if: matrix.artifact-suffix


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

We are getting random build failures on macOS while using the `hdiutil` command to create the archive, see https://github.com/supercollider/supercollider/runs/2495736121?check_suite_focus=true#step:14:15 

I couldn't find the reason of these failures... so for now I propose that we just run the command again in case it fails. 

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review
