### PR TITLE
Remove <p> after every `\prose` and modify line-spacing using `margin` in scdoc.css

### DIFF
--- a/HelpSource/static/scdoc.css
+++ b/HelpSource/static/scdoc.css
@@ -48,8 +48,8 @@ table table {
 }
 
 p {
-    margin-top: 1em;
-    margin-bottom: 0.3em;
+    margin-top: 0.5em;
+    margin-bottom: 0.5em;
 }
 
 a {
@@ -545,7 +545,8 @@ td p {
 }
 
 li {
-    padding-bottom: 0.5em;
+    margin-top: 0.5em;
+    margin-bottom: 0.5em;
 }
 
 ul.toc {


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

Currently, the lead (line spacing) between the first child of the nested list and the previous line is too small.
<img width="300" alt="Screenshot 2025-02-25 at 17 19 18" src="https://github.com/user-attachments/assets/ac72f4bd-10cb-49fb-b64f-03a0759b07a8" />

This PR adds `margin-top` to `li:first-child`, and the result is as follows:
<img width="300" alt="Screenshot 2025-02-25 at 17 18 26" src="https://github.com/user-attachments/assets/988a6451-4910-4fbb-b3f1-4ef5119ee46e" />

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
