### PR TITLE
CI: run ctests with linux build

### DIFF
--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -185,5 +185,6 @@ jobs:
           Xvfb $DISPLAY -screen 0 1024x768x16 &
 
       - name: Run CTests
+        continue-on-error: true
         if: matrix.ctest
         run: cmake --build $BUILD_PATH --config Release --target test

--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -20,6 +20,7 @@ jobs:
             cxx-compiler: "g++-9"
             use-syslibs: false
             shared-libscsynth: false
+            ctest: false
 
           - job-name: ""
             os-version: "22.04"
@@ -27,6 +28,7 @@ jobs:
             cxx-compiler: "g++-11"
             use-syslibs: false
             shared-libscsynth: false
+            ctest: false
 
           - job-name: ""
             os-version: "22.04"
@@ -35,6 +37,7 @@ jobs:
             use-syslibs: false
             shared-libscsynth: false
             artifact-suffix: "ubuntu-22.04-gcc12" # will trigger artifact upload; after changing this update the test-linux artifact-file in actions.yml
+            ctest: true
 
           - job-name: "use system libraries"
             os-version: "24.04"
@@ -42,6 +45,7 @@ jobs:
             cxx-compiler: "g++-13"
             use-syslibs: true
             shared-libscsynth: false
+            ctest: true
 
           - job-name: "shared libscsynth"
             os-version: "24.04"
@@ -49,6 +53,7 @@ jobs:
             cxx-compiler: "g++-14"
             use-syslibs: false
             shared-libscsynth: true
+            ctest: false
             
           - job-name: ""
             os-version: "22.04"
@@ -56,6 +61,7 @@ jobs:
             cxx-compiler: "clang++-11"
             use-syslibs: false
             shared-libscsynth: false
+            ctest: false
 
           - job-name: ""
             os-version: "24.04"
@@ -63,6 +69,7 @@ jobs:
             cxx-compiler: "clang++-15"
             use-syslibs: false
             shared-libscsynth: false
+            ctest: false
 
           - job-name: ""
             os-version: "24.04"
@@ -70,6 +77,7 @@ jobs:
             cxx-compiler: "clang++-16"
             use-syslibs: false
             shared-libscsynth: false
+            ctest: false
 
           - job-name: ""
             os-version: "24.04"
@@ -77,6 +85,7 @@ jobs:
             cxx-compiler: "clang++-17"
             use-syslibs: false
             shared-libscsynth: false
+            ctest: false
 
           - job-name: ""
             os-version: "24.04"
@@ -84,6 +93,7 @@ jobs:
             cxx-compiler: "clang++-18"
             use-syslibs: false
             shared-libscsynth: false
+            ctest: false
 
     name: Ubuntu ${{ matrix.os-version }} ${{ matrix.c-compiler }} ${{ matrix.job-name }}
     env:
@@ -149,6 +159,7 @@ jobs:
           cd $BUILD_PATH
           make install -j2
 
+
       - name: create archive
         if: matrix.artifact-suffix
         run: cd $INSTALL_PATH && zip --symlinks -r $ARTIFACT_FILE.zip .
@@ -159,3 +170,21 @@ jobs:
         with:
           name: ${{ env.ARTIFACT_FILE }}
           path: ${{ env.INSTALL_PATH }}/${{ env.ARTIFACT_FILE }}.zip
+
+      - name: Configure CTests
+        if: matrix.ctest
+        run: |
+          cd $BUILD_PATH
+          sudo apt-get install --yes xvfb jackd1 socat
+          # start jack
+          jackd --no-realtime --silent -d dummy &
+
+          # start virtual display server
+          export DISPLAY=:99
+          echo "DISPLAY=$DISPLAY" >> $GITHUB_ENV
+          Xvfb $DISPLAY -screen 0 1024x768x16 &
+
+      - name: Run CTests
+        if: matrix.ctest
+        run: cmake --build $BUILD_PATH --config Release --target test
+

