### PR TITLE
Add dialog to restart interpreter after switching config file

### DIFF
--- a/editors/sc-ide/widgets/settings/sclang_page.hpp
+++ b/editors/sc-ide/widgets/settings/sclang_page.hpp
@@ -57,10 +57,12 @@ private:
     void writeLanguageConfig();
     QString languageConfigFile();
     QStringList availableLanguageConfigFiles();
+    void dialogConfigFileUpdated();
 
     Ui::SclangConfigPage* ui;
 
     bool sclangConfigDirty;
+    bool sclangConfigChanged;
     QString selectedLanguageConfigFile;
 };
 


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

Fixes #3530

I moved the dialog to a separate function and added another flag to keep track of changed config file, without marking the file "dirty" (i.e. needing to save it). Please review the logic carefully.


~~Note: I'll rebase this after #6817 is in - I needed to include the commit from the other PR in order to test this functionality.~~ The PR is now rebased.

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix
- New feature (?)


## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [ ] All tests are passing
- [ ] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
