### PR TITLE
Add NSMotionUsageDescription for AirPod positional tracking support

### DIFF
--- a/cmake_modules/MacOSXBundleInfo.plist.in
+++ b/cmake_modules/MacOSXBundleInfo.plist.in
@@ -151,6 +151,8 @@
 	<string>NSApplication</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>SuperCollider wants to use your microphone or sound input.</string>
+	<key>NSMotionUsageDescription</key>
+	<string>SuperCollider wants to use your airpods to use spatial audio.</string>
 	<key>NSServices</key>
 	<array>
 		<dict>


### PR DESCRIPTION
## Purpose and Motivation

Allows to access positional tracking data from connected AirPods on macOS via external UGens.
See https://github.com/capital-G/sc_airpods/

Without this PR the server crashes when the plugin gets loaded due to missing permissions.

## Types of changes

- New feature

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
