### PR TITLE
Fix NodeMap

### DIFF
--- a/SCClassLibrary/JITLib/ProxySpace/NodeMap.sc
+++ b/SCClassLibrary/JITLib/ProxySpace/NodeMap.sc
@@ -135,7 +135,7 @@ ProxyNodeMap : NodeMap {
 			var rate = if(value.respondsTo(\rate) and:{
 				value.rate == \audio
 			}) { \audio } { \control };
-			res = res.add(ControlName(key, nil, rate, value))
+			res = res.add(ControlName(key, nil, rate, value.asControlInput))
 		};
 		^res
 	}

--- a/testsuite/scripts/gha_test_run_proto.json
+++ b/testsuite/scripts/gha_test_run_proto.json
@@ -83,12 +83,6 @@
             "skipReason":"UnitTest fails when run in qpm on Linux (FIXME)"
         },
         {
-            "suite":"TestProxyNodeMap",
-            "test":"test_nodeMap_controlNamesConvertsObjectToControlInput",
-            "skip":true,
-            "skipReason":"UnitTest has bugs (FIXME)"
-        },
-        {
             "suite":"TestSCDoc",
             "test":"test_helpSourceDirs_includedExtensions",
             "skip":true,


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

This PR fixes an issue with `NodeMap -controlNames`. The fix was proposed by @telephon.

The test that was failing because of this issue (`TestProxyNodeMap -test_nodeMap_controlNamesConvertsObjectToControlInput`) is now also enabled in our test suite.

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review
