### PR TITLE
Add nil's behaviour in Set and Nil documentation

### DIFF
--- a/HelpSource/Classes/Nil.schelp
+++ b/HelpSource/Classes/Nil.schelp
@@ -4,17 +4,23 @@ summary::Represents uninitialized data
 
 description::
 
-Nil has a single instance named nil and is used to represent uninitialized data,
+Nil has a single instance named code::nil:: and is used to represent uninitialized data,
 bad values, or terminal values such as end-of-stream.
+Internally, code::nil:: also serves as a sentinel value, used to mark empty or unoccupied slots
+in hash-based data structures such as code::Set::, and its subclasses.
+Because of this internal role, code::nil::—despite being a valid object—cannot be stored
+as an element in code::Set:: or any of its subclasses.
+Attempting to do so will result in a runtime error.
+See the link::Classes/Set:: for more information.
 
 note::
-Take note that Nil is a class and not the special value code::nil::. Comparing Nil and code::nil:: will return false.
-In normal use you should not need to use this class directly: use code::nil::
+Take note that code::Nil:: is a class and not the special value code::nil::. Comparing code::Nil:: and code::nil:: will return false.
+In normal use, you should not need to use this class directly; use code::nil::.
 
 code::
-Nil.isNil; // false
-Nil == nil; // false
-Nil === nil; // false
+Nil.isNil;    // false
+Nil == nil;   // false
+Nil === nil;  // false
 ::
 ::
 

--- a/HelpSource/Classes/Set.schelp
+++ b/HelpSource/Classes/Set.schelp
@@ -4,12 +4,12 @@ related::Classes/IdentitySet, Classes/List, Classes/Dictionary
 categories::Collections>Unordered
 
 DESCRIPTION::
-A Set is a collection of objects, no two of which are equal. Most of its methods are inherited from Collection. The contents of a Set are unordered; therefore, code must not rely on the order of elements in a Set. For an ordered variant, see link::Classes/OrderedIdentitySet::.
+emphasis::An instance of the Set class:: (a set) is a collection of objects, no two of which are equal. Most of its methods are inherited from Collection. The contents of emphasis::a set:: are unordered; therefore, code must not rely on the order of elements in emphasis::a set::. For an ordered variant, see link::Classes/OrderedIdentitySet::.
 
 note::
-Currently, a Set cannot contain code::nil:: as an element. Attempting to add code::nil:: will result in a runtime error: 
+Currently, emphasis::a set:: cannot contain code::nil:: as an element. Attempting to add code::nil:: will result in a runtime error: 
 teletype::
-ERROR: A Set cannot contain nil.
+ERROR: A set cannot contain nil.
 ::
 This restriction exists because code::nil:: is internally used as a sentinel value to represent unoccupied slots in hash-based collections. As a result, this limitation also applies to Set’s subclasses.
 ::

--- a/HelpSource/Classes/Set.schelp
+++ b/HelpSource/Classes/Set.schelp
@@ -4,7 +4,7 @@ related::Classes/IdentitySet, Classes/List, Classes/Dictionary
 categories::Collections>Unordered
 
 DESCRIPTION::
-emphasis::An instance of the Set class:: (a set) is a collection of objects, no two of which are equal. Most of its methods are inherited from Collection. The contents of emphasis::a set:: are unordered; therefore, code must not rely on the order of elements in emphasis::a set::. For an ordered variant, see link::Classes/OrderedIdentitySet::.
+emphasis::An instance of the set class:: (a set) is a collection of objects, in which no two elements are equal. Most of its methods are inherited from Collection. The contents of emphasis::a set:: are unordered; therefore, code must not rely on the order of elements in emphasis::a set::. For an ordered variant, see link::Classes/OrderedIdentitySet::.
 
 note::
 Currently, emphasis::a set:: cannot contain code::nil:: as an element. Attempting to add code::nil:: will result in a runtime error: 

--- a/HelpSource/Classes/Set.schelp
+++ b/HelpSource/Classes/Set.schelp
@@ -4,7 +4,17 @@ related::Classes/IdentitySet, Classes/List, Classes/Dictionary
 categories::Collections>Unordered
 
 DESCRIPTION::
-A Set is s collection of objects, no two of which are equal. Most of its methods are inherited from Collection. The contents of a Set are unordered. You must not depend on the order of items in a set. For an ordered set, see link::Classes/OrderedIdentitySet::.
+A Set is a collection of objects, no two of which are equal. Most of its methods are inherited from Collection. The contents of a Set are unordered; therefore, code must not rely on the order of elements in a Set. For an ordered variant, see link::Classes/OrderedIdentitySet::.
+
+note::
+Currently, a Set cannot contain code::nil:: as an element. Attempting to add code::nil:: will result in a runtime error: 
+teletype::
+ERROR: A Set cannot contain nil.
+::
+This restriction exists because code::nil:: is internally used as a sentinel value to represent unoccupied slots in hash-based collections. As a result, this limitation also applies to Set’s subclasses.
+::
+
+
 
 INSTANCEMETHODS::
 

--- a/HelpSource/Classes/Set.schelp
+++ b/HelpSource/Classes/Set.schelp
@@ -4,10 +4,12 @@ related::Classes/IdentitySet, Classes/List, Classes/Dictionary
 categories::Collections>Unordered
 
 DESCRIPTION::
-emphasis::An instance of the set class:: (a set) is a collection of objects, in which no two elements are equal. Most of its methods are inherited from Collection. The contents of emphasis::a set:: are unordered; therefore, code must not rely on the order of elements in emphasis::a set::. For an ordered variant, see link::Classes/OrderedIdentitySet::.
+An instance of the class code::Set:: (a set) is a collection of objects, in which no two elements are equal. Most of its methods are inherited from code::Collection::.
+The contents of a set are unordered; therefore, code must not rely on the order of elements in a set.
+For an ordered variant, see link::Classes/OrderedIdentitySet::; for multisets (i.e., sets in which distinct elements can be equal, but that remain unordered), see link::Classes/Bag::.
 
 note::
-Currently, emphasis::a set:: cannot contain code::nil:: as an element. Attempting to add code::nil:: will result in a runtime error: 
+Currently, a set cannot contain code::nil:: as an element. Attempting to add code::nil:: will result in a runtime error: 
 teletype::
 ERROR: A set cannot contain nil.
 ::

--- a/SCClassLibrary/Common/Collections/Set.sc
+++ b/SCClassLibrary/Common/Collections/Set.sc
@@ -28,7 +28,7 @@ Set : Collection {
 	}
 	add { arg item;
 		var index;
-		if (item.isNil, { Error("A Set cannot contain nil.\n").throw; });
+		if (item.isNil, { Error("A set cannot contain nil.\n").throw; });
 		index = this.scanFor(item);
 		if ( array.at(index).isNil, { this.putCheck(index, item) });
 	}


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation
This documentation update reflects the current behaviour of nil in SuperCollider, which serves multiple purposes: representing uninitialised values, terminal markers, and acting as an internal sentinel within collections. While this multipurpose usage may be reconsidered in the future, the current update ensures the existing implementation is accurately described.
If nil is later restricted to represent only uninitialised values, the affected documentation should be revised accordingly. See #7010.

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->

- Documentation
## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
