### PR TITLE
Plugins: Add 'ramp' flag to K2A

### DIFF
--- a/HelpSource/Classes/K2A.schelp
+++ b/HelpSource/Classes/K2A.schelp
@@ -7,8 +7,8 @@ categories::  UGens>Conversion
 Description::
 
 To be able to play a control rate UGen into an audio rate UGen,
-sometimes the rate must be converted. K2A converts via linear
-interpolation.
+sometimes the rate must be converted. By default, K2A converts via
+linear interpolation, though the interpolation can be turned off.
 
 
 classmethods::
@@ -17,6 +17,9 @@ method::ar
 
 argument::in
 The input signal.
+
+argument::ramp
+A flag to enable or disable linear interpolation. If nonzero, K2A will interpolate; if zero, there is no interpolation (the output is a zero-order hold, or stairstep). The default is 1.0 (enabled).
 
 Examples::
 
@@ -48,3 +51,22 @@ code::
 )
 ::
 
+subsection:: Ramp behavior
+
+The following plot contrasts a non-interpolated K2A against a normally interpolated K2A.
+
+If some degree of interpolation is desired, but not necessarily occupying a full control block, one option is to apply link::Classes/Slew:: to a non-interpolated K2A. (Note that the ramp time in this case will depend on the difference between the successive control rate values. Here, the difference between LFPulse values is always +1 or -1, so a slope of code::ControlRate.ir * 2:: will ramp over half of a control block. A smaller or larger differential would produce a shorter or longer ramp.)
+
+code::
+(
+{
+	var freq = ControlRate.ir * 0.25;
+	var krpulse = LFPulse.kr(freq);
+	var noRamp = K2A.ar(krpulse, 0);
+	var ramp = K2A.ar(krpulse, 1);
+	var slope = ControlRate.ir * 2;
+	var partialRamp = Slew.ar(noRamp, slope, slope);
+	[noRamp, ramp, partialRamp]
+}.plot;
+)
+::

--- a/SCClassLibrary/Common/Audio/Line.sc
+++ b/SCClassLibrary/Common/Audio/Line.sc
@@ -67,8 +67,8 @@ AmpCompA : AmpComp {
 }
 
 K2A : PureUGen { // control rate to audio rate converter
-	*ar { arg in = 0.0;
-		^this.multiNew('audio', in)
+	*ar { arg in = 0.0, ramp = 1.0;
+		^this.multiNew('audio', in, ramp)
 	}
 }
 

--- a/server/plugins/LFUGens.cpp
+++ b/server/plugins/LFUGens.cpp
@@ -1199,7 +1199,7 @@ struct K2A : SIMD_Unit {
 
     K2A(void) {
         mLevel.init(this);
-	mRamp.init(this);
+        mRamp.init(this);
         if (inRate(0) == calc_ScalarRate)
             set_unrolled_calc_function<K2A, &K2A::next_i<unrolled_64>, &K2A::next_i<unrolled>, &K2A::next_i<scalar>>();
         else
@@ -1212,7 +1212,7 @@ struct K2A : SIMD_Unit {
         else {
             mLevel.init(this);
             next_i<type>(inNumSamples);
-	}
+        }
     }
 
     template <int type> void next_i(int inNumSamples) { set_vec<type>(out(0), mLevel, inNumSamples); }

--- a/server/plugins/LFUGens.cpp
+++ b/server/plugins/LFUGens.cpp
@@ -1195,9 +1195,11 @@ void SyncSaw_Ctor(SyncSaw* unit) {
 
 struct K2A : SIMD_Unit {
     ControlRateInput<0> mLevel;
+    ControlRateInput<1> mRamp;
 
     K2A(void) {
         mLevel.init(this);
+	mRamp.init(this);
         if (inRate(0) == calc_ScalarRate)
             set_unrolled_calc_function<K2A, &K2A::next_i<unrolled_64>, &K2A::next_i<unrolled>, &K2A::next_i<scalar>>();
         else
@@ -1205,10 +1207,12 @@ struct K2A : SIMD_Unit {
     }
 
     template <int type> void next_k(int inNumSamples) {
-        if (mLevel.changed(this))
+        if (mRamp && mLevel.changed(this))
             slope_vec<type>(out(0), mLevel.slope(this), inNumSamples);
-        else
+        else {
+            mLevel.init(this);
             next_i<type>(inNumSamples);
+	}
     }
 
     template <int type> void next_i(int inNumSamples) { set_vec<type>(out(0), mLevel, inNumSamples); }


### PR DESCRIPTION
## Purpose and Motivation

Fixes #5803.

Currently, SC UGens assume that a control rate signal should always linearly interpolate, when being promoted to audio rate.

In cases where a user needs a zero-order hold, as far as I know, at present the only way is with Duty.ar. But that seems inefficient, clunky and un-intuitive.

One such use case: In my ddwWavetableSynth quark, the wavetable-position input is translated into an index into a buffer. This index must be aligned with the beginning of one of the wavetable variants (using some rounding math that I've used for a long time, for flip-flop crossfading between a pair of chains). When the index is interpolated, alignment is not guaranteed -- and in fact, if I modulate wtPos rapidly, the artifacts are unacceptable.

Note: #5803 proposed making 'ramp' a floating point value, such that 0.5 would ramp over half the control block, and 0.75 over 3/4 of it. I'm not skilled enough with advanced C++ to see how to do that with the SIMD functions. I'm not opposed to the idea but would basically need someone else to explain "for dummies" how to do it (or write it, and I'll check it in).

## Types of changes

- Documentation
- New feature
- Breaking change -- well... technically it's "breaking" in that there is a new input. But, K2A has never had a second input (not even `mul, add`, which don't make sense in this context anyway), so it doesn't invalidate any prior usage. (WRT non-SC clients, 2nd, 3rd inputs to K2A have always been ignored in the server.)

## To-do list

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review
