### PR TITLE
sclang: kwarg expand syntax

### DIFF
--- a/lang/LangSource/Bison/lang11d
+++ b/lang/LangSource/Bison/lang11d
@@ -1,13 +1,13 @@
 %token	NAME INTEGER SC_FLOAT ACCIDENTAL SYMBOL STRING ASCII PRIMITIVENAME CLASSNAME CURRYARG
 %token  VAR ARG CLASSVAR SC_CONST
 %token	NILOBJ TRUEOBJ FALSEOBJ
-%token	PSEUDOVAR
+%token	PSEUDOVAR KWEXPAND
 %token  ELLIPSIS DOTDOT PIE BEGINCLOSEDFUNC
 %token  BADTOKEN INTERPRET
 %token  BEGINGENERATOR LEFTARROW WHILE
 %left	':'
 %right  '='
-%left	BINOP KEYBINOP '-' '<' '>' '*' '+' '|' READWRITEVAR
+%left	BINOP KEYBINOP '-' '<' '>' '*' '+' '|' READWRITEVAR KWEXPAND
 %left	'.'
 %right  '`'
 %right  UMINUS
@@ -208,7 +208,7 @@ msgsend : name blocklist1
 				$$ = (intptr_t)newPyrCallNode((PyrSlotNode*)$2, (PyrParseNode*)$5,
 						(PyrParseNode*)$6, (PyrParseNode*)$8);
 			}
-		| name '(' arglistv1 optkeyarglist ')'
+		| name '(' argListWithPerformList optkeyarglist ')'
 			{
 				PyrSlotNode *selectornode;
 				PyrSlot slot;
@@ -226,7 +226,7 @@ msgsend : name blocklist1
 					newPyrPushLitNode((PyrSlotNode*)$1, NULL));
 				$$ = (intptr_t)newPyrCallNode(selectornode, args, (PyrParseNode*)$4, 0);
 			}
-		| '(' binop2 ')' '(' arglistv1 optkeyarglist ')'
+		| '(' binop2 ')' '(' argListWithPerformList optkeyarglist ')'
 			{
 				PyrSlotNode *selectornode;
 				PyrSlot slot;
@@ -287,7 +287,7 @@ msgsend : name blocklist1
 					(PyrParseNode*)$3);
 				$$ = (intptr_t)newPyrCallNode(selectornode, args, (PyrParseNode*)$4, (PyrParseNode*)$6);
 			}
-		| classname '(' arglistv1 optkeyarglist ')'
+		| classname '(' argListWithPerformList optkeyarglist ')'
 			{
 				PyrSlotNode *selectornode, *selectornode2;
 				PyrSlot slot, slot2;
@@ -308,6 +308,9 @@ msgsend : name blocklist1
 				args = linkNextNode(args, (PyrParseNode*)$3);
 				$$ = (intptr_t)newPyrCallNode(selectornode, args, (PyrParseNode*)$5, 0);
 			}
+
+
+
 		| expr '.' '(' ')' blocklist
 			{
 				PyrSlotNode *selectornode;
@@ -345,22 +348,7 @@ msgsend : name blocklist1
 				$$ = (intptr_t)newPyrCallNode(selectornode, args, (PyrParseNode*)$5, (PyrParseNode*)$7);
 			}
 
-		| expr '.' '*' '(' exprseq ',' exprseq ')'
-		    {
-		        PyrSlot slot, slot2;
-		        SetSymbol(&slot, s_performArgs);
-		        SetSymbol(&slot2, s_value);
-				PyrSlotNode* selectornode = newPyrSlotNode(&slot);
-				PyrParseNode* args = linkNextNode(
-					(PyrParseNode*)$1,
-					newPyrPushLitNode(newPyrSlotNode(&slot2), NULL)
-                );
-				args = linkNextNode(args, (PyrParseNode*)$5);
-				args = linkNextNode(args, (PyrParseNode*)$7);
-				$$ = (intptr_t)newPyrCallNode(selectornode, args, NULL, 0);
-            }
-
-		| expr '.' '(' arglistv1 optkeyarglist ')'
+		| expr '.' '(' argListWithPerformList optkeyarglist ')'
 			{
 				PyrSlotNode *selectornode;
 				PyrSlot slot, slot2;
@@ -382,6 +370,104 @@ msgsend : name blocklist1
 			}
 
 
+		// Keyword expand section
+		| expr '.' name '(' KWEXPAND expr ')'  
+			{
+				PyrSlot selectorSlot;
+				if (isSuperObjNode((PyrParseNode*)$1)) {
+					SetRaw(&((PyrPushNameNode*)$1)->mSlot, s_this);
+					SetSymbol(&selectorSlot, s_superPerformArgs);
+				} else {
+					SetSymbol(&selectorSlot, s_performArgs);
+				}
+				PyrSlotNode* selectornode = newPyrSlotNode(&selectorSlot);
+
+				PyrParseNode* args;
+				args = linkNextNode((PyrParseNode*)$1, newPyrPushLitNode((PyrSlotNode*)$3, NULL));
+				PyrSlot nil_slot;
+				SetNil(&nil_slot);
+				PyrSlotNode* nil_slot_node = newPyrSlotNode(&nil_slot);
+				args = linkNextNode(args, newPyrPushLitNode(nil_slot_node, NULL));
+				args = linkNextNode(args, (PyrParseNode*)$6);
+				$$ = (intptr_t)newPyrCallNode(selectornode, args, NULL, 0);
+			}
+
+		| expr '.' '(' KWEXPAND expr ')'  
+			{
+				PyrSlot selectorSlot;
+				if (isSuperObjNode((PyrParseNode*)$1)) {
+					SetRaw(&((PyrPushNameNode*)$1)->mSlot, s_this);
+					SetSymbol(&selectorSlot, s_superPerformArgs);
+				} else {
+					SetSymbol(&selectorSlot, s_performArgs);
+				}
+				PyrSlotNode* selectornode = newPyrSlotNode(&selectorSlot);
+
+				PyrParseNode* args;
+
+				PyrSlot value_slot;
+				SetSymbol(&value_slot, s_value);
+				PyrSlotNode* value_slot_node = newPyrSlotNode(&value_slot);
+				args = linkNextNode((PyrParseNode*)$1, newPyrPushLitNode(value_slot_node, NULL));
+
+				PyrSlot nil_slot;
+				SetNil(&nil_slot);
+				PyrSlotNode* nil_slot_node = newPyrSlotNode(&nil_slot);
+				args = linkNextNode(args, newPyrPushLitNode(nil_slot_node, NULL));
+
+				args = linkNextNode(args, (PyrParseNode*)$5);
+				$$ = (intptr_t)newPyrCallNode(selectornode, args, NULL, 0);
+			}
+		| classname '(' KWEXPAND expr ')'  
+			{ 
+				PyrSlot selectorSlot;
+				if (isSuperObjNode((PyrParseNode*)$1)) {
+					SetRaw(&((PyrPushNameNode*)$1)->mSlot, s_this);
+					SetSymbol(&selectorSlot, s_superPerformArgs);
+				} else {
+					SetSymbol(&selectorSlot, s_performArgs);
+				}
+				PyrSlotNode* selectornode = newPyrSlotNode(&selectorSlot);
+
+				PyrSlot value_slot;
+				SetSymbol(&value_slot, s_value);
+				PyrSlotNode* value_slot_node = newPyrSlotNode(&value_slot);
+
+				PyrParseNode* args;
+				args = linkNextNode((PyrParseNode*)$1, newPyrPushLitNode(value_slot_node, NULL));
+				PyrSlot nil_slot;
+				SetNil(&nil_slot);
+				PyrSlotNode* nil_slot_node = newPyrSlotNode(&nil_slot);
+				args = linkNextNode(args, newPyrPushLitNode(nil_slot_node, NULL));
+				args = linkNextNode(args, (PyrParseNode*)$4);
+				$$ = (intptr_t)newPyrCallNode(selectornode, args, NULL, 0);
+			}
+		| name '(' KWEXPAND expr ')'  
+			{ 
+				PyrSlot selectorSlot;
+				if (isSuperObjNode((PyrParseNode*)$1)) {
+					SetRaw(&((PyrPushNameNode*)$1)->mSlot, s_this);
+					SetSymbol(&selectorSlot, s_superPerformArgs);
+				} else {
+					SetSymbol(&selectorSlot, s_performArgs);
+				}
+				PyrSlotNode* selectornode = newPyrSlotNode(&selectorSlot);
+
+				PyrSlot value_slot;
+				SetSymbol(&value_slot, s_value);
+				PyrSlotNode* value_slot_node = newPyrSlotNode(&value_slot);
+
+				PyrParseNode* args;
+				args = linkNextNode((PyrParseNode*)$1, newPyrPushLitNode(value_slot_node, NULL));
+				PyrSlot nil_slot;
+				SetNil(&nil_slot);
+				PyrSlotNode* nil_slot_node = newPyrSlotNode(&nil_slot);
+				args = linkNextNode(args, newPyrPushLitNode(nil_slot_node, NULL));
+				args = linkNextNode(args, (PyrParseNode*)$4);
+				$$ = (intptr_t)newPyrCallNode(selectornode, args, NULL, 0);
+			}
+
+
 		| expr '.' name '(' ')' blocklist
 			{
 				$$ = (intptr_t)newPyrCallNode((PyrSlotNode*)$3, (PyrParseNode*)$1, NULL, (PyrParseNode*)$6);
@@ -392,7 +478,7 @@ msgsend : name blocklist1
 				args = linkNextNode((PyrParseNode*)$1, (PyrParseNode*)$5);
 				$$ = (intptr_t)newPyrCallNode((PyrSlotNode*)$3, args, (PyrParseNode*)$6, (PyrParseNode*)$8);
 			}
-		| expr '.' name '(' arglistv1 optkeyarglist ')'
+		| expr '.' name '(' argListWithPerformList optkeyarglist ')'
 			{
 				PyrSlotNode *selectornode;
 				PyrSlot slot;
@@ -1252,7 +1338,7 @@ arglist1	: exprseq
 					{ $$ = (intptr_t)linkNextNode((PyrParseNode*)$1, (PyrParseNode*)$3); }
 			;
 
-arglistv1	: '*' exprseq
+argListWithPerformList	: '*' exprseq
 				{ $$ = $2; }
 			| arglist1 ',' '*' exprseq
 					{ $$ = (intptr_t)linkNextNode((PyrParseNode*)$1, (PyrParseNode*)$4); }
@@ -1631,6 +1717,7 @@ pseudovar	: PSEUDOVAR { $$ = zzval; }
 
 binop	: BINOP { $$ = zzval; }
 		| READWRITEVAR { $$ = zzval; }
+		| KWEXPAND { $$ = zzval; }
 		| '<'  { $$ = zzval; }
 		| '>'  { $$ = zzval; }
 		| '-'  { $$ = zzval; }

--- a/lang/LangSource/Bison/lang11d_tab.cpp
+++ b/lang/LangSource/Bison/lang11d_tab.cpp
@@ -137,142 +137,143 @@ enum yysymbol_kind_t
   YYSYMBOL_TRUEOBJ = 18,                   /* TRUEOBJ  */
   YYSYMBOL_FALSEOBJ = 19,                  /* FALSEOBJ  */
   YYSYMBOL_PSEUDOVAR = 20,                 /* PSEUDOVAR  */
-  YYSYMBOL_ELLIPSIS = 21,                  /* ELLIPSIS  */
-  YYSYMBOL_DOTDOT = 22,                    /* DOTDOT  */
-  YYSYMBOL_PIE = 23,                       /* PIE  */
-  YYSYMBOL_BEGINCLOSEDFUNC = 24,           /* BEGINCLOSEDFUNC  */
-  YYSYMBOL_BADTOKEN = 25,                  /* BADTOKEN  */
-  YYSYMBOL_INTERPRET = 26,                 /* INTERPRET  */
-  YYSYMBOL_BEGINGENERATOR = 27,            /* BEGINGENERATOR  */
-  YYSYMBOL_LEFTARROW = 28,                 /* LEFTARROW  */
-  YYSYMBOL_WHILE = 29,                     /* WHILE  */
-  YYSYMBOL_30_ = 30,                       /* ':'  */
-  YYSYMBOL_31_ = 31,                       /* '='  */
-  YYSYMBOL_BINOP = 32,                     /* BINOP  */
-  YYSYMBOL_KEYBINOP = 33,                  /* KEYBINOP  */
-  YYSYMBOL_34_ = 34,                       /* '-'  */
-  YYSYMBOL_35_ = 35,                       /* '<'  */
-  YYSYMBOL_36_ = 36,                       /* '>'  */
-  YYSYMBOL_37_ = 37,                       /* '*'  */
-  YYSYMBOL_38_ = 38,                       /* '+'  */
-  YYSYMBOL_39_ = 39,                       /* '|'  */
-  YYSYMBOL_READWRITEVAR = 40,              /* READWRITEVAR  */
-  YYSYMBOL_41_ = 41,                       /* '.'  */
-  YYSYMBOL_42_ = 42,                       /* '`'  */
-  YYSYMBOL_UMINUS = 43,                    /* UMINUS  */
-  YYSYMBOL_44_ = 44,                       /* '{'  */
-  YYSYMBOL_45_ = 45,                       /* '}'  */
-  YYSYMBOL_46_ = 46,                       /* '['  */
-  YYSYMBOL_47_ = 47,                       /* ']'  */
-  YYSYMBOL_48_ = 48,                       /* ';'  */
-  YYSYMBOL_49_ = 49,                       /* ','  */
-  YYSYMBOL_50_ = 50,                       /* '('  */
-  YYSYMBOL_51_ = 51,                       /* ')'  */
-  YYSYMBOL_52_ = 52,                       /* '^'  */
-  YYSYMBOL_53_ = 53,                       /* '~'  */
-  YYSYMBOL_54_ = 54,                       /* '#'  */
-  YYSYMBOL_YYACCEPT = 55,                  /* $accept  */
-  YYSYMBOL_root = 56,                      /* root  */
-  YYSYMBOL_classes = 57,                   /* classes  */
-  YYSYMBOL_classextensions = 58,           /* classextensions  */
-  YYSYMBOL_classdef = 59,                  /* classdef  */
-  YYSYMBOL_classextension = 60,            /* classextension  */
-  YYSYMBOL_optname = 61,                   /* optname  */
-  YYSYMBOL_superclass = 62,                /* superclass  */
-  YYSYMBOL_classvardecls = 63,             /* classvardecls  */
-  YYSYMBOL_classvardecl = 64,              /* classvardecl  */
-  YYSYMBOL_methods = 65,                   /* methods  */
-  YYSYMBOL_methoddef = 66,                 /* methoddef  */
-  YYSYMBOL_optsemi = 67,                   /* optsemi  */
-  YYSYMBOL_optcomma = 68,                  /* optcomma  */
-  YYSYMBOL_optequal = 69,                  /* optequal  */
-  YYSYMBOL_funcbody = 70,                  /* funcbody  */
-  YYSYMBOL_cmdlinecode = 71,               /* cmdlinecode  */
-  YYSYMBOL_methbody = 72,                  /* methbody  */
-  YYSYMBOL_primitive = 73,                 /* primitive  */
-  YYSYMBOL_retval = 74,                    /* retval  */
-  YYSYMBOL_funretval = 75,                 /* funretval  */
-  YYSYMBOL_blocklist1 = 76,                /* blocklist1  */
-  YYSYMBOL_blocklistitem = 77,             /* blocklistitem  */
-  YYSYMBOL_blocklist = 78,                 /* blocklist  */
-  YYSYMBOL_msgsend = 79,                   /* msgsend  */
-  YYSYMBOL_generator = 80,                 /* generator  */
-  YYSYMBOL_81_1 = 81,                      /* $@1  */
-  YYSYMBOL_82_2 = 82,                      /* $@2  */
-  YYSYMBOL_nextqual = 83,                  /* nextqual  */
-  YYSYMBOL_qual = 84,                      /* qual  */
-  YYSYMBOL_expr1 = 85,                     /* expr1  */
-  YYSYMBOL_valrangex1 = 86,                /* valrangex1  */
-  YYSYMBOL_valrangeassign = 87,            /* valrangeassign  */
-  YYSYMBOL_valrangexd = 88,                /* valrangexd  */
-  YYSYMBOL_valrange2 = 89,                 /* valrange2  */
-  YYSYMBOL_valrange3 = 90,                 /* valrange3  */
-  YYSYMBOL_expr = 91,                      /* expr  */
-  YYSYMBOL_adverb = 92,                    /* adverb  */
-  YYSYMBOL_exprn = 93,                     /* exprn  */
-  YYSYMBOL_exprseq = 94,                   /* exprseq  */
-  YYSYMBOL_arrayelems = 95,                /* arrayelems  */
-  YYSYMBOL_arrayelems1 = 96,               /* arrayelems1  */
-  YYSYMBOL_arglist1 = 97,                  /* arglist1  */
-  YYSYMBOL_arglistv1 = 98,                 /* arglistv1  */
-  YYSYMBOL_keyarglist1 = 99,               /* keyarglist1  */
-  YYSYMBOL_keyarg = 100,                   /* keyarg  */
-  YYSYMBOL_optkeyarglist = 101,            /* optkeyarglist  */
-  YYSYMBOL_mavars = 102,                   /* mavars  */
-  YYSYMBOL_mavarlist = 103,                /* mavarlist  */
-  YYSYMBOL_slotliteral = 104,              /* slotliteral  */
-  YYSYMBOL_blockliteral = 105,             /* blockliteral  */
-  YYSYMBOL_pushname = 106,                 /* pushname  */
-  YYSYMBOL_pushliteral = 107,              /* pushliteral  */
-  YYSYMBOL_listliteral = 108,              /* listliteral  */
-  YYSYMBOL_block = 109,                    /* block  */
-  YYSYMBOL_funcvardecls = 110,             /* funcvardecls  */
-  YYSYMBOL_funcvardecls1 = 111,            /* funcvardecls1  */
-  YYSYMBOL_funcvardecl = 112,              /* funcvardecl  */
-  YYSYMBOL_argdecls = 113,                 /* argdecls  */
-  YYSYMBOL_argdecls1 = 114,                /* argdecls1  */
-  YYSYMBOL_constdeflist = 115,             /* constdeflist  */
-  YYSYMBOL_constdef = 116,                 /* constdef  */
-  YYSYMBOL_slotdeflist0 = 117,             /* slotdeflist0  */
-  YYSYMBOL_slotdeflist = 118,              /* slotdeflist  */
-  YYSYMBOL_slotdef = 119,                  /* slotdef  */
-  YYSYMBOL_vardeflist0 = 120,              /* vardeflist0  */
-  YYSYMBOL_vardeflist = 121,               /* vardeflist  */
-  YYSYMBOL_vardef = 122,                   /* vardef  */
-  YYSYMBOL_dictslotdef = 123,              /* dictslotdef  */
-  YYSYMBOL_dictslotlist1 = 124,            /* dictslotlist1  */
-  YYSYMBOL_dictslotlist = 125,             /* dictslotlist  */
-  YYSYMBOL_rwslotdeflist = 126,            /* rwslotdeflist  */
-  YYSYMBOL_rwslotdef = 127,                /* rwslotdef  */
-  YYSYMBOL_dictlit2 = 128,                 /* dictlit2  */
-  YYSYMBOL_litdictslotdef = 129,           /* litdictslotdef  */
-  YYSYMBOL_litdictslotlist1 = 130,         /* litdictslotlist1  */
-  YYSYMBOL_litdictslotlist = 131,          /* litdictslotlist  */
-  YYSYMBOL_listlit = 132,                  /* listlit  */
-  YYSYMBOL_listlit2 = 133,                 /* listlit2  */
-  YYSYMBOL_literallistc = 134,             /* literallistc  */
-  YYSYMBOL_literallist1 = 135,             /* literallist1  */
-  YYSYMBOL_rwspec = 136,                   /* rwspec  */
-  YYSYMBOL_rspec = 137,                    /* rspec  */
-  YYSYMBOL_integer = 138,                  /* integer  */
-  YYSYMBOL_floatr = 139,                   /* floatr  */
-  YYSYMBOL_accidental = 140,               /* accidental  */
-  YYSYMBOL_pie = 141,                      /* pie  */
-  YYSYMBOL_floatp = 142,                   /* floatp  */
-  YYSYMBOL_name = 143,                     /* name  */
-  YYSYMBOL_classname = 144,                /* classname  */
-  YYSYMBOL_primname = 145,                 /* primname  */
-  YYSYMBOL_trueobj = 146,                  /* trueobj  */
-  YYSYMBOL_falseobj = 147,                 /* falseobj  */
-  YYSYMBOL_nilobj = 148,                   /* nilobj  */
-  YYSYMBOL_ascii = 149,                    /* ascii  */
-  YYSYMBOL_symbol = 150,                   /* symbol  */
-  YYSYMBOL_string = 151,                   /* string  */
-  YYSYMBOL_pseudovar = 152,                /* pseudovar  */
-  YYSYMBOL_binop = 153,                    /* binop  */
-  YYSYMBOL_keybinop = 154,                 /* keybinop  */
-  YYSYMBOL_binop2 = 155,                   /* binop2  */
-  YYSYMBOL_curryarg = 156                  /* curryarg  */
+  YYSYMBOL_KWEXPAND = 21,                  /* KWEXPAND  */
+  YYSYMBOL_ELLIPSIS = 22,                  /* ELLIPSIS  */
+  YYSYMBOL_DOTDOT = 23,                    /* DOTDOT  */
+  YYSYMBOL_PIE = 24,                       /* PIE  */
+  YYSYMBOL_BEGINCLOSEDFUNC = 25,           /* BEGINCLOSEDFUNC  */
+  YYSYMBOL_BADTOKEN = 26,                  /* BADTOKEN  */
+  YYSYMBOL_INTERPRET = 27,                 /* INTERPRET  */
+  YYSYMBOL_BEGINGENERATOR = 28,            /* BEGINGENERATOR  */
+  YYSYMBOL_LEFTARROW = 29,                 /* LEFTARROW  */
+  YYSYMBOL_WHILE = 30,                     /* WHILE  */
+  YYSYMBOL_31_ = 31,                       /* ':'  */
+  YYSYMBOL_32_ = 32,                       /* '='  */
+  YYSYMBOL_BINOP = 33,                     /* BINOP  */
+  YYSYMBOL_KEYBINOP = 34,                  /* KEYBINOP  */
+  YYSYMBOL_35_ = 35,                       /* '-'  */
+  YYSYMBOL_36_ = 36,                       /* '<'  */
+  YYSYMBOL_37_ = 37,                       /* '>'  */
+  YYSYMBOL_38_ = 38,                       /* '*'  */
+  YYSYMBOL_39_ = 39,                       /* '+'  */
+  YYSYMBOL_40_ = 40,                       /* '|'  */
+  YYSYMBOL_READWRITEVAR = 41,              /* READWRITEVAR  */
+  YYSYMBOL_42_ = 42,                       /* '.'  */
+  YYSYMBOL_43_ = 43,                       /* '`'  */
+  YYSYMBOL_UMINUS = 44,                    /* UMINUS  */
+  YYSYMBOL_45_ = 45,                       /* '{'  */
+  YYSYMBOL_46_ = 46,                       /* '}'  */
+  YYSYMBOL_47_ = 47,                       /* '['  */
+  YYSYMBOL_48_ = 48,                       /* ']'  */
+  YYSYMBOL_49_ = 49,                       /* ';'  */
+  YYSYMBOL_50_ = 50,                       /* ','  */
+  YYSYMBOL_51_ = 51,                       /* '('  */
+  YYSYMBOL_52_ = 52,                       /* ')'  */
+  YYSYMBOL_53_ = 53,                       /* '^'  */
+  YYSYMBOL_54_ = 54,                       /* '~'  */
+  YYSYMBOL_55_ = 55,                       /* '#'  */
+  YYSYMBOL_YYACCEPT = 56,                  /* $accept  */
+  YYSYMBOL_root = 57,                      /* root  */
+  YYSYMBOL_classes = 58,                   /* classes  */
+  YYSYMBOL_classextensions = 59,           /* classextensions  */
+  YYSYMBOL_classdef = 60,                  /* classdef  */
+  YYSYMBOL_classextension = 61,            /* classextension  */
+  YYSYMBOL_optname = 62,                   /* optname  */
+  YYSYMBOL_superclass = 63,                /* superclass  */
+  YYSYMBOL_classvardecls = 64,             /* classvardecls  */
+  YYSYMBOL_classvardecl = 65,              /* classvardecl  */
+  YYSYMBOL_methods = 66,                   /* methods  */
+  YYSYMBOL_methoddef = 67,                 /* methoddef  */
+  YYSYMBOL_optsemi = 68,                   /* optsemi  */
+  YYSYMBOL_optcomma = 69,                  /* optcomma  */
+  YYSYMBOL_optequal = 70,                  /* optequal  */
+  YYSYMBOL_funcbody = 71,                  /* funcbody  */
+  YYSYMBOL_cmdlinecode = 72,               /* cmdlinecode  */
+  YYSYMBOL_methbody = 73,                  /* methbody  */
+  YYSYMBOL_primitive = 74,                 /* primitive  */
+  YYSYMBOL_retval = 75,                    /* retval  */
+  YYSYMBOL_funretval = 76,                 /* funretval  */
+  YYSYMBOL_blocklist1 = 77,                /* blocklist1  */
+  YYSYMBOL_blocklistitem = 78,             /* blocklistitem  */
+  YYSYMBOL_blocklist = 79,                 /* blocklist  */
+  YYSYMBOL_msgsend = 80,                   /* msgsend  */
+  YYSYMBOL_generator = 81,                 /* generator  */
+  YYSYMBOL_82_1 = 82,                      /* $@1  */
+  YYSYMBOL_83_2 = 83,                      /* $@2  */
+  YYSYMBOL_nextqual = 84,                  /* nextqual  */
+  YYSYMBOL_qual = 85,                      /* qual  */
+  YYSYMBOL_expr1 = 86,                     /* expr1  */
+  YYSYMBOL_valrangex1 = 87,                /* valrangex1  */
+  YYSYMBOL_valrangeassign = 88,            /* valrangeassign  */
+  YYSYMBOL_valrangexd = 89,                /* valrangexd  */
+  YYSYMBOL_valrange2 = 90,                 /* valrange2  */
+  YYSYMBOL_valrange3 = 91,                 /* valrange3  */
+  YYSYMBOL_expr = 92,                      /* expr  */
+  YYSYMBOL_adverb = 93,                    /* adverb  */
+  YYSYMBOL_exprn = 94,                     /* exprn  */
+  YYSYMBOL_exprseq = 95,                   /* exprseq  */
+  YYSYMBOL_arrayelems = 96,                /* arrayelems  */
+  YYSYMBOL_arrayelems1 = 97,               /* arrayelems1  */
+  YYSYMBOL_arglist1 = 98,                  /* arglist1  */
+  YYSYMBOL_argListWithPerformList = 99,    /* argListWithPerformList  */
+  YYSYMBOL_keyarglist1 = 100,              /* keyarglist1  */
+  YYSYMBOL_keyarg = 101,                   /* keyarg  */
+  YYSYMBOL_optkeyarglist = 102,            /* optkeyarglist  */
+  YYSYMBOL_mavars = 103,                   /* mavars  */
+  YYSYMBOL_mavarlist = 104,                /* mavarlist  */
+  YYSYMBOL_slotliteral = 105,              /* slotliteral  */
+  YYSYMBOL_blockliteral = 106,             /* blockliteral  */
+  YYSYMBOL_pushname = 107,                 /* pushname  */
+  YYSYMBOL_pushliteral = 108,              /* pushliteral  */
+  YYSYMBOL_listliteral = 109,              /* listliteral  */
+  YYSYMBOL_block = 110,                    /* block  */
+  YYSYMBOL_funcvardecls = 111,             /* funcvardecls  */
+  YYSYMBOL_funcvardecls1 = 112,            /* funcvardecls1  */
+  YYSYMBOL_funcvardecl = 113,              /* funcvardecl  */
+  YYSYMBOL_argdecls = 114,                 /* argdecls  */
+  YYSYMBOL_argdecls1 = 115,                /* argdecls1  */
+  YYSYMBOL_constdeflist = 116,             /* constdeflist  */
+  YYSYMBOL_constdef = 117,                 /* constdef  */
+  YYSYMBOL_slotdeflist0 = 118,             /* slotdeflist0  */
+  YYSYMBOL_slotdeflist = 119,              /* slotdeflist  */
+  YYSYMBOL_slotdef = 120,                  /* slotdef  */
+  YYSYMBOL_vardeflist0 = 121,              /* vardeflist0  */
+  YYSYMBOL_vardeflist = 122,               /* vardeflist  */
+  YYSYMBOL_vardef = 123,                   /* vardef  */
+  YYSYMBOL_dictslotdef = 124,              /* dictslotdef  */
+  YYSYMBOL_dictslotlist1 = 125,            /* dictslotlist1  */
+  YYSYMBOL_dictslotlist = 126,             /* dictslotlist  */
+  YYSYMBOL_rwslotdeflist = 127,            /* rwslotdeflist  */
+  YYSYMBOL_rwslotdef = 128,                /* rwslotdef  */
+  YYSYMBOL_dictlit2 = 129,                 /* dictlit2  */
+  YYSYMBOL_litdictslotdef = 130,           /* litdictslotdef  */
+  YYSYMBOL_litdictslotlist1 = 131,         /* litdictslotlist1  */
+  YYSYMBOL_litdictslotlist = 132,          /* litdictslotlist  */
+  YYSYMBOL_listlit = 133,                  /* listlit  */
+  YYSYMBOL_listlit2 = 134,                 /* listlit2  */
+  YYSYMBOL_literallistc = 135,             /* literallistc  */
+  YYSYMBOL_literallist1 = 136,             /* literallist1  */
+  YYSYMBOL_rwspec = 137,                   /* rwspec  */
+  YYSYMBOL_rspec = 138,                    /* rspec  */
+  YYSYMBOL_integer = 139,                  /* integer  */
+  YYSYMBOL_floatr = 140,                   /* floatr  */
+  YYSYMBOL_accidental = 141,               /* accidental  */
+  YYSYMBOL_pie = 142,                      /* pie  */
+  YYSYMBOL_floatp = 143,                   /* floatp  */
+  YYSYMBOL_name = 144,                     /* name  */
+  YYSYMBOL_classname = 145,                /* classname  */
+  YYSYMBOL_primname = 146,                 /* primname  */
+  YYSYMBOL_trueobj = 147,                  /* trueobj  */
+  YYSYMBOL_falseobj = 148,                 /* falseobj  */
+  YYSYMBOL_nilobj = 149,                   /* nilobj  */
+  YYSYMBOL_ascii = 150,                    /* ascii  */
+  YYSYMBOL_symbol = 151,                   /* symbol  */
+  YYSYMBOL_string = 152,                   /* string  */
+  YYSYMBOL_pseudovar = 153,                /* pseudovar  */
+  YYSYMBOL_binop = 154,                    /* binop  */
+  YYSYMBOL_keybinop = 155,                 /* keybinop  */
+  YYSYMBOL_binop2 = 156,                   /* binop2  */
+  YYSYMBOL_curryarg = 157                  /* curryarg  */
 };
 typedef enum yysymbol_kind_t yysymbol_kind_t;
 
@@ -600,19 +601,19 @@ union yyalloc
 /* YYFINAL -- State number of the termination state.  */
 #define YYFINAL  70
 /* YYLAST -- Last index in YYTABLE.  */
-#define YYLAST   1965
+#define YYLAST   2131
 
 /* YYNTOKENS -- Number of terminals.  */
-#define YYNTOKENS  55
+#define YYNTOKENS  56
 /* YYNNTS -- Number of nonterminals.  */
 #define YYNNTS  102
 /* YYNRULES -- Number of rules.  */
-#define YYNRULES  303
+#define YYNRULES  307
 /* YYNSTATES -- Number of states.  */
-#define YYNSTATES  571
+#define YYNSTATES  578
 
 /* YYMAXUTOK -- Last valid token kind.  */
