### PR TITLE
Docs: Tour of Special Functions (Boost) clarify what kind of functions, change category to math

### DIFF
--- a/HelpSource/Guides/Tour-of-Special-Functions.schelp
+++ b/HelpSource/Guides/Tour-of-Special-Functions.schelp
@@ -1,20 +1,20 @@
-TITLE:: Tour of Special Functions
+TITLE:: Tour of Special Mathematical Functions (Boost library)
 SUMMARY:: Examples and plots for Boost Special Functions
-CATEGORIES:: Guides
+CATEGORIES:: Math
 related:: Classes/SimpleNumber
 KEYWORD:: special functions, boost
 
+section:: Boost library Special Functions: usage, bounds and plots
 
-DESCRIPTION:: Special Functions supplied by the Boost library — usage, bounds and plots.
-
+Supercollider provides an array of special mathematical functions (e.g., Bessel, Chebyshev, etc.) as supplied by the Boost library. 
 The library's LINK::http://www.boost.org/doc/libs/1_66_0/libs/math/doc/html/special.html##online documentation::
- serves as the primary reference for the following functions.
+serves as the primary reference for the following functions.
 
-Many of the functions are only valid in certain numerical ranges. The following tour will
-show you plots that illustrate the behavior of the functions, their ranges and asymptotes.
+Many of the functions are only valid in certain numerical ranges. 
+The following tour will show you plots that illustrate the behavior of the functions, their ranges and asymptotes.
 
-Define the plotting functions in the next section, then you can use the Table of Contents
-menu to jump between function families.
+Define the plotting functions in the next section, 
+then you can use the Table of Contents menu to jump between function families.
 
 SECTION:: Before you get started...
 


### PR DESCRIPTION
Before this commit, the "guide" category had exactly 1 member: This file.
So in terms of overall organization it makes more sense to move this to another category: I chose "math".

I also added some more words to make it more apparent to folks that don't already know what the boost library is what _kind_ of functions these are (namely, math functions as opposed to functions in computer programming).
(I just realized that something like "special functions in math" is probably better than "special mathematical functions", will edit accordingly)

## Purpose and Motivation

yes please, give me Purpose and Motivation

## Types of changes


- Documentation

