### PR TITLE
Classlib: Dictionary: Disallow 'nil' as Dictionary key

### DIFF
--- a/SCClassLibrary/Common/Collections/Dictionary.sc
+++ b/SCClassLibrary/Common/Collections/Dictionary.sc
@@ -360,7 +360,7 @@ Dictionary : Set {
 	}
 	scanFor { arg argKey;
 		var maxHash = array.size div: 2;
-		var start = (argKey.hash % maxHash) * 2;
+		var start = (argKey.keyHash % maxHash) * 2;
 		var end = array.size-1;
 		var i = start;
 		forBy( start, end, 2, { arg i;

--- a/SCClassLibrary/Common/Core/Nil.sc
+++ b/SCClassLibrary/Common/Core/Nil.sc
@@ -129,4 +129,6 @@ Nil {
 	}
 
 	superclassesDo {}
+
+	keyHash { Error("'nil' is not valid as a Dictionary key").throw }
 }

--- a/SCClassLibrary/Common/Core/Object.sc
+++ b/SCClassLibrary/Common/Core/Object.sc
@@ -224,6 +224,7 @@ Object {
 	basicHash { _ObjectHash; ^this.primitiveFailed }
 	hash { _ObjectHash; ^this.primitiveFailed }
 	identityHash { _ObjectHash; ^this.primitiveFailed }
+	keyHash { _ObjectHash; ^this.primitiveFailed }
 
 	// lazy equality: same as == for objects
 	// "composed" for lazy operands (patterns, UGens)

--- a/testsuite/classlibrary/TestDictionary.sc
+++ b/testsuite/classlibrary/TestDictionary.sc
@@ -38,4 +38,18 @@ TestDictionary : UnitTest {
 		this.assertEquals(dict.trueAt(\k), true, "dictionary trueAt should respond true if its booleanValue is true.");
 	}
 
+	test_Dictionary_disallows_nil_as_key {
+		var dict = Dictionary[1 -> 2];
+		var err;
+		try {
+			dict.put(nil, 3);
+		} { |error|
+			err = error
+		};
+		this.assert(
+			err.notNil and: { err.errorString.contains("'nil' is not valid") },
+			"Dictionary should throw an error when trying to 'put' at nil as a key"
+		)
+	}
+
 }


### PR DESCRIPTION
## Purpose and Motivation

See https://scsynth.org/t/strange-bug-with-dictionary/12162/3

> The code below creates a Dictionary which is mysteriously missing keys 2, 4, 7, 9, 10, 11.

```
(
a = Dictionary.new;

a[nil] = 0;

12.do{|i|
	if(a[i] == nil,{
		a[i] = "yes";
	});
};
a.keysValuesDo{|key, val|
	[key,val].postln;
};
)
```

The approach here is to add a new selector `keyHash`, used by Dictionary to distinguish the purpose of requesting the hash. Nil:hash remains as is to handle cases like `[1, nil, 3].hash`. Dictionary:scanFor now uses keyHash, so that method dispatch by itself detects the faulty case.

Adding an `if(key.isNil)` branch into Dictionary:scanFor would have a small performance impact. This approach should not sacrifice any performance while still catching the error condition.

## Types of changes

- Bug fix

## To-do list

- [x] Code is tested
- [x] All tests are passing
- [ ] Updated documentation
- [x] This PR is ready for review

Probably should squash merge.