### PR TITLE
GHA: checkout older readline from vcpkg

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -523,6 +523,9 @@ jobs:
         if: matrix.vcpkg-triplet
         shell: bash
         run: |
+          cd $VCPKG_INSTALLATION_ROOT
+          git fetch origin 80f8da23a88a982cf2d81d1a01623c55bb58df15
+          git checkout 80f8da23a88a982cf2d81d1a01623c55bb58df15 -- ports/readline*
           vcpkg install readline --triplet="${{ matrix.vcpkg-triplet }}" --overlay-triplets="$GITHUB_WORKSPACE/vcpkg/triplets"
       - name: configure
         shell: bash


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->
It seems that readline shared library got broken in vcpkg - https://github.com/microsoft/vcpkg/issues/34501

I propose to roll back the readline port version until this is fixed upstream and makes its way to GHA images.

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [ ] All tests are passing
- [ ] Updated documentation
- [x] This PR is ready for review
