### PR TITLE
Fix Dictionary:-trueAt to respond to all objects

### DIFF
--- a/HelpSource/Classes/Dictionary.schelp
+++ b/HelpSource/Classes/Dictionary.schelp
@@ -193,24 +193,31 @@ d.matchAt(\abc)
 ::
 
 method::trueAt
-Returns link::Classes/True:: if the item's booleanValue at the key is true, otherwise false. This method is also valid in link::Classes/Object::.
-code::
-d = (x:true, y:false);
-d.trueAt(\x) // true
-d.trueAt(\y) // false
-d.trueAt(\foo) // false
+Returns link::Classes/True:: if the item's teletype::booleanValue:: at the key is teletype::true::, otherwise teletype::false::.
 
+code::
 // using binary value equivalents
 d = (x:1, y:0);
-d.trueAt(\x) // true
-d.trueAt(\y) // false
+d.trueAt(\x)   // true
+d.trueAt(\y)   // false
 d.trueAt(\foo) // false
+
+// other kinds of objects
+d = (num: 23.7, yes:true, no:false, sym:\foo);
+d.trueAt(\num) // true
+d.trueAt(\yes) // true
+d.trueAt(\no)  // false
+d.trueAt(\sym) // false
+d.trueAt(\bar) // false (d[\bar] is nil)
 ::
 
 method::falseAt
-Returns link::Classes/False:: if the item's booleanValue at the key is not true, otherwise true. This method is inherited from link::Classes/Object::.
+Returns link::Classes/True:: if the item's teletype::booleanValue:: at the key is teletype::false::, otherwise teletype::true::.
+See link::#-trueAt:: for examples.
+
 
 subsection::Testing
+
 method::includes
 Returns true if the specified item is stored in the Dictionary as a value. Element is checked for equality (not for identity). For identity matching see subclasses: link::Classes/IdentityDictionary:: or link::Classes/Event::.
 code::

--- a/SCClassLibrary/Common/Collections/Dictionary.sc
+++ b/SCClassLibrary/Common/Collections/Dictionary.sc
@@ -23,7 +23,12 @@ Dictionary : Set {
 		^nil
 	}
 	trueAt { arg key;
-		^this.at(key).booleanValue
+		var val = this.at(key);
+		if(val.respondsTo(\booleanValue).not) { ^false };
+		^val.booleanValue
+	}
+	falseAt { arg key;
+		^this.trueAt(key).not
 	}
 	add { arg anAssociation;
 		this.put(anAssociation.key, anAssociation.value);

--- a/SCClassLibrary/Common/Core/Object.sc
+++ b/SCClassLibrary/Common/Core/Object.sc
@@ -311,9 +311,7 @@ Object  {
 
 	matchItem {|item| ^this === item }
 	trueAt { ^false }
-	falseAt { arg key;
-		^this.trueAt(key).not
-	}
+	falseAt { ^true }
 
 	pointsTo { arg obj; _ObjectPointsTo; ^this.primitiveFailed }
 	mutable { _ObjectIsMutable; ^this.primitiveFailed }


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

#6001 introduced a breaking change that answers `-trueAt` based on the receiver's `-booleanValue`. 

But `-booleanValue` is only defined for `Boolean`, `Nil`, and `SimpleNumber`, so any other object will fail.

## Steps to reproduce (actual behavior)

```supercollider

d = (num: 23.7, yes:true, no:false, symb:\bar);
d.trueAt(\num) // true
d.trueAt(\yes) // true
d.trueAt(\no) // false
d.trueAt(\foo) // false (d[\foo] is nil)
d.trueAt(\symb) // breaks

```

## Proposed behavior

The proposed solution is that `Dictionary:-trueAt` answers `false` for any object that isn't `true` or a positive `SimpleNumber` (this aligns with the initial proposal in #6001).
```supercollider
trueAt { arg key;
	^try { this.at(key).booleanValue } { false }
}
```

This lets individual kinds of objects change behavior in the future by implementing `-booleanValue`, rather than implementing `Object:-booleanValue`, which could be trickier considering a default behavior for all kinds of objects.


## Types of changes

<!-- Delete lines that don't apply -->

- Documentation
- Bug fix
- New feature
- Breaking change


Also,  `Object:-falseAt` previously took a `key` argument and passed it to `trueAt`, which has no arguments defined. This updated method has identical behavior to the previous, but is more explicit in the implementation (the proposal to change behavior is a separate issue)

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [ ] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review
