### PR TITLE
Update analog-ringz-tuner: Replace deprecated file-open dialog

### DIFF
--- a/examples/GUI examples/analog-drum-tuner.scd
+++ b/examples/GUI examples/analog-drum-tuner.scd
@@ -163,8 +163,8 @@ s.waitForBoot({
 		.states_([["load"]])
 		.action_({
 			var	values;
-			File.openDialog("", { |path|
-				values = Object.readTextArchive(path[0]);
+			Dialog.openPanel({ |path|
+				values = Object.readTextArchive(path);
 				(values.size != 6).if({
 					Error("File does not contain a ringz spec.").throw;
 					}, {


### PR DESCRIPTION
## Purpose and Motivation

analog-ringz-tuner.scd could not load files because it uses the now-deprecated File.openDialog.

## Types of changes

- Example file

## To-do list

- [x] Code is tested
- [x] All tests are passing
- [n/a] Updated documentation
- [x] This PR is ready for review
