### PR TITLE
ClassLib: fix Set.remove not returning the item

### DIFF
--- a/SCClassLibrary/Common/Collections/Array2D.sc
+++ b/SCClassLibrary/Common/Collections/Array2D.sc
@@ -43,8 +43,9 @@ Array2D : Collection {
 		^array.copyRange(ri * cols, ri * cols + cols - 1)
 	}
 
-	// overide Array
-	// add { ^thisMethod.shouldNotImplement }
+	add { ^this.shouldNotImplement(thisMethod)  }
+	remove { ^this.shouldNotImplement(thisMethod) }
+
 	printOn { arg stream;
 		// not a compileable string
 		stream << this.class.name << "[" ;

--- a/SCClassLibrary/Common/Collections/Bag.sc
+++ b/SCClassLibrary/Common/Collections/Bag.sc
@@ -17,7 +17,7 @@ Bag : Collection {
 		});
 	}
 	remove { arg item, count=1;
-		var newCount;
+		var newCount, out;
 		if ( this.includes(item), {
 			newCount = contents.at(item) - count;
 			if (newCount <= 0, {
@@ -25,7 +25,9 @@ Bag : Collection {
 			},{
 				contents.put(item, newCount);
 			});
+			^item
 		});
+		^nil
 	}
 
 	// accessing

--- a/SCClassLibrary/Common/Collections/Bag.sc
+++ b/SCClassLibrary/Common/Collections/Bag.sc
@@ -17,7 +17,7 @@ Bag : Collection {
 		});
 	}
 	remove { arg item, count=1;
-		var newCount, out;
+		var newCount;
 		if ( this.includes(item), {
 			newCount = contents.at(item) - count;
 			if (newCount <= 0, {

--- a/SCClassLibrary/Common/Collections/Interval.sc
+++ b/SCClassLibrary/Common/Collections/Interval.sc
@@ -20,6 +20,7 @@ Interval : Collection {
 		forBy(start, end, step, function);
 	}
 
+	remove { ^this.shouldNotImplement(thisMethod) }
 	add { ^this.shouldNotImplement(thisMethod) }
 	put { ^this.shouldNotImplement(thisMethod) }
 	storeArgs { ^[start, end, step] }
@@ -50,6 +51,7 @@ Range : Collection {
 		^(val >= start) and: { (val < this.end)  and: { val.frac == 0 }}
 	}
 
+	remove { ^this.shouldNotImplement(thisMethod) }
 	add { ^this.shouldNotImplement(thisMethod) }
 	put { ^this.shouldNotImplement(thisMethod) }
 

--- a/SCClassLibrary/Common/Collections/LinkedList.sc
+++ b/SCClassLibrary/Common/Collections/LinkedList.sc
@@ -64,14 +64,16 @@ LinkedList : SequenceableCollection {
 		});
 		size = size + 1;
 	}
-	remove { arg obj;
+	remove { |obj|
 		var node = this.findNodeOfObj(obj);
 		if ( node.notNil, {
 			if (head == node, { head = node.next; });
 			if (tail == node, { tail = node.prev; });
 			node.remove;
 			size = size - 1;
+			^obj
 		});
+		^nil
 	}
 	pop {
 		var node;

--- a/SCClassLibrary/Common/Collections/ObjectTable.sc
+++ b/SCClassLibrary/Common/Collections/ObjectTable.sc
@@ -14,10 +14,11 @@ TwoWayIdentityDictionary : Collection {
 	}
 
 	remove { arg obj;
-		var key;
+		var key, out;
 		key = this.getID(obj);
-		idToObj.removeAt(key);
+		out = idToObj.removeAt(key);
 		objToID.removeAt(obj);
+		^out
 	}
 
 	removeAt { arg key;

--- a/SCClassLibrary/Common/Collections/Pair.sc
+++ b/SCClassLibrary/Common/Collections/Pair.sc
@@ -45,6 +45,9 @@ Pair : Collection {
 		^res
 	}
 
+	remove { ^this.shouldNotImplement(thisMethod) }
+	add { ^this.shouldNotImplement(thisMethod) }
+
 	traverse { arg function;
 		// the default traversal order
 		^this.depthFirstPreOrderTraversal(function)

--- a/SCClassLibrary/Common/Collections/SequenceableCollection.sc
+++ b/SCClassLibrary/Common/Collections/SequenceableCollection.sc
@@ -350,10 +350,12 @@ SequenceableCollection : Collection {
 		^this.species.fill(newSize, { |i| this.blendAt(i * factor) })
 	}
 
-	remove { arg item;
+	removeAt { |index| ^this.subclassResponsibility(thisMethod) }
+	remove { |item|
 		var index = this.indexOf(item);
 		^if ( index.notNil, {
 			this.removeAt(index);
+			^item
 		},{
 			nil
 		});

--- a/SCClassLibrary/Common/Collections/SequenceableCollection.sc
+++ b/SCClassLibrary/Common/Collections/SequenceableCollection.sc
@@ -355,7 +355,7 @@ SequenceableCollection : Collection {
 		var index = this.indexOf(item);
 		^if ( index.notNil, {
 			this.removeAt(index);
-			^item
+			item
 		},{
 			nil
 		});

--- a/SCClassLibrary/Common/Collections/SequenceableCollection.sc
+++ b/SCClassLibrary/Common/Collections/SequenceableCollection.sc
@@ -350,7 +350,7 @@ SequenceableCollection : Collection {
 		^this.species.fill(newSize, { |i| this.blendAt(i * factor) })
 	}
 
-	removeAt { |index| ^this.subclassResponsibility(thisMethod) }
+	removeAt { |index| this.subclassResponsibility(thisMethod) }
 	remove { |item|
 		var index = this.indexOf(item);
 		^if ( index.notNil, {

--- a/SCClassLibrary/Common/Collections/Set.sc
+++ b/SCClassLibrary/Common/Collections/Set.sc
@@ -38,7 +38,9 @@ Set : Collection {
 			array.put(index, nil);
 			size = size - 1;
 			this.fixCollisionsFrom(index);
+			^item
 		});
+		^nil
 	}
 	choose {
 		var index, val;

--- a/SCClassLibrary/Common/Collections/Set.sc
+++ b/SCClassLibrary/Common/Collections/Set.sc
@@ -223,8 +223,9 @@ OrderedIdentitySet : IdentitySet {
 	}
 
 	remove { arg item;
-		super.remove(item);
+		var out = super.remove(item);
 		items.remove(item);
+		^out
 	}
 	sort { arg func;
 		items.sort(func)

--- a/testsuite/classlibrary/TestCollection.sc
+++ b/testsuite/classlibrary/TestCollection.sc
@@ -1,10 +1,63 @@
 TestCollection : UnitTest {
-
 	test_asPairs {
-
-		this.assert([2,10,100,1000].collect{ |size| size.collect{ |i| i -> i }.asPairs.size >= (size * 2) }.reduce('&&')
-, "asPairs on an array of associations should create an array with size higher or equal to twice the number of elements in the original array");
-
+		this.assert(
+			[2,10,100,1000]
+			.collect{ |size|
+				size.collect{ |i| i -> i }.asPairs.size >= (size * 2)
+			}.reduce('&&'),
+			"asPairs on an array of associations should create an array "
+			"with size higher or equal to twice the number of elements in the original array"
+		);
 	}
 
+	test_remove {
+		var rejectList = [RingBuffer, ArrayedCollection, SequenceableCollection, RawArray] ++ RawArray.allSubclasses;
+		// RingBuffer needs revising.
+		// Subclasses of RawArray change the type so this test won't work.
+		var testable = Collection.allSubclasses.reject(rejectList.includes(_));
+
+		testable.do { |c|
+			var obj;
+			// only test classes than can be constructed like this.
+			try { obj = c.newFrom([1, 2]) };
+			obj !? {|o|
+			    var r;
+				try { r = o.remove(1) } { |e|
+				    // Ignore classes that explicitly don't implement remove.
+					if(e.isKindOf(ShouldNotImplementError)){
+					    r = \skip;
+					} {
+                        r = "Error, % should implement remove".format(c);
+					}
+				};
+				if (r !== \skip) {
+                    this.assertEquals(r, 1,
+                        "%.remove should return the value when present, expected % got %".format(c, 1, r)
+                    )
+                }
+			}
+		};
+
+		testable.do { |c|
+        			var obj;
+        			// only test classes than can be constructed like this.
+        			try { obj = c.new };
+        			obj !? {|o|
+        			    var r;
+        				try { r = o.remove(1) } { |e|
+        				    // Ignore classes that explicitly don't implement remove.
+        					if(e.isKindOf(ShouldNotImplementError)){
+        					    r = \skip;
+        					} {
+                                r = "Error, % should implement remove".format(c);
+        					}
+        				};
+        				if (r !== \skip) {
+                            this.assertEquals(r, nil,
+                                "%.remove should return nil when not present, expected % got %".format(c, nil, r)
+                            )
+                        }
+        			}
+		};
+	}
 }


### PR DESCRIPTION

## Purpose and Motivation

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

Fixes #6408 

```supercollider
[1, 2, 3].remove(3) //  3
Set[1, 2, 3].remove(3) // Set[1,2]  << incorrect


[1, 2].remove(3) // nil
Set[1, 2].remove(3) // Set[1, 2] << incorrect
```

From `Collection` help file
> Remove anObject from the receiver. Answers the removed object.

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

Could be a breaking bug fix, but documentation is clear

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [ ] Code is tested
- [ ] All tests are passing
- [ ] Updated documentation
- [ ] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
