### PR TITLE
Make SCDoc images resizable

### DIFF
--- a/HelpSource/Reference/SCDocSyntax.schelp
+++ b/HelpSource/Reference/SCDocSyntax.schelp
@@ -247,17 +247,55 @@ teletype:: IMAGE\:: ::
 teletype::
 image::foo.png::
 ::
-Optionally an image caption can be given:
+Optionally, an image caption can be provided:
 teletype::
 image::foo.png#Figure 1::
 ::
 
-And, the image can be clickable and link to another page:
+Additionally, the image can be clickable and linked to another page:
 teletype::
 image::foo.png#click this image#Classes/SinOsc::
 ::
 
-Just leave the caption empty if you want a link but no caption.
+If you want a link but no caption, just leave the caption field empty:ss
+teletype::
+image::foo.png##Classes/SinOsc::
+::
+
+The image size is automatically adjusted based on the width of the HTML page and table cells.
+If vertical length control is needed, you can specify a height in pixels by adding a number after the third `#`, while the width remains automatically adjusted.
+E.g.
+
+teletype::
+table::
+##No options have been applied:
+image::functions.png::Figure 1. This is ...
+||The caption option has been applied:
+image::functions.png#Figure 2. Function::This is ...
+\::
+table::
+##The caption and page link have been applied:
+image::functions.png#Figure 3. Function#Reference/Functions#120::Click to see more information.
+||The caption, page link, and vertical size have been applied:
+image::functions.png#Figure 4. Function#Reference/Functions#120::Click to see more information.
+\::
+::
+
+becomes:
+
+table::
+##No options have been applied:
+image::functions.png::Figure 1. This is ...
+||The caption option has been applied:
+image::functions.png#Figure 2. Function::This is ...
+::
+table::
+##The caption and page link have been applied:
+image::functions.png#Figure 3. Function#Reference/Functions#120::Click to see more information.
+||The caption, page link, and vertical size have been applied:
+image::functions.png#Figure 4. Function#Reference/Functions#120::Click to see more information.
+::
+
 
 ## keyword:: math\::
 teletype:: MATH\:: ::

--- a/SCClassLibrary/SCDoc/SCDocRenderer.sc
+++ b/SCClassLibrary/SCDoc/SCDocRenderer.sc
@@ -614,7 +614,7 @@ SCDocHTMLRenderer {
 			\IMAGE, {
 				f = node.text.split($#);
 				stream << "<div class='image'>";
-				img = "<img src='" ++ f[0] ++ "'/>";
+				img = "<img src='" ++ f[0] ++ "' width='auto' height='" ++ (f[3]?"") ++ "'/>";
 				if(f[2].isNil) {
 					stream << img;
 				} {


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation
**This is part of #6265. Since allowing HTML code in SCDoc is unlikely to be approved, I have implemented the same functionality using SCDoc syntax instead.**

Currently, there is no way to manually adjust the size of SCDoc images, as their dimensions are automatically determined based on the width of the HTML page and table cells.

**As a result, when rendering help documentation as HTML or converting it to PDF, larger images may get pushed to the next page, negatively affecting the document's layout. This PR addresses that issue.**

With this PR, users can control the image size by adjusting the vertical pixel value of an image. If vertical length control is needed, a height in pixels can be specified by adding a number after the third `#`, while the width remains automatically adjusted.

For example:
```supercollider
table::
##No options have been applied:
image::functions.png::Figure 1. This is ...
||The caption option has been applied:
image::functions.png#Figure 2. Function::This is ...
::
table::
##The caption and page link have been applied:
image::functions.png#Figure 3. Function#Reference/Functions#120::Click to see more information.
||The caption, page link, and vertical size have been applied:
image::functions.png#Figure 4. Function#Reference/Functions#120::Click to see more information.
::
```
![Screenshot 2025-04-25 at 09 40 35](https://github.com/user-attachments/assets/e558b4ce-5954-4b3a-b733-f8d58bfa387a)

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->

- Documentation
- New feature

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
