### PR TITLE
SCLang: add keywords to newCopyArgs as constructors are messy with many instance variables

### DIFF
--- a/HelpSource/Classes/Object.schelp
+++ b/HelpSource/Classes/Object.schelp
@@ -50,29 +50,36 @@ method::newCopyArgs
 
 Creates a new instance and copies the arguments to the instance variables in the order that the variables were defined.
 
-Importantly, super class constructors and NOT called, but the first values will be copied.
-Think of instance variables as entries in an array,
-the super class's instance variables are at the beginning and the child class's at the end,
-this method only copies the arguments into that array.
+Importantly, superclass constructors are NOT called, but the values are still placed in the superclass's instance variables.
 
 code::
 MyClass {
 	var a, b, c;
     // Will copy arg1, arg2, arg3 to variables a, b, c.
 	*new { |arg1, arg2, arg3| ^super.newCopyArgs(arg1, arg2, arg3) }
+	*newKw { |arg1| ^super.newCopyArgs(arg1, c: 10) }
 	value { ^[a, b, c] }
 }
-MyClass(1, 2, 3).() == [1, 2, 3]
+MyClass.new(1, 2, 3).value() == [1, 2, 3];
+MyClass.newKw(1).value() == [1, nil, 10];
 ::
 
+Example of inheritance.
 code::
