### PR TITLE
Plugins: Fix AudioControl and InFeedback processing for an extra cycle

### DIFF
--- a/server/plugins/IOUGens.cpp
+++ b/server/plugins/IOUGens.cpp
@@ -187,8 +187,7 @@ void AudioControl_next_k(AudioControl* unit, int inNumSamples) {
     int32* touched = world->mAudioBusTouched;
     int32* channelOffsets = unit->mParent->mAudioBusOffsets;
 
-    if(*mapin != unit->m_prevBus)
-    {
+    if (*mapin != unit->m_prevBus) {
         unit->m_busUsedInPrevCycle = false;
         unit->m_prevBus = *mapin;
     }
@@ -233,19 +232,16 @@ void AudioControl_next_k(AudioControl* unit, int inNumSamples) {
             if (validOffset && diff == 0) {
                 Copy(inNumSamples, out, *mapin);
                 unit->m_busUsedInPrevCycle = true;
-            }
-            else if(validOffset && diff == 1) {
-                if(unit->m_busUsedInPrevCycle) {
+            } else if (validOffset && diff == 1) {
+                if (unit->m_busUsedInPrevCycle) {
                     Fill(inNumSamples, out, 0.f);
                     unit->m_busUsedInPrevCycle = false;
-                }
-                else
+                } else
                     Copy(inNumSamples, out, *mapin);
-            }
-            else {
+            } else {
                 Fill(inNumSamples, out, 0.f);
                 unit->m_busUsedInPrevCycle = false;
-            } 
+            }
         } break;
         }
     }
