### PR TITLE
[skip ci] Help: Clarify full sysex format for all OSes

### DIFF
--- a/HelpSource/Classes/MIDIOut.schelp
+++ b/HelpSource/Classes/MIDIOut.schelp
@@ -52,12 +52,20 @@ method::sysex
 Sends a sysex command represented as an link::Classes/Int8Array:: to the device.
 
 note::
-On Windows, the function call must contain a full sysex message. In other words,
-it must start with 0xF0 (240 or -16) and end with 0xF7 (247 or -9).
+The method call should contain a full sysex message. In other words,
+it should start with 0xF0 (240 or -16) and end with 0xF7 (247 or -9).
 ::
 
 argument:: packet
 An Int8Array of data bytes to be sent.
+
+code::
+m = MIDIOut(0);
+
+m.sysex(Int8Array[0xF0, 1, 2, 3, 0xF7]);  // OK!
+
+m.sysex(Int8Array[1, 2, 3]);  // not OK
+::
 
 private::send, prSysex
 


### PR DESCRIPTION
## Purpose and Motivation

MIDIOut sysex help is confusing: "On Windows, the function call must contain a full sysex message..."

That implies that it may be different on other OSes.

I tested in Linux, and it's the same. And a [helpful person from the forum](https://scsynth.org/t/midi-sysex-out-platform-compatibility/6312/4?u=jamshark70) repeated the test in May, and also the same.

So it should really just advise the user to include the delimiters.

## Types of changes

- Documentation

## To-do list

- [n/a] Code is tested
- [n/a] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review
