### PR TITLE
Add tag name in the about dialog for tagged builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ if(CMAKE_SYSTEM_NAME MATCHES "Linux|FreeBSD|DragonFly|OpenBSD|NetBSD")
 endif()
 
 message(STATUS "SuperCollider Version: ${SC_VERSION}")
-message(STATUS "Building from branch ${GIT_BRANCH}, commit hash is ${GIT_COMMIT_HASH}")
+message(STATUS "Building from ${GIT_REF_TYPE} ${GIT_BRANCH_OR_TAG}, commit hash is ${GIT_COMMIT_HASH}")
 include(CTest)
 enable_testing()
 

--- a/HelpSource/Reference/Server-Command-Reference.schelp
+++ b/HelpSource/Reference/Server-Command-Reference.schelp
@@ -125,14 +125,14 @@ definitionlist::
 ## int || Major version number. Equivalent to sclang's code::Main.scVersionMajor::.
 ## int || Minor version number. Equivalent to sclang's code::Main.scVersionMinor::.
 ## string || Patch version name. Equivalent to the sclang code code::"." ++ Main.scVersionPatch ++ Main.scVersionTweak::.
-## string || Git branch name.
+## string || Git branch or tag name.
 ## string || First seven hex digits of the commit hash.
 ::
 ::
 
 The standard human-readable version string can be constructed by concatenating code:: major_version ++ "." ++ minor_version ++ patch_version ::. Since version information is easily accessible to sclang users via the methods described above, this command is mostly useful for alternate clients.
 
-The git branch name and commit hash could be anything if the user has forked SC, so they should only be used for display and user interface purposes.
+The git branch/tag name and commit hash could be anything if the user has forked SC, so they should only be used for display and user interface purposes.
 
 section:: Synth Definition Commands
 

--- a/SCVersion.txt
+++ b/SCVersion.txt
@@ -20,9 +20,21 @@ if(EXISTS "${CMAKE_SOURCE_DIR}/.git")
   execute_process(
     COMMAND git rev-parse --abbrev-ref HEAD
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-    OUTPUT_VARIABLE GIT_BRANCH
+    OUTPUT_VARIABLE GIT_BRANCH_OR_TAG
     OUTPUT_STRIP_TRAILING_WHITESPACE
   )
+  
+  set(GIT_REF_TYPE "branch")
+  
+  if(GIT_BRANCH_OR_TAG STREQUAL "HEAD")
+    set(GIT_REF_TYPE "tag")
+    execute_process(
+      COMMAND git describe --tags
+      WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+      OUTPUT_VARIABLE GIT_BRANCH_OR_TAG
+      OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+  endif()
 
   execute_process(
     COMMAND git log -1 --format=%h

--- a/common/SC_Version.hpp.in
+++ b/common/SC_Version.hpp.in
@@ -25,7 +25,8 @@ static const int SC_VersionMajor = @SC_VERSION_MAJOR@;
 static const int SC_VersionMinor = @SC_VERSION_MINOR@;
 static const int SC_VersionPatch = @SC_VERSION_PATCH@;
 static const char SC_VersionTweak[] = "@SC_VERSION_TWEAK@";
-static const char SC_Branch[] = "@GIT_BRANCH@";
+static const char SC_RefType[] = "@GIT_REF_TYPE@";
+static const char SC_BranchOrTag[] = "@GIT_BRANCH_OR_TAG@";
 static const char SC_CommitHash[] = "@GIT_COMMIT_HASH@";
 
 // For backward compatibility in scsynth and supernova only.
@@ -41,6 +42,6 @@ static inline std::string SC_VersionString()
 static inline std::string SC_BuildString()
 {
     std::stringstream out;
-    out << "Built from branch '" << SC_Branch << "' [" << SC_CommitHash << "]";
+    out << "Built from " << SC_RefType << " '" << SC_BranchOrTag << "' [" << SC_CommitHash << "]";
     return out.str();
 }

--- a/server/scsynth/SC_MiscCmds.cpp
+++ b/server/scsynth/SC_MiscCmds.cpp
@@ -1338,7 +1338,7 @@ SCErr meth_version(World* inWorld, int inSize, char* inData, ReplyAddress* inRep
     packet.addtag('s');
     packet.adds(SC_VersionPostfix);
     packet.addtag('s');
-    packet.adds(SC_Branch);
+    packet.adds(SC_BranchOrTag);
     packet.addtag('s');
     packet.adds(SC_CommitHash);
 

--- a/server/supernova/sc/sc_osc_handler.cpp
+++ b/server/supernova/sc/sc_osc_handler.cpp
@@ -1008,7 +1008,7 @@ template <bool realtime> void handle_version(endpoint_ptr const& endpoint_ref) {
 
         osc::OutboundPacketStream p(buffer, 4096);
         p << osc::BeginMessage("/version.reply") << "supernova" << (i32)SC_VersionMajor << (i32)SC_VersionMinor
-          << SC_VersionPostfix << SC_Branch << SC_CommitHash << osc::EndMessage;
+          << SC_VersionPostfix << SC_BranchOrTag << SC_CommitHash << osc::EndMessage;
         endpoint->send(p.Data(), p.Size());
     });
 }


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

Before this PR, the "About" dialog in the IDE of the release (tagged) builds would report `Built from branch 'HEAD' [<SHA>]`. After this PR, the dialog reads `Built from tag '<tag-name>' [<SHA>]`. The non-tagged builds display the branch name as they have previously.

Here are the dialogs from builds from this branch and from a temporary tag:
<img width="532" alt="Screen Shot 2022-01-13 at 11 23 25" src="https://user-images.githubusercontent.com/1589177/149398546-80dd33ee-e2d1-4a39-a92b-c74ef7d45b3a.png">
<img width="532" alt="Screen Shot 2022-01-13 at 11 26 37" src="https://user-images.githubusercontent.com/1589177/149398570-3861879a-2719-45f4-ab77-f42590672dda.png">

For a tagged commit, the beginning of cmake config now looks like this:
```
$ cmake ..
-- SuperCollider Version: 3.13.0-dev
-- Building from tag Version-3.13.0-testTagName, commit hash is 354b10d266
-- Please specify the build configuration in the next step
```
## API change...?

There is a very slight change to the response in the server API, if we even consider this a change. Previously, for the release builds the response to the `/version` message would include `HEAD` as the branch name, while currently it returns the tag name. These fields are marked in the help as informational only, so I don't believe it's an actual issue, but I wanted to point it out for the completeness sake
```supercollider
s.boot;
OSCFunc.trace(true, true);
s.sendMsg(\version);
```
Response:
```
OSC Message Received:
	time: 46.35657025
	address: a NetAddr(127.0.0.1, 57110)
	recvPort: 57120
	msg: [ /version.reply, scsynth, 3, 13, .0-dev, Version-3.13.0-testTagName, 354b10d266 ]
```

## Types of changes

<!-- Delete lines that don't apply -->

- New feature
- Breaking change (not really, but...)

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review
