### PR TITLE
Fix compatibility with CMake4 (portaudio)

### DIFF
--- a/external_libraries/portaudio/CMakeLists.txt
+++ b/external_libraries/portaudio/CMakeLists.txt
@@ -13,6 +13,10 @@ set(PA_LIBNAME_ADD_SUFFIX OFF CACHE BOOL "PortAudio static library suffix" FORCE
 # disable install target
 set(PA_DISABLE_INSTALL ON CACHE BOOL "Disable PortAudio install" FORCE)
 
+# bump up cmake version to fix compatibility with cmake 4
+# FIXME: remove this after the portaudio submodule is updated above v19.7.0
+set(CMAKE_POLICY_VERSION_MINIMUM 3.10)
+
 add_subdirectory(portaudio_submodule)
 
 if(WIN32 AND NOT PA_USE_ASIO)


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

This PR includes 2 workarounds to provide compatibility with Cmake 4 on Windows:
- set CMAKE_POLICY_VERSION_MINIMUM in CMake for PortAudio before adding the subproject
- ~~set CMAKE_POLICY_VERSION_MINIMUM env variable in CI to fix building libsndfile in vcpkg on Windows~~

Fixes #6696. 

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [n/a] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
