### PR TITLE
Classlib: Put 'protect' in PauseStreams (update state on error)

### DIFF
--- a/SCClassLibrary/Common/Streams/Stream.sc
+++ b/SCClassLibrary/Common/Streams/Stream.sc
@@ -442,13 +442,15 @@ Task : PauseStream {
 	// optimization:
 	// Task builds its own Routine, so 'protect' here
 	*new { arg func, clock;
-		var new = super.new(Routine({ |inval|
-			protect {
-				func.value(inval)
-			} {
-				new.streamError
-			};
-		}), clock);
+		var new = super.new(
+			Routine({ |inval|
+				protect {
+					func.value(inval)
+				} {
+					new.streamError
+				};
+			}
+		), clock);
 		^new
 	}
 	// then there is no need to let PauseStream wrap it in another Routine

--- a/SCClassLibrary/Common/Streams/Stream.sc
+++ b/SCClassLibrary/Common/Streams/Stream.sc
@@ -337,23 +337,28 @@ PauseStream : Stream {
 	isPlaying { ^stream.notNil }
 
 	play { arg argClock, doReset = (false), quant;
+		// check 'quant' first, before changing any state variables
+		// if there is an error, this object should be unaffected
+		var tempClock = argClock ? clock ? TempoClock.default;
+		var time = quant.asQuant.nextTimeOnGrid(tempClock);
+
 		if (stream.notNil, { "already playing".postln; ^this });
 		if (doReset, { this.reset });
-		clock = argClock ? clock ? TempoClock.default;
+		clock = tempClock;
 		streamHasEnded = false;
 		this.refresh; //stream = originalStream;
 		stream.clock = clock;
 		isWaiting = true;	// make sure that accidental play/stop/play sequences
 						// don't cause memory leaks
 		era = CmdPeriod.era;
-		clock.play({
+		clock.schedAbs(time, {
 			if(isWaiting and: { nextBeat.isNil }) {
 				clock.sched(0, this);
 				isWaiting = false;
 				this.changed(\playing)
 			};
 			nil
-		}, quant.asQuant);
+		});
 		this.changed(\userPlayed);
 		^this
 	}
@@ -391,7 +396,17 @@ PauseStream : Stream {
 	}
 
 	refresh {
-		stream = originalStream.threadPlayer_(this)
+		// a PauseStream may wrap *any* type of stream
+		// so the only way to 'protect' it is to embed it
+		// into a Routine under this PauseStream's control
+		stream = Routine { |inval|
+			protect {
+				originalStream.embedInStream(inval)
+			} {
+				this.streamError;
+			}
+		};
+		originalStream.threadPlayer_(this);
 	}
 
 	start { arg argClock, quant;
@@ -424,8 +439,21 @@ PauseStream : Stream {
 // Task is a PauseStream for wrapping a Routine
 
 Task : PauseStream {
+	// optimization:
+	// Task builds its own Routine, so 'protect' here
 	*new { arg func, clock;
-		^super.new(Routine(func), clock)
+		var new = super.new(Routine({ |inval|
+			protect {
+				func.value(inval)
+			} {
+				new.streamError
+			};
+		}), clock);
+		^new
+	}
+	// then there is no need to let PauseStream wrap it in another Routine
+	refresh {
+		stream = originalStream.threadPlayer_(this);
 	}
 	storeArgs { ^originalStream.storeArgs
 		++ if(clock != TempoClock.default) { clock }
@@ -444,7 +472,15 @@ EventStreamPlayer : PauseStream {
 
 	init {
 		cleanup = EventStreamCleanup.new;
-		routine = Routine{ | inTime | loop { inTime = this.prNext(inTime).yield } };
+		routine = Routine { |inTime|
+			protect {
+				loop { inTime = this.prNext(inTime).yield }
+			} { |result|
+				if(result.isException) {
+					this.streamError
+				}
+			}
+		};
 	}
 
 	// freeNodes is passed as false from
@@ -493,9 +529,14 @@ EventStreamPlayer : PauseStream {
 	asEventStreamPlayer { ^this }
 
 	play { arg argClock, doReset = (false), quant;
+		// check 'quant' first, before changing any state variables
+		// if there is an error, this object should be unaffected
+		var tempClock = argClock ? clock ? TempoClock.default;
+		var time = quant.asQuant.nextTimeOnGrid(tempClock);
+
 		if (stream.notNil, { "already playing".postln; ^this });
 		if (doReset, { this.reset });
-		clock = argClock ? clock ? TempoClock.default;
+		clock = tempClock;
 		streamHasEnded = false;
 		stream = originalStream;
 		stream.clock = clock;
@@ -505,14 +546,14 @@ EventStreamPlayer : PauseStream {
 		quant = quant.asQuant;
 		event = event.synchWithQuant(quant);
 
-		clock.play({
+		clock.schedAbs(time, {
 			if(isWaiting and: { nextBeat.isNil }) {
 				thisThread.clock.sched(0, this );
 				isWaiting = false;
 				this.changed(\playing)
 			};
 			nil
-		}, quant);
+		});
 		this.changed(\userPlayed);
 		^this
 	}


### PR DESCRIPTION
## Purpose and Motivation

Fixes #5597.

`Pprotect` is not sufficient to catch errors thrown while playing an event produced by a pattern. In this case, state variables had not been updated to reflect a PauseStream's new non-playing state.

Julian had the good idea to embed `protect` into the Routine being managed by a PauseStream (I hadn't thought of this!), but an earlier version didn't apply this consistently.

This version introduces it into `PauseStream`, `Task`, and `EventStreamPlayer`.

## Types of changes

- Bug fix

## To-do list

- [x] Code is tested
- [x] All tests are passing
- [x] This PR is ready for review

Under #5623, Julian had proposed some test cases, and volunteered to turn those into formal unit tests. So this PR does not include unit tests directly, but they will follow.