### PR TITLE
GHA: update macOS runner image to macOS 12

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -196,8 +196,8 @@ jobs:
         include:
 
           - job-name: 'universal'
-            os-version: '11'
-            xcode-version: '12.4'
+            os-version: '12'
+            xcode-version: '13.4.1'
             deployment-target: '10.14'
             cmake-architectures: 'x86_64;arm64'
             use-syslibs: false
@@ -570,7 +570,7 @@ jobs:
         include:
 
           - name: macOS
-            runs-on: macos-11
+            runs-on: macos-12
             sclang: 'build/Install/SuperCollider/SuperCollider.app/Contents/MacOS/sclang'
             artifact-suffix: macOS-universal
             artifact-extension: '.dmg'

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ See the [Raspberry Pi](README_RASPBERRY_PI.md) and [BeagleBone Black](README_BEA
 
 SuperCollider is tested with:
 - Windows 10 (32- and 64-bit) and MSVC 2019
-- macOS 11 and Xcode 12.4
+- macOS 12 and Xcode 13.4.1
 - Ubuntu 22.04 and gcc 12
 
 SuperCollider is known to support these platforms:


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

macOS 11 is not officially supported by homebrew anymore. This means that binary packages for some formulae stopped being available and homebrew would build them locally. This is problematic for large packages like Qt5 - the last CI attempt [stopped after 6 hours](https://github.com/supercollider/supercollider/actions/runs/6444265220/job/17497064701#step:15:428), in the middle of building qtwebengine...

Please note that I did not change the legacy build, since 1) we are not using Qt5 from homebrew there and 2) it will likely go away when we move to Qt6. It still builds fine though!

EDIT: I also updated macOS and Xcode versions in`README.md`.

## Types of changes

<!-- Delete lines that don't apply -->


- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [ ] All tests are passing
- [ ] Updated documentation
- [x] This PR is ready for review
