### PR TITLE
Help: Linux: Clarify behavior of MIDIOut objects with uid

### DIFF
--- a/HelpSource/Classes/MIDIOut.schelp
+++ b/HelpSource/Classes/MIDIOut.schelp
@@ -141,9 +141,15 @@ m.connect(1);  // connect to MIDIClient.destinations[1]
 
 WARNING:: The teletype::port:: argument to link::Classes/MIDIOut#*new:: has an entirely different meaning in Linux, compared to macOS and Windows. If user code calls this method emphasis::and:: cross-platform compatibility is needed, it is the user's responsibility to handle Linux separately. User code can check the platform using code::thisProcess.platform.name:: (which returns one of code::\osx::, code::\linux:: or code::\windows::). Or, for compatibility, use link::#*newByName:: instead.::
 
-link::Classes/MIDIOut#*new:: optionally takes a second argument, for the uid of the MIDI destination device. This establishes a direct connection to the target, which is not visible in Qjackctl. The teletype::port:: argument is irrelevant in this case; the MIDIOut instance is always one-to-one with the target.
+link::Classes/MIDIOut#*new:: optionally takes a second argument, for the uid of the MIDI destination device. If the uid is non-zero, then: 1/ all connections in the ALSA MIDI patchbay are ignored, and 2/ individual messages will be sent directly to the specified device.
 
-link::Classes/MIDIOut#*newByName:: should create one-to-one MIDIOut connections on all platforms.
+link::Classes/MIDIOut#*newByName:: locates a device by name and populates the uid in the new MIDIOut object. Thus uid should be non-zero for all MIDIOut objects created using this method.
+
+note::
+A non-zero uid (whether specified in teletype::MIDIOut.new::, found by teletype::MIDIOut.newByName::, or set manually later) does not create or use any ALSA MIDI connections. It is not a "connection" at all; rather, it is a parameter that causes outgoing MIDI messages to bypass ALSA MIDI connections and go directly to one specific device. Because it is not a connection, there is nothing to show in MIDI patchbay interfaces; users should not expect to see connections for these MIDIOut objects.
+
+Also, because a uid bypasses patchbay connections, it is meaningless to specify a uid and use teletype::.connect:: at the same time. A single MIDIOut object should not do both at once. (It does not break anything, but the patchbay connections are ignored.)
+::
 
 strong::Compatibility::
 list::

--- a/HelpSource/Classes/MIDIOut.schelp
+++ b/HelpSource/Classes/MIDIOut.schelp
@@ -143,7 +143,7 @@ WARNING:: The teletype::port:: argument to link::Classes/MIDIOut#*new:: has an e
 
 link::Classes/MIDIOut#*new:: optionally takes a second argument, for the uid of the MIDI destination device. If the uid is non-zero, then: 1/ all connections in the ALSA MIDI patchbay are ignored, and 2/ individual messages will be sent directly to the specified device.
 
-link::Classes/MIDIOut#*newByName:: locates a device by name and populates the uid in the new MIDIOut object. Thus uid should be non-zero for all MIDIOut objects created using this method.
+link::Classes/MIDIOut#*newByName:: locates a device by name and populates the uid in the new MIDIOut object. After successful completion, a MIDIOut object created using this method will have a non-zero uid.
 
 note::
 A non-zero uid (whether specified in teletype::MIDIOut.new::, found by teletype::MIDIOut.newByName::, or set manually later) does not create or use any ALSA MIDI connections. It is not a "connection" at all; rather, it is a parameter that causes outgoing MIDI messages to bypass ALSA MIDI connections and go directly to one specific device. Because it is not a connection, there is nothing to show in MIDI patchbay interfaces; users should not expect to see connections for these MIDIOut objects.


### PR DESCRIPTION
## Purpose and Motivation

Linux MIDIOut users frequently get confused when `MIDIOut.newByName` pseudo-connections don't appear in patchbay GUIs.

This documentation change explains that the mechanism bypasses visible connections altogether.

Previously, the documentation (written by myself) claimed that "one-to-one connections" were made. That's misleading -- targeting a device by uid is a completely separate mechanism.

## Types of changes

- Documentation

## To-do list

- [x] Updated documentation
- [x] This PR is ready for review
