### PR TITLE
Add various styles for note/warning boxes

### DIFF
--- a/HelpSource/Reference/SCDocSyntax.schelp
+++ b/HelpSource/Reference/SCDocSyntax.schelp
@@ -356,11 +356,81 @@ definitionlist::
 ## keyword:: note\::
 teletype:: NOTE\:: ::
 || Create a NOTE box with important content.
+
+teletype::
 note:: like this ::
+::
+becomes:
+note:: like this ::
+
+Alternatively, note boxes can also be styled as follows:
+
+teletype::
+note::/attention/
+
+like this
+\::
+::
+becomes:
+note:: /attention/
+
+like this
+::
+
+teletype::
+note:: /caution/ like this ::
+::
+becomes:
+note:: /caution/ like this::
+
+teletype::
+note:: /hint/ like this ::
+::
+becomes:
+note:: /hint/ like this ::
+
+teletype::
+note:: /important/ like this ::
+::
+becomes:
+note:: /important/ like this ::
+
+teletype::
+note:: /seealso/ like this ::
+::
+becomes:
+note:: /seealso/ like this ::
+
+teletype::
+note:: /tip/ like this ::
+::
+becomes:
+note:: /tip/ like this::
+
 ## keyword:: warning\::
 teletype:: WARNING\:: ::
 || Create a WARNING box with very important content.
 warning:: like this ::
+
+Alternatively, warning boxes can also be styled as follows:
+
+teletype::
+warning::/danger/
+
+like this
+\::
+::
+becomes:
+warning:: /danger/
+
+like this
+::
+
+teletype::
+warning:: /error/ like this ::
+::
+becomes:
+warning:: /error/ like this::
 ## keyword:: footnote\::
 teletype:: FOOTNOTE\:: ::
 || Create a footnote which will be rendered at the end of the document.

