### PR TITLE
GitHub Actions Windows: update ASIO download

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -485,9 +485,9 @@ jobs:
           ASIO_PATH: ${{ env.LIBS_DOWNLOAD_PATH }}/asio_sdk
         run: |
           mkdir -p $ASIO_PATH && cd $ASIO_PATH
-          curl -L https://www.steinberg.net/sdk_downloads/asiosdk2.3.zip -o asio.zip
+          curl -L https://www.steinberg.net/asiosdk -o asio.zip
           7z x asio.zip -y
-          mv ASIOSDK2.3 $GITHUB_WORKSPACE/external_libraries/portaudio/asiosdk
+          mv asiosdk_* $GITHUB_WORKSPACE/external_libraries/portaudio/asiosdk
       - name: configure
         shell: bash
         run: |


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

Steinberg has [updated their website](https://twitter.com/SteinbergMedia/status/1429046887726866435?s=19) recently and the download link for the ASIO library has changed. The new link is https://www.steinberg.net/asiosdk and seems to redirect to the latest SDK. This PR updates the download link in GitHub Actions so that Windows builds work again.

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] This PR is ready for review
