### PR TITLE
[plugins] EnvGen: fix initialization

### DIFF
--- a/HelpSource/Classes/Env.schelp
+++ b/HelpSource/Classes/Env.schelp
@@ -455,24 +455,45 @@ Env.cutoff(1, 1, \sine).test(2).plot;
 ::
 
 method::circle
-Creates a new envelope specification which cycles through its values. Unlike the link::#*new:: method, the strong::levels::, strong::times:: and strong::curve:: arrays are all the same size. The loopback time and curve are the last element of those arrays.
+Creates a new envelope which, when used by an link::Classes/EnvGen::, cycles through its values.
 
-For making a instantiated envelope cyclic, you can use the instance method link::#-circle::
+For making an already-created envelope cyclic, you can use the link::#-circle:: instance method, which takes the looparound time and curve as arguments.
 
 argument::levels
 The levels through which the envelope passes.
 
 argument::times
-The time between subsequent points in the envelope, which may be a single value (number), or an array of them. If too short, the array is extended.
+The time between subsequent strong::levels:: in the envelope. The last value is the looparound time.
+The array size of strong::times:: should be the same size of the strong::levels:: array.
 
 argument::curve
-The curvature of the envelope, which may be a single value (number or symbol), or an array of them.  If too short, the array is extended.
+The curvature of the envelope segments. The last value is the looparound curve. See link::#*new:: for valid values.
+The array size of strong::curve:: should be the same size of the strong::levels:: array.
 
+note::
+If a single value is given for strong::times:: or strong::curve::, or if the array is too short, it will be extended by wrapping around the given values
+::
 
 discussion::
+note::
+
+The circular code::Env:: must be instantiated inside the function used to construct the link::Classes/SynthDef::. It will not work not work if it is instantiated outside the function, e.g. passed in as a variable.
+
+Due to the internal initializing the cyclic behavior, there is a one-sample delay of the envelope.
+::
+
 code::
-// Plot the envelope
-{ EnvGen.kr(Env.circle([0.1, 1, 0.3], [0.01, 0.03, 0.06])) }.plot(0.4)
+( // Plot the envelope using *circle and -circle
+var loopBackTime = 0.06;
+{ [
+	EnvGen.kr(
+		Env.circle([0.5, 1, 0.3], [0.01, 0.03, loopBackTime])
+	),
+	EnvGen.kr(
+		Env.new([0.5, 1, 0.3], [0.01, 0.03]).circle(loopBackTime)
+	)
+] }.plot(0.1 * 4 - 0.01).plotMode_(\dlines)
+)
 
 // A sound example
 { SinOsc.ar(EnvGen.kr(Env.circle([0, 1, 0], [0.01, 0.5, 0.2])) * 440 + 200) * 0.2 }.play;
@@ -682,17 +703,31 @@ e.totalDuration;
 ::
 
 method::circle
-Declare the code::Env:: as circular, so that when used with link::Classes/EnvGen::, the code::Env:: is looped through cyclically.
+Declare the code::Env:: as circular so that, when used with link::Classes/EnvGen::, the code::Env:: is looped through cyclically.
 
-Note that if strong::timeFromLastToFirst:: is not specified, the loopback time is immediate (one sample). Create a circular code::Env:: directly with the class method link::#*circle::.
+You can create a circular code::Env:: directly with the link::#*circle:: class method.
+
+argument:: timeFromLastToFirst
+The time to loop around from the last to the first level of the code::Env::.
+If not specified, the looparound time is immediate (one sample).
+
+argument:: curve
+The curvature of segment connecting the last and first level of the code::Env::.
+Possible values are the same as in the link::#*new:: strong::curves:: argument.
 
 discussion::
+note::
+The circular code::Env:: must be instantiated inside the function used to construct the link::Classes/SynthDef::. It will not work not work if it is instantiated outside the function, e.g. passed in as a variable.
+
+Due to the internal initializing the cyclic behavior, there is a one-sample delay of the envelope.
+::
+
 code::
 // No args: loopback is immediate
-{ EnvGen.kr(Env([0.1, 1, 0.5], [0.01, 0.03]).circle) }.plot(0.2).plotMode_(\points)
+{ EnvGen.kr(Env([0.1, 1, 0.5], [0.01, 0.03]).circle) }.plot(0.2).plotMode_(\dlines)
 
 // With loopback time and curve specified
