### PR TITLE
Build libsndfile's dependencies and change DMG filesystem

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -283,7 +283,7 @@ jobs:
           cd ogg*/
           echo "*** building libogg ***"
           mkdir build && cd build
-          cmake -G"Unix Makefiles" -DBUILD_FRAMEWORK=OFF -DBUILD_SHARED_LIBS=OFF -DCMAKE_OSX_ARCHITECTURES=x86_64 -DRULE_LAUNCH_COMPILE=ccache -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_FLAGS="-Wall -Wextra" -DCMAKE_INSTALL_PREFIX=/usr/local ..
+          cmake -G"Unix Makefiles" -DBUILD_FRAMEWORK=OFF -DBUILD_SHARED_LIBS=OFF -DCMAKE_OSX_ARCHITECTURES=x86_64 -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_FLAGS="-Wall -Wextra" -DCMAKE_INSTALL_PREFIX=/usr/local ..
           cmake --build . --target install
           cd $GITHUB_WORKSPACE/..
           curl -L https://github.com/xiph/flac/archive/refs/tags/1.3.3.tar.gz --output flac.tar.xz
@@ -291,7 +291,7 @@ jobs:
           cd flac*/
           echo "*** building flac ***"
           cd build # build directory already exists
-          cmake -G"Unix Makefiles" -DBUILD_SHARED_LIBS=OFF -DCMAKE_OSX_ARCHITECTURES=x86_64 -DRULE_LAUNCH_COMPILE=ccache -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_FLAGS="-Wall -Wextra" -DCMAKE_INSTALL_PREFIX=/usr/local ..
+          cmake -G"Unix Makefiles" -DBUILD_SHARED_LIBS=OFF -DCMAKE_OSX_ARCHITECTURES=x86_64 -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_FLAGS="-Wall -Wextra" -DCMAKE_INSTALL_PREFIX=/usr/local ..
           cmake --build . --target install
           cd $GITHUB_WORKSPACE/..
           curl -L https://github.com/xiph/opus/archive/refs/tags/v1.3.1.tar.gz --output opus.tar.gz
@@ -299,7 +299,7 @@ jobs:
           cd opus*/
           echo "*** building opus ***"
           mkdir build && cd build
-          cmake -G"Unix Makefiles" -DBUILD_SHARED_LIBS=OFF -DCMAKE_OSX_ARCHITECTURES=x86_64 -DRULE_LAUNCH_COMPILE=ccache -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_FLAGS="-Wall -Wextra" -DCMAKE_INSTALL_PREFIX=/usr/local ..
+          cmake -G"Unix Makefiles" -DBUILD_SHARED_LIBS=OFF -DCMAKE_OSX_ARCHITECTURES=x86_64 -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_FLAGS="-Wall -Wextra" -DCMAKE_INSTALL_PREFIX=/usr/local ..
           cmake --build . --target install
           cd $GITHUB_WORKSPACE/..
           curl -L https://github.com/xiph/vorbis/releases/download/v1.3.7/libvorbis-1.3.7.tar.gz --output libvorbis.tar.gz
@@ -307,7 +307,7 @@ jobs:
           cd libvorbis*/
           echo "building *** libvorbis ***"
           mkdir build && cd build
-          cmake -G"Unix Makefiles" -DBUILD_FRAMEWORK=OFF -DBUILD_SHARED_LIBS=OFF -DCMAKE_OSX_ARCHITECTURES=x86_64 -DRULE_LAUNCH_COMPILE=ccache -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_FLAGS="-Wall -Wextra" -DCMAKE_INSTALL_PREFIX=/usr/local ..
+          cmake -G"Unix Makefiles" -DBUILD_FRAMEWORK=OFF -DBUILD_SHARED_LIBS=OFF -DCMAKE_OSX_ARCHITECTURES=x86_64 -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_FLAGS="-Wall -Wextra" -DCMAKE_INSTALL_PREFIX=/usr/local ..
           cmake --build . --target install
           cd $GITHUB_WORKSPACE/..
           curl -L https://github.com/libsndfile/libsndfile/releases/download/1.0.31/libsndfile-1.0.31.tar.bz2 --output libsndfile.tar.bz2
@@ -315,7 +315,7 @@ jobs:
           cd libsndfile*/
           echo "building libsndfile"
           mkdir build && cd build
