### PR TITLE
Docs: DetectIndex: add doc

### DIFF
--- a/HelpSource/Classes/DetectIndex.schelp
+++ b/HelpSource/Classes/DetectIndex.schelp
@@ -7,7 +7,8 @@ Linearly searches a buffer for a value (i.e., loops over the frames in the
 buffer from the beginning, checking for float equality), and returns index of first occurrence of said value.
 Returns -1 if value is not found.
 The object performs a search whenever a change in the strong::in:: argument is
-detected.
+detected; 
+changes in the strong::bufnum:: argument do not trigger searches.
 Checks for changes occur at the selected rate (ar or kr).
 
 classmethods::

--- a/HelpSource/Classes/DetectIndex.schelp
+++ b/HelpSource/Classes/DetectIndex.schelp
@@ -3,7 +3,12 @@ summary:: Search a buffer for a value
 categories:: UGens>Buffer
 
 description::
-Search a buffer for a value.
+Linearly searches a buffer for a value (i.e., loops over the frames in the
+buffer from the beginning, checking for float equality), and returns index of first occurrence of said value.
+Returns -1 if value is not found.
+The object performs a search whenever a change in the strong::in:: argument is
+detected.
+Checks for changes occur at the selected rate (ar or kr).
 
 classmethods::
 method:: ar, kr
@@ -13,7 +18,7 @@ index of the buffer
 argument:: in
 the input signal.
 returns::
-index
+index of first occurrence of value, or -1 if value is not found.
 
 examples::
 code::
@@ -30,7 +35,7 @@ s.listSendMsg(b.allocMsg(b.setnMsg(0, t)));
 	var index, in, out, f0, fdiff;
 	var bufnum = b;
 	var input;
-	input = MouseX.kr(0, max).round(1); // round to precision
+	input = MouseX.kr(0, max).round(1); // round to integer
 	index = DetectIndex.kr(bufnum, input);
 	index.poll;
 	SinOsc.ar(index.linexp(0, max, 200, 700)) * 0.1


### PR DESCRIPTION
As requested in Issue https://github.com/supercollider/supercollider/issues/6641.
First PR attempt https://github.com/supercollider/supercollider/pull/6656 had messy commit history, hopefully this one is better. 

Documents return values, search method, behavior in case of multiple possible matches.
Change to code comment for clarity.

## Purpose and Motivation
@JordanHendersonMusic's issue

## Types of changes

- Documentation
