### PR TITLE
Topic/integer xrand xrand2 overflow

### DIFF
--- a/SCClassLibrary/Common/Math/Integer.sc
+++ b/SCClassLibrary/Common/Math/Integer.sc
@@ -19,11 +19,13 @@ Integer : SimpleNumber {
 		if ( res == exclude ) { res = this };
 		^res;
 	}
+
 	xrand2 { arg exclude=0;
 		var res = this.rand2;
 		if ( res == exclude ) { res = [this, this.neg].choose };
 		^res;
 	}
+
 	degreeToKey { arg scale, stepsPerOctave = 12;
 		^scale.performDegreeToKey(this, stepsPerOctave)
 	}

--- a/SCClassLibrary/Common/Math/Integer.sc
+++ b/SCClassLibrary/Common/Math/Integer.sc
@@ -15,12 +15,14 @@ Integer : SimpleNumber {
 	odd { ^this.bitAnd(1) == 1 }
 
 	xrand { arg exclude=0;
-		^(exclude + (this - 1).rand + 1) % this;
+		var res = this.rand;
+		if ( res == exclude ) { res = this };
+		^res;
 	}
 	xrand2 { arg exclude=0;
-		var res;
-		res = (2 * this).rand - this;
-		if (res == exclude, { ^this },{ ^res });
+		var res = this.rand2;
+		if ( res == exclude ) { res = [this, this.neg].choose };
+		^res;
 	}
 	degreeToKey { arg scale, stepsPerOctave = 12;
 		^scale.performDegreeToKey(this, stepsPerOctave)


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

Fixed bug in xrand/xrand2 methods to avoid integer overflow when using large integers. Example: 2147483647.xrand2 currently returns either 2147483647 or -2147483648 due to overflow. Adding 1 when calling .rand on an integer will result in the same integer overflow bug.

## Types of changes

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [ ] Code is tested
- [ ] All tests are passing
- [ ] Updated documentation
- [ ] This PR is ready for review
