### PR TITLE
Insert an empty line after server boot

### DIFF
--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -966,6 +966,7 @@ Server {
 		statusWatcher.doWhenBooted({
 			statusWatcher.serverBooting = false;
 			this.bootInit(recover);
+			"".postln;
 		}, onFailure: onFailure ? false);
 
 		if(remoteControlled) {


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation
Currently, the SCDoc message `SCDoc: Indexing help-files...` appears without an empty line before it and is not bold, which makes the sequence of post window messages harder to read:
```
Booting server 'localhost' on address 127.0.0.1:57110.

Device options:
- MME : Microsoft 사운드 매퍼 - Input
  (2 ins, 0 outs)
- MME : Microphone(High Definition Audi
  (2 ins, 0 outs)
- MME : Microsoft 사운드 매퍼 - Output
  (0 ins, 2 outs)
- MME : Speakers(High Definition Audio 
  (0 ins, 8 outs)
- Windows DirectSound : 주 사운드 캡처 드라이버
  (2 ins, 0 outs)
- Windows DirectSound : Microphone(High Definition Audio Device)
  (2 ins, 0 outs)
- Windows DirectSound : 주 사운드 드라이버
  (0 ins, 2 outs)
- Windows DirectSound : Speakers(High Definition Audio Device)
  (0 ins, 8 outs)
- ASIO : Magix Low Latency 2016
  (2 ins, 8 outs)
- ASIO : ReaRoute ASIO (x64)
  (16 ins, 16 outs)
- Windows WASAPI : Speakers(High Definition Audio Device)
  (0 ins, 2 outs)
- Windows WASAPI : Microphone(High Definition Audio Device)
  (2 ins, 0 outs)
- Windows WDM-KS : Microphone (HD Audio Microphone)
  (2 ins, 0 outs)
- Windows WDM-KS : Speakers (HD Audio Speaker)
  (0 ins, 8 outs)

Requested devices:
  In:
  - (default)
  Out:
  - (default)

Selecting default system input/output devices

Booting with:
  In: Windows WASAPI : Microphone(High Definition Audio Device)
  Out: Windows WASAPI : Speakers(High Definition Audio Device)
  Sample rate: 48000.000
  Latency (in/out): 0.022 / 0.024 sec
SC_AudioDriver: sample rate = 48000.000000, driver's block size = 64
SuperCollider 3 server ready.
Requested notification messages from server 'localhost'
localhost: server process's maxLogins (1) matches with my options.
localhost: keeping clientID (0) as confirmed by server process.
Shared memory server interface initialized
SCDoc: Indexing help-files...
SCDoc: Indexed 1380 documents in 1.64 seconds
```
With this PR, the message will be updated as follows:
```
Booting server 'localhost' on address 127.0.0.1:57110.

Device options:
- MME : Microsoft 사운드 매퍼 - Input
  (2 ins, 0 outs)
- MME : Microphone(High Definition Audi
  (2 ins, 0 outs)
- MME : Microsoft 사운드 매퍼 - Output
  (0 ins, 2 outs)
- MME : Speakers(High Definition Audio 
  (0 ins, 8 outs)
- Windows DirectSound : 주 사운드 캡처 드라이버
  (2 ins, 0 outs)
- Windows DirectSound : Microphone(High Definition Audio Device)
  (2 ins, 0 outs)
- Windows DirectSound : 주 사운드 드라이버
  (0 ins, 2 outs)
- Windows DirectSound : Speakers(High Definition Audio Device)
  (0 ins, 8 outs)
- ASIO : Magix Low Latency 2016
  (2 ins, 8 outs)
- ASIO : ReaRoute ASIO (x64)
  (16 ins, 16 outs)
- Windows WASAPI : Speakers(High Definition Audio Device)
  (0 ins, 2 outs)
- Windows WASAPI : Microphone(High Definition Audio Device)
  (2 ins, 0 outs)
- Windows WDM-KS : Microphone (HD Audio Microphone)
  (2 ins, 0 outs)
- Windows WDM-KS : Speakers (HD Audio Speaker)
  (0 ins, 8 outs)

Requested devices:
  In:
  - (default)
  Out:
  - (default)

Selecting default system input/output devices

Booting with:
  In: Windows WASAPI : Microphone(High Definition Audio Device)
  Out: Windows WASAPI : Speakers(High Definition Audio Device)
  Sample rate: 48000.000
  Latency (in/out): 0.022 / 0.024 sec
SC_AudioDriver: sample rate = 48000.000000, driver's block size = 64
SuperCollider 3 server ready.
Requested notification messages from server 'localhost'
localhost: server process's maxLogins (1) matches with my options.
localhost: keeping clientID (0) as confirmed by server process.
Shared memory server interface initialized

*** SCDoc: Indexing help-files...
SCDoc: Indexed 1380 documents in 1.64 seconds
```
Please note that the line beginning with `***` renders the text in bold style.

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->

- New feature

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
