### PR TITLE
Topic/help browser more navigation

### DIFF
--- a/HelpSource/Classes/HelpBrowser.schelp
+++ b/HelpSource/Classes/HelpBrowser.schelp
@@ -26,9 +26,11 @@ table::
     ## soft::shift + j:: or soft::ctrl + minus:: || zoom out
     ## soft::shift + k:: or soft::ctrl + plus:: || zoom in
     ## soft::/:: or soft::ctrl + f:: || search in page
-    ## soft::t:: || toggle TOC
     ## soft::F3:: || open Search page
     ## soft::F5:: || reload page
+    ## soft::t:: || toggle TOC
+    ## soft::ctrl+{j,k}:: || scroll in TOC
+    ## soft::ESC:: || close TOC
 ::
 
 classmethods::

--- a/HelpSource/Classes/HelpBrowser.schelp
+++ b/HelpSource/Classes/HelpBrowser.schelp
@@ -11,6 +11,26 @@ There are two different help browsers in SuperCollider: the help browser built i
 
 Since the Qt WebEngine dependency is hefty and difficult to install on some systems, it is possible for sclang to have been built without WebView support (using the CMake flag code:: -DSC_USE_QTWEBENGINE=OFF :: at compile). If so, attempting to invoke this class will throw an error.
 
+subsection::Keyboard shortcuts
+Unlike the help browser built into SCIDE, the HelpBrowser offers vim-like keyboard shortcuts for navigation, along with several additional features that enhance workflow efficiency for those who prefer keyboard-based interaction.
+table::
+    ## strong::Shortcut:: || strong::Functionality::
+    ## soft::j:: || scroll down
+    ## soft::k:: || scroll up
+    ## soft::ctrl + d:: || scroll more lines down
+    ## soft::ctrl + u:: || scroll more lines up
+    ## soft::h:: or soft::alt + left arrow:: || go back
+    ## soft::l:: or soft::alt + right arrow:: || go forward
+    ## soft::G:: || go to bottom 
+    ## soft::g:: || go to top
+    ## soft::shift + j:: or soft::ctrl + minus:: || zoom out
+    ## soft::shift + k:: or soft::ctrl + plus:: || zoom in
+    ## soft::/:: or soft::ctrl + f:: || search in page
+    ## soft::t:: || toggle TOC
+    ## soft::F3:: || open Search page
+    ## soft::F5:: || reload page
+::
+
 classmethods::
 private:: getOldWrapUrl, initClass
 

--- a/HelpSource/scdoc.js
+++ b/HelpSource/scdoc.js
@@ -143,6 +143,12 @@ function set_up_toc() {
             $("#toc_search").focus();
         }
     });
+
+	$("#toc_search").on('keydown', function(event) {
+        if (event.key === 'Escape') {
+            $("#toc").toggle(); 
+        }
+    });
 }
 
 function fixTOC() {

--- a/HelpSource/scdoc.js
+++ b/HelpSource/scdoc.js
@@ -157,6 +157,16 @@ function set_up_toc() {
             firstMatch.click(); // Simulate a click on the first matched item
             $("#toc").toggle();
         }
+
+        //TOC scroll with ctrl+{j,k}
+        if (event.ctrlKey && event.key === "j") {
+            $("#toc").scrollTop($("#toc").scrollTop() + 10);
+        }
+    
+        if (event.ctrlKey && event.key === "k") {
+            event.preventDefault();
+            $("#toc").scrollTop($("#toc").scrollTop() - 10);
+        }
     });
 }
 

--- a/HelpSource/scdoc.js
+++ b/HelpSource/scdoc.js
@@ -1,3 +1,4 @@
+
 var storage;
 var menubar;
 
@@ -87,15 +88,19 @@ escape_regexp = function(str) {
 }
 
 var toc_items;
