### PR TITLE
Scale.degreeToRatio fix, document in Literals.schelp and Scale.schelp

### DIFF
--- a/HelpSource/Classes/Scale.schelp
+++ b/HelpSource/Classes/Scale.schelp
@@ -179,7 +179,7 @@ If the degree argument is not integer,
 the difference to the nearest integer is interpreted as an offset in cent,
 where 0.001 represents 1 cent (the ratio code::0.01.midiratio::, or code::2.pow(1/1200)::); 
 e.g., 2.1 is scale degree 3 according to tuning, plus one 12TET-semitone. 
-Maximum offset is 499 cent down, 500 cent up.
+Maximum offset is 499 cent.
 code::
 Scale.major.degreeToRatio(2, 1).round(0.001);		// 2.52
 Scale.major(\just).degreeToRatio(2, 1).round(0.001);	// 2.5

--- a/HelpSource/Classes/Scale.schelp
+++ b/HelpSource/Classes/Scale.schelp
@@ -175,9 +175,18 @@ Scale.major(\just).degreeToFreq(2, 60.midicps, 1);	// 654.06391...
 
 method::degreeToRatio
 Returns a ratio based on current tuning.
+If the degree argument is not integer,
+the difference to the nearest integer is interpreted as an offset in cent,
+where 0.001 represents 1 cent (the ratio code::0.01.midiratio::, or code::2.pow(1/1200)::); 
+e.g., 2.1 is scale degree 3 according to tuning, plus one 12TET-semitone. 
+Maximum offset is 499 cent down, 500 cent up.
 code::
 Scale.major.degreeToRatio(2, 1).round(0.001);		// 2.52
 Scale.major(\just).degreeToRatio(2, 1).round(0.001);	// 2.5
+// detune by 14 cent to make the 12TET third just (2 - 1.986 = 0.014):
+Scale.major.degreeToRatio(1.986, 1).round(0.001);	// 2.5 
+// or to make the just third boring:
+Scale.major(\just).degreeToRatio(2.014, 1).round(0.001);	// 2.52
 ::
 
 EXAMPLES::

--- a/HelpSource/Reference/Literals.schelp
+++ b/HelpSource/Reference/Literals.schelp
@@ -94,7 +94,11 @@ code::
 Hexidecimal numbers notated with code::0x:: may only be expressed as integers.
 
 subsection::Scale Degrees
