### PR TITLE
Let's consider macOS universal build... again

### DIFF
--- a/.github/workflows/build_macos.yml
+++ b/.github/workflows/build_macos.yml
@@ -13,32 +13,21 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - job-name: "arm64  with ctest"
+          - job-name: "universal arm64 x64 with ctest"
             os-version: "15"
             xcode-version: "16.0"
             qt-version: "6.7.3" # will use qt from aqtinstall
             qt-modules: 'qtwebengine qtwebchannel qtwebsockets qtpositioning'
             deployment-target: "11"
-            cmake-architectures: "arm64"
-            homebrew-packages: "libsndfile readline fftw portaudio"
-            vcpkg-packages: ""
-            vcpkg-triplet: ""
-            extra-cmake-flags: "" # -D SC_VERIFY_APP=ON # verify app doesn't seem to work with official qt6
-            artifact-suffix: "macOS-arm64"
-            ctest: true
-
-          - job-name: "x64 with ctest"
-            os-version: "13"
-            xcode-version: "15.2"
-            qt-version: "6.7.3" # will use qt from aqtinstall
-            qt-modules: 'qtwebengine qtwebchannel qtwebsockets qtpositioning'
-            deployment-target: "11"
-            cmake-architectures: "x86_64"
-            homebrew-packages: "libsndfile readline fftw portaudio"
-            vcpkg-packages: ""
-            vcpkg-triplet: ""
-            extra-cmake-flags: "" # -D SC_VERIFY_APP=ON # verify app doesn't seem to work with official qt6
-            artifact-suffix: "macOS-x64"
+            cmake-architectures: "x86_64;arm64"
+            homebrew-packages: ""
+            homebrew-uninstall: "readline"
+            vcpkg-packages: "readline libsndfile fftw3"
+            vcpkg-triplet: "arm64-osx-release-supercollider"
+            vcpkg-triplet-other: "x64-osx-release-supercollider"
+            vcpkg-triplet-universal: "universal" # we are not actually installing using this triplet, the packages will be manually copied there
+            extra-cmake-flags: "-D SYSTEM_PORTAUDIO=OFF" # -D SC_VERIFY_APP=ON # verify app doesn't seem to work with official qt6
+            artifact-suffix: "macOS-universal"
             ctest: true
 
           - job-name: "x64 legacy"
@@ -165,6 +154,19 @@ jobs:
           if [[ -n "${{ matrix.homebrew-uninstall }}" ]]; then brew uninstall --ignore-dependencies ${{ matrix.homebrew-uninstall }}; fi
           vcpkg install ${{ matrix.vcpkg-packages }} --triplet="${{ matrix.vcpkg-triplet }}" --overlay-triplets="$GITHUB_WORKSPACE/vcpkg/triplets"
 
+      - name: install combined architecture vcpkg packages
+        if: matrix.vcpkg-packages && matrix.vcpkg-triplet && matrix.vcpkg-triplet-other && matrix.vcpkg-triplet-universal
+        run: |
+          echo -e "\nInstalling additional vcpkg packages for triplet: ${{ matrix.vcpkg-triplet-other }}"
+          vcpkg install ${{ matrix.vcpkg-packages }} --triplet="${{ matrix.vcpkg-triplet-other }}" --overlay-triplets="$GITHUB_WORKSPACE/vcpkg/triplets"
+
+          echo "Creating universal libraries"
+          export VCPKG_ROOT=$VCPKG_INSTALLATION_ROOT
+          export ARCH1="${{ matrix.vcpkg-triplet }}"
+          export ARCH2="${{ matrix.vcpkg-triplet-other }}"
+          export ARCH_UNIVERSAL="${{ matrix.vcpkg-triplet-universal }}" 
+          ${{ github.workspace }}/tools/vcpkg_combine_libs.sh
+
       - name: install qt using aqtinstall
         uses: jurplel/install-qt-action@v4
         if: matrix.qt-version
