### PR TITLE
Sclang: PyrGC: Fix GC segfault caused by uncollected temporary function objects by placing an upper limit on un-scanned objects. 

### DIFF
--- a/lang/LangSource/GC.h
+++ b/lang/LangSource/GC.h
@@ -30,6 +30,7 @@ Based on Wilson and Johnstone's real time collector and the Baker treadmill.
 #include "VMGlobals.h"
 #include "AdvancingAllocPool.h"
 #include "function_attributes.h"
+#include <cstdint>
 
 void DumpSimpleBackTrace(VMGlobals* g);
 
@@ -37,7 +38,7 @@ const int kMaxPoolSet = 7;
 const int kNumGCSizeClasses = 28;
 const int kFinalizerSet = kNumGCSizeClasses;
 const int kNumGCSets = kNumGCSizeClasses + 1;
-const int kScanThreshold = 256;
+const std::int64_t kScanThreshold = 256LL;
 
 
 class GCSet {
@@ -197,7 +198,7 @@ private:
     PyrObjectHdr mGrey;
 
     int32 mPartialScanSlot;
-    int32 mNumToScan;
+    std::int64_t mNumToScan;
     int32 mNumGrey;
 
     int32 mFlips, mCollects, mAllocTotal, mScans, mNumAllocs, mStackScans, mNumPartialScans, mSlotsScanned,
@@ -286,7 +287,7 @@ inline void PyrGC::ToGrey(PyrObjectHdr* obj) {
     /* set grey list pointer to obj */
     obj->gc_color = mGreyColor;
     mNumGrey++;
-    mNumToScan += 1L << obj->obj_sizeclass;
+    mNumToScan += 1LL << obj->obj_sizeclass;
 }
 
 inline void PyrGC::ToGrey2(PyrObjectHdr* obj) {
@@ -303,9 +304,9 @@ inline void PyrGC::ToGrey2(PyrObjectHdr* obj) {
 }
 
 inline PyrObject* PyrGC::Allocate(size_t inNumBytes, int32 sizeclass, bool inRunCollection) {
-    if (inRunCollection && mNumToScan >= kScanThreshold)
+    if (inRunCollection && mNumToScan >= kScanThreshold) {
         Collect();
-    else {
+    } else {
         if (inRunCollection)
             mUncollectedAllocations = 0;
         else

--- a/testsuite/sclang/sclang_gc_crash_1.scd
+++ b/testsuite/sclang/sclang_gc_crash_1.scd
@@ -1,0 +1,6 @@
+// This first value caused a crash on some linux systems. 
+[ 1810000, 3620000, 7240000].do { |n|
+    var b = Pwhite().asStream;
+    Array.fill(n, { b.next });
+};
+0.exit;


### PR DESCRIPTION
## Purpose and Motivation

When there are a large number of temporary objects mNumToScan can overflow leading to undefined behaviour (from the overflow of a signed int) and the implementation defined behaviour of right shifting a negative value, creating a GC bug that only appears on some systems, and incorrect, potentially leaking, but non-crashing behaviour on others.

This code cause a crash on some systems.
```supercollider
b = Pwhite.new(0, 10, inf).asStream;
Array.fill(1810000, {b.next});`
```

This commit places an upper limit on the number of objects to scan (5'000'000). Note, SC uses an incremental allocator, meaning this isn't a limit on the amount of memory, but amount of unchecked memory.

While all allocations should cause a collection, when PyrParseNode.cpp creates a PyrMethod, sometimes it sets  'needsHeapContext' to false which disables collection. This is (presumably) done for optimization. What this fails to consider is that frames in supercollider are themselves heap allocated, meaning, no matter how small, they increase mNumToScan, leading to the above bug.

While a change to PyrParseNode.cpp could be possible, the code is without comments and very complex.

Setting a limit on mNumToScan has a potential minuscule impact on performance, as the additional scan happens only rarely, and in some cases, actually improves performance as the GC is allowed to recycle the memory, reducing the number of calls to malloc — this is only noticeable in tight loops with many iterations that create functions.

---

Fixes #6234, also see #6257 for history.

## Benchmarks

Test involving numerous temporary functions (that doesn't crash with the old behaviour).
```supercollider
b = Pwhite.new(0, 10, inf).asStream; 
100.collect{ 
   { 
      Array.fill(100000, {b.next})
   }.bench(false) 
}.mean
```
Old: 0.02174366042
New: 0.01934624595
Delta: +12%

A test without temporary functions that should be unaffected by this PR.
```supercollider
100.collect{ 
   {   
      var a = (\v: 0);   
      while { a[\v] < 100000 } {   
         a[\v] = a[\v].pow(1) + 0.1   
      }     
   }.bench(false)  
}.mean
```
Old: 0.08627185895
New: 0.0867351175
Delta: -0.5% 


## Types of changes

- Bug fix
- Change in GC strategy, observed performance gains, but possible performance regressions although I haven't observed any significant losses.

## To-do list

- [x] Code is tested
- [x] All tests are passing
- [x] This PR is ready for review
