### PR TITLE
cmake: repair windows resource compiling

### DIFF
--- a/editors/sc-ide/CMakeLists.txt
+++ b/editors/sc-ide/CMakeLists.txt
@@ -278,10 +278,12 @@ endif()
 # This sets up the exe icon for windows.
 if(WIN32)
  set(RES_FILES ${CMAKE_SOURCE_DIR}/platform/windows/Resources/scide.rc)
+ if(MINGW OR MSYS)
  set(CMAKE_RC_COMPILER_INIT windres)
  ENABLE_LANGUAGE(RC)
  SET(CMAKE_RC_COMPILE_OBJECT
  "<CMAKE_RC_COMPILER> -O coff <DEFINES> -i <SOURCE> -o <OBJECT>")
+ endif(MINGW OR MSYS)
 endif(WIN32)
 
 

--- a/lang/CMakeLists.txt
+++ b/lang/CMakeLists.txt
@@ -164,10 +164,12 @@ endif()
 # This sets up the exe icon for windows.
 if(WIN32)
  set(RES_FILES ${CMAKE_SOURCE_DIR}/platform/windows/Resources/sclang.rc)
+ if(MINGW OR MSYS)
  set(CMAKE_RC_COMPILER_INIT windres)
  ENABLE_LANGUAGE(RC)
  SET(CMAKE_RC_COMPILE_OBJECT
  "<CMAKE_RC_COMPILER> -O coff <DEFINES> -i <SOURCE> -o <OBJECT>")
+ endif(MINGW OR MSYS)
 endif(WIN32)
 
 if(SC_HIDAPI)


### PR DESCRIPTION
cmake: repair resource compiling of sclang for nmake without breaking MSYS or MINGW

fixes #6618 

only for sclang (still not scide)
The same can be done for sc-ide cmake (althought I can not try it but CI checks can)

It could also close PR #6111


Unrelated CI checks fails:
Known CI test errors: ` Could NOT find Qt6WebEngineCore (missing: Qt6WebEngineCore_DIR)` issue #6648
plus a new one!!
`TestMixedBundle_Server:test_send_synth_bundle (1.72s)`