### PR TITLE
Bump to `clang-format-14`

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -13,3 +13,12 @@ NamespaceIndentation: None
 SortIncludes: false
 SpaceBeforeCtorInitializerColon: false
 TabWidth: 4
+SpaceInEmptyBlock: false
+PackConstructorInitializers: CurrentLine 
+AllowShortFunctionsOnASingleLine: All
+AllowShortBlocksOnASingleLine: Always
+AllowShortLoopsOnASingleLine: false 
+ForEachMacros: ['Q_FOREACH', 'foreach']
+SpaceBeforeParens: Custom
+SpaceBeforeParensOptions:
+  AfterForeachMacros: true 

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -16,7 +16,7 @@ on:
     - cron:  '0 0 * * 0' # run weekly to refresh cache
 jobs:
   lint:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     outputs:
       sc-version: ${{ steps.set-version.outputs.version }}
     steps:
@@ -29,9 +29,9 @@ jobs:
           lintspaces -e .editorconfig SCClassLibrary/**/*.sc || true # ignore failure
       - name: lint cpp files
         run: |
-          sudo apt-get install -y clang-format-8
+          sudo apt-get install -y clang-format-14
           echo "Running tools/clang-format.py lintall"
-          tools/clang-format.py -c clang-format-8 -d clang-format-diff-8 lintall || exit 1
+          tools/clang-format.py -c clang-format-14 -d clang-format-diff-14 lintall || exit 1
           echo "Lint successful"
       - name: set version string for artifacts
         id: set-version

