### PR TITLE
classlib: nodeproxy: init filter role inside a synthdef

### DIFF
--- a/SCClassLibrary/JITLib/ProxySpace/wrapForNodeProxy.sc
+++ b/SCClassLibrary/JITLib/ProxySpace/wrapForNodeProxy.sc
@@ -296,9 +296,11 @@
 			filter: #{ | func, proxy, channelOffset = 0, index |
 				var ok, ugen;
 				if(proxy.isNeutral) {
-					ugen = func.value(Silent.ar);
-					ok = proxy.initBus(ugen.rate, ugen.numChannels + channelOffset);
-					if(ok.not) { Error("NodeProxy input: wrong rate/numChannels").throw }
+					asSynthDef {
+						ugen = func.value(Silent.ar);
+						ok = proxy.initBus(ugen.rate, ugen.numChannels + channelOffset);
+						if(ok.not) { Error("NodeProxy input: wrong rate/numChannels").throw }
+					}
 				};
 
 				{ | out |
@@ -309,7 +311,7 @@
 					} {
 						env = ctl * EnvGate(i_level: 0, doneAction:2, curve:\lin);
 						XOut.kr(out, env, SynthDef.wrap(func, nil, [In.kr(out, proxy.numChannels)]))
-                    };
+					};
 				}.buildForProxy( proxy, channelOffset, index )
 
 			},
@@ -357,9 +359,11 @@
 			filterIn: #{ | func, proxy, channelOffset = 0, index |
 				var ok, ugen;
 				if(proxy.isNeutral) {
-					ugen = func.value(Silent.ar);
-					ok = proxy.initBus(ugen.rate, ugen.numChannels + channelOffset);
-					if(ok.not) { Error("NodeProxy input: wrong rate/numChannels").throw }
+					asSynthDef {
+						ugen = func.value(Silent.ar);
+						ok = proxy.initBus(ugen.rate, ugen.numChannels + channelOffset);
+						if(ok.not) { Error("NodeProxy input: wrong rate/numChannels").throw }
+					}
 				};
 
 				{ | out |


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

Often, ugen functions expect to be called within a SynthDef. When probing the function for rates and numChannels, we need to create a context in which it is valid to call the ugen function. 

This concerns `\filter` and the `\filterIn` role of NodeProxy objects.

Fixes #7158.

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

Release Notes: functions with controlnames can be used as filter roles in NodeProxy.
