### PR TITLE
Update node tree view help / implementation

### DIFF
--- a/HelpSource/Classes/NodeTreeView.schelp
+++ b/HelpSource/Classes/NodeTreeView.schelp
@@ -6,9 +6,6 @@ related:: Classes/Server, Classes/ServerTree
 description::
 link::Classes/NodeTreeView:: shows the node tree on a server.
 
-note::
-Unlike to link::Classes/Server#-plotTree::, the link::Classes/NodeTreeView:: will not disappear when the pointed server is not running.
-::
 
 classmethods::
 

--- a/HelpSource/Classes/Server.schelp
+++ b/HelpSource/Classes/Server.schelp
@@ -672,56 +672,41 @@ note::
 To use multiple instances of link::Classes/NodeTreeView:: per link::Classes/Server:: instance or workspace, refer to the link::Classes/NodeTreeView#examples#Examples in NodeTreeView Documentation::.
 ::
 
-The method returns a link::Classes/Server:: (the receiver of this call), and the created link::Classes/View:: instance can be accessed via the link::#-nodeTreeView::.
-
-note::
-If the server is not running, the window containing teletype::plotTree:: will briefly appear and then close, displaying the following message in the Post window:
-teletype::
--> localhost
-WARNING: Server failed to respond to Group:queryTree!
-::
-::
+This method returns an instance of link::Classes/NodeTreeView::, which can also be accessed via link::#-nodeTreeView:: method. Before version 3.14, this method returned an instance of the Server itself.
 
 code::
 // start the SuperCollider server:
-s.boot
+s.boot;
 
-// Open a plotTree window with a default refresh rate of 0.5 seconds:
-s.plotTree
+// Open a NodeTreeView window with a default refresh rate every 0.5 seconds:
+s.plotTree;
 
 // Close it:
-s.nodeTreeView.close
-
-// Open a plotTree window named ~pTree with a default refresh rate:
-~pTree = s.plotTree
-
-// Close the plotTree window associated with ~pTree:
-~pTree.close
+s.nodeTreeView.close;
 ::
 
 code::
-~pTree = s.plotTree
+s.plotTree;
 
 // Define and play a repeating pattern that generates a new synth every 0.4 seconds:
 x = Pn((dur: 0.4, midinote: 69, amp: 0.1)).play;
 
 /*
-The ~pTree window dynamically displays active synth nodes.
-Initially, it shows the first node,
-and upon each refresh, it retains the previous node while adding a new one.
+The NodeTreeView window dynamically displays active synth nodes.
+Initially, it shows the first node, and upon each refresh, it retains the previous node while adding a new one.
 This results in the display of one or two subsequent nodes at each interval.
 */
 
 // stop updating plotTree:
-~pTree.stop
+s.nodeTreeView.stop;
 
 // start updating plotTree:
-~pTree.start
+s.nodeTreeView.start;
 
 // stop the playback of the pattern:
-x.stop
+x.stop;
 
-~pTree.close
+s.nodeTreeView.close;
 ::
 argument:: interval
 Polling interval.
@@ -729,7 +714,7 @@ code::
 (
 s.waitForBoot {
 	// Open a plotTree window with a refresh rate of 2 seconds:
-	var plotTree = s.plotTree(2);
+	s.plotTree(2);
 
 	// Define and play a repeating pattern that generates a new synth every 0.5 seconds:
 	x = Pn((dur: 0.5, midinote: 69, amp: 0.1)).play;
@@ -747,7 +732,7 @@ s.waitForBoot {
 
 	2.wait; // wait for 2 seconds.
 
-	plotTree.close; // close the plotTree window
+	s.nodeTreeView.close; // close the plotTree window
 }
 )
 ::
@@ -784,7 +769,7 @@ Parent view.
 argument:: actionIfFail
 Function to be evaluated in case communication with the server cannot be established.
 
-returns:: Function to be evaluated in order to clean up all actions performed inside the method. To be called for instance by the onClose method of the enclosing window.
+returns:: An Instance of link::Classes/NodeTreeView::.
 
 subsection:: Recording Support
 

--- a/SCClassLibrary/Common/GUI/PlusGUI/Control/ServerPlusGUI.sc
+++ b/SCClassLibrary/Common/GUI/PlusGUI/Control/ServerPlusGUI.sc
@@ -365,7 +365,7 @@
 			bounds = bounds ?? { Rect(128, 64, 400, 400) };
 			bounds = bounds.minSize(395@386);
 			window = Window(name.asString ++ " Node Tree", bounds, scroll:true).front;
-			this.plotTreeView(
+			nodeTreeView = this.plotTreeView(
 				interval ?? { 0.5 },
 				window);
 			window.onClose_({ nodeTreeView = nil });
@@ -378,7 +378,6 @@
 	}
 
 	plotTreeView { |interval=0.5, parent, actionIfFail|
-		nodeTreeView = NodeTreeView(this, parent: parent);
-		nodeTreeView.start(interval, actionIfFail);
+		^NodeTreeView(this, parent: parent).start(interval, actionIfFail);
 	}
 }


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

After merging #6834 I found some discrepancies between the documentation and the implementation.

- `s.plotTree` returns a `NodeTreeView`, as [introduced](https://github.com/supercollider/supercollider/pull/6834/files#diff-a35b5be480643c127f781e8f7c8cc60f263ca1af432aa3c881ba3d043623e6c0R377) in #6834. I reverted the previous change in this PR as suggested by @telephon.

- I made the `s.plotTreeView` (the method that actually creates a view, but that's not typically called directly by the user) return the newly created instance of the NodeTreeView. In SC 3.13 this return a function that needed to be called to clean it up, or something like that. This is technically a _breaking change_, comparing with the state in SC 3.13. I don't think this function is meant to be used directly by the users anyway, and it's not sound-related so I'm okay with this "breaking change" (btw breaking change was introduced first in #6834)

- **note slight interface change**: `s.nodeTreeView` instance variable is now updated by the `s.plotTree` method, NOT by `s.plotTreeView` method. I think that's clearer? But i'm open to feedback on this. Also, both methods still return an instance of `NodeTreeView`.

- ~~examples in the docs assumed that `s.plotTree` returns the `NodeTreeView`, or its parent `Window`, contrary to the previous statement about `s.plotTree` returning an instance of the server.~~ I updated the examples to get an instance of the view directly from the server - `s.nodeTreeView` - instead of assigning it to a variable.

- I removed the note about `s.plotTree` window automatically closing when the server is not running (this behavior was changed in #6834)


~~This PR depends on #6913, let's merge that one first.~~ done!

## Types of changes

<!-- Delete lines that don't apply -->

- Documentation
- Breaking change (kind of)


## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
