### PR TITLE
docs: Server.remote example bug

### DIFF
--- a/HelpSource/Classes/Server.schelp
+++ b/HelpSource/Classes/Server.schelp
@@ -75,7 +75,7 @@ s.boot;
 // on remote machine connecting to server
 (
 o = ServerOptions.new;
-o.options.maxLogins = 2;
+o.maxLogins = 2;
 t = Server.remote(\remote, NetAddr("192.168.0.130", 57110), o); // set to correct address and port
 // info about returned client ID should be posted in the post window
 t.makeWindow; // make a window for monitoring


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation
Fix for Server.remote example. SeverOptions object is already an holder for 'options' so this is fix for this small mistake.

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes



<!-- Delete lines that don't apply -->

- Documentation


## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [X] Code is tested
- [X] Updated documentation
- [X] This PR is ready for review
