### PR TITLE
add clipInsert method to ArrayedCollection and List

### DIFF
--- a/HelpSource/Classes/Array.schelp
+++ b/HelpSource/Classes/Array.schelp
@@ -81,6 +81,8 @@ copymethod:: ArrayedCollection -put
 
 copymethod:: ArrayedCollection -insert
 
+copymethod:: ArrayedCollection -clipInsert
+
 copymethod:: ArrayedCollection -clipAt
 
 copymethod:: ArrayedCollection -wrapAt

--- a/HelpSource/Classes/ArrayedCollection.schelp
+++ b/HelpSource/Classes/ArrayedCollection.schelp
@@ -247,6 +247,30 @@ y.postln;
 )
 ::
 
+method::clipInsert
+Inserts the item into the contents of the receiver, maintaining the size of the receiver. This method may return a new ArrayedCollection. For this reason, you should always assign the result of code::insert:: to a variable - never depend on add changing the receiver.
+code::
+~array = [10, 20, 30]
+~array_modified = ~array.clipInsert(0, 1)
+~array
+~array_modified
+
+~array = [10, 20, 30]
+~array_modified = ~array.clipInsert(1, 1)
+~array
+~array_modified
+
+~array = [10, 20, 30]
+~array_modified = ~array.clipInsert(2, 1)
+~array
+~array_modified
+
+~array = [10, 20, 30]
+~array_modified = ~array.clipInsert(3, 1)
+~array
+~array_modified
+::
+
 method::move
 Moves an item from one position to another.
 

--- a/HelpSource/Classes/List.schelp
+++ b/HelpSource/Classes/List.schelp
@@ -100,6 +100,31 @@ Inserts the strong::item:: at the beginning of the List.
 
 method::insert
 Inserts the strong::item:: into the contents of the List at the indicated strong::index::.
+code::
+~list = List[10, 20, 30, 40]
+~list.insert(0, 1)
+~list
+::
+
+method::clipInsert
+Inserts the strong::item:: into the contents of the List at the indicated strong::index::, maintaining the size of the List.
+code::
+~list = List[10, 20, 30, 40]
+~list.clipInsert(0, 1)
+~list
+
+~list = List[10, 20, 30, 40]
+~list.clipInsert(2, 1)
+~list
+
+~list = List[10, 20, 30, 40]
+~list.clipInsert(3, 1)
+~list
+
+~list = List[10, 20, 30, 40]
+~list.clipInsert(10, 1)
+~list
+::
 
 method::pop
 Remove and return the last element of the List.

--- a/SCClassLibrary/Common/Collections/ArrayedCollection.sc
+++ b/SCClassLibrary/Common/Collections/ArrayedCollection.sc
@@ -183,6 +183,11 @@ ArrayedCollection : SequenceableCollection {
 		_ArrayInsert
 		^this.primitiveFailed;
 	}
+	clipInsert { arg index, item;
+		var lastIndex = this.size - 1;
+		index = if(index > lastIndex) { lastIndex } { index };
+		^this.insert(index, item)[0..lastIndex]
+	}
 	move { arg fromIndex, toIndex;
 		^this.insert(toIndex, this.removeAt(fromIndex))
 	}

--- a/SCClassLibrary/Common/Collections/List.sc
+++ b/SCClassLibrary/Common/Collections/List.sc
@@ -48,6 +48,10 @@ List : SequenceableCollection {
 	add { arg item; array = array.add(item); }
 	addFirst { arg item; array = array.addFirst(item); }
 	insert { arg index, item; array = array.insert(index, item); }
+	clipInsert { arg index, item;
+		var lastIndex = this.size - 1;
+		index = if(index > lastIndex) { lastIndex } { index };
+		array = array.insert(index, item)[0..lastIndex] }
 	removeAt { arg index; ^array.removeAt(index); }
 	pop { ^array.pop }
 	first { if (this.size > 0, { ^array.at(0) }, { ^nil }) }


### PR DESCRIPTION
- add clipInsert method to ArrayedCollection and List
- update documentation for ArrayedCollection, Array and List

<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation
After seeing the following thread on the scsynth forum,
https://scsynth.org/t/list-array-expansion-question/9808/8
I think the necessity of the `.clipInsert` method for `ArrayedCollection` and `List`.

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->

- Documentation
- New feature
- 
## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
