### PR TITLE
class library: MultiOutUGen: better error for non-numeric numChannels arg

### DIFF
--- a/HelpSource/Classes/DecodeB2.schelp
+++ b/HelpSource/Classes/DecodeB2.schelp
@@ -17,7 +17,7 @@ method::ar, kr
 
 argument::numChans
 
-Number of output speakers. Typically 4 to 8.
+Number of output speakers. Typically 4 to 8. This cannot be assigned to a SynthDef argument and must be a fixed nonzero positive integer value.
 
 
 argument::w
@@ -66,4 +66,3 @@ code::
 )
 
 ::
-

--- a/HelpSource/Classes/DecodeB2.schelp
+++ b/HelpSource/Classes/DecodeB2.schelp
@@ -17,7 +17,7 @@ method::ar, kr
 
 argument::numChans
 
-Number of output speakers. Typically 4 to 8. This cannot be assigned to a SynthDef argument and must be a fixed nonzero positive integer value.
+Number of output speakers. Typically 4 to 8. Must be a nonzero, positive integer. This is fixed when the SynthDef is compiled so cannot be assigned to a SynthDef argument.
 
 
 argument::w

--- a/HelpSource/Classes/DiskIn.schelp
+++ b/HelpSource/Classes/DiskIn.schelp
@@ -18,7 +18,7 @@ private:: categories
 method::ar
 
 argument::numChannels
-Number of channels. This must match the number of channels in the buffer. This cannot be assigned to a SynthDef argument.
+Number of channels. This must match the number of channels in the buffer. Must be a nonzero, positive integer. This is fixed when the SynthDef is compiled so cannot be assigned to a SynthDef argument.
 
 argument::bufnum
 Buffer number

--- a/HelpSource/Classes/DiskIn.schelp
+++ b/HelpSource/Classes/DiskIn.schelp
@@ -18,7 +18,7 @@ private:: categories
 method::ar
 
 argument::numChannels
-Number of channels. This must match the number of channels in the buffer.
+Number of channels. This must match the number of channels in the buffer. This cannot be assigned to a SynthDef argument.
 
 argument::bufnum
 Buffer number
@@ -126,4 +126,3 @@ s.sendMsg("/b_close", 0); // close the file.
 
 s.sendMsg("/b_free", 0); // frees the buffer
 ::
-

--- a/HelpSource/Classes/GrainBuf.schelp
+++ b/HelpSource/Classes/GrainBuf.schelp
@@ -9,7 +9,7 @@ private:: categories
 method:: ar
 
 argument:: numChannels
-the number of channels to output. If 1, mono is returned and pan is ignored.
+the number of channels to output. If 1, mono is returned and pan is ignored. This cannot be assigned to a SynthDef argument and must be a fixed nonzero positive integer value.
 
 argument:: trigger
 a kr or ar trigger to start a new grain. If ar, grains after the start of the synth are sample accurate.
@@ -94,4 +94,3 @@ x.set(\envbuf, -1);
 
 x.set(\gate, 0);
 ::
-

--- a/HelpSource/Classes/GrainBuf.schelp
+++ b/HelpSource/Classes/GrainBuf.schelp
@@ -9,7 +9,7 @@ private:: categories
 method:: ar
 
 argument:: numChannels
-the number of channels to output. If 1, mono is returned and pan is ignored. This cannot be assigned to a SynthDef argument and must be a fixed nonzero positive integer value.
+the number of channels to output. If 1, mono is returned and pan is ignored. Must be a nonzero, positive integer. This is fixed when the SynthDef is compiled so cannot be assigned to a SynthDef argument.
 
 argument:: trigger
 a kr or ar trigger to start a new grain. If ar, grains after the start of the synth are sample accurate.

--- a/HelpSource/Classes/GrainFM.schelp
+++ b/HelpSource/Classes/GrainFM.schelp
@@ -9,7 +9,7 @@ private:: categories
 method:: ar
 
 argument:: numChannels
