### PR TITLE
Plotter: fix grid and axis labels

### DIFF
--- a/HelpSource/Classes/Plotter.schelp
+++ b/HelpSource/Classes/Plotter.schelp
@@ -87,6 +87,8 @@ subsection:: Embedding in another view
 method:: makeWindow
 Open given plotter in a new window or within a given composite view.
 
+See the link::#Embedding in another View or GUI:: example.
+
 argument:: argParent
 Either a link::Classes/Window:: or link::Classes/View:: may be passed in - then the plot is embedded. Otherwise a new link::Classes/Window:: is created.
 
@@ -159,7 +161,7 @@ color specified or if all colors of a multi-channel plot are the same, in which
 case a link::Classes/Color:: is returned.
 
 
-method::superpose
+method:: superpose
 If code::true::, plotter displays channels overlaid on a single plot. (keyboard shortcut: s)
 code::
 a = { (0..30).scramble }.dup(2).plot;
@@ -167,9 +169,24 @@ a.superpose = true; a.refresh;
 ::
 
 
+method:: labelX
+Get/set the label for the x-axes. Can be a link::Classes/String:: or an link::Classes/Array:: of
+link::Classes/String::s, or code::nil:: to remove the label.
+See link::#Axis labels:: example below.
+
+
+method:: labelY
+Get/set the label for the y-axes. Can be a link::Classes/String:: or an link::Classes/Array:: of
+link::Classes/String::s, or code::nil:: to remove the label.
+See link::#Axis labels:: example below.
+
 
 method:: setProperties
 Set properties of all plot views. Defaults are taken from code::GUI.skins.at(\plot);::
+
+warning:: It's preferrable to use Plotter's instance methods when possible
+to set Plot properties to ensure proper behavior when using link::#-superpose::.
+::
 
 argument:: ... pairs
 A list of symbol,value pairs. Supported properties:
@@ -217,26 +234,29 @@ subsection:: Data display properties
 
 method:: specs
 Set or get the link::Classes/ControlSpec##spec:: for the y-axis (codomain).
-note::
-The y-axis label will update with the strong::units:: assigned
-to your spec, if it has not been previously set.
-::
+
 code::
 a = { (40..3000).scramble }.dup(2).plot;
 a.specs = \freq.asSpec; a.refresh;
 ::
-See also link::#examples::.
+See also the link::#Explicit domain and axis specs:: example below.
+note::
+The y-axis label will update with the strong::units:: assigned
+to your spec, if it has not been previously set.
+::
 
 
 method:: domainSpecs
 Set or get the link::Classes/ControlSpec##spec:: for the x-axis (domain).
-note::
-The x-axis label will update with the strong::units:: assigned
-to your spec, if it has not been previously set.
-::
+
 code::
 a = { (40..300).scramble }.dup(2).plot;
 a.domainSpecs = \freq.asSpec; a.refresh;
+::
+See also the link::#Explicit domain and axis specs:: example below.
+note::
+The x-axis label will update with the strong::units:: assigned
+to your spec, if it has not been previously set.
 ::
 
 discussion::
@@ -247,13 +267,24 @@ code::maxval:: of the domainSpecs.
 
 If a new link::#-value:: is set, you will need to update your domainSpecs.
 
-For examples, see link::#-domain:: and link::#examples::.
-
 
 method:: domain
 Set or get the x-axis positions of your data points. The size of the
 code::domainArray:: must equal the size of your value array, i.e. a domain
 value specified for each data point.
+
+code::
+(
+var data, domain, plot;
+domain = 25.collect({rrand(0, 50)}).sort;
+data = domain.linlin(0, 50, 0, 1);
+
+plot = data.plot.plotMode_(\points);
+plot.domainSpecs_([0, 50].asSpec);
+plot.domain_(domain);
+)
+::
+See also the link::#Explicit domain and axis specs:: example below.
 
 discussion::
 Domain values are mapped into the range of the link::#-domainSpecs::, so need
@@ -266,20 +297,6 @@ share a single link::#-domain::. I.e. code::domainArray:: must be an
 link::Classes/Array:: of rank 1.
 
 If a new link::#-value:: is set, you will need to update your link::#-domain::.
-
-Example:
-code::
-(
-var data, domain, plot;
-domain = 25.collect({rrand(0, 50)}).sort;
-data = domain.linlin(0, 50, 0, 1);
-
-plot = data.plot.plotMode_(\points);
-plot.domainSpecs_([0, 50].asSpec);
-plot.domain_(domain);
-)
-::
-A more elaborate example can be found in the link::#examples::.
 
 
 method:: resolution
@@ -350,7 +367,7 @@ If the edit mode is set to true, the data may be edited via cursor.
 code::
 a = (0..20).plot;
 a.editMode = true; // now edit the data by clicking into the plot..
-a.value; // the value
+a.value; // the updated values
 ::
 
 
@@ -406,19 +423,6 @@ private:: plotColors, prReshape, pointIsInWhichPlot
 examples::
 
 code::
