### PR TITLE
Use tab to switch between documents

### DIFF
--- a/editors/sc-ide/widgets/multi_editor.cpp
+++ b/editors/sc-ide/widgets/multi_editor.cpp
@@ -560,18 +560,18 @@ void MultiEditor::createActions() {
 
     mActions[NextDocument] = action = new QAction(tr("Next Document"), this);
 #ifndef Q_OS_MAC
-    action->setShortcut(tr("Alt+Right", "Next Document"));
+    action->setShortcut(tr("Ctrl+Tab", "Next Document"));
 #else
-    action->setShortcut(tr("Ctrl+Alt+Right", "Next Document"));
+    action->setShortcut(tr("Meta+Tab", "Next Document"));
 #endif
     connect(action, SIGNAL(triggered()), this, SLOT(showNextDocument()));
     settings->addAction(action, "editor-document-next", editorCategory);
 
     mActions[PreviousDocument] = action = new QAction(tr("Previous Document"), this);
 #ifndef Q_OS_MAC
-    action->setShortcut(tr("Alt+Left", "Previous Document"));
+    action->setShortcut(tr("Ctrl+Shift+Tab", "Previous Document"));
 #else
-    action->setShortcut(tr("Ctrl+Alt+Left", "Previous Document"));
+    action->setShortcut(tr("Meta+Shift+Tab", "Previous Document"));
 #endif
     connect(action, SIGNAL(triggered()), this, SLOT(showPreviousDocument()));
     settings->addAction(action, "editor-document-previous", editorCategory);

--- a/editors/sc-ide/widgets/multi_editor.cpp
+++ b/editors/sc-ide/widgets/multi_editor.cpp
@@ -968,12 +968,16 @@ void MultiEditor::updateTabsOrder(QList<Document*> docOrder) {
 
 void MultiEditor::showNextDocument() {
     int currentIndex = mTabs->currentIndex();
-    mTabs->setCurrentIndex(qMin(currentIndex + 1, mTabs->count() - 1));
+    mTabs->setCurrentIndex((currentIndex + 1) % mTabs->count());
 }
 
 void MultiEditor::showPreviousDocument() {
     int currentIndex = mTabs->currentIndex();
-    mTabs->setCurrentIndex(qMax(0, currentIndex - 1));
+    if (currentIndex == 0) {
+        mTabs->setCurrentIndex(mTabs->count() - 1);
+    } else {
+        mTabs->setCurrentIndex(currentIndex - 1);
+    }
 }
 
 void MultiEditor::switchDocument() {

--- a/editors/sc-ide/widgets/multi_editor.cpp
+++ b/editors/sc-ide/widgets/multi_editor.cpp
@@ -577,11 +577,6 @@ void MultiEditor::createActions() {
     settings->addAction(action, "editor-document-previous", editorCategory);
 
     mActions[SwitchDocument] = action = new QAction(tr("Switch Document"), this);
-#ifndef Q_OS_MAC
-    action->setShortcut(tr("Ctrl+Tab", "Switch Document"));
-#else
-    action->setShortcut(tr("Alt+Tab", "Switch Document"));
-#endif
     connect(action, SIGNAL(triggered()), this, SLOT(switchDocument()));
     settings->addAction(action, "editor-document-switch", editorCategory);
 


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

This post will be kept up-to-date to reflect the state of the PR.

## Purpose and Motivation

Closes https://github.com/supercollider/supercollider/issues/977 by using ctrl+(shift)+tab to cycle through documents like tabs in a browser. (edit: this is actually control on macOS and windows).
This replaces the alt + arrow keys shortcut.

Works on macOS, needs testing on Windows and Linux.

This could be added to https://dev.docs.supercollider.online/Reference/KeyboardShortcuts.html but I somehow think this document should include not just macOS shortcuts, so I think this should be done in another PR?

## Types of changes

<!-- Delete lines that don't apply -->

- New feature

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [ ] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
