### PR TITLE
NEW  copy icons in help examples

### DIFF
--- a/HelpSource/scdoc.css
+++ b/HelpSource/scdoc.css
@@ -767,3 +767,41 @@ div.met_subclasses a.seemore {
     font-size: 9pt;
     color: #777;
 }
+
+/* copy example code buttons */
+.codeMirrorContainer {
+	position: relative;
+}
+
+.copyButton {
+	position: absolute;
+	top: 4px;
+	right: 10px;
+	display: none;
+	background: none;
+	border: none;
+	cursor: pointer;
+	width: 20px;
+	height: 20px;
+	margin: 0;
+	padding: 0;
+	z-index: 1000;
+}
+
+.copyButton svg {
+	fill: lightgrey;
+}
+
+.copyIcon {
+	width: 20px;
+	height: 20px;
+	display: block;
+}
+.checkmarkIcon {
+	width: 20px;
+	height: 20px;
+	display: none;
+	position: absolute;
+	top: 0px;
+	left: 0px;
+}

--- a/HelpSource/scdoc.css
+++ b/HelpSource/scdoc.css
@@ -791,6 +791,9 @@ div.met_subclasses a.seemore {
 .copyButton svg {
 	fill: lightgrey;
 }
+.copyButtonActive {
+	fill: black;
+}
 
 .copyIcon {
 	width: 20px;

--- a/HelpSource/scdoc.css
+++ b/HelpSource/scdoc.css
@@ -792,7 +792,7 @@ div.met_subclasses a.seemore {
 	outline: none;
 }
 
-.copyButton svg {
+.copyButtonVisible {
 	fill: lightgrey;
 }
 

--- a/HelpSource/scdoc.css
+++ b/HelpSource/scdoc.css
@@ -788,9 +788,14 @@ div.met_subclasses a.seemore {
 	z-index: 1000;
 }
 
+.copyButton:focus {
+	outline: none;
+}
+
 .copyButton svg {
 	fill: lightgrey;
 }
+
 .copyButtonActive {
 	fill: black;
 }

--- a/HelpSource/scdoc.js
+++ b/HelpSource/scdoc.js
@@ -256,7 +256,7 @@ document.addEventListener("DOMContentLoaded", function () {
           navigator.clipboard
           .writeText(editor.val())
           .then(function () {
-              console.log("Text copied to clipboard");
+              // console.log("Text copied to clipboard");
           })
           .catch(function (err) {
               console.error("Could not copy text: ", err);

--- a/HelpSource/scdoc.js
+++ b/HelpSource/scdoc.js
@@ -222,11 +222,11 @@ function setUpWebChannel(port) {
 var svgPaths = {
     // https://www.svgviewer.dev/s/488209/copy
     copyIcon:
-        '<svg xmlns="http://www.w3.org/2000/svg" class="copyIcon" fill="currentColor" viewBox="0 0 24 24"> <path d="M2 4a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2v4h4a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H10a2 2 0 0 1-2-2v-4H4a2 2 0 0 1-2-2V4zm8 12v4h10V10h-4v4a2 2 0 0 1-2 2h-4zm4-2V4H4v10h10z"/> </svg>',
+        '<svg xmlns="http://www.w3.org/2000/svg" class="copyIcon copyButtonVisible" fill="currentColor" viewBox="0 0 24 24"> <path d="M2 4a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2v4h4a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H10a2 2 0 0 1-2-2v-4H4a2 2 0 0 1-2-2V4zm8 12v4h10V10h-4v4a2 2 0 0 1-2 2h-4zm4-2V4H4v10h10z"/> </svg>',
 
     // https://www.svgviewer.dev/s/497361/check
     checkmarkIcon:
-        '<svg xmlns="http://www.w3.org/2000/svg" class="checkmarkIcon" fill="currentColor" viewBox="0 0 24 24"><path d= "M10,18a1,1,0,0,1-.71-.29l-5-5a1,1,0,0,1,1.42-1.42L10,15.59l8.29-8.3a1,1,0,1,1,1.42,1.42l-9,9A1,1,0,0,1,10,18Z" > </path></svg>',
+        '<svg xmlns="http://www.w3.org/2000/svg" class="checkmarkIcon copyButtonVisible" fill="currentColor" viewBox="0 0 24 24"><path d= "M10,18a1,1,0,0,1-.71-.29l-5-5a1,1,0,0,1,1.42-1.42L10,15.59l8.29-8.3a1,1,0,1,1,1.42,1.42l-9,9A1,1,0,0,1,10,18Z" > </path></svg>',
 }; // copy icons
 
 document.addEventListener("DOMContentLoaded", function () {

--- a/HelpSource/scdoc.js
+++ b/HelpSource/scdoc.js
@@ -217,3 +217,71 @@ function setUpWebChannel(port) {
         });
     }
 }
+
+
+var svgPaths = {
+    // https://www.svgviewer.dev/s/488209/copy
+    copyIcon:
+        '<svg xmlns="http://www.w3.org/2000/svg" class="copyIcon" fill="currentColor" viewBox="0 0 24 24"> <path d="M2 4a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2v4h4a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H10a2 2 0 0 1-2-2v-4H4a2 2 0 0 1-2-2V4zm8 12v4h10V10h-4v4a2 2 0 0 1-2 2h-4zm4-2V4H4v10h10z"/> </svg>',
+
+    // https://www.svgviewer.dev/s/497361/check
+    checkmarkIcon:
+        '<svg xmlns="http://www.w3.org/2000/svg" class="checkmarkIcon" fill="currentColor" viewBox="0 0 24 24"><path d= "M10,18a1,1,0,0,1-.71-.29l-5-5a1,1,0,0,1,1.42-1.42L10,15.59l8.29-8.3a1,1,0,1,1,1.42,1.42l-9,9A1,1,0,0,1,10,18Z" > </path></svg>',
+}; // copy icons
+
+document.addEventListener("DOMContentLoaded", function () {
+    let mouseon = false;
+
+    $(".copyButton").html(svgPaths.copyIcon + svgPaths.checkmarkIcon);
+
+    $(".codeMirrorContainer").each(function () {
+        var container = $(this);
+        var button = container.find(".copyButton");
+        var editor = container.find(".editor");
+
+        button.on("click", function () {
+          container.find(".copyIcon").fadeOut();
+          container
+            .find(".checkmarkIcon")
+            .fadeIn()
+            .delay(1000)
+            .queue(function (next) {
+                $(this).fadeOut();
+                if (mouseon) {
+                  container.find(".copyIcon").fadeIn();
+                }
+                next();
+            });
+
+          navigator.clipboard
+          .writeText(editor.val())
+          .then(function () {
+              console.log("Text copied to clipboard");
+          })
+          .catch(function (err) {
+              console.error("Could not copy text: ", err);
+          });
+      });
+    });
+
+    $(".copyIcon").hover(
+        function () {
+            $(this).css("fill", "black");
+        },
+        function () {
+            $(this).css("fill", "lightgrey");
+        },
+    );
+
+    $(".codeMirrorContainer").hover(
+        function () {
+            $(this).find(".copyButton, .copyIcon").fadeIn(100);
+            mouseon = true;
+        },
+        function () {
+            $(this).find(".copyIcon, .checkmarkIcon").fadeOut(100);
+            mouseon = false;
+        },
+    );
+});
+

--- a/HelpSource/scdoc.js
+++ b/HelpSource/scdoc.js
@@ -264,14 +264,9 @@ document.addEventListener("DOMContentLoaded", function () {
       });
     });
 
-    $(".copyIcon").hover(
-        function () {
-            $(this).css("fill", "black");
-        },
-        function () {
-            $(this).css("fill", "lightgrey");
-        },
-    );
+    $(".copyIcon").hover(function () {
+      $(this).children().toggleClass("copyButtonActive");
+    });
 
     $(".codeMirrorContainer").hover(
         function () {

--- a/SCClassLibrary/Common/GUI/tools/HelpBrowser.sc
+++ b/SCClassLibrary/Common/GUI/tools/HelpBrowser.sc
@@ -278,6 +278,8 @@ HelpBrowser {
 
 		webView.enterInterpretsSelection = true;
 
+		webView.setAttribute(\javascriptCanAccessClipboard, true);
+
 		window.view.keyDownAction = { arg view, char, mods, uni, kcode, key;
 			var keyPlus, keyZero, keyMinus, keyEquals, keySlash;
 			var keyD, keyU, keyF, keyG, keyH, keyJ, keyK, keyL;

--- a/SCClassLibrary/SCDoc/SCDoc.sc
+++ b/SCClassLibrary/SCDoc/SCDoc.sc
@@ -384,7 +384,7 @@ SCDocNode {
 SCDoc {
 
 	// Increment this whenever we make a change to the SCDoc system so that all help-files should be processed again
-	classvar version = 72;
+	classvar version = 73;
 
 	classvar <helpTargetDir;
 	classvar <helpTargetUrl;

--- a/SCClassLibrary/SCDoc/SCDocRenderer.sc
+++ b/SCClassLibrary/SCDoc/SCDocRenderer.sc
@@ -559,9 +559,10 @@ SCDocHTMLRenderer {
 				stream << this.htmlForLink(node.text);
 			},
 			\CODEBLOCK, {
-				stream << "<textarea class='editor'>"
+				stream << "<div class=\"codeMirrorContainer\"><textarea class='editor'>"
 				<< this.escapeSpecialChars(node.text)
 				<< "</textarea>\n";
+				stream << "<button class=\"copyButton\">Copy</button></div>\n";
 			},
 			\CODE, {
 				stream << "<code>"

--- a/editors/sc-ide/widgets/help_browser.cpp
+++ b/editors/sc-ide/widgets/help_browser.cpp
@@ -107,6 +107,8 @@ HelpBrowser::HelpBrowser(QWidget* parent): QWidget(parent) {
 
     applySettings(Main::settings());
 
+    mWebView->settings()->setAttribute(QWebEngineSettings::JavascriptCanAccessClipboard, true);
+
     setFocusProxy(mWebView);
 }
 


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation
This PR adds an icon to each code block in help files to easily copy the content of an example.
Works ONLY in ```HelpBrowser``` class. I still cannot figure out how to get it working in SCIDE help browser. I suppose the thing is with ```javascriptcanaccessClipboard``` permission. I'll try to investigate this further.

EDIT: works everywhere (also in SCIDE helpbrowser)

(icons have Public domain lincense from https://www.svgviewer.dev/. I put the links to the icons in js file)

![output](https://github.com/supercollider/supercollider/assets/9800392/d79d4b83-b737-485c-8617-9b6f1c370e67)

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->

- New feature

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] This PR is ready for review
