### PR TITLE
fix implicit specs in synth functions

### DIFF
--- a/SCClassLibrary/Common/Control/GraphBuilder.sc
+++ b/SCClassLibrary/Common/Control/GraphBuilder.sc
@@ -118,6 +118,9 @@ NamedControl {
 				Error("NamedControl: cannot have more than one set of "
 					"fixed lag values in the same control.").throw;
 			} {
+				if(spec.notNil) {
+					res.spec = spec; // set spec before early exit too
+				};
 				^res.control;
 			}
 		};


### PR DESCRIPTION
make sure specs in synthdef reach metadata in all cases

## Purpose and Motivation

implicit control parameters in synth functions allow setting control specs.
These specs specs should be stored in a synthdef's metadata, so they are 
available e.g. for controller ranges. 

Due to a bug in NamedControl, these specs are not stored when the control 
in question is optimized for fixed lag. 

```supercollider
// an implicit control without lag works:
~lagnone = SynthDef(\lagnone, { \ctl.kr(0.2, spec: [0, 11]); 0.0 }).add;
~lagnone.metadata; // \ctl specs here

// an implicit control with a fixed lag loses its spec:
~lagfix = SynthDef(\lagfix, { \ctl.kr(0.2, 0.2, spec: [0, 11]); 0.0 }).add;
~lagfix.metadata; // specs empty

// an implicit control with a variable lag also works
~lagvar = SynthDef(\lagvar, { \ctl.kr(0.2, \lag.kr(0.2, spec: [0, 10, 4]), spec: [0, 11]); 0.0 }).add;
~lagvar.metadata;  // specs empty too

```

## Types of changes

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [ ] Update of documentation not needed
- [x] This PR is ready for review
