### PR TITLE
Fix boost thread on clang17

### DIFF
--- a/external_libraries/boost/boost/thread/future.hpp
+++ b/external_libraries/boost/boost/thread/future.hpp
@@ -4668,7 +4668,7 @@ namespace detail
       }
       run_it& operator=(BOOST_THREAD_RV_REF(run_it) x) BOOST_NOEXCEPT {
         if (this != &x) {
-          that_=x.that;
+          that_=x.that_;
           x.that_.reset();
         }
         return *this;


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

macOS 15.4 bumps clang to version 17 which introduces an error when compiling `boost::thread` - see https://github.com/boostorg/thread/issues/402

```cmake
[3/5] Building CXX object lang/CMakeFi...bsclang.dir/LangSource/PyrObject.cpp.o
FAILED: lang/CMakeFiles/libsclang.dir/LangSource/PyrObject.cpp.o 
[...]
In file included from /Users/scheiba/github/supercollider/lang/LangSource/PyrObject.cpp:45:
/Users/scheiba/github/supercollider/external_libraries/boost/boost/thread/future.hpp:4671:19: error: no member named 'that' in 'run_it<FutureExecutorContinuationSharedState>'; did you mean 'that_'?
 4671 |           that_=x.that;
      |                   ^~~~
      |                   that_
/Users/scheiba/github/supercollider/external_libraries/boost/boost/thread/future.hpp:4649:55: note: 'that_' declared here
 4649 |     shared_ptr<FutureExecutorContinuationSharedState> that_;
      |                                                       ^
1 error generated.
```

This is a small fix/hack/patch so it is possible to build sclang again with the most recent version of macOS so we don't have to bump all of boost again (it seems boost 1.88 adds a bugfix).

The proper way would probably be to replace `boost::thread` with `std::thread`, which would be another PR.

## Types of changes

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->
