### PR TITLE
sclang/scsynth/supernova: Two fixes for UdpInPort error reporting

### DIFF
--- a/lang/LangPrimSource/SC_ComPort.cpp
+++ b/lang/LangPrimSource/SC_ComPort.cpp
@@ -111,7 +111,7 @@ void SC_UdpInPort::handleReceivedUDP(const boost::system::error_code& error, std
     }
 
     if (error) {
-        printf("SC_UdpInPort: received error - %s\n", error.message().c_str());
+        printf("(sclang) SC_UdpInPort: received error - %s\n", error.message().c_str());
         startReceiveUDP();
         return;
     }

--- a/server/scsynth/SC_ComPort.cpp
+++ b/server/scsynth/SC_ComPort.cpp
@@ -206,8 +206,14 @@ class SC_UdpInPort {
         if (error == boost::asio::error::operation_aborted)
             return; /* we're done */
 
+        if (error == boost::asio::error::connection_refused) {
+            // avoid windows error message
+            startReceiveUDP();
+            return;
+        }
+
         if (error) {
-            printf("SC_UdpInPort: received error - %s", error.message().c_str());
+            printf("(scsynth) SC_UdpInPort: received error - %s\n", error.message().c_str());
             startReceiveUDP();
             return;
         }

--- a/server/supernova/sc/sc_osc_handler.cpp
+++ b/server/supernova/sc/sc_osc_handler.cpp
@@ -656,7 +656,7 @@ void sc_osc_handler::handle_receive_udp(const boost::system::error_code& error, 
         return; /* we're done */
 
     if (error) {
-        std::cout << "sc_osc_handler received error code " << error << std::endl;
+        std::cout << "(supernova) sc_osc_handler received error code " << error << std::endl;
         start_receive_udp();
         return;
     }


### PR DESCRIPTION
## Purpose and Motivation

This fixes a couple of discrepancies in UdpInPort error reporting.

1. sclang prints newline after the error text; scsynth inexplicably does not. Obviously a typo.

2. In the current release, the above typo is the *only* way to tell whether sclang or scsynth encountered a UdpInPort error. This is rather less than informative from the user's perspective. So, this PR adds prefixes "(sclang)" "(scsynth)" "(supernova)" to the error posting.

3. sclang suppresses "connection refused" errors (apparently because this error happens a lot in Windows, spuriously). scsynth does not. Windows users encounter this error, particularly when quitting the server, and then worry that something has gone terribly wrong. So this PR copies the sclang `if` block into scsynth.

For the third -- I did not port the block into supernova -- I can do so if others feel that I should. Supernova tends to be more "strict" (favoring "correctness" over user-friendliness) so I think it's in keeping with the feeling of supernova that it would report unnecessary errors. But, if we would prefer supernova to behave closer to scsynth in this regard, then I'm happy to add another commit.

I suppose it could be called a bug, but as it's basically cosmetic, I left off the "bug" label.

## Types of changes

- Bug fix

## To-do list

- [x] Code is tested
- [x] All tests are passing (code builds successfully; both scsynth and supernova start, and receive messages OK)
- [ ] Updated documentation (n/a, I think)
- [x] This PR is ready for review
