### PR TITLE
Update GHA cache actions

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -303,13 +303,6 @@ jobs:
         with:
           path: ~/Library/Caches/Homebrew/downloads
           key: ${{ runner.os }}-${{ matrix.os-version }}-${{ matrix.xcode-version }}-${{ matrix.use-syslibs }}-${{ matrix.shared-libscsynth }}-${{ matrix.qt-version }}-${{ matrix.cmake-architectures }}-homebrew-${{ steps.current-date.outputs.week }}
-      - name: cache qt
-        id: cache-qt
-        uses: actions/cache@v1
-        if: matrix.qt-version
-        with:
-          path: ../Qt
-          key: ${{ runner.os }}-v1-${{ matrix.os-version }}-${{ matrix.xcode-version }}-${{ matrix.use-syslibs }}-${{ matrix.shared-libscsynth }}-qt${{ matrix.qt-version }}
       - name: cache qt universal binary
         id: cache-qt-universal
         uses: actions/cache@v3
@@ -513,14 +506,15 @@ jobs:
               combine_libraries $package
           done
       - name: install qt using aqtinstall
-        uses: jurplel/install-qt-action@v2
+        uses: jurplel/install-qt-action@v3
         if: matrix.qt-version
         env:
           DEVELOPER_DIR: '' # remove developer dir which causes installation to fail
         with:
           modules: 'qtwebengine'
           version: ${{ matrix.qt-version }}
-          cached: ${{ steps.cache-qt.outputs.cache-hit }}
+          cache: true
+          cache-key-prefix: ${{ runner.os }}-v1-${{ matrix.os-version }}-${{ matrix.xcode-version }}-${{ matrix.use-syslibs }}-${{ matrix.shared-libscsynth }}-qt${{ matrix.qt-version }}
 
       - name: configure
         run: |
@@ -587,6 +581,7 @@ jobs:
             vcvars-script: 'vcvars32.bat'
             vcpkg-triplet: x86-windows-release
             use-qtwebengine: 'ON' # might need to be turned off for MinGW
+            qt-modules: 'qtwebengine'
             ableton-link: 'ON' # might need to be turned off for MinGW
             artifact-suffix: 'win32' # set if needed - will trigger artifact upload
             create-installer: ${{ startsWith(github.ref, 'refs/tags/') }}
@@ -604,6 +599,7 @@ jobs:
             vcvars-script: 'vcvars64.bat'
             vcpkg-triplet: x64-windows-release
             use-qtwebengine: 'ON' # might need to be turned off for MinGW
+            qt-modules: 'qtwebengine'
             ableton-link: 'ON' # might need to be turned off for MinGW
             artifact-suffix: 'win64' # set if needed - will trigger artifact upload
             create-installer: ${{ startsWith(github.ref, 'refs/tags/') }}
@@ -618,6 +614,7 @@ jobs:
             cmake-generator: 'MinGW Makefiles'
             chocolatey-options: '' # '--forcex86' for 32-bit build
             use-qtwebengine: 'OFF' # might need to be turned off for MinGW
+            qt-modules: ''
             ableton-link: 'OFF' # might need to be turned off for MinGW
             artifact-suffix: 'win64-mingw' # set if needed - will trigger artifact upload
 
@@ -646,19 +643,14 @@ jobs:
           path: ~/AppData/Local/vcpkg/archives
           key: ${{ runner.os }}-${{ matrix.os-version }}-${{ matrix.cmake-arch }}-${{ matrix.vcpkg-triplet }}-${{ steps.current-date.outputs.stamp }}
           restore-keys: ${{ runner.os }}-${{ matrix.os-version }}-${{ matrix.cmake-arch }}-${{ matrix.vcpkg-triplet }}-
-      - name: cache qt
-        id: cache-qt
-        uses: actions/cache@v1
-        with:
-          path: ../Qt
-          key: ${{ runner.os }}-v1-${{ matrix.os-version }}-${{ matrix.qt-version }}-qt${{ matrix.qt-arch }}
       - name: install qt using aqtinstall
-        uses: jurplel/install-qt-action@v2
+        uses: jurplel/install-qt-action@v3
         with:
-          modules: 'qtwebengine'
+          modules: ${{ matrix.qt-modules }}
           version: ${{ matrix.qt-version }}
           arch: ${{ matrix.qt-arch }}
-          cached: ${{ steps.cache-qt.outputs.cache-hit }}
+          cache: true
+          cache-key-prefix: ${{ runner.os }}-v1-${{ matrix.os-version }}-${{ matrix.qt-version }}-qt${{ matrix.qt-arch }}
       - name: install libsndfile
         shell: bash
         run: |

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -137,7 +137,7 @@ jobs:
         id: current-date
         run: echo "::set-output name=stamp::$(date '+%Y-%m-%d')"
       - name: cache ccache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.ccache
           key: ${{ runner.os }}-${{ matrix.os-version }}-${{ matrix.c-compiler }}-${{ matrix.use-syslibs }}-${{ matrix.shared-libscsynth }}-${{ steps.current-date.outputs.stamp }}
