### PR TITLE
Destroy UDP socket explicitly

### DIFF
--- a/lang/LangPrimSource/OSCData.cpp
+++ b/lang/LangPrimSource/OSCData.cpp
@@ -862,9 +862,8 @@ void init_OSC(int port) {
 #endif
 
     startAsioThread();
-
     try {
-        gUDPport.reset(new InPort::UDP(port, HandlerType::OSC));
+        gUDPport = std::make_unique<InPort::UDP>(port, HandlerType::OSC);
     } catch (std::exception const& e) { postfl("No networking: %s", e.what()); }
 }
 
@@ -923,6 +922,10 @@ void closeAllCustomPorts() {
 
 void cleanup_OSC() {
     postfl("cleaning up OSC\n");
+
+    // NOTE: the socket must be destroyed *before* the IO service.
+    // We cannot rely on the global object destructor because the order would be undefined.
+    gUDPport = nullptr;
 
     stopAsioThread();
 


### PR DESCRIPTION
Big thanks to @Spacechild1 who came up with the solution and helped me a lot!

## Purpose and Motivation

Fixes https://github.com/supercollider/supercollider/issues/6488 and enables https://github.com/supercollider/supercollider/issues/6531
<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

Releasing the socket explicitly to avoid "double-destruction" of the global socket variable.

- Bug fix
 
## To-do list

Would be great if all major platforms could verify it works - simply exit `sclang` and if it exits without a crash/segfault, everything is how it should be.

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [ ] All tests are passing
- [ ] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
