### PR TITLE
SClang: typed argument checker for primitives

### DIFF
--- a/SCClassLibrary/Common/Core/Object.sc
+++ b/SCClassLibrary/Common/Core/Object.sc
@@ -954,4 +954,7 @@ Object  {
 	help {
 		this.class.asString.help
 	}
+	typedTest {|arg1, arg2, arg3, arg4, arg5|
+	    _TypedArgumentTest
+    }
 }

--- a/lang/LangPrimSource/TypedArguments.hpp
+++ b/lang/LangPrimSource/TypedArguments.hpp
@@ -1,0 +1,334 @@
+// Created by jordan on 12/06/24.
+
+#pragma once
+
+#include <optional>
+#include <array>
+#include <variant>
+#include <cstring>
+#include "PyrSlot.h"
+#include "PyrObject.h"
+#include "PyrKernel.h"
+#include "PyrSymbol.h"
+#include "VMGlobals.h"
+#include "SCBase.h"
+
+
+struct RawSlot {
+    static constexpr bool isNode = true;
+    using ReturnT = PyrSlot*;
+    static void printErrorName() {} // cannot error
+    static constexpr uint8 check(PyrSlot*) { return 1; }
+    static ReturnT asReturn(PyrSlot* slot, uint8 checkResult) { return slot; }
+};
+
+struct FloatChecker {
+    static constexpr bool isNode = true;
+    using ReturnT = double;
+    static void printErrorName() { post("Float "); }
+    static uint8 check(PyrSlot* slot) { return IsFloat(slot) ? 1 : 0; }
+    static ReturnT asReturn(PyrSlot* slot, uint8) { return slotRawFloat(slot); }
+};
+
+struct IntChecker {
+    static constexpr bool isNode = true;
+    using ReturnT = int;
+    static void printErrorName() { post("Int "); }
+    static uint8 check(PyrSlot* slot) { return IsInt(slot) ? 1 : 0; }
+    static ReturnT asReturn(PyrSlot* slot, uint8) { return slotRawInt(slot); }
+};
+
+struct SymbolChecker {
+    static constexpr bool isNode = true;
+    using ReturnT = PyrSymbol*;
+    static void printErrorName() { post("Symbol "); }
+    static uint8 check(PyrSlot* slot) { return IsSym(slot) ? 1 : 0; }
+    static ReturnT asReturn(PyrSlot* slot, uint8 checkResult) { return slotRawSymbol(slot); }
+};
+
+struct ArrayChecker {
+    static constexpr bool isNode = true;
+    using ReturnT = PyrObject*;
+    static void printErrorName() { post("Array "); }
+    static uint8 check(PyrSlot* slot) { return (IsObj(slot) && classOfSlot(slot) == class_array) ? 1 : 0; }
+    static ReturnT asReturn(PyrSlot* slot, uint8 checkResult) { return slotRawObject(slot); }
+};
+
+struct NilChecker {
+    static constexpr bool isNode = true;
+    using ReturnT = struct { uint8 empty; };
+    static void printErrorName() { post("Nil "); }
+    static uint8 check(PyrSlot* slot) { return IsNil(slot) ? 1 : 0; }
+    static ReturnT asReturn(PyrSlot* slot, uint8 checkResult) { return {}; }
+};
+
+namespace sc::priv {
+template <typename...> static constexpr auto is_unique = std::true_type {};
+
+template <typename T, typename... Rest>
+static constexpr auto is_unique<T, Rest...> =
+    std::bool_constant<(!std::is_same_v<T, Rest> && ...) && is_unique<Rest...>> {};
+}
+
+template <typename... Checkers> struct SlotContentVariant {
+    static_assert(sc::priv::is_unique<Checkers...>, "SlotContentVariant's children must be unique");
+
+    static_assert(sizeof...(Checkers) < 256);
+    static_assert(((sizeof(typename Checkers::ReturnT) <= 8) && ...));
+    static_assert((Checkers::isNode && ...));
+
+    using tupleReturns = std::tuple<typename Checkers::ReturnT...>;
+    using tupleCheckers = std::tuple<Checkers...>;
+
+    template <uint8 I> static SlotContentVariant make(std::tuple_element_t<I, tupleReturns> data) {
+        using D = std::tuple_element_t<I, tupleReturns>;
+        SlotContentVariant out(0, I);
+        std::memcpy(reinterpret_cast<D*>(&out.data), &data, sizeof(D));
+        return out;
+    }
+
+    static SlotContentVariant createUninitialized() { return { 0, 0 }; }
+
+    template <typename F> void visit(F&& f) {
+        static constexpr auto indices = std::make_index_sequence<sizeof...(Checkers)>();
+        auto&& func = std::forward<F>(f);
+        visitImpl(func, indices);
+    }
+
+    template <uint8 I> auto force() {
+        using D = std::tuple_element_t<I, tupleReturns>;
+        return *reinterpret_cast<D*>(&data);
+    }
+    template <typename T> auto force() {
+        static_assert((std::is_same_v<T, Checkers> || ...));
+        return force<indexOfType<T>()>();
+    }
+
+    template <typename T> bool holds() {
+        static_assert((std::is_same_v<T, Checkers> || ...));
+        return index == indexOfType<T>();
+    }
+
+    template <typename T> std::optional<typename T::ReturnT> tryHolds() {
+        static_assert((std::is_same_v<T, Checkers> || ...));
+        if (index == indexOfType<T>()) {
+            return { force<indexOfType<T>()>() };
+        } else {
+            return { std::nullopt };
+        }
+    }
+
+    SlotContentVariant() = delete;
+    SlotContentVariant(SlotContentVariant&&) = default;
+    SlotContentVariant(const SlotContentVariant&) = default;
+    SlotContentVariant& operator=(SlotContentVariant&&) = default;
+    SlotContentVariant& operator=(const SlotContentVariant&) = default;
+
+    template <typename T> static constexpr int32_t indexOfType() {
+        constexpr int32_t out = SlotContentVariant::indexOfTypeImpl<T>(std::make_index_sequence<sizeof...(Checkers)>());
+        return out;
+    }
+
+private:
+    SlotContentVariant(uint64 d, uint8 i): data(d), index(i) {}
+    uint64 data;
+    uint8_t index;
+
+    template <typename Type, typename I, I... ints>
+    static constexpr size_t indexOfTypeImpl(std::integer_sequence<I, ints...>) {
+        return (SlotContentVariant::indexOfTypeForEachImpl<Type, ints>() + ...);
+    }
+    template <typename Type, size_t I> static constexpr size_t indexOfTypeForEachImpl() {
+        if constexpr (std::is_same<Type, typename std::tuple_element<I, tupleCheckers>::type>::value) {
+            return I;
+        } else {
+            return 0;
+        }
+    }
+
+    template <typename F, typename T, T... ints> void visitImpl(F& f, std::integer_sequence<T, ints...>) {
+        (SlotContentVariant::visitEachImpl<ints>(f) || ...);
+    }
+    template <uint8 I, typename F> bool visitEachImpl(F& f) {
+        if (index == I) {
+            f(std::tuple_element_t<I, tupleCheckers> {}, force<I>());
+            return true;
+        } else {
+            return false;
+        }
+    }
+};
+
+template <typename Checker> struct OrNil {
+    static_assert(Checker::isNode);
+    static constexpr bool isNode = false;
+    using ReturnT = std::optional<typename Checker::ReturnT>;
+    static void printErrorName() {
+        post("Nil or ");
+        Checker::printErrorName();
+    }
+    static uint8 check(PyrSlot* slot) { return IsNil(slot) ? 2 : Checker::check(slot); }
+    static ReturnT asReturn(PyrSlot* slot, uint8 checkResult) {
+        if (checkResult == 2)
+            return std::nullopt;
+        return ReturnT(Checker::asReturn(slot, 1));
+    }
+};
+
+template <typename... Checkers> struct OrChecker {
+    static_assert(sc::priv::is_unique<Checkers...>, "OrChecker's children must be unique");
+    static_assert((Checkers::isNode && ...));
+    static constexpr bool isNode = false;
+
+    using ReturnT = SlotContentVariant<Checkers...>;
+
+    static void printErrorName() {
+        post("any of( ");
+        (Checkers::printErrorName(), ...);
+        post(") ");
+    }
+
+    static uint8 check(PyrSlot* slot) {
+        static constexpr auto indices = std::make_index_sequence<sizeof...(Checkers)>();
+        return OrChecker::checkImpl(slot, indices);
+    }
+
+    static ReturnT asReturn(PyrSlot* slot, uint8 checkResult) {
+        ReturnT out = ReturnT::createUninitialized();
+        OrChecker::asReturnImpl(slot, checkResult, std::make_index_sequence<sizeof...(Checkers)>(), out);
+        return out;
+    }
+
+private:
+    template <typename T, T... ints> static uint8 checkImpl(PyrSlot* slot, std::integer_sequence<T, ints...>) {
+        uint8 out;
+        (OrChecker::checkImplSingle<Checkers, ints>(slot, &out) || ...);
+        return out;
+    }
+
+    template <typename C, size_t I> static uint8 checkImplSingle(PyrSlot* slot, uint8* out) {
+        const auto r = C::check(slot);
+        if (r > 0) {
+            *out = static_cast<uint8>(I + 1);
+            return true;
+        }
+        return false;
+    }
+
+
+    template <typename T, T... ints>
+    static void asReturnImpl(PyrSlot* slot, uint8 checkResult, std::integer_sequence<T, ints...>, ReturnT& out) {
+        // or short circuits to the first
+        (OrChecker::asReturnForEach<Checkers, ints>(slot, checkResult, out) || ...);
+    }
+
+    template <typename C, size_t I> static bool asReturnForEach(PyrSlot* slot, uint8 checkResult, ReturnT& result) {
+        if (checkResult - 1 == I) {
+            result = ReturnT::template make<I>(C::asReturn(slot, 1));
+            return true;
+        }
+        return false;
+    }
+};
+
+
+template <typename... Checkers> class TypedArgsFromStack {
+    static constexpr size_t N = sizeof...(Checkers);
+    static constexpr auto indices = std::make_index_sequence<N>();
+    using ReturnT = std::tuple<typename Checkers::ReturnT...>;
+
+public:
+    static std::optional<ReturnT> get(VMGlobals* g, const char* primitiveName) {
+        const std::array<PyrSlot*, N> uncheckedArray = TypedArgsFromStack::getArray(indices, g);
+        const auto results = TypedArgsFromStack::checkAll(uncheckedArray, indices);
+
+        if (std::all_of(results.begin(), results.end(), [](uint8 c) { return c != 0; }))
+            return TypedArgsFromStack::getRet(uncheckedArray, indices, results);
+
+        post("Wrong argument type in primitive call to %s.\n", primitiveName);
+        TypedArgsFromStack::printErrors(uncheckedArray, indices, results);
+
+        return std::nullopt;
+    }
+
+
+private:
+    template <typename T, T... ints>
+    static ReturnT getRet(const std::array<PyrSlot*, N> array, std::integer_sequence<T, ints...>,
+                          const std::array<uint8, N> res) {
+        return { Checkers::asReturn(array[ints], res[ints])... };
+    }
+
+    template <typename T, T... ints>
+    static std::array<PyrSlot*, N> getArray(std::integer_sequence<T, ints...>, VMGlobals* g) {
+        // Supercollider's stack points (sp) points to the last element, not past it.
+        // Add one to compensate.
+        return { (g->sp - (N - (ints + 1)))... };
+    }
+
+    template <typename T, T... ints>
+    static std::array<uint8, N> checkAll(const std::array<PyrSlot*, N>& array, std::integer_sequence<T, ints...>) {
+        return { Checkers::check(array[ints])... };
+    }
+
+    template <typename T, T... ints>
+    static void printErrors(const std::array<PyrSlot*, N>& array, std::integer_sequence<T, ints...>,
+                            const std::array<uint8, N> results) {
+        (TypedArgsFromStack::printIfError<Checkers, ints>(array[ints], results[ints]), ...);
+    }
+
+    template <typename C, size_t I> static void printIfError(PyrSlot* slot, uint8 result) {
+        if (result > 0)
+            return;
+
+        post("\tArgument %d expected a ", I);
+        C::printErrorName();
+        post("but received a ");
+
+        if (IsObj(slot)) {
+            post("%s ", slotRawSymbol(&slotRawObject(slot)->classptr->name)->name);
+        } else {
+            switch (slot->tag) {
+            case tagNotInitialized:
+                post("Uninitialized Slot");
+                break;
+            case tagInt:
+                post("Int");
+                break;
+            case tagSym:
+                post("Symbol");
+                break;
+            case tagChar:
+                post("Char");
+                break;
+            case tagNil:
+                post("Nil");
+                break;
+            case tagFalse:
+                [[fallthrough]];
+            case tagTrue:
+                post("Boolean");
+                break;
+            case tagPtr:
+                post("Pointer");
+                break;
+            case tagFloat:
+                post("Float");
+                break;
+            case tagUnused:
+                post("Unused tag (please report this error on github)");
+            }
+        }
+
+        char str[128];
+        slotString(slot, str);
+        post(" with value %s.\n", str);
+    }
+};
+
+
+// Copied from cpp reference
+// helper type for the visitor #4
+template <class... Ts> struct Overloaded : Ts... { using Ts::operator()...; };
+// explicit deduction guide (not needed as of C++20)
+template <class... Ts> Overloaded(Ts...) -> Overloaded<Ts...>;


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->


