### PR TITLE
Tests: TestEnvGen_server: fix 2 tests

### DIFF
--- a/testsuite/classlibrary/TestEnvGen_server.sc
+++ b/testsuite/classlibrary/TestEnvGen_server.sc
@@ -27,6 +27,11 @@ TestEnvGen_server : UnitTest {
 			EnvGen.kr(Env([0, 1], [0.1]), doneAction: 2);
 		}.play(server);
 
+		// EnvGen is initialized by setting the state to the end of the Env,
+		// which fires the doneAction on initialization. So make sure that
+		// initialization has happened before adding these reponders.
+		server.sync;
+
 		n_off_resp = OSCFunc({
 			cleanup.value;
 			passed = false;
@@ -172,10 +177,11 @@ TestEnvGen_server : UnitTest {
 		var env = Env(curve: [\hold, \lin]);
 		var condvar = CondVar();
 		var result = [];
+		var timeScale = 0.01;
 
 		server.bootSync;
 
-		{ EnvGen.kr(env, timeScale: 0.01, doneAction:2) }.loadToFloatArray(0.01, server){ |values|
+		{ EnvGen.kr(env, timeScale: timeScale, doneAction:2) }.loadToFloatArray(env.duration * timeScale, server){ |values|
 			result = values;
 			condvar.signalOne;
 		};


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

One unit test has been breaking for a while on account of a doneAction firing in the course of initializing `EnvGen`:
- `test_zero_gate_n_off_not_sent`: let synth be initialized before adding responders

Another test started failing once the initialization sample problem for `EnvGen` was fixed (https://github.com/supercollider/supercollider/pull/6175), because incorrect initialization led to a false positive:
- `test_shapeHold_setEndValue`: let synth run long enough to pass.

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] This PR is ready for review
