### PR TITLE
Synth reblocking and upsampling

### DIFF
--- a/SCClassLibrary/Common/Control/Node.sc
+++ b/SCClassLibrary/Common/Control/Node.sc
@@ -457,7 +457,7 @@ Synth : Node {
 		if (blockSize.notNil or: { upsample.notNil }) {
 			server.sendMsg(67, //"s_newEx"
 				defName, nodeID, addActionID, targetNode.nodeID,
-				blockSize, upsample, *(args.asOSCArgArray)
+				blockSize ? 0, upsample ? 0.0, *(args.asOSCArgArray)
 			);
 		} {
 			server.sendMsg(9, //"s_new"
@@ -503,7 +503,7 @@ Synth : Node {
 		target = (target ? server.defaultGroup);
 		group = if(addActionID < 2) { target } { target.group };
 		if (blockSize.notNil or: { upsample.notNil }) {
-			^[67, defName, nodeID, addActionID, target.nodeID, blockSize, upsample ] ++
+			^[67, defName, nodeID, addActionID, target.nodeID, blockSize ? 0, upsample ? 0.0 ] ++
 			args.asOSCArgArray // "/s_newEx"
 		} {
 			^[9, defName, nodeID, addActionID, target.nodeID] ++

--- a/SCClassLibrary/Common/Control/Node.sc
+++ b/SCClassLibrary/Common/Control/Node.sc
@@ -425,46 +425,24 @@ Synth : Node {
 	var <>defName;
 
 	/** immediately sends **/
-	*new { arg defName, args, target, addAction=\addToHead;
-		var synth, server, addActionID;
+	*new { arg defName, args, target, addAction=\addToHead, blockSize, upsample;
+		var synth, server;
 		target = target.asTarget;
 		server = target.server;
-		addActionID = addActions[addAction];
 		synth = this.basicNew(defName, server);
-
-		synth.group = if(addActionID < 2) { target } { target.group };
-		server.sendMsg(9, //"s_new"
-			defName, synth.nodeID, addActionID, target.nodeID,
-			*(args.asOSCArgArray)
-		);
+		synth.prSend(target, addAction, blockSize, upsample, args);
 		^synth
 	}
 
-	*newPaused { arg defName, args, target, addAction=\addToHead;
-		var synth, server, addActionID;
+	*newPaused { arg defName, args, target, addAction=\addToHead, blockSize, upsample;
+		var synth, server;
 		target = target.asTarget;
 		server = target.server;
-		addActionID = addActions[addAction];
 		synth = this.basicNew(defName, server);
-		synth.group = if(addActionID < 2) { target } { target.group };
-		server.sendBundle(nil, [9, defName, synth.nodeID, addActionID, target.nodeID] ++
-			args.asOSCArgArray, [12, synth.nodeID, 0]); // "s_new" + "/n_run"
-		^synth
-	}
-
-	*replace { arg nodeToReplace, defName, args, sameID=false;
-		var synth, server, newNodeID;
-		if(sameID) { newNodeID = nodeToReplace.nodeID };
-		server = nodeToReplace.server;
-		synth = this.basicNew(defName, server, newNodeID);
-
-		server.sendMsg(9, //"s_new"
-			defName,
-			synth.nodeID,
-			4, // addReplace
-			nodeToReplace.nodeID,
-			*(args.asOSCArgArray)
-		);
+		server.sendBundle(nil,
+			synth.newMsg(target, args, addAction, blockSize, upsample),
+			[12, synth.nodeID, 0]
+		); // "s_new" + "/n_run"
 		^synth
 	}
 
@@ -473,68 +451,106 @@ Synth : Node {
 		^super.basicNew(server, nodeID).defName_(defName.asDefName)
 	}
 
-	newMsg { arg target, args, addAction = \addToHead;
+	prSend { arg targetNode, addAction, blockSize, upsample, args;
 		var addActionID = addActions[addAction];
-		target = target.asTarget;
-		group = if(addActionID < 2) { target } { target.group };
-		^[9, defName, nodeID, addActionID, target.nodeID] ++ args.asOSCArgArray //"/s_new"
+		group = if(addActionID < 2) { targetNode } { targetNode.group };
+		if (blockSize.notNil or: { upsample.notNil }) {
+			server.sendMsg(67, //"s_newEx"
+				defName, nodeID, addActionID, targetNode.nodeID,
+				blockSize, upsample, *(args.asOSCArgArray)
+			);
+		} {
+			server.sendMsg(9, //"s_new"
+				defName, nodeID, addActionID, targetNode.nodeID,
+				*(args.asOSCArgArray)
+			);
+		}
 	}
 
-	*after { arg aNode, defName, args;
-		^this.new(defName, args, aNode, \addAfter)
+	*after { arg aNode, defName, args, blockSize, upsample;
+		^this.new(defName, args, aNode, \addAfter, blockSize, upsample)
 	}
 
-	*before { arg aNode, defName, args;
-		^this.new(defName, args, aNode, \addBefore)
+	*before { arg aNode, defName, args, blockSize, upsample;
+		^this.new(defName, args, aNode, \addBefore, blockSize, upsample)
 	}
 
-	*head { arg aGroup, defName, args;
-		^this.new(defName, args, aGroup, \addToHead)
+	*head { arg aGroup, defName, args, blockSize, upsample;
+		^this.new(defName, args, aGroup, \addToHead, blockSize, upsample)
 	}
 
-	*tail { arg aGroup, defName, args;
-		^this.new(defName, args, aGroup, \addToTail)
+	*tail { arg aGroup, defName, args, blockSize, upsample;
+		^this.new(defName, args, aGroup, \addToTail, blockSize, upsample)
 	}
 
-	replace { arg defName, args, sameID;
-		^this.class.replace(this, defName, args, sameID)
+	*replace { arg nodeToReplace, defName, args, sameID=false, blockSize, upsample;
+		var synth, server, newNodeID;
+		if(sameID) { newNodeID = nodeToReplace.nodeID };
+		server = nodeToReplace.server;
+		synth = this.basicNew(defName, server, newNodeID);
+		synth.prSend(nodeToReplace, \addReplace, blockSize, upsample, args);
+		^synth
+	}
+
+	replace { arg defName, args, sameID, blockSize, upsample;
+		^this.class.replace(this, defName, args, sameID, blockSize, upsample)
 	}
 
 	// for bundling
-	addToHeadMsg { arg aGroup, args;
+	newMsg { arg target, args, addAction = \addToHead, blockSize, upsample;
+		var addActionID = addActions[addAction];
 		// if aGroup is nil set to default group of server specified when basicNew was called
-		group = (aGroup ? server.defaultGroup);
-		^[9, defName, nodeID, 0, group.nodeID] ++ args.asOSCArgArray	// "/s_new"
+		target = (target ? server.defaultGroup);
+		group = if(addActionID < 2) { target } { target.group };
+		if (blockSize.notNil or: { upsample.notNil }) {
+			^[67, defName, nodeID, addActionID, target.nodeID, blockSize, upsample ] ++
+			args.asOSCArgArray // "/s_newEx"
+		} {
+			^[9, defName, nodeID, addActionID, target.nodeID] ++
+			args.asOSCArgArray //"/s_new"
+		}
 	}
 
-	addToTailMsg { arg aGroup, args;
-		// if aGroup is nil set to default group of server specified when basicNew was called
-		group = (aGroup ? server.defaultGroup);
-		^[9, defName, nodeID, 1, group.nodeID] ++ args.asOSCArgArray // "/s_new"
+	addToHeadMsg { arg aGroup, args, blockSize, upsample;
+		^this.newMsg(aGroup, args, \addToHead, blockSize, upsample);
 	}
 
-	addAfterMsg { arg aNode, args;
-		group = aNode.group;
-		^[9, defName, nodeID, 3, aNode.nodeID] ++ args.asOSCArgArray // "/s_new"
+	addToTailMsg { arg aGroup, args, blockSize, upsample;
+		^this.newMsg(aGroup, args, \addToTail, blockSize, upsample);
 	}
 
-	addBeforeMsg { arg aNode, args;
-		group = aNode.group;
-		^[9, defName, nodeID, 2, aNode.nodeID] ++ args.asOSCArgArray // "/s_new"
+	addAfterMsg { arg aNode, args, blockSize, upsample;
+		^this.newMsg(aNode, args, \addAfter, blockSize, upsample);
 	}
 
-	addReplaceMsg { arg nodeToReplace, args;
-		group = nodeToReplace.group;
-		^[9, defName, nodeID, 4, nodeToReplace.nodeID] ++ args.asOSCArgArray // "/s_new"
+	addBeforeMsg { arg aNode, args, blockSize, upsample;
+		^this.newMsg(aNode, args, \addBefore, blockSize, upsample);
+	}
+
+	addReplaceMsg { arg nodeToReplace, args, sameID=false, blockSize, upsample;
+		var msg = this.newMsg(nodeToReplace, args, \addReplace,
+			blockSize, upsample);
+		if (sameID) {
+			// bash node ID
+			msg[2] = nodeToReplace.nodeID;
+		};
+		^msg;
 	}
 
 	// nodeID -1
-	*grain { arg defName, args, target, addAction=\addToHead;
-		var server;
+	*grain { arg defName, args, target, addAction=\addToHead, blockSize, upsample;
+		var server, addActionID;
 		target = target.asTarget;
 		server = target.server;
-		server.sendMsg(9, defName.asDefName, -1, addActions[addAction], target.nodeID,
-			*(args.asOSCArgArray)); //"/s_new"
+		addActionID = addActions[addAction];
+		if (blockSize.notNil or: { upsample.notNil }) {
+			server.sendMsg(67, defName.asDefName, -1, addActionID,
+				target.nodeID, blockSize ? 0, upsample ? 0.0,
+				*(args.asOSCArgArray)) //"/s_newEx"
+		} {
+			server.sendMsg(9, defName.asDefName, -1, addActionID,
+				target.nodeID, *(args.asOSCArgArray)); //"/s_new"
+		};
 		^nil
 	}
 

--- a/include/plugin_interface/SC_Graph.h
+++ b/include/plugin_interface/SC_Graph.h
@@ -24,6 +24,10 @@
 #include "SC_Rate.h"
 #include "SC_SndBuf.h"
 
+enum { kGraph_Reblock = 0x1, kGraph_Resample = 0x2 };
+
+#define kGraph_ReblockOrResample (kGraph_Reblock | kGraph_Resample)
+
 /*
  changes to this struct likely also mean that a change is needed for
     static const int sc_api_version = x;
@@ -31,6 +35,11 @@
  */
 struct Graph {
     Node mNode;
+
+    uint16 mNumTicks;
+    uint16 mTickCounter;
+
+    uint32 mFlags;
 
     uint32 mNumWires;
     struct Wire* mWire;
@@ -60,6 +69,9 @@ struct Graph {
     SndBuf* mLocalSndBufs;
     int32 localBufNum;
     int32 localMaxBufNum;
+
+    Rate* mFullRate;
+    Rate* mBufRate;
 
     void* mPrivate;
 };

--- a/include/plugin_interface/SC_Graph.h
+++ b/include/plugin_interface/SC_Graph.h
@@ -41,10 +41,13 @@ struct Graph {
 
     uint32 mFlags;
 
-    uint32 mNumWires;
-    struct Wire* mWire;
+    Rate* mFullRate;
+    Rate* mBufRate;
 
+    uint32 mNumWires;
     uint32 mNumControls;
+
+    struct Wire* mWire;
     float* mControls;
     float** mMapControls;
     int32* mAudioBusOffsets;
@@ -53,25 +56,22 @@ struct Graph {
     int32* mControlRates;
 
     uint32 mNumUnits;
-    struct Unit** mUnits;
-
     uint32 mNumCalcUnits;
+
+    struct Unit** mUnits;
     struct Unit** mCalcUnits; // excludes i-rate units.
 
     int32 mSampleOffset;
+    float mSubsampleOffset;
+
     struct RGen* mRGen;
 
     struct Unit* mLocalAudioBusUnit;
     struct Unit* mLocalControlBusUnit;
 
-    float mSubsampleOffset;
-
     SndBuf* mLocalSndBufs;
     int32 localBufNum;
     int32 localMaxBufNum;
-
-    Rate* mFullRate;
-    Rate* mBufRate;
 
     void* mPrivate;
 };

--- a/include/plugin_interface/SC_Unit.h
+++ b/include/plugin_interface/SC_Unit.h
@@ -120,9 +120,10 @@ template <typename ToType, typename Value>
 #define BUFLENGTH (unit->mBufLength)
 #define BUFRATE (unit->mRate->mBufRate)
 #define BUFDUR (unit->mRate->mBufDuration)
-#define FULLRATE (unit->mWorld->mFullRate.mSampleRate)
-#define FULLBUFLENGTH (unit->mWorld->mFullRate.mBufLength)
-#define FULLSAMPLEDUR (unit->mWorld->mFullRate.mSampleDur)
+#define FULLRATE (unit->mParent->mFullRate->mSampleRate)
+#define FULLSAMPLEDUR (unit->mParent->mFullRate->mSampleDur)
+#define FULLBUFLENGTH (unit->mParent->mFullRate->mBufLength)
+#define REBLOCK_OR_RESAMPLE (unit->mParent->mFlags & kGraph_ReblockOrResample)
 
 #ifdef SUPERNOVA
 

--- a/include/server/ErrorMessage.hpp
+++ b/include/server/ErrorMessage.hpp
@@ -71,7 +71,9 @@ std::string apiVersionMismatch(std::string const& utf8Filename, int const expect
     assert(expectedVersion != actualVersion);
 
     // both 1 and 2 were introduced in 3.6
-    static map<int, string> const scVersionForAPIVersion = { { 1, "3.6.0" }, { 2, "3.6.0" }, { 3, "3.9.0" } };
+    static map<int, string> const scVersionForAPIVersion = {
+        { 1, "3.6.0" }, { 2, "3.6.0" }, { 3, "3.9.0" }, { 4, "3.14" }
+    };
 
     stringstream message;
     message << "ERROR: API version mismatch: " << utf8Filename << "\n";

--- a/include/server/SC_OSC_Commands.h
+++ b/include/server/SC_OSC_Commands.h
@@ -119,5 +119,8 @@ enum {
 
     cmd_b_setSampleRate = 66,
 
-    NUMBER_OF_COMMANDS = 67
+    cmd_s_newEx = 67,
+    cmd_s_newargsEx = 68,
+
+    NUMBER_OF_COMMANDS = 69
 };

--- a/server/plugins/DelayUGens.cpp
+++ b/server/plugins/DelayUGens.cpp
@@ -439,7 +439,7 @@ void SampleDur_Ctor(Unit* unit, int inNumSamples) { ZOUT0(0) = FULLSAMPLEDUR; }
 
 void ControlDur_Ctor(Unit* unit, int inNumSamples) { ZOUT0(0) = BUFDUR; }
 
-void RadiansPerSample_Ctor(Unit* unit, int inNumSamples) { ZOUT0(0) = unit->mWorld->mFullRate.mRadiansPerSample; }
+void RadiansPerSample_Ctor(Unit* unit, int inNumSamples) { ZOUT0(0) = unit->mParent->mFullRate->mRadiansPerSample; }
 
 void BlockSize_Ctor(Unit* unit, int inNumSamples) { ZOUT0(0) = FULLBUFLENGTH; }
 

--- a/server/scsynth/SC_Graph.cpp
+++ b/server/scsynth/SC_Graph.cpp
@@ -34,6 +34,7 @@
 #include "SC_Prototypes.h"
 #include "SC_Errors.h"
 #include "Unroll.h"
+#include "clz.h"
 
 void Unit_ChooseMulAddFunc(Unit* unit);
 
@@ -63,6 +64,11 @@ void Graph_Dtor(Graph* inGraph) {
                 (dtor)(unit);
         }
     }
+
+    // NOTE: mBufRate is allocated as part of mFullRate, see Graph_Ctor()!
+    if (inGraph->mFullRate != &world->mFullRate)
+        World_Free(world, inGraph->mFullRate);
+
     // free queued Unit commands
     // AFAICT this can only happen if a Graph is created, Unit commands are sent and the Graph
     // is deleted all at the same time stamp.
@@ -89,19 +95,20 @@ void Graph_Dtor(Graph* inGraph) {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-SCErr Graph_New(World* inWorld, struct GraphDef* inGraphDef, int32 inID, struct sc_msg_iter* args, Graph** outGraph,
-                bool argtype) // true for normal args , false for setn type args
+SCErr Graph_New(struct World* inWorld, struct GraphDef* inGraphDef, int32 inID, int32 blockSize, double upsample,
+                struct sc_msg_iter* args, Graph** outGraph,
+                bool argtype) // true for normal args, false for setn type args
 {
     Graph* graph;
     int err = Node_New(inWorld, &inGraphDef->mNodeDef, inID, (Node**)&graph);
     if (err)
         return err;
-    Graph_Ctor(inWorld, inGraphDef, graph, args, argtype);
+    Graph_Ctor(inWorld, inGraphDef, graph, args, blockSize, upsample, argtype);
     *outGraph = graph;
     return err;
 }
 
-void Graph_Ctor(World* inWorld, GraphDef* inGraphDef, Graph* graph, sc_msg_iter* msg,
+void Graph_Ctor(World* inWorld, GraphDef* inGraphDef, Graph* graph, sc_msg_iter* msg, int32 blockSize, double upsample,
                 bool argtype) // true for normal args , false for setn type args
 {
     // scprintf("->Graph_Ctor\n");
@@ -376,6 +383,66 @@ void Graph_Ctor(World* inWorld, GraphDef* inGraphDef, Graph* graph, sc_msg_iter*
     graph->localBufNum = 0;
     graph->localMaxBufNum = 0; // this is set from synth
 
+    graph->mFlags = 0;
+
+    if (blockSize == 0 && upsample == 0) {
+        // no reblocking and no upsampling -> use the global rates
+        graph->mNumTicks = 1;
+        graph->mTickCounter = 0;
+        graph->mFullRate = &inWorld->mFullRate;
+        graph->mBufRate = &inWorld->mBufRate;
+    } else {
+        // reblocking or upsampling
+        if (upsample > 1.0) {
+            // make sure that 'upsample' is a power of two!
+            if (ISPOWEROFTWO((int)upsample)) {
+                upsample = (int)upsample;
+                graph->mFlags |= kGraph_Resample; // ok
+            } else {
+                scprintf("WARNING: Synth: upsample factor (%f) not a power of two\n", upsample);
+                upsample = 1.0;
+            }
+        } else if (upsample < 1.0) {
+            if (upsample > 0.0) {
+                scprintf("WARNING: Synth: downsampling (%f) not supported (yet)\n", upsample);
+            }
+            upsample = 1.0;
+        }
+
+        if (blockSize > 0) {
+            // block size cannot be larger than wire buffer size (yet)!
+            if (blockSize > inWorld->mBufLength) {
+                scprintf("WARNING: Synth: block size (%d) cannot be larger than Server "
+                         "block size (%d)\n",
+                         blockSize, inWorld->mBufLength);
+                blockSize = inWorld->mBufLength;
+            } else if (!ISPOWEROFTWO(blockSize)) {
+                scprintf("WARNING: Synth: block size (%d) not a power of two\n", blockSize);
+                blockSize = inWorld->mBufLength;
+            } else {
+                graph->mFlags |= kGraph_Reblock; // ok
+            }
+        } else {
+            blockSize = inWorld->mBufLength;
+        }
+
+        graph->mNumTicks = (inWorld->mBufLength / blockSize) * upsample;
+        graph->mTickCounter = 0;
+        double sampleRate = inWorld->mSampleRate * upsample;
+
+        // Hit allocator only once, see Graph_Dtor()
+        Rate* chunk = (Rate*)World_Alloc(inWorld, sizeof(Rate) * 2);
+
+        graph->mFullRate = chunk;
+        Rate_Init(graph->mFullRate, sampleRate, blockSize);
+
+        graph->mBufRate = chunk + 1;
+        Rate_Init(graph->mBufRate, sampleRate / blockSize, 1);
+    }
+
+    //  scprintf("Graph_Ctor: block size: %d, upsample: %f, ticks: %d\n",
+    //           blockSize, upsample, graph->mNumTicks);
+
     // so far mPrivate is only used for queued unit commands,
     // i.e. it just points to the head of the list.
     graph->mPrivate = nullptr;
@@ -391,7 +458,7 @@ void Graph_Ctor(World* inWorld, GraphDef* inGraphDef, Graph* graph, sc_msg_iter*
     UnitSpec* unitSpec = inGraphDef->mUnitSpecs;
     for (uint32 i = 0; i < numUnits; ++i, ++unitSpec) {
         // construct unit from spec
-        Unit* unit = Unit_New(inWorld, unitSpec, memory);
+        Unit* unit = Unit_New(inWorld, graph, unitSpec, memory);
 
         // set parent
         unit->mParent = graph;
@@ -541,39 +608,47 @@ void Graph_Calc(Graph* inGraph) {
 
     int unroll8 = numCalcUnits / 8;
     int remain8 = numCalcUnits % 8;
-    int i = 0;
-
-    for (int j = 0; j != unroll8; i += 8, ++j) {
-        Graph_Calc_unit(calcUnits[i]);
-        Graph_Calc_unit(calcUnits[i + 1]);
-        Graph_Calc_unit(calcUnits[i + 2]);
-        Graph_Calc_unit(calcUnits[i + 3]);
-        Graph_Calc_unit(calcUnits[i + 4]);
-        Graph_Calc_unit(calcUnits[i + 5]);
-        Graph_Calc_unit(calcUnits[i + 6]);
-        Graph_Calc_unit(calcUnits[i + 7]);
-    }
-
     int unroll4 = remain8 / 4;
     int remain4 = remain8 % 4;
-    if (unroll4) {
-        Graph_Calc_unit(calcUnits[i]);
-        Graph_Calc_unit(calcUnits[i + 1]);
-        Graph_Calc_unit(calcUnits[i + 2]);
-        Graph_Calc_unit(calcUnits[i + 3]);
-        i += 4;
-    }
-
     int unroll2 = remain4 / 2;
     int remain2 = remain4 % 2;
-    if (unroll2) {
-        Graph_Calc_unit(calcUnits[i]);
-        Graph_Calc_unit(calcUnits[i + 1]);
-        i += 2;
-    }
 
-    if (remain2)
-        Graph_Calc_unit(calcUnits[i]);
+    int numTicks = inGraph->mNumTicks;
+
+    for (int k = 0; k < numTicks; ++k) {
+        // set before calling Graph_Calc_unit()!
+        inGraph->mTickCounter = k;
+
+        int i = 0;
+
+        for (int j = 0; j != unroll8; i += 8, ++j) {
+            Graph_Calc_unit(calcUnits[i]);
+            Graph_Calc_unit(calcUnits[i + 1]);
+            Graph_Calc_unit(calcUnits[i + 2]);
+            Graph_Calc_unit(calcUnits[i + 3]);
+            Graph_Calc_unit(calcUnits[i + 4]);
+            Graph_Calc_unit(calcUnits[i + 5]);
+            Graph_Calc_unit(calcUnits[i + 6]);
+            Graph_Calc_unit(calcUnits[i + 7]);
+        }
+
+        if (unroll4) {
+            Graph_Calc_unit(calcUnits[i]);
+            Graph_Calc_unit(calcUnits[i + 1]);
+            Graph_Calc_unit(calcUnits[i + 2]);
+            Graph_Calc_unit(calcUnits[i + 3]);
+            i += 4;
+        }
+
+        if (unroll2) {
+            Graph_Calc_unit(calcUnits[i]);
+            Graph_Calc_unit(calcUnits[i + 1]);
+            i += 2;
+        }
+
+        if (remain2)
+            Graph_Calc_unit(calcUnits[i]);
+    }
 
     // scprintf("<-Graph_Calc\n");
 }
@@ -582,21 +657,25 @@ void Graph_CalcTrace(Graph* inGraph);
 void Graph_CalcTrace(Graph* inGraph) {
     uint32 numCalcUnits = inGraph->mNumCalcUnits;
     Unit** calcUnits = inGraph->mCalcUnits;
-    scprintf("\nTRACE %d  %s    #units: %d\n", inGraph->mNode.mID, inGraph->mNode.mDef->mName, numCalcUnits);
-    for (uint32 i = 0; i < numCalcUnits; ++i) {
-        Unit* unit = calcUnits[i];
-        scprintf("  unit %d %s\n    in ", i, (char*)unit->mUnitDef->mUnitDefName);
-        for (uint32 j = 0; j < unit->mNumInputs; ++j) {
-            scprintf(" %g", ZIN0(j));
+
+    for (uint32 k = 0; k < inGraph->mNumTicks; ++k) {
+        scprintf("\nTRACE %d  %s    #units: %d\n", inGraph->mNode.mID, inGraph->mNode.mDef->mName, numCalcUnits);
+        for (uint32 i = 0; i < numCalcUnits; ++i) {
+            Unit* unit = calcUnits[i];
+            scprintf("  unit %d %s\n    in ", i, (char*)unit->mUnitDef->mUnitDefName);
+            for (uint32 j = 0; j < unit->mNumInputs; ++j) {
+                scprintf(" %g", ZIN0(j));
+            }
+            scprintf("\n");
+            (unit->mCalcFunc)(unit, unit->mBufLength);
+            scprintf("    out");
+            for (uint32 j = 0; j < unit->mNumOutputs; ++j) {
+                scprintf(" %g", ZOUT0(j));
+            }
+            scprintf("\n");
         }
-        scprintf("\n");
-        (unit->mCalcFunc)(unit, unit->mBufLength);
-        scprintf("    out");
-        for (uint32 j = 0; j < unit->mNumOutputs; ++j) {
-            scprintf(" %g", ZOUT0(j));
-        }
-        scprintf("\n");
     }
+
     inGraph->mNode.mCalcFunc = (NodeCalcFunc)&Graph_Calc;
 }
 

--- a/server/scsynth/SC_Prototypes.h
+++ b/server/scsynth/SC_Prototypes.h
@@ -107,10 +107,10 @@ void Rate_Init(struct Rate* inRate, double inSampleRate, int inBufLength);
 #define GRAPHDEF(inGraph) ((GraphDef*)((inGraph)->mNode.mDef))
 #define GRAPH_PARAM_TABLE(inGraph) (GRAPHDEF(inGraph)->mParamSpecTable)
 
-SCErr Graph_New(World* inWorld, struct GraphDef* def, int32 inID, struct sc_msg_iter* args, struct Graph** outGraph,
-                bool argtype = true);
+SCErr Graph_New(World* inWorld, struct GraphDef* def, int32 inID, int32 blockSize, double upsample,
+                struct sc_msg_iter* args, struct Graph** outGraph, bool argtype = true);
 void Graph_Ctor(World* inWorld, struct GraphDef* inGraphDef, struct Graph* graph, struct sc_msg_iter* msg,
-                bool argtype);
+                int32 blockSize, double upsample, bool argtype);
 void Graph_Dtor(struct Graph* inGraph);
 SCErr Graph_GetControl(struct Graph* inGraph, uint32 inIndex, float& outValue);
 SCErr Graph_GetControl(struct Graph* inGraph, int32 inHash, int32* inName, uint32 inIndex, float& outValue);
@@ -181,7 +181,7 @@ void Group_QueryTreeAndControls(Group* inGroup, big_scpacket* packet);
 
 ////////////////////////////////////////////////////////////////////////
 
-struct Unit* Unit_New(World* inWorld, struct UnitSpec* inUnitSpec, char*& memory);
+struct Unit* Unit_New(World* inWorld, struct Graph* graph, struct UnitSpec* inUnitSpec, char*& memory);
 void Unit_EndCalc(struct Unit* inUnit, int inNumSamples);
 void Unit_End(struct Unit* inUnit);
 

--- a/server/scsynth/SC_Unit.cpp
+++ b/server/scsynth/SC_Unit.cpp
@@ -21,6 +21,7 @@
 
 #include <stdio.h>
 #include "SC_Endian.h"
+#include "SC_Graph.h"
 #include "SC_Unit.h"
 #include "SC_UnitSpec.h"
 #include "SC_UnitDef.h"
@@ -31,7 +32,7 @@
 
 void Unit_ChooseMulAddFunc(Unit* unit);
 
-Unit* Unit_New(World* inWorld, UnitSpec* inUnitSpec, char*& memory) {
+Unit* Unit_New(World* inWorld, Graph* graph, UnitSpec* inUnitSpec, char*& memory) {
     UnitDef* def = inUnitSpec->mUnitDef;
 
     Unit* unit = (Unit*)memory;
@@ -58,8 +59,8 @@ Unit* Unit_New(World* inWorld, UnitSpec* inUnitSpec, char*& memory) {
 
     unit->mCalcRate = inUnitSpec->mCalcRate;
     unit->mSpecialIndex = inUnitSpec->mSpecialIndex;
-    Rate* rateInfo = unit->mRate = inUnitSpec->mRateInfo;
-    unit->mBufLength = rateInfo->mBufLength;
+    unit->mRate = unit->mCalcRate == calc_FullRate ? graph->mFullRate : graph->mBufRate;
+    unit->mBufLength = unit->mRate->mBufLength;
 
     unit->mDone = false;
 

--- a/server/supernova/sc/sc_osc_handler.cpp
+++ b/server/supernova/sc/sc_osc_handler.cpp
@@ -1089,7 +1089,8 @@ static bool node_position_sanity_check(node_position_constraint const& constrain
     return true;
 }
 
-sc_synth* add_synth(const char* name, int node_id, int action, int target_id) {
+sc_synth* add_synth(const char* name, int node_id, int action, int target_id, int block_size = 0,
+                    double upsample = 0.0) {
     if (!check_node_id(node_id))
         return nullptr;
 
@@ -1101,7 +1102,7 @@ sc_synth* add_synth(const char* name, int node_id, int action, int target_id) {
     if (!node_position_sanity_check(pos))
         return nullptr;
 
-    abstract_synth* synth = instance->add_synth(name, node_id, pos);
+    abstract_synth* synth = instance->add_synth(name, node_id, pos, block_size, upsample);
     if (!synth)
         log_printf("Cannot create synth (synthdef: %s, node id: %d)\n", name, node_id);
 
@@ -1255,6 +1256,58 @@ void handle_s_new(ReceivedMessage const& msg) {
         target = 0;
 
     sc_synth* synth = add_synth(def_name, id, action, target);
+
+    if (synth == nullptr)
+        return;
+
+    try {
+        while (args != end)
+            set_control(synth, args, end);
+    } catch (std::exception& e) { log_printf("exception in /s_new: %s\n", e.what()); }
+}
+
+void handle_s_newEx(ReceivedMessage const& msg) {
+    osc::ReceivedMessageArgumentIterator args = msg.ArgumentsBegin(), end = msg.ArgumentsEnd();
+
+    const char* def_name = args->AsString();
+    ++args;
+    int32_t id = args->AsInt32();
+    ++args;
+
+    if (id == -1)
+        id = instance->generate_node_id();
+
+    int32_t action, target;
+
+    if (args != end) {
+        action = args->AsInt32();
+        ++args;
+    } else
+        action = 0;
+
+    if (args != end) {
+        target = args->AsInt32();
+        ++args;
+    } else
+        target = 0;
+
+    int32_t block_size;
+    if (args != end) {
+        block_size = args->AsInt32();
+        ++args;
+    } else {
+        block_size = 0;
+    }
+
+    double upsample;
+    if (args != end) {
+        upsample = args->AsFloat();
+        ++args;
+    } else {
+        upsample = 0.0;
+    }
+
+    sc_synth* synth = add_synth(def_name, id, action, target, block_size, upsample);
 
     if (synth == nullptr)
         return;
@@ -3064,6 +3117,10 @@ void sc_osc_handler::handle_message_int_address(ReceivedMessage const& message, 
         handle_s_new(message);
         break;
 
+    case cmd_s_newEx:
+        handle_s_newEx(message);
+        break;
+
     case cmd_s_noid:
         handle_s_noid(message);
         break;
@@ -3583,6 +3640,11 @@ void dispatch_synth_commands(const char* address, ReceivedMessage const& message
 
     if (strcmp(address + 3, "new") == 0) {
         handle_s_new(message);
+        return;
+    }
+
+    if (strcmp(address + 3, "newEx") == 0) {
+        handle_s_newEx(message);
         return;
     }
 

--- a/server/supernova/sc/sc_plugin_interface.cpp
+++ b/server/supernova/sc/sc_plugin_interface.cpp
@@ -575,7 +575,7 @@ SCBool send_message_to_RT(World* world, struct FifoMsg* msg) {
 namespace nova {
 
 
-inline void initialize_rate(Rate& rate, double sample_rate, int blocksize) {
+void initialize_rate(Rate& rate, double sample_rate, int blocksize) {
     rate.mSampleRate = sample_rate;
     rate.mSampleDur = 1. / sample_rate;
     rate.mRadiansPerSample = 2 * boost::math::constants::pi<double>() / sample_rate;

--- a/server/supernova/sc/sc_plugin_interface.hpp
+++ b/server/supernova/sc/sc_plugin_interface.hpp
@@ -33,6 +33,8 @@
 
 namespace nova {
 
+void initialize_rate(Rate& rate, double sample_rate, int blocksize);
+
 class sc_done_action_handler {
 public:
     void add_pause_node(server_node* node) {

--- a/server/supernova/sc/sc_synth.cpp
+++ b/server/supernova/sc/sc_synth.cpp
@@ -29,8 +29,9 @@
 
 namespace nova {
 
-sc_synth::sc_synth(int node_id, sc_synth_definition_ptr const& prototype): abstract_synth(node_id, prototype) {
-    World const& world = sc_factory->world;
+sc_synth::sc_synth(int node_id, sc_synth_definition_ptr const& prototype, int block_size, double upsample):
+    abstract_synth(node_id, prototype) {
+    World& world = sc_factory->world;
     const bool rt_synthesis = world.mRealTime;
 
     mNode.mWorld = &sc_factory->world;
@@ -45,6 +46,49 @@ sc_synth::sc_synth(int node_id, sc_synth_definition_ptr const& prototype): abstr
 
     localBufNum = 0;
     localMaxBufNum = 0;
+
+    if (block_size == 0 && upsample == 0) {
+        // no reblocking or resampling
+        mNumTicks = 1;
+        mTickCounter = 0;
+    } else {
+        // reblocking and/or upsampling
+        if (upsample > 1.0) {
+            // make sure that 'upsample' is a power of two!
+            if (ispoweroftwo((int)upsample)) {
+                upsample = (int)upsample;
+                mFlags |= kGraph_Resample; // ok
+            } else {
+                log_printf("WARNING: Synth: upsample factor (%f) not a power of two\n", upsample);
+                upsample = 1.0;
+            }
+        } else if (upsample < 1.0) {
+            if (upsample > 0.0) {
+                log_printf("WARNING: Synth: downsampling (%f) not supported (yet)\n", upsample);
+            }
+            upsample = 1.0;
+        }
+
+        if (block_size > 0) {
+            // block size cannot be larger than wire buffer size (yet)!
+            if (block_size > world.mBufLength) {
+                log_printf("WARNING: Synth: block size (%d) cannot be larger than Server "
+                           "block size (%d)\n",
+                           block_size, world.mBufLength);
+                block_size = world.mBufLength;
+            } else if (!ispoweroftwo(block_size)) {
+                log_printf("WARNING: Synth: block size (%d) not a power of two\n", block_size);
+                block_size = world.mBufLength;
+            } else {
+                mFlags |= kGraph_Reblock; // ok
+            }
+        } else {
+            block_size = world.mBufLength;
+        }
+
+        mNumTicks = (world.mBufLength / block_size) * upsample;
+        mTickCounter = 0;
+    }
 
     // so far mPrivate is only used for queued unit commands,
     // i.e. it just points to the head of the list.
@@ -61,10 +105,12 @@ sc_synth::sc_synth(int node_id, sc_synth_definition_ptr const& prototype): abstr
     const size_t wire_buffer_alignment = 64 * 8; // align to cache line boundaries
     const size_t alloc_size = prototype->memory_requirement();
 
+    const size_t rate_alloc_size = mFlags & kGraph_ReblockOrResample ? sizeof(Rate) * 2 : 0;
+
     const size_t sample_alloc_size =
         world.mBufLength * synthdef.buffer_count + wire_buffer_alignment /* for alignment */;
 
-    const size_t total_alloc_size = alloc_size + sample_alloc_size * sizeof(sample);
+    const size_t total_alloc_size = alloc_size + rate_alloc_size + sample_alloc_size * sizeof(sample);
 
     char* raw_chunk = rt_synthesis ? (char*)rt_pool.malloc(total_alloc_size) : (char*)malloc(total_alloc_size);
 
@@ -74,6 +120,7 @@ sc_synth::sc_synth(int node_id, sc_synth_definition_ptr const& prototype): abstr
     linear_allocator allocator(raw_chunk);
 
     /* prepare controls */
+    /* NB: mControls must be allocated first, see sc_synth::finalize()! */
     mNumControls = parameter_count;
     mControls = allocator.alloc<float>(parameter_count);
     mControlRates = allocator.alloc<int>(parameter_count);
@@ -86,6 +133,21 @@ sc_synth::sc_synth(int node_id, sc_synth_definition_ptr const& prototype): abstr
         mMapControls[i] = &mControls[i]; /* map to control values */
         mControlRates[i] = 0; /* init to 0*/
         mAudioBusOffsets[i] = -1; /* init to -1: not mapped to an audio bus yet */
+    }
+
+    /* allocate and init Rates */
+    if (rate_alloc_size > 0) {
+        /* reblocking and/or resampling */
+        mFullRate = allocator.alloc<Rate>();
+        mBufRate = allocator.alloc<Rate>();
+
+        double sampleRate = world.mSampleRate * upsample;
+        initialize_rate(*mFullRate, sampleRate, block_size);
+        initialize_rate(*mBufRate, sampleRate / block_size, 1);
+    } else {
+        /* use Server block size and sample rate */
+        mFullRate = &world.mFullRate;
+        mBufRate = &world.mBufRate;
     }
 
     /* allocate constant wires */

--- a/server/supernova/sc/sc_synth.cpp
+++ b/server/supernova/sc/sc_synth.cpp
@@ -51,6 +51,7 @@ sc_synth::sc_synth(int node_id, sc_synth_definition_ptr const& prototype, int bl
         // no reblocking or resampling
         mNumTicks = 1;
         mTickCounter = 0;
+        block_size = world.mBufLength;
     } else {
         // reblocking and/or upsampling
         if (upsample > 1.0) {
@@ -107,8 +108,7 @@ sc_synth::sc_synth(int node_id, sc_synth_definition_ptr const& prototype, int bl
 
     const size_t rate_alloc_size = mFlags & kGraph_ReblockOrResample ? sizeof(Rate) * 2 : 0;
 
-    const size_t sample_alloc_size =
-        world.mBufLength * synthdef.buffer_count + wire_buffer_alignment /* for alignment */;
+    const size_t sample_alloc_size = block_size * synthdef.buffer_count + wire_buffer_alignment; /* for alignment */
 
     const size_t total_alloc_size = alloc_size + rate_alloc_size + sample_alloc_size * sizeof(sample);
 

--- a/server/supernova/sc/sc_synth_definition.cpp
+++ b/server/supernova/sc/sc_synth_definition.cpp
@@ -104,8 +104,8 @@ sc_synth_definition::sc_synth_definition(sc_synthdef&& sd):
 }
 
 
-abstract_synth* sc_synth_definition::create_instance(int node_id) {
-    sc_synth* synth = new sc_synth(node_id, this);
+abstract_synth* sc_synth_definition::create_instance(int node_id, int block_size, double upsample) {
+    sc_synth* synth = new sc_synth(node_id, this, block_size, upsample);
     return synth;
 }
 

--- a/server/supernova/sc/sc_synth_definition.hpp
+++ b/server/supernova/sc/sc_synth_definition.hpp
@@ -40,7 +40,7 @@ public:
 private:
     friend class sc_synth;
 
-    virtual abstract_synth* create_instance(int) override;
+    virtual abstract_synth* create_instance(int, int, double) override;
 };
 
 typedef boost::intrusive_ptr<sc_synth_definition> sc_synth_definition_ptr;

--- a/server/supernova/sc/sc_ugen_factory.cpp
+++ b/server/supernova/sc/sc_ugen_factory.cpp
@@ -51,7 +51,7 @@ std::unique_ptr<sc_ugen_factory> sc_factory;
 
 Unit* sc_ugen_def::construct(sc_synthdef::unit_spec_t const& unit_spec, sc_synth* parent, int parentIndex, World* world,
                              linear_allocator& allocator) {
-    const int buffer_length = world->mBufLength;
+    const int buffer_length = parent->mFullRate->mBufLength;
 
     const size_t output_count = unit_spec.output_specs.size();
 
@@ -79,10 +79,10 @@ Unit* sc_ugen_def::construct(sc_synthdef::unit_spec_t const& unit_spec, sc_synth
     /* initialize members from synth */
     unit->mParent = static_cast<Graph*>(parent);
     unit->mParentIndex = parentIndex;
-    if (unit_spec.rate == 2)
-        unit->mRate = &world->mFullRate;
+    if (unit_spec.rate == calc_FullRate)
+        unit->mRate = parent->mFullRate;
     else
-        unit->mRate = &world->mBufRate;
+        unit->mRate = parent->mBufRate;
 
     unit->mBufLength = unit->mRate->mBufLength;
 

--- a/server/supernova/sc/sc_ugen_factory.cpp
+++ b/server/supernova/sc/sc_ugen_factory.cpp
@@ -98,7 +98,7 @@ Unit* sc_ugen_def::construct(sc_synthdef::unit_spec_t const& unit_spec, sc_synth
         w->mBuffer = nullptr;
         w->mScalarValue = 0;
 
-        if (unit->mCalcRate == 2) {
+        if (unit->mCalcRate == calc_FullRate) {
             /* allocate a new buffer */
             assert(unit_spec.buffer_mapping[i] >= 0);
             std::size_t buffer_id = unit_spec.buffer_mapping[i];

--- a/server/supernova/server/server.cpp
+++ b/server/supernova/server/server.cpp
@@ -127,8 +127,9 @@ void nova_server::perform_node_add(server_node* node, node_position_constraint c
     notification_node_started(node);
 }
 
-abstract_synth* nova_server::add_synth(const char* name, int id, node_position_constraint const& constraints) {
-    abstract_synth* ret = synth_factory::create_instance(name, id);
+abstract_synth* nova_server::add_synth(const char* name, int id, node_position_constraint const& constraints,
+                                       int block_size, double upsample) {
+    abstract_synth* ret = synth_factory::create_instance(name, id, block_size, upsample);
     if (ret == nullptr)
         return nullptr;
 

--- a/server/supernova/server/server.hpp
+++ b/server/supernova/server/server.hpp
@@ -166,7 +166,8 @@ public:
 public:
     /* @{ */
     /** node control */
-    abstract_synth* add_synth(const char* name, int id, node_position_constraint const& constraints);
+    abstract_synth* add_synth(const char* name, int id, node_position_constraint const& constraints, int block_size,
+                              double upsample);
     group* add_group(int id, node_position_constraint const& constraints);
     parallel_group* add_parallel_group(int id, node_position_constraint const& constraints);
 

--- a/server/supernova/server/synth_definition.hpp
+++ b/server/supernova/server/synth_definition.hpp
@@ -149,7 +149,7 @@ public:
 
     virtual ~synth_definition(void) = default;
 
-    virtual abstract_synth* create_instance(int node_id) = 0;
+    virtual abstract_synth* create_instance(int node_id, int block_size, double upsample) = 0;
 
     template <typename synth_t> static inline synth_t* allocate(void);
 };

--- a/server/supernova/server/synth_factory.hpp
+++ b/server/supernova/server/synth_factory.hpp
@@ -41,12 +41,12 @@ public:
         definition_map.insert(*ptr.get());
     }
 
-    abstract_synth* create_instance(const char* name, int node_id) {
+    abstract_synth* create_instance(const char* name, int node_id, int block_size, double upsample) {
         prototype_map_type::iterator it = definition_map.find(name, named_hash_hash(), named_hash_equal());
         if (it == definition_map.end())
             return nullptr;
 
-        return it->create_instance(node_id);
+        return it->create_instance(node_id, block_size, upsample);
     }
 
     void remove_definition(const char* name) {

--- a/testsuite/server/supernova/server_synth_factory_test.cpp
+++ b/testsuite/server/supernova/server_synth_factory_test.cpp
@@ -11,7 +11,9 @@ namespace {
 struct test_synth_definition : public synth_definition {
     test_synth_definition(): synth_definition(symbol("foo")) {}
 
-    abstract_synth* create_instance(int node_id) { return new test_synth(node_id, this); }
+    abstract_synth* create_instance(int node_id, int block_size, double upsample) {
+        return new test_synth(node_id, this);
+    }
 };
 }
 
@@ -22,7 +24,7 @@ BOOST_AUTO_TEST_CASE(synth_factory_test_1) {
 
     sf.register_definition(new test_synth_definition);
 
-    unique_ptr<abstract_synth> s(sf.create_instance("foo", 1));
+    unique_ptr<abstract_synth> s(sf.create_instance("foo", 1, 0, 0.0));
 
     BOOST_REQUIRE(s.get() != 0);
 }


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

This PR allows Synths to run at different block sizes or samplerates. This enables two important techniques that haven't been possible so far:
- tight feedback loops, down to a single sample
- upsampling + filtering to remove/reduce aliasing, e.g. for distortion, hard-syncing, osciallators and any other type of synthesis that is prone to aliasing

---

### For users

`Synth.new` (and similar methods) have two additional arguments:
- `blockSize`: the block size (`nil`: Server block size); can not be larger than the Server block size!
- `upsample`: the upsampling factor (`nil`: no upsampling); must be a power of two.
  (In the future we might also support downsampling, that's why the argument is a floating point number.)

Here are two practical examples:
```sc
// test 1 sample delay
(
SynthDef(\delay, { |out|
    var source, local;

    source = Decay.ar(Impulse.ar(2), 0.1) * WhiteNoise.ar(0.2);
    local = LocalIn.ar(2) + [source, 0]; // read feedback, add to source
	local = DelayC.ar(local, 0.5, MouseX.kr.pow(2) * 0.5); // delay sound

    // reverse channels to give ping pong effect, apply decay factor
	LocalOut.ar(local.reverse * MouseY.kr.pow(0.5).clip(0, 0.999));

	Out.ar(out, local);
}).add
)

Synth(\delay); // min. delay length: Server block size
Synth(\delay, blockSize: 16); // min. delay length: 16 samles
Synth(\delay, blockSize: 1); // min. delay length: 1 sample

// test upsampling + anti-aliasing
(
SynthDef(\hardsync, { |out|
	var cutoff = 18000;
	var sig = SyncSaw.ar(MouseY.kr(1, 1000, 2), MouseX.kr(100, 4000, 2));
	sig = LPF.ar(sig, cutoff);
	sig = LPF.ar(sig, cutoff);
	Out.ar(out, sig * 0.05 ! 2);
}).add;
)

// lots of aliasing
Synth(\hardsync); 
// watch aliasing disappear with increasing upsampling factors
Synth(\hardsync, upsample: 2.0);
Synth(\hardsync, upsample: 4.0);
Synth(\hardsync, upsample: 8.0);
```

---

### For plugin authors

On the implementation side, this adds new `mBufRate` and `mFullRate` members to `Graph`. For "normal" Synths, these just point to the global `Rate` members in `World`. If the Synth is reblocking and/or upsampling, it has its own `Rate` instances.

UGens "just work" as long as they consistently use the `SAMPLERATE`, `BUFLENGTH`, `FULLRATE`, `FULLBUFLENGTH` etc. macros in `SC_Unit.h` resp. the corresponding C++ methods in `SC_Plugin.hpp`, because they now refer to the Graph's rates instead of the global World rates.

The only UGens that need to aware of reblocking and upsampling are I/O UGens because they are responsible for reblocking/resampling when reading from / writing to Busses. (Actually, this applies to all UGens that use Busses, but there are very few third-party plugins that do, as far as I am aware.)

---

**NOTE**: this feature requires a break in the plugin API. I have bumped the plugin API version in this PR to make sure that existing third-party plugins are not loaded, as they would not behave correctly in reblocked/upsampled Synths. In the end, this has to be coordinated with other PRs that would also require a plugin API break. See also this meta-issue: https://github.com/supercollider/supercollider/issues/6102

---

### Testing

It would be great if you could test this PR by running your existing SynthDefs at different combinations of block sizes and upsampling factors and check if they still work/sound as expected.

Here are two important guide lines to avoid false positives:

- the Synth sounds different at lower block sizes -> please check that this isn't also the case when setting the global Server block size to the same value (ideally with the official SC build)
- the Synth sounds different when upsampled -> please check that this isn't also the case when running the Server at the corresponding global sample rate  (ideally with the official SC build)

UGens might behave weirdly in a reblocked/upsampled Synth, but they should never crash the Server.

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->

- New feature
- Breaking change

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [ ] Code is tested
- [ ] All tests are passing
- [ ] Updated documentation
- [ ] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
