### PR TITLE
Fix bad argTemplate in Buffer.getn

### DIFF
--- a/SCClassLibrary/Common/Control/Buffer.sc
+++ b/SCClassLibrary/Common/Control/Buffer.sc
@@ -455,7 +455,7 @@ Buffer {
 			// [/b_setn, bufnum, starting index, length, ...sample values].
 			// We want the sample values, which start at index 4.
 			action.value(message[4..]);
-		}, \b_setn, server.addr, argTemplate: [bufnum, index]).oneShot;
+		}, \b_setn, server.addr, argTemplate: [bufnum, index.asInteger]).oneShot;
 		server.listSendMsg(msg)
 	}
 

--- a/testsuite/classlibrary/TestBuffer_Server.sc
+++ b/testsuite/classlibrary/TestBuffer_Server.sc
@@ -222,6 +222,27 @@ TestBuffer_Server : UnitTest {
 		this.assertArrayFloatEquals(getn_values, collection[2..3], "Buffer:getn should get the requested values from the buffer");
 	}
 
+	test_regression_getn_float {
+		var timeout, condition = Condition.new;
+		var buffer, collection;
+		var getn_values;
+
+		collection = [88.88, 8, 888.8, 8.88];
+		buffer = Buffer.sendCollection(server, collection);
+		server.sync;
+
+		// Using a float as the index should still work
+		buffer.getn(2.0, 2, { |values|
+			getn_values = values;
+		});
+
+		timeout = fork { 3.wait; condition.unhang };
+		condition.hang;
+		timeout.stop;
+
+		this.assertArrayFloatEquals(getn_values, collection[2..3], "Buffer:getn should get the requested values from the buffer");
+	}
+
 	test_getToFloatArray {
 		var timeout, condition = Condition.new;
 		var buffer, collection;


### PR DESCRIPTION
## Purpose and Motivation

There is a bug in `Buffer.getn` that causes it to not call the `action` if the index passed in is a float. This happens because the OSC message generated casts the value to an integer, but the `argTemplate` does not.

#4598 did a large pass over the Buffer methods to try to make them all properly cast to integer in the right places, but it appears that this location was missed.

To repro the issue (and verify that it is fixed):
```sc
(
s.boot;
s.waitForBoot({
  b = Buffer.alloc(s, 10);
  s.sync;
  b.getn(0.0, 10, {|msg| msg.postln}); // Doesn't print anything without this fix
});
)
```

## Types of changes

- Bug fix

## To-do list

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review
