### PR TITLE
sclang: throw fatal exception

### DIFF
--- a/lang/LangSource/GC.cpp
+++ b/lang/LangSource/GC.cpp
@@ -26,6 +26,7 @@
 #include "InitAlloc.h"
 #include <string.h>
 #include <stdexcept>
+#include "PyrLexer.h"
 
 #define PAUSETIMES 0
 
@@ -139,8 +140,9 @@ void fatalerror(const char* str);
 void fatalerror(const char* str) {
     fputs(str, stderr);
     postfl(str);
-    throw std::runtime_error(str);
-    // exit(-1);
+    // This is the *only* exception that isn't caught by the main interpreter loop.
+    // This will be throw up and out of sclang to the surrounding call stack.
+    throw FatalInterpreterError(str);
 }
 
 inline int ScanSize(PyrObjectHdr* obj) { return obj->obj_format <= obj_slot ? obj->size : 0; }

--- a/lang/LangSource/PyrLexer.cpp
+++ b/lang/LangSource/PyrLexer.cpp
@@ -2262,7 +2262,7 @@ void signal_init_globs();
 
 void dumpByteCodes(PyrBlock* theBlock);
 
-SCLANG_DLLEXPORT_C void runLibrary(PyrSymbol* selector) {
+SCLANG_DLLEXPORT_C void runLibrary(PyrSymbol* selector) noexcept(false) {
     VMGlobals* g = gMainVMGlobals;
     g->canCallOS = true;
     try {
@@ -2273,7 +2273,10 @@ SCLANG_DLLEXPORT_C void runLibrary(PyrSymbol* selector) {
         } else {
             postfl("Library has not been compiled successfully.\n");
         }
-    } catch (std::exception& ex) {
+    } catch (const FatalInterpreterError& er) {
+        error("A fatal interpreter error has occured. Reason: %s\n", er.what());
+        std::rethrow_exception(std::current_exception());
+    } catch (const std::exception& ex) {
         PyrMethod* meth = g->method;
         if (meth) {
             int ip = slotRawInt8Array(&meth->code) ? g->ip - slotRawInt8Array(&meth->code)->b : -1;

--- a/lang/LangSource/PyrLexer.h
+++ b/lang/LangSource/PyrLexer.h
@@ -62,7 +62,13 @@ void traverseDepTree2(ClassDependancy* classdep, int level);
 void compileClassExtensions();
 void compileClass(PyrSymbol* fileSym, int startPos, int endPos, int lineOffset);
 
-SCLANG_DLLEXPORT_C void runLibrary(PyrSymbol* selector);
+
+struct FatalInterpreterError : public std::runtime_error {
+    using std::runtime_error::runtime_error;
+};
+
+// All exceptions are caught, except FataInterpreterErrors
+SCLANG_DLLEXPORT_C void runLibrary(PyrSymbol* selector) noexcept(false);
 
 void interpretCmdLine(const char* textbuf, int textlen, char* methodname);
 


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

When sclang has a fatal error and throws, the exception is caught in `runLibrary`, meaning the vm just sits there in an invalid state, without informing the call sight. Now the exception is bubbled up the call stack, cause a proper error where ever it is need. 

## Types of changes

<!-- Delete lines that don't apply -->

- New feature

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [ ] Code is tested
- [ ] All tests are passing
- [ ] Updated documentation
- [ ] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
