### PR TITLE
plugins: TriggerUGens: fix initialization sample

### DIFF
--- a/server/plugins/TriggerUGens.cpp
+++ b/server/plugins/TriggerUGens.cpp
@@ -899,8 +899,9 @@ void ToggleFF_Ctor(ToggleFF* unit) {
 
     unit->m_prevtrig = 0.f;
     unit->mLevel = 0.f;
-
-    ZOUT0(0) = 0.f;
+    ToggleFF_next(unit, 1);
+    unit->m_prevtrig = 0.f;
+    unit->mLevel = 0.f;
 }
 
 

--- a/server/plugins/TriggerUGens.cpp
+++ b/server/plugins/TriggerUGens.cpp
@@ -1664,7 +1664,10 @@ void Peak_Ctor(Peak* unit) {
         }
     }
     unit->m_prevtrig = 0.f;
-    ZOUT0(0) = unit->mLevel = ZIN0(0);
+    float initLevel = unit->mLevel = std::abs(ZIN0(0));
+    Peak_next_ai(unit, 1);
+    unit->m_prevtrig = 0.f;
+    unit->mLevel = initLevel;
 }
 
 void Peak_next_ak(Peak* unit, int inNumSamples) {
@@ -1938,7 +1941,9 @@ void PeakFollower_Ctor(PeakFollower* unit) {
     }
 
     unit->mDecay = ZIN0(1);
-    ZOUT0(0) = unit->mLevel = ZIN0(0);
+    float initLevel = unit->mLevel = std::abs(ZIN0(0));
+    PeakFollower_next(unit, 1);
+    unit->mLevel = initLevel;
 }
 
 void PeakFollower_next(PeakFollower* unit, int inNumSamples) {

--- a/server/plugins/TriggerUGens.cpp
+++ b/server/plugins/TriggerUGens.cpp
@@ -118,12 +118,12 @@ struct TDelay : public Unit {
 
 struct ZeroCrossing : public Unit {
     float mLevel, m_prevfrac, m_previn;
-    int32 mCounter;
+    long mCounter;
 };
 
 struct Timer : public Unit {
     float mLevel, m_prevfrac, m_previn;
-    int32 mCounter;
+    long mCounter;
 };
 
 struct Sweep : public Unit {

--- a/server/plugins/TriggerUGens.cpp
+++ b/server/plugins/TriggerUGens.cpp
@@ -1109,9 +1109,13 @@ void PulseDivider_Ctor(PulseDivider* unit) {
 
     unit->m_prevtrig = 0.f;
     unit->mLevel = 0.f;
-    unit->mCounter = (long)floor(ZIN0(2) + 0.5);
+    long initCounter = unit->mCounter = static_cast<long>(floor(ZIN0(2) + 0.5));
 
     PulseDivider_next(unit, 1);
+
+    unit->m_prevtrig = 0.f;
+    unit->mLevel = 0.f;
+    unit->mCounter = initCounter;
 }
 
 

--- a/server/plugins/TriggerUGens.cpp
+++ b/server/plugins/TriggerUGens.cpp
@@ -1377,9 +1377,14 @@ void Timer_Ctor(Timer* unit) {
     SETCALC(Timer_next_a);
 
     unit->m_prevfrac = 0.f;
-    unit->m_previn = ZIN0(0);
-    ZOUT0(0) = unit->mLevel = 0.f;
-    unit->mCounter = 0;
+    unit->m_previn = 0;
+    unit->mCounter = -1;
+    unit->mLevel = 0;
+    Timer_next_a(unit, 1);
+    unit->m_prevfrac = 0.f;
+    unit->m_previn = 0;
+    unit->mCounter = -1;
+    unit->mLevel = 0;
 }
 
 void Timer_next_a(Timer* unit, int inNumSamples) {


### PR DESCRIPTION
## Purpose and Motivation

This is the second part of the implementation plan in #6813.

This PR fixes a batch of UGens, affecting their init sample or output sample in a limited way. Although this is a breaking change, I would argue that it's of the same entity as the ones introduced by #6035, and so I propose we merge it in SC 3.14, if there is no objection of course.

### affected UGens

- ToggleFF: changes init sample to 1 if UGen has trig on first input sample (x[0] from now on)
- Peak, PeakFollower: changes init sample for negative input on x[0]
- PulseDivider: changes first output sample for x[0] > 0 and div[0] = 1
- Timer: changes output correcting the first measured duration by one sample

The following code illustrates the kind of breaking changes this PR introduces
```supercollider
(
~printOutput = { |fn, nSamples(s.options.blockSize), action(_.postln)|
	fn.loadToFloatArray(nSamples/s.sampleRate, s, action)
};
~printOutputTrig = { |fn, nSamples=32|
	~printOutput.(fn, nSamples, {|v| v.asInteger.join.postln })
};
~printInitSample = { |ugen|
	~printOutput.({IEnvGen.ar(Env([ugen.value]),0)}, 1)
};
~printInitAndY0 = { |ugen|
	{
		var out = ugen.value;
		var initSample = IEnvGen.ar(Env([out]),0);
		[initSample, out]
	}.loadToFloatArray(1/s.sampleRate, action: {|v|
		"init = %\ty(0) = %".format(v[0], v[1]).postln
	})
}
)

s.boot;

// ToggleFF: changes init sample
~printInitAndY0.({ToggleFF.ar(1)})
// before: init = 0.0	y(0) = 1.0
// after:  init = 1.0	y(0) = 1.0

// PeakFollower: changes init sample
~printInitAndY0.({PeakFollower.ar(DC.ar(-1))},1)
// before: init = -1.0	y(0) = 1.0
// after:  init = 1.0	y(0) = 1.0

// Peak: changes init sample
~printInitAndY0.({Peak.ar(DC.ar(-1))})
// before: init = -1.0	y(0) = 1.0
// after:  init = 1.0	y(0) = 1.0


// PulseDivider: changes y[0] (used to ignore trig on in(0)[0])
~printInitAndY0.({PulseDivider.ar(DC.ar(1),DC.ar(1))})
// before: init = 1.0	y(0) = 0.0
// after:  init = 1.0	y(0) = 1.0
~printOutputTrig.({PulseDivider.ar(DC.ar(1), 1)})
// before: 00000000000000000000000000000000
// after:  10000000000000000000000000000000
~printOutputTrig.({PulseDivider.ar(Impulse.ar(SampleRate.ir/2), 1)})
// before: 00101010101010101010101010101010
// after:  10101010101010101010101010101010
~printOutputTrig.({PulseDivider.ar(Impulse.ar(SampleRate.ir/2), 2)})
// before: 00100010001000100010001000100010
// after:  00100010001000100010001000100010

// Timer: changes output (for first measured duration)
~printInitAndY0.({Timer.ar(Impulse.ar(SampleRate.ir/2))})
// before: init = 0.0	y(0) = 0.0
// after:  init = 0.0	y(0) = 0.0
~printOutput.({Timer.ar(Impulse.ar(SampleRate.ir/2))})
// dividing output values by sampleDur for clarity
// before: 0, 0, 3, 3, 2, 2, 2, 2
// after:  0, 0, 2, 2, 2, 2, 2, 2
~printOutput.({
	var dt = SampleDur.ir * 4;
	Timer.ar(DelayN.ar(Impulse.ar(SampleRate.ir/2), dt, dt))
})
// before: 0, 0, 0, 0, 0.5, 0.5, 2, 2, 2, 2
// before: 0, 0, 0, 0, 4, 4, 2, 2, 2, 2
```

I wonder if we should turn these code snippets into tests. Let me know what you think!

## Types of changes

- Bug fix
- Breaking change

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested (no new tests so far)
- [x] All tests are passing (already present tests involving affected UGens are passing)
- [x] This PR is ready for review
