### PR TITLE
[3.12 branch] Git submodules: update urls to use https

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,12 +1,12 @@
 [submodule "external_libraries/nova-simd"]
 	path = external_libraries/nova-simd
-	url = git://github.com/timblechmann/nova-simd.git
+	url = https://github.com/timblechmann/nova-simd.git
 [submodule "external_libraries/nova-tt"]
 	path = external_libraries/nova-tt
-	url = git://github.com/timblechmann/nova-tt.git
+	url = https://github.com/timblechmann/nova-tt.git
 [submodule "external_libraries/hidapi"]
 	path = external_libraries/hidapi
-	url = git://github.com/supercollider/hidapi.git
+	url = https://github.com/supercollider/hidapi.git
 [submodule "editors/scvim"]
 	path = editors/scvim
 	url = https://github.com/supercollider/scvim.git


### PR DESCRIPTION


<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

This will make pulling 3.12 branch possible again. We are just adding the single commit without creating a new tag/release. See https://github.com/supercollider/supercollider/issues/5695#issuecomment-1100920416 for previous discussion.

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] This PR is ready for review
