### PR TITLE
Change some definitionlist to subsubsection for better layout; Add forum to subsection `For more information` 

### DIFF
--- a/HelpSource/Help.schelp
+++ b/HelpSource/Help.schelp
@@ -194,38 +194,47 @@ numberedlist::
 
 subsection:: Sharing your work
 
-definitionList::
-## Share Music || list::
+subsubsection:: Share Music
+list::
 ## link::https://scsynth.org/c/music##Music on scsynth.org::
 ::
-## Share Code || list::
+subsubsection:: Share Code
+list::
 ## http://sccode.org/
 ## link::https://scsynth.org/c/questions/code-review##Code Review on scsynth.org::
 ## link::https://scsynth.org/c/music/code-tennis##Code Tennis on scsynth.org::
 ## link::https://github.com/supercollider/supercollider/wiki/Style-Guidelines:-SuperCollider##Style Guide: SuperCollider Code (for sclang)::
 ::
-::
 
 subsection:: Contributing to SC
 
-definitionList::
-## Discussing || list::
+subsubsection:: Discussing
+
+list::
 ## link::https://scsynth.org/c/development##Development on scsynth.org::
 ::
-## Help Documents || list::
+
+subsubsection:: Help Documents
+
+list::
 ## link::Guides/WritingHelp::
 ## link::Reference/SCDocSyntax::
 ## link::https://github.com/supercollider/supercollider/wiki/Style-Guidelines:-SCDocs##Style Guide: SuperCollider Help Files::
 ::
-## Developing || list::
+
+subsubsection:: Developing
+
+list::
 ## link::https://github.com/supercollider/supercollider##SuperCollider on GitHub::
 ## link::https://github.com/supercollider/supercollider/wiki/Style-Guidelines:-Cpp##Style Guide: SuperCollider C++ Code (for scsynth)::
-::
 ::
 
 subsection:: For more information
 
-link:: https://github.com/supercollider/supercollider/wiki##SuperCollider Wiki::
+list::
+##link::https://github.com/supercollider/supercollider/wiki##SuperCollider Wiki::
+##link::https://scsynth.org##SuoerCollider Forum::
+::
 
 SECTION::Licensing
 


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

Yesterday, I accessed http://doc.sccode.org on my Android smartphone and realised the layout of the last three subsections are a bit ugly:
This PR amends some definition lists to subsections to align with the layout of the documentation.
- Before this PR:
    ![Screenshot 2025-06-10 at 15 16 18](https://github.com/user-attachments/assets/64a3bb33-454a-4b82-8275-f70fa3cf3e33)
- With this PR
    ![Screenshot 2025-06-11 at 00 56 34](https://github.com/user-attachments/assets/3a7dd637-03f2-4655-9bad-4893e187b969)

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
