### PR TITLE
Convert emacs and vim to an opt-in build flag on linux

### DIFF
--- a/README_LINUX.md
+++ b/README_LINUX.md
@@ -77,7 +77,6 @@ sudo apt-get install \
   libudev-dev \
   pkg-config \
   libncurses5-dev \
-  emacs \
   jackd2
 ```
 
@@ -157,7 +156,6 @@ sudo dnf install \
   fftw-devel \
   alsa-lib-devel \
   libatomic
-sudo dnf install emacs # if building with the sc-el backend (default)
 sudo dnf install libXt-devel 
 ```
 
@@ -249,11 +247,12 @@ cmake ..
 
 You can set CMake build flags via the command line using `cmake -DKEY=value ..` during the configure process where the `D` prefix is necessary!
 
-> **Example:** SuperCollider on Linux requires [Emacs](https://www.gnu.org/software/emacs/) as a build dependency - but this is only an optional build dependency which can be controlled via the build flag `SC_EL`.
-> So if you do not have `Emacs` installed, you should add `-DSC_EL=NO` as in the following command:
+> **Example:** It is possible to build an optional [Emacs](https://www.gnu.org/software/emacs/) plugin for SuperCollider.
+> As of 3.14, this plugin is not built in by default and must be enabled manually.
+> To tell CMake if this plugin should also be built as part of the build process, the flag `SC_EL` can be used - i.e. `-DSC_EL=YES`:
 >
 > ```shell
-> cmake -DSC_EL=NO ..
+> cmake -DSC_EL=YES ..
 > ```
 >
 > To display all available build flags and their values run `cmake -LH ..` in the `build` directory or use cmake gui-frontends like [`ccmake`](https://cmake.org/cmake/help/latest/manual/ccmake.1.html) or [`cmake-gui`](https://cmake.org/cmake/help/latest/manual/cmake-gui.1.html) to inspect and set the available flags.

--- a/editors/CMakeLists.txt
+++ b/editors/CMakeLists.txt
@@ -1,11 +1,6 @@
 
-if(CMAKE_SYSTEM_NAME MATCHES "Linux")
-	option(SC_EL "Build emacs-based IDE." ON)
-    option(SC_VIM "Build vim-based IDE." ON)
-else()
-	option(SC_EL "Build emacs-based IDE." OFF)
-    option(SC_VIM "Build vim-based IDE." OFF)
-endif()
+option(SC_EL "Build emacs-based IDE." OFF)
+option(SC_VIM "Build vim-based IDE." OFF)
 
 if(SC_IDE)
 	message(STATUS "Building the Qt IDE")


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

This PR only affects linux users.

When building SC on linux in the default configuration, one needs emacs as a dependency.
This PR makes emacs an optional dependency and one explicitly needs to turn on the building of the plugin using CMAKE flags.

At the same time I also turned off to build the vim plugin in the default configuration (though I think this didn't need to have vim as a dependency, or maybe this is only due that vim is already present on most systems).

I think this can be "voted" in the dev meeting - I personally think it would be good to have this merged for for 3.14 release.

edit: We still build the plugins in CI, so we don't abandon the build process and get aware of issues early.

## Types of changes

<!-- Delete lines that don't apply -->

- Documentation

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
