### PR TITLE
Fix multiple UnitTests

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -590,7 +590,7 @@ jobs:
 
           # install API quark
           mkdir $QUARKS_PATH && cd $QUARKS_PATH
-          git clone --depth=1 https://github.com/supercollider-quarks/API
+          git clone --depth=1 https://github.com/crucialfelix/API
 
           # make working copy of the script
           cp $SCRIPT_PROTO $SCRIPT_RUN

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -543,7 +543,7 @@ jobs:
       SCLANG: ${{ github.workspace }}/${{ matrix.sclang }}
       SCRIPT_PROTO: ${{ github.workspace }}/testsuite/scripts/gha_test_run_proto.json
       SCRIPT_RUN: ${{ github.workspace }}/testsuite/scripts/run/gha_test_run.json
-      QPM_URL: git+https://github.com/supercollider/qpm.git@topic/testclass-setup-teardown
+      QPM_URL: git+https://github.com/supercollider/qpm.git@topic/ignore-persistent-ui-error
     steps:
       - uses: actions/checkout@v2
         with:

--- a/testsuite/classlibrary/TestFunction.sc
+++ b/testsuite/classlibrary/TestFunction.sc
@@ -37,12 +37,19 @@ TestFunction : UnitTest {
 	}
 
 	test_plot {
-		{ |x| DC.ar(x) }.asBuffer(duration: 0.01, action: { |b|
+		var condition = CondVar.new;
+		var server = Server(thisMethod.name);
+		server.bootSync;
+		{ |x| DC.ar(x) }.asBuffer(duration: 0.01, target: server, action: { |b|
 			b.get(3, { |val|
 				this.assertEquals(val, 0, "unspecified function arguments should pass as 0 when function is written to a buffer");
 				b.free;
+				condition.signalOne;
 			})
-		})
+		});
+		condition.waitFor(2);
+		server.quit;
+		server.remove;
 	}
 
 

