### PR TITLE
Opportunities to link to `File` and `PathName` in Docs

### DIFF
--- a/HelpSource/Classes/Buffer.schelp
+++ b/HelpSource/Classes/Buffer.schelp
@@ -117,7 +117,7 @@ Allocate a buffer and immediately read a soundfile into it. This method sends a 
 argument:: server
 The server on which to allocate the buffer.
 argument:: path
-A String representing the path of the soundfile to be read.
+An instance of link::Classes/String:: representing the path of the soundfile to be read. For path handling and management, see link::Classes/File:: and link::Classes/PathName::
 argument:: startFrame
 The first frame of the soundfile to read. The default is 0, which is the beginning of the file.
 argument:: numFrames
@@ -161,7 +161,7 @@ As link::#*read:: above, but takes an link::Classes/Array:: of channel indices t
 argument:: server
 The server on which to allocate the buffer.
 argument:: path
-A String representing the path of the soundfile to be read.
+An instance of link::Classes/String:: representing the path of the soundfile to be read. For path handling and management, see link::Classes/File:: and link::Classes/PathName::.
 argument:: startFrame
 The first frame of the soundfile to read. The default is 0, which is the beginning of the file.
 argument:: numFrames
@@ -475,7 +475,7 @@ method:: duration
 Returns code::this.numFrames / this.sampleRate:: (language-side instance variables).
 
 method:: path
-Returns a string containing the path of a soundfile that has been loaded into the corresponding server-side buffer.
+Returns a link::Classes/String:: containing the path of a soundfile that has been loaded into the corresponding server-side buffer.
 
 
 subsection:: Explicit allocation
@@ -489,7 +489,7 @@ A valid OSC message or a Function which will return one. A Function will be pass
 method:: allocRead, allocReadMsg
 Read a soundfile into a buffer on the server for a Buffer previously created with link::#*new::. Note that this will not autoupdate instance variables. Call code::updateInfo:: in order to do this.
 argument:: argpath
-A String representing the path of the soundfile to be read.
+A link::Classes/String:: representing the path of the soundfile to be read.
 argument:: startFrame
 The first frame of the soundfile to read. The default is 0, which is the beginning of the file. (A floating-point value is truncated to integer.)
 argument:: numFrames
@@ -508,7 +508,7 @@ x.free; b.free;
 method:: allocReadChannel, allocReadChannelMsg
 As link::#-allocRead:: above, but allows you to specify which channels to read.
 argument:: argpath
-A String representing the path of the soundfile to be read.
+A link::Classes/String:: representing the path of the soundfile to be read.
 argument:: startFrame
 The first frame of the soundfile to read. The default is 0, which is the beginning of the file. (A floating-point value is truncated to integer.)
 argument:: numFrames
@@ -532,7 +532,7 @@ subsection:: Other methods
 method:: read
 Read a soundfile into an already allocated buffer.
 argument:: argpath
-A String representing the path of the soundfile to be read.
+A link::Classes/String:: representing the path of the soundfile to be read.
 argument:: fileStartFrame
 The first frame of the soundfile to read. The default is 0, which is the beginning of the file. (A floating-point value is truncated to integer.)
 argument:: numFrames
@@ -556,7 +556,7 @@ Note that if the number of frames in the file is greater than the number of fram
 method:: readChannel
 As link::#-read:: above, but allows you to specify which channels to read.
 argument:: argpath
-A String representing the path of the soundfile to be read.
+A link::Classes/String:: representing the path of the soundfile to be read.
 argument:: fileStartFrame
 The first frame of the soundfile to read. The default is 0, which is the beginning of the file. (A floating-point value is truncated to integer.)
 argument:: numFrames
