### PR TITLE
Plotter: add new plot modes

### DIFF
--- a/HelpSource/Classes/Impulse.schelp
+++ b/HelpSource/Classes/Impulse.schelp
@@ -54,12 +54,14 @@ code::Impulse:: would not support that.
 However, a you could generate an impulse train by phase modulation using the
 strong::rate:: parameter of a link::Classes/Phasor::, like this:
 code::
-({
+(
+{
 	var f = 1000;
 	HPZ1.ar(HPZ1.ar(
 		Phasor.ar(rate: f * SampleDur.ir)
 	)) > 1e-5
-}.plot(0.005))
+}.plot(0.005).plotMode_(\dstems)
+)
 ::
 
 

--- a/HelpSource/Classes/Plotter.schelp
+++ b/HelpSource/Classes/Plotter.schelp
@@ -104,11 +104,19 @@ Get/Set the style of data display. This can be an array of different modes for
 multi-channel data.
 Available modes:
 table::
-## code::\linear:: || connecting data points with linear interpolation
-## code::\points:: || draw data points only
-## code::\plines:: || combination of lines and points
-## code::\levels:: || horizontal lines
-## code::\steps:: || connecting data points with step interpolation
+## code::\points:: || draw data points as circles with a dot in the middle
+## code::\dots:: || draw data points as filled circles
+## code::\lines, \linear:: || lines connect data points
+## code::\plines:: || lines connect data points, marked also by code::\points::
+## code::\dlines:: || lines connect data points, marked also by code::\dots::
+## code::\stems:: || PCM-style vertical lines from zero to the data point
+## code::\pstems:: || vertical lines from zero to the data points, marked also by code::\points::
+## code::\dstems:: || vertical lines from zero to the data points, marked also by code::\dots::
+## code::\filled:: || fills the area under a waveform, and assumes a bipolar signal (filled to the zero-crossing)
+## code::\pfilled:: || code::\filled::, marked also by code::\points::
+## code::\dfilled:: || code::\filled::, marked also by code::\dots::
+## code::\levels:: || sample-and-hold style horizontal lines from the data point extending over the sample interval
+## code::\steps:: || "step interpolation": code::\levels:: connected by vertical lines
 ## code::\bars:: || bar graph with filled bars
 ::
 
@@ -125,21 +133,42 @@ are the same, in which case a single link::Classes/Symbol:: is returned.
 
 discussion::
 code::
-a = (0..20).scramble.plot;
-a.plotMode = \points; a.refresh;
-a.plotMode = \plines; a.refresh;
-a.plotMode = \levels; a.refresh;
-a.plotMode = \steps; a.refresh;
-a.plotMode = \linear; a.refresh;
-a.plotMode = \bars; a.refresh;
 
-/* mixed modes */
+p = (0..20).scramble.plot;
+p.plotMode = \points;
+p.plotMode = \plines;
+p.plotMode = \steps;
+
+/* Preview the available modes */
+(
+s.waitForBoot{
+    var modeList = [
+        \points, \dots, \levels, \steps,
+        \lines, \plines, \dlines,
+        \stems, \pstems, \dstems,
+        \filled, \dfilled, \pfilled, \bars,
+    ];
+    modeList.clump((modeList.size/2).ceil).do{ |modes, i|
+        var frq = 1000, w = 600, h = 800;
+        p = {
+            LFSaw.ar(frq) ! modes.size
+        }.plot(2.25 * frq.reciprocal);
+
+        0.25.wait; // let Plotter update with data
+        p.plotMode_(modes);
+        p.axisLabelX_(modes.collect(_.asString));
+        p.setProperties(\labelFont, (Font().size_(15)));
+        p.parent.bounds_(Rect(0, 0, w, h).left_(w*i));
+    };
+}
+)
+
+/* Mixed modes */
 (
 d = 4.collect({ |i| 100.collect({ |j| sinPi(1+i.squared*j * 50.reciprocal) })});
 p = d.plot;
 p.plotColor_([Color.red, Color.cyan, Color.green, Color.blue]);
 p.plotMode_([\steps, \linear, \plines, \points]);
-// superpose will trigger a refresh to update colors/modes
 p.superpose_(true);
 )
 ::
