### PR TITLE
scide: audio_status_box: init colors before widgets

### DIFF
--- a/editors/sc-ide/widgets/audio_status_box.cpp
+++ b/editors/sc-ide/widgets/audio_status_box.cpp
@@ -82,6 +82,10 @@ AudioStatusBox::AudioStatusBox(ScServer* server, QWidget* parent): StatusBox(par
     connect(server, SIGNAL(mutedChanged(bool)), this, SLOT(updateMuteLabel(bool)));
     connect(server, SIGNAL(recordingChanged(bool)), this, SLOT(updateRecordLabel(bool)));
 
+    auto const main = Main::instance();
+    applySettings(main->settings());
+    connect(main, &Main::applySettingsRequest, this, &AudioStatusBox::applySettings);
+
     onServerRunningChanged(false, "", 0, false);
     updateVolumeLabel(server->volume());
     updateMuteLabel(server->isMuted());
@@ -91,10 +95,6 @@ AudioStatusBox::AudioStatusBox(ScServer* server, QWidget* parent): StatusBox(par
     connect(this, &AudioStatusBox::decreaseVolume, [=]() { server->changeVolume(-0.5); });
 
     connect(this, &AudioStatusBox::increaseVolume, [=]() { server->changeVolume(+0.5); });
-
-    auto const main = Main::instance();
-    applySettings(main->settings());
-    connect(main, &Main::applySettingsRequest, this, &AudioStatusBox::applySettings);
 }
 
 void AudioStatusBox::applySettings(Settings::Manager* settings) {


### PR DESCRIPTION
## Purpose and Motivation

audio_status_box (the server status gui in scide) needs to initialize colors before rendering widgets. Otherwise the numbers displayed don't respect the theme colors until the server is booted a first time. This is particularly annoying on dark themes, since they are rendered in black.

## Types of changes

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
