### PR TITLE
GHA Windows: enable multithreaded builds for MSVC

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -539,9 +539,7 @@ jobs:
       - name: build
         shell: bash
         run: |
-          BUILD_PARALLELISM=
-          if [[ ${{ startsWith(matrix.cmake-generator, 'MinGW') }} == true ]]; then BUILD_PARALLELISM="-- -j2"; fi
-          cmake --build $BUILD_PATH --config Release --target install $BUILD_PARALLELISM
+          cmake --build $BUILD_PATH --config Release --target install --parallel 2
       - name: create archive
         if: matrix.artifact-suffix
         shell: bash


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

It [seems](https://gitlab.kitware.com/cmake/cmake/-/merge_requests/7926) that building parallelism is now available with cmake + msvc. In that case, let's set the parallelism to the number of cores of the gha runner for msvc.

## Types of changes

<!-- Delete lines that don't apply -->

- New feature (?)

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [ ] All tests are passing
- [ ] Updated documentation
- [ ] This PR is ready for review
