### PR TITLE
server: add /rtMemoryStatus cmd for debugging

### DIFF
--- a/HelpSource/Classes/Server.schelp
+++ b/HelpSource/Classes/Server.schelp
@@ -394,6 +394,13 @@ s.queryAllNodes; // note the root node (ID 0) and the default group (ID 1)
 s.quit;
 ::
 
+method:: rtMemoryStatus
+Queries the server for the amount of currently free real-time memory
+argument:: action
+a Function that will be evaluated when the server responds, with the current
+amount of free RT memory and the size of largest continuous block (both in bytes) passed as
+arguments. The default action prints a message.
+
 method:: peakCPU, avgCPU
 Get peak and average CPU usage.
 

--- a/HelpSource/Reference/Server-Command-Reference.schelp
+++ b/HelpSource/Reference/Server-Command-Reference.schelp
@@ -134,6 +134,18 @@ The standard human-readable version string can be constructed by concatenating c
 
 The git branch/tag name and commit hash could be anything if the user has forked SC, so they should only be used for display and user interface purposes.
 
+
+subsection:: /rtMemoryStatus
+
+Queries the amount of currently free real-time memory (in bytes).
+
+definitionlist::
+## /rtMemoryStatus.reply || table::
+## int || Amount of free real-time memory (in bytes).
+## int || Size of largest continuous block (in bytes).
+::
+::
+
 section:: Synth Definition Commands
 
 subsection:: /d_recv

--- a/include/server/SC_OSC_Commands.h
+++ b/include/server/SC_OSC_Commands.h
@@ -115,5 +115,7 @@ enum {
 
     cmd_version = 64,
 
-    NUMBER_OF_COMMANDS = 65
+    cmd_rtMemoryStatus = 65,
+
+    NUMBER_OF_COMMANDS = 66
 };

--- a/server/scsynth/SC_MiscCmds.cpp
+++ b/server/scsynth/SC_MiscCmds.cpp
@@ -1300,6 +1300,12 @@ SCErr meth_status(World* inWorld, int inSize, char* inData, ReplyAddress* inRepl
     return kSCErr_None;
 }
 
