### PR TITLE
GHA: don't run on docs-only changes

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -1,5 +1,17 @@
 name: CI
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+      - 'examples/**'
+      - 'HelpSource/**'
+      - 'sounds/**'
+      - '*.md'
+  pull_request:
+    paths-ignore:
+      - 'examples/**'
+      - 'HelpSource/**'
+      - 'sounds/**'
+      - '*.md'
 jobs:
   lint:
     runs-on: ubuntu-18.04


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

I'd like to propose that we limit unnecessary CI runs. 

This PR prevents GitHub Actions from running when only contents of the following paths have changed:
- `examples/**`
- `HelpSource/**`
- `sounds/**`
- `*.md` (.md files in the main directory only)

(`**` matches any character(s) including `/`, `*` matches any character(s) _except_ `/`)

Additionally, according to [GHA docs](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#onpushpull_requestpaths): `Path filters are not evaluated for pushes to tags` so this change should not have any adverse side effects on the release process, even if the last commit for the release changes files only in one of the excluded paths.

Testing if this works on a separate branch, which includes the change in this PR:
[This is a commit changing just an .schelp file pushed on top of this change](https://github.com/dyfer/supercollider/commit/12a452ce6e2801c5349f27d2593caa26da2a0483) - note that there's no CI run associated with it
[Here's another commit, changing CMakeLists.txt](https://github.com/dyfer/supercollider/commit/159f7b749cc432d5a227e46ba27d4ccb402bb0ea) - this one did trigger the CI

~~(CI failures on macOS are unrelated to this PR)~~

## Types of changes

<!-- Delete lines that don't apply -->

- New feature

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review
