### PR TITLE
GitHub Actions: fix Windows installer creation, release uploads

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -1,5 +1,17 @@
 name: CI
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+      - 'examples/**'
+      - 'HelpSource/**'
+      - 'sounds/**'
+      - '*.md'
+  pull_request:
+    paths-ignore:
+      - 'examples/**'
+      - 'HelpSource/**'
+      - 'sounds/**'
+      - '*.md'
 jobs:
   lint:
     runs-on: ubuntu-18.04

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -468,14 +468,14 @@ jobs:
           path: ${{ env.INSTALL_PATH }}/${{ env.ARTIFACT_FILE }}.zip
           retention-days: 7 # quickly remove test artifacts
       - name: create installer
-        if: matrix.create-installer == 'true'
+        if: matrix.create-installer == true
         shell: bash
         run: |
           export PATH="C:\Program Files (x86)\NSIS":$PATH
           cmake --build $BUILD_PATH --config Release --target installer
       - name: upload installer
         uses: actions/upload-artifact@v2
-        if: matrix.create-installer == 'true'
+        if: matrix.create-installer == true
         with:
           name: ${{ env.INSTALLER_FILE }}
           path: ${{ env.INSTALL_PATH }}/*.exe

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -687,8 +687,8 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           files: |
-            ${{ env.INSTALL_PATH }}/${{ env.ARTIFACT_FILE_PREFIX }}-macOS/*
-            ${{ env.INSTALL_PATH }}/${{ env.ARTIFACT_FILE_PREFIX }}-macOS-legacy/*
+            ${{ env.INSTALL_PATH }}/${{ env.ARTIFACT_FILE_PREFIX }}-macOS.dmg/*
+            ${{ env.INSTALL_PATH }}/${{ env.ARTIFACT_FILE_PREFIX }}-macOS-legacy.dmg/*
             ${{ env.INSTALL_PATH }}/${{ env.ARTIFACT_FILE_PREFIX }}-win32-installer/*
             ${{ env.INSTALL_PATH }}/${{ env.ARTIFACT_FILE_PREFIX }}-win64-installer/*
             ${{ env.INSTALL_PATH }}/${{ env.ARTIFACT_FILE_PREFIX }}-win32/*


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

Fixes #5505

This PR fixes the following issues:
- macOS binaries were not uploaded to the release page
- Windows installers were not created on tagged commits

I've also incorporated changes from #5452, triggering builds only for code changes (i.e. not for changes in `HelpSource` etc). These were tested previously (see #5452) except for the release process, but for this PR I've tested the release, effectively testing all the changes at once. If desired, I can remove changes from #5452 from this PR, please let me know, but I thought testing them on a release should be enough to get them in as well.

(One thing to note about the change to the CI is that documentation changes _only_ will not trigger new experimental builds (i.e. builds from the `develop` branch), which I'm fine with, but I wanted to point it out).

Here is the release I've tested these changes with: https://github.com/dyfer/supercollider/releases/tag/Version-3.12.0-test1
You can see that macOS DMGs as well as Windows installers are uploaded now.

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review
