### PR TITLE
[tests] TestCoreUGen updates

### DIFF
--- a/testsuite/classlibrary/TestCoreUGens.sc
+++ b/testsuite/classlibrary/TestCoreUGens.sc
@@ -39,7 +39,7 @@ TestCoreUGens : UnitTest {
 			"Line.kr can match LFSaw.kr" -> {Line.kr(0,1,1) - LFSaw.kr(0.5)},
 			"Line can match crossfaded DC" -> {Line.ar(0,1,1) - LinXFade2.ar(DC.ar(0), DC.ar(1), Line.ar(-1,1,1))},
 			// (Integrator goes a bit off ramp cos of roundoff error accumulations)
-			"Line.ar can match integrated DC" -> {Line.ar(0,1,1) - Integrator.ar(DC.ar(SampleDur.ir))},
+			"Line.ar can match integrated DC" -> {Line.ar(SampleDur.ir,1,1) - Integrator.ar(DC.ar(SampleDur.ir))},
 			"Line.ar can match EnvGen.ar with slope Env" -> {Line.ar - EnvGen.ar(Env([0,1],[1]))},
 
 			//////////////////////////////////////////

--- a/testsuite/classlibrary/TestCoreUGens.sc
+++ b/testsuite/classlibrary/TestCoreUGens.sc
@@ -266,7 +266,7 @@ TestCoreUGens : UnitTest {
 			[\squared, \sqrt],
 			[\cubed, { |x| x ** (1/3) }],
 			[\exp, \log],
-			[\midicps, \cpsmidi],
+			[\midicps, \cpsmidi], // this test currently limits passing tolerance for all tests
 			[\midiratio, \ratiomidi],
 			[\dbamp, \ampdb],
 			[\octcps, \cpsoct],
@@ -312,7 +312,9 @@ TestCoreUGens : UnitTest {
 
 		tests.keysValuesDo { |name, func, i|
 			func.loadToFloatArray(testDur, server, { |data|
-				this.assertArrayFloatEquals(data, 0, name.quote, within: 0.001, report: true);
+				this.assertArrayFloatEquals(data, 0, name.quote,
+					within: -90.dbamp, // could go to -100 if not for midicps(cpsmidi()) test
+					report: true);
 				completed = completed + 1;
 				cond.signalOne;
 			});
@@ -351,7 +353,7 @@ TestCoreUGens : UnitTest {
 			});
 			server.sync;
 		};
-		"timing out after % sec\n".postf(tests.size * testDur);
+
 		testsFinished = cond.waitFor((1.5 * tests.size * testDur).max(minTimeOut), { completed == tests.size });
 		this.assert(testsFinished, "TIMEOUT: exact_convergence tests", report: false);
 	}


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

This update does some minor fixes and updates to the CoreUGen tests, which came up in the course of other work.

- the tolerance of the UGen equivalence tests was too permissive — `0.001` corresponds to a -60 dB tolerance, so that's been lowered to -90 dB. It could be a bit lower if not for the reversible test for `\midicps`<-> `\cpsmidi` test, which seems to have higher error because of the exponential operations involved. 
  - this change caught an erroneously passing `Integrator`/`Line` equivalence test.

- the delays/bufdelays tests and the reversible ops tests were refactored with a rate switch for a smaller footprint
  - Note that for the delays tests, previously the `kr` test was still running the Delay UGens at `ar`, and only switching the delaytime argument to `kr`. I assume this was an oversight so now those UGens under test, and those used for its inputs, are made to run at `kr`.

## Types of changes

<!-- Delete lines that don't apply -->
- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [ ] All tests are passing
- [ ] Updated documentation: **N/A**
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
