### PR TITLE
Classlib: Invert the SynthDef topological sort (to fix a wide-graph case)

### DIFF
--- a/SCClassLibrary/Common/Audio/SynthDef.sc
+++ b/SCClassLibrary/Common/Audio/SynthDef.sc
@@ -508,7 +508,7 @@ SynthDef {
 			ugen.antecedents = ugen.antecedents.asArray.sort(
 								{ arg a, b; a.synthIndex < b.synthIndex }
 							);
-			ugen.makeAvailable; // all ugens with no antecedents are made available
+			ugen.makeAvailable; // all ugens with no descendants are made available
 		};
 	}
 	cleanupTopoSort {

--- a/SCClassLibrary/Common/Audio/SynthDef.sc
+++ b/SCClassLibrary/Common/Audio/SynthDef.sc
@@ -505,7 +505,7 @@ SynthDef {
 			ugen.initTopoSort;
 		};
 		children.reverseDo { arg ugen;
-			ugen.descendants = ugen.descendants.asArray.sort(
+			ugen.antecedents = ugen.antecedents.asArray.sort(
 								{ arg a, b; a.synthIndex < b.synthIndex }
 							);
 			ugen.makeAvailable; // all ugens with no antecedents are made available
@@ -525,7 +525,7 @@ SynthDef {
 		{
 			outStack = available.pop.schedule(outStack);
 		};
-		children = outStack;
+		children = outStack.reverse;
 		this.cleanupTopoSort;
 	}
 	indexUGens {

--- a/SCClassLibrary/Common/Audio/SynthDef.sc
+++ b/SCClassLibrary/Common/Audio/SynthDef.sc
@@ -504,7 +504,7 @@ SynthDef {
 			// this populates the descendants and antecedents
 			ugen.initTopoSort;
 		};
-		children.reverseDo { arg ugen;
+		children.do { arg ugen;
 			ugen.antecedents = ugen.antecedents.asArray.sort(
 								{ arg a, b; a.synthIndex < b.synthIndex }
 							);

--- a/SCClassLibrary/Common/Audio/UGen.sc
+++ b/SCClassLibrary/Common/Audio/UGen.sc
@@ -520,19 +520,19 @@ UGen : AbstractFunction {
 	}
 
 	makeAvailable {
-		if (antecedents.size == 0, {
+		if (descendants.size == 0, {
 			synthDef.available = synthDef.available.add(this);
 		});
 	}
 
-	removeAntecedent { arg ugen;
-		antecedents.remove(ugen);
+	removeDescendant { arg ugen;
+		descendants.remove(ugen);
 		this.makeAvailable;
 	}
 
 	schedule { arg outStack;
-		descendants.reverseDo({ arg ugen;
-			ugen.removeAntecedent(this);
+		antecedents.reverseDo({ arg ugen;
+			ugen.removeDescendant(this);
 		});
 		^outStack.add(this);
 	}


### PR DESCRIPTION
## Purpose and Motivation

Per Binary SynthDef Format help, "Unit generators should be listed in an order that permits efficient reuse of connection buffers, which means that a depth first topological sort of the graph is preferable to breadth first."

But note the difference between these cases:

```
// OK case: an entire branch is calculated before being muladd-ed in
(
SynthDef(\addTest, {
	var sig = Array.fill(5, { |i| SinOsc.ar(220 * (i+1), mul: Rand(0.5, 1.0)) });
	Out.ar(0, sig.sum)
}).dumpUGens.add;
)

[ 0_SinOsc, audio, [ 440, 0.0 ] ]
[ 1_Rand, scalar, [ 0.5, 1.0 ] ]
[ 2_*, audio, [ 0_SinOsc, 1_Rand ] ]
[ 3_SinOsc, audio, [ 220, 0.0 ] ]
[ 4_Rand, scalar, [ 0.5, 1.0 ] ]
[ 5_MulAdd, audio, [ 3_SinOsc, 4_Rand, 2_* ] ]
[ 6_SinOsc, audio, [ 660, 0.0 ] ]
[ 7_Rand, scalar, [ 0.5, 1.0 ] ]
[ 8_MulAdd, audio, [ 6_SinOsc, 7_Rand, 5_MulAdd ] ]
[ 9_SinOsc, audio, [ 880, 0.0 ] ]
[ 10_Rand, scalar, [ 0.5, 1.0 ] ]
[ 11_MulAdd, audio, [ 9_SinOsc, 10_Rand, 8_MulAdd ] ]
[ 12_SinOsc, audio, [ 1100, 0.0 ] ]
[ 13_Rand, scalar, [ 0.5, 1.0 ] ]
[ 14_MulAdd, audio, [ 12_SinOsc, 13_Rand, 11_MulAdd ] ]
[ 15_Out, audio, [ 0, 14_MulAdd ] ]

// failed case: all SinOscs clump at the top (width-first)!
(
SynthDef(\addTest, {
	var n = 5;
	var sig = SinOsc.ar(220 * (1..n));
	var amps = Array.fill(n, { Rand(0.5, 1.0) });
	Out.ar(0, (sig * amps).sum)
}).dumpUGens.add;
)

[ 0_SinOsc, audio, [ 220, 0.0 ] ]
[ 1_SinOsc, audio, [ 440, 0.0 ] ]
[ 2_SinOsc, audio, [ 660, 0.0 ] ]
[ 3_SinOsc, audio, [ 880, 0.0 ] ]
[ 4_SinOsc, audio, [ 1100, 0.0 ] ]
[ 5_Rand, scalar, [ 0.5, 1.0 ] ]
[ 6_Rand, scalar, [ 0.5, 1.0 ] ]
[ 7_*, audio, [ 1_SinOsc, 6_Rand ] ]
[ 8_MulAdd, audio, [ 0_SinOsc, 5_Rand, 7_* ] ]
[ 9_Rand, scalar, [ 0.5, 1.0 ] ]
[ 10_MulAdd, audio, [ 2_SinOsc, 9_Rand, 8_MulAdd ] ]
[ 11_Rand, scalar, [ 0.5, 1.0 ] ]
[ 12_MulAdd, audio, [ 3_SinOsc, 11_Rand, 10_MulAdd ] ]
[ 13_Rand, scalar, [ 0.5, 1.0 ] ]
[ 14_MulAdd, audio, [ 4_SinOsc, 13_Rand, 12_MulAdd ] ]
[ 15_Out, audio, [ 0, 14_MulAdd ] ]
```

To narrow this graph, the topo sort needs to know that SinOsc index 0 joins with Rand index 0. But there is no way, looking down from the top, to know this.

But if you work in reverse -- sort from the tail to the head -- then the MulAdd can pull in all of its ancestors right away, resulting in a narrower graph.

After the changes in this PR, the same failed case produces a properly interleaved UGen order:

```
[ 0_Rand, scalar, [ 0.5, 1.0 ] ]
[ 1_SinOsc, audio, [ 440, 0.0 ] ]
[ 2_*, audio, [ 1_SinOsc, 0_Rand ] ]
[ 3_Rand, scalar, [ 0.5, 1.0 ] ]
[ 4_SinOsc, audio, [ 220, 0.0 ] ]
[ 5_MulAdd, audio, [ 4_SinOsc, 3_Rand, 2_* ] ]
[ 6_Rand, scalar, [ 0.5, 1.0 ] ]
[ 7_SinOsc, audio, [ 660, 0.0 ] ]
[ 8_MulAdd, audio, [ 7_SinOsc, 6_Rand, 5_MulAdd ] ]
[ 9_Rand, scalar, [ 0.5, 1.0 ] ]
[ 10_SinOsc, audio, [ 880, 0.0 ] ]
[ 11_MulAdd, audio, [ 10_SinOsc, 9_Rand, 8_MulAdd ] ]
[ 12_Rand, scalar, [ 0.5, 1.0 ] ]
[ 13_SinOsc, audio, [ 1100, 0.0 ] ]
[ 14_MulAdd, audio, [ 13_SinOsc, 12_Rand, 11_MulAdd ] ]
[ 15_Out, audio, [ 0, 14_MulAdd ] ]
```

Note that this fixes a case from the forum: https://scsynth.org/t/maximum-value-for-numwirebufs/5887/7?u=jamshark70

```
SynthDef('wide!', {
	var n = 100;
	var a = SinOsc.ar(440 * (1..n));
	var b = LFSaw.kr({ ExpRand(1, 4) } ! n).range(0, 1);
	Out.ar(0, (a * b).sum)
}).add;

exception in GraphDef_Load: exceeded number of interconnect buffers.
```

No error with the patch!

## Types of changes

- Bug fix

I'm not sure if it should be called a breaking change or not. Users should notice nothing different because both topo sorts place all of a unit's descendants later than the ancestor unit(s). This change should never produce a wrong UGen order, though it may produce a different one from the unpatched SC version.

A risk here is that we don't have a comprehensive SynthDef test suite. That is too big a job for me to take on single-handed. I hope this PR will not be held up waiting for me to imagine every SynthDef permutation that requires an as-yet unwritten test.

## To-do list

- [x] Code is tested -- I checked a few of my synthdefs, no noticeable problems
- [x] All tests are passing
- [ ] Updated documentation -- needed? Maybe not. Topo sort logic isn't documented AFAIK.
- [x] This PR is ready for review
