### PR TITLE
Add UnitTest test_seti_nodeMap again

### DIFF
--- a/testsuite/classlibrary/TestNodeProxy.sc
+++ b/testsuite/classlibrary/TestNodeProxy.sc
@@ -423,10 +423,7 @@ TestNodeProxySeti : UnitTest {
 		this.assertEquals(keysValues[0][1], [200, 345, 345, 145, 200], "the 'freq' arg array should have been set to [200, 345, 345, 145, 200] in NodeProxy 'proxy'.");
 	}
 
-	// The following test works as expeceted locally if only tests in TestNodeProxySeti are executed.
-	// However, it fails in Github Actions with a mysterious error ("ERROR: BusPlug:setBus: bus can't be set to nil.").
-	// Hence, it's commented out for now
-	/*test_seti_nodeMap {
+	test_seti_nodeMap {
 		var controlProxy, keysValues;
 		controlProxy = NodeProxy.control(server, 1);
 		controlProxy.source = { DC.kr };
@@ -434,5 +431,5 @@ TestNodeProxySeti : UnitTest {
 		keysValues = proxy.getKeysValues;
 		this.assertEquals(keysValues[0][1], [200, 200, controlProxy, 200, 200], "the third slot in the 'freq' arg array should have been set to NodeProxy.control(server, 1)");
 		controlProxy.clear;
-	}*/
+	}
 }

--- a/testsuite/scripts/gha_test_run_proto.json
+++ b/testsuite/scripts/gha_test_run_proto.json
@@ -154,11 +154,11 @@
             "skip":true,
             "skipReason":"UnitTest sometimes fails when run in qpm"
         },
-	{
-	    "suite":"TestNodeProxySeti",
-	    "test":"test_seti_nodeMap",
-	    "skip":true,
-	    "skipReason":"test passes on local machine but fails in GHA for unknown reasons"
-	}
+        {
+            "suite":"TestNodeProxySeti",
+            "test":"test_seti_nodeMap",
+            "skip":true,
+            "skipReason":"test passes on local machine but fails in GHA for unknown reasons"
+        }
     ]
 }

--- a/testsuite/scripts/gha_test_run_proto.json
+++ b/testsuite/scripts/gha_test_run_proto.json
@@ -153,6 +153,12 @@
             "test":"test_findText_notFound",
             "skip":true,
             "skipReason":"UnitTest sometimes fails when run in qpm"
-        }
+        },
+	{
+	    "suite":"TestNodeProxySeti",
+	    "test":"test_seti_nodeMap",
+	    "skip":true,
+	    "skipReason":"test passes on local machine but fails in GHA for unknown reasons"
+	}
     ]
 }


### PR DESCRIPTION
The test passes locally but failes on GHA. Therefore it's been added to
gha_test_run_proto.json

Signed-off-by: Stefan Nussbaumer <st9fan@gmail.com>

<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

The test `test_seti_nodeMap` has always passed on my local machine but fails in GHA. So I've added the test to `gha_test_run_proto.json`

## Types of changes

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [ ] Code is tested
- [ ] All tests are passing
- [ ] Updated documentation
- [x] This PR is ready for review
