### PR TITLE
plugins: EnvGen: fix endtime

### DIFF
--- a/HelpSource/Classes/Env.schelp
+++ b/HelpSource/Classes/Env.schelp
@@ -471,7 +471,7 @@ The curvature of the envelope segments. The last value is the looparound curve. 
 The array size of strong::curve:: should be the same size of the strong::levels:: array.
 
 note::
-If a single value is given for strong::times:: or strong::curve::, or if the array is too short, it will be extended by wrapping around the given values.
+If the array of strong::times:: or strong::curve:: is too short, it will be extended by wrapping around the given values. If a single value is given, it applies to all envelope stages.
 ::
 
 discussion::

--- a/HelpSource/Classes/Env.schelp
+++ b/HelpSource/Classes/Env.schelp
@@ -471,7 +471,7 @@ The curvature of the envelope segments. The last value is the looparound curve. 
 The array size of strong::curve:: should be the same size of the strong::levels:: array.
 
 note::
-If a single value is given for strong::times:: or strong::curve::, or if the array is too short, it will be extended by wrapping around the given values
+If a single value is given for strong::times:: or strong::curve::, or if the array is too short, it will be extended by wrapping around the given values.
 ::
 
 discussion::

--- a/server/plugins/LFUGens.cpp
+++ b/server/plugins/LFUGens.cpp
@@ -2596,7 +2596,7 @@ static bool EnvGen_initSegment(EnvGen* unit, int& counter, double& level, double
         level = unit->m_a2 - unit->m_y1;
     } break;
     case shape_Welch: {
-        double w = (pi * 0.5) / counter;
+        double w = (pi * 0.5) / counter_fractional;
 
         unit->m_b1 = 2. * cos(w);
 
@@ -2614,23 +2614,23 @@ static bool EnvGen_initSegment(EnvGen* unit, int& counter, double& level, double
     case shape_Curve: {
         if (fabs(curve) < 0.001) {
             unit->m_shape = 1; // shape_Linear
-            unit->m_grow = (endLevel - level) / counter;
+            unit->m_grow = (endLevel - level) / counter_fractional;
         } else {
             double a1 = (endLevel - level) / (1.0 - exp(curve));
             unit->m_a2 = level + a1;
             unit->m_b1 = a1;
-            unit->m_grow = exp(curve / counter);
+            unit->m_grow = exp(curve / counter_fractional);
         }
     } break;
     case shape_Squared: {
         unit->m_y1 = sqrt(level);
         unit->m_y2 = sqrt(endLevel);
-        unit->m_grow = (unit->m_y2 - unit->m_y1) / counter;
+        unit->m_grow = (unit->m_y2 - unit->m_y1) / counter_fractional;
     } break;
     case shape_Cubed: {
         unit->m_y1 = pow(level, 1.0 / 3.0);
         unit->m_y2 = pow(endLevel, 1.0 / 3.0);
-        unit->m_grow = (unit->m_y2 - unit->m_y1) / counter;
+        unit->m_grow = (unit->m_y2 - unit->m_y1) / counter_fractional;
     } break;
     };
     return true;

--- a/server/plugins/LFUGens.cpp
+++ b/server/plugins/LFUGens.cpp
@@ -2562,7 +2562,8 @@ static bool EnvGen_initSegment(EnvGen* unit, int& counter, double& level, double
 
     // Carry the rounding error forward to be absorbed in the next segments
     double stageDurInSamples = dur * SAMPLERATE + unit->m_stageResidual;
-    int32 stageDurInSamples_floor = (int32)stageDurInSamples;
+    int32 stageDurInSamples_floor = static_cast<int32>(stageDurInSamples);
+    double counter_forGrowCalc = sc_max(1.0, stageDurInSamples);
     counter = sc_max(1, stageDurInSamples_floor);
     unit->m_stageResidual = stageDurInSamples - counter;
 
@@ -2641,6 +2642,7 @@ static bool check_gate(EnvGen* unit, float prevGate, float gate, int& counter, d
         return false;
     } else if (gate <= -1.f && prevGate > -1.f) {
         // forced release: jump to last segment overriding its duration
+        printf("check_gate: forced release\n");
         double dur = -gate - 1.f;
         counter = (int32)(dur * SAMPLERATE);
         counter = sc_max(1, counter) + counterOffset;
@@ -2650,6 +2652,7 @@ static bool check_gate(EnvGen* unit, float prevGate, float gate, int& counter, d
         unit->m_stageResidual = 0.0;
         return false;
     } else if (prevGate > 0.f && gate <= 0.f && unit->m_releaseNode >= 0 && !unit->m_released) {
+        printf("check_gate: close\n");
         counter = counterOffset;
         unit->m_stage = unit->m_releaseNode - 1;
         unit->m_released = true;

--- a/server/plugins/LFUGens.cpp
+++ b/server/plugins/LFUGens.cpp
@@ -2560,7 +2560,7 @@ static bool EnvGen_initSegment(EnvGen* unit, int& counter, double& level, double
     double curve = *envPtr[3];
     unit->m_endLevel = endLevel;
 
-    // Carry the rounding error forward to be absorbed in the next segments
+    // Carry the rounding error forward to be absorbed in the next stage
     double stageDurInSamples = dur * SAMPLERATE + unit->m_stageResidual;
     int32 stageDurInSamples_floor = static_cast<int32>(stageDurInSamples);
     double counter_forGrowCalc = sc_max(1.0, stageDurInSamples);
@@ -2578,17 +2578,16 @@ static bool EnvGen_initSegment(EnvGen* unit, int& counter, double& level, double
         level = previousEndLevel;
     } break;
     case shape_Linear: {
-        //                unit->m_grow = (endLevel - level) / (counter); // this assumes the previous endlevel was
-        //                reached
-        unit->m_grow = (endLevel - level) / counter_forGrowCalc; // this assumes the previous endlevel was reached
-        //        unit->m_grow = (endLevel - previousEndLevel) / counter_forGrowCalc; // this assumes the previous
-        //        endlevel was reached
+        // unit->m_grow = (endLevel - level) / (counter); // assumes the previous endlevel was reached
+        unit->m_grow = (endLevel - level) / counter_forGrowCalc;
+        // unit->m_grow = (endLevel - previousEndLevel) / counter_forGrowCalc;
     } break;
     case shape_Exponential: {
-        unit->m_grow = pow(endLevel / level, 1.0 / counter);
+        unit->m_grow = pow(endLevel / level, 1.0 / counter_forGrowCalc);
     } break;
     case shape_Sine: {
-        double w = pi / counter;
+//        double w = pi / counter;
+        double w = pi / counter_forGrowCalc;
 
         unit->m_a2 = (endLevel + level) * 0.5;
         unit->m_b1 = 2. * cos(w);

--- a/server/plugins/LFUGens.cpp
+++ b/server/plugins/LFUGens.cpp
@@ -2563,7 +2563,7 @@ static bool EnvGen_initSegment(EnvGen* unit, int& counter, double& level, double
     // Carry the rounding error forward to be absorbed in the next stage
     double stageDurInSamples = dur * SAMPLERATE + unit->m_stageResidual;
     int32 stageDurInSamples_floor = static_cast<int32>(stageDurInSamples);
-    double counter_forGrowCalc = sc_max(1.0, stageDurInSamples);
+    double counter_fractional = sc_max(1.0, stageDurInSamples);
     counter = sc_max(1, stageDurInSamples_floor);
     unit->m_stageResidual = stageDurInSamples - counter;
 
@@ -2579,15 +2579,15 @@ static bool EnvGen_initSegment(EnvGen* unit, int& counter, double& level, double
     } break;
     case shape_Linear: {
         // unit->m_grow = (endLevel - level) / (counter); // assumes the previous endlevel was reached
-        unit->m_grow = (endLevel - level) / counter_forGrowCalc;
+        unit->m_grow = (endLevel - level) / counter_fractional;
         // unit->m_grow = (endLevel - previousEndLevel) / counter_forGrowCalc;
     } break;
     case shape_Exponential: {
-        unit->m_grow = pow(endLevel / level, 1.0 / counter_forGrowCalc);
+        unit->m_grow = pow(endLevel / level, 1.0 / counter_fractional);
     } break;
     case shape_Sine: {
 //        double w = pi / counter;
-        double w = pi / counter_forGrowCalc;
+        double w = pi / counter_fractional;
 
         unit->m_a2 = (endLevel + level) * 0.5;
         unit->m_b1 = 2. * cos(w);

--- a/testsuite/classlibrary/TestCoreUGens.sc
+++ b/testsuite/classlibrary/TestCoreUGens.sc
@@ -319,7 +319,7 @@ TestCoreUGens : UnitTest {
 			func.loadToFloatArray(testDur, server, { |data|
 				this.assertArrayFloatEquals(data, 0, name.quote,
 					within: -90.dbamp, // could go to -100 if not for midicps(cpsmidi()) test
-					report: true);
+					report: false);
 				completed = completed + 1;
 				cond.signalOne;
 			});
@@ -354,7 +354,7 @@ TestCoreUGens : UnitTest {
 				}.loadToFloatArray(testDur, server, { |data|
 					this.assertArrayFloatEquals(data, 0,
 						"EnvGen should be equal to Line over short durations [% samples] with fast phase change. [%]".format(numSamps, rate),
-						within: -90.dbamp, report: true
+						within: -90.dbamp, report: false
 					);
 					completed = completed + 1;
 					cond.signalOne;
@@ -392,7 +392,7 @@ TestCoreUGens : UnitTest {
 
 		tests.keysValuesDo{ |text, func|
 			func.loadToFloatArray(testDur, server, { |data|
-				this.assertArrayFloatEquals(data, 0, text.quote, within: 0.0, report: true);
+				this.assertArrayFloatEquals(data, 0, text.quote, within: 0.0, report: false);
 				completed = completed + 1;
 				cond.signalOne;
 			});
@@ -420,7 +420,7 @@ TestCoreUGens : UnitTest {
 
 		tests.keysValuesDo{|name, func|
 			func.loadToFloatArray(testDur, server, { |data|
-				this.assertArrayFloatEquals(data, 0, name.quote, report: true);
+				this.assertArrayFloatEquals(data, 0, name.quote, report: false);
 				completed = completed + 1;
 				cond.signalOne;
 			});
@@ -514,7 +514,7 @@ TestCoreUGens : UnitTest {
 
 			this.assert(results.every(_ == results[0]),
 				"Impulse.%: all rate combinations of identical unmodulated input values should have identical output".format(rate),
-				report: true);
+				report: false);
 		};
 
 		/* Tests in response to historical bugs */
@@ -525,8 +525,8 @@ TestCoreUGens : UnitTest {
 		{ Impulse.kr(frq, 3.8) }.loadToFloatArray(
 			frq.reciprocal, // render one freq period (should contain only 1 impulse)
 			server, { |arr|
-				this.assert(arr.sum == 1.0, "Impulse.kr: phase that is far out-of-range should wrap immediately in-range, and not cause multiple impulses to fire.", report: true);
-				this.assert(arr[0] != 1.0, "Impulse.kr: a phase offset other than 0 or 1 should not produce an impulse on the first output sample.", report: true);
+				this.assert(arr.sum == 1.0, "Impulse.kr: phase that is far out-of-range should wrap immediately in-range, and not cause multiple impulses to fire.", report: false);
+				this.assert(arr[0] != 1.0, "Impulse.kr: a phase offset other than 0 or 1 should not produce an impulse on the first output sample.", report: false);
 				cond.signalOne;
 			}
 		);
@@ -540,7 +540,7 @@ TestCoreUGens : UnitTest {
 					frq.reciprocal, // 1 freq period
 					server, { |arr|
 						this.assert(arr[0] == 1.0,
-							"Impulse.%: initial phase of % should produce and impulse on the first frame.".format(rate, phs), report: true);
+							"Impulse.%: initial phase of % should produce and impulse on the first frame.".format(rate, phs), report: false);
 						cond.signalOne;
 					}
 				);
@@ -555,7 +555,7 @@ TestCoreUGens : UnitTest {
 				3 * server.options.blockSize / server.sampleRate, // 3 blocks
 				server, { |arr|
 					this.assert(arr[0] == 1.0 and: { arr.sum == 1.0 },
-						"Impulse.%: freq = 0 should produce a single impulse on the first frame and no more.".format(rate), report: true);
+						"Impulse.%: freq = 0 should produce a single impulse on the first frame and no more.".format(rate), report: false);
 					cond.signalOne;
 				}
 			);
@@ -569,7 +569,7 @@ TestCoreUGens : UnitTest {
 				server, { |arr|
 					arr = arr.clump(2).flop; // de-interleave
 					this.assertArrayFloatEquals(arr[0], arr[1],
-						"Impulse.%: positive and negative frequencies should produce the same output.".format(rate), report: true);
+						"Impulse.%: positive and negative frequencies should produce the same output.".format(rate), report: false);
 					cond.signalOne;
 				}
 			);
@@ -806,7 +806,7 @@ TestCoreUGens : UnitTest {
 					};
 
 					this.assertArrayFloatEquals(
-						data.keep(numPredelaySamples), target, errmsg, within: tolerance, report: true
+						data.keep(numPredelaySamples), target, errmsg, within: tolerance, report: false
 					);
 					cond.signalOne;
 				});
@@ -883,6 +883,7 @@ TestCoreUGens : UnitTest {
 		var completed = 0;
 		var testsFinished = false;
 		var cond = CondVar();
+		var tolerance = -100.dbamp;
 
 		server.bootSync;
 		[\ar, \kr].do { |rate|
@@ -907,7 +908,7 @@ TestCoreUGens : UnitTest {
 
 						this.assertFloatEquals(dataEndVal, envEndVal,
 							"EnvGen should not arrive late to its end value [dur % samples, %]".format(numSamps, rate),
-							within: -90.dbamp, report: false
+							within: tolerance, report: false
 						);
 
 						this.assert(dataEndVal != priorToEndVal,

--- a/testsuite/classlibrary/TestCoreUGens.sc
+++ b/testsuite/classlibrary/TestCoreUGens.sc
@@ -928,14 +928,12 @@ TestCoreUGens : UnitTest {
 			// EnvGen, standard Env and using Env:*circle and Env:-circle
 			target = 42; // first output sample should be the first level of the Env
 			[
-				Env([target, target*100], period_sec),
-				Env([target, target*100], period_sec).circle(period_sec),
-				Env.circle([target, target*100], [period_sec, period_sec])
-			].do{ |env, i|
-				{
-					EnvGen.perform(rate, env);
-				}.loadToFloatArray(period_sec * 1.5, server, { |data|
-					data.postln;
+				{ EnvGen.perform(rate, Env([target, target*100], period_sec)) },
+				// circular envs have to be instantiated from within the function in order for them to be interpreted as dynamic UGen inputs
+				{ EnvGen.perform(rate, Env([target, target*100], period_sec).circle(period_sec)) },
+				{ EnvGen.perform(rate, Env.circle([target, target*100], [period_sec, period_sec])) },
+			].do{ |testFunc, i|
+				testFunc.loadToFloatArray(period_sec * 1.5, server, { |data|
 					this.assertFloatEquals(data[0], target,
 						"EnvGen's first sample, should be its first level [%, env %]".format(rate, i),
 						within: tolerance, report: false


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

EnvGen accumulates rounding error over the durations of its segments. This can be especially noticeable if the Env has many breakpoints, especially at control rate. 

Another example is if you're expecting equivalence between, e.g., Line and linear segment of an Envelope, because of the incorrect Env duration, the step size is incorrect so sample values aren't identical to a Line with the same nominal duration.

For example, this envelope's duration is 1.0 sec but ends early:
```supercollider
(
{	EnvGen.kr(Env(
		[0, 1, 0.3].dup(10).flat ++ 0,
		[0.02, 0.03, 0.05].dup(10).flat // duration sums to 1.0
	))
}.plot(1)
)
```
<img width="512" alt="Screenshot 2025-03-18 at 11 11 14" src="https://github.com/user-attachments/assets/bf7e0c7c-e680-462a-a0a8-9e0ddb526e04" />


Fixes #6180. 

This follows on #6175, where the duration bug was found and partially addressed.

## Types of changes

- Documentation
- Bug fix
- Tests added
  - equivalence test for Line vs. linear Env, XLine vs. exp Env
  - test correct env times for all curve types) and modified (suppress output of successful tests)
  - replaces previous start/end sample value test with this more comprehensive test that tests sample values and timings
- Breaking change (technically breaking - the output changes)

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
