### PR TITLE
clang-format in docker

### DIFF
--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 RUN apt-get update && \
     apt-get install --yes \
@@ -6,10 +6,6 @@ RUN apt-get update && \
         git \
         clang-format-8 && \
     rm -rf /var/lib/apt/lists/*
-
-# add python3.6->python3 alias
-# clang needs python2 which already takes the python name
-RUN ln -s /usr/bin/python3.6 /usr/bin/python3
 
 ENV SC_CLANG_FORMAT=/usr/bin/clang-format-8
 ENV SC_CLANG_FORMAT_DIFF=/sc/tools/clang-format.py

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -1,0 +1,19 @@
+FROM ubuntu:18.04
+
+RUN apt-get update && \
+    apt-get install --yes \
+        python3.6 \
+        git \
+        clang-format-8 && \
+    rm -rf /var/lib/apt/lists/*
+
+# add python3.6->python3 alias
+# clang needs python2 which already takes the python name
+RUN ln -s /usr/bin/python3.6 /usr/bin/python3
+
+ENV SC_CLANG_FORMAT=/usr/bin/clang-format-8
+ENV SC_CLANG_FORMAT_DIFF=/sc/tools/clang-format.py
+
+WORKDIR /sc/
+
+ENTRYPOINT [ "python3", "/sc/tools/clang-format.py" ]


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

Installing clang-format is a rather tedious work, especially if there are no binaries for the specific version on the OS.
This PR allows to run the lint/format process inside a docker container in 2 simple statements on all major platforms (windows, linux and macos) by running

* `docker build -t clang-format .` - to build an image with the proper clang-format binary - takes around 1 minute and shall be executed in `tools/`
* `docker run -v ${PWD}:/sc/ clang-format formatall` - to create a container from the image, e.g. in the root dir of the repo, and run formatall

The documentation (https://github.com/supercollider/supercollider/wiki/Cpp-formatting-instructions) is not yet modified but is also not attached to code. I want to wait til I get approval for inserting this and I am unsure who has privileges to modify the wiki.

Edit: Rewrote git history of this branch to fix some git errors and switched from alpine docker image to ubuntu 18.04 which represents the state of the CI pipeline and also has the benefit that it has a binary available.

## Types of changes

<!-- Delete lines that don't apply -->

- Documentation
- New feature

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [ ] Updated documentation
- [x] This PR is ready for review
