### PR TITLE
QtCollider: AbstractStepValue widgets: improve wheelEvent scroll behavior + fix regression

### DIFF
--- a/QtCollider/widgets/QcAbstractStepValue.h
+++ b/QtCollider/widgets/QcAbstractStepValue.h
@@ -21,6 +21,9 @@
 
 #pragma once
 
+#include <QWheelEvent>
+#include <QGuiApplication>
+
 class QcAbstractStepValue {
 protected:
     QcAbstractStepValue(): _shiftScale(100.f), _ctrlScale(10.f), _altScale(0.1f) {}
@@ -37,3 +40,37 @@ private:
     double _ctrlScale;
     double _altScale;
 };
+
+static QPointF getNormalizedScrollRatio(const QWheelEvent* e, QSizeF pixelRatio) {
+    const auto platform = QGuiApplication::platformName();
+    const bool isX11 = platform == "xcb";
+    // angleDelta: relative to 360deg; pixelDelta: relative to widget size
+    QPointF ratio;
+    // Force using angleDelta on X11 (advice from Qt docs)
+    // the check for pixelRatio.isEmpty is to allow forcing angleDelta by passing pixelRatio = 0
+    if (e->pixelDelta().isNull() || pixelRatio.isEmpty() || isX11) {
+        ratio.setX(e->angleDelta().x() / 8. / 360.);
+        ratio.setY(e->angleDelta().y() / 8. / 360.);
+    } else {
+        ratio.setX(e->pixelDelta().x() * pixelRatio.width());
+        ratio.setY(e->pixelDelta().y() * pixelRatio.height());
+    }
+
+    // If Alt is pressed, Qt swaps scroll axis: undo it because we use alt to change scale
+    // only on linux (x11 and wayland) and Windows, not on macos
+    if (e->modifiers().testFlag(Qt::AltModifier) && (isX11 || platform == "wayland" || platform == "windows"))
+        ratio = ratio.transposed();
+
+    // Normally horiz scroll produces positive delta values if the wheel is moved to the left (Qt docs)
+    ratio.setX(ratio.x() * -1);
+
+    // Note: on some platforms (x11, wayland) "natural scrolling" is not detectable: inverted() returns always false
+    if (e->inverted())
+        ratio.setY(ratio.y() * -1);
+
+    return ratio;
+}
+
+static QPointF getNormalizedScrollRatio(const QWheelEvent* e, double pixelRatio) {
+    return getNormalizedScrollRatio(e, QSizeF(pixelRatio, pixelRatio));
+}

--- a/QtCollider/widgets/QcAbstractStepValue.h
+++ b/QtCollider/widgets/QcAbstractStepValue.h
@@ -61,12 +61,13 @@ static QPointF getNormalizedScrollRatio(const QWheelEvent* e, QSizeF pixelRatio)
     if (e->modifiers().testFlag(Qt::AltModifier) && (isX11 || platform == "wayland" || platform == "windows"))
         ratio = ratio.transposed();
 
-    // Normally horiz scroll produces positive delta values if the wheel is moved to the left (Qt docs)
-    ratio.setX(ratio.x() * -1);
-
     // Note: on some platforms (x11, wayland) "natural scrolling" is not detectable: inverted() returns always false
-    if (e->inverted())
+    if (e->inverted()) {
         ratio.setY(ratio.y() * -1);
+    } else {
+        // Normally horiz scroll produces positive delta values if the wheel is moved to the left (Qt docs)
+        ratio.setX(ratio.x() * -1);
+    };
 
     return ratio;
 }

