### PR TITLE
[lang, supernova] use cpp structured binding declarations

### DIFF
--- a/lang/LangPrimSource/PyrFilePrim.cpp
+++ b/lang/LangPrimSource/PyrFilePrim.cpp
@@ -1362,22 +1362,15 @@ int prPipeOpen(struct VMGlobals* g, int numArgsPushed) {
 
     PyrFile* pfile = reinterpret_cast<PyrFile*>(slotRawObject(callerSlot));
 
-    // c++17 structured binding declarations will make this into a single line
-    // auto [error, string] = ...
-    int error;
-    std::string commandLine;
-    std::tie(error, commandLine) = slotStrStdStrVal(commandLineSlot);
-    if (error != errNone)
-        return error;
+    auto [errorCmd, commandLine] = slotStrStdStrVal(commandLineSlot);
+    if (errorCmd != errNone)
+        return errorCmd;
 
-    std::string mode;
-    std::tie(error, mode) = slotStrStdStrVal(modeSlot);
-    if (error != errNone)
-        return error;
+    auto [errorMode, mode] = slotStrStdStrVal(modeSlot);
+    if (errorMode != errNone)
+        return errorMode;
 
-    pid_t pid;
-    FILE* file;
-    std::tie(pid, file) = sc_popen_shell(std::move(commandLine), mode);
+    auto [pid, file] = sc_popen_shell(std::move(commandLine), mode);
     if (file != nullptr) {
         SetPtr(&pfile->fileptr, file);
         SetInt(callerSlot, pid);
@@ -1413,22 +1406,15 @@ int prPipeOpenArgv(struct VMGlobals* g, int numArgsPushed) {
     if (argsColl->size < 1)
         return errFailed;
 
-    // c++17 structured binding declarations will make this into a single line
-    // auto [error, mode] = ...;
-    int error;
-    std::string mode;
-    std::tie(error, mode) = slotStrStdStrVal(modeSlot);
-    if (error != errNone)
-        return error;
+    auto [errorMode, mode] = slotStrStdStrVal(modeSlot);
+    if (errorMode != errNone)
+        return errorMode;
 
-    std::vector<std::string> strings;
-    std::tie(error, strings) = PyrCollToVectorStdString(argsColl);
-    if (error != errNone)
-        return error;
+    auto [errorStr, strings] = PyrCollToVectorStdString(argsColl);
+    if (errorStr != errNone)
+        return errorStr;
 
-    pid_t pid;
-    FILE* file;
-    std::tie(pid, file) = sc_popen_argv(strings, mode);
+    auto [pid, file] = sc_popen_argv(strings, mode);
 
     if (file != nullptr) {
         SetPtr(&pfile->fileptr, file);

--- a/lang/LangPrimSource/PyrUnixPrim.cpp
+++ b/lang/LangPrimSource/PyrUnixPrim.cpp
@@ -145,9 +145,7 @@ int prString_POpen(struct VMGlobals* g, int numArgsPushed) {
     PyrSlot* callerSlot = g->sp - 1;
     PyrSlot* postOutputSlot = g->sp;
 
-    int error;
-    std::string cmdline;
-    std::tie(error, cmdline) = slotStrStdStrVal(callerSlot);
+    auto [error, cmdline] = slotStrStdStrVal(callerSlot);
     if (error != errNone)
         return error;
 
@@ -156,9 +154,7 @@ int prString_POpen(struct VMGlobals* g, int numArgsPushed) {
     return errNone;
 #endif
 
-    pid_t pid;
-    FILE* stream;
-    std::tie(pid, stream) = sc_popen_shell(std::move(cmdline), "r");
+    auto [pid, stream] = sc_popen_shell(std::move(cmdline), "r");
     if (stream != nullptr) {
         SC_Thread thread(std::bind(string_popen_thread_func, pid, stream, IsTrue(postOutputSlot)));
         thread.detach();
@@ -189,15 +185,11 @@ int prArrayPOpen(struct VMGlobals* g, int numArgsPushed) {
     if (argsColl->size < 1)
         return errFailed;
 
-    int error;
-    std::vector<std::string> strings;
-    std::tie(error, strings) = PyrCollToVectorStdString(argsColl);
+    auto [error, strings] = PyrCollToVectorStdString(argsColl);
     if (error != errNone)
         return error;
 
-    pid_t pid;
-    FILE* stream;
-    std::tie(pid, stream) = sc_popen_argv(strings, "r");
+    auto [pid, stream] = sc_popen_argv(strings, "r");
     if (stream != nullptr) {
         SC_Thread thread(std::bind(string_popen_thread_func, pid, stream, IsTrue(postOutputSlot)));
         thread.detach();

--- a/lang/LangSource/PyrObject.cpp
+++ b/lang/LangSource/PyrObject.cpp
@@ -2780,9 +2780,7 @@ std::tuple<int, std::vector<std::string>> PyrCollToVectorStdString(PyrObject* co
     for (int i = 0; i < coll->size; ++i) {
         PyrSlot argSlot;
         getIndexedSlot(coll, &argSlot, i);
-        int error;
-        std::string string;
-        std::tie(error, string) = slotStrStdStrVal(&argSlot);
+        auto [error, string] = slotStrStdStrVal(&argSlot);
         if (error != errNone) {
             strings.clear();
             return std::make_tuple(error, strings);

--- a/server/supernova/server/server.cpp
+++ b/server/supernova/server/server.cpp
@@ -24,6 +24,8 @@
 #include "nova-tt/thread_priority.hpp"
 #include "nova-tt/name_thread.hpp"
 
+#include <tuple>
+
 #include "server.hpp"
 #include "sync_commands.hpp"
 
@@ -280,8 +282,7 @@ static bool set_realtime_priority(int thread_index) {
 #    elif defined(_WIN32)
         int priority = thread_priority_interval_rt().second;
 #    else
-        int min, max;
-        boost::tie(min, max) = thread_priority_interval_rt();
+        auto [min, max] = thread_priority_interval_rt();
         int priority = max - 3;
         priority = std::max(min, priority);
 #    endif


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

This PR replaces the use of `std::tie` and `boost::tie` with C++17 structured binding declarations `auto [var1, var2] = `.

This change was [suggested in the codebase](https://github.com/supercollider/supercollider/blob/develop/lang/LangPrimSource/PyrFilePrim.cpp#L1365-L1369). 

What prompted this PR was an investigation into a [missing boost include](https://github.com/supercollider/supercollider/pull/7118) in the file that used `boost::tie`.

Please review carefully, I'm out of my depth here.

Edit: Fixes #7120.

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->

- Maintenance

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
