### PR TITLE
OSCFunc.schelp: fix link to opensoundcontrol.org

### DIFF
--- a/HelpSource/Classes/OSCFunc.schelp
+++ b/HelpSource/Classes/OSCFunc.schelp
@@ -4,7 +4,7 @@ categories:: External Control>OSC
 related:: Guides/OSC_communication, Classes/OSCdef, Classes/NetAddr
 
 DESCRIPTION::
-OSCFunc (and its subclass link::Classes/OSCdef::) registers one or more functions to respond to an incoming OSC message which matches a specified OSC Address. Many of its methods are inherited from its superclass link::Classes/AbstractResponderFunc::. OSCFunc supports pattern matching of wildcards etc. in incoming messages. For efficiency reasons you must specify that an OSCFunc will employ pattern matching by creating it with the link::#*newMatching:: method, or by passing a matching dispatcher to link::#*new::. For details on the Open Sound Control protocol, see http://opensoundcontrol.org/spec-1_0
+OSCFunc (and its subclass link::Classes/OSCdef::) registers one or more functions to respond to an incoming OSC message which matches a specified OSC Address. Many of its methods are inherited from its superclass link::Classes/AbstractResponderFunc::. OSCFunc supports pattern matching of wildcards etc. in incoming messages. For efficiency reasons you must specify that an OSCFunc will employ pattern matching by creating it with the link::#*newMatching:: method, or by passing a matching dispatcher to link::#*new::. For details on the Open Sound Control protocol, see http://opensoundcontrol.org/spec-1_0.html
 
 CLASSMETHODS::
 private:: initClass, cmdPeriod


### PR DESCRIPTION
URL needs ".html" on the end or following it will return 404

<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->

- Documentation
- Bug fix
- New feature
- Breaking change

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [ ] Code is tested
- [ ] All tests are passing
- [ ] Updated documentation
- [ ] This PR is ready for review
