### PR TITLE
UnitTest.schelp - fix typo

### DIFF
--- a/HelpSource/Classes/UnitTest.schelp
+++ b/HelpSource/Classes/UnitTest.schelp
@@ -8,7 +8,7 @@ In order to make sure a method works correctly, a test can be implemented that a
 
 It is a common practice to write tests to clarify how an object should respond, and it may avoid inconsistencies on the long run. A test is always a subclass of code::UnitTest::, implementing at least one method starting with code::test_::.
 
-When running all tests of one class (see link::#run::), each test method is called in a separate instance of this class. Test methods, therefore, do not interfere with each other.
+When running all tests of one class (see link::#*run::), each test method is called in a separate instance of this class. Test methods, therefore, do not interfere with each other.
 
 note::
 UnitTests for the Common library classes are kept in the code::testsuite/classlibrary:: directory of the SuperCollider sources.


### PR DESCRIPTION
## Purpose and Motivation
While reading `UnitTest` documentation, I found a typo in a link. This is fixed.
## Types of changes

<!-- Delete lines that don't apply -->

- Documentation

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [ ] Code is tested
- [ ] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
