### PR TITLE
Add ClassTree to the Indexes of SCDoc Top Menu

### DIFF
--- a/HelpSource/scdoc.js
+++ b/HelpSource/scdoc.js
@@ -170,7 +170,7 @@ function fixTOC() {
         var indexes_menu = $("<div>", {class: "submenu"}).hide()
             .appendTo(li);
 
-        var nav_items = ["Documents", "Classes", "Methods"];
+        var nav_items = ["Documents", "Classes", "ClassTree", "Methods"];
         nav_items.forEach(function (item) {
             $("<a>", {
                 text: item,


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

I sometimes need an overview of class trees, and I think instant and direct access via the indexes at the top of the SCDoc menu would not be bad.

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->

- New feature
![Screenshot 2024-07-14 at 15 22 10](https://github.com/user-attachments/assets/3b7af0ab-d312-417e-b170-6adbcaed63f9)

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [ ] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
