### PR TITLE
classlib: kwargs for Pbindef and PbindProxy

### DIFF
--- a/HelpSource/Classes/PbindProxy.schelp
+++ b/HelpSource/Classes/PbindProxy.schelp
@@ -9,7 +9,20 @@ keeps a reference to a link::Classes/Pbind:: in which single keys can be replace
 ClassMethods::
 
 method::new
-create a new instance of PbindProxy with the given patternpairs
+Return a new instance of PbindProxy with the given patternpairs. Unlike link::Classes/Pbindef::, it has no internal name.
+
+code::
+a = PbindProxy(\note, Pseq([0, 7, 9], inf), \dur, 0.2).play;
+a.set(\note, Pseq([0, 6, 10]));
+a.stop;
+::
+
+It also supports keyword argument syntax:
+
+code::
+a = PbindProxy(note: Pseq([0, 7, 9]), dur: 0.2).play;
+a.stop;
+::
 
 InstanceMethods::
 
@@ -32,12 +45,12 @@ Examples::
 
 code::
 (
-SynthDef("Pdefhelp", { |out, freq, sustain = 1, amp = 1, pan|
-	var env, u = 1;
-	env = EnvGen.kr(Env.perc(0.03, sustain), 1, doneAction: Done.freeSelf);
-	5.do { var d; d = exprand(0.01, 1); u = SinOsc.ar(d * 300, u, rrand(0.1, 1.2) * d, 1) };
-	Out.ar(out, Pan2.ar(SinOsc.ar(u + 1 * freq, 0, amp * env), pan));
-}).add;
+	SynthDef(\Pdefhelp, { |out, freq, sustain = 1, amp = 1, pan|
+		var env, u = 1;
+		env = EnvGen.ar(Env.perc(0.03, sustain), 1, doneAction: Done.freeSelf);
+		5.do { var d; d = exprand(0.01, 1); u = SinOsc.ar(d * 300, u, rrand(0.1, 1.2) * d, 1) };
+		Out.ar(out, Pan2.ar(SinOsc.ar(u + 1 * freq, 0, amp * env), pan));
+	}).add;
 )
 s.boot;
 
@@ -60,16 +73,16 @@ x.set(\degree, Pseq([1, 2, 3, 4, 5, 6], 3), \dur, 0.02);
 x.play;
 
 x.set(\degree, Pseq([1, 2, 3, 4, 5, 6], 3), \dur, 0.1);
+x.set(\degree, Pseq([1b, 5, 3, 1b, 6, 2, 5, 0, 3, 0, 2], inf));
 x.play;
 
 
 // embed in other patterns:
 (
-x.set(\degree, Pseq([1b, 5, 3, 1b, 6, 2, 5, 0, 3, 0, 2], inf));
-Ppar([
-x,
-Pbindf(x, \ctranspose, 4)
-]).play;
+	Ppar([
+		x,
+		Pbindf(x, \ctranspose, 4)
+	]).play;
 )
 
 

--- a/HelpSource/Classes/Pbindef.schelp
+++ b/HelpSource/Classes/Pbindef.schelp
@@ -12,10 +12,20 @@ Pbindef and Pdef use the same global collection, while Pdef and Pdefn use separa
 
 Pbindef inherits most methods from link::Classes/Pdef::. Overview: link::Overviews/JITLib::
 
+code::
+Pbindef(\x, \note, Pseq([0, 7, 9]), \dur, 0.2).play;
+::
+
+It also supports keyword argument syntax:
+
+code::
+Pbindef(\x, note: Pseq([0, 7, 9]), dur: 0.2).play;
+::
+
 ClassMethods::
 
 method::new
