### PR TITLE
libsndfile: use a macro instead of redefining the struct

### DIFF
--- a/include/plugin_interface/SC_SndBuf.h
+++ b/include/plugin_interface/SC_SndBuf.h
@@ -22,7 +22,7 @@
 
 #include <stdint.h>
 
-typedef struct SNDFILE_tag SNDFILE;
+#define GETSNDFILE(x) ((SNDFILE*)x->sndfile)
 
 #ifdef SUPERNOVA
 
@@ -145,7 +145,7 @@ struct SndBuf {
     int mask; // for delay lines
     int mask1; // for interpolating oscillators.
     int coord; // used by fft ugens
-    SNDFILE* sndfile; // used by disk i/o
+    void* sndfile; // used by disk i/o
     // SF_INFO fileinfo; // used by disk i/o
 #ifdef SUPERNOVA
     bool isLocal;

--- a/server/plugins/DiskIO_UGens.cpp
+++ b/server/plugins/DiskIO_UGens.cpp
@@ -111,7 +111,7 @@ void DiskIOMsg::Perform() {
     sf_count_t count;
     switch (mCommand) {
     case kDiskCmd_Read:
-        count = buf->sndfile ? sf_readf_float(buf->sndfile, buf->data + mPos * buf->channels, mFrames) : 0;
+        count = buf->sndfile ? sf_readf_float(GETSNDFILE(buf), buf->data + mPos * buf->channels, mFrames) : 0;
         if (count < mFrames) {
             memset(buf->data + (mPos + count) * buf->channels, 0, (mFrames - count) * buf->channels * sizeof(float));
             World_GetBuf(mWorld, mBufNum)->mask = mPos + count;
@@ -126,17 +126,17 @@ void DiskIOMsg::Perform() {
             memset(buf->data + mPos * buf->channels, 0, mFrames * buf->channels * sizeof(float));
             goto leave;
         }
-        count = sf_readf_float(buf->sndfile, buf->data + mPos * buf->channels, mFrames);
+        count = sf_readf_float(GETSNDFILE(buf), buf->data + mPos * buf->channels, mFrames);
         while (mFrames -= count) {
-            sf_seek(buf->sndfile, 0, SEEK_SET);
-            count = sf_readf_float(buf->sndfile, buf->data + (mPos + count) * buf->channels, mFrames);
+            sf_seek(GETSNDFILE(buf), 0, SEEK_SET);
+            count = sf_readf_float(GETSNDFILE(buf), buf->data + (mPos + count) * buf->channels, mFrames);
         }
         break;
     case kDiskCmd_Write:
         // printf("kDiskCmd_Write %d %p\n", mBufNum, buf->sndfile);
         if (!buf->sndfile)
             goto leave;
-        count = sf_writef_float(buf->sndfile, buf->data + mPos * buf->channels, mFrames);
+        count = sf_writef_float(GETSNDFILE(buf), buf->data + mPos * buf->channels, mFrames);
         break;
     }
 
@@ -287,14 +287,14 @@ void DiskIn_next(DiskIn* unit, int inNumSamples) {
             if ((int)ZIN0(1)) { // loop
                 if (!bufr->sndfile)
                     memset(bufr->data + mPos * bufr->channels, 0, bufFrames2 * bufr->channels * sizeof(float));
-                count = sf_readf_float(bufr->sndfile, bufr->data + mPos * bufr->channels, bufFrames2);
+                count = sf_readf_float(GETSNDFILE(bufr), bufr->data + mPos * bufr->channels, bufFrames2);
                 while (bufFrames2 -= count) {
-                    sf_seek(bufr->sndfile, 0, SEEK_SET);
-                    count = sf_readf_float(bufr->sndfile, bufr->data + (mPos + count) * bufr->channels, bufFrames2);
+                    sf_seek(GETSNDFILE(bufr), 0, SEEK_SET);
+                    count = sf_readf_float(GETSNDFILE(bufr), bufr->data + (mPos + count) * bufr->channels, bufFrames2);
                 }
             } else { // non-loop
-                count =
-                    bufr->sndfile ? sf_readf_float(bufr->sndfile, bufr->data + mPos * bufr->channels, bufFrames2) : 0;
+                count = bufr->sndfile ? sf_readf_float(GETSNDFILE(bufr), bufr->data + mPos * bufr->channels, bufFrames2)
+                                      : 0;
                 if (count < bufFrames2) {
                     memset(bufr->data + (mPos + count) * bufr->channels, 0,
                            (bufFrames2 - count) * bufr->channels * sizeof(float));
@@ -469,13 +469,14 @@ static void VDiskIn_request_buffer(VDiskIn* unit, float fbufnum, uint32 bufFrame
         if ((int)ZIN0(2)) { // loop
             if (!bufr->sndfile)
                 memset(bufr->data + mPos * bufr->channels, 0, bufFrames2 * bufr->channels * sizeof(float));
-            count = sf_readf_float(bufr->sndfile, bufr->data + mPos * bufr->channels, bufFrames2);
+            count = sf_readf_float(GETSNDFILE(bufr), bufr->data + mPos * bufr->channels, bufFrames2);
             while (bufFrames2 -= count) {
-                sf_seek(bufr->sndfile, 0, SEEK_SET);
-                count = sf_readf_float(bufr->sndfile, bufr->data + (mPos + count) * bufr->channels, bufFrames2);
+                sf_seek(GETSNDFILE(bufr), 0, SEEK_SET);
+                count = sf_readf_float(GETSNDFILE(bufr), bufr->data + (mPos + count) * bufr->channels, bufFrames2);
             }
         } else { // non-loop
-            count = bufr->sndfile ? sf_readf_float(bufr->sndfile, bufr->data + mPos * bufr->channels, bufFrames2) : 0;
+            count =
+                bufr->sndfile ? sf_readf_float(GETSNDFILE(bufr), bufr->data + mPos * bufr->channels, bufFrames2) : 0;
             if (count < bufFrames2) {
                 memset(bufr->data + (mPos + count) * bufr->channels, 0,
                        (bufFrames2 - count) * bufr->channels * sizeof(float));

--- a/server/scsynth/SC_HiddenWorld.h
+++ b/server/scsynth/SC_HiddenWorld.h
@@ -37,6 +37,10 @@
 
 #include "../../common/server_shm.hpp"
 
+#ifndef NO_LIBSNDFILE
+#    include <sndfile.h>
+#endif
+
 extern HashTable<struct UnitDef, Malloc>* gUnitDefLib;
 
 

--- a/server/scsynth/SC_HiddenWorld.h
+++ b/server/scsynth/SC_HiddenWorld.h
@@ -38,7 +38,7 @@
 #include "../../common/server_shm.hpp"
 
 #ifndef NO_LIBSNDFILE
-#    include <sndfile.h>
+#    include <SC_SndFileHelpers.hpp> // includes sndfile.h with appropriate configuration
 #endif
 
 extern HashTable<struct UnitDef, Malloc>* gUnitDefLib;

--- a/server/scsynth/SC_SequencedCommand.cpp
+++ b/server/scsynth/SC_SequencedCommand.cpp
@@ -375,7 +375,7 @@ bool BufFreeCmd::Stage2() {
     mFreeData = buf->data;
 #ifndef NO_LIBSNDFILE
     if (buf->sndfile)
-        sf_close(buf->sndfile);
+        sf_close(GETSNDFILE(buf));
 #endif
     SndBuf_Init(buf);
     return true;
@@ -600,7 +600,7 @@ bool BufReadCmd::Stage2() {
     }
 
     if (buf->sndfile)
-        sf_close(buf->sndfile);
+        sf_close(GETSNDFILE(buf));
 
     if (mLeaveFileOpen) {
         buf->sndfile = sf;
@@ -903,7 +903,7 @@ bool BufReadChannelCmd::Stage2() {
 
 leave:
     if (buf->sndfile)
-        sf_close(buf->sndfile);
+        sf_close(GETSNDFILE(buf));
 
     if (mLeaveFileOpen) {
         buf->sndfile = sf;
@@ -1014,7 +1014,7 @@ bool BufWriteCmd::Stage2() {
     }
 
     if (buf->sndfile)
-        sf_close(buf->sndfile);
+        sf_close(GETSNDFILE(buf));
 
     if (mLeaveFileOpen) {
         buf->sndfile = sf;
@@ -1057,7 +1057,7 @@ bool BufCloseCmd::Stage2() {
 #else
     SndBuf* buf = World_GetNRTBuf(mWorld, mBufIndex);
     if (buf->sndfile) {
-        sf_close(buf->sndfile);
+        sf_close(GETSNDFILE(buf));
         buf->sndfile = nullptr;
     }
     return true;

--- a/server/scsynth/SC_World.cpp
+++ b/server/scsynth/SC_World.cpp
@@ -968,9 +968,9 @@ void World_Cleanup(World* world, bool unload_plugins) {
 
 #ifndef NO_LIBSNDFILE
         if (nrtbuf->sndfile)
-            sf_close(nrtbuf->sndfile);
+            sf_close(GETSNDFILE(nrtbuf));
         if (rtbuf->sndfile && rtbuf->sndfile != nrtbuf->sndfile)
-            sf_close(rtbuf->sndfile);
+            sf_close(GETSNDFILE(rtbuf));
 #endif
     }
 

--- a/server/supernova/sc/sc_plugin_interface.cpp
+++ b/server/supernova/sc/sc_plugin_interface.cpp
@@ -1041,7 +1041,7 @@ void sc_plugin_interface::buffer_close(uint32_t index) {
 
     if (buf->sndfile == nullptr)
         return;
-    sf_close(buf->sndfile);
+    sf_close(GETSNDFILE(buf));
     buf->sndfile = nullptr;
 }
 
@@ -1070,7 +1070,7 @@ void sc_plugin_interface::buffer_sync(uint32_t index) noexcept {
 void sc_plugin_interface::free_buffer(uint32_t index) {
     SndBuf* buf = world.mSndBufsNonRealTimeMirror + index;
     if (buf->sndfile)
-        sf_close(buf->sndfile);
+        sf_close(GETSNDFILE(buf));
 
     sndbuf_init(buf);
 }


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->
Fixes compatibility with `libsndfile` >=1.1.0
Fixes #5756 

See https://github.com/supercollider/supercollider/issues/5756#issuecomment-1094378766 for previous discussion.

Thanks @Spacechild1 for providing this fix.

I also had to add additional Windows includes in `SC_HiddenWorld.h`, similarly to `SC_SndFileHelpers.hpp`. 

Please review carefully, as I have limited experience with this aspect of the project.

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review
