### PR TITLE
registerUnit: make sure that the UGen class is not polymorphic

### DIFF
--- a/include/plugin_interface/SC_PlugIn.hpp
+++ b/include/plugin_interface/SC_PlugIn.hpp
@@ -245,6 +245,7 @@ template <class UGenClass> void destroyClass(Unit* unit) { static_cast<UGenClass
 }
 
 template <class Unit> void registerUnit(InterfaceTable* ft, const char* name, bool disableBufferAliasing = false) {
+    static_assert(!std::is_polymorphic<Unit>::value, "UGen class must not contain virtual functions!");
     UnitCtorFunc ctor = detail::constructClass<Unit>;
     UnitDtorFunc dtor = std::is_trivially_destructible<Unit>::value ? nullptr : detail::destroyClass<Unit>;
 


### PR DESCRIPTION
## Purpose and Motivation

Quoting myself from a recent Discord discussion:

> Late to the party, but I have run into this issue before! The problem is the following:

> Any instance of a class with virtual functions will start with its vtable pointer(s). With single inheritance, a derived class replaces the vtable pointer of its bass class. (With multiple inheritance its a bit more complicated.)

> Now, if the base class has no vtable (i.e. no virtual functions), the derived class will put the vtable pointer before the data members of the bass class. This means that the derived class has a different data layout than the base class! static_cast would fix up the pointers when casting between the two classes. Scsynth, however, does not obtain a Unit * via a static_cast from TestDummy * - after all, it does not even know that TestDummy exists -, it just assumes that all Ugens start with the data members of  Unit. In your case, scsynth accidentally passes a "wrong" Unit pointer to the constructor function, which in turn will access the wrong data members and crash.

> For the same reason, SCUnit does not have a virtual destructor, as it must not contain any virtual functions!

> The conclusion is: if your subclass contains virtual functions, so should the base class! You can break this rule (I sometimes do), but you need to be very aware of the consequences.

> Actually, registerUnit could check at compile time that the class does not contain virtual functions with std::is_polymorphic https://en.cppreference.com/w/cpp/types/is_polymorphic. I've put this on my to-do list!


## Types of changes

Static assertion

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] This PR is ready for review
