### PR TITLE
test: correct wrong assumption in test

### DIFF
--- a/HelpSource/Classes/NodeProxy.schelp
+++ b/HelpSource/Classes/NodeProxy.schelp
@@ -526,7 +526,7 @@ method::setRates
 set the default rate (\tr, \ir, numerical) for synthDef arg. A rate of nil removes setting.
 
 method::controlNames
-Returns the link::Classes/ControlName:: objects of all slots, strong::except:: the names of this list (default: code::[\out, \i_out, \gate, \fadeTime]:: , which are used internally).
+Returns the link::Classes/ControlName:: objects of all slots, strong::except:: the names of this list (default: code::[\out, \i_out, \gate, \fadeTime]:: , which are used internally). When the node proxy received a code::set:: for a given key, the code::defaultValue:: of the corresponding code::ControlName:: contains the object that was passed, which might be any object whatsoever.
 
 method::controlKeys
 Returns the keys (symbols) of all control names objects of all slots, strong::except:: the names of this list. (default: none).

--- a/testsuite/classlibrary/TestNodeMap.sc
+++ b/testsuite/classlibrary/TestNodeMap.sc
@@ -20,12 +20,12 @@ TestProxyNodeMap : UnitTest {
 		proxy.clear;
 	}
 
-	test_nodeMap_controlNamesConvertsObjectToControlInput {
+	test_nodeMap_controlNamesDoesNotConvertObjectToControlInput {
 		var proxy = NodeProxy.new;
 		var map = proxy.nodeMap;
 		var buffer = Buffer.alloc(numFrames:1);
 		map.set(\x, buffer);
-		this.assert(map.controlNames.first.defaultValue == buffer.bufnum);
+		this.assertEquals(map.controlNames.first.defaultValue, buffer);
 		buffer.free;
 		proxy.clear;
 	}

--- a/testsuite/classlibrary/TestNodeMap.sc
+++ b/testsuite/classlibrary/TestNodeMap.sc
@@ -29,5 +29,18 @@ TestProxyNodeMap : UnitTest {
 		buffer.free;
 		proxy.clear;
 	}
+
+	test_nodeMap_controlNamesConvertObjectToControlInputFinally {
+		var proxy = NodeProxy.new;
+		var map = proxy.nodeMap;
+		var buffer = Buffer.new(bufnum: 42, numFrames:1);
+		var args, i;
+		map.set(\x, buffer);
+		args = map.asOSCArgArray;
+		i = args.indexOf(\x);
+		this.assertEquals(args[i+1], buffer.bufnum);
+		buffer.free;
+		proxy.clear;
+	}
 }
 

--- a/testsuite/scripts/gha_test_run_proto.json
+++ b/testsuite/scripts/gha_test_run_proto.json
@@ -83,12 +83,6 @@
             "skipReason":"UnitTest fails when run in qpm on Linux (FIXME)"
         },
         {
-            "suite":"TestProxyNodeMap",
-            "test":"test_nodeMap_controlNamesConvertsObjectToControlInput",
-            "skip":true,
-            "skipReason":"UnitTest has bugs (FIXME)"
-        },
-        {
             "suite":"TestSCDoc",
             "test":"test_helpSourceDirs_includedExtensions",
             "skip":true,


### PR DESCRIPTION

## Purpose and Motivation

One would naturally assume that ControlNames always contain numbers as defaultValues, but here we use them differently: any object can be value of the ControlNames. This is now tested and documented.

See also #5796 and #5797.


## Types of changes

<!-- Delete lines that don't apply -->

- Documentation

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review
