### PR TITLE
classlib: IDE Document should set path before autorun

### DIFF
--- a/SCClassLibrary/scide_scqt/ScIDE.sc
+++ b/SCClassLibrary/scide_scqt/ScIDE.sc
@@ -347,7 +347,7 @@ ScIDE {
 	*close {|quuid|
 		this.send(\closeDocument, [quuid]);
 	}
-	
+
 	*save {|quuid, docPath|
 		this.send(\saveDocument, [quuid, docPath]);
 	}
@@ -761,11 +761,17 @@ Document {
 	}
 
 	prAdd {
+		var savePath;
 		allDocuments = allDocuments.add(this);
 		if (autoRun) {
-			if (this.rangeText(0,7) == "/*RUN*/")
-			{
-				this.text.interpret;
+			if (this.rangeText(0,7) == "/*RUN*/") {
+				savePath = thisProcess.nowExecutingPath;
+				protect {
+					thisProcess.nowExecutingPath = path;
+					this.text.interpret;
+				} {
+					thisProcess.nowExecutingPath = savePath;
+				}
 			}
 		};
 		initAction.value(this);


### PR DESCRIPTION
## Purpose and Motivation

When opening a `/*RUN*/` auto-run file, `thisProcess.nowExecutingPath` is not set so the code in the document can't resolve paths relative to its own location.

E.g. if I have `~/test.scd`:

```
/*RUN*/
thisProcess.nowExecutingPath.debug("path");
```

... and open it, I should get `path: /home/xxx/test.scd` in the post window. Without the fix, it's `path: nil`.

Easy fix.

## Types of changes

- Bug fix

## To-do list

- [x] Code is tested
- [x] All tests are passing
- ~[ ] Updated documentation~
- [x] This PR is ready for review
