### PR TITLE
Fixes for windows dev

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,14 @@ platform/mac/build
 CMakeLists.txt.user
 external_libraries/portaudio/asio*
 
+# Visual Studio
+.vs/**
+out/**
+CMakeSettings.json
+
+# CMake User Presets
+CMakeUserPresets.json
+
 # working files made by packager script
 common/Packager/LinuxExclusions.txt
 common/Packager/SuperCollider*.tar.gz

--- a/editors/sc-ide/CMakeLists.txt
+++ b/editors/sc-ide/CMakeLists.txt
@@ -277,16 +277,6 @@ if(APPLE)
     endforeach()
 endif()
 
-# This sets up the exe icon for windows.
-if(WIN32)
- set(RES_FILES ${CMAKE_SOURCE_DIR}/platform/windows/Resources/scide.rc)
- set(CMAKE_RC_COMPILER_INIT windres)
- ENABLE_LANGUAGE(RC)
- SET(CMAKE_RC_COMPILE_OBJECT
- "<CMAKE_RC_COMPILER> -O coff <DEFINES> -i <SOURCE> -o <OBJECT>")
-endif(WIN32)
-
-
 # final builds of the IDE seem to be broken atm
 if(0 AND FINAL_BUILD)
   CREATE_FINAL_FILE(scide_final.cpp ${ide_sources})
@@ -315,7 +305,14 @@ target_include_directories(libscide PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}/widgets/util
 )
 
-add_executable( SuperCollider MACOSX_BUNDLE core/main_function.cpp ${RES_FILES} ${AdditionalBundleSources} ${translations})
+add_executable( SuperCollider MACOSX_BUNDLE core/main_function.cpp ${AdditionalBundleSources} ${translations})
+
+if(WIN32)
+    target_sources(SuperCollider
+	PRIVATE
+		${CMAKE_SOURCE_DIR}/platform/windows/Resources/scide.rc
+	)
+endif()
 
 set_target_properties(libscide PROPERTIES PREFIX "")
 

--- a/lang/CMakeLists.txt
+++ b/lang/CMakeLists.txt
@@ -161,15 +161,6 @@ if(WIN32)
         list(APPEND sclang_sources LangPrimSource/SC_PortMidi.cpp)
 endif()
 
-# This sets up the exe icon for windows.
-if(WIN32)
- set(RES_FILES ${CMAKE_SOURCE_DIR}/platform/windows/Resources/sclang.rc)
- set(CMAKE_RC_COMPILER_INIT windres)
- ENABLE_LANGUAGE(RC)
- SET(CMAKE_RC_COMPILE_OBJECT
- "<CMAKE_RC_COMPILER> -O coff <DEFINES> -i <SOURCE> -o <OBJECT>")
-endif(WIN32)
-
 if(SC_HIDAPI)
     list(APPEND sclang_sources LangPrimSource/SC_HID_api.cpp)
     include_directories(
@@ -341,7 +332,15 @@ endif()
 
 target_link_libraries(libsclang ${YAMLCPP_LIBRARY})
 
-add_executable(sclang LangSource/cmdLineFuncs.cpp ${RES_FILES})
+add_executable(sclang LangSource/cmdLineFuncs.cpp)
+
+if(WIN32)
+    target_sources(sclang
+	PRIVATE
+	    ${CMAKE_SOURCE_DIR}/platform/windows/Resources/sclang.rc
+	)
+endif()
+
 target_link_libraries(sclang libsclang)
 target_link_libraries(sclang ${ICU_LIBRARIES})
 


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

Visual Studio has supported CMake projects for a while now, without the need to generate a VS project.

We fail to compile (at least in this mode) with VS2022 (possibly others, didn't check) due to the way we explicitly invoke the resource compiler (for setting things like the app icon etc) - which was now being called with invalid/deprecated args.

Adding the resource files (.rc) directly to the targets in question (sclang, scide), CMake will detect and invoke the resource compiler automatically for us, so we can simplify this quite a bit.

## Implementation

- Add extra ignores for Visual Studio when running in cmake mode
- Fix resource compilation by adding directly to target (CMake sorts it out for us, no need to explicitly call it)

## Types of changes
- Bug fix
## To-do list

- [ ] Code is tested
- [ ] All tests are passing
- [ ] Updated documentation
- [ ] This PR is ready for review
