### PR TITLE
scsynth: Buffer: Implementation of setSampleRate (a sampleRate setter)

### DIFF
--- a/HelpSource/Classes/Buffer.schelp
+++ b/HelpSource/Classes/Buffer.schelp
@@ -466,14 +466,20 @@ Returns the number of channels in the corresponding server-side buffer.
 method:: sampleRate
 Returns the language-side instance variable code::sampleRate::, of the corresponding server-side buffer. By default, this will be set to the server's sample rate when the code::Buffer:: is instantiated.
 
-The code::sampleRate:: setter method only changes the language-side instance variable. It does not resample the buffer or change its sample rate on the server.
-However, it can be useful, for example, for later inferring whether audio-rate or control-rate data has been writen to the buffer.
+The code::sampleRate:: setter method only changes the language-side instance variable. It does not resample the buffer or change its sample rate on the server. To change the server-side buffer sample rate, use code::setSampleRate::.
 note::
 Setting the code::sampleRate:: instance variable affects the returned link::#-duration:: (which returns code::numFrames / sampleRate::).
 ::
 warning::
 You can use link::#-query:: to inspect the buffer's sample rate on the server, but this will also emphasis::update the:: code::sampleRate:: emphasis::instance variable::, overwriting its value which you may have previously set.
 ::
+
+
+method:: setSampleRate
+Sets the sample rate of the buffer on the server side, and updates its value on the language side. This does not resample the audio.
+argument:: value
+The new desired sample rate.
+
 
 method:: duration
 Returns code::this.numFrames / this.sampleRate:: (language-side instance variables).

--- a/HelpSource/Reference/Server-Command-Reference.schelp
+++ b/HelpSource/Reference/Server-Command-Reference.schelp
@@ -720,6 +720,14 @@ table::
 ::
 Set contiguous ranges of sample indices to sets of values. For each range, the starting sample index is given followed by the number of samples to change, followed by the values.
 
+subsection:: /b_setSampleRate
+Set the sampling rate of the buffer.
+table::
+## strong::int:: || buffer number
+## strong::float:: || the desired sampling rate
+::
+Set the sampling rate of the buffer.
+
 subsection:: /b_fill
 Fill ranges of sample value(s).
 table::
@@ -1130,8 +1138,12 @@ enum {
 
     cmd_version = 64,
 
-    NUMBER_OF_COMMANDS = 65
-};
+    cmd_rtMemoryStatus = 65,
+    
+    cmd_b_setSampleRate = 66,
+    
+    NUMBER_OF_COMMANDS = 67
+    };
 ::
 
 copyright © 2002 James McCartney

--- a/SCClassLibrary/Common/Control/Buffer.sc
+++ b/SCClassLibrary/Common/Control/Buffer.sc
@@ -595,6 +595,17 @@ Buffer {
 		^[\b_query, bufnum]
 	}
 
+	setSampleRate { arg value;
+		// sends the message first to check sanity of sr before changing the langage-side instance variable
+		server.listSendMsg(this.setSampleRateMsg(value));
+		sampleRate = value !? _.asFloat;
+    }
+
+	setSampleRateMsg { arg value;
+		if(bufnum.isNil) { Error("Cannot change the sample rate of a % that has been freed".format(this.class.name)).throw };
+		^[\b_setSampleRate, bufnum, value !? _.asFloat ?? 0.0]
+	}
+
 	updateInfo { arg action;
 		// add to the array here. That way, update will be accurate even if this buf
 		// has been freed

--- a/include/server/SC_OSC_Commands.h
+++ b/include/server/SC_OSC_Commands.h
@@ -117,5 +117,7 @@ enum {
 
     cmd_rtMemoryStatus = 65,
 
-    NUMBER_OF_COMMANDS = 66
+    cmd_b_setSampleRate = 66,
+
+    NUMBER_OF_COMMANDS = 67
 };

--- a/server/supernova/sc/sc_osc_handler.cpp
+++ b/server/supernova/sc/sc_osc_handler.cpp
@@ -2493,6 +2493,22 @@ void handle_b_setn(ReceivedMessage const& msg) {
     }
 }
 
+void handle_b_setSampleRate(ReceivedMessage const& msg) {
+    osc::ReceivedMessageArgumentIterator it = msg.ArgumentsBegin();
+    osc::ReceivedMessageArgumentIterator end = msg.ArgumentsEnd();
+    verify_argument(it, end);
+    osc::int32 buffer_index = it->AsInt32();
+    ++it;
+
+    SndBuf* buf = sc_factory->get_buffer_struct(buffer_index);
+    if (!buf) {
+        log_printf("/b_setSampleRate called on unallocated buffer\n");
+        return;
+    }
+
+    buf->samplerate = it->AsFloat();
+    buf->sampledur = 1.0 / buf->samplerate;
+}
 void handle_b_fill(ReceivedMessage const& msg) {
     osc::ReceivedMessageArgumentIterator it = msg.ArgumentsBegin();
     osc::ReceivedMessageArgumentIterator end = msg.ArgumentsEnd();
@@ -3162,6 +3178,10 @@ void sc_osc_handler::handle_message_int_address(ReceivedMessage const& message, 
         handle_b_setn(message);
         break;
 
+    case cmd_b_setSampleRate:
+        handle_b_setSampleRate(message);
+        break;
+
     case cmd_b_fill:
         handle_b_fill(message);
         break;
@@ -3409,6 +3429,11 @@ void dispatch_buffer_commands(const char* address, ReceivedMessage const& messag
 
     if (strcmp(address + 3, "setn") == 0) {
         handle_b_setn(message);
+        return;
+    }
+
+    if (strcmp(address + 3, "setSampleRate") == 0) {
+        handle_b_setSampleRate(message);
         return;
     }
 


### PR DESCRIPTION
## Purpose and Motivation

The sampleRate method in the language was not updating the server side, which was a lost opportunity, as extensively discussed in both the [forum](https://scsynth.org/t/how-to-change-a-buffers-samplerate-everywhere/10379/15) and  bug report #6543 . After much considerations, it seems that it was worth implementing, as it would afford new creative coding opportunities without any backward compatibility issues.

## Types of changes

- Documentation
- Bug fix
- New feature

## To-do list

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review 
