### PR TITLE
Topic refactor function flop

### DIFF
--- a/HelpSource/Classes/Function.schelp
+++ b/HelpSource/Classes/Function.schelp
@@ -309,8 +309,19 @@ This method is kept for backward compatibility. Use code::flop:: instead.
 method::inEnvir
 
 returns an "environment-safe" function. See Environment for more details.
+Note that the function returned takes no keyword arguments.
 
 code::
+e = (a: "get it", b: "didn't");
+f = { ~b + ~a + "..." }.inEnvir(e);
+f.value;
+
+f = { |how = "", end = "..."| how + ~b + ~a + end }.inEnvir(e); // doesn't work with keyword arguments
+f.value(how: "really"); // WARNING: keyword arg 'how' not found in call to function (see inEnvirWithArgs).
+
+
+
+// a use case: defer is usually called in the call environment
 // prints nil because ~a is read from topEnvironment, not e
 e = (a: "got it", f: { { ~a.postln }.defer(0.5) });
 e.use { e.f };
@@ -318,6 +329,18 @@ e.use { e.f };
 // prints "got it" because { ~a.postln } is now bound to the e environment
 e = (a: "got it", f: { { ~a.postln }.inEnvir.defer(0.5) });
 e.use { e.f };
+::
+
+
+method::inEnvirWithArgs
+
+Like link::#inEnvir::, but returns a function which takes keyword arguments.
+Building this function makes a call to the interpreter and is less efficient than inEnvir
+
+code::
+e = (a: "get it", b: "didn't");
+f = { |how = "", end = "..."| how + ~b + ~a + end }.inEnvirWithArgs(e);
+f.value(how: "I really", end: "done!");
 ::
 
 

--- a/HelpSource/Classes/Function.schelp
+++ b/HelpSource/Classes/Function.schelp
@@ -269,14 +269,15 @@ x.value;
 
 method::flop
 
-Return a function that, when evaluated with nested arguments, does multichannel expansion by evaluating the receiver function for each channel. A flopped function responds like the "map" function in languages like Lisp.
+Return a function that, when evaluated with nested arguments, does multichannel expansion by evaluating the receiver function for each channel. A flopped function responds like the "map" function in languages like Lisp. The new function always returns an array.
 
 code::
+// multichannel expansion for if, here to protect from division by zero:
 f = { |a, b| if(b != 0) { a / b } { 0 } }.flop;
 f.value([1, 2, 3, 4], [0, 10, 1000]); //  -> [ 0, 0.2, 0.003, 0 ]
-f.value(2, 4); // [ 0.5 ]
+f.value(2, 4); // [ 0.5 ] (always returns an array)
 
-// strings don't count
+// strings don't expand
 f = { |a, b| a + b }.flop;
 f.("hello", ["world", "algorithm"]); // -> [ hello world, hello algorithm ]
 f.("hello", "world"); // -> [ hello world ]
@@ -285,14 +286,16 @@ f.("hello", "world"); // -> [ hello world ]
 
 method::flop1
 
-Same as link::#flop::, return only an array if the arguments contains an array
+Same as link::#flop::, return only an array if the arguments also contains an array. This can be used to implement link::Guides/Multichannel-Expansion::.
+
 code::
+// multichannel expansion for if, here to protect from division by zero:
 f = { |a, b| if(b != 0) { a / b } { 0 } }.flop1;
 f.value([1, 2, 3, 4], [0, 10, 1000]); //  -> [ 0, 0.2, 0.003, 0 ]
-f.value(2, 4); // -> 0.5
 f.value([2], 4); // -> [0.5]
+f.value(2, 4); // -> 0.5
 
-// strings don't count, like in flop
+// strings don't expand, like in flop
 f = { |a, b| a + b }.flop1;
 f.("hello", ["world", "algorithm"]); // -> [ hello world, hello algorithm ]
 f.("hello", "world"); // -> hello world

--- a/HelpSource/Classes/Function.schelp
+++ b/HelpSource/Classes/Function.schelp
@@ -272,10 +272,33 @@ method::flop
 Return a function that, when evaluated with nested arguments, does multichannel expansion by evaluating the receiver function for each channel. A flopped function responds like the "map" function in languages like Lisp.
 
 code::