@@ -159,12 +188,38 @@ An link::Classes/Array:: of link::Classes/Color::s, unless there is only one
 color specified or if all colors of a multi-channel plot are the same, in which
 case a link::Classes/Color:: is returned.
 
+discussion::
+code::
+// Colorize channels
+(
+d = 4.collect({ |i|
+    100.collect({ |j|
+        sinPi(1+i.squared*j * 50.reciprocal)
+    })
+});
+d.plot.plotColor_([Color.red, Color.cyan, Color.green, Color.blue]);
+)
+
+// Use 'filled' plotMode to show phase relationships
+(
+var freq = 100;
+{ LFPar.ar(freq * [1, 1.5, 2.25]) }.plot
+.plotMode_(\filled)
+.plotColor_(
+    [\red, \green, \blue].collect{ |col|
+        Color.perform(col).alpha_(0.2)
+    }
+).superpose_(true);
+)
+::
+
+
 
 method:: superpose
 If code::true::, plotter displays channels overlaid on a single plot. (keyboard shortcut: s)
 code::
 a = { (0..30).scramble }.dup(2).plot;
-a.superpose = true; a.refresh;
+a.superpose = true;
 ::
 
 
@@ -239,7 +294,6 @@ a.setProperties(
   \labelX, "Frames",
   \labelFontColor, Color.magenta
 );
-a.refresh;
 );
 
 GUI.skins.at(\plot); // defaults
@@ -541,17 +595,17 @@ a.value = (0..100).normalize(0, 8pi).sin;
 
 a.value = { |i| (0..90) % (i + 12) + ( (0..90) % (i + 2 * 1) ) }.dup(3);
 a.value = (0..12).squared;
-a.plotMode = \points; a.refresh;
-a.plotMode = \levels; a.refresh;
-a.plotMode = \plines; a.refresh;
+a.plotMode = \points;
+a.plotMode = \levels;
+a.plotMode = \plines;
 
-a.domainSpecs = [[0, 115, \lin, 1]]; a.refresh;
+a.domainSpecs = [[0, 115, \lin, 1]];
 
 a.parent.close; // close window
 a.makeWindow; a.updatePlotBounds; // open it again
 
 a.value = { (0..70).scramble }.dup(3);
-a.plotMode = \linear; a.refresh;
+a.plotMode = \linear;
 a.value = { |i| (0..2000).normalize(0, 4pi + i).sin } ! 4; // lots of values, test efficiency
 a.value = { |i| (0..10000).normalize(0, 8pi + i).sin } ! 3; // lots of values, test efficiency
 a.value = { (0..140).scramble } ! 7;
@@ -579,18 +633,18 @@ code::
 // Array:plot
 (
 a = (4 ** (-5..0)).postln.plot;
-a.specs = \delay; a.refresh;
-a.domainSpecs = [0, 10, \lin, 0, 0, " Kg"].asSpec; a.refresh;
+a.specs = \delay;
+a.domainSpecs = [0, 10, \lin, 0, 0, " Kg"].asSpec;
 );
 
-a.domainSpecs = [0.1, 10, \exponential, 0, 0, " Kg"].asSpec; a.refresh;
-a.domainSpecs = [-10, 10, \lin, 0, 0, " Kg"].asSpec; a.refresh;
+a.domainSpecs = [0.1, 10, \exponential, 0, 0, " Kg"].asSpec;
+a.domainSpecs = [-10, 10, \lin, 0, 0, " Kg"].asSpec;
 
 a = [(0..100) * 9, (200..1300) * 2, (200..1000)/ 5].plot;
 a.superpose = true;
 
 a = [[0, 1.2, 1.5], [0, 1.3, 1.5, 1.6], [0, 1.5, 1.8, 2, 6]].midiratio.plot;
