### PR TITLE
Add Ableton Link UGen

### DIFF
--- a/SCClassLibrary/Common/Audio/LinkUGen.sc
+++ b/SCClassLibrary/Common/Audio/LinkUGen.sc
@@ -1,0 +1,16 @@
+LinkUGen : MultiOutUGen {
+	*ar { |setTempo, newTempo, setPlaying, playingValue, quantum=1.0, hardwareBlockSize=512|
+	    var delay = hardwareBlockSize / SampleRate.ir;
+		^this.multiNew('audio', setTempo, newTempo, setPlaying, playingValue, quantum, delay);
+	}
+
+    *kr { |setTempo, newTempo, setPlaying, playingValue, quantum=1.0, hardwareBlockSize=512|
+        var delay = hardwareBlockSize / SampleRate.ir;
+        ^this.multiNew('control', setTempo, newTempo, setPlaying, playingValue, quantum, delay);
+    }
+
+	init {arg ... theInputs;
+		inputs = theInputs;
+		^this.initOutputs(2, rate);
+	}
+}

--- a/server/plugins/CMakeLists.txt
+++ b/server/plugins/CMakeLists.txt
@@ -142,6 +142,15 @@ add_library(ML_UGens MODULE
 	${scplugin_common_sources}
 )
 
+if(SC_ABLETON_LINK)
+	add_library(Link_UGen MODULE
+		LinkUGen.cpp
+	)
+	include(../../external_libraries/link/AbletonLinkConfig.cmake)
+	target_link_libraries(Link_UGen PRIVATE Ableton::Link)
+	list(APPEND plugins Link_UGen)
+endif()
+
 if(NOT NO_LIBSNDFILE)
 	set(diskio_sources DiskIO_UGens.cpp)
 

--- a/server/plugins/LinkUGen.cpp
+++ b/server/plugins/LinkUGen.cpp
@@ -1,0 +1,120 @@
+#include <ableton/Link.hpp>
+
+#include "SC_InterfaceTable.h"
+#include "SC_Unit.h"
+#include "SC_PlugIn.hpp"
+
+static InterfaceTable* ft;
+
+class LinkUGen : public SCUnit {
+public:
+    LinkUGen(): mLink(120.0) {
+        // this is not rt safe :p
+        mLink.enable(true);
+
+        mMSecPerTick = std::chrono::microseconds(static_cast<int>(10e6 / sampleRate()));
+
+        // how do we obtain the passed 'control' or 'audio' parameter in the plugin api?
+        if (isControlRateIn(0)) {
+            mCalcFunc = make_calc_function<LinkUGen, &LinkUGen::next_k>();
+            // prime the pipe
+            next_k(1);
+        } else {
+            mCalcFunc = make_calc_function<LinkUGen, &LinkUGen::next>();
+            next(1);
+        }
+    }
+    ~LinkUGen() {
+        mLink.enable(false);
+        // do we need to destroy mLink here ;?
+    }
+
+private:
+    // how to allocate this not during construction?
+    ableton::Link mLink;
+    std::chrono::microseconds mMSecPerTick = std::chrono::microseconds::zero();
+
+    void next_k(int numSamples) {
+        auto sessionState = mLink.captureAudioSessionState();
+
+        const float setTempo = in0(0);
+        const float newTempo = in0(1);
+        const float setIsPlaying = in0(2);
+        const float isPlayingVal = in0(3);
+        const float quantum = in0(4);
+        const float delay = in0(5);
+
+        bool tempoSet = false;
+        bool playSet = false;
+
+        const std::chrono::microseconds hardwareOffset = std::chrono::microseconds(static_cast<int>(10e6 * delay));
+
+        // should we calculate from the beginning or from middle of the block (size)?
+        const auto time = mLink.clock().micros() + hardwareOffset;
+
+        if (setTempo > 0.0f) {
+            tempoSet = true;
+            sessionState.setTempo(newTempo, time);
+        }
+        if (setIsPlaying > 0.0f) {
+            playSet = true;
+            sessionState.setIsPlaying(isPlayingVal, time);
+        }
+
+        if (playSet || tempoSet) {
+            mLink.commitAudioSessionState(sessionState);
+        }
+
+        // phase
+        out0(0) = sessionState.phaseAtTime(time, quantum);
+        // tempo
+        out0(1) = sessionState.tempo();
+    }
+
+    void next(int numSamples) {
+        auto sessionState = mLink.captureAudioSessionState();
+
+        float* phase = out(0);
+        float* tempo = out(1);
+
+        const float* setTempo = in(0);
+        const float* newTempo = in(1);
+        const float* setIsPlaying = in(2);
+        const float* isPlayingVal = in(3);
+        const float* quantum = in(4);
+        const float* delay = in(5);
+
+        bool tempoSet = false;
+        bool playSet = false;
+
+        const std::chrono::microseconds hardwareOffset = std::chrono::microseconds(static_cast<int>(10e6 * delay[0]));
+
+        for (int i = 0; i < numSamples; i++) {
+            // i * mSecPerTick could be pre-calculated once - this seems to be computational intensive for some reason?
+            const auto time = mLink.clock().micros() + (i * mMSecPerTick) + hardwareOffset;
+
+            if (setTempo[i] > 0.0f && !tempoSet) {
+                // only set once in a block? sample accurate though
+                tempoSet = true;
+                sessionState.setTempo(newTempo[i], time);
+            }
+            if (setIsPlaying[i] > 0.0f && !playSet) {
+                // only set once in a block? sample accurate though
+                playSet = true;
+                sessionState.setIsPlaying(isPlayingVal[i], time);
+            }
+
+            phase[i] = sessionState.phaseAtTime(time, quantum[i]);
+            tempo[i] = sessionState.tempo();
+        }
+
+        if (playSet || tempoSet) {
+            mLink.commitAudioSessionState(sessionState);
+        }
+    }
+};
+
+PluginLoad(LinkUGen) {
+    ft = inTable;
+    registerUnit<LinkUGen>(ft, "LinkUGen", false);
+}


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

