### PR TITLE
plugins: TriggerUGens standardize init sample

### DIFF
--- a/server/plugins/TriggerUGens.cpp
+++ b/server/plugins/TriggerUGens.cpp
@@ -849,6 +849,10 @@ void SetResetFF_Ctor(SetResetFF* unit) {
     unit->mLevel = 0.f;
 
     SetResetFF_next_k(unit, 1);
+
+    unit->m_prevtrig = 0.f;
+    unit->m_prevreset = 0.f;
+    unit->mLevel = 0.f;
 }
 
 
@@ -964,7 +968,10 @@ void Latch_Ctor(Latch* unit) {
     unit->m_prevtrig = 0.f;
     unit->mLevel = 0.f;
 
-    ZOUT0(0) = ZIN0(1) > 0.f ? ZIN0(0) : 0.f;
+    Latch_next_ak(unit, 1);
+
+    unit->m_prevtrig = 0.f;
+    unit->mLevel = 0.f;
 }
 
 
@@ -1043,6 +1050,8 @@ void Gate_Ctor(Gate* unit) {
     unit->mLevel = 0.f;
 
     Gate_next_ak(unit, 1);
+
+    unit->mLevel = 0.f;
 }
 
 
@@ -1082,6 +1091,8 @@ void Schmidt_Ctor(Schmidt* unit) {
     unit->mLevel = 0.f;
 
     Schmidt_next(unit, 1);
+
+    unit->mLevel = 0.f;
 }
 
 void Schmidt_next(Schmidt* unit, int inNumSamples) {
@@ -1152,6 +1163,10 @@ void PulseCount_Ctor(PulseCount* unit) {
     unit->mLevel = 0.f;
 
     PulseCount_next_k(unit, 1);
+
+    unit->m_prevtrig = 0.f;
+    unit->m_prevreset = 0.f;
+    unit->mLevel = 0.f;
 }
 
 
@@ -1222,6 +1237,10 @@ void Stepper_Ctor(Stepper* unit) {
     unit->mLevel = (float)resetval;
 
     Stepper_next_ak(unit, 1);
+
+    unit->m_prevtrig = 0.f;
+    unit->m_prevreset = 0.f;
+    unit->mLevel = (float)resetval;
 }
 
 
@@ -2020,6 +2039,9 @@ void MostChange_Ctor(MostChange* unit) {
     unit->mPrevB = 0.f;
     unit->mRecent = 1;
     MostChange_next_aa(unit, 1);
+    unit->mPrevA = 0.f;
+    unit->mPrevB = 0.f;
+    unit->mRecent = 1;
 }
 
 void MostChange_next_ak(MostChange* unit, int inNumSamples) {
@@ -2107,6 +2129,9 @@ void LeastChange_Ctor(LeastChange* unit) {
     unit->mPrevB = 0.f;
     unit->mRecent = 0;
     LeastChange_next_aa(unit, 1);
+    unit->mPrevA = 0.f;
+    unit->mPrevB = 0.f;
+    unit->mRecent = 0;
 }
 
 void LeastChange_next_ak(LeastChange* unit, int inNumSamples) {
@@ -2183,9 +2208,12 @@ void LastValue_Ctor(LastValue* unit) {
         SETCALC(LastValue_next_kk);
     }
 
-    unit->mPrev = ZIN0(0);
-    unit->mCurr = ZIN0(0);
+    float initPrev = unit->mPrev = ZIN0(0);
+    float initCurr = unit->mCurr = ZIN0(0);
     LastValue_next_kk(unit, 1);
+
+    unit->mPrev = initPrev;
+    unit->mCurr = initCurr;
 }
 
 void LastValue_next_kk(LastValue* unit, int inNumSamples) {


### PR DESCRIPTION
## Purpose and Motivation

Add internal state resets for the sake of enforcing conventions on UGens initialization.

This PR is the first part of a larger effort to fix init sample behavior for Trigger UGens. This part doesn't change any init sample or output value, so no breaking change. UGens that require a fix that would change either init sample or output values are left for subsequent PRs.

When initializing a UGen, the convention is to reset internal state after the first calc function call in Ctor. UGens changed by this PR were already calculating init sample and managing internal state correctly, so adding an explicit reset was not functionally necessary. However, it makes it easier to reason about initialization, by aligning with the convention, and provides a better reference to be imitated when writing new UGens.

I made an exception for 3 UGens (see exceptions below), for which I didn't enforce the convention.

Note that this is in principle not just a refactor: the side effect is it forces y(0) recalculation after Ctor, which was not the case before. However, due to the simplicity of these UGens, I argue that the performance cost is negligible (I haven't measured it though).

### affected UGens
These UGens could pre-calculate y(0) in Ctor and wouldn't need resetting their internal state to output a valid y(0). Internal state reset was added only for the sake of adhering to the convention.

- SetResetFF
- Gate
- Schmidt
- PulseCount
- Stepper
- LastValue
- Latch: I was unsure if making an exception for Latch, but I decided not to.
- LeastChange
- MostChange

Note for MostChange and LeastChange: although this PR doesn't affect their output or init sample, they behave differently from what the docs say (see #6814).

### exceptions:
These UGens don't call _next in Ctor, and I thought it was for a good reason, so I made an exception and didn't enforce the init convention of calling _next and resetting internal state.

- ZeroCrossing: needs at least 4 samples to output a value
- RunningMin: correctly initialize output to first input value, no calc needed
- RunningMax: correctly initialize output to first input value, no calc needed

### unchanged UGens
These UGens were doing all right already:

- Trig1: correct y(0), resets
- Trig: correct y(0), resets
- FreeSelf: no output, resets
- PauseSelf: no output, resets (ok to pause twice)
- FreeSelfWhenDone: no internal state
- PauseSelfWhenDone: no internal state
- Done: correct y(0), nothing to reset
- SendTrig: no output, shouldn't call calc in Ctor
- SendReply: no output, shouldn't call calc in Ctor
- Poll: no output, shouldn't call calc in Ctor
- Pause: no calcFunc call, shouldn't call pause in Ctor
- Free: no calcFunc call, shouldn't call NodeEnd in Ctor
- SendPeakRMS: no output, no calcFunc call in Ctor

### need fix
The remaining UGens need a fix that would change their init sample or output values. I'll fix them in a subsequent PR.

- PulseDivider: FIX reset internal state, changes output
- ToggleFF: FIX (changes init sample)
- Timer: FIX (changes init sample)
- PeakFollower: FIX (changes init sample)
- Peak: FIX (changes init sample)
- TDelay: FIX (changes output: trig at y(0) is not delayed correctly)
- Sweep: FIX: reset unit->m_previn (changes output)
- Phasor: FIX (changes output)

## Types of changes

- New feature (refactoring init sample logic)

## To-do list

- [x] This PR is ready for review
