### PR TITLE
Testsuite: LinkClock: Avoid Event errors in newFromTempoClock test

### DIFF
--- a/testsuite/classlibrary/TestLinkClock.sc
+++ b/testsuite/classlibrary/TestLinkClock.sc
@@ -195,7 +195,9 @@ TestLinkClock : UnitTest {
 			semaphore.signal;
 		});
 		routine = { loop{ 0.01.wait } }.fork(tempoClock);
-		streamplayer = Pbind(\dur, 0.02).play(tempoClock);
+		// the test here is about function/routine/pattern scheduling
+		// event activity shouldn't be a factor, so, \rest
+		streamplayer = Pbind(\type, \rest, \dur, 0.02).play(tempoClock);
 		0.1.wait;
 
 		linkClock = LinkClock.newFromTempoClock(tempoClock);


### PR DESCRIPTION
## Purpose and Motivation

Per discussion under #5421, we should remove one possible source of errors in the LinkClock test of `newFromTempoClock` rescheduling of patterns.

Note that #5421 includes other issues, so, merging this should not close that issue.

## Types of changes

- Bug fix

## To-do list

- [x] Code is tested
- [x] All tests are passing
- [ ] +Updated documentation+ n/a
- [+] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->