### PR TITLE
Fixed LTO builds failing due to incorrect flags.

### DIFF
--- a/lang/CMakeLists.txt
+++ b/lang/CMakeLists.txt
@@ -339,10 +339,14 @@ target_link_libraries(sclang ${ICU_LIBRARIES})
 target_compile_definitions(sclang PUBLIC USE_SC_TERMINAL_CLIENT)
 
 if(LTO)
-  target_compile_definitions(libsclang PUBLIC -flto -flto-report)
-
   set_property(TARGET sclang libsclang
+        APPEND PROPERTY COMPILE_FLAGS "-flto -flto-report")
+
+  set_property(TARGET sclang
         APPEND PROPERTY LINK_FLAGS "-flto -flto-report -fwhole-program")
+
+  set_property(TARGET libsclang
+        APPEND PROPERTY LINK_FLAGS "-flto -flto-report")
 endif()
 
 if(APPLE)


### PR DESCRIPTION
Original configuration would add `-D-flto -D-flto-report` to CFLAGS when building sclang, resulting in compilation failing.

## Purpose and Motivation

LTO builds don't work properly with current cmake configuration, this PR fixes this issue.

## Types of changes

- Bug fix

## To-do list

N/A, change is trivial.