### PR TITLE
Fix case typo on kwargs argument in docs of `Obect.performArgs`

### DIFF
--- a/HelpSource/Classes/Object.schelp
+++ b/HelpSource/Classes/Object.schelp
@@ -504,7 +504,7 @@ A link::Classes/Symbol:: of the method name.
 argument::args
 An link::Classes/Array:: of the arguments.
 
-argument::kwArgs
+argument::kwargs
 An link::Classes/Array:: of keyword-argument pairs.
 
 Example


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

Fixes

```
WARNING: SCDoc: In .../SuperCollider/SuperCollider.app/Contents/Resources/HelpSource/Classes/Object.schelp
  Method -performArgs has arg named 'kwargs', but doc has 'argument:: kwArgs'.
```

as reported @ https://github.com/supercollider/supercollider/pull/6427#issuecomment-2328079480

## Types of changes

<!-- Delete lines that don't apply -->

- Documentation
- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
