### PR TITLE
Make doc themes persistent

### DIFF
--- a/QtCollider/interface.cpp
+++ b/QtCollider/interface.cpp
@@ -90,11 +90,6 @@ void QtCollider::init() {
 
         gSystemPalette = qcApp->palette();
 
-#ifdef SC_USE_QTWEBENGINE
-        // Enable javascript localStorage for WebViews
-        QWebEngineProfile::defaultProfile()->settings()->setAttribute(QWebEngineSettings::LocalStorageEnabled, true);
-#endif
-
         // NOTE: Qt may tamper with the C language locale, affecting POSIX number-string conversions.
         // Revert the locale to default:
         setlocale(LC_NUMERIC, "C");

--- a/QtCollider/widgets/QcWebView.cpp
+++ b/QtCollider/widgets/QcWebView.cpp
@@ -31,6 +31,8 @@
 #    include <QKeyEvent>
 #    include <QApplication>
 #    include <QStyle>
+#    include <QStandardPaths>
+#    include <QWebEngineProfile>
 
 #    if (QT_VERSION < QT_VERSION_CHECK(6, 2, 0))
 #        include <QWebEngineCallback>
@@ -43,8 +45,8 @@
 
 namespace QtCollider {
 
-WebView::WebView(QWidget* parent): QWebEngineView(parent), _editable(false) {
-    QtCollider::WebPage* page = new WebPage(this);
+WebView::WebView(QWidget* parent, QWebEngineProfile* profile): QWebEngineView(parent), _editable(false) {
+    QtCollider::WebPage* page = new WebPage(this, profile);
     setPage(page);
     connectPage(page);
 

--- a/QtCollider/widgets/QcWebView.h
+++ b/QtCollider/widgets/QcWebView.h
@@ -28,6 +28,7 @@
 #include <QPointer>
 #include <QUrl>
 #include <QException>
+#include <QWebEngineProfile>
 #if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
 #    include <QWebEngineCallback>
 #endif
@@ -82,7 +83,7 @@ Q_SIGNALS:
     void recentlyAudibleChanged(bool recentlyAudible);
 
 public:
-    WebView(QWidget* parent = 0);
+    WebView(QWidget* parent = nullptr, QWebEngineProfile* profile = nullptr);
 
     Q_PROPERTY(qreal zoom READ zoomFactor WRITE setZoomFactor);
     Q_PROPERTY(bool hasSelection READ hasSelection);

--- a/QtCollider/widgets/web_page.hpp
+++ b/QtCollider/widgets/web_page.hpp
@@ -29,7 +29,10 @@ class WebPage : public QWebEnginePage {
     Q_OBJECT
 
 public:
-    WebPage(QObject* parent): QWebEnginePage(parent), _delegateReload(false), _delegateNavigation(false) {}
+    WebPage(QObject* parent, QWebEngineProfile* profile):
+        QWebEnginePage(profile, parent),
+        _delegateReload(false),
+        _delegateNavigation(false) {}
 
     virtual void triggerAction(WebAction action, bool checked = false) override;
 

--- a/editors/sc-ide/widgets/help_browser.cpp
+++ b/editors/sc-ide/widgets/help_browser.cpp
@@ -29,6 +29,8 @@
 #    include "../core/util/overriding_action.hpp"
 #    include "QtCollider/widgets/web_page.hpp"
 #    include "QtCollider/hacks/hacks_qt.hpp"
+#    include <SC_Filesystem.hpp>
+#    include "standard_dirs.hpp"
 
 #    include <QVBoxLayout>
 #    include <QToolBar>
@@ -43,6 +45,7 @@
 #    include <QKeyEvent>
 
 #    include <QWebEngineSettings>
+#    include <QWebEngineProfile>
 #    if (QT_VERSION < QT_VERSION_CHECK(6, 2, 0))
 #        include <QWebEngineContextMenuData>
 #    else
@@ -59,9 +62,14 @@ HelpBrowser::HelpBrowser(QWidget* parent): QWidget(parent) {
     QRect availableScreenRect = qApp->primaryScreen()->availableGeometry();
     mSizeHint = QSize(availableScreenRect.width() * 0.4, availableScreenRect.height() * 0.7);
 
+    // provide custom profile for WebView so LocalStorage is indeed persistent
+    auto const profile = new QWebEngineProfile("sc-qt-ide", this);
+    profile->settings()->setAttribute(QWebEngineSettings::LocalStorageEnabled, true);
+    profile->setPersistentStoragePath(standardDirectory(ScConfigUserDir) + "/webengine-cache");
+    profile->setPersistentCookiesPolicy(QWebEngineProfile::ForcePersistentCookies);
+
     // setPage does not take ownership of webPage; it must be deleted manually later (see below)
-    mWebView = new QtCollider::WebView(this);
-    mWebView->settings()->setAttribute(QWebEngineSettings::LocalStorageEnabled, true);
+    mWebView = new QtCollider::WebView(this, profile);
     mWebView->setContextMenuPolicy(Qt::CustomContextMenu);
 
     // Set the style's standard palette to avoid system's palette incoherencies


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

It seems the Qt6 change introduced a bug which made the local storage of the HelpBrowser not persistent.
This PR re-introduces this behavior by making the storage path explicit by providing a profile.
It also seems that changing the defaultProfile is not really working as the values were not modified when looked at them with a debugger - I therefore also removed the existing changes to it and included them in the new profile.

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
