### PR TITLE
class library: remove inline warnings in common

### DIFF
--- a/SCClassLibrary/Common/GUI/Base/Grid.sc
+++ b/SCClassLibrary/Common/GUI/Base/Grid.sc
@@ -97,9 +97,9 @@ DrawGridX {
 	}
 	commands {
 		var p;
+		var valNorm, lineColor;
 		if(cacheKey != [range,bounds],{ commands = nil });
 		^commands ?? {
-			var valNorm, lineColor;
 			cacheKey = [range,bounds];
 			commands = [];
 			p = grid.getParams(range[0],range[1],bounds.left,bounds.right);
@@ -176,10 +176,11 @@ DrawGridY : DrawGridX {
 	}
 	commands {
 		var p;
+		var valNorm, lineColor;
 		if(cacheKey != [range,bounds],{ commands = nil });
 
 		^commands ?? {
-			var valNorm, lineColor;
+
 			commands = [];
 
 			p = grid.getParams(range[0], range[1], bounds.top, bounds.bottom);


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

There should be no uninlinable variables in common, it creates inline warnings

## Types of changes

<!-- Delete lines that don't apply -->


- Bug fix


## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] This PR is ready for review
