### PR TITLE
SCLang: fix performArgs, wrong type was assumed as default.

### DIFF
--- a/lang/LangSource/PyrMessage.cpp
+++ b/lang/LangSource/PyrMessage.cpp
@@ -473,8 +473,10 @@ void prepareArgsForExecute(VMGlobals* g, PyrBlock* block, PyrFrame* callFrame, l
 
     // Put var arg array or default on stack.
     if (methHasVarArg) {
-        SetObject(outCallFrameStack + methNumNormArgs,
-                  variableArgumentsArray ? variableArgumentsArray : slotRawObject(&proto->slots[methNumNormArgs]));
+        if (variableArgumentsArray)
+            SetObject(outCallFrameStack + methNumNormArgs, variableArgumentsArray);
+        else
+            slotCopy(outCallFrameStack + methNumNormArgs, proto->slots + methNumNormArgs);
     }
 
     // Put var kwarg array or default on stack.
@@ -483,7 +485,7 @@ void prepareArgsForExecute(VMGlobals* g, PyrBlock* block, PyrFrame* callFrame, l
             keywordArgumentsArray->size = keywordArgumentSize;
             SetObject(outCallFrameStack + methNumNormArgs + 1, keywordArgumentsArray);
         } else {
-            SetObject(outCallFrameStack + methNumNormArgs + 1, slotRawObject(&proto->slots[methNumNormArgs + 1]));
+            slotCopy(outCallFrameStack + methNumNormArgs + 1, proto->slots + methNumNormArgs + 1);
         }
     }
 

--- a/testsuite/classlibrary/TestKwargs.sc
+++ b/testsuite/classlibrary/TestKwargs.sc
@@ -54,4 +54,45 @@ TestKwargs : UnitTest {
             (a: 1, b: 2, c: 3, args: [4], kwargs: [\foo, 10])
         );
     }
+
+    test_wrappers {
+        var inlined = { |func|
+        	{ |...args, kwargs|
+        		func.performArgs(\value, args, kwargs)
+        	}
+        };
+        var asVar = { |func|
+        	{ |...args, kwargs|
+        		var val = func.performArgs(\value, args, kwargs);
+        		val
+        	}
+        };
+
+        this.assertEquals(
+         inlined.({ |a, b=100, c| [a, b, c] }).([1, 2]),
+         [[1, 2], 100, nil]
+        );
+        this.assertEquals(
+         asVar.({ |a, b=100, c| [a, b, c] }).([1, 2]),
+         [[1, 2], 100, nil]
+        );
+
+        this.assertEquals(
+         inlined.({ |a, b=100, c| [a, b, c] }).([1, 2], 42),
+         [[1, 2], 42, nil]
+        );
+        this.assertEquals(
+         asVar.({ |a, b=100, c| [a, b, c] }).([1, 2], 42),
+         [[1, 2], 42, nil]
+        );
+
+        this.assertEquals(
+         inlined.({ |a, b=100, c| [a, b, c] }).([1, 2], 42, c: 23),
+         [[1, 2], 42, 23]
+        );
+        this.assertEquals(
+         asVar.({ |a, b=100, c| [a, b, c] }).([1, 2], 42, c: 23),
+         [[1, 2], 42, 23]
+        );
+    }
 }


### PR DESCRIPTION
Use slotCopy rather than SetObject as the default for kwargs is nil, not an empty array.

<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

Quick fix for bug found by @telephon.
```
(
~forwardCrash = { |func|
	{ |...args, kwargs|
		var val = func.performArgs(\value, args, kwargs);
		val
	}
};

~forwardWorks = { |func|
	{ |...args, kwargs|
		func.performArgs(\value, args, kwargs)
	}
};

~forwardWorks2 = { |func|
	{ |...args|
		func.performList(\value, args)
	}
};
)

f = ~forwardWorks.({ |a, b=100, c| [a, b, c] });
f.([1, 2])


f = ~forwardWorks2.({ |a, b=100, c| [a, b, c] });
f.([1, 2])


f = ~forwardCrash.({ |a, b=100, c| [a, b, c] }); // crashes.
f.([1, 2])

// while this is fine:



(
f = { |...args, kwargs|
	{ |a, b, c| [a, b=100, c] }.performArgs(\value, args, kwargs)
};
f.([1, 2])
)


```

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
