### PR TITLE
Date: Windows notes and testsuite fix

### DIFF
--- a/HelpSource/Classes/Date.schelp
+++ b/HelpSource/Classes/Date.schelp
@@ -37,6 +37,10 @@ Date(2016); // -> Fri Jan  1 00:00:00 2016
 d = Date(2010, day: 15, minute: 30); // -> Fri Jan 15 00:30:00 2010
 [d.asString, d.dayOfWeek, d.rawSeconds]; // dayOfWeek and rawSeconds were computed
 ::
+
+Note::
+On Windows, code::Date:: creation fails for dates before Unix epoch, i.e. before January 1st, 1970.
+::
 ::
 
 It is possible to specify dates with "out of range" values that will be resolved into a valid range -- this allows simple date offset calculations to be performed (see example below).

--- a/testsuite/classlibrary/TestDate.sc
+++ b/testsuite/classlibrary/TestDate.sc
@@ -42,7 +42,7 @@ TestDate : UnitTest {
 			d.rawSeconds.floor,
 			"Creation from all properties except dayOfWeek and rawSeconds");
 
-		this.assertEquals(Date(1969, 7, 20, minute: 18).stamp, "690720_001800",
+		this.assertEquals(Date(1970, 7, 20, minute: 18).stamp, "700720_001800",
 			"new with defaults");
 		this.assertEquals(Date(2016).stamp, "160101_000000",
 			"new with defaults");


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

On Windows `Date` resolution doesn't work for pre-Epoch dates.

I think for now we can "fix" this by documenting this behavior and using a post-epoch date in the test suite.

Fixes #6765

## Types of changes

<!-- Delete lines that don't apply -->

- Documentation
- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing - [Date tests also pass on Windows](https://github.com/supercollider/supercollider/actions/runs/15062068051/job/42339435365?pr=6763#step:7:1944)
- [x] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
