### PR TITLE
test: use condVar instead of wait in server boot

### DIFF
--- a/testsuite/classlibrary/TestServer_boot.sc
+++ b/testsuite/classlibrary/TestServer_boot.sc
@@ -100,14 +100,16 @@ TestServer_boot : UnitTest {
 	// test that setting notify=false, then notify=true doesn't cause ServerBoot to be run
 	test_notifyAndServerBootActions {
 		var count = 0;
-		var func = { count = count + 1 };
+		var condVar = CondVar.new;
+		var func = { count = count + 1; condVar.signalOne };
 
 		ServerBoot.add(func, s);
 		this.bootServer(s);
 		this.cycleNotify(s);
 
 		// No efficient way to ensure that ServerTree has run at this point, if it was going to.
-		1.wait;
+
+		condVar.waitFor(3);
 
 		this.assertEquals(count, 1, "Toggling Server.notify should not cause ServerBoot actions to run.");
 


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

The test `test_notifyAndServerBootActions` tends to fail in the CI. This is an attempt to fix it by using a condVar to wait instead of a fixed wait time.

```
UnitTest.runTest("TestServer_boot:test_notifyAndServerBootActions")
``` 

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [ ] Code is tested
- [ ] All tests are passing
- [ ] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
