### PR TITLE
Fix UGen initialization: LFUGens pt. 2/3

### DIFF
--- a/HelpSource/Classes/AmpCompA.schelp
+++ b/HelpSource/Classes/AmpCompA.schelp
@@ -45,16 +45,14 @@ argument::freq
 Input frequency value. For freq == root, the output is rootAmp.
 
 argument::root
-Root freq relative to which the curve is calculated (usually lowest freq).
+Root freq relative to which the curve is calculated (usually lowest freq). Non-modulatable.
 
 argument::minAmp
-Amplitude at the minimum point of the curve (around 2512 Hz).
+Amplitude at the minimum point of the curve (around 2512 Hz). Non-modulatable.
 
 argument::rootAmp
-Amplitude at the root frequency.
+Amplitude at the root frequency. Non-modulatable.
 
-discussion::
-Apart from code::freq::, the values are not modulatable
 
 Examples::
 

--- a/HelpSource/Classes/InRange.schelp
+++ b/HelpSource/Classes/InRange.schelp
@@ -6,38 +6,36 @@ categories::  UGens>Maths
 
 Description::
 
-If  code::in::  is ≥  code::lo::  and ≤
-code::hi::  output 1.0, otherwise output 0.0. Output is
-initially zero.
+If teletype::lo ≤ in ≤ hi::, output 1.0, otherwise output 0.0.
 
 
 classmethods::
 
-method::ar, kr, ir
+method:: ar, kr, ir
 
-argument::in
+argument:: in
 
-Signal to be tested.
-
-
-argument::lo
-
-Low threshold.
+Signal to be tested. If teletype::InRange:: is running at audio rate, strong::in:: must also be audio rate.
 
 
-argument::hi
+argument:: lo
 
-High threshold.
+Low threshold. Updated at control rate.
+
+
+argument:: hi
+
+High threshold. Updated at control rate.
 
 
 Examples::
 
 code::
 
-s.boot;
+// See the trigger
+{ InRange.kr(SinOsc.kr(1, 0, 0.2), -0.15, 0.15) }.scope;
 
-{ InRange.kr(SinOsc.kr(1, 0, 0.2), -0.15, 0.15) }.scope; // see the trigger
-
-{ InRange.kr(SinOsc.kr(1, 0, 0.2), -0.15, 0.15) * BrownNoise.ar(0.1) }.scope; // trigger noise Burst
+// Trigger noise burst
+{ InRange.kr(SinOsc.kr(1, 0, 0.2), -0.15, 0.15) * BrownNoise.ar(0.1) }.scope;
 
 ::

--- a/HelpSource/Classes/InRect.schelp
+++ b/HelpSource/Classes/InRect.schelp
@@ -9,31 +9,45 @@ A pair of signals x and y are treated as a point (x, y) in 2-D; if they fall wit
 
 
 classmethods::
-method::ar, kr
+method:: ar, kr
 
-argument::x
-X component signal
+argument:: x
+X component signal. If teletype::InRect:: is running at audio rate, strong::x:: must also be audio rate.
 
-argument::y
-Y component signal
+argument:: y
+Y component signal. If teletype::InRect:: is running at audio rate, strong::y:: must also be audio rate.
 
-argument::rect
+argument:: rect
 A link::Classes/Rect:: which defines the rectangular region to monitor; note that Rects are in screen co-ordinates, so the top is smaller than the bottom. The Rect is created once and cannot be modulated.
 
 examples::
+
 code::
-// we'll hear the sawtooth wave when the two sine oscillators are both in the region x = 0.0 to 0.5, y = 0.5 to 1.0
-{ InRect.ar(SinOsc.ar(1), SinOsc.ar(1.3), Rect(0, 0.5, 0.5, 0.5))*LFSaw.ar(44, 0, 0.1) }.play
 
-// stereo effect
-{ (InRect.ar(LFNoise0.ar([140, 141]), LFNoise0.ar(143), Rect(0, 0, 0.5, 1)).lag(0.1))*LFSaw.ar(SinOsc.ar(10, 0, 5, 400), 0, 0.1) }.play
+// We'll hear the sawtooth wave when the two sine oscillators are both in the region x = 0.0 to 0.5, y = 0.5 to 1.0
+(
+{
+	InRect.ar(
+		SinOsc.ar(1), SinOsc.ar(1.3), Rect(0, 0.5, 0.5, 0.5)
+	) * LFSaw.ar(44, 0, 0.1)
+}.play
+)
 
