### PR TITLE
Move filenameSym from Method to FunctionDef

### DIFF
--- a/SCClassLibrary/Common/Core/Kernel.sc
+++ b/SCClassLibrary/Common/Core/Kernel.sc
@@ -415,6 +415,7 @@ Process {
 FunctionDef {
 	var raw1, raw2, <code, <selectors, <constants, <prototypeFrame, <context, <argNames, <varNames;
 	var <sourceCode;
+	var <filenameSymbol;
 
 	// a FunctionDef is defined by a code within curly braces {}
 	// When you use a FunctionDef in your code it gets pushed on the stack
@@ -563,7 +564,7 @@ FunctionDef {
 
 Method : FunctionDef {
 	var <ownerClass, <name, <primitiveName;
-	var <filenameSymbol, <charPos;
+	var <charPos;
 
 	openCodeFile {
 		this.filenameSymbol.asString.openDocument(this.charPos, -1);
@@ -662,7 +663,6 @@ Interpreter {
 	interpretPrintCmdLine {
 		var res, func, code = cmdLine, doc, ideClass = \ScIDE.asClass;
 		preProcessor !? { cmdLine = preProcessor.value(cmdLine, this) };
-		func = this.compile(cmdLine);
 		if (ideClass.notNil) {
 			thisProcess.nowExecutingPath = ideClass.currentPath
 		} {
@@ -670,6 +670,7 @@ Interpreter {
 				thisProcess.nowExecutingPath = doc.tryPerform(\path);
 			}
 		};
+		func = this.compile(cmdLine);
 		res = func.value;
 		thisProcess.nowExecutingPath = nil;
 		codeDump.value(code, res, func, this);

--- a/lang/LangSource/PyrKernel.h
+++ b/lang/LangSource/PyrKernel.h
@@ -154,13 +154,13 @@ struct PyrBlock : public PyrObjectHdr {
     PyrSlot argNames; // ***arguments to block
     PyrSlot varNames; // ***variables in block
     PyrSlot sourceCode; // source code if it is a closed function.
+    PyrSlot filenameSym;
 };
 
 struct PyrMethod : public PyrBlock {
     PyrSlot ownerclass;
     PyrSlot name;
     PyrSlot primitiveName;
-    PyrSlot filenameSym;
     PyrSlot charPos;
     // PyrSlot byteMeter;
     // PyrSlot callMeter;


### PR DESCRIPTION

<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

Closes #6675

`thisProcess.nowExecutingPath` doesn't return the file path where the code was defined. 

This PR moves `filenameSym` from `Method` to `FunctionDef` (@jamshark70 's suggestion).

Save this code in a file. Either run it directly from the file, or use `String.load`.

```supercollider
thisFunctionDef.filenameSymbol.debug(\a);

fork { thisFunctionDef.filenameSymbol.debug(\b) };
```


## Types of changes

<!-- Delete lines that don't apply -->

- New feature


## To-do list

I haven't run the full test suits, and a test is yet to be added, but the implementation should be there. 

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [ ] Code is tested
- [ ] All tests are passing
- [ ] Updated documentation
- [ ] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
