### PR TITLE
GUI: QcRangeSlider: fix stretch behaviour

### DIFF
--- a/QtCollider/widgets/QcRangeSlider.cpp
+++ b/QtCollider/widgets/QcRangeSlider.cpp
@@ -34,7 +34,7 @@ QC_DECLARE_QWIDGET_FACTORY(QcRangeSlider);
 
 QcRangeSlider::QcRangeSlider(): QtCollider::Style::Client(this), _lo(0.0), _hi(1.0), _step(0.01f), mouseMode(None) {
     setFocusPolicy(Qt::StrongFocus);
-    setOrientation(static_cast<int>(Qt::Vertical));
+    setOrientation(Qt::Vertical);
     setAttribute(Qt::WA_AcceptTouchEvents);
 }
 

--- a/QtCollider/widgets/QcRangeSlider.cpp
+++ b/QtCollider/widgets/QcRangeSlider.cpp
@@ -34,12 +34,12 @@ QC_DECLARE_QWIDGET_FACTORY(QcRangeSlider);
 
 QcRangeSlider::QcRangeSlider(): QtCollider::Style::Client(this), _lo(0.0), _hi(1.0), _step(0.01f), mouseMode(None) {
     setFocusPolicy(Qt::StrongFocus);
-    setOrientation(Qt::Vertical);
+    setOrientation(static_cast<int>(Qt::Vertical));
     setAttribute(Qt::WA_AcceptTouchEvents);
 }
 
 void QcRangeSlider::setOrientation(int orientation) {
-    _ort = asOrientationWithDefault<Qt::Vertical>(orientation);
+    _ort = asOrientationWithDefault(orientation, Qt::Vertical);
 
     if (_ort == Qt::Horizontal) {
         setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
@@ -390,7 +390,7 @@ void QcRangeSlider::paintEvent(QPaintEvent* e) {
     }
 }
 
-template <Qt::Orientation defaultOrientation> Qt::Orientation asOrientationWithDefault(int orientationValue) {
+Qt::Orientation QcRangeSlider::asOrientationWithDefault(int orientationValue, Qt::Orientation defaultOrientation) {
     if (orientationValue == Qt::Horizontal || orientationValue == Qt::Vertical)
         return static_cast<Qt::Orientation>(orientationValue);
 

--- a/QtCollider/widgets/QcRangeSlider.cpp
+++ b/QtCollider/widgets/QcRangeSlider.cpp
@@ -390,10 +390,9 @@ void QcRangeSlider::paintEvent(QPaintEvent* e) {
     }
 }
 
-template <Qt::Orientation defaultOrientation> 
-Qt::Orientation asOrientationWithDefault(int orientationValue) {
+template <Qt::Orientation defaultOrientation> Qt::Orientation asOrientationWithDefault(int orientationValue) {
     if (orientationValue == Qt::Horizontal || orientationValue == Qt::Vertical)
-        return static_cast<Qt::Orientation> (orientationValue);
+        return static_cast<Qt::Orientation>(orientationValue);
 
     return defaultOrientation;
 }

--- a/QtCollider/widgets/QcRangeSlider.cpp
+++ b/QtCollider/widgets/QcRangeSlider.cpp
@@ -38,8 +38,8 @@ QcRangeSlider::QcRangeSlider(): QtCollider::Style::Client(this), _lo(0.0), _hi(1
     setAttribute(Qt::WA_AcceptTouchEvents);
 }
 
-void QcRangeSlider::setOrientation(int i) {
-    _ort = (Qt::Orientation)i;
+void QcRangeSlider::setOrientation(int orientation) {
+    _ort = asOrientationWithDefault<Qt::Vertical>(orientation);
 
     if (_ort == Qt::Horizontal) {
         setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
@@ -388,4 +388,12 @@ void QcRangeSlider::paintEvent(QPaintEvent* e) {
         else
             p.drawRect(valRect.adjusted(2, 1, -2, -1));
     }
+}
+
+template <Qt::Orientation defaultOrientation> 
+Qt::Orientation asOrientationWithDefault(int orientationValue) {
+    if (orientationValue == Qt::Horizontal || orientationValue == Qt::Vertical)
+        return static_cast<Qt::Orientation> (orientationValue);
+
+    return defaultOrientation;
 }

--- a/QtCollider/widgets/QcRangeSlider.cpp
+++ b/QtCollider/widgets/QcRangeSlider.cpp
@@ -38,13 +38,13 @@ QcRangeSlider::QcRangeSlider(): QtCollider::Style::Client(this), _lo(0.0), _hi(1
     setAttribute(Qt::WA_AcceptTouchEvents);
 }
 
-void QcRangeSlider::setOrientation(Qt::Orientation o) {
-    _ort = o;
+void QcRangeSlider::setOrientation(int i) {
+    _ort = (Qt::Orientation)i;
 
     if (_ort == Qt::Horizontal) {
-        setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
+        setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
     } else {
-        setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Expanding);
+        setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Expanding);
     }
 
     updateGeometry();

--- a/QtCollider/widgets/QcRangeSlider.h
+++ b/QtCollider/widgets/QcRangeSlider.h
@@ -82,8 +82,7 @@ private:
     void mouseReleaseEvent(QMouseEvent*);
     void keyPressEvent(QKeyEvent*);
     void paintEvent(QPaintEvent*);
-    template <Qt::Orientation> 
-    Qt::Orientation asOrientationWithDefault(int);
+    template <Qt::Orientation> Qt::Orientation asOrientationWithDefault(int);
 
     Qt::Orientation _ort;
     double _lo;

--- a/QtCollider/widgets/QcRangeSlider.h
+++ b/QtCollider/widgets/QcRangeSlider.h
@@ -82,7 +82,7 @@ private:
     void mouseReleaseEvent(QMouseEvent*);
     void keyPressEvent(QKeyEvent*);
     void paintEvent(QPaintEvent*);
-    template <Qt::Orientation> Qt::Orientation asOrientationWithDefault(int);
+    Qt::Orientation asOrientationWithDefault(int, Qt::Orientation);
 
     Qt::Orientation _ort;
     double _lo;

--- a/QtCollider/widgets/QcRangeSlider.h
+++ b/QtCollider/widgets/QcRangeSlider.h
@@ -45,7 +45,7 @@ public:
 
     QcRangeSlider();
     Qt::Orientation orientation() const { return _ort; }
-    void setOrientation(Qt::Orientation o);
+    void setOrientation(int);
     double loValue() const { return _lo; }
     void setLoValue(double);
     double hiValue() const { return _hi; }

--- a/QtCollider/widgets/QcRangeSlider.h
+++ b/QtCollider/widgets/QcRangeSlider.h
@@ -82,6 +82,8 @@ private:
     void mouseReleaseEvent(QMouseEvent*);
     void keyPressEvent(QKeyEvent*);
     void paintEvent(QPaintEvent*);
+    template <Qt::Orientation> 
+    Qt::Orientation asOrientationWithDefault(int);
 
     Qt::Orientation _ort;
     double _lo;


### PR DESCRIPTION
Fixes issue #3696. The proposed change makes it possible to
adjust the height / width of a RangeSlider by using stretch
factors. The behaviour of RangeSlider will then match the behaviour
of Slider.

<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

Fixes #3696

## Types of changes

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation -> no changes needed
- [x] This PR is ready for review