-// embedding in another GUI
-(
-w = Window("plot panel", Rect(20, 30, 520, 450));
-Slider.new(w, Rect(10, 10, 490, 20)).resize_(2).action_ { |v|
-    a.value = (0..(v.value.linexp(0, 1, 5, 8000)).asInteger).scramble;
-    w.refresh;
-};
-z = CompositeView(w, Rect(10, 35, 490, 400)).background_(Color.rand(0.7)).resize_(5);
-a = Plotter("plot", parent: z).value_([0, 1, 2, 3, 4].scramble * 100);
-w.front;
-)
-
-
 (
 a = Plotter("the plot", Rect(600, 30, 600, 400));
 a.value = (0..100).normalize(0, 8pi).sin;
@@ -445,7 +449,7 @@ a.value = { |i| (0..90).normalize(0, 8pi + (i*2pi)).sin } ! 2 * [400, 560] + 700
 a.value = { |i| (_ + 2.0.rand).dup(100).normalize(0, 8pi + i).sin } ! 2 * 400 + 700;
 
 
-// multi channel expansion of single values
+// Multi channel expansion of single values
 a.value = { |i| (_ + 2.0.rand).dup(100).normalize(0, 8pi + i).sin *.t [1, 2, 3] } ! 2 * 400 + 700;
 a.value = { |i| (0..10) **.t [1, 1.2, 1.3, 1.5] * (3.5 ** i) }.dup(3);
 
@@ -455,19 +459,11 @@ a.parent.bounds = Rect(600, 30, 500, 300);
 a.superpose = true;
 a.value = { |i| (0..20) * (3.5 ** i) }.dup(5);
 a.superpose = false;
+::
 
-// specs
+subsection:: Object .plot methods
 
-a.value = (50..90).midicps.scramble;
-a.specs = \freq; a.refresh;
-a.value = (1..60).scramble.neg;
-a.specs = \db; a.refresh;
-
-a.value = { |i| { exprand(1e3, (10 ** (i + 8))) }.dup(90) }.dup(3);
-a.value = { { exprand(1e3, 1e9) }.dup(90) }.dup(3);
-a.specs = [[1e3, 1e10, \exp], [1e3, 1e20, \exp], [1e3, 1e30, \exp]]; a.refresh;
-a.domainSpecs = [[0, 5], [-8, 100], [-1, 1]]; a.refresh;
-
+code::
 
 // Array:plot
 (
@@ -479,7 +475,6 @@ a.domainSpecs = [0, 10, \lin, 0, 0, " Kg"].asSpec; a.refresh;
 a.domainSpecs = [0.1, 10, \exponential, 0, 0, " Kg"].asSpec; a.refresh;
 a.domainSpecs = [-10, 10, \lin, 0, 0, " Kg"].asSpec; a.refresh;
 
-
 a = [(0..100) * 9, (200..1300) * 2, (200..1000)/ 5].plot;
 a.superpose = true;
 
@@ -487,22 +482,44 @@ a = [[0, 1.2, 1.5], [0, 1.3, 1.5, 1.6], [0, 1.5, 1.8, 2, 6]].midiratio.plot;
 a.plotMode = \levels; a.refresh;
 a.superpose = false;
 
-
 // Function:plot
 a = { SinOsc.ar([700, 357]) * SinOsc.ar([400, 476]) * 0.2 }.plot;
 a = { SinOsc.ar([700, 357] *0.02) * SinOsc.ar([400, 476]) * 0.3 }.plot(0.2, minval: -1);
 a = { SinOsc.ar(440) }.plot(1);
-
 
 // Env:plot
 Env.perc(0.4, 0.6).plot;
 Env.new({ 1.0.rand2 }! 8, { 1.0.rand } ! 7, \sin).plot;
 
 // Buffer:plot
-b = Buffer.read(s, Platform.resourceDir +/+ "sounds/SinedPink.aiff");
-		// Platform.resourceDir +/+ "sounds/SinedPink.aiff" contains SinOsc on left, PinkNoise on right
-b.plot;
-b.free;
+(
+s.waitForBoot({
+	var b = Buffer.read(s,
+		Platform.resourceDir +/+ "sounds/SinedPink.aiff"
+	);
+	s.sync;
+	b.plot;
+	b.free;
+});
+)
+::
+
+
+subsection:: Explicit domain and axis specs
+code::
+// data
+a = (50..90).midicps.scramble.plot;
+// specs (y-axis)
+a.specs = ControlSpec(100, 2000, units: "Hz"); a.refresh;
+
+a.value = 50.collect{ exprand(1e4, 1e7) };
+a.specs = [1e4, 1e7, \exp].asSpec; a.refresh;
+
+// domainSpecs (x-axis)
+// If domain is unassigned, values are
+// distributed evenly within the spec range
+a.domainSpecs = [-10, 70].asSpec; a.refresh;
+
 
 // Setting the domain, run the full block:
 (
@@ -551,6 +568,47 @@ p = (1, 2 .. 1000).plot.domainSpecs_([1, 1000, \lin].asSpec).refresh;
 p.specs_([[1, 1000, \exp].asSpec]).refresh;
 // then scale x axis exponentially
 p.domainSpecs_([1, 1000, \exp].asSpec).refresh;
+::
+
+
+subsection:: Axis labels
+
+code::
+(
+p = 4.collect({|cnt| 100.collect({rrand(0,1.0)})}).plot;
+p.plotColor_([Color.red, Color.blue, Color.green, Color.cyan]);
+)
+
+// a single label propagates through all Plots
+p.labelX_("one");
+// set each individually
+p.labelX_(["one", "two", "three", "four"]);
+// superposed plots default to the first label
+p.superpose_(true);
+p.superpose_(false); // labels are restored
+// nil element removes a label
+p.labelX_(["one", "two", nil, "four"]);
+// assigning nil removes all labels
+p.labelX_(nil);
+// ... labelY behaves the same way
+::
+
+subsection:: Embedding in another View or GUI
+
+code::
+(
+w = Window("plot panel", Rect(20, 30, 520, 450));
+Slider.new(w, Rect(10, 10, 490, 20)).resize_(2).action_ { |v|
+    p.value = (0..(v.value.linexp(0, 1, 5, 50)).asInteger).scramble;
+    w.refresh;
+};
+z = CompositeView(
+	w, Rect(10, 35, 490, 400)
+).background_(Color.rand(0.7)).resize_(5);
+
+p = Plotter("plot", parent: z).value_([0, 1, 2, 3, 4].scramble * 100);
+w.front;
+)
 ::
 
 

--- a/HelpSource/Classes/Plotter.schelp
+++ b/HelpSource/Classes/Plotter.schelp
@@ -3,8 +3,10 @@ summary:: Plot numerical data on a window or view
 categories:: GUI>Accessories
 related:: Reference/plot
 
+
 description::
 Plot data of up to three dimensions on a link::Classes/Window:: or link::Classes/UserView::.
+
 
 subsection:: Keyboard shortcuts
 
@@ -23,8 +25,10 @@ table::
 ## alt-click || post value
 ::
 
+
 subsection:: Method extensions
 Plotter extends other classes with methods. To see what classes implements plot, see link::Overviews/Methods#plot::
+
 
 method:: plot (args)
 
@@ -41,47 +45,20 @@ code::
 { SinOsc.ar([700, 357]) * SinOsc.ar([400, 476]) * 0.2 }.plot;
 
 // Buffer
-Buffer.read(s, Platform.resourceDir +/+ "sounds/SinedPink.aiff").plot;
+{ var b = Buffer.read(s, Platform.resourceDir +/+ "sounds/SinedPink.aiff"); s.sync; b.plot }.fork(AppClock);
 
 // Env
 Env.perc(0.4, 0.6).plot;
 ::
 
+
 method:: plotGraph (n,from,to,...)
 
 code::
-{ |x| sin(x) }.plotGraph(300,0,2*pi);
-{ |x| sin(1/x)*x }.plotGraph(from:0.0001,to:0.2);
+{ |x| sin(x) }.plotGraph(300, 0, 2*pi);
+{ |x| sin(1/x) * x }.plotGraph(from: 0.0001, to: 0.2);
 ::
 
-section:: Changing global defaults
-
-The default styles are kept (and may be overridden) in code::GUI.skin.at(\plot)::. See also link::Classes/GUI:: help.
-
-code::
-// specify plot layout
-(
-GUI.skin.plot.gridLinePattern = FloatArray[1, 0];
-GUI.skin.plot.fontColor = Color(0.5, 1, 0);
-GUI.skin.plot.gridColorX = Color.yellow(0.5);
-GUI.skin.plot.gridColorY = Color.yellow(0.5);
-GUI.skin.plot.background = Color.black;
-GUI.skin.plot.plotColor = (10..0).normalize(0.1, 1).collect { |i| Color.rand(i) };
-GUI.skin.plot.labelX = "X";
-GUI.skin.plot.labelY = "Y";
-);
-
-(
-x = { |i| (0..60).scramble.clump(8) * (3.5 ** i) }.dup(3);
-x.plot("ARRAY:PLOT", Rect(200, 300, 600, 500));
-)
-
-GUI.skin.plot.put(\plotColor, { Color.rand(0.0, 0.8) } ! 8);
-[(0..100), (20..120), (40..140)].squared.flop.bubble.plot;
-
-// reset the defaults:
-Plot.initClass;
-::
 
 classmethods::
 
@@ -100,30 +77,29 @@ a.value = (0..1000).normalize(0, 14pi).curdle(0.01).scramble.flat.sin;
 )
 ::
 
+
 instancemethods::
 
-subsection:: Accessing Instance Variables
+
+subsection:: Embedding in another view
+
 
 method:: makeWindow
 Open given plotter in a new window or within a given composite view.
+
 argument:: argParent
 Either a link::Classes/Window:: or link::Classes/View:: may be passed in - then the plot is embedded. Otherwise a new link::Classes/Window:: is created.
+
 argument:: argBounds
 The window bounds (a link::Classes/Rect::).
+
+
+subsection:: Plot properties
+
 
 method:: plotMode
 Get/Set the style of data display. This can be an array of different modes for
 multi-channel data.
-argument:: modes
-A link::Classes/Symbol:: or an link::Classes/Array:: of link::Classes/Symbol::s.
-
-If code::modes.size < numChannels::, the plots will emphasis::wrap:: around the
-array of modes.
-returns::
-An link::Classes/Array:: of link::Classes/Symbol::s,
-unless there is only one mode specified or if all modes of a multi-channel plot
-are the same, in which case a link::Classes/Symbol:: is returned.
-
 Available modes:
 table::
 ## code::\linear:: || connecting data points with linear interpolation
@@ -133,6 +109,18 @@ table::
 ## code::\steps:: || connecting data points with step interpolation
 ## code::\bars:: || bar graph with filled bars
 ::
+
+argument:: modes
+A link::Classes/Symbol:: or an link::Classes/Array:: of link::Classes/Symbol::s.
+
+If code::modes.size < numChannels::, the plots will emphasis::wrap:: around the
+array of modes.
+
+returns::
+An link::Classes/Array:: of link::Classes/Symbol::s,
+unless there is only one mode specified or if all modes of a multi-channel plot
+are the same, in which case a single link::Classes/Symbol:: is returned.
+
 discussion::
 code::
 a = (0..20).scramble.plot;
@@ -155,8 +143,34 @@ p.superpose_(true);
 )
 ::
 
+
+method:: plotColor
+Set or get the colors of your data plot.
+
+argument:: colors
+This can be an link::Classes/Array:: of link::Classes/Color::s for
+multichannel data, or a single link::Classes/Color:: to map to all channels.
+
+If code::colors.size < numChannels::, the plots will emphasis::wrap:: around the
+array of colors.
+returns::
+An link::Classes/Array:: of link::Classes/Color::s, unless there is only one
+color specified or if all colors of a multi-channel plot are the same, in which
+case a link::Classes/Color:: is returned.
+
+
+method::superpose
+If code::true::, plotter displays channels overlaid on a single plot. (keyboard shortcut: s)
+code::
+a = { (0..30).scramble }.dup(2).plot;
+a.superpose = true; a.refresh;
+::
+
+
+
 method:: setProperties
-Set properties of all plot views. Defaults are taken from code::GUI.skin.at(\plot);::
+Set properties of all plot views. Defaults are taken from code::GUI.skins.at(\plot);::
+
 argument:: ... pairs
 A list of symbol,value pairs. Supported properties:
 list::
@@ -173,6 +187,7 @@ list::
 ## gridOnX ( link::Classes/Boolean:: )
 ## gridOnY ( link::Classes/Boolean:: )
 ::
+
 discussion::
 Example:
 code::
@@ -188,87 +203,37 @@ a.setProperties(
 a.refresh;
 );
 
-GUI.skin.at(\plot); // defaults
+GUI.skins.at(\plot); // defaults
 ::
 
-method:: editMode
-If the edit mode is set to true, the data may be edited via cursor.
-code::
-a = (0..20).plot;
-a.editMode = true; // now edit the data by clicking into the plot..
-a.value; // the value
-::
-
-method:: resolution
-Set the minimum number of pixels between data points (default: 1)
-code::
-// Changing plot resolution (x-axis)
-p = 5000.collect({ |i| sinPi(i * 0.0025) }).plot;
-p.resolution_(5).refresh;  // 5px
-p.resolution_(10).refresh;
-p.resolution_(50).refresh; // undersampled
-p.resolution_(1).refresh;  // default
-::
-
-method:: findSpecs
-If true (default: code::true::), specs are derived from new data (using min and max values) automatically.
-
-method::superpose
-If set to true, plotter displays channels on top of each other (keyboard shortcut: s)
-code::
-a = { (0..30).scramble }.dup(2).plot;
-a.superpose = true; a.refresh;
-::
-
-method:: value
-Return or set the data values. Data may be numerical arrays of up to 3 dimensions.
-code::
-a = [1, 4, 2, 7, 4].dup(2).plot;
-a.value;
-::
-
-method::setValue
-Set the data values, with additional arguments determining how the plot is updated.
-argument:: arrays
-Arrays of data to plot. Data may be numerical arrays of up to 3 dimensions.
-argument:: findSpecs
-A code::Boolean::. If code::true:: (default), bounds of the plot(s) are determined automatically.
-If code::false::, previous bounds will persist.
-argument:: refresh
-A code::Boolean::. If code::true:: (default), refresh the view immediately.
-argument:: separately
-A code::Boolean::. If code::true:: (default), min and max of each set of data will be calculated
-and displayed separately for each plot. If code::false::, each plot's range on the
-y-axis will be the same.
-argument::minval
-(Optional) The minimum value displayed on the y-axis.
-argument::maxval
-(Optional) The maximum value displayed on the y-axis.
-argument:: defaultRange
-(Optional) A default range for the y-axis in the case
-that the max and min values of the data are identical.
-
-
-method:: data
-Reference to the current internal data.
-
-method:: cursorPos
-Returns:: the last cursorPos (a link::Classes/Point::).
 
 method:: plots
-Returns:: the single subplots (a link::Classes/Plot::).
+
+returns:: An link::Classes/Array:: of link::Classes/Plot::s.
+
+
+subsection:: Data display properties
 
 
 method:: specs
-Set or get the spec for the y-axis (codomain).
+Set or get the link::Classes/ControlSpec##spec:: for the y-axis (codomain).
+note::
+The y-axis label will update with the strong::units:: assigned
+to your spec, if it has not been previously set.
+::
 code::
 a = { (40..3000).scramble }.dup(2).plot;
 a.specs = \freq.asSpec; a.refresh;
 ::
 See also link::#examples::.
 
+
 method:: domainSpecs
-Set or get the spec for the x-axis (domain).
+Set or get the link::Classes/ControlSpec##spec:: for the x-axis (domain).
+note::
+The x-axis label will update with the strong::units:: assigned
+to your spec, if it has not been previously set.
+::
 code::
 a = { (40..300).scramble }.dup(2).plot;
 a.domainSpecs = \freq.asSpec; a.refresh;
@@ -284,6 +249,7 @@ If a new link::#-value:: is set, you will need to update your domainSpecs.
 
 For examples, see link::#-domain:: and link::#examples::.
 
+
 method:: domain
 Set or get the x-axis positions of your data points. The size of the
 code::domainArray:: must equal the size of your value array, i.e. a domain
@@ -298,7 +264,6 @@ code::maxval:: of the link::#-domainSpecs::.
 Currently, for multichannel data plots, it's assumed that all channels of data
 share a single link::#-domain::. I.e. code::domainArray:: must be an
 link::Classes/Array:: of rank 1.
-
 
 If a new link::#-value:: is set, you will need to update your link::#-domain::.
 
@@ -316,22 +281,82 @@ plot.domain_(domain);
 ::
 A more elaborate example can be found in the link::#examples::.
 
-method:: plotColor
-Set or get the colors of your data plot.
 
-argument:: colors
-This can be an link::Classes/Array:: of link::Classes/Color::s for
-multichannel data, or a single link::Classes/Color:: to map to all channels.
+method:: resolution
+Set the minimum number of pixels between data points (default: 1)
+code::
+// Changing plot resolution (x-axis)
+p = 5000.collect({ |i| sinPi(i * 0.0025) }).plot;
+p.resolution_(5).refresh;  // 5px
+p.resolution_(10).refresh;
+p.resolution_(50).refresh; // undersampled
+p.resolution_(1).refresh;  // default
+::
 
-If code::colors.size < numChannels::, the plots will emphasis::wrap:: around the
-array of colors.
-returns::
-An link::Classes/Array:: of link::Classes/Color::s, unless there is only one
-color specified or if all colors of a multi-channel plot are the same, in which
-case a link::Classes/Color:: is returned.
+
+subsection:: Plot data
+
+
+method:: value
+Return or set the data values. Data may be numerical arrays of up to 3 dimensions.
+code::
+a = [1, 4, 2, 7, 4].dup(2).plot;
+a.value;
+::
+
+
+method::setValue
+Set the data values, with additional arguments determining how the plot is updated.
+
+argument:: arrays
+Arrays of data to plot. Data may be numerical arrays of up to 3 dimensions.
+
+argument:: findSpecs
+A code::Boolean::. If code::true:: (default), bounds of the plot(s) are determined automatically.
+If code::false::, previous bounds will persist.
+
+argument:: refresh
+A code::Boolean::. If code::true:: (default), refresh the view immediately.
+
+argument:: separately
+A code::Boolean::. If code::true:: (default), min and max of each set of data will be calculated
+and displayed separately for each plot. If code::false::, each plot's range on the
+y-axis will be the same.
+
+argument::minval
+(Optional) The minimum value displayed on the y-axis.
+
+argument::maxval
+(Optional) The maximum value displayed on the y-axis.
+
+argument:: defaultRange
+(Optional) A default range for the y-axis in the case
+that the max and min values of the data are identical.
+
+
+method:: findSpecs
+If code::true::, specs are derived from new data (using min and max values) automatically. Default: code::true::.
+
+
+method:: data
+Reference to the current internal data (with shape up to depth of 3).
+
+
+subsection:: Edit mode
+
+
+method:: editMode
+If the edit mode is set to true, the data may be edited via cursor.
+code::
+a = (0..20).plot;
+a.editMode = true; // now edit the data by clicking into the plot..
+a.value; // the value
+::
+
 
 method:: editFunc
 Supply a function which is evaluated when editing data. The function is called with the arguments: code::plotter::, code::plotIndex::, code::index::, code::val::, code::x::, code::y::.
+
 discussion::
 Example:
 code::
@@ -369,7 +394,14 @@ a.parent.onClose = { x.release };
 );
 ::
 
