### PR TITLE
plugins: add BufIn to read buffer samples as flat array (like FluidBufToKr)

### DIFF
--- a/HelpSource/Classes/BufIn.schelp
+++ b/HelpSource/Classes/BufIn.schelp
@@ -1,16 +1,24 @@
 class:: BufIn
 summary:: Reads Buffer samples as flat array
-related:: Classes/BufRd
+related:: Classes/BufRd, Classes/Index
 categories:: UGens>Buffer
 
 Description::
+Outputs the contents of a buffer as a control signal, reading a number of
+consecutive samples as separate channels. Like link::Classes/Index::, but
+for multiple indices as the same time, saving the overhead of making multiple UGens.
 
-Outputs the contents of a buffer as a control signal, reading adjacent samples
-as separate channels.
-
-In comparison to link::Classes/BufRd:: :
+In comparison to link::Classes/BufRd:::
 BufRd has a single reading head that moves through buffer samples, BufIn has
-multiple heads, each staying still on a sample.
+multiple heads, each staying still on a different sample.
+
+BufIn treats multi-channel buffers as a flat, interleaved sequence of values.
+This means that reading for instance 2 samples of a 2-channels buffer will
+output only the first value for each channel. See link::#examples:: below, and
+link::Classes/Buffer#Multichannel Buffers:: for more info.
+
+Only the link::#*kr:: method is implemented, because the value at a single buffer index can't
+change between control periods.
 
 classmethods::
 private:: categories
@@ -21,13 +29,16 @@ Number of output channels, i.e. number of consecutive samples to read from the
 buffer.
 note::
 It doesn't have to match the Buffer's number of samples. If the
-buffer has less samples, the remaining output channels will return 0.::
+buffer has less samples than requested, the exceeding output channels will return 0.::
 
 argument::bufnum
 The index of the buffer to use.
 
 argument::offset
 The sample index to start reading from.
+
+returns::
+An array of output channels, corresponding to the requested buffer samples.
 
 instancemethods::
 private:: init, argNamesInputsOffset, checkInputs
@@ -36,10 +47,8 @@ Examples::
 
 code::
 
-(
 // load some numbers on a buffer
 b = Buffer.loadCollection(s, [34, 61, 104.3, 50]);
-)
 
 // print those numbers
 x = { BufIn.kr(4, b).poll }.play;
@@ -58,5 +67,21 @@ x.free;
 b.loadCollection({rrand(40,100)}!4);
 
 b.free
+::
 
+Values from multi-channel buffers are interleaved. Note that they need to be
+interleaved manually when using link::Classes/Buffer#*loadCollection::
+
+code::
+b = Buffer.loadCollection(s, [[1,2,3], [4,5,6]].lace);
+
+x = { BufIn.kr(6, b).poll }.play;
+// outputs [1, 4, 2, 5, 3, 6]
+// i.e. [ch0_0, ch1_0, ch0_1, ch1_1, ch0_2, ch1_2]
+
+x.free;
+
+// user can de-interleave manually afterwards
+x = { BufIn.kr(6, b).unlace(2).poll }.play;
+// outputs [1, 2, 3, 4, 5, 6]
 ::

--- a/HelpSource/Classes/BufIn.schelp
+++ b/HelpSource/Classes/BufIn.schelp
@@ -17,12 +17,9 @@ This means that reading for instance 2 samples of a 2-channels buffer will
 output only the first value for each channel. See link::#examples:: below, and
 link::Classes/Buffer#Multichannel Buffers:: for more info.
 
-Only the link::#*kr:: method is implemented, because the value at a single buffer index can't
-change between control periods.
-
 classmethods::
 private:: categories
-method:: kr
+method:: ar, kr
 
 argument::numChannels
 Number of output channels, i.e. number of consecutive samples to read from the

