### PR TITLE
SCLang: implement superPerformArgs fixing inf. loop

### DIFF
--- a/SCClassLibrary/Common/Collections/Dictionary.sc
+++ b/SCClassLibrary/Common/Collections/Dictionary.sc
@@ -541,7 +541,7 @@ IdentityDictionary : Dictionary {
 
 	doesNotUnderstand { |selector... args, kwargs|
 		if (know.not) {
-            ^super.performArgs(\doesNotUnderstand, args, kwargs)
+            ^this.superPerformArgs(\doesNotUnderstand, args, kwargs)
 		};
         this[selector] !? { |func|
 			^func.performArgs(\functionPerformList, [\value, this, args], kwargs);

--- a/SCClassLibrary/Common/Collections/Scale.sc
+++ b/SCClassLibrary/Common/Collections/Scale.sc
@@ -20,7 +20,7 @@ Scale {
 
 	*doesNotUnderstand { |selector... args, kwargs|
 		var scale = this.performArgs(\newFromKey, [selector] ++ args, kwargs).deepCopy;
-		^scale ?? { super.performArgs(\doesNotUnderstand, [selector] ++ args, kwargs) }
+		^scale ?? { this.superPerformArgs(\doesNotUnderstand, [selector] ++ args, kwargs) }
 	}
 
 	*newFromKey { |key, tuning|
@@ -186,7 +186,7 @@ Tuning {
 
 	*doesNotUnderstand { |selector... args, kwargs|
 		var tuning = this.performArgs(\newFromKey, [selector] ++ args, kwargs).deepCopy;
-		^tuning ?? { super.performArgs(\doesNotUnderstand, [selector] ++ args, kwargs) }
+		^tuning ?? { this.superPerformArgs(\doesNotUnderstand, [selector] ++ args, kwargs) }
 	}
 
 	*newFromKey { | key |

--- a/SCClassLibrary/Common/Core/Object.sc
+++ b/SCClassLibrary/Common/Core/Object.sc
@@ -80,6 +80,10 @@ Object {
 		_ObjectPerformArgs;
 		^this.primitiveFailed
 	}
+	superPerformArgs { |selector, args, kwargs|
+		_ObjectSuperPerformArgs;
+		^this.primitiveFailed
+	}
 	performMsg { |msg|
 		_ObjectPerformMsg;
 		^this.primitiveFailed

--- a/lang/LangPrimSource/PyrPrimitive.cpp
+++ b/lang/LangPrimSource/PyrPrimitive.cpp
@@ -979,7 +979,8 @@ int blockValueEnvirWithKeys(VMGlobals* g, int allArgsPushed, int numKeyArgsPushe
     return errNone;
 }
 
-int objectPerformArgs(struct VMGlobals* g, int numArgsPushed) {
+template <class SendMessageImpl>
+int objectPerformArgsImpl(struct VMGlobals* g, int numArgsPushed, SendMessageImpl&& sendMessageImpl) {
     auto receiverSlot = g->sp - numArgsPushed + 1;
     auto selectorSlot = receiverSlot + 1;
     auto argsArraySlot = selectorSlot + 1;
@@ -1022,7 +1023,7 @@ int objectPerformArgs(struct VMGlobals* g, int numArgsPushed) {
 
     if (argsSize == 0 && kwSize == 0) {
         g->sp -= 3;
-        sendMessage(g, selector, 1, 0);
+        std::forward<SendMessageImpl>(sendMessageImpl)(g, selector, 1, 0);
         g->numpop = 0;
         return errNone;
     }
@@ -1053,9 +1054,30 @@ int objectPerformArgs(struct VMGlobals* g, int numArgsPushed) {
     }
 
     g->sp = receiverSlot + argsSize + kwSize;
-    sendMessage(g, selector, argsSize + kwSize + 1, (kwSize / 2));
+    std::forward<SendMessageImpl>(sendMessageImpl)(g, selector, argsSize + kwSize + 1, (kwSize / 2));
     g->numpop = 0;
     return errNone;
+}
+
+int objectSuperPerformArgs(struct VMGlobals* g, int numArgsPushed) {
+    auto receiverSlot = g->sp - numArgsPushed + 1;
+    PyrClass* classobj = slotRawSymbol(&slotRawClass(&g->method->ownerclass)->superclass)->u.classobj;
+    if (!isKindOfSlot(receiverSlot, classobj)) {
+        error("superPerform must be called with 'this' as the receiver.\n");
+        return errFailed;
+    }
+
+    return objectPerformArgsImpl(g, numArgsPushed,
+                                 [](VMGlobals* g, PyrSymbol* selector, int num_args, int num_keywords) {
+                                     sendSuperMessage(g, selector, num_args, num_keywords);
+                                 });
+}
+
+int objectPerformArgs(struct VMGlobals* g, int numArgsPushed) {
+    return objectPerformArgsImpl(g, numArgsPushed,
+                                 [](VMGlobals* g, PyrSymbol* selector, int num_args, int num_keywords) {
+                                     sendMessage(g, selector, num_args, num_keywords);
+                                 });
 }
 
 int objectPerform(struct VMGlobals* g, int numArgsPushed) {
@@ -3738,6 +3760,7 @@ void initPrimitives() {
     definePrimitiveWithKeys(base, index, "_ObjectPerform", objectPerform, objectPerformWithKeys, 2, 1);
     index += 2;
     definePrimitive(base, index++, "_ObjectPerformArgs", objectPerformArgs, 4, 0);
+    definePrimitive(base, index++, "_ObjectSuperPerformArgs", objectSuperPerformArgs, 4, 0);
 
     definePrimitiveWithKeys(base, index, "_ObjectPerformList", objectPerformList, objectPerformListWithKeys, 2, 1);
     index += 2;

--- a/testsuite/classlibrary/TestPerformArgs.sc
+++ b/testsuite/classlibrary/TestPerformArgs.sc
@@ -1,49 +1,67 @@
 TestPerformArgs_O {
-    foo { |a, b, c, d, e, f... args, kwargs |
-        ^(a: a, b: b, c: c, d: d, e: e, f: f, args: args, kwargs: kwargs)
-    }
+	foo { |a, b, c, d, e, f... args, kwargs |
+		^(a: a, b: b, c: c, d: d, e: e, f: f, args: args, kwargs: kwargs)
+	}
+	doesNotUnderstand { |selector... args, kwargs|
+		^if (selector == \abc) {
+			true
+		} {
+			this.superPerformArgs(\doesNotUnderstand, [selector] ++ args, kwargs)
+		}
+	}
 }
 
 TestPerformArgs : UnitTest {
-    test_correct_behaviour {
-        this.assertEquals(
-            TestPerformArgs_O().performArgs(\foo, [1, 2], [\e, 10, \f, 11, \bar, 12]),
-            (a: 1, b: 2, e: 10, f: 11, args: [], kwargs: [\bar, 12]),
-            "performArgs should pass arguments correctly."
-        );
-        this.assertEquals(
-            TestPerformArgs_O().performArgs(\foo, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),
-            (a: 1, b: 2, c: 3, d: 4, e: 5, f: 6, args: [7, 8, 9, 10], kwargs: []),
-            "performArgs should pass arguments correctly to variable arguments."
-        );
-        this.assertEquals(
-            TestPerformArgs_O().performArgs(\foo, nil, [\a, 10, \b, 20]),
-            (a: 10, b: 20, args: [], kwargs: []),
-            "performArgs should work with only keyword arguments."
-        );
-    }
-    test_incorrect_behaviour {
-        this.assertException(
-            { TestPerformArgs_O().performArgs(()) },
-            PrimitiveFailedError,
-            "Passing incorrect selector should throw."
-        );
-        this.assertException(
-            { TestPerformArgs_O().performArgs(\foo, [1, 2, 3], [4, 5, 6]) },
-            PrimitiveFailedError,
-            "Passing incorrect kwargs should throw."
-        );
-        this.assertException(
-            { TestPerformArgs_O().performArgs(\foo, (a: 1, b: 2, c: 3), [4, 5, 6]) },
-            PrimitiveFailedError,
-            "Passing incorrect args should throw."
-        );
-    }
+	test_correct_behaviour {
+		this.assertEquals(
+			TestPerformArgs_O().performArgs(\foo, [1, 2], [\e, 10, \f, 11, \bar, 12]),
+			(a: 1, b: 2, e: 10, f: 11, args: [], kwargs: [\bar, 12]),
+			"performArgs should pass arguments correctly."
+		);
+		this.assertEquals(
+			TestPerformArgs_O().performArgs(\foo, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),
+			(a: 1, b: 2, c: 3, d: 4, e: 5, f: 6, args: [7, 8, 9, 10], kwargs: []),
+			"performArgs should pass arguments correctly to variable arguments."
+		);
+		this.assertEquals(
+			TestPerformArgs_O().performArgs(\foo, nil, [\a, 10, \b, 20]),
+			(a: 10, b: 20, args: [], kwargs: []),
+			"performArgs should work with only keyword arguments."
+		);
+	}
+
+	test_incorrect_behaviour {
+		this.assertException(
+			{ TestPerformArgs_O().performArgs(()) },
+			PrimitiveFailedError,
+			"Passing incorrect selector should throw."
+		);
+		this.assertException(
+			{ TestPerformArgs_O().performArgs(\foo, [1, 2, 3], [4, 5, 6]) },
+			PrimitiveFailedError,
+			"Passing incorrect kwargs should throw."
+		);
+		this.assertException(
+			{ TestPerformArgs_O().performArgs(\foo, (a: 1, b: 2, c: 3), [4, 5, 6]) },
+			PrimitiveFailedError,
+			"Passing incorrect args should throw."
+		);
+	}
+
 	test_duplicates {
-		 this.assertEquals(
+		this.assertEquals(
 			TestPerformArgs_O().performArgs(\foo, [1, 2], [\a: 10, \b: 20, \a: 30]),
-            (a: 30, b: 20, args: [], kwargs: []),
-            "performArgs should accept last value in cases of collision."
-        );
+			(a: 30, b: 20, args: [], kwargs: []),
+			"performArgs should accept last value in cases of collision."
+		);
+	}
+
+	test_correct_superPerformArgsImpl {
+		this.assert(TestPerformArgs_O().abc, report: false);
+		this.assertException(
+			{ TestPerformArgs_O().asd  }, // This will infinitly loop if wrong.
+			DoesNotUnderstandError,
+			"superPerformArgs works as expected"
+		);
 	}
 }


### PR DESCRIPTION
## Purpose and Motivation
`super.performArgs` doesn't work as expected, so this is needed.

Fixes #6567 

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix


## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
