### PR TITLE
Remove RTAlloc exceptions, and review all plugins' RTAlloc/RTFree

### DIFF
--- a/HelpSource/Guides/WritingUGens.schelp
+++ b/HelpSource/Guides/WritingUGens.schelp
@@ -161,8 +161,6 @@ Unit generator plugins are called from the real-time context, which means that s
 to avoid audio dropouts.
 
 definitionList::
-## Memory Allocation || Do not allocate memory from the OS via code::malloc:: / code::free:: or code::new::/ code::delete::.
-                        Instead you should use the real-time memory allocator via code::RTAlloc:: / code::RTFree::.
 ## STL Containers || It is generally not recommended to use STL containers, since they internally allocate memory. The only
                      way the STL containers can be used is by providing an Allocator, which maps to the allocating functions of
                      the server.
@@ -171,6 +169,81 @@ definitionList::
                          done in a lock-free manner.
 ::
 
+subsection:: Memory Allocation
+Do not allocate memory from the OS via code::malloc:: / code::free:: or code::new::/ code::delete::. Instead you should use the real-time memory allocator via code::RTAlloc:: / code::RTFree::.
+
+definitionList::
+## Remember to code::RTFree:: the memory you code::RTAlloc:: ||
+
+Like with code::malloc/free::, you are reponsible for freeing all the memory you allocate. Remember to include code::RTFree:: calls in your destructor functions.
+
+## Ensure your pointers are initialized to code::nullptr:: ||
+
+Not initialized pointers can have a garbage address, and when RTFree tries to free such a pointer, it can crash the server.
+To prevent this, ensure your member pointers are initialized to code::nullptr:: as early as possible in your constructor functions.
+
+## Use code::ClearUnitIfMemFailed:: ||
+This macro is used to check your pointers after memory allocation. If any of them is still code::nullptr::, it means that RTAlloc failed to allocate memory for it.
+The macro will then print an error message, set the UGen's calculation function to a no-op, and return from the calling function immediately.
+Since this can cause early exit from your constructor function, it is fundamental that all pointers are initialized to code::nullptr:: as early as possible, as stated above.
+
+code::ClearUnitIfMemFailed:: can be passed a single pointer, or it can check multiple pointers at the same time, by chaining them with the code::&&:: operator (see examples below).
+
+## For PV and FFT UGens ||
+UGens in FFT chains (such as the ones listed in LINK::Guides/FFT-Overview#PV and FFT UGens in the Standard Library::) should use code::ClearFFTUnitIfMemFailed:: instead. This is because, on a failed allocation, code::ClearUnitIfMemFailed:: would make them output code::0::, which would be interpreted by the next UGen in the FFT chain as "FFT data is ready to be processed on buffer number 0", which is not the case. code::ClearFFTUnitIfMemFailed:: will set their output to code::-1:: instead, meaning that FFT data is not ready, and thus blocking further processing for the rest of the FFT chain. For more informations please see LINK::Guides/FFT-Overview#How FFT UGens communicate::.
+
+code::ClearFFTUnitIfMemFailed:: is defined in code::FFT_UGens.h::
+::
+
+Minimal example, C style:
+code::
+struct MyUnit : public Unit {
+  float* m_values;
+  float* m_moreValues;
+}
+void MyUnit_Ctor(MyUnit* unit) {
+  // 1. Ensure pointers are initialized to nullptr
+  unit->m_values = unit->m_moreValues = nullptr;
+  // 2. Allocate memory
+  unit->m_values = (float*) RTAlloc(unit->mWorld, 64 * sizeof(float));
+  unit->m_moreValues = (float*) RTAlloc(unit->mWorld, 128 * sizeof(float));
+  // 3. Clear unit if any allocation failed
+  ClearUnitIfMemFailed(unit->m_values && unit->m_moreValues);
+  // 4. Feel free to access memory now
+  memset(unit->m_values, 0, 64 * sizeof(float));
+}
+
+void MyUnit_Dtor(MyUnit* unit) {
+  // 5. Free your allocated memory
+  RTFree(unit->mWorld, unit->m_values);
+  RTFree(unit->mWorld, unit->m_moreValues);
+}
+::
+Or, in C++ class style:
+code::
+namespace MyUnit {
+  // 1. Use initializer list to ensure pointers are initialized to nullptr
+  MyUnit::MyUnit():
+    mValues(nullptr),
+    mMoreValues(nullptr) {
+    // you'll need to define unit in order to use ClearUnitIfMemFailed
+    Unit* unit = (Unit*) this;
+    // 2. Allocate memory
+    mValues = (float*) RTAlloc(unit->mWorld, 64 * sizeof(float));
+    mMoreValues = (float*) RTAlloc(unit->mWorld, 128 * sizeof(float));
+    // 3. Clear unit if any allocation failed
+    ClearUnitIfMemFailed(mValues && mMoreValues);
+    // 4. Feel free to access memory now
+    memset(mValues, 0, 64 * sizeof(float));
+  }
+
+  MyUnit::~MyUnit() {
+    // 5. Free your allocated memory
+    RTFree(mWorld, mValues);
+    RTFree(mWorld, mMoreValues);
+  }
+}
+::
 
 subsection:: Thread Safety
 

--- a/common/SC_AllocPool.cpp
+++ b/common/SC_AllocPool.cpp
@@ -374,7 +374,9 @@ void* AllocPool::Alloc(size_t inReqSize) {
 // exit paths:
 found_nothing:
     // ipostbuf("alloc failed. size: %d\n", inReqSize);
-    throw std::runtime_error(std::string("alloc failed, increase server's memory allocation (e.g. via ServerOptions)"));
+    // throw std::runtime_error(std::string("alloc failed, increase server's memory allocation (e.g. via
+    // ServerOptions)"));
+    return 0;
 
 whole_new_area:
     // ipostbuf("whole_new_area\n");

--- a/include/plugin_interface/FFT_UGens.h
+++ b/include/plugin_interface/FFT_UGens.h
@@ -62,6 +62,17 @@ static inline SCComplexBuf* ToComplexApx(SndBuf* buf) {
 
 struct PV_Unit : Unit {};
 
+// Ordinary ClearUnitOutputs outputs zero, potentially telling the IFFT (+ PV UGens) to act on buffer zero, so let's
+// skip that:
+static inline void FFT_ClearUnitOutputs(Unit* unit, int wrongNumSamples) { ZOUT0(0) = -1; }
+
+#define ClearFFTUnitIfMemFailed(condition)                                                                             \
+    if (!(condition)) {                                                                                                \
+        Print("%s: alloc failed, increase server's RT memory (e.g. via ServerOptions)\n", __func__);                   \
+        SETCALC(FFT_ClearUnitOutputs);                                                                                 \
+        unit->mDone = true;                                                                                            \
+        return;                                                                                                        \
+    }
 
 #define sc_clipbuf(x, hi) ((x) >= (hi) ? 0 : ((x) < 0 ? 0 : (x)))
 

--- a/include/plugin_interface/SC_Unit.h
+++ b/include/plugin_interface/SC_Unit.h
@@ -80,6 +80,17 @@ enum { kUnitDef_CantAliasInputsToOutputs = 1 };
 // set the calculation function
 #define SETCALC(func) (unit->mCalcFunc = (UnitCalcFunc)&func)
 
+#define ClearUnitOnMemFailed                                                                                           \
+    Print("%s: alloc failed, increase server's RT memory (e.g. via ServerOptions)\n", __func__);                       \
+    SETCALC(*ClearUnitOutputs);                                                                                        \
+    unit->mDone = true;                                                                                                \
+    return;
+
+#define ClearUnitIfMemFailed(condition)                                                                                \
+    if (!(condition)) {                                                                                                \
+        ClearUnitOnMemFailed                                                                                           \
+    }
+
 // calculate a slope for control rate interpolation to audio rate.
 #define CALCSLOPE(next, prev) ((next - prev) * sc_typeof_cast(next) unit->mRate->mSlopeFactor)
 

--- a/lang/LangPrimSource/PyrArchiverT.h
+++ b/lang/LangPrimSource/PyrArchiverT.h
@@ -28,6 +28,7 @@ An object archiving system for SuperCollider.
 
 #include "PyrObject.h"
 #include "SC_AllocPool.h"
+#include "InitAlloc.h"
 
 #include "PyrKernel.h"
 #include "PyrPrimitive.h"
@@ -193,6 +194,7 @@ private:
 
         int32 newSize = newObjectArrayCapacity * sizeof(PyrObject*);
         PyrObject** newArray = (PyrObject**)g->allocPool->Alloc(newSize);
+        MEMFAIL(newArray);
         memcpy(newArray, mObjectArray, mNumObjects * sizeof(PyrObject*));
         if (mObjectArray != mInitialObjectArray) {
             g->allocPool->Free(mObjectArray);

--- a/lang/LangPrimSource/PyrDeepCopier.h
+++ b/lang/LangPrimSource/PyrDeepCopier.h
@@ -28,6 +28,7 @@ An object archiving system for SuperCollider.
 
 #include "PyrObject.h"
 #include "SC_AllocPool.h"
+#include "InitAlloc.h"
 
 #include "PyrKernel.h"
 #include "PyrPrimitive.h"
@@ -87,6 +88,7 @@ private:
 
         int32 newSize = newObjectArrayCapacity * sizeof(PyrObject*);
         PyrObject** newArray = (PyrObject**)g->allocPool->Alloc(newSize);
+        MEMFAIL(newArray);
         memcpy(newArray, objectArray, numObjects * sizeof(PyrObject*));
         if (objectArrayCapacity > kDeepCopierObjectArrayInitialCapacity) {
             g->allocPool->Free(objectArray);

--- a/lang/LangPrimSource/PyrDeepFreezer.h
+++ b/lang/LangPrimSource/PyrDeepFreezer.h
@@ -30,6 +30,7 @@ An object archiving system for SuperCollider.
 
 #include "PyrObject.h"
 #include "SC_AllocPool.h"
+#include "InitAlloc.h"
 #include "PyrKernel.h"
 #include "PyrPrimitive.h"
 #include "VMGlobals.h"
@@ -83,6 +84,7 @@ private:
 
         int32 newSize = newObjectArrayCapacity * sizeof(PyrObject*);
         PyrObject** newArray = (PyrObject**)g->allocPool->Alloc(newSize);
+        MEMFAIL(newArray);
         memcpy(newArray, objectArray, numObjects * sizeof(PyrObject*));
         if (objectArrayCapacity > kDeepFreezerObjectArrayInitialCapacity)
             g->allocPool->Free(objectArray);

--- a/lang/LangSource/GC.cpp
+++ b/lang/LangSource/GC.cpp
@@ -306,6 +306,7 @@ PyrObject* PyrGC::NewPermanent(size_t inNumBytes, long inFlags, long inFormat) {
 
     // allocate permanent objects
     PyrObject* obj = (PyrObject*)pyr_pool_runtime->Alloc(allocSize);
+    MEMFAIL(obj);
 
     obj->gc_color = obj_permanent;
     obj->next = obj->prev = nullptr;

--- a/lang/LangSource/PyrInterpreter3.cpp
+++ b/lang/LangSource/PyrInterpreter3.cpp
@@ -326,6 +326,7 @@ bool initRuntime(VMGlobals* g, int poolSize, AllocPool* inPool) {
     // create GC environment, process
     g->allocPool = inPool;
     g->gc = (PyrGC*)g->allocPool->Alloc(sizeof(PyrGC));
+    MEMFAIL(g->gc);
     new (g->gc) PyrGC(g, g->allocPool, class_main, poolSize);
     g->thread = slotRawThread(&g->process->mainThread);
     SetObject(&g->receiver, g->process);

--- a/lang/LangSource/PyrLexer.cpp
+++ b/lang/LangSource/PyrLexer.cpp
@@ -184,6 +184,7 @@ bool startLexer(PyrSymbol* fileSym, const bfs::path& p, int startPos, int endPos
             size_t sz = bfs::file_size(p);
 
             text = (char*)pyr_pool_compile->Alloc((sz + 1) * sizeof(char));
+            MEMFAIL(text);
             file.read(text, sz);
             text[sz] = '\0';
             fileSym->u.source = text;
@@ -228,6 +229,7 @@ bool startLexer(PyrSymbol* fileSym, const bfs::path& p, int startPos, int endPos
     printingCurrfilename = "file '" + SC_Codecvt::path_to_utf8_str(currfilename) + "'";
     maxlinestarts = 1000;
     linestarts = (int*)pyr_pool_compile->Alloc(maxlinestarts * sizeof(int*));
+    MEMFAIL(linestarts);
     linestarts[0] = 0;
     linestarts[1] = 0;
 
@@ -263,6 +265,7 @@ void startLexerCmdLine(char* textbuf, int textbuflen) {
     printingCurrfilename = currfilename.string();
     maxlinestarts = 1000;
     linestarts = (int*)pyr_pool_compile->Alloc(maxlinestarts * sizeof(int*));
+    MEMFAIL(linestarts);
     linestarts[0] = 0;
     linestarts[1] = 0;
 
@@ -1587,6 +1590,7 @@ ClassExtFile* newClassExtFile(PyrSymbol* fileSym, int startPos, int endPos);
 ClassExtFile* newClassExtFile(PyrSymbol* fileSym, int startPos, int endPos) {
     ClassExtFile* classext;
     classext = (ClassExtFile*)pyr_pool_compile->Alloc(sizeof(ClassExtFile));
+    MEMFAIL(classext);
     classext->fileSym = fileSym;
     classext->next = nullptr;
     classext->startPos = startPos;
@@ -1616,7 +1620,7 @@ ClassDependancy* newClassDependancy(PyrSymbol* className, PyrSymbol* superClassN
         return className->classdep;
     }
     classdep = (ClassDependancy*)pyr_pool_compile->Alloc(sizeof(ClassDependancy));
-    MEMFAIL(text);
+    MEMFAIL(classdep);
     classdep->className = className;
     classdep->superClassName = superClassName;
     classdep->fileSym = fileSym;
@@ -1907,6 +1911,7 @@ void initPassOne() {
     sClassExtFiles = nullptr;
 
     void* ptr = pyr_pool_runtime->Alloc(sizeof(SymbolTable));
+    MEMFAIL(ptr);
     gMainVMGlobals->symbolTable = new (ptr) SymbolTable(pyr_pool_runtime, 65536);
 
     initSymbols(); // initialize symbol globals

--- a/server/plugins/BeatTrack.cpp
+++ b/server/plugins/BeatTrack.cpp
@@ -140,6 +140,7 @@ void BeatTrack_Ctor(BeatTrack* unit) {
     unit->m_prevmag = (float*)RTAlloc(unit->mWorld, NOVER2 * sizeof(float));
     unit->m_prevphase = (float*)RTAlloc(unit->mWorld, NOVER2 * sizeof(float));
     unit->m_predict = (float*)RTAlloc(unit->mWorld, NOVER2 * sizeof(float));
+    ClearUnitIfMemFailed(unit->m_prevmag && unit->m_prevphase && unit->m_predict);
 
     ////////time positions//////////
     unit->m_frame = 1; // don't decide immediately, wait for maximum period!

--- a/server/plugins/Convolution.cpp
+++ b/server/plugins/Convolution.cpp
@@ -119,6 +119,8 @@ void Convolution_Ctor(Convolution* unit) {
     int framesize_f = unit->m_framesize * sizeof(float);
     int fftsize_f = unit->m_fftsize * sizeof(float);
 
+    unit->m_scfft1 = unit->m_scfft2 = unit->m_scfftR = nullptr;
+
     unit->m_inbuf1 = (float*)RTAlloc(unit->mWorld, framesize_f);
     unit->m_inbuf2 = (float*)RTAlloc(unit->mWorld, framesize_f);
     unit->m_fftbuf1 = (float*)RTAlloc(unit->mWorld, fftsize_f);
@@ -126,6 +128,9 @@ void Convolution_Ctor(Convolution* unit) {
 
     unit->m_outbuf = (float*)RTAlloc(unit->mWorld, fftsize_f);
     unit->m_overlapbuf = (float*)RTAlloc(unit->mWorld, framesize_f);
+
+    ClearUnitIfMemFailed(unit->m_inbuf1 && unit->m_inbuf2 && unit->m_fftbuf1 && unit->m_fftbuf2 && unit->m_outbuf
+                         && unit->m_overlapbuf);
 
     memset(unit->m_outbuf, 0, fftsize_f);
     memset(unit->m_overlapbuf, 0, framesize_f);
@@ -139,7 +144,7 @@ void Convolution_Ctor(Convolution* unit) {
         scfft_create(unit->m_fftsize, unit->m_fftsize, kRectWindow, unit->m_fftbuf2, unit->m_fftbuf2, kForward, alloc);
     unit->m_scfftR =
         scfft_create(unit->m_fftsize, unit->m_fftsize, kRectWindow, unit->m_fftbuf1, unit->m_outbuf, kBackward, alloc);
-
+    ClearUnitIfMemFailed(unit->m_scfft1 && unit->m_scfft2 && unit->m_scfftR);
     SETCALC(Convolution_next);
 
     // initialize output
@@ -278,6 +283,8 @@ void Convolution2_Ctor(Convolution2* unit) {
     uint32 kernelbufnum = (int)ZIN0(1);
     World* world = unit->mWorld;
 
+    unit->m_inbuf1 = unit->m_fftbuf1 = unit->m_fftbuf2 = unit->m_outbuf = unit->m_overlapbuf = nullptr;
+    unit->m_scfft1 = unit->m_scfft2 = unit->m_scfftR = nullptr;
     SndBuf* kernelbuf = ConvGetBuffer(unit, kernelbufnum, "Convolution2", 1);
 
     if (kernelbuf) {
@@ -301,10 +308,12 @@ void Convolution2_Ctor(Convolution2* unit) {
         unit->m_fftbuf2 = (float*)RTAlloc(world, fftsize_f);
 
         unit->m_outbuf = (float*)RTAlloc(world, fftsize_f);
-        memset(unit->m_outbuf, 0, fftsize_f);
         unit->m_overlapbuf = (float*)RTAlloc(world, framesize_f);
-        memset(unit->m_overlapbuf, 0, framesize_f);
+        ClearUnitIfMemFailed(unit->m_inbuf1 && unit->m_fftbuf1 && unit->m_fftbuf2 && unit->m_outbuf
+                             && unit->m_overlapbuf);
 
+        memset(unit->m_outbuf, 0, fftsize_f);
+        memset(unit->m_overlapbuf, 0, framesize_f);
         unit->m_pos = 0;
 
         SCWorld_Allocator alloc(ft, unit->mWorld);
@@ -314,12 +323,8 @@ void Convolution2_Ctor(Convolution2* unit) {
                                       kForward, alloc);
         unit->m_scfftR = scfft_create(unit->m_fftsize, unit->m_fftsize, kRectWindow, unit->m_fftbuf1, unit->m_outbuf,
                                       kBackward, alloc);
-        if (!unit->m_scfft1 || !unit->m_scfft2 || !unit->m_scfftR) {
-            printf("Could not create scfft.\n");
-            SETCALC(*ClearUnitOutputs);
-            unit->mDone = true;
-            return;
-        }
+        ClearUnitIfMemFailed(unit->m_scfft1 && unit->m_scfft2 && unit->m_scfftR);
+
         // calculate fft for kernel straight away
         // we cannot use a kernel larger than the fft size, so truncate if needed. the kernel may be smaller though.
         uint32 framesize = unit->m_framesize;
@@ -464,6 +469,12 @@ void Convolution2L_Ctor(Convolution2L* unit) {
     unit->m_fftbuf3 = (float*)RTAlloc(unit->mWorld, fftsize_f);
     unit->m_tempbuf = (float*)RTAlloc(unit->mWorld, fftsize_f);
 
+    unit->m_outbuf = unit->m_overlapbuf = nullptr;
+    unit->m_scfft1 = unit->m_scfft2 = unit->m_scfft3 = nullptr;
+    unit->m_scfftR = unit->m_scfftR2 = nullptr;
+
+    ClearUnitIfMemFailed(unit->m_inbuf1 && unit->m_fftbuf1 && unit->m_fftbuf2 && unit->m_fftbuf3 && unit->m_tempbuf);
+
     uint32 bufnum = (int)ZIN0(1); // fbufnum;
 
     SndBuf* buf = ConvGetBuffer(unit, bufnum, "Convolution2L", 1);
@@ -471,6 +482,8 @@ void Convolution2L_Ctor(Convolution2L* unit) {
     if (buf) {
         unit->m_outbuf = (float*)RTAlloc(unit->mWorld, fftsize_f);
         unit->m_overlapbuf = (float*)RTAlloc(unit->mWorld, framesize_f);
+
+        ClearUnitIfMemFailed(unit->m_outbuf && unit->m_overlapbuf);
 
         memset(unit->m_outbuf, 0, fftsize_f);
         memset(unit->m_overlapbuf, 0, framesize_f);
@@ -492,6 +505,7 @@ void Convolution2L_Ctor(Convolution2L* unit) {
         unit->m_scfftR2 = scfft_create(unit->m_fftsize, unit->m_fftsize, kRectWindow, unit->m_tempbuf, unit->m_tempbuf,
                                        kBackward, alloc);
 
+        ClearUnitIfMemFailed(unit->m_scfft1 && unit->m_scfft2 && unit->m_scfft3 && unit->m_scfftR && unit->m_scfftR2);
         scfft_dofft(unit->m_scfft2);
 
         unit->m_pos = 0;
@@ -707,6 +721,12 @@ void StereoConvolution2L_Ctor(StereoConvolution2L* unit) {
     unit->m_overlapbuf[0] = (float*)RTAlloc(unit->mWorld, framesize_f);
     unit->m_outbuf[1] = (float*)RTAlloc(unit->mWorld, fftsize_f);
     unit->m_overlapbuf[1] = (float*)RTAlloc(unit->mWorld, framesize_f);
+    unit->m_scfft1 = nullptr;
+    unit->m_scfft2[0] = unit->m_scfft3[0] = unit->m_scfftR[0] = unit->m_scfftR2[0] = nullptr;
+    unit->m_scfft2[1] = unit->m_scfft3[1] = unit->m_scfftR[1] = unit->m_scfftR2[1] = nullptr;
+    ClearUnitIfMemFailed(unit->m_inbuf1 && unit->m_fftbuf1 && unit->m_fftbuf2[0] && unit->m_fftbuf2[1]
+                         && unit->m_fftbuf3[0] && unit->m_fftbuf3[1] && unit->m_tempbuf[0] && unit->m_tempbuf[1]
+                         && unit->m_outbuf[0] && unit->m_outbuf[1] && unit->m_overlapbuf[0] && unit->m_overlapbuf[1]);
 
     memset(unit->m_outbuf[0], 0, fftsize_f);
     memset(unit->m_overlapbuf[0], 0, framesize_f);
@@ -733,6 +753,9 @@ void StereoConvolution2L_Ctor(StereoConvolution2L* unit) {
     unit->m_scfftR2[1] = scfft_create(unit->m_fftsize, unit->m_fftsize, kRectWindow, unit->m_tempbuf[1],
                                       unit->m_tempbuf[1], kBackward, alloc);
 
+    ClearUnitIfMemFailed(unit->m_scfft1 && unit->m_scfft2[0] && unit->m_scfft3[0] && unit->m_scfftR[0]
+                         && unit->m_scfftR2[0]);
+    ClearUnitIfMemFailed(unit->m_scfft2[1] && unit->m_scfft3[1] && unit->m_scfftR[1] && unit->m_scfftR2[1]);
     float fbufnum = ZIN0(1);
     uint32 bufnumL = (int)fbufnum;
     fbufnum = ZIN0(2);
@@ -999,6 +1022,8 @@ void Convolution3_Ctor(Convolution3* unit) {
 
     SndBuf* buf = ConvGetBuffer(unit, bufnum, "Convolution3", 1);
 
+    unit->m_inbuf1 = unit->m_inbuf2 = unit->m_outbuf = nullptr;
+
     if (buf) {
         if (unit->m_framesize <= 0) // if smaller than zero, equal to size of buffer
         {
@@ -1010,13 +1035,14 @@ void Convolution3_Ctor(Convolution3* unit) {
 
         unit->m_inbuf1 = (float*)RTAlloc(unit->mWorld, framesize_f);
         unit->m_inbuf2 = (float*)RTAlloc(unit->mWorld, framesize_f);
+        unit->m_outbuf = (float*)RTAlloc(unit->mWorld, framesize_f);
+        ClearUnitIfMemFailed(unit->m_inbuf1 && unit->m_inbuf2 && unit->m_outbuf);
 
         LOCK_SNDBUF_SHARED(buf);
         // calculate fft for kernel straight away
         memcpy(unit->m_inbuf2, buf->data, framesize_f);
         unit->m_pos = 0;
 
-        unit->m_outbuf = (float*)RTAlloc(unit->mWorld, framesize_f);
         memset(unit->m_outbuf, 0, framesize_f);
         unit->m_prevtrig = 0.f;
         if (INRATE(0) == calc_FullRate)

--- a/server/plugins/DelayUGens.cpp
+++ b/server/plugins/DelayUGens.cpp
@@ -587,13 +587,7 @@ static void LocalBuf_allocBuffer(LocalBuf* unit, SndBuf* buf, int numChannels, i
     // numFrames, numSamples * sizeof(float));
     const int alignment = 128; // in bytes
     unit->chunk = (float*)RTAlloc(unit->mWorld, numSamples * sizeof(float) + alignment);
-
-    if (!unit->chunk) {
-        if (unit->mWorld->mVerbosity > -2) {
-            Print("failed to allocate memory for LocalBuffer\n");
-        }
-        return;
-    }
+    ClearUnitIfMemFailed(unit->chunk);
 
     buf->data = (float*)((intptr_t)((char*)unit->chunk + (alignment - 1)) & -alignment);
 
@@ -611,7 +605,7 @@ static void LocalBuf_allocBuffer(LocalBuf* unit, SndBuf* buf, int numChannels, i
 
 void LocalBuf_Ctor(LocalBuf* unit) {
     Graph* parent = unit->mParent;
-
+    unit->chunk = nullptr;
     int offset = unit->mWorld->mNumSndBufs;
     int bufnum = parent->localBufNum;
     float fbufnum;
@@ -626,6 +620,8 @@ void LocalBuf_Ctor(LocalBuf* unit) {
         parent->localBufNum = parent->localBufNum + 1;
 
         LocalBuf_allocBuffer(unit, unit->m_buf, (int)IN0(0), (int)IN0(1));
+        if (!unit->chunk)
+            fbufnum = -1.f;
     }
 
     OUT0(0) = fbufnum;
@@ -651,6 +647,7 @@ void MaxLocalBufs_Ctor(MaxLocalBufs* unit) {
     int maxBufNum = (int)(IN0(0) + .5f);
     if (!parent->localMaxBufNum) {
         parent->mLocalSndBufs = (SndBuf*)RTAlloc(unit->mWorld, maxBufNum * sizeof(SndBuf));
+        ClearUnitIfMemFailed(parent->mLocalSndBufs);
 #ifdef SUPERNOVA
         for (int i = 0; i != maxBufNum; ++i)
             new (&parent->mLocalSndBufs[i]) SndBuf();
@@ -768,11 +765,7 @@ handle_failure:
     }                                                                                                                  \
     if (!unit->mIn) {                                                                                                  \
         unit->mIn = (float**)RTAlloc(unit->mWorld, numInputs * sizeof(float*));                                        \
-        if (unit->mIn == NULL) {                                                                                       \
-            unit->mDone = true;                                                                                        \
-            ClearUnitOutputs(unit, inNumSamples);                                                                      \
-            return;                                                                                                    \
-        }                                                                                                              \
+        ClearUnitIfMemFailed(unit->mIn);                                                                               \
     }                                                                                                                  \
     float** in = unit->mIn;                                                                                            \
     for (uint32 i = 0; i < numInputs; ++i) {                                                                           \
@@ -1708,6 +1701,7 @@ void Pitch_Ctor(Pitch* unit) {
     unit->m_size = sc_max(unit->m_maxperiod << 1, unit->m_execPeriod);
 
     unit->m_buffer = (float*)RTAlloc(unit->mWorld, unit->m_size * sizeof(float));
+    ClearUnitIfMemFailed(unit->m_buffer);
 
     unit->m_index = 0;
     unit->m_readp = 0;
@@ -3443,7 +3437,7 @@ void BufAllpassC_next_a_z(BufAllpassC* unit, int inNumSamples) { BufAllpassC_per
 ////////////////////////////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-static bool DelayUnit_AllocDelayLine(DelayUnit* unit, const char* className) {
+static bool DelayUnit_AllocDelayLine(DelayUnit* unit) {
     long delaybufsize = (long)ceil(unit->m_maxdelaytime * SAMPLERATE + 1.f);
     delaybufsize = delaybufsize + BUFLENGTH;
     delaybufsize = NEXTPOWEROFTWO(delaybufsize); // round up to next power of two
@@ -3457,14 +3451,6 @@ static bool DelayUnit_AllocDelayLine(DelayUnit* unit, const char* className) {
 	std::fill_n(unit->m_dlybuf, delaybufsize, std::numeric_limits<float>::signaling_NaN());
 #endif
 
-    if (unit->m_dlybuf == nullptr) {
-        SETCALC(ft->fClearUnitOutputs);
-        ClearUnitOutputs(unit, 1);
-
-        if (unit->mWorld->mVerbosity > -2)
-            Print("Failed to allocate memory for %s ugen.\n", className);
-    }
-
     unit->m_mask = delaybufsize - 1;
     return (unit->m_dlybuf != nullptr);
 }
@@ -3475,12 +3461,12 @@ template <typename Unit> static float CalcDelay(Unit* unit, float delaytime) {
     return sc_clip(next_dsamp, minDelay, unit->m_fdelaylen);
 }
 
-template <typename Unit> static bool DelayUnit_Reset(Unit* unit, const char* className) {
+template <typename Unit> static bool DelayUnit_Reset(Unit* unit) {
     unit->m_maxdelaytime = ZIN0(1);
     unit->m_delaytime = ZIN0(2);
     unit->m_dlybuf = nullptr;
 
-    if (!DelayUnit_AllocDelayLine(unit, className))
+    if (!DelayUnit_AllocDelayLine(unit))
         return false;
 
     unit->m_dsamp = CalcDelay(unit, unit->m_delaytime);
@@ -3495,10 +3481,10 @@ void DelayUnit_Dtor(DelayUnit* unit) { RTFree(unit->mWorld, unit->m_dlybuf); }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-template <typename Unit> static bool FeedbackDelay_Reset(Unit* unit, const char* className) {
+template <typename Unit> static bool FeedbackDelay_Reset(Unit* unit) {
     unit->m_decaytime = ZIN0(3);
 
-    bool allocationSucessful = DelayUnit_Reset(unit, className);
+    bool allocationSucessful = DelayUnit_Reset(unit);
     if (!allocationSucessful)
         return false;
 
@@ -3600,12 +3586,12 @@ static bool DelayUnit_init_0(DelayUnit* unit) {
         return false;
 }
 
-enum { initializationComplete, initializationIncomplete };
+enum { allocFailed, initializationComplete, initializationIncomplete };
 
-template <typename Delay> static int Delay_Ctor(Delay* unit, const char* className) {
-    bool allocationSucessful = DelayUnit_Reset(unit, className);
+template <typename Delay> static int Delay_Ctor(Delay* unit) {
+    bool allocationSucessful = DelayUnit_Reset(unit);
     if (!allocationSucessful)
-        return initializationComplete;
+        return allocFailed;
 
     // optimize for a constant delay of zero
     if (DelayUnit_init_0(unit))
@@ -3616,8 +3602,12 @@ template <typename Delay> static int Delay_Ctor(Delay* unit, const char* classNa
 ////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 void DelayN_Ctor(DelayN* unit) {
-    if (Delay_Ctor(unit, "DelayN") == initializationComplete)
+    int ctor_status = Delay_Ctor(unit);
+    if (ctor_status == allocFailed) {
+        ClearUnitOnMemFailed;
+    } else if (ctor_status == initializationComplete) {
         return;
+    }
 
     if (INRATE(2) == calc_FullRate)
         SETCALC(DelayN_next_a_z);
@@ -3694,8 +3684,12 @@ void DelayN_next_a_z(DelayN* unit, int inNumSamples) { DelayN_perform_a<true>(un
 ////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 void DelayL_Ctor(DelayL* unit) {
-    if (Delay_Ctor(unit, "DelayL") == initializationComplete)
+    int ctor_status = Delay_Ctor(unit);
+    if (ctor_status == allocFailed) {
+        ClearUnitOnMemFailed;
+    } else if (ctor_status == initializationComplete) {
         return;
+    }
 
     if (INRATE(2) == calc_FullRate)
         SETCALC(DelayL_next_a_z);
@@ -3724,8 +3718,12 @@ void DelayL_next_a_z(DelayL* unit, int inNumSamples) { DelayL_perform_a<true>(un
 ////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 void DelayC_Ctor(DelayC* unit) {
-    if (Delay_Ctor(unit, "DelayC") == initializationComplete)
+    int ctor_status = Delay_Ctor(unit);
+    if (ctor_status == allocFailed) {
+        ClearUnitOnMemFailed;
+    } else if (ctor_status == initializationComplete) {
         return;
+    }
 
     if (INRATE(2) == calc_FullRate)
         SETCALC(DelayC_next_a_z);
@@ -3825,9 +3823,8 @@ inline void FilterX_perform_a(CombX* unit, int inNumSamples, UnitCalcFunc resetF
 ////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 void CombN_Ctor(CombN* unit) {
-    bool allocationSucessful = FeedbackDelay_Reset(unit, "CombN");
-    if (!allocationSucessful)
-        return;
+    bool allocationSucessful = FeedbackDelay_Reset(unit);
+    ClearUnitIfMemFailed(allocationSucessful);
 
     if (INRATE(2) == calc_FullRate)
         SETCALC(CombN_next_a_z);
@@ -4006,9 +4003,8 @@ void CombN_next_a_z(CombN* unit, int inNumSamples) { CombN_perform_a<true>(unit,
 ////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 void CombL_Ctor(CombL* unit) {
-    bool allocationSucessful = FeedbackDelay_Reset(unit, "CombL");
-    if (!allocationSucessful)
-        return;
+    bool allocationSucessful = FeedbackDelay_Reset(unit);
+    ClearUnitIfMemFailed(allocationSucessful);
 
     if (INRATE(2) == calc_FullRate)
         SETCALC(CombL_next_a_z);
@@ -4036,9 +4032,8 @@ void CombL_next_a_z(CombL* unit, int inNumSamples) { CombL_perform_a<true>(unit,
 ////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 void CombC_Ctor(CombC* unit) {
-    bool allocationSucessful = FeedbackDelay_Reset(unit, "CombC");
-    if (!allocationSucessful)
-        return;
+    bool allocationSucessful = FeedbackDelay_Reset(unit);
+    ClearUnitIfMemFailed(allocationSucessful);
 
     if (INRATE(2) == calc_FullRate)
         SETCALC(CombC_next_a_z);
@@ -4068,9 +4063,8 @@ void CombC_next_a_z(CombC* unit, int inNumSamples) { CombC_perform_a<true>(unit,
 ////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 void AllpassN_Ctor(AllpassN* unit) {
-    bool allocationSucessful = FeedbackDelay_Reset(unit, "AllpassN");
-    if (!allocationSucessful)
-        return;
+    bool allocationSucessful = FeedbackDelay_Reset(unit);
+    ClearUnitIfMemFailed(allocationSucessful);
 
     if (INRATE(2) == calc_FullRate)
         SETCALC(AllpassN_next_a_z);
@@ -4253,9 +4247,8 @@ void AllpassN_next_a_z(AllpassN* unit, int inNumSamples) { AllpassN_perform_a<tr
 ////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 void AllpassL_Ctor(AllpassL* unit) {
-    bool allocationSucessful = FeedbackDelay_Reset(unit, "AllpassL");
-    if (!allocationSucessful)
-        return;
+    bool allocationSucessful = FeedbackDelay_Reset(unit);
+    ClearUnitIfMemFailed(allocationSucessful);
 
     if (INRATE(2) == calc_FullRate)
         SETCALC(AllpassL_next_a_z);
@@ -4284,9 +4277,8 @@ void AllpassL_next_a_z(AllpassL* unit, int inNumSamples) { AllpassL_perform_a<tr
 ////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 void AllpassC_Ctor(AllpassC* unit) {
-    bool allocationSucessful = FeedbackDelay_Reset(unit, "AllpassC");
-    if (!allocationSucessful)
-        return;
+    bool allocationSucessful = FeedbackDelay_Reset(unit);
+    ClearUnitIfMemFailed(allocationSucessful);
 
     if (INRATE(2) == calc_FullRate)
         SETCALC(AllpassC_next_a_z);
@@ -5000,7 +4992,9 @@ void PitchShift_Ctor(PitchShift* unit) {
 
     delaybufsize = delaybufsize + BUFLENGTH;
     delaybufsize = NEXTPOWEROFTWO(delaybufsize); // round up to next power of two
+    unit->dlybuf = nullptr;
     dlybuf = (float*)RTAlloc(unit->mWorld, delaybufsize * sizeof(float));
+    ClearUnitIfMemFailed(dlybuf);
 
     SETCALC(PitchShift_next_z);
 
@@ -5587,9 +5581,8 @@ void Pluck_Ctor(Pluck* unit) {
     unit->m_delaytime = IN0(3);
     unit->m_decaytime = IN0(4);
     unit->m_dlybuf = nullptr;
-    bool allocationSucessful = DelayUnit_AllocDelayLine(unit, "Pluck");
-    if (!allocationSucessful)
-        return;
+    bool allocationSucessful = DelayUnit_AllocDelayLine(unit);
+    ClearUnitIfMemFailed(allocationSucessful);
 
     unit->m_dsamp = CalcDelay(unit, unit->m_delaytime);
 

--- a/server/plugins/DemandUGens.cpp
+++ b/server/plugins/DemandUGens.cpp
@@ -419,12 +419,7 @@ void Demand_Ctor(Demand* unit) {
         OUT0(i) = 0.f;
 
     char* memoryChunk = (char*)RTAlloc(unit->mWorld, unit->mNumOutputs * (sizeof(float) + sizeof(float*)));
-
-    if (!memoryChunk) {
-        Print("Demand: RT memory allocation failed\n");
-        SETCALC(ClearUnitOutputs);
-        return;
-    }
+    ClearUnitIfMemFailed(memoryChunk);
 
     unit->m_prevout = (float*)memoryChunk;
     unit->m_out = (float**)(memoryChunk + unit->mNumOutputs * sizeof(float));
@@ -1863,12 +1858,7 @@ void Dshuf_Ctor(Dshuf* unit) {
 
     uint32 size = (unit->mNumInputs) - 1;
     unit->m_indices = (int32*)RTAlloc(unit->mWorld, size * sizeof(int32));
-
-    if (!unit->m_indices) {
-        Print("Dshuf: RT memory allocation failed\n");
-        SETCALC(ClearUnitOutputs);
-        return;
-    }
+    ClearUnitIfMemFailed(unit->m_indices);
 
     for (uint32 i = 0; i < size; ++i)
         unit->m_indices[i] = i + 1;
@@ -2094,12 +2084,7 @@ void Dpoll_Ctor(Dpoll* unit) {
     const int idStringSize = (int)IN0(3);
 
     unit->m_id_string = (char*)RTAlloc(unit->mWorld, (idStringSize + 1) * sizeof(char));
-
-    if (!unit->m_id_string) {
-        Print("Dpoll: RT memory allocation failed\n");
-        SETCALC(ClearUnitOutputs);
-        return;
-    }
+    ClearUnitIfMemFailed(unit->m_id_string);
 
     for (int i = 0; i < idStringSize; i++)
         unit->m_id_string[i] = (char)IN0(4 + i);

--- a/server/plugins/DemoUGens.cpp
+++ b/server/plugins/DemoUGens.cpp
@@ -80,9 +80,7 @@ void cmdCleanup(World* world, void* inUserData) {
     Print("cmdCleanup a %g  b %g  x %g  y %g  name %s\n", myCmdData->myPlugin->a, myCmdData->myPlugin->b, myCmdData->x,
           myCmdData->y, myCmdData->name);
 
-    if (myCmdData->name)
-        RTFree(world, myCmdData->name); // free the string
-
+    RTFree(world, myCmdData->name); // free the string
     RTFree(world, myCmdData); // free command data
     // scsynth will delete the completion message for you.
 }
@@ -95,6 +93,10 @@ void cmdDemoFunc(World* inWorld, void* inUserData, struct sc_msg_iter* args, voi
 
     // allocate command data, free it in cmdCleanup.
     MyCmdData* myCmdData = (MyCmdData*)RTAlloc(inWorld, sizeof(MyCmdData));
+    if (!myCmdData) {
+        Print("cmdDemoFunc: memory allocation failed!\n");
+        return;
+    }
     myCmdData->myPlugin = thePlugInData;
 
     // ..get data from args..
@@ -110,6 +112,10 @@ void cmdDemoFunc(World* inWorld, void* inUserData, struct sc_msg_iter* args, voi
     const char* name = args->gets(); // get the string argument
     if (name) {
         myCmdData->name = (char*)RTAlloc(inWorld, strlen(name) + 1); // allocate space, free it in cmdCleanup.
+        if (!myCmdData->name) {
+            Print("cmdDemoFunc: memory allocation failed!\n");
+            return;
+        }
         strcpy(myCmdData->name, name); // copy the string
     }
 
@@ -120,6 +126,10 @@ void cmdDemoFunc(World* inWorld, void* inUserData, struct sc_msg_iter* args, voi
         // allocate space for completion message
         // scsynth will delete the completion message for you.
         msgData = (char*)RTAlloc(inWorld, msgSize);
+        if (!msgData) {
+            Print("cmdDemoFunc: memory allocation failed!\n");
+            return;
+        }
         args->getb(msgData, msgSize); // copy completion message.
     }
 

--- a/server/plugins/FFT_UGens.cpp
+++ b/server/plugins/FFT_UGens.cpp
@@ -143,11 +143,11 @@ static int FFTBase_Ctor(FFTBase* unit, int frmsizinput) {
 void FFT_Ctor(FFT* unit) {
     int winType = sc_clip((int)ZIN0(3), -1, 1); // wintype may be used by the base ctor
     unit->m_wintype = winType;
+    // These zeroes are to prevent the dtor freeing things that don't exist:
+    unit->m_inbuf = nullptr;
+    unit->m_scfft = nullptr;
     if (!FFTBase_Ctor(unit, 5)) {
         SETCALC(FFT_ClearUnitOutputs);
-        // These zeroes are to prevent the dtor freeing things that don't exist:
-        unit->m_inbuf = nullptr;
-        unit->m_scfft = nullptr;
         return;
     }
     int audiosize = unit->m_audiosize * sizeof(float);
@@ -166,15 +166,12 @@ void FFT_Ctor(FFT* unit) {
     unit->m_shuntsize = unit->m_audiosize - hopsize;
 
     unit->m_inbuf = (float*)RTAlloc(unit->mWorld, audiosize);
+    ClearFFTUnitIfMemFailed(unit->m_inbuf);
 
     SCWorld_Allocator alloc(ft, unit->mWorld);
     unit->m_scfft = scfft_create(unit->m_fullbufsize, unit->m_audiosize, (SCFFT_WindowFunction)unit->m_wintype,
                                  unit->m_inbuf, unit->m_fftsndbuf->data, kForward, alloc);
-
-    if (!unit->m_scfft) {
-        SETCALC(*ClearUnitOutputs);
-        return;
-    }
+    ClearFFTUnitIfMemFailed(unit->m_scfft);
 
     memset(unit->m_inbuf, 0, audiosize);
 
@@ -199,9 +196,6 @@ void FFT_Dtor(FFT* unit) {
         RTFree(unit->mWorld, unit->m_inbuf);
 }
 
-// Ordinary ClearUnitOutputs outputs zero, potentially telling the IFFT (+ PV UGens) to act on buffer zero, so let's
-// skip that:
-void FFT_ClearUnitOutputs(FFT* unit, int wrongNumSamples) { ZOUT0(0) = -1; }
 
 void FFT_next(FFT* unit, int wrongNumSamples) {
     float* in = IN(1);
@@ -240,27 +234,24 @@ void FFT_next(FFT* unit, int wrongNumSamples) {
 void IFFT_Ctor(IFFT* unit) {
     int winType = sc_clip((int)ZIN0(1), -1, 1); // wintype may be used by the base ctor
     unit->m_wintype = winType;
+    // These zeroes are to prevent the dtor freeing things that don't exist:
+    unit->m_olabuf = nullptr;
+    unit->m_scfft = nullptr;
 
     if (!FFTBase_Ctor(unit, 2)) {
         SETCALC(*ClearUnitOutputs);
-        // These zeroes are to prevent the dtor freeing things that don't exist:
-        unit->m_olabuf = nullptr;
         return;
     }
 
     // This will hold the transformed and progressively overlap-added data ready for outputting.
     unit->m_olabuf = (float*)RTAlloc(unit->mWorld, unit->m_audiosize * sizeof(float));
+    ClearUnitIfMemFailed(unit->m_olabuf);
     memset(unit->m_olabuf, 0, unit->m_audiosize * sizeof(float));
 
     SCWorld_Allocator alloc(ft, unit->mWorld);
     unit->m_scfft = scfft_create(unit->m_fullbufsize, unit->m_audiosize, (SCFFT_WindowFunction)unit->m_wintype,
                                  unit->m_fftsndbuf->data, unit->m_fftsndbuf->data, kBackward, alloc);
-
-    if (!unit->m_scfft) {
-        SETCALC(*ClearUnitOutputs);
-        unit->m_olabuf = nullptr;
-        return;
-    }
+    ClearUnitIfMemFailed(unit->m_scfft);
 
     // "pos" will be reset to zero when each frame comes in. Until then, the following ensures silent output at first:
     unit->m_pos = 0; // unit->m_audiosize;

--- a/server/plugins/FeatureDetection.cpp
+++ b/server/plugins/FeatureDetection.cpp
@@ -110,6 +110,7 @@ void RunningSum_Dtor(RunningSum* unit);
 
 void PV_OnsetDetectionBase_Ctor(PV_OnsetDetectionBase* unit) {
     float fbufnum = ZIN0(0);
+    unit->m_prevframe = nullptr;
 
     PV_FEAT_GET_BUF_UNLOCKED
 
@@ -118,6 +119,7 @@ void PV_OnsetDetectionBase_Ctor(PV_OnsetDetectionBase* unit) {
 
     if (bufOK) {
         unit->m_prevframe = (float*)RTAlloc(unit->mWorld, insize);
+        ClearUnitIfMemFailed(unit->m_prevframe);
         memset(unit->m_prevframe, 0, insize);
     }
 
@@ -352,6 +354,7 @@ void RunningSum_Ctor(RunningSum* unit) {
     unit->mcount = 0; // unit->msamp-1;
 
     unit->msquares = (float*)RTAlloc(unit->mWorld, unit->msamp * sizeof(float));
+    ClearUnitIfMemFailed(unit->msquares);
     // initialise to zeroes
     for (int i = 0; i < unit->msamp; ++i)
         unit->msquares[i] = 0.f;

--- a/server/plugins/FilterUGens.cpp
+++ b/server/plugins/FilterUGens.cpp
@@ -3309,6 +3309,7 @@ void Normalizer_Ctor(Normalizer* unit) {
     // allocsize = NEXTPOWEROFTWO(allocsize);
 
     unit->m_table = (float*)RTAlloc(unit->mWorld, allocsize * sizeof(float));
+    ClearUnitIfMemFailed(unit->m_table);
 
     unit->m_pos = 0;
     unit->m_flips = 0;
@@ -3397,6 +3398,7 @@ void Limiter_Ctor(Limiter* unit) {
     allocsize = NEXTPOWEROFTWO(allocsize);
 
     unit->m_table = (float*)RTAlloc(unit->mWorld, allocsize * sizeof(float));
+    ClearUnitIfMemFailed(unit->m_table);
 
     unit->m_flips = 0;
     unit->m_pos = 0;

--- a/server/plugins/GendynUGens.cpp
+++ b/server/plugins/GendynUGens.cpp
@@ -89,6 +89,7 @@ void Gendy1_Ctor(Gendy1* unit) {
     unit->mIndex = 0;
     unit->mMemoryAmp = (float*)RTAlloc(unit->mWorld, unit->mMemorySize * sizeof(float));
     unit->mMemoryDur = (float*)RTAlloc(unit->mWorld, unit->mMemorySize * sizeof(float));
+    ClearUnitIfMemFailed(unit->mMemoryAmp && unit->mMemoryDur);
 
     RGen& rgen = *unit->mParent->mRGen;
 
@@ -323,6 +324,7 @@ void Gendy2_Ctor(Gendy2* unit) {
     unit->mMemoryDur = (float*)RTAlloc(unit->mWorld, unit->mMemorySize * sizeof(float));
     unit->mMemoryAmpStep = (float*)RTAlloc(unit->mWorld, unit->mMemorySize * sizeof(float));
     unit->mMemoryDurStep = (float*)RTAlloc(unit->mWorld, unit->mMemorySize * sizeof(float));
+    ClearUnitIfMemFailed(unit->mMemoryAmp && unit->mMemoryDur && unit->mMemoryAmpStep && unit->mMemoryDurStep);
 
     RGen& rgen = *unit->mParent->mRGen;
 
@@ -488,6 +490,7 @@ void Gendy3_Ctor(Gendy3* unit) {
     // one more in amp list for guard (wrap) element
     unit->mAmpList = (float*)RTAlloc(unit->mWorld, (unit->mMemorySize + 1) * sizeof(float));
     unit->mPhaseList = (double*)RTAlloc(unit->mWorld, (unit->mMemorySize + 1) * sizeof(double));
+    ClearUnitIfMemFailed(unit->mMemoryAmp && unit->mMemoryDur && unit->mAmpList && unit->mPhaseList);
 
     RGen& rgen = *unit->mParent->mRGen;
 

--- a/server/plugins/GrainUGens.cpp
+++ b/server/plugins/GrainUGens.cpp
@@ -604,6 +604,7 @@ void GrainIn_next_k(GrainIn* unit, int inNumSamples) {
         float maxGrains = IN0(5);
         unit->mMaxGrains = (int)maxGrains;
         unit->mGrains = (GrainInG*)RTAlloc(unit->mWorld, unit->mMaxGrains * sizeof(GrainInG));
+        ClearUnitIfMemFailed(unit->mGrains);
     }
 
     GrainIn_next_play_active(unit, inNumSamples);
@@ -624,6 +625,7 @@ void GrainIn_Ctor(GrainIn* unit) {
     unit->mFirst = true;
     unit->mNumActive = 0;
     unit->curtrig = 0.f;
+    unit->mGrains = nullptr;
     GrainIn_next_k(unit, 1);
 }
 
@@ -753,6 +755,7 @@ void GrainSin_next_k(GrainSin* unit, int inNumSamples) {
         float maxGrains = IN0(5);
         unit->mMaxGrains = (int)maxGrains;
         unit->mGrains = (GrainSinG*)RTAlloc(unit->mWorld, unit->mMaxGrains * sizeof(GrainSinG));
+        ClearUnitIfMemFailed(unit->mGrains);
     }
 
     GrainSin_next_play_active(unit, inNumSamples);
@@ -777,6 +780,7 @@ void GrainSin_Ctor(GrainSin* unit) {
     unit->curtrig = 0.f;
     unit->mNumActive = 0;
     unit->mFirst = true;
+    unit->mGrains = nullptr;
     GrainSin_next_k(unit, 1);
 }
 
@@ -921,6 +925,7 @@ void GrainFM_next_k(GrainFM* unit, int inNumSamples) {
         float maxGrains = IN0(7);
         unit->mMaxGrains = (int)maxGrains;
         unit->mGrains = (GrainFMG*)RTAlloc(unit->mWorld, unit->mMaxGrains * sizeof(GrainFMG));
+        ClearUnitIfMemFailed(unit->mGrains);
     }
 
     GrainFM_next_play_active(unit, inNumSamples);
@@ -944,6 +949,7 @@ void GrainFM_Ctor(GrainFM* unit) {
     unit->curtrig = 0.f;
     unit->mNumActive = 0;
     unit->mFirst = true;
+    unit->mGrains = nullptr;
     GrainFM_next_k(unit, 1);
 }
 
@@ -1220,6 +1226,7 @@ void GrainBuf_Ctor(GrainBuf* unit) {
     float maxGrains = IN0(8);
     unit->mMaxGrains = (int)maxGrains;
     unit->mGrains = (GrainBufG*)RTAlloc(unit->mWorld, unit->mMaxGrains * sizeof(GrainBufG));
+    ClearUnitIfMemFailed(unit->mGrains);
 
     if (unit->mNumOutputs == 1) {
         if (INRATE(0) == calc_FullRate)

--- a/server/plugins/IOUGens.cpp
+++ b/server/plugins/IOUGens.cpp
@@ -310,6 +310,7 @@ void AudioControl_next_1(AudioControl* unit, int inNumSamples) {
 void AudioControl_Ctor(AudioControl* unit) {
     unit->prevVal = (float*)RTAlloc(unit->mWorld, unit->mNumOutputs * sizeof(float));
     unit->m_prevBus = NULL;
+    ClearUnitIfMemFailed(unit->prevVal);
     for (int i = 0; i < unit->mNumOutputs; i++) {
         unit->prevVal[i] = 0.0;
     }
@@ -402,6 +403,7 @@ void LagControl_Ctor(LagControl* unit) {
     float** mapin = unit->mParent->mMapControls + unit->mSpecialIndex;
 
     char* chunk = (char*)RTAlloc(unit->mWorld, numChannels * 2 * sizeof(float));
+    ClearUnitIfMemFailed(chunk);
     unit->m_y1 = (float*)chunk;
     unit->m_b1 = unit->m_y1 + numChannels;
 
@@ -1327,6 +1329,7 @@ void OffsetOut_Ctor(OffsetOut* unit) {
     int numChannels = unit->mNumInputs - 1;
 
     unit->m_saved = (float*)RTAlloc(unit->mWorld, offset * numChannels * sizeof(float));
+    ClearUnitIfMemFailed(unit->m_saved);
     unit->m_empty = true;
     // Print("<-Out_Ctor\n");
 }
@@ -1542,6 +1545,7 @@ void LocalIn_Ctor(LocalIn* unit) {
     // align the buffer to 256 bytes so that we can use avx instructions
     unit->m_realData =
         (float*)RTAlloc(world, busDataSize * sizeof(float) + numChannels * sizeof(int32) + 32 * sizeof(float));
+    ClearUnitIfMemFailed(unit->m_realData);
     size_t alignment = (size_t)unit->m_realData & 31;
 
     unit->m_bus = alignment ? (float*)(size_t(unit->m_realData + 32) & ~31) : unit->m_realData;

--- a/server/plugins/KeyTrack.cpp
+++ b/server/plugins/KeyTrack.cpp
@@ -1012,6 +1012,7 @@ void KeyTrack_Ctor(KeyTrack* unit) {
 
     // only need space for half!
     unit->m_FFTBuf = (float*)RTAlloc(unit->mWorld, NOVER2 * sizeof(float));
+    ClearUnitIfMemFailed(unit->m_FFTBuf);
 
     // zero chroma
     Clear(12, unit->m_chroma);

--- a/server/plugins/LFUGens.cpp
+++ b/server/plugins/LFUGens.cpp
@@ -3110,6 +3110,7 @@ void IEnvGen_Ctor(IEnvGen* unit) {
     float offset = unit->m_offset = IN0(1);
     float point = unit->m_pointin = IN0(0) - offset;
     unit->m_envvals = (float*)RTAlloc(unit->mWorld, (int)(numvals + 1.) * sizeof(float));
+    ClearUnitIfMemFailed(unit->m_envvals);
 
     unit->m_envvals[0] = IN0(2);
     //  Print("offset of and initial  values %3,3f, %3.3f\n", offset, unit->m_envvals[0]);

--- a/server/plugins/Loudness.cpp
+++ b/server/plugins/Loudness.cpp
@@ -86,6 +86,7 @@ void Loudness_Ctor(Loudness* unit) {
     unit->m_numbands = 42;
 
     unit->m_ERBbands = (float*)RTAlloc(unit->mWorld, unit->m_numbands * sizeof(float));
+    ClearUnitIfMemFailed(unit->m_ERBbands);
 
     Clear(unit->m_numbands, unit->m_ERBbands);
 

--- a/server/plugins/MFCC.cpp
+++ b/server/plugins/MFCC.cpp
@@ -3320,10 +3320,6 @@ void MFCC_Ctor(MFCC* unit) {
     // fixed for now
     unit->m_numbands = 42;
 
-    unit->m_bands = (float*)RTAlloc(unit->mWorld, unit->m_numbands * sizeof(float));
-
-    Clear(unit->m_numbands, unit->m_bands);
-
     unit->m_numcoefficients = (int)ZIN0(1);
 
     // range checks
@@ -3334,8 +3330,11 @@ void MFCC_Ctor(MFCC* unit) {
         unit->m_numcoefficients = 42;
     }
 
+    unit->m_bands = (float*)RTAlloc(unit->mWorld, unit->m_numbands * sizeof(float));
     unit->m_mfcc = (float*)RTAlloc(unit->mWorld, unit->m_numcoefficients * sizeof(float));
+    ClearUnitIfMemFailed(unit->m_bands && unit->m_mfcc);
 
+    Clear(unit->m_numbands, unit->m_bands);
     Clear(unit->m_numcoefficients, unit->m_mfcc);
     for (int j = 0; j < unit->m_numcoefficients; ++j)
         ZOUT0(j) = 0.f;

--- a/server/plugins/ML_SpecStats.cpp
+++ b/server/plugins/ML_SpecStats.cpp
@@ -208,6 +208,7 @@ void SpecPcile_next(SpecPcile* unit, int inNumSamples) {
         // Used to be MAKE_TEMP_BUF but we can handle it more cleanly in this specific case:
         if (!unit->m_tempbuf) {
         unit->m_tempbuf = (float*)RTAlloc(unit->mWorld, numbins * sizeof(float));
+        ClearUnitIfMemFailed(unit->m_tempbuf);
         unit->m_numbins = numbins;
         unit->m_halfnyq_over_numbinsp2 = ((float)unit->mWorld->mSampleRate) * 0.5f / (float)(numbins + 2);
     }

--- a/server/plugins/Onsets.cpp
+++ b/server/plugins/Onsets.cpp
@@ -71,6 +71,8 @@ void Onsets_Ctor(Onsets* unit) {
 
     unit->m_needsinit = true;
     unit->m_ods = (OnsetsDS*)RTAlloc(unit->mWorld, sizeof(OnsetsDS));
+    unit->m_odsdata = nullptr;
+    ClearUnitIfMemFailed(unit->m_ods);
 
     ZOUT0(0) = unit->outval = 0.f;
 }
@@ -91,6 +93,7 @@ void Onsets_next(Onsets* unit, int inNumSamples) {
     if (unit->m_needsinit) {
         // Init happens here because we need to be sure about FFT size.
         unit->m_odsdata = (float*)RTAlloc(unit->mWorld, onsetsds_memneeded(odftype, buf->samples, medspan));
+        ClearUnitIfMemFailed(unit->m_odsdata);
 
         onsetsds_init(ods, unit->m_odsdata, ODS_FFT_SC3_POLAR, odftype, buf->samples, medspan, FULLRATE);
         onsetsds_setrelax(ods, relaxtime, buf->samples >> 1);
@@ -127,6 +130,7 @@ void Onsets_next_rawodf(Onsets* unit, int inNumSamples) {
     if (unit->m_needsinit) {
         // Init happens here because we need to be sure about FFT size.
         unit->m_odsdata = (float*)RTAlloc(unit->mWorld, onsetsds_memneeded(odftype, buf->samples, medspan));
+        ClearUnitIfMemFailed(unit->m_odsdata);
 
         onsetsds_init(ods, unit->m_odsdata, ODS_FFT_SC3_POLAR, odftype, buf->samples, medspan, FULLRATE);
         onsetsds_setrelax(ods, relaxtime, buf->samples >> 1);

--- a/server/plugins/OscUGens.cpp
+++ b/server/plugins/OscUGens.cpp
@@ -2715,17 +2715,6 @@ void Pulse_next(Pulse* unit, int inNumSamples) {
 ////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 static float Klang_SetCoefs(Klang* unit) {
-    unit->m_numpartials = (unit->mNumInputs - 2) / 3;
-
-    int numcoefs = unit->m_numpartials * 3;
-    unit->m_coefs = (float*)RTAlloc(unit->mWorld, numcoefs * sizeof(float));
-
-    if (!unit->m_coefs) {
-        Print("Klang: RT memory allocation failed\n");
-        SETCALC(ClearUnitOutputs);
-        return 0.f;
-    }
-
     float freqscale = ZIN0(0) * unit->mRate->mRadiansPerSample;
     float freqoffset = ZIN0(1) * unit->mRate->mRadiansPerSample;
 
@@ -2751,6 +2740,10 @@ static float Klang_SetCoefs(Klang* unit) {
 
 void Klang_Ctor(Klang* unit) {
     SETCALC(Klang_next);
+    unit->m_numpartials = (unit->mNumInputs - 2) / 3;
+    int numcoefs = unit->m_numpartials * 3;
+    unit->m_coefs = (float*)RTAlloc(unit->mWorld, numcoefs * sizeof(float));
+    ClearUnitIfMemFailed(unit->m_coefs);
     ZOUT0(0) = Klang_SetCoefs(unit);
 }
 
@@ -2906,11 +2899,7 @@ static void Klank_SetCoefs(Klank* unit) {
 
     int numcoefs = ((unit->m_numpartials + 3) & ~3) * 5;
     unit->m_coefs = (float*)RTAlloc(unit->mWorld, (numcoefs + unit->mWorld->mBufLength) * sizeof(float));
-    if (!unit->m_coefs) {
-        Print("Klang: RT memory allocation failed\n");
-        SETCALC(ClearUnitOutputs);
-        return;
-    }
+    ClearUnitIfMemFailed(unit->m_coefs);
 
     unit->m_buf = unit->m_coefs + numcoefs;
 

--- a/server/plugins/PV_UGens.cpp
+++ b/server/plugins/PV_UGens.cpp
@@ -947,6 +947,7 @@ void PV_RandComb_next(PV_RandComb* unit, int inNumSamples) {
 
     if (!unit->m_ordering) {
         unit->m_ordering = (int*)RTAlloc(unit->mWorld, numbins * sizeof(int));
+        ClearFFTUnitIfMemFailed(unit->m_ordering);
         unit->m_numbins = numbins;
         PV_RandComb_choose(unit);
     } else {
@@ -1012,6 +1013,7 @@ void PV_RandWipe_next(PV_RandWipe* unit, int inNumSamples) {
 
     if (!unit->m_ordering) {
         unit->m_ordering = (int*)RTAlloc(unit->mWorld, numbins * sizeof(int));
+        ClearFFTUnitIfMemFailed(unit->m_ordering);
         unit->m_numbins = numbins;
         PV_RandWipe_choose(unit);
     } else {
@@ -1063,6 +1065,7 @@ void PV_Diffuser_next(PV_Diffuser* unit, int inNumSamples) {
 
     if (!unit->m_shift) {
         unit->m_shift = (float*)RTAlloc(unit->mWorld, numbins * sizeof(float));
+        ClearFFTUnitIfMemFailed(unit->m_shift);
         unit->m_numbins = numbins;
         PV_Diffuser_choose(unit);
     } else {
@@ -1105,6 +1108,7 @@ void PV_MagFreeze_next(PV_MagFreeze* unit, int inNumSamples) {
 
     if (!unit->m_mags) {
         unit->m_mags = (float*)RTAlloc(unit->mWorld, numbins * sizeof(float));
+        ClearFFTUnitIfMemFailed(unit->m_mags);
         unit->m_numbins = numbins;
         // The first fft frame must use the else branch below
         // so that unit->m_mags gets populated with actual mag data
@@ -1181,6 +1185,7 @@ void PV_BinScramble_next(PV_BinScramble* unit, int inNumSamples) {
         unit->m_from = unit->m_to + numbins;
         unit->m_numbins = numbins;
         unit->m_tempbuf = (float*)RTAlloc(unit->mWorld, buf->samples * sizeof(float));
+        ClearFFTUnitIfMemFailed(unit->m_to && unit->m_tempbuf);
         PV_BinScramble_choose(unit);
     } else {
         if (numbins != unit->m_numbins)

--- a/server/plugins/PanUGens.cpp
+++ b/server/plugins/PanUGens.cpp
@@ -1278,11 +1278,7 @@ void PanAz_Ctor(PanAz* unit) {
             ZOUT0(i) = 0.f;
 
         unit->m_chanamp = (float*)RTAlloc(unit->mWorld, numOutputs * sizeof(float));
-        if (!unit->m_chanamp) {
-            Print("PanAz: RT memory allocation failed\n");
-            SETCALC(ClearUnitOutputs);
-            return;
-        }
+        ClearUnitIfMemFailed(unit->m_chanamp);
 
         std::fill_n(unit->m_chanamp, numOutputs, 0);
 

--- a/server/plugins/PartitionedConvolution.cpp
+++ b/server/plugins/PartitionedConvolution.cpp
@@ -71,25 +71,32 @@ void PartConv_Ctor(PartConv* unit) {
     unit->m_fftsize = (int)ZIN0(1);
     unit->m_nover2 = unit->m_fftsize >> 1;
 
+    unit->m_scfft = unit->m_scifft = nullptr;
+    unit->m_irspectra = unit->m_inputbuf2 = unit->m_spectrum2 = unit->m_output = unit->m_fd_accumulate = nullptr;
     unit->m_inputbuf = (float*)RTAlloc(unit->mWorld, unit->m_fftsize * sizeof(float));
     unit->m_spectrum = (float*)RTAlloc(unit->mWorld, unit->m_fftsize * sizeof(float));
+    ClearUnitIfMemFailed(unit->m_inputbuf && unit->m_spectrum);
 
     SCWorld_Allocator alloc(ft, unit->mWorld);
     unit->m_scfft = scfft_create(unit->m_fftsize, unit->m_fftsize, kRectWindow, unit->m_inputbuf, unit->m_spectrum,
                                  kForward, alloc);
+    ClearUnitIfMemFailed(unit->m_scfft);
 
     // inverse
     unit->m_inputbuf2 = (float*)RTAlloc(unit->mWorld, unit->m_fftsize * sizeof(float));
     unit->m_spectrum2 = (float*)RTAlloc(unit->mWorld, unit->m_fftsize * sizeof(float));
+    ClearUnitIfMemFailed(unit->m_inputbuf2 && unit->m_spectrum2);
     // in place this time
     unit->m_scifft = scfft_create(unit->m_fftsize, unit->m_fftsize, kRectWindow, unit->m_inputbuf2, unit->m_spectrum2,
                                   kBackward, alloc);
 
+    ClearUnitIfMemFailed(unit->m_scifft);
     // debug test: changing scale factors in case amplitude summation is a problem
     // unit->m_scfft->scalefac=1.0/45.254833995939;
     // unit->m_scifft->scalefac=1.0/45.254833995939;
 
     unit->m_output = (float*)RTAlloc(unit->mWorld, unit->m_fftsize * sizeof(float));
+    ClearUnitIfMemFailed(unit->m_output);
     unit->m_outputpos = 0;
 
     memset(unit->m_output, 0, unit->m_fftsize * sizeof(float));
@@ -180,6 +187,7 @@ void PartConv_Ctor(PartConv* unit) {
         // unit->m_lastamort);
 
         unit->m_fd_accumulate = (float*)RTAlloc(unit->mWorld, unit->m_fullsize * sizeof(float));
+        ClearUnitIfMemFailed(unit->m_fd_accumulate);
         memset(unit->m_fd_accumulate, 0, unit->m_fullsize * sizeof(float));
         unit->m_fd_accum_pos = 0;
 
@@ -396,10 +404,24 @@ void PreparePartConv(World* world, struct SndBuf* buf, struct sc_msg_iter* msg) 
     // numpartitions*fftsize, frames2);
 
     float* inputbuf = (float*)RTAlloc(world, fftsize * sizeof(float));
+    if (inputbuf == nullptr) {
+        printf("PreparePartConv: memory allocation failed.\n");
+        return;
+    }
     float* spectrum = (float*)RTAlloc(world, fftsize * sizeof(float));
-
+    if (spectrum == nullptr) {
+        RTFree(world, inputbuf);
+        printf("PreparePartConv: memory allocation failed.\n");
+        return;
+    }
     SCWorld_Allocator alloc(ft, world);
     scfft* m_scfft = scfft_create(fftsize, fftsize, kRectWindow, inputbuf, spectrum, kForward, alloc);
+    if (m_scfft == nullptr) {
+        RTFree(world, inputbuf);
+        RTFree(world, spectrum);
+        printf("PreparePartConv: memory allocation failed.\n");
+        return;
+    }
 
     memset(inputbuf, 0, sizeof(float) * fftsize); // for zero padding
 

--- a/server/plugins/TriggerUGens.cpp
+++ b/server/plugins/TriggerUGens.cpp
@@ -692,12 +692,7 @@ void SendReply_Ctor(SendReply* unit) {
     const int cmdNameAllocSize = (unit->m_cmdNameSize + 1) * sizeof(char);
     const int valuesAllocSize = unit->m_valueSize * sizeof(float);
     char* chunk = (char*)RTAlloc(unit->mWorld, cmdNameAllocSize + valuesAllocSize);
-
-    if (!chunk) {
-        Print("SendReply: RT memory allocation failed\n");
-        SETCALC(Unit_next_nop);
-        return;
-    }
+    ClearUnitIfMemFailed(chunk);
 
     unit->m_cmdName = chunk;
     unit->m_values = (float*)(chunk + cmdNameAllocSize);
@@ -773,12 +768,7 @@ void Poll_Ctor(Poll* unit) {
     unit->m_trig = IN0(0);
     const int idSize = (int)IN0(3); // number of chars in the id string
     unit->m_id_string = (char*)RTAlloc(unit->mWorld, (idSize + 1) * sizeof(char));
-
-    if (!unit->m_id_string) {
-        Print("Poll: RT memory allocation failed\n");
-        SETCALC(Unit_next_nop);
-        return;
-    }
+    ClearUnitIfMemFailed(unit->m_id_string);
 
     for (int i = 0; i < idSize; i++)
         unit->m_id_string[i] = (char)IN0(4 + i);
@@ -2400,11 +2390,7 @@ struct SendPeakRMS : public Unit {
         size_t cmdNameAllocSize = (cmdNameSize + 1) * sizeof(char);
 
         void* allocData = RTAlloc(unit->mWorld, channelDataAllocSize + cmdNameAllocSize);
-        if (!allocData) {
-            Print("SendPeakRMS: RT memory allocation failed\n");
-            SETCALC(Unit_next_nop);
-            return;
-        }
+        ClearUnitIfMemFailed(allocData);
 
         memset(allocData, 0, channelDataAllocSize);
         mChannelData = (float*)allocData;

--- a/server/scsynth/HashTable.h
+++ b/server/scsynth/HashTable.h
@@ -27,6 +27,7 @@
 #include <stddef.h>
 #include <stdlib.h>
 #include <string.h>
+#include <stdexcept>
 
 template <class T, class Allocator> class HashTable {
     Allocator* mPool;
@@ -53,6 +54,8 @@ public:
     T** AllocTable(int inTableSize) {
         size_t size = inTableSize * sizeof(T*);
         T** items = static_cast<T**>(mPool->Alloc(size));
+        if (items == NULL)
+            throw std::runtime_error("FAILURE IN SERVER: HashTable allocation failed: out of memory!\n");
         for (int i = 0; i < inTableSize; ++i) {
             items[i] = 0;
         }
@@ -194,6 +197,8 @@ public:
     T** AllocTable(int inTableSize) {
         size_t size = inTableSize * sizeof(T*);
         T** items = static_cast<T**>(mPool->Alloc(size));
+        if (items == NULL)
+            throw std::runtime_error("FAILURE IN SERVER: HashTable allocation failed: out of memory!\n");
         for (int i = 0; i < inTableSize; ++i) {
             items[i] = 0;
         }

--- a/server/scsynth/SC_CoreAudio.cpp
+++ b/server/scsynth/SC_CoreAudio.cpp
@@ -300,6 +300,8 @@ void Perform_ToEngine_Msg(FifoMsg* inMsg) {
 
 PacketStatus PerformCompletionMsg(World* inWorld, const OSC_Packet& inPacket) {
     OSC_Packet* packet = (OSC_Packet*)World_Alloc(inWorld, sizeof(OSC_Packet));
+    if (packet == NULL)
+        throw std::runtime_error("PerformCompletionMsg allocation failed: out of memory!\n");
     *packet = inPacket;
     packet->mIsBundle = gIsBundle.checkIsBundle((int32*)packet->mData);
     PacketStatus status = PerformOSCPacket(inWorld, packet, SC_ScheduledEvent::FreeInRT);

--- a/server/scsynth/SC_GraphDef.cpp
+++ b/server/scsynth/SC_GraphDef.cpp
@@ -547,6 +547,8 @@ SCErr GraphDef_Remove(World* inWorld, int32* inName) {
 
 SCErr SendReplyCmd_d_removed(World* inWorld, int inSize, char* inData, ReplyAddress* inReply) {
     void* space = World_Alloc(inWorld, sizeof(SendReplyCmd));
+    if (!space)
+        return kSCErr_OutOfRealTimeMemory;
     SendReplyCmd* cmd = new (space) SendReplyCmd(inWorld, inReply);
     if (!cmd)
         return kSCErr_Failed;

--- a/server/scsynth/SC_Node.cpp
+++ b/server/scsynth/SC_Node.cpp
@@ -49,7 +49,9 @@ int Node_New(World* inWorld, NodeDef* def, int32 inID, Node** outNode) {
     }
 
     Node* node = (Node*)World_Alloc(inWorld, def->mAllocSize);
-
+    if (!node) {
+        return kSCErr_OutOfRealTimeMemory;
+    }
     node->mWorld = inWorld;
     node->mDef = def;
     node->mParent = nullptr;

--- a/server/scsynth/SC_SequencedCommand.cpp
+++ b/server/scsynth/SC_SequencedCommand.cpp
@@ -32,10 +32,19 @@
 
 const size_t ERR_BUF_SIZE(512);
 
+#define ReturnSCErrIfNil(ptr)                                                                                          \
+    if (!ptr)                                                                                                          \
+    return kSCErr_OutOfRealTimeMemory
+#define ThrowIfNil(ptr)                                                                                                \
+    if (!ptr)                                                                                                          \
+        throw std::runtime_error(                                                                                      \
+            std::string("alloc failed, increase server's memory allocation (e.g. via ServerOptions)"));
+
 #define GET_COMPLETION_MSG(msg)                                                                                        \
     mMsgSize = msg.getbsize();                                                                                         \
     if (mMsgSize) {                                                                                                    \
         mMsgData = (char*)World_Alloc(mWorld, mMsgSize);                                                               \
+        ReturnSCErrIfNil(mMsgData);                                                                                    \
         msg.getb(mMsgData, mMsgSize);                                                                                  \
     }
 
@@ -106,6 +115,7 @@ char* allocAndRestrictPath(World* mWorld, const char* inPath, const char* restri
 
     // Now we can make a long-term home for the string and return it
     char* saferPath = (char*)World_Alloc(mWorld, strlen(strbuf) + 1);
+    ThrowIfNil(saferPath);
     strcpy(saferPath, strbuf);
     return saferPath;
 }
@@ -275,7 +285,11 @@ void BufAllocCmd::CallDestructor() { this->~BufAllocCmd(); }
 bool BufAllocCmd::Stage2() {
     SndBuf* buf = World_GetNRTBuf(mWorld, mBufIndex);
     mFreeData = buf->data;
-    bufAlloc(buf, mNumChannels, mNumFrames, mWorld->mFullRate.mSampleRate);
+    SCErr err = bufAlloc(buf, mNumChannels, mNumFrames, mWorld->mFullRate.mSampleRate);
+    if (err) {
+        scprintf("/b_alloc: memory allocation failed\n");
+        return false;
+    }
     mSndBuf = *buf;
     return true;
 }
@@ -307,6 +321,7 @@ BufGenCmd::~BufGenCmd() { World_Free(mWorld, mData); }
 int BufGenCmd::Init(char* inData, int inSize) {
     mSize = inSize;
     mData = (char*)World_Alloc(mWorld, mSize);
+    ReturnSCErrIfNil(mData);
     memcpy(mData, inData, mSize);
 
     sc_msg_iter msg(mSize, mData);
@@ -444,6 +459,7 @@ int BufAllocReadCmd::Init(char* inData, int inSize) {
         mFilename = allocAndRestrictPath(mWorld, filename, mWorld->mRestrictedPath);
     } else {
         mFilename = (char*)World_Alloc(mWorld, strlen(filename) + 1);
+        ReturnSCErrIfNil(mFilename);
         strcpy(mFilename, filename);
     }
 
@@ -533,6 +549,7 @@ int BufReadCmd::Init(char* inData, int inSize) {
         mFilename = allocAndRestrictPath(mWorld, filename, mWorld->mRestrictedPath);
     } else {
         mFilename = (char*)World_Alloc(mWorld, strlen(filename) + 1);
+        ReturnSCErrIfNil(mFilename);
         strcpy(mFilename, filename);
     }
 
@@ -689,6 +706,7 @@ int BufAllocReadChannelCmd::Init(char* inData, int inSize) {
         mFilename = allocAndRestrictPath(mWorld, filename, mWorld->mRestrictedPath);
     } else {
         mFilename = (char*)World_Alloc(mWorld, strlen(filename) + 1);
+        ReturnSCErrIfNil(mFilename);
         strcpy(mFilename, filename);
     }
 
@@ -808,6 +826,7 @@ int BufReadChannelCmd::Init(char* inData, int inSize) {
         mFilename = allocAndRestrictPath(mWorld, filename, mWorld->mRestrictedPath);
     } else {
         mFilename = (char*)World_Alloc(mWorld, strlen(filename) + 1);
+        ReturnSCErrIfNil(mFilename);
         strcpy(mFilename, filename);
     }
 
@@ -958,6 +977,7 @@ int BufWriteCmd::Init(char* inData, int inSize) {
         mFilename = allocAndRestrictPath(mWorld, filename, mWorld->mRestrictedPath);
     } else {
         mFilename = (char*)World_Alloc(mWorld, strlen(filename) + 1);
+        ReturnSCErrIfNil(mFilename);
         strcpy(mFilename, filename);
     }
 
@@ -1242,9 +1262,11 @@ SendFailureCmd::~SendFailureCmd() {
 
 void SendFailureCmd::InitSendFailureCmd(const char* inCmdName, const char* inErrString) {
     mCmdName = (char*)World_Alloc(mWorld, strlen(inCmdName) + 1);
+    ThrowIfNil(mCmdName);
     strcpy(mCmdName, inCmdName);
 
     mErrString = (char*)World_Alloc(mWorld, strlen(inErrString) + 1);
+    ThrowIfNil(mErrString);
     strcpy(mErrString, inErrString);
 }
 
@@ -1269,6 +1291,7 @@ int RecvSynthDefCmd::Init(char* inData, int inSize) {
         throw kSCErr_WrongArgType;
 
     mBuffer = (char*)World_Alloc(mWorld, size);
+    ReturnSCErrIfNil(mBuffer);
     msg.getb(mBuffer, size);
 
     GET_COMPLETION_MSG(msg);
@@ -1312,6 +1335,7 @@ int LoadSynthDefCmd::Init(char* inData, int inSize) {
         mFilename = allocAndRestrictPath(mWorld, filename, mWorld->mRestrictedPath);
     } else {
         mFilename = (char*)World_Alloc(mWorld, strlen(filename) + 1);
+        ReturnSCErrIfNil(mFilename);
         strcpy(mFilename, filename);
     }
 
@@ -1356,6 +1380,7 @@ int LoadSynthDefDirCmd::Init(char* inData, int inSize) {
         mFilename = allocAndRestrictPath(mWorld, filename, mWorld->mRestrictedPath);
     } else {
         mFilename = (char*)World_Alloc(mWorld, strlen(filename) + 1);
+        ReturnSCErrIfNil(mFilename);
         strcpy(mFilename, filename);
     }
 
@@ -1391,6 +1416,7 @@ SendReplyCmd::SendReplyCmd(World* inWorld, ReplyAddress* inReplyAddress):
 int SendReplyCmd::Init(char* inData, int inSize) {
     mMsgSize = inSize;
     mMsgData = (char*)World_Alloc(mWorld, mMsgSize);
+    ReturnSCErrIfNil(mMsgData);
     memcpy(mMsgData, inData, inSize);
     return kSCErr_None;
 }
@@ -1411,6 +1437,7 @@ int PerformAsynchronousCommand(
     AsyncStageFn stage4, // stage4 is non real time - sends done if stage4 returns true
     AsyncFreeFn cleanup, int completionMsgSize, void* completionMsgData) {
     void* space = World_Alloc(inWorld, sizeof(AsyncPlugInCmd));
+    ReturnSCErrIfNil(space);
     AsyncPlugInCmd* cmd = new (space) AsyncPlugInCmd(inWorld, (ReplyAddress*)replyAddr, cmdName, cmdData, stage2,
                                                      stage3, stage4, cleanup, completionMsgSize, completionMsgData);
     if (!cmd)
@@ -1441,6 +1468,7 @@ AsyncPlugInCmd::AsyncPlugInCmd(
     if (completionMsgSize && completionMsgData) {
         mMsgSize = completionMsgSize;
         mMsgData = (char*)World_Alloc(mWorld, mMsgSize);
+        ThrowIfNil(mMsgData);
         memcpy(mMsgData, completionMsgData, mMsgSize);
     }
 }

--- a/server/scsynth/SC_SequencedCommand.h
+++ b/server/scsynth/SC_SequencedCommand.h
@@ -37,6 +37,8 @@
 
 #define CallSequencedCommand(T, inWorld, inSize, inData, inReply)                                                      \
     void* space = World_Alloc(inWorld, sizeof(T));                                                                     \
+    if (!space)                                                                                                        \
+        return kSCErr_OutOfRealTimeMemory;                                                                             \
     T* cmd = new (space) T(inWorld, inReply);                                                                          \
     if (!cmd)                                                                                                          \
         return kSCErr_Failed;                                                                                          \
@@ -388,6 +390,8 @@ protected:
 
 #define CallSendFailureCommand(inWorld, inCmdName, inErrString, inReply)                                               \
     void* space = World_Alloc(inWorld, sizeof(SendFailureCmd));                                                        \
+    if (!space)                                                                                                        \
+        return kSCErr_OutOfRealTimeMemory;                                                                             \
     SendFailureCmd* cmd = new (space) SendFailureCmd(inWorld, inReply);                                                \
     if (!cmd)                                                                                                          \
         return kSCErr_Failed;                                                                                          \

--- a/testsuite/classlibrary/TestUGen_RTAlloc.sc
+++ b/testsuite/classlibrary/TestUGen_RTAlloc.sc
@@ -1,0 +1,347 @@
+TestUGen_RTAlloc : UnitTest {
+
+	var server;
+
+	setUp {
+		server = Server(this.class.name);
+		server.options.memSize = 1024;
+		server.options.blockSize = 64;
+		this.bootServer(server);
+	}
+
+	tearDown {
+		server.quit.remove;
+	}
+
+	test_allocFail_clearUnit {
+		var cond = CondVar(), output = -1;
+		{ DelayN.ar(DC.ar(1), 100); }.loadToFloatArray(1 / server.sampleRate, server, {|val|
+			output = val[0];
+			cond.signalOne();
+		});
+
+		cond.waitFor(1, { output != -1 });
+		this.assertFloatEquals(output, 0.0, "a failed RTAlloc should clear unit outputs")
+	}
+
+	test_allocFail_continueProcessing_sameNode {
+		var cond = CondVar(), output = -1;
+		{ DelayN.ar(Silent.ar, 100); DC.ar(1)}.loadToFloatArray(1 / server.sampleRate, server, {|val|
+			output = val[0];
+			cond.signalOne();
+		});
+
+		cond.waitFor(1, { output != -1 });
+		this.assertFloatEquals(output, 1.0, "a failed RTAlloc should not block other units in the same node")
+	}
+
+	test_allocFail_continueProcessing_otherNodes {
+		var cond = CondVar(), output = -1;
+		server.makeBundle(nil) {
+			{ DelayN.ar(Silent.ar, 100) }.play(server);
+			{ DC.ar(1) }.loadToFloatArray(1 / server.sampleRate, server, {|val|
+				output = val[0];
+				cond.signalOne();
+			});
+		};
+
+		cond.waitFor(1, { output != -1 });
+		this.assertFloatEquals(output, 1.0, "a failed RTAlloc should not block other nodes in the processing chain")
+	}
+
+	test_allocFail_setDoneFlag {
+		var cond = CondVar(), output = -1;
+		{
+			K2A.ar(Done.kr(DelayN.ar(Silent.ar, 100)))
+		}.loadToFloatArray(1 / server.sampleRate, server, {|val|
+			output = val[0];
+			cond.signalOne();
+		});
+
+		cond.waitFor(1, { output != -1 });
+		this.assertFloatEquals(output, 1.0, "a failed RTAlloc should set the Done flag")
+	}
+
+	// TEST ALL UGENS
+	// for each UGen in /server/plugins which calls RTAlloc
+	// test successful alloc: should output non-zero values
+	// test failed alloc: should only output zeros
+
+	// FFT UGens needs separate testing (see below)
+	// Some UGens were left out (see end of file)
+
+	test_allUGens {
+
+		var getDelayTest = { |ugen| { ugen.ar(DC.ar(1), 1, 0) } };
+
+		var ugenTests = (
+			AllpassC: getDelayTest.value(AllpassC),
+			AllpassL: getDelayTest.value(AllpassL),
+			AllpassN: getDelayTest.value(AllpassN),
+			CombC: getDelayTest.value(CombC),
+			CombL: getDelayTest.value(CombL),
+			CombN: getDelayTest.value(CombN),
+			DelayC: getDelayTest.value(DelayC),
+			DelayL: getDelayTest.value(DelayL),
+			DelayN: getDelayTest.value(DelayN),
+			Pluck: { Pluck.ar(DC.ar(1), 1, 1, 0.001) },
+			Pitch: { K2A.ar(Pitch.kr(SinOsc.ar, execFreq:1)[0]).round },
+
+			RunningSum: { RunningSum.ar(DC.ar(1), 2**12) },
+
+			Convolution: { Convolution.ar(DC.ar(1), DC.ar(1), 2**6) },
+			Convolution2: { Convolution2.ar(DC.ar(1), LocalBuf(2**6), 1, 2**6) },
+			Convolution2L: { Convolution2L.ar(DC.ar(1), LocalBuf(2**6), 1, 2**6) },
+			Convolution3: { Convolution3.ar(DC.ar(1), LocalBuf(2**8), 1, 2**8) },
+			StereoConvolution2L: {
+				StereoConvolution2L.ar(DC.ar(1), LocalBuf(2**6), LocalBuf(2**6), 1, 2**6)
+			},
+			GrainBuf: {
+				GrainBuf.ar(1, Impulse.kr(1000), 1, LocalBuf(1).set(1), maxGrains:1024)
+			},
+			GrainFM: { GrainFM.ar(1, Impulse.kr(1000), 1, maxGrains: 1024) },
+			GrainIn: { GrainIn.ar(1, Impulse.kr(1000), in:DC.ar(1), maxGrains:1024) },
+			GrainSin: { GrainSin.ar(1, Impulse.kr(1000), maxGrains: 1024) },
+
+			Gendy1: { Gendy1.ar(initCPs: 1024) },
+			Gendy2: { Gendy2.ar(initCPs: 1024) },
+			Gendy3: { Gendy3.ar(initCPs: 1024) },
+
+			IFFT: { IFFT(LocalBuf(2**9)) },
+			SpecPcile: { K2A.ar(SpecPcile.kr(LocalBuf(2**10))) },
+
+			// GVerb needs more tests, as it can fail multiple ways
+			GVerb: { GVerb.ar(DC.ar(1), 10) }
+		);
+
+		var longerRuntimeUGens = (
+			// these requires 0.02 seconds to run != 0
+			Limiter: { Limiter.ar(DC.ar(1), dur: 0.01) },
+			Normalizer: { Normalizer.ar(DC.ar(1), dur: 0.01) },
+			KeyTrack: { KeyTrack.kr(FFT(LocalBuf(2**10), SinOsc.ar, 0.25), 0, 0) },
+			BeatTrack2: { BeatTrack2.kr(FFT(LocalBuf(2**8)), 10) },
+			PitchShift: { PitchShift.ar(SinOsc.ar, 0.01) }, // here 0.01s would be fine
+			// Warning: not really testing allocFail here, because FFT fails first
+			// however, we need the extra runtime for allocPass to work
+			Onsets: { K2A.ar(Onsets.kr(FFT(LocalBuf(2**8), Impulse.ar(1)))) }
+		);
+
+		var onlyPassUGens = (
+			// Couldn't reliably test allocFail on these:
+			IEnvGen: { IEnvGen.ar(Env([1,1]), 0) },
+			PanAz: { PanAz.ar(12, DC.ar(1)) },
+			Klank: { Klank.ar(`[100!12, nil, 1], DC.ar(1)) },
+			Klang: { Klang.ar(`[100!12, nil, 1]) },
+			Dshuf: { Demand.ar(DC.ar(1),0, Dshuf(1!12)) },
+			// hard to make these fail before LocalBuf or FFT fails
+			Loudness: { K2A.ar(Loudness.kr(FFT(LocalBuf(2**8), SinOsc.ar))) },
+			BeatTrack: { K2A.ar(BeatTrack.kr(FFT(LocalBuf(2**8)))) },
+			MFCC: { K2A.ar(MFCC.kr(FFT(LocalBuf(2**8)), 60)) }
+		);
+
+		// test fuctions:
+
+		// function to alloc LocalBuf to fill realtime memory:
+		// maxFrames = memSizeBytes / frameBytes = 1024 * 1000 / 4
+		var fillMemFunc = { LocalBuf(1024 * 1000 / 4) };
+
+		var testAllocPass = { |name, func, runtime = 0.001|
+			var cond = CondVar(), nonZeroOut = nil;
+			func.loadToFloatArray(runtime, server) { |out|
+				nonZeroOut = out.sum != 0;
+				cond.signalOne();
+			};
+			cond.waitFor(1) { nonZeroOut.notNil };
+			if (nonZeroOut.notNil) {
+				this.assert(nonZeroOut,
+					"% allocPass test should produce non-zero output".format(name)
+				);
+			} {
+				this.assert(false, "% allocPass test should complete".format(name));
+			}
+		};
+
+		var testAllocFail = { |name, func, runtime = 0.001|
+			var cond = CondVar(), zeroOut = nil;
+			func.loadToFloatArray(runtime, server) { |out|
+				zeroOut = out.sum == 0;
+				cond.signalOne();
+			};
+			cond.waitFor(1) { zeroOut.notNil };
+			if (zeroOut.notNil) {
+				this.assert(zeroOut,
+					"% allocFail test should produce zero output".format(name.asString)
+				);
+			} {
+				this.assert(false, "% allocFail test should complete".format(name.asString));
+			}
+		};
+
+		// special test for PartConv: requires buffer alloc
+		var partConvTest = {
+			var b = Buffer.loadCollection(server, 1!(2**9));
+			var testFunc = { PartConv.ar(DC.ar(1), 2**8, b) };
+			var memFill;
+			server.sync;
+			testAllocPass.value("PartConv", testFunc, 0.1);
+			memFill = fillMemFunc.play(server);
+			testAllocFail.value("PartConv", testFunc, 0.1);
+			memFill.free;
+		};
+
+		var memFill;
+
+		// RUN TESTS
+
+		ugenTests.keysValuesDo {|name, func|
+			testAllocPass.value(name.asString, func, 0.001);
+		};
+
+		onlyPassUGens.keysValuesDo {|name, func|
+			testAllocPass.value(name.asString, func, 0.001);
+		};
+
+		longerRuntimeUGens.keysValuesDo {|name, func|
+			testAllocPass.value(name.asString, func, 0.02);
+		};
+
+		// now fill mem and test allocFail
+		memFill = fillMemFunc.play(server);
+
+		ugenTests.keysValuesDo {|name, func|
+			testAllocFail.value(name.asString, func, 0.001);
+		};
+
+		longerRuntimeUGens.keysValuesDo {|name, func|
+			testAllocFail.value(name.asString, func, 0.02);
+		};
+
+		memFill.free;
+		// now test PartConv
+		partConvTest.value;
+
+	}
+
+	// special test for LocalBuf alloc
+	test_LocalBuf {
+		var oneFrame = server.sampleRate.reciprocal;
+		var completed = nil, cond = CondVar();
+		{ K2A.ar(LocalBuf(512)) }.loadToFloatArray(oneFrame, server) { |out|
+			this.assert(out[0] > -1, "should allocate a valid LocalBuf");
+			completed = true;
+			cond.signalOne;
+		};
+		cond.waitFor(1) { completed.notNil };
+		if (completed.isNil) {
+			this.assert(false, "successful alloc test should complete");
+		};
+		completed = nil;
+		{ K2A.ar(LocalBuf(2**20)) }.loadToFloatArray(oneFrame, server) { |out|
+			this.assertFloatEquals(out[0], -1, "should return -1 on alloc fail");
+			completed = true;
+			cond.signalOne;
+		};
+		cond.waitFor(1) { completed.notNil };
+		if (completed.isNil) {
+			this.assert(false, "failed alloc test should complete");
+		};
+	}
+
+	// FFT UGens
+	// Test FFT and PV UGens using RTAlloc
+
+	// FFT should return always -1 when alloc fails
+	test_FFT {
+		var completed = nil, cond = CondVar();
+		var runtime = 2**9 / server.sampleRate / 4;
+		{ FFT(LocalBuf(2**9), DC.ar(1), 0.25) }.loadToFloatArray(runtime, server) { |out|
+			this.assert(out.any(_ > 0), "should return a valid bufnum");
+			completed = true;
+			cond.signalOne;
+		};
+		cond.waitFor(runtime + 1) { completed.notNil };
+		if (completed.isNil) {
+			this.assert(false, "successful alloc test should complete");
+		};
+		completed = nil;
+		runtime = 2**18 / server.sampleRate / 4;
+		{ FFT(LocalBuf(2**18), DC.ar(1), 0.25) }.loadToFloatArray(runtime, server) { |out|
+			this.assert(out.every(_ == (-1)), "should only return -1 on alloc fail");
+			completed = true;
+			cond.signalOne;
+		};
+		cond.waitFor(runtime + 1) { completed.notNil };
+		if (completed.isNil) {
+			this.assert(false, "failed alloc test should complete");
+		};
+	}
+
+	// PV_UGens
+	// we need to call .drop(1) on UGen output when testing
+	// because all these UGens just output their input for the first block, without calling _next
+	// (thus returning the valid bufnum even for failed allocations)
+	test_PVUGens {
+		var smallBuf = Buffer.alloc(server, 2**9);
+		var bigBuf = Buffer.alloc(server, 2**19);
+
+		var testAllocPass = { |ugen, testFunc|
+			var completed = nil, cond = CondVar();
+			testFunc.loadToFloatArray(0.1, server) { |out|
+				var noneIsInvalid = out.drop(1).any(_ == (-1)).not;
+				this.assert(noneIsInvalid,
+					"% successful alloc should return a valid bufnum".format(ugen)
+				);
+				completed = true;
+				cond.signalOne;
+			};
+			cond.waitFor(1) { completed.notNil };
+			if (completed.isNil) {
+				this.assert(false, "% successful alloc test should complete".format(ugen));
+			};
+		};
+
+		var testAllocFail = { |ugen, testFunc|
+			var completed = nil, cond = CondVar();
+			testFunc.loadToFloatArray(0.1, server) { |out|
+				var allInvalid = out.drop(1).every(_ == (-1));
+				this.assert(allInvalid,
+					"% should only return -1 on alloc fail".format(ugen)
+				);
+				completed = true;
+				cond.signalOne;
+			};
+			cond.waitFor(1) { completed.notNil };
+			if (completed.isNil) {
+				this.assert(false, "% failed alloc test should complete".format(ugen));
+			};
+		};
+
+		server.sync;
+
+		[PV_RandComb, PV_Diffuser, PV_MagFreeze, PV_BinScramble].do { |ugen|
+			testAllocPass.value(ugen, { ugen.value.new(smallBuf) });
+			testAllocFail.value(ugen, { ugen.value.new(bigBuf) });
+		};
+
+		testAllocPass.value(PV_RandWipe, {PV_RandWipe(smallBuf, smallBuf)});
+		testAllocFail.value(PV_RandWipe, {PV_RandWipe(bigBuf, bigBuf)});
+	}
+
+}
+
+
+/*
+// These UGens are left out:
+
+// MaxLocalBufs is delicate, can leak when calling .increment alone
+// { m = MaxLocalBufs(); 128.do{ m.increment } }.play
+
+// AudioControl, Demand, LocalIn (memory depends on numOutputs)
+// LagControl, OffsetOut, Out (memory depends on numInputs)
+// difficult to fail alloc before "exceeded number of interconnect buffers"
+
+// Poll, Dpoll, SendReply
+// memory depends on string size
+// difficult to allocFail before /s_new out of real time memory
+// {Duty.kr(0.5, 0, Dpoll(Dseq([1], inf), String.fill(400000, $a)))}.play
+*/


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation
This PR is backed by a RFC: https://github.com/supercollider/rfcs/pull/18

Fixes #3563 and #5634
Partially fixes #782 (sc3-plugins are not affected)

If real time allocation fails during a UGen constructor, an exception is thrown and the enclosing synth can't exit a loop trying to construct all its UGens over and over again, possibly leading to memory leaks. During the discussion, it was proposed to remove the throwing mechanism entirely, mainly because incompatible with plugin boundaries (sorry for the sloppy terminology here, for more details, please see the RFC).

This PR follows the program from the RFC:
NOTE: turns out `RTFree` doesn't need extra NULL checks, as they are already included in `AllocPool:Free`. The new macro `RTFreeSafe` proposed in the RFC is thus omitted.
- [x] Remove the throw from `RTAlloc`, return `NULL` instead
- [x] Handle possible `NULL` returns and eventually re-throw an exception in all places in `sclang` and `scsynth` where it's relevant
- [x] Introduce macros for safer `RTAlloc`, implement them in all server plugins, everywhere `RTAlloc` or `scfft_create` are used. The new macros are:
- `ClearUnitOnMemFailed`: disables unit's processing function, sets `mDone=true`, prints a nice error message and returns from the enclosing function (to exit early from Ctors when RTAlloc fails)
- `ClearUnitIfMemFailed`: calls the previous macro if the passed pointer is NULL. Can be used passing multiple pointers by chaining them with `&&` operator.
- [x] Update documentation for devs and plugin writers

## Types of changes

- Bug fix
- Documentation

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [ ] Code is tested
- [ ] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review
