### PR TITLE
SCLang: fix duplicate arg warning.

### DIFF
--- a/lang/LangSource/PyrMessage.cpp
+++ b/lang/LangSource/PyrMessage.cpp
@@ -437,11 +437,11 @@ void prepareArgsForExecute(VMGlobals* g, PyrBlock* block, PyrFrame* callFrame, l
 
         // If found in method.
         if (const auto argIndex = findKeywordArgIndex(argKeyword); argIndex.has_value()) {
-            // Greater than the number of normal args passed in by user, add it.
-            // SC docs show that in the case of colliding args, the last one added should always be the result.
             outCallFrameStack[*argIndex] = *argValue;
+
+            // SC docs show that in the case of colliding args, the last one added should always be the result.
             if (*argIndex < numNormalArgsAdded) {
-                // Already pushed, duplicate keyword found, ignore value, post warning.
+                // Already pushed, duplicate keyword found, update value, post warning.
                 if (!isMethod) {
                     post("Duplicate keyword '%s' at position %d found in function call\n", argKeyword->name, *argIndex);
                 } else {

--- a/lang/LangSource/PyrMessage.cpp
+++ b/lang/LangSource/PyrMessage.cpp
@@ -440,7 +440,7 @@ void prepareArgsForExecute(VMGlobals* g, PyrBlock* block, PyrFrame* callFrame, l
             // Greater than the number of normal args passed in by user, add it.
             // SC docs show that in the case of colliding args, the last one added should always be the result.
             outCallFrameStack[*argIndex] = *argValue;
-            if (*argIndex > numNormalArgsAdded) {
+            if (*argIndex < numNormalArgsAdded) {
                 // Already pushed, duplicate keyword found, ignore value, post warning.
                 if (!isMethod) {
                     post("Duplicate keyword '%s' at position %d found in function call\n", argKeyword->name, *argIndex);


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

I wrote an equality the wrong way around when tidying the code and create many duplicate keyword arguments by mistake — sorry all!. This fixes that.

Closes #6437

Test:
```
// none in class lib
f = { |a, b| }
f.(b: 10) // none
f.(1, b: 1) // none
f.(1, 1, b: 10) // duplicate b


f = { |x, y| [x, y] };
f.value(x:8); // OK
f.value(y:8) // OK
f.value(x: 2, y:8) // OK
```

## Types of changes

- Bug fix


## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing — https://github.com/supercollider/supercollider/actions/runs/10698059325/job/29656794435 (first commit, second is just comments).
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
