### PR TITLE
Do not display setting menu icons on macOS

### DIFF
--- a/editors/sc-ide/widgets/settings/dialog.cpp
+++ b/editors/sc-ide/widgets/settings/dialog.cpp
@@ -38,19 +38,6 @@
 
 namespace ScIDE { namespace Settings {
 
-// Since qt6 some icons are matched on macOS and some are not.
-// As there doesn't seem to be a consistent icon set available on macOS
-// the icons are omitted for macOS.
-// See https://github.com/supercollider/supercollider/issues/6560
-QListWidgetItem* makeListWidgetItem(const QIcon& icon, const QString& text) {
-#ifdef Q_OS_MAC
-    return new QListWidgetItem(text);
-#else
-    return new QListWidgetItem(QIcon::fromTheme(icon), text);
-#endif
-}
-
-
 Dialog::Dialog(Manager* settings, QWidget* parent): QDialog(parent), mManager(settings), ui(new Ui::ConfigDialog) {
     ui->setupUi(this);
 
@@ -58,25 +45,25 @@ Dialog::Dialog(Manager* settings, QWidget* parent): QDialog(parent), mManager(se
 
     w = new GeneralPage;
     ui->configPageStack->addWidget(w);
-    ui->configPageList->addItem(makeListWidgetItem(QIcon::fromTheme("preferences-system"), tr("General")));
+    ui->configPageList->addItem(new QListWidgetItem(tr("General")));
     connect(this, SIGNAL(storeRequest(Manager*)), w, SLOT(store(Manager*)));
     connect(this, SIGNAL(loadRequest(Manager*)), w, SLOT(load(Manager*)));
 
     w = new SclangPage;
     ui->configPageStack->addWidget(w);
-    ui->configPageList->addItem(makeListWidgetItem(QIcon::fromTheme("applications-system"), tr("Interpreter")));
+    ui->configPageList->addItem(new QListWidgetItem(tr("Interpreter")));
     connect(this, SIGNAL(storeRequest(Manager*)), w, SLOT(store(Manager*)));
     connect(this, SIGNAL(loadRequest(Manager*)), w, SLOT(load(Manager*)));
 
     w = new EditorPage;
     ui->configPageStack->addWidget(w);
-    ui->configPageList->addItem(makeListWidgetItem(QIcon::fromTheme("accessories-text-editor"), tr("Editor")));
+    ui->configPageList->addItem(new QListWidgetItem(tr("Editor")));
     connect(this, SIGNAL(storeRequest(Manager*)), w, SLOT(store(Manager*)));
     connect(this, SIGNAL(loadRequest(Manager*)), w, SLOT(load(Manager*)));
 
     w = new ShortcutsPage;
     ui->configPageStack->addWidget(w);
-    ui->configPageList->addItem(makeListWidgetItem(QIcon::fromTheme("input-keyboard"), tr("Shortcuts")));
+    ui->configPageList->addItem(new QListWidgetItem(tr("Shortcuts")));
     connect(this, SIGNAL(storeRequest(Manager*)), w, SLOT(store(Manager*)));
     connect(this, SIGNAL(loadRequest(Manager*)), w, SLOT(load(Manager*)));
 

--- a/editors/sc-ide/widgets/settings/dialog.cpp
+++ b/editors/sc-ide/widgets/settings/dialog.cpp
@@ -38,6 +38,19 @@
 
 namespace ScIDE { namespace Settings {
 
+// Since qt6 some icons are matched on macOS and some are not.
+// As there doesn't seem to be a consistent icon set available on macOS
+// the icons are omitted for macOS.
+// See https://github.com/supercollider/supercollider/issues/6560
+QListWidgetItem* makeListWidgetItem(const QIcon& icon, const QString& text) {
+#ifdef Q_OS_MAC
+    return new QListWidgetItem(text);
+#else
+    return new QListWidgetItem(QIcon::fromTheme(icon), text);
+#endif
+}
+
+
 Dialog::Dialog(Manager* settings, QWidget* parent): QDialog(parent), mManager(settings), ui(new Ui::ConfigDialog) {
     ui->setupUi(this);
 
@@ -45,25 +58,25 @@ Dialog::Dialog(Manager* settings, QWidget* parent): QDialog(parent), mManager(se
 
     w = new GeneralPage;
     ui->configPageStack->addWidget(w);
-    ui->configPageList->addItem(new QListWidgetItem(QIcon::fromTheme("preferences-system"), tr("General")));
+    ui->configPageList->addItem(makeListWidgetItem(QIcon::fromTheme("preferences-system"), tr("General")));
     connect(this, SIGNAL(storeRequest(Manager*)), w, SLOT(store(Manager*)));
     connect(this, SIGNAL(loadRequest(Manager*)), w, SLOT(load(Manager*)));
 
     w = new SclangPage;
     ui->configPageStack->addWidget(w);
-    ui->configPageList->addItem(new QListWidgetItem(QIcon::fromTheme("applications-system"), tr("Interpreter")));
+    ui->configPageList->addItem(makeListWidgetItem(QIcon::fromTheme("applications-system"), tr("Interpreter")));
     connect(this, SIGNAL(storeRequest(Manager*)), w, SLOT(store(Manager*)));
     connect(this, SIGNAL(loadRequest(Manager*)), w, SLOT(load(Manager*)));
 
     w = new EditorPage;
     ui->configPageStack->addWidget(w);
-    ui->configPageList->addItem(new QListWidgetItem(QIcon::fromTheme("accessories-text-editor"), tr("Editor")));
+    ui->configPageList->addItem(makeListWidgetItem(QIcon::fromTheme("accessories-text-editor"), tr("Editor")));
     connect(this, SIGNAL(storeRequest(Manager*)), w, SLOT(store(Manager*)));
     connect(this, SIGNAL(loadRequest(Manager*)), w, SLOT(load(Manager*)));
 
     w = new ShortcutsPage;
     ui->configPageStack->addWidget(w);
-    ui->configPageList->addItem(new QListWidgetItem(QIcon::fromTheme("input-keyboard"), tr("Shortcuts")));
+    ui->configPageList->addItem(makeListWidgetItem(QIcon::fromTheme("input-keyboard"), tr("Shortcuts")));
     connect(this, SIGNAL(storeRequest(Manager*)), w, SLOT(store(Manager*)));
     connect(this, SIGNAL(loadRequest(Manager*)), w, SLOT(load(Manager*)));
 


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

Closes https://github.com/supercollider/supercollider/issues/6560

Fixes a bug in the settings menu on macOS which was introduced by Qt6 which introduced QtIcons in some places on macOS.
As these icons seem to be not consistently available (I don't know where they are located and which are available) I decided to use conditions to only display icons in the settings menu if we are not on macOS, restoring the 3.13/qt5 layout for macOS.

w/o PR

<img width="980" alt="grafik" src="https://github.com/user-attachments/assets/52a66644-de67-42d3-b7ce-c5a523b7856f" />

w/ PR

<img width="980" alt="grafik" src="https://github.com/user-attachments/assets/b9a7e2f7-2b1a-452d-95b4-23c41d2bde41" />


## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [ ] Code is tested
- [ ] All tests are passing
- [ ] Updated documentation
- [ ] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
