### PR TITLE
plugins: fix regression in LocalIn

### DIFF
--- a/server/plugins/IOUGens.cpp
+++ b/server/plugins/IOUGens.cpp
@@ -1516,8 +1516,8 @@ void LocalIn_next_a(LocalIn* unit, int inNumSamples) {
         // Print("LocalIn  %d  %d  %g\n", i, diff, in[0]);
         if (diff == 1 || diff == 0)
             Copy(inNumSamples, out, in);
-        else
-            Clear(inNumSamples, out);
+        else // get default value from UGen input
+            Fill(inNumSamples, out, IN0(i));
     }
 }
 
@@ -1537,9 +1537,8 @@ FLATTEN void LocalIn_next_a_nova(LocalIn* unit, int inNumSamples) {
         // Print("LocalIn  %d  %d  %g\n", i, diff, in[0]);
         if (diff == 1 || diff == 0)
             nova::copyvec_simd(out, in, inNumSamples);
-        else
-            // nova::zerovec_simd(out, inNumSamples);
-            Clear(inNumSamples, out);
+        else // get default value from UGen input
+            Fill(inNumSamples, out, IN0(i));
     }
 }
 
@@ -1557,9 +1556,8 @@ FLATTEN void LocalIn_next_a_nova_64(LocalIn* unit, int inNumSamples) {
         // Print("LocalIn  %d  %d  %g\n", i, diff, in[0]);
         if (diff == 1 || diff == 0)
             nova::copyvec_simd<64>(out, in);
-        else
-            // nova::zerovec_simd<64>(out);
-            Clear(inNumSamples, out);
+        else // get default value from UGen input
+            Fill(inNumSamples, out, IN0(i));
     }
 }
 #endif
@@ -1575,8 +1573,8 @@ void LocalIn_next_k(LocalIn* unit, int inNumSamples) {
         int diff = bufCounter - touched[i];
         if (diff == 1 || diff == 0)
             OUT0(i) = in[i];
-        else
-            OUT0(i) = 0.f;
+        else // get default value from UGen input
+            OUT0(i) = IN0(i);
     }
 }
 


### PR DESCRIPTION
LocalIn takes the default values from its UGen inputs instead of just outputting zero!

Fixes a regression introduced by https://github.com/supercollider/supercollider/commit/8401e8633140b603573c418e4c99489951b3c284

<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
