### PR TITLE
SynthDef.build gets a changed posthook

### DIFF
--- a/SCClassLibrary/Common/Audio/SynthDef.sc
+++ b/SCClassLibrary/Common/Audio/SynthDef.sc
@@ -46,7 +46,7 @@ SynthDef {
 			this.buildUgenGraph(ugenGraphFunc, rates, prependArgs);
 			this.finishBuild;
 			func = ugenGraphFunc;
-			this.class.changed(\synthDefBuilt, this);
+			this.class.changed(\synthDefReady, this);
 		} {
 			UGen.buildSynthDef = nil;
 		}

--- a/SCClassLibrary/Common/Audio/SynthDef.sc
+++ b/SCClassLibrary/Common/Audio/SynthDef.sc
@@ -46,6 +46,7 @@ SynthDef {
 			this.buildUgenGraph(ugenGraphFunc, rates, prependArgs);
 			this.finishBuild;
 			func = ugenGraphFunc;
+			this.class.changed(\synthDefBuilt, this);
 		} {
 			UGen.buildSynthDef = nil;
 		}


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

Fixes #5656

## Types of changes

<!-- Documentation -->
- New feature

## To-do list

If reviewers don't think this is another horrible idea of mine, I'll even write a test case and documentation for this, if deemed necessary. SynthDescLib does document its `changed` notification hooks in the help, although many other classes in SC do not.

- [ ] Code is tested
- [ ] All tests are passing
- [ ] Updated documentation
- [x] This PR is ready for review
