### PR TITLE
Fix wrong behaviour of `lastForWhich` and `lastIndexForWhich` of `Collection`, also add synonym method of them

### DIFF
--- a/HelpSource/Classes/Collection.schelp
+++ b/HelpSource/Classes/Collection.schelp
@@ -249,7 +249,7 @@ method::lastForWhich
 Returns the last element of the collection for which the function is true. Synonym to link::#-detectLast::.
 
 method::lastIndexForWhich
-Returns the index of the last element of the collection for which the function is true. Synonym to link::#-detectLast::.
+Returns the index of the last element of the collection for which the function is true. Synonym to link::#-detectLastIndex::.
 
 method::inject
 In functional programming, the operation known as a left fold.

--- a/HelpSource/Classes/Collection.schelp
+++ b/HelpSource/Classes/Collection.schelp
@@ -231,6 +231,12 @@ code::
 List[1, 2, 3, 4].detectIndex({ |item, i| item.even });
 ::
 
+method::lastForWhich
+Similar to link::#-detect::, but doing in a reversed manner.
+
+method::lastIndexForWhich
+Similar to link::#-detectIndex::, but doing in a reversed manner.
+
 method::inject
 In functional programming, the operation known as a left fold.
 inject takes an initial value and a function and combines the elements of the collection by applying the function to the accumulated value and an element from the collection starting from the first element in the collection. The strong::function:: takes two arguments and returns the new value. The accumulated value is initialized to strong::initialValue::.

--- a/HelpSource/Classes/Collection.schelp
+++ b/HelpSource/Classes/Collection.schelp
@@ -227,6 +227,10 @@ List[1, 2, 3, 4].detect({ |item, i| item.even });
 
 method::detectLast
 Similar to link::#-detect::, but doing in a reversed manner.
+code::
+[2, 3, 4, 6, 8, 9, 10].detectLast({ arg item; item.odd }); // 9
+["a", "b", "c"].detectLast({ arg item; item == "d" }); // nil
+::
 
 method::detectIndex
 Similar to link::#-detect:: but returns the index instead of the item itself.
@@ -236,12 +240,16 @@ List[1, 2, 3, 4].detectIndex({ |item, i| item.even });
 
 method::detectLastIndex
 Similar to link::#-detectIndex::, but doing in a reversed manner.
+code::
+[0, 1, 2, 3, 4].detectLastIndex({ arg item; item.odd }); // 3
+["a", "b", "c"].detectLastIndex({ arg item; item == 0 }); // nil
+::
 
 method::lastForWhich
-Synonym to link::#-detectLast::, which is added to keep the consistency of naming.
+Returns the last element of the collection for which the function is true. Synonym to link::#-detectLast::.
 
 method::lastIndexForWhich
-Synonym to link::#-detectLastIndex::, which is added to keep the consistency of naming.
+Returns the index of the last element of the collection for which the function is true. Synonym to link::#-detectLast::.
 
 method::inject
 In functional programming, the operation known as a left fold.

--- a/HelpSource/Classes/Collection.schelp
+++ b/HelpSource/Classes/Collection.schelp
@@ -225,17 +225,23 @@ code::
 List[1, 2, 3, 4].detect({ |item, i| item.even });
 ::
 
+method::detectLast
+Similar to link::#-detect::, but doing in a reversed manner.
+
 method::detectIndex
 Similar to link::#-detect:: but returns the index instead of the item itself.
 code::
 List[1, 2, 3, 4].detectIndex({ |item, i| item.even });
 ::
 
+method::detectLastIndex
+Similar to link::#-detectIndex::, but doing in a reversed manner.
+
 method::lastForWhich
-Similar to link::#-detect::, but doing in a reversed manner.
+Synonym to link::#-detectLast::, which is added to keep the consistency of naming.
 
 method::lastIndexForWhich
-Similar to link::#-detectIndex::, but doing in a reversed manner.
+Synonym to link::#-detectLastIndex::, which is added to keep the consistency of naming.
 
 method::inject
 In functional programming, the operation known as a left fold.

--- a/SCClassLibrary/Common/Collections/Collection.sc
+++ b/SCClassLibrary/Common/Collections/Collection.sc
@@ -193,9 +193,15 @@ Collection {
 		this.do {|elem, i| if (function.value(elem, i)) { ^elem } }
 		^nil;
 	}
+	detectLast { | function |
+		^this.lastForWhich(function);
+	}
 	detectIndex { | function |
 		this.do {|elem, i| if (function.value(elem, i)) { ^i } }
 		^nil;
+	}
+	detectLastIndex { | function |
+		^this.lastIndexForWhich(function);
 	}
 	doMsg { | selector ... args |
 		this.do {| item | item.performList(selector, args) }

--- a/SCClassLibrary/Common/Collections/Collection.sc
+++ b/SCClassLibrary/Common/Collections/Collection.sc
@@ -216,26 +216,20 @@ Collection {
 		^this.detectIndex {| item | item.performList(selector, args) }
 	}
 	lastForWhich { | function |
-		var prev;
-		this.do {|elem, i|
+		this.reverseDo {|elem, i|
 			if (function.value(elem, i)) {
-				prev = elem;
-			}{
-				^prev
+				^elem
 			}
 		};
-		^prev
+		^nil
 	}
 	lastIndexForWhich { | function |
-		var prev;
-		this.do {|elem, i|
+		this.reverseDo {|elem, i|
 			if (function.value(elem, i)) {
-				prev = i;
-			}{
-				^prev
+				^this.size - i - 1
 			}
 		};
-		^prev
+		^nil
 	}
 	inject { | thisValue, function |
 		var nextValue = thisValue;

--- a/SCClassLibrary/Common/Collections/Collection.sc
+++ b/SCClassLibrary/Common/Collections/Collection.sc
@@ -194,14 +194,14 @@ Collection {
 		^nil;
 	}
 	detectLast { | function |
-		^this.lastForWhich(function);
+		^this.lastForWhich(function)
 	}
 	detectIndex { | function |
 		this.do {|elem, i| if (function.value(elem, i)) { ^i } }
 		^nil;
 	}
 	detectLastIndex { | function |
-		^this.lastIndexForWhich(function);
+		^this.lastIndexForWhich(function)
 	}
 	doMsg { | selector ... args |
 		this.do {| item | item.performList(selector, args) }


### PR DESCRIPTION
## Purpose and Motivation

The behaviour of `lastForWhich` and `lastIndexForWhich`, defined in `Collection` class, does not match their names. The original implementation **only** checks the first element of the array.

Also, to match the convention of naming in the `Collection` class, `detectLast` and `detectLastIndex` is suggested to be added as an alternative name of `lastForWhich` and `lastIndexForWhich`.

You can see the relevant discussion at [the post on `scsynth` site](https://scsynth.org/t/intention-for-undocumented-method-in-class-collection-lastforwhich-and-lastindexforwhich/11289).

## Types of changes

- Bug fix
- New feature
(synonym method, `detectLast` and `detectLastIndex`)

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->
