### PR TITLE
class library: improve efficiency of calling "order"

### DIFF
--- a/SCClassLibrary/Common/Collections/SequenceableCollection.sc
+++ b/SCClassLibrary/Common/Collections/SequenceableCollection.sc
@@ -1281,7 +1281,7 @@ SequenceableCollection : Collection {
 		// returns an array of indices that would sort the collection into order.
 		if(this.isEmpty) { ^[] };
 		if (function.isNil) { function = { arg a, b; a <= b }; };
-		array = [this, (0..this.lastIndex)].flop;
+		array = [this.asArray, (0..this.lastIndex)].flop;
 		orderFunc = {|a,b| function.value(a[0], b[0]) };
 		^array.mergeSort(orderFunc).flop[1]
 	}


### PR DESCRIPTION
When the collection "this" is not an array, a flop is very expensive. Better convert first. This commit is dedicated to John Bercow.

Discussion: https://scsynth.org/t/sorting-out-sorting-by/4472

<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

calling `order` on a `List` is very slow, and unnecessarily so.

## Types of changes

<!-- Delete lines that don't apply -->

- Breaking change (very unlikely, but in principle this is possible)

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [ ] All tests are passing
- [ ] Updated documentation
- [x] This PR is ready for review
