### PR TITLE
Fix example for bend Pbind

### DIFF
--- a/HelpSource/Overviews/MidiPatterns.schelp
+++ b/HelpSource/Overviews/MidiPatterns.schelp
@@ -158,7 +158,7 @@ p = Pbind(
 	\midicmd, \bend,
 
 	\chan, 0,
-	\bend, Pwhite(0, 8191, inf), // bend value
+	\val, Pwhite(0, 8191, inf), // bend value
 	\dur, Pseq([1,2,0.5], inf),
 
 ).play(quant: 1);


### PR DESCRIPTION
The example given to send pitchbend messages from a Pbind does not work as the `\bend` key used should be `\val`.