### PR TITLE
sclang: fix cli options flags initialization

### DIFF
--- a/lang/LangSource/SC_TerminalClient.h
+++ b/lang/LangSource/SC_TerminalClient.h
@@ -56,10 +56,10 @@ public:
 
     struct Options : public SC_LanguageClient::Options {
         std::string mLibraryConfigFile;
-        bool mDaemon;
-        bool mCallRun;
-        bool mCallStop;
-        bool mStandalone;
+        bool mDaemon = false;
+        bool mCallRun = false;
+        bool mCallStop = false;
+        bool mStandalone = false;
         std::vector<std::string> mArgs;
     };
 


### PR DESCRIPTION
## Purpose and Motivation

Fixes #6764

After #6644, uninitialized cli options caused problems at startup for sclang on linux (see issue above).
The issue was that bool members of SC_TerminalClient::Options need to be initialized to `false`, since they are not zeroed by the default constructor. Before #6644, it was done by the user-defined constructor now removed.
The effect is that sclang is forced in either daemon (no interactivity) or standalone (no lib) mode.

Initializing all bool members to false fixes it.

I don't know why this is a problem only on linux and not on macos and windows.

## Types of changes

Bug fix

## To-do list

- [ ] Code is tested
- [ ] All tests are passing
- [x] This PR is ready for review