-          cmake -G"Unix Makefiles" -DBUILD_SHARED_LIBS=ON -DCMAKE_OSX_ARCHITECTURES=x86_64 -DCMAKE_C_FLAGS="-Wall -Wextra" -DRULE_LAUNCH_COMPILE=ccache -DCMAKE_INSTALL_PREFIX=/usr/local ..
+          cmake -G"Unix Makefiles" -DBUILD_SHARED_LIBS=ON -DCMAKE_OSX_ARCHITECTURES=x86_64 -DCMAKE_C_FLAGS="-Wall -Wextra" -DCMAKE_INSTALL_PREFIX=/usr/local ..
           cmake --build . --target install
       - name: install system libraries
         if: env.USE_SYSLIBS == 'true'

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -294,8 +294,9 @@ jobs:
           cmake -G"Xcode" -DBUILD_SHARED_LIBS=OFF -DCMAKE_OSX_ARCHITECTURES=x86_64 -DCMAKE_C_FLAGS="-Wall -Wextra" -DCMAKE_INSTALL_PREFIX=/usr/local ..
           cmake --build . --config Release --target install
           cd $GITHUB_WORKSPACE/..
-          git clone https://github.com/xiph/opus.git # using git repo since https://github.com/xiph/opus/issues/129 seems not fixed in the release tarball
-          cd opus/
+          curl -L https://github.com/xiph/opus/archive/refs/tags/v1.3.1.tar.gz --output opus.tar.gz
+          tar xfvz opus.tar.gz
+          cd opus*/
           echo "*** building opus ***"
           mkdir build && cd build
           cmake -G"Xcode" -DBUILD_SHARED_LIBS=OFF -DCMAKE_OSX_ARCHITECTURES=x86_64 -DCMAKE_C_FLAGS="-Wall -Wextra" -DCMAKE_INSTALL_PREFIX=/usr/local ..

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -235,6 +235,7 @@ jobs:
       SHARED_LIBSCSYNTH: ${{ matrix.shared-libscsynth }}
       ARTIFACT_FILE: 'SuperCollider-${{ needs.lint.outputs.sc-version }}-${{ matrix.artifact-suffix }}.dmg'
       DEVELOPER_DIR: '/Applications/Xcode_${{ matrix.xcode-version }}.app/Contents/Developer'
+      MACOSX_DEPLOYMENT_TARGET: '${{ matrix.deployment-target }}'
     steps:
       - uses: actions/checkout@v2
         with:
@@ -274,15 +275,47 @@ jobs:
       - name: build libsndfile # to make it compatible with older OSes (lower deployment target)
         if: matrix.build-libsndfile == true
         run: |
-          brew uninstall --ignore-dependencies libsndfile
-          brew install automake mpg123
+          brew uninstall --ignore-dependencies libsndfile libvorbis libogg flac opus
+          brew install automake
+          cd $GITHUB_WORKSPACE/..
+          curl -L https://gitlab.xiph.org/xiph/ogg/-/archive/v1.3.5/ogg-v1.3.5.tar.bz2 --output ogg.tar.bz2
+          tar xfvz ogg.tar.bz2
+          cd ogg*/
+          echo "*** building libogg ***"
+          mkdir build && cd build
+          cmake -G"Xcode" -DBUILD_FRAMEWORK=OFF -DBUILD_SHARED_LIBS=OFF -DCMAKE_OSX_ARCHITECTURES=x86_64 -DCMAKE_C_FLAGS="-Wall -Wextra" -DCMAKE_INSTALL_PREFIX=/usr/local ..
+          cmake --build . --config Release --target install
+          cd $GITHUB_WORKSPACE/..
+          curl -L https://github.com/xiph/flac/archive/refs/tags/1.3.3.tar.gz --output flac.tar.xz
+          tar xfvz flac.tar.xz
+          cd flac*/
+          echo "*** building flac ***"
+          cd build # build directory already exists
+          cmake -G"Xcode" -DBUILD_SHARED_LIBS=OFF -DCMAKE_OSX_ARCHITECTURES=x86_64 -DCMAKE_C_FLAGS="-Wall -Wextra" -DCMAKE_INSTALL_PREFIX=/usr/local ..
+          cmake --build . --config Release --target install
+          cd $GITHUB_WORKSPACE/..
+          git clone https://github.com/xiph/opus.git # using git repo since https://github.com/xiph/opus/issues/129 seems not fixed in the release tarball
+          cd opus/
+          echo "*** building opus ***"
+          mkdir build && cd build
+          cmake -G"Xcode" -DBUILD_SHARED_LIBS=OFF -DCMAKE_OSX_ARCHITECTURES=x86_64 -DCMAKE_C_FLAGS="-Wall -Wextra" -DCMAKE_INSTALL_PREFIX=/usr/local ..
+          cmake --build . --config Release --target install
+          cd $GITHUB_WORKSPACE/..
+          curl -L https://github.com/xiph/vorbis/releases/download/v1.3.7/libvorbis-1.3.7.tar.gz --output libvorbis.tar.gz
+          tar xfvz libvorbis.tar.gz
+          cd libvorbis*/
+          echo "building *** libvorbis ***"
+          mkdir build && cd build
+          cmake -G"Xcode" -DBUILD_FRAMEWORK=OFF -DBUILD_SHARED_LIBS=OFF -DCMAKE_OSX_ARCHITECTURES=x86_64 -DCMAKE_C_FLAGS="-Wall -Wextra" -DCMAKE_INSTALL_PREFIX=/usr/local ..
+          cmake --build . --config Release --target install
           cd $GITHUB_WORKSPACE/..
           curl -L https://github.com/libsndfile/libsndfile/releases/download/1.0.31/libsndfile-1.0.31.tar.bz2 --output libsndfile.tar.bz2
           tar xfvz libsndfile.tar.bz2
           cd libsndfile*/
