### PR TITLE
Docs: PathName: Clarify that a PathName instance is not a valid pathname argument

### DIFF
--- a/HelpSource/Classes/PathName.schelp
+++ b/HelpSource/Classes/PathName.schelp
@@ -7,7 +7,7 @@ description::
 PathName is a utility class for manipulating file names and paths. It expects a path to a file, and lets you access parts of that file path.
 
 note::
-Despite what the class name might suggest, link::Classes/PathName:: instances are not valid pathname arguments. SuperCollider methods handle paths using link::Classes/String::s, as such, you will need to convert link::Classes/PathName:: instances to link::Classes/String:: format to pass them as arguments. The easiest way to do so is to use the code::.fullPath:: method.
+Most classes in SC that operate on files generally expect paths to be link::Classes/String::s, not an instance of link::Classes/PathName::. Use code::.fullPath:: to convert link::Classes/PathName:: to a link::Classes/String:: expected in most cases.
 ::
 
 ClassMethods::

--- a/HelpSource/Classes/PathName.schelp
+++ b/HelpSource/Classes/PathName.schelp
@@ -6,6 +6,10 @@ categories:: Files
 description::
 PathName is a utility class for manipulating file names and paths. It expects a path to a file, and lets you access parts of that file path.
 
+note::
+Despite what the class name might suggest, link::Classes/PathName:: instances are not valid pathname arguments. SuperCollider methods handle paths using link::Classes/String::s, as such, you will need to convert link::Classes/PathName:: instances to link::Classes/String:: format to pass them as arguments. The easiest way to do so is to use the code::.fullPath:: method.
+::
+
 ClassMethods::
 
 private::initClass


### PR DESCRIPTION
## Purpose and Motivation

I often had trouble specifying pathnames as method arguments. I just figured out why : I was expecting `PathName` instances to be valid pathname arguments. But they're not.

Somehow, `PathNames` are not pathnames. So I added a note to the help file to disambiguate the situation.

Someday, it might get worth reworking `PathName` so it can actually be used directly ? Could it inherit from `String` while retaining its functionalities ?

## Types of changes

- Documentation

## To-do list

- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review