### PR TITLE
classlib: Don't try to free a Volume synth that doesn't exist

### DIFF
--- a/SCClassLibrary/Common/Control/Volume.sc
+++ b/SCClassLibrary/Common/Control/Volume.sc
@@ -165,7 +165,9 @@ Volume {
 	}
 
 	freeSynth {
-		ampSynth.release;
+		if(ampSynth.isPlaying) {
+			ampSynth.release;
+		}
 	}
 
 	// sets volume back to 1 - removes the synth


### PR DESCRIPTION
## Purpose and Motivation

Fixes #6937.

It turns out that the Volume class *does* track whether the synth is expected to be playing, but it doesn't use this information to check whether it's necessary to release.

## Types of changes

- Bug fix

## To-do list

- [x] Code is tested
- [x] All tests are passing
- [ ] n/a Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->