### PR TITLE
classlib: Plotter: extend tick labels

### DIFF
--- a/HelpSource/Classes/AbstractGridLines.schelp
+++ b/HelpSource/Classes/AbstractGridLines.schelp
@@ -113,16 +113,16 @@ argument:: valueMax
 Maximum value of the data to be plotted. The highest grid line value returned may be lower than this value.
 
 argument:: pixelMin
-Lower bound of the grid's range, in pixels. Used to calculate the size of the available grid space when determining grid values based on strong::tickSpacing:: (if code::numTicks:: is code::nil::).
+Lower bound of the grid's range, in pixels. Used to calculate the size of the available grid space when determining grid values based on strong::tickSpacing:: (if strong::numTicks:: is code::nil::).
 
 argument:: pixelMax
-Upper bound of the grid's range, in pixels. Used to calculate the size of the available grid space when determining grid values based on strong::tickSpacing:: (if code::numTicks:: is code::nil::).
+Upper bound of the grid's range, in pixels. Used to calculate the size of the available grid space when determining grid values based on strong::tickSpacing:: (if strong::numTicks:: is code::nil::).
 
 argument:: numTicks
 Explicit number of ticks you would like to see on the graph (though the result is approximate). Set to code::nil:: if you'd like the number of ticks to be found automatically, based on strong::pixelMin::, strong::pixelMax::, and strong::tickSpacing::.
 
 argument:: tickSpacing
-Minimum distance between ticks (in pixels). This value is only used when code::numTicks:: is code::nil::.
+Minimum distance between ticks (in pixels). This value is only used when strong::numTicks:: is code::nil::.
 
 returns:: A link::Classes/Dictionary::.
 

--- a/HelpSource/Classes/Collection.schelp
+++ b/HelpSource/Classes/Collection.schelp
@@ -476,8 +476,8 @@ binwidth = range / steps;
 
 data.histo(steps).plot(minval: 0)
 .plotMode_(\steps)
-.labelY_("Occurrences")
-.labelX_("Bins")
+.axisLabelY_("Occurrences")
+.axisLabelX_("Bins")
 .domainSpecs_(minmax.asSpec)
 .domain_(binwidth * (0..steps-1) + data.minItem)
 ;

--- a/HelpSource/Classes/Plotter.schelp
+++ b/HelpSource/Classes/Plotter.schelp
@@ -180,6 +180,27 @@ link::Classes/String::s, or code::nil:: to remove the label.
 See link::#Axis labels:: example below.
 
 
+method:: showUnits
+Get/set whether the corresponding link::Classes/ControlSpec#-units:: are displayed as labels. The state of link::#-unitLocation:: determines whether the units are shown as axis labels or appended to the tick labels.
+
+argument:: bool
+A code::Boolean::.
+
+discussion::
+When enabling code::showUnits::, axis or tick labels will only be updated to show the units when the code::axisLabelX/Y:: or grid code::labelAppendString:: properties are code::nil::, empty, or were previously set to show the spec units — i.e. code::showUnits:: won't overwrite a label that has been explicitly set.
+
+See link::#Unit labels:: example below.
+
+
+method:: unitLocation
+Get/set the label type on which the code::Spec:: link::Classes/ControlSpec#-units:: are shown.
+
+See the Discussion in link::#-showUnits:: about the interraction with pre-existing labels at the strong::location::, and link::#Unit labels:: example below.
+
+argument:: location
+A code::Symbol::, code::\axis:: or code::\ticks::, to show the units as the axis label or appended to each of the tick labels, respectively.
+
+
 method:: setProperties
 Set properties of all plot views. Defaults are taken from code::GUI.skins.at(\plot);::
 
@@ -682,6 +703,39 @@ p.axisLabelX_(["one", "two", nil, "four"]);
 // assigning nil removes all labels
 p.axisLabelX_(nil);
 // ... axisLabelY behaves the same way
+::
+
+subsection:: Unit labels
+The units of the grid specs are shown as labels, either axis labels or appended to tick labels. Unit labels won't overwrite preexisting labels, and can be disabled altogether.
+code::
+( // units displayed in the axis labels by default
+p = (4 ** (-1.5, -1.25 .. 0)).plot;
+p.specs = \delay.asSpec.minval_(0.1);
+p.domainSpecs = [0, 10, \lin, 0, 0, "xUnits"].asSpec;
+p.setGridProperties(\y, \constrainLabelExtents, false);
+p.setGridProperties(\x, \constrainLabelExtents, true);
+)
+
+p.showUnits = false;      // hide units
+p.unitLocation = \ticks;  // move units to tick labels
+p.showUnits = true;       // show units
+p.axisLabelX = "X LABEL"; // set an axis label
+p.unitLocation = \axis;   // move units to axes
+// ... x-axis label isn't overwritten
+p.axisLabelX = nil        // remove x-axis label
+p.unitLocation = \axis;   // set units to axes again
+// ... units now appear on the x-axis
+
+// customize the Y labels
+p.setGridProperties(\y, \labelAppendString, " y");
+// move units to tick labels
+p.unitLocation = \ticks;
+// ... y-axis tick labels aren't overwritten
+// now remove y-tick label string
+p.setGridProperties(\y, \labelAppendString, nil);
+// set units to tick labels again
+p.unitLocation = \ticks;
+// ... units now appear on the y-tick labels
 ::
 
 subsection:: Embedding in another View or GUI

