### PR TITLE
classlib: Post: Remove reference to the 18-years-deleted '.flush' method

### DIFF
--- a/SCClassLibrary/Common/Streams/IOStream.sc
+++ b/SCClassLibrary/Common/Streams/IOStream.sc
@@ -223,7 +223,6 @@ Post {
 		];
 	}
 
-	//*flush { this.flushPostBuf }
 	* << { arg item;
 		item.printOn(this);
 	}
@@ -247,7 +246,7 @@ Post {
 	* nl { this.put(Char.nl); }
 	* ff { this.put(Char.ff); }
 	* tab { this.put(Char.tab); }
-	* close { this.flush; }
+	* close {}  // was this.flush but .flush was removed in 2007
 }
 
 


### PR DESCRIPTION
## Purpose and Motivation

This should be uncontroversial: Post's `*close` method has been invalid in the 18 years since the `flush` method that it calls was deleted. We need to keep `.close` for compatibility with File streams, but it should be a no-op rather than a thrower of a DoesNotUnderstandError.

## Types of changes

- Bug fix

## To-do list

- [x] Code is tested
- [x] All tests are passing
- [-] Updated documentation (no need)
- [x] This PR is ready for review