### PR TITLE
vDSP: support multiple threads

### DIFF
--- a/README_MACOS.md
+++ b/README_MACOS.md
@@ -46,8 +46,8 @@ Prerequisites:
 - **git, cmake >= 3.12, libsndfile, readline, and qt6 >= 6.2**, installed via homebrew:
   `brew install git cmake libsndfile readline qt@6`
 
-- If you want to build with the *supernova* server, you need **portaudio** and **fftw** packages, which can also be installed via homebrew:
-  `brew install portaudio fftw`
+- If you want to build with the *supernova* server, you need **portaudio** package, which can also be installed via homebrew:
+  `brew install portaudio`
 
 Obtaining the source code
 -------------------------

--- a/common/SC_fftlib.cpp
+++ b/common/SC_fftlib.cpp
@@ -23,6 +23,9 @@ NOTE:
 vDSP uses a "SplitBuf" as an intermediate representation of the data.
 For speed we keep this global, although this makes the code non-thread-safe.
 (This is not new to this refactoring. Just worth noting.)
+NEW ADDITION:
+Additional logic was used when adapting this for Supernova,
+ensuring that each thread has its own SplitBuf.
 */
 
 #include "clz.h"
@@ -98,7 +101,11 @@ static float* fftWindow[2][SC_FFT_LOG2_ABSOLUTE_MAXSIZE_PLUS1];
 
 #if SC_FFT_VDSP
 static FFTSetup fftSetup[SC_FFT_LOG2_ABSOLUTE_MAXSIZE_PLUS1]; // vDSP setups, one per FFT size
+#    ifdef SUPERNOVA
+thread_local static COMPLEX_SPLIT splitBuf;
+#    else
 static COMPLEX_SPLIT splitBuf; // Temp buf for holding rearranged data
+#    endif
 #endif
 
 #if SC_FFT_GREEN