-#define YYMAXUTOK   288
+#define YYMAXUTOK   289
 
 
 /* YYTRANSLATE(TOKEN-NUM) -- Symbol number corresponding to TOKEN-NUM
@@ -629,16 +630,16 @@ static const yytype_int8 yytranslate[] =
        0,     2,     2,     2,     2,     2,     2,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
-       2,     2,     2,     2,     2,    54,     2,     2,     2,     2,
-      50,    51,    37,    38,    49,    34,    41,     2,     2,     2,
-       2,     2,     2,     2,     2,     2,     2,     2,    30,    48,
-      35,    31,    36,     2,     2,     2,     2,     2,     2,     2,
+       2,     2,     2,     2,     2,    55,     2,     2,     2,     2,
+      51,    52,    38,    39,    50,    35,    42,     2,     2,     2,
+       2,     2,     2,     2,     2,     2,     2,     2,    31,    49,
+      36,    32,    37,     2,     2,     2,     2,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
-       2,    46,     2,    47,    52,     2,    42,     2,     2,     2,
+       2,    47,     2,    48,    53,     2,    43,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
-       2,     2,     2,    44,    39,    45,    53,     2,     2,     2,
+       2,     2,     2,    45,    40,    46,    54,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
@@ -654,7 +655,7 @@ static const yytype_int8 yytranslate[] =
        2,     2,     2,     2,     2,     2,     1,     2,     3,     4,
        5,     6,     7,     8,     9,    10,    11,    12,    13,    14,
       15,    16,    17,    18,    19,    20,    21,    22,    23,    24,
-      25,    26,    27,    28,    29,    32,    33,    40,    43
+      25,    26,    27,    28,    29,    30,    33,    34,    41,    44
 };
 
 #if YYDEBUG
@@ -668,30 +669,30 @@ static const yytype_int16 yyrline[] =
      142,   144,   148,   149,   153,   154,   159,   160,   165,   166,
      170,   171,   177,   178,   181,   182,   185,   189,   193,   197,
      202,   206,   211,   229,   242,   244,   255,   266,   277,   290,
-     311,   320,   329,   334,   348,   363,   385,   389,   395,   413,
-     419,   419,   429,   429,   436,   457,   461,   495,   533,   547,
-     558,   562,   587,   588,   589,   590,   591,   592,   593,   599,
-     609,   611,   613,   615,   617,   619,   632,   635,   662,   680,
-     707,   735,   754,   782,   809,   827,   852,   880,   899,   927,
-     946,   965,   982,   996,  1017,  1036,  1054,  1071,  1087,  1103,
-    1104,  1105,  1106,  1107,  1120,  1134,  1139,  1143,  1154,  1159,
-    1169,  1174,  1188,  1204,  1205,  1206,  1207,  1210,  1211,  1217,
-    1220,  1221,  1225,  1226,  1228,  1233,  1235,  1242,  1250,  1251,
-    1255,  1257,  1261,  1262,  1266,  1270,  1271,  1274,  1276,  1280,
-    1281,  1286,  1287,  1288,  1289,  1290,  1291,  1292,  1293,  1294,
-    1297,  1300,  1303,  1304,  1305,  1306,  1307,  1308,  1309,  1310,
-    1311,  1314,  1315,  1316,  1317,  1318,  1319,  1320,  1321,  1322,
-    1323,  1324,  1327,  1330,  1335,  1336,  1340,  1341,  1345,  1349,
-    1350,  1354,  1358,  1362,  1366,  1372,  1376,  1380,  1384,  1388,
-    1395,  1396,  1400,  1404,  1405,  1408,  1409,  1413,  1415,  1417,
-    1425,  1426,  1429,  1430,  1434,  1436,  1438,  1446,  1448,  1455,
-    1456,  1460,  1461,  1464,  1465,  1469,  1471,  1475,  1479,  1481,
-    1488,  1489,  1493,  1494,  1499,  1501,  1505,  1507,  1511,  1512,
-    1515,  1516,  1520,  1521,  1523,  1525,  1529,  1530,  1534,  1535,
-    1544,  1545,  1554,  1555,  1566,  1569,  1570,  1571,  1577,  1585,
-    1592,  1601,  1602,  1605,  1608,  1611,  1614,  1617,  1620,  1623,
-    1626,  1629,  1632,  1633,  1634,  1635,  1636,  1637,  1638,  1639,
-    1642,  1645,  1646,  1649
+     314,   323,   332,   337,   351,   374,   395,   421,   445,   471,
+     475,   481,   499,   505,   505,   515,   515,   522,   543,   547,
+     581,   619,   633,   644,   648,   673,   674,   675,   676,   677,
+     678,   679,   685,   695,   697,   699,   701,   703,   705,   718,
+     721,   748,   766,   793,   821,   840,   868,   895,   913,   938,
+     966,   985,  1013,  1032,  1051,  1068,  1082,  1103,  1122,  1140,
+    1157,  1173,  1189,  1190,  1191,  1192,  1193,  1206,  1220,  1225,
+    1229,  1240,  1245,  1255,  1260,  1274,  1290,  1291,  1292,  1293,
+    1296,  1297,  1303,  1306,  1307,  1311,  1312,  1314,  1319,  1321,
+    1328,  1336,  1337,  1341,  1343,  1347,  1348,  1352,  1356,  1357,
+    1360,  1362,  1366,  1367,  1372,  1373,  1374,  1375,  1376,  1377,
+    1378,  1379,  1380,  1383,  1386,  1389,  1390,  1391,  1392,  1393,
+    1394,  1395,  1396,  1397,  1400,  1401,  1402,  1403,  1404,  1405,
+    1406,  1407,  1408,  1409,  1410,  1413,  1416,  1421,  1422,  1426,
+    1427,  1431,  1435,  1436,  1440,  1444,  1448,  1452,  1458,  1462,
+    1466,  1470,  1474,  1481,  1482,  1486,  1490,  1491,  1494,  1495,
+    1499,  1501,  1503,  1511,  1512,  1515,  1516,  1520,  1522,  1524,
+    1532,  1534,  1541,  1542,  1546,  1547,  1550,  1551,  1555,  1557,
+    1561,  1565,  1567,  1574,  1575,  1579,  1580,  1585,  1587,  1591,
+    1593,  1597,  1598,  1601,  1602,  1606,  1607,  1609,  1611,  1615,
+    1616,  1620,  1621,  1630,  1631,  1640,  1641,  1652,  1655,  1656,
+    1657,  1663,  1671,  1678,  1687,  1688,  1691,  1694,  1697,  1700,
+    1703,  1706,  1709,  1712,  1715,  1718,  1719,  1720,  1721,  1722,
+    1723,  1724,  1725,  1726,  1729,  1732,  1733,  1736
 };
 #endif
 
@@ -710,8 +711,8 @@ static const char *const yytname[] =
   "\"end of file\"", "error", "\"invalid token\"", "NAME", "INTEGER",
   "SC_FLOAT", "ACCIDENTAL", "SYMBOL", "STRING", "ASCII", "PRIMITIVENAME",
   "CLASSNAME", "CURRYARG", "VAR", "ARG", "CLASSVAR", "SC_CONST", "NILOBJ",
-  "TRUEOBJ", "FALSEOBJ", "PSEUDOVAR", "ELLIPSIS", "DOTDOT", "PIE",
-  "BEGINCLOSEDFUNC", "BADTOKEN", "INTERPRET", "BEGINGENERATOR",
+  "TRUEOBJ", "FALSEOBJ", "PSEUDOVAR", "KWEXPAND", "ELLIPSIS", "DOTDOT",
+  "PIE", "BEGINCLOSEDFUNC", "BADTOKEN", "INTERPRET", "BEGINGENERATOR",
   "LEFTARROW", "WHILE", "':'", "'='", "BINOP", "KEYBINOP", "'-'", "'<'",
   "'>'", "'*'", "'+'", "'|'", "READWRITEVAR", "'.'", "'`'", "UMINUS",
   "'{'", "'}'", "'['", "']'", "';'", "','", "'('", "')'", "'^'", "'~'",
@@ -723,18 +724,18 @@ static const char *const yytname[] =
   "generator", "$@1", "$@2", "nextqual", "qual", "expr1", "valrangex1",
   "valrangeassign", "valrangexd", "valrange2", "valrange3", "expr",
   "adverb", "exprn", "exprseq", "arrayelems", "arrayelems1", "arglist1",
-  "arglistv1", "keyarglist1", "keyarg", "optkeyarglist", "mavars",
-  "mavarlist", "slotliteral", "blockliteral", "pushname", "pushliteral",
-  "listliteral", "block", "funcvardecls", "funcvardecls1", "funcvardecl",
-  "argdecls", "argdecls1", "constdeflist", "constdef", "slotdeflist0",
-  "slotdeflist", "slotdef", "vardeflist0", "vardeflist", "vardef",
-  "dictslotdef", "dictslotlist1", "dictslotlist", "rwslotdeflist",
-  "rwslotdef", "dictlit2", "litdictslotdef", "litdictslotlist1",
-  "litdictslotlist", "listlit", "listlit2", "literallistc", "literallist1",
-  "rwspec", "rspec", "integer", "floatr", "accidental", "pie", "floatp",
-  "name", "classname", "primname", "trueobj", "falseobj", "nilobj",
-  "ascii", "symbol", "string", "pseudovar", "binop", "keybinop", "binop2",
-  "curryarg", YY_NULLPTR
+  "argListWithPerformList", "keyarglist1", "keyarg", "optkeyarglist",
+  "mavars", "mavarlist", "slotliteral", "blockliteral", "pushname",
+  "pushliteral", "listliteral", "block", "funcvardecls", "funcvardecls1",
+  "funcvardecl", "argdecls", "argdecls1", "constdeflist", "constdef",
+  "slotdeflist0", "slotdeflist", "slotdef", "vardeflist0", "vardeflist",
+  "vardef", "dictslotdef", "dictslotlist1", "dictslotlist",
+  "rwslotdeflist", "rwslotdef", "dictlit2", "litdictslotdef",
+  "litdictslotlist1", "litdictslotlist", "listlit", "listlit2",
+  "literallistc", "literallist1", "rwspec", "rspec", "integer", "floatr",
+  "accidental", "pie", "floatp", "name", "classname", "primname",
+  "trueobj", "falseobj", "nilobj", "ascii", "symbol", "string",
+  "pseudovar", "binop", "keybinop", "binop2", "curryarg", YY_NULLPTR
 };
 
 static const char *
@@ -744,12 +745,12 @@ yysymbol_name (yysymbol_kind_t yysymbol)
 }
 #endif
 
-#define YYPACT_NINF (-477)
+#define YYPACT_NINF (-402)
 
 #define yypact_value_is_default(Yyn) \
   ((Yyn) == YYPACT_NINF)
 
-#define YYTABLE_NINF (-300)
+#define YYTABLE_NINF (-304)
 
 #define yytable_value_is_error(Yyn) \
   0
@@ -758,64 +759,64 @@ yysymbol_name (yysymbol_kind_t yysymbol)
    STATE-NUM.  */
 static const yytype_int16 yypact[] =
 {
-      23,   983,    60,    58,    60,    35,  -477,  -477,  -477,  -477,
-    -477,  -477,  -477,  -477,  -477,  -477,    53,    53,  -477,  -477,
-    -477,  -477,  -477,   127,  -477,   339,    53,  1815,   198,  1451,
-     879,  1815,    53,    43,  -477,  -477,  -477,  -477,  -477,    40,
-    -477,  -477,  -477,  1904,    59,    66,  -477,  -477,  -477,  -477,
-    1191,  -477,  1191,  -477,   108,   108,  -477,  -477,  -477,   271,
-     103,  -477,  -477,  -477,  -477,  -477,  -477,  -477,  -477,   102,
-    -477,  -477,    67,  -477,   -23,  -477,   109,   131,   182,    53,
-      53,  -477,  -477,  -477,  -477,  -477,   150,    42,  -477,   205,
-     931,  -477,  1815,  1815,  -477,  -477,   159,   163,   164,  1815,
-    1815,  1503,  -477,   339,  -477,  -477,  -477,  -477,    16,  -477,
-     196,    99,  1191,  1191,  -477,   176,   212,  -477,  1815,   217,
-     813,   243,  1901,   247,    21,  -477,   236,  1555,  -477,  -477,
-      82,  -477,   249,  1815,  -477,  -477,  -477,  -477,  -477,  1191,
-    -477,  -477,  1815,  1243,   174,  -477,  -477,  -477,  1451,  1035,
-     174,  -477,    60,    53,   240,  -477,    53,  1815,  1815,    53,
-    -477,   278,   276,   280,    54,  1191,    53,  -477,  -477,    53,
-    -477,   661,  -477,  -477,  1191,  1815,  -477,  1451,  -477,  -477,
-    -477,  1815,   241,    47,  -477,  1815,  1815,  1815,  -477,   252,
-     255,  1191,  1451,  -477,  -477,  -477,   183,  -477,  -477,  1815,
-    1901,  1867,  -477,  -477,  -477,   261,   265,   108,  -477,  -477,
-     272,  -477,  -477,  -477,  -477,  -477,  -477,  1815,    53,    53,
-    1901,  1815,  -477,    86,   282,  1607,  1087,   273,    28,  1815,
-    1904,  -477,  1904,  1815,   174,   279,   306,  -477,   275,   174,
-     279,   306,   308,  -477,  1815,   745,  -477,   303,  -477,  -477,
-    -477,  1904,   309,   317,    53,  -477,    53,  -477,   321,  -477,
-     162,  -477,  1815,    13,  -477,  -477,   108,  -477,  -477,  -477,
-    -477,  -477,  -477,  -477,   319,   323,   322,  -477,   351,  1815,
-    -477,  -477,  1815,  1815,  -477,  -477,   363,  -477,  -477,   335,
-     357,  -477,  1815,  1295,   174,  1904,   350,   358,  -477,   349,
-     348,  1901,  -477,  1901,  -477,  1901,  1904,  -477,  -477,   355,
-     356,  1659,   373,  1815,  1815,  1815,   147,   174,   279,   306,
-     308,  1815,  1139,   174,  -477,   401,  1815,  -477,  -477,   365,
-    -477,   174,  1347,  -477,   364,   374,   370,  -477,  -477,   371,
-     376,   374,   377,  -477,   604,  -477,  -477,   372,   381,   384,
-     237,  -477,  -477,   383,   199,  -477,  -477,    53,   390,  1399,
-    1399,  -477,  1815,  -477,  -477,   410,  1815,  -477,   174,   279,
-     306,  -477,  1901,  1867,  -477,  -477,  -477,  -477,   388,  -477,
-     411,   414,   399,  1815,  -477,   403,   408,  1711,   419,  -477,
-     406,   409,   413,  1904,   174,   279,   306,   308,   430,  1815,
-     308,   185,  -477,   174,  -477,  -477,   174,   439,   440,   127,
-     127,   442,   251,   251,   453,  -477,   783,  -477,  -477,    53,
-     451,  -477,    53,   301,   447,   444,    24,   454,  -477,  1815,
-    -477,   174,   449,   450,  -477,  -477,  -477,  1815,  1815,   467,
-    1904,  1815,   472,   473,   458,  1815,   174,  -477,   174,  -477,
-     455,   456,   457,  -477,  -477,  -477,  1815,  -477,  -477,  -477,
-     127,   127,  -477,  -477,  -477,  -477,  -477,  -477,   286,  -477,
-      53,   292,  -477,   298,  -477,    53,  -477,   470,  -477,   479,
-    1815,  1815,  -477,  1399,  -477,  1815,   484,  -477,  -477,   174,
-    -477,  1904,  1904,  1815,   462,  1815,  1815,   483,  1904,  -477,
-    -477,   174,  -477,   174,  1904,  -477,  -477,   154,   154,   237,
-    -477,   251,   486,  -477,  -477,   453,   490,  -477,  1815,   444,
-     444,  -477,   444,  1815,  -477,  1904,  -477,  1904,  1904,  1815,
-    -477,  -477,   154,   154,  -477,  1763,   477,  1763,  1920,  -477,
-     699,  -477,   699,   444,  -477,  -477,  -477,   444,  1904,  1763,
-    1763,  1815,   482,  -477,   476,  -477,   491,  -477,  -477,  -477,
-    -477,  -477,   495,   496,   813,  -477,  -477,  -477,  -477,  -477,
-    -477
+     141,   951,     6,    47,     6,    16,  -402,  -402,  -402,  -402,
+    -402,  -402,  -402,  -402,  -402,  -402,    30,    30,  -402,  -402,
+    -402,  -402,  -402,   124,  -402,   282,    30,  1799,   121,  1428,
+     837,  1799,    30,    97,  -402,  -402,  -402,  -402,  -402,    49,
+    -402,  -402,  -402,  2089,    60,    65,  -402,  -402,  -402,  -402,
+    1216,  -402,  1216,  -402,   108,   108,  -402,  -402,  -402,   206,
+     120,  -402,  -402,  -402,  -402,  -402,  -402,  -402,  -402,   102,
+    -402,  -402,    25,  -402,    52,  -402,   166,   128,   105,    30,
+      30,  -402,  -402,  -402,  -402,  -402,   174,    26,  -402,   242,
+     895,  -402,  1799,  1799,  -402,  -402,   176,   178,   192,  1799,
+    -402,  1799,  1481,  -402,   282,  -402,  -402,  -402,  -402,    27,
+    -402,   201,    15,  1216,  1216,  -402,   194,   209,  -402,  1799,
+     224,  2067,   251,  1908,   253,    42,  -402,   248,  1534,  -402,
+    -402,    59,  -402,   255,  1799,  -402,  -402,  -402,  -402,  -402,
+    1216,  -402,  -402,  1799,  1163,    -3,  -402,  -402,  -402,  1428,
+    1004,    -3,  -402,     6,    30,   257,  -402,    30,  1799,  1799,
+      30,  -402,   289,   162,   296,    55,  1216,    30,  -402,  -402,
+      30,  -402,   743,  -402,  -402,  1216,  1799,  -402,  1428,  -402,
+    -402,  -402,  1799,   256,    89,  -402,  1799,  1799,  1799,  -402,
+     270,   272,  1216,  1428,  -402,  -402,  -402,    68,  -402,  -402,
+    1799,  1908,  1873,  -402,  -402,  -402,   281,   284,   108,  -402,
+    -402,   294,  -402,  -402,  -402,  -402,  -402,  -402,  1799,    30,
+      30,  1908,  1799,  -402,   126,  1587,  1057,   214,    48,  1799,
+    2089,  -402,  2089,  1799,  1799,    -3,   299,   301,  -402,   298,
+    1799,    -3,   299,   301,   302,  -402,  1799,   790,  -402,   305,
+    -402,  -402,  -402,  2089,   306,   287,    30,  -402,    30,  -402,
+     311,  -402,   -24,  -402,  1799,    39,  -402,  -402,   108,  -402,
+    -402,  -402,  -402,  -402,  -402,  -402,   309,   312,   321,  -402,
+     337,  1799,  -402,  -402,  1799,  1799,  -402,  -402,   346,  -402,
+    -402,   318,   342,  -402,  1799,  1269,    -3,  2089,   326,   350,
+    -402,   327,   336,  1908,  -402,  1908,  -402,  1908,  2089,  -402,
+    -402,   341,   344,  1640,   361,  1799,  1799,   137,  1799,    -3,
+     299,   301,   302,  1799,  1110,    -3,  -402,   390,  1799,  -402,
+    -402,   353,  1979,  -402,    -3,  1322,  -402,   345,   362,   347,
+    -402,  2001,  -402,   349,   351,   362,   356,  -402,  1969,  -402,
+    -402,   357,   360,   367,   288,  -402,  -402,   364,   155,  -402,
+    -402,    30,   375,  1375,  1375,  -402,  1799,  -402,  -402,   406,
+    1799,  -402,    -3,   299,   301,  -402,  1908,  1873,  -402,  -402,
+    -402,  -402,   384,  -402,   401,   402,   388,  1799,  -402,   393,
+    1693,   413,  2023,  -402,   395,   397,   400,  2089,  1799,    -3,
+     299,   301,   302,   404,  -402,  1799,   302,    72,  -402,  -402,
+      -3,  -402,  -402,    -3,   408,   420,   124,   124,   421,   234,
+     234,   431,  -402,  1927,  -402,  -402,    30,   430,  -402,    30,
+     202,   426,   427,    29,   432,  -402,  1799,  -402,    -3,   434,
+     437,  -402,  -402,  -402,  1799,  1799,   447,  2089,   450,   451,
+     436,  1799,  -402,    -3,  -402,    -3,  2045,  -402,   438,   442,
+     443,  -402,  -402,  -402,  1799,  -402,  -402,  -402,   124,   124,
+    -402,  -402,  -402,  -402,  -402,  -402,   244,  -402,    30,   278,
+    -402,   283,  -402,    30,  -402,   457,  -402,   468,  1799,  1799,
+    -402,  1375,  -402,  1799,   472,  -402,  -402,    -3,  -402,  2089,
+    2089,  1799,  1799,  1799,   470,  2089,  -402,  -402,  -402,    -3,
+    -402,    -3,  2089,  -402,  -402,   165,   165,   288,  -402,   234,
+     471,  -402,  -402,   431,   473,  -402,  1799,   427,   427,  -402,
+     427,  1799,  -402,  2089,  2089,  2089,  1799,  -402,  -402,   165,
+     165,  -402,  1746,   455,  1746,  1948,  -402,  1851,  -402,  1851,
+     427,  -402,  -402,  -402,   427,  2089,  1746,  1746,  1799,   464,
+    -402,   458,  -402,   467,  -402,  -402,  -402,  -402,  -402,   469,
+     477,  2067,  -402,  -402,  -402,  -402,  -402,  -402
 };
 
 /* YYDEFACT[STATE-NUM] -- Default reduction number in state STATE-NUM.
@@ -823,96 +824,96 @@ static const yytype_int16 yypact[] =
    means the default is an error.  */
 static const yytype_int16 yydefact[] =
 {
-       5,    48,     0,     0,     2,     3,     7,   281,   268,   270,
-     272,   289,   290,   288,   283,   303,     0,   230,   287,   285,
-     286,   291,   274,   209,   282,     0,   223,     0,   209,   150,
-     241,     0,     0,     0,    41,     4,    33,    97,    94,   129,
-     106,   131,   130,   147,    27,    48,    93,    95,    92,   180,
-      48,   206,    48,   190,   182,   275,   276,   279,   183,   181,
-     132,   187,   188,   189,   184,   186,   185,   104,    96,     0,
-       1,     6,    14,     8,     0,   232,   234,     0,   231,   230,
-     223,   204,   269,   271,   273,   280,     0,    29,   225,    31,
-     241,   134,     0,     0,   204,   300,   152,     0,    29,     0,
-       0,     0,   292,   296,   294,   295,   297,   298,   223,   293,
-       0,     0,    48,    48,   239,    29,     0,   301,   302,     0,
-      27,    99,   258,     0,   167,   169,     0,     0,   296,   299,
-       0,   302,   143,    28,   149,    34,    40,   207,    39,    48,
-     278,   277,     0,     0,    56,    50,    53,    52,   150,     0,
-      65,    21,     0,    12,     0,   208,     0,     0,     0,     0,
-     215,     0,   231,     0,    29,    48,     0,   217,    30,     0,
-      32,     0,    80,    82,    48,     0,   100,    30,   151,   154,
-     120,     0,     0,     0,   101,   119,     0,     0,    98,     0,
-       0,    48,    30,   242,   103,   238,     0,    28,    49,     0,
-     258,   252,   260,   201,   200,     0,    29,   191,   192,   196,
-       0,   197,   198,   199,   193,   195,   194,     0,     0,     0,
-     258,     0,   158,     0,     0,     0,     0,    54,     0,     0,
-     148,    38,   136,     0,     0,    29,    29,    51,     0,    54,
-      29,    29,    29,   162,     0,     0,    15,     0,    13,    16,
-     233,   235,     0,     0,     0,   210,     0,   212,     0,   205,
-       0,   226,     0,     0,   228,   179,   171,   172,   176,   177,
-     178,   173,   175,   174,     0,     0,     0,   153,   155,     0,
-     124,   102,   125,     0,   121,   237,     0,    37,    36,     0,
-       0,   240,     0,     0,    57,   137,     0,     0,   250,    29,
-       0,     0,   254,    30,   259,   258,   140,   168,   170,     0,
-       0,     0,   105,     0,     0,     0,     0,    54,    29,    29,
-      29,     0,     0,    55,    79,     0,     0,   145,   144,   135,
-     160,    58,    30,   165,     0,    30,     0,    64,    66,     0,
-       0,    30,     0,   164,   297,    11,    22,     0,     0,    14,
-      21,   236,   216,     0,     0,   203,   218,     0,     0,     0,
-       0,   202,     0,   156,   126,     0,   123,    35,     0,    29,
-      29,   256,     0,    30,   253,   247,   249,   261,     0,   255,
-     108,   107,     0,     0,   159,     0,     0,     0,   133,    70,
-       0,     0,     0,   138,    54,    29,    29,    29,     0,     0,
-      29,    54,    62,    54,    69,   163,    54,     0,     0,   209,
-     209,     0,   262,   262,   266,    17,     0,   211,   213,     0,
-       0,   229,     0,     0,     0,    84,   181,     0,   157,   127,
-     122,    60,     0,     0,   248,   251,   257,     0,     0,   109,
-     141,     0,   114,   113,     0,     0,    54,    75,    54,    76,
-       0,     0,     0,   146,   161,   166,     0,    59,    68,    67,
-     209,   209,   204,   204,    16,   263,   265,   264,     0,   243,
-       0,     0,   267,    29,   220,     0,     9,     0,   219,     0,
-       0,     0,    81,     0,    89,     0,     0,    83,   128,    54,
-      63,   111,   110,     0,     0,     0,     0,   115,   142,    73,
-      71,    54,    78,    54,   139,   204,   204,    44,    44,    21,
-      19,   262,   245,    18,    20,   266,     0,   214,     0,    84,
-      84,    85,    84,     0,    61,   112,    74,   117,   116,     0,
-      77,    72,    44,    44,   284,    46,    27,    46,     0,   244,
-       0,   221,     0,    84,    91,    90,    86,    84,   118,    46,
-      46,     0,     0,    42,    46,    45,     0,    10,   246,   222,
-      88,    87,     0,     0,    27,    23,    43,    25,    24,    26,
-      47
+       5,    48,     0,     0,     2,     3,     7,   284,   271,   273,
+     275,   292,   293,   291,   286,   307,     0,   233,   290,   288,
+     289,   294,   277,   212,   285,     0,   226,     0,   212,   153,
+     244,     0,     0,     0,    41,     4,    33,   100,    97,   132,
+     109,   134,   133,   150,    27,    48,    96,    98,    95,   183,
+      48,   209,    48,   193,   185,   278,   279,   282,   186,   184,
+     135,   190,   191,   192,   187,   189,   188,   107,    99,     0,
+       1,     6,    14,     8,     0,   235,   237,     0,   234,   233,
+     226,   207,   272,   274,   276,   283,     0,    29,   228,    31,
+     244,   137,     0,     0,   207,   304,   155,     0,    29,     0,
+     297,     0,     0,   295,   300,   298,   299,   301,   302,   226,
+     296,     0,     0,    48,    48,   242,    29,     0,   305,   306,
+       0,    27,   102,   261,     0,   170,   172,     0,     0,   300,
+     303,     0,   306,   146,    28,   152,    34,    40,   210,    39,
+      48,   281,   280,     0,     0,    56,    50,    53,    52,   153,
+       0,    65,    21,     0,    12,     0,   211,     0,     0,     0,
+       0,   218,     0,   234,     0,    29,    48,     0,   220,    30,
+       0,    32,     0,    83,    85,    48,     0,   103,    30,   154,
+     157,   123,     0,     0,     0,   104,   122,     0,     0,   101,
+       0,     0,    48,    30,   245,   106,   241,     0,    28,    49,
+       0,   261,   255,   263,   204,   203,     0,    29,   194,   195,
+     199,     0,   200,   201,   202,   196,   198,   197,     0,     0,
+       0,   261,     0,   161,     0,     0,     0,    54,     0,     0,
+     151,    38,   139,     0,     0,     0,    29,    29,    51,     0,
+       0,    54,    29,    29,    29,   165,     0,     0,    15,     0,
+      13,    16,   236,   238,     0,     0,     0,   213,     0,   215,
+       0,   208,     0,   229,     0,     0,   231,   182,   174,   175,
+     179,   180,   181,   176,   178,   177,     0,     0,     0,   156,
+     158,     0,   127,   105,   128,     0,   124,   240,     0,    37,
+      36,     0,     0,   243,     0,     0,    57,   140,     0,     0,
+     253,    29,     0,     0,   257,    30,   262,   261,   143,   171,
+     173,     0,     0,     0,   108,     0,     0,     0,     0,    54,
+      29,    29,    29,     0,     0,    55,    82,     0,     0,   148,
+     147,   138,     0,   163,    58,    30,   168,     0,    30,     0,
+      64,     0,    66,     0,     0,    30,     0,   167,   301,    11,
+      22,     0,     0,    14,    21,   239,   219,     0,     0,   206,
+     221,     0,     0,     0,     0,   205,     0,   159,   129,     0,
+     126,    35,     0,    29,    29,   259,     0,    30,   256,   250,
+     252,   264,     0,   258,   111,   110,     0,     0,   162,     0,
+       0,   136,     0,    70,     0,     0,     0,   141,     0,    54,
+      29,    29,    29,     0,    78,     0,    29,    54,    62,    77,
+      54,    69,   166,    54,     0,     0,   212,   212,     0,   265,
+     265,   269,    17,     0,   214,   216,     0,     0,   232,     0,
+       0,     0,    87,   184,     0,   160,   130,   125,    60,     0,
+       0,   251,   254,   260,     0,     0,   112,   144,   117,   116,
+       0,     0,    76,    54,    74,    54,     0,    79,     0,     0,
+       0,   149,   164,   169,     0,    59,    68,    67,   212,   212,
+     207,   207,    16,   266,   268,   267,     0,   246,     0,     0,
+     270,    29,   223,     0,     9,     0,   222,     0,     0,     0,
+      84,     0,    92,     0,     0,    86,   131,    54,    63,   114,
+     113,     0,     0,     0,   118,   145,    73,    71,    75,    54,
+      81,    54,   142,   207,   207,    44,    44,    21,    19,   265,
+     248,    18,    20,   269,     0,   217,     0,    87,    87,    88,
+      87,     0,    61,   115,   120,   119,     0,    80,    72,    44,
+      44,   287,    46,    27,    46,     0,   247,     0,   224,     0,
+      87,    94,    93,    89,    87,   121,    46,    46,     0,     0,
+      42,    46,    45,     0,    10,   249,   225,    91,    90,     0,
+       0,    27,    23,    43,    25,    24,    26,    47
 };
 
 /* YYPGOTO[NTERM-NUM].  */
 static const yytype_int16 yypgoto[] =
 {
-    -477,  -477,  -477,  -477,  -477,   524,  -477,   186,    79,  -477,
-    -341,  -477,  -117,   -64,  -477,   420,  -477,  -273,  -263,   -10,
-     500,   -31,  -138,   145,  -477,   -52,  -477,  -477,  -247,  -346,
-    -477,  -477,  -477,  -477,  -477,  -477,   -27,  -477,  -477,   290,
-     402,  -477,  -102,  -116,  -136,   206,   -57,  -477,  -477,  -476,
-     341,  -477,  -477,  -158,  -477,   -93,    -8,    49,   -17,   519,
-    -477,    38,   475,   480,   392,   478,     1,   407,   378,  -477,
-    -477,   149,    63,  -477,   191,  -477,  -477,  -169,  -477,  -185,
-    -477,  -477,  -477,  -106,  -477,  -477,   -15,   -84,     4,   493,
-    -477,   -62,   -46,   -20,   158,   253,   318,  -477,  -240,   537,
-     -13,  -477
+    -402,  -402,  -402,  -402,  -402,   503,  -402,   161,    44,  -402,
+    -351,  -402,  -120,   -67,  -402,   580,  -402,  -276,  -292,   -44,
+     479,   -46,   -82,   232,  -402,   203,  -402,  -402,  -207,  -349,
+    -402,  -402,  -402,  -402,  -402,  -402,   -27,  -402,  -402,    91,
+     369,  -402,  -138,  -142,  -123,   180,   417,  -402,  -402,  -401,
+     271,  -402,  -402,  -177,  -402,   -50,   -23,    23,   -26,   496,
+    -402,     9,   449,   453,   365,   459,    -8,   373,   343,  -402,
+    -402,   114,    20,  -402,   163,  -402,  -402,  -167,  -402,  -178,
+    -402,  -402,  -402,   -87,  -402,  -402,   -14,   -78,     2,    35,
+    -402,     7,   143,   238,   286,   398,   425,  -402,  -226,   462,
+     -20,  -402
 };
 
 /* YYDEFGOTO[NTERM-NUM].  */
 static const yytype_int16 yydefgoto[] =
 {
-       0,     3,     4,     5,    71,     6,   247,   154,   350,   415,
-     245,   346,   134,   333,   171,    34,    35,   552,   535,   553,
-      36,   323,   145,   324,    37,    38,   274,   275,   484,   424,
-      39,    40,    41,    42,   110,   182,    43,   229,    44,    45,
-      97,    98,   223,   236,   400,   243,   334,   123,   124,   264,
-      46,    47,    48,   202,    49,   165,    50,   259,    81,    52,
-     473,   474,    86,    87,    88,    77,    74,    75,   114,   115,
-     116,   468,   469,   203,   298,   299,   300,    53,   204,   205,
-     206,   470,   475,    54,    55,    56,    57,    58,    59,    60,
-     536,    61,    62,    63,    64,    65,    66,    67,   117,   131,
-     132,    68
+       0,     3,     4,     5,    71,     6,   249,   155,   354,   422,
+     247,   350,   135,   336,   172,    34,    35,   559,   542,   560,
+      36,   325,   146,   326,    37,    38,   276,   277,   492,   431,
+      39,    40,    41,    42,   111,   183,    43,   229,    44,    45,
+      97,    98,   224,   237,   406,   245,   337,   124,   125,   266,
+      46,    47,    48,   203,    49,   166,    50,   261,    81,    52,
+     481,   482,    86,    87,    88,    77,    74,    75,   115,   116,
+     117,   476,   477,   204,   300,   301,   302,    53,   205,   206,
+     207,   478,   483,    54,    55,    56,    57,    58,    59,    60,
+     543,    61,    62,    63,    64,    65,    66,    67,   118,   132,
+     133,    68
 };
 
 /* YYTABLE[YYPACT[STATE-NUM]] -- What to do in state STATE-NUM.  If
@@ -920,504 +921,538 @@ static const yytype_int16 yydefgoto[] =
    number is the opposite.  If YYTABLE_NINF, syntax error.  */
 static const yytype_int16 yytable[] =
 {
-      91,   174,   265,   198,   120,   348,   237,   146,   146,   416,
-      85,    94,   237,   242,   427,   296,   207,   119,    78,     7,
-      76,    76,   112,   169,    14,   155,   156,     7,   144,   150,
-      89,     7,     8,   241,   178,   309,   121,   125,   208,   140,
-     141,   235,   218,   297,   139,    24,     7,   240,    23,     1,
-      51,   193,   485,    24,    14,   142,     7,    24,    70,   122,
-     211,     2,   325,  -224,   558,   266,   559,  -299,    28,   282,
-     219,    14,    24,     2,   143,  -224,   212,   119,   326,    51,
-     162,   167,    24,    76,    89,     7,   127,   267,    85,   122,
-     320,   168,   146,   257,   207,   207,   283,   152,   146,   137,
-     169,    51,   213,   168,   408,   191,   230,   133,   311,   268,
-     319,    24,    89,   153,   207,   232,   208,   208,    31,   224,
-     378,   185,   327,   316,   318,   269,   209,    23,   225,   186,
-     251,    22,   226,   312,   227,   313,   208,   521,   211,   211,
-     157,    79,   304,   376,   146,   377,   151,    28,   187,   148,
-     188,   270,   159,   149,   212,   212,   237,   248,   211,   158,
-      76,   137,    51,   253,   534,   294,    80,    16,   538,   387,
-     260,   166,   295,    89,   212,   146,   348,   370,   342,   336,
-     213,   213,   146,   339,   340,   237,   397,   146,   137,   175,
-     306,   369,   140,   237,   388,   207,   313,   207,    23,   207,
-     213,   356,   329,   331,   209,   209,   396,    23,  -227,    23,
-     176,   357,    79,   177,   434,   297,   456,   208,    28,   208,
-     395,   208,   307,   308,   209,   192,  -227,    28,    92,    28,
-     160,   156,   328,   293,  -227,   374,   170,    80,   418,   211,
-     137,   211,   146,   211,  -227,   537,    93,   184,   419,   347,
-     412,   140,   413,   414,  -227,   212,   392,   212,   353,   212,
-     354,   390,   391,   194,   556,   146,   207,   207,   196,   549,
-     550,   146,   544,   545,   199,   546,   562,   563,   217,   146,
-     214,   213,   220,   213,   249,   213,   465,   466,   208,   208,
-     228,   467,   281,   237,   393,    23,   560,    23,   348,   254,
-     561,   256,   142,   287,   321,   209,   288,   209,   302,   209,
-     211,   211,   432,   433,   303,    28,   146,    28,   305,    96,
-     111,   143,   337,   322,   255,   156,   212,   212,   332,   271,
-     480,   481,   314,   452,   510,   511,   455,   431,   450,   451,
-     513,   511,   146,    82,    83,    84,   514,   168,   407,   146,
-     349,   146,   213,   213,   146,   335,   440,   341,   214,   214,
-     351,   420,    22,   426,   426,   352,   355,   361,   359,   507,
-     508,   265,   360,   265,   146,   215,   209,   209,   214,   146,
-     111,   362,   172,   173,   338,   366,   367,   186,   372,   179,
-     180,   183,   462,   463,   146,   144,   146,   371,   373,   375,
-     147,   147,   379,   380,   383,    82,   130,    95,   195,   515,
-     491,   492,   532,   533,   152,   401,   409,   222,   498,   555,
-     347,   402,   403,   477,   272,   410,   479,   404,   406,   504,
-     486,   417,   429,   222,   266,   436,   266,   146,    96,   222,
-     216,   421,   437,   505,   506,   438,   439,   570,   252,   146,
-     445,   146,   441,   215,   215,   442,   267,   446,   267,   214,
-     447,   214,   389,   214,   448,   277,   525,   278,   527,   528,
-     136,   280,   138,   215,   512,   284,   285,   286,   268,   516,
-     268,   453,   290,   460,   461,   147,   464,   426,   472,   273,
-     478,   147,   482,   483,   269,    69,   269,    72,   493,   487,
-     489,   490,   548,   495,   496,   497,   501,   502,   503,   517,
-     518,   310,   523,   526,   529,   222,   222,   540,   216,   216,
-     270,   542,   270,   330,   564,   197,   126,   565,   551,    73,
-     214,   214,   189,   190,   343,   411,   567,   147,   216,   449,
-     568,   569,   347,   509,   566,   135,   457,   405,   458,   113,
-     238,   459,   358,   541,   215,   163,   215,   161,   215,   231,
-     164,   261,   471,   250,   435,     0,    99,   118,   147,   363,
-     291,     0,   364,   365,   539,   147,     0,     0,     0,     0,
-     147,     0,   195,   222,     0,   258,     0,     0,     0,     0,
-       0,   499,     0,   500,   276,     0,     0,     0,     0,     0,
-       0,   382,     0,   384,   385,   386,     0,     7,     0,     0,
-       0,   289,   222,     0,     0,   210,   398,     0,     0,   216,
-       0,   216,   384,   216,     0,   215,   215,   118,     0,     0,
-       0,     0,     0,    24,   524,   147,   102,     0,   128,   104,
-     105,   106,   107,   129,   109,   246,   530,     0,   531,   425,
-     425,     0,   428,     0,     0,     0,   430,     0,   147,     0,
-       0,     0,     0,     0,   147,     8,     9,    10,    11,    12,
-      13,     0,   147,     0,     0,     0,     0,   444,    18,    19,
-      20,     0,     0,     0,    22,    99,   244,     0,     0,   454,
-     216,   216,     0,   210,   210,    25,     0,     0,   271,     0,
-     271,     0,     0,     8,     9,    10,    11,    12,    13,   147,
-       0,   262,     0,   210,   279,   263,    18,    19,    20,   488,
-       0,     0,    22,     0,     0,     0,     0,     0,     0,   292,
-       0,   494,     0,    25,     0,   147,     0,     0,   301,     0,
-       0,     0,   147,     0,   147,     0,     0,   147,     7,     0,
-       0,     0,     0,   263,     0,     0,   126,     0,     0,     0,
-       0,     0,     0,   244,     0,     0,     0,   147,     0,     0,
-     519,   520,   147,   425,    24,   522,     0,   102,     0,   128,
-     104,   105,   344,   107,   129,   109,     7,   147,     0,   147,
-     345,     0,     0,   272,   210,   272,   210,     0,   210,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,   543,     0,
-       0,     0,    24,   547,     0,   102,     0,   128,   104,   105,
-     344,   107,   129,   109,     0,   554,     0,   554,   476,     0,
-     147,     0,     0,     0,     0,     0,     0,     0,     0,   554,
-     554,     0,   147,     0,   147,   102,    95,   128,   104,   105,
-     106,   107,   129,   109,   130,     0,     0,     0,   273,   244,
-     273,   197,     0,     0,     0,   210,   210,     0,     0,   244,
-       0,     0,   244,     0,     0,     0,     0,     0,   244,     0,
-       0,     0,     7,     8,     9,    10,    11,    12,    13,     0,
-      14,    15,    16,    17,     0,     0,    18,    19,    20,    21,
-       0,   100,    22,    23,     0,     0,     0,     0,    24,   101,
-     301,   102,    95,   103,   104,   105,   106,   107,   108,   109,
-       0,    27,     0,    28,     0,    29,     0,     0,     0,    90,
-       0,     0,    32,    33,     7,     8,     9,    10,    11,    12,
-      13,     0,    14,    15,     0,     0,     0,     0,    18,    19,
-      20,    21,     0,   100,    22,    23,     0,     0,     0,     0,
-      24,   101,     0,   102,    95,   103,   104,   105,   106,   107,
-     129,   109,     0,    27,     0,    28,     0,    29,     0,     0,
-       0,    90,     0,     0,    32,    33,     7,     8,     9,    10,
-      11,    12,    13,     0,    14,    15,    16,    17,     0,     0,
-      18,    19,    20,    21,     0,     0,    22,    23,     0,     0,
-       0,     0,    24,     0,     0,     0,     0,    25,     0,     0,
-       0,     0,    26,     0,     0,    27,     0,    28,     0,    29,
-       0,     0,     0,    30,     0,    31,    32,    33,     7,     8,
+      91,   199,    94,   423,   121,   267,   236,   113,   243,    78,
+     120,    85,   242,   145,   151,   434,   360,    14,    76,    76,
+     170,   352,    23,   298,    51,   299,   361,   244,    89,   140,
+       7,   179,     7,     7,   122,   126,   208,    69,   186,    72,
+     141,   142,    28,   311,   175,   209,   187,    70,  -227,   194,
+      14,     7,     8,    51,    23,     2,   153,    24,   493,    24,
+      24,   143,     7,   238,   219,   188,   168,   189,   127,   238,
+     120,   163,   154,   138,    28,    51,   169,  -227,    24,  -303,
+     144,    76,    89,   327,   321,   268,   123,   317,   320,    24,
+      85,   192,   220,    23,   269,   259,   128,    23,   170,   328,
+       7,   156,   157,   322,   464,   169,   225,   230,    14,   134,
+     226,    89,   284,    28,   208,   208,   232,    28,    31,   295,
+      96,   112,   415,   209,   209,   210,   380,    24,   381,   382,
+     212,   253,    22,   227,   208,    79,   138,    51,    79,   285,
+     306,   329,   529,   209,   123,    23,   565,   152,   566,   313,
+     160,   296,    92,   374,   161,   157,   250,   373,   211,    76,
+     390,    80,   255,   138,    80,    28,   545,   149,     1,   262,
+      93,   150,    89,   297,   314,   541,   315,   346,    16,   270,
+       2,   112,   401,   173,   174,   391,   400,   315,   248,   334,
+     180,   308,   181,   184,   141,   425,   167,   352,   158,   441,
+     299,   402,   331,   210,   210,   426,   332,   176,   212,   212,
+     196,   257,   157,   341,   238,   138,   208,   159,   208,   223,
+     208,   309,   310,   210,   544,   209,   177,   209,   212,   209,
+     330,    23,   488,   489,   378,   223,   211,   211,   143,    23,
+      96,   223,   178,   238,   193,  -230,   323,   556,   557,   351,
+     254,    28,   238,   185,   141,   396,   211,   144,   357,    28,
+     358,   195,   147,   147,  -230,   324,   213,   279,   563,   280,
+     473,   474,  -230,   282,   171,   475,   197,   286,   287,   288,
+     569,   570,  -230,   200,   292,   218,    82,    83,    84,   208,
+     208,   392,  -230,   518,   519,   221,   397,   228,   209,   209,
+     127,   419,   251,   420,   421,   210,    22,   210,   283,   210,
+     212,   256,   212,   312,   212,   271,   223,   223,   258,   352,
+     551,   552,   289,   553,   290,   333,   438,   521,   519,   304,
+     148,   148,   522,   169,   305,   460,   356,   347,   211,   463,
+     211,   307,   211,   567,   213,   213,   340,   568,   147,   335,
+     414,   338,   345,   353,   147,   362,   238,   359,   355,   363,
+     447,   214,   364,   427,   213,   433,   433,   365,   366,   370,
+     371,   456,   367,   187,   375,   368,   369,   377,   210,   210,
+     267,   376,   267,   212,   212,   196,   223,   145,   379,   383,
+     470,   471,   384,   387,    82,   131,    95,   407,   153,   408,
+     147,   410,   416,   411,   386,   417,   388,   389,   413,   215,
+     272,   211,   211,   424,   523,   223,   148,   499,   500,   403,
+     515,   516,   148,   562,   505,   351,   388,   428,   485,   436,
+     147,   487,   443,   444,   445,   494,   446,   512,   147,   214,
+     214,   448,   513,   514,   147,   451,   213,   453,   213,   454,
+     213,   577,   455,   468,   432,   432,   461,   435,   273,   214,
+     268,   437,   268,   539,   540,   469,   472,   480,   148,   269,
+     486,   269,   490,   342,   533,   534,   535,   491,   495,   501,
+     520,   450,   502,   503,   504,   524,   497,   215,   215,   498,
+     509,    99,   119,   433,   510,   511,   462,   525,   148,   147,
+     526,   531,   536,   547,   198,   549,   148,   215,    73,   555,
+     572,   558,   148,   574,   418,   575,   517,   573,   239,   213,
+     213,   216,   147,   576,   136,   412,   114,   496,   147,   164,
+     252,   571,   548,   165,   479,   263,   293,   147,   162,   546,
+     442,   214,     0,   214,     0,   214,     0,   351,   217,     0,
+       0,   393,   119,     0,   270,     0,   270,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,   148,     0,     0,
+     274,     0,     0,     0,     0,   147,     0,     0,     0,   527,
+     528,     0,   432,     0,   530,     0,     0,     0,     0,   215,
+     148,   215,     0,   215,     0,     0,   148,   275,     0,   216,
+     216,     0,   147,     0,     0,   148,     0,     0,     0,     0,
+     147,    99,   246,   147,   214,   214,   147,   550,     0,   216,
+       0,     0,   554,     0,     0,     0,   217,   217,     0,     0,
+     137,   457,   139,   561,     0,   561,   147,     0,     0,   465,
+     281,   147,   466,   148,     0,   467,   217,   561,   561,     0,
+       0,     0,     0,     0,   339,   294,   147,     0,   147,   343,
+     344,     0,   215,   215,   303,     0,     0,     0,     0,     0,
+     148,     0,     0,     0,     0,     0,     0,     0,   148,     0,
+       0,   148,     0,     0,   148,   506,     0,   507,   246,     0,
+     271,     0,   271,   190,   191,     0,     0,     0,     0,     0,
+     147,   216,     0,   216,   148,   216,     0,     0,     0,   148,
+       0,     0,   147,     0,   147,     0,     0,     0,     0,     0,
+     231,     0,     0,     0,   148,     0,   148,     0,   217,   532,
+     217,     0,   217,     0,     0,     0,     0,   394,   395,     0,
+       0,   537,     0,   538,     0,     0,   260,     8,     9,    10,
+      11,    12,    13,     0,     0,   278,     0,     0,     0,     0,
+      18,    19,    20,     0,     0,     0,     0,    22,   148,     0,
+       0,     0,   291,     0,   216,   216,     0,     0,    25,     0,
+     148,     0,   148,     0,     0,   272,   246,   272,     0,     0,
+     439,   440,     0,     7,   264,     0,     0,   246,   265,     0,
+     246,   217,   217,     0,     0,     0,     0,   246,     0,     0,
+       0,   100,     0,     0,     0,     0,     0,   458,   459,     0,
+      24,     0,     0,   103,     0,   129,   105,   106,   348,   108,
+     130,   110,     0,   273,     0,   273,   349,     0,     0,   303,
+       7,     8,     9,    10,    11,    12,    13,     0,    14,    15,
+      16,    17,     0,     0,    18,    19,    20,    21,   100,     0,
+     101,    22,    23,     0,     0,     0,     0,    24,   102,     0,
+     103,    95,   104,   105,   106,   107,   108,   109,   110,     0,
+      27,     0,    28,     0,    29,     0,     0,     0,    90,     0,
+       0,    32,    33,     0,     0,     0,     0,     0,     7,     8,
        9,    10,    11,    12,    13,     0,    14,    15,     0,     0,
-       0,     0,    18,    19,    20,    21,     0,     0,    22,    23,
+       0,     0,    18,    19,    20,    21,   100,     0,   101,    22,
+      23,     0,     0,     0,     0,    24,   102,     0,   103,    95,
+     104,   105,   106,   107,   108,   130,   110,     0,    27,     0,
+      28,     0,    29,     0,     0,   274,    90,   274,     0,    32,
+      33,     0,     0,     0,     7,     8,     9,    10,    11,    12,
+      13,     0,    14,    15,    16,    17,     0,     0,    18,    19,
+      20,    21,   275,     0,   275,    22,    23,     0,     0,     0,
+       0,    24,     0,     0,     0,     0,    25,     0,     0,     0,
+       0,    26,     0,     0,    27,     0,    28,     0,    29,     0,
+       0,     0,    30,     0,    31,    32,    33,     7,     8,     9,
+      10,    11,    12,    13,     0,    14,    15,     0,     0,     0,
+       0,    18,    19,    20,    21,   240,     0,     0,    22,    23,
        0,     0,     0,     0,    24,     0,     0,     0,    95,    25,
-       0,     0,   233,     0,     0,     0,     0,    27,     0,    28,
-       0,    29,     0,     0,     0,    90,   239,     0,    32,    33,
+       0,     0,   234,     0,     0,     0,     0,    27,     0,    28,
+       0,    29,     0,     0,     0,    90,   241,     0,    32,    33,
        7,     8,     9,    10,    11,    12,    13,     0,    14,    15,
-       0,     0,     0,     0,    18,    19,    20,    21,     0,     0,
-      22,    23,     0,     0,     0,     0,    24,     0,     0,     0,
-      95,    25,     0,     0,   233,     0,     0,     0,     0,    27,
-       0,    28,     0,    29,     0,     0,     0,    90,   317,     0,
-      32,    33,     7,     8,     9,    10,    11,    12,    13,     0,
-      14,    15,     0,     0,     0,     0,    18,    19,    20,    21,
-       0,     0,    22,    23,     0,     0,     0,     0,    24,     0,
-       0,     0,    95,    25,     0,     0,   233,     0,     0,     0,
-       0,    27,     0,    28,     0,    29,     0,     0,     0,    90,
-     394,     0,    32,    33,     7,     8,     9,    10,    11,    12,
-      13,     0,    14,    15,    16,     0,     0,     0,    18,    19,
-      20,    21,     0,     0,    22,    23,     0,     0,     0,     0,
-      24,     0,     0,     0,     0,    25,     0,     0,     0,     0,
+       0,     0,     0,     0,    18,    19,    20,    21,   318,     0,
+       0,    22,    23,     0,     0,     0,     0,    24,     0,     0,
+       0,    95,    25,     0,     0,   234,     0,     0,     0,     0,
+      27,     0,    28,     0,    29,     0,     0,     0,    90,   319,
+       0,    32,    33,     7,     8,     9,    10,    11,    12,    13,
+       0,    14,    15,     0,     0,     0,     0,    18,    19,    20,
+      21,   398,     0,     0,    22,    23,     0,     0,     0,     0,
+      24,     0,     0,     0,    95,    25,     0,     0,   234,     0,
        0,     0,     0,    27,     0,    28,     0,    29,     0,     0,
-       0,    90,     0,    31,    32,    33,     7,     8,     9,    10,
+       0,    90,   399,     0,    32,    33,     7,     8,     9,    10,
       11,    12,    13,     0,    14,    15,     0,     0,     0,     0,
-      18,    19,    20,    21,     0,     0,    22,    23,     0,     0,
-       0,     0,    24,     0,     0,     0,     0,    25,     0,     0,
-     233,     0,     0,     0,     0,    27,     0,    28,     0,    29,
-       0,     0,     0,    90,   234,     0,    32,    33,     7,     8,
-       9,    10,    11,    12,    13,     0,    14,    15,     0,     0,
-       0,     0,    18,    19,    20,    21,     0,     0,    22,    23,
-       0,     0,     0,     0,    24,     0,     0,     0,     0,    25,
-       0,     0,   233,     0,     0,     0,     0,    27,     0,    28,
-       0,    29,     0,     0,     0,    90,   368,     0,    32,    33,
-       7,     8,     9,    10,    11,    12,    13,     0,    14,    15,
-       0,     0,     0,     0,    18,    19,    20,    21,     0,     0,
-      22,    23,     0,     0,     0,     0,    24,     0,     0,     0,
-      95,    25,     0,     0,   399,     0,     0,     0,     0,    27,
-       0,    28,     0,    29,     0,     0,     0,    90,     0,     0,
-      32,    33,     7,     8,     9,    10,    11,    12,    13,     0,
-      14,    15,   422,     0,     0,     0,    18,    19,    20,    21,
-       0,     0,    22,    23,     0,     0,     0,     0,    24,   423,
-       0,     0,     0,    25,     0,     0,     0,     0,     0,     0,
-       0,    27,     0,    28,     0,    29,     0,     0,     0,    90,
-       0,     0,    32,    33,     7,     8,     9,    10,    11,    12,
-      13,     0,    14,    15,     0,     0,     0,     0,    18,    19,
-      20,    21,     0,     0,    22,    23,     0,     0,     0,     0,
-      24,     0,     0,     0,    95,    25,     0,     0,     0,     0,
-       0,     0,     0,    27,     0,    28,     0,    29,     0,     0,
-       0,    90,     0,     0,    32,    33,     7,     8,     9,    10,
-      11,    12,    13,     0,    14,    15,     0,     0,     0,     0,
-      18,    19,    20,    21,     0,   181,    22,    23,     0,     0,
-       0,     0,    24,     0,     0,     0,     0,    25,     0,     0,
-       0,     0,     0,     0,     0,    27,     0,    28,     0,    29,
-       0,     0,     0,    90,     0,     0,    32,    33,     7,     8,
-       9,    10,    11,    12,    13,     0,    14,    15,     0,     0,
-       0,     0,    18,    19,    20,    21,     0,   221,    22,    23,
-       0,     0,     0,     0,    24,     0,     0,     0,     0,    25,
-       0,     0,     0,     0,     0,     0,     0,    27,     0,    28,
-       0,    29,     0,     0,     0,    90,     0,     0,    32,    33,
-       7,     8,     9,    10,    11,    12,    13,     0,    14,    15,
-       0,     0,     0,     0,    18,    19,    20,    21,     0,   315,
+      18,    19,    20,    21,   233,     0,     0,    22,    23,     0,
+       0,     0,     0,    24,     0,     0,     0,     0,    25,     0,
+       0,   234,     0,     0,     0,     0,    27,     0,    28,     0,
+      29,     0,     0,     0,    90,   235,     0,    32,    33,     7,
+       8,     9,    10,    11,    12,    13,     0,    14,    15,    16,
+       0,     0,     0,    18,    19,    20,    21,     0,     0,     0,
       22,    23,     0,     0,     0,     0,    24,     0,     0,     0,
        0,    25,     0,     0,     0,     0,     0,     0,     0,    27,
-       0,    28,     0,    29,     0,     0,     0,    90,     0,     0,
+       0,    28,     0,    29,     0,     0,     0,    90,     0,    31,
       32,    33,     7,     8,     9,    10,    11,    12,    13,     0,
       14,    15,     0,     0,     0,     0,    18,    19,    20,    21,
+       0,     0,     0,    22,    23,     0,     0,     0,     0,    24,
+       0,     0,     0,     0,    25,     0,     0,   234,     0,     0,
+       0,     0,    27,     0,    28,     0,    29,     0,     0,     0,
+      90,   372,     0,    32,    33,     7,     8,     9,    10,    11,
+      12,    13,     0,    14,    15,     0,     0,     0,     0,    18,
+      19,    20,    21,     0,     0,     0,    22,    23,     0,     0,
+       0,     0,    24,     0,     0,     0,    95,    25,     0,     0,
+     405,     0,     0,     0,     0,    27,     0,    28,     0,    29,
+       0,     0,     0,    90,     0,     0,    32,    33,     7,     8,
+       9,    10,    11,    12,    13,     0,    14,    15,   429,     0,
+       0,     0,    18,    19,    20,    21,     0,     0,     0,    22,
+      23,     0,     0,     0,     0,    24,   430,     0,     0,     0,
+      25,     0,     0,     0,     0,     0,     0,     0,    27,     0,
+      28,     0,    29,     0,     0,     0,    90,     0,     0,    32,
+      33,     7,     8,     9,    10,    11,    12,    13,     0,    14,
+      15,     0,     0,     0,     0,    18,    19,    20,    21,     0,
        0,     0,    22,    23,     0,     0,     0,     0,    24,     0,
-       0,     0,     0,    25,     0,     0,     0,     0,     0,     0,
-       0,    27,     0,    28,     0,    29,   381,     0,     0,    90,
+       0,     0,    95,    25,     0,     0,     0,     0,     0,     0,
+       0,    27,     0,    28,     0,    29,     0,     0,     0,    90,
        0,     0,    32,    33,     7,     8,     9,    10,    11,    12,
       13,     0,    14,    15,     0,     0,     0,     0,    18,    19,
-      20,    21,     0,     0,    22,    23,     0,     0,     0,     0,
-      24,     0,     0,     0,     0,    25,     0,     0,     0,     0,
-       0,     0,     0,    27,     0,    28,     0,    29,   443,     0,
-       0,    90,     0,     0,    32,    33,     7,     8,     9,    10,
-      11,    12,    13,     0,    14,    15,     0,     0,     0,     0,
-      18,    19,    20,    21,     0,     0,    22,    23,     0,     0,
-       0,     0,    24,     0,     0,     0,     0,    25,     0,     0,
-       0,     0,     0,     0,     0,    27,     0,    28,     0,    29,
-       0,     0,     0,    90,     0,   551,    32,    33,     7,     8,
-       9,    10,    11,    12,    13,     0,    14,    15,     0,     0,
-       0,     0,    18,    19,    20,    21,     0,     0,    22,    23,
+      20,    21,     0,     0,   182,    22,    23,     0,     0,     0,
+       0,    24,     0,     0,     0,     0,    25,     0,     0,     0,
+       0,     0,     0,     0,    27,     0,    28,     0,    29,     0,
+       0,     0,    90,     0,     0,    32,    33,     7,     8,     9,
+      10,    11,    12,    13,     0,    14,    15,     0,     0,     0,
+       0,    18,    19,    20,    21,     0,     0,   222,    22,    23,
        0,     0,     0,     0,    24,     0,     0,     0,     0,    25,
        0,     0,     0,     0,     0,     0,     0,    27,     0,    28,
        0,    29,     0,     0,     0,    90,     0,     0,    32,    33,
-       7,     8,     9,    10,    11,    12,    13,     0,    14,     0,
-       0,     0,     0,     0,    18,    19,    20,     0,     0,     0,
-      22,     0,     0,     0,     0,     0,    24,     0,     0,     0,
-      95,    25,     0,     0,     7,     8,     9,    10,    11,    12,
-      13,     0,    14,   200,     0,     0,     0,   201,    18,    19,
-      20,     0,     0,     7,    22,     0,     0,     0,     0,     0,
-      24,     0,     0,     0,     0,    25,   102,    95,   128,   104,
-     105,   106,   107,   129,   109,   130,     0,   200,     0,    24,
-       0,   201,   102,     0,   128,   104,   105,   344,   107,   129,
-     109,     0,     0,     0,     0,   557
+       7,     8,     9,    10,    11,    12,    13,     0,    14,    15,
+       0,     0,     0,     0,    18,    19,    20,    21,     0,     0,
+     316,    22,    23,     0,     0,     0,     0,    24,     0,     0,
+       0,     0,    25,     0,     0,     0,     0,     0,     0,     0,
+      27,     0,    28,     0,    29,     0,     0,     0,    90,     0,
+       0,    32,    33,     7,     8,     9,    10,    11,    12,    13,
+       0,    14,    15,     0,     0,     0,     0,    18,    19,    20,
+      21,     0,     0,     0,    22,    23,     0,     0,     0,     0,
+      24,     0,     0,     0,     0,    25,     0,     0,     0,     0,
+       0,     0,     0,    27,     0,    28,     0,    29,   385,     0,
+       0,    90,     0,     0,    32,    33,     7,     8,     9,    10,
+      11,    12,    13,     0,    14,    15,     0,     0,     0,     0,
+      18,    19,    20,    21,     0,     0,     0,    22,    23,     0,
+       0,     0,     0,    24,     0,     0,     0,     0,    25,     0,
+       0,     0,     0,     0,     0,     0,    27,     0,    28,     0,
+      29,   449,     0,     0,    90,     0,     0,    32,    33,     7,
+       8,     9,    10,    11,    12,    13,     0,    14,    15,     0,
+       0,     0,     0,    18,    19,    20,    21,     0,     0,     0,
+      22,    23,     0,     0,     0,     0,    24,     0,     0,     0,
+       0,    25,     0,     0,     0,     0,     0,     0,     0,    27,
+       0,    28,     0,    29,     0,     0,     0,    90,     0,   558,
+      32,    33,     7,     8,     9,    10,    11,    12,    13,     0,
+      14,    15,     0,     0,     0,     0,    18,    19,    20,    21,
+       0,     0,     0,    22,    23,     0,     0,     0,     0,    24,
+       0,     0,     0,     0,    25,     0,     0,     0,     0,     0,
+       0,     0,    27,     0,    28,     0,    29,     0,     0,     0,
+      90,     0,     0,    32,    33,     8,     9,    10,    11,    12,
+      13,     0,     0,     0,     0,     0,     0,     0,    18,    19,
+      20,     0,     0,     0,     0,    22,     7,     8,     9,    10,
+      11,    12,    13,     0,    14,     0,    25,     0,     0,     0,
+      18,    19,    20,     0,     0,     0,     0,    22,     0,     0,
+       0,     0,     0,    24,     0,     0,   265,    95,    25,     0,
+       0,     7,     8,     9,    10,    11,    12,    13,     0,    14,
+     201,     0,     0,     0,   202,    18,    19,    20,     0,     0,
+       7,     0,    22,     0,     0,     0,     0,     0,    24,     0,
+       0,     0,     0,    25,     0,     0,     0,     0,   100,     0,
+       0,     7,     0,     0,     0,   201,     0,    24,     0,   202,
+     103,     0,   129,   105,   106,   348,   108,   130,   110,   100,
+       0,     0,     7,   484,     0,     0,     0,     0,    24,     0,
+       0,   103,     0,   129,   105,   106,   348,   108,   130,   110,
+     100,     0,     0,     0,   564,     0,     0,     0,     0,    24,
+     100,     0,   103,     0,   129,   105,   106,   107,   108,   130,
+     110,     0,   103,    95,   129,   105,   106,   107,   108,   130,
+     110,   131,   100,     0,     0,     0,     0,     0,     0,     0,
+       0,   404,     0,     0,   103,    95,   129,   105,   106,   107,
+     108,   130,   110,   131,   100,     0,     0,     0,     0,     0,
+       0,     0,     0,   409,     0,     0,   103,    95,   129,   105,
+     106,   107,   108,   130,   110,   131,   100,     0,     0,     0,
+       0,     0,     0,     0,     0,   452,     0,     0,   103,    95,
+     129,   105,   106,   107,   108,   130,   110,   131,   100,     0,
+       0,     0,     0,     0,     0,     0,     0,   508,     0,     0,
+     103,    95,   129,   105,   106,   107,   108,   130,   110,   131,
+     100,     0,     0,     0,     0,     0,   198,     0,     0,     0,
+       0,     0,   103,    95,   129,   105,   106,   107,   108,   130,
+     110,   131
 };
 
 static const yytype_int16 yycheck[] =
 {
-      27,    94,   171,   120,    31,   245,   144,    59,    60,   350,
-      25,    28,   150,   149,   360,   200,   122,    30,    17,     3,
-      16,    17,    30,    87,    11,    48,    49,     3,    59,    60,
-      26,     3,     4,   149,    98,   220,    32,    33,   122,    54,
-      55,   143,    21,   201,    52,    29,     3,   149,    24,    26,
-       1,   115,    28,    29,    11,    31,     3,    29,     0,    46,
-     122,    38,    34,    21,   540,   171,   542,    51,    44,    22,
-      49,    11,    29,    38,    50,    21,   122,    90,    50,    30,
-      79,    39,    29,    79,    80,     3,    46,   171,   103,    46,
-     226,    49,   144,    39,   200,   201,    49,    30,   150,    50,
-     164,    52,   122,    49,   344,   113,   133,    48,    22,   171,
-     226,    29,   108,    46,   220,   142,   200,   201,    52,    37,
-     305,    22,   228,   225,   226,   171,   122,    24,    46,    30,
-     157,    23,    50,    47,   130,    49,   220,   483,   200,   201,
-      31,    14,   206,   301,   196,   303,    44,    44,    49,    46,
-      51,   171,    21,    50,   200,   201,   294,   153,   220,    50,
-     156,   112,   113,   159,    10,   196,    39,    13,   509,    22,
-     166,    21,   199,   169,   220,   227,   416,   293,   242,   236,
-     200,   201,   234,   240,   241,   323,   322,   239,   139,    30,
-     217,   293,   207,   331,    47,   301,    49,   303,    24,   305,
-     220,    39,   229,   234,   200,   201,   322,    24,     3,    24,
-      47,    49,    14,    49,   372,   373,    31,   301,    44,   303,
-     322,   305,   218,   219,   220,    49,    21,    44,    30,    44,
-      48,    49,   228,    50,    29,   299,    31,    39,    39,   301,
-     191,   303,   294,   305,    39,   508,    48,    51,    49,   245,
-      13,   266,    15,    16,    49,   301,   320,   303,   254,   305,
-     256,   318,   319,    51,   537,   317,   372,   373,    51,   532,
-     533,   323,   519,   520,    31,   522,   549,   550,    31,   331,
-     122,   301,    46,   303,    44,   305,    35,    36,   372,   373,
-      41,    40,    51,   431,   321,    24,   543,    24,   538,    21,
-     547,    21,    31,    51,    31,   301,    51,   303,    47,   305,
-     372,   373,   369,   370,    49,    44,   368,    44,    46,    29,
-      30,    50,    47,    50,    48,    49,   372,   373,    49,   171,
-      29,    30,    50,   397,    48,    49,   400,   368,   395,   396,
-      48,    49,   394,     4,     5,     6,    48,    49,   344,   401,
-      47,   403,   372,   373,   406,    49,   383,    49,   200,   201,
-      51,   357,    23,   359,   360,    48,    45,    45,    49,   462,
-     463,   540,    49,   542,   426,   122,   372,   373,   220,   431,
-      90,    30,    92,    93,   239,    22,    51,    30,    30,    99,
-     100,   101,   409,   410,   446,   426,   448,    47,    49,    51,
-      59,    60,    47,    47,    31,     4,    41,    33,   118,   473,
-     437,   438,   505,   506,    30,    51,    44,   127,   445,   536,
-     416,    51,    51,   419,   171,    44,   422,    51,    51,   456,
-     426,    48,    22,   143,   540,    47,   542,   489,   148,   149,
-     122,    51,    31,   460,   461,    31,    47,   564,   158,   501,
-      31,   503,    49,   200,   201,    47,   540,    51,   542,   301,
-      51,   303,   317,   305,    51,   175,   493,   177,   495,   496,
-      50,   181,    52,   220,   470,   185,   186,   187,   540,   475,
-     542,    51,   192,    44,    44,   144,    44,   483,    35,   171,
-      39,   150,    45,    49,   540,     2,   542,     4,    31,    45,
-      51,    51,   529,    31,    31,    47,    51,    51,    51,    39,
-      31,   221,    28,    51,    31,   225,   226,    31,   200,   201,
-     540,    31,   542,   233,   551,    48,    33,    45,    52,     5,
-     372,   373,   112,   113,   244,   349,    45,   196,   220,   394,
-      45,    45,   538,   464,   554,    45,   401,   341,   403,    30,
-     148,   406,   262,   515,   301,    80,   303,    79,   305,   139,
-      80,   169,   413,   156,   373,    -1,    29,    30,   227,   279,
-     192,    -1,   282,   283,   511,   234,    -1,    -1,    -1,    -1,
-     239,    -1,   292,   293,    -1,   165,    -1,    -1,    -1,    -1,
-      -1,   446,    -1,   448,   174,    -1,    -1,    -1,    -1,    -1,
-      -1,   311,    -1,   313,   314,   315,    -1,     3,    -1,    -1,
-      -1,   191,   322,    -1,    -1,   122,   326,    -1,    -1,   301,
-      -1,   303,   332,   305,    -1,   372,   373,    90,    -1,    -1,
-      -1,    -1,    -1,    29,   489,   294,    32,    -1,    34,    35,
-      36,    37,    38,    39,    40,   152,   501,    -1,   503,   359,
-     360,    -1,   362,    -1,    -1,    -1,   366,    -1,   317,    -1,
-      -1,    -1,    -1,    -1,   323,     4,     5,     6,     7,     8,
-       9,    -1,   331,    -1,    -1,    -1,    -1,   387,    17,    18,
-      19,    -1,    -1,    -1,    23,   148,   149,    -1,    -1,   399,
-     372,   373,    -1,   200,   201,    34,    -1,    -1,   540,    -1,
-     542,    -1,    -1,     4,     5,     6,     7,     8,     9,   368,
-      -1,    50,    -1,   220,   177,    54,    17,    18,    19,   429,
-      -1,    -1,    23,    -1,    -1,    -1,    -1,    -1,    -1,   192,
-      -1,   441,    -1,    34,    -1,   394,    -1,    -1,   201,    -1,
-      -1,    -1,   401,    -1,   403,    -1,    -1,   406,     3,    -1,
-      -1,    -1,    -1,    54,    -1,    -1,   263,    -1,    -1,    -1,
-      -1,    -1,    -1,   226,    -1,    -1,    -1,   426,    -1,    -1,
-     480,   481,   431,   483,    29,   485,    -1,    32,    -1,    34,
-      35,    36,    37,    38,    39,    40,     3,   446,    -1,   448,
-      45,    -1,    -1,   540,   301,   542,   303,    -1,   305,    -1,
-      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   518,    -1,
-      -1,    -1,    29,   523,    -1,    32,    -1,    34,    35,    36,
-      37,    38,    39,    40,    -1,   535,    -1,   537,    45,    -1,
-     489,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   549,
-     550,    -1,   501,    -1,   503,    32,    33,    34,    35,    36,
-      37,    38,    39,    40,    41,    -1,    -1,    -1,   540,   322,
-     542,    48,    -1,    -1,    -1,   372,   373,    -1,    -1,   332,
-      -1,    -1,   335,    -1,    -1,    -1,    -1,    -1,   341,    -1,
-      -1,    -1,     3,     4,     5,     6,     7,     8,     9,    -1,
-      11,    12,    13,    14,    -1,    -1,    17,    18,    19,    20,
-      -1,    22,    23,    24,    -1,    -1,    -1,    -1,    29,    30,
-     373,    32,    33,    34,    35,    36,    37,    38,    39,    40,
-      -1,    42,    -1,    44,    -1,    46,    -1,    -1,    -1,    50,
-      -1,    -1,    53,    54,     3,     4,     5,     6,     7,     8,
-       9,    -1,    11,    12,    -1,    -1,    -1,    -1,    17,    18,
-      19,    20,    -1,    22,    23,    24,    -1,    -1,    -1,    -1,
-      29,    30,    -1,    32,    33,    34,    35,    36,    37,    38,
-      39,    40,    -1,    42,    -1,    44,    -1,    46,    -1,    -1,
-      -1,    50,    -1,    -1,    53,    54,     3,     4,     5,     6,
-       7,     8,     9,    -1,    11,    12,    13,    14,    -1,    -1,
-      17,    18,    19,    20,    -1,    -1,    23,    24,    -1,    -1,
-      -1,    -1,    29,    -1,    -1,    -1,    -1,    34,    -1,    -1,
-      -1,    -1,    39,    -1,    -1,    42,    -1,    44,    -1,    46,
-      -1,    -1,    -1,    50,    -1,    52,    53,    54,     3,     4,
+      27,   121,    28,   354,    31,   172,   144,    30,   150,    17,
+      30,    25,   150,    59,    60,   364,    40,    11,    16,    17,
+      87,   247,    25,   201,     1,   202,    50,   150,    26,    52,
+       3,    98,     3,     3,    32,    33,   123,     2,    23,     4,
+      54,    55,    45,   221,    94,   123,    31,     0,    22,   116,
+      11,     3,     4,    30,    25,    39,    31,    30,    29,    30,
+      30,    32,     3,   145,    22,    50,    40,    52,    33,   151,
+      90,    79,    47,    50,    45,    52,    50,    22,    30,    52,
+      51,    79,    80,    35,   226,   172,    47,   225,   226,    30,
+     104,   114,    50,    25,   172,    40,    47,    25,   165,    51,
+       3,    49,    50,   226,    32,    50,    47,   134,    11,    49,
+      51,   109,    23,    45,   201,   202,   143,    45,    53,    51,
+      29,    30,   348,   201,   202,   123,   303,    30,   305,   307,
+     123,   158,    24,   131,   221,    14,   113,   114,    14,    50,
+     207,   228,   491,   221,    47,    25,   547,    45,   549,    23,
+      22,   197,    31,   295,    49,    50,   154,   295,   123,   157,
+      23,    40,   160,   140,    40,    45,   517,    47,    27,   167,
+      49,    51,   170,   200,    48,    10,    50,   244,    13,   172,
+      39,    90,   324,    92,    93,    48,   324,    50,   153,   235,
+      99,   218,   101,   102,   208,    40,    22,   423,    32,   376,
+     377,   324,   229,   201,   202,    50,   233,    31,   201,   202,
+     119,    49,    50,   240,   296,   192,   303,    51,   305,   128,
+     307,   219,   220,   221,   516,   303,    48,   305,   221,   307,
+     228,    25,    30,    31,   301,   144,   201,   202,    32,    25,
+     149,   150,    50,   325,    50,     3,    32,   539,   540,   247,
+     159,    45,   334,    52,   268,   322,   221,    51,   256,    45,
+     258,    52,    59,    60,    22,    51,   123,   176,   544,   178,
+      36,    37,    30,   182,    32,    41,    52,   186,   187,   188,
+     556,   557,    40,    32,   193,    32,     4,     5,     6,   376,
+     377,   318,    50,    49,    50,    47,   323,    42,   376,   377,
+     265,    13,    45,    15,    16,   303,    24,   305,    52,   307,
+     303,    22,   305,   222,   307,   172,   225,   226,    22,   545,
+     527,   528,    52,   530,    52,   234,   372,    49,    50,    48,
+      59,    60,    49,    50,    50,   402,    49,   246,   303,   406,
+     305,    47,   307,   550,   201,   202,    48,   554,   145,    50,
+     348,    50,    50,    48,   151,   264,   438,    46,    52,    50,
+     387,   123,    50,   361,   221,   363,   364,    46,    31,    23,
+      52,   398,   281,    31,    48,   284,   285,    50,   376,   377,
+     547,    31,   549,   376,   377,   294,   295,   433,    52,    48,
+     416,   417,    48,    32,     4,    42,    34,    52,    31,    52,
+     197,    52,    45,    52,   313,    45,   315,   316,    52,   123,
+     172,   376,   377,    49,   481,   324,   145,   444,   445,   328,
+     470,   471,   151,   543,   451,   423,   335,    52,   426,    23,
+     227,   429,    48,    32,    32,   433,    48,   464,   235,   201,
+     202,    48,   468,   469,   241,    32,   303,    52,   305,    52,
+     307,   571,    52,    45,   363,   364,    52,   366,   172,   221,
+     547,   370,   549,   513,   514,    45,    45,    36,   197,   547,
+      40,   549,    46,   241,   501,   502,   503,    50,    46,    32,
+     478,   390,    32,    32,    48,   483,    52,   201,   202,    52,
+      52,    29,    30,   491,    52,    52,   405,    40,   227,   296,
+      32,    29,    32,    32,    49,    32,   235,   221,     5,   536,
+      46,    53,   241,    46,   353,    46,   472,   561,   149,   376,
+     377,   123,   319,    46,    45,   345,    30,   436,   325,    80,
+     157,   558,   523,    80,   420,   170,   193,   334,    79,   519,
+     377,   303,    -1,   305,    -1,   307,    -1,   545,   123,    -1,
+      -1,   319,    90,    -1,   547,    -1,   549,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,   296,    -1,    -1,
+     172,    -1,    -1,    -1,    -1,   372,    -1,    -1,    -1,   488,
+     489,    -1,   491,    -1,   493,    -1,    -1,    -1,    -1,   303,
+     319,   305,    -1,   307,    -1,    -1,   325,   172,    -1,   201,
+     202,    -1,   399,    -1,    -1,   334,    -1,    -1,    -1,    -1,
+     407,   149,   150,   410,   376,   377,   413,   526,    -1,   221,
+      -1,    -1,   531,    -1,    -1,    -1,   201,   202,    -1,    -1,
+      50,   399,    52,   542,    -1,   544,   433,    -1,    -1,   407,
+     178,   438,   410,   372,    -1,   413,   221,   556,   557,    -1,
+      -1,    -1,    -1,    -1,   237,   193,   453,    -1,   455,   242,
+     243,    -1,   376,   377,   202,    -1,    -1,    -1,    -1,    -1,
+     399,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   407,    -1,
+      -1,   410,    -1,    -1,   413,   453,    -1,   455,   226,    -1,
+     547,    -1,   549,   113,   114,    -1,    -1,    -1,    -1,    -1,
+     497,   303,    -1,   305,   433,   307,    -1,    -1,    -1,   438,
+      -1,    -1,   509,    -1,   511,    -1,    -1,    -1,    -1,    -1,
+     140,    -1,    -1,    -1,   453,    -1,   455,    -1,   303,   497,
+     305,    -1,   307,    -1,    -1,    -1,    -1,   320,   321,    -1,
+      -1,   509,    -1,   511,    -1,    -1,   166,     4,     5,     6,
+       7,     8,     9,    -1,    -1,   175,    -1,    -1,    -1,    -1,
+      17,    18,    19,    -1,    -1,    -1,    -1,    24,   497,    -1,
+      -1,    -1,   192,    -1,   376,   377,    -1,    -1,    35,    -1,
+     509,    -1,   511,    -1,    -1,   547,   324,   549,    -1,    -1,
+     373,   374,    -1,     3,    51,    -1,    -1,   335,    55,    -1,
+     338,   376,   377,    -1,    -1,    -1,    -1,   345,    -1,    -1,
+      -1,    21,    -1,    -1,    -1,    -1,    -1,   400,   401,    -1,
+      30,    -1,    -1,    33,    -1,    35,    36,    37,    38,    39,
+      40,    41,    -1,   547,    -1,   549,    46,    -1,    -1,   377,
+       3,     4,     5,     6,     7,     8,     9,    -1,    11,    12,
+      13,    14,    -1,    -1,    17,    18,    19,    20,    21,    -1,
+      23,    24,    25,    -1,    -1,    -1,    -1,    30,    31,    -1,
+      33,    34,    35,    36,    37,    38,    39,    40,    41,    -1,
+      43,    -1,    45,    -1,    47,    -1,    -1,    -1,    51,    -1,
+      -1,    54,    55,    -1,    -1,    -1,    -1,    -1,     3,     4,
        5,     6,     7,     8,     9,    -1,    11,    12,    -1,    -1,
-      -1,    -1,    17,    18,    19,    20,    -1,    -1,    23,    24,
-      -1,    -1,    -1,    -1,    29,    -1,    -1,    -1,    33,    34,
-      -1,    -1,    37,    -1,    -1,    -1,    -1,    42,    -1,    44,
-      -1,    46,    -1,    -1,    -1,    50,    51,    -1,    53,    54,
+      -1,    -1,    17,    18,    19,    20,    21,    -1,    23,    24,
+      25,    -1,    -1,    -1,    -1,    30,    31,    -1,    33,    34,
+      35,    36,    37,    38,    39,    40,    41,    -1,    43,    -1,
+      45,    -1,    47,    -1,    -1,   547,    51,   549,    -1,    54,
+      55,    -1,    -1,    -1,     3,     4,     5,     6,     7,     8,
+       9,    -1,    11,    12,    13,    14,    -1,    -1,    17,    18,
+      19,    20,   547,    -1,   549,    24,    25,    -1,    -1,    -1,
+      -1,    30,    -1,    -1,    -1,    -1,    35,    -1,    -1,    -1,
+      -1,    40,    -1,    -1,    43,    -1,    45,    -1,    47,    -1,
+      -1,    -1,    51,    -1,    53,    54,    55,     3,     4,     5,
+       6,     7,     8,     9,    -1,    11,    12,    -1,    -1,    -1,
+      -1,    17,    18,    19,    20,    21,    -1,    -1,    24,    25,
+      -1,    -1,    -1,    -1,    30,    -1,    -1,    -1,    34,    35,
+      -1,    -1,    38,    -1,    -1,    -1,    -1,    43,    -1,    45,
+      -1,    47,    -1,    -1,    -1,    51,    52,    -1,    54,    55,
+       3,     4,     5,     6,     7,     8,     9,    -1,    11,    12,
+      -1,    -1,    -1,    -1,    17,    18,    19,    20,    21,    -1,
+      -1,    24,    25,    -1,    -1,    -1,    -1,    30,    -1,    -1,
+      -1,    34,    35,    -1,    -1,    38,    -1,    -1,    -1,    -1,
+      43,    -1,    45,    -1,    47,    -1,    -1,    -1,    51,    52,
+      -1,    54,    55,     3,     4,     5,     6,     7,     8,     9,
+      -1,    11,    12,    -1,    -1,    -1,    -1,    17,    18,    19,
+      20,    21,    -1,    -1,    24,    25,    -1,    -1,    -1,    -1,
+      30,    -1,    -1,    -1,    34,    35,    -1,    -1,    38,    -1,
+      -1,    -1,    -1,    43,    -1,    45,    -1,    47,    -1,    -1,
+      -1,    51,    52,    -1,    54,    55,     3,     4,     5,     6,
+       7,     8,     9,    -1,    11,    12,    -1,    -1,    -1,    -1,
+      17,    18,    19,    20,    21,    -1,    -1,    24,    25,    -1,
+      -1,    -1,    -1,    30,    -1,    -1,    -1,    -1,    35,    -1,
+      -1,    38,    -1,    -1,    -1,    -1,    43,    -1,    45,    -1,
+      47,    -1,    -1,    -1,    51,    52,    -1,    54,    55,     3,
+       4,     5,     6,     7,     8,     9,    -1,    11,    12,    13,
+      -1,    -1,    -1,    17,    18,    19,    20,    -1,    -1,    -1,
+      24,    25,    -1,    -1,    -1,    -1,    30,    -1,    -1,    -1,
+      -1,    35,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    43,
+      -1,    45,    -1,    47,    -1,    -1,    -1,    51,    -1,    53,
+      54,    55,     3,     4,     5,     6,     7,     8,     9,    -1,
+      11,    12,    -1,    -1,    -1,    -1,    17,    18,    19,    20,
+      -1,    -1,    -1,    24,    25,    -1,    -1,    -1,    -1,    30,
+      -1,    -1,    -1,    -1,    35,    -1,    -1,    38,    -1,    -1,
+      -1,    -1,    43,    -1,    45,    -1,    47,    -1,    -1,    -1,
+      51,    52,    -1,    54,    55,     3,     4,     5,     6,     7,
+       8,     9,    -1,    11,    12,    -1,    -1,    -1,    -1,    17,
+      18,    19,    20,    -1,    -1,    -1,    24,    25,    -1,    -1,
+      -1,    -1,    30,    -1,    -1,    -1,    34,    35,    -1,    -1,
+      38,    -1,    -1,    -1,    -1,    43,    -1,    45,    -1,    47,
+      -1,    -1,    -1,    51,    -1,    -1,    54,    55,     3,     4,
+       5,     6,     7,     8,     9,    -1,    11,    12,    13,    -1,
+      -1,    -1,    17,    18,    19,    20,    -1,    -1,    -1,    24,
+      25,    -1,    -1,    -1,    -1,    30,    31,    -1,    -1,    -1,
+      35,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    43,    -1,
+      45,    -1,    47,    -1,    -1,    -1,    51,    -1,    -1,    54,
+      55,     3,     4,     5,     6,     7,     8,     9,    -1,    11,
+      12,    -1,    -1,    -1,    -1,    17,    18,    19,    20,    -1,
+      -1,    -1,    24,    25,    -1,    -1,    -1,    -1,    30,    -1,
+      -1,    -1,    34,    35,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    43,    -1,    45,    -1,    47,    -1,    -1,    -1,    51,
+      -1,    -1,    54,    55,     3,     4,     5,     6,     7,     8,
+       9,    -1,    11,    12,    -1,    -1,    -1,    -1,    17,    18,
+      19,    20,    -1,    -1,    23,    24,    25,    -1,    -1,    -1,
+      -1,    30,    -1,    -1,    -1,    -1,    35,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    43,    -1,    45,    -1,    47,    -1,
+      -1,    -1,    51,    -1,    -1,    54,    55,     3,     4,     5,
+       6,     7,     8,     9,    -1,    11,    12,    -1,    -1,    -1,
+      -1,    17,    18,    19,    20,    -1,    -1,    23,    24,    25,
+      -1,    -1,    -1,    -1,    30,    -1,    -1,    -1,    -1,    35,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    43,    -1,    45,
+      -1,    47,    -1,    -1,    -1,    51,    -1,    -1,    54,    55,
        3,     4,     5,     6,     7,     8,     9,    -1,    11,    12,
       -1,    -1,    -1,    -1,    17,    18,    19,    20,    -1,    -1,
-      23,    24,    -1,    -1,    -1,    -1,    29,    -1,    -1,    -1,
-      33,    34,    -1,    -1,    37,    -1,    -1,    -1,    -1,    42,
-      -1,    44,    -1,    46,    -1,    -1,    -1,    50,    51,    -1,
-      53,    54,     3,     4,     5,     6,     7,     8,     9,    -1,
+      23,    24,    25,    -1,    -1,    -1,    -1,    30,    -1,    -1,
+      -1,    -1,    35,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      43,    -1,    45,    -1,    47,    -1,    -1,    -1,    51,    -1,
+      -1,    54,    55,     3,     4,     5,     6,     7,     8,     9,
+      -1,    11,    12,    -1,    -1,    -1,    -1,    17,    18,    19,
+      20,    -1,    -1,    -1,    24,    25,    -1,    -1,    -1,    -1,
+      30,    -1,    -1,    -1,    -1,    35,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    43,    -1,    45,    -1,    47,    48,    -1,
+      -1,    51,    -1,    -1,    54,    55,     3,     4,     5,     6,
+       7,     8,     9,    -1,    11,    12,    -1,    -1,    -1,    -1,
+      17,    18,    19,    20,    -1,    -1,    -1,    24,    25,    -1,
+      -1,    -1,    -1,    30,    -1,    -1,    -1,    -1,    35,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    43,    -1,    45,    -1,
+      47,    48,    -1,    -1,    51,    -1,    -1,    54,    55,     3,
+       4,     5,     6,     7,     8,     9,    -1,    11,    12,    -1,
+      -1,    -1,    -1,    17,    18,    19,    20,    -1,    -1,    -1,
+      24,    25,    -1,    -1,    -1,    -1,    30,    -1,    -1,    -1,
+      -1,    35,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    43,
+      -1,    45,    -1,    47,    -1,    -1,    -1,    51,    -1,    53,
+      54,    55,     3,     4,     5,     6,     7,     8,     9,    -1,
       11,    12,    -1,    -1,    -1,    -1,    17,    18,    19,    20,
-      -1,    -1,    23,    24,    -1,    -1,    -1,    -1,    29,    -1,
-      -1,    -1,    33,    34,    -1,    -1,    37,    -1,    -1,    -1,
-      -1,    42,    -1,    44,    -1,    46,    -1,    -1,    -1,    50,
-      51,    -1,    53,    54,     3,     4,     5,     6,     7,     8,
-       9,    -1,    11,    12,    13,    -1,    -1,    -1,    17,    18,
-      19,    20,    -1,    -1,    23,    24,    -1,    -1,    -1,    -1,
-      29,    -1,    -1,    -1,    -1,    34,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,    42,    -1,    44,    -1,    46,    -1,    -1,
-      -1,    50,    -1,    52,    53,    54,     3,     4,     5,     6,
-       7,     8,     9,    -1,    11,    12,    -1,    -1,    -1,    -1,
-      17,    18,    19,    20,    -1,    -1,    23,    24,    -1,    -1,
-      -1,    -1,    29,    -1,    -1,    -1,    -1,    34,    -1,    -1,
-      37,    -1,    -1,    -1,    -1,    42,    -1,    44,    -1,    46,
-      -1,    -1,    -1,    50,    51,    -1,    53,    54,     3,     4,
-       5,     6,     7,     8,     9,    -1,    11,    12,    -1,    -1,
-      -1,    -1,    17,    18,    19,    20,    -1,    -1,    23,    24,
-      -1,    -1,    -1,    -1,    29,    -1,    -1,    -1,    -1,    34,
-      -1,    -1,    37,    -1,    -1,    -1,    -1,    42,    -1,    44,
-      -1,    46,    -1,    -1,    -1,    50,    51,    -1,    53,    54,
-       3,     4,     5,     6,     7,     8,     9,    -1,    11,    12,
-      -1,    -1,    -1,    -1,    17,    18,    19,    20,    -1,    -1,
-      23,    24,    -1,    -1,    -1,    -1,    29,    -1,    -1,    -1,
-      33,    34,    -1,    -1,    37,    -1,    -1,    -1,    -1,    42,
-      -1,    44,    -1,    46,    -1,    -1,    -1,    50,    -1,    -1,
-      53,    54,     3,     4,     5,     6,     7,     8,     9,    -1,
-      11,    12,    13,    -1,    -1,    -1,    17,    18,    19,    20,
-      -1,    -1,    23,    24,    -1,    -1,    -1,    -1,    29,    30,
-      -1,    -1,    -1,    34,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,    42,    -1,    44,    -1,    46,    -1,    -1,    -1,    50,
-      -1,    -1,    53,    54,     3,     4,     5,     6,     7,     8,
-       9,    -1,    11,    12,    -1,    -1,    -1,    -1,    17,    18,
-      19,    20,    -1,    -1,    23,    24,    -1,    -1,    -1,    -1,
-      29,    -1,    -1,    -1,    33,    34,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,    42,    -1,    44,    -1,    46,    -1,    -1,
-      -1,    50,    -1,    -1,    53,    54,     3,     4,     5,     6,
-       7,     8,     9,    -1,    11,    12,    -1,    -1,    -1,    -1,
-      17,    18,    19,    20,    -1,    22,    23,    24,    -1,    -1,
-      -1,    -1,    29,    -1,    -1,    -1,    -1,    34,    -1,    -1,
-      -1,    -1,    -1,    -1,    -1,    42,    -1,    44,    -1,    46,
-      -1,    -1,    -1,    50,    -1,    -1,    53,    54,     3,     4,
-       5,     6,     7,     8,     9,    -1,    11,    12,    -1,    -1,
-      -1,    -1,    17,    18,    19,    20,    -1,    22,    23,    24,
-      -1,    -1,    -1,    -1,    29,    -1,    -1,    -1,    -1,    34,
-      -1,    -1,    -1,    -1,    -1,    -1,    -1,    42,    -1,    44,
-      -1,    46,    -1,    -1,    -1,    50,    -1,    -1,    53,    54,
-       3,     4,     5,     6,     7,     8,     9,    -1,    11,    12,
-      -1,    -1,    -1,    -1,    17,    18,    19,    20,    -1,    22,
-      23,    24,    -1,    -1,    -1,    -1,    29,    -1,    -1,    -1,
-      -1,    34,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    42,
-      -1,    44,    -1,    46,    -1,    -1,    -1,    50,    -1,    -1,
-      53,    54,     3,     4,     5,     6,     7,     8,     9,    -1,
-      11,    12,    -1,    -1,    -1,    -1,    17,    18,    19,    20,
-      -1,    -1,    23,    24,    -1,    -1,    -1,    -1,    29,    -1,
-      -1,    -1,    -1,    34,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,    42,    -1,    44,    -1,    46,    47,    -1,    -1,    50,
-      -1,    -1,    53,    54,     3,     4,     5,     6,     7,     8,
-       9,    -1,    11,    12,    -1,    -1,    -1,    -1,    17,    18,
-      19,    20,    -1,    -1,    23,    24,    -1,    -1,    -1,    -1,
-      29,    -1,    -1,    -1,    -1,    34,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,    42,    -1,    44,    -1,    46,    47,    -1,
-      -1,    50,    -1,    -1,    53,    54,     3,     4,     5,     6,
-       7,     8,     9,    -1,    11,    12,    -1,    -1,    -1,    -1,
-      17,    18,    19,    20,    -1,    -1,    23,    24,    -1,    -1,
-      -1,    -1,    29,    -1,    -1,    -1,    -1,    34,    -1,    -1,
-      -1,    -1,    -1,    -1,    -1,    42,    -1,    44,    -1,    46,
-      -1,    -1,    -1,    50,    -1,    52,    53,    54,     3,     4,
-       5,     6,     7,     8,     9,    -1,    11,    12,    -1,    -1,
-      -1,    -1,    17,    18,    19,    20,    -1,    -1,    23,    24,
-      -1,    -1,    -1,    -1,    29,    -1,    -1,    -1,    -1,    34,
-      -1,    -1,    -1,    -1,    -1,    -1,    -1,    42,    -1,    44,
-      -1,    46,    -1,    -1,    -1,    50,    -1,    -1,    53,    54,
-       3,     4,     5,     6,     7,     8,     9,    -1,    11,    -1,
-      -1,    -1,    -1,    -1,    17,    18,    19,    -1,    -1,    -1,
-      23,    -1,    -1,    -1,    -1,    -1,    29,    -1,    -1,    -1,
-      33,    34,    -1,    -1,     3,     4,     5,     6,     7,     8,
-       9,    -1,    11,    46,    -1,    -1,    -1,    50,    17,    18,
-      19,    -1,    -1,     3,    23,    -1,    -1,    -1,    -1,    -1,
-      29,    -1,    -1,    -1,    -1,    34,    32,    33,    34,    35,
-      36,    37,    38,    39,    40,    41,    -1,    46,    -1,    29,
-      -1,    50,    32,    -1,    34,    35,    36,    37,    38,    39,
-      40,    -1,    -1,    -1,    -1,    45
+      -1,    -1,    -1,    24,    25,    -1,    -1,    -1,    -1,    30,
+      -1,    -1,    -1,    -1,    35,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    43,    -1,    45,    -1,    47,    -1,    -1,    -1,
+      51,    -1,    -1,    54,    55,     4,     5,     6,     7,     8,
+       9,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    17,    18,
+      19,    -1,    -1,    -1,    -1,    24,     3,     4,     5,     6,
+       7,     8,     9,    -1,    11,    -1,    35,    -1,    -1,    -1,
+      17,    18,    19,    -1,    -1,    -1,    -1,    24,    -1,    -1,
+      -1,    -1,    -1,    30,    -1,    -1,    55,    34,    35,    -1,
+      -1,     3,     4,     5,     6,     7,     8,     9,    -1,    11,
+      47,    -1,    -1,    -1,    51,    17,    18,    19,    -1,    -1,
+       3,    -1,    24,    -1,    -1,    -1,    -1,    -1,    30,    -1,
+      -1,    -1,    -1,    35,    -1,    -1,    -1,    -1,    21,    -1,
+      -1,     3,    -1,    -1,    -1,    47,    -1,    30,    -1,    51,
+      33,    -1,    35,    36,    37,    38,    39,    40,    41,    21,
+      -1,    -1,     3,    46,    -1,    -1,    -1,    -1,    30,    -1,
+      -1,    33,    -1,    35,    36,    37,    38,    39,    40,    41,
+      21,    -1,    -1,    -1,    46,    -1,    -1,    -1,    -1,    30,
+      21,    -1,    33,    -1,    35,    36,    37,    38,    39,    40,
+      41,    -1,    33,    34,    35,    36,    37,    38,    39,    40,
+      41,    42,    21,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    52,    -1,    -1,    33,    34,    35,    36,    37,    38,
+      39,    40,    41,    42,    21,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    52,    -1,    -1,    33,    34,    35,    36,
+      37,    38,    39,    40,    41,    42,    21,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    52,    -1,    -1,    33,    34,
+      35,    36,    37,    38,    39,    40,    41,    42,    21,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    52,    -1,    -1,
+      33,    34,    35,    36,    37,    38,    39,    40,    41,    42,
+      21,    -1,    -1,    -1,    -1,    -1,    49,    -1,    -1,    -1,
+      -1,    -1,    33,    34,    35,    36,    37,    38,    39,    40,
+      41,    42
 };
 
 /* YYSTOS[STATE-NUM] -- The symbol kind of the accessing symbol of
    state STATE-NUM.  */
 static const yytype_uint8 yystos[] =
 {
-       0,    26,    38,    56,    57,    58,    60,     3,     4,     5,
+       0,    27,    39,    57,    58,    59,    61,     3,     4,     5,
        6,     7,     8,     9,    11,    12,    13,    14,    17,    18,
-      19,    20,    23,    24,    29,    34,    39,    42,    44,    46,
-      50,    52,    53,    54,    70,    71,    75,    79,    80,    85,
-      86,    87,    88,    91,    93,    94,   105,   106,   107,   109,
-     111,   112,   114,   132,   138,   139,   140,   141,   142,   143,
-     144,   146,   147,   148,   149,   150,   151,   152,   156,   144,
-       0,    59,   144,    60,   121,   122,   143,   120,   121,    14,
-      39,   113,     4,     5,     6,   141,   117,   118,   119,   143,
-      50,    91,    30,    48,   113,    33,    94,    95,    96,   154,
-      22,    30,    32,    34,    35,    36,    37,    38,    39,    40,
-      89,    94,   111,   114,   123,   124,   125,   153,   154,   155,
-      91,   143,    46,   102,   103,   143,   144,    46,    34,    39,
-      41,   154,   155,    48,    67,    75,    70,   112,    70,   111,
-     141,   141,    31,    50,    76,    77,    80,   105,    46,    50,
-      76,    44,    30,    46,    62,    48,    49,    31,    50,    21,
-      48,   120,   121,   117,   118,   110,    21,    39,    49,    68,
-      31,    69,    94,    94,   110,    30,    47,    49,    68,    94,
-      94,    22,    90,    94,    51,    22,    30,    49,    51,    70,
-      70,   111,    49,    68,    51,    94,    51,    48,    67,    31,
-      46,    50,   108,   128,   133,   134,   135,   138,   142,   143,
-     144,   146,   147,   148,   149,   150,   151,    31,    21,    49,
-      46,    22,    94,    97,    37,    46,    50,   143,    41,    92,
-      91,    70,    91,    37,    51,    97,    98,    77,    95,    51,
-      97,    98,    99,   100,   154,    65,   144,    61,   143,    44,
-     122,    91,    94,   143,    21,    48,    21,    39,    70,   112,
-     143,   119,    50,    54,   104,   132,   138,   142,   146,   147,
-     148,   149,   150,   151,    81,    82,    70,    94,    94,   154,
-      94,    51,    22,    49,    94,    94,    94,    51,    51,    70,
-      94,   123,   154,    50,    76,    91,   134,   108,   129,   130,
-     131,   154,    47,    49,    68,    46,    91,   143,   143,   134,
-      94,    22,    47,    49,    50,    22,    97,    51,    97,    98,
-      99,    31,    50,    76,    78,    34,    50,   138,   143,    91,
-      94,    76,    49,    68,   101,    49,   101,    47,    78,   101,
-     101,    49,    68,    94,    37,    45,    66,   143,   153,    47,
-      63,    51,    48,   143,   143,    45,    39,    49,    94,    49,
-      49,    45,    30,    94,    94,    94,    22,    51,    51,    97,
-      98,    47,    30,    49,    68,    51,   108,   108,   134,    47,
-      47,    47,    94,    31,    94,    94,    94,    22,    47,    78,
-     101,   101,    68,    91,    51,    97,    98,    99,    94,    37,
-      99,    51,    51,    51,    51,   100,    51,   143,   153,    44,
-      44,    62,    13,    15,    16,    64,    65,    48,    39,    49,
-     143,    51,    13,    30,    84,    94,   143,    84,    94,    22,
-      94,    76,   101,   101,   108,   129,    47,    31,    31,    47,
-      91,    49,    47,    47,    94,    31,    51,    51,    51,    78,
-     101,   101,    68,    51,    94,    68,    31,    78,    78,    78,
-      44,    44,   113,   113,    44,    35,    36,    40,   126,   127,
-     136,   126,    35,   115,   116,   137,    45,   143,    39,   143,
-      29,    30,    45,    49,    83,    28,   143,    45,    94,    51,
-      51,    91,    91,    31,    94,    31,    31,    47,    91,    78,
-      78,    51,    51,    51,    91,   113,   113,   110,   110,    63,
-      48,    49,   143,    48,    48,    68,   143,    39,    31,    94,
-      94,    84,    94,    28,    78,    91,    51,    91,    91,    31,
-      78,    78,   110,   110,    10,    73,   145,    73,    65,   127,
-      31,   116,    31,    94,    83,    83,    83,    94,    91,    73,
-      73,    52,    72,    74,    94,    67,    72,    45,   104,   104,
-      83,    83,    72,    72,    91,    45,    74,    45,    45,    45,
-      67
+      19,    20,    24,    25,    30,    35,    40,    43,    45,    47,
+      51,    53,    54,    55,    71,    72,    76,    80,    81,    86,
+      87,    88,    89,    92,    94,    95,   106,   107,   108,   110,
+     112,   113,   115,   133,   139,   140,   141,   142,   143,   144,
+     145,   147,   148,   149,   150,   151,   152,   153,   157,   145,
+       0,    60,   145,    61,   122,   123,   144,   121,   122,    14,
+      40,   114,     4,     5,     6,   142,   118,   119,   120,   144,
+      51,    92,    31,    49,   114,    34,    95,    96,    97,   155,
+      21,    23,    31,    33,    35,    36,    37,    38,    39,    40,
+      41,    90,    95,   112,   115,   124,   125,   126,   154,   155,
+     156,    92,   144,    47,   103,   104,   144,   145,    47,    35,
+      40,    42,   155,   156,    49,    68,    76,    71,   113,    71,
+     112,   142,   142,    32,    51,    77,    78,    81,   106,    47,
+      51,    77,    45,    31,    47,    63,    49,    50,    32,    51,
+      22,    49,   121,   122,   118,   119,   111,    22,    40,    50,
+      69,    32,    70,    95,    95,   111,    31,    48,    50,    69,
+      95,    95,    23,    91,    95,    52,    23,    31,    50,    52,
+      71,    71,   112,    50,    69,    52,    95,    52,    49,    68,
+      32,    47,    51,   109,   129,   134,   135,   136,   139,   143,
+     144,   145,   147,   148,   149,   150,   151,   152,    32,    22,
+      50,    47,    23,    95,    98,    47,    51,   144,    42,    93,
+      92,    71,    92,    21,    38,    52,    98,    99,    78,    96,
+      21,    52,    98,    99,   100,   101,   155,    66,   145,    62,
+     144,    45,   123,    92,    95,   144,    22,    49,    22,    40,
+      71,   113,   144,   120,    51,    55,   105,   133,   139,   143,
+     147,   148,   149,   150,   151,   152,    82,    83,    71,    95,
+      95,   155,    95,    52,    23,    50,    95,    95,    95,    52,
+      52,    71,    95,   124,   155,    51,    77,    92,   135,   109,
+     130,   131,   132,   155,    48,    50,    69,    47,    92,   144,
+     144,   135,    95,    23,    48,    50,    23,    98,    21,    52,
+      98,    99,   100,    32,    51,    77,    79,    35,    51,   139,
+     144,    92,    92,    95,    77,    50,    69,   102,    50,   102,
+      48,    92,    79,   102,   102,    50,    69,    95,    38,    46,
+      67,   144,   154,    48,    64,    52,    49,   144,   144,    46,
+      40,    50,    95,    50,    50,    46,    31,    95,    95,    95,
+      23,    52,    52,    98,    99,    48,    31,    50,    69,    52,
+     109,   109,   135,    48,    48,    48,    95,    32,    95,    95,
+      23,    48,    92,    79,   102,   102,    69,    92,    21,    52,
+      98,    99,   100,    95,    52,    38,   100,    52,    52,    52,
+      52,    52,   101,    52,   144,   154,    45,    45,    63,    13,
+      15,    16,    65,    66,    49,    40,    50,   144,    52,    13,
+      31,    85,    95,   144,    85,    95,    23,    95,    77,   102,
+     102,   109,   130,    48,    32,    32,    48,    92,    48,    48,
+      95,    32,    52,    52,    52,    52,    92,    79,   102,   102,
+      69,    52,    95,    69,    32,    79,    79,    79,    45,    45,
+     114,   114,    45,    36,    37,    41,   127,   128,   137,   127,
+      36,   116,   117,   138,    46,   144,    40,   144,    30,    31,
+      46,    50,    84,    29,   144,    46,    95,    52,    52,    92,
+      92,    32,    32,    32,    48,    92,    79,    79,    52,    52,
+      52,    52,    92,   114,   114,   111,   111,    64,    49,    50,
+     144,    49,    49,    69,   144,    40,    32,    95,    95,    85,
+      95,    29,    79,    92,    92,    92,    32,    79,    79,   111,
+     111,    10,    74,   146,    74,    66,   128,    32,   117,    32,
+      95,    84,    84,    84,    95,    92,    74,    74,    53,    73,
+      75,    95,    68,    73,    46,   105,   105,    84,    84,    73,
+      73,    92,    46,    75,    46,    46,    46,    68
 };
 
 /* YYR1[RULE-NUM] -- Symbol kind of the left-hand side of rule RULE-NUM.  */
 static const yytype_uint8 yyr1[] =
 {
-       0,    55,    56,    56,    56,    57,    57,    58,    58,    59,
-      59,    60,    61,    61,    62,    62,    63,    63,    64,    64,
-      64,    65,    65,    66,    66,    66,    66,    67,    67,    68,
-      68,    69,    69,    70,    70,    71,    71,    71,    71,    71,
-      71,    71,    72,    72,    73,    73,    74,    74,    75,    75,
-      76,    76,    77,    77,    78,    78,    79,    79,    79,    79,
-      79,    79,    79,    79,    79,    79,    79,    79,    79,    79,
-      79,    79,    79,    79,    79,    79,    79,    79,    79,    79,
-      81,    80,    82,    80,    83,    83,    84,    84,    84,    84,
-      84,    84,    85,    85,    85,    85,    85,    85,    85,    85,
-      85,    85,    85,    85,    85,    85,    85,    86,    86,    86,
-      87,    87,    87,    88,    88,    88,    88,    88,    88,    89,
-      89,    89,    89,    89,    90,    90,    90,    90,    90,    91,
-      91,    91,    91,    91,    91,    91,    91,    91,    91,    91,
-      91,    91,    91,    92,    92,    92,    92,    93,    93,    94,
-      95,    95,    96,    96,    96,    96,    96,    96,    97,    97,
-      98,    98,    99,    99,   100,   101,   101,   102,   102,   103,
-     103,   104,   104,   104,   104,   104,   104,   104,   104,   104,
-     105,   106,   107,   107,   107,   107,   107,   107,   107,   107,
-     107,   108,   108,   108,   108,   108,   108,   108,   108,   108,
-     108,   108,   109,   109,   110,   110,   111,   111,   112,   113,
-     113,   113,   113,   113,   113,   114,   114,   114,   114,   114,
-     115,   115,   116,   117,   117,   118,   118,   119,   119,   119,
-     120,   120,   121,   121,   122,   122,   122,   123,   123,   124,
-     124,   125,   125,   126,   126,   127,   127,   128,   129,   129,
-     130,   130,   131,   131,   132,   132,   133,   133,   134,   134,
-     135,   135,   136,   136,   136,   136,   137,   137,   138,   138,
-     139,   139,   140,   140,   141,   142,   142,   142,   142,   142,
-     142,   143,   143,   144,   145,   146,   147,   148,   149,   150,
-     151,   152,   153,   153,   153,   153,   153,   153,   153,   153,
-     154,   155,   155,   156
+       0,    56,    57,    57,    57,    58,    58,    59,    59,    60,
+      60,    61,    62,    62,    63,    63,    64,    64,    65,    65,
+      65,    66,    66,    67,    67,    67,    67,    68,    68,    69,
+      69,    70,    70,    71,    71,    72,    72,    72,    72,    72,
+      72,    72,    73,    73,    74,    74,    75,    75,    76,    76,
+      77,    77,    78,    78,    79,    79,    80,    80,    80,    80,
+      80,    80,    80,    80,    80,    80,    80,    80,    80,    80,
+      80,    80,    80,    80,    80,    80,    80,    80,    80,    80,
+      80,    80,    80,    82,    81,    83,    81,    84,    84,    85,
+      85,    85,    85,    85,    85,    86,    86,    86,    86,    86,
+      86,    86,    86,    86,    86,    86,    86,    86,    86,    86,
+      87,    87,    87,    88,    88,    88,    89,    89,    89,    89,
+      89,    89,    90,    90,    90,    90,    90,    91,    91,    91,
+      91,    91,    92,    92,    92,    92,    92,    92,    92,    92,
+      92,    92,    92,    92,    92,    92,    93,    93,    93,    93,
+      94,    94,    95,    96,    96,    97,    97,    97,    97,    97,
+      97,    98,    98,    99,    99,   100,   100,   101,   102,   102,
+     103,   103,   104,   104,   105,   105,   105,   105,   105,   105,
+     105,   105,   105,   106,   107,   108,   108,   108,   108,   108,
+     108,   108,   108,   108,   109,   109,   109,   109,   109,   109,
+     109,   109,   109,   109,   109,   110,   110,   111,   111,   112,
+     112,   113,   114,   114,   114,   114,   114,   114,   115,   115,
+     115,   115,   115,   116,   116,   117,   118,   118,   119,   119,
+     120,   120,   120,   121,   121,   122,   122,   123,   123,   123,
+     124,   124,   125,   125,   126,   126,   127,   127,   128,   128,
+     129,   130,   130,   131,   131,   132,   132,   133,   133,   134,
+     134,   135,   135,   136,   136,   137,   137,   137,   137,   138,
+     138,   139,   139,   140,   140,   141,   141,   142,   143,   143,
+     143,   143,   143,   143,   144,   144,   145,   146,   147,   148,
+     149,   150,   151,   152,   153,   154,   154,   154,   154,   154,
+     154,   154,   154,   154,   155,   156,   156,   157
 };
 
 /* YYR2[RULE-NUM] -- Number of symbols on the right-hand side of rule RULE-NUM.  */
