### PR TITLE
NEW Vim like keyshortcuts in HelpBrowser

### DIFF
--- a/SCClassLibrary/Common/GUI/Base/QWebView.sc
+++ b/SCClassLibrary/Common/GUI/Base/QWebView.sc
@@ -255,6 +255,19 @@ WebView : View {
 	scrollPosition { ^this.getProperty('scrollPosition') }
 	scrollPosition_ { |point| ^this.setProperty('scrollPosition', point / this.zoom) }
 
+	scrollUp { |value|
+		this.scrollDown(value.neg)
+	}
+
+	scrollDown { |value|
+		var position = this.scrollPosition;
+		this.scrollPosition_(
+			Point(
+				position.x,
+				(position.y + value).clip(0, this.contentsSize.height - this.bounds.height)
+			)
+		);
+	}
 	audioMuted { ^this.getProperty('audioMuted') }
 	audioMuted_ { |muted| this.setProperty('audioMuted', muted) }
 

--- a/SCClassLibrary/Common/GUI/tools/HelpBrowser.sc
+++ b/SCClassLibrary/Common/GUI/tools/HelpBrowser.sc
@@ -119,6 +119,10 @@ HelpBrowser {
 
 	goForward { webView.forward; }
 
+	goDown { webView.scrollDown(40); }
+
+	goUp { webView.scrollUp(40); }
+
 /* ------------------------------ private ------------------------------ */
 
 	init { arg aHomeUrl, aNewWin;
@@ -273,7 +277,9 @@ HelpBrowser {
 		webView.enterInterpretsSelection = true;
 
 		window.view.keyDownAction = { arg view, char, mods, uni, kcode, key;
-			var keyPlus, keyZero, keyMinus, keyEquals, keyF;
+			var keyPlus, keyZero, keyMinus, keyEquals, keySlash;
+			var keyD, keyU, keyF, keyG, keyH, keyJ, keyK, keyL;
+			var keyF3, keyF5, keyLeftArrow, keyRightArrow;
 			var modifier, zoomIn;
 
 			modifier = Platform.case(\osx, {
@@ -282,34 +288,73 @@ HelpBrowser {
 				mods.isCtrl && mods.isCmd.not && mods.isAlt.not;
 			});
 
-			#keyPlus, keyZero, keyMinus, keyEquals, keyF = [43, 48, 45, 61, 70];
+			#keyPlus, keyZero, keyMinus, keyEquals, keySlash = [43, 48, 45, 61, 47];
+			#keyD, keyF, keyG, keyH, keyJ, keyK, keyL, keyU, keyF3, keyF5 = [68, 70, 71, 72, 74, 75, 76, 85];
+			#keyF3, keyF5 = [65472, 65474];
+			#keyLeftArrow, keyRightArrow = [65361, 65363];
 
 			// +/= has the same value on macOS when pressed with <Cmd>
 			zoomIn = Platform.case(\osx, {
-				(key == keyEquals) && modifier;
+				((key == keyEquals) && modifier) || ((key == keyK) && mods.isShift);
 			}, {
-				(key == keyPlus) && modifier;
+				((key == keyPlus) && modifier) || ((key == keyK) && mods.isShift);
 			});
 
-			if (zoomIn) {
-				webView.zoom = min(webView.zoom + 0.1, 2.0);
-			};
-
-			if ((key == keyMinus) && modifier) {
-				webView.zoom = max(webView.zoom - 0.1, 0.1);
-			};
-
-			if ((key == keyZero) && modifier) {
-				webView.zoom = 1.0;
-			};
-
-			if ((key == keyF) && modifier) {
-				toggleFind.value;
-			};
-
-			if (char.ascii == 27) { // Esc
-				if (findView.visible) { toggleFind.value };
-			};
+			case(
+				{ zoomIn }, {
+					webView.zoom = min(webView.zoom + 0.1, 2.0);
+				},
+				{ (key == keyMinus) && modifier }, {
+					webView.zoom = max(webView.zoom - 0.1, 0.1)
+				},
+				{ (key == keyZero) && modifier }, {
+					webView.zoom = 1.0
+				},
+				{ (key == keyF && modifier) || (key == keySlash) }, {
+					toggleFind.value
+				},
+				{ key == keyG }, {
+					if (mods.isShift) {
+						webView.scrollPosition_(0@(webView.contentsSize.height - webView.bounds.height))
+					} {
+						webView.scrollPosition_(0@0)
+					}
+				},
+				{ key == keyD && mods.isCtrl }, {
+					webView.scrollDown(350)
+				},
+				{ key == keyU && mods.isCtrl }, {
+					webView.scrollUp(350)
+				},
+				{ key == keyJ }, {
+					if (mods.asBoolean.not) {
+						this.goDown
+					};
+					if (mods.isShift) {
+						webView.zoom = max(webView.zoom - 0.1, 0.1)
+					};
+				},
+				{ key == keyK }, {
+					if (mods.asBoolean.not) {
+						this.goUp
+					};
+				},
+				{ (key == keyH) || ((kcode == keyLeftArrow) && mods.isAlt) }, {
+					this.goBack
+				},
+				{ (key == keyL) || ((kcode == keyRightArrow) && mods.isAlt) }, {
+					this.goForward
+				},
+				{ kcode == keyF5 }, {
+					this.goTo(webView.url)
+				},
+				{ kcode == keyF3 }, {
+					this.goTo(SCDoc.helpTargetUrl++"/Search.html");
+				},
+				{ (char.ascii == 27) && findView.visible }, {
+					toggleFind.value
+				}
+			);
 		};
 
 		toolbar[\Back].action = { this.goBack };

--- a/SCClassLibrary/Common/GUI/tools/HelpBrowser.sc
+++ b/SCClassLibrary/Common/GUI/tools/HelpBrowser.sc
@@ -2,6 +2,8 @@ HelpBrowser {
 	classvar singleton;
 	classvar <>defaultHomeUrl;
 	classvar <>openNewWindows = false;
+	classvar <>scrollStep = 40;
+	classvar <>scrollPageStep = 350;
 
 	var <>homeUrl;
 	var <window;
@@ -119,9 +121,9 @@ HelpBrowser {
 
 	goForward { webView.forward; }
 
-	goDown { webView.scrollDown(40); }
+	goDown { webView.scrollDown(HelpBrowser.scrollStep); }
 
-	goUp { webView.scrollUp(40); }
+	goUp { webView.scrollUp(HelpBrowser.scrollStep); }
 
 /* ------------------------------ private ------------------------------ */
 
@@ -321,10 +323,10 @@ HelpBrowser {
 					}
 				},
 				{ key == keyD && mods.isCtrl }, {
-					webView.scrollDown(350)
+					webView.scrollDown(HelpBrowser.scrollPageStep)
 				},
 				{ key == keyU && mods.isCtrl }, {
-					webView.scrollUp(350)
+					webView.scrollUp(HelpBrowser.scrollPageStep)
 				},
 				{ key == keyJ }, {
 					if (mods.asBoolean.not) {


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation
Users of fantastic scnvim plugin in neovim can choose pandoc version of helpfiles, or classic style, which uses ```HelpBrowser``` class. For those, which are using a classic helpdoc this PR adds some VIM like keystrokes for comfortable browsing documentation. I've found it very useful and handy, code is tested & working on Linux.

the new keys are:
* h,j,k,l - back histo,down, up, forward histo
* ctrl + D, ctrl + U - bigger step scroll down, up
* g,G - go to top, to bottom of document
* J,K - zoom out, zoom in
* F3 - go to main Search page
* F5 - reload page
* / - search page
* alt + leftArrow, alt + rightArrow - back histo, forward histo

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->

- New feature


## To-do list
This needs to be checked on other than Linux platforms.
<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [ ] Code is tested
- [ ] All tests are passing
- [ ] Updated documentation
- [ ] This PR is ready for review
