### PR TITLE
add version and build to Platform.userAppSupportDir

### DIFF
--- a/README_WINDOWS.md
+++ b/README_WINDOWS.md
@@ -172,9 +172,9 @@ You will likely see (the grandpa referred to earlier):
 
     C:\Users\<USERNAME>\AppData
 
-The userAppSupportDir is in the subfolder `Local\SuperCollider`:
+The userAppSupportDir is in the subfolder `Local\SuperCollider\<version>\<build>`:
 
-    C:\Users\<USERNAME>\AppData\Local\SuperCollider
+    C:\Users\<USERNAME>\AppData\Local\SuperCollider\<version>\<build>
 
 This folder is user writable and *not* deleted by uninstalling. Therefore your
 settings, quarks, and plugins persist through updates. This is usually good,

--- a/common/SC_Filesystem_iphone.cpp
+++ b/common/SC_Filesystem_iphone.cpp
@@ -102,7 +102,7 @@ Path SC_Filesystem::defaultUserHomeDirectory() {
 Path SC_Filesystem::defaultUserAppSupportDirectory() {
     // Note: I have not added XDG support here because that seems highly unlikely on iPhone. -BH
     const Path& p = defaultUserHomeDirectory();
-    return p.empty() ? p : p / DOCUMENTS_DIR_NAME;
+    return p.empty() ? p : p / DOCUMENTS_DIR_NAME / SC_VersionString() / SC_BuildString();
 }
 
 Path SC_Filesystem::defaultUserConfigDirectory() {

--- a/common/SC_Filesystem_macos.cpp
+++ b/common/SC_Filesystem_macos.cpp
@@ -168,11 +168,11 @@ Path SC_Filesystem::defaultUserAppSupportDirectory() {
     // see http://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html
     const char* home = getenv("XDG_DATA_HOME");
     if (home)
-        return Path(home) / SC_FOLDERNAME_APPLICATION_NAME;
+        return Path(home) / SC_FOLDERNAME_APPLICATION_NAME / SC_VersionString() / SC_BuildString();
 
     const Path& p = defaultUserHomeDirectory();
     // "/Users/[username]/Library/Application Support/[SuperCollider]"
-    return p.empty() ? p : p / LIBRARY_DIR_NAME / APPLICATION_SUPPORT_DIR_NAME / getBundleName();
+    return p.empty() ? p : p / LIBRARY_DIR_NAME / APPLICATION_SUPPORT_DIR_NAME / getBundleName() / SC_VersionString() / SC_BuildString();
 }
 
 Path SC_Filesystem::defaultUserConfigDirectory() {

--- a/common/SC_Filesystem_unix.cpp
+++ b/common/SC_Filesystem_unix.cpp
@@ -109,10 +109,10 @@ Path SC_Filesystem::defaultUserHomeDirectory() {
 Path SC_Filesystem::defaultUserAppSupportDirectory() {
     const char* xdg_data_home = getenv("XDG_DATA_HOME");
     if (xdg_data_home)
-        return Path(xdg_data_home) / SC_FOLDERNAME_APPLICATION_NAME;
+        return Path(xdg_data_home) / SC_FOLDERNAME_APPLICATION_NAME / SC_VersionString() / SC_BuildString();
 
     const Path& p = defaultUserHomeDirectory();
-    return p.empty() ? p : p / DOT_LOCAL / SHARE_DIR_NAME / SC_FOLDERNAME_APPLICATION_NAME;
+    return p.empty() ? p : p / DOT_LOCAL / SHARE_DIR_NAME / SC_FOLDERNAME_APPLICATION_NAME / SC_VersionString() / SC_BuildString();
 }
 
 Path SC_Filesystem::defaultUserConfigDirectory() {

--- a/common/SC_Filesystem_win.cpp
+++ b/common/SC_Filesystem_win.cpp
@@ -135,7 +135,7 @@ Path SC_Filesystem::defaultUserHomeDirectory() {
 Path SC_Filesystem::defaultUserAppSupportDirectory() {
     PWSTR wptr = nullptr;
     const HRESULT hr = SHGetKnownFolderPath(FOLDERID_LocalAppData, 0, nullptr, &wptr);
-    return FAILED(hr) ? Path() : Path(wptr) / SC_FOLDERNAME_APPLICATION_NAME;
+    return FAILED(hr) ? Path() : Path(wptr) / SC_FOLDERNAME_APPLICATION_NAME / SC_VersionString() / SC_BuildString();
 }
 
 Path SC_Filesystem::defaultUserConfigDirectory() { return defaultUserAppSupportDirectory(); }


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

Currently, Platform.userAppSupportDir is fixed as follows:

- Window:
%USERPROFILE%\AppData\Local\SuperCollider
- Linux:
~/.local/share/SuperCollider
- macOS:
~/Library/Application Support/SuperCollider

This leads to developers and users running multiple SCs sometimes removing some subfolders of Platform.userAppSupportDir (at least the Help folder).

This PR adds version and build to Platform.userAppSupportDir:
- Window:
%USERPROFILE%\AppData\Local\SuperCollider\<version>\<build>
- Linux:
~/.local/share/SuperCollider/<version>/<build>
- macOS:
~/Library/Application Support/SuperCollider/<version>/<build>


## Types of changes

<!-- Delete lines that don't apply -->

- Documentation
- New feature

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [ ] Code is tested
- [ ] All tests are passing
- [x] Updated documentation
- [x] This PR is a draft PR, but comments or reviews are needed to finalise it. <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
