### PR TITLE
sclang: fix `mod` behavior for negative integer modulus

### DIFF
--- a/HelpSource/Classes/Float.schelp
+++ b/HelpSource/Classes/Float.schelp
@@ -76,6 +76,9 @@ See also: link::Guides/Randomness::
 method::xrand2
 returns::a random float from this.neg to this, excluding the value exclude.
 
+method::modSeaside
+returns::the same result as code::this.mod(aNumber, adverb)::; provided for compatibility with link::Classes/Integer#-modSeaside::.
+
 method:: isFloat
 returns:: code::true:: since this is a Float.
 

--- a/HelpSource/Classes/Integer.schelp
+++ b/HelpSource/Classes/Integer.schelp
@@ -227,12 +227,32 @@ method:: -
 Subtraction.
 
 method:: modSeaside
-Pre-3.14 modulo with unexpected behavior for negative integer modulus. E.g., 
+
+Pre-3.14 modulo with unexpected behavior for negative integer modulus.
+
+For dividends smaller than a negative divisor, modSeaside pulls the resulting remainder below the divisor.
+It thereby leaves zero as peaks on the zero line. Like in the usual mod, all larger dividends result in remainders above zero.
+
 code::
-(..-9).mod(-3) 
+(..-9).mod(-3);
 // returns [0, -1, -2, 0, -1, -2, 0, -1, -2, 0]
-(..-9).modSeaside(-3)
+(..-9).modSeaside(-3);
 // returns [0, 2, 1, 0, -4, -5, 0, -4, -5, 0]
+
+// plot
+(-25..25).modSeaside(-5).plot.plotMode_(\steps);
+
+// modSeaside
+Pbind(\note, modSeaside(Pseries(-15, 1, 25), -5), \dur, 0.2).play;
+
+// modSeaside with different divisors
+Pbind(\note, modSeaside(Pseries(-15, 1, 25), [3, -4, -5]), \dur, 0.2).play;
+
+// mod
+Pbind(\note, mod(Pseries(-15, 1, 25), -5), \dur, 0.2).play;
+
+// mod with different divisors
+Pbind(\note, mod(Pseries(-15, 1, 25), [3, -4, -5]), \dur, 0.2).play;
 ::
 
 method:: clip

--- a/HelpSource/Classes/Integer.schelp
+++ b/HelpSource/Classes/Integer.schelp
@@ -226,6 +226,15 @@ Addition.
 method:: -
 Subtraction.
 
+method:: modSeaside
+Pre-3.14 modulo with unexpected behavior for negative integer modulus. E.g., 
+code::
+(..-9).mod(-3) 
+// returns [0, -1, -2, 0, -1, -2, 0, -1, -2, 0]
+(..-9).modSeaside(-3)
+// returns [0, 2, 1, 0, -4, -5, 0, -4, -5, 0]
+::
+
 method:: clip
 returns::
 LIST::

--- a/HelpSource/Classes/Number.schelp
+++ b/HelpSource/Classes/Number.schelp
@@ -27,6 +27,9 @@ Integer division.
 method:: %
 Modulo.
 
+method:: modSeaside
+Pre-3.14 modulo with unexpected behavior for negative integer modulus; see link::Classes/Integer#-modSeaside::. Calling code::modSeaside:: on a floating-point operand will fall back to code::mod:: behavior.
+
 method:: **
 Exponentiation.
 

--- a/HelpSource/Classes/SequenceableCollection.schelp
+++ b/HelpSource/Classes/SequenceableCollection.schelp
@@ -732,6 +732,9 @@ method:: +, -, *, /, div, min, max, <, <=, >, >=, bitXor, lcm, gcd, round, trunc
 
 method:: %, **, &, |, >>, +>>, <!
 
+method:: modSeaside
+Pre-3.14 modulo with unexpected behavior for negative integer modulus; see link::Classes/Integer#-modSeaside::. Calling code::modSeaside:: on a non-integer operand will fall back to code::mod:: behavior; see link::Classes/Float#-modSeaside::.
+
 method::performBinaryOp
 Creates a new collection of the results of applying the selector with the operand to all elements in the receiver. If the operand is a collection then elements of that collection are paired with elements of the receiver.
 code::

--- a/HelpSource/Overviews/Operators.schelp
+++ b/HelpSource/Overviews/Operators.schelp
@@ -303,7 +303,8 @@ method:: /
 Division.
 
 method:: %
