### PR TITLE
IDE: don't call resize(0, 0) on completion widget

### DIFF
--- a/editors/sc-ide/widgets/code_editor/completion_menu.cpp
+++ b/editors/sc-ide/widgets/code_editor/completion_menu.cpp
@@ -58,10 +58,7 @@ CompletionMenu::CompletionMenu(QWidget* parent): PopUpWidget(parent), mCompletio
 
 void CompletionMenu::addItem(QStandardItem* item) { mModel->appendRow(item); }
 
-void CompletionMenu::adapt() {
-    mListView->setFixedWidth(mListView->sizeHintForColumn(0));
-    resize(0, 0);
-}
+void CompletionMenu::adapt() { mListView->setFixedWidth(mListView->sizeHintForColumn(0)); }
 
 void CompletionMenu::addInfo(QString info) {
     mTextBrowser->setText(info);

--- a/editors/sc-ide/widgets/code_editor/completion_menu.cpp
+++ b/editors/sc-ide/widgets/code_editor/completion_menu.cpp
@@ -58,7 +58,10 @@ CompletionMenu::CompletionMenu(QWidget* parent): PopUpWidget(parent), mCompletio
 
 void CompletionMenu::addItem(QStandardItem* item) { mModel->appendRow(item); }
 
-void CompletionMenu::adapt() { mListView->setFixedWidth(mListView->sizeHintForColumn(0)); }
+void CompletionMenu::adapt() {
+    mListView->setFixedWidth(mListView->sizeHintForColumn(0));
+    adjustSize();
+}
 
 void CompletionMenu::addInfo(QString info) {
     mTextBrowser->setText(info);


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

Fixes #7007, according to a [user report](https://github.com/supercollider/supercollider/issues/7007#issuecomment-3049095148).

But... what does it break instead?

This is a somewhat blind attempt at fixing a crash on Wayland with multiple displays (see #7007 for bug description).

I don't know what was the purpose of `resize(0, 0)` in the first place though. For reference it was introduced in  https://github.com/supercollider/supercollider/commit/7f2db98b85e0cbdda03a55d6beb0ec8166e2ab39 as part of https://github.com/supercollider/supercollider/pull/1333. On the surface the autocomplete hints still show as they have before this PR, as far as I can tell...

I'd appreciate if others could test to make sure this doesn't break any functionality!

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [ ] Code is tested
- [ ] All tests are passing
- [ ] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
