### PR TITLE
Correct typo in MIDIOut.schelp to prevent rendering error

### DIFF
--- a/HelpSource/Classes/MIDIOut.schelp
+++ b/HelpSource/Classes/MIDIOut.schelp
@@ -1,7 +1,6 @@
 class:: MIDIOut
 summary:: send MIDI messages
-related:: Classes/MIDIClient, Classes/MIDIIn, Guides/MIDI, Guides/UsingMIDI,
-Overviews/MidiPatterns
+related:: Classes/MIDIClient, Classes/MIDIIn, Guides/MIDI, Guides/UsingMIDI, Overviews/MidiPatterns
 categories:: External Control>MIDI
 
 description::


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation
Correct typo in MIDIOut.schelp to prevent the following rendering error:
>ERROR: In /Applications/SuperCollider.app/Contents/Resources/HelpSource/Classes/MIDIOut.schelp:
  At line 4: syntax error, unexpected newline, expecting text or URL


<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
