### PR TITLE
Classlib:Plot:remove interpolation for resampling of integer data

### DIFF
--- a/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
+++ b/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
@@ -209,7 +209,7 @@ Plot {
 	value_ { |array|
 		value = array;
 		valueCache = nil;
-		interp = value.any { |v| v%1 > 0};
+		interp = value.any(_.isInteger.not);
 	}
 	spec_ { |sp|
 		spec = sp;


### PR DESCRIPTION
Not sure if this was the best use of my time, but here goes:

Adds a check in Plot.value_ whether codomain is integer (tested with `any(_.isInteger.not)`); if so, turns off interpolation in prResampValues.

Only has an effect when `Plot.value.size` is larger than approx. `Plotter.bounds.width - 50` or so(depending on labels etc.).

## Purpose and Motivation

When the aren't enough pixels available, Plotter will internally resample the data from a linearly interpolated version of `.value`. This is suitable for most pseudo-continuous data such as audio signals.
Where the data is discrete, however, this behavior may occasionally be unwanted. 
Here is an example adapted from Ppoisson.schelp. Width and data size are unmodified, I just removed the histogram and added the missing Window.front:
 ```
(
var a, c, w;
a = Ppoisson(10.0, inf);
c = a.asStream.nextN(500);
w = Window.new("Ppoisson", Rect(10, 10, 540, 400));
// plot the values
c.plot(bounds: Rect(10, 10, 520, 380), discrete: true, parent: w);
w.front
)
```
Because the `Plotter.bounds.width` is too small for the data (`value.size`), you have to enlarge the width to see that the distribution is discrete (as it should be). 
 
I guess in this case, it may be preferable to simply skip values rather than interpolate. With this PR, Plotter does this when value is an array of integers. That is, if the `interp` flag is set to false, instead of getting the values to be drawn from `value.blendAt(scaledIndex)`, plot takes them from `value.at(scaledIndex.asInteger)`. 

For pseudo-continuous signals that happen to be all in integers this slightly changes the behavior (from linear interpolation to no interpolation), but obviously only when there aren't enough pixels. I think this side effect is even more niche than the PR itself? 
But users can still effectively choose the behavior by passing in arrays of the respective datatype; i.e., if they want interpolation on some array of integers, just convert that to float before you pass it to plot.

## Types of changes

- Bug fix 

## To-do list
Tests: Tested on my installation, not sure if there are more serious tests I should be doing?

Doc: I don't think this fix itself needs to be documented, but maybe there should be some more explicit documentation of Plot's resampling behavior and how many pixels are needed to prevent resampling. Resampling is currently only briefly discussed in the examples, and there with respect to a DomainSpec; but (from what I could tell) the spec is implemented with continuous data in mind (there's a `spec.warp.unmap` somewhere, so the step argument to the spec won't do anything), so I don't think it can be used to solve the above issue.

