### PR TITLE
Fix doc icon position

### DIFF
--- a/HelpSource/scdoc.css
+++ b/HelpSource/scdoc.css
@@ -137,6 +137,7 @@ a.subclass_toggle:hover {
     background-repeat: no-repeat;
     background-position: 0.5em center;
     background-size: 1.5em;
+    display: inline-block;
 }
 
 a.menu-link {
@@ -150,6 +151,10 @@ a.menu-link {
 a.menu-link:hover {
     text-decoration: none;
     color: var(--color-fg-200);
+}
+
+li.menuitem a.menu-link.home {
+    padding-left: 2.5em;
 }
 
 #menubar .menuitem .home a {

--- a/HelpSource/scdoc.css
+++ b/HelpSource/scdoc.css
@@ -128,6 +128,7 @@ a.subclass_toggle:hover {
     border-right: 1px solid var(--color-fg-100);
     font-size: 10pt;
     display: inline-block;
+    vertical-align: top;
 }
 
 #menubar .menuitem .home {
@@ -155,12 +156,6 @@ a.menu-link:hover {
 
 li.menuitem a.menu-link.home {
     padding-left: 2.5em;
-}
-
-#menubar .menuitem .home a {
-    /* The cube logo is actually *under* the <a>, but it shows through so that it looks like it
-    is part of the link. */
-    padding-left: 2em;
 }
 
 #menubar .menuitem .home a:hover {


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

Current state:
<img width="403" alt="grafik" src="https://github.com/supercollider/supercollider/assets/8267062/dfa6e5b2-12ef-49db-9b6f-5c123d9a0b61">

Fixed state:
<img width="306" alt="grafik" src="https://github.com/supercollider/supercollider/assets/8267062/cd56a359-55f7-4aa0-be41-1b41ddc693d3">

Fix was made necessary by https://github.com/supercollider/supercollider/commit/39702ec3a9cdc9a4e2ee7385db747e9ba135c3d1

Supersedes https://github.com/supercollider/supercollider/pull/6275

Thanks @prko for bringing this up and providing the impulse.

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->

- Documentation
- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
