### PR TITLE
QtCollider: fix Q_INVOKABLE SharedImage typename

### DIFF
--- a/QtCollider/image.h
+++ b/QtCollider/image.h
@@ -199,4 +199,6 @@ typedef QSharedPointer<QtCollider::Image> SharedImage;
 
 } // namespace QtCollider
 
-Q_DECLARE_METATYPE(QtCollider::SharedImage);
+// SharedImage is a typedef, so Q_PROPERTY and Q_INVOKABLE need to use its full type name,
+// otherwise some type comparisons when invoking methods might fail
+Q_DECLARE_METATYPE(QSharedPointer<QtCollider::Image>);

--- a/QtCollider/widgets/BasicWidgets.cpp
+++ b/QtCollider/widgets/BasicWidgets.cpp
@@ -38,8 +38,8 @@ void QcSimpleWidget::setBackground(const QColor& c) {
     update();
 }
 
-void QcSimpleWidget::setBackgroundImage(const QtCollider::SharedImage& image, const QRectF& rect, int tileMode,
-                                        double opacity) {
+void QcSimpleWidget::setBackgroundImage(const QSharedPointer<QtCollider::Image>& image, const QRectF& rect,
+                                        int tileMode, double opacity) {
     _bkg_image.setImage(image, rect, tileMode, opacity);
     update();
 }

--- a/QtCollider/widgets/BasicWidgets.h
+++ b/QtCollider/widgets/BasicWidgets.h
@@ -37,7 +37,8 @@ public:
     const QColor& background() const { return _bkg; }
     void setBackground(const QColor& c);
     Q_INVOKABLE
-    void setBackgroundImage(const QtCollider::SharedImage& image, const QRectF& rect, int tileMode, double opacity);
+    void setBackgroundImage(const QSharedPointer<QtCollider::Image>& image, const QRectF& rect, int tileMode,
+                            double opacity);
     Q_INVOKABLE
     void removeBackgroundImage() {
         _bkg_image.clear();

--- a/QtCollider/widgets/QcButton.h
+++ b/QtCollider/widgets/QcButton.h
@@ -31,7 +31,7 @@ class QcButton : public QPushButton, QcHelper, QtCollider::Style::Client {
     Q_PROPERTY(int value READ getValue WRITE setValue);
     Q_PROPERTY(QColor focusColor READ focusColor WRITE setFocusColor);
     Q_PROPERTY(QcMenu* menu READ qcmenu WRITE setQcMenu);
-    Q_PROPERTY(const QtCollider::SharedImage& icon READ icon WRITE setIcon);
+    Q_PROPERTY(const QSharedPointer<QtCollider::Image>& icon READ icon WRITE setIcon);
 
 public:
     QcButton();

--- a/QtCollider/widgets/QcCanvas.cpp
+++ b/QtCollider/widgets/QcCanvas.cpp
@@ -68,7 +68,7 @@ void QcCanvas::setBackground(const QColor& c) {
         update();
 }
 
-void QcCanvas::setBackgroundImage(const QtCollider::SharedImage& image, const QRectF& rect, int tileMode,
+void QcCanvas::setBackgroundImage(const QSharedPointer<QtCollider::Image>& image, const QRectF& rect, int tileMode,
                                   double opacity) {
     _bkg_image.setImage(image, rect, tileMode, opacity);
 

--- a/QtCollider/widgets/QcCanvas.h
+++ b/QtCollider/widgets/QcCanvas.h
@@ -50,7 +50,8 @@ public:
     QColor background() const { return _bkg; }
     void setBackground(const QColor& c);
     Q_INVOKABLE
-    void setBackgroundImage(const QtCollider::SharedImage& image, const QRectF& rect, int tileMode, double opacity);
+    void setBackgroundImage(const QSharedPointer<QtCollider::Image>& image, const QRectF& rect, int tileMode,
+                            double opacity);
     Q_INVOKABLE
     void removeBackgroundImage() {
         _bkg_image.clear();

--- a/QtCollider/widgets/QcMenu.h
+++ b/QtCollider/widgets/QcMenu.h
@@ -49,7 +49,7 @@ class QcAction : public QAction {
 public:
     QcAction();
 
-    Q_PROPERTY(const QtCollider::SharedImage& icon READ icon WRITE setIcon);
+    Q_PROPERTY(const QSharedPointer<QtCollider::Image>& icon READ icon WRITE setIcon);
     Q_PROPERTY(QMenu* menu READ menu WRITE setMenu);
     Q_PROPERTY(QString shortcut READ shortcut WRITE setShortcut);
     Q_PROPERTY(bool separator READ isSeparator WRITE setSeparator);

--- a/QtCollider/widgets/QcSlider2D.cpp
+++ b/QtCollider/widgets/QcSlider2D.cpp
@@ -113,7 +113,7 @@ void QcSlider2D::keyPressEvent(QKeyEvent* e) {
     }
 }
 
-void QcSlider2D::setBackgroundImage(const QtCollider::SharedImage& image, const QRectF& rect, int tileMode,
+void QcSlider2D::setBackgroundImage(const QSharedPointer<QtCollider::Image>& image, const QRectF& rect, int tileMode,
                                     double opacity) {
     _backgroundImage.setImage(image, rect, tileMode, opacity);
 }

--- a/QtCollider/widgets/QcSlider2D.h
+++ b/QtCollider/widgets/QcSlider2D.h
@@ -67,7 +67,8 @@ public:
     }
 
     Q_INVOKABLE
-    void setBackgroundImage(const QtCollider::SharedImage& image, const QRectF& rect, int tileMode, double opacity);
+    void setBackgroundImage(const QSharedPointer<QtCollider::Image>& image, const QRectF& rect, int tileMode,
+                            double opacity);
 public Q_SLOTS:
     void incrementX(double factor = 1.f);
     void decrementX(double factor = 1.f);


### PR DESCRIPTION
## Purpose and Motivation

Fixes #6936 

We had this problem before with `TreeView`, see #6521. This PR applies the same fix. 

`SharedImage` is a typedef for `QSharedPointer<QtCollider::Image>`. Qt registers it as a MetaType with its full name `QSharedPointer<QtCollider::Image>`, so Q_INVOKABLE methods needs to use the same name, otherwise method calls fail with `QMetaMethod::invoke: cannot convert formal parameter 0 from QSharedPointer<QtCollider::Image> to SharedImage.`. Even if the type is the same, Qt gets confused about its name.

Here is a note from [Qt docs](https://doc.qt.io/qt-6/qtqml-cppintegration-exposecppattributes.html#exposing-properties):
> Note: Do not use typedef or using for [Q_PROPERTY](https://doc.qt.io/qt-6/qobject.html#Q_PROPERTY) types as these will confuse moc. This may make certain type comparisons fail.

For any other use than Q_INVOKABLE,  `SharedImage` should be fine, so we can keep the `typedef`.
I decided to patch also when used with Q_PROPERTY, since Qt mentions it explicitly, even though those methods didn't fail.

You can use this code to test affected Widgets:
```supercollider
var image = Image("PATH/TO/YOUR/IMAGE");
View(bounds:300@300).layout_(VLayout(
	View().setBackgroundImage(image),
	Button().icon_(image),
	Menu(MenuAction("test").icon_(image))
)).front
```

## Types of changes

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [ ] Code is tested
- [ ] All tests are passing
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
