### PR TITLE
class library: protect PauseStream and EventStreamPlayer

### DIFF
--- a/testsuite/classlibrary/TestPatternProxy.sc
+++ b/testsuite/classlibrary/TestPatternProxy.sc
@@ -366,4 +366,28 @@ TestPatternProxy : UnitTest {
 
 
 	}
+
+	test_Pdef_error_recovery {
+		var test = false;
+		Pdef.clear;
+		Pdef(\x).quant_(0).play(quant: 0);
+		Pdef(\x, (play: {  SinOsc.foo }, dur: 0.001)); // correctly throws an error
+		0.1.wait;
+		Pdef(\x, (play: {  "----".postln; test = true })).play(quant:0);
+		0.1.wait;
+		this.assert(test, "an error shouldn't block a playing Pdef");
+	}
+
+	test_Tdef_error_recovery {
+		var test = false;
+		Tdef.clear;
+		Tdef(\x).quant_(0).play(quant: 0);
+		Tdef(\x, { 0.01.wait; SinOsc.foo }); // correctly throws an error
+		0.1.wait;
+		Tdef(\x, { "----".postln; test = true }).play(quant:0);
+		0.1.wait;
+		this.assert(test, "an error shouldn't block a playing Tdef");
+	}
+
+
 }


### PR DESCRIPTION
## Purpose and Motivation

This will guarantee that an error thrown within a PauseStream and EventStreamPlayer correctly notify this player.

This will simplify code in various places where Pprotect was used.

This fixes #5597.

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix


## To-do list

- [x] Code is tested
- [x] All tests are passing
- [x] This PR is ready for review
