### PR TITLE
ServerPlugins: PanAZ: fix bug when width is small and negative

### DIFF
--- a/HelpSource/Classes/PanAz.schelp
+++ b/HelpSource/Classes/PanAz.schelp
@@ -38,9 +38,11 @@ A control rate level input.
 
 argument::width
 
-The width of the panning envelope. Nominally this is code::2.0:: which pans between pairs of adjacent speakers.
+The width of the panning envelope.
+Nominally this is code::2.0:: which pans between pairs of adjacent speakers.
 Values greater than code::2:: will spread the pan over greater numbers of speakers.
 Values less than code::1:: will leave silent gaps between speakers.
+The absolute of this value is taken as negative values have no meaning (a width of code::-1:: is the same as a width of code::1::).
 
 
 argument::orientation

--- a/server/plugins/PanUGens.cpp
+++ b/server/plugins/PanUGens.cpp
@@ -1302,7 +1302,7 @@ void PanAz_Dtor(PanAz* unit) {
 void PanAz_next_ak(PanAz* unit, int inNumSamples) {
     float pos = ZIN0(1);
     float level = ZIN0(2);
-    float width = ZIN0(3);
+    float width = std::abs(ZIN0(3));
     float orientation = ZIN0(4);
 
     int numOutputs = unit->mNumOutputs;
@@ -1347,7 +1347,7 @@ void PanAz_next_ak(PanAz* unit, int inNumSamples) {
 FLATTEN void PanAz_next_ak_nova(PanAz* unit, int inNumSamples) {
     float pos = ZIN0(1);
     float level = ZIN0(2);
-    float width = ZIN0(3);
+    float width = std::abs(ZIN0(3));
     float orientation = ZIN0(4);
 
     int numOutputs = unit->mNumOutputs;
@@ -1389,7 +1389,7 @@ FLATTEN void PanAz_next_ak_nova(PanAz* unit, int inNumSamples) {
 
 void PanAz_next_aa(PanAz* unit, int inNumSamples) {
     float level = ZIN0(2);
-    float width = ZIN0(3);
+    float width = std::abs(ZIN0(3));
     float orientation = ZIN0(4);
 
     int numOutputs = unit->mNumOutputs;


### PR DESCRIPTION
## Purpose and Motivation

When width is negative in `PanAz` the server crashes #6012 
```supercollider
{PanAz.ar(2, DC.ar, 0, 1, -0.001)}.play
```

Since width is a magnitude, it makes no sense for it to be negative. Taking the abs is an easy fix for #6012

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->
Fixes #6012

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix
- Docs

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] This PR is ready for review
