### PR TITLE
Classlib: DoesNotUnderstandError: Do not do method fuzzy matching until needed

### DIFF
--- a/SCClassLibrary/Common/Core/Error.sc
+++ b/SCClassLibrary/Common/Core/Error.sc
@@ -151,7 +151,9 @@ DoesNotUnderstandError : MethodError {
 		.selector_(selector)
 		.args_(args)
 		.keywordArgumentPairs_(keywordArgumentPairs)
-		.init
+		// note: deliberately not calling '.init'
+		// until a method suggestion is needed;
+		// see 'suggestion' below
 	}
 
 	init {
@@ -186,6 +188,13 @@ DoesNotUnderstandError : MethodError {
 		^"ERROR: Message '" ++ selector ++ "' not understood."
 	}
 
+	suggestion {
+		if(suggestion.size == 0) {  // size == 0 for both "" and nil
+			this.init;
+		};
+		^suggestion
+	}
+
 	reportError {
 		this.errorString.postln;
 		"RECEIVER:\n".post;
@@ -201,7 +210,7 @@ DoesNotUnderstandError : MethodError {
 		this.dumpBackTrace;
 		// this.adviceLink.postln;
 		"\n^^ %\nRECEIVER: %\n".postf(this.errorString, receiver);
-		suggestion.postln;
+		this.suggestion.postln;
 		"\n".post;
 	}
 	adviceLinkPage {


### PR DESCRIPTION
## Purpose and Motivation

(2nd try at this -- thank you, git :-\ )

I propose to defer DoesNotUnderstandError's initialization until the "suggestion" string is actually needed.

`.init` is expensive (fuzzy-string searching over the entire set of method selectors belonging to the class or any superclasses).

Currently, it is called in the error object's constructor.

This is fine on the assumption that an error will always be reported.

But we have `.try`, so that assumption is not correct.

```
bench { 100.do { try { 1.flippityblurghle } } }
time to run: 0.782680016 seconds.
```

Here, the user is explicitly swallowing the error. There's a lot of work being done to identify possible replacements for `flippityblurghle` and none of that work will ever be used, in this case = wasted CPU cycles.

With a change in this PR, `time to run: 0.00091296800000862 seconds.` -- 3 orders of magnitude faster.

Admittedly, this is a corner case -- 99.9999% of the time, the error will be reported. But, in the `.try` case, why not skip the expensive operation that might not be needed?

## Types of changes

- Enhancement

## To-do list

- [x] Code is tested
- [x] All tests are passing
- [ ] ~~Updated documentation~~
- [x] This PR is ready for review