### PR TITLE
classlib: update String .openOS on Windows

### DIFF
--- a/SCClassLibrary/Common/Collections/windows/extString_windows.sc
+++ b/SCClassLibrary/Common/Collections/windows/extString_windows.sc
@@ -4,14 +4,14 @@
 	}
 
 	openOS {
- 		// start "title" "command"
-     	if (PathName(this).isFolder) {
- 			// workaround for folders, see https://github.com/supercollider/supercollider/issues/6312
- 			// NB: Explorer.exe does not accept path names with forward slashes!
- 			["cmd", "/c", "start", "SuperCollider".quote, "Explorer.exe", this.replace("/", "\\").quote].unixCmd;
- 			} {
- 			// files or URLs
-			["cmd", "/c", "start", "SuperCollider".quote, this.quote].unixCmd;
-     	}
+		// start "title" "command"
+		if (PathName(this).isFolder) {
+			// workaround for folders, see https://github.com/supercollider/supercollider/issues/6312
+			// NB: Explorer.exe does not accept path names with forward slashes!
+			("start" + "SuperCollider".quote + "Explorer.exe" + this.replace("/", "\\").quote).unixCmd;
+		} {
+			// files or URLs
+			("start" + "SuperCollider".quote + this.quote).unixCmd;
+		}
 	}
 }


### PR DESCRIPTION


<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

`"start"` is a `cmd.exe` command so we can use String .unixCmd instead

Background: https://github.com/supercollider/supercollider/pull/6837 removed `cmd /c` from `SequenceableCollection .unixCmd`, which inadvertently broke `String .openOS`. The latter was then fixed in #6880, but probably a cleaner solution is to use `String .unixCmd` for `String .openOS`, as suggested by @Spacechild1 in https://github.com/supercollider/supercollider/pull/6858#issuecomment-2907722768.



## Types of changes

<!-- Delete lines that don't apply -->

- Cleanup?

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [ ] Code is tested
- [ ] All tests are passing
- [ ] Updated documentation
- [ ] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
