### PR TITLE
servers [windows]: select WASAPI as default device if available

### DIFF
--- a/HelpSource/Reference/AudioDeviceSelection.schelp
+++ b/HelpSource/Reference/AudioDeviceSelection.schelp
@@ -122,7 +122,7 @@ code::
 
 section:: Windows
 
-By default the server will boot to your system's default audio devices using teletype::MME:: driver (which usually means higher latency).
+By default the server will boot to your system's default audio devices using a teletype::WASAPI:: driver.
 
 On Windows there are multiple audio driver APIs (e.g. teletype::MME::, teletype::WASAPI::, teletype::ASIO:: etc.) that can be used to communicate with audio devices. The API (listed before the device name) needs to match between the input and the output, for example:
 code::

--- a/common/SC_PaUtils.hpp
+++ b/common/SC_PaUtils.hpp
@@ -12,6 +12,9 @@ std::string GetPaDeviceName(const PaDeviceInfo* pdi);
 // get PaDeviceIndex from device name
 PaDeviceIndex GetPaDeviceFromName(const char* device, bool isInput);
 
+// get default input/output device index; on Windows it will try to use WASAPI default devices
+PaDeviceIndex GetPaDefaultDevice(bool isInput);
+
 // select default PA devices if they are not defined
 // it will also try to check for some configuration problems
 // numIns, numOuts and sampleRate are only the requested values, may change later


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

Use WASAPI for the default device selection on Windows.

We seem to need this before we can disable old APIs, see https://github.com/supercollider/supercollider/pull/6900#issuecomment-2914914392

## Types of changes

<!-- Delete lines that don't apply -->

- New feature (?)

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
