### PR TITLE
class library: call dispatch on removeAt

### DIFF
--- a/SCClassLibrary/Common/Collections/EnvironmentRedirect.sc
+++ b/SCClassLibrary/Common/Collections/EnvironmentRedirect.sc
@@ -31,13 +31,20 @@ EnvironmentRedirect {
 		dispatch.value(key, obj);
 	}
 
+	removeAt { arg key;
+		var result = envir.removeAt(key);
+		dispatch.value(key, nil);
+		^result
+	}
+
 	localPut { arg key, obj;
 		envir.put(key, obj)
 	}
 
-	removeAt { arg key;
+	localRemoveAt { arg key;
 		^envir.removeAt(key)
 	}
+
 
 	// behave like environment
 
@@ -213,13 +220,22 @@ LazyEnvir : EnvironmentRedirect {
 
 	put { arg key, obj;
 		this.at(key).source_(obj);
-		dispatch.value(key, obj); // forward to dispatch for networking
+		dispatch.value(key, obj);
 	}
 
 	removeAt { arg key;
 		var proxy;
 		proxy = envir.removeAt(key);
 		if(proxy.notNil) { proxy.clear };
+		dispatch.value(key, nil);
+		^proxy
+	}
+
+	localRemoveAt { arg key;
+		var proxy;
+		proxy = envir.removeAt(key);
+		if(proxy.notNil) { proxy.clear };
+		^proxy
 	}
 
 	localPut { arg key, obj;


### PR DESCRIPTION

<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

This fixes #5922

- call dispatch on removeAt (because the object changed)
- return object on removeAt (this is standard in collections)
- add localRemoveAt for removing without dispatch


## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix
- New feature
- Breaking change

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [ ] Code is tested
- [ ] All tests are passing
- [ ] Updated documentation
- [ ] This PR is ready for review
