### PR TITLE
SinOscFB.schelp: updated FM caveat

### DIFF
--- a/HelpSource/Classes/SinOscFB.schelp
+++ b/HelpSource/Classes/SinOscFB.schelp
@@ -9,7 +9,7 @@ Description::
 SinOscFB is a sine oscillator that has phase modulation feedback; its output plugs back into the phase input.
 Basically this allows a modulation between a sine wave and a sawtooth like wave. Overmodulation causes chaotic oscillation. It may be useful if you want to simulate feedback FM synths.
 
-Please note: The frequency of SinOscFB can be modulated at control rate. When trying to modulate the frequency of SinOscFB at audio rate, you will notice audible artefacts at higher frequency modulation frequencies. This is due to SinOscFB updating incoming frequency modulation values only once every block of 64 samples, instead of updating on every sample (like e.g. SinOsc).
+Please note: The frequency of SinOscFB can be modulated at control rate. When trying to modulate the frequency of SinOscFB at audio rate, you will notice audible artefacts at higher frequency modulation frequencies. This is due to SinOscFB updating incoming frequency modulation values only once every control period (which is 64 samples long per default), instead of updating on every sample (like e.g. SinOsc).
 
 
 


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

Update to fix #5641.

In discussion of the PR #5654, @dyfer and @adcxyz suggested to refer to the default length of the control period instead of refering to a generic control rate ([see e.g. here](https://github.com/supercollider/supercollider/pull/5654#issuecomment-1008046281)).

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

- Documentation

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review
