### PR TITLE
CMake: fix qt6 detection

### DIFF
--- a/QtCollider/CMakeLists.txt
+++ b/QtCollider/CMakeLists.txt
@@ -16,7 +16,7 @@ set(
 
 # find Qt6 or Qt5
 find_package(QT NAMES Qt6 ${REQUIRED_QT_VERSION} QUIET COMPONENTS Core)
-if (NOT Qt6_FOUND)
+if (NOT QT_FOUND)
     set(REQUIRED_QT_VERSION 5.15)
     find_package(QT NAMES Qt5 ${REQUIRED_QT_VERSION} QUIET COMPONENTS Core)
 endif()


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

This ~~should fix~~ fixes Qt6 detection on some systems that have both Qt6 and Qt5 installed.

Since we run `find_package(QT (...) )` in CMake, then the resulting variable should indeed be `QT_FOUND` and not `Qt6_FOUND` (thought the latter seemed to work on some systems), since in the call to the `find_package` function we set the package name to be `QT`. This behavior is described in the [cmake help](https://cmake.org/cmake/help/latest/command/find_package.html#basic-signature).

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- n/a Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
