### PR TITLE
GHA/Build system: use ccache on windows

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -695,6 +695,11 @@ jobs:
           arch: ${{ matrix.qt-arch }}
           cache: true
           cache-key-prefix: ${{ runner.os }}-v1-${{ matrix.os-version }}-${{ matrix.qt-version }}-qt${{ matrix.qt-arch }}
+      - name: install ccache
+        shell: bash
+        run: |
+          choco install ccache --no-progress
+          echo "`echo c:/ProgramData/chocolatey/lib/ccache/tools/ccache*`" >> $GITHUB_PATH # put the direct path before the path of the choco's "shim" (link subsitute)
       - name: install libsndfile
         shell: bash
         run: |

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -687,6 +687,12 @@ jobs:
           path: ~/AppData/Local/vcpkg/archives
           key: ${{ runner.os }}-${{ matrix.os-version }}-${{ matrix.cmake-arch }}-${{ matrix.vcpkg-triplet }}-${{ steps.current-date.outputs.stamp }}
           restore-keys: ${{ runner.os }}-${{ matrix.os-version }}-${{ matrix.cmake-arch }}-${{ matrix.vcpkg-triplet }}-
+      - name: cache ccache
+        uses: actions/cache@v3
+        with:
+          path: ~/ccache # this is likely used when running ccache 4.6.3 in bash, NOTE may change in 4.7+, see https://github.com/ccache/ccache/issues/1023
+          key: ${{ runner.os }}-${{ matrix.os-version }}-${{ matrix.cmake-arch }}-${{ matrix.qt-arch }}-${{ matrix.qt-version }}-${{ steps.current-date.outputs.stamp }}
+          restore-keys: ${{ runner.os }}-${{ matrix.os-version }}-${{ matrix.cmake-arch }}-${{ matrix.qt-arch }}-${{ matrix.qt-version }}-
       - name: install qt using aqtinstall
         uses: jurplel/install-qt-action@v3
         with:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -156,6 +156,29 @@ if( CCacheExectuable )
   # only used with >=cmake-3.4
   set( CMAKE_C_COMPILER_LAUNCHER   "${CCacheExectuable}" )
   set( CMAKE_CXX_COMPILER_LAUNCHER "${CCacheExectuable}" )
+  if(NOT CMAKE_GENERATOR MATCHES "Xcode" AND (NOT CMAKE_GENERATOR MATCHES "Visual Studio")) # we already post a message when using Xcode or MSVC
+    message(STATUS "Found ccache at ${CCacheExectuable}: using ccache to speed up build process")
+  endif()
+
+  # fix for Visual Studio adapted from https://github.com/ccache/ccache/wiki/MS-Visual-Studio#usage
+  # NOTE: there is an issue with ccache installed from chocolatey
+  # since chocolatey puts a "shim" as opposed to the actual executable in the PATH
+  # the solution is to add the path to the actual ccache executable earlier in the path
+  # e.g. in bash: export PATH=`echo c:/ProgramData/chocolatey/lib/ccache/tools/ccache*`:$PATH
+  if (MSVC)
+    message(STATUS "Found ccache at ${CCacheExectuable}: using ccache with MSVC to speed up build process")
+    file(COPY_FILE
+      ${CCacheExectuable} ${CMAKE_BINARY_DIR}/cl.exe
+      ONLY_IF_DIFFERENT)
+
+    set(CMAKE_VS_GLOBALS
+      "CLToolExe=cl.exe"
+      "CLToolPath=${CMAKE_BINARY_DIR}"
+      "TrackFileAccess=false"
+      "UseMultiToolTask=true"
+      "DebugInformationFormat=OldStyle"
+    )
+  endif()
 endif()
 
 #############################################

--- a/README_WINDOWS.md
+++ b/README_WINDOWS.md
@@ -30,6 +30,7 @@ Table of contents
     - SuperNova
     - Other targets (install, installer)
     - PortAudio
+    - Ccache
   - Common build problems
     - Dirty build states
     - Wrong libraries found
@@ -466,6 +467,12 @@ like to tweak the PortAudio build you can single it out from the SC build with:
 DSound support out of the box. If you want ASIO or WDM-KS, you need to build
 PortAudio within MSYS2. Users have experienced issues using the WASAPI backend
 to build in MinGW-based environments. Use Visual Studio if you need WASAPI.
+
+### Ccache
+
+Ccache speeds up recompilation by caching previous compilations and detecting when the same compilation is being done again. Ccache added partial support for MSVC in version 4.6.1. When the ccache executable is found in the PATH during the configuration step, it will be used to speed up the build process.
+
+NOTE: there's a caveat when using ccache installed with "chocolatey" package manager. The current implementation of ccache with MSVC and CMake requires copying `ccache.exe` into the build directory. This is done automatically by CMake during the configure step. However, when ccache is installed with chocolatey, what CMake finds is actually a chocolatey "shim" - an executable that redirects to the original file. Copying the "shim" into the build directory does not work, as the "shim" is not able to find the original executable afterwards. The solution to this is to add the path to the actual ccache.exe earlier in the PATH. This can be done in the command prompt with e.g. ```set PATH=C:\ProgramData\chocolatey\lib\ccache\tools\ccache-4.6.3-windows-x86_64\;%PATH%```. Note that the path needs to be adjusted for the currently installed version of ccache.
 
 Common build problems
 ---------------------


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

Ccache added support for MSVC in version 4.6.1.
Using it with MSVC requires some additional switches in the CMake which I added. 
There's also one "gotcha" - the _actual_ ccache executable, not a chocolatey "shim", needs to be in the PATH for this to work. I've added a note about it in the Windows README


## Types of changes

<!-- Delete lines that don't apply -->

- New feature
- Documentation

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review
