### PR TITLE
classlib: Delete unused method `*findMethod` from ScIDE class

### DIFF
--- a/SCClassLibrary/scide_scqt/ScIDE.sc
+++ b/SCClassLibrary/scide_scqt/ScIDE.sc
@@ -197,47 +197,6 @@ ScIDE {
 		if (res.size > 0) { this.send(id, res) };
 	}
 
-	*findMethod { |id, text|
-		var cname, mname, tokens, res;
-		var class, method;
-
-		tokens = text.split($.);
-		if (tokens.size > 1) {
-			cname = tokens[0];
-			mname = tokens[1];
-		}{
-			mname = tokens[0];
-		};
-		if (mname.size < 1) { ^this };
-
-		if (cname.size > 0) {
-			class = cname.asSymbol.asClass;
-			if (class.isNil) {
-				warn("No class named" + cname.asString);
-				^this;
-			};
-			method = class.class.findRespondingMethodFor(mname.asSymbol);
-			if (method.isNil) {
-				warn("No such method:" + cname.asString ++ "." ++ mname.asString);
-				^this;
-			};
-			this.send(id, [this.serializeMethod(method)]);
-		}{
-			res = [];
-			this.allMethodsDo { |method|
-				if (method.name.asString == mname) {
-					res = res.add( this.serializeMethod(method) );
-				};
-			};
-			if (res.size > 0) {
-				this.send(id, res)
-			}{
-				warn("No such method:" + mname.asString);
-				^this;
-			};
-		}
-	}
-
 	*serializeMethod { arg method;
 		var data = [method.ownerClass.name, method.name];
 		if (method.argNames.size > 1) {


### PR DESCRIPTION
## Purpose and Motivation

Fixes #4557.

```
Class.allClasses.select { |cl| cl.findMethod(\duration).notNil };
```

Error:

```
ERROR: Message 'split' not understood.
RECEIVER:
   nil
ARGS:
   Character 46 '.'
CALL STACK:
	DoesNotUnderstandError:reportError
		arg this = <instance of DoesNotUnderstandError>
... snip ...
	Object:doesNotUnderstand
		arg this = nil
		arg selector = 'split'
		arg args = [*1]
	Meta_ScIDE:findMethod
```

Per discussion in #4557, the offending method seems to have been used in an early version of IDE auto completion, but all references to it were removed with a major re-factoring. As far as I can see, it's 1/ expected to be called from the IDE internally, 2/ unused in the IDE!, and 3/ breaks a core class library feature.

So I'm (2 years late) removing it.

## Types of changes

- Bug fix

## To-do list

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation  (no need, none of the ScIDE methods are not documented)
- [x] This PR is ready for review