--- a/testsuite/classlibrary/TestIndexUGenRates.sc
+++ b/testsuite/classlibrary/TestIndexUGenRates.sc
@@ -4,7 +4,7 @@ TestIndexUGenRates : UnitTest {
 
 	setUp {
 
-		server = Server.default;
+		server = Server(this.class.name);
 		this.bootServer(server);
 	}
 
@@ -12,6 +12,7 @@ TestIndexUGenRates : UnitTest {
 
 		Buffer.freeAll;
 		server.quit;
+		server.remove;
 	}
 
 	addSynthDefs {
@@ -95,7 +96,7 @@ TestIndexUGenRates : UnitTest {
 		this.addSynthDefs;
 		server.sync;
 
-		synth = Synth(\indexArPhaseAr, [\buf, writeBuf]);
+		synth = Synth(\indexArPhaseAr, [\buf, writeBuf], target: server);
 		synth.waitForFree;
 		writeBuf.get(index, { |i| value = i});
 		server.sync;
@@ -103,7 +104,7 @@ TestIndexUGenRates : UnitTest {
 		writeBuf.zero;
 		server.sync;
 
-		synth = Synth(\indexKrPhaseAr, [\buf, writeBuf]);
+		synth = Synth(\indexKrPhaseAr, [\buf, writeBuf], target: server);
 		synth.waitForFree;
 		writeBuf.get(index, { |i| value = i});
 		server.sync;
@@ -111,7 +112,7 @@ TestIndexUGenRates : UnitTest {
 		writeBuf.zero;
 		server.sync;
 
-		synth = Synth(\indexArPhaseKr, [\buf, writeBuf]);
+		synth = Synth(\indexArPhaseKr, [\buf, writeBuf], target: server);
 		synth.waitForFree;
 		writeBuf.get(index, { |i| value = i});
 		server.sync;
@@ -119,7 +120,7 @@ TestIndexUGenRates : UnitTest {
 		writeBuf.zero;
 		server.sync;
 
-		synth = Synth(\indexKrPhaseKr, [\buf, writeBuf]);
+		synth = Synth(\indexKrPhaseKr, [\buf, writeBuf], target: server);
 		synth.waitForFree;
 		writeBuf.get(index, { |i| value = i});
 		server.sync;

--- a/testsuite/classlibrary/TestNetAddr.sc
+++ b/testsuite/classlibrary/TestNetAddr.sc
@@ -9,7 +9,7 @@ TestNetAddr : UnitTest {
 		f = big.copyRange(0, (size ? big.size)-1);
 		bundleSize = f.bundleSize;
 
-		this.bootServer;
+		this.bootServer(server);
 
 		("Sending bundle with " + f.size + "messages " + "bundleSize: " + bundleSize).debug;
 
@@ -41,10 +41,11 @@ TestNetAddr : UnitTest {
 
 	tearDown {
 		server.quit;
+		server.remove;
 	}
 
 	setUp {
-		server = Server.default; 
+		server = Server(this.class.name);
 		addr = server.addr;
 
 		// mmmmmmm.   fixtures.

--- a/testsuite/classlibrary/TestNodeProxy.sc
+++ b/testsuite/classlibrary/TestNodeProxy.sc
@@ -391,7 +391,7 @@ TestNodeProxyBusMapping : UnitTest {
 TestNodeProxySeti : UnitTest {
 	var proxy, server;
 	setUp {
-		server = Server.default;
+		server = Server(this.class.name);
 		proxy = NodeProxy.audio(server, 5);
 		proxy.source = { SinOsc.ar(\freq.kr(200!5), \phase.kr(0!5)) };
 
@@ -399,6 +399,7 @@ TestNodeProxySeti : UnitTest {
 
 	tearDown {
 		proxy.clear;
+		server.remove;
 	}
 
 	test_seti {

--- a/testsuite/classlibrary/TestServer.sc
+++ b/testsuite/classlibrary/TestServer.sc
@@ -36,12 +36,13 @@ TestServer : UnitTest {
 	}
 
 	tearDown {
-		server.quit
+		server.quit;
+		server.remove;
 	}
 
 	setUp {
 
-		server = Server.default;
+		server = Server(this.class.name);
 		this.bootServer(server);
 
 		// mmmmmmm.   fixtures.

--- a/testsuite/scripts/gha_test_run_proto.json
+++ b/testsuite/scripts/gha_test_run_proto.json
@@ -119,6 +119,30 @@
             "skipReason":"Server might hang after these tests when run in qpm (FIXME)"
         },
         {
+            "suite":"TestServer_boot",
+            "test":"*",
+            "skip":true,
+            "skipReason":"Multiple tests fail (as reported by @dyfer)"
+        },
+        {
+            "suite":"TestServer_clientID_booted",
+            "test":"test_repeatedLogin",
+            "skip":true,
+            "skipReason":"UnitTest throws an error (FIXME))"
+        },
+        {
+            "suite":"TestServer_clientID_booted",
+            "test":"test_remoteLogin",
+            "skip":true,
+            "skipReason":"UnitTest throws an error (FIXME))"
+        },
+        {
+            "suite":"TestServer_clientID_booted",
+            "test":"test_repeatedRemoteLogin",
+            "skip":true,
+            "skipReason":"UnitTest throws an error (FIXME))"
+        },
+        {
             "suite":"TestSCDoc",
             "test":"test_helpSourceDirs_includedExtensions",
             "skip":true,
@@ -129,6 +153,12 @@
             "test":"test_nextTimeOnGrid_okAfterMeterChange",
             "skip":true,
             "skipReason":"UnitTest fails (FIXME)"
+        },
+        {
+            "suite":"TestVolume",
+            "test":"test_booting",
+            "skip":true,
+            "skipReason":"Multiple Volume synths are created when running test inside the suite"
         },
         {
             "suite":"TestWebView",

--- a/testsuite/scripts/gha_test_run_proto.json
+++ b/testsuite/scripts/gha_test_run_proto.json
@@ -23,6 +23,12 @@
             "skipReason":"UnitTest fails when run in qpm (FIXME)"
         },
         {
+            "suite":"TestCondVar",
+            "test":"test_waitFor_withPredicate_signaledButFalseSoTimedOut",
+            "skip":true,
+            "skipReason":"UnitTest fails when run in qpm (FIXME)"
+        },
+        {
             "suite":"TestCoreUGens",
             "test":"test_ugen_generator_equivalences",
             "skip":true,

--- a/testsuite/scripts/gha_test_run_proto.json
+++ b/testsuite/scripts/gha_test_run_proto.json
@@ -71,12 +71,6 @@
             "skipReason":"UnitTest has unknown issues when run in qpm (FIXME)"
         },
         {
-            "suite":"TestNodeProxy",
-            "test":"test_copy_nodeMapIsCopied",
-            "skip":true,
-            "skipReason":"UnitTest fails (FIXME)"
-        },
-        {
             "suite":"TestNodeProxyBusMapping",
             "test":"test_audiorate_mapping",
             "skip":true,
@@ -93,12 +87,6 @@
             "test":"test_proxyroles_xfade_smoothly",
             "skip":true,
             "skipReason":"UnitTest fails in qpm (FIXME)"
-        },
-        {
-            "suite":"TestNodeProxy_Server",
-            "test":"test_synthDef_isReleased_afterFree",
-            "skip":true,
-            "skipReason":"UnitTest fails (FIXME)"
         },
         {
             "suite":"TestNodeProxy_Server",

--- a/testsuite/scripts/gha_test_run_proto.json
+++ b/testsuite/scripts/gha_test_run_proto.json
@@ -141,12 +141,6 @@
             "test":"test_findText_notFound",
             "skip":true,
             "skipReason":"UnitTest sometimes fails when run in qpm"
-        },
-        {
-            "suite":"TestNodeProxySeti",
-            "test":"test_seti_nodeMap",
-            "skip":true,
-            "skipReason":"test passes on local machine but fails in GHA for unknown reasons"
         }
     ]
 }

--- a/testsuite/scripts/gha_test_run_proto.json
+++ b/testsuite/scripts/gha_test_run_proto.json
@@ -5,18 +5,6 @@
             "test":"*"
         },
         {
-            "suite":"TestBus",
-            "test":"test_get",
-            "skip":true,
-            "skipReason":"UnitTest fails when run in qpm (FIXME)"
-        },
-        {
-            "suite":"TestBus",
-            "test":"test_getn",
-            "skip":true,
-            "skipReason":"UnitTest fails when run in qpm (FIXME)"
-        },
-        {
             "suite":"TestCondition",
             "test":"*",
             "skip":true,

--- a/testsuite/scripts/gha_test_run_proto.json
+++ b/testsuite/scripts/gha_test_run_proto.json
@@ -101,30 +101,6 @@
             "skipReason":"UnitTest has bugs (FIXME)"
         },
         {
-            "suite":"TestServer_boot",
-            "test":"*",
-            "skip":true,
-            "skipReason":"Multiple tests fail (as reported by @dyfer)"
-        },
-        {
-            "suite":"TestServer_clientID_booted",
-            "test":"test_repeatedLogin",
-            "skip":true,
-            "skipReason":"UnitTest throws an error (FIXME))"
-        },
-        {
-            "suite":"TestServer_clientID_booted",
-            "test":"test_remoteLogin",
-            "skip":true,
-            "skipReason":"UnitTest throws an error (FIXME))"
-        },
-        {
-            "suite":"TestServer_clientID_booted",
-            "test":"test_repeatedRemoteLogin",
-            "skip":true,
-            "skipReason":"UnitTest throws an error (FIXME))"
-        },
-        {
             "suite":"TestSCDoc",
             "test":"test_helpSourceDirs_includedExtensions",
             "skip":true,

--- a/testsuite/scripts/gha_test_run_proto.json
+++ b/testsuite/scripts/gha_test_run_proto.json
@@ -41,12 +41,6 @@
             "skipReason":"UnitTest fails when run in qpm (FIXME)"
         },
         {
-            "suite":"TestDoneActions",
-            "test":"test_freeSelfAndResumeNext",
-            "skip":true,
-            "skipReason":"UnitTest fails when run in qpm (FIXME)"
-        },
-        {
             "suite":"TestEnvGen_server",
             "test":"test_zero_gate_n_off_not_sent",
             "skip":true,

--- a/testsuite/scripts/gha_test_run_proto.json
+++ b/testsuite/scripts/gha_test_run_proto.json
@@ -107,12 +107,6 @@
             "skipReason":"UnitTest has bugs (FIXME)"
         },
         {
-            "suite":"TestPV_ChainUGen",
-            "test":"*",
-            "skip":true,
-            "skipReason":"Server might hang after these tests when run in qpm (FIXME)"
-        },
-        {
             "suite":"TestServer_boot",
             "test":"*",
             "skip":true,


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

This PR fixes a number of issues with UnitTests, particularly for running them in the CI:
- most (all?) tests using a server now use a unique server instance
  - the use of default server, particularly if it was not shut down, has led to multiple tests failing, some without reporting failure in the CI (i.e. with the [Did not complete](https://github.com/supercollider/supercollider/runs/4808924636?check_suite_focus=true#step:8:12377) message)
  - `TestFunction -test_plot` arguably was hiding the server booting most covertly...
- a number of tests was fixed
- the link to the API quark, used by QPM for testing was updated to point to the address that's specified in the quarks directory
  - I'm not sure if this was causing any of the issues we experience in qpm or not...
- we now have ~~3483~~ **3507** passing tests _with no tests that did not finish_
  - the number of tests mysteriously failing in CI has greatly dropped; it appears that most of these failures were due to issues with booting the server or using the default server
  - there's a handful of tests still excluded, I tried updating lists in #5359 and #5360
- I've made [some changes to qpm](https://github.com/supercollider/qpm/compare/topic/testclass-setup-teardown...supercollider:topic/ignore-persistent-ui-error) and pointed our CI at its new branch, most notably increasing overall test suite timeout from 10 to 20 minutes (macOS tests slightly exceed 10 minutes right now)

## Types of changes

<!-- Delete lines that don't apply -->


- Bug fix


## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review
