### PR TITLE
testsuite: Document: add missing skips

### DIFF
--- a/testsuite/classlibrary/TestDocument.sc
+++ b/testsuite/classlibrary/TestDocument.sc
@@ -59,7 +59,6 @@ TestDocument : UnitTest {
 
 	test_document_getText_retrievesText {
 		var doc, str;
-		this.assert(Platform.ideName == "scqt", "Document tests are valid only when run in the IDE");
 		if (Platform.ideName == "scqt") {
 			doc = Document(string: "abc");
 			str = doc.getText;
@@ -73,7 +72,6 @@ TestDocument : UnitTest {
 	test_document_getTextAsync_retrievesText {
 		var doc, str,
 		cond = Condition.new;
-		this.assert(Platform.ideName == "scqt", "Document tests are valid only when run in the IDE");
 		if (Platform.ideName == "scqt") {
 			doc = Document(string: "abc");
 			doc.getTextAsync({ |text|

--- a/testsuite/classlibrary/TestDocument.sc
+++ b/testsuite/classlibrary/TestDocument.sc
@@ -60,23 +60,31 @@ TestDocument : UnitTest {
 	test_document_getText_retrievesText {
 		var doc, str;
 		this.assert(Platform.ideName == "scqt", "Document tests are valid only when run in the IDE");
-		doc = Document(string: "abc");
-		str = doc.getText;
-		doc.close;
-		this.assertEquals(str, "abc", "getText contents retrieved from document should match input contents");
+		if (Platform.ideName == "scqt") {
+			doc = Document(string: "abc");
+			str = doc.getText;
+			doc.close;
+			this.assertEquals(str, "abc", "getText contents retrieved from document should match input contents");
+		} {
+			// TODO: skip
+		}
 	}
 
 	test_document_getTextAsync_retrievesText {
 		var doc, str,
 		cond = Condition.new;
 		this.assert(Platform.ideName == "scqt", "Document tests are valid only when run in the IDE");
-		doc = Document(string: "abc");
-		doc.getTextAsync({ |text|
-			str = text;
-			cond.unhang;
-		}, 0, -1);
-		cond.hang;
-		doc.close;
-		this.assertEquals(str, "abc", "getTextAsync contents retrieved from document should match input contents");
+		if (Platform.ideName == "scqt") {
+			doc = Document(string: "abc");
+			doc.getTextAsync({ |text|
+				str = text;
+				cond.unhang;
+			}, 0, -1);
+			cond.hang;
+			doc.close;
+			this.assertEquals(str, "abc", "getTextAsync contents retrieved from document should match input contents");
+		} {
+			// TODO: skip
+		}
 	}
 }


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

Fixes errors occurring while testing the Document class outside the IDE. 

`Document` is not defined outside the IDE, so UnitTests needs to skip, and most of them do. This PR adds a few missing skips.

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] This PR is ready for review