-the number of channels to output. If 1, mono is returned and pan is ignored.
+the number of channels to output. If 1, mono is returned and pan is ignored. This cannot be assigned to a SynthDef argument and must be a fixed nonzero positive integer value.
 
 argument:: trigger
 a kr or ar trigger to start a new grain. If ar, grains after the start of the synth are sample accurate.
@@ -87,4 +87,3 @@ x.set(\envbuf, -1);
 
 x.set(\gate, 0);
 ::
-

--- a/HelpSource/Classes/GrainFM.schelp
+++ b/HelpSource/Classes/GrainFM.schelp
@@ -9,7 +9,7 @@ private:: categories
 method:: ar
 
 argument:: numChannels
-the number of channels to output. If 1, mono is returned and pan is ignored. This cannot be assigned to a SynthDef argument and must be a fixed nonzero positive integer value.
+the number of channels to output. If 1, mono is returned and pan is ignored. Must be a nonzero, positive integer. This is fixed when the SynthDef is compiled so cannot be assigned to a SynthDef argument.
 
 argument:: trigger
 a kr or ar trigger to start a new grain. If ar, grains after the start of the synth are sample accurate.

--- a/HelpSource/Classes/GrainIn.schelp
+++ b/HelpSource/Classes/GrainIn.schelp
@@ -9,7 +9,7 @@ private:: categories
 method:: ar
 
 argument:: numChannels
-the number of channels to output. If 1, mono is returned and pan is ignored.
+the number of channels to output. If 1, mono is returned and pan is ignored. This cannot be assigned to a SynthDef argument and must be a fixed nonzero positive integer value.
 
 argument:: trigger
 a kr or ar trigger to start a new grain. If ar, grains after the start of the synth are sample accurate.
@@ -78,4 +78,3 @@ x.set(\envbuf, -1);
 
 x.set(\gate, 0);
 ::
-

--- a/HelpSource/Classes/GrainIn.schelp
+++ b/HelpSource/Classes/GrainIn.schelp
@@ -9,7 +9,7 @@ private:: categories
 method:: ar
 
 argument:: numChannels
-the number of channels to output. If 1, mono is returned and pan is ignored. This cannot be assigned to a SynthDef argument and must be a fixed nonzero positive integer value.
+the number of channels to output. If 1, mono is returned and pan is ignored. Must be a nonzero, positive integer. This is fixed when the SynthDef is compiled so cannot be assigned to a SynthDef argument.
 
 argument:: trigger
 a kr or ar trigger to start a new grain. If ar, grains after the start of the synth are sample accurate.

--- a/HelpSource/Classes/GrainSin.schelp
+++ b/HelpSource/Classes/GrainSin.schelp
@@ -9,7 +9,7 @@ private:: categories
 method:: ar
 
 argument:: numChannels
-the number of channels to output. If 1, mono is returned and pan is ignored.
+the number of channels to output. If 1, mono is returned and pan is ignored. This cannot be assigned to a SynthDef argument and must be a fixed nonzero positive integer value.
 
 argument:: trigger
 a kr or ar trigger to start a new grain. If ar, grains after the start of the synth are sample accurate.
@@ -83,4 +83,3 @@ x.set(\envbuf, -1);
 
 x.set(\gate, 0);
 ::
-

--- a/HelpSource/Classes/GrainSin.schelp
+++ b/HelpSource/Classes/GrainSin.schelp
@@ -9,7 +9,7 @@ private:: categories
 method:: ar
 
 argument:: numChannels
-the number of channels to output. If 1, mono is returned and pan is ignored. This cannot be assigned to a SynthDef argument and must be a fixed nonzero positive integer value.
+the number of channels to output. If 1, mono is returned and pan is ignored. Must be a nonzero, positive integer. This is fixed when the SynthDef is compiled so cannot be assigned to a SynthDef argument.
 
 argument:: trigger
 a kr or ar trigger to start a new grain. If ar, grains after the start of the synth are sample accurate.