+          echo "building libsndfile"
           mkdir build && cd build
-          cmake -DCMAKE_OSX_ARCHITECTURES=x86_64 -DCMAKE_OSX_DEPLOYMENT_TARGET=${{ matrix.deployment-target }} -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON -DCMAKE_C_FLAGS="-Wall -Wextra" -DCMAKE_INSTALL_PREFIX=/usr/local ..
-          cmake --build . --target install
+          cmake -G"Xcode" -DBUILD_SHARED_LIBS=ON -DCMAKE_OSX_ARCHITECTURES=x86_64 -DCMAKE_C_FLAGS="-Wall -Wextra" -DCMAKE_INSTALL_PREFIX=/usr/local ..
+          cmake --build . --config Release --target install
       - name: install system libraries
         if: env.USE_SYSLIBS == 'true'
         run: brew install yaml-cpp boost

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -279,7 +279,7 @@ jobs:
           brew install automake
           cd $GITHUB_WORKSPACE/..
           curl -L https://gitlab.xiph.org/xiph/ogg/-/archive/v1.3.5/ogg-v1.3.5.tar.bz2 --output ogg.tar.bz2
-          tar xfvz ogg.tar.bz2
+          tar xfz ogg.tar.bz2
           cd ogg*/
           echo "*** building libogg ***"
           mkdir build && cd build
@@ -287,7 +287,7 @@ jobs:
           cmake --build . --target install
           cd $GITHUB_WORKSPACE/..
           curl -L https://github.com/xiph/flac/archive/refs/tags/1.3.3.tar.gz --output flac.tar.xz
-          tar xfvz flac.tar.xz
+          tar xfz flac.tar.xz
           cd flac*/
           echo "*** building flac ***"
           cd build # build directory already exists
@@ -295,7 +295,7 @@ jobs:
           cmake --build . --target install
           cd $GITHUB_WORKSPACE/..
           curl -L https://github.com/xiph/opus/archive/refs/tags/v1.3.1.tar.gz --output opus.tar.gz
-          tar xfvz opus.tar.gz
+          tar xfz opus.tar.gz
           cd opus*/
           echo "*** building opus ***"
           mkdir build && cd build
@@ -303,7 +303,7 @@ jobs:
           cmake --build . --target install
           cd $GITHUB_WORKSPACE/..
           curl -L https://github.com/xiph/vorbis/releases/download/v1.3.7/libvorbis-1.3.7.tar.gz --output libvorbis.tar.gz
-          tar xfvz libvorbis.tar.gz
+          tar xfz libvorbis.tar.gz
           cd libvorbis*/
           echo "building *** libvorbis ***"
           mkdir build && cd build
@@ -311,7 +311,7 @@ jobs:
           cmake --build . --target install
           cd $GITHUB_WORKSPACE/..
           curl -L https://github.com/libsndfile/libsndfile/releases/download/1.0.31/libsndfile-1.0.31.tar.bz2 --output libsndfile.tar.bz2
