### PR TITLE
Classlib: Allow any type of text stream in the FileReader hierarchy

### DIFF
--- a/SCClassLibrary/Common/Streams/TabFileReader.sc
+++ b/SCClassLibrary/Common/Streams/TabFileReader.sc
@@ -3,16 +3,25 @@ FileReader : Stream {
 	classvar <delim = $ ;	// space separated by default
 	var <stream, skipEmptyLines=false, skipBlanks=false, <delimiter;
 
-	*new { | pathOrFile, skipEmptyLines=false, skipBlanks=false,  delimiter |
+	*new { | pathOrFile, skipEmptyLines=false, skipBlanks=false, delimiter |
 		var stream;
-		if (pathOrFile.isKindOf(File) ) { stream = pathOrFile }  { stream =  File(pathOrFile, "r") };
-		if (stream.isOpen.not) { warn(this.name ++ ": file" + pathOrFile + "not found.") ^nil };
+		if(pathOrFile.respondsTo(\getChar) ) {
+			stream = pathOrFile
+		} {
+			stream = File(pathOrFile, "r");
+			if(stream.isOpen.not) {
+				warn(this.name ++ ": file" + pathOrFile + "not found.");
+				^nil
+			};
+		};
 		^super.newCopyArgs(stream, skipEmptyLines, skipBlanks,  delimiter ? this.delim)
 	}
 
 	reset { stream.reset }
 
-	close { stream.close }
+	// CollStream doesn't implement 'close'
+	// but is legal to use with readers otherwise
+	close { stream.tryPerform(\close) }
 
 	next {
 		var c, record, string = String.new;

--- a/SCClassLibrary/Common/Streams/TabFileReader.sc
+++ b/SCClassLibrary/Common/Streams/TabFileReader.sc
@@ -1,9 +1,9 @@
 FileReader : Stream {
 	// a class to read text files automatically
 	classvar <delim = $ ;	// space separated by default
-	var <stream, skipEmptyLines=false, skipBlanks=false, <delimiter;
+	var <stream, skipEmptyLines = false, skipBlanks = false, <delimiter;
 
-	*new { | pathOrFile, skipEmptyLines=false, skipBlanks=false, delimiter |
+	*new { |pathOrFile, skipEmptyLines = false, skipBlanks = false, delimiter|
 		var stream;
 		if(pathOrFile.respondsTo(\getChar) ) {
 			stream = pathOrFile


### PR DESCRIPTION
## Purpose and Motivation

```
c = CollStream("5,7,hello,\"a comma, in quotes!\"");
r = CSVFileReader(c);

ERROR: Primitive '_FileOpen' failed.
Wrong type.
```

But... FileReader's interaction with the `stream` is, in total:

- `stream.reset` -- `CollStream` implements this
- `stream.getChar` -- `CollStream` implements this
- `stream.close` -- `CollStream` doesn't implement this, but we can use `tryPerform` to make it a no-op

So there is not a compelling reason why a FileReader must be accessing a file on disk and disallow a stream of characters in memory.

(Editorial: The usual OOP advice is to program toward interfaces rather than class hierarchies: `respondsTo` rather than `isKindOf`. This looks like a case where "oh, `isKindOf` will be fine just this once" except that it isn't, not really.)

Since the really relevant operation is `getChar`, this PR changes the FileReader constructor so that any object implementing `getChar` will be allowed as the stream.

## Types of changes

- Bug fix

## To-do list

- [x] Code is tested
- [x] All tests are passing
- [ ] Updated documentation -- Note that the entire FileReader hierarchy has spotty documentation. "Updated documentation" would require essentially a complete rewrite of four or five help files. I'm afraid at the moment I don't have time to do that. If someone is concerned about this, I would recommend opening an issue.
- [x] This PR is ready for review
