### PR TITLE
help: replace Synth.play with {}.play

### DIFF
--- a/HelpSource/Classes/Limiter.schelp
+++ b/HelpSource/Classes/Limiter.schelp
@@ -35,21 +35,22 @@ Examples::
 code::
 (
 // example signal to process
-Synth.play({
+{
 	var z;
 	z = Decay2.ar(
 		Impulse.ar(8, LFSaw.kr(0.25, -0.6, 0.7)),
 		0.001, 0.3, FSinOsc.ar(500));
-}, 0.8)
+	z * 0.8
+}.play
 )
 
 (
-Synth.play({
+{
 	var z;
 	z = Decay2.ar(
 		Impulse.ar(8, LFSaw.kr(0.25, -0.6, 0.7)),
 		0.001, 0.3, FSinOsc.ar(500));
-	[z, Limiter.ar(z, 0.4, 0.01)]
-}, 0.5)
+	[z, Limiter.ar(z, 0.4, 0.01)] * 0.5
+}.play
 )
 ::

--- a/HelpSource/Classes/Median.schelp
+++ b/HelpSource/Classes/Median.schelp
@@ -39,7 +39,6 @@ This value will be added to the output.
 Examples::
 
 code::
-
 // a signal with impulse noise.
 { Saw.ar(500, 0.1) + Dust2.ar(100, 0.9) }.play;
 
@@ -67,16 +66,15 @@ code::
 
 // another noise reduction application:
 
-Synth.play({ WhiteNoise.ar(0.1) + SinOsc.ar(800, 0, 0.1) });
+{ WhiteNoise.ar(0.1) + SinOsc.ar(800, 0, 0.1) }.play;
 
 // use Median filter for high frequency noise
-Synth.play({ Median.ar(31, WhiteNoise.ar(0.1) + SinOsc.ar(800, 0, 0.1)) });
+{ Median.ar(31, WhiteNoise.ar(0.1) + SinOsc.ar(800, 0, 0.1)) }.play;
 
 (
 // use LeakDC for low frequency noise
-Synth.play({
+{
 	LeakDC.ar(Median.ar(31, WhiteNoise.ar(0.1) + SinOsc.ar(800, 0, 0.1)), 0.9)
-});
+}.play
 )
-
 ::

--- a/HelpSource/Classes/Normalizer.schelp
+++ b/HelpSource/Classes/Normalizer.schelp
@@ -32,25 +32,24 @@ This parameter cannot be modulated.
 Examples::
 
 code::
-
 (
 // example signal to process
-Synth.play({
+{
 	var z;
 	z = Decay2.ar(
 		Impulse.ar(8, LFSaw.kr(0.25, -0.6, 0.7)),
 		0.001, 0.3, FSinOsc.ar(500));
-}, 0.8)
+	z * 0.8
+}.play
 )
 
 (
-Synth.play({
+{
 	var z;
 	z = Decay2.ar(
 		Impulse.ar(8, LFSaw.kr(0.25, -0.6, 0.7)),
 		0.001, 0.3, FSinOsc.ar(500));
-	[z, Normalizer.ar(z, 0.4, 0.01)]
-}, 0.5)
+	[z, Normalizer.ar(z, 0.4, 0.01)] * 0.5
+}.play
 )
-
 ::

--- a/HelpSource/Guides/Backwards-Compatibility.schelp
+++ b/HelpSource/Guides/Backwards-Compatibility.schelp
@@ -5,14 +5,16 @@ categories:: Language>SC3 vs SC2
 There are a number of classes and methods that have been added to allow for backwards compatibility with SC2 code. The most notable of these is code::Synth.play::, which is basically a wrapper for code::Function.play::.
 
 code::
+Synth.play({ SinOsc.ar(440, 0, 0.5) }); // not compatible in SC3
+
 { SinOsc.ar(440, 0, 0.5) }.play; // creates an arbitrarily named SynthDef and a Synth to play it
-Synth.play({ SinOsc.ar(440, 0, 0.5) }); // in SC3 just a wrapper for Function.play with fewer args
+// in SC3 just a wrapper for Function.play with fewer args
 ::
 
 Both of these will create synth nodes on the default server. Note that neither requires the use of an code::Out.ar:: link::Classes/UGen::; they simply output to the first audio bus. One can however add an link::Classes/Out:: to Function.play in order to specify.
 
 code::
-Synth.play({ Out.ar(1, SinOsc.ar(440, 0, 0.5)) });
+({ Out.ar(1, SinOsc.ar(440, 0, 0.5)) }).play;
 ::
 
 In general, one should be aware of this distinction when using this code. When copying such code for reuse with other SC3 classes (for example in a reusable link::Classes/SynthDef::), it will usually be necessary to add an code::Out.ar::. Although useful for quick testing these methods are generally inferior to code::SynthDef.play::, as the latter is more direct, requires no modifications for general reuse, has greater general flexibility and has slightly less overhead. (Although this is insignificant in most cases, it could be relevant when large numbers of defs or nodes are being created.)

--- a/HelpSource/Guides/Backwards-Compatibility.schelp
+++ b/HelpSource/Guides/Backwards-Compatibility.schelp
@@ -5,16 +5,14 @@ categories:: Language>SC3 vs SC2
 There are a number of classes and methods that have been added to allow for backwards compatibility with SC2 code. The most notable of these is code::Synth.play::, which is basically a wrapper for code::Function.play::.
 
 code::
-Synth.play({ SinOsc.ar(440, 0, 0.5) }); // not compatible in SC3
-
 { SinOsc.ar(440, 0, 0.5) }.play; // creates an arbitrarily named SynthDef and a Synth to play it
-// in SC3 just a wrapper for Function.play with fewer args
+Synth.play({ SinOsc.ar(440, 0, 0.5) }); // in SC3 just a wrapper for Function.play with fewer args
 ::
 
 Both of these will create synth nodes on the default server. Note that neither requires the use of an code::Out.ar:: link::Classes/UGen::; they simply output to the first audio bus. One can however add an link::Classes/Out:: to Function.play in order to specify.
 
 code::
-({ Out.ar(1, SinOsc.ar(440, 0, 0.5)) }).play;
+Synth.play({ Out.ar(1, SinOsc.ar(440, 0, 0.5)) });
 ::
 
 In general, one should be aware of this distinction when using this code. When copying such code for reuse with other SC3 classes (for example in a reusable link::Classes/SynthDef::), it will usually be necessary to add an code::Out.ar::. Although useful for quick testing these methods are generally inferior to code::SynthDef.play::, as the latter is more direct, requires no modifications for general reuse, has greater general flexibility and has slightly less overhead. (Although this is insignificant in most cases, it could be relevant when large numbers of defs or nodes are being created.)


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

closes #7098

## Purpose and Motivation
This PR changes `Synth.play` to `{}.play`. `Synth.play` is no longer supported by sclang and returns `ERROR: Message ‘play’ not understood.`, so there is no reason to maintain this code example in help documentation.

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->

- Documentation

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
