### PR TITLE
scide: fix failing to open recent files if mnemonic is enabled

### DIFF
--- a/editors/sc-ide/widgets/main_window.cpp
+++ b/editors/sc-ide/widgets/main_window.cpp
@@ -849,8 +849,10 @@ void MainWindow::updateRecentDocsMenu() {
 
     const QStringList& recent = mMain->documentManager()->recents();
 
-    foreach (const QString& path, recent)
-        mRecentDocsMenu->addAction(path);
+    foreach (const QString& path, recent) {
+        QAction* action = mRecentDocsMenu->addAction(path);
+        action->setData(QVariant(path));
+    }
 
     if (!recent.isEmpty()) {
         mRecentDocsMenu->addSeparator();
@@ -858,7 +860,9 @@ void MainWindow::updateRecentDocsMenu() {
     }
 }
 
-void MainWindow::onOpenRecentDocument(QAction* action) { mMain->documentManager()->open(action->text()); }
+void MainWindow::onOpenRecentDocument(QAction* action) {
+    mMain->documentManager()->open(action->data().value<QString>());
+}
 
 void MainWindow::onInterpreterStateChanged(QProcess::ProcessState state) {
     switch (state) {


### PR DESCRIPTION
## Purpose and Motivation

I encountered the similar error message described in https://github.com/supercollider/supercollider/issues/2823#issuecomment-294336058

This pull request fixes https://github.com/supercollider/supercollider/issues/2823 by storing file path in `QAction`'s data field.


<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix


## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
