### PR TITLE
Add section 'Syntax subtleties' to Event helpfile

### DIFF
--- a/HelpSource/Classes/Event.schelp
+++ b/HelpSource/Classes/Event.schelp
@@ -240,6 +240,38 @@ q.y = q.x * q.n;	// shorter way to do the same (pseudo-methods)
 q.y;			// [100, 200, 300]
 ::
 
+subsection::Syntax subtleties
+
+Events have a very special meaning in a musical context within SuperCollider, especially when it comes to sequencing with Patterns. Nevertheless, as the class inherits from link::Classes/IdentityDictionary::, it is often used as a convenient-to-type replacement for (Identity)Dictionary-like objects:
+
+code::
+e = (a: 5, b: 7, c: 9);
+::
+
+As one can see the syntax very much reminds of the declaration of keyword arguments in function or method calls. However, there is a subtle difference:
+
+code::
+e = (a: 10); // -> ('a': 10)
+f = (a : 10); // -> nil
+              // ERROR: Primitive '_IdentDict_Put' failed.
+::
+
+Though the above declartion of code::f:: failed it's strong::not:: a syntax error:
+
+code::
+a = "abracadabra";
+f = (a : 10); // -> ("abracadabra": 10)
+::
+
+A declaration like code::(a: 5, c: 7):: constitutes an Event whose link::Classes/Dictionary#-keys#keys:: can be queried as a link::Classes/Set:: of link::Classes/Symbol::s and its link::Classes/Dictionary#-values#values:: as a link::Classes/List:: of values. Adding a space after a key and before the colon, however, breaks that rule in a way that sclang now regards the key as a emphasis::variable name::. Nevertheless, the same rules apply here as for all other Events or IdentityDictionaries: Values emphasis::must:: must be queried under a key emphasis::identical:: to the one it has been declared with:
+
+code::
+f["abracadabra"]; // -> nil - "abracadabra" is equal to the string stored in a, not identical
+f[a];             // -> 10
+::
+
+This may not be common practice but possibly worth mentioning and in some cases even come handy.
+
 subsection::Event for specifying different things to happen
 
 Event provides a link::#defaultParentEvent:: that defines a variety of different event types and provides a complete set of default key/value pairs for each type. The type is determined by the value of the key strong::\type:: which defaults to strong::\note::. Note events create synths on the server.

--- a/HelpSource/Classes/Event.schelp
+++ b/HelpSource/Classes/Event.schelp
@@ -246,6 +246,7 @@ Events have a very special meaning in a musical context within SuperCollider, es
 
 code::
 e = (a: 10);  // -> ('a': 10)
+a = nil;
 f = (a : 10); // -> nil
               // ERROR: Primitive '_IdentDict_Put' failed.
               // a is treated as a variable!

--- a/HelpSource/Classes/Event.schelp
+++ b/HelpSource/Classes/Event.schelp
@@ -254,8 +254,6 @@ f = (a : 10); // -> ("abc": 10)
 f["abc"];     // -> nil
               // "abc" is equal to the string stored in a but not identical
 f[a]:         // -> 10
-f.a;          // -> nil
-              // a is a variable, not a Symbol
 ::
 
 subsection::Event for specifying different things to happen

--- a/HelpSource/Classes/Event.schelp
+++ b/HelpSource/Classes/Event.schelp
@@ -4,7 +4,7 @@ related::Classes/Pattern, Classes/Environment, Classes/IdentityDictionary
 categories::Collections>Unordered, Streams-Patterns-Events>Events
 
 DESCRIPTION::
-An Event specifies an action to be taken in response to a link::#-play:: message. Its key/value pairs specify the parameters of that action. Event inherits most of its methods from its superclasses, especially from link::Classes/Dictionary::. For the usage and meaning of the code::parent:: and code::proto:: events, see link::Classes/IdentityDictionary::.
+An Event specifies an action to be taken in response to a link::#-play:: message. Its key/value pairs specify the parameters of that action. Event inherits most of its methods from its superclasses, especially from link::Classes/Dictionary::. Nevertheless Event inherits from link::Classes/IdentityDictionary:: and querying values is done by checking its keys for emphasis::identity::, not emphasis::equality::. For the usage and meaning of the code::parent:: and code::proto:: events, see link::Classes/IdentityDictionary::'s helpfile.
 
 code::
 a = (x: 6, y: 7, play: { (~x * ~y).postln });
@@ -242,35 +242,21 @@ q.y;			// [100, 200, 300]
 
 subsection::Syntax subtleties
 
-Events have a very special meaning in a musical context within SuperCollider, especially when it comes to sequencing with Patterns. Nevertheless, as the class inherits from link::Classes/IdentityDictionary::, it is often used as a convenient-to-type replacement for (Identity)Dictionary-like objects:
+Events have a very special meaning in a musical context within SuperCollider, especially when it comes to sequencing with Patterns. Nevertheless, as the class inherits from link::Classes/IdentityDictionary::, it is often used as a convenient-to-type replacement for (Identity)Dictionary-like objects. The syntax very much reminds of the declaration of keyword arguments in function or method calls. However, there is a subtle difference:
 
 code::
-e = (a: 5, b: 7, c: 9);
-::
-
-As one can see the syntax very much reminds of the declaration of keyword arguments in function or method calls. However, there is a subtle difference:
-
-code::
-e = (a: 10); // -> ('a': 10)
+e = (a: 10);  // -> ('a': 10)
 f = (a : 10); // -> nil
               // ERROR: Primitive '_IdentDict_Put' failed.
+              // a is treated as a variable!
+a = "abc";
+f = (a : 10); // -> ("abc": 10)
+f["abc"];     // -> nil
+              // "abc" is equal to the string stored in a but not identical
+f[a]:         // -> 10
+f.a;          // -> nil
+              // a is a variable, not a Symbol
 ::
-
-Though the above declartion of code::f:: failed it's strong::not:: a syntax error:
-
-code::
-a = "abracadabra";
-f = (a : 10); // -> ("abracadabra": 10)
-::
-
-A declaration like code::(a: 5, c: 7):: constitutes an Event whose link::Classes/Dictionary#-keys#keys:: can be queried as a link::Classes/Set:: of link::Classes/Symbol::s and its link::Classes/Dictionary#-values#values:: as a link::Classes/List:: of values. Adding a space after a key and before the colon, however, breaks that rule in a way that sclang now regards the key as a emphasis::variable name::. Nevertheless, the same rules apply here as for all other Events or IdentityDictionaries: Values emphasis::must:: must be queried under a key emphasis::identical:: to the one it has been declared with:
-
-code::
-f["abracadabra"]; // -> nil - "abracadabra" is equal to the string stored in a, not identical
-f[a];             // -> 10
-::
-
-This may not be common practice but possibly worth mentioning and in some cases even come handy.
 
 subsection::Event for specifying different things to happen
 


### PR DESCRIPTION
## Purpose and Motivation

This is a pull request in response to this discussion: #6386.


## Types of changes

I've added a subsection "Syntax subtleties" right below "Event as a name space for keeping objects" which in turn is the first paragraph under "Basic Usage" - seemed like the best place. Let me know if it should go somewhere else.

- Documentation

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [ ] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
