### PR TITLE
Float.schelp: add missing `code` tag.

### DIFF
--- a/HelpSource/Classes/Float.schelp
+++ b/HelpSource/Classes/Float.schelp
@@ -145,7 +145,7 @@ subsection::Using Floats as replacement for Integers
 
 In SuperCollider, Floats are 64 bits wide. Because an link::Classes/Integer:: is 32-bit, it can only capture integers in the range -2147483648 (code::-2^31::) to 2147483647 (code::2^31 - 1::).
 
-Therefore, in some situations it can be useful to calculate with floats also when only whole numbers are needed. You can use 64-bit floats for integer calculations in the range ::± 9007199254740992::, or about code::±2^53::. Sometimes one can go even further (see example below).
+Therefore, in some situations it can be useful to calculate with floats also when only whole numbers are needed. You can use 64-bit floats for integer calculations in the range code::± 9007199254740992::, or about code::±2^53::. Sometimes one can go even further (see example below).
 
 
 code::


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

The helpfile for `Float` would not render correctly after #6787 was merged:

```supercollider
ERROR: In /(...)/src/supercollider/HelpSource/Classes/Float.schelp:
  At line 148: syntax error, unexpected ::, expecting end of file
```

This PR adds the missing tag.

Note to self: it would be great to have a CI job that would catch schelp errors...

## Types of changes

<!-- Delete lines that don't apply -->

- Documentation
- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
