### PR TITLE
GHA: use updated ccache directory on Linux

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -181,7 +181,9 @@ jobs:
       - name: cache ccache
         uses: actions/cache@v3
         with:
-          path: ~/.ccache
+          path: |
+            ~/.ccache
+            ~/.cache/ccache
           key: ${{ runner.os }}-${{ matrix.os-version }}-${{ matrix.c-compiler }}-${{ matrix.use-syslibs }}-${{ matrix.shared-libscsynth }}-${{ steps.current-date.outputs.stamp }}
           restore-keys: ${{ runner.os }}-${{ matrix.os-version }}-${{ matrix.c-compiler }}-${{ matrix.use-syslibs }}-${{ matrix.shared-libscsynth }}-
       - name: install dependencies


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

I noticed that caching [didn't work](https://github.com/supercollider/supercollider/actions/runs/3942642953/jobs/6746690038#step:21:2) for the newer Linux builds in GHA.

The default ccache directory [has changed](https://ccache.dev/manual/4.3.html#:~:text=is%20set%2C%20otherwise-,%24HOME/.cache/ccache,-.%20Exception%3A%20If%20the) in a recent version of ccache. This PR updates our GHA workflow accordingly.

AFAIU, this change is only needed on Linux at this time.

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] This PR is ready for review
