### PR TITLE
SClang: GUI: Add thumbSize option for Slider2D

### DIFF
--- a/HelpSource/Classes/Slider2D.schelp
+++ b/HelpSource/Classes/Slider2D.schelp
@@ -74,6 +74,11 @@ METHOD:: knobColor
 	argument::
 		A Color.
 
+METHOD:: thumbSize
+	The size of the handle.
+
+	argument::
+		An Integer amount of pixels.
 
 
 SUBSECTION:: Interaction

--- a/QtCollider/widgets/QcSlider2D.h
+++ b/QtCollider/widgets/QcSlider2D.h
@@ -36,6 +36,7 @@ class QcSlider2D : public QWidget, QcHelper, QcAbstractStepValue, QtCollider::St
     Q_PROPERTY(double ctrlScale READ dummyFloat WRITE setCtrlScale);
     Q_PROPERTY(double altScale READ dummyFloat WRITE setAltScale);
     Q_PROPERTY(double step READ dummyFloat WRITE setStep)
+    Q_PROPERTY(int thumbSize READ thumbSize WRITE setThumbSize);
     Q_PROPERTY(QColor grooveColor READ grooveColor WRITE setGrooveColor);
     Q_PROPERTY(QColor focusColor READ focusColor WRITE setFocusColor);
     Q_PROPERTY(QColor knobColor READ knobColor WRITE setKnobColor);
@@ -56,6 +57,14 @@ public:
     }
     QSize sizeHint() const { return QSize(150, 150); }
     QSize minimumSizeHint() const { return QSize(30, 30); }
+
+    int thumbSize() const { return _thumbSize.width(); }
+    void setThumbSize(int i) {
+        const auto clamped = std::clamp(i, 0, std::numeric_limits<int>::max());
+        _thumbSize = QSize(clamped, clamped);
+        updateGeometry();
+        update();
+    }
 
     Q_INVOKABLE
     void setBackgroundImage(const QtCollider::SharedImage& image, const QRectF& rect, int tileMode, double opacity);

--- a/SCClassLibrary/Common/GUI/Base/QSlider2D.sc
+++ b/SCClassLibrary/Common/GUI/Base/QSlider2D.sc
@@ -58,6 +58,9 @@ Slider2D : QAbstractStepValue {
 	incrementY { arg factor=1.0; this.invokeMethod( \incrementY, factor.asFloat ); }
 	decrementY { arg factor=1.0; this.invokeMethod( \decrementY, factor.asFloat ); }
 
+	thumbSize { ^this.getProperty(\thumbSize) }
+	thumbSize_ { |pixels| this.setProperty(\thumbSize, pixels) }
+
 	randomize {
 		this.setXYActive( 1.0.rand, 1.0.rand );
 	}


### PR DESCRIPTION
## Purpose and Motivation

Simply adds another q_property to QcSlider2D.h

Closes #724.

Some code to demonstrate this change.
```supercollider
Window().layout_(
	VLayout(
		~a = Slider2D().action_({
			~b.thumbSize = ~a.x.linlin(0, 1, 5, 50)
		}),
		~b = Slider2D().action_({
			~a.thumbSize = ~b.x.linlin(0, 1, 5, 50)
		})
	)
)
.front
```

## Types of changes

- Documentation
- New feature

## To-do list

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review