+SCErr meth_rtMemoryStatus(World* inWorld, int inSize, char* inData, ReplyAddress* inReply);
+SCErr meth_rtMemoryStatus(World* inWorld, int inSize, char* inData, ReplyAddress* inReply) {
+    CallSequencedCommand(RTMemStatusCmd, inWorld, inSize, inData, inReply);
+    return kSCErr_None;
+}
+
 SCErr meth_quit(World* inWorld, int inSize, char* inData, ReplyAddress* inReply);
 SCErr meth_quit(World* inWorld, int inSize, char* inData, ReplyAddress* inReply) {
     CallSequencedCommand(AudioQuitCmd, inWorld, inSize, inData, inReply);
@@ -1871,6 +1877,7 @@ void initMiscCommands() {
     NEW_COMMAND(quit);
     NEW_COMMAND(clearSched);
     NEW_COMMAND(version);
+    NEW_COMMAND(rtMemoryStatus);
 
     NEW_COMMAND(d_recv);
     NEW_COMMAND(d_load);

--- a/server/scsynth/SC_SequencedCommand.cpp
+++ b/server/scsynth/SC_SequencedCommand.cpp
@@ -1168,6 +1168,33 @@ bool AudioStatusCmd::Stage2() {
 
 ///////////////////////////////////////////////////////////////////////////
 
+RTMemStatusCmd::RTMemStatusCmd(World* inWorld, ReplyAddress* inReplyAddress):
+    SC_SequencedCommand(inWorld, inReplyAddress) {}
+
+void RTMemStatusCmd::CallDestructor() { this->~RTMemStatusCmd(); }
+
+bool RTMemStatusCmd::Stage2() {
+    // we stop replying to status requests after receiving /quit
+    if (mWorld->hw->mTerminating == true)
+        return false;
+
+    small_scpacket packet;
+    packet.adds("/rtMemoryStatus.reply");
+    packet.maketags(3);
+    packet.addtag(',');
+    packet.addtag('i');
+    packet.addtag('i');
+
+    packet.addi(World_TotalFree(mWorld));
+    packet.addi(World_LargestFreeChunk(mWorld));
+
+    SendReply(&mReplyAddress, packet.data(), packet.size());
+
+    return false;
+}
+
+///////////////////////////////////////////////////////////////////////////
+
 NotifyCmd::NotifyCmd(World* inWorld, ReplyAddress* inReplyAddress): SC_SequencedCommand(inWorld, inReplyAddress) {}
 
 int NotifyCmd::Init(char* inData, int inSize) {

--- a/server/scsynth/SC_SequencedCommand.h
+++ b/server/scsynth/SC_SequencedCommand.h
@@ -370,6 +370,17 @@ protected:
 
 ///////////////////////////////////////////////////////////////////////////
 
+class RTMemStatusCmd : public SC_SequencedCommand {
+public:
+    RTMemStatusCmd(World* inWorld, ReplyAddress* inReplyAddress);
+
+    virtual bool Stage2(); // non real time
+
+protected:
+    virtual void CallDestructor();
+};
+///////////////////////////////////////////////////////////////////////////
+
 class NotifyCmd : public SC_SequencedCommand {
 public:
     NotifyCmd(World* inWorld, ReplyAddress* inReplyAddress);

--- a/server/supernova/sc/sc_osc_handler.cpp
+++ b/server/supernova/sc/sc_osc_handler.cpp
@@ -16,6 +16,7 @@
 //  the Free Software Foundation, Inc., 59 Temple Place - Suite 330,
 //  Boston, MA 02111-1307, USA.
 
+#include "server/memory_pool.hpp"
 #include <iostream>
 
 // AppleClang workaround
@@ -1009,6 +1010,25 @@ template <bool realtime> void handle_version(endpoint_ptr const& endpoint_ref) {
 }
 
 template <> void handle_version<false>(endpoint_ptr const& endpoint_ref) {}
+
+template <bool realtime> void handle_rtMemoryStatus(endpoint_ptr const& endpoint_ref) {
+    cmd_dispatcher<realtime>::fire_io_callback([=, endpoint = endpoint_ptr(endpoint_ref)]() {
+        if (unlikely(instance->quit_received))
+            return;
+
+        char buffer[4096];
+        typedef osc::int32 i32;
+
+        osc::OutboundPacketStream p(buffer, 4096);
+        p << osc::BeginMessage("/rtMemoryStatus.reply")
+            << (i32) (rt_pool.get_pool_size() - rt_pool.get_used_size())
+            << (i32) rt_pool.get_max_size()
+            << osc::EndMessage;
+        endpoint->send(p.Data(), p.Size());
+    });
+}
+
+template <> void handle_rtMemoryStatus<false>(endpoint_ptr const& endpoint_ref) {}
 
 void handle_unhandled_message(ReceivedMessage const& msg) {
     log_printf("unhandled message: %s\n", msg.AddressPattern());
@@ -3216,6 +3236,10 @@ void sc_osc_handler::handle_message_int_address(ReceivedMessage const& message, 
         handle_version<realtime>(endpoint);
         break;
 
+    case cmd_rtMemoryStatus:
+        handle_rtMemoryStatus<realtime>(endpoint);
+        break;
+
     default:
         handle_unhandled_message(message);
     }
@@ -3600,6 +3624,11 @@ void sc_osc_handler::handle_message_sym_address(ReceivedMessage const& message, 
 
     if (strcmp(address + 1, "version") == 0) {
         handle_version<realtime>(endpoint);
+        return;
+    }
+
+    if (strcmp(address + 1, "rtMemoryStatus") == 0) {
+        handle_rtMemoryStatus<realtime>(endpoint);
         return;
     }
 

--- a/server/supernova/utilities/simple_pool.hpp
+++ b/server/supernova/utilities/simple_pool.hpp
@@ -53,6 +53,7 @@ template <bool blocking = false> class simple_pool {
 
             std::memset(pool, 0, size);
             init_memory_pool(size, pool);
+            pool_size = size;
         }
 
         ~data(void) {
@@ -64,7 +65,9 @@ template <bool blocking = false> class simple_pool {
         }
 
         char* pool;
+        size_t pool_size;
     };
+
 
 public:
     simple_pool(void) {}
@@ -107,7 +110,9 @@ public:
         free_ex(p, data_.pool);
     }
 
+    std::size_t get_pool_size(void) { return data_.pool_size; }
     std::size_t get_max_size(void) { return ::get_max_size(data_.pool); }
+    std::size_t get_used_size(void) { return ::get_used_size(data_.pool); }
 #endif
 private:
     data data_;


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

scsynth provides a call for querying the amount of currently free real-time memory, but this call is never used and inaccessible. This PR adds a server /cmd (and related sclang interface) to get this information:
```
s.boot;
s.rtMemoryStatus
// Used RT memory: 16.5625 kb
// Free RT memory: 8175.4375 kb
// Largest free chunk: 8175.4375 kb

x = {DelayN.ar(DC.ar(0.0), maxdelaytime: 4.0)}.play;
s.rtMemoryStatus
// Used RT memory: 1043.0625 kb
// Free RT memory: 7148.9375 kb
// Largest free chunk: 7148.0625 kb

x.free;
s.rtMemoryStatus
// Used RT memory: 16.4375 kb
// Free RT memory: 8175.5625 kb
// Largest free chunk: 8175.5625 kb
```

I have no idea how to implement this for supernova.
Perhaps another option would be to include mem info in /status? Sounds nicer to me, but perhaps also too much of a breaking change?

## Types of changes

- New feature

## To-do list

- [ ] Code is tested
- [ ] All tests are passing
- [ ] Updated documentation
- [ ] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->
