### PR TITLE
Boost 1.87 support

### DIFF
--- a/QtCollider/LanguageClient.cpp
+++ b/QtCollider/LanguageClient.cpp
@@ -70,7 +70,7 @@ void LangClient::customEvent(QEvent* e) {
 
     case Event_SCRequest_Work:
         QApplication::removePostedEvents(this, Event_SCRequest_Work);
-        mIoService.poll();
+        mIoContext.poll();
         break;
     case Event_SCRequest_Quit: {
         int code = static_cast<SCRequestEvent*>(e)->data.toInt();

--- a/lang/LangPrimSource/OSCData.cpp
+++ b/lang/LangPrimSource/OSCData.cpp
@@ -745,7 +745,7 @@ static PyrObject* ConvertReplyAddress(ReplyAddress* inReply) {
     VMGlobals* g = gMainVMGlobals;
     PyrObject* obj = instantiateObject(g->gc, s_netaddr->u.classobj, 2, true, false);
     PyrSlot* slots = obj->slots;
-    SetInt(slots + 0, inReply->mAddress.to_v4().to_ulong());
+    SetInt(slots + 0, inReply->mAddress.to_v4().to_uint());
     SetInt(slots + 1, inReply->mPort);
     return obj;
 }

--- a/lang/LangPrimSource/OSCData.cpp
+++ b/lang/LangPrimSource/OSCData.cpp
@@ -934,7 +934,7 @@ void cleanup_OSC() {
 #endif
 }
 
-extern boost::asio::io_service ioService;
+extern boost::asio::io_context ioContext;
 
 static int prGetHostByName(VMGlobals* g, int numArgsPushed) {
     PyrSlot* a = g->sp;

--- a/lang/LangPrimSource/PyrSerialPrim.cpp
+++ b/lang/LangPrimSource/PyrSerialPrim.cpp
@@ -49,7 +49,7 @@
 using boost::uint8_t;
 using boost::asio::serial_port;
 
-extern boost::asio::io_service ioService; // defined in SC_ComPort.cpp
+extern boost::asio::io_context ioContext; // defined in SC_ComPort.cpp
 
 /**
  * \brief Serial port abstraction
@@ -104,7 +104,7 @@ public:
      */
     SerialPort(PyrObject* obj, const char* serialport, const Options& options):
         m_obj(obj),
-        m_port(ioService, serialport),
+        m_port(ioContext, serialport),
         m_options(options),
         m_rxErrors(0) {
         using namespace boost::asio;

--- a/lang/LangPrimSource/SC_ComPort.cpp
+++ b/lang/LangPrimSource/SC_ComPort.cpp
@@ -50,7 +50,8 @@ boost::asio::io_context ioContext;
 
 
 static void asioFunction() {
-    boost::asio::io_context::work work(ioContext);
+    boost::asio::executor_work_guard<boost::asio::io_context::executor_type> work =
+        boost::asio::make_work_guard(ioContext);
     ioContext.run();
 }
 

--- a/lang/LangPrimSource/SC_ComPort.h
+++ b/lang/LangPrimSource/SC_ComPort.h
@@ -44,7 +44,7 @@ class TCPConnection : public std::enable_shared_from_this<TCPConnection>, privat
 public:
     using pointer = std::shared_ptr<TCPConnection>;
 
-    TCPConnection(boost::asio::io_service& ioService, int portNum, HandlerType);
+    TCPConnection(boost::asio::io_context& ioContext, int portNum, HandlerType);
 
     void start();
     auto& getSocket() { return mSocket; }

--- a/lang/LangSource/SC_TerminalClient.cpp
+++ b/lang/LangSource/SC_TerminalClient.cpp
@@ -75,7 +75,7 @@ SC_TerminalClient::SC_TerminalClient(const char* name):
     SC_LanguageClient(name),
     mReturnCode(0),
     mUseReadline(false),
-    mWork(mIoContext),
+    mWork(boost::asio::make_work_guard(mIoContext)),
     mTimer(mIoContext),
 #ifndef _WIN32
     mStdIn(mInputContext, STDIN_FILENO)
@@ -614,7 +614,8 @@ void SC_TerminalClient::inputThreadFn() {
 
     startInputRead();
 
-    boost::asio::io_context::work work(mInputContext);
+    boost::asio::executor_work_guard<boost::asio::io_context::executor_type> work =
+        boost::asio::make_work_guard(mInputContext);
     mInputContext.run();
 }
 

--- a/lang/LangSource/SC_TerminalClient.cpp
+++ b/lang/LangSource/SC_TerminalClient.cpp
@@ -360,19 +360,19 @@ void SC_TerminalClient::onLibraryStartup() {
 void SC_TerminalClient::sendSignal(Signal sig) {
     switch (sig) {
     case sig_input:
-        mIoContext.post(boost::bind(&SC_TerminalClient::interpretInput, this));
+        boost::asio::post(boost::bind(&SC_TerminalClient::interpretInput, this));
         break;
 
     case sig_recompile:
-        mIoContext.post(boost::bind(&SC_TerminalClient::recompileLibrary, this));
+        boost::asio::post(boost::bind(&SC_TerminalClient::recompileLibrary, this));
         break;
 
     case sig_sched:
-        mIoContext.post(boost::bind(&SC_TerminalClient::tick, this, boost::system::error_code()));
+        boost::asio::post(boost::bind(&SC_TerminalClient::tick, this, boost::system::error_code()));
         break;
 
     case sig_stop:
-        mIoContext.post(boost::bind(&SC_TerminalClient::stopMain, this));
+        boost::asio::post(boost::bind(&SC_TerminalClient::stopMain, this));
         break;
     }
 }

--- a/lang/LangSource/SC_TerminalClient.cpp
+++ b/lang/LangSource/SC_TerminalClient.cpp
@@ -75,12 +75,12 @@ SC_TerminalClient::SC_TerminalClient(const char* name):
     SC_LanguageClient(name),
     mReturnCode(0),
     mUseReadline(false),
-    mWork(mIoService),
-    mTimer(mIoService),
+    mWork(mIoContext),
+    mTimer(mIoContext),
 #ifndef _WIN32
-    mStdIn(mInputService, STDIN_FILENO)
+    mStdIn(mInputContext, STDIN_FILENO)
 #else
-    mStdIn(mInputService, GetStdHandle(STD_INPUT_HANDLE))
+    mStdIn(mInputContext, GetStdHandle(STD_INPUT_HANDLE))
 #endif
 {
 }
@@ -360,19 +360,19 @@ void SC_TerminalClient::onLibraryStartup() {
 void SC_TerminalClient::sendSignal(Signal sig) {
     switch (sig) {
     case sig_input:
-        mIoService.post(boost::bind(&SC_TerminalClient::interpretInput, this));
+        mIoContext.post(boost::bind(&SC_TerminalClient::interpretInput, this));
         break;
 
     case sig_recompile:
-        mIoService.post(boost::bind(&SC_TerminalClient::recompileLibrary, this));
+        mIoContext.post(boost::bind(&SC_TerminalClient::recompileLibrary, this));
         break;
 
     case sig_sched:
-        mIoService.post(boost::bind(&SC_TerminalClient::tick, this, boost::system::error_code()));
+        mIoContext.post(boost::bind(&SC_TerminalClient::tick, this, boost::system::error_code()));
         break;
 
     case sig_stop:
-        mIoService.post(boost::bind(&SC_TerminalClient::stopMain, this));
+        mIoContext.post(boost::bind(&SC_TerminalClient::stopMain, this));
         break;
     }
 }
@@ -447,7 +447,7 @@ void SC_TerminalClient::tick(const boost::system::error_code& error) {
     }
 }
 
-void SC_TerminalClient::commandLoop() { mIoService.run(); }
+void SC_TerminalClient::commandLoop() { mIoContext.run(); }
 
 void SC_TerminalClient::daemonLoop() { commandLoop(); }
 
@@ -614,8 +614,8 @@ void SC_TerminalClient::inputThreadFn() {
 
     startInputRead();
 
-    boost::asio::io_service::work work(mInputService);
-    mInputService.run();
+    boost::asio::io_context::work work(mInputContext);
+    mInputContext.run();
 }
 
 
@@ -662,7 +662,7 @@ void SC_TerminalClient::startInput() {
 }
 
 void SC_TerminalClient::endInput() {
-    mInputService.stop();
+    mInputContext.stop();
     mStdIn.cancel();
 #ifdef _WIN32
     // Note this breaks Windows XP compatibility, since this function is only defined in Vista and later

--- a/lang/LangSource/SC_TerminalClient.h
+++ b/lang/LangSource/SC_TerminalClient.h
@@ -154,7 +154,7 @@ protected:
     boost::asio::io_context mIoContext;
 
 private:
-    boost::asio::io_context::work mWork;
+    boost::asio::executor_work_guard<boost::asio::io_context::executor_type> mWork;
     boost::asio::basic_waitable_timer<std::chrono::system_clock> mTimer;
 
     // input io service

--- a/lang/LangSource/SC_TerminalClient.h
+++ b/lang/LangSource/SC_TerminalClient.h
@@ -91,7 +91,7 @@ public:
     // NOTE: It may be called from any thread, and with interpreter locked.
     virtual void sendSignal(Signal code);
 
-    void stop() { mIoService.stop(); }
+    void stop() { mIoContext.stop(); }
 
 protected:
     bool parseOptions(int& argc, char**& argv, Options& opt);
@@ -151,14 +151,14 @@ private:
 
     // app-clock io service
 protected:
-    boost::asio::io_service mIoService;
+    boost::asio::io_context mIoContext;
 
 private:
-    boost::asio::io_service::work mWork;
+    boost::asio::io_context::work mWork;
     boost::asio::basic_waitable_timer<std::chrono::system_clock> mTimer;
 
     // input io service
-    boost::asio::io_service mInputService;
+    boost::asio::io_context mInputContext;
     SC_Thread mInputThread;
     void inputThreadFn();
 

--- a/server/scsynth/SC_ComPort.cpp
+++ b/server/scsynth/SC_ComPort.cpp
@@ -453,7 +453,8 @@ static void asioFunction() {
     nova::thread_set_priority_rt(priority);
 #endif
 
-    boost::asio::io_context::work work(ioContext);
+    boost::asio::executor_work_guard<boost::asio::io_context::executor_type> work =
+        boost::asio::make_work_guard(ioContext);
     ioContext.run();
 }
 

--- a/server/scsynth/SC_ComPort.cpp
+++ b/server/scsynth/SC_ComPort.cpp
@@ -257,7 +257,7 @@ public:
         BOOST_AUTO(protocol, ip::udp::v4());
         udpSocket.open(protocol);
 
-        udpSocket.bind(ip::udp::endpoint(boost::asio::ip::address::from_string(bindTo), inPortNum));
+        udpSocket.bind(ip::udp::endpoint(boost::asio::ip::make_address(bindTo), inPortNum));
         if (inPortNum == 0)
             mPortNum = udpSocket.local_endpoint().port();
 
@@ -400,7 +400,7 @@ class SC_TcpInPort {
 public:
     SC_TcpInPort(struct World* world, const std::string& bindTo, int inPortNum, int inMaxConnections, int inBacklog):
         mWorld(world),
-        acceptor(ioContext, boost::asio::ip::tcp::endpoint(boost::asio::ip::address::from_string(bindTo), inPortNum)),
+        acceptor(ioContext, boost::asio::ip::tcp::endpoint(boost::asio::ip::make_address(bindTo), inPortNum)),
         mAvailableConnections(inMaxConnections) {
         // FIXME: backlog???
 

--- a/server/supernova/sc/sc_osc_handler.hpp
+++ b/server/supernova/sc/sc_osc_handler.hpp
@@ -95,7 +95,7 @@ class sc_notify_observers {
 public:
     typedef enum { no_error = 0, already_registered = -1, not_registered = -2 } error_code;
 
-    sc_notify_observers(boost::asio::io_service& io_service): udp_socket(io_service) {}
+    sc_notify_observers(boost::asio::io_context& io_context): udp_socket(io_context) {}
 
     int add_observer(endpoint_ptr const& ep);
     int remove_observer(endpoint_ptr const& ep);
@@ -186,8 +186,8 @@ class sc_osc_handler : private detail::network_thread, public sc_notify_observer
 
 public:
     sc_osc_handler(server_arguments const& args):
-        sc_notify_observers(detail::network_thread::io_service_),
-        tcp_acceptor_(detail::network_thread::io_service_),
+        sc_notify_observers(detail::network_thread::io_context_),
+        tcp_acceptor_(detail::network_thread::io_context_),
         tcp_password_(args.server_password.size() ? args.server_password.c_str() : nullptr) {
         if (!args.non_rt) {
             if (args.tcp_port && !open_socket(IPPROTO_TCP, args.socket_address, args.tcp_port))

--- a/server/supernova/utilities/osc_server.hpp
+++ b/server/supernova/utilities/osc_server.hpp
@@ -55,7 +55,8 @@ public:
             name_thread("Network Receive");
 
             sem.post();
-            io_context::work work(io_context_);
+            boost::asio::executor_work_guard<boost::asio::io_context::executor_type> work =
+                boost::asio::make_work_guard(io_context_);
             io_context_.run();
         });
         sem.wait();

--- a/server/supernova/utilities/osc_server.hpp
+++ b/server/supernova/utilities/osc_server.hpp
@@ -30,7 +30,6 @@
 #    define BOOST_ASIO_HAS_STD_STRING_VIEW 1
 #endif
 
-#include <boost/asio/io_service.hpp>
 #include <boost/asio/ip/udp.hpp>
 
 #include "branch_hints.hpp"
@@ -56,8 +55,8 @@ public:
             name_thread("Network Receive");
 
             sem.post();
-            io_service::work work(io_service_);
-            io_service_.run();
+            io_context::work work(io_context_);
+            io_context_.run();
         });
         sem.wait();
     }
@@ -65,20 +64,20 @@ public:
     ~network_thread(void) {
         if (!thread_.joinable())
             return;
-        io_service_.stop();
+        io_context_.stop();
         thread_.join();
     }
 
-    io_service& get_io_service(void) { return io_service_; }
+    io_context& get_io_context(void) { return io_context_; }
 
     void send_udp(const char* data, unsigned int size, udp::endpoint const& receiver) {
-        udp::socket socket(io_service_);
+        udp::socket socket(io_context_);
         socket.open(udp::v4());
         socket.send_to(boost::asio::buffer(data, size), receiver);
     }
 
 protected:
-    io_service io_service_;
+    io_context io_context_;
 
 private:
     semaphore sem;


### PR DESCRIPTION
## Purpose and Motivation

Fixes #6572

Boost 1.87 replaces the deprecated `boost::asio::io_service` with `boost::asio::io_context`. The CI using system boost from brew is already failing because of this.
This PR simply replaces every `io_service` occurence with `io_context`.

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
