### PR TITLE
proj docs:readme Fixing "A Gentle Introduction to SC"'s link

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ The official docs can be viewed in the SuperCollider IDE's built-in documentatio
 
 We recommend the following resources for learning SC:
 
-- [A Gentle Introduction to SuperCollider](https://works.bepress.com/bruno-ruviaro/3/), a free ebook by Bruno Ruviaro
+- [A Gentle Introduction to SuperCollider](https://ccrma.stanford.edu/~ruviaro/texts/A_Gentle_Introduction_To_SuperCollider.pdf), a free ebook by Bruno Ruviaro
 - [Eli Fieldsteel's video tutorials](https://www.youtube.com/playlist?list=PLPYzvS8A_rTaNDweXe6PX4CXSGq4iEWYC)
 - [Getting Started with SC](http://doc.sccode.org/Tutorials/Getting-Started/00-Getting-Started-With-SC.html)
 - [Nick Collins' SC tutorial](https://composerprogrammer.com/teaching/supercollider/sctutorial/tutorial.html)


### PR DESCRIPTION
## Purpose and Motivation

Does what the title says.
Old link is expired, proposed change is both functional and perene (because it's a university link) https://ccrma.stanford.edu/~ruviaro/texts/A_Gentle_Introduction_To_SuperCollider.pdf

## Types of changes

- Documentation

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [ X] Updated documentation

[skip ci]
