### PR TITLE
GHA: disable RTAlloc tests

### DIFF
--- a/testsuite/scripts/gha_test_run_proto.json
+++ b/testsuite/scripts/gha_test_run_proto.json
@@ -101,6 +101,12 @@
             "skipReason":"UnitTest fails (FIXME)"
         },
         {
+            "suite":"TestUGen_RTAlloc",
+            "test":"test_allUGens",
+            "skip":true,
+            "skipReason":"UnitTest fails when run in qpm (FIXME)"
+        },
+        {
             "suite":"TestVolume",
             "test":"test_booting",
             "skip":true,


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->
#5713 introduced a number of fixes, along with tests for them. Unfortunately, these tests currently fail randomly when run in our CI. I can't reproduce tests' failures when running them locally...

For now, I suggest that we disable these tests in CI. I filed a separate issue so that we look at this again later (#5791).

## Types of changes

<!-- Delete lines that don't apply -->

- (workaround)

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [ ] All tests are passing
- [ ] This PR is ready for review
