### PR TITLE
Explicitly add ad hoc code signing on macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -248,6 +248,9 @@ option(SC_ABLETON_LINK "Build with Ableton Link support" ON)
 if(APPLE)
     # codesigning breaks increamental builds in Xcode 11+
     option(SC_DISABLE_XCODE_CODESIGNING "Disable codesigning in XCode" ON)
+    # however, codesigning is needed on arm64 to run the app locally at all
+    # but it is being broken by macdeployqt, hence we sign after deploying the app
+    option(SC_CODESIGN_AFTER_DEPLOY "Run ad hoc codesigning after creating the app bundle" ON)
     # verify_app fails with official Qt; we'll still use it for Qt from homebrew
     option(SC_VERIFY_APP "Run verify_app on the app bundle" OFF)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -246,10 +246,10 @@ endif()
 option(SC_ABLETON_LINK "Build with Ableton Link support" ON)
 
 if(APPLE)
-    # codesigning breaks increamental builds in Xcode 11+
-    option(SC_DISABLE_XCODE_CODESIGNING "Disable codesigning in XCode" ON)
-    # however, codesigning is needed on arm64 to run the app locally at all
-    # but it is being broken by macdeployqt, hence we sign after deploying the app
+    # codesigning used to break increamental builds in Xcode 11+, but it's now fixed
+    option(SC_DISABLE_XCODE_CODESIGNING "Disable codesigning in XCode" OFF)
+    # codesigning is also being broken by macdeployqt, but it is needed on arm64
+    # to run the app locally at all, hence we sign after deploying the app
     option(SC_CODESIGN_AFTER_DEPLOY "Run ad hoc codesigning after creating the app bundle" ON)
     # verify_app fails with official Qt; we'll still use it for Qt from homebrew
     option(SC_VERIFY_APP "Run verify_app on the app bundle" OFF)

--- a/editors/sc-ide/CMakeLists.txt
+++ b/editors/sc-ide/CMakeLists.txt
@@ -547,6 +547,20 @@ if(APPLE OR WIN32)
                 ")
         endif()
 
