### PR TITLE
Add <https://git-scm.com> to the Quark error message

### DIFF
--- a/SCClassLibrary/Common/Quarks/Git.sc
+++ b/SCClassLibrary/Common/Quarks/Git.sc
@@ -148,7 +148,7 @@ Git {
 			Pipe.callSync(gitFind, {
 				gitIsInstalled = true;
 			}, { arg error;
-				"Quarks requires git to be installed".error;
+				"ERROR: Quarks requires git to be installed. Follow the installation instructions at <https://git-scm.com>.".error;
 				gitIsInstalled = false;
 			});
 		};

--- a/SCClassLibrary/Common/Quarks/Git.sc
+++ b/SCClassLibrary/Common/Quarks/Git.sc
@@ -148,7 +148,7 @@ Git {
 			Pipe.callSync(gitFind, {
 				gitIsInstalled = true;
 			}, { arg error;
-				"ERROR: Quarks requires git to be installed. Follow the installation instructions at <https://git-scm.com>.".error;
+				"Quarks requires git to be installed. Follow the installation instructions at <https://git-scm.com>.".error;
 				gitIsInstalled = false;
 			});
 		};


### PR DESCRIPTION
Add a kind instruction to the error message for git not installed.

<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

Using Quarks is a barrier for newcomers. The current error message is not helpful in this regard:

 >ERROR: Quarks requires git to be installed

By adding the following sentence, newcomers can reduce the time to resolve the error:

>Follow the installation instructions at <https://git-scm.com>.

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->

- New feature: not exactly a new feature. Just an error message is a detailed explanation. 
 
## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [ ] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
