### PR TITLE
String literal size limit: Documentation and bugfix

### DIFF
--- a/HelpSource/Reference/Literals.schelp
+++ b/HelpSource/Reference/Literals.schelp
@@ -217,6 +217,22 @@ a.size // 9
 The SuperCollider IDE uses UTF-8 to decode and display strings.
 See link::Classes/String#Character encodings##String:: for more information.
 
+A string literal may comprise no more than 8188 characters (bytes). A
+string object can be larger as a result of string operations.
+
+code::
+// artificially generate a long string
+a = String.fill(9000, { "abcdefghijklmnopqrstuvwxyz".choose });
+
+// wrap it in quote marks to make it a literal
+a = "\"" ++ a ++ "\"";
+
+// interpret the literal
+b = a.interpret;
+
+b.size;  // 8188 and NOT 9000
+::
+
 section::Identifiers
 
 Names of methods and variables begin with a lower case alphabetic character,

--- a/SCClassLibrary/Common/Collections/String.sc
+++ b/SCClassLibrary/Common/Collections/String.sc
@@ -110,6 +110,21 @@ String[char] : RawArray {
 	isString { ^true }
 	asString { ^this }
 	asCompileString {
+		var out;
+		// empirically, the compiler limits `"literals"` to 8188 characters
+		// 8180 leaves a little headroom
+		^if(this.size <= 8180) {
+			this.prAsCompileString
+		} {
+			out = "[";
+			this.clump(8180).do { |substr, i|
+				if(i > 0) { out = out ++ ", " };
+				out = out ++ substr.prAsCompileString;
+			};
+			out ++ "].join"
+		}
+	}
+	prAsCompileString {
 		_String_AsCompileString
 		^this.primitiveFailed
 	}

--- a/testsuite/classlibrary/TestString.sc
+++ b/testsuite/classlibrary/TestString.sc
@@ -204,4 +204,10 @@ TestString : UnitTest {
 		var result = "the quick brown fox".findRegexp("moo");
 		this.assertEquals(result, Array.new, "Non-matching findRegexp should return empty array");
 	}
+
+	test_largeStringCompileString {
+		var large = String.fill(9000, { |i| "0123456789".wrapAt(i) });
+		var reconstructed = large.asCompileString.interpret;
+		this.assert(large == reconstructed, "A large string's compileString should interpret back to itself");
+	}
 }


### PR DESCRIPTION
## Purpose and Motivation

1. String literals have a size limit, enforced by the compiler. To my knowledge, this has never been documented before. So, here it is.

2. The lack of documentation has come up as an issue particularly for large strings in text archives (see https://scsynth.org/t/large-strings-truncated-by-object-readarchive/9894). I.e., if aString.size > 8188, then `aString.asCompileString` produces a string that does not compile back to the original string -- hence asCompileString is broken in that case. This PR fixes the bug by splitting long strings into this type of expression: `["substr0", "substr1", "substr2"...].join`.

## Types of changes

- Documentation
- Bug fix

## To-do list

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->