+var firstMatch = null; // Variable to store the first match
+
 function toc_search(search_string) {
-//TODO: on enter, go to first match
     var re = RegExp("^"+escape_regexp(search_string),"i");
+    firstMatch = null; // Reset first match on each search
 
     for(var i=0;i<toc_items.length;i++) {
         var li = toc_items[i];
         var a = li.firstChild;
         if(re.test(a.innerHTML)) {
             li.style.display = "";
+            if(firstMatch === null) firstMatch = a; // Set first match
+
             var lev = li.className[3];
             for(var i2 = i-1;i2>=0;i2--) {
                 var e = toc_items[i2];
@@ -110,7 +115,6 @@ function toc_search(search_string) {
         }
     }
 }
-
 
 function set_up_toc() {
     var toc_container = $("<div>", {id: "toc-container"})
@@ -144,12 +148,19 @@ function set_up_toc() {
         }
     });
 
-	$("#toc_search").on('keydown', function(event) {
+    $("#toc_search").on('keydown', function(event) {
         if (event.key === 'Escape') {
-            $("#toc").toggle(); 
+            $("#toc").toggle();
+        };
+
+        if (event.key === 'Enter' && firstMatch !== null) {
+            firstMatch.click(); // Simulate a click on the first matched item
+            $("#toc").toggle();
         }
     });
 }
+
+
 
 function fixTOC() {
     addInheritedMethods();

--- a/SCClassLibrary/Common/GUI/tools/HelpBrowser.sc
+++ b/SCClassLibrary/Common/GUI/tools/HelpBrowser.sc
@@ -291,7 +291,7 @@ HelpBrowser {
 			});
 
 			#keyPlus, keyZero, keyMinus, keyEquals, keySlash = [43, 48, 45, 61, 47];
-			#keyD, keyF, keyG, keyH, keyJ, keyK, keyL, keyU, keyF3, keyF5 = [68, 70, 71, 72, 74, 75, 76, 85];
+			#keyD, keyF, keyG, keyH, keyJ, keyK, keyL, keyU = [68, 70, 71, 72, 74, 75, 76, 85];
 			#keyF3, keyF5 = [65472, 65474];
 			#keyLeftArrow, keyRightArrow = [65361, 65363];
 

--- a/SCClassLibrary/Common/GUI/tools/HelpBrowser.sc
+++ b/SCClassLibrary/Common/GUI/tools/HelpBrowser.sc
@@ -280,7 +280,7 @@ HelpBrowser {
 
 		window.view.keyDownAction = { arg view, char, mods, uni, kcode, key;
 			var keyPlus, keyZero, keyMinus, keyEquals, keySlash;
-			var keyD, keyU, keyF, keyG, keyH, keyJ, keyK, keyL;
+			var keyD, keyU, keyF, keyG, keyH, keyJ, keyK, keyL, keyT;
 			var keyF3, keyF5, keyLeftArrow, keyRightArrow;
 			var modifier, zoomIn;
 
@@ -291,7 +291,7 @@ HelpBrowser {
 			});
 
 			#keyPlus, keyZero, keyMinus, keyEquals, keySlash = [43, 48, 45, 61, 47];
-			#keyD, keyF, keyG, keyH, keyJ, keyK, keyL, keyU = [68, 70, 71, 72, 74, 75, 76, 85];
+			#keyD, keyF, keyG, keyH, keyJ, keyK, keyL, keyT, keyU = [68, 70, 71, 72, 74, 75, 76, 84, 85];
 			#keyF3, keyF5 = [65472, 65474];
 			#keyLeftArrow, keyRightArrow = [65361, 65363];
 
@@ -346,6 +346,9 @@ HelpBrowser {
 				},
 				{ (key == keyL) || ((kcode == keyRightArrow) && mods.isAlt) }, {
 					this.goForward
+				},
+				{ key == keyT }, {
+					webView.runJavaScript("$(\"#toc\").toggle();$(\"#toc_search\").focus();");
 				},
 				{ kcode == keyF5 }, {
 					this.goTo(webView.url)


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

Another small enhancement of  HelpBrowser's navigation for keyboard based people.

## Types of changes

- New feature
In HelpBrowser (vim, neovim, emacs), a new keybinding 't' toggles the TOC (Table of Contents) window. The ESC key closes it.
This PR also corrects a mistake I made in previous commits, where two unnecessary variables were mistakenly left in the wrong place.


- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review
