### PR TITLE
Replace `boost::filesystem` with `std::filesystem`

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,10 @@ SuperCollider is tested with:
 
 SuperCollider is known to support these platforms:
 - Windows Vista, 7, 8, 10, 11
-- macOS 10.14-12.x
+- macOS 10.15-12.x
 - Ubuntu 18.04-22.04
 
-We also provide a legacy macOS binary for macOS 10.11 and above using Qt 5.9.
+We also provide a legacy macOS binary for macOS 10.15 and above using Qt 5.9.
 
 SuperCollider has guaranteed support for:
 - Windows 10, 11

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ SuperCollider is tested with:
 SuperCollider is known to support these platforms:
 - Windows Vista, 7, 8, 10, 11
 - macOS 10.15-12.x
-- Ubuntu 18.04-22.04
+- Ubuntu 20.04-22.04
 
 We also provide a legacy macOS binary for macOS 10.15 and above using Qt 5.9.
 

--- a/README_LINUX.md
+++ b/README_LINUX.md
@@ -6,7 +6,7 @@ Build requirements
 
 These are strict requirements for scsynth and supernova:
 
-- A C++ compiler with C++17 support. SuperCollider guarantees support for [gcc][gcc] >= 6.3 and [clang][clang] >= 3.9.
+- A C++ compiler with C++17 support. SuperCollider guarantees support for [gcc][gcc] >= 8.1 and [clang][clang] >= 3.9.
 - [cmake][cmake] >= 3.12: Cross-platform build system.
 - [libsndfile][libsndfile] >= 1.0: Soundfile I/O.
 - [libjack][libjack]: Development headers for the JACK Audio Connection Kit.

