### PR TITLE
Fix SequenceableCollection -unixCmd on Windows 

### DIFF
--- a/common/sc_popen.cpp
+++ b/common/sc_popen.cpp
@@ -24,7 +24,7 @@
 #    include <array>
 #    include <string>
 
-std::tuple<pid_t, FILE*> sc_popen_shell(std::string&& command, const std::string& type) {
+std::tuple<pid_t, FILE*> sc_popen_shell(std::string command, const std::string& type) {
     std::vector<std::string> argv;
     argv.emplace_back("/bin/sh");
     argv.emplace_back("-c");
@@ -166,7 +166,7 @@ std::tuple<pid_t, FILE*> sc_popen_argv(const std::vector<std::string>& strings, 
     return sc_popen_c(commandLine.data(), type.data());
 }
 
-std::tuple<pid_t, FILE*> sc_popen_shell(std::string&& command, const std::string& type) {
+std::tuple<pid_t, FILE*> sc_popen_shell(std::string command, const std::string& type) {
     command = "cmd /c " + command;
     return sc_popen_c(command.data(), type.data());
 }

--- a/common/sc_popen.cpp
+++ b/common/sc_popen.cpp
@@ -24,7 +24,7 @@
 #    include <array>
 #    include <string>
 
-std::tuple<pid_t, FILE*> sc_popen(std::string&& command, const std::string& type) {
+std::tuple<pid_t, FILE*> sc_popen_shell(std::string&& command, const std::string& type) {
     std::vector<std::string> argv;
     argv.emplace_back("/bin/sh");
     argv.emplace_back("-c");
@@ -166,7 +166,7 @@ std::tuple<pid_t, FILE*> sc_popen_argv(const std::vector<std::string>& strings, 
     return sc_popen_c(commandLine.data(), type.data());
 }
 
-std::tuple<pid_t, FILE*> sc_popen(std::string&& command, const std::string& type) {
+std::tuple<pid_t, FILE*> sc_popen_shell(std::string&& command, const std::string& type) {
     command = "cmd /c " + command;
     return sc_popen_c(command.data(), type.data());
 }

--- a/common/sc_popen.cpp
+++ b/common/sc_popen.cpp
@@ -163,10 +163,11 @@ std::tuple<pid_t, FILE*> sc_popen_argv(const std::vector<std::string>& strings, 
         strings.begin(), strings.end(), std::string(),
         [](const std::string& a, const std::string& b) -> std::string { return a + (a.length() > 0 ? " " : "") + b; });
 
-    return sc_popen(std::move(commandLine), type);
+    return sc_popen_c(commandLine.data(), type.data());
 }
 
 std::tuple<pid_t, FILE*> sc_popen(std::string&& command, const std::string& type) {
+    command = "cmd /c " + command;
     return sc_popen_c(command.data(), type.data());
 }
 
@@ -187,7 +188,7 @@ std::tuple<pid_t, FILE*> sc_popen_c(const char* utf8_cmd, const char* mode) {
         return error_result;
     }
 
-    std::wstring cmd = L"cmd /c " + SC_Codecvt::utf8_cstr_to_utf16_wstring(utf8_cmd);
+    std::wstring cmd = SC_Codecvt::utf8_cstr_to_utf16_wstring(utf8_cmd);
 
     current_pid = GetCurrentProcess();
 

--- a/common/sc_popen.h
+++ b/common/sc_popen.h
@@ -37,6 +37,6 @@ std::tuple<pid_t, FILE*> sc_popen_c_argv(const char* filename, char* const argv[
  *
  * This function assumes a UTF-8 encoded, narrow-char string.
  */
-std::tuple<pid_t, FILE*> sc_popen_shell(std::string&& command, const std::string& type);
+std::tuple<pid_t, FILE*> sc_popen_shell(std::string command, const std::string& type);
 std::tuple<pid_t, FILE*> sc_popen_argv(const std::vector<std::string>& strings, const std::string& type);
 int sc_pclose(FILE* iop, pid_t mPid);

--- a/common/sc_popen.h
+++ b/common/sc_popen.h
@@ -37,6 +37,6 @@ std::tuple<pid_t, FILE*> sc_popen_c_argv(const char* filename, char* const argv[
  *
  * This function assumes a UTF-8 encoded, narrow-char string.
  */
-std::tuple<pid_t, FILE*> sc_popen(std::string&& command, const std::string& type);
+std::tuple<pid_t, FILE*> sc_popen_shell(std::string&& command, const std::string& type);
 std::tuple<pid_t, FILE*> sc_popen_argv(const std::vector<std::string>& strings, const std::string& type);
 int sc_pclose(FILE* iop, pid_t mPid);

--- a/lang/LangPrimSource/PyrFilePrim.cpp
+++ b/lang/LangPrimSource/PyrFilePrim.cpp
@@ -1377,7 +1377,7 @@ int prPipeOpen(struct VMGlobals* g, int numArgsPushed) {
 
     pid_t pid;
     FILE* file;
-    std::tie(pid, file) = sc_popen(std::move(commandLine), mode);
+    std::tie(pid, file) = sc_popen_shell(std::move(commandLine), mode);
     if (file != nullptr) {
         SetPtr(&pfile->fileptr, file);
         SetInt(callerSlot, pid);

--- a/lang/LangPrimSource/PyrUnixPrim.cpp
+++ b/lang/LangPrimSource/PyrUnixPrim.cpp
@@ -158,7 +158,7 @@ int prString_POpen(struct VMGlobals* g, int numArgsPushed) {
 
     pid_t pid;
     FILE* stream;
-    std::tie(pid, stream) = sc_popen(std::move(cmdline), "r");
+    std::tie(pid, stream) = sc_popen_shell(std::move(cmdline), "r");
     if (stream != nullptr) {
         SC_Thread thread(std::bind(string_popen_thread_func, pid, stream, IsTrue(postOutputSlot)));
         thread.detach();


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->


In this PR:
- `ArrayedCollection -unixCmd` is fixed to _not_ run the command through `cmd.exe`, which matches behavior on *nix
  - as a result, a proper PID of the requested command is now returned from this method
- `sc_popen()` is renamed to `sc_popen_shell()` to reflect the behavior of the function.

The rest of the functionality previously present in this PR will be addressed in separate Issues/PRs.


How to test this:
```supercollider
// pid with ArrayedCollection
r = [Server.program, "-u", "57110"].unixCmd; // run scsynth using ArrayedCollection -unixCmd
r.postln; // this should match the scsynth pid in Task Manager
thisProcess.platform.killProcessByID(r); // scsynth should exit
```


## Types of changes

<!-- Delete lines that don't apply -->


- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [ ] All tests are passing
- [ ] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
