### PR TITLE
Add DrawGridTest

### DIFF
--- a/HelpSource/Classes/AbstractGridLines.schelp
+++ b/HelpSource/Classes/AbstractGridLines.schelp
@@ -12,7 +12,7 @@ code::
 \freq.asSpec.grid
 ::
 
-Subclasses of code::AbstractGridLines:: bind more tightly with the data they represent. For example, code::LinearGridLines:: and code::ExponentialGridLines:: represent data on a linear and exponential scale, respectively.
+Subclasses of code::AbstractGridLines:: correspond to the range and warp behavior of their assigned code::ControlSpec::. For example, code::LinearGridLines:: and code::ExponentialGridLines:: represent data on a linear and exponential scale, respectively.
 code::
 (
 // LinearGridLines
@@ -27,7 +27,7 @@ This default implementation does not know anything about the data is displaying:
 code::
 DrawGrid.test(nil, \midinote.asSpec.grid);
 ::
-A theoritical code::MidinoteGridLines:: could be written that labels these correctly, shows octaves and individual notes depending on the current zoom. Or a teletype::DegreeGridLines:: could draw pitch degree grid lines behind a frequency plot.
+A theoretical code::MidinoteGridLines:: could be written that labels these correctly, shows octaves and individual notes depending on the current zoom. Or a teletype::DegreeGridLines:: could draw pitch degree grid lines behind a frequency plot.
 
 Note that the code::AbstractGridLines:: does not know which axis it is to be used on and could also be used in polar plots or in 3D rendering.
 
@@ -38,7 +38,7 @@ METHOD:: new
 argument:: spec
 A link::Classes/ControlSpec:: that defines the numerical range, warp, and step.
 
-returns:: The newly instantiated object.
+returns:: An instance of this class.
 
 note:: code::AbstractGridLines:: shouldn't be instantiated directly. Instead, the link::Classes/GridLines:: factory class or the link::Classes/ControlSpec#-grid:: method should be used to return the appropriate code::AbstractGridLines:: subclass.
 ::
@@ -58,17 +58,19 @@ code::nil.asGrid:: returns a code::BlankGridLines:: (a subclass of code::Abstrac
 
 
 METHOD:: niceNum
-Rounds a value to a logical "nice number".  This method is used to support internal calculations for determining grid line values, though it may be useful for other applications.
+Rounds a value to a logical "nice number" that is within the same order of magnitude. See the discussion below for details.
 
 argument:: val
 The value you'd like to make nicer.
 
 argument:: round
-A boolean. Roughly speaking, rounding will allow the returned number to be above or below the input strong::val:: (similar to a code::round:: operation), while when code::false:: the returned number will tend be higher than strong::val:: (similar to code::ceil::).
+A boolean. Roughly speaking, rounding will allow the returned number to be above or below the input strong::val:: (similar to a code::round:: operation), while when code::false:: the returned number will tend to be higher than strong::val:: (similar to code::ceil::).
 
 returns:: The nice number.
 
 discussion::
+This method is used to support internal calculations for determining grid line values, though it may be useful for other applications.
+
 Observe the rounding behavior:
 code::
 (
@@ -79,7 +81,7 @@ var g = GridLines([0, 10000].asSpec);
 })
 )
 ::
-The implementation is based on: http://books.google.de/books?id=fvA7zLEFWZgC&pg=PA61&lpg=PA61.
+The implementation is based on: link::https://www.sciencedirect.com/book/9780080507538/graphics-gems##A. S. Glassner, Ed., Graphics Gems. San Diego: Morgan Kaufmann, 1990::.
 
 
 METHOD:: looseRange

--- a/HelpSource/Classes/AbstractGridLines.schelp
+++ b/HelpSource/Classes/AbstractGridLines.schelp
@@ -1,32 +1,33 @@
 CLASS:: AbstractGridLines
-summary:: given a spec and the actual data's min and max values, calculates the ideal spacing and labelling of grid lines for plotting
+summary:: Calculates the numerical values suitable for grid lines to be used for plotting or other UI elements.
 categories:: GUI>Accessories
-related:: Classes/GridLines, Reference/plot, Classes/Plotter, Classes/DrawGrid
+related:: Classes/GridLines, Classes/LinearGridLines, Classes/ExponentialGridLines, Classes/DrawGrid, Classes/ControlSpec, Classes/Plotter, Reference/plot
 
 DESCRIPTION::
-code::AbstractGridLines:: and its subclasses are strategy objects that implements a general strategy for finding a suitable min max range for graphing and suitable intervals for grid lines and labelling.
+code::AbstractGridLines:: and its subclasses are strategy objects that find suitable intervals for plotting grid lines and labels. The data range and warping behavior (e.g. linear or exponential) are derived from the corresponding link::Classes/ControlSpec::. The instance methods of code::AbstractGridLines:: are used by link::Classes/DrawGrid:: (which is in turn used by link::Classes/Plotter::) for getting logically spaced intervals that span the data for drawing grid lines on a plot.
 
-Neither code::AbstractGridLines:: nor its subclasses are to be instantiated directly. Instead, link::Classes/GridLines:: factory class should be used to return the code::AbstractGridLines:: subclass appropriate for the given link::Classes/ControlSpec::.
-
-The object that does the actual drawing on a view is link::Classes/DrawGrid::.
-
-An code::AbstractGridLines:: object uses a link::Classes/ControlSpec:: to define the minimum and maximum possible values.  Given a data set's actual minimum and maximum values, the code::AbstractGridLines:: object can choose a logical range for graphing that encompasses the data that will be plotted.
-
-Subclasses of code::AbstractGridLines:: bind more tightly with the data they are representing. E.g. code::LinearGridLines:: represents data on linear scale, while code::ExponentialGridLines:: represents data on exponential scale. Future development work could add other subclasses like e.g. DegreeGridLines to be used to draw pitch degree GridLines behind a frequency plot.
-
-link::Classes/Spec:: has a .grid variable that points to its preferred code::AbstractGridLines:: subclass that should be used for graphing.
+code::AbstractGridLines:: shouldn't be instantiated directly. Instead, the link::Classes/GridLines:: factory class or the link::Classes/ControlSpec#-grid:: method should be used to return the appropriate code::AbstractGridLines:: subclass for the given spec.
 
 code::
 \freq.asSpec.grid
 ::
 
-This default implementation does not know anything about the data is displaying:
+Subclasses of code::AbstractGridLines:: bind more tightly with the data they represent. For example, code::LinearGridLines:: and code::ExponentialGridLines:: represent data on a linear and exponential scale, respectively.
+code::
+(
+// LinearGridLines
+var linGrid = ControlSpec(0, 100, \lin, units: "Time").grid;
+// ExponentialGridLines
+var expGrid = \freq.asSpec.grid;
 
+DrawGrid.test(linGrid, expGrid);
+)
+::
+This default implementation does not know anything about the data is displaying:
 code::
 DrawGrid.test(nil, \midinote.asSpec.grid);
 ::
-
-A MidinoteGridLines could be written that labels these correctly, shows octaves and individual notes depending on the current zoom.
+A theoritical code::MidinoteGridLines:: could be written that labels these correctly, shows octaves and individual notes depending on the current zoom. Or a teletype::DegreeGridLines:: could draw pitch degree grid lines behind a frequency plot.
 
 Note that the code::AbstractGridLines:: does not know which axis it is to be used on and could also be used in polar plots or in 3D rendering.
 
@@ -35,100 +36,105 @@ CLASSMETHODS::
 METHOD:: new
 
 argument:: spec
