### PR TITLE
SCLang: make slot tag fixed width integer

### DIFF
--- a/lang/LangSource/PyrSlot64.h
+++ b/lang/LangSource/PyrSlot64.h
@@ -50,7 +50,7 @@ enum {
 };
 
 typedef struct pyrslot {
-    long tag;
+    uint64 tag;
 
     union {
         int64 c; /* char */


### PR DESCRIPTION
## Purpose and Motivation

On unix `long` is 64 bits, but on windows `long` is 32. Throughout the code assumptions are made that assume the size of the `PyrSlot` to be 128bits. This makes that explicit rather than relying on alignment, which I believe was the original intention as otherwise this could easily have been a uint8.

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

This fix should change nothing, just makes the code more explicit.


## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

Can't test because of broken CI, but should work.

- [ ] Code is tested
- [ ] All tests are passing
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