@@ -1430,30 +1465,30 @@ static const yytype_int8 yyr2[] =
        2,     1,     1,     2,     0,     2,     0,     3,     0,     3,
        1,     2,     1,     1,     0,     1,     2,     4,     4,     6,
        6,     8,     5,     7,     4,     2,     4,     6,     6,     5,
-       5,     7,     8,     7,     8,     6,     6,     8,     7,     4,
-       0,     7,     0,     7,     0,     2,     4,     5,     5,     2,
-       4,     4,     1,     1,     1,     1,     1,     1,     3,     2,
-       3,     3,     4,     3,     1,     4,     1,     5,     5,     6,
-       7,     7,     8,     6,     6,     7,     8,     8,     9,     2,
-       2,     3,     5,     4,     2,     2,     3,     4,     5,     1,
-       1,     1,     1,     5,     2,     4,     3,     4,     5,     7,
-       4,     6,     7,     0,     2,     2,     4,     1,     3,     2,
-       0,     2,     1,     3,     2,     3,     4,     5,     1,     3,
-       2,     4,     1,     3,     2,     1,     3,     1,     3,     1,
-       3,     1,     1,     1,     1,     1,     1,     1,     1,     1,
+       5,     7,     8,     7,     6,     7,     6,     5,     5,     6,
+       8,     7,     4,     0,     7,     0,     7,     0,     2,     4,
+       5,     5,     2,     4,     4,     1,     1,     1,     1,     1,
+       1,     3,     2,     3,     3,     4,     3,     1,     4,     1,
+       5,     5,     6,     7,     7,     8,     6,     6,     7,     8,
+       8,     9,     2,     2,     3,     5,     4,     2,     2,     3,
+       4,     5,     1,     1,     1,     1,     5,     2,     4,     3,
+       4,     5,     7,     4,     6,     7,     0,     2,     2,     4,
+       1,     3,     2,     0,     2,     1,     3,     2,     3,     4,
+       5,     1,     3,     2,     4,     1,     3,     2,     1,     3,
+       1,     3,     1,     3,     1,     1,     1,     1,     1,     1,
        1,     1,     1,     1,     1,     1,     1,     1,     1,     1,
        1,     1,     1,     1,     1,     1,     1,     1,     1,     1,