--- a/HelpSource/Classes/Plotter.schelp
+++ b/HelpSource/Classes/Plotter.schelp
@@ -135,10 +135,9 @@ a.plotMode = \bars; a.refresh;
 
 /* mixed modes */
 (
-c = [Color.red, Color.cyan, Color.green, Color.blue];
 d = 4.collect({ |i| 100.collect({ |j| sinPi(1+i.squared*j * 50.reciprocal) })});
 p = d.plot;
-p.plotColor_(c);
+p.plotColor_([Color.red, Color.cyan, Color.green, Color.blue]);
 p.plotMode_([\steps, \linear, \plines, \points]);
 // superpose will trigger a refresh to update colors/modes
 p.superpose_(true);
@@ -211,11 +210,13 @@ code::
 (
 a = { (0..30).scramble }.dup(2).plot;
 a.setProperties(
-	\fontColor, Color.red,
-	\plotColor, Color.blue,
-	\backgroundColor, Color.black,
-	\gridColorX, Color.white,
-	\labelX, "Humidity"
+  \fontColor, Color.yellow,
+  \plotColor, Color.magenta,
+  \backgroundColor, Color.black,
+  \gridColorX, Color.green,
+  \gridColorY, Color.green,
+  \labelX, "Frames",
+  \labelFontColor, Color.magenta
 );
 a.refresh;
 );
@@ -229,6 +230,119 @@ method:: plots
 returns:: An link::Classes/Array:: of link::Classes/Plot::s.
 
 
+subsection:: Grid properties
+
+method:: setGridProperties
+Set one or more properties of the code::DrawGridX:: or code::DrawGridY:: used by all code::Plots::.
+
+argument:: axis
+A code::Symbol:: denoting the axis whose grid you're modifying: code::\x:: or code::\y::.
+
+argument:: ... propertyPairs
+Key value pairs, listed as successive arguments, of the properties to change and their new values. The property key is a code::Symbol::.
+
+Any of setters of code::DrawGridX:: or code::DrawGridY:: can be used. Here is a subset of useful properties:
+table::
+## code::\labelAnchor:: || A code::Symbol:: denoting the point on the label's bounding link::Classes/Rect:: that anchors to the point where the grid line meets the base of the axis. code::\center, \top, \bottom, \left, \right, \topLeft, \topRight, \bottomLeft, \bottomRight, \leftTop, \rightTop, \leftBottom, \rightBottom::.
+## code::\labelOffset:: || A link::Classes/Point:: describing the offset of the code::\labelAnchor:: from the point where the grid line meets the base of the axis. The positive direction for the teletype::x:: and teletype::y:: dimensions is right and down, respectively.
+## code::\labelAlign:: || Alignment of the text within its bounding code::Rect::: code::\left::, code::\center::, or code::\right::.
+## code::\constrainLabelExtents:: || A code::Boolean:: specifying whether the tick labels at either end of the axis are constrained by, or can extend beyond, the grid bounds.
+## code::\drawBaseLine:: || A code::Boolean:: whether a line is drawn at the minimum extent of this strong::axis::.
+## code::\drawBoundingLines:: || A code::Boolean:: whether a line is drawn at both ends of the extent of this strong::axis::.
+## code::\drawBoundingRect:: || A code::Boolean:: whether a code::Rect:: is drawn around the bounds of the grid area.
+## code::\labelAppendString:: || A string to append to all of the axis's tick labels.
+## code::\tickSpacing:: || Set the emphasis::minimum:: spacing between grid lines ("ticks") for each axis. See link::Classes/DrawGrid#-tickSpacing:: for details.
+## code::\numTicks:: || Set the emphasis::approximate:: number of grid lines ("ticks") for each axis. See link::Classes/DrawGrid#-numTicks:: for details.
+## code::\font:: || A link::Classes/Font:: (including size) to be used for the tick labels.
+## code::\fontColor:: || The link::Classes/Color:: of the tick labels.
+## code::\gridColor:: || The link::Classes/Color:: of the axis grid lines.
+::
+
+The properties code::\drawBaseLine::,  code::\drawBoundingLines::, or code::\drawBoundingRect:: are mutually exlusive — setting any of them to true will set the others two to code::false::. In the context of code::Plotter::, setting code::\drawBoundingRect:: on one axis to code::true:: has the same appearance of setting code::\drawBoundingLines:: on emphasis::both:: axes to code::true::.
+
+discussion::
+This is a convenience method to set the grid properties for emphasis::all:: code::Plot::s to the same values.
+An Example:
+code::
+(
+var plotter = [10, 34, 167].collect({ |freq|
+	101.collect{|i| sin((i/1000) * 2pi * freq)}
+}).plot;
+plotter.setGridProperties(\x,
+	\labelAnchor, \topLeft,
+	\labelAlign, \left,
+	\labelOffset, 1 @ 5,
+	\labelAppendString, " samp"
+).setGridProperties(\y,
+	\labelAnchor, \right,
+	\labelAlign, \right,
+	\labelOffset, -5 @ 0,
+	\constrainLabelExtents, false
+)
+)
+::
+
+To set the properties of grids on each code::Plot:: separately, iterate over the plots:
+code::
+(
+var plotter, labelAnchors;
+plotter = [10, 34, 167].collect({ |freq|
+	101.collect{|i| sin((i/1000) * 2pi * freq)}
+}).plot;
+
+labelAnchors = [\topLeft, \top, \bottomLeft];
+
+plotter.plots.do{ |plot, i|
+	plot.drawGrid.x
+	.labelAnchor_(labelAnchors[i])
+	.constrainLabelExtents_(true);
+};
+plotter.updatePlotBounds;
+)
+::
+
+
+method:: getGridProperty
+Get the value of a grid property. See link::#-setGridProperties:: for a list of available properties.
+
+argument:: axis
+A code::Symbol:: denoting the axis whose grid you're modifying: code::\x:: or code::\y::.
+
+argument:: property
+The property name as a code::Symbol::.
+
+discussion::
+As a convenience method, code::getGridProperty:: assumes that properties across all code::Plot::s are the same (as would be the case if set by link::#-setGridProperties::) so returns a single value. Alternatively, properties from individual plot grids can be collected by iterating over the plots:
+code::
+( // inspect the \labelAnchor of each DrawGridX
+var plotter  = [10, 34, 167].collect({ |freq|
+	101.collect{|i| sin((i/1000) * 2pi * freq)}
+}).plot;
+
+plotter.plots.collect({ |plot|
+	plot.drawGrid.x.labelAnchor
+}).postln;
+)
+::
+
+
+method:: drawGridBoundingRect
+Set whether a link::Classes/Rect:: is drawn around the boundary of the grid. Setting to code::false:: disables any bounding grid lines (including "base" lines).
+
+argument:: bool
+A code::Boolean::.
+
+discussion::
+In some cases, the link::Classes/GridLines:: of the grid will not fall on the minimum or maximum of it's spec's range. Using link::#-drawGridBaseLines:: or link::#-drawGridBoundingRect:: will give the appearance of grid lines at the lower end ("base") of the grid, or at both ends of the grid, respectively.
+
+
+method:: drawGridBaseLines
+Set whether a line is drawn at the lower extent of the grid axes. Setting to code::false:: disables any bounding grid lines (including a bounding code::Rect::). See also the Discussion in link::#-drawGridBoundingRect::.
+
+argument:: bool
+A code::Boolean::.
+
+
 subsection:: Data display properties
 
 
@@ -237,13 +351,9 @@ Set or get the link::Classes/ControlSpec##spec:: for the y-axis (codomain).
 
 code::
 a = { (40..3000).scramble }.dup(2).plot;
-a.specs = \freq.asSpec; a.refresh;
+a.specs = \freq.asSpec;
 ::
 See also the link::#Explicit domain and axis specs:: example below.
-note::
-The y-axis label will update with the strong::units:: assigned
-to your spec, if it has not been previously set.
-::
 
 
 method:: domainSpecs
@@ -251,13 +361,9 @@ Set or get the link::Classes/ControlSpec##spec:: for the x-axis (domain).
 
 code::
 a = { (40..300).scramble }.dup(2).plot;
-a.domainSpecs = \freq.asSpec; a.refresh;
+a.domainSpecs = \freq.asSpec;
 ::
 See also the link::#Explicit domain and axis specs:: example below.
-note::
-The x-axis label will update with the strong::units:: assigned
-to your spec, if it has not been previously set.
-::
 
 discussion::
 When setting your code::Plotter:: link::#-value::, the default strong::domainSpecs:: is a linear spec in the range code::[0, value.size-1]:: (i.e. the indices of the values). Therefore, your values are displayed as evenly sampled between the code::minval:: and code::maxval::, unless you have explicitly set the link::#-domain:: values.
@@ -376,20 +482,9 @@ code::
 a = { (0..10).scramble.normalize }.dup(2).plot;
 a.editMode = true;
 a.editFunc = { |...args| args.postln };
-);
+)
 
 // using plotter as a control interface
-(
-a = (0..10).scramble.normalize(300, 400).plot;
-a.specs = \freq; a.plotMode = \points;
-a.editMode = true;
-x = { SinOsc.ar(\freq.kr(a.value)).mean * 0.1 }.play;
-a.editFunc = { |plotter, plotIndex, i, val|
-	x.setn(\freq, a.value)
-};
-a.parent.onClose = { x.release };
-);
-
 (
 a = { (0..10).scramble.normalize(300, 400) }.dup.plot;
 a.specs = \freq; a.plotMode = \bars;
@@ -403,7 +498,7 @@ a.editFunc = { |plotter, plotIndex, i, val|
 	x.setn(\rate, a.value[1]);
 };
 a.parent.onClose = { x.release };
-);
+)
 ::
 
 
@@ -412,7 +507,7 @@ method:: cursorPos
 returns:: The last cursorPos (a link::Classes/Point::).
 
 
-private:: plotColors, prReshape, pointIsInWhichPlot
+private:: plotColors, prReshape, pointIsInWhichPlot, prSetUpInteractionView
 
 
 examples::
@@ -432,7 +527,7 @@ a.plotMode = \plines; a.refresh;
 a.domainSpecs = [[0, 115, \lin, 1]]; a.refresh;
 
 a.parent.close; // close window
-a.makeWindow;	// open it again
+a.makeWindow; a.updatePlotBounds; // open it again
 
 a.value = { (0..70).scramble }.dup(3);
 a.plotMode = \linear; a.refresh;
@@ -480,7 +575,6 @@ a.superpose = false;
 // Function:plot
 a = { SinOsc.ar([700, 357]) * SinOsc.ar([400, 476]) * 0.2 }.plot;
 a = { SinOsc.ar([700, 357] *0.02) * SinOsc.ar([400, 476]) * 0.3 }.plot(0.2, minval: -1);
-a = { SinOsc.ar(440) }.plot(1);
 
 // Env:plot
 Env.perc(0.4, 0.6).plot;

--- a/HelpSource/Classes/Plotter.schelp
+++ b/HelpSource/Classes/Plotter.schelp
@@ -260,18 +260,13 @@ to your spec, if it has not been previously set.
 ::
 
 discussion::
-The default domainSpec when setting your Plotter link::#-value:: is a linear
-spec in the range code::[0, value.size-1]::. Unless you set link::#-domain::,
-your values are displayed as evenly sampled between the code::minval:: and
-code::maxval:: of the domainSpecs.
+When setting your code::Plotter:: link::#-value::, the default strong::domainSpecs:: is a linear spec in the range code::[0, value.size-1]:: (i.e. the indices of the values). Therefore, your values are displayed as evenly sampled between the code::minval:: and code::maxval::, unless you have explicitly set the link::#-domain:: values.
 
 If a new link::#-value:: is set, you will need to update your domainSpecs.
 
 
 method:: domain
-Set or get the x-axis positions of your data points. The size of the
-code::domainArray:: must equal the size of your value array, i.e. a domain
-value specified for each data point.
+Set/get the x-axis positions of your data points. The size of the code::domainArray:: must equal the size of your link::#-value:: array, i.e. a domain value specified for each data point.
 
 code::
 (

--- a/HelpSource/Classes/Plotter.schelp
+++ b/HelpSource/Classes/Plotter.schelp
@@ -169,13 +169,13 @@ a.superpose = true; a.refresh;
 ::
 
 
-method:: labelX
+method:: axisLabelX
 Get/set the label for the x-axes. Can be a link::Classes/String:: or an link::Classes/Array:: of
 link::Classes/String::s, or code::nil:: to remove the label.
 See link::#Axis labels:: example below.
 
 
-method:: labelY
+method:: axisLabelY
 Get/set the label for the y-axes. Can be a link::Classes/String:: or an link::Classes/Array:: of
 link::Classes/String::s, or code::nil:: to remove the label.
 See link::#Axis labels:: example below.
@@ -570,22 +570,24 @@ subsection:: Axis labels
 
 code::
 (
-p = 4.collect({|cnt| 100.collect({rrand(0,1.0)})}).plot;
+p = 4.collect({
+	100.collect({ rrand(0,1.0) })
+}).plot(bounds: Rect(50,50,500,650));
 p.plotColor_([Color.red, Color.blue, Color.green, Color.cyan]);
 )
 
 // a single label propagates through all Plots
-p.labelX_("one");
+p.axisLabelX_("one");
 // set each individually
-p.labelX_(["one", "two", "three", "four"]);
+p.axisLabelX_(["one", "two", "three", "four"]);
 // superposed plots default to the first label
 p.superpose_(true);
 p.superpose_(false); // labels are restored
 // nil element removes a label
-p.labelX_(["one", "two", nil, "four"]);
+p.axisLabelX_(["one", "two", nil, "four"]);
 // assigning nil removes all labels
-p.labelX_(nil);
-// ... labelY behaves the same way
+p.axisLabelX_(nil);
+// ... axisLabelY behaves the same way
 ::
 
 subsection:: Embedding in another View or GUI

--- a/HelpSource/Classes/Signal.schelp
+++ b/HelpSource/Classes/Signal.schelp
@@ -368,8 +368,8 @@ complex = fft(real, imag, cosTable);
 	(complex.magnitude) / size
 ]
 .plot("fft", Window.screenBounds.insetBy(*200!2))
