### PR TITLE
classlib: DoesNotUnderstandError: refactor suggestions

### DIFF
--- a/HelpSource/Classes/Class.schelp
+++ b/HelpSource/Classes/Class.schelp
@@ -72,6 +72,40 @@ method::findRespondingMethodFor
 
 As above, but climb the class tree to see if the method is inherited from a superclass. If not found, return nil.
 
+method::respondingMethods
+
+Return a list of methods for the selectors that an object of this class responds to.
+
+method::instancesRespondTo
+
+Return true if the message selector or array of message selectors are understood by objects of this class.
+
+code::
+Collection.instancesRespondTo(\flop); // false
+Set.instancesRespondTo(\clear); // true
+Set.instancesRespondTo([\flop, \clear]) // false: not both
+::
+
+method::findRespondingSubclasses
+
+Return a list of all subclasses whose instances respond to the message selector or all message selector in an array.
+
+code::
+Collection.findRespondingSubclasses(\flop); // a long list
+Set.findRespondingSubclasses(\clear);
+Set.findRespondingSubclasses([\flop, \clear]); // not both
+::
+
+method::findRespondingUpperSubclasses
+
+Return a list of all classes down the class tree starting from the receiver, whose instances respond to the message selector or all message selector in an array.
+
+code::
+Collection.findRespondingUpperSubclasses(\flop);
+Set.findRespondingUpperSubclasses(\clear);
+Set.findRespondingUpperSubclasses([\flop, \clear]); // not both
+::
+
 method::dumpAllMethods
 
 Post all instance methods which instances of this class responds too, including inherited ones. code::this.class.dumpAllMethods:: will post all class methods which this class responds to.
@@ -91,6 +125,7 @@ Post all the methods defined by this Class and their arguments.
 method::dumpFullInterface
 
 Post all the class and instance methods that this class responds to (i.e. those defined in this class and those inherited by it).
+
 
 method::help
 

--- a/HelpSource/Classes/Class.schelp
+++ b/HelpSource/Classes/Class.schelp
@@ -106,6 +106,16 @@ Set.findRespondingUpperSubclasses(\clear);
 Set.findRespondingUpperSubclasses([\flop, \clear]); // not both
 ::
 
+method::findSimilarSelectors
+
+Returns a list of selectors similar to the argument passed. For other arguments and sorting, see link::Classes/String#-findSimilarIn::.
+
+code::
+Array.findSimilarSelectors(\skramle);
+Array.findSimilarSelectors(\flip);
+Array.findSimilarSelectors(\flip, maxEditDistance: 7);
+::
+
 method::dumpAllMethods
 
 Post all instance methods which instances of this class responds too, including inherited ones. code::this.class.dumpAllMethods:: will post all class methods which this class responds to.

--- a/HelpSource/Classes/Class.schelp
+++ b/HelpSource/Classes/Class.schelp
@@ -64,17 +64,36 @@ method::browse
 
 Open a graphical browser for this Class. Shows methods, arguments, variables, subclasses, and has buttons for navigating to the superclass, source, helpfile, etc.
 
+code::
+Dictionary.browse;
+::
+
 method::findMethod
 
 Find the Method referred to by name. If not found, return nil.
+
+code::
+Integer.findMethod('>'); // nil
+Integer.findMethod('*'); // Integer:*
+::
+
 
 method::findRespondingMethodFor
 
 As above, but climb the class tree to see if the method is inherited from a superclass. If not found, return nil.
 
+code::
+Integer.findRespondingMethodFor('>'); // SimpleNumber:>
+Integer.findRespondingMethodFor('+'); // Integer:*
+::
+
 method::respondingMethods
 
 Return a list of methods for the selectors that an object of this class responds to.
+
+code::
+Integer.respondingMethods.do { |item| item.postln };
+::
 
 method::instancesRespondTo
 
@@ -120,30 +139,59 @@ method::dumpAllMethods
 
 Post all instance methods which instances of this class responds too, including inherited ones. code::this.class.dumpAllMethods:: will post all class methods which this class responds to.
 
+code::
+Integer.dumpAllMethods
+::
+
 method::dumpByteCodes
 
 Dump the byte codes of the named method.
+
+code::
+Integer.findMethod(\do).dumpByteCodes
+::
 
 method::dumpClassSubtree
 
 Post the tree of all Classes that inherit from this class.
 
+code::
+Collection.dumpClassSubtree
+::
+
 method::dumpInterface
 