+// Stereo effect
+(
+{
+	InRect.ar(
+		LFNoise0.ar([140, 141]), LFNoise0.ar(143), Rect(0, 0, 0.5, 1)
+	).lag(0.1) * LFSaw.ar(SinOsc.ar(10, 0, 5, 400), 0, 0.1)
+}.play
+)
 
-// for the Rect, create as left, 'top', width, height;
-r = Rect(0, 0, 0, 1)
+// For the Rect, create as left, 'top', width, height;
+r = Rect(0, 0, 1, 1)
 
 r.left
-r.right
 r.top
+r.right
 r.bottom
+
 ::

--- a/HelpSource/Classes/SyncSaw.schelp
+++ b/HelpSource/Classes/SyncSaw.schelp
@@ -23,14 +23,13 @@ Frequency of the fundamental.
 
 argument::sawFreq
 
-Frequency of the synched sawtooth wave. Should always be
-greater than
-code::syncFreq:: .
+Frequency of the synched sawtooth wave. Should always be greater than strong::syncFreq::.
+warning:: teletype::SyncSaw:: will go out of range if the frequency exceeds the sampling rate (which for control rate is code::s.sampleRate / s.options.blockSize::).::
 
 
 argument::mul
 
-Output will be multiplied by this value.
+The output will be multiplied by this value.
 
 
 argument::add

--- a/HelpSource/Classes/T2A.schelp
+++ b/HelpSource/Classes/T2A.schelp
@@ -10,9 +10,9 @@ classmethods::
 method:: ar
 
 argument:: in
-input signal.
+A control rate input signal.
 argument:: offset
-sample offset within control period.
+A sample offset within a control period. Internally clipped to an code::int:: in the range code::[0..blockSize-1]::.
 
 examples::
 code::

--- a/HelpSource/Classes/T2K.schelp
+++ b/HelpSource/Classes/T2K.schelp
@@ -4,13 +4,18 @@ categories:: UGens>Conversion, UGens>Triggers
 related:: Classes/T2A, Classes/K2A, Classes/A2K
 
 description::
-Converts audio rate trigger into control rate trigger, using the maximum trigger in the input during each control period.
+Converts audio rate trigger into control rate trigger, using the maximum trigger level in the input during each control period.
 
 classmethods::
 method:: kr
 
 argument:: in
-input signal.
+An audio rate input signal.
+
+discussion::
+note::
+During initialization of the UGen graph, teletype::T2K:: will only produce a trigger if one is received on the first audio-rate input frame. Any trigger received after the first frame, but within the first block, will not be seen at initialization time. Therefore, downstream UGens will also not receive that missed trigger, which may affect their initialization state. Once the Synth runs, however, teletype::T2K:: will trigger as expected.
+::
 
 examples::
 code::

--- a/HelpSource/Classes/VarSaw.schelp
+++ b/HelpSource/Classes/VarSaw.schelp
@@ -12,25 +12,37 @@ Sawtooth-triangle oscillator with variable duty.
 classmethods::
 private:: categories
 
-method::ar, kr
+method:: ar, kr
 
-argument::freq
-frequency in Hertz
+argument:: freq
+Frequency in Hertz. Positive frequencies only.
+warning:: teletype::VarSaw:: will go out of range if the frequency exceeds the sampling rate (which for control rate is code::s.sampleRate / s.options.blockSize::).::
 
-argument::iphase
-initial phase offset in cycles (0..1)
 
-argument::width
-duty cycle from zero to one.
+argument:: iphase
+Initial phase offset in cycles. [0..1]
 
-argument::mul
+argument:: width
+Duty cycle, denoting where in the cycle the waveform peaks.
+E.g. for widths of teletype::0, 0.5,:: or teletype::1.0::, the waveform will peak at the beginning, middle, or end of the cycle, respectively.
+[0..1] (clipped internally to [0.001..0.999])
 
-argument::add
+argument:: mul
+The output will be multiplied by this value.
+
+argument:: add
+This value will be added to the output.
+
+
 
 Examples::
 
 code::
 
