### PR TITLE
SCDoc improvements: 3. Some HTML tags are enabled.

### DIFF
--- a/HelpSource/Reference/HTML-tags.schelp
+++ b/HelpSource/Reference/HTML-tags.schelp
@@ -1,0 +1,668 @@
+TITLE::HTML tags in SCDocs
+summary::How to use HTML tags in SCDocs
+categories:: HelpSystem
+related:: Guides/WritingHelp, Classes/SCDoc, Classes/SCDocHTMLRenderer
+
+
+
+
+
+
+
+
+
+
+section:: Formatting Text
+
+
+
+
+
+subsection:: Paragraph spacing
+
+
+The following code prints a blank line:
+
+table::
+##
+code::
+Line 1 begins.
+It is still Line 1.
+
+Line 2
+
+<br>Line 4 due to '<br>'
+
+<br> Line 6 due to '<br>'
+
+<br>
+Line 8
+::
+
+||
+Line 1 begins.
+It is still Line 1.
+
+Line 2
+
+<br>Line 4 due to '<br>'
+
+<br> Line 6 due to '<br>'
+
+<br>
+Line 8
+::
+
+<br>
+
+The height of a line can be adjusted with the units like teletype::em::, teletype::rem:: and teletype::%:::
+
+table::
+##code::
+Line 1
+<p style='line-height:33%'><br>
+Line 4
+<p style='line-height:0.33em'><br>
+Line 6
+<p style='line-height:0.33rem'><br>
+Line 8
+<p style='line-height:0.66%'><br>
+Line 10
+<p style='line-height:0.66em'><br>
+Line 12
+<p style='line-height:0.66rem'><br>
+::
+||
+Line 1: default line-height
+
+Line 2: 'line-height:33%'
+<p style='line-height:33%'><br>
+Line 4: 'line-height:0.33em
+<p style='line-height:0.33em'><br>
+Line 6: 'line-height:0.33em'
+<p style='line-height:0.33rem'><br>
+Line 8: 'line-height:66%'
+<p style='line-height:66%'><br>
+Line 10: 'line-height:0.66em'
+<p style='line-height:0.66em'><br>
+Line 12: 'line-height:0.66rem'
+<p style='line-height:0.66rem'><br>
+::
+
+<br>
+
+table::
+##strong::An Example:::
+table::
+##The standard Lorem Ipsum passage, used since the 1500s:
+
+emphasis::Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.::
+
+<p style='line-height:0.3em'><br><p>
+
+Section 1.10.32 of “de Finibus Bonorum et Malorum”, written by Cicero in 45 BC:
+
+"emphasis::Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt. Neque porro quisquam est, qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit, sed quia non numquam eius modi tempora incidunt ut labore et dolore magnam aliquam quaerat voluptatem. Ut enim ad minima veniam, quis nostrum exercitationem ullam corporis suscipit laboriosam, nisi ut aliquid ex ea commodi consequatur? Quis autem vel eum iure reprehenderit qui in ea voluptate velit esse quam nihil molestiae consequatur, vel illum qui dolorem eum fugiat quo voluptas nulla pariatur?::"
+::
+::
+
+<br>
+
+
+
+
+
+subsection:: Table
+
+
+All table tags are supported as follow:
+
+code::
+  <table border='1px solid black' style='text-align:center'>
+    <caption>Order Details</caption>
+    <thead>
+      <tr>
+        <th scope='col' style='text-align:center'>Order ID</th>
+        <th scope='col'>Customer</th>
+        <th scope='col'>Items</th>
+		<th scope='col' colspan='2'>Shipping</th>
+      </tr>
+    </thead>
+
+    <tbody>
+      <tr>
+        <th scope='row' rowspan='2'>12345</th>
+        <td rowspan='2'>John Doe</td>
+        <td>Headphones</td>
+        <td rowspan='2'>Address</td>
+        <td>Standard</td>
+      </tr>
+      <tr>
+        <td>Speakers</td>
+        <td>Express</td>
+      </tr>
+      <tr>
+        <th scope='row'>67890</th>
+        <td>Jane Smith</td>
+        <td>Software Bundle</td>
+        <td colspan='2'>Downloadable</td>
+      </tr>
+    </tbody>
+  </table>
+::
+
+<br>
+
+table::
+##
+  <table border='1px solid black' style='text-align:center'>
+    <caption>Order Details</caption>
+    <thead>
+      <tr>
+        <th scope='col' style='text-align:center'>Order ID</th>
+        <th scope='col'>Customer</th>
+        <th scope='col'>Items</th>
+		<th scope='col' colspan='2'>Shipping</th>
+      </tr>
+    </thead>
+
+    <tbody>
+      <tr>
+        <th scope='row' rowspan='2'>12345</th>
+        <td rowspan='2'>John Doe</td>
+        <td>Headphones</td>
+        <td rowspan='2'>Address</td>
+        <td>Standard</td>
+      </tr>
+      <tr>
+        <td>Speakers</td>
+        <td>Express</td>
+      </tr>
+      <tr>
+        <th scope='row'>67890</th>
+        <td>Jane Smith</td>
+        <td>Software Bundle</td>
+        <td colspan='2'>Downloadable</td>
+      </tr>
+    </tbody>
+  </table>
+::
+
+
+
+
+subsection:: Horizontal Line
+
+
+The following code prints a horizontal line:
+
+code::
+<hr>
+::
+table::
+##<hr>
+::
+
+A horizontal line in teletype:
+
+table::
+##
+teletype::
+text
+<hr>text
+::
+::
+
+
+
+
+
+subsection:: Small Text
+
+
+The following code displays small text:
+code::
+<small>This is small text.</small>
+::
+
+table::
+##<small>This is small text.</small>
+::
+
+Normal and small text in teletype:
+
+table::
+##
+teletype::
+This is normal text.
+<small>This is small text.</small>
+::
+::
+
+
+
+
+
+subsection:: Strong and Emphasis
+
+
+list::
+##The following code displays bold text:
+code::
+strong::This is bold text.::
+::
+
+table::
+##strong::This is bold text.::
+::
+
+To use bold text in teletype, you can use a pair of the following tags:
+code::
+<strong></strong>
+::
+
+table::
+##
+teletype::
+<strong>This is bold text.</strong>
+::
+::
+
+##The following code
+code::
+emphasis::This is italic text.::
+::
+and the following code display italic text:
+code::
+<em>This is italic text.<em>
+::
+table::
+##
+<em>This is italic text.<em>
+::
+
+To use bold text in teletype, you can use a pair of the following tags:
+
+code::
+<em></em>
+::
+
+table::
+##
+teletype::
+<em>This is italic text.</em>
+::
+::
+
+##Bold italic text is not available with the built-in hardcoded link::Reference/SCDocSyntax::.
+The following code displays bold italic text:
+
+code::
+<em>strong::This is bold italic text.::</em>
+::
+
+table::
+##
+<em>strong::This is bold italic text.::</em>
+::
+
+To use bold text in teletype, you can use one of a pair of the following tags:
+
+code::
+<em><strong></strong></em>
+::
+table::
+##teletype::
+<em><strong>This is bold italic text.</strong></em>
+::
+::
+
+or
+
+code::
+<strong><em></em></strong>
+::
+
+table::
+##teletype::
+<strong><em>This is bold italic text.</em></strong>
+::
+::
+::
+
+<br>
+
+Small text can also be italic, bold and bold italic.
+table::
+##code||text||teletype
+##code::
+<small>small normal text</small>
+::
+||
+<small>small normal text</small>
+||
+teletype::
+<small>small normal text</small>
+::
+##
+code::
+<small><strong>small bold text</strong></small>
+::
+||
+<small><strong>small bold text</strong></small>
+||
+teletype::
+<small><strong>small bold text</strong></small>
+::
+##
+code::
+<small><em>small italic text</em></small>
+::
+||
+<small><em>small italic text</em></small>
+||
+teletype::
+<small><em>small italic text</em></small>
+::
+##
+code::
+<small><em><strong>small bold italic text</strong></em></small>
+::
+||
+<small><em><strong>small bold italic text</strong></em></small>
+||
+teletype::
+<small><em><strong>small bold italic text</strong></em></small>
+::
+::
+<br>
+<br>
+<br>
+
+
+
+
+
+subsection:: Superscript and Subscript
+
+
+For superscripts, see link::#Exponentiation: base and exponent in text body#Exponentiation: base and exponent in text body::.
+For subscripts, see link::#Logarithm: base and operand in text body#Logarithm: base and operand in text body::.
+<br>
+<br>
+<br>
+<br>
+
+
+
+
+
+
+
+
+section:: Mathematical Expressions
+
+
+subsection:: Exponentiation: base and exponent in text body
+
+
+The following code displays an exponential expression with base and exponent:
+
+code::
+2<sup>2</sup> = 4
+::
+2<sup>2</sup> = 4
+
+In teletype:
+
+teletype::
+2<sup>2</sup> = 4
+::
+
+
+list::
+##linear scale:
+teletype::
+1  2  3  4  5  6  7  8  9  10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32
+|  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |
+1  2     4           8                       16                                              32
+::
+##Logarithmic scale (expressed using exponentiation. See increasing exponents)
+teletype::
+1<sup> </sup>                 2<sup> </sup>                 4<sup> </sup>                 8<sup> </sup>                 16<sup> </sup>                32
+2<sup>0</sup>                 2<sup>1</sup>                 2<sup>2</sup>                 2<sup>3</sup>                 2<sup>4</sup>                 2<sup>5</sup>
+::
+::
+
+
+
+
+
+subsection:: Logarithm: base and operand in text body
+
+
+The following code displays a logarithmic expression with base and operand:
+
+code::
+log<sub>2</sub>2 = 1
+<em>log<sub>2</sub></em> 2 = 1
+::
+
+log<sub>2</sub>2 = 1
+
+<em>log<sub>2</sub></em>2 = 1
+
+In teletype:
+
+teletype::
+log<sub>2</sub>2 = 1
+<em>log<sub>2</sub></em>2 = 1
+::
+
+<br>
+table::
+##strong::Examples:::
+Amplitude and dB FS:
+table::
+##20 <em>log</em><sub>10</sub> (1 / 1) = 0 dB
+||
+code::
+20 * log10(1/1)
+::
+
+##20 <em>log</em><sub>10</sub> (0.1 / 1) = -20 dB
+||
+code::
+20 * log10(1e-1/1)
+::
+
+##20 <em>log</em><sub>10</sub> (0.01 / 1) = -40 dB
+||
+code::
+20 * log10(1e-2/1)
+::
+
+##20 <em>log</em><sub>10</sub> (0.001 / 1) = -60 dB
+||
+code::
+20 * log10(1e-3/1)
+::
+
+##20 <em>log</em><sub>10</sub> (0.0001 / 1) = -80 dB
+||
+code::
+20 * log10(1e-4/1)
+::
+
+##20 <em>log</em><sub>10</sub> (0.00001 / 1) = -100 dB
+||
+code::
+20 * log10(1e-5/1)
+::
+::
+::
+
+
+
+
+
+subsection:: Fraction in text body
+
+
+Fraction in text body can be presented as follows:
+
+code::
+1<sup>1</sup>/<sub>2</sub>
+::
+
+1<sup>1</sup>/<sub>2</sub>
+
+
+In paragraphs, you can use fractions such as 1<sup>1</sup>/<sub>2</sub> HTML’s superscript and subscript. It can also be used in teletype text. teletype::<sup>1</sup>/<sub>4</sub> : <sup>1</sup>/<sub>2</sub> : 1 : 2 : 4::.
+
+
+
+
+
+
+
+
+
+
+section:: Embedding other HTML with iframe
+
+
+The following code embeds a web page in an html document:
+
+code::
+<iframe width='100%' height='380' src='https://supercollider.github.io/' title='SuperCollider Forum scsynth' frameborder='0' allow='accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share' referrerpolicy='strict-origin-when-cross-origin' allowfullscreen></iframe>
+::
+<iframe width='100%' height='380' src='https://supercollider.github.io/' title='SuperCollider Forum scsynth' frameborder='0' allow='accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share' referrerpolicy='strict-origin-when-cross-origin' allowfullscreen></iframe>
+
+
+
+
+
+section:: Multimedia
+
+
+subsection:: Audio
+
+
+strong::Offline Audio::
+
+
+The following code demonstrates audio control using one or more local audio files:
+
+code::
+<audio controls>
+<source src='./resources/a11wlk01.mp3' type='audio/mpeg'>
+<source src='./resources/a11wlk01.ogg' type='audio/ogg'>
+<source src='./resources/a11wlk01.wav' type='audio/wav'>
+<source src='./resources/a11wlk01.aiff' type='audio/aiff'>
+<source src='./resources/a11wlk01.flac' type='audio/flac'>
+<source src='./resources/a11wlk01.m4a' type='audio/mp4'>
+<source src='./resources/a11wlk01.wma' type='audio/x-ms-wma'>
+Your browser does not support the audio element.
+</audio>
+::
+
+<audio controls>
+<source src='./resources/a11wlk01.mp3' type='audio/mpeg'>
+<source src='./resources/a11wlk01.ogg' type='audio/ogg'>
+<source src='./resources/a11wlk01.wav' type='audio/wav'>
+<source src='./resources/a11wlk01.aiff' type='audio/aiff'>
+<source src='./resources/a11wlk01.flac' type='audio/flac'>
+<source src='./resources/a11wlk01.m4a' type='audio/mp4'>
+<source src='./resources/a11wlk01.wma' type='audio/x-ms-wma'>
+Your browser does not support the audio element.
+</audio>
+
+
+
+
+
+strong::Online Audio::
+
+
+The following code demonstrates audio control with an online audio file:
+
+code::
+<audio controls>
+<source src='https://www.w3schools.com/html/horse.ogg' type='audio/ogg'>
+Your browser does not support the audio element.
+</audio>
+::
+
+<audio controls>
+<source src='https://www.w3schools.com/html/horse.ogg' type='audio/ogg'>
+Your browser does not support the audio element.
+</audio>
+
+
+
+
+
+
+
+
+
+
+subsection:: Video
+
+
+Videos can be embedded, but when printed, their contents won't show up in the video frame.
+
+<br>
+
+strong::Offline Video::
+
+The following code demonstrates video control using a local video file:
+
+table::
+##size <br><br> defined
+||
+
+code::
+<video controls width='114' height='77'>
+<source src='./resources/wave_propagation_simulation_2D.mp4' title='2D simulation of the propagation of a wave in air' type='video/mp4'>
+</video>
+::
+table::
+##
+<video controls width='114' height='77'>
+<source src='./resources/wave_propagation_simulation_2D.mp4' title='2D simulation of the propagation of a wave in air' type='video/mp4'>
+</video>
+::
+##size <br><br> not <br><br> defined
+||
+code::
+<video controls>
+<source src='./resources/wave_propagation_simulation_2D.mp4' title='2D simulation of the propagation of a wave in air' type='video/mp4'>
+</video>
+::
+table::
+##
+<video controls>
+<source src='./resources/wave_propagation_simulation_2D.mp4' title='2D simulation of the propagation of a wave in air' type='video/mp4'>
+</video>
+::
+::
+
+<br>
+
+
+
+
+
+strong::Online Video::
+
+
+The following code displays a YouTube video using an iframe:
+code::
+<iframe width='560' height='315' src='https://www.youtube.com/embed/FI5rYjP9Vn8?si=X4WSZJaBZQToE9je' title='YouTube video player' frameborder='0' allow='accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share' referrerpolicy='strict-origin-when-cross-origin' allowfullscreen></iframe>
+::
+<p style='line-height:0.2em'><br><p>
+<iframe width='560' height='315' src='https://www.youtube.com/embed/FI5rYjP9Vn8?si=X4WSZJaBZQToE9je' title='YouTube video player' frameborder='0' allow='accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share' referrerpolicy='strict-origin-when-cross-origin' allowfullscreen></iframe>
+
+ 

