### PR TITLE
Fix double invocation of unsaved documents dialog upon quitting

### DIFF
--- a/editors/sc-ide/widgets/main_window.cpp
+++ b/editors/sc-ide/widgets/main_window.cpp
@@ -244,7 +244,7 @@ void MainWindow::createActions() {
     // (such as cmd+q or window closing)
     action->setMenuRole(QAction::QuitRole);
 
-    QObject::connect(action, SIGNAL(triggered()), this, SLOT(onQuit()));
+    QObject::connect(action, &QAction::triggered, this, &QWidget::close, Qt::QueuedConnection);
     settings->addAction(action, "ide-quit", ideCategory);
 
     mActions[DocNew] = action = new QAction(QIcon::fromTheme("document-new"), tr("&New"), this);


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

Fixes #6562 

## Types of changes

- Bug fix

I checked the call stacks of both dialog instances

```cpp
// call stack of first window

ScIDE::MainWindow::promptSaveDocs() main_window.cpp:1224
ScIDE::MainWindow::quit() main_window.cpp:807
ScIDE::MainWindow::onQuit() main_window.cpp:819

// call stack of second window

ScIDE::MainWindow::promptSaveDocs() main_window.cpp:1224
ScIDE::MainWindow::quit() main_window.cpp:807
ScIDE::MainWindow::closeEvent(QCloseEvent *) main_window.cpp:885
```

~~I decided to make the second call stack, invoked by a `closeEvent`, to do nothing. Please review if this could have any unintended side-effects - but I haven't figured out any so far.~~
=> I applied the fix suggested in https://github.com/supercollider/supercollider/pull/6609#issuecomment-2646122928 which seems to fix the issue. Please verify on Windows and Linux.

I think the behavior was changed by the Qt6 switch because the life-cycle of the main-event-loop may have been adjusted by Qt?

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

As I haven't heard any other people complain about this I think this could be a macOS only problem? Therefore it may be good if people with Linux and Windows could try out this branch and see if it has some unintentional side-effects (e.g. no unsaved documents dialog popping up)

- [ ] Code is tested
- [ ] All tests are passing
- [ ] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->
