### PR TITLE
macOS 14 support / bump CI to macOS 14

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -197,7 +197,7 @@ jobs:
 
           - job-name: 'universal'
             os-version: '14'
-            xcode-version: '15.3'
+            xcode-version: '15.2'
             deployment-target: '10.14'
             cmake-architectures: 'x86_64;arm64'
             use-syslibs: false
@@ -211,7 +211,7 @@ jobs:
 
           - job-name: 'x64 legacy'
             os-version: '14'
-            xcode-version: '15.3'
+            xcode-version: '15.2'
             qt-version: '5.9.9' # will use qt from aqtinstall
             deployment-target: '10.11'
             cmake-architectures: x86_64
@@ -225,7 +225,7 @@ jobs:
 
           - job-name: 'x64 use system libraries'
             os-version: '14'
-            xcode-version: '15.3'
+            xcode-version: '15.2'
             deployment-target: '10.14'
             cmake-architectures: x86_64
             use-syslibs: true
@@ -234,7 +234,7 @@ jobs:
 
           - job-name: 'x64 shared libscsynth'
             os-version: '14'
-            xcode-version: '15.3'
+            xcode-version: '15.2'
             deployment-target: '10.14'
             cmake-architectures: x86_64
             use-syslibs: false

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -196,8 +196,8 @@ jobs:
         include:
 
           - job-name: 'universal'
-            os-version: '12'
-            xcode-version: '13.4.1'
+            os-version: '14'
+            xcode-version: '15.3'
             deployment-target: '10.14'
             cmake-architectures: 'x86_64;arm64'
             use-syslibs: false
@@ -210,8 +210,8 @@ jobs:
             verify-app: true
 
           - job-name: 'x64 legacy'
-            os-version: '12'
-            xcode-version: '13.4.1'
+            os-version: '14'
+            xcode-version: '15.3'
             qt-version: '5.9.9' # will use qt from aqtinstall
             deployment-target: '10.11'
             cmake-architectures: x86_64
@@ -224,8 +224,8 @@ jobs:
             artifact-suffix: 'macOS-x64-legacy' # set if needed - will trigger artifact upload
 
           - job-name: 'x64 use system libraries'
-            os-version: '12'
-            xcode-version: '13.4.1'
+            os-version: '14'
+            xcode-version: '15.3'
             deployment-target: '10.14'
             cmake-architectures: x86_64
             use-syslibs: true
@@ -233,8 +233,8 @@ jobs:
             verify-app: true
 
           - job-name: 'x64 shared libscsynth'
-            os-version: '12'
-            xcode-version: '13.4.1'
+            os-version: '14'
+            xcode-version: '15.3'
             deployment-target: '10.14'
             cmake-architectures: x86_64
             use-syslibs: false


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

The current CI runs on macOS 12 which is the last supported version of macOS.
We should always include the current supported macOS versions in our CI and this PR tries to achieve this.
Ideally this would be implemented with a matrix test, but maybe only for one specific kind of build instead of all types macOS builds? This could be discussed here.

There is the potential that macOS 14 introduced some breaking (see https://scsynth.org/t/boost-fail-to-compile-on-macos-14-1-1/8612) - with a more up-to-date pipeline, this could have been mitigated at a prior stage.

It seems that the current build pipeline is broken on macOS 14 (according to CI run @ https://github.com/capital-G/supercollider/actions/runs/8208341214), so while we are at it, we can try to fix the issues here.

I am still on macOS 13, but I think we can try to get this done in a collaborative manner.

This is still WIP, but anyone is welcome to contribute - hopefully it is nothing too big.

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [ ] Code is tested
- [ ] All tests are passing
- [ ] Updated documentation
- [ ] This PR is ready for review