-The ControlSpec that defines the minimum and maximum values, warp and step.
+A link::Classes/ControlSpec:: that defines the numerical range, warp, and step.
 
-returns:: a AbstractGridLines
+returns:: The newly instantiated object.
 
+note:: code::AbstractGridLines:: shouldn't be instantiated directly. Instead, the link::Classes/GridLines:: factory class or the link::Classes/ControlSpec#-grid:: method should be used to return the appropriate code::AbstractGridLines:: subclass.
+::
 
 INSTANCEMETHODS::
 
 METHOD:: spec
-get/set the spec
+Get/set the code::ControlSpec:: that defines the numerical range, warp, and step.
 
-returns:: a ControlSpec
+returns:: A link::Classes/ControlSpec::.
 
 METHOD:: asGrid
-return self.  nil.asGrid would return a BlankGridLines which is a subclass of AbstractGridLines.  So when plotting if you specify a grid of nil then you will get no lines at all.
+Return this object.
 
-returns:: self
+discussion::
+code::nil.asGrid:: returns a code::BlankGridLines:: (a subclass of code::AbstractGridLines::) which produces no drawn lines. So if code::nil:: is passed to the strong::grid:: argument of code::DrawGrid::, no lines are drawn on the corresponding axis.
+
 
 METHOD:: niceNum
-Based on: http://books.google.de/books?id=fvA7zLEFWZgC&pg=PA61&lpg=PA61
-
-This rounds a value to a logical nice number.  It is mostly used to support internal calculation, though it may be useful for other applications.
+Rounds a value to a logical "nice number".  This method is used to support internal calculations for determining grid line values, though it may be useful for other applications.
 
 argument:: val
-The value.
+The value you'd like to make nicer.
 
 argument:: round
-Boolean. Rounding uses a specific algorithm.  This is not simple rounding to an integer value.
+A boolean. Roughly speaking, rounding will allow the returned number to be above or below the input strong::val:: (similar to a code::round:: operation), while when code::false:: the returned number will tend be higher than strong::val:: (similar to code::ceil::).
 
-returns:: the nice number
+returns:: The nice number.
 
-METHOD:: ideals
-for internal use
+discussion::
+Observe the rounding behavior:
+code::
+(
+var g = GridLines([0, 10000].asSpec);
+"in val / rounded / not rounded".postln;
+10.collect{ 10000.rand }.sort.do({ |x|
+    postf("% / % / %\n", x, g.niceNum(x, true), g.niceNum(x, false))
+})
+)
+::
+The implementation is based on: http://books.google.de/books?id=fvA7zLEFWZgC&pg=PA61&lpg=PA61.
 
-argument:: min
-(describe argument here)
-
-argument:: max
-(describe argument here)
-
-argument:: ntick
-(describe argument here)
-
-returns:: (returnvalue)
 
 METHOD:: looseRange
-Returns the logical minimum and maximum that will contain the data.
+Returns the logical minimum and maximum that will contain the strong::min:: and strong::max::, determed internally using link::#-niceNum::.
 
 argument:: min
-minimum value
+Minimum value to include in the returned range.
 
 argument:: max
-maximum value.
+Maximum value to include in the returned range.
 
 argument:: ntick
-the number of lines you would like (which usually varies by how much screen space you have and what you consider cluttered)
+The number of lines ("ticks") you would like within the range of code::[min, max]::, default: code::5::.
 
-returns:: [ideal min, ideal max]
+returns:: An link::Classes/Array:: with the lower and upper bounds of the range containing your strong::min:: and strong::max::, i.e. code::[rangeMin, rangeMax]::.
+
 
 METHOD:: getParams
-Specifically for use by DrawGrid. This returns a dictionary filled with:
-'lines': an array of values where lines should be drawn
-'labels': [value, formatted label] for each line
+
+Specifically for use by link::Classes/DrawGrid::.
+This returns a link::Classes/Dictionary:: with keys: code::'lines'::, an array of values where lines should be drawn, and code::'labels'::, an array of 2-element arrays code::[value, "formatted label"]:: for each line.
+
+Note that the highest and lowest values returned don't necessarily contain your strong::valueMin:: and strong::valueMax::, but rather represent the values where grid lines will be drawn by code::DrawGrid:: (endcap lines are subsequently drawn at the data/grid bounds).
 
 argument:: valueMin
-minimum value of the data to be plotted
+Minimum value of the data to be plotted. The lowest grid line value returned may be higher than this value.
 
 argument:: valueMax
-maximum value of the data to be plotted
+Maximum value of the data to be plotted. The highest grid line value returned may be lower than this value.
 
 argument:: pixelMin
-If numTicks is nil: used to guess the ideal numTicks based on the graph size.
+Lower bound of the grid's range, in pixels. Used to calculate the size of the available grid space when determining grid values based on strong::tickSpacing:: (if code::numTicks:: is code::nil::).
 
 argument:: pixelMax
-If numTicks is nil: used to guess the ideal numTicks based on the graph size.
+Upper bound of the grid's range, in pixels. Used to calculate the size of the available grid space when determining grid values based on strong::tickSpacing:: (if code::numTicks:: is code::nil::).
 
 argument:: numTicks
-Explicit number of ticks you would like to see on the graph.
+Explicit number of ticks you would like to see on the graph (though the result is approximate). Set to code::nil:: if you'd like the number of ticks to be found automatically, based on strong::pixelMin::, strong::pixelMax::, and strong::tickSpacing::.
 
 argument:: tickSpacing
-Approximate distance between ticks (in pixels). This value is only used when code::numTicks:: is code::nil::.
+Minimum distance between ticks (in pixels). This value is only used when code::numTicks:: is code::nil::.
 
-returns:: A dictionary
+returns:: A link::Classes/Dictionary::.
+
 
 METHOD:: formatLabel
-Round the value and append the spec's units
+Format a numerical value for display as text, rounded to a desired precision.
 
 argument:: val
-The value
+The value to round and convert to a text label.
 
 argument:: numDecimalPlaces
-Number of decimal places
+Number of decimal places to represent in the returned code::String::.
 
-returns:: a string
-
-private:: prCheckWarp
+returns:: A link::Classes/String::.
 
 
+private:: prCheckWarp, ideals

--- a/HelpSource/Classes/ControlSpec.schelp
+++ b/HelpSource/Classes/ControlSpec.schelp
@@ -70,7 +70,10 @@ method::guessNumberStep
 Used for EZ GUI classes for guessing a sensible strong::step:: if none is specified.
 
 method::gridClass
-Returns the link::Classes/AbstractGridLines:: subclass appropriate for the current spec.
+Returns the link::Classes/AbstractGridLines:: subclass with an appropriate correspondence to the current spec, in particular its warp behavior.
+
+method::grid
+Get/set an instance of the link::Classes/AbstractGridLines:: subclass that describes the range and warp behavior of the current spec, e.g. for use by link::Classes/DrawGrid:: for drawing grids in link::Classes/Plotter::.
 
 Examples::
 

--- a/HelpSource/Classes/ControlSpec.schelp
+++ b/HelpSource/Classes/ControlSpec.schelp
@@ -70,7 +70,7 @@ method::guessNumberStep
 Used for EZ GUI classes for guessing a sensible strong::step:: if none is specified.
 
 method::gridClass
-Returns the link::Classes/AbstractGridLines:: subclass with an appropriate correspondence to the current spec, in particular its warp behavior.
+Returns the link::Classes/AbstractGridLines:: subclass corresponding to the current spec, in particular its warp behavior.
 
 method::grid
 Get/set an instance of the link::Classes/AbstractGridLines:: subclass that describes the range and warp behavior of the current spec, e.g. for use by link::Classes/DrawGrid:: for drawing grids in link::Classes/Plotter::.

