### PR TITLE
docs: fix note for perfectShuffle in ArrayedCollection help file

### DIFF
--- a/HelpSource/Classes/ArrayedCollection.schelp
+++ b/HelpSource/Classes/ArrayedCollection.schelp
@@ -420,7 +420,7 @@ code::
 ::
 
 method::perfectShuffle
-Returns a copy of the receiver with its items split into two equal halves, then reconstructed by interleaving the two halves. note::use an even number of item pairs in order to not loose any items in the shuffle.::
+Returns a copy of the receiver with its items split into two equal halves, then reconstructed by interleaving the two halves. note::the size of the collection should be even, otherwise the item directly in the middle of the collection will be lost in the shuffle.::
 code::
 (
 var y, z;


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation
Rephrased the Note accompanying perfectShuffle in the ArrayedCollection help file. The wording was inaccurate (the number of items should be even, rather than the number of item pairs) and there was also a spelling mistake.

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->

- Documentation

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review
