### PR TITLE
Add file tree widget to IDE

### DIFF
--- a/editors/sc-ide/CMakeLists.txt
+++ b/editors/sc-ide/CMakeLists.txt
@@ -88,6 +88,7 @@ set ( ide_moc_hdr
     widgets/tool_box.hpp
     widgets/audio_status_box.hpp
     widgets/lang_status_box.hpp
+    widgets/file_tree.hpp
     widgets/code_editor/editor.hpp
     widgets/code_editor/sc_editor.hpp
     widgets/code_editor/highlighter.hpp
@@ -140,6 +141,7 @@ set ( ide_src
     widgets/session_switch_dialog.cpp
     widgets/audio_status_box.cpp
     widgets/lang_status_box.cpp
+    widgets/file_tree.cpp
     widgets/code_editor/editor.cpp
     widgets/code_editor/sc_editor.cpp
     widgets/code_editor/highlighter.cpp

--- a/editors/sc-ide/widgets/file_tree.cpp
+++ b/editors/sc-ide/widgets/file_tree.cpp
@@ -1,0 +1,101 @@
+#include "file_tree.hpp"
+
+#include <QClipboard>
+#include <QDateTime>
+#include <QDir>
+#include <QFileSystemModel>
+#include <QMenu>
+
+#include "doc_manager.hpp"
+#include "sc_editor.hpp"
+
+namespace ScIDE {
+
+FileTreeWidget::FileTreeWidget(DocumentManager* manager, QWidget* parent): QTreeView(parent) {
+    QString rootPath = QDir::homePath();
+    mFileSystemModel = new QFileSystemModel(this);
+    mFileSystemModel->setRootPath(rootPath);
+    mFileSystemModel->setFilter(QDir::Files | QDir::Dirs | QDir::NoDot);
+
+    QTreeView::setModel(mFileSystemModel);
+    QTreeView::setRootIndex(mFileSystemModel->index(rootPath));
+
+    for (int i = 1; i < mFileSystemModel->columnCount(); i++) {
+        QTreeView::hideColumn(i);
+    }
+    QTreeView::expand(QTreeView::rootIndex());
+
+    connect(this, &QTreeView::doubleClicked, this, &FileTreeWidget::doubleClicked);
+    connect(manager, SIGNAL(opened(Document*, int, int)), this, SLOT(onOpen(Document*, int, int)));
+    mDocumentManager = manager;
+}
+
+void FileTreeWidget::doubleClicked(const QModelIndex& index) {
+    QString path = mFileSystemModel->filePath(index);
+    auto fileInfo = QFileInfo(path);
+    if (fileInfo.isDir()) {
+        QTreeView::setRootIndex(mFileSystemModel->index(fileInfo.absoluteFilePath()));
+    } else {
+        bool isScFile = fileInfo.suffix().toLower() == "sc" | fileInfo.suffix().toLower() == "scd";
+        if (isScFile) {
+            mDocumentManager->open(path);
+        } else {
+            // insert absolute path to document
+            if (auto document = mDocumentManager->open(path)) {
+                // @todo
+            }
+        }
+    }
+}
+
+void FileTreeWidget::contextMenuEvent(QContextMenuEvent* event) {
+    QModelIndex index = indexAt(event->pos());
+
+    if (!index.isValid()) {
+        return; // Ignore if no item is clicked
+    }
+    auto fileInfo = QFileInfo(mFileSystemModel->filePath(index));
+    bool isScFile = fileInfo.suffix().toLower() == "sc" | fileInfo.suffix().toLower() == "scd";
+    bool hasSavedDocument = mDocumentManager->activeDocument()->filePath().length() > 0;
+
+    QMenu contextMenu(this);
+
+    QAction* openAction = contextMenu.addAction("Open");
+    QAction* copyAbsolutePath = contextMenu.addAction("Copy absolute path");
+    QAction* copyRelativeDocumentPath = contextMenu.addAction("Copy relative path to current document");
+    QAction* copyRelativeViewPath = contextMenu.addAction("Copy relative path from view");
+
+    openAction->setEnabled(isScFile);
+    copyRelativeDocumentPath->setEnabled(hasSavedDocument);
+
+    QAction* selectedAction = contextMenu.exec(event->globalPos());
+
+    if (selectedAction == openAction) {
+        emit doubleClicked(index);
+    } else if (selectedAction == copyRelativeViewPath) {
+        QDir viewPath = mFileSystemModel->rootPath();
+        QGuiApplication::clipboard()->setText(viewPath.relativeFilePath(fileInfo.absolutePath()));
+    } else if (selectedAction == copyRelativeDocumentPath) {
+        if (hasSavedDocument) {
+            QDir documentPath = mDocumentManager->activeDocument()->filePath();
+            QGuiApplication::clipboard()->setText(documentPath.relativeFilePath(fileInfo.path()));
+        }
+    } else if (selectedAction == copyAbsolutePath) {
+        QDir absolutePath = fileInfo.absoluteFilePath();
+        QGuiApplication::clipboard()->setText(absolutePath.absolutePath());
+    }
+}
+
+void FileTreeWidget::onOpen(Document* document, int, int) {
+    if (document->filePath().length() > 0) {
+        auto dir = QFileInfo(document->filePath());
+        QTreeView::setRootIndex(mFileSystemModel->index(dir.absolutePath()));
+    }
+}
+
+FileTreeDocklet::FileTreeDocklet(DocumentManager* manager, QWidget* parent): Docklet(tr("File tree"), parent) {
+    mFileTreeWidget = new FileTreeWidget(manager, parent);
+    setAllowedAreas(Qt::LeftDockWidgetArea | Qt::RightDockWidgetArea);
+    setWidget(mFileTreeWidget);
+}
+}

--- a/editors/sc-ide/widgets/file_tree.hpp
+++ b/editors/sc-ide/widgets/file_tree.hpp
@@ -1,0 +1,36 @@
+#pragma once
+#include <QTreeView>
+#include <QFileSystemModel>
+
+#include "doc_manager.hpp"
+#include "sc_editor.hpp"
+#include "util/docklet.hpp"
+
+namespace ScIDE {
+class ScCodeEditor;
+
+class FileTreeWidget : public QTreeView {
+    Q_OBJECT
+
+public:
+    FileTreeWidget(DocumentManager* manager, QWidget* parent = 0);
+
+private Q_SLOTS:
+    void doubleClicked(const QModelIndex& index);
+    void onOpen(Document* document, int, int);
+    void contextMenuEvent(QContextMenuEvent* event);
+
+private:
+    QFileSystemModel* mFileSystemModel;
+    DocumentManager* mDocumentManager;
+};
+
+class FileTreeDocklet : public Docklet {
+    Q_OBJECT
+public:
+    FileTreeDocklet(DocumentManager* manager, QWidget* parent = 0);
+
+private:
+    FileTreeWidget* mFileTreeWidget;
+};
+}

--- a/editors/sc-ide/widgets/main_window.cpp
+++ b/editors/sc-ide/widgets/main_window.cpp
@@ -22,6 +22,7 @@
 
 #include "cmd_line.hpp"
 #include "doc_list.hpp"
+#include "file_tree.hpp"
 #include "documents_dialog.hpp"
 #include "find_replace_tool.hpp"
 #include "goto_line_tool.hpp"
@@ -146,6 +147,10 @@ MainWindow::MainWindow(Main* main): mMain(main), mClockLabel(0), mDocDialog(0) {
     mPostDocklet = new PostDocklet(this);
     mPostDocklet->setObjectName("post-dock");
     addDockWidget(Qt::RightDockWidgetArea, mPostDocklet->dockWidget());
+
+    mFileTreeDocklet = new FileTreeDocklet(main->documentManager(), this);
+    mFileTreeDocklet->setObjectName("file-tree-doc");
+    addDockWidget(Qt::RightDockWidgetArea, mFileTreeDocklet->dockWidget());
 
     // Layout
     QVBoxLayout* center_box = new QVBoxLayout;

--- a/editors/sc-ide/widgets/main_window.hpp
+++ b/editors/sc-ide/widgets/main_window.hpp
@@ -36,6 +36,7 @@ class TextFindReplacePanel;
 class GoToLineTool;
 class PostDocklet;
 class DocumentsDocklet;
+class FileTreeDocklet;
 class HelpBrowserDocklet;
 class CmdLine;
 class Document;
@@ -245,6 +246,7 @@ private:
     // Docks
     PostDocklet* mPostDocklet;
     DocumentsDocklet* mDocumentsDocklet;
+    FileTreeDocklet* mFileTreeDocklet;
 #ifdef SC_USE_QTWEBENGINE
     HelpBrowserDocklet* mHelpBrowserDocklet;
 #endif


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

Adds a file tree widget to the IDE. This widget can be positioned/opened/closed like a post window etc.

<img width="1894" alt="image" src="https://github.com/user-attachments/assets/4892696c-086a-4d08-8610-538f4e46df7f">

Double-clicking on a file will open the file in the IDE.
Right clicking on a file will show the menu

<img width="416" alt="image" src="https://github.com/user-attachments/assets/b0056004-90ed-4596-a3fc-92cc6516389d">

I think the main advantage is for bigger projects and to navigate within sample databases.

I coded this some weeks ago but before I would get the final touches on it I think it would be good to know what the general feedback on such a widget would be.

## Questions

* What should be the default directory to be opened? Currently it is `~/`
* Currently any file will be openend in the IDE, so even binary files. Maybe this should be limited to non-binary files (how?)
* Should the file tree follow
* Should there be an sclang API for this (e.g. `IDEFileTree.navigateTo("~/my/folder")`) - if this is possible
* Allow to display file attributes such as filesize and mtime in a dedicated column

## ToDo

* Test Windows and Linux
* Navigating to the parent of `~/` is possible but does not order the items accordingly anymore

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->
- New feature

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [ ] Code is tested
- [ ] All tests are passing
- [ ] Updated documentation
- [ ] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
