### PR TITLE
Fix asio post invocation for `SC_TerminalClient`

### DIFF
--- a/lang/LangSource/SC_TerminalClient.cpp
+++ b/lang/LangSource/SC_TerminalClient.cpp
@@ -360,19 +360,19 @@ void SC_TerminalClient::onLibraryStartup() {
 void SC_TerminalClient::sendSignal(Signal sig) {
     switch (sig) {
     case sig_input:
-        boost::asio::post(boost::bind(&SC_TerminalClient::interpretInput, this));
+        boost::asio::post(mIoContext, [this] { this->interpretInput(); });
         break;
 
     case sig_recompile:
-        boost::asio::post(boost::bind(&SC_TerminalClient::recompileLibrary, this));
+        boost::asio::post(mIoContext, [this] { this->recompileLibrary(); });
         break;
 
     case sig_sched:
-        boost::asio::post(boost::bind(&SC_TerminalClient::tick, this, boost::system::error_code()));
+        boost::asio::post(mIoContext, [this] { this->tick(boost::system::error_code()); });
         break;
 
     case sig_stop:
-        boost::asio::post(boost::bind(&SC_TerminalClient::stopMain, this));
+        boost::asio::post(mIoContext, [this] { this->stopMain(); });
         break;
     }
 }


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

Fixes intropsection and syntax highlighting within IDE as mentioned in https://github.com/supercollider/supercollider/pull/6576#issuecomment-2568267476 which is a regression of #6576 .

I decided to use lambda expressions here b/c `Context::post` has been deprecated for `boost::asio::post` and, iiuc, these can be checked during compile time(?).

Sorry for the inconvenience in the meantime.

Please verify that it actually works before merging :) But tested it on macOS 15 (intel) and ubuntu 22.04 where it fixes the issue. 

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