-f = { |a, b| if(a > 0) { a + b } { -inf } }.flop;
-f.value([-1, 2, 1, -3.0], [10, 1000]);
-f.value(2, 3);
+f = { |a, b| if(b != 0) { a / b } { 0 } }.flop;
+f.value([1, 2, 3, 4], [0, 10, 1000]); //  -> [ 0, 0.2, 0.003, 0 ]
+f.value(2, 4); // [ 0.5 ]
+
+// strings don't count
+f = { |a, b| a + b }.flop;
+f.("hello", ["world", "algorithm"]); // -> [ hello world, hello algorithm ]
+f.("hello", "world"); // -> [ hello world ]
+
 ::
+
+method::flop1
+
+Same as link::#flop::, return only an array if the arguments contains an array
+code::
+f = { |a, b| if(b != 0) { a / b } { 0 } }.flop1;
+f.value([1, 2, 3, 4], [0, 10, 1000]); //  -> [ 0, 0.2, 0.003, 0 ]
+f.value(2, 4); // -> 0.5
+f.value([2], 4); // -> [0.5]
+
+// strings don't count, like in flop
+f = { |a, b| a + b }.flop1;
+f.("hello", ["world", "algorithm"]); // -> [ hello world, hello algorithm ]
+f.("hello", "world"); // -> hello world
+
+::
+
 
 
 method::envirFlop
@@ -368,7 +391,7 @@ method:: awake
 
 This method is called by a link::Classes/Clock:: on which the function was
 scheduled when its scheduling time is up. It calls link::#-value::, passing
-on the scheduling time in beats as an argument. 
+on the scheduling time in beats as an argument.
 
 argument:: beats
 The scheduling time in beats. This is equal to the current logical time

--- a/HelpSource/Classes/FunctionDef.schelp
+++ b/HelpSource/Classes/FunctionDef.schelp
@@ -66,13 +66,41 @@ code::
 ::
 method::argumentString
 
-Return a string that contains  arguments and their default values for embedding in a string.
+Return a string that contains all argument names and their default values for embedding in a string.
 If there are no arguments, it returns nil.
 
 code::
-{ |a = 9, b = 10, c| a + b }.def.argumentString;
-{ "nothing to see here" }.def.argumentString;
+{ |a = 9, b = 10, c| a + b }.def.argumentString; // "a = 9, b = 10, c"
+{ "nothing to see here" }.def.argumentString; // nil
 ::
+
+argument::withDefaultValues
+If set to false, no default values are appended
+
+code::
+ // "a, b, c"
+{ |a = 9, b = 10, c| a + b }.def.argumentString(withDefaultValues: false);
+::
+
+argument::withEllipsis
+If set to true, ellipsis characters (code::" ... "::) are appended
+
+code::
+// "a = 9, b = 10 ... c"
+{ |a = 9, b = 10 ... c| a + b }.def.argumentString(withEllipsis: true);
+// "a = 9, b = 10, c"
+{ |a = 9, b = 10 ... c| a + b }.def.argumentString(withEllipsis: false);
+::
+
+argument::asArray
+If set to true, return the string for an array that represents all arguments. The other arguments are set to false.
+
+code::
+// "[a, b] ++ c"
+{ |a = 9, b = 10 ... c| a + b }.def.argumentString(asArray: true);
+::
+
+
 
 method::makeEnvirFromArgs
 
@@ -81,6 +109,49 @@ Get the Array of Symbols of the local variable names.
 code::
 { |a = 9, b = 10, c| a + b }.def.makeEnvirFromArgs;
 ::
