### PR TITLE
QtCollider: Fix touchpad mousewheel event scaling

### DIFF
--- a/QtCollider/QWidgetProxy.cpp
+++ b/QtCollider/QWidgetProxy.cpp
@@ -372,9 +372,15 @@ bool QWidgetProxy::interpretMouseWheelEvent(QObject* o, QEvent* e, QList<QVarian
     QWidget* w = widget();
     QPointF pt = _mouseEventWidget == w ? we->position() : _mouseEventWidget->mapTo(w, we->position().toPoint());
 
+    QPointF delta;
     // only hi-res trackpads return pixelDelta everything else uses angleDelta..
-    QPointF delta = we->pixelDelta().isNull() ? we->angleDelta() / 8.f // scaled to return steps of 15
-                                              : we->pixelDelta() * 0.25f; // this matches old scaling of delta
+    if (we->pixelDelta().isNull()) {
+        delta = we->angleDelta();
+        delta *= 0.125f; // scaled to return steps of 15
+    } else {
+        delta = we->pixelDelta();
+        delta *= 0.25f; // this matches old scaling of delta
+    }
 
     args << pt.x();
     args << pt.y();


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

Delta values in View.mouseWheelEvent are truncated, mostly producing zeroes, on my macbook trackpad. This is due to the delta integer being multiplied with 0.25 (apparently for historical reasons), truncating all small changes to zero. By casting the delta value to QPointF _before_ scaling, delta should no longer be truncated.

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested (manually)
- [ ] All tests are passing
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
