### PR TITLE
Add header, colspan, rowspan and line-height to table in SCDoc

### DIFF
--- a/HelpSource/Reference/SCDocSyntax.schelp
+++ b/HelpSource/Reference/SCDocSyntax.schelp
@@ -327,6 +327,27 @@ table::
 ## c 1 || c 2 || c 3
 ::
 
+Optionally, tables can include both vertical and horizontal headers, and cells can span multiple rows or columns.
+Additionally, users can change the line-height of individual cells.
+Refer to the example below:
+teletype::
+table\::
+## /h/ /l:10em/ head || /hh/ hHead 1 || /hh/ hHead 2 ||  /hh/ hHead 3
+## /vh/ vHead 1 || /x:2/1 1-2 || 1 3
+## /vh/ vHead 2 || /y:2/2-3 1 || 2 2 || 2 3
+## /vh/ vHead 3 || 3 2 || 3 3
+## /vh/ vHead 4 || 4 1 || 4 2 || 4 3
+\::
+::
+Renders:
+table::
+## /h/ /l:10em/ head || /hh/ hHead 1 || /hh/ hHead 2 ||  /hh/ hHead 3
+## /vh/ vHead 1 || /x:2/1 1-2 || 1 3
+## /vh/ vHead 2 || /y:2/2-3 1 || 2 2 || 2 3
+## /vh/ vHead 3 || 3 2 || 3 3
+## /vh/ vHead 4 || 4 1 || 4 2 || 4 3
+::
+
 ## keyword:: definitionlist\::
 teletype:: DEFINITIONLIST\:: ::
 || A definition list item consists of one or more terms prefixed with teletype::##:: followed by a description prefixed with teletype::||::. Example:

--- a/HelpSource/Reference/SCDocSyntax.schelp
+++ b/HelpSource/Reference/SCDocSyntax.schelp
@@ -332,19 +332,19 @@ Additionally, users can change the line-height of individual cells.
 Refer to the example below:
 teletype::
 table\::
-## /h/ /l:10em/ head || /hh/ hHead 1 || /hh/ hHead 2 ||  /hh/ hHead 3
-## /vh/ vHead 1 || /x:2/1 1-2 || 1 3
-## /vh/ vHead 2 || /y:2/2-3 1 || 2 2 || 2 3
-## /vh/ vHead 3 || 3 2 || 3 3
+## /h/ /l:5em/ head || /hh/ hHead 1 || /hh/ hHead 2 ||  /hh/ hHead 3
+## /vh/ /l:5rem/ vHead 1 || /x:2/1 1-2 || 1 3
+## /vh/ /l:5/ vHead 2 || /y:2/2-3 1 || 2 2 || 2 3
+## /vh/ /l:500%/ vHead 3 || 3 2 || 3 3
 ## /vh/ vHead 4 || 4 1 || 4 2 || 4 3
 \::
 ::
 Renders:
 table::
-## /h/ /l:10em/ head || /hh/ hHead 1 || /hh/ hHead 2 ||  /hh/ hHead 3
-## /vh/ vHead 1 || /x:2/1 1-2 || 1 3
-## /vh/ vHead 2 || /y:2/2-3 1 || 2 2 || 2 3
-## /vh/ vHead 3 || 3 2 || 3 3
+## /h/ /l:5em/ head || /hh/ hHead 1 || /hh/ hHead 2 ||  /hh/ hHead 3
+## /vh/ /l:5rem/ vHead 1 || /x:2/1 1-2 || 1 3
+## /vh/ /l:5/ vHead 2 || /y:2/2-3 1 || 2 2 || 2 3
+## /vh/ /l:500%/ vHead 3 || 3 2 || 3 3
 ## /vh/ vHead 4 || 4 1 || 4 2 || 4 3
 ::
 

--- a/HelpSource/scdoc.css
+++ b/HelpSource/scdoc.css
@@ -33,9 +33,27 @@ table {
     margin-top: 1em;
     margin-left: 2em;
 }
