### PR TITLE
Adjust the bottom position of the FreqScope and the bottom position of the ServerMeter for all platforms

### DIFF
--- a/HelpSource/Classes/Window.schelp
+++ b/HelpSource/Classes/Window.schelp
@@ -57,6 +57,11 @@ METHOD:: availableBounds
 
 	Returns a Rect describing the area of the screen that windows can actually occupy (i.e. excluding the Mac dock, the task bar, or similar).
 
+METHOD:: lowestPosition
+
+	Returns a floating-point value representing the lowest reasonable vertical position for a window on the screen.
+	This value is calculated to avoid overlap with system-reserved interface elements, such as the Windows taskbar, the macOS Dock, or the Linux dock (e.g. GNOME, KDE, etc.).
+	The result is not the absolute bottom edge of the screen, but rather the lowest position a window can occupy without interfering with areas reserved by the operating system.
 
 
 
@@ -174,6 +179,12 @@ METHOD:: addFlowLayout
 METHOD:: layout
 	Redirects to link::Classes/View#-layout:: of the link::#-view::.
 
+METHOD:: moveToBottom
+
+	Moves the window to the lowest usable screen position without overlapping system-reserved areas (e.g., taskbars, docks).
+
+	argument:: margin
+		Adds vertical offset from the bottom.
 
 
 SUBSECTION:: Appearance

--- a/SCClassLibrary/Common/GUI/Base/QWindow.sc
+++ b/SCClassLibrary/Common/GUI/Base/QWindow.sc
@@ -172,9 +172,16 @@ Window {
 	onClose { ^view.onClose }
 	onClose_ { arg func; view.onClose_(func) }
 
-	*availableBottom {
-		^this.screenBounds.height - this.availableBounds.top - this.availableBounds.height
-	}
+	*lowestPosition {
+ 		^this.screenBounds.bottom - this.availableBounds.bottom
+ 	}
+
+	moveToBottom { |margin = 0|
+		this.bounds = this.bounds.moveTo(
+			this.bounds.left,
+			Window.lowestPosition + margin
+		)
+    	}
 
 	// TODO
 	addToOnClose{ arg function; }

--- a/SCClassLibrary/Common/GUI/Base/QWindow.sc
+++ b/SCClassLibrary/Common/GUI/Base/QWindow.sc
@@ -173,15 +173,15 @@ Window {
 	onClose_ { arg func; view.onClose_(func) }
 
 	*lowestPosition {
- 		^this.screenBounds.bottom - this.availableBounds.bottom
- 	}
-
+		^this.screenBounds.bottom - this.availableBounds.bottom
+	}
+	
 	moveToBottom { |margin = 0|
 		this.bounds = this.bounds.moveTo(
 			this.bounds.left,
 			Window.lowestPosition + margin
 		)
-    	}
+	}
 
 	// TODO
 	addToOnClose{ arg function; }

--- a/SCClassLibrary/Common/GUI/Base/QWindow.sc
+++ b/SCClassLibrary/Common/GUI/Base/QWindow.sc
@@ -172,6 +172,10 @@ Window {
 	onClose { ^view.onClose }
 	onClose_ { arg func; view.onClose_(func) }
 
+	*availableBottom {
+		^this.screenBounds.height - this.availableBounds.top - this.availableBounds.height
+	}
+
 	// TODO
 	addToOnClose{ arg function; }
 	removeFromOnClose{ arg function; }

--- a/SCClassLibrary/Common/GUI/PlusGUI/Control/FreqScope.sc
+++ b/SCClassLibrary/Common/GUI/PlusGUI/Control/FreqScope.sc
@@ -373,12 +373,9 @@ FreqScope {
 				});
 			};
 
