### PR TITLE
update portaudio_submodule to last master branch

### DIFF
--- a/README_WINDOWS.md
+++ b/README_WINDOWS.md
@@ -304,7 +304,10 @@ following folder structure *exactly*:
             lib
         fftw
 
-In order to get support for ASIO drivers, follow this directory structure:
+In order to get support for ASIO drivers:
+PA_USE_ASIO must be set in cmake command `-DPA_USE_ASIO=ON`
+
+If cmake version is less than 3.18, you must also follow this directory structure:
 
     supercollider
         external_libraries
@@ -315,6 +318,7 @@ In order to get support for ASIO drivers, follow this directory structure:
                     common
                     ...
             ...
+Otherwise (cmake not less than 3.18) this is not needed.
 
 FFTW does not provide build files for Visual Studio. In the **Developer Command
 Prompt for VS2019** (or VS2017; note that this is not `cmd.exe`), `cd` to the

--- a/external_libraries/portaudio/CMakeLists.txt
+++ b/external_libraries/portaudio/CMakeLists.txt
@@ -5,8 +5,7 @@ if(WIN32)
     remove_definitions(-DWIN32_LEAN_AND_MEAN -DNOMINMAX)
 endif()
 
-set(PA_BUILD_STATIC ON CACHE BOOL "PortAudio static library" FORCE)
-set(PA_BUILD_SHARED OFF CACHE BOOL "PortAudio shared library" FORCE)
+set(PA_BUILD_SHARED_LIBS OFF CACHE BOOL "PortAudio shared library" FORCE)
 
 # disable platform suffix
 set(PA_LIBNAME_ADD_SUFFIX OFF CACHE BOOL "PortAudio static library suffix" FORCE)
@@ -21,4 +20,4 @@ endif()
 
 # when building PA ourselves, we need to specify PORTAUDIO_INCLUDE_DIRS and PORTAUDIO_LIBRARIES
 set(PORTAUDIO_INCLUDE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/portaudio_submodule/include" CACHE PATH "Portaudio include directory" FORCE)
-set(PORTAUDIO_LIBRARIES portaudio_static CACHE PATH "PORTAUDIO_LIBRARIES" FORCE)
+set(PORTAUDIO_LIBRARIES portaudio CACHE PATH "PORTAUDIO_LIBRARIES" FORCE)

--- a/external_libraries/portaudio/CMakeLists.txt
+++ b/external_libraries/portaudio/CMakeLists.txt
@@ -21,3 +21,11 @@ endif()
 # when building PA ourselves, we need to specify PORTAUDIO_INCLUDE_DIRS and PORTAUDIO_LIBRARIES
 set(PORTAUDIO_INCLUDE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/portaudio_submodule/include" CACHE PATH "Portaudio include directory" FORCE)
 set(PORTAUDIO_LIBRARIES portaudio CACHE PATH "PORTAUDIO_LIBRARIES" FORCE)
+
+# clear variables setted by FindJACK.cmake which calls supercollider module FindPthreads.cmake expecting the one provided by vcpkg (perhaps could be worked on portaudio?)
+if(PTHREADS_INCLUDE_DIR STREQUAL "PTHREADS_INCLUDE_DIR-NOTFOUND")
+    set(PTHREADS_FOUND "" CACHE STRING "" FORCE)#PARENT_SCOPE)
+    set(PTHREADS_INCLUDE_DIR "" CACHE STRING "" FORCE)#PARENT_SCOPE)
+    set(PTHREADS_LIBRARY "" CACHE STRING "" FORCE)#PARENT_SCOPE)
+    set(PTHREADS_DEFINITIONS "" CACHE STRING "" FORCE)#PARENT_SCOPE)
+endif()


### PR DESCRIPTION
## Purpose and Motivation

Update to last portaudio

## Types of changes

- Documentation
- New feature


## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

Due to changes in last portaudio `PA_USE_ASIO=ON` must be explicitly set in case ASIO is wanted. (which is a breaking change for ASIO building) see: https://github.com/PortAudio/portaudio/blob/master/CMakeLists.txt#L184

The advantages are: get new additions to portaudio and if CMake version is not less than 3.18 asiosdk is downloaded by cmake and patched as explained in https://github.com/PortAudio/portaudio/pull/997

A way to avoid any surprise caused by the breaking change could be adding `PA_USE_ASIO=ON` in CMakelists.txt when we are on windows, so that portaudio is always built with ASIO without any requirement for the user.

Portaudio is used on windows but can also be used in macos for supernova (without ASIO). I could not test that and I dont even know if it worked previously.

