### PR TITLE
GHA Windows: revert ccache version

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -487,7 +487,7 @@ jobs:
       - name: install ccache
         shell: bash
         run: |
-          choco install ccache --no-progress
+          choco install ccache --version=4.7.5 --no-progress # version is pinned due to issues with caching msvc in 4.8; unpin after ccache is updated to 4.8.1 in chocolatey
           echo "`echo c:/ProgramData/chocolatey/lib/ccache/tools/ccache*`" >> $GITHUB_PATH # put the direct path before the path of the choco's "shim" (link subsitute)
       - name: install libsndfile
         shell: bash


### PR DESCRIPTION


<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

I noticed that Windows builds were taking quite long, despite supposedly using ccache. It turns out that ccache 4.8 didn't cache our MSVC builds due to an [issue upstream](https://github.com/ccache/ccache/issues/1262); 4.8.1 should fix that, so in the meantime let's revert back to the version that worked.

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix


## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] This PR is ready for review