--- a/QtCollider/widgets/QcFileDialog.h
+++ b/QtCollider/widgets/QcFileDialog.h
@@ -62,7 +62,9 @@ private Q_SLOTS:
         if (res == QDialog::Accepted) {
             QStringList files = dialog->selectedFiles();
             QVariantList varFiles;
-            Q_FOREACH (QString f, files) { varFiles << QVariant(f); }
+            Q_FOREACH (QString f, files) {
+                varFiles << QVariant(f);
+            }
             Q_EMIT(accepted(varFiles));
         } else {
             Q_EMIT(rejected());

--- a/QtCollider/widgets/QcGraph.cpp
+++ b/QtCollider/widgets/QcGraph.cpp
@@ -879,7 +879,9 @@ void QcGraph::paintEvent(QPaintEvent*) {
         QList<QcGraphModel::Connection> conns = _model.connections();
 
         if (conns.count()) {
-            Q_FOREACH (QcGraphModel::Connection c, conns) { addCurve(lines, c.a, c.b); }
+            Q_FOREACH (QcGraphModel::Connection c, conns) {
+                addCurve(lines, c.a, c.b);
+            }
 
         } else {
             QcGraphElement* e1 = elems[0];

--- a/common/SC_AllocPool.h
+++ b/common/SC_AllocPool.h
@@ -164,17 +164,16 @@ private:
     static size_t SmallBinIndex(size_t inSize) { return inSize >> 4; }
 
     static size_t BinIndex2(size_t inSize) {
-        return ((inSize < 1024) ? (inSize >> 4)
-                                : (inSize < 2048)
-                        ? 56 + (inSize >> 7)
-                        : (inSize < 4096) ? 64 + (inSize >> 8)
-                                          : (inSize < 8192) ? 72 + (inSize >> 9)
-                                                            : (inSize < 16384) ? 80 + (inSize >> 10)
-                                                                               : (inSize < 32768) ? 88 + (inSize >> 11)
-                                                                                                  : (inSize < 65536)
-                                            ? 96 + (inSize >> 12)
-                                            : (inSize < 131072) ? 104 + (inSize >> 13)
-                                                                : (inSize < 262144) ? 112 + (inSize >> 14) : 127);
+        return ((inSize < 1024)         ? (inSize >> 4)
+                    : (inSize < 2048)   ? 56 + (inSize >> 7)
+                    : (inSize < 4096)   ? 64 + (inSize >> 8)
+                    : (inSize < 8192)   ? 72 + (inSize >> 9)
+                    : (inSize < 16384)  ? 80 + (inSize >> 10)
+                    : (inSize < 32768)  ? 88 + (inSize >> 11)
+                    : (inSize < 65536)  ? 96 + (inSize >> 12)
+                    : (inSize < 131072) ? 104 + (inSize >> 13)
+                    : (inSize < 262144) ? 112 + (inSize >> 14)
+                                        : 127);
     }
 
     static size_t BinIndex(size_t inSize) {
@@ -211,8 +210,7 @@ private:
         if (binBits >= bitValue) {
             binBits = (~(bitValue - 1) & binBits);
         } else {
-            for (++word; word < 4 && !mBinBlocks[word]; ++word) {
-            }
+            for (++word; word < 4 && !mBinBlocks[word]; ++word) {}
             if (word == 4)
                 return -1;
             binBits = mBinBlocks[word];

--- a/common/SC_VFP11.h
+++ b/common/SC_VFP11.h
@@ -11,7 +11,7 @@ inline void initVFP() {
     __asm__ __volatile__("fmrx %[tmp], fpscr\n\t"
                          "orr %[tmp], %[tmp], #(3 << 16)\n\t" /* set vector size to 4 */
                          "fmxr fpscr, %[tmp]\n\t"
-                         : [ tmp ] "=&r"(tmp)
+                         : [tmp] "=&r"(tmp)
                          :
                          : "cc", "memory");
 #endif
@@ -23,7 +23,7 @@ inline void releaseVFP() {
     __asm__ __volatile__("fmrx %[tmp], fpscr\n\t"
                          "bic %[tmp], %[tmp], #(7 << 16)\n\t" /* set vector size back to 1 */
                          "fmxr fpscr, %[tmp]\n\t"
-                         : [ tmp ] "=&r"(tmp)
+                         : [tmp] "=&r"(tmp)
                          :
                          : "cc", "memory");
 #endif
@@ -50,7 +50,7 @@ inline void vfill(float* dest, float val, int len) {
 
                          "bic %[tmp], %[tmp], #(7 << 16)\n\t" /* set vector size back to 1 */
                          "fmxr fpscr, %[tmp]\n\t"
-                         : [ dst ] "+&r"(dest), [ src1 ] "+&r"(v), [ len ] "+&r"(len), [ tmp ] "=&r"(tmp)
+                         : [dst] "+&r"(dest), [src1] "+&r"(v), [len] "+&r"(len), [tmp] "=&r"(tmp)
                          :
                          : "s0", "s1", "s2", "s3", "s4", "s5", "s6", "s7", "s8", "s9", "s10", "s11", "s12", "s13",
                            "s14", "s15", "s16", "s17", "s18", "s19", "s20", "s21", "s22", "s23", "s24", "s25", "s26",
@@ -63,49 +63,49 @@ inline void vfill(float* dest, float val, int len) {
 inline void vmuladd(float* dest, float* a, float* b, float* c, int len) {
 #if !TARGET_IPHONE_SIMULATOR
     int tmp;
-    __asm__ __volatile__("fmrx %[tmp], fpscr\n\t"
-                         "orr %[tmp], %[tmp], #(3 << 16)\n\t" /* set vector size to 4 */
-                         "fmxr fpscr, %[tmp]\n\t"
+    __asm__ __volatile__(
+        "fmrx %[tmp], fpscr\n\t"
+        "orr %[tmp], %[tmp], #(3 << 16)\n\t" /* set vector size to 4 */
+        "fmxr fpscr, %[tmp]\n\t"
 
-                         "fldmias %[src2]!, {s0-s3}\n\t"
-                         "fldmias %[src1]!, {s8-s11}\n\t"
-                         "fldmias %[src3]!, {s24-s27}\n\t"
-                         "fldmias %[src2]!, {s4-s7}\n\t"
-                         "fldmias %[src1]!, {s12-s15}\n\t"
-                         "fldmias %[src3]!, {s28-s31}\n\t"
-                         "fmacs s8, s0, s24\n\t"
-                         "1:\n\t"
-                         "subs %[len], %[len], #16\n\t"
-                         "fmacs s12, s4, s28\n\t"
-                         "fldmiasge %[src2]!, {s0-s3}\n\t"
-                         "fldmiasge %[src1]!, {s16-s19}\n\t"
-                         "fldmiasge %[src3]!, {s24-s27}\n\t"
-                         "fldmiasge %[src2]!, {s4-s7}\n\t"
-                         "fldmiasge %[src1]!, {s20-s23}\n\t"
-                         "fldmiasge %[src3]!, {s28-s31}\n\t"
-                         "fmacsge s16, s0, s24\n\t"
-                         "fstmias %[dst]!, {s8-s11}\n\t"
-                         "fstmias %[dst]!, {s12-s15}\n\t"
-                         "fmacsge s20, s4, s28\n\t"
-                         "fldmiasgt %[src2]!, {s0-s3}\n\t"
-                         "fldmiasgt %[src1]!, {s8-s11}\n\t"
-                         "fldmiasgt %[src3]!, {s24-s27}\n\t"
-                         "fldmiasgt %[src2]!, {s4-s7}\n\t"
-                         "fldmiasgt %[src1]!, {s12-s15}\n\t"
-                         "fldmiasgt %[src3]!, {s28-s31}\n\t"
-                         "fmacsge s8, s0, s24\n\t"
-                         "fstmiasge %[dst]!, {s16-s19}\n\t"
-                         "fstmiasge %[dst]!, {s20-s23}\n\t"
-                         "bgt 1b\n\t"
+        "fldmias %[src2]!, {s0-s3}\n\t"
+        "fldmias %[src1]!, {s8-s11}\n\t"
+        "fldmias %[src3]!, {s24-s27}\n\t"
+        "fldmias %[src2]!, {s4-s7}\n\t"
+        "fldmias %[src1]!, {s12-s15}\n\t"
+        "fldmias %[src3]!, {s28-s31}\n\t"
+        "fmacs s8, s0, s24\n\t"
+        "1:\n\t"
+        "subs %[len], %[len], #16\n\t"
+        "fmacs s12, s4, s28\n\t"
+        "fldmiasge %[src2]!, {s0-s3}\n\t"
+        "fldmiasge %[src1]!, {s16-s19}\n\t"
+        "fldmiasge %[src3]!, {s24-s27}\n\t"
+        "fldmiasge %[src2]!, {s4-s7}\n\t"
+        "fldmiasge %[src1]!, {s20-s23}\n\t"
+        "fldmiasge %[src3]!, {s28-s31}\n\t"
+        "fmacsge s16, s0, s24\n\t"
+        "fstmias %[dst]!, {s8-s11}\n\t"
+        "fstmias %[dst]!, {s12-s15}\n\t"
+        "fmacsge s20, s4, s28\n\t"
+        "fldmiasgt %[src2]!, {s0-s3}\n\t"
+        "fldmiasgt %[src1]!, {s8-s11}\n\t"
+        "fldmiasgt %[src3]!, {s24-s27}\n\t"
+        "fldmiasgt %[src2]!, {s4-s7}\n\t"
+        "fldmiasgt %[src1]!, {s12-s15}\n\t"
+        "fldmiasgt %[src3]!, {s28-s31}\n\t"
+        "fmacsge s8, s0, s24\n\t"
+        "fstmiasge %[dst]!, {s16-s19}\n\t"
+        "fstmiasge %[dst]!, {s20-s23}\n\t"
+        "bgt 1b\n\t"
 
-                         "bic %[tmp], %[tmp], #(7 << 16)\n\t" /* set vector size back to 1 */
-                         "fmxr fpscr, %[tmp]\n\t"
-                         : [ dst ] "+&r"(dest), [ src1 ] "+&r"(a), [ src2 ] "+&r"(b), [ src3 ] "+&r"(c),
-                           [ len ] "+&r"(len), [ tmp ] "=&r"(tmp)
-                         :
-                         : "s0", "s1", "s2", "s3", "s4", "s5", "s6", "s7", "s8", "s9", "s10", "s11", "s12", "s13",
-                           "s14", "s15", "s16", "s17", "s18", "s19", "s20", "s21", "s22", "s23", "s24", "s25", "s26",
-                           "s27", "s28", "s29", "s30", "s31", "cc", "memory");
+        "bic %[tmp], %[tmp], #(7 << 16)\n\t" /* set vector size back to 1 */
+        "fmxr fpscr, %[tmp]\n\t"
+        : [dst] "+&r"(dest), [src1] "+&r"(a), [src2] "+&r"(b), [src3] "+&r"(c), [len] "+&r"(len), [tmp] "=&r"(tmp)
+        :
+        : "s0", "s1", "s2", "s3", "s4", "s5", "s6", "s7", "s8", "s9", "s10", "s11", "s12", "s13", "s14", "s15", "s16",
+          "s17", "s18", "s19", "s20", "s21", "s22", "s23", "s24", "s25", "s26", "s27", "s28", "s29", "s30", "s31", "cc",
+          "memory");
 #endif
 }
 
@@ -141,8 +141,7 @@ inline void vscalarmul(float* dest, float scalar, float* b, int len) {
 
                          "bic %[tmp], %[tmp], #(7 << 16)\n\t" /* set vector size back to 1 */
                          "fmxr fpscr, %[tmp]\n\t"
-                         : [ dst ] "+&r"(dest), [ src1 ] "+&r"(s), [ src2 ] "+&r"(b), [ len ] "+&r"(len),
-                           [ tmp ] "=&r"(tmp)
+                         : [dst] "+&r"(dest), [src1] "+&r"(s), [src2] "+&r"(b), [len] "+&r"(len), [tmp] "=&r"(tmp)
                          :
                          : "s0", "s1", "s2", "s3", "s4", "s5", "s6", "s7", "s8", "s9", "s10", "s11", "s12", "s13",
                            "s14", "s15", "s16", "s17", "s18", "s19", "s20", "s21", "s22", "s23", "s24", "s25", "s26",
@@ -184,8 +183,7 @@ inline void vmul(float* dest, float* a, const float* b, int len) {
 
                          "bic %[tmp], %[tmp], #(7 << 16)\n\t" /* set vector size back to 1 */
                          "fmxr fpscr, %[tmp]\n\t"
-                         : [ dst ] "+&r"(dest), [ src1 ] "+&r"(a), [ src2 ] "+&r"(b), [ len ] "+&r"(len),
-                           [ tmp ] "=&r"(tmp)
+                         : [dst] "+&r"(dest), [src1] "+&r"(a), [src2] "+&r"(b), [len] "+&r"(len), [tmp] "=&r"(tmp)
                          :
                          : "s0", "s1", "s2", "s3", "s4", "s5", "s6", "s7", "s8", "s9", "s10", "s11", "s12", "s13",
                            "s14", "s15", "s16", "s17", "s18", "s19", "s20", "s21", "s22", "s23", "s24", "s25", "s26",
@@ -228,8 +226,7 @@ inline void vadd(float* dest, float* a, const float* b, int len) {
 
                          "bic %[tmp], %[tmp], #(7 << 16)\n\t" /* set vector size back to 1 */
                          "fmxr fpscr, %[tmp]\n\t"
-                         : [ dst ] "+&r"(dest), [ src1 ] "+&r"(a), [ src2 ] "+&r"(b), [ len ] "+&r"(len),
-                           [ tmp ] "=&r"(tmp)
+                         : [dst] "+&r"(dest), [src1] "+&r"(a), [src2] "+&r"(b), [len] "+&r"(len), [tmp] "=&r"(tmp)
                          :
                          : "s0", "s1", "s2", "s3", "s4", "s5", "s6", "s7", "s8", "s9", "s10", "s11", "s12", "s13",
                            "s14", "s15", "s16", "s17", "s18", "s19", "s20", "s21", "s22", "s23", "s24", "s25", "s26",
@@ -260,7 +257,7 @@ inline void vcopy(float* dest, float* a, int len) {
 
                          "bic %[tmp], %[tmp], #(7 << 16)\n\t" /* set vector size back to 1 */
                          "fmxr fpscr, %[tmp]\n\t"
-                         : [ dst ] "+&r"(dest), [ src1 ] "+&r"(a), [ len ] "+&r"(len), [ tmp ] "=&r"(tmp)
+                         : [dst] "+&r"(dest), [src1] "+&r"(a), [len] "+&r"(len), [tmp] "=&r"(tmp)
                          :
                          : "s0", "s1", "s2", "s3", "s4", "s5", "s6", "s7", "s8", "s9", "s10", "s11", "s12", "s13",
                            "s14", "s15", "s16", "s17", "s18", "s19", "s20", "s21", "s22", "s23", "s24", "s25", "s26",

--- a/editors/sc-ide/core/main_function.cpp
+++ b/editors/sc-ide/core/main_function.cpp
@@ -129,7 +129,9 @@ int main(int argc, char* argv[]) {
         sessions->newSession();
     }
 
-    foreach (QString argument, arguments) { main->documentManager()->open(argument); }
+    foreach (QString argument, arguments) {
+        main->documentManager()->open(argument);
+    }
 
     win->restoreDocuments();
 

--- a/editors/sc-ide/core/sc_process.cpp
+++ b/editors/sc-ide/core/sc_process.cpp
@@ -333,9 +333,7 @@ void ScProcess::onResponse(const QString& selector, const QString& data) {
                 Introspection newIntrospection = watcher->result();
                 mIntrospection = std::move(newIntrospection);
                 emit introspectionChanged();
-            } catch (std::exception& e) {
-                MainWindow::instance()->showStatusMessage(e.what());
-            }
+            } catch (std::exception& e) { MainWindow::instance()->showStatusMessage(e.what()); }
             watcher->deleteLater();
         });
 
@@ -383,9 +381,7 @@ void ScProcess::updateTextMirrorForDocument(Document* doc, int position, int cha
 
     try {
         sendSelectorAndData(mIpcSocket, QStringLiteral("updateDocText"), argList);
-    } catch (std::exception const& e) {
-        scPost(QStringLiteral("Exception during ScIDE_Send: %1\n").arg(e.what()));
-    }
+    } catch (std::exception const& e) { scPost(QStringLiteral("Exception during ScIDE_Send: %1\n").arg(e.what())); }
 }
 
 void ScProcess::updateSelectionMirrorForDocument(Document* doc, int start, int range) {
@@ -403,9 +399,7 @@ void ScProcess::updateSelectionMirrorForDocument(Document* doc, int start, int r
 
     try {
         sendSelectorAndData(mIpcSocket, QStringLiteral("updateDocSelection"), argList);
-    } catch (std::exception const& e) {
-        scPost(QStringLiteral("Exception during ScIDE_Send: %1\n").arg(e.what()));
-    }
+    } catch (std::exception const& e) { scPost(QStringLiteral("Exception during ScIDE_Send: %1\n").arg(e.what())); }
 }
 
 } // namespace ScIDE

--- a/editors/sc-ide/widgets/main_window.cpp
+++ b/editors/sc-ide/widgets/main_window.cpp
@@ -1440,9 +1440,7 @@ void MainWindow::showSettings() {
         int result = dialog.exec();
         if (result == QDialog::Accepted)
             mMain->applySettings();
-    } catch (std::exception const& e) {
-        qWarning() << "Error while executing settings dialog:" << e.what();
-    }
+    } catch (std::exception const& e) { qWarning() << "Error while executing settings dialog:" << e.what(); }
     showingSettings = false;
 }
 

--- a/editors/sc-ide/widgets/settings/sclang_page.cpp
+++ b/editors/sc-ide/widgets/settings/sclang_page.cpp
@@ -178,9 +178,7 @@ void SclangPage::readLanguageConfig() {
                 try {
                     bool postInlineWarnings = inlineWarnings.as<bool>();
                     ui->sclang_post_inline_warnings->setChecked(postInlineWarnings);
-                } catch (...) {
-                    qDebug() << "Warning: Cannot parse config file entry \"postInlineWarnings\"";
-                }
+                } catch (...) { qDebug() << "Warning: Cannot parse config file entry \"postInlineWarnings\""; }
             }
 
             const Node& excludeDefaultPaths = doc["excludeDefaultPaths"];
@@ -188,13 +186,10 @@ void SclangPage::readLanguageConfig() {
                 try {
                     bool excludeDefaultPathsBool = excludeDefaultPaths.as<bool>();
                     ui->sclang_exclude_default_paths->setChecked(excludeDefaultPathsBool);
-                } catch (...) {
-                    qDebug() << "Warning: Cannot parse config file entry \"excludeDefaultPaths\"";
-                }
+                } catch (...) { qDebug() << "Warning: Cannot parse config file entry \"excludeDefaultPaths\""; }
             }
         }
-    } catch (std::exception&) {
-    }
+    } catch (std::exception&) {}
 
     sclangConfigDirty = false;
 }
