### PR TITLE
Fix RF64 and W64 format recognition

### DIFF
--- a/lang/LangPrimSource/PyrFilePrim.cpp
+++ b/lang/LangPrimSource/PyrFilePrim.cpp
@@ -1513,6 +1513,9 @@ int headerFormatToString(struct SF_INFO* info, const char** string) {
     case SF_FORMAT_W64:
         *string = "W64";
         break;
+    case SF_FORMAT_RF64:
+        *string = "RF64";
+        break;
     case SF_FORMAT_FLAC:
         *string = "FLAC";
         break;

--- a/lang/LangPrimSource/PyrFilePrim.cpp
+++ b/lang/LangPrimSource/PyrFilePrim.cpp
@@ -1511,7 +1511,7 @@ int headerFormatToString(struct SF_INFO* info, const char** string) {
         *string = "raw";
         break;
     case SF_FORMAT_W64:
-        *string = "WAV";
+        *string = "W64";
         break;
     case SF_FORMAT_FLAC:
         *string = "FLAC";


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

I noticed that a wave file with RF64 header was not recognized properly:

```supercollider
f = SoundFile.new;
f.openRead("/path/to/rf64/file.wav");
f.headerFormat.postcs; // result: " "
f.close
```
This PR fixes this, so that `f.headerFormat` returns `RF64`.

I also noticed that when reading, the Wave64 header was returned as `WAV`. I don't think this is right, since when writing the Wave64 file, one should specify the header as `"W64"` (see [here](https://github.com/supercollider/supercollider/blob/develop/common/SC_SndFileHelpers.hpp#L79)). 
I changed this accordingly and Wave64 is now reported as the "W64" header.

I tested this by reading the RF64 and Wave64 files into `SoundFile` and checking the `headerFormat`. 

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix


## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- n/a All tests are passing
- n/a Updated documentation
- [x] This PR is ready for review
