### PR TITLE
SCLang: avoid collecting inside primitives

### DIFF
--- a/lang/LangPrimSource/PyrPrimitive.cpp
+++ b/lang/LangPrimSource/PyrPrimitive.cpp
@@ -3709,6 +3709,8 @@ void doPrimitiveWithKeys(VMGlobals* g, PyrMethod* meth, int allArgsPushed, int n
         }
     }
     g->numpop = numArgsNeeded - 1;
+
+    g->gc->pushInsidePrimitive();
     try {
         err = (*def->func)(g, numArgsNeeded);
     } catch (std::exception& ex) {
@@ -3718,6 +3720,8 @@ void doPrimitiveWithKeys(VMGlobals* g, PyrMethod* meth, int allArgsPushed, int n
         g->lastExceptions[g->thread] = std::make_pair(nullptr, meth);
         err = errException;
     }
+    g->gc->popInsidePrimitive();
+
     if (err <= errNone)
         g->sp -= g->numpop;
     else {

--- a/lang/LangPrimSource/PyrPrimitive.cpp
+++ b/lang/LangPrimSource/PyrPrimitive.cpp
@@ -3710,7 +3710,7 @@ void doPrimitiveWithKeys(VMGlobals* g, PyrMethod* meth, int allArgsPushed, int n
     }
     g->numpop = numArgsNeeded - 1;
 
-    g->gc->pushInsidePrimitive();
+    g->gc->enterDelayedCollectionContext();
     try {
         err = (*def->func)(g, numArgsNeeded);
     } catch (std::exception& ex) {
@@ -3720,7 +3720,7 @@ void doPrimitiveWithKeys(VMGlobals* g, PyrMethod* meth, int allArgsPushed, int n
         g->lastExceptions[g->thread] = std::make_pair(nullptr, meth);
         err = errException;
     }
-    g->gc->popInsidePrimitive();
+    g->gc->exitDelayedCollectionContext();
 
     if (err <= errNone)
         g->sp -= g->numpop;

--- a/lang/LangSource/GC.cpp
+++ b/lang/LangSource/GC.cpp
@@ -653,8 +653,8 @@ void PyrGC::Collect(int32 inNumToScan) {
 }
 
 HOT void PyrGC::Collect() {
-    if (insidePrimitive) {
-        attemptedToCollectInsidePrimitive = true;
+    if (delayCollection) {
+        attemptedToCollectWhenDelayed = true;
         return;
     }
     BEGINPAUSE

--- a/lang/LangSource/GC.cpp
+++ b/lang/LangSource/GC.cpp
@@ -653,8 +653,8 @@ void PyrGC::Collect(int32 inNumToScan) {
 }
 
 HOT void PyrGC::Collect() {
-    if (delayCollection) {
-        attemptedToCollectWhenDelayed = true;
+    if (mDelayCollection) {
+        mAttemptedToCollectWhenDelayed = true;
         return;
     }
     BEGINPAUSE

--- a/lang/LangSource/GC.cpp
+++ b/lang/LangSource/GC.cpp
@@ -653,6 +653,10 @@ void PyrGC::Collect(int32 inNumToScan) {
 }
 
 HOT void PyrGC::Collect() {
+    if (insidePrimitive) {
+        attemptedToCollectInsidePrimitive = true;
+        return;
+    }
     BEGINPAUSE
     bool stackScanned = false;
     mCollects++;

--- a/lang/LangSource/GC.h
+++ b/lang/LangSource/GC.h
@@ -124,7 +124,7 @@ public:
         }
     }
 
-    /// Don't called collect immediately, wait until some context has finished, then call collect.
+    /// Don't call collect immediately, wait until some context has finished, then call collect.
     /// This is implemented primarily for use inside primitives, where collecting while creating temporary objects can
     /// lead to them being freed unless care is taken.
     void enterDelayedCollectionContext() {

--- a/lang/LangSource/GC.h
+++ b/lang/LangSource/GC.h
@@ -124,6 +124,21 @@ public:
         }
     }
 
+    // Don't call collect from inside primitives, instead wait until leaving the primitive.
+    // This ensures that objects created inside the primitive are not destroyed by the collection cycle.
+    void pushInsidePrimitive() {
+        insidePrimitive = true;
+        attemptedToCollectInsidePrimitive = false;
+    }
+
+    void popInsidePrimitive() {
+        insidePrimitive = false;
+        if (attemptedToCollectInsidePrimitive) {
+            Collect();
+            attemptedToCollectInsidePrimitive = false;
+        }
+    }
+
     // users should not call anything below.
 
     void Collect();
@@ -207,6 +222,9 @@ private:
     unsigned char mBlackColor, mGreyColor, mWhiteColor, mFreeColor;
     bool mCanSweep;
     bool mRunning;
+
+    bool insidePrimitive { false };
+    bool attemptedToCollectInsidePrimitive { false };
 };
 
 inline void PyrGC::DLRemove(PyrObjectHdr* obj) {

--- a/lang/LangSource/GC.h
+++ b/lang/LangSource/GC.h
@@ -128,13 +128,13 @@ public:
     /// This is implemented primarily for use inside primitives, where collecting while creating temporary objects can
     /// lead to them being freed unless care is taken.
     void enterDelayedCollectionContext() {
-        delayCollection = true;
-        attemptedToCollectWhenDelayed = false;
+        mDelayCollection = true;
+        mAttemptedToCollectWhenDelayed = false;
     }
     void exitDelayedCollectionContext() {
-        delayCollection = false;
-        if (attemptedToCollectWhenDelayed) {
-            attemptedToCollectWhenDelayed = false;
+        mDelayCollection = false;
+        if (mAttemptedToCollectWhenDelayed) {
+            mAttemptedToCollectWhenDelayed = false;
             Collect();
         }
     }
@@ -142,8 +142,8 @@ public:
     /// a primitive). You probably don't want to call this. If you do (and have benchmarks to prove it), it must be
     /// called before any allocations are made (at the top of the primitive) otherwise memory leaks may arise.
     void enableImmediateCollections() {
-        delayCollection = false;
-        attemptedToCollectWhenDelayed = false;
+        mDelayCollection = false;
+        mAttemptedToCollectWhenDelayed = false;
     }
 
     // users should not call anything below.
@@ -230,8 +230,8 @@ private:
     bool mCanSweep;
     bool mRunning;
 
-    bool delayCollection { false };
-    bool attemptedToCollectWhenDelayed { false };
+    bool mDelayCollection { false };
+    bool mAttemptedToCollectWhenDelayed { false };
 };
 
 inline void PyrGC::DLRemove(PyrObjectHdr* obj) {

--- a/lang/LangSource/GC.h
+++ b/lang/LangSource/GC.h
@@ -124,19 +124,26 @@ public:
         }
     }
 
-    // Don't call collect from inside primitives, instead wait until leaving the primitive.
-    // This ensures that objects created inside the primitive are not destroyed by the collection cycle.
-    void pushInsidePrimitive() {
-        insidePrimitive = true;
-        attemptedToCollectInsidePrimitive = false;
+    /// Don't called collect immediately, wait until some context has finished, then call collect.
+    /// This is implemented primarily for use inside primitives, where collecting while creating temporary objects can
+    /// lead to them being freed unless care is taken.
+    void enterDelayedCollectionContext() {
+        delayCollection = true;
+        attemptedToCollectWhenDelayed = false;
     }
-
-    void popInsidePrimitive() {
-        insidePrimitive = false;
-        if (attemptedToCollectInsidePrimitive) {
+    void exitDelayedCollectionContext() {
+        delayCollection = false;
+        if (attemptedToCollectWhenDelayed) {
+            attemptedToCollectWhenDelayed = false;
             Collect();
-            attemptedToCollectInsidePrimitive = false;
         }
+    }
+    /// To be called when you **absolutely** know you want collect to be called inside a delay collection context (e.g.
+    /// a primitive). You probably don't want to call this. If you do (and have benchmarks to prove it), it must be
+    /// called before any allocations are made (at the top of the primitive) otherwise memory leaks may arise.
+    void enableImmediateCollections() {
+        delayCollection = false;
+        attemptedToCollectWhenDelayed = false;
     }
 
     // users should not call anything below.
@@ -223,8 +230,8 @@ private:
     bool mCanSweep;
     bool mRunning;
 
-    bool insidePrimitive { false };
-    bool attemptedToCollectInsidePrimitive { false };
+    bool delayCollection { false };
+    bool attemptedToCollectWhenDelayed { false };
 };
 
 inline void PyrGC::DLRemove(PyrObjectHdr* obj) {


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

When you allocate inside a primitive, if you don't connect that resource to the memory graph the next time you allocate (and call collect) the object might be collected, leaving you with an invalid memory resource. This has caused many bugs in the past. This PR simply holds off calling collect until the primitive has finished.

This has the potential draw back that if you are creating many temporary objects, you might run out of memory. But none of the primitives do this right now, and the ones that do allocate a lot of temporary objects usually disable the collection cycle anyway to avoid having the GC free the objects before they are placed on the stack.

## Types of changes

<!-- Delete lines that don't apply -->

- Memory management improvement


## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