-store the pattern in the global dictionary of link::Classes/Pdef:: under key. (if there is already a Pdef there, replace its pattern with the new one. If there is already a strong::Pbindef:: there, set the parameters only, or add a new one (the whole pattern is replaced).
+store the pattern in the global dictionary of link::Classes/Pdef:: under key. If there is already a Pdef of this key, replace its pattern with the new one. If there is already a strong::Pbindef:: af this key, set the parameters only, or add a new one (the whole pattern is replaced).
 
 Using strong::*new(key):: you can access the pattern at that key (if none is there, a default pattern is created). see link::Classes/Pdef::.
 
@@ -23,34 +33,33 @@ Examples::
 
 code::
 (
-SynthDef("Pdefhelp", { |out, freq, sustain = 1, amp = 1, pan|
-	var env, u = 1;
-	env = EnvGen.kr(Env.perc(0.01, sustain), 1, doneAction: Done.freeSelf);
-	5.do { var d; d = exprand(0.01, 1); u = SinOsc.ar(d * 300, u, rrand(0.1, 1.2) * d, 1) };
-	Out.ar(out, Pan2.ar(SinOsc.ar(u + 1 * freq, 0, amp * env), pan));
-}).add;
+	SynthDef(\Pdefhelp, { |out, freq, sustain = 1, amp = 1, pan|
+		var env, u = 1;
+		env = EnvGen.ar(Env.perc(0.01, sustain), 1, doneAction: Done.freeSelf);
+		5.do { var d; d = exprand(0.01, 1); u = SinOsc.ar(d * 300, u, rrand(0.1, 1.2) * d, 1) };
+		Out.ar(out, Pan2.ar(SinOsc.ar(u + 1 * freq, 0, amp * env), pan));
+	}).add;
 )
-s.boot;
 
 
-Pbindef(\a, \instrument, \Pdefhelp).play;
-Pbindef(\a, \degree, Pseq([0, 2, 5b, 1b], inf));
-Pbindef(\a, \dur, 0.1);
-Pbindef(\a, \degree, Pseq([1b, 5, 3, 1b, 6, 2, 5, 0, 3, 0, 2], inf));
-Pbindef(\a, \legato, Prand([1.0, 2.4, 0.2], inf), \mtranspose, -3);
-Pbindef(\a, \mtranspose, nil); // remove key
+Pbindef(\a, instrument: \Pdefhelp).play;
+Pbindef(\a, degree: Pseq([0, 2, 5b, 1b], inf));
+Pbindef(\a, dur: 0.1);
+Pbindef(\a, degree: Pseq([1b, 5, 3, 1b, 6, 2, 5, 0, 3, 0, 2], inf));
+Pbindef(\a, legato: Prand([1.0, 2.4, 0.2], inf), mtranspose: -3);
+Pbindef(\a, mtranspose: nil); // remove key
 
-Pbindef(\a, \degree, Pseq([1, 2, 3, 4, 5, 6], 1));
-Pbindef(\a, \degree, Pseq([1, 2, 3, 4, 5, 6], 3), \dur, 0.02);
-Pbindef(\a, \degree, Pseq([1, 2, 3, 4, 5, 6], 3), \dur, 0.1);
+Pbindef(\a, degree: Pseq([1, 2, 3, 4, 5, 6], 1));
+Pbindef(\a, degree: Pseq([1, 2, 3, 4, 5, 6], 3), dur: 0.02);
+Pbindef(\a, degree: Pseq([1, 2, 3, 4, 5, 6], 3), dur: 0.1);
 
 // apart from this Pbindef behaves like Pdef:
 
 Pbindef(\a).quant = 0.0;
-Pbindef(\a, \degree, Pseq([1, 2, 3, 4, 5, 6], 1));
+Pbindef(\a, degree: Pseq([1, 2, 3, 4, 5, 6], 1));
 
 Pbindef(\a).stop;
-Pbindef(\a, \degree, Pseq([1, 2, 3, 4, 5, 6], 1)); // does not resume now
+Pbindef(\a, degree: Pseq([1, 2, 3, 4, 5, 6], 1)); // does not resume now
 
 Pbindef(\a).playOnce; // play single instance
 Pseq([Pbindef(\a), Pdef(\a)]).play; // same here (Pdef(\a) is the same pattern as Pbindef))
@@ -61,10 +70,12 @@ Pbindef(\a) === Pdef(\a) // identical.
 
 // an already existing Pdef can be incrementally changed
 
-Pdef(\x, Pbind(\instrument, \Pdefhelp, \dur, 0.3));
+Pdef(\x, Pbind(\instrument, \Pdefhelp, dur: 0.3));
 Pdef(\x).play;
 
-Pbindef(\x, \degree, 7.rand);
-Pbindef(\x, \degree, Pseq([0, 7, 3, 7, 4], inf), \dur, Pn(Pseries(0.2, -0.02, 10)));
+Pbindef(\x, degree: 7.rand + 1);
+Pbindef(\x, degree: Pseq([0, 7, 3, 7, 4], inf), dur: Pn(Pseries(0.2, -0.02, 10)));
 Pbindef(\x, \stretch, 2);
+
+Pdef(\x).stop;
 ::

--- a/SCClassLibrary/JITLib/Patterns/Pdef.sc
+++ b/SCClassLibrary/JITLib/Patterns/Pdef.sc
@@ -10,7 +10,7 @@ PatternProxy : Pattern {
 
 	classvar <>defaultQuant, defaultEnvir;
 
-	*new { arg source;
+	*new { |source|
 		^super.new.source_(source)
 	}
 
@@ -20,9 +20,9 @@ PatternProxy : Pattern {
 	clock { ^clock ? TempoClock.default }
 
 	quant { ^quant ??  { this.class.defaultQuant } }
-	quant_ { arg val; quant = val }
+	quant_ { |val| quant = val }
 
-	source_ { arg obj;
+	source_ { |obj|
 		var pat = if(obj.isKindOf(Function)) { this.convertFunction(obj) }{ obj };
 		if (obj.isNil) { pat = this.class.default };
 		pattern = pat;
@@ -30,61 +30,61 @@ PatternProxy : Pattern {
 		this.changed(\source, obj);
 	}
 
-	setSource { arg obj;
+	setSource { |obj|
 		pattern = obj;
 		source = obj; // keep original here.
 		this.changed(\source, obj);
 	}
 
-	count { arg n=1;
+	count { |n=1|
 		condition = { |val,i| i % n == 0 }
 	}
 
 	reset { reset = reset ? 0 + 1 }
 
-	sched { arg func;
+	sched { |func|
 		if(quant.isNil)
 		{ func.value }
 		{ this.clock.schedAbs(quant.nextTimeOnGrid(this.clock), { func.value; nil }) }
 	}
 
 
-	convertFunction { arg func;
+	convertFunction { |func|
 		^Prout {
 			var inval = func.def.prototypeFrame !? { inval = this.defaultEvent };
 			func.value( inval ).embedInStream(inval)
 		}
 	}
 
-	*parallelise { arg list; ^Ptuple(list) }
+	*parallelise { |list| ^Ptuple(list) }
 
-	pattern_ { arg pat; this.source_(pat) }
+	pattern_ { |pat| this.source_(pat) }
 
-	timingOffset_ { arg val; quant = quant.instill(2, val) }
-	timingOffset { arg val; ^quant.obtain(2) }
-	phase_ { arg val; quant = quant.instill(1, val) }
-	phase { arg val; ^quant.obtain(1) }
-	quantBeat_ { arg val; quant = quant.instill(0, val) }
-	quantBeat { arg val; ^quant.obtain(0) }
+	timingOffset_ { |val| quant = quant.instill(2, val) }
+	timingOffset { |val| ^quant.obtain(2) }
+	phase_ { |val| quant = quant.instill(1, val) }
+	phase { |val| ^quant.obtain(1) }
+	quantBeat_ { |val| quant = quant.instill(0, val) }
+	quantBeat { |val| ^quant.obtain(0) }
 
-	set { arg ... args;
+	set { |...args|
 		if(envir.isNil) { this.envir = this.class.event };
 		args.pairsDo { arg key, val; envir.put(key, val) };
 		this.changed(\set, args);
 	}
 
-	unset { arg ... args;
+	unset { |...args|
 		if(envir.notNil) {
-			args.do { arg key; envir.removeAt(key) };
+			args.do { |key| envir.removeAt(key) };
 			this.changed(\unset, args);
 		}
 	}
 
-	get { arg key;
+	get { |key|
 		^if(envir.notNil) { envir[key] } { nil };
 	}
 
-	place { arg ... args;
+	place { |...args|
 		if(envir.isNil) { this.envir = this.class.event };
 		args.pairsDo { arg key, val; envir.place(key, val) }; // place is defined in the event.
 	}
@@ -97,7 +97,7 @@ PatternProxy : Pattern {
 		^if(val.notNil) { Pchain(this, val) } { this }.embedInStream
 	}
 
-	embedInStream { arg inval, embed = true, default;
+	embedInStream { |inval, embed = true, default|
 
 		var outval, count = 0;
 		var pat = pattern;
@@ -133,13 +133,13 @@ PatternProxy : Pattern {
 		}
 	}
 
-	endless { arg default;
+	endless { |default|
 		^Prout { arg inval;
 			this.embedInStream(inval, true, default ? this.class.defaultValue)
 		}
 	}
 
-	constrainStream { arg stream, newStream;
+	constrainStream { |stream, newStream|
 		^if(this.quant.isNil) {
 			newStream
 		} {
@@ -174,7 +174,7 @@ PatternProxy : Pattern {
 	}
 
 	*clear {
-		this.all.do { arg pat; pat.clear };
+		this.all.do { |pat| pat.clear };
 		this.all.clear;
 	}
 
@@ -190,23 +190,23 @@ PatternProxy : Pattern {
 	}
 
 	// backward compatibility
-	*basicNew { arg source;
+	*basicNew { |source|
 		^super.new.init(source)
 	}
 
 	// global storage
 
-	*at { arg key;
+	*at { |key|
 		^if(this.hasGlobalDictionary) { this.all.at(key) } { nil }
 	}
 
 	repositoryArgs { ^[this.key, this.source] }
 
-	*postRepository { arg keys, stream;
+	*postRepository { |keys, stream|
 		if(this.hasGlobalDictionary.not) { Error("This class has no global repository.").throw };
 		keys = keys ?? { this.all.keys };
 		stream = stream ? Post;
-		keys.do { arg key;
+		keys.do { |key|
 			var item;
 			item = this.all[key];
 			if(item.notNil and: { item.source !== this.default }) {
@@ -220,7 +220,7 @@ PatternProxy : Pattern {
 		};
 	}
 
-	*event { arg proxyClass = PatternProxy;
+	*event { |proxyClass = (PatternProxy)|
 		var event, res;
 		if(defaultEnvir.isNil) {
 			defaultEnvir = Event.default;
@@ -257,7 +257,7 @@ Pdefn : PatternProxy {
 	*initClass {
 		all = IdentityDictionary.new;
 	}
-	*new { arg key, item;
+	*new { |key, item|
 		var res = this.at(key);
 		if(res.isNil) {
 			res = super.new(item).prAdd(key);
@@ -268,7 +268,7 @@ Pdefn : PatternProxy {
 
 	}
 
-	map { arg ... args;
+	map { |...args|
 		if(envir.isNil) { this.envir = () };
 		args.pairsDo { |key, name| envir.put(key, Pdefn(name)) };
 		this.changed(\map, args);
@@ -283,7 +283,7 @@ Pdefn : PatternProxy {
 
 	dup { |n = 2| ^{ this }.dup(n) } // avoid copy in Object::dup
 
-	prAdd { arg argKey;
+	prAdd { |argKey|
 		key = argKey;
 		all.put(argKey, this);
 	}
@@ -301,7 +301,7 @@ TaskProxy : PatternProxy {
 
 	storeArgs { ^[source] }
 
-	source_ { arg obj;
+	source_ { |obj|
 		pattern = if(obj.isKindOf(Function)) { this.convertFunction(obj) }{ obj };
 		if (obj.isNil) { pattern = this.class.default; source = obj; };
 		this.wakeUp;
@@ -309,7 +309,7 @@ TaskProxy : PatternProxy {
 		this.changed(\source, obj);
 	}
 
-	convertFunction { arg func;
+	convertFunction { |func|
 		^Prout { |inevent|
 			var inval = func.def.prototypeFrame !? { this.defaultEvent };
 			if(inevent.isNumber or: {inevent.isNil} or: { inval.isNil }) {
@@ -329,7 +329,7 @@ TaskProxy : PatternProxy {
 	// here, the streams return values which are used as durations
 	// for scheduling the stream itself
 
-	constrainStream { arg stream, newStream;
+	constrainStream { |stream, newStream|
 		^if(this.quant.isNil) {
 			newStream
 		} {
@@ -348,7 +348,7 @@ TaskProxy : PatternProxy {
 
 	////////// playing interface //////////
 
-	playOnce { arg argClock, doReset = (false), quant;
+	playOnce { |argClock, doReset = (false), quant|
 		var pauseStream = PauseStream(
 			Pprotect(this, { pauseStream.streamError }).asStream
 		);
@@ -413,7 +413,7 @@ Tdef : TaskProxy {
 		all = IdentityDictionary.new;
 	}
 
-	*new { arg key, item;
+	*new { |key, item|
 		var res = this.at(key);
 		if(res.isNil) {
 			res = super.new(item).prAdd(key);
@@ -433,7 +433,7 @@ Tdef : TaskProxy {
 
 	dup { |n = 2| ^{ this }.dup(n) } // avoid copy in Object::dup
 
-	prAdd { arg argKey;
+	prAdd { |argKey|
 		key = argKey;
 		all.put(argKey, this);
 	}
@@ -450,7 +450,7 @@ EventPatternProxy : TaskProxy {
 
 	storeArgs { ^[source] }
 
-	source_ { arg obj;
+	source_ { |obj|
 		if(obj.isKindOf(Function)) // allow functions to be passed in
 		{ pattern = PlazyEnvirN(obj) }
 		{ if (obj.isNil)
@@ -470,7 +470,7 @@ EventPatternProxy : TaskProxy {
 
 	*defaultValue { ^Event.silent }
 
-	embedInStream { arg inval, embed = true, default;
+	embedInStream { |inval, embed = true, default|
 
 		var outval, count=0;
 		var pat = pattern;
@@ -552,10 +552,10 @@ EventPatternProxy : TaskProxy {
 		}
 	}
 
-	*parallelise { arg list; ^Ppar(list) }
+	*parallelise { |list| ^Ppar(list) }
 
-	outset_ { arg val; quant = quant.instill(3, val) }
-	outset { arg val; ^this.quant.obtain(3) }
+	outset_ { |val| quant = quant.instill(3, val) }
+	outset { |val| ^this.quant.obtain(3) }
 
 
 	// branching from another thread
@@ -602,7 +602,7 @@ Pdef : EventPatternProxy {
 
 	storeArgs { ^[key] }
 
-	*new { arg key, item;
+	*new { |key, item|
 		var res = this.at(key);
 		if(res.isNil) {
 			res = super.new(item).prAdd(key);
@@ -613,12 +613,12 @@ Pdef : EventPatternProxy {
 
 	}
 
-	map { arg ... args;
+	map { |...args|
 		if(envir.isNil) { this.envir = () };
 		args.pairsDo { |key, name| envir.put(key, Pdefn(name)) }
 	}
 
-	prAdd { arg argKey;
+	prAdd { |argKey|
 		key = argKey;
 		all.put(argKey, this);
 	}
@@ -728,20 +728,20 @@ PbindProxy : Pattern {
 	embedInStream { arg inval;
 		^source.embedInStream(inval)
 	}
-	find { arg key;
+	find { |key|
 		pairs.pairsDo { |u,x,i| if(u == key) { ^i } }; ^nil
 	}
-	quant_ { arg val;
-		pairs.pairsDo { arg key, item; item.quant = val }; // maybe use ref later
+	quant_ { |val|
+		pairs.pairsDo { |key, item| item.quant = val }; // maybe use ref later
 		source.quant = val;
 	}
 	quant { ^source.quant }
 	envir { ^source.envir }
 	envir_ { arg envir; source.envir_(envir) }
 
-	at { arg key; var i; i = this.find(key); ^if(i.notNil) { pairs[i+1] } { nil } }
+	at { |key| var i; i = this.find(key); ^if(i.notNil) { pairs[i+1] } { nil } }
 
-	set { arg ... args; // key, val ...
+	set { |...args| // key, val ...
 		var changedPairs = false, quant;
 		quant = this.quant;
 		args.pairsDo { |key, val|
@@ -800,7 +800,7 @@ Pbindef : Pdef {
 
 	storeArgs { ^[key]++pattern.storeArgs }
 	repositoryArgs { ^this.storeArgs }
-	quant_ { arg val; super.quant = val; source.quant = val }
+	quant_ { |val| super.quant = val; source.quant = val }
 
 	*hasGlobalDictionary { ^true }
 

--- a/SCClassLibrary/JITLib/Patterns/Pdef.sc
+++ b/SCClassLibrary/JITLib/Patterns/Pdef.sc
@@ -709,8 +709,8 @@ Pdef : EventPatternProxy {
 PbindProxy : Pattern {
 	var <>pairs, <source;
 
-	*new { arg ... pairs;
-		^super.newCopyArgs(pairs).init
+	*new { | ... pairs, kwargs |
+		^super.newCopyArgs(pairs ++ kwargs).init
 	}
 	init {
 		forBy(0, pairs.size-1, 2) { arg i;
@@ -777,8 +777,9 @@ PbindProxy : Pattern {
 
 
 Pbindef : Pdef {
-	*new { arg key ... pairs;
+	*new { | key ... pairs, kwargs |
 		var pat, src;
+		pairs = pairs ++ kwargs;
 		pat = super.new(key);
 		if(pairs.isEmpty.not) {
 			src = pat.source;


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

Since 3.14, we can write `Pbind(freq:8, dur:0.2)`, for the rc0, I forgot to add the syntax to `Pbindef` and `PbindProxy`. The change is trivial: `pairs = pairs ++ kwargs`. I've adjusted the whole file to use pipes as argument syntax.

The only functional change is here: https://github.com/supercollider/supercollider/pull/6977/commits/0a522a34cf401611875a05bc270ae6776b2a9d01

## Types of changes

- Documentation
- New feature


## To-do list

- [x] Code is tested
- [ ] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

- Release Notes: I'll edit the relesae note file accordingly.

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
