### PR TITLE
Add check before installing Quark dependencies

### DIFF
--- a/SCClassLibrary/Common/Quarks/Quarks.sc
+++ b/SCClassLibrary/Common/Quarks/Quarks.sc
@@ -10,7 +10,7 @@ Quarks {
 		cache,
 		regex,
 		installedPaths,
-		<>installing;
+		installing;
 
 	*install { |name, refspec|
 		var path, quark;
@@ -198,29 +198,27 @@ Quarks {
 			},
 			prev = this.installed.detect({ |q| q.name == quark.name });
 
-		if(prev.notNil and: {prev.localPath != quark.localPath}, {
+		if(prev.notNil and: {prev.localPath != quark.localPath}) {
 			("A version of % is already installed at %".format(quark, prev.localPath)).error;
 			^false
-		});
+		};
 
 		"Installing %".format(quark.name).postln;
 		// add currently installing quark to 'installing' Array
-		installing = (installing.size == 0).if{ quark.bubble }{ installing ++ quark.bubble };
+		installing = if(installing.size == 0) { quark.bubble } { installing ++ quark };
 		quark.checkout();
-		quark.isCompatible().not.if{
+		if(quark.isCompatible().not) {
 			^incompatible.value(quark.name);
 		};
 		quark.dependencies.do{ |dep|
 			var ok;
 			// check if dependency is already installing
-			installing.detect({ |q| q.name == dep.name }).isNil.if{				
+			if(installing.detect({ |q| q.name == dep.name }).isNil) {				
 				ok = dep.install();
-				ok.not.if{
+				if(ok.not) {
 					("Failed to install" + quark.name).error;
 					^false
 				}
-			}{
-				(dep.name + "already installing").postln
 			}
 		};
 		quark.runHook(\preInstall);

--- a/SCClassLibrary/Common/Quarks/Quarks.sc
+++ b/SCClassLibrary/Common/Quarks/Quarks.sc
@@ -210,8 +210,8 @@ Quarks {
 		});
 		quark.dependencies.do { |dep|
 			var ok, alreadyInstalled;
-			alreadyInstalled = this.installed.detect({ |q| q.name == quark.name }).notNil;
-			alreadyInstalled.if{
+			alreadyInstalled = this.installed.detect({ |q| q.name == quark.name}).notNil;
+			alreadyInstalled.not.if{				
 				ok = dep.install();
 				if(ok.not, {
 					("Failed to install" + quark.name).error;

--- a/SCClassLibrary/Common/Quarks/Quarks.sc
+++ b/SCClassLibrary/Common/Quarks/Quarks.sc
@@ -189,7 +189,7 @@ Quarks {
 	*installQuark { |quark|
 		var
 			deps,
-			incompatible = { arg name;
+			incompatible = { |name|
 				(quark.name
 					+ "reports an incompatibility with this SuperCollider version"
 					+ "or with other already installed quarks."
@@ -198,14 +198,14 @@ Quarks {
 			},
 			prev = this.installed.detect({ |q| q.name == quark.name });
 
-		if(prev.notNil and: {prev.localPath != quark.localPath}) {
+		if(prev.notNil and: { prev.localPath != quark.localPath }) {
 			("A version of % is already installed at %".format(quark, prev.localPath)).error;
 			^false
 		};
 
 		"Installing %".format(quark.name).postln;
 		// add currently installing quark to 'installing' Array
-		installing = if(installing.size == 0) { quark.bubble } { installing ++ quark };
+		installing = if(installing.size == 0) { [quark] } { installing ++ quark };
 		quark.checkout();
 		if(quark.isCompatible().not) {
 			^incompatible.value(quark.name);

--- a/SCClassLibrary/Common/Quarks/Quarks.sc
+++ b/SCClassLibrary/Common/Quarks/Quarks.sc
@@ -9,7 +9,8 @@ Quarks {
 		fetched=false,
 		cache,
 		regex,
-		installedPaths;
+		installedPaths,
+		<>installing;
 
 	*install { |name, refspec|
 		var path, quark;
@@ -203,23 +204,24 @@ Quarks {
 		});
 
 		"Installing %".format(quark.name).postln;
-
+		installing = installing.isNil.if{quark.bubble}{installing ++ quark.bubble};
 		quark.checkout();
-		if(quark.isCompatible().not, {
+		quark.isCompatible().not.if{
 			^incompatible.value(quark.name);
-		});
-		quark.dependencies.do { |dep|
+		};
+		quark.dependencies.do{ |dep|
 			var ok;
-			dep.isInstalled.not.if{				
+			installing.detect({|q| q.name == dep.name}).isNil.if{				
 				ok = dep.install();
-				if(ok.not, {
+				ok.not.if{
 					("Failed to install" + quark.name).error;
 					^false
-				});
+				};
 			}{
-				(dep.name + "already installed").postln
+				(dep.name + "already installing").postln
 			}
 		};
+		installing = installing.reject{|q| q.name == quark.name};
 		quark.runHook(\preInstall);
 		this.link(quark.localPath);
 		quark.runHook(\postInstall);

--- a/SCClassLibrary/Common/Quarks/Quarks.sc
+++ b/SCClassLibrary/Common/Quarks/Quarks.sc
@@ -204,7 +204,7 @@ Quarks {
 		});
 
 		"Installing %".format(quark.name).postln;
-		installing = installing.isNil.if{quark.bubble}{installing ++ quark.bubble};
+		installing = (installing.size == 0).if{quark.bubble}{installing ++ quark.bubble};
 		quark.checkout();
 		quark.isCompatible().not.if{
 			^incompatible.value(quark.name);

--- a/SCClassLibrary/Common/Quarks/Quarks.sc
+++ b/SCClassLibrary/Common/Quarks/Quarks.sc
@@ -209,11 +209,17 @@ Quarks {
 			^incompatible.value(quark.name);
 		});
 		quark.dependencies.do { |dep|
-			var ok = dep.install();
-			if(ok.not, {
-				("Failed to install" + quark.name).error;
-				^false
-			});
+			var ok, alreadyInstalled;
+			alreadyInstalled = this.installed.detect({ |q| q.name == quark.name }).notNil;
+			alreadyInstalled.if{
+				ok = dep.install();
+				if(ok.not, {
+					("Failed to install" + quark.name).error;
+					^false
+				});
+			}{
+				(dep.name + "already installed").postln
+			}
 		};
 		quark.runHook(\preInstall);
 		this.link(quark.localPath);

--- a/SCClassLibrary/Common/Quarks/Quarks.sc
+++ b/SCClassLibrary/Common/Quarks/Quarks.sc
@@ -204,6 +204,7 @@ Quarks {
 		});
 
 		"Installing %".format(quark.name).postln;
+		// add currently installing quark to 'installing' Array
 		installing = (installing.size == 0).if{ quark.bubble }{ installing ++ quark.bubble };
 		quark.checkout();
 		quark.isCompatible().not.if{
@@ -211,6 +212,7 @@ Quarks {
 		};
 		quark.dependencies.do{ |dep|
 			var ok;
+			// check if dependency is already installing
 			installing.detect({ |q| q.name == dep.name }).isNil.if{				
 				ok = dep.install();
 				ok.not.if{
@@ -221,11 +223,12 @@ Quarks {
 				(dep.name + "already installing").postln
 			}
 		};
-		installing = installing.reject{ |q| q.name == quark.name };
 		quark.runHook(\preInstall);
 		this.link(quark.localPath);
 		quark.runHook(\postInstall);
 		(quark.name + "installed").postln;
+		// remove quark from installing Array
+		installing = installing.reject{ |q| q.name == quark.name };
 		this.clearCache();
 		^true
 	}

--- a/SCClassLibrary/Common/Quarks/Quarks.sc
+++ b/SCClassLibrary/Common/Quarks/Quarks.sc
@@ -209,9 +209,8 @@ Quarks {
 			^incompatible.value(quark.name);
 		});
 		quark.dependencies.do { |dep|
-			var ok, alreadyInstalled;
-			alreadyInstalled = this.installed.detect({ |q| q.name == quark.name}).notNil;
-			alreadyInstalled.not.if{				
+			var ok;
+			dep.isInstalled.not.if{				
 				ok = dep.install();
 				if(ok.not, {
 					("Failed to install" + quark.name).error;

--- a/SCClassLibrary/Common/Quarks/Quarks.sc
+++ b/SCClassLibrary/Common/Quarks/Quarks.sc
@@ -204,24 +204,24 @@ Quarks {
 		});
 
 		"Installing %".format(quark.name).postln;
-		installing = (installing.size == 0).if{quark.bubble}{installing ++ quark.bubble};
+		installing = (installing.size == 0).if{ quark.bubble }{ installing ++ quark.bubble };
 		quark.checkout();
 		quark.isCompatible().not.if{
 			^incompatible.value(quark.name);
 		};
 		quark.dependencies.do{ |dep|
 			var ok;
-			installing.detect({|q| q.name == dep.name}).isNil.if{				
+			installing.detect({ |q| q.name == dep.name }).isNil.if{				
 				ok = dep.install();
 				ok.not.if{
 					("Failed to install" + quark.name).error;
 					^false
-				};
+				}
 			}{
 				(dep.name + "already installing").postln
 			}
 		};
-		installing = installing.reject{|q| q.name == quark.name};
+		installing = installing.reject{ |q| q.name == quark.name };
 		quark.runHook(\preInstall);
 		this.link(quark.localPath);
 		quark.runHook(\postInstall);


### PR DESCRIPTION
## Purpose and Motivation

Fixes #6155  - installing Quarks with circular dependencies would hang - I added an "installing" classvar that keeps track of any Quarks in the process of installing and prevents re-installing them as dependencies

## Types of changes

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [ ] Updated documentation
- [x ] This PR is ready for review
