### PR TITLE
mark SetResetFF explicitly as unipolar 

### DIFF
--- a/SCClassLibrary/Common/Audio/Trig.sc
+++ b/SCClassLibrary/Common/Audio/Trig.sc
@@ -127,6 +127,7 @@ PulseDivider : UGen {
 }
 
 SetResetFF : PulseCount {
+	signalRange { ^\unipolar }
 }
 
 ToggleFF : UGen {


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

Fixes #6022 as currently `.signalRange` returns bipolar on `SetResetFF` but it is indeed unipolar. This change was requested in #6020 

https://github.com/supercollider/supercollider/blob/18c4aad363c49f29e866f884f5ac5bd35969d828/HelpSource/Classes/SetResetFF.schelp#L1-L13

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [ ] Code is tested
- [ ] All tests are passing
- [ ] Updated documentation
- [x] This PR is ready for review
