### PR TITLE
Fix time precision issues with Psync and EventStreamPlayer

### DIFF
--- a/HelpSource/Classes/SimpleNumber.schelp
+++ b/HelpSource/Classes/SimpleNumber.schelp
@@ -73,6 +73,12 @@ Round to multiple of aNumber
 method:: roundUp
 Round up to a multiple of aNumber. For roundDown use Link::Classes/SimpleNumber#-trunc#trunc::.
 
+method:: smallButNotZero
+Check if the value is closer to zero than a threshold, but not zero.
+
+argument::thresh
+The threshold to use for comparison.
+
 method:: trunc
 Truncate to multiple of aNumber (e.g. it rounds numbers down to a multiple of aNumber).
 

--- a/SCClassLibrary/Common/Math/SimpleNumber.sc
+++ b/SCClassLibrary/Common/Math/SimpleNumber.sc
@@ -84,6 +84,7 @@ SimpleNumber : Number {
 	gcd { |aNumber, adverb| _GCD; ^aNumber.performBinaryOpOnSimpleNumber('gcd', this, adverb) }
 	round { |aNumber=1.0, adverb| _Round; ^aNumber.performBinaryOpOnSimpleNumber('round', this, adverb) }
 	roundUp { |aNumber=1.0, adverb| _RoundUp; ^aNumber.performBinaryOpOnSimpleNumber('roundUp', this, adverb) }
+	smallButNotZero { |thresh=1e-12| ^this != 0 and: {  this.abs < thresh  } }
 	trunc { |aNumber=1.0, adverb| _Trunc; ^aNumber.performBinaryOpOnSimpleNumber('trunc', this, adverb) }
 	atan2 { |aNumber, adverb| _Atan2; ^aNumber.performBinaryOpOnSimpleNumber('atan2', this, adverb) }
 	hypot { |aNumber, adverb| _Hypot; ^aNumber.performBinaryOpOnSimpleNumber('hypot', this, adverb) }

--- a/SCClassLibrary/Common/Streams/FilterPatterns.sc
+++ b/SCClassLibrary/Common/Streams/FilterPatterns.sc
@@ -455,7 +455,7 @@ Psync : FilterPattern {
 	storeArgs { ^[pattern, quant, maxdur, tolerance, mindur] }
 
 	embedInStream { arg event;
-		var item, stream, delta, elapsed = 0.0, nextElapsed, clock, inevent;
+		var item, stream, delta, elapsed = 0.0, nextElapsed, inevent;
 		var	localquant = quant.value(event), localmaxdur = maxdur.value(event);
 		var cleanup = EventStreamCleanup.new;
 
@@ -475,7 +475,7 @@ Psync : FilterPattern {
 			delta = inevent.delta;
 			nextElapsed = elapsed + delta;
 
-			if (localmaxdur.notNil and: { nextElapsed.round(tolerance) >= localmaxdur }) {
+			if (localmaxdur.notNil and: { nextElapsed.roundUp(tolerance) >= localmaxdur }) {
 				inevent = inevent.copy;
 				inevent.put(\delta, localmaxdur - elapsed);
 				event = inevent.yield;

--- a/SCClassLibrary/Common/Streams/Stream.sc
+++ b/SCClassLibrary/Common/Streams/Stream.sc
@@ -544,9 +544,17 @@ EventStreamPlayer : PauseStream {
 			this.removedFromScheduler;
 			^nil
 		}{
+			var roundedBeat;
+			var deltaFromRounded;
 			nextTime = outEvent.playAndDelta(cleanup, muteCount > 0);
 			if (nextTime.isNil) { this.removedFromScheduler; ^nil };
 			nextBeat = inTime + nextTime;	// inval is current logical beat
+			roundedBeat = nextBeat.round;
+			deltaFromRounded = roundedBeat - nextBeat;
+			if (deltaFromRounded.smallButNotZero) {
+				nextBeat = roundedBeat;
+				nextTime = nextTime + deltaFromRounded;
+			};
 			^nextTime
 		};
 	}

--- a/testsuite/classlibrary/TestPatternProxy.sc
+++ b/testsuite/classlibrary/TestPatternProxy.sc
@@ -366,4 +366,47 @@ TestPatternProxy : UnitTest {
 
 
 	}
+
+	test_time_precision {
+		var clock = TempoClock.new(25);
+		var cond = Condition.new;
+		var controller;
+		var degrees = [];
+		var beats = [];
+		Pdef.clear;
+
+		{
+			// Test for note duplication when redefining the source of a playing Pdef (PR #5891)
+			var finish = Pfunc{ |ev| ev.use{ degrees = degrees ++ ~degree }; 1 };
+			Pdef(\a).clock_(clock).quant_(1).play(clock);
+			controller = SimpleController(Pdef(\a).player).put(\stopped, { cond.unhang; });
+			Pdef(\a).source = Pbind(\degree, Pseq((1..14), inf), \dur, 1/7, \finish, finish);
+			(clock.timeToNextBeat + 0.86).wait;
+			Pdef(\a).source = Pbind(\degree, Pseq((1..15), inf), \dur, 1/5, \finish, finish);
+			(clock.timeToNextBeat + 0.82).wait;
+			Pdef(\a).source = Pbind(\degree, Pseq((1..21), inf), \dur, 1/7, \finish, finish);
+			(clock.timeToNextBeat + 1.86).wait;
+			Pdef(\a).source = Pbind(\degree, Pseq((1..3), 1), \dur, 1/3, \finish, finish);
+		}.fork(clock, quant: 1);
+		cond.hang;
+		this.assert(degrees == ((1..7) ++ (1..5) ++ (1..14) ++ (1..3)), "1.1", false);
+
+		{
+			// Test for time imprecision issues (when playing "triplets" should end exactly on a beat)
+			Pdef(\t, Pbind(
+				\t, Pfunc{ beats = beats ++ thisThread.clock.beatInBar },
+				\dur, Pseq([
+					Pseq([1], 4),
+					Pseq([4/3], 3)
+				])
+			)).play(clock, quant: -1);
+			controller = SimpleController(Pdef(\t).player).put(\stopped, { cond.unhang; });
+		}.fork(clock, quant: 1);
+		cond.hang;
+		this.assert(beats.collect{ |beat, i| [0, 1, 2, 3, 0, 4/3, 8/3, 0][i].equalWithPrecision(beat, 1e-12) }.reduce('and'),
+			"1.2", false);
+		this.assert(beats.last === 0.0, "1.3", false);
+
+		Pdef.clear;
+	}
 }

--- a/testsuite/classlibrary/TestSimpleNumber.sc
+++ b/testsuite/classlibrary/TestSimpleNumber.sc
@@ -161,6 +161,12 @@ TestSimpleNumber : UnitTest {
 		this.assertEquals(actual, expected, "%.asTimeString(decimalPlaces: 100)".format(totalTime));
 	}
 
+	test_smallButNotZero {
+		var testF = {|vals, thresh| vals.collect({|num| num.smallButNotZero(thresh)})};
+		var val = [-1e-9, -1e-12, -0.9e-12, -1e-13, 0, 1e-13, 0.9e-12, 1e-12, 1e-9];
+		this.assertEquals(testF.(val, 1e-12), [ false, false, true, true, false, true, true, false, false ], "Test 1: smallButNotZero(1e-12)");
+	}
+
 	test_softRound {
 		var val;
 		var testF = {|vals, g, t, s| vals.collect({|num| num.softRound(g, t, s)})};


### PR DESCRIPTION
- add smallButNotZero method on SimpleNumber.
- incorporate changes from @telephon PR #4801: Psync now rounds up time.
- add fix for #4767, related to time precision, causing Event doubling when redefining Pdefs.

## Purpose and Motivation

Fixes #4767.

## Types of changes

- Documentation
- Bug fix

## To-do list

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review
