### PR TITLE
QWebView: added ability to set scrollPosition of QcWebView

### DIFF
--- a/QtCollider/widgets/QcWebView.h
+++ b/QtCollider/widgets/QcWebView.h
@@ -116,8 +116,12 @@ public:
     Q_PROPERTY(QSizeF contentsSize READ contentsSize)
     QSizeF contentsSize() const { return page() ? page()->contentsSize() : QSizeF(0, 0); }
 
-    Q_PROPERTY(QPointF scrollPosition READ scrollPosition)
+    Q_PROPERTY(QPointF scrollPosition READ scrollPosition WRITE setScrollPosition)
     QPointF scrollPosition() const { return page() ? page()->scrollPosition() : QPointF(0, 0); }
+    void setScrollPosition(QPointF p) {
+        if (page())
+            page()->runJavaScript(QString("window.scrollTo(%1, %2);").arg(p.rx()).arg(p.ry()));
+    }
 
     Q_PROPERTY(bool audioMuted READ isAudioMuted WRITE setAudioMuted)
     bool isAudioMuted() const { return page() ? page()->isAudioMuted() : false; }

--- a/SCClassLibrary/Common/GUI/Base/QWebView.sc
+++ b/SCClassLibrary/Common/GUI/Base/QWebView.sc
@@ -253,7 +253,7 @@ WebView : View {
 	contentsSize { ^this.getProperty('contentsSize') }
 
 	scrollPosition { ^this.getProperty('scrollPosition') }
-	scrollPosition_ { |point| ^this.setProperty('scrollPosition', point) }
+	scrollPosition_ { |point| ^this.setProperty('scrollPosition', point / this.zoom) }
 
 	audioMuted { ^this.getProperty('audioMuted') }
 	audioMuted_ { |muted| this.setProperty('audioMuted', muted) }

--- a/SCClassLibrary/Common/GUI/Base/QWebView.sc
+++ b/SCClassLibrary/Common/GUI/Base/QWebView.sc
@@ -253,6 +253,7 @@ WebView : View {
 	contentsSize { ^this.getProperty('contentsSize') }
 
 	scrollPosition { ^this.getProperty('scrollPosition') }
+	scrollPosition_ { |point| ^this.setProperty('scrollPosition', point) }
 
 	audioMuted { ^this.getProperty('audioMuted') }
 	audioMuted_ { |muted| this.setProperty('audioMuted', muted) }


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation
WebView scrollPosition setter was not impemented even it was in docs. 
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes
This small example demonstrates what it does:

```
(
    ~webview = WebView();
    ~webview.url = "https://ferokiraly.com";
    View(bounds:900@700).layout_(VLayout(~webview)).front;
)


~webview.zoom_(1)
~webview.scrollPosition
~webview.scrollPosition_(0@504) // scroll it  !
~webview.scrollPosition // 0@504
~webview.zoom_(2)
~webview.scrollPosition_(0@0) // scrolls correctly back to top
~webview.zoom_(1) // zooms back


```

<!-- Delete lines that don't apply -->



- New feature


## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] This PR is ready for review
