### PR TITLE
ClassLib, ObjectPrototyping: fix bug when passing array as final arg of object prototyping

### DIFF
--- a/SCClassLibrary/Common/Collections/Dictionary.sc
+++ b/SCClassLibrary/Common/Collections/Dictionary.sc
@@ -544,7 +544,7 @@ IdentityDictionary : Dictionary {
             ^super.performArgs(\doesNotUnderstand, args, kwargs)
 		};
         this[selector] !? { |func|
-            ^func.performArgs(\functionPerformList, [\value, this] ++ args, kwargs);
+			^func.performArgs(\functionPerformList, [\value, this, args], kwargs);
         };
 
         if (selector.isSetter) {
@@ -557,7 +557,7 @@ IdentityDictionary : Dictionary {
         };
 
         this[\forward] !? { |func|
-            ^func.performArgs(\functionPerformList, [\value, this, selector] ++ args, kwargs);
+			^func.performArgs(\functionPerformList, [\value, this, selector, args], kwargs);
         };
 
         ^nil

--- a/testsuite/classlibrary/TestIdentityDictionaryObjectPrototyping.sc
+++ b/testsuite/classlibrary/TestIdentityDictionaryObjectPrototyping.sc
@@ -61,4 +61,9 @@ TestIdentityDictionaryObjectPrototyping : UnitTest {
 		this.assertEquals(result.args, [3, 4, 5]);
 		this.assertEquals(result.kwargs, [foo: 10, bar: 11]);
 	}
+	test_with_array {
+		var ev = (x: { |self, data| data });
+		var result = ev.x([1, 2, 3, 4]);
+		this.assertEquals(result, [1, 2, 3, 4], "Arrays should not be expanded by functionPerformList");
+	}
 }


### PR DESCRIPTION
…

<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

https://scsynth.org/t/dev-version-new-keyword-args-features-vs-old-style-dictionary-object-prototyping/9966

```
e = (x: { |self, data| data });

e.x([1, 2, 3]);
-> 1  // uh... no
```

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
