### PR TITLE
Increase font size of status box

### DIFF
--- a/editors/sc-ide/widgets/util/status_box.cpp
+++ b/editors/sc-ide/widgets/util/status_box.cpp
@@ -19,6 +19,8 @@
 */
 
 #include "status_box.hpp"
+
+#include <QApplication>
 #include <QtGui/qfontdatabase.h>
 
 namespace ScIDE {
@@ -31,7 +33,7 @@ StatusLabel::StatusLabel(QWidget* parent): QLabel(parent) {
     setTextColor(Qt::white);
 
     QFont font = QFontDatabase::systemFont(QFontDatabase::FixedFont);
-    font.setPointSize(font.pointSize() + 3);
+    font.setPointSizeF(QApplication::font().pointSizeF());
     font.setStyleHint(QFont::Monospace);
     font.setBold(true);
     setFont(font);

--- a/editors/sc-ide/widgets/util/status_box.cpp
+++ b/editors/sc-ide/widgets/util/status_box.cpp
@@ -31,7 +31,7 @@ StatusLabel::StatusLabel(QWidget* parent): QLabel(parent) {
     setTextColor(Qt::white);
 
     QFont font = QFontDatabase::systemFont(QFontDatabase::FixedFont);
-    font.setPointSize(font.pointSize());
+    font.setPointSize(font.pointSize() + 3);
     font.setStyleHint(QFont::Monospace);
     font.setBold(true);
     setFont(font);


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

Regression of #6329 - restores font size of 3.13.

Left side 3.14-rc1, right side w/ applied fix. I don't know why #6329 changed the font size, and this needs some multi-platform testing in order to verify that everything works as expected. Should be part of 3.14 IMO, therefore it targets this as well.
I am somehow unhappy with hardcoding numbers, but I don't know what to do about it otherwise.

![image](https://github.com/user-attachments/assets/9c533164-05d6-4daa-bee7-7f0c8e877392)


## Types of changes

<!-- Delete lines that don't apply -->
- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [ ] Code is tested
- [ ] All tests are passing
- [ ] Updated documentation
- [ ] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
