### PR TITLE
Topic/improve help modularity

### DIFF
--- a/HelpSource/BrokenLink.html
+++ b/HelpSource/BrokenLink.html
@@ -4,6 +4,7 @@
 <head>
     <title>Broken link</title>
     <link rel='stylesheet' href='./scdoc.css' type='text/css' />
+    <link rel='stylesheet' href='./frontend.css' type='text/css' />
     <link rel='stylesheet' href='./custom.css' type='text/css' />
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta http-equiv='Content-Type' content='text/html; charset=UTF-8' />

--- a/HelpSource/Browse.html
+++ b/HelpSource/Browse.html
@@ -6,6 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta http-equiv='Content-Type' content='text/html; charset=UTF-8' />
     <link rel='stylesheet' href='./scdoc.css' type='text/css' />
+    <link rel='stylesheet' href='./frontend.css' type='text/css' />
     <link rel='stylesheet' href='./custom.css' type='text/css' />
     <link rel='stylesheet' href='./browse.css' type='text/css' />
     <script src="lib/jquery.min.js"></script>
@@ -16,7 +17,7 @@
     <script src="docmap.js" type="text/javascript"></script>
     <script src="scdoc.js" type="text/javascript"></script>
     <script src="browse.js"></script>
-</head>
+    <script src="frontend.js"></script>
 
 <body>
     <noscript>

--- a/HelpSource/OldHelpWrapper.html
+++ b/HelpSource/OldHelpWrapper.html
@@ -3,11 +3,13 @@
 <head>
     <title>Old Help</title>
     <link rel='stylesheet' href='./scdoc.css' type='text/css' />
+    <link rel='stylesheet' href='./frontend.css' type='text/css' />
     <link rel='stylesheet' href='./custom.css' type='text/css' />
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta http-equiv='Content-Type' content='text/html; charset=UTF-8' />
     <script src="lib/jquery.min.js"></script>
     <script src="scdoc.js" type="text/javascript"></script>
+    <script src="frontend.js"></script>
     <style>
         #oldframe {
             border: none;

--- a/HelpSource/Overviews/Classes.html
+++ b/HelpSource/Overviews/Classes.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta http-equiv='Content-Type' content='text/html; charset=UTF-8' />
     <link rel='stylesheet' href='../scdoc.css' type='text/css' />
+    <link rel='stylesheet' href='../frontend.css' type='text/css' />
     <link rel='stylesheet' href='../custom.css' type='text/css' />
     <script src="../lib/jquery.min.js"></script>
     <script>
@@ -13,6 +14,7 @@
     </script>
     <script src="../docmap.js" type="text/javascript"></script>
     <script src="../scdoc.js" type="text/javascript"></script>
+    <script src="../frontend.js" type="text/javascript"></script>
 <noscript>
 <p>The class index needs JavaScript.
 </noscript>

--- a/HelpSource/Overviews/Documents.html
+++ b/HelpSource/Overviews/Documents.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta http-equiv='Content-Type' content='text/html; charset=UTF-8' />
     <link rel='stylesheet' href='../scdoc.css' type='text/css' />
+    <link rel='stylesheet' href='../frontend.css' type='text/css' />
     <link rel='stylesheet' href='../custom.css' type='text/css' />
     <script src="../lib/jquery.min.js"></script>
     <script>
@@ -13,6 +14,7 @@
     </script>
     <script src="../docmap.js" type="text/javascript"></script>
     <script src="../scdoc.js" type="text/javascript"></script>
+    <script src="../frontend.js" type="text/javascript"></script>
 <noscript>
 <p>The document index needs JavaScript.
 </noscript>

--- a/HelpSource/Overviews/Methods.html
+++ b/HelpSource/Overviews/Methods.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta http-equiv='Content-Type' content='text/html; charset=UTF-8' />
     <link rel='stylesheet' href='../scdoc.css' type='text/css' />
+    <link rel='stylesheet' href='../frontend.css' type='text/css' />
     <link rel='stylesheet' href='../custom.css' type='text/css' />
     <script src="../lib/jquery.min.js"></script>
     <script>
@@ -13,6 +14,7 @@
     </script>
     <script src="../docmap.js" type="text/javascript"></script>
     <script src="../scdoc.js" type="text/javascript"></script>
+    <script src="../frontend.js" type="text/javascript"></script>
 <noscript>
 <p>The method index needs JavaScript.
 </noscript>

--- a/HelpSource/Search.html
+++ b/HelpSource/Search.html
@@ -6,6 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta http-equiv='Content-Type' content='text/html; charset=UTF-8' />
     <link rel='stylesheet' href='./scdoc.css' type='text/css' />
+    <link rel='stylesheet' href='./frontend.css' type='text/css' />
     <link rel='stylesheet' href='./custom.css' type='text/css' />
     <script src="lib/jquery.min.js"></script>
     <script>
@@ -15,6 +16,7 @@
     <script src="docmap.js" type="text/javascript"></script>
     <script src="scdoc.js" type="text/javascript"></script>
     <script src="search.js"></script>
+    <script src="frontend.js"></script>
 </head>
 
 <body onload="onLoad()">

--- a/HelpSource/scdoc.css
+++ b/HelpSource/scdoc.css
@@ -125,7 +125,7 @@ a.subclass_toggle:hover {
     display: inline-block;
 }
 
-#menubar .menuitem:first-child {
+#menubar .menuitem .home {
     /* It is better to make the logo a background image instead of an <img> because it is purely
     decorative. */
     background-image: url("images/SC_icon.png");
@@ -147,13 +147,13 @@ a.menu-link:hover {
     color: #999;
 }
 
-#menubar .menuitem:first-child a {
+#menubar .menuitem .home a {
     /* The cube logo is actually *under* the <a>, but it shows through so that it looks like it
     is part of the link. */
     padding-left: 2em;
 }
 
-#menubar .menuitem:first-child a:hover {
+#menubar .menuitem .home a:hover {
     /* Lighten the background image by adding a translucent white layer over it. */
     background-color: rgba(255, 255, 255, 0.2);
 }
@@ -170,7 +170,7 @@ a.menu-link:hover {
 }
 
 @media (min-width: 512px) {
-    #menubar .menuitem:first-child a {
+    #menubar .menuitem .home a {
         padding-left: 2.5em;
     }
 

--- a/SCClassLibrary/SCDoc/SCDocRenderer.sc
+++ b/SCClassLibrary/SCDoc/SCDocRenderer.sc
@@ -247,6 +247,7 @@ SCDocHTMLRenderer {
 		<< "</script>\n"
 		<< "<script src='" << baseDir << "/scdoc.js' type='text/javascript'></script>\n"
 		<< "<script src='" << baseDir << "/docmap.js' type='text/javascript'></script>\n" // FIXME: remove?
+		<< "<script src='" << baseDir << "/frontend.js' type='text/javascript'></script>\n"
 		// QWebChannel access
 		<< "<script src='qrc:///qtwebchannel/qwebchannel.js' type='text/javascript'></script>\n"
 		<< "</head>\n"


### PR DESCRIPTION
## Purpose and Motivation

Minor improvements to customizing help on a per-frontend basis. Previously, SCDoc had a `frontend.css` file which could be used to specify css style details specific to a frontend or platform. This change introduces a frontend.js file, an equivalent for frontend specific javascript additions.

These changes are required by the [vscode-supercollider](https://github.com/scztt/vscode-supercollider) plugin, which needs to host the SCDoc files in an iframe and inject custom style details and some HTML elements to function correctly. These changes should have no effect on existing documentation behavior.

## Types of changes

- New feature

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation (no documentation change required)
- [x] This PR is ready for review
