### PR TITLE
Add pre commit

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -27,12 +27,11 @@ jobs:
         run: |
           sudo npm install -g lintspaces-cli
           lintspaces -e .editorconfig SCClassLibrary/**/*.sc || true # ignore failure
-      - name: lint cpp files
-        run: |
-          sudo apt-get install -y clang-format-14
-          echo "Running tools/clang-format.py lintall"
-          tools/clang-format.py -c clang-format-14 -d clang-format-diff-14 lintall || exit 1
-          echo "Lint successful"
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+      - uses: pre-commit/action@v3.0.0
+        name: 'Run pre-commit'
       - name: set version string for artifacts
         id: set-version
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
     hooks:
     -   id: clang_format
         name: Format C++ code
-        entry: python tools/clang-format.py formatall
+        entry: python tools/clang-format.py lintall
         pass_filenames: false
         types_or:
           - "c++"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,16 @@
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.3.0
+    hooks:
+    -   id: check-merge-conflict
+    -   id: check-case-conflict
+-   repo: local
+    hooks:
+    -   id: clang_format
+        name: Format C++ code
+        entry: python tools/clang-format.py formatall
+        pass_filenames: false
+        types_or:
+          - "c++"
+        language: python
+        additional_dependencies: ['clang-format==14.0.6']

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,15 @@ repos:
     hooks:
     -   id: clang_format
         name: Format C++ code
-        entry: python tools/clang-format.py lintall
+        entry: python tools/clang-format.py formatall
+        pass_filenames: false
+        types_or:
+          - "c++"
+        language: python
+        additional_dependencies: ['clang-format==14.0.6']
+    -   id: clang_lint
+        name: Lint C++ code
+        entry: python tools/clang-format.py lintall 
         pass_filenames: false
         types_or:
           - "c++"


### PR DESCRIPTION
Closes #6096 

<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation
SuperCollider has a formatter/linter policy for its C++ files, which is checked via clang-format.
This check is also done in CI, and any commit that does not pass the clang-format stage results in a failed build that is not checked further.

As the formatting rules of clang-format are not consistent between major versions, it is necessary to enforce a specific version of clang-format to create deterministic formatting - the correct version is checked by our formatting tool `clang-format.py`.

https://github.com/supercollider/supercollider/blob/766791ca951f39a9479de2663fe51ab76dd06841/tools/clang-format.py#L121-L122

To have access to a specific clang-format version on a system is not trivial and made e.g. #6196 necessary.

In order to reduce dev dependency management for users who occasionally want to work on CPP files, this PR suggests using https://pre-commit.com/ to manage any necessary formatting and its dependencies to apply that formatting.
Not only does pre-commit check that the files are properly formatted before committing, but it also allows the correct clang-format version to be downloaded as a Python dependency (see https://github.com/ssciwr/clang-format-wheel which supports all major clang format versions for linux/mac/windows).
As Python is already a dependency for formatting code, this does not introduce a new dependency beyond a Python package, but drops the dev dependency of clang-format as a system installation!

It is still possible to work without pre-commit, but this can still lead to rejection by CI if the code is not formatted properly.
The formatter will also only run if any C++ files have been touched.

If we update the clang format version, or want to add additional checks, we can simply edit/add them in the `.pre-commit-config.yaml` file - this makes working in branches easier, as formatting rules are specified via files.
Pre-commit will automatically pick up any necessary changes (e.g. to dependencies).

Pre-commit is a trusted tool within the Python community and beyond, and has been around for over 10 years, see https://github.com/pre-commit/pre-commit
The (optional) installation is as simple as `pip install pre-commit` and `pre-commit install`, see https://pre-commit.com/ for more details.

## Example

Lets say I have the following C++ file changes staged which I want now to commit

<img width="593" alt="grafik" src="https://github.com/supercollider/supercollider/assets/8267062/111a1ad6-8395-401a-8e88-e57e42469225">

These clash with how clang-format wants to format them, and when I want to commit this staged file, `pre-commit run` will automatically run in the background and check if the formatting is ok - as clang-format says it is not ok, the `git commit` process will fail.

<img width="594" alt="grafik" src="https://github.com/supercollider/supercollider/assets/8267062/115a12af-1e10-43b6-8930-d649f5eb484e">

The Python formatting script `tools/clang-format.py formatall` has already applied all formatting fixes to the staged files, and can be compared from the current (fixed) state to the staged state.

<img width="592" alt="grafik" src="https://github.com/supercollider/supercollider/assets/8267062/4febd9f3-dbdb-43c8-bb4b-815bdad30c12">

When we stage these fixes, we can run the `commit` command again, the files will be checked for formatting, and if the formatter does not complain, the commit will be performed successfully.
This allows to create properly formatted commits all the time without thinking about how to apply the formatting, it happens automatically in the background.

The CI will also check that the codebase passes the formatter, as before.

## Types of changes

<!-- Delete lines that don't apply -->

- New feature

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [ ] Updated documentation
- [ ] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

### Merge notes

Should also be documented in the wiki or dev setup docs.

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