--- a/common/SC_Codecvt.hpp
+++ b/common/SC_Codecvt.hpp
@@ -76,7 +76,7 @@ inline std::string utf16_wcstr_to_utf8_string(const wchar_t* s) {
  * conversion between UTF-16 and UTF-8. */
 inline std::string path_to_utf8_str(const std::filesystem::path& p) {
 #ifdef _WIN32
-    return p.string(std::codecvt_utf8_utf16<wchar_t>());
+    return std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>>().to_bytes(p.native());
 #else
     return p.string();
 #endif // _WIN32
@@ -88,7 +88,9 @@ inline std::string path_to_utf8_str(const std::filesystem::path& p) {
  * uses conversion between UTF-16 and UTF-8. */
 inline std::filesystem::path utf8_str_to_path(const std::string& s) {
 #ifdef _WIN32
-    return std::filesystem::path(s, std::codecvt_utf8_utf16<wchar_t>());
+    std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
+    std::wstring wideString = converter.from_bytes(s);
+    return std::filesystem::path(std::move(wideString));
 #else
     return std::filesystem::path(s);
 #endif // _WIN32

--- a/common/SC_Codecvt.hpp
+++ b/common/SC_Codecvt.hpp
@@ -39,7 +39,7 @@
 #pragma once
 
 #include <string> // string
-#include <boost/filesystem/path.hpp> // path
+#include <filesystem>
 
 #ifdef _WIN32
 #    include <codecvt> // std::codecvt_utf8_utf16, utf16
@@ -74,7 +74,7 @@ inline std::string utf16_wcstr_to_utf8_string(const wchar_t* s) {
  *
  * On POSIX platforms, this just converts using .string(). On Windows, uses
  * conversion between UTF-16 and UTF-8. */
-inline std::string path_to_utf8_str(const boost::filesystem::path& p) {
+inline std::string path_to_utf8_str(const std::filesystem::path& p) {
 #ifdef _WIN32
     return p.string(std::codecvt_utf8_utf16<wchar_t>());
 #else
@@ -86,11 +86,11 @@ inline std::string path_to_utf8_str(const boost::filesystem::path& p) {
  *
  * On POSIX platforms, this converts using the default constructor. On Windows,
  * uses conversion between UTF-16 and UTF-8. */
-inline boost::filesystem::path utf8_str_to_path(const std::string& s) {
+inline std::filesystem::path utf8_str_to_path(const std::string& s) {
 #ifdef _WIN32
-    return boost::filesystem::path(s, std::codecvt_utf8_utf16<wchar_t>());
+    return std::filesystem::path(s, std::codecvt_utf8_utf16<wchar_t>());
 #else
-    return boost::filesystem::path(s);
+    return std::filesystem::path(s);
 #endif // _WIN32
 }
 

--- a/common/SC_Filesystem.hpp
+++ b/common/SC_Filesystem.hpp
@@ -76,7 +76,7 @@
 #include <map> // map
 #include <algorithm> // std::transform
 #include <string> // std::string
-#include <boost/filesystem/path.hpp> // path
+#include <filesystem> // std::filesystem
 
 #include "SC_Codecvt.hpp" // path_to_utf8_str
 
@@ -101,7 +101,7 @@ public:
     enum class DirName;
     struct Glob;
 
-    typedef boost::filesystem::path Path; ///< Path type.
+    typedef std::filesystem::path Path; ///< Path type.
     typedef std::map<DirName, Path> DirMap; ///< Type of directory name-to-path map.
 
     /// SuperCollider common directory names.

--- a/common/SC_Filesystem_macos.cpp
+++ b/common/SC_Filesystem_macos.cpp
@@ -29,9 +29,7 @@
 
 #    include "SC_Filesystem.hpp"
 
-// boost
-#    include <boost/filesystem/path.hpp> // path, parent_path()
-#    include <boost/filesystem/operations.hpp> // canonical, current_path()
+#    include <filesystem> // path, parent_path(), canonical, current_path()
 
 // system includes
 #    include <Foundation/NSAutoreleasePool.h>
@@ -98,7 +96,7 @@ Path SC_Filesystem::resolveIfAlias(const Path& p, bool& isAlias) {
 
         // #4252 - URLByResolvingAliasFileAtURL will remove last trailing slash ('/Users/' ->
         // '/Users', '/Users///' -> '/Users//'). Protect against this case.
-        auto* pEnd = p.c_str() + p.size();
+        auto* pEnd = p.c_str() + p.string().size();
         const auto* mismatchPos = std::mismatch(p.c_str(), pEnd, resolvedNsPath).first;
         // note that p.size() >= 1 because empty string would fail 'fileExistsAtPath'
         if (mismatchPos == pEnd || (mismatchPos == pEnd - 1 && *mismatchPos == '/')) {
@@ -211,14 +209,14 @@ Path SC_Filesystem::defaultResourceDirectory() {
         uint32_t bufsize = PATH_MAX;
         char relDir[PATH_MAX];
         if (_NSGetExecutablePath(relDir, &bufsize) == 0) {
-            ret = boost::filesystem::canonical(relDir); // resolve symlink
+            ret = std::filesystem::canonical(relDir); // resolve symlink
             ret = ret.parent_path();
         } else {
             // in case it failed, fall back to current directory
-            ret = boost::filesystem::current_path();
+            ret = std::filesystem::current_path();
         }
     }
-    ret = boost::filesystem::canonical(ret); // resolve lingering symlink
+    ret = std::filesystem::canonical(ret); // resolve lingering symlink
     return ret;
 }
 

--- a/common/SC_Filesystem_win.cpp
+++ b/common/SC_Filesystem_win.cpp
@@ -67,7 +67,7 @@ SC_Filesystem::Glob* SC_Filesystem::makeGlob(const char* pattern) {
     // remove a trailing backslash. Even if searching with 'foo/.', this will
     // change to 'foo' harmlessly. Use has_parent_path() because otherwise '.'
     // (referring to the CWD) won't be recognized as a valid query.
-    if (path.filename_is_dot() && path.has_parent_path())
+    if (path.filename() == "." && path.has_parent_path())
         path = path.parent_path();
 
     // expand to home directory, if path starts with tilde
@@ -103,7 +103,7 @@ Path SC_Filesystem::globNext(Glob* glob) {
 
         if (!::FindNextFileW(glob->mHandle, &glob->mEntry))
             glob->mAtEnd = true;
-    } while (glob->mFilename.filename_is_dot() || glob->mFilename.filename_is_dot_dot());
+    } while (glob->mFilename.filename() == "." || glob->mFilename.filename() == "..");
 
     // add preferred separator (L'\\') for directories on Windows, to match
     // POSIX globbing. boost::filesystem::is_directory won't work for this because

--- a/common/SC_Filesystem_win.cpp
+++ b/common/SC_Filesystem_win.cpp
@@ -30,8 +30,7 @@
 #    include "SC_Filesystem.hpp"
 #    include "SC_Codecvt.hpp"
 
-// boost
-#    include <boost/filesystem/operations.hpp> // is_directory
+#    include <filesystem>
 
 // system
 #    include <Shlobj.h> // SHGetKnownFolderPath
@@ -63,7 +62,7 @@ SC_Filesystem::Glob* SC_Filesystem::makeGlob(const char* pattern) {
     Glob* glob = new Glob;
 
     // use make_preferred() to change / -> \ on Windows
-    boost::filesystem::path path = SC_Codecvt::utf8_str_to_path(pattern).make_preferred();
+    std::filesystem::path path = SC_Codecvt::utf8_str_to_path(pattern).make_preferred();
 
     // remove a trailing backslash. Even if searching with 'foo/.', this will
     // change to 'foo' harmlessly. Use has_parent_path() because otherwise '.'
@@ -111,7 +110,7 @@ Path SC_Filesystem::globNext(Glob* glob) {
     // in the case of input '.' and '..', the filename here is just a single folder,
     // not a relative path, and so can't be correctly identified. Plus, it's faster
     // to check the attributes than to make another system call.
-    return isDirectory ? glob->mFilename += boost::filesystem::path::preferred_separator : glob->mFilename;
+    return isDirectory ? glob->mFilename += std::filesystem::path::preferred_separator : glob->mFilename;
 }
 
 //============= PRIVATE METHODS ==============//

--- a/editors/sc-ide/core/util/standard_dirs.cpp
+++ b/editors/sc-ide/core/util/standard_dirs.cpp
@@ -22,7 +22,7 @@
 
 #include "SC_Filesystem.hpp" // getDirectory
 #include "SC_Codecvt.hpp" // path_to_utf8_str
-#include <boost/filesystem/path.hpp> // path
+#include <filesystem>
 
 namespace ScIDE {
 
@@ -59,7 +59,7 @@ QString standardDirectory(StandardDirectory type) {
         return QString();
     }
 
-    const boost::filesystem::path path = SC_Filesystem::instance().getDirectory(dn);
+    const std::filesystem::path path = SC_Filesystem::instance().getDirectory(dn);
     return QString(SC_Codecvt::path_to_utf8_str(path).c_str());
 }
 

--- a/lang/LangPrimSource/PyrFilePrim.cpp
+++ b/lang/LangPrimSource/PyrFilePrim.cpp
@@ -110,6 +110,8 @@ int prFileDeleteAll(struct VMGlobals* g, int numArgsPushed) {
 
 std::time_t to_time_t(std::filesystem::file_time_type file_time) {
     using namespace std::chrono;
+    // in case of C++20 update, consider
+    // https://stackoverflow.com/questions/61030383/how-to-convert-stdfilesystemfile-time-type-to-time-t
     auto sctp = time_point_cast<system_clock::duration>(file_time - std::filesystem::file_time_type::clock::now()
                                                         + system_clock::now());
     return system_clock::to_time_t(sctp);

--- a/lang/LangPrimSource/PyrFilePrim.cpp
+++ b/lang/LangPrimSource/PyrFilePrim.cpp
@@ -49,9 +49,7 @@ Primitives for File i/o.
 
 /* C++ stdlib headers */
 #include <tuple>
-
-/* boost headers */
-#include <boost/filesystem.hpp>
+#include <filesystem>
 
 /* system headers */
 #ifndef _WIN32
@@ -70,7 +68,7 @@ Primitives for File i/o.
 
 #define DELIMITOR ':'
 
-namespace bfs = boost::filesystem;
+namespace fs = std::filesystem;
 
 int prFileDelete(struct VMGlobals* g, int numArgsPushed) {
     PyrSlot *a = g->sp - 1, *b = g->sp;
@@ -80,9 +78,9 @@ int prFileDelete(struct VMGlobals* g, int numArgsPushed) {
     if (error != errNone)
         return error;
 
-    const bfs::path& p = SC_Codecvt::utf8_str_to_path(filename);
-    boost::system::error_code error_code;
-    bfs::remove(p, error_code);
+    const fs::path& p = SC_Codecvt::utf8_str_to_path(filename);
+    std::error_code error_code;
+    fs::remove(p, error_code);
 
     if (error_code)
         SetFalse(a);
@@ -100,8 +98,8 @@ int prFileDeleteAll(struct VMGlobals* g, int numArgsPushed) {
     if (error != errNone)
         return error;
 
-    const bfs::path& p = SC_Codecvt::utf8_str_to_path(filename);
-    if (bfs::remove_all(p) > 0) {
+    const fs::path& p = SC_Codecvt::utf8_str_to_path(filename);
+    if (fs::remove_all(p) > 0) {
         SetTrue(a);
     } else {
         SetFalse(a);
@@ -118,9 +116,10 @@ int prFileMTime(struct VMGlobals* g, int numArgsPushed) {
     if (error != errNone)
         return error;
 
-    const bfs::path& p = SC_Codecvt::utf8_str_to_path(filename);
-    time_t mtime = bfs::last_write_time(p);
-    SetInt(a, mtime);
+    const fs::path& p = SC_Codecvt::utf8_str_to_path(filename);
+    auto mtime = fs::last_write_time(p);
+    const time_t time = decltype(mtime)::clock::to_time_t(mtime);
+    SetInt(a, time);
     return errNone;
 }
 
@@ -132,8 +131,8 @@ int prFileExists(struct VMGlobals* g, int numArgsPushed) {
     if (error != errNone)
         return error;
 
-    const bfs::path& p = SC_Codecvt::utf8_str_to_path(filename);
-    bool res = bfs::exists(p);
+    const fs::path& p = SC_Codecvt::utf8_str_to_path(filename);
+    bool res = fs::exists(p);
     SetBool(a, res);
     return errNone;
 }
@@ -149,13 +148,13 @@ int prFileRealPath(struct VMGlobals* g, int numArgsPushed) {
         return err;
 
     bool isAlias = false;
-    bfs::path p = SC_Codecvt::utf8_str_to_path(ipath);
+    fs::path p = SC_Codecvt::utf8_str_to_path(ipath);
     p = SC_Filesystem::resolveIfAlias(p, isAlias);
     if (p.empty())
         return errFailed;
 
-    boost::system::error_code error_code;
-    p = bfs::canonical(p, error_code).make_preferred();
+    std::error_code error_code;
+    p = fs::canonical(p, error_code).make_preferred();
     if (error_code) {
         SetNil(a);
         return errNone;
@@ -178,8 +177,8 @@ int prFileMkDir(struct VMGlobals* g, int numArgsPushed) {
     if (error != errNone)
         return error;
 
-    const bfs::path& p = SC_Codecvt::utf8_str_to_path(filename);
-    bool result = bfs::create_directories(p);
+    const fs::path& p = SC_Codecvt::utf8_str_to_path(filename);
+    bool result = fs::create_directories(p);
 
     SetBool(a, result);
     return errNone;
@@ -197,10 +196,10 @@ int prFileCopy(struct VMGlobals* g, int numArgsPushed) {
     if (error != errNone)
         return error;
 
-    const bfs::path& p1 = SC_Codecvt::utf8_str_to_path(filename1);
-    const bfs::path& p2 = SC_Codecvt::utf8_str_to_path(filename2);
-    boost::system::error_code error_code;
-    bfs::copy(p1, p2, error_code);
+    const fs::path& p1 = SC_Codecvt::utf8_str_to_path(filename1);
+    const fs::path& p2 = SC_Codecvt::utf8_str_to_path(filename2);
+    std::error_code error_code;
+    fs::copy(p1, p2, error_code);
     if (error_code) {
         std::ostringstream s;
         s << error_code.message() << ": copy from \"" << filename1 << "\" to \"" << filename2 << "\"";
@@ -218,9 +217,9 @@ int prFileType(struct VMGlobals* g, int numArgsPushed) {
     if (error != errNone)
         return error;
 
-    const bfs::path& p = SC_Codecvt::utf8_str_to_path(filename);
-    bfs::file_status s(bfs::symlink_status(p));
-    SetInt(a, s.type());
+    const fs::path& p = SC_Codecvt::utf8_str_to_path(filename);
+    fs::file_status s(fs::symlink_status(p));
+    SetInt(a, static_cast<int>(s.type()));
     return errNone;
 }
 
@@ -232,8 +231,8 @@ int prFileSize(struct VMGlobals* g, int numArgsPushed) {
     if (error != errNone)
         return error;
 
-    const bfs::path& p = SC_Codecvt::utf8_str_to_path(filename);
-    uintmax_t sz = bfs::file_size(p);
+    const fs::path& p = SC_Codecvt::utf8_str_to_path(filename);
+    uintmax_t sz = fs::file_size(p);
     SetInt(a, sz);
     return errNone;
 }
@@ -261,7 +260,7 @@ int prFileOpen(struct VMGlobals* g, int numArgsPushed) {
 
     memcpy(filename, slotRawString(b)->s, slotRawObject(b)->size);
     filename[slotRawString(b)->size] = 0;
-    const bfs::path& path = SC_Codecvt::utf8_str_to_path(filename);
+    const fs::path& path = SC_Codecvt::utf8_str_to_path(filename);
 
     memcpy(mode, slotRawString(c)->s, slotRawObject(c)->size);
     mode[slotRawString(c)->size] = 0;
@@ -288,7 +287,7 @@ int prFileOpen(struct VMGlobals* g, int numArgsPushed) {
         // check if directory exisits
         // create a temporary file (somewhere) for a handle
         // the file is deleted automatically when closed
-        if (bfs::is_directory(path)) {
+        if (fs::is_directory(path)) {
             int err;
 #    ifdef _MSC_VER
             err = tmpfile_s(&file);

--- a/lang/LangPrimSource/PyrFilePrim.cpp
+++ b/lang/LangPrimSource/PyrFilePrim.cpp
@@ -108,6 +108,13 @@ int prFileDeleteAll(struct VMGlobals* g, int numArgsPushed) {
     return errNone;
 }
 
+std::time_t to_time_t(std::filesystem::file_time_type file_time) {
+    using namespace std::chrono;
+    auto sctp = time_point_cast<system_clock::duration>(file_time - std::filesystem::file_time_type::clock::now()
+                                                        + system_clock::now());
+    return system_clock::to_time_t(sctp);
+}
+
 int prFileMTime(struct VMGlobals* g, int numArgsPushed) {
     PyrSlot *a = g->sp - 1, *b = g->sp;
     char filename[PATH_MAX];
@@ -118,8 +125,7 @@ int prFileMTime(struct VMGlobals* g, int numArgsPushed) {
 
     const fs::path& p = SC_Codecvt::utf8_str_to_path(filename);
     auto mtime = fs::last_write_time(p);
-    const time_t time = decltype(mtime)::clock::to_time_t(mtime);
-    SetInt(a, time);
+    SetInt(a, to_time_t(mtime));
     return errNone;
 }
 

--- a/lang/LangPrimSource/PyrFilePrim.cpp
+++ b/lang/LangPrimSource/PyrFilePrim.cpp
@@ -215,6 +215,34 @@ int prFileCopy(struct VMGlobals* g, int numArgsPushed) {
     return errNone;
 }
 
+int prFileTypeToInt(const fs::file_type& type) {
+    // see https://en.cppreference.com/w/cpp/filesystem/file_type
+    // and also check this with the `File.type` method located in
+    // `Common/Files/Files.sc`
+    switch (type) {
+    case fs::file_type::none:
+        return 0;
+    case fs::file_type::not_found:
+        return 1;
+    case fs::file_type::regular:
+        return 2;
+    case fs::file_type::directory:
+        return 3;
+    case fs::file_type::symlink:
+        return 4;
+    case fs::file_type::block:
+        return 5;
+    case fs::file_type::character:
+        return 6;
+    case fs::file_type::fifo:
+        return 7;
+    case fs::file_type::socket:
+        return 8;
+    default:
+        return 0;
+    }
+}
+
 int prFileType(struct VMGlobals* g, int numArgsPushed) {
     PyrSlot *a = g->sp - 1, *b = g->sp;
     char filename[PATH_MAX];
@@ -225,7 +253,7 @@ int prFileType(struct VMGlobals* g, int numArgsPushed) {
 
     const fs::path& p = SC_Codecvt::utf8_str_to_path(filename);
     fs::file_status s(fs::symlink_status(p));
-    SetInt(a, static_cast<int>(s.type()));
+    SetInt(a, prFileTypeToInt(s.type()));
     return errNone;
 }
 

--- a/lang/LangPrimSource/PyrPlatformPrim.cpp
+++ b/lang/LangPrimSource/PyrPlatformPrim.cpp
@@ -34,15 +34,15 @@ Primitives for platform dependent directories, constants etc.
 #    include "Shlobj.h"
 #endif
 
-#include <boost/filesystem/path.hpp> // path
+#include <filesystem>
 #include <boost/predef/architecture.h>
 
-namespace bfs = boost::filesystem;
+namespace fs = std::filesystem;
 using DirName = SC_Filesystem::DirName;
 
 static inline int prPlatform_getDirectory(const struct VMGlobals* g, const DirName dirname) {
     PyrSlot* a = g->sp;
-    const bfs::path& p = SC_Filesystem::instance().getDirectory(dirname);
+    const fs::path& p = SC_Filesystem::instance().getDirectory(dirname);
     PyrString* string = newPyrString(g->gc, SC_Codecvt::path_to_utf8_str(p).c_str(), 0, true);
     SetObject(a, string);
     return errNone;

--- a/lang/LangPrimSource/PyrPrimitive.cpp
+++ b/lang/LangPrimSource/PyrPrimitive.cpp
@@ -59,13 +59,13 @@
 
 #include "SCDocPrim.h"
 
-#include <boost/filesystem/path.hpp> // path
+#include <filesystem>
 
 #ifdef __clang__
 #    pragma clang diagnostic ignored "-Warray-bounds"
 #endif
 
-namespace bfs = boost::filesystem;
+namespace fs = std::filesystem;
 
 int yyparse();
 
@@ -3120,7 +3120,7 @@ static int prLanguageConfig_addLibraryPath(struct VMGlobals* g, int numArgsPushe
     if (error)
         return errWrongType;
 
-    const bfs::path& native_path = SC_Codecvt::utf8_str_to_path(path);
+    const fs::path& native_path = SC_Codecvt::utf8_str_to_path(path);
     if (pathType == includePaths)
         gLanguageConfig->addIncludedDirectory(native_path);
     else
@@ -3144,7 +3144,7 @@ static int prLanguageConfig_removeLibraryPath(struct VMGlobals* g, int numArgsPu
     if (error)
         return errWrongType;
 
-    const bfs::path& native_path = SC_Codecvt::utf8_str_to_path(path);
+    const fs::path& native_path = SC_Codecvt::utf8_str_to_path(path);
     if (pathType == includePaths)
         gLanguageConfig->removeIncludedDirectory(native_path);
     else
@@ -3175,7 +3175,7 @@ static int prLanguageConfig_getCurrentConfigPath(struct VMGlobals* g, int numArg
 
 static int prLanguageConfig_writeConfigFile(struct VMGlobals* g, int numArgsPushed) {
     PyrSlot* fileString = g->sp;
-    bfs::path config_path;
+    fs::path config_path;
 
     if (NotNil(fileString)) {
         char path[MAXPATHLEN];

--- a/lang/LangPrimSource/PyrStringPrim.cpp
+++ b/lang/LangPrimSource/PyrStringPrim.cpp
@@ -45,13 +45,14 @@ Primitives for String.
 #include <boost/regex.hpp>
 #include <boost/intrusive/list.hpp>
 #include <boost/intrusive/unordered_set.hpp>
-#include <boost/filesystem/fstream.hpp> // ifstream
-#include <boost/filesystem/path.hpp> // path
+
+#include <fstream>
+#include <filesystem>
 
 #include <yaml-cpp/yaml.h>
 
 using namespace std;
-namespace bfs = boost::filesystem;
+namespace fs = std::filesystem;
 
 int prStringAsSymbol(struct VMGlobals* g, int numArgsPushed) {
     PyrSlot* a;
@@ -589,9 +590,9 @@ int prString_PathMatch(struct VMGlobals* g, int numArgsPushed) {
     }
 
     // read all paths into a vector
-    std::vector<bfs::path> paths;
+    std::vector<fs::path> paths;
     while (true) {
-        const bfs::path& matched_path = SC_Filesystem::globNext(glob);
+        const fs::path& matched_path = SC_Filesystem::globNext(glob);
         if (matched_path.empty())
             break;
         else
@@ -887,7 +888,7 @@ int prString_StandardizePath(struct VMGlobals* g, int /* numArgsPushed */) {
     if (err != errNone)
         return err;
 
-    bfs::path p = SC_Codecvt::utf8_str_to_path(ipath);
+    fs::path p = SC_Codecvt::utf8_str_to_path(ipath);
     p = SC_Filesystem::instance().expandTilde(p);
     bool isAlias;
     p = SC_Filesystem::resolveIfAlias(p, isAlias);
@@ -1028,8 +1029,8 @@ int prString_ParseYAMLFile(struct VMGlobals* g, int numArgsPushed) {
 
     string str((const char*)slotRawString(arg)->s, slotRawString(arg)->size);
 
-    const bfs::path& path = SC_Codecvt::utf8_str_to_path(str);
-    bfs::ifstream fin(path);
+    const fs::path& path = SC_Codecvt::utf8_str_to_path(str);
+    std::ifstream fin(path);
     YAML::Node doc = YAML::Load(fin);
     yaml_traverse(g, doc, nullptr, arg);
 

--- a/lang/LangPrimSource/PyrUnixPrim.cpp
+++ b/lang/LangPrimSource/PyrUnixPrim.cpp
@@ -46,7 +46,7 @@ Primitives for Unix.
 
 #include "SC_Lock.h"
 
-#include <boost/filesystem.hpp>
+#include <filesystem>
 
 #ifdef _WIN32
 #    include "SC_Win32Utils.h"
@@ -54,7 +54,7 @@ Primitives for Unix.
 #    include <libgen.h>
 #endif
 
-namespace bfs = boost::filesystem;
+namespace fs = std::filesystem;
 
 extern bool compiledOK;
 PyrSymbol* s_unixCmdAction;

--- a/lang/LangSource/PyrLexer.cpp
+++ b/lang/LangSource/PyrLexer.cpp
@@ -36,9 +36,8 @@
 #    include <sys/param.h>
 #endif
 
-#include <boost/filesystem/path.hpp>
-#include <boost/filesystem/operations.hpp>
-#include <boost/filesystem/string_file.hpp>
+#include <filesystem>
+#include <fstream>
 
 #include "PyrParseNode.h"
 #include "Bison/lang11d_tab.h"
@@ -84,12 +83,12 @@ int gNumCompiledFiles;
 thisProcess.interpreter.executeFile("Macintosh HD:score").size.postln;
 */
 
-namespace bfs = boost::filesystem;
+namespace fs = std::filesystem;
 using DirName = SC_Filesystem::DirName;
 
 PyrSymbol* gCompilingFileSym = nullptr;
 VMGlobals* gCompilingVMGlobals = nullptr;
-static bfs::path gCompileDir;
+static fs::path gCompileDir;
 
 //#define DEBUGLEX 1
 bool gDebugLexer = false;
@@ -102,7 +101,7 @@ int lastClosedFuncCharNo = 0;
 
 const char* binopchars = "!@%&*-+=|<>?/";
 char yytext[MAXYYLEN];
-bfs::path currfilename;
+fs::path currfilename;
 std::string printingCurrfilename; // for error reporting
 
 int yylen;
@@ -122,7 +121,7 @@ int textpos;
 int errLineOffset, errCharPosOffset;
 int parseFailed = 0;
 bool compiledOK = false;
-std::set<bfs::path> compiledDirectories;
+std::set<fs::path> compiledDirectories;
 
 /* so the text editor's dumb paren matching will work */
 #define OPENPAREN '('
@@ -170,18 +169,18 @@ double sc_strtof(const char* str, int n, int base) {
     return z;
 }
 
-bool startLexer(PyrSymbol* fileSym, const bfs::path& p, int startPos, int endPos, int lineOffset);
-bool startLexer(PyrSymbol* fileSym, const bfs::path& p, int startPos, int endPos, int lineOffset) {
+bool startLexer(PyrSymbol* fileSym, const fs::path& p, int startPos, int endPos, int lineOffset);
+bool startLexer(PyrSymbol* fileSym, const fs::path& p, int startPos, int endPos, int lineOffset) {
     const char* filename = fileSym->name;
 
     textlen = -1;
 
     if (!fileSym->u.source) {
         try {
-            bfs::ifstream file;
+            std::ifstream file;
             file.exceptions(std::ifstream::failbit | std::ifstream::badbit);
             file.open(p, std::ios_base::binary);
-            size_t sz = bfs::file_size(p);
+            size_t sz = fs::file_size(p);
 
             text = (char*)pyr_pool_compile->Alloc((sz + 1) * sizeof(char));
             MEMFAIL(text);
@@ -225,7 +224,7 @@ bool startLexer(PyrSymbol* fileSym, const bfs::path& p, int startPos, int endPos
     zzval = 0;
     parseFailed = 0;
     lexCmdLine = 0;
-    currfilename = bfs::path(filename);
+    currfilename = fs::path(filename);
     printingCurrfilename = "file '" + SC_Codecvt::path_to_utf8_str(currfilename) + "'";
     maxlinestarts = 1000;
     linestarts = (int*)pyr_pool_compile->Alloc(maxlinestarts * sizeof(int*));
@@ -261,7 +260,7 @@ void startLexerCmdLine(char* textbuf, int textbuflen) {
     zzval = 0;
     parseFailed = 0;
     lexCmdLine = 1;
-    currfilename = bfs::path("interpreted text");
+    currfilename = fs::path("interpreted text");
     printingCurrfilename = currfilename.string();
     maxlinestarts = 1000;
     linestarts = (int*)pyr_pool_compile->Alloc(maxlinestarts * sizeof(int*));
@@ -1721,7 +1720,7 @@ void compileClass(PyrSymbol* fileSym, int startPos, int endPos, int lineOffset) 
     gCompilingVMGlobals = nullptr;
     gRootParseNode = nullptr;
     initParserPool();
-    if (startLexer(fileSym, bfs::path(), startPos, endPos, lineOffset)) {
+    if (startLexer(fileSym, fs::path(), startPos, endPos, lineOffset)) {
         // postfl("->Parsing %s\n", fileSym->name); fflush(stdout);
         parseFailed = yyparse();
         // postfl("<-Parsing %s %d\n", fileSym->name, parseFailed); fflush(stdout);
@@ -1733,7 +1732,7 @@ void compileClass(PyrSymbol* fileSym, int startPos, int endPos, int lineOffset) 
             // postfl("done compiling\n");fflush(stdout);
         } else {
             compileErrors++;
-            bfs::path pathname(fileSym->name);
+            fs::path pathname(fileSym->name);
             error("file '%s' parse failed\n", SC_Codecvt::path_to_utf8_str(pathname).c_str());
             postfl("error parsing\n");
         }
@@ -1942,7 +1941,7 @@ void finiPassOne() {
 /**
  * \brief \c true if \c dir is one of the language config's default classlib directories
  */
-static bool isDefaultClassLibraryDirectory(const bfs::path& dir) {
+static bool isDefaultClassLibraryDirectory(const fs::path& dir) {
     auto const& defaultDirs = gLanguageConfig->defaultClassLibraryDirectories();
     auto const iter = std::find(defaultDirs.begin(), defaultDirs.end(), dir);
     return iter != defaultDirs.end();
@@ -1955,10 +1954,10 @@ static bool isDefaultClassLibraryDirectory(const bfs::path& dir) {
  * try to create it, silently ignoring failure (most likely from permissions failure).
  * Otherwise, warn the user to help catch mistyped/missing directory names. See #3468.
  */
-static void passOne_HandleMissingDirectory(const bfs::path& dir) {
+static void passOne_HandleMissingDirectory(const fs::path& dir) {
     if (isDefaultClassLibraryDirectory(dir)) {
-        boost::system::error_code ec {};
-        bfs::create_directories(dir, ec);
+        std::error_code ec {};
+        fs::create_directories(dir, ec);
     } else {
         post("WARNING: Could not open directory: '%s'\n"
              "\tTo resolve this, either create the directory or remove it from your compilation paths.\n\n",
@@ -1966,7 +1965,7 @@ static void passOne_HandleMissingDirectory(const bfs::path& dir) {
     }
 }
 
-bfs::path relativeToCompileDir(const bfs::path& p) { return bfs::relative(p, gCompileDir); }
+fs::path relativeToCompileDir(const fs::path& p) { return fs::relative(p, gCompileDir); }
 
 /** \brief Determines whether the directory should be skipped during compilation.
  *
@@ -1976,7 +1975,7 @@ bfs::path relativeToCompileDir(const bfs::path& p) { return bfs::relative(p, gCo
  * - the language configuration says this path is excluded
  * - SC_Filesystem::shouldNotCompileDirectory(dir) returns `true`
  */
-static bool passOne_ShouldSkipDirectory(const bfs::path& dir) {
+static bool passOne_ShouldSkipDirectory(const fs::path& dir) {
     return (compiledDirectories.find(dir) != compiledDirectories.end())
         || (gLanguageConfig && gLanguageConfig->pathIsExcluded(dir))
         || (SC_Filesystem::instance().shouldNotCompileDirectory(dir));
@@ -2003,24 +2002,24 @@ static bool passOne_ShouldSkipDirectory(const bfs::path& dir) {
  * \returns `true` if processing was successful, `false` if it failed.
  *   See above for what constitutes success and failure conditions.
  */
-static bool passOne_ProcessDir(const bfs::path& dir) {
+static bool passOne_ProcessDir(const fs::path& dir) {
     // Prefer non-throwing versions of filesystem functions, since they are actually not unexpected
     // and because it's faster to use error codes.
-    boost::system::error_code ec;
+    std::error_code ec;
 
     // Perform tilde expansion on incoming dir.
-    const bfs::path expdir = SC_Filesystem::instance().expandTilde(dir);
+    const fs::path expdir = SC_Filesystem::instance().expandTilde(dir);
 
     // Using a recursive_directory_iterator is much faster than actually calling this function
     // recursively. Speedup from the switch was about 1.5x. _Do_ recurse on symlinks.
-    bfs::recursive_directory_iterator rditer(expdir, bfs::symlink_option::recurse, ec);
+    fs::recursive_directory_iterator rditer(expdir, fs::directory_options::follow_directory_symlink, ec);
 
     // Check preconditions: are we able to access the file, and should we compile it according to
     // the language configuration?
     if (ec) {
         // If we got an error, post a warning if it was because the target wasn't found, and return success.
         // Otherwise, post the error and fail.
-        if (ec.default_error_condition().value() == boost::system::errc::no_such_file_or_directory) {
+        if (ec.default_error_condition() == std::errc::no_such_file_or_directory) {
             passOne_HandleMissingDirectory(expdir);
             return true;
         } else {
@@ -2042,14 +2041,14 @@ static bool passOne_ProcessDir(const bfs::path& dir) {
 
     // Invariant: we have processed (or begun to process) every directory or file already
     // touched by the iterator.
-    while (rditer != bfs::end(rditer)) {
-        const bfs::path path = *rditer;
+    while (rditer != fs::end(rditer)) {
+        const fs::path path = *rditer;
 
         // If the file is a directory, perform the same checks as above to see if we should
         // skip compilation on it.
-        if (bfs::is_directory(path)) {
+        if (fs::is_directory(path)) {
             if (passOne_ShouldSkipDirectory(path)) {
-                rditer.no_push(); // don't "push" into the next level of the hierarchy
+                rditer.disable_recursion_pending(); // don't "push" into the next level of the hierarchy
             } else {
                 // Mark this directory as compiled.
                 // By not calling no_push(), we allow the iterator to enter the directory
@@ -2062,8 +2061,8 @@ static bool passOne_ProcessDir(const bfs::path& dir) {
             // - resolution failed: returns empty path: let the user know
             // - it was not an alias, or was an alias that wasn't a directory: try to process it as a source file
             bool isAlias = false;
-            const bfs::path& respath = SC_Filesystem::resolveIfAlias(path, isAlias);
-            if (isAlias && bfs::is_directory(respath)) {
+            const fs::path& respath = SC_Filesystem::resolveIfAlias(path, isAlias);
+            if (isAlias && fs::is_directory(respath)) {
                 // If the resolved alias is a directory, recurse on it.
                 if (!passOne_ProcessDir(respath)) {
                     return false;
@@ -2095,8 +2094,8 @@ bool passOne() {
 }
 
 /// True if file doesn't begin with '.', and ends with either '.sc' or '.rtf'
-bool isValidSourceFileName(const bfs::path& path) {
-    const bfs::path& ext = path.extension();
+bool isValidSourceFileName(const fs::path& path) {
+    const fs::path& ext = path.extension();
     return path.filename().c_str()[0] != '.' && // must not be hidden file
         ((ext == ".sc") || (ext == ".rtf" && path.stem().extension() == ".sc"));
 }
@@ -2110,7 +2109,7 @@ bool isValidSourceFileName(const bfs::path& path) {
  * \returns Whether parsing was successful. The only failure condition occurs
  * when the file can't be opened.
  */
-bool passOne_ProcessOneFile(const bfs::path& path) {
+bool passOne_ProcessOneFile(const fs::path& path) {
     bool success = true;
 
     const std::string path_str = SC_Codecvt::path_to_utf8_str(path);

--- a/lang/LangSource/PyrLexer.h
+++ b/lang/LangSource/PyrLexer.h
@@ -25,7 +25,7 @@
 #include "PyrSymbol.h"
 #include "SC_Export.h"
 #include "SCBase.h"
-#include <boost/filesystem/path.hpp>
+#include <filesystem>
 
 extern int charno, lineno, linepos;
 extern int* linestarts;
@@ -78,10 +78,10 @@ void startLexerCmdLine(char* textbuf, int textbuflen);
 int yylex();
 void yyerror(const char* s);
 void fatal();
-bool isValidSourceFileName(const boost::filesystem::path& path);
-bool passOne_ProcessOneFile(const boost::filesystem::path& path);
+bool isValidSourceFileName(const std::filesystem::path& path);
+bool passOne_ProcessOneFile(const std::filesystem::path& path);
 
-boost::filesystem::path relativeToCompileDir(const boost::filesystem::path&);
+std::filesystem::path relativeToCompileDir(const std::filesystem::path&);
 
 void initLexer();
 

--- a/lang/LangSource/PyrParseNode.cpp
+++ b/lang/LangSource/PyrParseNode.cpp
@@ -41,7 +41,7 @@
 #include "SC_LanguageConfig.hpp"
 #include "SC_Codecvt.hpp"
 
-namespace bfs = boost::filesystem;
+namespace fs = std::filesystem;
 
 AdvancingAllocPool gParseNodePool;
 
@@ -289,7 +289,7 @@ PyrClassExtNode* newPyrClassExtNode(PyrSlotNode* className, PyrMethodNode* metho
 void PyrClassExtNode::compile(PyrSlot* result) {
     PyrClass* classobj = slotRawSymbol(&mClassName->mSlot)->u.classobj;
     if (!classobj) {
-        const bfs::path relpath = relativeToCompileDir(bfs::path(gCompilingFileSym->name));
+        const fs::path relpath = relativeToCompileDir(fs::path(gCompilingFileSym->name));
         error("Class extension for nonexistent class '%s'\n     In file:'%s'\n",
               slotRawSymbol(&mClassName->mSlot)->name, SC_Codecvt::path_to_utf8_str(relpath).c_str());
         return;

--- a/lang/LangSource/SC_LanguageConfig.cpp
+++ b/lang/LangSource/SC_LanguageConfig.cpp
@@ -29,8 +29,8 @@
 #include <algorithm> // std::find
 #include <functional> // std::function
 
-#include <boost/filesystem/operations.hpp> // exists (, canonical?)
-#include <boost/filesystem/fstream.hpp> // ofstream
+#include <filesystem>
+#include <fstream>
 #include <yaml-cpp/yaml.h> // YAML
 
 SC_LanguageConfig::Path SC_LanguageConfig::gConfigFile;
@@ -46,7 +46,7 @@ const char* SCLANG_YAML_CONFIG_FILENAME = "sclang_conf.yaml";
 static const char* EXCLUDE_DEFAULT_PATHS = "excludeDefaultPaths";
 
 using DirName = SC_Filesystem::DirName;
-namespace bfs = boost::filesystem;
+namespace fs = std::filesystem;
 
 void SC_LanguageConfig::setExcludeDefaultPaths(bool value) {
     if (mExcludeDefaultPaths != value) {
@@ -104,13 +104,13 @@ bool SC_LanguageConfig::removeIncludedDirectory(const Path& path) { return remov
 bool SC_LanguageConfig::removeExcludedDirectory(const Path& path) { return removePath(mExcludedDirectories, path); }
 
 static void processPathList(const char* nodeName, YAML::Node& doc,
-                            const std::function<void(const boost::filesystem::path&)>& func) {
+                            const std::function<void(const std::filesystem::path&)>& func) {
     const YAML::Node& items = doc[nodeName];
     if (items && items.IsSequence()) {
         for (auto const& item : items) {
             const std::string& path = item.as<std::string>("");
             if (!path.empty()) {
-                const boost::filesystem::path& native_path = SC_Codecvt::utf8_str_to_path(path);
+                const std::filesystem::path& native_path = SC_Codecvt::utf8_str_to_path(path);
                 func(native_path);
             }
         }
@@ -138,7 +138,7 @@ bool SC_LanguageConfig::readLibraryConfigYAML(const Path& fileName, bool standal
 
     using namespace YAML;
     try {
-        bfs::ifstream fin(fileName);
+        std::ifstream fin(fileName);
         Node doc = Load(fin);
         if (doc) {
             processBool(
@@ -160,7 +160,7 @@ bool SC_LanguageConfig::readLibraryConfigYAML(const Path& fileName, bool standal
 }
 
 bool SC_LanguageConfig::writeLibraryConfigYAML(const Path& fileName) {
-    if (!bfs::exists(fileName.parent_path()))
+    if (!fs::exists(fileName.parent_path()))
         return false;
 
     using namespace YAML;
@@ -174,13 +174,13 @@ bool SC_LanguageConfig::writeLibraryConfigYAML(const Path& fileName) {
 
     out << Key << INCLUDE_PATHS;
     out << Value << BeginSeq;
-    for (const bfs::path& it : gLanguageConfig->mIncludedDirectories)
+    for (const fs::path& it : gLanguageConfig->mIncludedDirectories)
         out << SC_Codecvt::path_to_utf8_str(it);
     out << EndSeq;
 
     out << Key << EXCLUDE_PATHS;
     out << Value << BeginSeq;
-    for (const bfs::path& it : gLanguageConfig->mExcludedDirectories)
+    for (const fs::path& it : gLanguageConfig->mExcludedDirectories)
         out << SC_Codecvt::path_to_utf8_str(it);
     out << EndSeq;
 
@@ -192,7 +192,7 @@ bool SC_LanguageConfig::writeLibraryConfigYAML(const Path& fileName) {
 
     out << EndMap;
 
-    bfs::ofstream fout(fileName);
+    std::ofstream fout(fileName);
     fout << out.c_str();
     return fout.good();
 }
@@ -207,20 +207,20 @@ bool SC_LanguageConfig::defaultLibraryConfig(bool standalone) {
 bool SC_LanguageConfig::readLibraryConfig(bool standalone) {
     bool configured = false;
 
-    if (bfs::exists(gConfigFile))
+    if (fs::exists(gConfigFile))
         configured = readLibraryConfigYAML(gConfigFile, standalone);
 
     if (!configured && !standalone) {
         const Path userYamlConfigFile =
             SC_Filesystem::instance().getDirectory(DirName::UserConfig) / SCLANG_YAML_CONFIG_FILENAME;
 
-        if (bfs::exists(userYamlConfigFile))
+        if (fs::exists(userYamlConfigFile))
             configured = readLibraryConfigYAML(userYamlConfigFile, standalone);
 
         if (!configured) {
             const Path globalYamlConfigFile = Path("/etc") / SCLANG_YAML_CONFIG_FILENAME;
 
-            if (bfs::exists(globalYamlConfigFile))
+            if (fs::exists(globalYamlConfigFile))
                 configured = readLibraryConfigYAML(globalYamlConfigFile, standalone);
         }
     }

--- a/lang/LangSource/SC_LanguageConfig.hpp
+++ b/lang/LangSource/SC_LanguageConfig.hpp
@@ -25,7 +25,7 @@
 
 #include <vector>
 #include <string>
-#include <boost/filesystem/path.hpp>
+#include <filesystem>
 
 class SC_LanguageConfig;
 extern SC_LanguageConfig* gLanguageConfig;
@@ -42,7 +42,7 @@ extern const char* SCLANG_YAML_CONFIG_FILENAME;
  */
 class SC_LanguageConfig {
 public:
-    typedef boost::filesystem::path Path;
+    typedef std::filesystem::path Path;
     typedef std::vector<Path> DirVector;
 
     const DirVector& includedDirectories() const { return mIncludedDirectories; }

--- a/lang/LangSource/SC_TerminalClient.cpp
+++ b/lang/LangSource/SC_TerminalClient.cpp
@@ -61,7 +61,7 @@
 #include "SC_LanguageConfig.hpp"
 #include "SC_Version.hpp"
 
-#include <boost/filesystem/operations.hpp>
+#include <filesystem>
 
 using namespace boost::placeholders;
 
@@ -255,8 +255,7 @@ int SC_TerminalClient::run(int argc, char** argv) {
 
     // Create config directory so that it can be used by Quarks, etc. See #2919.
     if (!opt.mStandalone && !opt.mLibraryConfigFile)
-        boost::filesystem::create_directories(
-            SC_Filesystem::instance().getDirectory(SC_Filesystem::DirName::UserConfig));
+        std::filesystem::create_directories(SC_Filesystem::instance().getDirectory(SC_Filesystem::DirName::UserConfig));
 
     // startup library
     compileLibrary(opt.mStandalone);

--- a/server/scsynth/SC_GraphDef.cpp
+++ b/server/scsynth/SC_GraphDef.cpp
@@ -45,10 +45,10 @@
 #include <stdexcept>
 #include <string>
 
-#include <boost/filesystem/operations.hpp> // recursive_directory_iterator
-#include <boost/filesystem/string_file.hpp> // load_string_file
+#include <filesystem>
+#include <fstream>
 
-namespace bfs = boost::filesystem;
+namespace fs = std::filesystem;
 
 extern Malloc gMalloc;
 
@@ -601,7 +601,7 @@ GraphDef* GraphDef_LoadGlob(World* inWorld, const char* pattern, GraphDef* inLis
     if (!glob)
         return inList;
 
-    bfs::path path;
+    fs::path path;
     while (!(path = SC_Filesystem::globNext(glob)).empty()) {
         if (path.extension() == ".scsyndef") {
             inList = GraphDef_Load(inWorld, path, inList);
@@ -614,10 +614,19 @@ GraphDef* GraphDef_LoadGlob(World* inWorld, const char* pattern, GraphDef* inLis
     return inList;
 }
 
-GraphDef* GraphDef_Load(World* inWorld, const bfs::path& path, GraphDef* inList) {
+std::string load_file(const std::filesystem::path& file_path) {
+    std::ifstream file(file_path);
+    if (!file.is_open()) {
+        throw std::runtime_error("Could not open file: " + file_path.string());
+    }
+    std::stringstream buffer;
+    buffer << file.rdbuf();
+    return buffer.str();
+}
+
+GraphDef* GraphDef_Load(World* inWorld, const fs::path& path, GraphDef* inList) {
     try {
-        std::string file_contents;
-        bfs::load_string_file(path, file_contents);
+        std::string file_contents = load_file(path);
         inList = GraphDefLib_Read(inWorld, &file_contents[0], inList);
     } catch (const std::exception& e) {
         scprintf("exception in GraphDef_Load: %s\n", e.what());
@@ -632,21 +641,21 @@ GraphDef* GraphDef_Load(World* inWorld, const bfs::path& path, GraphDef* inList)
     return inList;
 }
 
-GraphDef* GraphDef_LoadDir(World* inWorld, const bfs::path& dirname, GraphDef* inList) {
-    boost::system::error_code ec;
-    bfs::recursive_directory_iterator rditer(dirname, bfs::symlink_option::recurse, ec);
+GraphDef* GraphDef_LoadDir(World* inWorld, const fs::path& dirname, GraphDef* inList) {
+    std::error_code ec;
+    fs::recursive_directory_iterator rditer(dirname, fs::directory_options::follow_directory_symlink, ec);
 
     if (ec) {
         scprintf("*** ERROR: open directory failed '%s'\n", SC_Codecvt::path_to_utf8_str(dirname).c_str());
         return inList;
     }
 
-    while (rditer != bfs::end(rditer)) {
-        const bfs::path path = *rditer;
+    while (rditer != fs::end(rditer)) {
+        const fs::path path = *rditer;
 
-        if (bfs::is_directory(path)) {
+        if (fs::is_directory(path)) {
             if (SC_Filesystem::instance().shouldNotCompileDirectory(path))
-                rditer.no_push();
+                rditer.disable_recursion_pending();
             else
                 ; // do nothing; recursion will happen automatically
         } else if (path.extension() == ".scsyndef") { // ordinary file

--- a/server/scsynth/SC_GraphDef.h
+++ b/server/scsynth/SC_GraphDef.h
@@ -22,7 +22,7 @@
 
 #include "SC_SynthDef.h"
 #include "HashTable.h"
-#include <boost/filesystem/path.hpp> // path
+#include <filesystem>
 
 struct ParamSpec {
     int32 mName[kSCNameLen];
@@ -71,8 +71,8 @@ struct GraphDef {
 typedef struct GraphDef GraphDef;
 
 GraphDef* GraphDef_Recv(World* inWorld, char* buffer, GraphDef* inList);
-GraphDef* GraphDef_Load(struct World* inWorld, const boost::filesystem::path& path, GraphDef* inList);
-GraphDef* GraphDef_LoadDir(struct World* inWorld, const boost::filesystem::path& path, GraphDef* inList);
+GraphDef* GraphDef_Load(struct World* inWorld, const std::filesystem::path& path, GraphDef* inList);
+GraphDef* GraphDef_LoadDir(struct World* inWorld, const std::filesystem::path& path, GraphDef* inList);
 GraphDef* GraphDef_LoadGlob(World* inWorld, const char* pattern, GraphDef* inList);
 SCErr GraphDef_Remove(World* inWorld, int32* inName);
 SCErr GraphDef_DeleteMsg(struct World* inWorld, GraphDef* inDef);

--- a/server/scsynth/SC_SequencedCommand.cpp
+++ b/server/scsynth/SC_SequencedCommand.cpp
@@ -30,8 +30,7 @@
 #include "../../common/SC_SndFileHelpers.hpp"
 #include "SC_WorldOptions.h"
 
-/* boost headers */
-#include <boost/filesystem.hpp>
+#include <filesystem>
 
 const size_t ERR_BUF_SIZE(512);
 
@@ -1434,7 +1433,7 @@ LoadSynthDefDirCmd::~LoadSynthDefDirCmd() { World_Free(mWorld, mFilename); }
 void LoadSynthDefDirCmd::CallDestructor() { this->~LoadSynthDefDirCmd(); }
 
 bool LoadSynthDefDirCmd::Stage2() {
-    if (!boost::filesystem::exists(mFilename)) {
+    if (!std::filesystem::exists(mFilename)) {
         char str[ERR_BUF_SIZE];
         snprintf(str, ERR_BUF_SIZE, "Could not load synthdefs. Directory '%s' does not exist\n", mFilename);
         SendFailure(&mReplyAddress, "/d_loadDir", mFilename);

--- a/server/scsynth/SC_World.cpp
+++ b/server/scsynth/SC_World.cpp
@@ -75,9 +75,9 @@
 
 #include "server_shm.hpp"
 
-#include <boost/filesystem/path.hpp> // path
+#include <filesystem>
 
-namespace bfs = boost::filesystem;
+namespace fs = std::filesystem;
 
 InterfaceTable gInterfaceTable;
 PrintFunc gPrint = nullptr;
@@ -271,7 +271,7 @@ void World_LoadGraphDefs(World* world) {
             GraphDef_Define(world, list);
         }
     } else {
-        bfs::path path = SC_Filesystem::instance().getDirectory(DirName::UserAppSupport) / "synthdefs";
+        fs::path path = SC_Filesystem::instance().getDirectory(DirName::UserAppSupport) / "synthdefs";
         if (world->mVerbosity > 0)
             scprintf("Loading synthdefs from default path: %s\n", SC_Codecvt::path_to_utf8_str(path).c_str());
         list = GraphDef_LoadDir(world, path, list);

--- a/server/supernova/sc/sc_synth_definition.cpp
+++ b/server/supernova/sc/sc_synth_definition.cpp
@@ -19,7 +19,7 @@
 #include <iostream>
 #include <future>
 
-#include <boost/filesystem/operations.hpp>
+#include <filesystem>
 #include <boost/range/iterator_range.hpp>
 
 #include "sc_synth.hpp"
@@ -49,7 +49,7 @@ std::vector<sc_synthdef> sc_read_synthdefs_file(path const& file) {
 }
 
 std::vector<sc_synthdef> sc_read_synthdefs_dir(path const& dir) {
-    using namespace boost::filesystem;
+    using namespace std::filesystem;
     using namespace std;
 
     typedef vector<sc_synthdef> def_vector;

--- a/server/supernova/sc/sc_synth_definition.hpp
+++ b/server/supernova/sc/sc_synth_definition.hpp
@@ -18,7 +18,7 @@
 
 #pragma once
 
-#include <boost/filesystem/path.hpp>
+#include <filesystem>
 
 #include "sc_synthdef.hpp"
 
@@ -27,7 +27,7 @@
 
 namespace nova {
 
-using boost::filesystem::path;
+using std::filesystem::path;
 
 /* read synthdefs from path pattern */
 std::vector<sc_synthdef> sc_read_synthdefs_file(path const& filename);

--- a/server/supernova/sc/sc_synthdef.cpp
+++ b/server/supernova/sc/sc_synthdef.cpp
@@ -137,7 +137,7 @@ std::vector<sc_synthdef> read_synthdefs(const char* buffer, const char* buffer_e
     return ret;
 }
 
-std::vector<sc_synthdef> read_synthdef_file(boost::filesystem::path const& filename) {
+std::vector<sc_synthdef> read_synthdef_file(std::filesystem::path const& filename) {
     using namespace std;
 
     ifstream stream;

--- a/server/supernova/sc/sc_synthdef.hpp
+++ b/server/supernova/sc/sc_synthdef.hpp
@@ -22,9 +22,9 @@
 #include <map>
 #include <string>
 #include <vector>
+#include <filesystem>
 
 #include <boost/align/aligned_allocator.hpp>
-#include <boost/filesystem/path.hpp>
 
 #include "utilities/named_hash_entry.hpp"
 
@@ -134,6 +134,6 @@ private:
 };
 
 std::vector<sc_synthdef> read_synthdefs(const char* buffer, const char* buffer_end);
-std::vector<sc_synthdef> read_synthdef_file(boost::filesystem::path const& filename);
+std::vector<sc_synthdef> read_synthdef_file(std::filesystem::path const& filename);
 
 } /* namespace nova */

--- a/server/supernova/sc/sc_ugen_factory.cpp
+++ b/server/supernova/sc/sc_ugen_factory.cpp
@@ -26,7 +26,7 @@
 #    include "SC_Codecvt.hpp"
 #endif
 
-#include <boost/filesystem.hpp>
+#include <filesystem>
 
 #include "sc_ugen_factory.hpp"
 
@@ -216,8 +216,8 @@ bool sc_plugin_container::run_cmd_plugin(World* world, const char* name, struct 
 }
 
 
-void sc_ugen_factory::load_plugin_folder(boost::filesystem::path const& path) {
-    using namespace boost::filesystem;
+void sc_ugen_factory::load_plugin_folder(std::filesystem::path const& path) {
+    using namespace std::filesystem;
 
     directory_iterator end;
 
@@ -250,7 +250,7 @@ static bool check_api_version(int (*api_version)(), std::string const& filename)
 }
 
 #ifdef DLOPEN
-void sc_ugen_factory::load_plugin(boost::filesystem::path const& path) {
+void sc_ugen_factory::load_plugin(std::filesystem::path const& path) {
     using namespace std;
 
     // Ignore files that don't have the extension of an SC plugin
@@ -306,7 +306,7 @@ void sc_ugen_factory::close_handles(void) {
 
 #elif defined(_WIN32)
 
-void sc_ugen_factory::load_plugin(boost::filesystem::path const& path) {
+void sc_ugen_factory::load_plugin(std::filesystem::path const& path) {
     // Ignore files that don't have the extension of an SC plugin
     if (path.extension() != SC_PLUGIN_EXT) {
         return;

--- a/server/supernova/sc/sc_ugen_factory.hpp
+++ b/server/supernova/sc/sc_ugen_factory.hpp
@@ -177,8 +177,8 @@ public:
     uint32_t ugen_count(void) const { return ugen_count_; }
     /* @} */
 
-    void load_plugin_folder(boost::filesystem::path const& path);
-    void load_plugin(boost::filesystem::path const& path);
+    void load_plugin_folder(std::filesystem::path const& path);
+    void load_plugin(std::filesystem::path const& path);
 
 private:
     void close_handles(void);

--- a/server/supernova/server/main.cpp
+++ b/server/supernova/server/main.cpp
@@ -25,7 +25,7 @@
 #include "SC_Win32Utils.h"
 #include "SC_ServerBootDelayWarning.h"
 
-#include <boost/filesystem/path.hpp>
+#include <filesystem>
 #include <boost/algorithm/string.hpp>
 
 #include "server.hpp"

--- a/testsuite/server/supernova/sc_plugin_loader_test.cpp
+++ b/testsuite/server/supernova/sc_plugin_loader_test.cpp
@@ -2,7 +2,7 @@
 
 #include <iostream>
 
-#include <boost/filesystem.hpp>
+#include <filesystem>
 
 #include "sc/sc_ugen_factory.hpp"
 #include "server/memory_pool.hpp"
@@ -11,7 +11,7 @@
 using namespace nova;
 using namespace std;
 
-boost::filesystem::path base_path("/home/tim/workspace/nova-server/debug_plugins/");
+std::filesystem::path base_path("/home/tim/workspace/nova-server/debug_plugins/");
 
 BOOST_AUTO_TEST_CASE(ugen_factory_test_1) {
     server_arguments::initialize(0, 0);


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

With C++17, the API of [`boost::filesystem`](https://www.boost.org/doc/libs/master/libs/filesystem/doc/index.htm) has been adapted into [`std::filesystem`](https://en.cppreference.com/w/cpp/filesystem).
As SuperCollider currently already [targets C++17 officially](https://github.com/supercollider/supercollider/blob/24c716421b9fa9e3679df4e961b9433c2e1dbbd8/README.md?plain=1#L13), this PR proposes to replace `boost::filesystem` with `std::filesystem`

**Pro:**
* reduces denpendencies
* uses C++ standards which may help us in the future
* reduces compilation time in theory
* makes boost upgrades more easy and already fixes https://github.com/supercollider/supercollider/issues/5865
* As we also support system boost libraries we would need to adapt the code for boost 1.85. Recently brew updated to [boost 1.85](https://www.boost.org/users/history/version_1_85_0.html) which [failed](https://github.com/supercollider/supercollider/actions/runs/9187974816/job/25266805454#step:18:2557) our *macOS with boost system libraries* pipeline, therefore we would need to adjust the filesystem code already
  <details>
    <summary>More info</summary>
  
  The build chain *macOS with boost system libraries*  recently because of an boost-upgrade of brew which changed the  `boost::filesystem` API.
  
  ```
   /Users/runner/work/supercollider/supercollider/server/supernova/sc/sc_synth_definition.cpp:67:37: error: use of undeclared identifier 'recursive_directory_iterator'
         boost::make_iterator_range(recursive_directory_iterator(dir), recursive_directory_iterator())) {
  ```

  This is due [a change](https://www.boost.org/users/history/version_1_85_0.html) in the `boost::filesystem` API v.1.85?
  
  > On POSIX systems that support [fdopendir](https://pubs.opengroup.org/onlinepubs/9699919799/functions/fdopendir.html), openat and related APIs defined in POSIX.1-2008, as well as on Windows, `recursive_directory_iterator` now uses file descriptors/handles instead of paths to query the file statuses and open nested directories during iteration. This makes directory iteration more resilient to concurrent modifications of the filesystem.
  </details>

**Con:**
* makes C++17 support mandatory for the compiler - this drops some older compilers such as
  * g++7 - which I think is OK b/c the compiler is from 2017 and the oldest supported Debian version already uses g++8.3 [which supports](https://www.reddit.com/r/cpp/comments/7o9kg6/gcc_80_support_stdfilesystem_include_filesystem/) `std::filesystem` 
  * ~~mingw: uses an older version of g++8 which only supports C++17 in an experimental state. We can't update mingw that easily because Qt5 only supports mingw 8.1, see https://doc.qt.io/qt-5/windows.html - with a potential Qt6 upgrade it would allow us to use mingw11, see https://doc.qt.io/qt-6/windows.html. Maybe it is possible to make this available via Cmake flags but I could only test this via CI as I don't have a windows machine - any help or expertise for this platform would be great! :)~~ -> **UPDATE**: With a bump in the windows OS version from 2019->2022 this now works again.
  * We would need to drop macOS Mojave (10.14, got deprecated 2021) and below, so the next version of SuperCollider would only run on the 64bit-only macOS Catalina (10.15, released 2019) and beyond.

This is not ready for review yet and more an explicit kickstarter for a discussion.
I would be interested in still supporting mingw, maybe by switching to msys2?

~~There is also a file related test which fails `TestQuark:test_runQuarkInstallHooks`, see https://github.com/capital-G/supercollider/actions/runs/9300444791/job/25597559238#step:9:6936~~ -> Should be fixed via https://github.com/capital-G/supercollider/commit/f48ff264d17457578eb48073d7219f8db1b78f0b

A CI run based on https://github.com/supercollider/supercollider/pull/6331/commits/f48ff264d17457578eb48073d7219f8db1b78f0b with deactivated mingw can be found here https://github.com/capital-G/supercollider/actions/runs/9302363265

We could also replace `boost::container` with `std::container` in a similar manner - but this did not produce any problems so far.

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix
- Breaking change

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [ ] Updated documentation
- [ ] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
