### PR TITLE
Classlib: PlotView.sc: ArrayedCollection.plot should convert wavetables to Signals before passing to Plotter

### DIFF
--- a/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
+++ b/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
@@ -1312,18 +1312,11 @@ Plotter {
 
 		numChannels !? { array = array.unlace(numChannels) };
 		array = array.collect {|elem, i|
-			if (elem.isKindOf(Env)) {
-				elem.asMultichannelSignal.flop
-			} {
-				if(elem.isNil) {
-					Error("Cannot plot array: non-numeric value at index %".format(i)).throw
-				};
-				if(hasSubArrays) {
-					elem.asArray
-				} {
-					elem
-				}
-			}
+			case {elem.isKindOf(Env)}		{elem.asMultichannelSignal.flop}
+				 {elem.isKindOf(Wavetable)} {elem.asSignal}
+				 {elem.isNil}				{Error("Cannot plot array: non-numeric value at index %".format(i)).throw}
+  				 {hasSubArrays}				{elem.asArray} 
+			  	 {elem};
 		};
 
 		plotter.setValue(


### PR DESCRIPTION
Wavetable.plot internally calls Wavetable.asSignal.plot because Wavetables have a special format. The case of Arrays of Wavetables was overlooked, this commit fixes that.
Also replaces the nested ifs with case for clearer conditional structure. 

## Purpose and Motivation

Old behavior:
```
u = Wavetable.sineFill(1024, [1]);
u.plot; //single Wavetable works fine (picture on left)
u.dup(2).plot; //array of wavetables doesn't. (picture on right).
```
![Capture d’écran, le 2025-04-11 à 12 30 10](https://github.com/user-attachments/assets/58d58127-5580-4660-b48c-97b0f7e4d8a5)

New behavior: The expected one (i.e., sines not zigzags back and forth to 0).

## Types of changes

- Bug fix

Tested with all the examples from https://github.com/supercollider/supercollider/pull/6566 to ensure I didn't break anything by rearranging the conditional.


- [x] Code is tested
- [x] All tests are passing
- [x] This PR is ready for review


Noticed along the way: superpose doesn't work with Arrays of envelopes. Is this known behavior? 

