### PR TITLE
GHA: create macOS universal binary with homebrew libraries

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -258,10 +258,9 @@ jobs:
             use-syslibs: false
             shared-libscsynth: false
             system-portaudio: false
-            build-libsndfile: true
-            build-readline: true
-            build-fftw: true
-            vcpkg-triplet: arm64-osx-release-supercollider # required for build-libsndfile
+            build-libsndfile: false
+            build-readline: false
+            build-fftw: false
             artifact-suffix: 'macOS-arm64' # set if needed - will trigger artifact upload
             verify-app: true
 
@@ -325,8 +324,7 @@ jobs:
       DEVELOPER_DIR: '/Applications/Xcode_${{ matrix.xcode-version }}.app/Contents/Developer'
       MACOSX_DEPLOYMENT_TARGET: '${{ matrix.deployment-target }}'
       CMAKE_OSX_ARCHITECTURES: '${{ matrix.cmake-architectures }}'
-      QT_UNIVERSAL_PREP_DIR: ${{ github.workspace }}/qt-prepare
-      QT_UNIVERSAL_WORK_DIR: ${{ github.workspace }}/qt-prepare/tmp # needs to be under QT_UNIVERSAL_PREP_DIR for caching
+      BREW_UNIVERSAL_WORKDIR: ${{ github.workspace }}/brew-universal
     steps:
       - uses: actions/checkout@v3
         with:
@@ -347,13 +345,13 @@ jobs:
           path: ~/Library/Caches/Homebrew/downloads
           key: ${{ runner.os }}-${{ matrix.os-version }}-${{ matrix.xcode-version }}-${{ matrix.use-syslibs }}-${{ matrix.shared-libscsynth }}-${{ matrix.qt-version }}-${{ matrix.cmake-architectures }}-homebrew-${{ steps.current-date.outputs.stamp }}
           restore-keys: ${{ runner.os }}-${{ matrix.os-version }}-${{ matrix.xcode-version }}-${{ matrix.use-syslibs }}-${{ matrix.shared-libscsynth }}-${{ matrix.qt-version }}-${{ matrix.cmake-architectures }}-homebrew-
-      - name: cache qt universal binary
-        id: cache-qt-universal
+      - name: cache homebrew universal packages
         uses: actions/cache@v3
-        if: matrix.cmake-architectures != 'x86_64' && '!matrix.qt-version'
+        if: matrix.cmake-architectures != 'x86_64' && (matrix.build-libsndfile != true || matrix.build-readline != true || matrix.build-fftw != true)
         with:
-          path: ${{ env.QT_UNIVERSAL_WORK_DIR }}
-          key: ${{ runner.os }}-v1-${{ matrix.os-version }}-${{ matrix.xcode-version }}-${{ matrix.deployment-target }}-${{ matrix.vcpkg-triplet }}
+          path: ${{ env.BREW_UNIVERSAL_WORKDIR }}
+          key: ${{ runner.os }}-v1-${{ matrix.os-version }}-${{ matrix.xcode-version }}-${{ matrix.deployment-target }}-brew_universal-${{ steps.current-date.outputs.stamp }}
+          restore-keys: ${{ runner.os }}-v1-${{ matrix.os-version }}-${{ matrix.xcode-version }}-${{ matrix.deployment-target }}-brew_universal-
       - name: cache vcpkg
         if: matrix.vcpkg-triplet
         uses: actions/cache@v3
@@ -371,6 +369,17 @@ jobs:
           echo "/usr/local/opt/ccache/libexec" >> $GITHUB_PATH
           if [[ "${{ matrix.system-portaudio }}" != "false" ]]; then brew install portaudio; fi
           if [[ "${{ matrix.build-fftw }}" != "true" ]]; then brew install fftw; fi
