### PR TITLE
Fix block allocator 'reserve' for start addresses in the middle of a free range

### DIFF
--- a/SCClassLibrary/Common/Control/Engine.sc
+++ b/SCClassLibrary/Common/Control/Engine.sc
@@ -251,7 +251,7 @@ ContiguousBlockAllocator {
 				.format(address, size).warn;
 			};
 		} {
-			if(block.start == address) {
+			if(block.notNil and: { block.start == address }) {
 				new = this.prReserve(address, size, block);
 				^new
 			} {

--- a/testsuite/classlibrary/TestContiguousBlockAllocator.sc
+++ b/testsuite/classlibrary/TestContiguousBlockAllocator.sc
@@ -55,4 +55,27 @@ TestContiguousBlockAllocator : UnitTest {
 			alloc.top == (alloc.addrOffset + alloc.size - 1),
 			"ContiguousBlockAllocator should reclaim its full range after mixed allocation/removal.")
 	}
+
+	test_CBAllocator_can_reserve_multiple_range_types {
+		var alloc = ContiguousBlockAllocator(50);
+		var block;
+		var ok;
+
+		try {
+			block = alloc.reserve(0, 10);
+		};
+		this.assert(block.notNil, "ContiguousBlockAllocator can reserve from the start of its range");
+
+		block = nil;
+		try {
+			block = alloc.reserve(20, 10);
+		};
+		this.assert(block.notNil, "ContiguousBlockAllocator can reserve in the last free region");
+
+		block = nil;
+		try {
+			block = alloc.reserve(12, 5);
+		};
+		this.assert(block.notNil, "ContiguousBlockAllocator can reserve within an interior free region");
+	}
 }


### PR DESCRIPTION
## Purpose and Motivation

Fixes #6585. This isn't a high-traffic method but not good to leave a bug here.

## Types of changes

- Bug fix

## To-do list

- [x] Code is tested
- [x] All tests are passing
- [ ] ~Updated documentation~ (internal minor bugfix doesn't need doc update)
- [x] This PR is ready for review