### PR TITLE
Build: divide each test run into 5 deterministic separate jobs

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -13,6 +13,10 @@ on:
       - 'sounds/**'
       - '*.md'
 
+env:
+  # number of jobs to split each test suite into
+  NCLUMPS: 5
+
 jobs:
   lint:
     runs-on: ubuntu-22.04
@@ -40,8 +44,15 @@ jobs:
     runs-on: ubuntu-22.04
     outputs:
       sc-version: ${{ steps.set-version.outputs.version }}
+      n-clumps: ${{ steps.set-test-clumps.outputs.n-clumps }}
+      test-clumps-matrix: ${{ steps.set-test-clumps.outputs.test-clumps-matrix }}
 
     steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: testsuite/scripts/setup_test_clumps_output.sh
+          sparse-checkout-cone-mode: false
+
       - name: set version string for artifacts
         id: set-version
         run: |
@@ -52,7 +63,9 @@ jobs:
             SC_VERSION=$GITHUB_SHA
           fi
           echo "version=$SC_VERSION" >> $GITHUB_OUTPUT
-
+      - name: set test clumps
+        id: set-test-clumps
+        run: ./testsuite/scripts/setup_test_clumps_output.sh
   build-linux:
     needs: [lint, version-getter]
     uses: ./.github/workflows/build_linux.yml
@@ -79,6 +92,8 @@ jobs:
     uses: ./.github/workflows/test_linux.yml
     with:
       artifact-file: "SuperCollider-${{ needs.version-getter.outputs.sc-version }}-ubuntu-22.04-gcc12"
+      test-clumps-matrix: ${{ needs.version-getter.outputs.test-clumps-matrix }}
+      n-clumps: ${{ needs.version-getter.outputs.n-clumps }}
     secrets: inherit
 
   test-macos:
@@ -86,6 +101,8 @@ jobs:
     uses: ./.github/workflows/test_macos.yml
     with:
       artifact-file: "SuperCollider-${{ needs.version-getter.outputs.sc-version }}-macOS-x64.dmg"
+      test-clumps-matrix: ${{ needs.version-getter.outputs.test-clumps-matrix }}
+      n-clumps: ${{ needs.version-getter.outputs.n-clumps }}
     secrets: inherit
 
   # test-windows:
@@ -93,6 +110,8 @@ jobs:
   #   uses: ./.github/workflows/test_windows.yml
   #   with:
   #     artifact-file: "SuperCollider-${{ needs.version-getter.outputs.sc-version }}-win64"
+  #     test-clumps-matrix: ${{ needs.version-getter.outputs.test-clumps-matrix }}
+  #     n-clumps: ${{ needs.version-getter.outputs.n-clumps }}
   #   secrets: inherit
 
   deploy_s3:

--- a/.github/workflows/test_linux.yml
+++ b/.github/workflows/test_linux.yml
@@ -5,10 +5,20 @@ on:
       artifact-file:
         required: true
         type: string
+      test-clumps-matrix:
+        required: true
+        type: string
+      n-clumps:
+        required: true
+        type: string
 
 jobs:
   test-linux:
     runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        this-clump: ${{ fromJSON(inputs.test-clumps-matrix) }}
     env:
       INSTALL_PATH: ${{ github.workspace }}/build/Install
       ARTIFACT_FILE: ${{ inputs.artifact-file }}
@@ -62,7 +72,7 @@ jobs:
           # add path
           $SCLANG $SCRIPT_ADD_PATH $TESTS_PATH
           # run tests
-          timeout 1200 $SCLANG $SCRIPT_RUN_TESTS $TEST_LIST_PROTO $TEST_LIST_RESULT
+          timeout 1200 $SCLANG $SCRIPT_RUN_TESTS $TEST_LIST_PROTO $TEST_LIST_RESULT ${{ matrix.this-clump }} ${{ inputs.n-clumps }}
 
       - name: Post test results
         shell: bash

--- a/.github/workflows/test_macos.yml
+++ b/.github/workflows/test_macos.yml
@@ -5,10 +5,20 @@ on:
       artifact-file:
         required: true
         type: string
+      test-clumps-matrix:
+        required: true
+        type: string
+      n-clumps:
+        required: true
+        type: string
 
 jobs:
   test-macos:
     runs-on: macos-12
+    strategy:
+      fail-fast: false
+      matrix:
+        this-clump: ${{ fromJSON(inputs.test-clumps-matrix) }}
     env:
       INSTALL_PATH: ${{ github.workspace }}/build/Install
       ARTIFACT_FILE: ${{ inputs.artifact-file }}
@@ -55,7 +65,7 @@ jobs:
           # add path
           $SCLANG $SCRIPT_ADD_PATH $TESTS_PATH
           # run tests
-          timeout 1200 $SCLANG $SCRIPT_RUN_TESTS $TEST_LIST_PROTO $TEST_LIST_RESULT
+          timeout 1200 $SCLANG $SCRIPT_RUN_TESTS $TEST_LIST_PROTO $TEST_LIST_RESULT ${{ matrix.this-clump }} ${{ inputs.n-clumps }}
 
       - name: Post test results
         shell: bash

--- a/.github/workflows/test_windows.yml
+++ b/.github/workflows/test_windows.yml
@@ -5,10 +5,20 @@ on:
       artifact-file:
         required: true
         type: string
+      test-clumps-matrix:
+        required: true
+        type: string
+      n-clumps:
+        required: true
+        type: string
 
 jobs:
   test-windows:
     runs-on: windows-2022
