### PR TITLE
GHA macOS: clear homebrew downloads only

### DIFF
--- a/.github/workflows/build_macos.yml
+++ b/.github/workflows/build_macos.yml
@@ -94,7 +94,7 @@ jobs:
           restore-keys: ${{ runner.os }}-${{ matrix.os-version }}-${{ matrix.xcode-version }}-${{ matrix.deployment-target }}-${{ matrix.use-syslibs }}-${{ matrix.shared-libscsynth }}-${{ matrix.qt-version }}-${{ matrix.cmake-architectures }}-
 
       - name: cleanup homebrew downloads # always remove existing downloads first, as we bring back relevant downloads from cache
-        run: rm -rf $(brew --cache)
+        run: rm -rf $(brew --cache)/downloads
 
       - name: cache homebrew downloads
         uses: actions/cache@v4


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

Currently CI on macOS fails.

I realized that we were previously deleting all homebrew cache, instead of just the downloads. This PR fixes that. It also prevents the recent failures in macOS GHA runners.

With this change we won't need #6492 anymore.

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [ ] All tests are passing
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
