### PR TITLE
Made Supernova bind to the specified address, instead of always liste…

### DIFF
--- a/HelpSource/Classes/Server.schelp
+++ b/HelpSource/Classes/Server.schelp
@@ -386,6 +386,10 @@ method:: hasShmInterface
 Returns true if a link::Classes/ServerShmInterface:: is available. See also link::Classes/Bus#Synchronous control bus methods::.
 The shared memory interface is initialized after first server boot.
 
+warning::
+Currently, the shared memory interface treats server port as an unique identifier. In the rare case when there are multiple servers running on the same machine and listening on the same port, this leads to the shared memory interface of one of the servers being overwritten by the other.
+::
+
 method:: serverBooting
 code::true:: if the server is booting, code::false:: otherwise.
 

--- a/HelpSource/Classes/ServerOptions.schelp
+++ b/HelpSource/Classes/ServerOptions.schelp
@@ -98,7 +98,7 @@ The IP address that the server's TCP or UDP socket is listening on. The default 
 warning::
 Until SuperCollider 3.10.3, this was set to code::"0.0.0.0":: (listen on all network interfaces). However, this is a dangerous default configuration — for most users working on laptops connected to WiFi, this means that anyone on your local network can send OSC messages to the server. code::"0.0.0.0":: is only useful if you are running networked server/client, and only safe if your networking is properly configured.
 
-Until SuperCollider 3.12.x supernova listened to all network interfaces and ignored the code::bindAddress:: option. In later versions the behavior is identical to scsynth. 
+Before SuperCollider 3.12 supernova listened to all network interfaces and ignored the code::bindAddress:: option. In later versions the behavior is identical to scsynth. 
 ::
 
 method:: remoteControlVolume

--- a/HelpSource/Classes/ServerOptions.schelp
+++ b/HelpSource/Classes/ServerOptions.schelp
@@ -93,12 +93,12 @@ method:: protocol
 A Symbol representing the communications protocol. Either code::\udp:: or code::\tcp::. The default is code::\udp::.
 
 method:: bindAddress
-scsynth only. The IP address that the server's TCP or UDP socket is listening on. The default value is code::"127.0.0.1"::, meaning only listen to OSC messages on the host.
+The IP address that the server's TCP or UDP socket is listening on. The default value is code::"127.0.0.1"::, meaning only listen to OSC messages on the host.
 
 warning::
 Until SuperCollider 3.10.3, this was set to code::"0.0.0.0":: (listen on all network interfaces). However, this is a dangerous default configuration — for most users working on laptops connected to WiFi, this means that anyone on your local network can send OSC messages to the server. code::"0.0.0.0":: is only useful if you are running networked server/client, and only safe if your networking is properly configured.
 
-supernova always listens to all network interfaces, and ignores the code::bindAddress:: option. This cannot be configured. To avoid exposing yourself to security issues, you should switch to scsynth, or disable networking on your machine when running supernova.
+Until SuperCollider 3.12.x supernova listened to all network interfaces and ignored the code::bindAddress:: option. In later versions the behavior is identical to scsynth. 
 ::
 
 method:: remoteControlVolume

--- a/common/server_shm.hpp
+++ b/common/server_shm.hpp
@@ -39,6 +39,8 @@ namespace bi = boost::interprocess;
 using bi::managed_shared_memory;
 using bi::shared_memory_object;
 
+// FIXME: In case of multiple supernova instances on the same port (e.g. when running on
+// different interfaces), they can end up using the same shmem location.
 static inline string make_shmem_name(unsigned int port_number) {
     return string("SuperColliderServer_") + boost::lexical_cast<string>(port_number);
 }

--- a/server/supernova/sc/sc_osc_handler.cpp
+++ b/server/supernova/sc/sc_osc_handler.cpp
@@ -580,29 +580,29 @@ void sc_scheduled_bundles::execute_bundles(time_tag const& last, time_tag const&
 }
 
 
