### PR TITLE
revert adding empty sections within changelog.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,10 +97,6 @@ This change makes a number of new things possible, e.g.
 - `DoesNotUnderstandError` informs about keyword arguments.
 - Make `Pbind` work with kwargs (this syntax works now: `Pbind(note: Pseq([-3, -2, 0, 1, 6, 13]), dur: 0.05, amp: 0.1).play`) by @JordanHendersonMusic and @telephon in https://github.com/supercollider/supercollider/pull/6530 
 
-### General: Changed
-
-### General: Fixed
-
 ### Class library: Added
 
 - ScopeView: allow lissajou mode for more than two channels as overlaid pairs by @elgiano in https://github.com/supercollider/supercollider/pull/6212


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation
In https://github.com/supercollider/supercollider/pull/7079, two empty categories in CHANGELOG.md created. This PR removes them.

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->

- Documentation
- Bug fix
- New feature
- Breaking change

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
