### PR TITLE
scide: remove explicit window reactivations post-open/save dialogs

### DIFF
--- a/editors/sc-ide/widgets/main_window.cpp
+++ b/editors/sc-ide/widgets/main_window.cpp
@@ -995,22 +995,9 @@ bool MainWindow::save(Document* doc, bool forceChoose, bool saveInExtensionFolde
             // filepath with added suffix already exists!
         }
 
-#ifdef Q_OS_MAC
-        QWidget* last_active_window = QApplication::activeWindow();
-#endif
-
-        int result = dialog.exec();
-
-        // FIXME: workaround for Qt bug 25295
-        // See SC issue #678
-#ifdef Q_OS_MAC
-        if (last_active_window)
-            last_active_window->activateWindow();
-#endif
-
         QString save_path;
 
-        if (result == QDialog::Accepted) {
+        if (dialog.exec() == QDialog::Accepted) {
             save_path = dialog.selectedFiles()[0];
 
             if (save_path.indexOf('.') == -1 && !QFile::exists(save_path)) {
@@ -1079,22 +1066,11 @@ void MainWindow::openDocument() {
     filters << tr("All Files (*)") << tr("SuperCollider (*.scd *.sc)") << tr("SuperCollider Help Source (*.schelp)");
     dialog.setNameFilters(filters);
 
-#ifdef Q_OS_MAC
-    QWidget* last_active_window = QApplication::activeWindow();
-#endif
-
     if (dialog.exec()) {
         QStringList filenames = dialog.selectedFiles();
         foreach (QString filename, filenames)
             mMain->documentManager()->open(filename);
     }
-
-    // FIXME: workaround for Qt bug 25295
-    // See SC issue #678
-#ifdef Q_OS_MAC
-    if (last_active_window)
-        last_active_window->activateWindow();
-#endif
 }
 
 void MainWindow::restoreDocuments() {


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

Just noticed this while going through `main_window.cpp`—two todo comments reference a now-fixed (as of Qt 5.1, putatively) issue pertaining to focusing/window activation on macOS. 

This change essentially reverts 52e76de—tested this on Qt 6 and there is no difference w.r.t window focusing with/without the code. (Both exhibit the desired behavior—the main window refocuses after the open/save dialog closes.)

Link to the pertinent Qt bug report: https://bugreports.qt.io/browse/QTBUG-25295.

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

- Cleanup

## To-do list

- [x] Code is tested
- [x] This PR is ready for review 
