### PR TITLE
Help: Correct wording in Amplitude help (it's not the peak)

### DIFF
--- a/HelpSource/Classes/Amplitude.schelp
+++ b/HelpSource/Classes/Amplitude.schelp
@@ -3,7 +3,7 @@ summary:: Amplitude follower
 categories:: UGens>Analysis>Amplitude
 
 description::
-Tracks the relative amplitude of a signal.
+Tracks the relative amplitude of a signal, using an envelope follower algorithm. An envelope follower converges toward rising amplitude according to code::attackTime::, and toward falling amplitude according to code::releaseTime::. See the plot under Examples.
 
 classmethods::
 
@@ -24,7 +24,24 @@ argument::add
 
 examples::
 
+The first example produces a plot, comparing a fast attack/release against slower settings. The green line (fast settings) approximates the amplitude more quickly, but also oscillates according to the wave shape. The blue line (slow settings) rises more slowly, but oscillates less (more stable measurement).
+
 code::
+(
+{
+	// LFSaw begins at 0, illustrates attack time better
+	var sig = LFSaw.ar(440);
+	var amps = Amplitude.ar(
+		sig,
+		attackTime: [0.001, 0.01],
+		releaseTime: [0.01, 0.2]
+	);
+	[sig] ++ amps
+}.plot
+.superpose_(true)
+.plotColor_([Color.black, Color.green, Color.blue]);
+)
+
 (
 // use input amplitude to control SinOsc frequency
 {

--- a/HelpSource/Classes/Amplitude.schelp
+++ b/HelpSource/Classes/Amplitude.schelp
@@ -3,7 +3,7 @@ summary:: Amplitude follower
 categories:: UGens>Analysis>Amplitude
 
 description::
-Tracks the peak amplitude of a signal.
+Tracks the relative amplitude of a signal.
 
 classmethods::
 


### PR DESCRIPTION
## Purpose and Motivation

Facebook conversation:

> Why does Amplitude return an unexpected value?:
> (
> {
>  Amplitude.ar(SinOsc.ar).poll;
>  Silent.ar
> }.play
> )
> Polled value is around 0.63, but I would expect the value to be 1.

Me: "You're expecting the peak amplitude. Many ways of measuring amplitude (e.g. RMS, which is well standard in audio) reflect the average level rather than the peak. ... Amplitude will return a larger value for louder signals but if you really need the peak, see Peak.ar ."

Them: "Makes sense, although my assumption was based on the description of the UGen: 'Tracks the peak amplitude of a signal.'"

Misleading wording.

## Types of changes

- Documentation

## To-do list
- [x] Updated documentation
- [x] This PR is ready for review
