### PR TITLE
Correct "values for strong::index:: greater than the size of the ArrayedCollection/List"

### DIFF
--- a/HelpSource/Classes/ArrayedCollection.schelp
+++ b/HelpSource/Classes/ArrayedCollection.schelp
@@ -77,14 +77,14 @@ x[y]; // returns [10, 10, 30, 30, 20]
 ::
 
 method::clipAt
-Same as link::#-at::, but values for strong::index:: greater than the size of the ArrayedCollection will be clipped to the last index.
+Same as link::#-at::, but items for strong::index:: greater than the link::Classes/ArrayedCollection:: instance size minus one will be clipped to the last index.
 code::
 y = [1, 2, 3];
 y.clipAt(13).postln;
 ::
 
 method::wrapAt
-Same as link::#-at::, but values for strong::index:: greater than the size of the ArrayedCollection will be wrapped around to 0.
+Same as link::#-at::, but items for strong::index:: greater than the link::Classes/ArrayedCollection:: instance size minus one will be wrapped around to 0.
 code::
 y = [1, 2, 3];
 y.wrapAt(3).postln; // this returns the value at index 0
@@ -93,7 +93,7 @@ y.wrapAt([-2, 1])   // index can also be a collection or negative numbers
 ::
 
 method::foldAt
-Same as link::#-at::, but values for strong::index:: greater than the size of the ArrayedCollection will be folded back.
+Same as link::#-at::, but items for strong::index:: greater than the link::Classes/ArrayedCollection:: instance size minus one will be folded back.
 code::
 y = [1, 2, 3];
 y.foldAt(3).postln; // this returns the value at index 1
@@ -114,13 +114,13 @@ method::put
 Put strong::item:: at strong::index::, replacing what is there.
 
 method::clipPut
-Same as link::#-put::, but values for strong::index:: greater than the size of the ArrayedCollection will be clipped to the last index.
+Same as link::#-put::, but items for strong::index:: greater than the link::Classes/ArrayedCollection:: instance size minus one will be clipped to the last index.
 
 method::wrapPut
-Same as link::#-put::, but values for strong::index:: greater than the size of the ArrayedCollection will be wrapped around to 0.
+Same as link::#-put::, but items for strong::index:: greater than the link::Classes/ArrayedCollection:: instance size minus one will be wrapped around to 0.
 
 method::foldPut
-Same as link::#-put::, but values for strong::index:: greater than the size of the ArrayedCollection will be folded back.
+Same as link::#-put::, but items for strong::index:: greater than the link::Classes/ArrayedCollection:: instance size minus one will be folded back.
 
 method::putEach
 Put the strong::values:: in the corresponding indices given by strong::keys::. If one of the two argument arrays is longer then it will wrap.

--- a/HelpSource/Classes/ArrayedCollection.schelp
+++ b/HelpSource/Classes/ArrayedCollection.schelp
@@ -77,7 +77,7 @@ x[y]; // returns [10, 10, 30, 30, 20]
 ::
 
 method::clipAt
-Same as link::#-at::, but items for strong::index:: greater than the link::Classes/ArrayedCollection:: instance size minus one will be clipped to the last index.
+Same as link::#-at::, but items for strong::index:: greater than the link::Classes/ArrayedCollection:: instance size minus one will be clipped to code::size - 1::, which is the last index.
 code::
 y = [1, 2, 3];
 y.clipAt(13).postln;
@@ -114,7 +114,7 @@ method::put
 Put strong::item:: at strong::index::, replacing what is there.
 
 method::clipPut
-Same as link::#-put::, but items for strong::index:: greater than the link::Classes/ArrayedCollection:: instance size minus one will be clipped to the last index.
+Same as link::#-put::, but items for strong::index:: greater than the link::Classes/ArrayedCollection:: instance size minus one will be clipped to code::size - 1::, which is the last index.
 
 method::wrapPut
 Same as link::#-put::, but items for strong::index:: greater than the link::Classes/ArrayedCollection:: instance size minus one will be wrapped around to 0.

