### PR TITLE
Deprecate QuartzComposerView

### DIFF
--- a/HelpSource/Classes/QuartzComposerView.schelp
+++ b/HelpSource/Classes/QuartzComposerView.schelp
@@ -2,6 +2,8 @@ TITLE:: QuartzComposerView
 summary:: view for rendering Quartz Composer Compositions
 categories:: GUI>Views
 
+NOTE:: code::QuartzComposerView:: is deprecated in SC 3.13 and won't be available in subsequent versions that will use Qt 6.x. ::
+
 DESCRIPTION::
 QuartzComposerView allows for the rendering of Quartz Composer Compositions within SC on macOS. Quartz Composer is a visual programming environment for processing and rendering graphical data, which is distributed free of charge as part of Apple's XCode Development Tools. QC is highly optimised to work with the macOS graphics system, and in general should be more efficient than Pen. For more information on QC see: https://developer.apple.com/library/mac/documentation/GraphicsImaging/Conceptual/QuartzComposerUserGuide/qc_intro/qc_intro.html and http://en.wikipedia.org/wiki/Quartz_Composer
 

--- a/SCClassLibrary/deprecated/3.13/QQuartzComposerView.sc
+++ b/SCClassLibrary/deprecated/3.13/QQuartzComposerView.sc
@@ -1,6 +1,12 @@
 QuartzComposerView : View {
 	var <path, <inputKeys, <outputKeys;
 
+	*new {|...args|
+		// QuartzComposer is not available in Qt6 and thus will be removed
+		this.deprecated(thisMethod);
+		super.new(*args)
+	}
+
 	*qtClass { ^'QcQuartzComposerView' }
 
 	start{


### PR DESCRIPTION

<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

Quartz Composer bindings are not available in Qt 6. We currently plan to drop Quartz Composer once we move to Qt 6, so we'll deprecate it in SC 3.13.

## Types of changes

<!-- Delete lines that don't apply -->

- Deprecation

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] Updated documentation
- [x] This PR is ready for review
