### PR TITLE
Isolate Github release process in a separate workflow

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -38,63 +38,46 @@ jobs:
         env:
           FULL_CHECK: 1
 
-  version-getter:
-    runs-on: ubuntu-22.04
-    outputs:
-      sc-version: ${{ steps.set-version.outputs.version }}
-
-    steps:
-      - name: set version string for artifacts
-        id: set-version
-        run: |
-          if [[ "$GITHUB_REF" == refs/tags/* ]]; then
-            FULL_TAG=${GITHUB_REF#refs/tags/}
-            SC_VERSION=${FULL_TAG##Version-}
-          else
-            SC_VERSION=$GITHUB_SHA
-          fi
-          echo "version=$SC_VERSION" >> $GITHUB_OUTPUT
-
   build-linux:
-    needs: [lint, version-getter]
+    needs: [lint]
     uses: ./.github/workflows/build_linux.yml
     with:
-      sc-version: ${{ needs.version-getter.outputs.sc-version }}
+      sc-version: ${{ github.sha }}
     secrets: inherit
 
   build-macos:
-    needs: [lint, version-getter]
+    needs: [lint]
     uses: ./.github/workflows/build_macos.yml
     with:
-      sc-version: ${{ needs.version-getter.outputs.sc-version }}
+      sc-version: ${{ github.sha }}
     secrets: inherit
 
   build-windows:
-    needs: [lint, version-getter]
+    needs: [lint]
     uses: ./.github/workflows/build_windows.yml
     with:
-      sc-version: ${{ needs.version-getter.outputs.sc-version }}
+      sc-version: ${{ github.sha }}
     secrets: inherit
 
   test-linux:
-    needs: [version-getter, build-linux]
+    needs: [build-linux]
     uses: ./.github/workflows/test_linux.yml
     with:
-      artifact-file: "SuperCollider-${{ needs.version-getter.outputs.sc-version }}-linux-jammy-gcc12"
+      artifact-file: SuperCollider-${{ github.sha }}-linux-jammy-gcc12
     secrets: inherit
 
   test-macos:
-    needs: [version-getter, build-macos]
+    needs: [build-macos]
     uses: ./.github/workflows/test_macos.yml
     with:
-      artifact-file: "SuperCollider-${{ needs.version-getter.outputs.sc-version }}-macOS-universal.dmg"
+      artifact-file: SuperCollider-${{ github.sha }}-macOS-universal.dmg
     secrets: inherit
 
   # test-windows:
-  #   needs: [version-getter, build-windows]
+  #   needs: [build-windows]
   #   uses: ./.github/workflows/test_windows.yml
   #   with:
-  #     artifact-file: "SuperCollider-${{ needs.version-getter.outputs.sc-version }}-win64"
+  #     artifact-file: SuperCollider-${{ github.sha }}-win64
   #   secrets: inherit
 
   deploy_s3:
@@ -122,12 +105,12 @@ jobs:
             s3-create-latest-link: true # create link to pointing to the "latest" build
 
     if: github.repository_owner == 'supercollider' && github.event_name != 'pull_request' # run in the main repo, but not on pull requests
-    needs: [lint, version-getter, build-macos, build-windows]
+    needs: [lint, build-macos, build-windows]
     runs-on: ubuntu-latest
     name: 'deploy ${{ matrix.artifact-suffix }} to s3'
     env:
       INSTALL_PATH: ${{ github.workspace }}/build/Install
-      ARTIFACT_FILE: SuperCollider-${{ needs.version-getter.outputs.sc-version }}-${{ matrix.artifact-suffix }}${{ matrix.artifact-extension }}
+      ARTIFACT_FILE: SuperCollider-${{ github.sha }}-${{ matrix.artifact-suffix }}${{ matrix.artifact-extension }}
       UPLOAD_TO_S3: ${{ (secrets.S3_ACCESS_KEY_ID != 0) && !startsWith(github.ref, 'refs/tags/') }}
       S3_CREATE_LATEST_LINK: ${{ matrix.s3-create-latest-link && (secrets.S3_ACCESS_KEY_ID != 0) && startsWith(github.ref, 'refs/heads/') }}
       S3_ARTIFACT_PATH: ${{ github.workspace }}/build/s3-upload
@@ -191,33 +174,3 @@ jobs:
           echo $S3_BUILD_URL
           if [[ -n "$LATEST_HTML_URL" ]]; then echo $LATEST_HTML_URL; fi
           echo "::endgroup::"
-
-  # release - list of files uploaded to GH release is specified in the *upload* step
-  deploy_gh:
-    if: startsWith(github.ref, 'refs/tags/') # run on tagged commits
-    needs: [lint, version-getter, build-macos, build-windows]
-    runs-on: ubuntu-latest
-    name: 'deploy release'
-    env:
-      INSTALL_PATH: ${{ github.workspace }}/Install
-      ARTIFACT_FILE_PREFIX: 'SuperCollider-${{ needs.version-getter.outputs.sc-version }}'
-    steps:
-      - name: download artifacts
-        uses: actions/download-artifact@v4
-        with:
-          path: ${{ env.INSTALL_PATH }} # no "name" paramter - download all artifacts
-      - name: upload to the release page
-        uses: softprops/action-gh-release@v1
-        with:
-          files: |
-            ${{ env.INSTALL_PATH }}/${{ env.ARTIFACT_FILE_PREFIX }}-macOS-x64.dmg/*
-            ${{ env.INSTALL_PATH }}/${{ env.ARTIFACT_FILE_PREFIX }}-macOS-universal.dmg/*
-            ${{ env.INSTALL_PATH }}/${{ env.ARTIFACT_FILE_PREFIX }}-macOS-arm64.dmg/*
-            ${{ env.INSTALL_PATH }}/${{ env.ARTIFACT_FILE_PREFIX }}-macOS-x64-legacy.dmg/*
-            ${{ env.INSTALL_PATH }}/${{ env.ARTIFACT_FILE_PREFIX }}-win32-installer/*
-            ${{ env.INSTALL_PATH }}/${{ env.ARTIFACT_FILE_PREFIX }}-win64-installer/*
-            ${{ env.INSTALL_PATH }}/${{ env.ARTIFACT_FILE_PREFIX }}-win32/*
-            ${{ env.INSTALL_PATH }}/${{ env.ARTIFACT_FILE_PREFIX }}-win64/*
-          draft: true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,67 @@
+name: Release on Github
+on:
+  push:
+    tags:
+      - Version-[0-9]+.[0-9]+.[0-9]+*
+
+jobs:
+  version-getter:
+    runs-on: ubuntu-22.04
+    outputs:
+      sc-version: ${{ steps.set-version.outputs.version }}
+
+    steps:
+      - name: set version string for artifacts
+        id: set-version
+        run: |
+          SC_VERSION="${${{ github.ref_name }}##Version-}"
+          echo "version=$SC_VERSION" >> "$GITHUB_OUTPUT"
+
+  build-linux:
+    needs: [version-getter]
+    uses: ./.github/workflows/build_linux.yml
+    with:
+      sc-version: ${{ needs.version-getter.outputs.sc-version }}
+    secrets: inherit
+
+  build-macos:
+    needs: [version-getter]
+    uses: ./.github/workflows/build_macos.yml
+    with:
+      sc-version: ${{ needs.version-getter.outputs.sc-version }}
+    secrets: inherit
+
+  build-windows:
+    needs: [version-getter]
+    uses: ./.github/workflows/build_windows.yml
+    with:
+      sc-version: ${{ needs.version-getter.outputs.sc-version }}
+    secrets: inherit
+
+  github-release:
+    name: "Create GitHub release"
+    needs: [version-getter, build-linux, build-macos, build-windows]
+    runs-on: ubuntu-latest
+    env:
+      INSTALL_PATH: ${{ github.workspace }}/Install
+      ARTIFACT_FILE_PREFIX: SuperCollider-${{ needs.version-getter.outputs.sc-version }}
+    steps:
+      - name: Download release artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: ${{ env.INSTALL_PATH }} # no "name" paramter - download all artifacts
+
+      - name: Create and upload release files
+        uses: softprops/action-gh-release@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          files: |
+            ${{ env.INSTALL_PATH }}/${{ env.ARTIFACT_FILE_PREFIX }}-macOS-x64.dmg/*
+            ${{ env.INSTALL_PATH }}/${{ env.ARTIFACT_FILE_PREFIX }}-macOS-universal.dmg/*
+            ${{ env.INSTALL_PATH }}/${{ env.ARTIFACT_FILE_PREFIX }}-macOS-arm64.dmg/*
+            ${{ env.INSTALL_PATH }}/${{ env.ARTIFACT_FILE_PREFIX }}-macOS-x64-legacy.dmg/*
+            ${{ env.INSTALL_PATH }}/${{ env.ARTIFACT_FILE_PREFIX }}-win32-installer/*
+            ${{ env.INSTALL_PATH }}/${{ env.ARTIFACT_FILE_PREFIX }}-win64-installer/*
+            ${{ env.INSTALL_PATH }}/${{ env.ARTIFACT_FILE_PREFIX }}-win32/*
+            ${{ env.INSTALL_PATH }}/${{ env.ARTIFACT_FILE_PREFIX }}-win64/*
+          draft: true


### PR DESCRIPTION
## Purpose and Motivation

This PR moves the release process in a separate workflow from `actions.yml`.

This enhances the process so it's clear that only pushing a `Version-` prefixed tag will trigger the release process. With the current solution any tag would have a triggered a release as the check `startsWith(github.ref, 'refs/tags/')` doesn't verify the tag format.

Also since `actions.yml` is trigger on push, PRs and on a schedule it could have been possible to trigger a release multiple times by mistake. That's a really slim chance but it could have still have happened. 

Another problem could have happened if a tag is pushed long after the push that triggers `actions.yml`, at that point the release would have been skipped since the version from the `version-getter` would be simply the commit hash.

This change also made it possible to simplify a bit the logic in `actions.yml` as only the commit hash is now necessary to create the test binaries.

I decided not to run tests in the `release.yml` as I would expect whoever handles the release to tag only commits with passing checks.

--- 

I have not moved the release on S3 as I'm unsure what are the expectations of that job. I left a comment about this in [#6340](https://github.com/supercollider/supercollider/issues/6340#issuecomment-2194386306), let's discuss there.