### PR TITLE
Change class name `BufferExamplesPath` to `ExampleFiles`

### DIFF
--- a/HelpSource/Classes/Buffer.schelp
+++ b/HelpSource/Classes/Buffer.schelp
@@ -1,7 +1,7 @@
 class:: Buffer
 summary:: Client-side representation of a buffer on a server
 categories:: Server>Abstractions
-related:: Classes/BufferExamplesPath
+related:: Classes/ExampleFiles
 
 description::
 

--- a/HelpSource/Classes/ExampleFiles.schelp
+++ b/HelpSource/Classes/ExampleFiles.schelp
@@ -1,4 +1,4 @@
-TITLE:: BufferExamplesPath
+TITLE:: ExampleFiles
 summary:: A shortcut to example sounds bundled with SuperCollider
 categories:: Files
 related:: Classes/Buffer, Classes/Soundfile
@@ -10,7 +10,7 @@ CODE::
 // instead of writing
 Platform.resourceDir +/+ "sounds" +/+ "a11wlk01-44_1.aiff";
 // one can write
-BufferExamplesPath.apollo11;
+ExampleFiles.apollo11;
 ::
 
 CLASSMETHODS::
@@ -48,7 +48,7 @@ TABLE::
 returns:: The full path of TELETYPE::SinedPink.aiff:: as a LINK::Classes/String:: 
 
 METHOD:: child
-Allegedly a re-recording of Link::Classes/BufferExamplesPath#*apollo11:: performed by a child of a developer.
+Allegedly a re-recording of Link::Classes/ExampleFiles#*apollo11:: performed by a child of a developer.
 
 TABLE::
 ## Filename || TELETYPE::a11wlk01.wav::

--- a/HelpSource/Classes/ExampleFiles.schelp
+++ b/HelpSource/Classes/ExampleFiles.schelp
@@ -1,10 +1,10 @@
 TITLE:: ExampleFiles
 summary:: A shortcut to example sounds bundled with SuperCollider
 categories:: Files
-related:: Classes/Buffer, Classes/Soundfile
+related:: Classes/Buffer, Classes/Soundfile, Classes/File, Classes/PathName
 
 DESCRIPTION::
-Provides a shortcut to the paths of example sounds which are bundled with SuperCollider and are located in LINK::Classes/Platform#*resourceDir::.
+Provides a shortcut to the paths of example files which are bundled with SuperCollider and are located in LINK::Classes/Platform#*resourceDir::.
 
 CODE::
 // instead of writing

--- a/SCClassLibrary/Common/Files/ExampleFiles.sc
+++ b/SCClassLibrary/Common/Files/ExampleFiles.sc
@@ -1,4 +1,4 @@
-BufferExamplesPath {
+ExampleFiles {
 	*apollo11 {
 		^Platform.resourceDir +/+ "sounds" +/+ "a11wlk01-44_1.aiff";
 	}

--- a/testsuite/classlibrary/TestExampleFiles.sc
+++ b/testsuite/classlibrary/TestExampleFiles.sc
@@ -1,8 +1,8 @@
-TestBufferExamplesPath : UnitTest {
+TestExampleFiles : UnitTest {
 	test_filesExist {
 		// we use the methods of the meta class to access the static methods
-		Meta_BufferExamplesPath.methods.do({|staticMethod|
-			var filePath = BufferExamplesPath.performArgs(staticMethod.name);
+		Meta_ExampleFiles.methods.do({|staticMethod|
+			var filePath = ExampleFiles.performArgs(staticMethod.name);
 			this.assert(
 				boolean: PathName(filePath).isFile,
 				message: "% is an example file and should exist".format(filePath),


### PR DESCRIPTION
## Purpose and Motivation

This is a follow up from the conversation on https://github.com/supercollider/supercollider/pull/6685 about changing this class name. The conversation came the idea that `BufferExamplesPath` might be misleading in that the class points to soundfiles rather than "buffers", also that `ExampleFiles` was more generic and could be extended in the future to a variety of file types.

## Types of changes

<!-- Delete lines that don't apply -->

- Breaking change

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
