### PR TITLE
docs: modify description of pmindex argument

### DIFF
--- a/HelpSource/Classes/PMOsc.schelp
+++ b/HelpSource/Classes/PMOsc.schelp
@@ -19,7 +19,7 @@ argument::modfreq
 Modulator frequency in cycles per second.
 
 argument::pmindex
-Modulation index in radians.
+The modulation index, representing the ratio of modulator deviation to modulator frequency. Higher values generally produce denser spectra.
 
 argument::modphase
 A modulation input for the modulator's phase in radians.


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation
Provide improved description of pmindex argument in PMOsc help file. This value is not measured in radians; it represents the ratio of modulator deviation to modulator frequency.

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->

- Documentation

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review