-			window = Window(
-				"Freq Analyzer",
-				rect.resizeBy(pad[0] + pad[1] + 4, pad[2] + pad[3] + 4)
-				.moveTo(5, Window.availableBottom + 20)
-				, false
-			);
+			window = Window("Freq Analyzer", resizable: false).bounds_(
+ 				rect.resizeBy(pad[0] + pad[1] + 4, pad[2] + pad[3] + 4)
+			).moveToBottom;
 
 			freqLabel.size.do({ arg i;
 				freqLabel[i] = StaticText(window, Rect(pad[0] - (freqLabelDist*0.5) + (i*freqLabelDist), pad[2] - 10, freqLabelDist, 10))

--- a/SCClassLibrary/Common/GUI/PlusGUI/Control/FreqScope.sc
+++ b/SCClassLibrary/Common/GUI/PlusGUI/Control/FreqScope.sc
@@ -376,7 +376,7 @@ FreqScope {
 			window = Window(
 				"Freq Analyzer",
 				rect.resizeBy(pad[0] + pad[1] + 4, pad[2] + pad[3] + 4)
-				.moveTo(5, Window.availableBottom)
+				.moveTo(5, Window.availableBottom + 20)
 				, false
 			);
 

--- a/SCClassLibrary/Common/GUI/PlusGUI/Control/FreqScope.sc
+++ b/SCClassLibrary/Common/GUI/PlusGUI/Control/FreqScope.sc
@@ -373,7 +373,13 @@ FreqScope {
 				});
 			};
 
-			window = Window("Freq Analyzer", rect.resizeBy(pad[0] + pad[1] + 4, pad[2] + pad[3] + 4), false);
+			window = Window(
+				"Freq Analyzer",
+				rect.resizeBy(
+					pad[0] + pad[1] + 4,
+					pad[2] + pad[3] + 4
+				).moveTo(0, Platform.case(\windows, { 78 }, { 0 })),
+				false);
 
 			freqLabel.size.do({ arg i;
 				freqLabel[i] = StaticText(window, Rect(pad[0] - (freqLabelDist*0.5) + (i*freqLabelDist), pad[2] - 10, freqLabelDist, 10))

--- a/SCClassLibrary/Common/GUI/PlusGUI/Control/FreqScope.sc
+++ b/SCClassLibrary/Common/GUI/PlusGUI/Control/FreqScope.sc
@@ -374,7 +374,7 @@ FreqScope {
 			};
 
 			window = Window("Freq Analyzer", rect.resizeBy(pad[0] + pad[1] + 4, pad[2] + pad[3] + 4)
-				.moveTo(5, Window.screenBounds.height - Window.availableBounds.height * 1.6),
+				.moveTo(5, Window.screenBounds.height - Window.availableBounds.top - Window.availableBounds.height),
 				false
 			);
 

--- a/SCClassLibrary/Common/GUI/PlusGUI/Control/FreqScope.sc
+++ b/SCClassLibrary/Common/GUI/PlusGUI/Control/FreqScope.sc
@@ -374,12 +374,17 @@ FreqScope {
 			};
 
 			window = Window(
-				"Freq Analyzer",
-				rect.resizeBy(
-					pad[0] + pad[1] + 4,
-					pad[2] + pad[3] + 4
-				).moveTo(0, Platform.case(\windows, { 78 }, { 0 })),
-				false);
+ 				"Freq Analyzer",
+ 				rect.resizeBy(pad[0] + pad[1] + 4, pad[2] + pad[3] + 4
+ 				).moveTo(
+					5,
+					Platform.case(
+						\windows, { Window.screenBounds.height - Window.availableBounds.height * 1.6 },
+						{ 0 }
+						)
+					),
+				false
+			);
 
 			freqLabel.size.do({ arg i;
 				freqLabel[i] = StaticText(window, Rect(pad[0] - (freqLabelDist*0.5) + (i*freqLabelDist), pad[2] - 10, freqLabelDist, 10))

--- a/SCClassLibrary/Common/GUI/PlusGUI/Control/FreqScope.sc
+++ b/SCClassLibrary/Common/GUI/PlusGUI/Control/FreqScope.sc
@@ -373,16 +373,8 @@ FreqScope {
 				});
 			};
 
-			window = Window(
- 				"Freq Analyzer",
- 				rect.resizeBy(pad[0] + pad[1] + 4, pad[2] + pad[3] + 4
- 				).moveTo(
-					5,
-					Platform.case(
-						\windows, { Window.screenBounds.height - Window.availableBounds.height * 1.6 },
-						{ 0 }
-						)
-					),
+			window = Window("Freq Analyzer", rect.resizeBy(pad[0] + pad[1] + 4, pad[2] + pad[3] + 4)
+				.moveTo(5, Window.screenBounds.height - Window.availableBounds.height * 1.6),
 				false
 			);
 

--- a/SCClassLibrary/Common/GUI/PlusGUI/Control/FreqScope.sc
+++ b/SCClassLibrary/Common/GUI/PlusGUI/Control/FreqScope.sc
@@ -373,9 +373,11 @@ FreqScope {
 				});
 			};
 
-			window = Window("Freq Analyzer", rect.resizeBy(pad[0] + pad[1] + 4, pad[2] + pad[3] + 4)
-				.moveTo(5, Window.screenBounds.height - Window.availableBounds.top - Window.availableBounds.height),
-				false
+			window = Window(
+				"Freq Analyzer",
+				rect.resizeBy(pad[0] + pad[1] + 4, pad[2] + pad[3] + 4)
+				.moveTo(5, Window.availableBottom)
+				, false
 			);
 
 			freqLabel.size.do({ arg i;

--- a/SCClassLibrary/Common/GUI/tools/ServerMeter.sc
+++ b/SCClassLibrary/Common/GUI/tools/ServerMeter.sc
@@ -237,15 +237,9 @@ ServerMeter {
 
 		numIns = numIns ?? { server.options.numInputBusChannels };
 		numOuts = numOuts ?? { server.options.numOutputBusChannels };
-
-		window = Window.new(
-			server.name ++ " levels (dBFS)",
-			Rect(
-				5,
-				328 + 60 + Window.availableBottom,
-				ServerMeterView.getWidth(numIns, numOuts),
-				ServerMeterView.height
-			),
+		
+ 		window = Window.new(server.name ++ " levels (dBFS)",
+ 			Rect(5, 305, ServerMeterView.getWidth(numIns, numOuts), ServerMeterView.height),
 			false);
 
 		meterView = ServerMeterView(server, window, 0@0, numIns, numOuts);

--- a/SCClassLibrary/Common/GUI/tools/ServerMeter.sc
+++ b/SCClassLibrary/Common/GUI/tools/ServerMeter.sc
@@ -238,9 +238,12 @@ ServerMeter {
 		numIns = numIns ?? { server.options.numInputBusChannels };
 		numOuts = numOuts ?? { server.options.numOutputBusChannels };
 
-		window = Window.new(server.name ++ " levels (dBFS)",
-			Rect(5, 305, ServerMeterView.getWidth(numIns, numOuts), ServerMeterView.height),
-			false);
+		window = Window.new(server.name ++ " levels (dBFS)", resizable: false).bounds_(Rect(
+			5,
+			0,
+			ServerMeterView.getWidth(numIns, numOuts),
+			ServerMeterView.height
+		)).moveToBottom(356); // 356 is the height of FreqScope
 
 		meterView = ServerMeterView(server, window, 0@0, numIns, numOuts);
 		meterView.view.keyDownAction_( { arg view, char, modifiers;

--- a/SCClassLibrary/Common/GUI/tools/ServerMeter.sc
+++ b/SCClassLibrary/Common/GUI/tools/ServerMeter.sc
@@ -237,9 +237,9 @@ ServerMeter {
 
 		numIns = numIns ?? { server.options.numInputBusChannels };
 		numOuts = numOuts ?? { server.options.numOutputBusChannels };
-		
- 		window = Window.new(server.name ++ " levels (dBFS)",
- 			Rect(5, 305, ServerMeterView.getWidth(numIns, numOuts), ServerMeterView.height),
+
+		window = Window.new(server.name ++ " levels (dBFS)",
+			Rect(5, 305, ServerMeterView.getWidth(numIns, numOuts), ServerMeterView.height),
 			false);
 
 		meterView = ServerMeterView(server, window, 0@0, numIns, numOuts);

--- a/SCClassLibrary/Common/GUI/tools/ServerMeter.sc
+++ b/SCClassLibrary/Common/GUI/tools/ServerMeter.sc
@@ -238,8 +238,13 @@ ServerMeter {
 		numIns = numIns ?? { server.options.numInputBusChannels };
 		numOuts = numOuts ?? { server.options.numOutputBusChannels };
 
-		window = Window.new(server.name ++ " levels (dBFS)",
-			Rect(5, 305, ServerMeterView.getWidth(numIns, numOuts), ServerMeterView.height),
+		window = Window.new(
+			server.name ++ " levels (dBFS)",
+			Rect(
+				5,
+				372 + Platform.case(\windows, { 62 }, \linux, { 20 }, \osx, { 0 }),
+				ServerMeterView.getWidth(numIns, numOuts),
+				ServerMeterView.height),
 			false);
 
 		meterView = ServerMeterView(server, window, 0@0, numIns, numOuts);

--- a/SCClassLibrary/Common/GUI/tools/ServerMeter.sc
+++ b/SCClassLibrary/Common/GUI/tools/ServerMeter.sc
@@ -238,15 +238,9 @@ ServerMeter {
 		numIns = numIns ?? { server.options.numInputBusChannels };
 		numOuts = numOuts ?? { server.options.numOutputBusChannels };
 
-		window = Window.new(
- 			server.name ++ " levels (dBFS)",
- 			Rect(
- 				5,
- 				376 + Platform.case(\windows, { 58 }, \linux, { 26 }, \osx, { 0 }),
- 				ServerMeterView.getWidth(numIns, numOuts),
- 				ServerMeterView.height
-				),
- 			false);
+		window = Window.new(server.name ++ " levels (dBFS)",
+			Rect(5, Window.screenBounds.height - Window.availableBounds.height * 1.6 + 360, ServerMeterView.getWidth(numIns, numOuts), ServerMeterView.height),
+			false);
 
 		meterView = ServerMeterView(server, window, 0@0, numIns, numOuts);
 		meterView.view.keyDownAction_( { arg view, char, modifiers;

--- a/SCClassLibrary/Common/GUI/tools/ServerMeter.sc
+++ b/SCClassLibrary/Common/GUI/tools/ServerMeter.sc
@@ -238,8 +238,14 @@ ServerMeter {
 		numIns = numIns ?? { server.options.numInputBusChannels };
 		numOuts = numOuts ?? { server.options.numOutputBusChannels };
 
-		window = Window.new(server.name ++ " levels (dBFS)",
-			Rect(5, Window.screenBounds.height - Window.availableBounds.height * 1.6 + 360, ServerMeterView.getWidth(numIns, numOuts), ServerMeterView.height),
+		window = Window.new(
+			server.name ++ " levels (dBFS)",
+			Rect(
+				5, 
+				Window.screenBounds.height - Window.availableBounds.top - Window.availableBounds.height + 328 + 70, 
+				ServerMeterView.getWidth(numIns, numOuts), 
+				ServerMeterView.height
+			),
 			false);
 
 		meterView = ServerMeterView(server, window, 0@0, numIns, numOuts);

--- a/SCClassLibrary/Common/GUI/tools/ServerMeter.sc
+++ b/SCClassLibrary/Common/GUI/tools/ServerMeter.sc
@@ -239,13 +239,14 @@ ServerMeter {
 		numOuts = numOuts ?? { server.options.numOutputBusChannels };
 
 		window = Window.new(
-			server.name ++ " levels (dBFS)",
-			Rect(
-				5,
-				376 + Platform.case(\windows, { 58 }, \linux, { 20 }, \osx, { 0 }),
-				ServerMeterView.getWidth(numIns, numOuts),
-				ServerMeterView.height),
-			false);
+ 			server.name ++ " levels (dBFS)",
+ 			Rect(
+ 				5,
+ 				376 + Platform.case(\windows, { 58 }, \linux, { 26 }, \osx, { 0 }),
+ 				ServerMeterView.getWidth(numIns, numOuts),
+ 				ServerMeterView.height
+				),
+ 			false);
 
 		meterView = ServerMeterView(server, window, 0@0, numIns, numOuts);
 		meterView.view.keyDownAction_( { arg view, char, modifiers;

--- a/SCClassLibrary/Common/GUI/tools/ServerMeter.sc
+++ b/SCClassLibrary/Common/GUI/tools/ServerMeter.sc
@@ -241,9 +241,9 @@ ServerMeter {
 		window = Window.new(
 			server.name ++ " levels (dBFS)",
 			Rect(
-				5, 
-				Window.screenBounds.height - Window.availableBounds.top - Window.availableBounds.height + 328 + 70, 
-				ServerMeterView.getWidth(numIns, numOuts), 
+				5,
+				328 + 60 + Window.availableBottom,
+				ServerMeterView.getWidth(numIns, numOuts),
 				ServerMeterView.height
 			),
 			false);

--- a/SCClassLibrary/Common/GUI/tools/ServerMeter.sc
+++ b/SCClassLibrary/Common/GUI/tools/ServerMeter.sc
@@ -242,7 +242,7 @@ ServerMeter {
 			server.name ++ " levels (dBFS)",
 			Rect(
 				5,
-				372 + Platform.case(\windows, { 62 }, \linux, { 20 }, \osx, { 0 }),
+				376 + Platform.case(\windows, { 58 }, \linux, { 20 }, \osx, { 0 }),
 				ServerMeterView.getWidth(numIns, numOuts),
 				ServerMeterView.height),
 			false);


### PR DESCRIPTION
…m position of the ServerMeter for all platforms.

<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation
1. On Windows, the default position of `s.freqscope` and `FreqScope()` is covered by the taskbar.
  ![image](https://github.com/user-attachments/assets/81c827b4-a487-4cc6-8413-23614e07304c)
 
2. On all platforms, the position of `s.meter` and `ServerMeter(s, x, x)` and `s.freqscope` (also `FreqScope()`) collides as follows:
   - on Linux:
      ![Screenshot 2025-05-30 at 14 24 21](https://github.com/user-attachments/assets/fc3117c7-618b-4e39-a517-4d91aff9a543)
   - on Windows
      ![Screenshot 2025-05-30 at 14 25 39](https://github.com/user-attachments/assets/e39857a2-db0b-4d6f-be17-0f84ddf7668e)
   - on macOS
      ![Screenshot 2025-05-30 at 14 37 55](https://github.com/user-attachments/assets/e8a46047-7c80-4259-a738-3848e2476b12)

This PR resolves these collisions as follows:
- on Linux
![Screenshot 2025-05-30 at 14 45 06](https://github.com/user-attachments/assets/1510671a-cada-490b-af69-240df95d7043)
- on Windows
![Screenshot 2025-05-30 at 14 22 37](https://github.com/user-attachments/assets/5b07ece0-0a97-41e7-a809-b0e7a5f99b6a)
- on macOS
![Screenshot 2025-05-30 at 14 48 53](https://github.com/user-attachments/assets/e0683729-cec8-4098-9577-3595f64d10e0)

This is not a bug, but it is very inconvenient, and to me, at least, it seems to be buggy.


## Types of changes

<!-- Delete lines that don't apply -->
- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
