### PR TITLE
Windows build guild: Update SET command to persist Qt PATH

### DIFF
--- a/README_WINDOWS.md
+++ b/README_WINDOWS.md
@@ -339,12 +339,21 @@ Configuration and Building
 
 *Note:* You should always use forward slashes for paths passed to CMake.
 
+Set the environment variables PATH first.
+
+    setx PATH "C:\Qt\6.8.2\msvc2022_64\bin;%PATH%"
+
+*Note:* `setx` is usable from Windows 10. Unlike `SET`, which affects
+only current `cmd.exe`, `setx` makes the change persistent.
+
+*Note:* Do not execute this command multiple times. It will populate
+`PATH` environment variable with the same path.
+
 **Confirm the location of your Qt install before executing these commands.** You
 may need to modify them if you installed Qt somewhere else. The following
 commands should be executed starting from the root directory of the
 SuperCollider repository.
 
-    SET PATH=C:\Qt\6.2\msvc2017_64\bin;%PATH%
     SET CMAKE_PREFIX_PATH=C:\Qt\6.2.0\msvc2017_64
     mkdir build
     cd build


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

from the commit message:
> The environment variables by `set` command only valid during the `cmd.exe` process. To make the change persistent, there are a few different approaches. And using `setx` might be the most efficient, especially, because the doc is already using `cmd.exe`.
>
> Further down in the same doc, it is stressed to put the Qt's executable path in the PATH environment variable. But it does not mention how.

Personally, as a newbie to VS and SC build, I was puzzled when I firstly got "Qt6WebEngine" error. Further down, I found the note that the env var has to be persistent, then I realized `set` might not persist the change. Then, I found `setx`.

> I moved the command a bit earlier on the doc. Because this particular command is not required to be executed under the `supercollider/build` directory.
>
> [skip ci]

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->

- Documentation

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested (manual test with set env var with `set` and `setx`)
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
