### PR TITLE
Update Linux build matrix and Readme on supported OSes and Libraries

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -106,10 +106,10 @@ jobs:
             use-syslibs: true
             shared-libscsynth: false
 
-          - job-name: 'bionic clang6.0'
-            os-version: '18.04'
-            c-compiler: 'clang-6.0'
-            cxx-compiler: 'clang++-6.0'
+          - job-name: 'focal clang7'
+            os-version: '20.04'
+            c-compiler: 'clang-7'
+            cxx-compiler: 'clang++-7'
             use-syslibs: false
             shared-libscsynth: false
 
@@ -193,9 +193,7 @@ jobs:
           # install appropriate clang/gcc compilers
           if [[ "$CC" =~ clang-[1-9] ]]; then
             sudo apt-get install -y $CC # package names are clang-X
-            if [[ "$CC" != clang-6.0 ]]; then
-              sudo apt-get install -y libc++-${CC##clang-}-dev libc++abi-${CC##clang-}-dev # install additional libraries; package names are libc++-X-dev and libc++abi-X-dev
-            fi
+            sudo apt-get install -y libc++-${CC##clang-}-dev libc++abi-${CC##clang-}-dev # install additional libraries; package names are libc++-X-dev and libc++abi-X-dev
           elif [[ "$CC" =~ gcc-[1-9] ]]; then
             sudo apt-get install -y $CXX # package names are g++-X
           fi

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -56,20 +56,6 @@ jobs:
             use-syslibs: false
             shared-libscsynth: false
 
-          - job-name: 'focal gcc8'
-            os-version: '20.04'
-            c-compiler: 'gcc-8'
-            cxx-compiler: 'g++-8'
-            use-syslibs: false
-            shared-libscsynth: false
-
-          - job-name: 'focal gcc9'
-            os-version: '20.04'
-            c-compiler: 'gcc-9'
-            cxx-compiler: 'g++-9'
-            use-syslibs: false
-            shared-libscsynth: false
-
           - job-name: 'focal gcc9 shared libscsynth'
             os-version: '20.04'
             c-compiler: 'gcc-9'
@@ -84,13 +70,6 @@ jobs:
             use-syslibs: false
             shared-libscsynth: false
             artifact-suffix: 'linux-bionic-gcc10' # set if needed - will trigger artifact upload
-
-          # - job-name: 'focal gcc10 use system libraries' # disabled - boost version incompatible
-          #   os-version: '20.04'
-          #   c-compiler: 'gcc-10'
-          #   cxx-compiler: 'g++-10'
-          #   use-syslibs: true
-          #   shared-libscsynth: false
 
           - job-name: 'jammy gcc11'
             os-version: '22.04'
@@ -110,27 +89,6 @@ jobs:
             os-version: '20.04'
             c-compiler: 'clang-7'
             cxx-compiler: 'clang++-7'
-            use-syslibs: false
-            shared-libscsynth: false
-
-          - job-name: 'focal clang8'
-            os-version: '20.04'
-            c-compiler: 'clang-8'
-            cxx-compiler: 'clang++-8'
-            use-syslibs: false
-            shared-libscsynth: false
-
-          - job-name: 'focal clang9'
-            os-version: '20.04'
-            c-compiler: 'clang-9'
-            cxx-compiler: 'clang++-9'
-            use-syslibs: false
-            shared-libscsynth: false
-
-          - job-name: 'focal clang10'
-            os-version: '20.04'
-            c-compiler: 'clang-10'
-            cxx-compiler: 'clang++-10'
             use-syslibs: false
             shared-libscsynth: false
 

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -290,7 +290,6 @@ jobs:
           restore-keys: ${{ runner.os }}-${{ matrix.os-version }}-${{ matrix.xcode-version }}-${{ matrix.deployment-target }}-${{ matrix.vcpkg-triplet }}-
       - name: install dependencies
         run: |
-          brew install pkg-config # temporary fix due to an issue with GHA macOS runners fixed in https://github.com/actions/runner-images/pull/7125; should be okay to remove after approx 2023-03-10
           brew install ccache
           # add ccamke to PATH - see https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions
           echo "/usr/local/opt/ccache/libexec" >> $GITHUB_PATH

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -12,6 +12,8 @@ on:
       - 'HelpSource/**'
       - 'sounds/**'
       - '*.md'
+  schedule:
+    - cron:  '0 0 * * 0' # run weekly to refresh cache
 jobs:
   lint:
     runs-on: ubuntu-20.04

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -254,6 +254,7 @@ jobs:
       MACOSX_DEPLOYMENT_TARGET: '${{ matrix.deployment-target }}'
       CMAKE_OSX_ARCHITECTURES: '${{ matrix.cmake-architectures }}'
       BREW_UNIVERSAL_WORKDIR: ${{ github.workspace }}/brew-universal
+      SKIP_SIGNING: 1 # for brew-install-universal
     steps:
       - uses: actions/checkout@v3
         with:
@@ -301,7 +302,7 @@ jobs:
           # install universal versions of homebrew libraries
           if [[ "${{ matrix.cmake-architectures }}" != "x86_64" ]]; then
               echo "Downloading script for creating universal binaries from homebrew packages"
-              curl -O -J -L https://gist.githubusercontent.com/dyfer/6c83905d4593750105897e51e87ec345/raw/6bf8cb1b152e7e61c7199ff7151b0ea303f7307f/brew-install-universal.sh
+              curl -O -J -L https://gist.githubusercontent.com/dyfer/6c83905d4593750105897e51e87ec345/raw/cb818038b9d0d2fce7b1697b95b671a110c28afa/brew-install-universal.sh
               chmod +x brew-install-universal.sh
               if [[ "${{ matrix.build-libsndfile }}" != "true" ]]; then ./brew-install-universal.sh libsndfile; fi
               if [[ "${{ matrix.build-readline }}" != "true" ]]; then ./brew-install-universal.sh readline; fi

--- a/README.md
+++ b/README.md
@@ -31,23 +31,23 @@ SuperCollider is tested with:
 - Ubuntu 18.04 and gcc 10
 
 SuperCollider is known to support these platforms:
-- Windows Vista, 7, 8, and 10
+- Windows Vista, 7, 8, 10, 11
 - macOS 10.14-12.x
-- Ubuntu 14.04-22.04
+- Ubuntu 18.04-22.04
 
 We also provide a legacy macOS binary for macOS 10.10 and above using Qt 5.9.
 
 SuperCollider has guaranteed support for:
-- Windows 10
+- Windows 10, 11
 - MSVC 2017, 2019
-- macOS 10.14-10.15
-- Xcode 10-12
-- Debian >= 9.0
-- Ubuntu 16.04, 18.04, 20.04
-- Fedora 31, 32
+- macOS 11, 12
+- Xcode 11-13
+- Debian >= 11
+- Ubuntu 20.04, 22.04
+- Fedora 36, 37
 - Arch Linux
-- gcc >= 6.3
-- clang >= 3.9
+- gcc >= 9
+- clang >= 11
 - Qt >= 5.11
 
 For more information on platform support guarantees, see the [project


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

This is a GitHub Actions maintenance PR, combined with documentation update.

I updated README.md to reflect, more or less, our [platform support guarantees](https://github.com/supercollider/supercollider/wiki/Platform-Support), based on the build environment in GitHub Actions and information I came across on the forum and in the PRs in the last few months, with the exception of the following:
- MSVC version: there might be issues with MSVC 2022; in any case, I feel there should be a separate PR that updates the build environment to MSVC 2022, at which point we should update the Readme
- Qt version: I think this should be updated once we migrate to Qt6
- "Tested with": we are testing with OS version outside of the "guaranteed support" window; I am planning to provide a separate PR to update that

Notes on supported GCC and Clang versions:
- we officially support last 4 versions, so I removed most older versions to make the build matrix smaller
- still, I left the oldest compiler in the matrix, so that we can see when we actually have to break compatibility with older toolchains
  - I've swaped clang6.0 with clang7 since there seemed to be an issue getting `libstd++` for clang6.0 on Ubuntu 20.04 (and Ubuntu 18.04 image is deprecated).
  

I've also made one (possibly?) considerable change to the GHA workflow: I made it automatically run weekly, on top of the previous behavior (run on push, PR, tags etc). This will happen on the default `develop` branch. Now that we merge things into develop less frequently, there's often the case where it takes more than one week between builds on `develop`, which makes the caches expire. New PRs and pushes will use cache from the default branch, but if it expires, it's not available. This causes longer build times for new pushes and PRs after a break. With this addition, hopefully, we'll always have an up-to-date cache so that new PRs will be built quicker, even in periods of low activity for the project. The downside is that we add this automatic weekly build, which is otherwise unnecessary, except for renewing the cache.

## Types of changes

<!-- Delete lines that don't apply -->

- Documentation
- Maintenance

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review
