### PR TITLE
Update Linux build matrix

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -83,7 +83,7 @@ jobs:
             cxx-compiler: 'g++-10'
             use-syslibs: false
             shared-libscsynth: false
-            artifact-suffix: 'linux-bionic-gcc10' # set if needed - will trigger artifact upload
+            artifact-suffix: 'linux-focal-gcc10' # set if needed - will trigger artifact upload
 
           # - job-name: 'focal gcc10 use system libraries' # disabled - boost version incompatible
           #   os-version: '20.04'
@@ -781,9 +781,9 @@ jobs:
             artifact-extension: '.dmg'
 
           - name: Linux
-            runs-on: ubuntu-18.04
+            runs-on: ubuntu-20.04
             sclang: 'build/Install/bin/sclang'
-            artifact-suffix: linux-bionic-gcc10
+            artifact-suffix: linux-focal-gcc10
 
     needs: [lint, Linux, macOS] # unfortunately we can't use matrix expression here to make Linux test depend only on Linux build
     runs-on: '${{ matrix.runs-on }}'

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -188,10 +188,13 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install --yes build-essential cmake pkg-config libjack-jackd2-dev libsndfile1-dev libasound2-dev libavahi-client-dev libreadline6-dev libfftw3-dev libicu-dev libxt-dev libudev-dev emacs ccache
-          # clang and gcc compilers < 9.x are no longer on ubuntu images; install them manually
-          if [[ "$CC" =~ clang-[1-8] ]]; then
+          # install appropriate clang/gcc compilers
+          if [[ "$CC" =~ clang-[1-9] ]]; then
             sudo apt-get install -y $CC # package names are clang-X
