### PR TITLE
supernova: fix include w/ system boost

### DIFF
--- a/server/supernova/server/server.cpp
+++ b/server/supernova/server/server.cpp
@@ -18,6 +18,8 @@
 
 #include <stdexcept>
 
+#include <boost/tuple/tuple.hpp>
+
 #include "SC_Win32Utils.h"
 
 #include "nova-tt/thread_affinity.hpp"


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

when compiling w/ system boost (1.88.0) and w/o jack, it fails with
```
SuperCollider-3.14.0-Source/server/supernova/server/server.cpp:278:16: error: ‘tie’ is not a member of ‘boost’; did you mean ‘xtime’?
  278 |         boost::tie(min, max) = thread_priority_interval_rt();
      |                ^~~
      |                xtime
```

## Types of changes

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
