### PR TITLE
Deploy documentation via gh-pages

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -950,3 +950,47 @@ jobs:
           draft: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # originated from a combination of cmake target "doc" and GHA linux test
+  deploy_docs:
+    needs: [lint, Linux]
+    runs-on: ubuntu-18.04
+    name: 'deploy documentation'
+    env:
+      INSTALL_PATH: ${{ github.workspace }}/build/Install
+      SCLANG: 'build/Install/bin/sclang'
+      ARTIFACT_FILE: SuperCollider-${{ needs.lint.outputs.sc-version }}-linux-bionic-gcc10
+      RENDERED_HELP: ${{ github.workspace }}/RenderedHelp
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: false
+      - name: download linux artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: ${{ env.ARTIFACT_FILE }}
+          path: ${{ env.INSTALL_PATH }}
+      - name: extract artifact
+        run: |
+          cd $INSTALL_PATH
+          unzip $ARTIFACT_FILE.zip
+      - name: setup Linux environment
+        run: |
+          # install dependencies
+          sudo apt-get update
+          sudo apt-get install --yes libsndfile1 libavahi-client-dev libfftw3-dev libicu-dev libudev-dev qt5-default qtwebengine5-dev jackd1
+
+          # start jack
+          jackd --no-realtime -d dummy & 
+      - name: build HTML documentation
+        run: |
+          mkdir ${{ RENDERED_HELP }}
+          xvfb-run --server-args="-screen 0, 1280x720x24" -a ${{ SCLANG }} ${{ github.workspace }}/platform/renderAllHelp.scd ${{ github.workspace }}/HelpSource ${{ RENDERED_HELP }}
+      - name: replace URLs to GitHub URLs
+        run: |
+          cp ${{ RENDERED_HELP }}/Help.html ${{ RENDERED_HELP }}/index.html
+      - name: upload HTML documentation as gh-pages branch
+        uses: peaceiris/actions-gh-pages@v3.6.1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ${{ RENDERED_HELP }}

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -989,6 +989,10 @@ jobs:
       - name: replace URLs to GitHub URLs
         run: |
           cp $RENDERED_HELP/Help.html $RENDERED_HELP/index.html
+          find ./RenderedHelp/ -type f -exec sed -i -e 's_file:///home/runner/work/supercollider/supercollider/build/Install/share/SuperCollider/SCClassLibrary/_https://github.com/supercollider/supercollider/tree/develop/SCClassLibrary/_g' {} \;
+          find ./RenderedHelp/ -type f -exec sed -i -e 's_file:///home/runner/work/supercollider/supercollider/HelpSource/_https://github.com/supercollider/supercollider/tree/develop/HelpSource/_g' {} \; 
+          find ./RenderedHelp/ -type f -exec sed -i -e 's_/home/runner/work/supercollider/supercollider/build/Install/share/SuperCollider/SCClassLibrary/_https://github.com/supercollider/supercollider/tree/develop/SCClassLibrary/_g' {} \; 
+          find ./RenderedHelp/ -type f -exec sed -i -e 's_/home/runner/work/supercollider/supercollider/HelpSource/_https://github.com/supercollider/supercollider/tree/develop/HelpSource_g' {} \; 
       - name: upload HTML documentation as gh-pages branch
         uses: peaceiris/actions-gh-pages@v3.6.1
         with:

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -993,4 +993,4 @@ jobs:
         uses: peaceiris/actions-gh-pages@v3.6.1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ${{ RENDERED_HELP }}
+          publish_dir: $RENDERED_HELP

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -993,4 +993,4 @@ jobs:
         uses: peaceiris/actions-gh-pages@v3.6.1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: $RENDERED_HELP
+          publish_dir: RenderedHelp

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -3,13 +3,11 @@ on:
   push:
     paths-ignore:
       - 'examples/**'
-      - 'HelpSource/**'
       - 'sounds/**'
       - '*.md'
   pull_request:
     paths-ignore:
       - 'examples/**'
-      - 'HelpSource/**'
       - 'sounds/**'
       - '*.md'
 jobs:

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -984,11 +984,11 @@ jobs:
           jackd --no-realtime -d dummy & 
       - name: build HTML documentation
         run: |
-          mkdir ${{ RENDERED_HELP }}
-          xvfb-run --server-args="-screen 0, 1280x720x24" -a ${{ SCLANG }} ${{ github.workspace }}/platform/renderAllHelp.scd ${{ github.workspace }}/HelpSource ${{ RENDERED_HELP }}
+          mkdir $RENDERED_HELP
+          xvfb-run --server-args="-screen 0, 1280x720x24" -a $SCLANG ${{ github.workspace }}/platform/renderAllHelp.scd ${{ github.workspace }}/HelpSource $RENDERED_HELP
       - name: replace URLs to GitHub URLs
         run: |
-          cp ${{ RENDERED_HELP }}/Help.html ${{ RENDERED_HELP }}/index.html
+          cp $RENDERED_HELP/Help.html $RENDERED_HELP/index.html
       - name: upload HTML documentation as gh-pages branch
         uses: peaceiris/actions-gh-pages@v3.6.1
         with:

--- a/HelpSource/scdoc.css
+++ b/HelpSource/scdoc.css
@@ -15,6 +15,8 @@ body {
     font-size: 10pt;
     color: black;
     background: white;
+    margin: auto;
+    max-width: 1000px;
 }
 
 div.contents {
@@ -102,7 +104,7 @@ a.subclass_toggle:hover {
 
 
 #menubar {
-    position: fixed;
+    position: absolute;
     text-indent: 0;
     width: 100%;
     height: 33px;


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

Currently there is no official (?) supercollider documentation online, but one often gets on websites such as

* https://doc.sccode.org/Classes/Tdef.html (seems semi-official (?) but how it is maintained/deployed is unclear?)
* https://depts.washington.edu/dxscdoc/Help/Classes/Tdef.html 

While it is nice to have documentation hosted on multiple locations it is also nice to provide an official, always up-to-date documentation automatically with an officially associated URL where you also obtain the binaries from.
This also allows to modify the build in such a way that source files (`sc` and `schelp`) link to their respective files in develop branch on GitHub instead of non-accessible local files (therefore implements / fixes #5157 )

The deployment on my fork can be seen here: https://capital-g.github.io/supercollider/

The added GHA job can be observed here: https://github.com/capital-G/supercollider/actions/runs/3052357816/jobs/4921711256

## Types of changes

- Documentation
- New feature

Implemented a CI/CD pipeline which builds the documentation deploys it via github pages.
Currently the documentation is not build AFAIK but I think it is a good addition to build it automatically.

I modified the CSS file in such a way that the displaying on large monitors looks nicer (does not change look on a width below of 1000px)

New:
<img width="2372" alt="grafik" src="https://user-images.githubusercontent.com/8267062/190145333-2fba4666-7ee8-4fad-89ed-4920cb1c10a7.png">

Old:
<img width="2367" alt="grafik" src="https://user-images.githubusercontent.com/8267062/190145285-0f5f514d-fd18-4eac-9a16-aa22344cbf84.png">


## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review
- [ ] When should the pipeline be triggered (on tagged releases or on dev push?)
- [ ] Integrate it with supecollider.github.io

I have no experience with organization gh-pages (which allows to access https://github.com/supercollider/supercollider.github.io from https://supercollider.github.io ) and mixing them with repo gh-pages, [the gh documentation is a bit unclear about this](https://docs.github.com/en/pages/getting-started-with-github-pages/about-github-pages#types-of-github-pages-sites) but I think its possible to have both.

