### PR TITLE
Help: replace esoteric syntax in Pbind help file.

### DIFF
--- a/HelpSource/Classes/Pbind.schelp
+++ b/HelpSource/Classes/Pbind.schelp
@@ -59,7 +59,7 @@ Pbind(
 	\instrument,		\test,
 	\nharms,	     	Pseq([4, 10, 40], inf),
 	\dur,			    Pseq([1, 1, 2, 1]/10, inf),
-	#[freq, sustain],	Ptuple([ // assignment to multiple keys
+	[\freq, \sustain],	Ptuple([ // assignment to multiple keys
 					        Pseq((1..16) * 50, 4),
 				     	    Pseq([1/10, 0.5, 1, 2], inf)
 				        ])
@@ -81,7 +81,7 @@ Pbind(*[
 	instrument:			\test,
 	nharms:				Pseq([4, 10, 40], inf),
 	dur:				Pseq([1, 1, 2, 1]/10, inf),
-	#[freq, sustain]:	Ptuple([
+	[\freq, \sustain]:	Ptuple([
 							Pseq((1..16) * 50, 4),
 							Pseq([1/10, 0.5, 1, 2], inf)
 						])


### PR DESCRIPTION


<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

Applies the following conversion in Pbind's help file.
```supercollider
#[a, b] == [\a, \b]
```
The former is confusing because they look like variables and this is seldom used syntax. While there are places it is useful, it is unnecessary here.

## Types of changes

<!-- Delete lines that don't apply -->

- Documentation


## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

