### PR TITLE
classlib: support ugens for more math ops

### DIFF
--- a/HelpSource/Classes/UGen.schelp
+++ b/HelpSource/Classes/UGen.schelp
@@ -344,8 +344,34 @@ code::
 ::
 
 method::binaryValue
-Outputs 1, representing true for positive, 0 for negative or zero input values.
+Outputs 1, representing true for positive, 0 representing false for negative or zero input values.
 
+
+method::isPositive
+Outputs 1, representing true for positive or zero, 0 representing false for negative input values.
+
+method::isStrictlyPOsitive
+Outputs 1, representing true for positive, 0 representing false for negative or zero input values.
+
+method::isNegative
+Outputs 1, representing true for negative, 0 representing false for positive or zero input values.
+
+
+method::|==|
+Outputs 1, representing true, when the receiver and argument signal coincide. Note that this may be ambivalent in many cases, because of floating point arithmetic. A special sign is needed, because code::==:: compares the UGen objects, and not the signal they produce.
+
+code::
+// an example of floating point relevance for the |==| operator.
+// the rounded signal will match at some point, but not the direct signal
+(
+{
+	var a = Line.ar(0, 1, 0.008);
+	var b = a |==| 0.5;
+	var c = a.round(0.01) |==| 0.5;
+	[a, Trig1.ar(b, 0.001), Trig1.ar(c, 0.001)]
+}.plot
+)
+::
 
 method:: @
 Dynamic geometry support. Returns code::Point(this, y)::.

--- a/SCClassLibrary/Common/Audio/UGen.sc
+++ b/SCClassLibrary/Common/Audio/UGen.sc
@@ -285,6 +285,9 @@ UGen : AbstractFunction {
 
 	binaryValue { ^this.sign.max(0) }
 
+	isPositive { ^this >= 0 }
+	isNegative { ^this < 0 }
+	isStrictlyPositive { ^this > 0 }
 
 	// Note that this differs from |==| for other AbstractFunctions
 	// Other AbstractFunctions write '|==|' into the compound function

--- a/SCClassLibrary/Common/Math/Complex.sc
+++ b/SCClassLibrary/Common/Math/Complex.sc
@@ -99,7 +99,7 @@ Complex : Number {
 		var mag, sign;
 
 		mag = this.magnitude;
-		sign = if(imag.isPositive) { 1 } { -1 };  // +1 >= 0, -1 < 0
+		sign = (imag.sign + 0.5).sign; // +1 >= 0, -1 < 0
 
 		^(
 			2.sqrt.reciprocal * Complex(


### PR DESCRIPTION
- complex on ugens work for square root
- sign checks work for UGens

<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

- It is generally possible to use complex numbers whose components are ugens. Only the square root function has a tacit type assumption in it. This PR fixes this.
- there are a number of methods that check the sign of numbers – they should also be lifted to UGens.

## Types of changes

<!-- Delete lines that don't apply -->

- New feature


## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

