### PR TITLE
gha macos: run hdiutil again if it fails

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -298,8 +298,9 @@ jobs:
           cp ../../package/background_2_arrow.png SuperCollider/.background/background_2_arrow.png
           cp ../../package/ds_store SuperCollider/.DS_Store
           # the following assumes that we end up with the build in the folder SuperCollider
-          # we ignore the occasional hdiutil failure when unmounting the volume
-          hdiutil create -srcfolder SuperCollider -format UDZO $ARTIFACT_FILE || true
+          # hdiutil sometimes fails with "create failed - Resource busy"
+          # when that happens, we run it again
+          hdiutil create -srcfolder SuperCollider -format UDZO $ARTIFACT_FILE || hdiutil create -srcfolder SuperCollider -format UDZO $ARTIFACT_FILE
       - name: upload artifacts
         uses: actions/upload-artifact@v2
         if: matrix.artifact-suffix


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

It seems that macOS builds [fail again](https://github.com/supercollider/supercollider/runs/2713058604?check_suite_focus=true#step:14:20) due to an issue with `hdiutil`.

My assumption in #5462 was incorrect - `hdiutil` sometimes fails _before_, not after creating an image. This PR brings back the fix (more like a workaround) introduced in #5439.

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [ ] Code is tested
- [ ] All tests are passing
- [ ] Updated documentation
- [x] This PR is ready for review
