### PR TITLE
CMake: identify detached head state when describing repository branch/tag/commit

### DIFF
--- a/SCVersion.txt
+++ b/SCVersion.txt
@@ -28,10 +28,11 @@ if(EXISTS "${CMAKE_SOURCE_DIR}/.git")
   
   if(GIT_BRANCH_OR_TAG STREQUAL "HEAD")
     execute_process(
-      COMMAND git describe --tags 2>/dev/null
+      COMMAND git describe --tags
       WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
       OUTPUT_VARIABLE GIT_BRANCH_OR_TAG
       OUTPUT_STRIP_TRAILING_WHITESPACE
+      ERROR_QUIET
     )
     if(GIT_BRANCH_OR_TAG STREQUAL "")
       set(GIT_REF_TYPE "detached")

--- a/SCVersion.txt
+++ b/SCVersion.txt
@@ -27,13 +27,18 @@ if(EXISTS "${CMAKE_SOURCE_DIR}/.git")
   set(GIT_REF_TYPE "branch")
   
   if(GIT_BRANCH_OR_TAG STREQUAL "HEAD")
-    set(GIT_REF_TYPE "tag")
     execute_process(
-      COMMAND git describe --tags
+      COMMAND git describe --tags 2>/dev/null
       WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
       OUTPUT_VARIABLE GIT_BRANCH_OR_TAG
       OUTPUT_STRIP_TRAILING_WHITESPACE
     )
+    if(GIT_BRANCH_OR_TAG STREQUAL "")
+      set(GIT_REF_TYPE "detached")
+      set(GIT_BRANCH_OR_TAG "HEAD")
+    else()
+      set(GIT_REF_TYPE "tag")
+    endif()
   endif()
 
   execute_process(


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

I noticed that builds in the PRs are not on the tip of the branch and thus are not properly described in CMake and in the "about" window of the build from the PR (see [here](https://github.com/supercollider/supercollider/runs/5383960643?check_suite_focus=true#step:8:20) and [here](https://github.com/supercollider/supercollider/runs/5383961277?check_suite_focus=true#step:11:36))

This PRs aims to handle this case by [reporting](https://github.com/supercollider/supercollider/runs/5384387513?check_suite_focus=true#step:8:33) `building from detached HEAD, commit ...`

The implementation is arguably not the prettiest, i'm open to suggestions. 

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review
