### PR TITLE
Poll: fix initialization to fire on first-sample trigger

### DIFF
--- a/server/plugins/TriggerUGens.cpp
+++ b/server/plugins/TriggerUGens.cpp
@@ -765,7 +765,6 @@ void Poll_Ctor(Poll* unit) {
         SETCALC(Poll_next_kk);
     }
 
-    unit->m_trig = IN0(0);
     const int idSize = (int)IN0(3); // number of chars in the id string
     unit->m_id_string = (char*)RTAlloc(unit->mWorld, (idSize + 1) * sizeof(char));
     ClearUnitIfMemFailed(unit->m_id_string);
@@ -775,8 +774,7 @@ void Poll_Ctor(Poll* unit) {
 
     unit->m_id_string[idSize] = '\0';
     unit->m_mayprint = unit->mWorld->mVerbosity >= -1;
-
-    Poll_next_kk(unit, 1);
+    unit->m_trig = 0.f; // ready for trigger in first sample
 }
 
 void Poll_Dtor(Poll* unit) { RTFree(unit->mWorld, unit->m_id_string); }


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

`Poll` misses a trigger on the first sample... but not anymore!

This bug was revealed only with the updated behavior of `Impulse` (as of 3.13). There was no issue filed, but addresses a [discussion](https://github.com/supercollider/supercollider/issues/4127#issuecomment-1424294256) that uncovered the bug.

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [ ] All tests are passing
- [N/A] Updated documentation
- [x] This PR is ready for review