--- a/SCClassLibrary/SCDoc/SCDocRenderer.sc
+++ b/SCClassLibrary/SCDoc/SCDocRenderer.sc
@@ -50,6 +50,121 @@ SCDocHTMLRenderer {
 	*escapeSpacesInAnchor { |str|
 		^str.replace(" ", "%20")
 	}
+	*replaceRegexp { |source, findRegexp, replace|
+			var founds, replaced;
+			founds = source.findRegexp(findRegexp);
+			founds = if(findRegexp[0] == $^) {
+				founds.collect { |array| if (array[0] == 0) {array} {} }
+			} {
+				founds
+			};
+			while { founds.includes(nil) } { founds.remove(nil) };
+			founds = founds.asSet.asArray.sort({ |a, b| a[0] < b[0] });
+			replaced = source;
+			if(founds.size > 0) {
+				founds.reverse.do { |idx_str|
+					var foundIndex, foundString;
+					#foundIndex, foundString = idx_str;
+					replaced = if (foundIndex > 0) {
+						var lastString = replaced[foundIndex + foundString.size ..];
+						lastString = if(lastString != nil) { lastString } { "" };
+						replaced[0 .. foundIndex - 1] ++ replace ++ lastString
+					} {
+						replace ++ replaced[foundString.size ..]
+					}
+				}
+			} {
+				replaced
+			};
+			^replaced
+		}
+	*parseHTML{ |str|
+		var replaced;
+		if ("&lt;|&gt;".matchRegexp(str)) {
+			replaced = str
+
+			// paragraph, line height:
+			.replace("&lt;p&gt;", "\n<p>\n")
+			.replace("&lt;p style='line-height:", "<p style='line-height:")
+			.replace("&lt;/p&gt;", "\n</p>\n")
+
+			// horizontal line:
+			.replace("&lt;hr&gt;", "<hr>")
+
+			// small text:
+			.replace("&lt;small&gt;", "<small>")
+			.replace("&lt;/small&gt;", "</small>")
+
+			// italic:
+			.replace("&lt;em&gt;", "<em>")
+			.replace("&lt;/em&gt;", "</em>")
+			.replace("em'&gt;", "em'>")
+
+			// bold:
+			.replace("&lt;strong&gt;", "<strong>")
+			.replace("&lt;/strong&gt;", "</strong>")
+
+			// subscript and superscript:
+			.replace("&lt;sub&gt;", "<sub>")
+			.replace("&lt;/sub&gt;", "</sub>")
+			.replace("&lt;sup&gt;", "<sup>")
+			.replace("&lt;/sup&gt;", "</sup>")
+
+			// iframe::
+			.replace("&lt;iframe", "<iframe")
+			.replace("&lt;/iframe&gt;", "</iframe>")
+			.replace("'&gt; <source src='", "'> <source src='")
+			.replace("allowfullscreen&gt;", "allowfullscreen>")
+
+			// audio:
+			.replace("&lt;audio controls autoplay&gt;", "<audio controls autoplay>")
+			.replace("&lt;audio controls&gt;", "<audio controls>")
+			.replace("&lt;source src=", "<source src=")/*
+			.replace("/wav'&gt;", "/wav'>")
+			.replace("/aiff'&gt;", "/aiff'>")
+			.replace("/flac'&gt;", "/flac'>")
+			.replace("/ogg'&gt;", "/ogg'>")
+			.replace("/mpeg'&gt;", "/mpeg'>")
+			.replace("/mp4'&gt;", "/mp4'>")
+			.replace("/x-ms-wma'&gt;", "/x-ms-wma'>")*/
+			.replace("&lt;/audio&gt;", "</audio>")
+
+			// video:
+			.replace("&lt;video controls autoplay&gt;", "<video controls autoplay>")
+			.replace("&lt;video controls&gt;", "<video controls>")
+			.replace("&lt;video controls width=", "<video controls width=")
+			.replace("&lt;/video&gt;", "</video>")
+
+			// table:
+			.replace("&lt;table&gt;", "\n<table>")
+			.replace("&lt;table ", "\n<table ")
+			.replace("&lt;/table&gt;", "\n</table>")
+			.replace("&lt;caption&gt;", "\n<caption>")
+			.replace("&lt;/caption&gt;", "\n</caption>")
+			.replace("&lt;thead&gt;", "\n<thead>")
+			.replace("&lt;/thead&gt;", "\n</thead>")
+			.replace("&lt;tr&gt;", "\n<tr>")
+			.replace("&lt;/tr&gt;", "\n</tr>")
+			.replace("&lt;th scope='col'&gt;", "\n<th scope='col'>")
+			.replace("&lt;th scope='row'&gt;", "\n<th scope='row'>")
+			.replace("&lt;th ", "\n<th ")
+			.replace("&lt;/th&gt;", "\n</th>")
+			.replace("&lt;tbody&gt;", "\n<tbody>")
+			.replace("&lt;/tbody&gt;", "</tbody>")
+			.replace("&lt;/tbody&gt;", "</tbody>")
+			.replace("&lt;td&gt;", "\n<td>")
+			.replace("&lt;td", "\n<td")
+			.replace("&lt;/td&gt;", "\n</td>");
+
+			// empty line
+			replaced = SCDocHTMLRenderer.replaceRegexp(replaced, "(?<!'|')&lt;br&gt;(?!'|')", "\n<br>\n");
+			// '&gt; to > (only > converted using this method)'&gt;
+			replaced = SCDocHTMLRenderer.replaceRegexp(replaced, "(?<!n)'&gt;(?!'|\",|=|&|\n\s+<(?!\n)|NOTE:&lt;|WARNING:&lt;|Description&lt;|\n<source|\n<caption|\n</v|\n</a|\nYour)", "'>");
+		} {
+			replaced = str
+		};
+		^replaced
+	}
 
 	// Find the target (what goes after href=) for a link that stays inside the hlp system
 	*prLinkTargetForInternalLink { |linkBase, linkAnchor, originalLink|
@@ -158,16 +273,15 @@ SCDocHTMLRenderer {
 			linkText = if(linkText.isEmpty) { link } { linkText };
 			linkTarget = this.prLinkTargetForExternalLink(linkBase, linkAnchor);
 		} {
-		    // Process a link that goes to a URL within the help system
+			// Process a link that goes to a URL within the help system
 			linkText = this.prLinkTextForInternalLink(linkBase, linkAnchor, linkText);
 			linkTarget = this.prLinkTargetForInternalLink(linkBase, linkAnchor, link);
 		};
 
 		// Escape special characters in the link text if requested
 		if(escape) { linkText = this.escapeSpecialChars(linkText) };
-
 		// Return a well-formatted <a> tag using the target and link text
-		^"<a href=\"" ++ linkTarget ++ "\">" ++ linkText ++ "</a>";
+		^("<a href='" ++ linkTarget ++ "'>" ++ linkText ++ "</a>");
 	}
 
 	*makeArgString {|m, par=true|
@@ -217,8 +331,8 @@ SCDocHTMLRenderer {
 
 		stream
 		<< "<!doctype html>"
-		<< "<html lang='en'>"
-		<< "<head><title>";
+		<< "\n<html lang='en'>"
+		<< "\n<head>\n<title>";
 
 		if(thisIsTheMainHelpFile) {
 			stream << "SuperCollider " << Main.version << " Help";
@@ -250,7 +364,7 @@ SCDocHTMLRenderer {
 		<< "<script src='" << baseDir << "/frontend.js' type='text/javascript'></script>\n"
 		// QWebChannel access
 		<< "<script src='qrc:///qtwebchannel/qwebchannel.js' type='text/javascript'></script>\n"
-		<< "</head>\n"
+		<< "</head>\n\n"
 		<< "<body onload='fixTOC()'>\n";
 
 
@@ -262,13 +376,13 @@ SCDocHTMLRenderer {
 
 		stream
 		<< "<div id='toc'>\n"
-		<< "<div id='toctitle'>" << displayedTitle << ":</div>\n"
+		<< "<div id='toctitle'>" << displayedTitle << ":</div>"
 		<< "<span class='toc_search'>Filter: <input id='toc_search'></span>";
 		this.renderTOC(stream, body);
-		stream << "</div>";
+		stream << "\n</div>\n";
 
 		stream
-		<< "<div id='menubar'></div>\n"
+		<< "<div id='menubar'></div>"
 		<< "<div class='contents'>\n"
 		<< "<div class='header'>\n";
 
@@ -287,7 +401,7 @@ SCDocHTMLRenderer {
 					stream << " | "
 				};
 
-				stream << "<span id='categories'>"
+				stream << "\n<span id='categories'>"
 
 				<< (doc.categories.collect { | path |
 					// get all the components of a category path ("UGens>Generators>Deterministic")
@@ -305,10 +419,10 @@ SCDocHTMLRenderer {
 				<< "</span>\n";
 			};
 
-			stream << "</div>";
+			stream << "\n</div>";
 		};
 
-		stream << "<h1>" << displayedTitle;
+		stream << "\n<h1>" << displayedTitle;
 		if(thisIsTheMainHelpFile) {
 			stream << "<span class='headerimage'><img src='" << baseDir << "/images/SC_icon.png'/></span>";
 		};
@@ -325,12 +439,12 @@ SCDocHTMLRenderer {
 			<< "<div class='extension-indicator-ctr' title='This help file originates from a third-party quark or plugin for SuperCollider.'>"
 			<< "<img class='extension-indicator-icon' alt='Extension' src='" << baseDir << "/images/plugin.png'>"
 			<< "<span class='extension-indicator-text'>Extension</span>"
-			<< "</div>";
+			<< "\n</div>\n";
 		};
 		stream
 		<< "</h1>\n"
 		<< "<div id='summary'>" << this.escapeSpecialChars(doc.summary) << "</div>\n"
-		<< "</div>\n"
+		<< "\n</div>\n"
 		<< "<div class='subheader'>\n";
 
 		if(doc.isClassDoc) {
@@ -350,7 +464,7 @@ SCDocHTMLRenderer {
 					if(z) {
 						stream << "</span><a class='subclass_toggle' href='#' onclick='javascript:showAllSubclasses(this); return false'>&hellip;&nbsp;see&nbsp;all</a>";
 					};
-					stream << "</div>\n";
+					stream << "\n</div>\n";
 				};
 				if(currentImplClass.notNil) {
 					stream << "<div class='inheritance'>Implementing class: "
@@ -378,7 +492,7 @@ SCDocHTMLRenderer {
 			};
 		};
 
-		stream << "</div>\n";
+		stream << "\n</div>\n";
 	}
 
 	*renderChildren {|stream, node|
@@ -534,7 +648,7 @@ SCDocHTMLRenderer {
 		if(node.children.size > 1) {
 			stream << "<div class='method'>";
 			this.renderChildren(stream, node.children[1]);
-			stream << "</div>";
+			stream << "</div>\n";
 		};
 		currentMethod = nil;
 	}
@@ -546,42 +660,56 @@ SCDocHTMLRenderer {
 				if(noParBreak) {
 					noParBreak = false;
 				} {
-					stream << "\n<p>";
+					stream << "\n<p>\n";
 				};
 				this.renderChildren(stream, node);
 			},
 			\NL, { }, // these shouldn't be here..
 // Plain text and modal tags
 			\TEXT, {
-				stream << this.escapeSpecialChars(node.text);
+				stream << SCDocHTMLRenderer.parseHTML(this.escapeSpecialChars(node.text));
 			},
 			\LINK, {
-				stream << this.htmlForLink(node.text);
+				stream
+				<< this.htmlForLink(node.text)
+				.replace("<a href='http", "http")
+				.replace("''>http", "'>http")
+				.replace("'</a>", "</a>");
 			},
 			\CODEBLOCK, {
-				stream << "<textarea class='editor'>"
+				stream << "\n<textarea class='editor'>"
 				<< this.escapeSpecialChars(node.text)
 				<< "</textarea>\n";
 			},
 			\CODE, {
-				stream << "<code>"
+				stream << "\n<code>"
 				<< this.escapeSpecialChars(node.text)
-				<< "</code>";
+				<< "</code>\n";
 			},
 			\EMPHASIS, {
-				stream << "<em>" << this.escapeSpecialChars(node.text) << "</em>";
+				stream << "<em>"
+				<< SCDocHTMLRenderer.parseHTML(this.escapeSpecialChars(node.text))
+				<< "</em>";
 			},
 			\TELETYPEBLOCK, {
-				stream << "<pre>" << this.escapeSpecialChars(node.text) << "</pre>";
+				stream << "\n<pre>"
+				<< SCDocHTMLRenderer.parseHTML(this.escapeSpecialChars(node.text))
+				<< "</pre>\n";
 			},
 			\TELETYPE, {
-				stream << "<code>" << this.escapeSpecialChars(node.text) << "</code>";
+				stream << "\n<code>"
+				<< SCDocHTMLRenderer.parseHTML(this.escapeSpecialChars(node.text))
+				<< "</code>\n";
 			},
 			\STRONG, {
-				stream << "<strong>" << this.escapeSpecialChars(node.text) << "</strong>";
+				stream << "<strong>"
+				<< SCDocHTMLRenderer.parseHTML(this.escapeSpecialChars(node.text))
+				<< "</strong>";
 			},
 			\SOFT, {
-				stream << "<span class='soft'>" << this.escapeSpecialChars(node.text) << "</span>";
+				stream << "<span class='soft'>"
+				<< SCDocHTMLRenderer.parseHTML(this.escapeSpecialChars(node.text))
+				<< "</span>";
 			},
 			\ANCHOR, {
 				stream << "<a class='anchor' name='" << this.escapeSpacesInAnchor(node.text) << "'>&nbsp;</a>";
@@ -600,21 +728,23 @@ SCDocHTMLRenderer {
 				} {
 					stream << this.htmlForLink(f[2]++"#"++(f[3]?"")++"#"++img,false);
 				};
-				f[1] !? { stream << "<br><b>" << f[1] << "</b>" }; // ugly..
-				stream << "</div>\n";
+				f[1] !? { stream << "<br><b>"
+					<< SCDocHTMLRenderer.parseHTML(this.escapeSpecialChars(f[1]))
+					<< "</b>" }; // ugly..
+				stream << "\n</div>\n";
 			},
 // Other stuff
 			\NOTE, {
 				stream << "<div class='note'><span class='notelabel'>NOTE:</span> ";
 				noParBreak = true;
 				this.renderChildren(stream, node);
-				stream << "</div>";
+				stream << "\n</div>";
 			},
 			\WARNING, {
 				stream << "<div class='warning'><span class='warninglabel'>WARNING:</span> ";
 				noParBreak = true;
 				this.renderChildren(stream, node);
-				stream << "</div>";
+				stream << "\n</div>";
 			},
 			\FOOTNOTE, {
 				footNotes = footNotes.add(node);
@@ -627,28 +757,28 @@ SCDocHTMLRenderer {
 				<< "</sup></a> ";
 			},
 			\CLASSTREE, {
-				stream << "<ul class='tree'>";
+				stream << "\n<ul class='tree'>";
 				this.renderClassTree(stream, node.text.asSymbol.asClass);
-				stream << "</ul>";
+				stream << "</ul>\n";
 			},
 // Lists and tree
 			\LIST, {
-				stream << "<ul>\n";
+				stream << "\n<ul>\n";
 				this.renderChildren(stream, node);
 				stream << "</ul>\n";
 			},
 			\TREE, {
-				stream << "<ul class='tree'>\n";
+				stream << "\n<ul class='tree'>\n";
 				this.renderChildren(stream, node);
 				stream << "</ul>\n";
 			},
 			\NUMBEREDLIST, {
-				stream << "<ol>\n";
+				stream << "\n<ol>\n";
 				this.renderChildren(stream, node);
 				stream << "</ol>\n";
 			},
 			\ITEM, { // for LIST, TREE and NUMBEREDLIST
-				stream << "<li>";
+				stream << "\n<li>";
 				noParBreak = true;
 				this.renderChildren(stream, node);
 			},
@@ -673,16 +803,16 @@ SCDocHTMLRenderer {
 			},
 // Tables
 			\TABLE, {
-				stream << "<table>\n";
+				stream << "\n<table>";
 				this.renderChildren(stream, node);
 				stream << "</table>\n";
 			},
 			\TABROW, {
-				stream << "<tr>";
+				stream << "\n<tr>";
 				this.renderChildren(stream, node);
 			},
 			\TABCOL, {
-				stream << "<td>";
+				stream << "\n<td>";
 				noParBreak = true;
 				this.renderChildren(stream, node);
 			},
@@ -716,7 +846,7 @@ SCDocHTMLRenderer {
 			\CCOPYMETHOD, {},
 			\ICOPYMETHOD, {},
 			\ARGUMENTS, {
-				stream << "<h4>Arguments:</h4>\n<table class='arguments'>\n";
+				stream << "\n<h4>Arguments:</h4>\n<table class='arguments'>\n";
 				currArg = 0;
 				if(currentMethod.notNil and: {node.children.size < (currentNArgs-1)}) {
 					"SCDoc: In %\n"
@@ -783,7 +913,7 @@ SCDocHTMLRenderer {
 			\RETURNS, {
 				stream << "<h4>Returns:</h4>\n<div class='returnvalue'>";
 				this.renderChildren(stream, node);
-				stream << "</div>";
+				stream << "\n</div>\n";
 
 			},
 			\DISCUSSION, {
@@ -793,44 +923,44 @@ SCDocHTMLRenderer {
 // Sections
 			\CLASSMETHODS, {
 				if(node.notPrivOnly) {
-					stream << "<h2><a class='anchor' name='classmethods'>Class Methods</a></h2>\n";
+					stream << "\n<h2><a class='anchor' name='classmethods'>Class Methods</a></h2>\n";
 				};
 				this.renderChildren(stream, node);
 			},
 			\INSTANCEMETHODS, {
 				if(node.notPrivOnly) {
-					stream << "<h2><a class='anchor' name='instancemethods'>Instance Methods</a></h2>\n";
+					stream << "\n<h2><a class='anchor' name='instancemethods'>Instance Methods</a></h2>\n";
 				};
 				this.renderChildren(stream, node);
 			},
 			\DESCRIPTION, {
-				stream << "<h2><a class='anchor' name='description'>Description</a></h2>\n";
+				stream << "\n<h2><a class='anchor' name='description'>Description</a></h2>\n";
 				this.renderChildren(stream, node);
 			},
 			\EXAMPLES, {
-				stream << "<h2><a class='anchor' name='examples'>Examples</a></h2>\n";
+				stream << "\n<h2><a class='anchor' name='examples'>Examples</a></h2>\n";
 				this.renderChildren(stream, node);
 			},
 			\SECTION, {
-				stream << "<h2><a class='anchor' name='" << this.escapeSpacesInAnchor(node.text)
+				stream << "\n<h2><a class='anchor' name='" << this.escapeSpacesInAnchor(node.text)
 				<< "'>" << this.escapeSpecialChars(node.text) << "</a></h2>\n";
 				if(node.makeDiv.isNil) {
 					this.renderChildren(stream, node);
 				} {
 					stream << "<div id='" << node.makeDiv << "'>";
 					this.renderChildren(stream, node);
-					stream << "</div>";
+					stream << "\n</div>\n";
 				};
 			},
 			\SUBSECTION, {
-				stream << "<h3><a class='anchor' name='" << this.escapeSpacesInAnchor(node.text)
+				stream << "\n<h3><a class='anchor' name='" << this.escapeSpacesInAnchor(node.text)
 				<< "'>" << this.escapeSpecialChars(node.text) << "</a></h3>\n";
 				if(node.makeDiv.isNil) {
 					this.renderChildren(stream, node);
 				} {
-					stream << "<div id='" << node.makeDiv << "'>";
+					stream << "\n<div id='" << node.makeDiv << "'>";
 					this.renderChildren(stream, node);
-					stream << "</div>";
+					stream << "</div>\n";
 				};
 			},
 			{
@@ -900,7 +1030,7 @@ SCDocHTMLRenderer {
 					}
 				);
 			};
-			stream << "</ul>";
+			stream << "</ul>\n";
 		};
 	}
 
@@ -950,9 +1080,9 @@ SCDocHTMLRenderer {
 				<< "[<a href='#footnote_org_" << (i+1) << "'>" << (i+1) << "</a>] - ";
 				noParBreak = true;
 				this.renderChildren(stream, n);
-				stream << "</div>";
+				stream << "\n</div>\n";
 			};
-			stream << "</div>";
+			stream << "\n</div>\n";
 		};
 	}
 
@@ -963,10 +1093,10 @@ SCDocHTMLRenderer {
 			<< doc.fullPath << "</a><br>"
 		};
 		stream << "link::" << doc.path << "::<br>"
-		<< "</div>"
-		<< "</div>"
+		<< "\n</div>\n"
+		<< "\n</div>\n"
 		<< "<script src='" << baseDir << "/editor.js' type='text/javascript'></script>\n"
-		<< "</body></html>";
+		<< "</body>\n</html>";
 	}
 
 	*renderOnStream {|stream, doc, root|


### PR DESCRIPTION
This pull request enables you to incorporate HTML tags in order to enhance the appearance of the rendered HTML in both the web browser and SC Help Browser. Additionally, "\n" has been added to certain tags to make the rendered HTML more readable when viewed in a text editor.

## Purpose and Motivation
While working on writing educational material using SCdoc, I encountered the need to use HTML tags in order to improve the readability of the printed SCDoc. I used these tags to add empty lines and control line height, and so on. 

Some opinions have already been expressed in PRs #6260 and #6263. I am aware that some believe I may be doing things incorrectly. However, I am doing this in order to complete the task of dividing PR #6254.

This is a revised PR that addresses the relevant part of PR #6254. I plan to keep this PR open for several weeks to gather more feedback on my work. 

## Types of changes

<!-- Delete lines that don't apply -->

- Documentation
- New feature

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review
