### PR TITLE
SCLang: Too many args passed to certain 'inlined' methods

### DIFF
--- a/lang/LangSource/PyrInterpreter3.cpp
+++ b/lang/LangSource/PyrInterpreter3.cpp
@@ -2980,6 +2980,10 @@ HOT void Interpret(VMGlobals* g) {
                         for (m = 0, mmax = methraw->numargs - numArgsPushed; m < mmax; ++m)
                             slotCopy(++sp, ++qslot);
                         numArgsPushed = methraw->numargs;
+                    } else if (methraw->varargs == 0 && numArgsPushed > methraw->numargs) {
+                        const auto num_slots_to_chop = numArgsPushed - methraw->numargs;
+                        sp -= num_slots_to_chop;
+                        numArgsPushed = methraw->numargs;
                     }
                     selector = slotRawSymbol(&meth->selectors);
                     goto msg_lookup;
@@ -2991,6 +2995,10 @@ HOT void Interpret(VMGlobals* g) {
                         qslot = slotRawObject(&meth->prototypeFrame)->slots + numArgsPushed - 1;
                         for (m = 0, mmax = methraw->numargs - numArgsPushed; m < mmax; ++m)
                             slotCopy(++sp, ++qslot);
+                        numArgsPushed = methraw->numargs;
+                    } else if (methraw->varargs == 0 && numArgsPushed > methraw->numargs) {
+                        const auto num_slots_to_chop = numArgsPushed - methraw->numargs;
+                        sp -= num_slots_to_chop;
                         numArgsPushed = methraw->numargs;
                     }
                     selector = slotRawSymbol(&meth->selectors);
@@ -3004,6 +3012,10 @@ HOT void Interpret(VMGlobals* g) {
                         qslot = slotRawObject(&meth->prototypeFrame)->slots + numArgsPushed - 1;
                         for (m = 0, mmax = methraw->numargs - numArgsPushed; m < mmax; ++m)
                             slotCopy(++sp, ++qslot);
+                        numArgsPushed = methraw->numargs;
+                    } else if (methraw->varargs == 0 && numArgsPushed > methraw->numargs) {
+                        const auto num_slots_to_chop = numArgsPushed - methraw->numargs;
+                        sp -= num_slots_to_chop;
                         numArgsPushed = methraw->numargs;
                     }
                     selector = slotRawSymbol(&meth->selectors);
@@ -3021,6 +3033,10 @@ HOT void Interpret(VMGlobals* g) {
                         qslot = slotRawObject(&meth->prototypeFrame)->slots + numArgsPushed - 1;
                         for (m = 0, mmax = methraw->numargs - numArgsPushed; m < mmax; ++m)
                             slotCopy(++sp, ++qslot);
+                        numArgsPushed = methraw->numargs;
+                    } else if (methraw->varargs == 0 && numArgsPushed > methraw->numargs) {
+                        const auto num_slots_to_chop = numArgsPushed - methraw->numargs;
+                        sp -= num_slots_to_chop;
                         numArgsPushed = methraw->numargs;
                     }
                     selector = slotRawSymbol(&meth->selectors);

--- a/testsuite/classlibrary/TestCorrectArgCount.sc
+++ b/testsuite/classlibrary/TestCorrectArgCount.sc
@@ -1,0 +1,26 @@
+TestCorrectArgCountObj {
+	var <a, <b, <c;
+	*new {|a| ^super.newCopyArgs(a) }
+	*newVar {|...a| ^super.newCopyArgs(a) }
+	*newVarExpand {|...a| ^super.newCopyArgs(*a) }
+}
+TestCorrectArgCount : UnitTest {
+    test_var_args {
+        var o = TestCorrectArgCountObj.newVar(\a, \b, \c);
+		this.assertEquals(o.a, [\a, \b, \c], "first argument given in the method definition is passed correctly");
+		this.assertEquals(o.b, nil, "arguments absent from method definition should not be passed");
+		this.assertEquals(o.c, nil, "arguments absent from method definition should not be passed");
+    }
+    test_var_args_expanded {
+        var o = TestCorrectArgCountObj.newVarExpand(\a, \b, \c);
+		this.assertEquals(o.a, \a, "arguments should be expanded.");
+		this.assertEquals(o.b, \b, "arguments should be expanded.");
+		this.assertEquals(o.c, \c, "arguments should be expanded.");
+    }
+	test_correct_arg {
+		var o = TestCorrectArgCountObj(\a, \b, \c);
+		this.assertEquals(o.a, \a, "first argument given in the method definition is passed correctly");
+		this.assertEquals(o.b, nil, "arguments absent from method definition should not be passed");
+		this.assertEquals(o.c, nil, "arguments absent from method definition should not be passed");
+	}
+}


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

When the compile/parser see a method with only a single call, or a call to `super.something`, it 'inlines' it.

For these methods, all the user's arguments were being passed through, regardless of how many were declared in the function signature.

This commit checks this, and removes any excess args from the stack.

Fixes #1087

Here is some code to demonstrate the error, before this commit, `b` and `c` would be set.
```
TestCopyArgs {
    var a, b, c;
    *new { |a| ^super.newCopyArgs(a) }
}
```
```
TestCopyArgs(\a, \b, \c).dump
```



<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

This should not break any code, and if it does, that code is wrong.

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Appeasing the linter
- [x] This PR is ready for review
