### PR TITLE
plugins: Phasor: fix init sample: don't ignore trig on first sample

### DIFF
--- a/HelpSource/Classes/Phasor.schelp
+++ b/HelpSource/Classes/Phasor.schelp
@@ -60,7 +60,7 @@ code::
 
 // basic: ramp between 'start' and 'end'
 // note that the ramp ends at 9, not 10
-{ Phasor.kr(0, 1, start: 0, end: 10) }.plot(0.03)
+{ Phasor.kr(0, 1, start: 0, end: 10) }.plot(0.03).plotMode_(\dlines)
 
 // on trigger: ramp jumps to 'resetPos', goes until 'end' and wraps back to 'start'
 // note that the ramp starts from 'resetPos', since it receives a trigger immediately on its first sample
@@ -69,7 +69,7 @@ code::
 	var trig = Impulse.kr(ControlRate.ir/5);
 	var ramp = Phasor.kr(trig, 1, start: 0, end: 10, resetPos: 7);
 	[ramp, trig * 10]
-}.plot(0.03)
+}.plot(0.03).plotMode_([\dlines, \dstems])
 )
 
 

--- a/HelpSource/Classes/Phasor.schelp
+++ b/HelpSource/Classes/Phasor.schelp
@@ -58,6 +58,21 @@ Examples::
 
 code::
 
+// basic: ramp between 'start' and 'end'
+// note that the ramp ends at 9, not 10
+{ Phasor.kr(0, 1, start: 0, end: 10) }.plot(0.03)
+
+// on trigger: ramp jumps to 'resetPos', goes until 'end' and wraps back to 'start'
+// note that the ramp starts from 'resetPos', since it receives a trigger immediately on its first sample
+(
+{
+	var trig = Impulse.kr(ControlRate.ir/5);
+	var ramp = Phasor.kr(trig, 1, start: 0, end: 10, resetPos: 7);
+	[ramp, trig * 10]
+}.plot(0.03)
+)
+
+
 // phasor controls sine frequency: end frequency matches a second sine wave.
 
 (

--- a/server/plugins/TriggerUGens.cpp
+++ b/server/plugins/TriggerUGens.cpp
@@ -1574,7 +1574,9 @@ void Phasor_Ctor(Phasor* unit) {
 
     unit->m_previn = 0;
     unit->mLevel = IN0(2);
-    Phasor_next_kk(unit, 1);
+
+    unit->mCalcFunc(unit, 1);
+
     unit->m_previn = 0;
     unit->mLevel = IN0(2);
 }

--- a/server/plugins/TriggerUGens.cpp
+++ b/server/plugins/TriggerUGens.cpp
@@ -1572,8 +1572,11 @@ void Phasor_Ctor(Phasor* unit) {
         SETCALC(Phasor_next_ak);
     }
 
-    unit->m_previn = ZIN0(0);
-    ZOUT0(0) = unit->mLevel = ZIN0(2);
+    unit->m_previn = 0;
+    unit->mLevel = IN0(2);
+    Phasor_next_kk(unit, 1);
+    unit->m_previn = 0;
+    unit->mLevel = IN0(2);
 }
 
 void Phasor_next_kk(Phasor* unit, int inNumSamples) {

--- a/server/plugins/TriggerUGens.cpp
+++ b/server/plugins/TriggerUGens.cpp
@@ -1573,12 +1573,12 @@ void Phasor_Ctor(Phasor* unit) {
     }
 
     unit->m_previn = 0;
-    unit->mLevel = IN0(2);
+    float initLevel = unit->mLevel = IN0(2);
 
     unit->mCalcFunc(unit, 1);
 
     unit->m_previn = 0;
-    unit->mLevel = IN0(2);
+    unit->mLevel = initLevel;
 }
 
 void Phasor_next_kk(Phasor* unit, int inNumSamples) {


### PR DESCRIPTION
## Purpose and Motivation

Phasor was not calling its calcFunc in its Ctor, ignoring a trigger on its first sample and assuming its initial value to be its startPos. This PR fixes it, causing Phasor to start from resetPos instead if triggered on its first input sample.

This PR is part of #6813, and introduces a bug-fixing breaking change in Phasor output.

This is the only PR in this process for which I think somebody might be using the wrong behavior on purpose (Phasor always starts from startPos, and can reset to resetPos only later). However, I still see it as marginal. Documentation is clear on Phasor resetting to resetPos every time it receives a trigger, and never mentions it ignoring a trig on x[0] or always starting from startPos regardless of trig. There is no instance in the docs or examples in which this behavior is used or even encountered. But I also didn't find any complaint against this unwanted behavior, perhaps because I hardly find examples of different startPos and resetPos.


## Types of changes

- Bug fix
- Breaking change

This code shows the breaking changes in Phasor behavior, if Phasor is triggered at x[0] and has startPos != endPos.
If Phasor is triggered at x[0], and then again, then the change is only occurring between the first two triggers.

```supercollider
(
~printOutput = { |fn, nSamples(s.options.blockSize), action(_.postln)|
	fn.loadToFloatArray(nSamples/s.sampleRate, s, action)
};
~printOutputTrig = { |fn, nSamples=32|
	~printOutput.(fn, nSamples, {|v| v.round.asInteger.join.postln })
};
~printInitAndY0 = { |ugen, nSamples(s.options.blockSize)|
	~printOutput.({
		var out = ugen.value;
		var initSample = if (out.rate == \audio) {
			IEnvGen.ar(Env([out]),0);
		} {
			IEnvGen.kr(Env([out]),0);
		};
		[initSample, out]
	}, nSamples, {|v|
		"init = %\ty(0) = %".format(v[0], v[1]).postln
	})
}
)

~printInitAndY0.({Phasor.ar(1, 1, 0, 10, 5)})
// before: init = 0.0	y(0) = 0.0
// after:  init = 5.0	y(0) = 5.0
~printOutputTrig.({Phasor.ar(1, 1, 0, 10, 5)})
// before: 012345678901234567890
// after:  567890123456789012345
```

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [ ] Code is tested
- [ ] All tests are passing
- [ ] Updated documentation
- [x] This PR is ready for review

All already existing tests involving Phasor are passing.
For more discussion about testing (needs a special UGen) and documentation (needs a UGen Changelog), see #6813.