@@ -292,13 +292,13 @@ jobs:
           echo "::set-output name=stamp::$(date '+%Y-%m-%d')"
           echo "::set-output name=week::$(date '+%V')"
       - name: cache ccache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/Library/Caches/ccache
           key: ${{ runner.os }}-${{ matrix.os-version }}-${{ matrix.xcode-version }}-${{ matrix.use-syslibs }}-${{ matrix.shared-libscsynth }}-${{ matrix.qt-version }}-${{ matrix.cmake-architectures }}-${{ steps.current-date.outputs.stamp }}
           restore-keys: ${{ runner.os }}-${{ matrix.os-version }}-${{ matrix.xcode-version }}-${{ matrix.use-syslibs }}-${{ matrix.shared-libscsynth }}-${{ matrix.qt-version }}-${{ matrix.cmake-architectures }}-
       - name: cache homebrew downloads
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: cache-homebrew
         with:
           path: ~/Library/Caches/Homebrew/downloads
@@ -319,7 +319,7 @@ jobs:
           key: ${{ runner.os }}-v1-${{ matrix.os-version }}-${{ matrix.xcode-version }}-${{ matrix.deployment-target }}-${{ matrix.vcpkg-triplet }}
       - name: cache vcpkg
         if: matrix.vcpkg-triplet
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.cache/vcpkg/archives
           key: ${{ runner.os }}-${{ matrix.os-version }}-${{ matrix.xcode-version }}-${{ matrix.deployment-target }}-${{ matrix.vcpkg-triplet }}-${{ steps.current-date.outputs.stamp }}
@@ -641,7 +641,7 @@ jobs:
           echo "::set-output name=week::$(date '+%V')"
       - name: cache vcpkg
         if: matrix.vcpkg-triplet
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/AppData/Local/vcpkg/archives
           key: ${{ runner.os }}-${{ matrix.os-version }}-${{ matrix.cmake-arch }}-${{ matrix.vcpkg-triplet }}-${{ steps.current-date.outputs.stamp }}

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -290,7 +290,6 @@ jobs:
         id: current-date
         run: |
           echo "::set-output name=stamp::$(date '+%Y-%m-%d')"
-          echo "::set-output name=week::$(date '+%V')"
       - name: cache ccache
         uses: actions/cache@v3
         with:
@@ -302,7 +301,8 @@ jobs:
         id: cache-homebrew
         with:
           path: ~/Library/Caches/Homebrew/downloads
-          key: ${{ runner.os }}-${{ matrix.os-version }}-${{ matrix.xcode-version }}-${{ matrix.use-syslibs }}-${{ matrix.shared-libscsynth }}-${{ matrix.qt-version }}-${{ matrix.cmake-architectures }}-homebrew-${{ steps.current-date.outputs.week }}
+          key: ${{ runner.os }}-${{ matrix.os-version }}-${{ matrix.xcode-version }}-${{ matrix.use-syslibs }}-${{ matrix.shared-libscsynth }}-${{ matrix.qt-version }}-${{ matrix.cmake-architectures }}-homebrew-${{ steps.current-date.outputs.stamp }}
+          restore-keys: ${{ runner.os }}-${{ matrix.os-version }}-${{ matrix.xcode-version }}-${{ matrix.use-syslibs }}-${{ matrix.shared-libscsynth }}-${{ matrix.qt-version }}-${{ matrix.cmake-architectures }}-homebrew-
       - name: cache qt universal binary
         id: cache-qt-universal
         uses: actions/cache@v3
@@ -635,7 +635,6 @@ jobs:
         id: current-date
         run: |
           echo "::set-output name=stamp::$(date '+%Y-%m-%d')"
-          echo "::set-output name=week::$(date '+%V')"
       - name: cache vcpkg
         if: matrix.vcpkg-triplet
         uses: actions/cache@v3


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

This is a maintenance PR, updating the cache action to the newest version.

`install-qt-action` was also updated and now features built-in caching, which is enabled instead of a separate caching action for downloaded qt.

I also added `restore-keys` to homebrew cache, so that the download cache will get updated daily, while still using cache from the previous day.

EDIT: `qtwebengine` was explicitly added to the Windows build matrix so that it can be disabled in the MinGW build. IIUC qtwebengine was never available for the `'win64_mingw81'` architecture, but previous version of the `install-qt-action` would not check that and proceeded to install qt regardless.

## Types of changes

<!-- Delete lines that don't apply -->

- Housekeeping (?)

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- n/a All tests are passing
- n/a Updated documentation
- [x] This PR is ready for review