-{ EnvGen.kr(Env([0.1, 1, 0.5], [0.01, 0.03]).circle(0.05, \sin)) }.plot(0.2).plotMode_(\points)
+{ EnvGen.kr(Env([0.1, 1, 0.5], [0.01, 0.03]).circle(0.05, \sin)) }.plot(0.2).plotMode_(\dlines)
 
 ( // Looping frequency modulation
 {

--- a/SCClassLibrary/Common/Audio/Env.sc
+++ b/SCClassLibrary/Common/Audio/Env.sc
@@ -321,7 +321,7 @@ Env {
 	circle { arg timeFromLastToFirst = 0.0, curve = \lin;
 		var first0Then1;
 		if(UGen.buildSynthDef.isNil) { ^this };
-		first0Then1 = Latch.kr(1.0, Delay1.kr(Impulse.kr(0.0)));
+		first0Then1 = Latch.kr(1.0, Delay1.kr(Impulse.kr(0.0), x1: 0.0));
 		if(releaseNode.isNil) {
 			levels = [0.0] ++ levels ++ 0.0;
 			curves = [curve] ++ curves.asArray.wrapExtend(times.size) ++ \lin;

--- a/SCClassLibrary/Common/Audio/Env.sc
+++ b/SCClassLibrary/Common/Audio/Env.sc
@@ -323,12 +323,12 @@ Env {
 		if(UGen.buildSynthDef.isNil) { ^this };
 		first0Then1 = Latch.kr(1.0, Delay1.kr(Impulse.kr(0.0), x1: 0.0));
 		if(releaseNode.isNil) {
-			levels = [0.0] ++ levels ++ 0.0;
+			levels = [levels.first] ++ levels ++ 0.0; // appended 0.0 is a dummy value - never reached
 			curves = [curve] ++ curves.asArray.wrapExtend(times.size) ++ \lin;
 			times  = [first0Then1 * timeFromLastToFirst] ++ times ++ inf;
 			releaseNode = levels.size - 2;
 		} {
-			levels = [0.0] ++ levels;
+			levels = [levels.first] ++ levels;
 			curves = [curve] ++ curves.asArray.wrapExtend(times.size);
 			times  = [first0Then1 * timeFromLastToFirst] ++ times;
 			releaseNode = releaseNode + 1;

--- a/server/plugins/LFUGens.cpp
+++ b/server/plugins/LFUGens.cpp
@@ -2483,7 +2483,6 @@ void EnvGen_next_ak_nova(EnvGen* unit, int inNumSamples);
 #define ENVGEN_NOT_STARTED 1000000000
 
 void EnvGen_Ctor(EnvGen* unit) {
-    // Print("EnvGen_Ctor A\n");
     if (unit->mCalcRate == calc_FullRate) {
         if (INRATE(0) == calc_FullRate) {
             SETCALC(EnvGen_next_aa);
@@ -2540,9 +2539,6 @@ void EnvGen_Ctor(EnvGen* unit) {
 // - level: current envelope value
 // - dur: if supplied and >= 0, stretch segment to last dur seconds (used in forced release)
 static bool EnvGen_initSegment(EnvGen* unit, int& counter, double& level, double dur = -1) {
-    // Print("stage %d\n", unit->m_stage);
-    // Print("initSegment\n");
-    // out = unit->m_level;
     int stageOffset = (unit->m_stage << 2) + kEnvGen_nodeOffset;
 
     if (stageOffset + 4 > unit->mNumInputs) {
@@ -2572,7 +2568,6 @@ static bool EnvGen_initSegment(EnvGen* unit, int& counter, double& level, double
 
     if (counter == 1)
         unit->m_shape = 1; // shape_Linear
-    // Print("new counter = %d  shape = %d\n", counter, unit->m_shape);
     switch (unit->m_shape) {
     case shape_Step: {
         level = endLevel;
@@ -2582,7 +2577,6 @@ static bool EnvGen_initSegment(EnvGen* unit, int& counter, double& level, double
     } break;
     case shape_Linear: {
         unit->m_grow = (endLevel - level) / counter;
-        // Print("grow %g\n", unit->m_grow);
     } break;
     case shape_Exponential: {
         unit->m_grow = pow(endLevel / level, 1.0 / counter);
@@ -2629,7 +2623,7 @@ static bool EnvGen_initSegment(EnvGen* unit, int& counter, double& level, double
         unit->m_grow = (unit->m_y2 - unit->m_y1) / counter;
     } break;
     case shape_Cubed: {
-        unit->m_y1 = pow(level, 1.0 / 3.0); // 0.33333333);
+        unit->m_y1 = pow(level, 1.0 / 3.0);
         unit->m_y2 = pow(endLevel, 1.0 / 3.0);
         unit->m_grow = (unit->m_y2 - unit->m_y1) / counter;
     } break;
@@ -2678,12 +2672,9 @@ static inline bool check_gate_ar(EnvGen* unit, int i, float& prevGate, float*& g
 }
 
 static inline bool EnvGen_nextSegment(EnvGen* unit, int& counter, double& level) {
-    // Print("stage %d rel %d\n", unit->m_stage, (int)ZIN0(kEnvGen_releaseNode));
     int numstages = (int)ZIN0(kEnvGen_numStages);
 
-    // Print("stage %d   numstages %d\n", unit->m_stage, numstages);
     if (unit->m_stage + 1 >= numstages) { // num stages
-        // Print("stage+1 > num stages\n");
         counter = INT_MAX;
         unit->m_shape = 0;
         level = unit->m_endLevel;
@@ -2703,7 +2694,6 @@ static inline bool EnvGen_nextSegment(EnvGen* unit, int& counter, double& level)
             unit->m_shape = shape_Sustain;
             level = unit->m_endLevel;
         }
-        // Print("sustain\n");
     } else {
         unit->m_stage++;
         return EnvGen_initSegment(unit, counter, level);
@@ -2832,7 +2822,6 @@ static inline void EnvGen_perform(EnvGen* unit, float*& out, double& level, int 
 
 void EnvGen_next_k(EnvGen* unit, int inNumSamples) {
     float gate = ZIN0(kEnvGen_gate);
-    // Print("->EnvGen_next_k gate %g\n", gate);
     int counter = unit->m_counter;
     double level = unit->m_level;
 
@@ -2852,7 +2841,6 @@ void EnvGen_next_k(EnvGen* unit, int inNumSamples) {
     float* out = ZOUT(0);
     EnvGen_perform(unit, out, level, 1);
 
-    // Print("x %d %d %d %g\n", unit->m_stage, counter, unit->m_shape, *out);
     unit->m_level = level;
     unit->m_counter = counter - 1;
 }
@@ -2880,7 +2868,7 @@ void EnvGen_next_ak(EnvGen* unit, int inNumSamples) {
         remain -= nsmps;
         counter -= nsmps;
     }
-    // Print("x %d %d %d %g\n", unit->m_stage, counter, unit->m_shape, ZOUT0(0));
+
     unit->m_level = level;
     unit->m_counter = counter;
 }
@@ -2935,7 +2923,7 @@ FLATTEN void EnvGen_next_ak_nova(EnvGen* unit, int inNumSamples) {
         remain -= nsmps;
         counter -= nsmps;
     }
-    // Print("x %d %d %d %g\n", unit->m_stage, counter, unit->m_shape, ZOUT0(0));
+
     unit->m_level = level;
     unit->m_counter = counter;
 }


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation
This fixes the initialization of `EnvGen` as well as improves (but doesn't fully fix) a segment duration bug, #6180.

Additionally:
- unit tests added to check initialization by the first output sample.
- fix an `Env.circle` startup behavior

This PR is part of an ongoing effort to [fix UGen initializations](https://github.com/supercollider/rfcs/pull/19), the progress of which is [tracked here](https://github.com/mtmccrea/supercollider/wiki/UGen-Fix-List).

**Note:** I did some cleanup of extraneous print statements and stray comments, as a standalone commit. If this isn't preferred, I can remove it. I think it's helpful to clean up as we go.

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->


## Types of changes

<!-- Delete lines that don't apply -->

- Bug fixes
- Breaking change - changes are technically breaking for the first output sample (or, e.g., a one-sample phase change from previously)

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
  - ~~the state of the CoreUGens unit test is the same as reported in https://github.com/supercollider/supercollider/pull/6035 (all relevant tests passing)~~
  - ~~`TestEnvGen_server:test_shapeHold_setEndValue` fails but is fixed by fixed by #6185~~
- [ ] Documentation updated: n/a
- [x] This PR is ready for review