### PR TITLE
Fix NamedControl example code

### DIFF
--- a/HelpSource/Classes/NamedControl.schelp
+++ b/HelpSource/Classes/NamedControl.schelp
@@ -5,7 +5,7 @@ related:: Classes/ControlName, Classes/Control
 
 description::
 
-A NamedControl directly combines a ControlName and a Control UGen conveniently. Also this makes it safe even if several identical controls exist (see example below).
+A NamedControl directly combines a ControlName and a Control UGen conveniently. It can be saved to a var to send the control value to different parts of the function or SynthDef.
 
 There are syntax shortcuts that generate NamedControls from the name:
 code::
@@ -58,8 +58,12 @@ a.setn(\freq, [0, 2, 5].midiratio * 400);
 a = { SinOsc.ar(\freq.kr([300, 330, 370], [1, 0.3, 0.02])).sum * 0.1 }.play;
 
 // multiple usage of the same name:
-a = { SinOsc.ar(\freq.kr(440, 3.5)) + Saw.ar(\freq.kr(440, 0.05) * 0.5) * 0.1 }.play;
-
+(
+a = {
+	var freq = \freq.kr(440, 3.5);
+	SinOsc.ar(freq) + Saw.ar(freq * 0.5) * 0.1;
+}.play;
+)
 
 a.set(\freq, 1220)
 a.set(\freq, 120)
@@ -72,15 +76,16 @@ code::
 // compare:
 (
 a = {
-	var x, y;
-	x = NamedControl.kr(\freq, 440, 3.5);
-	y = NamedControl.kr(\freq, 440, 1);
-	SinOsc.ar([x, y] * [2, 1.2]) * 0.1
+	var freq, x, y;
+	freq = NamedControl.kr(\freq, 440);
+	x = freq.lag(3.5);
+	y = freq.lag(1);
+	SinOsc.ar([x, y] * [2, 1.2]) * 0.1;
 }.play;
 )
 
-a.set(\freq, 1220)
-a.set(\freq, 120)
+a.set(\freq, 1220);
+a.set(\freq, 120);
 
 (
 a = {

--- a/HelpSource/Classes/NamedControl.schelp
+++ b/HelpSource/Classes/NamedControl.schelp
@@ -5,7 +5,7 @@ related:: Classes/ControlName, Classes/Control
 
 description::
 
-A NamedControl directly combines a ControlName and a Control UGen conveniently. It can be saved to a var to send the control value to different parts of the function or SynthDef.
+A NamedControl directly combines a ControlName and a Control UGen conveniently. Also this makes it safe even if several identical controls exist (see example below).
 
 There are syntax shortcuts that generate NamedControls from the name:
 code::
@@ -56,48 +56,65 @@ a.setn(\freq, [0, 2, 5].midiratio * 400);
 
 // synonymous:
 a = { SinOsc.ar(\freq.kr([300, 330, 370], [1, 0.3, 0.02])).sum * 0.1 }.play;
+::
 
+subsection:: Multiple usage of the same name
+
+Identical controls can not make use of different defaults and lag values. They can be saved to a variable to avoid duplicate code.
+code::
 // multiple usage of the same name:
+a = { SinOsc.ar(\freq.kr(440, 1.0)) + Saw.ar(\freq.kr(440, 1.0) * 0.5) * 0.1 }.play;
+
+a.set(\freq, 1220);
+a.set(\freq, 120);
+
+// with different lag values:
+a = { SinOsc.ar(\freq.kr(440).lag(3.5)) + Saw.ar(\freq.kr(440).lag(0.05) * 0.5) * 0.1 }.play;
+
+a.set(\freq, 1220);
+a.set(\freq, 120);
+
+// control saved to a variable:
 (
 a = {
-	var freq = \freq.kr(440, 3.5);
-	SinOsc.ar(freq) + Saw.ar(freq * 0.5) * 0.1;
+	var freq = \freq.kr(440);
+	SinOsc.ar(freq.lag(3.5)) + Saw.ar(freq.lag(0.05) * 0.5) * 0.1;
 }.play;
 )
 
-a.set(\freq, 1220)
-a.set(\freq, 120)
+a.set(\freq, 1220);
+a.set(\freq, 120);
 ::
 
 subsection:: Comparison with direct use of Controls
 
 In the situation when functions are used to combine UGens to more complex SynthDefs, it may not be known which ControlNames are already taken by others. NamedControl allows to reuse existing control names.
 code::
-// compare:
+// compare this:
 (
 a = {
-	var freq, x, y;
-	freq = NamedControl.kr(\freq, 440);
-	x = freq.lag(3.5);
-	y = freq.lag(1);
-	SinOsc.ar([x, y] * [2, 1.2]) * 0.1;
+    var x, y;
+    x = NamedControl.kr(\freq, 440).lag(3.5);
+    y = NamedControl.kr(\freq, 440).lag(1);
+    SinOsc.ar([x, y] * [2, 1.2]) * 0.1
 }.play;
 )
 
 a.set(\freq, 1220);
 a.set(\freq, 120);
 
+// to this:
 (
 a = {
-	var x, y;
-	x = Control.names([\freq]).kr(440).lag(3.5);
-	y = Control.names([\freq]).kr(440).lag(1);
-	SinOsc.ar([x, y] * [2, 1.2]) * 0.1
+    var x, y;
+    x = Control.names([\freq]).kr(440).lag(3.5);
+    y = Control.names([\freq]).kr(440).lag(1); // this hangs when set
+    SinOsc.ar([x, y] * [2, 1.2]) * 0.1
 }.play;
 )
 
-a.set(\freq, 1220)
-a.set(\freq, 120)
+a.set(\freq, 1220);
+a.set(\freq, 120);
 ::
 
 subsection:: Using dictionary with functions to build SynthDefs


### PR DESCRIPTION
Refactors the examples in the help file to working code. Before an exception was thrown because the NamedControl was instanced with multiple different default values.

## Types of changes

<!-- Delete lines that don't apply -->

- Documentation

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review
