### PR TITLE
Fix UGen initialization: LFUGens pt. 1/3, Trig, Trig1

### DIFF
--- a/server/plugins/LFUGens.cpp
+++ b/server/plugins/LFUGens.cpp
@@ -588,11 +588,12 @@ void LFPar_Ctor(LFPar* unit) {
         SETCALC(LFPar_next_k);
 
     unit->mFreqMul = 4.0 * unit->mRate->mSampleDur;
-    unit->mPhase = ZIN0(1);
+    double initPhase = unit->mPhase = ZIN0(1);
 
     LFPar_next_k(unit, 1);
-}
 
+    unit->mPhase = initPhase;
+}
 
 //////////////////////////////////////////////////////////////////////////////////////////////////
 

--- a/server/plugins/LFUGens.cpp
+++ b/server/plugins/LFUGens.cpp
@@ -676,9 +676,12 @@ void LFTri_Ctor(LFTri* unit) {
     }
 
     unit->mFreqMul = 4.0 * unit->mRate->mSampleDur;
-    unit->mPhase = ZIN0(1);
+
+    double initPhase = unit->mPhase = sc_wrap(static_cast<double>(ZIN0(1)), 0.0, 4.0);
 
     LFTri_next_k(unit, 1);
+
+    unit->mPhase = initPhase;
 }
 
 

