### PR TITLE
Better function flop implementation that works with string ellipsis and keyword arguments

### DIFF
--- a/HelpSource/Classes/Function.schelp
+++ b/HelpSource/Classes/Function.schelp
@@ -281,14 +281,7 @@ f.value(2, 3);
 
 method::envirFlop
 
-like flop, but implements an environment argument passing (valueEnvir).
-Less efficient in generation than flop, but not a big difference in evaluation.
-
-code::
-f = { |a| if(a > 0) { a + 1 } { -inf } }.envirFlop;
-e = (a: [20, 40]);
-e.use { f.value }
-::
+This method is kept for backward compatibility. Use code::flop:: instead.
 
 
 method::inEnvir

--- a/SCClassLibrary/Common/Core/Function.sc
+++ b/SCClassLibrary/Common/Core/Function.sc
@@ -248,13 +248,33 @@ Function : AbstractFunction {
 		}
 	}
 
-	makeFlopFunc {
+	makeFlopFuncString {
+		var ellipsisArgName, valueBlock, i, argBlock;
 		if(def.argNames.isNil) { ^this };
 
-		^interpret(
-			"#{ arg " ++ " " ++ def.argumentString(true) ++ "; "
-			++ "[ " ++ def.argumentString(false) ++ " ].flop };"
-		)
+		argBlock = def.argumentString(withDefaultValues: true, withEllipsis: true);
+		valueBlock = def.argumentString(withDefaultValues: false, withEllipsis: false);
+
+		if(def.varArgs) { // ellipsis arguments
+			i = valueBlock.findBackwards(" ");
+			if(i.isNil) { // just one argument, no space
+				ellipsisArgName = valueBlock;
+				valueBlock = ""
+			} {
+				ellipsisArgName = valueBlock[i + 1..];
+				valueBlock = valueBlock[..i];
+			};
+			valueBlock = "([%] ++ %).flop".format(valueBlock, ellipsisArgName)
+		} {
+
+			valueBlock = "[%].flop".format(valueBlock)
+		};
+
+		^"#{ arg %; % }".format(argBlock, valueBlock);
+	}
+
+	makeFlopFunc {
+		^this.makeFlopFuncString.interpret
 	}
 
 	// attach the function to a specific environment

--- a/SCClassLibrary/Common/Core/Function.sc
+++ b/SCClassLibrary/Common/Core/Function.sc
@@ -237,9 +237,7 @@ Function : AbstractFunction {
 
 
 	flop {
-		var code;
-		if(def.argNames.isNil) { ^this };
-		code = this.makeFlopFuncString({ |str|
+		var code = this.makeFlopFuncString({ |str|
 			"%.collect { |item| func.valueArray(item) }".format(str)
 		});
 		^"{ |func| % }".format(code).interpret.value(this)
@@ -251,7 +249,9 @@ Function : AbstractFunction {
 
 	makeFlopFuncString { |modifier|
 		var functionBlock, valueBlock, callBlock, argBlock, singleArgument, i;
-		if(def.argNames.isNil) { ^this };
+		if(def.argNames.isNil) {
+			^"[func.value]"
+		};
 
 		argBlock = def.argumentString(withDefaultValues: true, withEllipsis: true);
 		valueBlock = def.argumentString(withDefaultValues: false, withEllipsis: false);

--- a/SCClassLibrary/Common/Core/Function.sc
+++ b/SCClassLibrary/Common/Core/Function.sc
@@ -249,7 +249,7 @@ Function : AbstractFunction {
 	}
 
 	makeFlopFuncString {
-		var ellipsisArgName, valueBlock, i, argBlock;
+		var ellipsisArgName, valueBlock, i, argBlock, singleArgument;
 		if(def.argNames.isNil) { ^this };
 
 		argBlock = def.argumentString(withDefaultValues: true, withEllipsis: true);
@@ -257,16 +257,17 @@ Function : AbstractFunction {
 
 		if(def.varArgs) { // ellipsis arguments
 			i = valueBlock.findBackwards(" ");
-			if(i.isNil) { // just one argument, no space
+			singleArgument = i.isNil; // just one argument, no space
+			if(singleArgument) {
 				ellipsisArgName = valueBlock;
-				valueBlock = ""
+				valueBlock = "%.flop".format(valueBlock)
 			} {
 				ellipsisArgName = valueBlock[i + 1..];
 				valueBlock = valueBlock[..i];
+				valueBlock = "([% %.flop]).flop".format(valueBlock, ellipsisArgName)
 			};
-			valueBlock = "([%] ++ %).flop".format(valueBlock, ellipsisArgName)
-		} {
 
+		} {
 			valueBlock = "[%].flop".format(valueBlock)
 		};
 

--- a/SCClassLibrary/Common/Core/Function.sc
+++ b/SCClassLibrary/Common/Core/Function.sc
@@ -262,9 +262,11 @@ Function : AbstractFunction {
 			} {
 				i = valueBlock.findBackwards(" ");
 				callBlock =
-				"\nvar res = [%], ell = %;\n"
-				"if(ell.notNil) { res = res.add(ell.flop) };\n"
-				"res.flop\n";
+				"\nvar res = [%], ell = %, ellSize = ell.size;\n"
+				"res = res ++ ell;\n"
+				"res = res.flop\n";
+				// after flop, we have to repack the ellipsis array again
+				"if(ellSize > 0) { res = res.collect { |x| x.drop(ellSize.neg).add(res.keep(ellSize.neg)) } };\n";
 				functionBlock = callBlock.format(valueBlock[..i], valueBlock[i + 1..])
 			}
 		} {
@@ -272,7 +274,7 @@ Function : AbstractFunction {
 		};
 		if(modifier.notNil) { functionBlock = modifier.value(functionBlock) };
 
-		^"{ arg %; % }".format(argBlock, functionBlock);
+		^"{ arg %; % }".format(argBlock, functionBlock)
 	}
 
 	makeFlopFunc {

--- a/SCClassLibrary/Common/Core/Function.sc
+++ b/SCClassLibrary/Common/Core/Function.sc
@@ -235,20 +235,18 @@ Function : AbstractFunction {
 
 	// multichannel expand function return values
 
+
 	flop {
+		var code;
 		if(def.argNames.isNil) { ^this };
-		^this.flopInterpret
+		code = this.makeFlopFuncString({ |str|
+			"%.collect { |item| func.valueArray(item) }".format(str)
+		});
+		^"{ |func| % }".format(code).interpret.value(this)
 	}
 
 	envirFlop {
 		^this.flop
-	}
-
-	flopInterpret {
-		var code = this.makeFlopFuncString({ |str|
-			"%.collect { |item| func.valueArray(item) }".format(str)
-		});
-		^"{ |func| % }".format(code).interpret.value(this)
 	}
 
 	makeFlopFuncString { |modifier|

--- a/SCClassLibrary/Common/Core/Function.sc
+++ b/SCClassLibrary/Common/Core/Function.sc
@@ -249,29 +249,28 @@ Function : AbstractFunction {
 	}
 
 	makeFlopFuncString {
-		var ellipsisArgName, valueBlock, i, argBlock, singleArgument;
+		var functionBlock, valueBlock, i, callBlock, argBlock, singleArgument;
 		if(def.argNames.isNil) { ^this };
 
 		argBlock = def.argumentString(withDefaultValues: true, withEllipsis: true);
 		valueBlock = def.argumentString(withDefaultValues: false, withEllipsis: false);
 
 		if(def.varArgs) { // ellipsis arguments
-			i = valueBlock.findBackwards(" ");
-			singleArgument = i.isNil; // just one argument, no space
-			if(singleArgument) {
-				ellipsisArgName = valueBlock;
-				valueBlock = "%.flop".format(valueBlock)
+			if(def.argNames.size == 1) { // single ellipsis like { |...args| }
+				functionBlock = "%.flop".format(valueBlock)
 			} {
-				ellipsisArgName = valueBlock[i + 1..];
-				valueBlock = valueBlock[..i];
-				valueBlock = "([% %.flop]).flop".format(valueBlock, ellipsisArgName)
-			};
-
+				i = valueBlock.findBackwards(" ");
+				callBlock =
+				"\nvar res = [%], ell = %;\n"
+				"if(ell.notNil) { res = res.add(ell.flop) };\n"
+				"res.flop\n";
+				functionBlock = callBlock.format(valueBlock[..i], valueBlock[i + 1..])
+			}
 		} {
-			valueBlock = "[%].flop".format(valueBlock)
+			functionBlock = "[%].flop".format(valueBlock)
 		};
 
-		^"#{ arg %; % }".format(argBlock, valueBlock);
+		^"#{ arg %; % }".format(argBlock, functionBlock);
 	}
 
 	makeFlopFunc {

--- a/SCClassLibrary/Common/Core/Function.sc
+++ b/SCClassLibrary/Common/Core/Function.sc
@@ -240,16 +240,19 @@ Function : AbstractFunction {
 		^{ |... args| args.flop.collect(this.valueArray(_)) }
 	}
 
-
-	envirFlop {
-		var func = this.makeFlopFunc;
-		^{ |... args|
-			func.valueArrayEnvir(args).collect(this.valueArray(_))
-		}
+	flopInterpret {
+		var code = this.makeFlopFuncString({ |str|
+			"%.collect { |item| func.valueArray(item) }".format(str)
+		});
+		^"{ |func| % }".format(code).interpret.value(this)
 	}
 
-	makeFlopFuncString {
-		var functionBlock, valueBlock, i, callBlock, argBlock, singleArgument;
+	envirFlop {
+		^this.flopInterpret
+	}
+
+	makeFlopFuncString { |modifier|
+		var functionBlock, valueBlock, callBlock, argBlock, singleArgument, i;
 		if(def.argNames.isNil) { ^this };
 
 		argBlock = def.argumentString(withDefaultValues: true, withEllipsis: true);
@@ -269,8 +272,9 @@ Function : AbstractFunction {
 		} {
 			functionBlock = "[%].flop".format(valueBlock)
 		};
+		if(modifier.notNil) { functionBlock = modifier.value(functionBlock) };
 
-		^"#{ arg %; % }".format(argBlock, functionBlock);
+		^"{ arg %; % }".format(argBlock, functionBlock);
 	}
 
 	makeFlopFunc {

--- a/SCClassLibrary/Common/Core/Function.sc
+++ b/SCClassLibrary/Common/Core/Function.sc
@@ -237,7 +237,9 @@ Function : AbstractFunction {
 
 
 	flop {
-		var code = this.makeFlopFuncString({ |str|
+		var code;
+		if(def.argNames.isNil) { ^{ [this.value] } };
+		code = this.makeFlopFuncString({ |str|
 			"%.collect { |item| func.valueArray(item) }".format(str)
 		});
 		^"{ |func| % }".format(code).interpret.value(this)
@@ -249,9 +251,7 @@ Function : AbstractFunction {
 
 	makeFlopFuncString { |modifier|
 		var functionBlock, valueBlock, callBlock, argBlock, singleArgument, i;
-		if(def.argNames.isNil) {
-			^"[func.value]"
-		};
+		if(def.argNames.isNil) { Error("a function without arguments has no flop string").throw };
 
 		argBlock = def.argumentString(withDefaultValues: true, withEllipsis: true);
 		valueBlock = def.argumentString(withDefaultValues: false, withEllipsis: false);

--- a/SCClassLibrary/Common/Core/Function.sc
+++ b/SCClassLibrary/Common/Core/Function.sc
@@ -237,7 +237,11 @@ Function : AbstractFunction {
 
 	flop {
 		if(def.argNames.isNil) { ^this };
-		^{ |... args| args.flop.collect(this.valueArray(_)) }
+		^this.flopInterpret
+	}
+
+	envirFlop {
+		^this.flop
 	}
 
 	flopInterpret {
@@ -245,10 +249,6 @@ Function : AbstractFunction {
 			"%.collect { |item| func.valueArray(item) }".format(str)
 		});
 		^"{ |func| % }".format(code).interpret.value(this)
-	}
-
-	envirFlop {
-		^this.flopInterpret
 	}
 
 	makeFlopFuncString { |modifier|

--- a/SCClassLibrary/Common/Core/Kernel.sc
+++ b/SCClassLibrary/Common/Core/Kernel.sc
@@ -472,25 +472,30 @@ FunctionDef {
 	checkCanArchive { "cannot archive FunctionDefs".warn }
 	archiveAsCompileString { ^true }
 
-	argumentString { arg withDefaultValues=true;
+	argumentString { arg withDefaultValues=true, withEllipsis=false;
 		var res = "", pairs = this.keyValuePairsFromArgs;
-		var last, noVarArgs;
+		var lastIndex, noVarArgs, varArgName;
 		if(pairs.isEmpty) { ^nil };
-		last = pairs.lastIndex;
-		noVarArgs = this.varArgs.not;
+		if(this.varArgs) {
+			varArgName = pairs.keep(-2).first;
+			pairs = pairs.drop(-2);
+		};
+
+		lastIndex = pairs.lastIndex;
 		pairs.pairsDo { |name, defaultValue, i|
-			var value, notLast;
-			notLast = i + 1 != last;
-			if(notLast or: noVarArgs) {
-				res = res ++ name;
-				if(withDefaultValues and: { defaultValue.notNil }) {
-					res = res ++ " = " ++ defaultValue.asCompileString;
-				};
-			} {
-				res = res ++ "... " ++ name;
+			res = res ++ name;
+			if(withDefaultValues and: { defaultValue.notNil }) {
+				res = res ++ " = " ++ defaultValue.asCompileString;
 			};
-			if(notLast) { res = res ++ ", " };
-		}
+			if(i + 1 < lastIndex) { res = res ++ ", " };
+		};
+		if(varArgName.notNil) {
+			if(withEllipsis) {
+				res = res ++ " ... " ++ varArgName
+			} {
+				res = res ++ ", " ++ varArgName
+			}
+		};
 		^res
 	}
 

--- a/SCClassLibrary/Common/Core/Kernel.sc
+++ b/SCClassLibrary/Common/Core/Kernel.sc
@@ -480,7 +480,6 @@ FunctionDef {
 			varArgName = pairs.keep(-2).first;
 			pairs = pairs.drop(-2);
 		};
-
 		lastIndex = pairs.lastIndex;
 		pairs.pairsDo { |name, defaultValue, i|
 			res = res ++ name;
@@ -493,7 +492,11 @@ FunctionDef {
 			if(withEllipsis) {
 				res = res ++ " ... " ++ varArgName
 			} {
-				res = res ++ ", " ++ varArgName
+				if(res == "") {
+					res = res ++ varArgName
+				} {
+					res = res ++ ", " ++ varArgName
+				}
 			}
 		};
 		^res

--- a/testsuite/classlibrary/TestFunction.sc
+++ b/testsuite/classlibrary/TestFunction.sc
@@ -131,21 +131,19 @@ TestFunction : UnitTest {
 		}
 	}
 
-	test_envirFlop {
+	test_makeFlopFunc_inEnvir {
 		var envir = Environment.new;
 		var function, flopFunction, result, directResult;
 		envir.use {
-			~x = [1, 2];
-			~y = [10, 100, 1000];
+			~x = [1, 10];
+			~y = [2, 20, 200];
 		};
-		function = { |x, y ... z|
-			if(x > 1) { x * y } { 0 }
-		};
+		function = { |x, y| x + y };
 		flopFunction = function.envirFlop;
 		envir.use {
 			result = flopFunction.valueEnvir;
 		};
-		directResult = [ 0, 200, 0 ];
+		directResult = [ 3, 30, 201 ];
 		this.assertEquals(result, directResult, "envirFlop should work in environment")
 
 	}
@@ -170,6 +168,13 @@ TestFunction : UnitTest {
 		var result = function.(1, [2, 3], [4, 5], [6, 7]);
 		var directResult = [ [ 1, 2, [ 4, 6 ] ], [ 1, 3, [ 5, 7 ] ] ];
 		this.assertEquals(result, directResult, "makeFlopFunc should work with ellipsis arguments")
+	}
+
+	test_makeFlopFunc_ellipsis_nothingPassed {
+		var function = { |a, b ... c| [a, b, c] }.makeFlopFunc;
+		var result = function.(1, [2, 3]);
+		var directResult = [ [ 1, 2, [ ]], [ 1, 3, [ ]]];
+		this.assertEquals(result, directResult, "makeFlopFunc should work with ellipsis when nothing has been passed to it")
 	}
 
 

--- a/testsuite/classlibrary/TestFunction.sc
+++ b/testsuite/classlibrary/TestFunction.sc
@@ -169,10 +169,24 @@ TestFunction : UnitTest {
 		this.assertEquals(result, directResult, "flop should work with default arguments")
 	}
 
+	test_flop_defaultArg2 {
+		var function = { |a, b ([100, 200])| [a, b] }.flop;
+		var result = function.([1, 2, 3], nil);
+		var directResult = [ [ 1, [ 100, 200 ] ], [ 2, [ 100, 200 ] ], [ 3, [ 100, 200 ] ] ];
+		this.assertEquals(result, directResult, "flop should work with default arguments")
+	}
+
 	test_flop_ellipsis {
 		var function = { |a, b ... c| [a, b, c] }.flop;
 		var result = function.(1, [2, 3], [4, 5], [6, 7]);
 		var directResult = [ [ 1, 2, [ 4, 6 ] ], [ 1, 3, [ 5, 7 ] ] ];
+		this.assertEquals(result, directResult, "flop should work with ellipsis arguments")
+	}
+
+	test_flop_ellipsis_expandFromEllipsis {
+		var function = { |a, b ... c| [a, b, c] }.flop;
+		var result = function.(1, 2, [4, 5], [6, 7, 8]);
+		var directResult = [ [ 1, 2, [ 4, 6 ] ], [ 1, 2, [ 5, 7 ] ], [ 1, 2, [ 4, 8 ] ], ];
 		this.assertEquals(result, directResult, "flop should work with ellipsis arguments")
 	}
 
@@ -181,6 +195,13 @@ TestFunction : UnitTest {
 		var result = function.(1, [2, 3]);
 		var directResult = [ [ 1, 2, [ ]], [ 1, 3, [ ]]];
 		this.assertEquals(result, directResult, "flop should work with ellipsis when nothing has been passed to it")
+	}
+
+	test_flop_ellipsis_noExpansion {
+		var function = { |a, b ... c| [a, b, c] }.flop;
+		var result = function.(1, 2, 3, 4);
+		var directResult = [ [ 1, 2, [3, 4] ]];
+		this.assertEquals(result, directResult, "flop should work with ellipsis arguments for the non-expanding case")
 	}
 
 

--- a/testsuite/classlibrary/TestFunction.sc
+++ b/testsuite/classlibrary/TestFunction.sc
@@ -45,6 +45,72 @@ TestFunction : UnitTest {
 		})
 	}
 
+	test_argumentString_without_defaultArguments {
+		var function = { |a, b, c| };
+		var arguments = [[true, true], [true, false], [false, true], [false, false]];
+		var strings = arguments.collect { |pair|
+			function.def.argumentString(withDefaultValues: pair[0], withEllipsis: pair[1])
+		};
+		var results = [
+			"a, b, c",
+			"a, b, c",
+			"a, b, c",
+			"a, b, c"
+		];
+		strings.do { |x, i|
+			this.assertEquals(x, results[i], "argument string should match")
+		}
+	}
+	test_argumentString_with_defaultArguments {
+		var function = { |a = 1, b = 2, c| };
+		var arguments = [[true, true], [true, false], [false, true], [false, false]];
+		var strings = arguments.collect { |pair|
+			function.def.argumentString(withDefaultValues: pair[0], withEllipsis: pair[1])
+		};
+		var results = [
+			"a = 1, b = 2, c",
+			"a = 1, b = 2, c",
+			"a, b, c",
+			"a, b, c"
+		];
+		strings.do { |x, i|
+			this.assertEquals(x, results[i], "argument string should match")
+		}
+	}
+
+	test_argumentString_with_ellipsisArguments {
+		var function = { |a, b ... c| };
+		var arguments = [[true, true], [true, false], [false, true], [false, false]];
+		var strings = arguments.collect { |pair|
+			function.def.argumentString(withDefaultValues: pair[0], withEllipsis: pair[1])
+		};
+		var results = [
+			"a, b ... c",
+			"a, b, c",
+			"a, b ... c",
+			"a, b, c"
+		];
+		strings.do { |x, i|
+			this.assertEquals(x, results[i], "argument string should match")
+		}
+	}
+	test_argumentString_with_ellipsis_andDefaultArguments {
+		var function = { |a = 1, b ... c| };
+		var arguments = [[true, true], [true, false], [false, true], [false, false]];
+		var strings = arguments.collect { |pair|
+			function.def.argumentString(withDefaultValues: pair[0], withEllipsis: pair[1])
+		};
+		var results = [
+			"a = 1, b ... c",
+			"a = 1, b, c",
+			"a, b ... c",
+			"a, b, c"
+		];
+		strings.do { |x, i|
+			this.assertEquals(x, results[i], "argument string should match")
+		}
+	}
+
 
 }
 

--- a/testsuite/classlibrary/TestFunction.sc
+++ b/testsuite/classlibrary/TestFunction.sc
@@ -168,7 +168,7 @@ TestFunction : UnitTest {
 	test_makeFlopFunc_ellipsis {
 		var function = { |a, b ... c| [a, b, c] }.makeFlopFunc;
 		var result = function.(1, [2, 3], [4, 5], [6, 7]);
-		var directResult = [ [ 1, 2, 4, 6 ], [ 1, 3, 5, 7 ] ];
+		var directResult = [ [ 1, 2, [ 4, 6 ] ], [ 1, 3, [ 5, 7 ] ] ];
 		this.assertEquals(result, directResult, "makeFlopFunc should work with ellipsis arguments")
 	}
 

--- a/testsuite/classlibrary/TestFunction.sc
+++ b/testsuite/classlibrary/TestFunction.sc
@@ -94,6 +94,26 @@ TestFunction : UnitTest {
 			this.assertEquals(x, results[i], "argument string should match")
 		}
 	}
+
+	test_argumentString_with_single_ellipsisArguments {
+		var function = { | ... a| };
+		var arguments = [[true, true], [true, false], [false, true], [false, false]];
+		var strings = arguments.collect { |pair|
+			function.def.argumentString(withDefaultValues: pair[0], withEllipsis: pair[1])
+		};
+		var results = [
+			" ... a",
+			"a",
+			" ... a",
+			"a"
+		];
+		strings.do { |x, i|
+			x.postcs;
+			this.assertEquals(x, results[i], "argument string should match")
+		}
+	}
+
+
 	test_argumentString_with_ellipsis_andDefaultArguments {
 		var function = { |a = 1, b ... c| };
 		var arguments = [[true, true], [true, false], [false, true], [false, false]];
@@ -109,6 +129,33 @@ TestFunction : UnitTest {
 		strings.do { |x, i|
 			this.assertEquals(x, results[i], "argument string should match")
 		}
+	}
+
+	test_envirFlop {
+		var envir = Environment.new;
+		var function, flopFunction, result, directResult;
+		envir.use {
+			~x = [1, 2];
+			~y = [10, 100, 1000];
+		};
+		function = { |x, y ... z|
+			if(x > 1) { x * y } { 0 }
+		};
+		flopFunction = function.envirFlop;
+		envir.use {
+			result = flopFunction.valueEnvir;
+		};
+		directResult = [ 0, 200, 0 ];
+		this.assertEquals(result, directResult, "envirFlop should work in environment")
+
+	}
+
+
+	test_envirFlop_ellipsis {
+		var function = { |a, b ... c| [a, b, c] }.envirFlop;
+		var result = function.(1, [2, 3], [4, 5], [6, 7]);
+		var directResult = [ [ 1, 2, 4, 6 ], [ 1, 3, 5, 7 ] ];
+		this.assertEquals(result, directResult, "envirFlop should work with ellipsis arguments")
 	}
 
 

--- a/testsuite/classlibrary/TestFunction.sc
+++ b/testsuite/classlibrary/TestFunction.sc
@@ -131,7 +131,7 @@ TestFunction : UnitTest {
 		}
 	}
 
-	test_makeFlopFunc_inEnvir {
+	test_flop_inEnvir {
 		var envir = Environment.new;
 		var function, flopFunction, result, directResult;
 		envir.use {
@@ -139,7 +139,7 @@ TestFunction : UnitTest {
 			~y = [2, 20, 200];
 		};
 		function = { |x, y| x + y };
-		flopFunction = function.envirFlop;
+		flopFunction = function.flop;
 		envir.use {
 			result = flopFunction.valueEnvir;
 		};
@@ -148,33 +148,39 @@ TestFunction : UnitTest {
 
 	}
 
-	test_makeFlopFunc_severalArgs {
-		var function = { |a, b| [a, b] }.makeFlopFunc;
+	test_flop_severalArgs {
+		var function = { |a, b| [a, b] }.flop;
 		var result = function.([1, 2, 3], [100, 200]);
 		var directResult = [ [ 1, 100 ], [ 2, 200 ], [ 3, 100 ] ];
-		this.assertEquals(result, directResult, "makeFlopFunc should work with default arguments")
+		this.assertEquals(result, directResult, "flop should work with default arguments")
 	}
 
+	test_flop_noArgs {
+		var function = { 1 }.flop;
+		var result = function.value;
+		var directResult = [ 1 ];
+		this.assertEquals(result, directResult, "flop should work with functions without default arguments")
+	}
 
-	test_makeFlopFunc_defaultArg {
-		var function = { |a, b = #[100, 200]| [a, b] }.makeFlopFunc;
+	test_flop_defaultArg {
+		var function = { |a, b = #[100, 200]| [a, b] }.flop;
 		var result = function.([1, 2, 3]);
 		var directResult = [ [ 1, 100 ], [ 2, 200 ], [ 3, 100 ] ];
-		this.assertEquals(result, directResult, "makeFlopFunc should work with default arguments")
+		this.assertEquals(result, directResult, "flop should work with default arguments")
 	}
 
-	test_makeFlopFunc_ellipsis {
-		var function = { |a, b ... c| [a, b, c] }.makeFlopFunc;
+	test_flop_ellipsis {
+		var function = { |a, b ... c| [a, b, c] }.flop;
 		var result = function.(1, [2, 3], [4, 5], [6, 7]);
 		var directResult = [ [ 1, 2, [ 4, 6 ] ], [ 1, 3, [ 5, 7 ] ] ];
-		this.assertEquals(result, directResult, "makeFlopFunc should work with ellipsis arguments")
+		this.assertEquals(result, directResult, "flop should work with ellipsis arguments")
 	}
 
-	test_makeFlopFunc_ellipsis_nothingPassed {
-		var function = { |a, b ... c| [a, b, c] }.makeFlopFunc;
+	test_flop_ellipsis_nothingPassed {
+		var function = { |a, b ... c| [a, b, c] }.flop;
 		var result = function.(1, [2, 3]);
 		var directResult = [ [ 1, 2, [ ]], [ 1, 3, [ ]]];
-		this.assertEquals(result, directResult, "makeFlopFunc should work with ellipsis when nothing has been passed to it")
+		this.assertEquals(result, directResult, "flop should work with ellipsis when nothing has been passed to it")
 	}
 
 

--- a/testsuite/classlibrary/TestFunction.sc
+++ b/testsuite/classlibrary/TestFunction.sc
@@ -150,12 +150,26 @@ TestFunction : UnitTest {
 
 	}
 
+	test_makeFlopFunc_severalArgs {
+		var function = { |a, b| [a, b] }.makeFlopFunc;
+		var result = function.([1, 2, 3], [100, 200]);
+		var directResult = [ [ 1, 100 ], [ 2, 200 ], [ 3, 100 ] ];
+		this.assertEquals(result, directResult, "makeFlopFunc should work with default arguments")
+	}
 
-	test_envirFlop_ellipsis {
-		var function = { |a, b ... c| [a, b, c] }.envirFlop;
+
+	test_makeFlopFunc_defaultArg {
+		var function = { |a, b = #[100, 200]| [a, b] }.makeFlopFunc;
+		var result = function.([1, 2, 3]);
+		var directResult = [ [ 1, 100 ], [ 2, 200 ], [ 3, 100 ] ];
+		this.assertEquals(result, directResult, "makeFlopFunc should work with default arguments")
+	}
+
+	test_makeFlopFunc_ellipsis {
+		var function = { |a, b ... c| [a, b, c] }.makeFlopFunc;
 		var result = function.(1, [2, 3], [4, 5], [6, 7]);
 		var directResult = [ [ 1, 2, 4, 6 ], [ 1, 3, 5, 7 ] ];
-		this.assertEquals(result, directResult, "envirFlop should work with ellipsis arguments")
+		this.assertEquals(result, directResult, "makeFlopFunc should work with ellipsis arguments")
 	}
 
 


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

Reimplements `flop` by `makeFlopFuncString`, which returns a flopped function s that can be used with keyword arguments. This also fixes #5498. Ellipsis arguments didn't work before, and for all usual cases there tests have been added.

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix
- New Functionality

There is a possibly breaking change, that functions without arguments will also flop: `{ 3 }.flop.value`returns `[3]` and not `3`. just like  in the case of arrays `[3].flop` returns `[[3]]` and not `[3]`. It is probable that the original behaviour caused more trouble, because it is unexpected. This change is up to discussion and can be separated from the rest of the changes if so desired.



## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] This PR is ready for review