-          elif [[ "$CC" =~ gcc-[1-8] ]]; then
+            if [[ "$CC" != clang-6.0 ]]; then
+              sudo apt-get install -y libc++-${CC##clang-}-dev libc++abi-${CC##clang-}-dev # install additional libraries; package names are libc++-X-dev and libc++abi-X-dev
+            fi
+          elif [[ "$CC" =~ gcc-[1-9] ]]; then
             sudo apt-get install -y $CXX # package names are g++-X
           fi
       - name: install system libraries

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -92,6 +92,13 @@ jobs:
           #   use-syslibs: true
           #   shared-libscsynth: false
 
+          - job-name: 'focal gcc11'
+            os-version: '20.04'
+            c-compiler: 'gcc-11'
+            cxx-compiler: 'g++-11'
+            use-syslibs: false
+            shared-libscsynth: false
+
           - job-name: 'jammy gcc11 use system libraries'
             os-version: '22.04'
             c-compiler: 'gcc-11'

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -14,7 +14,7 @@ on:
       - '*.md'
 jobs:
   lint:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     outputs:
       sc-version: ${{ steps.set-version.outputs.version }}
     steps:

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -77,8 +77,8 @@ jobs:
             use-syslibs: false
             shared-libscsynth: true
 
-          - job-name: 'bionic gcc10'
-            os-version: '18.04'
+          - job-name: 'focal gcc10'
+            os-version: '20.04'
             c-compiler: 'gcc-10'
             cxx-compiler: 'g++-10'
             use-syslibs: false

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -77,13 +77,13 @@ jobs:
             use-syslibs: false
             shared-libscsynth: true
 
-          - job-name: 'focal gcc10'
-            os-version: '20.04'
+          - job-name: 'bionic gcc10'
+            os-version: '18.04'
             c-compiler: 'gcc-10'
             cxx-compiler: 'g++-10'
             use-syslibs: false
             shared-libscsynth: false
-            artifact-suffix: 'linux-focal-gcc10' # set if needed - will trigger artifact upload
+            artifact-suffix: 'linux-bionic-gcc10' # set if needed - will trigger artifact upload
 
           # - job-name: 'focal gcc10 use system libraries' # disabled - boost version incompatible
           #   os-version: '20.04'
@@ -781,9 +781,9 @@ jobs:
             artifact-extension: '.dmg'
 
           - name: Linux
-            runs-on: ubuntu-20.04
+            runs-on: ubuntu-18.04
             sclang: 'build/Install/bin/sclang'
-            artifact-suffix: linux-focal-gcc10
+            artifact-suffix: linux-bionic-gcc10
 
     needs: [lint, Linux, macOS] # unfortunately we can't use matrix expression here to make Linux test depend only on Linux build
     runs-on: '${{ matrix.runs-on }}'

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -191,7 +191,7 @@ jobs:
         if: env.USE_SYSLIBS == 'true'
         run: sudo apt-get install --yes libboost-thread-dev libboost-system-dev libboost-filesystem-dev libboost-regex-dev libboost-test-dev libboost-program-options-dev libyaml-cpp-dev
       - name: install qt from apt
-        run: sudo apt-get install qt5-default qt5-qmake qttools5-dev qttools5-dev-tools qtdeclarative5-dev libqt5svg5-dev libqt5websockets5-dev qtwebengine5-dev
+        run: sudo apt-get install qtbase5-dev qt5-qmake qttools5-dev qttools5-dev-tools qtdeclarative5-dev libqt5svg5-dev libqt5websockets5-dev qtwebengine5-dev
       - name: configure
         run: |
           mkdir $BUILD_PATH && cd $BUILD_PATH

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -92,6 +92,13 @@ jobs:
           #   use-syslibs: true
           #   shared-libscsynth: false
 
+          - job-name: 'jammy gcc11 use system libraries'
+            os-version: '22.04'
+            c-compiler: 'gcc-11'
+            cxx-compiler: 'g++-11'
+            use-syslibs: true
+            shared-libscsynth: false
+
           - job-name: 'bionic clang6.0'
             os-version: '18.04'
             c-compiler: 'clang-6.0'
@@ -117,6 +124,34 @@ jobs:
             os-version: '20.04'
             c-compiler: 'clang-10'
             cxx-compiler: 'clang++-10'
+            use-syslibs: false
+            shared-libscsynth: false
+
+          - job-name: 'focal clang11'
+            os-version: '20.04'
+            c-compiler: 'clang-11'
+            cxx-compiler: 'clang++-11'
+            use-syslibs: false
+            shared-libscsynth: false
+
+          - job-name: 'focal clang12'
+            os-version: '20.04'
+            c-compiler: 'clang-12'
+            cxx-compiler: 'clang++-12'
+            use-syslibs: false
+            shared-libscsynth: false
+
+          - job-name: 'jammy clang13'
+            os-version: '22.04'
+            c-compiler: 'clang-13'
+            cxx-compiler: 'clang++-13'
+            use-syslibs: false
+            shared-libscsynth: false
+
+          - job-name: 'jammy clang14'
+            os-version: '22.04'
+            c-compiler: 'clang-14'
+            cxx-compiler: 'clang++-14'
             use-syslibs: false
             shared-libscsynth: false
 

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -49,29 +49,29 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - job-name: 'bionic gcc7'
-            os-version: '18.04'
+          - job-name: 'focal gcc7'
+            os-version: '20.04'
             c-compiler: 'gcc-7'
             cxx-compiler: 'g++-7'
             use-syslibs: false
             shared-libscsynth: false
 
-          - job-name: 'bionic gcc8'
-            os-version: '18.04'
+          - job-name: 'focal gcc8'
+            os-version: '20.04'
             c-compiler: 'gcc-8'
             cxx-compiler: 'g++-8'
             use-syslibs: false
             shared-libscsynth: false
 
-          - job-name: 'bionic gcc9'
-            os-version: '18.04'
+          - job-name: 'focal gcc9'
+            os-version: '20.04'
             c-compiler: 'gcc-9'
             cxx-compiler: 'g++-9'
             use-syslibs: false
             shared-libscsynth: false
 
-          - job-name: 'bionic gcc9 shared libscsynth'
-            os-version: '18.04'
+          - job-name: 'focal gcc9 shared libscsynth'
+            os-version: '20.04'
             c-compiler: 'gcc-9'
             cxx-compiler: 'g++-9'
             use-syslibs: false
@@ -92,8 +92,8 @@ jobs:
           #   use-syslibs: true
           #   shared-libscsynth: false
 
-          - job-name: 'focal gcc11'
-            os-version: '20.04'
+          - job-name: 'jammy gcc11'
+            os-version: '22.04'
             c-compiler: 'gcc-11'
             cxx-compiler: 'g++-11'
             use-syslibs: false
@@ -113,15 +113,15 @@ jobs:
             use-syslibs: false
             shared-libscsynth: false
 
-          - job-name: 'bionic clang8'
-            os-version: '18.04'
+          - job-name: 'focal clang8'
+            os-version: '20.04'
             c-compiler: 'clang-8'
             cxx-compiler: 'clang++-8'
             use-syslibs: false
             shared-libscsynth: false
 
-          - job-name: 'bionic clang9'
-            os-version: '18.04'
+          - job-name: 'focal clang9'
+            os-version: '20.04'
             c-compiler: 'clang-9'
             cxx-compiler: 'clang++-9'
             use-syslibs: false

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -99,10 +99,10 @@ jobs:
             use-syslibs: false
             shared-libscsynth: false
 
-          - job-name: 'jammy gcc11 use system libraries'
+          - job-name: 'jammy gcc12 use system libraries'
             os-version: '22.04'
-            c-compiler: 'gcc-11'
-            cxx-compiler: 'g++-11'
+            c-compiler: 'gcc-12'
+            cxx-compiler: 'g++-12'
             use-syslibs: true
             shared-libscsynth: false
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ SuperCollider is tested with:
 SuperCollider is known to support these platforms:
 - Windows Vista, 7, 8, and 10
 - macOS 10.14-12.x
-- Ubuntu 14.04-20.04
+- Ubuntu 14.04-22.04
 
 We also provide a legacy macOS binary for macOS 10.10 and above using Qt 5.9.
 


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

Our build matrix had no builds on Ubuntu 22.04 and only one on 20.04. This update brings building using newer compilers and newer OSs.

~~Please note, Linux builds with `clang-11`, `clang-12` and `clang-13` fail to build (see https://github.com/dyfer/supercollider/runs/6531974521?check_suite_focus=true) and are thus disabled. I don't know whether the issue has to do with the OS configuration/missing packages, or with our build system... However, clang builds seem to be fine on macOS (I think locally I've been building using all or most of these clang versions throughout the last few years) so I'm hoping this is not an issue with our codebase.~~

~~EDIT: After discussion with @jrsurge he decided to look into the reason for these failures. Let's wait for a proposed fix before merging this PR.~~

EDIT: it turns out that issue with clang builds was due to missing libraries; we needed to install proper versions of the `libc++` libs in CI and this PR now provides that.

I've also updated the Qt5 package name for Ubuntu, which seems to work fine in all the OS versions we use here (18.04, 20.04, and 22.04).

EDIT: ~~I also updated the tests to run on Ubuntu 20.04. This was semi-intended change, but I think it's better to test on a slightly newer system anyway...~~ That seemed to be failing for some reason when installing QPM. Fixing that is definitely out of scope for this PR, so I reverted to testing with 18.04.

I updated ~~"tested with" and~~ "known to support" entries in our `README.md`. The "guaranteed support" section should be updated too, but I think it's out of scope for this PR.

## Types of changes

<!-- Delete lines that don't apply -->

- New feature (?)
- Documentation

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review
