### PR TITLE
server: LIB_SUFFIX should be STRING, not BOOL

### DIFF
--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -4,7 +4,7 @@ if (NOT APPLE AND NOT WIN32)
 endif()
 
 if(UNIX AND NOT APPLE)
-	option(LIB_SUFFIX "Install plugins to suffixed lib directory: eg. `64` for `lib64`")
+	set(LIB_SUFFIX "" CACHE STRING "Install plugins to suffixed lib directory: eg. `64` for `lib64`")
 	set(LINUX_SC_PLUGIN_DIR ${CMAKE_INSTALL_PREFIX}/lib${LIB_SUFFIX}/SuperCollider/plugins)
 endif()
 


### PR DESCRIPTION
## Purpose and Motivation

after ee2aba7984fcb50a6a29093e2d97e52f5939fa63 `LIB_SUFFIX` was defined using  `option`, and thus as a boolean option with a default value of `OFF`. 
This incorrectly caused the default search path for plugins to be `/CMAKE_INSTALL_PREFIX/libOFF`. As a consequences, scsynth wouldn't find `sc3-plugins` anymore, if they were built and installed from source.

Fixed by using `set` instead of `option`.

References:
https://cmake.org/cmake/help/latest/command/option.html
https://cmake.org/cmake/help/latest/command/set.html#set-cache-entry

## Types of changes


- Bug fix

## To-do list

- [x] This PR is ready for review
