### PR TITLE
GHA: update build matrix

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -87,7 +87,7 @@ jobs:
     needs: [version-getter, build-macos]
     uses: ./.github/workflows/test_macos.yml
     with:
-      artifact-file: "SuperCollider-${{ needs.version-getter.outputs.sc-version }}-macOS-universal.dmg"
+      artifact-file: "SuperCollider-${{ needs.version-getter.outputs.sc-version }}-macOS-x64.dmg"
     secrets: inherit
 
   # test-windows:
@@ -102,18 +102,12 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - artifact-suffix: macOS-universal
+          - artifact-suffix: macOS-x64
             s3-os-name: osx
             s3-artifact-suffx: ''
             s3-artifact-extension: 'dmg'
             artifact-extension: '.dmg' # for download-artifacts action, for non-zip only, should include `.`
-            s3-create-latest-link: true # create link to pointing to the "latest" build; activate only one per branch per s3-os-name
-
-          - artifact-suffix: win32
-            s3-os-name: win32
-            s3-artifact-suffx: ''
-            s3-artifact-extension: 'zip'
-            s3-create-latest-link: true # create link to pointing to the "latest" build
+            s3-create-latest-link: true # create link to pointing to the "latest" build; activate only one per branch per s3-os-name  
 
           - artifact-suffix: win64
             s3-os-name: win64
