### PR TITLE
Plotter: fix steplike data displays

### DIFF
--- a/HelpSource/Classes/Plotter.schelp
+++ b/HelpSource/Classes/Plotter.schelp
@@ -115,8 +115,15 @@ table::
 ## code::\filled:: || fills the area under a waveform, and assumes a bipolar signal (filled to the zero-crossing)
 ## code::\pfilled:: || code::\filled::, marked also by code::\points::
 ## code::\dfilled:: || code::\filled::, marked also by code::\dots::
-## code::\levels:: || sample-and-hold style horizontal lines from the data point extending over the sample interval
-## code::\steps:: || "step interpolation": code::\levels:: connected by vertical lines
+## code::\levels:: || horizontal lines, sample-and-hold style
+## code::\plevels:: || code::\levels::, with a code::\points:: data markers
+## code::\dlevels:: || code::\levels::, with a code::\dots:: data markers
+## code::\levelsCentered:: || horizontal lines, centered on the data point
+## code::\plevelsCentered:: || code::\levelsCentered::, with a code::\points:: data markers
+## code::\dlevelsCentered:: || code::\levelsCentered::, with a code::\dots:: data markers
+## code::\steps:: || "step interpolation", sample-and-hold style, connected by vertical lines
+## code::\psteps:: || code::\steps::, with a code::\points:: data markers
+## code::\dsteps:: || code::\steps::, with a code::\dots:: data markers
 ## code::\bars:: || bar graph with filled bars
 ::
 
@@ -142,17 +149,12 @@ p.plotMode = \steps;
 /* Preview the available modes */
 (
 s.waitForBoot{
-    var modeList = [
-        \points, \dots, \levels, \steps,
-        \lines, \plines, \dlines,
-        \stems, \pstems, \dstems,
-        \filled, \dfilled, \pfilled, \bars,
-    ];
-    modeList.clump((modeList.size/2).ceil).do{ |modes, i|
-        var frq = 1000, w = 600, h = 800;
+    var modeList = Plotter.modes;
+    modeList.clump((modeList.size/3).ceil).do{ |modes, i|
+        var frq = 3000, w = 500, h = 800;
         p = {
-            LFSaw.ar(frq) ! modes.size
-        }.plot(2.25 * frq.reciprocal);
+            SinOsc.ar(frq) ! modes.size
+        }.plot(0.75 * frq.reciprocal);
 
         0.25.wait; // let Plotter update with data
         p.plotMode_(modes);

--- a/HelpSource/Classes/Plotter.schelp
+++ b/HelpSource/Classes/Plotter.schelp
@@ -141,7 +141,7 @@ are the same, in which case a single link::Classes/Symbol:: is returned.
 discussion::
 code::
 
-p = (0..20).scramble.plot;
+p = (0..20).scramble.plot;  p.parent.alwaysOnTop = true;
 p.plotMode = \points;
 p.plotMode = \plines;
 p.plotMode = \steps;
@@ -173,6 +173,31 @@ p.plotColor_([Color.red, Color.cyan, Color.green, Color.blue]);
 p.plotMode_([\steps, \linear, \plines, \points]);
 p.superpose_(true);
 )
+::
+
+warning::
+Plot modes  code::\levels::, code::\steps::, and their variants display data in a sample-and-hold manner, 
+so unless the link::#-domainSpecs:: has been set explicitly to extend beyond the last data point,
+the "step" of the last data point may not be visible.
+code::
+( // Can't see the rightmost data point
+p = [4,2,5,3].plot.minval_(0).maxval_(6).plotMode_(\levels);
+p.parent.alwaysOnTop = true;
+)
+
+// Adding the "point" makes it visible
+p.plotMode_(\plevels);
+
+// Adjusting the domainSpec makes the "step" visible
+p.domain_((0..3)).domainSpecs_([0,4].asSpec);
+
+p.parent.close;
+::
+
+This is not an issue for plot modes that center the levels on the data points, e.g. code::\levelsCentered::, code::\bars::, and their variants.
+code::
+[4,2,5,3].plot.minval_(0).maxval_(6).plotMode_(\bars);
+::
 ::
 
 
@@ -214,7 +239,6 @@ var freq = 100;
 ).superpose_(true);
 )
 ::
-
 
 
 method:: superpose

