### PR TITLE
Update SCDocSyntax.schelp

### DIFF
--- a/HelpSource/Reference/SCDocSyntax.schelp
+++ b/HelpSource/Reference/SCDocSyntax.schelp
@@ -380,7 +380,7 @@ sectiontag        ::= "CLASSMETHODS::"
 optsections       ::= [ sections ]
 sections          ::= sections section
                     | section
-                    | subsubsections
+                    | subsections
 section           ::= ( "SECTION::" words2 eol | sectiontag ) optsubsections
 optsubsections    ::= [ subsections ]
 subsections       ::= subsections subsection


### PR DESCRIPTION
subsubsections in line 383 seem to be a typo. I think it should be subsections

<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation
Helping readers understand the documentation
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->

- Documentation

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [ ] Code is tested
- [ ] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review

Close it if I am wrong!
