### PR TITLE
servers: fix PortAudio hostAPI stream info (Win32)

### DIFF
--- a/common/SC_PaUtils.cpp
+++ b/common/SC_PaUtils.cpp
@@ -174,20 +174,22 @@ PaStreamParameters MakePaStreamParameters(int device, int channelCount, double s
     streamParams.hostApiSpecificStreamInfo = &macInfo;
 #elif defined(_WIN32)
     // WASAPI options
-    static PaWasapiStreamInfo wasapiInfo = []() {
-        PaWasapiStreamInfo info;
-        memset(&info, 0, sizeof(info));
-        info.size = sizeof(PaWasapiStreamInfo);
-        info.hostApiType = paWASAPI;
-        info.version = 1;
-        info.flags = paWinWasapiAutoConvert; // automatic sample rate conversion
-        return info;
-    }();
-
     const PaDeviceInfo* info = Pa_GetDeviceInfo(device);
     const PaHostApiInfo* api = Pa_GetHostApiInfo(info->hostApi);
-    if (api->type == paWASAPI)
+    if (api->type == paWASAPI) {
+        static PaWasapiStreamInfo wasapiInfo = []() {
+            PaWasapiStreamInfo info;
+            memset(&info, 0, sizeof(info));
+            info.size = sizeof(PaWasapiStreamInfo);
+            info.hostApiType = paWASAPI;
+            info.version = 1;
+            info.flags = paWinWasapiAutoConvert; // automatic sample rate conversion
+            return info;
+        }();
         streamParams.hostApiSpecificStreamInfo = &wasapiInfo;
+    } else {
+        streamParams.hostApiSpecificStreamInfo = nullptr;
+    }
 #else
     streamParams.hostApiSpecificStreamInfo = nullptr;
 #endif


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

#6899 broke booting the server on Windows with non-WASAPI devices (i.e. the default device...)

This PR fixes that, allowing the servers to boot again.

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested - tested booting with the default device (MME) and with a WASAPI device
- [x] All tests are passing
- [n/a] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
