### PR TITLE
Unify path name and string to simplify filepath handling

### DIFF
--- a/SCClassLibrary/Common/Collections/String.sc
+++ b/SCClassLibrary/Common/Collections/String.sc
@@ -447,7 +447,8 @@ String[char] : RawArray {
 		var sep = thisProcess.platform.pathSeparator;
 		var hasLeftSep, hasRightSep;
 
-		if (path.respondsTo(\fullPath)) {
+		// if second arg is PathName, make it a PathName
+		if (path.isKindOf(PathName)) {
 			^PathName(this +/+ path.fullPath)
 		};
 
@@ -468,7 +469,19 @@ String[char] : RawArray {
 	}
 
 	asRelativePath { |relativeTo|
-		^PathName(this).asRelativePath(relativeTo)
+		var r, a, b, i, mePath;
+		mePath = this.absolutePath;
+		relativeTo = (relativeTo ? PathName.scroot ).absolutePath;
+		r = Platform.pathSeparator;
+
+		a = mePath.split(r);
+		b = relativeTo.split(r);
+
+		i = 0;
+		while { a[i] == b[i] and: { i < a.size } } {
+			i = i + 1;
+		};
+		^(".." ++ r).dup(b.size - i).join ++ a[i..].join(r)
 	}
 	asAbsolutePath {
 			// changed because there is no need to create a separate object

--- a/SCClassLibrary/Common/Files/PathName.sc
+++ b/SCClassLibrary/Common/Files/PathName.sc
@@ -1,6 +1,6 @@
 PathName {
 
-	var <fullPath, colonIndices;
+	var <fullPath;
 
 	classvar <>scroot;
 	classvar <>tmp;
@@ -17,236 +17,68 @@ PathName {
 		})
 	}
 
-	colonIndices {
-		^colonIndices ?? {
-			colonIndices = List.new;
-			fullPath.do({ | eachChar, i |
-				if(eachChar.isPathSeparator, { colonIndices.add(i) })
-			});
-			colonIndices
-		}
+	asPath { ^fullPath }
+
+	// old PathName methods, colon was Mac OS9 path separator...
+	colonIndices { ^fullPath.separatorIndices }
+	lastColonIndex { ^fullPath.lastSeparatorIndex }
+	// new better names
+	separatorIndices { ^fullPath.separatorIndices }
+	lastSeparatorIndex { ^fullPath.lastSeparatorIndex }
+
+	fileName { ^fullPath.fileName }
+	fileNameWithoutExtension { ^fullPath.fileNameWithoutExtension }
+	fileNameWithoutDoubleExtension { ^fullPath.fileNameWithoutDoubleExtension }
+	extension { ^fullPath.extension }
+
+	dirname { ^fullPath.dirname }
+	pathOnly { ^fullPath.pathOnly }
+
+	diskName { ^fullPath.diskName }
+
+	isRelativePath { ^fullPath.isRelativePath }
+	isAbsolutePath { ^fullPath.isAbsolutePath }
+	absolutePath { ^fullPath.absolutePath }
+
+	asRelativePath { |relativeTo| ^fullPath.asRelativePath(relativeTo) }
+	asAbsolutePath { ^fullPath.asAbsolutePath }
+
+	allFolders { ^fullPath.allFolders }
+
+	folderName { ^fullPath.folderName }
+
+	nextName { ^fullPath.nextName }
+	noEndNumbers { ^fullPath.noEndNumbers }
+	endNumber { ^fullPath.endNumber }
+	endNumberIndex { ^fullPath.endNumberIndex }
+
+	== { |other| { ^fullPath.absolutePath }
+		^other.respondsTo(\fullPath) and: { other.fullPath == this.fullPath }
 	}
 
-	fileName {
-		^fullPath.copyRange((this.lastColonIndex) + 1, (fullPath.size -1).max(0))
-	}
-
-	fileNameWithoutExtension {
-		var fileName = this.fileName;
-		fileName.reverseDo({ | char, i |
-			if(char == $.,{
-				^fileName.copyRange(0,fileName.size - (i + 2))
-			})
-		});
-		^fileName
-	}
-
-	fileNameWithoutDoubleExtension {
-		var fileName, pathName;
-		fileName = this.fileNameWithoutExtension;
-		pathName = PathName( fileName );
-		^pathName.fileNameWithoutExtension
-	}
-
-	extension {
-		var fileName;
-		fileName = this.fileName;
-		fileName.reverseDo({ | char, i |
-			if(char == $., {
-				^fileName.copyRange(fileName.size - i,fileName.size - 1)
-			})
-		});
-		^""
-	}
-
-	pathOnly {
-		^fullPath.copyRange(0, this.lastColonIndex)
-	}
-
-	diskName {
-		^fullPath.copyRange(0, this.colonIndices.first - 1)
-	}
-
-	isRelativePath { ^this.isAbsolutePath.not }
-
-	isAbsolutePath {
-		^fullPath.at(0).isPathSeparator
-	}
-
-	absolutePath{
-		^fullPath.absolutePath
-	}
-
-	asRelativePath { |relativeTo|
-		var r, a, b, i, mePath;
-		mePath = this.fullPath.absolutePath;
-		relativeTo = (relativeTo ? scroot ).absolutePath;
-		r = thisProcess.platform.pathSeparator;
-
-		a = mePath.split(r);
-		b = relativeTo.split(r);
-
-		i = 0;
-		while { a[i] == b[i] and: { i < a.size } } {
-			i = i + 1;
-		};
-		^(".." ++ r).dup(b.size - i).join ++ a[i..].join(r)
-	}
-
-	asAbsolutePath {
-		if(this.isAbsolutePath,{
-			^fullPath
-		},{
-			// this assumes relative to the sc app
-			^fullPath.absolutePath
-		})
-	}
-
-	allFolders {
-		var folderNames, pathCopy;
-		folderNames = List.new;
-		pathCopy = fullPath;
-
-		this.colonIndices.doAdjacentPairs({ | startColon, endColon |
-			folderNames.add( fullPath.copyRange(startColon + 1, endColon - 1) )
-		});
-
-		^folderNames
-	}
-
-	folderName {
-		var indexBeforeFolder;
-		var ci = this.colonIndices;
-		if (ci.isEmpty, { ^"" });
-
-		indexBeforeFolder =
-		if (ci.size == 1, 0, { ci.at(ci.size - 2) + 1 });
-
-		^fullPath.copyRange(indexBeforeFolder, this.lastColonIndex - 1)
-	}
-
-	lastColonIndex {
-		var ci = this.colonIndices;
-		^if(ci.isEmpty, { -1 }, { ci.last }) ;
-	}
-
-	nextName {
-		^if(fullPath.last.isDecDigit, {
-			this.noEndNumbers ++ (this.endNumber + 1)
-		}, {
-			fullPath ++ "1"
-		})
-	}
-
-	noEndNumbers {
-		^fullPath[..this.endNumberIndex]
-	}
-
-	endNumber {	// turn consecutive digits at the end of fullPath into a number.
-		^fullPath[this.endNumberIndex + 1..].asInteger
-	}
-
-	endNumberIndex {
-		var index = fullPath.lastIndex;
-		while({
-			index > 0 and: { fullPath.at(index).isDecDigit }
-		}, {
-			index = index - 1
-		});
-		^index
-	}
-
-	/* concatenation */
+/* concatenation */
 	+/+ { | path |
 		var otherFullPath = path.respondsTo(\fullPath).if({ path.fullPath }, { path.asString });
 		^this.class.new(fullPath +/+ otherFullPath)
 	}
 
-	entries {
-		var path = fullPath;
-		if(path.isEmpty) { ^[] };
-		^pathMatch(path +/+ "*").collect({ | item | PathName(item) })
-	}
+	pathMatch { ^fullPath.pathMatch }
+	entries { ^fullPath.entries }
+	isFolder { ^fullPath.isFolder }
+	isFile { ^fullPath.isFile }
 
-	pathMatch {
-		^pathMatch(fullPath)
-	}
+	files { ^fullPath.files }
+	folders { ^fullPath.folders }
+	deepFiles { ^fullPath.deepFiles }
 
-	isFolder {
-		var path = this.pathMatch;
-		^if(path.notEmpty, {
-			path.at(0).last.isPathSeparator
-		}, { false })
-	}
+	parentPath { ^fullPath.parentPath }
 
-	isFile {
-		var path = this.pathMatch;
-		^if(path.notEmpty, {
-			path.at(0).last.isPathSeparator.not
-		}, { false })
-	}
+	filesDo { |func| ^fullPath.filesDo(func) }
 
-	files {
-		^this.entries.select({ | item | item.isFile })
-	}
-
-	folders {
-		^this.entries.select({ | item | item.isFolder })
-	}
-
-	deepFiles {
-		^this.entries.collect({ | item |
-			if(item.isFile, {
-				item
-			},{
-				item.deepFiles
-			})
-		}).flat
-	}
-
-	parentPath {
-		var ci = this.colonIndices;
-
-		^if((fullPath.last.isPathSeparator) and: { ci.size > 1 }, {
-			fullPath.copyRange(0, ci[ci.size - 2])
-		}, {
-			fullPath.copyRange(0, this.lastColonIndex)
-		})
-	}
-
-	filesDo { | func |
-		this.files.do(func);
-		this.folders.do { | pathname |
-			pathname.filesDo(func)
-		};
-	}
-
-	streamTree { | str, tabs = 0 |
-		str << this.fullPath << Char.nl;
-		this.files.do({ | item |
-			tabs.do({ str << Char.tab });
-			str << item.fileNameWithoutExtension  << Char.nl
-		});
-		this.folders.do({ | item |
-			item.streamTree(str, tabs + 1);
-		});
-	}
-
-	dumpTree {
-		this.streamTree(Post)
-	}
-
+	streamTree { | str, tabs = 0 | fullPath.streamTree(str, tabs) }
+	dumpTree { fullPath.dumpTree }
 	printOn { | stream |
-		stream << "PathName(" << fullPath << ")"
+		stream << "PathName(" << fullPath.cs << ")"
 	}
-
-	dumpToDoc { | title="Untitled" |
-		var str, doc;
-		doc = Document.new(title);
-		str = CollStream.new;
-		this.streamTree(str);
-		doc.string = str.collection;
-		^doc
-	}
-
+	dumpToDoc { | title="Untitled" | fullPath.dumpToDoc(title) }
 }

--- a/SCClassLibrary/Common/Files/String_pathName.sc
+++ b/SCClassLibrary/Common/Files/String_pathName.sc
@@ -4,8 +4,8 @@
 + String {
 
 	// // backwards compat to PathName:
-	// fullPath { ^this.asPath }
 	asPath { ^this.standardizePath }
+	fullPath { ^this.asPath }
 
 	// bad name, old macOS ...
 	colonIndices { ^this.separatorIndices }
@@ -65,9 +65,6 @@
 		^(".." ++ r).dup(b.size - i).join ++ a[i..].join(r)
 	}
 
-	// old PathName method
-	asAbsolutePath { ^this.absolutePath }
-
 	allFolders {
 		^this.dirname.split.selectAs (_ != "", List)
 	}
@@ -75,11 +72,15 @@
 	folderName { ^this.dirname.basename }
 
 	nextName {
-		^if(this.last.isDecDigit, {
-			this.noEndNumbers ++ (this.endNumber + 1)
-		}, {
-			this ++ "1"
-		})
+		var name, ext;
+		if (this.last.isDecDigit) {
+			^this.noEndNumbers ++ (this.endNumber + 1)
+		};
+		#name, ext = this.splitext;
+		if (ext.isNil) {
+			^name ++ "1"
+		};
+		^name.nextName ++ "." ++ ext
 	}
 
 	noEndNumbers {

--- a/SCClassLibrary/Common/Files/String_pathName.sc
+++ b/SCClassLibrary/Common/Files/String_pathName.sc
@@ -1,0 +1,172 @@
+// All methods from PathName moved to String class,
+// so PathName methods only redirect here.
+
++ String {
+
+	// // backwards compat to PathName:
+	// fullPath { ^this.asPath }
+	asPath { ^this.standardizePath }
+
+	// bad name, old macOS ...
+	colonIndices { ^this.separatorIndices }
+
+	lastSeparatorIndex {
+		this.reverseDo { |char, revIndex|
+			if (Platform.isPathSeparator(char)) {
+				^this.size - revIndex - 1
+			};
+		};
+		^-1
+	}
+	lastColonIndex { ^this.lastSeparatorIndex }
+
+	separatorIndices {
+		var res = List[];
+		this.do { |ch, i| if (ch.isPathSeparator) { res = res.add(i) } };
+		^res
+	}
+
+	//
+	fileName { ^this.basename }
+	fileNameWithoutExtension { ^this.basename.splitext[0] }
+	fileNameWithoutDoubleExtension {
+		^this.basename.splitext[0].splitext[0]
+	}
+	extension {
+		^this.splitext.last ? ""
+	}
+
+	// PathName:pathOnly ended with separator
+	pathOnly {
+		^this.dirname +/+ Platform.pathSeparator
+	}
+	// not sure this is useful in any way.
+	// but backwards compat.
+	diskName {
+		^this.copyRange(0, this.colonIndices.first - 1)
+	}
+
+	isRelativePath { ^this.isAbsolutePath.not }
+	isAbsolutePath { ^this.at(0).isPathSeparator }
+
+	asRelativePath { |relativeTo|
+		var r, a, b, i, mePath;
+		mePath = this.absolutePath;
+		relativeTo = (relativeTo ? PathName.scroot ).absolutePath;
+		r = Platform.pathSeparator;
+
+		a = mePath.split(r);
+		b = relativeTo.split(r);
+
+		i = 0;
+		while { a[i] == b[i] and: { i < a.size } } {
+			i = i + 1;
+		};
+		^(".." ++ r).dup(b.size - i).join ++ a[i..].join(r)
+	}
+
+	// old PathName method
+	asAbsolutePath { ^this.absolutePath }
+
+	allFolders {
+		^this.dirname.split.selectAs (_ != "", List)
+	}
+
+	folderName { ^this.dirname.basename }
+
+	nextName {
+		^if(this.last.isDecDigit, {
+			this.noEndNumbers ++ (this.endNumber + 1)
+		}, {
+			this ++ "1"
+		})
+	}
+
+	noEndNumbers {
+		^this[..this.endNumberIndex]
+	}
+
+	endNumber {	// turn consecutive digits at the end of this into a number.
+		^this[this.endNumberIndex + 1..].asInteger
+	}
+
+	endNumberIndex {
+		var index = this.lastIndex;
+		while({
+			index > 0 and: { this.at(index).isDecDigit }
+		}, {
+			index = index - 1
+		});
+		^index
+	}
+
+	entries { ^pathMatch(this +/+ "*") }
+	isFolder { ^this.last.isPathSeparator }
+
+	isFile {
+		var path = this.pathMatch;
+		^if(path.notEmpty, {
+			path.at(0).last.isPathSeparator.not
+		}, { false })
+	}
+
+	files {
+		^this.entries.select({ | item | item.isFile })
+	}
+
+	folders {
+		^this.entries.select({ | item | item.isFolder })
+	}
+
+	deepFiles {
+		^this.entries.collect({ | item |
+			if(item.isFile, {
+				item
+			},{
+				item.deepFiles
+			})
+		}).flatIf { |item| item.isKindOf(String).not }
+	}
+
+	parentPath {
+		var ci = this.colonIndices;
+
+		^if((this.last.isPathSeparator) and: { ci.size > 1 }, {
+			this.copyRange(0, ci[ci.size - 2])
+		}, {
+			this.copyRange(0, this.lastColonIndex)
+		})
+	}
+
+	filesDo { | func |
+		this.files.do(func);
+		this.folders.do { | pathname |
+			pathname.filesDo(func)
+		};
+	}
+
+	streamTree { | str, tabs = 0 |
+		str << this << Char.nl;
+		this.files.do({ | item |
+			tabs.do({ str << Char.tab });
+			str << item.fileNameWithoutExtension  << Char.nl
+		});
+		this.folders.do({ | item |
+			item.streamTree(str, tabs + 1);
+		});
+	}
+
+	dumpTree {
+		this.streamTree(Post)
+	}
+
+	dumpToDoc { | title="Untitled" |
+		var str, doc;
+		doc = Document.new(title);
+		str = CollStream.new;
+		this.streamTree(str);
+		doc.string = str.collection;
+		^doc
+	}
+
+}

--- a/testsuite/classlibrary/TestPathName.sc
+++ b/testsuite/classlibrary/TestPathName.sc
@@ -26,15 +26,15 @@ bench { TestPathName.run };
 
 TestPathName : UnitTest {
 
-		// all string manipulation methods
+	// all string manipulation methods
 	test_filePathMethods {
 
 		var p = PathName("/Users/adc/src/Sounds/FunkyChicken.abc.scd");
 
 		// keep List type for full compat
 		this.assertEquals(p.colonIndices, List[0, 6, 10, 14, 21], "colonIndices");
-		//// new, better name
-		// this.assertEquals(p.separatorIndices, List[0, 6, 10, 14, 21], "separatorIndices");
+		// new, better name
+		this.assertEquals(p.separatorIndices, List[0, 6, 10, 14, 21], "separatorIndices");
 
 		this.assertEquals(p.fileName, "FunkyChicken.abc.scd", "fileName");
 		this.assertEquals(p.fileNameWithoutExtension, "FunkyChicken.abc", "fileNameWithoutExtension");
@@ -61,11 +61,15 @@ TestPathName : UnitTest {
 
 		this.assertEquals(PathName("abc").nextName, "abc1", "nextName, no number, no extension");
 		this.assertEquals(PathName("abc9").nextName, "abc10", "nextName with number, no extension");
-		// this.assertEquals(PathName("/where/ever/abc99.txt").nextName, "/where/ever/abc100.txt",
-		//	"nextName with extension, long path and high number");
+		this.assertEquals(
+			PathName("/where/ever/abc99.txt").nextName,
+			"/where/ever/abc100.txt",
+			"nextName with extension, long path and high number"
+		);
 
 		this.assertEquals(PathName("abc/") +/+ "def", PathName("abc/def"), "concat with String");
-		this.assertEquals(PathName("abc/") +/+ PathName("/def"), PathName("abc/def"), "concat with PathName");
+		this.assertEquals(PathName("abc/") +/+ PathName("/def"), PathName("abc/def"),
+			"concat with 2 PathNames");
 
 	}
 

--- a/testsuite/classlibrary/TestPathName.sc
+++ b/testsuite/classlibrary/TestPathName.sc
@@ -1,0 +1,103 @@
+/*
+// do we have full coverage of in
+PathName.methods.collect(_.name).postcs.removeAll(String.methods.collect(_.name));
+
+Tests for all PathName methods by group:
+
+// simple filename/path-related
+'colonIndices', 'separatorIndices', // synonom for back/comp
+'fileName', 'fileNameWithoutExtension', 'fileNameWithoutDoubleExtension', 'extension',
+'dirname', 'pathOnly', // synonym
+
+'diskName', // useful at all? seems dated
+
+'isRelativePath', 'isAbsolutePath', 'absolutePath',
+'asRelativePath', 'asAbsolutePath', 'allFolders', 'folderName', 'lastColonIndex',
+
+// should work as in old style without extensions, and new with extensions!
+'nextName', 'noEndNumbers', 'endNumber', 'endNumberIndex',
+
+// hierarchical folder access
+'entries', 'pathMatch', 'isFolder', 'isFile', 'files', 'folders', 'deepFiles', 'parentPath', 'filesDo', 'streamTree', 'dumpTree', 'printOn', 'dumpToDoc'
+
+bench { TestPathName.run };
+
+*/
+
+TestPathName : UnitTest {
+
+		// all string manipulation methods
+	test_filePathMethods {
+
+		var p = PathName("/Users/adc/src/Sounds/FunkyChicken.abc.scd");
+
+		// keep List type for full compat
+		this.assertEquals(p.colonIndices, List[0, 6, 10, 14, 21], "colonIndices");
+		//// new, better name
+		// this.assertEquals(p.separatorIndices, List[0, 6, 10, 14, 21], "separatorIndices");
+
+		this.assertEquals(p.fileName, "FunkyChicken.abc.scd", "fileName");
+		this.assertEquals(p.fileNameWithoutExtension, "FunkyChicken.abc", "fileNameWithoutExtension");
+		this.assertEquals(p.fileNameWithoutDoubleExtension, "FunkyChicken", "fileNameWithoutDoubleExtension");
+		this.assertEquals(p.extension, "scd", "extension");
+
+		// pathOnly ends with a training slash
+		this.assertEquals(p.pathOnly, "/Users/adc/src/Sounds/", "pathOnly");
+
+		// diskName expects no separator at beginning ...
+		this.assertEquals(PathName("ABC/def/ghj.scd").diskName, "ABC", "diskName");
+
+		this.assert(p.isAbsolutePath, "isAbsolutePath"); // true, because ~/ expanded correctly
+		this.assert(PathName("relative.scd").isRelativePath, "isRelativePath");
+		this.assertEquals(p.asRelativePath("~/src"), "Sounds/FunkyChicken.abc.scd");
+
+		this.assertEquals(p.allFolders, List["Users", "adc", "src", "Sounds"], "allFolders");
+
+		this.assertEquals(p.folderName, "Sounds", "folderName");
+
+		this.assertEquals(p.lastColonIndex, 21, "lastColonIndex when it exists");
+		this.assertEquals(PathName("123").lastColonIndex, -1, "lastColonIndex when not found");
+
+
+		this.assertEquals(PathName("abc").nextName, "abc1", "nextName, no number, no extension");
+		this.assertEquals(PathName("abc9").nextName, "abc10", "nextName with number, no extension");
+		// this.assertEquals(PathName("/where/ever/abc99.txt").nextName, "/where/ever/abc100.txt",
+		//	"nextName with extension, long path and high number");
+
+		this.assertEquals(PathName("abc/") +/+ "def", PathName("abc/def"), "concat with String");
+		this.assertEquals(PathName("abc/") +/+ PathName("/def"), PathName("abc/def"), "concat with PathName");
+
+	}
+
+	test_fileAndFolderAccessMethods {
+		var defaultLibFolder = Main.filenameSymbol.asString.dirname;
+		var classLibFolder = defaultLibFolder.dirname;
+		var fileCount = 0, postStream;
+		//  hierarchical access to files and folders
+		// [ 'isFolder', 'isFile', 'entries', 'files', 'folders', 'deepFiles', 'parentPath',
+		// 'filesDo', 'streamTree', 'dumpTree', 'printOn', 'dumpToDoc']
+
+		this.assert(PathName("~/").isFolder, "isFolder: home should be a folder");
+		this.assert(PathName("~/").isFile.not, "isFile: home should not be a file");
+		this.assert(PathName(defaultLibFolder).entries.size > 0, "DefaultLibrary has entries");
+		this.assert(PathName(defaultLibFolder).files.size > 0, "DefaultLibrary has files");
+		this.assert(PathName(classLibFolder).folders.size > 0, "SCClassLibrary has folders");
+		this.assert(
+			PathName(classLibFolder).deepFiles.size > PathName(classLibFolder).folders.size,
+			"deepFiles: SCClassLibrary has more deepFiles than folders"
+		);
+		this.assertEquals(
+			PathName(defaultLibFolder).parentPath, (classLibFolder +/+ "/"),
+			"parentPath is correct"
+		);
+
+		PathName(classLibFolder).filesDo {|path, i| fileCount = fileCount + 1 };
+		this.assertEquals(fileCount, PathName(classLibFolder).deepFiles.size,
+			"filesDo and deepFiles find the same number of files.");
+
+		postStream = CollStream.new;
+		PathName(PathName.filenameSymbol.asString.dirname).streamTree(postStream);
+		this.assert(postStream.contents.contains("\nPathName\n"));
+
+	}
+}

--- a/testsuite/classlibrary/TestPathName.sc
+++ b/testsuite/classlibrary/TestPathName.sc
@@ -75,7 +75,7 @@ TestPathName : UnitTest {
 
 	test_fileAndFolderAccessMethods {
 		var defaultLibFolder = Main.filenameSymbol.asString.dirname;
-		var classLibFolder = defaultLibFolder.dirname;
+		var classLibFolder = Platform.classLibraryDir;
 		var fileCount = 0, postStream;
 		//  hierarchical access to files and folders
 		// [ 'isFolder', 'isFile', 'entries', 'files', 'folders', 'deepFiles', 'parentPath',


### PR DESCRIPTION
## Purpose and Motivation

This PR proposes to make file path handling in SC easier and more consistent. 
File paths in SC are Strings, and PathName is a wrapper for a string that adds functionality for handling file paths.
As noted in  #6752 and #6753, the name PathName leads one to expect that pathNames will just work as file paths, but ATM they don't.

Ideally, PathName and String should be fully interchangeable anywhere.
As PathName used in much existing code, we have to keep backwards compatibility.

## Description of Proposed Feature

- This PR moves all method functionality from PathName to String, 
and redirects  the PathName methods to their String versions, 
so String objects can be used in place of PathName objects everywhere.
- This PR adds tests for all PathName methods which test the redirections.

For full interchangeability, I see two options:
1. Have PathName.new always return a String immediately. 
Then these strings directly work as filepaths anywhere. 
This requires no change to any file access methods,
it even allows to remove the PathName redirection methods again, 
as any path generated with PathName will already be a standardized String, 
and thus work direcly in any and all file access operations.
In effect, this removes unneeded complexity introduced by PathName. 

2. Keep PathName objects as they are now, 
and add a conversion step PathName:asPath, analogous to asGroup, asUGenInput, etc 
to convert them to Strings in all lowest-level file access methods in the class library.

I prefer option 1 :-) 
Opinions welcome!

## Types of changes
- New feature

## To-do list

- [x] Code is tested
- [x] All tests are passing
- [ ] add interchangeability option 1 or 2, asPath conversion or direct string option
- [ ] Update documentation
- [ ] Make PR ready for review 

comp: classlib
