### PR TITLE
Resolve the conflict between SC-cube and text in the SC help Home with a typo correction in scdoc.css

### DIFF
--- a/HelpSource/scdoc.css
+++ b/HelpSource/scdoc.css
@@ -131,7 +131,7 @@ a.subclass_toggle:hover {
     background-image: url("images/SC_icon.png");
     background-repeat: no-repeat;
     background-position: 0.5em center;
-    background-size: 1.5em;
+    background-size: 1.1em;
 }
 
 a.menu-link {
@@ -688,7 +688,7 @@ table#search_settings {
     color: #555;
     width: 100%;
     margin-left: 0px;
-    margin-right: 0px;*/
+    margin-right: 0px;
     margin: 0px;
     padding: 0px;
     border-collapse: collapse;

--- a/HelpSource/scdoc.js
+++ b/HelpSource/scdoc.js
@@ -159,8 +159,8 @@ function fixTOC() {
     create_menubar_item("", helpRoot + "/Help.html", function (a, li) {
         a.addClass("home");
         $('<span>', { 
-            text: "SuperCollider"
-        }).appendTo(a);
+            text: "    SuperCollider"
+        }).css('white-space', 'pre').appendTo(a);;
     });
 
     create_menubar_item("Browse", helpRoot + "/Browse.html");


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation
1. This PR fixes the problem reported in #6138.
   - The reported problem:
   ![Screenshot 2024-04-28 at 14 49 11](https://github.com/supercollider/supercollider/assets/416281/9f95edfc-c85b-43a7-ad4a-c71aa4b0dd6d)
   - Fixed with this PR:
   ![Screenshot 2024-04-28 at 14 50 37](https://github.com/supercollider/supercollider/assets/416281/32ea0e3f-e3f1-4e5e-b9af-c80e25196ae1)

I do not think my fix is the only way. I can remove it from this PR if @scztt fixes it, because I think this problem is definitely due to @scztt's fix as described in https://github.com/supercollider/supercollider/issues/6138#issuecomment-1930754168.

2. This PR also removes an unnecessary */ on line 691 in scdoc.css:
   https://github.com/supercollider/supercollider/blob/3b3eca75a1b42ad4a6c1146ad1893568d083d5c5/HelpSource/scdoc.css#L691
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes


<!-- Delete lines that don't apply -->

- Documentation
- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review