+
+          # install universal versions of homebrew libraries
+          if [[ "${{ matrix.cmake-architectures }}" != "x86_64" ]]; then
+              echo "Downloading script for creating universal binaries from homebrew packages"
+              curl -O -J -L https://gist.githubusercontent.com/dyfer/6c83905d4593750105897e51e87ec345/raw/6bf8cb1b152e7e61c7199ff7151b0ea303f7307f/brew-install-universal.sh
+              chmod +x brew-install-universal.sh
+              if [[ "${{ matrix.build-libsndfile }}" != "true" ]]; then ./brew-install-universal.sh libsndfile; fi
+              if [[ "${{ matrix.build-readline }}" != "true" ]]; then ./brew-install-universal.sh readline; fi
+              if [[ "${{ matrix.build-fftw }}" != "true" ]]; then ./brew-install-universal.sh fftw; fi
+              if [[ "${{ matrix.system-portaudio }}" != "false" ]]; then ./brew-install-universal.sh portaudio; fi
+          fi
       - name: install libsndfile # to make it compatible with older OSes (lower deployment target)
         if: matrix.build-libsndfile == true && matrix.vcpkg-triplet
         run: |
@@ -379,12 +388,10 @@ jobs:
       - name: install readline # to allow cross-compiling
         if: matrix.build-readline == true && matrix.vcpkg-triplet
         run: |
-          # brew uninstall --ignore-dependencies readline
-          # vcpkg install readline --triplet="${{ matrix.vcpkg-triplet }}" --overlay-triplets="$GITHUB_WORKSPACE/vcpkg/triplets" 
+          brew uninstall --ignore-dependencies readline
+          vcpkg install readline --triplet="${{ matrix.vcpkg-triplet }}" --overlay-triplets="$GITHUB_WORKSPACE/vcpkg/triplets" 
           # vcpkg readline currently fails on arm64 (ncurses dependency)
           # see https://github.com/microsoft/vcpkg/issues/22654
-          # as a workaround, let's install arm64 readline bottle manually
-          # this is currently done in the "install qt universal binary" step
       - name: install fftw # to allow cross-compiling
         if: matrix.build-fftw == true && matrix.vcpkg-triplet
         run: |
@@ -395,160 +402,9 @@ jobs:
       - name: install qt from homebrew
         if: matrix.cmake-architectures == 'x86_64' && '!matrix.qt-version' 
         run: brew install qt5