--- a/SCClassLibrary/Common/GUI/Base/Grid.sc
+++ b/SCClassLibrary/Common/GUI/Base/Grid.sc
@@ -419,7 +419,7 @@ DrawGridX {
 			} {
 				protoLabel.bounds(Font(Font.defaultSansFace, 9)).asSize
 			};
-			labelSz.width = labelSz.width * 1.1;
+			labelSz.width = labelSz.width * 1.3;
 			lastLabelSize = labelSz;
 
 			^labelSz

--- a/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
+++ b/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
@@ -718,20 +718,39 @@ Plot {
 		^#[\levelsCentered, \plevelsCentered, \dlevelsCentered, \bars].includesAny(plotMode)
 	}
 
+	hasHoldlikeDisplay {
+		^#[\levels, \plevels, \dlevels, \steps, \psteps, \dsteps].includesAny(plotMode)
+	}
+
 	getIndex { |x|
 		var ycoord = this.dataCoordinates;
-		var xPosNorm;
+		var xPosNorm, idxPlusOne;
 
 		^if (plotter.domain.notNil) {
-			this.domainCoordinates(nil).indexIn(x);
+			if(this.hasHoldlikeDisplay) {
+				idxPlusOne = this.domainCoordinates(nil).indexOfGreaterThan(x);
+				if(idxPlusOne.isNil) {
+					value.size - 1
+				} {
+					max(idxPlusOne - 1, 0)
+				}
+			} {
+				this.domainCoordinates(nil).indexIn(x)
+			}
 		} {
 			// domain is nil, values are evenly distributed between either side of the plot
 			xPosNorm = (x - plotBounds.left) / plotBounds.width;
-			if (this.hasCenteredSteplikeDisplay, {
-					xPosNorm * value.size - 0.5
-			}, {
-					xPosNorm * (value.size - 1)
-			}).round.clip(0, value.size-1).asInteger;
+			case
+			{ this.hasCenteredSteplikeDisplay } {
+				xPosNorm * value.size - 0.5
+			}
+			{ this.hasHoldlikeDisplay } {
+				xPosNorm * (value.size - 1) - 0.5
+			}
+			{ // otherwise
+				xPosNorm * (value.size - 1)
+			}
+			.round.clip(0, value.size-1).asInteger;
 		}
 	}
 


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

This pull request improves visual alignment for step-like data. 

There are two type os step-like data: centered respresentation (e.g. `\bars`) and sample-and-hold representation (e.g. `\steps` and `\levels`).

Previously, `\bars` were offset so they didn't align with their domain/x-axis index, and the last value wouldn't be shown (see #5296):
```supercollider
[5, 0, 1, 2, 3, 4].plot.plotMode_([\bars])
````
<img width="300" alt="Screenshot 2025-07-29 at 14 08 21" src="https://github.com/user-attachments/assets/f1a4ca94-1aa2-433c-8f2c-33d25f0170e0" />

Now fixed:
<img width="300" alt="Screenshot 2025-07-29 at 14 00 25" src="https://github.com/user-attachments/assets/65a75317-610c-410e-9322-9079a41e3b41" />

While fixing this, various minor issues came up with step-like data, such as partially hidden values and buggy behavior with `editMode` enabled. This led to adding more plot modes, including a centered version of `levels`. Other new modes place markers (dots or points) at the x-position where the data is sampled, as is already done with `plines`, `dfilled`, etc. modes, and to disambiguated centered and hold-like displays. This is in part inspired by the idea of using plots as fader banks (where the data marker would be a "handle").

All available modes are shown here (new modes highlighted):
<img width="1502" height="835" alt="Screenshot 2025-07-28 at 14 55 15" src="https://github.com/user-attachments/assets/2c4a1077-5c0b-4b2e-a731-ef10e10380cb" />

Additional changes:
- Introduced `prDomainSpec` to manage the padding for plot modes that require it, leaving user-facing `domainSpec` to accurately reflect the spec supplied by the user.
- Check that user-specified mode is valid, warning if not
- Update `plotMode_` to refresh plot specifications dynamically when modes are changed. 
- Increased label width multiplier in `Grid.sc` to avoid cutting off text of tick labels.
- Updated documentation to clarify behavior for step-like plot modes and their visibility constraints. (addresses concerns in #6479)

Thanks @prko for getting this started in #6944.

## Types of changes

Fixes #5296

<!-- Delete lines that don't apply -->

- Documentation
- Bug fix
- New feature


## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