+
+subsection::Generating Strings
+
+method::makeFuncArgModifierString
+
+Return a string that can be interpreted as code for a new function which extracts the arguments from the receiver. This can be used to build a hygienic macro which returns a function with valid keyword arguments, instead of just anonymously forwarding the arguments, like in code::{ |...args| func.valueArray(args) }::.
+
+For an implementation example link::Classes/Function#flop:: (as below).
+
+
+argument::modifier
+A function to which a string is passed that represents the array of all arguments. It should return a string that can be interpreted.
+
+code::
+// basic usage
+f = { |x, y| x.squared + y.squared }; // a function
+a = f.def.makeFuncModifierString({ |argString| "%.scramble".format(argString) });
+a.interpret.value(4, 5)
+
+// use as a macro: multichannel expansion like in flop
+f = { |x, y = 1| if(x > 0) { 1 } { 0 } * y }; // some function
+// generate the body of a function that has a free and yet undefined variable "func"
+// -> "{ arg x, y = 1; ([x, y]).flop.collect { |x| func.valueArray(x) } }"
+a = f.def.makeFuncModifierString({ |str| str ++ ".flop.collect { |x| func.valueArray(x) }" });
+// wrap that body into a function that takes "func" as argument and returns the function above
+// now we have a valid code for a function:
+// -> "{ |func| { arg x, y = 1; [x, y].flop.collect { |x| func.valueArray(x) } } }"
+b = "{ |func| % }".format(a);
+// interpret the code to a function
+g = b.interpret;
+// pass the function f to g, which returns a function from a where "func" is bound to f
+h = g.value(f);
+// we can now use h in place of f, but all arguments are multichannel expanded:
+f.([1, 0], [6, 7]); // does not work
+h.([1, 0], [6, 7]); // [6, 0]
+// and the new function supports the same keywords arguments:
+h.(x:(-2..2), y:(-2..2));
+
+// this functionality is implemented for function in the method "flop"
+h = f.flop;
+h.([1, 0], [6, 7]); // [6, 0]
+::
+
 
 subsection::Utilities
 

--- a/HelpSource/Classes/FunctionDef.schelp
+++ b/HelpSource/Classes/FunctionDef.schelp
@@ -66,10 +66,12 @@ code::
 ::
 method::argumentString
 
-Return a string that contains  arguments and their default values for embedding in a string
+Return a string that contains  arguments and their default values for embedding in a string.
+If there are no arguments, it returns nil.
 
 code::
 { |a = 9, b = 10, c| a + b }.def.argumentString;
+{ "nothing to see here" }.def.argumentString;
 ::
 
 method::makeEnvirFromArgs

--- a/HelpSource/Guides/Multichannel-Expansion.schelp
+++ b/HelpSource/Guides/Multichannel-Expansion.schelp
@@ -82,7 +82,7 @@ code::
 ["foo","bar","zoo"].multiChannelPerform('++', ["l","ba"])
 ::
 
