### PR TITLE
testsuite: TestServer_clientID_booted: fix cleanup

### DIFF
--- a/testsuite/classlibrary/TestServer_clientID_booted.sc
+++ b/testsuite/classlibrary/TestServer_clientID_booted.sc
@@ -158,7 +158,7 @@ TestServer_clientID_booted : UnitTest {
 			"after first login, remote client should have its requested clientID."
 		);
 
-		remote1.remove;
+		remote1.stopAliveThread.remove;
 		thisProcess.platform.killProcessByID(serverPid);
 		testsFinished = exitCond.waitFor(5); // wait for the server process to exit
 		this.assert(testsFinished, "TIMEOUT: server process did not quit");
@@ -216,8 +216,8 @@ TestServer_clientID_booted : UnitTest {
 		);
 
 		// cleanup
-		remote1.remove;
-		remote2.remove;
+		remote1.stopAliveThread.remove;
+		remote2.stopAliveThread.remove;
 		thisProcess.platform.killProcessByID(serverPid);
 		testsFinished = exitCond.waitFor(5); // wait for the server process to exit
 		this.assert(testsFinished, "TIMEOUT: server process did not quit")


### PR DESCRIPTION
## Purpose and Motivation

Two tests in `TestServer_clientID_booted` mock remote servers by launching an extra scsynth process and then calling `Server.remote`,  which initializes a `StatusWatcher`, but when the process exits, doesn't clean it up by default. This causes an accumulation of `/status.reply` listeners, resulting in multiple ServerAction calls when another server shares their same address (which is `localhost:57110`, so every other default server).

To be discussed if we should fix this behavior in any other way, for now I just fixed the tests by adding `stopAliveThread`. Perhaps `stopAliveThread` could be called by `Server:-remove`?

This should fix the failures for `TestServer_boot:test_notifyAndServerBootActions` and `TestServer_boot:test_notifyAndServerTreeActions`, or at least one possible cause of them.

## Types of changes

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] This PR is ready for review
