### PR TITLE
Increase UDP socket buffer size

### DIFF
--- a/lang/LangPrimSource/SC_ComPort.cpp
+++ b/lang/LangPrimSource/SC_ComPort.cpp
@@ -205,8 +205,8 @@ UDP::UDP(int inPortNum, HandlerType handlerType, int portsToCheck): mPortNum(inP
         }
     }
 
-    boost::asio::socket_base::send_buffer_size sendBufferSize;
     try {
+        boost::asio::socket_base::send_buffer_size sendBufferSize;
         mUdpSocket.get_option(sendBufferSize);
         if (sendBufferSize.value() < UDP::sendBufferSize) {
             sendBufferSize = UDP::sendBufferSize;
@@ -216,8 +216,8 @@ UDP::UDP(int inPortNum, HandlerType handlerType, int portsToCheck): mPortNum(inP
         printf("(sclang) SC_UdpInPort: WARNING: failed to set send buffer size\n");
     }
 
-    boost::asio::socket_base::receive_buffer_size receiveBufferSize;
     try {
+        boost::asio::socket_base::receive_buffer_size receiveBufferSize;
         mUdpSocket.get_option(receiveBufferSize);
         if (receiveBufferSize.value() < UDP::receiveBufferSize) {
             receiveBufferSize = UDP::receiveBufferSize;

--- a/lang/LangPrimSource/SC_ComPort.cpp
+++ b/lang/LangPrimSource/SC_ComPort.cpp
@@ -212,7 +212,6 @@ UDP::UDP(int inPortNum, HandlerType handlerType, int portsToCheck): mPortNum(inP
         try {
             mUdpSocket.set_option(sendBufferSize);
         } catch (boost::system::system_error& e) {}
-        mUdpSocket.get_option(sendBufferSize);
     }
 
     boost::asio::socket_base::receive_buffer_size receiveBufferSize;
@@ -222,7 +221,6 @@ UDP::UDP(int inPortNum, HandlerType handlerType, int portsToCheck): mPortNum(inP
         try {
             mUdpSocket.set_option(receiveBufferSize);
         } catch (boost::system::system_error& e) {}
-        mUdpSocket.get_option(receiveBufferSize);
     }
 
     initHandler(handlerType);

--- a/lang/LangPrimSource/SC_ComPort.cpp
+++ b/lang/LangPrimSource/SC_ComPort.cpp
@@ -207,8 +207,8 @@ UDP::UDP(int inPortNum, HandlerType handlerType, int portsToCheck): mPortNum(inP
 
     boost::asio::socket_base::send_buffer_size sendBufferSize;
     mUdpSocket.get_option(sendBufferSize);
-    if (sendBufferSize.value() < 8 * 1024 * 1024) {
-        sendBufferSize = 8 * 1024 * 1024;
+    if (sendBufferSize.value() < UDP::sendBufferSize) {
+        sendBufferSize = UDP::sendBufferSize;
         try {
             mUdpSocket.set_option(sendBufferSize);
         } catch (boost::system::system_error& e) {}
@@ -217,8 +217,8 @@ UDP::UDP(int inPortNum, HandlerType handlerType, int portsToCheck): mPortNum(inP
 
     boost::asio::socket_base::receive_buffer_size receiveBufferSize;
     mUdpSocket.get_option(receiveBufferSize);
-    if (receiveBufferSize.value() < 8 * 1024 * 1024) {
-        receiveBufferSize = 8 * 1024 * 1024;
+    if (receiveBufferSize.value() < UDP::receiveBufferSize) {
+        receiveBufferSize = UDP::receiveBufferSize;
         try {
             mUdpSocket.set_option(receiveBufferSize);
         } catch (boost::system::system_error& e) {}

--- a/lang/LangPrimSource/SC_ComPort.cpp
+++ b/lang/LangPrimSource/SC_ComPort.cpp
@@ -206,22 +206,22 @@ UDP::UDP(int inPortNum, HandlerType handlerType, int portsToCheck): mPortNum(inP
     }
 
     boost::asio::socket_base::send_buffer_size sendBufferSize;
-    mUdpSocket.get_option(sendBufferSize);
-    if (sendBufferSize.value() < UDP::sendBufferSize) {
-        sendBufferSize = UDP::sendBufferSize;
-        try {
+    try {
+        mUdpSocket.get_option(sendBufferSize);
+        if (sendBufferSize.value() < UDP::sendBufferSize) {
+            sendBufferSize = UDP::sendBufferSize;
             mUdpSocket.set_option(sendBufferSize);
-        } catch (boost::system::system_error& e) {}
-    }
+        }
+    } catch (boost::system::system_error& e) { printf("(sclang) SC_UdpInPort: WARNING: failed to set send buffer size\n"); }
 
     boost::asio::socket_base::receive_buffer_size receiveBufferSize;
-    mUdpSocket.get_option(receiveBufferSize);
-    if (receiveBufferSize.value() < UDP::receiveBufferSize) {
-        receiveBufferSize = UDP::receiveBufferSize;
-        try {
+    try {
+        mUdpSocket.get_option(receiveBufferSize);
+        if (receiveBufferSize.value() < UDP::receiveBufferSize) {
+            receiveBufferSize = UDP::receiveBufferSize;
             mUdpSocket.set_option(receiveBufferSize);
-        } catch (boost::system::system_error& e) {}
-    }
+        }
+    } catch (boost::system::system_error& e) { printf("(sclang) SC_UdpInPort: WARNING: failed to set receive buffer size\n"); }
 
     initHandler(handlerType);
 

--- a/lang/LangPrimSource/SC_ComPort.cpp
+++ b/lang/LangPrimSource/SC_ComPort.cpp
@@ -212,7 +212,9 @@ UDP::UDP(int inPortNum, HandlerType handlerType, int portsToCheck): mPortNum(inP
             sendBufferSize = UDP::sendBufferSize;
             mUdpSocket.set_option(sendBufferSize);
         }
-    } catch (boost::system::system_error& e) { printf("(sclang) SC_UdpInPort: WARNING: failed to set send buffer size\n"); }
+    } catch (boost::system::system_error& e) {
+        printf("(sclang) SC_UdpInPort: WARNING: failed to set send buffer size\n");
+    }
 
     boost::asio::socket_base::receive_buffer_size receiveBufferSize;
     try {
@@ -221,7 +223,9 @@ UDP::UDP(int inPortNum, HandlerType handlerType, int portsToCheck): mPortNum(inP
             receiveBufferSize = UDP::receiveBufferSize;
             mUdpSocket.set_option(receiveBufferSize);
         }
-    } catch (boost::system::system_error& e) { printf("(sclang) SC_UdpInPort: WARNING: failed to set receive buffer size\n"); }
+    } catch (boost::system::system_error& e) {
+        printf("(sclang) SC_UdpInPort: WARNING: failed to set receive buffer size\n");
+    }
 
     initHandler(handlerType);
 

--- a/lang/LangPrimSource/SC_ComPort.cpp
+++ b/lang/LangPrimSource/SC_ComPort.cpp
@@ -205,24 +205,24 @@ UDP::UDP(int inPortNum, HandlerType handlerType, int portsToCheck): mPortNum(inP
         }
     }
 
-    boost::asio::socket_base::send_buffer_size send_buffer_size;
-    mUdpSocket.get_option(send_buffer_size);
-    if (send_buffer_size.value() < 8 * 1024 * 1024) {
-        send_buffer_size = 8 * 1024 * 1024;
+    boost::asio::socket_base::send_buffer_size sendBufferSize;
+    mUdpSocket.get_option(sendBufferSize);
+    if (sendBufferSize.value() < 8 * 1024 * 1024) {
+        sendBufferSize = 8 * 1024 * 1024;
         try {
-            mUdpSocket.set_option(send_buffer_size);
+            mUdpSocket.set_option(sendBufferSize);
         } catch (boost::system::system_error& e) {}
-        mUdpSocket.get_option(send_buffer_size);
+        mUdpSocket.get_option(sendBufferSize);
     }
 
-    boost::asio::socket_base::receive_buffer_size recv_buffer_size;
-    mUdpSocket.get_option(recv_buffer_size);
-    if (recv_buffer_size.value() < 8 * 1024 * 1024) {
-        recv_buffer_size = 8 * 1024 * 1024;
+    boost::asio::socket_base::receive_buffer_size receiveBufferSize;
+    mUdpSocket.get_option(receiveBufferSize);
+    if (receiveBufferSize.value() < 8 * 1024 * 1024) {
+        receiveBufferSize = 8 * 1024 * 1024;
         try {
-            mUdpSocket.set_option(recv_buffer_size);
+            mUdpSocket.set_option(receiveBufferSize);
         } catch (boost::system::system_error& e) {}
-        mUdpSocket.get_option(recv_buffer_size);
+        mUdpSocket.get_option(receiveBufferSize);
     }
 
     initHandler(handlerType);

--- a/lang/LangPrimSource/SC_ComPort.cpp
+++ b/lang/LangPrimSource/SC_ComPort.cpp
@@ -205,13 +205,25 @@ UDP::UDP(int inPortNum, HandlerType handlerType, int portsToCheck): mPortNum(inP
         }
     }
 
-    boost::asio::socket_base::send_buffer_size send_buffer_size(65536);
-    mUdpSocket.set_option(send_buffer_size);
+    boost::asio::socket_base::send_buffer_size send_buffer_size;
+    mUdpSocket.get_option(send_buffer_size);
+    if (send_buffer_size.value() < 8 * 1024 * 1024) {
+        send_buffer_size = 8 * 1024 * 1024;
+        try {
+            mUdpSocket.set_option(send_buffer_size);
+        } catch (boost::system::system_error& e) {}
+        mUdpSocket.get_option(send_buffer_size);
+    }
 
-    boost::asio::socket_base::receive_buffer_size recv_buffer_size(8 * 1024 * 1024);
-    try {
-        mUdpSocket.set_option(recv_buffer_size);
-    } catch (boost::system::system_error e) {}
+    boost::asio::socket_base::receive_buffer_size recv_buffer_size;
+    mUdpSocket.get_option(recv_buffer_size);
+    if (recv_buffer_size.value() < 8 * 1024 * 1024) {
+        recv_buffer_size = 8 * 1024 * 1024;
+        try {
+            mUdpSocket.set_option(recv_buffer_size);
+        } catch (boost::system::system_error& e) {}
+        mUdpSocket.get_option(recv_buffer_size);
+    }
 
     initHandler(handlerType);
 

--- a/lang/LangPrimSource/SC_ComPort.cpp
+++ b/lang/LangPrimSource/SC_ComPort.cpp
@@ -205,8 +205,13 @@ UDP::UDP(int inPortNum, HandlerType handlerType, int portsToCheck): mPortNum(inP
         }
     }
 
-    boost::asio::socket_base::send_buffer_size option(65536);
-    mUdpSocket.set_option(option);
+    boost::asio::socket_base::send_buffer_size send_buffer_size(65536);
+    mUdpSocket.set_option(send_buffer_size);
+
+    boost::asio::socket_base::receive_buffer_size recv_buffer_size(8 * 1024 * 1024);
+    try {
+        mUdpSocket.set_option(recv_buffer_size);
+    } catch (boost::system::system_error e) {}
 
     initHandler(handlerType);
 

--- a/lang/LangPrimSource/SC_ComPort.h
+++ b/lang/LangPrimSource/SC_ComPort.h
@@ -82,6 +82,8 @@ private:
 
     int mPortNum;
     HandleDataFunc mHandleFunc;
+    static constexpr int receiveBufferSize = 8 * 1024 * 1024;
+    static constexpr int sendBufferSize = 8 * 1024 * 1024;
     std::array<char, kTextBufSize> mRecvBuffer;
     boost::asio::ip::udp::endpoint mRemoteEndpoint;
     boost::asio::ip::udp::socket mUdpSocket;

--- a/server/scsynth/SC_ComPort.cpp
+++ b/server/scsynth/SC_ComPort.cpp
@@ -261,24 +261,24 @@ public:
         if (inPortNum == 0)
             mPortNum = udpSocket.local_endpoint().port();
 
-        boost::asio::socket_base::send_buffer_size send_buffer_size;
-        udpSocket.get_option(send_buffer_size);
-        if (send_buffer_size.value() < 8 * 1024 * 1024) {
-            send_buffer_size = 8 * 1024 * 1024;
+        boost::asio::socket_base::send_buffer_size sendBufferSize;
+        udpSocket.get_option(sendBufferSize);
+        if (sendBufferSize.value() < 8 * 1024 * 1024) {
+            sendBufferSize = 8 * 1024 * 1024;
             try {
-                udpSocket.set_option(send_buffer_size);
+                udpSocket.set_option(sendBufferSize);
             } catch (boost::system::system_error& e) {}
-            udpSocket.get_option(send_buffer_size);
+            udpSocket.get_option(sendBufferSize);
         }
 
-        boost::asio::socket_base::receive_buffer_size recv_buffer_size;
-        udpSocket.get_option(recv_buffer_size);
-        if (recv_buffer_size.value() < 8 * 1024 * 1024) {
-            recv_buffer_size = 8 * 1024 * 1024;
+        boost::asio::socket_base::receive_buffer_size receiveBufferSize;
+        udpSocket.get_option(receiveBufferSize);
+        if (receiveBufferSize.value() < 8 * 1024 * 1024) {
+            receiveBufferSize = 8 * 1024 * 1024;
             try {
-                udpSocket.set_option(recv_buffer_size);
+                udpSocket.set_option(receiveBufferSize);
             } catch (boost::system::system_error& e) {}
-            udpSocket.get_option(recv_buffer_size);
+            udpSocket.get_option(receiveBufferSize);
         }
 
 #ifdef USE_RENDEZVOUS

--- a/server/scsynth/SC_ComPort.cpp
+++ b/server/scsynth/SC_ComPort.cpp
@@ -245,6 +245,9 @@ class SC_UdpInPort {
                                                  asio::placeholders::bytes_transferred));
     }
 
+    static constexpr int receiveBufferSize = 8 * 1024 * 1024;
+    static constexpr int sendBufferSize = 8 * 1024 * 1024;
+
 public:
     boost::asio::ip::udp::socket udpSocket;
 
@@ -263,8 +266,8 @@ public:
 
         boost::asio::socket_base::send_buffer_size sendBufferSize;
         udpSocket.get_option(sendBufferSize);
-        if (sendBufferSize.value() < 8 * 1024 * 1024) {
-            sendBufferSize = 8 * 1024 * 1024;
+        if (sendBufferSize.value() < SC_UdpInPort::sendBufferSize) {
+            sendBufferSize = SC_UdpInPort::sendBufferSize;
             try {
                 udpSocket.set_option(sendBufferSize);
             } catch (boost::system::system_error& e) {}
@@ -273,8 +276,8 @@ public:
 
         boost::asio::socket_base::receive_buffer_size receiveBufferSize;
         udpSocket.get_option(receiveBufferSize);
-        if (receiveBufferSize.value() < 8 * 1024 * 1024) {
-            receiveBufferSize = 8 * 1024 * 1024;
+        if (receiveBufferSize.value() < SC_UdpInPort::receiveBufferSize) {
+            receiveBufferSize = SC_UdpInPort::receiveBufferSize;
             try {
                 udpSocket.set_option(receiveBufferSize);
             } catch (boost::system::system_error& e) {}

--- a/server/scsynth/SC_ComPort.cpp
+++ b/server/scsynth/SC_ComPort.cpp
@@ -271,7 +271,6 @@ public:
             try {
                 udpSocket.set_option(sendBufferSize);
             } catch (boost::system::system_error& e) {}
-            udpSocket.get_option(sendBufferSize);
         }
 
         boost::asio::socket_base::receive_buffer_size receiveBufferSize;
@@ -281,7 +280,6 @@ public:
             try {
                 udpSocket.set_option(receiveBufferSize);
             } catch (boost::system::system_error& e) {}
-            udpSocket.get_option(receiveBufferSize);
         }
 
 #ifdef USE_RENDEZVOUS

--- a/server/scsynth/SC_ComPort.cpp
+++ b/server/scsynth/SC_ComPort.cpp
@@ -261,8 +261,21 @@ public:
         if (inPortNum == 0)
             mPortNum = udpSocket.local_endpoint().port();
 
-        boost::asio::socket_base::send_buffer_size option(65536);
-        udpSocket.set_option(option);
+        boost::asio::socket_base::send_buffer_size send_buffer_size(65536);
+        udpSocket.set_option(send_buffer_size);
+
+        boost::asio::socket_base::receive_buffer_size recv_buffer_size;
+
+        udpSocket.get_option(recv_buffer_size);
+        scprintf("SC_UDP_PORT: default socket receive buffer size: %d\n", recv_buffer_size.value());
+
+        recv_buffer_size = 8 * 1024 * 1024;
+        try {
+            udpSocket.set_option(recv_buffer_size);
+        } catch (boost::system::system_error e) {}
+        udpSocket.get_option(recv_buffer_size);
+        scprintf("SC_UDP_PORT: Set socket receive buffer size to %d bytes (actual size: %d)\n", 8 * 1024 * 1024,
+                 recv_buffer_size.value());
 
 #ifdef USE_RENDEZVOUS
         if (world->mRendezvous) {

--- a/server/scsynth/SC_ComPort.cpp
+++ b/server/scsynth/SC_ComPort.cpp
@@ -264,8 +264,8 @@ public:
         if (inPortNum == 0)
             mPortNum = udpSocket.local_endpoint().port();
 
-        boost::asio::socket_base::send_buffer_size sendBufferSize;
         try {
+            boost::asio::socket_base::send_buffer_size sendBufferSize;
             udpSocket.get_option(sendBufferSize);
             if (sendBufferSize.value() < SC_UdpInPort::sendBufferSize) {
                 sendBufferSize = SC_UdpInPort::sendBufferSize;
@@ -273,8 +273,8 @@ public:
             }
         } catch (boost::system::system_error& e) { printf("WARNING: failed to set send buffer size\n"); }
 
-        boost::asio::socket_base::receive_buffer_size receiveBufferSize;
         try {
+            boost::asio::socket_base::receive_buffer_size receiveBufferSize;
             udpSocket.get_option(receiveBufferSize);
             if (receiveBufferSize.value() < SC_UdpInPort::receiveBufferSize) {
                 receiveBufferSize = SC_UdpInPort::receiveBufferSize;

--- a/server/scsynth/SC_ComPort.cpp
+++ b/server/scsynth/SC_ComPort.cpp
@@ -265,21 +265,25 @@ public:
             mPortNum = udpSocket.local_endpoint().port();
 
         boost::asio::socket_base::send_buffer_size sendBufferSize;
-        udpSocket.get_option(sendBufferSize);
-        if (sendBufferSize.value() < SC_UdpInPort::sendBufferSize) {
-            sendBufferSize = SC_UdpInPort::sendBufferSize;
-            try {
+        try {
+            udpSocket.get_option(sendBufferSize);
+            if (sendBufferSize.value() < SC_UdpInPort::sendBufferSize) {
+                sendBufferSize = SC_UdpInPort::sendBufferSize;
                 udpSocket.set_option(sendBufferSize);
-            } catch (boost::system::system_error& e) {}
+            }
+        } catch (boost::system::system_error& e) {
+            printf("WARNING: failed to set send buffer size\n");
         }
 
         boost::asio::socket_base::receive_buffer_size receiveBufferSize;
-        udpSocket.get_option(receiveBufferSize);
-        if (receiveBufferSize.value() < SC_UdpInPort::receiveBufferSize) {
-            receiveBufferSize = SC_UdpInPort::receiveBufferSize;
-            try {
+        try {
+            udpSocket.get_option(receiveBufferSize);
+            if (receiveBufferSize.value() < SC_UdpInPort::receiveBufferSize) {
+                receiveBufferSize = SC_UdpInPort::receiveBufferSize;
                 udpSocket.set_option(receiveBufferSize);
-            } catch (boost::system::system_error& e) {}
+            }
+        } catch (boost::system::system_error& e) {
+            printf("WARNING: failed to set receive buffer size\n");
         }
 
 #ifdef USE_RENDEZVOUS

--- a/server/scsynth/SC_ComPort.cpp
+++ b/server/scsynth/SC_ComPort.cpp
@@ -271,9 +271,7 @@ public:
                 sendBufferSize = SC_UdpInPort::sendBufferSize;
                 udpSocket.set_option(sendBufferSize);
             }
-        } catch (boost::system::system_error& e) {
-            printf("WARNING: failed to set send buffer size\n");
-        }
+        } catch (boost::system::system_error& e) { printf("WARNING: failed to set send buffer size\n"); }
 
         boost::asio::socket_base::receive_buffer_size receiveBufferSize;
         try {
@@ -282,9 +280,7 @@ public:
                 receiveBufferSize = SC_UdpInPort::receiveBufferSize;
                 udpSocket.set_option(receiveBufferSize);
             }
-        } catch (boost::system::system_error& e) {
-            printf("WARNING: failed to set receive buffer size\n");
-        }
+        } catch (boost::system::system_error& e) { printf("WARNING: failed to set receive buffer size\n"); }
 
 #ifdef USE_RENDEZVOUS
         if (world->mRendezvous) {

--- a/server/supernova/sc/sc_osc_handler.cpp
+++ b/server/supernova/sc/sc_osc_handler.cpp
@@ -612,21 +612,25 @@ void sc_osc_handler::open_udp_socket(ip::address address, unsigned int port) {
         sc_notify_observers::udp_socket.open(udp::v4());
 
     boost::asio::socket_base::send_buffer_size send_buffer_size;
-    udp_socket.get_option(send_buffer_size);
-    if (send_buffer_size.value() < sc_osc_handler::udp_send_buffer_size) {
-        send_buffer_size = sc_osc_handler::udp_send_buffer_size;
-        try {
+    try {
+        udp_socket.get_option(send_buffer_size);
+        if (send_buffer_size.value() < sc_osc_handler::udp_send_buffer_size) {
+            send_buffer_size = sc_osc_handler::udp_send_buffer_size;
             udp_socket.set_option(send_buffer_size);
-        } catch (boost::system::system_error& e) {}
+        }
+    } catch (boost::system::system_error& e) {
+        printf("WARNING: failed to set send buffer size\n");
     }
 
     boost::asio::socket_base::receive_buffer_size recv_buffer_size;
-    udp_socket.get_option(recv_buffer_size);
-    if (recv_buffer_size.value() < sc_osc_handler::udp_receive_buffer_size) {
-        recv_buffer_size = sc_osc_handler::udp_receive_buffer_size;
-        try {
+    try {
+        udp_socket.get_option(recv_buffer_size);
+        if (recv_buffer_size.value() < sc_osc_handler::udp_receive_buffer_size) {
+            recv_buffer_size = sc_osc_handler::udp_receive_buffer_size;
             udp_socket.set_option(recv_buffer_size);
-        } catch (boost::system::system_error& e) {}
+        }
+    } catch (boost::system::system_error& e) {
+        printf("WARNING: failed to set receive buffer size\n");
     }
 
     sc_notify_observers::udp_socket.bind(udp::endpoint(address, port));

--- a/server/supernova/sc/sc_osc_handler.cpp
+++ b/server/supernova/sc/sc_osc_handler.cpp
@@ -618,9 +618,7 @@ void sc_osc_handler::open_udp_socket(ip::address address, unsigned int port) {
             send_buffer_size = sc_osc_handler::udp_send_buffer_size;
             udp_socket.set_option(send_buffer_size);
         }
-    } catch (boost::system::system_error& e) {
-        printf("WARNING: failed to set send buffer size\n");
-    }
+    } catch (boost::system::system_error& e) { printf("WARNING: failed to set send buffer size\n"); }
 
     boost::asio::socket_base::receive_buffer_size recv_buffer_size;
     try {
@@ -629,9 +627,7 @@ void sc_osc_handler::open_udp_socket(ip::address address, unsigned int port) {
             recv_buffer_size = sc_osc_handler::udp_receive_buffer_size;
             udp_socket.set_option(recv_buffer_size);
         }
-    } catch (boost::system::system_error& e) {
-        printf("WARNING: failed to set receive buffer size\n");
-    }
+    } catch (boost::system::system_error& e) { printf("WARNING: failed to set receive buffer size\n"); }
 
     sc_notify_observers::udp_socket.bind(udp::endpoint(address, port));
 }

--- a/server/supernova/sc/sc_osc_handler.cpp
+++ b/server/supernova/sc/sc_osc_handler.cpp
@@ -611,23 +611,23 @@ void sc_osc_handler::open_udp_socket(ip::address address, unsigned int port) {
     else
         sc_notify_observers::udp_socket.open(udp::v4());
 
-    boost::asio::socket_base::send_buffer_size send_buffer_size;
     try {
+        boost::asio::socket_base::send_buffer_size send_buffer_size;
         udp_socket.get_option(send_buffer_size);
         if (send_buffer_size.value() < sc_osc_handler::udp_send_buffer_size) {
             send_buffer_size = sc_osc_handler::udp_send_buffer_size;
             udp_socket.set_option(send_buffer_size);
         }
-    } catch (boost::system::system_error& e) { printf("WARNING: failed to set send buffer size\n"); }
+    } catch (boost::system::system_error& e) { std::cout << "WARNING: failed to set send buffer size\n"; }
 
-    boost::asio::socket_base::receive_buffer_size recv_buffer_size;
     try {
+        boost::asio::socket_base::receive_buffer_size recv_buffer_size;
         udp_socket.get_option(recv_buffer_size);
         if (recv_buffer_size.value() < sc_osc_handler::udp_receive_buffer_size) {
             recv_buffer_size = sc_osc_handler::udp_receive_buffer_size;
             udp_socket.set_option(recv_buffer_size);
         }
-    } catch (boost::system::system_error& e) { printf("WARNING: failed to set receive buffer size\n"); }
+    } catch (boost::system::system_error& e) { std::cout << "WARNING: failed to set receive buffer size\n"; }
 
     sc_notify_observers::udp_socket.bind(udp::endpoint(address, port));
 }

--- a/server/supernova/sc/sc_osc_handler.cpp
+++ b/server/supernova/sc/sc_osc_handler.cpp
@@ -618,7 +618,6 @@ void sc_osc_handler::open_udp_socket(ip::address address, unsigned int port) {
         try {
             udp_socket.set_option(send_buffer_size);
         } catch (boost::system::system_error& e) {}
-        udp_socket.get_option(send_buffer_size);
     }
 
     boost::asio::socket_base::receive_buffer_size recv_buffer_size;
@@ -628,7 +627,6 @@ void sc_osc_handler::open_udp_socket(ip::address address, unsigned int port) {
         try {
             udp_socket.set_option(recv_buffer_size);
         } catch (boost::system::system_error& e) {}
-        udp_socket.get_option(recv_buffer_size);
     }
 
     sc_notify_observers::udp_socket.bind(udp::endpoint(address, port));

--- a/server/supernova/sc/sc_osc_handler.cpp
+++ b/server/supernova/sc/sc_osc_handler.cpp
@@ -611,10 +611,25 @@ void sc_osc_handler::open_udp_socket(ip::address address, unsigned int port) {
     else
         sc_notify_observers::udp_socket.open(udp::v4());
 
-    boost::asio::socket_base::receive_buffer_size recv_buffer_size(8 * 1024 * 1024);
-    try {
-        sc_notify_observers::udp_socket.set_option(recv_buffer_size);
-    } catch (boost::system::system_error e) {}
+    boost::asio::socket_base::send_buffer_size send_buffer_size;
+    udp_socket.get_option(send_buffer_size);
+    if (send_buffer_size.value() < 8 * 1024 * 1024) {
+        send_buffer_size = 8 * 1024 * 1024;
+        try {
+            udp_socket.set_option(send_buffer_size);
+        } catch (boost::system::system_error& e) {}
+        udp_socket.get_option(send_buffer_size);
+    }
+
+    boost::asio::socket_base::receive_buffer_size recv_buffer_size;
+    udp_socket.get_option(recv_buffer_size);
+    if (recv_buffer_size.value() < 8 * 1024 * 1024) {
+        recv_buffer_size = 8 * 1024 * 1024;
+        try {
+            udp_socket.set_option(recv_buffer_size);
+        } catch (boost::system::system_error& e) {}
+        udp_socket.get_option(recv_buffer_size);
+    }
 
     sc_notify_observers::udp_socket.bind(udp::endpoint(address, port));
 }

--- a/server/supernova/sc/sc_osc_handler.cpp
+++ b/server/supernova/sc/sc_osc_handler.cpp
@@ -613,8 +613,8 @@ void sc_osc_handler::open_udp_socket(ip::address address, unsigned int port) {
 
     boost::asio::socket_base::send_buffer_size send_buffer_size;
     udp_socket.get_option(send_buffer_size);
-    if (send_buffer_size.value() < 8 * 1024 * 1024) {
-        send_buffer_size = 8 * 1024 * 1024;
+    if (send_buffer_size.value() < sc_osc_handler::udp_send_buffer_size) {
+        send_buffer_size = sc_osc_handler::udp_send_buffer_size;
         try {
             udp_socket.set_option(send_buffer_size);
         } catch (boost::system::system_error& e) {}
@@ -623,8 +623,8 @@ void sc_osc_handler::open_udp_socket(ip::address address, unsigned int port) {
 
     boost::asio::socket_base::receive_buffer_size recv_buffer_size;
     udp_socket.get_option(recv_buffer_size);
-    if (recv_buffer_size.value() < 8 * 1024 * 1024) {
-        recv_buffer_size = 8 * 1024 * 1024;
+    if (recv_buffer_size.value() < sc_osc_handler::udp_receive_buffer_size) {
+        recv_buffer_size = sc_osc_handler::udp_receive_buffer_size;
         try {
             udp_socket.set_option(recv_buffer_size);
         } catch (boost::system::system_error& e) {}

--- a/server/supernova/sc/sc_osc_handler.cpp
+++ b/server/supernova/sc/sc_osc_handler.cpp
@@ -611,6 +611,11 @@ void sc_osc_handler::open_udp_socket(ip::address address, unsigned int port) {
     else
         sc_notify_observers::udp_socket.open(udp::v4());
 
+    boost::asio::socket_base::receive_buffer_size recv_buffer_size(8 * 1024 * 1024);
+    try {
+        sc_notify_observers::udp_socket.set_option(recv_buffer_size);
+    } catch (boost::system::system_error e) {}
+
     sc_notify_observers::udp_socket.bind(udp::endpoint(address, port));
 }
 

--- a/server/supernova/sc/sc_osc_handler.hpp
+++ b/server/supernova/sc/sc_osc_handler.hpp
@@ -355,6 +355,9 @@ private:
     const char* tcp_password_; /* we are not owning this! */
 
     std::array<char, 1 << 15> recv_buffer_;
+
+    static constexpr int udp_receive_buffer_size = 8 * 1024 * 1024;
+    static constexpr int udp_send_buffer_size = 8 * 1024 * 1024;
     /* @} */
 };
 


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation
Set `SOL_SOCKET/SO_RCVBUF` using [boost API](https://live.boost.org/doc/libs/1_86_0/doc/html/boost_asio/reference/basic_datagram_socket/receive_buffer_size.html) to increase default UDP receive socket buffer size. Close #5993 and probably #5870. For now, I increase the buffer size to 8MB. But the choose is somewhat arbitrary and I'm happy to change it if we come up with a better default.

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->

- New feature

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested (only on Linux)
- [ ] All tests are passing
- [ ] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