@@ -256,7 +251,9 @@ QStringList SclangPage::availableLanguageConfigFiles() {
     fileFilters << "sclang_conf*.yaml";
     QFileInfoList configFileList = qdir.entryInfoList(fileFilters);
     QStringList canonicalPaths;
-    foreach (QFileInfo aFile, configFileList) { canonicalPaths.append(aFile.canonicalFilePath()); }
+    foreach (QFileInfo aFile, configFileList) {
+        canonicalPaths.append(aFile.canonicalFilePath());
+    }
     return canonicalPaths;
 }
 

--- a/include/plugin_interface/SC_RGen.h
+++ b/include/plugin_interface/SC_RGen.h
@@ -250,16 +250,14 @@ inline double RGen::exprandrng(double lo, double hi) { return lo * exp(log(hi / 
 
 inline double RGen::exprand(double scale) {
     double z;
-    while ((z = drand()) == 0.0) {
-    }
+    while ((z = drand()) == 0.0) {}
     return -log(z) * scale;
 }
 
 /// Bilateral exponentially distributed random double from -scale to +scale.
 inline double RGen::biexprand(double scale) {
     double z;
-    while ((z = drand2(1.)) == 0.0 || z == -1.0) {
-    }
+    while ((z = drand2(1.)) == 0.0 || z == -1.0) {}
     if (z > 0.0)
         z = log(z);
     else

--- a/lang/LangPrimSource/OSCData.cpp
+++ b/lang/LangPrimSource/OSCData.cpp
@@ -777,9 +777,7 @@ void init_OSC(int port) {
 
     try {
         gUDPport.reset(new InPort::UDP(port, HandlerType::OSC));
-    } catch (std::exception const& e) {
-        postfl("No networking: %s", e.what());
-    }
+    } catch (std::exception const& e) { postfl("No networking: %s", e.what()); }
 }
 
 int prOpenOSCUDPPort(VMGlobals* g, int numArgsPushed);

--- a/lang/LangPrimSource/PyrArchiverT.h
+++ b/lang/LangPrimSource/PyrArchiverT.h
@@ -152,9 +152,7 @@ public:
         } catch (std::exception& ex) {
             error(ex.what());
             err = errFailed;
-        } catch (...) {
-            err = errFailed;
-        }
+        } catch (...) { err = errFailed; }
         // postfl("<-readArchive\n");
         return err;
     }

--- a/lang/LangPrimSource/SC_Clock.hpp
+++ b/lang/LangPrimSource/SC_Clock.hpp
@@ -116,9 +116,7 @@ template <typename Clock> int prClock_New(struct VMGlobals* g, int numArgsPushed
     try {
         Clock* clock = new Clock(g, slotRawObject(a), tempo, beats, seconds);
         SetPtr(slotRawObject(a)->slots + 1, clock);
-    } catch (int err) {
-        return err;
-    }
+    } catch (int err) { return err; }
 
     return errNone;
 }

--- a/lang/LangSource/PyrLexer.cpp
+++ b/lang/LangSource/PyrLexer.cpp
@@ -2125,8 +2125,7 @@ bool passOne_ProcessOneFile(const bfs::path& path) {
         PyrSymbol* fileSym = getsym(path_c_str);
         fileSym->u.source = nullptr;
         if (startLexer(fileSym, path, -1, -1, -1)) {
-            while (parseOneClass(fileSym)) {
-            };
+            while (parseOneClass(fileSym)) {};
             finiLexer();
         } else {
             error("file '%s' open failed\n", path_c_str);
@@ -2286,8 +2285,6 @@ SCLANG_DLLEXPORT_C void runLibrary(PyrSymbol* selector) {
             post("caught exception in runLibrary\n");
         }
         error(ex.what());
-    } catch (...) {
-        postfl("DANGER: OUT of MEMORY. Operation failed.\n");
-    }
+    } catch (...) { postfl("DANGER: OUT of MEMORY. Operation failed.\n"); }
     g->canCallOS = false;
 }

