### PR TITLE
Fixes Segfault with arrays of certain sizes.

### DIFF
--- a/lang/LangSource/GC.cpp
+++ b/lang/LangSource/GC.cpp
@@ -664,7 +664,7 @@ HOT void PyrGC::Collect() {
     if (mNumToScan > 0) {
         // post("->Collect  ns %d  ng %d  s %d\n", mNumToScan, mNumGrey, mScans);
         // DumpInfo();
-        mNumToScan += mNumToScan >> 3;
+        mNumToScan += static_cast<uint32>(mNumToScan) >> 3;
 
         // post("->Collect2  ns %d  ng %d  s %d\n", mNumToScan, mNumGrey, mScans);
         // mCurSet = 0;


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

Fixes #6234

On my machine , the following code consistently crashes in release mode, but not debug.

```supercollider
b = Pwhite.new(0, 10, inf).asStream;
Array.fill(1810000, {b.next});
```
I was able to trace this down to the member PyrGC::mNumToScan being negative by using print statements at the start and end of all the methods of PyrGC. 
 
For some reason that I cannot understand, this static_cast fixes the problem and avoid ever setting the variable to a negative value. I've even tested this with in a print statement that clearly shows that the signed and unsigned right shifted values are the same??

I have ran it multiple times, and as far as I can tell, completely fixes the issue. 


My machine: 
linux 64bit, manjaro, latest dev branch, compling with GCC13.2.1, -DNATIVE=(ON and OFF) -DINSTALL_HELP=ON -DSC_EL=OFF -DSYSTEM_BOOST=ON 
## Types of changes

<!-- Delete lines that don't apply -->

Added a single static_cast that should effect nothing.


## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] This PR is ready for review
