### PR TITLE
Add note about '+/+' and url address

### DIFF
--- a/HelpSource/Classes/String.schelp
+++ b/HelpSource/Classes/String.schelp
@@ -299,7 +299,7 @@ Returns code::this:: and code::path:: concatenated. If code::path:: was a PathNa
 PathName; otherwise, it is a String.
 
 note::
-Avoid using code::+/+:: to separate URL addresses, as this can lead to unintended concatenation issues.
+Do not use code::+/+:: in URLs or in other situations where forward slash is expected. code::+/+:: should only be used with filesystem paths, where it will resolve to either forward or backward slash, depending on the operating system's requirements.
 ::
 
 argument::path

--- a/HelpSource/Classes/String.schelp
+++ b/HelpSource/Classes/String.schelp
@@ -298,6 +298,10 @@ using code::++::. If neither side has a path separator, the platform's preferred
 Returns code::this:: and code::path:: concatenated. If code::path:: was a PathName, the result is a
 PathName; otherwise, it is a String.
 
+note::
+Avoid using code::+/+:: to separate URL addresses, as this can lead to unintended concatenation issues.
+::
+
 argument::path
 
 Any object that can be converted to a string. Typically, either a String, link::Classes/Symbol::, or


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation
While testing #6312 and #6639, I found the following code does not work on Windows due to `+/+`:

```supercollider
(
var url = "https://raw.githubusercontent.com/supercollider/supercollider"
	+/+ "refs/heads/develop/sounds/a11wlk01.wav";
var localPath = "~/Downloads".standardizePath +/+ url.split($/).last;
/// var localPath = Platform.defaultTempDir +/+ url.split($/).last;
var finishedFunc = {
	localPath.openOS;
	"downloaded to %".format(localPath).postln
	};
var errorFunc = {"error".postln };
var progressFunc = { |receivedBytes, totalBytes|
	var downloadProgress = (receivedBytes / totalBytes * 100).round(1e-2);
	"Downloaded %\\%".format(downloadProgress).postln;
};

d = Download(url, localPath, finishedFunc, errorFunc, progressFunc)
)
``` 
I believe there may be other users who, like myself, separate long URL addresses and concatenate the fragments using `+/+`. This pull request aims to prevent such misuses.

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->

- Documentation

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
