### PR TITLE
ServerPlusGUI: defer GUI updates

### DIFF
--- a/SCClassLibrary/Common/GUI/PlusGUI/Control/ServerPlusGUI.sc
+++ b/SCClassLibrary/Common/GUI/PlusGUI/Control/ServerPlusGUI.sc
@@ -135,19 +135,23 @@
 
 		if (isLocal) {
 			running = {
-				active.stringColor_(Color.new255(74, 120, 74));
-				active.string = "running";
-				booter.setProperty(\value,1);
-				recorder.enabled = true;
+				defer {
+					active.stringColor_(Color.new255(74, 120, 74));
+					active.string = "running";
+					booter.setProperty(\value,1);
+					recorder.enabled = true;
+				}
 			};
 			stopped = {
-				active.stringColor_(Color.grey(0.3));
-				active.string = "inactive";
-				stopDump.value;
-				booter.setProperty(\value,0);
-				recorder.setProperty(\value,0);
-				recorder.enabled = false;
-				countsViews.do(_.string = "");
+				defer {
+					active.stringColor_(Color.grey(0.3));
+					active.string = "inactive";
+					stopDump.value;
+					booter.setProperty(\value,0);
+					recorder.setProperty(\value,0);
+					recorder.enabled = false;
+					countsViews.do(_.string = "");
+				}
 			};
 			booting = {
 				active.stringColor_(Color.new255(255, 140, 0));
@@ -185,13 +189,17 @@
 
 		} {
 			running = {
-				active.stringColor_(Color.new255(74, 120, 74));
-				active.string = "running";
-				active.background = Color.clear;
+				defer {
+					active.stringColor_(Color.new255(74, 120, 74));
+					active.string = "running";
+					active.background = Color.clear;
+				}
 			};
 			stopped = {
-				active.stringColor_(Color.grey(0.5));
-				active.string = "inactive";
+				defer {
+					active.stringColor_(Color.grey(0.5));
+					active.string = "inactive";
+				}
 			};
 			booting = {
 				active.stringColor_(Color.new255(255, 140, 0));


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

Fixes #5485 

Before this fix, the following would cause `ERROR: Qt: You can not use this Qt functionality in the current thread. Try scheduling on AppClock instead. (...)`:
```supercollider
(
(Server.program + ServerOptions().maxLogins_(10).asOptionsString).unixCmd;
Server.default.makeGui;
)

// recompile class library

// after recompile run
Server.default.makeGui;
```
See the issue for more information.

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review
