### PR TITLE
Update SCVersion on develop

### DIFF
--- a/SCVersion.txt
+++ b/SCVersion.txt
@@ -4,7 +4,7 @@
 set(SC_VERSION_MAJOR 3)
 set(SC_VERSION_MINOR 14)
 set(SC_VERSION_PATCH 0)
-set(SC_VERSION_TWEAK "-rc1")
+set(SC_VERSION_TWEAK "-dev")
 set(SC_VERSION ${SC_VERSION_MAJOR}.${SC_VERSION_MINOR}.${SC_VERSION_PATCH}${SC_VERSION_TWEAK})
 
 # Note: these are provided for backwards compatibility only. In the main project, PROJECT_VERSION_PATCH


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

The version on `develop` should end in `-dev`. 
This will create a conflict for the later merge `3.13` -> `develop`, but once it's resolved (on the first merge), it shouldn't be an issue anymore.

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->

- Misc

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] This PR is ready for review
