### PR TITLE
GHA: update Windows image to 2022 and remove 2019 image

### DIFF
--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -16,12 +16,12 @@ jobs:
           - job-name: "32-bit with ctest"
             fftw-arch: "x86"
             cmake-arch: "Win32"
-            os-version: "2019"
+            os-version: "2022"
             qt-version: "5.15.2"
             qt-arch: "win32_msvc2019"
             fftw-url: "ftp://ftp.fftw.org/pub/fftw/fftw-3.3.5-dll32.zip"
-            cmake-generator: "Visual Studio 16 2019"
-            vcvars-script-path: "C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Auxiliary/Build/vcvars32.bat"
+            cmake-generator: "Visual Studio 17 2022"
+            vcvars-script-path: "C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Auxiliary/Build/vcvars64.bat"
             vcpkg-triplet: x86-windows-release
             use-qtwebengine: "ON" # might need to be turned off for MinGW
             qt-modules: "qtwebengine"
@@ -47,21 +47,6 @@ jobs:
             artifact-suffix: "win64" # set if needed - will trigger artifact upload
             create-installer: ${{ startsWith(github.ref, 'refs/tags/') }}
             installer-suffix: "win64-installer"
-            ctest-cmd: "RUN_TESTS"
-
-          - job-name: "64-bit MSVC 2019"
-            fftw-arch: "x64"
-            cmake-arch: "x64"
-            os-version: "2019"
-            qt-version: "6.7.3"
-            qt-arch: "win64_msvc2019_64"
-            fftw-url: "ftp://ftp.fftw.org/pub/fftw/fftw-3.3.5-dll64.zip"
-            cmake-generator: "Visual Studio 16 2019"
-            vcvars-script-path: "C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Auxiliary/Build/vcvars64.bat"
-            vcpkg-triplet: x64-windows-release
-            use-qtwebengine: "ON" # might need to be turned off for MinGW
-            qt-modules: 'qtwebengine qtwebchannel qtwebsockets qtpositioning'
-            ctest: false
             ctest-cmd: "RUN_TESTS"
 
           - job-name: "64-bit MinGW with ctest"


### PR DESCRIPTION


<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

Windows 2019 runners are being removed: https://github.com/actions/runner-images/issues/12045

This PR updates the Win32 build to use the "2022" Windows image and MSVC 2022. It also removes the MSVC 2019 build, as that won't be available moving forward, IIUC.

I think we should do this before the release so that we don't accidentally have the pipeline blocked (I think S3 upload won't trigger if some builds didn't finish).

## Types of changes

<!-- Delete lines that don't apply -->

- Maintenance

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [ ] Code is tested
- [ ] All tests are passing
- [ ] Updated documentation
- [ ] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
