### PR TITLE
supernova: fix Print plugin API method

### DIFF
--- a/server/supernova/server/server.hpp
+++ b/server/supernova/server/server.hpp
@@ -246,18 +246,6 @@ inline void run_scheduler_tick(void) {
     }
 }
 
-inline bool log_printf(const char* fmt, ...) {
-    if (instance->get_error_posting()) {
-        va_list vargs;
-        va_start(vargs, fmt);
-        auto result = instance->log_printf(fmt, vargs);
-        va_end(vargs);
-        return result;
-    }
-    return true;
-}
-
-
 inline void realtime_engine_functor::sync_clock(void) {
     if (instance->use_system_clock) {
         double nows = (uint64)(OSCTime(std::chrono::system_clock::now())) * kOSCtoSecs;
@@ -299,7 +287,6 @@ inline void realtime_engine_functor::run_tick(void) {
         instance->increment_logical_time();
 }
 
-
 inline bool log(const char* string) {
     if (instance->get_error_posting())
         return instance->log(string);
@@ -309,6 +296,24 @@ inline bool log(const char* string) {
 inline bool log(const char* string, size_t length) {
     if (instance->get_error_posting())
         return instance->log(string, length);
+    return true;
+}
+
+inline bool log_printf(const char* fmt, ...) {
+    if (instance->get_error_posting()) {
+        va_list vargs;
+        va_start(vargs, fmt);
+        auto result = instance->log_printf(fmt, vargs);
+        va_end(vargs);
+        return result;
+    }
+    return true;
+}
+
+inline bool log_printf(const char* fmt, va_list vargs) {
+    if (instance->get_error_posting()) {
+        return instance->log_printf(fmt, vargs);
+    }
     return true;
 }
 


### PR DESCRIPTION
## Purpose and Motivation

Currently, Supernova's `Print` plugin API method prints garbage if variadic arguments are used.

This regression has been introduced with https://github.com/supercollider/supercollider/commit/bd3aa3fd3256ea69f79be4b3e9b31b5085a07840. Mea culpa.

## Types of changes

add missing `va_list` overload for `nova::log_printf`.

- Bug fix

## To-do list

- [x] Code is tested
- [x] All tests are passing
- [ ] Updated documentation
- [x] This PR is ready for review
