### PR TITLE
Further `README_LINUX.md` improvements

### DIFF
--- a/README_LINUX.md
+++ b/README_LINUX.md
@@ -268,7 +268,7 @@ sudo ldconfig
 ```
 To uninstall:
 ```shell
-make sudo uninstall
+sudo make uninstall
 ```
 (or `make uninstall` if you did user-wide installation).
 

--- a/README_LINUX.md
+++ b/README_LINUX.md
@@ -56,40 +56,28 @@ There are dedicated READMEs in this repository for building on particular embedd
 - BeagleBone Black: README_BEAGLEBONE_BLACK.md
 - Bela: README_BELA.md
 
-On Debian-like systems (e.g: Ubuntu, Linux Mint, Kali Linux, Elementary OS, Knoppix, Corel Linux, Lindows and so on), the following commands can be execueted step by step to install all necessary dependencies and build SuperCollider:
+On Debian-like systems (e.g: Ubuntu, Linux Mint, Kali Linux, Elementary OS, Knoppix, Corel Linux, Lindows and so on), the following terminal commands can be executed step by step to install all necessary dependencies and build SuperCollider:
 
-### Step 1: Update the package list on your system
-
-    sudo apt-get update
-
-### Step 2: Install newer versions of the software packages that are already installed on your system
-
-    sudo apt-get upgrade
-
-If Step 2 requests reboot:
-
-    reboot
-
-### Step 3: Install emacs if you need emacs:
-
-    sudo apt-get install emacs 
-    
-**Note:** If you do not install emacs using the command above, you should use the following command when running cmake with default settings:
-
-    cmake -DSC_EL=NO ..
-    
-### Step 4: Install the JACK Audio Connection Kit (JACK), specifically the version 2
-
-    sudo apt-get install jackd2
-
-### Step 5: Install dependencies
-
-The following command installs all the recommended dependencies for sclang except for Qt:
-
-    sudo apt-get install git libasound2-dev libicu-dev libreadline6-dev libudev-dev pkg-config libncurses5-dev
-
-**Note:** The following command installs the minimal recommended dependencies for compiling scsynth and supernova:
-
+Before installing the dependencies, it is highly recommended to update the package list on your system with the following command:
+```shell
+sudo apt-get update
+```
+It is also recommended to install newer versions of software packages already installed on your system using the following command:
+```shell
+sudo apt-get upgrade
+```
+**Note::** If this updates the Linux system kernel, the terminal window may require the system to be rebooted. 
+In this case, it is recommended to reboot the system with the following command:
+```shell
+reboot
+```
+After rebooting, you can proceed with the next steps of installing the dependencies.
+The following command will install all recommended dependencies for sclang except Qt:
+```shell
+sudo apt-get install git libasound2-dev libicu-dev libreadline6-dev libudev-dev pkg-config libncurses5-dev emacs jackd2
+```
+**Note:** The following command will install the minimum recommended dependencies for compiling scsynth and supernova:
+```shell
 sudo apt-get install \
   build-essential \
   cmake \
@@ -99,14 +87,14 @@ sudo apt-get install \
   libxt-dev \
   libavahi-client-dev \
   libudev-dev
-
-If you need to use JACK1 replace libjack-jackd2-dev by libjack-dev.
+```
+If you need to use JACK1 replace libjack-jackd2-dev with libjack-dev.
 
 Installing requirements on Fedora
 ---------------------------------
 
 The following commands should install all the recommended SuperCollider dependencies on Fedora, except for Qt:
-```sh
+```shell
 sudo dnf groupinstall "Development Tools"
 sudo dnf install cmake libsndfile-devel wayland-devel xorg-x11-server-Xwayland-devel pipewire-devel pipewire-jack-audio-connection-kit-devel systemd-devel fftw-devel alsa-lib-devel libatomic
 sudo dnf install emacs # if building with the sc-el backend (default)
@@ -120,13 +108,13 @@ Installing Qt
 ### Installing Qt on recent Debian-like operating systems
 
 Try this command to query the Qt6 version available to you:
-
-    apt-cache policy qt6-base-dev
-
+```shell
+apt-cache policy qt6-base-dev
+```
 If this displays version 6.2 or later, you can install Qt6 using `apt`. Please note that this list of packages might not be complete, as it hasn't been revised for Qt6.
-
-    sudo apt-get install qt6-base-dev qt6-base-dev-tools qt6-tools-dev qt6-tools-dev-tools libqt6websockets6-dev libqt6webenginecore6 qt6-webengine-dev qt6-webengine-dev-tools libqt6svgwidgets6
-
+```shell
+sudo apt-get install qt6-base-dev qt6-base-dev-tools qt6-tools-dev qt6-tools-dev-tools libqt6websockets6-dev libqt6webenginecore6 qt6-webengine-dev qt6-webengine-dev-tools libqt6svgwidgets6
+```
 If you are on Ubuntu, check the sections below. If these instructions don't work, you will have to use the official Qt installer.
 
 ### Installing Qt on Ubuntu 22.04, 24.04
@@ -140,7 +128,7 @@ On 22.04 and 24.04 Qt6 is available in the system's package manager. The followi
 
 Please note, this list has not been tested after upgrading to Qt6. Additional packages may be needed.
 
-```sh
+```shell
 sudo dnf install qt6-qtbase-devel qt6-qtsvg-devel qt6-qtwebengine-devel qt6-linguist qt6-qtwebsockets-devel
 ```
 
@@ -169,21 +157,21 @@ Obtaining the SuperCollider source code can be done either by downloading a rele
 SuperCollider releases are available to download here: https://github.com/supercollider/supercollider/releases
 
 Cloning the repository can be done with the following command:
-
-    git clone --recurse-submodules https://github.com/SuperCollider/SuperCollider.git
-
+```shell
+git clone --recurse-submodules https://github.com/SuperCollider/SuperCollider.git
+```
 The `--recurse-submodules` option will clone the repository's submodules which are needed to build SuperCollider. The submodules can also be obtained by navigating to the root of your locally cloned SuperCollider repository and running the following command:
-
-    git submodule update --init --recursive
-
+```shell
+git submodule update --init --recursive
+```
 ### Step 2: Make a build directory
 
 First, `cd` into the root of the SuperCollider source directory (where this file resides).
 
 Create a build directory and `cd` into it:
-
-    mkdir build && cd build
-
+```shell
+mkdir build && cd build
+```
 You can actually name this whatever you want, allowing you to have multiple independent build directories. If your SuperCollider source is also a git repository, the `.gitignore` file is configured to ignore files of the form `build*`.
 
 ### Step 3: Set CMake flags
@@ -191,11 +179,17 @@ You can actually name this whatever you want, allowing you to have multiple inde
 Depending on what SuperCollider components you wish to build and install, you can set CMake flags.
 
 To run cmake with default settings:
-
-    cmake ..
-
+```shell
+cmake ..
+```
 You can set CMake flags on the command line using `cmake -DKEY=value ..` where the `D` prefix is necessary!
 You can also use cmake gui-frontends like [`ccmake`](https://packages.debian.org/en/sid/cmake-curses-gui) or [`cmake-gui`](https://packages.debian.org/sid/cmake-qt-gui) to inspect and set the available flags.
+
+**Example:**
+If you did not install emacs, you should use the following command:
+```shell
+cmake -DSC_EL=NO ..
+```
 It is also possible to edit the `CMakeCache.txt` file or re-execute the `cmake` command with the desired flags.
 CMake flags are persistent and you only need to run these commands once each.
 
@@ -204,43 +198,43 @@ We will cover a few important settings. There are others, which you can view wit
 #### Nonstandard Qt locations
 
 If you are installing sclang with GUI features and the IDE, and you installed Qt using the official Qt installer, you will need to tell SuperCollider where Qt is. To do so:
-
-    cmake -DCMAKE_PREFIX_PATH=/path/to/qt6 ..
-
+```shell
+cmake -DCMAKE_PREFIX_PATH=/path/to/qt6 ..
+```
 The location of `/path/to/qt6` will depend on how you installed Qt:
 
 - If you downloaded Qt from the Qt website, the path is two directories down from the top-level unpacked Qt directory, in a folder called `gcc`: `Qt/5.11.0/gcc_64/` (64-bit Linux) or `Qt/5.11.0/gcc/` (32-bit). By default, the Qt installer places `Qt/` in your home directory.
 
 If you want to build without Qt entirely, run
-
-    cmake -DSC_QT=OFF ..
-
+```shell
+cmake -DSC_QT=OFF ..
+```
 #### Compiler optimizations
 
 If you're building SC for production use and/or don't plan on using a debugger, make sure to build in release mode:
-
-    cmake -DCMAKE_BUILD_TYPE=Release ..
-
+```shell
+cmake -DCMAKE_BUILD_TYPE=Release ..
+```
 This sets the compiler to the best optimization settings. Switch back to the defaults using `cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo ..`.
 
 If you're compiling SC only for use on your own machine (that is, you aren't cross-compiling or packaging SC for distribution), it is recommended to turn on the `NATIVE` flag to enable CPU-specific optimizations:
-
-    cmake -DNATIVE=ON ..
-
+```shell
+cmake -DNATIVE=ON ..
+```
 #### Install location
 
 By default, SuperCollider installs in `/usr/local`, a system-wide install. Maybe you can't or don't want to use superuser privileges, or just want to install for a single user. To do so, set `CMAKE_INSTALL_PREFIX` to the desired installation directory. One good place to put it would be `$HOME/usr/local`:
-
-    cmake -DCMAKE_INSTALL_PREFIX=~/usr/local ..
-
+```shell
+cmake -DCMAKE_INSTALL_PREFIX=~/usr/local ..
+```
 Make sure `~/usr/local/bin` is in your `PATH` if you do this. You can do that by adding a line such as `PATH=$PATH:$HOME/usr/local/bin` to `~/.profile`.
 
 #### Speeding up repeated builds
 
 If you are developing SC or you're constantly pulling in the latest changes, rebuilding SC repeatedly can be a drag. Installing `ccache` can speed up re-compilation. Here is how to configure cmake to use it:
-
-    cmake -DCMAKE_CXX_COMPILER=/usr/lib/ccache/g++ -DCMAKE_C_COMPILER=/usr/lib/ccache/gcc ..
-
+```shell
+cmake -DCMAKE_CXX_COMPILER=/usr/lib/ccache/g++ -DCMAKE_C_COMPILER=/usr/lib/ccache/gcc ..
+```
 This assumes your ccache executables are installed into `/usr/lib/ccache` - you may need to change the path to reflect your installation.
 
 #### Library suffix
@@ -249,34 +243,34 @@ In some situations, it is preferable to install libraries and plugins
 not in the `lib` directory but in a suffixed one, e.g. `lib64`.
 In such a case you can set the cmake variable `LIB_SUFFIX`.
 For example if you wish to install into `lib64`:
-
-    cmake -DLIB_SUFFIX=64 ..
-
+```shell
+cmake -DLIB_SUFFIX=64 ..
+```
 ### Step 4: Build
 
 If CMake ran successfully without errors, you are ready to move on to building. You can freely alternate between building and setting CMake flags.
 
 After setting your CMake flags, just run
-
-    make
-
+```shell
+make
+```
 The `-j` option allows multiple jobs to be run simultaneously, which can improve compile times on machines with multiple cores. The optimal `-j` setting varies between machines, but a good rule of thumb is the number of cores plus one. For example, on a 4-core system, try `make -j5`.
 
 And to install, run
-
-    sudo make install
-
+```shell
+sudo make install
+```
 You will need to use `make install` if you are doing a user-wide installation, which is not the default.
 
 After installing for the first time, please run
-
-    sudo ldconfig
-
+```shell
+sudo ldconfig
+```
 To uninstall:
-
-    make uninstall
-
-(or `sudo make uninstall`).
+```shell
+make sudo uninstall
+```
+(or `make uninstall` if you did user-wide installation).
 
 Building a Debian package
 -------------------------
@@ -314,8 +308,7 @@ Running sclang
 --------------
 
 Supercollider comes with its own powerful IDE. Run it with:
-
-```
+```shell
 $> scide
 ```
 
@@ -352,25 +345,25 @@ environment variables:
 
  * SC_JACK_DEFAULT_INPUTS comma-separated list of jack ports that the server's inputs should connect by default
 
-   ```
+   ```shell
    $> export SC_JACK_DEFAULT_INPUTS="system:capture_1,system:capture_2"
    ```
 
    in order to connect the first ports of one jack client, it is possible to specify only the client name
 
-   ```
+   ```shell
    $> export SC_JACK_DEFAULT_INPUTS="system"
    ```
 
  * SC_JACK_DEFAULT_OUTPUTS comma-separated list of jack ports that the server's outputs should be connected to by default.
 
-   ```
+   ```shell
    $> export SC_JACK_DEFAULT_OUTPUTS="system:playback_1,system:playback_2"
    ```
 
    In order to connect the first ports of one jack client, it is possible to specify only the client name
 
-   ```
+   ```shell
    $> export SC_JACK_DEFAULT_OUTPUTS="system"
    ```
 
@@ -380,7 +373,7 @@ names are separated by ':' as in the Unix PATH variable:
 
  * SC_PLUGIN_PATH, SC_SYNTHDEF_PATH
 
-   ```
+   ```shell
    $> export SC_SYNTHDEF_PATH="./synthdefs:/home/sk/SuperCollider/synthdefs"
    ```
 