--- a/HelpSource/Classes/List.schelp
+++ b/HelpSource/Classes/List.schelp
@@ -57,7 +57,7 @@ List[1, 2, 3].at(0).postln;
 ::
 
 method::clipAt
-Same as link::#-at::, but items for strong::index:: greater than the link::Classes/List:: instance size minus one will be clipped to the last index.
+Same as link::#-at::, but items for strong::index:: greater than the link::Classes/List:: instance size minus one will be clipped to code::size - 1::, which is the last index.
 code::
 y = List[1, 2, 3];
 y.clipAt(13).postln;
@@ -84,7 +84,7 @@ method::put
 Put strong::item:: at strong::index::, replacing what is there.
 
 method::clipPut
-Same as link::#-put::, but items for strong::index:: greater than the link::Classes/List:: instance size minus one will be clipped to the last index.
+Same as link::#-put::, but items for strong::index:: greater than the link::Classes/List:: instance size minus one will be clipped to code::size - 1::, which is the last index.
 
 method::wrapPut
 Same as link::#-put::, but items for strong::index:: greater than the link::Classes/List:: instance size minus one will be wrapped around to 0.

--- a/HelpSource/Classes/List.schelp
+++ b/HelpSource/Classes/List.schelp
@@ -57,14 +57,14 @@ List[1, 2, 3].at(0).postln;
 ::
 
 method::clipAt
-Same as link::#-at::, but values for strong::index:: greater than the size of the List will be clipped to the last index.
+Same as link::#-at::, but items for strong::index:: greater than the link::Classes/List:: instance size minus one will be clipped to the last index.
 code::
 y = List[1, 2, 3];
 y.clipAt(13).postln;
 ::
 
 method::wrapAt
-Same as link::#-at::, but values for strong::index:: greater than the size of the List will be wrapped around to 0.
+Same as link::#-at::, but items for strong::index:: greater than the link::Classes/List:: instance size minus one will be wrapped around to 0.
 code::
 y = List[1, 2, 3];
 y.wrapAt(3).postln; // this returns the value at index 0
@@ -72,7 +72,7 @@ y.wrapAt(4).postln; // this returns the value at index 1
 ::
 
 method::foldAt
-Same as link::#-at::, but values for strong::index:: greater than the size of the List will be folded back.
+Same as link::#-at::, but items for strong::index:: greater than the link::Classes/List:: instance size minus one will be folded back.
 code::
 y = List[1, 2, 3];
 y.foldAt(3).postln; // this returns the value at index 1
@@ -84,13 +84,13 @@ method::put
 Put strong::item:: at strong::index::, replacing what is there.
 
 method::clipPut
-Same as link::#-put::, but values for strong::index:: greater than the size of the List will be clipped to the last index.
+Same as link::#-put::, but items for strong::index:: greater than the link::Classes/List:: instance size minus one will be clipped to the last index.
 
 method::wrapPut
-Same as link::#-put::, but values for strong::index:: greater than the size of the List will be wrapped around to 0.
+Same as link::#-put::, but items for strong::index:: greater than the link::Classes/List:: instance size minus one will be wrapped around to 0.
 
 method::foldPut
-Same as link::#-put::, but values for strong::index:: greater than the size of the List will be folded back.
+Same as link::#-put::, but items for strong::index:: greater than the link::Classes/List:: instance size minus one will be folded back.
 
 method::add
 Adds an strong::item:: to the end of the List.


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation
While working on #6394, @cdbzb [mentioned an issue regarding an expression](https://github.com/supercollider/supercollider/commit/5e18589a240aa319f02e7744454cb8b2daf754e3#r156161407):

>values for strong::index:: greater than the size of the List/ArrayedCollection.

This expression is not entirely accurate, as the last index is reduced by one from the instance’s total size.
This PR resolves this issue.

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->

- Documentation
- Bug fix

## To-do list
Correct "values for strong::index:: greater than the size of the ArrayedCollection/List"
<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
