### PR TITLE
SCLang: Refactor primitives and keyword arguments

### DIFF
--- a/QtCollider/primitives/prim_QWidget.cpp
+++ b/QtCollider/primitives/prim_QWidget.cpp
@@ -48,7 +48,7 @@ QC_LANG_PRIMITIVE(QWidget_SetFocus, 1, PyrSlot* r, PyrSlot* a, VMGlobals* g) {
     return errNone;
 }
 
-QC_LANG_PRIMITIVE(QWidget_BringFront, 1, PyrSlot* r, PyrSlot* a, VMGlobals* g) {
+QC_LANG_PRIMITIVE(QWidget_BringFront, 0, PyrSlot* r, PyrSlot* a, VMGlobals* g) {
     QWidgetProxy* proxy = QWIDGET_PROXY_RECEIVER(r);
 
     QApplication::postEvent(proxy, new QEvent((QEvent::Type)QtCollider::Event_Proxy_BringFront));
@@ -56,7 +56,7 @@ QC_LANG_PRIMITIVE(QWidget_BringFront, 1, PyrSlot* r, PyrSlot* a, VMGlobals* g) {
     return errNone;
 }
 
-QC_LANG_PRIMITIVE(QWidget_Refresh, 1, PyrSlot* r, PyrSlot* a, VMGlobals* g) {
+QC_LANG_PRIMITIVE(QWidget_Refresh, 0, PyrSlot* r, PyrSlot* a, VMGlobals* g) {
     QWidgetProxy* proxy = QWIDGET_PROXY_RECEIVER(r);
 
     if (!proxy->compareThread())
@@ -189,7 +189,7 @@ QC_LANG_PRIMITIVE(QWidget_SetAcceptsMouse, 1, PyrSlot* r, PyrSlot* a, VMGlobals*
     return errNone;
 }
 
-QC_LANG_PRIMITIVE(QWidget_AcceptsMouse, 1, PyrSlot* r, PyrSlot* a, VMGlobals* g) {
+QC_LANG_PRIMITIVE(QWidget_AcceptsMouse, 0, PyrSlot* r, PyrSlot* a, VMGlobals* g) {
     QWidgetProxy* proxy = QWIDGET_PROXY_RECEIVER(r);
     if (!proxy->compareThread())
         return QtCollider::wrongThreadError();

--- a/SCClassLibrary/Common/Collections/String.sc
+++ b/SCClassLibrary/Common/Collections/String.sc
@@ -383,10 +383,6 @@ String[char] : RawArray {
 		_String_StandardizePath
 		^this.primitiveFailed
 	}
-	realPath {
-		_String_RealPath
-		^this.primitiveFailed
-	}
 
 	withTrailingSlash {
 		^if(this.isEmpty or: { this.last.isPathSeparator.not }) {

--- a/SCClassLibrary/Common/Control/SerialPort.sc
+++ b/SCClassLibrary/Common/Control/SerialPort.sc
@@ -168,7 +168,7 @@ SerialPort {
 	}
 
 	// PRIMITIVE
-	prOpen { | ... args |
+	prOpen { | portName, exclusive, baudrate, databits, stopBits, parity, crtscts, xonxoff |
 		_SerialPort_Open
 		^this.primitiveFailed
 	}

--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -215,7 +215,7 @@ ServerShmInterface {
 		^this
 	}
 
-	connect {
+	connect { |portNumber|
 		_ServerShmInterface_connectSharedMem
 		^this.primitiveFailed
 	}
@@ -225,22 +225,22 @@ ServerShmInterface {
 		^this.primitiveFailed
 	}
 
-	getControlBusValue {
+	getControlBusValue { |busNumber|
 		_ServerShmInterface_getControlBusValue
 		^this.primitiveFailed
 	}
 
-	getControlBusValues {
+	getControlBusValues { |busNumber, count|
 		_ServerShmInterface_getControlBusValues
 		^this.primitiveFailed
 	}
 
-	setControlBusValue {
+	setControlBusValue { |busNumber, value|
 		_ServerShmInterface_setControlBusValue
 		^this.primitiveFailed
 	}
 
-	setControlBusValues {
+	setControlBusValues { |busNumber, values|
 		_ServerShmInterface_setControlBusValues
 		^this.primitiveFailed
 	}

--- a/SCClassLibrary/Common/Core/Function.sc
+++ b/SCClassLibrary/Common/Core/Function.sc
@@ -28,7 +28,7 @@ Function : AbstractFunction {
 
 
 	// evaluation
-	value { arg ... args;
+	value { | ...args, kwargs|
 		_FunctionValue
 		// evaluate a function with args
 		^this.primitiveFailed
@@ -40,7 +40,7 @@ Function : AbstractFunction {
 		^this.primitiveFailed
 	}
 
-	valueEnvir { arg ... args;
+	valueEnvir { | ...args, kwargs|
 		_FunctionValueEnvir
 		// evaluate a function with args.
 		// unsupplied argument names are looked up in the currentEnvironment
@@ -53,7 +53,7 @@ Function : AbstractFunction {
 		// unsupplied argument names are looked up in the currentEnvironment
 		^this.primitiveFailed
 	}
-	functionPerformList { |... args, kwargs|
+	functionPerformList { | ...args, kwargs|
         _ObjectPerformList;
         this.primitiveFailed
 	}

--- a/SCClassLibrary/Common/Core/Object.sc
+++ b/SCClassLibrary/Common/Core/Object.sc
@@ -84,7 +84,7 @@ Object {
 		_ObjectPerformMsg;
 		^this.primitiveFailed
 	}
-	perform { arg selector ... args;
+	perform { |selector ...args, kwargs|
 		_ObjectPerform;
 		^this.primitiveFailed
 	}
@@ -104,7 +104,7 @@ Object {
 	// \perform would be looked up in the superclass, not the selector you are interested in.
 	// Hence these methods, which look up the selector in the superclass.
 	// These methods must be called with this as the receiver.
-	superPerform { | ... args, kwargs|
+	superPerform { | ...args, kwargs|
 		_SuperPerform;
 		^this.primitiveFailed
 	}
@@ -113,13 +113,13 @@ Object {
 		^this.primitiveFailed
 	}
 
-	tryPerform { |  ... args, kwargs|
+	tryPerform { | ...args, kwargs|
 		^if(this.respondsTo(args[0]), {
-			this.performArgs(args[0],  args[1..], kwargs)
+			this.performArgs(args[0], args[1..], kwargs)
 		})
 	}
 
-	multiChannelPerform { arg selector ... args;
+	multiChannelPerform { |selector ... args|
 		^flop([this, selector] ++ args).collect { |item|
 			performList(item[0], item[1], item[2..])
 		}
@@ -745,7 +745,7 @@ Object {
 		// to actually put things in the object you need to
 		// add them.
 	}
-	*prNewCopyArgs { arg ... args;
+	*prNewCopyArgs { | ...args, kwargs|
 		_BasicNewCopyArgsToInstVars
 		^this.primitiveFailed
 		// creates a new instance which holds the args as slots

--- a/SCClassLibrary/Common/Core/Symbol.sc
+++ b/SCClassLibrary/Common/Core/Symbol.sc
@@ -189,10 +189,10 @@ Symbol {
 	rrand { ^this }
 	exprand { ^this }
 
-	< { arg aNumber; _LT; ^this }
-	> { arg aNumber; _GT; ^this }
-	<= { arg aNumber; _LE; ^this }
-	>= { arg aNumber; _GE; ^this }
+	< { |aNumber, adverb| _LT; ^this }
+	> { |aNumber, adverb| _GT; ^this }
+	<= { |aNumber, adverb| _LE; ^this }
+	>= { |aNumber, adverb| _GE; ^this }
 
 	degreeToKey { ^this }
 

--- a/SCClassLibrary/Common/GUI/Base/QImage.sc
+++ b/SCClassLibrary/Common/GUI/Base/QImage.sc
@@ -394,7 +394,7 @@ Image {
 		^this.primitiveFailed
 	}
 
-	prNewSVG { arg path;
+	prNewSVG { |path, size, element|
 		_QImage_NewSVG
 		^this.primitiveFailed
 	}

--- a/SCClassLibrary/Common/GUI/Base/QPalette.sc
+++ b/SCClassLibrary/Common/GUI/Base/QPalette.sc
@@ -68,7 +68,7 @@ QPalette {
 		^this.primitiveFailed
 	}
 
-	prAuto {
+	prAuto { |button, window|
 		_QPalette_Auto
 		^this.primitiveFailed
 	}

--- a/SCClassLibrary/Common/GUI/Base/QPen.sc
+++ b/SCClassLibrary/Common/GUI/Base/QPen.sc
@@ -300,16 +300,6 @@ Pen {
 
 	//---------------------- PRIVATE! -- Painter on/off-----------------------------
 
-	*prBegin { arg aView;
-		_QPen_Begin
-		^this.primitiveFailed;
-	}
-
-	*prEnd {
-		_QPen_End
-		^this.primitiveFailed;
-	}
-
 	*prDrawImage { arg target, image, source, operation, opacity;
 		_QPen_DrawImage
 		^this.primitiveFailed;

--- a/SCClassLibrary/Common/GUI/Base/QView.sc
+++ b/SCClassLibrary/Common/GUI/Base/QView.sc
@@ -219,7 +219,7 @@ View : QObject {
 		^this.getProperty( \focus );
 	}
 
-	acceptsMouse {
+	acceptsMouse { 
 		_QWidget_AcceptsMouse
 		^this.primitiveFailed;
 	}

--- a/SCClassLibrary/Common/GUI/PlusGUI/Collections/StringPlusGUI.sc
+++ b/SCClassLibrary/Common/GUI/PlusGUI/Collections/StringPlusGUI.sc
@@ -40,14 +40,6 @@
 	drawInRect { arg rect, font, color;
 		Pen.stringInRect( this, rect, font, color )
 	}
-	prDrawAtPoint { arg point, font, color;
-		_String_DrawAtPoint
-		^this.primitiveFailed
-	}
-	prDrawInRect { arg rect, font, color;
-		_String_DrawInRect
-		^this.primitiveFailed
-	}
 	drawCenteredIn { arg rect, font, color;
 		Pen.stringCenteredIn( this, rect, font, color )
 	}
@@ -72,10 +64,6 @@
 		},{
 			^GUI.stringBounds(this, font)
 		});
-	}
-	prBounds { arg rect, font;
-		_String_GetBounds
-		^this.primitiveFailed
 	}
 
 

--- a/SCClassLibrary/Common/Geometry/Rect.sc
+++ b/SCClassLibrary/Common/Geometry/Rect.sc
@@ -155,13 +155,6 @@ Rect {
 		stream << this.class.name << "(" <<* [left, top, width, height] << ")";
 	}
 
-	// the drawing routine here use Quickdraw.
-	// If you want CoreGraphics drawing, use methods in Pen.
-	draw { arg color, operation=2;
-		_Rect_Draw
-		^this.primitiveFailed
-	}
-
 	asRect { ^this }
 	asSize { ^Size(width, height) }
 	bounds { ^Rect.new(left, top, width, height) }

--- a/SCClassLibrary/Common/Math/Signal.sc
+++ b/SCClassLibrary/Common/Math/Signal.sc
@@ -262,36 +262,36 @@ Signal[float] : FloatArray {
 	scurve { _SCurve; ^this.primitiveFailed }
 	ramp { _Ramp; ^this.primitiveFailed }
 
-	+ { arg aNumber; _Add; ^aNumber.performBinaryOpOnSignal('+', this) }
-	- { arg aNumber; _Sub; ^aNumber.performBinaryOpOnSignal('-', this) }
-	* { arg aNumber; _Mul; ^aNumber.performBinaryOpOnSignal('*', this) }
-	/ { arg aNumber; _FDiv; ^aNumber.performBinaryOpOnSignal('/', this) }
-	mod { arg aNumber; _Mod; ^aNumber.performBinaryOpOnSignal('mod', this) }
-	modSeaside { arg aNumber; _Mod; ^aNumber.performBinaryOpOnSignal('mod', this) }
-	div { arg aNumber; _IDiv; ^aNumber.performBinaryOpOnSignal('div', this) }
-	pow { arg aNumber; _Pow; ^aNumber.performBinaryOpOnSignal('pow', this) }
-	min { arg aNumber; _Min; ^aNumber.performBinaryOpOnSignal('min', this) }
-	max { arg aNumber; _Max; ^aNumber.performBinaryOpOnSignal('max', this) }
-	ring1 { arg aNumber; _Ring1; ^aNumber.performBinaryOpOnSignal('ring1', this) }
-	ring2 { arg aNumber; _Ring2; ^aNumber.performBinaryOpOnSignal('ring2', this) }
-	ring3 { arg aNumber; _Ring3; ^aNumber.performBinaryOpOnSignal('ring3', this) }
-	ring4 { arg aNumber; _Ring4; ^aNumber.performBinaryOpOnSignal('ring4', this) }
-	difsqr { arg aNumber; _DifSqr; ^aNumber.performBinaryOpOnSignal('difsqr', this) }
-	sumsqr { arg aNumber; _SumSqr; ^aNumber.performBinaryOpOnSignal('sumsqr', this) }
-	sqrsum { arg aNumber; _SqrSum; ^aNumber.performBinaryOpOnSignal('sqrsum', this) }
-	sqrdif { arg aNumber; _SqrDif; ^aNumber.performBinaryOpOnSignal('sqrdif', this) }
-	absdif { arg aNumber; _AbsDif; ^aNumber.performBinaryOpOnSignal('absdif', this) }
-	thresh { arg aNumber; _Thresh; ^aNumber.performBinaryOpOnSignal('thresh', this) }
-	amclip { arg aNumber; _AMClip; ^aNumber.performBinaryOpOnSignal('amclip', this) }
-	scaleneg { arg aNumber; _ScaleNeg; ^aNumber.performBinaryOpOnSignal('scaleneg', this) }
-	clip2 { arg aNumber=1; _Clip2; ^aNumber.performBinaryOpOnSignal('clip2', this) }
-	fold2 { arg aNumber=1; _Fold2; ^aNumber.performBinaryOpOnSignal('fold2', this) }
-	wrap2 { arg aNumber=1; _Wrap2; ^aNumber.performBinaryOpOnSignal('wrap2', this) }
-	excess { arg aNumber=1; _Excess; ^aNumber.performBinaryOpOnSignal('excess', this) }
-	firstArg { arg aNumber; _FirstArg; ^aNumber.performBinaryOpOnSignal('firstArg', this) }
+	+ { arg aNumber, adverb; _Add; ^aNumber.performBinaryOpOnSignal('+', this) }
+	- { arg aNumber, adverb; _Sub; ^aNumber.performBinaryOpOnSignal('-', this) }
+	* { arg aNumber, adverb; _Mul; ^aNumber.performBinaryOpOnSignal('*', this) }
+	/ { arg aNumber, adverb; _FDiv; ^aNumber.performBinaryOpOnSignal('/', this) }
+	mod { arg aNumber, adverb; _Mod; ^aNumber.performBinaryOpOnSignal('mod', this) }
+	modSeaside { arg aNumber, adverb; _Mod; ^aNumber.performBinaryOpOnSignal('mod', this) }
+	div { arg aNumber, adverb; _IDiv; ^aNumber.performBinaryOpOnSignal('div', this) }
+	pow { arg aNumber, adverb; _Pow; ^aNumber.performBinaryOpOnSignal('pow', this) }
+	min { arg aNumber, adverb; _Min; ^aNumber.performBinaryOpOnSignal('min', this) }
+	max { arg aNumber, adverb; _Max; ^aNumber.performBinaryOpOnSignal('max', this) }
+	ring1 { arg aNumber, adverb; _Ring1; ^aNumber.performBinaryOpOnSignal('ring1', this) }
+	ring2 { arg aNumber, adverb; _Ring2; ^aNumber.performBinaryOpOnSignal('ring2', this) }
+	ring3 { arg aNumber, adverb; _Ring3; ^aNumber.performBinaryOpOnSignal('ring3', this) }
+	ring4 { arg aNumber, adverb; _Ring4; ^aNumber.performBinaryOpOnSignal('ring4', this) }
+	difsqr { arg aNumber, adverb; _DifSqr; ^aNumber.performBinaryOpOnSignal('difsqr', this) }
+	sumsqr { arg aNumber, adverb; _SumSqr; ^aNumber.performBinaryOpOnSignal('sumsqr', this) }
+	sqrsum { arg aNumber, adverb; _SqrSum; ^aNumber.performBinaryOpOnSignal('sqrsum', this) }
+	sqrdif { arg aNumber, adverb; _SqrDif; ^aNumber.performBinaryOpOnSignal('sqrdif', this) }
+	absdif { arg aNumber, adverb; _AbsDif; ^aNumber.performBinaryOpOnSignal('absdif', this) }
+	thresh { arg aNumber, adverb; _Thresh; ^aNumber.performBinaryOpOnSignal('thresh', this) }
+	amclip { arg aNumber, adverb; _AMClip; ^aNumber.performBinaryOpOnSignal('amclip', this) }
+	scaleneg { arg aNumber, adverb; _ScaleNeg; ^aNumber.performBinaryOpOnSignal('scaleneg', this) }
+	clip2 { arg aNumber=1, adverb; _Clip2; ^aNumber.performBinaryOpOnSignal('clip2', this) }
+	fold2 { arg aNumber=1, adverb; _Fold2; ^aNumber.performBinaryOpOnSignal('fold2', this) }
+	wrap2 { arg aNumber=1, adverb; _Wrap2; ^aNumber.performBinaryOpOnSignal('wrap2', this) }
+	excess { arg aNumber=1, adverb; _Excess; ^aNumber.performBinaryOpOnSignal('excess', this) }
+	firstArg { arg aNumber, adverb; _FirstArg; ^aNumber.performBinaryOpOnSignal('firstArg', this) }
 
-	== { arg aNumber; _EQ; ^aNumber.performBinaryOpOnSignal('==', this) }
-	!= { arg aNumber; _NE; ^aNumber.performBinaryOpOnSignal('!=', this) }
+	== { arg aNumber, adverb; _EQ; ^aNumber.performBinaryOpOnSignal('==', this) }
+	!= { arg aNumber, adverb; _NE; ^aNumber.performBinaryOpOnSignal('!=', this) }
 
 	clip { arg lo, hi; _ClipSignal; ^this.primitiveFailed }
 	wrap { arg lo, hi; _WrapSignal; ^this.primitiveFailed }

--- a/SCClassLibrary/deprecated/3.13/GUI/QQuartzComposerView.sc
+++ b/SCClassLibrary/deprecated/3.13/GUI/QQuartzComposerView.sc
@@ -26,21 +26,6 @@ QuartzComposerView : View {
 
 	openInQC{ ("open" + path.quote + "-a 'Quartz Composer'").unixCmd }
 
-	setInputValue{|key, value|
-		_QQuartzComposer_SetInputPort
-		^this.primitiveFailed;
-	}
-
-	getInputValue{|key|
-		_QQuartzComposer_GetInputPort
-		^this.primitiveFailed;
-	}
-
-	getOutputValue{|key|
-		_QQuartzComposer_GetOutputPort
-		^this.primitiveFailed;
-	}
-
 	maxFPS_{|rate|
 		this.invokeMethod(\setMaxRenderingFrameRate, rate.asFloat);
 	}

--- a/editors/sc-ide/primitives/sc_ipc_client.cpp
+++ b/editors/sc-ide/primitives/sc_ipc_client.cpp
@@ -475,7 +475,7 @@ void initScIDEPrimitives() {
     definePrimitive(base, index++, "_ScIDE_Connect", ScIDE_Connect, 2, 0);
     definePrimitive(base, index++, "_ScIDE_Connected", ScIDE_Connected, 1, 0);
     definePrimitive(base, index++, "_ScIDE_Send", ScIDE_Send, 3, 0);
-    definePrimitive(base, index++, "_ScIDE_GetQUuid", ScIDE_GetQUuid, 0, 0);
+    definePrimitive(base, index++, "_ScIDE_GetQUuid", ScIDE_GetQUuid, 1, 0);
     definePrimitive(base, index++, "_ScIDE_GetDocTextMirror", ScIDE_GetDocTextMirror, 4, 0);
     definePrimitive(base, index++, "_ScIDE_SetDocTextMirror", ScIDE_SetDocTextMirror, 5, 0);
     definePrimitive(base, index++, "_ScIDE_GetDocSelectionStart", ScIDE_GetDocSelectionStart, 2, 0);

--- a/lang/LangPrimSource/PyrArrayPrimitives.cpp
+++ b/lang/LangPrimSource/PyrArrayPrimitives.cpp
@@ -2487,8 +2487,9 @@ int arrayLevenshteinDistance(PyrSlot* result, const PyrObject* thisArray, const 
 }
 
 int prArrayLevenshteinDistance(struct VMGlobals* g, int numArgsPushed) {
-    auto* slotThatArray = g->sp;
-    auto* slotThisArray = g->sp - 1;
+    // compareFunc = g->sp;  ignored
+    auto* slotThatArray = g->sp - 1;
+    auto* slotThisArray = g->sp - 2;
 
     if (NotObj(slotThisArray) || NotObj(slotThatArray))
         return errWrongType;
@@ -2759,7 +2760,7 @@ void initArrayPrimitives() {
     definePrimitive(base, index++, "_ArrayIndexOfGreaterThan", prArrayIndexOfGreaterThan, 2, 0);
     definePrimitive(base, index++, "_ArrayUnlace", prArrayUnlace, 3, 0);
 
-    definePrimitive(base, index++, "_ArrayLevenshteinDistance", prArrayLevenshteinDistance, 2, 0);
+    definePrimitive(base, index++, "_ArrayLevenshteinDistance", prArrayLevenshteinDistance, 3, 0);
     definePrimitive(base, index++, "_ArrayIsRectangular", prArrayIsRectangular, 1, 0);
 
     definePrimitive(base, index++, "_ArrayHungarianSolve", prArrayHungarianSolve, 1, 0);

--- a/lang/LangPrimSource/PyrBitPrim.cpp
+++ b/lang/LangPrimSource/PyrBitPrim.cpp
@@ -95,8 +95,9 @@ int prSetBit(VMGlobals* g, int numArgsPushed) {
 }
 
 int prHammingDistance(VMGlobals* g, int numArgsPushed) {
-    PyrSlot* a = g->sp - 1;
-    PyrSlot* b = g->sp;
+    PyrSlot* a = g->sp - 2;
+    PyrSlot* b = g->sp - 1;
+    PyrSlot* adverb = g->sp; // Ignored
 
     if (NotInt(a) || NotInt(b))
         return errWrongType;
@@ -128,5 +129,5 @@ void initBitPrimitives() {
     definePrimitive(base, index++, "_Log2Ceil", prLog2Ceil, 1, 0);
     definePrimitive(base, index++, "_SetBit", prSetBit, 3, 0);
     definePrimitive(base, index++, "_BinaryGrayCode", prBinaryGrayCode, 1, 0);
-    definePrimitive(base, index++, "_HammingDistance", prHammingDistance, 2, 0);
+    definePrimitive(base, index++, "_HammingDistance", prHammingDistance, 3, 0);
 }

--- a/lang/LangPrimSource/PyrMathPrim.cpp
+++ b/lang/LangPrimSource/PyrMathPrim.cpp
@@ -95,8 +95,18 @@ template <typename Functor> inline int prOpNum(VMGlobals* g, int numArgsPushed) 
     PyrSlot *a, *b;
     PyrSymbol* msg;
 
-    a = g->sp - 1;
-    b = g->sp;
+    if (numArgsPushed == -1) {
+        // We have called this from the interpreter.
+        // This is quite a hack, consider refactoring this in future so a 'special' value isn't used.
+        a = g->sp - 1;
+        b = g->sp;
+    } else {
+        a = g->sp - (numArgsPushed - 1);
+        b = g->sp - (numArgsPushed - 2);
+    }
+
+    // adverb is ignored. I've written it here to make it clear that it is still passed to the primitive.
+    PyrSlot* adverb = g->sp;
 
     switch (GetTag(a)) {
     case tagInt:
@@ -187,7 +197,13 @@ template <typename Functor> inline int prOpNum(VMGlobals* g, int numArgsPushed) 
         }
         break;
     }
-    g->sp--; // drop
+
+    // drop
+    if (numArgsPushed == -1) {
+        g->sp--;
+    } else {
+        g->sp = g->sp - (numArgsPushed - 1);
+    }
     g->numpop = 0;
 #if TAILCALLOPTIMIZE
     g->tailCall = 0;
@@ -207,8 +223,15 @@ template <typename Functor> inline int prOpInt(VMGlobals* g, int numArgsPushed) 
     PyrSlot *a, *b;
     PyrSymbol* msg;
 
-    a = g->sp - 1;
-    b = g->sp;
+    if (numArgsPushed == -1) {
+        // We have called this from the interpreter.
+        // This is quite a hack, consider refactoring this in future so a 'special' value isn't used.
+        a = g->sp - 1;
+        b = g->sp;
+    } else {
+        a = g->sp - (numArgsPushed - 1);
+        b = g->sp - (numArgsPushed - 2);
+    }
 
     switch (GetTag(b)) {
     case tagInt:
@@ -233,7 +256,13 @@ template <typename Functor> inline int prOpInt(VMGlobals* g, int numArgsPushed) 
         SetFloat(a, Functor::run((double)slotRawInt(a), slotRawFloat(b)));
         break;
     }
-    g->sp--; // drop
+
+    // drop
+    if (numArgsPushed == -1) {
+        g->sp--;
+    } else {
+        g->sp = g->sp - (numArgsPushed - 1);
+    }
     g->numpop = 0;
 #if TAILCALLOPTIMIZE
     g->tailCall = 0;
@@ -253,8 +282,16 @@ template <typename Functor> inline int prOpFloat(VMGlobals* g, int numArgsPushed
     PyrSlot *a, *b;
     PyrSymbol* msg;
 
-    a = g->sp - 1;
-    b = g->sp;
+    if (numArgsPushed == -1) {
+        // We have called this from the interpreter.
+        // This is quite a hack, consider refactoring this in future so a 'special' value isn't used.
+        a = g->sp - 1;
+        b = g->sp;
+    } else {
+        a = g->sp - (numArgsPushed - 1);
+        b = g->sp - (numArgsPushed - 2);
+    }
+
 
     switch (GetTag(b)) {
     case tagInt:
@@ -279,7 +316,13 @@ template <typename Functor> inline int prOpFloat(VMGlobals* g, int numArgsPushed
         SetRaw(a, Functor::run(slotRawFloat(a), slotRawFloat(b)));
         break;
     }
-    g->sp--; // drop
+
+    // drop
+    if (numArgsPushed == -1) {
+        g->sp--;
+    } else {
+        g->sp = g->sp - (numArgsPushed - 1);
+    }
     g->numpop = 0;
 #if TAILCALLOPTIMIZE
     g->tailCall = 0;
@@ -315,8 +358,8 @@ int prSubInt(VMGlobals* g, int numArgsPushed) { return prOpInt<subNum>(g, numArg
 int prMulInt(VMGlobals* g, int numArgsPushed) { return prOpInt<mulNum>(g, numArgsPushed); }
 
 int prModSeasideInt(struct VMGlobals* g, int numArgsPushed) {
-    PyrSlot* a = g->sp - 1;
-    PyrSlot* b = g->sp;
+    PyrSlot* a = g->sp - 2;
+    PyrSlot* b = g->sp - 1;
     int in;
     int err;
 
@@ -1337,13 +1380,14 @@ void initMathPrimitives() {
 
     base = nextPrimitiveIndex();
     index = 0;
-    definePrimitive(base, index++, "_AddInt", prAddInt, 2, 0);
-    definePrimitive(base, index++, "_SubInt", prSubInt, 2, 0);
-    definePrimitive(base, index++, "_MulInt", prMulInt, 2, 0);
-    definePrimitive(base, index++, "_ModSeasideInt", prModSeasideInt, 2, 0);
-    definePrimitive(base, index++, "_AddFloat", prAddFloat, 2, 0);
-    definePrimitive(base, index++, "_SubFloat", prSubFloat, 2, 0);
-    definePrimitive(base, index++, "_MulFloat", prMulFloat, 2, 0);
+    definePrimitive(base, index++, "_AddInt", prAddInt, 3, 0);
+    definePrimitive(base, index++, "_SubInt", prSubInt, 3, 0);
+    definePrimitive(base, index++, "_MulInt", prMulInt, 3, 0);
+    definePrimitive(base, index++, "_ModSeasideInt", prModSeasideInt, 3, 0);
+    definePrimitive(base, index++, "_AddFloat", prAddFloat, 3, 0);
+    definePrimitive(base, index++, "_SubFloat", prSubFloat, 3, 0);
+    definePrimitive(base, index++, "_MulFloat", prMulFloat, 3, 0);
+
     definePrimitive(base, index++, "_NthPrime", prNthPrime, 1, 0);
     definePrimitive(base, index++, "_PrevPrime", prPrevPrime, 1, 0);
     definePrimitive(base, index++, "_NextPrime", prNextPrime, 1, 0);

--- a/lang/LangPrimSource/PyrPrimitive.cpp
+++ b/lang/LangPrimSource/PyrPrimitive.cpp
@@ -3618,14 +3618,9 @@ void doPrimitive(VMGlobals* g, PyrMethod* meth, int numArgsPushed) {
 }
 
 void doPrimitiveWithKeys(VMGlobals* g, PyrMethod* meth, int allArgsPushed, int numKeyArgsPushed) {
-    const auto maybe_gc_sanitycheck = [&]() {
 #ifdef GC_SANITYCHECK
-        g->gc->SanityCheck();
+    g->gc->SanityCheck();
 #endif
-    };
-
-    maybe_gc_sanitycheck();
-
     const int numNormalArgsGiven = allArgsPushed - (numKeyArgsPushed * 2);
 
     PyrMethodRaw* methraw = METHRAW(meth);
@@ -3634,15 +3629,15 @@ void doPrimitiveWithKeys(VMGlobals* g, PyrMethod* meth, int allArgsPushed, int n
     g->primitiveIndex = primIndex - def->base;
     g->primitiveMethod = meth;
 
-    PyrSlot* reciever = g->sp - allArgsPushed + 1;
+    PyrSlot* receiver = g->sp - allArgsPushed + 1;
 
     // Remove kwargs from stack to temporary stack.
     if (numKeyArgsPushed > 0) {
-        PyrSlot* first_kwarg = g->sp - (numKeyArgsPushed * 2) + 1;
+        PyrSlot* firstKwarg = g->sp - (numKeyArgsPushed * 2) + 1;
         for (size_t i { 0 }; i < numKeyArgsPushed * 2; i += 2) {
-            temporaryKeywordStack[i] = first_kwarg[i];
-            assert(first_kwarg[i].isSymbol());
-            temporaryKeywordStack[i + 1] = first_kwarg[i + 1];
+            temporaryKeywordStack[i] = firstKwarg[i];
+            assert(firstKwarg[i].isSymbol());
+            temporaryKeywordStack[i + 1] = firstKwarg[i + 1];
         }
         g->sp -= numKeyArgsPushed * 2;
     }
@@ -3665,9 +3660,8 @@ void doPrimitiveWithKeys(VMGlobals* g, PyrMethod* meth, int allArgsPushed, int n
             }
         } else {
             const unsigned int needed = numNeededArgs - numNormalArgsGiven;
-            const auto disFromSPToReciever = std::distance(g->sp, reciever);
             if (maybeReallocStack(g, needed)) {
-                reciever = g->sp + disFromSPToReciever;
+                receiver = g->sp + std::distance(g->sp, receiver);
             }
             PyrSlot* from = slotRawObject(&meth->prototypeFrame)->slots + numNormalArgsGiven - 1;
             PyrSlot* to = g->sp;
@@ -3679,7 +3673,7 @@ void doPrimitiveWithKeys(VMGlobals* g, PyrMethod* meth, int allArgsPushed, int n
         }
     }
 
-    int num_variable_kwargs = 0;
+    int numVariadicKwargs = 0;
     // Put keywords back on the stack, overriding what was already there on the stack.
     if (numKeyArgsPushed && methraw->totalNumberArguments) {
         PyrSymbol** argNames = slotRawSymbolArray(&meth->argNames)->symbols;
@@ -3690,7 +3684,7 @@ void doPrimitiveWithKeys(VMGlobals* g, PyrMethod* meth, int allArgsPushed, int n
             // We start at one here because you can't override 'this'.
             for (size_t argN { 1 }; argN < methraw->numNormalArguments; ++argN) {
                 if (key == argNames[argN]) {
-                    reciever[argN] = temporaryKeywordStack[keyword + 1];
+                    receiver[argN] = temporaryKeywordStack[keyword + 1];
                     goto found;
                 }
             }
@@ -3701,7 +3695,7 @@ void doPrimitiveWithKeys(VMGlobals* g, PyrMethod* meth, int allArgsPushed, int n
                          slotRawSymbol(&slotRawClass(&meth->ownerclass)->name)->name, slotRawSymbol(&meth->name)->name);
                 }
             } else {
-                num_variable_kwargs += 1;
+                numVariadicKwargs += 1;
                 g->sp += 1;
                 g->sp[0] = temporaryKeywordStack[keyword];
                 g->sp += 1;
@@ -3712,12 +3706,12 @@ void doPrimitiveWithKeys(VMGlobals* g, PyrMethod* meth, int allArgsPushed, int n
         }
     }
 
-    if (num_variable_kwargs) {
+    if (numVariadicKwargs) {
         g->numpop = numArgsOnStack - 1;
         g->gc->enterDelayedCollectionContext();
         int err;
         try {
-            err = ((PrimitiveWithKeysHandler)def[1].func)(g, numArgsOnStack, num_variable_kwargs);
+            err = ((PrimitiveWithKeysHandler)def[1].func)(g, numArgsOnStack, numVariadicKwargs);
         } catch (std::exception& ex) {
             g->lastExceptions[g->thread] = std::make_pair(std::current_exception(), meth);
             err = errException;
@@ -3759,6 +3753,7 @@ void doPrimitiveWithKeys(VMGlobals* g, PyrMethod* meth, int allArgsPushed, int n
             setupForMethod(g, meth, numArgsOnStack, 0);
         }
     }
+
 #ifdef GC_SANITYCHECK
     g->gc->SanityCheck();
 #endif

--- a/lang/LangPrimSource/PyrPrimitive.cpp
+++ b/lang/LangPrimSource/PyrPrimitive.cpp
@@ -3660,8 +3660,10 @@ void doPrimitiveWithKeys(VMGlobals* g, PyrMethod* meth, int allArgsPushed, int n
             }
         } else {
             const unsigned int needed = numNeededArgs - numNormalArgsGiven;
+            // distance is cached here because we are about to reallocate the stack.
+            const auto disFromSPToReciever = std::distance(g->sp, receiver);
             if (maybeReallocStack(g, needed)) {
-                receiver = g->sp + std::distance(g->sp, receiver);
+                receiver = g->sp + disFromSPToReciever;
             }
             PyrSlot* from = slotRawObject(&meth->prototypeFrame)->slots + numNormalArgsGiven - 1;
             PyrSlot* to = g->sp;

--- a/lang/LangPrimSource/PyrPrimitive.cpp
+++ b/lang/LangPrimSource/PyrPrimitive.cpp
@@ -18,6 +18,7 @@
     Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
 */
 
+#include "PyrErrors.h"
 #include "PyrKernel.h"
 #include "PyrObject.h"
 #include "PyrPrimitive.h"
@@ -37,6 +38,7 @@
 #include "SC_AudioDevicePrim.hpp"
 #include "SC_LanguageConfig.hpp"
 #include "SC_Filesystem.hpp"
+#include "VMGlobals.h"
 
 #include <iterator>
 #include <map>
@@ -3748,17 +3750,72 @@ void doPrimitiveWithKeys(VMGlobals* g, PyrMethod* meth, int allArgsPushed, int n
         }
         g->gc->exitDelayedCollectionContext();
 
-    if (err <= errNone)
-        g->sp -= g->numpop;
-    else {
-        // post("primerr %d\n", err);
-        SetInt(&g->thread->primitiveIndex, methraw->specialIndex);
-        SetInt(&g->thread->primitiveError, err);
-        setupForMethod(g, meth, numArgsOnStack, 0);
+        if (err <= errNone)
+            g->sp -= g->numpop;
+        else {
+            // post("primerr %d\n", err);
+            SetInt(&g->thread->primitiveIndex, methraw->specialIndex);
+            SetInt(&g->thread->primitiveError, err);
+            setupForMethod(g, meth, numArgsOnStack, 0);
+        }
     }
 #ifdef GC_SANITYCHECK
     g->gc->SanityCheck();
 #endif
+}
+
+
+namespace sc::primitive_test {
+
+int noKwNoVarArgs(VMGlobals* g, int numArgs) {
+    if (numArgs != 4)
+        return errFailed;
+
+    PyrSlot* a = g->sp - 3;
+    PyrSlot* b = g->sp - 2;
+    PyrSlot* c = g->sp - 1;
+    PyrSlot* d = g->sp;
+
+    auto array = newPyrArray(g->gc, 4, 0, false);
+    array->slots[0] = *a;
+    array->slots[1] = *b;
+    array->slots[2] = *c;
+    array->slots[3] = *d;
+    array->size = 4;
+    *a = PyrSlot::make(array);
+    return errNone;
+}
+
+int noKwWithVarArgs(VMGlobals* g, int numArgs) {
+    if (numArgs < 4)
+        return errFailed;
+    auto array = newPyrArray(g->gc, numArgs, 0, false);
+    std::copy(g->sp - (numArgs - 1), g->sp + 1, array->slots);
+    array->size = numArgs;
+    *(g->sp - numArgs + 1) = PyrSlot::make(array);
+    return errNone;
+}
+
+int kwWithVarArgsSansKw(VMGlobals* g, int numArgs) {
+    if (numArgs < 4)
+        return errFailed;
+    auto array = newPyrArray(g->gc, numArgs, 0, false);
+    std::copy(g->sp - (numArgs - 1), g->sp + 1, array->slots);
+    array->size = numArgs;
+    *(g->sp - numArgs + 1) = PyrSlot::make(array);
+    return errNone;
+}
+
+int kwWithVarArgs(VMGlobals* g, int numArgs, int numKw) {
+    if (numArgs < 4)
+        return errFailed;
+    auto array = newPyrArray(g->gc, numArgs, 0, false);
+    std::copy(g->sp - (numArgs - 1), g->sp + 1, array->slots);
+    array->size = numArgs;
+    *(g->sp - numArgs + 1) = PyrSlot::make(array);
+    return errNone;
+}
+
 }
 
 void initPrimitives() {
@@ -3891,10 +3948,10 @@ void initPrimitives() {
     index = 0;
 
     // tests
-    definePrimitive(base, index++, "_PrimitiveTestNoKwargsNoVarArg", primitiveTests::noKwNoVarArgs, 4, 0);
-    definePrimitive(base, index++, "_PrimitiveTestNoKwargsWithVarArgs", primitiveTests::noKwWithVarArgs, 4, 1);
-    definePrimitiveWithVariableKeys(base, index, "_PrimitiveTestWithKwargs", primitiveTests::kwWithVarArgsSansKw,
-                                    primitiveTests::kwWithVarArgs, 4);
+    definePrimitive(base, index++, "_PrimitiveTestNoKwargsNoVarArg", sc::primitive_test::noKwNoVarArgs, 4, 0);
+    definePrimitive(base, index++, "_PrimitiveTestNoKwargsWithVarArgs", sc::primitive_test::noKwWithVarArgs, 4, 1);
+    definePrimitiveWithVariableKeys(base, index, "_PrimitiveTestWithKwargs", sc::primitive_test::kwWithVarArgsSansKw,
+                                    sc::primitive_test::kwWithVarArgs, 4);
     index += 2;
 
 

--- a/lang/LangPrimSource/PyrPrimitive.cpp
+++ b/lang/LangPrimSource/PyrPrimitive.cpp
@@ -22,18 +22,15 @@
 #include "PyrObject.h"
 #include "PyrPrimitive.h"
 #include "PyrPrimitiveProto.h"
-#include "PyrSignal.h"
 #include "PyrSignalPrim.h"
 #include "PyrMathPrim.h"
 #include "PyrListPrim.h"
-#include "Opcodes.h"
-#include "SC_InlineBinaryOp.h"
+#include "PyrSlot.h"
 #include "PyrMessage.h"
 #include "PyrParseNode.h"
 #include "PyrLexer.h"
 #include "PyrKernelProto.h"
 #include "PyrInterpreter.h"
-#include "PyrArchiverT.h"
 #include "PyrDeepCopier.h"
 #include "PyrDeepFreezer.h"
 #include "InitAlloc.h"
@@ -41,6 +38,7 @@
 #include "SC_LanguageConfig.hpp"
 #include "SC_Filesystem.hpp"
 
+#include <iterator>
 #include <map>
 #include <cstdlib>
 #include <cstring>
@@ -74,24 +72,8 @@ PyrSymbol* s_recvmsg;
 
 void initPatternPrimitives();
 
-typedef struct {
-    PrimitiveHandler func;
-    PyrSymbol* name;
-    unsigned short base;
-    unsigned char numArgs;
-    unsigned char varArgs;
-    unsigned char keyArgs;
-} PrimitiveDef;
 
-typedef struct {
-    int size, maxsize;
-    PrimitiveDef* table;
-} PrimitiveTable;
-
-extern PrimitiveTable gPrimitiveTable;
-
-
-int getPrimitiveNumArgs(int index) { return gPrimitiveTable.table[index].numArgs; }
+int getPrimitiveNumArgs(int index) { return gPrimitiveTable.table[index].numNormalArguments; }
 
 PyrSymbol* getPrimitiveName(int index) { return gPrimitiveTable.table[index].name; }
 
@@ -422,7 +404,7 @@ int prObjectString(struct VMGlobals* g, int numArgsPushed) {
     PyrString* string;
     char str[256];
 
-    a = g->sp;
+    a = g->sp - 1;
     if (IsSym(a)) {
         string = newPyrString(g->gc, slotRawSymbol(a)->name, 0, true);
         SetObject(a, string);
@@ -965,7 +947,7 @@ HOT std::tuple<PyrFrame*, PyrBlock*> buildFrameForBlockPrims(VMGlobals* g, PyrSl
         // setup frame
         auto context = slotRawFrame(&closure->context);
         frame->classptr = class_frame;
-        frame->size = FRAMESIZE + methraw->numtemps;
+        frame->size = FRAMESIZE + methraw->numSlots;
         SetObject(&frame->method, block);
         slotCopy(&frame->homeContext, &context->homeContext);
         slotCopy(&frame->context, &closure->context);
@@ -1153,6 +1135,9 @@ int objectPerformArgs(struct VMGlobals* g, int numArgsPushed) {
 }
 
 int objectPerform(struct VMGlobals* g, int numArgsPushed) {
+    if (numArgsPushed < 2)
+        return errFailed;
+
     PyrSlot *recvrSlot, *selSlot, *listSlot;
     PyrSlot *pslot, *qslot;
     PyrSymbol* selector;
@@ -1230,6 +1215,8 @@ int objectPerform(struct VMGlobals* g, int numArgsPushed) {
 
 int objectPerformWithKeys(VMGlobals* g, int numArgsPushed, int numKeyArgsPushed);
 int objectPerformWithKeys(VMGlobals* g, int numArgsPushed, int numKeyArgsPushed) {
+    if (numArgsPushed < 2)
+        return errFailed;
     PyrSlot *recvrSlot, *selSlot, *listSlot;
     PyrSlot *pslot, *qslot;
     PyrSymbol* selector;
@@ -1293,6 +1280,8 @@ int objectPerformWithKeys(VMGlobals* g, int numArgsPushed, int numKeyArgsPushed)
 
 
 int objectSuperPerform(struct VMGlobals* g, int numArgsPushed) {
+    if (numArgsPushed < 2)
+        return errFailed;
     PyrSlot *recvrSlot, *selSlot, *listSlot;
     PyrSlot *pslot, *qslot;
     PyrSymbol* selector;
@@ -1363,6 +1352,8 @@ int objectSuperPerform(struct VMGlobals* g, int numArgsPushed) {
 
 int objectSuperPerformWithKeys(VMGlobals* g, int numArgsPushed, int numKeyArgsPushed);
 int objectSuperPerformWithKeys(VMGlobals* g, int numArgsPushed, int numKeyArgsPushed) {
+    if (numArgsPushed < 2)
+        return errFailed;
     PyrSlot *recvrSlot, *selSlot, *listSlot;
     PyrSlot *pslot, *qslot;
     PyrSymbol* selector;
@@ -1529,6 +1520,8 @@ int performListTemplate(struct VMGlobals* g, int numArgsPushed, int numKeyArgsPu
 }
 
 int objectPerformListWithKeys(struct VMGlobals* g, int numArgsPushed, int numKeyArgsPushed) {
+    if (numArgsPushed < 2)
+        return errFailed;
     return performListTemplate(
         g, numArgsPushed, numKeyArgsPushed,
         [](struct VMGlobals* g, int numArgs, int numKeyArgs) -> int {
@@ -1542,6 +1535,8 @@ int objectPerformListWithKeys(struct VMGlobals* g, int numArgsPushed, int numKey
 int objectPerformList(struct VMGlobals* g, int numArgsPushed) { return objectPerformListWithKeys(g, numArgsPushed, 0); }
 
 int objectSuperPerformListWithKeys(struct VMGlobals* g, int numArgsPushed, int numKeyArgs) {
+    if (numArgsPushed < 2)
+        return errFailed;
     return performListTemplate(
         g, numArgsPushed, numKeyArgs,
         [](struct VMGlobals* g, int numArgs, int numKeyArgs) -> int {
@@ -1814,8 +1809,8 @@ private:
         SetObject(debugFrameObj->slots + 0, meth);
         SetPtr(debugFrameObj->slots + 5, meth);
 
-        const int numargs = methraw->numargs;
-        const int numvars = methraw->numvars;
+        const int numargs = methraw->numNormalArguments;
+        const int numvars = methraw->numVariables;
         if (numargs) {
             PyrObject* argArray = (PyrObject*)newPyrArray(g->gc, numargs, 0, false);
             SetObject(debugFrameObj->slots + 1, argArray);
@@ -2156,7 +2151,7 @@ int prFunDef_NumArgs(struct VMGlobals* g, int numArgsPushed) {
 
     a = g->sp;
     methraw = METHRAW(slotRawBlock(a));
-    SetInt(a, methraw->numargs);
+    SetInt(a, methraw->numNormalArguments);
     return errNone;
 }
 
@@ -2167,7 +2162,7 @@ int prFunDef_NumVars(struct VMGlobals* g, int numArgsPushed) {
 
     a = g->sp;
     methraw = METHRAW(slotRawBlock(a));
-    SetInt(a, methraw->numvars);
+    SetInt(a, methraw->numVariables);
     return errNone;
 }
 
@@ -2178,7 +2173,7 @@ int prFunDef_VarArgs(struct VMGlobals* g, int numArgsPushed) {
 
     a = g->sp;
     methraw = METHRAW(slotRawBlock(a));
-    if (methraw->varargs) {
+    if (methraw->numVariableArguments) {
         SetTrue(a);
     } else {
         SetFalse(a);
@@ -2189,7 +2184,7 @@ int prFunDef_VarArgs(struct VMGlobals* g, int numArgsPushed) {
 int prFunDef_VarArgsValue(struct VMGlobals* g, int numArgsPushed) {
     auto a = g->sp;
     auto methodRaw = METHRAW(slotRawBlock(a));
-    SetInt(a, methodRaw->varargs);
+    SetInt(a, methodRaw->numVariableArguments);
     return errNone;
 }
 
@@ -3438,9 +3433,9 @@ void initPrimitiveTable() {
         gPrimitiveTable.table[i].func = undefinedPrimitive;
         gPrimitiveTable.table[i].name = s_none;
         gPrimitiveTable.table[i].base = 0;
-        gPrimitiveTable.table[i].numArgs = 0;
-        gPrimitiveTable.table[i].varArgs = 0;
-        gPrimitiveTable.table[i].keyArgs = 0;
+        gPrimitiveTable.table[i].numNormalArguments = 0;
+        gPrimitiveTable.table[i].hasVariablePositionalArguments = false;
+        gPrimitiveTable.table[i].hasVariableKeywordArguments = false;
     }
 }
 
@@ -3460,14 +3455,15 @@ void growPrimitiveTable(int newsize) {
         gPrimitiveTable.table[i].func = undefinedPrimitive;
         gPrimitiveTable.table[i].name = s_none;
         gPrimitiveTable.table[i].base = 0;
-        gPrimitiveTable.table[i].numArgs = 0;
-        gPrimitiveTable.table[i].varArgs = 0;
-        gPrimitiveTable.table[i].keyArgs = 0;
+        gPrimitiveTable.table[i].numNormalArguments = 0;
+        gPrimitiveTable.table[i].hasVariablePositionalArguments = false;
+        gPrimitiveTable.table[i].hasVariableKeywordArguments = false;
     }
     pyr_pool_runtime->Free(oldtable);
 }
 
 int definePrimitive(int base, int index, const char* name, PrimitiveHandler handler, int numArgs, int varArgs) {
+    assert(numArgs);
     int tableIndex;
     PyrSymbol* sym;
 
@@ -3494,17 +3490,17 @@ int definePrimitive(int base, int index, const char* name, PrimitiveHandler hand
     gPrimitiveTable.table[tableIndex].func = handler;
     gPrimitiveTable.table[tableIndex].name = sym;
     gPrimitiveTable.table[tableIndex].base = base;
-    gPrimitiveTable.table[tableIndex].numArgs = numArgs;
-    gPrimitiveTable.table[tableIndex].varArgs = varArgs;
-    gPrimitiveTable.table[tableIndex].keyArgs = 0;
+    gPrimitiveTable.table[tableIndex].numNormalArguments = numArgs;
+    gPrimitiveTable.table[tableIndex].hasVariablePositionalArguments = varArgs;
+    gPrimitiveTable.table[tableIndex].hasVariableKeywordArguments = 0;
     if (tableIndex > gPrimitiveTable.size)
         gPrimitiveTable.size = tableIndex;
     sym->u.index = tableIndex;
     return tableIndex;
 }
 
-int definePrimitiveWithKeys(int base, int index, const char* name, PrimitiveHandler handler,
-                            PrimitiveWithKeysHandler keyhandler, int numArgs, int varArgs) {
+int definePrimitiveWithVariableKeys(int base, int index, const char* name, PrimitiveHandler handler,
+                                    PrimitiveWithKeysHandler keyhandler, int numArgs) {
     int tableIndex;
     PyrSymbol* sym;
 
@@ -3531,18 +3527,18 @@ int definePrimitiveWithKeys(int base, int index, const char* name, PrimitiveHand
     gPrimitiveTable.table[tableIndex].func = handler;
     gPrimitiveTable.table[tableIndex].name = sym;
     gPrimitiveTable.table[tableIndex].base = base;
-    gPrimitiveTable.table[tableIndex].numArgs = numArgs;
-    gPrimitiveTable.table[tableIndex].varArgs = varArgs;
-    gPrimitiveTable.table[tableIndex].keyArgs = 1;
+    gPrimitiveTable.table[tableIndex].numNormalArguments = numArgs;
+    gPrimitiveTable.table[tableIndex].hasVariablePositionalArguments = true;
+    gPrimitiveTable.table[tableIndex].hasVariableKeywordArguments = true;
     sym->u.index = tableIndex;
 
     tableIndex++;
     gPrimitiveTable.table[tableIndex].func = (PrimitiveHandler)keyhandler;
     gPrimitiveTable.table[tableIndex].name = sym;
     gPrimitiveTable.table[tableIndex].base = base;
-    gPrimitiveTable.table[tableIndex].numArgs = numArgs;
-    gPrimitiveTable.table[tableIndex].varArgs = varArgs;
-    gPrimitiveTable.table[tableIndex].keyArgs = 1;
+    gPrimitiveTable.table[tableIndex].numNormalArguments = numArgs;
+    gPrimitiveTable.table[tableIndex].hasVariablePositionalArguments = true;
+    gPrimitiveTable.table[tableIndex].hasVariableKeywordArguments = true;
     if (tableIndex > gPrimitiveTable.size)
         gPrimitiveTable.size = tableIndex;
     return tableIndex;
@@ -3563,7 +3559,7 @@ void doPrimitive(VMGlobals* g, PyrMethod* meth, int numArgsPushed) {
     int primIndex = methraw->specialIndex;
 
     PrimitiveDef* def = gPrimitiveTable.table + primIndex;
-    int numArgsNeeded = def->numArgs;
+    int numArgsNeeded = def->numNormalArguments;
     int diff = numArgsNeeded - numArgsPushed;
 
     if (diff != 0) { // incorrect num of args
@@ -3574,7 +3570,7 @@ void doPrimitive(VMGlobals* g, PyrMethod* meth, int numArgsPushed) {
                 slotCopy(++pslot, ++qslot);
 
             g->sp += diff;
-        } else if (def->varArgs) { // has var args
+        } else if (def->hasVariablePositionalArguments) { // has var args
             numArgsNeeded = numArgsPushed;
         } else {
             g->sp += diff; // remove excess args
@@ -3620,29 +3616,106 @@ void doPrimitive(VMGlobals* g, PyrMethod* meth, int numArgsPushed) {
 }
 
 void doPrimitiveWithKeys(VMGlobals* g, PyrMethod* meth, int allArgsPushed, int numKeyArgsPushed) {
-    int i, j, m, diff, err;
-    PyrSlot *pslot, *qslot;
-    int numArgsNeeded, numArgsPushed;
-
+    const auto maybe_gc_sanitycheck = [&]() {
 #ifdef GC_SANITYCHECK
-    g->gc->SanityCheck();
+        g->gc->SanityCheck();
 #endif
-    // post("doPrimitive %s:%s\n", slotRawSymbol(&slotRawClass(&meth->ownerclass)->name)->name,
-    // slotRawSymbol(&meth->name)->name); printf("doPrimitive %s:%s\n",
-    // slotRawSymbol(&slotRawClass(&meth->ownerclass)->name)->name, slotRawSymbol(&meth->name)->name);
+    };
+
+    maybe_gc_sanitycheck();
+
+    const int numNormalArgsGiven = allArgsPushed - (numKeyArgsPushed * 2);
 
     PyrMethodRaw* methraw = METHRAW(meth);
-    int primIndex = methraw->specialIndex;
+    const int primIndex = methraw->specialIndex;
     PrimitiveDef* def = gPrimitiveTable.table + primIndex;
     g->primitiveIndex = primIndex - def->base;
     g->primitiveMethod = meth;
 
-    if (def->keyArgs && numKeyArgsPushed) {
-        g->numpop = allArgsPushed - 1;
+    PyrSlot* reciever = g->sp - allArgsPushed + 1;
 
+    // Remove kwargs from stack to temporary stack.
+    if (numKeyArgsPushed > 0) {
+        PyrSlot* first_kwarg = g->sp - (numKeyArgsPushed * 2) + 1;
+        for (size_t i { 0 }; i < numKeyArgsPushed * 2; i += 2) {
+            temporaryKeywordStack[i] = first_kwarg[i];
+            assert(first_kwarg[i].isSymbol());
+            temporaryKeywordStack[i + 1] = first_kwarg[i + 1];
+        }
+        g->sp -= numKeyArgsPushed * 2;
+    }
+
+    // If needed, put any defaults arguments onto the stack.
+
+    const int numNeededArgs = def->numNormalArguments;
+    bool usedNormalVarArgs = false;
+    int numArgsOnStack = numNormalArgsGiven;
+
+    if (numNeededArgs != numNormalArgsGiven) {
+        if (numNormalArgsGiven > numNeededArgs) {
+            if (!def->hasVariablePositionalArguments) {
+                const unsigned int dif = numNormalArgsGiven - numNeededArgs;
+                g->sp -= dif;
+                numArgsOnStack = numNeededArgs;
+            } else {
+                usedNormalVarArgs = true;
+                numArgsOnStack = numNormalArgsGiven;
+            }
+        } else {
+            const unsigned int needed = numNeededArgs - numNormalArgsGiven;
+            const auto disFromSPToReciever = std::distance(g->sp, reciever);
+            if (maybeReallocStack(g, needed)) {
+                reciever = g->sp + disFromSPToReciever;
+            }
+            PyrSlot* from = slotRawObject(&meth->prototypeFrame)->slots + numNormalArgsGiven - 1;
+            PyrSlot* to = g->sp;
+            for (size_t i { 0 }; i < needed; ++i) {
+                to[i + 1] = from[i];
+            }
+            g->sp += needed;
+            numArgsOnStack = numNeededArgs;
+        }
+    }
+
+    int num_variable_kwargs = 0;
+    // Put keywords back on the stack, overriding what was already there on the stack.
+    if (numKeyArgsPushed && methraw->totalNumberArguments) {
+        PyrSymbol** argNames = slotRawSymbolArray(&meth->argNames)->symbols;
+
+        for (size_t keyword { 0 }; keyword < numKeyArgsPushed * 2; keyword += 2) {
+            PyrSymbol* key = slotRawSymbol(&temporaryKeywordStack[keyword]);
+
+            // We start at one here because you can't override 'this'.
+            for (size_t argN { 1 }; argN < methraw->numNormalArguments; ++argN) {
+                if (key == argNames[argN]) {
+                    reciever[argN] = temporaryKeywordStack[keyword + 1];
+                    goto found;
+                }
+            }
+
+            if (methraw->numVariableArguments != 2) {
+                if (gKeywordError) {
+                    post("WARNING: keyword arg '%s' not found in call to %s:%s\n", key->name,
+                         slotRawSymbol(&slotRawClass(&meth->ownerclass)->name)->name, slotRawSymbol(&meth->name)->name);
+                }
+            } else {
+                num_variable_kwargs += 1;
+                g->sp += 1;
+                g->sp[0] = temporaryKeywordStack[keyword];
+                g->sp += 1;
+                g->sp[0] = temporaryKeywordStack[keyword + 1];
+                numArgsOnStack += 2;
+            }
+        found:;
+        }
+    }
+
+    if (num_variable_kwargs) {
+        g->numpop = numArgsOnStack - 1;
         g->gc->enterDelayedCollectionContext();
+        int err;
         try {
-            err = ((PrimitiveWithKeysHandler)def[1].func)(g, allArgsPushed, numKeyArgsPushed);
+            err = ((PrimitiveWithKeysHandler)def[1].func)(g, numArgsOnStack, num_variable_kwargs);
         } catch (std::exception& ex) {
             g->lastExceptions[g->thread] = std::make_pair(std::current_exception(), meth);
             err = errException;
@@ -3655,80 +3728,25 @@ void doPrimitiveWithKeys(VMGlobals* g, PyrMethod* meth, int allArgsPushed, int n
         if (err <= errNone)
             g->sp -= g->numpop;
         else {
-            // post("primerr %d\n", err);
             SetInt(&g->thread->primitiveIndex, methraw->specialIndex);
             SetInt(&g->thread->primitiveError, err);
             setupForMethod(g, meth, allArgsPushed, numKeyArgsPushed);
         }
-#ifdef GC_SANITYCHECK
-        g->gc->SanityCheck();
-#endif
-        return;
-    }
-    numArgsNeeded = def->numArgs;
-    numArgsPushed = allArgsPushed - (numKeyArgsPushed * 2);
+    } else {
+        g->numpop = numArgsOnStack - 1;
 
-    if (numKeyArgsPushed) {
-        // evacuate keyword args to separate area
-        pslot = temporaryKeywordStack + (numKeyArgsPushed << 1);
-        qslot = g->sp + 1;
-        for (m = 0; m < numKeyArgsPushed; ++m) {
-            slotCopy(--pslot, --qslot);
-            slotCopy(--pslot, --qslot);
+        g->gc->enterDelayedCollectionContext();
+        int err;
+        try {
+            err = (*def->func)(g, numArgsOnStack);
+        } catch (std::exception& ex) {
+            g->lastExceptions[g->thread] = std::make_pair(std::current_exception(), meth);
+            err = errException;
+        } catch (...) {
+            g->lastExceptions[g->thread] = std::make_pair(nullptr, meth);
+            err = errException;
         }
-    }
-
-    diff = numArgsNeeded - numArgsPushed;
-    if (diff != 0) { // incorrect num of args
-        if (diff > 0) { // not enough args
-            g->sp += numArgsNeeded - allArgsPushed; // expand stack to correct size
-            pslot = g->sp - diff;
-            qslot = slotRawObject(&meth->prototypeFrame)->slots + numArgsPushed - 1;
-            for (m = 0; m < diff; ++m)
-                slotCopy(++pslot, ++qslot);
-        } else if (def->varArgs) { // has var args
-            numArgsNeeded = numArgsPushed;
-            g->sp += numArgsNeeded - allArgsPushed; // expand stack to correct size
-        } else {
-            g->sp += numArgsNeeded - allArgsPushed; // remove excess args
-        }
-    }
-
-    // do keyword lookup:
-    if (numKeyArgsPushed && methraw->posargs) {
-        PyrSymbol **name0, **name;
-        PyrSlot *key, *vars;
-        name0 = slotRawSymbolArray(&meth->argNames)->symbols + 1;
-        key = temporaryKeywordStack;
-        vars = g->sp - numArgsNeeded + 1;
-        for (i = 0; i < numKeyArgsPushed; ++i, key += 2) {
-            name = name0;
-            for (j = 1; j < methraw->posargs; ++j, ++name) {
-                if (*name == slotRawSymbol(key)) {
-                    slotCopy(&vars[j], &key[1]);
-                    goto found;
-                }
-            }
-            if (gKeywordError) {
-                post("WARNING: keyword arg '%s' not found in call to %s:%s\n", slotRawSymbol(key)->name,
-                     slotRawSymbol(&slotRawClass(&meth->ownerclass)->name)->name, slotRawSymbol(&meth->name)->name);
-            }
-        found:;
-        }
-    }
-    g->numpop = numArgsNeeded - 1;
-
-    g->gc->enterDelayedCollectionContext();
-    try {
-        err = (*def->func)(g, numArgsNeeded);
-    } catch (std::exception& ex) {
-        g->lastExceptions[g->thread] = std::make_pair(std::current_exception(), meth);
-        err = errException;
-    } catch (...) {
-        g->lastExceptions[g->thread] = std::make_pair(nullptr, meth);
-        err = errException;
-    }
-    g->gc->exitDelayedCollectionContext();
+        g->gc->exitDelayedCollectionContext();
 
     if (err <= errNone)
         g->sp -= g->numpop;
@@ -3736,7 +3754,7 @@ void doPrimitiveWithKeys(VMGlobals* g, PyrMethod* meth, int allArgsPushed, int n
         // post("primerr %d\n", err);
         SetInt(&g->thread->primitiveIndex, methraw->specialIndex);
         SetInt(&g->thread->primitiveError, err);
-        setupForMethod(g, meth, numArgsNeeded, 0);
+        setupForMethod(g, meth, numArgsOnStack, 0);
     }
 #ifdef GC_SANITYCHECK
     g->gc->SanityCheck();
@@ -3814,9 +3832,9 @@ void initPrimitives() {
 
     // binary operators
     base = nextPrimitiveIndex();
-    definePrimitive(base, opAdd, "_Add", prAddNum, 2, 0);
-    definePrimitive(base, opSub, "_Sub", prSubNum, 2, 0);
-    definePrimitive(base, opMul, "_Mul", prMulNum, 2, 0);
+    definePrimitive(base, opAdd, "_Add", prAddNum, 3, 0);
+    definePrimitive(base, opSub, "_Sub", prSubNum, 3, 0);
+    definePrimitive(base, opMul, "_Mul", prMulNum, 3, 0);
 
     definePrimitive(base, opIDiv, "_IDiv", prSpecialBinaryArithMsg, 3, 0);
     definePrimitive(base, opFDiv, "_FDiv", prSpecialBinaryArithMsg, 3, 0);
@@ -3871,6 +3889,15 @@ void initPrimitives() {
     // general primitives
     base = nextPrimitiveIndex();
     index = 0;
+
+    // tests
+    definePrimitive(base, index++, "_PrimitiveTestNoKwargsNoVarArg", primitiveTests::noKwNoVarArgs, 4, 0);
+    definePrimitive(base, index++, "_PrimitiveTestNoKwargsWithVarArgs", primitiveTests::noKwWithVarArgs, 4, 1);
+    definePrimitiveWithVariableKeys(base, index, "_PrimitiveTestWithKwargs", primitiveTests::kwWithVarArgsSansKw,
+                                    primitiveTests::kwWithVarArgs, 4);
+    index += 2;
+
+
     definePrimitive(base, index++, "_Halt", haltInterpreter, 1, 0);
     definePrimitive(base, index++, "_InstVarAt", instVarAt, 2, 0);
     definePrimitive(base, index++, "_InstVarPut", instVarPut, 3, 0);
@@ -3879,15 +3906,15 @@ void initPrimitives() {
     definePrimitive(base, index++, "_ObjectClass", objectClass, 1, 0);
     definePrimitive(base, index++, "_BasicNew", basicNew, 2, 0);
     definePrimitive(base, index++, "_BasicNewClear", basicNewClear, 2, 0);
-    definePrimitiveWithKeys(base, index, "_BasicNewCopyArgsToInstVars", basicNewCopyArgsToInstanceVars,
-                            basicNewCopyArgsToInstanceVarsWithKeys, 1, 1);
+    definePrimitiveWithVariableKeys(base, index, "_BasicNewCopyArgsToInstVars", basicNewCopyArgsToInstanceVars,
+                                    basicNewCopyArgsToInstanceVarsWithKeys, 1);
     index += 2;
 
     // definePrimitive(base, index++, "_BasicNewCopyArgsByName", basicNewCopyArgsByName, 1, 1);
 
-    definePrimitiveWithKeys(base, index, "_FunctionValue", blockValue, blockValueWithKeys, 1, 1);
+    definePrimitiveWithVariableKeys(base, index, "_FunctionValue", blockValue, blockValueWithKeys, 1);
     index += 2;
-    definePrimitiveWithKeys(base, index, "_FunctionValueEnvir", blockValueEnvir, blockValueEnvirWithKeys, 1, 1);
+    definePrimitiveWithVariableKeys(base, index, "_FunctionValueEnvir", blockValueEnvir, blockValueEnvirWithKeys, 1);
     index += 2;
 
     definePrimitive(base, index++, "_FunctionValueArray", blockValueArray, 1, 1);
@@ -3915,22 +3942,22 @@ void initPrimitives() {
 
     definePrimitive(base, index++, "_Identical", objectIdentical, 2, 0);
     definePrimitive(base, index++, "_NotIdentical", objectNotIdentical, 2, 0);
-    definePrimitiveWithKeys(base, index, "_ObjectPerform", objectPerform, objectPerformWithKeys, 2, 1);
+    definePrimitiveWithVariableKeys(base, index, "_ObjectPerform", objectPerform, objectPerformWithKeys, 2);
     index += 2;
     definePrimitive(base, index++, "_ObjectPerformArgs", objectPerformArgs, 4, 0);
     definePrimitive(base, index++, "_ObjectSuperPerformArgs", objectSuperPerformArgs, 4, 0);
 
-    definePrimitiveWithKeys(base, index, "_ObjectPerformList", objectPerformList, objectPerformListWithKeys, 2, 1);
+    definePrimitiveWithVariableKeys(base, index, "_ObjectPerformList", objectPerformList, objectPerformListWithKeys, 1);
     index += 2;
 
-    definePrimitiveWithKeys(base, index, "_SuperPerform", objectSuperPerform, objectSuperPerformWithKeys, 2, 1);
+    definePrimitiveWithVariableKeys(base, index, "_SuperPerform", objectSuperPerform, objectSuperPerformWithKeys, 1);
     index += 2;
-    definePrimitiveWithKeys(base, index++, "_SuperPerformList", objectSuperPerformList, objectSuperPerformListWithKeys,
-                            2, 1);
+    definePrimitiveWithVariableKeys(base, index++, "_SuperPerformList", objectSuperPerformList,
+                                    objectSuperPerformListWithKeys, 1);
     index += 2;
     definePrimitive(base, index++, "_ObjectPerformMsg", objectPerformSelList, 2, 0);
     // definePrimitive(base, index++, "_ArrayPerformMsg", arrayPerformMsg, 1, 1);
-    definePrimitive(base, index++, "_ObjectString", prObjectString, 1, 0);
+    definePrimitive(base, index++, "_ObjectString", prObjectString, 2, 0);
     definePrimitive(base, index++, "_Float_AsStringPrec", prFloat_AsStringPrec, 2, 0);
     definePrimitive(base, index++, "_ObjectCompileString", prAsCompileString, 1, 0);
     definePrimitive(base, index++, "_ClassString", prClassString, 1, 0);

--- a/lang/LangPrimSource/PyrSerialPrim.cpp
+++ b/lang/LangPrimSource/PyrSerialPrim.cpp
@@ -61,8 +61,6 @@ extern boost::asio::io_context ioContext; // defined in SC_ComPort.cpp
  */
 class SerialPort {
 public:
-    // 7, not 6 - the last two options passed in are condensed into flow_control
-    static const int kNumOptions = 7;
     static const int kBufferSize = 8192;
 
     /// Type of the underlying FIFO buffer.
@@ -320,7 +318,7 @@ static serial_port::flow_control::type asFlowControlType(bool hardware, bool sof
 // primitives
 
 static int prSerialPort_Open(struct VMGlobals* g, int numArgsPushed) {
-    PyrSlot* args = g->sp - 1 - SerialPort::kNumOptions;
+    PyrSlot* args = g->sp - 8;
 
     int err;
 
@@ -472,7 +470,7 @@ void initSerialPrimitives() {
     base = nextPrimitiveIndex();
     index = 0;
 
-    definePrimitive(base, index++, "_SerialPort_Open", prSerialPort_Open, 2 + SerialPort::kNumOptions, 0);
+    definePrimitive(base, index++, "_SerialPort_Open", prSerialPort_Open, 9, 0);
     definePrimitive(base, index++, "_SerialPort_Close", prSerialPort_Close, 1, 0);
     definePrimitive(base, index++, "_SerialPort_Next", prSerialPort_Next, 1, 0);
     definePrimitive(base, index++, "_SerialPort_Put", prSerialPort_Put, 2, 0);

--- a/lang/LangPrimSource/SC_HID_api.cpp
+++ b/lang/LangPrimSource/SC_HID_api.cpp
@@ -978,7 +978,7 @@ void initHIDAPIPrimitives() {
     definePrimitive(base, index++, "_HID_API_BuildDeviceList", prHID_API_BuildDeviceList, 1,
                     0); // this gets device info about the various devices that are attached
 
-    definePrimitive(base, index++, "_HID_API_OpenDevice", prHID_API_Open, 3, 0); // opens a specific device
+    definePrimitive(base, index++, "_HID_API_OpenDevice", prHID_API_Open, 4, 0); // opens a specific device
     definePrimitive(base, index++, "_HID_API_CloseDevice", prHID_API_Close, 2, 0); // closes a specific device
 
     definePrimitive(base, index++, "_HID_API_GetInfo", prHID_API_GetInfo, 2, 0); // gets info about a specific device
@@ -988,12 +988,12 @@ void initHIDAPIPrimitives() {
                     0); // gets info about a specific device element
     definePrimitive(base, index++, "_HID_API_GetNumberOfElements", prHID_API_GetNumberOfElements, 2,
                     0); // gets number of elements of a device
-    definePrimitive(base, index++, "_HID_API_GetElementInfo", prHID_API_GetElementInfo, 4,
+    definePrimitive(base, index++, "_HID_API_GetElementInfo", prHID_API_GetElementInfo, 3,
                     0); // gets info about a specific device element
 
-    definePrimitive(base, index++, "_HID_API_SetElementOutput", prHID_API_SetElementOutput, 3,
+    definePrimitive(base, index++, "_HID_API_SetElementOutput", prHID_API_SetElementOutput, 4,
                     0); // sets the output value of a specific device element, and sends the report
-    definePrimitive(base, index++, "_HID_API_SetElementRepeat", prHID_API_SetElementRepeat, 3,
+    definePrimitive(base, index++, "_HID_API_SetElementRepeat", prHID_API_SetElementRepeat, 4,
                     0); // sets the repeat property of a specific device element
 
     s_hidElementData = getsym("prHIDElementData"); // send back element data

--- a/lang/LangSource/PyrInterpreter3.cpp
+++ b/lang/LangSource/PyrInterpreter3.cpp
@@ -1375,7 +1375,7 @@ HOT void Interpret(VMGlobals* g) {
 
             InterpretOpcode(PushAllArgsAndSendMsg) {
                 const auto [selectorIndex] = PushAllArgsAndSendMsg.pullOperandsFromInstructions(ip);
-                numArgsPushed = METHRAW(g->block)->numargs;
+                numArgsPushed = METHRAW(g->block)->numNormalArguments;
                 PyrSlot* pslot = g->frame->vars - 1;
                 for (int m = 0; m < numArgsPushed; ++m)
                     *++sp = *++pslot;
@@ -1387,7 +1387,7 @@ HOT void Interpret(VMGlobals* g) {
 
             InterpretOpcode(PushAllButFirstArgAndSendMsg) {
                 const auto [selectorIndex] = PushAllButFirstArgAndSendMsg.pullOperandsFromInstructions(ip);
-                numArgsPushed = METHRAW(g->block)->numargs;
+                numArgsPushed = METHRAW(g->block)->numNormalArguments;
                 PyrSlot* pslot = g->frame->vars;
                 for (int m = 0; m < numArgsPushed - 1; ++m)
                     *++sp = *++pslot;
@@ -1399,7 +1399,7 @@ HOT void Interpret(VMGlobals* g) {
 
             InterpretOpcode(PushAllArgsAndSendSpecialMsg) {
                 const auto [selectorIndex] = PushAllArgsAndSendSpecialMsg.pullOperandsFromInstructions(ip);
-                numArgsPushed = METHRAW(g->block)->numargs;
+                numArgsPushed = METHRAW(g->block)->numNormalArguments;
                 PyrSlot* pslot = g->frame->vars - 1;
                 for (int m = 0; m < numArgsPushed; ++m)
                     *++sp = *++pslot;
@@ -1411,7 +1411,7 @@ HOT void Interpret(VMGlobals* g) {
 
             InterpretOpcode(PushAllButFirstArgAndSendSpecialMsg) {
                 const auto [specialIndex] = PushAllButFirstArgAndSendSpecialMsg.pullOperandsFromInstructions(ip);
-                numArgsPushed = METHRAW(g->block)->numargs;
+                numArgsPushed = METHRAW(g->block)->numNormalArguments;
                 PyrSlot* pslot = g->frame->vars;
                 for (int m = 0; m < numArgsPushed - 1; ++m)
                     *++sp = *++pslot;
@@ -1423,7 +1423,7 @@ HOT void Interpret(VMGlobals* g) {
 
             InterpretOpcode(PushAllButFirstTwoArgsAndSendMsg) {
                 const auto [index] = PushAllButFirstTwoArgsAndSendMsg.pullOperandsFromInstructions(ip);
-                numArgsPushed = METHRAW(g->block)->numargs + 1;
+                numArgsPushed = METHRAW(g->block)->numNormalArguments + 1;
                 PyrSlot* pslot = g->frame->vars;
                 for (int m = 0; m < numArgsPushed - 2; ++m)
                     *++sp = *++pslot;
@@ -1435,7 +1435,7 @@ HOT void Interpret(VMGlobals* g) {
 
             InterpretOpcode(PushAllButFirstTwoArgsAndSendSpecialMsg) {
                 const auto [index] = PushAllButFirstTwoArgsAndSendSpecialMsg.pullOperandsFromInstructions(ip);
-                numArgsPushed = METHRAW(g->block)->numargs + 1;
+                numArgsPushed = METHRAW(g->block)->numNormalArguments + 1;
                 PyrSlot* pslot = g->frame->vars;
                 for (int m = 0; m < numArgsPushed - 2; ++m)
                     *++sp = *++pslot;
@@ -2246,17 +2246,17 @@ HOT void Interpret(VMGlobals* g) {
 
             PyrMethodRaw* methraw = METHRAW(meth);
             const auto pushDefaultArgsAndChopUnused = [&]() {
-                if (numArgsPushed < methraw->numargs) {
+                if (numArgsPushed < methraw->numNormalArguments) {
                     // Not enough args pushed.
                     PyrSlot* qslot = slotRawObject(&meth->prototypeFrame)->slots + numArgsPushed - 1;
-                    for (int m = 0, mmax = methraw->numargs - numArgsPushed; m < mmax; ++m)
+                    for (int m = 0, mmax = methraw->numNormalArguments - numArgsPushed; m < mmax; ++m)
                         slotCopy(++sp, ++qslot);
-                    numArgsPushed = methraw->numargs;
-                } else if (methraw->varargs == 0 && numArgsPushed > methraw->numargs) {
+                    numArgsPushed = methraw->numNormalArguments;
+                } else if (methraw->numVariableArguments == 0 && numArgsPushed > methraw->numNormalArguments) {
                     // Too many args.
-                    const auto num_slots_to_chop = numArgsPushed - methraw->numargs;
+                    const auto num_slots_to_chop = numArgsPushed - methraw->numNormalArguments;
                     sp -= num_slots_to_chop;
-                    numArgsPushed = methraw->numargs;
+                    numArgsPushed = methraw->numNormalArguments;
                 }
             };
 

--- a/lang/LangSource/PyrKernel.h
+++ b/lang/LangSource/PyrKernel.h
@@ -135,13 +135,14 @@ struct PyrMethodRaw {
 #endif
 
     unsigned char unused2;
-    unsigned char numargs;
-    unsigned char varargs;
-    unsigned char numvars;
-    unsigned char numtemps;
+    unsigned char numNormalArguments; // Does not include variable arguments (...args, kwargs)
+    unsigned char numVariableArguments; // 0, 1, or 2, for no variable arguments, positional variable arguments, and
+                                        // positional and keyword.
+    unsigned char numVariables;
+    unsigned char numSlots; // sum of totalNumberArguments and numVariables
     unsigned char needsHeapContext;
-    unsigned char popSize;
-    unsigned char posargs;
+    unsigned char popSize; // Sometime different to the numSlots as this isn't always popped.
+    unsigned char totalNumberArguments; // Sum of numNormalArguments and numVariableArguments.
 };
 
 

--- a/lang/LangSource/PyrMessage.cpp
+++ b/lang/LangSource/PyrMessage.cpp
@@ -136,9 +136,9 @@ lookup_again:
 
     const auto pushDefaultArgsIfNotEnoughSupplied = [&]() {
         auto defaultArgs = slotRawObject(&method->prototypeFrame)->slots;
-        std::copy(defaultArgs + numArgsPushed, defaultArgs + methodRaw->numargs, g->sp + 1);
-        g->sp += methodRaw->numargs - numArgsPushed; // fix stack pointer to point to last arg pushed.
-        numArgsPushed = methodRaw->numargs;
+        std::copy(defaultArgs + numArgsPushed, defaultArgs + methodRaw->numNormalArguments, g->sp + 1);
+        g->sp += methodRaw->numNormalArguments - numArgsPushed; // fix stack pointer to point to last arg pushed.
+        numArgsPushed = methodRaw->numNormalArguments;
     };
 
     const auto applyKeywords = [&]() {
@@ -219,7 +219,7 @@ lookup_again:
     }
 
     case methRedirect: { // Send a different selector to this, e.g. this.subclassResponsibility.
-        if (numArgsPushed < methodRaw->numargs)
+        if (numArgsPushed < methodRaw->numNormalArguments)
             pushDefaultArgsIfNotEnoughSupplied();
         if (numKeyArgsPushed > 0)
             applyKeywords();
@@ -228,7 +228,7 @@ lookup_again:
     }
 
     case methRedirectSuper: { // Send a different selector to super, e.g. super.subclassResponsibility.
-        if (numArgsPushed < methodRaw->numargs)
+        if (numArgsPushed < methodRaw->numNormalArguments)
             pushDefaultArgsIfNotEnoughSupplied();
         if (numKeyArgsPushed > 0)
             applyKeywords();
@@ -240,7 +240,7 @@ lookup_again:
     case methForwardInstVar: { // Forward to an object instance variable, e.g., ^foo.bar.
         if (numKeyArgsPushed > 0)
             applyKeywords();
-        else if (numArgsPushed < methodRaw->numargs)
+        else if (numArgsPushed < methodRaw->numNormalArguments)
             pushDefaultArgsIfNotEnoughSupplied();
         selector = slotRawSymbol(&method->selectors);
         slotCopy(recvrSlot, &slotRawObject(recvrSlot)->slots[methodRaw->specialIndex]);
@@ -251,7 +251,7 @@ lookup_again:
     case methForwardClassVar: { // Forward to a class variable, e.g., ^Class.foo.bar.
         if (numKeyArgsPushed > 0)
             applyKeywords();
-        else if (numArgsPushed < methodRaw->numargs)
+        else if (numArgsPushed < methodRaw->numNormalArguments)
             pushDefaultArgsIfNotEnoughSupplied();
         selector = slotRawSymbol(&method->selectors);
         slotCopy(recvrSlot, &g->classvars->slots[methodRaw->specialIndex]);
@@ -380,12 +380,12 @@ void prepareArgsForExecute(VMGlobals* g, PyrBlock* block, PyrFrame* callFrame, s
     PyrObject* proto = slotRawObject(&block->prototypeFrame);
 
     const PyrMethodRaw* methodRaw = METHRAW(block);
-    const auto methNumActualArgs = methodRaw->posargs;
+    const auto methNumActualArgs = methodRaw->totalNumberArguments;
     const auto numNormalSuppliedArgs = totalSuppliedArgs - (numKwArgsSupplied * 2);
-    const bool methHasVarArg = methodRaw->varargs > 0;
-    const bool methHasKwArg = methodRaw->varargs > 1;
-    const auto methNumNormArgs = methodRaw->numargs;
-    const auto methNumVariables = methodRaw->numvars;
+    const bool methHasVarArg = methodRaw->numVariableArguments > 0;
+    const bool methHasKwArg = methodRaw->numVariableArguments > 1;
+    const auto methNumNormArgs = methodRaw->numNormalArguments;
+    const auto methNumVariables = methodRaw->numVariables;
     const auto methArgNames = slotRawSymbolArray(&block->argNames)->symbols;
 
     PyrSlot* outCallFrameStack = callFrame->vars;
@@ -756,7 +756,7 @@ int keywordFixStack(VMGlobals* g, PyrMethod* meth, PyrMethodRaw* methraw, std::i
     PyrSlot* vars = g->sp - allArgsPushed + 1;
 
     numArgsPushed = allArgsPushed - (numKeyArgsPushed << 1);
-    numArgsNeeded = methraw->numargs;
+    numArgsNeeded = methraw->numNormalArguments;
     diff = numArgsNeeded - numArgsPushed;
     if (diff > 0) { // not enough args
         pslot = vars + numArgsPushed - 1;
@@ -767,12 +767,12 @@ int keywordFixStack(VMGlobals* g, PyrMethod* meth, PyrMethodRaw* methraw, std::i
     }
 
     // do keyword lookup:
-    if (numKeyArgsPushed && methraw->posargs) {
+    if (numKeyArgsPushed && methraw->totalNumberArguments) {
         PyrSymbol** name0 = slotRawSymbolArray(&meth->argNames)->symbols + 1;
         PyrSlot* key = temporaryKeywordStack;
         for (i = 0; i < numKeyArgsPushed; ++i, key += 2) {
             PyrSymbol** name = name0;
-            for (j = 1; j < methraw->posargs; ++j, ++name) {
+            for (j = 1; j < methraw->totalNumberArguments; ++j, ++name) {
                 if (*name == slotRawSymbol(key)) {
                     slotCopy(&vars[j], &key[1]);
                     goto found;

--- a/lang/LangSource/PyrObject.cpp
+++ b/lang/LangSource/PyrObject.cpp
@@ -2223,10 +2223,10 @@ void DumpFrame(PyrFrame* frame) {
 
     meth = slotRawMethod(&frame->method);
     methraw = METHRAW(meth);
-    if (methraw->numtemps) {
+    if (methraw->numSlots) {
         post("\t%s\n", str);
-        numargs = methraw->numargs + methraw->varargs;
-        for (i = 0; i < methraw->numtemps; ++i) {
+        numargs = methraw->numNormalArguments + methraw->numVariableArguments;
+        for (i = 0; i < methraw->numSlots; ++i) {
             slotOneWord(frame->vars + i, str);
             // slotString(frame->vars + i, str);
             if (i < numargs) {
@@ -2260,10 +2260,10 @@ void DumpDetailedFrame(PyrFrame* frame) {
     meth = slotRawMethod(&frame->method);
     methraw = METHRAW(meth);
 
-    if (methraw->numtemps) {
+    if (methraw->numSlots) {
         post("\t%s\n", mstr);
-        numargs = methraw->numargs + methraw->varargs;
-        for (i = 0; i < methraw->numtemps; ++i) {
+        numargs = methraw->numNormalArguments + methraw->numVariableArguments;
+        for (i = 0; i < methraw->numSlots; ++i) {
             slotOneWord(frame->vars + i, str);
             // slotString(frame->vars + i, str);
             if (i < numargs) {
@@ -2278,7 +2278,7 @@ void DumpDetailedFrame(PyrFrame* frame) {
 
     post("\t....%s details:\n", mstr);
     post("\t\tneedsHeapContext  = %d\n", methraw->needsHeapContext);
-    post("\t\tnumtemps  = %d\n", methraw->numtemps);
+    post("\t\tnumtemps  = %d\n", methraw->numSlots);
     post("\t\tpopSize  = %d\n", methraw->popSize);
 
     slotString(&frame->method, str);
@@ -2493,10 +2493,10 @@ PyrBlock* newPyrBlock(int flags) {
     methraw->methType = methBlock;
     methraw->needsHeapContext = 0;
     methraw->frameSize = 0;
-    methraw->varargs = 0;
-    methraw->numargs = 0;
-    methraw->numvars = 0;
-    methraw->numtemps = 0;
+    methraw->numVariableArguments = 0;
+    methraw->numNormalArguments = 0;
+    methraw->numVariables = 0;
+    methraw->numSlots = 0;
     methraw->popSize = 0;
 
     nilSlots(&block->rawData1, numSlots);

--- a/lang/LangSource/PyrParseNode.cpp
+++ b/lang/LangSource/PyrParseNode.cpp
@@ -43,6 +43,7 @@
 #include "SC_Codecvt.hpp"
 #include "SpecialSelectorsOperatorsAndClasses.h"
 #include "text_location.hpp"
+#include "PyrPrimitive.h"
 
 namespace fs = std::filesystem;
 
@@ -645,11 +646,11 @@ void fillClassPrototypes(PyrClassNode* node, PyrClass* classobj, PyrClass* super
                     methraw = METHRAW(method);
                     methraw->unused1 = 0;
                     methraw->unused2 = 0;
-                    methraw->numargs = 1;
-                    methraw->numvars = 0;
-                    methraw->posargs = 1;
-                    methraw->varargs = 0;
-                    methraw->numtemps = 1;
+                    methraw->numNormalArguments = 1;
+                    methraw->numVariables = 0;
+                    methraw->totalNumberArguments = 1;
+                    methraw->numVariableArguments = 0;
+                    methraw->numSlots = 1;
                     methraw->popSize = 0;
                     SetNil(&method->contextDef);
                     SetNil(&method->varNames);
@@ -676,11 +677,11 @@ void fillClassPrototypes(PyrClassNode* node, PyrClass* classobj, PyrClass* super
                     methraw = METHRAW(method);
                     methraw->unused1 = 0;
                     methraw->unused2 = 0;
-                    methraw->numargs = 2;
-                    methraw->numvars = 0;
-                    methraw->posargs = 2;
-                    methraw->varargs = 0;
-                    methraw->numtemps = 2;
+                    methraw->numNormalArguments = 2;
+                    methraw->numVariables = 0;
+                    methraw->totalNumberArguments = 2;
+                    methraw->numVariableArguments = 0;
+                    methraw->numSlots = 2;
                     methraw->popSize = 1;
                     SetNil(&method->contextDef);
                     SetNil(&method->varNames);
@@ -713,11 +714,11 @@ void fillClassPrototypes(PyrClassNode* node, PyrClass* classobj, PyrClass* super
                     methraw = METHRAW(method);
                     methraw->unused1 = 0;
                     methraw->unused2 = 0;
-                    methraw->numargs = 1;
-                    methraw->numvars = 0;
-                    methraw->posargs = 1;
-                    methraw->varargs = 0;
-                    methraw->numtemps = 1;
+                    methraw->numNormalArguments = 1;
+                    methraw->numVariables = 0;
+                    methraw->totalNumberArguments = 1;
+                    methraw->numVariableArguments = 0;
+                    methraw->numSlots = 1;
                     methraw->popSize = 0;
                     SetNil(&method->contextDef);
                     SetNil(&method->varNames);
@@ -744,11 +745,11 @@ void fillClassPrototypes(PyrClassNode* node, PyrClass* classobj, PyrClass* super
                     // create setter method
                     method = newPyrMethod();
                     methraw = METHRAW(method);
-                    methraw->numargs = 2;
-                    methraw->numvars = 0;
-                    methraw->posargs = 2;
-                    methraw->varargs = 0;
-                    methraw->numtemps = 2;
+                    methraw->numNormalArguments = 2;
+                    methraw->numVariables = 0;
+                    methraw->totalNumberArguments = 2;
+                    methraw->numVariableArguments = 0;
+                    methraw->numSlots = 2;
                     methraw->popSize = 1;
                     SetNil(&method->contextDef);
                     SetNil(&method->varNames);
@@ -782,11 +783,11 @@ void fillClassPrototypes(PyrClassNode* node, PyrClass* classobj, PyrClass* super
                     methraw = METHRAW(method);
                     methraw->unused1 = 0;
                     methraw->unused2 = 0;
-                    methraw->numargs = 1;
-                    methraw->numvars = 0;
-                    methraw->posargs = 1;
-                    methraw->varargs = 0;
-                    methraw->numtemps = 1;
+                    methraw->numNormalArguments = 1;
+                    methraw->numVariables = 0;
+                    methraw->totalNumberArguments = 1;
+                    methraw->numVariableArguments = 0;
+                    methraw->numSlots = 1;
                     methraw->popSize = 0;
                     SetNil(&method->contextDef);
                     SetNil(&method->varNames);
@@ -1318,13 +1319,13 @@ void PyrMethodNode::compile(PyrSlot* result) {
 
     methraw->needsHeapContext = 0;
 
-    methraw->varargs = 0;
+    methraw->numVariableArguments = 0;
     if (mArglist) {
         if (mArglist->mRest) {
-            methraw->varargs += 1;
+            methraw->numVariableArguments += 1;
             numVariableArgs = 1;
             if (mArglist->mKeywordArgs) {
-                methraw->varargs += 1;
+                methraw->numVariableArguments += 1;
                 numKwArgs = 1;
             }
         }
@@ -1335,14 +1336,14 @@ void PyrMethodNode::compile(PyrSlot* result) {
     numSlots = numArgs + numVariableArgs + numKwArgs + numVars;
     methraw->frameSize = (numSlots + FRAMESIZE) * sizeof(PyrSlot);
 
-    methraw->numargs = numArgs;
-    methraw->numvars = numVars;
-    methraw->posargs = numArgs + numVariableArgs + numKwArgs;
-    methraw->numtemps = numSlots;
+    methraw->numNormalArguments = numArgs;
+    methraw->numVariables = numVars;
+    methraw->totalNumberArguments = numArgs + numVariableArgs + numKwArgs;
+    methraw->numSlots = numSlots;
     methraw->popSize = numSlots - 1;
     firstKeyIndex = numArgs + numVariableArgs + numKwArgs;
 
-    numArgNames = methraw->posargs;
+    numArgNames = methraw->totalNumberArguments;
 
     if (numSlots == 1) {
         slotCopy(&method->argNames, &o_argnamethis);
@@ -1545,7 +1546,7 @@ void PyrMethodNode::compile(PyrSlot* result) {
                     } else {
                         if (funcFindArg((PyrBlock*)method, slotRawSymbol(rslot), &index)) { // return arg ?
                             // eliminate the case where its an ellipsis or keyword argument
-                            if (index < methraw->numargs) {
+                            if (index < methraw->numNormalArguments) {
                                 methType = methReturnArg;
                                 methraw->specialIndex = index; // when you change sp to sp - 1
                                 // methraw->specialIndex = index - 1;
@@ -1600,6 +1601,39 @@ void PyrMethodNode::compile(PyrSlot* result) {
     methraw->methType = methType;
     // set primitive
     // optimize common cases
+
+
+    if (mPrimitiveName) {
+        auto prim = gPrimitiveTable.table[methraw->specialIndex];
+        if (prim.func == undefinedPrimitive) {
+            error("Method %s:%s has an undefined primitive.\n",
+                  slotRawSymbol(&slotRawClass(&method->ownerclass)->name)->name, slotRawSymbol(&method->name)->name);
+            nodePostErrorLine((PyrParseNode*)mPrimitiveName);
+            compileErrors++;
+        }
+
+        if (prim.numNormalArguments != numArgs) {
+            error("Method %s:%s's number of arguments does not match the primitive.\n",
+                  slotRawSymbol(&slotRawClass(&method->ownerclass)->name)->name, slotRawSymbol(&method->name)->name);
+            nodePostErrorLine((PyrParseNode*)mPrimitiveName);
+            compileErrors++;
+        }
+
+        if (prim.hasVariablePositionalArguments && methraw->numVariableArguments < 1) {
+            error("Primitive has variable arguments but method %s:%s does not.\n",
+                  slotRawSymbol(&slotRawClass(&method->ownerclass)->name)->name, slotRawSymbol(&method->name)->name);
+            nodePostErrorLine((PyrParseNode*)mPrimitiveName);
+            compileErrors++;
+        }
+
+        if (prim.hasVariableKeywordArguments && methraw->numVariableArguments < 2) {
+            error("Primitive has variable keyword arguments but method %s:%s does not.\n",
+                  slotRawSymbol(&slotRawClass(&method->ownerclass)->name)->name, slotRawSymbol(&method->name)->name);
+            nodePostErrorLine((PyrParseNode*)mPrimitiveName);
+            compileErrors++;
+        }
+    }
+
 
     if (methType == methNormal || methType == methPrimitive) {
         // compile body
@@ -1841,7 +1875,7 @@ void PyrCallNodeBase::compilePartialApplication(int numCurryArgs, PyrSlot* resul
 
     SetObject(&block->contextDef, prevBlock);
     ////
-    methraw->varargs = 0;
+    methraw->numVariableArguments = 0;
 
     methraw->frameSize = (numCurryArgs + FRAMESIZE) * sizeof(PyrSlot);
     PyrObject* proto = newPyrArray(compileGC(), numCurryArgs, flags, false);
@@ -1854,10 +1888,10 @@ void PyrCallNodeBase::compilePartialApplication(int numCurryArgs, PyrSlot* resul
 
     SetNil(&block->varNames);
 
-    methraw->numargs = numCurryArgs;
-    methraw->numvars = 0;
-    methraw->posargs = numCurryArgs;
-    methraw->numtemps = numCurryArgs;
+    methraw->numNormalArguments = numCurryArgs;
+    methraw->numVariables = 0;
+    methraw->totalNumberArguments = numCurryArgs;
+    methraw->numSlots = numCurryArgs;
     methraw->popSize = numCurryArgs;
     methraw->methType = methBlock;
 
@@ -1931,7 +1965,7 @@ void PyrCallNode::compileCall(PyrSlot* result) {
     int numArgs = nodeListLength(argnode);
     int numKeyArgs = nodeListLength(keynode);
     int isSuper = isSuperObjNode(argnode);
-    int numBlockArgs = METHRAW(gCompilingBlock)->numargs;
+    int numBlockArgs = METHRAW(gCompilingBlock)->numNormalArguments;
 
     slotRawSymbol(&mSelector->mSlot)->flags |= sym_Called;
     int selType;
@@ -3928,40 +3962,41 @@ PyrBlockNode* newPyrBlockNode(sc::lex::SourceCodeRange loc, PyrArgListNode* argl
 }
 
 void PyrBlockNode::compile(PyrSlot* slotResult) {
-    PyrBlock *block, *prevBlock;
-    PyrMethodRaw* methraw;
-    int i, j, numArgs, numVars;
+    int i, j, numArgs;
     int numVariableArgs = 0;
     int numKwArgs = 0;
-    int numSlots, numArgNames, flags;
+    int numSlots, numArgNames;
     PyrVarDefNode* vardef;
     PyrObject* proto;
-    PyrSymbolArray *argNames, *varNames;
     PyrSlot dummy;
     bool hasVarExprs = false;
 
     // create a new block object
 
-    flags = gCompilingCmdLine ? obj_immutable : obj_permanent | obj_immutable;
-    block = newPyrBlock(flags);
-    SetObject(slotResult, block);
+    const auto flags = gCompilingCmdLine ? obj_immutable : obj_permanent | obj_immutable;
 
     int prevFunctionHighestExternalRef = gFunctionHighestExternalRef;
     bool prevFunctionCantBeClosed = gFunctionCantBeClosed;
     gFunctionHighestExternalRef = 0;
     gFunctionCantBeClosed = false;
 
-    prevBlock = gCompilingBlock;
-    PyrClass* prevClass = gCompilingClass;
+    // This functionDef is what we actually produce here.
+    auto block = newPyrBlock(flags);
+    SetObject(slotResult, block);
 
+    // More global state.
+    auto* prevBlock = gCompilingBlock;
     gCompilingBlock = block;
-    PyrBlock* prevPartiallyAppliedFunction = gPartiallyAppliedFunction;
+
+    auto* prevClass = gCompilingClass;
+
+    auto* prevPartiallyAppliedFunction = gPartiallyAppliedFunction;
     gPartiallyAppliedFunction = nullptr;
 
-    methraw = METHRAW(block);
-    methraw->unused1 = 0;
-    methraw->unused2 = 0;
 
+
+    // PyrMethodRaw holds meta data about the function def in a smaller format.
+    auto* methraw = METHRAW(block);
     methraw->needsHeapContext = 0;
     if (mIsTopLevel) {
         gCompilingClass = class_interpreter;
@@ -3970,21 +4005,30 @@ void PyrBlockNode::compile(PyrSlot* slotResult) {
         SetObject(&block->contextDef, prevBlock);
     }
 
-    methraw->varargs = 0;
+    methraw->unused1 = 0;
+    methraw->unused2 = 0;
+    methraw->needsHeapContext = 0;
+    methraw->numVariableArguments = 0;
+    methraw->methType = methBlock;
     if (mArglist) {
         if (mArglist->mRest) {
-            methraw->varargs += 1;
-            numVariableArgs = 1;
+            methraw->numVariableArguments += 1;
             if (mArglist->mKeywordArgs) {
-                methraw->varargs += 1;
-                numKwArgs = 1;
+                methraw->numVariableArguments += 1;
             }
+        } else {
+            // We don't support variable keywords without variable arguments.
+            assert(mArglist->mKeywordArgs == nullptr);
         }
     }
-    numArgs = mArglist ? nodeListLength((PyrParseNode*)mArglist->mVarDefs) : 0;
-    numVars = mVarlist ? nodeListLength((PyrParseNode*)mVarlist->mVarDefs) : 0;
 
-    if (numArgs > 255) {
+    // Argument counts, there are a few different types.
+    const uint32 numVariableArguments = methraw->numVariableArguments;
+    const uint32 numNormalArguments = mArglist ? nodeListLength(mArglist->mVarDefs) : 0;
+    const uint32 numVars = mVarlist ? nodeListLength(mVarlist->mVarDefs) : 0;
+    const uint32 numArgsTotal = numNormalArguments + numVariableArguments;
+
+    if (numNormalArguments > 255) {
         error("Too many arguments in function definition (> 255)\n");
         nodePostErrorLine((PyrParseNode*)mArglist->mVarDefs);
         compileErrors++;
@@ -3996,185 +4040,155 @@ void PyrBlockNode::compile(PyrSlot* slotResult) {
         compileErrors++;
     }
 
-    numSlots = numArgs + numVariableArgs + numKwArgs + numVars;
-    methraw->frameSize = (numSlots + FRAMESIZE) * sizeof(PyrSlot);
-    if (numSlots) {
-        proto = newPyrArray(compileGC(), numSlots, flags, false);
-        proto->size = numSlots;
+    const uint32 numSlotsForProtoFrame = numArgsTotal + numVars;
+    methraw->frameSize = (numSlotsForProtoFrame + FRAMESIZE) * sizeof(PyrSlot);
+    if (numSlotsForProtoFrame) {
+        auto proto = newPyrArray(compileGC(), numSlotsForProtoFrame, flags, false);
+        proto->size = numSlotsForProtoFrame;
         SetObject(&block->prototypeFrame, proto);
     } else {
         SetNil(&block->prototypeFrame);
     }
 
-    methraw->numargs = numArgs;
-    methraw->numvars = numVars;
-    methraw->posargs = numArgs + numVariableArgs + numKwArgs;
-    methraw->numtemps = numSlots;
-    methraw->popSize = numSlots;
+    methraw->numNormalArguments = numNormalArguments;
+    methraw->numVariables = numVars;
+    methraw->totalNumberArguments = numArgsTotal;
+    methraw->numSlots = numSlotsForProtoFrame;
+    methraw->popSize = numSlotsForProtoFrame;
 
-    numArgNames = methraw->posargs;
-
-    if (numArgNames) {
-        argNames = newPyrSymbolArray(compileGC(), numArgNames, flags, false);
-        argNames->size = numArgNames;
-        SetObject(&block->argNames, argNames);
+    // Build argname and varname array
+    auto* argNames = numArgsTotal > 0 ? newPyrSymbolArray(compileGC(), numArgsTotal, flags, false) : nullptr;
+    if (numArgsTotal) {
+        argNames->size = numArgsTotal;
+        block->argNames = PyrSlot::make(argNames);
     } else {
-        SetNil(&block->argNames);
+        block->argNames = PyrSlot::make(PyrNil {});
     }
 
-    if (numVars) {
-        varNames = newPyrSymbolArray(compileGC(), numVars, flags, false);
+    auto* varNames = numVars > 0 ? newPyrSymbolArray(compileGC(), numVars, flags, false) : nullptr;
+    if (numVars > 0) {
         varNames->size = numVars;
-        SetObject(&block->varNames, varNames);
+        block->varNames = PyrSlot::make(varNames);
     } else {
-        SetNil(&block->varNames);
+        block->varNames = PyrSlot::make(PyrNil {});
     }
 
-    // declare args
-    if (numArgs) {
-        PyrSymbol** blockargs;
-        blockargs = slotRawSymbolArray(&block->argNames)->symbols;
-        vardef = mArglist->mVarDefs;
-        for (i = 0; i < numArgs; ++i, vardef = (PyrVarDefNode*)vardef->mNext) {
-            PyrSlot* varslot;
-            varslot = &vardef->mVarName->mSlot;
-            // already declared as arg?
-            for (j = 0; j < i; ++j) {
-                if (blockargs[j] == slotRawSymbol(varslot)) {
-                    error("Function argument '%s' already declared in %s:%s\n", slotRawSymbol(varslot)->name,
-                          slotRawSymbol(&gCompilingClass->name)->name, slotRawSymbol(&gCompilingMethod->name)->name);
-                    nodePostErrorLine((PyrParseNode*)vardef);
-                    compileErrors++;
-                }
-            }
-            // put it in mArglist
-            blockargs[i] = slotRawSymbol(varslot);
+
+    // Ensure no variable or argument in this scope collides.
+    std::vector<PyrSymbol*> encounteredNames {};
+    encounteredNames.reserve(numSlotsForProtoFrame);
+    const auto compilerErrorIfDuplicate = [&](PyrSymbol* sym, PyrParseNode* where) {
+        if (const auto fnd = std::find(encounteredNames.begin(), encounteredNames.end(), sym);
+            fnd != encounteredNames.end()) {
+            error("Duplicate name in function: %s\n", (*fnd)->name);
+            nodePostErrorLine(where);
+            compileErrors++;
+        }
+        encounteredNames.push_back(sym);
+    };
+
+    // put normal argument names into argNames array.
+    if (mArglist) {
+        auto* argIt = mArglist->mVarDefs;
+        for (size_t i { 0 }; i < numNormalArguments; ++i, argIt = reinterpret_cast<PyrVarDefNode*>(argIt->mNext)) {
+            auto* sym = argIt->mVarName->mSlot.getSymbol();
+            assert(sym);
+            compilerErrorIfDuplicate(sym, argIt);
+            argNames->symbols[i] = sym;
+        }
+    } else {
+        assert(numNormalArguments == 0);
+    }
+    // put variable postiional and keyword argument names into argNames array.
+    if (numVariableArguments >= 1) {
+        assert(mArglist);
+        assert(mArglist->mRest);
+        auto* variableArgNameSym = mArglist->mRest->mSlot.getSymbol();
+        assert(variableArgNameSym);
+        compilerErrorIfDuplicate(variableArgNameSym, mArglist->mRest);
+        argNames->symbols[numNormalArguments] = variableArgNameSym;
+        if (numVariableArguments == 2) {
+            // put variable keyword arguments into argNames array.
+            auto* variableKeywordArgNameSym = mArglist->mKeywordArgs->mSlot.getSymbol();
+            assert(variableKeywordArgNameSym);
+            compilerErrorIfDuplicate(variableKeywordArgNameSym, mArglist->mKeywordArgs);
+            argNames->symbols[numNormalArguments + 1] = variableKeywordArgNameSym;
         }
     }
 
-    if (numVariableArgs > 0) {
-        PyrSlot* varslot;
-        PyrSymbol** blockargs;
-        blockargs = slotRawSymbolArray(&block->argNames)->symbols;
-        varslot = &mArglist->mRest->mSlot;
-        // already declared as arg?
-        for (j = 0; j < numArgs; ++j) {
-            if (blockargs[j] == slotRawSymbol(varslot)) {
-                error("Function argument '%s' already declared in %s:%s\n", slotRawSymbol(varslot)->name,
-                      slotRawSymbol(&gCompilingClass->name)->name, slotRawSymbol(&gCompilingMethod->name)->name);
-                nodePostErrorLine((PyrParseNode*)vardef);
-                compileErrors++;
-            }
-        }
-        // put it in mArglist
-        blockargs[numArgs] = slotRawSymbol(varslot);
-
-        if (numKwArgs > 0) {
-            PyrSlot* kwvarslot;
-            kwvarslot = &mArglist->mKeywordArgs->mSlot;
-            // already declared as arg?
-            // Add one here to numArgs to include the name of the variableArgument slot
-            for (j = 0; j < numArgs + 1; ++j) {
-                if (blockargs[j] == slotRawSymbol(kwvarslot)) {
-                    error("Argument '%s' already declared in %s:%s\n", slotRawSymbol(kwvarslot)->name,
-                          slotRawSymbol(&gCompilingClass->name)->name, slotRawSymbol(&gCompilingMethod->name)->name);
-                    nodePostErrorLine((PyrParseNode*)kwvarslot);
-                    compileErrors++;
-                }
-            }
-            blockargs[numArgs + 1] = slotRawSymbol(kwvarslot);
-        }
-    }
-
-    // declare vars
-    if (numVars) {
-        PyrSymbol **blockargs, **blockvars;
-        blockargs = block->argNames.isObjectHdr() ? slotRawSymbolArray(&block->argNames)->symbols : nullptr;
-        blockvars = slotRawSymbolArray(&block->varNames)->symbols;
-        vardef = mVarlist->mVarDefs;
-        for (i = 0; i < numVars; ++i, vardef = (PyrVarDefNode*)vardef->mNext) {
-            PyrSlot* varslot;
-            varslot = &vardef->mVarName->mSlot;
-            const PyrSymbol* name = slotRawSymbol(varslot);
+    // put variable names into varNames array.
+    if (mVarlist) {
+        auto* varIt = mVarlist->mVarDefs;
+        for (size_t i { 0 }; i < numVars; ++i, varIt = reinterpret_cast<PyrVarDefNode*>(varIt->mNext)) {
+            auto* name = varIt->mVarName->mSlot.getSymbol();
+            assert(name);
+            compilerErrorIfDuplicate(name, varIt);
             if (name == s_this) {
                 error("Cannot redefine 'this'\n");
-                nodePostErrorLine((PyrParseNode*)vardef);
+                nodePostErrorLine(varIt);
                 emitCompilerErrorFromVersion({ 3, 16, 0 });
             } else if (name == s_curProcess) {
                 error("Cannot redefine 'thisProcess'\n");
-                nodePostErrorLine((PyrParseNode*)vardef);
+                nodePostErrorLine(varIt);
                 emitCompilerErrorFromVersion({ 3, 16, 0 });
             } else if (name == s_curMethod) {
                 error("Cannot redefine 'thisMethod'\n");
-                nodePostErrorLine((PyrParseNode*)vardef);
+                nodePostErrorLine(varIt);
                 emitCompilerErrorFromVersion({ 3, 16, 0 });
             } else if (name == s_curBlock) {
                 error("Cannot redefine 'thisFunctionDef'\n");
-                nodePostErrorLine((PyrParseNode*)vardef);
+                nodePostErrorLine(varIt);
                 emitCompilerErrorFromVersion({ 3, 16, 0 });
             } else if (name == s_curClosure) {
                 error("Cannot redefine 'thisFunction'\n");
-                nodePostErrorLine((PyrParseNode*)vardef);
+                nodePostErrorLine(varIt);
                 emitCompilerErrorFromVersion({ 3, 16, 0 });
             } else if (name == s_curThread) {
                 error("Cannot redefine 'thisThread'\n");
-                nodePostErrorLine((PyrParseNode*)vardef);
+                nodePostErrorLine(varIt);
                 emitCompilerErrorFromVersion({ 3, 16, 0 });
             } else if (name == s_super) {
                 error("Cannot redefine 'super'\n");
-                nodePostErrorLine((PyrParseNode*)vardef);
+                nodePostErrorLine(varIt);
                 emitCompilerErrorFromVersion({ 3, 16, 0 });
             }
 
-            // already declared as arg?
-            for (j = 0; j < numArgNames; ++j) {
-                if (blockargs[j] == slotRawSymbol(varslot)) {
-                    error("Function variable '%s' already declared in %s:%s\n", slotRawSymbol(varslot)->name,
-                          slotRawSymbol(&gCompilingClass->name)->name, slotRawSymbol(&gCompilingMethod->name)->name);
-                    nodePostErrorLine((PyrParseNode*)vardef);
-                    compileErrors++;
-                }
-            }
-            // already declared as var?
-            for (j = 0; j < i; ++j) {
-                if (blockvars[j] == slotRawSymbol(varslot)) {
-                    error("Function variable '%s' already declared in %s:%s\n", slotRawSymbol(varslot)->name,
-                          slotRawSymbol(&gCompilingClass->name)->name, slotRawSymbol(&gCompilingMethod->name)->name);
-                    nodePostErrorLine((PyrParseNode*)vardef);
-                    compileErrors++;
-                }
-            }
-            // put it in varlist
-            blockvars[i] = slotRawSymbol(varslot);
+            varNames->symbols[i] = name;
+        }
+    } else {
+        assert(numVars == 0);
+    }
+
+    // fill prototype frame
+    auto* prototypeFrame = block->prototypeFrame.getPyrObjType<PyrObject>();
+    assert(numSlotsForProtoFrame > 0 ? prototypeFrame != nullptr : true);
+    bool hasNonLiteralDefaultInitialisers = false; // Will require compiling the assignments if true.
+
+    // Put argument defaults into proto if literals.
+    if (mArglist) {
+        auto* argIt = mArglist->mVarDefs;
+        for (size_t i = 0; i < numNormalArguments; ++i, argIt = (PyrVarDefNode*)argIt->mNext) {
+            PyrSlot litval;
+            if (argIt->hasExpr(&litval))
+                hasNonLiteralDefaultInitialisers = true;
+            prototypeFrame->slots[i] = litval;
         }
     }
 
-    if (numArgs) {
-        vardef = mArglist->mVarDefs;
-        for (i = 0; i < numArgs; ++i, vardef = (PyrVarDefNode*)vardef->mNext) {
-            PyrSlot *slot, litval;
-            slot = slotRawObject(&block->prototypeFrame)->slots + i;
-            if (vardef->hasExpr(&litval))
-                hasVarExprs = true;
-            *slot = litval;
-        }
+    // put variable argument and variable keyword arguments default into proto, always the empty array.
+    for (size_t i = numNormalArguments; i < numArgsTotal; ++i) {
+        prototypeFrame->slots[i] = o_emptyarray;
     }
 
-    if (numVariableArgs > 0) {
-        slotCopy(&slotRawObject(&block->prototypeFrame)->slots[numArgs], &o_emptyarray);
-        if (numKwArgs > 0) {
-            slotCopy(&slotRawObject(&block->prototypeFrame)->slots[numArgs + 1], &o_emptyarray);
-        }
-    }
-
-    if (numVars) {
-        vardef = mVarlist->mVarDefs;
-        for (i = 0; i < numVars; ++i, vardef = (PyrVarDefNode*)vardef->mNext) {
-            PyrSlot *slot, litval;
-            slot = slotRawObject(&block->prototypeFrame)->slots + i + numArgs + numVariableArgs;
-            if (vardef->hasExpr(&litval))
-                hasVarExprs = true;
-            *slot = litval;
+    // put variable defaults into proto if literals.
+    if (mVarlist) {
+        auto* varIt = mVarlist->mVarDefs;
+        for (size_t i = numArgsTotal, j = 0; i < numArgsTotal + numVars;
+             ++i, ++j, varIt = reinterpret_cast<PyrVarDefNode*>(varIt->mNext)) {
+            PyrSlot litval;
+            if (varIt->hasExpr(&litval))
+                hasNonLiteralDefaultInitialisers = true;
+            prototypeFrame->slots[i] = litval;
         }
     }
     methraw->methType = methBlock;
@@ -4182,20 +4196,23 @@ void PyrBlockNode::compile(PyrSlot* slotResult) {
     // compile body
     initByteCodes();
     {
+        PyrSlot dummy;
+
         SetTailBranch branch(true);
         SetTailIsMethodReturn mr(false);
-        if (hasVarExprs) {
+
+        // Compile the arguments if not literals (or nil).
+        if (hasNonLiteralDefaultInitialisers) {
+            // Only compiles the node if they aren't literals.
             if (mArglist) {
-                vardef = mArglist->mVarDefs;
-                for (i = 0; i < numArgs; ++i, vardef = (PyrVarDefNode*)vardef->mNext) {
+                auto* vardef = mArglist->mVarDefs;
+                for (size_t i = 0; i < numNormalArguments; ++i, vardef = (PyrVarDefNode*)vardef->mNext)
                     vardef->compileArg(&dummy);
-                }
             }
             if (mVarlist) {
-                vardef = mVarlist->mVarDefs;
-                for (i = 0; i < numVars; ++i, vardef = (PyrVarDefNode*)vardef->mNext) {
+                auto* vardef = mVarlist->mVarDefs;
+                for (size_t i = 0; i < numVars; ++i, vardef = (PyrVarDefNode*)vardef->mNext)
                     vardef->compile(&dummy);
-                }
             }
         }
         if (mBody->mClassno == pn_BlockReturnNode) {
@@ -4460,7 +4477,7 @@ bool findVarName(PyrBlock* func, PyrClass** classobj, PyrSymbol* name, int* varT
     j = 0;
     while (func != nullptr) {
         methraw = METHRAW(func);
-        numargs = methraw->posargs;
+        numargs = methraw->totalNumberArguments;
         for (i = 0; i < numargs; ++i) {
             argname = slotRawSymbolArray(&func->argNames)->symbols[i];
             // postfl("    %d %d arg '%s' '%s'\n", j, i, argname->name, name->name);
@@ -4475,7 +4492,7 @@ bool findVarName(PyrBlock* func, PyrClass** classobj, PyrSymbol* name, int* varT
                 return true;
             }
         }
-        for (i = 0, k = numargs; i < methraw->numvars; ++i, ++k) {
+        for (i = 0, k = numargs; i < methraw->numVariables; ++i, ++k) {
             varname = slotRawSymbolArray(&func->varNames)->symbols[i];
             // postfl("    %d %d %d var '%s' '%s'\n", j, i, k, varname->name, name->name);
             if (varname == name) {

--- a/lang/LangSource/PyrParseNode.cpp
+++ b/lang/LangSource/PyrParseNode.cpp
@@ -3994,7 +3994,6 @@ void PyrBlockNode::compile(PyrSlot* slotResult) {
     gPartiallyAppliedFunction = nullptr;
 
 
-
     // PyrMethodRaw holds meta data about the function def in a smaller format.
     auto* methraw = METHRAW(block);
     methraw->needsHeapContext = 0;

--- a/lang/LangSource/PyrPrimitive.h
+++ b/lang/LangSource/PyrPrimitive.h
@@ -30,11 +30,29 @@ Functions for defining language primitives.
 typedef int (*PrimitiveHandler)(struct VMGlobals* g, int numArgsPushed);
 typedef int (*PrimitiveWithKeysHandler)(struct VMGlobals* g, int numArgsPushed, int numKeyArgsPushed);
 
+int undefinedPrimitive(struct VMGlobals* g, int numArgsPushed);
+
 int nextPrimitiveIndex();
 int definePrimitive(int base, int index, const char* name, PrimitiveHandler handler, int numArgs, int varArgs);
-int definePrimitiveWithKeys(int base, int index, const char* name, PrimitiveHandler handler,
-                            PrimitiveWithKeysHandler keyhandler, int numArgs, int varArgs);
+int definePrimitiveWithVariableKeys(int base, int index, const char* name, PrimitiveHandler handler,
+                                    PrimitiveWithKeysHandler keyhandler, int numArgs, int varArgs);
 int getPrimitiveNumArgs(int index);
 PyrSymbol* getPrimitiveName(int index);
 
 void switchToThread(VMGlobals* g, PyrThread* newthread, int oldstate, int* numArgsPushed);
+
+typedef struct {
+    PrimitiveHandler func;
+    PyrSymbol* name;
+    unsigned short base;
+    unsigned char numNormalArguments;
+    bool hasVariablePositionalArguments;
+    bool hasVariableKeywordArguments;
+} PrimitiveDef;
+
+typedef struct {
+    int size, maxsize;
+    PrimitiveDef* table;
+} PrimitiveTable;
+
+extern PrimitiveTable gPrimitiveTable;

--- a/testsuite/classlibrary/TestIdentityDictionary.sc
+++ b/testsuite/classlibrary/TestIdentityDictionary.sc
@@ -1,0 +1,35 @@
+
+TestIdentityDictionary : UnitTest {
+    test_put {
+        this.assertEquals(
+            ().put(\meow, 1),
+            (meow: 1),
+            "Normal put works"
+        );
+
+        this.assertEquals(
+            ().put(key: \meow, value: 1),
+            (meow: 1),
+            "Put with keyword arguments work"
+        );
+
+        this.assertEquals(
+            ().put(\meow, 1, 10),
+            (meow: 1),
+            "Normal put works with extra arguments"
+        );
+
+        this.assertEquals(
+            ().put(key: \meow, value: 1, woof: 10),
+            (meow: 1),
+            "Put with extra keyword arguments works"
+        );
+
+        this.assertEquals(
+            ().put(\meow, 1, woof: 10),
+            (meow: 1),
+            "Put with extra keyword arguments and normal arguments work"
+        );
+
+    }
+}

--- a/testsuite/classlibrary/TestKwargs.sc
+++ b/testsuite/classlibrary/TestKwargs.sc
@@ -73,6 +73,11 @@ TestKwargs : UnitTest {
 			f.(1, b: 2, args: 10, kwargs: 20),
 			(a: 1, b: 2, args: [], kwargs: [\args, 10, \kwargs: 20]),
 			"Should be able to pass 'args' and 'kwargs' to methods"
+		);
+		this.assertEquals(
+			f.(1, b: 2),
+			(a: 1, b: 2, args: [], kwargs: []),
+			"Should be able to pass 'args' and 'kwargs' to methods"
 		)
 	}
 
@@ -156,27 +161,43 @@ TestKwargs : UnitTest {
 	test_control_flow {
 		var i = 0;
 		// These all used to crash.
-		this.assertEquals(true.if(trueFunc: {'s'}), 's');
-		this.assertEquals(true.if(falseFunc: {'s'}), nil);
+		this.assertEquals(true.if(trueFunc: {'s'}), 's', "If with truefunc");
+		this.assertEquals(true.if(falseFunc: {'s'}), nil, "If with falseFunc");
 
-		this.assertEquals(false.if(trueFunc: {'s'}), nil);
-		this.assertEquals(false.if(falseFunc: {'s'}), 's');
+		this.assertEquals(false.if(trueFunc: {'s'}), nil, "If with trueFunc, but false");
+		this.assertEquals(false.if(falseFunc: {'s'}), 's', "If with falseFunc, but false");
 
 		// Posts a warning, but that is fine.
-		this.assertEquals(100.loop(xyz: 1).(), 100);
+		this.assertEquals(100.loop(xyz: 1).(), 100, "loop");
 
-		this.assertEquals(true.and(that: {1}), 1);
-		this.assertEquals(false.and(that: {1}), false);
+		this.assertEquals(true.and(that: {1}), 1, "and true");
+		this.assertEquals(false.and(that: {1}), false, "and false");
 
 		// Unary messages
-		this.assertEquals(true.not(asd: 1), false);
-		this.assertEquals(false.not(asd: 1), true);
+		this.assertEquals(true.not(asd: 1), false, "not true");
+		this.assertEquals(false.not(asd: 1), true, "not false");
 
 		// Binary, note the unusual syntax needed to call these with keywords!
-		this.assertEquals( (!?)(1, obj: 2),  2);
-		this.assertEquals((+)(1, aNumber: 10 ), 11);
+		this.assertEquals((!?)(1, obj: 2),  2, "binary !? with kwargs");
+
+		// This one isn't inlined, and so actually does the kwargs lookup in doPrimitiveWithKeys
+		this.assertEquals((+)(1, aNumber: 10), 11, "binary + with kwargs");
 
 		while({ i < 10 }, body: { i = i + 1 });
-		this.assertEquals(i, 10);
+		this.assertEquals(i, 10, "while with kwargs works");
+	}
+
+	test_block {
+
+		var f = {
+			| a=1, b=2 ...args, kwargs|
+			var bar = 10;
+			this.assertEquals(a, 1);
+			this.assertEquals(b, 2);
+			this.assertEquals(bar, 10);
+			this.assertEquals(args, []);
+			this.assertEquals(kwargs, []);
+		};
+		f.();
 	}
 }

--- a/testsuite/classlibrary/TestPrimitive.sc
+++ b/testsuite/classlibrary/TestPrimitive.sc
@@ -1,0 +1,112 @@
+TestPrimitive_Obj {
+	noKwargsNoVarArgs { |a, b, c|
+		_PrimitiveTestNoKwargsNoVarArg;
+		1 + 1;
+		^this.primitiveFailed
+	}
+
+	noKwargsWithVarArgs { |a, b, c... args|
+		_PrimitiveTestNoKwargsWithVarArgs;
+		1 + 1;
+		^this.primitiveFailed
+	}
+
+	kwargsWithVarArgs { |a, b, c... args, kwargs|
+		_PrimitiveTestWithKwargs;
+		1 + 1;
+		^this.primitiveFailed
+	}
+}
+
+TestPrimitive_Obj_NoError {
+	noKwargsNoVarArgs { |a, b, c| _PrimitiveTestNoKwargsNoVarArg }
+	noKwargsWithVarArgs { |a, b, c... args| _PrimitiveTestNoKwargsWithVarArgs }
+	kwargsWithVarArgs { |a, b, c... args, kwargs| _PrimitiveTestWithKwargs }
+}
+
+TestPrimitives : UnitTest {
+	no_var_args { |obj|
+		this.assertEquals(
+			obj.noKwargsNoVarArgs(1, 2, 3),
+			[obj, 1, 2, 3]
+		);
+		this.assertEquals(
+			obj.noKwargsNoVarArgs(a: 1, b: 2, c: 3),
+			[obj, 1, 2, 3]
+		);
+		this.assertEquals(
+			obj.noKwargsNoVarArgs(1, 2, c: 3),
+			[obj, 1, 2, 3]
+		);
+		this.assertEquals(
+			obj.noKwargsNoVarArgs(1, 2, 3, 4, 5),
+			[obj, 1, 2, 3]
+		);
+		this.assertEquals(
+			obj.noKwargsNoVarArgs(1, 2, 3, 4, f: 5),
+			[obj, 1, 2, 3]
+		);
+	}
+
+	with_var_args { |obj| 
+		this.assertEquals(
+			obj.noKwargsWithVarArgs(1, 2, 3),
+			[obj, 1, 2, 3]
+		);
+		this.assertEquals(
+			obj.noKwargsWithVarArgs(a: 1, b: 2, c: 3),
+			[obj, 1, 2, 3]
+		);
+		this.assertEquals(
+			obj.noKwargsWithVarArgs(1, 2, c: 3),
+			[obj, 1, 2, 3]
+		);
+		this.assertEquals(
+			obj.noKwargsWithVarArgs(1, 2, 3, 4, 5),
+			[obj, 1, 2, 3, 4, 5]
+		);
+		this.assertEquals(
+			obj.noKwargsWithVarArgs(1, 2, 3, 4, f: 5),
+			[obj, 1, 2, 3, 4]
+		);
+	}
+
+	with_kw_and_var_args { |obj|
+		this.assertEquals(
+			obj.kwargsWithVarArgs(1, 2, 3),
+			[obj, 1, 2, 3]
+		);
+		this.assertEquals(
+			obj.kwargsWithVarArgs(a: 1, b: 2, c: 3),
+			[obj, 1, 2, 3]
+		);
+		this.assertEquals(
+			obj.kwargsWithVarArgs(1, 2, c: 3),
+			[obj, 1, 2, 3]
+		);
+		this.assertEquals(
+			obj.kwargsWithVarArgs(1, 2, 3, 4, 5),
+			[obj, 1, 2, 3, 4, 5]
+		);
+		this.assertEquals(
+			obj.kwargsWithVarArgs(1, 2, 3, 4, f: 5),
+			[obj, 1, 2, 3, 4, f: 5]
+		);
+	}
+
+	test_no_kw_no_var_args {
+		this.no_var_args(TestPrimitive_Obj());
+		this.no_var_args(TestPrimitive_Obj_NoError());
+	}
+
+	// basic, with var args
+	test_no_kw_with_var_args {
+		this.with_var_args(TestPrimitive_Obj());
+		this.with_var_args(TestPrimitive_Obj_NoError());
+	}
+
+	test_kw_with_var_args {
+		this.with_kw_and_var_args(TestPrimitive_Obj());
+		this.with_kw_and_var_args(TestPrimitive_Obj_NoError());
+	}
+}

--- a/testsuite/classlibrary/TestString.sc
+++ b/testsuite/classlibrary/TestString.sc
@@ -287,4 +287,8 @@ TestString : UnitTest {
 		var expected = json.parseJSON;
 		this.assertEquals(result, expected);
 	}
+
+	test_asStringLimit {
+		this.assert((0..1024).asString(32).size < (0..1024).asString, "asString should pass on the limit argument and make the string shorter.");
+	}
 }


### PR DESCRIPTION
## Purpose and Motivation

From now on, primitives in c++ and sclang must have the same number of arguments, including variable arguments and variable keyword arguments, it is also a compile error to write a primitive that doesn't exist.

Previously, primitives could be declared with `n` arguments in c++ but `m` arguments in sclang. This was very confusing.

Previously, having a primitive with keyword arguments meant all keyword arguments were passed with the key to the primitive, even if they were declared as positional in sclang. This meant that
```
A {
   *new { |foo... args, kwargs|
          _PrintAllArgs
   }
}
A(foo: 10, bar: 20)
```
would print `[\foo, 10, \bar, 20]` rather than `[10, \bar, 20]`, which is unique behaviour.

Fixes bug `().put(\asdf, 123, meow: 23)` which would crash because the stack pointer wasn't decremented when removing them from the stack. I do not know when this bug was introduced.

Introduces a number of tests to ensure primitives will always be working correctly.

## Review guide

To start, I'd recommend having a look at the tests. 

## Difference

```
// All primitives just return the stack in an array.
TestPrimitive_Obj {
	noKwargsNoVarArgs { |a, b, c|
		_PrimitiveTestNoKwargsNoVarArg;
		^this.primitiveFailed
	}

	noKwargsWithVarArgs { |a, b, c... args|
		_PrimitiveTestNoKwargsWithVarArgs;
		^this.primitiveFailed
	}

	kwargsWithVarArgs { |a, b, c... args, kwargs|
		_PrimitiveTestWithKwargs;
		^this.primitiveFailed
	}
}

TestPrimitive_Obj().kwargsWithVarArgs(a: 1, b: 2, c: 3)
// old
 [a TestPrimitive_Obj, a, 1, b, 2, c, 3]
// new
 [a TestPrimitive_Obj, 1, 2, 3]

TestPrimitive_Obj().noKwargsWithVarArgs(1, 2, c: 3)
// old
 [a TestPrimitive_Obj, 1, 2, c, 3] 
// new
 [a TestPrimitive_Obj, 1, 2, 3] 
```

Previously, `definePrimitiveWithKey` was only meant to implement functions with variable keyword arguments and **no** positional arguments. If the sclang method had positional arguments, and they were specified as a keyword arguments, they would be placed on the end, now they are placed correctly. 

## Types of changes

<!-- Delete lines that don't apply -->


- Bug fix
- Breaking change ?? Maybe, I am unsure.

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
