### PR TITLE
synthdef load needs binary on windows

### DIFF
--- a/server/scsynth/SC_GraphDef.cpp
+++ b/server/scsynth/SC_GraphDef.cpp
@@ -615,7 +615,7 @@ GraphDef* GraphDef_LoadGlob(World* inWorld, const char* pattern, GraphDef* inLis
 }
 
 std::string load_file(const std::filesystem::path& file_path) {
-    std::ifstream file(file_path);
+    std::ifstream file(file_path, std::ifstream::binary);
     if (!file.is_open()) {
         throw std::runtime_error("Could not open file: " + file_path.string());
     }

--- a/server/supernova/sc/sc_synthdef.cpp
+++ b/server/supernova/sc/sc_synthdef.cpp
@@ -141,7 +141,7 @@ std::vector<sc_synthdef> read_synthdef_file(std::filesystem::path const& filenam
     using namespace std;
 
     ifstream stream;
-    stream.open(filename.string().c_str());
+    stream.open(filename.string().c_str(), std::ifstream::binary);
 
     if (!stream.is_open()) {
         cout << "cannot open file " << filename << endl;


### PR DESCRIPTION
solves issue #6611 

There are other ifstream and ofstream in the codebase that COULD need that but they are in components not used by me, so I am not sure.
Basically: when a file is opened in binary mode in windows there is not alteration of content, when it is opened in text mode ends of line are converted.

https://stackoverflow.com/questions/73570406/what-are-the-consequences-of-opening-a-file-in-c-in-text-or-binary-mode