### PR TITLE
fix: Tap Ugen samplerate compensation with BufRateScale.kr()

### DIFF
--- a/SCClassLibrary/Common/Audio/BufIO.sc
+++ b/SCClassLibrary/Common/Audio/BufIO.sc
@@ -137,7 +137,7 @@ Tap : UGen {
 	*ar { arg bufnum = 0, numChannels = 1, delaytime = 0.2;
 		var n;
 		n = delaytime * SampleRate.ir.neg; // this depends on the session sample rate, not buffer.
-		^PlayBuf.ar(numChannels, bufnum, 1, 0, n, 1);
+		^PlayBuf.ar(numChannels, bufnum, BufRateScale.kr(bufnum) * 1, 0, n, 1);
 	}
 }
 

--- a/SCClassLibrary/Common/Audio/BufIO.sc
+++ b/SCClassLibrary/Common/Audio/BufIO.sc
@@ -135,9 +135,9 @@ ScopeOut2 : UGen {
 
 Tap : UGen {
 	*ar { arg bufnum = 0, numChannels = 1, delaytime = 0.2;
-		var n;
-		n = delaytime * SampleRate.ir.neg; // this depends on the session sample rate, not buffer.
-		^PlayBuf.ar(numChannels, bufnum, BufRateScale.kr(bufnum) * 1, 0, n, 1);
+		var scale = BufRateScale.kr(bufnum);
+		var n = delaytime * (SampleRate.ir.neg * scale);
+		^PlayBuf.ar(numChannels, bufnum, scale, 0, n, 1);
 	}
 }
 


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation
To prevent unintentional changes in pitch due to the difference between the system samplerate and the buffer samplerate.

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [ ] All tests are passing
- [ ] Updated documentation
- [x] This PR is ready for review
