### PR TITLE
Use newer SC version on the develop branch

### DIFF
--- a/SCVersion.txt
+++ b/SCVersion.txt
@@ -2,9 +2,9 @@
 # Note that you need to "make install" for this information to be copied into all places.
 
 set(SC_VERSION_MAJOR 3)
-set(SC_VERSION_MINOR 12)
-set(SC_VERSION_PATCH 2)
-set(SC_VERSION_TWEAK "")
+set(SC_VERSION_MINOR 13)
+set(SC_VERSION_PATCH 0)
+set(SC_VERSION_TWEAK "-dev")
 set(SC_VERSION ${SC_VERSION_MAJOR}.${SC_VERSION_MINOR}.${SC_VERSION_PATCH}${SC_VERSION_TWEAK})
 
 # Note: these are provided for backwards compatibility only. In the main project, PROJECT_VERSION_PATCH


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

As discussed in https://github.com/supercollider/rfcs/pull/16, I'd like to propose that the builds from the `develop` branch indicate the "next" SC version, along with the appropriate suffix, like `-prerelease` or `-preview`. This change has been briefly discussed with @joshpar and @jrsurge during the dev meeting on 2021-09-05 and I'm open to further suggestions on this. 

One expected side effect of this is that any future merges from the `<release>`/`main` branch into `develop` would need to resolve the conflict in `SCVersion.txt` (only once per version change though). The version on the develop brach should still stay as the "next" version.

## Types of changes

<!-- Delete lines that don't apply -->

- New feature

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [ ] Updated documentation - wiki
- [ ] Update the build python script
- [x] This PR is ready for review