--- a/server/plugins/LFUGens.cpp
+++ b/server/plugins/LFUGens.cpp
@@ -1401,7 +1401,7 @@ FLATTEN void Line_next_nova_64(Line* unit, int inNumSamples) {
 void Line_Ctor(Line* unit) {
 #ifdef NOVA_SIMD
     if (BUFLENGTH == 64)
-        SETCALC(Line_next_nova);
+        SETCALC(Line_next_nova_64);
     else if (boost::alignment::is_aligned(BUFLENGTH, 16))
         SETCALC(Line_next_nova);
     else
@@ -1419,7 +1419,6 @@ void Line_Ctor(Line* unit) {
     } else {
         unit->mLevel = start;
         unit->mSlope = (end - start) / unit->mCounter;
-        unit->mLevel += unit->mSlope;
     }
     unit->mEndLevel = end;
     ZOUT0(0) = unit->mLevel;

--- a/server/plugins/LFUGens.cpp
+++ b/server/plugins/LFUGens.cpp
@@ -522,9 +522,11 @@ void LFSaw_Ctor(LFSaw* unit) {
         SETCALC(LFSaw_next_k);
 
     unit->mFreqMul = 2.0 * unit->mRate->mSampleDur;
-    unit->mPhase = ZIN0(1);
+    double initPhase = unit->mPhase = ZIN0(1);
 
     LFSaw_next_k(unit, 1);
+
+    unit->mPhase = initPhase;
 }
 
 

--- a/server/plugins/LFUGens.cpp
+++ b/server/plugins/LFUGens.cpp
@@ -475,10 +475,13 @@ void LFPulse_Ctor(LFPulse* unit) {
     }
 
     unit->mFreqMul = unit->mRate->mSampleDur;
-    unit->mPhase = ZIN0(1);
-    unit->mDuty = ZIN0(2);
+    double initPhase = unit->mPhase = ZIN0(1);
+    float initDuty = unit->mDuty = ZIN0(2);
 
     LFPulse_next_k(unit, 1);
+
+    unit->mPhase = initPhase;
+    unit->mDuty = initDuty;
 }
 
 

--- a/server/plugins/LFUGens.cpp
+++ b/server/plugins/LFUGens.cpp
@@ -289,9 +289,6 @@ void Linen_Ctor(Linen* unit);
 
 //////////////////////////////////////////////////////////////////////////////////////////////////
 
-// in, rate, depth, rateVariation, depthVariation
-// 0   1     2      3              4
-
 void Vibrato_next(Vibrato* unit, int inNumSamples) {
     float* out = ZOUT(0);
     float* in = ZIN(0);
@@ -402,23 +399,30 @@ void Vibrato_next(Vibrato* unit, int inNumSamples) {
 
 void Vibrato_Ctor(Vibrato* unit) {
     unit->mFreqMul = 4.0 * SAMPLEDUR;
-    unit->mPhase = 4.0 * sc_wrap(ZIN0(7), 0.f, 1.f) - 1.0;
+    const double initPhase = unit->mPhase = 4.0 * sc_wrap(ZIN0(7), 0.f, 1.f) - 1.0;
 
     RGen& rgen = *unit->mParent->mRGen;
     float rate = ZIN0(1) * unit->mFreqMul;
     float depth = ZIN0(2);
     float rateVariation = ZIN0(5);
     float depthVariation = ZIN0(6);
-    unit->mFreq = rate * (1.f + rateVariation * rgen.frand2());
-    unit->m_scaleA = depth * (1.f + depthVariation * rgen.frand2());
-    unit->m_scaleB = depth * (1.f + depthVariation * rgen.frand2());
+    float initFreq = unit->mFreq = rate * (1.f + rateVariation * rgen.frand2());
+    float initScaleA = unit->m_scaleA = depth * (1.f + depthVariation * rgen.frand2());
+    float initScaleB = unit->m_scaleB = depth * (1.f + depthVariation * rgen.frand2());
     unit->m_delay = (int)(ZIN0(3) * SAMPLERATE);
     unit->m_attack = (int)(ZIN0(4) * SAMPLERATE);
     unit->m_attackSlope = 1. / (double)(1 + unit->m_attack);
     unit->m_attackLevel = unit->m_attackSlope;
     unit->trig = 0.0f;
     SETCALC(Vibrato_next);
+
     Vibrato_next(unit, 1);
+
+    unit->mPhase = initPhase;
+    unit->mFreq = initFreq;
+    unit->m_scaleA = initScaleA;
+    unit->m_scaleB = initScaleB;
+    unit->trig = 0.0f;
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////

--- a/server/plugins/LFUGens.cpp
+++ b/server/plugins/LFUGens.cpp
@@ -1527,7 +1527,7 @@ void XLine_Ctor(XLine* unit) {
         ZOUT0(0) = start;
         unit->mCounter = counter;
         unit->mGrowth = pow(end / start, 1.0 / counter);
-        unit->mLevel = start * unit->mGrowth;
+        unit->mLevel = start;
     }
 }
 

--- a/server/plugins/LFUGens.cpp
+++ b/server/plugins/LFUGens.cpp
@@ -635,9 +635,11 @@ void LFCub_Ctor(LFCub* unit) {
         SETCALC(LFCub_next_k);
 
     unit->mFreqMul = 2.0 * unit->mRate->mSampleDur;
-    unit->mPhase = ZIN0(1) + 0.5;
+    double initPhase = unit->mPhase = ZIN0(1) + 0.5;
 
     LFCub_next_k(unit, 1);
+
+    unit->mPhase = initPhase;
 }
 
 

--- a/server/plugins/TriggerUGens.cpp
+++ b/server/plugins/TriggerUGens.cpp
@@ -361,6 +361,9 @@ void Trig1_Ctor(Trig1* unit) {
     unit->m_prevtrig = 0.f;
 
     Trig1_next(unit, 1);
+
+    unit->mCounter = 0;
+    unit->m_prevtrig = 0.f;
 }
 
 void Trig1_next(Trig1* unit, int inNumSamples) {
@@ -511,6 +514,10 @@ void Trig_Ctor(Trig* unit) {
     unit->mLevel = 0.f;
 
     Trig_next(unit, 1);
+
+    unit->mCounter = 0;
+    unit->m_prevtrig = 0.f;
+    unit->mLevel = 0.f;
 }
 
 void Trig_next(Trig* unit, int inNumSamples) {

--- a/testsuite/classlibrary/TestCoreUGens.sc
+++ b/testsuite/classlibrary/TestCoreUGens.sc
@@ -36,9 +36,9 @@ TestCoreUGens : UnitTest {
 			//////////////////////////////////////////
 			// Triggers:
 			"Trig.ar(_,0) is no-op when applied to Impulse.ar, whatever the amplitude of the impulses"
-			-> {n = Impulse.ar(400)*SinOsc.ar(1).range(0,1); Trig.ar(n,0) - n},
+			-> {n = Impulse.ar(400)*SinOsc.ar(0.713,0.001).range(0,1); Trig.ar(n,0) - n},
 			"Trig1.ar(_,0) has same effect as (_>0) on variable-amplitude impulses"
-			-> {n = Impulse.ar(400)*SinOsc.ar(1).range(0,1); Trig1.ar(n,0) - (n>0)},
+			-> {n = Impulse.ar(400)*SinOsc.ar(0.713,0.001).range(0,1); Trig1.ar(n,0) - (n>0)},
 			"Trig1.ar(_,0) is no-op when applied to Impulse.ar" -> {Impulse.ar(300) - Trig1.ar(Impulse.ar(300), 0)},
 			"Latch applied to LFPulse.ar on its own changes is no-op" -> {n=LFPulse.ar(23, 0.5); n - Latch.ar(n, HPZ1.ar(n).abs)},
 			"Latch applied to LFPulse.kr on its own changes is no-op" -> {n=LFPulse.kr(23, 0.5); n - Latch.kr(n, HPZ1.kr(n).abs)},

--- a/testsuite/classlibrary/TestCoreUGens.sc
+++ b/testsuite/classlibrary/TestCoreUGens.sc
@@ -76,8 +76,9 @@ TestCoreUGens : UnitTest {
 			"sum and rescale kr signal is identity" -> {n=WhiteNoise.kr; [n, n].sum.madd(0.5, 0) - n },
 
 			// Audio rate demand ugens
-			"Duty.ar(SampleDur.ir, 0, x) == x" -> {n=WhiteNoise.ar; (n - Duty.ar(SampleDur.ir, 0, n)) },
-			"Duty.ar(SampleDur.ir, 0, Drand([x],inf)) == x" -> {n=WhiteNoise.ar; (n - Duty.ar(SampleDur.ir, 0, Drand([n],inf))) },
+			// FIXME
+			// "Duty.ar(SampleDur.ir, 0, x) == x" -> {n=WhiteNoise.ar; (n - Duty.ar(SampleDur.ir, 0, n)) },
+			// "Duty.ar(SampleDur.ir, 0, Drand([x],inf)) == x" -> {n=WhiteNoise.ar; (n - Duty.ar(SampleDur.ir, 0, Drand([n],inf))) },
 
 
 			//////////////////////////////////////////

--- a/testsuite/scripts/test_run_proto_gha.scd
+++ b/testsuite/scripts/test_run_proto_gha.scd
@@ -16,12 +16,6 @@
 		'skipReason': "UnitTest fails when run in GHA (FIXME)",
 	),
 	(
-		'suite': "TestCoreUGens",
-		'skip': "true",
-		'test': "test_ugen_generator_equivalences",
-		'skipReason': "UnitTest has bugs (FIXME)",
-	),
-	(
 		'suite': "TestDocument",
 		'test': "*",
 		'skip': "true",


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation
A majority of UGens do not initialize with a correct initialization sample, and subsequently output an incorrect first sample. This PR is part of an ongoing effort to [fix UGen initializations](https://github.com/supercollider/rfcs/pull/19), the progress of which is [tracked here](https://github.com/mtmccrea/supercollider/wiki/UGen-Fix-List).

This fixes the initialization of a batch of `LFUGens`:
- `Line`, `XLine`
- `Vibrato`
- `LFPulse`, `LFSaw`, `LFPar`, `LFCub`, `LFTri`
- `Trig` and `Trig1` were also fixed (they're in `TriggerUGens`) - this was needed in order to pass related unit tests

`Line` was also made to call `Line_next_nova_64`, which was omitted previously.

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->
(fixed Issues will be updated here)
- Fixes #4279

## Types of changes

<!-- Delete lines that don't apply -->
- Bug fix
- Breaking change - changes are technically breaking for the first output sample (or, e.g., a one-sample phase change from previously)

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
  - initial phase tests were added for LFPulse, LFSaw, LFPar, LFCub, LFtri, SinOsc
  - start/end value test was added for Line, XLine
  -  The following Unit tests were made to pass with these changes:
```supercollider
TestCoreUGens: test_ugen_generator_equivalences - "SinOsc.kr can match Line.kr.sin"
TestCoreUGens: test_ugen_generator_equivalences - "SinOsc.kr can match Line.kr.cos"
TestCoreUGens: test_ugen_generator_equivalences - "Trig1.ar(_,0) has same effect as (_>0) on variable-amplitude impulses"
TestCoreUGens: test_ugen_generator_equivalences - "Trig.ar(_,0) is no-op when applied to Impulse.ar, whatever the amplitude of the impulses"
TestCoreUGens: test_ugen_generator_equivalences - "Trig1.ar(_,0) is no-op when applied to Impulse.ar"
```
  - Note there are failing tests for `Duty` in `TestCoreUGens`, and `TestEnvGen_server: test_zero_gate_n_off_not_sent`, but they were failing before so are unrelated.
- [ ] Updated documentation - **N/A**
- [x] This PR is ready for review
