### PR TITLE
classlib: ContiguousBlockAllocator: Fix 'reserve' bug when addrOffset > 0

### DIFF
--- a/HelpSource/Classes/ContiguousBlock.schelp
+++ b/HelpSource/Classes/ContiguousBlock.schelp
@@ -1,0 +1,122 @@
+TITLE:: ContiguousBlock
+summary:: Represents a range of integer addresses
+categories:: Control
+related:: Classes/ContiguousBlockAllocator
+
+DESCRIPTION::
+A ContiguousBlock is a range of addresses (generally integers >= 0) used in a link::Classes/ContiguousBlockAllocator::.
+ContiguousBlockAllocator is used in link::Classes/Server:: to manage buffer numbers and audio/control bus indices.
+
+code::ContiguousBlock(10, 2):: spans address indices 10 and 11.
+
+Additionally, a ContiguousBlock may be marked as in use or free. See link::#-used::.
+
+
+CLASSMETHODS::
+
+METHOD:: new
+Returns a new instance.
+
+ARGUMENT:: start
+The starting address of the block.
+
+ARGUMENT:: size
+The number of addresses after teletype::start:: to cover. Should be at least 1.
+
+
+INSTANCEMETHODS::
+
+METHOD:: start
+The starting address of the block.
+
+METHOD:: size
+The number of addresses covered in the block.
+
+METHOD:: address
+A synonym for teletype::start::.
+
+returns:: The starting address of the block.
+
+METHOD:: lastAddress
+The last address covered within this block: code::ContiguousBlock(10, 2).lastAddress:: returns 11.
+
+METHOD:: nextAddress
+The starting address immediately following this block. code::ContiguousBlock(10, 2).lastAddress:: returns 12, because an adjoining block following this block must begin at address 12.
+
+METHOD:: used
+Boolean. teletype::true:: indicates that the block is in use, and teletype::false:: that it is available.
+
+METHOD:: adjoins
+Answers teletype::true:: if this block touches or overlaps with the argument, and teletype::false:: if there is a gap between the two blocks.
+
+ARGUMENT:: block
+A second teletype::ContiguousBlock::.
+
+returns:: Boolean.
+
+
+subsection:: Operations
+
+METHOD:: join
+Given two adjoining blocks, combines them into a single block. If the blocks do not adjoin, the result is code::nil::.
+
+ARGUMENT:: block
+A second teletype::ContiguousBlock::.
+
+returns:: A new ContiguousBlock, spanning the full range of both input blocks.
+
+
+METHOD:: split
+Divides a ContiguousBlock into two new blocks.
+
+ARGUMENT:: span
+The size of the first new block. The remainder of the receiver block's size will be allocated to the second block.
+
+returns:: There are three return cases:
+
+definitionlist::
+## Receiver's size > span || Returns an array of two ContiguousBlocks, partitioning the original address space.
+## Receiver's size == span || Returns an array with the original (identical) block and nil for the second partition.
+## Receiver's size < span || Returns nil, because the original address space cannot be partitioned to be larger than itself.
+::
+
+
+EXAMPLES::
+
+code::
+c = ContiguousBlock(10, 2);
+d = ContiguousBlock(6, 3);
+e = ContiguousBlock(6, 4);
+f = ContiguousBlock(12, 1);
+g = ContiguousBlock(14, 5);
+h = ContiguousBlock(11, 4);
+
+
+// .adjoins
+
+c.adjoins(d)  // false: 6-8 then 10-11
+c.adjoins(e)  // true: 6-9, 10-11
+c.adjoins(f)  // true: 10-11, 12
+c.adjoins(g)  // false: 10-11. 14-18
+c.adjoins(h)  // true: overlap (10-11, 11-14)
+
+
+// .join
+
+// join 10-11 to 6-9, new block is 6-11
+c.join(e)  // ContiguousBlock(6, 6, false)
+
+c.join(d)  // nil because they don't adjoin
+
+
+// .split
+
+// g spans 14-18
+// split(2) gives 14-15 for the first partition
+// and 16-18 for the second
+g.split(2)  // [ContiguousBlock(14, 2, false), ContiguousBlock(16, 3, false)]
+
+c.split(2)  // [ContiguousBlock(10, 2, false), nil]
+
+f.split(2)  // nil because 'f' isn't large enough
+::

