### PR TITLE
sclang: warn too many vars

### DIFF
--- a/lang/LangSource/PyrParseNode.cpp
+++ b/lang/LangSource/PyrParseNode.cpp
@@ -3833,6 +3833,12 @@ void PyrBlockNode::compile(PyrSlot* slotResult) {
         compileErrors++;
     }
 
+    if (numVars > 255) {
+        error("Too many variables in function definition (> 255)\n");
+        nodePostErrorLine((PyrParseNode*)mVarlist->mVarDefs);
+        compileErrors++;
+    }
+
     numSlots = numArgs + numVariableArgs + numKwArgs + numVars;
     methraw->frameSize = (numSlots + FRAMESIZE) * sizeof(PyrSlot);
     if (numSlots) {


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

https://scsynth.org/t/max-number-of-vars/11757

When you have more than 255 vars, the compile doesn't say anything until you try to access them. 
This puts posts the warning when you create too many vars.

Technically, if people had more than 255 vars but didn't use them, their code will now break, but this is unlikely. 

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->
- Earlier error warning


## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [ ] Code is tested
- [ ] All tests are passing
- [ ] Updated documentation
- [ ] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
