### PR TITLE
Help: Amplitude's convergence time is really 20 dB

### DIFF
--- a/HelpSource/Classes/Amplitude.schelp
+++ b/HelpSource/Classes/Amplitude.schelp
@@ -13,10 +13,10 @@ argument::in
 Input signal
 
 argument::attackTime
-60dB convergence time for following attacks.
+20dB convergence time for following attacks.
 
 argument::releaseTime
-60dB convergence time for following decays.
+20dB convergence time for following decays.
 
 argument::mul
 


### PR DESCRIPTION
## Purpose and Motivation

Amplitude help claims that the convergence times are toward 60 dB.

But in the plugin source code, a 60 dB convergence coefficient is calculated as `exp(log001 / (decayTime * SAMPLERATE));` (see [Decay](https://github.com/supercollider/supercollider/blob/develop/server/plugins/FilterUGens.cpp#L1127)).

Amplitude uses `exp(log1 / (clampTime * SAMPLERATE));` ([line 3495](https://github.com/supercollider/supercollider/blob/develop/server/plugins/FilterUGens.cpp#L3495)) where log1 = std::log(0.1) (SC_Constants.h).

The first is calculated relative to 0.001 == -60 dB while the second is relative to 0.1 == -20 dB, so I conclude that the Amplitude convergence time is really 20 dB.

## Types of changes

- Documentation

## To-do list

- [ ] ~Code is tested~
- [ ] ~All tests are passing~
- [x] Updated documentation
- [x] This PR is ready for review