+// observe different duty widths
+{ VarSaw.ar(1000, 0, [0, 0.5, 1]) }.plot
+
+(
 play({
 	VarSaw.ar(
 		LFPulse.kr(3, 0, 0.3, 200, 200),
@@ -38,7 +50,7 @@ play({
 		LFTri.kr(1.0).range(0, 1), // width
 		0.1)
 });
-
+)
 
 play({ VarSaw.ar(LFPulse.kr(3, 0, 0.3, 200, 200), 0, 0.2, 0.1) });
 

--- a/SCClassLibrary/Common/Audio/Trig.sc
+++ b/SCClassLibrary/Common/Audio/Trig.sc
@@ -225,13 +225,17 @@ InRange : UGen {
 }
 
 InRect : UGen {
-	*ar { arg x = 0.0, y = 0.0, rect;
+	*ar { arg x, y, rect;
 		^this.multiNew('audio', x, y, rect.left, rect.top,
 			rect.right, rect.bottom)
 	}
 	*kr { arg x = 0.0, y = 0.0, rect;
 		^this.multiNew('control', x, y, rect.left, rect.top,
 			rect.right, rect.bottom)
+	}
+	checkInputs {
+		if(rate == \audio) { ^this.checkNInputs(2) };
+		^this.checkValidInputs
 	}
 }
 

--- a/SCClassLibrary/Common/Audio/Trig.sc
+++ b/SCClassLibrary/Common/Audio/Trig.sc
@@ -235,17 +235,6 @@ InRect : UGen {
 	}
 }
 
-
-//Trapezoid : UGen
-//{
-//	*ar { arg in = 0.0, a = 0.2, b = 0.4, c = 0.6, d = 0.8;
-//		^this.multiNew('audio', in, a, b, c, d)
-//	}
-//	*kr { arg in = 0.0, a = 0.2, b = 0.4, c = 0.6, d = 0.8;
-//		^this.multiNew('control', in, a, b, c, d)
-//	}
-//}
-
 Fold : InRange {}
 Clip : InRange {}
 Wrap : InRange {}

--- a/SCClassLibrary/Common/Audio/UGen.sc
+++ b/SCClassLibrary/Common/Audio/UGen.sc
@@ -343,7 +343,6 @@ UGen : AbstractFunction {
 		if (rate == 'audio') {
 			n.do {| i |
 				if (inputs.at(i).rate != 'audio') {
-					//"failed".postln;
 					^("input " ++ i ++ " is not audio rate: " + inputs.at(i) + inputs.at(0).rate);
 				};
 			};

--- a/server/plugins/LFUGens.cpp
+++ b/server/plugins/LFUGens.cpp
@@ -2114,7 +2114,7 @@ void AmpComp_Ctor(AmpComp* unit) {
         unit->m_exponent = -1.f * exp;
         SETCALC(AmpComp_next);
     }
-    AmpComp_next(unit, 1);
+    AmpComp_next_kk(unit, 1);
 }
 
 

--- a/server/plugins/LFUGens.cpp
+++ b/server/plugins/LFUGens.cpp
@@ -114,6 +114,7 @@ struct Fold : public Unit {
     float m_lo, m_hi, m_range;
 };
 
+// Note: no classlib definition for Unwrap!
 struct Unwrap : public Unit {
     float m_range, m_half, m_offset, m_prev;
 };
@@ -1963,6 +1964,7 @@ void Clip_Ctor(Clip* unit) {
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////
+// Note: no classlib definition for Unwrap!
 
 void Unwrap_next(Unwrap* unit, int inNumSamples) {
     float* out = ZOUT(0);

--- a/server/plugins/LFUGens.cpp
+++ b/server/plugins/LFUGens.cpp
@@ -93,11 +93,6 @@ struct XLine : public Unit {
     int mCounter;
 };
 
-struct Cutoff : public Unit {
-    double mLevel, mSlope;
-    int mWaitCounter;
-};
-
 struct LinExp : public Unit {
     float m_dstratio, m_rsrcrange, m_rrminuslo, m_dstlo;
 };

--- a/server/plugins/LFUGens.cpp
+++ b/server/plugins/LFUGens.cpp
@@ -1096,13 +1096,16 @@ void VarSaw_Ctor(VarSaw* unit) {
     }
 
     unit->mFreqMul = unit->mRate->mSampleDur;
-    unit->mPhase = ZIN0(1);
-    float duty = ZIN0(2);
-    duty = unit->mDuty = sc_clip(duty, 0.001, 0.999);
+    double phase = unit->mPhase = sc_wrap(static_cast<double>(ZIN0(1)), 0.0, 1.0);
+    float duty = unit->mDuty = sc_clip(ZIN0(2), 0.001f, 0.999f);
     unit->mInvDuty = 2.f / duty;
     unit->mInv1Duty = 2.f / (1.f - duty);
 
-    ZOUT0(0) = 0.f;
+    VarSaw_next_k(unit, 1);
+
+    unit->mPhase = phase;
+    // other members need not be reset, duty is unchanged because phase is
+    // guaranteed to be in range
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////

--- a/server/plugins/LFUGens.cpp
+++ b/server/plugins/LFUGens.cpp
@@ -1553,38 +1553,6 @@ void XLine_Ctor(XLine* unit) {
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////
-/*
-void Wrap_next(Wrap* unit, int inNumSamples)
-{
-    float *out = ZOUT(0);
-    float *in   = ZIN(0);
-    float lo = unit->m_lo;
-    float hi = unit->m_hi;
-    float range = unit->m_range;
-
-    LOOP1(inNumSamples,
-        ZXP(out) = sc_wrap(ZXP(in), lo, hi, range);
-    );
-}
-
-void Wrap_Ctor(Wrap* unit)
-{
-
-    SETCALC(Wrap_next);
-    unit->m_lo = ZIN0(1);
-    unit->m_hi = ZIN0(2);
-
-    if (unit->m_lo > unit->m_hi) {
-        float temp = unit->m_lo;
-        unit->m_lo = unit->m_hi;
-        unit->m_hi = temp;
-    }
-    unit->m_range = unit->m_hi - unit->m_lo;
-
-    Wrap_next(unit, 1);
-}
-*/
-
 
 void Wrap_next_kk(Wrap* unit, int inNumSamples) {
     float* out = ZOUT(0);
@@ -1661,39 +1629,7 @@ void Wrap_Ctor(Wrap* unit) {
 
 
 //////////////////////////////////////////////////////////////////////////////////////////////////
-/*
-void Fold_next(Fold* unit, int inNumSamples)
-{
-    float *out = ZOUT(0);
-    float *in   = ZIN(0);
-    float lo = unit->m_lo;
-    float hi = unit->m_hi;
-    float range = unit->m_range;
-    float range2 = unit->m_range2;
 
-    LOOP1(inNumSamples,
-        ZXP(out) = sc_fold(ZXP(in), lo, hi, range, range2);
-    );
-}
-
-void Fold_Ctor(Fold* unit)
-{
-
-    SETCALC(Fold_next);
-    unit->m_lo = ZIN0(1);
-    unit->m_hi = ZIN0(2);
-
-    if (unit->m_lo > unit->m_hi) {
-        float temp = unit->m_lo;
-        unit->m_lo = unit->m_hi;
-        unit->m_hi = temp;
-    }
-    unit->m_range = unit->m_hi - unit->m_lo;
-    unit->m_range2 = 2.f * unit->m_range;
-
-    Fold_next(unit, 1);
-}
-*/
 void Fold_next_kk(Fold* unit, int inNumSamples) {
     float* out = ZOUT(0);
     float* in = ZIN(0);

--- a/server/plugins/LFUGens.cpp
+++ b/server/plugins/LFUGens.cpp
@@ -1262,7 +1262,7 @@ void T2K_Ctor(T2K* unit) {
 
 static inline void T2A_write_trigger(T2A* unit, float level) {
     float* out = OUT(0);
-    int offset = (int)IN0(1);
+    int offset = sc_clip(static_cast<int>(IN0(1)), 0, BUFLENGTH - 1);
     out[offset] = level;
 }
 
@@ -1308,7 +1308,10 @@ void T2A_Ctor(T2A* unit) {
     else
 #endif
         SETCALC(T2A_next);
+
+    unit->mLevel = 0.f;
     T2A_next(unit, 1);
+    unit->mLevel = 0.f;
 }
 
 

--- a/server/plugins/LFUGens.cpp
+++ b/server/plugins/LFUGens.cpp
@@ -138,11 +138,6 @@ struct InRect : public Unit {
     // nothing
 };
 
-// struct Trapezoid : public Unit
-//{
-//  float m_leftScale, m_rightScale, m_a, m_b, m_c, m_d;
-//};
-
 struct A2K : public Unit {};
 
 struct T2K : public Unit {};

--- a/server/plugins/LFUGens.cpp
+++ b/server/plugins/LFUGens.cpp
@@ -2422,15 +2422,6 @@ static void LinExp_SetCalc(LinExp* unit) {
 
     if (!allScalar)
         return;
-
-    float srclo = ZIN0(1);
-    float srchi = ZIN0(2);
-    float dstlo = ZIN0(3);
-    float dsthi = ZIN0(4);
-    unit->m_dstlo = dstlo;
-    unit->m_dstratio = dsthi / dstlo;
-    unit->m_rsrcrange = sc_reciprocal(srchi - srclo);
-    unit->m_rrminuslo = unit->m_rsrcrange * -srclo;
 }
 
 void LinExp_Ctor(LinExp* unit) {

--- a/testsuite/classlibrary/TestCoreUGens.sc
+++ b/testsuite/classlibrary/TestCoreUGens.sc
@@ -55,6 +55,19 @@ TestCoreUGens : UnitTest {
 			"Latch applied to LFPulse.kr on its own changes is no-op" -> {n=LFPulse.kr(23, 0.5); n - Latch.kr(n, HPZ1.kr(n).abs)},
 			"Gate applied to LFPulse.ar on its own changes is no-op" -> {n=LFPulse.ar(23, 0.5); n - Gate.ar(n, HPZ1.ar(n).abs)},
 			"Gate applied to LFPulse.kr on its own changes is no-op" -> {n=LFPulse.kr(23, 0.5); n - Gate.kr(n, HPZ1.kr(n).abs)},
+			"T2A should recover an ar signal passed through T2K" -> {
+				// note this freq has to be less than half critical sampling at control rate
+				// so that the kr signal goes to zero between frames so it's interpreted
+				// as a trigger by T2A (otherwise it's just a DC kr signal, which isn't a trigger)
+				var trigFreq = server.sampleRate / (server.options.blockSize) / 2;
+				var arTrig = Impulse.ar(trigFreq);
+				arTrig - T2A.ar(T2K.kr(arTrig))
+			},
+			"T2A with offset should recover a delayed ar signal passed through T2K" -> {
+				var trigFreq = server.sampleRate / (server.options.blockSize) / 2;
+				var arTrig = Delay2.ar(Impulse.ar(trigFreq));
+				arTrig - T2A.ar(T2K.kr(arTrig), offset: 2)
+			},
 
 			//////////////////////////////////////////
 			// Linear-to-exponential equivalences:


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation
A majority of UGens do not initialize with a correct initialization sample, and subsequently output an incorrect first sample. This PR is part of an ongoing effort to [fix UGen initializations](https://github.com/supercollider/rfcs/pull/19), the progress of which is [tracked here](https://github.com/mtmccrea/supercollider/wiki/UGen-Fix-List).

#### This fixes the initialization of a batch of `LFUGens`:
- `VarSaw`: properly reset state on initialization
- `T2A`: fix initialization, clip offset to buflength
- `InRect`: check input rates on x and y, init is OK
- `AmpComp`: call correct calc func in Ctor
#### Tests added for:
- `VarSaw`, `T2A`
#### Cleanup
- `LinExp`: remove repeated code from `LinExp_SetCalc`
- `Wrap`, `Trapezoid`: remove commented-out code
- `Unwrap`:  add note re: missing class definition
- `Cutoff`: remove struct to non-existant UGen
#### Documentation was added to:
- `VarSaw`, `SyncSaw`, `T2K`, `T2A`, `InRect`, `InRange`, `AmpCompA`
#### UGens reviewed and tested, no fix needed:
- `A2K`, `DC`, `Clip`, `Wrap`, `Fold`, `ModDif`

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->
(fixed Issues will be updated here)
- Fixes #4228

## Types of changes

<!-- Delete lines that don't apply -->

- Documentation
- Bug fix
- Breaking change - changes are technically breaking for the first output sample (or, e.g., a one-sample phase change from previously)

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review
