### PR TITLE
Add primitive `isRectangular` to array.

### DIFF
--- a/HelpSource/Classes/ArrayedCollection.schelp
+++ b/HelpSource/Classes/ArrayedCollection.schelp
@@ -52,6 +52,20 @@ code::
 [4, 5, 6].maxSize; // gosh
 ::
 
+method::isRectangular
+Returns true if all nested sub arrays are the same size and all elements have the same depth.
+This is a requirement of several nested array algorithms and formats, notably multichannel audio files.
+
+Example:
+code::
+[1, 2, 3].isRectangular // true
+[[1, 2], [3, 4]].isRectangular // true
+
+[1, 2, [3]].isRectangular // false
+[[1, 2], [3]].isRectangular // false
+[[1, 2], [3, [4, 5]]].isRectangular // false
+::
+
 method::at
 Return the item at strong::index::.
 
@@ -439,25 +453,36 @@ a.performInPlace(\normalizeSum, 3, 6);
 ::
 
 method::rank
-Rank is the number of dimensions in a multidimensional array.
+Returns the number of dimensions of the collection.
+code::rank:: inspects the size of the left-most elements of sub-arrays only,
+i.e. it's assumed that the collection link::#-isRectangular::,
+so subarrays of mismatched sizes may not return an expected result.
+A single value has a rank of code::0::.
+An empty array has a rank of code::1::.
+
 code::
-a = [4,7,6,8];
-a.rank;
-a = [[4,7],[6,8]];
-a.rank;
+0.rank // 0
+[].rank // 1
+[4, 7, 6, 8].rank // 1
+[[4, 7], [6, 8]].rank // 2
+[1 ,2, [3, 4]].rank // 1, this array is not rectangular and returns a meaningless value.
 ::
 
 method::shape
-For a multidimensional array, returns the number of elements along each dimension.
+Returns an array describing the dimension of each nested array.
+Requires link::#-isRectangular:: as a precondition.
+
 code::
-a = [4,7,6,8];
-a.shape;
-a = [[4,7],[6,8]];
-a.shape;
+[4, 7, 6, 8].shape // [4]
+[[4, 7], [6, 8]].shape // [2, 2]
+[[[4, 7]], [[6, 8]]].shape // [2, 1, 2]
+[1, 2, [3, 4]].shape // [3], this array is not rectangular and returns a meaningless value.
 ::
 
 method::reshape
-For a multidimensional array, rearranges the data using the desired number of elements along each dimension. The data may be extended using wrapExtend if needed.
+For a multidimensional array, rearranges the data using the desired number of elements along each dimension.
+The data may be extended using link::Classes/Array#-wrapExtend:: if needed.
+This will always return a rectangular array, see link::#-isRectangular::.
 code::
 a = [4,7,6,8];
 a.reshape(2,2);

--- a/HelpSource/Classes/Object.schelp
+++ b/HelpSource/Classes/Object.schelp
@@ -112,6 +112,17 @@ method::size
 
 Different classes respond to this message differently. Object always returns 0.
 
+method::rank
+Returns the number of dimensions the value has.
+A single value (scalar) has rank of zero.
+See link::Classes/ArrayedCollection#-rank:: for cases where this is useful.
+
+method::shape
+For a multidimensional array,
+returns an array of the number of elements along each consecutive dimension,
+see link::Classes/ArrayedCollection#-shape::.
+For a scalar value (most objects) returns nil.
+
 subsection::Copying
 
 method::copy

--- a/SCClassLibrary/Common/Collections/ArrayedCollection.sc
+++ b/SCClassLibrary/Common/Collections/ArrayedCollection.sc
@@ -321,15 +321,17 @@ ArrayedCollection : SequenceableCollection {
 	}
 
 	// concepts borrowed from J programming language
