### PR TITLE
scdoc renderer: use forward slash on Windows

### DIFF
--- a/SCClassLibrary/SCDoc/SCDocRenderer.sc
+++ b/SCClassLibrary/SCDoc/SCDocRenderer.sc
@@ -82,6 +82,9 @@ SCDocHTMLRenderer {
 			};
 		};
 
+		// use only forward slash as path separator
+		result = result.replace(Platform.pathSeparator, "/");
+
 		if(linkAnchor.isEmpty) {
 			^result
 		} {


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

When creating links on Windows, use `/` instead of `\`. This caused some `TestSCDocHTMLRenderer` tests to fail on Windows.

I haven't follow the logic of SCDocRenderer fully... please review carefully. I'm looking forward to any feedback on this.

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix


## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested (in #6763)
- [x] All (relevant) tests are passing
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
