### PR TITLE
SCLang: fix disable collect in primitives

### DIFF
--- a/lang/LangPrimSource/PyrPrimitive.cpp
+++ b/lang/LangPrimSource/PyrPrimitive.cpp
@@ -3586,6 +3586,8 @@ void doPrimitive(VMGlobals* g, PyrMethod* meth, int numArgsPushed) {
     g->primitiveMethod = meth;
     g->args = g->sp - numArgsNeeded;
     int err;
+
+    g->gc->enterDelayedCollectionContext();
     try {
 #ifdef GC_SANITYCHECK
         g->gc->SanityCheck();
@@ -3601,6 +3603,9 @@ void doPrimitive(VMGlobals* g, PyrMethod* meth, int numArgsPushed) {
         g->lastExceptions[g->thread] = std::make_pair(nullptr, meth);
         err = errException;
     }
+    g->gc->exitDelayedCollectionContext();
+
+
     if (err <= errNone)
         g->sp -= g->numpop;
     else {
@@ -3635,6 +3640,8 @@ void doPrimitiveWithKeys(VMGlobals* g, PyrMethod* meth, int allArgsPushed, int n
 
     if (def->keyArgs && numKeyArgsPushed) {
         g->numpop = allArgsPushed - 1;
+
+        g->gc->enterDelayedCollectionContext();
         try {
             err = ((PrimitiveWithKeysHandler)def[1].func)(g, allArgsPushed, numKeyArgsPushed);
         } catch (std::exception& ex) {
@@ -3644,6 +3651,8 @@ void doPrimitiveWithKeys(VMGlobals* g, PyrMethod* meth, int allArgsPushed, int n
             g->lastExceptions[g->thread] = std::make_pair(nullptr, meth);
             err = errException;
         }
+        g->gc->exitDelayedCollectionContext();
+
         if (err <= errNone)
             g->sp -= g->numpop;
         else {


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

Previously I missed these two other places where primitives are called. It only worked in one of the three cases where primitives are called. 


## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix


## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [ ] Code is tested
- [x] All tests are passing
- [ ] Updated documentation
- [ ] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
