### PR TITLE
Use aqt for macOS x64 in CI and switch macOS system lib build to arm

### DIFF
--- a/.github/workflows/build_macos.yml
+++ b/.github/workflows/build_macos.yml
@@ -55,11 +55,11 @@ jobs:
             extra-cmake-flags: ""
             artifact-suffix: "macOS-x64-legacy" # set if needed - will trigger artifact upload
 
-          - job-name: "x64 use system libraries"
-            os-version: "13"
-            xcode-version: "15.2"
+          - job-name: "arm64 use system libraries"
+            os-version: "15"
+            xcode-version: "16.0"
             deployment-target: ""
-            cmake-architectures: x86_64
+            cmake-architectures: "arm64"
             homebrew-packages: "qt@6 libsndfile readline fftw portaudio yaml-cpp boost"
             vcpkg-packages: ""
             vcpkg-triplet: ""

--- a/.github/workflows/build_macos.yml
+++ b/.github/workflows/build_macos.yml
@@ -68,9 +68,11 @@ jobs:
           - job-name: "x64 shared libscsynth"
             os-version: "13"
             xcode-version: "15.2"
+            qt-version: "6.7.3" # will use qt from aqtinstall
+            qt-modules: 'qtwebengine qtwebchannel qtwebsockets qtpositioning'
             deployment-target: ""
             cmake-architectures: x86_64
-            homebrew-packages: "qt@6 libsndfile readline fftw portaudio"
+            homebrew-packages: "libsndfile readline fftw portaudio"
             vcpkg-packages: ""
             vcpkg-triplet: ""
             extra-cmake-flags: "-D LIBSCSYNTH=ON"


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

Fixes #6648 - See https://github.com/supercollider/supercollider/issues/6648#issuecomment-2706222529 for more details.

Essentially it gets harder to build SuperCollider on older macOS x64 platforms due to lacking support from Hombrew (new qt version 6.8.2 ships without webengine on macOS 13 on x64 and it is somehow hard to install older versions using homebrew. Although the most recent macOS 15 still works w/ x64 macs, this is not supported by GitHub anymore...).

This PR bumps Qt to 6.8.2 in our macOS CI and switches completely to aqt for installing Qt on macOS (instead of using homebrew).
This provides a more stable CI, but may create a divergence on how users build SuperCollider locally and how we build in CI, but that's just the way it is now it seems :/
Maybe we can introduce an macOS arm build which is using qt from homebrew, but this is something for another PR.

I thought about adding a disclaimer for macOS 13 users but decided against this for now.

Edit: This PR has a _high priority_ as our CI is currently failing b/c of this and makes reviewing a bit more difficult.

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
