### PR TITLE
NdefMixer: optionally follow server instead of proxyspace.

### DIFF
--- a/HelpSource/Classes/NdefMixer.schelp
+++ b/HelpSource/Classes/NdefMixer.schelp
@@ -50,16 +50,19 @@ CLASSMETHODS::
 method:: forServer
 Make an NdefMixer that follows the specific server given. This becomes relevant when Ndef.clear is used:
 code::
-x = NdefMixer.new(s, 5); //
+// NdefMixer as before
+x = NdefMixer.new(s, 5);
+// NdefMixer that has a server to follow
 y = NdefMixer.forServer(s, 5).moveTo(10, 50);
-Ndef(\foo, {SinOsc.ar}); // m gets updated
-// Clear all proxyspaces in Ndef.all, and replace with new ones
+
+Ndef(\foo, {SinOsc.ar}); // both show foo
+// Clear all proxyspaces in Ndef.all, and replace with new ones:
 Ndef.clear; // -> foo disappears on both.
 // running foo it again, it does not show on x,
-// because m is still holding on to the old proxyspace;
-// but because y follows the server, it shows there:
+// because x is still holding on to its old proxyspace;
+// it does show on y, because y follows its server:
 Ndef(\foo, {SinOsc.ar});
-x.server; // x does not know its server
+x.server; // x does not have its server
 y.server; // y does.
 ::
 

--- a/HelpSource/Classes/NdefMixer.schelp
+++ b/HelpSource/Classes/NdefMixer.schelp
@@ -3,20 +3,23 @@ summary:: mix control for an Ndef proxyspace
 categories:: JITLib>GUI, Live Coding
 related:: Classes/ProxyMixer, Classes/JITGui, Classes/NdefGui
 
+
 description::
 
-NdefMixer is nearly identical to link::Classes/ProxyMixer::, except that it looks at the proxyspaces for each server that code::Ndef.all:: contains.
+NdefMixer is nearly identical to link::Classes/ProxyMixer::, except that it looks at the proxyspaces for each server that code::Ndef.all:: contains, and that it can be set to always follow a specific server.
 
-Examples::
+subsection:: First examples
 
 code::
 n = NdefMixer(s);
 n.parent.alwaysOnTop_(true); // show mixer in front of IDE
 
+// variant that follows specified server even after Ndef.clear:
+n = NdefMixer.forServer(s);
+
 s.boot;
 // if you have JITLibExtensions installed, try ProxyMeter to see the proxy levels:
 if (\ProxyMeter.asClass.notNil) { ProxyMeter.addMixer(n) };
-
 
 "bcdefghijk".do { |k| Ndef(k.asSymbol).ar };
 
@@ -42,3 +45,47 @@ n.editGui.object_(Ndef(\aaaaaa));
 
 NdefMixer(Server.internal, 24);
 ::
+
+CLASSMETHODS::
+method:: forServer
+Make an NdefMixer that follows the specific server given. This becomes relevant when Ndef.clear is used:
+code::
+x = NdefMixer.new(s, 5); //
+y = NdefMixer.forServer(s, 5).moveTo(10, 50);
+Ndef(\foo, {SinOsc.ar}); // m gets updated
+// Clear all proxyspaces in Ndef.all, and replace with new ones
+Ndef.clear; // -> foo disappears on both.
+// running foo it again, it does not show on x,
+// because m is still holding on to the old proxyspace;
+// but because y follows the server, it shows there:
+Ndef(\foo, {SinOsc.ar});
+x.server; // x does not know its server
+y.server; // y does.
+::
+
+argument::server
+the server to follow
+
+argument::numItems
+how many slots for proxies to make
+
+argument::parent
+which parent view or window to show the mixer on
+
+argument::bounds
+bounds within which to show the mixer
+
+argument::makeSkip
+flag whether to make a skipjack for this mixer
+
+argument::options
+options for configuring the mixer
+
+INSTANCEMETHODS::
+
+method:: server
+setting this server veriable explicitly will tell the NdefMixer to follow this server even when its proxyspace changes, for example when Ndef.clear is used.
+
+method:: object
+obj can be a server name, a server, or a proxyspace.
+

--- a/SCClassLibrary/JITLib/GUI/ProxyMixer.sc
+++ b/SCClassLibrary/JITLib/GUI/ProxyMixer.sc
@@ -380,10 +380,42 @@ ProxyMixer : JITGui {
 }
 
 NdefMixer : ProxyMixer {
-	object_ { |obj|
-		obj = Server.named.at(obj) ? obj;
-		if (obj.isKindOf(Server)) {
-				super.object_(Ndef.dictFor(obj));
+
+	var <server;
+
+	*forServer { |server, numItems = 16, parent, bounds, makeSkip = true, options|
+		var proxyspace = Ndef.dictFor(server ? Server.default);
+		^super.new(server, numItems, parent, bounds, makeSkip, options).server_(server);
+	}
+	// if server.notNil, always watch proxyspace of that server
+	server_ { |inServer|
+		if (inServer.notNil) {
+			server = inServer;
+			this.object_(Ndef.dictFor(inServer))
 		}
+	}
+
+	object_ { |obj|
+		// can be server name (symbol)
+		if (obj.isKindOf(Symbol)) {
+			obj = Server.named.at(obj);
+		};
+		// or a server
+		if (obj.isKindOf(Server)) {
+			super.object_(Ndef.dictFor(obj));
+		} {
+			// or a proxyspace or nil
+			super.object_(obj)
+		}
+	}
+
+	checkUpdate {
+		// if server exists, stick with server's proxyspace
+		if (this.server.notNil) {
+			if (this.object != Ndef.dictFor(this.server)) {
+				this.server_(this.server)
+			}
+		};
+		super.checkUpdate
 	}
 }


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

As #6189 states, NdefMixer does not follow a server, but only holds a proxyspace. 
When this proxyspace is cleared and replaced, the mixer loses track. 
This PR adds a server instance variable, which when set, ties the mixer to that server, 
and lets the mixer even follow when Ndef.clear resets Ndef.all completely. 
This PR closes  #6189 
```
// NdefMixer as before
x = NdefMixer.new(s, 5); 
// NdefMixer that has a server to follow
y = NdefMixer.forServer(s, 5).moveTo(10, 50); 

Ndef(\foo, {SinOsc.ar}); // both show foo
// Clear all proxyspaces in Ndef.all, and replace with new ones:
Ndef.clear; // -> foo disappears on both.
// running foo it again, it does not show on x,
// because x is still holding on to its old proxyspace;
// it does show on y, because y follows its server:
Ndef(\foo, {SinOsc.ar});
x.server; // x does not have its server
y.server; // y does.

## Types of changes

- Documentation
- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review 


<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
