### PR TITLE
GHA: update Ubuntu 18.04 jobs

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -682,7 +682,7 @@ jobs:
 
     if: github.repository_owner == 'supercollider' && github.event_name != 'pull_request' # run in the main repo, but not on pull requests
     needs: [lint, macOS, Windows]
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     name: 'deploy ${{ matrix.artifact-suffix }} to s3'
     env:
       INSTALL_PATH: ${{ github.workspace }}/build/Install
@@ -755,7 +755,7 @@ jobs:
   deploy_gh:
     if: startsWith(github.ref, 'refs/tags/') # run on tagged commits
     needs: [lint, macOS, Windows]
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     name: 'deploy release'
     env:
       INSTALL_PATH: ${{ github.workspace }}/Install


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

Ubuntu 18.04 images are [deprecated](https://github.blog/changelog/2022-08-09-github-actions-the-ubuntu-18-04-actions-runner-image-is-being-deprecated-and-will-be-removed-by-12-1-22/) and will soon be unavailable (see [this job](https://github.com/supercollider/supercollider/actions/runs/4633290823)). This PR updates some jobs to use the latest ubuntu images. 

Please note that I've changed these jobs to use `ubuntu-latest`, which will be periodically updated by GH to point to the latest "stable" image. I believe that for the "helper" tasks (upload to S3 and upload to the release) this should be fine.

Remaining 18.04 jobs are updated in #6003 

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix


## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] This PR is ready for review
