### PR TITLE
class library: complete bool interface for AbstractFunction

### DIFF
--- a/SCClassLibrary/Common/Core/AbstractFunction.sc
+++ b/SCClassLibrary/Common/Core/AbstractFunction.sc
@@ -160,6 +160,8 @@ AbstractFunction {
 
 	|| { arg function, adverb; ^this.composeBinaryOp('||', function, adverb) }
 	&& { arg function, adverb; ^this.composeBinaryOp('&&', function, adverb) }
+	or { arg function, adverb; ^this.composeBinaryOp('or', function, adverb) }
+	and { arg function, adverb; ^this.composeBinaryOp('and', function, adverb) }
 	xor { arg function, adverb; ^this.composeBinaryOp('xor', function, adverb) }
 	nand { arg function, adverb; ^this.composeBinaryOp('nand', function, adverb) }
 	not { ^this.composeUnaryOp('not') }


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

At first, it seems not logical that we have `nand` and `&&`, and `and`  for Boolean, but `and` and `or` are missing from `AbstractFunction`. This implements it.

But we get a (minor?) problem, namely that `and` and `or` try to inline the function, so that we get an inline warning for a term like this:
```
a = and({ |x| x.not }, { |x| x }); // WARNING: FunctionDef contains variable declarations and so will not be inlined.
a.(true)
``` 

So let's not yet merge this, but decide first if we need to document better why there is no `and` and `or` for Functions, or make sure that inline warnings are thrown for the right reason (the fact that the function has an an argument seems to to be the right reason).

Note: implementing it like this:
```supercollider
	|| { arg function, adverb; ^this.composeBinaryOp('||', function, adverb) }
	&& { arg function, adverb; ^this.composeBinaryOp('&&', function, adverb) }
	or { arg function, adverb; ^this.composeBinaryOp('||', function, adverb) }
	and { arg function, adverb; ^this.composeBinaryOp('&&', function, adverb) }
```

won't help, it's an interpreter thing.

## Types of changes

<!-- Delete lines that don't apply -->

- New feature


