### PR TITLE
Docs: Normalizer/Limiter: update help file

### DIFF
--- a/HelpSource/Classes/Limiter.schelp
+++ b/HelpSource/Classes/Limiter.schelp
@@ -24,11 +24,11 @@ argument::level
 The peak output amplitude level to which to normalize the input.
 
 argument::dur
-aka lookAheadTime.
+Also called lookAheadTime.
 The buffer delay time. Shorter times will produce smaller delays
 and quicker transient response times, but may introduce amplitude
 modulation artifacts.
-
+This parameter cannot be modulated.
 
 Examples::
 

--- a/HelpSource/Classes/Normalizer.schelp
+++ b/HelpSource/Classes/Normalizer.schelp
@@ -23,11 +23,11 @@ argument::level
 The peak output amplitude level to which to normalize the input.
 
 argument::dur
-
+Also called lookAheadTime.
 The buffer delay time. Shorter times will produce smaller delays
 and quicker transient response times, but may introduce amplitude
 modulation artifacts.
-
+This parameter cannot be modulated.
 
 Examples::
 


### PR DESCRIPTION
## Purpose and Motivation

I figured out you cannot change `Normalizer` and `Limiter` durations once the synth is running.
This can be tested with:

```
(
x = SynthDef(\normalizerTest, { |dur = 0.01|
	var signal = Impulse.ar(1);
	var result = Normalizer.ar(signal, 1.0, dur);
	Out.ar(0, [signal, result]);
}).play;
)

x.set(\dur, 0.25)
```

So I added notes about this within related help files. Since I was there, I updated the reference to the `lookAheadTime` concept.

## Types of changes

- Documentation

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review