### PR TITLE
Add `scroll-margin-top` to fix scrolling to anchor

### DIFF
--- a/HelpSource/static/scdoc.css
+++ b/HelpSource/static/scdoc.css
@@ -1,3 +1,7 @@
+:root {
+    --menu-bar-height: 33px;
+}
+
 *, *::before, *::after {
     box-sizing: inherit;
 }
@@ -46,6 +50,12 @@ table table {
 p {
     margin-top: 1em;
     margin-bottom: 0.3em;
+}
+
+a {
+    /* The menu bar takes some pixels which we need to respect
+    when jumping to an anchor. */
+    scroll-margin-top: var(--menu-bar-height);
 }
 
 a:link, a:visited, a:link:hover {
@@ -111,7 +121,7 @@ a.subclass_toggle:hover {
     position: fixed;
     text-indent: 0;
     width: 100%;
-    height: 33px;
+    height: var(--menu-bar-height);
     padding: 0.5em 0;
     background-color: var(--color-bg);
     box-shadow: 0em 0em 0.25em var(--color-fg-200);

--- a/HelpSource/static/scdoc.css
+++ b/HelpSource/static/scdoc.css
@@ -28,7 +28,7 @@ input, select, textarea {
 
 div.contents {
     margin: 0;
-    padding: calc(33px + .5em) 1em 1em;
+    padding: calc(var(--menu-bar-height) + .5em) 1em 1em;
 }
 
 table {
@@ -215,7 +215,7 @@ li.menuitem a.menu-link.home {
 
 .submenu, #toc {
     position: absolute;
-    top: 33px;
+    top: var(--menu-bar-height);
     padding: 0.5em;
     display: none;
     background-color: var(--color-bg);


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

Merge note: Squash it

## Purpose and Motivation

When navigating to a method one "overshoots" currently b/c the height of the menu bar is not respected - e.g.

<img width="474" alt="image" src="https://github.com/user-attachments/assets/68268b3d-427d-4743-b6a9-0f3f612cf29d" />

This PR fixes this by providing a `scroll-margin-top` to every anchor

<img width="473" alt="image" src="https://github.com/user-attachments/assets/574b3f2e-13f1-4767-8aee-b5b800b05cf4" />

I hope we are not using something else than `a` for anchors...

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
