### PR TITLE
Removed white space in brackets printed on the post window.

### DIFF
--- a/SCClassLibrary/Common/Collections/Array.sc
+++ b/SCClassLibrary/Common/Collections/Array.sc
@@ -290,15 +290,15 @@ Array[slot] : ArrayedCollection {
 
 	printOn { arg stream;
 		if (stream.atLimit, { ^this });
-		stream << "[ " ;
+		stream << "[" ;
 		this.printItemsOn(stream);
-		stream << " ]" ;
+		stream << "]" ;
 	}
 	storeOn { arg stream;
 		if (stream.atLimit, { ^this });
-		stream << "[ " ;
+		stream << "[" ;
 		this.storeItemsOn(stream);
-		stream << " ]" ;
+		stream << "]" ;
 	}
 	prUnarchive { arg slotArray;
 		slotArray.pairsDo {|index, slots| this[index].setSlots(slots) };

--- a/SCClassLibrary/Common/Collections/Array2D.sc
+++ b/SCClassLibrary/Common/Collections/Array2D.sc
@@ -47,11 +47,11 @@ Array2D : Collection {
 	// add { ^thisMethod.shouldNotImplement }
 	printOn { arg stream;
 		// not a compileable string
-		stream << this.class.name << "[ " ;
+		stream << this.class.name << "[" ;
 		this.rowsDo({ arg r;
 			r.printOn(stream);
 		});
-		stream << " ]" ;
+		stream << "]" ;
 	}
 	storeOn { arg stream;
 		var title;

--- a/SCClassLibrary/Common/Collections/Collection.sc
+++ b/SCClassLibrary/Common/Collections/Collection.sc
@@ -683,15 +683,15 @@ Collection {
 
 	printOn { | stream |
 		if (stream.atLimit) { ^this };
-		stream << this.class.name << "[ " ;
+		stream << this.class.name << "[" ;
 		this.printItemsOn(stream);
-		stream << " ]" ;
+		stream << "]" ;
 	}
 	storeOn { | stream |
 		if (stream.atLimit) { ^this };
-		stream << this.class.name << "[ " ;
+		stream << this.class.name << "[" ;
 		this.storeItemsOn(stream);
-		stream << " ]" ;
+		stream << "]" ;
 	}
 	storeItemsOn { | stream |
 		var addComma = false;

--- a/SCClassLibrary/Common/Collections/EnvironmentRedirect.sc
+++ b/SCClassLibrary/Common/Collections/EnvironmentRedirect.sc
@@ -163,9 +163,9 @@ EnvironmentRedirect {
 
 	printOn { | stream |
 		if (stream.atLimit) { ^this };
-		stream << this.class.name << "[ " ;
+		stream << this.class.name << "[" ;
 		envir.printItemsOn(stream);
-		stream << " ]" ;
+		stream << "]" ;
 	}
 
 	linkDoc { arg doc;

--- a/SCClassLibrary/Common/Collections/SparseArray.sc
+++ b/SCClassLibrary/Common/Collections/SparseArray.sc
@@ -430,9 +430,9 @@ SparseArray : Order {
 
 	storeOn { | stream |
 		if (stream.atLimit) { ^this };
-		stream << this.class.name << "[ " ;
+		stream << this.class.name << "[" ;
 		this.storeItemsOn(stream);
-		stream << " ]" ;
+		stream << "]" ;
 	}
 
 	// private implementation


### PR DESCRIPTION
This PR is a correct PR (based on my branch) of the following closed wrong PR (based on the develop branch):

https://github.com/supercollider/supercollider/pull/6105

## Purpose and Motivation

The post window output of the collection's subclasses does not follow the recommended code style.
This PR makes these post-window outputs follow the recommended code style, so that users can use the post-window output in new code without removing whitespace.

Please see the following scsynth forum thread:

https://scsynth.org/t/array-recommended-style-of-code-and-how-to-return-to-the-post-window/8310

## Types of changes

- minor but practical change
 
## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [ ] Updated documentation <- not required
- [x] This PR is ready for review