--- a/QtCollider/widgets/QcAbstractStepValue.h
+++ b/QtCollider/widgets/QcAbstractStepValue.h
@@ -49,14 +49,6 @@ static QPointF getScrollSteps(const QWheelEvent* e) {
     QPointF steps =
         (e->pixelDelta().isNull() || isX11) ? QPointF(e->angleDelta()) / 120. : QPointF(e->pixelDelta()) / 10.;
 
-    // Use angleDelta (and not pixelDelta) for consistency with SC versions before 3.14
-    // QPointF ratio(e->angleDelta().x() / 120., e->angleDelta().y() / 120.);
-
-    if (!e->pixelDelta().isNull())
-        printf("scroll: angleDelta/12(%d,%d) pxDelta(%d,%d) px/step(%f) steps(%f,%f)\n", (e->angleDelta() / 12.).x(),
-               (e->angleDelta() / 12.).y(), e->pixelDelta().x(), e->pixelDelta().y(),
-               (e->pixelDelta().y() != 0) ? e->pixelDelta().y() * 120. / e->angleDelta().y() : 0, steps.x(), steps.y());
-
     // If Alt is pressed, Qt swaps scroll axis: undo it because we use alt to change scale
     // only on linux (x11 and wayland) and Windows, not on macos
     if (e->modifiers().testFlag(Qt::AltModifier) && (isX11 || platform == "wayland" || platform == "windows"))

--- a/QtCollider/widgets/QcAbstractStepValue.h
+++ b/QtCollider/widgets/QcAbstractStepValue.h
@@ -44,8 +44,9 @@ private:
 static QPointF getScrollSteps(const QWheelEvent* e) {
     // use pixelDelta on systems that support it, except x11 (Qt docs say it's unreliable)
     const auto platform = QGuiApplication::platformName();
-    const bool isX11 = platform == "x11";
-    // angleDelta: map 15deg/step, pixelDelta: map 10px/step (found empirically to match angleDelta)
+    const bool isX11 = platform == "xcb";
+    // angleDelta: map 15deg/step (conventional)
+    // pixelDelta: map 10px/step (found empirically to match angleDelta on wayland)
     QPointF steps =
         (e->pixelDelta().isNull() || isX11) ? QPointF(e->angleDelta()) / 120. : QPointF(e->pixelDelta()) / 10.;
 

--- a/QtCollider/widgets/QcKnob.cpp
+++ b/QtCollider/widgets/QcKnob.cpp
@@ -22,7 +22,6 @@
 #include "QcKnob.hpp"
 #include "../QcWidgetFactory.h"
 #include "../style/routines.hpp"
-#include "widgets/QcAbstractStepValue.h"
 
 #include <QMouseEvent>
 #include <QPainter>

--- a/QtCollider/widgets/QcKnob.cpp
+++ b/QtCollider/widgets/QcKnob.cpp
@@ -31,7 +31,7 @@ using namespace QtCollider;
 
 QC_DECLARE_QWIDGET_FACTORY(QcKnob);
 
-QcKnob::QcKnob(): Style::Client(this), _value(0.f), _step(0.01), _mode(0), _centered(false) {
+QcKnob::QcKnob(): Style::Client(this), _value(0.f), _step(0.01), _mode(0), _centered(false), scrollRemainder(0.) {
     setFocusPolicy(Qt::StrongFocus);
     setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Minimum);
     setAttribute(Qt::WA_AcceptTouchEvents);
@@ -78,10 +78,7 @@ void QcKnob::wheelEvent(QWheelEvent* e) {
     const double size = qMin(width(), height()) * PI;
     const double pixelStep = size > 0. ? 1. / size : 0.;
     double step = qMax(_step, pixelStep);
-
-    const double scrollRatio = getNormalizedScrollRatio(e, pixelStep).y();
-
-    double numSteps = scrollRatio / step;
+    double numSteps = getScrollSteps(e).y();
     modifyStep(&step);
     // accumulate fractional numSteps to help scrolling through big steps
     scrollRemainder = std::modf(numSteps + scrollRemainder, &numSteps);

--- a/QtCollider/widgets/QcKnob.cpp
+++ b/QtCollider/widgets/QcKnob.cpp
@@ -80,8 +80,11 @@ void QcKnob::wheelEvent(QWheelEvent* e) {
     // use angleDelta for X11 (advice from Qt docs)
     const bool isX11 = QGuiApplication::platformName() == "xcb";
     // angleDelta: relative to 360deg; pixelDelta: relative to widget size
-    double scrollRatio =
-        (e->pixelDelta().isNull() || isX11) ? e->angleDelta().y() / 8. / 360. : e->pixelDelta().y() * pixelStep;
+    const QPointF scrollRatioXY = (e->pixelDelta().isNull() || isX11) ? e->angleDelta().toPointF() / 8. / 360.
+                                                                      : e->pixelDelta().toPointF() * pixelStep;
+
+    // If Alt is pressed, Qt swaps scroll axis: undo it because we use alt to change scale
+    double scrollRatio = e->modifiers().testFlag(Qt::AltModifier) ? scrollRatioXY.x() : scrollRatioXY.y();
 
     // note: on some platforms (x11, wayland) "natural scrolling" is not detectable: inverted() returns always false
     if (e->inverted())

--- a/QtCollider/widgets/QcKnob.hpp
+++ b/QtCollider/widgets/QcKnob.hpp
@@ -61,6 +61,7 @@ protected:
     virtual void mousePressEvent(QMouseEvent*);
     virtual void mouseMoveEvent(QMouseEvent*);
     virtual void paintEvent(QPaintEvent*);
+    virtual void wheelEvent(QWheelEvent*);
 
 private:
     double value(const QPoint&);
@@ -70,4 +71,5 @@ private:
     int _mode;
     QPoint _prevPos;
     bool _centered;
+    double scrollRemainder;
 };

--- a/QtCollider/widgets/QcNumberBox.cpp
+++ b/QtCollider/widgets/QcNumberBox.cpp
@@ -312,7 +312,9 @@ void QcNumberBox::mouseMoveEvent(QMouseEvent* event) {
 
 void QcNumberBox::wheelEvent(QWheelEvent* event) {
     if (scroll && isReadOnly() && _valueType == Number) {
-        double delta = event->angleDelta().y() / 120.f;
+        // If Alt is pressed, Qt swaps scroll axis: undo it because we use alt to change scale
+        double delta = event->modifiers().testFlag(Qt::AltModifier) ? event->angleDelta().x() : event->angleDelta().y();
+        delta /= 120.;
         if (event->inverted())
             delta *= -1.;
         scrollRemainder = std::modf(delta + scrollRemainder, &delta);

--- a/QtCollider/widgets/QcNumberBox.cpp
+++ b/QtCollider/widgets/QcNumberBox.cpp
@@ -310,11 +310,9 @@ void QcNumberBox::mouseMoveEvent(QMouseEvent* event) {
 }
 
 void QcNumberBox::wheelEvent(QWheelEvent* event) {
-    if (scroll && isReadOnly() && _valueType == Number && event->angleDelta().x()) {
-        const QPointF delta = event->pixelDelta().isNull()
-            ? event->angleDelta() / 8.f // scaled to return steps of 15
-            : event->pixelDelta() * 0.25f; // this matches old scaling of delta
-        stepBy(delta.x() > 0 ? 1 : -1, scrollStep);
+    const auto delta = event->angleDelta().y();
+    if (scroll && isReadOnly() && _valueType == Number && delta != 0) {
+        stepBy(delta > 0 ? 1 : -1, scrollStep);
         Q_EMIT(action());
     }
 }

--- a/QtCollider/widgets/QcNumberBox.cpp
+++ b/QtCollider/widgets/QcNumberBox.cpp
@@ -27,6 +27,7 @@
 #include <QMouseEvent>
 #include <QApplication>
 
+#include <cmath>
 #include <math.h>
 #include <qmath.h>
 
@@ -310,10 +311,15 @@ void QcNumberBox::mouseMoveEvent(QMouseEvent* event) {
 }
 
 void QcNumberBox::wheelEvent(QWheelEvent* event) {
-    const auto delta = event->angleDelta().y();
-    if (scroll && isReadOnly() && _valueType == Number && delta != 0) {
-        stepBy(delta > 0 ? 1 : -1, scrollStep);
-        Q_EMIT(action());
+    if (scroll && isReadOnly() && _valueType == Number) {
+        double delta = event->angleDelta().y() / 120.f;
+        if (event->inverted())
+            delta *= -1.;
+        scrollRemainder = std::modf(delta + scrollRemainder, &delta);
+        if (delta > 0. || delta < 0) {
+            stepBy(delta, scrollStep);
+            Q_EMIT(action());
+        }
     }
 }
 

--- a/QtCollider/widgets/QcNumberBox.cpp
+++ b/QtCollider/widgets/QcNumberBox.cpp
@@ -312,11 +312,7 @@ void QcNumberBox::mouseMoveEvent(QMouseEvent* event) {
 
 void QcNumberBox::wheelEvent(QWheelEvent* event) {
     if (scroll && isReadOnly() && _valueType == Number) {
-        // If Alt is pressed, Qt swaps scroll axis: undo it because we use alt to change scale
-        double delta = event->modifiers().testFlag(Qt::AltModifier) ? event->angleDelta().x() : event->angleDelta().y();
-        delta /= 120.;
-        if (event->inverted())
-            delta *= -1.;
+        double delta = getNormalizedScrollRatio(event, 0).y() * 3.;
         scrollRemainder = std::modf(delta + scrollRemainder, &delta);
         if (delta > 0. || delta < 0) {
             stepBy(delta, scrollStep);

--- a/QtCollider/widgets/QcNumberBox.cpp
+++ b/QtCollider/widgets/QcNumberBox.cpp
@@ -312,7 +312,7 @@ void QcNumberBox::mouseMoveEvent(QMouseEvent* event) {
 
 void QcNumberBox::wheelEvent(QWheelEvent* event) {
     if (scroll && isReadOnly() && _valueType == Number) {
-        double delta = getNormalizedScrollRatio(event, 0).y() * 3.;
+        double delta = getScrollSteps(event).y();
         scrollRemainder = std::modf(delta + scrollRemainder, &delta);
         if (delta > 0. || delta < 0) {
             stepBy(delta, scrollStep);

--- a/QtCollider/widgets/QcNumberBox.h
+++ b/QtCollider/widgets/QcNumberBox.h
@@ -117,6 +117,8 @@ private:
     ValueType _valueType;
     int _minDec;
     int _maxDec;
+
+    double scrollRemainder;
 };
 
 #if 0

--- a/QtCollider/widgets/QcSlider.cpp
+++ b/QtCollider/widgets/QcSlider.cpp
@@ -21,6 +21,7 @@
 
 #include "QcSlider.h"
 #include "../QcWidgetFactory.h"
+#include "widgets/QcAbstractStepValue.h"
 
 #include <QMouseEvent>
 #include <QKeyEvent>
@@ -115,19 +116,8 @@ void QcSlider::mouseMoveEvent(QMouseEvent* e) {
 
 void QcSlider::wheelEvent(QWheelEvent* e) {
     double step = qMax(_step, pixelStep());
-    // use angleDelta for X11 (advice from Qt docs)
-    const bool isX11 = QGuiApplication::platformName() == "xcb";
-    // angleDelta: relative to 360deg; pixelDelta: relative to widget size
-    const QPointF scrollRatioXY = (e->pixelDelta().isNull() || isX11) ? e->angleDelta().toPointF() / 8. / 360.
-                                                                      : e->pixelDelta().toPointF() * pixelStep();
 
-    // If Alt is pressed, Qt swaps scroll axis: undo it because we use alt to change scale
-    double scrollRatio = e->modifiers().testFlag(Qt::AltModifier) ? scrollRatioXY.x() : scrollRatioXY.y();
-
-    // note: on some platforms (x11, wayland) "natural scrolling" is not detectable: inverted() returns always false
-    if (e->inverted())
-        scrollRatio *= -1;
-
+    const double scrollRatio = getNormalizedScrollRatio(e, pixelStep()).y();
     // convert ratio to number of steps (totSteps = 1/step)
     double numSteps = scrollRatio / step;
     modifyStep(&step);

--- a/QtCollider/widgets/QcSlider.cpp
+++ b/QtCollider/widgets/QcSlider.cpp
@@ -114,9 +114,10 @@ void QcSlider::mouseMoveEvent(QMouseEvent* e) {
 void QcSlider::wheelEvent(QWheelEvent* e) {
     double step = qMax(_step, pixelStep());
     modifyStep(&step);
-    const auto deltaX = e->pixelDelta().isNull() ? e->angleDelta().y() / 8.f : e->pixelDelta().y();
-    double dval = deltaX / 120.0 * step;
+    const double scrollSteps = e->pixelDelta().isNull() ? e->angleDelta().y() / 120.0 : e->pixelDelta().y();
+    double dval = scrollSteps * step;
     setValue(_value + dval);
+
     Q_EMIT(action());
 }
 

--- a/QtCollider/widgets/QcSlider.cpp
+++ b/QtCollider/widgets/QcSlider.cpp
@@ -21,12 +21,10 @@
 
 #include "QcSlider.h"
 #include "../QcWidgetFactory.h"
-#include "widgets/QcAbstractStepValue.h"
 
 #include <QMouseEvent>
 #include <QKeyEvent>
 #include <QWheelEvent>
-#include <qnamespace.h>
 
 QC_DECLARE_QWIDGET_FACTORY(QcSlider);
 

--- a/QtCollider/widgets/QcSlider.cpp
+++ b/QtCollider/widgets/QcSlider.cpp
@@ -116,10 +116,7 @@ void QcSlider::mouseMoveEvent(QMouseEvent* e) {
 
 void QcSlider::wheelEvent(QWheelEvent* e) {
     double step = qMax(_step, pixelStep());
-
-    const double scrollRatio = getNormalizedScrollRatio(e, pixelStep()).y();
-    // convert ratio to number of steps (totSteps = 1/step)
-    double numSteps = scrollRatio / step;
+    double numSteps = getScrollSteps(e).y();
     modifyStep(&step);
     // accumulate fractional numSteps to help scrolling through big steps
     scrollRemainder = std::modf(numSteps + scrollRemainder, &numSteps);

--- a/QtCollider/widgets/QcSlider.cpp
+++ b/QtCollider/widgets/QcSlider.cpp
@@ -111,13 +111,25 @@ void QcSlider::mouseMoveEvent(QMouseEvent* e) {
     Q_EMIT(action());
 }
 
+
 void QcSlider::wheelEvent(QWheelEvent* e) {
     double step = qMax(_step, pixelStep());
-    modifyStep(&step);
-    const double scrollSteps = e->pixelDelta().isNull() ? e->angleDelta().y() / 120.0 : e->pixelDelta().y();
-    double dval = scrollSteps * step;
-    setValue(_value + dval);
+    // use angleDelta for X11 (advice from Qt docs)
+    const bool isX11 = QGuiApplication::platformName() == "xcb";
+    // angleDelta: relative to 360deg; pixelDelta: relative to widget size
+    double scrollRatio =
+        (e->pixelDelta().isNull() || isX11) ? e->angleDelta().y() / 8. / 360. : e->pixelDelta().y() * pixelStep();
 
+    // note: on some platforms (x11, wayland) "natural scrolling" is not detectable: inverted() returns always false
+    if (e->inverted())
+        scrollRatio *= -1;
+
+    // convert ratio to number of steps (totSteps = 1/step)
+    double numSteps = scrollRatio / step;
+    modifyStep(&step);
+    // accumulate fractional numSteps to help scrolling through big steps
+    scrollRemainder = std::modf(numSteps + scrollRemainder, &numSteps);
+    setValue(_value + numSteps * step);
     Q_EMIT(action());
 }
 

--- a/QtCollider/widgets/QcSlider.cpp
+++ b/QtCollider/widgets/QcSlider.cpp
@@ -25,6 +25,7 @@
 #include <QMouseEvent>
 #include <QKeyEvent>
 #include <QWheelEvent>
+#include <qnamespace.h>
 
 QC_DECLARE_QWIDGET_FACTORY(QcSlider);
 
@@ -117,8 +118,11 @@ void QcSlider::wheelEvent(QWheelEvent* e) {
     // use angleDelta for X11 (advice from Qt docs)
     const bool isX11 = QGuiApplication::platformName() == "xcb";
     // angleDelta: relative to 360deg; pixelDelta: relative to widget size
-    double scrollRatio =
-        (e->pixelDelta().isNull() || isX11) ? e->angleDelta().y() / 8. / 360. : e->pixelDelta().y() * pixelStep();
+    const QPointF scrollRatioXY = (e->pixelDelta().isNull() || isX11) ? e->angleDelta().toPointF() / 8. / 360.
+                                                                      : e->pixelDelta().toPointF() * pixelStep();
+
+    // If Alt is pressed, Qt swaps scroll axis: undo it because we use alt to change scale
+    double scrollRatio = e->modifiers().testFlag(Qt::AltModifier) ? scrollRatioXY.x() : scrollRatioXY.y();
 
     // note: on some platforms (x11, wayland) "natural scrolling" is not detectable: inverted() returns always false
     if (e->inverted())

--- a/QtCollider/widgets/QcSlider.h
+++ b/QtCollider/widgets/QcSlider.h
@@ -95,4 +95,5 @@ private:
     int _hndLen;
 
     QColor _knobColor;
+    double scrollRemainder;
 };

--- a/QtCollider/widgets/QcSlider2D.cpp
+++ b/QtCollider/widgets/QcSlider2D.cpp
@@ -86,18 +86,14 @@ void QcSlider2D::wheelEvent(QWheelEvent* e) {
 
     double stepX = qMax(_step, pxStep.width());
     double stepY = qMax(_step, pxStep.height());
-
-    double scrollRatioX, scrollRatioY;
-    const auto scrollRatio = getNormalizedScrollRatio(e, pxStep);
-    // convert ratio to number of steps (totSteps = 1/step)
-    QSizeF numSteps(scrollRatio.x() / stepX, scrollRatio.y() / stepY);
+    QPointF numSteps = getScrollSteps(e);
     modifyStep(&stepX);
     modifyStep(&stepY);
+
     // accumulate fractional numSteps to help scrolling through big steps
-    numSteps += scrollRemainder;
-    double dx, dy;
-    scrollRemainder.setWidth(std::modf(numSteps.width(), &dx));
-    scrollRemainder.setHeight(std::modf(numSteps.height(), &dy));
+    double dx = numSteps.x(), dy = numSteps.y();
+    scrollRemainder.setWidth(std::modf(dx + scrollRemainder.width(), &dx));
+    scrollRemainder.setHeight(std::modf(dy + scrollRemainder.height(), &dy));
 
     QPointF newValue(_x + dx * stepX, _y + dy * stepY);
     setValue(newValue);

--- a/QtCollider/widgets/QcSlider2D.cpp
+++ b/QtCollider/widgets/QcSlider2D.cpp
@@ -78,21 +78,15 @@ void QcSlider2D::mousePressEvent(QMouseEvent* ev) {
     setValue(val);
 }
 
-QSizeF QcSlider2D::pixelStep() const {
-    using namespace QtCollider::Style;
-
-    QRect contRect(sunkenContentsRect(rect()));
-
-    QSizeF range(contRect.width(), contRect.height());
-    range -= _thumbSize;
-
-    return QSizeF(range.width() > 0 ? 1 / range.width() : 0, range.height() > 0 ? 1 / range.height() : 0);
-}
-
 void QcSlider2D::wheelEvent(QWheelEvent* e) {
-    const QSizeF pxStep = pixelStep();
+    const QRect contRect(QtCollider::Style::sunkenContentsRect(rect()));
+    const auto range = QSizeF(contRect.width(), contRect.height()) - _thumbSize;
+    const QSizeF pxStep =
+        QSizeF(range.width() > 0 ? 1. / range.width() : 0, range.height() > 0 ? 1. / range.height() : 0);
+
     double stepX = qMax(_step, pxStep.width());
     double stepY = qMax(_step, pxStep.height());
+
     double scrollRatioX, scrollRatioY;
     const auto scrollRatio = getNormalizedScrollRatio(e, pxStep);
     // convert ratio to number of steps (totSteps = 1/step)

--- a/QtCollider/widgets/QcSlider2D.cpp
+++ b/QtCollider/widgets/QcSlider2D.cpp
@@ -22,7 +22,6 @@
 #include "QcSlider2D.h"
 #include "../QcWidgetFactory.h"
 #include "../style/routines.hpp"
-#include "widgets/QcAbstractStepValue.h"
 
 #include <QKeyEvent>
 #include <QMouseEvent>

--- a/QtCollider/widgets/QcSlider2D.cpp
+++ b/QtCollider/widgets/QcSlider2D.cpp
@@ -105,6 +105,13 @@ void QcSlider2D::wheelEvent(QWheelEvent* e) {
         scrollRatioY = e->pixelDelta().y() * pxStep.height();
     }
 
+    // If Alt is pressed, Qt swaps scroll axis: undo it because we use alt to change scale
+    if (e->modifiers().testFlag(Qt::AltModifier)) {
+        const auto tmp = scrollRatioX;
+        scrollRatioX = scrollRatioY;
+        scrollRatioY = tmp;
+    }
+
     if (e->inverted()) {
         scrollRatioY *= -1;
     } else {

--- a/QtCollider/widgets/QcSlider2D.h
+++ b/QtCollider/widgets/QcSlider2D.h
@@ -95,6 +95,5 @@ private:
     QColor _knobColor;
     QtCollider::ImagePainter _backgroundImage;
 
-    QSizeF pixelStep() const;
     QSizeF scrollRemainder;
 };

--- a/QtCollider/widgets/QcSlider2D.h
+++ b/QtCollider/widgets/QcSlider2D.h
@@ -83,6 +83,7 @@ private:
     void setValue(const QPointF val, bool doAction = true);
     void mouseMoveEvent(QMouseEvent*);
     void mousePressEvent(QMouseEvent*);
+    void wheelEvent(QWheelEvent*);
     void keyPressEvent(QKeyEvent*);
     void paintEvent(QPaintEvent*);
 
@@ -93,4 +94,7 @@ private:
 
     QColor _knobColor;
     QtCollider::ImagePainter _backgroundImage;
+
+    QSizeF pixelStep() const;
+    QSizeF scrollRemainder;
 };

--- a/editors/sc-ide/widgets/audio_status_box.cpp
+++ b/editors/sc-ide/widgets/audio_status_box.cpp
@@ -24,6 +24,7 @@
 #include <QHBoxLayout>
 #include <QWheelEvent>
 
+#include "QtCollider/widgets/QcAbstractStepValue.h"
 #include "main.hpp"
 
 namespace ScIDE {
@@ -138,7 +139,7 @@ void AudioStatusBox::onServerRunningChanged(bool running, const QString&, int, b
 
 void AudioStatusBox::wheelEvent(QWheelEvent* event) {
     // If Alt is pressed, Qt swaps scroll axis: undo it because we use alt to change scale
-    double delta = event->modifiers().testFlag(Qt::AltModifier) ? event->angleDelta().x() : event->angleDelta().y();
+    const double delta = getNormalizedScrollRatio(event, 0).y();
     if (delta) {
         if (delta > 0 || event->inverted())
             emit increaseVolume();

--- a/editors/sc-ide/widgets/audio_status_box.cpp
+++ b/editors/sc-ide/widgets/audio_status_box.cpp
@@ -138,7 +138,7 @@ void AudioStatusBox::onServerRunningChanged(bool running, const QString&, int, b
 
 void AudioStatusBox::wheelEvent(QWheelEvent* event) {
     if (!event->angleDelta().isNull()) {
-        if (event->angleDelta().y() > 0)
+        if (event->angleDelta().y() > 0 || event->inverted())
             emit increaseVolume();
         else
             emit decreaseVolume();

--- a/editors/sc-ide/widgets/audio_status_box.cpp
+++ b/editors/sc-ide/widgets/audio_status_box.cpp
@@ -141,7 +141,7 @@ void AudioStatusBox::wheelEvent(QWheelEvent* event) {
     // If Alt is pressed, Qt swaps scroll axis: undo it because we use alt to change scale
     const double delta = getNormalizedScrollRatio(event, 0).y();
     if (delta) {
-        if (delta > 0 || event->inverted())
+        if (delta > 0)
             emit increaseVolume();
         else
             emit decreaseVolume();

--- a/editors/sc-ide/widgets/audio_status_box.cpp
+++ b/editors/sc-ide/widgets/audio_status_box.cpp
@@ -139,7 +139,7 @@ void AudioStatusBox::onServerRunningChanged(bool running, const QString&, int, b
 
 void AudioStatusBox::wheelEvent(QWheelEvent* event) {
     // If Alt is pressed, Qt swaps scroll axis: undo it because we use alt to change scale
-    const double delta = getNormalizedScrollRatio(event, 0).y();
+    const double delta = getScrollSteps(event).y();
     if (delta) {
         if (delta > 0)
             emit increaseVolume();

--- a/editors/sc-ide/widgets/audio_status_box.cpp
+++ b/editors/sc-ide/widgets/audio_status_box.cpp
@@ -138,7 +138,7 @@ void AudioStatusBox::onServerRunningChanged(bool running, const QString&, int, b
 
 void AudioStatusBox::wheelEvent(QWheelEvent* event) {
     if (!event->angleDelta().isNull()) {
-        if (event->angleDelta().x() > 0)
+        if (event->angleDelta().y() > 0)
             emit increaseVolume();
         else
             emit decreaseVolume();

--- a/editors/sc-ide/widgets/audio_status_box.cpp
+++ b/editors/sc-ide/widgets/audio_status_box.cpp
@@ -137,8 +137,10 @@ void AudioStatusBox::onServerRunningChanged(bool running, const QString&, int, b
 }
 
 void AudioStatusBox::wheelEvent(QWheelEvent* event) {
-    if (!event->angleDelta().isNull()) {
-        if (event->angleDelta().y() > 0 || event->inverted())
+    // If Alt is pressed, Qt swaps scroll axis: undo it because we use alt to change scale
+    double delta = event->modifiers().testFlag(Qt::AltModifier) ? event->angleDelta().x() : event->angleDelta().y();
+    if (delta) {
+        if (delta > 0 || event->inverted())
             emit increaseVolume();
         else
             emit decreaseVolume();


### PR DESCRIPTION
## Purpose and Motivation

Fixes #7008

When migrating from deprecated .delta() to .angleDelta()/.pixelDelta() (9d10e196ce263faff1f9951d0db012a948ffbc87)
there were some errors in scaling the delta values, and some probably typos turning vertical scaling to horizontal.

`angleDelta()` is a direct translation of the old deprecated `delta()`, so I think we could skip checking for `pixelDelta()` in widgets like QcSlider and just use `angleDelta()`, to get the old behavior back. I'm not sure if using pixelDelta gives any better precision/smoothness in this case. However, for now I've kept also `pixelDelta`, and changed it's scaling to a value that gives me the same feel as angleDelta (and as in 3.13).

Can someone on a mac try it and report how does scrolling feel between this PR, 3.13 and 3.14-rc1? For me on linux (X11/Wayland) it's now the same across all versions.

While at it, I also added support for wheelEvent in other widgets. Full list of affected widgets:
- QcSlider: adjusted
- QcNumberBox: adjusted
- ScIDE AudioStatusBox (accepts scrolling for adjusting server volume): adjusted
- QcSlider2D: added
- QcKnob: added

Note: this is not about Qt6, as .angleDelta and .pixelDelta were introduced in Qt5, and .delta was deprecated already then

## Types of changes

- Bug fix

## To-do list

- [ ] Code is tested
- [ ] All tests are passing
- [ ] Updated documentation
- [ ] This PR is ready for review

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
