### PR TITLE
making Synthdef work in many threads

### DIFF
--- a/SCClassLibrary/Common/Audio/BasicOpsUGen.sc
+++ b/SCClassLibrary/Common/Audio/BasicOpsUGen.sc
@@ -172,7 +172,7 @@ BinaryOpUGen : BasicOpUGen {
 
 		if (b.isKindOf(UnaryOpUGen) and: { b.operator == 'neg' and: { b.descendants.size == 1 } }) {
 			// a + b.neg -> a - b
-			buildSynthDef.removeUGen(b);
+			UGen.buildSynthDef.removeUGen(b);
 			replacement = a - b.inputs[0];
 			// this is the first time the dependants logic appears. It's repeated below.
 			// We will remove 'this' from the synthdef, and replace it with 'replacement'.
@@ -186,7 +186,7 @@ BinaryOpUGen : BasicOpUGen {
 
 		if (a.isKindOf(UnaryOpUGen) and: { a.operator == 'neg' and: { a.descendants.size == 1 } }) {
 			// a.neg + b -> b - a
-			buildSynthDef.removeUGen(a);
+			UGen.buildSynthDef.removeUGen(a);
 			replacement = b - a.inputs[0];
 			replacement.descendants = descendants;
 			this.optimizeUpdateDescendants(replacement, a);
@@ -204,14 +204,14 @@ BinaryOpUGen : BasicOpUGen {
 			and: { a.descendants.size == 1 }})
 		{
 			if (MulAdd.canBeMulAdd(a.inputs[0], a.inputs[1], b)) {
-				buildSynthDef.removeUGen(a);
+				UGen.buildSynthDef.removeUGen(a);
 				replacement = MulAdd.new(a.inputs[0], a.inputs[1], b).descendants_(descendants);
 				this.optimizeUpdateDescendants(replacement, a);
 				^replacement
 			};
 
 			if (MulAdd.canBeMulAdd(a.inputs[1], a.inputs[0], b)) {
-				buildSynthDef.removeUGen(a);
+				UGen.buildSynthDef.removeUGen(a);
 				replacement = MulAdd.new(a.inputs[1], a.inputs[0], b).descendants_(descendants);
 				this.optimizeUpdateDescendants(replacement, a);
 				^replacement
@@ -222,14 +222,14 @@ BinaryOpUGen : BasicOpUGen {
 			and: { b.descendants.size == 1 }})
 		{
 			if (MulAdd.canBeMulAdd(b.inputs[0], b.inputs[1], a)) {
-				buildSynthDef.removeUGen(b);
+				UGen.buildSynthDef.removeUGen(b);
 				replacement = MulAdd.new(b.inputs[0], b.inputs[1], a).descendants_(descendants);
 				this.optimizeUpdateDescendants(replacement, b);
 				^replacement
 			};
 
 			if (MulAdd.canBeMulAdd(b.inputs[1], b.inputs[0], a)) {
-				buildSynthDef.removeUGen(b);
+				UGen.buildSynthDef.removeUGen(b);
 				replacement = MulAdd.new(b.inputs[1], b.inputs[0], a).descendants_(descendants);
 				this.optimizeUpdateDescendants(replacement, b);
 				^replacement
@@ -245,7 +245,7 @@ BinaryOpUGen : BasicOpUGen {
 
 		if (a.isKindOf(BinaryOpUGen) and: { a.operator == '+'
 			and: { a.descendants.size == 1 }}) {
-			buildSynthDef.removeUGen(a);
+			UGen.buildSynthDef.removeUGen(a);
 			if(a === b) {
 				replacement = Sum4(a.inputs[0], a.inputs[0], a.inputs[1], a.inputs[1])
 				.descendants_(descendants);
@@ -258,7 +258,7 @@ BinaryOpUGen : BasicOpUGen {
 
 		if (b.isKindOf(BinaryOpUGen) and: { b.operator == '+'
 			and: { b.descendants.size == 1 }}) {
-			buildSynthDef.removeUGen(b);
+			UGen.buildSynthDef.removeUGen(b);
 			// we do not need the a === b check here
 			// if a === b, then the 'a' branch above must have handled it
 			replacement = Sum3(b.inputs[0], b.inputs[1], a).descendants_(descendants);
@@ -275,14 +275,14 @@ BinaryOpUGen : BasicOpUGen {
 		if(a.rate == \demand or: { b.rate == \demand }) { ^nil };
 
 		if (a.isKindOf(Sum3) and: { a.descendants.size == 1 }) {
-			buildSynthDef.removeUGen(a);
+			UGen.buildSynthDef.removeUGen(a);
 			replacement = Sum4(a.inputs[0], a.inputs[1], a.inputs[2], b).descendants_(descendants);
 			this.optimizeUpdateDescendants(replacement, a);
 			^replacement;
 		};
 
 		if (b.isKindOf(Sum3) and: { b.descendants.size == 1 }) {
-			buildSynthDef.removeUGen(b);
+			UGen.buildSynthDef.removeUGen(b);
 			replacement = Sum4(b.inputs[0], b.inputs[1], b.inputs[2], a).descendants_(descendants);
 			this.optimizeUpdateDescendants(replacement, b);
 			^replacement;
@@ -296,7 +296,7 @@ BinaryOpUGen : BasicOpUGen {
 
 		if (b.isKindOf(UnaryOpUGen) and: { b.operator == 'neg' and: { b.descendants.size == 1 } }) {
 			// a - b.neg -> a + b
-			buildSynthDef.removeUGen(b);
+			UGen.buildSynthDef.removeUGen(b);
 
 			replacement = BinaryOpUGen('+', a, b.inputs[0]);
 			replacement.descendants = descendants;
@@ -352,13 +352,13 @@ BinaryOpUGen : BasicOpUGen {
 			#aa, bb = a.inputs;
 			if (b.isKindOf(SimpleNumber)) {
 				if (aa.isKindOf(SimpleNumber)) {
-					buildSynthDef.removeUGen(a);
+					UGen.buildSynthDef.removeUGen(a);
 					this.inputs[0] = aa.perform(operator, b);
 					this.inputs[1] = bb;
 					^this
 				};
 				if (bb.isKindOf(SimpleNumber)) {
-					buildSynthDef.removeUGen(a);
+					UGen.buildSynthDef.removeUGen(a);
 					this.inputs[0] = bb.perform(operator, b);
 					this.inputs[1] = aa;
 					^this
@@ -379,13 +379,13 @@ BinaryOpUGen : BasicOpUGen {
 			#cc, dd = b.inputs;
 			if (a.isKindOf(SimpleNumber)) {
 				if (cc.isKindOf(SimpleNumber)) {
-					buildSynthDef.removeUGen(b);
+					UGen.buildSynthDef.removeUGen(b);
 					this.inputs[0] = a.perform(operator, cc);
 					this.inputs[1] = dd;
 					^this
 				};
 				if (dd.isKindOf(SimpleNumber)) {
-					buildSynthDef.removeUGen(b);
+					UGen.buildSynthDef.removeUGen(b);
 					this.inputs[0] = a.perform(operator, dd);
 					this.inputs[1] = cc;
 					^this

--- a/SCClassLibrary/Common/Audio/FFT.sc
+++ b/SCClassLibrary/Common/Audio/FFT.sc
@@ -3,7 +3,7 @@
 
 WidthFirstUGen : UGen {
 	addToSynth {
-		synthDef = buildSynthDef;
+		synthDef = UGen.buildSynthDef;
 		if (synthDef.notNil, {
 			synthDef.addUGen(this);
 			synthDef.widthFirstUGens = synthDef.widthFirstUGens.add(this);

--- a/SCClassLibrary/Common/Audio/FFTUnpacking.sc
+++ b/SCClassLibrary/Common/Audio/FFTUnpacking.sc
@@ -81,7 +81,7 @@ PV_ChainUGen : WidthFirstUGen {
 	addCopiesIfNeeded {
 		var directDescendants, frames, buf, copy;
 		// find UGens that have me as an input
-		directDescendants = buildSynthDef.children.select ({ |child|
+		directDescendants = UGen.buildSynthDef.children.select ({ |child|
 			var inputs;
 			child.isKindOf(PV_Copy).not and: { child.isKindOf(WidthFirstUGen) } and: {
 				inputs = child.inputs;
@@ -100,10 +100,10 @@ PV_ChainUGen : WidthFirstUGen {
 						copy = PV_Copy(this, buf);
 						copy.widthFirstAntecedents = widthFirstAntecedents ++ [buf];
 						desc.inputs[j] = copy;
-						buildSynthDef.children = buildSynthDef.children.drop(-3).insert(this.synthIndex + 1, frames);
-						buildSynthDef.children = buildSynthDef.children.insert(this.synthIndex + 2, buf);
-						buildSynthDef.children = buildSynthDef.children.insert(this.synthIndex + 3, copy);
-						buildSynthDef.indexUGens;
+						UGen.buildSynthDef.children = UGen.buildSynthDef.children.drop(-3).insert(this.synthIndex + 1, frames);
+						UGen.buildSynthDef.children = UGen.buildSynthDef.children.insert(this.synthIndex + 2, buf);
+						UGen.buildSynthDef.children = UGen.buildSynthDef.children.insert(this.synthIndex + 3, copy);
+						UGen.buildSynthDef.indexUGens;
 					});
 				});
 			});

--- a/SCClassLibrary/Common/Audio/UGen.sc
+++ b/SCClassLibrary/Common/Audio/UGen.sc
@@ -1,5 +1,4 @@
 UGen : AbstractFunction {
-	classvar <>buildSynthDef; // the synth currently under construction
 	var <>synthDef;
 	var <>inputs;
 	var <>rate = 'audio';
@@ -7,6 +6,8 @@ UGen : AbstractFunction {
 	var <>synthIndex = -1, <>specialIndex=0;
 
 	var <>antecedents, <>descendants, <>widthFirstAntecedents; // topo sorting
+
+    *buildSynthDef { ^SynthDef.getActiveSingleton }
 
 	// instance creation
 	*new1 { arg rate ... args;
@@ -305,7 +306,7 @@ UGen : AbstractFunction {
 	@ { arg y; ^Point.new(this, y) } // dynamic geometry support
 
 	addToSynth {
-		synthDef = buildSynthDef;
+		synthDef = UGen.buildSynthDef;
 		if (synthDef.notNil, { synthDef.addUGen(this) });
 	}
 
@@ -551,7 +552,7 @@ UGen : AbstractFunction {
 					a.optimizeGraph
 				}
 			};
-			buildSynthDef.removeUGen(this);
+			UGen.buildSynthDef.removeUGen(this);
 			^true;
 		};
 		^false
@@ -611,7 +612,7 @@ OutputProxy : UGen {
 		^super.new1(rate, itsSourceUGen, index)
 	}
 	addToSynth {
-		synthDef = buildSynthDef;
+		synthDef = UGen.buildSynthDef;
 	}
 	init { arg argSource, argIndex;
 		source = argSource;

--- a/SCClassLibrary/Common/Core/ThreadSingleton.sc
+++ b/SCClassLibrary/Common/Core/ThreadSingleton.sc
@@ -1,0 +1,81 @@
+/* Used to create a single instance of some class that is accessible from anywhere.
+ * This allows for different threads to each have their own instance, 
+ *   or use their parent's.
+ * Basic usage:
+ *    1. make a classvar containing a ThreadSingletonManager called threadSingletonManager
+ *      init in initClass - e.g. for class MyBuilder set `threadSingletonManager = ThreadSingletonManager(MyBuilder)`
+ *    2. inherit from ThreadSingletonInstance or ThreadSingletonNestable depending on whether the instances can be nested
+ *    3. call this.setActiveSingleton and this.removeActiveSingleton to push and pop the instance as the active
+ *    4. to let other classes access the active instance, create a classmethod returning `threadSingletonManager.getActive` in MyBuilder (for example)
+ *
+ *
+ * Basic example
+ *
+ * MyBuilder : ThreadSingletonInstance {
+ *   classvar threadSingletonManager;
+ *   *initClass { threadSingletonManager = ThreadSingletonManager(MyBuilder) }
+ *   *getActiveSingleton { ^threadSingletonManager.getActive }
+ *   with {|thingToDo|
+ *      this.setActiveSingleton; // push this as active
+ *      thingToDo.();
+ *      this.removeActiveSingleton // remove this as active
+ *   }
+ * }
+ */
+
+
+
+ErrorThreadSingletonManager : Error {}
+
+ThreadSingletonManager {
+    var classname;
+	var activePerThread;
+	*new { |class| ^super.newCopyArgs(class.name, IdentityDictionary()) }
+
+	setActive {|o| ^activePerThread[thisThread] = o }
+    removeActive {|instance| 
+        activePerThread.keysValuesDo{|k, v|
+            if(v === instance) {
+                ^activePerThread[k] = nil
+            }
+        };
+		ErrorThreadSingletonManager("Could not find instance").throw;
+    }
+
+    getActiveOwningThread {
+		var t = thisThread;
+		while {t.isNil.not} {
+			if(activePerThread[t].isNil.not){ ^t };
+			t = t.parent;
+		};
+		ErrorThreadSingletonManager("Could not find thread").throw;
+    }
+
+	getActive { ^activePerThread[this.getActiveOwningThread] }
+}
+
+ThreadSingletonInstance {
+	var threadSingletonManagerRef;
+	setActiveSingleton { ^threadSingletonManagerRef.setActive(this) }
+    removeActiveSingleton { ^threadSingletonManagerRef.removeActive(this) }
+	getActiveSingleton { ^threadSingletonManagerRef.getActive }
+}
+
+ThreadSingletonNestable : ThreadSingletonInstance {
+	var <maybeParent;
+	doWith { |func|
+		var old = this.getActiveSingleton;
+        this.setActiveSingleton(this);
+		func.();
+		threadSingletonManagerRef.setActive(old);
+		^this
+	}
+    // branch of family tree from root to this as tip
+	getLineage { 
+		var l = List();
+		var c = this;
+		while{c.isNil.not}{ l.append(c); c = c.maybeParent };
+		^l.reverse
+	}
+}
+


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

Go off the conversation around threads on scsynth....
If many things are promises or otherwise capable of waiting, it becomes necessary for synthdefs to work in multiple threads. 
Since synthdef is the most 'basic' and only way for a user or even Quark library writer to make a 'synth' (as it is tied into UGen.buildSynthDef) it ought to do the write thing.

Further, in my own work I often want to make owned resource as a part of the synthdef and synth creation process.
Since I have rewritten most of my code to make use of promises, not being able to define multiple synthdefs at a time is a big issue. This fixed that, and as far as I can tell, is the only way to fix it.

## Types of changes

- A couple of new classes to deal with thread local and thread hierarchy  singletons 
- Bug fix - synthdef doesn't work in threads
- Breaking change (small) - `buildSynthDef` -> `UGen.buildSynthDef`

There is one breaking change.
Code that once called the classvar `buildSynthDef` must now call `UGen.buildSynthDef`. Many classes already do this so there was only a few changes to make. 
This will require Quarks to change their code, but it is minimal and once done, works as before.
I think this is the smallest change that is needed to achieve the result. 

## To-do list

I have not done the documentation for this as I'm just curious to know if it might be accepted.

- [x] Code is tested
- [x] All tests are passing
- [ ] Updated documentation
- [ ] This PR is ready for review


Examples

This code works, clearly alternating between each synthdef whilst still producing the correct controls.
```supercollider
(
s.waitForBoot {
	fork {
		SynthDef(\a, {
			'doingA'.postln;
			\arg1.kr(1);
			1.0.wait;
			'doingA'.postln;
			\arg2.kr(2);
			SinOsc.ar(223, mul: 0.1) |> Out.ar(0, _)
		}).add;
	};

	fork {
		SynthDef(\b, {
			0.5.wait;
			'doingB'.postln;
			\argm1.kr(-1);
			1.0.wait;
			'doingB'.postln;
			\argm2.kr(-2);
			SinOsc.ar(432, mul: 0.1) |> Out.ar(1, _)
		}).add;
	};
}
)


SynthDescLib.at(\a)
SynthDescLib.at(\b)
```