### PR TITLE
Classlib: QuarksGUI should check schelp as well as helpdoc

### DIFF
--- a/SCClassLibrary/Common/Quarks/GUI/QuarksGui.sc
+++ b/SCClassLibrary/Common/Quarks/GUI/QuarksGui.sc
@@ -322,7 +322,9 @@ QuarkDetailView {
 				this.pushRow("Dependencies", dependencies.collect(_.asString).join(Char.nl));
 			};
 			if(isInstalled or: {
-				isDownloaded and: {model.data['helpdoc'].isString}
+				isDownloaded and: {
+					#['schelp', 'helpdoc'].any { |key| model.data[key].isString }
+				}
 			}, {
 				this.pushRow("Help", makeBtn.value("Open help", { model.help }));
 			});


### PR DESCRIPTION
## Purpose and Motivation

Quark:help first tries to display a SCDoc help file, if one is listed under `schelp` in the quark file.

Failing this, it falls back to `helpdoc` (which is handled by `openOS`).

But QuarksGUI will display the "Open help" button only if `helpdoc` is populated.

So, in current development, if a quark author wants the help doc to be a SCDoc help file, they have to specify both schelp and helpdoc, but helpdoc will never be used.

Expected behavior: Check both keys, and display the button if either one is populated with a string.

## Types of changes

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [ ] Updated documentation
- [x] This PR is ready for review