--- a/platform/windows/compat_stuff/getopt/getopt.c
+++ b/platform/windows/compat_stuff/getopt/getopt.c
@@ -24,19 +24,19 @@
 /* This tells Alpha OSF/1 not to define a getopt prototype in <stdio.h>.
    Ditto for AIX 3.2 and <stdlib.h>.  */
 #ifndef _NO_PROTO
-#    define _NO_PROTO
+#define _NO_PROTO
 #endif
 
 #ifdef HAVE_CONFIG_H
-#    include <config.h>
+#include <config.h>
 #endif
 
 #if !defined __STDC__ || !__STDC__
 /* This is a separate conditional since some stdc systems
    reject `defined (const)'.  */
-#    ifndef const
-#        define const
-#    endif
+#ifndef const
+#    define const
+#endif
 #endif
 
 #include <stdio.h>
@@ -51,10 +51,10 @@
 
 #define GETOPT_INTERFACE_VERSION 2
 #if !defined _LIBC && defined __GLIBC__ && __GLIBC__ >= 2
-#    include <gnu-versions.h>
-#    if _GNU_GETOPT_INTERFACE_VERSION == GETOPT_INTERFACE_VERSION
-#        define ELIDE_CODE
-#    endif
+#include <gnu-versions.h>
+#if _GNU_GETOPT_INTERFACE_VERSION == GETOPT_INTERFACE_VERSION
+#    define ELIDE_CODE
+#endif
 #endif
 
 #ifndef ELIDE_CODE
@@ -62,38 +62,38 @@
 
 /* This needs to come after some library #include
    to get __GNU_LIBRARY__ defined.  */
-#    ifdef __GNU_LIBRARY__
+#ifdef __GNU_LIBRARY__
 /* Don't include stdlib.h for non-GNU C libraries because some of them
    contain conflicting prototypes for getopt.  */
-#        include <stdlib.h>
+#    include <stdlib.h>
 //# include <unistd.h>
-#    endif /* GNU C library.  */
+#endif /* GNU C library.  */
 
-#    ifdef VMS
-#        include <unixlib.h>
-#        if HAVE_STRING_H - 0
-#            include <string.h>
-#        endif
+#ifdef VMS
+#    include <unixlib.h>
+#    if HAVE_STRING_H - 0
+#        include <string.h>
 #    endif
+#endif
 
-#    ifndef _
+#ifndef _
 /* This is for other GNU distributions with internationalized messages.  */
-#        if (HAVE_LIBINTL_H && ENABLE_NLS) || defined _LIBC
-#            include <libintl.h>
-#            ifndef _
-#                define _(msgid) gettext(msgid)
-#            endif
-#        else
-#            define _(msgid) (msgid)
+#    if (HAVE_LIBINTL_H && ENABLE_NLS) || defined _LIBC
+#        include <libintl.h>
+#        ifndef _
+#            define _(msgid) gettext(msgid)
 #        endif
-#        if defined _LIBC && defined USE_IN_LIBIO
-#            include <wchar.h>
-#        endif
+#    else
+#        define _(msgid) (msgid)
 #    endif
+#    if defined _LIBC && defined USE_IN_LIBIO
+#        include <wchar.h>
+#    endif
+#endif
 
-#    ifndef attribute_hidden
-#        define attribute_hidden
-#    endif
+#ifndef attribute_hidden
+#    define attribute_hidden
+#endif
 
 /* This version of `getopt' appears to the caller like standard Unix `getopt'
    but it behaves differently for the user, since it allows the user
@@ -109,7 +109,7 @@
    GNU application programs can use a third alternative mode in which
    they can distinguish the relative order of options and other arguments.  */
 
-#    include "getopt.h"
+#include "getopt.h"
 
 /* For communication from `getopt' to the caller.
    When `getopt' finds an option that takes an argument,
@@ -194,17 +194,17 @@ static enum { REQUIRE_ORDER, PERMUTE, RETURN_IN_ORDER } ordering;
 /* Value of POSIXLY_CORRECT environment variable.  */
 static char* posixly_correct;
 
-#    ifdef __GNU_LIBRARY__
+#ifdef __GNU_LIBRARY__
 /* We want to avoid inclusion of string.h with non-GNU libraries
    because there are many ways it can cause trouble.
    On some systems, it contains special magic macros that don't work
    in GCC.  */
-#        include <string.h>
-#        define my_index strchr
-#    else
+#    include <string.h>
+#    define my_index strchr
+#else
 
 //# if HAVE_STRING_H
-#        include <string.h>
+#    include <string.h>
 //# else
 //#  include <strings.h>
 //# endif
@@ -212,9 +212,9 @@ static char* posixly_correct;
 /* Avoid depending on library functions or files
    whose names are inconsistent.  */
 
-#        ifndef getenv
+#    ifndef getenv
 extern char* getenv();
-#        endif
+#    endif
 
 static char* my_index(str, chr) const char* str;
 int chr;
@@ -229,17 +229,17 @@ int chr;
 
 /* If using GCC, we can safely declare strlen this way.
    If not using GCC, it is ok not to declare it.  */
-#        ifdef __GNUC__
+#    ifdef __GNUC__
 /* Note that Motorola Delta 68k R3V7 comes with GCC but not stddef.h.
    That was relevant to code that was here before.  */
-#            if (!defined __STDC__ || !__STDC__) && !defined strlen
+#        if (!defined __STDC__ || !__STDC__) && !defined strlen
 /* gcc with -traditional declares the built-in strlen to return int,
    and has done so at least since version 2.4.5. -- rms.  */
 extern int strlen(const char*);
-#            endif /* not __STDC__ */
-#        endif /* __GNUC__ */
+#        endif /* not __STDC__ */
+#    endif /* __GNUC__ */
 
-#    endif /* not __GNU_LIBRARY__ */
+#endif /* not __GNU_LIBRARY__ */
 
 /* Handle permutation of arguments.  */
 
@@ -250,7 +250,7 @@ extern int strlen(const char*);
 static int first_nonopt;
 static int last_nonopt;
 
-#    ifdef _LIBC
+#ifdef _LIBC
 /* Stored original parameters.
    XXX This is no good solution.  We should rather copy the args so
    that we can compare them later.  But we must not use malloc(3).  */
@@ -260,27 +260,27 @@ extern char** __libc_argv;
 /* Bash 2.0 gives us an environment variable containing flags
    indicating ARGV elements that should not be considered arguments.  */
 
-#        ifdef USE_NONOPTION_FLAGS
+#    ifdef USE_NONOPTION_FLAGS
 /* Defined in getopt_init.c  */
 extern char* __getopt_nonoption_flags;
 
 static int nonoption_flags_max_len;
 static int nonoption_flags_len;
-#        endif
+#    endif
 
-#        ifdef USE_NONOPTION_FLAGS
-#            define SWAP_FLAGS(ch1, ch2)                                                                               \
-                if (nonoption_flags_len > 0) {                                                                         \
-                    char __tmp = __getopt_nonoption_flags[ch1];                                                        \
-                    __getopt_nonoption_flags[ch1] = __getopt_nonoption_flags[ch2];                                     \
-                    __getopt_nonoption_flags[ch2] = __tmp;                                                             \
-                }
-#        else
-#            define SWAP_FLAGS(ch1, ch2)
-#        endif
-#    else /* !_LIBC */
+#    ifdef USE_NONOPTION_FLAGS
+#        define SWAP_FLAGS(ch1, ch2)                                                                                   \
+            if (nonoption_flags_len > 0) {                                                                             \
+                char __tmp = __getopt_nonoption_flags[ch1];                                                            \
+                __getopt_nonoption_flags[ch1] = __getopt_nonoption_flags[ch2];                                         \
+                __getopt_nonoption_flags[ch2] = __tmp;                                                                 \
+            }
+#    else
 #        define SWAP_FLAGS(ch1, ch2)
-#    endif /* _LIBC */
+#    endif
+#else /* !_LIBC */
+#    define SWAP_FLAGS(ch1, ch2)
+#endif /* _LIBC */
 
 /* Exchange two adjacent subsequences of ARGV.
    One subsequence is elements [first_nonopt,last_nonopt)
@@ -291,9 +291,9 @@ static int nonoption_flags_len;
    `first_nonopt' and `last_nonopt' are relocated so that they describe
    the new indices of the non-options in ARGV after they are moved.  */
 
