### PR TITLE
Add `localIP`, `localEndPoint` and `localIPs` class methods to NetAddr

### DIFF
--- a/HelpSource/Classes/NetAddr.schelp
+++ b/HelpSource/Classes/NetAddr.schelp
@@ -47,8 +47,21 @@ close all TCP connections.
 method::broadcastFlag
 Get or set the broadcast flag (whether or not broadcast messages can be sent).
 
+method::localIPs
+Get all local IP addresses (NICs) on this computer.
+
+argument::family
+A Symbol that specifies the desired address family.
+table::
+## code::all:: || all addresses
+## code::ipv4:: || only IPv4 addresses
+## code::ipv6:: || only IPv6 addresses
+::
+
+returns::An link::Classes/Array:: containing all local IP addresses of the desired family.
+
 method::matchLangIP
-Test an IP address to see if it matches that of one of the NICs on this computer.
+Test an IP address to see if it matches any local IP address. See also link::#*localIPs::.
 
 argument::ipstring
 A link::Classes/String:: to test containing an IP number in dot decimal notation (e.g. "192.168.34.56").

--- a/HelpSource/Classes/NetAddr.schelp
+++ b/HelpSource/Classes/NetAddr.schelp
@@ -23,6 +23,21 @@ create new net address using an integer IP number.
 method::langPort
 Get the port sclang is currently listening on (may change after a recompile).
 
+method::localIP
+Get the local IP address as a String.
+
+argument::network
+An optional IP string to select a particular network. This might be necessary if your machine is connected to multiple networks. Typically, you would use the IP address of the router, but it can really be any address within the network.
+
+method::localEndPoint
+Get a NetAddr with the local IP address and a user provided port number.
+
+argument::port
+The port number. If omitted, the sclang port is used.
+
+argument::network
+An optional IP string to select a particular network. See also link::#*localIP::.
+
 method::localAddr
 Get a NetAddr which corresponds to localhost and the port sclang is listening on.
 

--- a/SCClassLibrary/Common/Control/NetAddr.sc
+++ b/SCClassLibrary/Common/Control/NetAddr.sc
@@ -26,8 +26,13 @@ NetAddr {
 		^this.primitiveFailed;
 	}
 
-	*localEndPoint {
-		^this.new(this.langIP, this.langPort)
+	*localIP { arg network;
+		_LocalIP
+		^this.primitiveFailed;
+	}
+
+	*localEndPoint { arg port, network;
+		^this.new(this.localIP(network), port ?? { this.langPort })
 	}
 
 	*localAddr {
@@ -56,7 +61,7 @@ NetAddr {
 			}
 		}
 	}
-	
+
 	*connections {
 		^connections.copy;
 	}

--- a/SCClassLibrary/Common/Control/NetAddr.sc
+++ b/SCClassLibrary/Common/Control/NetAddr.sc
@@ -22,12 +22,17 @@ NetAddr {
 	}
 
 	*matchLangIP {|ipstring|
-		_MatchLangIP
-		^this.primitiveFailed;
+		ipstring = ipstring.asString;
+		^this.localIPs.includesEqual(ipstring);
 	}
 
 	*localIP { arg network;
 		_LocalIP
+		^this.primitiveFailed;
+	}
+
+	*localIPs { arg family = \all;
+		_LocalIPs
 		^this.primitiveFailed;
 	}
 

--- a/lang/LangPrimSource/OSCData.cpp
+++ b/lang/LangPrimSource/OSCData.cpp
@@ -71,7 +71,7 @@ std::unique_ptr<InPort::UDP> gUDPport {};
 
 PyrString* newPyrString(VMGlobals* g, char* s, int flags, bool runGC);
 
-PyrSymbol *s_call, *s_write, *s_recvoscmsg, *s_recvoscbndl, *s_netaddr, *s_recvrawmsg;
+PyrSymbol *s_call, *s_write, *s_recvoscmsg, *s_recvoscbndl, *s_netaddr, *s_recvrawmsg, *s_ipv4, *s_ipv6, *s_all;
 extern bool compiledOK;
 
 std::vector<std::unique_ptr<InPort::UDPCustom>> gCustomUdpPorts;
@@ -996,8 +996,7 @@ static int prGetHostByName(VMGlobals* g, int numArgsPushed) {
 #endif
 }
 
