### PR TITLE
UDP: set max buffer size to 4MB and fallback to 1MB

### DIFF
--- a/lang/LangPrimSource/SC_ComPort.cpp
+++ b/lang/LangPrimSource/SC_ComPort.cpp
@@ -210,7 +210,12 @@ UDP::UDP(int inPortNum, HandlerType handlerType, int portsToCheck): mPortNum(inP
         mUdpSocket.get_option(sendBufferSize);
         if (sendBufferSize.value() < UDP::sendBufferSize) {
             sendBufferSize = UDP::sendBufferSize;
-            mUdpSocket.set_option(sendBufferSize);
+            boost::system::error_code ec;
+            mUdpSocket.set_option(sendBufferSize, ec);
+            if (ec) {
+                sendBufferSize = 1024 * 1024;
+                mUdpSocket.set_option(sendBufferSize);
+            }
         }
     } catch (boost::system::system_error& e) {
         printf("(sclang) SC_UdpInPort: WARNING: failed to set send buffer size\n");
@@ -221,7 +226,12 @@ UDP::UDP(int inPortNum, HandlerType handlerType, int portsToCheck): mPortNum(inP
         mUdpSocket.get_option(receiveBufferSize);
         if (receiveBufferSize.value() < UDP::receiveBufferSize) {
             receiveBufferSize = UDP::receiveBufferSize;
-            mUdpSocket.set_option(receiveBufferSize);
+            boost::system::error_code ec;
+            mUdpSocket.set_option(receiveBufferSize, ec);
+            if (ec) {
+                receiveBufferSize = 1024 * 1024;
+                mUdpSocket.set_option(receiveBufferSize);
+            }
         }
     } catch (boost::system::system_error& e) {
         printf("(sclang) SC_UdpInPort: WARNING: failed to set receive buffer size\n");

--- a/lang/LangPrimSource/SC_ComPort.cpp
+++ b/lang/LangPrimSource/SC_ComPort.cpp
@@ -208,12 +208,13 @@ UDP::UDP(int inPortNum, HandlerType handlerType, int portsToCheck): mPortNum(inP
     try {
         boost::asio::socket_base::send_buffer_size sendBufferSize;
         mUdpSocket.get_option(sendBufferSize);
-        if (sendBufferSize.value() < UDP::sendBufferSize) {
+        int originalBufferSize = sendBufferSize.value();
+        if (originalBufferSize < UDP::sendBufferSize) {
             sendBufferSize = UDP::sendBufferSize;
             boost::system::error_code ec;
             mUdpSocket.set_option(sendBufferSize, ec);
-            if (ec) {
-                sendBufferSize = 1024 * 1024;
+            if (ec && originalBufferSize < UDP::fallbackBufferSize) {
+                sendBufferSize = UDP::fallbackBufferSize;
                 mUdpSocket.set_option(sendBufferSize);
             }
         }
@@ -224,12 +225,13 @@ UDP::UDP(int inPortNum, HandlerType handlerType, int portsToCheck): mPortNum(inP
     try {
         boost::asio::socket_base::receive_buffer_size receiveBufferSize;
         mUdpSocket.get_option(receiveBufferSize);
-        if (receiveBufferSize.value() < UDP::receiveBufferSize) {
+        int originalBufferSize = receiveBufferSize.value();
+        if (originalBufferSize < UDP::receiveBufferSize) {
             receiveBufferSize = UDP::receiveBufferSize;
             boost::system::error_code ec;
             mUdpSocket.set_option(receiveBufferSize, ec);
-            if (ec) {
-                receiveBufferSize = 1024 * 1024;
+            if (ec && originalBufferSize < UDP::fallbackBufferSize) {
+                receiveBufferSize = UDP::fallbackBufferSize;
                 mUdpSocket.set_option(receiveBufferSize);
             }
         }

--- a/lang/LangPrimSource/SC_ComPort.cpp
+++ b/lang/LangPrimSource/SC_ComPort.cpp
@@ -219,7 +219,7 @@ UDP::UDP(int inPortNum, HandlerType handlerType, int portsToCheck): mPortNum(inP
             }
         }
     } catch (boost::system::system_error& e) {
-        printf("(sclang) SC_UdpInPort: WARNING: failed to set send buffer size\n");
+        printf("(sclang) SC_UdpInPort: WARNING: failed to set send buffer size (%s)\n", e.what());
     }
 
     try {
@@ -236,7 +236,7 @@ UDP::UDP(int inPortNum, HandlerType handlerType, int portsToCheck): mPortNum(inP
             }
         }
     } catch (boost::system::system_error& e) {
-        printf("(sclang) SC_UdpInPort: WARNING: failed to set receive buffer size\n");
+        printf("(sclang) SC_UdpInPort: WARNING: failed to set receive buffer size (%s)\n", e.what());
     }
 
     initHandler(handlerType);

--- a/lang/LangPrimSource/SC_ComPort.h
+++ b/lang/LangPrimSource/SC_ComPort.h
@@ -82,8 +82,8 @@ private:
 
     int mPortNum;
     HandleDataFunc mHandleFunc;
-    static constexpr int receiveBufferSize = 8 * 1024 * 1024;
-    static constexpr int sendBufferSize = 8 * 1024 * 1024;
+    static constexpr int receiveBufferSize = 4 * 1024 * 1024;
+    static constexpr int sendBufferSize = 4 * 1024 * 1024;
     std::array<char, kTextBufSize> mRecvBuffer;
     boost::asio::ip::udp::endpoint mRemoteEndpoint;
     boost::asio::ip::udp::socket mUdpSocket;

--- a/lang/LangPrimSource/SC_ComPort.h
+++ b/lang/LangPrimSource/SC_ComPort.h
@@ -84,6 +84,7 @@ private:
     HandleDataFunc mHandleFunc;
     static constexpr int receiveBufferSize = 4 * 1024 * 1024;
     static constexpr int sendBufferSize = 4 * 1024 * 1024;
+    static constexpr int fallbackBufferSize = 1 * 1024 * 1024;
     std::array<char, kTextBufSize> mRecvBuffer;
     boost::asio::ip::udp::endpoint mRemoteEndpoint;
     boost::asio::ip::udp::socket mUdpSocket;

--- a/server/scsynth/SC_ComPort.cpp
+++ b/server/scsynth/SC_ComPort.cpp
@@ -245,8 +245,8 @@ class SC_UdpInPort {
                                                  asio::placeholders::bytes_transferred));
     }
 
-    static constexpr int receiveBufferSize = 8 * 1024 * 1024;
-    static constexpr int sendBufferSize = 8 * 1024 * 1024;
+    static constexpr int receiveBufferSize = 4 * 1024 * 1024;
+    static constexpr int sendBufferSize = 4 * 1024 * 1024;
 
 public:
     boost::asio::ip::udp::socket udpSocket;
@@ -269,7 +269,12 @@ public:
             udpSocket.get_option(sendBufferSize);
             if (sendBufferSize.value() < SC_UdpInPort::sendBufferSize) {
                 sendBufferSize = SC_UdpInPort::sendBufferSize;
-                udpSocket.set_option(sendBufferSize);
+                boost::system::error_code ec;
+                udpSocket.set_option(sendBufferSize, ec);
+                if (ec) {
+                    sendBufferSize = 1024 * 1024;
+                    udpSocket.set_option(sendBufferSize);
+                }
             }
         } catch (boost::system::system_error& e) { printf("WARNING: failed to set send buffer size\n"); }
 
@@ -278,7 +283,12 @@ public:
             udpSocket.get_option(receiveBufferSize);
             if (receiveBufferSize.value() < SC_UdpInPort::receiveBufferSize) {
                 receiveBufferSize = SC_UdpInPort::receiveBufferSize;
-                udpSocket.set_option(receiveBufferSize);
+                boost::system::error_code ec;
+                udpSocket.set_option(receiveBufferSize, ec);
+                if (ec) {
+                    receiveBufferSize = 1024 * 1024;
+                    udpSocket.set_option(receiveBufferSize);
+                }
             }
         } catch (boost::system::system_error& e) { printf("WARNING: failed to set receive buffer size\n"); }
 

--- a/server/scsynth/SC_ComPort.cpp
+++ b/server/scsynth/SC_ComPort.cpp
@@ -278,7 +278,7 @@ public:
                     udpSocket.set_option(sendBufferSize);
                 }
             }
-        } catch (boost::system::system_error& e) { printf("WARNING: failed to set send buffer size\n"); }
+        } catch (boost::system::system_error& e) { printf("WARNING: failed to set send buffer size (%s)\n", e.what()); }
 
         try {
             boost::asio::socket_base::receive_buffer_size receiveBufferSize;
@@ -293,7 +293,9 @@ public:
                     udpSocket.set_option(receiveBufferSize);
                 }
             }