-void sc_osc_handler::open_tcp_acceptor(tcp const& protocol, unsigned int port) {
+void sc_osc_handler::open_tcp_acceptor(tcp const& protocol, string host, unsigned int port) {
     tcp_acceptor_.open(protocol);
 
-    tcp_acceptor_.bind(tcp::endpoint(protocol, port));
+    tcp_acceptor_.bind(tcp::endpoint(address::from_string(host), port));
     tcp_acceptor_.listen();
     start_tcp_accept();
 }
 
-void sc_osc_handler::open_udp_socket(udp const& protocol, unsigned int port) {
+void sc_osc_handler::open_udp_socket(udp const& protocol, string host, unsigned int port) {
     sc_notify_observers::udp_socket.open(protocol);
-    sc_notify_observers::udp_socket.bind(udp::endpoint(protocol, port));
+    sc_notify_observers::udp_socket.bind(udp::endpoint(address::from_string(host), port));
 }
 
-bool sc_osc_handler::open_socket(int family, int type, int protocol, unsigned int port) {
+bool sc_osc_handler::open_socket(int family, int type, int protocol, string host, unsigned int port) {
     try {
         if (protocol == IPPROTO_TCP) {
             if (type != SOCK_STREAM)
                 return false;
 
             if (family == AF_INET)
-                open_tcp_acceptor(tcp::v4(), port);
+                open_tcp_acceptor(tcp::v4(), host, port);
             else if (family == AF_INET6)
-                open_tcp_acceptor(tcp::v6(), port);
+                open_tcp_acceptor(tcp::v6(), host, port);
             else
                 return false;
             return true;
@@ -611,9 +611,9 @@ bool sc_osc_handler::open_socket(int family, int type, int protocol, unsigned in
                 return false;
 
             if (family == AF_INET)
-                open_udp_socket(udp::v4(), port);
+                open_udp_socket(udp::v4(), host, port);
             else if (family == AF_INET6)
-                open_udp_socket(udp::v6(), port);
+                open_udp_socket(udp::v6(), host, port);
             else
                 return false;
             start_receive_udp();

--- a/server/supernova/sc/sc_osc_handler.cpp
+++ b/server/supernova/sc/sc_osc_handler.cpp
@@ -581,7 +581,7 @@ void sc_scheduled_bundles::execute_bundles(time_tag const& last, time_tag const&
 
 
 void sc_osc_handler::open_tcp_acceptor(ip::address address, unsigned int port) {
-    if(address.is_v6())
+    if (address.is_v6())
         tcp_acceptor_.open(tcp::v6());
     else
         tcp_acceptor_.open(tcp::v4());
@@ -592,7 +592,7 @@ void sc_osc_handler::open_tcp_acceptor(ip::address address, unsigned int port) {
 }
 
 void sc_osc_handler::open_udp_socket(ip::address address, unsigned int port) {
-    if(address.is_v6())
+    if (address.is_v6())
         sc_notify_observers::udp_socket.open(udp::v6());
     else
         sc_notify_observers::udp_socket.open(udp::v4());

--- a/server/supernova/sc/sc_osc_handler.hpp
+++ b/server/supernova/sc/sc_osc_handler.hpp
@@ -179,9 +179,9 @@ private:
 class sc_osc_handler : private detail::network_thread, public sc_notify_observers {
     /* @{ */
     /** constructor helpers */
-    void open_tcp_acceptor(tcp const& protocol, unsigned int port);
-    void open_udp_socket(udp const& protocol, unsigned int port);
-    bool open_socket(int family, int type, int protocol, unsigned int port);
+    void open_tcp_acceptor(tcp const& protocol, std::string host, unsigned int port);
+    void open_udp_socket(udp const& protocol, std::string host, unsigned int port);
+    bool open_socket(int family, int type, int protocol, std::string host, unsigned int port);
     /* @} */
 
 public:
@@ -190,9 +190,9 @@ public:
         tcp_acceptor_(detail::network_thread::io_service_),
         tcp_password_(args.server_password.size() ? args.server_password.c_str() : nullptr) {
         if (!args.non_rt) {
-            if (args.tcp_port && !open_socket(AF_INET, SOCK_STREAM, IPPROTO_TCP, args.tcp_port))
+            if (args.tcp_port && !open_socket(AF_INET, SOCK_STREAM, IPPROTO_TCP, args.socket_address, args.tcp_port))
                 throw std::runtime_error("cannot open socket");
-            if (args.udp_port && !open_socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP, args.udp_port))
+            if (args.udp_port && !open_socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP, args.socket_address, args.udp_port))
                 throw std::runtime_error("cannot open socket");
         }
     }

--- a/server/supernova/sc/sc_osc_handler.hpp
+++ b/server/supernova/sc/sc_osc_handler.hpp
@@ -179,9 +179,9 @@ private:
 class sc_osc_handler : private detail::network_thread, public sc_notify_observers {
     /* @{ */
     /** constructor helpers */
-    void open_tcp_acceptor(tcp const& protocol, std::string host, unsigned int port);
-    void open_udp_socket(udp const& protocol, std::string host, unsigned int port);
-    bool open_socket(int family, int type, int protocol, std::string host, unsigned int port);
+    void open_tcp_acceptor(ip::address address, unsigned int port);
+    void open_udp_socket(ip::address address, unsigned int port);
+    bool open_socket(int protocol, ip::address address, unsigned int port);
     /* @} */
 
 public:
@@ -190,9 +190,9 @@ public:
         tcp_acceptor_(detail::network_thread::io_service_),
         tcp_password_(args.server_password.size() ? args.server_password.c_str() : nullptr) {
         if (!args.non_rt) {
-            if (args.tcp_port && !open_socket(AF_INET, SOCK_STREAM, IPPROTO_TCP, args.socket_address, args.tcp_port))
+            if (args.tcp_port && !open_socket(IPPROTO_TCP, args.socket_address, args.tcp_port))
                 throw std::runtime_error("cannot open socket");
-            if (args.udp_port && !open_socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP, args.socket_address, args.udp_port))
+            if (args.udp_port && !open_socket(IPPROTO_UDP, args.socket_address, args.udp_port))
                 throw std::runtime_error("cannot open socket");
         }
     }

--- a/server/supernova/server/server.cpp
+++ b/server/supernova/server/server.cpp
@@ -45,7 +45,10 @@ namespace nova {
 class nova_server* instance = nullptr;
 
 nova_server::nova_server(server_arguments const& args):
+    // FIXME: In case of multiple supernova instances on the same port (e.g. when running on
+    // different interfaces), they can end up using the same shmem location.
     server_shared_memory_creator(args.port(), args.control_busses),
+
     scheduler<thread_init_functor>(args.threads, !args.non_rt),
     buffer_manager(args.buffers),
     sc_osc_handler(args) {

--- a/server/supernova/server/server_args.cpp
+++ b/server/supernova/server/server_args.cpp
@@ -75,7 +75,8 @@ server_arguments::server_arguments(int argc, char* argv[]) {
 #endif
         ("restricted-path,P", value<vector<string> >(&restrict_paths), "if specified, prevents file-accessing OSC commands from accessing files outside <restricted-path>")
         ("threads,T", value<uint16_t>(&threads)->default_value(boost::thread::physical_concurrency()), "number of audio threads")
-        ("socket-address,B", value<string>()->default_value("127.0.0.1"), "reserved (not used)")
+        ("socket-address,B", value<string>(&socket_address)->default_value("127.0.0.1"), "Bind the UDP or TCP socket to this address.\n"
+                                                            "Set to 0.0.0.0 to listen on all interfaces.")
         ;
 
     options_description audio_options("audio options");

--- a/server/supernova/server/server_args.cpp
+++ b/server/supernova/server/server_args.cpp
@@ -137,7 +137,8 @@ server_arguments::server_arguments(int argc, char* argv[]) {
     try {
         socket_address = boost::asio::ip::make_address(vm["socket-address"].as<std::string>());
     } catch (boost::exception const& e) {
-        cout << "Cannot parse `" << vm["socket-address"].as<std::string>() << "` as a valid IP address. Exiting." << endl;
+        cout << "Cannot parse `" << vm["socket-address"].as<std::string>() << "` as a valid IP address. Exiting."
+             << endl;
         std::exit(EXIT_FAILURE);
     };
 }

--- a/server/supernova/server/server_args.cpp
+++ b/server/supernova/server/server_args.cpp
@@ -75,7 +75,7 @@ server_arguments::server_arguments(int argc, char* argv[]) {
 #endif
         ("restricted-path,P", value<vector<string> >(&restrict_paths), "if specified, prevents file-accessing OSC commands from accessing files outside <restricted-path>")
         ("threads,T", value<uint16_t>(&threads)->default_value(boost::thread::physical_concurrency()), "number of audio threads")
-        ("socket-address,B", value<string>(&socket_address)->default_value("127.0.0.1"), "Bind the UDP or TCP socket to this address.\n"
+        ("socket-address,B", value<string>(&socket_address_str)->default_value("127.0.0.1"), "Bind the UDP or TCP socket to this address.\n"
                                                             "Set to 0.0.0.0 to listen on all interfaces.")
         ;
 
@@ -133,6 +133,13 @@ server_arguments::server_arguments(int argc, char* argv[]) {
 
     if (vm.count("hardware-device-name"))
         hw_name = vm["hardware-device-name"].as<std::vector<std::string>>();
+
+    try {
+        socket_address = boost::asio::ip::make_address(vm["socket-address"].as<std::string>());
+    } catch (boost::exception const& e) {
+        cout << "Cannot parse `" << vm["socket-address"].as<std::string>() << "` as a valid IP address. Exiting." << endl;
+        std::exit(EXIT_FAILURE);
+    };
 }
 
 std::unique_ptr<server_arguments> server_arguments::instance_;

--- a/server/supernova/server/server_args.hpp
+++ b/server/supernova/server/server_args.hpp
@@ -23,6 +23,8 @@
 #include <vector>
 #include <memory>
 
+#include <boost/asio.hpp>
+
 namespace nova {
 
 class server_arguments {
@@ -47,7 +49,8 @@ public:
     }
 
     uint32_t udp_port, tcp_port;
-    std::string socket_address;
+    std::string socket_address_str;
+    boost::asio::ip::address socket_address;
 
     uint32_t control_busses, audio_busses;
     uint32_t blocksize, samplerate;

--- a/server/supernova/server/server_args.hpp
+++ b/server/supernova/server/server_args.hpp
@@ -47,6 +47,8 @@ public:
     }
 
     uint32_t udp_port, tcp_port;
+    std::string socket_address;
+
     uint32_t control_busses, audio_busses;
     uint32_t blocksize, samplerate;
     int32_t hardware_buffer_size;


### PR DESCRIPTION
…ning on all interfaces.

<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

Fixes #4864

Supernova currently binds to 0.0.0.0 regardless of address provided in arguments. This PR makes it honor user supplied address, as well as binding on 127.0.0.1 by default.

As @brianlheim pointed out in #4864, this fix can potentially cause issues if there are multiple supernova servers running on same port but different interfaces. I think it's worth to create a separate issue to discuss how this can be fixed, possibly in a different PR. 

## Types of changes

<!-- Delete lines that don't apply -->

- New feature
- Breaking change

This PR changes the default (insecure) behavior, by making supernova listen on 127.0.0.1 when no address is supplied. The security improvement, as well as making supernova behave more like scsynth should justify this change.

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review
