### PR TITLE
CondVar.prWait: fix duplication in waitingThreads

### DIFF
--- a/SCClassLibrary/Common/Core/CondVar.sc
+++ b/SCClassLibrary/Common/Core/CondVar.sc
@@ -63,8 +63,14 @@ CondVar {
 	deepCopy { this.shouldNotImplement(thisMethod) }
 
 	prWait {
+		var tp = thisThread.threadPlayer;
 		this.prSleepThread(thisThread);
-		\wait.yield
+		\wait.yield;
+		waitingThreads.remove(tp);
+		// ^^ Sadly, prRemoveWaitingThread takes the wrong argument for what we
+		// need to ensure corectness here if the threadPlayer of thisThread
+		// changes while this method has yielded control to one that does
+		// something like that at the yield above.
 	}
 
 	// Returns true iff we were woken via signal (and not timeout)


### PR DESCRIPTION
## Purpose and Motivation

Fixes #5669 & fixes #5668 as well.

It would enable a simple fix for #5660 as well, simply by switching to using CondVar over there instead of Condition, after #5670 is applied.

## Types of changes

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [ ] Code is tested
- [ ] All tests are passing
- [x] This PR is ready for review
