### PR TITLE
Git submodules: update urls to use https

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,12 +1,12 @@
 [submodule "external_libraries/nova-simd"]
 	path = external_libraries/nova-simd
-	url = git://github.com/timblechmann/nova-simd.git
+	url = https://github.com/timblechmann/nova-simd.git
 [submodule "external_libraries/nova-tt"]
 	path = external_libraries/nova-tt
-	url = git://github.com/timblechmann/nova-tt.git
+	url = https://github.com/timblechmann/nova-tt.git
 [submodule "external_libraries/hidapi"]
 	path = external_libraries/hidapi
-	url = git://github.com/supercollider/hidapi.git
+	url = https://github.com/supercollider/hidapi.git
 [submodule "editors/scvim"]
 	path = editors/scvim
 	url = https://github.com/supercollider/scvim.git


### PR DESCRIPTION


<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

Fixes #5693

GitHub made changes to improve security, deprecating the use of `git://` protocol. Our builds started to fail because of this, since the submodules were not being fetched. The solution is to update the submodule URLs to use `https://`. 

See https://github.blog/2021-09-01-improving-git-protocol-security-github for more details.

## Updating forks

After this change is pulled in, all repository users should **update their forks** to pull in the fix and then **run `git submodule sync` afterwards** to update the URLs in the local repository.
## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review
