### PR TITLE
Document keystate usage on macOS

### DIFF
--- a/HelpSource/Classes/KeyState.schelp
+++ b/HelpSource/Classes/KeyState.schelp
@@ -19,6 +19,11 @@ The UGen will return MATH::0.0:: as constant value.
 For more information see https://github.com/supercollider/supercollider/issues/4544
 ::
 
+WARNING::
+MacOS users will need to add the SuperCollider application to the Input Monitoring group in the Privacy & Security preferences to have all keys captured.
+See https://support.apple.com/en-us/guide/mac-help/mchl4cedafb6/mac
+::
+
 classmethods::
 
 method::kr


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

Compare 

```
Ndef(\k, {KeyState.kr((0..127), lag: 0.0).sum.poll})
```

with and without Security Settings applied - only if Input monitoring is allowed keys like `abc` will be received by SuperCollider, otherwise it will only capture the arrow keys etc.

This PR documents that keystate usage is tied to Security settings on macOS.

## Types of changes

<!-- Delete lines that don't apply -->

- Documentation


## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
