### PR TITLE
Revert #4725 - MIDI use logical time on macOS

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -326,6 +326,8 @@ jobs:
       - name: install qt using aqtinstall
         uses: jurplel/install-qt-action@v2
         if: matrix.qt-version
+        env:
+          DEVELOPER_DIR: '' # remove developer dir which causes installation to fail
         with:
           modules: 'qtwebengine'
           version: ${{ matrix.qt-version }}

--- a/lang/LangPrimSource/SC_CoreMIDI.cpp
+++ b/lang/LangPrimSource/SC_CoreMIDI.cpp
@@ -72,8 +72,6 @@ MIDIClientRef gMIDIClient = 0;
 MIDIPortRef gMIDIInPort[kMaxMidiPorts], gMIDIOutPort[kMaxMidiPorts];
 int gNumMIDIInPorts = 0, gNumMIDIOutPorts = 0;
 bool gMIDIInitialized = false;
-UInt64 gCoreAudioInitTime = 0, gLogicalInitTime = 0;
-
 // cp
 static bool gSysexFlag = false;
 static Byte gRunningStatus = 0;
@@ -637,9 +635,6 @@ int prDisconnectMIDIIn(struct VMGlobals* g, int numArgsPushed) {
 
     return errNone;
 }
-
-UInt64 logicalTimeToNanos(struct VMGlobals* g) { return slotRawFloat(&g->thread->seconds) * 1000000000; }
-
 int prInitMIDI(struct VMGlobals* g, int numArgsPushed);
 int prInitMIDI(struct VMGlobals* g, int numArgsPushed) {
     // PyrSlot *a = g->sp - 2;
@@ -655,19 +650,7 @@ int prInitMIDI(struct VMGlobals* g, int numArgsPushed) {
     if (err)
         return errWrongType;
 
-    err = initMIDI(numIn, numOut);
-
-    // capture initialization times to compute offsets
-    gLogicalInitTime = logicalTimeToNanos(g);
-    // do this last to minimize offset from logical
-
-#if SC_IPHONE
-    // TODO use logical time for IOS scheduling
-#else
-    gCoreAudioInitTime = AudioGetCurrentHostTime();
-#endif
-
-    return err;
+    return initMIDI(numIn, numOut);
 }
 int prDisposeMIDIClient(VMGlobals* g, int numArgsPushed);
 int prDisposeMIDIClient(VMGlobals* g, int numArgsPushed) { return midiCleanUp(); }
@@ -726,7 +709,7 @@ static struct mach_timebase_info machTimebaseInfo() {
     return info;
 }
 
-static MIDITimeStamp midiTime(float latencySeconds, UInt64 time) {
+static MIDITimeStamp midiTime(float latencySeconds) {
     // add the latency expressed in seconds, to the current host time base.
     static struct mach_timebase_info info = machTimebaseInfo(); // cache the timebase info.
     Float64 latencyNanos = 1000000000 * latencySeconds;
@@ -736,23 +719,16 @@ static MIDITimeStamp midiTime(float latencySeconds, UInt64 time) {
 
 #else
 
-static MIDITimeStamp midiTime(float latencySeconds, UInt64 time) {
-    UInt64 latencyNanos = 1000000000 * latencySeconds;
-    UInt64 timeElapsed = time - gLogicalInitTime;
-    UInt64 schedTime = AudioConvertNanosToHostTime(timeElapsed + gCoreAudioInitTime);
-    /* post("%lld, %lld, %lld, %lld, %lld, %lld, %lld \n",
-         gLogicalInitTime, gCoreAudioInitTime,
-         AudioGetCurrentHostTime(), AudioGetCurrentHostTime() - gCoreAudioInitTime,
-         time, timeElapsed, schedTime); */
-    return (MIDITimeStamp)schedTime + AudioConvertNanosToHostTime(latencyNanos);
+static MIDITimeStamp midiTime(float latencySeconds) {
+    // add the latency expressed in seconds, to the current host time base.
+    UInt64 latencyNanos = 1000000000 * latencySeconds; // secs to nano
+    return (MIDITimeStamp)AudioGetCurrentHostTime() + AudioConvertNanosToHostTime(latencyNanos);
 }
 
 #endif
 
-void sendmidi(int port, MIDIEndpointRef dest, int length, int hiStatus, int loStatus, int aval, int bval, float late,
-              UInt64 time);
-void sendmidi(int port, MIDIEndpointRef dest, int length, int hiStatus, int loStatus, int aval, int bval, float late,
-              UInt64 time) {
+void sendmidi(int port, MIDIEndpointRef dest, int length, int hiStatus, int loStatus, int aval, int bval, float late);
+void sendmidi(int port, MIDIEndpointRef dest, int length, int hiStatus, int loStatus, int aval, int bval, float late) {
     MIDIPacketList mpktlist;
     MIDIPacketList* pktlist = &mpktlist;
     MIDIPacket* pk = MIDIPacketListInit(pktlist);
@@ -760,7 +736,7 @@ void sendmidi(int port, MIDIEndpointRef dest, int length, int hiStatus, int loSt
     pk->data[0] = (Byte)(hiStatus & 0xF0) | (loStatus & 0x0F);
     pk->data[1] = (Byte)aval;
     pk->data[2] = (Byte)bval;
-    pk = MIDIPacketListAdd(pktlist, sizeof(struct MIDIPacketList), pk, midiTime(late, time), nData, pk->data);
+    pk = MIDIPacketListAdd(pktlist, sizeof(struct MIDIPacketList), pk, midiTime(late), nData, pk->data);
     /*OSStatus error =*/MIDISend(gMIDIOutPort[port], dest, pktlist);
 }
 
@@ -783,8 +759,6 @@ int prSendMIDIOut(struct VMGlobals* g, int numArgsPushed) {
 
     int err, outputIndex, uid, length, hiStatus, loStatus, aval, bval;
     float late;
-    UInt64 time;
-
     err = slotIntVal(p, &outputIndex);
     if (err)
         return err;
@@ -813,8 +787,6 @@ int prSendMIDIOut(struct VMGlobals* g, int numArgsPushed) {
     if (err)
         return err;
 
-    time = logicalTimeToNanos(g);
-
     MIDIEndpointRef dest;
     MIDIObjectType mtype;
     MIDIObjectFindByUniqueID(uid, (MIDIObjectRef*)&dest, &mtype);
@@ -824,7 +796,7 @@ int prSendMIDIOut(struct VMGlobals* g, int numArgsPushed) {
     if (!dest)
         return errFailed;
 
-    sendmidi(outputIndex, dest, length, hiStatus, loStatus, aval, bval, late, time);
+    sendmidi(outputIndex, dest, length, hiStatus, loStatus, aval, bval, late);
     return errNone;
 }
 


### PR DESCRIPTION

This reverts commit c6790a9168be1972724034e79f83d53ef4f0399c, reversing changes made to 13be6e8202674a98d0e20b58201ec10763515de3.

<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

Fixes #5622

See linked issue for explanation and details.
I also cherry-picked CI commit that fixes the macOS legacy build.

I'm suggesting to merge this into `3.12` branch in order to release `3.12.2` with this fix, but I'm open to suggestions about this.

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review
