### PR TITLE
Docs: Add documentation for DebugFrame

### DIFF
--- a/HelpSource/Classes/DebugFrame.schelp
+++ b/HelpSource/Classes/DebugFrame.schelp
@@ -1,0 +1,69 @@
+class:: DebugFrame
+summary:: A representation of the call frame
+categories::  Core/Kernel
+
+Description::
+A representation of the call frame.
+Can be used to reconstruct a backtrace by using link::#-caller::.
+
+An instance can be acquired by calling link::Classes/Object#-getBackTrace::.
+While this is often not useful due to function inlining,
+it is useful when called on an link::Classes/Exception::,
+see the implementation of link::Classes/Exception#-reportError:: where a call to link::Classes/Object#-dumpBackTrace:: can be replaced by a call to link::Classes/Object#-getBackTrace:: and a call stack constructed manually.
+
+Instancemethods::
+
+method:: functionDef
+Returns a link::Classes/FunctionDef:: or a link::Classes/Method:: of the current function or method.
+
+method:: caller
+Returns another link::Classes/DebugFrame:: for the function that called this function.
+
+discussion::
+Can be used to make a back trace, but watch out for function inlining.
+code::
+(
+var debugFrame = { 1.0.getBackTrace }.();
+
+while{ debugFrame.isNil.not }{
+	var def = debugFrame.functionDef;
+	def.postln;
+	if(def.isKindOf(Method)){
+		File.readAllString(def.filenameSymbol.asString)[def.charPos..def.charPos + 200].post;
+		"...".postln;
+	} {
+		def.sourceCode.postln
+	};
+	"\n".post;
+	debugFrame = debugFrame.caller
+}
+)
+::
+
+method:: args
+Returns an link::Classes/Array:: of the argument's values, if there are no arguments, returns a link::Classes/Nil::.
+This does not contain the argument names, which must be accessed through the link::#-functionDef::.
+
+
+discussion::
+code::
+{ thisFunction.getBackTrace }.().args == nil;
+{ |a, b, c| thisFunction.getBackTrace }.().args == [nil, nil, nil];
+{ |a, b, c = 1| thisFunction.getBackTrace }.().args == [nil, nil, 1];
+{ |a, b, c = 1| thisFunction.getBackTrace }.(2, 3, c: 4).args == [2, 3, 4];
+::
+
+method:: vars
+Same as link::#-args:: but for the variables.
+discussion::
+code::
+{ thisFunction.getBackTrace }.().vars == nil
+{ var a; thisFunction.getBackTrace }.().vars == [nil]
+{ var a, b = 1; thisFunction.getBackTrace }.().vars == [nil, 1]
+::
+
+method:: address
+Returns a link::Classes/RawPointer::, rarely useful.
+
+method:: context
+Returns another link::Classes/DebugFrame:: of the compiling context, rarely useful.


### PR DESCRIPTION
## Purpose and Motivation
`DebugFrame` had no documentation, now it does.

Creates a new file.

Also includes an example of how to construct a backtrace.

## Types of changes

- Documentation

## To-do list

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review