-a.plotMode = \levels; a.refresh;
+a.plotMode = \levels;
 a.superpose = false;
 
 // Function:plot
@@ -620,15 +674,15 @@ code::
 // data
 a = (50..90).midicps.scramble.plot;
 // specs (y-axis)
-a.specs = ControlSpec(100, 2000, units: "Hz"); a.refresh;
+a.specs = ControlSpec(100, 2000, units: "Hz");
 
 a.value = 50.collect{ exprand(1e4, 1e7) };
-a.specs = [1e4, 1e7, \exp].asSpec; a.refresh;
+a.specs = [1e4, 1e7, \exp].asSpec;
 
 // domainSpecs (x-axis)
 // If domain is unassigned, values are
 // distributed evenly within the spec range
-a.domainSpecs = [-10, 70].asSpec; a.refresh;
+a.domainSpecs = [-10, 70].asSpec;
 
 
 // Setting the domain, run the full block:
@@ -673,11 +727,11 @@ plt2.domainSpecs_(([-0.5pi, 2.5pi]).asSpec);
 
 // Non-linear scaling of axes.
 // plot 1000 values, linearly distributed on X and Y
-p = (1, 2 .. 1000).plot.domainSpecs_([1, 1000, \lin].asSpec).refresh;
+p = (1, 2 .. 1000).plot.domainSpecs_([1, 1000, \lin].asSpec);
 // scale y axis exponentially
-p.specs_([[1, 1000, \exp].asSpec]).refresh;
+p.specs_([[1, 1000, \exp].asSpec]);
 // then scale x axis exponentially
-p.domainSpecs_([1, 1000, \exp].asSpec).refresh;
+p.domainSpecs_([1, 1000, \exp].asSpec);
 ::
 
 


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation
This PR adds a number of new modes for plotting:
- `dots` is like `points` but with filled circles. (not crazy about the name, open to suggestions)
  - in the following, modes are prepended with 'p' or 'd' denoting that 'points' or 'dots' are added to the mode
- `stems`, `pstems`, and `dstems` introduce a mode for a [PCM](https://en.wikipedia.org/wiki/Pulse-code_modulation#Modulation)-style perspective on discrete time sampling/synthesis, common in DSP pedagogy.
- `dlines` is probably the most common waveform representation when "zoomed in" (in DAWs, editors, etc), again highlighting _discrete_ sampling. This is the same as the existing `plines` mode, but the "dots" are filled.
- `filled` fills the area under a waveform, and assumes a bipolar signal (filled to the zero-crossing), like SC's `Stethoscope`. `pfilled` and `dfilled` add points and dots, respectively, to this mode. 
- `lines` was added as a synonym for `linear`, to align with with other modes, which have plural names (and is easier to remember imo)

Left: current modes, Right: added modes (click to enlarge)
<img width="1496" alt="Screenshot 2024-01-23 at 11 50 27" src="https://github.com/supercollider/supercollider/assets/923342/4510b865-f6dc-49fe-9424-d25281b85041">

The `filled` modes can be particularly useful for showing, e.g., phase relationships:
<img width="802" alt="Screenshot 2024-01-23 at 18 24 25" src="https://github.com/supercollider/supercollider/assets/923342/173f9512-1dd6-47ee-8019-4388d994e0fe">


Other changes:
- `dlines` was made to be the default mode in the `-plot` method of `ArrayedCollection`, when the density of samples is low
- A number of the methods for the plotting modes were refactored to simply use a combination of `lines` and `dots`, and the responsibility of whether to `fill` or `stroke` the drawing was moved to the mode method, rather than the `drawData` method (which wouldn't have supported these "combined" modes like `\dlines`, `\plines`, etc.). 
  - As a consequence, the `-needsPenFill` method was removed, because it was only used for the `\bars` mode, which and now fills in that mode's method.

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->

- Documentation
- New feature

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review
