### PR TITLE
class library: only one server meter by default

### DIFF
--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -357,7 +357,7 @@ Server {
 	var <defaultGroup, <defaultGroups;
 
 	var <syncThread, <syncTasks;
-	var <window, <>scopeWindow, <emacsbuf;
+	var <window, <>scopeWindow, <serverMeter, <emacsbuf;
 	var <volume, <recorder, <statusWatcher;
 	var <pid, serverInterface;
 	var pidReleaseCondition;

--- a/SCClassLibrary/Common/GUI/PlusGUI/Control/server-meter.sc
+++ b/SCClassLibrary/Common/GUI/PlusGUI/Control/server-meter.sc
@@ -1,7 +1,10 @@
 + Server {
 	meter { |numIns, numOuts|
-		^if( GUI.id == \swing and: { \JSCPeakMeter.asClass.notNil }, {
-			\JSCPeakMeter.asClass.meterServer( this );
-		}, { ServerMeter(this, numIns, numOuts) });
+		if(numIns.notNil or: numOuts.notNil and: { serverMeter.notNil }) { serverMeter.close };
+		if(serverMeter.isNil or: { serverMeter.isClosed }) {
+			serverMeter = ServerMeter(this, numIns, numOuts)
+		} {
+			serverMeter.window.front
+		}
 	}
 }

--- a/SCClassLibrary/Common/GUI/tools/ServerMeter.sc
+++ b/SCClassLibrary/Common/GUI/tools/ServerMeter.sc
@@ -255,4 +255,12 @@ ServerMeter {
 		^super.newCopyArgs(window, meterView)
 
 	}
+
+	close {
+		window.close
+	}
+
+	isClosed {
+		^window.isClosed
+	}
 }

--- a/SCVersion.txt
+++ b/SCVersion.txt
@@ -2,7 +2,7 @@
 # Note that you need to "make install" for this information to be copied into all places.
 
 set(SC_VERSION_MAJOR 3)
-set(SC_VERSION_MINOR 13)
+set(SC_VERSION_MINOR 14)
 set(SC_VERSION_PATCH 0)
 set(SC_VERSION_TWEAK "-rc1")
 set(SC_VERSION ${SC_VERSION_MAJOR}.${SC_VERSION_MINOR}.${SC_VERSION_PATCH}${SC_VERSION_TWEAK})

--- a/SCVersion.txt
+++ b/SCVersion.txt
@@ -2,7 +2,7 @@
 # Note that you need to "make install" for this information to be copied into all places.
 
 set(SC_VERSION_MAJOR 3)
-set(SC_VERSION_MINOR 14)
+set(SC_VERSION_MINOR 13)
 set(SC_VERSION_PATCH 0)
 set(SC_VERSION_TWEAK "-rc1")
 set(SC_VERSION ${SC_VERSION_MAJOR}.${SC_VERSION_MINOR}.${SC_VERSION_PATCH}${SC_VERSION_TWEAK})


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

This fixes #5545. ServerMeter now behaves like Scope. By result of the discussions in #5549, it may make sense to rethink the design of all server windows, and potentially an easy way to handle unique windows.

A refactoring of the server views is recommended, this is just the minimal step to fix the issue at hand.

Multiple ServerMeters can be created by directly instantiating the object (like Stethoscopse for multiple scopes).

Thanks to @capital-G and everyone else for discussion.

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix
- Breaking change

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] This PR is ready for review
