### PR TITLE
Plugins/classlib: Support multiple RandIDs in one SynthDef

### DIFF
--- a/HelpSource/Classes/RandID.schelp
+++ b/HelpSource/Classes/RandID.schelp
@@ -18,6 +18,14 @@ method::kr, ir
 argument::id
 The random number generator ID.
 
+argument::force
+A Boolean flag. A positive value is 'true', and indicates that RandID should set the synth's random number generator ID on every evaluation, even if the input ID has not changed. Negative or zero is 'false', meaning that RandID should set the synth's random number generator ID only when the input ID changes. Default is 0 (false), for compatibility with versions prior to the addition of this feature.
+
+"Forcing" is useful in the special case where different parts of the same SynthDef graph need to use different random number generators. See examples below.
+
+note:: code::RandID.ir:: will always evaluate only once, at the start of the synth, so the code::force:: argument has no effect in that case. ::
+
+
 Examples::
 
 code::
@@ -35,8 +43,8 @@ SynthDef("help-RandID", { arg out=0, id=1;
 //reset the seed of my rgen at a variable rate
 (
 SynthDef("help-RandSeed", { arg seed=1910, id=1;
-		RandID.kr(id);
-		RandSeed.kr(Impulse.kr(FSinOsc.kr(0.2, 0, 10, 11)), seed);
+	RandID.kr(id);
+	RandSeed.kr(Impulse.kr(FSinOsc.kr(0.2, 0, 10, 11)), seed);
 }).add;
 
 )
@@ -50,6 +58,87 @@ x = Synth("help-RandSeed", [\id, 1]);
 
 //change the target randgen to 2 (affects right channel)
 x.set(\id, 2);
-
 ::
 
+subsection:: Multiple random number generators and 'force'
+
+In most cases, randomized UGens in a SynthDef may all pull from the same random number generator. In this typical case, it's likely unnecessary to set the ID or re-seed at all.
+
+If, however, one is merging randomized signals from multiple synths into a single synth, and one wants to retain individual control over these separate streams, then the following sequence of evaluation is needed:
+
+numberedlist::
+## Set RNG ID (and re-seed).
+## Calculate some randomized UGens.
+## Set a different RNG ID (and re-seed).
+## Calculate some other randomized UGens.
+::
+
+This entire sequence needs to be performed, in this order, on every control block.
+
+The original RandID implementation would set the ID only when the input changed. Here, even though the code looks like it should produce two identical pseudo-random sequences, they are different because both LFNoise0 units are using the same RNG (ID = 1).
+
+code::
+(
+{
+	var a, b;
+	RandID.kr(0);
+	RandSeed.ir(1, 88372);
+	a = LFDNoise0.ar(440);
+	RandID.kr(1);
+	RandSeed.ir(1, 88372);
+	b = LFDNoise0.ar(440);
+	[a, b, a - b]
+}.plot;
+)
+::
+
+By "forcing" the RNG ID to be updated on every control block, then the random sequences do match.
+
+code::
+(
+{
+	var a, b;
+	RandID.kr(0, 1);
+	RandSeed.ir(1, 88372);
+	a = LFDNoise0.ar(440);
+	RandID.kr(1, 1);
+	RandSeed.ir(1, 88372);
+	b = LFDNoise0.ar(440);
+	[a, b, a - b]
+}.plot;
+)
+::
+
+note:: In such cases, use a SynthDef and check the order of UGens carefully.
+
+code::
+(
+SynthDef(\test, {
+	var a, b;
+	RandID.kr(0, 1);
+	RandSeed.ir(1, 88372);
+	a = LFDNoise0.ar(440);
+	RandID.kr(1, 1);
+	RandSeed.ir(1, 88372);
+	b = LFDNoise0.ar(440);
+	Out.ar(1000, [a, b, a - b])
+}).dumpUGens
+)
+
+// correct order! annotated:
+
+// one RNG chain, id = 0
+[0_RandID, control, [0, 1]]
+[1_RandSeed, scalar, [1, 88372]]
+[2_LFDNoise0, audio, [440]]
+
+// another RNG chain, id = 1
+[3_RandID, control, [1, 1]]
+[4_RandSeed, scalar, [1, 88372]]
+[5_LFDNoise0, audio, [440]]
+
+[6_-, audio, [2_LFDNoise0, 5_LFDNoise0]]
+[7_Out, audio, [1000, 2_LFDNoise0, 5_LFDNoise0, 6_-]]
+::
+
+::

--- a/SCClassLibrary/Common/Audio/Noise.sc
+++ b/SCClassLibrary/Common/Audio/Noise.sc
@@ -33,12 +33,12 @@ RandSeed : WidthFirstUGen {
 
 RandID : WidthFirstUGen {
 	// choose which random number generator to use for this synth .
-	*kr { arg id=0;
-		this.multiNew('control', id)
+	*kr { arg id = 0, force = 0;
+		this.multiNew('control', id, force)
 		^0.0		// RandID has no output
 	}
-	*ir { arg id=0;
-		this.multiNew('scalar', id)
+	*ir { arg id = 0, force = 0;
+		this.multiNew('scalar', id, force)
 		^0.0		// RandID has no output
 	}
 }

--- a/server/plugins/NoiseUGens.cpp
+++ b/server/plugins/NoiseUGens.cpp
@@ -790,9 +790,13 @@ void RandID_Ctor(RandID* unit) {
 
 void RandID_next(RandID* unit, int inNumSamples) {
     float id = ZIN0(0);
+    bool fire = ZIN0(1) > 0;
 
     if (id != unit->m_id) {
         unit->m_id = id;
+        fire = true;
+    }
+    if (fire) {
         uint32 iid = (uint32)id;
         if (iid < unit->mWorld->mNumRGens) {
             unit->mParent->mRGen = unit->mWorld->mRGen + iid;


### PR DESCRIPTION
## Purpose and Motivation

See https://scsynth.org/t/different-randseed-for-the-same-synthdef/7248/27, where it was desired to use more than one RNG ID in the same SynthDef. Prior to this change, this was impossible because RandID would set the ID only when the ID input changed. This use case requires setting the ID on every control block, once for one part of the graph, and again for the other part.

However, losing the old behavior would also not be desirable.

So this change adds a new input to RandID, `force`.

- If `force <= 0` (false), RandID behaves the old way, looking for changes in the input.
- If `force > 0` (true), RandID will set the ID in every control block, whether it changed or not.

The default is the old way.

As with a couple of other recent PRs, I would prefer not to have to write a unit test until we are reasonably sure this will be merged. So a unit test isn't yet provided. The approach would be to generate two separate, identically-seeded random number streams and make sure they are the same.

## Types of changes

- Documentation
- New feature
- Breaking change -- minimal impact I think(?)

## To-do list

- [x] Code is tested (informally -- unit test to be written later)
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review
