### PR TITLE
SCLang: tidy duplicated error message

### DIFF
--- a/lang/LangSource/PyrParseNode.cpp
+++ b/lang/LangSource/PyrParseNode.cpp
@@ -3780,12 +3780,6 @@ void PyrBlockNode::compile(PyrSlot* slotResult) {
         compileErrors++;
     }
 
-    if (numArgs > 255) {
-        error("Too many arguments in function definition (> 255).\n");
-        nodePostErrorLine((PyrParseNode*)mArglist->mVarDefs);
-        compileErrors++;
-    }
-
     numSlots = numArgs + funcVarArgs + numVars;
     methraw->frameSize = (numSlots + FRAMESIZE) * sizeof(PyrSlot);
     if (numSlots) {


### PR DESCRIPTION

<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

This is uncontroversial and can be quickly reviewed.

Cannot have more than 255 arguments to a function, but the message was printed twice. This removes that duplication.
Some code to test, it should only show one error message after this PR.

```supercollider
{| foo , foo0, foo1, foo2, foo3, foo4, foo5, foo6, foo7, foo8, foo9, foo10, foo11, foo12, foo13, foo14, foo15, foo16, foo17, foo18, foo19, foo20, foo21, foo22, foo23, foo24, foo25, foo26, foo27, foo28, foo29, foo30, foo31, foo32, foo33, foo34, foo35, foo36, foo37, foo38, foo39, foo40, foo41, foo42, foo43, foo44, foo45, foo46, foo47, foo48, foo49, foo50, foo51, foo52, foo53, foo54, foo55, foo56, foo57, foo58, foo59, foo60, foo61, foo62, foo63, foo64, foo65, foo66, foo67, foo68, foo69, foo70, foo71, foo72, foo73, foo74, foo75, foo76, foo77, foo78, foo79, foo80, foo81, foo82, foo83, foo84, foo85, foo86, foo87, foo88, foo89, foo90, foo91, foo92, foo93, foo94, foo95, foo96, foo97, foo98, foo99, foo100, foo101, foo102, foo103, foo104, foo105, foo106, foo107, foo108, foo109, foo110, foo111, foo112, foo113, foo114, foo115, foo116, foo117, foo118, foo119, foo120, foo121, foo122, foo123, foo124, foo125, foo126, foo127, foo128, foo129, foo130, foo131, foo132, foo133, foo134, foo135, foo136, foo137, foo138, foo139, foo140, foo141, foo142, foo143, foo144, foo145, foo146, foo147, foo148, foo149, foo150, foo151, foo152, foo153, foo154, foo155, foo156, foo157, foo158, foo159, foo160, foo161, foo162, foo163, foo164, foo165, foo166, foo167, foo168, foo169, foo170, foo171, foo172, foo173, foo174, foo175, foo176, foo177, foo178, foo179, foo180, foo181, foo182, foo183, foo184, foo185, foo186, foo187, foo188, foo189, foo190, foo191, foo192, foo193, foo194, foo195, foo196, foo197, foo198, foo199, foo200, foo201, foo202, foo203, foo204, foo205, foo206, foo207, foo208, foo209, foo210, foo211, foo212, foo213, foo214, foo215, foo216, foo217, foo218, foo219, foo220, foo221, foo222, foo223, foo224, foo225, foo226, foo227, foo228, foo229, foo230, foo231, foo232, foo233, foo234, foo235, foo236, foo237, foo238, foo239, foo240, foo241, foo242, foo243, foo244, foo245, foo246, foo247, foo248, foo249, foo250, foo251, foo252, foo253, foo254| 
	
}
```


Closes #5592


## Types of changes

<!-- Delete lines that don't apply -->

- An error message was duplicated, fixes that.

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review
