### PR TITLE
Add Link to Dev Documentation on Help Home Page

### DIFF
--- a/HelpSource/Help.schelp
+++ b/HelpSource/Help.schelp
@@ -4,6 +4,18 @@ categories::Help
 
 NOTE:: link::Guides/News-3_14##News in SuperCollider version 3.14:: ::
 
+note::
+The most up-to-date online help documentation for SuperCollider is built weekly from the development branch and is available at:
+
+link::https://dev.docs.supercollider.online/::.
+This version reflects the latest changes and contributions from active development.
+
+For stable release documentation, refer to the main site:
+
+link::https://docs.supercollider.online/::.
+This site corresponds to the latest official release and is recommended for most users.
+::
+
 SECTION:: An introductory overview
 
 emphasis::SuperCollider:: is a cross-platform environment for audio synthesis and algorithmic composition used by musicians, artists and researchers working with sound.


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation
There have been multiple requests for access to the most up-to-date help documentation. For example:
- https://scsynth.org/t/development-meetings-scheduling-polls/234/122?u=prko
- https://scsynth.org/t/development-meetings-scheduling-polls/234/124?u=prko

The linked posts above highlight the need for clearer access to documentation built from the development branch.

This PR aims to address those requests by adding a link to the

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->

- Documentation

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
