### PR TITLE
Fix .sqrt and .reciprocal on the server on M1 CPUs

### DIFF
--- a/server/plugins/UnaryOpUGens.cpp
+++ b/server/plugins/UnaryOpUGens.cpp
@@ -1015,13 +1015,21 @@ static UnaryOpFunc ChooseNovaSimdFunc(UnaryOpUGen* unit) {
         case opCubed:
             return &cubed_nova_64;
         case opSqrt:
+#    ifdef __ARM_NEON // remove this once nova-simd implementation is fixed
+            func = &sqrt_a;
+#    else
             func = &sqrt_nova_64;
+#    endif
             break;
         case opExp:
             func = &exp_nova;
             break;
         case opRecip:
+#    ifdef __ARM_NEON // remove this once nova-simd implementation is fixed
+            return &recip_a;
+#    else
             return &recip_nova_64;
+#    endif
         case opMIDICPS:
             func = &midicps_nova;
             break;
@@ -1171,13 +1179,21 @@ static UnaryOpFunc ChooseNovaSimdFunc(UnaryOpUGen* unit) {
         func = &cubed_nova;
         break;
     case opSqrt:
+#    ifdef __ARM_NEON // remove this once nova-simd implementation is fixed
+        func = &sqrt_a;
+#    else
         func = &sqrt_nova;
+#    endif
         break;
     case opExp:
         func = &exp_nova;
         break;
     case opRecip:
+#    ifdef __ARM_NEON // remove this once nova-simd implementation is fixed
+        func = &recip_a;
+#    else
         func = &recip_nova;
+#    endif
         break;
     case opMIDICPS:
         func = &midicps_nova;


### PR DESCRIPTION

<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->
This is a workaround for #5893 and fixes the behavior of `.sqrt` and `.reciprocal` UGens on Apple M1.

The PR disables nova-simd (vectorized) implementations of `recip` and `sqrt` functions on ARM CPUs due to an issue upstream: https://github.com/timblechmann/nova-simd/issues/11

Once these functions are fixed upstream, the changes introduced in this PR should be reverted for best performance.

I'm adding the `macOS` label since performance on Apple M1 CPU is the primary target of this "fix". However, this might apply to all ARM64 CPUs, so I'm guessing it may also affect RaspberryPi 4 (not tested).

To test:
```supercollider
s.boot;
x = {DC.ar(2).reciprocal.poll; Silent.ar()}.play; // UGen(UnaryOpUGen): 0.5 (was: 0.499998)
x = {DC.ar(0).sqrt.poll; Silent.ar()}.play; // UGen(UnaryOpUGen): 0 (was: nan)
```


## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [ ] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review
