### PR TITLE
HelpSource: group CSS colors as variables

### DIFF
--- a/HelpSource/Classes/SCDocHTMLRenderer.schelp
+++ b/HelpSource/Classes/SCDocHTMLRenderer.schelp
@@ -41,3 +41,9 @@ The rendered HTML reads the global style from teletype::scdoc.css::, but also re
 
 So to customise the CSS, the user can create a teletype::custom.css:: in their link::Classes/SCDoc#*helpTargetDir:: or at the root of any HelpSource directory (for example in teletype::YourExtension/HelpSource/custom.css:: ).
 
+subsection:: CSS colors
+All default colors are defined as variables at the top of teletype::scdoc.css::
+and teletype::editor.css::. In order to change the whole color palette of the
+docs, it's sufficient to override these variables in a user's
+teletype::frontend.css:: or teletype::custom.css::.
+

--- a/HelpSource/browse.css
+++ b/HelpSource/browse.css
@@ -11,11 +11,11 @@
     border: none;
 }
 .result_doc {
-    border-bottom: 1px solid var(--color-fg-50);
+    border-bottom: 1px solid var(--color-fg-100);
     margin-top: 0.5em;
 }
 .result_summary {
-    color: var(--color-fg-400);
+    color: var(--color-fg-300);
     font-size: 9pt;
     max-width: 18em;
     margin-bottom: 0.6em;
@@ -53,7 +53,7 @@
 #search_checks {
     font-size: 9pt;
     color: var(--color-fg-300);
-    border-bottom: 1px solid var(--color-fg-50);
+    border-bottom: 1px solid var(--color-fg-100);
     margin-top: 1em;
     padding-bottom: 1em;
 }

--- a/HelpSource/browse.css
+++ b/HelpSource/browse.css
@@ -11,11 +11,11 @@
     border: none;
 }
 .result_doc {
-    border-bottom: 1px solid #ddd;
+    border-bottom: 1px solid var(--color-fg-50);
     margin-top: 0.5em;
 }
 .result_summary {
-    color: #444;
+    color: var(--color-fg-400);
     font-size: 9pt;
     max-width: 18em;
     margin-bottom: 0.6em;
@@ -25,11 +25,11 @@
     border-bottom: 1px solid transparent;
 }
 .cat_selected {
-    border-bottom: 1px solid #777;
+    border-bottom: 1px solid var(--color-fg-200);
 }
 .cat_header {
-    border-bottom: 2px solid #999;
-    color: #777;
+    border-bottom: 2px solid var(--color-fg-100);
+    color: var(--color-fg-200);
 /*    background: #aaa;
     color: white;*/
     margin-bottom: 0.25em;
@@ -37,36 +37,36 @@
 /*    font-weight: bold;*/
 }
 .category a {
-    color: #555;
+    color: var(--color-fg-300);
     font-weight: bold;
 }
 .cat_selected a {
-    color: #000;
+    color: var(--color-fg);
     font-weight: bold;
 }
 .cat_arrow {
     float: right;
     padding-left: 1ex;
-    color: #555;
+    color: var(--color-fg-300);
 }
 
 #search_checks {
     font-size: 9pt;
-    color: #555;
-    border-bottom: 1px solid #ddd;
+    color: var(--color-fg-300);
+    border-bottom: 1px solid var(--color-fg-50);
     margin-top: 1em;
     padding-bottom: 1em;
 }
 .cat_count {
-    color: #777;
+    color: var(--color-fg-200);
     font-size: 9pt;
 }
 #total_count {
     font-size: 9pt;
