### PR TITLE
Fix typo in documentation (class `SequenceableCollection`'s method `flatten`)

### DIFF
--- a/HelpSource/Classes/SequenceableCollection.schelp
+++ b/HelpSource/Classes/SequenceableCollection.schelp
@@ -327,7 +327,7 @@ Specifies how many levels downward (inward) to flatten. Zero returns the origina
 
 code::
 a = [1, 2, [3, 4, [5, 6, [7, 8, [9, 0]]]]];
-a.flatten(1); // [ 1, 2, [ 3, 4, [ 5, 6, [ 7, 8, [9, 0] ] ] ] ]
+a.flatten(1); // [ 1, 2, 3, 4, [ 5, 6, [ 7, 8, [9, 0] ] ] ]
 a.flatten(2); // [ 1, 2, 3, 4, 5, 6, [ 7, 8, [9, 0] ] ]
 a.flatten(3); // [ 1, 2, 3, 4, 5, 6, 7, 8, [9, 0] ]
 a.flatten(4); // [1, 2, 3, 4, 5, 6, 7, 8, 9, 0]


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

The documentation for class `SequenceableCollection`'s method `flatten`'s example seems to have a typo. For:

```
a = [1, 2, [3, 4, [5, 6, [7, 8, [9, 0]]]]];
a.flatten(1);
```

It should return `[ 1, 2, 3, 4, [ 5, 6, [ 7, 8, [9, 0] ] ] ]` rather than `[ 1, 2, [ 3, 4, [ 5, 6, [ 7, 8, [9, 0] ] ] ] ]` (which is recorded in the current documentation).

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->

- Documentation

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

This pull request only changes documentation.

- [ ] Code is tested
- [ ] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
