### PR TITLE
Update macOS build matrix

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -191,9 +191,9 @@ jobs:
         include:
 
           - job-name: ''
-            os-version: '10.15'
-            xcode-version: '11.7'
-            deployment-target: '10.13' # Qt 5.15 runs on macOS 10.13 and newer
+            os-version: '11'
+            xcode-version: '12.4'
+            deployment-target: '10.14' # Qt 5.15 runs on macOS 10.13 and newer; however homebrew build of Qt on macOS 11 only supports 10.14+
             use-syslibs: false
             shared-libscsynth: false
             build-libsndfile: true
@@ -202,8 +202,8 @@ jobs:
             verify-app: true
 
           - job-name: 'legacy'
-            os-version: '10.15'
-            xcode-version: '10.3'
+            os-version: '11'
+            xcode-version: '12.4'
             qt-version: '5.9.9' # will use qt from aqtinstall
             deployment-target: '10.10'
             use-syslibs: false
@@ -213,17 +213,17 @@ jobs:
             artifact-suffix: 'macOS-legacy' # set if needed - will trigger artifact upload
 
           - job-name: 'use system libraries'
-            os-version: '10.15'
-            xcode-version: '11.7'
-            deployment-target: '10.15'
+            os-version: '12'
+            xcode-version: '13.4.1'
+            deployment-target: '10.14'
             use-syslibs: true
             shared-libscsynth: false
             verify-app: true
 
           - job-name: 'shared libscsynth'
-            os-version: '10.15'
-            xcode-version: '11.7'
-            deployment-target: '10.13'
+            os-version: '12'
+            xcode-version: '13.4.1'
+            deployment-target: '10.14'
             use-syslibs: false
             shared-libscsynth: true
             verify-app: true
@@ -520,7 +520,7 @@ jobs:
         include:
 
           - name: macOS
-            runs-on: macos-10.15
+            runs-on: macos-11
             sclang: 'build/Install/SuperCollider/SuperCollider.app/Contents/MacOS/sclang'
             artifact-suffix: macOS
             artifact-extension: '.dmg'

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -209,6 +209,7 @@ jobs:
             use-syslibs: false
             shared-libscsynth: false
             build-libsndfile: true
+            system-portaudio: false
             vcpkg-triplet: x64-osx-release-supercollider # required for build-libsndfile
             artifact-suffix: 'macOS-legacy' # set if needed - will trigger artifact upload
 
@@ -280,9 +281,10 @@ jobs:
         run: rm -rf $(brew --cache)
       - name: install dependencies
         run: |
-          brew install portaudio ccache fftw
+          brew install ccache fftw
           # add ccamke to PATH - see https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions
           echo "/usr/local/opt/ccache/libexec" >> $GITHUB_PATH
+          if [[ "${{ matrix.system-portaudio }}" != "false" ]]; then brew install portaudio; fi
       - name: install libsndfile # to make it compatible with older OSes (lower deployment target)
         if: matrix.build-libsndfile == true && matrix.vcpkg-triplet
         run: |
@@ -317,6 +319,8 @@ jobs:
           if [[ -z "${{ matrix.qt-version }}" ]]; then EXTRA_CMAKE_FLAGS="-DCMAKE_PREFIX_PATH=`brew --prefix qt5` $EXTRA_CMAKE_FLAGS"; fi
 
           if [[ "${{ matrix.verify-app }}" == "true" ]]; then EXTRA_CMAKE_FLAGS="-DSC_VERIFY_APP=ON $EXTRA_CMAKE_FLAGS"; fi
+
+          if [[ "${{ matrix.system-portaudio }}" == "false" ]]; then EXTRA_CMAKE_FLAGS="-DSYSTEM_PORTAUDIO=OFF $EXTRA_CMAKE_FLAGS"; fi
 
           if [[ -n "${{ matrix.vcpkg-triplet }}" ]]; then
             export VCPKG_ROOT=$VCPKG_INSTALLATION_ROOT

--- a/README.md
+++ b/README.md
@@ -27,12 +27,12 @@ See the [Raspberry Pi](README_RASPBERRY_PI.md) and [BeagleBone Black](README_BEA
 
 SuperCollider is tested with:
 - Windows 10 (32- and 64-bit) and MSVC 2019
-- macOS 10.15 and Xcode 11.7
+- macOS 11 and Xcode 12.4
 - Ubuntu 18.04 and gcc 10
 
 SuperCollider is known to support these platforms:
 - Windows Vista, 7, 8, and 10
-- macOS 10.13-11.x
+- macOS 10.14-12.x
 - Ubuntu 14.04-20.04
 
 We also provide a legacy macOS binary for macOS 10.10 and above using Qt 5.9.


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

Fixes #5843

Github Actions runner image of macOS 10.15 is getting deprecated. This PR updates our build matrix to use macOS 11 and macOS 12 images.

- the legacy build still works down to macOS 10.10. I confirmed that by testing on that system
  -  in order for this to work, I switched to build the "vendored" portaudio library (just for the legacy build); this applies to supernova only anyway
  - for reference, the build only seemed to work on 10.10 when built using Xcode 12.4; it did not work when built using 11.7 or 13.1 (I haven't investigated that further, just chose the configuration that worked)
- the main build **doesn't work on macOS 10.13** (High Sierra) anymore. This is due to the use of homebrew build of Qt, which only supports macOS 10.14 (for homebrew installed on macOS 11). I've updated the documentation accordingly
- I've set other macOS builds to use macOS 12 and Xcode 13.4.1 for testing purposes
  - I've originally tried to set the main build to use this config as well, but it further limited backwards compatibility of the release build, so I stuck to using macOS 11 and Xcode 12 there

I have tested (*) these builds on macOS 10.10, 10.13 (legacy), 10.14 and 12.4 (main)

(*) I've only checked whether the app opens, interpreter starts and whether the servers boot

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix (?)
- Breaking change (platform support for the main SC build)

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing (the application runs on various platforms as described above)
- [x] Updated documentation
- [x] This PR is ready for review