-        } catch (boost::system::system_error& e) { printf("WARNING: failed to set receive buffer size\n"); }
+        } catch (boost::system::system_error& e) {
+            printf("WARNING: failed to set receive buffer size (%s)\n", e.what());
+        }
 
 #ifdef USE_RENDEZVOUS
         if (world->mRendezvous) {

--- a/server/scsynth/SC_ComPort.cpp
+++ b/server/scsynth/SC_ComPort.cpp
@@ -247,6 +247,7 @@ class SC_UdpInPort {
 
     static constexpr int receiveBufferSize = 4 * 1024 * 1024;
     static constexpr int sendBufferSize = 4 * 1024 * 1024;
+    static constexpr int fallbackBufferSize = 1 * 1024 * 1024;
 
 public:
     boost::asio::ip::udp::socket udpSocket;
@@ -267,12 +268,13 @@ public:
         try {
             boost::asio::socket_base::send_buffer_size sendBufferSize;
             udpSocket.get_option(sendBufferSize);
-            if (sendBufferSize.value() < SC_UdpInPort::sendBufferSize) {
+            int defaultBufferSize = sendBufferSize.value();
+            if (defaultBufferSize < SC_UdpInPort::sendBufferSize) {
                 sendBufferSize = SC_UdpInPort::sendBufferSize;
                 boost::system::error_code ec;
                 udpSocket.set_option(sendBufferSize, ec);
-                if (ec) {
-                    sendBufferSize = 1024 * 1024;
+                if (ec && defaultBufferSize < SC_UdpInPort::fallbackBufferSize) {
+                    sendBufferSize = SC_UdpInPort::fallbackBufferSize;
                     udpSocket.set_option(sendBufferSize);
                 }
             }
@@ -281,12 +283,13 @@ public:
         try {
             boost::asio::socket_base::receive_buffer_size receiveBufferSize;
             udpSocket.get_option(receiveBufferSize);
-            if (receiveBufferSize.value() < SC_UdpInPort::receiveBufferSize) {
+            int defaultBufferSize = receiveBufferSize.value();
+            if (defaultBufferSize < SC_UdpInPort::receiveBufferSize) {
                 receiveBufferSize = SC_UdpInPort::receiveBufferSize;
                 boost::system::error_code ec;
                 udpSocket.set_option(receiveBufferSize, ec);
-                if (ec) {
-                    receiveBufferSize = 1024 * 1024;
+                if (ec && defaultBufferSize < SC_UdpInPort::fallbackBufferSize) {
+                    receiveBufferSize = SC_UdpInPort::fallbackBufferSize;
                     udpSocket.set_option(receiveBufferSize);
                 }
             }

--- a/server/supernova/sc/sc_osc_handler.cpp
+++ b/server/supernova/sc/sc_osc_handler.cpp
@@ -624,7 +624,9 @@ void sc_osc_handler::open_udp_socket(ip::address address, unsigned int port) {
                 udp_socket.set_option(send_buffer_size);
             }
         }
-    } catch (boost::system::system_error& e) { std::cout << "WARNING: failed to set send buffer size\n"; }
+    } catch (boost::system::system_error& e) {
+        std::cout << "WARNING: failed to set send buffer size" << " (" << e.what() << ")\n";
+    }
 
     try {
         boost::asio::socket_base::receive_buffer_size receieve_buffer_size;
@@ -639,7 +641,9 @@ void sc_osc_handler::open_udp_socket(ip::address address, unsigned int port) {
                 udp_socket.set_option(receieve_buffer_size);
             }
         }
-    } catch (boost::system::system_error& e) { std::cout << "WARNING: failed to set receive buffer size\n"; }
+    } catch (boost::system::system_error& e) {
+        std::cout << "WARNING: failed to set receieve buffer size" << " (" << e.what() << ")\n";
+    }
 
     sc_notify_observers::udp_socket.bind(udp::endpoint(address, port));
 }

--- a/server/supernova/sc/sc_osc_handler.cpp
+++ b/server/supernova/sc/sc_osc_handler.cpp
@@ -614,12 +614,13 @@ void sc_osc_handler::open_udp_socket(ip::address address, unsigned int port) {
     try {
         boost::asio::socket_base::send_buffer_size send_buffer_size;
         udp_socket.get_option(send_buffer_size);
-        if (send_buffer_size.value() < sc_osc_handler::udp_send_buffer_size) {
+        int default_buffer_size = send_buffer_size.value();
+        if (default_buffer_size < sc_osc_handler::udp_send_buffer_size) {
             send_buffer_size = sc_osc_handler::udp_send_buffer_size;
             boost::system::error_code ec;
             udp_socket.set_option(send_buffer_size, ec);
-            if (ec) {
-                send_buffer_size = 1024 * 1024;
+            if (ec && default_buffer_size < sc_osc_handler::udp_fallback_buffer_size) {
+                send_buffer_size = sc_osc_handler::udp_fallback_buffer_size;
                 udp_socket.set_option(send_buffer_size);
             }
         }
@@ -628,12 +629,13 @@ void sc_osc_handler::open_udp_socket(ip::address address, unsigned int port) {
     try {
         boost::asio::socket_base::receive_buffer_size receieve_buffer_size;
         udp_socket.get_option(receieve_buffer_size);
-        if (receieve_buffer_size.value() < sc_osc_handler::udp_receive_buffer_size) {
+        int default_buffer_size = receieve_buffer_size.value();
+        if (default_buffer_size < sc_osc_handler::udp_receive_buffer_size) {
             receieve_buffer_size = sc_osc_handler::udp_receive_buffer_size;
             boost::system::error_code ec;
             udp_socket.set_option(receieve_buffer_size, ec);
-            if (ec) {
-                receieve_buffer_size = 1024 * 1024;
+            if (ec && default_buffer_size < sc_osc_handler::udp_fallback_buffer_size) {
+                receieve_buffer_size = sc_osc_handler::udp_fallback_buffer_size;
                 udp_socket.set_option(receieve_buffer_size);
             }
         }

--- a/server/supernova/sc/sc_osc_handler.cpp
+++ b/server/supernova/sc/sc_osc_handler.cpp
@@ -616,16 +616,26 @@ void sc_osc_handler::open_udp_socket(ip::address address, unsigned int port) {
         udp_socket.get_option(send_buffer_size);
         if (send_buffer_size.value() < sc_osc_handler::udp_send_buffer_size) {
             send_buffer_size = sc_osc_handler::udp_send_buffer_size;
-            udp_socket.set_option(send_buffer_size);
+            boost::system::error_code ec;
+            udp_socket.set_option(send_buffer_size, ec);
+            if (ec) {
+                send_buffer_size = 1024 * 1024;
+                udp_socket.set_option(send_buffer_size);
+            }
         }
     } catch (boost::system::system_error& e) { std::cout << "WARNING: failed to set send buffer size\n"; }
 
     try {
-        boost::asio::socket_base::receive_buffer_size recv_buffer_size;
-        udp_socket.get_option(recv_buffer_size);
-        if (recv_buffer_size.value() < sc_osc_handler::udp_receive_buffer_size) {
-            recv_buffer_size = sc_osc_handler::udp_receive_buffer_size;
-            udp_socket.set_option(recv_buffer_size);
+        boost::asio::socket_base::receive_buffer_size receieve_buffer_size;
+        udp_socket.get_option(receieve_buffer_size);
+        if (receieve_buffer_size.value() < sc_osc_handler::udp_receive_buffer_size) {
+            receieve_buffer_size = sc_osc_handler::udp_receive_buffer_size;
+            boost::system::error_code ec;
+            udp_socket.set_option(receieve_buffer_size, ec);
+            if (ec) {
+                receieve_buffer_size = 1024 * 1024;
+                udp_socket.set_option(receieve_buffer_size);
+            }
         }
     } catch (boost::system::system_error& e) { std::cout << "WARNING: failed to set receive buffer size\n"; }
 

--- a/server/supernova/sc/sc_osc_handler.cpp
+++ b/server/supernova/sc/sc_osc_handler.cpp
@@ -625,7 +625,8 @@ void sc_osc_handler::open_udp_socket(ip::address address, unsigned int port) {
             }
         }
     } catch (boost::system::system_error& e) {
-        std::cout << "WARNING: failed to set send buffer size" << " (" << e.what() << ")\n";
+        std::cout << "WARNING: failed to set send buffer size"
+                  << " (" << e.what() << ")\n";
     }
 
     try {
@@ -642,7 +643,8 @@ void sc_osc_handler::open_udp_socket(ip::address address, unsigned int port) {
             }
         }
     } catch (boost::system::system_error& e) {
-        std::cout << "WARNING: failed to set receieve buffer size" << " (" << e.what() << ")\n";
+        std::cout << "WARNING: failed to set receieve buffer size"
+                  << " (" << e.what() << ")\n";
     }
 
     sc_notify_observers::udp_socket.bind(udp::endpoint(address, port));

--- a/server/supernova/sc/sc_osc_handler.hpp
+++ b/server/supernova/sc/sc_osc_handler.hpp
@@ -356,8 +356,8 @@ private:
 
     std::array<char, 1 << 15> recv_buffer_;
 
-    static constexpr int udp_receive_buffer_size = 8 * 1024 * 1024;
-    static constexpr int udp_send_buffer_size = 8 * 1024 * 1024;
+    static constexpr int udp_receive_buffer_size = 4 * 1024 * 1024;
+    static constexpr int udp_send_buffer_size = 4 * 1024 * 1024;
     /* @} */
 };
 

--- a/server/supernova/sc/sc_osc_handler.hpp
+++ b/server/supernova/sc/sc_osc_handler.hpp
@@ -358,6 +358,7 @@ private:
 
     static constexpr int udp_receive_buffer_size = 4 * 1024 * 1024;
     static constexpr int udp_send_buffer_size = 4 * 1024 * 1024;
+    static constexpr int udp_fallback_buffer_size = 1 * 1024 * 1024;
     /* @} */
 };
 


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation
Fix #6969. Set UDP buffer size to 4 MB and fallback to 1MB if we fail to do that. 

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [ ] Code is tested
- [ ] All tests are passing
- [ ] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
