### PR TITLE
[tests] fix test runner Lists management

### DIFF
--- a/testsuite/scripts/sclang_test_runner.scd
+++ b/testsuite/scripts/sclang_test_runner.scd
@@ -67,6 +67,7 @@ if(File.exists(~testProto).not) {
 	var tests = ~getTestRecord.(protoFile);
 	var skipped, toExpand, toExclude;
 	var currentSuite = "";
+	var newTests = List();
 
 	// try {
 
@@ -80,7 +81,7 @@ if(File.exists(~testProto).not) {
 	toExpand = tests.select({|t| (t[\test] == "*") && (t[\completed] != true) });
 	~verboseSetup.if({"Expanding %\n".postf(toExpand)});
 	toExpand.do {|wildcardTest|
-		var allTests, newTest, class;
+		var class;
 
 		class = wildcardTest[\suite].asSymbol.asClass;
 
@@ -91,25 +92,23 @@ if(File.exists(~testProto).not) {
 		if (class.isNil) {
 			wildcardTest[\error] = "Class % not found".format(class);
 			wildcardTest[\completed] = true;
-			// ~writeResult.(test_record, file);
 		} {
 			~verboseSetup.if({"class: %".format(class).postln});
 			class.tryPerform(\findTestMethods).do {|testMethod|
 				~verboseSetup.if({"method: %".format(testMethod.name).postln});
-				newTest = Dictionary.newFrom((
+				newTests.add(Dictionary.newFrom((
 					\suite: class.name.asString,
 					\test: testMethod.name,
 					\skip: wildcardTest[\skip],
 					\skipReason: wildcardTest[\skipReason],
-				));
-
-				tests.add(newTest);
-				~verboseSetup.if({"tests.size: %".format(tests.size).postln});
+				)));
 			};
-			tests.remove(wildcardTest);
-			// ~writeResult.(test_record, file);
-		}
+		};
 	};
+
+	tests.removeAll(toExpand);
+	tests.addAll(newTests);
+	~verboseSetup.if({"tests.size after expansion: %".format(tests.size).postln});
 
 	// Ensure excluded tests are not run
 	toExclude = tests.select({|t|


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

I was debugging our test runner with an LLM and one suggestion was that we may be getting an interaction from Garbage Collector when we add/remove data to large Lists.

This PR creates a new List when expanding the list of tests to run.

For reference, here's a reliable reproducer that mimics test runner logic for the issue managing large lists. Instead of tests, it captures all the classes/methods from the standard library.
<details>

```supercollider
(
// ~parentClass = Collection; // does not error out
~parentClass = Object; // errors out

~exitWhenDone = false;

~verbose = false;
// ~verbose = true;

~writeResult = {|results, path|
	results.writeArchive(path);
};

// extract the test record dictionary from the input file
~getTestRecord = {
	var test_record;

	test_record = [
		(
			'suite': "*",
			'test': "*",
		),
	];

	test_record;
};

~allMethods =  {|parentClass|
	var allTestClasses = parentClass.allSubclasses.collectAs({ |class|
		var classkey = class.asSymbol;//[4..]; // drop Meta_
		var methtests = class.methods.collectAs({ | method |
			method.name.asString -> {
				"Function that runs %.%".format(classkey, method).postln;
			}
		}, Dictionary);
		classkey -> methtests;
	}, Dictionary);
	allTestClasses;
};


// expand { suite: * } to a dictionary of { test: * } records
~expandSuiteGlob = { |testsDict|
	var all;
	var suiteGlob = testsDict.select { |item| item[\suite] == "*" };

	if (suiteGlob.notEmpty) {
		all = ~allMethods.(~parentClass).keys.select({ |t| t != "...All..." }).asArray.collect({ |className|
			Dictionary.newFrom((\suite: className, \test: "*"))
		});
		testsDict.removeAll(suiteGlob);
		testsDict = all ++ testsDict;
	};

	testsDict;
};

~testrun = {
	var tests = ~getTestRecord.();
	var skipped, toExpand, toExclude;
	var currentSuite = "";

	tests = ~expandSuiteGlob.(tests);

	tests = List.newFrom(tests.collect(Dictionary.newFrom(_)));

	// Expand *'s
	toExpand = tests.select({|t| (t[\test] == "*") && (t[\completed] != true) });
	~verbose.if({"---Expanding %\n".postf(toExpand)});
	toExpand.do {|wildcardTest|
		var allTests, newTest, class;

		class = wildcardTest[\suite].asSymbol.asClass;

		class = (class.name.asString).asSymbol.asClass;

		if (class.isNil) {
			wildcardTest[\error] = "--- Class % not found".format(class);
			wildcardTest[\completed] = true;
			// ~writeResult.(test_record, file);
		} {
			~verbose.if({"--- class: %".format(class).postln});
			class.methods.do {|testMethod|
				~verbose.if({"--- method: %".format(testMethod.name).postln});
				newTest = Dictionary.newFrom((
					\suite: class.name.asString,
					\test: testMethod.name,
					\skip: wildcardTest[\skip],
					\skipReason: wildcardTest[\skipReason],
				));

				tests.add(newTest);
				~verbose.if({"--- tests.size: %".format(tests.size).postln});
			};
			~verbose.if({"--- removing %".format(class).postln});
			tests.remove(wildcardTest);
		}
	};

	// Ensure excluded tests are not run
	toExclude = tests.select({|t|
		if(t.isKindOf(Set)) { // sometimes we don't get a dictionary here... it shouldn't be the case, but ?
			t[\skip].() ? false;
		} {
			"detected a non-dictionary entry: %. Skipping...".format(t.asCompileString).warn;
			true;
		}
	});

	~verbose.if({"--- Excluding: %".format(toExclude.join(", ")).postln});
	tests = tests.reject({|t|
		~verbose.if({"-- t: ".post; t.postcs});
		if(t.isKindOf(Set)) { // sometimes we don't get a dictionary here... it shouldn't be the case, but ?
			(toExclude.detect({|excluded|
				(t[\suite].asString == excluded[\suite].asString)
				&& (t[\test].asString == excluded[\test].asString)
				&& (t !== excluded)
			}).size > 0)
		} {
			"--- detected a non-dictionary entry: %. Rejecting...".format(t.asCompileString).warn;
			true;
		}
	});
	~verbose.if({"--- After exclude: ".post; tests.do(_.postln)});
};

~testrun.();
)

```
</details>

I believe this PR should fix some of the occasional testsuite failures in CI (🤞) - the errors where the runner stops at the very beginning of the test procedure, like [here](https://github.com/supercollider/supercollider/actions/runs/18358098429/job/52302864706#step:6:40).

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [ ] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
