### PR TITLE
help: SystemSynthDefs - remove EOF whitespace

### DIFF
--- a/HelpSource/Classes/SystemSynthDefs.schelp
+++ b/HelpSource/Classes/SystemSynthDefs.schelp
@@ -50,9 +50,3 @@ a.defName; // has the prefix 'temp__', followed by a number
 method::maxTempDefNames
 
 A maximum count for the numbers to add to the tempNamePrefix
-
-
-
-
-
-


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation
Just whitespace cleanup... I merged a PR without a [comment](https://github.com/supercollider/supercollider/pull/6323#discussion_r1636417548) being addressed, this addresses that.