--- a/README_LINUX.md
+++ b/README_LINUX.md
@@ -186,7 +186,7 @@ You can set CMake flags on the command line using `cmake -DKEY=value ..` where t
 You can also use cmake gui-frontends like [`ccmake`](https://packages.debian.org/en/sid/cmake-curses-gui) or [`cmake-gui`](https://packages.debian.org/sid/cmake-qt-gui) to inspect and set the available flags.
 
 **Example:**
-If you did not install emacs, you should use the following command:
+If you do not have emacs installed, you should add `-DSC_EL=NO` as in the following command:
 ```shell
 cmake -DSC_EL=NO ..
 ```

--- a/README_LINUX.md
+++ b/README_LINUX.md
@@ -56,16 +56,44 @@ There are dedicated READMEs in this repository for building on particular embedd
 - BeagleBone Black: README_BEAGLEBONE_BLACK.md
 - Bela: README_BELA.md
 
-On Debian-like systems, the following command installs the minimal recommended dependencies for compiling scsynth and supernova:
+On Debian-like systems (e.g: Ubuntu, Linux Mint, Kali Linux, Elementary OS, Raspberry Pi OS, Knoppix, Corel Linux, Lindows and so on), the following commands could be execueted step by step:
 
-    sudo apt-get install build-essential cmake libjack-jackd2-dev libsndfile1-dev libfftw3-dev libxt-dev libavahi-client-dev
+### Step 1: Update the package list on your system
 
-If you need to use JACK1 replace libjack-jackd2-dev by libjack-dev.
+    sudo apt-get update
+
+### Step 2: Install newer versions of the software packages that are already installed on your system
+
+    sudo apt-get upgrade
+
+If Step 2 requests reboot:
+
+    reboot
+
+### Step 3: Install emacs if you need emacs:
+
+    sudo apt-get install emacs 
+    
+!!! If you do not install emacs using the command above, you should use the following command when runninc cmake with default settings:
+
+    cmake -DSC_EL=NO ..
+    
+### Step 4: Install the JACK Audio Connection Kit (JACK), specifically the version 2
+
+    sudo apt-get install jackd2
+
+### Step 5: Install dependencies
 
 The following command installs all the recommended dependencies for sclang except for Qt:
 
     sudo apt-get install git libasound2-dev libicu-dev libreadline6-dev libudev-dev pkg-config libncurses5-dev
-    
+
+!!! The following command installs the minimal recommended dependencies for compiling scsynth and supernova:
+
+    sudo apt-get install build-essential cmake libjack-jackd2-dev libsndfile1-dev libfftw3-dev libxt-dev libavahi-client-dev libudev-dev
+
+If you need to use JACK1 replace libjack-jackd2-dev by libjack-dev.
+
 Installing requirements on Fedora
 ---------------------------------
 
@@ -146,14 +174,19 @@ First, `cd` into the root of the SuperCollider source directory (where this file
 
 Create a build directory and `cd` into it:
 
-    mkdir build
-    cd build
+    mkdir build && cd build
 
 You can actually name this whatever you want, allowing you to have multiple independent build directories. If your SuperCollider source is also a git repository, the `.gitignore` file is configured to ignore files of the form `build*`.
 
 ### Step 3: Set CMake flags
 
-Depending on what SuperCollider components you wish to install, you can set CMake flags. You can set CMake flags on the command line using `cmake -DKEY=value ..`. You can also use cmake frontends like ccmake or cmake-gui, or simply edit the `CMakeCache.txt` file. CMake flags are persistent and you only need to run these commands once each.
+Depending on what SuperCollider components you wish to install, you can set CMake flags:
+
+To run cmake with default settings:
+
+    cmake ..
+
+You can set CMake flags on the command line using `cmake -DKEY=value ..`. You can also use cmake frontends like ccmake or cmake-gui, or simply edit the `CMakeCache.txt` file. CMake flags are persistent and you only need to run these commands once each.
 
 We will cover a few important settings. There are others, which you can view with `cmake -LH ..`. We will document more of them in this README file soon.
 
@@ -220,9 +253,9 @@ The `-j` option allows multiple jobs to be run simultaneously, which can improve
 
 And to install, run
 
-    make install
+    sudo make install
 
-You will need to use `sudo make install` if you are doing a system-wide installation, which is the default.
+You will need to use `make install` if you are doing a user-wide installation, which is not the default.
 
 After installing for the first time, please run
 

--- a/README_LINUX.md
+++ b/README_LINUX.md
@@ -188,7 +188,7 @@ You can actually name this whatever you want, allowing you to have multiple inde
 
 ### Step 3: Set CMake flags
 
-Depending on what SuperCollider components you wish to install, you can set CMake flags:
+Depending on what SuperCollider components you wish to build and install, you can set CMake flags.
 
 To run cmake with default settings:
 

--- a/README_LINUX.md
+++ b/README_LINUX.md
@@ -90,7 +90,15 @@ The following command installs all the recommended dependencies for sclang excep
 
 **Note:** The following command installs the minimal recommended dependencies for compiling scsynth and supernova:
 
-    sudo apt-get install build-essential cmake libjack-jackd2-dev libsndfile1-dev libfftw3-dev libxt-dev libavahi-client-dev libudev-dev
+sudo apt-get install \
+  build-essential \
+  cmake \
+  libjack-jackd2-dev \
+  libsndfile1-dev \
+  libfftw3-dev \
+  libxt-dev \
+  libavahi-client-dev \
+  libudev-dev
 
 If you need to use JACK1 replace libjack-jackd2-dev by libjack-dev.
 

--- a/README_LINUX.md
+++ b/README_LINUX.md
@@ -98,6 +98,7 @@ The following commands should install all the recommended SuperCollider dependen
 sudo dnf groupinstall "Development Tools"
 sudo dnf install cmake libsndfile-devel wayland-devel xorg-x11-server-Xwayland-devel pipewire-devel pipewire-jack-audio-connection-kit-devel systemd-devel fftw-devel alsa-lib-devel libatomic
 sudo dnf install emacs # if building with the sc-el backend (default)
+sudo dnf install libXt-devel 
 ```
 
 Installing Qt
@@ -130,6 +131,7 @@ Please note, this list has not been tested after upgrading to Qt6. Additional pa
 
 ```shell
 sudo dnf install qt6-qtbase-devel qt6-qtsvg-devel qt6-qtwebengine-devel qt6-linguist qt6-qtwebsockets-devel
+sudo dnf install qt6-qttools-devel
 ```
 
 ### Installing Qt using the official installer

--- a/README_LINUX.md
+++ b/README_LINUX.md
@@ -1,82 +1,73 @@
-Building SuperCollider on Linux
-===============================
+# Building SuperCollider on Linux
 
-Build requirements
-------------------
+## Build requirements
 
 These are strict requirements for scsynth and supernova:
 
-- A C++ compiler with C++17 support. 
-- [cmake][cmake] >= 3.12: Cross-platform build system.
-- [libsndfile][libsndfile] >= 1.0: Soundfile I/O.
-- [libjack][libjack]: Development headers for the JACK Audio Connection Kit.
-- [fftw][fftw] >= 3.0: FFT library.
+- A C++ compiler with C++17 support such as [gcc](http://www.gnu.org/software/gcc) or [clang](https://clang.llvm.org)
+- [cmake](http://www.cmake.org) >= 3.12: Cross-platform build system.
+- [libsndfile](http://www.mega-nerd.com/libsndfile) >= 1.0: Soundfile I/O.
+- [libjack](http://www.jackaudio.org/): Development headers for the JACK Audio Connection Kit.
+- [fftw](http://www.fftw.org) >= 3.0: FFT library.
 
 These packages are required by default for scsynth and supernova, but the components that require them can be disabled with flags:
 
-- [libxt][libxt]: X toolkit intrinsics, required for UGens such as `MouseX`. To build the servers without X, use the `NO_X11=ON` CMake flag.
-- [libavahi-client][libavahi-client]: For zero-configuration networking. To build the servers without Avahi, use the `NO_AVAHI=ON` CMake flag.
+- [libxt](http://www.X.org): X toolkit intrinsics, required for UGens such as `MouseX`.
+  To build the servers without X, use the `NO_X11=ON` CMake flag.
+- [libavahi-client](http://www.avahi.org): For zero-configuration networking.
+  To build the servers without Avahi, use the `NO_AVAHI=ON` CMake flag.
 
-[gcc]: http://www.gnu.org/software/gcc
-[clang]: https://clang.llvm.org
-[libjack]: http://www.jackaudio.org/
-[cmake]: http://www.cmake.org
-[libsndfile]: http://www.mega-nerd.com/libsndfile
-[fftw]: http://www.fftw.org
-[libavahi-client]: http://www.avahi.org
-[libxt]: http://www.X.org
-
-Recommended packages
---------------------
+### Recommended packages
 
 For sclang and scide:
 
-- [Qt][Qt] >= 6.2 with QtWebEngine and QtWebSockets: Cross-platform GUI library, required for the IDE and for sclang's Qt GUI kit.
-- [git][git]: Required for sclang's Quarks system.
-- [ALSA][ALSA]: Linux sound library, required for sclang MIDI support.
-- [libudev][libudev]: Device manager library, required for HID support.
-- [Linux kernel][Linux kernel] >= 2.6: Required for LID support.
-- [libreadline][libreadline] >= 5: Required for sclang's CLI interface.
-- [ncurses][ncurses]: Required for sclang's CLI interface.
+- [Qt](http://qt-project.org) >= 6.2 with QtWebEngine and QtWebSockets: Cross-platform GUI library, required for the IDE and for sclang's Qt GUI kit.
+- [git](https://git-scm.com/): Required for sclang's Quarks system.
+- [ALSA](http://www.alsa-project.org): Linux sound library, required for sclang MIDI support.
+- [libudev](http://www.freedesktop.org/software/systemd/man/libudev.html): Device manager library, required for HID support.
+- [Linux kernel](http://www.kernel.org) >= 2.6: Required for LID support.
+- [libreadline](http://savannah.gnu.org/projects/readline) >= 5: Required for sclang's CLI interface.
+- [ncurses](https://invisible-island.net/ncurses/): Required for sclang's CLI interface.
 
-[Qt]: http://qt-project.org
-[ALSA]: http://www.alsa-project.org
-[libudev]: http://www.freedesktop.org/software/systemd/man/libudev.html
-[libreadline]: http://savannah.gnu.org/projects/readline
-[ncurses]: https://invisible-island.net/ncurses/
-[Linux kernel]: http://www.kernel.org
-[git]: https://git-scm.com/
-
-Installing requirements on Debian
----------------------------------
+### Installing requirements on Debian
 
 There are dedicated READMEs in this repository for building on particular embedded Linux platforms:
 
-- Raspberry Pi: README_RASPBERRY_PI.md
-- BeagleBone Black: README_BEAGLEBONE_BLACK.md
-- Bela: README_BELA.md
+- Raspberry Pi: `README_RASPBERRY_PI.md`
+- BeagleBone Black: `README_BEAGLEBONE_BLACK.md`
+- Bela: `README_BELA.md`
 
-On Debian-like systems (e.g: Ubuntu, Linux Mint, Kali Linux, Elementary OS, Knoppix, Corel Linux, Lindows and so on), the following terminal commands can be executed step by step to install all necessary dependencies and build SuperCollider:
+> Before installing the dependencies, it is recommended to update the package list on your system via
+>
+> ```shell
+> sudo apt-get update
+> ```
+>
+> It is also recommended to update the already installed packages on your system using the following command:
+>
+> ```shell
+> sudo apt-get upgrade
+> ```
 
-Before installing the dependencies, it is highly recommended to update the package list on your system with the following command:
-```shell
-sudo apt-get update
-```
-It is also recommended to install newer versions of software packages already installed on your system using the following command:
-```shell
-sudo apt-get upgrade
-```
-**Note::** If this updates the Linux system kernel, the terminal window may require the system to be rebooted. 
-In this case, it is recommended to reboot the system with the following command:
-```shell
-reboot
-```
-After rebooting, you can proceed with the next steps of installing the dependencies.
+On Debian-like systems (e.g: Ubuntu, Linux Mint, Kali Linux, Elementary OS, Knoppix, Corel Linux, Lindows, ...), the following commands can be executed step by step to install all necessary dependencies and build SuperCollider.
+
 The following command will install all recommended dependencies for sclang except Qt:
+
 ```shell
-sudo apt-get install git libasound2-dev libicu-dev libreadline6-dev libudev-dev pkg-config libncurses5-dev emacs jackd2
+sudo apt-get install \
+  git \
+  libasound2-dev \
+  libicu-dev \
+  libreadline6-dev \
+  libudev-dev \
+  pkg-config \
+  libncurses5-dev \
+  emacs \
+  jackd2
 ```
+
 **Note:** The following command will install the minimum recommended dependencies for compiling scsynth and supernova:
+
 ```shell
 sudo apt-get install \
   build-essential \
@@ -88,155 +79,248 @@ sudo apt-get install \
   libavahi-client-dev \
   libudev-dev
 ```
-If you need to use JACK1 replace libjack-jackd2-dev with libjack-dev.
 
-Installing requirements on Fedora
----------------------------------
+If you need to use JACK1 replace `libjack-jackd2-dev` with `libjack-dev`.
+
+#### Installing Qt
+
+**Qt 6.2 or later** is required to be able to run the SuperCollider IDE and sclang's Qt GUI system.
+
+Try this command to query the Qt6 version available to you:
+
+```shell
+apt-cache policy qt6-base-dev
+```
+
+If this displays version 6.2 or later, you can install Qt6 using `apt-get`.
+Please note that this list of packages might not be complete, as it hasn't been revised for Qt6.
+
+```shell
+sudo apt-get install \
+  qt6-base-dev \
+  qt6-base-dev-tools \
+  qt6-tools-dev \
+  qt6-tools-dev-tools \
+  libqt6websockets6-dev \
+  libqt6webenginecore6 \
+  qt6-webengine-dev \
+  qt6-webengine-dev-tools \
+  libqt6svgwidgets6
+```
+
+If you are on Ubuntu, check the sections below. If these instructions don't work, you will have to use the official Qt installer.
+
+##### Installing Qt on Ubuntu 22.04, 24.04
+
+On 22.04 and 24.04 Qt6 is available in the system's package manager.
+The following should install the correct packages:
+
+```shell
+  sudo apt-get install \
+    qt6-base-dev \
+    qt6-base-dev-tools \
+    qt6-tools-dev qt6-tools-dev-tools \
+    qt6-declarative-dev \
+    libqt6gui6 \
+    libqt6printsupport6 \
+    libqt6svgwidgets6 \
+    libqt6websockets6-dev \
+    libqt6webenginecore6 \
+    libqt6webenginecore6-bin \
+    qt6-webengine-dev \
+    qt6-webengine-dev-tools \
+    libqt6webchannel6-dev \
+    libqt6opengl6-dev \
+    libqt6svg6-dev \
+    linguist-qt6 \
+    qt6-l10n-tools \
+    libglx-dev libgl1-mesa-dev \
+    libvulkan-dev \
+    libxkbcommon-dev \
+    libxcb-xkb-dev
+```
+
+### Installing requirements on Fedora
 
 The following commands should install all the recommended SuperCollider dependencies on Fedora, except for Qt:
+
 ```shell
 sudo dnf groupinstall "Development Tools"
-sudo dnf install cmake libsndfile-devel wayland-devel xorg-x11-server-Xwayland-devel pipewire-devel pipewire-jack-audio-connection-kit-devel systemd-devel fftw-devel alsa-lib-devel libatomic
+sudo dnf install \
+  cmake \
+  libsndfile-devel \
+  wayland-devel \
+  xorg-x11-server-Xwayland-devel \
+  pipewire-devel \
+  pipewire-jack-audio-connection-kit-devel \
+  systemd-devel \
+  fftw-devel \
+  alsa-lib-devel \
+  libatomic
 sudo dnf install emacs # if building with the sc-el backend (default)
 sudo dnf install libXt-devel 
 ```
 
-Installing Qt
--------------
+#### Installing Qt on Fedora
 
-**Qt 6.2 or later** is required to be able to run the SuperCollider IDE and sclang's Qt GUI system.
-
-### Installing Qt on recent Debian-like operating systems
-
-Try this command to query the Qt6 version available to you:
-```shell
-apt-cache policy qt6-base-dev
-```
-If this displays version 6.2 or later, you can install Qt6 using `apt`. Please note that this list of packages might not be complete, as it hasn't been revised for Qt6.
-```shell
-sudo apt-get install qt6-base-dev qt6-base-dev-tools qt6-tools-dev qt6-tools-dev-tools libqt6websockets6-dev libqt6webenginecore6 qt6-webengine-dev qt6-webengine-dev-tools libqt6svgwidgets6
-```
-If you are on Ubuntu, check the sections below. If these instructions don't work, you will have to use the official Qt installer.
-
-### Installing Qt on Ubuntu 22.04, 24.04
-
-On 22.04 and 24.04 Qt6 is available in the system's package manager. The following should install the correct packages:
-
-    sudo apt-get install qt6-base-dev qt6-base-dev-tools qt6-tools-dev qt6-tools-dev-tools qt6-declarative-dev libqt6gui6 libqt6printsupport6 libqt6svgwidgets6 libqt6websockets6-dev libqt6webenginecore6 libqt6webenginecore6-bin qt6-webengine-dev qt6-webengine-dev-tools libqt6webchannel6-dev libqt6opengl6-dev libqt6svg6-dev linguist-qt6 qt6-l10n-tools  libglx-dev libgl1-mesa-dev libvulkan-dev libxkbcommon-dev libxcb-xkb-dev
-
-
-### Installing Qt on Fedora
-
-Please note, this list has not been tested after upgrading to Qt6. Additional packages may be needed.
+Please note, this list has not been tested after upgrading to Qt6.
+Additional packages may be needed.
 
 ```shell
-sudo dnf install qt6-qtbase-devel qt6-qtsvg-devel qt6-qtwebengine-devel qt6-linguist qt6-qtwebsockets-devel
-sudo dnf install qt6-qttools-devel
+sudo dnf install \
+  qt6-qtbase-devel \
+  qt6-qtsvg-devel \
+  qt6-qtwebengine-devel \
+  qt6-linguist \
+  qt6-qtwebsockets-devel\
+  qt6-qttools-devel
 ```
 
 ### Installing Qt using the official installer
 
-Worst case scenario, you can grab Qt off the [Qt official website](https://www.qt.io/). It's best to get the latest version. Click "Download," select the open source license, and download the Qt installer. The Qt installer has a step that prompts for you to log in to a Qt Account, but you don't actually need to authenticate and you can safely click "Skip" at that step.
+Worst case scenario, you can grab Qt off the [Qt official website](https://www.qt.io/).
+It's best to get the latest version. Click "Download," select the open source license, and download the Qt installer. The Qt installer has a step that prompts for you to log in to a Qt Account, but you don't actually need to authenticate and you can safely click "Skip" at that step.
 
-At the "Select Components" step, pop open Qt, select the latest version, and check the "Desktop" option. If you are building the IDE, also select "QWebEngine."
+At the "Select Components" step, pop open Qt, select the latest version, and check the "Desktop" option.
+If you are building the IDE, also select "QWebEngine."
 
 Unfortunately, the Qt installer does not allow you to deselect the multi-gigabyte QtCreator download.
 
-Using Clang
------------
+### Using Clang
 
-SuperCollider can be compiled with Clang. By default on Linux clang will use libstdc++ instead of libc++ (`-DSC_CLANG_USES_LIBSTDCPP=ON`). You can set this option to off to use libc++ instead; this will however likely cause issues when linking with Qt6.
+SuperCollider can be compiled with Clang.
+By default on Linux clang will use libstdc++ instead of libc++ (`-DSC_CLANG_USES_LIBSTDCPP=ON`).
+You can set this option to off to use libc++ instead; this will however likely cause issues when linking with Qt6.
 
-Building
---------
+## Building
 
-### Step 1: Obtain the source code
+### Obtain the source code
 
-SuperCollider is hosted on Github: https://github.com/SuperCollider/SuperCollider
-
+SuperCollider is hosted on Github at <https://github.com/SuperCollider/SuperCollider>.
 Obtaining the SuperCollider source code can be done either by downloading a release tarball, or by cloning the repository.
 
-SuperCollider releases are available to download here: https://github.com/supercollider/supercollider/releases
+The SuperCollider release tarballes are available to download via <https://github.com/supercollider/supercollider/releases>.
 
-Cloning the repository can be done with the following command:
+Cloning the repository via `git` can be done with the following command:
+
 ```shell
 git clone --recurse-submodules https://github.com/SuperCollider/SuperCollider.git
 ```
+
+> This command will obtain the source code of the development version of SuperCollider.
+> In order to checkout a specific release (or commit) use the tag name or the commit ID and pass it to the [`clone` command](https://www.atlassian.com/git/tutorials/setting-up-a-repository/git-clone) via
+>
+> ```shell
+> git clone --branch 3.13.1 --recurse-submodules https://github.com/SuperCollider/SuperCollider.git
+> ```
+>
+> Use [`git checkout`](https://www.atlassian.com/git/tutorials/using-branches/git-checkout) to switch to another version/branch of SuperCollider after cloning.
+
 The `--recurse-submodules` option will clone the repository's submodules which are needed to build SuperCollider. The submodules can also be obtained by navigating to the root of your locally cloned SuperCollider repository and running the following command:
+
 ```shell
 git submodule update --init --recursive
 ```
-### Step 2: Make a build directory
+
+> **Important**: Please do not download the repository via GitHubs _Download ZIP_ button as this will not contain all necessary submodules!
+
+### Make a build directory
 
 First, `cd` into the root of the SuperCollider source directory (where this file resides).
 
 Create a build directory and `cd` into it:
+
 ```shell
 mkdir build && cd build
 ```
-You can actually name this whatever you want, allowing you to have multiple independent build directories. If your SuperCollider source is also a git repository, the `.gitignore` file is configured to ignore files of the form `build*`.
 
-### Step 3: Set CMake flags
+You can actually name this whatever you want, allowing you to have multiple independent build directories.
+If your SuperCollider source is also a git repository, the `.gitignore` file is configured to ignore files of the form `build*`.
 
-Depending on what SuperCollider components you wish to build and install, you can set CMake flags.
+### Configure the build via CMake
 
-To run cmake with default settings:
+Depending on what SuperCollider components you wish to build and install, you can set CMake flags which will _configure_ the build accordingly and create the necessary files to build SuperCollider accordingly.
+
+To let cmake configure the build with default settings run the following command in the `build` directory
+
 ```shell
 cmake ..
 ```
-You can set CMake flags on the command line using `cmake -DKEY=value ..` where the `D` prefix is necessary!
-You can also use cmake gui-frontends like [`ccmake`](https://packages.debian.org/en/sid/cmake-curses-gui) or [`cmake-gui`](https://packages.debian.org/sid/cmake-qt-gui) to inspect and set the available flags.
 
-**Example:**
-If you do not have emacs installed, you should add `-DSC_EL=NO` as in the following command:
-```shell
-cmake -DSC_EL=NO ..
-```
-It is also possible to edit the `CMakeCache.txt` file or re-execute the `cmake` command with the desired flags.
-CMake flags are persistent and you only need to run these commands once each.
+You can set CMake build flags via the command line using `cmake -DKEY=value ..` during the configure process where the `D` prefix is necessary!
 
-We will cover a few important settings. There are others, which you can view with `cmake -LH ..`. We will document more of them in this README file soon.
+> **Example:** SuperCollider on Linux requires [Emacs](https://www.gnu.org/software/emacs/) as a build dependency - but this is only an optional build dependency which can be controlled via the build flag `SC_EL`.
+> So if you do not have `Emacs` installed, you should add `-DSC_EL=NO` as in the following command:
+>
+> ```shell
+> cmake -DSC_EL=NO ..
+> ```
+>
+> To display all available build flags and their values run `cmake -LH ..` in the `build` directory or use cmake gui-frontends like [`ccmake`](https://cmake.org/cmake/help/latest/manual/ccmake.1.html) or [`cmake-gui`](https://cmake.org/cmake/help/latest/manual/cmake-gui.1.html) to inspect and set the available flags.
+>
+> It is also possible to edit the `CMakeCache.txt` file or re-execute the `cmake` command with the desired flags.
+> CMake flags are persistent and you only need to run these commands once each.
 
 #### Nonstandard Qt locations
 
-If you are installing sclang with GUI features and the IDE, and you installed Qt using the official Qt installer, you will need to tell SuperCollider where Qt is. To do so:
+If you are installing sclang with GUI features and the IDE, and you installed Qt using the official Qt installer, you will need to tell SuperCollider where Qt is.
+To do so it is necessary to specify the Qt path via the build variable `DCMAKE_PREFIX_PATH` during the configure process like so:
+
 ```shell
 cmake -DCMAKE_PREFIX_PATH=/path/to/qt6 ..
 ```
+
 The location of `/path/to/qt6` will depend on how you installed Qt:
 
 - If you downloaded Qt from the Qt website, the path is two directories down from the top-level unpacked Qt directory, in a folder called `gcc`: `Qt/5.11.0/gcc_64/` (64-bit Linux) or `Qt/5.11.0/gcc/` (32-bit). By default, the Qt installer places `Qt/` in your home directory.
 
-If you want to build without Qt entirely, run
+If you want to build without Qt entirely, use
+
 ```shell
 cmake -DSC_QT=OFF ..
 ```
+
 #### Compiler optimizations
 
 If you're building SC for production use and/or don't plan on using a debugger, make sure to build in release mode:
+
 ```shell
 cmake -DCMAKE_BUILD_TYPE=Release ..
 ```
-This sets the compiler to the best optimization settings. Switch back to the defaults using `cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo ..`.
+
+This sets the compiler to the best optimization settings.
+Switch back to the defaults using `cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo ..`.
 
 If you're compiling SC only for use on your own machine (that is, you aren't cross-compiling or packaging SC for distribution), it is recommended to turn on the `NATIVE` flag to enable CPU-specific optimizations:
+
 ```shell
 cmake -DNATIVE=ON ..
 ```
+
 #### Install location
 
-By default, SuperCollider installs in `/usr/local`, a system-wide install. Maybe you can't or don't want to use superuser privileges, or just want to install for a single user. To do so, set `CMAKE_INSTALL_PREFIX` to the desired installation directory. One good place to put it would be `$HOME/usr/local`:
+By default, SuperCollider installs in `/usr/local`, a system-wide install.
+Maybe you can't or don't want to use superuser privileges, or just want to install for a single user.
+To do so, set `CMAKE_INSTALL_PREFIX` to the desired installation directory.
+One good place to put it would be `$HOME/usr/local`:
+
 ```shell
 cmake -DCMAKE_INSTALL_PREFIX=~/usr/local ..
 ```
-Make sure `~/usr/local/bin` is in your `PATH` if you do this. You can do that by adding a line such as `PATH=$PATH:$HOME/usr/local/bin` to `~/.profile`.
+
+Make sure `~/usr/local/bin` is in your `PATH` if you do this.
+You can do that by adding a line such as `PATH=$PATH:$HOME/usr/local/bin` to `~/.profile`.
 
 #### Speeding up repeated builds
 
-If you are developing SC or you're constantly pulling in the latest changes, rebuilding SC repeatedly can be a drag. Installing `ccache` can speed up re-compilation. Here is how to configure cmake to use it:
+If you are developing SC or you're constantly pulling in the latest changes, rebuilding SC repeatedly can be a drag.
+Installing `ccache` can speed up re-compilation.
+Here is how to configure cmake to use it:
+
 ```shell
 cmake -DCMAKE_CXX_COMPILER=/usr/lib/ccache/g++ -DCMAKE_C_COMPILER=/usr/lib/ccache/gcc ..
 ```
+
 This assumes your ccache executables are installed into `/usr/lib/ccache` - you may need to change the path to reflect your installation.
 
 #### Library suffix
@@ -245,145 +329,139 @@ In some situations, it is preferable to install libraries and plugins
 not in the `lib` directory but in a suffixed one, e.g. `lib64`.
 In such a case you can set the cmake variable `LIB_SUFFIX`.
 For example if you wish to install into `lib64`:
+
 ```shell
 cmake -DLIB_SUFFIX=64 ..
 ```
-### Step 4: Build
 
-If CMake ran successfully without errors, you are ready to move on to building. You can freely alternate between building and setting CMake flags.
+### Build
+
+If CMake ran successfully without errors, you are ready to move on to building.
+You can freely alternate between building and setting CMake flags.
 
 After setting your CMake flags, just run
+
 ```shell
 make
 ```
-The `-j` option allows multiple jobs to be run simultaneously, which can improve compile times on machines with multiple cores. The optimal `-j` setting varies between machines, but a good rule of thumb is the number of cores plus one. For example, on a 4-core system, try `make -j5`.
+
+The `-j` option allows multiple jobs to be run simultaneously, which can improve compile times on machines with multiple cores.
+The optimal `-j` setting varies between machines, but a good rule of thumb is the number of cores plus one.
+For example, on a 4-core system, try `make -j5`.
 
 And to install, run
+
 ```shell
 sudo make install
 ```
+
 You will need to use `make install` if you are doing a user-wide installation, which is not the default.
 
 After installing for the first time, please run
+
 ```shell
 sudo ldconfig
 ```
+
 To uninstall:
+
 ```shell
 sudo make uninstall
 ```
+
 (or `make uninstall` if you did user-wide installation).
 
-Building a Debian package
--------------------------
+### Building a Debian package
 
 The most up-to-date Debian packaging rules are maintained by the
 Debian Multimedia team. Repository (with debian/ folder):
 
-https://salsa.debian.org/multimedia-team/supercollider
+<https://salsa.debian.org/multimedia-team/supercollider>
 
+## Running scsynth or supernova (standalone)
 
-Running scsynth or supernova (standalone)
-----------------------------
+Run `scsynth --help`  or `supernova --help` to get an option summary.
+Don't forget to start jackd before starting the server.
+If you want to add directories to supercollider's search path or assign default jack ports, set up your environment as described below.
 
-Run `scsynth --help`  or `supernova --help` to get an option summary. Don't forget to
-start jackd before starting the server. If you want to add
-directories to supercollider's search path or assign default jack
-ports, set up your environment as described below.
+You can specify the number of jack input/output channels created with the options `-i` and `-o`, respectively.
 
-You can specify the number of jack input/output channels created with
-the options `-i` and `-o`, respectively.
+The `-H` option can be used to specify a jack server to connect to and to set the jack client identifier.
+The format is either `<SERVER-NAME>:<CLIENT-NAME>` or just `<CLIENT-NAME>` when connecting to the default server.
 
-the `-H` option can be used to specify a jack server to connect to and
-to set the jack client identifier. The format is either
+## Running sclang
 
-`<SERVER-NAME>:<CLIENT-NAME>`
+Supercollider comes with its own powerful IDE.
+Run it with:
 
-or just
-
-`<CLIENT-NAME>`
-
-when connecting to the default server.
-
-
-Running sclang
---------------
-
-Supercollider comes with its own powerful IDE. Run it with:
 ```shell
-$> scide
+scide
 ```
 
-Alternatively you can use sclang in combination with your preferred text
-editor out of emacs/vim/gedit. See the `README.md` files in `editors/*` for
-installation and usage. Another alternative is to simply run the
-`sclang` executable which will provide a readline-based interface.
+Alternatively you can use sclang in combination with your preferred text editor out of emacs/vim/gedit.
+See the `README.md` files in `editors/*` for installation and usage.
+Another alternative is to simply run the `sclang` executable which will provide a readline-based interface.
 
-`sclang` executes the startup file `~/.config/SuperCollider/startup.scd` after class library
-initialization. This file can contain statements to set up your
-supercollider environment, like setting default variables. An example can
-be found in `linux/examples/sclang.sc`.
+`sclang` executes the startup file `~/.config/SuperCollider/startup.scd` after class library initialization.
+This file can contain statements to set up your supercollider environment, like setting default variables.
+An example can be found in `linux/examples/sclang.sc`.
 
-You _have_ to have a directory `~/.local/share/SuperCollider`. This is where
-a synthdefs directory is automatically created. It is also the place
-to put Extensions to the class library, in a folder called Extensions.
+You _have_ to have a directory `~/.local/share/SuperCollider`. This is where a synthdefs directory is automatically created.
+It is also the place to put Extensions to the class library, in a folder called Extensions.
 
-The runtime directory is either the current working directory or the
-path specified with the `-d` option.
+The runtime directory is either the current working directory or the path specified with the `-d` option.
 
-#### Headless operation
+### Headless operation
 
-Even though the standard distribution of SuperCollider is built with the Qt framework, `sclang` can still be run in terminal without the X server. In order to do that, the `QT_QPA_PLATFORM` environment variable needs to be set to `offscreen`:
+Even though the standard distribution of SuperCollider is built with the Qt framework, `sclang` can still be run in terminal without the X server.
+In order to do that, the `QT_QPA_PLATFORM` environment variable needs to be set to `offscreen`:
+
 ```shell
-$> export QT_QPA_PLATFORM=offscreen
-$> sclang
+export QT_QPA_PLATFORM=offscreen
+sclang
 ```
 
-Environment
------------
+On platforms without any display server at all it may be necessary to build SuperCollider without `X11` and `Qt` respectively - refer to the build flags to disable those features while configuring the build.
+
+## Environment variables
 
 The jack audio driver interface is configured based on various
 environment variables:
 
- * SC_JACK_DEFAULT_INPUTS comma-separated list of jack ports that the server's inputs should connect by default
+- `SC_JACK_DEFAULT_INPUTS` comma-separated list of jack ports that the server's inputs should connect by default
 
-   ```shell
-   $> export SC_JACK_DEFAULT_INPUTS="system:capture_1,system:capture_2"
-   ```
+  ```shell
+  export SC_JACK_DEFAULT_INPUTS="system:capture_1,system:capture_2"
+  ```
 
-   in order to connect the first ports of one jack client, it is possible to specify only the client name
+  in order to connect the first ports of one jack client, it is possible to specify only the client name
 
-   ```shell
-   $> export SC_JACK_DEFAULT_INPUTS="system"
-   ```
+  ```shell
+  export SC_JACK_DEFAULT_INPUTS="system"
+  ```
 
- * SC_JACK_DEFAULT_OUTPUTS comma-separated list of jack ports that the server's outputs should be connected to by default.
+- `SC_JACK_DEFAULT_OUTPUTS` comma-separated list of jack ports that the server's outputs should be connected to by default.
 
-   ```shell
-   $> export SC_JACK_DEFAULT_OUTPUTS="system:playback_1,system:playback_2"
-   ```
+  ```shell
+  export SC_JACK_DEFAULT_OUTPUTS="system:playback_1,system:playback_2"
+  ```
 
-   In order to connect the first ports of one jack client, it is possible to specify only the client name
+  In order to connect the first ports of one jack client, it is possible to specify only the client name
 
-   ```shell
-   $> export SC_JACK_DEFAULT_OUTPUTS="system"
-   ```
+  ```shell
+  export SC_JACK_DEFAULT_OUTPUTS="system"
+  ```
 
-Two additional environment variables substitute directories for the default
-search path for plugins and synth definitions, respectively. Directory
-names are separated by ':' as in the Unix PATH variable:
+- Two additional environment variables substitute directories for the default search path for plugins and synth definitions, respectively.
+  Directory names are separated by ':' as in the Unix PATH variable: `SC_PLUGIN_PATH`, `SC_SYNTHDEF_PATH`
 
- * SC_PLUGIN_PATH, SC_SYNTHDEF_PATH
+  ```shell
+  export SC_SYNTHDEF_PATH="./synthdefs:/home/sk/SuperCollider/synthdefs"
+  ```
 
-   ```shell
-   $> export SC_SYNTHDEF_PATH="./synthdefs:/home/sk/SuperCollider/synthdefs"
-   ```
+## Contributors to this document
 
-
-Contributors to this document
------------------------------
-
-- stefan kersten <sk AT k-hornz DOT de>
+- stefan kersten (sk AT k-hornz DOT de)
 - andi pieper
 - maurizio umberto puxeddu
 - rohan drape

--- a/README_LINUX.md
+++ b/README_LINUX.md
@@ -223,7 +223,7 @@ The `--recurse-submodules` option will clone the repository's submodules which a
 git submodule update --init --recursive
 ```
 
-> **Important**: Please do not download the repository via GitHubs _Download ZIP_ button as this will not contain all necessary submodules!
+> **Important**: Please do not download the repository via GitHub's _Download ZIP_ button as this will not contain all necessary submodules!
 
 ### Make a build directory
 
@@ -471,3 +471,4 @@ environment variables:
 - nescivi (marije baalman)
 - dan stowell
 - tim blechmann
+- prko

--- a/README_LINUX.md
+++ b/README_LINUX.md
@@ -194,7 +194,10 @@ To run cmake with default settings:
 
     cmake ..
 
-You can set CMake flags on the command line using `cmake -DKEY=value ..`. You can also use cmake frontends like ccmake or cmake-gui, or simply edit the `CMakeCache.txt` file. CMake flags are persistent and you only need to run these commands once each.
+You can set CMake flags on the command line using `cmake -DKEY=value ..` where the `D` prefix is necessary!
+You can also use cmake gui-frontends like [`ccmake`](https://packages.debian.org/en/sid/cmake-curses-gui) or [`cmake-gui`](https://packages.debian.org/sid/cmake-qt-gui) to inspect and set the available flags.
+It is also possible to edit the `CMakeCache.txt` file or re-execute the `cmake` command with the desired flags.
+CMake flags are persistent and you only need to run these commands once each.
 
 We will cover a few important settings. There are others, which you can view with `cmake -LH ..`. We will document more of them in this README file soon.
 

--- a/README_LINUX.md
+++ b/README_LINUX.md
@@ -51,22 +51,7 @@ There are dedicated READMEs in this repository for building on particular embedd
 
 On Debian-like systems (e.g: Ubuntu, Linux Mint, Kali Linux, Elementary OS, Knoppix, Corel Linux, Lindows, ...), the following commands can be executed step by step to install all necessary dependencies and build SuperCollider.
 
-The following command will install all recommended dependencies for sclang except Qt:
-
-```shell
-sudo apt-get install \
-  git \
-  libasound2-dev \
-  libicu-dev \
-  libreadline6-dev \
-  libudev-dev \
-  pkg-config \
-  libncurses5-dev \
-  emacs \
-  jackd2
-```
-
-**Note:** The following command will install the minimum recommended dependencies for compiling scsynth and supernova:
+The following dependencies are recommended for compiling scsynth and supernova:
 
 ```shell
 sudo apt-get install \
@@ -82,9 +67,25 @@ sudo apt-get install \
 
 If you need to use JACK1 replace `libjack-jackd2-dev` with `libjack-dev`.
 
+The following command will install all recommended dependencies for sclang except Qt
+
+```shell
+sudo apt-get install \
+  git \
+  libasound2-dev \
+  libicu-dev \
+  libreadline6-dev \
+  libudev-dev \
+  pkg-config \
+  libncurses5-dev \
+  emacs \
+  jackd2
+```
+
 #### Installing Qt
 
-**Qt 6.2 or later** is required to be able to run the SuperCollider IDE and sclang's Qt GUI system.
+[Qt](https://www.qt.io/) 6.2 (or later) provides the GUI for SuperCollider like its IDE and allows to build custom user GUIs via *QtCollider* and is the default and recommended way to use and set up SuperCollider.
+For systems without display capabilities, it is also possible to build SuperCollider without Qt (see configure build section).
 
 Try this command to query the Qt6 version available to you:
 
@@ -108,7 +109,7 @@ sudo apt-get install \
   libqt6svgwidgets6
 ```
 
-If you are on Ubuntu, check the sections below. If these instructions don't work, you will have to use the official Qt installer.
+If you are on Ubuntu, check the sections below. If these instructions don't work, you will have to use the official Qt installer (see below).
 
 ##### Installing Qt on Ubuntu 22.04, 24.04
 
@@ -116,28 +117,28 @@ On 22.04 and 24.04 Qt6 is available in the system's package manager.
 The following should install the correct packages:
 
 ```shell
-  sudo apt-get install \
-    qt6-base-dev \
-    qt6-base-dev-tools \
-    qt6-tools-dev qt6-tools-dev-tools \
-    qt6-declarative-dev \
-    libqt6gui6 \
-    libqt6printsupport6 \
-    libqt6svgwidgets6 \
-    libqt6websockets6-dev \
-    libqt6webenginecore6 \
-    libqt6webenginecore6-bin \
-    qt6-webengine-dev \
-    qt6-webengine-dev-tools \
-    libqt6webchannel6-dev \
-    libqt6opengl6-dev \
-    libqt6svg6-dev \
-    linguist-qt6 \
-    qt6-l10n-tools \
-    libglx-dev libgl1-mesa-dev \
-    libvulkan-dev \
-    libxkbcommon-dev \
-    libxcb-xkb-dev
+sudo apt-get install \
+  qt6-base-dev \
+  qt6-base-dev-tools \
+  qt6-tools-dev qt6-tools-dev-tools \
+  qt6-declarative-dev \
+  libqt6gui6 \
+  libqt6printsupport6 \
+  libqt6svgwidgets6 \
+  libqt6websockets6-dev \
+  libqt6webenginecore6 \
+  libqt6webenginecore6-bin \
+  qt6-webengine-dev \
+  qt6-webengine-dev-tools \
+  libqt6webchannel6-dev \
+  libqt6opengl6-dev \
+  libqt6svg6-dev \
+  linguist-qt6 \
+  qt6-l10n-tools \
+  libglx-dev libgl1-mesa-dev \
+  libvulkan-dev \
+  libxkbcommon-dev \
+  libxcb-xkb-dev
 ```
 
 ### Installing requirements on Fedora
@@ -270,9 +271,9 @@ To do so it is necessary to specify the Qt path via the build variable `DCMAKE_P
 cmake -DCMAKE_PREFIX_PATH=/path/to/qt6 ..
 ```
 
-The location of `/path/to/qt6` will depend on how you installed Qt:
-
-- If you downloaded Qt from the Qt website, the path is two directories down from the top-level unpacked Qt directory, in a folder called `gcc`: `Qt/5.11.0/gcc_64/` (64-bit Linux) or `Qt/5.11.0/gcc/` (32-bit). By default, the Qt installer places `Qt/` in your home directory.
+The location of `/path/to/qt6` will depend on how you installed Qt.
+If you downloaded Qt from the Qt website, the path is two directories down from the top-level unpacked Qt directory, in a folder called `gcc`: `Qt/6.2.0/gcc_64/` on 64 bit systems.
+By default, the Qt installer places `Qt/` in your home directory.
 
 If you want to build without Qt entirely, use
 

--- a/README_LINUX.md
+++ b/README_LINUX.md
@@ -56,7 +56,7 @@ There are dedicated READMEs in this repository for building on particular embedd
 - BeagleBone Black: README_BEAGLEBONE_BLACK.md
 - Bela: README_BELA.md
 
-On Debian-like systems (e.g: Ubuntu, Linux Mint, Kali Linux, Elementary OS, Raspberry Pi OS, Knoppix, Corel Linux, Lindows and so on), the following commands could be execueted step by step:
+On Debian-like systems (e.g: Ubuntu, Linux Mint, Kali Linux, Elementary OS, Knoppix, Corel Linux, Lindows and so on), the following commands can be execueted step by step to install all necessary dependencies and build SuperCollider:
 
 ### Step 1: Update the package list on your system
 

--- a/README_LINUX.md
+++ b/README_LINUX.md
@@ -74,7 +74,7 @@ If Step 2 requests reboot:
 
     sudo apt-get install emacs 
     
-!!! If you do not install emacs using the command above, you should use the following command when runninc cmake with default settings:
+**Note:** If you do not install emacs using the command above, you should use the following command when runninc cmake with default settings:
 
     cmake -DSC_EL=NO ..
     
@@ -88,7 +88,7 @@ The following command installs all the recommended dependencies for sclang excep
 
     sudo apt-get install git libasound2-dev libicu-dev libreadline6-dev libudev-dev pkg-config libncurses5-dev
 
-!!! The following command installs the minimal recommended dependencies for compiling scsynth and supernova:
+**Note:** The following command installs the minimal recommended dependencies for compiling scsynth and supernova:
 
     sudo apt-get install build-essential cmake libjack-jackd2-dev libsndfile1-dev libfftw3-dev libxt-dev libavahi-client-dev libudev-dev
 

--- a/README_LINUX.md
+++ b/README_LINUX.md
@@ -74,7 +74,7 @@ If Step 2 requests reboot:
 
     sudo apt-get install emacs 
     
-**Note:** If you do not install emacs using the command above, you should use the following command when runninc cmake with default settings:
+**Note:** If you do not install emacs using the command above, you should use the following command when running cmake with default settings:
 
     cmake -DSC_EL=NO ..
     


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

Based on #6694 (and therefore supersedes #6694) plus

* makes the md document https://github.com/DavidAnson/markdownlint-cli2 compliant (e.g. use `##` as headline indicator instead of a mix of `----` and `##`) and add some blanklines between parts
* put each dependency in its dedicated line to provide a better overview and allow annotation of dependencies and have better git history support
* put each sentence into its dedicated line for better git history support
* move dedicated Qt installation part as part of Debian/Fedora dependency installation
* add some more explanation regarding build flags

Please review @prko :)

See https://github.com/capital-G/supercollider/blob/linux-readme-improvements/README_LINUX.md for a rendered version

## Types of changes

- Documentation
