### PR TITLE
build-system: cmake: added compiler flags for c++17

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -289,6 +289,13 @@ if(APPLE)
     option(SC_VERIFY_APP "Run verify_app on the app bundle" OFF)
 endif()
 
+include(CheckCXXCompilerFlag)
+CHECK_CXX_COMPILER_FLAG("-std=c++17" COMPILER_SUPPORTS_CXX17)
+if(COMPILER_SUPPORTS_CXX17)
+    add_compile_definitions(_LIBCPP_ENABLE_CXX17_REMOVED_UNARY_BINARY_FUNCTION)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-enum-constexpr-conversion")
+endif()
+
 #############################################
 # some default libraries
 


### PR DESCRIPTION
## Purpose and Motivation

Fixes #6244 (on my Mac at least).

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

- [X ] Code is tested // i.e., builds
- [X ] All tests are passing // ctest only. Crash tests are supposed to segfault, right?
- [n/a ] Updated documentation
- [ X] This PR is ready for review
