### PR TITLE
GHA: update macOS system libraries build

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -212,7 +212,7 @@ jobs:
           - job-name: 'use system libraries'
             os-version: '10.15'
             xcode-version: '11.7'
-            deployment-target: '10.13'
+            deployment-target: '10.15'
             use-syslibs: true
             shared-libscsynth: false
 


### PR DESCRIPTION


<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

In GitHub Actions current "macOS system libraries" builds fail, most likely due to requesting compatibility with the older deployment target than what the system libraries provide. This PR should fix this failure.

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix


## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review
