### PR TITLE
GHA: refresh some caches weekly, not daily

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -261,7 +261,9 @@ jobs:
           submodules: recursive
       - name: prepare timestamp for cache
         id: current-date
-        run: echo "stamp=$(date '+%Y-%m-%d')" >> $GITHUB_OUTPUT
+        run: |
+          echo "stamp=$(date '+%Y-%m-%d')" >> $GITHUB_OUTPUT
+          echo "week=$(date '+%U')" >> $GITHUB_OUTPUT
       - name: cache ccache
         uses: actions/cache@v3
         with:
@@ -275,14 +277,14 @@ jobs:
         id: cache-homebrew
         with:
           path: ~/Library/Caches/Homebrew/downloads
-          key: ${{ runner.os }}-${{ matrix.os-version }}-${{ matrix.xcode-version }}-${{ matrix.use-syslibs }}-${{ matrix.shared-libscsynth }}-${{ matrix.qt-version }}-${{ matrix.cmake-architectures }}-homebrew-${{ steps.current-date.outputs.stamp }}
+          key: ${{ runner.os }}-${{ matrix.os-version }}-${{ matrix.xcode-version }}-${{ matrix.use-syslibs }}-${{ matrix.shared-libscsynth }}-${{ matrix.qt-version }}-${{ matrix.cmake-architectures }}-homebrew-${{ steps.current-date.outputs.week }}
           restore-keys: ${{ runner.os }}-${{ matrix.os-version }}-${{ matrix.xcode-version }}-${{ matrix.use-syslibs }}-${{ matrix.shared-libscsynth }}-${{ matrix.qt-version }}-${{ matrix.cmake-architectures }}-homebrew-
       - name: cache homebrew universal packages
         uses: actions/cache@v3
         if: matrix.cmake-architectures != 'x86_64' && (matrix.build-libsndfile != true || matrix.build-readline != true || matrix.build-fftw != true)
         with:
           path: ${{ env.BREW_UNIVERSAL_WORKDIR }}
-          key: ${{ runner.os }}-v1-${{ matrix.os-version }}-${{ matrix.xcode-version }}-${{ matrix.deployment-target }}-brew_universal-${{ steps.current-date.outputs.stamp }}
+          key: ${{ runner.os }}-v1-${{ matrix.os-version }}-${{ matrix.xcode-version }}-${{ matrix.deployment-target }}-brew_universal-${{ steps.current-date.outputs.week }}
           restore-keys: ${{ runner.os }}-v1-${{ matrix.os-version }}-${{ matrix.xcode-version }}-${{ matrix.deployment-target }}-brew_universal-
       - name: cache vcpkg
         if: matrix.vcpkg-triplet


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

Our build caches are fairly large and we are hitting [GHA's 10GB limit](https://github.com/supercollider/supercollider/actions/caches) fairly soon, after just a few subsequent builds. The worst offender is the cache for homebrew "universal" binaries (1.3 GB per run, once in the matrix), with homebrew downloads being also considerable (~140 MB * ~~4~~ 3 macOS builds). 

Currently each build cache uses the daily timestamp, so a new build each day would create new cache. This becomes a problem if we have just a few PRs building and the cache from the `develop` build gets evicted (if we go over 10GB total). This will cause every new build on a new branch after that not having the cache available and thus taking much longer.

I think this can be minimized by changing renewal of the caches in question to be done weekly. I think this should prevent new caches from being created in that time period ~~(caches might be created for every PR still, but they should only be renewed weekly after that)~~. In any case, it should be an improvement over what we have right now.


## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix (kind of)

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- n/a ~~[ ] Updated documentation~~
- [x] This PR is ready for review
