### PR TITLE
docs: ways of getting current doc's path [skip ci]

### DIFF
--- a/HelpSource/Classes/Document.schelp
+++ b/HelpSource/Classes/Document.schelp
@@ -77,6 +77,7 @@ A Document.
 discussion::
 code::
 Document.current.name.postln; // Prints "Document.html"
+Document.current.dir; // Prints the current document's path
 ::
 
 method:: allDocuments
@@ -121,6 +122,8 @@ code::
 Document.dir = "~/Documents/SuperCollider";
 ::
 
+To get the current document's directory, see link::Classes/Document#-dir::.
+
 method:: standardizePath
 argument:: p
 The file system path to the directory. An instance of link::Classes/String::.
@@ -162,12 +165,18 @@ code::
 Document.current.path.postln;
 ::
 
+See also link::Classes/Process#-nowExecutingPath:: and
+link::Classes/String#-resolveRelative::
+
 method:: dir
 Returns the directory of a Document.
 discussion::
 code::
 Document.current.dir.postln;
 ::
+
+See also link::Classes/Process#-nowExecutingPath:: and
+link::Classes/String#-resolveRelative::
 
 method:: ==
 A binary operator.

--- a/HelpSource/Classes/File.schelp
+++ b/HelpSource/Classes/File.schelp
@@ -33,11 +33,22 @@ method::open
 Same as link::#*new::, but a more intuitive name.
 
 method::getcwd
-POSIX standard 'get current working directory'.
-code::
-// example;
-File.getcwd;
+POSIX standard 'get current working directory': returns the path from where
+strong::sclang:: was launched. It can be also set by passing the code::-d:: flag to
+sclang, or via an option in ScIDE code::(Preferences > Interpreter > Runtime
+Directory)::. Otherwise, it returns different values according to the OS, since
+each OS runs sclang differently:
+list::
+## macOS: teletype::/::
+## Linux: teletype::~::
+## Windows: link::Classes/Platform#*resourceDir::
 ::
+
+Also note that this is not necessarily the same
+directory of the file currently being executed. For that, see
+link::Classes/Process#-nowExecutingPath::,
+link::Classes/String#-resolveRelative::,  and the editor-specific
+link::Classes/Document#-dir::.
 
 method::use
 Open the file, evaluate the function with the file as argument, and close it again. If the process fails, close the file and throw an error.

--- a/HelpSource/Classes/Process.schelp
+++ b/HelpSource/Classes/Process.schelp
@@ -22,9 +22,60 @@ Usage: code::thisProcess.nowExecutingPath::
 
 Returns the full path to the file containing the code that is currently executing emphasis::interactively:: in the interpreter. Usually this is the current document. If the code block executes another file on disk, using link::Classes/String#-load:: or link::Classes/String#-loadPaths::, teletype::nowExecutingPath:: will be the location of the executed file.
 
-teletype::nowExecutingPath:: is valid only for interactive code, i.e., code files with a teletype::.scd:: extension. It does not apply to class definitions (teletype::.sc::). For that, use code::thisMethod.filenameSymbol:: or code::this.class.filenameSymbol::.
+code::
+// in file testScript.scd
+thisProcess.nowExecutingPath // > /path/to/testScript.scd
 
-This method is supported in the SuperCollider IDE, the macOS-only SuperCollider.app, and the scel (SuperCollider-Emacs-Lisp) environment. In other editor environments, it will return code::nil::.
+// in file anotherScript.scd
+thisProcess.nowExecutingPath // > /path/to/anotherScript.scd
+"testScript.scd".loadRelative  // > [/path/to/testScript.scd]
+::
+
+Use as current document's path (i.e. when not executing a file explicitly with
+link::Classes/String#-load::) is supported in the SuperCollider IDE, and in any editor that
+implements code::Document.current.path::, or it will return code::nil::.
+
+discussion::
+
+teletype::nowExecutingPath:: is valid only for interactive code, i.e., code
+files with a teletype::.scd:: extension. It does not apply to class definitions
+(teletype::.sc::). For that, use code::thisMethod.filenameSymbol::
+ or code::this.class.filenameSymbol::.
+
+ Calling code::thisProcess.nowExecutingPath:: within a class method, will return the path to the file from which the class method was called, rather than the one where it's defined.
+
+code::
+// in file TestPaths.sc
+TestPaths {
+	*callerPath { ^thisProcess.nowExecutingPath }
+	*definitionPath { ^thisMethod.filenameSymbol }
+}
+// in file TestPathsExtension.sc
++TestPaths {
+	*extensionPath { ^thisMethod.filenameSymbol }
+	*extDefPath { ^this.class.filenameSymbol }
+}
+
+// testScript.scd
+TestPaths.callerPath     // > testScript.scd
+TestPaths.definitionPath // > TestPaths.sc
+TestPaths.extensionPath  // > TestPathsExtension.sc
+TestPaths.extDefPath     // > TestPaths.sc 
+::
+
+See also link::Classes/String#-resolveRelative::, which automatically select the
+appropriate method whether code is run from a class or interactively.
+
+code::
+// currently executed .scd file's directory
+thisProcess.nowExecutingPath.dirname
+// currently open (in editor) file's directory
+Document.current.dir
+// current .sc or .scd file's directory
+"".resolveRelative
+// sclang current working directory: doesn't depend on current file
+File.getcwd;
+::
 
 WARNING:: teletype::nowExecutingPath:: has a corresponding setter method, teletype::nowExecutingPath_::, for internal use only by the interpreter. Do not call the setter method!::
 

--- a/HelpSource/Classes/String.schelp
+++ b/HelpSource/Classes/String.schelp
@@ -777,6 +777,24 @@ A function that is called for each file path that is found.
 method::resolveRelative
 Convert the receiver from a relative path to an absolute path, relative to the current document or text file. Requires that the current text file has been saved. Absolute paths are left untransformed.
 
+It can also be called from a class method in a teletype::.sc:: file, in which
+case it returns link::Classes/Method#-filenameSymbol::.
+
+For getting the current document's path, see also:
+link::Classes/Process:-nowExecutingPath:: and the editor-specific
+link::Classes/Document#-path::.
+
+code::
+// currently executed .scd file's directory
+thisProcess.nowExecutingPath.dirname
+// currently open (in editor) file's directory
+Document.current.dir
+// current .sc or .scd file's directory
+"".resolveRelative
+// sclang current working directory: doesn't depend on current file
+File.getcwd;
+::
+
 method::standardizePath
 Expand ~ to your home directory, and resolve aliases on macOS. See link::Classes/PathName:: for more complex needs. See link::Classes/File#*realpath:: if you want to resolve symlinks.
 code::


### PR DESCRIPTION
## Purpose and Motivation

Fixes #5757

Attempting to put all the knowledge emerged from #5757 in the docs.
`File.getcwd` now lists common defaults for each OS, mentions how to affect cwd via CLI and IDE, and specifies that this is not necessarily the current document's path.
`File.cwd`, `thisProcess.nowExecutingPath`, `String.resolveRelative` and `Document.current.dir` all refer to each other as "see also".
I also added some examples to thisProcess.nowExecutingPath, trying to clarify the differences with String.resolveRelative and filenameSymbol.

Maybe it's too much information? As often, in SC we have different method to do almost the same thing. In this case, they all do something slightly different and have different reasons to exist, so let's document them all. Perhaps we should a dedicated "Guide" section somewhere, instead of having most info in `thisProcess.nowExecutingPath` and cross references everywhere?

## Types of changes

- Documentation

## To-do list

- [x] Updated documentation
- [x] This PR is ready for review 

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
