### PR TITLE
docs: ez ranger typo

### DIFF
--- a/HelpSource/Classes/EZRanger.schelp
+++ b/HelpSource/Classes/EZRanger.schelp
@@ -1,13 +1,13 @@
 class:: EZRanger
 summary:: A wrapper class for a label, a rangeslider, and numberboxes
 categories:: GUI>EZ-GUI
-related:: Classes/EZGui, Classes/StaticText, Classes/Slider, Classes/NumberBox
+related:: Classes/EZGui, Classes/StaticText, Classes/RangeSlider, Classes/NumberBox
 
 description::
-EZRanger is wrapper class which creates an (optional) link::Classes/StaticText::, and a link::Classes/Slider:: plus a link::Classes/NumberBox::. If the parent is code::nil::, then EZRanger will create its own window. See link::Classes/EZGui:: more options.
+EZRanger is wrapper class which creates an (optional) link::Classes/StaticText::, and a link::Classes/RangeSlider:: plus a link::Classes/NumberBox::. If the parent is code::nil::, then EZRanger will create its own window. See link::Classes/EZGui:: more options.
 
 subsection:: Scrolling and Arrow Keys
-EZRanger's number boxs scroll by default, using the step size of the link::Classes/ControlSpec::. If the controlSpec's step is set to 0, or is not set, then the stepping and scrolling will be guessed according to the code::minval:: and code::maxval:: values of the spec on creation of the view.  Unlike the step variable of a regular link::Classes/NumberBox::, code::controlSpec.step:: is also the smallest possible increment for the link::Classes/NumberBox::s.  By default, the shift-key modifier will allow you to step by 100x code::controlSpec.step::, while the ctrl-key will give you 10x code::controlSpec.step::. Since the alt-key would give you 0.1 of the minimum step, it is disabled by default, but you can change that by setting code::numberView.alt_step:: to any value you like. Accordingly you can customize the other modifiers to fit your needs. See link::Classes/NumberBox:: and link::Classes/Slider::. This also effects the arrow keys for the slider.
+EZRanger's number boxes scroll by default, using the step size of the link::Classes/ControlSpec::. If the ControlSpec's step is set to 0, or is not set, then the stepping and scrolling will be guessed according to the code::minval:: and code::maxval:: values of the spec on creation of the view.  Unlike the step variable of a regular link::Classes/NumberBox::, code::controlSpec.step:: is also the smallest possible increment for the number boxes. By default, the shift-key modifier will allow you to step by 100x code::controlSpec.step::, while the ctrl-key will give you 10x code::controlSpec.step::. Since the alt-key would give you 0.1 of the minimum step, it is disabled by default, but you can change that by setting code::numberView.alt_step:: to any value you like. Accordingly, you can customize the other modifier keys to fit your needs. This also affects the arrow keys for the slider.
 
 classmethods::
 

--- a/HelpSource/Classes/NotificationCenter.schelp
+++ b/HelpSource/Classes/NotificationCenter.schelp
@@ -56,7 +56,7 @@ code::
 // using default server as subject and a symbol as observer:
 NotificationCenter.register(Server.default, \newAllocators, \yourself, {
 	// Substitute anything more meaningful here:
-	"symbol yourself was notified newAllocators by defaul server".postln;
+	"symbol yourself was notified newAllocators by default server".postln;
 });
 ::
 

--- a/HelpSource/Classes/ProxySpace.schelp
+++ b/HelpSource/Classes/ProxySpace.schelp
@@ -107,7 +107,7 @@ method::end
 end all proxies (free and stop the monitors)
 
 method::clear
-clear the node proxy and remove it from the environment. this frees all buses. If a fadeTime is given, first fade out, then clear.
+clear all proxies and remove them from the environment. This frees all buses. If a fadeTime is given, first fade out, then clear.
 
 method::add
 add the ProxySpace to the repository (name required)


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation
EZRanger.schelp references ```Slider``` several times, but should probably be referencing ```RangeSlider``` instead. Removed what felt like a superfluous link to ```NumberBox``` help file. Also fixed a few typo/language issues.

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->

- Documentation

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review