-#    if defined __STDC__ && __STDC__
+#if defined __STDC__ && __STDC__
 static void exchange(char**);
-#    endif
+#endif
 
 static void exchange(argv) char** argv;
 {
@@ -307,7 +307,7 @@ static void exchange(argv) char** argv;
        It leaves the longer segment in the right place overall,
        but it consists of two parts that need to be swapped next.  */
 
-#    if defined _LIBC && defined USE_NONOPTION_FLAGS
+#if defined _LIBC && defined USE_NONOPTION_FLAGS
     /* First make sure the handling of the `__getopt_nonoption_flags'
        string can work normally.  Our top argument must be in the range
        of the string.  */
@@ -324,7 +324,7 @@ static void exchange(argv) char** argv;
             __getopt_nonoption_flags = new_str;
         }
     }
-#    endif
+#endif
 
     while (top > middle && middle > bottom) {
         if (top - middle > middle - bottom) {
@@ -366,10 +366,11 @@ static void exchange(argv) char** argv;
 
 /* Initialize the internal data when the first call is made.  */
 
-#    if defined __STDC__ && __STDC__
+#if defined __STDC__ && __STDC__
 static const char* _getopt_initialize(int, char* const*, const char*);
-#    endif
-static const char* _getopt_initialize(argc, argv, optstring) int argc;
+#endif
+static const char* _getopt_initialize(argc, argv, optstring)
+int argc;
 char* const* argv;
 const char* optstring;
 {
@@ -396,7 +397,7 @@ const char* optstring;
     else
         ordering = PERMUTE;
 
-#    if defined _LIBC && defined USE_NONOPTION_FLAGS
+#if defined _LIBC && defined USE_NONOPTION_FLAGS
     if (posixly_correct == NULL && argc == __libc_argc && argv == __libc_argv) {
         if (nonoption_flags_max_len == 0) {
             if (__getopt_nonoption_flags == NULL || __getopt_nonoption_flags[0] == '\0')
@@ -416,7 +417,7 @@ const char* optstring;
         nonoption_flags_len = nonoption_flags_max_len;
     } else
         nonoption_flags_len = 0;
-#    endif
+#endif
 
     return optstring;
 }
@@ -477,7 +478,8 @@ const char* optstring;
    If LONG_ONLY is nonzero, '-' as well as '--' can introduce
    long-named options.  */
 
-int _getopt_internal(argc, argv, optstring, longopts, longind, long_only) int argc;
+int _getopt_internal(argc, argv, optstring, longopts, longind, long_only)
+int argc;
 char* const* argv;
 const char* optstring;
 const struct option* longopts;
@@ -504,13 +506,13 @@ int long_only;
        Either it does not have option syntax, or there is an environment flag
        from the shell indicating it is not an option.  The later information
        is only used when the used in the GNU libc.  */
-#    if defined _LIBC && defined USE_NONOPTION_FLAGS
-#        define NONOPTION_P                                                                                            \
-            (argv[optind][0] != '-' || argv[optind][1] == '\0'                                                         \
-             || (optind < nonoption_flags_len && __getopt_nonoption_flags[optind] == '1'))
-#    else
-#        define NONOPTION_P (argv[optind][0] != '-' || argv[optind][1] == '\0')
-#    endif
+#if defined _LIBC && defined USE_NONOPTION_FLAGS
+#    define NONOPTION_P                                                                                                \
+        (argv[optind][0] != '-' || argv[optind][1] == '\0'                                                             \
+         || (optind < nonoption_flags_len && __getopt_nonoption_flags[optind] == '1'))
+#else
+#    define NONOPTION_P (argv[optind][0] != '-' || argv[optind][1] == '\0')
+#endif
 
     if (nextchar == NULL || *nextchar == '\0') {
         /* Advance to the next ARGV-element.  */
@@ -633,7 +635,7 @@ int long_only;
 
         if (ambig && !exact) {
             if (print_errors) {
-#    if defined _LIBC && defined USE_IN_LIBIO
+#if defined _LIBC && defined USE_IN_LIBIO
                 char* buf;
 
                 if (__asprintf(&buf, _("%s: option `%s' is ambiguous\n"), argv[0], argv[optind]) >= 0) {
@@ -644,9 +646,9 @@ int long_only;
 
                     free(buf);
                 }
-#    else
+#else
                 fprintf(stderr, _("%s: option `%s' is ambiguous\n"), argv[0], argv[optind]);
-#    endif
+#endif
             }
             nextchar += strlen(nextchar);
             optind++;
@@ -664,36 +666,36 @@ int long_only;
                     optarg = nameend + 1;
                 else {
                     if (print_errors) {
-#    if defined _LIBC && defined USE_IN_LIBIO
+#if defined _LIBC && defined USE_IN_LIBIO
                         char* buf;
                         int n;
-#    endif
+#endif
 
                         if (argv[optind - 1][1] == '-') {
                             /* --option */
-#    if defined _LIBC && defined USE_IN_LIBIO
+#if defined _LIBC && defined USE_IN_LIBIO
                             n = __asprintf(&buf, _("\
 %s: option `--%s' doesn't allow an argument\n"),
                                            argv[0], pfound->name);
-#    else
+#else
                             fprintf(stderr, _("\
 %s: option `--%s' doesn't allow an argument\n"),
                                     argv[0], pfound->name);
-#    endif
+#endif
                         } else {
                             /* +option or -option */
-#    if defined _LIBC && defined USE_IN_LIBIO
+#if defined _LIBC && defined USE_IN_LIBIO
                             n = __asprintf(&buf, _("\
 %s: option `%c%s' doesn't allow an argument\n"),
                                            argv[0], argv[optind - 1][0], pfound->name);
-#    else
+#else
                             fprintf(stderr, _("\
 %s: option `%c%s' doesn't allow an argument\n"),
                                     argv[0], argv[optind - 1][0], pfound->name);
-#    endif
+#endif
                         }
 
-#    if defined _LIBC && defined USE_IN_LIBIO
+#if defined _LIBC && defined USE_IN_LIBIO
                         if (n >= 0) {
                             if (_IO_fwide(stderr, 0) > 0)
                                 __fwprintf(stderr, L"%s", buf);
@@ -702,7 +704,7 @@ int long_only;
 
                             free(buf);
                         }
-#    endif
+#endif
                     }
 
                     nextchar += strlen(nextchar);
@@ -715,7 +717,7 @@ int long_only;
                     optarg = argv[optind++];
                 else {
                     if (print_errors) {
-#    if defined _LIBC && defined USE_IN_LIBIO
+#if defined _LIBC && defined USE_IN_LIBIO
                         char* buf;
 
                         if (__asprintf(&buf, _("\
@@ -729,9 +731,9 @@ int long_only;
 
                             free(buf);
                         }
-#    else
+#else
                         fprintf(stderr, _("%s: option `%s' requires an argument\n"), argv[0], argv[optind - 1]);
-#    endif
+#endif
                     }
                     nextchar += strlen(nextchar);
                     optopt = pfound->val;
@@ -754,28 +756,28 @@ int long_only;
        Otherwise interpret it as a short option.  */
         if (!long_only || argv[optind][1] == '-' || my_index(optstring, *nextchar) == NULL) {
             if (print_errors) {
-#    if defined _LIBC && defined USE_IN_LIBIO
+#if defined _LIBC && defined USE_IN_LIBIO
                 char* buf;
                 int n;
-#    endif
+#endif
 
                 if (argv[optind][1] == '-') {
                     /* --option */
-#    if defined _LIBC && defined USE_IN_LIBIO
+#if defined _LIBC && defined USE_IN_LIBIO
                     n = __asprintf(&buf, _("%s: unrecognized option `--%s'\n"), argv[0], nextchar);
-#    else
+#else
                     fprintf(stderr, _("%s: unrecognized option `--%s'\n"), argv[0], nextchar);
-#    endif
+#endif
                 } else {
                     /* +option or -option */
-#    if defined _LIBC && defined USE_IN_LIBIO
+#if defined _LIBC && defined USE_IN_LIBIO
                     n = __asprintf(&buf, _("%s: unrecognized option `%c%s'\n"), argv[0], argv[optind][0], nextchar);
-#    else
+#else
                     fprintf(stderr, _("%s: unrecognized option `%c%s'\n"), argv[0], argv[optind][0], nextchar);
-#    endif
+#endif
                 }
 
-#    if defined _LIBC && defined USE_IN_LIBIO
+#if defined _LIBC && defined USE_IN_LIBIO
                 if (n >= 0) {
                     if (_IO_fwide(stderr, 0) > 0)
                         __fwprintf(stderr, L"%s", buf);
@@ -784,7 +786,7 @@ int long_only;
 
                     free(buf);
                 }
-#    endif
+#endif
             }
             nextchar = (char*)"";
             optind++;
@@ -805,27 +807,27 @@ int long_only;
 
         if (temp == NULL || c == ':') {
             if (print_errors) {
-#    if defined _LIBC && defined USE_IN_LIBIO
+#if defined _LIBC && defined USE_IN_LIBIO
                 char* buf;
                 int n;
-#    endif
+#endif
 
                 if (posixly_correct) {
                     /* 1003.2 specifies the format of this message.  */
-#    if defined _LIBC && defined USE_IN_LIBIO
+#if defined _LIBC && defined USE_IN_LIBIO
                     n = __asprintf(&buf, _("%s: illegal option -- %c\n"), argv[0], c);
-#    else
+#else
                     fprintf(stderr, _("%s: illegal option -- %c\n"), argv[0], c);
-#    endif
+#endif
                 } else {
-#    if defined _LIBC && defined USE_IN_LIBIO
+#if defined _LIBC && defined USE_IN_LIBIO
                     n = __asprintf(&buf, _("%s: invalid option -- %c\n"), argv[0], c);
-#    else
+#else
                     fprintf(stderr, _("%s: invalid option -- %c\n"), argv[0], c);
-#    endif
+#endif
                 }
 
-#    if defined _LIBC && defined USE_IN_LIBIO
+#if defined _LIBC && defined USE_IN_LIBIO
                 if (n >= 0) {
                     if (_IO_fwide(stderr, 0) > 0)
                         __fwprintf(stderr, L"%s", buf);
@@ -834,7 +836,7 @@ int long_only;
 
                     free(buf);
                 }
-#    endif
+#endif
             }
             optopt = c;
             return '?';
@@ -858,7 +860,7 @@ int long_only;
             } else if (optind == argc) {
                 if (print_errors) {
                     /* 1003.2 specifies the format of this message.  */
-#    if defined _LIBC && defined USE_IN_LIBIO
+#if defined _LIBC && defined USE_IN_LIBIO
                     char* buf;
 
                     if (__asprintf(&buf, _("%s: option requires an argument -- %c\n"), argv[0], c) >= 0) {
@@ -869,9 +871,9 @@ int long_only;
 
                         free(buf);
                     }
-#    else
+#else
                     fprintf(stderr, _("%s: option requires an argument -- %c\n"), argv[0], c);
-#    endif
+#endif
                 }
                 optopt = c;
                 if (optstring[0] == ':')
@@ -910,7 +912,7 @@ int long_only;
                 }
             if (ambig && !exact) {
                 if (print_errors) {
-#    if defined _LIBC && defined USE_IN_LIBIO
+#if defined _LIBC && defined USE_IN_LIBIO
                     char* buf;
 
                     if (__asprintf(&buf, _("%s: option `-W %s' is ambiguous\n"), argv[0], argv[optind]) >= 0) {
@@ -921,9 +923,9 @@ int long_only;
 
                         free(buf);
                     }
-#    else
+#else
                     fprintf(stderr, _("%s: option `-W %s' is ambiguous\n"), argv[0], argv[optind]);
-#    endif
+#endif
                 }
                 nextchar += strlen(nextchar);
                 optind++;
@@ -938,7 +940,7 @@ int long_only;
                         optarg = nameend + 1;
                     else {
                         if (print_errors) {
-#    if defined _LIBC && defined USE_IN_LIBIO
+#if defined _LIBC && defined USE_IN_LIBIO
                             char* buf;
 
                             if (__asprintf(&buf, _("\
@@ -952,11 +954,11 @@ int long_only;
 
                                 free(buf);
                             }
-#    else
+#else
                             fprintf(stderr, _("\
 %s: option `-W %s' doesn't allow an argument\n"),
                                     argv[0], pfound->name);
-#    endif
+#endif
                         }
 
                         nextchar += strlen(nextchar);
@@ -967,7 +969,7 @@ int long_only;
                         optarg = argv[optind++];
                     else {
                         if (print_errors) {
-#    if defined _LIBC && defined USE_IN_LIBIO
+#if defined _LIBC && defined USE_IN_LIBIO
                             char* buf;
 
                             if (__asprintf(&buf, _("\
@@ -981,9 +983,9 @@ int long_only;
 
                                 free(buf);
                             }
-#    else
+#else
                             fprintf(stderr, _("%s: option `%s' requires an argument\n"), argv[0], argv[optind - 1]);
-#    endif
+#endif
                         }
                         nextchar += strlen(nextchar);
                         return optstring[0] == ':' ? ':' : '?';
@@ -1020,7 +1022,7 @@ int long_only;
                 } else if (optind == argc) {
                     if (print_errors) {
                         /* 1003.2 specifies the format of this message.  */
-#    if defined _LIBC && defined USE_IN_LIBIO
+#if defined _LIBC && defined USE_IN_LIBIO
                         char* buf;
 
                         if (__asprintf(&buf, _("\
@@ -1034,9 +1036,9 @@ int long_only;
 
                             free(buf);
                         }
-#    else
+#else
                         fprintf(stderr, _("%s: option requires an argument -- %c\n"), argv[0], c);
-#    endif
+#endif
                     }
                     optopt = c;
                     if (optstring[0] == ':')
@@ -1054,7 +1056,8 @@ int long_only;
     }
 }
 
-int getopt(argc, argv, optstring) int argc;
+int getopt(argc, argv, optstring)
+int argc;
 char* const* argv;
 const char* optstring;
 { return _getopt_internal(argc, argv, optstring, (const struct option*)0, (int*)0, 0); }
@@ -1066,7 +1069,8 @@ const char* optstring;
 /* Compile with -DTEST to make an executable for use in testing
    the above definition of `getopt'.  */
 
-int main(argc, argv) int argc;
+int main(argc, argv)
+int argc;
 char** argv;
 {
     int c;

--- a/server/plugins/BinaryOpUGens.cpp
+++ b/server/plugins/BinaryOpUGens.cpp
@@ -1145,9 +1145,9 @@ void rrand_d(BinaryOpUGen* unit, int inNumSamples) {
         float xa = DEMANDINPUT_A(0, inNumSamples);
         float xb = DEMANDINPUT_A(1, inNumSamples);
         RGen& rgen = *unit->mParent->mRGen;
-        OUT0(0) = sc_isnan(xa) || sc_isnan(xb)
-            ? NAN
-            : xb > xa ? xa + rgen.frand() * (xb - xa) : (xb + rgen.frand() * (xa - xb));
+        OUT0(0) = sc_isnan(xa) || sc_isnan(xb) ? NAN
+            : xb > xa                          ? xa + rgen.frand() * (xb - xa)
+                                               : (xb + rgen.frand() * (xa - xb));
     } else {
         RESETINPUT(0);
         RESETINPUT(1);

--- a/server/plugins/iPhoneUGens.mm
+++ b/server/plugins/iPhoneUGens.mm
@@ -165,8 +165,7 @@ void AccelerometerZ_Ctor(AccelerometerUGen* unit) {
 @implementation AccelerometerDelegate
 
 - (id)init {
-    if (self = [super init]) {
-    }
+    if (self = [super init]) {}
     return self;
 }
 

--- a/server/scsynth/SC_Bela.cpp
+++ b/server/scsynth/SC_Bela.cpp
@@ -246,9 +246,7 @@ void SC_BelaDriver::BelaAudioCallback(BelaContext* belaContext) {
         if (mWorld->mBelaScope)
             mWorld->mBelaScope->logBuffer();
 
-    } catch (std::exception& exc) {
-        scprintf("SC_BelaDriver: exception in real time: %s\n", exc.what());
-    } catch (...) {
+    } catch (std::exception& exc) { scprintf("SC_BelaDriver: exception in real time: %s\n", exc.what()); } catch (...) {
         scprintf("SC_BelaDriver: unknown exception in real time\n");
     }
 

--- a/server/scsynth/SC_ComPort.cpp
+++ b/server/scsynth/SC_ComPort.cpp
@@ -514,9 +514,7 @@ template <typename T, typename... Args> static bool protectedOpenPort(const char
         }
     } catch (const std::exception& exc) {
         scprintf("\n*** ERROR: failed to open %s socket: %s\n", socketType, exc.what());
-    } catch (...) {
-        scprintf("\n*** ERROR: failed to open %s socket: Unknown error\n", socketType);
-    }
+    } catch (...) { scprintf("\n*** ERROR: failed to open %s socket: Unknown error\n", socketType); }
     return false;
 }
 

--- a/server/scsynth/SC_CoreAudio.cpp
+++ b/server/scsynth/SC_CoreAudio.cpp
@@ -1398,9 +1398,7 @@ void SC_CoreAudioDriver::Run(const AudioBufferList* inInputData, AudioBufferList
             }
             oscTime = mOSCbuftime = nextTime;
         }
-    } catch (std::exception& exc) {
-        scprintf("exception in real time: %s\n", exc.what());
-    } catch (...) {
+    } catch (std::exception& exc) { scprintf("exception in real time: %s\n", exc.what()); } catch (...) {
         scprintf("unknown exception in real time\n");
     }
     int64 systemTimeAfter = AudioGetCurrentHostTime();
@@ -1754,9 +1752,7 @@ bool SC_CoreAudioDriver::DriverStart() {
                 return false;
             }
         }
-    } catch (...) {
-        scprintf("exception in SC_CoreAudioDriver::DriverStart\n");
-    }
+    } catch (...) { scprintf("exception in SC_CoreAudioDriver::DriverStart\n"); }
     if (mWorld->mVerbosity >= 1) {
         scprintf("<-SC_CoreAudioDriver::DriverStart\n");
     }
@@ -2125,9 +2121,7 @@ void SC_iCoreAudioDriver::Run(const AudioBufferList* inInputData, AudioBufferLis
             }
             oscTime = mOSCbuftime = nextTime;
         }
-    } catch (std::exception& exc) {
-        scprintf("exception in real time: %s\n", exc.what());
-    } catch (...) {
+    } catch (std::exception& exc) { scprintf("exception in real time: %s\n", exc.what()); } catch (...) {
         scprintf("unknown exception in real time\n");
     }
 
@@ -2378,9 +2372,7 @@ bool SC_iCoreAudioDriver::DriverStart() {
     try {
         OSStatus ret = AUGraphStart(graph);
         AudioOutputUnitStart(inputUnit);
-    } catch (...) {
-        scprintf("exception in SC_CoreAudioDriver::DriverStart\n");
-    }
+    } catch (...) { scprintf("exception in SC_CoreAudioDriver::DriverStart\n"); }
     if (mWorld->mVerbosity >= 0) {
         scprintf("<-SC_CoreAudioDriver::DriverStart\n");
     }

--- a/server/scsynth/SC_GraphDef.cpp
+++ b/server/scsynth/SC_GraphDef.cpp
@@ -589,9 +589,7 @@ SCErr GraphDef_DeleteMsg(World* inWorld, GraphDef* inDef) {
 GraphDef* GraphDef_Recv(World* inWorld, char* buffer, GraphDef* inList) {
     try {
         inList = GraphDefLib_Read(inWorld, buffer, inList);
-    } catch (std::exception& exc) {
-        scprintf("exception in GraphDef_Recv: %s\n", exc.what());
-    } catch (...) {
+    } catch (std::exception& exc) { scprintf("exception in GraphDef_Recv: %s\n", exc.what()); } catch (...) {
         scprintf("unknown exception in GraphDef_Recv\n");
     }
 

--- a/server/scsynth/SC_Jack.cpp
+++ b/server/scsynth/SC_Jack.cpp
@@ -486,9 +486,7 @@ void SC_JackDriver::Run() {
         }
     } catch (std::exception& exc) {
         scprintf("%s: exception in real time: %s\n", kJackDriverIdent, exc.what());
-    } catch (...) {
-        scprintf("%s: unknown exception in real time\n", kJackDriverIdent);
-    }
+    } catch (...) { scprintf("%s: unknown exception in real time\n", kJackDriverIdent); }
 
     double cpuUsage = (double)jack_cpu_load(mClient);
     mAvgCPU = mAvgCPU + 0.1 * (cpuUsage - mAvgCPU);

--- a/server/scsynth/SC_Lib.cpp
+++ b/server/scsynth/SC_Lib.cpp
@@ -186,17 +186,13 @@ SCErr SC_LibCmd::Perform(struct World* inWorld, int inSize, char* inData, ReplyA
     //	int kSendError = 1;		// i.e., 0x01 | 0x02;
     try {
         err = (mFunc)(inWorld, inSize, inData, inReply);
-    } catch (int iexc) {
-        err = iexc;
-    } catch (std::exception& exc) {
+    } catch (int iexc) { err = iexc; } catch (std::exception& exc) {
         if (inWorld->mLocalErrorNotification <= 0 && inWorld->mErrorNotification) {
             CallSendFailureCommand(inWorld, (char*)Name(), exc.what(), inReply);
             scprintf("FAILURE IN SERVER %s %s\n", (char*)Name(), exc.what());
         }
         return kSCErr_Failed;
-    } catch (...) {
-        err = kSCErr_Failed;
-    }
+    } catch (...) { err = kSCErr_Failed; }
     if (err && (inWorld->mLocalErrorNotification <= 0 && inWorld->mErrorNotification)) {
         char errstr[128];
         SC_ErrorString(err, errstr);

--- a/server/scsynth/SC_PortAudio.cpp
+++ b/server/scsynth/SC_PortAudio.cpp
@@ -243,9 +243,7 @@ int SC_PortAudioDriver::PortAudioCallback(const void* input, void* output, unsig
         }
     } catch (std::exception& exc) {
         scprintf("SC_PortAudioDriver: exception in real time: %s\n", exc.what());
-    } catch (...) {
-        scprintf("SC_PortAudioDriver: unknown exception in real time\n");
-    }
+    } catch (...) { scprintf("SC_PortAudioDriver: unknown exception in real time\n"); }
 
     double cpuUsage = Pa_GetStreamCpuLoad(mStream) * 100.0;
     mAvgCPU = mAvgCPU + 0.1 * (cpuUsage - mAvgCPU);

--- a/server/scsynth/SC_Str4.h
+++ b/server/scsynth/SC_Str4.h
@@ -47,8 +47,7 @@ inline int str4len(const char* src) {
 // returns length in words of a int32 *
 inline int str4len(const int32* src) {
     const int32* src0 = src;
-    while (*src++ & kLASTCHAR) {
-    }
+    while (*src++ & kLASTCHAR) {}
     int wordlen = src - src0;
     return wordlen;
 }

--- a/server/scsynth/SC_World.cpp
+++ b/server/scsynth/SC_World.cpp
@@ -477,8 +477,7 @@ World* World_New(WorldOptions* inOptions) {
         scprintf("Exception in World_New: %s\n", exc.what());
         World_Cleanup(world, true);
         return nullptr;
-    } catch (...) {
-    }
+    } catch (...) {}
     return world;
 }
 
@@ -765,9 +764,7 @@ void World_WaitForQuit(struct World* inWorld, bool unload_plugins) {
     try {
         inWorld->hw->mQuitProgram->wait();
         World_Cleanup(inWorld, unload_plugins);
-    } catch (std::exception& exc) {
-        scprintf("Exception in World_WaitForQuit: %s\n", exc.what());
-    } catch (...) {
+    } catch (std::exception& exc) { scprintf("Exception in World_WaitForQuit: %s\n", exc.what()); } catch (...) {
     }
 }
 

--- a/server/supernova/audio_backend/sndfile_backend.hpp
+++ b/server/supernova/audio_backend/sndfile_backend.hpp
@@ -234,8 +234,7 @@ private:
                 break;
         }
 
-        while (poll_writer_queue(data_to_write.get(), deque_per_tick, pending_samples)) {
-        }
+        while (poll_writer_queue(data_to_write.get(), deque_per_tick, pending_samples)) {}
     }
 
     bool poll_writer_queue(sample_type* data_to_write, const size_t buffer_samples, size_t& pending_samples) {

--- a/server/supernova/sc/sc_osc_handler.cpp
+++ b/server/supernova/sc/sc_osc_handler.cpp
@@ -502,8 +502,7 @@ void sc_notify_observers::send_node_reply(int32_t node_id, int reply_id, const c
             p << osc::EndMessage;
 
             instance->send_notification(p.Data(), p.Size());
-        } catch (...) {
-        }
+        } catch (...) {}
 
         cmd_dispatcher<true>::free_in_rt_thread(std::move(value_array), std::move(cmd));
 
@@ -711,9 +710,7 @@ void sc_osc_handler::tcp_connection::send(const char* data, size_t length) {
         socket_.send(boost::asio::buffer(&len, sizeof(len)));
         size_t written = socket_.send(boost::asio::buffer(data, length));
         assert(length == written);
-    } catch (std::exception const& err) {
-        std::cout << "Exception when sending message over TCP: " << err.what();
-    }
+    } catch (std::exception const& err) { std::cout << "Exception when sending message over TCP: " << err.what(); }
 }
 
 
@@ -879,9 +876,7 @@ void sc_osc_handler::handle_message(ReceivedMessage const& message, size_t msg_s
             handle_message_int_address<realtime>(message, msg_size, endpoint);
         else
             handle_message_sym_address<realtime>(message, msg_size, endpoint);
-    } catch (std::exception const& e) {
-        log_printf("exception in handle_message: %s\n", e.what());
-    }
+    } catch (std::exception const& e) { log_printf("exception in handle_message: %s\n", e.what()); }
 }
 
 namespace {
@@ -1213,9 +1208,7 @@ void handle_s_new(ReceivedMessage const& msg) {
     try {
         while (args != end)
             set_control(synth, args, end);
-    } catch (std::exception& e) {
-        log_printf("exception in /s_new: %s\n", e.what());
-    }
+    } catch (std::exception& e) { log_printf("exception in /s_new: %s\n", e.what()); }
 }
 
 
@@ -1336,9 +1329,7 @@ template <bool realtime> void g_query_tree(int node_id, bool flag, endpoint_ptr 
             movable_array<char> message(p.Size(), data.c_array());
             cmd_dispatcher<realtime>::fire_message(endpoint, std::move(message));
             return;
-        } catch (...) {
-            max_msg_size *= 2; /* if we run out of memory, retry with doubled memory resources */
-        }
+        } catch (...) { max_msg_size *= 2; /* if we run out of memory, retry with doubled memory resources */ }
     }
 }
 
