### PR TITLE
classlib: protect EventPatternProxy.prNext

### DIFF
--- a/SCClassLibrary/Common/Streams/Stream.sc
+++ b/SCClassLibrary/Common/Streams/Stream.sc
@@ -483,7 +483,11 @@ EventStreamPlayer : PauseStream {
 			this.removedFromScheduler;
 			^nil
 		}{
-			nextTime = outEvent.playAndDelta(cleanup, muteCount > 0);
+			protect {
+				nextTime = outEvent.playAndDelta(cleanup, muteCount > 0);
+			} { |err|
+				if (err.notNil) { this.streamError };
+			};
 			if (nextTime.isNil) { this.removedFromScheduler; ^nil };
 			nextBeat = inTime + nextTime;	// inval is current logical beat
 			^nextTime

--- a/testsuite/classlibrary/TestEventPatternProxy.sc
+++ b/testsuite/classlibrary/TestEventPatternProxy.sc
@@ -38,4 +38,13 @@ TestEventPatternProxy : UnitTest{
 	// without any changes to that method. test_update_withEvents
 	// from (the same) TestPatternProxy would need more refactoring though
 	// to separate global JITlib lookups (Pdef, Pdefn) from source updating.
+
+	test_EventPatternProxy_playNewSource_afterInternalError {
+		var newSourceCalledAfterError = false, t = EventPatternProxy(''), c = CondVar();
+		t.play(quant:0);
+		t.source = { newSourceCalledAfterError = true; c.signalAll; nil };
+		c.waitFor(1) { newSourceCalledAfterError };
+		this.assert(newSourceCalledAfterError,
+			"EventPatternProxy should resume playing after an error, when a new source is provided.");
+	}
 }

--- a/testsuite/classlibrary/TestPatternProxy.sc
+++ b/testsuite/classlibrary/TestPatternProxy.sc
@@ -366,4 +366,23 @@ TestPatternProxy : UnitTest {
 
 
 	}
+
+	test_PatternProxy_playNewSource_afterInternalError {
+		var newSourceCalledAfterError = false, t = PatternProxy(''), c = CondVar();
+		t.play(quant:0);
+		t.source = { newSourceCalledAfterError = true; c.signalAll; nil };
+		c.waitFor(1) { newSourceCalledAfterError };
+		this.assert(newSourceCalledAfterError,
+			"PatternProxy should resume playing after an error, when a new source is provided.");
+	}
+
+	test_Pdef_playNewSource_afterInternalError {
+		var newSourceCalledAfterError = false, c = CondVar();
+		Pdef(\test, '').play(quant:0);
+		Pdef(\test).source = { newSourceCalledAfterError = true; c.signalAll; nil };
+		c.waitFor(1) { newSourceCalledAfterError };
+		Pdef(\test).clear;
+		this.assert(newSourceCalledAfterError,
+			"Pdef should resume playing after an error, when a new source is provided.");
+	}
 }

--- a/testsuite/classlibrary/TestTaskProxy.sc
+++ b/testsuite/classlibrary/TestTaskProxy.sc
@@ -12,4 +12,23 @@ TestTaskProxy : UnitTest{
         this.assertEquals(actualClock, clock, "TaskProxy.play() should use instance's clock if no argClock is given");
     }
 
+	test_TaskProxy_playNewSource_afterInternalError {
+		var newSourceCalledAfterError = false, t = TaskProxy(''), c = CondVar();
+		t.play(quant:0);
+		t.source = { newSourceCalledAfterError = true; c.signalAll; nil };
+		c.waitFor(1) { newSourceCalledAfterError };
+		this.assert(newSourceCalledAfterError,
+			"TaskProxy should resume playing after an error, when a new source is provided.");
+	}
+
+	test_Tdef_playNewSource_afterInternalError {
+		var newSourceCalledAfterError = false, c = CondVar();
+		Tdef(\test, '').play(quant:0);
+		Tdef(\test).source = { newSourceCalledAfterError = true; c.signalAll; nil };
+		c.waitFor(1) { newSourceCalledAfterError };
+		Tdef(\test).clear;
+		this.assert(newSourceCalledAfterError,
+			"Tdef should resume playing after an error, when a new source is provided.");
+	}
+
 }


### PR DESCRIPTION
to ensure proper cleanup of Pdefs, PatternProxies and EventPatternProxies if events occur during their players' .prNext
## Purpose and Motivation
fixes #5597 

## Types of changes
- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] This PR is ready for review

There are probably too many tests, my idea was to test the "feature": Pdefs, Tdefs, PatternProxies, EventPatternProxies and TaskProxies should all be able to restart playing after an error occurs in their players, when a new source is provided. However, I didn't touch PauseStream, which is used as a player by Tdef and TaskProxy, and indeed, my tests for those two classes would be successful also without this fix.