### PR TITLE
SoundFileView - cast sampleRate to Integer in setData

### DIFF
--- a/HelpSource/Classes/SoundFileView.schelp
+++ b/HelpSource/Classes/SoundFileView.schelp
@@ -716,7 +716,7 @@ f.close;
 
 (
 var w = Window("test", Rect(700, 200, 600, 300)),
-file, sfv, sfZoom, mouseButton,
+sfv, sfZoom, mouseButton,
 dur = d.size / f.sampleRate / f.numChannels;
 
 w.layout = VLayout(

--- a/SCClassLibrary/Common/GUI/Base/QSoundFileView.sc
+++ b/SCClassLibrary/Common/GUI/Base/QSoundFileView.sc
@@ -36,7 +36,7 @@ SoundFileView : View {
 	setData { arg data, block, startFrame=0, channels=1, samplerate=44100;
 		if( data.isKindOf(DoubleArray).not and: {data.isKindOf(FloatArray).not} )
 		{ data = data.as(DoubleArray) };
-		this.invokeMethod( \load, [data, startFrame, channels, samplerate] );
+		this.invokeMethod( \load, [data, startFrame, channels, samplerate.asInteger] );
 	}
 
 	set { arg offset=0, data;


### PR DESCRIPTION
avoid common error when setting data. a Float samplerate crashes sclang.
also removed unused variable in helpfile last example.

## Purpose and Motivation

problem demonstration...
```
s.boot;
a= SoundFileView().front;
a.setData({1.0.rand2}!100, samplerate: s.sampleRate);

ERROR: Primitive '_QObject_InvokeMethod' failed.
```

to get around the error one always have to use an integer (e.g. in the above demo `s.sampleRate.asInteger`), so i propose we include .asInteger in the source code.

## Types of changes

minor, harmless

## To-do list

- [x] Code is tested
