### PR TITLE
Update README_LINUX for Ubuntu 18.04-22.04

### DIFF
--- a/README_LINUX.md
+++ b/README_LINUX.md
@@ -81,7 +81,13 @@ If this displays version 5.7 or later, installing Qt is easy:
 
     sudo apt-get install qt5-default qt5-qmake qttools5-dev qttools5-dev-tools qtwebengine5-dev libqt5svg5-dev libqt5websockets5-dev
 
-If you are on Ubuntu 14.04 (Trusty) or 16.04 (Xenial), check the next section. Otherwise, you will have to use the official Qt installer. Sorry.
+If you are on Ubuntu, check the sections below. If these instructions don't work, you will have to use the official Qt installer.
+
+### Installing Qt on Ubuntu Bionic, Focal, or Jammy
+
+On Ubuntu 18.04 (Bionic), 20.04 (Focal), and 22.04 (Jammy) Qt5 is available in the system's package manager. The following should install the correct packages:
+
+    sudo apt-get install qtbase5-dev qt5-qmake qttools5-dev qttools5-dev-tools qtdeclarative5-dev libqt5svg5-dev libqt5websockets5-dev qtwebengine5-dev
 
 ### Installing Qt on Ubuntu Trusty or Xenial
 


### PR DESCRIPTION


<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

Trying to update our Linux build matrix I found that the package names in the Linux readme don't always work - particularly `qt5-default` doesn't seem to be available in Ubuntu 22.04. The packages now listed in the "Ubuntu" section of the Readme seem to work for Ubuntu 18.04, 20.04 and 22.04, at least in the configurations provided by GitHub Actions. 

I would appreciate if some Ubuntu users could confirm the updated packages are correct and complete (particularly, whether `qt5-default` is still needed for older systems).

## Types of changes

<!-- Delete lines that don't apply -->

- Documentation

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Updated documentation
- [x] This PR is ready for review
