### PR TITLE
classlib: remove whitespace from .storeOn .printOn

### DIFF
--- a/SCClassLibrary/Common/Collections/Event.sc
+++ b/SCClassLibrary/Common/Collections/Event.sc
@@ -126,28 +126,28 @@ Event : Environment {
 		var max, itemsPerLinem1, i=0;
 		itemsPerLinem1 = itemsPerLine - 1;
 		max = this.size;
-		stream << "( ";
+		stream << "(";
 		this.keysValuesDo({ arg key, val;
 			stream <<< key << ": " << val;
 			if ((i=i+1) < max, { stream.comma.space;
 				if (i % itemsPerLine == itemsPerLinem1, { stream.nl.space.space });
 			});
 		});
-		stream << " )";
+		stream << ")";
 	}
 
 	storeOn { arg stream, itemsPerLine = 5;
 		var max, itemsPerLinem1, i=0;
 		itemsPerLinem1 = itemsPerLine - 1;
 		max = this.size;
-		stream << "( ";
+		stream << "(";
 		this.keysValuesDo({ arg key, val;
 			stream <<< key << ": " <<< val;
 			if ((i=i+1) < max, { stream.comma.space;
 				if (i % itemsPerLine == itemsPerLinem1, { stream.nl.space.space });
 			});
 		});
-		stream << " )";
+		stream << ")";
 		if(proto.notNil) { stream << "\n.proto_(" <<< proto << ")" };
 		if(parent.notNil) { stream << "\n.parent_(" <<< parent << ")" };
 	}

--- a/SCClassLibrary/Common/Collections/SparseArray.sc
+++ b/SCClassLibrary/Common/Collections/SparseArray.sc
@@ -177,7 +177,7 @@ Order : SequenceableCollection {
 
 	storeOn { arg stream;
 		stream << this.class.name;
-		stream << ".newFromIndices( " <<<* [ array, indices ] << " )";
+		stream << ".newFromIndices(" <<<* [array, indices] << ")";
 	}
 }
 

--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -1345,7 +1345,7 @@ Server {
 			Server.default, { if(sync_s) { "s" } { "Server.default" } },
 			Server.local,	{ "Server.local" },
 			Server.internal, { "Server.internal" },
-			{ "Server.fromName(" + name.asCompileString + ")" }
+			{ "Server.fromName(" ++ name.asCompileString ++ ")" }
 		);
 		stream << codeStr;
 	}

--- a/SCClassLibrary/Common/Geometry/Point.sc
+++ b/SCClassLibrary/Common/Geometry/Point.sc
@@ -92,7 +92,7 @@ Point {
 	}
 
 	printOn { arg stream;
-		stream << this.class.name << "( " << x << ", " << y << " )";
+		stream << this.class.name << "(" << x << ", " << y << ")";
 	}
 	storeArgs { ^[x,y] }
 }

--- a/SCClassLibrary/Common/Math/Complex.sc
+++ b/SCClassLibrary/Common/Math/Complex.sc
@@ -162,6 +162,6 @@ Complex : Number {
 	asPoint { ^Point.new(this.real, this.imag) }
 
 	printOn { arg stream;
-		stream << "Complex( " << real << ", " << imag << " )";
+		stream << "Complex(" << real << ", " << imag << ")";
 	}
 }

--- a/SCClassLibrary/Common/Math/Polar.sc
+++ b/SCClassLibrary/Common/Math/Polar.sc
@@ -54,7 +54,7 @@ Polar : Number {
 	}
 
 	printOn { arg stream;
-		stream << "Polar( " << rho << ", " << theta << " )";
+		stream << "Polar(" << rho << ", " << theta << ")";
 	}
 	storeArgs { ^[rho,theta] }
 }

--- a/testsuite/classlibrary/TestNodeProxy.sc
+++ b/testsuite/classlibrary/TestNodeProxy.sc
@@ -50,14 +50,14 @@ TestNodeProxy : UnitTest {
 	}
 
 	test_asCode_basic {
-		var codeString = "a = NodeProxy.new(Server.fromName( 'TestNodeProxy' ));\n";
+		var codeString = "a = NodeProxy.new(Server.fromName('TestNodeProxy'));\n";
 
 		this.assertEquals(proxy.asCode, codeString,
 			"asCode-posting basic nodeproxy should post valid source code.");
 	}
 
 	test_asCode_single {
-		var codeString = "a = NodeProxy.new(Server.fromName( 'TestNodeProxy' )).source_({ DC.ar });\n";
+		var codeString = "a = NodeProxy.new(Server.fromName('TestNodeProxy')).source_({ DC.ar });\n";
 		proxy.source = { DC.ar };
 
 		this.assertEquals(proxy.asCode, codeString,
@@ -81,7 +81,7 @@ TestNodeProxy : UnitTest {
 	test_asCode_settings {
 		var codeString =
 		"(\n"
-		"a = NodeProxy.new(Server.fromName( 'TestNodeProxy' ));\n"
+		"a = NodeProxy.new(Server.fromName('TestNodeProxy'));\n"
 		"a.set('freq', 440);\n"
 		");\n";
 		proxy.set('freq', 440);
@@ -95,7 +95,7 @@ TestNodeProxy : UnitTest {
 	test_asCode_playState {
 		var codeString =
 		"(\n"
-		"a = NodeProxy.new(Server.fromName( 'TestNodeProxy' ));\n"
+		"a = NodeProxy.new(Server.fromName('TestNodeProxy'));\n"
 		"a.play(\n"
 		"	out: 8, \n"
 		"	vol: 0.25\n"


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->
Remove whitespace from .storeOn .printOn methods. A follow-up PR for #6106. 

Not thoroughly tested...
 
## Types of changes

<!-- Delete lines that don't apply -->

- Breaking change (technically)

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [ ] Code is tested
- [ ] All tests are passing
- [ ] Updated documentation
- [ ] This PR is ready for review
