### PR TITLE
Remove scale degrees subsection from Literals.schelp

### DIFF
--- a/HelpSource/Reference/Literals.schelp
+++ b/HelpSource/Reference/Literals.schelp
@@ -93,39 +93,6 @@ code::
 
 Hexidecimal numbers notated with code::0x:: may only be expressed as integers.
 
-subsection::Scale Degrees
-Integer numbers as scale degrees supports accidentals notation by adding the suffixes strong::s:: for sharp and strong::b:: for flat. Accidentals are represented as floating point values.
-
-code::
-2s == 2.1  // scale degree two, sharp
-2b == 1.9  // scale degree two, flat
-2ss == 2.2 // scale degree two, double sharp
-2bb == 1.8 // scale degree two, double flat
-::
-
-Up to four:
-
-code::
-2ssss == 2.4
-2bbbb == 1.6
-::
-
-With negative scale degrees it reverses:
-
-code::
--2s == -1.9
--2b == -2.1
--2ss == -1.8
--2bb == -2.2
-::
-
-Accidentals can also specify cents deviation up to 499 cents:
-
-code::
-2b50 == 1.95 // scale degree two, fifty cents flat
-2s204 == 2.204 // scale degree two, 204 cents sharp
-::
-
 section::Characters
 
 Characters are preceded by a dollar sign:


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

Removed scale degrees section and examples from Literals.schelp because, apparently, this functionality was never implemented. See Issue #7088 , which this PR would also close

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->

- Documentation

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [ ] Code is tested
- [ ] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

Should close Issue #7088 

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
