### PR TITLE
classlib: Fix Event's handling of 'lag' for MIDI events

### DIFF
--- a/SCClassLibrary/Common/Collections/Event.sc
+++ b/SCClassLibrary/Common/Collections/Event.sc
@@ -811,13 +811,21 @@ Event : Environment {
 						bndl.do {|msgArgs, i|
 							var latency;
 
-							latency = i * strum + lag;
+							latency = i * strum;
 
-							if(latency == 0.0) {
-								midiout.performList(midicmd, msgArgs)
+							if(lag == 0.0) {
+								if(latency == 0.0) {
+									midiout.performList(midicmd, msgArgs)
+								} {
+									thisThread.clock.sched(latency, {
+										midiout.performList(midicmd, msgArgs);
+									})
+								}
 							} {
-								thisThread.clock.sched(latency, {
-									midiout.performList(midicmd, msgArgs);
+								SystemClock.sched(lag, {
+									thisThread.clock.sched(latency, {
+										midiout.performList(midicmd, msgArgs);
+									})
 								})
 							};
 							if(hasGate and: { midicmd === \noteOn }) {


### PR DESCRIPTION
## Purpose and Motivation

Event's `\lag` key is documented as being expressed in seconds, and it's defined in `schedBundleArrayOnClock` as seconds for server-messaging events.

The default event prototype's `midi` event type, however, treats it as beats.

This PR mimics the schedBundleArrayOnClock logic for MIDI sending.

Technically this is a breaking change, so we don't know how much existing user code will be affected. We might guess "not much," however, because the MIDI event type was [implemented in 2005](https://github.com/supercollider/supercollider/blame/a36edf848fe3fb7f38a41253528482730839637f/SCClassLibrary/Common/Collections/Event.sc#L756), not substantially changed since then, and nobody noticed the bug until 2023. I take this to suggest that `\lag` vs MIDI has not been widely used (plausibly, perhaps never used). I think it's worth changing.

I'd like some consensus to be reached on that before I spend time writing a unit test, though. (If the PR won't be merged then it's not a productive use of my time to write a formal test.)

## Types of changes

- Bug fix
- Breaking change

## To-do list

- [ ] Code is tested (not written a formal unit test yet; informal test passes)
- [ ] All tests are passing
- [ ] ~Updated documentation~ The change brings behavior in line with documentation, so no doc update needed
- [ ] This PR is ready for review