@@ -1350,9 +1341,7 @@ template <bool realtime> void handle_g_queryTree(ReceivedMessage const& msg, end
             osc::int32 id, flag;
             args >> id >> flag;
             g_query_tree<realtime>(id, flag, endpoint);
-        } catch (std::exception& e) {
-            log_printf("exception in handle_g_queryTree: %s\n", e.what());
-        }
+        } catch (std::exception& e) { log_printf("exception in handle_g_queryTree: %s\n", e.what()); }
     }
 }
 
@@ -1441,9 +1430,7 @@ void handle_g_dumpTree(ReceivedMessage const& msg) {
             osc::int32 id, flag;
             args >> id >> flag;
             g_dump_tree(id, flag);
-        } catch (std::exception& e) {
-            log_printf("exception in /g_dumpTree: %s\n", e.what());
-        }
+        } catch (std::exception& e) { log_printf("exception in /g_dumpTree: %s\n", e.what()); }
     }
 }
 
@@ -1460,9 +1447,7 @@ void handle_n_free(ReceivedMessage const& msg) {
                 continue;
 
             instance->free_node(node);
-        } catch (std::exception& e) {
-            log_printf("exception in /n_free: %s\n", e.what());
-        }
+        } catch (std::exception& e) { log_printf("exception in /n_free: %s\n", e.what()); }
     }
 }
 
