### PR TITLE
Fix test setUpClass and tearDownClass not being called

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -494,7 +494,7 @@ jobs:
       SCLANG: ${{ github.workspace }}/${{ matrix.sclang }}
       SCRIPT_PROTO: ${{ github.workspace }}/testsuite/scripts/gha_test_run_proto.json
       SCRIPT_RUN: ${{ github.workspace }}/testsuite/scripts/run/gha_test_run.json
-      QPM_URL: git+https://github.com/supercollider/qpm.git@topic/xvfb-off
+      QPM_URL: git+https://github.com/supercollider/qpm.git@topic/testclass-setup-teardown
     steps:
       - uses: actions/checkout@v2
         with:

--- a/SCClassLibrary/Common/UnitTesting/UnitTest.sc
+++ b/SCClassLibrary/Common/UnitTesting/UnitTest.sc
@@ -14,8 +14,8 @@ UnitTest {
 			var classkey = class.asString[4..]; // drop Meta_
 			var methtests = class.findTestMethods.collectAs({ | method |
 				method.name.asString -> {
-					this.prRunWithinSetUpClass {
-						class.new.runTestMethod(method)
+					class.prRunWithinSetUpClass {
+						class.new.runTestMethod(method);
 					}
 				}
 			}, Dictionary);
@@ -37,8 +37,8 @@ UnitTest {
 		if(method.isNil) {
 			Error("Test method not found " + methodName).throw
 		};
-		this.prRunWithinSetUpClass {
-			class.new.runTestMethod(method)
+		class.prRunWithinSetUpClass {
+			class.new.runTestMethod(method);
 		}
 	}
 

--- a/testsuite/scripts/gha_test_run_proto.json
+++ b/testsuite/scripts/gha_test_run_proto.json
@@ -143,12 +143,6 @@
             "skipReason":"UnitTest fails (FIXME)"
         },
         {
-            "suite":"TestUnitTest",
-            "test":"test_setUpClass_already_happened",
-            "skip":true,
-            "skipReason":"test fails when run the first time after interpreter boot"
-        },
-        {
             "suite":"TestWebView",
             "test":"test_findText_found",
             "skip":true,


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

This PR fixes an issue where a test class' `setUpClass` and `tearDownClass` functions aren't being called. To reproduce the issue, try running the following:

```supercollider
// reboot the interpreter before running this
UnitTest.runTest("TestUnitTest:test_setUpClass_already_happened")
```

`setUpClass` and `tearDownClass` are being run on `UnitTest` not `TestUnitTest`. To fix this, I've called `prRunWithinSetUpClass` on `class` instead of `this` in a couple places inside `UnitTest`.

This seems to work, however, I'd appreciate having another pair of eyes on this. I can't tell if this change will have any unforeseen side-effects, or if the same change needs to be made elsewhere.

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [X] Code is tested
- [X] All tests are passing
- [ ] Updated documentation
- [X] This PR is ready for review
