### PR TITLE
Add documentation about wayland incompatibility of keyboard/mouse UGens

### DIFF
--- a/HelpSource/Classes/KeyState.schelp
+++ b/HelpSource/Classes/KeyState.schelp
@@ -13,6 +13,12 @@ helpful to select a GUI window rather than an SC document when using
 KeyState, as the latter will be altered by any keystrokes.
 ::
 
+WARNING::
+This UGen will not work for Linux users using Wayland, as the Wayland protocol does not allow a global keyboard or mouse state to be captured.
+The UGen will return MATH::0.0:: as constant value.
+For more information see https://github.com/supercollider/supercollider/issues/4544
+::
+
 classmethods::
 
 method::kr

--- a/HelpSource/Classes/MouseButton.schelp
+++ b/HelpSource/Classes/MouseButton.schelp
@@ -8,6 +8,11 @@ Description::
 
 Mouse button UGen.
 
+WARNING::
+This UGen will not work for Linux users using Wayland, as the Wayland protocol does not allow a global keyboard or mouse state to be captured.
+The UGen will return MATH::0.0:: as constant value.
+For more information see https://github.com/supercollider/supercollider/issues/4544
+::
 
 classmethods::
 

--- a/HelpSource/Classes/MouseX.schelp
+++ b/HelpSource/Classes/MouseX.schelp
@@ -8,6 +8,11 @@ Description::
 
 Cursor tracking UGen.
 
+WARNING::
+This UGen will not work for Linux users using Wayland, as the Wayland protocol does not allow a global keyboard or mouse state to be captured.
+The UGen will return a constant random value between MATH::0.0:: and MATH::1.0::.
+For more information see https://github.com/supercollider/supercollider/issues/4544
+::
 
 classmethods::
 

--- a/HelpSource/Classes/MouseY.schelp
+++ b/HelpSource/Classes/MouseY.schelp
@@ -8,6 +8,11 @@ Description::
 
 Cursor tracking UGen.
 
+WARNING::
+This UGen will not work for Linux users using Wayland, as the Wayland protocol does not allow a global keyboard or mouse state to be captured.
+The UGen will return a constant random value between MATH::0.0:: and MATH::1.0::.
+For more information see https://github.com/supercollider/supercollider/issues/4544
+::
 
 classmethods::
 


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

Based on testing on Fedora 41 (Kernel 6.13.0) using Gnome 47 w/ Wayland.

Documents the status of https://github.com/supercollider/supercollider/issues/4544#top and also as requested in the forum , e.g. @ https://scsynth.org/t/mousex-mousey-not-working-on-rpi5/11376/6?u=dscheiba


## Types of changes

- Documentation

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Updated documentation


<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
