### PR TITLE
Bug fixed: Clicking on a generic method name in the TOC now works!

### DIFF
--- a/SCClassLibrary/SCDoc/SCDocRenderer.sc
+++ b/SCClassLibrary/SCDoc/SCDocRenderer.sc
@@ -399,7 +399,7 @@ SCDocHTMLRenderer {
 			methodType,
 			\classMethod, { "*" },
 			\instanceMethod, { "-" },
-			\genericMethod, { "" }
+			\genericMethod, { "." }
 		);
 
 		minArgs = inf;


### PR DESCRIPTION
A demo video of the fix of this PR:
https://www.dropbox.com/scl/fi/0t7kl9x6f5npp1qcnintr/resolved-the-problem-of-Operators-help-document.mov?rlkey=8z3av3cfzacwmmgw377rm3atv&dl=0

<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation
This fix the problem described in the following post in scsynth forum:
https://scsynth.org/t/scdoc-links-to-named-anchors-seem-not-to-be-working/4380/8

A demo video of the problem:
https://www.dropbox.com/scl/fi/1j70bx7qf0fschsj1bln7/problem-of-Operators-help-document.mov?rlkey=vkdvuj4w33h6z1l80zort9gdo&dl=0

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [ ] Updated documentation
- [x] This PR is ready for review
