### PR TITLE
sclang / qt: fix positioning of non-resizable windows.

### DIFF
--- a/QtCollider/widgets/QcWindow.cpp
+++ b/QtCollider/widgets/QcWindow.cpp
@@ -61,10 +61,9 @@ static void qcInitWindow(QWidget* window, const QString& title, const QRectF& ge
         geom.setSize(window->sizeHint());
     }
 
-    if (resizable) {
-        window->setGeometry(geom);
-    } else {
-        window->move(geom.topLeft());
+    window->setGeometry(geom);
+
+    if (!resizable) {
         window->setFixedSize(geom.size());
     }
 


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

Fix positioning of non-resizable windows.

Test:
```supercollider
Window("resizable", Rect(100, 100, 300, 300), true).front;
Window("not resizable", Rect(400, 100, 300, 300), false).front;
```

Before:
<img width="659" height="390" alt="468408545-bad93bf4-6ecc-4810-9c2f-abf5c9e3f54e" src="https://github.com/user-attachments/assets/28b3147f-dc16-4b8d-87c6-7776573a52f5" />

After:
<img width="635" height="356" alt="Screenshot 2025-07-20 at 12 50 46 PM" src="https://github.com/user-attachments/assets/ce5a10ed-0fe6-4f3b-933c-197553477b83" />

Details: windows position was previously set using `move` for non-resizable and `setGeometry` for resizable windows. [move](https://doc.qt.io/qt-6/qwidget.html#move-1) (which is a setter for [pos](https://doc.qt.io/qt-6/qwidget.html#pos-prop)) calculates the position including the window frame. [setGeometry](https://doc.qt.io/qt-6/qwidget.html#setGeometry-1) (setter for [geometry](https://doc.qt.io/qt-6/qwidget.html#geometry-prop)) sets the position excluding the frame. This PR uses `setGeometry` whether the window is resizable or not, which seems to result in a consistent behavior.

Fixes #7044

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [ ] Updated documentation (n/a?)
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