@@ -182,7 +184,10 @@ jobs:
 
           CMAKE_FLAGS="-G Xcode -D SUPERNOVA=ON  ${{ matrix.extra-cmake-flags }}"
 
-          if [[ -n "${{ matrix.vcpkg-triplet }}" ]]; then
+          if [[ -n "${{ matrix.vcpkg-triplet-universal }}" ]]; then
+            export VCPKG_ROOT=$VCPKG_INSTALLATION_ROOT
+            CMAKE_FLAGS="-DVCPKG_TARGET_TRIPLET=${{ matrix.vcpkg-triplet-universal }} -DCMAKE_BUILD_TYPE=Release $CMAKE_FLAGS"
+          elif [[ -n "${{ matrix.vcpkg-triplet }}" ]]; then
             export VCPKG_ROOT=$VCPKG_INSTALLATION_ROOT
             CMAKE_FLAGS="-DVCPKG_TARGET_TRIPLET=${{ matrix.vcpkg-triplet }} -DCMAKE_BUILD_TYPE=Release $CMAKE_FLAGS"
           fi

--- a/.github/workflows/test_macos.yml
+++ b/.github/workflows/test_macos.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: macos-15
     env:
       INSTALL_PATH: ${{ github.workspace }}/build/Install
-      ARTIFACT_FILE: "SuperCollider-${{ inputs.sc-version }}-macOS-arm64.dmg"
+      ARTIFACT_FILE: "SuperCollider-${{ inputs.sc-version }}-macOS-universal.dmg"
       TESTS_PATH: ${{ github.workspace }}/testsuite/classlibrary
       SCLANG: ${{ github.workspace }}/build/Install/SuperCollider/SuperCollider.app/Contents/MacOS/sclang
       TEST_LIST_PROTO: ${{ github.workspace }}/testsuite/scripts/test_run_proto_gha.scd