-Post all the methods defined by this Class and their arguments.
+Post all the methods defined in this Class and their arguments.
+
+code::
+Array.dumpInterface
+Array.class.dumpInterface
+::
 
 method::dumpFullInterface
 
-Post all the class and instance methods that this class responds to (i.e. those defined in this class and those inherited by it).
+Post all the class and instance methods that this class responds to.
+
+code::
+Array.dumpFullInterface
+::
 
 
 method::help
 
-Opens the help file for this Class if it exists.
+Opens the help file for this Class if it exists. It may take a little while until the help window responds.
+
+code::
+Array.help
+::
 
 method::helpFilePath
 
 Returns the path of this Class's helpfile as a String.
+
+code::
+Array.helpFilePath
+::
 
 method::helpFileForMethod
 
@@ -172,25 +220,58 @@ method::nextclass
 
 The next class in a linked list of all classes.
 
+code::
+Set.nextclass
+::
+
 method::superclass
 
 The Class from which this class directly inherits.
+
+code::
+Set.superclass // Collection
+::
 
 method::superclasses
 
 An Array of this class's superclasses, going back to Object.
 
+code::
+Set.superclasses // [class Collection, class Object]
+::
+
 method::subclasses
 
 An Array of the direct subclasses of this.
+
+code::
+Set.subclasses // [class Dictionary, class IdentitySet]
+::
 
 method::allSubclasses
 
 An Array of all subclasses of this.
 
+code::
+Set.allSubclasses
+::
+
+method::superclassesDo
+
+Call a function passing each superclass of the receiver.
+
+code::
+List.superclassesDo { |x| x.postln };
+::
+
+
 method::methods
 
 An Array of the methods of this class.
+
+code::
+Set.methods.do { |item| item.name.postln }
+::
 
 method::instVarNames
 
@@ -211,3 +292,7 @@ An Array of the initial values of class variables.
 method::filenameSymbol
 
 A Symbol which is a path to the file which defines the Class.
+
+code::
+Set.filenameSymbol
+::

--- a/HelpSource/Classes/Object.schelp
+++ b/HelpSource/Classes/Object.schelp
@@ -98,11 +98,13 @@ code::
 
 method::respondsTo
 
-Answer a link::Classes/Boolean:: whether the receiver understands the message selector.
+Answer a link::Classes/Boolean:: whether the receiver understands the message selector or array of message selectors.
 
 code::
 5.respondsTo('+'); // true
 5.respondsTo('indexOf'); // false
+5.respondsTo(['+', '-']); // true
+5.respondsTo(['+', 'indexOf']); // false
 ::
 
 

--- a/HelpSource/Classes/String.schelp
+++ b/HelpSource/Classes/String.schelp
@@ -489,6 +489,33 @@ code::
 "These are several words which are fish".findAll("fish").postln;
 ::
 
+method::findSimilarIn
+
+From a list of strings, find similar strings, sorted by edit distance and limited by similarity.
+
+code::
+"hi".findSimilarIn(["ho", "hu?", "hugs", "Hola", "else"], 2); // [ho, hu?]
+"hi".findSimilarIn(["ho", "hu?", "hugs", "Hola", "else"], 3); // [ho, hu?, hugs, Hola]
+"hi".findSimilarIn(["ho", "Hi", "hugs", "Hola", "else"], 3, prioritizeCapitalization: false); // [ho, Hi, hugs]
+"hi".findSimilarIn(["ho", "Hi", "hugs", "Hola", "else"], 3, prioritizeCapitalization: true); // [Hi, ho, hugs, Hola]
+"hi".findSimilarIn(["ho", "Hi", "hugs", "Hola", "else"], 4, minSimilarity: nil); // [Hi, ho, hugs, Hola, else]
+"hi".findSimilarIn(["ho", "Hi", "hugs", "Hola", "else"], 4, minSimilarity: 0.01); // [Hi, ho, hugs, Hola]
+::
+
+argument::array
+An array of strings to find similar strings in.
+
+argument::maxEditDistance
+The largest link::Classes/SequenceableCollection#editDistance#edit distance:: that is accepted as a match.
+
+argument::minSimilarity
+Keep only results whose link::Classes/SequenceableCollection#similarity#similarity:: is larger than this value. If set to code::nil::, all values are accepted.
+
+argument::prioritizeCapitalization
+If true, calculated the edit distances on lower case versions.
+
+
+
 method::contains
 Returns a link::Classes/Boolean:: indicating if the String contains string.
 code::

