### PR TITLE
[Windows] switch system calls to UTF-16

### DIFF
--- a/common/SC_Win32Utils.cpp
+++ b/common/SC_Win32Utils.cpp
@@ -52,14 +52,6 @@ void win32_ExtractContainingFolder(char* folder, const char* pattern, int maxCha
         folder[0] = 0;
 }
 
-void win32_GetKnownFolderPath(int folderId, char* dest, int size) {
-    // Use a temporary buffer, as SHGetFolderLocation() requires it
-    // to be at least MAX_PATH size, but destination size may be less
-    char buf[MAX_PATH];
-    SHGetFolderPath(NULL, folderId, NULL, 0, buf);
-    strncpy(dest, buf, size);
-}
-
 char* win32_basename(char* path) {
     int pathLen = strlen(path);
     int lastPathSepFoundPos = -1;

--- a/common/SC_Win32Utils.h
+++ b/common/SC_Win32Utils.h
@@ -56,7 +56,6 @@ typedef int pid_t;
 void win32_ReplaceCharInString(char* string, int len, char src, char dst);
 // Finds the parent folder of a specified path pattern (including trailing slash)
 void win32_ExtractContainingFolder(char* folder, const char* pattern, int maxChars);
-void win32_GetKnownFolderPath(int folderId, char* dest, int size);
 void win32_synctimes();
 char* win32_basename(char* path);
 char* win32_dirname(char* path);

--- a/editors/sc-ide/CMakeLists.txt
+++ b/editors/sc-ide/CMakeLists.txt
@@ -348,6 +348,7 @@ if(APPLE)
     target_link_libraries( libscide PUBLIC "-framework Cocoa" )
 elseif(WIN32)
     target_link_libraries( libscide PUBLIC wsock32 )
+    target_compile_definitions( libscide PUBLIC UNICODE _UNICODE)
     # The following prevents a Windows console from showing up
     # when the executable is started:
     set_target_properties( SuperCollider PROPERTIES WIN32_EXECUTABLE TRUE )

--- a/lang/CMakeLists.txt
+++ b/lang/CMakeLists.txt
@@ -370,6 +370,8 @@ elseif(WIN32)
         set_target_properties(sclang PROPERTIES RUNTIME_OUTPUT_DIRECTORY "$<CONFIG>")
     endif(NOT MSVC)
 
+    target_compile_definitions(sclang PUBLIC UNICODE _UNICODE)
+
     set(SC_WIN_DLL_DIRS)
     if(SNDFILE_LIBRARY_DIR)
       list(APPEND SC_WIN_DLL_DIRS "${SNDFILE_LIBRARY_DIR}")

--- a/server/scsynth/CMakeLists.txt
+++ b/server/scsynth/CMakeLists.txt
@@ -236,6 +236,7 @@ target_include_directories(libscsynth PUBLIC ${boost_include_dirs})
 
 if (WIN32)
 	target_link_libraries(libscsynth wsock32 ws2_32 winmm)
+	target_compile_definitions(libscsynth PUBLIC UNICODE _UNICODE)
 endif()
 
 if(NOT WIN32)

--- a/server/scsynth/SC_Lib_Cintf.cpp
+++ b/server/scsynth/SC_Lib_Cintf.cpp
@@ -38,6 +38,7 @@
 
 #ifdef _WIN32
 #    include "SC_Win32Utils.h"
+#    include "SC_Codecvt.hpp"
 #else
 #    include <dlfcn.h>
 #    include <libgen.h>
@@ -288,11 +289,12 @@ static bool PlugIn_Load(const bfs::path& filename) {
     // because the native encoding on Windows is utf-16.
     const std::string filename_utf8_str = SC_Codecvt::path_to_utf8_str(filename);
     if (!hinstance) {
-        char* s;
+        wchar_t* s;
         DWORD lastErr = GetLastError();
-        FormatMessage(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS, NULL,
-                      lastErr, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (char*)&s, 0, NULL);
-        scprintf("*** ERROR: LoadLibrary '%s' err '%s'\n", filename_utf8_str.c_str(), s);
+        FormatMessageW(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
+                       NULL, lastErr, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (wchar_t*)&s, 0, NULL);
+        scprintf("*** ERROR: LoadLibrary '%s' err '%s'\n", filename_utf8_str.c_str(),
+                 SC_Codecvt::utf16_wcstr_to_utf8_string(s).c_str());
         LocalFree(s);
         return false;
     }
@@ -311,10 +313,10 @@ static bool PlugIn_Load(const bfs::path& filename) {
 
     void* ptr = (void*)GetProcAddress(hinstance, "load");
     if (!ptr) {
-        char* s;
-        FormatMessage(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS, NULL,
-                      GetLastError(), MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (char*)&s, 0, NULL);
-        scprintf("*** ERROR: GetProcAddress err '%s'\n", s);
+        wchar_t* s;
+        FormatMessageW(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
+                       NULL, GetLastError(), MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (wchar_t*)&s, 0, NULL);
+        scprintf("*** ERROR: GetProcAddress err '%s'\n", SC_Codecvt::utf16_wcstr_to_utf8_string(s).c_str());
         LocalFree(s);
 
         FreeLibrary(hinstance);

--- a/server/supernova/CMakeLists.txt
+++ b/server/supernova/CMakeLists.txt
@@ -207,6 +207,7 @@ endif()
 
 if(WIN32)
     target_link_libraries(libsupernova wsock32 ws2_32 winmm)
+    target_compile_definitions(libsupernova PUBLIC UNICODE _UNICODE)
 endif()
 
 

--- a/server/supernova/sc/sc_ugen_factory.cpp
+++ b/server/supernova/sc/sc_ugen_factory.cpp
@@ -23,6 +23,7 @@
 #    include <dlfcn.h>
 #elif defined(_WIN32)
 #    include "SC_Win32Utils.h"
+#    include "SC_Codecvt.hpp"
 #endif
 
 #include <boost/filesystem.hpp>
@@ -313,14 +314,14 @@ void sc_ugen_factory::load_plugin(boost::filesystem::path const& path) {
 
     // std::cout << "try open plugin: " << path << std::endl;
     const char* filename = path.string().c_str();
-    HINSTANCE hinstance = LoadLibrary(path.string().c_str());
+    HINSTANCE hinstance = LoadLibraryW(path.wstring().c_str());
     if (!hinstance) {
-        char* s;
+        wchar_t* s;
         DWORD lastErr = GetLastError();
-        FormatMessage(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
-                      nullptr, lastErr, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (char*)&s, 0, NULL);
+        FormatMessageW(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
+                       nullptr, lastErr, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (wchar_t*)&s, 0, NULL);
 
-        std::cout << "Cannot open plugin: " << path << s << std::endl;
+        std::cout << "Cannot open plugin: " << path << SC_Codecvt::utf16_wcstr_to_utf8_string(s).c_str() << std::endl;
         LocalFree(s);
         return;
     }
@@ -347,11 +348,11 @@ void sc_ugen_factory::load_plugin(boost::filesystem::path const& path) {
 
     void* ptr = (void*)GetProcAddress(hinstance, "load");
     if (!ptr) {
-        char* s;
-        FormatMessage(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
-                      nullptr, GetLastError(), MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (char*)&s, 0, NULL);
+        wchar_t* s;
+        FormatMessageW(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
+                       nullptr, GetLastError(), MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (wchar_t*)&s, 0, NULL);
 
-        std::cout << "*** ERROR: GetProcAddress err " << s << std::endl;
+        std::cout << "*** ERROR: GetProcAddress err " << SC_Codecvt::utf16_wcstr_to_utf8_string(s).c_str() << std::endl;
         LocalFree(s);
 
         FreeLibrary(hinstance);


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

On Windows it seems that for the Qt6 build we need to be building with the `UNICODE` flag set, and in turn make system calls using UTF-16 (WideChar) functions and convert the strings to/from UTF-8 as needed. This PR includes only the UTF-16 changes so that it can be reviewed separately from the rest of the Qt6 update (which is still WIP). Another improvement is that it's now possible to use any allowed unicode characters for environment variables on Windows.

EDIT:
This is updated after env variable interface was redone with `std::string`: #6216.

This PR is now using the [codecvt](https://github.com/supercollider/supercollider/blob/develop/common/SC_Codecvt.hpp#L60-L69) functions that already existed in the codebase, instead of adding more helper functions.

I removed unused function `win32_GetKnownFolderPath` along the way.

Outdated comments hidden below:
<details>

Please review carefully, in particular in terms of memory management, as I don't have much experience in this area.

EDIT: 
After consulting with @jrsurge , I've set up wrapper functions to handle the conversion and used `unique_ptr` to help managing the memory.

Please note: I've snuck in one semi-related change into this PR - I increased the hardcoded maximum size for the value of an environment variable. The previous max was 1024 and on my Windows system `PATH` was already ~1500 characters long, so I couldn't fully set it from SC if I wanted to. I increased the max size to 32767, which seems to be the [maximum size on Windows](https://learn.microsoft.com/en-us/windows/win32/procthread/environment-variables?redirectedfrom=MSDN#:~:text=The%20maximum%20size%20of%20a%20user%2Ddefined%20environment%20variable%20is%2032%2C767%20characters.). On POSIX the maximum size appears to be [larger](https://man7.org/linux/man-pages/man2/execve.2.html#:~:text=Limits%20on%20size%20of%20arguments%20and%20environment), so I think the Windows's max is a reasonable choice.

</details>

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review
