### PR TITLE
lang: Fix system realtime message type codes

### DIFF
--- a/testsuite/classlibrary/TestMIDI.sc
+++ b/testsuite/classlibrary/TestMIDI.sc
@@ -1,0 +1,49 @@
+TestMIDI : UnitTest {
+	test_linuxRealtimeCodesAreCorrect {
+		var in, out;
+		var find = { |array, str|
+			array.detectIndex { |dev| dev.device.containsi(str) }
+		};
+		var inIndex;
+		var currentTest;
+		var cond = CondVar.new;
+		var tested;
+
+		if(thisProcess.platform.name == \linux) {
+			if(MIDIClient.initialized.not) {
+				MIDIClient.init;
+			};
+			// for macOS and Windows, 'in' would be in 'sources'
+			// in Linux, you connect to a destination
+			// check the MIDIOut help file, Linux section
+			inIndex = find.(MIDIClient.destinations, "supercollider");
+			if(inIndex.isNil) {
+				this.assert(false, "SC MIDI input port not found");
+				^this
+			};
+			out = MIDIOut(0).connect(inIndex).latency_(0);
+			in = MIDIFunc.sysrt({ |data, srcID, index|
+				this.assertEquals(index, currentTest.value,
+					"Index for '%' sysrt message should match spec".format(currentTest.key)
+				);
+				tested = true;
+				cond.signalAll;
+			});
+			[\start -> 10, \midiClock -> 8, \continue -> 11,
+				\stop -> 12, \songPtr -> 2, \reset -> 15
+			].do { |assn|
+				tested = false;
+				currentTest = assn;
+				out.perform(assn.key, 0);
+				cond.waitFor(0.5, { tested });
+				if(tested.not) {
+					this.assert(false, "% message was not received".format(assn.key));
+				};
+			};
+			in.free;
+			out.disconnect(inIndex);
+		} {
+			this.assert(true, "Realtime codes cannot be tested in macOS or Windows without external configuration, passing preemptively.");
+		};
+	}
+}

--- a/testsuite/scripts/gha_test_run_proto.json
+++ b/testsuite/scripts/gha_test_run_proto.json
@@ -117,6 +117,12 @@
             "test":"test_findText_notFound",
             "skip":true,
             "skipReason":"UnitTest sometimes fails when run in qpm"
+        },
+        {
+            "suite":"TestMIDI",
+            "test":"test_linuxRealtimeCodesAreCorrect",
+            "skip":true,
+            "skipReason":"Requires ALSA kernel module, not allowed in GHA"
         }
     ]
 }


### PR DESCRIPTION
## Purpose and Motivation

Fixes #5198 (for Linux, not totally sure about Windows -- there is a pending PR to fix a related crash in Windows).

In Linux, song position pointer and song select messages were sent with an incorrect sysrt message type code. We thought we were getting the type code from `evt->data.control.channel` (and maybe that was actually the case a decade or two ago), but I found in testing that this is always 0.

SC_CoreMIDI.cpp and SC_PortMIDI.cpp simply pass the code byte as a constant. So, I'm updating SC_AlsaMIDI.cpp accordingly.

I also found that the song position data value (`(pkt->data[2] << 7) | pkt->data[1]` for Core MIDI) is a wrong calculation in Alsa. Through debugging posts, I found that `evt->data.control.value` is already the 14-bit value, and doing `evt->data.control.value << 7` means that the value passed into the language is 128 times the correct value. With this change, if I send MIDI bytes `242 101 2`, the expected song position is `101 | (2 << 7)` == 357, and 357 is in fact the value received in the language.

## Types of changes

- Bug fix

## To-do list

- [x] Code is tested (now with UnitTest!)
- [x] All tests are passing
- [x] This PR is ready for review