### PR TITLE
complete binaryValue implementation for AbstractFunction and UGen

### DIFF
--- a/HelpSource/Classes/UGen.schelp
+++ b/HelpSource/Classes/UGen.schelp
@@ -41,7 +41,7 @@ code::
 subsection:: Internally used class methods
 
 method:: multiNew
-These methods are responsible for multichannel expansion. They call code::*new1(rate, ...args):: for each parallel combination. Most code::*ar/*kr:: methods delegate to link::#*multiNewList::.
+These methods are responsible for multichannel expansion. They call code::*new1(rate, ...args):: for each parallel combination. Most code::*ar / *kr:: methods delegate to link::#*multiNewList::.
 argument:: ... args
 The first argument is rate, then the rest of the arguments. code::(rate, ...args)::
 
@@ -342,6 +342,10 @@ code::
 
 { Trig1.ar(Dust.ar(3), 0.2).lag(0.1).if(FSinOsc.ar(440), FSinOsc.ar(880)) * 0.1 }.play;
 ::
+
+method::binaryValue
+Outputs 1, representing true for positive, 0 for negative or zero input values.
+
 
 method:: @
 Dynamic geometry support. Returns code::Point(this, y)::.

--- a/SCClassLibrary/Common/Audio/UGen.sc
+++ b/SCClassLibrary/Common/Audio/UGen.sc
@@ -283,6 +283,9 @@ UGen : AbstractFunction {
 		^ModDif.multiNew(this.rate, this, that, mod)
 	}
 
+	binaryValue { ^this.sign.max(0) }
+
+
 	// Note that this differs from |==| for other AbstractFunctions
 	// Other AbstractFunctions write '|==|' into the compound function
 	// for the sake of their 'storeOn' (compile string) representation.

--- a/SCClassLibrary/Common/Core/AbstractFunction.sc
+++ b/SCClassLibrary/Common/Core/AbstractFunction.sc
@@ -87,6 +87,7 @@ AbstractFunction {
 	isPositive { ^this.composeUnaryOp('isPositive') }
 	isNegative { ^this.composeUnaryOp('isNegative') }
 	isStrictlyPositive { ^this.composeUnaryOp('isStrictlyPositive') }
+	binaryValue { ^this.composeUnaryOp('binaryValue') }
 
 	rho {  ^this.composeUnaryOp('rho') }
 	theta {  ^this.composeUnaryOp('theta') }

--- a/testsuite/classlibrary/TestCoreUGens.sc
+++ b/testsuite/classlibrary/TestCoreUGens.sc
@@ -619,5 +619,32 @@ TestCoreUGens : UnitTest {
 
 	}
 
+	test_binaryValue_isUniform {
+		var from = [100, -100, 0, { 100 }, { -100 }, { 0 }];
+		var to = [1, 0, 0, 1, 0, 0];
+		var text = ["positive", "negative", "zero", "positive valued function", "negative valued function", "zero valued function"];
+		var condvar = CondVar();
+		var completed = 0;
+
+		server.bootSync;
+
+		from.size.do { |i|
+			this.assert(from[i].binaryValue.value == to[i], "% should correspond to %".format(text[i], to[i]));
+		};
+
+		from.size.do { |i|
+
+			{ DC.ar(from[i]).binaryValue }.loadToFloatArray(0.001, server, { |data|
+				this.assertFloatEquals(data[0], to[i],"% signal should correspond to %".format(text[i], to[i]), within: 0.1);
+				completed = completed + 1;
+				condvar.signalOne;
+			})
+		};
+
+		condvar.waitFor(1, { completed == from.size });
+
+	}
+
+
 
 } // end TestCoreUGens class


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

The method `binaryValue` is valid only for booleans and numbers, not for functions and UGens. This makes it valid.

Note that there is a comment in SimpleNumber: " // TODO in the long-run, deprecate for asInteger"
We did this because we thought that it is better expressed as a conversion (beginning with "as").
But I don't think it should be `asInteger` but `asBinaryValue`. This is a separate issue.

## Types of changes

<!-- Delete lines that don't apply -->

- New feature


## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review
