### PR TITLE
FlowVar.condition switchover to CondVar; add reset method

### DIFF
--- a/SCClassLibrary/Common/Core/Condition.sc
+++ b/SCClassLibrary/Common/Core/Condition.sc
@@ -48,17 +48,18 @@ FlowVar {
 	}
 	init { arg inVal;
 		value = inVal;
-		condition = Condition { value != \unbound };
+		condition = CondVar.new;
 	}
 	value_ { arg inVal;
 		if (value != \unbound) {
 			Error("cannot rebind a FlowVar").throw
 		};
 		value = inVal;
-		condition.signal;
+		condition.signalAll;
 	}
 	value {
-		condition.wait
+		condition.wait { value != \unbound };
 		^value
 	}
+	reset { value = \unbound }
 }


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

FlowVar switchover to using CondVar for its `condition`. Partially fixes #5660, meanig the first example in there because `CondVar.wait` implements its own condition-re-checking `while` loop, when supplied with a predicate. This PR will also help fix the 2nd example that I alas put the same #5660 bug report then when #5670 is merged, fixing and underlying issue in CondVar (that also exists in Condition).

I've also added a `reset` method in the same commit that resolves #5663 since I didn't see any objections to the enhancement request. It's in the same commit  because the proximity of the lines changed would likely have created a gratuitous merge conflict otherwise. 

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->

<!-- todo - Documentation -->
- Bug fix
- New feature

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [ ] Code is tested
- [ ] All tests are passing
- [ ] Updated documentation
- [x] This PR is ready for review
