### PR TITLE
prSimpleNumberSeries (a,b..c) size calculation adjusted to offset float error. 

### DIFF
--- a/HelpSource/Classes/SimpleNumber.schelp
+++ b/HelpSource/Classes/SimpleNumber.schelp
@@ -510,7 +510,10 @@ returns::
 An link::Classes/Array::.
 
 discussion::
-The last value may not be included in the result if the step size does not divide evenly into the range of the series.
+The last value will not be included in the result if the step size does not divide evenly into the range of the series. 
+(E.g., code:: series(5, 7, 10):: returns code::[5, 7, 9]::.)
+While this method internally compensates for floating point error in its size calculation,
+consider using link::Classes/Array#*series:: if stability of size is very important.
 
 method:: seriesIter
 Create a link::Classes/Routine:: that iterates over an arithmetic series from teletype::this:: over strong::second:: to strong::last::.

--- a/HelpSource/Classes/SimpleNumber.schelp
+++ b/HelpSource/Classes/SimpleNumber.schelp
@@ -509,11 +509,46 @@ code::
 returns::
 An link::Classes/Array::.
 
-discussion::
-The last value will not be included in the result if the step size does not divide evenly into the range of the series. 
-(E.g., code:: series(5, 7, 10):: returns code::[5, 7, 9]::.)
-While this method internally compensates for floating point error in its size calculation,
-consider using link::Classes/Array#*series:: if stability of size is very important.
+note::
+strong::Size of resultant Array:::
+If all arguments are link::Classes/Integer::s and the step size (teletype::second - this::) does not evenly subdivide the range (teletype::last - this::) of the series, 
+the teletype::last:: argument will not be included in the result.
+
+code:: series(5, 7, 10) // -> [5, 7, 9]::
+
+If arguments include link::Classes/Float::s, the behavior will be the same: 
+
+code::series(1.0, 2.0, 3.999999999) // -> [1.0, 2.0, 3.0]::
+
+In previous versions of SuperCollider (up to 3.14), cases could be encountered where floating point error resulted in omission of the final element:
+
+code::(1.5, 1.45..1.35).last // (SC 3.14) -> [1.5, 1.45, 1.4]; 1.35 omitted!:: 
+
+This is no longer the case as of version 3.15, as the method now compensates for its own floating point error in its calculation of the size.
+footnote:: 
+Note that the link::#-series:: method cannot possibly compensate for the floating point error that might have arisen in the calculations of the arguments themselves. 
+Therefore, in numerically extreme cases, it might be better to use an integer series with a multiplier, or  link::Classes/Array#*series::, where the size of the array can be directly given as an argument.
+code::
+( 
+//extremely contrived example of the kind of arguments
+// that contain enough floating point error to affect .series's size calculation:
+var one = (exp(log(17/11) + log(13/7)) * 7 * 11 / 13 /17).pow(2);
+var one_thousandths = 1/(one * 1000);
+var two_thousandths = (one + one) * one/1000;
+var size = (one_thousandths, two_thousandths, 1000/one).size;
+[one, one_thousandths, two_thousandths].collect (_.asStringPrec(20)).postln;
+size.postln;
+) // -> 999999; but algebraically, size should be 1000000
+
+(
+//for numerically complicated cases where size of the array is important, use Array.series 
+Array.series(1000000, one_thousandths, one_thousandths);
+// or an  integer series with a multiplier:
+(1..1000000) * one_thousandths
+)
+::
+::
+::
 
 method:: seriesIter
 Create a link::Classes/Routine:: that iterates over an arithmetic series from teletype::this:: over strong::second:: to strong::last::.