-      - name: prepare qt universal binary # this can be cached
-        if: matrix.cmake-architectures != 'x86_64' && '!matrix.qt-version' && steps.cache-qt-universal.outputs.cache-hit != 'true'
-        run: |
-          # this is a workaround to create a universal x64/arm64 binary of qt5
-          # it's not a fully-featured universal binary, since qt's dependencies are still single architecture
-          # once we support Qt6, you should be able to drop this and use official Qt6 binaries instead, which are universal (x64 + arm64)
-          mkdir $QT_UNIVERSAL_PREP_DIR && cd $QT_UNIVERSAL_PREP_DIR
-
-          packages_to_process=( freetype gettext giflib glib jpeg-turbo libpng libtiff pcre pcre2 webp readline qt@5) # note it needs to be qt@5, not qt5 here
-
-          DOWNLOAD_PATH="${QT_UNIVERSAL_PREP_DIR}/downloads"
-          TEMP_PATH="${QT_UNIVERSAL_WORK_DIR}"
-
-          echo "making downloads folder "$DOWNLOAD_PATH
-          mkdir -p "$DOWNLOAD_PATH"
-          mkdir -p "$TEMP_PATH"
-
-          HOMEBREW_PREFIX=`brew --prefix`
-          echo "homebrew prefix: "$HOMEBREW_PREFIX
-
-          HOMEBREW_CELLAR=`brew --cellar`
-          echo "homebrew cellar: "$HOMEBREW_CELLAR
-
-          BOTTLE_ID="arm64_big_sur" # TODO: detect big_sur / monterey based on the host OS 
-
-          get_bottle_sha () { # takes name
-              brew cat --formula ${1} | grep "$BOTTLE_ID" | awk '{print $NF }' | sed 's/\"//g'
-          }
-
-          download_bottle () { #takes name
-              name=$1
-              sha=$(get_bottle_sha $name)
-              os_id=$BOTTLE_ID
-              destination=$DOWNLOAD_PATH
-              url="https://ghcr.io/v2/homebrew/core/${name/@//}/blobs/sha256:${sha}"
-              filename="${name}.${os_id}.bottle.tar.gz"
-              dest_full_path="${destination}/${filename}"
-              if [[ -f "$dest_full_path" ]]; then
-                  # TODO: check if sha matches
-                  echo "$filename already exists, not downloading"
-              else
-                  echo "downloading ${filename} from ${url}"
-                  curl -f -L -H "Authorization: Bearer QQ==" -o "$dest_full_path" "$url"
-              fi
-          }
-
-          decompress_bottle () { # takes name
-              name=$1
-              os_id=$BOTTLE_ID
-              source=$DOWNLOAD_PATH
-              destination=$TEMP_PATH
-              filename="${name}.${os_id}.bottle.tar.gz"
-              echo "decompressing ${filename}"
-              tar xf "${source}/${filename}" --directory "$destination"
-          }
-
-          set_loader_paths () { # takes name
-              name=$1
-              find "${TEMP_PATH}/${1}" -print0 | while IFS= read -r -d '' file
-              do
-                  if [ -f "$file" ]; then
-                      file_type_string=`file -bh "${file}"`
-                      if [[ $file_type_string == *"shared library"* ]] || [[ $file_type_string == "Mach-O"*"executable"* ]]; then
-                          loader_paths=`otool -XL "$file" | awk '{print $1 }'`
-                          install_name=`otool -XD "$file"`
-                          echo "--- ${file} ---"
-                          basename=$(basename -- "$file")
-                          if [[ $install_name == *"@@HOMEBREW_PREFIX@@"* ]]; then
-                              corrected_path=`echo "$install_name" | sed s~@@HOMEBREW_PREFIX@@~${HOMEBREW_PREFIX}~`
-                              echo "${basename}: setting install name to ${corrected_path}"
-                              install_name_tool -id "$corrected_path" "$file" 2>/dev/null
-                          fi
-                          if [[ $install_name == *"@@HOMEBREW_CELLAR@@"* ]]; then
-                              corrected_path=`echo "$install_name" | sed s~@@HOMEBREW_CELLAR@@~${HOMEBREW_CELLAR}~`
-                              echo "${basename}: setting install name to ${corrected_path}"
-                              install_name_tool -id "$corrected_path" "$file" 2>/dev/null
-                          fi
-                          for this_path in $loader_paths
-                          do
-                              if [[ $this_path == *"@@HOMEBREW_PREFIX@@"* ]]; then
-                                  # echo $this_path
-                                  corrected_path=`echo "$this_path" | sed s~@@HOMEBREW_PREFIX@@~${HOMEBREW_PREFIX}~`
-                                  # echo $corrected_path
-                                  echo "${this_path}: changing path to ${corrected_path}"
-                                  install_name_tool -change "$this_path" "$corrected_path" "$file" 2>/dev/null
-                              fi
-                              if [[ $this_path == *"@@HOMEBREW_CELLAR@@"* ]]; then
-                                  # echo $this_path
-                                  corrected_path=`echo "$this_path" | sed s~@@HOMEBREW_CELLAR@@~${HOMEBREW_CELLAR}~`
-                                  # echo $corrected_path
-                                  echo "${this_path}: changing path to ${corrected_path}"
-                                  install_name_tool -change "$this_path" "$corrected_path" "$file" 2>/dev/null
-                              fi
-                          done
-                      fi
-                  fi
-              done
-          }
-
-          for package in "${packages_to_process[@]}"
-          do
-              echo "--- processing ${package} ---"
-              download_bottle $package
-              decompress_bottle $package
-              set_loader_paths $package
-          done
-
-      - name: install qt universal binary
+      - name: install qt universal binary from homebrew
         if: matrix.cmake-architectures != 'x86_64' && '!matrix.qt-version'
