### PR TITLE
docs: fix ProxySpace typo

### DIFF
--- a/HelpSource/Classes/ProxySpace.schelp
+++ b/HelpSource/Classes/ProxySpace.schelp
@@ -107,7 +107,7 @@ method::end
 end all proxies (free and stop the monitors)
 
 method::clear
-clear the node proxy and remove it from the environment. this frees all buses. If a fadeTime is given, first fade out, then clear.
+clear all proxies and remove them from the environment. This frees all buses. If a fadeTime is given, first fade out, then clear.
 
 method::add
 add the ProxySpace to the repository (name required)


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation
fix typo issues in ProxySpace.schelp. ```clear``` applies to all node proxies, rather than a single node proxy.

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->

- Documentation

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review