@@ -1483,9 +1468,7 @@ void handle_n_free(ReceivedMessage const& msg) {
         try {                                                                                                          \
             while (it != msg.ArgumentsEnd())                                                                           \
                 function(node, it);                                                                                    \
-        } catch (std::exception & e) {                                                                                 \
-            log_printf("Exception during /n_" #cmd "handler: %s\n", e.what());                                         \
-        }                                                                                                              \
+        } catch (std::exception & e) { log_printf("Exception during /n_" #cmd "handler: %s\n", e.what()); }            \
     }
 
 void set_control(server_node* node, osc::ReceivedMessageArgumentIterator& it) {
@@ -1957,8 +1940,7 @@ completion_message extract_completion_message(osc::ReceivedMessageArgumentStream
     if (!args.Eos()) {
         try {
             args >> blob;
-        } catch (osc::WrongArgumentTypeException& e) {
-        }
+        } catch (osc::WrongArgumentTypeException& e) {}
     }
 
     return completion_message(blob.size, blob.data);

--- a/server/supernova/sc/sc_plugin_interface.cpp
+++ b/server/supernova/sc/sc_plugin_interface.cpp
@@ -330,18 +330,14 @@ bool define_unit(const char* inUnitClassName, size_t inAllocSize, UnitCtorFunc i
     try {
         nova::sc_factory->register_ugen(inUnitClassName, inAllocSize, inCtor, inDtor, inFlags);
         return true;
-    } catch (...) {
-        return false;
-    }
+    } catch (...) { return false; }
 }
 
 bool define_bufgen(const char* name, BufGenFunc func) {
     try {
         nova::sc_factory->register_bufgen(name, func);
         return true;
-    } catch (...) {
-        return false;
-    }
+    } catch (...) { return false; }
 }
 
 bool define_unitcmd(const char* unitClassName, const char* cmdName, UnitCmdFunc inFunc) {

--- a/server/supernova/sc/sc_synthdef.cpp
+++ b/server/supernova/sc/sc_synthdef.cpp
@@ -132,9 +132,7 @@ std::vector<sc_synthdef> read_synthdefs(const char* buffer, const char* buffer_e
 #else
             ret.emplace_back(buffer, buffer_end, version);
 #endif
-        } catch (std::exception const& e) {
-            std::cout << "Exception when reading synthdef: " << e.what() << std::endl;
-        }
+        } catch (std::exception const& e) { std::cout << "Exception when reading synthdef: " << e.what() << std::endl; }
     }
     return ret;
 }

