### PR TITLE
Decay, Decay2: fix UGen initialization

### DIFF
--- a/HelpSource/Classes/Decay.schelp
+++ b/HelpSource/Classes/Decay.schelp
@@ -1,15 +1,12 @@
 class:: Decay
 summary:: Exponential decay
-related:: Classes/Decay2
+related:: Classes/Decay2, Classes/Integrator
 categories:: UGens>Filters>Linear, UGens>Envelopes
 
 Description::
 
-This is essentially the same as  link::Classes/Integrator::  except that
-instead of supplying the coefficient directly, it is calculated from a 60
-dB decay time. This is the time required for the integrator to lose 99.9%
-of its value or -60dB. This is useful for exponential decaying envelopes
-triggered by impulses.
+An integrating filter which, if given an impulse, will produce an exponentially decaying envelope.
+code::Decay:: is essentially the same as link::Classes/Integrator::, but instead of specifying the integration coefficient directly, it is calculated from the strong::decayTime::—the time required for input signal to attentuate 60 dB, or decay to 99.9% of its value.
 
 classmethods::
 
@@ -19,18 +16,78 @@ argument::in
 The input signal.
 
 argument::decayTime
-60 dB decay time in seconds.
+The time it takes for the input signal to decay 60 dB.
 
 argument::mul
+The output will be multiplied by this value.
 
 argument::add
+This value will be added to the output.
 
 Examples::
 
 code::
-plot({ Decay.ar(Impulse.ar(1), 0.01) });
-
-// used as an envelope
-play({ Decay.ar(Impulse.ar(XLine.kr(1,50,20), 0.25), 0.2, PinkNoise.ar, 0) });
+// Plot the exponentially decaying envelope
+(
+var t60 = 0.1; // decayTime
+plot({ Decay.ar(Impulse.ar(0), t60) }, t60);
+)
 ::
 
+code::
+// Used as an evelope generator
+(
+play({
+    Decay.ar(
+        in: Impulse.ar(XLine.kr(5,50,10), 0.25),
+        decayTime: 0.2,
+        mul: FSinOsc.ar(300)
+    )
+})
+)
+::
+
+As can be heard in the previous example, when code::Decay:: is used as a modulator, its immediate onset can lead to discontinuities and audible clicks. This can be seen in the waveform:
+
+code::
+(
+plot({
+    Decay.ar(
+        in: Impulse.ar(50),
+        decayTime: 0.015,
+        mul: FSinOsc.ar(370)
+    )
+}, 0.1, bounds: Rect(50,50,1200,400))
+)
+::
+
+link::Classes/Decay2:: allows for onset control, as shown below:
+
+code::
+(
+var t60, riseScale, riseFac, normFac;
+
+t60 = 0.3; // decay time
+
+// Onset control and normalization factor for Decay2
+// (See Decay2 Help doc for more info)
+riseScale = 0.3;
+riseFac = riseScale / (2 - riseScale);
+normFac = riseFac.pow(riseFac / (riseFac - 1)) / (1 - riseFac);
+
+// Compare Decay (blue) and Decay2 (red)
+plot({
+    var imp = Impulse.ar(0);
+    [
+        Decay.ar(imp, t60),
+        Decay2.ar(imp,
+            attackTime: t60 * riseFac,
+            decayTime: t60,
+            mul: normFac
+        )
+    ]
+}, duration: t60/2)
+.plotColor_([Color.blue, Color.red])
+.superpose_(true)
+)
+::

--- a/HelpSource/Classes/Decay2.schelp
+++ b/HelpSource/Classes/Decay2.schelp
@@ -1,17 +1,23 @@
 class:: Decay2
 summary:: Exponential decay
-related:: Classes/Decay
+related:: Classes/Decay, Classes/Integrator
 categories::  UGens>Filters>Linear, UGens>Envelopes
 
 
 Description::
-link::Classes/Decay::  has a very sharp attack and can produce clicks.
-Decay2 rounds off the attack by subtracting one Decay from another.
-code:: Decay2.ar(in, attackTime, decayTime):: is equivalent to:
+An integrating filter like link::Classes/Decay::, but both the onset time and decay time can be specified.
 
-code::
+teletype::
+Decay2.ar(in, attackTime, decayTime)
+::
+
+is equivalent to:
+
+teletype::
 Decay.ar(in, decayTime) - Decay.ar(in, attackTime)
 ::
