### PR TITLE
SCLang: use likely and unlikely attributes for a performance boost

### DIFF
--- a/lang/LangSource/GC.h
+++ b/lang/LangSource/GC.h
@@ -303,7 +303,7 @@ inline void PyrGC::ToGrey2(PyrObjectHdr* obj) {
 }
 
 inline PyrObject* PyrGC::Allocate(size_t inNumBytes, int32 sizeclass, bool inRunCollection) {
-    if (inRunCollection && mNumToScan >= kScanThreshold)
+    if (inRunCollection && mNumToScan >= kScanThreshold) [[unlikely]]
         Collect();
     else {
         if (inRunCollection)
@@ -315,7 +315,7 @@ inline PyrObject* PyrGC::Allocate(size_t inNumBytes, int32 sizeclass, bool inRun
     GCSet* gcs = mSets + sizeclass;
 
     PyrObject* obj = (PyrObject*)gcs->mFree;
-    if (!IsMarker(obj)) {
+    if (!IsMarker(obj)) [[likely]] {
         // from free list
         gcs->mFree = obj->next;
         assert(obj->obj_sizeclass == sizeclass);

--- a/lang/LangSource/GC.h
+++ b/lang/LangSource/GC.h
@@ -303,9 +303,9 @@ inline void PyrGC::ToGrey2(PyrObjectHdr* obj) {
 }
 
 inline PyrObject* PyrGC::Allocate(size_t inNumBytes, int32 sizeclass, bool inRunCollection) {
-    if (inRunCollection && mNumToScan >= kScanThreshold) [[unlikely]]
+    if (inRunCollection && mNumToScan >= kScanThreshold) [[unlikely]] {
         Collect();
-    else {
+    } else {
         if (inRunCollection)
             mUncollectedAllocations = 0;
         else


### PR DESCRIPTION
Measured at anywhere between a 5 and 19 percent boost!! No regressions encountered.


<details><summary>Using this benchmark</summary>
<p>

```
~b = { |func|
	var n = 1000;
	var f = n.collect {
		func.bench(false)
	};

	(f.sum / n).postln;
};

~b.({
	var e = ();
	10000.do{ |i|
		var n = 10000.rand;
		if(e[n.asSymbol].isNil) {
			e[n.asSymbol] = ();
		} {
			e[n.asSymbol][i.asSymbol] = n
		}
	};
});

~b.({
	10000.collect( _ * 2 );
});

~b.({
	10000.collect({|n| n.asFloat * 2.0 });
});

~b.({
	10000
	.collect(Ref(_))
	.collect(_.value)
	.collect(Ref(_))
	.collect(_.value)
	.collect(Ref(_))
	.collect(_.value)
	.collect(_.asString)
	.collect(_.asArray)
	.collect(_.asInteger)
	.sum
	;
});

~b.({
	var p = Pwhite().asStream;
	Array.fill(10000, {p.next})
});


"done";

```


</p>
</details> 

I saw the following performance increases:
```
17%
8%
5%
15%
19%
```
Linux GCC.
I think these are too good and I'm currently doing some more benchmarks to get a better value, but it is some improvement.

Pretty compelling for such a simple change. Would be great if others could test this!

## Types of changes

- C++ attributes, no functional changes.

I've added unlikely on the error path, and likely on the message lookup case because other op codes jumps to it with a `goto`. Also added this to the GC preferring when memory is recycled.

## To-do list



- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