-Integer numbers as scale degrees supports accidentals notation by adding the suffixes strong::s:: for sharp and strong::b:: for flat. Accidentals are represented as floating point values.
+Integer numbers as scale degrees supports accidentals notation by adding the suffixes strong::s:: for sharp and strong::b:: for flat. 
+Accidentals are represented as floating point values, 
+where each 0.1 of difference to the nearest integer corresponds to 100 cents (i.e., a semitone in 12TET).
+While the digit to the left of the decimal separator is a degree, and thus is affected by tuning and scale, 
+the digits to the right are not, and are always in cents. (See link::Classes/Scale#-degreeToRatio::)
 
 code::
 2s == 2.1  // scale degree two, sharp

--- a/SCClassLibrary/Common/Collections/Scale.sc
+++ b/SCClassLibrary/Common/Collections/Scale.sc
@@ -104,8 +104,11 @@ Scale {
 	}
 
 	degreeToRatio { |degree, octave = 0|
-		octave = octave + (degree div: degrees.size);
-		^this.ratios.wrapAt(degree) * (this.octaveRatio ** octave);
+		// extra steps to make scale degree literals like 2b == 1.9 work.
+		var degDiatonic = degree.round(1);
+        var centOffset = (degree - degDiatonic) * 10;
+		octave = octave + (degDiatonic div: degrees.size);
+		^this.ratios.wrapAt(degDiatonic) * (this.octaveRatio ** octave) * centOffset.midiratio;
 	}
 
 	degreeToFreq { |degree, rootFreq, octave|


### PR DESCRIPTION
## Purpose and Motivation

See discussion in #7088, #7168. 
Should have made this clearer: This is ultimately about the "scale degree literals" documented in Literals.schelp. 
They allow you to write sharps and flats and other detuning/accidental business, such as "1b" for flattened scale degree two, which the interpreter will read as a floating point number. Try it out. Whether this is a reasonable design in the first place is beyond the purview of this addition. 

```
2b == 1.9; 
3s == 3.1; 
2b050 = 1.950 
etc.
```
To put it simply, one could understand the present PR as implementing for Scale.degreeToRatio the same kind of interface **already present** in SimpleNumber.degreeToKey :

Compare this (NOT my addition, but simply the way SimpleNumber.degreeToKey currently works). Notice it rounds as well. 
```
	degreeToKey { |scale, stepsPerOctave = 12|
		var scaleDegree = this.round.asInteger;
		var accidental = (this - scaleDegree) * 10.0;
		^scale.performDegreeToKey(scaleDegree, stepsPerOctave, accidental)
	}
```
to this (my addition to Scale.sc):
```
degreeToRatio { |degree, octave = 0|
		// extra steps to make scale degree literals like 2b == 1.9 work.
		var degDiatonic = degree.round(1);
        var centOffset = (degree - degDiatonic) * 10;
		octave = octave + (degDiatonic div: degrees.size);
		^this.ratios.wrapAt(degDiatonic) * (this.octaveRatio ** octave) * centOffset.midiratio;
 	}
```
The difference here is only that degreeToKey is (to my knowledge) always completely 12TET, whereas in Scale.degreeToRatio, alternate tunings can be taken into account but _only_ for the scale degree, not for any further accidentals or cent offset. 

This PR would not be a breaking change, but rather an implementation of a missing feature. 
1. Currently (before this PR) Scale.degreeToRatio contains a wrapAt that truncates floats and thus will simply ignore non-integer values. That means unless someone was already using Scale.degreeToRatio with non-integer values, there will not be a change in behavior.
2. On the other hand, _if_ any users were already using Scale.degreeToRatio with non-integer values, then this was probably unintentional, because those non-integer values would have done nothing (i.e., would have been truncated to integers).
If on the other hand they were using them intentionally and didn't _notice_ that they got truncated to integers, then finally I figure that this change here also won't bother them.

<details><summary>Older blah: </summary>
<p>
@jamshark70, @tedmoore, @JordanHendersonMusic 
I realized I was a bit too militant about this because of a brain fart and/or too much overthinking. 
Scale degrees + accidentals of course aren't totally useless as a convenience.
 I was for some reason only thinking about scale degree _interval_ + accidentals,  which is that thing that you only need in figured bass. 
 In my mind it started becoming more useful once I started to think about the digits after the decimal point as a cent offset that lets you detune individual notes... (of course there's other/better ways to do this, but nvm).

Implementation and design is still questionable, but this is a quick fix. The one thing I wonder is if the additional arithmetics in there will have any relevant performance implications.  Otoh I don't think there's any quicker way to do this without redesigning this.
</p>
</details> 

## Types of changes

- Documentation
- Bug fix

<details><summary>Some testing: </summary>
<p>
Here's the code I tested it with:
```
(
(0,0.05..2).do {|x| var deg = x.round(1), offs = (x - deg).round(0.05);
    var midi = Scale.major.degreeToRatio(x, 0).ratiomidi.round(0.01);
("Degree: " ++ (deg + 1) ++ " | offset: "  ++ offs ++ " | midi: " ++ midi).postln
}
)
```
outcome: (note that "degree" here is 1-based for your convenience).
Note that the big skip in resulting semitones is not between  .5 and .55, but between .45 and .5, because that's how the rounding works (it rounds up the degree, and then takes the difference to the rounded value as offset, which means that the difference suddenly becomes negative).    

```
Degree: 1.0 | offset: 0.0 | midi: 0.0
Degree: 1.0 | offset: 0.05 | midi: 0.5
Degree: 1.0 | offset: 0.1 | midi: 1.0
Degree: 1.0 | offset: 0.15 | midi: 1.5
Degree: 1.0 | offset: 0.2 | midi: 2.0
Degree: 1.0 | offset: 0.25 | midi: 2.5
Degree: 1.0 | offset: 0.3 | midi: 3.0
Degree: 1.0 | offset: 0.35 | midi: 3.5
Degree: 1.0 | offset: 0.4 | midi: 4.0
Degree: 1.0 | offset: 0.45 | midi: 4.5
Degree: 2.0 | offset: -0.5 | midi: -3.0
Degree: 2.0 | offset: -0.45 | midi: -2.5
Degree: 2.0 | offset: -0.4 | midi: -2.0
Degree: 2.0 | offset: -0.35 | midi: -1.5
Degree: 2.0 | offset: -0.3 | midi: -1.0
Degree: 2.0 | offset: -0.25 | midi: -0.5
Degree: 2.0 | offset: -0.2 | midi: 0.0
Degree: 2.0 | offset: -0.15 | midi: 0.5
Degree: 2.0 | offset: -0.1 | midi: 1.0
Degree: 2.0 | offset: -0.05 | midi: 1.5
Degree: 2.0 | offset: 0.0 | midi: 2.0
Degree: 2.0 | offset: 0.05 | midi: 2.5
Degree: 2.0 | offset: 0.1 | midi: 3.0
Degree: 2.0 | offset: 0.15 | midi: 3.5
Degree: 2.0 | offset: 0.2 | midi: 4.0
Degree: 2.0 | offset: 0.25 | midi: 4.5
Degree: 2.0 | offset: 0.3 | midi: 5.0
Degree: 2.0 | offset: 0.35 | midi: 5.5
Degree: 2.0 | offset: 0.4 | midi: 6.0
Degree: 2.0 | offset: 0.45 | midi: 6.5
Degree: 3.0 | offset: -0.5 | midi: -1.0
Degree: 3.0 | offset: -0.45 | midi: -0.5
Degree: 3.0 | offset: -0.4 | midi: 0.0
Degree: 3.0 | offset: -0.35 | midi: 0.5
Degree: 3.0 | offset: -0.3 | midi: 1.0
Degree: 3.0 | offset: -0.25 | midi: 1.5
Degree: 3.0 | offset: -0.2 | midi: 2.0
Degree: 3.0 | offset: -0.15 | midi: 2.5
Degree: 3.0 | offset: -0.1 | midi: 3.0
Degree: 3.0 | offset: -0.05 | midi: 3.5
```
</p>
</details>
## To-do list

- [X] Code is tested
- [X] Updated documentation
- [X] This PR is ready for review 