-       1,     1,     5,     5,     0,     2,     1,     2,     3,     0,
-       3,     5,     3,     5,     7,     3,     5,     3,     5,     7,
-       1,     3,     4,     0,     1,     1,     3,     1,     3,     5,
-       0,     1,     1,     3,     1,     3,     4,     3,     2,     1,
-       3,     0,     2,     1,     3,     2,     4,     3,     3,     2,
-       1,     3,     0,     2,     4,     5,     3,     4,     0,     2,
-       1,     3,     0,     1,     1,     1,     0,     1,     1,     2,
-       1,     2,     1,     2,     1,     1,     1,     2,     2,     1,
-       2,     1,     1,     1,     1,     1,     1,     1,     1,     1,
+       1,     1,     1,     1,     1,     5,     5,     0,     2,     1,
+       2,     3,     0,     3,     5,     3,     5,     7,     3,     5,
+       3,     5,     7,     1,     3,     4,     0,     1,     1,     3,
+       1,     3,     5,     0,     1,     1,     3,     1,     3,     4,
+       3,     2,     1,     3,     0,     2,     1,     3,     2,     4,
+       3,     3,     2,     1,     3,     0,     2,     4,     5,     3,
+       4,     0,     2,     1,     3,     0,     1,     1,     1,     0,
+       1,     1,     2,     1,     2,     1,     2,     1,     1,     1,
+       2,     2,     1,     2,     1,     1,     1,     1,     1,     1,
        1,     1,     1,     1,     1,     1,     1,     1,     1,     1,
