### PR TITLE
Add interval notation guide in random section of SimpleNumber.schelp

### DIFF
--- a/HelpSource/Classes/SimpleNumber.schelp
+++ b/HelpSource/Classes/SimpleNumber.schelp
@@ -978,6 +978,16 @@ prints this on the given stream
 subsection:: random
 Unless noted otherwise, the return value of all these methods will be an link::Classes/Integer:: only when the receiver and all arguments are Integers as well.
 
+note::Interval Notation Guide for this part:
+table::
+## Notation || Name || Inclusion || Example meaning (numeric range)
+## teletype::[a, b]:: || Closed interval || Includes both a and b || a ≤ x ≤ b → e.g. [1, 5] = 1 ≤ x ≤ 5
+## teletype::(a, b):: || Open interval || Excludes both a and b || a < x < b → e.g. (1, 5) = 1 < x < 5
+## teletype::[a, b):: || Half‑open interval (left‑closed) || Includes a, excludes b || a ≤ x < b → e.g. [1, 5) = 1 ≤ x < 5
+## teletype::(a, b]:: || Half‑open interval (right‑closed) || Excludes a, includes b || a < x ≤ b → e.g. (1, 5] = 1 < x ≤ 5
+::
+::
+
 method:: coin
 Let emphasis::x:: be the receiver clipped to the range [0, 1].
 With probability emphasis::x::, return true.

--- a/HelpSource/Classes/SimpleNumber.schelp
+++ b/HelpSource/Classes/SimpleNumber.schelp
@@ -981,10 +981,10 @@ Unless noted otherwise, the return value of all these methods will be an link::C
 note::Interval Notation Guide for this part:
 table::
 ## Notation || Name || Inclusion || Meaning (Range)
-## teletype::[a, b]:: || Closed interval || Includes both teletype::a:: and teletype::b:: || math::a \leqq x \leqq b::
+## teletype::[a, b]:: || Closed interval || Includes both teletype::a:: and teletype::b:: || math::a \leq x \leq b::
 ## teletype::(a, b):: || Open interval || Excludes both teletype::a:: and teletype::b:: ||  math::a \lt x \lt b::
-## teletype::[a, b):: || Half‑open interval (left‑closed) || Includes teletype::a::, excludes teletype::b:: || math::a \leqq x \lt b::
-## teletype::(a, b]:: || Half‑open interval (right‑closed) || Excludes teletype::a::, includes teletype::b:: ||  math::a \lt x \leqq b::
+## teletype::[a, b):: || Half‑open interval (left‑closed) || Includes teletype::a::, excludes teletype::b:: || math::a \leq x \lt b::
+## teletype::(a, b]:: || Half‑open interval (right‑closed) || Excludes teletype::a::, includes teletype::b:: ||  math::a \lt x \leq b::
 ::
 ::
 

--- a/HelpSource/Classes/SimpleNumber.schelp
+++ b/HelpSource/Classes/SimpleNumber.schelp
@@ -980,11 +980,11 @@ Unless noted otherwise, the return value of all these methods will be an link::C
 
 note::Interval Notation Guide for this part:
 table::
-## Notation || Name || Inclusion || Example meaning (numeric range)
-## teletype::[a, b]:: || Closed interval || Includes both a and b || a ≤ x ≤ b → e.g. [1, 5] = 1 ≤ x ≤ 5
-## teletype::(a, b):: || Open interval || Excludes both a and b || a < x < b → e.g. (1, 5) = 1 < x < 5
-## teletype::[a, b):: || Half‑open interval (left‑closed) || Includes a, excludes b || a ≤ x < b → e.g. [1, 5) = 1 ≤ x < 5
-## teletype::(a, b]:: || Half‑open interval (right‑closed) || Excludes a, includes b || a < x ≤ b → e.g. (1, 5] = 1 < x ≤ 5
+## Notation || Name || Inclusion || Meaning (Range)
+## teletype::[a, b]:: || Closed interval || Includes both a and b || math::a \leqq x \leqq b::
+## teletype::(a, b):: || Open interval || Excludes both a and b ||  math::a \lt x \lt b::
+## teletype::[a, b):: || Half‑open interval (left‑closed) || Includes a, excludes b || math::a \leqq x \lt b::
+## teletype::(a, b]:: || Half‑open interval (right‑closed) || Excludes a, includes b ||  math::a \lt x \leqq b::
 ::
 ::
 

--- a/HelpSource/Classes/SimpleNumber.schelp
+++ b/HelpSource/Classes/SimpleNumber.schelp
@@ -981,10 +981,10 @@ Unless noted otherwise, the return value of all these methods will be an link::C
 note::Interval Notation Guide for this part:
 table::
 ## Notation || Name || Inclusion || Meaning (Range)
-## teletype::[a, b]:: || Closed interval || Includes both a and b || math::a \leqq x \leqq b::
-## teletype::(a, b):: || Open interval || Excludes both a and b ||  math::a \lt x \lt b::
-## teletype::[a, b):: || Half‑open interval (left‑closed) || Includes a, excludes b || math::a \leqq x \lt b::
-## teletype::(a, b]:: || Half‑open interval (right‑closed) || Excludes a, includes b ||  math::a \lt x \leqq b::
+## teletype::[a, b]:: || Closed interval || Includes both teletype::a:: and teletype::b:: || math::a \leqq x \leqq b::
+## teletype::(a, b):: || Open interval || Excludes both teletype::a:: and teletype::b:: ||  math::a \lt x \lt b::
+## teletype::[a, b):: || Half‑open interval (left‑closed) || Includes teletype::a::, excludes teletype::b:: || math::a \leqq x \lt b::
+## teletype::(a, b]:: || Half‑open interval (right‑closed) || Excludes teletype::a::, includes teletype::b:: ||  math::a \lt x \leqq b::
 ::
 ::
 


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

I raised the possibility of including a brief guide to interval notation within the section on random number generation in SimpleNumber.schelp. I believe this addition would be beneficial for readers who may not be familiar with musical notation, particularly in the context of intervals. By providing a concise explanation, we can make the documentation more accessible and informative for a broader audience.
This PR is motivated by https://github.com/supercollider/supercollider/pull/7079#discussion_r2304962174.

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->

- Documentation
- 
## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
