### PR TITLE
GHA macOS legacy: build fftw

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -219,6 +219,7 @@ jobs:
             shared-libscsynth: false
             build-libsndfile: true
             system-portaudio: false
+            build-fftw: true
             vcpkg-triplet: x64-osx-release-supercollider # required for build-libsndfile
             artifact-suffix: 'macOS-x64-legacy' # set if needed - will trigger artifact upload
 

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -210,8 +210,8 @@ jobs:
             verify-app: true
 
           - job-name: 'x64 legacy'
-            os-version: '11'
-            xcode-version: '12.4'
+            os-version: '12'
+            xcode-version: '13.4.1'
             qt-version: '5.9.9' # will use qt from aqtinstall
             deployment-target: '10.11'
             cmake-architectures: x86_64


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

While I acknowledge that it's unsure how much longer we'll be supporting the macOS legacy build, I'd like to make its impact on our GHA build times minimal.
Due to homebrew dropping support for macOS 11, some dependencies of fftw started to [build from source](https://github.com/supercollider/supercollider/actions/runs/6579631472/job/17881931695#step:9:115), increasing build times significantly. I'd like to switch fftw to build from vcpkg, which is faster, and is also cached.

EDIT: I decided to also change the runner image to macOS 12, since there seem to be other issues with using macOS 11.

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix (kind of)

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [ ] Updated documentation
- [x] This PR is ready for review