--- a/SCClassLibrary/Common/Collections/String.sc
+++ b/SCClassLibrary/Common/Collections/String.sc
@@ -261,6 +261,25 @@ String[char] : RawArray {
 		_String_FindBackwards
 		^this.primitiveFailed
 	}
+	findSimilarIn { |array, maxEditDistance, minSimilarity, prioritizeCapitalization = true|
+		var names, editDistances, bestMatchIndices, searchFor;
+		if(prioritizeCapitalization) {
+			names = array.collect { |x| x.asString.toLower };
+			searchFor = this.toLower;
+		} {
+			names = array.collect { |x| x.asString };
+			searchFor = this;
+		};
+
+		editDistances = names.collect(editDistance(_, searchFor));
+		bestMatchIndices = editDistances.order;
+		bestMatchIndices = bestMatchIndices.select { |i|
+			maxEditDistance.isNil or: { editDistances[i] <= maxEditDistance }
+			and:
+			{ minSimilarity.isNil or: { similarity(names[i], searchFor) >= minSimilarity } }
+		}
+		^array[bestMatchIndices]
+	}
 	endsWith { arg string;
 		^this.contains(string, this.size - string.size)
 	}
@@ -487,7 +506,6 @@ String[char] : RawArray {
 	}
 	asAbsolutePath {
 			// changed because there is no need to create a separate object
-			// when String already knows how to make an absolute path
 		^this.absolutePath;  // was ^PathName(this).asAbsolutePath
 	}
 

--- a/SCClassLibrary/Common/Core/Error.sc
+++ b/SCClassLibrary/Common/Core/Error.sc
@@ -162,16 +162,16 @@ DoesNotUnderstandError : MethodError {
 			if(methodSuggestions.notEmpty) {
 				plural = if(methodSuggestions.size > 1) { "s" } { "" };
 				suggestedCorrection = methodSuggestions.first;
-				methodSuggestions = methodSuggestions.join(", ");
+				methodSuggestions = methodSuggestions.join("\n\t");
 				suggestion = suggestion ++
-				"\nClosest matching message% found for the receiver:\n\t%\n".format(plural, methodSuggestions);
+				"\nMessage% understood by the receiver with a similar name:\n\t%\n".format(plural, methodSuggestions);
 			};
 			classSuggestions = this.classSuggestions.keep(4);
 			if(classSuggestions.notEmpty) {
 				plural = if(classSuggestions.size > 1) { "s" } { "" };
-				classSuggestions = classSuggestions.join(", ");
+				classSuggestions = classSuggestions.join("\n\t");
 				suggestion = suggestion ++
-				"\nObject% which understand the selector % derive from:\n\t%\n".format(plural, selector, classSuggestions)
+				"\nObject% which understand the selector '%' derive from:\n\t%\n".format(plural, selector, classSuggestions)
 			}
 		}
 	}

