### PR TITLE
Skip verify on macOS universal CI

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -208,7 +208,7 @@ jobs:
             build-readline: false
             build-fftw: false
             artifact-suffix: 'macOS-universal'
-            verify-app: true
+            verify-app: false
 
           - job-name: 'x64 legacy'
             os-version: '12'


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

A **temporary** fix for building the macOS universal binary, see #6352 
Supersedes https://github.com/supercollider/supercollider/pull/6357 which deactivated the build completely, here we just de-activate the verifying step during build macOS - I am surprised that the binary can be picked up by a different runner for testing though.

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix
- 
## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [ ] Code is tested
- [ ] All tests are passing
- [ ] Updated documentation
- [ ] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
