### PR TITLE
testsuite: fix NodeProxy ar mapping test

### DIFF
--- a/testsuite/classlibrary/TestNodeProxy.sc
+++ b/testsuite/classlibrary/TestNodeProxy.sc
@@ -297,6 +297,7 @@ TestNodeProxyBusMapping : UnitTest {
 
 	setUp {
 		server = Server(this.class.name);
+		server.latency = 0.1;
 		this.bootServer(server);
 		server.sync;
 	}
@@ -307,7 +308,7 @@ TestNodeProxyBusMapping : UnitTest {
 	}
 
 	test_audiorate_mapping {
-		var proxy, controlProxy;
+		var proxy, inputProxy;
 		var synthValues, controlValues, defaultValues;
 
 		defaultValues = [-1.0, -2.0];
@@ -322,8 +323,8 @@ TestNodeProxyBusMapping : UnitTest {
 			A2K.kr(in);
 		};
 
-		controlProxy = NodeProxy(server, \control);
-		controlProxy.source = {
+		inputProxy = NodeProxy(server, \audio);
+		inputProxy.source = {
 			DC.ar(controlValues)
 		};
 
@@ -335,9 +336,9 @@ TestNodeProxyBusMapping : UnitTest {
 
 		this.assertEquals(synthValues, defaultValues, "before mapping, synth values should be default values");
 
-		proxy <<>.in controlProxy;
+		proxy <<>.in inputProxy;
 
-		0.3.wait;
+		0.2.wait;
 
 		synthValues = server.getControlBusValues(proxy.bus.index, proxy.numChannels);
 
@@ -347,7 +348,7 @@ TestNodeProxyBusMapping : UnitTest {
 	}
 
 	test_audiorate_mapping_elasticity {
-		var proxy, controlProxy;
+		var proxy, inputProxy;
 		var synthValues, controlValues, defaultValues;
 
 		defaultValues = [-1.0, -2.0, -3.0];
@@ -362,10 +363,10 @@ TestNodeProxyBusMapping : UnitTest {
 			A2K.kr(in);
 		};
 
-		controlProxy = NodeProxy(server, \audio, 2);
-		controlProxy.reshaping = \elastic;
-		controlProxy.fadeTime = 0.001;
-		controlProxy.source = {
+		inputProxy = NodeProxy(server, \audio, 2);
+		inputProxy.reshaping = \elastic;
+		inputProxy.fadeTime = 0.001;
+		inputProxy.source = {
 			DC.ar(controlValues)
 		};
 
@@ -378,7 +379,7 @@ TestNodeProxyBusMapping : UnitTest {
 
 		this.assertEquals(synthValues.round, defaultValues.round, "before mapping, synth values should be default values");
 
-		proxy <<>.in controlProxy;
+		proxy <<>.in inputProxy;
 
 		0.2.wait;
 

--- a/testsuite/scripts/gha_test_run_proto.json
+++ b/testsuite/scripts/gha_test_run_proto.json
@@ -77,18 +77,6 @@
             "skipReason":"UnitTest fails (FIXME)"
         },
         {
-            "suite":"TestNodeProxyBusMapping",
-            "test":"test_audiorate_mapping",
-            "skip":true,
-            "skipReason":"UnitTest fails (FIXME)"
-        },
-        {
-            "suite":"TestNodeProxyBusMapping",
-            "test":"test_audiorate_mapping_elasticity",
-            "skip":true,
-            "skipReason":"UnitTest fails (FIXME)"
-        },
-        {
             "suite":"TestNodeProxyRoles",
             "test":"test_proxyroles_xfade_smoothly",
             "skip":true,


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

Fix what looks like a typo in `TestNodeProxyBusMapping:test_audiorate_mapping`.

I think control proxy for this test should be audio rate, for the mapping to be audio rate. Other than this, having it control rate with no `numChannels` specified makes it mixed down to mono by default, creating the discrepancy that makes this test impossible to pass. Initializing `controlProxy` as `\audio` fixes it.

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] This PR is ready for review