+	isRectangular {
+	    _ArrayIsRectangular
+		^this.primitiveFailed
+	}
 	rank {
-		// rank is the number of dimensions in a multidimensional array.
-		// see also Object-rank
-		// this assumes every element has the same rank
-		^1 + this.first.rank
+        // precondition: isRectangular
+        ^1 + this.first.rank
 	}
 	shape {
-		// this assumes every element has the same shape
-		^[this.size] ++ this[0].shape
+        // precondition: isRectangular
+        ^[this.size] ++ this[0].shape
 	}
 	reshape { arg ... shape;
 		var size = shape.product;
@@ -452,11 +454,13 @@ ArrayedCollection : SequenceableCollection {
 }
 
 RawArray : ArrayedCollection {
-	// species { ^this.class }
 	archiveAsCompileString { ^true }
 	archiveAsObject { ^true }
 
 	rate { ^\scalar }
+	isRectangular { ^true }
+	shape { ^[this.size] }
+	rank { ^1 }
 
 	readFromStream { |stream, method|
 		if(method.notNil) {

--- a/lang/LangSource/PyrKernel.h
+++ b/lang/LangSource/PyrKernel.h
@@ -58,13 +58,13 @@ struct PyrClass : public PyrObjectHdr {
 };
 
 
-inline bool isKindOf(PyrObjectHdr* obj, struct PyrClass* testclass) {
+inline bool isKindOf(const PyrObjectHdr* obj, const struct PyrClass* testclass) {
     int objClassIndex = slotRawInt(&obj->classptr->classIndex);
     return objClassIndex >= slotRawInt(&testclass->classIndex)
         && objClassIndex <= slotRawInt(&testclass->maxSubclassIndex);
 }
 
-inline bool isKindOfSlot(PyrSlot* slot, struct PyrClass* testclass) {
+inline bool isKindOfSlot(const PyrSlot* slot, const struct PyrClass* testclass) {
     return IsObj(slot) && isKindOf(slotRawObject(slot), testclass);
 }
 

--- a/testsuite/classlibrary/TestArray.sc
+++ b/testsuite/classlibrary/TestArray.sc
@@ -341,6 +341,28 @@ TestArray : UnitTest {
 	test_mirror1_twoElementArray_size { this.assertEquals([1, 2].mirror1.size, 2); }
 	test_mirror2_twoElementArray_size { this.assertEquals([1, 2].mirror2.size, 4); }
 
+	test_is_rectangular_flat {
+	    this.assert([1, 2, 3, 4].isRectangular, "isRectangular: flat arrays, [n1, n2,...], should always be rectangular");
+    }
+	test_is_rectangular_nested_flat {
+	    this.assert([[1, 2, 3, 4]].isRectangular, "isRectangular: single nested flat array, [[n1, n2 ...]] should be rectangular");
+    }
+	test_is_rectangular_square {
+	    this.assert([[1, 2], [3, 4]].isRectangular, "isRectangular: square matrix is rectangular");
+    }
+	test_is_rectangular_deep {
+	    this.assert([[[[[1], [2]], [[3], [4]]]]].isRectangular, "isRectangular: should work at any depth");
+    }
+	test_is_rectangular_false_case {
+	    this.assert([1, [2, 3]].isRectangular.not, "isRectangular: should reject different dimension sizes");
+    }
+	test_is_rectangular_with_raw_array {
+	    this.assert([FloatArray[1,2], Signal[3,4]].isRectangular, "isRectangular: should work on RawArrays (true case)");
+    }
+	test_is_rectangular_with_raw_array_false_case {
+	    this.assert([FloatArray[1,2], Signal[3,4,5]].isRectangular.not, "isRectangular: should work on RawArrays (false case)");
+	}
+
 } // End class
 
 TestArrayLace : UnitTest {


### PR DESCRIPTION
## Purpose and Motivation
Checks that array is regular is shape (not [jagged](https://en.wikipedia.org/wiki/Jagged_array#:~:text=In%20computer%20science%2C%20a%20jagged,edges%20when%20visualized%20as%20output.)).

I needed this in SoundFile:write to make sure all the channels were the same size, while this is overkill for that solution, functions like Array:size and others make this assumption. 

Implementing this is sclang would be significantly slower.

However, by doing it as a primitive means it only works on Array, and not List. This is because List overloads what a 'size' is. 

Examples:
```supercollider
[].isRegular == true;

(0..10).isRegular == true;

[[1,2], [3,4]].isRegular == true;

[[1,2], [3]].isRegular == false;
// yet...
[[1,2], [3,4]].shape == [[1,2], [3]].shape;

[[1], []].isRegular == false;
```

## Types of changes

- New primitive 

## To-do list

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review
