### PR TITLE
scide: HelpBrowser fix ambiguous shortcuts

### DIFF
--- a/QtCollider/widgets/QcWebView.cpp
+++ b/QtCollider/widgets/QcWebView.cpp
@@ -57,6 +57,8 @@ WebView::WebView(QWidget* parent): QWebEngineView(parent), _editable(false) {
     page->action(QWebEnginePage::Copy)->setShortcut(QKeySequence::Copy);
     page->action(QWebEnginePage::Paste)->setShortcut(QKeySequence::Paste);
     page->action(QWebEnginePage::Reload)->setShortcut(QKeySequence::Refresh);
+    page->action(QWebEnginePage::Back)->setShortcut(QKeySequence::Back);
+    page->action(QWebEnginePage::Forward)->setShortcut(QKeySequence::Forward);
 
     connect(this, SIGNAL(loadFinished(bool)), this, SLOT(pageLoaded(bool)));
 }

--- a/editors/sc-ide/widgets/help_browser.cpp
+++ b/editors/sc-ide/widgets/help_browser.cpp
@@ -154,14 +154,26 @@ void HelpBrowser::createActions() {
     // For the sake of display:
     mWebView->pageAction(QWebEnginePage::Copy)->setShortcut(QKeySequence::Copy);
     mWebView->pageAction(QWebEnginePage::Paste)->setShortcut(QKeySequence::Paste);
+
+    // proxy page actions to avoid shortcuts conflicts with main window
+    // note that we assign shortcuts here as they don't depend on IDE settings
+    auto proxyPageAction = [this](QAction* pageAction) {
+        // OverridingAction limits shortcut context to this widget
+        auto ovrAction = new OverridingAction(pageAction->icon(), pageAction->text(), this);
+        connect(ovrAction, SIGNAL(triggered()), pageAction, SLOT(trigger()));
+        // disable pageAction shortcut and assign it to ovrAction instead
+        ovrAction->setShortcut(pageAction->shortcut());
+        pageAction->setShortcut(QKeySequence());
+        ovrAction->addToWidget(this);
+        return ovrAction;
+    };
+    mActions[Back] = proxyPageAction(mWebView->pageAction(QWebEnginePage::Back));
+    mActions[Forward] = proxyPageAction(mWebView->pageAction(QWebEnginePage::Forward));
+    mActions[Reload] = proxyPageAction(mWebView->pageAction(QWebEnginePage::Reload));
 }
 
 void HelpBrowser::applySettings(Settings::Manager* settings) {
     settings->beginGroup("IDE/shortcuts");
-
-    mWebView->pageAction(QWebEnginePage::Back)->setShortcut(QKeySequence::Back);
-
-    mWebView->pageAction(QWebEnginePage::Forward)->setShortcut(QKeySequence::Forward);
 
     mActions[DocClose]->setShortcut(settings->shortcut("ide-document-close"));
 
@@ -388,9 +400,9 @@ void HelpBrowser::onContextMenuRequest(const QPoint& pos) {
         menu.addSeparator();
     }
 
-    menu.addAction(mWebView->pageAction(QWebEnginePage::Back));
-    menu.addAction(mWebView->pageAction(QWebEnginePage::Forward));
-    menu.addAction(mWebView->pageAction(QWebEnginePage::Reload));
+    menu.addAction(mActions[Back]);
+    menu.addAction(mActions[Forward]);
+    menu.addAction(mActions[Reload]);
 
 #    if (QT_VERSION < QT_VERSION_CHECK(6, 2, 0))
     if (contextData.selectedText().isEmpty())
@@ -403,9 +415,9 @@ void HelpBrowser::onContextMenuRequest(const QPoint& pos) {
 
     menu.addSeparator();
 
-    menu.addAction(mWebView->pageAction(QWebEnginePage::Back));
-    menu.addAction(mWebView->pageAction(QWebEnginePage::Forward));
-    menu.addAction(mWebView->pageAction(QWebEnginePage::Reload));
+    menu.addAction(mActions[Back]);
+    menu.addAction(mActions[Forward]);
+    menu.addAction(mActions[Reload]);
 
     menu.addSeparator();
 
@@ -483,9 +495,9 @@ HelpBrowserDocklet::HelpBrowserDocklet(QWidget* parent): Docklet(tr("Help browse
 
     toolBar()->addWidget(mHelpBrowser->loadProgressIndicator(), 1);
     toolBar()->addAction(mHelpBrowser->mActions[HelpBrowser::GoHome]);
-    toolBar()->addAction(mHelpBrowser->mWebView->pageAction(QWebEnginePage::Back));
-    toolBar()->addAction(mHelpBrowser->mWebView->pageAction(QWebEnginePage::Forward));
-    toolBar()->addAction(mHelpBrowser->mWebView->pageAction(QWebEnginePage::Reload));
+    toolBar()->addAction(mHelpBrowser->mActions[HelpBrowser::Back]);
+    toolBar()->addAction(mHelpBrowser->mActions[HelpBrowser::Forward]);
+    toolBar()->addAction(mHelpBrowser->mActions[HelpBrowser::Reload]);
     toolBar()->addWidget(mFindBox);
 
     connect(mFindBox, SIGNAL(query(QString, bool)), mHelpBrowser, SLOT(findText(QString, bool)));

--- a/editors/sc-ide/widgets/help_browser.hpp
+++ b/editors/sc-ide/widgets/help_browser.hpp
@@ -89,6 +89,9 @@ public:
         ResetZoom,
         Evaluate,
         EvaluateRegion,
+        Back,
+        Forward,
+        Reload,
 
         ActionCount
     };


### PR DESCRIPTION
## Purpose and Motivation
Fixes #6315 , #6136, #5672

Keyboard shortcuts for "Back", "Forward" and "Reload" actions can be ambiguous depending on OS and Desktop Environment.
This PR makes sure these actions are called when the Help Browser is in focus, resolving the ambiguity.
It also makes the "Reload" shortcut configurable in IDE settings (using the same shortcut as ide-reload-document).


## Types of changes

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [ ] Code is tested
- [ ] All tests are passing
- [ ] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
