### PR TITLE
Wrap post test results in timeout

### DIFF
--- a/.github/workflows/test_linux.yml
+++ b/.github/workflows/test_linux.yml
@@ -67,4 +67,4 @@ jobs:
       - name: Post test results
         shell: bash
         run: |
-          $SCLANG $SCRIPT_PRINT_RESULTS $TEST_LIST_RESULT
+          timeout 1m $SCLANG $SCRIPT_PRINT_RESULTS $TEST_LIST_RESULT

--- a/.github/workflows/test_macos.yml
+++ b/.github/workflows/test_macos.yml
@@ -60,4 +60,4 @@ jobs:
       - name: Post test results
         shell: bash
         run: |
-          $SCLANG $SCRIPT_PRINT_RESULTS $TEST_LIST_RESULT
+          timeout 1m $SCLANG $SCRIPT_PRINT_RESULTS $TEST_LIST_RESULT


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

Fixes #6442 by wrapping the post test results command in a timeout for macOS and Linux.
More of a hack as the post script should not freeze in the first place, but in the end it works and I think is a valid approach using common Unix tools.

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
