### PR TITLE
ScopeView: allow lissajou for more than 2 chs as overlaid pairs

### DIFF
--- a/HelpSource/Classes/ScopeView.schelp
+++ b/HelpSource/Classes/ScopeView.schelp
@@ -44,7 +44,7 @@ METHOD:: style
     list::
     ## 0 = the channels are vertically spaced
     ## 1 = the channels are overlaid
-    ## 2 = lissajou; the first two channels are used for 2D plotting (as streams of x and y coordinates).
+    ## 2 = lissajou; each pair of channels is used for 2D plotting (as streams of x and y coordinates).
     ::
 
     argument::

--- a/HelpSource/Classes/Stethoscope.schelp
+++ b/HelpSource/Classes/Stethoscope.schelp
@@ -231,6 +231,21 @@ c.scope;
 // fact that ScopeOut.kr doesn't work yet.)
 ::
 
+SUBSECTION:: Multi-channel Lissajou plots
+code::
+(
+{ 
+	var f = { |l,h| SinOsc.kr(0.1, {pi.rand}).range(l, h) } ;
+	Pulse.ar({ f.(20, 1000) }!6, { f.(0.0, 1) }!6, { f.(0.0, 1.0) }!6) 
+}.play;
+)
+
+c = s.scope;
+c.numChannels = 6;
+c.scopeView.waveColors = [Color.red, Color.red, Color.cyan, Color.cyan, Color.white, Color.white];
+c.style = 2;
+::
+
 SUBSECTION:: Embedded use
 You can pass your own view in to add a stethoscope to it:
 

--- a/HelpSource/Classes/Stethoscope.schelp
+++ b/HelpSource/Classes/Stethoscope.schelp
@@ -165,7 +165,7 @@ METHOD:: style
     list::
     ## 0 = the channels are vertically spaced
     ## 1 = the channels are overlaid
-    ## 2 = lissajou; the first two channels are used for 2D plotting (as streams of x and y coordinates).
+    ## 2 = lissajou; each pair of channels is used for 2D plotting (as streams of x and y coordinates).
     ::
 
     argument::

--- a/QtCollider/widgets/QcScopeShm.cpp
+++ b/QtCollider/widgets/QcScopeShm.cpp
@@ -307,23 +307,28 @@ void QcScopeShm::paint2D(int chanCount, int maxFrames, int frameCount, const QRe
     painter.translate(center.x(), center.y());
     painter.scale(xRatio, yRatio);
 
-    QPainterPath path;
-
     if (chanCount >= 2) {
-        float* data1 = _data;
-        float* data2 = _data + maxFrames;
+        for (int i = 0; i + 1 < chanCount; i += 2) {
+            float* data1 = _data + maxFrames * i;
+            float* data2 = _data + maxFrames * (i + 1);
 
-        path.moveTo(data1[0], data2[0]);
-        for (int f = 1; f < frameCount; ++f)
-            path.lineTo(data1[f], data2[f]);
+            QPainterPath path;
+            path.moveTo(data1[0], data2[0]);
+            for (int f = 1; f < frameCount; ++f)
+                path.lineTo(data1[f], data2[f]);
+
+            pen.setColor(i < colors.count() ? colors[i] : QColor(255, 255, 255));
+            painter.setPen(pen);
+            painter.drawPath(path);
+        }
     } else {
         float* data1 = _data;
+        QPainterPath path;
         path.moveTo(data1[0], 0.f);
         for (int f = 1; f < frameCount; ++f)
             path.lineTo(data1[f], 0.f);
+        painter.drawPath(path);
     }
-
-    painter.drawPath(path);
 }
 
 void QcScopeShm::connectSharedMemory(int port) {


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

Currently ScopeView's lissajou style limits itself to the first two channels being monitored. It is however useful to be able to plot lissajou curves for more than one channel pair, the simplest way being overlaying them. ScopeView is already able to monitor more than two channels, and it has an option to choose different `waveColors`, which make overlaid XY plots discernible, like in the current `overlay` style.

Before making this PR, I've tried composing two stethoscopes in a `StackLayout`, with transparent backgrounds, but it failed at overlaying plots, perhaps due to the QtCollider implementation drawing a bitmap.

This PR doesn't compromise previous functionality: when scoping a 2 channel bus, XY plots are still 2 channels, and default GUIs have options to change number of channels monitored and their offset, so that switching between adjacent channel pairs is still possible the same way as it was before. However, if anyone is relying on ScopeView hiding every other channel than the first two from XY plots, e.g. expecting to see XY plots only for the first 2 channels when monitoring a 6 channels bus, they would now get more confusing plots, especially if they use default colors.

*Possible use cases*:
- inspecting the stereo image of multiple sub-mixes in the same plot
- my real use case: monitoring time-delay phase-space plots of multiple channels in the same plot

*Documentation*:
I've changed the spots where it says that only the first two channels would be plotted

*Tests*:
I couldn't come up with ideas for tests of this new functionality, as we can't easily check how many channels are being plotted in lissajou style.

## Types of changes

- New feature

## To-do list

- [x] Updated documentation
- [x] This PR is ready for review
