### PR TITLE
Add Server -quitSync

### DIFF
--- a/HelpSource/Classes/Server.schelp
+++ b/HelpSource/Classes/Server.schelp
@@ -935,6 +935,11 @@ Routine.run {
 )
 ::
 
+method:: quitSync
+Quit the Server and wait until the server process actually shuts down.
+argument:: condition
+an optional instance of link::Classes/Condition:: to be used within the synchronisation process.
+
 subsection:: Bela
 
 method:: belaScope

--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -1056,6 +1056,41 @@ Server {
 		this.newAllocators;
 	}
 
+	quitSync { |condition|
+		condition ?? { condition = Condition.new };
+		condition.test = false;
+		this.quit;
+		this.prWaitForPidRelease({
+			condition.test = true;
+			condition.signal
+		}, {
+			// we may end up here
+			// if the server happened to become unresponsive recently
+			// in that case we try to quit again
+			this.quit;
+			this.prWaitForPidRelease({
+				condition.test = true;
+				condition.signal
+			}, {
+				// as a last resort...
+				"Server '%' failed to quit".format(this.name).postln;
+				this.pid !? {
+					"Forcing process with pid % to stop via system command.".format(this.pid).postln;
+					thisProcess.platform.killProcessByID(this.pid)
+				};
+				this.prWaitForPidRelease({
+					condition.test = true;
+					condition.signal
+				}, {
+					"The process did not stop after a timeout, which may result in dangling network resources.".warn;
+					condition.test = true;
+					condition.signal
+				});
+			});
+		}, this.statusWatcher.timeoutBeforeConsideredDeadOnExit * 1.5); // timeout is longer than ServerStatusWatcher waiting to declare the server unresponsive
+		condition.wait;
+	}
+
 	*quitAll { |watchShutDown = true|
 		all.do { |server|
 			if(server.sendQuit === true) {

--- a/SCClassLibrary/Common/Control/ServerStatus.sc
+++ b/SCClassLibrary/Common/Control/ServerStatus.sc
@@ -12,6 +12,7 @@ ServerStatusWatcher {
 	var <sampleRate, <actualSampleRate;
 
 	var reallyDeadCount = 0, bootNotifyFirst = true;
+	var <>timeoutBeforeConsideredDeadOnExit = 3.0;
 
 	*new { |server|
 		^super.newCopyArgs(server)
@@ -100,13 +101,13 @@ ServerStatusWatcher {
 					}
 				}, '/done', server.addr);
 
-				AppClock.sched(3.0, {
+				AppClock.sched(timeoutBeforeConsideredDeadOnExit, {
 					if(serverReallyQuit.not) {
 						if(unresponsive) {
-							"Server '%' remained unresponsive during quit."
+							"Server '%' remained unresponsive during quit.".format(server.name).warn;
 						} {
-							"Server '%' failed to quit after 3.0 seconds."
-						}.format(server.name).warn;
+							"Server '%' failed to quit after % seconds.".format(server.name, timeoutBeforeConsideredDeadOnExit).warn;
+						};
 						// don't accumulate quit-watchers if /done doesn't come back
 						serverReallyQuitWatcher.free;
 						statusWatcher !? { statusWatcher.disable };

--- a/testsuite/classlibrary/TestBuffer_Server.sc
+++ b/testsuite/classlibrary/TestBuffer_Server.sc
@@ -9,7 +9,7 @@ TestBuffer_Server : UnitTest {
 
 	tearDown {
 		Buffer.freeAll(server);
-		server.quit;
+		server.quitSync;
 		server.remove;
 	}
 

--- a/testsuite/classlibrary/TestBus.sc
+++ b/testsuite/classlibrary/TestBus.sc
@@ -76,7 +76,7 @@ TestBus : UnitTest {
 		this.assertFloatEquals(get_value, set_value, "Bus:get works", 0.001);
 
 		bus.free;
-		s.quit;
+		s.quitSync;
 		s.remove;
 	}
 
@@ -105,7 +105,7 @@ TestBus : UnitTest {
 		this.assertArrayFloatEquals(get_values, set_values[0..1], "Bus:getn works", 0.001);
 
 		bus.free;
-		s.quit;
+		s.quitSync;
 		s.remove;
 	}
 

--- a/testsuite/classlibrary/TestCoreUGens.sc
+++ b/testsuite/classlibrary/TestCoreUGens.sc
@@ -21,7 +21,7 @@ TestCoreUGens : UnitTest {
 	}
 
 	tearDown {
-		server.quit;
+		server.quitSync;
 		server.remove;
 	}
 

--- a/testsuite/classlibrary/TestDoneActions.sc
+++ b/testsuite/classlibrary/TestDoneActions.sc
@@ -16,7 +16,7 @@ TestDoneActions : UnitTest {
 
 	tearDown {
 
-		server.quit.remove;
+		server.quitSync.remove;
 
 	}
 

--- a/testsuite/classlibrary/TestEnvGen_server.sc
+++ b/testsuite/classlibrary/TestEnvGen_server.sc
@@ -7,7 +7,7 @@ TestEnvGen_server : UnitTest {
 	}
 
 	tearDown {
-		if(server.serverRunning) { server.quit };
+		if(server.serverRunning) { server.quitSync };
 		server.remove;
 	}
 
@@ -61,7 +61,7 @@ TestEnvGen_server : UnitTest {
 		var cleanup = {
 			tr_resp.free;
 			n_end_resp.free;
-			server.quit;
+			server.quitSync;
 			Server.scsynth;
 		};
 
@@ -92,8 +92,10 @@ TestEnvGen_server : UnitTest {
 			}, '/tr', server.addr, argTemplate: [synth.nodeID]);
 
 			n_end_resp = OSCFunc({ |msg|
-				cleanup.value;
-				cond.unhang;
+				fork{ // we need to for to wait for the server to quit with quitSync inside the cleanup function
+					cleanup.value;
+					cond.unhang;
+				}
 			}, '/n_end', server.addr, argTemplate: [synth.nodeID]);
 
 			cond.hang;

--- a/testsuite/classlibrary/TestFilterUGens.sc
+++ b/testsuite/classlibrary/TestFilterUGens.sc
@@ -7,7 +7,7 @@ TestFilterUGens : UnitTest {
 	}
 
 	tearDown {
-		server.quit;
+		server.quitSync;
 		server.remove;
 	}
 

--- a/testsuite/classlibrary/TestFunction.sc
+++ b/testsuite/classlibrary/TestFunction.sc
@@ -48,7 +48,7 @@ TestFunction : UnitTest {
 			})
 		});
 		condition.waitFor(2);
-		server.quit;
+		server.quitSync;
 		server.remove;
 	}
 

--- a/testsuite/classlibrary/TestIOUGens.sc
+++ b/testsuite/classlibrary/TestIOUGens.sc
@@ -7,7 +7,7 @@ TestIOUGens : UnitTest {
 	}
 
 	tearDown {
-		server.quit;
+		server.quitSync;
 		server.remove;
 	}
 

--- a/testsuite/classlibrary/TestIndexUGenRates.sc
+++ b/testsuite/classlibrary/TestIndexUGenRates.sc
@@ -11,7 +11,7 @@ TestIndexUGenRates : UnitTest {
 	tearDown {
 
 		Buffer.freeAll;
-		server.quit;
+		server.quitSync;
 		server.remove;
 	}
 

--- a/testsuite/classlibrary/TestLinkUGen.sc
+++ b/testsuite/classlibrary/TestLinkUGen.sc
@@ -12,8 +12,7 @@ TestLinkUGens : UnitTest {
 
 	tearDown {
 		LinkPhase.stop(server);
-		server.sync;
-		server.quit;
+		server.quitSync;
 		server.remove;
 	}
 

--- a/testsuite/classlibrary/TestMixedBundle_Server.sc
+++ b/testsuite/classlibrary/TestMixedBundle_Server.sc
@@ -10,7 +10,7 @@ TestMixedBundle_Server : UnitTest {
 	}
 
 	tearDown {
-		server.quit;
+		server.quitSync;
 		server.remove;
 	}
 

--- a/testsuite/classlibrary/TestNetAddr_Server.sc
+++ b/testsuite/classlibrary/TestNetAddr_Server.sc
@@ -41,7 +41,7 @@ TestNetAddr_Server : UnitTest {
 	*/
 
 	tearDown {
-		server.quit;
+		server.quitSync;
 		server.remove;
 	}
 

--- a/testsuite/classlibrary/TestNodeProxy.sc
+++ b/testsuite/classlibrary/TestNodeProxy.sc
@@ -113,7 +113,7 @@ TestNodeProxy : UnitTest {
 			"asCode-posting nodeproxy with settings should post these correctly."
 		);
 
-		server.quit;
+		server.quitSync;
 	}
 
 	test_asCode_single_ndef {
@@ -278,7 +278,7 @@ TestNodeProxy : UnitTest {
 
 		this.assertFloatEquals(result, proxy.source, "after the crossfade from a ugen function to a value the bus should have this value");
 
-		server.quit;
+		server.quitSync;
 		server.remove;
 	}
 
@@ -324,7 +324,7 @@ TestNodeProxyBusMapping : UnitTest {
 
 
 	tearDown {
-		server.quit.remove;
+		server.quitSync.remove;
 	}
 
 	test_audiorate_mapping {

--- a/testsuite/classlibrary/TestNodeProxyRoles.sc
+++ b/testsuite/classlibrary/TestNodeProxyRoles.sc
@@ -11,7 +11,7 @@ TestNodeProxyRoles : UnitTest {
 
 	tearDown {
 		proxy.clear;
-		server.quit;
+		server.quitSync;
 		server.remove;
 	}
 

--- a/testsuite/classlibrary/TestNodeProxy_Server.sc
+++ b/testsuite/classlibrary/TestNodeProxy_Server.sc
@@ -11,8 +11,7 @@ TestNodeProxy_Server : UnitTest {
 
 	tearDown {
 		proxy.clear;
-		server.sync;
-		server.quit;
+		server.quitSync;
 		server.remove;
 	}
 
@@ -80,13 +79,13 @@ TestNodeProxy_Server : UnitTest {
 
 	test_loaded_after_quit {
 		proxy.send;
-		server.quit;
+		server.quitSync;
 		this.assertEquals(proxy.loaded, false, "NodeProxy should not be loaded after server quit");
 	}
 
 	test_send_after_quit {
 		proxy.send;
-		server.quit;
+		server.quitSync;
 		proxy.send;
 		this.assertEquals(proxy.loaded, false, "After server quit, sending should not set node as loaded");
 	}
@@ -95,7 +94,7 @@ TestNodeProxy_Server : UnitTest {
 		var build;
 
 		proxy.source = { build = true; Silent.ar };
-		server.quit;
+		server.quitSync;
 		proxy.rebuild;
 		this.assertEquals(build, true, "After server quit, rebuilding NodeProxy should rebuild SynthDef");
 	}

--- a/testsuite/classlibrary/TestNode_Server.sc
+++ b/testsuite/classlibrary/TestNode_Server.sc
@@ -8,7 +8,7 @@ TestNode_Server : UnitTest {
 	}
 
 	tearDown {
-		server.quit.remove;
+		server.quitSync.remove;
 	}
 
 	test_get {

--- a/testsuite/classlibrary/TestOSCBundle.sc
+++ b/testsuite/classlibrary/TestOSCBundle.sc
@@ -8,7 +8,7 @@ TestOSCBundle : UnitTest {
 	}
 
 	tearDown {
-		server.quit;
+		server.quitSync;
 		server.remove;
 	}
 

--- a/testsuite/classlibrary/TestPV_ChainUGen.sc
+++ b/testsuite/classlibrary/TestPV_ChainUGen.sc
@@ -85,8 +85,7 @@ TestPV_ChainUGen : UnitTest {
 			this.assert(c.waitFor(3, { done }), "TIMEOUT: pv_equivalencetests_common", report: false);
 			b.free;
 		};
-		s.sync;
-		s.quit;
+		s.quitSync;
 		s.remove;
 	}
 

--- a/testsuite/classlibrary/TestPanAz.sc
+++ b/testsuite/classlibrary/TestPanAz.sc
@@ -7,7 +7,7 @@ TestPanAz : UnitTest {
 	}
 
 	tearDown {
-		if(server.serverRunning) { server.quit };
+		if(server.serverRunning) { server.quitSync };
 		server.remove;
 	}
 

--- a/testsuite/classlibrary/TestPluginCommand.sc
+++ b/testsuite/classlibrary/TestPluginCommand.sc
@@ -64,10 +64,7 @@ TestPluginCommand : UnitTest {
 		this.assert(busValue == 0.0, "%: failed async plugin command did not perform completion message".format(serverName));
 
 		if (server.serverRunning) {
-			server.quit;
-			// avoid UDP address in use errors when restarting the Server.
-			// Unfortunately, there is no way to wait for the Server to quit...
-			1.wait;
+			server.quitSync;
 		};
 	}
 

--- a/testsuite/classlibrary/TestProxySpace.sc
+++ b/testsuite/classlibrary/TestProxySpace.sc
@@ -7,7 +7,7 @@ TestProxySpace : UnitTest {
 	}
 
 	tearDown {
-		server.quit;
+		server.quitSync;
 		server.remove;
 	}
 

--- a/testsuite/classlibrary/TestQuery.sc
+++ b/testsuite/classlibrary/TestQuery.sc
@@ -12,7 +12,7 @@ TestQuery : UnitTest {
 	tearDown {
 
 		Buffer.freeAll;
-		server.quit.remove;
+		server.quitSync.remove;
 
 	}
 

--- a/testsuite/classlibrary/TestReblock.sc
+++ b/testsuite/classlibrary/TestReblock.sc
@@ -9,7 +9,7 @@ TestReblockBase : UnitTest {
 	}
 
 	tearDown {
-		server.quit;
+		server.quitSync;
 		server.remove;
 	}
 

--- a/testsuite/classlibrary/TestSanitize.sc
+++ b/testsuite/classlibrary/TestSanitize.sc
@@ -8,7 +8,7 @@ TestSanitize : UnitTest {
 	}
 
 	tearDown {
-		server.quit;
+		server.quitSync;
 		server.remove;
 	}
 

--- a/testsuite/classlibrary/TestServer.sc
+++ b/testsuite/classlibrary/TestServer.sc
@@ -36,7 +36,7 @@ TestServer : UnitTest {
 	}
 
 	tearDown {
-		server.quit;
+		server.quitSync;
 		server.remove;
 	}
 

--- a/testsuite/classlibrary/TestServer_GUI.sc
+++ b/testsuite/classlibrary/TestServer_GUI.sc
@@ -40,7 +40,7 @@ TestServer_GUI : UnitTest {
 		this.assert(button.value == 1, "ServerBoot should be able to update GUI objects in the main function");
 
 		ServerBoot.remove(updateFunc, server);
-		server.quit;
+		server.quitSync;
 	}
 
 	// Test that a GUI function executed by ServerTree completes during boot.
@@ -59,7 +59,7 @@ TestServer_GUI : UnitTest {
 		this.assert(button.value == 1, "ServerTree should be able to update GUI objects in the main function during boot");
 
 		ServerTree.remove(updateFunc, server);
-		server.quit;
+		server.quitSync;
 	}
 
 	// Test that a GUI function executed by ServerTree completes during cmd-period.
@@ -81,7 +81,7 @@ TestServer_GUI : UnitTest {
 		this.assert(button.value == 1, "ServerTree should be able to update GUI objects in the main function during CmdPeriod");
 
 		ServerTree.remove(updateFunc, server);
-		server.quit;
+		server.quitSync;
 	}
 
 	// Test that a GUI function executed by ServerQuit completes.
@@ -93,7 +93,7 @@ TestServer_GUI : UnitTest {
 		ServerQuit.add(updateFunc, server);
 
 		server.bootSync;
-		server.quit;
+		server.quitSync;
 
 		fork { 3.wait; cond.test_(true).signal };
 		cond.wait;

--- a/testsuite/classlibrary/TestServer_ServerGUI.sc
+++ b/testsuite/classlibrary/TestServer_ServerGUI.sc
@@ -75,7 +75,7 @@ TestServer_ServerGUI : UnitTest {
 		var expEnabled = [true, true, true, true, true];
 		this.bootServer(server);
 		this.assertButtonStates(expValues, expEnabled, "After booting");
-		server.quit;
+		server.quitSync;
 	}
 
 	// GUI state after booting and muting the server
@@ -86,7 +86,7 @@ TestServer_ServerGUI : UnitTest {
 		server.volume.mute;
 		this.assertButtonStates(expValues, expEnabled, "After muting");
 		server.volume.unmute;
-		server.quit;
+		server.quitSync;
 	}
 
 	// GUI state after booting, muting, then unmuting the server
@@ -97,7 +97,7 @@ TestServer_ServerGUI : UnitTest {
 		server.volume.mute;
 		server.volume.unmute;
 		this.assertButtonStates(expValues, expEnabled, "After muting and unmuting");
-		server.quit;
+		server.quitSync;
 	}
 
 	// GUI state after booting then quitting
@@ -105,7 +105,7 @@ TestServer_ServerGUI : UnitTest {
 		var expValues = [0, 0, 0, 0, 0];
 		var expEnabled = [true, true, true, false, true];
 		this.bootServer(server);
-		server.quit;
+		server.quitSync;
 		this.assertButtonStates(expValues, expEnabled, "After quitting");
 	}
 

--- a/testsuite/classlibrary/TestServer_SynthDefVersion1.sc
+++ b/testsuite/classlibrary/TestServer_SynthDefVersion1.sc
@@ -20,7 +20,7 @@ TestServer_SynthDefVersion1 : UnitTest {
 
 		this.assert(server.serverRunning, "sonic-pi-beep synthdef should not crash server");
 		if (server.serverRunning) {
-			server.quit;
+			server.quitSync;
 		};
 
 		server.remove;

--- a/testsuite/classlibrary/TestServer_boot.sc
+++ b/testsuite/classlibrary/TestServer_boot.sc
@@ -45,7 +45,7 @@ TestServer_boot : UnitTest {
 		);
 
 		of.free;
-		s.quit;
+		s.quitSync;
 	}
 
 	test_bootSync {
@@ -64,7 +64,7 @@ TestServer_boot : UnitTest {
 		);
 
 		of.free;
-		s.quit;
+		s.quitSync;
 	}
 
 	test_rebootOffServer {
@@ -74,7 +74,7 @@ TestServer_boot : UnitTest {
 		condvar.waitFor(5);
 
 		this.assertEquals(s.serverRunning, true, "Calling reboot should boot a non-booted Server.");
-		s.quit;
+		s.quitSync;
 	}
 
 	test_rebootRunningServer {
@@ -93,7 +93,7 @@ TestServer_boot : UnitTest {
 		condvar.waitFor(10);
 
 		this.assertEquals(s.serverRunning, true, "Calling reboot should reboot a running Server.");
-		s.quit;
+		s.quitSync;
 	}
 
 
@@ -111,7 +111,7 @@ TestServer_boot : UnitTest {
 
 		this.assertEquals(count, 1, "Toggling Server.notify should not cause ServerBoot actions to run.");
 
-		s.quit;
+		s.quitSync;
 		ServerBoot.remove(func, s);
 	}
 
@@ -129,7 +129,7 @@ TestServer_boot : UnitTest {
 
 		this.assertEquals(count, 1, "Toggling Server.notify should not cause ServerTree actions to run.");
 
-		s.quit;
+		s.quitSync;
 		ServerTree.remove(func, s);
 	}
 
@@ -159,7 +159,7 @@ TestServer_boot : UnitTest {
 		cond.hang;
 
 		timer.stop;
-		s.quit;
+		s.quitSync;
 		ServerBoot.remove(func, s);
 		of.free;
 
@@ -176,7 +176,7 @@ TestServer_boot : UnitTest {
 		cond.wait;
 
 		ServerQuit.remove(func, s);
-		s.quit;
+		s.quitSync;
 
 		this.assert(cond.test.not, "ServerQuit should not run when the server boots.");
 	}
@@ -204,7 +204,7 @@ TestServer_boot : UnitTest {
 		// exit early if server boot fails
 		if(s.serverRunning.not) {
 			this.assert(false, "Server did not boot after 5 seconds.");
-			s.quit;
+			s.quitSync;
 			^nil
 		};
 
@@ -221,7 +221,7 @@ TestServer_boot : UnitTest {
 		this.assert(failed.not,
 			"allocating nodeIDs while booting should not produce duplicate nodeIDs."
 		);
-		s.quit;
+		s.quitSync;
 	}
 
 	// Check that with s.waitForBoot, the four most common ways of creating sound processes will work.
@@ -260,7 +260,7 @@ TestServer_boot : UnitTest {
 		cond.hang;
 
 		// clean up
-		s.quit;
+		s.quitSync;
 		o.free;
 
 		// check whether each pair of channels was nonzero

--- a/testsuite/classlibrary/TestServer_clientID_booted.sc
+++ b/testsuite/classlibrary/TestServer_clientID_booted.sc
@@ -10,7 +10,7 @@ TestServer_clientID_booted : UnitTest {
 		var s = Server(this.class.name);
 		this.bootServer(s);
 		this.assertEquals(s.clientID, 0, "clientID should be 0 by default");
-		s.quit;
+		s.quitSync;
 		s.remove;
 	}
 
@@ -21,7 +21,7 @@ TestServer_clientID_booted : UnitTest {
 
 		this.bootServer(s);
 		this.assertEquals(s.clientID, 3, "clientID should be settable by clientID_ before boot.");
-		s.quit;
+		s.quitSync;
 		s.remove;
 	}
 
@@ -31,7 +31,7 @@ TestServer_clientID_booted : UnitTest {
 
 		this.bootServer(s);
 		this.assertEquals(s.clientID, 3, "clientID should be settable by Server constructor.");
-		s.quit;
+		s.quitSync;
 		s.remove;
 	}
 
@@ -50,7 +50,7 @@ TestServer_clientID_booted : UnitTest {
 
 		synth1.free;
 		synth2.free;
-		s.quit;
+		s.quitSync;
 		ServerTree.remove(func, s);
 		s.remove;
 	}
@@ -67,7 +67,7 @@ TestServer_clientID_booted : UnitTest {
 		this.assertEquals(s.clientID, lockedID,
 			"clientID should be locked while server is running.");
 
-		s.quit;
+		s.quitSync;
 		s.remove;
 	}
 
@@ -120,7 +120,7 @@ TestServer_clientID_booted : UnitTest {
 			"after repeated login, nodeID allocator should not be reset."
 		);
 
-		server.quit;
+		server.quitSync;
 		server.remove;
 
 	}

--- a/testsuite/classlibrary/TestSoundFile_Server.sc
+++ b/testsuite/classlibrary/TestSoundFile_Server.sc
@@ -12,7 +12,7 @@ TestSoundFile_Server : UnitTest {
 	tearDown {
 		soundFile.close;
 		Buffer.freeAll;
-		server.quit.remove;
+		server.quitSync.remove;
 	}
 
 	test_cue_passInEvent {

--- a/testsuite/classlibrary/TestSynthDefVersions_Server.sc
+++ b/testsuite/classlibrary/TestSynthDefVersions_Server.sc
@@ -76,10 +76,7 @@ TestSynthDefVersions_Server : UnitTest {
 		};
 
 		if (server.serverRunning) {
-			server.quit;
-			// avoid UDP address in use errors when restarting the Server.
-			// Unfortunately, there is no way to wait for the Server to quit...
-			1.wait;
+			server.quitSync;
 		};
 
 		server.remove;
@@ -121,10 +118,7 @@ TestSynthDefVersions_Server : UnitTest {
 		};
 
 		if (server.serverRunning) {
-			server.quit;
-			// avoid UDP address in use errors when restarting the Server.
-			// Unfortunately, there is no way to wait for the Server to quit...
-			1.wait;
+			server.quitSync;
 		};
 
 		server.remove;

--- a/testsuite/classlibrary/TestSynthMapping.sc
+++ b/testsuite/classlibrary/TestSynthMapping.sc
@@ -15,7 +15,7 @@ TestSynthAudioMapping : UnitTest {
 	}
 
 	tearDown {
-		server.quit.remove;
+		server.quitSync.remove;
 	}
 
 	sendSynthDef { |n1, n2|

--- a/testsuite/classlibrary/TestTWindex.sc
+++ b/testsuite/classlibrary/TestTWindex.sc
@@ -6,7 +6,7 @@ TestTWindex : UnitTest {
 	}
 
 	tearDown {
-		server.quit;
+		server.quitSync;
 		server.remove;
 	}
 

--- a/testsuite/classlibrary/TestUGen_Duty.sc
+++ b/testsuite/classlibrary/TestUGen_Duty.sc
@@ -8,7 +8,7 @@ TestUGen_Duty : UnitTest {
 	}
 
 	tearDown {
-		server.quit.remove;
+		server.quitSync.remove;
 	}
 
 	/*

--- a/testsuite/classlibrary/TestUGen_RTAlloc.sc
+++ b/testsuite/classlibrary/TestUGen_RTAlloc.sc
@@ -16,7 +16,7 @@ TestUGen_RTAlloc : UnitTest {
 	}
 
 	tearDown {
-		server.quit;
+		server.quitSync;
 		server.remove;
 	}
 

--- a/testsuite/classlibrary/TestUnitCommand.sc
+++ b/testsuite/classlibrary/TestUnitCommand.sc
@@ -49,10 +49,7 @@ TestUnitCommand : UnitTest {
 		this.assert(busValue == -3.0, "%: synchronous unit command (non-queued) works".format(serverName));
 
 		if (server.serverRunning) {
-			server.quit;
-			// avoid UDP address in use errors when restarting the Server.
-			// Unfortunately, there is no way to wait for the Server to quit...
-			1.wait;
+			server.quitSync;
 		};
 	}
 
@@ -160,10 +157,7 @@ TestUnitCommand : UnitTest {
 		this.assert(busValue == 0.0, "%: cancelled async unit command did not perform completion message".format(serverName));
 
 		if (server.serverRunning) {
-			server.quit;
-			// avoid UDP address in use errors when restarting the Server.
-			// Unfortunately, there is no way to wait for the Server to quit...
-			1.wait;
+			server.quitSync;
 		};
 	}
 

--- a/testsuite/classlibrary/TestUnitTest.sc
+++ b/testsuite/classlibrary/TestUnitTest.sc
@@ -45,7 +45,7 @@ TestUnitTest : UnitTest {
 		var server = Server(this.class.name);
 		server.bootSync;
 		this.assert(server.serverRunning, "The test's Server should be booted while we waited");
-		server.quit.remove;
+		server.quitSync.remove;
 	}
 
 	test_assert {

--- a/testsuite/classlibrary/TestVolume.sc
+++ b/testsuite/classlibrary/TestVolume.sc
@@ -26,7 +26,7 @@ TestVolume : UnitTest {
 			"Server boot should send volume synthdef and create synth immediately when set to nonzero volume.");
 
 		s.volume.reset;
-		s.quit.remove;
+		s.quitSync.remove;
 	}
 
 	test_setVolume {
@@ -47,7 +47,7 @@ TestVolume : UnitTest {
 		this.assertFloatEquals(ampSynthVolume, s.volume.volume.dbamp, "volume level correctly set", 0.0001);
 
 		s.volume.reset;
-		s.quit.remove;
+		s.quitSync.remove;
 	}
 
 	test_numOutputs {
@@ -62,7 +62,7 @@ TestVolume : UnitTest {
 
 		this.assert(s.outputBus.numChannels == s.volume.numOutputChannels, "volume synth has correct number of channels");
 
-		s.quit.remove;
+		s.quitSync.remove;
 	}
 
 	test_remoteSetVolume {
@@ -94,7 +94,7 @@ TestVolume : UnitTest {
 			"server should update volume level when set from remote client."
 		);
 
-		s.quit.remove;
+		s.quitSync.remove;
 	}
 
 	test_resetVolumeAfterKill {
@@ -121,7 +121,7 @@ TestVolume : UnitTest {
 			"server should reset volume level when ampSynth dies irregularly."
 		);
 
-		s.quit.remove;
+		s.quitSync.remove;
 	}
 
 

--- a/testsuite/classlibrary/server/TestMixedBundleTester.sc
+++ b/testsuite/classlibrary/server/TestMixedBundleTester.sc
@@ -10,7 +10,7 @@ TestMixedBundleTester : UnitTest {
 	}
 
 	tearDown {
-		server.quit;
+		server.quitSync;
 		server.remove;
 	}
 


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

We didn't have an async quit method that actually waits for the server process to quit (i.e. for the callback from the system command to be triggered). This PR adds method `quitSync` and changes all unitTests to use this method instead of .quit. This is done to ensure that the server is fully shut down, before a new server instance is started, especially under heavy system load.

### Notes
This is a workaround-quality implementation: our watching of the server status is quite messy IMO and there have been attempts to rewrite it in the past. This PR does not attempts this, but instead leverages currently available methods. 

In particular, for local servers the final "onComplete" callback for shutdown should be called when the process exists, i.e. it should be triggered by the server command callback function. This is just a note for a possible future implementation.

### ~~Failed unit tests~~

EDIT: I found the reason of the failures (calling `s.sync` after `s.quitSync`) and fixed it.
<details>

**This is not an issue anymore**

After implementing `.quitSync` in the test suite, the following tests would hang the testing routine:

[`TestNodeProxy_Server -test_loaded_after_quit`](https://github.com/supercollider/supercollider/blob/develop/testsuite/classlibrary/TestNodeProxy_Server.sc#L81)
[`TestNodeProxy_Server -test_send_after_quit `](https://github.com/supercollider/supercollider/blob/develop/testsuite/classlibrary/TestNodeProxy_Server.sc#L87)
[`TestNodeProxy_Server -test_rebuild_after_quit `](https://github.com/supercollider/supercollider/blob/develop/testsuite/classlibrary/TestNodeProxy_Server.sc#L94)

~~I didn't follow the logic enough to understand what the issue might me. These tests have been disabled in this PR.~~

~~I appreciate any feedback on this!~~
</details>

## Types of changes

<!-- Delete lines that don't apply -->

- New feature


## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
