### PR TITLE
scsynth tcp: fixes uninitialized ReplyAddress (issue #6647)

### DIFF
--- a/server/scsynth/SC_ComPort.cpp
+++ b/server/scsynth/SC_ComPort.cpp
@@ -376,6 +376,9 @@ private:
         packet->mReplyAddr.mProtocol = kTCP;
         packet->mReplyAddr.mReplyFunc = tcp_reply_func;
         packet->mReplyAddr.mReplyData = (void*)&socket;
+        packet->mReplyAddr.mPort = socket.remote_endpoint().port();
+        packet->mReplyAddr.mSocket = 0;
+        packet->mReplyAddr.mAddress = socket.remote_endpoint().address();
 
         packet->mSize = OSCMsgLength;
 

--- a/server/scsynth/SC_ComPort.cpp
+++ b/server/scsynth/SC_ComPort.cpp
@@ -377,7 +377,7 @@ private:
         packet->mReplyAddr.mReplyFunc = tcp_reply_func;
         packet->mReplyAddr.mReplyData = (void*)&socket;
         packet->mReplyAddr.mPort = socket.remote_endpoint().port();
-        packet->mReplyAddr.mSocket = 0;
+        packet->mReplyAddr.mSocket = socket.native_handle();
         packet->mReplyAddr.mAddress = socket.remote_endpoint().address();
 
         packet->mSize = OSCMsgLength;
@@ -492,6 +492,8 @@ SCSYNTH_DLLEXPORT_C bool World_SendPacketWithContext(World* inWorld, int inSize,
         packet->mReplyAddr.mReplyFunc = inFunc;
         packet->mReplyAddr.mReplyData = inContext;
         packet->mReplyAddr.mSocket = 0;
+        packet->mReplyAddr.mProtocol = 0;
+        packet->mReplyAddr.mPort = 0;
 
         if (!UnrollOSCPacket(inWorld, inSize, inData, packet)) {
             free(packet);

--- a/server/scsynth/SC_ComPort.cpp
+++ b/server/scsynth/SC_ComPort.cpp
@@ -492,7 +492,7 @@ SCSYNTH_DLLEXPORT_C bool World_SendPacketWithContext(World* inWorld, int inSize,
         packet->mReplyAddr.mReplyFunc = inFunc;
         packet->mReplyAddr.mReplyData = inContext;
         packet->mReplyAddr.mSocket = 0;
-        packet->mReplyAddr.mProtocol = 0;
+        packet->mReplyAddr.mProtocol = kUDP;
         packet->mReplyAddr.mPort = 0;
 
         if (!UnrollOSCPacket(inWorld, inSize, inData, packet)) {


### PR DESCRIPTION
Fixes issue #6647

Also fixed for internal server.

Just in case: supernova does not have this issue.

- [X] Code is tested
- [x] All tests are passing
- [x] This PR is ready for review 

(There are two failing CI tests completely unrelated and they also fail in other PRs)
`CMake Error at QtCollider/CMakeLists.txt:38 (find_package):`