-int prGetLangPort(VMGlobals* g, int numArgsPushed);
-int prGetLangPort(VMGlobals* g, int numArgsPushed) {
+static int prGetLangPort(VMGlobals* g, int numArgsPushed) {
     PyrSlot* a = g->sp;
     if (!gUDPport)
         return errFailed;
@@ -1005,85 +1004,122 @@ int prGetLangPort(VMGlobals* g, int numArgsPushed) {
     return errNone;
 }
 
-int prMatchLangIP(VMGlobals* g, int numArgsPushed);
-int prMatchLangIP(VMGlobals* g, int numArgsPushed) {
-    PyrSlot* argString = g->sp;
-    char ipstring[40];
-    int err = slotStrVal(argString, ipstring, 39);
-    if (err)
-        return err;
-
-    std::string loopback("127.0.0.1");
-    // check for loopback address
-    if (!loopback.compare(ipstring)) {
-        SetTrue(g->sp - 1);
-        return errNone;
+static int prLocalIPs(VMGlobals* g, int numArgsPushed) {
+    PyrSlot* a = g->sp;
+    int addressFamily = AF_UNSPEC; // IPv4 + IPv6
+    if (IsSym(a)) {
+        PyrSymbol* sym = slotRawSymbol(a);
+        if (sym == s_ipv4) {
+            addressFamily = AF_INET;
+        } else if (sym == s_ipv6) {
+            addressFamily = AF_INET6;
+        } else if (sym != s_all) {
+            error("ignoring unknown option %s\n", sym->name);
+        }
+    } else if (NotNil(a)) {
+        return errWrongType;
     }
 
 #ifdef _WIN32
 
-    DWORD rv, size = 0;
-    PIP_ADAPTER_ADDRESSES adapter_addresses, aa;
-    PIP_ADAPTER_UNICAST_ADDRESS ua;
-
     // first get the size of the required buffer
-    rv = GetAdaptersAddresses(AF_UNSPEC, GAA_FLAG_INCLUDE_PREFIX, NULL, NULL, &size);
+    ULONG size = 0;
+    auto rv = GetAdaptersAddresses(AF_UNSPEC, GAA_FLAG_INCLUDE_PREFIX, NULL, NULL, &size);
     if (rv != ERROR_BUFFER_OVERFLOW) {
-        error("GetAdaptersAddresses() failed...");
+        error("GetAdaptersAddresses() failed.\n");
         return errFailed;
     }
+
     // now allocate a buffer for the linked list
-    adapter_addresses = (PIP_ADAPTER_ADDRESSES)malloc(size);
-
-    rv = GetAdaptersAddresses(AF_UNSPEC, GAA_FLAG_INCLUDE_PREFIX, NULL, adapter_addresses, &size);
+    PIP_ADAPTER_ADDRESSES adapterAddresses = (PIP_ADAPTER_ADDRESSES)malloc(size);
+    rv = GetAdaptersAddresses(AF_UNSPEC, GAA_FLAG_INCLUDE_PREFIX, NULL, adapterAddresses, &size);
     if (rv != ERROR_SUCCESS) {
-        error("GetAdaptersAddresses() failed...");
-        free(adapter_addresses);
+        error("GetAdaptersAddresses() failed.\n");
+        free(adapterAddresses);
         return errFailed;
     }
 
-    for (aa = adapter_addresses; aa != NULL; aa = aa->Next) {
-        for (ua = aa->FirstUnicastAddress; ua != NULL; ua = ua->Next) {
-            char buf[40];
-            memset(buf, 0, sizeof(buf));
-            getnameinfo(ua->Address.lpSockaddr, ua->Address.iSockaddrLength, buf, sizeof(buf), NULL, 0, NI_NUMERICHOST);
-            if (strcmp(ipstring, buf) == 0) {
-                SetTrue(g->sp - 1);
-                free(adapter_addresses);
-                return errNone;
-            }
-        }
-    }
-
-    free(adapter_addresses);
-
-#else
-
-    struct ifaddrs *ifap, *ifa;
-    if (getifaddrs(&ifap) != 0) {
-        error(strerror(errno));
-        return errFailed;
-    }
-
-    for (ifa = ifap; ifa; ifa = ifa->ifa_next) {
-        if (ifa->ifa_addr) {
-            int family = ifa->ifa_addr->sa_family;
-            if (family == AF_INET || family == AF_INET6) {
-                struct sockaddr_in* sa = (struct sockaddr_in*)ifa->ifa_addr;
-                char* addr = inet_ntoa(sa->sin_addr);
-                if (strcmp(ipstring, addr) == 0) {
-                    SetTrue(g->sp - 1);
-                    freeifaddrs(ifap);
-                    return errNone;
+    // first count the addresses
+    int count = 0;
+    for (auto aa = adapterAddresses; aa != NULL; aa = aa->Next) {
+        // skip interfaces that are not available
+        if (aa->OperStatus == IfOperStatusUp) {
+            for (auto ua = aa->FirstUnicastAddress; ua != NULL; ua = ua->Next) {
+                int family = ua->Address.lpSockaddr->sa_family;
+                if (addressFamily == AF_UNSPEC || addressFamily == family) {
+                    count++;
                 }
             }
         }
     }
 
+    // now allocate and fill Array
+    PyrObject* array = newPyrArray(g->gc, count, 0, true);
+    int index = 0;
+    for (auto aa = adapterAddresses; aa != NULL; aa = aa->Next) {
+        if (aa->OperStatus == IfOperStatusUp) {
+            for (auto ua = aa->FirstUnicastAddress; ua != NULL; ua = ua->Next) {
+                int family = ua->Address.lpSockaddr->sa_family;
+                if (addressFamily == AF_UNSPEC || addressFamily == family) {
+                    char buf[40];
+                    memset(buf, 0, sizeof(buf));
+                    getnameinfo(ua->Address.lpSockaddr, ua->Address.iSockaddrLength, buf, sizeof(buf), NULL, 0,
+                                NI_NUMERICHOST);
+                    PyrString* str = newPyrString(g->gc, buf, 0, false);
+                    SetObject(array->slots + index, (PyrObjectHdr*)str);
+                    index++;
+                }
+            }
+        }
+    }
+    array->size = index;
+
+    free(adapterAddresses);
+
+#else
+
+    struct ifaddrs* ifap;
+    if (getifaddrs(&ifap) != 0) {
+        error("getifaddrs() failed: %s.\n", strerror(errno));
+        return errFailed;
+    }
+
+    // first count addresses
+    int count = 0;
+    for (auto ifa = ifap; ifa; ifa = ifa->ifa_next) {
+        if (ifa->ifa_addr) {
+            int family = ifa->ifa_addr->sa_family;
+            if (addressFamily == AF_UNSPEC || addressFamily == family) {
+                count++;
+            }
+        }
+    }
+
+    // now allocate and fill Array
+    PyrObject* array = newPyrArray(g->gc, count, 0, true);
+    int index = 0;
+    for (auto ifa = ifap; ifa; ifa = ifa->ifa_next) {
+        if (ifa->ifa_addr) {
+            int family = ifa->ifa_addr->sa_family;
+            if (addressFamily == AF_UNSPEC || addressFamily == family) {
+                socklen_t len = (family == AF_INET6) ? sizeof(sockaddr_in6) : sizeof(sockaddr_in);
+                char buf[40];
+                memset(buf, 0, sizeof(buf));
+                // NB: getnameinfo() will fail if an interface is not available
+                if (getnameinfo(ifa->ifa_addr, len, buf, sizeof(buf), NULL, 0, NI_NUMERICHOST) == 0) {
+                    PyrString* str = newPyrString(g->gc, buf, 0, false);
+                    SetObject(array->slots + index, (PyrObjectHdr*)str);
+                    index++;
+                }
+            }
+        }
+    }
+    array->size = index; // set actual size (interfaces may have been skipped)
+
     freeifaddrs(ifap);
 #endif
 
-    SetFalse(g->sp - 1);
+    SetObject(g->sp - 1, (PyrObjectHdr*)array);
     return errNone;
 }
 
@@ -1569,7 +1605,7 @@ void init_OSC_primitives() {
     definePrimitive(base, index++, "_OSCBytes_Array", prOSCBytes_Array, 1, 0);
     definePrimitive(base, index++, "_GetHostByName", prGetHostByName, 1, 0);
     definePrimitive(base, index++, "_GetLangPort", prGetLangPort, 1, 0);
-    definePrimitive(base, index++, "_MatchLangIP", prMatchLangIP, 2, 0);
+    definePrimitive(base, index++, "_LocalIPs", prLocalIPs, 2, 0);
     definePrimitive(base, index++, "_LocalIP", prLocalIP, 2, 0);
     definePrimitive(base, index++, "_Exit", prExit, 1, 0);
 #ifndef NO_INTERNAL_SERVER
@@ -1598,4 +1634,7 @@ void init_OSC_primitives() {
     s_recvrawmsg = getsym("recvRawMessage");
     s_recvoscbndl = getsym("recvOSCbundle");
     s_netaddr = getsym("NetAddr");
+    s_ipv4 = getsym("ipv4");
+    s_ipv6 = getsym("ipv6");
+    s_all = getsym("all");
 }


### PR DESCRIPTION
- `localIP` returns the local IP address as a String; the optional `network` argument allows to specify a particular network, in case the machine is connected to multiple networks.

- `localEndPoint` returns a `NetAddr` with the local IP and a user provided port number (default: sclang port)

Interestingly, the `localEndPoint` class method already existed, but it was not documented and did not really work. Strangely, it tried to call a class method `langIP`, which does not really exist, thus it would always fail.

I have successfully tested this with
- a single interface with Internet
- a single interface without Internet
- two interfaces (one with Internet, the other without)

Also, `NetAddr.localIP("127.0.0.1")` correctly yields "127.0.0.1".

I implemented this as a result of the following discussion: https://scsynth.org/t/code-to-get-local-ip-on-all-platforms/5791/12?u=spacechild1

For example, this is useful if you want to quickly find out your own (local) IP address, so that other users in a LAN can send messages to you.

---

- `localIPs` returns an Array containing the IP addresses of all (available) network interfaces.
  With the optional `family` argument you can restrict the output to IPv4 addresses, IPv6 addresses, or both.
  Tested successfully on Windows and Linux.

- `matchLangIP` is now implemented in sclang, using the output of `localIPs`

## Types of changes

<!-- Delete lines that don't apply -->

- New feature

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review