-MyClass {
+Base {
 	var a, b, c;
-    // Also supports keyword arguments, unassigned variables default to nil.
-	*new { |arg1| ^super.newCopyArgs(arg1, c: 10) }
-	value { ^[a, b, c] }
+	*new { ^\didNotCallBase } // This is NEVER called
 }
-MyClass(1).() == [1, nil, 10]
+
+Derived : Base {
+    var d, e, f;
+    *new { |d, e, f| ^super.newCopyArgs(1, 2, 3, d, e, f) }
+    *newKw { |d, e, f| ^super.newCopyArgs(c: 3, d: d, e: e, f: f) }
+	value { ^[a, b, c, d, e, f] }
+}
+
+Derived.new(10, 11, 12).value() == [1, 2, 3, 10, 11, 12];
+Derived.newKw(10, 11, 12).value() == [nil, nil, 3, 10, 11, 12];
 ::
 
 

--- a/HelpSource/Classes/Object.schelp
+++ b/HelpSource/Classes/Object.schelp
@@ -50,7 +50,7 @@ method::newCopyArgs
 
 Creates a new instance and copies the arguments to the instance variables in the order that the variables were defined.
 
-Importantly, superclass constructors are NOT called, but the values are still placed in the superclass's instance variables.
+Importantly, superclass constructors are NOT called, but the values are directly placed in the superclass's instance variables.
 
 code::
 MyClass {

--- a/HelpSource/Classes/Object.schelp
+++ b/HelpSource/Classes/Object.schelp
@@ -48,19 +48,33 @@ Create a new instance. The creation of new instances of any Object actually happ
 
 method::newCopyArgs
 
-Creates a new instance and copies the arguments to the instance variables in the order that the variables were defined. If the superclass's code::new:: method requires arguments, the first arguments passed to code::newCopyArgs:: will be passed on to that method, and the following arguments will be copied to this class's instance variables. Class variables are ignored.
+Creates a new instance and copies the arguments to the instance variables in the order that the variables were defined.
+
+Importantly, super class constructors and NOT called, but the first values will be copied.
+Think of instance variables as entries in an array,
+the super class's instance variables are at the beginning and the child class's at the end,
+this method only copies the arguments into that array.
 
 code::
 MyClass {
 	var a, b, c;
-
-	*new {
-		arg arg1, arg2, arg3;
-		// will copy arg1, arg2, arg3 to variables a, b, c
-		^super.newCopyArgs(arg1, arg2, arg3);
-	}
+    // Will copy arg1, arg2, arg3 to variables a, b, c.
+	*new { |arg1, arg2, arg3| ^super.newCopyArgs(arg1, arg2, arg3) }
+	value { ^[a, b, c] }
 }
+MyClass(1, 2, 3).() == [1, 2, 3]
 ::
+
+code::
+MyClass {
+	var a, b, c;
+    // Also supports keyword arguments, unassigned variables default to nil.
+	*new { |arg1| ^super.newCopyArgs(arg1, c: 10) }
+	value { ^[a, b, c] }
+}
+MyClass(1).() == [1, nil, 10]
+::
+
 
 instancemethods::
 private::addFunc, addFuncTo, removeFunc, removeFuncFrom

--- a/SCClassLibrary/Common/Audio/SynthDef.sc
+++ b/SCClassLibrary/Common/Audio/SynthDef.sc
@@ -33,9 +33,13 @@ SynthDef {
 		synthDefDir.mkdir;
 	}
 
-	*new { arg name, ugenGraphFunc, rates, prependArgs, variants, metadata;
-		^super.newCopyArgs(name.asSymbol).variants_(variants).metadata_(metadata ?? {()}).children_(Array.new(64))
-			.build(ugenGraphFunc, rates, prependArgs)
+	*new { |name, ugenGraphFunc, rates, prependArgs, variants, metadata|
+	    ^super.newCopyArgs(
+	        name: name.asSymbol,
+	        variants: variants,
+	        metadata: metadata ?? {()},
+	        children: Array(64)
+        ).build(ugenGraphFunc, rates, prependArgs)
 	}
 
 	storeArgs { ^[name, func] }

--- a/SCClassLibrary/Common/Core/Object.sc
+++ b/SCClassLibrary/Common/Core/Object.sc
@@ -11,13 +11,9 @@ Object {
 		// to actually put things in the object you need to
 		// add them.
 	}
-	*newCopyArgs { arg ... args;
+	*newCopyArgs { | ... args, kwargs |
 		_BasicNewCopyArgsToInstVars
 		^this.primitiveFailed
-		// creates a new instance that can hold up to maxSize
-		// indexable slots. the indexed size will be zero.
-		// to actually put things in the object you need to
-		// add them.
 	}
 
 	// debugging and diagnostics

--- a/lang/LangSource/PyrParseNode.cpp
+++ b/lang/LangSource/PyrParseNode.cpp
@@ -1455,7 +1455,12 @@ void PyrMethodNode::compile(PyrSlot* result) {
                     PyrCallNode* cnode;
                     PyrClass* specialClass = nullptr;
                     cnode = (PyrCallNode*)xnode;
-                    methType = compareCallArgs(this, cnode, &specialIndex, &specialClass);
+                    // The optimization breaks when there are keyword arguments in the call.
+                    if (cnode->mKeyarglist) {
+                        methType = methNormal;
+                    } else {
+                        methType = compareCallArgs(this, cnode, &specialIndex, &specialClass);
+                    }
                     if (methType != methNormal) {
                         methraw->specialIndex = specialIndex;
                         method->selectors = cnode->mSelector->mSlot;

--- a/testsuite/classlibrary/TestConstructor.sc
+++ b/testsuite/classlibrary/TestConstructor.sc
@@ -1,0 +1,26 @@
+TestConstructorA {
+    var a, b, c;
+    *new { |...args, kwargs| ^super.performArgs(\newCopyArgs, args, kwargs) }
+    value { ^[a, b, c] }
+}
+
+TestConstructor : UnitTest {
+    test_kw_construct {
+        this.assertEquals(
+            TestConstructorA(1, b: 10, c: 20).(),
+            [1, 10, 20]
+        );
+        this.assertEquals(
+            TestConstructorA(b: 10, c: 20).(),
+            [nil, 10, 20]
+        );
+        this.assertEquals(
+            TestConstructorA(1, 2, 3, 4, 5).(),
+            [1, 2, 3]
+        );
+        this.assertEquals(
+            TestConstructorA(e: 20).(),
+            [nil, nil, nil]
+        );
+    }
+}

--- a/testsuite/classlibrary/TestConstructor.sc
+++ b/testsuite/classlibrary/TestConstructor.sc
@@ -1,16 +1,20 @@
 TestConstructorA {
     var a, b, c;
     *new { |...args, kwargs| ^super.performArgs(\newCopyArgs, args, kwargs) }
+	*newNonExistentKeywords {  ^super.newCopyArgs(1, 2, 3, y: \c, d: \c, x: \c) }
     value { ^[a, b, c] }
 }
 
 TestConstructorBase {
     var a, b, c;
+	*newNonExistentKeywords {  ^super.newCopyArgs(1, 2, 3, y: 10, d: 20, x: 30) }
 }
+
 TestConstructorDerived : TestConstructorBase {
     var d, e, f;
     *new { |d, e, f| ^super.newCopyArgs(1, 2, 3, d, e, f) }
     *newKw { |d, e, f| ^super.newCopyArgs(c: 3, d: d, e: e, f: f) }
+
 	value { ^[a, b, c, d, e, f] }
 }
 
@@ -29,10 +33,11 @@ TestConstructor : UnitTest {
             [1, 2, 3]
         );
         this.assertEquals(
-            TestConstructorA(e: 20).(),
+			TestConstructorA(e: 20).(), // gives a warning as 'e' doesn't exist
             [nil, nil, nil]
         );
     }
+
     test_kw_constructor {
         this.assertEquals(
             TestConstructorDerived.new(10, 11, 12).(),
@@ -43,4 +48,15 @@ TestConstructor : UnitTest {
             [nil, nil, 3, 10, 11, 12]
         );
     }
+
+	test_kw_non_existent_keywords {
+		 this.assertEquals(
+			TestConstructorA.newNonExistentKeywords().(),
+			[1, 2, 3]
+		);
+		this.assertEquals(
+            TestConstructorDerived.newNonExistentKeywords().(),
+            [1, 2, 3, 20, nil, nil]
+        );
+	}
 }

--- a/testsuite/classlibrary/TestConstructor.sc
+++ b/testsuite/classlibrary/TestConstructor.sc
@@ -4,8 +4,18 @@ TestConstructorA {
     value { ^[a, b, c] }
 }
 
+TestConstructorBase {
+    var a, b, c;
+}
+TestConstructorDerived : TestConstructorBase {
+    var d, e, f;
+    *new { |d, e, f| ^super.newCopyArgs(1, 2, 3, d, e, f) }
+    *newKw { |d, e, f| ^super.newCopyArgs(c: 3, d: d, e: e, f: f) }
+	value { ^[a, b, c, d, e, f] }
+}
+
 TestConstructor : UnitTest {
-    test_kw_construct {
+    test_kw_constructor_with_performArg {
         this.assertEquals(
             TestConstructorA(1, b: 10, c: 20).(),
             [1, 10, 20]
@@ -21,6 +31,16 @@ TestConstructor : UnitTest {
         this.assertEquals(
             TestConstructorA(e: 20).(),
             [nil, nil, nil]
+        );
+    }
+    test_kw_constructor {
+        this.assertEquals(
+            TestConstructorDerived.new(10, 11, 12).(),
+            [1, 2, 3, 10, 11, 12]
+        );
+        this.assertEquals(
+            TestConstructorDerived.newKw(10, 11, 12).(),
+            [nil, nil, 3, 10, 11, 12]
         );
     }
 }


### PR DESCRIPTION
## Purpose and Motivation
If you have a class with many instance variables and want to only initialise some of them, you currently need to call setters, which gets messy and can be overloaded.

Now you can call them like so...
```
super.newCopyArgs(1, 2, 3, foo: 10, bar: 20)
```

You can also directly expose the constructor like this...
```
*new { |...args, kwargs|
   ^super.performArgs(\newCopyArgs, args, kwargs)
}
```
In future this could become the default implementation of `Object*new`.

This PR applied this to `SynthDef` as an example.

## Types of changes

- New feature

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [ ] All tests are passing
- [ ] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->
