### PR TITLE
Help: Correct error in Linux env vars discussion

### DIFF
--- a/HelpSource/Reference/AudioDeviceSelection.schelp
+++ b/HelpSource/Reference/AudioDeviceSelection.schelp
@@ -92,7 +92,9 @@ teletype::SC_JACK_DEFAULT_OUTPUTS::. These allow SuperCollider to detect system 
 
 These variables are written as a string that specifies another jack client or a comma-separated list of jack ports formatted as a string.
 
-If these are not set, SuperCollider will default to connecting SuperCollider's inputs and outputs to your system's inputs and outputs. This is the recommended way of changing the Jack environment variables for SuperCollider from within a SuperCollider script:
+If these are not set, the server will not connect to any JACK ports automatically. You may connect them manually, or by issuing teletype::jack_connect:: / teletype::jack_disconnect:: shell commands (link::Classes/String#-unixCmd::). Note that the SuperCollider language client sets these environment variables to "system" by default, so that a server booted from SC language emphasis::will:: connect by default. However, a server booted from the command line will not auto-connect, unless you set the variables in the same terminal session or shell profile (below).
+
+This is the recommended way of changing the Jack environment variables for SuperCollider from within a SuperCollider script:
 
 code::
 // connect first to input channels with system
@@ -107,6 +109,13 @@ As an alternative, these may be also be changed by setting the following environ
 code::
 export SC_JACK_DEFAULT_INPUTS="system"
 export SC_JACK_DEFAULT_OUTPUTS="system"
+::
+
+To disable autoconnect from the language:
+
+code::
+"SC_JACK_DEFAULT_INPUTS".unsetenv;
+"SC_JACK_DEFAULT_OUTPUTS".unsetenv;
 ::
 
 section:: Windows

--- a/HelpSource/Reference/AudioDeviceSelection.schelp
+++ b/HelpSource/Reference/AudioDeviceSelection.schelp
@@ -92,7 +92,9 @@ teletype::SC_JACK_DEFAULT_OUTPUTS::. These allow SuperCollider to detect system 
 
 These variables are written as a string that specifies another jack client or a comma-separated list of jack ports formatted as a string.
 
-If these are not set, the server will not connect to any JACK ports automatically. You may connect them manually, or by issuing teletype::jack_connect:: / teletype::jack_disconnect:: shell commands (link::Classes/String#-unixCmd::). Note that the SuperCollider language client sets these environment variables to "system" by default, so that a server booted from SC language emphasis::will:: connect by default. However, a server booted from the command line will not auto-connect, unless you set the variables in the same terminal session or shell profile (below).
+The SuperCollider language client sets these environment variables to "system" by default, so that a server booted from SC language will connect by default.
+
+If these are not set, the server will not connect to any JACK ports automatically. You may connect them manually, or by issuing teletype::jack_connect:: / teletype::jack_disconnect:: shell commands (link::Classes/String#-unixCmd::). A server booted from the command line will thus not auto-connect, unless you set the variables in the same terminal session or shell profile (below).
 
 This is the recommended way of changing the Jack environment variables for SuperCollider from within a SuperCollider script:
 


### PR DESCRIPTION
## Purpose and Motivation

Help stated: "If these are not set, SuperCollider will default to connecting SuperCollider's inputs and outputs to your system's inputs and outputs." This is not true. PR matches current behavior.

## Types of changes

- Documentation

## To-do list

- [x] Updated documentation
- [x] This PR is ready for review
