### PR TITLE
Disable IDE menu bar icons on macOS

### DIFF
--- a/editors/sc-ide/widgets/main_window.cpp
+++ b/editors/sc-ide/widgets/main_window.cpp
@@ -508,6 +508,9 @@ void MainWindow::createMenus() {
     // On Mac, create a parent-less menu bar to be shared by all windows:
 #ifdef Q_OS_MAC
     menuBar = new QMenuBar(0);
+    // icons in menu bars impacts the performance on (intel) macs considerably
+    // while switching windows, therefore we de-activate those. (#6523)
+    QApplication::instance()->setAttribute(Qt::AA_DontShowIconsInMenus, true);
 #else
     menuBar = this->menuBar();
 #endif


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

Fixes https://github.com/supercollider/supercollider/issues/6523

## Purpose and Motivation

Only affects macOS.

Currently the IDE takes around 1-2 seconds after "tabbing into" before it displays, while also consuming lots of CPU.
I profiled the application and it turns out that the scaling of icons consumes lots of CPU cycles.

<img width="1702" alt="grafik" src="https://github.com/user-attachments/assets/5c53b99f-9eb7-48d0-bd39-e7a98ae1e749">

I remembered that the icons appeared with Qt6 (see https://github.com/supercollider/supercollider/pull/6475#issuecomment-2351937292) so, I decided to disable the icons and the "tabbing in" performance is as in Qt5 now.

Old:
<img width="455" alt="grafik" src="https://github.com/user-attachments/assets/8f1b201d-de11-4be0-86b5-b66f5fb756c1">


With PR:
<img width="486" alt="grafik" src="https://github.com/user-attachments/assets/ee197554-2aac-4c9e-afd5-f9b75f42a90a">

For some reason this problem only seems to affect Intel Macs (verification needed), so maybe there is a better way than simply disabling the Icons? I looked through https://doc.qt.io/qt-6/qiconengine.html (which is present in the flamegraph), but I couldn't find a setting.

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
