### PR TITLE
CMake: update ccache integration

### DIFF
--- a/.github/workflows/build_macos.yml
+++ b/.github/workflows/build_macos.yml
@@ -175,7 +175,7 @@ jobs:
         run: |
           mkdir $BUILD_PATH && cd $BUILD_PATH
 
-          CMAKE_FLAGS="-G Xcode -D RULE_LAUNCH_COMPILE=ccache -D SUPERNOVA=ON  ${{ matrix.extra-cmake-flags }}"
+          CMAKE_FLAGS="-G Xcode -D SUPERNOVA=ON  ${{ matrix.extra-cmake-flags }}"
 
           if [[ -n "${{ matrix.vcpkg-triplet }}" ]]; then
             export VCPKG_ROOT=$VCPKG_INSTALLATION_ROOT

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,32 +46,6 @@ CONFIGURE_FILE(
   "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake"
   IMMEDIATE @ONLY)
 
-# workaround for using ccache with Xcode generator
-# thanks to Craig Scott: https://crascit.com/2016/04/09/using-ccache-with-cmake/
-get_property(RULE_LAUNCH_COMPILE GLOBAL PROPERTY RULE_LAUNCH_COMPILE)
-if(RULE_LAUNCH_COMPILE AND CMAKE_GENERATOR STREQUAL "Xcode")
-
-    # find ccache
-    find_program(CCACHE_PROGRAM ccache)
-
-    message(STATUS "Xcode and ccache detected: using ccache to speed up build process")
-
-    # Set up wrapper scripts
-    set(SC_LAUNCH_C_SCRIPT   "${CMAKE_BINARY_DIR}/launch-c")
-    set(SC_LAUNCH_CXX_SCRIPT "${CMAKE_BINARY_DIR}/launch-cxx")
-
-    configure_file("cmake_modules/launch-c.in"   launch-c)
-    configure_file("cmake_modules/launch-cxx.in" launch-cxx)
-    execute_process(COMMAND chmod a+rx "${SC_LAUNCH_C_SCRIPT}" "${SC_LAUNCH_CXX_SCRIPT}")
-
-    # Set Xcode project attributes to route compilation and linking
-    # through our scripts
-    set(CMAKE_XCODE_ATTRIBUTE_CC         "${SC_LAUNCH_C_SCRIPT}")
-    set(CMAKE_XCODE_ATTRIBUTE_CXX        "${SC_LAUNCH_CXX_SCRIPT}")
-    set(CMAKE_XCODE_ATTRIBUTE_LD         "${SC_LAUNCH_C_SCRIPT}")
-    set(CMAKE_XCODE_ATTRIBUTE_LDPLUSPLUS "${SC_LAUNCH_CXX_SCRIPT}")
-endif()
-
 ADD_CUSTOM_TARGET(uninstall
   "${CMAKE_COMMAND}" -P "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake")
 
