### PR TITLE
docs: fix slider example indentation [skip ci]

### DIFF
--- a/HelpSource/Classes/Slider.schelp
+++ b/HelpSource/Classes/Slider.schelp
@@ -245,32 +245,31 @@ a.action = nil;
 subsection:: Use Slider for triggering sounds
 code::
 
-	(
-		s.waitForBoot({
-			
-			SynthDef(\pluck, { |out, freq=55|
-				Out.ar(out,
-					Pluck.ar(WhiteNoise.ar(0.06),
-						EnvGen.kr(Env.perc(0,4), 1.0, doneAction: Done.freeSelf),
-						freq.reciprocal,
-						freq.reciprocal,
-						10,
-						coef:0.1)
-				);
-			}).add;
+(
+s.waitForBoot({
+
+	SynthDef(\pluck, { |out, freq=55|
+		Out.ar(out,
+			Pluck.ar(WhiteNoise.ar(0.06),
+				EnvGen.kr(Env.perc(0,4), 1.0, doneAction: Done.freeSelf),
+				freq.reciprocal,
+				freq.reciprocal,
+				10,
+				coef:0.1)
+		);
+	}).add;
 
 
-			w = Window.new("Hold arrow keys to trigger sound",
-				Rect(300, Window.screenBounds.height - 300, 400, 100)).front;
-			a = Slider(w, Rect(50, 20, 300, 40)).value_(0.5).step_(0.05).focus
-			.action_({
-				// trigger a synth with varying frequencies
-				Synth(\pluck, [\freq, 55 + (1100 * a.value)]);
-				w.view.background_(Gradient(Color.rand,Color.rand));
-			})
-		});
-
-	)
+	w = Window.new("Hold arrow keys to trigger sound",
+		Rect(300, Window.screenBounds.height - 300, 400, 100)).front;
+	a = Slider(w, Rect(50, 20, 300, 40)).value_(0.5).step_(0.05).focus
+	.action_({
+		// trigger a synth with varying frequencies
+		Synth(\pluck, [\freq, 55 + (1100 * a.value)]);
+		w.view.background_(Gradient(Color.rand,Color.rand));
+	})
+});
+)
 ::
 
 subsection:: Change background color of Window


### PR DESCRIPTION


<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

One example had excessive indentation, which prevented code-block execution from the Help Browser

## Types of changes

<!-- Delete lines that don't apply -->

- Documentation

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review
