### PR TITLE
plugin interface: fix ClearUnitOnMemFailed macro

### DIFF
--- a/include/plugin_interface/SC_Unit.h
+++ b/include/plugin_interface/SC_Unit.h
@@ -83,10 +83,14 @@ enum { kUnitDef_CantAliasInputsToOutputs = 1 };
 
 #define ClearUnitOnMemFailed                                                                                           \
     Print("%s: alloc failed, increase server's RT memory (e.g. via ServerOptions)\n", __func__);                       \
-    SETCALC(*ClearUnitOutputs);                                                                                        \
+    SETCALC(ClearUnitOutputs);                                                                                         \
+    ClearUnitOutputs(unit, 1);                                                                                         \
     unit->mDone = true;                                                                                                \
     return;
 
+// macro for handling RT allocation failures. Example usage:
+//     unit->mBuf = RTAlloc(mWorld, numBytes);
+//     ClearUnitIfMemFailed(unit->mBuf);
 #define ClearUnitIfMemFailed(condition)                                                                                \
     if (!(condition)) {                                                                                                \
         ClearUnitOnMemFailed                                                                                           \


### PR DESCRIPTION
## Purpose and Motivation

The `ClearUnitOnMemFailed` macro must zero the first sample of all outputs before returning from the current function; otherwise the output will contain garbage.

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
