### PR TITLE
scsynth/supernova: refactor SC_ServerBootDelayWarning

### DIFF
--- a/common/SC_ServerBootDelayWarning.cpp
+++ b/common/SC_ServerBootDelayWarning.cpp
@@ -1,44 +1,39 @@
 #include "SC_ServerBootDelayWarning.h"
 
 #ifdef _WIN32
+#    include <cassert>
 #    include <iostream>
-#    include <thread>
-#    include <mutex>
 #    include <chrono>
-#    include <condition_variable>
 
-static bool g_isServerBooted = false;
-static std::mutex g_serverBootWarningMutex;
-static std::condition_variable g_serverBootWarningConditionVariable;
-static std::thread g_bootWarningThread;
-
-static void displayWarningIfServerHasNotBooted() {
-    std::unique_lock<std::mutex> lock(g_serverBootWarningMutex);
-
-    if (!g_serverBootWarningConditionVariable.wait_for(lock, std::chrono::seconds(10),
-                                                       [] { return g_isServerBooted; })) {
-        std::cout << "Server: possible boot delay." << std::endl;
-        std::cout << "On some Windows-based machines, Windows Defender sometimes ";
-        std::cout << "delays server boot by one minute." << std::endl;
-        std::cout << "You can add scsynth.exe and/or supernova.exe *processes* to ";
-        std::cout << "Windows Defender exclusion list to avoid this delay. It's safe." << std::endl;
+ServerBootDelayWarningTimer::~ServerBootDelayWarningTimer() {
+    if (mThread.joinable()) {
+        stop();
     }
 }
-#endif //_WIN32
 
-void startServerBootDelayWarningTimer() {
-#ifdef _WIN32
-    g_bootWarningThread = std::thread(displayWarningIfServerHasNotBooted);
-#endif //_WIN32
+void ServerBootDelayWarningTimer::start() {
+    mThread = std::thread([this]() {
+        // display warning if server has not booted in time
+        std::unique_lock<std::mutex> lock(mMutex);
+
+        if (!mCondVar.wait_for(lock, std::chrono::seconds(10), [this] { return mIsServerBooted; })) {
+            std::cout << "Server: possible boot delay." << std::endl;
+            std::cout << "On some Windows-based machines, Windows Defender sometimes ";
+            std::cout << "delays server boot by one minute." << std::endl;
+            std::cout << "You can add scsynth.exe and/or supernova.exe *processes* to ";
+            std::cout << "Windows Defender exclusion list to avoid this delay. It's safe." << std::endl;
+        }
+    });
 }
 
-void stopServerBootDelayWarningTimer() {
-#ifdef _WIN32
+void ServerBootDelayWarningTimer::stop() {
+    assert(mThread.joinable());
     {
-        const std::lock_guard<std::mutex> lock(g_serverBootWarningMutex);
-        g_isServerBooted = true;
+        std::lock_guard<std::mutex> lock(mMutex);
+        mIsServerBooted = true;
     }
-    g_serverBootWarningConditionVariable.notify_all();
-    g_bootWarningThread.join();
-#endif //_WIN32
+    mCondVar.notify_all();
+    mThread.join();
 }
+
+#endif //_WIN32

--- a/common/SC_ServerBootDelayWarning.h
+++ b/common/SC_ServerBootDelayWarning.h
@@ -3,12 +3,38 @@
 
 #pragma once
 
-// On Windows, starts a timer that will display a warning message
-// after 10 seconds if the server has not booted,
-// which may be due to Windows Defender.
-// On other platforms, it does not do anything.
-// Must be called at the start of the server boot sequence.
-void startServerBootDelayWarningTimer();
+#ifdef _WIN32
+#    include <condition_variable>
+#    include <thread>
+#    include <mutex>
 
-// Must be called at the end of the server boot sequence.
-void stopServerBootDelayWarningTimer();
+class ServerBootDelayWarningTimer {
+public:
+    // Automatically stops the timer thread if necessary.
+    ~ServerBootDelayWarningTimer();
+
+    // Starts a timer that will display a warning message after
+    // 10 seconds if the server has not booted, which may be due
+    // to Windows Defender.
+    // Must be called at the start of the server boot sequence.
+    void start();
+    // Call this at the end of the server boot sequence.
+    void stop();
+
+private:
+    std::mutex mMutex;
+    std::condition_variable mCondVar;
+    std::thread mThread;
+    bool mIsServerBooted = false;
+};
+
+#else
+
+// Does nothing on non-Windows platforms
+class ServerBootDelayWarningTimer {
+public:
+    void start() {}
+    void stop() {}
+};
+
+#endif // _WIN32

--- a/server/scsynth/scsynth_main.cpp
+++ b/server/scsynth/scsynth_main.cpp
@@ -154,7 +154,8 @@ void Usage() {
 
 
 int scsynth_main(int argc, char** argv) {
-    startServerBootDelayWarningTimer();
+    ServerBootDelayWarningTimer bootDelayWarningTimer;
+    bootDelayWarningTimer.start();
 
     setlinebuf(stdout);
 
@@ -419,6 +420,8 @@ int scsynth_main(int argc, char** argv) {
         return 1;
 
     if (!options.mRealTime) {
+        // Server is ready!
+        bootDelayWarningTimer.stop();
 #ifdef NO_LIBSNDFILE
         return 1;
 #else
@@ -446,7 +449,8 @@ int scsynth_main(int argc, char** argv) {
         }
     }
 
-    stopServerBootDelayWarningTimer();
+    // Server is ready!
+    bootDelayWarningTimer.stop();
 
     if (options.mVerbosity >= 0) {
 #ifdef NDEBUG

--- a/server/supernova/server/main.cpp
+++ b/server/supernova/server/main.cpp
@@ -355,7 +355,8 @@ int supernova_main(int argc, char* argv[]) {
     cout << "compiled for debugging" << endl;
 #endif
 
-    startServerBootDelayWarningTimer();
+    ServerBootDelayWarningTimer bootDelayWarningTimer;
+    bootDelayWarningTimer.start();
 
     // FIXME should have more granular error handling
     try {
@@ -366,11 +367,11 @@ int supernova_main(int argc, char* argv[]) {
         set_plugin_paths(args, sc_factory.get());
         load_synthdefs(server, args);
 
-        stopServerBootDelayWarningTimer();
-
         if (!args.non_rt) {
             try {
                 start_audio_backend(args);
+                // Server is ready!
+                bootDelayWarningTimer.stop();
                 cout << "Supernova ready" << endl;
             } catch (exception const& e) {
                 cout << "\n*** ERROR: could not start audio backend: " << e.what() << endl;
@@ -378,6 +379,8 @@ int supernova_main(int argc, char* argv[]) {
             }
             EventLoop::run([&server]() { server.run(); });
         } else {
+            // Server is ready!
+            bootDelayWarningTimer.stop();
             try {
                 server.run_nonrt_synthesis(args);
             } catch (exception const& e) {


### PR DESCRIPTION
## Purpose and Motivation

Currently, the Server boot delay timer thread is not joined when the main function returns early due to an error condition. This causes the program to terminate instead of exiting cleanly.

I have turned the free functions into a RAII class to make sure that the timer thread will be joined automatically when the main function returns.

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix
- Refactoring

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [ ] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
