### PR TITLE
GHA macOS: use homebrew qt for share libscsynth build

### DIFF
--- a/.github/workflows/build_macos.yml
+++ b/.github/workflows/build_macos.yml
@@ -58,14 +58,13 @@ jobs:
             extra-cmake-flags: "-D SYSTEM_BOOST=ON -D SYSTEM_YAMLCPP=ON"
             ctest: true
 
-          - job-name: "x64 shared libscsynth"
-            os-version: "13"
-            xcode-version: "15.2"
-            qt-version: "6.7.3" # will use qt from aqtinstall
+          - job-name: "arm64 shared libscsynth"
+            os-version: "15"
+            xcode-version: "16.0"
             qt-modules: 'qtwebengine qtwebchannel qtwebsockets qtpositioning'
             deployment-target: ""
-            cmake-architectures: x86_64
-            homebrew-packages: "libsndfile readline fftw portaudio"
+            cmake-architectures: "arm64"
+            homebrew-packages: "qt@6 libsndfile readline fftw portaudio"
             vcpkg-packages: ""
             vcpkg-triplet: ""
             extra-cmake-flags: "-D LIBSCSYNTH=ON"


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

The libscsynth build was taking a longer time due to using qt from aqtinstall. As this build only tests scsynth build configuration, it doesn't matter much which OS and Qt source is used. 

I _think_ that not using aqt install here will also lower our GHA cache usage (1.6 GB per build).

Alternatively, we could disable it altogether, but I don't fully understand myself whether it's useful to have it or not.

## Types of changes

<!-- Delete lines that don't apply -->

- Maintenance?

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
