### PR TITLE
Topic/slash asterisk pairs in quotes are rewritten differently.

### DIFF
--- a/HelpSource/Classes/OSCFunc.schelp
+++ b/HelpSource/Classes/OSCFunc.schelp
@@ -107,7 +107,7 @@ m = NetAddr("127.0.0.1", NetAddr.langPort); // loopback
 m.sendMsg("/chat", "Hello App 1");
 m.sendMsg("/chat", "Hello App 1"); // oneshot gone
 m.sendMsg("/ch?t", "Hello App 1");
-m.sendMsg("/*", "Hello App 1");
+m.sendMsg("/" ++ "*", "Hello App 1");
 m.sendMsg("/chit", "Hello App 1"); // nothing
 
 // Introspection

--- a/HelpSource/Classes/OSCdef.schelp
+++ b/HelpSource/Classes/OSCdef.schelp
@@ -118,7 +118,7 @@ m = NetAddr("127.0.0.1", 57120); // loopback
 m.sendMsg("/chat", "Hello App 1");
 m.sendMsg("/chat", "Hello App 1"); // oneshot gone
 m.sendMsg("/ch?t", "Hello App 1");
-m.sendMsg("/*", "Hello App 1");
+m.sendMsg("/" ++ "*", "Hello App 1");
 m.sendMsg("/chit", "Hello App 1"); // nothing
 
 // Introspection

--- a/HelpSource/Classes/SoundFile.schelp
+++ b/HelpSource/Classes/SoundFile.schelp
@@ -57,7 +57,7 @@ returns:: A new SoundFile instance if successful, or code::nil:: if file open fa
 method::collect
 Returns an link::Classes/Array:: of SoundFile objects whose paths match the pattern. (The associated files are closed. These objects can be used to cue playback buffers)
 code::
-SoundFile.collect("sounds/*").do { |f| f.path.postln };
+SoundFile.collect("sounds" +/+ "*").do { |f| f.path.postln };
 ::
 
 method::use
@@ -110,7 +110,7 @@ The control strong::sustainTime:: determines playback duration based on the firs
 argument::playNow
 This is a link::Classes/Boolean:: that determines whether the file is to be played immediately after cueing.
 code::
-f = SoundFile.collect("sounds/*");
+f = SoundFile.collect("sounds" +/+ "*");
 e = f[1].cue;
 
 e = f[1].cue( (addAction: 2, group: 1) );	// synth will play ahead of the default group

--- a/HelpSource/Classes/String.schelp
+++ b/HelpSource/Classes/String.schelp
@@ -708,7 +708,7 @@ Make a directory from the given path location.
 method::pathMatch
 Returns an link::Classes/Array:: containing all paths matching this String. Wildcards apply, non-recursive.
 code::
-Post << "Help/*".pathMatch;
+Post << "Help" +/+ "*".pathMatch;
 ::
 
 method::load

--- a/HelpSource/Classes/String.schelp
+++ b/HelpSource/Classes/String.schelp
@@ -708,7 +708,7 @@ Make a directory from the given path location.
 method::pathMatch
 Returns an link::Classes/Array:: containing all paths matching this String. Wildcards apply, non-recursive.
 code::
-Post << "Help" +/+ "*".pathMatch;
+Post << ("Help" +/+ "*").pathMatch;
 ::
 
 method::load


### PR DESCRIPTION
## Purpose and Motivation
`"/*"` is sometimes confused by sclang, so `/*` is sometimes treated as part of a comment. This leads to errors.
`" +/+ "*"` or `"/" ++ "*"` is better to avoid this problem.

## Types of changes
- Documentation

## To-do list
- [ ] Code is tested
- [ ] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review
