### PR TITLE
Restart server for each RTAlloc test

### DIFF
--- a/testsuite/classlibrary/TestUGen_RTAlloc.sc
+++ b/testsuite/classlibrary/TestUGen_RTAlloc.sc
@@ -1,13 +1,13 @@
 TestUGen_RTAlloc : UnitTest {
 
-	classvar server;
+	var server;
 
 	*initClass {
 		passVerbosity = UnitTest.brief;
 	}
 
-	*setUpClass {
-		server = Server(this.name);
+	setUp {
+		server = Server(this.class.name);
 		server.options.sampleRate = 48000;
 		server.options.blockSize = 64;
 		server.options.memSize = 2 ** 13; // scsynth default
@@ -17,8 +17,9 @@ TestUGen_RTAlloc : UnitTest {
 		server.bootSync;
 	}
 
-	*tearDownClass {
-		server.quit.remove;
+	tearDown {
+		server.quit;
+		server.remove;
 	}
 
 	// Async helpers


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

Currently we have a high failure rate of macOS tests. I haven't made a proper analysis yet, but I came across the following error multiple times.
Notice the timestamps.

**Example 1**

```log
2024-12-01T20:17:00.1068700Z UNIT TESTS FOR 'TestUGen_RTAlloc' COMPLETED
2024-12-01T20:17:00.1069460Z There were no failures
2024-12-01T20:17:00.5599240Z server 'TestUGen_RTAlloc' disconnected shared memory interface
2024-12-01T20:17:00.5600460Z '/quit' message sent to server 'TestUGen_RTAlloc'.
2024-12-01T20:17:00.5601920Z 
2024-12-01T20:17:00.5603110Z 	Test: [1mtest_allocFail_continueProcessing_otherNodes[0m
2024-12-01T20:17:00.5603710Z TestUGen_RTAlloc : setting clientID to 0.
2024-12-01T20:17:00.5669380Z Booting server 'TestUGen_RTAlloc' on address 127.0.0.1:57110.
2024-12-01T20:17:00.6813470Z Number of Devices: 1
2024-12-01T20:17:00.6839520Z    0 : "Null Audio"
2024-12-01T20:17:00.6840100Z 
2024-12-01T20:17:00.6898250Z "Null Audio" Input Device
2024-12-01T20:17:00.6898890Z    Streams: 1
2024-12-01T20:17:00.6899670Z       0  channels 2
2024-12-01T20:17:00.6900420Z 
2024-12-01T20:17:00.6914570Z "Null Audio" Output Device
2024-12-01T20:17:00.6915200Z    Streams: 1
2024-12-01T20:17:00.6916220Z       0  channels 2
2024-12-01T20:17:00.6917310Z 
2024-12-01T20:17:00.6928760Z SC_AudioDriver: sample rate = 48000.000000, driver's block size = 512
2024-12-01T20:17:00.7155140Z 
2024-12-01T20:17:00.7205830Z *** ERROR: failed to open UDP socket: address in use.
2024-12-01T20:17:00.7207520Z This could be because another instance of scsynth is already using it.
2024-12-01T20:17:00.7209830Z You can use SuperCollider (sclang) to kill all running servers by running `Server.killAll`.
2024-12-01T20:17:00.7211110Z You can also kill scsynth using a terminal or your operating system's task manager.
2024-12-01T20:17:00.7211900Z Server 'TestUGen_RTAlloc' exited with exit code 0.
2024-12-01T20:17:00.7517930Z Server 'TestUGen_RTAlloc' exited with exit code 1.
2024-12-01T20:27:32.7037980Z ##[error]Process completed with exit code 124.
```

**Example 2**

```log
2024-12-01T22:06:48.3247270Z UNIT TESTS FOR 'TestUGen_RTAlloc' COMPLETED
2024-12-01T22:06:48.3248990Z There were no failures
2024-12-01T22:06:48.5859420Z server 'TestUGen_RTAlloc' disconnected shared memory interface
2024-12-01T22:06:48.5859770Z '/quit' message sent to server 'TestUGen_RTAlloc'.
2024-12-01T22:06:48.5860200Z 
2024-12-01T22:06:48.5860560Z 	Test: [1mtest_allUGens_allocFail[0m
2024-12-01T22:06:48.5860990Z TestUGen_RTAlloc : setting clientID to 0.
2024-12-01T22:06:48.5922220Z Booting server 'TestUGen_RTAlloc' on address 127.0.0.1:57110.
2024-12-01T22:06:48.6755990Z Number of Devices: 3
2024-12-01T22:06:48.6757430Z    0 : "Apple Virtual Sound Device"
2024-12-01T22:06:48.6759250Z    1 : "Apple Virtual Sound Device"
2024-12-01T22:06:48.6769200Z    2 : "Null Audio"
2024-12-01T22:06:48.6769690Z 
2024-12-01T22:06:48.6925530Z "Apple Virtual Sound Device" Input Device
2024-12-01T22:06:48.7028140Z    Streams: 1
2024-12-01T22:06:48.7137920Z       0  channels 2
2024-12-01T22:06:48.7184810Z 
2024-12-01T22:06:48.7185790Z "Apple Virtual Sound Device" Output Device
2024-12-01T22:06:48.7186140Z    Streams: 1
2024-12-01T22:06:48.7186360Z       0  channels 2
2024-12-01T22:06:48.7186610Z 
2024-12-01T22:06:48.7186820Z SC_AudioDriver: sample rate = 48000.000000, driver's block size = 512
2024-12-01T22:06:48.7201460Z 
2024-12-01T22:06:48.7201740Z *** ERROR: failed to open UDP socket: address in use.
2024-12-01T22:06:48.7202130Z This could be because another instance of scsynth is already using it.
2024-12-01T22:06:48.7202690Z You can use SuperCollider (sclang) to kill all running servers by running `Server.killAll`.
2024-12-01T22:06:48.7203190Z You can also kill scsynth using a terminal or your operating system's task manager.
2024-12-01T22:06:48.7333570Z Server 'TestUGen_RTAlloc' exited with exit code 0.
2024-12-01T22:06:48.7962240Z Server 'TestUGen_RTAlloc' exited with exit code 1.
2024-12-01T22:19:40.6796240Z ##[error]Process completed with exit code 124.
```

It seems the server restarts before it was exited properly.
This could have multiple reasons, maybe caused by [`/quit`](https://docs.supercollider.online/Reference/Server-Command-Reference.html) being async?

## Types of changes

I simply adapted the server setup procedure from https://github.com/supercollider/supercollider/blob/develop/testsuite/classlibrary/TestBuffer_Server.sc (which doesn't fail often?) by switching from a server located at class level to a server managed by each test.
This will slow down tests a bit but make them more reliable?

Or maybe there is a better fix for this?

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [ ] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
