### PR TITLE
class library: ndefgui handle buffer instance as argument

### DIFF
--- a/SCClassLibrary/JITLib/ProxySpace/NodeMap.sc
+++ b/SCClassLibrary/JITLib/ProxySpace/NodeMap.sc
@@ -132,7 +132,9 @@ ProxyNodeMap : NodeMap {
 	controlNames {
 		var res = Array.new;
 		this.keysValuesDo { |key, value|
-			var rate = if(value.rate == \audio) { \audio } { \control };
+			var rate = if(value.respondsTo(\rate) and:{
+				value.rate == \audio
+			}) { \audio } { \control };
 			res = res.add(ControlName(key, nil, rate, value))
 		};
 		^res


### PR DESCRIPTION
## Purpose and Motivation

avoids ERROR: Message 'rate' not understood when calling .gui on a Ndef with a Buffer instance argument.
Buffer does not implement .rate so need to check for that.

reference issue: #5691 

## Types of changes

- Bug fix

## To-do list

- [x] Code is tested
- [ ] All tests are passing
- [ ] Updated documentation
- [x] This PR is ready for review
