### PR TITLE
classlib: more tolerant plot

### DIFF
--- a/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
+++ b/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
@@ -1290,8 +1290,8 @@ Plotter {
 		depth = array.maxDepth;
 		hasSubArrays = depth > 1;
 
-		if(depth > 2) {
-			"Cannot currently plot an array with more than 2 dimensions".warn;
+		if(depth > 3) {
+			"Cannot currently plot an array with more than 3 dimensions".warn;
 			^nil
 		};
 

--- a/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
+++ b/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
@@ -1284,13 +1284,17 @@ Plotter {
 
 + ArrayedCollection {
 	plot { |name, bounds, discrete = false, numChannels, minval, maxval, separately = true, parent|
-		var array, plotter;
+		var array, plotter, depth, hasSubArrays;
 		array = this.as(Array);
 
-		if(array.maxDepth > 3) {
-			"Cannot currently plot an array with more than 3 dimensions".warn;
+		depth = array.maxDepth;
+		hasSubArrays = depth > 1;
+
+		if(depth > 2) {
+			"Cannot currently plot an array with more than 2 dimensions".warn;
 			^nil
 		};
+
 		plotter = Plotter(name, bounds, parent);
 		if(discrete) {
 			plotter.plotMode = \points
@@ -1309,7 +1313,11 @@ Plotter {
 				if(elem.isNil) {
 					Error("Cannot plot array: non-numeric value at index %".format(i)).throw
 				};
-				elem
+				if(hasSubArrays) {
+					elem.asArray
+				} {
+					elem
+				}
 			}
 		};
 

--- a/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
+++ b/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
@@ -1290,8 +1290,8 @@ Plotter {
 		depth = array.maxDepth;
 		hasSubArrays = depth > 1;
 
-		if(depth > 3) {
-			"Cannot currently plot an array with more than 3 dimensions".warn;
+		if(depth > 2) {
+			"Cannot currently plot an array with more than 2 dimensions".warn;
 			^nil
 		};
 

--- a/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
+++ b/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
@@ -932,11 +932,16 @@ Plotter {
 
 	superpose_ { |flag|
 		var dom, domSpecs;
+		if(flag and: { value.isRectangular.not }) {
+			"Plotter can't superpose unequally sized arrays.".warn;
+			^this
+		};
+
 		dom = domain.copy;
 		domSpecs = domainSpecs.copy;
 
 		superpose = flag;
-		if ( value.notNil ){
+		if(value.notNil) {
 			this.setValue(value, false, false);
 		};
 


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

Fixes #6565

It easily happens that a subarray is a number.

## Types of changes

- more tolerant plot behaviour

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [ ] Code is tested
- [ ] All tests are passing
- [ ] Updated documentation
- [ ] This PR is ready for review
- Release Notes: plot doesn't fail with opaque error when subarray turns out to be a number in a multichannel array

