### PR TITLE
scsynth: /n_fill fix behaviour

### DIFF
--- a/server/scsynth/SC_MiscCmds.cpp
+++ b/server/scsynth/SC_MiscCmds.cpp
@@ -609,11 +609,6 @@ SCErr meth_n_fill(World* inWorld, int inSize, char* inData, ReplyAddress* /*inRe
             int32* name = msg.gets4();
             int32 hash = Hash(name);
             int32 n = msg.geti();
-            float32 value = msg.getf();
-
-            for (int i = 0; i < n; ++i) {
-                Node_SetControl(node, hash, name, i, value);
-            }
 
             if (msg.nextTag('f') == 's') {
                 const char* string = msg.gets();
@@ -632,11 +627,6 @@ SCErr meth_n_fill(World* inWorld, int inSize, char* inData, ReplyAddress* /*inRe
         } else {
             int32 index = msg.geti();
             int32 n = msg.geti();
-            float32 value = msg.getf();
-
-            for (int i = 0; i < n; ++i) {
-                Node_SetControl(node, index + i, value);
-            }
             if (msg.nextTag('f') == 's') {
                 const char* string = msg.gets();
                 if (*string == 'c') {


### PR DESCRIPTION
Removes getting and setting the value prior to checking the type. This caused the function to try to get and set the value two times, with the second time getting and setting a value of 0, as no more osc messages were provided.

## Purpose and Motivation

Fixes #5973
As described in the issue linked above, _n_fill_ command seems to be broken (or at least not behaving the same way is documented.
Looking at the code and debugging the code execution, I've found that the first (and correctly documented) value argument passed via osc, is wrongly overwritten by another value that is always 0 (as no new value is provided) or is a non meaningful value of the next "block" of control - n values - value.

What I've detected (and comparing it to other similar commands such as _n_set_, or _n_setn_. Is that before checking the next osc message type, the value is requested and set, and after that, the "correct" (at least at my eyes) way of dealing with the message is applied, and thus, the first (and documented) value passed is not significant, as it's being overwritten by wrongly parsed, next argument.

## Types of changes

- Bug fix
- Breaking change

Removing the unnecessary getter of the value and setting the node control to that value before the correct way of dealing with it, I think achieves the correct behaviour of the n_fill command, but breaks code [where an extra parameter was used as a workaround to deal with this issue](https://github.com/PlaymodesStudio/ofxSuperCollider/blob/f633f1733bfbe3051f244f2880ec0b97ee2b89ce/src/ofxSCSynth.cpp#L142-L143).

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [ ] Code is tested
- [ ] All tests are passing
- [ ] Updated documentation
- [ ] This PR is ready for review