--- a/SCClassLibrary/Common/Control/Engine.sc
+++ b/SCClassLibrary/Common/Control/Engine.sc
@@ -165,17 +165,19 @@ ContiguousBlock {
 	*new { |start, size| ^super.newCopyArgs(start, size) }
 
 	address { ^start }
+	nextAddress { ^start + size }
+	lastAddress { ^start + size - 1 }
 
 	adjoins { |block|
 		^(start < block.start and: { start + size >= block.start })
-			or: { start > block.start and: { block.start + block.size >= start } }
+			or: { start > block.start and: { block.nextAddress >= start } }
 	}
 
 	join { |block|
 		var newstart;
 		if(this.adjoins(block)) {
 			^this.class.new(newstart = min(start, block.start),
-				max(start + size, block.start + block.size) - newstart)
+				max(start + size, block.nextAddress) - newstart)
 		} {
 			^nil
 		};
@@ -216,7 +218,7 @@ ContiguousBlockAllocator {
 
 	// For every ContiguousBlock in the array,
 	// there should ALWAYS be the next ContiguousBlock at
-	// block.start + block.size.
+	// block.nextAddress.
 	// E.g. block at 0 above --> 0+2 --> 2 and there's a block at index 2.
 	// If this is not true, the allocator is in an inconsistent state.
 	// This should never happen by following the public interface:
@@ -240,34 +242,43 @@ ContiguousBlockAllocator {
 	}
 
 	reserve { |address, size = 1, warn = true|
-		var block = array[address] ?? { this.prFindNext(address) };
-		var new;
-		if(block.notNil and:
-			{ block.used and:
-				{ address + size > block.start }
-		}) {
-			if(warn) {
-				"The block at (%, %) is already in use and cannot be reserved."
-				.format(address, size).warn;
-			};
-		} {
-			if(block.notNil and: { block.start == address }) {
-				new = this.prReserve(address, size, block);
-				^new
-			} {
-				block = this.prFindPrevious(address);
-				if(block.notNil and:
-					{ block.used and:
-						{ block.start + block.size > address }
-				}) {
-					if(warn) {
-						"The block at (%, %) is already in use and cannot be reserved."
-						.format(address, size).warn;
-					};
-				} {
-					new = this.prReserve(address, size, nil, block);
-					^new
+		var block = array[address - addrOffset];
+
+		// block exists: if unused and big enough, reserve, else nil
+		if(block.notNil) {
+			if(block.used or: { block.size < size }) {
+				if(warn) {
+					"The block at (%, %) is already in use and cannot be reserved."
+					.format(address, size).warn;
 				};
+				^nil
+			} {
+				^this.prReserve(address, size, block);
+			}
+		} {
+			// block didn't exist:
+			// search backward and validate 2 conditions
+			block = this.prFindPrevious(address);
+			if(block.isNil) {
+				if(warn) {
+					"Address % should be at least %".format(address, addrOffset).warn;
+				};
+				^nil
+			};
+			if(block.nextAddress < address) {
+				Error("ContiguousBlockAllocator:reserve previous block doesn't span requested address (should never happen)").throw;
+			};
+			// is it used, or too small?
+			if(block.used or: {
+				block.nextAddress < (address + size)
+			}) {
+				if(warn) {
+					"The block at (%, %) is already in use and cannot be reserved."
+					.format(address, size).warn;
+				};
+				^nil
+			} {
+				^this.prReserve(address, size, nil, block);
 			};
 		};
 		^nil
@@ -363,9 +374,9 @@ ContiguousBlockAllocator {
 		if(temp.notNil) {
 			// Yes.
 			// In that case (see comments at the top of the class),
-			// the next block is expected to be at temp.start + temp.size.
+			// the next block is expected to be at temp.nextAddress.
 			// So the 'else' block's search is redundant.
-			indexOfNextBlock = temp.start + temp.size;
+			indexOfNextBlock = temp.nextAddress;
 		} {
 			// No.
 			// We know there is no block at 'address',

--- a/testsuite/classlibrary/TestContiguousBlockAllocator.sc
+++ b/testsuite/classlibrary/TestContiguousBlockAllocator.sc
@@ -78,4 +78,28 @@ TestContiguousBlockAllocator : UnitTest {
 		};
 		this.assert(block.notNil, "ContiguousBlockAllocator can reserve within an interior free region");
 	}
+
+	test_CBAllocator_can_reserve_with_nonzero_offset {
+		var offset = 10;
+		var alloc = ContiguousBlockAllocator(50, addrOffset: offset);
+		var block;
+		var ok;
+
+		try {
+			block = alloc.reserve(offset, 10);
+		};
+		this.assert(block.notNil, "ContiguousBlockAllocator with offset > 0 can reserve from the start of its range");
+
+		block = nil;
+		try {
+			block = alloc.reserve(offset + 20, 10);
+		};
+		this.assert(block.notNil, "ContiguousBlockAllocator with offset > 0 can reserve in the last free region");
+
+		block = nil;
+		try {
+			block = alloc.reserve(offset + 12, 5);
+		};
+		this.assert(block.notNil, "ContiguousBlockAllocator with offset > 0 can reserve within an interior free region");
+	}
 }


### PR DESCRIPTION
## Purpose and Motivation

Fixes #5464, where `reserve` logic failed for allocators whose addrOffset is nonzero (e.g., server's audioBusAllocator).

(Note, because of #6764, I had to base this on an earlier commit than current dev head. I think nothing since that point touches Engine.sc, though.)

## Types of changes

- Bug fix

## To-do list

- [x] Code is tested
- [x] All tests are passing -- copied 'reserve' unit test and added an offset to it (passing)
- [ ] ~~Updated documentation~~
- [x] This PR is ready for review