@@ -267,8 +263,7 @@ void AudioControl_next_1(AudioControl* unit, int inNumSamples) {
     int32 bufCounter = world->mBufCounter;
     int32* channelOffsets = unit->mParent->mAudioBusOffsets;
 
-    if(*mapin != unit->m_prevBus)
-    {
+    if (*mapin != unit->m_prevBus) {
         unit->m_busUsedInPrevCycle = false;
         unit->m_prevBus = *mapin;
     }
@@ -298,16 +293,13 @@ void AudioControl_next_1(AudioControl* unit, int inNumSamples) {
         if (validOffset && diff == 0) {
             Copy(inNumSamples, out, *mapin);
             unit->m_busUsedInPrevCycle = true;
-        }
-        else if(validOffset && diff == 1) {
-            if(unit->m_busUsedInPrevCycle) {
+        } else if (validOffset && diff == 1) {
+            if (unit->m_busUsedInPrevCycle) {
                 Fill(inNumSamples, out, 0.f);
                 unit->m_busUsedInPrevCycle = false;
-            }
-            else
+            } else
                 Copy(inNumSamples, out, *mapin);
-        }
-        else {
+        } else {
             Fill(inNumSamples, out, 0.f);
             unit->m_busUsedInPrevCycle = false;
         }
@@ -701,7 +693,7 @@ void InFeedback_next_a(InFeedback* unit, int inNumSamples) {
     int numChannels = unit->mNumOutputs;
 
     float fbusChannel = ZIN0(0);
-    if(fbusChannel != unit->m_fbusChannel)
+    if (fbusChannel != unit->m_fbusChannel)
         unit->m_busUsedInPrevCycle = false;
     IO_a_update_channels(unit, world, fbusChannel, numChannels, bufLength);
 
@@ -716,19 +708,16 @@ void InFeedback_next_a(InFeedback* unit, int inNumSamples) {
         float* out = OUT(i);
         int diff = bufCounter - touched[i];
 
-        if(guard.isValid && diff == 0) {
+        if (guard.isValid && diff == 0) {
             Copy(inNumSamples, out, in);
             unit->m_busUsedInPrevCycle = true;
-        }
-        else if(guard.isValid && diff == 1) {
-            if(unit->m_busUsedInPrevCycle) {
+        } else if (guard.isValid && diff == 1) {
+            if (unit->m_busUsedInPrevCycle) {
                 Fill(inNumSamples, out, 0.f);
                 unit->m_busUsedInPrevCycle = false;
-            }
-            else
+            } else
                 Copy(inNumSamples, out, in);
-        }
-        else {
+        } else {
             Fill(inNumSamples, out, 0.f);
             unit->m_busUsedInPrevCycle = false;
         }

--- a/server/plugins/IOUGens.cpp
+++ b/server/plugins/IOUGens.cpp
@@ -62,8 +62,13 @@ struct OffsetOut : public IOUnit {
     bool m_empty;
 };
 
-struct AudioControl : public IOUnit {
+struct InFeedback : public IOUnit {
+    bool m_busUsedInPrevCycle;
+};
+
+struct AudioControl : public InFeedback {
     float* prevVal; // this will have to be a pointer later!
+    float* m_prevBus;
 };
 
 const int kMaxLags = 16;
@@ -114,8 +119,8 @@ void LagIn_Ctor(LagIn* unit);
 void LagIn_next_0(LagIn* unit, int inNumSamples);
 void LagIn_next_k(LagIn* unit, int inNumSamples);
 
-void InFeedback_Ctor(IOUnit* unit);
-void InFeedback_next_a(IOUnit* unit, int inNumSamples);
+void InFeedback_Ctor(InFeedback* unit);
+void InFeedback_next_a(InFeedback* unit, int inNumSamples);
 
 void LocalIn_Ctor(LocalIn* unit);
 void LocalIn_Dtor(LocalIn* unit);
@@ -182,6 +187,12 @@ void AudioControl_next_k(AudioControl* unit, int inNumSamples) {
     int32* touched = world->mAudioBusTouched;
     int32* channelOffsets = unit->mParent->mAudioBusOffsets;
 
+    if(*mapin != unit->m_prevBus)
+    {
+        unit->m_busUsedInPrevCycle = false;
+        unit->m_prevBus = *mapin;
+    }
+
     for (uint32 i = 0; i < numChannels; ++i, mapin++) {
         float* out = OUT(i);
         int* mapRatep;
@@ -217,14 +228,24 @@ void AudioControl_next_k(AudioControl* unit, int inNumSamples) {
                 previous control period (to enable an InFeedback type of mapping)...
             */
             int thisChannelOffset = channelOffsets[unit->mSpecialIndex + i];
-            //  ... are we good to write? Copy! or ...
-            if ((thisChannelOffset >= 0)
-                && ((touched[thisChannelOffset] == bufCounter) || (touched[thisChannelOffset] == bufCounter - 1))) {
+            bool validOffset = thisChannelOffset >= 0;
+            int diff = bufCounter - touched[thisChannelOffset];
+            if (validOffset && diff == 0) {
                 Copy(inNumSamples, out, *mapin);
-            } else {
-                //  ... old data, so zero it out.
-                Fill(inNumSamples, out, 0.f);
+                unit->m_busUsedInPrevCycle = true;
             }
+            else if(validOffset && diff == 1) {
+                if(unit->m_busUsedInPrevCycle) {
+                    Fill(inNumSamples, out, 0.f);
+                    unit->m_busUsedInPrevCycle = false;
+                }
+                else
+                    Copy(inNumSamples, out, *mapin);
+            }
+            else {
+                Fill(inNumSamples, out, 0.f);
+                unit->m_busUsedInPrevCycle = false;
+            } 
         } break;
         }
     }
@@ -246,6 +267,12 @@ void AudioControl_next_1(AudioControl* unit, int inNumSamples) {
     int32 bufCounter = world->mBufCounter;
     int32* channelOffsets = unit->mParent->mAudioBusOffsets;
 
+    if(*mapin != unit->m_prevBus)
+    {
+        unit->m_busUsedInPrevCycle = false;
+        unit->m_prevBus = *mapin;
+    }
+
     switch (mapRate) {
     case 0: {
         for (int i = 0; i < inNumSamples; i++) {
@@ -266,11 +293,23 @@ void AudioControl_next_1(AudioControl* unit, int inNumSamples) {
          */
     case 2: {
         int thisChannelOffset = channelOffsets[unit->mSpecialIndex];
-        if ((thisChannelOffset >= 0)
-            && ((touched[thisChannelOffset] == bufCounter) || (touched[thisChannelOffset] == bufCounter - 1))) {
+        bool validOffset = thisChannelOffset >= 0;
+        int diff = bufCounter - touched[thisChannelOffset];
+        if (validOffset && diff == 0) {
             Copy(inNumSamples, out, *mapin);
-        } else {
+            unit->m_busUsedInPrevCycle = true;
+        }
+        else if(validOffset && diff == 1) {
+            if(unit->m_busUsedInPrevCycle) {
+                Fill(inNumSamples, out, 0.f);
+                unit->m_busUsedInPrevCycle = false;
+            }
+            else
+                Copy(inNumSamples, out, *mapin);
+        }
+        else {
             Fill(inNumSamples, out, 0.f);
+            unit->m_busUsedInPrevCycle = false;
         }
     } break;
     }
@@ -278,6 +317,7 @@ void AudioControl_next_1(AudioControl* unit, int inNumSamples) {
 
 void AudioControl_Ctor(AudioControl* unit) {
     unit->prevVal = (float*)RTAlloc(unit->mWorld, unit->mNumOutputs * sizeof(float));
+    unit->m_prevBus = NULL;
     for (int i = 0; i < unit->mNumOutputs; i++) {
         unit->prevVal[i] = 0.0;
     }
@@ -655,12 +695,14 @@ void LagIn_Ctor(LagIn* unit) {
 
 //////////////////////////////////////////////////////////////////////////////////////////////////
 
-void InFeedback_next_a(IOUnit* unit, int inNumSamples) {
+void InFeedback_next_a(InFeedback* unit, int inNumSamples) {
     World* world = unit->mWorld;
     int bufLength = world->mBufLength;
     int numChannels = unit->mNumOutputs;
 
     float fbusChannel = ZIN0(0);
+    if(fbusChannel != unit->m_fbusChannel)
+        unit->m_busUsedInPrevCycle = false;
     IO_a_update_channels(unit, world, fbusChannel, numChannels, bufLength);
 
     float* in = unit->m_bus;
@@ -673,15 +715,28 @@ void InFeedback_next_a(IOUnit* unit, int inNumSamples) {
 
         float* out = OUT(i);
         int diff = bufCounter - touched[i];
-        if (guard.isValid && (diff == 1 || diff == 0))
+
+        if(guard.isValid && diff == 0) {
             Copy(inNumSamples, out, in);
-        else
+            unit->m_busUsedInPrevCycle = true;
+        }
+        else if(guard.isValid && diff == 1) {
+            if(unit->m_busUsedInPrevCycle) {
+                Fill(inNumSamples, out, 0.f);
+                unit->m_busUsedInPrevCycle = false;
+            }
+            else
+                Copy(inNumSamples, out, in);
+        }
+        else {
             Fill(inNumSamples, out, 0.f);
+            unit->m_busUsedInPrevCycle = false;
+        }
     }
 }
 
 
-void InFeedback_Ctor(IOUnit* unit) {
+void InFeedback_Ctor(InFeedback* unit) {
     // Print("->InFeedback_Ctor\n");
     World* world = unit->mWorld;
     unit->m_fbusChannel = -1.;

--- a/testsuite/classlibrary/TestIOUGens.sc
+++ b/testsuite/classlibrary/TestIOUGens.sc
@@ -22,7 +22,7 @@ TestIOUGens : UnitTest {
             var inFeedback = InFeedback.ar(bus.index);
             inFeedback - in;
         }.loadToFloatArray(0.5, server, { | data |
-            this.assertFloatEquals(data.sum, 0.0, "InFeedback is not equal to In", report:true);
+            this.assertFloatEquals(data.sum, 0.0, "InFeedback should be equal to In when no other signal has been written to its bus", report:true);
             condition.unhang;
         });
 
@@ -30,7 +30,7 @@ TestIOUGens : UnitTest {
     }
 
     //Test that AudioControl is equal to In when write / read are in the right order
-    test_AudioControl_equals_In {
+    test_AudioControl_equals_In_for_read_after_write {
         var condition = Condition();
         var bus = Bus.audio(server);
         var sumBus = Bus.audio(server);
@@ -56,7 +56,7 @@ TestIOUGens : UnitTest {
 
         server.bind({
             sum.loadToFloatArray(0.5, server, { | data |
-                this.assertFloatEquals(data.sum, 0.0, "AudioControl is not equal to In", report:true);
+                this.assertFloatEquals(data.sum, 0.0, "AudioControl should be equal to In for read after write", report:true);
                 condition.unhang;
             });
 			in.play(server);
@@ -68,7 +68,7 @@ TestIOUGens : UnitTest {
     }
 
     //Test that InFeedback is equal to In + a delay of BlockSize when write/read are one cycle apart
-    test_InFeedback_equals_delayed_In {
+    test_InFeedback_equals_In_for_write_after_read {
         var condition = Condition();
         var bus = Bus.audio(server);
 
@@ -79,7 +79,7 @@ TestIOUGens : UnitTest {
             var delayedIn = DelayN.ar(In.ar(bus.index), blockSizeMs, blockSizeMs);
             inFeedback - delayedIn;
         }.loadToFloatArray(0.5, server, { | data |
-            this.assertFloatEquals(data.sum, 0.0, "InFeedback is not equal to delayed In", report:true);
+            this.assertFloatEquals(data.sum, 0.0, "InFeedback should be equal to In + a delay of BlockSize when write/read are one cycle apart", report:true);
             condition.unhang;
         });
 
@@ -87,7 +87,7 @@ TestIOUGens : UnitTest {
     }
 
     //Test that AudioControl is equal to In + a delay of BlockSize when write/read are one cycle apart
-    test_AudioControl_equals_delayed_In {
+    test_AudioControl_equals_In_for_write_after_read {
         var condition = Condition();
         var bus = Bus.audio(server);
         var sumBus = Bus.audio(server);
@@ -114,7 +114,7 @@ TestIOUGens : UnitTest {
 
         server.bind({
             sum.loadToFloatArray(0.5, server, { | data |
-                this.assertFloatEquals(data.sum, 0.0, "AudioControl is not equal to delayed In", report:true);
+                this.assertFloatEquals(data.sum, 0.0, "AudioControl should be equal to In + a delay of BlockSize when write/read are one cycle apart", report:true);
                 condition.unhang;
             });
 			delayedIn.play(server);

--- a/testsuite/classlibrary/TestIOUGens.sc
+++ b/testsuite/classlibrary/TestIOUGens.sc
@@ -37,17 +37,17 @@ TestIOUGens : UnitTest {
 
         var writer = {
             Out.ar(bus.index, SinOsc.ar(1));
-            Silence.ar;
+            Silent.ar;
         };
 
         var in = {
             Out.ar(sumBus.index, In.ar(bus.index));
-            Silence.ar;
+            Silent.ar;
         };
 
         var audioControl = {
             Out.ar(sumBus.index, -1 * (\in.ar)); //Invert to perform difference at sumBus
-            Silence.ar;
+            Silent.ar;
         };
 
         var sum = {
@@ -94,18 +94,18 @@ TestIOUGens : UnitTest {
 
         var writer = {
             Out.ar(bus.index, SinOsc.ar(1));
-            Silence.ar;
+            Silent.ar;
         };
 
         var delayedIn = {
             var blockSizeMs = BlockSize.ir / SampleRate.ir;
             Out.ar(sumBus.index, DelayN.ar(In.ar(bus.index), blockSizeMs, blockSizeMs));
-            Silence.ar;
+            Silent.ar;
         };
 
         var audioControl = {
             Out.ar(sumBus.index, -1 * (\in.ar)); //Invert to perform difference at sumBus
-            Silence.ar;
+            Silent.ar;
         };
 
         var sum = {

--- a/testsuite/classlibrary/TestIOUGens.sc
+++ b/testsuite/classlibrary/TestIOUGens.sc
@@ -1,0 +1,127 @@
+TestIOUGens : UnitTest {
+    var server;
+
+	setUp {
+		server = Server(this.class.name);
+		server.bootSync;
+	}
+
+	tearDown {
+		server.quit;
+		server.remove;
+	}
+
+    //Test that InFeedback is equal to In when write / read are in the right order
+    test_InFeedback_equals_In {
+        var condition = Condition();
+        var bus = Bus.audio(server);
+
+        {
+            var writer = Out.ar(bus.index, SinOsc.ar(1));
+            var in = In.ar(bus.index);
+            var inFeedback = InFeedback.ar(bus.index);
+            inFeedback - in;
+        }.loadToFloatArray(0.5, server, { | data |
+            this.assertFloatEquals(data.sum, 0.0, "InFeedback is not equal to In", report:true);
+            condition.unhang;
+        });
+
+        condition.hang;
+    }
+
+    //Test that AudioControl is equal to In when write / read are in the right order
+    test_AudioControl_equals_In {
+        var condition = Condition();
+        var bus = Bus.audio(server);
+        var sumBus = Bus.audio(server);
+
+        var writer = {
+            Out.ar(bus.index, SinOsc.ar(1));
+            Silence.ar;
+        };
+
+        var in = {
+            Out.ar(sumBus.index, In.ar(bus.index));
+            Silence.ar;
+        };
+
+        var audioControl = {
+            Out.ar(sumBus.index, -1 * (\in.ar)); //Invert to perform difference at sumBus
+            Silence.ar;
+        };
+
+        var sum = {
+            In.ar(sumBus.index);
+        };
+
+        server.bind({
+            sum.loadToFloatArray(0.5, server, { | data |
+                this.assertFloatEquals(data.sum, 0.0, "AudioControl is not equal to In", report:true);
+                condition.unhang;
+            });
+			in.play(server);
+            audioControl.play(server, args:[ \in, 'a' ++ bus.index ]);
+			writer.play(server);
+        });
+
+        condition.hang;
+    }
+
+    //Test that InFeedback is equal to In + a delay of BlockSize when write/read are one cycle apart
+    test_InFeedback_equals_delayed_In {
+        var condition = Condition();
+        var bus = Bus.audio(server);
+
+        {
+            var inFeedback = InFeedback.ar(bus.index);
+            var writer = Out.ar(bus.index, SinOsc.ar(1));
+            var blockSizeMs = BlockSize.ir / SampleRate.ir;
+            var delayedIn = DelayN.ar(In.ar(bus.index), blockSizeMs, blockSizeMs);
+            inFeedback - delayedIn;
+        }.loadToFloatArray(0.5, server, { | data |
+            this.assertFloatEquals(data.sum, 0.0, "InFeedback is not equal to delayed In", report:true);
+            condition.unhang;
+        });
+
+        condition.hang;
+    }
+
+    //Test that AudioControl is equal to In + a delay of BlockSize when write/read are one cycle apart
+    test_AudioControl_equals_delayed_In {
+        var condition = Condition();
+        var bus = Bus.audio(server);
+        var sumBus = Bus.audio(server);
+
+        var writer = {
+            Out.ar(bus.index, SinOsc.ar(1));
+            Silence.ar;
+        };
+
+        var delayedIn = {
+            var blockSizeMs = BlockSize.ir / SampleRate.ir;
+            Out.ar(sumBus.index, DelayN.ar(In.ar(bus.index), blockSizeMs, blockSizeMs));
+            Silence.ar;
+        };
+
+        var audioControl = {
+            Out.ar(sumBus.index, -1 * (\in.ar)); //Invert to perform difference at sumBus
+            Silence.ar;
+        };
+
+        var sum = {
+            In.ar(sumBus.index);
+        };
+
+        server.bind({
+            sum.loadToFloatArray(0.5, server, { | data |
+                this.assertFloatEquals(data.sum, 0.0, "AudioControl is not equal to delayed In", report:true);
+                condition.unhang;
+            });
+			delayedIn.play(server);
+			writer.play(server);
+            audioControl.play(server, args:[ \in, 'a' ++ bus.index ]);
+        });
+
+        condition.hang;
+    }
+}


### PR DESCRIPTION
## Purpose and Motivation

I have noticed a weird behavior of the `AudioControl` and `InFeedback` UGens.

If you run this code, you'll notice that the last audio cycle will run twice, generating a "double" dropout:

```SuperCollider
(
s.waitForBoot({
	SynthDef(\test, {
		Out.ar(\out.ir(0), { SinOsc.ar(2) * EnvGen.ar(Env([1, 1], [0.2]), doneAction:2) })
	}).add;

	s.sync;

	~bus = Bus.audio(s);

	Pbind(
		\instrument, \test,
		\dur, 1,
		\out, ~bus.index,
		\addAction, \addToHead
	).play;

	~reader = { \in.ar }.play(args:[ \in, 'a' ++ ~bus.index]);

	{ In.ar(0) }.plot(0.5);
})
)
```

![image](https://user-images.githubusercontent.com/32070555/137885438-1df7ef74-dd2c-4386-9609-60098df08849.png)

This happens because the `AudioControl` UGen (as well as the `InFeedback` one) only check if the bus has been touched in the current audio cycle. In my opinion, it should probably take into consideration if the bus has been touched in the previous audio cycle aswell, in order to avoid this "repetition" effect.

This PR fixes this issue. It basically allows `AudioControl` and `InFeedback` to work just like `In` when the `~reader` `Synth` is later in the chain, and just like `InFeedback` when the `~reader` `Synth` is before in the chain (reading the previous audio cycle).

`Pbind (\addToHead) -> ~reader:`
![image (1)](https://user-images.githubusercontent.com/32070555/137885661-f84d1fd4-fcfe-4aae-a965-f07d191611cc.png)

`-> ~reader Pbind (\addToTail) ->:`
![image (2)](https://user-images.githubusercontent.com/32070555/137885694-5c87ced2-7420-4382-81a4-14f1639c84d3.png)

## Types of changes

- Bug fix

## To-do list

- [X] Code is tested
- [X] All tests are passing
- [X] Updated documentation
- [x] This PR is ready for review
