### PR TITLE
Fix table width to improve readability

### DIFF
--- a/HelpSource/scdoc.css
+++ b/HelpSource/scdoc.css
@@ -30,8 +30,9 @@ div.contents {
 table {
     border-collapse: collapse;
     font-size: 10pt;
-    margin-top: 1em;
-    margin-left: 2em;
+    margin: 0.7em 0;
+    width: 100%;
+    table-layout: auto;
 }
 table td {
     border: 1px solid var(--color-fg-200);


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

Currently, the width of the table depends on the length of the text in the table. This is fine if there is only one table.
However, multiple tables with different table widths reduce readability.
Compare the following two examples:
<img width="612" alt="Screenshot 2025-02-21 at 01 18 15" src="https://github.com/user-attachments/assets/3973f181-a8b4-48b3-a88e-653f2c071758" />.
<img width="604" alt="Screenshot 2025-02-21 at 01 37 36" src="https://github.com/user-attachments/assets/0a547899-ce0b-4a41-871a-abe0ae6409c8" />.
To me, the inconsistent table width seems to be a bug.


## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