+    strategy:
+      fail-fast: false
+      matrix:
+        this-clump: ${{ fromJSON(inputs.test-clumps-matrix) }}
     env:
       INSTALL_PATH: ${{ github.workspace }}/build/Install
       ARTIFACT_FILE: ${{ inputs.artifact-file }}
@@ -61,7 +71,7 @@ jobs:
           # add path
           $SCLANG $SCRIPT_ADD_PATH $TESTS_PATH
           # run tests
-          timeout 1200 $SCLANG $SCRIPT_RUN_TESTS $TEST_LIST_PROTO $TEST_LIST_RESULT
+          timeout 1200 $SCLANG $SCRIPT_RUN_TESTS $TEST_LIST_PROTO $TEST_LIST_RESULT ${{ matrix.this-clump }} ${{ inputs.n-clumps }}
 
       - name: Post test results
         shell: bash

--- a/testsuite/scripts/sclang_test_runner.scd
+++ b/testsuite/scripts/sclang_test_runner.scd
@@ -1,15 +1,28 @@
-// this script is meant to be run with two arguments: path to test prototype indicating tests to be run, and path to test result
+// this script is meant to be run with four arguments:
+// 1. path to test prototype indicating tests to be run
+// 2. path to test result
+// 3. which partition of the tests should be run (zero based)
+// 4. the number of test partitions
 (
 ~exitWhenDone = false;
 if(thisProcess.argv.size > 0) {
 	"passed args: %".format(thisProcess.argv).postln;
 	~testProto = thisProcess.argv[0];
 	~testResult = thisProcess.argv[1];
+  if(thisProcess.argv.size > 2) {
+    ~thisClump = thisProcess.argv[2].asInteger();
+    ~nClumps = thisProcess.argv[3].asInteger();
+  } {
+    ~thisClump = 0;
+    ~nClumps = 1;
+  };
 	~exitWhenDone = true;
 } {
 	~testProto = PathName(thisProcess.nowExecutingPath).pathOnly +/+ "test_run_proto_gha.scd";
 	// ~testProto = PathName(thisProcess.nowExecutingPath).pathOnly +/+ "test_run_proto_all.scd"; // for testing
 	~testResult = PathName(thisProcess.nowExecutingPath).pathOnly +/+ "run" +/+ "test_result.scxtar";
+	~thisClump = 0;
+	~nClumps = 1;
 };
 
 if(File.exists(~testProto).not) {
@@ -18,6 +31,7 @@ if(File.exists(~testProto).not) {
 
 "~testProto path: %".format(~testProto).postln;
 "~testResult path: %".format(~testResult).postln;
+"clump % of %".format(~thisClump, ~nClumps).postln;
 
 ~verboseSetup = false; // true or false
 
@@ -62,6 +76,11 @@ if(File.exists(~testProto).not) {
 
 	testsDict;
 };
+
+~selectThisTestClump = {|tests,thisClump,nClumps|
+  tests.clump(tests.size()/nClumps).at(thisClump) ?? #[];
+};
+
 
 ~testrun = {|protoFile, resultFile|
 	var tests = ~getTestRecord.(protoFile);
@@ -143,6 +162,10 @@ if(File.exists(~testProto).not) {
 	// test_record["tests"] = tests;
 	// ~writeResult.(tests, file);
 	~verboseSetup.if({"After exclude: ".post; tests.do(_.postln)});
+
+  tests = ~selectThisTestClump.(tests, ~thisClump, ~nClumps);
+
+	~verboseSetup.if({"After clump: ".post; tests.do(_.postln)});
 
 	"\n\n\t*** Running the tests ***\n\n".post;
 

--- a/testsuite/scripts/setup_test_clumps_output.sh
+++ b/testsuite/scripts/setup_test_clumps_output.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# clump tests into $NCLUMPS jobs
+#
+# Demo:
+# $ NCLUMPS=5 GITHUB_OUTPUT=gh ./setup_test_clumps_output.sh
+# $ cat gh
+# n-clumps=5
+# test-clumps-matrix=[0,1,2,3,4]
+
+set -euo pipefail
+
+
+if [ $NCLUMPS -lt 0 ]; then
+  echo "Clumps must be positive"
+  exit 1
+fi
+echo "Setting output: n-clumps=$NCLUMPS"
+echo "n-clumps=$NCLUMPS" >> $GITHUB_OUTPUT
+TEST_CLUMPS='[0'
+for (( i=1; i<NCLUMPS; i++ )) ; {
+  TEST_CLUMPS="${TEST_CLUMPS},${i}"
+}
+TEST_CLUMPS="${TEST_CLUMPS}]"
+echo "Setting output: test-clumps-matrix=${TEST_CLUMPS}"
+echo "test-clumps-matrix=${TEST_CLUMPS}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

Related https://github.com/supercollider/supercollider/issues/6439

This PR speeds up CI runs of `test-macos` and `test-linux` by about 3-4x (12m => 4m).

The approach is to deterministically partition the tests into separate concurrent jobs. Test failures will be locally reproducible by passing the same arguments to the test script as whichever job fails.

Demonstration: https://github.com/frenchy64/supercollider/actions/runs/11807687690

## Types of changes

- CI Build performance improvement

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

## Merge notes

Reviewers please help me verify that the test partitioning logic is deterministic (per commit). Each test should run exactly once and in the same order.

`.clumps()` partitions the tests but it assumes the array it is clumping is itself deterministic. Please double check this.

Suggestions welcome on how to improve `testsuite/scripts/setup_test_clumps_output.sh`. Generating JSON from bash is ugly, but it at least seems lean and fast. 

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
