### PR TITLE
replace "Monospace" with system monospace font

### DIFF
--- a/editors/sc-ide/widgets/util/status_box.cpp
+++ b/editors/sc-ide/widgets/util/status_box.cpp
@@ -31,7 +31,7 @@ StatusLabel::StatusLabel(QWidget* parent): QLabel(parent) {
     setTextColor(Qt::white);
 
     QFont font = QFontDatabase::systemFont(QFontDatabase::FixedFont);
-    font.setPointSize(font.pointSize() + 3);
+    font.setPointSize(font.pointSize());
     font.setStyleHint(QFont::Monospace);
     font.setBold(true);
     setFont(font);

--- a/editors/sc-ide/widgets/util/status_box.cpp
+++ b/editors/sc-ide/widgets/util/status_box.cpp
@@ -19,6 +19,7 @@
 */
 
 #include "status_box.hpp"
+#include <QtGui/qfontdatabase.h>
 
 namespace ScIDE {
 
@@ -29,7 +30,8 @@ StatusLabel::StatusLabel(QWidget* parent): QLabel(parent) {
     setBackground(Qt::black);
     setTextColor(Qt::white);
 
-    QFont font("Monospace");
+    QFont font = QFontDatabase::systemFont(QFontDatabase::FixedFont);
+    font.setPointSize(font.pointSize() + 3);
     font.setStyleHint(QFont::Monospace);
     font.setBold(true);
     setFont(font);


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

During startup of the IDE, it yields a log message

```
qt.qpa.fonts: Populating font family aliases took 242 ms. Replace uses of missing font family "Monospace" with one that exists to avoid this cost. 
```

This can also take longer (500ms), depending on your system, slowing down every startup of the IDE.

This PR replaces the font with the default monospace font of the system and therefore removes the error message.
I increased the font size a bit in order to match the current size (only checked this on MacOS).

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
