### PR TITLE
Docs: add some links to WIKI 'Errors FAQ' page

### DIFF
--- a/HelpSource/Classes/Server.schelp
+++ b/HelpSource/Classes/Server.schelp
@@ -774,3 +774,6 @@ argument:: numChannels
 Number of channels to send to BelaScope, starting from the index supplied. Defaults to 2, or to link::Classes/ServerOptions#-numOutputBusChannels:: if index is 0.
 
 returns:: A link::Classes/Synth::, linking this Server's desired bus channels to BelaScope's bus.
+
+subsection:: Server issues
+Some insights about common Server issues can be found on the WIKI link::https://github.com/supercollider/supercollider/wiki/Errors-FAQ#server-issues::

--- a/HelpSource/Classes/SynthDef.schelp
+++ b/HelpSource/Classes/SynthDef.schelp
@@ -518,3 +518,6 @@ code::
 ~def.specs.amp.postln;
 )
 ::
+
+subsection:: SynthDef issues
+Some insights about common SynthDef issues can be found on the WIKI link::https://github.com/supercollider/supercollider/wiki/Errors-FAQ#synthdef-issues::

--- a/HelpSource/Guides/GUI-Introduction.schelp
+++ b/HelpSource/Guides/GUI-Introduction.schelp
@@ -391,3 +391,6 @@ Routine{
 ::
 
 As mentioned above, using the GUI system is also not allowed in code performed directly in response to OSC messages (this includes functions given to all kinds of OSC responder classes). The same solutions as above apply:
+
+subsection:: GUI issues
+Some insights about common GUI issues can be found on the WIKI link::https://github.com/supercollider/supercollider/wiki/Errors-FAQ#calling-gui-primitives-from-a-systemclock-routine::

--- a/HelpSource/Help.schelp
+++ b/HelpSource/Help.schelp
@@ -22,6 +22,7 @@ definitionlist::
 ## link::Guides/ClientVsServer:: || Explaining the client vs server architecture.
 ## link::Guides/More-On-Getting-Help:: || How to find more help
 ## link::Browse.html#Tutorials#All tutorials:: || Index of all help files categorized under "Tutorials."
+## link::https://github.com/supercollider/supercollider/wiki/Errors-FAQ:: || Common Errors and FAQ on SuperCollider WIKI
 ::
 
 SECTION::Documentation indexes


### PR DESCRIPTION
## Purpose and Motivation

While copying some of the (old) website WIKI to the WIKI here (see https://github.com/supercollider/supercollider.github.io/issues/247), @dyfer suggested adding a link to the [Errors FAQ](https://github.com/supercollider/supercollider/wiki/Errors-FAQ) page on the corrsponding helpfiles (main Help page, Server, SynthDef, Guides -> GUI).

## Types of changes

- Documentation

- [x] This PR is ready for review