### PR TITLE
fix asStringPrec method

### DIFF
--- a/lang/LangPrimSource/PyrPrimitive.cpp
+++ b/lang/LangPrimSource/PyrPrimitive.cpp
@@ -455,7 +455,7 @@ int prFloat_AsStringPrec(struct VMGlobals* g, int numArgsPushed) {
     if (precision >= 200)
         precision = 200; // Nothing is that big anyway. And we know we will be smaller than our 256 char string
 
-    sprintf(fmt, "%%.%dg", precision);
+    sprintf(fmt, "%%.%df", precision);
     sprintf(str, fmt, slotRawFloat(a));
 
     PyrString* string = newPyrString(g->gc, str, 0, true);


### PR DESCRIPTION
Related to issue #6048

@dyfer

This PR addresses a formatting issue with floating-point numbers. The existing code uses the` %.g format` specifier, which isn't quite what we need if we want to have fine control over the number of decimal places. The thing with %.g is that it switches between fixed-point or exponential notation based on which is shorter, and the precision value specifies the maximum number of significant digits, rather than just decimal places.

Let’s take an example. Before the change, formatting 17.1 with a precision of 1 turned it into scientific notation, like this:

```
17.1.asStringPrec(1) // -> 2e+01
11.0.asStringPrec(0) // -> 1e+01

```
With this PR's changes, the output is more intuitive (and is closer to the behavior prior to #4425):

```
17.1.asStringPrec(1) // -> 17.1
11.0.asStringPrec(0) // -> 11.0
```

Now, there's a catch. I noticed that, ideally, `11.0.asStringPrec(0) `should return 11 (without the .0), as was before and is presently on Linux. Although it's not a mirror of C++, we might want to discuss if mirroring C++ is essential or if this alternative makes more sense.

--

Also, I’d like to propose considering an alternative approach. Instead of:

```
sprintf(fmt, "%%.%df", precision);
sprintf(str, fmt, slotRawFloat(a));
```

We could use the safer `snprintf`:

`snprintf(str, sizeof(str), "%.*f", precision, slotRawFloat(a));`

Looking forward to your feedback and thoughts on this!

Cheers!