-          tar xfvz libsndfile.tar.bz2
+          tar xfz libsndfile.tar.bz2
           cd libsndfile*/
           echo "building libsndfile"
           mkdir build && cd build

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -283,40 +283,40 @@ jobs:
           cd ogg*/
           echo "*** building libogg ***"
           mkdir build && cd build
-          cmake -G"Xcode" -DBUILD_FRAMEWORK=OFF -DBUILD_SHARED_LIBS=OFF -DCMAKE_OSX_ARCHITECTURES=x86_64 -DRULE_LAUNCH_COMPILE=ccache -DCMAKE_C_FLAGS="-Wall -Wextra" -DCMAKE_INSTALL_PREFIX=/usr/local ..
-          cmake --build . --config Release --target install
+          cmake -G"Unix Makefiles" -DBUILD_FRAMEWORK=OFF -DBUILD_SHARED_LIBS=OFF -DCMAKE_OSX_ARCHITECTURES=x86_64 -DRULE_LAUNCH_COMPILE=ccache -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_FLAGS="-Wall -Wextra" -DCMAKE_INSTALL_PREFIX=/usr/local ..
+          cmake --build . --target install
           cd $GITHUB_WORKSPACE/..
           curl -L https://github.com/xiph/flac/archive/refs/tags/1.3.3.tar.gz --output flac.tar.xz
           tar xfvz flac.tar.xz
           cd flac*/
           echo "*** building flac ***"
           cd build # build directory already exists
-          cmake -G"Xcode" -DBUILD_SHARED_LIBS=OFF -DCMAKE_OSX_ARCHITECTURES=x86_64 -DRULE_LAUNCH_COMPILE=ccache -DCMAKE_C_FLAGS="-Wall -Wextra" -DCMAKE_INSTALL_PREFIX=/usr/local ..
-          cmake --build . --config Release --target install
+          cmake -G"Unix Makefiles" -DBUILD_SHARED_LIBS=OFF -DCMAKE_OSX_ARCHITECTURES=x86_64 -DRULE_LAUNCH_COMPILE=ccache -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_FLAGS="-Wall -Wextra" -DCMAKE_INSTALL_PREFIX=/usr/local ..
+          cmake --build . --target install
           cd $GITHUB_WORKSPACE/..
           curl -L https://github.com/xiph/opus/archive/refs/tags/v1.3.1.tar.gz --output opus.tar.gz
           tar xfvz opus.tar.gz
           cd opus*/
           echo "*** building opus ***"
           mkdir build && cd build
-          cmake -G"Xcode" -DBUILD_SHARED_LIBS=OFF -DCMAKE_OSX_ARCHITECTURES=x86_64 -DCMAKE_C_FLAGS="-Wall -Wextra" -DRULE_LAUNCH_COMPILE=ccache -DCMAKE_INSTALL_PREFIX=/usr/local ..
-          cmake --build . --config Release --target install
+          cmake -G"Unix Makefiles" -DBUILD_SHARED_LIBS=OFF -DCMAKE_OSX_ARCHITECTURES=x86_64 -DRULE_LAUNCH_COMPILE=ccache -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_FLAGS="-Wall -Wextra" -DCMAKE_INSTALL_PREFIX=/usr/local ..
+          cmake --build . --target install
           cd $GITHUB_WORKSPACE/..
           curl -L https://github.com/xiph/vorbis/releases/download/v1.3.7/libvorbis-1.3.7.tar.gz --output libvorbis.tar.gz
           tar xfvz libvorbis.tar.gz
           cd libvorbis*/
           echo "building *** libvorbis ***"
           mkdir build && cd build
-          cmake -G"Xcode" -DBUILD_FRAMEWORK=OFF -DBUILD_SHARED_LIBS=OFF -DCMAKE_OSX_ARCHITECTURES=x86_64 -DCMAKE_C_FLAGS="-Wall -Wextra" -DRULE_LAUNCH_COMPILE=ccache -DCMAKE_INSTALL_PREFIX=/usr/local ..
-          cmake --build . --config Release --target install
+          cmake -G"Unix Makefiles" -DBUILD_FRAMEWORK=OFF -DBUILD_SHARED_LIBS=OFF -DCMAKE_OSX_ARCHITECTURES=x86_64 -DRULE_LAUNCH_COMPILE=ccache -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_FLAGS="-Wall -Wextra" -DCMAKE_INSTALL_PREFIX=/usr/local ..
+          cmake --build . --target install
           cd $GITHUB_WORKSPACE/..
           curl -L https://github.com/libsndfile/libsndfile/releases/download/1.0.31/libsndfile-1.0.31.tar.bz2 --output libsndfile.tar.bz2
           tar xfvz libsndfile.tar.bz2
           cd libsndfile*/
           echo "building libsndfile"
           mkdir build && cd build
