### PR TITLE
supernova: catch exceptions in NRT synthesis

### DIFF
--- a/server/scsynth/SC_GraphDef.cpp
+++ b/server/scsynth/SC_GraphDef.cpp
@@ -631,7 +631,7 @@ GraphDef* GraphDef_Load(World* inWorld, const fs::path& path, GraphDef* inList) 
     } catch (const std::exception& e) {
         scprintf("exception in GraphDef_Load: %s\n", e.what());
         const std::string path_utf8_str = SC_Codecvt::path_to_utf8_str(path);
-        scprintf("while reading file: '%s'", path_utf8_str.c_str());
+        scprintf("while reading file: '%s'\n", path_utf8_str.c_str());
     } catch (...) {
         scprintf("unknown exception in GrafDef_Load\n");
         const std::string path_utf8_str = SC_Codecvt::path_to_utf8_str(path);

--- a/server/scsynth/scsynth_main.cpp
+++ b/server/scsynth/scsynth_main.cpp
@@ -422,14 +422,14 @@ int scsynth_main(int argc, char** argv) {
 #ifdef NO_LIBSNDFILE
         return 1;
 #else
-        int exitCode = 0;
         try {
             World_NonRealTimeSynthesis(world, &options);
-        } catch (std::exception& exc) {
-            scprintf("%s\n", exc.what());
-            exitCode = 1;
+            return 0;
+        } catch (const std::exception& exc) {
+            scprintf("NRT synthesis failed: %s\n", exc.what());
+            World_Cleanup(world, true);
+            return 1;
         }
-        return exitCode;
 #endif
     }
 

--- a/server/supernova/audio_backend/sndfile_backend.hpp
+++ b/server/supernova/audio_backend/sndfile_backend.hpp
@@ -56,6 +56,11 @@ class sndfile_backend : public detail::audio_backend_base<sample_type, float, bl
 public:
     sndfile_backend(void): read_frames(queue_size), write_frames(queue_size) {}
 
+    ~sndfile_backend() {
+        if (audio_is_active())
+            deactivate_audio();
+    }
+
     size_t get_audio_blocksize(void) const { return block_size_; }
 
     std::vector<sample_type> const& get_peaks() const { return max_peaks; }
@@ -103,6 +108,8 @@ public:
     bool audio_is_active(void) { return running.load(std::memory_order_acquire); }
 
     void activate_audio(void) {
+        assert(running.load() == false);
+
         running.store(true);
 
         if (input_file) {
@@ -110,12 +117,13 @@ public:
             reader_thread = std::thread(std::bind(&sndfile_backend::sndfile_read_thread, this));
         }
 
-
         writer_running.store(true);
         writer_thread = std::thread(std::bind(&sndfile_backend::sndfile_write_thread, this));
     }
 
     void deactivate_audio(void) {
+        assert(running.load() == true);
+
         running.store(false);
 
         if (input_file) {
@@ -298,7 +306,7 @@ private:
     std::thread reader_thread, writer_thread;
     boost::lockfree::spsc_queue<sample_type> read_frames, write_frames;
     boost::sync::semaphore read_semaphore, write_semaphore;
-    std::atomic<bool> running = { false }, reader_running = { false }, writer_running = { false };
+    std::atomic<bool> running { false }, reader_running { false }, writer_running { false };
     std::vector<sample_type> max_peaks;
 };
 

--- a/server/supernova/server/main.cpp
+++ b/server/supernova/server/main.cpp
@@ -377,8 +377,14 @@ int supernova_main(int argc, char* argv[]) {
                 exit(1);
             }
             EventLoop::run([&server]() { server.run(); });
-        } else
-            server.run_nonrt_synthesis(args);
+        } else {
+            try {
+                server.run_nonrt_synthesis(args);
+            } catch (exception const& e) {
+                cout << "Non-rt synthesis failed: " << e.what() << endl;
+                exit(1);
+            }
+        }
     } catch (const std::exception& exc) {
         cout << "\n*** ERROR: in main(): " << exc.what() << endl;
         exit(1);


### PR DESCRIPTION
1. Supernova: catch exceptions in NRT synthesis and post helpful error message, instead of silently aborting the program.
  Also make sure that the soundfile backend is automatically closed in the destructor so we can rely on RAII.
  Fixes https://github.com/supercollider/supercollider/issues/6746

2. Scsynth: call `World_CleanUp()` after `World_NonRealTimeSynthesis()` throws an exception to prevent hang

<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
