### PR TITLE
SCLang: add caching to `GetBackTrace`

### DIFF
--- a/lang/LangPrimSource/PyrPrimitive.cpp
+++ b/lang/LangPrimSource/PyrPrimitive.cpp
@@ -1774,10 +1774,15 @@ int prDumpBackTrace(struct VMGlobals* g, int numArgsPushed) {
 
 /* the DebugFrameConstructor uses a work queue in order to avoid recursions, which could lead to stack overflows */
 struct DebugFrameConstructor {
-    void makeDebugFrame(VMGlobals* g, PyrFrame* frame, PyrSlot* outSlot) {
+    DebugFrameConstructor(VMGlobals* g, PyrFrame* frame, PyrSlot* outSlot) {
         workQueue.push_back(std::make_pair(frame, outSlot));
         run_queue(g);
     }
+    DebugFrameConstructor() = delete;
+    DebugFrameConstructor(DebugFrameConstructor&&) = delete;
+    DebugFrameConstructor(const DebugFrameConstructor&) = delete;
+    DebugFrameConstructor& operator=(DebugFrameConstructor&&) = delete;
+    DebugFrameConstructor& operator=(const DebugFrameConstructor&) = delete;
 
 private:
     void run_queue(VMGlobals* g) {
@@ -1789,6 +1794,17 @@ private:
     }
 
     void fillDebugFrame(VMGlobals* g, PyrFrame* frame, PyrSlot* outSlot) {
+        // If a frame (which represents a specific **invocation** of a method/block) has been seen before, just copy it
+        // in.
+        // Because the number of unique frames is relatively small (less than a thousand) linear search should be
+        // faster than a hash map, assuming the compiler vectorises this in a sane way.
+        for (std::size_t i { 0 }; i < visited_frames.size(); ++i) {
+            if (visited_frames[i] == frame) {
+                slotCopy(outSlot, visited_frames_final_location[i]);
+                return;
+            }
+        }
+
         PyrMethod* meth = slotRawMethod(&frame->method);
         PyrMethodRaw* methraw = METHRAW(meth);
 
@@ -1798,8 +1814,8 @@ private:
         SetObject(debugFrameObj->slots + 0, meth);
         SetPtr(debugFrameObj->slots + 5, meth);
 
-        int numargs = methraw->numargs;
-        int numvars = methraw->numvars;
+        const int numargs = methraw->numargs;
+        const int numvars = methraw->numvars;
         if (numargs) {
             PyrObject* argArray = (PyrObject*)newPyrArray(g->gc, numargs, 0, false);
             SetObject(debugFrameObj->slots + 1, argArray);
@@ -1833,25 +1849,21 @@ private:
             workQueue.push_back(newWork);
         } else
             SetNil(debugFrameObj->slots + 4);
+
+        visited_frames.push_back(frame);
+        visited_frames_final_location.push_back(outSlot);
     }
 
     typedef std::pair<PyrFrame*, PyrSlot*> WorkQueueItem;
     typedef std::vector<WorkQueueItem> WorkQueueType;
-    WorkQueueType workQueue;
+    WorkQueueType workQueue {};
+
+    std::vector<PyrFrame*> visited_frames {};
+    std::vector<PyrSlot*> visited_frames_final_location {};
 };
 
-static void MakeDebugFrame(VMGlobals* g, PyrFrame* frame, PyrSlot* outSlot) {
-    DebugFrameConstructor constructor;
-    constructor.makeDebugFrame(g, frame, outSlot);
-}
-
-int prGetBackTrace(VMGlobals* g, int numArgsPushed);
 int prGetBackTrace(VMGlobals* g, int numArgsPushed) {
-    PyrSlot* a;
-
-    a = g->sp;
-    MakeDebugFrame(g, g->frame, a);
-
+    DebugFrameConstructor(g, g->frame, g->sp);
     return errNone;
 }
 


### PR DESCRIPTION
Thanks to @jamshark70 for reporting and helping with this.

Caches all frames in the back trace. If a duplicate frame is found, just copy in the previous `DebugFrame`, don't make a new one.

Take the following example.
```
~good = { |level|
	if(level > 0) {	~good.(level - 1) } { Error("meow").throw	};
};

try { ~good.(20) }
```
This would perform fine.

However, adding a layer of function indirection would show super-linear memory usage and easily crash my machine.
```
~bad = { |level|
	{
		if(level > 0) {	~bad.(level - 1) } { Error("meow").throw	};
	}.();
};

try { ~bad.(20) }
```

Now, the two example both scale linearly as `level` increases, the bad example scales faster, but it is still linear.

<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->


## Types of changes

<!-- Delete lines that don't apply -->


- Bug fix


## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
