### PR TITLE
typo correction: change Ugen/Ugens in help documents to UGen/UGens

### DIFF
--- a/HelpSource/Classes/Function.schelp
+++ b/HelpSource/Classes/Function.schelp
@@ -516,7 +516,7 @@ method::plot
 note::See link::Reference/plot:: for a general reference on plotting::
 
 
-Calculates duration in seconds worth of the output of this function asynchronously, and plots it in a GUI window. Unlike play and scope it will not work with explicit Out Ugens, so your function should return a UGen or an Array of them. The plot will be calculated in realtime.
+Calculates duration in seconds worth of the output of this function asynchronously, and plots it in a GUI window. Unlike play and scope it will not work with explicit Out UGens, so your function should return a UGen or an Array of them. The plot will be calculated in realtime.
 
 code::
 { SinOsc.ar(440) }.plot(0.01, bounds: Window.screenBounds);

--- a/HelpSource/Classes/OSCpathResponder.schelp
+++ b/HelpSource/Classes/OSCpathResponder.schelp
@@ -23,7 +23,7 @@ subsection::Command paths
 
 OSC commands sometimes include additional parameters to specify the right responder.
 
-For example code::/tr:: commands, which are generated on the server by the link::Classes/SendTrig:: Ugen create an OSC packet consisting of: code:: [ /tr, nodeID, triggerID, value] ::.
+For example code::/tr:: commands, which are generated on the server by the link::Classes/SendTrig:: UGen create an OSC packet consisting of: code:: [ /tr, nodeID, triggerID, value] ::.
 This array actually specifies the source of value: code:: [ /tr, nodeID, triggerID] ::.
 We will refer to that array as a command path.
 

--- a/HelpSource/Classes/Synth.schelp
+++ b/HelpSource/Classes/Synth.schelp
@@ -385,7 +385,7 @@ y.free;
 r.free;
 
 // look at the Server window
-// still see 4 Ugens and 1 synth?
+// still see 4 UGens and 1 synth?
 // you can't hear me, but don't forget to free me
 t.free;
 ::

--- a/HelpSource/Guides/News-3_11.schelp
+++ b/HelpSource/Guides/News-3_11.schelp
@@ -60,7 +60,7 @@ Prevented coreaudio from resampling audio stream when using portaudio on macOS (
 
 Fixed an erroneous include  that stopped supernova from compiling in some cases (#4018)
 
-section:: Ugens: Fixed
+section:: UGens: Fixed
 
 Fixed an issue with the Done flags on EnvGen (#4789)
 

--- a/HelpSource/Guides/SuperColliderAU.schelp
+++ b/HelpSource/Guides/SuperColliderAU.schelp
@@ -38,7 +38,7 @@ list::
 ## MemorySize: amount of real time memory allocated to this server.
 ## NumWireBufs: maximum number of buffers for connecting ugens.
 ## DoNoteOn: (experimental) if true the server will send an OSC bundle setting the "note" and "velocity" parameters when a MIDI noteon or noteoff message is received. For this to work you need a host that supports Midi effect AudioUnits and sends them MIDI messages.
-## BeatDiv: For linking Demand Ugens to the Host tempo. If this number is set, SuperColliderAU will trigger bus 0 each beat division and use bus 1 for reset.
+## BeatDiv: For linking Demand UGens to the Host tempo. If this number is set, SuperColliderAU will trigger bus 0 each beat division and use bus 1 for reset.
 ::
 
 subsection::pluginSpec.plist

--- a/HelpSource/Guides/Tracing-Processes.schelp
+++ b/HelpSource/Guides/Tracing-Processes.schelp
@@ -125,7 +125,7 @@ code::
 { SinOsc.ar(SinOsc.kr(0.2, 0, 300, 400).poll(label: "freq")) * 0.1 }.play;
 ::
 
-For demand ugens, poll does not work - these ugens are called by a Demand or Duty Ugen at certain intervals. The message dpoll creates a Dpoll ugen that posts when they are called (see link::Classes/Dpoll:: helpfile)
+For demand ugens, poll does not work - these ugens are called by a Demand or Duty UGen at certain intervals. The message dpoll creates a Dpoll ugen that posts when they are called (see link::Classes/Dpoll:: helpfile)
 
 code::
 { SinOsc.ar(Duty.kr(0.5, 0, (Dseries(0, 1, inf) * 200 + 300).dpoll)) * 0.1 }.play;

--- a/HelpSource/Overviews/Operators.schelp
+++ b/HelpSource/Overviews/Operators.schelp
@@ -3,7 +3,7 @@ categories:: Language, Common methods
 summary:: common unary and binary operators
 related:: Reference/Adverbs
 
-SuperCollider supports operator overloading. Operators can thus be applied to a variety of different objects; Numbers, Ugens, Collections, and so on. When operators are applied to ugens they result in link::Classes/BinaryOpUGen::s or link::Classes/UnaryOpUGen::s, through the methods of link::Classes/AbstractFunction::.
+SuperCollider supports operator overloading. Operators can thus be applied to a variety of different objects; Numbers, UGens, Collections, and so on. When operators are applied to ugens they result in link::Classes/BinaryOpUGen::s or link::Classes/UnaryOpUGen::s, through the methods of link::Classes/AbstractFunction::.
 
 This is a list of some of the common unary and binary operators that are implemented by several classes.
 See the specific classes for details and other operators.

--- a/HelpSource/Tutorials/Mark_Polishook_tutorial/08_Rates.schelp
+++ b/HelpSource/Tutorials/Mark_Polishook_tutorial/08_Rates.schelp
@@ -5,7 +5,7 @@ related:: Tutorials/Mark_Polishook_tutorial/00_Introductory_tutorial
 
 section::Audio rate
 
-Ugens to which an .ar message is sent run at the audio rate, by default, at 44,100 samples per second. Send the .ar message to unit generators when they're part of the audio chain that will be heard.
+UGens to which an .ar message is sent run at the audio rate, by default, at 44,100 samples per second. Send the .ar message to unit generators when they're part of the audio chain that will be heard.
 
 code::
 SinOsc.ar(440, 0, 1);
@@ -13,7 +13,7 @@ SinOsc.ar(440, 0, 1);
 
 section::Control rate
 
-Ugens to which a .kr message is appended run at the control rate.
+UGens to which a .kr message is appended run at the control rate.
 
 code::
 SinOsc.kr(440, 0, 1);

--- a/HelpSource/Tutorials/Mark_Polishook_tutorial/Japanese_version/09.schelp
+++ b/HelpSource/Tutorials/Mark_Polishook_tutorial/Japanese_version/09.schelp
@@ -101,7 +101,7 @@ code::
 { WhiteNoise.ar(0.1) * SinOsc.kr(1, 1) }.scope;
 ::
 
-次の例は、2つのノイズを生成するUgenがサイン波でスケーリングされてBinaryOpUGenを生成し、それがまた別のBinaryOpUGenに加算されるというものです。
+次の例は、2つのノイズを生成するUGenがサイン波でスケーリングされてBinaryOpUGenを生成し、それがまた別のBinaryOpUGenに加算されるというものです。
 
 code::
 (


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation
I recently saw a PR where Ugen was considered a typo. I found all these things in the built-in schelp and changed it accordingly.

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->

- Documentation

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review