-    color: #777;
+    color: var(--color-fg-200);
 }
 .doc_kind {
-    color: #666;
+    color: var(--color-fg-300);
     float: right;
     font-size: 8pt;
     padding: 0 2px;

--- a/HelpSource/editor.css
+++ b/HelpSource/editor.css
@@ -1,21 +1,3 @@
-:root {
-    --color-cm-background: white;
-    --color-cm-border: #e1e1e1;
-    --color-cm-selection: rgba(248, 162, 0, 0.5);
-    --color-cm-flash: rgba(248, 162, 0, 0);
-    --color-cm-keyword: #0000e6;
-    --color-cm-built-in: #3333bf;
-    --color-cm-number: #980099;
-    --color-cm-symbol: #007300;
-    --color-cm-class: #0000d2;
-    --color-cm-primitive: #0000d2;
-    --color-cm-char: #007300;
-    --color-cm-env-var: #8c4614;
-    --color-cm-comment: #bf0000;
-    --color-cm-string: #5f5f5f;
-    --color-cm-text: #000000;
-}
-
 textarea.editor {
     opacity: 0;
 }

--- a/HelpSource/editor.css
+++ b/HelpSource/editor.css
@@ -1,3 +1,21 @@
+:root {
+    --color-cm-background: white;
+    --color-cm-border: #e1e1e1;
+    --color-cm-selection: rgba(248, 162, 0, 0.5);
+    --color-cm-flash: rgba(248, 162, 0, 0);
+    --color-cm-keyword: #0000e6;
+    --color-cm-built-in: #3333bf;
+    --color-cm-number: #980099;
+    --color-cm-symbol: #007300;
+    --color-cm-class: #0000d2;
+    --color-cm-primitive: #0000d2;
+    --color-cm-char: #007300;
+    --color-cm-env-var: #8c4614;
+    --color-cm-comment: #bf0000;
+    --color-cm-string: #5f5f5f;
+    --color-cm-text: #000000;
+}
+
 textarea.editor {
     opacity: 0;
 }
@@ -6,9 +24,10 @@ textarea.editor {
     height: auto;
     padding: 0 1em;
     margin-top: 1em;
-    border-left: 2px solid #e1e1e1;
+    border-left: 2px solid var(--color-cm-border);
     font-size: 1em;
     line-height: normal;
+    background: var(--color-cm-background);
 }
 
 .CodeMirror-cursors,
@@ -20,21 +39,21 @@ textarea.editor {
 .CodeMirror-line::selection,
 .CodeMirror-line > span::selection,
 .CodeMirror-line > span > span::selection { 
-    background: rgba(248, 162, 0, 0.5) !important;
+    background: var(--color-cm-selection) !important;
 }
 
 @keyframes text-flash {
     0% { 
-        background: rgba(248, 162, 0, 0);
-        color: black;
+        background: var(--color-cm-flash);
+        color: var(--color-cm-text);
     }
     40% { 
-        background: rgba(248, 162, 0, 1); 
-        color: black,
+        background: var(--color-cm-flash); 
+        color: var(--color-cm-text);
     }
     100% { 
-        background: rgba(248, 162, 0, 0); 
-        color: black;
+        background: var(--color-cm-flash); 
+        color: var(--color-cm-text);
     }
 }
 
@@ -43,28 +62,30 @@ textarea.editor {
 }
 
 /* syntax hightlighting */
-.cm-s-default .cm-keyword { color: #0000e6; font-weight: bold; }
-.cm-s-default .cm-built-in { color: #3333bf; }
-.cm-s-default .cm-number { color: #980099; }
-.cm-s-default .cm-symbol { color: #007300; }
-.cm-s-default .cm-class { color: #0000d2; }
-.cm-s-default .cm-primitive { color: #0000d2; }
-.cm-s-default .cm-char { color: #007300; }
-.cm-s-default .cm-env-var { color: #8c4614; }
-.cm-s-default .cm-comment { color: #bf0000; }
-.cm-s-default .cm-string { color: #5f5f5f; }
-.cm-s-default .cm-text { color: #000000; }
+.cm-s-default .cm-keyword { color: var(--color-cm-keyword); font-weight: bold; }
+.cm-s-default .cm-built-in { color: var(--color-cm-built-in); }
+.cm-s-default .cm-number { color: var(--color-cm-number); }
+.cm-s-default .cm-symbol { color: var(--color-cm-symbol); }
+.cm-s-default .cm-class { color: var(--color-cm-class); }
+.cm-s-default .cm-primitive { color: var(--color-cm-primitive); }
+.cm-s-default .cm-char { color: var(--color-cm-char); }
+.cm-s-default .cm-env-var { color: var(--color-cm-env-var); }
+.cm-s-default .cm-comment { color: var(--color-cm-comment); }
+.cm-s-default .cm-string { color: var(--color-cm-string); }
+.cm-s-default .cm-text { color: var(--color-cm-text); }
 
 @media print {
-    .cm-s-default .cm-keyword { color: #0000e6; font-weight: bold; }
-    .cm-s-default .cm-built-in { color: #3333bf; font-weight: bold; }
-    .cm-s-default .cm-number { color: #980099; }
-    .cm-s-default .cm-symbol { color: #007300; }
-    .cm-s-default .cm-class { color: #0000d2; font-weight: bold; }
-    .cm-s-default .cm-primitive { color: #0000d2; }
-    .cm-s-default .cm-char { color: #007300; }
-    .cm-s-default .cm-env-var { color: #8c4614; }
-    .cm-s-default .cm-comment { color: #bf0000; font-style: italic; }
-    .cm-s-default .cm-string { color: #5f5f5f; }
-    .cm-s-default .cm-text { color: #000000; }
+    .cm-s-default .cm-keyword { color: var(--color-cm-keyword); font-weight: bold; }
+    .cm-s-default .cm-built-in { color: var(--color-cm-built-in); font-weight: bold; }
+    .cm-s-default .cm-number { color: var(--color-cm-number); }
+    .cm-s-default .cm-symbol { color: var(--color-cm-symbol); }
+    .cm-s-default .cm-class { color: var(--color-cm-class); font-weight: bold; }
+    .cm-s-default .cm-primitive { color: var(--color-cm-primitive); }
+    .cm-s-default .cm-char { color: var(--color-cm-char); }
+    .cm-s-default .cm-env-var { color: var(--color-cm-env-var); }
+    .cm-s-default .cm-comment { color: var(--color-cm-comment); font-style: italic; }
+    .cm-s-default .cm-string { color: var(--color-cm-string); }
+    .cm-s-default .cm-text { color: var(--color-cm-text); }
 }
+
+

--- a/HelpSource/scdoc.css
+++ b/HelpSource/scdoc.css
@@ -1,3 +1,25 @@
+:root {
+    /* Main foreground (text) color shades, from strong to weak */
+    --color-fg: black;
+    --color-fg-400: #333;
+    --color-fg-300: #555;
+    --color-fg-200: #777;
+    --color-fg-100: #aaa;
+    --color-fg-50:  #ddd;
+    /* Backgrounds */
+    --color-bg: white;
+    --color-bg-menu: #f9f9f9;
+    /* Colors */
+    --color-links: #449;
+    --color-extension-bg: #601c8b;
+    --color-extension-fg: white;
+    --color-extension-border: #39174F;
+    --color-warning-bg: #f7f7d7;
+    --color-warning-fg: black;
+    --color-error: red;
+    --color-undocumented: #88b;
+}
+
 *, *::before, *::after {
     box-sizing: inherit;
 }
@@ -13,8 +35,8 @@ html, body {
 body {
     font-family: Arial, Helvetica, sans-serif;
     font-size: 10pt;
-    color: black;
-    background: white;
+    color: var(--color-fg);
+    background: var(--color-bg);
 }
 
 div.contents {
@@ -29,7 +51,7 @@ table {
     margin-left: 2em;
 }
 table td {
-    border: 1px solid #ddd;
+    border: 1px solid var(--color-fg-50);
     padding: 0.3em;
 }
 
@@ -44,7 +66,7 @@ p {
 
 a:link, a:visited, a:link:hover {
     text-decoration: none;
-    color: #449;
+    color: var(--color-links);
 }
 
 a:link:hover {
@@ -53,6 +75,8 @@ a:link:hover {
 
 input {
     max-width: 100%;
+    background-color: var(--color-fg-50);
+    color: var(--color-fg-300);
 }
 
 #inheritedclassmets, #inheritedinstmets {
@@ -61,12 +85,12 @@ input {
 
 .inheritedmets_class {
     font-weight: bold;
-    color: #555;
+    color: var(--color-fg-300);
     margin-top: 0.5em;
     margin-bottom: 0.25em;
 }
 .inheritedmets_class a {
-    color: #333;
+    color: var(--color-fg-400);
 }
 ul.inheritedmets {
     list-style: none;
@@ -80,24 +104,24 @@ ul.inheritedmets li {
 }
 a.inheritedmets_toggle {
     font-size: 9pt;
-    color: #558;
+    color: var(--color-links);
     font-weight: normal;
 /*    margin-left: 2em;*/
 }
 
 a.inheritedmets_toggle:hover {
     text-decoration: none;
-    color: #000;
+    color: var(--color-fg);
 }
 
 a.subclass_toggle {
-    color: #555;
+    color: var(--color-fg-300);
     font-weight: normal;
 }
 
 a.subclass_toggle:hover {
     text-decoration: none;
-    color: #000;
+    color: var(--color-fg);
 }
 
 
@@ -107,7 +131,7 @@ a.subclass_toggle:hover {
     width: 100%;
     height: 33px;
     padding: 0.5em 0;
-    background-color: #f9f9f9;
+    background-color: var(--color-bg-menu);
     box-shadow: 0em 0em 0.25em rgba(128, 128, 128, 0.5);
     z-index: 2;
 }
@@ -120,7 +144,7 @@ a.subclass_toggle:hover {
 #menubar .menuitem {
     padding: 0;
     margin: 0;
-    border-right: 1px solid #ddd;
+    border-right: 1px solid var(--color-fg-50);
     font-size: 10pt;
     display: inline-block;
 }
@@ -135,7 +159,7 @@ a.subclass_toggle:hover {
 }
 
 a.menu-link {
-    color: #666;
+    color: var(--color-fg-300);
     padding: 0 0.75em 0 0.75em;
     /* This ensures that the logo isn't cut off. */
     min-height: 1.5em;
@@ -144,7 +168,7 @@ a.menu-link {
 }
 a.menu-link:hover {
     text-decoration: none;
-    color: #999;
+    color: var(--color-fg-200);
 }
 
 #menubar .menuitem .home a {
@@ -184,21 +208,20 @@ a.menu-link:hover {
     border-right: none;
 }
 
+/* UNUSED
 #topdoctitle {
-/*    font-weight: bold;*/
     font-style: italic;
-/*    color: #fff;*/
     color: #444;
     cursor: pointer;
-}
+}*/
 
 .submenu, #toc {
     position: absolute;
     top: 33px;
     padding: 0.5em;
     display: none;
-    background-color: #f9f9f9;
-    border: thin solid #ddd;
+    background-color: var(--color-bg-menu);
+    border: thin solid var(--color-fg-50);
 }
 
 .submenu a {
@@ -211,18 +234,18 @@ a.menu-link:hover {
         white-space: nowrap;
         text-align: left;
 /*      text-decoration: none;*/
-        color: #447;
+        color: var(--color-links);
         font-weight: bold;
 }
 
 .toc_search {
     margin-left: 10px;
-    color: #999;
+    color: var(--color-fg-200);
     font-size: 9pt;
 }
 
 .toc_search input {
-    border: 1px solid #ddd;
+    border: 1px solid var(--color-fg-50);
 }
 
 
@@ -231,7 +254,7 @@ a.menu-link:hover {
 }
 
 #label {
-    color: #666;
+    color: var(--color-fg-300);
     font-size: 0.9em;
 }
 
@@ -239,7 +262,7 @@ a.menu-link:hover {
     font-weight: normal;
     font-size: 1.1em;
     font-style: italic;
-    color: #444;
+    color: var(--color-444);
 }
 #related {
     font-weight: bold;
@@ -255,7 +278,7 @@ a.menu-link:hover {
 
 #superclasses {
     font-size: 9pt;
-    color: #444;
+    color: var(--color-444);
     font-weight: normal;
 }
 
@@ -263,10 +286,10 @@ a.menu-link:hover {
     float: right;
     font-size: 12pt;
     padding: 0.4em 0.4em 0.2em 0.4em;
-    background-color: #601c8b;
-    color: white;
+    background-color: var(--color-extension-bg);
+    color: var(--color-extension-fg);
     border-radius: 3px;
-    border-bottom: 2px solid #39174F;
+    border-bottom: 2px solid var(--color-extension-border);
 }
 
 .extension-indicator-icon {
@@ -280,14 +303,14 @@ a.menu-link:hover {
 
 .subheader {
     font-size: 9pt;
-    color: #444;
+    color: var(--color-444);
     margin-top: 1em;
 }
 
 .jump {
     text-align: right;
     font-size: 9pt;
-    color: #555;
+    color: var(--color-fg-300);
 }
 .jump a {
     font-weight: bold;
@@ -300,7 +323,7 @@ a.footnote {
     top: -0.1em;
 }
 div.footnotes {
-    border-top: 1px solid #aaa;
+    border-top: 1px solid var(--color-fg-100);
     margin-left: 2em;
     margin-top: 3em;
     margin-right: 2em;
@@ -312,7 +335,7 @@ div.footnote {
 }
 
 .soft {
-    color: #777;
+    color: var(--color-fg-200);
 }
 
 h1 {
@@ -322,7 +345,7 @@ h1 {
 }
 
 h2 {
-    border-bottom: 1px solid #ddd;
+    border-bottom: 1px solid var(--color-fg-50);
     margin-top: 1.0em;
     text-align: left;
     margin-bottom: 2px;
@@ -340,7 +363,7 @@ h4 {
     margin-top: 1em;
     margin-bottom: 0em;
     margin-left: 0em;
-    color: #777;
+    color: var(--color-fg-200);
 }
 
 h1,
@@ -382,7 +405,7 @@ code, pre {
 }
 
 pre {
-    border-left: 2px solid #e0e0e0;
+    border-left: 2px solid var(--color-fg-50);
     padding-left: 1em;
 }
 
@@ -399,7 +422,7 @@ pre {
 
 .methprefix {
     font-weight: normal;
-    color: #777;
+    color: var(--color-fg-200);
     padding-right: 0.5em;
     margin-left: -1em;
 }
@@ -417,7 +440,7 @@ pre {
 }
 
 a.method-name {
-    color: black;
+    color: var(--color-fg);
     font-weight: bold;
 }
 
@@ -432,13 +455,13 @@ a.method-name {
 
 .extmethod {
     font-size: 9pt;
-    color: #444;
+    color: var(--color-444);
     padding-left: 0.2em;
 }
 
 .supmethod {
     font-size: 9pt;
-    color: #444;
+    color: var(--color-444);
     padding-left: 0.2em;
 }
 
@@ -470,7 +493,8 @@ td p {
 
 .note, .warning {
 /*    border-left: 4px solid #eea;*/
-    background: #f7f7d7;
+    background: var(--color-warning-bg);
+    color: var(--color-warning-fg);
     padding: 0.5em;
     margin-top: 1em;
     margin-bottom: 1em;
@@ -479,7 +503,7 @@ td p {
     font-weight: bold;
 }
 .warninglabel {
-    color: red;
+    color: var(--color-error);
 }
 
 /*.version {
@@ -492,17 +516,18 @@ td p {
 
 .doclink {
     font-size: 9pt;
-    color: #888;
+    color: var(--color-fg-200);
     text-align: right;
     margin-top: 2em;
     margin-bottom: 2em;
-    border-top: 1px solid #ddd;
+    border-top: 1px solid var(--color-fg-50);
 }
 .doclink a {
-    color: #444;
+    color: var(--color-fg-400);
     word-wrap: break-word;
 }
 
+/* UNUSED
 #sidetoc {
     position: fixed;
     display: block;
@@ -512,7 +537,6 @@ td p {
     padding: 10px;
     height: 100%;
     overflow: auto;
-/*    background: #eee;*/
     background: #fff;
     border-right: 1px solid #bbb;
 }
@@ -520,7 +544,7 @@ td p {
 #sidetoc a:hover {
     text-decoration: none;
     color: black;
-}
+}*/
 
 #toc-container {
     float: right;
@@ -539,7 +563,7 @@ td p {
     font-weight: bold;
     font-size: 120%;
     margin: 0.7em 0.5em;
-    color: #333;
+    color: var(--color-fg-400);
 }
 
 li {
@@ -565,20 +589,20 @@ ul.toc li a {
 }
 
 ul.toc li a:hover {
-    background: #eee;
+    background: var(--color-eee);
 }
 
 .toc1 {
     font-weight: bold;
 }
 .toc1 a {
-    color: #444;
+    color: var(--color-444);
 }
 .toc2 {
     font-weight: normal;
 }
 .toc2 a {
-    color: #444;
+    color: var(--color-444);
 }
 .toc3 {
     font-family: monospace;
@@ -586,7 +610,7 @@ ul.toc li a:hover {
 /*    font-size: 9.5pt;*/
 }
 .toc3 a {
-    color: #555;
+    color: var(--color-fg-300);
 }
 
 ul.tree, ul.tree ul {
@@ -611,7 +635,7 @@ ul.tree li {
 }
 
 ul.tree li:last-child {
- background: #fff url(images/lastnode.png) no-repeat;
+ background: var(--color-bg) url(images/lastnode.png) no-repeat;
 }
 
 :target {
@@ -621,7 +645,7 @@ ul.tree li:last-child {
 }
 
 a.undoc {
-    color: #88b;
+    color: var(--color-undocumented);
     text-decoration: line-through;
 }
 
@@ -633,17 +657,17 @@ div#search_box {
 }
 
 #search_input {
-    border: 1px solid #aaa;
-    background: #eee;
+    border: 1px solid var(--color-fg-100);
+    background: var(--color-eee);
     margin-left: 0.5em;
 }
 div#search_count {
-    border-bottom: 2px solid #aaa;
-    color: #333;
+    border-bottom: 2px solid var(--color-fg-100);
+    color: var(--color-fg-400);
 }
 
 div.result_category {
-    color: #555;
+    color: var(--color-fg-300);
     margin-top: 1em;
     margin-bottom: 0.5em;
 /*    font-size: 9.5pt;
@@ -657,38 +681,36 @@ div.met_docs {
 }
 div.met_subclasses {
     font-size: 9pt;
-    color: #777;
+    color: var(--color-fg-200);
     margin-left: 3em;
     text-align: left;
 }
 div.met_subclasses a {
-    color: #444;
+    color: var(--color-444);
 }
 div.met_subclasses a.seemore {
     margin-left: 0.2em;
-    color: #558;
+    color: var(--color-links);
 }
 #search_checks {
     padding: 0.5em;
     padding-top: 0.25em;
     padding-bottom: 0.25em;
     font-size: 9pt;
-    color: #555;
-    background: #eee;
+    color: var(--color-fg-300);
+    background: var(--color-eee);
 }
 #search_checks0 {
     font-size: 9pt;
-    color: #555;
-    border-bottom: 1px solid #ddd;
+    color: var(--color-fg-300);
+    border-bottom: 1px solid var(--color-fg-50);
     margin-top: 1em;
     padding-bottom: 1em;
 }
 table#search_settings {
     font-size: 9pt;
-    color: #555;
+    color: var(--color-fg-300);
     width: 100%;
-    margin-left: 0px;
-    margin-right: 0px;*/
     margin: 0px;
     padding: 0px;
     border-collapse: collapse;
@@ -704,7 +726,7 @@ table#search_settings {
 #js_error {
     font-family: Andale Mono, monospace;
     font-size: 9pt;
-    color: red;
+    color: var(--color-error);
 }
 
 /* from Methods.html in HelpSource/Overview/ */
@@ -717,20 +739,6 @@ table#search_settings {
     margin-bottom: 0.2em;
     margin-left: 2em;
 }
-div.met_subclasses {
-    font-size: 9pt;
-    color: #777;
-    margin-left: 3em;
-    text-align: left;
-}
-div.met_subclasses a {
-    color: #444;
-}
-
-div.met_subclasses a.seemore {
-    margin-left: 0.2em;
-    color: #558;
-}
 
 .method_name {
     font-family: Andale Mono, monospace;
@@ -738,17 +746,18 @@ div.met_subclasses a.seemore {
 }
 #method_note {
     font-size: 9pt;
-    color: #777;
-    border-top: 1px solid #ddd;
+    color: var(--color-fg-200);
+    border-top: 1px solid var(--color-fg-50);
     text-align: center;
     margin-top: 2em;
 }
 #total_count {
     font-size: 9pt;
-    color: #777;
+    color: var(--color-fg-200);
 }
 .searchlink {
-    background: #eed;
+    background: var(--color-warning-bg);
+    color: var(--color-warning-fg);
     text-align: center;
     font-size: 9pt;
     padding: 0.25em;
@@ -762,8 +771,4 @@ div.met_subclasses a.seemore {
 .result_item {
     margin-left: 1.5em;
     margin-top: 0.2em;
-}
-#total_count {
-    font-size: 9pt;
-    color: #777;
 }

--- a/HelpSource/scdoc.css
+++ b/HelpSource/scdoc.css
@@ -1,23 +1,38 @@
 :root {
+    /* Default color theme */
     /* Main foreground (text) color shades, from strong to weak */
     --color-fg: black;
-    --color-fg-400: #333;
-    --color-fg-300: #555;
-    --color-fg-200: #777;
-    --color-fg-100: #aaa;
-    --color-fg-50:  #ddd;
+    --color-fg-300: #444;
+    --color-fg-200: #888;
+    --color-fg-100: #ddd;
     /* Backgrounds */
     --color-bg: white;
     --color-bg-menu: #f9f9f9;
+    --color-bg-input: #f0f0f0;
     /* Colors */
     --color-links: #449;
-    --color-extension-bg: #601c8b;
-    --color-extension-fg: white;
-    --color-extension-border: #39174F;
     --color-warning-bg: #f7f7d7;
     --color-warning-fg: black;
     --color-error: red;
-    --color-undocumented: #88b;
+    --color-extension-bg: #601c8b;
+    --color-extension-fg: white;
+    --color-extension-border: #39174F;
+    /* CodeMirror */
+    --color-cm-background: white;
+    --color-cm-border: #e1e1e1;
+    --color-cm-selection: rgba(248, 162, 0, 0.5);
+    --color-cm-flash: rgba(248, 162, 0, 0);
+    --color-cm-keyword: #0000e6;
+    --color-cm-built-in: #3333bf;
+    --color-cm-number: #980099;
+    --color-cm-symbol: #007300;
+    --color-cm-class: #0000d2;
+    --color-cm-primitive: #0000d2;
+    --color-cm-char: #007300;
+    --color-cm-env-var: #8c4614;
+    --color-cm-comment: #bf0000;
+    --color-cm-string: #5f5f5f;
+    --color-cm-text: #000000;
 }
 
 *, *::before, *::after {
@@ -39,6 +54,11 @@ body {
     background: var(--color-bg);
 }
 
+input, select, textarea {
+    background: var(--color-bg-input);
+    color: var(--color-fg);
+}
+
 div.contents {
     margin: 0;
     padding: calc(33px + .5em) 1em 1em;
@@ -51,7 +71,7 @@ table {
     margin-left: 2em;
 }
 table td {
-    border: 1px solid var(--color-fg-50);
+    border: 1px solid var(--color-fg-200);
     padding: 0.3em;
 }
 
@@ -75,8 +95,6 @@ a:link:hover {
 
 input {
     max-width: 100%;
-    background-color: var(--color-fg-50);
-    color: var(--color-fg-300);
 }
 
 #inheritedclassmets, #inheritedinstmets {
@@ -85,12 +103,12 @@ input {
 
 .inheritedmets_class {
     font-weight: bold;
-    color: var(--color-fg-300);
+    color: var(--color-fg-200);
     margin-top: 0.5em;
     margin-bottom: 0.25em;
 }
 .inheritedmets_class a {
-    color: var(--color-fg-400);
+    color: var(--color-fg-300);
 }
 ul.inheritedmets {
     list-style: none;
@@ -144,7 +162,7 @@ a.subclass_toggle:hover {
 #menubar .menuitem {
     padding: 0;
     margin: 0;
-    border-right: 1px solid var(--color-fg-50);
+    border-right: 1px solid var(--color-fg-100);
     font-size: 10pt;
     display: inline-block;
 }
@@ -221,7 +239,7 @@ a.menu-link:hover {
     padding: 0.5em;
     display: none;
     background-color: var(--color-bg-menu);
-    border: thin solid var(--color-fg-50);
+    border: thin solid var(--color-fg-100);
 }
 
 .submenu a {
@@ -245,7 +263,7 @@ a.menu-link:hover {
 }
 
 .toc_search input {
-    border: 1px solid var(--color-fg-50);
+    border: 1px solid var(--color-fg-100);
 }
 
 
@@ -262,7 +280,7 @@ a.menu-link:hover {
     font-weight: normal;
     font-size: 1.1em;
     font-style: italic;
-    color: var(--color-444);
+    color: var(--color-fg-300);
 }
 #related {
     font-weight: bold;
@@ -278,7 +296,7 @@ a.menu-link:hover {
 
 #superclasses {
     font-size: 9pt;
-    color: var(--color-444);
+    color: var(--color-fg-300);
     font-weight: normal;
 }
 
@@ -303,7 +321,7 @@ a.menu-link:hover {
 
 .subheader {
     font-size: 9pt;
-    color: var(--color-444);
+    color: var(--color-fg-300);
     margin-top: 1em;
 }
 
@@ -345,7 +363,7 @@ h1 {
 }
 
 h2 {
-    border-bottom: 1px solid var(--color-fg-50);
+    border-bottom: 1px solid var(--color-fg-100);
     margin-top: 1.0em;
     text-align: left;
     margin-bottom: 2px;
@@ -405,7 +423,7 @@ code, pre {
 }
 
 pre {
-    border-left: 2px solid var(--color-fg-50);
+    border-left: 2px solid var(--color-fg-100);
     padding-left: 1em;
 }
 
@@ -455,13 +473,13 @@ a.method-name {
 
 .extmethod {
     font-size: 9pt;
-    color: var(--color-444);
+    color: var(--color-fg-300);
     padding-left: 0.2em;
 }
 
 .supmethod {
     font-size: 9pt;
-    color: var(--color-444);
+    color: var(--color-fg-300);
     padding-left: 0.2em;
 }
 
@@ -520,10 +538,10 @@ td p {
     text-align: right;
     margin-top: 2em;
     margin-bottom: 2em;
-    border-top: 1px solid var(--color-fg-50);
+    border-top: 1px solid var(--color-fg-100);
 }
 .doclink a {
-    color: var(--color-fg-400);
+    color: var(--color-fg-300);
     word-wrap: break-word;
 }
 
@@ -563,7 +581,7 @@ td p {
     font-weight: bold;
     font-size: 120%;
     margin: 0.7em 0.5em;
-    color: var(--color-fg-400);
+    color: var(--color-fg-300);
 }
 
 li {
@@ -589,20 +607,20 @@ ul.toc li a {
 }
 
 ul.toc li a:hover {
-    background: var(--color-eee);
+    background: var(--color-bg-input);
 }
 
 .toc1 {
     font-weight: bold;
 }
 .toc1 a {
-    color: var(--color-444);
+    color: var(--color-fg-300);
 }
 .toc2 {
     font-weight: normal;
 }
 .toc2 a {
-    color: var(--color-444);
+    color: var(--color-fg-300);
 }
 .toc3 {
     font-family: monospace;
@@ -645,7 +663,7 @@ ul.tree li:last-child {
 }
 
 a.undoc {
-    color: var(--color-undocumented);
+    opacity: 50%;
     text-decoration: line-through;
 }
 
@@ -658,12 +676,11 @@ div#search_box {
 
 #search_input {
     border: 1px solid var(--color-fg-100);
-    background: var(--color-eee);
     margin-left: 0.5em;
 }
 div#search_count {
     border-bottom: 2px solid var(--color-fg-100);
-    color: var(--color-fg-400);
+    color: var(--color-fg-300);
 }
 
 div.result_category {
@@ -686,7 +703,7 @@ div.met_subclasses {
     text-align: left;
 }
 div.met_subclasses a {
-    color: var(--color-444);
+    color: var(--color-fg-300);
 }
 div.met_subclasses a.seemore {
     margin-left: 0.2em;
@@ -698,12 +715,12 @@ div.met_subclasses a.seemore {
     padding-bottom: 0.25em;
     font-size: 9pt;
     color: var(--color-fg-300);
-    background: var(--color-eee);
+    background: var(--color-bg-input);
 }
 #search_checks0 {
     font-size: 9pt;
     color: var(--color-fg-300);
-    border-bottom: 1px solid var(--color-fg-50);
+    border-bottom: 1px solid var(--color-fg-100);
     margin-top: 1em;
     padding-bottom: 1em;
 }
@@ -747,7 +764,7 @@ table#search_settings {
 #method_note {
     font-size: 9pt;
     color: var(--color-fg-200);
-    border-top: 1px solid var(--color-fg-50);
+    border-top: 1px solid var(--color-fg-100);
     text-align: center;
     margin-top: 2em;
 }


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

I refactored HelpSource css files to have all color definitions as variables, at the top of both scdoc.css (for general ui colors) and editor.css (for code blocks).
This will make it easier for users to override schelp color schemes, for example to achieve dark mode.
Through the process I have removed two rarely used shades of grey, replacing them with others that were more used throughout the docs.
I have also removed two unused css definitions from scdoc.css.

With this PR it will be easier to define color schemes for scdoc, using the existing "frontend.css" mechanism: a user can create a file called "frontend.css" and put it in `SCDoc.helpTargetDir`. Now instead of having to override all sorts of color definitions, one needs only to override a fixed number of easy to find variable definitions.

I've added a note in the documentation, let me know if you happen to know a better place to document this feat.

Here is an example frontend.css, for dark mode:
```css
:root {
--color-fg:  #EFEFEF ;
--color-fg-400:  #D0D0D0 ;
--color-fg-300:  #B2B1B1 ;
--color-fg-200:  #939292 ;
--color-fg-100:  #747373 ;
--color-fg-50:   #555454 ;
--color-bg:  #222020 ;
--color-bg-menu:  #222020 ;
--color-links:  #0986D3 ;
--color-undocumented:  #05436A ;
--color-extension-bg: #601c8b;
--color-extension-fg: white;
--color-extension-border: #39174F;
--color-warning-bg: #f7f7d7;
--color-warning-fg: black;
--color-error: red;

--color-cm-background:  #3D3D3D ;
--color-cm-border:  #0986D3 ;
--color-cm-selection:  #606476 ;
--color-cm-flash:  #636397 ;
--color-cm-flash-fg:  #636397 ;
--color-cm-keyword:  #ff76c7 ;
--color-cm-built-in:  #e2e37a ;
--color-cm-number:  #be90fc ;
--color-cm-symbol:  #45fc75 ;
--color-cm-class:  #65e5ff ;
--color-cm-primitive:  #aaff7f ;
--color-cm-char:  #ff55ff ;
--color-cm-env-var:  #ffb965 ;
--color-cm-comment:  #6071a6 ;
--color-cm-string:  #5df884 ;
--color-cm-text:  #f7fdff ;
}
```

## Types of changes

- Documentation
- New feature

## To-do list

- [x] Updated documentation
- [ ] This PR is ready for review