+
+For precise control over the attack, decay, and level of code::Decay2:: see link::#Onset control and normalizing the envelope of Decay2:: and link::#Calculating rise time and maximum rise time of Decay2:: below.
 
 
 classmethods::
@@ -19,37 +25,134 @@ classmethods::
 method::ar, kr
 
 argument::in
-
 The input signal.
 
-
 argument::attackTime
-
 60 dB attack time in seconds.
 
-
 argument::decayTime
-
 60 dB decay time in seconds.
 
-
 argument::mul
+The output will be multiplied by this value.
 
 argument::add
+This value will be added to the output.
 
 
 Examples::
 
 code::
-// since attack and decay are a difference of two Decays,
-// swapping the values, the envelope turns upside down:
-plot({ Decay2.ar(Impulse.ar(1), 0.001, 0.01) })
-plot({ Decay2.ar(Impulse.ar(1), 0.01, 0.001) })
-
-// used as an envelope
-{ Decay2.ar(Impulse.ar(XLine.kr(1,50,20), 0.25), 0.01, 0.2, FSinOsc.ar(600)) }.play;
-
-// compare the above with Decay used as the envelope
-{ Decay.ar(Impulse.ar(XLine.kr(1,50,20), 0.25), 0.2, FSinOsc.ar(600), 0)  }.play;
+// Used as an envelope
+play{ Decay2.ar(Impulse.ar(XLine.kr(1,50,20), 0.25), 0.01, 0.2, FSinOsc.ar(600)) };
+// Compare to Decay
+play{ Decay.ar(Impulse.ar(XLine.kr(1,50,20), 0.25), 0.2, FSinOsc.ar(600), 0) };
 ::
 
+Since code::Decay2:: is equivalent to the difference of two link::Classes/Decay::s, swapping the strong::attackTime:: and strong::decayTime:: inverts the envelope:
+
+code::
+(
+plot({
+    var attack = 0.001, decay = 0.01;
+    var imp = Impulse.ar(0);
+    [
+        Decay2.ar(imp, attack, decay),
+        Decay2.ar(imp, decay, attack)
+    ]
+}, duration: 0.01).superpose_(true)
+)
+::
+
+
+Subsection:: Onset control and normalizing the envelope of Decay2
+
+It can be useful to parameterize code::Decay2:: so that its peak value is code::1.0::, and to be able to control when the peak value is reached.
+The following example normalizes the envelope of code::Decay2:: and provides a parameter, code::riseScale::, to shift the onset earlier or later.
+
+A code::riseScale:: value of code::0.0:: gives a sharp onset time of just one sample, making it nearly equivalent to link::Classes/Decay::.
+A value of just less than code::1.0:: (it cannot be equal to code::1.0::) will generate the latest possible onset time, which is ~15% of the strong::decayTime::.
+
+code::
+(
+var t60, riseScale, riseFac, normFac;
+
+// Approximate 60 dB decay time
+// (actual t60 will increase with riseScale)
+t60 = 0.01;
+
+// Scale the rise time (< 1.0)
+riseScale = 0.1;
+
+// Calculate normalization factor
+riseFac = riseScale / (2 - riseScale);
+normFac = riseFac.pow(riseFac / (riseFac - 1)) / (1 - riseFac);
+
+// Plot and compare to Decay
+plot({
+    var imp = Impulse.ar(0);
+    [
+        Decay.ar(imp, t60),
+        Decay2.ar(imp,
+            attackTime: t60 * riseFac,
+            decayTime: t60,
+            mul: normFac
+        )
+    ]
+}, duration: t60)
+.plotColor_([Color.blue, Color.red])
+.superpose_(true)
+)
+::
+
+In the previous example, note that code::t60:: is "approximate" because, while the emphasis::rate:: of decay converges to that of the corresponding decay time, the actual time when the impulse response decays to -60 dB will be delayed as code::riseScale:: increases.
+This is apparent when looking at the impulse response on a decibel scale, with increasing values for code::riseScale::.
+
+code::
+(
+var t60, riseScale, riseFac, normFac;
+
+t60 = 0.01;
+riseScale = [0.0, 0.2, 0.5, 0.9];
+riseFac = riseScale / (2 - riseScale);
+normFac = riseFac.pow(riseFac / (riseFac - 1)) / (1 - riseFac);
+
+// Plot in dB to inspect decay time
+plot(
+    {
+        Decay2.ar(Impulse.ar(0),
+            attackTime: t60 * riseFac,
+            decayTime: t60,
+            mul: normFac
+        ).ampdb.max(-120) // to dB, clip -inf
+    },
+    duration: t60, minval: -60
+).superpose_(true)
+.axisLabelY_("dB")
+.axisLabelX_("Time (s)")
+)
+::
+
+
+Subsection:: Calculating rise time and maximum rise time of Decay2
+
+The longest possible rise time is constrained to ~15% of the strong::decayTime::. This maximum rise time, as well as exact rise time for a given code::riseScale:: factor, can be calculated as follows:
+
+code::
+(
+var t60, riseScale, riseFac, riseTime, maxRiseTime;
+
+t60 = 0.3; // decay time
+riseScale = 0.1;
+
+riseFac = riseScale / (2 - riseScale);
+maxRiseTime = t60 * 60.dbamp.log.reciprocal;
+riseTime = maxRiseTime * (riseFac * riseFac.log) / (riseFac - 1);
+
+postf(
+    "For decayTime = % sec, the max possible rise time is % sec.\n"
+    "When riseScale = %, the rise time is % sec.\n",
+    *round([t60, maxRiseTime, riseScale, riseTime], 0.001)
+);""
+)
+::