-table td {
+table td, table th {
     border: 1px solid var(--color-fg-200);
     padding: 0.3em;
+}
+.v-header {
+    border-right: 4px double var(--color-fg-200);
+    border-left: 1px solid var(--color-fg-200);
+    border-bottom: 1px solid var(--color-fg-200);
+    border-top: 1px solid var(--color-fg-200);
+}
+.h-header {
+    border-bottom: 4px double var(--color-fg-200);
+    border-left: 1px solid var(--color-fg-200);
+    border-right: 1px solid var(--color-fg-200);
+    border-top: 1px solid var(--color-fg-200);
+}
+.hv-header {
+    border-right: 4px double var(--color-fg-200);
+    border-bottom: 4px double var(--color-fg-200);
+    border-left: 1px solid var(--color-fg-200);
+    border-top: 1px solid var(--color-fg-200);
 }
 
 table table {

--- a/SCClassLibrary/SCDoc/SCDocRenderer.sc
+++ b/SCClassLibrary/SCDoc/SCDocRenderer.sc
@@ -567,7 +567,7 @@ SCDocHTMLRenderer {
 				.replaceRegexp("/hh/(| )", "")
 				.replaceRegexp("/vh/(| )", "")
 				.replaceRegexp("/h/(| )", "")
-				.replaceRegexp("/l\:\\d+\\w*/(| )", "")
+				.replaceRegexp("/l\:\\d+[rem%]*/(| )", "")
 				.replaceRegexp("/(x|y)\:\\d+/(| )", "")
 			},
 			\LINK, {
@@ -726,9 +726,9 @@ SCDocHTMLRenderer {
 						var thisTextOld = thisText;
 						"rowspan='" ++ thisTextOld[indexStart..indexLast] ++ "'>"
 						}
-					{ "/l:\\d+\\w*/".matchRegexp(thisText) } {
-						var indexStart = thisText.findRegexp("/l:\\d+\\w*/")[0][0] + 3;
-						var indexLast = thisText.findRegexp("/l:\\d+\\w*/")[0][1].size - 5 + indexStart;
+					{ "/l:\\d+[rem%]*/".matchRegexp(thisText) } {
+						var indexStart = thisText.findRegexp("/l:\\d+[rem%]*/")[0][0] + 3;
+						var indexLast = thisText.findRegexp("/l:\\d+[rem%]*/")[0][1].size - 5 + indexStart;
 						var thisTextOld = thisText;
 						"style='line-height:" ++ thisTextOld[indexStart..indexLast] ++ ";'>"
 						}


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

**This is part of #6265. Since allowing HTML code in SCDoc is unlikely to be approved, I have implemented the same functionality using SCDoc syntax instead.**
In the current SCDoc syntax for tables, there is no provision to:
- Specify headers (both row and column headers)
- Merge cells vertically and/or horizontally
- Adjust the line-height for individual rows

As a consequence, when rendering help documentation as HTML or converting it to PDF, larger tables may be pushed onto the following page, thereby adversely affecting the document’s layout. This pull request addresses these issues.

With this update, users can:
- Control the height of individual table cells by adjusting the line-height using units such as pixels, ems, rems, or percentages
- Define both row and column headers
- Merge cells vertically and horizontally

I envisioned it as an extended switch for the designated keyword tag. Consequently, I did not modify `SCDoc.l` or `SCDoc.y`; instead, I added the /option/ extension after the tags.

![Screenshot 2025-04-25 at 16 53 27](https://github.com/user-attachments/assets/a70ad4d6-fca7-411a-8280-8ece34080a15)

---
### An Example of Improvement:

For example, consider the following code from:
https://github.com/supercollider/supercollider/blob/823a9362447a89110bf9f5aa47e74d47abbd1c00/HelpSource/Reference/KeyboardShortcuts.schelp#L143-L184

It is currently rendered incorrectly:
![Screenshot 2025-04-25 at 14 38 11](https://github.com/user-attachments/assets/ee79e1ed-c363-4888-b8c9-c5aef17847b6)

It could be rewritten as:
```
table::
## /h/ Functionalities
|| /hh/ macOS
|| /hh/ Vim (scvim)
|| /hh/ /x:2/ Emacs (scel)

## /vh/ Open text document
|| cmd-o
|| ctl-o
|| :e
|| C-x C-f

## /vh/ New text document
|| cmd-n
|| ctl-n
|| :enew
|| (open non-existent file w. new name)

## /vh/ Close text document
|| cmd-w
|| ctl-w
|| :close
|| C-x k

## /vh/ Save text document
|| cmd-s
|| ctl-s
|| :w
|| C-x C-s

## /vh/ Save text document as
|| cmd-sh-s
|| ctl-sh-s
|| :sav
|| C-x C-w

## /vh/ HTML doc window => code win
||
|| ctl-t
||
|| E
::
```
This version should render as intended. (I cannot confirm the exact behaviour for all applications, as my primary tools are SC-IDE and VSCode:
![Screenshot 2025-04-25 at 16 51 33](https://github.com/user-attachments/assets/7736d7a7-a368-400b-9c55-81274a7558d6)

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->

- Documentation
- Bug fix
- New feature

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
