### PR TITLE
Fix `incompatible-pointer-types` warning/error for portmidi

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,10 +104,6 @@ if (${CMAKE_COMPILER_IS_GNUCXX})
 
     add_compile_options(
         -Werror=return-type      # Error out if function definitions lack a return type
-        # GCC 14 has made -Wincompatible-pointer-types an error by default and as a
-        # consequence, some external C would fail to compile. This is a temporary fix!
-        # Ideally, the affected dependencies should be fixed upstream.
-        -Wno-error=incompatible-pointer-types
         -fschedule-insns2        # Optimize instruction scheduling
         -fomit-frame-pointer     # Optimize by omitting the frame pointer where possible
         -fno-math-errno          # Optimize math functions by not setting errno

--- a/external_libraries/portmidi/pm_win/pmwinmm.c
+++ b/external_libraries/portmidi/pm_win/pmwinmm.c
@@ -1049,7 +1049,7 @@ static PmError winmm_write_byte(PmInternal *midi, unsigned char byte,
         m->hdr = hdr = get_free_output_buffer(midi);
         assert(hdr);
         midi->fill_base = (unsigned char *) m->hdr->lpData;
-        midi->fill_offset_ptr = &(hdr->dwBytesRecorded);
+        midi->fill_offset_ptr = (uint32_t *) &(hdr->dwBytesRecorded);
         /* when buffer fills, Pm_WriteSysEx will revert to calling
          * pmwin_write_byte, which expect to have space, so leave
          * one byte free for pmwin_write_byte. Leave another byte


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->
## Purpose and Motivation

Fix `incompatible-pointer-types` warning/error for portmidi. Fixes #6435.


I originally wanted to fix this by updating protmidi to a newer version, but then realized the upstream fix has not been released yet.

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [ ] Code is tested
- [ ] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
