### PR TITLE
ClassLib: Version/VersionConstraint implementation (Semantic Versioning)

### DIFF
--- a/HelpSource/Classes/Version.schelp
+++ b/HelpSource/Classes/Version.schelp
@@ -1,0 +1,144 @@
+TITLE:: Version
+summary:: Implementation of the Semantic Versioning standard
+categories:: Development
+related:: Classes/VersionConstraint
+
+DESCRIPTION::
+Version is a tool designed to ease dependency management when developping SuperCollider projects. You will need it if you intend to develop a Quark, or if you'd like to implement semantic versioning inside your own project.
+
+Version provides basic tools to work with semantic versioning. If this subject is new to you, you should read the Semantic Versioning standard documentation before you go further : https://semver.org/ .
+
+It provides getters for standard initial versions, automatic version increments, and basic version comparisons.
+
+CLASSMETHODS::
+
+subsection::Instancing Class Methods
+
+METHOD:: new
+ARGUMENT:: semverString
+: a correct Semantic Versioning string. Please note that this class provides all the tools you need to never have to type the string yourself, which is the recommended method.
+returns:: A new Version which string is equal to semverString, or "0.1.0" if none is provided.
+
+METHOD:: helloWorld
+returns:: a new Version which string is equal to "0.1.0".
+
+METHOD:: beta
+returns:: a new Version which string is equal to "1.0.0-beta".
+
+METHOD:: alpha
+returns:: a new Version which string is equal to "1.0.0-alpha".
+
+METHOD:: v1
+returns:: a new Version which string is equal to "1.0.0".
+
+subsection::Private Class Methods
+
+METHOD:: prSemverStringToEvent
+A private method that converts the Semantic Versioning string into an Event to allow further manipulation. Should not be used directly.
+ARGUMENT:: semverString
+returns:: the Semantic Versioning string formatted as an Event.
+
+
+INSTANCEMETHODS::
+
+subsection::Getters Instance Methods
+
+METHOD:: string
+This method returns the current Semantic Version string, correctly formatted. This is the only information you'll need to store into your project once the Version has been modified.
+returns:: the Semantic Version string, correctly formatted.
+
+METHOD:: major
+returns:: the major version, as an Integer.
+
+METHOD:: minor
+returns:: the minor version, as an Integer.
+
+METHOD:: patch
+returns:: the patch version, as an Integer.
+
+subsection::Setters Instance Methods
+
+METHOD:: bumpMajor
+Increase the major version by 1, resetting both minor and patch version. Pre-release and build are left untouched, meaning you might want to use .clear to reset them aswell.
+
+METHOD:: bumpMinor
+Increase the minor version by 1, resetting patch version. Pre-release and build are left untouched, meaning you might want to use .clear to reset them aswell.
+
+METHOD:: bumpPatch
+Increase the patch version by 1. Pre-release and build are left untouched, meaning you might want to use .clear to reset them aswell.
+
+METHOD:: clear
+Sets both build and pre-release versions to nil. Usually called after incrementing major, minor or patch version.
+
+subsection::SetGet Instance Methods
+
+METHOD:: preRelease
+Replaces current pre-release version with aString, or sets it to nil if aString equals "".
+ARGUMENT:: aString
+
+METHOD:: build
+Replaces current build version with aString, or sets it to nil if aString equals "".
+ARGUMENT:: aString
+
+subsection::Comparison Instance Methods
+
+METHOD:: ==
+Returns true if both versions major, minor, patch and pre-release are the same, false otherwise. Does not compare builds.
+ARGUMENT:: aVersion
+returns:: aBoolean
+
+METHOD:: !=
+Returns true if at least one of the two versions major, minor, patch or pre-release are the different, false otherwise. Does not compare builds.
+ARGUMENT:: aVersion
+returns:: aBoolean
+
+METHOD:: ===
+Returns true if both versions major, minor, patch, pre-release and build are the same, false otherwise.
+ARGUMENT:: aVersion
+returns:: aBoolean
+
+METHOD:: !==
+Returns true if at least one of the two versions major, minor, patch, pre-release or build are the different, false otherwise.
+ARGUMENT:: aVersion
+returns:: aBoolean
+
+METHOD:: isMajorEqual
+Returns true if compared Versions have the same major version number, false otherwise.
+ARGUMENT:: aVersion
+returns:: aBoolean
+
+METHOD:: isMinorEqual
+Returns true if compared Versions have the same major version number and the same minor version number, false otherwise.
+ARGUMENT:: aVersion
+returns:: aBoolean
+
+METHOD:: isPatchEqual
+Returns true if compared Versions have the same major version number, the same minor version number and the same patch version number, false otherwise.
+ARGUMENT:: aVersion
+returns:: aBoolean
+
+METHOD:: <
+Returns true if the receiver version is strictly inferior to the argument version. Cannot compare two pre-release precedence, so will yield false by default if patches are the same and both Versions have differents pre-release.
+ARGUMENT:: aVersion
+returns:: aBoolean
+
+METHOD:: <=
+Returns true if the receiver version is equal or inferior to the argument version. Cannot compare two pre-release precedence, so will yield false by default if patches are the same and both Versions have differents pre-release.
+ARGUMENT:: aVersion
+returns:: aBoolean
+
+METHOD:: >
+Returns true if the receiver version is strictly posterior to the argument version. Cannot compare two pre-release precedence, so will yield false by default if patches are the same and both Versions have differents pre-release.
+ARGUMENT:: aVersion
+returns:: aBoolean
+
+METHOD:: >=
+Returns true if the receiver version is equal or posterior to the argument version. Cannot compare two pre-release precedence, so will yield false by default if patches are the same and both Versions have differents pre-release.
+ARGUMENT:: aVersion
+returns:: aBoolean
+
+subsection::Private Instance Methods
+
+METHOD:: init
+Called when the instance is created. Will convert the Semantic Version string into an Event, and assign instance's variables accordingly.
+ARGUMENT:: semverString

