### PR TITLE
ide: gui: restart sclang after config change

### DIFF
--- a/editors/sc-ide/widgets/settings/sclang_page.cpp
+++ b/editors/sc-ide/widgets/settings/sclang_page.cpp
@@ -29,6 +29,7 @@
 #include "ui_settings_sclang.h"
 #include "../../core/settings/manager.hpp"
 #include "../../core/util/standard_dirs.hpp"
+#include "../../core/main.hpp"
 
 #include <yaml-cpp/yaml.h>
 
@@ -305,8 +306,21 @@ void SclangPage::dialogDeleteCurrentConfigFile() {
 }
 
 void SclangPage::dialogConfigFileUpdated() {
-    QMessageBox::information(this, tr("Sclang configuration file updated"),
-                             tr("The SuperCollider language configuration has been updated. "
-                                "Reboot the interpreter to apply the changes."));
+    QMessageBox::StandardButton reply =
+        QMessageBox::question(this, tr("Sclang configuration file updated"),
+                              tr("The SuperCollider language configuration has been updated.\n"
+                                 "The interpreter needs to reboot to apply the changes.\n\n"
+                                 "Would you like to reboot now?\n"
+                                 "WARNING: all sound will stop."),
+                              QMessageBox::Yes | QMessageBox::No, QMessageBox::No);
+
+    if (reply == QMessageBox::Yes) {
+        if (auto process = Main::instance()->scProcess()) {
+            process->restartLanguage();
+        } else {
+            qWarning() << "SclangPage::dialogConfigFileUpdated(): "
+                          "Main->scProcess pointer is null!";
+        }
+    }
 }
 }} // namespace ScIDE::Settings


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

This PR adds a button to allow restarting interpreter when the language config changes are applied. This was suggested in https://github.com/supercollider/supercollider/pull/6818#pullrequestreview-2827772629.

~~I wasn't sure what's the best way to connect the `SclangPage` with `ScProcess` - I ended up going through the settings manager. But I don't have a good birds eye view of scide, so I'm not sure if this was the best way to go...~~

<img width="372" alt="Screenshot 2025-06-02 at 2 54 06 PM" src="https://github.com/user-attachments/assets/1abbab51-0cf5-44bf-b699-f302057a606a" />

## Types of changes

<!-- Delete lines that don't apply -->

- New feature


## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- ~~[ ] Updated documentation~~
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