--- a/HelpSource/Classes/MultiOutUGen.schelp
+++ b/HelpSource/Classes/MultiOutUGen.schelp
@@ -15,3 +15,5 @@ instancemethods::
 method:: initOutputs
 Create an array of OutputProxies for the outputs.
 
+argument:: numChannels
+Number of outputs. This cannot be assigned to a SynthDef argument and must be a fixed nonzero positive integer value.

--- a/HelpSource/Classes/MultiOutUGen.schelp
+++ b/HelpSource/Classes/MultiOutUGen.schelp
@@ -16,4 +16,4 @@ method:: initOutputs
 Create an array of OutputProxies for the outputs.
 
 argument:: numChannels
-Number of outputs. This cannot be assigned to a SynthDef argument and must be a fixed nonzero positive integer value.
+Number of outputs. Must be a nonzero, positive integer. This is fixed when the SynthDef is compiled so cannot be assigned to a SynthDef argument.

--- a/HelpSource/Classes/PanAz.schelp
+++ b/HelpSource/Classes/PanAz.schelp
@@ -15,7 +15,7 @@ method::ar, kr
 
 argument::numChans
 
-Number of output channels.
+Number of output channels. This cannot be assigned to a SynthDef argument and must be a fixed nonzero positive integer value.
 
 
 argument::in
@@ -118,4 +118,3 @@ code::
 )
 
 ::
-

--- a/HelpSource/Classes/PanAz.schelp
+++ b/HelpSource/Classes/PanAz.schelp
@@ -15,7 +15,7 @@ method::ar, kr
 
 argument::numChans
 
-Number of output channels. This cannot be assigned to a SynthDef argument and must be a fixed nonzero positive integer value.
+Number of output channels. Must be a nonzero, positive integer. This is fixed when the SynthDef is compiled so cannot be assigned to a SynthDef argument.
 
 
 argument::in

--- a/HelpSource/Classes/TGrains.schelp
+++ b/HelpSource/Classes/TGrains.schelp
@@ -15,7 +15,7 @@ classmethods::
 method::ar
 
 argument::numChannels
-The number of output channels.
+The number of output channels. This cannot be assigned to a SynthDef argument and must be a fixed nonzero positive integer value.
 
 argument::trigger
 At each trigger, the following arguments are sampled and used as

--- a/HelpSource/Classes/TGrains.schelp
+++ b/HelpSource/Classes/TGrains.schelp
@@ -15,7 +15,7 @@ classmethods::
 method::ar
 
 argument::numChannels
-The number of output channels. This cannot be assigned to a SynthDef argument and must be a fixed nonzero positive integer value.
+The number of output channels. Must be a nonzero, positive integer. This is fixed when the SynthDef is compiled so cannot be assigned to a SynthDef argument.
 
 argument::trigger
 At each trigger, the following arguments are sampled and used as

--- a/HelpSource/Classes/VDiskIn.schelp
+++ b/HelpSource/Classes/VDiskIn.schelp
@@ -10,7 +10,7 @@ classmethods::
 method:: ar
 
 argument:: numChannels
-number of channels
+number of channels. This cannot be assigned to a SynthDef argument and must be a fixed nonzero positive integer value.
 
 argument:: bufnum
 buffer number

--- a/HelpSource/Classes/VDiskIn.schelp
+++ b/HelpSource/Classes/VDiskIn.schelp
@@ -10,7 +10,7 @@ classmethods::
 method:: ar
 
 argument:: numChannels
-number of channels. This cannot be assigned to a SynthDef argument and must be a fixed nonzero positive integer value.
+number of channels. Must be a nonzero, positive integer. This is fixed when the SynthDef is compiled so cannot be assigned to a SynthDef argument.
 
 argument:: bufnum
 buffer number

--- a/HelpSource/Classes/Warp1.schelp
+++ b/HelpSource/Classes/Warp1.schelp
@@ -10,7 +10,7 @@ private:: categories
 
 method:: ar
 argument::numChannels