--- a/SCClassLibrary/Common/Core/Error.sc
+++ b/SCClassLibrary/Common/Core/Error.sc
@@ -157,6 +157,7 @@ DoesNotUnderstandError : MethodError {
 	init {
 		var methodSuggestions, classSuggestions, plural;
 		if(receiver.notNil and: { selector.notNil }) {
+
 			methodSuggestions = this.methodSuggestions.keep(4);
 			if(methodSuggestions.notEmpty) {
 				plural = if(methodSuggestions.size > 1) { "s" } { "" };
@@ -177,7 +178,7 @@ DoesNotUnderstandError : MethodError {
 
 	methodSuggestions {
 		var names = receiver.class.respondingMethods.collect(_.name);
-		^selector.asString.findSimilarStringsIn(names, maxEditDistance: 2)
+		^selector.asString.findSimilarIn(names, maxEditDistance: 2)
 	}
 
 	classSuggestions {

--- a/SCClassLibrary/Common/Core/Error.sc
+++ b/SCClassLibrary/Common/Core/Error.sc
@@ -168,10 +168,9 @@ DoesNotUnderstandError : MethodError {
 			};
 			classSuggestions = this.classSuggestions.keep(4);
 			if(classSuggestions.notEmpty) {
-				plural = if(classSuggestions.size > 1) { "s" } { "" };
 				classSuggestions = classSuggestions.join("\n\t");
 				suggestion = suggestion ++
-				"\nObject% which understand the selector '%' derive from:\n\t%\n".format(plural, selector, classSuggestions)
+				"\nObjects which understand the selector '%' derive from:\n\t%\n".format(selector, classSuggestions)
 			}
 		}
 	}
@@ -182,7 +181,7 @@ DoesNotUnderstandError : MethodError {
 	}
 
 	classSuggestions {
-		^Object.findRespondingSubclasses(selector).collect(_.name)
+		^Object.findRespondingUpperSubclasses(selector).collect(_.name)
 	}
 
 	errorString {

--- a/SCClassLibrary/Common/Core/Error.sc
+++ b/SCClassLibrary/Common/Core/Error.sc
@@ -169,11 +169,11 @@ DoesNotUnderstandError : MethodError {
 				if(classSuggestions.size < 8) {
 					classSuggestions = classSuggestions.join("\n\t");
 					suggestion = suggestion ++
-					"\nObjects which understand the selector '%' derive from:\n\t%"
+					"\nObjects which respond to the selector '%' derive from:\n\t%"
 					.format(selector, classSuggestions)
 				} {
 					suggestion = suggestion ++
-					"\nMany other objects understand the selector '%' (found % superclasses)."
+					"\nMany other objects respond to the message '%' (found % superclasses)."
 					.format(selector, classSuggestions.size)
 				}
 			}

--- a/SCClassLibrary/Common/Core/Error.sc
+++ b/SCClassLibrary/Common/Core/Error.sc
@@ -145,7 +145,7 @@ ShouldNotImplementError : MethodError {
 }
 
 DoesNotUnderstandError : MethodError {
-	var <>selector, <>args, <>keywordArgumentPairs, <suggestedCorrection, suggestion = "";
+	var <>selector, <>args, <>keywordArgumentPairs, suggestion = "";
 	*new { arg receiver, selector, args, keywordArgumentPairs;
 		^super.new(nil, receiver)
 		.selector_(selector)
@@ -158,26 +158,25 @@ DoesNotUnderstandError : MethodError {
 		var methodSuggestions, classSuggestions, plural;
 		if(receiver.notNil and: { selector.notNil }) {
 
-			methodSuggestions = this.methodSuggestions.keep(4);
+			methodSuggestions = this.methodSuggestions;
 			if(methodSuggestions.notEmpty) {
 				plural = if(methodSuggestions.size > 1) { "s" } { "" };
-				suggestedCorrection = methodSuggestions.first;
 				methodSuggestions = methodSuggestions.join("\n\t");
 				suggestion = suggestion ++
-				"\nMessage% understood by the receiver with a similar name:\n\t%\n".format(plural, methodSuggestions);
+				"\nMessage% with a similar name understood by the receiver:\n\t%\n".format(plural, methodSuggestions);
 			};
 			classSuggestions = this.classSuggestions.keep(4);
 			if(classSuggestions.notEmpty) {
 				classSuggestions = classSuggestions.join("\n\t");
 				suggestion = suggestion ++
-				"\nObjects which understand the selector '%' derive from:\n\t%\n".format(selector, classSuggestions)
+				"\nObjects which understand the selector '%' derive from:\n\t%".format(selector, classSuggestions)
 			}
 		}
 	}
 
 	methodSuggestions {
 		var names = receiver.class.respondingMethods.collect(_.name);
-		^selector.asString.findSimilarIn(names, maxEditDistance: 2)
+		^selector.asString.findSimilarIn(names, minSimilarity: 0.5, maxEditDistance: 2)
 	}
 
 	classSuggestions {
@@ -204,7 +203,7 @@ DoesNotUnderstandError : MethodError {
 		// this.adviceLink.postln;
 		"\n^^ %\nRECEIVER: %\n".postf(this.errorString, receiver);
 		suggestion.postln;
-		"\n\n\n".post;
+		"\n".post;
 	}
 	adviceLinkPage {
 		^"%#%".format(this.class.name, selector)

--- a/SCClassLibrary/Common/Core/Error.sc
+++ b/SCClassLibrary/Common/Core/Error.sc
@@ -167,8 +167,8 @@ DoesNotUnderstandError : MethodError {
 			classSuggestions = Object.findRespondingUpperSubclasses(selector).collect(_.name);
 			if(classSuggestions.notEmpty) {
 				if(classSuggestions.size < 8) {
-				classSuggestions = classSuggestions.join("\n\t");
-				suggestion = suggestion ++
+					classSuggestions = classSuggestions.join("\n\t");
+					suggestion = suggestion ++
 					"\nObjects which understand the selector '%' derive from:\n\t%"
 					.format(selector, classSuggestions)
 				} {

--- a/SCClassLibrary/Common/Core/Error.sc
+++ b/SCClassLibrary/Common/Core/Error.sc
@@ -156,7 +156,7 @@ DoesNotUnderstandError : MethodError {
 
 	init {
 		var methodSuggestions, classSuggestions, plural;
-		if(receiver.notNil and: { selector.notNil }) {
+		if(selector.notNil) {
 			methodSuggestions = receiver.class.findSimilarSelectors(selector, minSimilarity: 0.5, maxEditDistance: 2);
 			if(methodSuggestions.notEmpty) {
 				plural = if(methodSuggestions.size > 1) { "s" } { "" };
@@ -177,6 +177,8 @@ DoesNotUnderstandError : MethodError {
 					.format(selector, classSuggestions.size)
 				}
 			}
+		} {
+			"DoesNotUnderstandError selector for % was nil".format(receiver).warn;
 		}
 	}
 

--- a/SCClassLibrary/Common/Core/Error.sc
+++ b/SCClassLibrary/Common/Core/Error.sc
@@ -163,25 +163,25 @@ DoesNotUnderstandError : MethodError {
 				suggestedCorrection = methodSuggestions.first;
 				methodSuggestions = methodSuggestions.join(", ");
 				suggestion = suggestion ++
-				"\nClosest matching message% found for the receiver:\n\t%".format(plural, methodSuggestions);
+				"\nClosest matching message% found for the receiver:\n\t%\n".format(plural, methodSuggestions);
 			};
 			classSuggestions = this.classSuggestions.keep(4);
 			if(classSuggestions.notEmpty) {
-				plural = if(classSuggestions.size > 1) { "es" } { "" };
+				plural = if(classSuggestions.size > 1) { "s" } { "" };
 				classSuggestions = classSuggestions.join(", ");
 				suggestion = suggestion ++
-				"\nClosest matching class% found for the selector:\n\t%".format(plural, classSuggestions)
+				"\nObject% which understand the selector % derive from:\n\t%\n".format(plural, selector, classSuggestions)
 			}
 		}
 	}
 
 	methodSuggestions {
 		var names = receiver.class.respondingMethods.collect(_.name);
-		^selector.asString.findSimilarIn(names, maxEditDistance: 2);
+		^selector.asString.findSimilarStringsIn(names, maxEditDistance: 2)
 	}
+
 	classSuggestions {
-		var names = Object.findRespondingSubclasses(selector).collect(_.name);
-		^receiver.class.name.asString.findSimilarIn(names, maxEditDistance: 5);
+		^Object.findRespondingSubclasses(selector).collect(_.name)
 	}
 
 	errorString {

--- a/SCClassLibrary/Common/Core/Kernel.sc
+++ b/SCClassLibrary/Common/Core/Kernel.sc
@@ -40,7 +40,7 @@ Class {
 			classesInited.add(aClass);
 
 			if(aClass.isMetaClass.not and: { aClass.class.findMethod(\initClass).notNil }, {
-					aClass.initClass;
+				aClass.initClass;
 			});
 
 			if(aClass.subclasses.notNil,{
@@ -73,6 +73,19 @@ Class {
 		};
 		^nil
 	}
+	respondingMethods {
+		var all = Array.new, selectors = IdentitySet.new;
+		this.superclassesDo { arg class;
+			class.methods.do { arg item;
+				var name = item.name;
+				if(selectors.includes(name).not) {
+					all = all.add(item);
+					selectors.add(name)
+				}
+			}
+		};
+		^all
+	}
 	superclassesDo { arg function;
 		var class = this;
 		while { class.notNil } {
@@ -88,7 +101,7 @@ Class {
 	}
 
 	dumpClassSubtree {
-		 _DumpClassSubtree
+		_DumpClassSubtree
 		^this.primitiveFailed
 	}
 	dumpInterface {
@@ -169,6 +182,32 @@ Class {
 			references = class.findReferences(aSymbol, references);
 		});
 		^references;
+	}
+	findRespondingSubclasses { arg selector;
+		var list = [];
+		subclasses.do { arg class;
+			if(class.instancesRespondTo(selector)) {
+				list = list.add(class);
+			};
+			list = list.addAll(class.findRespondingSubclasses(selector))
+		};
+		^list
+	}
+	findRespondingUpperSubclasses { arg selector;
+		var list = [];
+		if(this.instancesRespondTo(selector)) { ^list.add(this) };
+		subclasses.do { arg class;
+			if(class.instancesRespondTo(selector)) {
+				list = list.add(class);
+			} {
+				list = list.addAll(class.findRespondingUpperSubclasses(selector))
+			}
+		};
+		^list
+	}
+	instancesRespondTo { arg selector;
+		_InstancesOfClassRespondTo
+		^this.primitiveFailed
 	}
 	allSubclasses {
 		var list;
@@ -710,8 +749,8 @@ Interpreter {
 		protect {
 			result = this.compileFile(pathName).valueArray(args)
 		} { |exception|
-				exception !? { exception.path = pathName };
-				thisProcess.nowExecutingPath = saveExecutingPath
+			exception !? { exception.path = pathName };
+			thisProcess.nowExecutingPath = saveExecutingPath
 		};
 		^result
 	}
@@ -740,7 +779,7 @@ Interpreter {
 		// Do not edit this method!
 
 		{}	// this forces the compiler to generate a heap allocated frame rather than
-			// a frame on the stack
+		// a frame on the stack
 	}
 	shallowCopy { ^this }
 }

--- a/SCClassLibrary/Common/Core/Kernel.sc
+++ b/SCClassLibrary/Common/Core/Kernel.sc
@@ -205,6 +205,10 @@ Class {
 		};
 		^list
 	}
+	findSimilarSelectors { arg selector, maxEditDistance = 2, minSimilarity = 0.5, prioritizeCapitalization = true;
+		var names = this.respondingMethods.collect(_.name);
+		^selector.asString.findSimilarIn(names, maxEditDistance, minSimilarity, prioritizeCapitalization)
+	}
 	instancesRespondTo { arg selector;
 		_InstancesOfClassRespondTo
 		^this.primitiveFailed

--- a/SCClassLibrary/Common/GUI/Base/EZgui.sc
+++ b/SCClassLibrary/Common/GUI/Base/EZgui.sc
@@ -46,7 +46,7 @@ EZGui { // an abstract class
 	}
 
 	prSetViewParams {
-		^this.subclassResponsibility
+		^this.subclassResponsibility(thisMethod)
 	}
 
 	///////// private methods. You can still override these in subclasses

--- a/lang/LangPrimSource/PyrPrimitive.cpp
+++ b/lang/LangPrimSource/PyrPrimitive.cpp
@@ -2227,26 +2227,22 @@ int prObjectPointsTo(struct VMGlobals* g, int numArgsPushed) {
 
 int prObjectRespondsTo(struct VMGlobals* g, int numArgsPushed) {
     PyrSlot *a, *b;
-    PyrClass* classobj;
-    PyrMethod* meth;
-    PyrSymbol* selector;
-    int index;
 
     a = g->sp - 1;
     b = g->sp;
 
-    classobj = classOfSlot(a);
+    PyrClass* classobj = classOfSlot(a);
 
     if (IsSym(b)) {
-        selector = slotRawSymbol(b);
+        PyrSymbol* selector = slotRawSymbol(b);
         if ((selector->flags & sym_Class) != 0) {
             // if selector is a class name, a lookup in gRowTable would be indexed out of bounds
             // so here, we return false
             slotCopy(a, &o_false);
             return errNone;
         }
-        index = slotRawInt(&classobj->classIndex) + selector->u.index;
-        meth = gRowTable[index];
+        int index = slotRawInt(&classobj->classIndex) + selector->u.index;
+        PyrMethod* meth = gRowTable[index];
         if (slotRawSymbol(&meth->name) != selector) {
             slotCopy(a, &o_false);
         } else {
@@ -2259,15 +2255,15 @@ int prObjectRespondsTo(struct VMGlobals* g, int numArgsPushed) {
             if (NotSym(slot))
                 return errWrongType;
 
-            selector = slotRawSymbol(slot);
+            PyrSymbol* selector = slotRawSymbol(slot);
             if ((selector->flags & sym_Class) != 0) {
                 // if selector is a class name, a lookup in gRowTable would be indexed out of bounds
                 // so here, we return false
                 slotCopy(a, &o_false);
                 return errNone;
             }
-            index = slotRawInt(&classobj->classIndex) + selector->u.index;
-            meth = gRowTable[index];
+            int index = slotRawInt(&classobj->classIndex) + selector->u.index;
+            PyrMethod* meth = gRowTable[index];
             if (slotRawSymbol(&meth->name) != selector) {
                 slotCopy(a, &o_false);
                 return errNone;
@@ -2278,6 +2274,57 @@ int prObjectRespondsTo(struct VMGlobals* g, int numArgsPushed) {
         return errWrongType;
     return errNone;
 }
+
+int prInstancesOfClassRespondTo(struct VMGlobals* g, int numArgsPushed) {
+    PyrSlot *a, *b;
+
+    a = g->sp - 1;
+    b = g->sp;
+
+    PyrClass* classobj = slotRawClass(a);
+
+    if (IsSym(b)) {
+        PyrSymbol* selector = slotRawSymbol(b);
+        if ((selector->flags & sym_Class) != 0) {
+            // if selector is a class name, a lookup in gRowTable would be indexed out of bounds
+            // so here, we return false
+            slotCopy(a, &o_false);
+            return errNone;
+        }
+        int index = slotRawInt(&classobj->classIndex) + selector->u.index;
+        PyrMethod* meth = gRowTable[index];
+        if (slotRawSymbol(&meth->name) != selector) {
+            slotCopy(a, &o_false);
+        } else {
+            slotCopy(a, &o_true);
+        }
+    } else if (isKindOfSlot(b, class_array)) {
+        int size = slotRawObject(b)->size;
+        PyrSlot* slot = slotRawObject(b)->slots;
+        for (int i = 0; i < size; ++i, ++slot) {
+            if (NotSym(slot))
+                return errWrongType;
+
+            PyrSymbol* selector = slotRawSymbol(slot);
+            if ((selector->flags & sym_Class) != 0) {
+                // if selector is a class name, a lookup in gRowTable would be indexed out of bounds
+                // so here, we return false
+                slotCopy(a, &o_false);
+                return errNone;
+            }
+            int index = slotRawInt(&classobj->classIndex) + selector->u.index;
+            PyrMethod* meth = gRowTable[index];
+            if (slotRawSymbol(&meth->name) != selector) {
+                slotCopy(a, &o_false);
+                return errNone;
+            }
+        }
+        slotCopy(a, &o_true);
+    } else
+        return errWrongType;
+    return errNone;
+}
+
 
 PyrMethod* GetFunctionCompileContext(VMGlobals* g);
 PyrMethod* GetFunctionCompileContext(VMGlobals* g) {
@@ -3888,6 +3935,7 @@ void initPrimitives() {
     definePrimitive(base, index++, "_ObjectCopySeries", prObjectCopySeries, 4, 0);
     definePrimitive(base, index++, "_ObjectPointsTo", prObjectPointsTo, 2, 0);
     definePrimitive(base, index++, "_ObjectRespondsTo", prObjectRespondsTo, 2, 0);
+    definePrimitive(base, index++, "_InstancesOfClassRespondTo", prInstancesOfClassRespondTo, 2, 0);
     definePrimitive(base, index++, "_ObjectIsMutable", prObjectIsMutable, 1, 0);
     definePrimitive(base, index++, "_ObjectIsPermanent", prObjectIsPermanent, 1, 0);
     definePrimitive(base, index++, "_ObjectDeepFreeze", prDeepFreeze, 1, 0);

--- a/lang/LangSource/PyrPrimitiveProto.h
+++ b/lang/LangSource/PyrPrimitiveProto.h
@@ -63,6 +63,7 @@ int prObjectShallowCopy(VMGlobals* g, int numArgsPushed);
 int prObjectCopyRange(VMGlobals* g, int numArgsPushed);
 int prObjectPointsTo(VMGlobals* g, int numArgsPushed);
 int prObjectRespondsTo(VMGlobals* g, int numArgsPushed);
+int prInstancesOfClassRespondTo(VMGlobals* g, int numArgsPushed);
 
 int prCompileString(VMGlobals* g, int numArgsPushed);
 int prDumpBackTrace(VMGlobals* g, int numArgsPushed);

--- a/testsuite/classlibrary/TestClass.sc
+++ b/testsuite/classlibrary/TestClass.sc
@@ -1,0 +1,31 @@
+TestClass : UnitTest {
+
+	test_respondingMethods_no_duplicates {
+		var methods = Array.respondingMethods;
+		var selectors = methods.collect(_.name);
+		var selectorsWithoutDuplicates = selectors.as(IdentitySet);
+		var hasDuplicates = selectors.size > selectorsWithoutDuplicates.size;
+		this.assert(hasDuplicates.not, "The response from respondingMethods should contain only one method of each selector");
+	}
+
+	test_findRespondingSubclasses_from_Object {
+		var classesFound = Object.findRespondingSubclasses(\dummyMethodForTest);
+		this.assertEquals(classesFound, [this.class] ++ TestClassDummy, "Object findRespondingSubclasses should find correct class")
+	}
+
+	test_findRespondingUpperSubclasses {
+		var classesFound = this.class.findRespondingUpperSubclasses(\dummyMethodForTest);
+		this.assertEquals(classesFound, [this.class], "Class findRespondingUpperSubclasses should find correct class")
+	}
+
+	test_findRespondingSubclasses {
+		var classesFound = this.class.findRespondingSubclasses(\dummyMethodForTest);
+		this.assertEquals(classesFound, [TestClassDummy], "Class findRespondingSubclasses should find correct class")
+	}
+
+	dummyMethodForTest {}
+
+
+}
+
+TestClassDummy : TestClass {}

--- a/testsuite/classlibrary/TestDoesNotUnderstandError.sc
+++ b/testsuite/classlibrary/TestDoesNotUnderstandError.sc
@@ -8,11 +8,4 @@ TestDoesNotUnderstandError : UnitTest {
 		this.assertEquals(error.args, [4, 5]);
 		this.assertEquals(error.suggestedCorrection, nil);
 	}
-
-	test_suggestedCorrection {
-		var error;
-		try { Object().szie } { |e| error = e };
-
-		this.assertEquals(error.suggestedCorrection, Object.findMethod(\size));
-	}
 }

--- a/testsuite/classlibrary/TestDoesNotUnderstandError.sc
+++ b/testsuite/classlibrary/TestDoesNotUnderstandError.sc
@@ -6,6 +6,5 @@ TestDoesNotUnderstandError : UnitTest {
 		this.assertEquals(error.receiver, 3);
 		this.assertEquals(error.selector, 'bogusTestMethodNameXyz');
 		this.assertEquals(error.args, [4, 5]);
-		this.assertEquals(error.suggestedCorrection, nil);
 	}
 }


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->


## Purpose and Motivation

The DoesNotUnderstandError suggestions sometimes are over-confident, because:
- they only give one suggestion even if there may be others that match almost as well
- they suggest that there has been a typo where there may have been other reasons
- the errorString contained the suggestion, which one may want to keep separate


## Types of changes

This improves the DoesNotUnderstandError posting:
- it now suggests up to 4 similar names
- it uses a neutral language that doesn't speculate about the reason
- The errorString itself now does not contain the suggestion
- As an experiment to be evaluated over time, we sometimes post class suggestions if they are appropriate.
- for better introspection, some new methods have been introduced
- the implementation of DoesNotUnderstand is refactored

I took the liberty to remove an instance variable called `suggestedCorrection`, because it makes no sense anymore (we have different kinds of suggestions)

So this is a breaking change if you happen to be using it (rather unlikely).

For this, I took the occasion to add a better interface to `Class`, which allows us to retrieve all responing methods of an object through its class (`respondingMethods`). A unit test for this is added as well.

Maybe the expression "Closest matching message found for the receiver:" is not yet optimal, suggestions welcome!



```supercollider

[1, 2, 3].collkt

// before

^^ ERROR: Message 'collkt' not understood.
Perhaps you misspelled 'collect', or meant to call 'collkt' on another receiver?
RECEIVER: [1, 2, 3]

// now:

^^ ERROR: Message 'collkt' not understood.
RECEIVER: [1, 2, 3]
Closest matching message found for the receiver:
	collect


[1, 2, 3].coll

// before

^^ ERROR: Message 'coll' not understood.
Perhaps you misspelled 'poll', or meant to call 'coll' on another receiver?
RECEIVER: [1, 2, 3]

// now:

^^ ERROR: Message 'coll' not understood.
RECEIVER: [1, 2, 3]
Closest matching messages found for the receiver:
	poll, call, dpoll, fill

```

```supercollider
// Sometimes, we get suggestions for classes:

// examples
View.new.drawingEnabled;
^^ ERROR: Message 'drawingEnabled' not understood.
RECEIVER: a View

Closest matching classes found for the selector:
	UserView, QUserView


```

<!-- Delete lines that don't apply -->

- New feature

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

## Merge notes
- Release Notes: Improve the DoesNotUnderstandError posting by providing more than one suggestion and rephrasing the string. Note that the suggestion is not part of the error string anymore.


<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