--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -30,7 +30,7 @@ jobs:
             shared-libscsynth: false
             ctest: false
 
-          - job-name: ""
+          - job-name: "with ctest"
             os-version: "22.04"
             c-compiler: "gcc-12"
             cxx-compiler: "g++-12"
@@ -39,7 +39,7 @@ jobs:
             artifact-suffix: "ubuntu-22.04-gcc12" # will trigger artifact upload; after changing this update the test-linux artifact-file in actions.yml
             ctest: true
 
-          - job-name: "use system libraries"
+          - job-name: "use system libraries with ctest"
             os-version: "24.04"
             c-compiler: "gcc-13"
             cxx-compiler: "g++-13"
@@ -87,13 +87,13 @@ jobs:
             shared-libscsynth: false
             ctest: false
 
-          - job-name: ""
+          - job-name: "with ctest"
             os-version: "24.04"
             c-compiler: "clang-18"
             cxx-compiler: "clang++-18"
             use-syslibs: false
             shared-libscsynth: false
-            ctest: false
+            ctest: true
 
     name: Ubuntu ${{ matrix.os-version }} ${{ matrix.c-compiler }} ${{ matrix.job-name }}
     env:
@@ -187,4 +187,3 @@ jobs:
       - name: Run CTests
         if: matrix.ctest
         run: cmake --build $BUILD_PATH --config Release --target test
-

--- a/.github/workflows/build_macos.yml
+++ b/.github/workflows/build_macos.yml
@@ -215,5 +215,6 @@ jobs:
           path: ${{ env.INSTALL_PATH }}/${{ env.ARTIFACT_FILE }}
 
       - name: Run CTests
+        continue-on-error: true
         if: matrix.ctest
         run: cmake --build $BUILD_PATH --config Release --target RUN_TESTS

--- a/.github/workflows/build_macos.yml
+++ b/.github/workflows/build_macos.yml
@@ -25,6 +25,7 @@ jobs:
             vcpkg-triplet: ""
             extra-cmake-flags: "" # -D SC_VERIFY_APP=ON # verify app doesn't seem to work with official qt6
             artifact-suffix: "macOS-arm64"
+            ctest: true
 
           - job-name: "x64"
             os-version: "13"
@@ -38,6 +39,7 @@ jobs:
             vcpkg-triplet: ""
             extra-cmake-flags: "" # -D SC_VERIFY_APP=ON # verify app doesn't seem to work with official qt6
             artifact-suffix: "macOS-x64"
+            ctest: true
 
           - job-name: "x64 legacy"
             os-version: "13"
@@ -54,6 +56,7 @@ jobs:
             vcpkg-triplet: x64-osx-release-supercollider # required for build-libsndfile
             extra-cmake-flags: ""
             artifact-suffix: "macOS-x64-legacy" # set if needed - will trigger artifact upload
+            ctest: false
 
           - job-name: "arm64 use system libraries"
             os-version: "15"
@@ -64,6 +67,7 @@ jobs:
             vcpkg-packages: ""
             vcpkg-triplet: ""
             extra-cmake-flags: "-D SYSTEM_BOOST=ON -D SYSTEM_YAMLCPP=ON"
+            ctest: true
 
           - job-name: "x64 shared libscsynth"
             os-version: "13"
@@ -76,6 +80,7 @@ jobs:
             vcpkg-packages: ""
             vcpkg-triplet: ""
             extra-cmake-flags: "-D LIBSCSYNTH=ON"
+            ctest: false
 
     name: macOS ${{ matrix.job-name }}
     env:
@@ -208,3 +213,11 @@ jobs:
         with:
           name: ${{ env.ARTIFACT_FILE }}
           path: ${{ env.INSTALL_PATH }}/${{ env.ARTIFACT_FILE }}
+
+      - name: Configure CTests
+        if: matrix.ctest
+        run: cd ${{ github.workspace }}
+
+      - name: Run CTests
+        if: matrix.ctest
+        run: cmake --build $BUILD_PATH --config Release --target test

