### PR TITLE
class library: loadRelative – improve behaviour of error

### DIFF
--- a/SCClassLibrary/Common/Collections/String.sc
+++ b/SCClassLibrary/Common/Collections/String.sc
@@ -391,20 +391,20 @@ String[char] : RawArray {
 	}
 	loadRelative { arg warn = true, action;
 		var path = thisProcess.nowExecutingPath;
-		if(path.isNil) { Error("can't load relative to an unsaved file").throw};
+		if(path.isNil) { Error("can't load relative to an unsaved file.\nPath to resolve: \"%\"\n".format(this)).throw };
 		if(path.basename == this) { Error("should not load a file from itself").throw };
 		^(path.dirname ++ thisProcess.platform.pathSeparator ++ this).loadPaths(warn, action)
 	}
 	resolveRelative {
 		var path, caller;
 		caller = thisMethod.getBackTrace.caller.functionDef;
-		if(caller.isKindOf(Method) && (caller != Interpreter.findMethod(\interpretPrintCmdLine)), {
+		if(caller.isKindOf(Method) && (caller != Interpreter.findMethod(\interpretPrintCmdLine))) {
 			path = caller.filenameSymbol.asString;
-		}, {
+		} {
 			path = thisProcess.nowExecutingPath;
-		});
-		if(this[0] == thisProcess.platform.pathSeparator, {^this});
-		if(path.isNil) { Error("can't resolve relative to an unsaved file").throw};
+		};
+		if(this[0] == thisProcess.platform.pathSeparator) { ^this };
+		if(path.isNil) { Error("can't resolve relative to an unsaved file.\nPath to resolve: \"%\"\n".format(this)).throw };
 		^(path.dirname ++ thisProcess.platform.pathSeparator ++ this)
 	}
 	include {


### PR DESCRIPTION
When a file is unsaved or a path can't be found for other reasons, `loadRelative` and `resolveRelative` warn the user. So far, they have thrown an error, but it seems better to warn with more details and bail out instead.


## Types of changes

<!-- Delete lines that don't apply -->

- New feature
- Breaking change (possibly)

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] This PR is ready for review
