### PR TITLE
Help: Improve SynthDef arrayed control help

### DIFF
--- a/HelpSource/Classes/SynthDef.schelp
+++ b/HelpSource/Classes/SynthDef.schelp
@@ -30,13 +30,32 @@ definitionlist::
 ## trigger rate
 || Arguments that begin with "t_" (e.g. code::t_trig::), or that are specified as code::\tr:: in the def's rates argument (see below), will be made as a link::Classes/TrigControl::. Setting the argument will create a control-rate impulse at the set value. This is useful for triggers.
 ## literal arrays
-|| Arguments which have literal arrays as default values (see link::Reference/Literals::) result in multichannel controls, which can be set as a group with link::Classes/Node#setn#Node-setn:: or code::/n_setn::. When setting such controls no bounds checking is done, so you are responsible for making sure that you set the correct number of arguments.
+|| Arguments which have literal arrays as default values (see link::Reference/Literals::) result in multichannel controls, which can be set as a group with link::Classes/Node#setn#Node-setn:: or code::/n_setn::.
 ::
 
 See the examples below for more detail on how this works.
 
 Certain argument names (such as 'out' to specify an out bus) are in such common use that adopting them might be said to constitute 'good style'.
 One of these, 'gate' when used to control the gate input of an link::Classes/EnvGen::, deserves special mention, as it allows one to use Node's release method. See link::Classes/Node:: for an example and more detail.
+
+subsection:: Arrayed controls
+
+In some cases, it is useful to send a group of values to a single control name, for instance, code::aSynth.set(\freqs, [300, 400, 500])::, or for passing envelopes at Synth instantiation. This requires an emphasis::arrayed control:: to be defined in the SynthDef.
+
+There are two ways to define arrayed controls:
+
+numberedlist::
+## link::Classes/NamedControl:: -- recommended for flexibility and clarity.
+## Literal arrays (as noted above).
+::
+
+NamedControl can accept default values determined in code. For example, passing an envelope requires four values per breakpoint. It is easy to create a template for the arrayed control by writing code::NamedControl.kr(\env, Env.newClear(numSegments: 8).asArray)::.
+
+Literal arrays may be more convenient for very small arrays where all of the default values are known in advance.
+
+In general, it is likely to be simpler in most cases to use NamedControl for arrayed controls.
+
+See the example under link::#Array Arguments::.
 
 subsection:: Static versus Dynamic Elements
 
@@ -331,12 +350,13 @@ Synth('vartest.gamma');
 Synth('vartest.alpha', [\release, 3, \freq, 660]);
 ::
 
-subsection:: Literal Array Arguments
+subsection:: Array Arguments
 code::
-// freqs has a literal array of defaults. This makes a multichannel Control of the same size.
+// freqs is defined as an arrayed control. This makes a multichannel Control of the same size.
 (
-SynthDef(\arrayarg, { |out, amp = 0.1, freqs = #[300, 400, 500, 600], gate = 1|
+SynthDef(\arrayarg, { |out, amp = 0.1, gate = 1|
 	var env, sines;
+	var freqs = NamedControl.kr(\freqs, [300, 400, 500, 600]);
 	env = Linen.kr(gate, 0.1, 1, 1, 2) * amp;
 	sines = SinOsc.ar(freqs +.t [0,0.5]).cubed.sum; // A mix of 4 oscillators
 	Out.ar(out, sines * env);
@@ -346,9 +366,11 @@ SynthDef(\arrayarg, { |out, amp = 0.1, freqs = #[300, 400, 500, 600], gate = 1|
 x = Synth(\arrayarg);
 x.setn(\freqs, [440, 441, 442, 443]);
 
-// Don't accidentally set too many values, or you may have unexpected side effects
-// The code below inadvertently sets the gate arg, and frees the synth
+// Values outside of the array bounds are ignored --
+// 0 is dropped
 x.setn(\freqs, [300, 400, 500, 600, 0]);
+
+x.release;
 
 // Mr. McCartney's more complex example
 (


### PR DESCRIPTION
## Purpose and Motivation

AFAIK, SynthDef help is the main place to read about arrayed controls.

Some of the information about it in this help file is outdated or misleading:

1. We have had bounds checking for arrayed controls for several years now (I did retest this). I needed to remove two remarks claiming that this is the user's responsibility.
2. The help file discusses only literal arrays. IMO it's better practice generally to use `NamedControl` for arrays, with literal arrays as a convenience for simpler cases. This point in particular greatly misled a new user on the forum.

So I've added a new subsection near the top introducing NamedControl and literal arrays (while recommending NamedControl), and changed the example near the bottom to use NamedControl.

I suppose the latter change might be somewhat contentious for users who strongly prefer literal arrays for this use case. But, I think it's better for our documentation to model code styles that invite less confusion. NamedControl works in the same way for every arrayed-control case. Literal arrays work in simple cases but are clumsy to scale up to cases such as long envelopes. Also, for the forum user, it caused considerable confusion that literal arrays are immutable while they controls created from them are not. My personal opinion is that there is not much benefit in recommending literal arrays as the first choice here.

## Types of changes

- Documentation

## To-do list

- [x] Updated documentation
- [x] This PR is ready for review