### PR TITLE
sclang: exit if the library has not been compiled

### DIFF
--- a/lang/LangSource/SC_TerminalClient.cpp
+++ b/lang/LangSource/SC_TerminalClient.cpp
@@ -25,6 +25,7 @@
 */
 
 #include "SC_TerminalClient.h"
+#include <cstdlib>
 #ifdef SC_QT
 #    include "../../QtCollider/LanguageClient.h"
 #endif
@@ -259,6 +260,14 @@ int SC_TerminalClient::run(int argc, char** argv) {
 
     // startup library
     compileLibrary(opt.mStandalone);
+
+    if (!compiledOK) {
+        post("ERROR: Library has not been compiled successfully.\n");
+        shutdownLibrary();
+        flush();
+        shutdownRuntime();
+        return EXIT_FAILURE;
+    }
 
     // enter main loop
     if (codeFile)


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

Currently, when the library compilation fails, we get stuck in a limbo; the interpreter doesn't quit, but also doesn't operate. This makes it impossible to react to such failure programmatically.

I believe this would be an improvement for testing etc., among possible future uses.

~~This behavior can be disabled by setting an environment variable `SCLANG_NO_EXIT_ON_FATAL_ERROR`, borrowed from #6671. I'm open to suggestions whether we really need an env var, or if it should be called something else. I thought it would be easiest if it's the same as in the other PR, but that can also change.~~

~~I've chosen `1` as the exit code. Another option would be `-1` I guess (IIUC that would overflow to `255`?).~~ EDIT: I changed the exit code to `EXIT_FAILURE` macro from `<cstdlib>`, but ideally we'd rework exit codes project-wide - see https://github.com/supercollider/supercollider/issues/6728.

I'm open to any feedback on this!

Fixes #5218

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [ ] Updated documentation - TBD... I feel like the env vars should be documented somewhere.
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