-       1,     1,     1,     1
+       1,     1,     1,     1,     1,     1,     1,     1
 };
 
 
@@ -2189,37 +2224,37 @@ yyreduce:
   case 2: /* root: classes  */
 #line 40 "lang11d"
                         { gRootParseNode = (PyrParseNode*)yyvsp[0]; gParserResult = 1; }
-#line 2193 "lang11d_tab.cpp"
+#line 2228 "lang11d_tab.cpp"
     break;
 
   case 3: /* root: classextensions  */
 #line 42 "lang11d"
                         { gRootParseNode = (PyrParseNode*)yyvsp[0]; gParserResult = 1; }
-#line 2199 "lang11d_tab.cpp"
+#line 2234 "lang11d_tab.cpp"
     break;
 
   case 4: /* root: INTERPRET cmdlinecode  */
 #line 44 "lang11d"
                         { gRootParseNode = (PyrParseNode*)yyvsp[0]; gParserResult = 2; }
-#line 2205 "lang11d_tab.cpp"
+#line 2240 "lang11d_tab.cpp"
     break;
 
   case 5: /* classes: %empty  */
 #line 47 "lang11d"
           { yyval = 0; }
-#line 2211 "lang11d_tab.cpp"
+#line 2246 "lang11d_tab.cpp"
     break;
 
   case 6: /* classes: classes classdef  */
 #line 49 "lang11d"
                         { yyval = (intptr_t)linkNextNode((PyrParseNode*)yyvsp[-1], (PyrParseNode*)yyvsp[0]); }
-#line 2217 "lang11d_tab.cpp"
+#line 2252 "lang11d_tab.cpp"
     break;
 
   case 8: /* classextensions: classextensions classextension  */
 #line 54 "lang11d"
                                 { yyval = (intptr_t)linkNextNode((PyrParseNode*)yyvsp[-1], (PyrParseNode*)yyvsp[0]); }
-#line 2223 "lang11d_tab.cpp"
+#line 2258 "lang11d_tab.cpp"
     break;
 
   case 9: /* classdef: classname superclass '{' classvardecls methods '}'  */
@@ -2227,7 +2262,7 @@ yyreduce:
                                 { yyval = (intptr_t)newPyrClassNode((PyrSlotNode*)yyvsp[-5], (PyrSlotNode*)yyvsp[-4],
 					(PyrVarListNode*)yyvsp[-2], (PyrMethodNode*)yyvsp[-1], 0);
 				}
-#line 2231 "lang11d_tab.cpp"
+#line 2266 "lang11d_tab.cpp"
     break;
 
   case 10: /* classdef: classname '[' optname ']' superclass '{' classvardecls methods '}'  */
@@ -2236,7 +2271,7 @@ yyreduce:
 					(PyrVarListNode*)yyvsp[-2], (PyrMethodNode*)yyvsp[-1],
 					(PyrSlotNode*)yyvsp[-6]);
 				}
-#line 2240 "lang11d_tab.cpp"
+#line 2275 "lang11d_tab.cpp"
     break;
 
   case 11: /* classextension: '+' classname '{' methods '}'  */
@@ -2244,185 +2279,185 @@ yyreduce:
                                 {
 					yyval = (intptr_t)newPyrClassExtNode((PyrSlotNode*)yyvsp[-3], (PyrMethodNode*)yyvsp[-1]);
 				}
-#line 2248 "lang11d_tab.cpp"
+#line 2283 "lang11d_tab.cpp"
     break;
 
   case 12: /* optname: %empty  */
 #line 74 "lang11d"
                   { yyval = 0; }
-#line 2254 "lang11d_tab.cpp"
+#line 2289 "lang11d_tab.cpp"
     break;
 
   case 14: /* superclass: %empty  */
 #line 78 "lang11d"
                   { yyval = 0; }
-#line 2260 "lang11d_tab.cpp"
+#line 2295 "lang11d_tab.cpp"
     break;
 
   case 15: /* superclass: ':' classname  */
 #line 80 "lang11d"
                                 { yyval = yyvsp[0]; }
-#line 2266 "lang11d_tab.cpp"
+#line 2301 "lang11d_tab.cpp"
     break;
 
   case 16: /* classvardecls: %empty  */
 #line 83 "lang11d"
                   { yyval = 0; }
-#line 2272 "lang11d_tab.cpp"
+#line 2307 "lang11d_tab.cpp"
     break;
 
   case 17: /* classvardecls: classvardecls classvardecl  */
 #line 85 "lang11d"
                                         { yyval = (intptr_t)linkNextNode((PyrParseNode*)yyvsp[-1], (PyrParseNode*)yyvsp[0]); }
-#line 2278 "lang11d_tab.cpp"
+#line 2313 "lang11d_tab.cpp"
     break;
 
   case 18: /* classvardecl: CLASSVAR rwslotdeflist ';'  */
 #line 89 "lang11d"
                                         { yyval = (intptr_t)newPyrVarListNode((PyrVarDefNode*)yyvsp[-1], varClass); }
-#line 2284 "lang11d_tab.cpp"
+#line 2319 "lang11d_tab.cpp"
     break;
 
   case 19: /* classvardecl: VAR rwslotdeflist ';'  */
 #line 91 "lang11d"
                                         { yyval = (intptr_t)newPyrVarListNode((PyrVarDefNode*)yyvsp[-1], varInst); }
-#line 2290 "lang11d_tab.cpp"
+#line 2325 "lang11d_tab.cpp"
     break;
 
   case 20: /* classvardecl: SC_CONST constdeflist ';'  */
 #line 93 "lang11d"
                                         { yyval = (intptr_t)newPyrVarListNode((PyrVarDefNode*)yyvsp[-1], varConst); }
-#line 2296 "lang11d_tab.cpp"
+#line 2331 "lang11d_tab.cpp"
     break;
 
   case 21: /* methods: %empty  */
 #line 96 "lang11d"
                   { yyval = 0; }
-#line 2302 "lang11d_tab.cpp"
+#line 2337 "lang11d_tab.cpp"
     break;
 
   case 22: /* methods: methods methoddef  */
 #line 98 "lang11d"
                                 { yyval = (intptr_t)linkNextNode((PyrParseNode*)yyvsp[-1], (PyrParseNode*)yyvsp[0]); }
-#line 2308 "lang11d_tab.cpp"
+#line 2343 "lang11d_tab.cpp"
     break;
 
   case 23: /* methoddef: name '{' argdecls funcvardecls primitive methbody '}'  */
 #line 102 "lang11d"
                                 { yyval = (intptr_t)newPyrMethodNode((PyrSlotNode*)yyvsp[-6], (PyrSlotNode*)yyvsp[-2],
 					(PyrArgListNode*)yyvsp[-4], (PyrVarListNode*)yyvsp[-3], (PyrParseNode*)yyvsp[-1], 0); }
-#line 2315 "lang11d_tab.cpp"
+#line 2350 "lang11d_tab.cpp"
     break;
 
   case 24: /* methoddef: '*' name '{' argdecls funcvardecls primitive methbody '}'  */
 #line 105 "lang11d"
                                 { yyval = (intptr_t)newPyrMethodNode((PyrSlotNode*)yyvsp[-6], (PyrSlotNode*)yyvsp[-2],
 					(PyrArgListNode*)yyvsp[-4], (PyrVarListNode*)yyvsp[-3], (PyrParseNode*)yyvsp[-1], 1); }
-#line 2322 "lang11d_tab.cpp"
+#line 2357 "lang11d_tab.cpp"
     break;
 
   case 25: /* methoddef: binop '{' argdecls funcvardecls primitive methbody '}'  */
 #line 108 "lang11d"
                                 { yyval = (intptr_t)newPyrMethodNode((PyrSlotNode*)yyvsp[-6], (PyrSlotNode*)yyvsp[-2],
 					(PyrArgListNode*)yyvsp[-4], (PyrVarListNode*)yyvsp[-3], (PyrParseNode*)yyvsp[-1], 0); }
-#line 2329 "lang11d_tab.cpp"
+#line 2364 "lang11d_tab.cpp"
     break;
 
   case 26: /* methoddef: '*' binop '{' argdecls funcvardecls primitive methbody '}'  */
 #line 111 "lang11d"
                                 { yyval = (intptr_t)newPyrMethodNode((PyrSlotNode*)yyvsp[-6], (PyrSlotNode*)yyvsp[-2],
 					(PyrArgListNode*)yyvsp[-4], (PyrVarListNode*)yyvsp[-3], (PyrParseNode*)yyvsp[-1], 1); }
-#line 2336 "lang11d_tab.cpp"
+#line 2371 "lang11d_tab.cpp"
     break;
 
   case 34: /* funcbody: exprseq funretval  */
 #line 129 "lang11d"
                                 { yyval = (intptr_t)newPyrDropNode((PyrParseNode*)yyvsp[-1], (PyrParseNode*)yyvsp[0]); }
-#line 2342 "lang11d_tab.cpp"
+#line 2377 "lang11d_tab.cpp"
     break;
 
   case 35: /* cmdlinecode: '(' argdecls1 funcvardecls1 funcbody ')'  */
 #line 133 "lang11d"
                                 { yyval = (intptr_t)newPyrBlockNode((PyrArgListNode*)yyvsp[-3], (PyrVarListNode*)yyvsp[-2], (PyrParseNode*)yyvsp[-1], false); }
-#line 2348 "lang11d_tab.cpp"
+#line 2383 "lang11d_tab.cpp"
     break;
 
   case 36: /* cmdlinecode: '(' argdecls1 funcbody ')'  */
 #line 135 "lang11d"
                                 { yyval = (intptr_t)newPyrBlockNode((PyrArgListNode*)yyvsp[-2], NULL, (PyrParseNode*)yyvsp[-1], false); }
-#line 2354 "lang11d_tab.cpp"
+#line 2389 "lang11d_tab.cpp"
     break;
 
   case 37: /* cmdlinecode: '(' funcvardecls1 funcbody ')'  */
 #line 137 "lang11d"
                                 { yyval = (intptr_t)newPyrBlockNode(NULL, (PyrVarListNode*)yyvsp[-2], (PyrParseNode*)yyvsp[-1], false); }
-#line 2360 "lang11d_tab.cpp"
+#line 2395 "lang11d_tab.cpp"
     break;
 
   case 38: /* cmdlinecode: argdecls1 funcvardecls1 funcbody  */
 #line 139 "lang11d"
                                 { yyval = (intptr_t)newPyrBlockNode((PyrArgListNode*)yyvsp[-2], (PyrVarListNode*)yyvsp[-1], (PyrParseNode*)yyvsp[0], false); }
-#line 2366 "lang11d_tab.cpp"
+#line 2401 "lang11d_tab.cpp"
     break;
 
   case 39: /* cmdlinecode: argdecls1 funcbody  */
 #line 141 "lang11d"
                                 { yyval = (intptr_t)newPyrBlockNode((PyrArgListNode*)yyvsp[-1], NULL, (PyrParseNode*)yyvsp[0], false); }
-#line 2372 "lang11d_tab.cpp"
+#line 2407 "lang11d_tab.cpp"
     break;
 
   case 40: /* cmdlinecode: funcvardecls1 funcbody  */
 #line 143 "lang11d"
                                 { yyval = (intptr_t)newPyrBlockNode(NULL, (PyrVarListNode*)yyvsp[-1], (PyrParseNode*)yyvsp[0], false); }
-#line 2378 "lang11d_tab.cpp"
+#line 2413 "lang11d_tab.cpp"
     break;
 
   case 41: /* cmdlinecode: funcbody  */
 #line 145 "lang11d"
                                 { yyval = (intptr_t)newPyrBlockNode(NULL, NULL, (PyrParseNode*)yyvsp[0], false); }
-#line 2384 "lang11d_tab.cpp"
+#line 2419 "lang11d_tab.cpp"
     break;
 
   case 43: /* methbody: exprseq retval  */
 #line 150 "lang11d"
                                 { yyval = (intptr_t)newPyrDropNode((PyrParseNode*)yyvsp[-1], (PyrParseNode*)yyvsp[0]); }
-#line 2390 "lang11d_tab.cpp"
+#line 2425 "lang11d_tab.cpp"
     break;
 
   case 44: /* primitive: %empty  */
 #line 153 "lang11d"
                   { yyval = 0; }
-#line 2396 "lang11d_tab.cpp"
+#line 2431 "lang11d_tab.cpp"
     break;
 
   case 45: /* primitive: primname optsemi  */
 #line 155 "lang11d"
                                 { yyval = yyvsp[-1]; }
-#line 2402 "lang11d_tab.cpp"
+#line 2437 "lang11d_tab.cpp"
     break;
 
   case 46: /* retval: %empty  */
 #line 159 "lang11d"
                         { yyval = (intptr_t)newPyrReturnNode(NULL); }
-#line 2408 "lang11d_tab.cpp"
+#line 2443 "lang11d_tab.cpp"
     break;
 
   case 47: /* retval: '^' expr optsemi  */
 #line 161 "lang11d"
                         { yyval = (intptr_t)newPyrReturnNode((PyrParseNode*)yyvsp[-1]); }
-#line 2414 "lang11d_tab.cpp"
+#line 2449 "lang11d_tab.cpp"
     break;
 
   case 48: /* funretval: %empty  */
 #line 165 "lang11d"
                         { yyval = (intptr_t)newPyrBlockReturnNode(); }
-#line 2420 "lang11d_tab.cpp"
+#line 2455 "lang11d_tab.cpp"
     break;
 
   case 49: /* funretval: '^' expr optsemi  */
 #line 167 "lang11d"
                         { yyval = (intptr_t)newPyrReturnNode((PyrParseNode*)yyvsp[-1]); }
-#line 2426 "lang11d_tab.cpp"
+#line 2461 "lang11d_tab.cpp"
     break;
 
   case 51: /* blocklist1: blocklist1 blocklistitem  */
@@ -2430,13 +2465,13 @@ yyreduce:
                                 {
 					yyval = (intptr_t)linkNextNode((PyrParseNode*)yyvsp[-1], (PyrParseNode*)yyvsp[0]);
 				}
-#line 2434 "lang11d_tab.cpp"
+#line 2469 "lang11d_tab.cpp"
     break;
 
   case 54: /* blocklist: %empty  */
 #line 181 "lang11d"
                         { yyval = 0; }
-#line 2440 "lang11d_tab.cpp"
+#line 2475 "lang11d_tab.cpp"
     break;
 
   case 56: /* msgsend: name blocklist1  */
@@ -2444,7 +2479,7 @@ yyreduce:
                         {
 				yyval = (intptr_t)newPyrCallNode((PyrSlotNode*)yyvsp[-1], (PyrParseNode*)yyvsp[0], 0, 0);
 			}
-#line 2448 "lang11d_tab.cpp"
+#line 2483 "lang11d_tab.cpp"
     break;
 
   case 57: /* msgsend: '(' binop2 ')' blocklist1  */
@@ -2452,7 +2487,7 @@ yyreduce:
                         {
 				yyval = (intptr_t)newPyrCallNode((PyrSlotNode*)yyvsp[-2], (PyrParseNode*)yyvsp[0], 0, 0);
 			}
-#line 2456 "lang11d_tab.cpp"
+#line 2491 "lang11d_tab.cpp"
     break;
 
   case 58: /* msgsend: name '(' ')' blocklist1  */
@@ -2460,7 +2495,7 @@ yyreduce:
                         {
 				yyval = (intptr_t)newPyrCallNode((PyrSlotNode*)yyvsp[-3], NULL, NULL, (PyrParseNode*)yyvsp[0]);
 			}
-#line 2464 "lang11d_tab.cpp"
+#line 2499 "lang11d_tab.cpp"
     break;
 
   case 59: /* msgsend: name '(' arglist1 optkeyarglist ')' blocklist  */
@@ -2469,7 +2504,7 @@ yyreduce:
 				yyval = (intptr_t)newPyrCallNode((PyrSlotNode*)yyvsp[-5], (PyrParseNode*)yyvsp[-3],
 						(PyrParseNode*)yyvsp[-2], (PyrParseNode*)yyvsp[0]);
 			}
-#line 2473 "lang11d_tab.cpp"
+#line 2508 "lang11d_tab.cpp"
     break;
 
   case 60: /* msgsend: '(' binop2 ')' '(' ')' blocklist1  */
@@ -2477,7 +2512,7 @@ yyreduce:
                         {
 				yyval = (intptr_t)newPyrCallNode((PyrSlotNode*)yyvsp[-4], NULL, NULL, (PyrParseNode*)yyvsp[0]);
 			}
-#line 2481 "lang11d_tab.cpp"
+#line 2516 "lang11d_tab.cpp"
     break;
 
   case 61: /* msgsend: '(' binop2 ')' '(' arglist1 optkeyarglist ')' blocklist  */
@@ -2486,10 +2521,10 @@ yyreduce:
 				yyval = (intptr_t)newPyrCallNode((PyrSlotNode*)yyvsp[-6], (PyrParseNode*)yyvsp[-3],
 						(PyrParseNode*)yyvsp[-2], (PyrParseNode*)yyvsp[0]);
 			}
-#line 2490 "lang11d_tab.cpp"
+#line 2525 "lang11d_tab.cpp"
     break;
 
-  case 62: /* msgsend: name '(' arglistv1 optkeyarglist ')'  */
+  case 62: /* msgsend: name '(' argListWithPerformList optkeyarglist ')'  */
 #line 212 "lang11d"
                         {
 				PyrSlotNode *selectornode;
@@ -2508,10 +2543,10 @@ yyreduce:
 					newPyrPushLitNode((PyrSlotNode*)yyvsp[-4], NULL));
 				yyval = (intptr_t)newPyrCallNode(selectornode, args, (PyrParseNode*)yyvsp[-1], 0);
 			}
-#line 2512 "lang11d_tab.cpp"
+#line 2547 "lang11d_tab.cpp"
     break;
 
-  case 63: /* msgsend: '(' binop2 ')' '(' arglistv1 optkeyarglist ')'  */
+  case 63: /* msgsend: '(' binop2 ')' '(' argListWithPerformList optkeyarglist ')'  */
 #line 230 "lang11d"
                         {
 				PyrSlotNode *selectornode;
@@ -2525,13 +2560,13 @@ yyreduce:
 					newPyrPushLitNode((PyrSlotNode*)yyvsp[-5], NULL));
 				yyval = (intptr_t)newPyrCallNode(selectornode, args, (PyrParseNode*)yyvsp[-1], 0);
 			}
-#line 2529 "lang11d_tab.cpp"
+#line 2564 "lang11d_tab.cpp"
     break;
 
   case 64: /* msgsend: classname '[' arrayelems ']'  */
 #line 243 "lang11d"
                         { yyval = (intptr_t)newPyrDynListNode((PyrParseNode*)yyvsp[-3], (PyrParseNode*)yyvsp[-1]); }
-#line 2535 "lang11d_tab.cpp"
+#line 2570 "lang11d_tab.cpp"
     break;
 
   case 65: /* msgsend: classname blocklist1  */
@@ -2546,7 +2581,7 @@ yyreduce:
 				args = (PyrParseNode*)newPyrPushNameNode((PyrSlotNode*)yyvsp[-1]);
 				yyval = (intptr_t)newPyrCallNode(selectornode, args, 0, (PyrParseNode*)yyvsp[0]);
 			}
-#line 2550 "lang11d_tab.cpp"
+#line 2585 "lang11d_tab.cpp"
     break;
 
   case 66: /* msgsend: classname '(' ')' blocklist  */
@@ -2561,7 +2596,7 @@ yyreduce:
 				args = (PyrParseNode*)newPyrPushNameNode((PyrSlotNode*)yyvsp[-3]);
 				yyval = (intptr_t)newPyrCallNode(selectornode, args, NULL, (PyrParseNode*)yyvsp[0]);
 			}
-#line 2565 "lang11d_tab.cpp"
+#line 2600 "lang11d_tab.cpp"
     break;
 
   case 67: /* msgsend: classname '(' keyarglist1 optcomma ')' blocklist  */
@@ -2576,7 +2611,7 @@ yyreduce:
 				args = (PyrParseNode*)newPyrPushNameNode((PyrSlotNode*)yyvsp[-5]);
 				yyval = (intptr_t)newPyrCallNode(selectornode, args, (PyrParseNode*)yyvsp[-3], (PyrParseNode*)yyvsp[0]);
 			}
-#line 2580 "lang11d_tab.cpp"
+#line 2615 "lang11d_tab.cpp"
     break;
 
   case 68: /* msgsend: classname '(' arglist1 optkeyarglist ')' blocklist  */
@@ -2593,10 +2628,10 @@ yyreduce:
 					(PyrParseNode*)yyvsp[-3]);
 				yyval = (intptr_t)newPyrCallNode(selectornode, args, (PyrParseNode*)yyvsp[-2], (PyrParseNode*)yyvsp[0]);
 			}
-#line 2597 "lang11d_tab.cpp"
+#line 2632 "lang11d_tab.cpp"
     break;
 
-  case 69: /* msgsend: classname '(' arglistv1 optkeyarglist ')'  */
+  case 69: /* msgsend: classname '(' argListWithPerformList optkeyarglist ')'  */
 #line 291 "lang11d"
                         {
 				PyrSlotNode *selectornode, *selectornode2;
@@ -2618,11 +2653,11 @@ yyreduce:
 				args = linkNextNode(args, (PyrParseNode*)yyvsp[-2]);
 				yyval = (intptr_t)newPyrCallNode(selectornode, args, (PyrParseNode*)yyvsp[0], 0);
 			}
-#line 2622 "lang11d_tab.cpp"
+#line 2657 "lang11d_tab.cpp"
     break;
 
   case 70: /* msgsend: expr '.' '(' ')' blocklist  */
-#line 312 "lang11d"
+#line 315 "lang11d"
                         {
 				PyrSlotNode *selectornode;
 				PyrSlot slot;
@@ -2631,11 +2666,11 @@ yyreduce:
 				selectornode = newPyrSlotNode(&slot);
 				yyval = (intptr_t)newPyrCallNode(selectornode, (PyrParseNode*)yyvsp[-4], NULL, (PyrParseNode*)yyvsp[0]);
 			}
-#line 2635 "lang11d_tab.cpp"
+#line 2670 "lang11d_tab.cpp"
     break;
 
   case 71: /* msgsend: expr '.' '(' keyarglist1 optcomma ')' blocklist  */
-#line 321 "lang11d"
+#line 324 "lang11d"
                         {
 				PyrSlotNode *selectornode;
 				PyrSlot slot;
@@ -2644,20 +2679,20 @@ yyreduce:
 				selectornode = newPyrSlotNode(&slot);
 				yyval = (intptr_t)newPyrCallNode(selectornode, (PyrParseNode*)yyvsp[-6], (PyrParseNode*)yyvsp[-3], (PyrParseNode*)yyvsp[0]);
 			}
-#line 2648 "lang11d_tab.cpp"
+#line 2683 "lang11d_tab.cpp"
     break;
 
   case 72: /* msgsend: expr '.' name '(' keyarglist1 optcomma ')' blocklist  */
-#line 330 "lang11d"
+#line 333 "lang11d"
                         {
 				yyval = (intptr_t)newPyrCallNode((PyrSlotNode*)yyvsp[-5], (PyrParseNode*)yyvsp[-7],
 					(PyrParseNode*)yyvsp[-3], (PyrParseNode*)yyvsp[0]);
 			}
-#line 2657 "lang11d_tab.cpp"
+#line 2692 "lang11d_tab.cpp"
     break;
 
   case 73: /* msgsend: expr '.' '(' arglist1 optkeyarglist ')' blocklist  */
-#line 335 "lang11d"
+#line 338 "lang11d"
                         {
 				PyrSlotNode *selectornode;
 				PyrSlot slot;
@@ -2670,29 +2705,11 @@ yyreduce:
 					(PyrParseNode*)yyvsp[-3]);
 				yyval = (intptr_t)newPyrCallNode(selectornode, args, (PyrParseNode*)yyvsp[-2], (PyrParseNode*)yyvsp[0]);
 			}
-#line 2674 "lang11d_tab.cpp"
+#line 2709 "lang11d_tab.cpp"
     break;
 
-  case 74: /* msgsend: expr '.' '*' '(' exprseq ',' exprseq ')'  */
-#line 349 "lang11d"
-                    {
-		        PyrSlot slot, slot2;
-      SetSymbol(&slot, s_performArgs);
-      SetSymbol(&slot2, s_value);
-				PyrSlotNode* selectornode = newPyrSlotNode(&slot);
-				PyrParseNode* args = linkNextNode(
-					(PyrParseNode*)yyvsp[-7],
-					newPyrPushLitNode(newPyrSlotNode(&slot2), NULL)
-                );
-				args = linkNextNode(args, (PyrParseNode*)yyvsp[-3]);
-				args = linkNextNode(args, (PyrParseNode*)yyvsp[-1]);
-				yyval = (intptr_t)newPyrCallNode(selectornode, args, NULL, 0);
-            }
-#line 2692 "lang11d_tab.cpp"
-    break;
-
-  case 75: /* msgsend: expr '.' '(' arglistv1 optkeyarglist ')'  */
-#line 364 "lang11d"
+  case 74: /* msgsend: expr '.' '(' argListWithPerformList optkeyarglist ')'  */
+#line 352 "lang11d"
                         {
 				PyrSlotNode *selectornode;
 				PyrSlot slot, slot2;
@@ -2712,29 +2729,139 @@ yyreduce:
 				args = linkNextNode(args, (PyrParseNode*)yyvsp[-2]);
 				yyval = (intptr_t)newPyrCallNode(selectornode, args, (PyrParseNode*)yyvsp[-1], 0);
 			}
-#line 2716 "lang11d_tab.cpp"
+#line 2733 "lang11d_tab.cpp"
     break;
 
