### PR TITLE
classlib: fix Server.remote startAliveThread

### DIFF
--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -389,7 +389,8 @@ Server {
 	}
 
 	*remote { |name, addr, options, clientID|
-		^this.new(name, addr, options, clientID).connectToServerAddr({ this.startAliveThread })
+		var remoteServer = this.new(name, addr, options, clientID);
+		^remoteServer.connectToServerAddr({ remoteServer.startAliveThread })
 	}
 
 	init { |argName, argAddr, argOptions, argClientID|


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

After commit c3301b8b0573ee1329210766505612e0be4260f2, `Server.remote` is broken. At this line:
https://github.com/supercollider/supercollider/blob/c3301b8b0573ee1329210766505612e0be4260f2/SCClassLibrary/Common/Control/Server.sc#L392
`this` is evaluated as `Server`, the class, instead of the newly created instance, resulting in `^^ ERROR: Message 'startAliveThread' not understood. RECEIVER: Server`

Before this PR, test `Server_clientID_booted:test_remoteLogin` was failing, which is not anymore the case.

## Types of changes

<!-- Delete lines that don't apply -->
- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] This PR is ready for review
