### PR TITLE
Uniformly use NamedControl in JITLib

### DIFF
--- a/SCClassLibrary/JITLib/ProxySpace/ProxySynthDef.sc
+++ b/SCClassLibrary/JITLib/ProxySpace/ProxySynthDef.sc
@@ -124,7 +124,7 @@ ProxySynthDef : SynthDef {
 						}
 					}
 				};
-				outCtl = Control.names(\out).ir(0) + channelOffset;
+				outCtl = \out.ir(0) + channelOffset; // todo: maybe let user specify the intial value by calling just .ir here
 				(if(rate === \audio and: { sampleAccurate }) { OffsetOut } { Out }).multiNewList([rate, outCtl] ++ output)
 			})
 		});

--- a/SCClassLibrary/JITLib/ProxySpace/wrapForNodeProxy.sc
+++ b/SCClassLibrary/JITLib/ProxySpace/wrapForNodeProxy.sc
@@ -301,7 +301,7 @@
 				};
 
 				{ | out |
-					var env, ctl = Control.names(["wet"++(index ? 0)]).kr(1.0);
+					var env, ctl = ("wet"++(index ? 0)).asSymbol.kr(1.0);
 					if(proxy.rate === 'audio') {
 						env = ctl * EnvGate(i_level: 0, doneAction:2, curve:\sin);
 						XOut.ar(out, env, SynthDef.wrap(func, nil, [In.ar(out, proxy.numChannels)]))
@@ -350,6 +350,7 @@
 					event
 				}.buildForProxy( proxy, channelOffset, index );
 			},
+			// todo: this is undocumented and looks unclear in purpose; creates nameless controls
 			control: #{ | values, proxy, channelOffset = 0, index |
 				{ Control.kr(values) }.buildForProxy( proxy, channelOffset, index );
 			},
