### PR TITLE
Add additional waiting time in `TestNodeProxy_Server:test_synthDef_isReleased_afterFree`

### DIFF
--- a/testsuite/classlibrary/TestNodeProxy_Server.sc
+++ b/testsuite/classlibrary/TestNodeProxy_Server.sc
@@ -68,13 +68,17 @@ TestNodeProxy_Server : UnitTest {
 		server.sync;
 		proxy.source = nil;
 
+		// ... we give the server some time to catch up? ...
+		// see https://github.com/supercollider/supercollider/issues/6438
+		0.1.wait;
+
 		// ... and also afterwards, we force an update
 		server.sync;
 		server.sendStatusMsg;
 		numAfter = server.statusWatcher.numSynthDefs;
 
 		this.assertEquals(numBefore, numAfter,
-			"Removing the  NodeProxy source function should remove SynthDef from server"
+			"Removing the NodeProxy source function should remove SynthDef from server (was %, is %)".format(numBefore, numAfter)
 		);
 	}
 


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

This is rather unstable test and it is unclear to me why it occasionally fails (see https://github.com/supercollider/supercollider/actions/runs/10649343960/job/29543125921#step:7:3469).
I now added a waiting time in case the server needs some time for garbage collection or else? If this still fails, there should be a waiting time added in the beginning of the test.

I am unsure if this PR actually fixes the underlying issue, but at least it provides some additional information about the state of the test through printing.

If everything goes well, this fixes #6438 

Generally these tests could also run on the same server, instead of booting and killing it for every test - see #6440 (max 50 seconds to gain here).

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix


## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
