### PR TITLE
GHA: remove retention time for GHA artifacts

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -181,7 +181,6 @@ jobs:
         with:
           name: ${{ env.ARTIFACT_FILE }}
           path: ${{ env.INSTALL_PATH }}/${{ env.ARTIFACT_FILE }}.zip
-          retention-days: 7 # quickly remove test artifacts
 
   macOS:
     needs: lint
@@ -368,7 +367,6 @@ jobs:
         with:
           name: ${{ env.ARTIFACT_FILE }}
           path: ${{ env.INSTALL_PATH }}/${{ env.ARTIFACT_FILE }}
-          retention-days: 7 # quickly remove test artifacts
 
   Windows:
     needs: lint
@@ -504,7 +502,6 @@ jobs:
         with:
           name: ${{ env.ARTIFACT_FILE }}
           path: ${{ env.INSTALL_PATH }}/${{ env.ARTIFACT_FILE }}.zip
-          retention-days: 7 # quickly remove test artifacts
       - name: create installer
         if: matrix.create-installer == true
         shell: bash
@@ -517,7 +514,6 @@ jobs:
         with:
           name: ${{ env.INSTALLER_FILE }}
           path: ${{ env.INSTALL_PATH }}/*.exe
-          retention-days: 7 # quickly remove test artifacts
 
   test:
     strategy:


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

I've originally set artifacts produced by GitHub Actions to expire rather quickly, after 7 days.
I think this time could be extended (e.g. I wanted to check out a build from a PR from 10 days ago and the artifact was no longer there). 
Moreover, I see now that the default retention period can be set in the repository preferences (Settings -> Actions).
In that case, I proposed that we remove the hardcoded retention time from the actions yaml file and instead rely on the time set in preferences. This way it will also be individually configurable in forks, I believe.

I've set the retention time in the settings of the main repo for 30 days.

## Types of changes

<!-- Delete lines that don't apply -->

- Maintenance

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review