@@ -161,42 +135,10 @@ add_definitions(-DBOOST_CHRONO_HEADER_ONLY -DBOOST_CONFIG_SUPPRESS_OUTDATED_MESS
 
 
 #############################################
-# Detect CCache
-
-find_program(CCacheExectuable ccache)
-if( CCacheExectuable )
-  # only used with >=cmake-3.4
-  set( CMAKE_C_COMPILER_LAUNCHER   "${CCacheExectuable}" )
-  set( CMAKE_CXX_COMPILER_LAUNCHER "${CCacheExectuable}" )
-  if(NOT CMAKE_GENERATOR MATCHES "Xcode" AND (NOT CMAKE_GENERATOR MATCHES "Visual Studio")) # we already post a message when using Xcode or MSVC
-    message(STATUS "Found ccache at ${CCacheExectuable}: using ccache to speed up build process")
-  endif()
-
-  # fix for Visual Studio adapted from https://github.com/ccache/ccache/wiki/MS-Visual-Studio#usage
-  # NOTE: there is an issue with ccache installed from chocolatey
-  # since chocolatey puts a "shim" as opposed to the actual executable in the PATH
-  # the solution is to add the path to the actual ccache executable earlier in the path
-  # e.g. in bash: export PATH=`echo c:/ProgramData/chocolatey/lib/ccache/tools/ccache*`:$PATH
-  if (MSVC)
-    message(STATUS "Found ccache at ${CCacheExectuable}: using ccache with MSVC to speed up build process")
-    file(COPY_FILE
-      ${CCacheExectuable} ${CMAKE_BINARY_DIR}/cl.exe
-      ONLY_IF_DIFFERENT)
-
-    set(CMAKE_VS_GLOBALS
-      "CLToolExe=cl.exe"
-      "CLToolPath=${CMAKE_BINARY_DIR}"
-      "TrackFileAccess=false"
-      "UseMultiToolTask=true"
-      "DebugInformationFormat=OldStyle"
-    )
-  endif()
-endif()
-
-#############################################
 # Options
 option(NOVA_SIMD "Build with nova-simd support." ON)
 option(FINAL_BUILD "Build as single source file." OFF)
+option(USE_CCACHE "Use ccache if available." ON)
 
 option(FFT_GREEN "Use internal 'Green' FFT lib rather than FFTW. (Not recommended.)" OFF)
 
@@ -299,6 +241,65 @@ if(APPLE)
     option(SC_CODESIGN_AFTER_DEPLOY "Run ad hoc codesigning after creating the app bundle" ON)
     # verify_app fails with official Qt; we'll still use it for Qt from homebrew
     option(SC_VERIFY_APP "Run verify_app on the app bundle" OFF)
+endif()
+
+#############################################
+# Detect CCache
+
+if(USE_CCACHE)
+
+  # find ccache
+  find_program(CCACHE_PROGRAM ccache)
+
+  if(CCACHE_PROGRAM)
+
+    set(CMAKE_C_COMPILER_LAUNCHER "${CCACHE_PROGRAM}")
+    set(CMAKE_CXX_COMPILER_LAUNCHER "${CCACHE_PROGRAM}")
+
+    if (MSVC)
+      # workaround for Visual Studio adapted from https://github.com/ccache/ccache/wiki/MS-Visual-Studio#usage
+      # NOTE: there is an issue with ccache installed from chocolatey
+      # since chocolatey puts a "shim" as opposed to the actual executable in the PATH
+      # the solution is to add the path to the actual ccache executable earlier in the path
+      # e.g. in bash: export PATH=`echo c:/ProgramData/chocolatey/lib/ccache/tools/ccache*`:$PATH
+      message(STATUS "Found ccache at ${CCACHE_PROGRAM}: using ccache with MSVC to speed up build process")
+
+      file(COPY_FILE
+        ${CCACHE_PROGRAM} ${CMAKE_BINARY_DIR}/cl.exe
+        ONLY_IF_DIFFERENT)
+
+      set(CMAKE_VS_GLOBALS
+        "CLToolExe=cl.exe"
+        "CLToolPath=${CMAKE_BINARY_DIR}"
+        "TrackFileAccess=false"
+        "UseMultiToolTask=true"
+        "DebugInformationFormat=OldStyle"
+      )
+    else()
+      if(CMAKE_GENERATOR STREQUAL "Xcode")
+        message(STATUS "Found ccache at ${CCACHE_PROGRAM}: using ccache with Xcode to speed up build process")
+
+        # workaround for using ccache with Xcode generator
+        # thanks to Craig Scott: https://crascit.com/2016/04/09/using-ccache-with-cmake/
+
+        # Set up wrapper scripts
+        set(SC_LAUNCH_C_SCRIPT   "${CMAKE_BINARY_DIR}/launch-c")
+        set(SC_LAUNCH_CXX_SCRIPT "${CMAKE_BINARY_DIR}/launch-cxx")
+        configure_file("cmake_modules/launch-c.in"   launch-c)
+        configure_file("cmake_modules/launch-cxx.in" launch-cxx)
+        execute_process(COMMAND chmod a+rx "${SC_LAUNCH_C_SCRIPT}" "${SC_LAUNCH_CXX_SCRIPT}")
+
+        # Set Xcode project attributes to route compilation and linking
+        # through our scripts
+        set(CMAKE_XCODE_ATTRIBUTE_CC         "${SC_LAUNCH_C_SCRIPT}")
+        set(CMAKE_XCODE_ATTRIBUTE_CXX        "${SC_LAUNCH_CXX_SCRIPT}")
+        set(CMAKE_XCODE_ATTRIBUTE_LD         "${SC_LAUNCH_C_SCRIPT}")
+        set(CMAKE_XCODE_ATTRIBUTE_LDPLUSPLUS "${SC_LAUNCH_CXX_SCRIPT}")
+      else()
+        message(STATUS "Found ccache at ${CCACHE_PROGRAM}: using ccache to speed up build process")
+      endif() # Xcode
+    endif() # MSVC
+  endif() # ccache found
 endif()
 
 #############################################

--- a/README_LINUX.md
+++ b/README_LINUX.md
@@ -315,11 +315,9 @@ You can do that by adding a line such as `PATH=$PATH:$HOME/usr/local/bin` to `~/
 
 If you are developing SC or you're constantly pulling in the latest changes, rebuilding SC repeatedly can be a drag.
 Installing `ccache` can speed up re-compilation.
-Here is how to configure cmake to use it:
+Ccache will be used automatically if it's in the PATH. 
+Use can disable using ccache by setting `-D USE_CCACHE=OFF`.
 
-```shell
-cmake -DCMAKE_CXX_COMPILER=/usr/lib/ccache/g++ -DCMAKE_C_COMPILER=/usr/lib/ccache/gcc ..
-```
 
 This assumes your ccache executables are installed into `/usr/lib/ccache` - you may need to change the path to reflect your installation.
 

--- a/README_MACOS.md
+++ b/README_MACOS.md
@@ -274,8 +274,10 @@ Using ccache with Xcode
 -----------------------
 
 Although cmake does not support using `ccache` with Xcode out of the box, this project is set up to
-allow it with the option `-DRULE_LAUNCH_COMPILE=ccache`. This can speed up build times
+support it. By default, ccache will be used if it's present on your system. This can speed up build times
 significantly, even when the build directory has been cleared.
+
+Using `ccache` can be disabled by setting cmake option `-D USE_CCACHE=OFF`.
 
 Building without Qt or the IDE
 ------------------------------

--- a/cmake_modules/launch-c.in
+++ b/cmake_modules/launch-c.in
@@ -2,4 +2,4 @@
 
 # thanks to Craig Scott: https://crascit.com/2016/04/09/using-ccache-with-cmake/
 export CCACHE_CPP2=true
-exec "${RULE_LAUNCH_COMPILE}" "${CMAKE_CXX_COMPILER}" "$@"
+exec "${CCACHE_PROGRAM}" "${CMAKE_C_COMPILER}" "$@"

--- a/cmake_modules/launch-cxx.in
+++ b/cmake_modules/launch-cxx.in
@@ -2,4 +2,4 @@
 # Thanks to Craig Scott: https://crascit.com/2016/04/09/using-ccache-with-cmake/
 
 export CCACHE_CPP2=true
-exec "${RULE_LAUNCH_COMPILE}" "${CMAKE_CXX_COMPILER}" "$@"
+exec "${CCACHE_PROGRAM}" "${CMAKE_CXX_COMPILER}" "$@"


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->


## Purpose and Motivation

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

This PR cleans up our ccache integration, inspired by redundancies exposed by #6209. It also adds the `USE_CCACHE` CMake flag which allows disabling ccache. This PR supersedes #6209.

Waiting for the CI run to confirm caching still works, particularly on macOS, where the implementation was updated... EDIT: seems to work! The [build step took under a minute](https://github.com/supercollider/supercollider/actions/runs/14697811939/job/41242079773#step:14:1).

## Outstanding questions

I kept the option to use ccache **ON** by default. CMake configuration posts an information if ccache is found, but there's no posting if it isn't. Do we have a preference on setting it on or off by default? I'm happy to go either way and update this PR as needed (including CI and docs).

## Types of changes

<!-- Delete lines that don't apply -->

- Documentation
- Bug fix
- New feature

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [ ] Decide whether ccache should be ON or OFF by default
- [x] Code is tested
- [ ] All tests are passing (test failures are unrelated to this PR)
- [x] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
