### PR TITLE
Disable redrawing lang status box on theme change

### DIFF
--- a/editors/sc-ide/widgets/lang_status_box.cpp
+++ b/editors/sc-ide/widgets/lang_status_box.cpp
@@ -60,7 +60,9 @@ void LangStatusBox::applySettings(Settings::Manager* settings) {
 
     // re-render the box, otherwise we will not update after e.g. a theme switch
     if (mLang != nullptr) {
-        onInterpreterStateChanged(mLang->state());
+        // this crashes on linux and windows, so we will skip that currently,
+        // see https://github.com/supercollider/supercollider/issues/6862
+        // onInterpreterStateChanged(mLang->state());
     }
 }
 


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

#6838 has introduced a serious bug on linux and windows, making the IDE crash during startup.
For more information see https://github.com/supercollider/supercollider/issues/6862#issuecomment-2889937573

This introduces a quick fix which simply comments out the line which creates a segfault (at least on Linux).
W/o this line the style of the language status box will not be updated upon a theme change - not nice but better than a crash of the IDE ;)

I tested this fix on linux, but @jamshark70 can you give this a try if this fixes your issue?

@prko @dyfer can you verify that this also fixes the issue on windows?

Once it is verified that it fixes the issue on windows I think this could be merged?

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [ ] Code is tested
- [ ] All tests are passing
- [ ] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