-          cmake -G"Xcode" -DBUILD_SHARED_LIBS=ON -DCMAKE_OSX_ARCHITECTURES=x86_64 -DCMAKE_C_FLAGS="-Wall -Wextra" -DRULE_LAUNCH_COMPILE=ccache -DCMAKE_INSTALL_PREFIX=/usr/local ..
-          cmake --build . --config Release --target install
+          cmake -G"Unix Makefiles" -DBUILD_SHARED_LIBS=ON -DCMAKE_OSX_ARCHITECTURES=x86_64 -DCMAKE_C_FLAGS="-Wall -Wextra" -DRULE_LAUNCH_COMPILE=ccache -DCMAKE_INSTALL_PREFIX=/usr/local ..
+          cmake --build . --target install
       - name: install system libraries
         if: env.USE_SYSLIBS == 'true'
         run: brew install yaml-cpp boost

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -283,7 +283,7 @@ jobs:
           cd ogg*/
           echo "*** building libogg ***"
           mkdir build && cd build
-          cmake -G"Xcode" -DBUILD_FRAMEWORK=OFF -DBUILD_SHARED_LIBS=OFF -DCMAKE_OSX_ARCHITECTURES=x86_64 -DCMAKE_C_FLAGS="-Wall -Wextra" -DCMAKE_INSTALL_PREFIX=/usr/local ..
+          cmake -G"Xcode" -DBUILD_FRAMEWORK=OFF -DBUILD_SHARED_LIBS=OFF -DCMAKE_OSX_ARCHITECTURES=x86_64 -DRULE_LAUNCH_COMPILE=ccache -DCMAKE_C_FLAGS="-Wall -Wextra" -DCMAKE_INSTALL_PREFIX=/usr/local ..
           cmake --build . --config Release --target install
           cd $GITHUB_WORKSPACE/..
           curl -L https://github.com/xiph/flac/archive/refs/tags/1.3.3.tar.gz --output flac.tar.xz
@@ -291,7 +291,7 @@ jobs:
           cd flac*/
           echo "*** building flac ***"
           cd build # build directory already exists
-          cmake -G"Xcode" -DBUILD_SHARED_LIBS=OFF -DCMAKE_OSX_ARCHITECTURES=x86_64 -DCMAKE_C_FLAGS="-Wall -Wextra" -DCMAKE_INSTALL_PREFIX=/usr/local ..
+          cmake -G"Xcode" -DBUILD_SHARED_LIBS=OFF -DCMAKE_OSX_ARCHITECTURES=x86_64 -DRULE_LAUNCH_COMPILE=ccache -DCMAKE_C_FLAGS="-Wall -Wextra" -DCMAKE_INSTALL_PREFIX=/usr/local ..
           cmake --build . --config Release --target install
           cd $GITHUB_WORKSPACE/..
           curl -L https://github.com/xiph/opus/archive/refs/tags/v1.3.1.tar.gz --output opus.tar.gz
@@ -299,7 +299,7 @@ jobs:
           cd opus*/
           echo "*** building opus ***"
           mkdir build && cd build
-          cmake -G"Xcode" -DBUILD_SHARED_LIBS=OFF -DCMAKE_OSX_ARCHITECTURES=x86_64 -DCMAKE_C_FLAGS="-Wall -Wextra" -DCMAKE_INSTALL_PREFIX=/usr/local ..
+          cmake -G"Xcode" -DBUILD_SHARED_LIBS=OFF -DCMAKE_OSX_ARCHITECTURES=x86_64 -DCMAKE_C_FLAGS="-Wall -Wextra" -DRULE_LAUNCH_COMPILE=ccache -DCMAKE_INSTALL_PREFIX=/usr/local ..
           cmake --build . --config Release --target install
           cd $GITHUB_WORKSPACE/..
           curl -L https://github.com/xiph/vorbis/releases/download/v1.3.7/libvorbis-1.3.7.tar.gz --output libvorbis.tar.gz
@@ -307,7 +307,7 @@ jobs:
           cd libvorbis*/
           echo "building *** libvorbis ***"
           mkdir build && cd build
