### PR TITLE
Fix Pwalk boundary behavior when using directionPattern for folding

### DIFF
--- a/SCClassLibrary/Common/Streams/ListPatterns.sc
+++ b/SCClassLibrary/Common/Streams/ListPatterns.sc
@@ -391,7 +391,7 @@ Pwalk : ListPattern {
 
 
 	embedInStream { arg inval;
-		var	step;
+		var	step, stepDir;
 		var index = startPos.value(inval);
 		var stepStream = stepPattern.asStream;
 		var directionStream = directionPattern.asStream;
@@ -403,13 +403,14 @@ Pwalk : ListPattern {
 			(step = stepStream.next(inval)).notNil
 		},{
 			inval = list[index].embedInStream(inval);  // get value/stream out
-			step = step * direction;	// apply direction
+			stepDir = step * direction;	// apply direction
 				// if next thing will be out of bounds
-			if(((index + step) < 0) or: { (index + step) >= list.size }, {
+			if(((index + stepDir) < 0) or: { (index + stepDir) >= list.size }, {
 				direction = directionStream.next(inval) ? 1;  // next direction, or 1
-				step = step.abs * direction.sign;  // apply to this step
+				stepDir = step * direction;  // apply to this step
 			});
-			index = (index + step) % list.size;
+			index = (index + stepDir) % list.size;
+			// inval = list[index].embedInStream(inval);  // get value/stream out
 		});
 
 		^inval;

--- a/SCClassLibrary/Common/Streams/ListPatterns.sc
+++ b/SCClassLibrary/Common/Streams/ListPatterns.sc
@@ -410,7 +410,6 @@ Pwalk : ListPattern {
 				stepDir = step * direction;  // apply to this step
 			});
 			index = (index + stepDir) % list.size;
-			// inval = list[index].embedInStream(inval);  // get value/stream out
 		});
 
 		^inval;

--- a/SCClassLibrary/Common/Streams/ListPatterns.sc
+++ b/SCClassLibrary/Common/Streams/ListPatterns.sc
@@ -391,7 +391,7 @@ Pwalk : ListPattern {
 
 
 	embedInStream { arg inval;
-		var	step, stepDir;
+		var	step, directedStep;
 		var index = startPos.value(inval);
 		var stepStream = stepPattern.asStream;
 		var directionStream = directionPattern.asStream;
@@ -403,13 +403,13 @@ Pwalk : ListPattern {
 			(step = stepStream.next(inval)).notNil
 		},{
 			inval = list[index].embedInStream(inval);  // get value/stream out
-			stepDir = step * direction;	// apply direction
+			directedStep = step * direction;	// apply direction
 				// if next thing will be out of bounds
-			if(((index + stepDir) < 0) or: { (index + stepDir) >= list.size }, {
+			if(((index + directedStep) < 0) or: { (index + directedStep) >= list.size }, {
 				direction = directionStream.next(inval) ? 1;  // next direction, or 1
-				stepDir = step * direction;  // apply to this step
+				directedStep = step * direction;  // apply to this step
 			});
-			index = (index + stepDir) % list.size;
+			index = (index + directedStep) % list.size;
 		});
 
 		^inval;

--- a/testsuite/classlibrary/TestPattern.sc
+++ b/testsuite/classlibrary/TestPattern.sc
@@ -193,6 +193,13 @@ TestPattern : UnitTest {
 		this.assert(event.isRest, "The final event of a Pfindur, if it was originally a rest, should still be a rest");
 	}
 
+	test_Pwalk_boundary_folding {
+		var stream = Pwalk((1..6), 2, Pseq([1, -1], inf)).asStream;
+		var values = stream.nextN(8);
+		this.assertEquals(values, [1, 3, 5, 3, 1, 3, 5, 3],
+			"Pwalk applies directionPattern correctly at boundaries"
+		);
+	}
 
 /*
 	test_storeArgs {


### PR DESCRIPTION
## Purpose and Motivation

See discussion at https://scsynth.org/t/pwalk-how-do-you-always-fold-at-both-boundaries/10401/10?u=jamshark70

## Types of changes

- Bug fix

## To-do list

- [x] Code is tested
- [x] All tests are passing
- [ ] ~Updated documentation~
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->