+        if(SC_CODESIGN_AFTER_DEPLOY)
+            string(APPEND VERIFY_CMD "
+                message(STATUS \"Running ad hoc code signing\")
+                execute_process(COMMAND 
+                    sh -c \
+                    \"find ${CONTENTS_DIR} \
+                    \\\\( -name \\\"*.dylib\\\" -o -name \\\"*.framework\\\" \
+                    -o -name \\\"SuperCollider\\\" -o -name \\\"sclang\\\" \
+                    -o -name \\\"scsynth\\\" -o -name \\\"supernova\\\" -maxdepth 2 \
+                    \\\\) -exec codesign --force --deep --sign - {} \\\;\"
+                )
+            ")
+        endif()
+
         if(SC_VERIFY_APP)
             string(APPEND VERIFY_CMD "
                 message(STATUS \"Verifying app\")

--- a/editors/sc-ide/CMakeLists.txt
+++ b/editors/sc-ide/CMakeLists.txt
@@ -555,12 +555,22 @@ if(APPLE OR WIN32)
             string(APPEND VERIFY_CMD "
                 message(STATUS \"Running ad hoc code signing\")
                 execute_process(COMMAND 
+                    codesign --force --deep --sign - ${CONTENTS_DIR}/MacOS/SuperCollider
+                )
+                execute_process(COMMAND 
                     sh -c \
-                    \"find ${CONTENTS_DIR} \
-                    \\\\( -name \\\"*.dylib\\\" -o -name \\\"*.framework\\\" \
-                    -o -name \\\"SuperCollider\\\" -o -name \\\"sclang\\\" \
-                    -o -name \\\"scsynth\\\" -o -name \\\"supernova\\\" -maxdepth 2 \
-                    \\\\) -exec codesign --force --deep --sign - {} \\\;\"
+                    \"find ${CONTENTS_DIR}/MacOS ${CONTENTS_DIR}/Frameworks \
+                    ${CONTENTS_DIR}/Resources ${CONTENTS_DIR}/Resources/plugins \
+                    \\\\( \
+                        -name \\\"*.dylib\\\" \
+                        -o -name \\\"*.framework\\\" \
+                        -o -name \\\"sclang\\\" \
+                        -o -name \\\"scsynth\\\" \
+                        -o -name \\\"supernova\\\" \
+                        -o -name \\\"DiskIO_UGens*\\\" \
+                        -maxdepth 1 \
+                    \\\\) \
+                    -exec codesign --force --sign - {} \\\;\"
                 )
             ")
         endif()

--- a/editors/sc-ide/CMakeLists.txt
+++ b/editors/sc-ide/CMakeLists.txt
@@ -321,6 +321,10 @@ set_target_properties(libscide PROPERTIES PREFIX "")
 
 if(APPLE)
     set_target_properties(SuperCollider PROPERTIES OUTPUT_NAME "${ide_name}")
+    if(NOT SC_DISABLE_XCODE_CODESIGNING)
+        # codesign --deep seems to be needed for the SuperCollider binary to allow incremental builds
+        set_target_properties(SuperCollider PROPERTIES XCODE_ATTRIBUTE_OTHER_CODE_SIGN_FLAGS "--deep")
+    endif()
 else()
     set_target_properties(SuperCollider PROPERTIES OUTPUT_NAME "scide")
 endif()

--- a/editors/sc-ide/CMakeLists.txt
+++ b/editors/sc-ide/CMakeLists.txt
@@ -572,6 +572,9 @@ if(APPLE OR WIN32)
                     \\\\) \
                     -exec codesign --force --sign - {} \\\;\"
                 )
+                execute_process(COMMAND 
+                    codesign --force --sign - ${CMAKE_INSTALL_PREFIX}/SuperCollider/SuperCollider.app
+                )
             ")
         endif()
 

--- a/editors/sc-ide/CMakeLists.txt
+++ b/editors/sc-ide/CMakeLists.txt
@@ -567,7 +567,7 @@ if(APPLE OR WIN32)
                         -o -name \\\"sclang\\\" \
                         -o -name \\\"scsynth\\\" \
                         -o -name \\\"supernova\\\" \
-                        -o -name \\\"DiskIO_UGens*\\\" \
+                        -o -name \\\"*.scx\\\" \
                         -maxdepth 1 \
                     \\\\) \
                     -exec codesign --force --sign - {} \\\;\"


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

Fixes #5603

On macOS all binaries needs to be signed when run on M1 hardware (arm64 / aarch64)
When building, the binaries are signed ad hoc, however it turns out that `macdeployqt`, as well as manipulations with `install_name_tool` invalidate these signatures.
I propose the solution that runs ad hoc signing after the `macdeployqt` step.

I'm open to suggestions whether this is the desired solution and if there's a better name for the introduced CMake flag.

The PR includes the following changes:
- A new option is added to `CMakeLists.txt` to trigger ad-hoc codesigning after building (`SC_CODESIGN_AFTER_DEPLOY`, defaults to `ON`, macOS only)
- The following components are signed: binaries `SuperCollider`, `sclang`, `scsynth`, `supernova`, all `.framework` and `.dylib` files in `Contents/Frameworks/`, `DiskIO_UGens` plugins, and `SuperCollider.app` itself (last). 
  - `SuperCollider` binary is signed with the `--deep` flag to avoid `code object is not signed at all` error; signing other files is done without that flag
  - Signing `DiskIO_UGens` was needed due to a rather obscure issue with codesigning - the servers would not boot, but only after incremental builds, while running fine on clean builds. Signing this specific ugen file seems to have fixed that. I made a note of it in the commit message.
- I added `--deep` flag to build-time codesigning for the `SuperCollider` target. This seems to me like a more proper solution to #4664 than turning off build-time codesigning altogether. 
  - Since the incremental builds do work now with the build-time codesigning turned on, I decided to turn OFF `SC_DISABLE_XCODE_CODESIGNING` by default, as I don't think it's needed anymore.


## Purpose and Motivation

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review
