### PR TITLE
Add SoundFile:*write that works with multichannel files

### DIFF
--- a/HelpSource/Classes/SoundFile.schelp
+++ b/HelpSource/Classes/SoundFile.schelp
@@ -34,6 +34,25 @@ Full path to the sound file. Use link::Classes/String#-standardizePath:: to reso
 
 returns:: A new SoundFile instance if successful, or code::nil:: if file open failed. User code should check for code::nil:: before doing anything with the SoundFile object.
 
+method:: write
+Writes an array (or nested array) to a path as a sound file.
+
+argument:: pathName
+The path as a link::Classes/String::.
+
+argument:: array
+The data to write. Can be an array of number, or if multichannel, an array of arrays of multichannel.
+
+argument:: headerFormat
+See link::Classes/SoundFile#-headerFormat::.
+
+argument:: sampleRate
+A number, defaults to 44100.
+
+argument:: sampleFormat
+See link::Classes/SoundFile#-sampleFormat::.
+
+
 method:: openWrite
 Try to create an audio file at the given path. Note that there is no code::numFrames:: argument: the number of frames is counted after writing data into the file.
 

--- a/SCClassLibrary/Common/Collections/String.sc
+++ b/SCClassLibrary/Common/Collections/String.sc
@@ -130,6 +130,7 @@ String[char] : RawArray {
 	format { arg ... items; ^this.prFormat( items.collect(_.asString) ) }
 	prFormat { arg items; _String_Format ^this.primitiveFailed }
 	matchRegexp { arg string, start = 0, end; _String_Regexp ^this.primitiveFailed }
+	replaceRegex { |regex, replaceWith| _String_ReplaceRegex ^this.primitiveFailed }
 
 	fformat { arg ... args;
 		var str, resArgs, val, func;

--- a/SCClassLibrary/Common/Files/SoundFile.sc
+++ b/SCClassLibrary/Common/Files/SoundFile.sc
@@ -70,6 +70,36 @@ SoundFile {
 		^res
 	}
 
+	*write {|pathName, array, headerFormat, sampleRate, sampleFormat|
+		var file = SoundFile.new;
+
+		if(array.isKindOf(SequenceableCollection).not,
+			{Error("Argument 'array' must be an instance of SequenceableCollection (e.g., Array). Received" + array.class.asString + "with value" + array.asString).throw});
+
+		if(array.shape.size > 2,
+			{Error(
+				"Cannot write an array with nested channels."
+				+ "The array should be formatted as: "
+				+ "[  [channel 1 samples...], [channel 2 samples...], ...]"
+			).throw}
+		);
+
+		headerFormat !? file.headerFormat_(_);
+		sampleFormat !? file.sampleFormat_(_);
+		sampleRate !? file.sampleRate_(_);
+
+		file.numChannels_(if(array.shape.size == 1, 1, {array.shape[0]}));
+
+		if(file.openWrite(pathName).not,
+			{Error("Could not open file at path:" + pathName).throw});
+
+		// interlace the samples and write
+		file.writeData(FloatArray.with(*array.lace(array.shape.reduce('*')).asFloat));
+
+		file.close;
+		^pathName
+	}
+
 	openRead{ arg pathName;
 		path = pathName ? path;
 		^this.prOpenRead(path);


### PR DESCRIPTION
There is no mention in the documentation of how a multichannel sound file should be written. This makes it work by default, and provides several error messages.

<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

It is not clear how a multichannel sound file should be written from the documentation, nor from SoundFile's interface.
Often, a sound file just wants to be written, this wraps all the logic of handling the file and interlacing the samples into a single method call. 

## Example of use
Creates 20 channels of 1 second of white noise. 
```supercollider
SoundFile.write("/tmp/test3.aiff", { {-1.0.rrand(1.0)} ! 44100} ! 20)
```
Without this changes the user would have to do...
```supercollider
a = { {-1.0.rrand(1.0)} ! 44100} ! 20;
a = a.lace(20*44100).asFloat.as(FloatArray);
f = SoundFile.new.numChannels_(20);
f.openWrite("/tmp/test3.aiff");
f.writeData(a);
f.close;
```
Where the conversion to FloatArray can be tricky if a nested array is passed in. While it might be better to make the change there instead, it is implemented as a primitive. 

## Types of changes
- New feature

## To-do list

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review
