### PR TITLE
clarified use of supernova and fixed build instructions with qt5

### DIFF
--- a/README_MACOS.md
+++ b/README_MACOS.md
@@ -66,10 +66,9 @@ Build instructions
     cd SuperCollider
     mkdir -p build
     cd build
-    # the default way is to build SC with supernova: 
-    cmake -G Xcode -DSUPERNOVA=ON ..
-    # or, if you want to build without it:
     cmake -G Xcode  ..
+    # or, if you want to build with supernove:
+    cmake -G Xcode -DSUPERNOVA=ON ..
     # then start the build
     cmake --build . --target install --config RelWithDebInfo
 
@@ -83,7 +82,7 @@ To install, you may move this to /Applications or use it in place from the build
 **Qt5 is outdated** and will soon be deprecated. It is strongly advised to build with Qt6. If your system also has Qt5 installed you may have to adjust your brew and shell config. In order to build with Qt5, Qt6 needs to be uninstalled or unlinked:
 
     brew unlink qt@6
-    cmake -G Xcode -DCMAKE_PREFIX_PATH=`brew --prefix qt@5` -DSUPERNOVA=ON ..
+    cmake -G Xcode -DCMAKE_PREFIX_PATH=`brew --prefix qt@5` ..
     cmake --build . --target install --config RelWithDebInfo
 
 More info on *supernova* can be found in the section **Frequently used cmake settings** below.

--- a/README_MACOS.md
+++ b/README_MACOS.md
@@ -83,7 +83,7 @@ To install, you may move this to /Applications or use it in place from the build
 **Qt5 is outdated** and will soon be deprecated. It is strongly advised to build with Qt6. If your system also has Qt5 installed you may have to adjust your brew and shell config. In order to build with Qt5, Qt6 needs to be uninstalled or unlinked:
 
     brew unlink qt@6
-    cmake -G Xcode -DCMAKE_PREFIX_PATH=`brew --prefix qt@5' -DSUPERNOVA=ON ..
+    cmake -G Xcode -DCMAKE_PREFIX_PATH=`brew --prefix qt@5` -DSUPERNOVA=ON ..
     cmake --build . --target install --config RelWithDebInfo
 
 More info on *supernova* can be found in the section **Frequently used cmake settings** below.

--- a/README_MACOS.md
+++ b/README_MACOS.md
@@ -66,8 +66,8 @@ Build instructions
     cd SuperCollider
     mkdir -p build
     cd build
-    cmake -G Xcode  ..
-    # or, if you want to build with supernove:
+    cmake -G Xcode ..
+    # or, if you want to build with supernova:
     cmake -G Xcode -DSUPERNOVA=ON ..
     # then start the build
     cmake --build . --target install --config RelWithDebInfo

--- a/README_MACOS.md
+++ b/README_MACOS.md
@@ -79,7 +79,7 @@ You can see the available build options with ```cmake -LH```.
 
 To install, you may move this to /Applications or use it in place from the build directory.
 
-**Qt 5.15 compatibility**: 
+**Qt 5.15 compatibility**:  
 **Qt5 is outdated** and will soon be deprecated. It is strongly advised to build with Qt6. If your system also has Qt5 installed you may have to adjust your brew and shell config. In order to build with Qt5, Qt6 needs to be uninstalled or unlinked:
 
     brew unlink qt@6

--- a/README_MACOS.md
+++ b/README_MACOS.md
@@ -66,9 +66,10 @@ Build instructions
     cd SuperCollider
     mkdir -p build
     cd build
-    cmake -G Xcode ..
-    # or, if you want to build with supernova:
+    # the default way is to build SC with supernova: 
     cmake -G Xcode -DSUPERNOVA=ON ..
+    # or, if you want to build without it:
+    cmake -G Xcode  ..
     # then start the build
     cmake --build . --target install --config RelWithDebInfo
 
@@ -78,10 +79,11 @@ You can see the available build options with ```cmake -LH```.
 
 To install, you may move this to /Applications or use it in place from the build directory.
 
-**Qt 5.15 compatibility**: For the time being, SuperCollider can still be built against Qt 5.15. Note that in order to build with Qt5, Qt6 needs to be uninstalled or unlinked:
+**Qt 5.15 compatibility**: 
+**Qt5 is outdated** and will soon be deprecated. It is strongly advised to build with Qt6. If your system also has Qt5 installed you may have to adjust your brew and shell config. In order to build with Qt5, Qt6 needs to be uninstalled or unlinked:
 
-    brew unlink qt@5
-    cmake -G Xcode -DCMAKE_PREFIX_PATH=`brew --prefix qt@5` -DSUPERNOVA=ON ..
+    brew unlink qt@6
+    cmake -G Xcode -DCMAKE_PREFIX_PATH=`brew --prefix qt@5' -DSUPERNOVA=ON ..
     cmake --build . --target install --config RelWithDebInfo
 
 More info on *supernova* can be found in the section **Frequently used cmake settings** below.


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation
As discovered in https://github.com/supercollider/supercollider/issues/7003 there was a typo in the qt5 building instructions in the macOS readme. 

Also clarified the use of supernova and added a stronger suggestion to drop Qt5 (EOL). 
See also https://github.com/supercollider/supercollider/issues/7006

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->

- Documentation
- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
