### PR TITLE
GHA: update artifact name for upload to AWS S3

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -704,7 +704,7 @@ jobs:
       matrix:
         include:
 
-          - artifact-suffix: macOS-x64
+          - artifact-suffix: macOS-universal
             s3-os-name: osx
             s3-artifact-suffx: ''
             s3-artifact-extension: 'dmg'


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

This was missing from #5953 
S3 upload seems broken ATM anyway due to an issue with credentials, but the name should've been updated for the universal build.

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] This PR is ready for review