--- a/HelpSource/Classes/VersionConstraint.schelp
+++ b/HelpSource/Classes/VersionConstraint.schelp
@@ -1,0 +1,67 @@
+TITLE:: VersionConstraint
+summary:: Comparing dependency requirements when using Semantic Versioning
+categories:: Development
+related:: Classes/Version
+
+DESCRIPTION::
+VersionConstraint is a development tool designed to check dependency requirements when using SuperCollider's implementation of Semantic Versioning link::Classes/Version:: class.
+
+It allows you to specifiy a set of rules and to check a Semver string against those rules to see if the version meets the requirements. It will return a boolean.
+
+Rules are specified as a link::Classes/String::, which format is a set of substrings separated with empty spaces characters. Each of those substrings begin with an operand, directly followed by the semver string to compare the version with. See the example below for a practical example.
+
+Available operands are code::= ! === !== < <= > >=:: .
+
+Additionally, you can use code::noPreRelease:: to exclude versions which have a pre-release tag.
+
+note::This class does not support individual version components comparisons. There is no syntax to directly ask for a major version match. For example, to match version 1, you need to match superior or equal to version 1.0.0, and inferior to version 2.0.0 : code::VersionConstraint(">=1.0.0 <2.0.0"):: .::
+
+
+CLASSMETHODS::
+
+METHOD:: new
+Create a new link::Classes/VersionConstraint:: with the specified requirements.
+ARGUMENT:: requirements
+returns:: a link::Classes/VersionConstraint:: instance.
+
+
+INSTANCEMETHODS::
+
+METHOD:: setRequirements
+Update the instance's requirements.
+ARGUMENT:: requirements
+
+METHOD:: compatibleWith
+Given a Semver link::Classes/String::, checks if the associated link::Classes/Version:: matches the current requirements, and returns the result.
+ARGUMENT:: aSemverString
+returns:: aBoolean
+
+
+EXAMPLES::
+
+code::
+(
+// This set of rules specifies :
+// - superior or equal to version 1.0.0
+// - inferior to version 2.0.0
+// - different from version 1.3.7
+// - pre-release versions do not match
+
+var constraint =
+VersionConstraint(">=1.0.0 <2.0.0 !1.3.7 noPreRelease");
+
+var versionA = "1.0.0";
+var versionB = "3.0.7";
+var versionC = "1.3.7";
+var versionD = "1.1.0-alpha";
+var versionE = "1.2.3+2";
+var versionF = "1.7.22";
+
+constraint.compatibleWith(versionA).postln;
+constraint.compatibleWith(versionB).postln;
+constraint.compatibleWith(versionC).postln;
+constraint.compatibleWith(versionD).postln;
+constraint.compatibleWith(versionE).postln;
+constraint.compatibleWith(versionF).postln;
+)
+::

