### PR TITLE
Klang, Klank: Fix initialization

### DIFF
--- a/server/plugins/OscUGens.cpp
+++ b/server/plugins/OscUGens.cpp
@@ -2898,9 +2898,7 @@ static void Klank_SetCoefs(Klank* unit) {
     float freqscale = ZIN0(1) * unit->mRate->mRadiansPerSample;
     float freqoffset = ZIN0(2) * unit->mRate->mRadiansPerSample;
     float decayscale = ZIN0(3);
-
     float* coefs = unit->m_coefs;
-
     int numpartials = unit->m_numpartials;
     float sampleRate = SAMPLERATE;
 
@@ -2920,7 +2918,6 @@ static void Klank_SetCoefs(Klank* unit) {
         coefs[k + 8] = twoR * cost; // b1
         coefs[k + 12] = -R2; // b2
         coefs[k + 16] = level * 0.25; // a0
-        // Print("coefs %d  %g %g %g\n", i, twoR * cost, -R2, ampf * 0.25);
     }
 }
 
@@ -3079,7 +3076,6 @@ void Klank_next(Klank* unit, int inNumSamples) {
         b2_0 = coefs[12];
         a0_0 = coefs[16];
 
-        // Print("rcoefs %g %g %g %g %g\n", y1_0, y2_0, b1_0, b2_0, a0_0);
         in = in0;
         out = unit->m_buf - 1;
         LooP(unit->mRate->mFilterLoops) {
@@ -3094,7 +3090,6 @@ void Klank_next(Klank* unit, int inNumSamples) {
             inf = *++in;
             y1_0 = inf + b1_0 * y2_0 + b2_0 * y0_0;
             *++out = a0_0 * y1_0;
-            // Print("out %g %g %g\n", y0_0, y2_0, y1_0);
         }
         LooP(unit->mRate->mFilterRemain) {
             inf = *++in;
@@ -3102,7 +3097,6 @@ void Klank_next(Klank* unit, int inNumSamples) {
             *++out = a0_0 * y0_0;
             y2_0 = y1_0;
             y1_0 = y0_0;
-            // Print("out %g\n", y0_0);
         }
         /*
         coefs[0] = y1_0;	coefs[4] = y2_0;

--- a/server/plugins/OscUGens.cpp
+++ b/server/plugins/OscUGens.cpp
@@ -2727,11 +2727,12 @@ static float Klang_SetCoefs(Klang* unit) {
         float phase = ZIN0(j + 2);
 
         if (phase != 0.f) {
-            outf += * ++coefs = level * sin(phase); // y1
-            *++coefs = level * sin(phase - w); // y2
+            outf += level * sin(phase);
+            *++coefs = level * sin(phase - w); // y1
+            *++coefs = level * sin(phase - w - w); // y2
         } else {
-            outf += * ++coefs = 0.f; // y1
-            *++coefs = level * -sin(w); // y2
+            *++coefs = level * -sin(w); // y1
+            *++coefs = level * -sin(w + w); // y2
         }
         *++coefs = 2. * cos(w); // b1
     }


### PR DESCRIPTION
## Purpose and Motivation

Part fo the [initialization sample fix project](https://github.com/supercollider/rfcs/pull/19), specifically in the [OscUGens subset](https://github.com/supercollider/supercollider/pull/5787).

## Types of changes

- Bug fix

Changes to `Klang`:
- correct the initial phase (it was off by 1 sample).

Change to `Klank`:
- Don’t assume init sample is zero—reorganize coeff calc func and ctor to get correct init sample.
- The memory allocation for `m_coefs` was moved to the Ctor, otherwise, the `return` statement escapes the `Klank_SetCoefs`, but not the Ctor, so `m_coefs` might still be accessed after allocation fails.
- Calculate the correct init sample by calling `Klank_next(unit, 1)`, temporarily setting `mFilterLoops` and  `mFilterRemain` for the single cycle of initialization. 
  - Usually the pattern of calling `_next(unit, 1)` works, but `Klank_next` doesn’t actually use the `inNumSamples` argument, because it uses the looping scheme designed to optimize second-order filter calculations. As a consequence, a full block of calculations are run over which memory assigned for input data is accessed before it’s been written, so it’s running unnecessary calculations with garbage memory.
  - Here’s a small dump from that internal loop:

```
[Klank_next 133] 0.052083
[Klank_next 144] 0.103113
[Klank_next 155] 5818479576238205845020707127296.000000
[Klank_next 133] 11667158119450385126825574531072.000000
[Klank_next 144] 17284522609726230684285924278272.000000
...
```
- The last commit removes commented Print statements. I’m not sure what the etiquette is for touching old code for trivial changes, so I can revert this commit if needed.


## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing (`TestUGen_RTAlloc`)
- [-] Updated documentation
- [x] This PR is ready for review
