### PR TITLE
Classlib: Support multiple instruments in the default Event prototype

### DIFF
--- a/SCClassLibrary/Common/Control/asDefName.sc
+++ b/SCClassLibrary/Common/Control/asDefName.sc
@@ -23,6 +23,20 @@
 	asDefName { ^this }
 }
 
++ SequenceableCollection {
+	asDefName {
+		var out = Array(this.size);
+		this.do { |item|
+			if(item.respondsTo(\asDefName)) {
+				out.add(item.asDefName)
+			} {
+				Error("Invalid item in defname array" + item).throw;
+			};
+		};
+		^out
+	}
+}
+
 + Function {
 	/*
 		this is mainly for  {}.play and Synth({ })

--- a/SCClassLibrary/Common/Streams/Patterns.sc
+++ b/SCClassLibrary/Common/Streams/Patterns.sc
@@ -388,7 +388,7 @@ Pmono : Pattern {
 	var <>synthName, <>patternpairs;
 	*new { arg name ... pairs;
 		if (pairs.size.odd, { Error("Pmono should have odd number of args.\n").throw; });
-		^super.newCopyArgs(name.asSymbol, pairs)
+		^super.newCopyArgs(name, pairs)
 	}
 
 	embedInStream { | inevent |

--- a/SCClassLibrary/Common/Streams/PmonoStreams.sc
+++ b/SCClassLibrary/Common/Streams/PmonoStreams.sc
@@ -7,7 +7,7 @@ PmonoStream : Stream {
 		event,
 		streamout, name,
 		streampairs, endval,
-		msgFunc, hasGate, synthLib, desc, schedBundleArray, schedBundle;
+		synthLib, descs, schedBundleArray, schedBundle;
 
 	*new { |pattern|
 		^super.newCopyArgs(pattern)
@@ -41,16 +41,8 @@ PmonoStream : Stream {
 
 		event = inevent.copy;
 		event.use {
-			synthLib = ~synthLib ?? { SynthDescLib.global };
-			~synthDesc = desc = synthLib.match(pattern.synthName);
-			if (desc.notNil) {
-				~hasGate = hasGate = desc.hasGate;
-				~msgFunc = desc.msgFunc;
-			}{
-				~msgFunc = ~defaultMsgFunc;
-				~hasGate = hasGate = false;
-			};
-			msgFunc = ~msgFunc;
+			~instrument = pattern.synthName;
+			descs = ~getInstrumentDescs.();
 		}
 	}
 
@@ -68,11 +60,14 @@ PmonoStream : Stream {
 				if(event.isRest.not) {
 					~type = \monoNote;
 					~instrument = pattern.synthName;
+					~instrDescs = descs;
 					currentCleanupFunc = cleanup.addFunction(event, { | flag |
-						if (flag and: { id.notNil }) { (id: id, server: server, type: \off,
-							hasGate: hasGate,
-							schedBundleArray: schedBundleArray,
-							schedBundle: schedBundle).play
+						if (flag and: { id.notNil }) {
+							(id: id, server: server, type: \off,
+								instrDescs: descs,
+								schedBundleArray: schedBundleArray,
+								schedBundle: schedBundle
+							).play
 						};
 						currentCleanupFunc = nil;
 						id = nil;
@@ -109,7 +104,7 @@ PmonoStream : Stream {
 			~server = server;
 			~id = id;
 			~type = \monoSet;
-			~msgFunc= msgFunc;
+			~instrDescs = descs;
 		};
 	}
 }


### PR DESCRIPTION
## Purpose and Motivation

A recurring forum question is how to multichannel-expand `\instrument`.

This approach:

1. Introduces a data structure, instrumentDesc, which bundles instrument, synthLib, msgFunc and hasGate into an event. (Otherwise, instrument, msgFunc and hasGate have to be parallel arrays, which can be harder to manage.)

2. In `note`, `monoNote`, etc., populates an array of instrumentDescs.

3. Gets parameters from the event by union-ing the control names from each SynthDesc.

After that, the `flop` logic is mostly unchanged (except for filling in the potentially different synthdef names).

I double checked and I see that I didn't handle `\set` yet, and don't have time this morning. So this is WIP for now.

I did a quick review of other event types and I think it's probably not necessary to support this in every one. (E.g., `type: \Synth` looks like it has never supported multichannel expansion.) If reviewers find any other places, of course, register them here and I would update it.

## Types of changes

<!-- Delete lines that don't apply -->

- Documentation
- Bug fix
- New feature
- Breaking change

## To-do list

- [x] Code is tested (`\note` and Pmono have been tested)
- [x] All tests are passing
- [ ] Updated documentation
- [ ] This PR is ready for review
