### PR TITLE
help: typos and link corrections

### DIFF
--- a/HelpSource/Classes/Array.schelp
+++ b/HelpSource/Classes/Array.schelp
@@ -421,5 +421,5 @@ argument:: scopeChannel
 Bela's oscilloscope channel to start scoping on. This has to be a non-negative number, and can't be changed after scoping starts.
 
 argument:: server
-The server on which BelaScope is running. If not specified, it looks for the first server for which BelaScope was already initialized. If none is found, it attempts to initialize a link::Classes/BelaScope:: instance on link::Server#*default::.
+The server on which BelaScope is running. If not specified, it looks for the first server for which BelaScope was already initialized. If none is found, it attempts to initialize a link::Classes/BelaScope:: instance on link::Classes/Server#*default::.
 returns:: This Array.

--- a/HelpSource/Classes/ArrayedCollection.schelp
+++ b/HelpSource/Classes/ArrayedCollection.schelp
@@ -210,7 +210,7 @@ y.postln;
 ::
 
 method::fill
-Inserts the item into the contents of the receiver. note::the difference between this and link::Classes/Collection#fill#Collection's *fill::.::
+Inserts the item into the contents of the receiver. note::the difference between this and link::Classes/Collection#*fill#Collection's *fill::.::
 code::
 (
 var z;

--- a/HelpSource/Classes/BelaScope.schelp
+++ b/HelpSource/Classes/BelaScope.schelp
@@ -60,7 +60,10 @@ Number of bus channels to scope
 argument::target
 Bela's SuperCollider server, or any node on that server. The bus is monitored strong::after:: this target, or after this server's link::Classes/RootNode:: if a server is provided as target.
 
-returns:: A link::Class/Synth:: used to monitor the bus.
+argument::rate
+A symbol. The default is code::\audio::. Anything else will use control rate.
+
+returns:: A link::Classes/Synth:: used to monitor the bus.
 
 code::
 // scope 2 channels from audio bus 4 on Bela Oscilloscope's channel 3

--- a/HelpSource/Classes/Button.schelp
+++ b/HelpSource/Classes/Button.schelp
@@ -11,7 +11,7 @@ Failure to set any states at all results in an invisible button.
 
 The button performs its action upon releasing the mouse. In musical contexts, you might want to use code::mouseDownAction_():: to set a function to be performed on pressing the mouse (see link::Classes/View::, and examples below).
 
-If the drag contains a number, then code::valueAction_():: is performed using the code::currentDrag::. If the drag contains anything else, code::action:: is set to the current drag. You could, for example, drag a function to an Button, and action would then be set to that function.
+If the drag contains a number, then code::valueAction_():: is performed using the code::currentDrag::. If the drag contains anything else, code::action:: is set to the current drag. You could, for example, drag a function to a Button, and action would then be set to that function.
 
 classmethods::
 
@@ -92,7 +92,7 @@ b.string = "hello button";
 
 method:: font
 Sets the Font of the button. Default value is the default font: Font.default .
-argument:: font
+argument:: aFont
 An instance of link::Classes/Font::.
 
 
@@ -162,7 +162,7 @@ b.valueAction = -1;
 b.valueAction = 3.3;
 ::
 
-In a musical context, a button-down press is more meaningful than a button-up (release) as it's more intuitive to press a button on the beat. For that you can use link::Classes/View::'s link::Classes/View#mouseDownAction:: (a superclass of Button).
+In a musical context, a button-down press is more meaningful than a button-up (release) as it's more intuitive to press a button on the beat. For that you can use link::Classes/View::'s link::Classes/View#-mouseDownAction:: (a superclass of Button).
 code::
 (
 s.waitForBoot({

--- a/HelpSource/Classes/Color.schelp
+++ b/HelpSource/Classes/Color.schelp
@@ -76,7 +76,7 @@ argument:: alpha
 Transparency between 0 and 1 as link::Classes/Float::.
 
 method:: rand
-A random RGB Color where the colors are randomly chosen between code::lo:: and code::hi::. See link::Classes/Color#new::.
+A random RGB Color where the colors are randomly chosen between code::lo:: and code::hi::. See link::#*new::.
 argument:: lo
 An instance of link::Classes/Float:: between 0 and 1.
 argument:: hi

--- a/HelpSource/Classes/Document.schelp
+++ b/HelpSource/Classes/Document.schelp
@@ -111,7 +111,7 @@ subsection:: Path Utilities
 Utilities and settings for dealing with documents such as SuperCollider code files. By default the document directory is SuperCollider's application directory.
 
 method:: dir
-Get/set the default document directory. The default is dependent on link::Classes/Document#implementationClass::.
+Get/set the default document directory. The default is dependent on link::#*implementationClass::.
 argument:: path
 The file system path to the directory. An instance of link::Classes/String::.
 discussion::
@@ -183,7 +183,7 @@ argument:: bool
 An instance of link::Classes/Boolean::.
 
 method:: name
-Get / set the title (same as link::Classes/Document#title::).
+Get / set the title (same as link::#-title::).
 argument:: aname
 An instance of link::Classes/String::.
 discussion::
@@ -192,7 +192,7 @@ Document.current.name.postln;
 ::
 
 method:: title
-Get / set the title (same as link::Classes/Document#name::).
+Get / set the title (same as link::#-name::).
 argument:: newTitle
 An instance of link::Classes/String::.
 
@@ -214,10 +214,10 @@ method:: isFront
 Returns code::true:: if the document is in front.
 
 method:: didBecomeKey
-Saves the current link::Classes/Environment::, makes the document current, and performs its link::Classes/Document#toFrontAction::.
+Saves the current link::Classes/Environment::, makes the document current, and performs its link::#-toFrontAction::.
 
 method:: didResignKey
-Performs the Document's link::Classes/Document#endFrontAction:: and restores the current link::Classes/Environment::.
+Performs the Document's link::#-endFrontAction:: and restores the current link::Classes/Environment::.
 
 
 
@@ -261,14 +261,14 @@ argument:: value
 An instance of link::Classes/Function:: or link::Classes/FunctionList::.
 
 method:: mouseDownAction
-Get/set the action to be performed on link::Classes/Document#mouseDown::.
+Get/set the action to be performed on link::#-mouseDown::.
 
 argument:: action
 An instance of link::Classes/Function:: or link::Classes/FunctionList::. The arguments passed to the function are: code::document::, code::x::, code::y::, code::modifiers::, code::buttonNumber::, code::clickCount::.
 
 
 method:: mouseUpAction
-Get/set the action to be performed on link::Classes/Document#mouseUp::.
+Get/set the action to be performed on link::#-mouseUp::.
 argument:: action
 An instance of link::Classes/Function:: or link::Classes/FunctionList::. The arguments passed to the function are: code::document::, code::x::, code::y::, code::modifiers::, code::buttonNumber::.
 discussion::
@@ -294,12 +294,12 @@ s.waitForBoot({
 ::
 Test here and click in front of the numbers: 17 and 23.
 code::
-Document.current.mouseUpAction = nil; // clear mouseUpActiont
+Document.current.mouseUpAction = nil; // clear mouseUpAction
 ::
 
 
 method:: keyDownAction
-Get/set the action to be performed on link::Classes/Document#keyDown::.
+Get/set the action to be performed on link::#-keyDown::.
 argument:: action
 An instance of link::Classes/Function:: or link::Classes/FunctionList::. The arguments passed to the function are: code::document::, code::char::, code::modifiers::, code::unicode::, code::keycode::. See link::Classes/View#Key actions:: for details on these arguments.
 discussion::
@@ -310,7 +310,7 @@ Document.current.keyDownAction = nil;
 ::
 
 method:: keyUpAction
-Get/set the action to be performed on link::Classes/Document#keyUp::.
+Get/set the action to be performed on link::#-keyUp::.
 argument:: action
 An instance of link::Classes/Function:: or link::Classes/FunctionList::. The arguments passed to the function are: code::document::, code::char::, code::modifiers::, code::unicode::, code::keycode::. See link::Classes/View#Key actions:: for details on these arguments.
 discussion::
@@ -429,7 +429,7 @@ An link::Classes/Integer:: for the number of characters to retrieve. -1 retrieve
 method:: getTextAsync
 Get a range of text from the document. Asynchronous. The text is passed to the code::action:: function as an argument.
 
-note:: Currently, in Windows, link::Classes/Document#-getText:: and link::Classes/Document#-string:: may be unreliable. Windows users are recommended to use link::Classes/Document#-getTextAsync:: for the time being.
+note:: Currently, in Windows, link::#-getText:: and link::#-string:: may be unreliable. Windows users are recommended to use link::#-getTextAsync:: for the time being.
 ::
 
 argument:: action

--- a/HelpSource/Classes/DynKlank.schelp
+++ b/HelpSource/Classes/DynKlank.schelp
@@ -1,6 +1,6 @@
 class:: DynKlank
 summary:: Bank of resonators.
-related:: Classes/Klang, Classes/Klank
+related:: Classes/Klang, Classes/DynKlang, Classes/Klank
 categories::  UGens>Generators>Deterministic, UGens>Filters>Linear
 
 

--- a/HelpSource/Classes/Env.schelp
+++ b/HelpSource/Classes/Env.schelp
@@ -155,7 +155,7 @@ code::
 method::newClear
 Creates a new envelope specification with strong::numSegments:: and strong::numChannels:: for filling in later.
 discussion::
-This can be useful when passing Env parameters as args to a link::Classes/Synth::. Note that the maximum number of segments is fixed and cannot be changed once embedded in a link::Classes/SynthDef::. Trying to set an Env with more segments than then this may result in other args being unexpectedly set.
+This can be useful when passing Env parameters as args to a link::Classes/Synth::. Note that the maximum number of segments is fixed and cannot be changed once embedded in a link::Classes/SynthDef::. Trying to set an Env with more segments than this may result in other args being unexpectedly set.
 
 code::
 (

--- a/HelpSource/Classes/GrainBuf.schelp
+++ b/HelpSource/Classes/GrainBuf.schelp
@@ -1,7 +1,7 @@
 class:: GrainBuf
 summary:: Granular synthesis with sound stored in a buffer
 categories:: UGens>Buffer, UGens>Generators>Granular
-related:: Classes/GrainIn, Classes/GrainFM, Classes/GrainSin
+related:: Classes/GrainIn, Classes/GrainFM, Classes/GrainSin, Classes/TGrains
 
 classmethods::
 private:: categories

--- a/HelpSource/Classes/GridLines.schelp
+++ b/HelpSource/Classes/GridLines.schelp
@@ -33,7 +33,7 @@ CLASSMETHODS::
 METHOD:: new
 
 argument:: spec
-The ControlSpec that defines the mininum and maximum values, warn and step.
+The ControlSpec that defines the minimum and maximum values, warn and step.
 
 returns:: a GridLines
 

--- a/HelpSource/Classes/IndexInBetween.schelp
+++ b/HelpSource/Classes/IndexInBetween.schelp
@@ -1,7 +1,7 @@
 class:: IndexInBetween
 summary:: Finds the (lowest) point in the Buffer at which the input signal lies in-between the two values
 categories:: UGens>Buffer
-related:: Classes/Index, Classes/IndexL, Classes/SequenceableCollection#indexInBetween
+related:: Classes/Index, Classes/IndexL, Classes/SequenceableCollection#-indexInBetween
 
 description::
 Finds the (lowest) point in the link::Classes/Buffer:: at which the input signal lies in-between the two values, and returns the index. The fractional part of the index is suitable for linearly interpolating between the buffer slot values.

--- a/HelpSource/Classes/LinkClock.schelp
+++ b/HelpSource/Classes/LinkClock.schelp
@@ -93,10 +93,10 @@ argument:: beats
 The time in beats, corresponding to the reference time. Default to code::0::.
 
 argument:: seconds
-The reference time in seconds. See link::Classes/TempoClock#-new::.
+The reference time in seconds. See link::Classes/TempoClock#*new::.
 
 argument:: queueSize
-The storage size of the scheduling queue. See link::Classes/TempoClock#-new::.
+The storage size of the scheduling queue. See link::Classes/TempoClock#*new::.
 
 discussion::
 If an existing Link session is found on the local network, the object connects

--- a/HelpSource/Classes/List.schelp
+++ b/HelpSource/Classes/List.schelp
@@ -116,7 +116,7 @@ y.postln;
 ::
 
 method::fill
-Inserts the item into the contents of the receiver, possibly returning a new collection. note::the difference between this and link::Classes/Collection#fill#Collection's *fill::.::
+Inserts the item into the contents of the receiver, possibly returning a new collection. note::the difference between this and link::Classes/Collection#*fill#Collection's *fill::.::
 code::
 (
 var z;

--- a/HelpSource/Classes/MainMenu.schelp
+++ b/HelpSource/Classes/MainMenu.schelp
@@ -62,7 +62,7 @@ METHOD:: register
 			## Help
 		::
 
-		If registering menu items for a Quark, consider registering as a sub-menu of the Quarks menu. This can easily be done using the link::Classes/MainMenu#registerQuarkMenu:: method.
+		If registering menu items for a Quark, consider registering as a sub-menu of the Quarks menu. This can easily be done using the link::#*registerQuarkMenu:: method.
 
 METHOD:: registerQuarkMenu
 	Convenience method for registering a menu of functionality related to a Quark.

--- a/HelpSource/Classes/Ndef.schelp
+++ b/HelpSource/Classes/Ndef.schelp
@@ -59,10 +59,10 @@ Ndef(\x, { Dust.ar }); // returns the proxy and set the source object.
 ::
 
 method::ar
-equivalent to code::*new(key).ar(numChannels, offset):: (see link::Classes/BusPlug#ar::)
+equivalent to code::*new(key).ar(numChannels, offset):: (see link::Classes/BusPlug#-ar::)
 
 method::kr
-equivalent to code::*new(key).kr(numChannels, offset):: (see link::Classes/BusPlug#kr::)
+equivalent to code::*new(key).kr(numChannels, offset):: (see link::Classes/BusPlug#-kr::)
 
 method::clear
 clear all proxies

--- a/HelpSource/Classes/NodeProxy.schelp
+++ b/HelpSource/Classes/NodeProxy.schelp
@@ -157,13 +157,13 @@ argument::obj
 can be one of the supported inputs (see link::#Supported sources::)
 
 note::
-When reshaping is set, e.g. to \elastic, setting the source can change the number of channels of the proxy. This means that its bus changes, and that child proxies, which read signals from it, may also change. See the example in link::#routing::.
+When reshaping is set, e.g. to \elastic, setting the source can change the number of channels of the proxy. This means that its bus changes, and that child proxies, which read signals from it, may also change. See the example in link::#Routing::.
 ::
 
 subsection::Routing
 Signals can be routed between any number of node proxies.
 
-See also: link::Classes/BusPlug#ar::, link::Classes/BusPlug#value::, link::#reshaping::.
+See also: link::Classes/BusPlug#-ar::, link::Classes/BusPlug#-value::, link::#Reshaping::.
 
 Here is a simple example, using Ndef (NodeProxy works similarly):
 

--- a/HelpSource/Classes/Object.schelp
+++ b/HelpSource/Classes/Object.schelp
@@ -243,7 +243,7 @@ A lazy inequality operator, defined as code::not(this |==| that)::. See link::Cl
 
 method::fuzzyEqual
 
-Returns the degree of equality between two objects with regard to a given precision. Objects to compare must support max, substraction, and division.
+Returns the degree of equality between two objects with regard to a given precision. Objects to compare must support max, subtraction, and division.
 
 code::
 5.0.fuzzyEqual(5.0, 0.5); // 1 - full equality
@@ -801,7 +801,7 @@ Yields the receiver
 
 method::idle
 
-within a routine, return values (the receiver) until this time is over. (see also link::Classes/Routine#play::)
+within a routine, return values (the receiver) until this time is over. (see also link::Classes/Routine#-play::)
 Time is measured relative to the thread's clock.
 code::
 a = Routine { 1.yield; 0.idle(3); 400.yield };

--- a/HelpSource/Classes/Routine.schelp
+++ b/HelpSource/Classes/Routine.schelp
@@ -178,7 +178,7 @@ argument::quant
 see the link::Classes/Quant:: helpfile
 
 discussion::
-using link::Classes/Object#idle#Object:idle:: within a routine, return values until this time is over. Time is measured relative to the thread's clock.
+using link::Classes/Object#-idle:: within a routine, return values until this time is over. Time is measured relative to the thread's clock.
 code::
 // for 6 seconds, return 200, then continue
 (

--- a/HelpSource/Classes/SequenceableCollection.schelp
+++ b/HelpSource/Classes/SequenceableCollection.schelp
@@ -622,7 +622,7 @@ code::
 ::
 
 method::convertDigits
-Returns an integer resulting from interpreting the elements as digits to a given base (default 10). See also asDigits in link::Classes/Integer#asDigits:: for the complementary method.
+Returns an integer resulting from interpreting the elements as digits to a given base (default 10). See also asDigits in link::Classes/Integer#-asDigits:: for the complementary method.
 code::
 [1, 0, 0, 0].convertDigits;
 [1, 0, 0, 0].convertDigits(2);
@@ -643,7 +643,7 @@ subsection:: Fuzzy comparisons
 With fuzzy comparisons, the arrays do not need to match exactly. We can check how similar they are, and make decisions based on that. This is the magic behind autocorrection.
 
 method::editDistance
-Returns the mininum number of changes to modify this teletype::SequenceableCollection:: into the other teletype::SequenceableCollection::.
+Returns the minimum number of changes to modify this teletype::SequenceableCollection:: into the other teletype::SequenceableCollection::.
 A change can be: an addition, a deletion, or a substitution.
 This is known as the Levenshtein Distance and is implemented in SuperCollider using the Wagner–Fischer algorithm.
 

--- a/HelpSource/Classes/SerialPort.schelp
+++ b/HelpSource/Classes/SerialPort.schelp
@@ -2,16 +2,11 @@ class:: SerialPort
 summary:: serial port interface
 categories:: External Control
 
-This class provides basic support for serial port communication. Ports are opened with link::#*new::
- and closed with link::#-close::.
+This class provides basic support for serial port communication. Ports are opened with link::#*new:: and closed with link::#-close::.
 
-Each SerialPort object uses an 8KB internal buffer and reads data as soon as it is available. If the
-data is not read out of the buffer and the buffer fills up, incoming bytes will be dropped. Use
-link::#-rxErrors:: to get a count of the number of bytes dropped.
+Each SerialPort object uses an 8KB internal buffer and reads data as soon as it is available. If the data is not read out of the buffer and the buffer fills up, incoming bytes will be dropped. Use link::#-rxErrors:: to get a count of the number of bytes dropped.
 
-Since it is constantly polling the port for available data, a SerialPort object knows almost
-immediately when the port has been lost. When this happens, it will call the link::#-doneAction::
-callback and mark itself as closed.
+Since it is constantly polling the port for available data, a SerialPort object knows almost immediately when the port has been lost. When this happens, it will call the link::#-doneAction:: callback and mark itself as closed.
 
 ClassMethods::
 
@@ -53,7 +48,7 @@ code::crtscts:: and code::xonxoff:: cannot both be true; code::*new:: will throw
 are set.
 
 method::devices
-Retrieve an array of available devices represented as link::Classes/String#Strings::. On macOS and Linux, this list is obtained using a number of regular expression rules on files in the code::/dev/:: directory. On Windows, this is obtained using a registry key. The matching rules are designed to be identical to that of the Arduino IDE.
+Retrieve an array of available devices represented as link::Classes/String##Strings::. On macOS and Linux, this list is obtained using a number of regular expression rules on files in the code::/dev/:: directory. On Windows, this is obtained using a registry key. The matching rules are designed to be identical to that of the Arduino IDE.
 
 For backward compatibility, if code::SerialPort.devicePattern:: is not nil, code::SerialPort.devicePattern.pathMatch:: is returned instead of the default behavior.
 

--- a/HelpSource/Classes/Server.schelp
+++ b/HelpSource/Classes/Server.schelp
@@ -385,7 +385,7 @@ The getter returns the client ID of this client on the remote process. code::nil
 The setter attempts to set the client ID of this client for the remote server process. Fails on invalid input or if the server is running. Valid inputs are in the range code::[0..(this.maxNumClients-1)]::.
 
 method:: hasShmInterface
-Returns true if a link::Classes/ServerShmInterface:: is available. See also link::Classes/Bus#Synchronous control bus methods::.
+Returns true if a link::Classes/ServerShmInterface:: is available. See also link::Classes/Bus#Synchronous Control Bus Methods::.
 The shared memory interface is initialized after first server boot.
 
 warning::
@@ -667,7 +667,7 @@ this is optional, and is passed to code::prepareForRecord:: (above).
 argument:: bus
 the bus to record - defaults to 0
 argument:: numChannels
-the number of channels to record - defaults to server numChannels
+the number of channels to record - defaults to 2
 argument:: node
 the node to record - defaults to server rootnode
 argument:: duration
@@ -722,7 +722,7 @@ one or more OSC messages which will be bundled before the sync message (thus ens
 allows for the message to be evaluated at a specific point in the future.
 
 discussion::
-This may be slightly less safe then sendMsgSync under UDP on a wide area network, as packets may arrive out of order, but on a local network should be okay. Under TCP this should always be safe.
+This may be slightly less safe than sendMsgSync under UDP on a wide area network, as packets may arrive out of order, but on a local network should be okay. Under TCP this should always be safe.
 code::
 (
 Routine.run {

--- a/HelpSource/Classes/Slope.schelp
+++ b/HelpSource/Classes/Slope.schelp
@@ -31,5 +31,5 @@ code::
 )
 ::
 
-For another example of Slope see link::Classes/AbstractFunction#hypot#AbstractFunction:hypot::.
+For another example of Slope see link::Classes/AbstractFunction#-hypot::.
 

--- a/HelpSource/Classes/SynthDef.schelp
+++ b/HelpSource/Classes/SynthDef.schelp
@@ -6,7 +6,7 @@ related:: Classes/Synth, Reference/Synth-Definition-File-Format, Classes/SynthDe
 description::
 
 The server application uses synth definitions as templates for creating link::Classes/Synth:: nodes.
-(Methods such as link::Classes/Function#play#Function-play::, etc. are simply conveniences which automatically create such a def.)
+(Methods such as link::Classes/Function#-play::, etc. are simply conveniences which automatically create such a def.)
 The SynthDef class encapsulates the client-side representation of a given def, and provides methods for creating new defs, writing them to disk, and streaming them to a server.
 
 SynthDef is one of the more complicated classes in SC and an exhaustive explanation of it is beyond the scope of this document. As such, the examples at the bottom of this document and those found in the various tutorials accessible from link::Help:: may be necessary to make some aspects of its use clear.
@@ -19,7 +19,7 @@ The core of a def is its link::Classes/UGen##unit generator:: graph function.
 This is an instance of link::Classes/Function:: which details how the def's unit generators are interconnected, its inputs and outputs, and what parameters are available for external control.
 In a synth based on the def, arguments to the function will become instances of link::Classes/Control::.
 These can have default values, or can be set at the time the synth is created.
-After creation they will be controllable through link::Classes/Node::'s code::set:: and code::setn:: methods, or the n_set and n_setn link::Browse#OpenSoundControl#OSC:: messages.
+After creation they will be controllable through link::Classes/Node::'s code::set:: and code::setn:: methods, or the n_set and n_setn link::Guides/NodeMessaging##OSC:: messages.
 
 There are four special types of arguments, which are treated differently:
 definitionlist::
@@ -30,7 +30,7 @@ definitionlist::
 ## trigger rate
 || Arguments that begin with "t_" (e.g. code::t_trig::), or that are specified as code::\tr:: in the def's rates argument (see below), will be made as a link::Classes/TrigControl::. Setting the argument will create a control-rate impulse at the set value. This is useful for triggers.
 ## literal arrays
-|| Arguments which have literal arrays as default values (see link::Reference/Literals::) result in multichannel controls, which can be set as a group with link::Classes/Node#setn#Node-setn:: or code::/n_setn::.
+|| Arguments which have literal arrays as default values (see link::Reference/Literals::) result in multichannel controls, which can be set as a group with link::Classes/Node#-setn:: or code::/n_setn::.
 ::
 
 See the examples below for more detail on how this works.

--- a/HelpSource/Classes/TGrains.schelp
+++ b/HelpSource/Classes/TGrains.schelp
@@ -1,6 +1,7 @@
 class:: TGrains
 summary:: Buffer granulator.
 categories::  UGens>Buffer, UGens>Generators>Granular
+related:: Classes/GrainBuf
 
 Description::
 Triggers generate grains from a buffer. Each grain has a Hanning envelope

--- a/HelpSource/Classes/UGen.schelp
+++ b/HelpSource/Classes/UGen.schelp
@@ -432,5 +432,5 @@ argument:: channelOffset
 Bela's oscilloscope channel to start scoping on. This has to be a non-negative number, and can't be changed after scoping starts.
 
 argument:: server
-The server on which BelaScope is running. If not specified, it looks for the first server for which BelaScope was already initialized. If none is found, it attempts to initialize a link::Classes/BelaScope:: instance on link::Server#*default::.
+The server on which BelaScope is running. If not specified, it looks for the first server for which BelaScope was already initialized. If none is found, it attempts to initialize a link::Classes/BelaScope:: instance on link::Classes/Server#*default::.
 returns:: This UGen.

--- a/HelpSource/Classes/UnitTest.schelp
+++ b/HelpSource/Classes/UnitTest.schelp
@@ -8,7 +8,7 @@ In order to make sure a method works correctly, a test can be implemented that a
 
 It is a common practice to write tests to clarify how an object should respond, and it may avoid inconsistencies on the long run. A test is always a subclass of code::UnitTest::, implementing at least one method starting with code::test_::.
 
-When running all tests of one class (see link::#run::), each test method is called in a seperate instance of this class. Test methods therefore do not interefere with each other.
+When running all tests of one class (see link::#run::), each test method is called in a separate instance of this class. Test methods, therefore, do not interfere with each other.
 
 note::
 UnitTests for the Common library classes are kept in the code::testsuite/classlibrary:: directory of the SuperCollider sources.

--- a/HelpSource/Classes/UserView.schelp
+++ b/HelpSource/Classes/UserView.schelp
@@ -30,7 +30,7 @@ METHOD:: drawFunc
 
 	Sets the Function to evaluate whenever the view is asked to redraw itself. This may be, for example, due to being hidden and shown again, being resized, another view moving on top of it, or after the link::Classes/View#-refresh:: method has been called.
 
-	Within that Function you are allowed to use the link::Classes/Pen:: class to draw withing the bounds of the view. All the coordinates given to methods of Pen are relative to the top-left corner of the view. Usage of Pen is not allowed outside of that Function.
+	Within that Function you are allowed to use the link::Classes/Pen:: class to draw within the bounds of the view. All the coordinates given to the methods of Pen are relative to the top-left corner of the view. Usage of Pen is not allowed outside of that Function.
 
 	The Function will be passed this view as the argument when evaluated.
 

--- a/HelpSource/Guides/Multichannel-Expansion.schelp
+++ b/HelpSource/Guides/Multichannel-Expansion.schelp
@@ -113,7 +113,7 @@ fork {
 )
 ::
 
-Similarly, link::Classes/Function#flop#Function:flop:: returns an unevaluated function that will expand to its arguments when evaluated:
+Similarly, link::Classes/Function#-flop#Function:flop:: returns an unevaluated function that will expand to its arguments when evaluated:
 code::
 (
 SynthDef("blip", { |out, freq|

--- a/HelpSource/Guides/NodeMessaging.schelp
+++ b/HelpSource/Guides/NodeMessaging.schelp
@@ -92,7 +92,7 @@ note::
 IMPORTANT: If you wish to have the functionality of the default_group (e.g. problem free use of Server's record and scope functionality) you should treat ID 1 (the default_group) as the root of your node tree rather than ID 0 (the RootNode). See default_group for more details.
 ::
 
-Note that link::Classes/Function#play#Function-play:: and link::Classes/SynthDef#play#SynthDef-play:: return a synth object that can be used to send messages to.
+Note that link::Classes/Function#-play#Function-play:: and link::Classes/SynthDef#-play#SynthDef-play:: return a synth object that can be used to send messages to.
 code::
 x = { arg freq=1000; Ringz.ar(Crackle.ar(1.95, 0.1), freq, 0.05) }.play(s);
 x.set(\freq, 1500);

--- a/HelpSource/Guides/Server-Guide.schelp
+++ b/HelpSource/Guides/Server-Guide.schelp
@@ -39,11 +39,11 @@ If a Server has been booted from the command line you must call code::initTree::
 
 subsection:: Local vs. Internal
 
-In general, when working with a single machine one will probably be using one of two Server objects which are created at startup and stored in the class variables link::#*local:: and link::#*internal::. In SuperCollider.app (OSX), two GUI windows are created to control these. Use link::#-makeGui:: to create a GUI window manually.
+In general, when working with a single machine one will probably be using one of two Server objects which are created at startup and stored in the class variables link::Classes/Server#*local#*local:: and link::Classes/Server#*internal#*internal::. In SuperCollider.app (OSX), two GUI windows are created to control these. Use link::Classes/Server#-makeGui#-makeGui:: to create a GUI window manually.
 
 The difference between the two is that the local server runs as a separate application with its own address space, and the internal server runs within the same space as the language/client app.
 
-Both local and internal server supports link::#-scope#scoping:: and link::Classes/Bus#Synchronous control bus methods#synchronous bus access::.
+Both local and internal server supports link::Classes/Server#-scope#scoping:: and link::Classes/Bus#Synchronous Control Bus Methods#synchronous bus access::.
 
 The local server, and any other server apps running on your local machine, have the advantage that if the language app crashes, it (and thus possibly your piece) will continue to run. It is thus an inherently more robust arrangement. But note that even if the synths on the server continue to run, any language-side sequencing and control will terminate if the language app crashes.
 
@@ -55,9 +55,9 @@ There is always a default Server, which is stored in the class variable code::de
 
 subsection:: Local vs. Remote Servers, Multi-client Configurations
 
-Most of the time users work with a server app running on the same machine as the SC language client. It is possible to use a server running on a different machine via a network, providing you know the IP address and port of that server. The link::#*remote:: method provides a convenient way to do this. note::To enable remote connections you will need to change link::Classes/ServerOptions#-bindAddress:: in the server's link::Classes/ServerOptions:: as the default value only allows connections from the local machine. code::s.options.bindAddress = "0.0.0.0":: will allow connections from any address.::
+Most of the time users work with a server app running on the same machine as the SC language client. It is possible to use a server running on a different machine via a network, providing you know the IP address and port of that server. The link::Classes/Server#*remote#*remote:: method provides a convenient way to do this. note::To enable remote connections you will need to change link::Classes/ServerOptions#-bindAddress:: in the server's link::Classes/ServerOptions:: as the default value only allows connections from the local machine. code::s.options.bindAddress = "0.0.0.0":: will allow connections from any address.::
 
-One common variant of this approach is multiple clients using the same server. If you wish to do this you will need to set the server's link::Classes/ServerOptions#-maxLogins:: to at least the number of clients you wish to allow.  When a client registers for link::#-notify#notifications:: the server will supply a client ID. This also configures the allocators to avoid conflicts when allocating link::Classes/Node##Nodes::, link::Classes/Buffer##Buffers::, or link::Classes/Bus##Busses::. For more info see link::Guides/MultiClient_Setups::.
+One common variant of this approach is multiple clients using the same server. If you wish to do this you will need to set the server's link::Classes/ServerOptions#-maxLogins:: to at least the number of clients you wish to allow.  When a client registers for link::Classes/Server#-notify#notifications:: the server will supply a client ID. This also configures the allocators to avoid conflicts when allocating link::Classes/Node##Nodes::, link::Classes/Buffer##Buffers::, or link::Classes/Bus##Busses::. For more info see link::Guides/MultiClient_Setups::.
 
 In order to use a remote server with tcp one should first boot the remote server using the code::-t:: option e.g. as follows:
 code::

--- a/HelpSource/Reference/Control-Structures.schelp
+++ b/HelpSource/Reference/Control-Structures.schelp
@@ -310,7 +310,7 @@ x.postln;
 
 section:: Other Control Structures
 
-Using Functions, many control structures can be defined like the ones above. In the class link::Classes/Collection#iteration:: there are many more messages defined for iterating over Collections.
+Using Functions, many control structures can be defined like the ones above. In the class link::Classes/Collection#Iteration:: there are many more messages defined for iterating over Collections.
 
 section:: Inline optimization
 


### PR DESCRIPTION
links broken in different ways: case sensitivity, link to class instead of instance method, paragraph copied without updating link, missing * or - etc.
also caught a few typos and made some documentation corrections (Server-record).

## Purpose and Motivation

just finding and fixing broken links in the help system.

## Types of changes

- Documentation

## To-do list

- [ ] Code is tested
- [ ] All tests are passing
- [ ] Updated documentation
- [x] This PR is ready for review
