### PR TITLE
improve/fix plugin unloading

### DIFF
--- a/HelpSource/Guides/WritingUGens.schelp
+++ b/HelpSource/Guides/WritingUGens.schelp
@@ -133,6 +133,13 @@ list::
 ## The unit generator destructor is named code::PluginName_Dtor::
 ::
 
+subsection:: The Exit Point
+
+The optional code::PluginUnload():: macro exports a function that is called when the library is deinitialized,
+right before it is unloaded. This is only required in rare cases, typically for resource cleanup that cannot be safely done
+in a global object destructor. For example, the DiskIO UGens and UI UGens in code::DiskIO_UGens.cpp:: resp. code::UIUGens.cpp::
+use the unload function to safely join their worker threads.
+
 subsection:: The Calculation Function
 
 The meat of the UGen is its calculation function, which gets called every control period with the UGen object as an

--- a/include/plugin_interface/SC_InterfaceTable.h
+++ b/include/plugin_interface/SC_InterfaceTable.h
@@ -204,6 +204,7 @@ typedef enum { sc_server_scsynth = 0, sc_server_supernova = 1 } SC_ServerType;
 
 #ifdef STATIC_PLUGINS
 #    define PluginLoad(name) void name##_Load(InterfaceTable* inTable)
+#    define PluginUnload(name) void name##_Unload(void)
 #else
 #    ifdef SUPERNOVA
 #        define SUPERNOVA_CHECK                                                                                        \
@@ -217,6 +218,8 @@ typedef enum { sc_server_scsynth = 0, sc_server_supernova = 1 } SC_ServerType;
         C_LINKAGE SC_API_EXPORT int api_version(void) { return sc_api_version; }                                       \
         SUPERNOVA_CHECK                                                                                                \
         C_LINKAGE SC_API_EXPORT void load(InterfaceTable* inTable)
+
+#    define PluginUnload(name) C_LINKAGE SC_API_EXPORT void unload(void)
 #endif
 
 #define scfft_create (*ft->fSCfftCreate)

--- a/server/plugins/DiskIO_UGens.cpp
+++ b/server/plugins/DiskIO_UGens.cpp
@@ -627,7 +627,6 @@ void VDiskIn_next_rate1(VDiskIn* unit, int inNumSamples) {
 
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////
-C_LINKAGE SC_API_EXPORT void unload(InterfaceTable* inTable) { delete gDiskIO; }
 
 PluginLoad(DiskIO) {
     ft = inTable;
@@ -638,5 +637,7 @@ PluginLoad(DiskIO) {
     DefineDtorUnit(DiskOut);
     DefineSimpleUnit(VDiskIn);
 }
+
+PluginUnload(DiskIO) { delete gDiskIO; }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////

--- a/server/plugins/UIUGens.cpp
+++ b/server/plugins/UIUGens.cpp
@@ -275,7 +275,7 @@ PluginLoad(UIUGens) {
 }
 
 
-C_LINKAGE SC_API_EXPORT void unload(InterfaceTable* inTable) {
+PluginUnload(UIUGens) {
     inputThreadRunning = false;
     uiListenThread.join();
 

--- a/server/plugins/UIUGens.mm
+++ b/server/plugins/UIUGens.mm
@@ -205,7 +205,7 @@ PluginLoad(UIUGens) {
     DefineUnit("MouseButton", sizeof(MouseInputUGen), (UnitCtorFunc)&MouseButton_Ctor, 0, 0);
 }
 
-C_LINKAGE SC_API_EXPORT void unload(InterfaceTable* inTable) {
+PluginUnload(UIUGens) {
     inputThreadRunning = false;
     uiListenThread.join();
 }


### PR DESCRIPTION
## Purpose and Motivation

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

scsynth and supernova already try to unload plugins by searching for an "unload" function. However, this is not documented in the plugin API yet.

Changes:

* add `PluginUnload` macro to `SC_InterfaceTable.h`, so it can be easily used by third-party plugins

* use `PluginUnload` macro for the DiskIO and UI UGens (which actually had a wrong function signature!)

* unload static plugins

* don't forget to call `LoadLibrary()` resp. `dlclose()` in scsynth

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix
- New feature

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [ ] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review
