### PR TITLE
Update UsingExtensions.schelp

### DIFF
--- a/HelpSource/Guides/UsingExtensions.schelp
+++ b/HelpSource/Guides/UsingExtensions.schelp
@@ -17,14 +17,16 @@ code::Platform.userExtensionDir:: and code::Platform.systemExtensionDir::.
 
 Typical user-specific extensions directories:
 table::
-## macOS     || ~/Library/Application Support/SuperCollider/Extensions/
+## macOS   || ~/Library/Application Support/SuperCollider/Extensions/
 ## Linux   || ~/.local/share/SuperCollider/Extensions/
+## Windows || %LOCALAPPDATA%/SuperCollider/Extensions/
 ::
 
 Typical system-wide extension directories:
 table::
-## macOS     || /Library/Application Support/SuperCollider/Extensions/
+## macOS   || /Library/Application Support/SuperCollider/Extensions/
 ## Linux   || /usr/share/SuperCollider/Extensions/
+## Windows || %PROGRAMDATA%/SuperCollider/Extensions/
 ::
 
 section:: How Extensions Folders Should be Organised


### PR DESCRIPTION
In the following two directories, Windows OS paths are excluded:
- Typical user-specific extensions directories
- Typical system-wide extensions directories

These two directories are added.

## Purpose and Motivation

to add missing information

## Types of changes

- Documentation
Added missing information

## To-do list

- [ ] Code is tested
- [ ] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review
