### PR TITLE
Topic/two way pipe

### DIFF
--- a/SCClassLibrary/Common/Files/File.sc
+++ b/SCClassLibrary/Common/Files/File.sc
@@ -184,6 +184,17 @@ Pipe : UnixFILE {
 		^super.new.openArgv(args, mode);
 	}
 
+	*argvReadWrite { arg args;
+		var pid, readPipe, writePipe;
+
+		#pid, readPipe, writePipe = this.prOpenArgvReadWrite(args);
+
+		^[
+			super.newCopyArgs(readPipe, pid).addOpenFile(), 
+			super.newCopyArgs(writePipe, pid).addOpenFile()
+		]
+	}
+
 	*call { arg command, onSuccess, onError, maxLineLength=4096;
 		var r, cancel, closePipe;
 		r = Routine.run({
@@ -277,12 +288,18 @@ Pipe : UnixFILE {
 		^this.primitiveFailed
 	}
 
-	prOpenArgv { arg  args, mode;
+	prOpenArgv { arg args, mode;
 		/* open the file with explicit list of arguments. mode is a string passed
 			to popen, so should be one of:
 			"r","w"
 		*/
 		_PipeOpenArgv
+		^this.primitiveFailed
+	}
+
+	*prOpenArgvReadWrite {
+		 arg args;
+		_PipeOpenArgvReadWrite
 		^this.primitiveFailed
 	}
 }

--- a/common/sc_popen.cpp
+++ b/common/sc_popen.cpp
@@ -59,7 +59,6 @@ std::tuple<pid_t, std::array<FILE*, 2>> sc_popen_argv_twoway(std::vector<std::st
 
     const pid_t pid = fork();
     if (pid == 0) { // CHILD PROCESS
-
         // close the ends of the pipes used by parent
         close(readPipe[0]);
         close(writePipe[1]);

--- a/common/sc_popen.cpp
+++ b/common/sc_popen.cpp
@@ -24,6 +24,16 @@
 #    include <array>
 #    include <string>
 
+std::vector<char*> stringsToArgv(const std::vector<std::string>& strings) {
+    std::vector<char*> argv(strings.size() + 1);
+    for (int i = 0; i < strings.size(); ++i) {
+        // execv wants argv as char *const argv[] - need to make the pointer const
+        argv[i] = const_cast<char*>(strings[i].data());
+    }
+    argv[strings.size()] = nullptr;
+    return argv;
+}
+
 std::tuple<pid_t, FILE*> sc_popen(std::string&& command, const std::string& type) {
     std::vector<std::string> argv;
     argv.emplace_back("/bin/sh");
@@ -33,14 +43,48 @@ std::tuple<pid_t, FILE*> sc_popen(std::string&& command, const std::string& type
 }
 
 std::tuple<pid_t, FILE*> sc_popen_argv(const std::vector<std::string>& strings, const std::string& type) {
-    std::vector<char*> argv(strings.size() + 1);
-    for (int i = 0; i < strings.size(); ++i) {
-        // execv wants argv as char *const argv[]
-        // need to make the pointer const
-        argv[i] = const_cast<char*>(strings[i].data());
-    }
-    argv[strings.size()] = nullptr;
+    const auto argv = stringsToArgv(strings);
     return sc_popen_c_argv(argv[0], argv.data(), type.c_str());
+}
+
+std::tuple<pid_t, std::array<FILE*, 2>> sc_popen_argv_twoway(const std::vector<std::string>& args) {
+    auto argv = stringsToArgv(args);
+    const char* filename = argv[0];
+
+    int readPipe[2];
+    int writePipe[2];
+
+    pipe(readPipe);
+    pipe(writePipe);
+
+    const pid_t pid = fork();
+    if (pid == 0) { // CHILD PROCESS
+
+        // close the ends of the pipes used by parent
+        close(readPipe[0]);
+        close(writePipe[1]);
+
+        // replace stdin and stdout with the pipes
+        close(STDIN_FILENO);
+        close(STDOUT_FILENO);
+        dup2(writePipe[0], STDIN_FILENO);
+        dup2(readPipe[1], STDOUT_FILENO);
+
+        execvp(filename, argv.data());
+        exit(127);
+
+    } else { // PARENT PROCESS
+
+        // close the ends of the pipes used by child
+        close(readPipe[1]);
+        close(writePipe[0]);
+
+        // open other ends of pipes
+        FILE* readFD = fdopen(readPipe[0], "r");
+        FILE* writeFD = fdopen(writePipe[1], "w");
+
+        return std::make_tuple(pid, std::array<FILE*, 2> { readFD, writeFD });
+    }
 }
 
 std::tuple<pid_t, FILE*> sc_popen_c_argv(const char* filename, char* const argv[], const char* type) {
@@ -119,15 +163,21 @@ std::tuple<pid_t, FILE*> sc_popen_c_argv(const char* filename, char* const argv[
  */
 int sc_pclose(FILE* iop, pid_t mPid) {
     int pstat = 0;
-    pid_t pid;
+    pid_t pid {-1};
 
-    (void)fclose(iop);
+    (void)sc_fclose(iop);
 
-    do {
-        pid = wait4(mPid, &pstat, 0, (struct rusage*)0);
-    } while (pid == -1 && errno == EINTR);
+    if (mPid) {
+        do {
+            pid = wait4(mPid, &pstat, 0, (struct rusage*)0);
+        } while (pid == -1 && errno == EINTR);
+    }    
 
     return (pid == -1 ? -1 : pstat);
+}
+
+int sc_fclose(FILE* iop) {
+    return fclose(iop);
 }
 
 #else

--- a/common/sc_popen.cpp
+++ b/common/sc_popen.cpp
@@ -34,20 +34,20 @@ std::vector<char*> stringsToArgv(const std::vector<std::string>& strings) {
     return argv;
 }
 
-std::tuple<pid_t, FILE*> sc_popen(std::string&& command, const std::string& type) {
+std::tuple<pid_t, FILE*> sc_popen(std::string command, const std::string& type) {
     std::vector<std::string> argv;
     argv.emplace_back("/bin/sh");
     argv.emplace_back("-c");
     argv.push_back(std::move(command));
-    return sc_popen_argv(argv, type);
+    return sc_popen_argv(std::move(argv), type);
 }
 
-std::tuple<pid_t, FILE*> sc_popen_argv(const std::vector<std::string>& strings, const std::string& type) {
+std::tuple<pid_t, FILE*> sc_popen_argv(std::vector<std::string> strings, const std::string& type) {
     const auto argv = stringsToArgv(strings);
     return sc_popen_c_argv(argv[0], argv.data(), type.c_str());
 }
 
-std::tuple<pid_t, std::array<FILE*, 2>> sc_popen_argv_twoway(const std::vector<std::string>& args) {
+std::tuple<pid_t, std::array<FILE*, 2>> sc_popen_argv_twoway(std::vector<std::string> args) {
     auto argv = stringsToArgv(args);
     const char* filename = argv[0];
 
@@ -163,7 +163,7 @@ std::tuple<pid_t, FILE*> sc_popen_c_argv(const char* filename, char* const argv[
  */
 int sc_pclose(FILE* iop, pid_t mPid) {
     int pstat = 0;
-    pid_t pid {-1};
+    pid_t pid { -1 };
 
     (void)sc_fclose(iop);
 
@@ -171,14 +171,12 @@ int sc_pclose(FILE* iop, pid_t mPid) {
         do {
             pid = wait4(mPid, &pstat, 0, (struct rusage*)0);
         } while (pid == -1 && errno == EINTR);
-    }    
+    }
 
     return (pid == -1 ? -1 : pstat);
 }
 
-int sc_fclose(FILE* iop) {
-    return fclose(iop);
-}
+int sc_fclose(FILE* iop) { return fclose(iop); }
 
 #else
 #    include <numeric>

--- a/common/sc_popen.h
+++ b/common/sc_popen.h
@@ -39,4 +39,6 @@ std::tuple<pid_t, FILE*> sc_popen_c_argv(const char* filename, char* const argv[
  */
 std::tuple<pid_t, FILE*> sc_popen(std::string&& command, const std::string& type);
 std::tuple<pid_t, FILE*> sc_popen_argv(const std::vector<std::string>& strings, const std::string& type);
+std::tuple<pid_t, std::array<FILE*, 2>> sc_popen_argv_twoway(const std::vector<std::string>& args);
 int sc_pclose(FILE* iop, pid_t mPid);
+int sc_fclose(FILE* iop);

--- a/common/sc_popen.h
+++ b/common/sc_popen.h
@@ -37,8 +37,8 @@ std::tuple<pid_t, FILE*> sc_popen_c_argv(const char* filename, char* const argv[
  *
  * This function assumes a UTF-8 encoded, narrow-char string.
  */
-std::tuple<pid_t, FILE*> sc_popen(std::string&& command, const std::string& type);
-std::tuple<pid_t, FILE*> sc_popen_argv(const std::vector<std::string>& strings, const std::string& type);
-std::tuple<pid_t, std::array<FILE*, 2>> sc_popen_argv_twoway(const std::vector<std::string>& args);
+std::tuple<pid_t, FILE*> sc_popen(std::string command, const std::string& type);
+std::tuple<pid_t, FILE*> sc_popen_argv(std::vector<std::string> strings, const std::string& type);
+std::tuple<pid_t, std::array<FILE*, 2>> sc_popen_argv_twoway(std::vector<std::string> args);
 int sc_pclose(FILE* iop, pid_t mPid);
 int sc_fclose(FILE* iop);

--- a/lang/LangPrimSource/PyrFilePrim.cpp
+++ b/lang/LangPrimSource/PyrFilePrim.cpp
@@ -1377,7 +1377,7 @@ int prPipeOpenArgvReadWrite(struct VMGlobals* g, int numArgsPushed) {
     if (error != errNone)
         return error;
 
-    auto [pid, files] = sc_popen_argv_twoway(strings);
+    auto [pid, files] = sc_popen_argv_twoway(std::move(strings));
 
     PyrObject* result = newPyrArray(g->gc, 3, 0, true); // runGC = true
     SetObject(callerSlot, result);
@@ -1443,7 +1443,7 @@ int prPipeOpenArgv(struct VMGlobals* g, int numArgsPushed) {
 
     pid_t pid;
     FILE* file;
-    std::tie(pid, file) = sc_popen_argv(strings, mode);
+    std::tie(pid, file) = sc_popen_argv(std::move(strings), mode);
 
     if (file != nullptr) {
         SetPtr(&pfile->fileptr, file);

--- a/lang/LangPrimSource/PyrUnixPrim.cpp
+++ b/lang/LangPrimSource/PyrUnixPrim.cpp
@@ -197,7 +197,7 @@ int prArrayPOpen(struct VMGlobals* g, int numArgsPushed) {
 
     pid_t pid;
     FILE* stream;
-    std::tie(pid, stream) = sc_popen_argv(strings, "r");
+    std::tie(pid, stream) = sc_popen_argv(std::move(strings), "r");
     if (stream != nullptr) {
         SC_Thread thread(std::bind(string_popen_thread_func, pid, stream, IsTrue(postOutputSlot)));
         thread.detach();

--- a/testsuite/classlibrary/TestPIpe.sc
+++ b/testsuite/classlibrary/TestPIpe.sc
@@ -1,0 +1,11 @@
+TestPipe : UnitTest {
+
+	test_basic_pipe {
+        if (thisProcess.platform.isKindOf(UnixPlatform)) {
+            var pipe = Pipe.argv(["date", "+%H"], "r");
+            var result = pipe.getLine();
+            assert("^[0-9]+$".matchRegexp(result)))
+        }
+	}
+
+}


### PR DESCRIPTION
## Purpose and Motivation

sclang currently has no ability to communicate bidirectionally with a subprocess called by `argv`. This introduces a primitive which opens both a read and write pipe (stdin / stdout) for a subprocess and returns both.

Note that this is NOT intended as a "high-level" interface to bidirectional pipes, but only as an initial primitive that a user-facing representation could be built on top of. Designing proper bidirectional subprocess communication is a larger pure-sclang task that can be tackled separately.

This change is critical for the sclang code formatter (https://github.com/scztt/sclang-format).

## Types of changes

- Documentation
- New feature

## To-do list

- [x] Code is tested
- [x] All tests are passing
- [ ] Updated documentation
- [ ] This PR is ready for review

## Unresolved

- **WINDOWS SUPPORT**: The Windows `argv` implementation is completely separate from the OSX. My knowledge of pipes is limited on unix systems, and basically zero on Windows, so some help would be appreciated in implementing the Windows half of this PR.
- **PID MANAGEMENT**: Currently, Pipes have an associated pid if they correspond to a subprocess - the subprocess is closed when the pipe is closed. Since we have two pipes here, we have a two choices... We can bind the pid to ONE of the two Pipes - closing this pipe would result in the underlying process being closed. Or (the implementation in this PR), we can tie the pid to BOTH pipes, and close it when the first pipe is closed. This can result in an error message if code attempts to close the second pipe, since the PID is already closed. It's important to note again that this is a *primitive* API - ideally, this would be wrapped in a high-level user facing class that handles the details so users don't have to care about closing what Pipe when.
- **BLOCKING**: As is always the case with pipes, reads are blocking and it's easy to hang sclang if the pipe is not ready for reading. As I'm not THAT familiar with pipes, I'm not sure if there are things we can do to avoid some of these language hangs, either in the primitive itself or via sclang code. Help / advice here would be appreciated.