-Floating point modulo.
+Modulo.
+NOTE:: Uses floored division. Prior to SC 3.14, integer modulo would exhibit unexpected behavior for negative modulus; see link::Classes/Integer#-modSeaside::.::
 
 method:: **
 Exponentiation. Same as pow.

--- a/SCClassLibrary/Common/Collections/SequenceableCollection.sc
+++ b/SCClassLibrary/Common/Collections/SequenceableCollection.sc
@@ -850,6 +850,7 @@ SequenceableCollection : Collection {
 	/ { arg aNumber, adverb; ^this.performBinaryOp('/', aNumber, adverb) }
 	div { arg aNumber, adverb; ^this.performBinaryOp('div', aNumber, adverb) }
 	mod { arg aNumber, adverb; ^this.performBinaryOp('mod', aNumber, adverb) }
+	modSeaside { arg aNumber, adverb; ^this.performBinaryOp('modSeaside', aNumber, adverb) }
 	pow { arg aNumber, adverb; ^this.performBinaryOp('pow', aNumber, adverb) }
 	min { arg aNumber, adverb; ^this.performBinaryOp('min', aNumber, adverb) }
 	max { arg aNumber=0, adverb; ^this.performBinaryOp('max', aNumber, adverb) }

--- a/SCClassLibrary/Common/Core/AbstractFunction.sc
+++ b/SCClassLibrary/Common/Core/AbstractFunction.sc
@@ -100,6 +100,7 @@ AbstractFunction {
 	/ { arg function, adverb; ^this.composeBinaryOp('/', function, adverb) }
 	div { arg function, adverb; ^this.composeBinaryOp('div', function, adverb) }
 	mod { arg function, adverb; ^this.composeBinaryOp('mod', function, adverb) }
+	modSeaside { arg function, adverb; ^this.composeBinaryOp('modSeaside', function, adverb) }
 	pow { arg function, adverb; ^this.composeBinaryOp('pow', function, adverb) }
 	min { arg function, adverb; ^this.composeBinaryOp('min', function, adverb) }
 	max { arg function=0, adverb; ^this.composeBinaryOp('max', function, adverb) }

--- a/SCClassLibrary/Common/Core/Symbol.sc
+++ b/SCClassLibrary/Common/Core/Symbol.sc
@@ -166,6 +166,7 @@ Symbol {
 	* { ^this }
 	/ { ^this }
 	mod { ^this }
+	modSeaside { ^this }
 	min { ^this }
 	max { ^this }
 	bitAnd { ^this }

--- a/SCClassLibrary/Common/Geometry/Point.sc
+++ b/SCClassLibrary/Common/Geometry/Point.sc
@@ -85,10 +85,16 @@ Point {
 		^Point(x.trunc(quant.x), y.trunc(quant.y))
 	}
 
-	mod {|that|
+	mod { |that|
 		var thatPoint;
 		thatPoint = that.asPoint;
 		^Point(this.x mod: thatPoint.x, this.y mod: thatPoint.y)
+	}
+	
+	modSeaside { |that|
+		var thatPoint;
+		thatPoint = that.asPoint;
+		^Point(this.x modSeaside: thatPoint.x, this.y modSeaside: thatPoint.y)
 	}
 
 	printOn { arg stream;

--- a/SCClassLibrary/Common/Math/Float.sc
+++ b/SCClassLibrary/Common/Math/Float.sc
@@ -5,6 +5,8 @@ Float : SimpleNumber {
 	+ { arg aNumber, adverb; _AddFloat; ^aNumber.performBinaryOpOnSimpleNumber('+', this, adverb) }
 	- { arg aNumber, adverb; _SubFloat; ^aNumber.performBinaryOpOnSimpleNumber('-', this, adverb) }
 	* { arg aNumber, adverb; _MulFloat; ^aNumber.performBinaryOpOnSimpleNumber('*', this, adverb) }
+	
+	modSeaside { arg aNumber, adverb; _Mod; ^aNumber.performBinaryOpOnSimpleNumber('mod', this, adverb) }
 
 	clip { arg lo, hi; _ClipFloat; ^this.primitiveFailed }
 	wrap { arg lo, hi; _WrapFloat; ^this.primitiveFailed }

--- a/SCClassLibrary/Common/Math/Integer.sc
+++ b/SCClassLibrary/Common/Math/Integer.sc
@@ -6,6 +6,8 @@ Integer : SimpleNumber {
 	+ { arg aNumber, adverb; _AddInt; ^aNumber.performBinaryOpOnSimpleNumber('+', this, adverb) }
 	- { arg aNumber, adverb; _SubInt; ^aNumber.performBinaryOpOnSimpleNumber('-', this, adverb) }
 	* { arg aNumber, adverb; _MulInt; ^aNumber.performBinaryOpOnSimpleNumber('*', this, adverb) }
+	
+	modSeaside { arg aNumber, adverb; _ModSeasideInt; ^aNumber.performBinaryOpOnSimpleNumber('modSeaside', this, adverb) }
 
 	clip { arg lo, hi; _ClipInt; ^this.primitiveFailed }
 	wrap { arg lo, hi; _WrapInt; ^this.primitiveFailed }

--- a/SCClassLibrary/Common/Math/Number.sc
+++ b/SCClassLibrary/Common/Math/Number.sc
@@ -6,6 +6,7 @@ Number : Magnitude {
 	* { arg aNumber; ^this.subclassResponsibility(thisMethod) }
 	/ { arg aNumber; ^this.subclassResponsibility(thisMethod) }
 	mod { arg aNumber; ^this.subclassResponsibility(thisMethod) }
+	modSeaside { arg aNumber; ^this.subclassResponsibility(thisMethod) }
 	div { arg aNumber; ^this.subclassResponsibility(thisMethod) }
 	pow { arg aNumber; ^this.subclassResponsibility(thisMethod) }
 

--- a/SCClassLibrary/Common/Math/Signal.sc
+++ b/SCClassLibrary/Common/Math/Signal.sc
@@ -267,6 +267,7 @@ Signal[float] : FloatArray {
 	* { arg aNumber; _Mul; ^aNumber.performBinaryOpOnSignal('*', this) }
 	/ { arg aNumber; _FDiv; ^aNumber.performBinaryOpOnSignal('/', this) }
 	mod { arg aNumber; _Mod; ^aNumber.performBinaryOpOnSignal('mod', this) }
+	modSeaside { arg aNumber; _Mod; ^aNumber.performBinaryOpOnSignal('mod', this) }
 	div { arg aNumber; _IDiv; ^aNumber.performBinaryOpOnSignal('div', this) }
 	pow { arg aNumber; _Pow; ^aNumber.performBinaryOpOnSignal('pow', this) }
 	min { arg aNumber; _Min; ^aNumber.performBinaryOpOnSignal('min', this) }

--- a/include/plugin_interface/SC_InlineBinaryOp.h
+++ b/include/plugin_interface/SC_InlineBinaryOp.h
@@ -324,16 +324,6 @@ inline int sc_div(int a, int b) {
     return c;
 }
 
-/*
-inline int sc_mod(int a, int b)
-{
-    long c;
-    c = a % b;
-    if (c<0) c += b;
-    return c;
-}
-*/
-
 /// Modulo
 inline int sc_mod(int in, int hi) {
     // avoid the divide if possible
@@ -351,6 +341,28 @@ inline int sc_mod(int in, int hi) {
 
     if (hi == lo)
         return lo;
+    return in - hi * sc_floor((float64)in / hi);
+}
+
+/**
+ * Modulo with old behavior;
+ * gives unexpected results for all values with negative integer modulus,
+ *  i.e., affected cases: for a, b both integers: a mod -b.
+ */
+inline int sc_mod_seaside(int in, int hi) {
+    // avoid the divide if possible
+    const int lo = 0;
+    if (in >= hi) {
+        in -= hi;
+        if (in < hi)
+            return in;
+    } else if (in < lo) {
+        in += hi;
+        if (in >= lo)
+            return in;
+    } else
+        return in;
+
 
     int c;
     c = in % hi;

--- a/lang/LangPrimSource/PyrMathPrim.cpp
+++ b/lang/LangPrimSource/PyrMathPrim.cpp
@@ -302,6 +302,36 @@ int prSubInt(VMGlobals* g, int numArgsPushed) { return prOpInt<subNum>(g, numArg
 
 int prMulInt(VMGlobals* g, int numArgsPushed) { return prOpInt<mulNum>(g, numArgsPushed); }
 
+int prModSeasideInt(struct VMGlobals* g, int numArgsPushed) {
+    PyrSlot* a = g->sp - 1;
+    PyrSlot* b = g->sp;
+    int in;
+    int err;
+
+    if (NotInt(a) || (NotInt(b) && NotFloat(b)))
+        return errWrongType;
+
+    err = slotIntVal(a, &in);
+    if (err)
+        return err;
+    if (IsInt(b)) {
+        int hi, res;
+        err = slotIntVal(b, &hi);
+        if (err)
+            return err;
+        res = sc_mod_seaside(in, hi);
+        SetRaw(a, res);
+    } else {
+        float hi, res;
+        err = slotFloatVal(b, &hi);
+        if (err)
+            return err;
+        res = sc_mod((double)in, (double)hi);
+        SetFloat(a, res);
+    }
+
+    return errNone;
+}
 
 int prNthPrime(VMGlobals* g, int numArgsPushed) {
     PyrSlot* a;
@@ -1299,6 +1329,7 @@ void initMathPrimitives() {
     definePrimitive(base, index++, "_AddInt", prAddInt, 2, 0);
     definePrimitive(base, index++, "_SubInt", prSubInt, 2, 0);
     definePrimitive(base, index++, "_MulInt", prMulInt, 2, 0);
+    definePrimitive(base, index++, "_ModSeasideInt", prModSeasideInt, 2, 0);
     definePrimitive(base, index++, "_AddFloat", prAddFloat, 2, 0);
     definePrimitive(base, index++, "_SubFloat", prSubFloat, 2, 0);
     definePrimitive(base, index++, "_MulFloat", prMulFloat, 2, 0);

--- a/testsuite/classlibrary/TestMod.sc
+++ b/testsuite/classlibrary/TestMod.sc
@@ -1,0 +1,29 @@
+TestMod : UnitTest {
+	test_mod_integer {
+		var array = [1, (2 ** 30).asInteger, -10, 11, -2, (2 ** 30).asInteger.neg];
+		var modulus = [1, (2 ** 30 + 1).asInteger, 12, -3, -6, (2 ** 30 + 100).asInteger.neg];
+		this.assertEquals(array.mod(modulus), [0, 1073741824, 2, -1, -2, -1073741824], "mod should give expected results for Integer");
+	}
+
+	test_modSeaside_integer {
+		var array = [1, (2 ** 30).asInteger, -10, 11, -2, (2 ** 30).asInteger.neg];
+		var modulus = [1, (2 ** 30 + 1).asInteger, 12, -3, -6, (2 ** 30 + 100).asInteger.neg];
+		this.assertEquals(array.modSeaside(modulus), [0, 1073741824, 2, 2, 4, 100], "modSeaside should give expected results for Integer");
+	}
+
+	test_mod_float {
+		var array = [1.0, -10.7, 11.3, -13.4, (2 ** -53)];
+		var modulus = [1.0, 12.0, -11.4, -6.2, (2 ** -53 - 0.1)];
+		var result = array.mod(modulus);
+		this.assertArrayFloatEquals(result, [0.0, 1.3, -0.1, -1.0, -0.1], "mod should give expected results for Float");
+		this.assertEquals(result, array.modSeaside(modulus), "modSeaside should match mod for Floats");
+
+		this.assertFloatEquals((2 ** 53).mod(2 ** 53 + 1.1), 9.007199254741e+15, "mod should give relatively accurate results for large Floats", 10);
+	}
+
+	test_modSeaside_combined {
+		var array = [1, (2 ** 30), -12.0, 13.2, 40];
+		var modulus = [1, (2 ** 30 + 2).asInteger, -9, -15, -17];
+		this.assertArrayFloatEquals(array.modSeaside(modulus), [0, 1073741824.0, -3.0, -1.8, 6], "modSeaside should exhibit desired behaviors for SequenceableCollections with both Floats and Ints");
+	}
+}


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

Fixes #6698. Currently, `mod` for negative integers gives unexpected results (particularly, when that negative integer is the modulus). This fix puts `mod`'s behavior for `int`s closer to `mod`'s behavior for `double`s and `float`s and so applies a consistent definition of modulo.
<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix
- Breaking change (output changes)

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Documentation updated
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
