### PR TITLE
GHA: add an option to manually trigger GHA builds

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -12,6 +12,7 @@ on:
       - 'HelpSource/**'
       - 'sounds/**'
       - '*.md'
+  workflow_dispatch:
 
 jobs:
   lint:


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

Sometimes we may want to [manually re-trigger a build](https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-workflow-runs/manually-running-a-workflow#configuring-a-workflow-to-run-manually) without pushing a new commit and this PR will allow that _once it's merged_. I don't think this is testable before it's merged, unfortunately.

(We could also consider whether we really need to run CI on every push to non-protected branches if we can trigger them manually, but that's for a separate issue, PR).

## Types of changes

<!-- Delete lines that don't apply -->


- New feature

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [ ] Code is tested
- [ ] All tests are passing
- [ ] Updated documentation
- [ ] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