-        run: |
-          cd $QT_UNIVERSAL_PREP_DIR
-
-          brew install qt5 # we need to make sure homebrew knows about qt installation; this does nothing when not using cache
-
-          # prepare universal versions of the dependencies
-
-          packages_to_process=( freetype gettext giflib glib jpeg-turbo libpng libtiff pcre pcre2 webp readline qt@5)
-
-          DOWNLOAD_PATH="${QT_UNIVERSAL_PREP_DIR}/downloads"
-          TEMP_PATH="${QT_UNIVERSAL_WORK_DIR}"
-
-          # echo "making downloads folder "$DOWNLOAD_PATH
-          # mkdir -p "$DOWNLOAD_PATH"
-          # mkdir -p "$TEMP_PATH"
-
-          combine_libraries () { # takes name
-              name=$1
-              base_path="${TEMP_PATH}/${1}/"
-              varname=`ls "${base_path}/"` # we assume there's only one subdirectory
-              base_src_path="${base_path}/${varname}"
-              base_dst_path=`brew --prefix ${name}`
-              find  "$base_src_path" -print0 | while IFS= read -r -d '' file
-              do
-                  if [ -f "$file" ] && [ ! -h "$file" ]; then
-                      file_type_string=`file -bh "${file}"`
-                      if [[ $file_type_string == *"current ar archive"* ]] || [[ $file_type_string == *"shared library"* ]] || [[ $file_type_string == "Mach-O"*"executable"* ]]; then
-                          # echo "--- ${file} ---"
-                          basename=$(basename -- "$file")
-                          base_relative_path=${file##$base_src_path}
-                          dst_full_path="${base_dst_path}${base_relative_path}"
-                          if [ -f "$dst_full_path" ]; then
-                              echo "combining ${file} and ${dst_full_path}"
-                              lipo "$file" "$dst_full_path" -create -output "$dst_full_path"
-                          fi
-                      fi
-                  fi
-              done
-          }
-
-          for package in "${packages_to_process[@]}"
-          do
-              echo "--- processing ${package} ---"
-              combine_libraries $package
-          done
+        run: ./brew-install-universal.sh qt5
       - name: install qt using aqtinstall
         uses: jurplel/install-qt-action@v3
         if: matrix.qt-version

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -235,50 +235,19 @@ jobs:
       matrix:
         include:
 
-          - job-name: 'x64'
+          - job-name: 'universal'
             os-version: '11'
             xcode-version: '12.4'
-            deployment-target: '10.14' # Qt 5.15 runs on macOS 10.13 and newer; however homebrew build of Qt on macOS 11 only supports 10.14+
-            cmake-architectures: x86_64
+            deployment-target: '10.14'
+            cmake-architectures: 'x86_64;arm64'
             use-syslibs: false
             shared-libscsynth: false
             system-portaudio: true
-            build-libsndfile: true
-            build-readline: false
-            build-fftw: false
-            vcpkg-triplet: x64-osx-release-supercollider # required for build-libsndfile
-            artifact-suffix: 'macOS-x64' # set if needed - will trigger artifact upload
-            verify-app: true
-
-          - job-name: 'arm64'
-            os-version: '11'
-            xcode-version: '12.4'
-            deployment-target: '11.0'
-            cmake-architectures: arm64
-            use-syslibs: false
-            shared-libscsynth: false
-            system-portaudio: false
             build-libsndfile: false
             build-readline: false
             build-fftw: false
-            artifact-suffix: 'macOS-arm64' # set if needed - will trigger artifact upload
+            artifact-suffix: 'macOS-universal'
             verify-app: true
-
-          # universal build is disabled for now, since libsndfile dependencies don't build correctly with vcpkg as universal binaries
-          # - job-name: 'universal'
-          #   os-version: '11'
-          #   xcode-version: '12.4'
-          #   deployment-target: '10.14'
-          #   cmake-architectures: 'x86_64;arm64'
-          #   use-syslibs: false
-          #   shared-libscsynth: false
-          #   system-portaudio: false
-          #   build-libsndfile: true
-          #   build-readline: true
-          #   build-fftw: true
-          #   vcpkg-triplet: x64-arm64-osx-release-supercollider
-          #   artifact-suffix: 'macOS-universal'
-          #   verify-app: true
 
           - job-name: 'x64 legacy'
             os-version: '11'
@@ -644,7 +613,7 @@ jobs:
           - name: macOS
             runs-on: macos-11
             sclang: 'build/Install/SuperCollider/SuperCollider.app/Contents/MacOS/sclang'
-            artifact-suffix: macOS-x64
+            artifact-suffix: macOS-universal
             artifact-extension: '.dmg'
 
           - name: Linux

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,7 +74,7 @@ Updates and fixes for the automated build system (GitHub Actions):
 @dyfer in https://github.com/supercollider/supercollider/pull/5776  
 ### General: Added
 
-arm64 macOS build for Apple M1 CPUs by @dyfer in https://github.com/supercollider/supercollider/pull/5869
+Universal macOS build for both Intel x86_64 and Apple arm64 CPUs by @dyfer in https://github.com/supercollider/supercollider/pull/5953
 
 Better description in the about dialog for tagged builds by @dyfer in https://github.com/supercollider/supercollider/pull/5697 and https://github.com/supercollider/supercollider/pull/5739
 

--- a/HelpSource/Guides/News-3_13.schelp
+++ b/HelpSource/Guides/News-3_13.schelp
@@ -38,7 +38,7 @@ Updates and fixes for the automated build system (GitHub Actions):
 
 section::  General: Added
 
-arm64 macOS build for Apple M1 CPUs by @dyfer in https://github.com/supercollider/supercollider/pull/5869
+Universal macOS build for both Intel x86_64 and Apple arm64 CPUs by @dyfer in https://github.com/supercollider/supercollider/pull/5953
 
 Better description in the about dialog for tagged builds by @dyfer in https://github.com/supercollider/supercollider/pull/5697 and https://github.com/supercollider/supercollider/pull/5739
 


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

This PR replaces a partial script for manual creation of universal libraries for homebrew packages with a [3rd-party script which I wrote](https://gist.github.com/dyfer/6c83905d4593750105897e51e87ec345), that achieves this more reliably.

A little history how we got here:
GHA does not offer arm64 macOS runners, so in order to provide an arm64 build (or a universal one), we need to cross-compile. This requires all dependencies to be available as universal binaries, so at first we used vcpkg to create arm64 binaries of libsndfile and fftw, and created a script that manually created universal binaries of readline, qt5 and its dependencies. This script was fairly specific, didn't handle some packages well, was able to use caching in a limited way etc. Also, libsndfile in homebrew was not supporting mpeg at that time, so libsndfile was installed from vcpkg. Unfortunately, it wasn't possible to create a universal binary of libsndfile (because of the build issue with LAME library, I believe), only a single architecture arm64.

Libsndfile in homebrew now offers mpeg support, so we're coming full circle, again using homebrew dependencies in the main supercollider build, but this time as a universal binary.

I opted to download the script from my gist, as opposed to including it in this repo, as I believe it doesn't really belong here - it's a medium-term solution and rather circumstantial to SC itself. Eventually, I think we can stop using this method and use 1) official qt installer to get the universal binary of Qt6 (once we move to Qt6) and 2) use vcpkg to build universal binary of libsndfile (once the build issue is fixed). For now, this solution offers a universal binary and **appears to support the same range of OS versions** as the regular build (I tried running the universal build on macOS 10.14, which is currently the oldest supported OS for the regular build, and it seems to work fine).

One outstanding question is whether we pull it into `develop` for the next release, or do we want to release 3.13.1 with this, or maybe even 3.13.0-rcX so that it lands in 3.13.0?


## Types of changes

<!-- Delete lines that don't apply -->

- New feature

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation (N/A)
- [x] This PR is ready for review
