### PR TITLE
Scsynth & Plugin: Remove c cast from CALCSCOPE and fix GVerbs roomsize.

### DIFF
--- a/HelpSource/Classes/GVerb.schelp
+++ b/HelpSource/Classes/GVerb.schelp
@@ -9,8 +9,7 @@ A two-channel reverb link::Classes/UGen::, based on the "GVerb" LADSPA effect by
 subsection:: Known issues
 list::
 ## There is a large CPU spike when the synth is instantiated while all the delay lines are zeroed out.
-## Quick changes in roomsize result in zipper noise.
-## emphasis::Changing the roomsize does not work properly! Still trying to look for the bug... (-josh)::
+## Changes in roomsize result in pitch shifting and noise.
 ::
 
 classmethods::

--- a/include/common/SC_Types.h
+++ b/include/common/SC_Types.h
@@ -59,6 +59,7 @@ typedef union {
 const unsigned int kSCNameLen = 8;
 const unsigned int kSCNameByteLen = 8 * sizeof(int32);
 
+// Do not use this. C casting is bad and causes many subtle issues.
 #ifdef __GXX_EXPERIMENTAL_CXX0X__
 #    define sc_typeof_cast(x) (decltype(x))
 #elif defined(__GNUC__)

--- a/include/plugin_interface/SC_Unit.h
+++ b/include/plugin_interface/SC_Unit.h
@@ -21,6 +21,7 @@
 
 #pragma once
 
+#include <type_traits>
 #include "SC_Types.h"
 #include "SC_SndBuf.h"
 
@@ -91,8 +92,13 @@ enum { kUnitDef_CantAliasInputsToOutputs = 1 };
         ClearUnitOnMemFailed                                                                                           \
     }
 
+template <typename ToType, typename Value>
+[[nodiscard]] inline constexpr auto copyAndCastToTypeOfFirstArg(const ToType&, const Value& value) noexcept {
+    using TargetT = std::remove_cv_t<std::remove_reference_t<ToType>>;
+    return static_cast<TargetT>(value);
+}
 // calculate a slope for control rate interpolation to audio rate.
-#define CALCSLOPE(next, prev) ((next - prev) * sc_typeof_cast(next) unit->mRate->mSlopeFactor)
+#define CALCSLOPE(next, prev) ((next - prev) * copyAndCastToTypeOfFirstArg(next, unit->mRate->mSlopeFactor))
 
 // get useful values
 #define SAMPLERATE (unit->mRate->mSampleRate)


### PR DESCRIPTION
## Purpose and Motivation
This decltype...
```c++
float a[12];
decltype( a[0] );
```` 
...returns a referenced type, e.g. `float&`, ***not*** `float`.
The macro `sc_typeof_cast` and `CALCSCOPE` used this to perform a c cast.
When converting from a double to a float, this is fine. 
When converting from an double to a float&, this is ***very bad***, and was the main issue with GVerb's roomsize. 


This PR creates a new conversion function using static_cast that does the correct behaviour and will break at compile time if the user attempts to pass something unexpected.

Following the alias violations (#6245) I retested GVerb, and this stopped it from blowing up. The second commit here just adds just more static_casts and uses `std::pow` converting everything to doubles, which further improved it.


Fixes #2302.
Partially fixes #6245, and an outstanding issues from 2007 in GVerb's roomsize — @joshpar.

Is it possible to remove `sc_typeof_cast`? It is in a header that other plugins use. Is there any way to stop people from using it if it can't be removed?

## Types of changes

<!-- Delete lines that don't apply -->

- Documentation
- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review
