### PR TITLE
SCDocHTMLRenderer: Remove script referring to non-existing files from SCDoc HTML

### DIFF
--- a/SCClassLibrary/SCDoc/SCDocRenderer.sc
+++ b/SCClassLibrary/SCDoc/SCDocRenderer.sc
@@ -246,7 +246,7 @@ SCDocHTMLRenderer {
 		<< "var scdoc_sc_version = '" << Main.version << "';\n"
 		<< "</script>\n"
 		<< "<script src='" << baseDir << "/scdoc.js' type='text/javascript'></script>\n"
-		// << "<script src='" << baseDir << "/docmap.js' type='text/javascript'></script>\n" // FIXME: remove?  // does not exist
+		<< "<script src='" << baseDir << "/docmap.js' type='text/javascript'></script>\n" // FIXME: remove?
 		// << "<script src='" << baseDir << "/frontend.js' type='text/javascript'></script>\n" // does not exist
 		// QWebChannel access
 		// << "<script src='qrc:///qtwebchannel/qwebchannel.js' type='text/javascript'></script>\n" // does not exist

--- a/SCClassLibrary/SCDoc/SCDocRenderer.sc
+++ b/SCClassLibrary/SCDoc/SCDocRenderer.sc
@@ -246,10 +246,10 @@ SCDocHTMLRenderer {
 		<< "var scdoc_sc_version = '" << Main.version << "';\n"
 		<< "</script>\n"
 		<< "<script src='" << baseDir << "/scdoc.js' type='text/javascript'></script>\n"
-		<< "<script src='" << baseDir << "/docmap.js' type='text/javascript'></script>\n" // FIXME: remove?
-		<< "<script src='" << baseDir << "/frontend.js' type='text/javascript'></script>\n"
+		// << "<script src='" << baseDir << "/docmap.js' type='text/javascript'></script>\n" // FIXME: remove?  // does not exist
+		// << "<script src='" << baseDir << "/frontend.js' type='text/javascript'></script>\n" // does not exist
 		// QWebChannel access
-		<< "<script src='qrc:///qtwebchannel/qwebchannel.js' type='text/javascript'></script>\n"
+		// << "<script src='qrc:///qtwebchannel/qwebchannel.js' type='text/javascript'></script>\n" // does not exist
 		<< "</head>\n"
 		<< "<body onload='fixTOC()'>\n";
 


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

I found unnecessary parts in SCDocRenderer and marked them as comments for future development. The commented lines create scripts that refer to the non-existing files. It only makes errors when loading the SC help documentation HTML file.

<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review
