### PR TITLE
scsynth: add cmdName to error when /cmd not found

### DIFF
--- a/server/scsynth/SC_UnitDef.cpp
+++ b/server/scsynth/SC_UnitDef.cpp
@@ -132,7 +132,7 @@ int Unit_DoCmd(World* inWorld, int inSize, char* inData) {
         return kSCErr_Failed;
     UnitCmd* cmd = unitDef->mCmds->Get(cmdName);
     if (!cmd)
-        return kSCErr_Failed;
+        throw std::runtime_error(std::string((char*)cmdName) + " not found");
 
     // only run unit command if the ctor has been called!
     if (graph->mNode.mCalcFunc == (NodeCalcFunc)&Graph_FirstCalc
@@ -154,7 +154,7 @@ int PlugIn_DoCmd(World* inWorld, int inSize, char* inData, ReplyAddress* inReply
 
     PlugInCmd* cmd = GetPlugInCmd(cmdName);
     if (!cmd)
-        return kSCErr_Failed;
+        throw std::runtime_error(std::string((char*)cmdName) + " not found");
 
     (cmd->mFunc)(inWorld, cmd->mUserData, &msg, (void*)inReply);
 


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

When triggering a Plug-in defined command (with a `/cmd` osc message), and that command is not registered, the current error message is:

    FAILURE IN SERVER /cmd failed

Which could be clearer, if the requested command name and actual failure reason were specified. This PR makes it to:

    FAILURE IN SERVER /cmd /nn_load not found

Where /nn_load is the supposed plug-in command name, thus giving users a more precise hint of what has gone wrong. While I was there I have also applied the same change to Unit Commands.

Note that in order to print a dynamic error message, I had to resort to throwing an exception, which although didn't have precedents in any other server command, is already expected (and caught) by the function which runs these commands. An alternative could be to directly print to stdout.

## Types of changes

- New feature

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] This PR is ready for review


<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
