### PR TITLE
class library: subBus uses same server as receiver

### DIFF
--- a/SCClassLibrary/Common/Control/Bus.sc
+++ b/SCClassLibrary/Common/Control/Bus.sc
@@ -39,7 +39,7 @@ Bus {
 		if(offset > bus.numChannels or: { numChannels + offset > bus.numChannels }) {
 			Error("Bus:newFrom tried to reach outside the channel range of %".format( bus )).throw
 		};
-		^this.new(bus.rate, bus.index + offset, numChannels)
+		^this.new(bus.rate, bus.index + offset, numChannels, bus.server)
 	}
 
 	isSettable {


### PR DESCRIPTION

When returning a subBus, the bus should use the same server as the receiver. 

## Purpose and Motivation

This fixes #5886. Thanks to @catniptwinz.

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix


## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] This PR is ready for review