-  case 76: /* msgsend: expr '.' name '(' ')' blocklist  */
-#line 386 "lang11d"
+  case 75: /* msgsend: expr '.' name '(' KWEXPAND expr ')'  */
+#line 375 "lang11d"
+                        {
+				PyrSlot selectorSlot;
+				if (isSuperObjNode((PyrParseNode*)yyvsp[-6])) {
+					SetRaw(&((PyrPushNameNode*)yyvsp[-6])->mSlot, s_this);
+					SetSymbol(&selectorSlot, s_superPerformArgs);
+				} else {
+					SetSymbol(&selectorSlot, s_performArgs);
+				}
+				PyrSlotNode* selectornode = newPyrSlotNode(&selectorSlot);
+
+				PyrParseNode* args;
+				args = linkNextNode((PyrParseNode*)yyvsp[-6], newPyrPushLitNode((PyrSlotNode*)yyvsp[-4], NULL));
+				PyrSlot nil_slot;
+				SetNil(&nil_slot);
+				PyrSlotNode* nil_slot_node = newPyrSlotNode(&nil_slot);
+				args = linkNextNode(args, newPyrPushLitNode(nil_slot_node, NULL));
+				args = linkNextNode(args, (PyrParseNode*)yyvsp[-1]);
+				yyval = (intptr_t)newPyrCallNode(selectornode, args, NULL, 0);
+			}
+#line 2757 "lang11d_tab.cpp"
+    break;
+
+  case 76: /* msgsend: expr '.' '(' KWEXPAND expr ')'  */
+#line 396 "lang11d"
+                        {
+				PyrSlot selectorSlot;
+				if (isSuperObjNode((PyrParseNode*)yyvsp[-5])) {
+					SetRaw(&((PyrPushNameNode*)yyvsp[-5])->mSlot, s_this);
+					SetSymbol(&selectorSlot, s_superPerformArgs);
+				} else {
+					SetSymbol(&selectorSlot, s_performArgs);
+				}
+				PyrSlotNode* selectornode = newPyrSlotNode(&selectorSlot);
+
+				PyrParseNode* args;
+
+				PyrSlot value_slot;
+				SetSymbol(&value_slot, s_value);
+				PyrSlotNode* value_slot_node = newPyrSlotNode(&value_slot);
+				args = linkNextNode((PyrParseNode*)yyvsp[-5], newPyrPushLitNode(value_slot_node, NULL));
+
+				PyrSlot nil_slot;
+				SetNil(&nil_slot);
+				PyrSlotNode* nil_slot_node = newPyrSlotNode(&nil_slot);
+				args = linkNextNode(args, newPyrPushLitNode(nil_slot_node, NULL));
+
+				args = linkNextNode(args, (PyrParseNode*)yyvsp[-1]);
+				yyval = (intptr_t)newPyrCallNode(selectornode, args, NULL, 0);
+			}
+#line 2787 "lang11d_tab.cpp"
+    break;
+
+  case 77: /* msgsend: classname '(' KWEXPAND expr ')'  */
+#line 422 "lang11d"
+                        { 
+				PyrSlot selectorSlot;
+				if (isSuperObjNode((PyrParseNode*)yyvsp[-4])) {
+					SetRaw(&((PyrPushNameNode*)yyvsp[-4])->mSlot, s_this);
+					SetSymbol(&selectorSlot, s_superPerformArgs);
+				} else {
+					SetSymbol(&selectorSlot, s_performArgs);
+				}
+				PyrSlotNode* selectornode = newPyrSlotNode(&selectorSlot);
+
+				PyrSlot value_slot;
+				SetSymbol(&value_slot, s_value);
+				PyrSlotNode* value_slot_node = newPyrSlotNode(&value_slot);
+
+				PyrParseNode* args;
+				args = linkNextNode((PyrParseNode*)yyvsp[-4], newPyrPushLitNode(value_slot_node, NULL));
+				PyrSlot nil_slot;
+				SetNil(&nil_slot);
+				PyrSlotNode* nil_slot_node = newPyrSlotNode(&nil_slot);
+				args = linkNextNode(args, newPyrPushLitNode(nil_slot_node, NULL));
+				args = linkNextNode(args, (PyrParseNode*)yyvsp[-1]);
+				yyval = (intptr_t)newPyrCallNode(selectornode, args, NULL, 0);
+			}
+#line 2815 "lang11d_tab.cpp"
+    break;
+
+  case 78: /* msgsend: name '(' KWEXPAND expr ')'  */
+#line 446 "lang11d"
+                        { 
+				PyrSlot selectorSlot;
+				if (isSuperObjNode((PyrParseNode*)yyvsp[-4])) {
+					SetRaw(&((PyrPushNameNode*)yyvsp[-4])->mSlot, s_this);
+					SetSymbol(&selectorSlot, s_superPerformArgs);
+				} else {
+					SetSymbol(&selectorSlot, s_performArgs);
+				}
+				PyrSlotNode* selectornode = newPyrSlotNode(&selectorSlot);
+
+				PyrSlot value_slot;
+				SetSymbol(&value_slot, s_value);
+				PyrSlotNode* value_slot_node = newPyrSlotNode(&value_slot);
+
+				PyrParseNode* args;
+				args = linkNextNode((PyrParseNode*)yyvsp[-4], newPyrPushLitNode(value_slot_node, NULL));
+				PyrSlot nil_slot;
+				SetNil(&nil_slot);
+				PyrSlotNode* nil_slot_node = newPyrSlotNode(&nil_slot);
+				args = linkNextNode(args, newPyrPushLitNode(nil_slot_node, NULL));
+				args = linkNextNode(args, (PyrParseNode*)yyvsp[-1]);
+				yyval = (intptr_t)newPyrCallNode(selectornode, args, NULL, 0);
+			}
+#line 2843 "lang11d_tab.cpp"
+    break;
+
+  case 79: /* msgsend: expr '.' name '(' ')' blocklist  */
+#line 472 "lang11d"
                         {
 				yyval = (intptr_t)newPyrCallNode((PyrSlotNode*)yyvsp[-3], (PyrParseNode*)yyvsp[-5], NULL, (PyrParseNode*)yyvsp[0]);
 			}
-#line 2724 "lang11d_tab.cpp"
+#line 2851 "lang11d_tab.cpp"
     break;
 
-  case 77: /* msgsend: expr '.' name '(' arglist1 optkeyarglist ')' blocklist  */
-#line 390 "lang11d"
+  case 80: /* msgsend: expr '.' name '(' arglist1 optkeyarglist ')' blocklist  */
+#line 476 "lang11d"
                         {
 				PyrParseNode* args;
 				args = linkNextNode((PyrParseNode*)yyvsp[-7], (PyrParseNode*)yyvsp[-3]);
 				yyval = (intptr_t)newPyrCallNode((PyrSlotNode*)yyvsp[-5], args, (PyrParseNode*)yyvsp[-2], (PyrParseNode*)yyvsp[0]);
 			}
-#line 2734 "lang11d_tab.cpp"
+#line 2861 "lang11d_tab.cpp"
     break;
 
-  case 78: /* msgsend: expr '.' name '(' arglistv1 optkeyarglist ')'  */
-#line 396 "lang11d"
+  case 81: /* msgsend: expr '.' name '(' argListWithPerformList optkeyarglist ')'  */
+#line 482 "lang11d"
                         {
 				PyrSlotNode *selectornode;
 				PyrSlot slot;
@@ -2752,25 +2879,25 @@ yyreduce:
 				args = linkNextNode(args, (PyrParseNode*)yyvsp[-2]);
 				yyval = (intptr_t)newPyrCallNode(selectornode, args, (PyrParseNode*)yyvsp[-1], 0);
 			}
-#line 2756 "lang11d_tab.cpp"
+#line 2883 "lang11d_tab.cpp"
     break;
 
-  case 79: /* msgsend: expr '.' name blocklist  */
-#line 414 "lang11d"
+  case 82: /* msgsend: expr '.' name blocklist  */
+#line 500 "lang11d"
                         {
 				yyval = (intptr_t)newPyrCallNode((PyrSlotNode*)yyvsp[-1], (PyrParseNode*)yyvsp[-3], 0, (PyrParseNode*)yyvsp[0]);
 			}
-#line 2764 "lang11d_tab.cpp"
+#line 2891 "lang11d_tab.cpp"
     break;
 
-  case 80: /* $@1: %empty  */
-#line 419 "lang11d"
+  case 83: /* $@1: %empty  */
+#line 505 "lang11d"
                             { pushls(&generatorStack, yyvsp[0]); pushls(&generatorStack, 1); }
-#line 2770 "lang11d_tab.cpp"
+#line 2897 "lang11d_tab.cpp"
     break;
 
-  case 81: /* generator: '{' ':' exprseq $@1 ',' qual '}'  */
-#line 420 "lang11d"
+  case 84: /* generator: '{' ':' exprseq $@1 ',' qual '}'  */
+#line 506 "lang11d"
                         {
 				PyrSlot slot;
 				SetSymbol(&slot, getsym("r"));
@@ -2780,25 +2907,25 @@ yyreduce:
 				PyrParseNode *blocklit = (PyrParseNode*)newPyrPushLitNode(NULL, block);
 				yyval = (intptr_t)newPyrCallNode(selectornode, (PyrParseNode*)blocklit, 0, 0);
 			}
-#line 2784 "lang11d_tab.cpp"
+#line 2911 "lang11d_tab.cpp"
     break;
 
-  case 82: /* $@2: %empty  */
-#line 429 "lang11d"
+  case 85: /* $@2: %empty  */
+#line 515 "lang11d"
                                   { pushls(&generatorStack, yyvsp[0]); pushls(&generatorStack, 2); }
-#line 2790 "lang11d_tab.cpp"
+#line 2917 "lang11d_tab.cpp"
     break;
 
-  case 83: /* generator: '{' ';' exprseq $@2 ',' qual '}'  */
-#line 430 "lang11d"
+  case 86: /* generator: '{' ';' exprseq $@2 ',' qual '}'  */
+#line 516 "lang11d"
                         {
 				yyval = yyvsp[-1];
 			}
-#line 2798 "lang11d_tab.cpp"
+#line 2925 "lang11d_tab.cpp"
     break;
 
-  case 84: /* nextqual: %empty  */
-#line 436 "lang11d"
+  case 87: /* nextqual: %empty  */
+#line 522 "lang11d"
                                 {
 					// innermost part
 					int action = popls(&generatorStack);
@@ -2820,17 +2947,17 @@ yyreduce:
 						} break;
 					}
 				}
-#line 2824 "lang11d_tab.cpp"
+#line 2951 "lang11d_tab.cpp"
     break;
 
-  case 85: /* nextqual: ',' qual  */
-#line 458 "lang11d"
+  case 88: /* nextqual: ',' qual  */
+#line 544 "lang11d"
                                 { yyval = yyvsp[0]; }
-#line 2830 "lang11d_tab.cpp"
+#line 2957 "lang11d_tab.cpp"
     break;
 
-  case 86: /* qual: name LEFTARROW exprseq nextqual  */
-#line 462 "lang11d"
+  case 89: /* qual: name LEFTARROW exprseq nextqual  */
+#line 548 "lang11d"
                         {
 				// later should check if exprseq is a series and optimize it to for loop
 				PyrParseNode *exprseq = (PyrParseNode*)yyvsp[-1];
@@ -2864,11 +2991,11 @@ yyreduce:
 					yyval = (intptr_t)newPyrCallNode(selectornode, args2, 0, 0);
 				}
 			}
-#line 2868 "lang11d_tab.cpp"
+#line 2995 "lang11d_tab.cpp"
     break;
 
-  case 87: /* qual: name name LEFTARROW exprseq nextqual  */
-#line 496 "lang11d"
+  case 90: /* qual: name name LEFTARROW exprseq nextqual  */
+#line 582 "lang11d"
                         {
 				// later should check if exprseq is a series and optimize it to for loop
 				PyrParseNode *exprseq = (PyrParseNode*)yyvsp[-1];
@@ -2906,11 +3033,11 @@ yyreduce:
 					yyval = (intptr_t)newPyrCallNode(selectornode, args2, 0, 0);
 				}
 			}
-#line 2910 "lang11d_tab.cpp"
+#line 3037 "lang11d_tab.cpp"
     break;
 
-  case 88: /* qual: VAR name '=' exprseq nextqual  */
-#line 534 "lang11d"
+  case 91: /* qual: VAR name '=' exprseq nextqual  */
+#line 620 "lang11d"
                         {
 				PyrSlot slot;
 				SetSymbol(&slot, s_value);
@@ -2924,11 +3051,11 @@ yyreduce:
 
 				yyval = (intptr_t)newPyrCallNode(selectornode, args2, 0, 0);
 			}
-#line 2928 "lang11d_tab.cpp"
+#line 3055 "lang11d_tab.cpp"
     break;
 
-  case 89: /* qual: exprseq nextqual  */
-#line 548 "lang11d"
+  case 92: /* qual: exprseq nextqual  */
+#line 634 "lang11d"
                         {
 				PyrSlot slot;
 				SetSymbol(&slot, getsym("if"));
@@ -2939,19 +3066,19 @@ yyreduce:
 
 				yyval = (intptr_t)newPyrCallNode(selectornode, args2, 0, 0);
 			}
-#line 2943 "lang11d_tab.cpp"
+#line 3070 "lang11d_tab.cpp"
     break;
 
-  case 90: /* qual: ':' ':' exprseq nextqual  */
-#line 559 "lang11d"
+  case 93: /* qual: ':' ':' exprseq nextqual  */
+#line 645 "lang11d"
                         {
 				yyval = (intptr_t)newPyrDropNode((PyrParseNode*)yyvsp[-1], (PyrParseNode*)yyvsp[0]);
 			}
-#line 2951 "lang11d_tab.cpp"
+#line 3078 "lang11d_tab.cpp"
     break;
 
-  case 91: /* qual: ':' WHILE exprseq nextqual  */
-#line 563 "lang11d"
+  case 94: /* qual: ':' WHILE exprseq nextqual  */
+#line 649 "lang11d"
                         {
 				PyrSlot slot;
 				SetSymbol(&slot, getsym("alwaysYield"));
@@ -2974,21 +3101,21 @@ yyreduce:
 
 				yyval = (intptr_t)newPyrCallNode(selectornode2, args3, 0, 0);
 			}
-#line 2978 "lang11d_tab.cpp"
+#line 3105 "lang11d_tab.cpp"
     break;
 
-  case 98: /* expr1: '(' exprseq ')'  */
-#line 594 "lang11d"
+  case 101: /* expr1: '(' exprseq ')'  */
+#line 680 "lang11d"
                         {
 				PyrParseNode* node = (PyrParseNode*)yyvsp[-1];
 				node->mParens = 1;
 				yyval = yyvsp[-1];
 			}
-#line 2988 "lang11d_tab.cpp"
+#line 3115 "lang11d_tab.cpp"
     break;
 
-  case 99: /* expr1: '~' name  */
-#line 600 "lang11d"
+  case 102: /* expr1: '~' name  */
+#line 686 "lang11d"
                         {
 				PyrParseNode* argnode;
 				PyrSlotNode* selectornode;
@@ -2998,41 +3125,41 @@ yyreduce:
 				selectornode = newPyrSlotNode(&slot);
 				yyval = (intptr_t)newPyrCallNode(selectornode, argnode, 0, 0);
 			}
-#line 3002 "lang11d_tab.cpp"
+#line 3129 "lang11d_tab.cpp"
     break;
 
-  case 100: /* expr1: '[' arrayelems ']'  */
-#line 610 "lang11d"
+  case 103: /* expr1: '[' arrayelems ']'  */
+#line 696 "lang11d"
                         { yyval = (intptr_t)newPyrDynListNode(0, (PyrParseNode*)yyvsp[-1]); }
-#line 3008 "lang11d_tab.cpp"
+#line 3135 "lang11d_tab.cpp"
     break;
 
-  case 101: /* expr1: '(' valrange2 ')'  */
-#line 612 "lang11d"
+  case 104: /* expr1: '(' valrange2 ')'  */
+#line 698 "lang11d"
                         { yyval = yyvsp[-1]; }
-#line 3014 "lang11d_tab.cpp"
+#line 3141 "lang11d_tab.cpp"
     break;
 
-  case 102: /* expr1: '(' ':' valrange3 ')'  */
-#line 614 "lang11d"
+  case 105: /* expr1: '(' ':' valrange3 ')'  */
+#line 700 "lang11d"
                         { yyval = yyvsp[-1]; }
-#line 3020 "lang11d_tab.cpp"
+#line 3147 "lang11d_tab.cpp"
     break;
 
-  case 103: /* expr1: '(' dictslotlist ')'  */
-#line 616 "lang11d"
+  case 106: /* expr1: '(' dictslotlist ')'  */
+#line 702 "lang11d"
                         { yyval = (intptr_t)newPyrDynDictNode((PyrParseNode*)yyvsp[-1]); }
-#line 3026 "lang11d_tab.cpp"
+#line 3153 "lang11d_tab.cpp"
     break;
 
-  case 104: /* expr1: pseudovar  */
-#line 618 "lang11d"
+  case 107: /* expr1: pseudovar  */
+#line 704 "lang11d"
                         { yyval = (intptr_t)newPyrPushNameNode((PyrSlotNode*)yyvsp[0]); }
-#line 3032 "lang11d_tab.cpp"
+#line 3159 "lang11d_tab.cpp"
     break;
 
-  case 105: /* expr1: expr1 '[' arglist1 ']'  */
-#line 620 "lang11d"
+  case 108: /* expr1: expr1 '[' arglist1 ']'  */
+#line 706 "lang11d"
                         {
 				PyrSlotNode *selectornode;
 				PyrSlot slot;
@@ -3045,11 +3172,11 @@ yyreduce:
 					(PyrParseNode*)yyvsp[-1]);
 				yyval = (intptr_t)newPyrCallNode(selectornode, args, 0, 0);
 			}
-#line 3049 "lang11d_tab.cpp"
+#line 3176 "lang11d_tab.cpp"
     break;
 
-  case 107: /* valrangex1: expr1 '[' arglist1 DOTDOT ']'  */
-#line 636 "lang11d"
+  case 110: /* valrangex1: expr1 '[' arglist1 DOTDOT ']'  */
+#line 722 "lang11d"
                         {
 				PyrSlotNode *selectornode;
 				PyrPushLitNode *nilnode1, *nilnode2;
@@ -3076,11 +3203,11 @@ yyreduce:
 				args = linkNextNode(args, nilnode2);
 				yyval = (intptr_t)newPyrCallNode(selectornode, args, 0, 0);
 			}
-#line 3080 "lang11d_tab.cpp"
+#line 3207 "lang11d_tab.cpp"
     break;
 
-  case 108: /* valrangex1: expr1 '[' DOTDOT exprseq ']'  */
-#line 663 "lang11d"
+  case 111: /* valrangex1: expr1 '[' DOTDOT exprseq ']'  */
+#line 749 "lang11d"
                         {
 				PyrSlotNode *selectornode;
 				PyrPushLitNode *nilnode1, *nilnode2;
@@ -3098,11 +3225,11 @@ yyreduce:
 				args = linkNextNode(args, (PyrParseNode*)yyvsp[-1]);
 				yyval = (intptr_t)newPyrCallNode(selectornode, args, 0, 0);
 			}
-#line 3102 "lang11d_tab.cpp"
+#line 3229 "lang11d_tab.cpp"
     break;
 
-  case 109: /* valrangex1: expr1 '[' arglist1 DOTDOT exprseq ']'  */
-#line 681 "lang11d"
+  case 112: /* valrangex1: expr1 '[' arglist1 DOTDOT exprseq ']'  */
+#line 767 "lang11d"
                         {
 				PyrSlotNode *selectornode;
 				PyrPushLitNode *nilnode1;
@@ -3127,11 +3254,11 @@ yyreduce:
 				args = linkNextNode(args, (PyrParseNode*)yyvsp[-1]);
 				yyval = (intptr_t)newPyrCallNode(selectornode, args, 0, 0);
 			}
-#line 3131 "lang11d_tab.cpp"
+#line 3258 "lang11d_tab.cpp"
     break;
 
-  case 110: /* valrangeassign: expr1 '[' arglist1 DOTDOT ']' '=' expr  */
-#line 708 "lang11d"
+  case 113: /* valrangeassign: expr1 '[' arglist1 DOTDOT ']' '=' expr  */
+#line 794 "lang11d"
                         {
 				PyrSlotNode *selectornode;
 				PyrPushLitNode *nilnode1, *nilnode2;
@@ -3159,11 +3286,11 @@ yyreduce:
 				args = linkNextNode(args, (PyrParseNode*)yyvsp[0]);
 				yyval = (intptr_t)newPyrCallNode(selectornode, args, 0, 0);
 			}
-#line 3163 "lang11d_tab.cpp"
+#line 3290 "lang11d_tab.cpp"
     break;
 
-  case 111: /* valrangeassign: expr1 '[' DOTDOT exprseq ']' '=' expr  */
-#line 736 "lang11d"
+  case 114: /* valrangeassign: expr1 '[' DOTDOT exprseq ']' '=' expr  */
+#line 822 "lang11d"
                         {
 				PyrSlotNode *selectornode;
 				PyrPushLitNode *nilnode1, *nilnode2;
@@ -3182,11 +3309,11 @@ yyreduce:
 				args = linkNextNode(args, (PyrParseNode*)yyvsp[0]);
 				yyval = (intptr_t)newPyrCallNode(selectornode, args, 0, 0);
 			}
-#line 3186 "lang11d_tab.cpp"
+#line 3313 "lang11d_tab.cpp"
     break;
 
-  case 112: /* valrangeassign: expr1 '[' arglist1 DOTDOT exprseq ']' '=' expr  */
-#line 755 "lang11d"
+  case 115: /* valrangeassign: expr1 '[' arglist1 DOTDOT exprseq ']' '=' expr  */
+#line 841 "lang11d"
                         {
 				PyrSlotNode *selectornode;
 				PyrPushLitNode *nilnode1;
@@ -3212,11 +3339,11 @@ yyreduce:
 				args = linkNextNode(args, (PyrParseNode*)yyvsp[0]);
 				yyval = (intptr_t)newPyrCallNode(selectornode, args, 0, 0);
 			}
-#line 3216 "lang11d_tab.cpp"
+#line 3343 "lang11d_tab.cpp"
     break;
 
-  case 113: /* valrangexd: expr '.' '[' arglist1 DOTDOT ']'  */
-#line 783 "lang11d"
+  case 116: /* valrangexd: expr '.' '[' arglist1 DOTDOT ']'  */
+#line 869 "lang11d"
                         {
 				PyrSlotNode *selectornode;
 				PyrPushLitNode *nilnode1, *nilnode2;
@@ -3243,11 +3370,11 @@ yyreduce:
 				args = linkNextNode(args, nilnode2);
 				yyval = (intptr_t)newPyrCallNode(selectornode, args, 0, 0);
 			}
-#line 3247 "lang11d_tab.cpp"
+#line 3374 "lang11d_tab.cpp"
     break;
 
-  case 114: /* valrangexd: expr '.' '[' DOTDOT exprseq ']'  */
-#line 810 "lang11d"
+  case 117: /* valrangexd: expr '.' '[' DOTDOT exprseq ']'  */
+#line 896 "lang11d"
                         {
 				PyrSlotNode *selectornode;
 				PyrPushLitNode *nilnode1, *nilnode2;
@@ -3265,11 +3392,11 @@ yyreduce:
 				args = linkNextNode(args, (PyrParseNode*)yyvsp[-1]);
 				yyval = (intptr_t)newPyrCallNode(selectornode, args, 0, 0);
 			}
-#line 3269 "lang11d_tab.cpp"
+#line 3396 "lang11d_tab.cpp"
     break;
 
-  case 115: /* valrangexd: expr '.' '[' arglist1 DOTDOT exprseq ']'  */
-#line 828 "lang11d"
+  case 118: /* valrangexd: expr '.' '[' arglist1 DOTDOT exprseq ']'  */
+#line 914 "lang11d"
                         {
 				PyrSlotNode *selectornode;
 				PyrPushLitNode *nilnode1;
@@ -3294,11 +3421,11 @@ yyreduce:
 				args = linkNextNode(args, (PyrParseNode*)yyvsp[-1]);
 				yyval = (intptr_t)newPyrCallNode(selectornode, args, 0, 0);
 			}
-#line 3298 "lang11d_tab.cpp"
+#line 3425 "lang11d_tab.cpp"
     break;
 
-  case 116: /* valrangexd: expr '.' '[' arglist1 DOTDOT ']' '=' expr  */
-#line 853 "lang11d"
+  case 119: /* valrangexd: expr '.' '[' arglist1 DOTDOT ']' '=' expr  */
+#line 939 "lang11d"
                         {
 				PyrSlotNode *selectornode;
 				PyrPushLitNode *nilnode1, *nilnode2;
@@ -3326,11 +3453,11 @@ yyreduce:
 				args = linkNextNode(args, (PyrParseNode*)yyvsp[0]);
 				yyval = (intptr_t)newPyrCallNode(selectornode, args, 0, 0);
 			}
-#line 3330 "lang11d_tab.cpp"
+#line 3457 "lang11d_tab.cpp"
     break;
 
-  case 117: /* valrangexd: expr '.' '[' DOTDOT exprseq ']' '=' expr  */
-#line 881 "lang11d"
+  case 120: /* valrangexd: expr '.' '[' DOTDOT exprseq ']' '=' expr  */
+#line 967 "lang11d"
                         {
 				PyrSlotNode *selectornode;
 				PyrPushLitNode *nilnode1, *nilnode2;
@@ -3349,11 +3476,11 @@ yyreduce:
 				args = linkNextNode(args, (PyrParseNode*)yyvsp[0]);
 				yyval = (intptr_t)newPyrCallNode(selectornode, args, 0, 0);
 			}
-#line 3353 "lang11d_tab.cpp"
+#line 3480 "lang11d_tab.cpp"
     break;
 
-  case 118: /* valrangexd: expr '.' '[' arglist1 DOTDOT exprseq ']' '=' expr  */
-#line 900 "lang11d"
+  case 121: /* valrangexd: expr '.' '[' arglist1 DOTDOT exprseq ']' '=' expr  */
+#line 986 "lang11d"
                         {
 				PyrSlotNode *selectornode;
 				PyrPushLitNode *nilnode1;
@@ -3379,11 +3506,11 @@ yyreduce:
 				args = linkNextNode(args, (PyrParseNode*)yyvsp[0]);
 				yyval = (intptr_t)newPyrCallNode(selectornode, args, 0, 0);
 			}
-#line 3383 "lang11d_tab.cpp"
+#line 3510 "lang11d_tab.cpp"
     break;
 
-  case 119: /* valrange2: exprseq DOTDOT  */
-#line 928 "lang11d"
+  case 122: /* valrange2: exprseq DOTDOT  */
+#line 1014 "lang11d"
                         {
 				// if this is not used in a 'do' or list comprehension, then should return an error.
 				PyrSlotNode *selectornode;
@@ -3401,11 +3528,11 @@ yyreduce:
 				args = linkNextNode(args, nilnode2);
 				yyval = (intptr_t)newPyrCallNode(selectornode, args, 0, 0);
 			}
-#line 3405 "lang11d_tab.cpp"
+#line 3532 "lang11d_tab.cpp"
     break;
 
-  case 120: /* valrange2: DOTDOT exprseq  */
-#line 947 "lang11d"
+  case 123: /* valrange2: DOTDOT exprseq  */
+#line 1033 "lang11d"
                         {
 				PyrSlotNode *selectornode;
 				PyrPushLitNode *nilnode, *zeronode;
@@ -3423,11 +3550,11 @@ yyreduce:
 				args = linkNextNode(args, (PyrParseNode*)yyvsp[0]);
 				yyval = (intptr_t)newPyrCallNode(selectornode, args, 0, 0);
 			}
-#line 3427 "lang11d_tab.cpp"
+#line 3554 "lang11d_tab.cpp"
     break;
 
-  case 121: /* valrange2: exprseq DOTDOT exprseq  */
-#line 966 "lang11d"
+  case 124: /* valrange2: exprseq DOTDOT exprseq  */
+#line 1052 "lang11d"
                         {
 				PyrSlotNode *selectornode;
 				PyrPushLitNode *nilnode;
@@ -3443,11 +3570,11 @@ yyreduce:
 				args = linkNextNode(args, (PyrParseNode*)yyvsp[0]);
 				yyval = (intptr_t)newPyrCallNode(selectornode, args, 0, 0);
 			}
-#line 3447 "lang11d_tab.cpp"
+#line 3574 "lang11d_tab.cpp"
     break;
 
-  case 122: /* valrange2: exprseq ',' exprseq DOTDOT exprseq  */
-#line 983 "lang11d"
+  case 125: /* valrange2: exprseq ',' exprseq DOTDOT exprseq  */
+#line 1069 "lang11d"
                         {
 				PyrSlotNode *selectornode;
 				PyrSlot selectorSlot;
@@ -3461,11 +3588,11 @@ yyreduce:
 				args = linkNextNode(args, (PyrParseNode*)yyvsp[0]);
 				yyval = (intptr_t)newPyrCallNode(selectornode, args, 0, 0);
 			}
-#line 3465 "lang11d_tab.cpp"
+#line 3592 "lang11d_tab.cpp"
     break;
 
-  case 123: /* valrange2: exprseq ',' exprseq DOTDOT  */
-#line 997 "lang11d"
+  case 126: /* valrange2: exprseq ',' exprseq DOTDOT  */
+#line 1083 "lang11d"
                         {
 				// if this is not used in a 'do' or list comprehension, then should return an error.
 				PyrSlotNode *selectornode;
@@ -3484,11 +3611,11 @@ yyreduce:
 				args = linkNextNode(args, nilnode);
 				yyval = (intptr_t)newPyrCallNode(selectornode, args, 0, 0);
 			}
-#line 3488 "lang11d_tab.cpp"
+#line 3615 "lang11d_tab.cpp"
     break;
 
-  case 124: /* valrange3: DOTDOT exprseq  */
-#line 1018 "lang11d"
+  case 127: /* valrange3: DOTDOT exprseq  */
+#line 1104 "lang11d"
                         {
 				PyrSlotNode *selectornode;
 				PyrPushLitNode *nilnode, *zeronode;
@@ -3506,11 +3633,11 @@ yyreduce:
 				args = linkNextNode(args, (PyrParseNode*)yyvsp[0]);
 				yyval = (intptr_t)newPyrCallNode(selectornode, args, 0, 0);
 			}
-#line 3510 "lang11d_tab.cpp"
+#line 3637 "lang11d_tab.cpp"
     break;
 
-  case 125: /* valrange3: exprseq DOTDOT  */
-#line 1037 "lang11d"
+  case 128: /* valrange3: exprseq DOTDOT  */
+#line 1123 "lang11d"
                         {
 				PyrSlotNode *selectornode;
 				PyrPushLitNode *nilnode, *nilnode2;
@@ -3527,11 +3654,11 @@ yyreduce:
 				args = linkNextNode(args, nilnode2);
 				yyval = (intptr_t)newPyrCallNode(selectornode, args, 0, 0);
 			}
-#line 3531 "lang11d_tab.cpp"
+#line 3658 "lang11d_tab.cpp"
     break;
 
-  case 126: /* valrange3: exprseq DOTDOT exprseq  */
-#line 1055 "lang11d"
+  case 129: /* valrange3: exprseq DOTDOT exprseq  */
+#line 1141 "lang11d"
                         {
 				PyrSlotNode *selectornode;
 				PyrPushLitNode *nilnode;
@@ -3547,11 +3674,11 @@ yyreduce:
 				args = linkNextNode(args, (PyrParseNode*)yyvsp[0]);
 				yyval = (intptr_t)newPyrCallNode(selectornode, args, 0, 0);
 			}
-#line 3551 "lang11d_tab.cpp"
+#line 3678 "lang11d_tab.cpp"
     break;
 
-  case 127: /* valrange3: exprseq ',' exprseq DOTDOT  */
-#line 1072 "lang11d"
+  case 130: /* valrange3: exprseq ',' exprseq DOTDOT  */
+#line 1158 "lang11d"
                         {
 				PyrSlotNode *selectornode;
 				PyrPushLitNode *nilnode;
@@ -3567,11 +3694,11 @@ yyreduce:
 				args = linkNextNode(args, nilnode);
 				yyval = (intptr_t)newPyrCallNode(selectornode, args, 0, 0);
 			}
-#line 3571 "lang11d_tab.cpp"
+#line 3698 "lang11d_tab.cpp"
     break;
 
-  case 128: /* valrange3: exprseq ',' exprseq DOTDOT exprseq  */
-#line 1088 "lang11d"
+  case 131: /* valrange3: exprseq ',' exprseq DOTDOT exprseq  */
+#line 1174 "lang11d"
                         {
 				PyrSlotNode *selectornode;
 				PyrSlot selectorSlot;
@@ -3585,17 +3712,17 @@ yyreduce:
 				args = linkNextNode(args, (PyrParseNode*)yyvsp[0]);
 				yyval = (intptr_t)newPyrCallNode(selectornode, args, 0, 0);
 			}
-#line 3589 "lang11d_tab.cpp"
+#line 3716 "lang11d_tab.cpp"
     break;
 
-  case 132: /* expr: classname  */
-#line 1106 "lang11d"
+  case 135: /* expr: classname  */
+#line 1192 "lang11d"
                             { yyval = (intptr_t)newPyrPushNameNode((PyrSlotNode*)yyvsp[0]); }
-#line 3595 "lang11d_tab.cpp"
+#line 3722 "lang11d_tab.cpp"
     break;
 
-  case 133: /* expr: expr '.' '[' arglist1 ']'  */
-#line 1108 "lang11d"
+  case 136: /* expr: expr '.' '[' arglist1 ']'  */
+#line 1194 "lang11d"
                         {
 				PyrSlotNode *selectornode;
 				PyrSlot slot;
@@ -3608,11 +3735,11 @@ yyreduce:
 					(PyrParseNode*)yyvsp[-1]);
 				yyval = (intptr_t)newPyrCallNode(selectornode, args, 0, 0);
 			}
-#line 3612 "lang11d_tab.cpp"
+#line 3739 "lang11d_tab.cpp"
     break;
 
-  case 134: /* expr: '`' expr  */
-#line 1121 "lang11d"
+  case 137: /* expr: '`' expr  */
+#line 1207 "lang11d"
                         {
 				PyrParseNode *node, *args;
 				PyrSlotNode *slotnode;
@@ -3626,28 +3753,28 @@ yyreduce:
 				slotnode = newPyrSlotNode(&slot);
 				yyval = (intptr_t)newPyrCallNode(slotnode, args, 0, 0);
 			}
-#line 3630 "lang11d_tab.cpp"
+#line 3757 "lang11d_tab.cpp"
     break;
 
-  case 135: /* expr: expr binop2 adverb expr  */
-#line 1135 "lang11d"
+  case 138: /* expr: expr binop2 adverb expr  */
+#line 1221 "lang11d"
                         {
 				yyval = (intptr_t)newPyrBinopCallNode((PyrSlotNode*)yyvsp[-2],
 						(PyrParseNode*)yyvsp[-3], (PyrParseNode*)yyvsp[0], (PyrParseNode*)yyvsp[-1]);
 			}
-#line 3639 "lang11d_tab.cpp"
+#line 3766 "lang11d_tab.cpp"
     break;
 
-  case 136: /* expr: name '=' expr  */
-#line 1140 "lang11d"
+  case 139: /* expr: name '=' expr  */
+#line 1226 "lang11d"
                         {
 				yyval = (intptr_t)newPyrAssignNode((PyrSlotNode*)yyvsp[-2], (PyrParseNode*)yyvsp[0], 0);
 			}
-#line 3647 "lang11d_tab.cpp"
+#line 3774 "lang11d_tab.cpp"
     break;
 
-  case 137: /* expr: '~' name '=' expr  */
-#line 1144 "lang11d"
+  case 140: /* expr: '~' name '=' expr  */
+#line 1230 "lang11d"
                         {
 				PyrParseNode *argnode, *args;
 				PyrSlotNode* selectornode;
@@ -3658,20 +3785,20 @@ yyreduce:
 				selectornode = newPyrSlotNode(&slot);
 				yyval = (intptr_t)newPyrCallNode(selectornode, args, 0, 0);
 			}
-#line 3662 "lang11d_tab.cpp"
+#line 3789 "lang11d_tab.cpp"
     break;
 
