### PR TITLE
GHA: use Xcode 10.3 for macOS legacy build

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -252,8 +252,8 @@ jobs:
             verify-app: true
 
           - job-name: 'x64 legacy'
-            os-version: '11'
-            xcode-version: '12.4'
+            os-version: '10.15'
+            xcode-version: '10.3'
             qt-version: '5.9.9' # will use qt from aqtinstall
             deployment-target: '10.10'
             cmake-architectures: x86_64


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation
This is a temporary change to make it work down to macOS 10.10. macOS 10.15 images will be unavailable at the end of March 2023.
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

This should allow for making one last release that supports macOS 10.10. After that we'll have to bump to... 10.11 :) (this seems to work fine on macOS 11 runner with Xcode 12)

This is a fix for an issue reported [on the forum](https://scsynth.org/t/problem-starting-sc-13-3/7188).

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix


## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- ~~[ ] Updated documentation~~
- [x] This PR is ready for review
