### PR TITLE
GHA macOS: Fix an issue with hardcoded bottle urls

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -304,7 +304,7 @@ jobs:
           # install universal versions of homebrew libraries
           if [[ "${{ matrix.cmake-architectures }}" != "x86_64" ]]; then
               echo "Downloading script for creating universal binaries from homebrew packages"
-              curl -O -J -L https://gist.githubusercontent.com/dyfer/6c83905d4593750105897e51e87ec345/raw/cb818038b9d0d2fce7b1697b95b671a110c28afa/brew-install-universal.sh
+              curl -O -J -L https://gist.githubusercontent.com/dyfer/6c83905d4593750105897e51e87ec345/raw/18f34a3def7dff91f34b30c17a4ccd50b4df264d/brew-install-universal.sh
               chmod +x brew-install-universal.sh
               if [[ "${{ matrix.build-libsndfile }}" != "true" ]]; then ./brew-install-universal.sh libsndfile; fi
               if [[ "${{ matrix.build-readline }}" != "true" ]]; then ./brew-install-universal.sh readline; fi


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->
Our main macOS universal build started to fail. 
FYI In the universal build we use [my script](https://gist.github.com/dyfer/6c83905d4593750105897e51e87ec345#file-brew-install-universal-sh) for creating "universal" (x86_64 + arm64) homebrew binaries.
The script recently stopped producing proper binaries, due to hardcoding homebrew bottles' urls. I [updated](https://gist.github.com/dyfer/6c83905d4593750105897e51e87ec345/revisions#diff-984e11579406a2aa02938c5257e95cbf5e850d5173b3a7e484211aa5189b5637L139) the script on my repo to extract the urls from `brew info` command instead.

This PR updates the version of the script in our CI to pull in this change.

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review
