### PR TITLE
classlib: NodeMap: move map to base class

### DIFF
--- a/HelpSource/Classes/NodeMap.schelp
+++ b/HelpSource/Classes/NodeMap.schelp
@@ -20,6 +20,9 @@ set arguments of a node
 method::unset
 remove settings
 
+method::map
+map arguments of a node (synonymous with code::set::, mapping is done automatically when a suitable argument is passed).
+
 method::unmap
 remove mappings
 

--- a/SCClassLibrary/JITLib/ProxySpace/NodeMap.sc
+++ b/SCClassLibrary/JITLib/ProxySpace/NodeMap.sc
@@ -28,6 +28,12 @@ NodeMap : IdentityDictionary {
 		this.changed(\unset, keys);
 	}
 
+	map { |...args|
+		this.putPairs(args);
+		upToDate = false;
+		this.changed(\map, args);
+	}
+
 	unmap { |... keys|
 		keys.do { |x| this.put(x, nil) };
 		this.changed(\unmap, keys);
@@ -105,14 +111,6 @@ ProxyNodeMap : NodeMap {
 
 	wakeUpParentsToBundle { | bundle, checkedAlready |
 		this.pairsDo({ |key, item| item.wakeUpToBundle(bundle, checkedAlready) });
-	}
-
-	// map works only for proxies so far
-
-	map { |...args|
-		this.putPairs(args);
-		upToDate = false;
-		this.changed(\map, args);
 	}
 
 	mapEnvir { |... keys|


### PR DESCRIPTION
## Purpose and Motivation

NodeMap implements unmap, so we expact map, even if this is a synonym

## Types of changes

<!-- Delete lines that don't apply -->

- Documentation
- New feature

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->


Release Notes: NodeMap now implements map (synonym with set), instead of only ProxyNodeMap.