--- a/HelpSource/Classes/DrawGrid.schelp
+++ b/HelpSource/Classes/DrawGrid.schelp
@@ -4,15 +4,11 @@ categories:: GUI>Accessories
 related:: Reference/plot, Classes/AbstractGridLines, Classes/GridLines, Classes/Plotter, Classes/UserView
 
 DESCRIPTION::
-DrawGrid is used by Plotter to draw the grid lines on a graph. It can however
-also be used to draw link::Classes/AbstractGridLines:: on any
-link::Classes/UserView:: and could even be used to add grid lines to UserViews
-behind sliders or in any GUI.
+code::DrawGrid:: is used to draw link::Classes/GridLines:: and its labels on a link::Classes/UserView::. It is notably used by link::Classes/Plotter:: to draw the grid lines on a plot but can also be used to add grid lines to any code::UserView::, e.g. behind sliders or another GUI element.
 
-Note that DrawGrid does not hold any reference to the UserView but is meant to
-have its .draw method called inside of the UserView's drawFunc.  It only needs
-to know what bounds the grid lines should be drawn within and what the
-horizontal and vertical AbstractGridLines are.
+See the example below for its link::#Basic use in a UserView#basic use in a UserView::.
+
+Note that code::DrawGrid:: does not hold any reference to the code::UserView:: but is meant to have its code::-draw:: method called inside of the code::-drawFunc:: of the code::UserView::.  It only needs to know what bounds in which to draw the grid lines and what the horizontal and vertical code::GridLines:: are.
 
 
 CLASSMETHODS::
@@ -20,63 +16,74 @@ CLASSMETHODS::
 METHOD:: new
 
 argument:: bounds
-The bounds describing the extents of the grid (not including any labels).
-Multiple DrawGrid may be used to draw grids on a single
-link::Classes/UserView::.
+A link::Classes/Point:: or link::Classes/Rect:: describing the size and position of the grid within the parent view (not including any labels).
 
 argument:: horzGrid
-An link::Classes/AbstractGridLines:: subclass.
+A grid lines object for the x-axis, instantiated via link::Classes/GridLines::, or link::Classes/ControlSpec#-grid:: method, or code::nil:: (resulting in no grid lines).
 
 argument:: vertGrid
-An link::Classes/AbstractGridLines:: subclass.
+A grid lines object for the y-axis, see strong::horzGrid::.
 
-returns:: A DrawGrid.
+returns:: A code::DrawGrid::.
+
+discussion::
+For the strong::horizGrid:: and strong::vertGrid:: arguments, link::Classes/GridLines:: or link::Classes/ControlSpec#-grid:: will instantiate a subclass of link::Classes/AbstractGridLines::, such as link::Classes/LinearGridLines:: or link::Classes/ExponentialGridLines::, based on the code::ControlSpec::'s warp behavior.
+
+Multiple code::DrawGrid:: may be used to draw grids on a single link::Classes/UserView::.
+
 
 METHOD:: test
-For testing new link::Classes/AbstractGridLines:: objects.
+For testing a new link::Classes/AbstractGridLines:: object.
 code::
 DrawGrid.test(\freq.asSpec.grid, \amp.asSpec.grid);
+::
+code::
 DrawGrid.test(nil, \lofreq.asSpec.grid);
 ::
 
 argument:: horzGrid
-An link::Classes/AbstractGridLines:: subclass.
+A grid lines object for the x-axis, instantiated via link::Classes/GridLines::, or link::Classes/Spec#-grid:: method, or code::nil:: (resulting in a link::Classes/BlankGridLines::).
 
 argument:: vertGrid
-An link::Classes/AbstractGridLines:: subclass.
+A grid lines object for the y-axis, see strong::horzGrid::.
 
 argument:: bounds
-Bounds describing the extents of the grid (not including any labels) within the
-parent view. Can be a link::Classes/Point:: or link::Classes/Rect::.
+A link::Classes/Point:: or link::Classes/Rect:: describing the size and position of the grid within the parent view (not including any labels).
 Default: code::500 @ 400::.
 
-returns:: A DrawGrid.
+returns:: A code::DrawGridTest:: (a subclass of code::DrawGrid::).
+
+discussion::
+See link::#-test:: if you'd like to preview or test modifications of a code::DrawGrid:: that has already been created. Also see link::#Testing and modifying#Examples:: below.
+
+Inspecting the source code of code::DrawGridTest:makeWindow:: can serve as a guide on how to embed a code::DrawGrid:: in a code::UserView::.
 
 
 INSTANCEMETHODS::
 
 METHOD:: draw
-This draws to the currently active link::Classes/UserView::. This method is
-meant to be called from inside the
-link::Classes/UserView#-drawFunc#drawFunc:: of a UserView.
+This draws to the currently active link::Classes/UserView::. This method is meant to be called from inside the link::Classes/UserView#-drawFunc#-drawFunc:: of a code::UserView::.
 
-returns:: nil
+returns:: code::nil::
+
+discussion::
+See the example below for its link::#Basic use in a UserView#basic use in a UserView::, including how to manage its bounds when the enclosing view resizes.
 
 
 METHOD:: horzGrid
-Set the X axis grid lines.
+Set the x-axis grid lines.
 
 argument:: g
-An link::Classes/AbstractGridLines:: subclass.
+An link::Classes/AbstractGridLines:: subclass, instantiated via link::Classes/GridLines::, or link::Classes/ControlSpec#-grid:: method, or code::nil:: (resulting in no grid lines).
 
 returns:: Self.
 
 
 METHOD:: vertGrid
-Set the Y axis grid lines.
+Set the y-axis grid lines.
 
 argument:: g
-An link::Classes/AbstractGridLines:: subclass.
+An link::Classes/AbstractGridLines:: subclass, instantiated via link::Classes/GridLines::, or link::Classes/ControlSpec#-grid:: method, or code::nil:: (resulting in no grid lines).
 
 returns:: Self.
 
@@ -117,54 +124,158 @@ returns:: Self.
 METHOD:: opacity
 Get/set opacity.
 
-returns:: A Float.
+returns:: A code::Float::.
 
 METHOD:: smoothing
-A Boolean which turns on/off anti-aliasing. See link::Classes/Pen#*smoothing::.
+A code::Boolean:: which turns on/off anti-aliasing. See link::Classes/Pen#*smoothing::.
 
-returns:: A Boolean.
+returns:: A code::Boolean::.
 
 METHOD:: linePattern
-Set the line dash pattern. pattern should be a link::Classes/FloatArray:: of
-values that specify the lengths of the painted segments and not painted
-segments. See link::Classes/Pen#*lineDash::.
+Set the line dash pattern. The strong::value:: should be a link::Classes/FloatArray:: of values that specify the lengths of the alternating dashes and spaces.
+For example, code::FloatArray[10.0, 3.0, 5.0, 3.0]::, for dashes of lengths code::10.0:: and code::5.0:: pixels, separated by spaces of code::3.0:: pixels.
+See link::Classes/Pen#*lineDash::.
 
 returns:: Self.
 
 METHOD:: x
-A link::Classes/DrawGridX:: object that draws the x (horizontal) axis. In
+A code::DrawGridX:: object that draws the x (horizontal) axis. In
 general you shouldn't need to set this.
 
-returns:: A link::Classes/DrawGridX::.
+returns:: A code::DrawGridX::.
 
 METHOD:: y