-.labelX_(["Signal (real, samples)", "Signal (imaginary, samples)", "FFT spectrum (bins)"])
-.labelY_(["Amplitude", "Amplitude", "Magnitude"])
+.axisLabelX_(["Signal (real, samples)", "Signal (imaginary, samples)", "FFT spectrum (bins)"])
+.axisLabelY_(["Amplitude", "Amplitude", "Magnitude"])
 .plotMode_([\linear, \linear, \steps]);
 )
 ::
@@ -399,8 +399,8 @@ ifft = complex.real.ifft(complex.imag, cosTable);
 	ifft.real
 ]
 .plot("fft -> ifft", Window.screenBounds.insetBy(*200!2))
-.labelX_(["Real signal (samples)", "Restored signal (samples)"])
-.labelY_("Amplitude");
+.axisLabelX_(["Real signal (samples)", "Restored signal (samples)"])
+.axisLabelY_("Amplitude");
 )
 ::
 

--- a/HelpSource/Classes/SimpleNumber.schelp
+++ b/HelpSource/Classes/SimpleNumber.schelp
@@ -599,7 +599,7 @@ code::
 	.domainSpecs_(
 		[vals.minItem, vals.maxItem].asSpec
 	)
-	.labelX_("input").labelY_("output")
+	.axisLabelX_("input").axisLabelY_("output")
 )
 ::
 

--- a/SCClassLibrary/Common/Control/Spec.sc
+++ b/SCClassLibrary/Common/Control/Spec.sc
@@ -192,10 +192,10 @@ ControlSpec : Spec {
 			\unipolar -> ControlSpec(0, 1),
 			\bipolar -> ControlSpec(-1, 1, default: 0),
 
-			\freq -> ControlSpec(20, 20000, \exp, 0, 440, units: " Hz"),
-			\lofreq -> ControlSpec(0.1, 100, \exp, 0, 6, units: " Hz"),
-			\midfreq -> ControlSpec(25, 4200, \exp, 0, 440, units: " Hz"),
-			\widefreq -> ControlSpec(0.1, 20000, \exp, 0, 440, units: " Hz"),
+			\freq -> ControlSpec(20, 20000, \exp, 0, 440, units: "Hz"),
+			\lofreq -> ControlSpec(0.1, 100, \exp, 0, 6, units: "Hz"),
+			\midfreq -> ControlSpec(25, 4200, \exp, 0, 440, units: "Hz"),
+			\widefreq -> ControlSpec(0.1, 20000, \exp, 0, 440, units: "Hz"),
 			\phase -> ControlSpec(0, 2pi),
 			\rq -> ControlSpec(0.001, 2, \exp, 0, 0.707),
 
@@ -206,16 +206,16 @@ ControlSpec : Spec {
 			\midinote -> ControlSpec(0, 127, default: 60),
 			\midivelocity -> ControlSpec(1, 127, default: 64),
 
-			\db -> ControlSpec(0.ampdb, 1.ampdb, \db, units: " dB"),
+			\db -> ControlSpec(0.ampdb, 1.ampdb, \db, units: "dB"),
 			\amp -> ControlSpec(0, 1, \amp, 0, 0),
-			\boostcut -> ControlSpec(-20, 20, units: " dB",default: 0),
+			\boostcut -> ControlSpec(-20, 20, units: "dB", default: 0),
 
 			\pan -> ControlSpec(-1, 1, default: 0),
-			\detune -> ControlSpec(-20, 20, default: 0, units: " Hz"),
+			\detune -> ControlSpec(-20, 20, default: 0, units: "Hz"),
 			\rate -> ControlSpec(0.125, 8, \exp, 0, 1),
-			\beats -> ControlSpec(0, 20, units: " Hz"),
+			\beats -> ControlSpec(0, 20, units: "Hz"),
 
-			\delay -> ControlSpec(0.0001, 1, \exp, 0, 0.3, units: " secs")
+			\delay -> ControlSpec(0.0001, 1, \exp, 0, 0.3, units: "sec")
 		]);
 	}
 

