### PR TITLE
Correct a typo in SinOsc.schelp (#7064)

### DIFF
--- a/HelpSource/Classes/SinOsc.schelp
+++ b/HelpSource/Classes/SinOsc.schelp
@@ -9,7 +9,7 @@ Description::
 Generates a sine wave.
 Uses a wavetable lookup oscillator with linear interpolation.
 Frequency and phase modulation are provided for audio-rate modulation.
-Technically, code:SinOsc:: uses the same implementation as  link::Classes/Osc::  except that its table is fixed to be a sine wave made of code::8192:: samples.
+Technically, code::SinOsc:: uses the same implementation as  link::Classes/Osc::  except that its table is fixed to be a sine wave made of code::8192:: samples.
 
 subsection:: Other sinewaves oscillators
 


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

Fix a typo (by @prko) - cherry pick #7064

Note, the typo was [introduced in 3.14.0-rc2](https://github.com/prko/supercollider/commit/fcdee4d6b08bbfb8bbd25d776f9efa18521dfd1b#diff-f4b6ed3bfc22c81984fa1fd9925fff175c5bfb01bb13afaa8d081b789a5c6596R12) so we need to fix this for the final 3.14.0 release, otherwise SinOsc helpfile won't render.

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->

- Documentation

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
