### PR TITLE
Ndef: make clear methods more flexible

### DIFF
--- a/HelpSource/Classes/Ndef.schelp
+++ b/HelpSource/Classes/Ndef.schelp
@@ -65,7 +65,10 @@ method::kr
 equivalent to code::*new(key).kr(numChannels, offset):: (see link::Classes/BusPlug#-kr::)
 
 method::clear
-clear all proxies
+clear all proxies (in all proxyspaces)
+
+method::hardClear
+clear all proxies and remove all existing proxyspaces
 
 method::defaultServer
 set the default server (default: code::Server.default::)

--- a/HelpSource/Classes/Ndef.schelp
+++ b/HelpSource/Classes/Ndef.schelp
@@ -67,7 +67,7 @@ equivalent to code::*new(key).kr(numChannels, offset):: (see link::Classes/BusPl
 method::clear
 clear all proxies (in all proxyspaces)
 
-method::hardClear
+method::clearDict
 clear all proxies and remove all existing proxyspaces
 
 method::defaultServer

--- a/HelpSource/Classes/Ndef.schelp
+++ b/HelpSource/Classes/Ndef.schelp
@@ -65,10 +65,10 @@ method::kr
 equivalent to code::*new(key).kr(numChannels, offset):: (see link::Classes/BusPlug#-kr::)
 
 method::clear
-clear all proxies (in all proxyspaces)
+clear all Ndefs in all proxyspaces of the Ndef class
 
 method::clearDict
-clear all proxies and remove all existing proxyspaces
+clear all Ndefs and remove all proxyspaces of the Ndef class
 
 method::defaultServer
 set the default server (default: code::Server.default::)

--- a/SCClassLibrary/JITLib/ProxySpace/NodeProxy.sc
+++ b/SCClassLibrary/JITLib/ProxySpace/NodeProxy.sc
@@ -1109,6 +1109,10 @@ Ndef : NodeProxy {
 	}
 
 	*clear { | fadeTime |
+		all.do(_.clear(fadeTime))
+	}
+
+	*hardClear { | fadeTime |
 		all.do(_.clear(fadeTime));
 		all.clear;
 	}

--- a/SCClassLibrary/JITLib/ProxySpace/NodeProxy.sc
+++ b/SCClassLibrary/JITLib/ProxySpace/NodeProxy.sc
@@ -1112,7 +1112,7 @@ Ndef : NodeProxy {
 		all.do(_.clear(fadeTime))
 	}
 
-	*hardClear { | fadeTime |
+	*clearDict { | fadeTime |
 		all.do(_.clear(fadeTime));
 		all.clear;
 	}


### PR DESCRIPTION
## Purpose and Motivation

Current Ndef.clear seems too drastic for many uses, so this PR proposes two separate methods: 
```Ndef.hardClear;```, which clears all existing Ndefs, and removes the proxyspaces in ```Ndef.all```, 
which is how Ndef.clear behaves so far. 
and 
```Ndef.clear;```, which clears all existing Ndefs, but now keeps the (empty) proxyspaces in Ndef.all.

This changes the default behavior of clear: all objects that track spaces in Ndef.all will keep seeing them, 
which fixes the surprise/arguable bug noted in #6189 with minimal intervention.

The current harder behavior is still available with a clearer name ```hardClear```, 
in analogy to ```Server:freeAll, Server:hardFreeAll```, ```Main:stop, Main:hardStop```, etc. 

## Types of changes

- Small change of default behavior
- Bug fix
- Documentation

## To-do list

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review
