### PR TITLE
Add basic zoom via touchpad gesture

### DIFF
--- a/editors/sc-ide/widgets/code_editor/editor.cpp
+++ b/editors/sc-ide/widgets/code_editor/editor.cpp
@@ -873,7 +873,7 @@ void GenericCodeEditor::resetFontSize() { mDoc->resetDefaultFont(); }
 
 void GenericCodeEditor::zoomFont(int steps) {
     QFont currentFont = mDoc->defaultFont();
-    const int newSize = clampFontSize(currentFont.pointSize() + steps);
+    const float newSize = clampFontSize(currentFont.pointSizeF() + steps);
     currentFont.setPointSizeF(newSize);
     mDoc->setDefaultFont(currentFont);
 }

--- a/editors/sc-ide/widgets/code_editor/editor.cpp
+++ b/editors/sc-ide/widgets/code_editor/editor.cpp
@@ -465,8 +465,8 @@ bool GenericCodeEditor::gestureEvent(QGestureEvent* event) {
     if (QGesture* pinch = event->gesture(Qt::PinchGesture)) {
         auto* pinchGesture = static_cast<QPinchGesture*>(pinch);
         if (pinchGesture->state() == Qt::GestureUpdated) {
-            qreal scaleFactor = pinchGesture->scaleFactor();
-            zoomFontScaler(scaleFactor);
+            float scaleFactor = pinchGesture->scaleFactor();
+            zoomFont(scaleFactor);
         }
         return true;
     }
@@ -873,20 +873,21 @@ void GenericCodeEditor::resetFontSize() { mDoc->resetDefaultFont(); }
 
 void GenericCodeEditor::zoomFont(int steps) {
     QFont currentFont = mDoc->defaultFont();
-    const int newSize = currentFont.pointSize() + steps;
-    if (newSize <= 7 || newSize >= 50)
-        return;
-    currentFont.setPointSize(newSize);
+    const int newSize = clampFontSize(currentFont.pointSize() + steps);
+    currentFont.setPointSizeF(newSize);
     mDoc->setDefaultFont(currentFont);
 }
 
-void GenericCodeEditor::zoomFontScaler(float scaler) {
+void GenericCodeEditor::zoomFont(float scaler) {
     QFont currentFont = mDoc->defaultFont();
-    auto defaultFontSize = Main::settings()->codeFont().pointSizeF();
-    auto newSize = currentFont.pointSizeF() * scaler;
-    newSize = std::clamp(newSize, defaultFontSize * 0.5, defaultFontSize * 8.0);
+    const float newSize = clampFontSize(currentFont.pointSizeF() * scaler);
     currentFont.setPointSizeF(newSize);
     mDoc->setDefaultFont(currentFont);
+}
+
+float GenericCodeEditor::clampFontSize(float newSize) {
+    float defaultFontSize = Main::settings()->codeFont().pointSizeF();
+    return std::clamp(newSize, defaultFontSize * 0.5f, defaultFontSize * 8.0f);
 }
 
 void GenericCodeEditor::onDocumentFontChanged() {

--- a/editors/sc-ide/widgets/code_editor/editor.cpp
+++ b/editors/sc-ide/widgets/code_editor/editor.cpp
@@ -466,12 +466,7 @@ bool GenericCodeEditor::gestureEvent(QGestureEvent* event) {
         auto* pinchGesture = static_cast<QPinchGesture*>(pinch);
         if (pinchGesture->state() == Qt::GestureUpdated) {
             qreal scaleFactor = pinchGesture->scaleFactor();
-            if (scaleFactor >= 1.0) {
-                // some magic number - 2 seems to "feel good"
-                zoomFont(2);
-            } else {
-                zoomFont(-2);
-            }
+            zoomFontScaler(scaleFactor);
         }
         return true;
     }
@@ -882,6 +877,15 @@ void GenericCodeEditor::zoomFont(int steps) {
     if (newSize <= 7 || newSize >= 50)
         return;
     currentFont.setPointSize(newSize);
+    mDoc->setDefaultFont(currentFont);
+}
+
+void GenericCodeEditor::zoomFontScaler(float scaler) {
+    QFont currentFont = mDoc->defaultFont();
+    auto defaultFontSize = Main::settings()->codeFont().pointSizeF();
+    auto newSize = currentFont.pointSizeF() * scaler;
+    newSize = std::clamp(newSize, defaultFontSize * 0.5, defaultFontSize * 8.0);
+    currentFont.setPointSizeF(newSize);
     mDoc->setDefaultFont(currentFont);
 }
 

--- a/editors/sc-ide/widgets/code_editor/editor.hpp
+++ b/editors/sc-ide/widgets/code_editor/editor.hpp
@@ -20,6 +20,7 @@
 
 #pragma once
 
+#include <QGestureEvent>
 #include <QPlainTextEdit>
 #include <QGraphicsScene>
 #include <QList>
@@ -64,6 +65,7 @@ public:
 
     void showPosition(int charPosition, int selectionLength = 0);
     QString symbolUnderCursor();
+    bool gestureEvent(QGestureEvent* event);
     int inactiveFadeAlpha() { return mInactiveFadeAlpha; }
 
 protected:

--- a/editors/sc-ide/widgets/code_editor/editor.hpp
+++ b/editors/sc-ide/widgets/code_editor/editor.hpp
@@ -68,6 +68,8 @@ public:
     bool gestureEvent(QGestureEvent* event);
     int inactiveFadeAlpha() { return mInactiveFadeAlpha; }
 
+    static float clampFontSize(float newSize);
+
 protected:
     virtual bool event(QEvent*);
     virtual void keyPressEvent(QKeyEvent*);
@@ -118,7 +120,7 @@ protected:
     virtual void indentCurrentRegion() {}
 
     void zoomFont(int steps);
-    void zoomFontScaler(float scaler);
+    void zoomFont(float scaler);
 
     void copyUpDown(bool up);
     void moveLineUpDown(bool up);

--- a/editors/sc-ide/widgets/code_editor/editor.hpp
+++ b/editors/sc-ide/widgets/code_editor/editor.hpp
@@ -118,6 +118,7 @@ protected:
     virtual void indentCurrentRegion() {}
 
     void zoomFont(int steps);
+    void zoomFontScaler(float scaler);
 
     void copyUpDown(bool up);
     void moveLineUpDown(bool up);

--- a/editors/sc-ide/widgets/post_window.cpp
+++ b/editors/sc-ide/widgets/post_window.cpp
@@ -25,6 +25,7 @@
 #include "../core/settings/manager.hpp"
 #include "../core/settings/theme.hpp"
 #include "../core/util/overriding_action.hpp"
+#include "editor.hpp"
 
 #include <QApplication>
 #include <QScreen>
@@ -251,18 +252,14 @@ void PostWindow::zoomOut(int steps) { zoomFont(-steps); }
 
 void PostWindow::zoomFont(int steps) {
     QFont currentFont = font();
-    const int newSize = currentFont.pointSize() + steps;
-    if (newSize <= 0)
-        return;
+    const int newSize = GenericCodeEditor::clampFontSize(currentFont.pointSize() + steps);
     currentFont.setPointSize(newSize);
     setFont(currentFont);
 }
 
-void PostWindow::zoomFontScaler(float scaler) {
+void PostWindow::zoomFont(float scaler) {
     QFont currentFont = font();
-    auto defaultFontSize = Main::settings()->codeFont().pointSizeF();
-    auto newSize = currentFont.pointSizeF() * scaler;
-    newSize = std::clamp(newSize, defaultFontSize * 0.5, defaultFontSize * 8.0);
+    auto newSize = GenericCodeEditor::clampFontSize(currentFont.pointSizeF() * scaler);
     currentFont.setPointSizeF(newSize);
     setFont(currentFont);
 }
@@ -352,8 +349,8 @@ bool PostWindow::gestureEvent(QGestureEvent* event) {
     if (QGesture* pinch = event->gesture(Qt::PinchGesture)) {
         auto* pinchGesture = static_cast<QPinchGesture*>(pinch);
         if (pinchGesture->state() == Qt::GestureUpdated) {
-            qreal scaleFactor = pinchGesture->scaleFactor();
-            zoomFontScaler(scaleFactor);
+            float scaleFactor = pinchGesture->scaleFactor();
+            zoomFont(scaleFactor);
         }
         return true;
     }

--- a/editors/sc-ide/widgets/post_window.cpp
+++ b/editors/sc-ide/widgets/post_window.cpp
@@ -252,9 +252,18 @@ void PostWindow::zoomOut(int steps) { zoomFont(-steps); }
 void PostWindow::zoomFont(int steps) {
     QFont currentFont = font();
     const int newSize = currentFont.pointSize() + steps;
-    if (newSize <= 7 || newSize >= 50)
+    if (newSize <= 0)
         return;
     currentFont.setPointSize(newSize);
+    setFont(currentFont);
+}
+
+void PostWindow::zoomFontScaler(float scaler) {
+    QFont currentFont = font();
+    auto defaultFontSize = Main::settings()->codeFont().pointSizeF();
+    auto newSize = currentFont.pointSizeF() * scaler;
+    newSize = std::clamp(newSize, defaultFontSize * 0.5, defaultFontSize * 8.0);
+    currentFont.setPointSizeF(newSize);
     setFont(currentFont);
 }
 
@@ -344,12 +353,7 @@ bool PostWindow::gestureEvent(QGestureEvent* event) {
         auto* pinchGesture = static_cast<QPinchGesture*>(pinch);
         if (pinchGesture->state() == Qt::GestureUpdated) {
             qreal scaleFactor = pinchGesture->scaleFactor();
-            if (scaleFactor >= 1.0) {
-                // same as document zoom steps in editor.cpp
-                zoomFont(2);
-            } else {
-                zoomFont(-2);
-            }
+            zoomFontScaler(scaleFactor);
         }
         return true;
     }

--- a/editors/sc-ide/widgets/post_window.cpp
+++ b/editors/sc-ide/widgets/post_window.cpp
@@ -252,14 +252,14 @@ void PostWindow::zoomOut(int steps) { zoomFont(-steps); }
 
 void PostWindow::zoomFont(int steps) {
     QFont currentFont = font();
-    const int newSize = GenericCodeEditor::clampFontSize(currentFont.pointSize() + steps);
-    currentFont.setPointSize(newSize);
+    const float newSize = GenericCodeEditor::clampFontSize(currentFont.pointSizeF() + steps);
+    currentFont.setPointSizeF(newSize);
     setFont(currentFont);
 }
 
 void PostWindow::zoomFont(float scaler) {
     QFont currentFont = font();
-    auto newSize = GenericCodeEditor::clampFontSize(currentFont.pointSizeF() * scaler);
+    const float newSize = GenericCodeEditor::clampFontSize(currentFont.pointSizeF() * scaler);
     currentFont.setPointSizeF(newSize);
     setFont(currentFont);
 }

--- a/editors/sc-ide/widgets/post_window.hpp
+++ b/editors/sc-ide/widgets/post_window.hpp
@@ -95,6 +95,7 @@ private:
     void createActions(Settings::Manager*);
     void updateActionShortcuts(Settings::Manager*);
     void zoomFont(int steps);
+    void zoomFontScaler(float scaler);
     QTextCharFormat formatForPostLine(QString line);
 
     QAction* mActions[ActionCount];

--- a/editors/sc-ide/widgets/post_window.hpp
+++ b/editors/sc-ide/widgets/post_window.hpp
@@ -95,7 +95,7 @@ private:
     void createActions(Settings::Manager*);
     void updateActionShortcuts(Settings::Manager*);
     void zoomFont(int steps);
-    void zoomFontScaler(float scaler);
+    void zoomFont(float scaler);
     QTextCharFormat formatForPostLine(QString line);
 
     QAction* mActions[ActionCount];

--- a/editors/sc-ide/widgets/post_window.hpp
+++ b/editors/sc-ide/widgets/post_window.hpp
@@ -22,6 +22,7 @@
 
 #include "util/docklet.hpp"
 #include <QAction>
+#include <QGestureEvent>
 #include <QPlainTextEdit>
 
 namespace ScIDE {
@@ -75,6 +76,8 @@ public slots:
     void openDefinition();
     void openCommandLine();
     void findReferences();
+
+    bool gestureEvent(QGestureEvent* event);
 
 protected:
     virtual bool event(QEvent*);


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

Allows to zoom via touchpad. Only tested on macOS. Is not the "native macOS" zoom as it only increases the font size and does not increase the focus of a viewport - still useful.

https://github.com/user-attachments/assets/b11ff198-d7e6-435b-8f02-285d8f458b9d

Also added a boundary for font size.

## Types of changes

<!-- Delete lines that don't apply -->

- New feature

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [ ] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
