### PR TITLE
Document.string_ : fix default args

### DIFF
--- a/SCClassLibrary/scide_scqt/ScIDE.sc
+++ b/SCClassLibrary/scide_scqt/ScIDE.sc
@@ -810,7 +810,7 @@ Document {
 		^this.rangeText(rangestart, rangesize);
 	}
 
-	string_ { | string, rangestart = -1, rangesize = 1 |
+	string_ { | string, rangestart = 0, rangesize = -1 |
 		this.prSetText(string, nil, rangestart, rangesize);
 	}
 


### PR DESCRIPTION
## Purpose

This PR fixes a bug in Document.string_, 
where default arguments for start and range are wrong.

```
// Demonstrate current bug:
d = Document("test-string", "string")
// ask its string:
d.string // correct: -> string 

// now set it to something else
d.string = "strong"

// now the open document shows "strongtring", which is wrong;
// and it thinks it still has "string", which is also wrong.
d.string 
// by comparison, setting via .text_ works as expected:
d.text = "strong"
d.text.cs // correct "strong"
```

This PR sets the default so ```d.string_ = "something" ``` works correctly. 

## Types of changes
- Bug fix


## To-do list

- [x] Code is tested
- [x] All tests are passing
- [x] This PR is ready for review