@@ -214,9 +208,7 @@ jobs:
             ${{ env.INSTALL_PATH }}/${{ env.ARTIFACT_FILE_PREFIX }}-macOS-universal.dmg/*
             ${{ env.INSTALL_PATH }}/${{ env.ARTIFACT_FILE_PREFIX }}-macOS-arm64.dmg/*
             ${{ env.INSTALL_PATH }}/${{ env.ARTIFACT_FILE_PREFIX }}-macOS-x64-legacy.dmg/*
-            ${{ env.INSTALL_PATH }}/${{ env.ARTIFACT_FILE_PREFIX }}-win32-installer/*
             ${{ env.INSTALL_PATH }}/${{ env.ARTIFACT_FILE_PREFIX }}-win64-installer/*
-            ${{ env.INSTALL_PATH }}/${{ env.ARTIFACT_FILE_PREFIX }}-win32/*
             ${{ env.INSTALL_PATH }}/${{ env.ARTIFACT_FILE_PREFIX }}-win64/*
           draft: true
         env:

--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -64,27 +64,26 @@ jobs:
             use-syslibs: false
             shared-libscsynth: false
 
-            # clang 16-18 disabled due to incompatible boost code - re-enable after updating bundled boost > ~1.80
-          # - job-name: ""
-          #   os-version: "24.04"
-          #   c-compiler: "clang-16"
-          #   cxx-compiler: "clang++-16"
-          #   use-syslibs: false
-          #   shared-libscsynth: false
+          - job-name: ""
+            os-version: "24.04"
+            c-compiler: "clang-16"
+            cxx-compiler: "clang++-16"
+            use-syslibs: false
+            shared-libscsynth: false
 
-          # - job-name: ""
-          #   os-version: "24.04"
-          #   c-compiler: "clang-17"
-          #   cxx-compiler: "clang++-17"
-          #   use-syslibs: false
-          #   shared-libscsynth: false
+          - job-name: ""
+            os-version: "24.04"
+            c-compiler: "clang-17"
+            cxx-compiler: "clang++-17"
+            use-syslibs: false
+            shared-libscsynth: false
 
-          # - job-name: ""
-          #   os-version: "24.04"
-          #   c-compiler: "clang-18"
-          #   cxx-compiler: "clang++-18"
-          #   use-syslibs: false
-          #   shared-libscsynth: false
+          - job-name: ""
+            os-version: "24.04"
+            c-compiler: "clang-18"
+            cxx-compiler: "clang++-18"
+            use-syslibs: false
+            shared-libscsynth: false
 
     name: Ubuntu ${{ matrix.os-version }} ${{ matrix.c-compiler }} ${{ matrix.job-name }}
     env:

--- a/.github/workflows/build_macos.yml
+++ b/.github/workflows/build_macos.yml
@@ -13,21 +13,31 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - job-name: "universal"
-            os-version: "13"
-            xcode-version: "14.1"
-            qt-version: '6.7.2' # will use qt from aqtinstall
+          - job-name: "arm64"
+            os-version: "15"
+            xcode-version: "16.0"
+            qt-version: "6.7.3" # will use qt from aqtinstall
             qt-modules: 'qtwebengine qtwebchannel qtwebsockets qtpositioning qt5compat'
-            deployment-target: "12"
-            cmake-architectures: "x86_64;arm64"
-            use-syslibs: false
-            shared-libscsynth: false
-            system-portaudio: true
-            build-libsndfile: false
-            build-readline: false
-            build-fftw: false
-            artifact-suffix: "macOS-universal"
-            verify-app: false # verify_app doesn't work properly with qt's rpaths
+            deployment-target: "11"
+            cmake-architectures: "arm64"
+            homebrew-packages: "libsndfile readline fftw portaudio"
+            vcpkg-packages: ""
+            vcpkg-triplet: ""
+            extra-cmake-flags: "" # -D SC_VERIFY_APP=ON # verify app doesn't seem to work with official qt6
+            artifact-suffix: "macOS-arm64"
+
+          - job-name: "x64"
+            os-version: "13"
+            xcode-version: "15.2"
+            qt-version: "6.7.3" # will use qt from aqtinstall
+            qt-modules: 'qtwebengine qtwebchannel qtwebsockets qtpositioning qt5compat'
+            deployment-target: "11"
+            cmake-architectures: "x86_64"
+            homebrew-packages: "libsndfile readline fftw portaudio"
+            vcpkg-packages: ""
+            vcpkg-triplet: ""
+            extra-cmake-flags: "" # -D SC_VERIFY_APP=ON # verify app doesn't seem to work with official qt6
+            artifact-suffix: "macOS-x64"
 
           - job-name: "x64 legacy"
             os-version: "13"
@@ -36,31 +46,34 @@ jobs:
             qt-modules: 'qtwebengine'
             deployment-target: "10.15"
             cmake-architectures: x86_64
-            use-syslibs: false
-            shared-libscsynth: false
-            build-libsndfile: true
-            system-portaudio: false
-            build-fftw: true
+            homebrew-packages: "readline portaudio"
+            vcpkg-packages: "libsndfile fftw3"
+            # homebrew-packages: "" # use this instead when cross-compiling for x86_64 on arm64
+            # homebrew-uninstall: "readline" # use this instead when cross-compiling for x86_64 on arm64
+            # vcpkg-packages: "readline portaudio libsndfile fftw3" # use this instead when cross-compiling for x86_64 on arm64
             vcpkg-triplet: x64-osx-release-supercollider # required for build-libsndfile
+            extra-cmake-flags: ""
             artifact-suffix: "macOS-x64-legacy" # set if needed - will trigger artifact upload
 
           - job-name: "x64 use system libraries"
             os-version: "13"
-            xcode-version: "14.1"
+            xcode-version: "15.2"
             deployment-target: ""
             cmake-architectures: x86_64
-            use-syslibs: true
-            shared-libscsynth: false
-            verify-app: false # verify app also doesn't work with homebrew's qt6
+            homebrew-packages: "qt@6 libsndfile readline fftw portaudio yaml-cpp boost"
+            vcpkg-packages: ""
+            vcpkg-triplet: ""
+            extra-cmake-flags: "-D SYSTEM_BOOST=ON -D SYSTEM_YAMLCPP=ON"
 
           - job-name: "x64 shared libscsynth"
             os-version: "13"
-            xcode-version: "14.1"
+            xcode-version: "15.2"
             deployment-target: ""
             cmake-architectures: x86_64
-            use-syslibs: false
-            shared-libscsynth: true
-            verify-app: false # verify app also doesn't work with homebrew's qt6
+            homebrew-packages: "qt@6 libsndfile readline fftw portaudio"
+            vcpkg-packages: ""
+            vcpkg-triplet: ""
+            extra-cmake-flags: "-D LIBSCSYNTH=ON"
 
     name: macOS ${{ matrix.job-name }}
     env:
@@ -93,8 +106,8 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/Library/Caches/ccache
-          key: ${{ runner.os }}-${{ matrix.os-version }}-${{ matrix.xcode-version }}-${{ matrix.deployment-target }}-${{ matrix.use-syslibs }}-${{ matrix.shared-libscsynth }}-${{ matrix.qt-version }}-${{ matrix.cmake-architectures }}-${{ steps.current-date.outputs.stamp }}
-          restore-keys: ${{ runner.os }}-${{ matrix.os-version }}-${{ matrix.xcode-version }}-${{ matrix.deployment-target }}-${{ matrix.use-syslibs }}-${{ matrix.shared-libscsynth }}-${{ matrix.qt-version }}-${{ matrix.cmake-architectures }}-
+          key: ${{ runner.os }}-${{ matrix.os-version }}-${{ matrix.xcode-version }}-${{ matrix.deployment-target }}-${{ matrix.cmake-architectures }}-${{ steps.current-date.outputs.stamp }}
+          restore-keys: ${{ runner.os }}-${{ matrix.os-version }}-${{ matrix.xcode-version }}-${{ matrix.deployment-target }}-${{ matrix.cmake-architectures }}-
 
       - name: cleanup homebrew downloads # always remove existing downloads first, as we bring back relevant downloads from cache
         run: rm -rf $(brew --cache)/downloads
@@ -104,16 +117,8 @@ jobs:
         id: cache-homebrew
         with:
           path: ~/Library/Caches/Homebrew/downloads
-          key: ${{ runner.os }}-${{ matrix.os-version }}-${{ matrix.xcode-version }}-${{ matrix.use-syslibs }}-${{ matrix.shared-libscsynth }}-${{ matrix.qt-version }}-${{ matrix.cmake-architectures }}-homebrew-${{ steps.current-date.outputs.week }}
-          restore-keys: ${{ runner.os }}-${{ matrix.os-version }}-${{ matrix.xcode-version }}-${{ matrix.use-syslibs }}-${{ matrix.shared-libscsynth }}-${{ matrix.qt-version }}-${{ matrix.cmake-architectures }}-homebrew-
-
-      - name: cache homebrew universal packages
-        uses: actions/cache@v4
-        if: matrix.cmake-architectures != 'x86_64' && (matrix.build-libsndfile != true || matrix.build-readline != true || matrix.build-fftw != true)
-        with:
-          path: ${{ env.BREW_UNIVERSAL_WORKDIR }}
-          key: ${{ runner.os }}-v1-${{ matrix.os-version }}-${{ matrix.xcode-version }}-${{ matrix.deployment-target }}-brew_universal-${{ steps.current-date.outputs.week }}
-          restore-keys: ${{ runner.os }}-v1-${{ matrix.os-version }}-${{ matrix.xcode-version }}-${{ matrix.deployment-target }}-brew_universal-
+          key: ${{ runner.os }}-${{ matrix.os-version }}-${{ matrix.cmake-architectures }}-homebrew-${{ steps.current-date.outputs.week }}
+          restore-keys: ${{ runner.os }}-${{ matrix.os-version }}-${{ matrix.cmake-architectures }}-homebrew-
 
       - name: cache vcpkg
         if: matrix.vcpkg-triplet
@@ -123,57 +128,35 @@ jobs:
           key: ${{ runner.os }}-${{ matrix.os-version }}-${{ matrix.xcode-version }}-${{ matrix.deployment-target }}-${{ matrix.vcpkg-triplet }}-${{ steps.current-date.outputs.stamp }}
           restore-keys: ${{ runner.os }}-${{ matrix.os-version }}-${{ matrix.xcode-version }}-${{ matrix.deployment-target }}-${{ matrix.vcpkg-triplet }}-
 
-      - name: install dependencies
+      - name: setup ccache
         run: |
-          brew install ccache
-          # add ccamke to PATH - see https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions
-          echo "/usr/local/opt/ccache/libexec" >> $GITHUB_PATH
-          if [[ "${{ matrix.system-portaudio }}" != "false" ]]; then brew install portaudio; fi
-          if [[ "${{ matrix.build-fftw }}" != "true" ]]; then brew install fftw; fi
+          brew install ccache --quiet
+          # add ccache to PATH
+          echo "`brew --prefix ccache`/libexec" >> $GITHUB_PATH
 
-          # install universal versions of homebrew libraries
-          if [[ "${{ matrix.cmake-architectures }}" != "x86_64" ]]; then
-              UNIVERSAL_PACKAGES=
-              if [[ "${{ matrix.build-libsndfile }}" != "true" ]]; then UNIVERSAL_PACKAGES="libsndfile $UNIVERSAL_PACKAGES"; fi
-              if [[ "${{ matrix.build-readline }}" != "true" ]]; then UNIVERSAL_PACKAGES="readline $UNIVERSAL_PACKAGES"; fi
-              if [[ "${{ matrix.build-fftw }}" != "true" ]]; then UNIVERSAL_PACKAGES="fftw $UNIVERSAL_PACKAGES"; fi
-              if [[ "${{ matrix.system-portaudio }}" != "false" ]]; then UNIVERSAL_PACKAGES="portaudio $UNIVERSAL_PACKAGES"; fi
-              echo "Downloading script for creating universal binaries from homebrew packages"
-              curl --no-progress-meter -O -J -L https://gist.githubusercontent.com/dyfer/6c83905d4593750105897e51e87ec345/raw/98e073d755cc3ca8426e20c30f51e9bac2bc9858/brew-install-universal.sh
-              chmod +x brew-install-universal.sh
-              ./brew-install-universal.sh $UNIVERSAL_PACKAGES
+      - name: setup vcpkg # vcpkg is not automatically installed in newer macOS runner images
+        if: matrix.vcpkg-packages && matrix.vcpkg-triplet
+        run: |
+          if [[ -z "${VCPKG_INSTALLATION_ROOT}" ]]; then
+            cd ${{ github.workspace }}/..
+            echo "setting up vcpkg in `pwd`"
+            git clone https://github.com/microsoft/vcpkg.git
+            cd vcpkg
+            ls -a
+            ./bootstrap-vcpkg.sh
+            echo "VCPKG_INSTALLATION_ROOT=`pwd`" >> $GITHUB_ENV # use the same env var that was used for VCPKG in older runner images
+            echo "`pwd`" >> $GITHUB_PATH
           fi
 
-      - name: install libsndfile # to make it compatible with older OSes (lower deployment target)
-        if: matrix.build-libsndfile == true && matrix.vcpkg-triplet
+      - name: install homebrew packages
+        if: matrix.homebrew-packages
+        run: brew install ${{ matrix.homebrew-packages }} --quiet
+
+      - name: install vcpkg packages
+        if: matrix.vcpkg-packages && matrix.vcpkg-triplet
         run: |
-          brew unlink libsndfile libvorbis libogg flac opus || true
-          vcpkg install libsndfile --triplet="${{ matrix.vcpkg-triplet }}" --overlay-triplets="$GITHUB_WORKSPACE/vcpkg/triplets"
-
-      - name: install readline # to allow cross-compiling
-        if: matrix.build-readline == true && matrix.vcpkg-triplet
-        run: |
-          brew uninstall --ignore-dependencies readline
-          vcpkg install readline --triplet="${{ matrix.vcpkg-triplet }}" --overlay-triplets="$GITHUB_WORKSPACE/vcpkg/triplets"
-          # vcpkg readline currently fails on arm64 (ncurses dependency)
-          # see https://github.com/microsoft/vcpkg/issues/22654
-
-      - name: install fftw # to allow cross-compiling
-        if: matrix.build-fftw == true && matrix.vcpkg-triplet
-        run: |
-          vcpkg install fftw3 --triplet="${{ matrix.vcpkg-triplet }}" --overlay-triplets="$GITHUB_WORKSPACE/vcpkg/triplets"
-
-      - name: install system libraries
-        if: env.USE_SYSLIBS == 'true'
-        run: brew install yaml-cpp boost
-
-      - name: install qt from homebrew
-        if: matrix.cmake-architectures == 'x86_64' && !matrix.qt-version
-        run: brew install qt@6
-
-      - name: install qt universal binary from homebrew
-        if: matrix.cmake-architectures != 'x86_64' && !matrix.qt-version
-        run: ./brew-install-universal.sh qt@6
+          if [[ -n "${{ matrix.homebrew-uninstall }}" ]]; then brew uninstall --ignore-dependencies ${{ matrix.homebrew-uninstall }}; fi
+          vcpkg install ${{ matrix.vcpkg-packages }} --triplet="${{ matrix.vcpkg-triplet }}" --overlay-triplets="$GITHUB_WORKSPACE/vcpkg/triplets"
 
       - name: install qt using aqtinstall
         uses: jurplel/install-qt-action@v3
@@ -184,30 +167,22 @@ jobs:
           modules: ${{ matrix.qt-modules }}
           version: ${{ matrix.qt-version }}
           cache: true
-          cache-key-prefix: ${{ runner.os }}-v1-${{ matrix.os-version }}-${{ matrix.xcode-version }}-${{ matrix.use-syslibs }}-${{ matrix.shared-libscsynth }}-qt${{ matrix.qt-version }}
+          cache-key-prefix: ${{ runner.os }}-qt${{ matrix.qt-version }}-${{ matrix.qt-modules }}
 
       - name: configure
         run: |
           mkdir $BUILD_PATH && cd $BUILD_PATH
 
-          EXTRA_CMAKE_FLAGS=
-
-          if $USE_SYSLIBS; then EXTRA_CMAKE_FLAGS="-DSYSTEM_BOOST=ON -DSYSTEM_YAMLCPP=ON $EXTRA_CMAKE_FLAGS"; fi
-
-          if $SHARED_LIBSCSYNTH; then EXTRA_CMAKE_FLAGS="-DLIBSCSYNTH=ON $EXTRA_CMAKE_FLAGS"; fi
-
-          if [[ "${{ matrix.verify-app }}" == "true" ]]; then EXTRA_CMAKE_FLAGS="-DSC_VERIFY_APP=ON $EXTRA_CMAKE_FLAGS"; fi
-
-          if [[ "${{ matrix.system-portaudio }}" == "false" ]]; then EXTRA_CMAKE_FLAGS="-DSYSTEM_PORTAUDIO=OFF $EXTRA_CMAKE_FLAGS"; fi
+          CMAKE_FLAGS="-G Xcode -D RULE_LAUNCH_COMPILE=ccache -D SUPERNOVA=ON  ${{ matrix.extra-cmake-flags }}"
 
           if [[ -n "${{ matrix.vcpkg-triplet }}" ]]; then
             export VCPKG_ROOT=$VCPKG_INSTALLATION_ROOT
-            EXTRA_CMAKE_FLAGS="-DVCPKG_TARGET_TRIPLET=${{ matrix.vcpkg-triplet }} -DCMAKE_BUILD_TYPE=Release $EXTRA_CMAKE_FLAGS"
+            CMAKE_FLAGS="-DVCPKG_TARGET_TRIPLET=${{ matrix.vcpkg-triplet }} -DCMAKE_BUILD_TYPE=Release $CMAKE_FLAGS"
           fi
 
-          echo "EXTRA_CMAKE_FLAGS:" $EXTRA_CMAKE_FLAGS
+          echo "CMAKE_FLAGS:" $CMAKE_FLAGS
 
-          cmake -G"Xcode" -DRULE_LAUNCH_COMPILE=ccache -DSUPERNOVA=ON $EXTRA_CMAKE_FLAGS ..
+          cmake $CMAKE_FLAGS ..
 
       - name: build
         run: cmake --build $BUILD_PATH --config Release --target install

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -21,31 +21,42 @@ jobs:
             qt-arch: "win32_msvc2019"
             fftw-url: "ftp://ftp.fftw.org/pub/fftw/fftw-3.3.5-dll32.zip"
             cmake-generator: "Visual Studio 16 2019"
-            msvc-year: "2019"
-            vcvars-script: "vcvars32.bat"
+            vcvars-script-path: "C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Auxiliary/Build/vcvars32.bat"
             vcpkg-triplet: x86-windows-release
             use-qtwebengine: "ON" # might need to be turned off for MinGW
             qt-modules: "qtwebengine"
-            artifact-suffix: "win32" # set if needed - will trigger artifact upload
-            create-installer: ${{ startsWith(github.ref, 'refs/tags/') }}
-            installer-suffix: "win32-installer"
+            # artifact-suffix: "win32" # set if needed - will trigger artifact upload
+            # create-installer: ${{ startsWith(github.ref, 'refs/tags/') }}
+            # installer-suffix: "win32-installer"
 
-          - job-name: "64-bit"
+          - job-name: "64-bit MSVC 2022"
             fftw-arch: "x64"
             cmake-arch: "x64"
-            os-version: "2019"
-            qt-version: "6.7.2"
+            os-version: "2022"
+            qt-version: "6.7.3"
             qt-arch: "win64_msvc2019_64"
             fftw-url: "ftp://ftp.fftw.org/pub/fftw/fftw-3.3.5-dll64.zip"
-            cmake-generator: "Visual Studio 16 2019"
-            msvc-year: "2019"
-            vcvars-script: "vcvars64.bat"
+            cmake-generator: "Visual Studio 17 2022"
+            vcvars-script-path: "C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Auxiliary/Build/vcvars64.bat"
             vcpkg-triplet: x64-windows-release
             use-qtwebengine: "ON" # might need to be turned off for MinGW
             qt-modules: 'qtwebengine qtwebchannel qtwebsockets qtpositioning qt5compat'
             artifact-suffix: "win64" # set if needed - will trigger artifact upload
             create-installer: ${{ startsWith(github.ref, 'refs/tags/') }}
             installer-suffix: "win64-installer"
+
+          - job-name: "64-bit MSVC 2019"
+            fftw-arch: "x64"
+            cmake-arch: "x64"
+            os-version: "2019"
+            qt-version: "6.7.3"
+            qt-arch: "win64_msvc2019_64"
+            fftw-url: "ftp://ftp.fftw.org/pub/fftw/fftw-3.3.5-dll64.zip"
+            cmake-generator: "Visual Studio 16 2019"
+            vcvars-script-path: "C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Auxiliary/Build/vcvars64.bat"
+            vcpkg-triplet: x64-windows-release
+            use-qtwebengine: "ON" # might need to be turned off for MinGW
+            qt-modules: 'qtwebengine qtwebchannel qtwebsockets qtpositioning qt5compat'
 
           - job-name: "64-bit MinGW"
             fftw-arch: "x64"
@@ -64,7 +75,6 @@ jobs:
       BUILD_PATH: ${{ github.workspace }}/build
       INSTALL_PATH: ${{ github.workspace }}/build/Install
       LIBS_DOWNLOAD_PATH: ${{ github.workspace }}/../3rd-party
-      VCVARS_SCRIPT_PATH: "C:/Program Files (x86)/Microsoft Visual Studio/${{ matrix.msvc-year }}/Enterprise/VC/Auxiliary/Build/${{ matrix.vcvars-script }}"
       FFTW_INSTALL_DIR: "C:/Program Files/fftw"
       ARTIFACT_FILE: "SuperCollider-${{ inputs.sc-version }}-${{ matrix.artifact-suffix }}"
       INSTALLER_FILE: "SuperCollider-${{ inputs.sc-version }}-${{ matrix.installer-suffix }}"
@@ -90,8 +100,8 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/AppData/Local/ccache # updated in ccache 4.7, see https://github.com/ccache/ccache/issues/1023
-          key: ${{ runner.os }}-${{ matrix.os-version }}-${{ matrix.cmake-arch }}-${{ matrix.qt-arch }}-${{ matrix.qt-version }}-${{ steps.current-date.outputs.stamp }}
-          restore-keys: ${{ runner.os }}-${{ matrix.os-version }}-${{ matrix.cmake-arch }}-${{ matrix.qt-arch }}-${{ matrix.qt-version }}-
+          key: ${{ runner.os }}-${{ matrix.os-version }}-${{ matrix.cmake-arch }}-${{ matrix.qt-arch }}-${{ steps.current-date.outputs.stamp }}
+          restore-keys: ${{ runner.os }}-${{ matrix.os-version }}-${{ matrix.cmake-arch }}-${{ matrix.qt-arch }}-
 
       - name: install qt using aqtinstall
         uses: jurplel/install-qt-action@v3
@@ -100,7 +110,7 @@ jobs:
           version: ${{ matrix.qt-version }}
           arch: ${{ matrix.qt-arch }}
           cache: true
-          cache-key-prefix: ${{ runner.os }}-v1-${{ matrix.os-version }}-${{ matrix.qt-version }}-qt${{ matrix.qt-arch }}
+          cache-key-prefix: ${{ runner.os }}-${{ matrix.os-version }}-${{ matrix.qt-version }}-qt${{ matrix.qt-arch }}-${{ matrix.qt-modules }}
 
       - name: install ccache
         shell: bash
@@ -125,11 +135,11 @@ jobs:
           7z x fftw.zip -y
 
       - name: create fftw msvc library
-        if: matrix.vcvars-script
+        if: matrix.vcvars-script-path
         shell: cmd
         working-directory: ${{ env.FFTW_INSTALL_DIR }}
         run: |
-          call "%VCVARS_SCRIPT_PATH%"
+          call "${{ matrix.vcvars-script-path }}"
           lib.exe /machine:${{ matrix.fftw-arch }} /def:libfftw3f-3.def
 
       - name: install asio sdk

--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ See the [Raspberry Pi](README_RASPBERRY_PI.md) and [BeagleBone Black](README_BEA
 ### Platform support
 
 SuperCollider is tested with:
-- Windows 10 64-bit and MSVC 2019
-- macOS 13 and Xcode 14.1
+- Windows 10 64-bit and MSVC 2022
+- macOS 12 and Xcode 15.2
 - Ubuntu 22.04 and gcc 12
 
 SuperCollider is known to support these platforms:


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

~~Draft PR to explore issues with the toolchain upgrades~~

This PR updates the build matrix:
- Linux
  - enable clang 16-18 builds
- macOS:
  - separate arm64 and x64 builds
  - remove `brew-install-universal` script and the "universal" build, which took a long time
  - use qt6 from aqt install to provide compatibility with macOS versions lower than the build OS (I checked, the builds using homebrew qt@6 done on macOS 13 did not run on macOS 12)
    - update qt to version 6.7.3, the last one compatible with macOS 11
  - change structure of the build script, grouping installation steps by package source, rather than package name
  - minor cleanup of the yaml file - cache keys etc
- Windows:
  - add MSVC 2022 build and use artifacts from it for releases etc
  - update qt to version 6.7.3
  - stop uploading windows 32-bit builds
  - minor cleanup of the yaml file - cache keys etc


Outstanding issues:
- on macOS qt@6 from aqt install takes a relatively long time to install when not cached and the cache is large; however cached install is not too bad. We can't do anything about this anyway...
- on macOS both x64 and arm64 builds are large; the qt libraries in the app bundle end up including both architectures (i.e. are "universal"). My understanding is that `macdeployqt` [should "strip" the binaries by default](https://doc.qt.io/qt-6/macos-deployment.html#:~:text=dmg%20disk%20image-,%2Dno%2Dstrip,-Don%27t%20run%20%27strip), leaving just one architecture, but this doesn't seem to be the case here.
  - this nullifies the "smaller binaries" argument of dropping the universal build, but the separate builds are still a bit faster

## Types of changes

<!-- Delete lines that don't apply -->

- New feature / maintenance
- Documentation

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
