### PR TITLE
Update CMakeLists.txt replace deprecated commands

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,20 +96,32 @@ endif(WIN32)
 # Compiler flags etc
 
 if (${CMAKE_COMPILER_IS_GNUCXX})
-	exec_program(${CMAKE_CXX_COMPILER} ARGS -dumpversion OUTPUT_VARIABLE _gcc_version)
+    execute_process(
+            COMMAND ${CMAKE_CXX_COMPILER} -dumpversion
+            OUTPUT_VARIABLE _gcc_version
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
 
-	add_definitions("-fschedule-insns2" "-fomit-frame-pointer")
-
-	add_definitions("-Wreturn-type")
+    add_compile_options(
+        -fschedule-insns2        # Optimize instruction scheduling
+        -fomit-frame-pointer     # Optimize by omitting the frame pointer where possible
+        -Wreturn-type            # Warn if function definitions lack a return type
+        -fno-math-errno          # Optimize math functions by not setting errno
+        -fno-signaling-nans      # Assume no signaling NaNs for better optimization
+        -fsigned-zeros           # Maintain distinction between -0.0 and +0.0
+        -fno-associative-math    # Prevent reordering of floating-point operations
+    )
 
 	if(${_gcc_version} VERSION_LESS 4.8)
 		message(FATAL_ERROR "SuperCollider requires at least gcc-4.8 when compiled with gcc.")
 	endif()
 
-	add_definitions("-fno-math-errno -fno-signaling-nans -fsigned-zeros -fno-associative-math")
-
 	if(APPLE)
-		exec_program(${CMAKE_CXX_COMPILER} ARGS --version OUTPUT_VARIABLE _gcc_version_info)
+        execute_process(
+                COMMAND ${CMAKE_CXX_COMPILER} --version
+                OUTPUT_VARIABLE _gcc_version_info
+                OUTPUT_STRIP_TRAILING_WHITESPACE
+        )
 		if ("${_gcc_version_info}" MATCHES "Apple")
 			add_definitions("-fpascal-strings")
 		endif()
@@ -400,8 +412,8 @@ if(MSVC)
     set(${flag} "${${flag}} /wd4996") # The POSIX name for this item is deprecated.
   endforeach()
 
-# this flag causes MSVC to correctly report __cplusplus, which prevents a compiler error 
-# caused by some versions of libsndfile's C++ header redefining nullptr as NULL. 
+# this flag causes MSVC to correctly report __cplusplus, which prevents a compiler error
+# caused by some versions of libsndfile's C++ header redefining nullptr as NULL.
 # See https://devblogs.microsoft.com/cppblog/msvc-now-correctly-reports-__cplusplus/
   add_compile_options("/Zc:__cplusplus")
 

--- a/cmake_modules/cmake_uninstall.cmake.in
+++ b/cmake_modules/cmake_uninstall.cmake.in
@@ -1,21 +1,31 @@
-IF(NOT EXISTS "@CMAKE_CURRENT_BINARY_DIR@/install_manifest.txt")
-  MESSAGE(FATAL_ERROR "Cannot find install manifest: \"@CMAKE_CURRENT_BINARY_DIR@/install_manifest.txt\"")
-ENDIF(NOT EXISTS "@CMAKE_CURRENT_BINARY_DIR@/install_manifest.txt")
+# Check if install manifest file exists
+if(NOT EXISTS "${CMAKE_CURRENT_BINARY_DIR}/install_manifest.txt")
+  message(FATAL_ERROR "Cannot find install manifest: \"${CMAKE_CURRENT_BINARY_DIR}/install_manifest.txt\"")
+endif()
 
-FILE(READ "@CMAKE_CURRENT_BINARY_DIR@/install_manifest.txt" files)
-STRING(REGEX REPLACE "\n" ";" files "${files}")
-FOREACH(file ${files})
-  MESSAGE(STATUS "Uninstalling \"$ENV{DESTDIR}${file}\"")
-  IF(EXISTS "$ENV{DESTDIR}${file}")
-    EXEC_PROGRAM(
-      "@CMAKE_COMMAND@" ARGS "-E remove \"$ENV{DESTDIR}${file}\""
+# Read install manifest file
+file(READ "${CMAKE_CURRENT_BINARY_DIR}/install_manifest.txt" files)
+
+# Replace newline with semicolons
+string(REGEX REPLACE "\n" ";" files "${files}")
+
+# Iterate over  list:
+foreach(file IN LISTS files)
+  message(STATUS "Uninstalling \"${ENV{DESTDIR}}${file}\"")
+  # Check if file exists
+  if(EXISTS "${ENV{DESTDIR}}${file}")
+    # Remove file
+    execute_process(
+      COMMAND "${CMAKE_COMMAND}" -E remove "${ENV{DESTDIR}}${file}"
       OUTPUT_VARIABLE rm_out
-      RETURN_VALUE rm_retval
-      )
-    IF(NOT "${rm_retval}" STREQUAL 0)
-      MESSAGE(FATAL_ERROR "Problem when removing \"$ENV{DESTDIR}${file}\"")
-    ENDIF(NOT "${rm_retval}" STREQUAL 0)
-  ELSE(EXISTS "$ENV{DESTDIR}${file}")
-    MESSAGE(STATUS "File \"$ENV{DESTDIR}${file}\" does not exist.")
-  ENDIF(EXISTS "$ENV{DESTDIR}${file}")
-ENDFOREACH(file)
+      RESULT_VARIABLE rm_retval
+    )
+    # Check if the removal was successful
+    if(NOT "${rm_retval}" STREQUAL "0")
+      message(FATAL_ERROR "Problem when removing \"${ENV{DESTDIR}}${file}\"")
+    endif()
+  else()
+    # File does not exist
+    message(STATUS "File \"${ENV{DESTDIR}}${file}\" does not exist.")
+  endif()
+endforeach()


### PR DESCRIPTION
## Motivation 

This PR updates deprecated commands and improves the handling of compiler flags with recommended syntax. Goal: more clear, forward-compatible code, with some added comments. 

No changes in functionality. 

## Changes

- Overall: a) clarity and compatibility; b) documentation for future devs

- Replacement of deprecated command: Replaced the deprecated `exec_program` with `execute_process` for better handling of compiler version, and compatibility with future CMake versions

- Compiler flag: Replaced `add_definitions` with `add_compile_options` to specify compiler flags. `add_compile_options` is used to add any compiler options, making it more flexible, not just preprocessor definitions. `add_definitions is not recommended and primarily intended for adding preprocessor definitions, so its use is being discouraged.

- Added documentation comments for each flag.

- [x] Code is tested.
- [x] This PR is ready for review. 
