### PR TITLE
Fix the `custom.css` path in search.html 

### DIFF
--- a/HelpSource/Search.html
+++ b/HelpSource/Search.html
@@ -8,7 +8,7 @@
     <link rel='stylesheet' href='./static/scdoc.css' type='text/css' />
     <link rel='stylesheet' href='./static/frontend.css' type='text/css' />
     <link rel='stylesheet' id='scdoc-theme' href='./static/themes/default.css' type='text/css' />
-    <link rel='stylesheet' href='./static/custom.css' type='text/css' />
+    <link rel='stylesheet' href='./custom.css' type='text/css' />
     <script src="./static/lib/jquery.min.js"></script>
     <script>
         var scdoc_title = "Search";


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation
In #6627, the `custom.css` path in `search.html` is mistyped.
This PR fixes the typo.
<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->
- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