--- a/.github/workflows/build_macos.yml
+++ b/.github/workflows/build_macos.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - job-name: "arm64"
+          - job-name: "arm64  with ctest"
             os-version: "15"
             xcode-version: "16.0"
             qt-version: "6.7.3" # will use qt from aqtinstall
@@ -27,7 +27,7 @@ jobs:
             artifact-suffix: "macOS-arm64"
             ctest: true
 
-          - job-name: "x64"
+          - job-name: "x64 with ctest"
             os-version: "13"
             xcode-version: "15.2"
             qt-version: "6.7.3" # will use qt from aqtinstall
@@ -58,7 +58,7 @@ jobs:
             artifact-suffix: "macOS-x64-legacy" # set if needed - will trigger artifact upload
             ctest: false
 
-          - job-name: "arm64 use system libraries"
+          - job-name: "arm64 use system libraries with ctest"
             os-version: "15"
             xcode-version: "16.0"
             deployment-target: ""
@@ -214,10 +214,6 @@ jobs:
           name: ${{ env.ARTIFACT_FILE }}
           path: ${{ env.INSTALL_PATH }}/${{ env.ARTIFACT_FILE }}
 
-      - name: Configure CTests
-        if: matrix.ctest
-        run: cd ${{ github.workspace }}
-
       - name: Run CTests
         if: matrix.ctest
-        run: cmake --build $BUILD_PATH --config Release --target test
+        run: cmake --build $BUILD_PATH --config Release --target RUN_TESTS

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -211,6 +211,7 @@ jobs:
         run: cd ${{ github.workspace }}
 
       - name: Run CTests
+        continue-on-error: true
         if: matrix.ctest
         working-directory: ${{ env.BUILD_PATH }}
         shell: cmd

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -25,6 +25,7 @@ jobs:
             vcpkg-triplet: x86-windows-release
             use-qtwebengine: "ON" # might need to be turned off for MinGW
             qt-modules: "qtwebengine"
+            ctest: true
             # artifact-suffix: "win32" # set if needed - will trigger artifact upload
             # create-installer: ${{ startsWith(github.ref, 'refs/tags/') }}
             # installer-suffix: "win32-installer"
@@ -41,6 +42,7 @@ jobs:
             vcpkg-triplet: x64-windows-release
             use-qtwebengine: "ON" # might need to be turned off for MinGW
             qt-modules: 'qtwebengine qtwebchannel qtwebsockets qtpositioning'
+            ctest: true
             artifact-suffix: "win64" # set if needed - will trigger artifact upload
             create-installer: ${{ startsWith(github.ref, 'refs/tags/') }}
             installer-suffix: "win64-installer"
@@ -57,6 +59,7 @@ jobs:
             vcpkg-triplet: x64-windows-release
             use-qtwebengine: "ON" # might need to be turned off for MinGW
             qt-modules: 'qtwebengine qtwebchannel qtwebsockets qtpositioning'
+            ctest: false
 
           - job-name: "64-bit MinGW"
             fftw-arch: "x64"
@@ -69,6 +72,7 @@ jobs:
             use-qtwebengine: "OFF" # might need to be turned off for MinGW
             qt-modules: "qtpositioning"
             artifact-suffix: "win64-mingw" # set if needed - will trigger artifact upload
+            ctest: true
 
     name: Windows ${{ matrix.job-name }}
     env:
