### PR TITLE
ClassLib: fix nil.addAll returning original collection instead of a copy

### DIFF
--- a/SCClassLibrary/Common/Core/Nil.sc
+++ b/SCClassLibrary/Common/Core/Nil.sc
@@ -79,7 +79,14 @@ Nil {
 		// array = array.add(thing);     Instead, it just works.
 		^[value]
 	}
-	addAll { arg array; ^array.asArray }
+	addAll { |array|
+		var result = array.asArray;
+		^if(result === array) {
+			result.copy
+		} {
+			result
+		}
+	}
 	++ { arg array; ^array }
 	asCollection { ^[] }
 	remove {}


### PR DESCRIPTION
## Purpose and Motivation

Fix nil.addAll returning original collection instead of a copy.
Adapting addAll method to piping syntax.
Fixes #6414 .

## Types of changes

- Bug fix

## To-do list

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review