### PR TITLE
Set background color of scope via sclang

### DIFF
--- a/HelpSource/Classes/ScopeView.schelp
+++ b/HelpSource/Classes/ScopeView.schelp
@@ -83,6 +83,12 @@ METHOD:: waveColors
     argument::
         An Array of Colors, one per channel.
 
+METHOD:: background
+    The background color of the scope.
+
+    argument::
+        A link::Classes/Color::.
+
 EXAMPLES::
 
 SUBSECTION:: A step-by-step example

--- a/SCClassLibrary/Common/GUI/Base/ScopeView.sc
+++ b/SCClassLibrary/Common/GUI/Base/ScopeView.sc
@@ -56,4 +56,12 @@ ScopeView : View {
 		waveColors = aColorArray;
 		this.setProperty( \waveColors, aColorArray );
 	}
+
+	background {
+		^this.getProperty(\background);
+	}
+
+	background_ {|color|
+		this.setProperty(\background, color);
+	}
 }


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

Allows to set the background color of a scope, see https://scsynth.org/t/accessing-parameters-from-qtscopeshm-in-sclang/11708

The C++ side already implemented the setting of background color

https://github.com/supercollider/supercollider/blob/9028422a145230c322cfc923e3c1a41fc4a1b998/QtCollider/widgets/QcScopeShm.h#L69-L72

https://github.com/supercollider/supercollider/blob/9028422a145230c322cfc923e3c1a41fc4a1b998/QtCollider/widgets/QcScopeShm.h#L50

but the sclang side lacked this implementation. This PR fixes this.

<img width="467" alt="grafik" src="https://github.com/user-attachments/assets/3a616e79-9e5a-406a-ac18-5802a6ff3c2a" />

## Types of changes

<!-- Delete lines that don't apply -->

- Documentation
- New feature

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
