### PR TITLE
plugins: SpecPcile output zeros on RTAlloc fail

### DIFF
--- a/server/plugins/ML_SpecStats.cpp
+++ b/server/plugins/ML_SpecStats.cpp
@@ -209,7 +209,10 @@ void SpecPcile_next(SpecPcile* unit, int inNumSamples) {
         // Used to be MAKE_TEMP_BUF but we can handle it more cleanly in this specific case:
         if (!unit->m_tempbuf) {
         unit->m_tempbuf = (float*)RTAlloc(unit->mWorld, numbins * sizeof(float));
-        ClearUnitIfMemFailed(unit->m_tempbuf);
+        if (!unit->m_tempbuf) {
+            ClearUnitOutputs(unit, inNumSamples);
+            ClearUnitOnMemFailed;
+        }
         unit->m_numbins = numbins;
         unit->m_halfnyq_over_numbinsp2 = ((float)unit->mWorld->mSampleRate) * 0.5f / (float)(numbins + 2);
     }


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

SpecPcile calls RTAlloc in its _next function (thus after _Ctor). If RTAlloc fails, the UGen still outputs some non-zero values for one block. This is not the expected behavior, especially by RTAlloc UnitTests, which were failing.

This PR ensures clear output when RTAlloc fails.

## Types of changes

<!-- Delete lines that don't apply -->
- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [ ] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