--- a/HelpSource/Classes/BufIn.schelp
+++ b/HelpSource/Classes/BufIn.schelp
@@ -12,16 +12,18 @@ In comparison to link::Classes/BufRd:::
 BufRd has a single reading head that moves through buffer samples, BufIn has
 multiple heads, each staying still on a different sample.
 
-BufIn treats multi-channel buffers as a flat, interleaved sequence of values.
-This means that reading for instance 2 samples of a 2-channels buffer will
-output only the first value for each channel. See link::#examples:: below, and
-link::Classes/Buffer#Multichannel Buffers:: for more info.
+For multi-channel buffers, BufIn defaults to reading a single channel, but can
+also read all of them as a flat, interleaved sequence of values, by setting the
+channel argument to -1. Note that the provided number of outputs has to take
+this into account, e.g. to read 2 frames of a 2-channel buffer,
+teletype::numOutputs:: has to be set to 4.
+See link::#examples:: below, and link::Classes/Buffer#Multichannel Buffers:: for more info.
 
 classmethods::
 private:: categories
 method:: ar, kr
 
-argument::numChannels
+argument::numOutputs
 Number of output channels, i.e. number of consecutive samples to read from the
 buffer.
 note::
@@ -31,8 +33,13 @@ buffer has less samples than requested, the exceeding output channels will retur
 argument::bufnum
 The index of the buffer to use.
 
+argument::channel
+Select which channel to read, or teletype::-1:: for reading all of them as an
+interleaved flat series (see link::examples:: below).
+
 argument::offset
-The sample index to start reading from.
+The sample index to start reading from. Exceeding the buffer's number of
+channels will results in zeros being returned.
 
 returns::
 An array of output channels, corresponding to the requested buffer samples.
@@ -66,13 +73,44 @@ b.loadCollection({rrand(40,100)}!4);
 b.free
 ::
 
-Values from multi-channel buffers are interleaved. Note that they need to be
-interleaved manually when using link::Classes/Buffer#*loadCollection::
+Reading a single channel from a multi-channel buffer:
+code::
+b = Buffer.loadCollection(s, [[1,2,3], [4,5,6]].lace);
+
+x = { BufIn.kr(3, b, channel: 0).poll }.play;
+// outputs [1, 2, 3]
+x.free;
+
+x = { BufIn.kr(3, b, channel: 1).poll }.play;
+// outputs [4, 5, 6]
+x.free;
+
+// multichannel expansion
+x = { BufIn.kr(3, b, channel: [0,1]).poll }.play;
+// outputs [[1, 2, 3], [4, 5, 6]]
+x.free;
+
+// note that 'channel' is modulatable
+(
+x = { 
+	var ch = ToggleFF.kr(Impulse.kr(1)).poll(label:'channel')).poll;
+	BufIn.kr(3, b, channel: ch)
+}.play;
+)
+
+x.free;
+
+b.free;
+::
+
+To read all channels at the same time, set teletype::`channel: -1`::. The output
+will be a flat array with all channels interleaved.
+Note that they need to be interleaved manually when using link::Classes/Buffer#*loadCollection::
 
 code::
 b = Buffer.loadCollection(s, [[1,2,3], [4,5,6]].lace);
 
-x = { BufIn.kr(6, b).poll }.play;
+x = { BufIn.kr(6, b, channel: -1).poll }.play;
 // outputs [1, 4, 2, 5, 3, 6]
 // i.e. [ch0_0, ch1_0, ch0_1, ch1_1, ch0_2, ch1_2]
 
@@ -81,4 +119,6 @@ x.free;
 // user can de-interleave manually afterwards
 x = { BufIn.kr(6, b).unlace(2).poll }.play;
 // outputs [1, 2, 3, 4, 5, 6]
+
+b.free
 ::

