### PR TITLE
Update SC_PortAudio.cpp

### DIFF
--- a/server/scsynth/SC_PortAudio.cpp
+++ b/server/scsynth/SC_PortAudio.cpp
@@ -272,7 +272,7 @@ bool SC_PortAudioDriver::DriverSetup(int* outNumSamples, double* outSampleRate) 
     fprintf(stdout, "\nDevice options:\n");
     for (int i = 0; i < numDevices; i++) {
         pdi = Pa_GetDeviceInfo(i);
-        fprintf(stdout, "  - %s   (device #%d with %d ins %d outs)\n", GetPaDeviceName(i).c_str(), i,
+        fprintf(stdout, "  - %s\n   (device #%d with %d ins %d outs)\n", GetPaDeviceName(i).c_str(), i,
                 pdi->maxInputChannels, pdi->maxOutputChannels);
     }
 


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation
On Windows, each item in the device list is excessively long when presented in a single line, which significantly reduces readability
```
-> localhost
Booting server 'localhost' on address 127.0.0.1:57110.

Device options:
  - MME : Microsoft Sound Mapper - Input   (device #0 with 2 ins 0 outs)
  - MME : Microphone (High Definition Aud   (device #1 with 2 ins 0 outs)
  - MME : Microsoft Sound Mapper - Output   (device #2 with 0 ins 2 outs)
  - MME : Speakers (High Definition Audio   (device #3 with 0 ins 8 outs)
  - Windows DirectSound : Primary Sound Capture Driver   (device #4 with 2 ins 0 outs)
  - Windows DirectSound : Microphone (High Definition Audio Device)   (device #5 with 2 ins 0 outs)
  - Windows DirectSound : Primary Sound Driver   (device #6 with 0 ins 2 outs)
  - Windows DirectSound : Speakers (High Definition Audio Device)   (device #7 with 0 ins 8 outs)
  - ASIO : Magix Low Latency 2016   (device #8 with 2 ins 8 outs)
  - ASIO : ReaRoute ASIO (x64)   (device #9 with 16 ins 16 outs)
  - Windows WASAPI : Speakers (High Definition Audio Device)   (device #10 with 0 ins 2 outs)
  - Windows WASAPI : Microphone (High Definition Audio Device)   (device #11 with 2 ins 0 outs)
  - Windows WDM-KS : Microphone (HD Audio Microphone)   (device #12 with 2 ins 0 outs)
  - Windows WDM-KS : Speakers (HD Audio Speaker)   (device #13 with 0 ins 8 outs)

Requested devices:
  In:
  - (default)
  Out:
  - (default)

Selecting default system input/output devices

Booting with:
  In: MME : Microphone (High Definition Aud
  Out: MME : Speakers (High Definition Audio
  Sample rate: 44100.000
  Latency (in/out): 0.013 / 0.091 sec
SC_AudioDriver: sample rate = 44100.000000, driver's block size = 64
SuperCollider 3 server ready.
Requested notification messages from server 'localhost'
localhost: server process's maxLogins (1) matches with my options.
localhost: keeping clientID (0) as confirmed by server process.
Shared memory server interface initialized
```
This PR changes this as follows:
```
-> localhost
Booting server 'localhost' on address 127.0.0.1:57110.

Device options:
  - MME : Microsoft Sound Mapper - Input
     (device #0 with 2 ins 0 outs)
  - MME : Microphone (High Definition Aud
     (device #1 with 2 ins 0 outs)
  - MME : Microsoft Sound Mapper - Output
     (device #2 with 0 ins 2 outs)
  - MME : Speakers (High Definition Audio
     (device #3 with 0 ins 8 outs)
  - Windows DirectSound : Primary Sound Capture Driver
     (device #4 with 2 ins 0 outs)
  - Windows DirectSound : Microphone (High Definition Audio Device)
     (device #5 with 2 ins 0 outs)
  - Windows DirectSound : Primary Sound Driver
     (device #6 with 0 ins 2 outs)
  - Windows DirectSound : Speakers (High Definition Audio Device)
     (device #7 with 0 ins 8 outs)
  - ASIO : Magix Low Latency 2016
     (device #8 with 2 ins 8 outs)
  - ASIO : ReaRoute ASIO (x64)
     (device #9 with 16 ins 16 outs)
  - Windows WASAPI : Speakers (High Definition Audio Device)
     (device #10 with 0 ins 2 outs)
  - Windows WASAPI : Microphone (High Definition Audio Device)
     (device #11 with 2 ins 0 outs)
  - Windows WDM-KS : Microphone (HD Audio Microphone)
     (device #12 with 2 ins 0 outs)
  - Windows WDM-KS : Speakers (HD Audio Speaker)
     (device #13 with 0 ins 8 outs)

Requested devices:
  In:
  - (default)
  Out:
  - (default)

Selecting default system input/output devices

Booting with:
  In: MME : Microphone (High Definition Aud
  Out: MME : Speakers (High Definition Audio
  Sample rate: 44100.000
  Latency (in/out): 0.013 / 0.091 sec
SC_AudioDriver: sample rate = 44100.000000, driver's block size = 64
SuperCollider 3 server ready.
Requested notification messages from server 'localhost'
localhost: server process's maxLogins (1) matches with my options.
localhost: keeping clientID (0) as confirmed by server process.
Shared memory server interface initialized
```

To me, this version is more readable. What do you think? I am unsure whether I have correctly modified the line with the appropriate changes, as I am not familiar with C++.

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->

- New feature (?)

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [ ] Code is tested
- [ ] All tests are passing
- [ ] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
