### PR TITLE
supernova: use the `/error` messages to turn on / off the console printing

### DIFF
--- a/server/supernova/sc/sc_osc_handler.hpp
+++ b/server/supernova/sc/sc_osc_handler.hpp
@@ -277,6 +277,8 @@ public:
 
     void set_error_posting(int val) { error_posting = val; }
 
+    int get_error_posting() { return error_posting; }
+
 private:
     int error_posting = 1;
     /* @} */

--- a/server/supernova/server/server.hpp
+++ b/server/supernova/server/server.hpp
@@ -246,8 +246,7 @@ inline void run_scheduler_tick(void) {
     }
 }
 
-inline bool log_printf(const char* fmt, ...) 
-{
+inline bool log_printf(const char* fmt, ...) {
     if (instance->get_error_posting()) {
         va_list vargs;
         va_start(vargs, fmt);

--- a/server/supernova/server/server.hpp
+++ b/server/supernova/server/server.hpp
@@ -246,12 +246,16 @@ inline void run_scheduler_tick(void) {
     }
 }
 
-inline bool log_printf(const char* fmt, ...) {
-    va_list vargs;
-    va_start(vargs, fmt);
-    auto result = instance->log_printf(fmt, vargs);
-    va_end(vargs);
-    return result;
+inline bool log_printf(const char* fmt, ...) 
+{
+    if(instance->get_error_posting()) {
+        va_list vargs;
+        va_start(vargs, fmt);
+        auto result = instance->log_printf(fmt, vargs);
+        va_end(vargs);
+        return result;
+    }
+    return true;
 }
 
 
@@ -297,8 +301,16 @@ inline void realtime_engine_functor::run_tick(void) {
 }
 
 
-inline bool log(const char* string) { return instance->log(string); }
+inline bool log(const char* string) {
+    if(instance->get_error_posting())
+        return instance->log(string); 
+    return true;
+}
 
-inline bool log(const char* string, size_t length) { return instance->log(string, length); }
+inline bool log(const char* string, size_t length) { 
+    if(instance->get_error_posting())
+        return instance->log(string, length); 
+    return true;
+}
 
 } /* namespace nova */

--- a/server/supernova/server/server.hpp
+++ b/server/supernova/server/server.hpp
@@ -306,7 +306,7 @@ inline bool log(const char* string) {
     return true;
 }
 
-inline bool log(const char* string, size_t length) { 
+inline bool log(const char* string, size_t length) {
     if (instance->get_error_posting())
         return instance->log(string, length);
     return true;

--- a/server/supernova/server/server.hpp
+++ b/server/supernova/server/server.hpp
@@ -248,7 +248,7 @@ inline void run_scheduler_tick(void) {
 
 inline bool log_printf(const char* fmt, ...) 
 {
-    if(instance->get_error_posting()) {
+    if (instance->get_error_posting()) {
         va_list vargs;
         va_start(vargs, fmt);
         auto result = instance->log_printf(fmt, vargs);
@@ -302,13 +302,13 @@ inline void realtime_engine_functor::run_tick(void) {
 
 
 inline bool log(const char* string) {
-    if(instance->get_error_posting())
+    if (instance->get_error_posting())
         return instance->log(string); 
     return true;
 }
 
 inline bool log(const char* string, size_t length) { 
-    if(instance->get_error_posting())
+    if (instance->get_error_posting())
         return instance->log(string, length); 
     return true;
 }

--- a/server/supernova/server/server.hpp
+++ b/server/supernova/server/server.hpp
@@ -302,13 +302,13 @@ inline void realtime_engine_functor::run_tick(void) {
 
 inline bool log(const char* string) {
     if (instance->get_error_posting())
-        return instance->log(string); 
+        return instance->log(string);
     return true;
 }
 
 inline bool log(const char* string, size_t length) { 
     if (instance->get_error_posting())
-        return instance->log(string, length); 
+        return instance->log(string, length);
     return true;
 }
 


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

Allow supernova to use the `/error` message just like scsynth. This was previously being ignored. As discussed on the [forum](https://scsynth.org/t/error-message-not-working-for-supernova/6275/4), it is a feature that is needed to match scsynth's capabilities. 

This patch does not take into account the local bundles (`/error, -1` and `/error, -2`), as supernova appears to treat the OSC bundles a little differently than scsynth, and I am still studying that part of the code base. This will come as a secondary patch in the future

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [X] Code is tested
- [ ] All tests are passing
- [X] Updated documentation
- [X] This PR is ready for review
