### PR TITLE
Fix data race in CondVar timeout

### DIFF
--- a/SCClassLibrary/Common/Core/CondVar.sc
+++ b/SCClassLibrary/Common/Core/CondVar.sc
@@ -86,7 +86,7 @@ CondVar {
 			// if wokenThread is nil, we asssume a signal happened
 			// immediately prior to timeout and the thread is already awake
 			// no call to prWakeThread happens in this case
-			wokenThread !? { this.prWakeThread(wokenThread) };
+			if(wokenThread.notNil) { this.prWakeThread(wokenThread) };
 		};
 
 		timeoutThread.play(thisThread.clock);

--- a/SCClassLibrary/Common/Core/CondVar.sc
+++ b/SCClassLibrary/Common/Core/CondVar.sc
@@ -79,11 +79,14 @@ CondVar {
 
 			didNotTimeout = false;
 
-			// wokenThread must be non-nil. If our waiting thread is signaled before
-			// this timeout fires, the timeout routine will be stopped after prWait
-			// below and we won't get here.
+			// If our waiting thread is signaled before this timeout fires
+			// the timeout routine will be stopped after prWait below
+			// and we won't get here.
 			wokenThread = this.prRemoveWaitingThread(waitingThread);
-			this.prWakeThread(wokenThread);
+			// if wokenThread is nil, we asssume a signal happened
+			// immediately prior to timeout and the thread is already awake
+			// no call to prWakeThread happens in this case
+			wokenThread !? { this.prWakeThread(wokenThread) };
 		};
 
 		timeoutThread.play(thisThread.clock);


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

This PR fixes a data race that can happen when a `CondVar` is signaled immediately as it is timing out. The problem is easy to reproduce:

```supercollider
(
var cond = CondVar();
var test = false;
var waitTime = 1.0;

fork {
    waitTime.wait;
    cond.signalOne;
};

fork {
    cond.waitFor(waitTime, { test });
    "waitFor timed out".postln;
};
)
```

An error is thrown because the time out mechanism is trying to wake a thread that has already been woken by the signal. `this.prRemoveWaitingThread(waitingThread);` returns `nil` in this case, so `this.prWakeThread(wokenThread);` throws an error having received a `nil` value.

It doesn't look like this change has any adverse effects. `TestCondVar.sc` is still passing. I tried to write a test for this issue, but couldn't figure out a way to write one using `assertNoException`. If anyone knows how I can write a test for this, please let me know and I'll add it to this PR.

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix


## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [X] Code is tested
- [X] All tests are passing
- [ ] Updated documentation
- [X] This PR is ready for review
