### PR TITLE
scsynth: improve audio thread priority setting on macOS

### DIFF
--- a/server/scsynth/SC_ComPort.cpp
+++ b/server/scsynth/SC_ComPort.cpp
@@ -483,8 +483,13 @@ SC_TcpConnection::~SC_TcpConnection() { mParent->connectionDestroyed(); }
 //////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 static void asioFunction() {
-    /* NB: on macOS we just keep the default thread priority */
-#ifdef NOVA_TT_PRIORITY_RT
+#ifdef __APPLE__
+    // on macOS, set the thread priority to user-interactive
+    int result = pthread_set_qos_class_self_np(QOS_CLASS_USER_INTERACTIVE, -10);
+    if (result != 0) {
+        scprintf("SC_ComPort: could not set asioFunction thread priority to user-interactive: %s\n", strerror(result));
+    }
+#elif defined(NOVA_TT_PRIORITY_RT)
     int priority = nova::thread_priority_interval_rt().first;
     nova::thread_set_priority_rt(priority);
 #endif


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

I observed, that it is somewhat easy to create dropouts in scsynth when e.g. application windows are moved. That makes me think that maybe the thread priorities are not set appropriately.

I tried to leverage the `thread_set_priority_rt()` function for this. It has _slightly_ improved the situation on my system (M1pro). Test code below.

I'm not sure if this is the best sollution, or if the `computation` and `constraint` values should be adjusted further.

<details><summary>Example code I used for stressing scsynth</summary>

```supercollider
(
Server.scsynth;
s.options.memSize_(2 ** 20); // needed for the load test
s.options.hardwareBufferSize_(128);

~numSynths = 500;
s.waitForBoot{
	SynthDef(\sinVerb, { arg out = 0, amp = 0.01;
		Out.ar(out, GVerb.ar(SinOsc.ar(Rand(400, 700))) * amp);
	}).add;

	~allSynths ?? {~allSynths = []};
	~allSynths = ~allSynths.addAll(
		~numSynths.collect({
			s.sync;
			Synth(\sinVerb, [\amp, -60.dbamp]);
		})

	)
}
)

~allSynths.do(_.free)

// macOS 14, CPU Apple M1pro, 500 synths
// this PR: peak around 90-100%, avg around 72%; no or minimal dropouts when moving windows
// 3.13: peak around 90-100%, avg around 85%; no dropouts when idle; dropouts when moving windows
```

</details>

Regarding the implementation: note that I had to move the thread creation to after the driver was initialized - this was needed in order to get the samplerate, which is needed to set the deadlines.

EDIT:
I have also tested this on a 2015 MacBook Air (Intel). 
For 100 synths from the example, SC 3.13 produced constant dropouts; this build produced only minimal and occasional dropouts.

EDIT 2:
~~Note that before SC 3.14 we were inadvertently dropping the thread priority for the audio thread...~~ We were dropping the thread NRT thread, apparently. See https://github.com/supercollider/supercollider/pull/6043. 

## Types of changes

<!-- Delete lines that don't apply -->

- New feature (?)

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [ ] All tests are passing
- [ ] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
