### PR TITLE
Possibly Fixes #2954 

### DIFF
--- a/lang/LangPrimSource/PyrSymbolPrim.cpp
+++ b/lang/LangPrimSource/PyrSymbolPrim.cpp
@@ -43,7 +43,7 @@ int prSymbolIsPrefix(struct VMGlobals* g, int numArgsPushed) {
     int32 alen = slotRawSymbol(a)->length;
     int32 blen = slotRawSymbol(b)->length;
     length = sc_min(alen, blen);
-    if (memcmp(slotRawSymbol(a)->name, slotRawSymbol(b)->name, length) == 0) {
+    if (memcmp(slotRawSymbol(a)->name, slotRawSymbol(b)->name, length) == 0 && length > 0) {
         SetTrue(a);
     } else {
         SetFalse(a);


### PR DESCRIPTION
The situation presented in #2954 stemmed from Symbol:isPrimitiveName testing a string and returning true given an empty symbol. Checking the minimum length between the two symbol and making sure it isn't 0 might fix this. The prefix method still works as intended but now doesn't accept empty symbols as input.