### PR TITLE
tests: escape regexp in TestSCDoc

### DIFF
--- a/testsuite/classlibrary/TestSCDoc.sc
+++ b/testsuite/classlibrary/TestSCDoc.sc
@@ -5,7 +5,7 @@ TestSCDoc : UnitTest {
         var extensionPaths = [thisProcess.platform.systemExtensionDir, thisProcess.platform.userExtensionDir];
         var prevSetting = LanguageConfig.excludeDefaultPaths;
         LanguageConfig.excludeDefaultPaths = true;
-        result = SCDoc.prRescanHelpSourceDirs.any { |p| extensionPaths.any { |ep| ("^"++ep).matchRegexp(p) } };
+        result = SCDoc.prRescanHelpSourceDirs.any { |p| extensionPaths.any { |ep| ("^"++ep.escapeChar($\\)).matchRegexp(p) } };
         LanguageConfig.excludeDefaultPaths = prevSetting;
         this.assert(result.not, "should not search for extensions' HelpSource when LanguageConfig.excludeDefaultPaths = true");
     }
@@ -15,7 +15,7 @@ TestSCDoc : UnitTest {
         var extensionPaths = [thisProcess.platform.systemExtensionDir, thisProcess.platform.userExtensionDir];
         var prevSetting = LanguageConfig.excludeDefaultPaths;
         LanguageConfig.excludeDefaultPaths = false;
-        result = SCDoc.prRescanHelpSourceDirs.any { |p| extensionPaths.any { |ep| ("^"++ep).matchRegexp(p) } };
+        result = SCDoc.prRescanHelpSourceDirs.any { |p| extensionPaths.any { |ep| ("^"++ep.escapeChar($\\)).matchRegexp(p) } };
         LanguageConfig.excludeDefaultPaths = prevSetting;
         this.assert(result, "should search for extensions' HelpSource when LanguageConfig.excludeDefaultPaths = false");
     }


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

Backward slashes need to be escaped when used with regexp. This came up when running these tests on Windows

## Types of changes

<!-- Delete lines that don't apply -->


- Bug fix


## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [ ] Code is tested
- [ ] All tests are passing
- [ ] Updated documentation
- [ ] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
