### PR TITLE
ndef uses embedded specs for guis

### DIFF
--- a/SCClassLibrary/Common/Audio/SynthDef.sc
+++ b/SCClassLibrary/Common/Audio/SynthDef.sc
@@ -667,11 +667,8 @@ SynthDef {
 	}
 
 	findSpecFor { |controlName|
-		^if(metadata[\specs].isNil) {
-			nil
-		} {
-			metadata[\specs][controlName]
-		}
+		var specs = metadata[\specs];
+		^specs !? { specs[controlName] }
 	}
 
 	specs {

--- a/SCClassLibrary/Common/Audio/SynthDef.sc
+++ b/SCClassLibrary/Common/Audio/SynthDef.sc
@@ -666,6 +666,14 @@ SynthDef {
 		^desc
 	}
 
+	findSpec { |name|
+		^if(metadata[\specs].isNil) {
+			nil
+		} {
+			metadata[\specs][name]
+		}
+	}
+
 	specs {
 		if(metadata[\specs].isNil) { metadata[\specs] = () };
 		^metadata[\specs]

--- a/SCClassLibrary/Common/Audio/SynthDef.sc
+++ b/SCClassLibrary/Common/Audio/SynthDef.sc
@@ -666,11 +666,11 @@ SynthDef {
 		^desc
 	}
 
-	findSpec { |name|
+	findSpecFor { |controlName|
 		^if(metadata[\specs].isNil) {
 			nil
 		} {
-			metadata[\specs][name]
+			metadata[\specs][controlName]
 		}
 	}
 

--- a/SCClassLibrary/JITLib/GUI/EnvirGui.sc
+++ b/SCClassLibrary/JITLib/GUI/EnvirGui.sc
@@ -321,12 +321,18 @@ EnvirGui : JITGui {
 		}
 	}
 
-	// this finds global specs and local specs in the gui only
-	// - use JITLibExtensions for specs attached to the JITGui objects.
-	// precedence: global specs first, then cached local,
-	// else guess an initial spec and remember it.
+	// first, check the object if it has a local spec (in synth func)
+	// if not, use local gui specs, then global specs;
+	// if none found, guess an initial spec and remember it.
+	// note: for specs attached to proxies, use JITLibExtensions quark
 	getSpec { |key, value|
-		var spec = specs[key] ?? { key.asSpec };
+		var spec;
+		if (object.respondsTo(\findFirstSpecFor)) {
+			spec = object.findFirstSpecFor(key);
+			if (spec.notNil) { ^spec };
+		};
+
+		spec = specs[key] ?? { key.asSpec };
 		if (spec.isNil) {
 			spec = Spec.guess(key, value);
 			specs.put(key, spec);

--- a/SCClassLibrary/JITLib/ProxySpace/NodeProxy.sc
+++ b/SCClassLibrary/JITLib/ProxySpace/NodeProxy.sc
@@ -1031,12 +1031,13 @@ NodeProxy : BusPlug {
 		^SynthDef(name, func);
 	}
 
-	// return the first spec, ignore multiples
-	findSpec { |name|
+	// for lookup speed, always return first spec found in objects,
+	// ignore when the same controlName sets specs in multiple objects.
+	findFirstSpecFor { |controlName|
 		var spec;
 		this.objects.do { |obj|
-			if (obj.respondsTo(\findSpec)) {
-				spec = obj.findSpec(name);
+			if (obj.respondsTo(\findSpecFor)) {
+				spec = obj.findSpecFor(controlName);
 				if (spec.notNil) {
 					^spec
 				}

--- a/SCClassLibrary/JITLib/ProxySpace/NodeProxy.sc
+++ b/SCClassLibrary/JITLib/ProxySpace/NodeProxy.sc
@@ -1031,6 +1031,20 @@ NodeProxy : BusPlug {
 		^SynthDef(name, func);
 	}
 
+	// return the first spec, ignore multiples
+	findSpec { |name|
+		var spec;
+		this.objects.do { |obj|
+			if (obj.respondsTo(\findSpec)) {
+				spec = obj.findSpec(name);
+				if (spec.notNil) {
+					^spec
+				}
+			}
+		};
+		^nil
+	}
+
 	specs {
 		var specs = ();
 		this.objects.do {

--- a/SCClassLibrary/JITLib/ProxySpace/ProxyInterfaces.sc
+++ b/SCClassLibrary/JITLib/ProxySpace/ProxyInterfaces.sc
@@ -413,8 +413,8 @@ SynthDefControl : SynthControl {
 		bytes = control.bytes; // copy cached data
 	}
 
-	findSpec { |name|
-		^synthDef.findSpec(name)
+	findSpecFor { |controlName|
+		^synthDef.findSpecFor(controlName)
 	}
 	specs {
 		^synthDef.specs

--- a/SCClassLibrary/JITLib/ProxySpace/ProxyInterfaces.sc
+++ b/SCClassLibrary/JITLib/ProxySpace/ProxyInterfaces.sc
@@ -413,6 +413,9 @@ SynthDefControl : SynthControl {
 		bytes = control.bytes; // copy cached data
 	}
 
+	findSpec { |name|
+		^synthDef.findSpec(name)
+	}
 	specs {
 		^synthDef.specs
 	}


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

Fixes #5515.

Currently, NdefGui does not find controlspecs embedded in synth functions, 
thus NdefGui cannot use such specs for its slider ranges.
With this PR, core JITLib NdefGui finds these specs and uses them. 

## Types of changes

- Bug fix

```
// Ndef with an embedded spec:
n = Ndef(\1, { Saw.ar(freq: \fff.kr(200, spec: [50, 500, \exp])) * 0.1 });
// before this PR, this gui uses guessed range of 10-4000
n.gui;

// with this PR, ndef finds the embedded spec:
n.findFirstSpecFor(\fff);
// also in the specs method
n.specs;
// and the gui uses the 50 - 500 range given in the embedded spec:
n.gui;
```
Note: this fix works for plain SC without JITLibExtensions quark;
JITLibExtensions update to use it is simple, and ready to go. 

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [ ] All tests are passing
- [ ] Updated documentation
- [x] This PR is ready for review
