### PR TITLE
fixes #5579

### DIFF
--- a/server/scsynth/SC_MiscCmds.cpp
+++ b/server/scsynth/SC_MiscCmds.cpp
@@ -1213,15 +1213,14 @@ SCErr meth_g_head(World* inWorld, int inSize, char* inData, ReplyAddress* /*inRe
         if (!node)
             return kSCErr_NodeNotFound;
 
-        Group* prevGroup = node->mParent;
+        // Group* prevGroup = node->mParent;
 
         Node_Remove(node);
-
         Group_AddHead(group, node);
 
-        if (group != prevGroup) {
-            Node_StateMsg(node, kNode_Move);
-        }
+        // if (group != prevGroup) {
+        Node_StateMsg(node, kNode_Move);
+        // }
     }
     return kSCErr_None;
 }
@@ -1245,7 +1244,7 @@ SCErr meth_g_tail(World* inWorld, int inSize, char* inData, ReplyAddress* /*inRe
 
         // if (group != prevGroup) {
         Node_StateMsg(node, kNode_Move);
-        //}
+        // }
     }
     return kSCErr_None;
 }

--- a/server/scsynth/SC_MiscCmds.cpp
+++ b/server/scsynth/SC_MiscCmds.cpp
@@ -1213,14 +1213,10 @@ SCErr meth_g_head(World* inWorld, int inSize, char* inData, ReplyAddress* /*inRe
         if (!node)
             return kSCErr_NodeNotFound;
 
-        // Group* prevGroup = node->mParent;
-
         Node_Remove(node);
         Group_AddHead(group, node);
 
-        // if (group != prevGroup) {
         Node_StateMsg(node, kNode_Move);
-        // }
     }
     return kSCErr_None;
 }
@@ -1237,14 +1233,10 @@ SCErr meth_g_tail(World* inWorld, int inSize, char* inData, ReplyAddress* /*inRe
         if (!node)
             return kSCErr_NodeNotFound;
 
-        // Group *prevGroup = node->mParent;
-
         Node_Remove(node);
         Group_AddTail(group, node);
 
-        // if (group != prevGroup) {
         Node_StateMsg(node, kNode_Move);
-        // }
     }
     return kSCErr_None;
 }


### PR DESCRIPTION
- g_head should always fire an n_move reply,
  even if the parent group remains the same.
  This is in line with the other commands such
  as g_tail, and ensures that a client can build
  a copy of the tree structure by observing the
  server's n_move notifications.

## Purpose and Motivation

fixes #5579

## Types of changes

- Bug fix

## To-do list

- [X] Code is tested
- [ ] All tests are passing
- [n/a] Updated documentation
- [X] This PR is ready for review
