### PR TITLE
scide style.cpp: fix icon sizes on tab bar and help toolbar

### DIFF
--- a/editors/sc-ide/widgets/style/style.cpp
+++ b/editors/sc-ide/widgets/style/style.cpp
@@ -140,9 +140,10 @@ void Style::drawComplexControl(ComplexControl control, const QStyleOptionComplex
             QIcon::State iconState = option->state & QStyle::State_Selected ? QIcon::On : QIcon::Off;
 
             QPixmap pixmap = icon.pixmap(toolOption->iconSize, iconMode, iconState);
-            QRect pixRect = pixmap.rect();
+            QRect pixRect;
+            pixRect.setSize(QSize(16, 16));
             pixRect.moveCenter(option->rect.center());
-            painter->drawPixmap(pixRect.topLeft(), pixmap);
+            painter->drawPixmap(pixRect, pixmap);
         } else {
             QStyle::PrimitiveElement elem = Style::PE_CustomBase;
             switch (toolBtn->arrowType()) {
@@ -239,7 +240,8 @@ void Style::drawControl(ControlElement element, const QStyleOption* option, QPai
 
         if (!tabOption->icon.isNull()) {
             QPixmap pixmap = tabOption->icon.pixmap(tabOption->iconSize);
-            QRect iconRect = pixmap.rect();
+            QRect iconRect;
+            iconRect.setSize(QSize(14, 14));
             iconRect.moveCenter(tabOption->rect.center());
             int lmargin = 5;
             if (tabOption->leftButtonSize.width() > 0)


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->
When building with the latest Qt6 changes, the icons in the tab bar and help toolbar are showing up with the wrong size in the tab bar case and not centered properly in the help toolbar case. This commit should hopefully fix the issue, although more testing may be needed for other platforms and display resolutions.

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [ ] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
