### PR TITLE
Add GitHub Actions reminders

### DIFF
--- a/.github/workflows/org_post_reminder.yml
+++ b/.github/workflows/org_post_reminder.yml
@@ -1,0 +1,13 @@
+name: Issue Comment Events
+
+on:
+  issue_comment:
+    types: [created, edited]
+
+jobs:
+  reminder:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: check for reminder
+        uses: agrc/create-reminder-action@v1

--- a/.github/workflows/org_scan_reminder.yml
+++ b/.github/workflows/org_scan_reminder.yml
@@ -1,0 +1,17 @@
+name: Scheduled Events
+
+on:
+  schedule:
+    - cron: '0 * * * *'
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  reminder:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: check reminders and notify
+        uses: agrc/reminder-action@v1


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

In order to counteract a staleness of PRs and issues here I think it would be nice to have a reminder tool - e.g. I'd like to set a reminder in 2 weeks that this can be merged on https://github.com/supercollider/supercollider/pull/6643#pullrequestreview-2650404002

Sadly, this is not available natively via github, so we have to rely on an GitHub action to inform us.

For usage see

https://github.com/agrc/kitchen-sink/issues/285#issuecomment-2316411983
https://github.com/agrc/reminder-action?tab=readme-ov-file

## Types of changes

- New feature

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
