### PR TITLE
added defaultBranchName method to Git.sc

### DIFF
--- a/SCClassLibrary/Common/Quarks/GUI/QuarksGui.sc
+++ b/SCClassLibrary/Common/Quarks/GUI/QuarksGui.sc
@@ -475,7 +475,7 @@ QuarkDetailView {
 		if(tags.size == 0 or: {
 			remoteLatest != model.git.shaForTag(tags.first);
 		}, {
-			versions.add([remoteLatest, "Latest master"]);
+			versions.add([remoteLatest, "Latest default"]);
 		});
 
 		// working copy

--- a/SCClassLibrary/Common/Quarks/Git.sc
+++ b/SCClassLibrary/Common/Quarks/Git.sc
@@ -1,5 +1,5 @@
 Git {
-	var <>localPath, >url, tag, sha, remoteLatest, tags;
+	var <>localPath, >url, tag, sha, remoteLatest, defaultBranchName, tags;
 	classvar gitIsInstalled;
 
 	*isGit { |localPath|
@@ -17,7 +17,7 @@ Git {
 		this.url = url;
 	}
 	pull {
-		this.git(["pull", "origin", "master"])
+		this.git(["pull", "origin", this.defaultBranchName])
 	}
 	checkout { |refspec|
 		this.git(["checkout", refspec])
@@ -88,10 +88,16 @@ Git {
 			sha = this.git(["rev-parse HEAD"]);
 		}
 	}
+	defaultBranchName {
+		//find out what the remote default branch name is (ie master or main)
+		^defaultBranchName ?? {
+			defaultBranchName = this.git(["symbolic-ref refs/remotes/origin/HEAD --short"]).split($/)[1]
+		}
+	}
 	remoteLatest {
 		// find what the latest commit on the remote is
 		^remoteLatest ?? {
-			remoteLatest = this.git(["rev-parse origin/master"]);
+			remoteLatest = this.git(["rev-parse origin/" ++ this.defaultBranchName]);
 		}
 	}
 	tags {

--- a/SCClassLibrary/Common/Quarks/Git.sc
+++ b/SCClassLibrary/Common/Quarks/Git.sc
@@ -97,7 +97,7 @@ Git {
 	remoteLatest {
 		// find what the latest commit on the remote is
 		^remoteLatest ?? {
-			remoteLatest = this.git(["rev-parse origin/" ++ this.defaultBranchName]);
+			remoteLatest = this.git(["rev-parse origin" +/+ ( this.defaultBranchName ? "" )]);
 		}
 	}
 	tags {

--- a/SCClassLibrary/Common/Quarks/Git.sc
+++ b/SCClassLibrary/Common/Quarks/Git.sc
@@ -17,7 +17,7 @@ Git {
 		this.url = url;
 	}
 	pull {
-		this.git(["pull", "origin", this.defaultBranchName])
+		this.git(["pull", "origin", this.defaultBranchName ? ""])
 	}
 	checkout { |refspec|
 		this.git(["checkout", refspec])

--- a/SCClassLibrary/Common/Quarks/Quark.sc
+++ b/SCClassLibrary/Common/Quarks/Quark.sc
@@ -104,7 +104,7 @@ Quark {
 			this.runHook(\preUpdate);
 			git = Git(localPath);
 			git.pull();
-			git.checkout(git.defaultBranchName);
+			git.checkout(git.defaultBranchName ? "");
 			// force reload of data by resetting it to nil
 			data = nil;
 			this.runHook(\postUpdate);

--- a/SCClassLibrary/Common/Quarks/Quark.sc
+++ b/SCClassLibrary/Common/Quarks/Quark.sc
@@ -104,7 +104,7 @@ Quark {
 			this.runHook(\preUpdate);
 			git = Git(localPath);
 			git.pull();
-			git.checkout("master");
+			git.checkout(git.defaultBranchName);
 			// force reload of data by resetting it to nil
 			data = nil;
 			this.runHook(\postUpdate);


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation
currently "master" is hardcoded as the branch to checkout in Quark.update causing update to fail for Quarks using "main" (which has become a norm in recent years).

This adds a method which uses "git symbolic-ref refs/remotes/origin/HEAD --short
" to find out the appropriate name

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->
Fixes #6071  
Fixes #5096

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

If someone could test further it would be great! Its working for me so far.

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [ ] Code is tested
- [ ] All tests are passing
- [ ] Updated documentation
- [ ] This PR is ready for review