-subsection:: Using flop for multichannel expansion
+subsection:: Using flop and flop1 for multichannel expansion
 The method flop swaps columns and rows, allowing to derive series of argument sets:
 code::
 (
@@ -113,20 +113,40 @@ fork {
 )
 ::
 
-Similarly, link::Classes/Function#-flop#Function:flop:: returns an unevaluated function that will expand to its arguments when evaluated:
+Similarly, link::Classes/Function#-flop#Function:flop:: and link::Classes/Function#-flop1#Function:flop1:: return an unevaluated function that will expand to its arguments when evaluated.
+
 code::
+// multichannel expansion for if, here to protect from division by zero.
+// flop always returns an array
+f = { |a, b| if(b != 0) { a / b } { 0 } }.flop;
+f.value([1, 2, 3, 4], [0, 10, 1000]); //  -> [ 0, 0.2, 0.003, 0 ]
+f.value(2, 4); // [ 0.5 ] (always returns an array)
+
+// multichannel expansion for if, here to protect from division by zero
+// flop1 returns an array only if the arguments include an array
+f = { |a, b| if(b != 0) { a / b } { 0 } }.flop1;
+f.value([1, 2, 3, 4], [0, 10, 1000]); //  -> [ 0, 0.2, 0.003, 0 ]
+f.value([2], 4); // -> [0.5]
+f.value(2, 4); // -> 0.5
+::
+
+
+code::
+// multichannel expand a function that forks a task
 (
-SynthDef("blip", { |out, freq|
+SynthDef(\blip, { |out, freq|
 	Out.ar(out,
 		Line.ar(0.1, 0, 0.05, 1, 0, 2) * Pulse.ar(freq * [1, 1.02])
 	)
 }).add;
 
 a = { |dur=1, x=1, n=10, freq=400|
-	fork { n.do {
-			if(x.coin) { Synth("blip", [\freq, freq]) };
+	fork {
+		n.do {
+			if(x.coin) { Synth(\blip, [\freq, freq]) };
 			(dur / n).wait;
-	} }
+		}
+	}
 }.flop;
 )
 

--- a/SCClassLibrary/Common/Core/Function.sc
+++ b/SCClassLibrary/Common/Core/Function.sc
@@ -244,6 +244,20 @@ Function : AbstractFunction {
 		^"{ |func| % }".format(code).interpret.value(this)
 	}
 
+	// flop only when at least one non-string array is passed as argument.
+	flop1 {
+		var code, modifierString;
+		if(def.argNames.isNil) { ^{ [this.value] } };
+		modifierString = "\nvar arguments = %;\n"
+		"if(arguments.any { |x| x.isSequenceableCollection and: { x.isString.not } }) {\n"
+		"	arguments.flop.collect { |x| func.valueArray(x) }\n"
+		"} {\n"
+		"	func.valueArray(arguments)\n"
+		"}\n";
+		code = this.makeFuncModifierString({ |str| modifierString.format(str) });
+		^"{ |func| % }".format(code).interpret.value(this)
+	}
+
 	// backwards compatibility
 	makeFlopFunc { ^this.flop }
 	envirFlop { ^this.flop }

--- a/SCClassLibrary/Common/Core/Function.sc
+++ b/SCClassLibrary/Common/Core/Function.sc
@@ -273,6 +273,16 @@ Function : AbstractFunction {
 
 	// attach the function to a specific environment
 	inEnvir { |envir|
+		envir ?? { envir = currentEnvironment };
+		^if(def.argNames.isNil) {
+			{ envir.use { this.value } }
+		} {
+			{ |... args| envir.use { this.valueArray(args) } }
+		}
+	}
+
+	// attach the function to a specific environment
+	inEnvirWithArgs { |envir|
 		var code, modifierString;
 		envir ?? { envir = currentEnvironment };
 		if(def.argNames.isNil) { ^{ envir.use({ this.value }) } };

--- a/SCClassLibrary/Common/Core/Function.sc
+++ b/SCClassLibrary/Common/Core/Function.sc
@@ -298,7 +298,11 @@ Function : AbstractFunction {
 				"[%] ++ %".format(valueBlock[..i-2], valueBlock[i+1..])
 			};
 		} {
-			"[%]".format(valueBlock)
+			if(def.hasPartialApplication) {
+				"%".format(valueBlock)
+			} {
+				"[%]".format(valueBlock)
+			}
 		};
 
 		if(modifier.notNil) { functionBlock = modifier.value(functionBlock) };

--- a/SCClassLibrary/Common/Core/Kernel.sc
+++ b/SCClassLibrary/Common/Core/Kernel.sc
@@ -474,7 +474,7 @@ FunctionDef {
 	archiveAsCompileString { ^true }
 
 	hasPartialApplication {
-		^this.numArgs > 0 and: { argNames[0] == \_ }
+		^argNames.size > 0 and: { argNames[0] == \_ }
 	}
 
 	argumentString { arg withDefaultValues=true, withEllipsis=false;

--- a/SCClassLibrary/Common/Core/Kernel.sc
+++ b/SCClassLibrary/Common/Core/Kernel.sc
@@ -480,8 +480,9 @@ FunctionDef {
 	argumentString { arg withDefaultValues=true, withEllipsis=false, asArray=false;
 		var res = "", pairs;
 		var lastIndex, noVarArgs, varArgName;
-		if(asArray && withDefaultValues) { Error("argumentString as array should not have default values").throw };
-		if(asArray && withEllipsis) { Error("argumentString as array should not have ellipsis").throw };
+		if(asArray) {
+			withEllipsis = withDefaultValues = false;
+		};
 		if(this.hasPartialApplication) {
 			^if(withEllipsis) { " ... args" } { "args" }
 		};

--- a/SCClassLibrary/Common/Core/Kernel.sc
+++ b/SCClassLibrary/Common/Core/Kernel.sc
@@ -473,9 +473,17 @@ FunctionDef {
 	checkCanArchive { "cannot archive FunctionDefs".warn }
 	archiveAsCompileString { ^true }
 
+	hasPartialApplication {
+		^this.numArgs > 0 and: { argNames[0] == \_ }
+	}
+
 	argumentString { arg withDefaultValues=true, withEllipsis=false;
-		var res = "", pairs = this.keyValuePairsFromArgs;
+		var res = "", pairs;
 		var lastIndex, noVarArgs, varArgName;
+		if(this.hasPartialApplication) {
+			^if(withEllipsis) { " ... args" } { "args" }
+		};
+		pairs = this.keyValuePairsFromArgs;
 		if(pairs.isEmpty) { ^nil };
 		if(this.varArgs) {
 			varArgName = pairs.keep(-2).first;

--- a/testsuite/classlibrary/TestFunction.sc
+++ b/testsuite/classlibrary/TestFunction.sc
@@ -140,7 +140,7 @@ TestFunction : UnitTest {
 
 	test_makeFuncModifierString_without_defaultArguments {
 		var function = { |a, b, c| [a, b, c]};
-		var string = function.makeFuncModifierString;
+		var string = function.def.makeFuncModifierString;
 		var should = [1, 2, 3];
 		var is = string.interpret.value(1, 2, 3);
 		this.assertEquals(is, should, "arguments should be passed correctly");
@@ -148,7 +148,7 @@ TestFunction : UnitTest {
 
 	test_makeFuncModifierString_with_defaultArguments {
 		var function = { |a, b, c=3| [a, b, c]};
-		var string = function.makeFuncModifierString;
+		var string = function.def.makeFuncModifierString;
 		var should = [1, 2, 3];
 		var is = string.interpret.value(1, 2);
 		this.assertEquals(is, should, "arguments should be passed correctly");
@@ -156,7 +156,7 @@ TestFunction : UnitTest {
 
 	test_makeFuncModifierString_with_ellipsisArguments {
 		var function = { |a, b ... c| [a, b] ++ c};
-		var string = function.makeFuncModifierString;
+		var string = function.def.makeFuncModifierString;
 		var should = [1, 2, 3, 4];
 		var is = string.interpret.value(1, 2, 3, 4);
 		this.assertEquals(is, should, "arguments should be passed correctly");
@@ -164,7 +164,7 @@ TestFunction : UnitTest {
 
 	test_makeFuncModifierString_with_ellipsisArguments_empty {
 		var function = { |a, b ... c| [a, b] ++ c};
-		var string = function.makeFuncModifierString;
+		var string = function.def.makeFuncModifierString;
 		var should = [1, 2];
 		var is = string.interpret.value(1, 2);
 		this.assertEquals(is, should, "arguments should be passed correctly");
@@ -173,7 +173,7 @@ TestFunction : UnitTest {
 
 	test_makeFuncModifierString_with_single_ellipsisArguments {
 		var function = { |...a| a };
-		var string = function.makeFuncModifierString;
+		var string = function.def.makeFuncModifierString;
 		var should = [1, 2];
 		var is = string.interpret.value(1, 2);
 		this.assertEquals(is, should, "arguments should be passed correctly");

--- a/testsuite/classlibrary/TestFunction.sc
+++ b/testsuite/classlibrary/TestFunction.sc
@@ -256,6 +256,21 @@ TestFunction : UnitTest {
 	}
 
 
+	test_inEnvir {
+		var envir = Environment.make { ~a = 9 };
+		var func = { ~a }.inEnvir(envir);
+		var result = func.value;
+		this.assertEquals(result, 9, "inEnvir should bind function to environment")
+	}
+
+	test_inEnvirWithArgs {
+		var envir = Environment.make { ~a = 9 };
+		var func = { |b| [~a, b] }.inEnvirWithArgs(envir);
+		var result = func.value(b: 4);
+		this.assertEquals(result, [9, 4], "inEnvirWithArgs should bind function to environment and take keyword args")
+	}
+
+
 }
 
 CommonTestClass {

--- a/testsuite/classlibrary/TestFunction.sc
+++ b/testsuite/classlibrary/TestFunction.sc
@@ -255,6 +255,27 @@ TestFunction : UnitTest {
 		this.assertEquals(result, directResult, "flop should work with ellipsis arguments for the non-expanding case")
 	}
 
+	test_flop_partialApplication {
+		var function = [_, _].flop;
+		var result = function.([1, 2, 3], [100, 200]);
+		var directResult = [ [ 1, 100 ], [ 2, 200 ], [ 3, 100 ] ];
+		this.assertEquals(result, directResult, "flop should work with partial application")
+	}
+
+	test_flop1_partialApplication {
+		var function = [_, _].flop1;
+		var result = function.([1, 2, 3], [100, 200]);
+		var directResult = [ [ 1, 100 ], [ 2, 200 ], [ 3, 100 ] ];
+		this.assertEquals(result, directResult, "flop1 should work with partial application")
+	}
+
+	test_flop1_unbubble {
+		var function = { |x| x }.flop1;
+		var result = function.(1);
+		var directResult = 1;
+		this.assertEquals(result, directResult, "flop1 should not expand for non-array arguments")
+	}
+
 
 	test_inEnvir {
 		var envir = Environment.make { ~a = 9 };

--- a/testsuite/classlibrary/TestFunction.sc
+++ b/testsuite/classlibrary/TestFunction.sc
@@ -120,7 +120,6 @@ TestFunction : UnitTest {
 		}
 	}
 
-
 	test_argumentString_with_ellipsis_andDefaultArguments {
 		var function = { |a = 1, b ... c| };
 		var arguments = [[true, true], [true, false], [false, true], [false, false]];
@@ -137,6 +136,51 @@ TestFunction : UnitTest {
 			this.assertEquals(x, results[i], "argument string should match")
 		}
 	}
+
+
+	test_makeFuncModifierString_without_defaultArguments {
+		var function = { |a, b, c| [a, b, c]};
+		var string = function.makeFuncModifierString;
+		var should = [1, 2, 3];
+		var is = string.interpret.value(1, 2, 3);
+		this.assertEquals(is, should, "arguments should be passed correctly");
+	}
+
+	test_makeFuncModifierString_with_defaultArguments {
+		var function = { |a, b, c=3| [a, b, c]};
+		var string = function.makeFuncModifierString;
+		var should = [1, 2, 3];
+		var is = string.interpret.value(1, 2);
+		this.assertEquals(is, should, "arguments should be passed correctly");
+	}
+
+	test_makeFuncModifierString_with_ellipsisArguments {
+		var function = { |a, b ... c| [a, b] ++ c};
+		var string = function.makeFuncModifierString;
+		var should = [1, 2, 3, 4];
+		var is = string.interpret.value(1, 2, 3, 4);
+		this.assertEquals(is, should, "arguments should be passed correctly");
+	}
+
+	test_makeFuncModifierString_with_ellipsisArguments_empty {
+		var function = { |a, b ... c| [a, b] ++ c};
+		var string = function.makeFuncModifierString;
+		var should = [1, 2];
+		var is = string.interpret.value(1, 2);
+		this.assertEquals(is, should, "arguments should be passed correctly");
+	}
+
+
+	test_makeFuncModifierString_with_single_ellipsisArguments {
+		var function = { |...a| a };
+		var string = function.makeFuncModifierString;
+		var should = [1, 2];
+		var is = string.interpret.value(1, 2);
+		this.assertEquals(is, should, "arguments should be passed correctly");
+	}
+
+
+
 
 	test_flop_inEnvir {
 		var envir = Environment.new;


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

- The old implementation of function flop was hard to understand and not useful for other puroses.
- inEnvir had no support for keyword arguments

This fixes both.
Up for discussion: the benchmarks are all very low. Maybe just replace the old inEnvir with the new one.

```
f = { |a, b| [a, b, ~c, ~d] };
x = f.inEnvir((c: 1, d: 2));
y = f.inEnvirWithArgs((c: 1, d: 2));

bench { 1000.do { x.value(1, 2) } }
bench { 1000.do { y.value(1, 2) } }

bench { 100.do { f.inEnvir((c: 1, d: 2)) } }
bench { 100.do { f.inEnvirWithArgs((c: 1, d: 2)) } }
```

## Types of changes

- New feature


## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review
