### PR TITLE
[docs] Impulse: remove repeated Discussion, reword.

### DIFF
--- a/HelpSource/Classes/Impulse.schelp
+++ b/HelpSource/Classes/Impulse.schelp
@@ -15,7 +15,6 @@ method::ar, kr
 argument::freq
 Frequency in Hertz. strong::freq:: may be negative.
 
-
 argument::phase
 Phase offset in cycles (0..1). Staying in this range offers a slight efficiency
 advantage, though phase offsets outside this range are supported and wrapped
@@ -24,16 +23,8 @@ internally.
 argument::mul
 The output will be multiplied by this value.
 
-
 argument::add
 This value will be added to the output.
-
-Discussion::
-code::Impulse:: will output an impulse on the first sample (assuming no phase
-offset).
-
-When the initial code::freq = 0::, a single impulse is output on first sample,
-followed by silence until the frequency changes.
 
 Discussion::
 code::Impulse:: will output a code::1.0:: on the first sample (assuming no
@@ -47,20 +38,30 @@ code::(a,a)::, code::(a,k)::, code::(a,i)::,
 code::(k,k)::, code::(k,i)::,
 code::(i,k)::, code::(i,i)::.
 
+code::Impulse:: is based on a wrapping phasor: phase advances on
+each frame and if the phase goes out of range and is wrapped in that frame,
+an impulse is output.
 
-Internally, code::Impulse:: is based on a wrapping phasor: when the phase wraps,
-an impulse is output. Any strong::phase:: offset is added and wrapped before
-the phase increment (determined by strong::freq::) is applied. Therefore, it is
-the phase increment (freq) that triggers an impulse, not the phase offset. For
-example, if you wanted to drive and impulse train directly by the phase,
-code::Impulse:: would not support that. However, a small UGen network could
-achieve this result:
+Internally, the strong::phase:: offset value is applied
+and wrapped into range emphasis::before:: applying the phase increment
+(which is determined by the strong::freq::). After this phase increment,
+the trigger condition is checked. Therefore, it is the phase increment (freq)
+that triggers an impulse, emphasis::not:: the phase offset.
+
+For example, if you wanted to create an impulse train by setting
+code::freq: 0:: and modulating the strong::phase:: offset directly,
+code::Impulse:: would not support that.
+However, a you could generate an impulse train by phase modulation using the
+strong::rate:: parameter of a link::Classes/Phasor::, like this:
 code::
-({ var f = 1000;
-    HPZ1.ar(HPZ1.ar(Phasor.ar(rate: f * SampleDur.ir))) > 1e-5
-}.plot(0.005)
-);
+({
+	var f = 1000;
+	HPZ1.ar(HPZ1.ar(
+		Phasor.ar(rate: f * SampleDur.ir)
+	)) > 1e-5
+}.plot(0.005))
 ::
+
 
 Examples::
 


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

A block of duplicate text somehow made it into the `Impulse` help file, which also broke the `DISCUSSION` delimiter.
This PR fixes that, and while I was at it I clarified some of the language in that section.

## Types of changes

<!-- Delete lines that don't apply -->

- [x] Documentation

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review
