### PR TITLE
macOS: raise legacy build OS requirement to 10.11

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -213,7 +213,7 @@ jobs:
             os-version: '11'
             xcode-version: '12.4'
             qt-version: '5.9.9' # will use qt from aqtinstall
-            deployment-target: '10.10'
+            deployment-target: '10.11'
             cmake-architectures: x86_64
             use-syslibs: false
             shared-libscsynth: false

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ SuperCollider is known to support these platforms:
 - macOS 10.14-12.x
 - Ubuntu 18.04-22.04
 
-We also provide a legacy macOS binary for macOS 10.10 and above using Qt 5.9.
+We also provide a legacy macOS binary for macOS 10.11 and above using Qt 5.9.
 
 SuperCollider has guaranteed support for:
 - Windows 10, 11


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

After 3.13 release it turned out that setting 10.10 deployment target with Xcode 12 yielded unbootable server. We [fixed that temporarily](https://github.com/supercollider/supercollider/pull/5984) for 3.13 by using the older OS image with Xcode 10.3, but this image is deprecated and won't be available after March of 2023.

In my previous tests, I discovered that setting deployment target to 10.11 (one version higher) results in a working build with bootable server, so I suggest we update our legacy build to that setting.

**NOTE:** ~~I don't have a 10.11 system right now to test this. However,~~ EDIT: I tested the legacy build on both 10.11 and 10.13 and the server booted, so I think this is okay.

## Types of changes

<!-- Delete lines that don't apply -->


- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review
