### PR TITLE
HistoryGui: improve display readability (fontsize and tabWidth)

### DIFF
--- a/SCClassLibrary/Common/GUI/PlusGUI/Core/HistoryGui.sc
+++ b/SCClassLibrary/Common/GUI/PlusGUI/Core/HistoryGui.sc
@@ -32,12 +32,14 @@ HistoryGui : JITGui {
 		);
 	}
 
+	winName { ^"History" }
+
 	makeViews { |options|
 		var font, flow;
 		var textViewHeight = numItems * skin.buttonHeight;
 		var listViewHeight = textViewHeight * 1.6;
 
-		font = Font(Font.defaultSansFace, 9);
+		font = Font(*GUI.skins.jit.fontSpecs);
 		flow = zone.addFlowLayout(2@2, 1@1);
 
 		zone.resize_(5);
@@ -66,6 +68,8 @@ HistoryGui : JITGui {
 				};
 			};
 		})
+		.font_(font)
+		.tabWidth_(font.size * 0.6 * 4) // ca. 4 chars
 		.resize_(2);
 
 		// to do: disable if history is not current!

--- a/SCClassLibrary/Common/GUI/PlusGUI/Core/HistoryGui.sc
+++ b/SCClassLibrary/Common/GUI/PlusGUI/Core/HistoryGui.sc
@@ -69,7 +69,7 @@ HistoryGui : JITGui {
 			};
 		})
 		.font_(font)
-		.tabWidth_(font.size * 0.6 * 4) // ca. 4 chars
+		.tabWidth_("1234".bounds(font)) // ca. 4 chars
 		.resize_(2);
 
 		// to do: disable if history is not current!


### PR DESCRIPTION
## Purpose and Motivation

HistoryGui has not been updated for Qt Guis, and thus had visual problems: 
Too small font size and too large tabWidth. 
Also, the window name was a bit confusingly "HistoryGui_History", 
which this PR clarifies to just say "History".
 
- [x] Code is tested
- [x] All tests are passing
- [x] This PR is ready for review
