### PR TITLE
class library: when NodeProxy is neutral, rest source pattern

### DIFF
--- a/SCClassLibrary/JITLib/ProxySpace/wrapForNodeProxy.sc
+++ b/SCClassLibrary/JITLib/ProxySpace/wrapForNodeProxy.sc
@@ -237,7 +237,7 @@
 			server = proxy.server;
 			out = {
 				var n = proxy.numChannels;
-				if(n.isNil) { -1 } {
+				if(n.isNil) { \rest } {
 					(~channelOffset ? channelOffset) % n + index
 				}
 			};


### PR DESCRIPTION

<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

This fixes #6222. The number `-1` was probably a misunderstanding anyway, since the node id is -1 for anonymous synths. There is no such thing as a meaningful bus number of -1.


## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix


## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] This PR is ready for review
