### PR TITLE
scsynth/supernova: fix thread priorities

### DIFF
--- a/server/scsynth/SC_ComPort.cpp
+++ b/server/scsynth/SC_ComPort.cpp
@@ -443,12 +443,10 @@ SC_TcpConnection::~SC_TcpConnection() { mParent->connectionDestroyed(); }
 //////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 static void asioFunction() {
+    /* NB: on macOS we just keep the default thread priority */
 #ifdef NOVA_TT_PRIORITY_RT
     std::pair<int, int> priorities = nova::thread_priority_interval_rt();
     nova::thread_set_priority_rt((priorities.first + priorities.second) / 2);
-#else
-    std::pair<int, int> priorities = nova::thread_priority_interval();
-    nova::thread_set_priority(priorities.second);
 #endif
 
     boost::asio::io_service::work work(ioService);

--- a/server/scsynth/SC_ComPort.cpp
+++ b/server/scsynth/SC_ComPort.cpp
@@ -445,8 +445,8 @@ SC_TcpConnection::~SC_TcpConnection() { mParent->connectionDestroyed(); }
 static void asioFunction() {
     /* NB: on macOS we just keep the default thread priority */
 #ifdef NOVA_TT_PRIORITY_RT
-    std::pair<int, int> priorities = nova::thread_priority_interval_rt();
-    nova::thread_set_priority_rt((priorities.first + priorities.second) / 2);
+    int priority = nova::thread_priority_interval_rt().first;
+    nova::thread_set_priority_rt(priority);
 #endif
 
     boost::asio::io_service::work work(ioService);

--- a/server/scsynth/SC_CoreAudio.cpp
+++ b/server/scsynth/SC_CoreAudio.cpp
@@ -107,13 +107,7 @@ static void syncOSCOffsetWithTimeOfDay() {
 }
 
 static void resyncThreadFunc() {
-#    ifdef NOVA_TT_PRIORITY_RT
-    std::pair<int, int> priorities = nova::thread_priority_interval_rt();
-    nova::thread_set_priority_rt((priorities.first + priorities.second) / 2);
-#    else
-    std::pair<int, int> priorities = nova::thread_priority_interval();
-    nova::thread_set_priority(priorities.second);
-#    endif
+    /* keep the default thread priority */
 
     while (true) {
         sleep(20);
@@ -345,12 +339,10 @@ SC_AudioDriver::~SC_AudioDriver() {
 }
 
 void SC_AudioDriver::RunThread() {
+    /* NB: on macOS we just keep the default thread priority */
 #ifdef NOVA_TT_PRIORITY_RT
     std::pair<int, int> priorities = nova::thread_priority_interval_rt();
     nova::thread_set_priority_rt((priorities.first + priorities.second) / 2);
-#else
-    std::pair<int, int> priorities = nova::thread_priority_interval();
-    nova::thread_set_priority(priorities.second);
 #endif
 
     TriggersFifo* trigfifo = &mWorld->hw->mTriggers;

--- a/server/scsynth/SC_CoreAudio.cpp
+++ b/server/scsynth/SC_CoreAudio.cpp
@@ -341,8 +341,8 @@ SC_AudioDriver::~SC_AudioDriver() {
 void SC_AudioDriver::RunThread() {
     /* NB: on macOS we just keep the default thread priority */
 #ifdef NOVA_TT_PRIORITY_RT
-    std::pair<int, int> priorities = nova::thread_priority_interval_rt();
-    nova::thread_set_priority_rt((priorities.first + priorities.second) / 2);
+    int priority = nova::thread_priority_interval_rt().first;
+    nova::thread_set_priority_rt(priority);
 #endif
 
     TriggersFifo* trigfifo = &mWorld->hw->mTriggers;

--- a/server/supernova/server/server.cpp
+++ b/server/supernova/server/server.cpp
@@ -292,12 +292,10 @@ void thread_init_functor::operator()(int thread_index) {
 }
 
 void io_thread_init_functor::operator()() const {
+    /* NB: on macOS we just keep the default thread priority */
 #ifdef NOVA_TT_PRIORITY_RT
     int priority = thread_priority_interval_rt().first;
     thread_set_priority_rt(priority);
-#else
-    int priority = thread_priority_interval().second;
-    thread_set_priority(priority);
 #endif
 
     name_thread("Network Send");

--- a/server/supernova/utilities/osc_server.hpp
+++ b/server/supernova/utilities/osc_server.hpp
@@ -49,6 +49,7 @@ class network_thread {
 public:
     void start_receive(void) {
         thread_ = std::thread([this] {
+        /* NB: on macOS we just keep the default thread priority */
 #ifdef NOVA_TT_PRIORITY_RT
             thread_set_priority_rt(thread_priority_interval_rt().first);
 #endif


### PR DESCRIPTION
On macOS, `nova::thread_priority_interval()` just returns dummy values (0), thus it would accidentally *lower* the thread priority. This can lead to particularly poor performance on recent Apple Silicon machines because the thread might get scheduled on efficiency cores. I removed any calls to `nova::thread_priority_interval`; instead we simply keep the default thread priority (for now).

On Windows, thread priorities are not a continuous range, so you cannot take the mean of the range return by `nova::thread_priority_interval_rt`. In fact, this would pass an invalid value to `SetThreadPriority` and essentially do nothing. Instead I simply use the lower value which effectively raises the thread priority a bit (`THREAD_PRIORITY_ABOVE_NORMAL`). This also matches the behavior of Supernova, see `io_thread_init_functor`: https://github.com/supercollider/supercollider/blob/ef627ce2c564fe323125234e4374c9c4b0fc7f1d/server/supernova/server/server.cpp#L294-L297

<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

Fixes https://github.com/supercollider/supercollider/issues/5948

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [ ] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review
