### PR TITLE
class library: make sure color is not converted to array

### DIFF
--- a/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
+++ b/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
@@ -776,7 +776,7 @@ Plotter {
 	}
 
 	plotColor_ { |colors|
-		plotColor = colors.as(Array);
+		if(colors.isArray.not) { colors = colors.bubble };
 		plots.do { |plt, i|
 			// rotate colors to ensure proper behavior with superpose
 			plt.plotColor_(plotColor.rotate(i.neg))

--- a/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
+++ b/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
@@ -86,8 +86,7 @@ Plot {
 		})
 	}
 	plotColor_ { |c|
-		colors = colors.as(Array);
-		plotColor = c;
+		plotColor = c.as(Array);
 	}
 	gridColorX_ { |c|
 		drawGrid.x.gridColor = c;

--- a/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
+++ b/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
@@ -775,7 +775,7 @@ Plotter {
 	}
 
 	plotColor_ { |colors|
-		colors = colors.as(Array);
+		plotColor = colors.as(Array);
 		plots.do { |plt, i|
 			// rotate colors to ensure proper behavior with superpose
 			plt.plotColor_(plotColor.rotate(i.neg))

--- a/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
+++ b/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
@@ -86,7 +86,7 @@ Plot {
 		})
 	}
 	plotColor_ { |c|
-		if(c.isArray.not) { c = c.bubble };
+		colors = colors.as(Array);
 		plotColor = c;
 	}
 	gridColorX_ { |c|
@@ -776,7 +776,7 @@ Plotter {
 	}
 
 	plotColor_ { |colors|
-		if(colors.isArray.not) { colors = colors.bubble };
+		colors = colors.as(Array);
 		plots.do { |plt, i|
 			// rotate colors to ensure proper behavior with superpose
 			plt.plotColor_(plotColor.rotate(i.neg))

--- a/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
+++ b/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
@@ -86,7 +86,8 @@ Plot {
 		})
 	}
 	plotColor_ { |c|
-		plotColor = c.asArray;
+		if(c.isArray.not) { c = c.bubble };
+		plotColor = c;
 	}
 	gridColorX_ { |c|
 		drawGrid.x.gridColor = c;


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

The example:
```supercollider
(
a = { (0..30).scramble }.dup(2).plot;
a.setProperties(
    \fontColor, Color.red,
    \plotColor, Color.red,
    \backgroundColor, Color.gray,
    \gridColorX, Color.white,
    \gridColorY, Color.black,

    \labelX, "Humidity"
);
a.refresh;
);
```
would not have a red `plotColor` because it was internally converted to an array (`Color`unfortunately responds to `asArray`with an array of values).

This fixes it.

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix


## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] This PR is ready for review
