### PR TITLE
class library: use makeFlopFunc for function flop

### DIFF
--- a/SCClassLibrary/Common/Core/Function.sc
+++ b/SCClassLibrary/Common/Core/Function.sc
@@ -237,7 +237,7 @@ Function : AbstractFunction {
 
 	flop {
 		if(def.argNames.isNil) { ^this };
-		^{ |... args| args.flop.collect(this.valueArray(_)) }
+		^this.makeFlopFunc
 	}
 
 


### PR DESCRIPTION

## Purpose and Motivation

A function that has been returned from function flop does not work with keyword and ellipsis arguments. This change uses the existing `makeFlopFunction` and makes this work. Downside is that we have to call `interpret` for this.

For discussion, see: #5499

## Types of changes

<!-- Delete lines that don't apply -->

- New feature


## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [ ] Code is tested
- [ ] All tests are passing
- [ ] Updated documentation
- [ ] This PR is ready for review