-          cmake -G"Xcode" -DBUILD_FRAMEWORK=OFF -DBUILD_SHARED_LIBS=OFF -DCMAKE_OSX_ARCHITECTURES=x86_64 -DCMAKE_C_FLAGS="-Wall -Wextra" -DCMAKE_INSTALL_PREFIX=/usr/local ..
+          cmake -G"Xcode" -DBUILD_FRAMEWORK=OFF -DBUILD_SHARED_LIBS=OFF -DCMAKE_OSX_ARCHITECTURES=x86_64 -DCMAKE_C_FLAGS="-Wall -Wextra" -DRULE_LAUNCH_COMPILE=ccache -DCMAKE_INSTALL_PREFIX=/usr/local ..
           cmake --build . --config Release --target install
           cd $GITHUB_WORKSPACE/..
           curl -L https://github.com/libsndfile/libsndfile/releases/download/1.0.31/libsndfile-1.0.31.tar.bz2 --output libsndfile.tar.bz2
@@ -315,7 +315,7 @@ jobs:
           cd libsndfile*/
           echo "building libsndfile"
           mkdir build && cd build
-          cmake -G"Xcode" -DBUILD_SHARED_LIBS=ON -DCMAKE_OSX_ARCHITECTURES=x86_64 -DCMAKE_C_FLAGS="-Wall -Wextra" -DCMAKE_INSTALL_PREFIX=/usr/local ..
+          cmake -G"Xcode" -DBUILD_SHARED_LIBS=ON -DCMAKE_OSX_ARCHITECTURES=x86_64 -DCMAKE_C_FLAGS="-Wall -Wextra" -DRULE_LAUNCH_COMPILE=ccache -DCMAKE_INSTALL_PREFIX=/usr/local ..
           cmake --build . --config Release --target install
       - name: install system libraries
         if: env.USE_SYSLIBS == 'true'

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -325,7 +325,7 @@ jobs:
           # the following assumes that we end up with the build in the folder SuperCollider
           # hdiutil sometimes fails with "create failed - Resource busy"
           # when that happens, we run it again
-          hdiutil create -srcfolder SuperCollider -format UDZO $ARTIFACT_FILE || hdiutil create -srcfolder SuperCollider -format UDZO $ARTIFACT_FILE
+          hdiutil create -srcfolder SuperCollider -format UDZO -fs HFS+ $ARTIFACT_FILE || hdiutil create -srcfolder SuperCollider -format UDZO -fs HFS+ $ARTIFACT_FILE
       - name: upload artifacts
         uses: actions/upload-artifact@v2
         if: matrix.artifact-suffix

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -344,7 +344,7 @@ jobs:
 
           echo "EXTRA_CMAKE_FLAGS:" $EXTRA_CMAKE_FLAGS
 
-          cmake -G"Xcode" -DRULE_LAUNCH_COMPILE=ccache -DCMAKE_OSX_DEPLOYMENT_TARGET=${{ matrix.deployment-target }} -DSUPERNOVA=ON $EXTRA_CMAKE_FLAGS .. --debug-output
+          cmake -G"Xcode" -DRULE_LAUNCH_COMPILE=ccache -DSUPERNOVA=ON $EXTRA_CMAKE_FLAGS .. --debug-output
       - name: build
         run: cmake --build $BUILD_PATH --config Release --target install
       - name: create archive


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

Fixes #5536

There seem to be 2 issues with the current macOS legacy build:
- it uses APFS, unsupported on older systems
- even though we build `libsndfile` ourselves, it depends on `libvorbis` and other libraries provided by homebrew.

I propose to change this by building all of the libsndfile's dependencies ourselves (libvorbis, libogg, flac, opus). I've also changed filesystem in the DMG to HFS+.

Currently in this PR all of the libsndfile's dependencies (libvorbis, libogg, flac, opus) **are build as static libraries.** `libsndfile` itself stays as shared library. Please let me know what you think about this. [I was having problems](https://github.com/dyfer/supercollider/runs/3268243473?check_suite_focus=true#step:14:21666) when they were all shared libraries.

~~I'm still testing whether the build is taking advantage of ccache.~~ ccache seems to be working. The build time for libsndfile et al went from 3+' to ~1'30".

Since our 3.12.0 legacy builds don't seem to support some legacy systems, I'm suggesting to put this into 3.12 branch and release a patch release (3.12.1) with this fix later on.

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review
