### PR TITLE
sclang: protect method lookup from out of bounds index

### DIFF
--- a/lang/LangPrimSource/PyrPrimitive.cpp
+++ b/lang/LangPrimSource/PyrPrimitive.cpp
@@ -2239,6 +2239,10 @@ int prObjectRespondsTo(struct VMGlobals* g, int numArgsPushed) {
 
     if (IsSym(b)) {
         selector = slotRawSymbol(b);
+        if ((selector->flags & sym_Class) != 0) {
+            slotCopy(a, &o_false);
+            return errNone;
+        }
         index = slotRawInt(&classobj->classIndex) + selector->u.index;
         meth = gRowTable[index];
         if (slotRawSymbol(&meth->name) != selector) {
@@ -2254,6 +2258,10 @@ int prObjectRespondsTo(struct VMGlobals* g, int numArgsPushed) {
                 return errWrongType;
 
             selector = slotRawSymbol(slot);
+            if ((selector->flags & sym_Class) != 0) {
+                slotCopy(a, &o_false);
+                return errNone;
+            }
             index = slotRawInt(&classobj->classIndex) + selector->u.index;
             meth = gRowTable[index];
             if (slotRawSymbol(&meth->name) != selector) {

--- a/lang/LangPrimSource/PyrPrimitive.cpp
+++ b/lang/LangPrimSource/PyrPrimitive.cpp
@@ -2240,6 +2240,8 @@ int prObjectRespondsTo(struct VMGlobals* g, int numArgsPushed) {
     if (IsSym(b)) {
         selector = slotRawSymbol(b);
         if ((selector->flags & sym_Class) != 0) {
+            // if selector is a class name, a lookup in gRowTable would be indexed out of bounds
+            // so here, we return false
             slotCopy(a, &o_false);
             return errNone;
         }
@@ -2259,6 +2261,8 @@ int prObjectRespondsTo(struct VMGlobals* g, int numArgsPushed) {
 
             selector = slotRawSymbol(slot);
             if ((selector->flags & sym_Class) != 0) {
+                // if selector is a class name, a lookup in gRowTable would be indexed out of bounds
+                // so here, we return false
                 slotCopy(a, &o_false);
                 return errNone;
             }

--- a/lang/LangSource/PyrMessage.cpp
+++ b/lang/LangSource/PyrMessage.cpp
@@ -118,6 +118,10 @@ HOT void sendMessageImpl(VMGlobals* g, PyrSymbol* selector, PyrSlot* recvrSlot, 
     // In cases of redirect and super calls the function to be recursively call, this is implemented with a goto.
 
 lookup_again:
+    if ((selector->flags & sym_Class) != 0) {
+        post("A method selector can't be a class name\n");
+        return;
+    };
     // The variables classobj and selector are updated when the goto is triggered, causing these to change.
     auto method = gRowTable[slotRawInt(&classobj->classIndex) + selector->u.index];
     auto methodRaw = METHRAW(method);
@@ -342,8 +346,8 @@ void doesNotUnderstand(VMGlobals* g, PyrSymbol* selector, std::int64_t numArgsPu
         std::rotate(rargBegin, rargBegin + 1, rargEnd);
     }
     auto selectorSlot = g->sp - numArgsPushed + 1;
-
     const auto callIndex = slotRawInt(&classObject->classIndex) + s_doesNotUnderstand->u.index;
+
     auto method = gRowTable[callIndex];
 
     if (tryUniqueMethod(g, method, receiverSlot, selectorSlot, numArgsPushed, numKeyArgsPushed))

--- a/lang/LangSource/PyrMessage.cpp
+++ b/lang/LangSource/PyrMessage.cpp
@@ -118,11 +118,12 @@ HOT void sendMessageImpl(VMGlobals* g, PyrSymbol* selector, PyrSlot* recvrSlot, 
     // In cases of redirect and super calls the function to be recursively call, this is implemented with a goto.
 
 lookup_again:
-    if ((selector->flags & sym_Class) != 0) {
-        post("A method selector can't be a class name\n");
-        return;
-    };
     // The variables classobj and selector are updated when the goto is triggered, causing these to change.
+    if ((selector->flags & sym_Class) != 0) {
+        // if selector is a class name, a lookup in gRowTable would be indexed out of bounds
+        doesNotUnderstand(g, selector, numArgsPushed, numKeyArgsPushed);
+        return;
+    }
     auto method = gRowTable[slotRawInt(&classobj->classIndex) + selector->u.index];
     auto methodRaw = METHRAW(method);
 


### PR DESCRIPTION
When the method selector is a symbol that is a class name, method lookup may be out of bounds. We check if the symbol is a monster and return.

This fixes #7016 and #7020.

```supercollider
[].respondsTo(\Object)
[].doesNotUnderstand(\Object)
[].perform(\Object);
[].performList(\Object);
[].performArgs(\Object);
```

## Discussion

This adds an extra check in a central place of method dispatch.
We should discuss if this is the best way to go, and make sure this is really the most performant way.

The community hasn't noticed this bug for 20 years, so is it worth checking for the monster every method call? Maybe yes, maybe no.

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->


- Bug fix


## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [ ] All tests are passing
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
