### PR TITLE
testsuite: skip TestThreadReschedule in GHA

### DIFF
--- a/testsuite/scripts/test_run_proto_gha.scd
+++ b/testsuite/scripts/test_run_proto_gha.scd
@@ -94,6 +94,12 @@
 		'skip': "true",
 	),
 	(
+		'suite': "TestThreadReschedule",
+		'test': "test_Threads_rescheduleToOtherClock",
+		'skipReason': "UnitTest sometime fails when run in GHA on Linux (FIXME)",
+		'skip': "true",
+	),
+	(
 		'suite': "TestUGen_RTAlloc",
 		'test': "test_FFT",
 		'skip': "true",


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

The test `TestThreadReschedule:test_Threads_rescheduleToOtherClock` often fails on Linux when run in GHA, see e.g. [1](https://github.com/supercollider/supercollider/actions/runs/5844171201/job/15953568411#step:9:128), [2](https://github.com/supercollider/supercollider/actions/runs/5633446654/job/15262730723#step:9:128)

Since the failure seems to be hard to recreate (likely requiring heavy system load) and my lack of understanding of the thread mechanisms in SC, I'm not attempting to fix it at this time.

I propose to disable this test for now so that we have fewer CI failures unrelated to issues at hand.

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix (?)

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [ ] Code is tested
- [ ] All tests are passing
- ~~[ ] Updated documentation~~
- [ ] This PR is ready for review
