### PR TITLE
add `FULL_CHECK` flag for clang-format

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -32,6 +32,8 @@ jobs:
           python-version: '3.10'
       - uses: pre-commit/action@v3.0.0
         name: 'Run pre-commit'
+        env:
+            FULL_CHECK: 1
       - name: set version string for artifacts
         id: set-version
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
     hooks:
     -   id: clang_format
         name: Format C++ code
-        entry: python tools/clang-format.py formatall
+        entry: python tools/clang-format.py format
         pass_filenames: false
         types_or:
           - "c++"
@@ -16,7 +16,7 @@ repos:
         additional_dependencies: ['clang-format==14.0.6']
     -   id: clang_lint
         name: Lint C++ code
-        entry: python tools/clang-format.py lintall 
+        entry: python tools/clang-format.py lint
         pass_filenames: false
         types_or:
           - "c++"

--- a/tools/clang-format.py
+++ b/tools/clang-format.py
@@ -587,6 +587,20 @@ occurs.
     options.clang_format = resolve_program_name(options.clang_format, 'SC_CLANG_FORMAT', 'clang-format')
     options.clang_format_diff = resolve_program_name(options.clang_format_diff, 'SC_CLANG_FORMAT_DIFF', 'clang-format-diff.py')
 
+    # in CI we want to replace the 'lint' and 'format' command with a full scan
+    # to obtain a full stateless scan of the repository.
+    # We do this by passing an env variable, see `.pre-commit-config.yaml`
+    # and github actions workflow
+    if os.environ.get("FULL_CHECK") is not None:
+        print("Found FULL_CHECK environment variable. Perform a full scan")
+        if options.command == 'lint':
+            options.command = 'lintall'
+        elif options.command == 'format':
+            options.command = 'formatall'
+        else:
+            print("FULL_CHECK is only compatible with 'format' and 'lint' commands")
+            sys.exit(1)
+
     try:
         if options.command == 'lint' or options.command == 'format':
             commit = 'HEAD' if options.commit1 == '' else options.commit1


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

Currently pre-commit performs a full scan of the C++ files on every commit that touches them - this is necessary because we need to verify the state of the full repo in the CI and not just of the latest commit so it is not possible to "sneak in" unformatted code when pushing multiple commits.

We can assume though that for local setups it is sufficient to check only the diff staged for the current commit.
This drastically speeds up local pre-commit times (from 50 seconds down to 2 seconds).
On CI we still perform a full check of the repo. As it is not possible to pass the `--all-files` flag of the pre-commit invocation to the actual script, we use an environment variable.

Also see https://github.com/supercollider/supercollider/pull/6319#issuecomment-2159966408 and reply/below

## Types of changes

<!-- Delete lines that don't apply -->

- New feature

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [ ] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

=> Will update wiki with a note on how to perform a full scan when this gets merged

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
