### PR TITLE
Remove some use of SCWindow and SCButton from the documentation code.

### DIFF
--- a/HelpSource/Classes/Document.schelp
+++ b/HelpSource/Classes/Document.schelp
@@ -580,14 +580,12 @@ loop {
 };
 
 Document.new("type some text")
-	.bounds_(Rect(100, SCWindow.screenBounds.height - 250, 400, 200))
 	.keyDownAction = { |doc, key| r.value(key) ; time = Main.elapsedTime };
 )
 
 // play back text in time
 (
-d = Document.new("type some text")
-	.bounds_(Rect(550, SCWindow.screenBounds.height-250, 400, 200));
+d = Document.new("type some text");
 fork({
 	a.do { |pair|
 		d.string = d.string ++ pair[0];

--- a/HelpSource/Classes/Platform.schelp
+++ b/HelpSource/Classes/Platform.schelp
@@ -96,7 +96,7 @@ subsection:: Features
 method:: when
 Evaluate ifFunction if all features are present, otherwise evaluate elseFunction.
 code::
-Platform.when(#[\Document, \SCWindow], { "yeehah!".postln });
+Platform.when(#[\Document, \Window], { "yeehah!".postln });
 ::
 
 instancemethods::
@@ -211,7 +211,7 @@ method:: hasFeature
 Return true if the feature aSymbol is present in the runtime system. aSymbol can refer to explicitly declared features as well as class and primitive names.
 code::
 thisProcess.platform.hasFeature(\Object);
-thisProcess.platform.hasFeature('_SCWindow_BeginFullScreen');
+thisProcess.platform.hasFeature('_Window_BeginFullScreen');
 thisProcess.platform.hasFeature('_myFuncyPrimitive');
 
 thisProcess.platform.declareFeature('superCrazyCompositionSystem');
@@ -221,5 +221,5 @@ thisProcess.platform.hasFeature('superCrazyCompositionSystem');
 method:: when
 Evaluate ifFunction if all features are present, otherwise evaluate elseFunction.
 code::
-thisProcess.platform.when(#[\Document, \SCWindow], { "yeehah!".postln });
+thisProcess.platform.when(#[\Document, \Window], { "yeehah!".postln });
 ::

--- a/HelpSource/Classes/Routine.schelp
+++ b/HelpSource/Classes/Routine.schelp
@@ -492,7 +492,7 @@ code::
 // Using Routine to set button states on the fly.
 (
 var update, w, b;
-w = SCWindow.new("State Window", Rect(150, SCWindow.screenBounds.height-140, 380, 60));
+w = Window.new("State Window", Rect(150, Window.screenBounds.height-140, 380, 60));
 
 // a convenient way to set the button label
 update = {
@@ -500,7 +500,7 @@ update = {
 	but.refresh;
 };
 
-b = SCButton(w, Rect(10, 10, 360, 40));
+b = Button(w, Rect(10, 10, 360, 40));
 b.font_(Font("Impact", 24));
 
 update.value(b, "there is only one state");

--- a/HelpSource/Guides/Internal-Snooping.schelp
+++ b/HelpSource/Guides/Internal-Snooping.schelp
@@ -159,7 +159,7 @@ code::
 }
 )
 
-Window.allWindows.dump;	// dump a list of all open SCWindows
+Window.allWindows.dump;	// dump a list of all open Windows
 
 // a little more helpful, dump their names
 Window.allWindows.collect { | w | w.name }.postln;


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation
I found some `SCWindow` and `SCButton` in the documentation code, and removed them.
I did not modify the schelp files of the deprecated classes.

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->

- Documentation

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
