### PR TITLE
[classlib] Function:plot fix sample alignment with grid lines

### DIFF
--- a/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
+++ b/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
@@ -1128,31 +1128,52 @@ Plotter {
 
 + Function {
 	plot { |duration = 0.01, target, bounds, minval, maxval, separately = false|
+		var server, plotter, action;
+		var name = this.asCompileString;
 
-		var name = this.asCompileString, plotter, action;
-		if(name.size > 50 or: { name.includes(Char.nl) }) { name = "Function plot" };
+		if(name.size > 50 or: { name.includes(Char.nl) }) { name = "function plot" };
+
 		plotter = Plotter(name, bounds);
+		// init data in case function data is delayed (e.g. server booting)
 		plotter.value = [0.0];
+
 		target = target.asTarget;
+		server = target.server;
 		action = { |array, buf|
 			var numChan = buf.numChannels;
-			{
+			var numFrames = buf.numFrames;
+			var frameDur;
+
+			defer {
 				plotter.setValue(
-					array.unlace(numChan).collect(_.drop(-1)),
+					array.unlace(numChan),
 					findSpecs: true,
 					refresh: false,
 					separately: separately,
 					minval: minval,
 					maxval: maxval
 				);
+
 				plotter.domainSpecs = ControlSpec(0, duration, units: "Time (s)");
-			}.defer
+
+				// If individual values might be separated by at least 2.5 px
+				// (based on a plot at full screen width), set the x values (domain)
+				// explicitly for accurate time alignment with grid lines.
+				if(numFrames < (Window.screenBounds.width / 2.5)) {
+					frameDur = (this.value.rate == \control).if({
+						server.options.blockSize / server.sampleRate;
+					}, {
+						1 / server.sampleRate;
+					});
+					plotter.domain = numFrames.collect(_ * frameDur);
+				};
+			}
 		};
 
-		if(target.server.isLocal) {
-			this.loadToFloatArray(duration, target, action:action)
+		if(server.isLocal) {
+			this.loadToFloatArray(duration, target, action: action)
 		} {
-			this.getToFloatArray(duration, target, action:action)
+			this.getToFloatArray(duration, target, action: action)
 		};
 
 		^plotter

--- a/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
+++ b/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
@@ -1160,14 +1160,14 @@ Plotter {
 				// (based on a plot at full screen width), set the x values (domain)
 				// explicitly for accurate time alignment with grid lines.
 				if(numFrames < (Window.screenBounds.width / 2.5)) {
-					frameDur = (this.value.rate == \control).if({
-						server.options.blockSize / server.sampleRate;
-					}, {
-						1 / server.sampleRate;
-					});
+					frameDur = if(this.value.rate == \control) {
+						server.options.blockSize / server.sampleRate
+					} {
+						1 / server.sampleRate
+					};
 					plotter.domain = numFrames.collect(_ * frameDur);
 				};
-			}
+			};
 		};
 
 		if(server.isLocal) {

--- a/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
+++ b/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
@@ -573,7 +573,7 @@ Plot {
 		} {
 			("0" ! charCnt).join.bounds(Font(Font.defaultSansFace, 9)).size
 		};
-		labelSize.height = labelSize.height;
+		labelSize.width = labelSize.width * 1.1;
 
 		^[labelSize, params.labels]
 	}


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation
When plotting functions with a short duration, individual samples are visibly misaligned with the grid. The x-axis position of each sample doesn't account for the duration of the last sample period (a "fencepost problem"). This PR sets the sample position of the plotted points explicitly in the case that this time offset would be visible (i.e. a maximally wide plot would contain samples separated by ~2.5 pixels).

### Example
Below, both `SinOsc` and `Impulse` are plotted for a duration of 2 times their cycle period. So we expect the cycles to start at the leftmost part the plot (first cycle) and the center of the plot (second cycle). 

Currently:
<img width="300" alt="Screen Shot 2022-08-28 at 00 44 20" src="https://user-images.githubusercontent.com/923342/187092506-7198d42a-4ec1-4cb8-82ce-c54cf7ad3d28.png"><img width="300" alt="Screen Shot 2022-08-28 at 00 45 28" src="https://user-images.githubusercontent.com/923342/187092584-1f70b29e-1692-4ad9-8999-927cba6b82ac.png">
After the fix:
<img width="300" alt="Screen Shot 2022-08-28 at 00 46 58" src="https://user-images.githubusercontent.com/923342/187092757-50e51187-b224-4130-a64f-b1f13f7c1359.png"><img width="300" alt="Screen Shot 2022-08-28 at 00 47 24" src="https://user-images.githubusercontent.com/923342/187092760-39d13434-a864-4cea-980f-f6bb9082fe54.png">

Note the differences: 1. the second cycle begins at the center of the plot, 2. the _duration_ of the last sample is properly accounted for on the  time grid. The second point is further clarified when using the `plotMode = \steps` to visualize the sample-and-hold nature of discrete-time sampling:
<img width="350" alt="Screen Shot 2022-08-28 at 00 47 06" src="https://user-images.githubusercontent.com/923342/187092850-f5d7437d-5f6a-4739-978b-848402a14122.png">

Reproduce with ([more examples](https://gist.github.com/mtmccrea/dedb79a48312cd197b042d5c884ab44d)):
```
// SinOsc: the second cycle should begin exactly at
// time t = period (centered in the plot). fs = 48kHz.
(
var period = 0.0005, dur = period * 2;
f = { SinOsc.ar(period.reciprocal) };
f.plot(dur, bounds: Window.screenBounds.insetBy(400, 200)).plotMode_(\plines);
)
// Impulse - Control rate
( 
s.waitForBoot{
	var persamps = 6;
	var period = persamps * s.options.blockSize / s.sampleRate; // n samples per cycle
	var nper = 2;
	var dur = period * nper;
	postf("Expecting an impulse at:\n\ttime %\n\tsample %\n", period, nper.collect(_*persamps+1));

	f = { Impulse.kr(period.reciprocal) };
	f.loadToFloatArray(dur, action: {|arr| a = arr });
	f.plot(dur, bounds: Window.screenBounds.insetBy(400, 200)).plotMode_(\plines);
}
)
```

This PR also sneaks in a slight padding of x-grid tick labels, which was needed in some cases when the bounding rect of a `String` underestimates the width of the string (second commit).

## Types of changes

- Bug fix.

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing (`TestPlotter`)
~~[ ] Updated documentation~~
- [x] This PR is ready for review
