### PR TITLE
Add BufferExamplesPath class

### DIFF
--- a/HelpSource/Classes/Buffer.schelp
+++ b/HelpSource/Classes/Buffer.schelp
@@ -1,6 +1,7 @@
 class:: Buffer
 summary:: Client-side representation of a buffer on a server
 categories:: Server>Abstractions
+related:: Classes/BufferExamplesPath
 
 description::
 

--- a/HelpSource/Classes/BufferExamplesPath.schelp
+++ b/HelpSource/Classes/BufferExamplesPath.schelp
@@ -1,0 +1,61 @@
+TITLE:: BufferExamplesPath
+summary:: A shortcut to example sounds bundled with SuperCollider
+categories:: Files
+related:: Classes/Buffer, Classes/Soundfile
+
+DESCRIPTION::
+Provides a shortcut to the paths of example sounds which are bundled with SuperCollider and are located in LINK::Classes/Platform#*resourceDir::.
+
+CODE::
+// instead of writing
+Platform.resourceDir +/+ "sounds" +/+ "a11wlk01-44_1.aiff";
+// one can write
+BufferExamplesPath.apollo11;
+::
+
+CLASSMETHODS::
+
+METHOD:: apollo11 
+A radio recording from the Apollo 11 moon landing program where Bruce McCandless says EMPHASIS::"Columbia, this is Houston. Over."::.
+For more information see LINK::https://www.nasa.gov/history/alsj/a11/a11.mobility.html:: at the mark TELETYPE::110:25:41:: (it seems to be the third repetition, though the pitch does not match).
+
+TABLE::
+## Filename || TELETYPE::a11wlk01-44_1.aiff::
+## Channels || 1
+## Samplerate || 44100 Hz
+## Format || pcm_s16be
+## Duration || 00:00:02.44
+::
+
+RETURNS:: The full path of TELETYPE::a11wlk01-44_1.aiff:: as a LINK::Classes/String::
+
+DISCUSSION::
+Trivia time: Although the file in its current form was introduced on 2004-07-11 by Scott Wilson via commit TELETYPE::bc9a4d4fd8cdccd2b1c787010c776176c7993d2c::, its original version as a 11025 Hz mono file dates back to at least 2002-09-28 via the commit TELETYPE::f30d769ab6b8eb1f36027ed3a400efd3b829f43a:: by James McCartney.
+
+This can be considered the "Hello world" audio sample of SuperCollider.
+
+METHOD:: sinedPink
+A very short stereo sample which has 10 cycles of a 440Hz LINK::Classes/SinOsc:: on its first channel and a LINK::Classes/PinkNoise:: on its second channel. 
+
+TABLE::
+## Filename || TELETYPE::SinedPink.aiff::
+## Channels || 2
+## Samplerate || 44100 Hz
+## Format || pcm_f32be
+## Duration || 00:00:00.02
+::
+
+returns:: The full path of TELETYPE::SinedPink.aiff:: as a LINK::Classes/String:: 
+
+METHOD:: child
+Allegedly a re-recording of Link::Classes/BufferExamplesPath#*apollo11:: performed by a child of a developer.
+
+TABLE::
+## Filename || TELETYPE::a11wlk01.wav::
+## Channels || 1
+## Samplerate || 44100 Hz
+## Format || pcm_s16le
+## Duration || 00:00:04.28
+::
+
+returns:: The full path of TELETYPE::a11wlk01.wav:: as a LINK::Classes/String::

--- a/SCClassLibrary/Common/Files/BufferExamplesPath.sc
+++ b/SCClassLibrary/Common/Files/BufferExamplesPath.sc
@@ -1,0 +1,13 @@
+BufferExamplesPath {
+	*apollo11 {
+		^Platform.resourceDir +/+ "sounds" +/+ "a11wlk01-44_1.aiff";
+	}
+
+	*sinedPink {
+		^Platform.resourceDir +/+ "sounds" +/+ "SinedPink.aiff";
+	}
+
+	*child {
+		^Platform.resourceDir +/+ "sounds" +/+ "a11wlk01.wav";
+	}
+}

--- a/testsuite/classlibrary/TestBufferExamplesPath.sc
+++ b/testsuite/classlibrary/TestBufferExamplesPath.sc
@@ -1,0 +1,12 @@
+TestBufferExamplesPath : UnitTest {
+	test_filesExist {
+		// we use the methods of the meta class to access the static methods
+		Meta_BufferExamplesPath.methods.do({|staticMethod|
+			var filePath = BufferExamplesPath.performArgs(staticMethod.name);
+			this.assert(
+				boolean: PathName(filePath).isFile,
+				message: "% is an example file and should exist".format(filePath),
+			);
+		});
+	}
+}


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

Closes #5859

Hopefully I am not the only one who would consider such a class helpful - still can't remember `a11wlk01-44_1.aiff` after some years...

Docs:

![Screenshot 2025-03-26 at 20-28-47 BufferExamplesPath SuperCollider 3 14 0-dev Help](https://github.com/user-attachments/assets/0c3e2703-06d4-4941-8209-8625db72ff64)

In a future this class could be used to add additional sound examples.

## Types of changes

- Documentation
- New feature

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

Questions:

* [x] Should we add tests? (Would allow additional assurance that we don't move files by accident?)
* [ ] Should we add some information about license? (can be added later?)
* [ ] Should such a class return Strings or PathName? Strings seem to be the more common way when operating with Buffers though?


<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
