### PR TITLE
 Implement Dynamic Precision Floating-Point Formatting in asStringPrec

### DIFF
--- a/lang/LangPrimSource/PyrPrimitive.cpp
+++ b/lang/LangPrimSource/PyrPrimitive.cpp
@@ -43,13 +43,18 @@
 #include "PyrArchiverT.h"
 #include "PyrDeepCopier.h"
 #include "PyrDeepFreezer.h"
-//#include "Wacom.h"
+// #include "Wacom.h"
 #include "InitAlloc.h"
 #include "SC_AudioDevicePrim.hpp"
 #include "SC_LanguageConfig.hpp"
 #include "SC_Filesystem.hpp"
 #include "SC_Version.hpp"
 #include <map>
+
+#include <cstdio> // For snprintf
+#include <cstring> // For strrchr
+#include <cmath> // For std::fabs
+#include <algorithm>
 
 #ifdef _WIN32
 #    include <direct.h>
@@ -438,6 +443,19 @@ int prObjectString(struct VMGlobals* g, int numArgsPushed) {
     }
 }
 
+void trimTrailingZeros(char* str) {
+    char* point = strrchr(str, '.');
+    if (point != nullptr) {
+        char* end = str + strlen(str) - 1;
+        while (end > point && *end == '0') {
+            *end-- = '\0';
+        }
+        if (end == point) { // If only the decimal point is left, remove it too
+            *end = '\0';
+        }
+    }
+}
+
 int prFloat_AsStringPrec(struct VMGlobals* g, int numArgsPushed);
 int prFloat_AsStringPrec(struct VMGlobals* g, int numArgsPushed) {
     PyrSlot* a = g->sp - 1;
@@ -445,23 +463,52 @@ int prFloat_AsStringPrec(struct VMGlobals* g, int numArgsPushed) {
 
     int precision;
     int err = slotIntVal(b, &precision);
-    if (err)
-        return err;
+    if (err) {
+        return err; // Return error if precision cannot be obtained
+    }
 
-    char fmt[8], str[256];
-    // if our precision is bigger than our stringsize, we can generate a very nasty buffer overflow here. So
-    if (precision <= 0)
-        precision = 1;
-    if (precision >= 200)
-        precision = 200; // Nothing is that big anyway. And we know we will be smaller than our 256 char string
+    double value = slotRawFloat(a);
 
-    sprintf(fmt, "%%.%dg", precision);
-    sprintf(str, fmt, slotRawFloat(a));
+    if (std::isnan(value) || std::isinf(value)) {
+        return errFailed;
+    }
+
+    // Calculate the number of significant digits in the value
+    // This approach assumes normal floating-point numbers and avoids edge cases
+    int significantDigits = value == 0 ? 1 : std::max(1, static_cast<int>(std::log10(std::fabs(value)) + 1));
+
+
+    // Apply the precision limit only if the requested precision exceeds the number of significant digits
+    if (precision > significantDigits) {
+        precision = std::min(precision, significantDigits + 15);
+    }
+
+    char fmt[12]; // Buffer size accounts for potential format strings like "%.15g" plus null terminator
+    char str[256]; // Output buffer for the formatted number, sufficiently large for most use cases
+
+    // Formatting logic remains the same, now with dynamic precision adjustment
+    if (precision > 15 || std::fabs(value) < 1e-5 || std::fabs(value) >= 1e5) {
+        snprintf(fmt, sizeof(fmt), "%%.%dg", precision);
+    } else {
+        snprintf(fmt, sizeof(fmt), "%%.%df", precision);
+    }
+
+    int written = snprintf(str, sizeof(str), fmt, value);
+    if (written < 0 || written >= sizeof(str)) {
+        return errFailed;
+    }
+
+    trimTrailingZeros(str); // Improve readability by trimming unnecessary trailing zeros
 
     PyrString* string = newPyrString(g->gc, str, 0, true);
+    if (!string) {
+        return errFailed;
+    }
+
     SetObject(a, string);
     return errNone;
 }
+
 
 int prAsCompileString(struct VMGlobals* g, int numArgsPushed);
 int prAsCompileString(struct VMGlobals* g, int numArgsPushed) {


### PR DESCRIPTION
 Implement Dynamic Precision Adjustment and Special Value Handling in Floating-Point Formatting in asStringPrec(precision)

This commit introduces changes to the floating-point formatting capabilities within the PyrPrimitive module,  targeting the `prFloat_AsStringPrec` function (float.asStringPrec). The changes aim to improve the formatted outputs' accuracy, safety, and readability, accommodating contexts.

Changes:

- **Dynamic Precision Adjustment**: Implemented a nuanced approach to adjusting requested precision. The function now limits precision to `significantDigits + 15` when the requested precision exceeds the actual significant digits of the value, accommodating the **practical** limits of floating-point representation while allowing for detailed precision where possible.

- **Trimming Trailing Zeros**: Introduced a utility function, `trimTrailingZeros`, to clean up the formatted output, enhancing readability by removing unnecessary zeros and decimal points that do not contribute to the value's accuracy or understanding.

- **Special Floating-Point Value Handling**: Added checks for NaN and inf values. If the input value is NaN or infinity, the function now returns `errFailed`

- **Error Handling and Buffer Size Adjustments**: Improved error handling mechanisms for snprintf operations and PyrString object creation, ensuring against potential issues. Also, buffer sizes were adjusted to safely accommodate format strings and the resulting formatted numbers, mitigating the risk of buffer overflows.

Floating-point numbers present unique challenges in representation due to their inherent precision limits and the binary format used for storage. Adjusting the precision based on the value's significant digits and handling exceptional cases like NaN and infinity ensures that our formatting function produces meaningful and accurate representations for a broad spectrum of floating-point values.



## Purpose and Motivation

Avoid things like this:

7.4.asStringPrec(50)
-> 7.4000000000000003552713678800500929355621337890625

Now:

pi
-> 3.1415926535898

pi.asStringPrec(3)
-> 3.142

pi.asStringPrec(6)
-> 3.141593

(pi * 0.0001).asStringPrec(3)
-> 0

7.4.asStringPrec(5)
-> 7.4

7.4.asStringPrec(50)
-> 7.4



## Types of changes


- Bug fix
- New feature


## To-do list


- [x] Code is tested
- [ ] All tests are passing
- [ ] Updated documentation
- [x] This PR is ready for review
