### PR TITLE
Supernova: thread affinity fixes/improvements

### DIFF
--- a/HelpSource/Classes/ServerOptions.schelp
+++ b/HelpSource/Classes/ServerOptions.schelp
@@ -122,8 +122,10 @@ method:: restrictedPath
 Allows you to restrict the system paths in which the server is allowed to read/write files during running. A nil value (the default) means no restriction. Otherwise, set it as a string representing a single path.
 
 method:: threads
-Number of audio threads that are spawned by supernova. For scsynth this value is ignored. If it is code::nil::or 0, it
-uses the one thread per CPU. Default is code::nil::.
+Number of audio threads that are spawned by supernova. For scsynth this value is ignored. If it is code::nil::or 0, it uses one thread per CPU core. Default is code::nil::.
+
+method:: threadPinning
+Enable/disable thread pinning. For scsynth this value is ignored. Thread pinning forces each thread to only run on a particular CPU core. Depending on the system, this might give better or worse performance. Default is code::nil:: which means that the value is chosen by Supernova. (At the time of writing, it is by default enabled on Linux and disabled on macOS and Windows.)
 
 method:: useSystemClock
 Tells supernova whether to sync to the driver's sample clock, or to the system clock.

--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -217,12 +217,12 @@ ServerOptions {
 			o = o ++ " -L";
 		});
 		if (threads.notNil, {
-			if (Server.program.asString.endsWith("supernova")) {
+			if (Server.program.asString.contains("supernova")) {
 				o = o ++ " -T " ++ threads;
 			}
 		});
 		if (threadPinning.notNil, {
-			if (Server.program.asString.endsWith("supernova")) {
+			if (Server.program.asString.contains("supernova")) {
 				o = o ++ " -y " ++ threadPinning.asBoolean.asInteger;
 			}
 		});

--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -38,6 +38,7 @@ ServerOptions {
 
 	var <>memoryLocking;
 	var <>threads; // for supernova
+	var <>threadPinning; // for supernova
 	var <>useSystemClock;  // for supernova
 
 	var <numPrivateAudioBusChannels;
@@ -88,6 +89,7 @@ ServerOptions {
 				remoteControlVolume: false,
 				memoryLocking: false,
 				threads: nil,
+				threadPinning: nil, // default value chosen by Supernova
 				useSystemClock: true,
 				numPrivateAudioBusChannels: 1020, // see corresponding setter method below
 				reservedNumAudioBusChannels: 0,
@@ -217,6 +219,11 @@ ServerOptions {
 		if (threads.notNil, {
 			if (Server.program.asString.endsWith("supernova")) {
 				o = o ++ " -T " ++ threads;
+			}
+		});
+		if (threadPinning.notNil, {
+			if (Server.program.asString.endsWith("supernova")) {
+				o = o ++ " -y " ++ threadPinning.asBoolean.asInteger;
 			}
 		});
 		if (useSystemClock, {

--- a/common/SC_Win32Utils.cpp
+++ b/common/SC_Win32Utils.cpp
@@ -171,6 +171,47 @@ int win32_pipewrite(int s, char* buf, int len) {
     return ret;
 }
 
+// Microsoft doesn't recommend the use of SetThreadAffinityMask - except for testing
+// individual processors - because it can interfere with the OS scheduler and decrease
+// multi-processing performance.
+// https://docs.microsoft.com/en-us/windows/win32/procthread/multiple-processors
+//
+// In my tests SetThreadIdealProcessor() doesn't seem to improve performance at all.
+// It is only a hint after all, and the OS is free to ignore it - which it will!
+//
+// SetThreadAffinityMask(), on the other hand, really makes a big difference when using
+// all hardware threads on an Intel SMT machine:
+// * without thread pinning performance can be *worse* than single thread performance (!)
+// * with SetThreadAffinityMask() performance can be better than with the default number
+//   of threads (= physical concurrency).
+//
+// If someone decides to use thread pinning, they probably are serious about it, so we
+// use SetThreadAffinity() by default (= STRICT_THREAD_AFFINITY 1)
+
+#    define STRICT_THREAD_AFFINITY 1
+#    define DEBUG_THREAD_AFFINITY 0
+
+bool win32_thread_set_affinity(int i) {
+#    if STRICT_THREAD_AFFINITY
+    // SetThreadAffinityMask forces a thread to run only on the specified core(s)
+    DWORD_PTR mask = 1 << i;
+    DWORD_PTR prev = SetThreadAffinityMask(GetCurrentThread(), mask);
+#        if DEBUG_THREAD_AFFINITY
+    fprintf(stdout, "set thread %d affinity mask: previous: %lx, new: %lx\n", i, prev, mask);
+    fflush(stdout);
+#        endif
+    return prev != 0;
+#    else
+    // SetThreadIdealProcessor is merely a hint to the OS scheduler
+    DWORD prev = SetThreadIdealProcessor(GetCurrentThread(), i);
+#        if DEBUG_THREAD_AFFINITY
+    fprintf(stdout, "set thread %d ideal processor: previous: %d, new: %d\n", i, prev, i);
+    fflush(stdout);
+#        endif
+    return prev >= 0;
+#    endif
+}
+
 using SetThreadDescriptionType = HRESULT(WINAPI*)(HANDLE, PCWSTR);
 
 int win32_name_thread(const char* name) {

--- a/common/SC_Win32Utils.h
+++ b/common/SC_Win32Utils.h
@@ -65,6 +65,7 @@ int win32_piperead(int s, char* buf, int len);
 int win32_pipewrite(int s, char* buf, int len);
 
 // missing Windows implementations in nova_tt
+bool win32_thread_set_affinity(int i);
 int win32_name_thread(const char* name);
 
 // alloca

--- a/common/SC_Win32Utils.h
+++ b/common/SC_Win32Utils.h
@@ -64,6 +64,9 @@ int win32_pipe(int handles[2]);
 int win32_piperead(int s, char* buf, int len);
 int win32_pipewrite(int s, char* buf, int len);
 
+// missing Windows implementations in nova_tt
+int win32_name_thread(const char* name);
+
 // alloca
 #    include <malloc.h>
 #    ifndef alloca // MinGW has alloca defined in malloc.h, MSVC not

--- a/server/supernova/CMakeLists.txt
+++ b/server/supernova/CMakeLists.txt
@@ -53,6 +53,8 @@ set(libsupernova_src
     server/node_graph.cpp
     server/server.cpp
     server/server_args.cpp
+
+    utilities/hardware_topology.cpp
 )
 
 if(APPLE)

--- a/server/supernova/dsp_thread_queue/dsp_thread.hpp
+++ b/server/supernova/dsp_thread_queue/dsp_thread.hpp
@@ -37,7 +37,7 @@ using std::uint16_t;
 struct nop_thread_init {
     nop_thread_init(void) {}
 
-    template <typename Arg> nop_thread_init(Arg const&) {}
+    template <typename... Args> nop_thread_init(Args const&...) {}
 
     void operator()(int thread_index) {}
 };

--- a/server/supernova/server/main.cpp
+++ b/server/supernova/server/main.cpp
@@ -68,6 +68,10 @@ using namespace nova;
 using namespace std;
 using DirName = SC_Filesystem::DirName;
 
+namespace nova {
+void parse_hardware_topology(void);
+}
+
 namespace {
 
 /* signal handler */
@@ -320,9 +324,10 @@ void lock_memory(server_arguments const& args) {
 } /* namespace */
 
 int supernova_main(int argc, char* argv[]) {
-    drop_rt_scheduling(); // when being called from sclang, we inherit a low rt-scheduling priority. but we don't want
-                          // it!
+    drop_rt_scheduling(); // when being called from sclang, we inherit a low rt-scheduling priority.
+                          // but we don't want it!
     enable_core_dumps();
+    parse_hardware_topology();
 
     server_arguments::initialize(argc, argv);
     server_arguments const& args = server_arguments::instance();

--- a/server/supernova/server/server.cpp
+++ b/server/supernova/server/server.cpp
@@ -213,7 +213,13 @@ void nova_server::rebuild_dsp_queue(void) {
 static void name_current_thread(int thread_index) {
     char buf[1024];
     sprintf(buf, "DSP Thread %d", thread_index);
+#if defined(__linux__)
     name_thread(buf);
+#elif defined(__APPLE__)
+    // TODO
+#elif defined(_WIN32)
+    win32_name_thread(buf);
+#endif
 }
 
 static void set_daz_ftz(void) {

--- a/server/supernova/server/server.cpp
+++ b/server/supernova/server/server.cpp
@@ -252,12 +252,12 @@ static bool set_realtime_priority(int thread_index) {
     if (!success) {
 #ifdef NOVA_TT_PRIORITY_RT
 
-#    ifdef JACK_BACKEND
+#    if defined(JACK_BACKEND)
         int priority = instance->realtime_priority();
         if (priority >= 0)
             success = true;
 
-#    elif _WIN32
+#    elif defined(_WIN32)
         int priority = thread_priority_interval_rt().second;
 #    else
         int min, max;
@@ -266,7 +266,7 @@ static bool set_realtime_priority(int thread_index) {
         priority = std::max(min, priority);
 #    endif
 
-        if (success)
+        if (!success)
             success = thread_set_priority_rt(priority);
 #endif
     }

--- a/server/supernova/server/server.cpp
+++ b/server/supernova/server/server.cpp
@@ -261,8 +261,15 @@ static bool set_realtime_priority(int thread_index) {
 
 #    if defined(JACK_BACKEND)
         int priority = instance->realtime_priority();
+        /* This line has effectively been bypassed for years because
+         * of a logic error further below. With the logic error fixed,
+         * it would cause lower realtime priorities for DSP helper threads.
+         * Let's keep the old behavior until we figure out what this code
+         * is supposed to do in the first place... */
+#        if 0
         if (priority >= 0)
             success = true;
+#        endif
 
 #    elif defined(_WIN32)
         int priority = thread_priority_interval_rt().second;

--- a/server/supernova/server/server.hpp
+++ b/server/supernova/server/server.hpp
@@ -88,12 +88,13 @@ private:
  *
  * */
 struct thread_init_functor {
-    thread_init_functor(bool real_time): rt(real_time) {}
+    thread_init_functor(bool real_time, bool pin_threads): rt(real_time), pin(pin_threads) {}
 
     void operator()(int thread_index);
 
 private:
     const bool rt;
+    const bool pin;
 };
 
 struct io_thread_init_functor {
@@ -123,6 +124,7 @@ public:
     SC_TimeDLL mDLL;
     bool use_system_clock;
     bool non_rt;
+    bool pin_threads;
     double smooth_samplerate;
 
     typedef detail::audio_backend audio_backend;

--- a/server/supernova/server/server_args.cpp
+++ b/server/supernova/server/server_args.cpp
@@ -34,6 +34,13 @@ server_arguments::server_arguments(int argc, char* argv[]) {
     /* prepare options */
     options_description options("general options");
 
+    // only enable thread pinning by default on Linux
+#if defined(__linux__)
+    bool def_thread_pinning = true;
+#else
+    bool def_thread_pinning = false;
+#endif
+
     // clang-format off
     options.add_options()
         ("help,h", "show this help")
@@ -75,6 +82,7 @@ server_arguments::server_arguments(int argc, char* argv[]) {
 #endif
         ("restricted-path,P", value<vector<string> >(&restrict_paths), "if specified, prevents file-accessing OSC commands from accessing files outside <restricted-path>")
         ("threads,T", value<uint16_t>(&threads)->default_value(boost::thread::physical_concurrency()), "number of audio threads")
+        ("thread-pinning,y", value<bool>(&thread_pinning)->default_value(def_thread_pinning), "pin threads to CPU cores")
         ("socket-address,B", value<string>(&socket_address_str)->default_value("127.0.0.1"), "Bind the UDP or TCP socket to this address.\n"
                                                             "Set to 0.0.0.0 to listen on all interfaces.")
         ;

--- a/server/supernova/server/server_args.hpp
+++ b/server/supernova/server/server_args.hpp
@@ -67,6 +67,7 @@ public:
     std::vector<std::string> hw_name;
     bool memory_locking;
     uint16_t threads;
+    bool thread_pinning;
 
     std::vector<std::string> ugen_paths, restrict_paths;
 

--- a/server/supernova/server/server_scheduler.hpp
+++ b/server/supernova/server/server_scheduler.hpp
@@ -79,8 +79,8 @@ protected:
 
 public:
     /* start thread_count - 1 scheduler threads */
-    scheduler(thread_count_t thread_count = 1, bool realtime = false):
-        threads(thread_count, !realtime, thread_init_functor(realtime)) {}
+    scheduler(thread_count_t thread_count = 1, bool realtime = false, bool pin_threads = false):
+        threads(thread_count, !realtime, thread_init_functor(realtime, pin_threads)) {}
 
     void start_dsp_threads(void) { threads.start_threads(); }
 

--- a/server/supernova/utilities/hardware_topology.cpp
+++ b/server/supernova/utilities/hardware_topology.cpp
@@ -1,0 +1,236 @@
+//  parse hardware topology
+//  Copyright (C) 2022 Christof Ressi
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation; either version 2 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; see the file COPYING.  If not, write to
+//  the Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+//  Boston, MA 02111-1307, USA.
+
+#if defined(_WIN32)
+#    include <windows.h>
+#    include <malloc.h>
+#elif defined(__APPLE__) || defined(__FreeBSD__) || defined(__FreeBSD_kernel__)
+#    include <sys/sysctl.h>
+#    include <errno.h>
+#else /* Linux */
+#    include <unistd.h>
+#    include <sys/sysinfo.h>
+#endif
+
+#include <boost/thread.hpp>
+#include <thread>
+#include <vector>
+#include <string>
+#include <iostream>
+#include <fstream>
+
+#ifndef DEBUG_HARDWARE_TOPOLOGY
+#    define DEBUG_HARDWARE_TOPOLOGY 0
+#endif
+
+namespace {
+
+struct cpu_info {
+    int physical_id;
+    int core_id;
+    int sibling_id;
+    int id;
+
+    bool operator<(const cpu_info& other) const { return to_int() < other.to_int(); }
+
+    bool operator>(const cpu_info& other) const { return to_int() > other.to_int(); }
+
+private:
+    /* convert members to a single uint64_t to simplify comparison.
+     * We try to keep siblings as far apart as possible, followed by physical
+     * packages, so that cores of the same package are close to each other. */
+    uint64_t to_int() const {
+        return ((uint64_t)sibling_id << 24) | ((uint64_t)physical_id << 16) | ((uint64_t)core_id);
+    }
+};
+
+std::vector<cpu_info> cpu_info_vec;
+int core_count = 0;
+int package_count = 0;
+
+void print_cpu_info(void) {
+    std::cout << "hardware topology:\n"
+              << "\tlogical processors: " << cpu_info_vec.size() << "\n"
+              << "\tCPU cores: " << core_count << "\n"
+              << "\tphysical packages: " << package_count << "\n"
+              << "\t---\n";
+    for (auto& info : cpu_info_vec) {
+        std::cout << "\t#" << info.id << " package: " << info.physical_id << ", core: " << info.core_id
+                  << ", sibling: " << info.sibling_id << "\n";
+    }
+}
+
+} /* namespace */
+
+namespace nova {
+
+void parse_hardware_topology(void) {
+#if defined(_WIN32) /* Windows */
+    typedef BOOL(WINAPI * func_type)(PSYSTEM_LOGICAL_PROCESSOR_INFORMATION, PDWORD);
+
+    /* available since Windows XP SP3 */
+    auto fn = (func_type)GetProcAddress(GetModuleHandleA("kernel32"), "GetLogicalProcessorInformation");
+    if (!fn) {
+        std::cout << "GetLogicalProcessorInformation() not supported" << std::endl;
+        return;
+    }
+
+    /* call with size 0 to retrieve the actual size;
+     * ERROR_INSUFFICIENT_BUFFER is expected. */
+    DWORD err, size = 0;
+    fn(NULL, &size);
+    if ((err = GetLastError()) != ERROR_INSUFFICIENT_BUFFER) {
+        std::cout << "GetLogicalProcessorInformation() failed (" << err << ")" << std::endl;
+        return;
+    }
+    auto info = (PSYSTEM_LOGICAL_PROCESSOR_INFORMATION)alloca(size);
+    if (fn(info, &size) == FALSE) {
+        std::cout << "GetLogicalProcessorInformation() failed (" << GetLastError() << ")" << std::endl;
+        return;
+    }
+    size_t n = (size_t)size / sizeof(SYSTEM_LOGICAL_PROCESSOR_INFORMATION);
+
+    /* loop over CPU cores */
+    for (size_t i = 0; i < n; ++i) {
+        if (info[i].Relationship == RelationProcessorCore) {
+            /* add all siblings to CPU list */
+            int siblings = 0;
+            ULONG_PTR mask = info[i].ProcessorMask;
+            for (int j = 0; mask; j++, mask >>= 1) {
+                if (mask & 1) {
+                    cpu_info_vec.push_back({ 0, core_count, siblings, j });
+                    siblings++;
+                }
+            }
+            core_count++;
+        }
+    }
+
+    /* loop again for physical packages */
+    for (size_t i = 0; i < n; ++i) {
+        if (info[i].Relationship == RelationProcessorPackage) {
+            ULONG_PTR mask = info[i].ProcessorMask;
+            /* loop over all processors and find corresponding t_cpuinfo */
+            for (size_t j = 0; mask != 0; ++j, mask >>= 1) {
+                if (mask & 1) {
+                    for (auto& cpu : cpu_info_vec) {
+                        if (cpu.id == j)
+                            cpu.physical_id = package_count;
+                    }
+                }
+            }
+            package_count++;
+        }
+    }
+#elif defined(__linux__) /* Linux */
+    /* The file /proc/cpuinfo contains all logical CPUs where
+     * each entry has a property "physical id" and "core id". */
+    std::ifstream fs("/proc/cpuinfo");
+    if (!fs) {
+        std::cout << "could not open /proc/cpuinfo" << std::endl;
+        return;
+    }
+
+    auto parse_line = [](const std::string& line, const char* key, int& value) {
+        if (line.find(key) != std::string::npos) {
+            auto pos = line.find(":");
+            if (pos != std::string::npos) {
+                value = std::stoi(line.substr(pos + 1));
+                return true;
+            } else {
+                throw std::runtime_error("missing colon after key");
+            }
+        } else {
+            return false;
+        }
+    };
+
+    int physical_id = -1;
+    int core_id = -1;
+    try {
+        for (std::string line; std::getline(fs, line);) {
+            if (line.empty())
+                continue;
+
+            /* search for "physical id" and "core id" */
+            if (!parse_line(line, "physical id", physical_id) && !parse_line(line, "core id", core_id)) {
+                continue;
+            }
+            if (physical_id >= 0 && core_id >= 0) {
+                int id = (int)cpu_info_vec.size();
+                /* get sibling number */
+                int sibling_id = 0;
+                for (auto& cpu : cpu_info_vec) {
+                    if ((cpu.physical_id == physical_id) && (cpu.core_id == core_id)) {
+                        sibling_id++;
+                    }
+                }
+                if (sibling_id == 0)
+                    core_count++;
+
+                /* check for new physical package */
+                if (std::find_if(cpu_info_vec.begin(), cpu_info_vec.end(),
+                                 [&](auto& cpu) { return cpu.physical_id == physical_id; })
+                    == cpu_info_vec.end()) {
+                    package_count++;
+                }
+
+                cpu_info_vec.push_back({ physical_id, core_id, sibling_id, id });
+
+                physical_id = core_id = -1;
+            }
+        }
+    } catch (const std::exception& e) {
+        std::cout << "could not parse /proc/cpuinfo: " << e.what() << std::endl;
+        cpu_info_vec.clear();
+        core_count = 0;
+        package_count = 0;
+        return;
+    }
+#else /* Apple, BSDs, etc. */
+    // std::cout << "parse_hardware_topology() not implemented" << std::endl;
+    return;
+#endif
+
+    /* parsing done */
+#if DEBUG_HARDWARE_TOPOLOGY
+    print_cpu_info(); /* print original list */
+#endif
+    /* sort the list so that we can simply pick
+     * consecutive CPUs for effective thread pinning. */
+    std::sort(cpu_info_vec.begin(), cpu_info_vec.end());
+#if DEBUG_HARDWARE_TOPOLOGY
+    /* print the sorted list */
+    std::cout << "sorted CPU list:" << std::endl;
+    for (auto& info : cpu_info_vec) {
+        std::cout << "\t#" << info.id << " package: " << info.physical_id << ", core: " << info.core_id
+                  << ", sibling: " << info.sibling_id << "\n";
+    }
+    std::cout << std::endl;
+#endif
+}
+
+int get_cpu_for_thread_index(int thread_index) {
+    if (!cpu_info_vec.empty()) {
+        return cpu_info_vec[thread_index % cpu_info_vec.size()].id;
+    } else {
+        return thread_index;
+    }
+}
+
+} /* namespace nova */


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

1. Fix bogus error message `Warning: cannot raise thread priority` on Windows

2. Add Windows implementation of `nova::name_thread` (only really works on Windows 10+, but still compiles/runs on older Windows versions)

3. Add Windows implementation of `nova::thread_set_affinity` (two different implementations; can be chosen at compile time)

4. Make thread pinning a runtime option:
    * add `--thread-pinning` resp. `-y` option to `supernova` app
    * add `threadPinning` member to `ServerOptions` class (ignored for `scsynth`)

5. Fix "supernova" check on Windows for Server options.

6. Fix assignment of CPUs to DSP helper threads.
    Before, supernova would simply pick CPUs in ascending order; with SMT enabled, this might cause DSP helper threads to share a single CPU core. Instead, we parse the actual hardware topology and sort the CPU list appropriately, so that each DSP helper thread is really pinned to a dedicated CPU core.

Also fixes https://github.com/supercollider/supercollider/issues/5540.

NOTE: we keep the default thread-pinning behavior (Linux: on, Windows/macOS: off), we just make it configurable at run time.

## Types of changes

<!-- Delete lines that don't apply -->

- Documentation
- Bug fix
- New feature

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review
