### PR TITLE
GHA: update the brew-install-universal script

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -247,6 +247,7 @@ jobs:
       HOMEBREW_NO_ANALYTICS: 1
       HOMEBREW_NO_AUTO_UPDATE: 1
       HOMEBREW_NO_INSTALL_CLEANUP: 1
+      HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: 1
       USE_SYSLIBS: ${{ matrix.use-syslibs }}
       SHARED_LIBSCSYNTH: ${{ matrix.shared-libscsynth }}
       ARTIFACT_FILE: 'SuperCollider-${{ needs.lint.outputs.sc-version }}-${{ matrix.artifact-suffix }}.dmg'
@@ -304,7 +305,7 @@ jobs:
           # install universal versions of homebrew libraries
           if [[ "${{ matrix.cmake-architectures }}" != "x86_64" ]]; then
               echo "Downloading script for creating universal binaries from homebrew packages"
-              curl -O -J -L https://gist.githubusercontent.com/dyfer/6c83905d4593750105897e51e87ec345/raw/18f34a3def7dff91f34b30c17a4ccd50b4df264d/brew-install-universal.sh
+              curl -O -J -L https://gist.githubusercontent.com/dyfer/6c83905d4593750105897e51e87ec345/raw/1f89f2fe767a2e637387e74f0c8dcc86a0963f60/brew-install-universal.sh
               chmod +x brew-install-universal.sh
               if [[ "${{ matrix.build-libsndfile }}" != "true" ]]; then ./brew-install-universal.sh libsndfile; fi
               if [[ "${{ matrix.build-readline }}" != "true" ]]; then ./brew-install-universal.sh readline; fi


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

We use my [script](https://gist.github.com/dyfer/6c83905d4593750105897e51e87ec345#file-brew-install-universal-sh) to create "universal" (x86_64 + arm64) homebrew packages to facilitate macOS universal build.

A recent change in homebrew caused an issue with deploying some libraries with `macdeployqt` (see https://github.com/supercollider/supercollider/issues/6104). While we wait (I think?) for the updated libsndfile bottle in homebrew, I realized that I can "manually" change the non-fully qualified paths to full paths in the manually prepared bottles, since I am manipulating the paths already: https://gist.github.com/dyfer/6c83905d4593750105897e51e87ec345#file-brew-install-universal-sh-L226-L251

In this update, the script converts the non-fully qualified paths (@loader_path/.. etc) to fully qualified paths, to avoid problems with macdeployqt.

I also added the `HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK`, since some "universal" packages were being overwritten by the automatic update (i.e. the single architecture package would overwrite the one installed with a script).

With this update, we are getting back functional macOS builds in the CI.

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix (kind of)


## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [ ] Updated documentation
- [x] This PR is ready for review