--- a/HelpSource/Classes/BufIn.schelp
+++ b/HelpSource/Classes/BufIn.schelp
@@ -1,0 +1,62 @@
+class:: BufIn
+summary:: Reads Buffer samples as flat array
+related:: Classes/BufRd
+categories:: UGens>Buffer
+
+Description::
+
+Outputs the contents of a buffer as a control signal, reading adjacent samples
+as separate channels.
+
+In comparison to link::Classes/BufRd:: :
+BufRd has a single reading head that moves through buffer samples, BufIn has
+multiple heads, each staying still on a sample.
+
+classmethods::
+private:: categories
+method:: kr
+
+argument::numChannels
+Number of output channels, i.e. number of consecutive samples to read from the
+buffer.
+note::
+It doesn't have to match the Buffer's number of samples. If the
+buffer has less samples, the remaining output channels will return 0.::
+
+argument::bufnum
+The index of the buffer to use.
+
+argument::offset
+The sample index to start reading from.
+
+instancemethods::
+private:: init, argNamesInputsOffset, checkInputs
+
+Examples::
+
+code::
+
+(
+// load some numbers on a buffer
+b = Buffer.loadCollection(s, [34, 61, 104.3, 50]);
+)
+
+// print those numbers
+x = { BufIn.kr(4, b).poll }.play;
+
+x.free;
+
+// use as control signals for other UGens
+(
+{ 
+	var notes = BufIn.kr(4, b);
+	Splay.ar(SinOsc.ar(notes.midicps) * 0.2)
+}.play;
+)
+
+// change buffer contents, sound updates automatically
+b.loadCollection({rrand(40,100)}!4);
+
+b.free
+
+::

