### PR TITLE
Topic/use named controls in node proxy

### DIFF
--- a/SCClassLibrary/JITLib/ProxySpace/ProxySynthDef.sc
+++ b/SCClassLibrary/JITLib/ProxySpace/ProxySynthDef.sc
@@ -124,7 +124,7 @@ ProxySynthDef : SynthDef {
 						}
 					}
 				};
-				outCtl = Control.names(\out).ir(0) + channelOffset;
+				outCtl = NamedControl.ir(\out, 0) + channelOffset;
 				(if(rate === \audio and: { sampleAccurate }) { OffsetOut } { Out }).multiNewList([rate, outCtl] ++ output)
 			})
 		});

--- a/SCClassLibrary/JITLib/ProxySpace/wrapForNodeProxy.sc
+++ b/SCClassLibrary/JITLib/ProxySpace/wrapForNodeProxy.sc
@@ -301,7 +301,7 @@
 				};
 
 				{ | out |
-					var env, ctl = NamedControl.kr("wet" ++ (index ? 0));
+					var env, ctl = NamedControl.kr("wet" ++ (index ? 0), 1.0);
 					if(proxy.rate === 'audio') {
 						env = ctl * EnvGate(i_level: 0, doneAction:2, curve:\sin);
 						XOut.ar(out, env, SynthDef.wrap(func, nil, [In.ar(out, proxy.numChannels)]))

--- a/SCClassLibrary/JITLib/ProxySpace/wrapForNodeProxy.sc
+++ b/SCClassLibrary/JITLib/ProxySpace/wrapForNodeProxy.sc
@@ -301,7 +301,7 @@
 				};
 
 				{ | out |
-					var env, ctl = Control.names(["wet"++(index ? 0)]).kr(1.0);
+					var env, ctl = NamedControl.kr("wet" ++ (index ? 0)).kr(1.0);
 					if(proxy.rate === 'audio') {
 						env = ctl * EnvGate(i_level: 0, doneAction:2, curve:\sin);
 						XOut.ar(out, env, SynthDef.wrap(func, nil, [In.ar(out, proxy.numChannels)]))
@@ -363,7 +363,7 @@
 
 				{ | out |
 					var in, env;
-					var wetamp = Control.names(["wet"++(index ? 0)]).kr(1.0);
+					var wetamp = NamedControl.kr("wet" ++ (index ? 0), 1.0);
 					var dryamp = 1 - wetamp;
 					var sig = { |in| SynthDef.wrap(func, nil, [in * wetamp]) + (dryamp * in) };
 
@@ -382,7 +382,7 @@
 			mix: #{ | func, proxy, channelOffset = 0, index |
 
 				{
-					var ctl = Control.names(["mix" ++ (index ? 0)]).kr(1.0);
+					var ctl = NamedControl.kr("mix" ++ (index ? 0), 1.0);
 					var sig = SynthDef.wrap(func);
 					var curve = if(sig.rate === \audio) { \sin } { \lin };
 					var env = EnvGate(i_level: 0, doneAction:2, curve:curve);

--- a/SCClassLibrary/JITLib/ProxySpace/wrapForNodeProxy.sc
+++ b/SCClassLibrary/JITLib/ProxySpace/wrapForNodeProxy.sc
@@ -301,7 +301,7 @@
 				};
 
 				{ | out |
-					var env, ctl = NamedControl.kr("wet" ++ (index ? 0)).kr(1.0);
+					var env, ctl = NamedControl.kr("wet" ++ (index ? 0));
 					if(proxy.rate === 'audio') {
 						env = ctl * EnvGate(i_level: 0, doneAction:2, curve:\sin);
 						XOut.ar(out, env, SynthDef.wrap(func, nil, [In.ar(out, proxy.numChannels)]))


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

As  @avdrd has noticed (thanks!), node proxies may collide with uses of `NamedControl`: #5648 
This is a lightweight, partial fix. A complete fix will require touching `SynthDef` more deeply.

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] This PR is ready for review