Closes https://github.com/supercollider/supercollider/issues/6689 which adds a way to synchronize language and server (and other software) through Ableton Link.

This is only a first draft until a good API has been established - please provide some feedback :)

## Demo

```supercollider
s.reboot;


// create a tempo clock through a ugen
(
Ndef(\clock, {
	var phase, tempo;
	var modTempo = LFDNoise3.kr(1.0).exprange(100, 380).poll(1.0, \tempo);
	#phase, tempo = LinkUGen.kr(
		setTempo: DC.kr(1.0),
		newTempo: modTempo,
		setPlaying: DC.kr(0.0),
		playingValue: DC.kr(1.0),
		quantum: 1.0,
	);
	// some annoying metronome
	SinOscFB.ar(1440.0, 1.0) * (phase < 0.1) * 0.2.dup;
}).play;
)


// this gets synced after a short time :) - works also accross network!
(
Ndef(\otherClock, {
	var phase, tempo;
	#phase, tempo = LinkUGen.kr(
		setTempo: DC.kr(0.0),
		newTempo: DC.kr(0.0),
		setPlaying: DC.kr(0.0),
		playingValue: DC.kr(1.0),
		quantum: 1.0,
	);
	// some other annoying metronome
	SinOscFB.ar(4440.0, 1.0) * (phase < 0.1) * 0.2.dup;
}).play;
)

// create a language clock
l = LinkClock(1.0).latency_(Server.default.latency);

// pattern is now in sync w/ UGen clock :)
(
Pdef(\p, Pbind(
	\dur, 0.5,
	\amp, 0.5,
	\scale, Scale.minor,
	\degree, Pwrap(Pseries(0.0, 1.1), lo: 0.0, hi: 8.9),
)).clock_(l).play;
)


// delete master clock - tempo is now static
Ndef(\clock).clear;

Pdef(\p).clear;

Ndef.clear;
```

Things to work out:

### Interface

* How should a "jump to beat" be established?
* Maybe do not expose tempo at all and instead rely solely on phase? Tempo seems to be somehow more for UI feedback than for usage according to docs? 

### Implementation

* Improve performance (how though?)
* On heavy tempo modulation, some events of a pattern will not be released - maybe due to UDP overflow?
* Improve init - use a pointer for ableton link which then can be initialized in a deferred thread? Yet this is something which won't be spawned 100s of times, probably one wants to keep this like a singleton
* How to obtain output latency of the current hardware? (Is this output latency also respected within sclang?)
* On high tempi it seems that `phase < 0.1` is not working correctly anymore, even when using audio rate. Maybe I calculate some offsets wrong?

## Types of changes

<!-- Delete lines that don't apply -->

- New feature

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [ ] Code is tested
- [ ] All tests are passing
- [ ] Updated documentation
- [ ] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
