### PR TITLE
GHA updates - FFTW on Windows

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -343,7 +343,7 @@ jobs:
         include:
 
           - job-name: '32-bit'
-            fftw-arch: 'x32'
+            fftw-arch: 'x86'
             cmake-arch: 'Win32'
             os-version: '2019'
             qt-version: '5.15.2'
@@ -394,6 +394,7 @@ jobs:
       INSTALL_PATH: ${{ github.workspace }}/build/Install
       LIBS_DOWNLOAD_PATH: ${{ github.workspace }}/../3rd-party
       VCVARS_SCRIPT_PATH: 'C:/Program Files (x86)/Microsoft Visual Studio/${{ matrix.msvc-year }}/Enterprise/VC/Auxiliary/Build/${{ matrix.vcvars-script }}'
+      FFTW_INSTALL_DIR: "C:/Program Files/fftw"
       ARTIFACT_FILE: 'SuperCollider-${{ needs.lint.outputs.sc-version }}-${{ matrix.artifact-suffix }}'
       INSTALLER_FILE: 'SuperCollider-${{ needs.lint.outputs.sc-version }}-${{ matrix.installer-suffix }}'
     steps:
@@ -422,29 +423,17 @@ jobs:
         run: choco install libsndfile ${{ matrix.chocolatey-options }}
       - name: download fftw
         shell: bash
-        env:
-          FFTW_PATH: ${{ env.LIBS_DOWNLOAD_PATH }}/fftw
         run: |
-          mkdir -p $FFTW_PATH && cd $FFTW_PATH
+          mkdir -p "$FFTW_INSTALL_DIR" && cd "$FFTW_INSTALL_DIR"
           curl -L ${{ matrix.fftw-url }} -o fftw.zip
           7z x fftw.zip -y
-          # add env var for subsequent steps
-          echo 'FFTW_PATH<<EOF' >> $GITHUB_ENV
-          echo $FFTW_PATH >> $GITHUB_ENV
-          echo 'EOF' >> $GITHUB_ENV
       - name: create fftw msvc library
         if: matrix.vcvars-script
         shell: cmd
-        env:
-          FFTW_ARCH: ${{ matrix.fftw-arch }}
+        working-directory: ${{ env.FFTW_INSTALL_DIR }}
         run: |
           call "%VCVARS_SCRIPT_PATH%"
-          cd "%FFTW_PATH%"
-          lib.exe /machine:%FFTW_ARCH% /def:libfftw3f-3.def
-      - name: move fftw
-        shell: bash
-        run: |
-          mv $FFTW_PATH "C:/Program Files/fftw"
+          lib.exe /machine:${{ matrix.fftw-arch }} /def:libfftw3f-3.def
       - name: install asio sdk
         shell: bash
         env:


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

Working on sc3-plugins GitHub actions, I noticed that the platform for creating MSVC FFTW library (Windows) was [set incorrectly](https://github.com/supercollider/supercollider/runs/3107869909#step:8:27) for the 32-bit build. The reason it worked was that it defaulted to `x32`. I've also streamlined FFTW installation - the zip is downloaded straight to the proper `Program Files` location and expanded there. The msvc library is created in the same location.

~~It's not crucial that it gets into 3.12, but it's a relatively simple fix so it might as well... let me know what you think.~~ Maybe let's not risk anything, I've changed base to `develop`.

I've tried the Win32 build, started the server, run `Tartini`, and it seems to work fine.

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review
