### PR TITLE
Fix uint8 size of PyrSymbol

### DIFF
--- a/editors/sc-ide/primitives/sc_ipc_client.cpp
+++ b/editors/sc-ide/primitives/sc_ipc_client.cpp
@@ -368,12 +368,13 @@ int ScIDE_SetDocTextMirror(struct VMGlobals* g, int numArgsPushed) {
 
     PyrSlot* textSlot = g->sp - 2;
 
-    if(!(IsSym(textSlot) or isKindOfSlot(textSlot, class_string)))
+    if (!(IsSym(textSlot) or isKindOfSlot(textSlot, class_string)))
         return errWrongType;
 
 
     const auto [errCode, text] = slotStdStrVal(textSlot);
-    if(errCode) return errCode;
+    if (errCode)
+        return errCode;
 
     int pos, range, err = errNone;
     PyrSlot* posSlot = g->sp - 1;

--- a/editors/sc-ide/primitives/sc_ipc_client.cpp
+++ b/editors/sc-ide/primitives/sc_ipc_client.cpp
@@ -368,15 +368,12 @@ int ScIDE_SetDocTextMirror(struct VMGlobals* g, int numArgsPushed) {
 
     PyrSlot* textSlot = g->sp - 2;
 
-    int length = slotStrLen(textSlot);
-
-    if (length == -1)
+    if(!(IsSym(textSlot) or isKindOfSlot(textSlot, class_string)))
         return errWrongType;
 
-    std::vector<char> text(length + 1);
 
-    if (slotStrVal(textSlot, text.data(), length + 1))
-        return errWrongType;
+    const auto [errCode, text] = slotStdStrVal(textSlot);
+    if(errCode) return errCode;
 
     int pos, range, err = errNone;
     PyrSlot* posSlot = g->sp - 1;
@@ -390,7 +387,7 @@ int ScIDE_SetDocTextMirror(struct VMGlobals* g, int numArgsPushed) {
         return err;
 
     QByteArray key = QByteArray(id);
-    QString docText = QString(text.data());
+    QString docText = QString::fromStdString(text);
 
     gIpcClient->setTextMirrorForDocument(key, docText, pos, range);
 

--- a/include/plugin_interface/Hash.h
+++ b/include/plugin_interface/Hash.h
@@ -36,9 +36,9 @@ using hash_t = int32;
 
 // hash function for a string
 constexpr inline hash_t Hash(const char* key) {
-// the one-at-a-time hash.
-// a very good hash function. ref: a web page by Bob Jenkins.
-// http://www.burtleburtle.net/bob/hash/doobs.html
+    // the one-at-a-time hash.
+    // a very good hash function. ref: a web page by Bob Jenkins.
+    // http://www.burtleburtle.net/bob/hash/doobs.html
     hash_t hash = 0;
     while (*key) {
         hash += *key++;
@@ -53,8 +53,8 @@ constexpr inline hash_t Hash(const char* key) {
 
 // hash function for a string that also returns the length
 constexpr inline hash_t Hash(const char* key, size_t* outLength) {
-// the one-at-a-time hash.
-// a very good hash function. ref: a web page by Bob Jenkins.
+    // the one-at-a-time hash.
+    // a very good hash function. ref: a web page by Bob Jenkins.
     const char* startKey = key;
     hash_t hash = 0;
     while (*key) {
@@ -77,8 +77,8 @@ constexpr inline std::tuple<hash_t, size_t> HashWithSize(const char* in) {
 
 // hash function for an array of char
 constexpr inline hash_t Hash(const char* key, uint32 inLength) {
-// the one-at-a-time hash.
-// a very good hash function. ref: a web page by Bob Jenkins.
+    // the one-at-a-time hash.
+    // a very good hash function. ref: a web page by Bob Jenkins.
     hash_t hash = 0;
     for (decltype(inLength) i = 0; i < inLength; ++i) {
         hash += *key++;
@@ -93,9 +93,9 @@ constexpr inline hash_t Hash(const char* key, uint32 inLength) {
 
 // hash function for integers
 constexpr inline hash_t Hash(int32 inKey) {
-// Thomas Wang's integer hash.
-// http://www.concentric.net/~Ttwang/tech/inthash.htm
-// a faster hash for integers. also very good.
+    // Thomas Wang's integer hash.
+    // http://www.concentric.net/~Ttwang/tech/inthash.htm
+    // a faster hash for integers. also very good.
     auto hash = (uint32)inKey;
     hash += ~(hash << 15);
     hash ^= hash >> 10;
@@ -108,7 +108,7 @@ constexpr inline hash_t Hash(int32 inKey) {
 
 // this function isn't used in the vm (where hash_t is int32), but might be used elsewhere
 constexpr inline int64 Hash64(int64 inKey) {
-// Thomas Wang's 64 bit integer hash.
+    // Thomas Wang's 64 bit integer hash.
     auto hash = (uint64)inKey;
     hash += ~(hash << 32);
     hash ^= (hash >> 22);
@@ -122,8 +122,8 @@ constexpr inline int64 Hash64(int64 inKey) {
 }
 
 constexpr inline hash_t Hash(const int32* inKey, uint32 inLength) {
-// one-at-a-time hashing of a string of int32's.
-// uses Thomas Wang's integer hash for the combining step.
+    // one-at-a-time hashing of a string of int32's.
+    // uses Thomas Wang's integer hash for the combining step.
     hash_t hash = 0;
     for (decltype(inLength) i = 0; i < inLength; ++i)
         hash = Hash(hash + *inKey++);
@@ -137,8 +137,8 @@ const int32 kLASTCHAR = (int32)0x000000FF;
 #endif
 
 constexpr inline hash_t Hash(const int32* inKey) {
-// hashing of a string of int32's.
-// uses Thomas Wang's integer hash for the combining step.
+    // hashing of a string of int32's.
+    // uses Thomas Wang's integer hash for the combining step.
     hash_t hash = 0;
     for (;;) {
         const int32 c = *inKey++;

--- a/include/plugin_interface/Hash.h
+++ b/include/plugin_interface/Hash.h
@@ -30,27 +30,9 @@
 // TODO: could this be made unsigned, integer overflow is only implementation defined on signed types?
 using hash_t = int32;
 
-
-// bit cast from c++20, copied from cpp-ref, used to remove the c cast, which is implementation defined.
-template <class To, class From>
-constexpr inline
-std::enable_if_t<sizeof(To) == sizeof(From) && std::is_trivially_copyable_v<From> && std::is_trivially_copyable_v<To>,
-    To>
-bit_cast(const From& src) noexcept {
-    static_assert(std::is_trivially_constructible_v<To>,
-                  "This implementation additionally requires "
-                  "destination type to be trivially constructible");
-
-    To dst;
-    memcpy(&dst, &src, sizeof(To));
-    return dst;
-}
-
-
 // These hash functions are among the best there are in terms of both speed and quality.
 // A good hash function makes a lot of difference.
 // I have not used Bob Jenkins own hash function because the keys I use are relatively short.
-
 
 // hash function for a string
 constexpr inline hash_t Hash(const char* key) {
@@ -83,8 +65,6 @@ constexpr inline hash_t Hash(const char* key, size_t* outLength) {
     hash += hash << 3;
     hash ^= hash >> 11;
     hash += hash << 15;
-// pedantic but possible
-    static_assert(std::numeric_limits<size_t>::max() >= std::numeric_limits<decltype(key - startKey)>::max());
     *outLength = static_cast<size_t>(key - startKey);
     return hash;
 }
@@ -116,7 +96,7 @@ constexpr inline hash_t Hash(int32 inKey) {
 // Thomas Wang's integer hash.
 // http://www.concentric.net/~Ttwang/tech/inthash.htm
 // a faster hash for integers. also very good.
-    auto hash = bit_cast<uint32>(inKey);
+    auto hash = (uint32)inKey;
     hash += ~(hash << 15);
     hash ^= hash >> 10;
     hash += hash << 3;
@@ -129,7 +109,7 @@ constexpr inline hash_t Hash(int32 inKey) {
 // this function isn't used in the vm (where hash_t is int32), but might be used elsewhere
 constexpr inline int64 Hash64(int64 inKey) {
 // Thomas Wang's 64 bit integer hash.
-    auto hash = bit_cast<uint64>(inKey);
+    auto hash = (uint64)inKey;
     hash += ~(hash << 32);
     hash ^= (hash >> 22);
     hash += ~(hash << 13);

--- a/lang/LangPrimSource/ReadWriteMacros.h
+++ b/lang/LangPrimSource/ReadWriteMacros.h
@@ -72,21 +72,19 @@ public:
         writeUInt8((uint8)(inInt >> 24));
     }
 
-    template<class I>
-    void writeInteger_be(I sz){
+    template <class I> void writeInteger_be(I sz) {
         static_assert(std::is_integral_v<I>);
         uint8 bytes[sizeof(I)];
         std::memcpy(bytes, reinterpret_cast<void*>(&sz), sizeof(I));
-        for(size_t i = 0; i < sizeof(I); ++i)
+        for (size_t i = 0; i < sizeof(I); ++i)
             writeUInt8(bytes[sizeof(I) - 1 - i]);
     }
 
-    template<class I>
-    void writeInteger_le(I sz) {
+    template <class I> void writeInteger_le(I sz) {
         static_assert(std::is_integral_v<I>);
         uint8 bytes[sizeof(I)];
         std::memcpy(bytes, reinterpret_cast<void*>(&sz), sizeof(I));
-        for(size_t i = 0; i < sizeof(I); ++i)
+        for (size_t i = 0; i < sizeof(I); ++i)
             writeUInt8(bytes[sizeof(I)]);
     }
 
@@ -197,26 +195,24 @@ public:
         return (int32)((d << 24) | (c << 16) | (b << 8) | a);
     }
 
-    template<class I>
-    I readInteger_le() {
+    template <class I> I readInteger_le() {
         static_assert(std::is_integral_v<I>);
         uint8 bytes[sizeof(I)];
-        for(size_t i=0; i < sizeof(I); ++i)
+        for (size_t i = 0; i < sizeof(I); ++i)
             bytes[i] = readUInt8();
         std::reverse(bytes, bytes + sizeof(I));
         I out;
-        std::memcpy(reinterpret_cast<uint8 *>(&out), bytes, sizeof(I));
+        std::memcpy(reinterpret_cast<uint8*>(&out), bytes, sizeof(I));
         return out;
     }
 
-    template<class I>
-    I readInteger_be() {
+    template <class I> I readInteger_be() {
         static_assert(std::is_integral_v<I>);
         uint8 bytes[sizeof(I)];
-        for(size_t i=0; i < sizeof(I); ++i)
+        for (size_t i = 0; i < sizeof(I); ++i)
             bytes[i] = readUInt8();
         I out;
-        std::memcpy(reinterpret_cast<uint8 *>(&out), bytes, sizeof(I));
+        std::memcpy(reinterpret_cast<uint8*>(&out), bytes, sizeof(I));
         return out;
     }
 

--- a/lang/LangPrimSource/ReadWriteMacros.h
+++ b/lang/LangPrimSource/ReadWriteMacros.h
@@ -23,8 +23,8 @@
 
 #include "SC_Types.h"
 #include "SC_Endian.h"
-#include <stdio.h>
-#include <string.h>
+#include <cstdio>
+#include <cstring>
 #include <stdexcept>
 
 template <class T> class SC_IOStream {
@@ -32,8 +32,8 @@ protected:
     T s;
 
 public:
-    SC_IOStream(): s(0) { }
-    SC_IOStream(T inStream): s(inStream) { }
+    SC_IOStream(): s(0) {}
+    SC_IOStream(T inStream): s(inStream) {}
 
     void SetStream(T inStream) { s = inStream; }
     T GetStream() { return s; }

--- a/lang/LangSource/InitAlloc.h
+++ b/lang/LangSource/InitAlloc.h
@@ -24,8 +24,12 @@
 #include "SC_AllocPool.h"
 #include <stdexcept>
 
+
+namespace exceptionMsgs {
+constexpr static auto outOfMemory = "Out of memory!\n";
+}
 #define MEMFAIL(ptr)                                                                                                   \
     if (!(ptr)) {                                                                                                      \
-        throw std::runtime_error("Out of memory!\n");                                                                  \
+        throw std::runtime_error(exceptionMsgs::outOfMemory);                                                                  \
     }
-#define MEMFAILED throw std::runtime_error("Out of memory!\n");
+#define MEMFAILED throw std::runtime_error(exceptionMsgs::outOfMemory);

--- a/lang/LangSource/InitAlloc.h
+++ b/lang/LangSource/InitAlloc.h
@@ -30,6 +30,6 @@ constexpr static auto outOfMemory = "Out of memory!\n";
 }
 #define MEMFAIL(ptr)                                                                                                   \
     if (!(ptr)) {                                                                                                      \
-        throw std::runtime_error(exceptionMsgs::outOfMemory);                                                                  \
+        throw std::runtime_error(exceptionMsgs::outOfMemory);                                                          \
     }
 #define MEMFAILED throw std::runtime_error(exceptionMsgs::outOfMemory);

--- a/lang/LangSource/PyrObject.cpp
+++ b/lang/LangSource/PyrObject.cpp
@@ -1071,7 +1071,7 @@ static ColumnDescriptor* prepareColumnTable(ColumnDescriptor* sels, int numSelec
     SymbolTable* symbolTable = gMainVMGlobals->symbolTable;
 
     int selectorTableIndex = 0;
-    for (int i : boost::irange(0, symbolTable->TableSize())) {
+    for (auto i : boost::irange(decltype(symbolTable->TableSize())(0), symbolTable->TableSize())) {
         PyrSymbol* sym = symbolTable->Get(i);
         if (sym && (sym->flags & sym_Selector))
             sels[selectorTableIndex++].selector = sym;

--- a/lang/LangSource/PyrSlot.h
+++ b/lang/LangSource/PyrSlot.h
@@ -61,7 +61,7 @@ int slotStrVal(PyrSlot* slot, char* str, size_t maxlen);
 std::tuple<int, std::string> slotStdStrVal(PyrSlot* slot);
 std::tuple<int, std::string> slotStrStdStrVal(PyrSlot* slot);
 size_t slotStrLenAssumeTextual(PyrSlot* slot);
-//int slotPStrVal(PyrSlot* slot, unsigned char* str);
+// int slotPStrVal(PyrSlot* slot, unsigned char* str);
 int slotSymbolVal(PyrSlot* slot, PyrSymbol** symbol);
 
 template <typename numeric_type> inline void setSlotVal(PyrSlot* slot, numeric_type value);

--- a/lang/LangSource/PyrSlot.h
+++ b/lang/LangSource/PyrSlot.h
@@ -57,11 +57,11 @@ int asCompileString(PyrSlot* slot, char* str);
 int slotIntVal(PyrSlot* slot, int* value);
 int slotFloatVal(PyrSlot* slot, float* value);
 int slotDoubleVal(PyrSlot* slot, double* value);
-int slotStrVal(PyrSlot* slot, char* str, int maxlen);
+int slotStrVal(PyrSlot* slot, char* str, size_t maxlen);
 std::tuple<int, std::string> slotStdStrVal(PyrSlot* slot);
 std::tuple<int, std::string> slotStrStdStrVal(PyrSlot* slot);
-int slotStrLen(PyrSlot* slot);
-int slotPStrVal(PyrSlot* slot, unsigned char* str);
+size_t slotStrLenAssumeTextual(PyrSlot* slot);
+//int slotPStrVal(PyrSlot* slot, unsigned char* str);
 int slotSymbolVal(PyrSlot* slot, PyrSymbol** symbol);
 
 template <typename numeric_type> inline void setSlotVal(PyrSlot* slot, numeric_type value);

--- a/lang/LangSource/PyrSymbol.h
+++ b/lang/LangSource/PyrSymbol.h
@@ -83,7 +83,7 @@ inline PyrSymbol::PyrSymbol(char* iname, hash_t ihash, int16 ispecialIndex) noex
     specialIndex(ispecialIndex),
     flags(build_flags(iname, length)),
     u(),
-    classdep(nullptr) { }
+    classdep(nullptr) {}
 
 inline PyrSymbol::PyrSymbol(char* iname, hash_t ihash, size_t ilength, int16 ispecialIndex) noexcept:
     name(iname),
@@ -92,4 +92,4 @@ inline PyrSymbol::PyrSymbol(char* iname, hash_t ihash, size_t ilength, int16 isp
     specialIndex(ispecialIndex),
     flags(build_flags(iname, ilength)),
     u(),
-    classdep(nullptr) { }
+    classdep(nullptr) {}

--- a/lang/LangSource/PyrSymbol.h
+++ b/lang/LangSource/PyrSymbol.h
@@ -27,22 +27,34 @@ A PyrSymbol is a unique string that resides in a global hash table.
 
 #include "SC_Types.h"
 #include "PyrSlot.h"
+#include "Hash.h"
+
 
 struct PyrSymbol {
-    char* name;
-    long hash;
-    short specialIndex;
+    // Assumes name is a valid c string (length is greater than 0), which this class takes ownership of.
+    PyrSymbol(char* name, hash_t hash, int16 specialIndex) noexcept;
+    // Assumes name is a valid c string (length is greater than 0), which this class takes ownership of.
+    PyrSymbol(char* name, hash_t hash, size_t length, int16 specialIndex) noexcept;
+    PyrSymbol() = delete;
+    PyrSymbol(PyrSymbol&&) noexcept = default;
+    PyrSymbol(const PyrSymbol&) noexcept = default;
+    PyrSymbol& operator=(PyrSymbol&&) noexcept = default;
+    PyrSymbol& operator=(const PyrSymbol&) noexcept = default;
+
+    /* owning */ char* name;
+    size_t length;
+    hash_t hash;
+    int16 specialIndex;
     uint8 flags;
-    uint8 length;
     union {
-        intptr_t index; // index in row table or primitive table
+        intptr_t index = 0; // index in row table or primitive table
         struct PyrClass* classobj; // pointer to class with this name.
         char* source; // source code for sym_Filename; used only during compilation.
     } u;
-    struct classdep* classdep;
+    struct classdep* classdep = nullptr;
 };
 
-enum {
+enum : uint8 {
     sym_Selector = 1,
     sym_Class = 2,
     sym_Compiled = 4,
@@ -52,3 +64,32 @@ enum {
     sym_MetaClass = 64,
     sym_Filename = 128
 };
+
+inline uint8 build_flags(const char* name, size_t len) {
+    uint8 out;
+    if (isupper(name[0]))
+        out |= sym_Class;
+    if (len > 1 and name[0] == '_') // could be a symbol of an underscore (which is not a primitive)
+        out |= sym_Primitive;
+    if (len > 1 and name[len - 1] == '_')
+        out |= sym_Setter;
+    return out;
+}
+
+inline PyrSymbol::PyrSymbol(char* iname, hash_t ihash, int16 ispecialIndex) noexcept:
+    name(iname),
+    hash(ihash),
+    length(strlen(iname)),
+    specialIndex(ispecialIndex),
+    flags(build_flags(iname, length)),
+    u(),
+    classdep(nullptr) { }
+
+inline PyrSymbol::PyrSymbol(char* iname, hash_t ihash, size_t ilength, int16 ispecialIndex) noexcept:
+    name(iname),
+    hash(ihash),
+    length(ilength),
+    specialIndex(ispecialIndex),
+    flags(build_flags(iname, ilength)),
+    u(),
+    classdep(nullptr) { }


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation


The size of PyrSymbol was uint8. This caused many bug with long symbols. In many places, core code was calling strlen on the pointer, so this was clearly a known issue.

There are numerous places where implicit casting of integers looses precision, I have caught a few that relate to symbol, but there are many more.
 
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->
Fixes #6214 

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

There should be no breaking changes.

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [ ] Code is tested
- [ ] All tests are passing
- [ ] This PR is ready for review
