### PR TITLE
doc: add undefined overflow notes to affected Number, RawArray classes

### DIFF
--- a/HelpSource/Classes/DoubleArray.schelp
+++ b/HelpSource/Classes/DoubleArray.schelp
@@ -27,6 +27,11 @@ list::
 ## link::Classes/SymbolArray:: - symbols
 ::
 
+note::
+The overflow/underflow behavior of an element in a DoubleArray is undefined but usually code::inf::/code::-inf::, respectively. This occurs whenever the result of an operation does not fit in the range of values supported by the return type, in this case, a 64-bit floating point number. 
+See the note in link::Classes/Float::.
+::
+
 INSTANCEMETHODS::
 
 method::readFromStream

--- a/HelpSource/Classes/Float.schelp
+++ b/HelpSource/Classes/Float.schelp
@@ -3,7 +3,7 @@ summary:: 64-bit Floating point number
 categories:: Math
 
 description::
-A 64-bit double precision floating point number. Float inherits most of its behaviour from its superclass.
+A 64-bit double precision floating point number. Float inherits most of its behaviour from its superclass, link::Classes/SimpleNumber::.
 
 code::
 // generate 10 random floats between 0 and 1
@@ -21,6 +21,10 @@ apotome / limma
 
 Note that despite its name, link::Classes/FloatArray:: only holds 32-bit (single precision) floats.
 For a raw array of 64-bit floats, use link::Classes/DoubleArray::.
+
+note::
+The overflow/underflow behavior of a Float is undefined but usually code::inf::/code::-inf::, respectively, since most CPUs comply well enough IEEE-754 floating point. However, the overflow/underflow behavior is still usually handed to the hardware and thus can vary per system. This (overflow/underflow) occurs whenever the result of an operation does not fit in the range of values supported by the return type, in this case, a 64-bit floating point number.
+::
 
 ClassMethods::
 
@@ -139,9 +143,9 @@ class   decmial          significant part      exponent part
 
 subsection::Using Floats as replacement for Integers
 
-In SuperCollider, Floats are 64-bit wide. Because  an link::Classes/Integer::  is 32-bit, it can only capture integers in the range code::-2147483648 .. +2147483647::, or about code:: 2 x 10^9 ::.
+In SuperCollider, Floats are 64 bits wide. Because an link::Classes/Integer:: is 32-bit, it can only capture integers in the range -2147483648 (code::-2^31::) to 2147483647 (code::2^31 - 1::).
 
-Therefore, in some situations it can be useful to calculate with floats also when only whole numbers are needed. You can use 64-bit floats for integer calculations up to code::± 9007199254740992:: (code::2^53::, or about code::9 x 10^15::). Sometimes one can go even further (see example below).
+Therefore, in some situations it can be useful to calculate with floats also when only whole numbers are needed. You can use 64-bit floats for integer calculations in the range ::± 9007199254740992::, or about code::±2^53::. Sometimes one can go even further (see example below).
 
 
 code::

--- a/HelpSource/Classes/FloatArray.schelp
+++ b/HelpSource/Classes/FloatArray.schelp
@@ -28,6 +28,11 @@ list::
 ## link::Classes/SymbolArray:: - symbols
 ::
 
+note::
+The overflow/underflow behavior of an element in a FloatArray is undefined but usually code::inf::/code::-inf::, respectively. This occurs whenever the result of an operation does not fit in the range of values supported by the return type, in this case, a 32-bit floating point number. 
+See the note in link::Classes/Float::.
+::
+
 INSTANCEMETHODS::
 
 method::readFromStream

--- a/HelpSource/Classes/Int16Array.schelp
+++ b/HelpSource/Classes/Int16Array.schelp
@@ -14,6 +14,10 @@ list::
 ## SymbolArray - symbols
 ::
 
+note::
+The overflow behavior of an element in an Int16Array is undefined. This occurs whenever the result of an operation does not fit in the range of values supported by the return type, in this case, a 16-bit signed integer.
+::
+
 INSTANCEMETHODS::
 
 method::readFromStream

--- a/HelpSource/Classes/Int32Array.schelp
+++ b/HelpSource/Classes/Int32Array.schelp
@@ -14,6 +14,12 @@ list::
 ## SymbolArray - symbols
 ::
 
+note::
+The overflow behavior of an element in an Int32Array is undefined. This occurs whenever the result of an operation does not fit in the range of values supported by the return type, in this case, a 32-bit signed integer.
+
+Elements in Int32Array are not guaranteed to behave like link::Classes/Integer::s.
+::
+
 INSTANCEMETHODS::
 
 method::readFromStream

--- a/HelpSource/Classes/Int8Array.schelp
+++ b/HelpSource/Classes/Int8Array.schelp
@@ -14,6 +14,10 @@ list::
 ## SymbolArray - symbols
 ::
 
+note::
+The overflow behavior of an element in an Int8Array is undefined. This occurs whenever the result of an operation does not fit in the range of values supported by the return type, in this case, an 8-bit signed integer.
+::
+
 INSTANCEMETHODS::
 
 method::readFromStream

--- a/HelpSource/Classes/Integer.schelp
+++ b/HelpSource/Classes/Integer.schelp
@@ -1,12 +1,14 @@
 class:: Integer
-summary:: Integer number
+summary:: 32-bit Integer number
 categories:: Math
 
 description::
-A 32 bit integer. Integer inherits most of its behaviour from its superclass.
+A 32-bit integer. Integer inherits most of its behaviour from its superclass, link::Classes/SimpleNumber::.
 
 note::
-A 32 bit signed integer can represent values in the range -2147483648 to 2147483647. Adding up further returns in a wrapped result, so that and 2147483647+1 = -2147483648. For a larger range, one can use link::Classes/Float::, which is 64 bit and supports many (but not all) numerical methods that int does.
+Integer can represent values in the range -2147483648 (code::-2^31::) to 2147483647 (code::2^31 - 1::).
+
+The overflow behavior of an Integer is undefined. This occurs whenever the result of an operation does not fit in the range of values supported by the return type, in this case, a 32-bit signed integer. Consider using the 64-bit link::Classes/Float:: for larger numbers (up to code::±2^53::).
 ::
 
 


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

Closes #6687. Overflow is an interesting behavior whose definition or lack thereof should be apparent in the documentation for classes that exhibit the behavior. Overflow behavior for float and (signed) integer types in C++ is undefined, and those types are on the backend of several `Number` and `RawArray` classes in sclang. 

There's already a divergence in overflow behavior for the `Int32Array` dependent on the platform (see linked issue).

(If I missed any other affected classes, please let me know.)

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->

- Documentation

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
