### PR TITLE
Fix Env:-circle, add to docs

### DIFF
--- a/HelpSource/Classes/Env.schelp
+++ b/HelpSource/Classes/Env.schelp
@@ -435,23 +435,38 @@ Env.cutoff(1, 1, \sine).test(2).plot;
 ::
 
 method::circle
-Creates a new envelope specification which cycles through its values. For making a given envelope cyclic, you can use the instance method link::#-circle::
+Creates a new envelope specification which cycles through its values. Unlike the link::#*new:: method, the strong::levels::, strong::times:: and strong::curve:: arrays are all the same size. The loopback time and curve are the last element of those arrays.
+
+For making a instantiated envelope cyclic, you can use the instance method link::#-circle::
 
 argument::levels
 The levels through which the envelope passes.
 
 argument::times
-The time between subsequent points in the envelope, which may be a single value (number), or an array of them. If too short, the array is extended. In difference to the *new method, the size of the times array is the same as that of the levels, because it includes the loop time.
+The time between subsequent points in the envelope, which may be a single value (number), or an array of them. If too short, the array is extended.
 
 argument::curve
-The curvature of the envelope, which may be a single value (number or symbol), or an array of them.  If too short, the array is extended. In difference to the *new method, the size of the curve array is the same as that of the levels, because it includes the loop time.
+The curvature of the envelope, which may be a single value (number or symbol), or an array of them.  If too short, the array is extended.
 
 
 discussion::
 code::
+// Plot the envelope
+{ EnvGen.kr(Env.circle([0.1, 1, 0.3], [0.01, 0.03, 0.06])) }.plot(0.4)
+
+// A sound example
 { SinOsc.ar(EnvGen.kr(Env.circle([0, 1, 0], [0.01, 0.5, 0.2])) * 440 + 200) * 0.2 }.play;
+
+// Times are repeated if times.size < levels.size
 { SinOsc.ar(EnvGen.kr(Env.circle([0, 1, 0, 2, 0, 1, 0], [0.01, 0.3])) * 440 + 200) * 0.2 }.play;
-{ SinOsc.ar(EnvGen.kr(Env.circle([0, 1, 0, (2..4), 0, (1..3), 0], [0.01, 0.3])) * 440 + 200).sum * 0.2 }.play; // multichannel expanded levels
+
+( // Multichannel expansion of levels
+{ SinOsc.ar(EnvGen.kr(Env.circle(
+    [0, 1, 0, 0.5 * (1..4), 0, 2.sqrt/2 * (1..4), 0],
+    [0.01, 0.3]
+)) * 440 + 200).clump(2).collect(_.sum) * 0.2
+}.scope;
+)
 ::
 
 subsection::Multichannel expansion
@@ -645,25 +660,44 @@ e.totalDuration;
 ::
 
 method::circle
-circle from end to beginning over the time specified, with the curve specified. See also the class method link::#*circle::
+Declare the code::Env:: as circular, so that when used with link::Classes/EnvGen::, the code::Env:: is looped through cyclically.
+
+Note that if strong::timeFromLastToFirst:: is not specified, the loopback time is immediate (one sample). Create a circular code::Env:: directly with the class method link::#*circle::.
 
 discussion::
 code::
-(
-{ SinOsc.ar(
-	EnvGen.kr(
-		Env([6000, 700, 100], [1, 1], ['exp', 'lin']).circle.postcs)
-	) * 0.1
-	+ Impulse.ar(1) }.play;
+// No args: loopback is immediate
+{ EnvGen.kr(Env([0.1, 1, 0.5], [0.01, 0.03]).circle) }.plot(0.2).plotMode_(\points)
+
+// With loopback time and curve specified
+{ EnvGen.kr(Env([0.1, 1, 0.5], [0.01, 0.03]).circle(0.05, \sin)) }.plot(0.2).plotMode_(\points)
+
+( // Looping frequency modulation
+{
+    SinOsc.ar(
+        EnvGen.kr(
+            Env(
+                [6000, 700, 100], [1, 1], ['exp', 'lin']
+            ).circle.postcs // post internal representation
+        )
+    ) * 0.1
+    // add an audible metronome
+    + (SinOsc.ar(280) * Decay.ar(Impulse.ar(1), 0.05) * 0.5)
+}.play;
 )
 
-(
-{ SinOsc.ar(
-	EnvGen.kr(
-		Env([6000, 700, 100], [1, 1], ['exp', 'lin']).circle(1).postcs,
-		MouseX.kr > 0.5)
-	) * 0.1
-	+ Impulse.ar(1) }.play;
+( // Control the gate with MouseX
+{
+    SinOsc.ar(
+        EnvGen.kr(
+            Env(
+                [6000, 700, 100], [0.5, 0.5], ['exp', 'lin']
+            ).circle(1).postcs,
+            MouseX.kr > 0.5
+        )
+    ) * 0.1
+    + (SinOsc.ar(280) * Decay.ar(Impulse.ar(1), 0.05) * 0.5)
+}.play;
 )
 ::
 

--- a/SCClassLibrary/Common/Audio/Env.sc
+++ b/SCClassLibrary/Common/Audio/Env.sc
@@ -321,7 +321,7 @@ Env {
 	circle { arg timeFromLastToFirst = 0.0, curve = \lin;
 		var first0Then1;
 		if(UGen.buildSynthDef.isNil) { ^this };
-		first0Then1 = Latch.kr(1.0, Impulse.kr(0.0));
+		first0Then1 = Latch.kr(1.0, Delay1.kr(Impulse.kr(0.0)));
 		if(releaseNode.isNil) {
 			levels = [0.0] ++ levels ++ 0.0;
 			curves = [curve] ++ curves.asArray.wrapExtend(times.size) ++ \lin;


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

Since `Impulse` was fixed, this construction doesn't work as intended (last line):
```supercollider
    circle { arg timeFromLastToFirst = 0.0, curve = \lin;
        var first0Then1;
        if(UGen.buildSynthDef.isNil) { ^this };
        first0Then1 = Latch.kr(1.0, Impulse.kr(0.0));
```
This PR fixes that, but relies on the merge of https://github.com/supercollider/supercollider/pull/6110, which fixes `Delay1`

An alternative would be 
```supercollider
first0Then1 = Latch.kr(1.0, TDelay.kr(Impulse.kr(0.0), ControlDur.ir));
```
But there's unfortunately a yet-to-be corrected initialization bug in `TDelay`.

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->
Discovered in, but is a separate bug than, https://github.com/supercollider/supercollider/issues/6180.

## Types of changes

<!-- Delete lines that don't apply -->

- Documentation
- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [ ] All tests are passing
  - it's complicated... but this doesn't cause any tests to fail that weren't failing already
- [x] Updated documentation
- [x] This PR is ready for review