-A link::Classes/DrawGridY:: object that draws the y (vertical) axis. In general
+A code::DrawGridY:: object that draws the y (vertical) axis. In general
 you shouldn't need to set this.
 
-returns:: A link::Classes/DrawGridY::.
+returns:: A code::DrawGridY::.
+
+
+METHOD:: numTicks
+Set the emphasis::approximate:: number of grid lines ("ticks") for each axis. If set, the number of ticks is fixed and code::numTicks:: takes precedence over link::#-tickSpacing::. If code::nil::, the number of grid lines change with the view size, constrained by the code::tickSpacing::.
+Default: code::nil::.
+
+See link::#Testing in a UserView#Examples:: below.
+
+argument:: numx
+emphasis::Approximate:: number of grid lines ("ticks") for the x-axis.
+
+argument:: numy
+emphasis::Approximate:: number of grid lines for the y-axis.
+
+discussion::
+The resulting number of ticks is approximate because of the underlying algorithm in link::Classes/GridLines#-niceNum::, which tries to find suitable values for the grid lines based on the data range and your requested code::numTicks::. You can observe the behavior of code::GridLines:-niceNum:: with this snippet:
+code::
+(
+g = GridLines([0, 200].asSpec);
+"requested / returned".postln;
+(0, 3 .. 21).do({ |ntck|
+  "% / %\n".postf(ntck, g.niceNum(ntck, true))
+})
+)
+::
+
+
+METHOD:: tickSpacing
+Set the emphasis::minimum:: spacing between grid lines ("ticks") for each axis. The number of grid lines will change with the view size, but won't be spaced less than this code::tickSpacing::, allowing you to control the density of grid lines. However if link::#-numTicks:: is not code::nil::, it takes precedence over code::tickSpacing::.
+
+See link::#Testing in a UserView#Examples:: below.
+
+argument:: xpx
+emphasis::Minimum:: spacing between grid lines ("ticks") on the x-axis (pixels, default: 64).
+
+argument:: ypx
+emphasis::Minimum:: spacing between grid lines on the y-axis (pixels, default: 64).
+
+
+METHOD:: test
+Test this code::DrawGrid:: object by creating a window with a view showing the code::DrawGrid:: in its current state.
+
+code::
+d = DrawGrid(nil, \freq.asSpec.grid, \amp.asSpec.grid);
+d.linePattern_(FloatArray[10.0, 5.0, 2.0, 5.0]);
+d.test;
+::
+
+
+See link::#*test:: for creating a code::DrawGrid:: and previewing it immediately. See also link::#Testing in a UserView#Examples:: below.
 
 
 METHOD:: copy
 Safely make a copy of this object and its working members.
 
-returns:: A new link::Classes/DrawGrid::.
+returns:: A new code::DrawGrid::.
 
 
 PRIVATE:: clearCache, init
 
 EXAMPLES::
 
+SUBSECTION:: Basic use in a UserView
+
 code::
 (
 w = Window.new.front;
 u = UserView(w,w.bounds.size.asRect);
 
-// the Spec can define its preferred grid system
-x = \lofreq.asSpec.grid;
-y = \amp.asSpec.grid;
-d = DrawGrid(u.bounds.size.asRect.insetBy(20), x, y);
+// The spec defines its preferred grid system
+x = \lofreq.asSpec.grid; // x grid lines
+y = \amp.asSpec.grid;    // y grid lines
+i = 40;                  // grid inset
+
+d = DrawGrid(u.bounds.size.asRect.insetBy(i), x, y);
 
 u.drawFunc = { d.draw };
-u.resize_(5).onResize = { |u| d.bounds = u.bounds.size.asRect.insetBy(20) }
+u.resize_(5);
+u.onResize = { |u|
+	d.bounds = u.bounds.size.asRect.insetBy(i)
+};
 )
+::
+
+SUBSECTION:: Testing and modifying
+
+For testing the look and feel of your code::GridLines::, you can create and immediately render your code::DrawGrid:: using the link::#*test:: class method, or call link::#-test:: on your already-instantiated code::DrawGrid:: object.
+
+Create and immediately render your code::DrawGrid:: using the link::#*test:: class method:
+code::
+(
+c = ControlSpec.new(20,200, \lin, units: "myUnits");
+g = c.grid;
+~test = DrawGrid.test(g,g)
+)
+::
+
+Modifying its properties then refresh the view to see the changes:
+code::
+// Modify the number of grid lines on each axis separately
+~test.x.tickSpacing_(18); // fixed *density* of x ticks
+~test.y.numTicks_(8);     // fixed *number* of y ticks (approximate)
+~test.refresh;            // refresh the test view
+
+~test.y.numTicks_(nil); // numTicks = nil: auto, follows -tickSpacing
+~test.refresh;
+::
+
+The returned code::DrawGridTest:: is a subclass of code::DrawGrid::, so you can call all the methods you would on code::DrawGrid::. Convenience methods like link::#-numTicks:: and link::#-tickSpacing:: adjust both axes together:
+code::
+// Fixed number of grid lines; -numTicks takes precedence over -tickSpacing
+~test.numTicks_(10, 10).tickSpacing_(30, 75).refresh;
+
+// Dynamic number of grid lines; -tickSpacing determines minimum line spacing when resizing
+~test.numTicks_(nil, nil).tickSpacing_(30, 75).refresh;
+~test.linePattern_(FloatArray[10.0, 5.0, 2.0, 5.0]).refresh;
+::
+
+Alternatively, you can instantiate your code::DrawGrid::, modify its properties, then preview it with the link::#-test:: method:
+code::
+(
+// Instantiate a new DrawGrid, modify it
+var xspec = ControlSpec.new(20, 2000, \lin, units: "xUnits");
+var yspec = ControlSpec.new(20, 200, \lin, units: "yUnits");
+d = DrawGrid.new(horzGrid: xspec.grid, vertGrid: yspec.grid);
+d.x.tickSpacing_(25); // set its properties before testing
+)
+// Test it, returning and displaying a "test version" of it for more modification
+~test = d.test;
 ::

--- a/HelpSource/Classes/DrawGrid.schelp
+++ b/HelpSource/Classes/DrawGrid.schelp
@@ -157,10 +157,10 @@ Default: code::nil::.
 
 See link::#Testing and modifying#Examples:: below.
 
-argument:: numx
+argument:: x
 emphasis::Approximate:: number of grid lines ("ticks") for the x-axis.
 
-argument:: numy
+argument:: y
 emphasis::Approximate:: number of grid lines for the y-axis.
 
 discussion::
@@ -181,10 +181,10 @@ Set the emphasis::minimum:: spacing between grid lines ("ticks") for each axis. 
 
 See link::#Testing and modifying#Examples:: below.
 
-argument:: xpx
+argument:: x
 emphasis::Minimum:: spacing between grid lines ("ticks") on the x-axis (pixels, default: 64).
 
-argument:: ypx
+argument:: y
 emphasis::Minimum:: spacing between grid lines on the y-axis (pixels, default: 64).
 
 

--- a/HelpSource/Classes/DrawGrid.schelp
+++ b/HelpSource/Classes/DrawGrid.schelp
@@ -27,36 +27,11 @@ A grid lines object for the y-axis, see strong::horzGrid::.
 returns:: A code::DrawGrid::.
 
 discussion::
