### PR TITLE
lang: LinkClock beats/secs conversion should trap 'inf'

### DIFF
--- a/lang/LangPrimSource/SC_LinkClock.cpp
+++ b/lang/LangPrimSource/SC_LinkClock.cpp
@@ -45,12 +45,14 @@ void LinkClock::SetAll(double tempo, double inBeats, double inSeconds) {
 }
 
 double LinkClock::BeatsToSecs(double beats) const {
+    if(std::isinf(beats)) return beats;
     auto sessionState = mLink.captureAppSessionState();
     double secs = linkToHrTime(sessionState.timeAtBeat(beats, mQuantum)) - mLatency;
     return secs;
 }
 
 double LinkClock::SecsToBeats(double secs) const {
+    if(std::isinf(secs)) return secs;
     auto sessionState = mLink.captureAppSessionState();
     double beats = sessionState.beatAtTime(hrToLinkTime(secs + mLatency), mQuantum);
     return beats;

--- a/lang/LangPrimSource/SC_LinkClock.cpp
+++ b/lang/LangPrimSource/SC_LinkClock.cpp
@@ -45,14 +45,16 @@ void LinkClock::SetAll(double tempo, double inBeats, double inSeconds) {
 }
 
 double LinkClock::BeatsToSecs(double beats) const {
-    if(std::isinf(beats)) return beats;
+    if(std::isinf(beats))
+        return beats;
     auto sessionState = mLink.captureAppSessionState();
     double secs = linkToHrTime(sessionState.timeAtBeat(beats, mQuantum)) - mLatency;
     return secs;
 }
 
 double LinkClock::SecsToBeats(double secs) const {
-    if(std::isinf(secs)) return secs;
+    if(std::isinf(secs))
+        return secs;
     auto sessionState = mLink.captureAppSessionState();
     double beats = sessionState.beatAtTime(hrToLinkTime(secs + mLatency), mQuantum);
     return beats;

--- a/lang/LangPrimSource/SC_LinkClock.cpp
+++ b/lang/LangPrimSource/SC_LinkClock.cpp
@@ -45,7 +45,7 @@ void LinkClock::SetAll(double tempo, double inBeats, double inSeconds) {
 }
 
 double LinkClock::BeatsToSecs(double beats) const {
-    if(std::isinf(beats))
+    if (std::isinf(beats))
         return beats;
     auto sessionState = mLink.captureAppSessionState();
     double secs = linkToHrTime(sessionState.timeAtBeat(beats, mQuantum)) - mLatency;
@@ -53,7 +53,7 @@ double LinkClock::BeatsToSecs(double beats) const {
 }
 
 double LinkClock::SecsToBeats(double secs) const {
-    if(std::isinf(secs))
+    if (std::isinf(secs))
         return secs;
     auto sessionState = mLink.captureAppSessionState();
     double beats = sessionState.beatAtTime(hrToLinkTime(secs + mLatency), mQuantum);

--- a/testsuite/classlibrary/TestLinkClock.sc
+++ b/testsuite/classlibrary/TestLinkClock.sc
@@ -339,4 +339,24 @@ TestLinkClock : UnitTest {
 		clock1.stop;
 		clock2.stop;
 	}
+
+	test_beats2secs_handlesInf {
+		var clock = LinkClock.new;
+		this.assertEquals(
+			clock.beats2secs(inf), inf,
+			"LinkClock:beats2secs should return inf for 'inf' beats"
+		);
+		clock.stop;
+	}
+
+	test_secs2beats_handlesInf {
+		var clock = LinkClock.new;
+		this.assertEquals(
+			clock.secs2beats(inf), inf,
+			"LinkClock:secs2beats should return inf for 'inf' beats"
+		);
+		clock.stop;
+	}
+
+
 }

--- a/testsuite/classlibrary/TestTempoClock.sc
+++ b/testsuite/classlibrary/TestTempoClock.sc
@@ -56,6 +56,23 @@ TestTempoClock : UnitTest {
 		)
 	}
 
+	// note: *not* assertFloatEquals
+	// because inf - inf < within is always false,
+	// while inf == inf is always true
+	test_beats2secs_handlesInf {
+		this.assertEquals(
+			clock.beats2secs(inf), inf,
+			"TempoClock:beats2secs should return inf for 'inf' beats"
+		)
+	}
+
+	test_secs2beats_handlesInf {
+		this.assertEquals(
+			clock.secs2beats(inf), inf,
+			"TempoClock:secs2beats should return inf for 'inf' beats"
+		)
+	}
+
 	test_beatsPerBar_defaultIs4 {
 		this.assertEquals(
 			clock.beatsPerBar, 4,


### PR DESCRIPTION
## Purpose and Motivation

Fixes #6355.

For compatibility with TempoClock, beats2secs(inf) and secs2beats(inf) should return inf (and, -inf --> -inf).

## Types of changes

- Bug fix (I believe it's a regression -- critical bug for my live coding system actually, it breaks slurring notes)

## To-do list

- [x] Code is tested
- [x] All tests are passing
- ~~ [ ] Updated documentation~~
- [x] This PR is ready for review