@@ -197,3 +201,12 @@ jobs:
         with:
           name: ${{ env.INSTALLER_FILE }}
           path: ${{ env.INSTALL_PATH }}/*.exe
+
+      - name: Configure CTests
+        if: matrix.ctest
+        run: cd ${{ github.workspace }}
+
+      - name: Run CTests
+        if: matrix.ctest
+        shell: bash
+        run: cmake --build $BUILD_PATH --config Release --target test

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - job-name: "32-bit"
+          - job-name: "32-bit with ctest"
             fftw-arch: "x86"
             cmake-arch: "Win32"
             os-version: "2019"
@@ -26,11 +26,12 @@ jobs:
             use-qtwebengine: "ON" # might need to be turned off for MinGW
             qt-modules: "qtwebengine"
             ctest: true
+            ctest-cmd: "RUN_TESTS"
             # artifact-suffix: "win32" # set if needed - will trigger artifact upload
             # create-installer: ${{ startsWith(github.ref, 'refs/tags/') }}
             # installer-suffix: "win32-installer"
 
-          - job-name: "64-bit MSVC 2022"
+          - job-name: "64-bit MSVC 2022 with ctest"
             fftw-arch: "x64"
             cmake-arch: "x64"
             os-version: "2022"
@@ -46,6 +47,7 @@ jobs:
             artifact-suffix: "win64" # set if needed - will trigger artifact upload
             create-installer: ${{ startsWith(github.ref, 'refs/tags/') }}
             installer-suffix: "win64-installer"
+            ctest-cmd: "RUN_TESTS"
 
           - job-name: "64-bit MSVC 2019"
             fftw-arch: "x64"
@@ -60,8 +62,9 @@ jobs:
             use-qtwebengine: "ON" # might need to be turned off for MinGW
             qt-modules: 'qtwebengine qtwebchannel qtwebsockets qtpositioning'
             ctest: false
+            ctest-cmd: "RUN_TESTS"
 
-          - job-name: "64-bit MinGW"
+          - job-name: "64-bit MinGW with ctest"
             fftw-arch: "x64"
             os-version: "2022"
             qt-version: "6.7.0"
@@ -73,6 +76,7 @@ jobs:
             qt-modules: "qtpositioning"
             artifact-suffix: "win64-mingw" # set if needed - will trigger artifact upload
             ctest: true
+            ctest-cmd: "test"
 
     name: Windows ${{ matrix.job-name }}
     env:
@@ -208,5 +212,6 @@ jobs:
 
       - name: Run CTests
         if: matrix.ctest
-        shell: bash
-        run: cmake --build $BUILD_PATH --config Release --target test
+        working-directory: ${{ env.BUILD_PATH }}
+        shell: cmd
+        run: cmake --build . --config Release --target ${{ matrix.ctest-cmd }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,11 @@ message(STATUS "Building from ${GIT_REF_TYPE} ${GIT_BRANCH_OR_TAG}, commit hash 
 include(CTest)
 enable_testing()
 
+
+if(CMAKE_GENERATOR MATCHES "Xcode")
+	set(CMAKE_XCODE_GENERATE_SCHEME YES)
+endif()
+
 include (cmake_modules/FinalFile.cmake)
 
 if(CMAKE_GENERATOR MATCHES "Visual Studio" OR CMAKE_GENERATOR MATCHES "Xcode")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,11 +23,6 @@ message(STATUS "Building from ${GIT_REF_TYPE} ${GIT_BRANCH_OR_TAG}, commit hash 
 include(CTest)
 enable_testing()
 
-
-if(CMAKE_GENERATOR MATCHES "Xcode")
-	set(CMAKE_XCODE_GENERATE_SCHEME YES)
-endif()
-
 include (cmake_modules/FinalFile.cmake)
 
 if(CMAKE_GENERATOR MATCHES "Visual Studio" OR CMAKE_GENERATOR MATCHES "Xcode")


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

We have shit C++ test coverage (with the exception of supernova), and the ones we have, we don't run. Going forward we should add more C++ tests,  which can easily be done using the already existing boost tests.

Enable ctests during build on CI.

You can't run these in the 'test' phase because you need the build directory and only the install directory is exported as an artefact.
This means the sclang unit tests won't run unless the ctests pass, but that seems fine.

This is only run on linux because that is the only one I know how to make a virtual display for. In future we could run this elsewhere.

## Types of changes

<!-- Delete lines that don't apply -->

- new tests
- ci change

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

