### PR TITLE
docs: added bus allocation and LFO mapping example

### DIFF
--- a/HelpSource/Guides/Non-Realtime-Synthesis.schelp
+++ b/HelpSource/Guides/Non-Realtime-Synthesis.schelp
@@ -89,7 +89,7 @@ list::
 ## Read a buffer from disk: code::[time, Buffer(server).allocReadMsg(path)]::
 ::
 
-NOTE:: Normal usage of link::Classes/Synth:: or link::Classes/Buffer:: communicates immediately with the server: code::Synth.new(...):: transmits teletype::/s_new::; code::Buffer.alloc(server, ...):: sends teletype::/b_alloc::. To build a NRT score, create the object as a placeholder (no immediate communication) and then ask a placeholder for the message: link::Classes/Synth#*basicNew:: and link::Classes/Synth#-newMsg::, or link::Classes/Buffer#*new:: and link::Classes/Buffer#-allocMsg:: or link::Classes/Buffer#-allocReadMsg::. If you have only used realtime synthesis, this code style is unfamiliar, but it's worth practicing.
+NOTE:: Normal usage of link::Classes/Synth:: or link::Classes/Buffer:: communicates immediately with the server: code::Synth.new(...):: transmits teletype::/s_new::; code::Buffer.alloc(server, ...):: sends teletype::/b_alloc::. To build a NRT score, create the object as a placeholder (no immediate communication) and then ask a placeholder for the message: link::Classes/Synth#*basicNew:: and link::Classes/Synth#-newMsg::, or link::Classes/Buffer#*new:: and link::Classes/Buffer#-allocMsg:: or link::Classes/Buffer#-allocReadMsg::. There is no need for a bus-allocation message simmilar to link::Classes/Buffer#-allocMsg::. If you have only used realtime synthesis, this code style is unfamiliar, but it's worth practicing.
 
 (The result of, e.g., teletype::newMsg:: is already the array representing the message. So it is sufficient for each Score item to be an array containing the time and method call. The subarray should be explicit only when writing the message by hand.) ::
 
@@ -532,4 +532,52 @@ f.close;
 
 // after rendering, always remember to clean up your mess:
 File.delete(PathName.tmp +/+ "Cmds.osc");
+::
+
+section:: Bus allocation and synth/LFO mapping
+
+In this example, a control bus and LFO map is used to have various affects on the source sound.
+
+code::
+(
+var nrtserver = Server(\nrt,
+    options: ServerOptions.new
+    .numOutputBusChannels_(2)
+    .numInputBusChannels_(2)
+);
+
+//control bus allocation
+var bus = Bus.control(nrtserver, 2);
+var lfo, sine;
+
+//LFO
+SynthDef.new(\lfo, {|out, freq=100|
+	Out.kr(out, LFNoise0.kr(freq).exprange(20.0,1000))
+}).load;
+
+lfo = Synth.basicNew(\lfo, server: nrtserver);
+
+SynthDef.new(\NRTsine, {|out=0, freq=440|
+	Out.ar(out, SinOsc.ar(freq, 0, 0.2).dup)
+}).load;
+
+sine = Synth.basicNew(\NRTsine, server: nrtserver);
+
+a = Score([
+	[0.0, lfo.newMsg(args:[\out, bus])],
+	[0.0, sine.newMsg],
+	[0.0, sine.mapMsg(\freq, bus)],
+]);
+
+a.recordNRT(
+    outputFilePath: "~/nrtbus-help.wav".standardizePath,
+    headerFormat: "wav",
+    sampleFormat: "int16",
+    options: nrtserver.options,
+    duration: 1,
+    action: { "done".postln }
+);
+
+nrtserver.remove;
+)
 ::


### PR DESCRIPTION

<!-- Please see CONTRIBUTING.md for guidelines. -->

Added an example in Non-Realtime-Synthesis.schelp called "Bus allocation and synth/LFO mapping" at the bottom of the page.
I also added an addition to the note found in "Timed messages" to stop users from looking for bus allocation OSC messages.

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

Fixes #5609 

<!-- Delete lines that don't apply -->

- Documentation


## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x ] Code is tested
- [x ] All tests are passing
- [x ] Updated documentation
- [x ] This PR is ready for review
