### PR TITLE
JITLib: TaskProxyGui: improve src/env editing

### DIFF
--- a/SCClassLibrary/JITLib/GUI/TaskProxyGui.sc
+++ b/SCClassLibrary/JITLib/GUI/TaskProxyGui.sc
@@ -240,8 +240,12 @@ TaskProxyGui : JITGui {
 	}
 
 	openDoc { |strings, bounds|
-		var doc = strings.join.newTextWindow("edit me");
-		try { doc.bounds_(bounds ? Rect(0, 400, 400, 200)) };
+        var doc = Document.new("edit" + super.getName, strings.join, false);
+		try {
+            doc.front;
+            doc.promptToSave = false;
+            doc.bounds_(bounds ? Rect(0, 400, 400, 200))
+        };
 	}
 
 }

--- a/SCClassLibrary/JITLib/GUI/TaskProxyGui.sc
+++ b/SCClassLibrary/JITLib/GUI/TaskProxyGui.sc
@@ -244,7 +244,7 @@ TaskProxyGui : JITGui {
 		try {
             doc.front;
             doc.promptToSave = false;
-            doc.bounds_(bounds ? Rect(0, 400, 400, 200))
+            doc.bounds_(bounds ?? { Rect(0, 400, 400, 200) })
         };
 	}
 


### PR DESCRIPTION
- always focus the new editor
- include proxy key in doc name instead of just "edit me"
- do not prompt to save on close
- fix doc reference, was broken

<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

It is nice to edit src/env contents directly from TaskProxyGui but was annoying to work with it. The newly opened editor was not in focus and closing it triggered a save dialog needlessly.

Also, upon a closer look the code was expecting to receive a doc reference from `String.newTextWindow` which actually returns the string; so the call to set the new document bounds would have never worked. Note that there are other instances  of `newTextWindow` usage with this exact problem, this PR does not address them.

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix/improvement

A fairly minimal change to 12 year old code, opening a document directly instead of via `String.newTextWindow` so the latter remains unchanged.

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [ ] All tests are passing
- [ ] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