--- a/SCClassLibrary/Common/Quarks/Version.sc
+++ b/SCClassLibrary/Common/Quarks/Version.sc
@@ -1,0 +1,368 @@
+Version : Object {
+
+	var majorVersion = 0;
+	var minorVersion = 1;
+	var patchVersion = 0;
+	var preReleaseVersion = nil;
+	var buildVersion = nil;
+
+	*new { |semverString = "0.1.0"|
+		^super.new.init(semverString);
+	}
+
+	init { |semverString|
+		// Convert the given string into an event
+		var semverAsEvent
+		= Version.prSemverStringToEvent(semverString);
+		// Assign version specifications
+		// to the instance
+		majorVersion = semverAsEvent[\major];
+		minorVersion = semverAsEvent[\minor];
+		patchVersion = semverAsEvent[\patch];
+		preReleaseVersion = semverAsEvent[\preRelease];
+		buildVersion = semverAsEvent[\build];
+	}
+
+	// Converts a semver string
+	// into an event for further manipulations
+	// Expects a correct semver string
+	*prSemverStringToEvent { |semverString|
+		// This is an event and not a list because
+		// 4th element could be either
+		// a pre-release or a build information
+		var semverAsEvent = (
+			major: nil,
+			minor: nil,
+			patch: nil,
+			preRelease: nil,
+			build: nil
+		);
+		var semver = semverString;
+		var split;
+
+		// Checking if semver string
+		// contains build information
+		if("[[.+.]]".matchRegexp(semver)) {
+			var split = semver.split($+);
+			semverAsEvent[\build] = split[1];
+			semver = split[0];
+		};
+
+		// Checking if semver string
+		// contains pre-release information
+		// This needs a particular algorithm
+		// because several hyphens are tolerated,
+		// with only the first one delimiting
+		// version numbers from pre-release
+		// identifier
+		if("[[.-.]]".matchRegexp(semver)) {
+			var position = 0;
+			var delimiterReached = false;
+			var semverString = "";
+			var releaseString = "";
+			while { position < semver.size } {
+				if(delimiterReached.not) {
+					if(semver[position] != $-) {
+						semverString =
+						semverString ++ semver[position];
+					} {
+						delimiterReached = true;
+					};
+				} {
+					releaseString =
+					releaseString ++ semver[position];
+				};
+				position = position + 1;
+			};
+			semverAsEvent[\preRelease] = releaseString;
+			semver = semverString;
+		};
+
+		// Separating Major / Minor / Patch
+		split = semver.split($.);
+		semverAsEvent[\major] = split[0].asInteger;
+		semverAsEvent[\minor] = split[1].asInteger;
+		semverAsEvent[\patch] = split[2].asInteger;
+
+		// Return the event
+		^semverAsEvent
+	}
+
+	// Version specification getters
+	major {
+		^majorVersion
+	}
+
+	minor {
+		^minorVersion
+	}
+
+	patch {
+		^patchVersion
+	}
+
+	preRelease {
+		^preReleaseVersion
+	}
+
+	build {
+		^buildVersion
+	}
+
+	// Special getters
+	*helloWorld {
+		^this.new
+	}
+
+	*beta {
+		^this.new.bumpMajor.preRelease_("beta")
+	}
+
+	*alpha {
+		^this.new.bumpMajor.preRelease_("alpha")
+	}
+
+	*v1 {
+		^this.new.bumpMajor
+	}
+
+	// Version specification setters
+	bumpMajor {
+		majorVersion = majorVersion + 1;
+		minorVersion = 0;
+		patchVersion = 0;
+	}
+
+	bumpMinor {
+		minorVersion = minorVersion + 1;
+		patchVersion = 0;
+	}
+
+	bumpPatch {
+		patchVersion = patchVersion + 1;
+	}
+
+	// Should it remove "-"
+	// if it is the first character ?
+	preRelease_ { |aString|
+		if(aString != "")
+		{ preReleaseVersion = aString; }
+		{ preReleaseVersion = nil; };
+	}
+
+	// Should it remove "+"
+	// if it is the first character ?
+	build_ { |aString|
+		if(aString != "")
+		{ buildVersion = aString; }
+		{ buildVersion = nil; };
+	}
+
+	// Special setter
+	clear {
+		preReleaseVersion = nil;
+		buildVersion = nil;
+	}
+
+	// Semver String getter
+	string {
+		var string = "";
+		string = string ++ majorVersion.asString;
+		string = string ++ ".";
+		string = string ++ minorVersion.asString;
+		string = string ++ ".";
+		string = string ++ patchVersion.asString;
+		// Append pre-release if needed
+		if(preReleaseVersion.notNil) {
+			string = string ++ "-";
+			string = string ++ preReleaseVersion;
+		};
+		// Append build if needed
+		if(buildVersion.notNil) {
+			string = string ++ "+";
+			string = string ++ buildVersion;
+		};
+		// Return
+		^string
+	}
+
+	// Comparisons tools
+
+	// Equality symbol checks equality
+	// WITHOUT comparing builds
+	== { |aVersion|
+		var equality = (majorVersion == aVersion.major);
+		if(equality)
+		{ equality = (minorVersion == aVersion.minor); };
+		if(equality)
+		{ equality = (patchVersion == aVersion.patch); };
+		if(equality) {
+			equality =
+			(preReleaseVersion == aVersion.preRelease);
+		};
+		^equality
+	}
+
+	!= { |aVersion|
+		^(this == aVersion).not
+	}
+
+	// Identity symbol also checks builds equality
+	=== { |aVersion|
+		^(this.string == aVersion.string);
+	}
+
+	!== { |aVersion|
+		^(this.string == aVersion.string).not
+	}
+
+	isPatchEqual { |aVersion|
+		var identity = (majorVersion == aVersion.major);
+		if(identity)
+		{ identity = (minorVersion == aVersion.minor); };
+		if(identity)
+		{ identity = (patchVersion == aVersion.patch); };
+		^identity
+	}
+
+	isMinorEqual { |aVersion|
+		var identity = (majorVersion == aVersion.major);
+		if(identity)
+		{ identity = (minorVersion == aVersion.minor); };
+		^identity
+	}
+
+	isMajorEqual { |aVersion|
+		var identity = (majorVersion == aVersion.major);
+		^identity
+	}
+
+	// Precedency && Posteriority don't check
+	// pre-release content itself,
+	// only if it's nil or not
+	// "1.0.0" > "1.0.0-beta" equals True
+	// "1.0.0-alpha" > "1.0.0-beta" equals False
+
+	< { |aVersion|
+		if(majorVersion != aVersion.major) {
+			if(majorVersion < aVersion.major)
+			{ ^true }
+			{ ^false };
+		} { // if majors are equal
+			if(minorVersion != aVersion.minor) {
+				if(minorVersion < aVersion.minor)
+				{ ^true }
+				{ ^false };
+			} { // if minors are also equal
+				if(patchVersion != aVersion.patch) {
+					if(patchVersion < aVersion.patch)
+					{ ^true }
+					{ ^false };
+				} { // if patches are also equal
+					// Only thing we can distinguish for now
+					// is either 'equality'
+					// or the presence of pre-release information
+					// pre-release strings are not comparable
+					// without a collective 'hard-coded'
+					// decision procedure
+					if(this == aVersion)
+					{ ^false }
+					{ ^(preReleaseVersion.notNil && aVersion.preRelease.isNil) };
+				};
+			};
+		};
+	}
+
+	<= { |aVersion|
+		if(majorVersion != aVersion.major) {
+			if(majorVersion < aVersion.major)
+			{ ^true }
+			{ ^false };
+		} { // if majors are equal
+			if(minorVersion != aVersion.minor) {
+				if(minorVersion < aVersion.minor)
+				{ ^true }
+				{ ^false };
+			} { // if minors are also equal
+				if(patchVersion != aVersion.patch) {
+					if(patchVersion < aVersion.patch)
+					{ ^true }
+					{ ^false };
+				} { // if patches are also equal
+					if(this == aVersion)
+					{ ^true }
+					{ if(preReleaseVersion.notNil && aVersion.preRelease.isNil)
+						{ ^true }
+						// Yield false if both versions have
+						// different pre-release informations
+						// because we can't compare their precedence
+						// though precedence could technically be true
+						{ ^false };
+					};
+				};
+			};
+		};
+	}
+
+	> { |aVersion|
+		if(majorVersion != aVersion.major) {
+			if(majorVersion > aVersion.major)
+			{ ^true }
+			{ ^false };
+		} { // if majors are equal
+			if(minorVersion != aVersion.minor) {
+				if(minorVersion > aVersion.minor)
+				{ ^true }
+				{ ^false };
+			} { // if minors are also equal
+				if(patchVersion != aVersion.patch) {
+					if(patchVersion > aVersion.patch)
+					{ ^true }
+					{ ^false };
+				} { // if patches are also equal
+					// Only thing we can distinguish for now
+					// is either 'equality'
+					// or the presence of pre-release information
+					// pre-release strings are not comparable
+					// without a collective 'hard-coded'
+					// decision procedure
+					if(this == aVersion)
+					{ ^false }
+					{ ^(preReleaseVersion.isNil && aVersion.preRelease.notNil) };
+				};
+			};
+		};
+	}
+
+	>= { |aVersion|
+		if(majorVersion != aVersion.major) {
+			if(majorVersion > aVersion.major)
+			{ ^true }
+			{ ^false };
+		} { // if majors are equal
+			if(minorVersion != aVersion.minor) {
+				if(minorVersion > aVersion.minor)
+				{ ^true }
+				{ ^false };
+			} { // if minors are also equal
+				if(patchVersion != aVersion.patch) {
+					if(patchVersion > aVersion.patch)
+					{ ^true }
+					{ ^false };
+				} { // if patches are also equal
+					if(this == aVersion)
+					{ ^true }
+					{ if(preReleaseVersion.isNil && aVersion.preRelease.notNil)
+						{ ^true }
+						// Yield false if both versions have
+						// different pre-release informations
+						// because we can't compare their posteriority
+						// though posteriority could technically be true
+						{ ^false };
+					};
+				};
+			};
+		};
+	}
+
+}

