### PR TITLE
Recurse submodules by default

### DIFF
--- a/SCClassLibrary/Common/Quarks/Git.sc
+++ b/SCClassLibrary/Common/Quarks/Git.sc
@@ -8,12 +8,14 @@ Git {
 	*new { |localPath|
 		^super.new.localPath_(localPath)
 	}
-	clone { |url|
-		this.git([
+	clone { |url, additionalFlags(["--recurse-submodules"])|
+        var command = [
 			"clone",
 			url,
 			thisProcess.platform.formatPathForCmdLine(localPath)
-		], false);
+		] ++ additionalFlags;
+
+		this.git(command, false);
 		this.url = url;
 	}
 	pull {


### PR DESCRIPTION
This makes git.clone recurse submodules by default so that it's possible to make Quarks with git submodules registered.

<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

Fixes https://github.com/supercollider/supercollider/issues/5754

## Types of changes

<!-- Delete lines that don't apply -->


- New feature

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [ ] Code is tested
- [ ] All tests are passing
- [ ] Updated documentation
- [ ] This PR is ready for review