-private:: plotColors
+
+method:: cursorPos
+
+returns:: The last cursorPos (a link::Classes/Point::).
+
+
+private:: plotColors, prReshape, pointIsInWhichPlot
+
 
 examples::
 
@@ -519,4 +551,34 @@ p = (1, 2 .. 1000).plot.domainSpecs_([1, 1000, \lin].asSpec).refresh;
 p.specs_([[1, 1000, \exp].asSpec]).refresh;
 // then scale x axis exponentially
 p.domainSpecs_([1, 1000, \exp].asSpec).refresh;
+::
+
+
+subsection:: Changing global defaults
+
+The default styles are kept (and may be overridden) in code::GUI.skins.at(\plot)::. See also link::Classes/GUI:: help.
+
+code::
+// specify plot layout
+(
+GUI.skins.plot.gridLinePattern = FloatArray[1, 0];
+GUI.skins.plot.fontColor = Color(0.5, 1, 0);
+GUI.skins.plot.gridColorX = Color.yellow(0.5);
+GUI.skins.plot.gridColorY = Color.yellow(0.5);
+GUI.skins.plot.background = Color.black;
+GUI.skins.plot.plotColor = Color.red;
+GUI.skins.plot.labelX = "X";
+GUI.skins.plot.labelY = "Y";
+)
+
+(
+x = { |i| (0..60).scramble * (3.5 ** i) }.dup(3);
+x.plot("ARRAY:PLOT", Rect(200, 300, 600, 500));
+)
+
+GUI.skins.plot.put(\plotColor, { Color.rand(0.0, 0.8) } ! 8);
+[(0..100), (20..120), (40..140)].squared.flop.bubble.plot;
+
+// reset the defaults:
+Plot.initClass;
 ::