-the number of channels in the soundfile used in bufnum. This cannot be assigned to a SynthDef argument.
+the number of channels in the soundfile used in bufnum. Must be a nonzero, positive integer. This is fixed when the SynthDef is compiled so cannot be assigned to a SynthDef argument.
 
 argument::bufnum
 the buffer number of a mono soundfile.

--- a/HelpSource/Classes/Warp1.schelp
+++ b/HelpSource/Classes/Warp1.schelp
@@ -10,7 +10,7 @@ private:: categories
 
 method:: ar
 argument::numChannels
-the number of channels in the soundfile used in bufnum.
+the number of channels in the soundfile used in bufnum. This cannot be assigned to a SynthDef argument.
 
 argument::bufnum
 the buffer number of a mono soundfile.
@@ -101,4 +101,3 @@ b = Buffer.read(s, Platform.resourceDir +/+ "sounds/a11wlk01-44_1.aiff");
 )
 b.free;
 ::
-

--- a/SCClassLibrary/Common/Audio/InOut.sc
+++ b/SCClassLibrary/Common/Audio/InOut.sc
@@ -208,9 +208,6 @@ InFeedback : AbstractIn {
 		^this.multiNew('audio', numChannels, bus)
 	}
 	init { arg numChannels ... argBus;
-		numChannels.isNumber.or {
-			Error("InFeedback: numChannels not a number").throw;
-		};
 		inputs = argBus.asArray;
 		^this.initOutputs(numChannels, rate)
 	}

--- a/SCClassLibrary/Common/Audio/InOut.sc
+++ b/SCClassLibrary/Common/Audio/InOut.sc
@@ -208,6 +208,9 @@ InFeedback : AbstractIn {
 		^this.multiNew('audio', numChannels, bus)
 	}
 	init { arg numChannels ... argBus;
+		numChannels.isNumber.or {
+			Error("InFeedback: numChannels not a number").throw;
+		};
 		inputs = argBus.asArray;
 		^this.initOutputs(numChannels, rate)
 	}

--- a/SCClassLibrary/Common/Audio/UGen.sc
+++ b/SCClassLibrary/Common/Audio/UGen.sc
@@ -576,8 +576,8 @@ MultiOutUGen : UGen {
 	}
 
 	initOutputs { arg numChannels, rate;
-		if(numChannels.isNil or: { numChannels < 1 }, {
-			Error("%: wrong number of channels (%)".format(this, numChannels)).throw
+		if(numChannels.isInteger.not or: { numChannels < 1 }, {
+			Error("%: numChannels must be nonzero positive integer (%)".format(this, numChannels)).throw
 		});
 		channels = Array.fill(numChannels, { arg i;
 			OutputProxy(rate, this, i);

--- a/SCClassLibrary/Common/Audio/UGen.sc
+++ b/SCClassLibrary/Common/Audio/UGen.sc
@@ -577,7 +577,8 @@ MultiOutUGen : UGen {
 
 	initOutputs { arg numChannels, rate;
 		if(numChannels.isInteger.not or: { numChannels < 1 }, {
-			Error("%: numChannels must be nonzero positive integer (%)".format(this, numChannels)).throw
+			Error("%: numChannels must be a nonzero positive integer, but received (%)."
+              .format(this, numChannels)).throw
 		});
 		channels = Array.fill(numChannels, { arg i;
 			OutputProxy(rate, this, i);


### PR DESCRIPTION
## Purpose and Motivation

`InFeedback` and other MultiOutUGen subclasses only accept numerical arguments for `numChannels`, throwing a confusing error ("Non boolean in test"). This PR validates the `numChannels` argument in `init` and throws a straightforward error there. In addition it validates for integer values only.

## Types of changes

- Bug fix (really an improvement, but arguably the old error was a "bug")

## To-do list

I don't think testing is appropriate, given that this simply reports a failure differently/better. IMO validating error message text in tests is not a good practice on its own. Any errors introduced by this change should be discovered in CI.

- [ ] Code is tested (N/A)
- [ ] All tests are passing (N/A)
- [x] Updated documentation 
- [x] This PR is ready for review
