### PR TITLE
fix Windows pathname resolution

### DIFF
--- a/common/SC_Filesystem_win.cpp
+++ b/common/SC_Filesystem_win.cpp
@@ -74,7 +74,8 @@ SC_Filesystem::Glob* SC_Filesystem::makeGlob(const char* pattern) {
     path = SC_Filesystem::instance().expandTilde(path);
 
     auto path_string = path.wstring();
-    while (path_string.back() == '\\') path_string.pop_back();
+    while (path_string.back() == '\\')
+        path_string.pop_back();
 
     glob->mHandle = ::FindFirstFileW(path_string.c_str(), &glob->mEntry);
     if (glob->mHandle == INVALID_HANDLE_VALUE) {

--- a/common/SC_Filesystem_win.cpp
+++ b/common/SC_Filesystem_win.cpp
@@ -73,7 +73,10 @@ SC_Filesystem::Glob* SC_Filesystem::makeGlob(const char* pattern) {
     // expand to home directory, if path starts with tilde
     path = SC_Filesystem::instance().expandTilde(path);
 
-    glob->mHandle = ::FindFirstFileW(path.wstring().c_str(), &glob->mEntry);
+    auto path_string = path.wstring();
+    while (path_string.back() == '\\') path_string.pop_back();
+
+    glob->mHandle = ::FindFirstFileW(path_string.c_str(), &glob->mEntry);
     if (glob->mHandle == INVALID_HANDLE_VALUE) {
         delete glob;
         return nullptr;


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->
Fixes #6501

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [ ] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->

The fix is related to the incompatibility of `FindFirstFileW` with paths that end in trailing path separators, documented [here](https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-findfirstfilew). If anyone knows of a better way to do this without having to mess with strings, suggestions are welcome!