### PR TITLE
Splay level comp flexify

### DIFF
--- a/HelpSource/Classes/LevelComp.schelp
+++ b/HelpSource/Classes/LevelComp.schelp
@@ -68,12 +68,15 @@ s.meter;
 s.scope;
 
 // direct synthesis at level 0.1 -> -20db on each channel
+(
 { var n = 2, level = 0.1, spread = 1, pan = 0;
 	LFPulse.ar({ 100.exprand(2000) } ! n).range(-1, 1) * level
 }.play;
+)
 
 // with levelComp true by default:
 // the same with 2 chans, spread 1, level 0.1, panned to center: -20db
+(
 x = { |spread = 1, level = 0.1, center = 0|
 	var n = 2;
 	var snd = Splay.ar(LFPulse.ar({ 100.exprand(2000) } ! n).range(-1, 1),
@@ -81,7 +84,7 @@ x = { |spread = 1, level = 0.1, center = 0|
 	Amplitude.ar(snd, 0.01, 1).ampdb.poll(1);
 	snd
 }.play;
-
+)
 // at full spread, level -20, pan to center,
 x.set(\spread, 1, \center, 0); // -23
 // no spread, in center:
@@ -90,6 +93,7 @@ x.set(\spread, 0, \center, 0); // -20
 x.set(\spread, 0, \center, -1); // -17db
 
 //// The same tests with 20 channels, levelComp true as is default:
+(
 x = { |spread = 1, level = 0.1, center = 0|
 	var n = 20;
 	var snd = Splay.ar(LFPulse.ar({ 100.exprand(2000) } ! n).range(-1, 1),
@@ -97,6 +101,7 @@ x = { |spread = 1, level = 0.1, center = 0|
 	Amplitude.ar(snd, 0.01, 1).ampdb.poll(1);
 	snd
 }.play;
+)
 
 // at full spread, level -20, pan to center, -17 db
 x.set(\spread, 1, \center, 0); // -17

--- a/HelpSource/Classes/LevelComp.schelp
+++ b/HelpSource/Classes/LevelComp.schelp
@@ -1,0 +1,133 @@
+TITLE:: LevelComp
+summary:: Level compensation logic for Splay and SplayAz
+categories:: Panning
+related:: Classes/Splay, Classes/SplayAz, Guides/Level_Compensation
+
+DESCRIPTION::
+Mixing and Panning multichannel signals often requires link::Guides/Level_Compensation::.
+LevelComp provides a logic for this that is used in the link::Splay:: and ::SplayAz::.
+It calculates a levelComp factor
+
+CLASSMETHODS::
+
+METHOD:: new
+calculate a levelCompensation factor for the given number of channels,
+based on levelComp argument.
+
+ARGUMENT:: levelComp
+the levelComp value or flag:
+true for equal power level compensation (default),
+false for off / no level change,
+float between 0.0 and 1.0 for smooth tuning of levelComp factor:
+0.0 is none -> factor 1
+0.5 is equal power -> factor (1/n).squared
+1.0 is equal amplitude -> factor (1/n)
+
+ARGUMENT:: rate
+the rate for which to calculate - \audio or \control.
+
+ARGUMENT:: n
+the number of signal channels for which to calculate levelComp factor.
+
+returns::
+the levelComp factor by which to multiply the output signals.
+
+EXAMPLES::
+
+Overview of levelComp variants:
+code::
+// default is equal power comp: level / ( numchans.sqrt)
+Splay.ar(ins, spread, level, center ); // true is default
+// write it explicitly for clarity
+Splay.ar(ins, spread, level, center, levelComp: true);
+// or do equal power as float levelComp
+Splay.ar(ins, spread, level, center, levelComp: 0.5); //
+
+// maximum peak safety by equal amplitude comp: level / numchans
+Splay.ar(ins, spread, level, center, levelComp: 1);
+// or calculate by hand:
+Splay.ar(ins, spread, level / ins.size, center, levelComp: false);
+
+// no compensation, just tune level by hand
+Splay.ar(ins, spread, level, center, levelComp: false);
+Splay.ar(ins, spread, level, center, levelComp: 0);
+
+// levelComp by float: level / (numchans ** levelComp),
+// so 0.0 is no compensation: level / 1;
+//    0.5 is equal power : level / ( numchans.sqrt)
+//    1.0 is equal amplitude : level / ( numchans)
+// can be used to tune e.g. between equal power and equal amp:
+Splay.ar(ins, spread, level, center, levelComp: 0.75);
+
+::
+
+subsection:: Discussion and demonstration of level compensation options:
+code::
+
+s.meter;
+s.scope;
+
+// direct synthesis at level 0.1 -> -20db on each channel
+{ var n = 2, level = 0.1, spread = 1, pan = 0;
+	LFPulse.ar({ 100.exprand(2000) } ! n).range(-1, 1) * level
+}.play;
+
+// with levelComp true by default:
+// the same with 2 chans, spread 1, level 0.1, panned to center: -20db
+x = { |spread = 1, level = 0.1, center = 0|
+	var n = 2;
+	var snd = Splay.ar(LFPulse.ar({ 100.exprand(2000) } ! n).range(-1, 1),
+		spread, level, center);
+	Amplitude.ar(snd, 0.01, 1).ampdb.poll(1);
+	snd
+}.play;
+
+// at full spread, level -20, pan to center,
+x.set(\spread, 1, \center, 0); // -23
+// no spread, in center:
+x.set(\spread, 0, \center, 0); // -20
+// worst case: no spread, pan full left
+x.set(\spread, 0, \center, -1); // -17db
+
+//// The same tests with 20 channels, levelComp true as is default:
+x = { |spread = 1, level = 0.1, center = 0|
+	var n = 20;
+	var snd = Splay.ar(LFPulse.ar({ 100.exprand(2000) } ! n).range(-1, 1),
+		spread, level, center);
+	Amplitude.ar(snd, 0.01, 1).ampdb.poll(1);
+	snd
+}.play;
+
+// at full spread, level -20, pan to center, -17 db
+x.set(\spread, 1, \center, 0); // -17
+// no spread, in center: -21
+x.set(\spread, 0, \center, 0); // -16
+// worst case: no spread, pan full left
+x.set(\spread, 0, \center, -1); // -14db
+
+
+// here the theoretical worst case for 20 channels: 13 db too loud!
+{ Splay.ar(DC.ar(1!20), 0, 1, 0.999).ampdb.poll }.plot;
+{ Splay.ar(DC.ar(1!200), 0, 1, 0.999).ampdb.poll }.plot; // 23 db louder
+{ Splay.ar(DC.ar(1!2000), 0, 1, 0.999).ampdb.poll }.plot; // 33 db louder
+
+
+// For maximum peak safety, turn levelComp off / false,
+// and divide by the number of channels - i.e. equal amplitude:
+{ n = 2; Splay.ar(DC.ar(1!n), 1, 1/n, 0, false).ampdb.poll }.plot; // -6 db on both
+{ n = 2; Splay.ar(DC.ar(1!n), 0, 1/n, 0, false).ampdb.poll }.plot; // -3 db on both
+{ n = 2; Splay.ar(DC.ar(1!n), 0, 1/n, 0.99, false).ampdb.poll }.plot; // 0 db
+
+// these are now the same for all
+{ n = 20; Splay.ar(DC.ar(1!n), 1, 1/n, 0, false).ampdb.poll }.plot; // -4 db
+{ n = 20; Splay.ar(DC.ar(1!n), 0, 1/n, 0, false).ampdb.poll }.plot; // -3 db
+{ n = 20; Splay.ar(DC.ar(1!n), 0, 1/n, 0.99, false).ampdb.poll }.plot; // 0 db on right
+
+{ n = 200; Splay.ar(DC.ar(1!n), 1, 1/n, 0, false).ampdb.poll }.plot; // -4 db
+{ n = 200; Splay.ar(DC.ar(1!n), 0, 1/n, 0, false).ampdb.poll }.plot; // -3 db
+{ n = 200; Splay.ar(DC.ar(1!n), 0, 1/n, 0.99, false).ampdb.poll }.plot; // 0 db on right
+
+{ n = 2000; Splay.ar(DC.ar(1!n), 1, 1/n, 0, false).ampdb.poll }.plot; // -4 db
+{ n = 2000; Splay.ar(DC.ar(1!n), 0, 1/n, 0, false).ampdb.poll }.plot; // -3 db
+{ n = 2000; Splay.ar(DC.ar(1!n), 0, 1/n, 0.99, false).ampdb.poll }.plot; // 0 db on right
+::

--- a/HelpSource/Classes/LevelComp.schelp
+++ b/HelpSource/Classes/LevelComp.schelp
@@ -5,39 +5,45 @@ related:: Classes/Splay, Classes/SplayAz, Guides/Level_Compensation
 
 DESCRIPTION::
 Mixing and Panning multichannel signals often requires link::Guides/Level_Compensation::.
-LevelComp provides a logic for this that is used in the link::Classes/Splay:: and link::Classes/SplayAz::.
-It calculates a levelComp factor
+LevelComp provides a logic for this that is used internally in the link::Classes/Splay:: and link::Classes/SplayAz:: UGens.
+Using the code::levelComp:: argument of code::Splay/Az::, it calculates a level compensation factor applied to the input signals, depending on the number of output channels.
 
 CLASSMETHODS::
 
 METHOD:: new
-calculate a levelCompensation factor for the given number of channels,
-based on levelComp argument.
+Calculate a scaling factor based on the code::levelComp:: argument and the number of channels to be mixed.
 
 ARGUMENT:: levelComp
-the levelComp value or flag:
-true for equal power level compensation (default),
-false for off / no level change,
-float between 0.0 and 1.0 for smooth tuning of levelComp factor:
-0.0 is none -> factor 1
-0.5 is equal power -> factor (1/n).squared
-1.0 is equal amplitude -> factor (1/n)
+a flag or numeric value:
+
+list::
+##code::true:: : equal power level compensation (default)
+##code::false:: : off / no level change,
+##float between code::0.0:: and code::1.0:: : smooth tuning of levelComp factor:
+list::
+##code::0.0:: is none -> factor 1
+##code::0.5:: is equal power -> factor (1/n).squared
+##code::1.0:: is equal amplitude -> factor (1/n)
+::
+::
 
 ARGUMENT:: rate
 the rate for which to calculate - \audio or \control.
 
 ARGUMENT:: n
-the number of signal channels for which to calculate levelComp factor.
+the number of channels being mixed and scaled.
 
 returns::
 the levelComp factor by which to multiply the output signals.
 
 EXAMPLES::
 
-Overview of levelComp variants:
+code::Splay:: and code::SplayAz:: use code::LevelComp:: internally via the code::levelComp:: argument, and obtaining rate and number of channels from code::Splay/Az::.
+
+Here is an Overview of the code::levelComp:: usage variants:
 code::
-// default is equal power comp: level / ( numchans.sqrt)
-Splay.ar(ins, spread, level, center ); // true is default
+// default is equal power comp: level / (numchans.sqrt)
+Splay.ar(ins, spread, level, center); // true is default
 // write it explicitly for clarity
 Splay.ar(ins, spread, level, center, levelComp: true);
 // or do equal power as float levelComp
@@ -54,8 +60,8 @@ Splay.ar(ins, spread, level, center, levelComp: 0);
 
 // levelComp by float: level / (numchans ** levelComp),
 // so 0.0 is no compensation: level / 1;
-//    0.5 is equal power : level / ( numchans.sqrt)
-//    1.0 is equal amplitude : level / ( numchans)
+//    0.5 is equal power : level / (numchans.sqrt)
+//    1.0 is equal amplitude : level / (numchans)
 // can be used to tune e.g. between equal power and equal amp:
 Splay.ar(ins, spread, level, center, levelComp: 0.75);
 
@@ -67,30 +73,37 @@ code::
 s.meter;
 s.scope;
 
-// direct synthesis at level 0.1 -> -20db on each channel
+// synthesize 2 signals at level 0.1 (-20 dB), on separate channels
 (
 { var n = 2, level = 0.1, spread = 1, pan = 0;
 	LFPulse.ar({ 100.exprand(2000) } ! n).range(-1, 1) * level
 }.play;
 )
 
-// with levelComp true by default:
-// the same with 2 chans, spread 1, level 0.1, panned to center: -20db
+// now using Splay with 2 inputs, level at 0.1 (-20dB)
 (
 x = { |spread = 1, level = 0.1, center = 0|
-	var n = 2;
-	var snd = Splay.ar(LFPulse.ar({ 100.exprand(2000) } ! n).range(-1, 1),
-		spread, level, center);
-	Amplitude.ar(snd, 0.01, 1).ampdb.poll(1);
-	snd
+    var n = 2;
+	var snd = LFPulse.ar({ 100.exprand(2000) } ! n).range(-1, 1);
+	var stereo = Splay.ar(snd, spread, level, center);
+	Peak.ar(stereo, Impulse.kr(2)).ampdb.poll(2);
+    stereo
 }.play;
 )
-// at full spread, level -20, pan to center,
-x.set(\spread, 1, \center, 0); // -23
-// no spread, in center:
-x.set(\spread, 0, \center, 0); // -20
-// worst case: no spread, pan full left
-x.set(\spread, 0, \center, -1); // -17db
+
+// full spread, panned to center:
+// the 2 signals are discrete, left and right
+// we see the energy-based levelComp applied (1/2.sqrt).ampdb = -3
+x.set(\spread, 1, \center, 0); // -20 - 3 = -23dB
+
+// no spread, panned center:
+// each signal decreases by 3dB as they move to the center (from the panning function)
+// and the two signals mix on each channel, increasing the peak by 6dB
+x.set(\spread, 0, \center, 0); // -23 - 3 + 6 = -20dB
+
+// no spread, panned fully right:
+// the signals fully mix in the right channel (+6 dB)
+x.set(\spread, 0, \center, 1); // -23 + 6 = -17db
 
 //// The same tests with 20 channels, levelComp true as is default:
 (
@@ -103,36 +116,39 @@ x = { |spread = 1, level = 0.1, center = 0|
 }.play;
 )
 
-// at full spread, level -20, pan to center, -17 db
-x.set(\spread, 1, \center, 0); // -17
-// no spread, in center: -21
-x.set(\spread, 0, \center, 0); // -16
-// worst case: no spread, pan full left
-x.set(\spread, 0, \center, -1); // -14db
+// at full spread, level -20, pan to center:
+// amplitude is somewhat higher at -17 db
+x.set(\spread, 1, \center, 0);
+// with no spread, i.e. all panned center, a bit higher : -16 db
+x.set(\spread, 0, \center, 0);
+// worst case: no spread, pan full left: -14db
+x.set(\spread, 0, \center, -1);
 
 
-// here the theoretical worst case for 20 channels: 13 db too loud!
-{ Splay.ar(DC.ar(1!20), 0, 1, 0.999).ampdb.poll }.plot;
-{ Splay.ar(DC.ar(1!200), 0, 1, 0.999).ampdb.poll }.plot; // 23 db louder
-{ Splay.ar(DC.ar(1!2000), 0, 1, 0.999).ampdb.poll }.plot; // 33 db louder
+// Finally, here the theoretical worst case for 20 channels: 13 db too loud!
+{ Splay.ar(DC.ar(1!20), 0, 1, 0.999).ampdb }.plot;
+{ Splay.ar(DC.ar(1!200), 0, 1, 0.999).ampdb }.plot; // 200: 23 db louder
+{ Splay.ar(DC.ar(1!2000), 0, 1, 0.999).ampdb }.plot; // 2000: 33 db louder
 
 
-// For maximum peak safety, turn levelComp off / false,
+// So for maximum peak safety, use levelComp 1, or equivalently,
+// turn levelComp off / false, and explicitly set level to 1/n.
 // and divide by the number of channels - i.e. equal amplitude:
-{ n = 2; Splay.ar(DC.ar(1!n), 1, 1/n, 0, false).ampdb.poll }.plot; // -6 db on both
-{ n = 2; Splay.ar(DC.ar(1!n), 0, 1/n, 0, false).ampdb.poll }.plot; // -3 db on both
-{ n = 2; Splay.ar(DC.ar(1!n), 0, 1/n, 0.99, false).ampdb.poll }.plot; // 0 db
+{ n = 2; Splay.ar(DC.ar(1!n), 1, 1, 0, levelComp: 1).ampdb }.plot; // -6 db on both
+{ n = 2; Splay.ar(DC.ar(1!n), 1, 1/n, 0, levelComp: false).ampdb }.plot;
+{ n = 2; Splay.ar(DC.ar(1!n), 0, 1, 0, levelComp: 1).ampdb }.plot; // -3 db on both
+{ n = 2; Splay.ar(DC.ar(1!n), 0, 1, 0.99, levelComp: 1).ampdb }.plot; // 0 db
 
-// these are now the same for all
-{ n = 20; Splay.ar(DC.ar(1!n), 1, 1/n, 0, false).ampdb.poll }.plot; // -4 db
-{ n = 20; Splay.ar(DC.ar(1!n), 0, 1/n, 0, false).ampdb.poll }.plot; // -3 db
-{ n = 20; Splay.ar(DC.ar(1!n), 0, 1/n, 0.99, false).ampdb.poll }.plot; // 0 db on right
+// these are now the same for all tested values of n:
+{ n = 20; Splay.ar(DC.ar(1!n), 1, 1, 0, levelComp: 1).ampdb }.plot; // -4 db
+{ n = 20; Splay.ar(DC.ar(1!n), 0, 1, 0, levelComp: 1).ampdb }.plot; // -3 db
+{ n = 20; Splay.ar(DC.ar(1!n), 0, 1, 0.99, levelComp: 1).ampdb }.plot; // 0 db on right
 
-{ n = 200; Splay.ar(DC.ar(1!n), 1, 1/n, 0, false).ampdb.poll }.plot; // -4 db
-{ n = 200; Splay.ar(DC.ar(1!n), 0, 1/n, 0, false).ampdb.poll }.plot; // -3 db
-{ n = 200; Splay.ar(DC.ar(1!n), 0, 1/n, 0.99, false).ampdb.poll }.plot; // 0 db on right
+{ n = 200; Splay.ar(DC.ar(1!n), 1, 1, 0, levelComp: 1).ampdb }.plot; // -4 db
+{ n = 200; Splay.ar(DC.ar(1!n), 0, 1, 0, levelComp: 1).ampdb }.plot; // -3 db
+{ n = 200; Splay.ar(DC.ar(1!n), 0, 1, 0.99, levelComp: 1).ampdb }.plot; // 0 db on right
 
-{ n = 2000; Splay.ar(DC.ar(1!n), 1, 1/n, 0, false).ampdb.poll }.plot; // -4 db
-{ n = 2000; Splay.ar(DC.ar(1!n), 0, 1/n, 0, false).ampdb.poll }.plot; // -3 db
-{ n = 2000; Splay.ar(DC.ar(1!n), 0, 1/n, 0.99, false).ampdb.poll }.plot; // 0 db on right
+{ n = 2000; Splay.ar(DC.ar(1!n), 1, 1, 0, levelComp: 1).ampdb }.plot; // -4 db
+{ n = 2000; Splay.ar(DC.ar(1!n), 0, 1, 0, levelComp: 1).ampdb }.plot; // -3 db
+{ n = 2000; Splay.ar(DC.ar(1!n), 0, 1, 0.99, levelComp: 1).ampdb }.plot; // 0 db on right
 ::

--- a/HelpSource/Classes/LevelComp.schelp
+++ b/HelpSource/Classes/LevelComp.schelp
@@ -6,7 +6,7 @@ related:: Classes/Splay, Classes/SplayAz, Guides/Level_Compensation
 DESCRIPTION::
 Mixing and Panning multichannel signals often requires link::Guides/Level_Compensation::.
 LevelComp provides a logic for this that is used internally in the link::Classes/Splay:: and link::Classes/SplayAz:: UGens.
-Using the code::levelComp:: argument of code::Splay/Az::, it calculates a level compensation factor applied to the input signals, depending on the number of output channels.
+Using the code::levelComp:: argument of code::Splay/Az::, it calculates a level compensation factor applied to the input signals, depending on the number of input channels.
 
 CLASSMETHODS::
 
@@ -38,7 +38,7 @@ the levelComp factor by which to multiply the output signals.
 
 EXAMPLES::
 
-code::Splay:: and code::SplayAz:: use code::LevelComp:: internally via the code::levelComp:: argument, and obtaining rate and number of channels from code::Splay/Az::.
+code::Splay:: and code::SplayAz:: use code::LevelComp:: internally via the code::levelComp:: argument, and obtain rate and number of channels from code::Splay/Az::.
 
 Here is an Overview of the code::levelComp:: usage variants:
 code::
@@ -68,19 +68,22 @@ Splay.ar(ins, spread, level, center, levelComp: 0.75);
 ::
 
 subsection:: Discussion and demonstration of level compensation options:
+
+We begin testing with equal power compensation: how much too high can the summed levels rise for different numbers of channel to mix/pan with link::Classes/Splay::?
+
 code::
 
 s.meter;
 s.scope;
 
-// synthesize 2 signals at level 0.1 (-20 dB), on separate channels
+// synthesize 2 test signals at level 0.1 (-20 dB), first on separate channels
 (
 { var n = 2, level = 0.1, spread = 1, pan = 0;
 	LFPulse.ar({ 100.exprand(2000) } ! n).range(-1, 1) * level
 }.play;
 )
 
-// now using Splay with 2 inputs, level at 0.1 (-20dB)
+// now mix/pan these 2 signals using Splay, level at 0.1 (-20dB)
 (
 x = { |spread = 1, level = 0.1, center = 0|
     var n = 2;
@@ -91,64 +94,74 @@ x = { |spread = 1, level = 0.1, center = 0|
 }.play;
 )
 
-// full spread, panned to center:
+// when we set full spread, panned to center:
 // the 2 signals are discrete, left and right
 // we see the energy-based levelComp applied (1/2.sqrt).ampdb = -3
 x.set(\spread, 1, \center, 0); // -20 - 3 = -23dB
 
 // no spread, panned center:
 // each signal decreases by 3dB as they move to the center (from the panning function)
-// and the two signals mix on each channel, increasing the peak by 6dB
-x.set(\spread, 0, \center, 0); // -23 - 3 + 6 = -20dB
+// and the two signals mix on each channel, so we get -20 dB
+x.set(\spread, 0, \center, 0); //  -20dB
 
 // no spread, panned fully right:
 // the signals fully mix in the right channel (+6 dB)
 x.set(\spread, 0, \center, 1); // -23 + 6 = -17db
+::
 
-//// The same tests with 20 channels, levelComp true as is default:
+Trying the same example with 20 channels and with equal power compensation,
+(which we get with levelComp code::true::), we see that the resulting sum
+levels are much higher:
+
+code::
 (
 x = { |spread = 1, level = 0.1, center = 0|
 	var n = 20;
 	var snd = Splay.ar(LFPulse.ar({ 100.exprand(2000) } ! n).range(-1, 1),
 		spread, level, center);
-	Amplitude.ar(snd, 0.01, 1).ampdb.poll(1);
+	Peak.ar(snd, 0.01, 1).ampdb.poll(1);
 	snd
 }.play;
 )
 
 // at full spread, level -20, pan to center:
-// amplitude is somewhat higher at -17 db
+// peak is higher at -11 db
 x.set(\spread, 1, \center, 0);
-// with no spread, i.e. all panned center, a bit higher : -16 db
+// with no spread, i.e. all panned center, slightly higher -10
 x.set(\spread, 0, \center, 0);
-// worst case: no spread, pan full left: -14db
-x.set(\spread, 0, \center, -1);
+// worst case: no spread, pan full left: -8db
+x.set(\spread, 0, \center, -1); // -8
+::
 
+Finally, here are the theoretical worst cases for 20, 200, and 2000 channels,
+with equal power: 13, 23 and 33 db louder!
 
-// Finally, here the theoretical worst case for 20 channels: 13 db too loud!
-{ Splay.ar(DC.ar(1!20), 0, 1, 0.999).ampdb }.plot;
-{ Splay.ar(DC.ar(1!200), 0, 1, 0.999).ampdb }.plot; // 200: 23 db louder
-{ Splay.ar(DC.ar(1!2000), 0, 1, 0.999).ampdb }.plot; // 2000: 33 db louder
+code::
+// plot 0.01 seconds, and poll for precise amp readout
+{ Splay.ar(DC.ar(1!20), 0, 1, 0.999).ampdb.poll }.plot;
+{ Splay.ar(DC.ar(1!200), 0, 1, 0.999).ampdb.poll }.plot; // 200: 23 db louder
+{ Splay.ar(DC.ar(1!2000), 0, 1, 0.999).ampdb.poll }.plot; // 2000: 33 db louder
+::
 
+So for maximum peak safety, use code::levelComp: 1:: (or equivalently, set code::levelComp: false::, and explicitly set level to 1/n, i.e. divide by the number of channels for amplitude compensation).
 
-// So for maximum peak safety, use levelComp 1, or equivalently,
-// turn levelComp off / false, and explicitly set level to 1/n.
-// and divide by the number of channels - i.e. equal amplitude:
-{ n = 2; Splay.ar(DC.ar(1!n), 1, 1, 0, levelComp: 1).ampdb }.plot; // -6 db on both
-{ n = 2; Splay.ar(DC.ar(1!n), 1, 1/n, 0, levelComp: false).ampdb }.plot;
-{ n = 2; Splay.ar(DC.ar(1!n), 0, 1, 0, levelComp: 1).ampdb }.plot; // -3 db on both
-{ n = 2; Splay.ar(DC.ar(1!n), 0, 1, 0.99, levelComp: 1).ampdb }.plot; // 0 db
+Then the levels predictably remain the same, independent of the number of channels to be mixed.
+code::
+{ n = 2; Splay.ar(DC.ar(1!n), 1, 1, 0, levelComp: 1).ampdb.poll }.plot; // -6 db on both
+{ n = 2; Splay.ar(DC.ar(1!n), 1, 1/n, 0, levelComp: false).ampdb.poll }.plot;
+{ n = 2; Splay.ar(DC.ar(1!n), 0, 1, 0, levelComp: 1).ampdb.poll }.plot; // -3 db on both
+{ n = 2; Splay.ar(DC.ar(1!n), 0, 1, 0.99, levelComp: 1).ampdb.poll }.plot; // 0 db
 
 // these are now the same for all tested values of n:
-{ n = 20; Splay.ar(DC.ar(1!n), 1, 1, 0, levelComp: 1).ampdb }.plot; // -4 db
-{ n = 20; Splay.ar(DC.ar(1!n), 0, 1, 0, levelComp: 1).ampdb }.plot; // -3 db
-{ n = 20; Splay.ar(DC.ar(1!n), 0, 1, 0.99, levelComp: 1).ampdb }.plot; // 0 db on right
+{ n = 20; Splay.ar(DC.ar(1!n), 1, 1, 0, levelComp: 1).ampdb.poll }.plot; // -4 db
+{ n = 20; Splay.ar(DC.ar(1!n), 0, 1, 0, levelComp: 1).ampdb.poll }.plot; // -3 db
+{ n = 20; Splay.ar(DC.ar(1!n), 0, 1, 0.99, levelComp: 1).ampdb.poll }.plot; // 0 db on right
 
-{ n = 200; Splay.ar(DC.ar(1!n), 1, 1, 0, levelComp: 1).ampdb }.plot; // -4 db
-{ n = 200; Splay.ar(DC.ar(1!n), 0, 1, 0, levelComp: 1).ampdb }.plot; // -3 db
-{ n = 200; Splay.ar(DC.ar(1!n), 0, 1, 0.99, levelComp: 1).ampdb }.plot; // 0 db on right
+{ n = 200; Splay.ar(DC.ar(1!n), 1, 1, 0, levelComp: 1).ampdb.poll }.plot; // -4 db
+{ n = 200; Splay.ar(DC.ar(1!n), 0, 1, 0, levelComp: 1).ampdb.poll }.plot; // -3 db
+{ n = 200; Splay.ar(DC.ar(1!n), 0, 1, 0.99, levelComp: 1).ampdb.poll }.plot; // 0 db on right
 
-{ n = 2000; Splay.ar(DC.ar(1!n), 1, 1, 0, levelComp: 1).ampdb }.plot; // -4 db
-{ n = 2000; Splay.ar(DC.ar(1!n), 0, 1, 0, levelComp: 1).ampdb }.plot; // -3 db
-{ n = 2000; Splay.ar(DC.ar(1!n), 0, 1, 0.99, levelComp: 1).ampdb }.plot; // 0 db on right
+{ n = 2000; Splay.ar(DC.ar(1!n), 1, 1, 0, levelComp: 1).ampdb.poll }.plot; // -4 db
+{ n = 2000; Splay.ar(DC.ar(1!n), 0, 1, 0, levelComp: 1).ampdb.poll }.plot; // -3 db
+{ n = 2000; Splay.ar(DC.ar(1!n), 0, 1, 0.99, levelComp: 1).ampdb.poll }.plot; // 0 db on right
 ::

--- a/HelpSource/Classes/LevelComp.schelp
+++ b/HelpSource/Classes/LevelComp.schelp
@@ -5,7 +5,7 @@ related:: Classes/Splay, Classes/SplayAz, Guides/Level_Compensation
 
 DESCRIPTION::
 Mixing and Panning multichannel signals often requires link::Guides/Level_Compensation::.
-LevelComp provides a logic for this that is used in the link::Splay:: and ::SplayAz::.
+LevelComp provides a logic for this that is used in the link::Classes/Splay:: and link::Classes/SplayAz::.
 It calculates a levelComp factor
 
 CLASSMETHODS::

--- a/HelpSource/Classes/Splay.schelp
+++ b/HelpSource/Classes/Splay.schelp
@@ -115,7 +115,4 @@ Splay.ar(ins, spread, level, center, levelComp: 0);
 //    1.0 is equal amplitude : level / ( numchans)
 // can be used to tune e.g. between equal power and equal amp:
 Splay.ar(ins, spread, level, center, levelComp: 0.75);
-
 ::
-
-

--- a/HelpSource/Classes/Splay.schelp
+++ b/HelpSource/Classes/Splay.schelp
@@ -1,7 +1,7 @@
 class:: Splay
 summary:: Splay spreads an array of channels across the stereo field
 categories:: UGens>Multichannel>Panners
-related:: Classes/SplayAz, Classes/SplayZ
+related:: Classes/SplayAz, Classes/SplayZ, Classes/LevelComp, Guides/Level_Compensation
 
 description::
 Splay spreads an array of channels across the stereo field.
@@ -89,7 +89,9 @@ true, false as before for rough equal power level compensation,
 and newly added: a float between 0 and 1. This is to offer more choices for level compensation, such as equal maximum amplitude.
 ::
 
-Overview of levelComp variants:
+For a full discussion, see link::Classes/LevelComp::;
+here is an overview of the levelComp variants:
+
 code::
 // default is equal power comp: level / ( numchans.sqrt)
 Splay.ar(ins, spread, level, center ); // true is default
@@ -116,74 +118,4 @@ Splay.ar(ins, spread, level, center, levelComp: 0.75);
 
 ::
 
-subsection:: Discussion and demonstration of level compensation options:
-code::
-
-s.meter;
-s.scope;
-
-// direct synthesis at level 0.1 -> -20db on each channel
-{ var n = 2, level = 0.1, spread = 1, pan = 0;
-	LFPulse.ar({ 100.exprand(2000) } ! n).range(-1, 1) * level
-}.play;
-
-// with levelComp true by default:
-// the same with 2 chans, spread 1, level 0.1, panned to center: -20db
-x = { |spread = 1, level = 0.1, center = 0|
-	var n = 2;
-	var snd = Splay.ar(LFPulse.ar({ 100.exprand(2000) } ! n).range(-1, 1),
-		spread, level, center);
-	Amplitude.ar(snd, 0.01, 1).ampdb.poll(1);
-	snd
-}.play;
-
-// at full spread, level -20, pan to center,
-x.set(\spread, 1, \center, 0); // -23
-// no spread, in center:
-x.set(\spread, 0, \center, 0); // -20
-// worst case: no spread, pan full left
-x.set(\spread, 0, \center, -1); // -17db
-
-//// The same tests with 20 channels, levelComp true as is default:
-x = { |spread = 1, level = 0.1, center = 0|
-	var n = 20;
-	var snd = Splay.ar(LFPulse.ar({ 100.exprand(2000) } ! n).range(-1, 1),
-		spread, level, center);
-	Amplitude.ar(snd, 0.01, 1).ampdb.poll(1);
-	snd
-}.play;
-
-// at full spread, level -20, pan to center, -17 db
-x.set(\spread, 1, \center, 0); // -17
-// no spread, in center: -21
-x.set(\spread, 0, \center, 0); // -16
-// worst case: no spread, pan full left
-x.set(\spread, 0, \center, -1); // -14db
-
-
-// here the theoretical worst case for 20 channels: 13 db too loud!
-{ Splay.ar(DC.ar(1!20), 0, 1, 0.999).ampdb.poll }.plot;
-{ Splay.ar(DC.ar(1!200), 0, 1, 0.999).ampdb.poll }.plot; // 23 db louder
-{ Splay.ar(DC.ar(1!2000), 0, 1, 0.999).ampdb.poll }.plot; // 33 db louder
-
-
-// For maximum peak safety, turn levelComp off / false,
-// and divide by the number of channels - i.e. equal amplitude:
-{ n = 2; Splay.ar(DC.ar(1!n), 1, 1/n, 0, false).ampdb.poll }.plot; // -6 db on both
-{ n = 2; Splay.ar(DC.ar(1!n), 0, 1/n, 0, false).ampdb.poll }.plot; // -3 db on both
-{ n = 2; Splay.ar(DC.ar(1!n), 0, 1/n, 0.99, false).ampdb.poll }.plot; // 0 db
-
-// these are now the same for all
-{ n = 20; Splay.ar(DC.ar(1!n), 1, 1/n, 0, false).ampdb.poll }.plot; // -4 db
-{ n = 20; Splay.ar(DC.ar(1!n), 0, 1/n, 0, false).ampdb.poll }.plot; // -3 db
-{ n = 20; Splay.ar(DC.ar(1!n), 0, 1/n, 0.99, false).ampdb.poll }.plot; // 0 db on right
-
-{ n = 200; Splay.ar(DC.ar(1!n), 1, 1/n, 0, false).ampdb.poll }.plot; // -4 db
-{ n = 200; Splay.ar(DC.ar(1!n), 0, 1/n, 0, false).ampdb.poll }.plot; // -3 db
-{ n = 200; Splay.ar(DC.ar(1!n), 0, 1/n, 0.99, false).ampdb.poll }.plot; // 0 db on right
-
-{ n = 2000; Splay.ar(DC.ar(1!n), 1, 1/n, 0, false).ampdb.poll }.plot; // -4 db
-{ n = 2000; Splay.ar(DC.ar(1!n), 0, 1/n, 0, false).ampdb.poll }.plot; // -3 db
-{ n = 2000; Splay.ar(DC.ar(1!n), 0, 1/n, 0.99, false).ampdb.poll }.plot; // 0 db on right
-::
 

--- a/HelpSource/Classes/Splay.schelp
+++ b/HelpSource/Classes/Splay.schelp
@@ -81,7 +81,7 @@ x.set(\spread, 1,   \center, 0);   // full stereo
 (
 x = { |spread = 1, level = 0.2, center = 0.0|
 	var numchans = 10;
-	Splay.arFill(10,
+	Splay.arFill(numchans,
 		{ |i| SinOsc.ar(LFNoise2.kr(rrand(10, 20), 200, i + 3 * 100))  },
 		spread,
 		level,
@@ -100,7 +100,7 @@ For a full discussion, see link::Classes/LevelComp::;
 here is an overview of the levelComp variants:
 
 code::
-// default is equal power comp: level / ( numchans.sqrt)
+// default is equal power comp: level / (numchans.sqrt)
 Splay.ar(ins, spread, level, center ); // true is default
 // write it explicitly for clarity
 Splay.ar(ins, spread, level, center, levelComp: true);
@@ -116,10 +116,10 @@ Splay.ar(ins, spread, level / ins.size, center, levelComp: false);
 Splay.ar(ins, spread, level, center, levelComp: false);
 Splay.ar(ins, spread, level, center, levelComp: 0);
 
-// levelComp by float: level / (numchans.pow(levelComp),
+// levelComp by float: level / numchans.pow(levelComp),
 // so 0.0 is no compensation: level / 1;
-//    0.5 is equal power : level / ( numchans.sqrt)
-//    1.0 is equal amplitude : level / ( numchans)
+//    0.5 is equal power : level / (numchans.sqrt)
+//    1.0 is equal amplitude : level / (numchans)
 // can be used to tune e.g. between equal power and equal amp:
 Splay.ar(ins, spread, level, center, levelComp: 0.75);
 ::

--- a/HelpSource/Classes/Splay.schelp
+++ b/HelpSource/Classes/Splay.schelp
@@ -101,7 +101,7 @@ here is an overview of the levelComp variants:
 
 code::
 // default is equal power comp: level / (numchans.sqrt)
-Splay.ar(ins, spread, level, center ); // true is default
+Splay.ar(ins, spread, level, center); // true is default
 // write it explicitly for clarity
 Splay.ar(ins, spread, level, center, levelComp: true);
 // or do equal power as float levelComp

--- a/HelpSource/Classes/Splay.schelp
+++ b/HelpSource/Classes/Splay.schelp
@@ -19,11 +19,18 @@ An amplitude multiplier for all channels
 argument:: center
 Shift the centre of the distribution.
 argument:: levelComp
-level compensation based on number of inArray channels:
-false or floating point 0.0 is no compensation,
-true or floating point 0.5 is equal power compensation,
-and floating point 1.0 is equal amplitude compensation.
-(See discussion below)
+a flag or numeric value:
+
+list::
+##code::true:: :  maintain equal power, keeping overall loudness the same.
+##code::false:: : off / no level change,
+##float between code::0.0:: and code::1.0:: : smooth tuning of levelComp factor:
+list::
+##code::0.0:: is none -> factor 1
+##code::0.5:: is equal power -> factor (1/n).squared
+##code::1.0:: is equal amplitude -> factor (1/n)
+::
+::
 
 method:: arFill
 In analogy to Mix:arFill, this method takes a function that produces the channels. The counting index is passed to it.
@@ -109,7 +116,7 @@ Splay.ar(ins, spread, level / ins.size, center, levelComp: false);
 Splay.ar(ins, spread, level, center, levelComp: false);
 Splay.ar(ins, spread, level, center, levelComp: 0);
 
-// levelComp by float: level / (numchans ** levelComp),
+// levelComp by float: level / (numchans.pow(levelComp),
 // so 0.0 is no compensation: level / 1;
 //    0.5 is equal power : level / ( numchans.sqrt)
 //    1.0 is equal amplitude : level / ( numchans)

--- a/HelpSource/Classes/Splay.schelp
+++ b/HelpSource/Classes/Splay.schelp
@@ -19,7 +19,11 @@ An amplitude multiplier for all channels
 argument:: center
 Shift the centre of the distribution.
 argument:: levelComp
-
+level compensation based on number of inArray channels:
+false or floating point 0.0 is no compensation,
+true or floating point 0.5 is equal power compensation,
+and floating point 1.0 is equal amplitude compensation.
+(See discussion below)
 
 method:: arFill
 In analogy to Mix:arFill, this method takes a function that produces the channels. The counting index is passed to it.
@@ -34,33 +38,42 @@ An amplitude multiplier for all channels
 argument:: center
 Shift the centre of the distribution.
 argument:: levelComp
+see above
 
 examples::
 
+Basic usage:
 code::
+// splay 10 chans of sound into 2
 (
 x = { |spread = 1, level = 0.2, center = 0.0|
+	var numchans = 10;
 	Splay.ar(
-		SinOsc.ar({ |i| LFNoise2.kr(1).exprange(200, 4000) } ! 10),
+		SinOsc.ar({ |i| LFNoise2.kr(1).exprange(200, 4000) } ! numchans),
 		spread,
 		level,
 		center
+		// use levelComp default true
 	);
 }.play;
 )
 
-x.set(\spread, 1,   \center, 0);  // full stereo
-x.set(\spread, 0.5, \center, 0);  // less wide
-x.set(\spread, 0,   \center, 0);  // mono center
-x.set(\spread, 0.5, \center, 0.5);
-// spread from center to right
-x.set(\spread, 0,   \center, -1); // all left
-x.set(\spread, 1,   \center, 0);  // full stereo
+s.meter;
+s.scope;
 
+// change settings dynamically:
 
-// the a similar example written with arFill:
+x.set(\spread, 1,   \center, 0);   // full stereo
+x.set(\spread, 0.5, \center, 0);   // less wide
+x.set(\spread, 0,   \center, 0);   // mono center
+x.set(\spread, 0.5, \center, 0.5); // spread from center to right
+x.set(\spread, 0,   \center, -1);  // all left
+x.set(\spread, 1,   \center, 0);   // full stereo
+
+// A similar example written with arFill:
 (
 x = { |spread = 1, level = 0.2, center = 0.0|
+	var numchans = 10;
 	Splay.arFill(10,
 		{ |i| SinOsc.ar(LFNoise2.kr(rrand(10, 20), 200, i + 3 * 100))  },
 		spread,
@@ -70,12 +83,107 @@ x = { |spread = 1, level = 0.2, center = 0.0|
 }.play;
 )
 
-
-// with mouse control
-(
-x = { var src;
-	src = SinOsc.ar({ |i| LFNoise2.kr(rrand(10, 20), 200, i + 3 * 100) } ! 10);
-	Splay.ar(src, MouseY.kr(1, 0), 0.2, MouseX.kr(-1, 1));
-}.play;
-)
 ::
+NOTE:: levelComp new takes multiple input options:
+true, false as before for rough equal power level compensation,
+and newly added: a float between 0 and 1. This is to offer more choices for level compensation, such as equal maximum amplitude.
+::
+
+Overview of levelComp variants:
+code::
+// default is equal power comp: level / ( numchans.sqrt)
+Splay.ar(ins, spread, level, center ); // true is default
+// write it explicitly for clarity
+Splay.ar(ins, spread, level, center, levelComp: true);
+// or do equal power as float levelComp
+Splay.ar(ins, spread, level, center, levelComp: 0.5); //
+
+// maximum peak safety by equal amplitude comp: level / numchans
+Splay.ar(ins, spread, level, center, levelComp: 1);
+// or calculate by hand:
+Splay.ar(ins, spread, level / ins.size, center, levelComp: false);
+
+// no compensation, just tune level by hand
+Splay.ar(ins, spread, level, center, levelComp: false);
+Splay.ar(ins, spread, level, center, levelComp: 0);
+
+// levelComp by float: level / (numchans ** levelComp),
+// so 0.0 is no compensation: level / 1;
+//    0.5 is equal power : level / ( numchans.sqrt)
+//    1.0 is equal amplitude : level / ( numchans)
+// can be used to tune e.g. between equal power and equal amp:
+Splay.ar(ins, spread, level, center, levelComp: 0.75);
+
+::
+
+subsection:: Discussion and demonstration of level compensation options:
+code::
+
+s.meter;
+s.scope;
+
+// direct synthesis at level 0.1 -> -20db on each channel
+{ var n = 2, level = 0.1, spread = 1, pan = 0;
+	LFPulse.ar({ 100.exprand(2000) } ! n).range(-1, 1) * level
+}.play;
+
+// with levelComp true by default:
+// the same with 2 chans, spread 1, level 0.1, panned to center: -20db
+x = { |spread = 1, level = 0.1, center = 0|
+	var n = 2;
+	var snd = Splay.ar(LFPulse.ar({ 100.exprand(2000) } ! n).range(-1, 1),
+		spread, level, center);
+	Amplitude.ar(snd, 0.01, 1).ampdb.poll(1);
+	snd
+}.play;
+
+// at full spread, level -20, pan to center,
+x.set(\spread, 1, \center, 0); // -23
+// no spread, in center:
+x.set(\spread, 0, \center, 0); // -20
+// worst case: no spread, pan full left
+x.set(\spread, 0, \center, -1); // -17db
+
+//// The same tests with 20 channels, levelComp true as is default:
+x = { |spread = 1, level = 0.1, center = 0|
+	var n = 20;
+	var snd = Splay.ar(LFPulse.ar({ 100.exprand(2000) } ! n).range(-1, 1),
+		spread, level, center);
+	Amplitude.ar(snd, 0.01, 1).ampdb.poll(1);
+	snd
+}.play;
+
+// at full spread, level -20, pan to center, -17 db
+x.set(\spread, 1, \center, 0); // -17
+// no spread, in center: -21
+x.set(\spread, 0, \center, 0); // -16
+// worst case: no spread, pan full left
+x.set(\spread, 0, \center, -1); // -14db
+
+
+// here the theoretical worst case for 20 channels: 13 db too loud!
+{ Splay.ar(DC.ar(1!20), 0, 1, 0.999).ampdb.poll }.plot;
+{ Splay.ar(DC.ar(1!200), 0, 1, 0.999).ampdb.poll }.plot; // 23 db louder
+{ Splay.ar(DC.ar(1!2000), 0, 1, 0.999).ampdb.poll }.plot; // 33 db louder
+
+
+// For maximum peak safety, turn levelComp off / false,
+// and divide by the number of channels - i.e. equal amplitude:
+{ n = 2; Splay.ar(DC.ar(1!n), 1, 1/n, 0, false).ampdb.poll }.plot; // -6 db on both
+{ n = 2; Splay.ar(DC.ar(1!n), 0, 1/n, 0, false).ampdb.poll }.plot; // -3 db on both
+{ n = 2; Splay.ar(DC.ar(1!n), 0, 1/n, 0.99, false).ampdb.poll }.plot; // 0 db
+
+// these are now the same for all
+{ n = 20; Splay.ar(DC.ar(1!n), 1, 1/n, 0, false).ampdb.poll }.plot; // -4 db
+{ n = 20; Splay.ar(DC.ar(1!n), 0, 1/n, 0, false).ampdb.poll }.plot; // -3 db
+{ n = 20; Splay.ar(DC.ar(1!n), 0, 1/n, 0.99, false).ampdb.poll }.plot; // 0 db on right
+
+{ n = 200; Splay.ar(DC.ar(1!n), 1, 1/n, 0, false).ampdb.poll }.plot; // -4 db
+{ n = 200; Splay.ar(DC.ar(1!n), 0, 1/n, 0, false).ampdb.poll }.plot; // -3 db
+{ n = 200; Splay.ar(DC.ar(1!n), 0, 1/n, 0.99, false).ampdb.poll }.plot; // 0 db on right
+
+{ n = 2000; Splay.ar(DC.ar(1!n), 1, 1/n, 0, false).ampdb.poll }.plot; // -4 db
+{ n = 2000; Splay.ar(DC.ar(1!n), 0, 1/n, 0, false).ampdb.poll }.plot; // -3 db
+{ n = 2000; Splay.ar(DC.ar(1!n), 0, 1/n, 0.99, false).ampdb.poll }.plot; // 0 db on right
+::
+

--- a/HelpSource/Classes/SplayAz.schelp
+++ b/HelpSource/Classes/SplayAz.schelp
@@ -1,11 +1,12 @@
 class:: SplayAz
 summary:: Spreads an array of channels across a ring of channels
 categories:: UGens>Multichannel>Panners
-related:: Classes/Splay, Classes/PanAz, Classes/SelectXFocus
+related:: Classes/Splay, Classes/PanAz, Classes/SelectXFocus, Classes/LevelComp, Guides/Level_Compensation
 
 description::
 SplayAz spreads an array of channels across a ring of channels.
-Optional spread and center controls, and equal power levelCompensation.
+Optional spread and center controls, and flexible levelCompensation
+tunable for equal power and/or equal amplitude.
 numChans and orientation are as in link::Classes/PanAz::.
 
 code::
@@ -44,7 +45,15 @@ speaker will be directly in front. Should be 0.5 if the front
 bisects a side of the polygon. Then the first speaker will be the
 one left of center.
 argument:: levelComp
-If true, the signal level is adjusted to maintain overall loudness the same (n.reciprocal.sqrt).
+If true, the signal level is adjusted to maintain equal power,
+keeping overall loudness the same (n.reciprocal.sqrt).
+if false, no compensation.
+if float, tunable between 0.0 and 1.0:
+0.0 is no compensation,
+0.5 is equal power,
+1.0 is equal amplitude (1/n)
+
+See link::Classes/LevelComp::
 
 method:: arFill
 argument:: numChans

--- a/HelpSource/Classes/SplayAz.schelp
+++ b/HelpSource/Classes/SplayAz.schelp
@@ -44,16 +44,22 @@ Should be zero if the front is a vertex of the polygon. The first
 speaker will be directly in front. Should be 0.5 if the front
 bisects a side of the polygon. Then the first speaker will be the
 one left of center.
-argument:: levelComp
-If true, the signal level is adjusted to maintain equal power,
-keeping overall loudness the same (n.reciprocal.sqrt).
-if false, no compensation.
-if float, tunable between 0.0 and 1.0:
-0.0 is no compensation,
-0.5 is equal power,
-1.0 is equal amplitude (1/n)
 
-See link::Classes/LevelComp::
+argument:: levelComp
+a flag or numeric value:
+
+list::
+##code::true:: :  maintain equal power, keeping overall loudness the same.
+##code::false:: : off / no level change,
+##float between code::0.0:: and code::1.0:: : smooth tuning of levelComp factor:
+list::
+##code::0.0:: is none -> factor 1
+##code::0.5:: is equal power -> factor (1/n).squared
+##code::1.0:: is equal amplitude -> factor (1/n)
+::
+::
+
+See link::Classes/LevelComp:: for full discussion.
 
 method:: arFill
 argument:: numChans

--- a/HelpSource/Guides/Level_Compensation.schelp
+++ b/HelpSource/Guides/Level_Compensation.schelp
@@ -18,7 +18,7 @@ To balance these aspects, it helps to know more about the signals to be mixed/pa
 
 strong::Degree of Phase Correlation: :: How likely is it that the momentary peaks of the individual signals will line up in time? The two border cases are fully strong::in-phase: :: the same signal on all channels, so the peaks will always line up, and fully strong::random phase: :: different noise signals on all channels, where the peaks will be statistically very unlikely to ever line up. Most musical signals are somewhere between these extremes, i.e. phase-correlated to some degree.
 
-strong::Equal Amplitude Compensation:: is the safe bet for highly correlated signals: divide the sum of the number of channels; strong::Equal Power Compensation :: is commonly used for weakly correlated signals, as it keeps the acoustic energy constant by dividing the sum through the square root of the number of channels. As most musical signals are somewhere between the extremes, it makes sense to consider and test for the specific case whenever in doubt.
+strong::Equal Amplitude Compensation:: is the safe bet for highly correlated signals: divide the sum of the number of channels; strong::Equal Power Compensation:: is commonly used for weakly correlated signals, as it keeps the acoustic energy constant by dividing the sum through the square root of the number of channels. As most musical signals are somewhere between the extremes, it makes sense to consider and test for the specific case whenever in doubt.
 
 In the acoustics literature, this level compensation factor is called the p-value [1], and it can be generalized as follows:
 
@@ -35,7 +35,8 @@ code::
 Here are some examples for the common cases of Mixing and Panning.
 
 subsection:: Mixing M channels to 1
-Mixing down to mono is the simplest case to show the different approaches to level compensation. UGens or functions for this are Mix.ar, sum, mean.
+Mixing down to mono is the simplest case to show the different approaches to level compensation. UGens or functions for this are link::Classes/Mix::, code::sum::, code::mean::.
+
 code::
 s.meter; s.scope;
 
@@ -72,7 +73,7 @@ n = 10;
 
 subsection:: Panning 1 channel to 2
 
-Pan2 uses equal power panning:
+link::Classes/Pan2:: uses equal power panning:
 when panned to the center, both signals are at 0.7, or -3 dB
 code::
 { Pan2.ar(DC.ar(1), Line.kr(-1, 1, 0.1)) }.plot(0.1);
@@ -80,7 +81,7 @@ code::
 { Pan2.ar(PinkNoise.ar(0.2), SinOsc.kr(0.3)) }.play;
 
 ::
-LinPan2 uses equal amplitude panning:
+link::Classes/LinPan2:: uses equal amplitude panning:
 in the center, both signals are at 0.5.
 code::
 { LinPan2.ar(DC.ar(1), Line.kr(-1, 1, 0.1)) }.plot(0.1);
@@ -90,8 +91,8 @@ code::
 ::
 
 subsection:: Panning 1 channel to N
-PanAz uses equal power panning, so with a default width of 2,
-it keeps the energy constant, like Pan2.
+link::Classes/PanAz:: uses equal power panning, so with a default width of 2,
+it keeps the energy constant, like link::Classes/Pan2::.
 code::
 { PanAz.ar(4, DC.ar(1), Line.kr(-1, 1, 0.1), orientation: 0) }.plot(0.1);
 
@@ -101,8 +102,7 @@ code::
 ::
 
 subsection:: Mix/Panning M to 2 channels
-Splay mixes an array of input channels down to stereo using Pan2,
-and it has 3 options for level compensation:
+link::Classes/Splay:: mixes an array of input channels down to stereo using link::Classes/Pan2::, and it has 3 options for level compensation:
 code::
 s.meter; s.scope;
 
@@ -126,7 +126,7 @@ Note that this levelComp factor scales with the number of channels,
 so tuning to somewhere between 0.5 and 1.0 should work well when experimenting with changing numbers of channels.
 
 subsection:: Mix/Panning M channels to N
-SplayAz mixes an array of M input channels to N outputs using PanAz;
+link::Classes/SplayAz:: mixes an array of M input channels to N outputs using link::Classes/PanAz::;
 it has 3 options for level compensation:
 code::
 s.meter; s.scope;

--- a/HelpSource/Guides/Level_Compensation.schelp
+++ b/HelpSource/Guides/Level_Compensation.schelp
@@ -65,7 +65,7 @@ n = 10;
 // compare single channel ...
 { PinkNoise.ar }.play;
 
-//with mixdown of n to 1 with equal power compensation:
+// with mixdown of n to 1 with equal power compensation:
 // volume is quite similar, can peak, but will very rarely
 { PinkNoise.ar({ 1 } ! n).sum / n.sqrt }.play;
 ::
@@ -115,7 +115,6 @@ s.meter; s.scope;
 // levelComp can be a number between 0.0 -> no comp,
 // and 1.0 -> equal amplitude comp, with 0.5 being equal power,
 // which allows fine/tuning by hand via the exponent:
-// [[[ requires PR on Splay ]]]
 { Splay.ar(Saw.ar([100, 150, 250]), levelComp: 0.5) }.scope;
 
 // When setting spread low, levels and peaks will go up;

--- a/HelpSource/Guides/Level_Compensation.schelp
+++ b/HelpSource/Guides/Level_Compensation.schelp
@@ -1,7 +1,7 @@
 title:: Level Compensation when Mixing and Panning
 categories:: Multichannel, Mixing, Panning
 summary:: Balancing Levels when Mixing and Panning in SC
-related:: Classes/Pan2, Classes/PanAz, Classes/Splay, Classes/SplayAz
+related:: Classes/Pan2, Classes/PanAz, Classes/Splay, Classes/SplayAz, Classes/LevelComp
 
 section::Considerations
 

--- a/HelpSource/Guides/Level_Compensation.schelp
+++ b/HelpSource/Guides/Level_Compensation.schelp
@@ -1,0 +1,159 @@
+title:: Level Compensation when Mixing and Panning
+categories:: Multichannel, Mixing, Panning
+summary:: Balancing Levels when Mixing and Panning in SC
+related:: Classes/Pan2, Classes/PanAz, Classes/Splay, Classes/SplayAz
+
+section::Considerations
+
+link::Guides/Multichannel-Expansion:: is one of the key features in SuperCollider, making it easy to explore complex polyphonic synthesis and spatialisation. Mixing and panning these signals usually involves going from a number of input channels to a different number of output channels, and for adapting the signal amplitude levels meaningfully, there are two aspects to consider:
+
+strong::
+1. Technical safety: What will be the maximum amplitude of the new signals? In the worst case, can they clip the audio hardware (by going above +-1.0)?::
+
+strong::
+2. Perceived loudness: How loud should the new signals it be, relative to others present?
+::
+
+To balance these aspects, it helps to know more about the signals to be mixed/panned. Most UGens in SC produce a signal amplitude of 1.0, so we will use that value for the discussion here.
+
+strong::Degree of Phase Correlation: :: How likely is it that the momentary peaks of the individual signals will line up in time? The two border cases are fully strong::in-phase: :: the same signal on all channels, so the peaks will always line up, and fully strong::random phase: :: different noise signals on all channels, where the peaks will be statistically very unlikely to ever line up. Most musical signals are somewhere between these extremes, i.e. phase-correlated to some degree.
+
+strong::Equal Amplitude Compensation:: is the safe bet for highly correlated signals: divide the sum of the number of channels; strong::Equal Power Compensation :: is commonly used for weakly correlated signals, as it keeps the acoustic energy constant by dividing the sum through the square root of the number of channels. As most musical signals are somewhere between the extremes, it makes sense to consider and test for the specific case whenever in doubt.
+
+In the acoustics literature, this level compensation factor is called the p-value [1], and it can be generalized as follows:
+
+code::
+
+~levelCompFactor = { |numChans=2, p_value=1|
+	numChans ** p_value.clip(0, 1).neg
+};
+~levelCompFactor.value(2, 1); // equal amplitude, multiply by 1/n
+~levelCompFactor.value(2, 0.5); // equal power, mul by square root of 1/n
+~levelCompFactor.value(2, 0); // keep full level, no level scaling
+::
+
+Here are some examples for the common cases of Mixing and Panning.
+
+subsection:: Mixing M channels to 1
+Mixing down to mono is the simplest case to show the different approaches to level compensation. UGens or functions for this are Mix.ar, sum, mean.
+code::
+s.meter; s.scope;
+
+n = 10;
+// 10 chans to 1, fully coherent in-phase signals:
+{ (SinOsc.ar ! n) }.plot;
+{ (SinOsc.ar ! n).sum }.plot;       // sum : +-10
+// equal amplitude: divide by number of channels -> peak 1
+{ (SinOsc.ar ! n).sum / n }.plot;   // sum
+{ Mix.ar(SinOsc.ar ! n) / n }.plot; // same with Mix.ar
+{ (SinOsc.ar ! n).mean }.plot;      // mean directly divides by n!
+
+// 10 chans to 1, quasi coherent with 100Hz shared root:
+{ SinOsc.ar((1..n) * 100, 0.5pi) }.plot(0.05);
+
+// because peaks coincide exactly (with 0.5pi phase shift),
+// we have to divide by n to stay within +-1:
+{ SinOsc.ar((1..n) * 100, 0.5pi).sum / n }.plot(0.05);
+{ SinOsc.ar((1..n) * 100, 0.5pi).sum / n }.play;
+
+// signals are less coherent with random freqs in the same range
+{ SinOsc.ar({ rrand(100.0, 1000.0).postln }! n, 0.5pi).sum / n }.play;
+
+// very random-phase signals
+{ PinkNoise.ar(1 ! n) }.play;
+
+// compare single channel ...
+{ PinkNoise.ar }.play;
+
+//with mixdown of n to 1 with equal power compensation:
+// volume is quite similar, can peak, but will very rarely
+{ PinkNoise.ar({ 1 } ! n).sum / n.sqrt }.play;
+::
+
+subsection:: Panning 1 channel to 2
+
+Pan2 uses equal power panning:
+when panned to the center, both signals are at 0.7, or -3 dB
+code::
+{ Pan2.ar(DC.ar(1), Line.kr(-1, 1, 0.1)) }.plot(0.1);
+// loudness seems constant when panning
+{ Pan2.ar(PinkNoise.ar(0.2), SinOsc.kr(0.3)) }.play;
+
+::
+LinPan2 uses equal amplitude panning:
+in the center, both signals are at 0.5.
+code::
+{ LinPan2.ar(DC.ar(1), Line.kr(-1, 1, 0.1)) }.plot(0.1);
+// loudness seems to drop slightly when in the center
+{ LinPan2.ar(PinkNoise.ar(0.2), SinOsc.kr(0.3)) }.play;
+
+::
+
+subsection:: Panning 1 channel to N
+PanAz uses equal power panning, so with a default width of 2,
+it keeps the energy constant, like Pan2.
+code::
+{ PanAz.ar(4, DC.ar(1), Line.kr(-1, 1, 0.1), orientation: 0) }.plot(0.1);
+
+// with larger width, the overlaps get bigger, and the overall energy rises,
+// so one may want to compensate amplitude for larger width
+{ PanAz.ar(4, DC.ar(1), Line.kr(-1, 1, 0.1), width: 4, orientation: 0) }.plot(0.1);
+::
+
+subsection:: Mix/Panning M to 2 channels
+Splay mixes an array of input channels down to stereo using Pan2,
+and it has 3 options for level compensation:
+code::
+s.meter; s.scope;
+
+// levelComp defaults to true, which is equal power -
+// this is kept this way for backwards compatibility.
+{ Splay.ar(Saw.ar([20, 30, 50]), 1, levelComp: true) }.scope;
+// levelComp can be turned off to set level otherwise:
+{ Splay.ar(Saw.ar([20, 30, 50]), level: 0.6, levelComp: false) }.scope;
+
+// levelComp can be a number between 0.0 -> no comp,
+// and 1.0 -> equal amplitude comp, with 0.5 being equal power,
+// which allows fine/tuning by hand via the exponent:
+// [[[ requires PR on Splay ]]]
+{ Splay.ar(Saw.ar([100, 150, 250]), levelComp: 0.5) }.scope;
+
+// When setting spread low, levels and peaks will go up;
+// the worst case is panning all inputs to a single channel:
+{ Splay.ar(Saw.ar([100, 150, 250]), spread: 0, center: 1, levelComp: 0.5) }.scope;
+
+::
+Note that this levelComp factor scales with the number of channels,
+so tuning to somewhere between 0.5 and 1.0 should work well when experimenting with changing numbers of channels.
+
+subsection:: Mix/Panning M channels to N
+SplayAz mixes an array of M input channels to N outputs using PanAz;
+it has 3 options for level compensation:
+code::
+s.meter; s.scope;
+
+n = 10;
+// levelComp defaults to true, which is equal power:
+{ SplayAz.ar(4, Saw.ar({ exprand(100, 500) }! n), 1, levelComp: true) }.scope;
+// levelComp can be off to compensate by hand/ear:
+{ SplayAz.ar(4, Saw.ar({ exprand(100, 500) }! n), level: (1/n).sqrt, levelComp: false) }.scope;
+
+// as in Splay, levelComp can be a number between 0.0 -> no comp,
+// and 1.0 -> equal amplitude comp, with 0.5 being equal power.
+// This allows fine-tuning by hand via the levelComp exponent:
+// requires PR on SplayAz
+{ SplayAz.ar(4, Saw.ar({ exprand(100, 500) }! n), level: 0.5, levelComp: 0.7) }.scope;
+
+// When setting spread low, levels on single channel(s) go up:
+{ SplayAz.ar(4, Saw.ar({ exprand(100, 500) }! n), level: 0.5, spread: 0, orientation: 0) }.scope;
+
+// Worst case: all panned to same out channel go up:
+{ SplayAz.ar(4, Saw.ar({ exprand(100, 500) }! n), level: 0.5) }.scope;
+
+// When width values are high, the overall output level also rises,
+// because each channel is directed to more channels:
+{ SplayAz.ar(4, Saw.ar({ exprand(100, 500) }! n), level: 0.5, width: 4) }.scope;
+
+::
+
+[1] Laitinen, Mikko-Ville, et al. "Gain normalization in amplitude panning as a function of frequency and room reverberance." Audio Engineering Society Conference: 55th International Conference: Spatial Audio. Audio Engineering Society, 2014.

--- a/SCClassLibrary/Common/Audio/Splay.sc
+++ b/SCClassLibrary/Common/Audio/Splay.sc
@@ -1,3 +1,25 @@
+LevelComp {
+	*new { |levelComp, rate|
+		if (levelComp == true) {
+			^if(rate == \audio) {
+				// ar default is equal power for backwards compatibility
+				n.reciprocal.sqrt
+			} {
+				// kr default is equal amplitude
+				n.reciprocal
+			}
+		};
+		// if false, level is untouched
+		if (levelComp == false) { ^1 };
+
+		// if a number or control signal,
+		// scale by exponent: 0 is no change,
+		// 0.5 is square root = equal power
+		// 1.0 is level / numchans = equal amplitude
+		(n.reciprocal ** levelComp.clip(0.0, 1.0));
+	}
+}
+
 Splay : UGen {
 
 	*new1 { arg rate, spread = 1, level = 1, center = 0.0, levelComp = true ... inArray;
@@ -5,26 +27,7 @@ Splay : UGen {
 		var n = max(2, inArray.size);
 		var n1 = n - 1;
 		var positions = ((0 .. n1) * (2 / n1) - 1) * spread + center;
-
-		if (levelComp == true) {
-			// ar default is equal power for backwards compatibility
-			if(rate == \audio) {
-				level = level * n.reciprocal.sqrt
-			} {
-				// kr default is equal amplitude
-				level = level / n
-			}
-		} {
-			// if false, level is untouched
-			if (levelComp != false) {
-				// if number or control signal,
-				// scale by exponent: 0 is none,
-				// 0.5 is square root = equal power
-				// 1.0 is level / numchans = equal amplitude
-				level = level / (n ** levelComp.clip(0.0, 1.0));
-			};
-		};
-		level.poll;
+		level = level * LevelComp(levelComp, rate);
 
 		^Mix(Pan2.perform(this.methodSelectorForRate(rate), inArray, positions)) * level;
 	}
@@ -51,18 +54,20 @@ SplayAz : UGen {
 	*kr { arg numChans = 4, inArray, spread = 1, level = 1, width = 2, center = 0.0, orientation = 0.5, levelComp = true;
 
 		var n = max(1, inArray.size);
-		var pos = if(n == 1) { center } { [ center - spread, center + spread ].resamp1(n) };
-		if (levelComp) { level = level * n.reciprocal.sqrt };
+		var normSpread = spread * (n - 1 / n);
+		var pos = if(n == 1) { center } { [ center - normSpread, center + normSpread ].resamp1(n) };
+
 		^PanAz.kr(numChans, inArray.asArray, pos, level, width, orientation).flop.collect(Mix(_))
 	}
 
 	*ar { arg numChans = 4, inArray, spread = 1, level = 1, width = 2, center = 0.0, orientation = 0.5, levelComp = true;
 
 		var n = max(1, inArray.size);
-		var normalizedSpread = spread * (n - 1 / n);
-		var pos = if(n == 1) { center } { [ center - normalizedSpread, center + normalizedSpread ].resamp1(n) };
+		var normSpread = spread * (n - 1 / n);
+		var pos = if(n == 1) { center } { [ center - normSpread, center + normSpread ].resamp1(n) };
 
-		if (levelComp) { level = level * n.reciprocal.sqrt };
+		level = level * LevelComp(levelComp, rate);
+
 		^PanAz.ar(numChans, inArray.asArray, pos, level, width, orientation).flop.collect(Mix(_))
 	}
 

--- a/SCClassLibrary/Common/Audio/Splay.sc
+++ b/SCClassLibrary/Common/Audio/Splay.sc
@@ -6,13 +6,25 @@ Splay : UGen {
 		var n1 = n - 1;
 		var positions = ((0 .. n1) * (2 / n1) - 1) * spread + center;
 
-		if (levelComp) {
+		if (levelComp == true) {
+			// ar default is equal power for backwards compatibility
 			if(rate == \audio) {
 				level = level * n.reciprocal.sqrt
 			} {
+				// kr default is equal amplitude
 				level = level / n
 			}
+		} {
+			// if false, level is untouched
+			if (levelComp != false) {
+				// if number or control signal,
+				// scale by exponent: 0 is none,
+				// 0.5 is square root = equal power
+				// 1.0 is level / numchans = equal amplitude
+				level = level / (n ** levelComp.clip(0.0, 1.0));
+			};
 		};
+		level.poll;
 
 		^Mix(Pan2.perform(this.methodSelectorForRate(rate), inArray, positions)) * level;
 	}

--- a/SCClassLibrary/Common/Audio/Splay.sc
+++ b/SCClassLibrary/Common/Audio/Splay.sc
@@ -1,5 +1,5 @@
 LevelComp {
-	*new { |levelComp, rate|
+	*new { |levelComp, rate, n|
 		if (levelComp == true) {
 			^if(rate == \audio) {
 				// ar default is equal power for backwards compatibility
@@ -27,7 +27,7 @@ Splay : UGen {
 		var n = max(2, inArray.size);
 		var n1 = n - 1;
 		var positions = ((0 .. n1) * (2 / n1) - 1) * spread + center;
-		level = level * LevelComp(levelComp, rate);
+		level = level * LevelComp(levelComp, rate, n);
 
 		^Mix(Pan2.perform(this.methodSelectorForRate(rate), inArray, positions)) * level;
 	}
@@ -56,6 +56,7 @@ SplayAz : UGen {
 		var n = max(1, inArray.size);
 		var normSpread = spread * (n - 1 / n);
 		var pos = if(n == 1) { center } { [ center - normSpread, center + normSpread ].resamp1(n) };
+		level = level * LevelComp(levelComp, \control);
 
 		^PanAz.kr(numChans, inArray.asArray, pos, level, width, orientation).flop.collect(Mix(_))
 	}
@@ -66,7 +67,7 @@ SplayAz : UGen {
 		var normSpread = spread * (n - 1 / n);
 		var pos = if(n == 1) { center } { [ center - normSpread, center + normSpread ].resamp1(n) };
 
-		level = level * LevelComp(levelComp, rate);
+		level = level * LevelComp(levelComp, \audio);
 
 		^PanAz.ar(numChans, inArray.asArray, pos, level, width, orientation).flop.collect(Mix(_))
 	}

--- a/SCClassLibrary/Common/Audio/Splay.sc
+++ b/SCClassLibrary/Common/Audio/Splay.sc
@@ -56,7 +56,7 @@ SplayAz : UGen {
 		var n = max(1, inArray.size);
 		var normSpread = (n - 1 / n) * spread;
 		var pos = if(n == 1) { center } { [ center - normSpread, center + normSpread ].resamp1(n) };
-		level = level * LevelComp(levelComp, \control);
+		level = level * LevelComp(levelComp, \control, n);
 
 		^PanAz.kr(numChans, inArray.asArray, pos, level, width, orientation).flop.collect(Mix(_))
 	}
@@ -67,7 +67,7 @@ SplayAz : UGen {
 		var normSpread = (n - 1 / n) * spread;
 		var pos = if(n == 1) { center } { [ center - normSpread, center + normSpread ].resamp1(n) };
 
-		level = level * LevelComp(levelComp, \audio);
+		level = level * LevelComp(levelComp, \audio, n);
 
 		^PanAz.ar(numChans, inArray.asArray, pos, level, width, orientation).flop.collect(Mix(_))
 	}

--- a/SCClassLibrary/Common/Audio/Splay.sc
+++ b/SCClassLibrary/Common/Audio/Splay.sc
@@ -12,8 +12,8 @@ LevelComp {
 		// if false, level is untouched
 		if (levelComp == false) { ^1 };
 
-		// if a number or control signal,
-		// scale by exponent: 0 is no change,
+		// now levelComp is a number or UGen,
+		// so we scale by exponent: 0 is no change,
 		// 0.5 is square root = equal power
 		// 1.0 is level / numchans = equal amplitude
 		^n.reciprocal ** levelComp.clip(0.0, 1.0)

--- a/SCClassLibrary/Common/Audio/Splay.sc
+++ b/SCClassLibrary/Common/Audio/Splay.sc
@@ -16,7 +16,7 @@ LevelComp {
 		// scale by exponent: 0 is no change,
 		// 0.5 is square root = equal power
 		// 1.0 is level / numchans = equal amplitude
-		(n.reciprocal ** levelComp.clip(0.0, 1.0));
+		^n.reciprocal ** levelComp.clip(0.0, 1.0)
 	}
 }
 
@@ -54,7 +54,7 @@ SplayAz : UGen {
 	*kr { arg numChans = 4, inArray, spread = 1, level = 1, width = 2, center = 0.0, orientation = 0.5, levelComp = true;
 
 		var n = max(1, inArray.size);
-		var normSpread = spread * (n - 1 / n);
+		var normSpread = (n - 1 / n) * spread;
 		var pos = if(n == 1) { center } { [ center - normSpread, center + normSpread ].resamp1(n) };
 		level = level * LevelComp(levelComp, \control);
 
@@ -64,7 +64,7 @@ SplayAz : UGen {
 	*ar { arg numChans = 4, inArray, spread = 1, level = 1, width = 2, center = 0.0, orientation = 0.5, levelComp = true;
 
 		var n = max(1, inArray.size);
-		var normSpread = spread * (n - 1 / n);
+		var normSpread = (n - 1 / n) * spread;
 		var pos = if(n == 1) { center } { [ center - normSpread, center + normSpread ].resamp1(n) };
 
 		level = level * LevelComp(levelComp, \audio);


### PR DESCRIPTION
## Purpose and Motivation

Level Compensation for Splay and SplayAz were questioned and discussed at length 
in #5706. As there is not one single correct formula, but situation-dependent considerations, 
this PR adds: 
- A Guide page that discusses these considerations, with examples.
- A LevelComp class that implements a fully backwards-compatible, more flexible logic.
- Updates to Splay and SplayAz that use this logic. 

## Types of changes
- Documentation / Guide
- Bug fix - sync pos calculation in PanAz.kr with fix in PanAz.ar
- New feature - more flexible level compensation.

## To-do list

[x] Code is tested
[x] All tests are passing
[x] Documentation : updated Splay and SplayAz help files, added Guide file.
[x] This PR is ready for review