## Purpose and Motivation

Managing the stack pointer is annoying. 

Making sure primitives check the types and produce good consistent errors is annoying.

Ensuring you don't overwrite a value on the stack while you are writing to it is annoying.

Here is a proposal for a solution I came up with — would love opinions!


```c++
int typedArgumentTest(struct VMGlobals* g, int numArgsPushed) {
    auto maybeArgs =
        TypedArgsFromStack<
                           FloatChecker,
                           IntChecker,
                           SymbolChecker,
                           OrNil<ArrayChecker>,
                           OrNil<FloatChecker>,
                           OrChecker<FloatChecker, IntChecker>
       >::get(g, "typedArgumentTest");

    if (!maybeArgs)
        return errWrongType;

 
    auto [arg0, arg1, arg2, arg3, arg4, arg5] = *maybeArgs;
    ...
}
```

See how IDEs can even insert type hints and giving you proper lsp support.

![0004](https://github.com/supercollider/supercollider/assets/54682166/331732c0-b98c-4dc7-8879-e0d828c1f09e)




They can then be used as expected.
```c++
    post("arg0: %f\n", arg0); // this is a double
    post("arg1: %d\n", arg1); // this is a int
    post("arg2: %s\n", arg2->name); // this is a PyrSymbol*

    if (arg3)   // an optional<PyrObject*>
        post("arg3: is an array\n");
    else
        post("arg3: is nil\n");

    if (arg4)
        post("arg4: %d\n", *arg4);  
    else
        post("arg4: is nil\n");

    // the OrChecker produces a variant.
   arg5.visit(Overloaded {
        [](FloatChecker, double f) { post("arg5 is a float: %f\n", f); },
        [](IntChecker, int i) { post("arg5 is a int: %d\n", i); },
        [](ArrayChecker, PyrObject* a) { post("arg5 is an array with size %d\n", a->size); },
    });

   if (arg5.holds<FloatChecker>())
        post("arg5: got a float: %f\n", arg5.force<FloatChecker>());
    else if (arg5.holds<IntChecker>())
        post("arg5: got a int %d\n", arg5.force<IntChecker>());
    else if (arg5.holds<ArrayChecker>())
        post("arg5: got an array with size %d\n", arg5.force<ArrayChecker>()->size);
    else
        post("arg5: falied\n");


    if (auto f = arg5.tryHolds<FloatChecker>(); f)
        post("arg5: got a float: %f\n", *f);
    else if (auto i = arg5.tryHolds<IntChecker>(); i)
        post("arg5: got an int: %d\n", *i);
    else if (auto a = arg5.tryHolds<ArrayChecker>(); a)
        post("arg5: got an array of size: %d\n", (*a)->size);
    else
        post("arg5: failed\n");


```


If the user makes a mistake only the arguments that are invalid have error messages printed.

Here is what happens when you call the above primitive with only a receiver.
```
Wrong argument type in primitive call to typedArgumentTest.
	Argument 1 expected a Int but received a Nil with value nil.
	Argument 2 expected a Symbol but received a Nil with value nil.
	Argument 5 expected a any of( Float Int ) but received a Nil with value nil.
```

Here, argument 3 and 4 are not printed because nil is a valid state for them.


This commit also contains some demo code (that would obviously be removed). 

If any one wants to try it out, you can do...
```
something.typedTest
```

Turns out the old mac doesn't support `std::visit` so the demo code I've written won't work. It might be worth writing a custom variant for this. Since we know what types it will have, its not too hard (also, I like this kind of code).

## Types of changes

- New feature

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [ ] All tests are passing
- [ ] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->
