### PR TITLE
SCLang, UnitTests: standardise nan & inf printing across platforms

### DIFF
--- a/lang/LangSource/DumpParseNode.cpp
+++ b/lang/LangSource/DumpParseNode.cpp
@@ -388,6 +388,14 @@ static void printObject(PyrSlot* slot, PyrObject* obj, char* str) {
 
 // Assumed: str has enough space to hold the representation of d
 static void prettyFormatFloat(char* str, double d) {
+    if (std::isnan(d)) {
+        // Do this manually as different implementations disagree on how to format nan.
+        str[0] = 'n';
+        str[1] = 'a';
+        str[2] = 'n';
+        str[3] = '\0';
+        return;
+    }
     sprintf(str, "%.14g", d);
 
     // append a trailing '.0' if the number would look like an integer.

--- a/lang/LangSource/DumpParseNode.cpp
+++ b/lang/LangSource/DumpParseNode.cpp
@@ -395,6 +395,20 @@ static void prettyFormatFloat(char* str, double d) {
         str[2] = 'n';
         str[3] = '\0';
         return;
+    } else if (std::isinf(d)) {
+        if (d > 0.0) {
+            str[0] = 'i';
+            str[1] = 'n';
+            str[2] = 'f';
+            str[3] = '\0';
+        } else {
+            str[0] = '-';
+            str[1] = 'i';
+            str[2] = 'n';
+            str[3] = 'f';
+            str[4] = '\0';
+        }
+        return;
     }
     sprintf(str, "%.14g", d);
 

--- a/testsuite/classlibrary/TestFloat.sc
+++ b/testsuite/classlibrary/TestFloat.sc
@@ -44,11 +44,7 @@ TestFloat : UnitTest {
 
 	test_asString_nan {
 		var zeroDivString = (0/0).asString;
-		if(zeroDivString == "-nan") {
-			this.assertEquals(zeroDivString, "-nan")
-		} {
-			this.assertEquals(zeroDivString, "nan")
-		}
+		this.assertEquals(zeroDivString, "nan");
 	}
 
 	test_asString_largeNumberUsesExp {

--- a/testsuite/classlibrary/TestFloat.sc
+++ b/testsuite/classlibrary/TestFloat.sc
@@ -51,4 +51,13 @@ TestFloat : UnitTest {
 		this.assertEquals((1e26).asString, "1e+26")
 	}
 
+	test_asCompileString {
+		this.assertEquals(1.0.asCompileString.compile.(), 1.0, "1.0 as compile string");
+		this.assertEquals(inf.asCompileString.compile.(), inf, "inf as compile string");
+		this.assertEquals(-inf.asCompileString.compile.(), -inf, "-inf as compile string");
+
+		// Since 'nan' isn't a keyword in sc, there is no way to perform this check.
+		// This means the conversion from value to string to value isn't complete over the float type.
+	}
+
 }


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

Closes #6863

Nan & inf should be printed the same across platforms and c library implementations.

This is particularly salient for `inf` as it must be convertible to a compile string and back.

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix
- Breaking change ? Maybe if someone relied on this, but it didn't work across platform anyway.

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [ ] Code is tested
- [ ] All tests are passing
- [ ] Updated documentation
- [ ] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