-For the strong::horizGrid:: and strong::vertGrid:: arguments, link::Classes/GridLines:: or link::Classes/ControlSpec#-grid:: will instantiate a subclass of link::Classes/AbstractGridLines::, such as link::Classes/LinearGridLines:: or link::Classes/ExponentialGridLines::, based on the code::ControlSpec::'s warp behavior.
+The warp behavior of the strong::horizGrid:: and strong::vertGrid:: is based on the warp behavior of the code::ControlSpec:: used by the grid lines object assigned to each axis.
 
 Multiple code::DrawGrid:: may be used to draw grids on a single link::Classes/UserView::.
 
-
-METHOD:: test
-For testing a new link::Classes/AbstractGridLines:: object.
-code::
-DrawGrid.test(\freq.asSpec.grid, \amp.asSpec.grid);
-::
-code::
-DrawGrid.test(nil, \lofreq.asSpec.grid);
-::
-
-argument:: horzGrid
-A grid lines object for the x-axis, instantiated via link::Classes/GridLines::, or link::Classes/Spec#-grid:: method, or code::nil:: (resulting in a link::Classes/BlankGridLines::).
-
-argument:: vertGrid
-A grid lines object for the y-axis, see strong::horzGrid::.
-
-argument:: bounds
-A link::Classes/Point:: or link::Classes/Rect:: describing the size and position of the grid within the parent view (not including any labels).
-Default: code::500 @ 400::.
-
-returns:: A code::DrawGridTest:: (a subclass of code::DrawGrid::).
-
-discussion::
-See link::#-test:: if you'd like to preview or test modifications of a code::DrawGrid:: that has already been created. Also see link::#Testing and modifying#Examples:: below.
-
-Inspecting the source code of code::DrawGridTest:makeWindow:: can serve as a guide on how to embed a code::DrawGrid:: in a code::UserView::.
+See link::#-preview:: if you'd like to preview modifications of this code::DrawGrid::. See link::#Testing and modifying#Examples:: below.
 
 
 INSTANCEMETHODS::
@@ -188,18 +163,17 @@ argument:: y
 emphasis::Minimum:: spacing between grid lines on the y-axis (pixels, default: 64).
 
 
-METHOD:: test
-Test this code::DrawGrid:: object by creating a window with a view showing the code::DrawGrid:: in its current state.
+METHOD:: preview
+Preview this code::DrawGrid:: object by creating a window with a view showing the code::DrawGrid:: in its current state.
 
 code::
 d = DrawGrid(nil, \freq.asSpec.grid, \amp.asSpec.grid);
 d.linePattern_(FloatArray[10.0, 5.0, 2.0, 5.0]);
-d.test;
+d.preview;
 ::
+If the code::DrawGrid:: is modified, you can code::-refresh:: the returned code::UserView:: to see its updated state, or simply call code::-preview:: again to update the view (or create the preview again if the code::Window:: was closed). See link::#Testing and modifying#Examples:: below.
 
-
-See link::#*test:: for creating a code::DrawGrid:: and previewing it immediately. See also link::#Testing and modifying#Examples:: below.
-
+returns:: A link::Classes/UserView:: which draws this code::DrawGrid::.
 
 METHOD:: copy
 Safely make a copy of this object and its working members.