--- a/SCClassLibrary/Common/GUI/Base/Grid.sc
+++ b/SCClassLibrary/Common/GUI/Base/Grid.sc
@@ -16,9 +16,9 @@ DrawGrid {
 		this.gridColors = [Color.grey(0.7), Color.grey(0.7)];
 	}
 	bounds_ { arg b;
-		bounds = b;
-		x.bounds = b;
-		y.bounds = b;
+		bounds = b.asRect;
+		x.bounds = bounds;
+		y.bounds = bounds;
 	}
 	draw {
 		Pen.push;

--- a/SCClassLibrary/Common/GUI/Base/Grid.sc
+++ b/SCClassLibrary/Common/GUI/Base/Grid.sc
@@ -66,9 +66,8 @@ DrawGrid {
 
 	// make a Window with a UserView that draws this DrawGrid
 	preview {
-		var insetH = 45, insetV = 35; // left, bottom margins for labels
+		var insetH = 30, insetV = 15; // left, bottom margins for labels
 		var gridPad = 15;             // right, top margin
-		var axLabelPad = 3;           // label offset from window's edge
 		var win, winBounds, font, fcolor;
 
 		// refresh and return the view if it already exists
@@ -85,7 +84,7 @@ DrawGrid {
 
 		// bounds of the grid lines, without its labels
 		this.bounds = this.bounds ?? { Rect(0, 0, 500, 400) };
-		// translate the grid to make room for axis & tick labels
+		// translate the grid to make room for tick labels
 		this.bounds = this.bounds.moveTo(insetH-gridPad, gridPad);
 
 		winBounds = this.bounds + Size(insetH, insetV);
@@ -98,33 +97,7 @@ DrawGrid {
 			win, winBounds.size.asRect
 		)
 		.drawFunc_({ |uv|
-			var unitsStr;
-
-			// draw the drid
-			this.draw;
-
-			// draw x-axis label
-			unitsStr = this.x.grid.spec.units;
-			if(unitsStr.size > 0) {
-				Pen.push;
-				Pen.translate(this.bounds.center.x, uv.bounds.bottom);
-				Pen.stringCenteredIn(unitsStr,
-					unitsStr.bounds.center_(0@0).bottom_(axLabelPad.neg),
-					font, fcolor);
-				Pen.pop;
-			};
-
-			// draw y-axis label
-			unitsStr = this.y.grid.spec.units;
-			if(unitsStr.size > 0) {
-				Pen.push;
-				Pen.translate(0, this.bounds.center.y);
-				Pen.rotateDeg(-90);
-				Pen.stringCenteredIn(unitsStr,
-					unitsStr.bounds.center_(0@0).top_(axLabelPad),
-					font, fcolor);
-				Pen.pop;
-			};
+			this.draw; // draw the drid
 		})
 		.onResize_({ |uv|
 			this.bounds = uv.bounds

--- a/SCClassLibrary/Common/GUI/Base/Grid.sc
+++ b/SCClassLibrary/Common/GUI/Base/Grid.sc
@@ -97,7 +97,7 @@ DrawGrid {
 			win, winBounds.size.asRect
 		)
 		.drawFunc_({ |uv|
-			this.draw; // draw the drid
+			this.draw;
 		})
 		.onResize_({ |uv|
 			this.bounds = uv.bounds
@@ -124,6 +124,7 @@ DrawGridX {
 	var <tickSpacing = 64;
 	var <numTicks = nil; // nil for dynamic numTicks with view size
 	var <>showLabels = true; // tick labels
+	var <>labelsHiddenBySize = false;
 	var <labelAppendString = nil;
 	var <drawBoundingRect = true, <drawBaseLine = false, <drawBoundingLines = false;
 
@@ -295,7 +296,7 @@ DrawGridX {
 			};
 
 			// Tick labels
-			if(showLabels and: { p['labels'].notNil }, {
+			if(showLabels and: { labelsHiddenBySize.not and: { p['labels'].notNil } }) {
 				commands = commands.add(['font_',font ] );
 				commands = commands.add(['color_',fontColor ] );
 
@@ -339,7 +340,7 @@ DrawGridX {
 						commands = commands.add([alignSym, val[1], labelRect]);
 					}
 				}
-			});
+			};
 
 			commands // return
 		}
@@ -349,13 +350,18 @@ DrawGridX {
 	// grid, given its size, anchoring, and offset. Userful when laying out
 	// this grid in a UserView to allowing room for labels.
 	labelOverhang { |labelStr|
+		var strRect, rect;
 		var overhang = [0, 0, 0, 0]; // left, top, right, bottom
-		var strRect = if(labelStr.notNil) {
+
+		if (showLabels.not) {
+			^overhang
+		};
+		strRect = if(labelStr.notNil) {
 			labelStr.bounds(font);
 		} {
 			this.labelSize.asRect
 		};
-		var rect = strRect.anchorTo(labelOffset, labelAnchor);
+		rect = strRect.anchorTo(labelOffset, labelAnchor);
 
 		// top side: assumes label doesn't extend past top bound
 		overhang[3] = abs(max(rect.bottom, 0)); // bottom
@@ -493,7 +499,7 @@ DrawGridY : DrawGridX {
 				};
 			};
 
-			if(showLabels and: { p['labels'].notNil }, {
+			if(showLabels and: { labelsHiddenBySize.not and: { p['labels'].notNil } }) {
 				commands = commands.add(['font_',font ] );
 				commands = commands.add(['color_',fontColor ] );
 
@@ -536,7 +542,7 @@ DrawGridY : DrawGridX {
 					);
 					commands = commands.add([alignSym, labelStr, labelRect]);
 				};
-			});
+			};
 
 			commands // return
 		}
@@ -544,9 +550,15 @@ DrawGridY : DrawGridX {
 
 	// See description in DrawGridX:-labelOverhang
 	labelOverhang { |labelStr|
+		var strRect, rect;
 		var overhang = [0, 0, 0, 0]; // left, top, right, bottom
-		var strRect = if(labelStr.notNil) { labelStr.bounds(font) } { this.labelSize.asRect };
-		var rect = strRect.anchorTo(labelOffset, labelAnchor);
+
+		if (showLabels.not) {
+			^overhang
+		};
+
+		strRect = if(labelStr.notNil) { labelStr.bounds(font) } { this.labelSize.asRect };
+		rect = strRect.anchorTo(labelOffset, labelAnchor);
 
 		// right side: assume label doesn't extend past right bound
 		overhang[0] = abs(min(rect.left, 0)); // left

--- a/SCClassLibrary/Common/GUI/Base/Grid.sc
+++ b/SCClassLibrary/Common/GUI/Base/Grid.sc
@@ -8,8 +8,8 @@ DrawGrid {
 		^super.new.init(bounds, horzGrid, vertGrid)
 	}
 	init { arg bounds, h, v;
-		x = DrawGridX(h);
-		y = DrawGridY(v);
+		x = DrawGridX(h, bounds.asRect);
+		y = DrawGridY(v, bounds.asRect);
 		this.bounds = bounds;
 		this.font = Font(Font.defaultSansFace, 9);
 		this.fontColor = Color.grey(0.3);
@@ -22,11 +22,11 @@ DrawGrid {
 	}
 	draw {
 		Pen.push;
-			Pen.alpha = opacity;
-			Pen.smoothing = smoothing;
-			if(linePattern.notNil) {Pen.lineDash_(linePattern)};
-			x.commands.do({ arg cmd; Pen.perform(cmd) });
-			y.commands.do({ arg cmd; Pen.perform(cmd) });
+		Pen.alpha = opacity;
+		Pen.smoothing = smoothing;
+		if(linePattern.notNil) {Pen.lineDash_(linePattern)};
+		x.commands.do({ arg cmd; Pen.perform(cmd) });
+		y.commands.do({ arg cmd; Pen.perform(cmd) });
 		Pen.pop;
 	}
 	font_ { arg f;
@@ -68,7 +68,7 @@ DrawGrid {
 	preview {
 		var insetH = 45, insetV = 35; // left, bottom margins for labels
 		var gridPad = 15;             // right, top margin
-		var txtPad = 2;               // label offset from window's edge
+		var axLabelPad = 3;           // label offset from window's edge
 		var win, winBounds, font, fcolor;
 
 		// refresh and return the view if it already exists
@@ -109,7 +109,7 @@ DrawGrid {
 				Pen.push;
 				Pen.translate(this.bounds.center.x, uv.bounds.bottom);
 				Pen.stringCenteredIn(unitsStr,
-					unitsStr.bounds.center_(0@0).bottom_(txtPad.neg),
+					unitsStr.bounds.center_(0@0).bottom_(axLabelPad.neg),
 					font, fcolor);
 				Pen.pop;
 			};
@@ -121,7 +121,7 @@ DrawGrid {
 				Pen.translate(0, this.bounds.center.y);
 				Pen.rotateDeg(-90);
 				Pen.stringCenteredIn(unitsStr,
-					unitsStr.bounds.center_(0@0).top_(txtPad),
+					unitsStr.bounds.center_(0@0).top_(axLabelPad),
 					font, fcolor);
 				Pen.pop;
 			};
@@ -143,20 +143,32 @@ DrawGrid {
 
 DrawGridX {
 
-	var <grid,<>range,<>bounds;
-	var <font,<fontColor,<gridColor,<labelOffset;
-	var commands,cacheKey;
-	var txtPad = 2; // match with Plot:txtPad
+	var <grid,<>bounds;
+	var <>range;
+	var <font,<fontColor,<gridColor;
+	var <labelOffset, <labelAlign, <labelAnchor, <constrainLabelExtents;
+	var commands, cacheKey, lastLabelSize;
 	var <tickSpacing = 64;
-	var <numTicks = nil; // nil for dynamic with view size
+	var <numTicks = nil; // nil for dynamic numTicks with view size
+	var <>showLabels = true; // tick labels
+	var <labelAppendString = nil;
+	var <drawBoundingRect = true, <drawBaseLine = false, <drawBoundingLines = false;
 
-	*new { arg grid;
-		^super.newCopyArgs(grid.asGrid).init
+
+	*new { arg grid, bounds;
+		^super.newCopyArgs(grid.asGrid, bounds).init
 	}
 
 	init {
 		range = [grid.spec.minval, grid.spec.maxval];
-		labelOffset = "20000".bounds.size.asPoint;
+		labelAnchor = \top;
+		labelOffset = 0 @ 2;
+		labelAlign = \center;
+		constrainLabelExtents = false;
+		font = Font(Font.defaultSansFace, 9);
+		fontColor = Color.grey(0.3);
+		gridColor = Color.grey(0.7);
+		lastLabelSize = "000".bounds(font).asSize;
 	}
 	grid_ { arg g;
 		grid = g.asGrid;
@@ -166,153 +178,357 @@ DrawGridX {
 	setZoom { arg min,max;
 		range = [min, max];
 	}
-	tickSpacing_{ |px|
+	tickSpacing_ { |px|
 		px !? {
 			tickSpacing = px;
 			this.clearCache;
 		};
 	}
-	numTicks_{ |num|
+	numTicks_ { |num|
 		numTicks = num;
 		this.clearCache;
 	}
-	font_{ |afont|
+	font_ { |afont|
 		font = afont;
 		this.clearCache;
 	}
-	fontColor_{ |color|
+	fontColor_ { |color|
 		fontColor = color;
 		this.clearCache;
 	}
-	gridColor_{ |color|
+	gridColor_ { |color|
 		gridColor = color;
 		this.clearCache;
 	}
-	// labelOffset is effectively a point describing the size of a grid label
-	labelOffset_{ |pt|
-		labelOffset = pt;
+	labelOffset_ { |pnt|
+		try {
+			labelOffset = pnt.asPoint;
+		} {
+			Error("[DrawGridX/Y:labelOffset_] "
+				"pt argument needs to be able to respond to the .asPoint method, "
+				"e.g. a Point, Size, Rect, or SimpleNumber.").throw
+		};
 		this.clearCache;
 	}
+	labelAlign_ { |align|
+		var alignSym = align.asSymbol;
+		var alignList = #[\center, \left, \right];
+
+		if(alignList.includes(alignSym)) {
+			labelAlign = alignSym
+		} {
+			warn("[DrawGridX/Y:labelAlign_] "
+				"Invalid align argument, options are: %".format(alignList))
+		};
+		this.clearCache;
+	}
+	labelAnchor_ { |anchor|
+		var anchorSym = anchor.asSymbol;
+		var anchorList = #[ // these need to match keys in Rect:-anchorTo
+			\center, \top, \bottom, \left, \right,
+			\topLeft, \topRight, \bottomLeft, \bottomRight,
+			\leftTop, \rightTop, \leftBottom, \rightBottom,
+		];
+
+		if(anchorList.includes(anchorSym)) {
+			labelAnchor = anchorSym
+		} {
+			warn("[DrawGridX/Y:labelAnchor_] "
+				"Invalid anchor argument, options are: %".format(anchorList))
+		};
+		this.clearCache;
+	}
+	labelAppendString_ { |str|
+		this.grid.appendLabel_(str);
+		this.clearCache;
+	}
+	constrainLabelExtents_ { |bool|
+		constrainLabelExtents = bool;
+		this.clearCache;
+	}
+	drawBaseLine_ { |bool|
+		drawBaseLine = bool;
+		if(bool) {
+			drawBoundingLines = false;
+			drawBoundingRect = false;
+		};
+		this.clearCache;
+	}
+	drawBoundingLines_ { |bool|
+		drawBoundingLines = bool;
+		if(bool) {
+			drawBaseLine = false;
+			drawBoundingRect = false;
+		};
+		this.clearCache;
+	}
+	drawBoundingRect_ { |bool|
+		drawBoundingRect = bool;
+		if(bool) {
+			drawBoundingLines = false;
+			drawBaseLine = false;
+		};
+		this.clearCache;
+	}
+
 	commands {
-		var p;
-		var valNorm, lineColor;
+		var p, labelSz, valNorm, lineColor;
+		var x, labelRect, anchorPoint, alignSym;
+		var rightBound = bounds.right.asInteger;
+		var leftBound = bounds.left.asInteger;
+		var bottomBound = bounds.bottom;
+		var constrainedPad = 1;
+
 		if(cacheKey != [range,bounds],{ commands = nil });
+
 		^commands ?? {
 			cacheKey = [range,bounds];
 			commands = [];
-			p = grid.getParams(range[0], range[1], bounds.left, bounds.right, numTicks, tickSpacing);
+			p = grid.getParams(range[0], range[1], leftBound, rightBound, numTicks, tickSpacing);
 
+			// Lines
 			p['lines'].do { arg val, i;
-				var x;
 				val = val.asArray; // value, [color]
 				valNorm = grid.spec.unmap(val[0]);
-				x = valNorm.linlin(0, 1, bounds.left, bounds.right);
+				x = valNorm.linlin(0, 1, leftBound, rightBound);
 				lineColor = val[1];
 
 				commands = this.prAddLineCmds(commands, x, lineColor);
-
-				// always draw line on left and right edges
-				case
-				{i == 0 and: { valNorm != 0 }} {
-					commands = this.prAddLineCmds(commands, bounds.left, lineColor);
-				}
-				{i == (p['lines'].size-1) and: { valNorm != 1 }} {
-					commands = this.prAddLineCmds(commands, bounds.right, lineColor);
-				}
 			};
-			// Handle case where there is only one line:
-			// left and middle line has been added, now need a right line
-			if (p['lines'].size == 1 and: { valNorm != 1 }) {
-				commands = this.prAddLineCmds(commands, bounds.right, lineColor);
+			commands = commands.add( ['stroke'] );
+
+			// Bounding lines
+			// This check ensures it obeys Plot:-gridOnX (e.g. toggling grids on/off)
+			if(grid.class != BlankGridLines) {
+				// Could add different line characteristics (color, weight) to boundinglines here
+				if(drawBoundingRect) {
+					commands = commands.addAll([
+						['strokeColor_', lineColor ? gridColor],
+						['addRect', bounds],
+						['stroke']
+					]);
+				} {
+					if(drawBoundingLines) {
+						commands = this.prAddLineCmds(commands, leftBound, lineColor);
+						commands = this.prAddLineCmds(commands, rightBound, lineColor);
+						commands = commands.add(['stroke']);
+					} {
+						if(drawBaseLine) {
+							commands = this.prAddLineCmds(commands, leftBound, lineColor);
+							commands = commands.add(['stroke']);
+						}
+					}
+				};
 			};
 
-			if(p['labels'].notNil and: { labelOffset.x > 0 }, {
+			// Tick labels
+			if(showLabels and: { p['labels'].notNil }, {
 				commands = commands.add(['font_',font ] );
 				commands = commands.add(['color_',fontColor ] );
-				p['labels'].do { arg val; // [value, label, (color, font, dropIfNeeded)]
-					var x;
-					if(val[4].asBoolean.not) {
+
+				labelSz = this.labelSize(p['labels']);
+
+				p['labels'].do { arg val, i; // [value, label, (color, font, dropIfNeeded)]
+					if(val[4].asBoolean.not) { // dropIfNeeded = false
 						if(val[2].notNil) {
 							commands = commands.add( ['color_',val[2] ] );
 						};
 						if(val[3].notNil) {
 							commands = commands.add( ['font_',val[3] ] );
 						};
-						x = grid.spec.unmap(val[0]).linlin(0, 1, bounds.left, bounds.right);
 
-						commands = commands.add([
-							'stringCenteredIn', val[1].asString,
-							Rect.aboutPoint(
-								x @ bounds.bottom, labelOffset.x/2, labelOffset.y/2
-							).top_(bounds.bottom + txtPad)
-						]);
+						x = grid.spec.unmap(val[0]).linlin(0, 1, leftBound, rightBound);
+						anchorPoint = Point(x, bottomBound);
+						labelRect = labelSz.asRect.anchorTo(anchorPoint + labelOffset, labelAnchor);
+
+						if(constrainLabelExtents, {
+							// left and rightmost xlabels are constrained to grid bounds
+							switch(x.asInteger,
+								rightBound, {
+									labelRect = labelRect.right_(
+										min(labelRect.right, rightBound - constrainedPad)
+									);
+									alignSym = this.prGetJustString(\right);
+								},
+								leftBound, {
+									labelRect = labelRect.left_(
+										max(labelRect.left, leftBound + constrainedPad)
+									);
+									alignSym = this.prGetJustString(\left);
+								}, {
+									alignSym = this.prGetJustString(labelAlign)
+								}
+							);
+						}, {
+							alignSym = this.prGetJustString(labelAlign);
+						});
+
+						commands = commands.add([alignSym, val[1], labelRect]);
 					}
 				}
 			});
-			commands
+
+			commands // return
 		}
 	}
 
-	prAddLineCmds { |cmds, val, color|
-		cmds = cmds.add( ['strokeColor_', color ? gridColor] );
-		cmds = if (this.class == DrawGridX) {
-			cmds.add( ['line', Point(val, bounds.top), Point(val, bounds.bottom) ] );
-		} { // DrawGridY
-			cmds.add( ['line', Point(bounds.left, val), Point(bounds.right, val) ] );
+	// Get the amount that a tick label will overhang each bounding edge of the
+	// grid, given its size, anchoring, and offset. Userful when laying out
+	// this grid in a UserView to allowing room for labels.
+	labelOverhang { |labelStr|
+		var overhang = [0, 0, 0, 0]; // left, top, right, bottom
+		var strRect = if(labelStr.notNil) {
+			labelStr.bounds(font);
+		} {
+			this.labelSize.asRect
 		};
-		^cmds = cmds.add( ['stroke'] ); // return
+		var rect = strRect.anchorTo(labelOffset, labelAnchor);
+
+		// top side: assumes label doesn't extend past top bound
+		overhang[3] = abs(max(rect.bottom, 0)); // bottom
+		if (constrainLabelExtents) {
+			overhang[[0,2]] = 0; // left, right
+		} {
+			overhang[0] = abs(min(rect.left, 0));  // left
+			overhang[2] = abs(max(rect.right, 0)); // right
+		};
+
+		^overhang
+	}
+
+	// Get the Size of the largest tick label on this axis.
+	// Labels will be calculated if not provided.
+	labelSize { |labels|
+		var protoLabel, labelSz;
+		var axisBounds = this.prGetAxisBounds;
+
+		if (labels.isNil) {
+			labels = this.grid.getParams(
+				this.range[0], this.range[1], axisBounds[0], axisBounds[1]
+			).labels;
+		};
+
+		if (labels.isNil) {
+			// There are currently no labels, return last used size
+			^lastLabelSize
+		} {
+			protoLabel = "0".dup(
+				try { labels.flatten.collect(_.size).maxItem } { 4 }
+			).join;
+			labelAppendString !? {
+				protoLabel = protoLabel ++ labelAppendString
+			};
+
+			labelSz = try {
+				protoLabel.bounds(font).asSize
+			} {
+				protoLabel.bounds(Font(Font.defaultSansFace, 9)).asSize
+			};
+			labelSz.width = labelSz.width * 1.1;
+			lastLabelSize = labelSz;
+
+			^labelSz
+		};
 	}
 
 	clearCache { cacheKey = nil; }
 	copy { ^super.copy.clearCache }
+
+	prAddLineCmds { |cmds, val, color|
+		cmds = cmds.add(['strokeColor_', color ? gridColor]);
+		cmds = if (this.class == DrawGridX) {
+			cmds.add(['line', Point(val, bounds.top), Point(val, bounds.bottom)]);
+		} { // DrawGridY
+			cmds.add(['line', Point(bounds.left, val), Point(bounds.right, val)]);
+		};
+		^cmds
+	}
+
+	prGetJustString { |alignSym|
+		^switch(alignSym,
+			\center, { 'stringCenteredIn' },
+			\left,   { 'stringLeftJustIn' },
+			\right,  { 'stringRightJustIn' }
+		);
+	}
+
+	prGetAxisBounds { ^[this.bounds.left, this.bounds.right] }
 }
 
 
 DrawGridY : DrawGridX {
 
+	init {
+		var rangeStrings, nfrac, res;
+		range = [grid.spec.minval, grid.spec.maxval];
+		labelAnchor = \right;
+		labelOffset = -3 @ 0;
+		labelAlign = \right;
+		constrainLabelExtents = true;
+		font = Font(Font.defaultSansFace, 9);
+		fontColor = Color.grey(0.3);
+		gridColor = Color.grey(0.7);
+		lastLabelSize = "000".bounds(font).asSize;
+	}
+
 	commands {
 		var p;
-		var valNorm, lineColor;
+		var labelSz, labelRect, labelStr, anchorPoint, alignSym;
+		var y, valNorm, lineColor;
+		var bottomBound = bounds.bottom.asInteger;
+		var topBound = bounds.top.asInteger;
+		var constrainedPad = 1;
+
 		if(cacheKey != [range,bounds],{ commands = nil });
 
 		^commands ?? {
-
 			commands = [];
+			p = grid.getParams(range[0], range[1], topBound, bottomBound, numTicks, tickSpacing);
 
-			p = grid.getParams(range[0], range[1], bounds.top, bounds.bottom, numTicks, tickSpacing);
-
+			// Lines
 			p['lines'].do { arg val, i; // value, [color]
-				var y;
 				val = val.asArray;
 				valNorm = grid.spec.unmap(val[0]);
 				lineColor = val[1];
-				y = valNorm.linlin(0, 1, bounds.bottom, bounds.top);
+				y = valNorm.linlin(0, 1, bottomBound, topBound);
 
 				commands = this.prAddLineCmds(commands, y, lineColor);
+			};
+			commands = commands.add( ['stroke'] );
 
-				// draw grid line on top and bottom bound even if there is no 'line' there
-				case
-				{ i == 0 and: { valNorm != 0 } } { // bottom
-					commands = this.prAddLineCmds(commands, bounds.bottom, lineColor);
-				}
-				{ i == (p['lines'].size-1) and: { valNorm != 1 } } { // top
-					commands = this.prAddLineCmds(commands, bounds.top, lineColor);
+			// Bounding lines
+			// This check ensures it obeys Plot:-gridOnX (e.g. toggling grids on/off)
+			if(grid.class != BlankGridLines) {
+				// Could add different line characteristics (color, weight) to boundinglines here
+				if(drawBoundingRect) {
+					commands = commands.addAll([
+						['strokeColor_', lineColor ? gridColor],
+						['addRect', bounds],
+						['stroke']
+					]);
+				} {
+					if(drawBoundingLines) {
+						commands = this.prAddLineCmds(commands, topBound, lineColor);
+						commands = this.prAddLineCmds(commands, bottomBound, lineColor);
+						commands = commands.add(['stroke']);
+					} {
+						if(drawBaseLine) {
+							commands = this.prAddLineCmds(commands, bottomBound, lineColor);
+							commands = commands.add(['stroke']);
+						}
+					}
 				};
 			};
-			// Handle case where there is only one line:
-			// bottom and middle line has been added, now need a top line
-			if (p['lines'].size == 1 and: { valNorm != 1 }) {
-				commands = this.prAddLineCmds(commands, bounds.top, lineColor);
-			};
 
-			if(p['labels'].notNil and: { labelOffset.y > 0 }, {
+			if(showLabels and: { p['labels'].notNil }, {
 				commands = commands.add(['font_',font ] );
 				commands = commands.add(['color_',fontColor ] );
 
-				p['labels'].do { arg val;
-					var y, lblRect;
+				labelSz = this.labelSize(p['labels']);
 
-					y = grid.spec.unmap(val[0]).linlin(0, 1, bounds.bottom, bounds.top);
+				p['labels'].do { arg val, i;
+					y = grid.spec.unmap(val[0]).linlin(0, 1, bottomBound, topBound);
+
 					if(val[2].notNil) {
 						commands = commands.add( ['color_', val[2]] );
 					};
@@ -320,22 +536,58 @@ DrawGridY : DrawGridX {
 						commands = commands.add( ['font_', val[3]] );
 					};
 
-					lblRect = Rect.aboutPoint(
-						Point(0, y), labelOffset.x/2, labelOffset.y/2
-					).right_(bounds.left - txtPad);
+					anchorPoint = Point(bounds.left, y);
+					labelRect = labelSz.asRect.anchorTo(anchorPoint + labelOffset, labelAnchor);
 
-					switch(y.asInteger,
-						bounds.bottom.asInteger, {
-							lblRect = lblRect.bottom_(bounds.bottom + txtPad) },
-						bounds.top.asInteger, {
-							lblRect = lblRect.top_(bounds.top - txtPad) }
+					if(constrainLabelExtents) {
+						// bottom and top ylabels are constrained to grid bounds
+						// note: downward direction is positive
+						switch(y.asInteger,
+							bottomBound, {
+								labelRect = labelRect.bottom_(
+									min(labelRect.bottom, bottomBound - constrainedPad)
+								)
+							},
+							topBound, {
+								labelRect = labelRect.top_(
+									max(labelRect.top, topBound + constrainedPad)
+								)
+							}
+						);
+					};
+
+					alignSym = this.prGetJustString(labelAlign);
+					labelStr = if(labelAppendString.isNil,
+						{ val[1].asString },
+						{ val[1].asString ++ labelAppendString }
 					);
-					commands = commands.add(['stringRightJustIn', val[1].asString, lblRect]);
-				}
+					commands = commands.add([alignSym, labelStr, labelRect]);
+				};
 			});
-			commands
+
+			commands // return
 		}
 	}
+
+	// See description in DrawGridX:-labelOverhang
+	labelOverhang { |labelStr|
+		var overhang = [0, 0, 0, 0]; // left, top, right, bottom
+		var strRect = if(labelStr.notNil) { labelStr.bounds(font) } { this.labelSize.asRect };
+		var rect = strRect.anchorTo(labelOffset, labelAnchor);
+
+		// right side: assume label doesn't extend past right bound
+		overhang[0] = abs(min(rect.left, 0)); // left
+		if (constrainLabelExtents) {
+			overhang[[1,3]] = 0; // top, bottom
+		} {
+			overhang[1] = abs(min(rect.top, 0)); // top
+			overhang[3] = abs(max(rect.bottom, 0)); // bottom
+		};
+
+		^overhang
+	}
+
+	prGetAxisBounds { ^[this.bounds.top, this.bounds.bottom] }
 }
 
 // "Factory" class to return appropriate AbstractGridLines subclass based on the spec
@@ -348,7 +600,7 @@ GridLines {
 
 AbstractGridLines {
 
-	var <>spec;
+	var <>spec, <appendLabel;
 
 	*new { arg spec;
 		^super.newCopyArgs(spec.asSpec).prCheckWarp;
@@ -409,12 +661,15 @@ AbstractGridLines {
 		^this.subclassResponsibility
 	}
 	formatLabel { arg val, numDecimalPlaces;
-		if (numDecimalPlaces == 0) {
-			^val.asInteger.asString
+		var str;
+		str = if (numDecimalPlaces == 0) {
+			val.asInteger.asString
 		} {
-			^val.round( (10**numDecimalPlaces).reciprocal).asString
-		}
+			val.round( (10**numDecimalPlaces).reciprocal).asString
+		};
+		^if(appendLabel.notNil) { str = str ++ appendLabel } { str }
 	}
+	appendLabel_ { |str| appendLabel = str.asString }
 }
 
 LinearGridLines : AbstractGridLines {
@@ -451,6 +706,8 @@ ExponentialGridLines : AbstractGridLines {
 		var lines,p,pixRange;
 		var nfrac,d,graphmin,graphmax,range, nfracarr;
 		var nDecades, first, step, tick, expRangeIsValid, expRangeIsPositive, roundFactor;
+		var drawLabel = true, maxNumTicks;
+
 		pixRange = pixelMax - pixelMin;
 		lines = [];
 		nfracarr = [];
@@ -478,7 +735,6 @@ ExponentialGridLines : AbstractGridLines {
 			numTicks ?? {numTicks = (pixRange / (tickSpacing * nDecades))};
 			tick = first;
 			while ({tick <= (valueMax + step)}) {
-				var drawLabel = true, maxNumTicks;
 				if(round(tick, roundFactor).inclusivelyBetween(valueMin, valueMax)) {
 					if(
 						(numTicks > 4) or:

--- a/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
+++ b/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
@@ -11,7 +11,7 @@ Plot {
 	var <>showTickLabelsX = true, <>showTickLabelsY = true;
 	var <>labelMargin = 2;  // margin around tick or axis labels
 	var <>borderMargin = 3; // margin separating the edge of the view from its inner elements
-	var <>hideLabelsHeightRatio = 1.4, <>hideLabelsWidthRatio = 3; // plot:labels min spacing threshold
+	var <>hideLabelsHeightRatio = 1.2, <>hideLabelsWidthRatio = 2.5; // plot:labels min spacing threshold
 	var valueCache, resolution;
 
 	*initClass {

--- a/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
+++ b/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
@@ -209,19 +209,6 @@ Plot {
 		spec = sp;
 		if(gridOnY and: { spec.notNil }) {
 			drawGrid.vertGrid = spec.grid;
-
-			if (spec.units.isEmpty) {
-				// remove label if previously set by spec units
-				if (labelYisUnits) {
-					labelY = nil;
-					labelYisUnits = false;
-				};
-			} { // add new or overwrite previous unit label
-				if(labelY.isNil or: { labelYisUnits }) {
-					labelY = spec.units;
-					labelYisUnits = true;
-				}
-			};
 		} {
 			drawGrid.vertGrid = nil;
 		};
@@ -230,18 +217,6 @@ Plot {
 		domainSpec = sp;
 		if(gridOnX and: { domainSpec.notNil }) {
 			drawGrid.horzGrid = domainSpec.grid;
-
-			if (domainSpec.units.isEmpty) { // see comments in spec_
-				if (labelXisUnits) {
-					labelX = nil;
-					labelXisUnits = false;
-				};
-			} {
-				if(labelX.isNil or: { labelXisUnits }) {
-					labelX = domainSpec.units;
-					labelXisUnits = true;
-				}
-			};
 		} {
 			drawGrid.horzGrid = nil;
 		};
@@ -1010,7 +985,7 @@ Plotter {
 
 	axisLabelX {
 		^axisLabelX !? {
-			if (axisLabelX.every(_ == axisLabelX.first)) { axisLabelX.first } { axisLabelX }
+			if (axisLabelX.every(_ == axisLabelX.first)) { axisLabelX.first } { axisLabelX };
 		};
 	}
 
@@ -1273,6 +1248,10 @@ Plotter {
 					};
 					plotter.domain = numFrames.collect(_ * frameDur);
 				};
+
+				if(numChan < 4) {
+					plotter.axisLabelX_("Seconds")
+				};
 			};
 		};
 
@@ -1322,6 +1301,7 @@ Plotter {
 		);
 
 		action = { |array, buf|
+			var unitStr = if (buf.numChannels == 1) { "Samples" } { "Frames" };
 			{
 				plotter.setValue(
 					array.unlace(buf.numChannels),
@@ -1331,10 +1311,10 @@ Plotter {
 					minval: minval,
 					maxval: maxval
 				);
-				plotter.domainSpecs = ControlSpec(
-					0.0, buf.numFrames,
-					units: if (buf.numChannels == 1) { "Samples" } { "Frames" }
-				);
+				plotter.domainSpecs = ControlSpec(0.0, buf.numFrames, units: unitStr);
+				if(buf.numChannels < 4) {
+					plotter.axisLabelX_(unitStr)
+				};
 			}.defer
 		};
 

--- a/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
+++ b/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
@@ -675,7 +675,15 @@ Plotter {
 			interactionView = UserView.new(parent, bounds);
 			interactionView.drawFunc = { this.draw };
 		};
+		this.prSetUpInteractionView;
 
+		modes = [\points, \levels, \linear, \plines, \steps, \bars].iter.loop;
+		this.plotMode = \linear;
+		this.plotColor = GUI.skins.plot.plotColor;
+		// at this point no values are set, so no Plots have been created
+	}
+
+	prSetUpInteractionView {
 		// set up interactionView
 		interactionView
 		.background_(Color.clear)
@@ -750,7 +758,6 @@ Plotter {
 					},*/
 
 					// normalize
-
 					$n, {
 						if(normalized) {
 							this.specs = specs.collect(_.normalize)
@@ -760,7 +767,6 @@ Plotter {
 						};
 						normalized = normalized.not;
 					},
-
 					// toggle grid
 					$g, {
 						plots.do { |x| x.gridOnY = x.gridOnY.not }
@@ -790,12 +796,7 @@ Plotter {
 				parent.refresh;
 			};
 		}) // end keyDownAction_
-		;  // end interactionView setup
-
-		modes = [\points, \levels, \linear, \plines, \steps, \bars].iter.loop;
-		this.plotMode = \linear;
-		this.plotColor = GUI.skins.plot.plotColor;
-		// at this point no values are set, so no Plots have been created
+		;
 	}
 
 	value_ { |arrays|

--- a/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
+++ b/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
@@ -97,7 +97,7 @@ Plot {
 	// instance vars to skip corresponding calculations below when false.
 	prCalcLabelSpace { |viewRect|
 		var gridRect;
-		var xTkWd, yTkHt, tkLHang, tkBHang;
+		var tkLHang, tkBHang;
 		var xTkLHang, xTkTHang, xTkRHang, xTkBHang;
 		var yTkLHang, yTkTHang, yTkRHang, yTkBHang;
 		var tkBMargin, tkTMargin, bottomMargin, totalBottomPad, totalTopPad, totalVertSpace;
@@ -115,15 +115,12 @@ Plot {
 			^[gridRect, false, false]
 		};
 
-		xTkWd = drawGrid.x.labelSize.width; // _tick_ label size
-		yTkHt = drawGrid.y.labelSize.height;
-
 		// Left, Top, Right, Bottom overhang space
 		#xTkLHang, xTkTHang, xTkRHang, xTkBHang = drawGrid.x.labelOverhang.max(0);
 		#yTkLHang, yTkTHang, yTkRHang, yTkBHang = drawGrid.y.labelOverhang.max(0);
 
 		if(labelX.notNil) {
-			xAxHt     = labelX.bounds(labelFont).height;
+			xAxHt = labelX.bounds(labelFont).height;
 			xAxMargin = labelMargin;
 		};
 
@@ -141,19 +138,19 @@ Plot {
 		bottomMargin = maxItem([xAxMargin, borderMargin, tkBMargin]);
 
 		// add up all elements extending below the grid
-		totalBottomPad    = tkBHang + xAxMargin + xAxHt + bottomMargin;
-		totalTopPad       = yTkTHang + tkTMargin.max(borderMargin);
-		totalVertSpace    = totalTopPad + totalBottomPad;
-		htAllowsXLabels   = viewRect.height >= (totalVertSpace * (hideLabelsHeightRatio+1));
+		totalBottomPad = tkBHang + xAxMargin + xAxHt + bottomMargin;
+		totalTopPad = yTkTHang + tkTMargin.max(borderMargin);
+		totalVertSpace = totalTopPad + totalBottomPad;
+		htAllowsXLabels = viewRect.height >= (totalVertSpace * (hideLabelsHeightRatio+1));
 		sizeAllowsXLabels = htAllowsXLabels;
 
 		// If x labels are still shown calculate horizontal space needed
 		// to determine if they will be hidden based on the view width.
 		if(htAllowsXLabels) {
-			xLeftPad          = if(xTkLHang > 0) { xTkLHang + labelMargin } { 0 };
-			xRightPad         = if(xTkRHang > 0) { xTkRHang + labelMargin } { 0 };
-			totalHorizPad     = xLeftPad.max(borderMargin) + xRightPad.max(borderMargin);
-			wdAllowsXLabels   = viewRect.width >= (totalHorizPad * (hideLabelsWidthRatio+1));
+			xLeftPad = if(xTkLHang > 0) { xTkLHang + labelMargin } { 0 };
+			xRightPad = if(xTkRHang > 0) { xTkRHang + labelMargin } { 0 };
+			totalHorizPad = xLeftPad.max(borderMargin) + xRightPad.max(borderMargin);
+			wdAllowsXLabels = viewRect.width >= (totalHorizPad * (hideLabelsWidthRatio+1));
 			sizeAllowsXLabels = wdAllowsXLabels;
 			// if width is too small for x labels, it should be too small for Y labels too
 			sizeAllowsYLabels = wdAllowsXLabels;
@@ -163,19 +160,19 @@ Plot {
 		if(sizeAllowsXLabels) {
 			// show X labels, make space for them
 			gridRect.height = viewRect.height - (borderMargin + totalBottomPad);
-			gridRect.width  = viewRect.width  - totalHorizPad;
 			gridRect.left   = xLeftPad;
+			gridRect.width = viewRect.width  - totalHorizPad;
 		} {
 			// if y tick label extends below bottom, they need to be turned off too.
-			totalBottomPad    = if(yTkBHang > 0) { yTkBHang + labelMargin } { 0 };
-			htAllowsYLabels   = totalBottomPad <= borderMargin;
+			totalBottomPad = if(yTkBHang > 0) { yTkBHang + labelMargin } { 0 };
+			htAllowsYLabels = totalBottomPad <= borderMargin;
 			sizeAllowsYLabels = htAllowsYLabels;
 		};
 
 		// Y-axis label area
 		if (sizeAllowsYLabels) {
 			if(labelY.notNil) {
-				yAxWd     = labelY.bounds(labelFont).height;
+				yAxWd = labelY.bounds(labelFont).height;
 				yAxMargin = labelMargin;
 			};
 			if(sizeAllowsXLabels.not) {
@@ -183,25 +180,25 @@ Plot {
 			};
 
 			// left side
-			tkLHang    = maxItem([xTkLHang, yTkLHang, 0]);
-			tkLMargin  = if(tkLHang > 0) { labelMargin } { 0 };
+			tkLHang = maxItem([xTkLHang, yTkLHang, 0]);
+			tkLMargin = if(tkLHang > 0) { labelMargin } { 0 };
 			// only the largest margin of all elements is needed
 			leftMargin = maxItem([yAxMargin, borderMargin, tkLMargin]);
-			leftPad    = leftMargin + yAxWd + yAxMargin + tkLHang;
+			leftPad = leftMargin + yAxWd + yAxMargin + tkLHang;
 
-			rightPad   = max(
+			rightPad = max(
 				if(xTkRHang > 0) { xTkRHang + labelMargin } { 0 },
 				borderMargin
 			);
 
-			totalHorizPad   = leftPad + rightPad;
+			totalHorizPad = leftPad + rightPad;
 			wdAllowsYLabels = viewRect.width >= (totalHorizPad * (hideLabelsWidthRatio+1));
 
 			sizeAllowsYLabels = wdAllowsYLabels and: { htAllowsYLabels };
 
 			if(sizeAllowsYLabels) {
 				gridRect.width = viewRect.width - (leftPad + rightPad);
-				gridRect.left  = leftPad;
+				gridRect.left = leftPad;
 			};
 		};
 
@@ -214,44 +211,44 @@ Plot {
 	}
 	spec_ { |sp|
 		spec = sp;
-		if(gridOnY and: { spec.notNil }, {
+		if(gridOnY and: { spec.notNil }) {
 			drawGrid.vertGrid = spec.grid;
 
-			if (spec.units.isEmpty, {
+			if (spec.units.isEmpty) {
 				// remove label if previously set by spec units
-				if (labelYisUnits, {
+				if (labelYisUnits) {
 					labelY = nil;
 					labelYisUnits = false;
-				});
-			},{ // add new or overwrite previous unit label
-				if(labelY.isNil or: labelYisUnits) {
+				};
+			} { // add new or overwrite previous unit label
+				if(labelY.isNil or: { labelYisUnits }) {
 					labelY = spec.units;
 					labelYisUnits = true;
 				}
-			})
-		},{
-			drawGrid.vertGrid = nil
-		})
+			};
+		} {
+			drawGrid.vertGrid = nil;
+		};
 	}
 	domainSpec_ { |sp|
 		domainSpec = sp;
-		if(gridOnX and: { domainSpec.notNil }, {
+		if(gridOnX and: { domainSpec.notNil }) {
 			drawGrid.horzGrid = domainSpec.grid;
 
-			if (domainSpec.units.isEmpty, { // see comments in spec_
-				if (labelXisUnits, {
+			if (domainSpec.units.isEmpty) { // see comments in spec_
+				if (labelXisUnits) {
 					labelX = nil;
 					labelXisUnits = false;
-				});
-			},{
-				if(labelX.isNil or: labelXisUnits) {
+				};
+			} {
+				if(labelX.isNil or: { labelXisUnits }) {
 					labelX = domainSpec.units;
 					labelXisUnits = true;
 				}
-			})
-		},{
-			drawGrid.horzGrid = nil
-		})
+			};
+		} {
+			drawGrid.horzGrid = nil;
+		};
 	}
 	plotColor_ { |c|
 		plotColor = c.as(Array);

--- a/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
+++ b/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
@@ -100,8 +100,8 @@ Plot {
 		var tkLHang, tkBHang;
 		var xTkLHang, xTkTHang, xTkRHang, xTkBHang;
 		var yTkLHang, yTkTHang, yTkRHang, yTkBHang;
-		var tkBMargin, tkTMargin, bottomMargin, totalBottomPad, totalTopPad, totalVertSpace;
-		var tkLMargin, leftMargin, xLeftPad, xRightPad, leftPad, rightPad, totalHorizPad;
+		var tkBMargin, bottomMargin, totalBottomPad, totalTopPad, totalVertSpace;
+		var tkLMargin, leftMargin, xLeftPad, xRightPad, leftPad, rightPad, totalHorizPad, addTopPad;
 
 		var htAllowsXLabels = true, htAllowsYLabels = true;
 		var wdAllowsXLabels = true, wdAllowsYLabels = true;
@@ -125,17 +125,14 @@ Plot {
 		// (If so, Y labels that overhang vertically may need to also be hidden).
 
 		tkBHang = max(xTkBHang, yTkBHang);
-
 		// if there's label overhang, give it its margin
-		tkBMargin = if(tkBHang  > 0) { labelMargin } { 0 };
-		tkTMargin = if(yTkTHang > 0) { labelMargin } { 0 };
-
+		tkBMargin = if(tkBHang > 0) { labelMargin } { 0 };
 		// only the largest margin of all elements is needed
 		bottomMargin = maxItem([xAxMargin, borderMargin, tkBMargin]);
 
 		// add up all elements extending below the grid
 		totalBottomPad = tkBHang + xAxMargin + xAxHt + bottomMargin;
-		totalTopPad = yTkTHang + tkTMargin.max(borderMargin);
+		totalTopPad = (yTkTHang + labelMargin).max(borderMargin);
 		totalVertSpace = totalTopPad + totalBottomPad;
 		htAllowsXLabels = viewRect.height >= (totalVertSpace * (hideLabelsHeightRatio+1));
 		sizeAllowsXLabels = htAllowsXLabels;
@@ -195,6 +192,12 @@ Plot {
 			if(sizeAllowsYLabels) {
 				gridRect.width = viewRect.width - (leftPad + rightPad);
 				gridRect.left = leftPad;
+				// add additional space to top border margin if y label extends past bound
+				addTopPad = totalTopPad - borderMargin;
+				if (addTopPad > 0) {
+					gridRect.height = gridRect.height - addTopPad;
+					gridRect.top = gridRect.top + addTopPad;
+				};
 			};
 		};
 

--- a/SCClassLibrary/Common/Geometry/Rect.sc
+++ b/SCClassLibrary/Common/Geometry/Rect.sc
@@ -144,6 +144,7 @@ Rect {
 	}
 
 	asRect { ^this }
+	asSize { ^Size(width, height) }
 	bounds { ^Rect.new(left, top, width, height) }
 	== { arg that;
 		^this.compareObject(that, #[\left, \top, \width, \height])

--- a/SCClassLibrary/Common/Geometry/Rect.sc
+++ b/SCClassLibrary/Common/Geometry/Rect.sc
@@ -65,6 +65,25 @@ Rect {
 	moveToPoint { arg aPoint;
 		^this.class.new(aPoint.x, aPoint.y, width, height)
 	}
+	anchorTo { arg pt, position;
+		^switch(position,
+			// center_ returns new Rect, side setters modify this
+			\center,      { this.center_(pt) },
+			\top,         { this.center_(pt).top_(pt.y) },
+			\bottom,      { this.center_(pt).bottom_(pt.y) },
+			\left,        { this.center_(pt).left_(pt.x) },
+			\right,       { this.center_(pt).right_(pt.x) },
+			\topLeft,     { this.copy.top_(pt.y).left_(pt.x) },
+			\topRight,    { this.copy.top_(pt.y).right_(pt.x) },
+			\bottomLeft,  { this.copy.bottom_(pt.y).left_(pt.x) },
+			\bottomRight, { this.copy.bottom_(pt.y).right_(pt.x) },
+			// support synonymous keys that match preexisting Rect getters
+			\leftTop,     { this.copy.top_(pt.y).left_(pt.x) },
+			\rightTop,    { this.copy.top_(pt.y).right_(pt.x) },
+			\leftBottom,  { this.copy.bottom_(pt.y).left_(pt.x) },
+			\rightBottom, { this.copy.bottom_(pt.y).right_(pt.x) }
+		)
+	}
 	resizeBy { arg h, v;
 		^this.class.new(left, top, width + h, height + (v ? h))
 	}


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

This follows  up #5161, in response to [feedback](https://github.com/supercollider/supercollider/pull/5161#issuecomment-1321457870) about retaining previous functionality in how the tick labels are handled in `DrawGrid`.

In particular this adds functionality so that you can achieve the same look as previous version of SC:
- Move and align tick axis labels
- Append a string to axis labels
- Constrain labels to the edges of the grids
- en/disable labels independently
- set the Font and Color of tick and axis labels independently

~~This PR is unfinished but as it's blocking the next RC, I'm posting it early so those involved can comment on what's been done so far. @dyfer @sternsc.~~

This required basically a complete overhaul of how the new tick/axis label spacing is calculated so that everything resizes properly. ~~As such, I have a good amount of testing to do.~~

This PR is now ready for review (I'll clean up the commit history at the final stage).

Depending on the timeline of the RC, documentation won't be the priority, but I'll submit that as a separate PR later if the RC makes it out before I get to it.

Here's a few examples of the new interface to set `Plot` and `DrawDrid` properties from `Plotter`.
```supercollider
(     // default behavior plus axis labels
p = [10, 34, 1672].collect({ |f|
	101.collect{ |i| sin((i/1000) * 2pi * f) }
}).plot;
p.axisLabelY_("Amp")
.axisLabelX_((1..3).collect{ |elem| "X label " ++ elem })
)

(    // vertically compact
p = [10, 34, 1672].collect({ |f|
	101.collect{ |i| sin((i/1000) * 2pi * f) }
}).plot;
p.setGridProperties(\y,
	\labelAnchor, \right, \labelAlign, \center,
	\constrainLabelExtents, true, \labelOffset, -3 @ 0
).setGridProperties(\x,
	\labelAnchor, \leftBottom, \labelAlign, \left,
	\constrainLabelExtents, true, \labelOffset, 3 @ -1,
	\fontColor, Color.red, \labelAppendString, " sec"
).specs_([-1.5, 1.5].asSpec) // give data headroom to see inlaid y tick labels
)

(    // minimal
p = [10, 34, 1672].collect({ |f|
	101.collect{ |i| sin((i/1000) * 2pi * f) }
}).plot;
p.setProperties( \showTickLabelsX, false, \showTickLabelsY, false)
)
```
The three above examples produce these plots:
<img width="700" alt="Screen Shot 2023-01-03 at 21 56 20" src="https://user-images.githubusercontent.com/923342/210434877-bed3f74d-ab06-4c85-9199-47b5353aa127.png">

Note that because I opted not to add convenience methods to `Plotter` that would allow direct access to setting grid properties at this time, that is accomplished with the `Plotter:-setGridProperties`, which mimics the behavior of `Plotter:-setGridProperties:-setProperties`, in that it accepts a list of key-value pairs. 

The advantage is that setting multiple parameters (as is likely when customizing your grid) is more compact than multiple method calls to individual parameters for each axis. The downside is the user doesn't get the benefit of auto-complete for hints about to the available parameters. So I'll add a section to the docs in the future that will list the grid and plot parameters.

## Types of changes

<!-- Delete lines that don't apply -->

- Documentation
- Bug fix
- New feature

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation (More to follow this PR)
- [x] This PR is ready for review
