### PR TITLE
`HelpSource/Guides/EqualityIdentity.schelp`: Fix Typo Causing Rendering Error 

### DIFF
--- a/HelpSource/Guides/EqualityIdentity.schelp
+++ b/HelpSource/Guides/EqualityIdentity.schelp
@@ -13,7 +13,7 @@ The present discussion is more narrowly concerned with an overview of how the di
 section:: Two objects that are equal to each other are not necessarily identical.
 
 Note:: The word "object" here refers to emphasis::instances:: of classes, not to the abstract class link::Classes/Object::.
-See link::Guides/Intro-to-Objects::.
+See link::Guides/Intro-to-Objects::.::
 
 A factory may produce thousands of screwdrivers each day that are all emphasis::equal:: to each other with respect to some specification; but each single screwdriver is emphasis::identical:: only to itself (because it occupies this particular location at this particular time, or has a particular serial number stamped on it).
 Thus we can say that identity, the relation of an object to itself, is a stronger relation than equality, the relation of an object so some other object with respect to a common property.


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

The new documentation created via #6922 is missing a :: after the first note tag, resulting in incorrect rendering. This PR resolves the issue.”

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