--- a/server/plugins/FilterUGens.cpp
+++ b/server/plugins/FilterUGens.cpp
@@ -1102,15 +1102,17 @@ void Integrator_next(Integrator* unit, int inNumSamples) {
 
 void Decay_Ctor(Decay* unit) {
     SETCALC(Decay_next);
+
     unit->m_decayTime = uninitializedControl;
     unit->m_b1 = 0.f;
     unit->m_y1 = 0.f;
+
     Decay_next(unit, 1);
+
+    unit->m_y1 = 0.f;
 }
 
 void Decay_next(Decay* unit, int inNumSamples) {
-    // printf("Decay_next_a\n");
-
     float* out = ZOUT(0);
     float* in = ZIN(0);
     float decayTime = ZIN0(1);
@@ -1127,7 +1129,7 @@ void Decay_next(Decay* unit, int inNumSamples) {
         unit->m_b1 = decayTime == 0.f ? 0.f : exp(log001 / (decayTime * SAMPLERATE));
         unit->m_decayTime = decayTime;
         double b1_slope = CALCSLOPE(unit->m_b1, b1);
-        // printf("decayTime %g  %g %g\n", unit->m_decayTime, next_b1, b1);
+
         LOOP1(inNumSamples, double y0 = ZXP(in); ZXP(out) = y1 = y0 + b1 * y1; b1 += b1_slope;);
     }
     unit->m_y1 = zapgremlins(y1);
@@ -1145,16 +1147,16 @@ void Decay2_Ctor(Decay2* unit) {
     unit->m_b1b = attackTime == 0.f ? 0.f : exp(log001 / (attackTime * SAMPLERATE));
     unit->m_decayTime = decayTime;
     unit->m_attackTime = attackTime;
+    unit->m_y1a = 0.f;
+    unit->m_y1b = 0.f;
 
-    float y0 = ZIN0(0);
-    unit->m_y1a = y0;
-    unit->m_y1b = y0;
-    ZOUT0(0) = 0.f;
+    Decay2_next(unit, 1);
+
+    unit->m_y1a = 0.f;
+    unit->m_y1b = 0.f;
 }
 
 void Decay2_next(Decay2* unit, int inNumSamples) {
-    // printf("Decay2_next_a\n");
-
     float* out = ZOUT(0);
     float* in = ZIN(0);
     float attackTime = ZIN0(1);


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation
A majority of UGens do not initialize with a correct initialization sample, and subsequently output an incorrect first sample. This addressed that issue for `Decay` and `Decay2`. Unit test also added.

Fixes #6143

This PR is part of an ongoing effort to [fix UGen initializations](https://github.com/supercollider/rfcs/pull/19), the progress of which is [tracked here](https://github.com/mtmccrea/supercollider/wiki/UGen-Fix-List).

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix
- Breaking change - initial sample changes are technically breaking.

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing 
  - added unit test for `Decay2`
- [x] Updated documentation
- [x] This PR is ready for review
