### PR TITLE
SCDocHTMLRenderer: Insert a Space at Each Line Break

### DIFF
--- a/SCClassLibrary/SCDoc/SCDocRenderer.sc
+++ b/SCClassLibrary/SCDoc/SCDocRenderer.sc
@@ -563,7 +563,7 @@ SCDocHTMLRenderer {
 				};
 				this.renderChildren(stream, node);
 			},
-			\NL, { }, // these shouldn't be here..
+			\NL, { stream << " "; }, // these shouldn't be here..
 // Plain text and modal tags
 			\TEXT, {
 				stream << this.escapeSpecialChars(node.text);


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

fixes #7001
## Purpose and Motivation

The current implementation of SCDocHTMLRenderer does not insert a space when a new line begins, as outlined in issue #7001. This pull request addresses and resolves that problem.

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
