### PR TITLE
class library: MIDIClient init cleans up old connections

### DIFF
--- a/SCClassLibrary/Common/Control/MIDIOut.sc
+++ b/SCClassLibrary/Common/Control/MIDIOut.sc
@@ -15,7 +15,7 @@ MIDIClient {
 	classvar <initialized=false;
 	*init { arg inports, outports, verbose=true; // by default initialize all available ports
 								// you still must connect to them using MIDIIn.connect
-
+		this.disposeClient; // remove old sources and destinations, in case init is called repeatedly
 		this.prInitClient;
 		this.list;
 		if(inports.isNil,{inports = sources.size});


### PR DESCRIPTION
## Purpose and Motivation

For those who forgot to clean up MIDIClient before calling init several times, this caused an issue. This does it automatically. Fixes #4495.

## To-do list

- [ ] Code is tested
- [ ] All tests are passing
- [ ] This PR is ready for review