### PR TITLE
docs: Add overview of pattern midi events

### DIFF
--- a/HelpSource/Overviews/MidiPatterns.schelp
+++ b/HelpSource/Overviews/MidiPatterns.schelp
@@ -1,0 +1,184 @@
+title:: How to control midi events using patterns
+categories:: Midi, Streams-Events-Patterns
+summary:: An overview of midi commands and how to use them with Pbind, etc.
+
+This document is a brief overview of some commonly used midi commands
+available in the midievent part of LINK::Classes/Event:: and which arguments
+they offer.
+
+To use them in a event pattern such as LINK::Classes/Pbind::, you need to first
+initialise a midi out device.
+
+CODE::
+
+// This posts a list of available midi devices
+// Note their names and bus names and use them in the next step
+MIDIClient.init;
+
+// Initialise a midi out using the name and bus name (see above)
+// As an example:
+m = MIDIOut.newByName("IAC Driver", "Bus 1");
+::
+
+In the examples below, it is assumed that you have initialised a midi out.
+
+NOTE::All midi numbers in SuperCollider are 0-indexed. That is, what on most
+devices is called "midi channel 1" is actually midi channel 0 in SuperCollider
+and vice-versa.::
+
+Now, to use it in a Pbind:
+
+CODE::
+p = Pbind(
+	// These keys are common to all midi commands
+    \type, \midi,
+    \midiout, m,
+    \midicmd, \noteOn, // Choose which command to use
+
+    \chan, 0,
+	// degree is converted to midinote, not just frequency
+    \degree, Pwhite(-7, 12, inf),
+    \dur, Pwrand([0.25, Pn(0.125, 2)], #[0.8, 0.2], inf),
+    \legato, sin(Ptime(inf) * 0.5).linexp(-1, 1, 1/3, 3),
+    \amp, Pexprand(0.5, 1.0, inf)
+).play(quant: 1);
+)
+
+p.stop;
+::
+
+SECTION:: \noteOn and \noteOff
+
+The most common midi commands are \noteOn and \noteOff. They are used to play
+notes. \noteOff is automatically transmitted after the note duration when you
+use the \noteOn command.
+
+CODE::
+p = Pbind(
+	// These keys are common to all midi commands
+    \type, \midi,
+    \midiout, m,
+    \midicmd, \noteOn, // Choose which command to use
+
+    \chan, 0,
+	// degree is converted to midinote, not just frequency
+    \degree, Pwhite(-7, 12, inf),
+    \dur, Pseq([1,2,0.5], inf),
+	// amp is converted to velocity
+    \amp, Pexprand(0.5, 1.0, inf)
+).play(quant: 1);
+)
+
+p.stop;
+::
+
+SECTION:: control change
+
+Send control change messages.
+
+CODE::
+p = Pbind(
+	// These keys are common to all midi commands
+    \type, \midi,
+    \midiout, m,
+    \midicmd, \control,
+
+    \chan, 0,
+	\ctlNum, 0, // cc number
+	\control, Pwhite(0, 127, inf), // cc value
+    \dur, Pseq([1,2,0.5], inf),
+
+).play(quant: 1);
+)
+
+p.stop;
+::
+
+SECTION:: \polyTouch
+
+CODE::
+p = Pbind(
+	// These keys are common to all midi commands
+	\type, \midi,
+	\midiout, m,
+	\midicmd, \polyTouch,
+
+	\chan, 0,
+	\midinote, Pwhite(0, 127, inf), // note number
+	\polyTouch, Pwhite(0, 127, inf), // pressure value
+	\dur, Pseq([1,2,0.5], inf),
+
+).play(quant: 1);
+)
+::
+
+SECTION:: \program
+
+CODE::
+p = Pbind(
+	// These keys are common to all midi commands
+	\type, \midi,
+	\midiout, m,
+	\midicmd, \program,
+
+	\chan, 0,
+	\progNum, Pwhite(0, 127, inf), // program number
+	\dur, Pseq([1,2,0.5], inf),
+
+).play(quant: 1);
+)
+::
+
+SECTION:: \touch
+
+Emit after touch messages.
+
+CODE::
+p = Pbind(
+	// These keys are common to all midi commands
+	\type, \midi,
+	\midiout, m,
+	\midicmd, \touch,
+
+	\chan, 0,
+	\touch, Pwhite(0, 127, inf), // pressure value
+	\dur, Pseq([1,2,0.5], inf),
+
+).play(quant: 1);
+)
+::
+
+SECTION:: \bend
+
+CODE::
+p = Pbind(
+	// These keys are common to all midi commands
+	\type, \midi,
+	\midiout, m,
+	\midicmd, \bend,
+
+	\chan, 0,
+	\bend, Pwhite(0, 8191, inf), // bend value
+	\dur, Pseq([1,2,0.5], inf),
+
+).play(quant: 1);
+)
+::
+
+SECTION:: \sysex
+
+Send a sysex message.
+
+CODE::
+p = Pbind(
+	// These keys are common to all midi commands
+	\type, \midi,
+	\midiout, m,
+	\midicmd, \sysex,
+
+	\sysex, Int8Array[0xF0, 0x7D, 0x00, 0x00, 0x04, 0x01, 0x60, 0x00, 0xF7], // sysex message
+	\dur, 8,
+
+).play(quant: 1);
+)
+::


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

This is a small PR that adds an overview file in the help system for midi commands. I generally found it very hard to figure out without having to dig into the Event.sc source code, so I figure someone else could use this :) 

## Types of changes

<!-- Delete lines that don't apply -->

- Documentation