@@ -167,6 +174,23 @@ static inline float* scfft_create_fftwindow(int wintype, int log2n) {
 
 static void scfft_ensurewindow(unsigned short log2_fullsize, unsigned short log2_winsize, short wintype);
 
+#if SC_FFT_VDSP
+// initialize splitbuf memory
+void scfft_init_splitbuf() {
+    // vDSP prepares its memory-aligned buffer for rearranging input data.
+    // Note max size here - meaning max input buffer size is these two sizes added together.
+    // vec_malloc used in API docs, but apparently that's deprecated and malloc is sufficient for aligned memory on OSX.
+    splitBuf.realp = (float*)malloc(SC_FFT_MAXSIZE * sizeof(float) / 2);
+    splitBuf.imagp = (float*)malloc(SC_FFT_MAXSIZE * sizeof(float) / 2);
+}
+#endif
+
+void scfft_thread_init() {
+#if SC_FFT_VDSP
+    scfft_init_splitbuf();
+#endif
+}
+
 static bool scfft_global_initialization(void) {
     for (int wintype = 0; wintype < 2; ++wintype) {
         for (int i = 0; i < SC_FFT_LOG2_ABSOLUTE_MAXSIZE_PLUS1; ++i) {
@@ -192,11 +216,12 @@ static bool scfft_global_initialization(void) {
             printf("FFT ERROR: Mac vDSP library could not allocate FFT setup for size %i\n", 1 << i);
         }
     }
-    // vDSP prepares its memory-aligned buffer for rearranging input data.
-    // Note max size here - meaning max input buffer size is these two sizes added together.
-    // vec_malloc used in API docs, but apparently that's deprecated and malloc is sufficient for aligned memory on OSX.
-    splitBuf.realp = (float*)malloc(SC_FFT_MAXSIZE * sizeof(float) / 2);
-    splitBuf.imagp = (float*)malloc(SC_FFT_MAXSIZE * sizeof(float) / 2);
+#    ifndef SUPERNOVA
+    // allocate splitBuf memory
+    // on supernova we do that by calling scfft_thread_init() from
+    // realtime_engine_functor::init_thread() and thread_init_functor::operator()
+    scfft_init_splitbuf();
+#    endif
     // printf("SC FFT global init: vDSP initialised.\n");
 #elif SC_FFT_FFTW
     size_t maxSize = 1 << SC_FFT_LOG2_MAXSIZE;

--- a/editors/sc-ide/CMakeLists.txt
+++ b/editors/sc-ide/CMakeLists.txt
@@ -518,7 +518,6 @@ if(APPLE OR WIN32)
             endif()
         endif()
         if(SUPERNOVA)
-            get_target_property(LINK_FFTW libsupernova SUPERNOVA_FFTW)
             string(APPEND DEPLOY_CMD "
                 -executable=${CONTENTS_DIR}/Resources/supernova
                 -executable=${CONTENTS_DIR}/Resources/plugins/DiskIO_UGens_supernova.scx

--- a/include/common/SC_fftlib.h
+++ b/include/common/SC_fftlib.h
@@ -64,3 +64,6 @@ void scfft_doifft(scfft* f);
 
 // destroy any resources held internally.
 void scfft_destroy(scfft* f, SCFFT_Allocator& alloc);
+
+// initialize thread local buffers
+void scfft_thread_init();

--- a/server/scsynth/CMakeLists.txt
+++ b/server/scsynth/CMakeLists.txt
@@ -1,7 +1,8 @@
 # here we choose who provides us with the FFT lib
 # this is done independently for scsynth and supernova
-# on macOS scsynth uses vDSP implementation for FFT
-# which is not thread-safe
+# for historical reasons, as the vDSP implementation
+# wasn't thread-safe in the past
+# and couldn't be used in supernova
 
 if (APPLE)
     add_definitions("-DSC_FFT_VDSP")

--- a/server/supernova/CMakeLists.txt
+++ b/server/supernova/CMakeLists.txt
@@ -13,22 +13,25 @@ endif(CMAKE_COMPILER_IS_GNUCXX)
 
 # here we choose who provides us with the FFT lib
 # this is done independently for scsynth and supernova
-# scsynth uses vDSP implementation for FFT on macOS
-# however current implementation of vDSP is not thread-safe
-# so we use FFTW with supernova on macOS
-# once vDSP implementation becomes thread-safe
-# this logic can be reworked to use vDSP on macOS
+# for historical reasons, as the vDSP implementation
+# wasn't thread-safe in the past
+# and couldn't be used in supernova
 
-find_package(FFTW3f 3.3)
-
-if (NOT FFTW3F_FOUND OR FFT_GREEN)
-    message(STATUS "FFT library (supernova): Green")
-    set(FFT_GREEN 1)
-    add_definitions("-DSC_FFT_GREEN")
+if (APPLE)
+    add_definitions("-DSC_FFT_VDSP")
+    message(STATUS "FFT library (supernova): vDSP")
 else()
-    message(STATUS "Found fftw3f: ${FFTW3F_LIBRARY}")
-    message(STATUS "FFT library (supernova): FFTW")
-    add_definitions("-DSC_FFT_FFTW")
+    find_package(FFTW3f 3.3)
+
+    if (NOT FFTW3F_FOUND OR FFT_GREEN)
+        message(STATUS "FFT library (supernova): Green")
+        set(FFT_GREEN 1)
+        add_definitions("-DSC_FFT_GREEN")
+    else()
+        message(STATUS "Found fftw3f: ${FFTW3F_LIBRARY}")
+        message(STATUS "FFT library (supernova): FFTW")
+        add_definitions("-DSC_FFT_FFTW")
+    endif()
 endif()
 
 set(libsupernova_src
@@ -195,7 +198,6 @@ endif()
 if (FFTW3F_FOUND)
     target_include_directories(libsupernova PUBLIC ${FFTW3F_INCLUDE_DIR})
     target_link_libraries(libsupernova ${FFTW3F_LIBRARY})
-    set_property(TARGET libsupernova PROPERTY SUPERNOVA_FFTW ON) # for fixing linking in macdeployqt
 endif()
 
 if(CMAKE_SYSTEM_NAME MATCHES "Linux")

--- a/server/supernova/audio_backend/sndfile_backend.hpp
+++ b/server/supernova/audio_backend/sndfile_backend.hpp
@@ -285,6 +285,10 @@ private:
 
 public:
     void audio_fn_noinput(size_t frames_per_tick) {
+        if (unlikely(!engine_initialized)) {
+            engine_functor::init_thread();
+            engine_initialized = true;
+        }
         engine_functor::run_tick();
         write_output_buffers(frames_per_tick);
     }
@@ -292,14 +296,14 @@ public:
     void audio_fn(size_t frames_per_tick) {
         super::clear_outputs(frames_per_tick);
         read_input_buffers(frames_per_tick);
-        engine_functor::run_tick();
-        write_output_buffers(frames_per_tick);
+        audio_fn_noinput(frames_per_tick);
     }
 
 private:
     SndfileHandle input_file, output_file;
     std::size_t read_position;
     int block_size_;
+    bool engine_initialized = false;
 
     aligned_storage_ptr<sample_type> temp_buffer;
 

--- a/server/supernova/server/server.cpp
+++ b/server/supernova/server/server.cpp
@@ -321,6 +321,9 @@ void thread_init_functor::operator()(int thread_index) {
         if (!result)
             std::cout << "Warning: cannot set thread affinity of audio helper thread" << std::endl;
     }
+
+    // initialize thread local buffers
+    scfft_thread_init();
 }
 
 void io_thread_init_functor::operator()() const {
@@ -366,6 +369,9 @@ void realtime_engine_functor::init_thread(void) {
     }
 
     name_current_thread(0);
+
+    // initialize thread local buffers
+    scfft_thread_init();
 }
 
 void realtime_engine_functor::log_(const char* str) {


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

The vDSP (FFT library on macOS) implementation originally was not multithreaded due to optimization strategy using a global buffer for holding the intermediate representation of FFT data. Once that was discovered, we [switched to using FFTW on macOS in supernova](https://github.com/supercollider/supercollider/pull/4583).

See https://github.com/supercollider/supercollider/issues/4289 for code example triggering the original error.

I wanted to switch back to using vDSP as it brings supernova's requirements closer to scsynth on macOS.

### Implementation details:

~~When using fftlib with supernova, in this PR we are allocating as many temporary buffers as there are CPU cores (hardware concurrency). Supernova [caps max number of threads to hardware concurrency](https://github.com/supercollider/supercollider/blob/develop/server/supernova/dsp_thread_queue/dsp_thread.hpp#L179), so we should never run out IIUC, but in case something changed, more buffers will be allocated if a buffer is requested beyond the preallocated pool. That will happen in the audio thread, IIUC, but that's still better than a server crash, right?~~

~~Please review carefully. While I came up myself with the logic that allocates multiple buffers and assigns them per-thread, I was using help from LLMs when implementing it.~~

## Types of changes

<!-- Delete lines that don't apply -->

- Documentation
- New feature (?)

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
