### PR TITLE
Use CondVar instead of UnitTest.wait in tests

### DIFF
--- a/HelpSource/Classes/UnitTest.schelp
+++ b/HelpSource/Classes/UnitTest.schelp
@@ -271,13 +271,15 @@ For arguments, see link::#-assertException::.
 
 
 method::wait
-Wait for a condition, consider failed after maxTime. Only valid within a test (or a routine).
+Wait for a predicate function to return code::true::. Considers the test failed after code::maxTime::. Only valid within a test (or a routine).
+
+note:: It's best to avoid using this method in tests. See link::Classes/CondVar#-waitFor:: for a better option.::
 
 code::
 (
 {
 	s.reboot;
-	UnitTest.new.wait(s.serverRunning, "server failed to boot in time", 2);
+	UnitTest.new.wait({ s.serverRunning }, "server failed to boot in time", 2);
 }.fork
 )
 ::

--- a/testsuite/classlibrary/TestDocument.sc
+++ b/testsuite/classlibrary/TestDocument.sc
@@ -4,15 +4,19 @@ TestDocument : UnitTest {
 	classvar <>success;
 
 	test_new_document_runs_initAction {
-		var success = false, doc, save;
+		var condvar = CondVar();
+		var success = false;
+		var doc, save;
+
 		if(Platform.ideName == "scqt") {
 			save = Document.initAction;
 			protect {
-				Document.initAction = { success = true };
+				Document.initAction = {
+					success = true;
+					condvar.signalOne;
+				};
 				doc = Document.new;
-				// failureMessage is deliberately nil
-				// we will assert below, we don't need `wait` to call `failed` itself
-				this.wait({ success }, failureMessage: nil, maxTime: 0.2);
+				condvar.waitFor(0.2);
 				doc.close;
 			} {
 				Document.initAction = save;

--- a/testsuite/classlibrary/TestEnvGen_server.sc
+++ b/testsuite/classlibrary/TestEnvGen_server.sc
@@ -169,15 +169,19 @@ TestEnvGen_server : UnitTest {
 
 	// issue #5104
 	test_shapeHold_setEndValue {
-		var env = Env(curves: [\hold, \lin]);
-		var condition = Condition();
+		var env = Env(curve: [\hold, \lin]);
+		var condvar = CondVar();
 		var result = [];
+
 		server.bootSync;
+
 		{ EnvGen.kr(env, timeScale: 0.01, doneAction:2) }.loadToFloatArray(0.01, server){ |values|
 			result = values;
-			condition.test_(true).signal;
+			condvar.signalOne;
 		};
-		this.wait(condition, "timeout when waiting for EnvGen results from server", 0.1);
+
+		condvar.waitFor(5);
+
 		this.assert(result.any { |v| v > 0 }, "Env(curves: [\hold, \lin]) should not be rendered as silent");
 	}
 

--- a/testsuite/classlibrary/TestNode_Server.sc
+++ b/testsuite/classlibrary/TestNode_Server.sc
@@ -34,8 +34,8 @@ TestNode_Server : UnitTest {
 
 	// this one currently fails with supernova (3.9.3)
 	test_getn {
-		var setnValues, getnValues, node, timeout = 1;
-		var condition = Condition.new;
+		var setnValues, getnValues, node;
+		var condvar = CondVar();
 
 		SynthDef(\test_getn, { |control1 = 2, control2 = 22.2, control3 = 222| }).add;
 		server.sync;
@@ -50,10 +50,10 @@ TestNode_Server : UnitTest {
 		getnValues = 0;
 		node.getn(0, 3, { |values|
 			getnValues = values;
-			condition.test = true;
+			condvar.signalOne;
 		});
 
-		this.wait({ condition.test }, "getn response timed out after % seconds.".format(timeout), timeout);
+		condvar.waitFor(1);
 
 		this.assertArrayFloatEquals(getnValues, setnValues, "Node:getn works", 0.001);
 		node.free;

--- a/testsuite/classlibrary/TestOSCBundle.sc
+++ b/testsuite/classlibrary/TestOSCBundle.sc
@@ -14,17 +14,22 @@ TestOSCBundle : UnitTest {
 
 	test_doPrepare {
 		var synthDef, bundle;
-		var completed = Condition(false);
+		var condvar = CondVar();
+		var completed = false;
 
 		bundle = OSCBundle.new;
 		synthDef = Array.fill(100, { |i|
 			var def = SynthDef("TestOSCBundle" ++ i, { Silent.ar });
 			bundle.addPrepare(["/d_recv", def.asBytes])
 		});
-		bundle.doPrepare(server, { completed.test = true });
-		this.wait(completed, "% timed out waiting for bundle to be sent".format(thisMethod));
+		bundle.doPrepare(server, {
+			completed = true;
+			condvar.signalOne;
+		});
 
-		this.assertEquals(completed.test, true, "'doPrepare' sent the prepare bundle to the server");
+		condvar.waitFor(5);
+
+		this.assertEquals(completed, true, "'doPrepare' sent the prepare bundle to the server");
 	}
 
 }

--- a/testsuite/classlibrary/TestServer.sc
+++ b/testsuite/classlibrary/TestServer.sc
@@ -5,6 +5,8 @@ TestServer : UnitTest {
 	// helper method, not a test
 	sync { |size|
 		var f, condition, bundleSize;
+		var condvar = CondVar();
+
 		f = big.copyRange(0, (size ? big.size)-1);
 		bundleSize = f.bundleSize;
 
@@ -12,8 +14,8 @@ TestServer : UnitTest {
 		server.sync(condition, f, server.latency);
 
 		// 60 seconds
-		this.wait(condition, "waiting for server to finish sync", 60);
-		this.assert(true, "server synced bundle with " + f.size + "messages " + "bundleSize: " + bundleSize)
+		condvar.waitFor(60, condition.test);
+		this.assertEquals(condition.test, true, "server synced bundle with " + f.size + "messages " + "bundleSize: " + bundleSize)
 	}
 
 	test_sync5 {

--- a/testsuite/classlibrary/TestUnitTest.sc
+++ b/testsuite/classlibrary/TestUnitTest.sc
@@ -76,14 +76,14 @@ TestUnitTest : UnitTest {
 	}
 
 	test_wait {
-		var condition = Condition.new;
+		var unblock = false;
 		var r = Routine {
 			0.01.yield;
-			condition.test = true;
+			unblock = true;
 		};
 		r.play;
-		this.wait(condition, maxTime:0.02);
-		this.assert(condition.test, "UnitTest.wait should continue when test is true");
+		this.wait({ unblock }, maxTime: 0.02);
+		this.assertEquals(unblock, true, "UnitTest.wait should continue when test is true");
 	}
 
 

--- a/testsuite/classlibrary/TestWebView.sc
+++ b/testsuite/classlibrary/TestWebView.sc
@@ -64,14 +64,16 @@ TestWebView : UnitTest {
 			"[1, 2, 'hello']": [1, 2, "hello"] -> Array
 		).keysValuesDo { |jsCode, expected|
 			var expectedClass = expected.value, expectedResult = expected.key;
-			var condition = Condition(), returnedResult;
+			var returnedResult;
+			var condvar = CondVar();
 
 			WebView().runJavaScript(jsCode){ |res|
 				returnedResult = res;
-				condition.test_(true).signal
+				condvar.signalOne;
 			};
 
-			this.wait(condition, "runJavaScript() callback was not called before timeout", 0.5);
+			condvar.waitFor(0.5);
+
 			this.assertEquals(returnedResult, expectedResult,
 				"runJavaScript(\"%\") should return the expected result %"
 				.format(jsCode, expectedResult)
@@ -80,7 +82,6 @@ TestWebView : UnitTest {
 				"runJavaScript(\"%\") should return an instance of %. Returned: %"
 				.format(jsCode, expectedClass, returnedResult.class)
 			);
-			condition.test = false;
-		};
+		}
 	}
 }

--- a/testsuite/classlibrary/server/TestMixedBundleTester.sc
+++ b/testsuite/classlibrary/server/TestMixedBundleTester.sc
@@ -53,13 +53,13 @@ TestMixedBundleTester : UnitTest {
 	test_send {
 		var sent;
 		var numDefs = 100;
-		var functionFired = false;
+		var condvar = CondVar();
 
 		this.makeDefs(numDefs);
-		tester.addFunction({ functionFired = true });
+		tester.addFunction({ condvar.signalOne });
 
 		tester.send(server);
-		this.wait({ functionFired }, "% timed out while waiting".format(thisMethod));
+		condvar.waitFor(1);
 
 		// should be 100 in preparationMessages
 		this.assertEquals(MixedBundleTester.bundlesSent.size, 1, "should be 1 bundle sent");

--- a/testsuite/scripts/gha_test_run_proto.json
+++ b/testsuite/scripts/gha_test_run_proto.json
@@ -8,7 +8,13 @@
             "suite":"TestBus",
             "test":"test_get",
             "skip":true,
-            "skipReason":"UnitTest sometimes fails when run in qpm (FIXME)"
+            "skipReason":"UnitTest fails when run in qpm (FIXME)"
+        },
+        {
+            "suite":"TestBus",
+            "test":"test_getn",
+            "skip":true,
+            "skipReason":"UnitTest fails when run in qpm (FIXME)"
         },
         {
             "suite":"TestCondition",
@@ -18,7 +24,7 @@
         },
         {
             "suite":"TestCoreUGens",
-            "test":"*",
+            "test":"test_ugen_generator_equivalences",
             "skip":true,
             "skipReason":"UnitTest has bugs (FIXME)"
         },
@@ -26,7 +32,7 @@
             "suite":"TestDocument",
             "test":"*",
             "skip":true,
-            "skipReason":"UnitTest has bugs (FIXME)"
+            "skipReason":"Document tests are only valid inside the IDE"
         },
         {
             "suite":"TestDocumentEnvironment",
@@ -59,34 +65,10 @@
             "skipReason":"UnitTest fails on supernova in qpm on Linux (FIXME)"
         },
         {
-            "suite":"TestEnvGen_server",
-            "test":"test_shapeHold_setEndValue",
-            "skip":true,
-            "skipReason":"UnitTest fails on when run in qpm on Linux (FIXME)"
-        },
-        {
-            "suite":"TestFilterUGens",
-            "test":"*",
-            "skip":true,
-            "skipReason":"UnitTest has bugs (FIXME)"
-        },
-        {
-            "suite":"TestFilterUGens",
-            "test":"*",
-            "skip":true,
-            "skipReason":"UnitTest has bugs (FIXME)"
-        },
-        {
             "suite":"TestLinkClock",
             "test":"*",
             "skip":true,
             "skipReason":"UnitTest has unknown issues when run in qpm (FIXME)"
-        },
-        {
-            "suite":"TestMixedBundleTester",
-            "test":"*",
-            "skip":true,
-            "skipReason":"UnitTest has bugs (FIXME)"
         },
         {
             "suite":"TestNodeProxy",
@@ -125,12 +107,6 @@
             "skipReason":"UnitTest fails (FIXME)"
         },
         {
-            "suite":"TestNode_Server",
-            "test":"*",
-            "skip":true,
-            "skipReason":"UnitTest has bugs (FIXME)"
-        },
-        {
             "suite":"TestOSCFunc",
             "test":"test_argSizeMatching_Succeeds",
             "skip":true,
@@ -161,12 +137,6 @@
             "skipReason":"UnitTest fails (FIXME)"
         },
         {
-            "suite":"TestServer_boot",
-            "test":"*",
-            "skip":true,
-            "skipReason":"UnitTest has bugs (FIXME)"
-        },
-        {
             "suite":"TestTempoClock",
             "test":"test_nextTimeOnGrid_okAfterMeterChange",
             "skip":true,
@@ -176,13 +146,19 @@
             "suite":"TestUnitTest",
             "test":"test_setUpClass_already_happened",
             "skip":true,
-            "skipReason":"UnitTest fails (FIXME)"
+            "skipReason":"test fails when run the first time after interpreter boot"
         },
         {
             "suite":"TestWebView",
-            "test":"*",
+            "test":"test_findText_found",
             "skip":true,
-            "skipReason":"UnitTest sometimes fails when run in qpm on Linux (FIXME)"
+            "skipReason":"UnitTest sometimes fails when run in qpm"
+        },
+        {
+            "suite":"TestWebView",
+            "test":"test_findText_notFound",
+            "skip":true,
+            "skipReason":"UnitTest sometimes fails when run in qpm"
         }
     ]
 }


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

Fixes #5366

This PR removes all but one use of `UnitTest.wait` inside our test suite (the exception being testing that method itself). `CondVar` is used as a preferred alternative. I've updated the documentation, and added comments and notes pointing users towards `CondVar`.

I've also re-written the implementation of `UnitTest.wait`. This method no longer makes use of `Condition` as this Class is likely going to be deprecated in the future (or at least no longer be used inside the SC class library).

## Types of changes

<!-- Delete lines that don't apply -->

- Documentation
- Bug fix
- Breaking change (maybe?)

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [X] Code is tested
- [X] All tests are passing
- [X] Updated documentation
- [X] This PR is ready for review