-  case 138: /* expr: expr '.' name '=' expr  */
-#line 1155 "lang11d"
+  case 141: /* expr: expr '.' name '=' expr  */
+#line 1241 "lang11d"
                         {
 				yyval = (intptr_t)newPyrSetterNode((PyrSlotNode*)yyvsp[-2],
 						(PyrParseNode*)yyvsp[-4], (PyrParseNode*)yyvsp[0]);
 			}
-#line 3671 "lang11d_tab.cpp"
+#line 3798 "lang11d_tab.cpp"
     break;
 
-  case 139: /* expr: name '(' arglist1 optkeyarglist ')' '=' expr  */
-#line 1160 "lang11d"
+  case 142: /* expr: name '(' arglist1 optkeyarglist ')' '=' expr  */
+#line 1246 "lang11d"
                         {
 				if (yyvsp[-3] != 0) {
 					error("Setter method called with keyword arguments.\n");
@@ -3681,20 +3808,20 @@ yyreduce:
 				yyval = (intptr_t)newPyrSetterNode((PyrSlotNode*)yyvsp[-6],
 						(PyrParseNode*)yyvsp[-4], (PyrParseNode*)yyvsp[0]);
 			}
-#line 3685 "lang11d_tab.cpp"
+#line 3812 "lang11d_tab.cpp"
     break;
 
-  case 140: /* expr: '#' mavars '=' expr  */
-#line 1170 "lang11d"
+  case 143: /* expr: '#' mavars '=' expr  */
+#line 1256 "lang11d"
                         {
 				yyval = (intptr_t)newPyrMultiAssignNode((PyrMultiAssignVarListNode*)yyvsp[-2],
 					(PyrParseNode*)yyvsp[0], 0);
 			}
-#line 3694 "lang11d_tab.cpp"
+#line 3821 "lang11d_tab.cpp"
     break;
 
-  case 141: /* expr: expr1 '[' arglist1 ']' '=' expr  */
-#line 1175 "lang11d"
+  case 144: /* expr: expr1 '[' arglist1 ']' '=' expr  */
+#line 1261 "lang11d"
                         {
 				PyrSlotNode *selectornode;
 				PyrSlot slot;
@@ -3708,11 +3835,11 @@ yyreduce:
 				args = linkNextNode( args, (PyrParseNode*)yyvsp[0]);
 				yyval = (intptr_t)newPyrCallNode(selectornode, args, 0, 0);
 			}
-#line 3712 "lang11d_tab.cpp"
+#line 3839 "lang11d_tab.cpp"
     break;
 
-  case 142: /* expr: expr '.' '[' arglist1 ']' '=' expr  */
-#line 1189 "lang11d"
+  case 145: /* expr: expr '.' '[' arglist1 ']' '=' expr  */
+#line 1275 "lang11d"
                         {
 				PyrSlotNode *selectornode;
 				PyrSlot slot;
@@ -3726,737 +3853,737 @@ yyreduce:
 				args = linkNextNode( args, (PyrParseNode*)yyvsp[0]);
 				yyval = (intptr_t)newPyrCallNode(selectornode, args, 0, 0);
 			}
-#line 3730 "lang11d_tab.cpp"
+#line 3857 "lang11d_tab.cpp"
     break;
 
-  case 143: /* adverb: %empty  */
-#line 1204 "lang11d"
+  case 146: /* adverb: %empty  */
+#line 1290 "lang11d"
           { yyval = 0; }
-#line 3736 "lang11d_tab.cpp"
+#line 3863 "lang11d_tab.cpp"
     break;
 
-  case 144: /* adverb: '.' name  */
-#line 1205 "lang11d"
+  case 147: /* adverb: '.' name  */
+#line 1291 "lang11d"
                            { yyval = (intptr_t)newPyrPushLitNode((PyrSlotNode*)yyvsp[0], NULL); }
-#line 3742 "lang11d_tab.cpp"
+#line 3869 "lang11d_tab.cpp"
     break;
 
-  case 145: /* adverb: '.' integer  */
-#line 1206 "lang11d"
+  case 148: /* adverb: '.' integer  */
+#line 1292 "lang11d"
                               { yyval = (intptr_t)newPyrPushLitNode((PyrSlotNode*)yyvsp[0], NULL); }
-#line 3748 "lang11d_tab.cpp"
+#line 3875 "lang11d_tab.cpp"
     break;
 
-  case 146: /* adverb: '.' '(' exprseq ')'  */
-#line 1207 "lang11d"
+  case 149: /* adverb: '.' '(' exprseq ')'  */
+#line 1293 "lang11d"
                                       { yyval = yyvsp[-1]; }
-#line 3754 "lang11d_tab.cpp"
+#line 3881 "lang11d_tab.cpp"
     break;
 
-  case 148: /* exprn: exprn ';' expr  */
-#line 1212 "lang11d"
+  case 151: /* exprn: exprn ';' expr  */
+#line 1298 "lang11d"
                         {
 				yyval = (intptr_t)newPyrDropNode((PyrParseNode*)yyvsp[-2], (PyrParseNode*)yyvsp[0]);
 			}
-#line 3762 "lang11d_tab.cpp"
+#line 3889 "lang11d_tab.cpp"
     break;
 
-  case 150: /* arrayelems: %empty  */
-#line 1220 "lang11d"
+  case 153: /* arrayelems: %empty  */
+#line 1306 "lang11d"
                   { yyval = 0; }
-#line 3768 "lang11d_tab.cpp"
+#line 3895 "lang11d_tab.cpp"
     break;
 
-  case 151: /* arrayelems: arrayelems1 optcomma  */
-#line 1222 "lang11d"
+  case 154: /* arrayelems: arrayelems1 optcomma  */
+#line 1308 "lang11d"
                           { yyval = yyvsp[-1]; }
-#line 3774 "lang11d_tab.cpp"
+#line 3901 "lang11d_tab.cpp"
     break;
 
-  case 153: /* arrayelems1: exprseq ':' exprseq  */
-#line 1227 "lang11d"
+  case 156: /* arrayelems1: exprseq ':' exprseq  */
+#line 1313 "lang11d"
                                 { yyval = (intptr_t)linkNextNode((PyrParseNode*)yyvsp[-2], (PyrParseNode*)yyvsp[0]); }
-#line 3780 "lang11d_tab.cpp"
+#line 3907 "lang11d_tab.cpp"
     break;
 
-  case 154: /* arrayelems1: keybinop exprseq  */
-#line 1229 "lang11d"
+  case 157: /* arrayelems1: keybinop exprseq  */
+#line 1315 "lang11d"
                                 {
 					PyrParseNode* key = newPyrPushLitNode((PyrSlotNode*)yyvsp[-1], NULL);
 					yyval = (intptr_t)linkNextNode(key, (PyrParseNode*)yyvsp[0]);
 				}
-#line 3789 "lang11d_tab.cpp"
+#line 3916 "lang11d_tab.cpp"
     break;
 
-  case 155: /* arrayelems1: arrayelems1 ',' exprseq  */
-#line 1234 "lang11d"
+  case 158: /* arrayelems1: arrayelems1 ',' exprseq  */
+#line 1320 "lang11d"
                                         { yyval = (intptr_t)linkNextNode((PyrParseNode*)yyvsp[-2], (PyrParseNode*)yyvsp[0]); }
-#line 3795 "lang11d_tab.cpp"
+#line 3922 "lang11d_tab.cpp"
     break;
 
-  case 156: /* arrayelems1: arrayelems1 ',' keybinop exprseq  */
-#line 1236 "lang11d"
+  case 159: /* arrayelems1: arrayelems1 ',' keybinop exprseq  */
+#line 1322 "lang11d"
                                 {
 					PyrParseNode* elems;
 					PyrParseNode* key = newPyrPushLitNode((PyrSlotNode*)yyvsp[-1], NULL);
 					elems = (PyrParseNode*)linkNextNode(key, (PyrParseNode*)yyvsp[0]);
 					yyval = (intptr_t)linkNextNode((PyrParseNode*)yyvsp[-3], elems);
 				}
-#line 3806 "lang11d_tab.cpp"
+#line 3933 "lang11d_tab.cpp"
     break;
 
-  case 157: /* arrayelems1: arrayelems1 ',' exprseq ':' exprseq  */
-#line 1243 "lang11d"
+  case 160: /* arrayelems1: arrayelems1 ',' exprseq ':' exprseq  */
+#line 1329 "lang11d"
                                 {
 					PyrParseNode* elems;
 					elems = (PyrParseNode*)linkNextNode((PyrParseNode*)yyvsp[-2], (PyrParseNode*)yyvsp[0]);
 					yyval = (intptr_t)linkNextNode((PyrParseNode*)yyvsp[-4], elems);
 				}
-#line 3816 "lang11d_tab.cpp"
+#line 3943 "lang11d_tab.cpp"
     break;
 
-  case 159: /* arglist1: arglist1 ',' exprseq  */
-#line 1252 "lang11d"
+  case 162: /* arglist1: arglist1 ',' exprseq  */
+#line 1338 "lang11d"
                                         { yyval = (intptr_t)linkNextNode((PyrParseNode*)yyvsp[-2], (PyrParseNode*)yyvsp[0]); }
-#line 3822 "lang11d_tab.cpp"
+#line 3949 "lang11d_tab.cpp"
     break;
 
-  case 160: /* arglistv1: '*' exprseq  */
-#line 1256 "lang11d"
+  case 163: /* argListWithPerformList: '*' exprseq  */
+#line 1342 "lang11d"
                                 { yyval = yyvsp[0]; }
-#line 3828 "lang11d_tab.cpp"
+#line 3955 "lang11d_tab.cpp"
     break;
 
-  case 161: /* arglistv1: arglist1 ',' '*' exprseq  */
-#line 1258 "lang11d"
+  case 164: /* argListWithPerformList: arglist1 ',' '*' exprseq  */
+#line 1344 "lang11d"
                                         { yyval = (intptr_t)linkNextNode((PyrParseNode*)yyvsp[-3], (PyrParseNode*)yyvsp[0]); }
-#line 3834 "lang11d_tab.cpp"
+#line 3961 "lang11d_tab.cpp"
     break;
 
-  case 163: /* keyarglist1: keyarglist1 ',' keyarg  */
-#line 1263 "lang11d"
+  case 166: /* keyarglist1: keyarglist1 ',' keyarg  */
+#line 1349 "lang11d"
                                         { yyval = (intptr_t)linkNextNode((PyrParseNode*)yyvsp[-2], (PyrParseNode*)yyvsp[0]); }
-#line 3840 "lang11d_tab.cpp"
+#line 3967 "lang11d_tab.cpp"
     break;
 
-  case 164: /* keyarg: keybinop exprseq  */
-#line 1267 "lang11d"
+  case 167: /* keyarg: keybinop exprseq  */
+#line 1353 "lang11d"
                                 { yyval = (intptr_t)newPyrPushKeyArgNode((PyrSlotNode*)yyvsp[-1], (PyrParseNode*)yyvsp[0]); }
-#line 3846 "lang11d_tab.cpp"
+#line 3973 "lang11d_tab.cpp"
     break;
 
-  case 165: /* optkeyarglist: optcomma  */
-#line 1270 "lang11d"
+  case 168: /* optkeyarglist: optcomma  */
+#line 1356 "lang11d"
                            { yyval = 0; }
-#line 3852 "lang11d_tab.cpp"
+#line 3979 "lang11d_tab.cpp"
     break;
 
-  case 166: /* optkeyarglist: ',' keyarglist1 optcomma  */
-#line 1271 "lang11d"
+  case 169: /* optkeyarglist: ',' keyarglist1 optcomma  */
+#line 1357 "lang11d"
                                                            { yyval = yyvsp[-1]; }
-#line 3858 "lang11d_tab.cpp"
+#line 3985 "lang11d_tab.cpp"
     break;
 
-  case 167: /* mavars: mavarlist  */
-#line 1275 "lang11d"
+  case 170: /* mavars: mavarlist  */
+#line 1361 "lang11d"
                         { yyval = (intptr_t)newPyrMultiAssignVarListNode((PyrSlotNode*)yyvsp[0], NULL); }
-#line 3864 "lang11d_tab.cpp"
+#line 3991 "lang11d_tab.cpp"
     break;
 
-  case 168: /* mavars: mavarlist ELLIPSIS name  */
-#line 1277 "lang11d"
+  case 171: /* mavars: mavarlist ELLIPSIS name  */
+#line 1363 "lang11d"
                         { yyval = (intptr_t)newPyrMultiAssignVarListNode((PyrSlotNode*)yyvsp[-2], (PyrSlotNode*)yyvsp[0]); }
-#line 3870 "lang11d_tab.cpp"
+#line 3997 "lang11d_tab.cpp"
     break;
 
-  case 170: /* mavarlist: mavarlist ',' name  */
-#line 1282 "lang11d"
+  case 173: /* mavarlist: mavarlist ',' name  */
+#line 1368 "lang11d"
                                         { yyval = (intptr_t)linkNextNode((PyrParseNode*)yyvsp[-2], (PyrParseNode*)yyvsp[0]); }
-#line 3876 "lang11d_tab.cpp"
+#line 4003 "lang11d_tab.cpp"
     break;
 
-  case 171: /* slotliteral: integer  */
-#line 1286 "lang11d"
+  case 174: /* slotliteral: integer  */
+#line 1372 "lang11d"
                                 { yyval = (intptr_t)newPyrLiteralNode((PyrSlotNode*)yyvsp[0], NULL); }
-#line 3882 "lang11d_tab.cpp"
+#line 4009 "lang11d_tab.cpp"
     break;
 
-  case 172: /* slotliteral: floatp  */
-#line 1287 "lang11d"
+  case 175: /* slotliteral: floatp  */
+#line 1373 "lang11d"
                                 { yyval = (intptr_t)newPyrLiteralNode((PyrSlotNode*)yyvsp[0], NULL); }
-#line 3888 "lang11d_tab.cpp"
+#line 4015 "lang11d_tab.cpp"
     break;
 
-  case 173: /* slotliteral: ascii  */
-#line 1288 "lang11d"
+  case 176: /* slotliteral: ascii  */
+#line 1374 "lang11d"
                                 { yyval = (intptr_t)newPyrLiteralNode((PyrSlotNode*)yyvsp[0], NULL); }
-#line 3894 "lang11d_tab.cpp"
+#line 4021 "lang11d_tab.cpp"
     break;
 
-  case 174: /* slotliteral: string  */
-#line 1289 "lang11d"
+  case 177: /* slotliteral: string  */
+#line 1375 "lang11d"
                                 { yyval = (intptr_t)newPyrLiteralNode((PyrSlotNode*)yyvsp[0], NULL); }
-#line 3900 "lang11d_tab.cpp"
+#line 4027 "lang11d_tab.cpp"
     break;
 
-  case 175: /* slotliteral: symbol  */
-#line 1290 "lang11d"
+  case 178: /* slotliteral: symbol  */
+#line 1376 "lang11d"
                                 { yyval = (intptr_t)newPyrLiteralNode((PyrSlotNode*)yyvsp[0], NULL); }
-#line 3906 "lang11d_tab.cpp"
+#line 4033 "lang11d_tab.cpp"
     break;
 
-  case 176: /* slotliteral: trueobj  */
-#line 1291 "lang11d"
+  case 179: /* slotliteral: trueobj  */
+#line 1377 "lang11d"
                                 { yyval = (intptr_t)newPyrLiteralNode((PyrSlotNode*)yyvsp[0], NULL); }
-#line 3912 "lang11d_tab.cpp"
+#line 4039 "lang11d_tab.cpp"
     break;
 
-  case 177: /* slotliteral: falseobj  */
-#line 1292 "lang11d"
+  case 180: /* slotliteral: falseobj  */
+#line 1378 "lang11d"
                                 { yyval = (intptr_t)newPyrLiteralNode((PyrSlotNode*)yyvsp[0], NULL); }
-#line 3918 "lang11d_tab.cpp"
+#line 4045 "lang11d_tab.cpp"
     break;
 
-  case 178: /* slotliteral: nilobj  */
-#line 1293 "lang11d"
+  case 181: /* slotliteral: nilobj  */
+#line 1379 "lang11d"
                                 { yyval = (intptr_t)newPyrLiteralNode((PyrSlotNode*)yyvsp[0], NULL); }
-#line 3924 "lang11d_tab.cpp"
+#line 4051 "lang11d_tab.cpp"
     break;
 
-  case 179: /* slotliteral: listlit  */
-#line 1294 "lang11d"
+  case 182: /* slotliteral: listlit  */
+#line 1380 "lang11d"
                                 { yyval = (intptr_t)newPyrLiteralNode(NULL, (PyrParseNode*)yyvsp[0]); }
-#line 3930 "lang11d_tab.cpp"
+#line 4057 "lang11d_tab.cpp"
     break;
 
-  case 180: /* blockliteral: block  */
-#line 1297 "lang11d"
+  case 183: /* blockliteral: block  */
+#line 1383 "lang11d"
                         { yyval = (intptr_t)newPyrPushLitNode(NULL, (PyrParseNode*)yyvsp[0]); }
-#line 3936 "lang11d_tab.cpp"
+#line 4063 "lang11d_tab.cpp"
     break;
 
-  case 181: /* pushname: name  */
-#line 1300 "lang11d"
+  case 184: /* pushname: name  */
+#line 1386 "lang11d"
                                 { yyval = (intptr_t)newPyrPushNameNode((PyrSlotNode*)yyvsp[0]); }
-#line 3942 "lang11d_tab.cpp"
-    break;
-
-  case 182: /* pushliteral: integer  */
-#line 1303 "lang11d"
-                                { yyval = (intptr_t)newPyrPushLitNode((PyrSlotNode*)yyvsp[0], NULL); }
-#line 3948 "lang11d_tab.cpp"
-    break;
-
-  case 183: /* pushliteral: floatp  */
-#line 1304 "lang11d"
-                                        { yyval = (intptr_t)newPyrPushLitNode((PyrSlotNode*)yyvsp[0], NULL); }
-#line 3954 "lang11d_tab.cpp"
-    break;
-
-  case 184: /* pushliteral: ascii  */
-#line 1305 "lang11d"
-                                        { yyval = (intptr_t)newPyrPushLitNode((PyrSlotNode*)yyvsp[0], NULL); }
-#line 3960 "lang11d_tab.cpp"
-    break;
-
-  case 185: /* pushliteral: string  */
-#line 1306 "lang11d"
-                                        { yyval = (intptr_t)newPyrPushLitNode((PyrSlotNode*)yyvsp[0], NULL); }
-#line 3966 "lang11d_tab.cpp"
-    break;
-
-  case 186: /* pushliteral: symbol  */
-#line 1307 "lang11d"
-                                        { yyval = (intptr_t)newPyrPushLitNode((PyrSlotNode*)yyvsp[0], NULL); }
-#line 3972 "lang11d_tab.cpp"
-    break;
-
-  case 187: /* pushliteral: trueobj  */
-#line 1308 "lang11d"
-                                        { yyval = (intptr_t)newPyrPushLitNode((PyrSlotNode*)yyvsp[0], NULL); }
-#line 3978 "lang11d_tab.cpp"
-    break;
-
-  case 188: /* pushliteral: falseobj  */
-#line 1309 "lang11d"
-                                        { yyval = (intptr_t)newPyrPushLitNode((PyrSlotNode*)yyvsp[0], NULL); }
-#line 3984 "lang11d_tab.cpp"
-    break;
-
-  case 189: /* pushliteral: nilobj  */
-#line 1310 "lang11d"
-                                        { yyval = (intptr_t)newPyrPushLitNode((PyrSlotNode*)yyvsp[0], NULL); }
-#line 3990 "lang11d_tab.cpp"
-    break;
-
-  case 190: /* pushliteral: listlit  */
-#line 1311 "lang11d"
-                                        { yyval = (intptr_t)newPyrPushLitNode(NULL, (PyrParseNode*)yyvsp[0]); }
-#line 3996 "lang11d_tab.cpp"
-    break;
-
-  case 191: /* listliteral: integer  */
-#line 1314 "lang11d"
-                                { yyval = (intptr_t)newPyrLiteralNode((PyrSlotNode*)yyvsp[0], NULL); }
-#line 4002 "lang11d_tab.cpp"
-    break;
-
-  case 192: /* listliteral: floatp  */
-#line 1315 "lang11d"
-                                        { yyval = (intptr_t)newPyrLiteralNode((PyrSlotNode*)yyvsp[0], NULL); }
-#line 4008 "lang11d_tab.cpp"
-    break;
-
-  case 193: /* listliteral: ascii  */
-#line 1316 "lang11d"
-                                        { yyval = (intptr_t)newPyrLiteralNode((PyrSlotNode*)yyvsp[0], NULL); }
-#line 4014 "lang11d_tab.cpp"
-    break;
-
-  case 194: /* listliteral: string  */
-#line 1317 "lang11d"
-                                        { yyval = (intptr_t)newPyrLiteralNode((PyrSlotNode*)yyvsp[0], NULL); }
-#line 4020 "lang11d_tab.cpp"
-    break;
-
-  case 195: /* listliteral: symbol  */
-#line 1318 "lang11d"
-                                        { yyval = (intptr_t)newPyrLiteralNode((PyrSlotNode*)yyvsp[0], NULL); }
-#line 4026 "lang11d_tab.cpp"
-    break;
-
-  case 196: /* listliteral: name  */
-#line 1319 "lang11d"
-                                        { yyval = (intptr_t)newPyrLiteralNode((PyrSlotNode*)yyvsp[0], NULL); }
-#line 4032 "lang11d_tab.cpp"
-    break;
-
-  case 197: /* listliteral: trueobj  */
-#line 1320 "lang11d"
-                                        { yyval = (intptr_t)newPyrLiteralNode((PyrSlotNode*)yyvsp[0], NULL); }
-#line 4038 "lang11d_tab.cpp"
-    break;
-
-  case 198: /* listliteral: falseobj  */
-#line 1321 "lang11d"
-                                        { yyval = (intptr_t)newPyrLiteralNode((PyrSlotNode*)yyvsp[0], NULL); }
-#line 4044 "lang11d_tab.cpp"
-    break;
-
-  case 199: /* listliteral: nilobj  */
-#line 1322 "lang11d"
-                                        { yyval = (intptr_t)newPyrLiteralNode((PyrSlotNode*)yyvsp[0], NULL); }
-#line 4050 "lang11d_tab.cpp"
-    break;
-
-  case 200: /* listliteral: listlit2  */
-#line 1323 "lang11d"
-                                        { yyval = (intptr_t)newPyrLiteralNode(NULL, (PyrParseNode*)yyvsp[0]); }
-#line 4056 "lang11d_tab.cpp"
-    break;
-
-  case 201: /* listliteral: dictlit2  */
-#line 1324 "lang11d"
-                                    { yyval = (intptr_t)newPyrLiteralNode(NULL, (PyrParseNode*)yyvsp[0]); }
-#line 4062 "lang11d_tab.cpp"
-    break;
-
-  case 202: /* block: '{' argdecls funcvardecls funcbody '}'  */
-#line 1328 "lang11d"
-                                { yyval = (intptr_t)newPyrBlockNode((PyrArgListNode*)yyvsp[-3], (PyrVarListNode*)yyvsp[-2],
-					(PyrParseNode*)yyvsp[-1], false); }
 #line 4069 "lang11d_tab.cpp"
     break;
 
-  case 203: /* block: BEGINCLOSEDFUNC argdecls funcvardecls funcbody '}'  */
-#line 1331 "lang11d"
+  case 185: /* pushliteral: integer  */
+#line 1389 "lang11d"
+                                { yyval = (intptr_t)newPyrPushLitNode((PyrSlotNode*)yyvsp[0], NULL); }
+#line 4075 "lang11d_tab.cpp"
+    break;
+
+  case 186: /* pushliteral: floatp  */
+#line 1390 "lang11d"
+                                        { yyval = (intptr_t)newPyrPushLitNode((PyrSlotNode*)yyvsp[0], NULL); }
+#line 4081 "lang11d_tab.cpp"
+    break;
+
+  case 187: /* pushliteral: ascii  */
+#line 1391 "lang11d"
+                                        { yyval = (intptr_t)newPyrPushLitNode((PyrSlotNode*)yyvsp[0], NULL); }
+#line 4087 "lang11d_tab.cpp"
+    break;
+
+  case 188: /* pushliteral: string  */
+#line 1392 "lang11d"
+                                        { yyval = (intptr_t)newPyrPushLitNode((PyrSlotNode*)yyvsp[0], NULL); }
+#line 4093 "lang11d_tab.cpp"
+    break;
+
+  case 189: /* pushliteral: symbol  */
+#line 1393 "lang11d"
+                                        { yyval = (intptr_t)newPyrPushLitNode((PyrSlotNode*)yyvsp[0], NULL); }
+#line 4099 "lang11d_tab.cpp"
+    break;
+
+  case 190: /* pushliteral: trueobj  */
+#line 1394 "lang11d"
+                                        { yyval = (intptr_t)newPyrPushLitNode((PyrSlotNode*)yyvsp[0], NULL); }
+#line 4105 "lang11d_tab.cpp"
+    break;
+
+  case 191: /* pushliteral: falseobj  */
+#line 1395 "lang11d"
+                                        { yyval = (intptr_t)newPyrPushLitNode((PyrSlotNode*)yyvsp[0], NULL); }
+#line 4111 "lang11d_tab.cpp"
+    break;
+
+  case 192: /* pushliteral: nilobj  */
+#line 1396 "lang11d"
+                                        { yyval = (intptr_t)newPyrPushLitNode((PyrSlotNode*)yyvsp[0], NULL); }
+#line 4117 "lang11d_tab.cpp"
+    break;
+
+  case 193: /* pushliteral: listlit  */
+#line 1397 "lang11d"
+                                        { yyval = (intptr_t)newPyrPushLitNode(NULL, (PyrParseNode*)yyvsp[0]); }
+#line 4123 "lang11d_tab.cpp"
+    break;
+
+  case 194: /* listliteral: integer  */
+#line 1400 "lang11d"
+                                { yyval = (intptr_t)newPyrLiteralNode((PyrSlotNode*)yyvsp[0], NULL); }
+#line 4129 "lang11d_tab.cpp"
+    break;
+
+  case 195: /* listliteral: floatp  */
+#line 1401 "lang11d"
+                                        { yyval = (intptr_t)newPyrLiteralNode((PyrSlotNode*)yyvsp[0], NULL); }
+#line 4135 "lang11d_tab.cpp"
+    break;
+
+  case 196: /* listliteral: ascii  */
+#line 1402 "lang11d"
+                                        { yyval = (intptr_t)newPyrLiteralNode((PyrSlotNode*)yyvsp[0], NULL); }
+#line 4141 "lang11d_tab.cpp"
+    break;
+
+  case 197: /* listliteral: string  */
+#line 1403 "lang11d"
+                                        { yyval = (intptr_t)newPyrLiteralNode((PyrSlotNode*)yyvsp[0], NULL); }
+#line 4147 "lang11d_tab.cpp"
+    break;
+
+  case 198: /* listliteral: symbol  */
+#line 1404 "lang11d"
+                                        { yyval = (intptr_t)newPyrLiteralNode((PyrSlotNode*)yyvsp[0], NULL); }
+#line 4153 "lang11d_tab.cpp"
+    break;
+
+  case 199: /* listliteral: name  */
+#line 1405 "lang11d"
+                                        { yyval = (intptr_t)newPyrLiteralNode((PyrSlotNode*)yyvsp[0], NULL); }
+#line 4159 "lang11d_tab.cpp"
+    break;
+
+  case 200: /* listliteral: trueobj  */
+#line 1406 "lang11d"
+                                        { yyval = (intptr_t)newPyrLiteralNode((PyrSlotNode*)yyvsp[0], NULL); }
+#line 4165 "lang11d_tab.cpp"
+    break;
+
+  case 201: /* listliteral: falseobj  */
+#line 1407 "lang11d"
+                                        { yyval = (intptr_t)newPyrLiteralNode((PyrSlotNode*)yyvsp[0], NULL); }
+#line 4171 "lang11d_tab.cpp"
+    break;
+
+  case 202: /* listliteral: nilobj  */
+#line 1408 "lang11d"
+                                        { yyval = (intptr_t)newPyrLiteralNode((PyrSlotNode*)yyvsp[0], NULL); }
+#line 4177 "lang11d_tab.cpp"
+    break;
+
+  case 203: /* listliteral: listlit2  */
+#line 1409 "lang11d"
+                                        { yyval = (intptr_t)newPyrLiteralNode(NULL, (PyrParseNode*)yyvsp[0]); }
+#line 4183 "lang11d_tab.cpp"
+    break;
+
+  case 204: /* listliteral: dictlit2  */
+#line 1410 "lang11d"
+                                    { yyval = (intptr_t)newPyrLiteralNode(NULL, (PyrParseNode*)yyvsp[0]); }
+#line 4189 "lang11d_tab.cpp"
+    break;
+
+  case 205: /* block: '{' argdecls funcvardecls funcbody '}'  */
+#line 1414 "lang11d"
+                                { yyval = (intptr_t)newPyrBlockNode((PyrArgListNode*)yyvsp[-3], (PyrVarListNode*)yyvsp[-2],
+					(PyrParseNode*)yyvsp[-1], false); }
+#line 4196 "lang11d_tab.cpp"
+    break;
+
+  case 206: /* block: BEGINCLOSEDFUNC argdecls funcvardecls funcbody '}'  */
+#line 1417 "lang11d"
                                 { yyval = (intptr_t)newPyrBlockNode((PyrArgListNode*)yyvsp[-3], (PyrVarListNode*)yyvsp[-2],
 					(PyrParseNode*)yyvsp[-1], true); }
-#line 4076 "lang11d_tab.cpp"
+#line 4203 "lang11d_tab.cpp"
     break;
 
-  case 204: /* funcvardecls: %empty  */
-#line 1335 "lang11d"
+  case 207: /* funcvardecls: %empty  */
+#line 1421 "lang11d"
                   { yyval = 0; }
-#line 4082 "lang11d_tab.cpp"
+#line 4209 "lang11d_tab.cpp"
     break;
 
-  case 205: /* funcvardecls: funcvardecls funcvardecl  */
-#line 1337 "lang11d"
+  case 208: /* funcvardecls: funcvardecls funcvardecl  */
+#line 1423 "lang11d"
                                         { yyval = (intptr_t)linkNextNode((PyrParseNode*)yyvsp[-1], (PyrParseNode*)yyvsp[0]); }
-#line 4088 "lang11d_tab.cpp"
+#line 4215 "lang11d_tab.cpp"
     break;
 
-  case 207: /* funcvardecls1: funcvardecls1 funcvardecl  */
-#line 1342 "lang11d"
+  case 210: /* funcvardecls1: funcvardecls1 funcvardecl  */
+#line 1428 "lang11d"
                                         { yyval = (intptr_t)linkNextNode((PyrParseNode*)yyvsp[-1], (PyrParseNode*)yyvsp[0]); }
-#line 4094 "lang11d_tab.cpp"
+#line 4221 "lang11d_tab.cpp"
     break;
 
-  case 208: /* funcvardecl: VAR vardeflist ';'  */
-#line 1346 "lang11d"
+  case 211: /* funcvardecl: VAR vardeflist ';'  */
+#line 1432 "lang11d"
                                 { yyval = (intptr_t)newPyrVarListNode((PyrVarDefNode*)yyvsp[-1], varLocal); }
-#line 4100 "lang11d_tab.cpp"
+#line 4227 "lang11d_tab.cpp"
     break;
 
-  case 209: /* argdecls: %empty  */
-#line 1349 "lang11d"
+  case 212: /* argdecls: %empty  */
+#line 1435 "lang11d"
                   { yyval = 0; }
-#line 4106 "lang11d_tab.cpp"
+#line 4233 "lang11d_tab.cpp"
     break;
 
-  case 210: /* argdecls: ARG vardeflist ';'  */
-#line 1351 "lang11d"
+  case 213: /* argdecls: ARG vardeflist ';'  */
+#line 1437 "lang11d"
                                 {
 					yyval = (intptr_t)newPyrArgListNode((PyrVarDefNode*)yyvsp[-1], NULL, NULL);
 				}
-#line 4114 "lang11d_tab.cpp"
+#line 4241 "lang11d_tab.cpp"
     break;
 
-  case 211: /* argdecls: ARG vardeflist0 ELLIPSIS name ';'  */
-#line 1355 "lang11d"
+  case 214: /* argdecls: ARG vardeflist0 ELLIPSIS name ';'  */
+#line 1441 "lang11d"
                                 {
 					yyval = (intptr_t)newPyrArgListNode((PyrVarDefNode*)yyvsp[-3], (PyrSlotNode*)yyvsp[-1], NULL);
 				}
-#line 4122 "lang11d_tab.cpp"
+#line 4249 "lang11d_tab.cpp"
     break;
 
-  case 212: /* argdecls: '|' slotdeflist '|'  */
-#line 1359 "lang11d"
+  case 215: /* argdecls: '|' slotdeflist '|'  */
+#line 1445 "lang11d"
                                 {
 					yyval = (intptr_t)newPyrArgListNode((PyrVarDefNode*)yyvsp[-1], NULL, NULL);
 				}
-#line 4130 "lang11d_tab.cpp"
+#line 4257 "lang11d_tab.cpp"
     break;
 
-  case 213: /* argdecls: '|' slotdeflist0 ELLIPSIS name '|'  */
-#line 1363 "lang11d"
+  case 216: /* argdecls: '|' slotdeflist0 ELLIPSIS name '|'  */
+#line 1449 "lang11d"
                                 {
 					yyval = (intptr_t)newPyrArgListNode((PyrVarDefNode*)yyvsp[-3], (PyrSlotNode*)yyvsp[-1], NULL);
 				}
-#line 4138 "lang11d_tab.cpp"
+#line 4265 "lang11d_tab.cpp"
     break;
 
-  case 214: /* argdecls: '|' slotdeflist0 ELLIPSIS name ',' name '|'  */
-#line 1367 "lang11d"
+  case 217: /* argdecls: '|' slotdeflist0 ELLIPSIS name ',' name '|'  */
+#line 1453 "lang11d"
                             {
 					yyval = (intptr_t)newPyrArgListNode((PyrVarDefNode*)yyvsp[-5], (PyrSlotNode*)yyvsp[-3], (PyrSlotNode*)yyvsp[-1]);
 			    }
-#line 4146 "lang11d_tab.cpp"
+#line 4273 "lang11d_tab.cpp"
     break;
 
-  case 215: /* argdecls1: ARG vardeflist ';'  */
-#line 1373 "lang11d"
+  case 218: /* argdecls1: ARG vardeflist ';'  */
+#line 1459 "lang11d"
                                 {
 					yyval = (intptr_t)newPyrArgListNode((PyrVarDefNode*)yyvsp[-1], NULL, NULL);
 				}
-#line 4154 "lang11d_tab.cpp"
+#line 4281 "lang11d_tab.cpp"
     break;
 
-  case 216: /* argdecls1: ARG vardeflist0 ELLIPSIS name ';'  */
-#line 1377 "lang11d"
+  case 219: /* argdecls1: ARG vardeflist0 ELLIPSIS name ';'  */
+#line 1463 "lang11d"
                                 {
 					yyval = (intptr_t)newPyrArgListNode((PyrVarDefNode*)yyvsp[-3], (PyrSlotNode*)yyvsp[-1], NULL);
 				}
-#line 4162 "lang11d_tab.cpp"
+#line 4289 "lang11d_tab.cpp"
     break;
 
-  case 217: /* argdecls1: '|' slotdeflist '|'  */
-#line 1381 "lang11d"
+  case 220: /* argdecls1: '|' slotdeflist '|'  */
+#line 1467 "lang11d"
                                 {
 					yyval = (intptr_t)newPyrArgListNode((PyrVarDefNode*)yyvsp[-1], NULL, NULL);
 				}
-#line 4170 "lang11d_tab.cpp"
+#line 4297 "lang11d_tab.cpp"
     break;
 
-  case 218: /* argdecls1: '|' slotdeflist0 ELLIPSIS name '|'  */
-#line 1385 "lang11d"
+  case 221: /* argdecls1: '|' slotdeflist0 ELLIPSIS name '|'  */
+#line 1471 "lang11d"
                                 {
 					yyval = (intptr_t)newPyrArgListNode((PyrVarDefNode*)yyvsp[-3], (PyrSlotNode*)yyvsp[-1], NULL);
 				}
-#line 4178 "lang11d_tab.cpp"
+#line 4305 "lang11d_tab.cpp"
     break;
 
-  case 219: /* argdecls1: '|' slotdeflist0 ELLIPSIS name ',' name '|'  */
-#line 1389 "lang11d"
+  case 222: /* argdecls1: '|' slotdeflist0 ELLIPSIS name ',' name '|'  */
+#line 1475 "lang11d"
                             {
 					yyval = (intptr_t)newPyrArgListNode((PyrVarDefNode*)yyvsp[-5], (PyrSlotNode*)yyvsp[-3], (PyrSlotNode*)yyvsp[-1]);
 			    }
-#line 4186 "lang11d_tab.cpp"
+#line 4313 "lang11d_tab.cpp"
     break;
 
-  case 221: /* constdeflist: constdeflist optcomma constdef  */
-#line 1397 "lang11d"
+  case 224: /* constdeflist: constdeflist optcomma constdef  */
+#line 1483 "lang11d"
                                         { yyval = (intptr_t)linkNextNode((PyrParseNode*)yyvsp[-2], (PyrParseNode*)yyvsp[0]); }
-#line 4192 "lang11d_tab.cpp"
+#line 4319 "lang11d_tab.cpp"
     break;
 
-  case 222: /* constdef: rspec name '=' slotliteral  */
-#line 1401 "lang11d"
+  case 225: /* constdef: rspec name '=' slotliteral  */
+#line 1487 "lang11d"
                                 { yyval = (intptr_t)newPyrVarDefNode((PyrSlotNode*)yyvsp[-2], (PyrParseNode*)yyvsp[0], yyvsp[-3]); }
-#line 4198 "lang11d_tab.cpp"
+#line 4325 "lang11d_tab.cpp"
     break;
 
-  case 223: /* slotdeflist0: %empty  */
-#line 1404 "lang11d"
+  case 226: /* slotdeflist0: %empty  */
+#line 1490 "lang11d"
                   { yyval = 0; }
-#line 4204 "lang11d_tab.cpp"
+#line 4331 "lang11d_tab.cpp"
     break;
 
-  case 226: /* slotdeflist: slotdeflist optcomma slotdef  */
-#line 1410 "lang11d"
+  case 229: /* slotdeflist: slotdeflist optcomma slotdef  */
+#line 1496 "lang11d"
                                 { yyval = (intptr_t)linkNextNode((PyrParseNode*)yyvsp[-2], (PyrParseNode*)yyvsp[0]); }
-#line 4210 "lang11d_tab.cpp"
+#line 4337 "lang11d_tab.cpp"
     break;
 
-  case 227: /* slotdef: name  */
-#line 1414 "lang11d"
+  case 230: /* slotdef: name  */
+#line 1500 "lang11d"
                                 { yyval = (intptr_t)newPyrVarDefNode((PyrSlotNode*)yyvsp[0], NULL, 0); }
-#line 4216 "lang11d_tab.cpp"
+#line 4343 "lang11d_tab.cpp"
     break;
 
-  case 228: /* slotdef: name optequal slotliteral  */
-#line 1416 "lang11d"
+  case 231: /* slotdef: name optequal slotliteral  */
+#line 1502 "lang11d"
                                 { yyval = (intptr_t)newPyrVarDefNode((PyrSlotNode*)yyvsp[-2], (PyrParseNode*)yyvsp[0], 0); }
-#line 4222 "lang11d_tab.cpp"
+#line 4349 "lang11d_tab.cpp"
     break;
 
-  case 229: /* slotdef: name optequal '(' exprseq ')'  */
-#line 1418 "lang11d"
+  case 232: /* slotdef: name optequal '(' exprseq ')'  */
+#line 1504 "lang11d"
                                 {
 					PyrParseNode* node = (PyrParseNode*)yyvsp[-1];
 					node->mParens = 1;
 					yyval = (intptr_t)newPyrVarDefNode((PyrSlotNode*)yyvsp[-4], node, 0);
 				}
-#line 4232 "lang11d_tab.cpp"
+#line 4359 "lang11d_tab.cpp"
     break;
 
-  case 230: /* vardeflist0: %empty  */
-#line 1425 "lang11d"
+  case 233: /* vardeflist0: %empty  */
+#line 1511 "lang11d"
                   { yyval = 0; }
-#line 4238 "lang11d_tab.cpp"
+#line 4365 "lang11d_tab.cpp"
     break;
 
-  case 233: /* vardeflist: vardeflist ',' vardef  */
-#line 1431 "lang11d"
+  case 236: /* vardeflist: vardeflist ',' vardef  */
+#line 1517 "lang11d"
                                 { yyval = (intptr_t)linkNextNode((PyrParseNode*)yyvsp[-2], (PyrParseNode*)yyvsp[0]); }
-#line 4244 "lang11d_tab.cpp"
+#line 4371 "lang11d_tab.cpp"
     break;
 
-  case 234: /* vardef: name  */
-#line 1435 "lang11d"
+  case 237: /* vardef: name  */
+#line 1521 "lang11d"
                                 { yyval = (intptr_t)newPyrVarDefNode((PyrSlotNode*)yyvsp[0], NULL, 0); }
-#line 4250 "lang11d_tab.cpp"
+#line 4377 "lang11d_tab.cpp"
     break;
 
-  case 235: /* vardef: name '=' expr  */
-#line 1437 "lang11d"
+  case 238: /* vardef: name '=' expr  */
+#line 1523 "lang11d"
                                 { yyval = (intptr_t)newPyrVarDefNode((PyrSlotNode*)yyvsp[-2], (PyrParseNode*)yyvsp[0], 0); }
-#line 4256 "lang11d_tab.cpp"
+#line 4383 "lang11d_tab.cpp"
     break;
 
-  case 236: /* vardef: name '(' exprseq ')'  */
-#line 1439 "lang11d"
+  case 239: /* vardef: name '(' exprseq ')'  */
+#line 1525 "lang11d"
                                 {
 									PyrParseNode* node = (PyrParseNode*)yyvsp[-1];
 									node->mParens = 1;
 									yyval = (intptr_t)newPyrVarDefNode((PyrSlotNode*)yyvsp[-3], node, 0);
 								}
-#line 4266 "lang11d_tab.cpp"
+#line 4393 "lang11d_tab.cpp"
     break;
 
-  case 237: /* dictslotdef: exprseq ':' exprseq  */
-#line 1447 "lang11d"
+  case 240: /* dictslotdef: exprseq ':' exprseq  */
+#line 1533 "lang11d"
                                 { yyval = (intptr_t)linkNextNode((PyrParseNode*)yyvsp[-2], (PyrParseNode*)yyvsp[0]); }
-#line 4272 "lang11d_tab.cpp"
+#line 4399 "lang11d_tab.cpp"
     break;
 
-  case 238: /* dictslotdef: keybinop exprseq  */
-#line 1449 "lang11d"
+  case 241: /* dictslotdef: keybinop exprseq  */
+#line 1535 "lang11d"
                                 {
 					PyrParseNode* key = newPyrPushLitNode((PyrSlotNode*)yyvsp[-1], NULL);
 					yyval = (intptr_t)linkNextNode(key, (PyrParseNode*)yyvsp[0]);
 				}
-#line 4281 "lang11d_tab.cpp"
+#line 4408 "lang11d_tab.cpp"
     break;
 
-  case 240: /* dictslotlist1: dictslotlist1 ',' dictslotdef  */
-#line 1457 "lang11d"
+  case 243: /* dictslotlist1: dictslotlist1 ',' dictslotdef  */
+#line 1543 "lang11d"
                                         { yyval = (intptr_t)linkNextNode((PyrParseNode*)yyvsp[-2], (PyrParseNode*)yyvsp[0]); }
-#line 4287 "lang11d_tab.cpp"
+#line 4414 "lang11d_tab.cpp"
     break;
 
-  case 241: /* dictslotlist: %empty  */
-#line 1460 "lang11d"
+  case 244: /* dictslotlist: %empty  */
+#line 1546 "lang11d"
                   { yyval = 0; }
-#line 4293 "lang11d_tab.cpp"
+#line 4420 "lang11d_tab.cpp"
     break;
 
-  case 244: /* rwslotdeflist: rwslotdeflist ',' rwslotdef  */
-#line 1466 "lang11d"
+  case 247: /* rwslotdeflist: rwslotdeflist ',' rwslotdef  */
+#line 1552 "lang11d"
                                         { yyval = (intptr_t)linkNextNode((PyrParseNode*)yyvsp[-2], (PyrParseNode*)yyvsp[0]); }
-#line 4299 "lang11d_tab.cpp"
+#line 4426 "lang11d_tab.cpp"
     break;
 
-  case 245: /* rwslotdef: rwspec name  */
-#line 1470 "lang11d"
+  case 248: /* rwslotdef: rwspec name  */
+#line 1556 "lang11d"
                                         { yyval = (intptr_t)newPyrVarDefNode((PyrSlotNode*)yyvsp[0], NULL, yyvsp[-1]); }
-#line 4305 "lang11d_tab.cpp"
+#line 4432 "lang11d_tab.cpp"
     break;
 
-  case 246: /* rwslotdef: rwspec name '=' slotliteral  */
-#line 1472 "lang11d"
+  case 249: /* rwslotdef: rwspec name '=' slotliteral  */
+#line 1558 "lang11d"
                                         { yyval = (intptr_t)newPyrVarDefNode((PyrSlotNode*)yyvsp[-2], (PyrParseNode*)yyvsp[0], yyvsp[-3]); }
-#line 4311 "lang11d_tab.cpp"
+#line 4438 "lang11d_tab.cpp"
     break;
 
-  case 247: /* dictlit2: '(' litdictslotlist ')'  */
-#line 1476 "lang11d"
+  case 250: /* dictlit2: '(' litdictslotlist ')'  */
+#line 1562 "lang11d"
                                 { yyval = (intptr_t)newPyrLitDictNode((PyrParseNode*)yyvsp[-1]); }
-#line 4317 "lang11d_tab.cpp"
+#line 4444 "lang11d_tab.cpp"
     break;
 
-  case 248: /* litdictslotdef: listliteral ':' listliteral  */
-#line 1480 "lang11d"
+  case 251: /* litdictslotdef: listliteral ':' listliteral  */
+#line 1566 "lang11d"
                                 { yyval = (intptr_t)linkNextNode((PyrParseNode*)yyvsp[-2], (PyrParseNode*)yyvsp[0]); }
-#line 4323 "lang11d_tab.cpp"
+#line 4450 "lang11d_tab.cpp"
     break;
 
-  case 249: /* litdictslotdef: keybinop listliteral  */
-#line 1482 "lang11d"
+  case 252: /* litdictslotdef: keybinop listliteral  */
+#line 1568 "lang11d"
                                 {
 					PyrParseNode* key = newPyrPushLitNode((PyrSlotNode*)yyvsp[-1], NULL);
 					yyval = (intptr_t)linkNextNode(key, (PyrParseNode*)yyvsp[0]);
 				}
-#line 4332 "lang11d_tab.cpp"
+#line 4459 "lang11d_tab.cpp"
     break;
 
-  case 251: /* litdictslotlist1: litdictslotlist1 ',' litdictslotdef  */
-#line 1490 "lang11d"
+  case 254: /* litdictslotlist1: litdictslotlist1 ',' litdictslotdef  */
+#line 1576 "lang11d"
                                         { yyval = (intptr_t)linkNextNode((PyrParseNode*)yyvsp[-2], (PyrParseNode*)yyvsp[0]); }
-#line 4338 "lang11d_tab.cpp"
+#line 4465 "lang11d_tab.cpp"
     break;
 
-  case 252: /* litdictslotlist: %empty  */
-#line 1493 "lang11d"
+  case 255: /* litdictslotlist: %empty  */
+#line 1579 "lang11d"
                   { yyval = 0; }
-#line 4344 "lang11d_tab.cpp"
+#line 4471 "lang11d_tab.cpp"
     break;
 
-  case 254: /* listlit: '#' '[' literallistc ']'  */
-#line 1500 "lang11d"
+  case 257: /* listlit: '#' '[' literallistc ']'  */
+#line 1586 "lang11d"
                                 { yyval = (intptr_t)newPyrLitListNode(0, (PyrParseNode*)yyvsp[-1]); }
-#line 4350 "lang11d_tab.cpp"
+#line 4477 "lang11d_tab.cpp"
     break;
 
-  case 255: /* listlit: '#' classname '[' literallistc ']'  */
-#line 1502 "lang11d"
+  case 258: /* listlit: '#' classname '[' literallistc ']'  */
+#line 1588 "lang11d"
                                 { yyval = (intptr_t)newPyrLitListNode((PyrParseNode*)yyvsp[-3], (PyrParseNode*)yyvsp[-1]); }
-#line 4356 "lang11d_tab.cpp"
+#line 4483 "lang11d_tab.cpp"
     break;
 
-  case 256: /* listlit2: '[' literallistc ']'  */
-#line 1506 "lang11d"
+  case 259: /* listlit2: '[' literallistc ']'  */
+#line 1592 "lang11d"
                                 { yyval = (intptr_t)newPyrLitListNode(0, (PyrParseNode*)yyvsp[-1]); }
-#line 4362 "lang11d_tab.cpp"
+#line 4489 "lang11d_tab.cpp"
     break;
 
-  case 257: /* listlit2: classname '[' literallistc ']'  */
-#line 1508 "lang11d"
+  case 260: /* listlit2: classname '[' literallistc ']'  */
+#line 1594 "lang11d"
                                 { yyval = (intptr_t)newPyrLitListNode((PyrParseNode*)yyvsp[-3], (PyrParseNode*)yyvsp[-1]); }
-#line 4368 "lang11d_tab.cpp"
+#line 4495 "lang11d_tab.cpp"
     break;
 
-  case 258: /* literallistc: %empty  */
-#line 1511 "lang11d"
+  case 261: /* literallistc: %empty  */
+#line 1597 "lang11d"
                   { yyval = 0; }
-#line 4374 "lang11d_tab.cpp"
+#line 4501 "lang11d_tab.cpp"
     break;
 
-  case 261: /* literallist1: literallist1 ',' listliteral  */
-#line 1517 "lang11d"
+  case 264: /* literallist1: literallist1 ',' listliteral  */
+#line 1603 "lang11d"
                                         { yyval = (intptr_t)linkNextNode((PyrParseNode*)yyvsp[-2], (PyrParseNode*)yyvsp[0]); }
-#line 4380 "lang11d_tab.cpp"
+#line 4507 "lang11d_tab.cpp"
     break;
 
-  case 262: /* rwspec: %empty  */
-#line 1520 "lang11d"
+  case 265: /* rwspec: %empty  */
+#line 1606 "lang11d"
            { yyval = rwPrivate; }
-#line 4386 "lang11d_tab.cpp"
+#line 4513 "lang11d_tab.cpp"
     break;
 
-  case 263: /* rwspec: '<'  */
-#line 1522 "lang11d"
+  case 266: /* rwspec: '<'  */
+#line 1608 "lang11d"
                         { yyval = rwReadOnly; }
-#line 4392 "lang11d_tab.cpp"
+#line 4519 "lang11d_tab.cpp"
     break;
 
-  case 264: /* rwspec: READWRITEVAR  */
-#line 1524 "lang11d"
+  case 267: /* rwspec: READWRITEVAR  */
+#line 1610 "lang11d"
                         { yyval = rwReadWrite; }
-#line 4398 "lang11d_tab.cpp"
+#line 4525 "lang11d_tab.cpp"
     break;
 
-  case 265: /* rwspec: '>'  */
-#line 1526 "lang11d"
+  case 268: /* rwspec: '>'  */
+#line 1612 "lang11d"
                         { yyval = rwWriteOnly; }
-#line 4404 "lang11d_tab.cpp"
+#line 4531 "lang11d_tab.cpp"
     break;
 
-  case 266: /* rspec: %empty  */
-#line 1529 "lang11d"
+  case 269: /* rspec: %empty  */
+#line 1615 "lang11d"
            { yyval = rwPrivate; }
-#line 4410 "lang11d_tab.cpp"
+#line 4537 "lang11d_tab.cpp"
     break;
 
-  case 267: /* rspec: '<'  */
-#line 1531 "lang11d"
+  case 270: /* rspec: '<'  */
+#line 1617 "lang11d"
                         { yyval = rwReadOnly; }
-#line 4416 "lang11d_tab.cpp"
+#line 4543 "lang11d_tab.cpp"
     break;
 
-  case 268: /* integer: INTEGER  */
-#line 1534 "lang11d"
+  case 271: /* integer: INTEGER  */
+#line 1620 "lang11d"
                   { yyval = zzval; }
-#line 4422 "lang11d_tab.cpp"
+#line 4549 "lang11d_tab.cpp"
     break;
 
-  case 269: /* integer: '-' INTEGER  */
-#line 1536 "lang11d"
+  case 272: /* integer: '-' INTEGER  */
+#line 1622 "lang11d"
                         {
 				PyrSlotNode *node;
 				node = (PyrSlotNode*)zzval;
 				SetRaw(&node->mSlot, -slotRawInt(&node->mSlot));
 				yyval = zzval;
 			}
-#line 4433 "lang11d_tab.cpp"
+#line 4560 "lang11d_tab.cpp"
     break;
 
-  case 270: /* floatr: SC_FLOAT  */
-#line 1544 "lang11d"
+  case 273: /* floatr: SC_FLOAT  */
+#line 1630 "lang11d"
                    { yyval = zzval; }
-#line 4439 "lang11d_tab.cpp"
+#line 4566 "lang11d_tab.cpp"
     break;
 
-  case 271: /* floatr: '-' SC_FLOAT  */
-#line 1546 "lang11d"
+  case 274: /* floatr: '-' SC_FLOAT  */
+#line 1632 "lang11d"
                         {
 				PyrSlotNode *node;
 				node = (PyrSlotNode*)zzval;
 				SetRaw(&node->mSlot, -slotRawFloat(&node->mSlot));
 				yyval = zzval;
 			}
-#line 4450 "lang11d_tab.cpp"
+#line 4577 "lang11d_tab.cpp"
     break;
 
-  case 272: /* accidental: ACCIDENTAL  */
-#line 1554 "lang11d"
+  case 275: /* accidental: ACCIDENTAL  */
+#line 1640 "lang11d"
                         { yyval = zzval; }
-#line 4456 "lang11d_tab.cpp"
+#line 4583 "lang11d_tab.cpp"
     break;
 
-  case 273: /* accidental: '-' ACCIDENTAL  */
-#line 1556 "lang11d"
+  case 276: /* accidental: '-' ACCIDENTAL  */
+#line 1642 "lang11d"
                                 {
 					PyrSlotNode *node;
 					double intval, fracval;
@@ -4466,27 +4593,27 @@ yyreduce:
 					SetRaw(&node->mSlot, -intval + fracval);
 					yyval = zzval;
 				}
-#line 4470 "lang11d_tab.cpp"
+#line 4597 "lang11d_tab.cpp"
     break;
 
-  case 274: /* pie: PIE  */
-#line 1566 "lang11d"
+  case 277: /* pie: PIE  */
+#line 1652 "lang11d"
                       { yyval = zzval; }
-#line 4476 "lang11d_tab.cpp"
+#line 4603 "lang11d_tab.cpp"
     break;
 
-  case 277: /* floatp: floatr pie  */
-#line 1572 "lang11d"
+  case 280: /* floatp: floatr pie  */
+#line 1658 "lang11d"
                         {
 				PyrSlotNode *node;
 				node = (PyrSlotNode*)yyvsp[-1];
 				SetRaw(&node->mSlot, slotRawFloat(&node->mSlot) * pi);
 			}
-#line 4486 "lang11d_tab.cpp"
+#line 4613 "lang11d_tab.cpp"
     break;
 
-  case 278: /* floatp: integer pie  */
-#line 1578 "lang11d"
+  case 281: /* floatp: integer pie  */
+#line 1664 "lang11d"
                         {
 				PyrSlotNode *node;
 				double ival;
@@ -4494,159 +4621,165 @@ yyreduce:
 				ival = slotRawInt(&node->mSlot);
 				SetFloat(&node->mSlot, ival * pi);
 			}
-#line 4498 "lang11d_tab.cpp"
+#line 4625 "lang11d_tab.cpp"
     break;
 
-  case 279: /* floatp: pie  */
-#line 1586 "lang11d"
+  case 282: /* floatp: pie  */
+#line 1672 "lang11d"
                         {
 				PyrSlotNode *node;
 				node = (PyrSlotNode*)zzval;
 				SetFloat(&node->mSlot, pi);
 				yyval = zzval;
 			}
-#line 4509 "lang11d_tab.cpp"
+#line 4636 "lang11d_tab.cpp"
     break;
 
-  case 280: /* floatp: '-' pie  */
-#line 1593 "lang11d"
+  case 283: /* floatp: '-' pie  */
+#line 1679 "lang11d"
                         {
 				PyrSlotNode *node;
 				node = (PyrSlotNode*)zzval;
 				SetFloat(&node->mSlot, -pi);
 				yyval = zzval;
 			}
-#line 4520 "lang11d_tab.cpp"
+#line 4647 "lang11d_tab.cpp"
     break;
 
-  case 281: /* name: NAME  */
-#line 1601 "lang11d"
+  case 284: /* name: NAME  */
+#line 1687 "lang11d"
                        { yyval = zzval; }
-#line 4526 "lang11d_tab.cpp"
+#line 4653 "lang11d_tab.cpp"
     break;
 
-  case 282: /* name: WHILE  */
-#line 1602 "lang11d"
+  case 285: /* name: WHILE  */
+#line 1688 "lang11d"
                                 { yyval = zzval; }
-#line 4532 "lang11d_tab.cpp"
+#line 4659 "lang11d_tab.cpp"
     break;
 
-  case 283: /* classname: CLASSNAME  */
-#line 1605 "lang11d"
+  case 286: /* classname: CLASSNAME  */
+#line 1691 "lang11d"
                                     { yyval = zzval; }
-#line 4538 "lang11d_tab.cpp"
+#line 4665 "lang11d_tab.cpp"
     break;
 
-  case 284: /* primname: PRIMITIVENAME  */
-#line 1608 "lang11d"
+  case 287: /* primname: PRIMITIVENAME  */
+#line 1694 "lang11d"
                                         { yyval = zzval; }
-#line 4544 "lang11d_tab.cpp"
+#line 4671 "lang11d_tab.cpp"
     break;
 
-  case 285: /* trueobj: TRUEOBJ  */
-#line 1611 "lang11d"
+  case 288: /* trueobj: TRUEOBJ  */
+#line 1697 "lang11d"
                           { yyval = zzval; }
-#line 4550 "lang11d_tab.cpp"
+#line 4677 "lang11d_tab.cpp"
     break;
 
-  case 286: /* falseobj: FALSEOBJ  */
-#line 1614 "lang11d"
+  case 289: /* falseobj: FALSEOBJ  */
+#line 1700 "lang11d"
                            { yyval = zzval; }
-#line 4556 "lang11d_tab.cpp"
+#line 4683 "lang11d_tab.cpp"
     break;
 
-  case 287: /* nilobj: NILOBJ  */
-#line 1617 "lang11d"
+  case 290: /* nilobj: NILOBJ  */
+#line 1703 "lang11d"
                          { yyval = zzval; }
-#line 4562 "lang11d_tab.cpp"
+#line 4689 "lang11d_tab.cpp"
     break;
 
-  case 288: /* ascii: ASCII  */
-#line 1620 "lang11d"
+  case 291: /* ascii: ASCII  */
+#line 1706 "lang11d"
                         { yyval = zzval; }
-#line 4568 "lang11d_tab.cpp"
+#line 4695 "lang11d_tab.cpp"
     break;
 
-  case 289: /* symbol: SYMBOL  */
-#line 1623 "lang11d"
+  case 292: /* symbol: SYMBOL  */
+#line 1709 "lang11d"
                          { yyval = zzval; }
-#line 4574 "lang11d_tab.cpp"
+#line 4701 "lang11d_tab.cpp"
     break;
 
-  case 290: /* string: STRING  */
-#line 1626 "lang11d"
+  case 293: /* string: STRING  */
+#line 1712 "lang11d"
                          { yyval = zzval; }
-#line 4580 "lang11d_tab.cpp"
+#line 4707 "lang11d_tab.cpp"
     break;
 
-  case 291: /* pseudovar: PSEUDOVAR  */
-#line 1629 "lang11d"
+  case 294: /* pseudovar: PSEUDOVAR  */
+#line 1715 "lang11d"
                             { yyval = zzval; }
-#line 4586 "lang11d_tab.cpp"
+#line 4713 "lang11d_tab.cpp"
     break;
 
-  case 292: /* binop: BINOP  */
-#line 1632 "lang11d"
+  case 295: /* binop: BINOP  */
+#line 1718 "lang11d"
                 { yyval = zzval; }
-#line 4592 "lang11d_tab.cpp"
+#line 4719 "lang11d_tab.cpp"
     break;
 
-  case 293: /* binop: READWRITEVAR  */
-#line 1633 "lang11d"
+  case 296: /* binop: READWRITEVAR  */
+#line 1719 "lang11d"
                                { yyval = zzval; }
-#line 4598 "lang11d_tab.cpp"
+#line 4725 "lang11d_tab.cpp"
     break;
 
-  case 294: /* binop: '<'  */
-#line 1634 "lang11d"
+  case 297: /* binop: KWEXPAND  */
+#line 1720 "lang11d"
+                           { yyval = zzval; }
+#line 4731 "lang11d_tab.cpp"
+    break;
+
+  case 298: /* binop: '<'  */
+#line 1721 "lang11d"
                        { yyval = zzval; }
-#line 4604 "lang11d_tab.cpp"
+#line 4737 "lang11d_tab.cpp"
     break;
 
-  case 295: /* binop: '>'  */
-#line 1635 "lang11d"
+  case 299: /* binop: '>'  */
+#line 1722 "lang11d"
                        { yyval = zzval; }
-#line 4610 "lang11d_tab.cpp"
+#line 4743 "lang11d_tab.cpp"
     break;
 
-  case 296: /* binop: '-'  */
-#line 1636 "lang11d"
+  case 300: /* binop: '-'  */
+#line 1723 "lang11d"
                        { yyval = zzval; }
-#line 4616 "lang11d_tab.cpp"
+#line 4749 "lang11d_tab.cpp"
     break;
 
-  case 297: /* binop: '*'  */
-#line 1637 "lang11d"
+  case 301: /* binop: '*'  */
+#line 1724 "lang11d"
                        { yyval = zzval; }
-#line 4622 "lang11d_tab.cpp"
+#line 4755 "lang11d_tab.cpp"
     break;
 
-  case 298: /* binop: '+'  */
-#line 1638 "lang11d"
+  case 302: /* binop: '+'  */
+#line 1725 "lang11d"
                        { yyval = zzval; }
-#line 4628 "lang11d_tab.cpp"
+#line 4761 "lang11d_tab.cpp"
     break;
 
-  case 299: /* binop: '|'  */
-#line 1639 "lang11d"
+  case 303: /* binop: '|'  */
+#line 1726 "lang11d"
                        { yyval = zzval; }
-#line 4634 "lang11d_tab.cpp"
+#line 4767 "lang11d_tab.cpp"
     break;
 
-  case 300: /* keybinop: KEYBINOP  */
-#line 1642 "lang11d"
+  case 304: /* keybinop: KEYBINOP  */
+#line 1729 "lang11d"
                     { yyval = zzval; }
-#line 4640 "lang11d_tab.cpp"
+#line 4773 "lang11d_tab.cpp"
     break;
 
-  case 303: /* curryarg: CURRYARG  */
-#line 1649 "lang11d"
+  case 307: /* curryarg: CURRYARG  */
+#line 1736 "lang11d"
                     { yyval = zzval; }
-#line 4646 "lang11d_tab.cpp"
+#line 4779 "lang11d_tab.cpp"
     break;
 
 
-#line 4650 "lang11d_tab.cpp"
+#line 4783 "lang11d_tab.cpp"
 
       default: break;
     }

