### PR TITLE
fix Dictionary trueAt

### DIFF
--- a/SCClassLibrary/Common/Collections/Dictionary.sc
+++ b/SCClassLibrary/Common/Collections/Dictionary.sc
@@ -23,7 +23,7 @@ Dictionary : Set {
 		^nil
 	}
 	trueAt { arg key;
-		^this.at(key) ? false
+		^this.at(key) == true
 	}
 	add { arg anAssociation;
 		this.put(anAssociation.key, anAssociation.value);

--- a/SCClassLibrary/Common/Collections/Dictionary.sc
+++ b/SCClassLibrary/Common/Collections/Dictionary.sc
@@ -23,7 +23,7 @@ Dictionary : Set {
 		^nil
 	}
 	trueAt { arg key;
-		^this.at(key) == true
+		^this.at(key).booleanValue
 	}
 	add { arg anAssociation;
 		this.put(anAssociation.key, anAssociation.value);

--- a/testsuite/classlibrary/TestDictionary.sc
+++ b/testsuite/classlibrary/TestDictionary.sc
@@ -27,4 +27,9 @@ TestDictionary : UnitTest {
 
 	}
 
+	test_trueAt {
+		var dict = (x:7, y:false, z:true);
+		this.assert([\x, \y].every(dict.falseAt(_)) and: dict.trueAt(\z), "dictionary trueAt and falseAt should respond only true if the value really equals true.");
+	}
+
 }


### PR DESCRIPTION
This fixes #6000.

## Types of changes

- Bug fix
- Breaking Change

Considering the possible breaking changes:


|      trueAt            | obj | nil | true | false |
|-|--|-|-|-|
| previous: | obj | false | true |false |
| new:        | false | false | true |false |

So if you were assuming that `trueAt` and `falseAt` would return a boolean, your code would previously fail.
The change only extends the range of possible correct answers and does not change those that were already correct.

I however can imagine boundary cases where you'd use a `try { }` around the statement. Or, if someone were trying to fix the problem by calling `.trueAt(key).asBoolean`.

*Edit* There is an alternative possibility, that I favour (not implemented here yet, please discuss): The original idea of `trueAt` – I think – was to allow an empty (unspecified) value to count as `false`. So maybe better throw an error if it is neither:

```supercollider
trueAt { |key|
   var value = this.at(key);
   if(value.notNil and: { value.isKindOf(Boolean).not }) { 
       Error("trueAt requires either a boolean or nil entry").throw
   });
   ^value == true
}
```

Alternatively, one could also call `asBoolean` to allow numbers. But I don't like this so much.

=> please discuss

P.S. by the way, `Object.trueAt` returns `false` for any key. This may be an argument for *not* throwing an error in the case of a dictionary that has an object at the respective key?

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] This PR is ready for review
