### PR TITLE
Free/PauseSelf: restate state of Ctor after init sample calc

### DIFF
--- a/server/plugins/TriggerUGens.cpp
+++ b/server/plugins/TriggerUGens.cpp
@@ -2240,6 +2240,7 @@ void FreeSelf_Ctor(FreeSelf* unit) {
     SETCALC(FreeSelf_next);
     unit->m_prevtrig = 0.f;
     FreeSelf_next(unit, 1);
+    unit->m_prevtrig = 0.f;
 }
 
 

--- a/server/plugins/TriggerUGens.cpp
+++ b/server/plugins/TriggerUGens.cpp
@@ -2257,6 +2257,7 @@ void PauseSelf_Ctor(PauseSelf* unit) {
     SETCALC(PauseSelf_next);
     unit->m_prevtrig = 0.f;
     PauseSelf_next(unit, 1);
+    unit->m_prevtrig = 0.f;
 }
 
 


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->
Reset state of `PauseSelf` and `FreeSelf` after init sample calculation, otherwise a trigger on the first sample will be missed.

Note the `FreeSelf` change fixes an edge case where a UGen would free the synth on the  first sample.

This example doesn't currently work, but works with this proposed fix.
```supercollider
(
x = {
	Silent.ar.poll(4, label: "I am not paused.");
	// FreeSelf.kr(Impulse.kr(0)); // immediately free
	FreeSelf.kr(Impulse.kr(1, phase: 0.5)); // free after 0.5 sec
}.play
)
```

## Purpose and Motivation

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->
Fixes #5910, and hopefully [SuperDirt #277](https://github.com/musikinformatik/SuperDirt/issues/277)

## Types of changes

<!-- Delete lines that don't apply -->

- [x] Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [ ] Updated documentation
- [x] This PR is ready for review
