### PR TITLE
fix `slotStrVal` implementation

### DIFF
--- a/lang/LangPrimSource/PyrPrimitive.cpp
+++ b/lang/LangPrimSource/PyrPrimitive.cpp
@@ -108,13 +108,15 @@ int slotStrLen(PyrSlot* slot) {
     return -1;
 }
 
-int slotStrVal(PyrSlot* slot, char* str, int maxlen) {
+int slotStrVal(PyrSlot* slot, char* str, size_t maxSize) {
+    assert(maxSize > 0);
     if (IsSym(slot)) {
-        strncpy(str, slotRawSymbol(slot)->name, maxlen);
+        size_t len = sc_min(maxSize - 1, slotRawSymbol(slot)->length);
+        memcpy(str, slotRawSymbol(slot)->name, len);
+        str[len] = 0;
         return errNone;
     } else if (isKindOfSlot(slot, class_string)) {
-        int len;
-        len = sc_min(maxlen - 1, slotRawObject(slot)->size);
+        size_t len = sc_min(maxSize - 1, slotRawObject(slot)->size);
         memcpy(str, slotRawString(slot)->s, len);
         str[len] = 0;
         return errNone;

--- a/lang/LangSource/PyrSlot.h
+++ b/lang/LangSource/PyrSlot.h
@@ -57,7 +57,7 @@ int asCompileString(PyrSlot* slot, char* str);
 int slotIntVal(PyrSlot* slot, int* value);
 int slotFloatVal(PyrSlot* slot, float* value);
 int slotDoubleVal(PyrSlot* slot, double* value);
-int slotStrVal(PyrSlot* slot, char* str, int maxlen);
+int slotStrVal(PyrSlot* slot, char* str, size_t maxSize);
 std::tuple<int, std::string> slotStdStrVal(PyrSlot* slot);
 std::tuple<int, std::string> slotStrStdStrVal(PyrSlot* slot);
 int slotStrLen(PyrSlot* slot);


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

In `slotStrVal`, use `memcpy` instead of `strncpy`, since the latter does not terminate the string if the length exceeds the given buffer size! See https://en.cppreference.com/w/cpp/string/byte/strncpy. In general, `strncpy` should always be avoided.

There are a few other occurances of `strncpy` in the SC codebase, but this one has the largest impact, as `slotStrVal` is widely used.

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review
