### PR TITLE
GitHub Actions: build libsndfile on macos

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -185,6 +185,7 @@ jobs:
             deployment-target: '10.13' # Qt 5.15 runs on macOS 10.13 and newer
             use-syslibs: false
             shared-libscsynth: false
+            build-libsndfile: true
             artifact-suffix: 'macOS' # set if needed - will trigger artifact upload
 
           - job-name: 'legacy'
@@ -194,6 +195,7 @@ jobs:
             deployment-target: '10.10'
             use-syslibs: false
             shared-libscsynth: false
+            build-libsndfile: true
             artifact-suffix: 'macOS-legacy' # set if needed - will trigger artifact upload
 
           - job-name: 'use system libraries'
@@ -220,6 +222,7 @@ jobs:
       USE_SYSLIBS: ${{ matrix.use-syslibs }}
       SHARED_LIBSCSYNTH: ${{ matrix.shared-libscsynth }}
       ARTIFACT_FILE: 'SuperCollider-${{ needs.lint.outputs.sc-version }}-${{ matrix.artifact-suffix }}.dmg'
+      DEVELOPER_DIR: '/Applications/Xcode_${{ matrix.xcode-version }}.app/Contents/Developer'
     steps:
       - uses: actions/checkout@v2
         with:
@@ -253,9 +256,21 @@ jobs:
         run: rm -rf $(brew --cache)
       - name: install dependencies
         run: |
-          brew install libsndfile portaudio ccache fftw
+          brew install portaudio ccache fftw
           # add ccamke to PATH - see https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions
           echo "/usr/local/opt/ccache/libexec" >> $GITHUB_PATH
+      - name: build libsndfile # to make it compatible with older OSes (lower deployment target)
+        if: matrix.build-libsndfile == true
+        run: |
+          brew uninstall --ignore-dependencies libsndfile
+          brew install automake mpg123
+          cd $GITHUB_WORKSPACE/..
+          curl -L https://github.com/libsndfile/libsndfile/releases/download/1.0.31/libsndfile-1.0.31.tar.bz2 --output libsndfile.tar.bz2
+          tar xfvz libsndfile.tar.bz2
+          cd libsndfile*/
+          mkdir build && cd build
+          cmake -DCMAKE_OSX_ARCHITECTURES=x86_64 -DCMAKE_OSX_DEPLOYMENT_TARGET=${{ matrix.deployment-target }} -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON -DCMAKE_C_FLAGS="-Wall -Wextra" -DCMAKE_INSTALL_PREFIX=/usr/local ..
+          cmake --build . --target install
       - name: install system libraries
         if: env.USE_SYSLIBS == 'true'
         run: brew install yaml-cpp boost
@@ -271,8 +286,6 @@ jobs:
           cached: ${{ steps.cache-qt.outputs.cache-hit }}
 
       - name: configure
-        env:
-          DEVELOPER_DIR: '/Applications/Xcode_${{ matrix.xcode-version }}.app/Contents/Developer'
         run: |
           mkdir $BUILD_PATH && cd $BUILD_PATH
 


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

Fixes #5510

It turns out that `libsndfile` installed with homebrew doesn't work on macOS <10.14. One option is to build libsndfile ourselves, specifying an earlier deployment target. This adds ~90 seconds to our macOS build time.

I'm open to suggestions whether this is the right solution.

I've tested this on macOS 10.13, using the example in the linked issue.

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review
