### PR TITLE
Qt: replace QRegExp with QRegularExpression

### DIFF
--- a/editors/sc-ide/core/sc_lexer.hpp
+++ b/editors/sc-ide/core/sc_lexer.hpp
@@ -23,7 +23,7 @@
 #include "../widgets/code_editor/tokens.hpp"
 
 #include <QVector>
-#include <QRegExp>
+#include <QRegularExpression>
 #include <QString>
 
 namespace ScIDE {
@@ -47,7 +47,7 @@ private:
         LexicalRule(Token::Type t, const QString& s): type(t), expr(s) {}
 
         Token::Type type;
-        QRegExp expr;
+        QRegularExpression expr;
     };
 
     static void initKeywordsRules();

--- a/editors/sc-ide/widgets/code_editor/editor.cpp
+++ b/editors/sc-ide/widgets/code_editor/editor.cpp
@@ -177,22 +177,23 @@ void GenericCodeEditor::setShowWhitespace(bool show) {
 
 void GenericCodeEditor::setShowLinenumber(bool show) { mLineIndicator->setHideLineIndicator(!show); }
 
-static bool findInBlock(QTextDocument* doc, const QTextBlock& block, const QRegExp& expr, int offset,
-                        QTextDocument::FindFlags options, QTextCursor& cursor) {
+static bool findInBlock(QTextDocument* doc, const QTextBlock& block, const QRegularExpression& expr, int offset,
+                        QTextDocument::FindFlags options, QTextCursor& cursor, QRegularExpressionMatch* match) {
     QString text = block.text();
     if (options & QTextDocument::FindBackward)
         text.truncate(offset);
     text.replace(QChar::Nbsp, QLatin1Char(' '));
 
-    int idx = -1;
+    qsizetype idx = -1;
     while (offset >= 0 && offset <= text.length()) {
-        idx = (options & QTextDocument::FindBackward) ? expr.lastIndexIn(text, offset) : expr.indexIn(text, offset);
+        idx = (options & QTextDocument::FindBackward) ? text.lastIndexOf(expr, offset, match)
+                                                      : text.indexOf(expr, offset, match);
         if (idx == -1)
             return false;
 
         if (options & QTextDocument::FindWholeWords) {
-            const int start = idx;
-            const int end = start + expr.matchedLength();
+            const qsizetype start = idx;
+            const qsizetype end = start + match->capturedLength(0);
             if ((start != 0 && text.at(start - 1).isLetterOrNumber())
                 || (end != text.length() && text.at(end).isLetterOrNumber())) {
                 // if this is not a whole word, continue the search in the string
@@ -210,15 +211,21 @@ static bool findInBlock(QTextDocument* doc, const QTextBlock& block, const QRegE
 
     cursor = QTextCursor(doc);
     cursor.setPosition(block.position() + idx);
-    cursor.setPosition(cursor.position() + expr.matchedLength(), QTextCursor::KeepAnchor);
+    cursor.setPosition(cursor.position() + match->capturedLength(0), QTextCursor::KeepAnchor);
     return true;
 }
 
-bool GenericCodeEditor::find(const QRegExp& expr, QTextDocument::FindFlags options) {
+static bool findInBlock(QTextDocument* doc, const QTextBlock& block, const QRegularExpression& expr, int offset,
+                        QTextDocument::FindFlags options, QTextCursor& cursor) {
+    QRegularExpressionMatch match;
+    return findInBlock(doc, block, expr, offset, options, cursor, &match);
+}
+
+bool GenericCodeEditor::find(const QRegularExpression& expr, QTextDocument::FindFlags options) {
     // Although QTextDocument provides a find() method, we implement
     // our own, because the former one is not adequate.
 
-    if (expr.isEmpty())
+    if (expr.pattern().isEmpty())
         return true;
 
     bool backwards = options & QTextDocument::FindBackward;
@@ -226,7 +233,7 @@ bool GenericCodeEditor::find(const QRegExp& expr, QTextDocument::FindFlags optio
     QTextCursor c(textCursor());
     int pos;
     if (c.hasSelection()) {
-        bool matching = expr.exactMatch(c.selectedText());
+        bool matching = expr.match(c.selectedText()).hasMatch();
 
         if (backwards == matching)
             pos = c.selectionStart();
@@ -286,10 +293,10 @@ bool GenericCodeEditor::find(const QRegExp& expr, QTextDocument::FindFlags optio
         return false;
 }
 
-int GenericCodeEditor::findAll(const QRegExp& expr, QTextDocument::FindFlags options) {
+int GenericCodeEditor::findAll(const QRegularExpression& expr, QTextDocument::FindFlags options) {
     mSearchSelections.clear();
 
-    if (expr.isEmpty()) {
+    if (expr.pattern().isEmpty()) {
         this->updateExtraSelections();
         return 0;
     }
@@ -321,81 +328,94 @@ int GenericCodeEditor::findAll(const QRegExp& expr, QTextDocument::FindFlags opt
     return mSearchSelections.count();
 }
 
-//#define CSTR(QSTR) QSTR.toStdString().c_str()
+// #define CSTR(QSTR) QSTR.toStdString().c_str()
 
-static QString resolvedReplacement(const QString& replacement, const QRegExp& expr) {
+static QString replace_backreferences_with_capturing_groups(const QString& replacement,
+                                                            const QRegularExpressionMatch& match) {
     // qDebug("START");
-    static const QRegExp rexpr("(\\\\\\\\)|(\\\\[0-9]+)");
+    static const QRegularExpression rexpr("(\\\\\\\\)|(\\\\[0-9]+)");
     QString str(replacement);
-    int i = 0;
-    while (i < str.size() && ((i = rexpr.indexIn(str, i)) != -1)) {
-        int len = rexpr.matchedLength();
-        if (rexpr.pos(1) != -1) {
-            // qDebug("%i (%s): escape", i, CSTR(rexpr.cap(1)));
+    qsizetype i = 0;
+    while (i < str.size()) {
+        QRegularExpressionMatch backref_match = rexpr.match(str, i);
+        if (!backref_match.hasMatch())
+            break;
+        i = backref_match.capturedStart(0);
+        qsizetype len = backref_match.capturedLength(0);
+        if (backref_match.capturedStart(1) != -1) {
+            // qDebug("%lli (%s): escape", i, CSTR(backref_match.captured(1)));
             str.replace(i, len, "\\");
             i += 1;
-        } else if (rexpr.pos(2) != -1) {
-            QString num_str = rexpr.cap(2);
+        } else if (backref_match.capturedStart(2) != -1) {
+            QString num_str = backref_match.captured(2);
             num_str.remove(0, 1);
             int num = num_str.toInt();
-            // qDebug("%i (%s): backref = %i", i, CSTR(rexpr.cap(2)), num);
-            if (num <= expr.captureCount()) {
-                QString cap = expr.cap(num);
+            // qDebug("%lli (%s): backref = %i", i, CSTR(backref_match.captured(2)), num);
+            if (num <= match.lastCapturedIndex()) {
+                QString cap = match.captured(num);
                 // qDebug("resolving ref to: %s", CSTR(cap));
                 str.replace(i, len, cap);
                 i += cap.size();
             } else {
-                // qDebug("ref out of range", i, num);
+                // qDebug("%lli ref out of range: backref = %i", i, num);
                 str.remove(i, len);
             }
         } else {
-            // qDebug("%i (%s): unknown match", i, CSTR(rexpr.cap(0)));
+            // qDebug("%lli (%s): unknown match", i, CSTR(backref_match.captured(0)));
             str.remove(i, len);
         }
-        // qDebug(">> [%s] %i", CSTR(str), i);
+        // qDebug(">> [%s] %lli", CSTR(str), i);
     }
     // qDebug("END");
     return str;
 }
 
-bool GenericCodeEditor::replace(const QRegExp& expr, const QString& replacement, QTextDocument::FindFlags options) {
-    if (expr.isEmpty())
+bool GenericCodeEditor::replace(const QRegularExpression& expr, const QString& replacement,
+                                QTextDocument::FindFlags options) {
+    if (expr.pattern().isEmpty())
         return true;
 
     QTextCursor cursor = textCursor();
-    if (cursor.hasSelection() && expr.exactMatch(cursor.selectedText())) {
-        QString rstr = replacement;
-        if (expr.patternSyntax() != QRegExp::FixedString)
-            rstr = resolvedReplacement(rstr, expr);
-        cursor.insertText(rstr);
+    bool captures = (expr.patternOptions() & QRegularExpression::PatternOption::DontCaptureOption) == 0;
+    if (cursor.hasSelection()) {
+        QRegularExpressionMatch match = expr.match(cursor.selectedText());
+        if (match.hasMatch()) {
+            QString rstr = replacement;
+            if (captures) {
+                rstr = replace_backreferences_with_capturing_groups(rstr, match);
+            }
+            cursor.insertText(rstr);
+        }
     }
 
     return find(expr, options);
 }
 
-int GenericCodeEditor::replaceAll(const QRegExp& expr, const QString& replacement, QTextDocument::FindFlags options) {
+int GenericCodeEditor::replaceAll(const QRegularExpression& expr, const QString& replacement,
+                                  QTextDocument::FindFlags options) {
     mSearchSelections.clear();
     updateExtraSelections();
 
-    if (expr.isEmpty())
+    if (expr.pattern().isEmpty())
         return 0;
 
     int replacements = 0;
-    bool caps = expr.patternSyntax() != QRegExp::FixedString;
+    bool captures = (expr.patternOptions() & QRegularExpression::PatternOption::DontCaptureOption) == 0;
 
     QTextDocument* doc = QPlainTextEdit::document();
     QTextBlock block = doc->begin();
     QTextCursor cursor;
+    QRegularExpressionMatch match;
 
     QTextCursor(doc).beginEditBlock();
 
     while (block.isValid()) {
         int blockPos = block.position();
         int offset = 0;
-        while (findInBlock(doc, block, expr, offset, options, cursor)) {
+        while (findInBlock(doc, block, expr, offset, options, cursor, &match)) {
             QString rstr = replacement;
-            if (caps)
-                rstr = resolvedReplacement(rstr, expr);
+            if (captures)
+                rstr = replace_backreferences_with_capturing_groups(rstr, match);
             cursor.insertText(rstr);
             ++replacements;
             offset = cursor.selectionEnd() - blockPos;
@@ -1142,7 +1162,7 @@ void GenericCodeEditor::gotoPreviousEmptyLine() { gotoEmptyLineUpDown(true); }
 void GenericCodeEditor::gotoNextEmptyLine() { gotoEmptyLineUpDown(false); }
 
 void GenericCodeEditor::gotoEmptyLineUpDown(bool up) {
-    static const QRegExp whiteSpaceLine("^\\s*$");
+    static const QRegularExpression whiteSpaceLine("^\\s*$");
 
     const QTextCursor::MoveOperation direction = up ? QTextCursor::PreviousBlock : QTextCursor::NextBlock;
 
@@ -1153,13 +1173,13 @@ void GenericCodeEditor::gotoEmptyLineUpDown(bool up) {
 
     // find first non-whitespace line
     while (cursor.movePosition(direction)) {
-        if (!whiteSpaceLine.exactMatch(cursor.block().text()))
+        if (!whiteSpaceLine.match(cursor.block().text()).hasMatch())
             break;
     }
 
     // find first whitespace line
     while (cursor.movePosition(direction)) {
-        if (whiteSpaceLine.exactMatch(cursor.block().text())) {
+        if (whiteSpaceLine.match(cursor.block().text()).hasMatch()) {
             setTextCursor(cursor);
             cursorMoved = true;
             break;

--- a/editors/sc-ide/widgets/code_editor/editor.hpp
+++ b/editors/sc-ide/widgets/code_editor/editor.hpp
@@ -23,7 +23,7 @@
 #include <QPlainTextEdit>
 #include <QGraphicsScene>
 #include <QList>
-#include <QRegExp>
+#include <QRegularExpression>
 
 namespace ScIDE {
 
@@ -57,10 +57,10 @@ public:
     QTextDocument* textDocument() { return QPlainTextEdit::document(); }
     bool showWhitespace();
     bool showLinenumber();
-    bool find(const QRegExp& expr, QTextDocument::FindFlags options);
-    bool replace(const QRegExp& expr, const QString& replacement, QTextDocument::FindFlags options);
-    int findAll(const QRegExp& expr, QTextDocument::FindFlags options);
-    int replaceAll(const QRegExp& expr, const QString& replacement, QTextDocument::FindFlags options);
+    bool find(const QRegularExpression& expr, QTextDocument::FindFlags options);
+    bool replace(const QRegularExpression& expr, const QString& replacement, QTextDocument::FindFlags options);
+    int findAll(const QRegularExpression& expr, QTextDocument::FindFlags options);
+    int replaceAll(const QRegularExpression& expr, const QString& replacement, QTextDocument::FindFlags options);
 
     void showPosition(int charPosition, int selectionLength = 0);
     QString symbolUnderCursor();

--- a/editors/sc-ide/widgets/code_editor/sc_editor.cpp
+++ b/editors/sc-ide/widgets/code_editor/sc_editor.cpp
@@ -770,8 +770,8 @@ void ScCodeEditor::triggerAutoCompletion() { mAutoCompleter->triggerCompletion()
 void ScCodeEditor::triggerMethodCallAid() { mAutoCompleter->triggerMethodCallAid(); }
 
 static bool isSingleLineComment(QTextBlock const& block) {
-    static QRegExp commentRegex("^\\s*//.*");
-    return commentRegex.exactMatch(block.text());
+    static QRegularExpression commentRegex("^\\s*//.*");
+    return commentRegex.match(block.text()).hasMatch();
 }
 
 static bool isSingleLineComment(QTextCursor const& selection) {

--- a/editors/sc-ide/widgets/find_replace_tool.hpp
+++ b/editors/sc-ide/widgets/find_replace_tool.hpp
@@ -29,7 +29,7 @@
 #include <QAction>
 #include <QMenu>
 #include <QToolButton>
-#include <QRegExp>
+#include <QRegularExpression>
 
 namespace ScIDE {
 
@@ -62,7 +62,7 @@ public:
     bool matchCase() const { return mMatchCaseAction->isChecked(); }
     bool asRegExp() const { return mRegExpAction->isChecked(); }
     bool wholeWords() const { return mWholeWordAction->isChecked(); }
-    QRegExp regexp();
+    QRegularExpression regexp();
     QTextDocument::FindFlags flags();
 
     QAction* action(ActionRole role) { return mActions[role]; }

--- a/editors/sc-ide/widgets/util/gui_utilities.hpp
+++ b/editors/sc-ide/widgets/util/gui_utilities.hpp
@@ -21,23 +21,27 @@
 #pragma once
 
 #include <QPlainTextEdit>
-#include <QRegExp>
+#include <QRegularExpression>
 #include <QTextBlock>
 
 namespace ScIDE {
 
 // match words, environment variable and symbols
 inline QString tokenInStringAt(int position, const QString& source) {
-    const QRegExp wordRegexp("(~?|\\\\?)\\w+");
+    const QRegularExpression wordRegexp("(~?|\\\\?)\\w+");
 
     int offset = 0;
     while (offset <= position) {
-        int index = wordRegexp.indexIn(source, offset);
-        if (index == -1)
+        QRegularExpressionMatch match = wordRegexp.match(source, offset);
+        if (!match.hasMatch())
             break;
-        int len = wordRegexp.matchedLength();
+
+        int index = match.capturedStart();
+        int len = match.capturedLength();
+
         if (index <= position && index + len >= position)
-            return wordRegexp.cap(0);
+            return match.captured(0);
+
         offset = index + len;
     }
 


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->


## Purpose and Motivation

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

This pull request is a follow-up for the Qt6 [migration](https://github.com/supercollider/supercollider/issues/5169),  replacing `QRegExp` with `QRegularExpression` in the scide codebase.


## Types of changes

<!-- Delete lines that don't apply -->

- New feature

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [ ] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
