### PR TITLE
Do not change indentation within multiline comments

### DIFF
--- a/editors/sc-ide/widgets/code_editor/highlighter.cpp
+++ b/editors/sc-ide/widgets/code_editor/highlighter.cpp
@@ -245,8 +245,10 @@ void SyntaxHighlighter::highlightBlock(const QString& text) {
             break;
 
         default:
-            if (lexer.state() >= ScLexer::InComment)
+            if (lexer.state() >= ScLexer::InComment) {
                 highlightBlockInComment(lexer);
+                blockData->isInMultilineComment = true;
+            }
         }
     }
 

--- a/editors/sc-ide/widgets/code_editor/sc_editor.cpp
+++ b/editors/sc-ide/widgets/code_editor/sc_editor.cpp
@@ -595,7 +595,6 @@ void ScCodeEditor::indentCurrentRegion() { indent(currentRegion()); }
 void ScCodeEditor::indent(EditBlockMode editBlockMode) { indent(textCursor(), editBlockMode); }
 
 void ScCodeEditor::indent(const QTextCursor& selection, EditBlockMode editBlockMode) {
-    static QString plainMultilineCommentBegin = QString("*/");
     if (selection.isNull())
         return;
 
@@ -665,7 +664,7 @@ void ScCodeEditor::indent(const QTextCursor& selection, EditBlockMode editBlockM
                 indentLevel = 0;
             // lexer does not detect "/*" as in comment, therefore we check if the current
             // block is equal to it. If so, also do not indent the multi-line comment start
-            if (!in_comment && block.text() != plainMultilineCommentBegin) {
+            if (!in_comment && block.text() != "/*") {
                 block = indent(block, indentLevel);
             }
         }

--- a/editors/sc-ide/widgets/code_editor/sc_editor.cpp
+++ b/editors/sc-ide/widgets/code_editor/sc_editor.cpp
@@ -665,7 +665,7 @@ void ScCodeEditor::indent(const QTextCursor& selection, EditBlockMode editBlockM
                 indentLevel = 0;
             // lexer does not detect "/*" as in comment, therefore we check if the current
             // block is equal to it. If so, also do not indent the multi-line comment start
-            if (!in_comment and block.text() != plainMultilineCommentBegin) {
+            if (!in_comment && block.text() != plainMultilineCommentBegin) {
                 block = indent(block, indentLevel);
             }
         }

--- a/editors/sc-ide/widgets/code_editor/tokens.hpp
+++ b/editors/sc-ide/widgets/code_editor/tokens.hpp
@@ -71,6 +71,7 @@ struct Token {
 
 struct TextBlockData : public QTextBlockUserData {
     std::vector<Token> tokens;
+    bool isInMultilineComment = false;
 };
 
 class TokenIterator {


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

Currently the IDE resets the indentation within multi-line comments - this PR changes the behavior.

E.g. given the code

<img width="525" alt="image" src="https://github.com/user-attachments/assets/f8a486fa-8f52-438b-b6ce-aed4d8e44300">

Currently the IDE aligns the indentation within the multi-line comment with its surrounding, resulting in

<img width="501" alt="image" src="https://github.com/user-attachments/assets/0fbffa4e-b915-47ad-af9d-7cbcc75442cc">

This PR disables the indentation within multi-line comments, so the code would look like in image 1 after indentation. 
It also does not align/indent a line if it is equal to `/*` (the beginning of a multi-line comment).

I am not sure if this is the proper way to implement, therefore I would greatly appreciate a review.

edit: it seems win32 does not allow for `and` within if cases? Am I right if this should be switched for `&&`?
Also sorry for pushing directly as a sc branch, I forgot to set the proper origin.

## Types of changes

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [ ] Code is tested
- [ ] All tests are passing
- [ ] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

## Merge note

Should be squashed.

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
