### PR TITLE
TestUGen_RTAlloc: don't set samplerate or blocksize

### DIFF
--- a/testsuite/classlibrary/TestUGen_RTAlloc.sc
+++ b/testsuite/classlibrary/TestUGen_RTAlloc.sc
@@ -8,8 +8,6 @@ TestUGen_RTAlloc : UnitTest {
 
 	setUp {
 		server = Server(this.class.name);
-		server.options.sampleRate = 48000;
-		server.options.blockSize = 64;
 		server.options.memSize = 2 ** 13; // scsynth default
 		// - tests fail with memSize < 256 (GVerb fails)
 		// - testing with memSize >= 2 ** 20 would require multiple allocations


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

When I was running the TestUGen_RTAlloc test locally, it failed to boot the server, as my hardware was not able to run at the requested samplerate (there might be a separate bug here...).
I don't believe tests should request a specific samplerate, as this is environment dependent. AFAICT this is the only test that actually requests a particular sample rate.

I understand that there might be tests that are samplerate-specific, but I think handling such cases should be discussed separately.

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [n/a] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
