### PR TITLE
remove bogus argument keyword in Pfindur help file

### DIFF
--- a/HelpSource/Classes/Pfindur.schelp
+++ b/HelpSource/Classes/Pfindur.schelp
@@ -33,7 +33,7 @@ x = a.asStream;
 
 (
 var a, b;
-a = Pfindur(5, Pbind(\dur, Prand([1, 2, 0.5, 0.1], 4)), filling: (note: 1920));
+a = Pfindur(5, Pbind(\dur, Prand([1, 2, 0.5, 0.1], 4)));
 x = a.asStream;
 9.do({ x.next(Event.default).postln; });
 )


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation
Removed an invalid keyword from a code example in the Pfindur help file. This example included the keyword 'filling.' Evaluating this example returns a warning, and I have absolutely no idea why this keyword is included in the example.

I believe this example, in combination with the example immediately above it, are simply meant to show how Pfindur behaves when constraining an infinite-length pattern compared to a finite-length pattern.

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->

- Documentation

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review
