### PR TITLE
IDE: fix sclang config file dialog behavior

### DIFF
--- a/editors/sc-ide/widgets/settings/editor_page.cpp
+++ b/editors/sc-ide/widgets/settings/editor_page.cpp
@@ -46,11 +46,11 @@ EditorPage::EditorPage(QWidget* parent):
     connect(ui->tabs, SIGNAL(currentChanged(int)), this, SLOT(onCurrentTabChanged(int)));
 
     connect(ui->onlyMonoFonts, SIGNAL(toggled(bool)), this, SLOT(onMonospaceToggle(bool)));
-    connect(ui->fontCombo, SIGNAL(currentTextChanged(QString)), this, SLOT(updateFontPreview()));
+    connect(ui->fontCombo, &QComboBox::currentTextChanged, this, &EditorPage::updateFontPreview);
     connect(ui->fontSize, SIGNAL(valueChanged(int)), this, SLOT(updateFontPreview()));
     connect(ui->fontAntialias, SIGNAL(stateChanged(int)), this, SLOT(updateFontPreview()));
 
-    connect(ui->themeCombo, SIGNAL(currentTextChanged(QString)), this, SLOT(updateTheme(QString)));
+    connect(ui->themeCombo, &QComboBox::currentTextChanged, this, &EditorPage::updateTheme);
     connect(ui->themeCopyBtn, SIGNAL(clicked()), this, SLOT(dialogCopyTheme()));
     connect(ui->themeDeleteBtn, SIGNAL(clicked()), this, SLOT(deleteTheme()));
     connect(ui->textFormats, SIGNAL(currentItemChanged(QTreeWidgetItem*, QTreeWidgetItem*)), this,
@@ -227,7 +227,7 @@ void EditorPage::populateFontList(bool onlyMonospaced) {
 
 void EditorPage::populateThemeList(const QString& sel) {
     /* managing the combo box send parasite signals */
-    disconnect(ui->themeCombo, SIGNAL(currentTextChanged(QString)), this, SLOT(updateTheme(QString)));
+    disconnect(ui->themeCombo, &QComboBox::currentTextChanged, this, &EditorPage::updateTheme);
 
     QMap<QString, Theme*>::const_iterator itr = mThemes.begin();
     QList<QString> list = itr.value()->availableThemes();
@@ -247,7 +247,7 @@ void EditorPage::populateThemeList(const QString& sel) {
             i++;
     }
 
-    connect(ui->themeCombo, SIGNAL(currentTextChanged(QString)), this, SLOT(updateTheme(QString)));
+    connect(ui->themeCombo, &QComboBox::currentTextChanged, this, &EditorPage::updateTheme);
 }
 
 void EditorPage::store(Manager* s) {

--- a/editors/sc-ide/widgets/settings/editor_page.cpp
+++ b/editors/sc-ide/widgets/settings/editor_page.cpp
@@ -46,11 +46,11 @@ EditorPage::EditorPage(QWidget* parent):
     connect(ui->tabs, SIGNAL(currentChanged(int)), this, SLOT(onCurrentTabChanged(int)));
 
     connect(ui->onlyMonoFonts, SIGNAL(toggled(bool)), this, SLOT(onMonospaceToggle(bool)));
-    connect(ui->fontCombo, SIGNAL(currentIndexChanged(QString)), this, SLOT(updateFontPreview()));
+    connect(ui->fontCombo, SIGNAL(currentTextChanged(QString)), this, SLOT(updateFontPreview()));
     connect(ui->fontSize, SIGNAL(valueChanged(int)), this, SLOT(updateFontPreview()));
     connect(ui->fontAntialias, SIGNAL(stateChanged(int)), this, SLOT(updateFontPreview()));
 
-    connect(ui->themeCombo, SIGNAL(currentIndexChanged(QString)), this, SLOT(updateTheme(QString)));
+    connect(ui->themeCombo, SIGNAL(currentTextChanged(QString)), this, SLOT(updateTheme(QString)));
     connect(ui->themeCopyBtn, SIGNAL(clicked()), this, SLOT(dialogCopyTheme()));
     connect(ui->themeDeleteBtn, SIGNAL(clicked()), this, SLOT(deleteTheme()));
     connect(ui->textFormats, SIGNAL(currentItemChanged(QTreeWidgetItem*, QTreeWidgetItem*)), this,
@@ -227,7 +227,7 @@ void EditorPage::populateFontList(bool onlyMonospaced) {
 
 void EditorPage::populateThemeList(const QString& sel) {
     /* managing the combo box send parasite signals */
-    disconnect(ui->themeCombo, SIGNAL(currentIndexChanged(QString)), this, SLOT(updateTheme(QString)));
+    disconnect(ui->themeCombo, SIGNAL(currentTextChanged(QString)), this, SLOT(updateTheme(QString)));
 
     QMap<QString, Theme*>::const_iterator itr = mThemes.begin();
     QList<QString> list = itr.value()->availableThemes();
@@ -247,7 +247,7 @@ void EditorPage::populateThemeList(const QString& sel) {
             i++;
     }
 
-    connect(ui->themeCombo, SIGNAL(currentIndexChanged(QString)), this, SLOT(updateTheme(QString)));
+    connect(ui->themeCombo, SIGNAL(currentTextChanged(QString)), this, SLOT(updateTheme(QString)));
 }
 
 void EditorPage::store(Manager* s) {

--- a/editors/sc-ide/widgets/settings/sclang_page.cpp
+++ b/editors/sc-ide/widgets/settings/sclang_page.cpp
@@ -49,7 +49,7 @@ SclangPage::SclangPage(QWidget* parent): QWidget(parent), ui(new Ui::SclangConfi
 
     ui->runtimeDir->setFileMode(QFileDialog::Directory);
 
-    connect(ui->activeConfigFileComboBox, SIGNAL(currentIndexChanged(const QString&)), this,
+    connect(ui->activeConfigFileComboBox, SIGNAL(currentTextChanged(const QString&)), this,
             SLOT(changeSelectedLanguageConfig(const QString&)));
     connect(ui->sclang_add_configfile, SIGNAL(clicked()), this, SLOT(dialogCreateNewConfigFile()));
     connect(ui->sclang_remove_configfile, SIGNAL(clicked()), this, SLOT(dialogDeleteCurrentConfigFile()));

--- a/editors/sc-ide/widgets/settings/sclang_page.cpp
+++ b/editors/sc-ide/widgets/settings/sclang_page.cpp
@@ -49,8 +49,9 @@ SclangPage::SclangPage(QWidget* parent): QWidget(parent), ui(new Ui::SclangConfi
 
     ui->runtimeDir->setFileMode(QFileDialog::Directory);
 
-    connect(ui->activeConfigFileComboBox, SIGNAL(currentTextChanged(const QString&)), this,
-            SLOT(changeSelectedLanguageConfig(const QString&)));
+    connect(ui->activeConfigFileComboBox, &QComboBox::currentTextChanged, this,
+            &SclangPage::changeSelectedLanguageConfig);
+
     connect(ui->sclang_add_configfile, SIGNAL(clicked()), this, SLOT(dialogCreateNewConfigFile()));
     connect(ui->sclang_remove_configfile, SIGNAL(clicked()), this, SLOT(dialogDeleteCurrentConfigFile()));
 


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

Fixes #6692

Apparently `currentIndexChanged(const QString&)` signal has been deprecated / removed and instead we should use `currentTextChanged(const QString&)`.

This also fixes theme/font dialogs, I believe.

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix


## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [ ] All tests are passing (the failing tests are unrelated to this PR...)
- ~~[n/a] Updated documentation~~
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
