### PR TITLE
Classlib: Prevent possible infinite recursion in *initClassTree

### DIFF
--- a/SCClassLibrary/Common/Core/Kernel.sc
+++ b/SCClassLibrary/Common/Core/Kernel.sc
@@ -37,11 +37,12 @@ Class {
 		// start the process: Class.initClassTree(Object)
 		if(classesInited.isNil, { classesInited = IdentitySet.new });
 		if(classesInited.includes(aClass).not, {
+			classesInited.add(aClass);
+
 			if(aClass.isMetaClass.not and: { aClass.class.findMethod(\initClass).notNil }, {
 					aClass.initClass;
 			});
 
-			classesInited.add(aClass);
 			if(aClass.subclasses.notNil,{
 				aClass.subclasses.do({ arg class; this.initClassTree(class); });
 			});


### PR DESCRIPTION
## Purpose and Motivation

Fixes #5574 by moving `classesInited.add(aClass);` to precede the potentially recursive call.

This test case does hang the interpreter without the fix, and doesn't hang it with the fix.

```supercollider
Kaboom {
	*initClass {
		Class.initClassTree(this);
	}
}
```

## Types of changes

- Bug fix

## To-do list

- [x] Code is tested
- [x] All tests are passing
- [x] This PR is ready for review

I can't imagine a good way to unit-test this.