### PR TITLE
Docs: remove references to Travis

### DIFF
--- a/HelpSource/Guides/WritingTests.schelp
+++ b/HelpSource/Guides/WritingTests.schelp
@@ -25,8 +25,8 @@ Best practise is to create a separate code::.yaml:: configuration file that resi
 
 code::
 ~sclangConf = "SCLANG_CONF".getenv;
-LanguageConfig.addIncludePath(~travisBuildDir +/+ "testsuite/classlibrary");
-+   LanguageConfig.addExcludePath(~travisBuildDir +/+ "testsuite/classlibrary/server");
+LanguageConfig.addIncludePath(~scSourceDir +/+ "testsuite/classlibrary");
++   LanguageConfig.addExcludePath(~scSourceDir +/+ "testsuite/classlibrary/server");
 +   LanguageConfig.addExcludePath(Quarks.folder +/+ "UnitTesting/tests");
 +   postf("Writing configuration to %\n", ~sclangConf);
 +   LanguageConfig.store(~sclangConf);
@@ -36,8 +36,8 @@ LanguageConfig.addIncludePath(~travisBuildDir +/+ "testsuite/classlibrary");
 section:: Organisation
 
 Core class code::UnitTest::s are located in the directory
-1.  UnitTests go into parrallel directlry
-2.  server-related tests go into `server` subdir (travis)
+1.  UnitTests go into parrallel directory
+2.  server-related tests go into `server` subdir
 3.  UnitTests should use assert and assertFloat
 4.  look at existing UnitTests to understand what are good UnitTests
 5.  UnitTest setup

--- a/README_MACOS.md
+++ b/README_MACOS.md
@@ -156,15 +156,15 @@ Removing the CMakeCache.txt should fix most build problems. After running each o
 
 If you wish to build multiple git branches you should usually create a new build folder for each branch you're building. In practice, though, you can usually switch between similar branches and rebuild by simply deleting your CMakeCache.txt.
 
-### Travis continuous integration
+### GitHub Actions continuous integration
 
-The code on github is tested anytime a contributor pushes new changes, so if a mistake was made in the cutting edge development version and something is broken, then you should be able to see this by visiting the Travis status page:
+The code on github is tested anytime a contributor pushes new changes, so if a mistake was made in the cutting edge development version and something is broken, then you should be able to see this by visiting the GitHub Actions status page for the `develop` branch:
 
-https://travis-ci.org/supercollider/supercollider
+https://github.com/supercollider/supercollider/actions/workflows/actions.yml?query=branch%3Adevelop
 
 If the latest build status is failing, then you can switch your local copy to a previous commit that is still working (until the developers get a chance to fix the problem):
 
-- locate the most recent green build on the travis,
+- locate the most recent passing build in the GitHub Actions,
 - find it's git commit id (e.g. `595b956`), and
 - check out that change in git: `git checkout 595b956`
 - build

--- a/README_WINDOWS.md
+++ b/README_WINDOWS.md
@@ -621,16 +621,9 @@ higher priority than the environment path. So if you bump into a case, please
 report it to the SC community. Or even better: create a pull request on Github
 that enhances the build system.
 
-Of course there could also be bugs in the SC source. A source for the
-current build status of SC is the travis-ci status page:
+You can find the status of the current automated build from the `develop` branch at the GitHub Actions page:
 
-https://travis-ci.org/supercollider/supercollider
-
-Unfortunately though there is no Continuous Integration system in place for
-Windows yet. Therefore you are strongly encouraged to report Windows build
-issues in one of the mailing lists, or the SC issue tracker on Github.
-Reporting Windows build issues is currently the only way to detect errors
-for SCWin resulting from progress in mainstream SC development.
+https://github.com/supercollider/supercollider/actions/workflows/actions.yml?query=branch%3Adevelop
 
 Walkthroughs
 ------------


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

I saw that we were referencing Travis (the build system we stopped using a while back) in a few places. Let's remove these references.

## Types of changes

<!-- Delete lines that don't apply -->

- Documentation

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Updated documentation
- [x] This PR is ready for review
