### PR TITLE
Server: Add /g_dumpTree end delimiter

### DIFF
--- a/server/scsynth/SC_Group.cpp
+++ b/server/scsynth/SC_Group.cpp
@@ -107,6 +107,8 @@ void Group_DumpNodeTree(Group* inGroup) {
         child = next;
     }
     tabCount--;
+    if (tabCount == 0)
+        scprintf("END NODE TREE Group %d\n", inGroup->mNode.mID);
 }
 
 void Group_DumpNodeTreeAndControls(Group* inGroup) {
@@ -179,6 +181,8 @@ void Group_DumpNodeTreeAndControls(Group* inGroup) {
         child = next;
     }
     tabCount--;
+    if (tabCount == 0)
+        scprintf("END NODE TREE Group %d\n", inGroup->mNode.mID);
 }
 
 void Group_CalcDumpTree(Group* inGroup) {

--- a/server/supernova/sc/sc_osc_handler.cpp
+++ b/server/supernova/sc/sc_osc_handler.cpp
@@ -1473,6 +1473,7 @@ void g_dump_tree(int id, bool flag) {
     stream << "NODE TREE Group " << id << std::endl;
 
     g_dump_node(stream, *node, flag, 1);
+    stream << "END NODE TREE Group " << id << std::endl;
     log(stream.str().c_str(), stream.str().size());
 }
 


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

It's well known that large node trees can overflow `/g_queryTree` OSC packets. An alternative approach to gathering the complete node tree output is to read it from the server process's stdout. However, there's no way to know _explicitly_ when the output has completed. One can attempt contrived methods of guaranteeing completion: sleeping, dumping the node tree twice, trying to sync, etc. But the simplest means of knowing the dump has completed is to just add an end delimiter to the output.

This PR adds an `END NODE TREE Group {node id}` message to the server output as the final line of `/g_dumpTree` output for both `scsynth` and `supernova`.

PS: Why do I want the node tree output? I use when unit-testing changes to complex server setups.

## Types of changes

- New feature

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [ ] Code is tested
- [ ] All tests are passing
- [ ] Updated documentation
- [ ] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