@@ -579,7 +579,7 @@ method:: readChannelMsg
 method:: cueSoundFile, cueSoundFileMsg
 A convenience method to cue a soundfile into the buffer for use with a link::Classes/DiskIn::. The buffer must have been allocated with a multiple of (2 * the server's block size) frames.  A common size is 32768 frames.
 argument:: path
-A String representing the path of the soundfile to be read.
+An instance of link::Classes/String:: representing the path of the soundfile to be read. For path handling and management, see link::Classes/File:: and link::Classes/PathName::
 argument:: startFrame
 The first frame of the soundfile to read. The default is 0, which is the beginning of the file. (A floating-point value is truncated to integer.)
 argument:: completionMessage
@@ -600,12 +600,12 @@ x.free; b.close; b.free;
 method:: write, writeMsg
 Write the contents of the buffer to a file. See link::Classes/SoundFile:: for information on valid values for headerFormat and sampleFormat.
 argument:: path
-A String representing the path of the soundfile to be written.
+An instance of link::Classes/String:: representing the path of the soundfile to be written. For path handling and management, see link::Classes/File:: and link::Classes/PathName::
 If no path is given, Buffer writes into the default recording directory with a generic name.
 argument:: headerFormat
-A String.
+A link::Classes/String::.
 argument:: sampleFormat
-A String.
+A link::Classes/String::.
 argument:: numFrames
 The number of frames to write. The default is -1, which will write the whole buffer. (A floating-point value is truncated to integer.)
 argument:: startFrame
@@ -911,7 +911,7 @@ These correspond to the various b_gen OSC Commands, which fill the buffer with v
 method:: gen, genMsg
 This is a generalized version of the commands below.
 argument:: genCommand
-A String indicating the name of the command to use. See Server-Command-Reference for a list of valid command names.
+A link::Classes/String:: indicating the name of the command to use. See Server-Command-Reference for a list of valid command names.
 argument:: genArgs
 An Array containing the corresponding arguments to the command.
 argument:: normalize

--- a/HelpSource/Classes/Dialog.schelp
+++ b/HelpSource/Classes/Dialog.schelp
@@ -21,8 +21,8 @@ METHOD:: openPanel
 	ARGUMENT:: multipleSelection
 		A Boolean indicating whether multiple files can be selected.
 	ARGUMENT:: path
-		A string. The dialog will initially display the contents of this path. The default is the current
-		user's home directory.
+		A link::Classes/String::. The dialog will initially display the contents of this path. The default is the current
+		user's home directory. For path handling and management, see link::Classes/File:: and link::Classes/PathName::.
 	DISCUSSION::
 	Example:
 code::
@@ -43,8 +43,8 @@ METHOD:: savePanel
 	ARGUMENT:: cancelFunc
 		An object to be evaluated when Cancel is pressed.
 	ARGUMENT:: path
-		A string. The dialog will initially display the contents of this path. The default is the current
-		user's home directory.
+		A link::Classes/String::. The dialog will initially display the contents of this path. The default is the current
+		user's home directory. For path handling and management, see link::Classes/File:: and link::Classes/PathName::.
 	DISCUSSION::
 	Example:
 code::

--- a/HelpSource/Classes/Document.schelp
+++ b/HelpSource/Classes/Document.schelp
@@ -36,7 +36,7 @@ Document.new("this is the title", "this is the text");
 method:: open
 Open a document from a path.
 argument:: path
-The file system path to the document. An instance of link::Classes/String::. An instance of link::Classes/String::. For path handling and management, see link::Classes/File:: and link::Classes/PathName::.
+An instance of link::Classes/String:: indicating the files system path to the document. For path handling and management, see link::Classes/File:: and link::Classes/PathName::.
 argument:: selectionStart
 The beginning of the cursor selection of the file content.
 argument:: selectionLength
@@ -114,7 +114,7 @@ Utilities and settings for dealing with documents such as SuperCollider code fil
 method:: dir
 Get/set the default document directory. The default is dependent on link::#*implementationClass::.
 argument:: path
-The file system path to the directory. An instance of link::Classes/String::.
+An instance of link::Classes/String:: indicating the file system path to the directory.  For path handling and management, see link::Classes/File:: and link::Classes/PathName::.
 discussion::
 In Main-startUp you can set this to a more practical directory:
 code::
@@ -123,7 +123,7 @@ Document.dir = "~/Documents/SuperCollider";
 
 method:: standardizePath
 argument:: p
-The file system path to the directory. An instance of link::Classes/String::.
+An instance of link::Classes/String:: indicating the file system path to the directory.
 discussion::
 If it is a relative path, expand it to an absolute path relative to your document directory. Expand tildes in path (your home directory), resolve symbolic links (but not aliases). Also converts from Mac OS 9 path format. See PathName for more complex needs.
 code::
@@ -142,7 +142,7 @@ Document.standardizePath("Patches/newfoots/fastRuckAndTuck")
 method:: abrevPath
 Returns a path relative to Document.dir, if the path is inside Document.dir.
 argument:: path
-The file system path to the directory. An instance of link::Classes/String::.
+An instance of link::Classes/String:: indicating the file system path to the directory.
 
 
 

--- a/HelpSource/Classes/Document.schelp
+++ b/HelpSource/Classes/Document.schelp
@@ -36,7 +36,7 @@ Document.new("this is the title", "this is the text");
 method:: open
 Open a document from a path.
 argument:: path
-The file system path to the document. An instance of link::Classes/String::.
+The file system path to the document. An instance of link::Classes/String::. An instance of link::Classes/String::. For path handling and management, see link::Classes/File:: and link::Classes/PathName::.
 argument:: selectionStart
 The beginning of the cursor selection of the file content.
 argument:: selectionLength


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

I noticed a few places where help information about a `path` argument just said "A String". I think it is good to include a link to `link::Classes/PathName::` and `link::Classes/File::` since those are useful classes for dealing with `path`s. There are likely more opportunities in the help for this to happen. Perhaps in a forthcoming help styleguide this can be included.

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->

- Documentation

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [ ] Code is tested
- [ ] All tests are passing
- [ ] Updated documentation
- [ ] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
