### PR TITLE
Add doc for issue #2674

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "workbench.colorCustomizations": {
+        "activityBar.background": "#3F2906",
+        "titleBar.activeBackground": "#593A09",
+        "titleBar.activeForeground": "#FEF9F1"
+    }
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,0 @@
-{
-    "workbench.colorCustomizations": {
-        "activityBar.background": "#3F2906",
-        "titleBar.activeBackground": "#593A09",
-        "titleBar.activeForeground": "#FEF9F1"
-    }
-}

--- a/HelpSource/Classes/Function.schelp
+++ b/HelpSource/Classes/Function.schelp
@@ -33,8 +33,10 @@ code::
 NOTE:: 
 In case you already know how to define your own classes, you came accross the usage
 of teletype::^:: within methods to return values back to the caller. Please be aware
-that usage of teletype::^:: in functions not part of classes is not implemented yet
+that usage of teletype::^:: in functions not part of classes is not implemented.
 and will most likely behave in a non-intuitive way!
+
+Consider using the teletype::block:: method in case you really need the semantic of teletype::^:: in this context.
 ::
 
 subsection:: Related Keywords

--- a/HelpSource/Classes/Function.schelp
+++ b/HelpSource/Classes/Function.schelp
@@ -30,6 +30,13 @@ code::
 ((lambda (x) x) 1) // Lisp
 ::
 
+NOTE:: 
+In case you already know how to define your own classes, you came accross the usage
+of teletype::^:: within methods to return values back to the caller. Please be aware
+that usage of teletype::^:: in functions not part of classes is not implemented yet
+and will most likely behave in a non-intuitive way!
+::
+
 subsection:: Related Keywords
 
 method:: thisFunction

--- a/HelpSource/Guides/WritingClasses.schelp
+++ b/HelpSource/Guides/WritingClasses.schelp
@@ -77,6 +77,13 @@ To return from the method use teletype::^:: (caret). Multiple exit points also p
 specified, the method will return the instance (and in the case of Class methods, will return the class). There is no
 such thing as returning void in SuperCollider.
 
+NOTE::
+Please be aware that usage of teletype::^:: to return values is only allowed 
+within implementation of instance or class methods. 
+Especially in normal functions the usage of teletype::^:: can lead to a 
+non-intuitive behavior.
+::
+
 code::
 MyClass {
 	someMethod {

--- a/HelpSource/Reference/Functions.schelp
+++ b/HelpSource/Reference/Functions.schelp
@@ -27,6 +27,13 @@ code::
 {}.value.postln;
 ::
 
+NOTE:: 
+In case you already know how to define your own classes, you came accross the usage
+of teletype::^:: within methods to return values back to the caller. Please be aware
+that usage of teletype::^:: in functions not part of classes is not implemented yet
+and will most likely behave in a non-intuitive way!
+::
+
 A function can be thought as a machine able to perform a task on demand, e.g. a calculator. The calculator can receive input (args) and can output a value, the result of the performed operations. The function definition can then be thought as the building of the calculator: once built, the calculator does nothing until it is requested to work (by passing the value method to a function).
 The following figure depicts an empty function, input without output, output without input, and the general case with input and output.
 

--- a/HelpSource/Reference/Functions.schelp
+++ b/HelpSource/Reference/Functions.schelp
@@ -30,8 +30,10 @@ code::
 NOTE:: 
 In case you already know how to define your own classes, you came accross the usage
 of teletype::^:: within methods to return values back to the caller. Please be aware
-that usage of teletype::^:: in functions not part of classes is not implemented yet
+that usage of teletype::^:: in functions not part of classes is not implemented.
 and will most likely behave in a non-intuitive way!
+
+Consider using the teletype::block:: method in case you really need the semantic of teletype::^:: in this context.
 ::
 
 A function can be thought as a machine able to perform a task on demand, e.g. a calculator. The calculator can receive input (args) and can output a value, the result of the performed operations. The function definition can then be thought as the building of the calculator: once built, the calculator does nothing until it is requested to work (by passing the value method to a function).


### PR DESCRIPTION
## Purpose and Motivation

Document strange behavior when using caret symbol ```^``` in functions which are not part of a class definition.
Reported in issue #5931 and than had been identified as duplicate of issue #2674

As discussed with @dyfer at least documentation of the behavior is needed. This pull request put corresponding notes within three help pages suggested by @dyfer.

## Types of changes

- Documentation

## To-do list

- [x] Local build had been performed
- [x] SuperCollider IDE shows the notes within the internal browser
