### PR TITLE
Avoid writing invalid synthdef files

### DIFF
--- a/SCClassLibrary/Common/Audio/SynthDef.sc
+++ b/SCClassLibrary/Common/Audio/SynthDef.sc
@@ -335,7 +335,7 @@ SynthDef {
 			};
 
 			allControlNamesTemp = allControlNames.reject { |cn|
-				cn.rate == \noncontrol or: cn.name.isNil
+				cn.rate == \noncontrol or: { cn.name.isNil }
 			};
 			file.putInt32(allControlNamesTemp.size);
 			allControlNamesTemp.do { | item |

--- a/SCClassLibrary/Common/Audio/SynthDef.sc
+++ b/SCClassLibrary/Common/Audio/SynthDef.sc
@@ -334,13 +334,13 @@ SynthDef {
 				file.putFloat(item);
 			};
 
-			allControlNamesTemp = allControlNames.reject { |cn| cn.rate == \noncontrol };
+			allControlNamesTemp = allControlNames.reject { |cn|
+				cn.rate == \noncontrol or: cn.name.isNil
+			};
 			file.putInt32(allControlNamesTemp.size);
 			allControlNamesTemp.do { | item |
-				if (item.name.notNil) {
-					file.putPascalString(item.name.asString);
-					file.putInt32(item.index);
-				};
+				file.putPascalString(item.name.asString);
+				file.putInt32(item.index);
 			};
 
 			file.putInt32(children.size);


### PR DESCRIPTION
Move the check for name.isNil from the do to the reject loop.

Another (less conservative) approach would have been to eliminate
the check altogether.  It likely never did anything anyways,
because if it did, it would have resulted in an invalid file.