--- a/SCClassLibrary/Common/Audio/BufIO.sc
+++ b/SCClassLibrary/Common/Audio/BufIO.sc
@@ -112,12 +112,12 @@ RecordBuf : UGen {
 
 
 BufIn : MultiOutUGen {
-	*ar { arg numChannels, bufnum=0, offset=0;
-		^this.multiNew('audio', numChannels, bufnum, offset)
+	*ar { arg numOutputs, bufnum=0, channel=0, offset=0;
+		^this.multiNew('audio', numOutputs, bufnum, channel, offset)
 	}
 
-	*kr { arg numChannels, bufnum=0, offset=0;
-		^this.multiNew('control', numChannels, bufnum, offset)
+	*kr { arg numOutputs, bufnum=0, channel=0, offset=0;
+		^this.multiNew('control', numOutputs, bufnum, channel, offset)
 	}
 
 	init { arg argNumChannels ... theInputs;

--- a/SCClassLibrary/Common/Audio/BufIO.sc
+++ b/SCClassLibrary/Common/Audio/BufIO.sc
@@ -112,6 +112,10 @@ RecordBuf : UGen {
 
 
 BufIn : MultiOutUGen {
+	*ar { arg numChannels, bufnum=0, offset=0;
+		^this.multiNew('audio', numChannels, bufnum, offset)
+	}
+
 	*kr { arg numChannels, bufnum=0, offset=0;
 		^this.multiNew('control', numChannels, bufnum, offset)
 	}

--- a/SCClassLibrary/Common/Audio/BufIO.sc
+++ b/SCClassLibrary/Common/Audio/BufIO.sc
@@ -111,6 +111,23 @@ RecordBuf : UGen {
 }
 
 
+BufIn : MultiOutUGen {
+	*kr { arg numChannels, bufnum=0, offset=0;
+		^this.multiNew('control', numChannels, bufnum, offset)
+	}
+
+	init { arg argNumChannels ... theInputs;
+		inputs = theInputs;
+		^this.initOutputs(argNumChannels, rate);
+	}
+	argNamesInputsOffset { ^2 }
+
+	checkInputs {
+		^this.checkValidInputs;
+	}
+}
+
+
 ScopeOut : UGen {
 	*ar { arg inputArray , bufnum=0;
 		this.multiNewList(['audio', bufnum] ++ inputArray.asArray);

--- a/server/plugins/DelayUGens.cpp
+++ b/server/plugins/DelayUGens.cpp
@@ -1619,9 +1619,8 @@ void BufIn_Ctor(BufIn* unit) {
 
 void BufIn_next(BufIn* unit, int inNumSamples) {
     GET_BUF_SHARED
-    uint32 numOutputs = unit->mNumOutputs;
+    const uint32 numOutputs = unit->mNumOutputs;
     int offset = static_cast<int>(ZIN0(1));
-    bool loop = ZIN0(2) > 0;
 
     if (!bufData) {
         if (unit->mWorld->mVerbosity > -1 && !unit->mDone && (unit->m_failedBufNum != fbufnum)) {
@@ -1637,12 +1636,15 @@ void BufIn_next(BufIn* unit, int inNumSamples) {
 
     uint32 outCh = 0, bufCh = offset;
     for (; outCh < numOutputs && bufCh < bufFrames; outCh++) {
-        OUT(outCh)[0] = bufData[bufCh++];
+        const float val = bufData[bufCh++];
+        for (uint32 outSamp = 0; outSamp < inNumSamples; ++outSamp)
+            OUT(outCh)[outSamp] = val;
     }
 
     // zero eventual extra channels
     for (; outCh < numOutputs; outCh++) {
-        OUT(outCh)[0] = 0;
+        for (uint32 outSamp = 0; outSamp < inNumSamples; ++outSamp)
+            OUT(outCh)[outSamp] = 0;
     }
 }
 

--- a/server/plugins/DelayUGens.cpp
+++ b/server/plugins/DelayUGens.cpp
@@ -99,6 +99,12 @@ struct RecordBuf : public Unit {
     float** mIn;
 };
 
+struct BufIn : public Unit {
+    float m_fbufnum;
+    float m_failedBufNum;
+    SndBuf* m_buf;
+};
+
 struct Pitch : public Unit {
     float m_values[kMAXMEDIANSIZE];
     int m_ages[kMAXMEDIANSIZE];
@@ -278,6 +284,9 @@ void RecordBuf_Ctor(RecordBuf* unit);
 void RecordBuf_Dtor(RecordBuf* unit);
 void RecordBuf_next(RecordBuf* unit, int inNumSamples);
 void RecordBuf_next_10(RecordBuf* unit, int inNumSamples);
+
+void BufIn_Ctor(BufIn* unit);
+void BufIn_next(BufIn* unit, int inNumSamples);
 
 void Pitch_Ctor(Pitch* unit);
 void Pitch_next_a(Pitch* unit, int inNumSamples);
@@ -1599,6 +1608,37 @@ void RecordBuf_next_10(RecordBuf* unit, int inNumSamples) {
 
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+void BufIn_Ctor(BufIn* unit) {
+    unit->m_fbufnum = -1e9f;
+    unit->m_failedBufNum = -1e9f;
+
+    SETCALC(BufIn_next);
+    BufIn_next(unit, 1);
+}
+
+void BufIn_next(BufIn* unit, int inNumSamples) {
+    GET_BUF_SHARED
+    uint32 numOutputs = unit->mNumOutputs;
+    uint32 offset = static_cast<uint32>(ZIN0(1));
+
+    if (!bufData) {
+        if (unit->mWorld->mVerbosity > -1 && !unit->mDone && (unit->m_failedBufNum != fbufnum)) {
+            Print("Buffer UGen: no buffer data\n");
+            unit->m_failedBufNum = fbufnum;
+        }
+        ClearUnitOutputs(unit, inNumSamples);
+        return;
+    }
+
+    // we could wrap around buf samples, but no other ugen does it
+    if (offset < 0)
+        offset = 0;
+
+    for (size_t ch = offset; ch < numOutputs; ch++) {
+        OUT(ch)[0] = bufData[ch];
+    }
+}
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -6928,6 +6968,7 @@ PluginLoad(Delay) {
     DefineDtorUnit(RecordBuf);
     DefineSimpleUnit(BufRd);
     DefineSimpleUnit(BufWr);
+    DefineSimpleUnit(BufIn);
     DefineDtorUnit(Pitch);
 
     DefineSimpleUnit(BufDelayN);

--- a/server/plugins/DelayUGens.cpp
+++ b/server/plugins/DelayUGens.cpp
@@ -1620,8 +1620,9 @@ void BufIn_Ctor(BufIn* unit) {
 void BufIn_next(BufIn* unit, int inNumSamples) {
     GET_BUF_SHARED
     const uint32 numOutputs = unit->mNumOutputs;
-    const uint32 bufSize = buf->frames;
-    int offset = static_cast<int>(ZIN0(1));
+    const uint32 bufSize = buf->samples;
+    int channel = static_cast<int>(ZIN0(1));
+    int offset = static_cast<int>(ZIN0(2));
     if (offset < 0)
         offset = 0;
 
@@ -1634,11 +1635,24 @@ void BufIn_next(BufIn* unit, int inNumSamples) {
         return;
     }
 
-    uint32 outCh = 0, bufCh = offset;
-    for (; outCh < numOutputs && bufCh < bufSize; outCh++) {
-        const float val = bufData[bufCh++];
+    if (channel > buf->channels) {
+        Print("BufIn: requested channel %d, but buffer %d has only %d channels\n", channel, static_cast<int>(fbufnum),
+              buf->channels);
+        ClearUnitOutputs(unit, inNumSamples);
+        return;
+    }
+
+    // channels < 0: output all channels interleaved
+    // channels >= 0: output only selected channel
+    const uint32 channelHop = channel < 0 ? 1 : buf->channels;
+
+    uint32 bufSamp = (offset * buf->channels) + (channel < 0 ? 0 : channel);
+    uint32 outCh = 0;
+    for (; outCh < numOutputs && bufSamp < bufSize; outCh++) {
+        const float val = bufData[bufSamp];
         for (uint32 outSamp = 0; outSamp < inNumSamples; ++outSamp)
             OUT(outCh)[outSamp] = val;
+        bufSamp += channelHop;
     }
 
     // zero eventual extra channels

--- a/server/plugins/DelayUGens.cpp
+++ b/server/plugins/DelayUGens.cpp
@@ -1620,22 +1620,22 @@ void BufIn_Ctor(BufIn* unit) {
 void BufIn_next(BufIn* unit, int inNumSamples) {
     GET_BUF_SHARED
     const uint32 numOutputs = unit->mNumOutputs;
+    const uint32 bufSize = buf->frames;
     int offset = static_cast<int>(ZIN0(1));
+    if (offset < 0)
+        offset = 0;
 
     if (!bufData) {
         if (unit->mWorld->mVerbosity > -1 && !unit->mDone && (unit->m_failedBufNum != fbufnum)) {
-            Print("Buffer UGen: no buffer data\n");
+            Print("BufIn: no buffer data\n");
             unit->m_failedBufNum = fbufnum;
         }
         ClearUnitOutputs(unit, inNumSamples);
         return;
     }
 
-    if (offset < 0)
-        offset = 0;
-
     uint32 outCh = 0, bufCh = offset;
-    for (; outCh < numOutputs && bufCh < bufFrames; outCh++) {
+    for (; outCh < numOutputs && bufCh < bufSize; outCh++) {
         const float val = bufData[bufCh++];
         for (uint32 outSamp = 0; outSamp < inNumSamples; ++outSamp)
             OUT(outCh)[outSamp] = val;

--- a/server/plugins/DelayUGens.cpp
+++ b/server/plugins/DelayUGens.cpp
@@ -1620,7 +1620,8 @@ void BufIn_Ctor(BufIn* unit) {
 void BufIn_next(BufIn* unit, int inNumSamples) {
     GET_BUF_SHARED
     uint32 numOutputs = unit->mNumOutputs;
-    uint32 offset = static_cast<uint32>(ZIN0(1));
+    int offset = static_cast<int>(ZIN0(1));
+    bool loop = ZIN0(2) > 0;
 
     if (!bufData) {
         if (unit->mWorld->mVerbosity > -1 && !unit->mDone && (unit->m_failedBufNum != fbufnum)) {
@@ -1631,12 +1632,17 @@ void BufIn_next(BufIn* unit, int inNumSamples) {
         return;
     }
 
-    // we could wrap around buf samples, but no other ugen does it
     if (offset < 0)
         offset = 0;
 
-    for (size_t ch = offset; ch < numOutputs; ch++) {
-        OUT(ch)[0] = bufData[ch];
+    uint32 outCh = 0, bufCh = offset;
+    for (; outCh < numOutputs && bufCh < bufFrames; outCh++) {
+        OUT(outCh)[0] = bufData[bufCh++];
+    }
+
+    // zero eventual extra channels
+    for (; outCh < numOutputs; outCh++) {
+        OUT(outCh)[0] = 0;
     }
 }
 

--- a/testsuite/classlibrary/TestBufUGens.sc
+++ b/testsuite/classlibrary/TestBufUGens.sc
@@ -15,24 +15,28 @@ TestBufUGens : UnitTest {
 
   assertBufInOuptut { |data, message, numSamples(data.size), offset=0, expected(data), timeout=1|
 		var buffer = Buffer.sendCollection(server, data);
-		var period = server.options.blockSize / server.sampleRate;
 		var cond = CondVar();
 		var out = nil;
 		server.sync;
-		{ BufIn.kr(numSamples, buffer, offset) }.loadToFloatArray(period, server) { |v|
-				out = v;
-				cond.signalOne;
-		};
-		cond.waitFor(1){ out.notNil };
+		[\ar, \kr].do { |method|
+				var period = if (method === \ar) { 1 } { server.options.blockSize } / server.sampleRate;
+				{ BufIn.perform(method, numSamples, buffer, offset) }
+				.loadToFloatArray(period, server) { |v|
+						out = v;
+						cond.signalOne;
+				};
+				cond.waitFor(1){ out.notNil };
 
-		if (out.isNil) {
-				this.assert(false,
-						"timeout while expecting values from server")
-		} {
-				this.assertArrayFloatEquals(out, expected, message, 1e-5)
+				if (out.isNil) {
+						this.assert(false,
+								"timeout while expecting values from server")
+				} {
+						this.assertArrayFloatEquals(out, expected, message + " (%)".format(method), 1e-5)
+				};
 		};
 
 		buffer.free;
+		server.sync;
   }
 
 	test_BufIn_readCorrectValues {

--- a/testsuite/classlibrary/TestBufUGens.sc
+++ b/testsuite/classlibrary/TestBufUGens.sc
@@ -13,22 +13,79 @@ TestBufUGens : UnitTest {
 		server.remove;
 	}
 
-	test_BufIn_readCorrectValues {
-		var data = [89, -2.0, 12345678, -0.1];
+  assertBufInOuptut { |data, message, numSamples(data.size), offset=0, expected(data), timeout=1|
 		var buffer = Buffer.sendCollection(server, data);
 		var period = server.options.blockSize / server.sampleRate;
 		var cond = CondVar();
 		var out = nil;
 		server.sync;
-		{ BufIn.kr(data.size, buffer) }.loadToFloatArray(period, server) { |v|
+		{ BufIn.kr(numSamples, buffer, offset) }.loadToFloatArray(period, server) { |v|
 				out = v;
 				cond.signalOne;
 		};
 		cond.waitFor(1){ out.notNil };
 
-		this.assertArrayFloatEquals(out, data, "should output correct buffer values", 1e-5);
+		if (out.isNil) {
+				this.assert(false,
+						"timeout while expecting values from server")
+		} {
+				this.assertArrayFloatEquals(out, expected, message, 1e-5)
+		};
 
 		buffer.free;
+  }
+
+	test_BufIn_readCorrectValues {
+		var data = [89, -2.0, 12345678, -0.1];
+		this.assertBufInOuptut(data,  "should output correct buffer values");
+
+		data = [[19, -4.0], [1234678, -0.5]].lace;
+		this.assertBufInOuptut(data,  "should output interleaved buffer values for a multi-channel buffer");
+	}
+
+	test_BufIn_readCorrectValues_tooManyOutChannels {
+		var data = [123, -456];
+		this.assertBufInOuptut(data,
+				"should output correct buffer values followed by zeros for extra channels",
+				numSamples: 4,
+				expected: [123, -456, 0, 0]
+		);
+
+		data = [456, -789, 123, -456];
+		this.assertBufInOuptut(data,
+				"should output correct buffer values when reading less channels",
+				numSamples: 2,
+				expected: [456, -789]
+		);
+	}
+
+	test_BufIn_readCorrectValues_offsets {
+		var data = [56, -12, 0.5, 1];
+		this.assertBufInOuptut(data,
+				"should output correct buffer values when given a valid offset",
+				numSamples: 2, offset: 2,
+				expected: [0.5, 1]
+		);
+
+		data = [456, -123, 891];
+		this.assertBufInOuptut(data,
+				"should start from 0 when given offset is negative",
+				offset: -2,
+		);
+
+		data = [4567, -3123, 817];
+		this.assertBufInOuptut(data,
+				"should output zeros when given offset is too big",
+				offset: 4,
+				expected: [0, 0, 0]
+		);
+
+		data = [46, -23];
+		this.assertBufInOuptut(data,
+				"should output correct buffer values when given a float offset (truncated)",
+				offset: 0.95,
+				expected: [46, -23]
+		);
 	}
 
 }

--- a/testsuite/classlibrary/TestBufUGens.sc
+++ b/testsuite/classlibrary/TestBufUGens.sc
@@ -13,14 +13,18 @@ TestBufUGens : UnitTest {
 		server.remove;
 	}
 
-  assertBufInOuptut { |data, message, numSamples(data.size), offset=0, expected(data), timeout=1|
+  assertBufInOuptut { |data, message, numSamples(data.size), channel=0, offset=0, expected(data), timeout=1|
 		var cond = CondVar();
 		var out = nil;
-		var buffer = Buffer.sendCollection(server, data);
+		var buffer = if (data.rank > 1) {
+				Buffer.sendCollection(server, data.lace, data.shape[0])
+		} {
+				Buffer.sendCollection(server, data, 1)
+		};
 		server.sync;
 		[\ar, \kr].do { |method|
 				var period = if (method === \ar) { 1 } { server.options.blockSize } / server.sampleRate;
-				{ BufIn.perform(method, numSamples, buffer, offset) }
+				{ BufIn.perform(method, numSamples, buffer, channel, offset) }
 				.loadToFloatArray(period, server) { |v|
 						out = v;
 						cond.signalOne;
@@ -45,10 +49,38 @@ TestBufUGens : UnitTest {
 		this.assertBufInOuptut(data,  "should output correct buffer values");
 
 		data = [[19, -4.0], [1234678, -0.5]].lace;
-		this.assertBufInOuptut(data,  "should output interleaved buffer values for a multi-channel buffer");
+		this.assertBufInOuptut(data,
+				"should output interleaved buffer values for a multi-channel buffer",
+				channel: -1,
+				expected: data.lace
+		);
+
+		data = [[19, -4.0], [1234678, -0.5]];
+		this.assertBufInOuptut(data,
+				"should read correct channel of a multi-channel buffer",
+				channel: 1,
+				numSamples: data[1].size,
+				expected: data[1]
+		);
+
+		this.assertBufInOuptut(data,
+				"should output zeros when reading an exceeding channel of a multi-channel buffer",
+				channel: 10,
+				expected: data.lace.collect(0)
+		);
+
+		// TODO: refactor assertBufInOuptut for this to make sense
+		// data = [[19, -4.0], [1234678, -0.5]];
+		// this.assertBufInOuptut(data,
+		// 		"should default to reading channel 0 of a multi-channel buffer",
+		// 		expected: data[0],
+		// );
+
+		// TODO: test for multi-channel expansion of channels?
+
 	}
 
-	test_BufIn_readCorrectValues_tooManyOutChannels {
+	test_BufIn_readCorrectValues_numOutputs {
 		var data = [123, -456];
 		this.assertBufInOuptut(data,
 				"should output correct buffer values followed by zeros for extra channels",
@@ -92,5 +124,4 @@ TestBufUGens : UnitTest {
 				expected: [46, -23]
 		);
 	}
-
 }

--- a/testsuite/classlibrary/TestBufUGens.sc
+++ b/testsuite/classlibrary/TestBufUGens.sc
@@ -1,0 +1,34 @@
+TestBufUGens : UnitTest {
+
+	var server;
+
+	setUp {
+		server = Server(this.class.name);
+		server.bootSync;
+	}
+
+	tearDown {
+		Buffer.freeAll(server);
+		server.quit;
+		server.remove;
+	}
+
+	test_BufIn_readCorrectValues {
+		var data = [89, -2.0, 12345678, -0.1];
+		var buffer = Buffer.sendCollection(server, data);
+		var period = server.options.blockSize / server.sampleRate;
+		var cond = CondVar();
+		var out = nil;
+		server.sync;
+		{ BufIn.kr(data.size, buffer) }.loadToFloatArray(period, server) { |v|
+				out = v;
+				cond.signalOne;
+		};
+		cond.waitFor(1){ out.notNil };
+
+		this.assertArrayFloatEquals(out, data, "should output correct buffer values", 1e-5);
+
+		buffer.free;
+	}
+
+}

--- a/testsuite/classlibrary/TestBufUGens.sc
+++ b/testsuite/classlibrary/TestBufUGens.sc
@@ -14,9 +14,9 @@ TestBufUGens : UnitTest {
 	}
 
   assertBufInOuptut { |data, message, numSamples(data.size), offset=0, expected(data), timeout=1|
-		var buffer = Buffer.sendCollection(server, data);
 		var cond = CondVar();
 		var out = nil;
+		var buffer = Buffer.sendCollection(server, data);
 		server.sync;
 		[\ar, \kr].do { |method|
 				var period = if (method === \ar) { 1 } { server.options.blockSize } / server.sampleRate;
@@ -35,8 +35,9 @@ TestBufUGens : UnitTest {
 				};
 		};
 
+		server.sync; // make sure synths are freed before freeing buffer
 		buffer.free;
-		server.sync;
+		server.sync; // make sure buf is freed before moving on
   }
 
 	test_BufIn_readCorrectValues {


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

When users want to read Buffer data as a control stream, they need to create as many BufRd UGens as the number of samples they want to read. This pattern is common for example in FluCoMa, where a buffer often contains multi-channel analysis data, and FluCoMa indeed provides the `FluidBufToKr` pseudo-UGen precisely to pull this data out of a buffer and make it available as a control stream for other non-buffer-reading UGens. Having a dedicated UGen saves the overhead of having to spawn, say, 1024 BufRd UGens.

This is a draft, I just wrote the basic functionality for now:
- only KR
- simple test (in a new file)
- drafted documentation

I'm happy to receive comments about pretty much everything, from the name to how to write the inner loop, the docs, or in which file to place the tests.


## Types of changes

- New feature

## To-do list

- [ ] Code is tested
- [ ] All tests are passing
- [ ] Updated documentation
- [ ] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
