### PR TITLE
plugins: TDelay: fix initialization sample

### DIFF
--- a/server/plugins/TriggerUGens.cpp
+++ b/server/plugins/TriggerUGens.cpp
@@ -1300,6 +1300,9 @@ void TDelay_Ctor(TDelay* unit) {
     unit->mCounter = 0;
 
     TDelay_next(unit, 1);
+
+    unit->m_prevtrig = 0.f;
+    unit->mCounter = 0;
 }
 
 


### PR DESCRIPTION
## Purpose and Motivation

Minimal fix for TDelay initialization, just providing the necessary internal state reset.
Due to missing internal state reset after init, TDelay used to incorrectly advance its internal counter. This caused an incorrect delay time of a trigger occuring on its first input sample, which would be delayed one sample too early.

This PR is part of #6813, and introduces small bug-fixing breaking changes in TDelay output.

## Types of changes

- Bug fix
- Breaking change

Output changes only if TDelay has a trigger on its first sample of input. If delayTime > dt (where dt is the time between first and second trigger), the output re-aligns with the previous version at the second trigger.
```supercollider
(
~printOutput = { |fn, nSamples(s.options.blockSize), action(_.postln)|
	fn.loadToFloatArray(nSamples/s.sampleRate, s, action)
};
~printOutputTrig = { |fn, nSamples=32|
	~printOutput.(fn, nSamples, {|v| v.round.asInteger.join.postln })
};
~printInitSample = { |ugen|
	~printOutput.({IEnvGen.ar(Env([ugen.value]),0)}, 1)
};
~printInitAndY0 = { |ugen, nSamples(s.options.blockSize)|
	~printOutput.({
		var out = ugen.value;
		var initSample = if (out.rate == \audio) {
			IEnvGen.ar(Env([out]),0);
		} {
			IEnvGen.kr(Env([out]),0);
		};
		[initSample, out]
	}, nSamples, {|v|
		"init = %\ty(0) = %".format(v[0], v[1]).postln
	})
}
)

// init sample is unchanged, output changes if triggered on x[0]
~printInitAndY0.({TDelay.ar(Impulse.ar(s.sampleRate/2), 1/SampleRate.ir)})
// before: init = 0.0	y(0) = 1.0
// after:  init = 0.0	y(0) = 0.0

// examples of outputs re-aligning after second trigger
// note that before PR the initial trig wasn't delayed correctly
~printOutput.({ var sr = SampleRate.ir; TDelay.ar(Impulse.ar(sr/2), 1/sr)})
// before: 10010101....
// after:  01010101....
~printOutputTrig.({ var sr = SampleRate.ir; TDelay.ar(Impulse.ar(sr/3), 5/sr)})
// before: 00001000000010000010000010000010
// after:  00000100000010000010000010000010

// example of outputs non re-aligning
~printOutputTrig.({ var sr = SampleRate.ir; TDelay.ar(Impulse.ar(sr/3), 4/sr)}, 64)
// b: 0001000010000010000010000010000010000010000010000010000010000010
// a: 0000100000010000010000010000010000010000010000010000010000010000
```

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [ ] Code is tested
- [ ] All tests are passing
- [ ] Updated documentation
- [x] This PR is ready for review

Existing tests involving TDelay are passing.
For discussion about testing and documentation (Changelog), see #6813
