### PR TITLE
Add link to tutorials and publications to documentation home (need to update sc wiki)

### DIFF
--- a/HelpSource/Help.schelp
+++ b/HelpSource/Help.schelp
@@ -55,6 +55,7 @@ definitionlist::
 ## link::Guides/More-On-Getting-Help:: || Using Help Files effectively and inspecting class definition files to build more understanding
 ## link::Browse.html#Tutorials#All tutorials:: || Index of all help files categorized under "Tutorials"
 ## link::Guides/UserFAQ:: || Common Errors and FAQ
+## link::https://github.com/supercollider/supercollider/wiki/Tutorials##Community Learning Resources (Tutorials & Publications):: || SuperCollider Tutorials Wiki: Community-curated tutorial index and learning resources
 ::
 
 subsection:: Getting Sound


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation
closes #2911?

This is a draft to add tutorials and publications list to the documentation.
I am not sure if this is a good idea, and I think some developers do not want this kind of documentation.
(I am ready to close this ;))
<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->

- Documentation

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