--- a/tools/clang-format.py
+++ b/tools/clang-format.py
@@ -118,8 +118,8 @@ except ImportError:  # Forced testing
 # Constants
 #
 
-CLANG_FORMAT_ACCEPTED_VERSION_REGEX = re.compile("8\\.\\d+\\.\\d+")
-CLANG_FORMAT_ACCEPTED_VERSION_STRING = "8.y.z"
+CLANG_FORMAT_ACCEPTED_VERSION_REGEX = re.compile("14\\.\\d+\\.\\d+")
+CLANG_FORMAT_ACCEPTED_VERSION_STRING = "14.y.z"
 
 # all the extensions we format with clang-format in SC (no JS!)
 CLANG_FORMAT_FILES_REGEX = re.compile('\\.(cpp|hpp|h|c|m|mm)$')


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

llvm-8 is not supported by macOS 13+ anymore, therefore it is nearly impossible to apply the necessary formatting rules under an up-to-date macOS.

This PR bumps `clang-format` to version 14 which should be available for most OS and most architectures.
This is a more "conservative" PR which only bumps `clang-format` to version 14 and does not change how the linting/formatting is applied. See #6096 which was the initial point of this PR, but used pre-commit to apply formatting and obtain a `clang-format` binary.

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

- Bug fix
- Breaking change

---

Changes performed

* Bumped ubuntu version to 22.04 for linting CI b/c clang-format-14 is not available via apt on 20.04
* Added new formatting rules in order to keep linting noise as low as possible

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [ ] Code is tested
- [ ] All tests are passing
- [ ] Updated documentation
- [x] This PR is ready for review
