### PR TITLE
GHA: fix logic for installing Qt from homebrew

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -371,10 +371,10 @@ jobs:
         if: env.USE_SYSLIBS == 'true'
         run: brew install yaml-cpp boost
       - name: install qt from homebrew
-        if: matrix.cmake-architectures == 'x86_64' && '!matrix.qt-version' 
+        if: matrix.cmake-architectures == 'x86_64' && !matrix.qt-version
         run: brew install qt5
       - name: install qt universal binary from homebrew
-        if: matrix.cmake-architectures != 'x86_64' && '!matrix.qt-version'
+        if: matrix.cmake-architectures != 'x86_64' && !matrix.qt-version
         run: ./brew-install-universal.sh qt5
       - name: install qt using aqtinstall
         uses: jurplel/install-qt-action@v3


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

It seems we were unnecessarily installing Qt from homebrew when we also used Qt from `aqtinstall` action. This just wasted some time, there are no functional changes here. 

In practice, this only affected the macOS legacy build.

~~This PR should go in after #5976 is merged.~~ This is now rebased on top of `develop`, ready for review/merging.

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- ~~[ ] Updated documentation~~
- [x] This PR is ready for review
