### PR TITLE
IDE<->sclang Document fixes

### DIFF
--- a/SCClassLibrary/scide_scqt/ScIDE.sc
+++ b/SCClassLibrary/scide_scqt/ScIDE.sc
@@ -5,6 +5,7 @@ ScIDE {
 	classvar serverController;
 	classvar volumeController, suppressAmpResponse = false;
 	classvar docRoutine;
+	classvar handshakeCondition;
 
 	*initClass {
 		subListSorter = { | a b | a[0].perform('<', b[0]) };
@@ -24,12 +25,25 @@ ScIDE {
 	}
 
 	*handshake {
-		this.send(\classLibraryRecompiled);
-		this.send(\requestDocumentList);
-		this.send(\requestCurrentPath);
+		fork{
+			handshakeCondition !? { "%: handshakeCondition is not nil!".format(thisMethod.asString).warn };
+			handshakeCondition = CondVar();
 
-		this.defaultServer = Server.default;
-		this.sendIntrospection;
+			this.send(\classLibraryRecompiled);
+			this.send(\requestDocumentList);
+			handshakeCondition.waitFor(5);
+			this.send(\requestCurrentPath);
+			handshakeCondition.waitFor(5);
+
+			this.defaultServer = Server.default;
+			this.sendIntrospection;
+
+			handshakeCondition = nil;
+		}
+	}
+
+	*prSignalHandshakeCond {
+		handshakeCondition !? { handshakeCondition.signalOne };
 	}
 
 	*defaultServer_ {|server|

--- a/SCClassLibrary/scide_scqt/ScIDE.sc
+++ b/SCClassLibrary/scide_scqt/ScIDE.sc
@@ -491,8 +491,8 @@ Document {
 	*prCurrent_ {|newCurrent|
 		current = this.current;
 		if((newCurrent === current).not, {
-			if(current.notNil, {current.didResignKey});
-			newCurrent.didBecomeKey;
+			current !? { current.didResignKey };
+			newCurrent !? { newCurrent.didBecomeKey };
 		});
 	}
 

--- a/editors/sc-ide/core/doc_manager.cpp
+++ b/editors/sc-ide/core/doc_manager.cpp
@@ -711,6 +711,7 @@ void DocumentManager::handleDocListScRequest() {
         command = command.append(docData);
     }
     command = command.append("]);");
+    command = command.append(QStringLiteral("ScIDE.prSignalHandshakeCond;"));
     Main::evaluateCode(command, true);
 }
 
@@ -1187,9 +1188,11 @@ void DocumentManager::sendActiveDocument() {
         } else {
             command = command.append(QStringLiteral("ScIDE.currentPath_(\"%1\");").arg(mCurrentDocumentPath));
         }
+        command = command.append(QStringLiteral("ScIDE.prSignalHandshakeCond;"));
         Main::evaluateCodeIfCompiled(command, true);
     } else
-        Main::evaluateCodeIfCompiled(QStringLiteral("ScIDE.currentPath_(nil); Document.current = nil;"), true);
+        Main::evaluateCodeIfCompiled(
+            QStringLiteral("ScIDE.currentPath_(nil); Document.current = nil; ScIDE.prSignalHandshakeCond;"), true);
 }
 
 void DocumentManager::updateCurrentDocContents(int position, int charsRemoved, int charsAdded) {

--- a/editors/sc-ide/widgets/multi_editor.cpp
+++ b/editors/sc-ide/widgets/multi_editor.cpp
@@ -1024,7 +1024,9 @@ void MultiEditor::onDocModified(Document* doc) {
         icon = mDocModifiedIcon;
 
     Main::evaluateCodeIfCompiled(
-        QStringLiteral("Document.findByQUuid(\'%1\').prSetEdited(%2)").arg(doc->id().constData()).arg(isModified),
+        QStringLiteral("var doc = Document.findByQUuid(\'%1\'); doc !? { doc.prSetEdited(%2) };")
+            .arg(doc->id().constData())
+            .arg(isModified),
         true);
 
     mTabs->setTabIcon(tabIdx, icon);


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

This PR aims to improve the sclang <-> ScIDE communication and adds a rudimentary signaling during the handshaking process. This should solve issues with the Document classes and calls from IDE triggering sclang errors, particularly on Windows.

This is possibly not a final fix, but it should be a reasonable workaround for the linked issues.

### Please test! 
It seems to work fine on a Windows 11 VM, but more testing would be very desirable.

#### Testing procedure
There's no need to uninstall your current SC version!

First, **confirm that the issue still occurs** on your system using a recent [develop build](http://supercollider.s3.amazonaws.com/builds/supercollider/supercollider/win64/develop-latest.html)
- download a [develop build](http://supercollider.s3.amazonaws.com/builds/supercollider/supercollider/win64/develop-latest.html)
- unpack it somewhere, e.g. on the desktop (I tend to rename the `SuperCollider` folder to e.g. `SuperCollider_develop` to keep of the versions)
- open `scide.exe`
- select a clean sclang config file in the ide preferences (to make sure no extensions interfere with testing)
- make sure that you **don't have** a [workaround like this one](https://github.com/supercollider/supercollider/issues/4413#issuecomment-997326364) or similar installed on your system
- make sure that your `startup.scd` doesn't have anything interfering with the `Document`, `ScIDE` or `Server` classes (`Server` is listed to preemptively address any issues that may arise with booting the server, which is unrelated to this PR)
- reboot interpreter
- confirm that you get errors/warnings when interacting with scd documents:
  - edit text document, open/close document, recompile the library with no documents open and with a document open, run code, etc etc

After confirming that the issue occurs using a develop build, **test this PR**:
- download the [build artifact from this PR](https://github.com/supercollider/supercollider/actions/runs/14918506810/artifacts/3090517202)
- unpack it
- start scide.exe
- (you should still be using a clean sclang config file and have no relevant code in `startup.scd`)
- test interaction with the scd documents in the ide, as you did with the develop build
- report back whether you got any warnings/errors or not
  - if possible, please report the exact version of Windows you are running


## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
