### PR TITLE
GHA: move macOS tests to the latest OS

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -85,7 +85,7 @@ jobs:
     needs: [version-getter, build-macos]
     uses: ./.github/workflows/test_macos.yml
     with:
-      artifact-file: "SuperCollider-${{ needs.version-getter.outputs.sc-version }}-macOS-x64.dmg"
+      artifact-file: "SuperCollider-${{ needs.version-getter.outputs.sc-version }}-macOS-arm64.dmg"
     secrets: inherit
 
   # test-windows:

--- a/.github/workflows/test_macos.yml
+++ b/.github/workflows/test_macos.yml
@@ -48,6 +48,9 @@ jobs:
           HOMEBREW_NO_INSTALL_CLEANUP: 1
         run: brew install coreutils # to get 'timeout' utility
 
+      - name: Grant microphone access # solution from https://github.com/actions/runner-images/issues/9330#issuecomment-1938616628
+        run: sqlite3 $HOME/Library/Application\ Support/com.apple.TCC/TCC.db "INSERT OR IGNORE INTO access VALUES ('kTCCServiceMicrophone','/usr/local/opt/runner/provisioner/provisioner',1,2,4,1,NULL,NULL,0,'UNUSED',NULL,0,1687786159,NULL,NULL,'UNUSED',1687786159);"
+
       - name: Run tests
         shell: bash
         continue-on-error: true

--- a/.github/workflows/test_macos.yml
+++ b/.github/workflows/test_macos.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   test-macos:
-    runs-on: macos-12
+    runs-on: macos-15
     env:
       INSTALL_PATH: ${{ github.workspace }}/build/Install
       ARTIFACT_FILE: ${{ inputs.artifact-file }}

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ See the [Raspberry Pi](README_RASPBERRY_PI.md) and [BeagleBone Black](README_BEA
 
 SuperCollider is tested with:
 - Windows 10 64-bit and MSVC 2022
-- macOS 12 and Xcode 15.2
+- macOS 15 and Xcode 15.2
 - Ubuntu 22.04 and gcc 12
 
 SuperCollider is known to support these platforms:


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

macOS 12 runners will be disabled soon; let's run the tests on macOS 15.

Fixes #6531 

EDIT: it turned out that on newer macOS runners we need to grant microphone access to `/usr/local/opt/runner/provisioner/provisioner`. This PR adds it as well.

## Types of changes

<!-- Delete lines that don't apply -->

- Maintenance
- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