@@ -235,47 +209,37 @@ u.onResize = { |u|
 
 SUBSECTION:: Testing and modifying
 
-For testing the look and feel of your code::GridLines::, you can create and immediately render your code::DrawGrid:: using the link::#*test:: class method, or call link::#-test:: on your already-instantiated code::DrawGrid:: object.
-
-Create and immediately render your code::DrawGrid:: using the link::#*test:: class method:
+For previewing the look and feel of your code::GridLines::, you can render your code::DrawGrid:: using the link::#-preview:: method:
 code::
 (
-c = ControlSpec.new(20,200, \lin, units: "myUnits");
-g = c.grid;
-~test = DrawGrid.test(g,g)
+x = [0, 10].asSpec.units_("sec");
+y = [0, 1].asSpec.units_("amp");
+d = DrawGrid((500@250).asRect, x.grid, y.grid);
+
+// set its properties before testing
+d.x.tickSpacing_(25);
+d.linePattern_(FloatArray[10.0, 5.0, 2.0, 5.0]);
+
+// generate a preview
+~testView = d.preview;
 )
 ::
-
-Modifying its properties then refresh the view to see the changes:
+Use code::DrawGrid::'s convenience methods to set the grids' properties, then refresh the view:
+code::
+d.tickSpacing_(50, 25).linePattern_(FloatArray[1.0]);
+~testView.refresh;
+::
+Or just call code::.preview:: again and it will refresh the existing view:
+code::
+d.linePattern_(FloatArray[10.0, 5.0, 2.0, 5.0]).preview;
+::
+Proterties of the individual x- and y-grids can also be accessed and changed separately:
 code::
 // Modify the number of grid lines on each axis separately
-~test.x.tickSpacing_(18); // fixed *density* of x ticks
-~test.y.numTicks_(8);     // fixed *number* of y ticks (approximate)
-~test.refresh;            // refresh the test view
+d.x.tickSpacing_(18); // fixed (max) *density* of x ticks
+d.y.numTicks_(8);     // fixed *number* of y ticks (approximate)
+d.preview;            // refresh the test view
 
-~test.y.numTicks_(nil); // numTicks = nil: auto, follows -tickSpacing
-~test.refresh;
-::
-
-The returned code::DrawGridTest:: is a subclass of code::DrawGrid::, so you can call all the methods you would on code::DrawGrid::. Convenience methods like link::#-numTicks:: and link::#-tickSpacing:: adjust both axes together:
-code::
-// Fixed number of grid lines; -numTicks takes precedence over -tickSpacing
-~test.numTicks_(10, 10).tickSpacing_(30, 75).refresh;
-
-// Dynamic number of grid lines; -tickSpacing determines minimum line spacing when resizing
-~test.numTicks_(nil, nil).tickSpacing_(30, 75).refresh;
-~test.linePattern_(FloatArray[10.0, 5.0, 2.0, 5.0]).refresh;
-::
-
-Alternatively, you can instantiate your code::DrawGrid::, modify its properties, then preview it with the link::#-test:: method:
-code::
-(
-// Instantiate a new DrawGrid, modify it
-var xspec = ControlSpec.new(20, 2000, \lin, units: "xUnits");
-var yspec = ControlSpec.new(20, 200, \lin, units: "yUnits");
-d = DrawGrid.new(horzGrid: xspec.grid, vertGrid: yspec.grid);
-d.x.tickSpacing_(25); // set its properties before testing
-)
-// Test it, returning and displaying a "test version" of it for more modification
-~test = d.test;
+d.y.numTicks_(nil);   // numTicks = nil: auto, follows -tickSpacing
+d.preview;
 ::

--- a/HelpSource/Classes/DrawGrid.schelp
+++ b/HelpSource/Classes/DrawGrid.schelp
@@ -8,7 +8,7 @@ code::DrawGrid:: is used to draw link::Classes/GridLines:: and its labels on a l
 
 See the example below for its link::#Basic use in a UserView#basic use in a UserView::.
 
-Note that code::DrawGrid:: does not hold any reference to the code::UserView:: but is meant to have its code::-draw:: method called inside of the code::-drawFunc:: of the code::UserView::.  It only needs to know what bounds in which to draw the grid lines and what the horizontal and vertical code::GridLines:: are.
+Note that code::DrawGrid:: does not hold any reference to the code::UserView:: but is meant to have its code::-draw:: method called inside of the code::-drawFunc:: of the code::UserView::.  It only needs to know what bounds to draw the grid lines in and what the horizontal and vertical code::GridLines:: are.
 
 
 CLASSMETHODS::
@@ -155,7 +155,7 @@ METHOD:: numTicks
 Set the emphasis::approximate:: number of grid lines ("ticks") for each axis. If set, the number of ticks is fixed and code::numTicks:: takes precedence over link::#-tickSpacing::. If code::nil::, the number of grid lines change with the view size, constrained by the code::tickSpacing::.
 Default: code::nil::.
 
-See link::#Testing in a UserView#Examples:: below.
+See link::#Testing and modifying#Examples:: below.
 
 argument:: numx
 emphasis::Approximate:: number of grid lines ("ticks") for the x-axis.
@@ -164,7 +164,7 @@ argument:: numy
 emphasis::Approximate:: number of grid lines for the y-axis.
 
 discussion::
-The resulting number of ticks is approximate because of the underlying algorithm in link::Classes/GridLines#-niceNum::, which tries to find suitable values for the grid lines based on the data range and your requested code::numTicks::. You can observe the behavior of code::GridLines:-niceNum:: with this snippet:
+The resulting number of ticks is approximate because of the underlying algorithm in link::Classes/AbstractGridLines#-niceNum::, which tries to find suitable values for the grid lines based on the data range and your requested code::numTicks::. You can observe the behavior of code::GridLines:-niceNum:: with this snippet:
 code::
 (
 g = GridLines([0, 200].asSpec);
@@ -179,7 +179,7 @@ g = GridLines([0, 200].asSpec);
 METHOD:: tickSpacing
 Set the emphasis::minimum:: spacing between grid lines ("ticks") for each axis. The number of grid lines will change with the view size, but won't be spaced less than this code::tickSpacing::, allowing you to control the density of grid lines. However if link::#-numTicks:: is not code::nil::, it takes precedence over code::tickSpacing::.
 
-See link::#Testing in a UserView#Examples:: below.
+See link::#Testing and modifying#Examples:: below.
 
 argument:: xpx
 emphasis::Minimum:: spacing between grid lines ("ticks") on the x-axis (pixels, default: 64).
@@ -198,7 +198,7 @@ d.test;
 ::
 
 
-See link::#*test:: for creating a code::DrawGrid:: and previewing it immediately. See also link::#Testing in a UserView#Examples:: below.
+See link::#*test:: for creating a code::DrawGrid:: and previewing it immediately. See also link::#Testing and modifying#Examples:: below.
 
 
 METHOD:: copy

--- a/HelpSource/Classes/ExponentialGridLines.schelp
+++ b/HelpSource/Classes/ExponentialGridLines.schelp
@@ -1,0 +1,35 @@
+CLASS:: ExponentialGridLines
+summary:: Calculates the numerical values suitable for exponentially-spaced grid lines to be used for plotting or other UI elements.
+categories:: GUI>Accessories
+related:: Classes/GridLines, Classes/AbstractGridLines, Classes/LinearGridLines, Classes/DrawGrid, Classes/ControlSpec, Classes/Plotter, Reference/plot
+
+DESCRIPTION::
+code::ExponentialGridLines:: is a strategy object that finds suitable intervals for plotting grid lines and labels. The values span the range defined by a corresponding link::Classes/ControlSpec::. Most of the functionality of code::ExponentialGridLines:: is inherited from its superclass, link::Classes/AbstractGridLines::. The instance methods are used by link::Classes/DrawGrid:: (which is in turn used by link::Classes/Plotter::) which handles the drawing of the lines and labels.
+
+code::ExponentialGridLines:: isn't usually instantiated directly, but rather by the link::Classes/GridLines:: factory class or the link::Classes/ControlSpec#-grid:: method which return the appropriate code::AbstractGridLines:: subclass for the given spec.
+
+code::
+(
+// LinearGridLines
+var linGrid = ControlSpec(0, 100, \lin, units: "Time").grid;
+// ExponentialGridLines
+var expGrid = \freq.asSpec.grid;
+
+DrawGrid.test(linGrid, expGrid);
+)
+::
+
+CLASSMETHODS::
+
+COPYMETHOD:: AbstractGridLines *new
+
+INSTANCEMETHODS::
+
+COPYMETHOD:: AbstractGridLines -spec
+COPYMETHOD:: AbstractGridLines -asGrid
+COPYMETHOD:: AbstractGridLines -niceNum
+COPYMETHOD:: AbstractGridLines -looseRange
+COPYMETHOD:: AbstractGridLines -getParams
+COPYMETHOD:: AbstractGridLines -formatLabel
+
+private:: prCheckWarp, ideals

--- a/HelpSource/Classes/GridLines.schelp
+++ b/HelpSource/Classes/GridLines.schelp
@@ -1,10 +1,11 @@
 CLASS:: GridLines
 summary:: A factory class for AbstractGridLines
 categories:: GUI>Accessories
-related:: Classes/AbstractGridLines
+related:: Classes/AbstractGridLines, Classes/LinearGridLines, Classes/ExponentialGridLines, Classes/DrawGrid, Classes/ControlSpec, Classes/Plotter, Reference/plot
+
 
 DESCRIPTION::
-code::GridLines:: is a factory class that returns the appropriate subclass of link::Classes/AbstractGridLines:: for a given code::ControlSpec::.
+code::GridLines:: is a factory class that returns the appropriate subclass of link::Classes/AbstractGridLines:: for a given code::ControlSpec::, e.g. a link::Classes/LinearGridLines:: or link::Classes/ExponentialGridLines:: for a linear or exponential spec, respectively. See those help files for examples and information on modifying their behavior.
 
 
 CLASSMETHODS::
@@ -12,6 +13,6 @@ CLASSMETHODS::
 METHOD:: new
 
 argument:: spec
-The ControlSpec that defines the minimum and maximum values, warp and step.
+A link::Classes/ControlSpec:: that defines the minimum and maximum values, warp and step.
 
-returns:: a subclass of link::Classes/AbstractGridLines::
+returns:: A subclass of link::Classes/AbstractGridLines::, e.g. link::Classes/LinearGridLines:: or link::Classes/ExponentialGridLines::.

--- a/HelpSource/Classes/LinearGridLines.schelp
+++ b/HelpSource/Classes/LinearGridLines.schelp
@@ -1,0 +1,35 @@
+CLASS:: LinearGridLines
+summary:: Calculates the numerical values suitable for linearly-spaced grid lines to be used for plotting or other UI elements.
+categories:: GUI>Accessories
+related:: Classes/GridLines, Classes/AbstractGridLines, Classes/ExponentialGridLines, Classes/DrawGrid, Classes/ControlSpec, Classes/Plotter, Reference/plot
+
+DESCRIPTION::
+code::LinearGridLines:: is a strategy object that finds suitable intervals for plotting grid lines and labels. The values span the range defined by a corresponding link::Classes/ControlSpec::. Most of the functionality of code::LinearGridLines:: is inherited from its superclass, link::Classes/AbstractGridLines::. The instance methods are used by link::Classes/DrawGrid:: (which is in turn used by link::Classes/Plotter::) which handles the drawing of the lines and labels.
+
+code::LinearGridLines:: isn't usually instantiated directly, but rather by the link::Classes/GridLines:: factory class or the link::Classes/ControlSpec#-grid:: method which return the appropriate code::AbstractGridLines:: subclassfor the given spec.
+
+code::
+(
+// LinearGridLines
+var linGrid = ControlSpec(0, 100, \lin, units: "Time").grid;
+// ExponentialGridLines
+var expGrid = \freq.asSpec.grid;
+
+DrawGrid.test(linGrid, expGrid);
+)
+::
+
+CLASSMETHODS::
+
+COPYMETHOD:: AbstractGridLines *new
+
+INSTANCEMETHODS::
+
+COPYMETHOD:: AbstractGridLines -spec
+COPYMETHOD:: AbstractGridLines -asGrid
+COPYMETHOD:: AbstractGridLines -niceNum
+COPYMETHOD:: AbstractGridLines -looseRange
+COPYMETHOD:: AbstractGridLines -getParams
+COPYMETHOD:: AbstractGridLines -formatLabel
+
+private:: prCheckWarp, ideals

--- a/SCClassLibrary/Common/GUI/Base/Grid.sc
+++ b/SCClassLibrary/Common/GUI/Base/Grid.sc
@@ -336,7 +336,7 @@ AbstractGridLines {
 		^this.ideals(min,max,ntick).at( [ 0,1] )
 	}
 	getParams {
-		^()
+		^this.subclassResponsibility
 	}
 	formatLabel { arg val, numDecimalPlaces;
 		if (numDecimalPlaces == 0) {

--- a/SCClassLibrary/Common/GUI/Base/Grid.sc
+++ b/SCClassLibrary/Common/GUI/Base/Grid.sc
@@ -53,13 +53,13 @@ DrawGrid {
 	vertGrid_ { arg g;
 		y.grid = g;
 	}
-	tickSpacing_ { arg xpx, ypx;
-		x.tickSpacing = xpx;
-		y.tickSpacing = ypx;
+	tickSpacing_ { arg x, y;
+		this.x.tickSpacing = x;
+		this.y.tickSpacing = y;
 	}
-	numTicks_ { arg numx, numy;
-		x.numTicks = numx;
-		y.numTicks = numy;
+	numTicks_ { arg x, y;
+		this.x.numTicks = x;
+		this.y.numTicks = y;
 	}
 	copy {
 		^DrawGrid(bounds,x.grid,y.grid).x_(x.copy).y_(y.copy).opacity_(opacity).smoothing_(smoothing).linePattern_(linePattern)

--- a/SCClassLibrary/Common/GUI/Base/Grid.sc
+++ b/SCClassLibrary/Common/GUI/Base/Grid.sc
@@ -297,8 +297,8 @@ AbstractGridLines {
 		// http://books.google.de/books?id=fvA7zLEFWZgC&pg=PA61&lpg=PA61
 		var exp,f,nf,rf;
 		exp = floor(log10(val));
-		f = val / 10.pow(exp);
 		rf = 10.pow(exp);
+		f = val / rf;
 		if(round,{
 			if(f < 1.5,{
 				^rf *  1.0

--- a/SCClassLibrary/Common/GUI/Base/Grid.sc
+++ b/SCClassLibrary/Common/GUI/Base/Grid.sc
@@ -268,9 +268,7 @@ DrawGridY : DrawGridX {
 	}
 }
 
-// DrawGridRadial : DrawGridX {}
-
-// "factory" class
+// "Factory" class to return appropriate AbstractGridLines subclass based on the spec
 GridLines {
 
 	*new { arg spec;
@@ -287,8 +285,10 @@ AbstractGridLines {
 	}
 
 	prCheckWarp {
-		if(this.class.name != this.spec.gridClass.name) {
-			"% expects a spec with %, but was passed a spec with % instead.".format(this.class.name, this.spec.warp.class.name, spec.asSpec.warp.class.name).warn;
+		if(this.class != this.spec.gridClass) {
+			"The ControlSpec 'warp' expected by this % does not match 'warp' of the supplied ControlSpec (%).".format(
+				this.class, this.spec.warp.class
+			).warn;
 		};
 	}
 

--- a/SCClassLibrary/Common/GUI/Base/Grid.sc
+++ b/SCClassLibrary/Common/GUI/Base/Grid.sc
@@ -44,8 +44,9 @@ DrawGrid {
 		y.fontColor = c;
 	}
 	gridColors_ { arg colors;
-		x.gridColor = colors[0];
-		y.gridColor = colors[1];
+		colors = colors.as(Array);
+		x.gridColor = colors.wrapAt(0);
+		y.gridColor = colors.wrapAt(1);
 	}
 	horzGrid_ { arg g;
 		x.grid = g;

--- a/SCClassLibrary/Common/GUI/Base/Grid.sc
+++ b/SCClassLibrary/Common/GUI/Base/Grid.sc
@@ -1,4 +1,5 @@
 DrawGrid {
+
 	var <bounds, <>x, <>y;
 	var <>opacity=0.7, <>smoothing=false, <>linePattern;
 
@@ -52,9 +53,13 @@ DrawGrid {
 	vertGrid_ { arg g;
 		y.grid = g;
 	}
-	tickSpacing_ { arg val;
-		x.tickSpacing = val;
-		y.tickSpacing = val;
+	tickSpacing_ { arg xpx, ypx;
+		x.tickSpacing = xpx;
+		y.tickSpacing = ypx;
+	}
+	numTicks_ { arg numx, numy;
+		x.numTicks = numx;
+		y.numTicks = numy;
 	}
 	copy {
 		^DrawGrid(bounds,x.grid,y.grid).x_(x.copy).y_(y.copy).opacity_(opacity).smoothing_(smoothing).linePattern_(linePattern)
@@ -69,11 +74,11 @@ DrawGrid {
 DrawGridX {
 
 	var <grid,<>range,<>bounds;
-	var <>font,<>fontColor,<>gridColor,<>labelOffset;
+	var <font,<fontColor,<gridColor,<labelOffset;
 	var commands,cacheKey;
 	var txtPad = 2; // match with Plot:txtPad
-	var <>tickSpacing = 64;
-	var <>numTicks = nil; // nil for dynamic with view size
+	var <tickSpacing = 64;
+	var <numTicks = nil; // nil for dynamic with view size
 
 	*new { arg grid;
 		^super.newCopyArgs(grid.asGrid).init
@@ -81,7 +86,6 @@ DrawGridX {
 
 	init {
 		range = [grid.spec.minval, grid.spec.maxval];
-		// labelOffset is effectively the bounding rect for a single grid label
 		labelOffset = "20000".bounds.size.asPoint;
 	}
 	grid_ { arg g;
@@ -90,7 +94,34 @@ DrawGridX {
 		this.clearCache;
 	}
 	setZoom { arg min,max;
-		range = [min,max];
+		range = [min, max];
+	}
+	tickSpacing_{ |px|
+		px !? {
+			tickSpacing = px;
+			this.clearCache;
+		};
+	}
+	numTicks_{ |num|
+		numTicks = num;
+		this.clearCache;
+	}
+	font_{ |afont|
+		font = afont;
+		this.clearCache;
+	}
+	fontColor_{ |color|
+		fontColor = color;
+		this.clearCache;
+	}
+	gridColor_{ |color|
+		gridColor = color;
+		this.clearCache;
+	}
+	// labelOffset is effectively a point describing the size of a grid label
+	labelOffset_{ |pt|
+		labelOffset = pt;
+		this.clearCache;
 	}
 	commands {
 		var p;
@@ -302,7 +333,7 @@ AbstractGridLines {
 		^[graphmin,graphmax,nfrac,d];
 	}
 	looseRange { arg min,max,ntick=5;
-		^this.ideals(min,max).at( [ 0,1] )
+		^this.ideals(min,max,ntick).at( [ 0,1] )
 	}
 	getParams {
 		^()
@@ -435,16 +466,15 @@ ExponentialGridLines : AbstractGridLines {
 
 BlankGridLines : AbstractGridLines {
 
-	getParams {
-		^()
-	}
-	prCheckWarp {}
+	getParams { ^() }
+
+	prCheckWarp { }
 }
 
 DrawGridTest : DrawGrid {
 	var <testView;
 	var insetH = 45, insetV = 35; // left, bottom margins for labels
-	var gridPad = 15; 			  // right, top margin
+	var gridPad = 15;             // right, top margin
 	var txtPad = 2;               // label offset from window's edge
 	var win, winBounds, font, fcolor;
 

--- a/SCClassLibrary/Common/GUI/Base/Grid.sc
+++ b/SCClassLibrary/Common/GUI/Base/Grid.sc
@@ -1,5 +1,4 @@
 DrawGrid {
-
 	var <bounds, <>x, <>y;
 	var <>opacity=0.7, <>smoothing=false, <>linePattern;
 
@@ -7,66 +6,13 @@ DrawGrid {
 		^super.new.init(bounds, horzGrid, vertGrid)
 	}
 
-	*test { arg horzGrid, vertGrid, bounds;
-		var w, grid;
-		var insetH = 45, insetV = 35; // left, bottom margins for labels
-		var gridPad = 15; 			  // right, top margin
-		var txtPad = 2;               // label offset from window's edge
-		var font = Font( Font.defaultSansFace, 9 ); // match this.font
-		var fcolor = Color.grey(0.3); // match this.fontColor
-
-		bounds = bounds ?? { Rect(0, 0, 500, 400) };
-		bounds = bounds.asRect;       // in case bounds are a Point
-		insetH = insetH + gridPad;
-		insetV = insetV + gridPad;
-
-		grid = DrawGrid(
-			bounds.insetBy(insetH.half, insetV.half).moveTo(insetH-gridPad, gridPad),
-			horzGrid, vertGrid
-		);
-
-		w = Window("Grid test", bounds.center_(Window.screenBounds.center)).front;
-
-		UserView(w, bounds ?? { w.bounds.moveTo(0,0) })
-		.drawFunc_({ |v|
-			var units;
-
-			grid.draw;
-
-			units = grid.x.grid.spec.units; // x label
-			if(units.size > 0) {
-				Pen.push;
-				Pen.translate(grid.bounds.center.x, v.bounds.bottom);
-				Pen.stringCenteredIn(units,
-					units.bounds.center_(0@0).bottom_(txtPad.neg),
-					font, fcolor);
-				Pen.pop;
-			};
-
-			units = grid.y.grid.spec.units; // y label
-			if(units.size > 0) {
-				Pen.push;
-				Pen.translate(0, grid.bounds.center.y);
-				Pen.rotateDeg(-90);
-				Pen.stringCenteredIn(units,
-					units.bounds.center_(0@0).top_(txtPad),
-					font, fcolor);
-				Pen.pop;
-			};
-		})
-		.onResize_({ |v|
-			grid.bounds = v.bounds
-			.insetBy(insetH.half, insetV.half)
-			.moveTo(insetH - gridPad, gridPad);
-		})
-		.resize_(5)
-		.background_(Color.white);
-
-		^grid
+	*test { arg horzGrid, vertGrid, bounds = (500@400);
+		^DrawGrid(bounds.asRect, horzGrid, vertGrid).test
 	}
 
+	test { ^DrawGridTest(this) }
+
 	init { arg bounds, h, v;
-		var w;
 		x = DrawGridX(h);
 		y = DrawGridY(v);
 		this.bounds = bounds;
@@ -105,6 +51,10 @@ DrawGrid {
 	}
 	vertGrid_ { arg g;
 		y.grid = g;
+	}
+	tickSpacing_ { arg val;
+		x.tickSpacing = val;
+		y.tickSpacing = val;
 	}
 	copy {
 		^DrawGrid(bounds,x.grid,y.grid).x_(x.copy).y_(y.copy).opacity_(opacity).smoothing_(smoothing).linePattern_(linePattern)
@@ -483,13 +433,88 @@ ExponentialGridLines : AbstractGridLines {
 	}
 }
 
-
 BlankGridLines : AbstractGridLines {
 
 	getParams {
 		^()
 	}
 	prCheckWarp {}
+}
+
+DrawGridTest : DrawGrid {
+	var <testView;
+	var insetH = 45, insetV = 35; // left, bottom margins for labels
+	var gridPad = 15; 			  // right, top margin
+	var txtPad = 2;               // label offset from window's edge
+	var win, winBounds, font, fcolor;
+
+	*new { arg drawGrid;
+		^super.new(
+			drawGrid.bounds, drawGrid.x.grid, drawGrid.y.grid
+		)
+		.opacity_(drawGrid.opacity)
+		.smoothing_(drawGrid.smoothing)
+		.linePattern_(drawGrid.linePattern)
+		.makeWindow;
+	}
+
+	makeWindow {
+		font = Font( Font.defaultSansFace, 9 ); // match this.font
+		fcolor = Color.grey(0.3); // match this.fontColor
+		insetH = insetH + gridPad;
+		insetV = insetV + gridPad;
+
+		// bounds of the grid lines
+		this.bounds = this.bounds ?? { Rect(0, 0, 500, 400) };
+		// move grid bounds to make room for tick & axis labels
+		this.bounds = this.bounds.moveTo(insetH-gridPad, gridPad);
+
+		winBounds = this.bounds + Size(insetH, insetV);
+		win = Window("Grid test",
+			winBounds.center_(Window.screenBounds.center)
+		).front;
+
+		// the view holding the gridlines
+		testView = UserView(win, winBounds.size.asRect)
+		.drawFunc_({ |uv|
+			var unitsStr;
+
+			// draw the drid
+			this.draw;
+
+			// draw x-axis label
+			unitsStr = this.x.grid.spec.units;
+			if(unitsStr.size > 0) {
+				Pen.push;
+				Pen.translate(this.bounds.center.x, uv.bounds.bottom);
+				Pen.stringCenteredIn(unitsStr,
+					unitsStr.bounds.center_(0@0).bottom_(txtPad.neg),
+					font, fcolor);
+				Pen.pop;
+			};
+
+			// draw y-axis label
+			unitsStr = this.y.grid.spec.units;
+			if(unitsStr.size > 0) {
+				Pen.push;
+				Pen.translate(0, this.bounds.center.y);
+				Pen.rotateDeg(-90);
+				Pen.stringCenteredIn(unitsStr,
+					unitsStr.bounds.center_(0@0).top_(txtPad),
+					font, fcolor);
+				Pen.pop;
+			};
+		})
+		.onResize_({ |uv|
+			this.bounds = uv.bounds
+			.insetBy(insetH.half, insetV.half)
+			.moveTo(insetH - gridPad, gridPad);
+		})
+		.resize_(5)
+		.background_(Color.white);
+	}
+
+	refresh { testView.refresh }
 }
 
 

--- a/SCClassLibrary/deprecated/3.13/GUI/Grid.sc
+++ b/SCClassLibrary/deprecated/3.13/GUI/Grid.sc
@@ -1,0 +1,10 @@
++ DrawGrid {
+
+	*test {
+		warn(
+			"DrawGrid:*test is deprecated. "
+			"Instantiate your DrawGrid and call -preview instead."
+		);
+		^nil
+	}
+}


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

This is a follow-on PR to the recently merged #5161, refactoring the `DrawGrid:*test` into  a new standalone class, removing clutter from `DrawGrid` and allowing access to the grid object under test as well as its enclosing view. This was brought up in the discussion of #5161, but deferred to its own PR.

There's also expanded and clarified the documentation, with examples and scdoc syntax formatting added.

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->

- Documentation
- Bug fix
- New feature
  - `DrawGrid:-numTicks` and `-tickSpacing` now allows setting x and y axes individually.

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review