--- a/lang/LangSource/Bison/lang11d_tab.h
+++ b/lang/LangSource/Bison/lang11d_tab.h
@@ -72,19 +72,20 @@ extern int yydebug;
     TRUEOBJ = 273,                 /* TRUEOBJ  */
     FALSEOBJ = 274,                /* FALSEOBJ  */
     PSEUDOVAR = 275,               /* PSEUDOVAR  */
-    ELLIPSIS = 276,                /* ELLIPSIS  */
-    DOTDOT = 277,                  /* DOTDOT  */
-    PIE = 278,                     /* PIE  */
-    BEGINCLOSEDFUNC = 279,         /* BEGINCLOSEDFUNC  */
-    BADTOKEN = 280,                /* BADTOKEN  */
-    INTERPRET = 281,               /* INTERPRET  */
-    BEGINGENERATOR = 282,          /* BEGINGENERATOR  */
-    LEFTARROW = 283,               /* LEFTARROW  */
-    WHILE = 284,                   /* WHILE  */
-    BINOP = 285,                   /* BINOP  */
-    KEYBINOP = 286,                /* KEYBINOP  */
-    READWRITEVAR = 287,            /* READWRITEVAR  */
-    UMINUS = 288                   /* UMINUS  */
+    KWEXPAND = 276,                /* KWEXPAND  */
+    ELLIPSIS = 277,                /* ELLIPSIS  */
+    DOTDOT = 278,                  /* DOTDOT  */
+    PIE = 279,                     /* PIE  */
+    BEGINCLOSEDFUNC = 280,         /* BEGINCLOSEDFUNC  */
+    BADTOKEN = 281,                /* BADTOKEN  */
+    INTERPRET = 282,               /* INTERPRET  */
+    BEGINGENERATOR = 283,          /* BEGINGENERATOR  */
+    LEFTARROW = 284,               /* LEFTARROW  */
+    WHILE = 285,                   /* WHILE  */
+    BINOP = 286,                   /* BINOP  */
+    KEYBINOP = 287,                /* KEYBINOP  */
+    READWRITEVAR = 288,            /* READWRITEVAR  */
+    UMINUS = 289                   /* UMINUS  */
   };
   typedef enum yytokentype yytoken_kind_t;
 #endif

--- a/lang/LangSource/Bison/make_parser.sh
+++ b/lang/LangSource/Bison/make_parser.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-bison --defines=lang11d_tab.h --output=lang11d_tab.cpp lang11d
+bison --defines=lang11d_tab.h --output=lang11d_tab.cpp -Wcounterexamples lang11d
 

--- a/lang/LangSource/PyrLexer.cpp
+++ b/lang/LangSource/PyrLexer.cpp
@@ -946,6 +946,8 @@ int processbinop(char* token) {
         return '>';
     if (strcmp(token, "-") == 0)
         return '-';
+    if (strcmp(token, "**") == 0)
+        return KWEXPAND;
     if (strcmp(token, "*") == 0)
         return '*';
     if (strcmp(token, "+") == 0)

--- a/lang/LangSource/PyrObject.cpp
+++ b/lang/LangSource/PyrObject.cpp
@@ -150,7 +150,7 @@ PyrSymbol* s_next;
 PyrSymbol* s_env;
 PyrSymbol *s_new, *s_ref, *s_value, *s_at, *s_put;
 PyrSymbol *s_performList, *s_superPerformList;
-PyrSymbol* s_performArgs;
+PyrSymbol *s_performArgs, *s_superPerformArgs;
 PyrSymbol *s_series, *s_copyseries, *s_putseries;
 PyrSymbol *s_envirGet, *s_envirPut;
 PyrSymbol *s_synth, *s_environment, *s_event;
@@ -258,7 +258,10 @@ void initSymbols() {
     s_value = getsym("value");
     s_performList = getsym("performList");
     s_superPerformList = getsym("superPerformList");
+
     s_performArgs = getsym("performArgs");
+    s_superPerformArgs = getsym("superPerformArgs");
+
     s_at = getsym("at");
     s_put = getsym("put");
     s_prstart = getsym("prStart");

--- a/lang/LangSource/PyrObject.h
+++ b/lang/LangSource/PyrObject.h
@@ -203,7 +203,7 @@ extern PyrSymbol *s_series, *s_copyseries, *s_putseries;
 extern PyrSymbol* s_value;
 extern PyrSymbol* s_performList;
 extern PyrSymbol* s_superPerformList;
-extern PyrSymbol* s_performArgs;
+extern PyrSymbol *s_performArgs, *s_superPerformArgs;
 extern PyrSymbol *s_new, *s_ref;
 extern PyrSymbol *s_synth, *s_environment, *s_event;
 extern PyrSymbol* s_interpreter;

--- a/lang/LangSource/PyrParseNode.cpp
+++ b/lang/LangSource/PyrParseNode.cpp
@@ -3110,9 +3110,11 @@ PyrPushLitNode* newPyrPushLitNode(PyrSlotNode* literalSlot, PyrParseNode* litera
     if (literalSlot) {
         node = literalSlot;
         node->mClassno = pn_PushLitNode;
-    } else {
+    } else if (literalObj) {
         node = ALLOCSLOTNODE(PyrSlotNode, pn_PushLitNode);
         SetPtr(&node->mSlot, (PyrObject*)literalObj);
+    } else {
+        error("newPyrPushLitNode: shouldn't get here,\n");
     }
     return node;
 }


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

Closes #6882.

```supercollider
a = ()
a.meow = {|self... a, k| (self: self, a: a, k: k)}

b = [q: 10]

a.meow(**b) // ('self': ('meow': a Function), 'a': [], 'k': [q, 10])

f = {|... a, k| (a: a, k: k)}
f.(**b) // ('a': [], 'k': [q, 10])
```

Currently, I can't get `f.(*args, **kwargs)`. Pleasing the parser here is a pain, this is probably because I find bottom--up parsing very confusing.

This would be good to land in 3.14, but the deadline is close.

## Types of changes

<!-- Delete lines that don't apply -->

- New feature

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [ ] Code is tested
- [ ] All tests are passing
- [ ] Updated documentation
- [ ] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
