### PR TITLE
GHA macOS: temporary fix for the legacy build

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -334,6 +334,7 @@ jobs:
           restore-keys: ${{ runner.os }}-${{ matrix.os-version }}-${{ matrix.xcode-version }}-${{ matrix.deployment-target }}-${{ matrix.vcpkg-triplet }}-
       - name: install dependencies
         run: |
+          brew install pkg-config # temporary fix due to an issue with GHA macOS runners fixed in https://github.com/actions/runner-images/pull/7125; should be okay to remove after approx 2023-03-10
           brew install ccache
           # add ccamke to PATH - see https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions
           echo "/usr/local/opt/ccache/libexec" >> $GITHUB_PATH


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

The recent macOS legacy builds are [failing](https://github.com/supercollider/supercollider/actions/runs/4208593518/jobs/7304787719#step:10:67) because vcpkg needs `pkg-config`, which is missing. This issue was [fixed upstream](https://github.com/actions/runner-images/pull/7125), but - IIUC - it will take about 2 weeks until this makes it into the runner image release. In order to be able to release SC in the meantime, I propose to manually install `pkg-config`. This can be reverted once the issue is fixed upstream.

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- ~~[ ] Updated documentation~~
- [x] This PR is ready for review
