### PR TITLE
classlib: helpFileForMethod jumps to method

### DIFF
--- a/SCClassLibrary/DefaultLibrary/dumpFullInterface.sc
+++ b/SCClassLibrary/DefaultLibrary/dumpFullInterface.sc
@@ -130,9 +130,8 @@
 		});
 	}
 
-	helpFileForMethod {
-		arg methodSymbol;
-		this.findRespondingMethodFor(methodSymbol).ownerClass.help;
+	helpFileForMethod { arg methodSymbol;
+		this.findRespondingMethodFor(methodSymbol).help;
 	}
 
 		// show all subclasses of this class sorted in alpha order (not tree order)


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

helpFileForMethod jumps to method, instead of just to the class documentation.


## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

## Merge notes
     - helpFileForMethod jumps to the method description, instead of to the class documentation only.


<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
