### PR TITLE
Add kitty and alacritty to list of Linux terminals

### DIFF
--- a/SCClassLibrary/Platform/linux/LinuxPlatform.sc
+++ b/SCClassLibrary/Platform/linux/LinuxPlatform.sc
@@ -55,7 +55,7 @@ LinuxPlatform : UnixPlatform {
 			"xfce4-terminal -T % -e %",
 			"mate-terminal -t % -e %",
 			"gnome-terminal -t % -- %",
-			"konsole --title % -e %"
+			"konsole --title % -e %",
 		].do{ |cmd|
 			if("command -v % > /dev/null".format(cmd.split($ ).first).systemCmd == 0) {
 				^cmd

--- a/SCClassLibrary/Platform/linux/LinuxPlatform.sc
+++ b/SCClassLibrary/Platform/linux/LinuxPlatform.sc
@@ -48,8 +48,8 @@ LinuxPlatform : UnixPlatform {
 			"termite --title % -e %",
 			"rxvt -T % -e %",
 			"terminator -T % -e %",
-			"xterm -T % -e %", 
-			"kitty -T % -e %", 
+			"xterm -T % -e %",
+			"kitty -T % -e %",
 			"alacritty -t % -e %",
 			// DE-specific terminals last: avoid problems if not on GNOME or KDE but term installed
 			"xfce4-terminal -T % -e %",

--- a/SCClassLibrary/Platform/linux/LinuxPlatform.sc
+++ b/SCClassLibrary/Platform/linux/LinuxPlatform.sc
@@ -49,11 +49,13 @@ LinuxPlatform : UnixPlatform {
 			"rxvt -T % -e %",
 			"terminator -T % -e %",
 			"xterm -T % -e %",
+            "kitty -T % -e %",
+            "alacritty -t % -e %",
 			// DE-specific terminals last: avoid problems if not on GNOME or KDE but term installed
 			"xfce4-terminal -T % -e %",
 			"mate-terminal -t % -e %",
 			"gnome-terminal -t % -- %",
-			"konsole --title % -e %",
+			"konsole --title % -e %"
 		].do{ |cmd|
 			if("command -v % > /dev/null".format(cmd.split($ ).first).systemCmd == 0) {
 				^cmd

--- a/SCClassLibrary/Platform/linux/LinuxPlatform.sc
+++ b/SCClassLibrary/Platform/linux/LinuxPlatform.sc
@@ -49,8 +49,8 @@ LinuxPlatform : UnixPlatform {
 			"rxvt -T % -e %",
 			"terminator -T % -e %",
 			"xterm -T % -e %", 
-            "kitty -T % -e %", 
-            "alacritty -t % -e %",
+			"kitty -T % -e %", 
+			"alacritty -t % -e %",
 			// DE-specific terminals last: avoid problems if not on GNOME or KDE but term installed
 			"xfce4-terminal -T % -e %",
 			"mate-terminal -t % -e %",

--- a/SCClassLibrary/Platform/linux/LinuxPlatform.sc
+++ b/SCClassLibrary/Platform/linux/LinuxPlatform.sc
@@ -48,8 +48,8 @@ LinuxPlatform : UnixPlatform {
 			"termite --title % -e %",
 			"rxvt -T % -e %",
 			"terminator -T % -e %",
-			"xterm -T % -e %",
-            "kitty -T % -e %",
+			"xterm -T % -e %", 
+            "kitty -T % -e %", 
             "alacritty -t % -e %",
 			// DE-specific terminals last: avoid problems if not on GNOME or KDE but term installed
 			"xfce4-terminal -T % -e %",


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

This adds to the awesome work made on the LinuxPlatform class in 3.12 where .runInTerminal was improved and had default terminals added to it. The list is missing two (gpu accelerated and) popular terminals: kitty and alacritty and so this is a simple PR that adds those two

## Types of changes

- New feature


## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [ ] Code is tested
- [ ] All tests are passing
- [ ] Updated documentation
- [x ] This PR is ready for review