--- a/tools/vcpkg_combine_libs.sh
+++ b/tools/vcpkg_combine_libs.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# This script merges two vcpkg triplets into a universal triplet for macOS
+# It combines static and shared libraries, headers, and other resources
+# note: it will attempt to combine all packages found in the first triplet
+
+# environment variables:
+# VCPKG_ROOT: root directory of vcpkg installation
+# ARCH1: first triplet (e.g. x64-osx-release)
+# ARCH2: second triplet (e.g. arm64-osx-release)
+# ARCH_UNIVERSAL: output universal triplet (e.g. x64-arm64-osx-release)
+
+# Ensure required environment variables are set
+: "${VCPKG_ROOT:?VCPKG_ROOT must be set to the vcpkg installation root directory}"
+: "${ARCH1:?ARCH1 must be set to the first triplet (e.g. x64-osx-release)}"
+: "${ARCH2:?ARCH2 must be set to the second triplet (e.g. arm64-osx-release)}"
+: "${ARCH_UNIVERSAL:?ARCH_UNIVERSAL must be set to the output universal triplet (e.g. x64-arm64-osx-release)}"
+
+INSTALL_DIR="${VCPKG_ROOT}/installed"
+OUT_DIR="${INSTALL_DIR}/${ARCH_UNIVERSAL}"
+mkdir -p "$OUT_DIR"
+
+echo -e "\nMerging packages from ${INSTALL_DIR}/${ARCH1} and ${INSTALL_DIR}/${ARCH2} into ${OUT_DIR}"
+
+for pkg in $(ls "${INSTALL_DIR}/${ARCH1}/share"); do
+  echo "Merging package: $pkg"
+  pkg_lower=$(echo "$pkg" | tr '[:upper:]' '[:lower:]')
+
+  PKG1="${INSTALL_DIR}/${ARCH1}"
+  PKG2="${INSTALL_DIR}/${ARCH2}"
+  PKG_UNI="${OUT_DIR}"
+
+  # Merge static libraries
+  for libtype in lib debug/lib; do
+    if [[ -d "${PKG1}/${libtype}" && -d "${PKG2}/${libtype}" ]]; then
+      mkdir -p "${PKG_UNI}/${libtype}"
+      for lib1 in "${PKG1}/${libtype}/lib${pkg_lower}"*.a; do
+        [[ -f "$lib1" ]] || continue
+        libname=$(basename "$lib1")
+        lib2="${PKG2}/${libtype}/${libname}"
+        if [[ -f "$lib2" ]]; then
+          echo "  - [static] $libname"
+          lipo -create "$lib1" "$lib2" -output "${PKG_UNI}/${libtype}/$libname"
+        fi
+      done
+    fi
+  done
+
+  # Merge shared libraries
+  for libtype in lib debug/lib; do
+    if [[ -d "${PKG1}/${libtype}" && -d "${PKG2}/${libtype}" ]]; then
+      mkdir -p "${PKG_UNI}/${libtype}"
+      for dylib1 in "${PKG1}/${libtype}/lib${pkg_lower}"*.dylib; do
+        [[ -f "$dylib1" ]] || continue
+        libname=$(basename "$dylib1")
+        dylib2="${PKG2}/${libtype}/${libname}"
+        if [[ -f "$dylib2" ]]; then
+          echo "  - [shared] $libname"
+          lipo -create "$dylib1" "$dylib2" -output "${PKG_UNI}/${libtype}/$libname"
+          install_name_tool -id "@rpath/$libname" "${PKG_UNI}/${libtype}/$libname"
+        fi
+      done
+    fi
+  done
+
+  # Copy headers
+  if [[ -d "${PKG1}/include" ]]; then
+      echo "  - Copying headers"
+      cp -a "${PKG1}/include" "${PKG_UNI}/"
+  fi
+
+  # Copy share/ usage & config files
+  if [[ -d "${PKG1}/share/${pkg_lower}" ]]; then
+      echo "  - Copying share/${pkg_lower}"
+      mkdir -p "${PKG_UNI}/share"
+      cp -a "${PKG1}/share/${pkg_lower}" "${PKG_UNI}/share/"
+  fi
+
+  # Copy tools if needed
+  if [[ -d "${PKG1}/tools/${pkg_lower}" ]]; then
+      echo "  - Copying tools/${pkg_lower}"
+      mkdir -p "${PKG_UNI}/tools"
+      cp -a "${PKG1}/tools/${pkg_lower}" "${PKG_UNI}/tools/"
+  fi
+done
+
+echo "Finished merging into: ${OUT_DIR}"


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

The official Qt6 binaries that we use for the releases are compiled for both arm64 and x64 architectures. The only thing that prevented us from building a universal binary of SC on macOS was the unavailaility of dual-architecture dependencies: fftw, libsndfile, and readline.

I was previously experimenting with adding a universal "triplet" for vcpkg, but that doesn't work with some of the libraries which use autotools. 

Another option is to build packages for both architectures and then combine them manually. This is what this PR does... This is not the most elegant solution, but it seems to work. The script is embedded directly in the vcpkg install step, which makes the workflow file a bit bigger. Luckily, the script is not nearly as extensive as what we [used to use for making universal binaries of homebrew libs](https://gist.github.com/dyfer/6c83905d4593750105897e51e87ec345).

As a bonus, we have one less macOS job running concurrently, and when cache is available, it takes a similar amount of time as the other macOS builds. 

The practical changes are: 
- fftw, libsndfile, and readline are now installed with vcpkg
- their dependencies are embedded (they are built as static libs), that's why we don't have e.g. libogg in the bundle as a separate lib
- portaudio is built from our source tree (so that there's one less package to keep track of, but this could come from vcpkg as well if we'd like)
- [FindReadline.cmake](https://github.com/supercollider/supercollider/blob/48ff7d923d7503c86da1b201776096ec2640e99f/cmake_modules/FindReadline.cmake) script is updated to not blindly use brew prefix command, but to check where the header/library files are located (this was needed to enable finding readline in vcpkg on macOS)

## Types of changes

<!-- Delete lines that don't apply -->

- New feature

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [ ] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
