### PR TITLE
Fix couple of typos in Stream-Patterns-Events tutorial

### DIFF
--- a/HelpSource/Tutorials/Streams-Patterns-Events1.schelp
+++ b/HelpSource/Tutorials/Streams-Patterns-Events1.schelp
@@ -208,7 +208,7 @@ code::
 	Routine({
 		loop({
 			Synth(\help_SPE1, [ \freq, stream.next.midicps ] );
-			dur.wait; // synonym for yield, used by .play to schedule next occurence
+			dur.wait; // synonym for yield, used by .play to schedule next occurrence
 		})
 	}).play
 )

--- a/HelpSource/Tutorials/Streams-Patterns-Events7.schelp
+++ b/HelpSource/Tutorials/Streams-Patterns-Events7.schelp
@@ -5,7 +5,7 @@ categories:: Tutorials>Streams-Patterns-Events
 
 section::Practical Considerations
 
-subsection::Using your own ~instrument
+subsection::Using your own instrument
 
 code::
 (


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

Corrected a couple of typos on said tutorial. The "~instrument" one was especially jarring, or is there something I'm not getting about it?

## Types of changes

<!-- Delete lines that don't apply -->

- Documentation

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review
