### PR TITLE
[qt5] QMetaType fix for Qt5

### DIFF
--- a/QtCollider/QObjectProxy.cpp
+++ b/QtCollider/QObjectProxy.cpp
@@ -87,7 +87,11 @@ static bool serializeSignature(QVarLengthArray<char, 512>& dst, const char* meth
     int i;
     for (i = 0; i < argc; ++i) {
         int typeId = argv[i].type()->id();
+#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
+        const char* typeName = QMetaType::typeName(typeId);
+#else
         const char* typeName = QMetaType(typeId).name();
+#endif
         int len = qstrlen(typeName);
         if (len <= 0) {
             qcErrorMsg("Could not get argument type name.");

--- a/QtCollider/QcObjectFactory.h
+++ b/QtCollider/QcObjectFactory.h
@@ -54,7 +54,11 @@ static void qcNoConstructorMsg(const QMetaObject* metaObject, int argc, QtCollid
         if (type) {
             if (i > 0)
                 str += ", ";
+#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
+            str += QMetaType::typeName(type->id());
+#else
             str += QMetaType(type->id()).name();
+#endif
         } else
             break;
     }

--- a/QtCollider/metatype.hpp
+++ b/QtCollider/metatype.hpp
@@ -130,14 +130,22 @@ public:
 
     QGenericArgument toGenericArgument() {
         if (mType)
+#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
+            return QGenericArgument(QMetaType::typeName(mType->id()), mData);
+#else
             return QGenericArgument(QMetaType(mType->id()).name(), mData);
+#endif
         else
             return QGenericArgument();
     }
 
     QGenericReturnArgument toGenericReturnArgument() {
         if (mType)
+#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
+            return QGenericReturnArgument(QMetaType::typeName(mType->id()), mData);
+#else
             return QGenericReturnArgument(QMetaType(mType->id()).name(), mData);
+#endif
         else
             return QGenericReturnArgument();
     }


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

In the process of reviewing https://github.com/supercollider/supercollider/pull/6521 it turned out that the issue in https://github.com/supercollider/supercollider/issues/6508 was already present with Qt 5.15 after adding https://github.com/supercollider/supercollider/commit/f70364c704ea18f00e5aa10aa390aa1ef1b8fdb6. This PR brings back old behavior at the cost of four extra ifdefs in the codebase, reverting that change for Qt5. See discussion in https://github.com/supercollider/supercollider/pull/6521#issuecomment-2539351954.

Thanks @xunil-cloud for the tip.

There might be a better way to address this issue, but I have no expertise to pursue that. I think the ifdef is a quick and easy fix, and will be removed when we remove Qt5 support altogether.

Fixes https://github.com/supercollider/supercollider/issues/6508 for Qt 5.15 (macOS legacy build).

Code that was previously failing for reference:
```supercollider
(
t = TreeView().front;
t.addItem(["hi"]);
)
```

## Types of changes

<!-- Delete lines that don't apply -->


- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- n/a Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
