### PR TITLE
Include cassert import for clang 15

### DIFF
--- a/common/SC_Filesystem_macos.cpp
+++ b/common/SC_Filesystem_macos.cpp
@@ -30,6 +30,7 @@
 #    include "SC_Filesystem.hpp"
 
 #    include <filesystem> // path, parent_path(), canonical, current_path()
+#    include <cassert>
 
 // system includes
 #    include <Foundation/NSAutoreleasePool.h>


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

To make SC compile for macOS 14/clang15, we need to import cassert.
Thanks for reporting this, @mtmccrea @ https://github.com/supercollider/supercollider/pull/6477#issuecomment-2352375615


## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