--- a/SCClassLibrary/Common/GUI/Base/Grid.sc
+++ b/SCClassLibrary/Common/GUI/Base/Grid.sc
@@ -101,7 +101,6 @@ DrawGridX {
 			cacheKey = [range,bounds];
 			commands = [];
 			p = grid.getParams(range[0],range[1],bounds.left,bounds.right);
-			p['lines'].do { arg val;
 				// value, [color]
 				var x;
 				val = val.asArray;
@@ -111,10 +110,11 @@ DrawGridX {
 				commands = commands.add( ['stroke' ] );
 			};
 			if(p['labels'].notNil and: { labelOffset.x > 0 }, {
+
 				commands = commands.add(['font_',font ] );
 				commands = commands.add(['color_',fontColor ] );
 				p['labels'].do { arg val;
-					var x;
+					var x, margin = 2;
 					// value, label, [color, font]
 					if(val[2].notNil,{
 						commands = commands.add( ['color_',val[2] ] );
@@ -122,14 +122,14 @@ DrawGridX {
 					if(val[3].notNil,{
 						commands = commands.add( ['font_',val[3] ] );
 					});
-					x = grid.spec.unmap(val[0]).linlin(0, 1 ,bounds.left, bounds.right);
-					commands = commands.add( [
+					x = grid.spec.unmap(val[0]).linlin(0, 1, bounds.left, bounds.right);
+
+					commands = commands.add([
 						'stringCenteredIn', val[1].asString,
 						Rect.aboutPoint(
-							Point(x, bounds.bottom + (labelOffset.y/2) + 2),
-							bounds.width/(p['labels'].size-1*2), labelOffset.y
-						);
-					] );
+							x @ (bounds.bottom + margin + (labelOffset.y/2)),
+							labelOffset.x/2, labelOffset.y )
+					]);
 				}
 			});
 			commands
@@ -166,8 +166,10 @@ DrawGridY : DrawGridX {
 			if(p['labels'].notNil and: { labelOffset.y > 0 }, {
 				commands = commands.add(['font_',font ] );
 				commands = commands.add(['color_',fontColor ] );
-				p['labels'].do { arg val,i;
-					var y;
+
+				p['labels'].do { arg val;
+					var y, lblRect, margin = 2;
+
 					y = grid.spec.unmap(val[0]).linlin(0, 1 ,bounds.bottom, bounds.top);
 					if(val[2].notNil,{
 						commands = commands.add( ['color_',val[2] ] );
@@ -175,13 +177,19 @@ DrawGridY : DrawGridX {
 					if(val[3].notNil,{
 						commands = commands.add( ['font_',val[3] ] );
 					});
-					commands = commands.add( [
-						'stringRightJustIn', val[1].asString,
-						Rect.aboutPoint(
-							Point(labelOffset.x/2 - 2, y),
-							labelOffset.x/2, bounds.height/(p['labels'].size-1*2)
-						)
-					] );
+
+					lblRect = Rect.aboutPoint(
+						Point(labelOffset.x/2 - margin, y),
+						labelOffset.x/2, labelOffset.y/2
+					);
+
+					switch(y.asInteger,
+						bounds.bottom.asInteger, {
+							lblRect = lblRect.bottom_(bounds.bottom+2) },
+						bounds.top.asInteger, {
+							lblRect = lblRect.top_(bounds.top-2) }
+					);
+					commands = commands.add(['stringRightJustIn', val[1].asString, lblRect]);
 				}
 			});
 			commands

--- a/SCClassLibrary/Common/GUI/Base/Grid.sc
+++ b/SCClassLibrary/Common/GUI/Base/Grid.sc
@@ -101,6 +101,7 @@ DrawGridX {
 			cacheKey = [range,bounds];
 			commands = [];
 			p = grid.getParams(range[0],range[1],bounds.left,bounds.right);
+
 			p['lines'].do { arg val, i;
 				// value, [color]
 				var x, valNorm;
@@ -120,8 +121,8 @@ DrawGridX {
 					commands = commands.add( ['stroke' ] );
 				}
 			};
-			if(p['labels'].notNil and: { labelOffset.x > 0 }, {
 
+			if(p['labels'].notNil and: { labelOffset.x > 0 }, {
 				commands = commands.add(['font_',font ] );
 				commands = commands.add(['color_',fontColor ] );
 				p['labels'].do { arg val;
@@ -163,8 +164,8 @@ DrawGridY : DrawGridX {
 		if(cacheKey != [range,bounds],{ commands = nil });
 		^commands ?? {
 			commands = [];
-
 			p = grid.getParams(range[0],range[1],bounds.top,bounds.bottom);
+
 			p['lines'].do { arg val, i;
 				// value, [color]
 				var y, valNorm, addExtraLine = true, extraY;

--- a/SCClassLibrary/Common/GUI/Base/Grid.sc
+++ b/SCClassLibrary/Common/GUI/Base/Grid.sc
@@ -1,5 +1,3 @@
-
-
 DrawGrid {
 
 	var <bounds,<>x,<>y;
@@ -112,7 +110,7 @@ DrawGridX {
 				commands = commands.add( ['line', Point( x, bounds.top), Point(x,bounds.bottom) ] );
 				commands = commands.add( ['stroke' ] );
 			};
-			if(labelOffset.y > 0, {
+			if(p['labels'].notNil and: { labelOffset.x > 0 }, {
 				commands = commands.add(['font_',font ] );
 				commands = commands.add(['color_',fontColor ] );
 				p['labels'].do { arg val;
@@ -128,7 +126,7 @@ DrawGridX {
 					commands = commands.add( [
 						'stringCenteredIn', val[1].asString,
 						Rect.aboutPoint(
-							Point(x + labelOffset.x, bounds.bottom + (labelOffset.y/2) + 2),
+							Point(x, bounds.bottom + (labelOffset.y/2) + 2),
 							bounds.width/(p['labels'].size-1*2), labelOffset.y
 						);
 					] );
@@ -164,7 +162,8 @@ DrawGridY : DrawGridX {
 				commands = commands.add( ['line', Point( bounds.left,y), Point(bounds.right,y) ] );
 				commands = commands.add( ['stroke' ] );
 			};
-			if(labelOffset.x > 0, {
+
+			if(p['labels'].notNil and: { labelOffset.y > 0 }, {
 				commands = commands.add(['font_',font ] );
 				commands = commands.add(['color_',fontColor ] );
 				p['labels'].do { arg val,i;
@@ -179,7 +178,7 @@ DrawGridY : DrawGridX {
 					commands = commands.add( [
 						'stringRightJustIn', val[1].asString,
 						Rect.aboutPoint(
-							Point(labelOffset.x/2 - 2, y + labelOffset.y),
+							Point(labelOffset.x/2 - 2, y),
 							labelOffset.x/2, bounds.height/(p['labels'].size-1*2)
 						)
 					] );

--- a/SCClassLibrary/Common/GUI/Base/Grid.sc
+++ b/SCClassLibrary/Common/GUI/Base/Grid.sc
@@ -77,6 +77,7 @@ DrawGridX {
 	var <grid,<>range,<>bounds;
 	var <>font,<>fontColor,<>gridColor,<>labelOffset;
 	var commands,cacheKey;
+	var txtPad = 2; // match with Plot:txtPad
 
 	*new { arg grid;
 		^super.newCopyArgs(grid.asGrid).init
@@ -126,7 +127,7 @@ DrawGridX {
 				commands = commands.add(['font_',font ] );
 				commands = commands.add(['color_',fontColor ] );
 				p['labels'].do { arg val;
-					var x, margin = 2;
+					var x;
 
 					// value, label, [color, font]
 					if(val[2].notNil,{
@@ -140,8 +141,8 @@ DrawGridX {
 					commands = commands.add([
 						'stringCenteredIn', val[1].asString,
 						Rect.aboutPoint(
-							x @ (bounds.bottom + margin + (labelOffset.y/2)),
-							labelOffset.x/2, labelOffset.y )
+							x @ bounds.bottom, labelOffset.x/2, labelOffset.y/2
+						).top_(bounds.bottom + txtPad)
 					]);
 				}
 			});
@@ -198,26 +199,26 @@ DrawGridY : DrawGridX {
 				commands = commands.add(['color_',fontColor ] );
 
 				p['labels'].do { arg val;
-					var y, lblRect, margin = 2;
+					var y, lblRect;
 
 					y = grid.spec.unmap(val[0]).linlin(0, 1 ,bounds.bottom, bounds.top);
 					if(val[2].notNil,{
-						commands = commands.add( ['color_',val[2] ] );
+						commands = commands.add( ['color_', val[2]] );
 					});
 					if(val[3].notNil,{
-						commands = commands.add( ['font_',val[3] ] );
+						commands = commands.add( ['font_', val[3]] );
 					});
 
 					lblRect = Rect.aboutPoint(
-						Point(labelOffset.x/2 - margin, y),
+						Point(labelOffset.x/2 - txtPad, y),
 						labelOffset.x/2, labelOffset.y/2
 					);
 
 					switch(y.asInteger,
 						bounds.bottom.asInteger, {
-							lblRect = lblRect.bottom_(bounds.bottom+2) },
+							lblRect = lblRect.bottom_(bounds.bottom + txtPad) },
 						bounds.top.asInteger, {
-							lblRect = lblRect.top_(bounds.top-2) }
+							lblRect = lblRect.top_(bounds.top - txtPad) }
 					);
 					commands = commands.add(['stringRightJustIn', val[1].asString, lblRect]);
 				}

--- a/SCClassLibrary/Common/GUI/Base/Grid.sc
+++ b/SCClassLibrary/Common/GUI/Base/Grid.sc
@@ -112,7 +112,7 @@ DrawGridX {
 				commands = commands.add( ['line', Point( x, bounds.top), Point(x,bounds.bottom) ] );
 				commands = commands.add( ['stroke' ] );
 			};
-			if(bounds.width >= 12	,{
+			if(labelOffset.y > 0, {
 				commands = commands.add(['font_',font ] );
 				commands = commands.add(['color_',fontColor ] );
 				p['labels'].do { arg val;
@@ -125,7 +125,13 @@ DrawGridX {
 						commands = commands.add( ['font_',val[3] ] );
 					});
 					x = grid.spec.unmap(val[0]).linlin(0, 1 ,bounds.left, bounds.right);
-					commands = commands.add( ['stringAtPoint', val[1].asString, Point(x, bounds.bottom) + labelOffset ] );
+					commands = commands.add( [
+						'stringCenteredIn', val[1].asString,
+						Rect.aboutPoint(
+							Point(x + labelOffset.x, bounds.bottom + (labelOffset.y/2) + 2),
+							bounds.width/(p['labels'].size-1*2), labelOffset.y
+						);
+					] );
 				}
 			});
 			commands
@@ -158,7 +164,7 @@ DrawGridY : DrawGridX {
 				commands = commands.add( ['line', Point( bounds.left,y), Point(bounds.right,y) ] );
 				commands = commands.add( ['stroke' ] );
 			};
-			if(bounds.height >= 20	,{
+			if(labelOffset.x > 0, {
 				commands = commands.add(['font_',font ] );
 				commands = commands.add(['color_',fontColor ] );
 				p['labels'].do { arg val,i;
@@ -170,14 +176,19 @@ DrawGridY : DrawGridX {
 					if(val[3].notNil,{
 						commands = commands.add( ['font_',val[3] ] );
 					});
-					commands = commands.add( ['stringAtPoint', val[1].asString, Point(bounds.left, y) + labelOffset ] );
+					commands = commands.add( [
+						'stringRightJustIn', val[1].asString,
+						Rect.aboutPoint(
+							Point(labelOffset.x/2 - 2, y + labelOffset.y),
+							labelOffset.x/2, bounds.height/(p['labels'].size-1*2)
+						)
+					] );
 				}
 			});
 			commands
 		}
 	}
 }
-
 
 // DrawGridRadial : DrawGridX {}
 

--- a/SCClassLibrary/Common/GUI/Base/Grid.sc
+++ b/SCClassLibrary/Common/GUI/Base/Grid.sc
@@ -230,7 +230,6 @@ DrawGridY : DrawGridX {
 
 // DrawGridRadial : DrawGridX {}
 
-
 GridLines {
 
 	var <>spec;
@@ -302,12 +301,17 @@ GridLines {
 		p = ();
 		p['lines'] = lines;
 		if(pixRange / numTicks > 9) {
+			if (sum(lines % 1) == 0) { nfrac = 0 };
 			p['labels'] = lines.collect({ arg val; [val, this.formatLabel(val,nfrac) ] });
 		};
 		^p
 	}
 	formatLabel { arg val, numDecimalPlaces;
-		^val.round( (10**numDecimalPlaces).reciprocal).asString + (spec.units?"")
+		if (numDecimalPlaces == 0) {
+			^val.asInteger.asString
+		} {
+			^val.round( (10**numDecimalPlaces).reciprocal).asString
+		}
 	}
 }
 

--- a/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
+++ b/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
@@ -1133,6 +1133,7 @@ Plotter {
 					maxval: maxval
 				);
 				plotter.domainSpecs = ControlSpec(0.0, buf.numFrames, units:"frames");
+				plotter.setProperties(\labelX, "Frames");
 				plotter.refresh;
 			}.defer
 		};

--- a/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
+++ b/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
@@ -72,9 +72,10 @@ Plot {
 
 	bounds_ { |viewRect|
 		var ylabelSize, xlabelSize, xlabels, ylabels;
-		var gridRect, xlabelOffset, ylabelOffset, hinset, vinset;
+		var gridRect, xlabelOffset, ylabelOffset;
 		var maxWidthWithLabel, maxHeightWithLabel;
-		var minGridMargin = 4, hshift = 0, vshift = 0;
+		var hshift, vshift, hinset, vinset;
+		var minGridMargin = 4;
 
 		bounds = viewRect;
 		valueCache = nil;
@@ -85,21 +86,32 @@ Plot {
 
 		// zeroing out disables labels, see DrawGridX:,DrawGridY:commands
 		xlabelOffset = ylabelOffset = Point(0, 0);
-		hinset = vinset = minGridMargin;
 		maxWidthWithLabel = ylabelSize.width * 4;
 		maxHeightWithLabel = xlabelSize.height * 4;
+		hshift = vshift = hinset = vinset = 0;
 
 		if(viewRect.height >= maxHeightWithLabel and: { xlabels.notNil }) {
-			xlabelOffset = Point(xlabelSize.width, xlabelSize.height);
+			hinset = xlabelSize.width/2;
 			vinset = xlabelSize.height * (2/3);     // inset more on sides with labels
 			vshift = xlabelSize.height * (1/3).neg;
-			hinset = xlabelSize.width / 2; 		    // don't cut off right/leftmost x labels
+			xlabelOffset = Point(xlabelSize.width, xlabelSize.height);
 		};
 		if(viewRect.width >= maxWidthWithLabel and: { ylabels.notNil }) {
+			var lw, rw;
+
+			if (hinset > 0) { // xlabels present
+				rw = xlabelSize.width/2;
+				lw = max(rw, ylabelSize.width);
+				hinset = (rw + lw) / 2;
+				hshift = max(0, lw - hinset);
+			} { // only y labels present
+				hinset = (ylabelSize.width + minGridMargin) / 2;
+				hshift = ylabelSize.width - hinset;
+			};
 			ylabelOffset = Point(ylabelSize.width, ylabelSize.height);
-			hinset = ylabelSize.width  * (2/3);
-			hshift = ylabelSize.width  * (1/3);
 		};
+		hinset = max(hinset, minGridMargin);
+		vinset = max(vinset, minGridMargin);
 		drawGrid.x.labelOffset = xlabelOffset;
 		drawGrid.y.labelOffset = ylabelOffset;
 		gridRect = viewRect.insetBy(hinset, vinset) + [hshift, vshift, 0, 0];

--- a/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
+++ b/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
@@ -1031,8 +1031,8 @@ Plotter {
 		plotter.setValue(
 			array,
 			findSpecs: true,
-			separately: separately,
 			refresh: true,
+			separately: separately,
 			minval: minval,
 			maxval: maxval
 		);
@@ -1067,8 +1067,8 @@ Plotter {
 				plotter.setValue(
 					array.unlace(numChan).collect(_.drop(-1)),
 					findSpecs: true,
-					separately: separately,
 					refresh: false,
+					separately: separately,
 					minval: minval,
 					maxval: maxval
 				);
@@ -1127,8 +1127,8 @@ Plotter {
 				plotter.setValue(
 					array.unlace(buf.numChannels),
 					findSpecs: true,
-					separately: separately,
 					refresh: false,
+					separately: separately,
 					minval: minval,
 					maxval: maxval
 				);

--- a/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
+++ b/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
@@ -585,7 +585,7 @@ Plotter {
 
 	var <>name, <>bounds, <>parent;
 	var <value, <data, <domain;
-	var <plots, <specs, <domainSpecs, plotColor;
+	var <plots, <specs, <domainSpecs, plotColor, labelX, labelY;
 	var <cursorPos, plotMode, <>editMode = false, <>normalized = false;
 	var <>resolution = 1, <>findSpecs = true, <superpose = false;
 	var modes, <interactionView;
@@ -799,7 +799,11 @@ Plotter {
 
 		// for individual plots, restore previous domain state
 		this.domain_(dom);
-		if (superpose.not) { this.domainSpecs_(domSpecs) };
+		if (superpose.not) {
+			this.domainSpecs_(domSpecs);
+		};
+		this.labelX !? { this.labelX_(this.labelX) };
+		this.labelY !? { this.labelY_(this.labelY) };
 		this.refresh;
 	}
 
@@ -929,7 +933,7 @@ Plotter {
 	plotMode_ { |modes|
 		plotMode = modes.asArray;
 		plots.do { |plt, i|
-			// rotate modes to ensure proper behavior with superpose
+			// rotate to ensure proper behavior with superpose
 			plt.plotMode_(plotMode.rotate(i.neg))
 		}
 	}
@@ -937,6 +941,40 @@ Plotter {
 	plotMode {
 		var first = plotMode.first;
 		^if (plotMode.every(_ == first)) { first } { plotMode };
+	}
+
+	labelX_ { |labels|
+		labelX = if(labels.isKindOf(Array)) {
+			labels.collect(_ !? (_.asString))
+		} { [ labels !? (_.asString) ] };
+		plots.do { |plt, i|
+			// rotate to ensure proper behavior with superpose
+			plt.labelX_(labelX.rotate(i.neg)[0])
+		};
+		this.updatePlotBounds;
+	}
+
+	labelX {
+		^ labelX !? {
+			if (labelX.every(_ == labelX.first)) { labelX.first } { labelX }
+		};
+	}
+
+	labelY_ { |labels|
+		labelY = if(labels.isKindOf(Array)) {
+			labels.collect(_ !? (_.asString))
+		} { [ labels !? (_.asString) ] };
+		plots.do { |plt, i|
+			// rotate to ensure proper behavior with superpose
+			plt.labelY_(labelY.rotate(i.neg)[0])
+		};
+		this.updatePlotBounds;
+	}
+
+	labelY {
+		^ labelY !? {
+			if (labelY.every(_ == labelY.first)) { labelY.first } { labelY };
+		};
 	}
 
 	// specs

--- a/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
+++ b/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
@@ -96,6 +96,7 @@ Plot {
 
 		hshift = vshift = hinset = vinset = 0;
 
+		// x axis label spacing
 		if( viewRect.height >= maxHeightWithLabel
 			and: { viewRect.width >= (xtkLabelSize.width*3)
 				and: { xtkLabels.notNil }
@@ -107,6 +108,7 @@ Plot {
 			xLabelGridOffset = Point(xtkLabelSize.width, xtkLabelSize.height);
 		};
 
+		// y axis label spacing
 		if(viewRect.width >= maxWidthWithLabel and: { ytkLabels.notNil }) {
 			lmargin = txtPad + ytkLabelSize.width + txtPad;
 			if (yLabelSize.height > 0) {
@@ -1073,7 +1075,7 @@ Plotter {
 					maxval: maxval
 				);
 				plotter.domainSpecs = ControlSpec(0, duration, units: "s");
-				plotter.refresh;
+				plotter.setProperties(\labelX, "Time (s)"); // will refresh
 			}.defer
 		};
 
@@ -1133,8 +1135,7 @@ Plotter {
 					maxval: maxval
 				);
 				plotter.domainSpecs = ControlSpec(0.0, buf.numFrames, units:"frames");
-				plotter.setProperties(\labelX, "Frames");
-				plotter.refresh;
+				plotter.setProperties(\labelX, "Frames"); // will refresh
 			}.defer
 		};
 

--- a/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
+++ b/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
@@ -102,7 +102,7 @@ Plot {
 				and: { xtkLabels.notNil }
 		}) {
 			totalVSpace = txtPad + xtkLabelSize.height + txtPad + xLabelSize.height + txtPad;
-			hinset = xtkLabelSize.width/2;
+			hinset = xtkLabelSize.width/2 + txtPad;
 			vinset = totalVSpace * (2/3);     // inset more on sides with labels
 			vshift = totalVSpace * (1/3).neg;
 			xLabelGridOffset = Point(xtkLabelSize.width, xtkLabelSize.height);
@@ -224,7 +224,7 @@ Plot {
 				lbounds = labelY.bounds(font);
 				Pen.push;
 				Pen.translate(
-					plotBounds.left - drawGrid.y.labelOffset.x + txtPad + lbounds.height,
+					plotBounds.left - drawGrid.y.labelOffset.x + txtPad + (lbounds.height/2),
 					plotBounds.center.y);
 				Pen.rotateDeg(-90);
 				Pen.stringCenteredIn(labelY, lbounds.center_(0@0), font, fontColor);

--- a/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
+++ b/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
@@ -1150,7 +1150,7 @@ Plotter {
 
 + Env {
 	plot { |size = 400, bounds, minval, maxval, name|
-		var plotLabel = if (name.isNil) { "envelope plot" } { name };
+		var plotLabel = if (name.isNil) { "Envelope plot" } { name };
 		var plotter = [this.asMultichannelSignal(size).flop]
 		.plot(name, bounds, minval: minval, maxval: maxval);
 
@@ -1159,8 +1159,7 @@ Plotter {
 
 		var totalDuration = if (channelCount == 1) { duration } { duration.maxItem ! channelCount };
 
-		plotter.domainSpecs = totalDuration.collect(ControlSpec(0, _, units: "s"));
-		plotter.setProperties(\labelX, "time");
+		plotter.domainSpecs = totalDuration.collect(ControlSpec(0, _));
 		plotter.refresh;
 		^plotter
 	}

--- a/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
+++ b/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
@@ -775,7 +775,8 @@ Plotter {
 			plot.bounds_(
 				Rect(bounds.left, distY * i + bounds.top, bounds.width, height)
 			)
-		}
+		};
+		this.refresh;
 	}
 
 	makePlots {
@@ -786,7 +787,6 @@ Plotter {
 		this.plotColor_(plotColor);
 		this.plotMode_(plotMode);
 		this.updatePlotSpecs;
-		this.updatePlotBounds;
 	}
 
 	updatePlots {
@@ -828,7 +828,9 @@ Plotter {
 					plot.domainSpec = domainSpecs.clipAt(i)
 				}
 			}
-		}
+		};
+
+		this.updatePlotBounds;
 	}
 
 	setProperties { |... pairs|

--- a/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
+++ b/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
@@ -71,8 +71,8 @@ Plot {
 	}
 
 	bounds_ { |viewRect|
-		var ylabelSize, xlabelSize, xlabels, ylabels;
-		var gridRect, xlabelOffset, ylabelOffset;
+		var ytkLabelSize, xtkLabelSize, xtkLabels, ytkLabels;
+		var gridRect, xtkLabelOffset, ytkLabelOffset;
 		var maxWidthWithLabel, maxHeightWithLabel;
 		var hshift, vshift, hinset, vinset;
 		var minGridMargin = 4;
@@ -80,47 +80,47 @@ Plot {
 		bounds = viewRect;
 		valueCache = nil;
 
-		// find the size of the largest labels
-		#xlabelSize, xlabels = this.prGetLabelSize(drawGrid.x);
-		#ylabelSize, ylabels = this.prGetLabelSize(drawGrid.y);
+		// find the size of the largest tick labels
+		#xtkLabelSize, xtkLabels = this.prGetTickLabelSize(drawGrid.x);
+		#ytkLabelSize, ytkLabels = this.prGetTickLabelSize(drawGrid.y);
 
 		// zeroing out disables labels, see DrawGridX:,DrawGridY:commands
-		xlabelOffset = ylabelOffset = Point(0, 0);
+		xtkLabelOffset = ytkLabelOffset = Point(0, 0);
 
 		// labels disappear below these size thresholds
-		maxWidthWithLabel = ylabelSize.width * 4;
-		maxHeightWithLabel = xlabelSize.height * 4;
+		maxWidthWithLabel = ytkLabelSize.width * 4;
+		maxHeightWithLabel = xtkLabelSize.height * 4;
 
 		hshift = vshift = hinset = vinset = 0;
 		if( viewRect.height >= maxHeightWithLabel
-			and: { viewRect.width >= (xlabelSize.width*3)
-				and: { xlabels.notNil }
+			and: { viewRect.width >= (xtkLabelSize.width*3)
+				and: { xtkLabels.notNil }
 		}) {
-			hinset = xlabelSize.width/2;
-			vinset = xlabelSize.height * (2/3);     // inset more on sides with labels
-			vshift = xlabelSize.height * (1/3).neg;
-			xlabelOffset = Point(xlabelSize.width, xlabelSize.height);
+			hinset = xtkLabelSize.width/2;
+			vinset = xtkLabelSize.height * (2/3);     // inset more on sides with labels
+			vshift = xtkLabelSize.height * (1/3).neg;
+			xtkLabelOffset = Point(xtkLabelSize.width, xtkLabelSize.height);
 		};
 
-		if(viewRect.width >= maxWidthWithLabel and: { ylabels.notNil }) {
+		if(viewRect.width >= maxWidthWithLabel and: { ytkLabels.notNil }) {
 			var lmargin, rmargin;
 
-			if (hinset > 0) { // xlabels present
-				rmargin = xlabelSize.width/2;
-				lmargin = max(rmargin, ylabelSize.width);
+			if (hinset > 0) { // xtkLabels present
+				rmargin = xtkLabelSize.width/2;
+				lmargin = max(rmargin, ytkLabelSize.width);
 				hinset = (rmargin + lmargin) / 2;
 				hshift = max(0, lmargin - hinset);
 			} { // only y labels present
-				hinset = (ylabelSize.width + minGridMargin) / 2;
-				hshift = ylabelSize.width - hinset;
+				hinset = (ytkLabelSize.width + minGridMargin) / 2;
+				hshift = ytkLabelSize.width - hinset;
 			};
-			ylabelOffset = Point(ylabelSize.width, ylabelSize.height);
+			ytkLabelOffset = Point(ytkLabelSize.width, ytkLabelSize.height);
 		};
 
 		hinset = max(hinset, minGridMargin);
 		vinset = max(vinset, minGridMargin);
-		drawGrid.x.labelOffset = xlabelOffset;
-		drawGrid.y.labelOffset = ylabelOffset;
+		drawGrid.x.labelOffset = xtkLabelOffset;
+		drawGrid.y.labelOffset = ytkLabelOffset;
 		gridRect = viewRect.insetBy(hinset, vinset) + [hshift, vshift, 0, 0];
 		drawGrid.bounds = gridRect;
 
@@ -200,14 +200,19 @@ Plot {
 	}
 
 	drawLabels {
-		var sbounds;
+		var sbounds, margin = 2;
 		if(gridOnX and: { labelX.notNil }) {
 			sbounds = try { labelX.bounds(font) } ? 0;
-			Pen.stringAtPoint(labelX,
-				plotBounds.right - sbounds.width @ plotBounds.bottom,
-				font,
-				fontColor
-			)
+			// Pen.stringAtPoint(labelX,
+			// 	plotBounds.right - sbounds.width @ plotBounds.bottom,
+			// 	font,
+			// 	fontColor
+			// )
+			Pen.stringCenteredIn(labelX,
+				sbounds.center_(Point(
+					plotBounds.center.x, (plotBounds.bottom + (sbounds.height * 1.5) + (2 * margin))
+				)), font, fontColor
+			);
 		};
 		if(gridOnY and: { labelY.notNil }) {
 			sbounds = try { labelY.bounds(font) } ? 0;
@@ -507,7 +512,7 @@ Plot {
 		}
 	}
 
-	prGetLabelSize { |drawGrid|
+	prGetTickLabelSize { |drawGrid|
 		var params, charCnt, labelSize;
 		var gridEdges = if ( drawGrid.isKindOf(DrawGridY) ) {
 			[drawGrid.bounds.top, drawGrid.bounds.bottom]


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

This adds full support for grid labels and axis labels for `Plotter`.

## Types of changes

### Changes
- build label margins for each axis independently
- refresh when updating plot bounds
- account for x-AND y-labels when sizing left and right margins
- always draw the outer edge grid lines
- xlabels: handle edge case of very small width
- distinguish between x and y grid edges when getting label size
- rename x/yLabels -> x/ytkLabels - they're tick labels not axis labels
- fully support axis labels: add -labelX, -labelY methods, support multichannel plot labels
- docs: cleanup, fix examples, reorganize by subcategory
- don't display `.0` if all grid labels are whole numbers
- Env:plot: don't assume units are seconds.
- Buffer:plot: display units in x-axis label, not grid labels.
- Buffer:plot: match argument order to default/auto-complete
- don't call refresh again after `setProperties`
- add padding to x tick label inset, properly center y label
- ensure there's edge lines when only one grid line
- update axis label if axis specs contain units

<!-- Delete lines that don't apply -->

  [x] Documentation
  [x] Bug fix
  [x] New feature

Some examples of the changes:
Note axis labels, grid labels, labels disappearing under height/width size limits, units listed as axis labels instead of grid labels, grid lines appearing at max/min plot bounds, etc.
![aggregate imgs](https://user-images.githubusercontent.com/923342/181745994-8bf1f918-9bcf-4097-9fb9-a44e658a0cab.jpg)

## To-do list
<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] Tests are passing (`TestPlotter`)
- [x] Updated documentation
- [x] This PR is ready for review