--- a/SCClassLibrary/Common/Quarks/VersionConstraint.sc
+++ b/SCClassLibrary/Common/Quarks/VersionConstraint.sc
@@ -1,0 +1,91 @@
+VersionConstraint : Object {
+
+	var versionRequirements = nil;
+	var noPreRelease = false;
+
+	*new { |requirements = nil|
+		^super.new.init(requirements);
+	}
+
+	init { |requirements|
+		this.setRequirements(requirements);
+	}
+
+	setRequirements { |requirements = nil|
+		if(requirements.notNil) {
+			versionRequirements = requirements.split(Char.space);
+			if(versionRequirements.includesEqual("noPreRelease")) {
+				noPreRelease = true;
+				versionRequirements =
+				versionRequirements.select({ |item|
+					item != "noPreRelease"; });
+			};
+		} {
+			versionRequirements = nil;
+		};
+	}
+
+	compatibleWith { |aSemverString|
+		if(versionRequirements.isNil) {
+			^true
+		} {
+			var version = Version(aSemverString);
+			var operators = "=!<>";
+			// Check noPreRelease condition
+			if(noPreRelease) {
+				if(version.preRelease.notNil) {
+					^false
+				};
+			};
+			// Iterate through conditions
+			versionRequirements.do({ |requirement|
+				var operand = "";
+				var semverString = "";
+				var versionComparator;
+				// Parse operand and semver String
+				requirement.do({ |char|
+					if(operators.includes(char))
+					{ operand = operand ++ char; }
+					{ semverString = semverString ++ char; };
+				});
+				versionComparator = Version(semverString);
+				switch(operand)
+				{ "=" } {
+					if(version != versionComparator)
+					{ ^false };
+				}
+				{ "!" } {
+					if(version == versionComparator)
+					{ ^false };
+				}
+				{ "===" } {
+					if(version !== versionComparator)
+					{ ^false };
+				}
+				{ "!==" } {
+					if(version === versionComparator)
+					{ ^false };
+				}
+				{ "<" } {
+					if((version < versionComparator).not)
+					{ ^false };
+				}
+				{ "<=" } {
+					if((version <= versionComparator).not)
+					{ ^false };
+				}
+				{ ">" } {
+					if((version > versionComparator).not)
+					{ ^false };
+				}
+				{ ">=" } {
+					if((version >= versionComparator).not)
+					{ ^false };
+				}
+			});
+			// If no condition returned false, then true
+			^true
+		};
+	}
+
+}


### PR DESCRIPTION
## Purpose and Motivation

Implementing Semantic Versioning support within SuperCollider.
User _scztt_ proposed this as a first step to ease Quark management, which could in the long term reduce SC's entropy.
More info [in my original GitHub project about this](https://github.com/SimonDeplat/SuperCollider-Semantic-Versioning).

## Types of changes

- New feature

Two classes, `Version` and `VersionConstraint`.
First one manipulates a version string, and can be automated to increase versions.
Second can be used to detect if a particular Version matches a certain set of rules (>1.0, etc).

## To-do list

I've put class files into `CL/Common/Quarks/`, which made more sense than `CL/Common/Core/` or `CL/Common/Files`, but maybe it had a place somewhere else ?

Sadly, if people don't use it, it might be a pointless addition (even though it might be useful, in theory). I think this is to be considered.

- [x] Code is tested
- [ ] All tests are passing
- [x] Updated documentation
- [ ] This PR is ready for review