--- a/SCClassLibrary/SCDoc/SCDocRenderer.sc
+++ b/SCClassLibrary/SCDoc/SCDocRenderer.sc
@@ -633,10 +633,9 @@ SCDocHTMLRenderer {
 			},
 // Other stuff
 			\NOTE, {
-				var thisText = if (node.children.isArray) {
-					if(node.children[0].children.isArray) {
-						node.children[0].children[0].text
-					}
+				var thisText = if(node.children[0].children[0].text.isString || node.children[0].children[0].isArray) {
+					node.children[0].children[0].text } {
+					""
 				};
 				stream << ( "<div class='note'><span class='notelabel'>" ++
 					(
@@ -656,10 +655,9 @@ SCDocHTMLRenderer {
 				stream << "</div>";
 			},
 			\WARNING, {
-				var thisText = if (node.children.isArray) {
-					if(node.children[0].children.isArray) {
-						node.children[0].children[0].text
-					}
+				var thisText = if(node.children[0].children[0].text.isString || node.children[0].children[0].isArray) {
+					node.children[0].children[0].text } {
+					""
 				};
 				stream << ( "<div class='warning'><span class='warninglabel'>" ++
 					(

--- a/SCClassLibrary/SCDoc/SCDocRenderer.sc
+++ b/SCClassLibrary/SCDoc/SCDocRenderer.sc
@@ -633,8 +633,16 @@ SCDocHTMLRenderer {
 			},
 // Other stuff
 			\NOTE, {
-				var thisText = if(node.children[0].children[0].text.isString || node.children[0].children[0].isArray) {
-					node.children[0].children[0].text } {
+				var thisText = if (node.children.isArray) {
+					if (node.children[0].isArray) {
+						if(node.children[0].children[0].text.isString || node.children[0].children[0].isArray) {
+							node.children[0].children[0].text } {
+							""
+						}
+					}{
+						""
+					}
+				} {
 					""
 				};
 				stream << ( "<div class='note'><span class='notelabel'>" ++
@@ -655,8 +663,16 @@ SCDocHTMLRenderer {
 				stream << "</div>";
 			},
 			\WARNING, {
-				var thisText = if(node.children[0].children[0].text.isString || node.children[0].children[0].isArray) {
-					node.children[0].children[0].text } {
+ 				var thisText = if (node.children.isArray) {
+					if (node.children[0].isArray) {
+						if(node.children[0].children[0].text.isString || node.children[0].children[0].isArray) {
+							node.children[0].children[0].text } {
+							""
+						}
+					}{
+						""
+					}
+				} {
 					""
 				};
 				stream << ( "<div class='warning'><span class='warninglabel'>" ++

--- a/SCClassLibrary/SCDoc/SCDocRenderer.sc
+++ b/SCClassLibrary/SCDoc/SCDocRenderer.sc
@@ -563,7 +563,15 @@ SCDocHTMLRenderer {
 			\NL, { }, // these shouldn't be here..
 // Plain text and modal tags
 			\TEXT, {
-				stream << this.escapeSpecialChars(node.text);
+				stream << this.escapeSpecialChars(node.text)
+				.replace("/attention/", "")
+				.replace("/caution/", "")
+				.replace("/danger/", "")
+				.replace("/error/", "")
+				.replace("/hint/", "")
+				.replace("/important/", "")
+				.replace("/seealso/", "")
+				.replace("/tip/", "")
 			},
 			\LINK, {
 				stream << this.htmlForLink(node.text);
@@ -625,13 +633,43 @@ SCDocHTMLRenderer {
 			},
 // Other stuff
 			\NOTE, {
-				stream << "<div class='note'><span class='notelabel'>NOTE:</span> ";
+				var thisText = if (node.children.isArray) {
+					if(node.children[0].children.isArray) {
+						node.children[0].children[0].text
+					}
+				};
+				stream << ( "<div class='note'><span class='notelabel'>" ++
+					(
+						case
+						{ thisText.contains("/attention/") } {"ATTENTION"}
+						{ thisText.contains("/caution/") } {"CAUTION"}
+						{ thisText.contains("/hint/") } {"HINT"}
+						{ thisText.contains("/important/") } {"IMPORTANT"}
+						{ thisText.contains("/seealso/") } {"SEE ALSO"}
+						{ thisText.contains("/tip/") } {"TIP"}
+						{ "NOTE" }
+					)
+					++ ":</span> "
+				);
 				noParBreak = true;
 				this.renderChildren(stream, node);
 				stream << "</div>";
 			},
 			\WARNING, {
-				stream << "<div class='warning'><span class='warninglabel'>WARNING:</span> ";
+				var thisText = if (node.children.isArray) {
+					if(node.children[0].children.isArray) {
+						node.children[0].children[0].text
+					}
+				};
+				stream << ( "<div class='warning'><span class='warninglabel'>" ++
+					(
+						case
+						{ thisText.contains("/danger/") } {"DANGER"}
+						{ thisText.contains("/error/") } {"ERROR"}
+						{ "WARNING" }
+					)
+					++ ":</span> "
+				);
 				noParBreak = true;
 				this.renderChildren(stream, node);
 				stream << "</div>";


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation
**This is part of https://github.com/supercollider/supercollider/pull/6265. Since allowing HTML code in SCDoc is unlikely to be approved, I have implemented the same functionality using SCDoc syntax instead.**

This implementation is a practical adaptation of the idea proposed by @capital-G and discussed with @smoge in issues #6265 and #6304. I envisioned it as an extended switch for the designated keyword tag. Consequently, I did not modify `SCDoc.l` or `SCDoc.y`; instead, I added the `/stylename/` extension after the tags.

I implemented the admonitions as detailed in the [the MyST Parser documentation](https://myst-parser.readthedocs.io/en/latest/syntax/admonitions.html), one of the references mentioned by @capital-G. However, I did not modify SCDoc.css, so only two styles are currently available: note and warning:
![Screenshot 2025-04-25 at 15 52 49](https://github.com/user-attachments/assets/0a9f7124-2d63-414f-b288-007a215161a8)


<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->

- Documentation
- New feature

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