--- a/lang/LangPrimSource/PyrMathPrim.cpp
+++ b/lang/LangPrimSource/PyrMathPrim.cpp
@@ -885,7 +885,16 @@ int prSimpleNumberSeries(struct VMGlobals* g, int numArgsPushed) {
         if (step == 0.f) {
             size = 1;
         } else {
-            size = (int)((last - first) / step) + 1;
+            double range = last - first;
+            double tolerance = 0.000001; // 1e-6; pretty arbitrary choice. Discuss?
+            size = static_cast<int>(round(range / step)); // this will often be 1 too few
+            // size * step represents the value of a hypothetical additional element;
+            // but we only add it if it is within the allowed tolerance.
+            if (fabs(size * step) <= fabs(range + step * tolerance)) {
+                ++size;
+            }
+            // step and range will be of same sign (if not, error below);
+            // fabs() is only to not have to change comparison operator for positive and negative step/range.
         }
 
         if ((size < 1) || ((step >= 0) && (last < first)) || ((step <= 0) && (last > first))) {

--- a/lang/LangPrimSource/PyrMathPrim.cpp
+++ b/lang/LangPrimSource/PyrMathPrim.cpp
@@ -886,15 +886,9 @@ int prSimpleNumberSeries(struct VMGlobals* g, int numArgsPushed) {
             size = 1;
         } else {
             double range = last - first;
-            double tolerance = 0.000001; // 1e-6; pretty arbitrary choice. Discuss?
-            size = static_cast<int>(round(range / step)); // this will often be 1 too few
-            // size * step represents the value of a hypothetical additional element;
-            // but we only add it if it is within the allowed tolerance.
-            if (fabs(size * step) <= fabs(range + step * tolerance)) {
-                ++size;
-            }
-            // step and range will be of same sign (if not, error below);
-            // fabs() is only to not have to change comparison operator for positive and negative step/range.
+            double size_w_error = range / step;
+            // the multiplier below is for float error compensation and equals 1 + 2.pow(-49)
+            size = static_cast<int>(0x1.0000000000008p0 * size_w_error) + 1; // cast truncates
         }
 
         if ((size < 1) || ((step >= 0) && (last < first)) || ((step <= 0) && (last > first))) {

--- a/testsuite/classlibrary/TestSimpleNumber.sc
+++ b/testsuite/classlibrary/TestSimpleNumber.sc
@@ -241,19 +241,42 @@ TestSimpleNumber : UnitTest {
 	}
 
 	test_series {
-		var first = 0;
-		var step = 2.0001;
-		var last = 8;
-		var arr = first.series(step, last);
-		this.assert(arr.last <= last, "SimpleNumber:series should not produce an array whose last value is greater than the specified 'last' argument.");
-
-		first = 1;
-		arr = first.series(first, first);
-		this.assert(arr.size == 1, "SimpleNumber:series Int types with first == last and step == 0 should return an array of [ first ]");
-
-		first = 1.1;
-		arr = first.series(first, first);
-		this.assert(arr.size == 1, "SimpleNumber:series Float types with first == last and step == 0 should return an array of [ first ]");
+		var tolerance = 1e-6;
+		// higher/greater in the following descriptions is with respect to step direction. (I.e., if step is negative, -3 counts as "higher" than -2.)
+		// still lots of redundancy in there I think. 
+		// 1
+        this.assert(series(0, 1 + tolerance,      4).size == 4, "SimpleNumber:series should not produce an array whose last value is greater than the 'last' argument plus a tolerance");
+		// 2
+        this.assert(series(0,-1 - tolerance,     -4).size == 4, "SimpleNumber:series should not produce an array whose last value is greater than the 'last' argument plus a tolerance");
+		// 3
+        this.assert(series(0, 1 + (tolerance/10), 4).size == 5,  "SimpleNumber:series should be able to produce an array whose last value is _slightly_ greater than the 'last' argument");
+		// 4
+        this.assert(series(0,-1 - (tolerance/10),-4).size == 5,  "SimpleNumber:series should be able to produce an array whose last value is _slightly_ greater than the 'last' argument");
+		// 5
+        this.assert(series(-29/7,-27/7, 29/7 ).last >= (29/7),     "SimpleNumber:series should be able to include the last value of an arithmetic series even if its float representation is slightly higher than the 'last' argument");
+		// 6
+        this.assert(series(1.5, 1.45, -1.5 ).last <= -1.5,     "SimpleNumber:series should be able to include the last value of an arithmetic series even if its float representation is slightly higher than the 'last' argument");
+		// 7
+        this.assert(series(1.5, 1.45, -1.5 ).last <= -1.5,     "SimpleNumber:series should be able to include the last value of an arithmetic series even if its float representation is slightly higher than the 'last' argument");
+		// 8
+        this.assertException({series(1.5, 2, -1.5)}, PrimitiveFailedError, "SimpleNumber:series should throw an Error when (second-first) and (last-first) are of different sign");
+		// 9
+        this.assertException({series(-1.5, -2, 1.5)}, PrimitiveFailedError, "SimpleNumber:series should throw an Error when (second-first) and (last-first) are of different sign");
+		// 10
+        this.assertException({series(1,1,3)}, PrimitiveFailedError, "SimpleNumber:series should throw an Error when (second-first) is 0 and (last-first) is not");
+		// 11
+        this.assertException({series(1,1,-3)}, PrimitiveFailedError, "SimpleNumber:series should throw an Error when (second-first) is 0 and (last-first) is not");
+		// 12
+        this.assertException({series(1.5, 4, -3)}, PrimitiveFailedError, "SimpleNumber:series should throw an Error when size calculation resulted in size < 1");
+		// 13
+        this.assertException({series(0, 1, 2.pow(27))}, PrimitiveFailedError, "SimpleNumber:series should throw an Error when size calculation resulted in size > INT_MAX_BY_PyrSlot");
+		// 14
+		this.assert(series(1,1,1).size == 1, "SimpleNumber:series Int types with first == last and step == 0 should return an array of [ first ]");
+		// 15
+		this.assert(series(1.1,1.1,1.1).size == 1, "SimpleNumber:series Int types with first == last and step == 0 should return an array of [ first ]");
+        // the next one will slow down testing, not sure if this is necessary. Just don't make arrays this big!
+		// 16
+        this.assertNoException({series(0, 1, 2.pow(26.9))}, "SimpleNumber:series should not throw an Error when size calculation resulted in size <= INT_MAX_BY_PyrSlot");
 	}
 
 	test_midiratio {

--- a/testsuite/classlibrary/TestSimpleNumber.sc
+++ b/testsuite/classlibrary/TestSimpleNumber.sc
@@ -240,41 +240,22 @@ TestSimpleNumber : UnitTest {
 		this.assertEquals(testF.(val,1,2,1), [ -1, 0, 0, 1, 1, 1 ] , "Test 11 (edge case): snap(1, 2, 1)");
 	}
 
+
 	test_series {
-		var tolerance = 1e-6;
-		// higher/greater in the following descriptions is with respect to step direction. (I.e., if step is negative, -3 counts as "higher" than -2.)
-		// still lots of redundancy in there I think. 
-		// 1
-        this.assert(series(0, 1 + tolerance,      4).size == 4, "SimpleNumber:series should not produce an array whose last value is greater than the 'last' argument plus a tolerance");
-		// 2
-        this.assert(series(0,-1 - tolerance,     -4).size == 4, "SimpleNumber:series should not produce an array whose last value is greater than the 'last' argument plus a tolerance");
-		// 3
-        this.assert(series(0, 1 + (tolerance/10), 4).size == 5,  "SimpleNumber:series should be able to produce an array whose last value is _slightly_ greater than the 'last' argument");
-		// 4
-        this.assert(series(0,-1 - (tolerance/10),-4).size == 5,  "SimpleNumber:series should be able to produce an array whose last value is _slightly_ greater than the 'last' argument");
-		// 5
-        this.assert(series(-29/7,-27/7, 29/7 ).last >= (29/7),     "SimpleNumber:series should be able to include the last value of an arithmetic series even if its float representation is slightly higher than the 'last' argument");
-		// 6
-        this.assert(series(1.5, 1.45, -1.5 ).last <= -1.5,     "SimpleNumber:series should be able to include the last value of an arithmetic series even if its float representation is slightly higher than the 'last' argument");
-		// 7
+        this.assert(series(0, 3, 4).size == 2, "SimpleNumber:series with integers should not produce an array whose last value is greater than the 'last' argument");
+        this.assert(series(1.0, 2.0, 7.9).size == 7, "SimpleNumber:series with floats should not produce an array whose last value is greater than the 'last' argument");
+
+        this.assert(series(-1.5, -1.45, -1.35).size == 4, "SimpleNumber:series compensates for floating point error even in relatively short arrays");
+        this.assert(series(0.001, 0.002, 999.999999999998).size == 999999, "Floating point error compensation should be less than a billionth of size");
+        // (it's actually 2^-49, i.e. ca. 10e-15 of the size).
+
         this.assertException({series(1.5, 2, -1.5)}, PrimitiveFailedError, "SimpleNumber:series should throw an Error when (second-first) and (last-first) are of different sign");
-		// 9
-        this.assertException({series(-1.5, -2, 1.5)}, PrimitiveFailedError, "SimpleNumber:series should throw an Error when (second-first) and (last-first) are of different sign");
-		// 10
-        this.assertException({series(1,1,3)}, PrimitiveFailedError, "SimpleNumber:series should throw an Error when (second-first) is 0 and (last-first) is not");
-		// 11
         this.assertException({series(1,1,-3)}, PrimitiveFailedError, "SimpleNumber:series should throw an Error when (second-first) is 0 and (last-first) is not");
-		// 12
-        this.assertException({series(1.5, 4, -3)}, PrimitiveFailedError, "SimpleNumber:series should throw an Error when size calculation resulted in size < 1");
-		// 13
-        this.assertException({series(0, 1, 2.pow(27))}, PrimitiveFailedError, "SimpleNumber:series should throw an Error when size calculation resulted in size > INT_MAX_BY_PyrSlot");
-		// 14
-		this.assert(series(1,1,1).size == 1, "SimpleNumber:series Int types with first == last and step == 0 should return an array of [ first ]");
-		// 15
-		this.assert(series(1.1,1.1,1.1).size == 1, "SimpleNumber:series Int types with first == last and step == 0 should return an array of [ first ]");
-        // the next one will slow down testing, not sure if this is necessary. Just don't make arrays this big!
-		// 16
-        // this.assertNoException({series(0, 1, 2.pow(26.9))}, "SimpleNumber:series should not throw an Error when size calculation resulted in size <= INT_MAX_BY_PyrSlot");
+        this.assertException({series(0, 1, 2.pow(28))}, PrimitiveFailedError, "SimpleNumber:series should throw an Error when size calculation resulted in size > INT_MAX_BY_PyrSlot");
+
+		this.assert(series(1,1,1) == [1], "SimpleNumber:series Int types with  first == second == last  should return an array of [ first ]");
+		this.assert(series(1.1,1.1,1.1) == [1.1], "SimpleNumber:series Float types with first == second == last should return an array of [ first ]");
+        // this.assertNoException({series(0, 1, 2.pow(28) - 1)}, "SimpleNumber:series should not throw an Error when size calculation resulted in size <= INT_MAX_BY_PyrSlot");
 	}
 
 	test_midiratio {

--- a/testsuite/classlibrary/TestSimpleNumber.sc
+++ b/testsuite/classlibrary/TestSimpleNumber.sc
@@ -257,8 +257,6 @@ TestSimpleNumber : UnitTest {
 		// 6
         this.assert(series(1.5, 1.45, -1.5 ).last <= -1.5,     "SimpleNumber:series should be able to include the last value of an arithmetic series even if its float representation is slightly higher than the 'last' argument");
 		// 7
-        this.assert(series(1.5, 1.45, -1.5 ).last <= -1.5,     "SimpleNumber:series should be able to include the last value of an arithmetic series even if its float representation is slightly higher than the 'last' argument");
-		// 8
         this.assertException({series(1.5, 2, -1.5)}, PrimitiveFailedError, "SimpleNumber:series should throw an Error when (second-first) and (last-first) are of different sign");
 		// 9
         this.assertException({series(-1.5, -2, 1.5)}, PrimitiveFailedError, "SimpleNumber:series should throw an Error when (second-first) and (last-first) are of different sign");
@@ -276,7 +274,7 @@ TestSimpleNumber : UnitTest {
 		this.assert(series(1.1,1.1,1.1).size == 1, "SimpleNumber:series Int types with first == last and step == 0 should return an array of [ first ]");
         // the next one will slow down testing, not sure if this is necessary. Just don't make arrays this big!
 		// 16
-        this.assertNoException({series(0, 1, 2.pow(26.9))}, "SimpleNumber:series should not throw an Error when size calculation resulted in size <= INT_MAX_BY_PyrSlot");
+        // this.assertNoException({series(0, 1, 2.pow(26.9))}, "SimpleNumber:series should not throw an Error when size calculation resulted in size <= INT_MAX_BY_PyrSlot");
 	}
 
 	test_midiratio {


### PR DESCRIPTION
To address #7181, where floats don't play nice with (a,b..c) (i.e., SimpleNumber.series).
EDIT (Jan 23): this is now good to be reviewed.


Summary (Oct 18): 
My changes concern the size calculation of series for floats with step size != 0 only.
The way this was done previously, for a series `(first, second..last`), where `step = second - first` and `range = last - first` is this:
Divide `range` by `step` and truncate; then add 1 to that. (I.e., `(int)(range/step + 1))`
That guaranteed that the final calculated value was never higher than the last argument, because that value for an array size n would be` first + (step * (size-1))`, which is the same as `first + (trunc(range/step) * step)`. But that also resulted in a brutal and a bit unpredictable chopping off of the last value when`step` (or `first`) had an inconvenient floating point representation. 

This PR adjust the calculation: it now multiplies `range/step` by `(1 + 2.pow(-49))` to compensate for floating point error.

This  for the following behavior:
```
//unchanged: 
(0.0, 2.0..7.0) // -> [0, 2, 4, 6] as before;
//  even, as an extreme example (from the added tests):
(0.001, 0.002.. 999.999999999998).size // -> 999999 (not 1e6!)
// this is a very artificial example, meant to illustrate that the error compensation is at the end of the day fairly small, 
// even where the array size isn't.  

// changed: cases where the exclusion of the last element was due to floating point error:
(-1.5, -1.45..1.5).last // -> 1.5; would have been 1.45 before
(-1.5, -1.45..-1.35).last // -> -1.35; would have been -1.4 before.
```




<details><summary>older musings, resolved</summary>
<p>
The rewrite here starts with a size is that is (often) 1 too little: and then checks if another element can be added that is within the range plus some tolerance, which is relative to step (to allow for floating point error). If yes, it increments the size by 1. If not, it doesn't.
Basically what remains to be done is:
Settle on tolerance and the way to calculate it - currently I have it set at a millionth of the step size, but I pulled that fraction out of thin air more or less. Gotta start somewhere.
Write some more tests, and weed out some of the more redundant ones I put in there.
Mabye mention it in the documentation.
</p>
</details> 