### PR TITLE
Update testsuite printing result(s)

### DIFF
--- a/testsuite/scripts/print_results.scd
+++ b/testsuite/scripts/print_results.scd
@@ -99,7 +99,7 @@ if(failed > 0) {
 	failedList.do({ |str| str.postln; });
 	"".postln;
 	"\t----------------------------------------".postln;
-	"\t%, %, out of %".format(makeRed.("% TESTS FAILED".format(failed)), makeYellow.("% skipped".format(skipped)), passed + skipped + failed).postln;
+	"\t%, %, out of %".format(makeRed.("% TEST% FAILED".format(failed, (failed > 1).if({"S"},{""}))), makeYellow.("% skipped".format(skipped)), passed + skipped + failed).postln;
 	"\t----------------------------------------".postln;
 } {
 	"".postln;


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

This is a silly little change...
If we have failures, it's quite often only 1 _test_ failing, so I thought I'd make the posting grammatically correct.

Now the failed posting says:
```
        ----------------------------------------
	1 TEST FAILED, xx skipped, out of xxx
	----------------------------------------
```
or
```
	----------------------------------------
	2 TESTS FAILED, xx skipped, out of xxx
	----------------------------------------
```

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->

- Maintenance

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [ ] Code is tested
- [ ] All tests are passing
- [ ] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