@@ -363,7 +364,7 @@
 
 				{ | out |
 					var in, env;
-					var wetamp = Control.names(["wet"++(index ? 0)]).kr(1.0);
+					var wetamp = ("wet"++(index ? 0)).asSymbol.kr(1.0);
 					var dryamp = 1 - wetamp;
 					var sig = { |in| SynthDef.wrap(func, nil, [in * wetamp]) + (dryamp * in) };
 
@@ -382,7 +383,7 @@
 			mix: #{ | func, proxy, channelOffset = 0, index |
 
 				{
-					var ctl = Control.names(["mix" ++ (index ? 0)]).kr(1.0);
+					var ctl = ("mix" ++ (index ? 0)).asSymbol.kr(1.0);
 					var sig = SynthDef.wrap(func);
 					var curve = if(sig.rate === \audio) { \sin } { \lin };
 					var env = EnvGate(i_level: 0, doneAction:2, curve:curve);


### PR DESCRIPTION
## Purpose and Motivation

Addresses one of the issues discussed in #5648, namely (the third one there), but which I'll illustrate here with a simpler example.

```
Ndef.clear
n = Ndef(\noise, { \out.ir /* has side effect */; WhiteNoise.ar })
// ^^ yeah, it plays on audio bus 0 immediately without any .play invoked
d = n.objects[0].synthDef
d.allControlNames collect: _.name
// -> [ out, gate, fadeTime, out ]
// ^^ has two controls named 'out'.
```

When Ndef builds that and tries to set the 'out' (by name) to some private bus, the server only sets the first 'out' it finds by name, which is mapped to `0_Control` in the graph below, but it's the second 'out' (`6_Control`) that's actually connected to the Out ugen.
```
d.dumpUGens
/*
[ 0_Control, scalar, nil ]
[ 1_WhiteNoise, audio, [  ] ]
[ 2_Control, control, nil ]
[ 3_Control, control, nil ]
[ 4_EnvGen, control, [ 2_Control[0], 1.0, 0.0, 3_Control[0], 2, 0, 2, 1, -99, 1.0, 1.0, 3, 0, 0.0, 1.0, 3, 0 ] ]
[ 5_*, audio, [ 1_WhiteNoise, 4_EnvGen ] ]
[ 6_Control, scalar, nil ]
[ 7_Out, audio, [ 6_Control[0], 5_* ] ]
*/
```

I'm starting with this one as the first PR towards addressing #5648 because I think it's the simplest among the changes proposed there, yet it fixes a fairly real use case in itself. You'd normally try to read from `\out.ir` with something like `In.ar(\out.ir)` not just pointlessly call it as above discarding its value, but the above is a minimal example that audibly demonstrates the issue.

The commit in this PR is rather orthogonal to the other proposed changes in #5648 *unless* you hate NamedControl being used internally in JITLib, in which case I have to inform you it already happens in `GraphBuilder.sc` (specifically, for `\gate` and `\fadeTime`), which is in turn even used for building Synths that aren't technically part of JITLib, meaning those bits that already produce NamedControls in `GraphBuilder.sc` are also called by `Function.play` to build "plain" SynthDefs that are not ProxySynthDefs.  So it seems pretty reasonable to me to make JITLib internally use NamedControls for every control it generates itself.

This commit will also give us a baseline that there are actually no more `Control.names` uses in the standard SC library after this commit is merged, so it *can be* a step toward deprecating `Control.names`, although more features would probably have to be added to NamedControl before that happens. NamedControl  might need to have a way to create a shared control with multiple names mapped on it as some quarks (e.g. crucial lib) use<!-- todo add link here--> `Control.names` like that. There were no such (sophisticated) uses of `Control.names` in the SC library though, meaning all uses replaced in this commit had a single name passed to each `Contol.names` call, so no Control objects shared by multiple names were being created in JITLib, making replacement with NamedControl straightforward at each call site.

Related to the above, there is actually one obscure bit in proxy roles that [creates nameless controls](https://github.com/supercollider/supercollider/commit/b031519a0926b2392c0bfb02dcd53ee115ecca18#diff-1b5b339bcf1744215bbf41b4006d873c90f36ecc2bd52ce7237eba48595a90fcR353). I didn't touch that one since NamedControl can't create nameless controls. Maybe someone can comment on what the purpose of that role is. The documentation says

> (\control -> array or number)
> prepare an efficient way to set values by index

But it's still rather unclear to me why a proxy role is need for that. That bit was [added](https://github.com/supercollider/supercollider/commit/3afe3b684f418a883d66334b66e4c685618d7f64) some 17 years ago, and apparently it might have been used by an `EDC` class that doesn't seem to exist anymore, unless it was renamed.

## Types of changes

- Bug fix
- New feature
- Breaking change

I'm not sure how many of these bullets apply. It depends whether you want to consider a bug fix, new feature, or even breaking change that programs like the above that didn't work as one might have intuitively expected, will do so with this commit.

- Documentation

The documentation is rather ambiguous on this.  It says

> Reserved parameters
> Three parameters are automatically specified if they don't exist in a given UGen function. You can override their use: [\out, \gate, \fadeTime]

It seems somewhat awkward to say they are "reserved parameters" but then that "you can override their use". I don't want to bog this one down with help wording tweaks, but if this PR ie merged, the documentation should perhaps say that JITLib (uniformly) uses NamedControls when it internally generates controls, so that the (expert) user would know what to expect if they try to change or read any control values for control names that JITLib also implements some functionality for.

For this latter info to be truly useful for the *average* user, the interaction of the 3 namespaces (arg-generated, NamedControl-generated, and Control.names-generated) would have to be documented somewhere in the help, and presently that's not the case. Also, changes in other proposed commits for the other issues in #5648 would change some of those interactions, so it's not worthwhile prematurely writing very detailed documentation on this, before deciding whether some other patches for #5648 are merged (or not).

I suppose a test suite case is desirable for this change, along the lines of the first example, Let me know where it should be placed. I'm guessing in TestNodeProxy.sc since the non-duplicate names generation can be tested without the server running. There don't seem to be separate tests for ProxySynthDef. Also, it's probably not worth the hassle testing that the change took effect in all the proxy roles, even though TestNodeProxyRoles exists, because of the repetitive nature of those changes. It's probably good enough that/if it doesn't break the latter test suite.

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [ ] Code is tested
- [ ] All tests are passing
- [ ] Updated documentation
- [x] This PR is ready for review
