### PR TITLE
SCLang: Gluons: implement ffi interface

### DIFF
--- a/.github/workflows/build_macos.yml
+++ b/.github/workflows/build_macos.yml
@@ -223,4 +223,4 @@ jobs:
       - name: Run CTests
         continue-on-error: true
         if: matrix.ctest
-        run: cmake --build $BUILD_PATH --config Release --target all && cmake --build $BUILD_PATH --config Release --target RUN_TESTS
+        run: cmake --build $BUILD_PATH --config Release --target RUN_TESTS

--- a/.github/workflows/build_macos.yml
+++ b/.github/workflows/build_macos.yml
@@ -223,4 +223,4 @@ jobs:
       - name: Run CTests
         continue-on-error: true
         if: matrix.ctest
-        run: cmake --build $BUILD_PATH --config Release --target RUN_TESTS
+        run: cmake --build $BUILD_PATH --config Release --target all && cmake --build $BUILD_PATH --config Release --target RUN_TESTS

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -201,4 +201,4 @@ jobs:
         if: matrix.ctest
         working-directory: ${{ env.BUILD_PATH }}
         shell: cmd
-        run: cmake --build . --config Release --target ${{ matrix.ctest-cmd }}
+        run: cmake --build . --config Release --target all && cmake --build . --config Release --target ${{ matrix.ctest-cmd }}

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -201,4 +201,4 @@ jobs:
         if: matrix.ctest
         working-directory: ${{ env.BUILD_PATH }}
         shell: cmd
-        run: cmake --build . --config Release --target all && cmake --build . --config Release --target ${{ matrix.ctest-cmd }}
+        run: cmake --build . --config Release --target ${{ matrix.ctest-cmd }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -478,7 +478,7 @@ add_subdirectory(platform)
 add_subdirectory(editors)
 
 if(UNIX AND NOT APPLE)
-    install(DIRECTORY include/common include/plugin_interface include/server include/lang
+    install(DIRECTORY include/common include/plugin_interface include/server include/lang include/gluon_ffi_interface
         DESTINATION ${CMAKE_INSTALL_PREFIX}/include/SuperCollider
 	FILES_MATCHING PATTERN "*.h" PATTERN "*.hpp"
     )

--- a/SCClassLibrary/Common/Core/Gluon.sc
+++ b/SCClassLibrary/Common/Core/Gluon.sc
@@ -39,9 +39,8 @@ Gluon {
 	}
 
 	*with { |pathToLibrary, func|
-	 	var l;
+		var l = Gluon.open(pathToLibrary);
 		protect {
-			l = Gluon.open(pathToLibrary);
 			func.(l);
 		} {
 			Gluon.close(l);

--- a/SCClassLibrary/Common/Core/Gluon.sc
+++ b/SCClassLibrary/Common/Core/Gluon.sc
@@ -1,0 +1,88 @@
+PRGluonCallbackWrapper {
+	var func;
+	*new { |f| ^super.newCopyArgs(func: f) }
+	value { |...args, kwargs| func.performArgs(\value, args, kwargs) }
+}
+
+Gluon {
+	classvar openLibraries;
+	var <id;
+
+	*initClass { openLibraries = () }
+	*new { Error("Do not create an Gluon manually, use Gluon.open or Gluon.with").throw }
+	*prNew { |id| ^super.newCopyArgs(id) }
+
+	*inbuilt { |name|
+		// inbuilt library do not need to be closed.
+		var id = Gluon.prInbuilt(name);
+		^Gluon.prNew(id);
+	}
+
+	*prInbuilt { |name|
+		_GetInbuiltGluonID
+		^this.primitiveFailed;
+	}
+
+	*open { |pathToLibrary|
+		var id = Gluon.prOpenGetID(pathToLibrary.asString);
+		var lib = Gluon.prNew(id);
+		openLibraries[lib.id] = lib;
+		^lib
+	}
+
+	*close { |library|
+		if (library.isKindOf(Gluon).not) {
+			Error("Can only close an Gluon").throw
+		};
+		Gluon.prCloseLibrary(library.id);
+		openLibraries[library.id] = nil;
+	}
+
+	*with { |pathToLibrary, func|
+	 	var l;
+		protect {
+			l = Gluon.open(pathToLibrary);
+			func.(l);
+		} {
+			Gluon.close(l);
+		}
+	}
+
+	*prOpenGetID { |pathToLibrary|
+		_OpenGluon
+		^this.primitiveFailed;
+	}
+
+	*prCloseLibrary { |id|
+		_CloseGluon
+		^this.primitiveFailed;
+	 }
+
+	close { ^Gluon.close(this) }
+
+	value { |functionNameSymbol ...args, kwargs|
+		if (kwargs.size() == 2 and: {kwargs[0] == \callback}) {
+			^this.prValueWithCallback(id, functionNameSymbol, PRGluonCallbackWrapper(kwargs[1]), *args);
+		} {
+			if (kwargs.size() != 0) {
+				Error("Cannot call a gluon ffi function with keyword arguments").throw
+			}
+			^this.prValue(id, functionNameSymbol, *args);
+		}
+	}
+
+	prValue { |library_id, functionNameSymbol ...args|
+		_CallGluon
+		^this.primitiveFailed;
+	}
+
+	prValueWithCallback { |library_id, functionNameSymbol, callback ...args|
+		_CallGluonWithCallback
+		^this.primitiveFailed;
+	}
+
+
+	doesNotUnderstand { |selector... args, kwargs|
+		^this.performArgs(\value, [selector] ++ args, kwargs);
+	}
+}

--- a/SCClassLibrary/Common/Core/Gluon.sc
+++ b/SCClassLibrary/Common/Core/Gluon.sc
@@ -23,8 +23,8 @@ Gluon {
 		^this.primitiveFailed;
 	}
 
-	*open { |pathToLibrary|
-		var id = Gluon.prOpenGetID(pathToLibrary.asString);
+	*open { |pathToLibrary ...args|
+		var id = Gluon.prOpenGetID(pathToLibrary.asString, *args);
 		var lib = Gluon.prNew(id);
 		openLibraries[lib.id] = lib;
 		^lib
@@ -47,7 +47,7 @@ Gluon {
 		}
 	}
 
-	*prOpenGetID { |pathToLibrary|
+	*prOpenGetID { |pathToLibrary ...args|
 		_OpenGluon
 		^this.primitiveFailed;
 	}

--- a/SCClassLibrary/Common/Core/Gluon.sc
+++ b/SCClassLibrary/Common/Core/Gluon.sc
@@ -24,10 +24,15 @@ Gluon {
 	}
 
 	*open { |pathToLibrary ...args|
-		var id = Gluon.prOpenGetID(pathToLibrary.asString, *args);
-		var lib = Gluon.prNew(id);
-		openLibraries[lib.id] = lib;
-		^lib
+		var id, lib;
+		if (PathName(pathToLibrary).isFile.not) {
+			Error("Could not find gluon at path: " ++ pathToLibrary).throw
+		} {
+			id = Gluon.prOpenGetID(pathToLibrary.asString, *args);
+			lib = Gluon.prNew(id);
+			openLibraries[lib.id] = lib;
+			^lib
+		}
 	}
 
 	*close { |library|

--- a/include/gluon_ffi_interface/cpp/sc_gluon_v1_util.hpp
+++ b/include/gluon_ffi_interface/cpp/sc_gluon_v1_util.hpp
@@ -7,91 +7,98 @@
 namespace sc_gluon::v1 {
 using param_t = struct sc_gluon_param_v1_t;
 using data_t = sc_gluon_data_v1;
-using callback_obj_t = sc_gluon_callable_object_v1_t;
+using callback_obj_t = sc_gluon_callback_object_v1_t;
 using callback_release_t = sc_gluon_release_callback_object_v1_f;
 using do_callback_t = sc_gluon_do_callback_v1_f;
 
-[[nodiscard]] constexpr param_t priv_basic(sc_gluon_data_v1 data, sc_gluon_param_tag_v1 tag) noexcept {
+// MSVC doesn't support forward compatible constexpr union initialisation.
+#if (_MSC_VER) && (_MSVC_LANG < 202002L)
+#    define SC_GLUON_CONSTEXPR
+#else
+#    define SC_GLUON_CONSTEXPR constexpr
+#endif
+
+[[nodiscard]] inline SC_GLUON_CONSTEXPR param_t priv_basic(sc_gluon_data_v1 data, sc_gluon_param_tag_v1 tag) noexcept {
     return { data, 1, tag, false };
 }
-[[nodiscard]] constexpr param_t priv_array(sc_gluon_data_v1 data, sc_gluon_param_tag_v1 tag, uint32_t size,
-                                           bool owns_data) noexcept {
+[[nodiscard]] inline SC_GLUON_CONSTEXPR param_t priv_array(sc_gluon_data_v1 data, sc_gluon_param_tag_v1 tag,
+                                                           uint32_t size, bool owns_data) noexcept {
     return { data, size, tag, owns_data };
 }
 
-[[nodiscard]] constexpr param_t create_param() noexcept {
+[[nodiscard]] inline SC_GLUON_CONSTEXPR param_t create_param() noexcept {
     data_t d {};
     d.nil_ = {};
     return priv_basic(d, sc_gluon_nil);
 }
 
-[[nodiscard]] constexpr param_t create_param(int32_t i) noexcept {
+[[nodiscard]] inline SC_GLUON_CONSTEXPR param_t create_param(int32_t i) noexcept {
     data_t d {};
     d.i32 = i;
     return priv_basic(d, sc_gluon_i32);
 }
 
-[[nodiscard]] constexpr param_t create_param(double f) noexcept {
+[[nodiscard]] inline SC_GLUON_CONSTEXPR param_t create_param(double f) noexcept {
     data_t d {};
     d.f64 = f;
     return priv_basic(d, sc_gluon_f64);
 }
 
-[[nodiscard]] constexpr param_t create_param(char c) noexcept {
+[[nodiscard]] inline SC_GLUON_CONSTEXPR param_t create_param(char c) noexcept {
     data_t d {};
     d.character = c;
     return priv_basic(d, sc_gluon_char);
 }
 
-[[nodiscard]] constexpr param_t create_param(bool b) noexcept {
+[[nodiscard]] inline SC_GLUON_CONSTEXPR param_t create_param(bool b) noexcept {
     data_t d {};
     d.boolean = b;
     return priv_basic(d, sc_gluon_bool);
 }
 
-[[nodiscard]] constexpr param_t create_param(void* p) noexcept {
+[[nodiscard]] inline SC_GLUON_CONSTEXPR param_t create_param(void* p) noexcept {
     data_t d {};
     d.raw_pointer = p;
     return priv_basic(d, sc_gluon_raw_pointer);
 }
 
-[[nodiscard]] constexpr param_t create_param(uint64_t s) noexcept {
+[[nodiscard]] inline SC_GLUON_CONSTEXPR param_t create_param(uint64_t s) noexcept {
     data_t d {};
     d.symbol_value = s;
     return priv_basic(d, sc_gluon_symbol_value);
 }
 
-[[nodiscard]] constexpr param_t create_param(uint8_t* a, uint32_t size, bool owns_data) noexcept {
+[[nodiscard]] inline SC_GLUON_CONSTEXPR param_t create_param(uint8_t* a, uint32_t size, bool owns_data) noexcept {
     data_t d {};
     d.u8_array = a;
-    return priv_array(d, sc_gluon_u8_array, size, owns_data);
+    return priv_array(d, sc_gluon_u8_array, size, owns_data ? 1 : 0);
 }
 
-[[nodiscard]] constexpr param_t create_param(double* a, uint32_t size, bool owns_data) noexcept {
+[[nodiscard]] inline SC_GLUON_CONSTEXPR param_t create_param(double* a, uint32_t size, bool owns_data) noexcept {
     data_t d {};
     d.f64_array = a;
-    return priv_array(d, sc_gluon_f64_array, size, owns_data);
+    return priv_array(d, sc_gluon_f64_array, size, owns_data ? 1 : 0);
 }
 
-[[nodiscard]] constexpr param_t create_param(float* a, uint32_t size, bool owns_data) noexcept {
+[[nodiscard]] inline SC_GLUON_CONSTEXPR param_t create_param(float* a, uint32_t size, bool owns_data) noexcept {
     data_t d {};
     d.f32_array = a;
-    return priv_array(d, sc_gluon_f32_array, size, owns_data);
+    return priv_array(d, sc_gluon_f32_array, size, owns_data ? 1 : 0);
 }
 
-[[nodiscard]] constexpr param_t create_param(char* a, uint32_t size, bool owns_data) noexcept {
+[[nodiscard]] inline SC_GLUON_CONSTEXPR param_t create_param(char* a, uint32_t size, bool owns_data) noexcept {
     data_t d {};
     d.character_array = a;
-    return priv_array(d, sc_gluon_char_array, size, owns_data);
+    return priv_array(d, sc_gluon_char_array, size, owns_data ? 1 : 0);
 }
 
-[[nodiscard]] constexpr param_t create_param(param_t* a, uint32_t size, bool owns_data) noexcept {
+[[nodiscard]] inline SC_GLUON_CONSTEXPR param_t create_param(param_t* a, uint32_t size, bool owns_data) noexcept {
     data_t d {};
     d.param_array = a;
-    return priv_array(d, sc_gluon_param_array, size, owns_data);
+    return priv_array(d, sc_gluon_param_array, size, owns_data ? 1 : 0);
 }
 
-[[nodiscard]] constexpr bool has_heap_allocated_data(param_t p) noexcept {
+[[nodiscard]] inline SC_GLUON_CONSTEXPR bool has_heap_allocated_data(param_t p) noexcept {
     switch (p.tag) {
     case sc_gluon_u8_array:
     case sc_gluon_f64_array:
@@ -103,5 +110,7 @@ using do_callback_t = sc_gluon_do_callback_v1_f;
         return false;
     }
 }
+
+#undef SC_GLUON_CONSTEXPR
 
 } // namespace sc_gluon::v1

--- a/include/gluon_ffi_interface/cpp/sc_gluon_v1_util.hpp
+++ b/include/gluon_ffi_interface/cpp/sc_gluon_v1_util.hpp
@@ -5,11 +5,12 @@
 #include <stdexcept>
 
 namespace sc_gluon::v1 {
-using param_t = struct sc_gluon_param_v1_t;
-using data_t = sc_gluon_data_v1;
-using callback_obj_t = sc_gluon_callback_object_v1_t;
+using param_t = ::sc_gluon_param_v1_t;
+using tag_t = ::sc_gluon_param_tag_v1;
+using data_t = ::sc_gluon_data_v1;
+using callback_obj_t = ::sc_gluon_callback_object_v1_t;
 using callback_release_t = sc_gluon_release_callback_object_v1_f;
-using do_callback_t = sc_gluon_do_callback_v1_f;
+using do_callback_t = ::sc_gluon_do_callback_v1_f;
 
 // MSVC doesn't support forward compatible constexpr union initialisation.
 #if (_MSC_VER) && (_MSVC_LANG < 202002L)
@@ -18,11 +19,11 @@ using do_callback_t = sc_gluon_do_callback_v1_f;
 #    define SC_GLUON_CONSTEXPR constexpr
 #endif
 
-[[nodiscard]] inline SC_GLUON_CONSTEXPR param_t priv_basic(sc_gluon_data_v1 data, sc_gluon_param_tag_v1 tag) noexcept {
+[[nodiscard]] inline SC_GLUON_CONSTEXPR param_t priv_basic(data_t data, tag_t tag) noexcept {
     return { data, 1, tag, false };
 }
-[[nodiscard]] inline SC_GLUON_CONSTEXPR param_t priv_array(sc_gluon_data_v1 data, sc_gluon_param_tag_v1 tag,
-                                                           uint32_t size, bool owns_data) noexcept {
+[[nodiscard]] inline SC_GLUON_CONSTEXPR param_t priv_array(data_t data, tag_t tag, uint32_t size,
+                                                           bool owns_data) noexcept {
     return { data, size, tag, owns_data };
 }
 

--- a/include/gluon_ffi_interface/cpp/sc_gluon_v1_util.hpp
+++ b/include/gluon_ffi_interface/cpp/sc_gluon_v1_util.hpp
@@ -1,0 +1,107 @@
+#include "../sc_gluon_v1_types.h"
+#include <vector>
+#include <array>
+#include <cstring>
+#include <stdexcept>
+
+namespace sc_gluon::v1 {
+using param_t = struct sc_gluon_param_v1_t;
+using data_t = sc_gluon_data_v1;
+using callback_obj_t = sc_gluon_callable_object_v1_t;
+using callback_release_t = sc_gluon_release_callback_object_v1_f;
+using do_callback_t = sc_gluon_do_callback_v1_f;
+
+[[nodiscard]] constexpr param_t priv_basic(sc_gluon_data_v1 data, sc_gluon_param_tag_v1 tag) noexcept {
+    return { data, 1, tag, false };
+}
+[[nodiscard]] constexpr param_t priv_array(sc_gluon_data_v1 data, sc_gluon_param_tag_v1 tag, uint32_t size,
+                                           bool owns_data) noexcept {
+    return { data, size, tag, owns_data };
+}
+
+[[nodiscard]] constexpr param_t create_param() noexcept {
+    data_t d {};
+    d.nil_ = {};
+    return priv_basic(d, sc_gluon_nil);
+}
+
+[[nodiscard]] constexpr param_t create_param(int32_t i) noexcept {
+    data_t d {};
+    d.i32 = i;
+    return priv_basic(d, sc_gluon_i32);
+}
+
+[[nodiscard]] constexpr param_t create_param(double f) noexcept {
+    data_t d {};
+    d.f64 = f;
+    return priv_basic(d, sc_gluon_f64);
+}
+
+[[nodiscard]] constexpr param_t create_param(char c) noexcept {
+    data_t d {};
+    d.character = c;
+    return priv_basic(d, sc_gluon_char);
+}
+
+[[nodiscard]] constexpr param_t create_param(bool b) noexcept {
+    data_t d {};
+    d.boolean = b;
+    return priv_basic(d, sc_gluon_bool);
+}
+
+[[nodiscard]] constexpr param_t create_param(void* p) noexcept {
+    data_t d {};
+    d.raw_pointer = p;
+    return priv_basic(d, sc_gluon_raw_pointer);
+}
+
+[[nodiscard]] constexpr param_t create_param(uint64_t s) noexcept {
+    data_t d {};
+    d.symbol_value = s;
+    return priv_basic(d, sc_gluon_symbol_value);
+}
+
+[[nodiscard]] constexpr param_t create_param(uint8_t* a, uint32_t size, bool owns_data) noexcept {
+    data_t d {};
+    d.u8_array = a;
+    return priv_array(d, sc_gluon_u8_array, size, owns_data);
+}
+
+[[nodiscard]] constexpr param_t create_param(double* a, uint32_t size, bool owns_data) noexcept {
+    data_t d {};
+    d.f64_array = a;
+    return priv_array(d, sc_gluon_f64_array, size, owns_data);
+}
+
+[[nodiscard]] constexpr param_t create_param(float* a, uint32_t size, bool owns_data) noexcept {
+    data_t d {};
+    d.f32_array = a;
+    return priv_array(d, sc_gluon_f32_array, size, owns_data);
+}
+
+[[nodiscard]] constexpr param_t create_param(char* a, uint32_t size, bool owns_data) noexcept {
+    data_t d {};
+    d.character_array = a;
+    return priv_array(d, sc_gluon_char_array, size, owns_data);
+}
+
+[[nodiscard]] constexpr param_t create_param(param_t* a, uint32_t size, bool owns_data) noexcept {
+    data_t d {};
+    d.param_array = a;
+    return priv_array(d, sc_gluon_param_array, size, owns_data);
+}
+
+[[nodiscard]] constexpr bool has_heap_allocated_data(param_t p) noexcept {
+    switch (p.tag) {
+    case sc_gluon_u8_array:
+    case sc_gluon_f64_array:
+    case sc_gluon_f32_array:
+    case sc_gluon_char_array:
+    case sc_gluon_param_array:
+        return true;
+    default:
+        return false;
+    }
+}
+
+} // namespace sc_gluon::v1

--- a/include/gluon_ffi_interface/sc_gluon_v1_entry_points.h
+++ b/include/gluon_ffi_interface/sc_gluon_v1_entry_points.h
@@ -1,0 +1,26 @@
+#pragma once
+#include "sc_gluon_v1_types.h"
+
+#ifdef __cplusplus
+#    define SC_GLUON_EXTERN extern "C"
+#endif
+
+#define SC_GLUON_EXPORT SC_GLUON_EXTERN __attribute__((__visibility__("hidden")))
+
+// Required
+SC_GLUON_EXPORT uint32_t sc_gluon_version();
+
+// Required
+SC_GLUON_EXPORT sc_gluon_library_data_v1_t
+sc_gluon_load_library(sc_gluon_do_callback_v1_f, sc_gluon_release_callback_object_v1_f,
+                      struct sc_gluon_function_declarations_v1_t** const out_decls, uint32_t* out_size);
+
+
+// Optional
+SC_GLUON_EXPORT void sc_gluon_post_load_library(sc_gluon_library_data_v1_t,
+                                                struct sc_gluon_function_declarations_v1_t* decls_to_be_freed,
+                                                uint32_t decls_size);
+
+
+// Optional
+SC_GLUON_EXPORT void sc_gluon_unload_library(sc_gluon_library_data_v1_t);

--- a/include/gluon_ffi_interface/sc_gluon_v1_entry_points.h
+++ b/include/gluon_ffi_interface/sc_gluon_v1_entry_points.h
@@ -5,7 +5,7 @@
 #    define SC_GLUON_EXTERN extern "C"
 #endif
 
-#define SC_GLUON_EXPORT SC_GLUON_EXTERN __attribute__((__visibility__("hidden")))
+#define SC_GLUON_EXPORT SC_GLUON_EXTERN __attribute__((__visibility__("default")))
 
 // Required
 SC_GLUON_EXPORT uint32_t sc_gluon_version();

--- a/include/gluon_ffi_interface/sc_gluon_v1_entry_points.h
+++ b/include/gluon_ffi_interface/sc_gluon_v1_entry_points.h
@@ -1,3 +1,5 @@
+// SuperCollider foreign function interface.
+// Author Jordan Henderson - JordanHendersonMusic 2025
 #pragma once
 #include "sc_gluon_v1_types.h"
 
@@ -5,15 +7,21 @@
 #    define SC_GLUON_EXTERN extern "C"
 #endif
 
-#define SC_GLUON_EXPORT SC_GLUON_EXTERN __attribute__((__visibility__("default")))
+#if defined(_WIN32) || defined(_WIN64) || defined(WIN32) || defined(WIN64)
+#    define SC_GLUON_EXPORT SC_GLUON_EXTERN __declspec(dllexport)
+#else
+#    define SC_GLUON_EXPORT SC_GLUON_EXTERN __attribute__((__visibility__("default")))
+#endif
 
 // Required
 SC_GLUON_EXPORT uint32_t sc_gluon_version();
 
 // Required
-SC_GLUON_EXPORT sc_gluon_library_data_v1_t
-sc_gluon_load_library(sc_gluon_do_callback_v1_f, sc_gluon_release_callback_object_v1_f,
-                      struct sc_gluon_function_declarations_v1_t** const out_decls, uint32_t* out_size);
+SC_GLUON_EXPORT uint8_t sc_gluon_load_library(sc_gluon_param_v1_t* in_params, uint32_t num_in_params,
+                                              sc_gluon_do_callback_v1_f do_callback,
+                                              sc_gluon_release_callback_object_v1_f release_callback,
+                                              sc_gluon_function_declarations_v1_t** const out_decls,
+                                              uint32_t* out_decls_size, sc_gluon_library_data_v1_t* out_library_data);
 
 
 // Optional

--- a/include/gluon_ffi_interface/sc_gluon_v1_types.h
+++ b/include/gluon_ffi_interface/sc_gluon_v1_types.h
@@ -135,10 +135,10 @@ union sc_gluon_data_v1 {
 
 struct sc_gluon_param_v1_t {
     union sc_gluon_data_v1 data;
+    uint32_t size; // For non-array parameters, this is ignored, but set to '1' as a good practice.
     enum sc_gluon_param_tag_v1 tag;
     bool owns_data; // Indicates that the param owns some heap allocated data, and will be deallocated when the lifetime
                     // of the parameter ends.
-    uint32_t size; // For non-array parameters, this is ignored, but set to '1' as a good practice.
 };
 
 union sc_gluon_out_param_or_maybe_diagnostic_v1 {

--- a/include/gluon_ffi_interface/sc_gluon_v1_types.h
+++ b/include/gluon_ffi_interface/sc_gluon_v1_types.h
@@ -179,3 +179,44 @@ inline void sc_gluon_free_param_v1(struct sc_gluon_param_v1_t param) {
         }
     }
 }
+
+inline struct sc_gluon_param_v1_t sc_gluon_copy_param_data_v1(struct sc_gluon_param_v1_t param) {
+    switch (param.tag) {
+    case sc_gluon_param_array: {
+        // Recursive case.
+        sc_gluon_data_v1 d {};
+        d.param_array = (sc_gluon_param_v1_t*)malloc(param.size * sizeof(sc_gluon_param_v1_t));
+        for (uint32_t i = 0; i < param.size; ++i)
+            d.param_array[i] = sc_gluon_copy_param_data_v1(param.data.param_array[i]);
+
+        return { d, param.size, sc_gluon_param_array, true };
+    }
+    case sc_gluon_u8_array: {
+        sc_gluon_data_v1 d {};
+        d.u8_array = (uint8_t*)malloc(param.size * sizeof(uint8_t));
+        memcpy(d.u8_array, param.data.u8_array, param.size * sizeof(uint8_t));
+        return { d, param.size, sc_gluon_u8_array, true };
+    }
+    case sc_gluon_f64_array: {
+        sc_gluon_data_v1 d {};
+        d.f64_array = (double*)malloc(param.size * sizeof(double));
+        memcpy(d.f64_array, param.data.f64_array, param.size * sizeof(double));
+        return { d, param.size, sc_gluon_f64_array, true };
+    }
+    case sc_gluon_f32_array: {
+        sc_gluon_data_v1 d {};
+        d.f32_array = (float*)malloc(param.size * sizeof(float));
+        memcpy(d.f32_array, param.data.f64_array, param.size * sizeof(float));
+        return { d, param.size, sc_gluon_f32_array, true };
+    }
+    case sc_gluon_char_array: {
+        sc_gluon_data_v1 d {};
+        d.character_array = (char*)malloc(param.size * sizeof(char));
+        memcpy(d.character_array, param.data.character_array, param.size * sizeof(char));
+        return { d, param.size, sc_gluon_char_array, true };
+    }
+    default: {
+        return param;
+    }
+    }
+}

--- a/include/gluon_ffi_interface/sc_gluon_v1_types.h
+++ b/include/gluon_ffi_interface/sc_gluon_v1_types.h
@@ -3,7 +3,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <stdlib.h>
-
+#include <cstring>
 /*
 
 SuperCollider foreign function interface.

--- a/include/gluon_ffi_interface/sc_gluon_v1_types.h
+++ b/include/gluon_ffi_interface/sc_gluon_v1_types.h
@@ -111,8 +111,7 @@ enum sc_gluon_param_tag_v1 {
     sc_gluon_u8_array,
     sc_gluon_f64_array,
     sc_gluon_f32_array,
-    sc_gluon_char_array,
-    sc_gluon_symbol_value_array,
+    sc_gluon_char_array, // Note, this is not a null terminated string, but an array with a size.
     //
     sc_gluon_param_array,
 };
@@ -124,12 +123,11 @@ union sc_gluon_data_v1 {
     char character;
     bool boolean;
     void* raw_pointer;
-    intptr_t symbol_value;
+    uint64_t symbol_value;
     uint8_t* u8_array;
     double* f64_array;
     float* f32_array;
     char* character_array;
-    intptr_t* symbol_value_array;
     struct sc_gluon_param_v1_t* param_array;
 };
 
@@ -173,10 +171,6 @@ inline void sc_gluon_free_param_v1(struct sc_gluon_param_v1_t param) {
             }
             case sc_gluon_char_array: {
                 free(param.data.character_array);
-                break;
-            }
-            case sc_gluon_symbol_value_array: {
-                free(param.data.symbol_value_array);
                 break;
             }
             default:

--- a/include/gluon_ffi_interface/sc_gluon_v1_types.h
+++ b/include/gluon_ffi_interface/sc_gluon_v1_types.h
@@ -1,18 +1,15 @@
-
+// SuperCollider foreign function interface.
+// Author Jordan Henderson - JordanHendersonMusic 2025
 #pragma once
 #include <stdint.h>
-#include <stdbool.h>
 #include <stdlib.h>
 #include <cstring>
 /*
 
-SuperCollider foreign function interface.
-Author Jordan Henderson - JordanHendersonMusic 2025
-
 There are three parts to this header:
     1. Entry points, these are functions that will be called from the sc host. They must be named accordingly.
-    2. The definition of the function signature. When implementing a function to be called from sc, it must have this
-        signature.
+    2. The definition of the foreign function signature. When implementing a function to be called from sc, it must have
+        this signature.
     3. The parameter definition. To avoid exposing sc internals (which may change), an intermediate format is given for
         arguments, this means not all supercollider types can be passed to foreign functions.
 
@@ -23,82 +20,107 @@ The three types of entry point are 'version', 'load', 'post_load', and 'unload'.
 
     In 'load', a pointer to an array of structures describing what functions the library offers must be set.
     A name, an implementation pointer, the number of params expected (-1 if accepts any number), and a
-    bool indicating whether the function accepts a callback must all be provided. A pointer to some data
-    for the library may be returned, this will be passed to each function allowing for library state without using
-    globals. Additionally, the function provides a callback function, which should be stored in the case a function
-    wishes to return execution back to sc from another thread.
+    uint8_t (bool) indicating whether the function accepts a callback must all be provided. A pointer to some data
+    for the library may be returned via an out param, this will be passed to each function allowing for library state
+    without using globals. Additionally, the function provides a callback function, which should be stored in the case a
+    function wishes to return execution back to sc from another thread. Parameters from supercollider can also be passed
+    in at this stage. This function must return a parameter (even nil) to indicate a successful load. This parameter is
+    NOT passed back to supercollider.
 
     In 'post_load' you are provided the opportunity to deallocate the array of function descriptions.
 
     In 'unload' you can deallocate the library state.
 
 
-The functions accepts the library state, a nullable pointer to some callback object (this is a type erased
-PyrObject* of which `value' will be called upon), the input parameter array, and an output parameter or potential
-diagnostic. Additionally, it must return a tag indicating whether an output parameter or diagnostic has been produced.
+The foreign functions accepts the library state, a nullable pointer to some callback object, the input parameter array,
+and an output parameter or potential diagnostic. Additionally, it must return a tag indicating whether an output
+parameter or diagnostic has been produced.
 
-Parameters are essentially tagged unions that when containing allocated resources indicate their size and whether they
+Parameters are tagged unions that when containing allocated resources indicate their size and whether they
 own their memory.
 
-All input parameters that have allocated resources (arrays) will be freed after the function has finished if they 'own'
-their data. To prevent this, the 'owns_data' member may be set to false, thereby taking ownership of the memory.
+All input parameters that have allocated resources (arrays) will be freed after the foreign function has finished if
+they 'own' their data. To prevent this, the 'owns_data' member may be set to 0, thereby taking ownership of the memory.
 This memory can either be freed manually at a later date, or returned as a part of an output parameter, ensuring the
 output parameter 'owns' the data.
 
 Input parameters who do not own their data have unknown lifetimes, the data will persist for the duration of the
-function call, but may be freed immediately after, or by sc's garbage collector at an unknown point in time.
+foreign function call, but may be freed immediately after, or by sc's garbage collector at an unknown point in time.
+Mutating 'non-owned' data will allows you to directly alter the contents of structures like Signals without creating
+copies.
 
-When passing any 'owned' memory back to the sc host, it must be allocate with malloc as free will be called on it.
-Alternatively, you can pass unowned memory back to the host and no attempt to deallocate will be made.
+
+When passing parameters back to supercollider, if the memory is marked as 'owned' no copy will be made and supercollider
+will take ownership of it. Ensure that all memory stored inside of a parameter is valid to be deallocated with 'free'.
+If in doubt, set the 'owns_data' flag to 0, and supercollider will copy the data.
 
 */
 
+////// Report which version of the gluon ffi interface used..
 typedef uint32_t (*sc_gluon_version_f)();
 
+////// Pointer to custom user defined library data
 typedef void* sc_gluon_library_data_v1_t;
-typedef void* sc_gluon_callable_object_v1_t;
-typedef void (*sc_gluon_do_callback_v1_f)(sc_gluon_callable_object_v1_t, struct sc_gluon_param_v1_t* params,
+
+////// Pointer to some gc reserved supercollider object
+typedef void* sc_gluon_callback_object_v1_t;
+
+////// Function to trigger callback object in supercollider, can pass parameters, must not be called on the main thread.
+typedef void (*sc_gluon_do_callback_v1_f)(sc_gluon_callback_object_v1_t, struct sc_gluon_param_v1_t* params,
                                           uint32_t num_params);
-typedef void (*sc_gluon_release_callback_object_v1_f)(sc_gluon_callable_object_v1_t);
 
-//////////// ENTRY POINTS FOR LIBRARY.
+////// Release the callback object allowing the garbage collector to clean it up, must not be called on the main thread.
+typedef void (*sc_gluon_release_callback_object_v1_f)(sc_gluon_callback_object_v1_t);
 
+
+//////////// MAIN ENTRY POINTS FOR LIBRARY.
+
+////// Load library
 // Required. Must be called: sc_gluon_load_library
-typedef sc_gluon_library_data_v1_t (*sc_gluon_load_library_v1_f)(
-    sc_gluon_do_callback_v1_f, sc_gluon_release_callback_object_v1_f,
-    struct sc_gluon_function_declarations_v1_t** const out_decls, uint32_t* out_size);
+// Return 0 for successful load.
+typedef uint8_t (*sc_gluon_load_library_v1_f)(struct sc_gluon_param_v1_t* in_params, uint32_t num_in_params,
+                                              sc_gluon_do_callback_v1_f do_callback,
+                                              sc_gluon_release_callback_object_v1_f release_callback,
+                                              struct sc_gluon_function_declarations_v1_t** const out_decls,
+                                              uint32_t* out_decls__size, sc_gluon_library_data_v1_t* out_library_data);
 
+////// Post load library
 // Optional. Must be called: sc_gluon_post_load_library.
 typedef void (*sc_gluon_post_load_library_v1_f)(sc_gluon_library_data_v1_t,
                                                 struct sc_gluon_function_declarations_v1_t* decls_to_be_freed,
                                                 uint32_t decls_size);
 
+////// Post unload library
 // Optional. Must be called: sc_gluon_unload_library.
 typedef void (*sc_gluon_unload_library_v1_f)(sc_gluon_library_data_v1_t);
 
-////////////  FUNCTION PTRS
 
+//////////// Foreign function signature
+////// Functions that will be called in supercollider must have this signature.
+
+////// Used to report whether some function produce some parameter to pass back to supercollider, or whether an error
+/// occurred.
 enum sc_gluon_out_param_tag_v1 {
     sc_gluon_produced_param,
     sc_gluon_error_with_owned_diagnostic,
     sc_gluon_error_with_non_owned_diagnostic,
-    sc_gluon_error_without_diagnostic,
 };
 
 typedef enum sc_gluon_out_param_tag_v1 (*sc_gluon_function_v1_f)(
-    sc_gluon_library_data_v1_t library_data, sc_gluon_callable_object_v1_t maybe_callback_data,
+    sc_gluon_library_data_v1_t library_data, sc_gluon_callback_object_v1_t maybe_callback_data,
     struct sc_gluon_param_v1_t* in_params, uint32_t num_in_params,
     union sc_gluon_out_param_or_maybe_diagnostic_v1* out_param);
 
-
-//////////// PARAMS
-
+////// Used to report back to supercollider what functions the library implements.
+////// See sc_gluon_load_library_v1_f
 struct sc_gluon_function_declarations_v1_t {
     const char* name;
     sc_gluon_function_v1_f ptr;
     int32_t num_parms; // negative means accepts any number of arguments.
-    bool accepts_callback;
+    uint8_t accepts_callback;
 };
+
+//////////////// PARAMETERS
 
 enum sc_gluon_param_tag_v1 {
     sc_gluon_nil,
@@ -115,13 +137,12 @@ enum sc_gluon_param_tag_v1 {
     //
     sc_gluon_param_array,
 };
-
 union sc_gluon_data_v1 {
     int32_t nil_;
     int32_t i32;
     double f64;
     char character;
-    bool boolean;
+    uint8_t boolean;
     void* raw_pointer;
     uint64_t symbol_value;
     uint8_t* u8_array;
@@ -135,22 +156,25 @@ struct sc_gluon_param_v1_t {
     union sc_gluon_data_v1 data;
     uint32_t size; // For non-array parameters, this is ignored, but set to '1' as a good practice.
     enum sc_gluon_param_tag_v1 tag;
-    bool owns_data; // Indicates that the param owns some heap allocated data, and will be deallocated when the lifetime
-                    // of the parameter ends.
+    uint8_t owns_data; // Indicates that the param owns some heap allocated data, and will be deallocated when the
+                       // lifetime of the parameter ends.
 };
 
+////// Holds either an parameter to pass back to supercollider, or a null terminated diagnostic string.
 union sc_gluon_out_param_or_maybe_diagnostic_v1 {
     struct sc_gluon_param_v1_t out_param;
+    // sc_gluon_out_param_tag_v1 indicates whether this is an owned pointer. Null terminated. Can be nullptr.
     const char* maybe_diagnostic;
 };
+
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // HELPERS
 
-inline void sc_gluon_free_param_v1(struct sc_gluon_param_v1_t param) {
+inline void sc_gluon_free_param_if_owned_v1(struct sc_gluon_param_v1_t param) {
     if (param.tag == sc_gluon_param_array) {
         for (uint32_t i = 0; i < param.size; ++i)
-            sc_gluon_free_param_v1(param.data.param_array[i]);
+            sc_gluon_free_param_if_owned_v1(param.data.param_array[i]);
 
         if (param.owns_data)
             free(param.data.param_array);
@@ -180,40 +204,40 @@ inline void sc_gluon_free_param_v1(struct sc_gluon_param_v1_t param) {
     }
 }
 
-inline struct sc_gluon_param_v1_t sc_gluon_copy_param_data_v1(struct sc_gluon_param_v1_t param) {
+inline struct sc_gluon_param_v1_t sc_gluon_copy_param_v1(struct sc_gluon_param_v1_t param) {
     switch (param.tag) {
     case sc_gluon_param_array: {
         // Recursive case.
         sc_gluon_data_v1 d {};
         d.param_array = (sc_gluon_param_v1_t*)malloc(param.size * sizeof(sc_gluon_param_v1_t));
         for (uint32_t i = 0; i < param.size; ++i)
-            d.param_array[i] = sc_gluon_copy_param_data_v1(param.data.param_array[i]);
+            d.param_array[i] = sc_gluon_copy_param_v1(param.data.param_array[i]);
 
-        return { d, param.size, sc_gluon_param_array, true };
+        return { d, param.size, sc_gluon_param_array, 1 };
     }
     case sc_gluon_u8_array: {
         sc_gluon_data_v1 d {};
         d.u8_array = (uint8_t*)malloc(param.size * sizeof(uint8_t));
         memcpy(d.u8_array, param.data.u8_array, param.size * sizeof(uint8_t));
-        return { d, param.size, sc_gluon_u8_array, true };
+        return { d, param.size, sc_gluon_u8_array, 1 };
     }
     case sc_gluon_f64_array: {
         sc_gluon_data_v1 d {};
         d.f64_array = (double*)malloc(param.size * sizeof(double));
         memcpy(d.f64_array, param.data.f64_array, param.size * sizeof(double));
-        return { d, param.size, sc_gluon_f64_array, true };
+        return { d, param.size, sc_gluon_f64_array, 1 };
     }
     case sc_gluon_f32_array: {
         sc_gluon_data_v1 d {};
         d.f32_array = (float*)malloc(param.size * sizeof(float));
         memcpy(d.f32_array, param.data.f64_array, param.size * sizeof(float));
-        return { d, param.size, sc_gluon_f32_array, true };
+        return { d, param.size, sc_gluon_f32_array, 1 };
     }
     case sc_gluon_char_array: {
         sc_gluon_data_v1 d {};
         d.character_array = (char*)malloc(param.size * sizeof(char));
         memcpy(d.character_array, param.data.character_array, param.size * sizeof(char));
-        return { d, param.size, sc_gluon_char_array, true };
+        return { d, param.size, sc_gluon_char_array, 1 };
     }
     default: {
         return param;

--- a/include/gluon_ffi_interface/sc_gluon_v1_types.h
+++ b/include/gluon_ffi_interface/sc_gluon_v1_types.h
@@ -1,0 +1,187 @@
+
+#pragma once
+#include <stdint.h>
+#include <stdbool.h>
+#include <stdlib.h>
+
+/*
+
+SuperCollider foreign function interface.
+Author Jordan Henderson - JordanHendersonMusic 2025
+
+There are three parts to this header:
+    1. Entry points, these are functions that will be called from the sc host. They must be named accordingly.
+    2. The definition of the function signature. When implementing a function to be called from sc, it must have this
+        signature.
+    3. The parameter definition. To avoid exposing sc internals (which may change), an intermediate format is given for
+        arguments, this means not all supercollider types can be passed to foreign functions.
+
+
+The three types of entry point are 'version', 'load', 'post_load', and 'unload'.
+
+    Version declared which api to use, it is the only entry point shared across all versions.
+
+    In 'load', a pointer to an array of structures describing what functions the library offers must be set.
+    A name, an implementation pointer, the number of params expected (-1 if accepts any number), and a
+    bool indicating whether the function accepts a callback must all be provided. A pointer to some data
+    for the library may be returned, this will be passed to each function allowing for library state without using
+    globals. Additionally, the function provides a callback function, which should be stored in the case a function
+    wishes to return execution back to sc from another thread.
+
+    In 'post_load' you are provided the opportunity to deallocate the array of function descriptions.
+
+    In 'unload' you can deallocate the library state.
+
+
+The functions accepts the library state, a nullable pointer to some callback object (this is a type erased
+PyrObject* of which `value' will be called upon), the input parameter array, and an output parameter or potential
+diagnostic. Additionally, it must return a tag indicating whether an output parameter or diagnostic has been produced.
+
+Parameters are essentially tagged unions that when containing allocated resources indicate their size and whether they
+own their memory.
+
+All input parameters that have allocated resources (arrays) will be freed after the function has finished if they 'own'
+their data. To prevent this, the 'owns_data' member may be set to false, thereby taking ownership of the memory.
+This memory can either be freed manually at a later date, or returned as a part of an output parameter, ensuring the
+output parameter 'owns' the data.
+
+Input parameters who do not own their data have unknown lifetimes, the data will persist for the duration of the
+function call, but may be freed immediately after, or by sc's garbage collector at an unknown point in time.
+
+When passing any 'owned' memory back to the sc host, it must be allocate with malloc as free will be called on it.
+Alternatively, you can pass unowned memory back to the host and no attempt to deallocate will be made.
+
+*/
+
+typedef uint32_t (*sc_gluon_version_f)();
+
+typedef void* sc_gluon_library_data_v1_t;
+typedef void* sc_gluon_callable_object_v1_t;
+typedef void (*sc_gluon_do_callback_v1_f)(sc_gluon_callable_object_v1_t, struct sc_gluon_param_v1_t* params,
+                                          uint32_t num_params);
+typedef void (*sc_gluon_release_callback_object_v1_f)(sc_gluon_callable_object_v1_t);
+
+//////////// ENTRY POINTS FOR LIBRARY.
+
+// Required. Must be called: sc_gluon_load_library
+typedef sc_gluon_library_data_v1_t (*sc_gluon_load_library_v1_f)(
+    sc_gluon_do_callback_v1_f, sc_gluon_release_callback_object_v1_f,
+    struct sc_gluon_function_declarations_v1_t** const out_decls, uint32_t* out_size);
+
+// Optional. Must be called: sc_gluon_post_load_library.
+typedef void (*sc_gluon_post_load_library_v1_f)(sc_gluon_library_data_v1_t,
+                                                struct sc_gluon_function_declarations_v1_t* decls_to_be_freed,
+                                                uint32_t decls_size);
+
+// Optional. Must be called: sc_gluon_unload_library.
+typedef void (*sc_gluon_unload_library_v1_f)(sc_gluon_library_data_v1_t);
+
+////////////  FUNCTION PTRS
+
+enum sc_gluon_out_param_tag_v1 {
+    sc_gluon_produced_param,
+    sc_gluon_error_with_owned_diagnostic,
+    sc_gluon_error_with_non_owned_diagnostic,
+    sc_gluon_error_without_diagnostic,
+};
+
+typedef enum sc_gluon_out_param_tag_v1 (*sc_gluon_function_v1_f)(
+    sc_gluon_library_data_v1_t library_data, sc_gluon_callable_object_v1_t maybe_callback_data,
+    struct sc_gluon_param_v1_t* in_params, uint32_t num_in_params,
+    union sc_gluon_out_param_or_maybe_diagnostic_v1* out_param);
+
+
+//////////// PARAMS
+
+struct sc_gluon_function_declarations_v1_t {
+    const char* name;
+    sc_gluon_function_v1_f ptr;
+    int32_t num_parms; // negative means accepts any number of arguments.
+    bool accepts_callback;
+};
+
+enum sc_gluon_param_tag_v1 {
+    sc_gluon_nil,
+    sc_gluon_i32,
+    sc_gluon_f64,
+    sc_gluon_char,
+    sc_gluon_bool,
+    sc_gluon_raw_pointer,
+    sc_gluon_symbol_value,
+    sc_gluon_u8_array,
+    sc_gluon_f64_array,
+    sc_gluon_f32_array,
+    sc_gluon_char_array,
+    sc_gluon_symbol_value_array,
+    //
+    sc_gluon_param_array,
+};
+
+union sc_gluon_data_v1 {
+    int32_t nil_;
+    int32_t i32;
+    double f64;
+    char character;
+    bool boolean;
+    void* raw_pointer;
+    intptr_t symbol_value;
+    uint8_t* u8_array;
+    double* f64_array;
+    float* f32_array;
+    char* character_array;
+    intptr_t* symbol_value_array;
+    struct sc_gluon_param_v1_t* param_array;
+};
+
+struct sc_gluon_param_v1_t {
+    union sc_gluon_data_v1 data;
+    enum sc_gluon_param_tag_v1 tag;
+    bool owns_data; // Indicates that the param owns some heap allocated data, and will be deallocated when the lifetime
+                    // of the parameter ends.
+    uint32_t size; // For non-array parameters, this is ignored, but set to '1' as a good practice.
+};
+
+union sc_gluon_out_param_or_maybe_diagnostic_v1 {
+    struct sc_gluon_param_v1_t out_param;
+    const char* maybe_diagnostic;
+};
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// HELPERS
+
+inline void sc_gluon_free_param_v1(struct sc_gluon_param_v1_t param) {
+    if (param.tag == sc_gluon_param_array) {
+        for (uint32_t i = 0; i < param.size; ++i)
+            sc_gluon_free_param_v1(param.data.param_array[i]);
+
+        if (param.owns_data)
+            free(param.data.param_array);
+    } else {
+        if (param.owns_data) {
+            switch (param.tag) {
+            case sc_gluon_u8_array: {
+                free(param.data.u8_array);
+                break;
+            }
+            case sc_gluon_f64_array: {
+                free(param.data.f64_array);
+                break;
+            }
+            case sc_gluon_f32_array: {
+                free(param.data.f32_array);
+                break;
+            }
+            case sc_gluon_char_array: {
+                free(param.data.character_array);
+                break;
+            }
+            case sc_gluon_symbol_value_array: {
+                free(param.data.symbol_value_array);
+                break;
+            }
+            default:
+                break;
+            }
+        }
+    }
+}

--- a/lang/CMakeLists.txt
+++ b/lang/CMakeLists.txt
@@ -4,6 +4,7 @@ include_directories(${CMAKE_SOURCE_DIR}/include/common
                     ${CMAKE_SOURCE_DIR}/include/plugin_interface
                     ${CMAKE_SOURCE_DIR}/include/server
                     ${CMAKE_SOURCE_DIR}/common
+                    ${CMAKE_SOURCE_DIR}/include/gluon_ffi_interface
 
                     LangSource
                     LangPrimSource
@@ -30,11 +31,14 @@ else ()
 endif ()
 
 set(sclang_sources
+	LangSource/GluonFFIV1.cpp
+	LangSource/GluonFFI.cpp
     LangPrimSource/SC_LinkClock.cpp
     LangPrimSource/SC_AudioDevicePrim.cpp
 	LangPrimSource/PyrSignalPrim.cpp
 	LangPrimSource/PyrSched.cpp
 	LangPrimSource/PyrPrimitive.cpp
+	LangPrimSource/PyrFFIPrimitives.cpp
 	LangPrimSource/PyrMathPrim.cpp
 	LangPrimSource/SC_ComPort.cpp
 	LangPrimSource/OSCData.cpp

--- a/lang/LangPrimSource/PyrFFIPrimitives.cpp
+++ b/lang/LangPrimSource/PyrFFIPrimitives.cpp
@@ -7,17 +7,22 @@
 
 
 int openGluon(VMGlobals* g, int numArgsPushed) {
-    assert(numArgsPushed == 2);
+    assert(numArgsPushed >= 2);
+    const auto numArgsToPass = numArgsPushed - 2;
 
-    PyrSlot* rec = g->sp - 1;
-    PyrSlot* path_slot = g->sp;
+    PyrSlot* rec = g->sp - numArgsPushed + 1;
+    PyrSlot* path_slot = rec + 1;
+    PyrSlot* first_arg = path_slot + 1;
+
+    dumpPyrSlot(rec);
+    dumpPyrSlot(path_slot);
 
     PyrString* s = slotRawString(path_slot);
 
     const auto [err, str] = slotStdStrVal(path_slot);
     if (err)
         return errFailed;
-    const auto library_id = g->gluonManager.register_library(str.c_str());
+    const auto library_id = g->gluonManager.register_library(str.c_str(), first_arg, numArgsToPass);
 
     SetInt(rec, library_id);
     return errNone;
@@ -89,7 +94,7 @@ void initFFIPrimitives() {
 
     base = nextPrimitiveIndex();
 
-    definePrimitive(base, index++, "_OpenGluon", openGluon, 2, 0);
+    definePrimitive(base, index++, "_OpenGluon", openGluon, 2, 1);
     definePrimitive(base, index++, "_CloseGluon", closeGluon, 2, 0);
     definePrimitive(base, index++, "_CallGluon", callGluon, 3, 1);
     definePrimitive(base, index++, "_CallGluonWithCallback", callGluonWithCallback, 4, 1);

--- a/lang/LangPrimSource/PyrFFIPrimitives.cpp
+++ b/lang/LangPrimSource/PyrFFIPrimitives.cpp
@@ -1,0 +1,97 @@
+// Author Jordan Henderson - JordanHendersonMusic
+#include "PyrPrimitive.h"
+#include "VMGlobals.h"
+#include "PyrObject.h"
+#include "PyrSlot.h"
+#include <cassert>
+
+
+int openGluon(VMGlobals* g, int numArgsPushed) {
+    assert(numArgsPushed == 2);
+
+    PyrSlot* rec = g->sp - 1;
+    PyrSlot* path_slot = g->sp;
+
+    PyrString* s = slotRawString(path_slot);
+
+    const auto [err, str] = slotStdStrVal(path_slot);
+    if (err)
+        return errFailed;
+    const auto library_id = g->gluonManager.register_library(str.c_str());
+
+    SetInt(rec, library_id);
+    return errNone;
+}
+
+int closeGluon(VMGlobals* g, int numArgsPushed) {
+    assert(numArgsPushed == 2);
+    PyrSlot* rec = g->sp - 1;
+    PyrSlot* id = g->sp;
+    if (!IsInt(id))
+        return errFailed;
+    const auto library_id = slotRawInt(id);
+    g->gluonManager.unregister_library(library_id);
+    return errNone;
+}
+
+int callGluon(VMGlobals* g, int numArgsPushed) {
+    assert(numArgsPushed >= 3);
+    PyrSlot* return_slot = (g->sp - numArgsPushed) + 1;
+    PyrSlot* id_slot = return_slot + 1;
+    PyrSlot* function_name_slot = id_slot + 1;
+
+    if (!IsInt(id_slot))
+        return errFailed;
+    if (!IsSym(function_name_slot))
+        return errFailed;
+
+    g->gluonManager.evaluate_function(slotRawInt(id_slot), slotRawSymbol(function_name_slot), g, nullptr, return_slot,
+                                      function_name_slot + 1, numArgsPushed - 3);
+    return errNone;
+}
+
+int callGluonWithCallback(VMGlobals* g, int numArgsPushed) {
+    assert(numArgsPushed >= 4);
+    PyrSlot* return_slot = (g->sp - numArgsPushed) + 1;
+    PyrSlot* id_slot = return_slot + 1;
+    PyrSlot* function_name_slot = id_slot + 1;
+    PyrSlot* callback_slot = function_name_slot + 1;
+
+    if (!IsInt(id_slot))
+        return errFailed;
+    if (!IsSym(function_name_slot))
+        return errFailed;
+    if (!IsObj(callback_slot))
+        return errFailed;
+
+    PyrObject* callback = slotRawObject(callback_slot);
+
+    g->gluonManager.evaluate_function(slotRawInt(id_slot), slotRawSymbol(function_name_slot), g, callback, return_slot,
+                                      callback_slot + 1, numArgsPushed - 4);
+    return errNone;
+}
+
+int getInbuiltGluonID(VMGlobals* g, int numArgsPushed) {
+    assert(numArgsPushed == 2);
+    PyrSlot* return_slot = (g->sp - numArgsPushed) + 1;
+    PyrSlot* name_slot = return_slot + 1;
+    if (!IsSym(name_slot))
+        return errFailed;
+
+    const auto library_id = g->gluonManager.get_inbuilt_library_id(slotRawSymbol(name_slot));
+
+    SetInt(return_slot, library_id);
+    return errNone;
+}
+
+void initFFIPrimitives() {
+    int base, index = 0;
+
+    base = nextPrimitiveIndex();
+
+    definePrimitive(base, index++, "_OpenGluon", openGluon, 2, 0);
+    definePrimitive(base, index++, "_CloseGluon", closeGluon, 2, 0);
+    definePrimitive(base, index++, "_CallGluon", callGluon, 3, 1);
+    definePrimitive(base, index++, "_CallGluonWithCallback", callGluonWithCallback, 4, 1);
+    definePrimitive(base, index++, "_GetInbuiltGluonID", getInbuiltGluonID, 2, 0);
+}

--- a/lang/LangPrimSource/PyrPrimitive.cpp
+++ b/lang/LangPrimSource/PyrPrimitive.cpp
@@ -4023,6 +4023,10 @@ void initPrimitives() {
     definePrimitive(base, index++, "_NumUninlinedFunctionInClassLib", numUninlinedFunctionsInClassLib, 1, 0);
     definePrimitive(base, index++, "_SC_BuildString", prBuildString, 1, 0);
 
+
+    void initFFIPrimitives();
+    initFFIPrimitives();
+
     // void initOscilPrimitives();
     // void initControllerPrimitives();
 

--- a/lang/LangSource/GC.cpp
+++ b/lang/LangSource/GC.cpp
@@ -128,7 +128,7 @@ scan phase:
         when a non local object is reached, mark it, and put it on the list if not retained.
 sweep phase:
     send any new retained objects to other system
-    send any no longer reatined objects to the other system.
+    send any no longer retained objects to the other system.
     send this list to
     enqueue finalization messages
         finalize: call finalize method, move from sweep area to free area
@@ -282,12 +282,21 @@ PyrGC::PyrGC(VMGlobals* g, AllocPool* inPool, PyrClass* mainProcessClass, std::i
     g->process = nullptr; // initPyrThread checks to see if process has been started
     mProcess = newPyrProcess(g, mainProcessClass);
 
+    // don't call gc, as gc doesn't exist yet!
+    mStackOfExternalObjects = newPyrArray(g->gc, 32, 0, false);
+    mStackOfExternalObjects->size = 32;
+    for (size_t i { 0 }; i < 32; ++i) {
+        SetNil(mStackOfExternalObjects->slots + i);
+    }
+    mStackOfExternalObjects->classptr = class_array;
+
     mStack = slotRawObject(&slotRawThread(&mProcess->mainThread)->stack);
     ToBlack(mStack);
     SetNil(&slotRawThread(&mProcess->mainThread)->stack);
 
     mNumGrey = 0;
     ToGrey2(mProcess);
+    ToGrey(mStackOfExternalObjects);
     g->sp = mStack->slots - 1;
     g->process = mProcess;
     mRunning = true;
@@ -465,6 +474,43 @@ PyrObject* PyrGC::NewFinalizer(ObjFuncPtr finalizeFunc, PyrObject* inObject, boo
     return obj;
 }
 
+void PyrGC::StoreExternalObject(PyrObject* obj) {
+    for (size_t i { 0 }; i < mStackOfExternalObjects->size; ++i) {
+        if (IsNil(mStackOfExternalObjects->slots + i)) {
+            SetObject(mStackOfExternalObjects->slots + i, obj);
+            return;
+        }
+    }
+
+    // No free slots
+    const auto old_size = mStackOfExternalObjects->size;
+    assert(old_size != 0);
+    PyrObject* new_array = newPyrArray(this, old_size * 2, 0, true);
+    new_array->size = old_size * 2;
+    memcpy(new_array->slots, mStackOfExternalObjects->slots, sizeof(PyrSlot) * old_size);
+
+    // Here, we know mStackOfExternalObjects can't be referenced anywhere else, therefore it is safe to make it white.
+    // ToWhite(mStackOfExternalObjects);
+
+    mStackOfExternalObjects = new_array;
+    for (int i { old_size }; i < old_size * 2; ++i) {
+        SetNil(mStackOfExternalObjects->slots + i);
+    }
+    ToGrey(mStackOfExternalObjects);
+    SetObject(&mStackOfExternalObjects->slots[old_size], obj);
+}
+
+void PyrGC::RemoveExternalObject(PyrObject* obj) {
+    for (size_t i { 0 }; i < mStackOfExternalObjects->size; ++i) {
+        if (IsObj(&mStackOfExternalObjects->slots[i]) && slotRawObject(&mStackOfExternalObjects->slots[i]) == obj) {
+            SetNil(&mStackOfExternalObjects->slots[i]);
+            return;
+        }
+    }
+
+    throw std::runtime_error { "Could not find object in external object list" };
+}
+
 
 void PyrGC::SweepBigObjects() {
     if (!mCanSweep)
@@ -627,6 +673,7 @@ void PyrGC::Flip() {
     // move root to grey area
     mNumGrey = 0;
     ToGrey2(mProcess);
+    ToGrey(mStackOfExternalObjects);
 
     ToBlack(mStack);
 

--- a/lang/LangSource/GC.h
+++ b/lang/LangSource/GC.h
@@ -41,6 +41,8 @@ const int kNumGCSets = kNumGCSizeClasses + 1;
 const std::int64_t kScanThreshold = 256LL;
 
 
+void fatalerror(const char* str);
+
 class GCSet {
 public:
     GCSet() {}
@@ -91,6 +93,10 @@ public:
     bool ObjIsGrey(PyrObjectHdr* inObj) { return IsGrey(inObj); }
     bool ObjIsFree(PyrObjectHdr* inObj) { return IsFree(inObj); }
 
+    // External objects provide a mechanism for other threads to 'own' PyrObjects
+    // This is useful, for example, when storing a callback which will be called at a later date.
+    void StoreExternalObject(PyrObject* obj);
+    void RemoveExternalObject(PyrObject* obj);
 
     // general purpose write barriers:
     void GCWrite(PyrObjectHdr* inParent, PyrSlot* inSlot) {
@@ -216,6 +222,7 @@ private:
     GCSet mSets[kNumGCSets];
     PyrProcess* mProcess; // the root is the pyrprocess which contains this struct
     PyrObject* mStack;
+    PyrObject* mStackOfExternalObjects;
     PyrObject* mPartialScanObj;
     PyrObjectHdr mGrey;
 

--- a/lang/LangSource/GluonFFI.cpp
+++ b/lang/LangSource/GluonFFI.cpp
@@ -95,17 +95,20 @@ void sc_gluon::GluonManager::reset_or_prep_for_close() {
 }
 void sc_gluon::GluonManager::create_testing_library() { create_testing_library_v1(); }
 
-LibraryID sc_gluon::GluonManager::register_library(const char* path) noexcept(false) {
+LibraryID sc_gluon::GluonManager::register_library(const char* path, PyrSlot* first_parameter_slot,
+                                                   int num_parameters) noexcept(false) {
 #ifndef _WIN32
     void* library_handle = dlopen(path, RTLD_NOW | RTLD_LOCAL);
     if (library_handle == nullptr) {
         throw std::runtime_error { "Could not load library" };
     }
 
+    const auto close_library = [&]() { dlclose(library_handle); };
+
     void* version_f = dlsym(library_handle, "sc_gluon_version");
     const char* error = dlerror();
     if (error != nullptr || version_f == nullptr) {
-        dlclose(library_handle);
+        close_library();
         throw std::runtime_error { std::string { error } };
     }
 
@@ -118,26 +121,23 @@ LibraryID sc_gluon::GluonManager::register_library(const char* path) noexcept(fa
         throw std::runtime_error { "Could not load library" };
     }
 
+    const auto close_library = [&]() { FreeLibrary(library_handle); };
+
     void* version_f = (void*)GetProcAddress(library_handle, "sc_gluon_version");
     if (version_f == nullptr) {
-        FreeLibrary(library_handle);
+        close_library();
         throw std::runtime_error { "Could not load sc_gluon_version from library" };
     }
 
 #endif
 
-
     const sc_gluon_version_f version_func = (sc_gluon_version_f)version_f;
     const uint32_t version_v = version_func();
 
     if (version_v == 1) {
-        return register_library_v1(library_handle);
+        return register_library_v1(library_handle, first_parameter_slot, num_parameters);
     } else {
-#ifndef _WIN32
-        dlclose(library_handle);
-#else
-        FreeLibrary(library_handle);
-#endif
+        close_library();
         throw std::runtime_error { "Received unexpected version number for library." };
     }
 }

--- a/lang/LangSource/GluonFFI.cpp
+++ b/lang/LangSource/GluonFFI.cpp
@@ -1,0 +1,143 @@
+#include <cstring>
+#include <thread>
+#include <chrono>
+#include <filesystem>
+
+#include "GluonFFI.hpp"
+#include "VMGlobals.h"
+#include "GC.h"
+#include "PyrObject.h"
+#include "PyrKernel.h"
+#include "PyrSignal.h"
+#include "PyrSched.h"
+#include "PyrInterpreter.h"
+#include "PyrSlot.h"
+#include "PyrSymbolTable.h"
+
+
+#ifdef _WIN32
+#    include "SC_Win32Utils.h"
+#    include "SC_Codecvt.hpp"
+#else
+#    include <dlfcn.h>
+#endif
+
+using namespace sc_gluon;
+
+
+void* sc_gluon::details::LibraryV1::prepare_for_unload_return_handle() const {
+    if (unloader)
+        unloader(library_data);
+    return library_handle;
+}
+
+struct LibraryEvaluatorVisitor {
+    PyrSymbol* function_name;
+    struct VMGlobals* g;
+    PyrObject* maybe_callback;
+    PyrSlot *return_slot, *first_argument_slot;
+    int num_args_given;
+
+    template <typename T> void operator()(const T& t) const {
+        t.evaluate(function_name, g, maybe_callback, return_slot, first_argument_slot, num_args_given);
+    }
+};
+
+struct LibraryUnloaderVisitor {
+    template <typename T> void* operator()(const T& t) const { return t.prepare_for_unload_return_handle(); }
+};
+
+void GluonManager::evaluate_function(LibraryID library_id, PyrSymbol* function_name, VMGlobals* g,
+                                     PyrObject* maybe_callback, PyrSlot* return_slot, PyrSlot* first_argument_slot,
+                                     int num_args_given) const {
+    const auto& lib = libraries.at(library_id);
+    std::visit(
+        LibraryEvaluatorVisitor { function_name, g, maybe_callback, return_slot, first_argument_slot, num_args_given },
+        lib);
+}
+
+void sc_gluon::GluonManager::unregister_library_maybe_close(LibraryID library_id, bool close) noexcept(false) {
+    const auto& lib = libraries.at(library_id);
+    void* library_handle = std::visit(LibraryUnloaderVisitor {}, lib);
+
+    if (library_handle) {
+#ifndef _WIN32
+        const auto r = dlclose(library_handle);
+        const char* error = dlerror(); // discard error
+        if (close)
+            libraries.erase(library_id);
+        if (r != 0)
+            throw std::runtime_error { std::string { error } };
+#else
+        FreeLibrary((HMODULE)library_handle);
+        if (close)
+            libraries.erase(library_id);
+#endif
+    }
+
+    if (close)
+        libraries.erase(library_id);
+}
+
+LibraryID sc_gluon::GluonManager::get_inbuilt_library_id(PyrSymbol* name) const noexcept(false) {
+    return inbuilt_test_to_library_id.at(name);
+}
+
+void sc_gluon::GluonManager::reset_or_prep_for_close() {
+    for (const auto& [key, value] : libraries) {
+        try {
+            unregister_library_maybe_close(key, false);
+        } catch (...) {}
+    }
+    libraries = std::unordered_map<LibraryID, LibraryVariant> {};
+    inbuilt_test_to_library_id = std::unordered_map<PyrSymbol*, LibraryID> {};
+    library_counter = std::numeric_limits<LibraryID>::min();
+}
+void sc_gluon::GluonManager::create_testing_library() { create_testing_library_v1(); }
+
+LibraryID sc_gluon::GluonManager::register_library(const char* path) noexcept(false) {
+#ifndef _WIN32
+    void* library_handle = dlopen(path, RTLD_NOW | RTLD_LOCAL);
+    if (library_handle == nullptr) {
+        throw std::runtime_error { "Could not load library" };
+    }
+
+    void* version_f = dlsym(library_handle, "sc_gluon_version");
+    const char* error = dlerror();
+    if (error != nullptr || version_f == nullptr) {
+        dlclose(library_handle);
+        throw std::runtime_error { std::string { error } };
+    }
+
+#else
+    const std::string path_str { path };
+    const std::filesystem::path filename { path_str };
+
+    HINSTANCE library_handle = LoadLibraryW(filename.wstring().c_str());
+    if (!library_handle) {
+        throw std::runtime_error { "Could not load library" };
+    }
+
+    void* version_f = (void*)GetProcAddress(library_handle, "sc_gluon_version");
+    if (version_f == nullptr) {
+        FreeLibrary(library_handle);
+        throw std::runtime_error { "Could not load sc_gluon_version from library" };
+    }
+
+#endif
+
+
+    const sc_gluon_version_f version_func = (sc_gluon_version_f)version_f;
+    const uint32_t version_v = version_func();
+
+    if (version_v == 1) {
+        return register_library_v1(library_handle);
+    } else {
+#ifndef _WIN32
+        dlclose(library_handle);
+#else
+        FreeLibrary(library_handle);
+#endif
+        throw std::runtime_error { "Received unexpected version number for library." };
+    }
+}

--- a/lang/LangSource/GluonFFI.hpp
+++ b/lang/LangSource/GluonFFI.hpp
@@ -57,7 +57,8 @@ public:
                            PyrSlot* return_slot, PyrSlot* first_argument_slot, int num_args_given) const
         noexcept(false);
 
-    [[nodiscard]] LibraryID register_library(const char* path) noexcept(false);
+    [[nodiscard]] LibraryID register_library(const char* path, PyrSlot* first_parameter_slot,
+                                             int num_parameters) noexcept(false);
     void unregister_library(LibraryID lib) noexcept(false) { unregister_library_maybe_close(lib, true); };
 
     [[nodiscard]] LibraryID get_inbuilt_library_id(PyrSymbol*) const noexcept(false);
@@ -66,7 +67,8 @@ private: // create tests for all versions
     void create_testing_library_v1();
 
 private: // register libary versions
-    [[nodiscard]] LibraryID register_library_v1(void* library) noexcept(false);
+    [[nodiscard]] LibraryID register_library_v1(void* library, PyrSlot* first_parameter_slot,
+                                                int num_parameters) noexcept(false);
 
 private: // helpers
     void unregister_library_maybe_close(LibraryID, bool) noexcept(false);

--- a/lang/LangSource/GluonFFI.hpp
+++ b/lang/LangSource/GluonFFI.hpp
@@ -1,0 +1,81 @@
+// Author Jordan Henderson - JordanHendersonMusic
+#pragma once
+#include <memory>
+#include <limits>
+#include <unordered_map>
+#include <optional>
+#include <vector>
+#include <variant>
+
+#include "sc_gluon_v1_types.h"
+
+#include "PyrSlot.h"
+
+struct PyrObject;
+struct VMGlobals;
+struct PyrSymbol;
+
+namespace sc_gluon {
+
+using LibraryID = int32_t;
+
+namespace details {
+struct FunctionDataV1 {
+    sc_gluon_function_v1_f ptr;
+    int32_t num_params;
+    bool accepts_callback;
+    bool accepts_variable_params() const { return num_params < 0; }
+};
+struct LibraryV1 {
+    void* library_handle { nullptr };
+    sc_gluon_library_data_v1_t library_data { nullptr };
+    sc_gluon_unload_library_v1_f unloader { nullptr };
+
+    std::vector<PyrSymbol*> function_names {};
+    std::vector<FunctionDataV1> function_data {};
+
+    void evaluate(PyrSymbol* function_name, VMGlobals* g, PyrObject* maybe_callback, PyrSlot* return_slot,
+                  PyrSlot* first_argument_slot, int num_args_given) const;
+
+    void* prepare_for_unload_return_handle() const;
+};
+}
+
+class GluonManager {
+public:
+    GluonManager() = default;
+    GluonManager(GluonManager&&) noexcept = delete;
+    GluonManager& operator=(GluonManager&&) noexcept = delete;
+    GluonManager(const GluonManager&) = delete;
+    GluonManager& operator=(const GluonManager&) = delete;
+
+    void reset_or_prep_for_close();
+    void create_testing_library();
+
+    // Callback only works if the ffi functions expects a callback.
+    void evaluate_function(LibraryID library_id, PyrSymbol* function_name, VMGlobals* g, PyrObject* maybe_callback,
+                           PyrSlot* return_slot, PyrSlot* first_argument_slot, int num_args_given) const
+        noexcept(false);
+
+    [[nodiscard]] LibraryID register_library(const char* path) noexcept(false);
+    void unregister_library(LibraryID lib) noexcept(false) { unregister_library_maybe_close(lib, true); };
+
+    [[nodiscard]] LibraryID get_inbuilt_library_id(PyrSymbol*) const noexcept(false);
+
+private: // create tests for all versions
+    void create_testing_library_v1();
+
+private: // register libary versions
+    [[nodiscard]] LibraryID register_library_v1(void* library) noexcept(false);
+
+private: // helpers
+    void unregister_library_maybe_close(LibraryID, bool) noexcept(false);
+
+private: // private members
+    using LibraryVariant = std::variant<details::LibraryV1>;
+    std::unordered_map<LibraryID, LibraryVariant> libraries {};
+    std::unordered_map<PyrSymbol*, LibraryID> inbuilt_test_to_library_id;
+    LibraryID library_counter = std::numeric_limits<LibraryID>::min();
+};
+
+}

--- a/lang/LangSource/GluonFFIV1.cpp
+++ b/lang/LangSource/GluonFFIV1.cpp
@@ -15,6 +15,8 @@
 #include "PyrSlot.h"
 #include "PyrSymbolTable.h"
 
+#include "cpp/sc_gluon_v1_util.hpp"
+
 
 #ifdef _WIN32
 #    include "SC_Win32Utils.h"
@@ -24,10 +26,11 @@
 #endif
 
 using namespace sc_gluon;
+
 sc_gluon_param_v1_t slot_to_param(PyrSlot slot);
 PyrSlot move_param_to_slot(sc_gluon_param_v1_t&& param, VMGlobals* g) noexcept;
 
-void sc_gluon_callback_action_v1(void* callback_data, sc_gluon_param_v1_t* params, uint32_t num_params) {
+void do_callback(void* callback_data, sc_gluon_param_v1_t* params, uint32_t num_params) {
     assert(num_params > 0 ? (params != nullptr) : params == nullptr);
     if (callback_data == nullptr)
         return;
@@ -56,7 +59,7 @@ void sc_gluon_callback_action_v1(void* callback_data, sc_gluon_param_v1_t* param
     }
 }
 
-void sc_gluon_release_callback_object_v1(void* callback_data) {
+void release_callback(void* callback_data) {
     extern bool compiledOK;
 
     using namespace std::chrono_literals;
@@ -72,134 +75,45 @@ void sc_gluon_release_callback_object_v1(void* callback_data) {
     }
 }
 
-
-// Because MSVC doesn't support designated initializers, unions are annoying to initialise.
-// Here are a bunch of helpers.
-
-namespace sc_gluon::v1 {
-
-using param = sc_gluon_param_v1_t;
-using data = sc_gluon_data_v1;
-
-param priv_basic(sc_gluon_data_v1 data, sc_gluon_param_tag_v1 tag) { return { data, 1, tag, false }; }
-param priv_array(sc_gluon_data_v1 data, sc_gluon_param_tag_v1 tag, uint32_t size, bool owns_data) {
-    return { data, size, tag, owns_data };
-}
-
-param nil_() {
-    data d;
-    d.nil_ = {};
-    return priv_basic(d, sc_gluon_nil);
-}
-
-param i32(int32_t i) {
-    data d;
-    d.i32 = i;
-    return priv_basic(d, sc_gluon_i32);
-}
-
-param f64(double f) {
-    data d;
-    d.f64 = f;
-    return priv_basic(d, sc_gluon_f64);
-}
-
-param character(char c) {
-    data d;
-    d.character = c;
-    return priv_basic(d, sc_gluon_char);
-}
-
-param boolean(bool b) {
-    data d;
-    d.boolean = b;
-    return priv_basic(d, sc_gluon_bool);
-}
-
-param raw_pointer(void* p) {
-    data d;
-    d.raw_pointer = p;
-    return priv_basic(d, sc_gluon_raw_pointer);
-}
-
-param symbol_value(uint64_t s) {
-    data d;
-    d.symbol_value = s;
-    return priv_basic(d, sc_gluon_symbol_value);
-}
-
-param u8_array(uint8_t* a, uint32_t size, bool owns_data) {
-    data d;
-    d.u8_array = a;
-    return priv_array(d, sc_gluon_u8_array, size, owns_data);
-}
-
-param f64_array(double* a, uint32_t size, bool owns_data) {
-    data d;
-    d.f64_array = a;
-    return priv_array(d, sc_gluon_f64_array, size, owns_data);
-}
-
-param f32_array(float* a, uint32_t size, bool owns_data) {
-    data d;
-    d.f32_array = a;
-    return priv_array(d, sc_gluon_f32_array, size, owns_data);
-}
-
-param character_array(char* a, uint32_t size, bool owns_data) {
-    data d;
-    d.character_array = a;
-    return priv_array(d, sc_gluon_char_array, size, owns_data);
-}
-
-
-param param_array(param* a, uint32_t size, bool owns_data) {
-    data d;
-    d.param_array = a;
-    return priv_array(d, sc_gluon_param_array, size, owns_data);
-}
-}
-
-
 sc_gluon_param_v1_t slot_to_param(PyrSlot slot) {
     if (IsNil(&slot)) {
-        return v1::nil_();
+        return v1::create_param();
     } else if (IsInt(&slot)) {
-        return v1::i32(slotRawInt(&slot));
+        return v1::create_param(slotRawInt(&slot));
     } else if (IsFloat(&slot)) {
-        return v1::f64(slotRawFloat(&slot));
+        return v1::create_param(slotRawFloat(&slot));
     } else if (IsChar(&slot)) {
-        return v1::character(static_cast<char>(slotRawChar(&slot)));
+        return v1::create_param(static_cast<char>(slotRawChar(&slot)));
     } else if (IsPtr(&slot)) {
-        return v1::raw_pointer(slotRawPtr(&slot));
+        return v1::create_param(slotRawPtr(&slot));
     } else if (IsTrue(&slot)) {
-        return v1::boolean(true);
+        return v1::create_param(true);
     } else if (IsFalse(&slot)) {
-        return v1::boolean(false);
+        return v1::create_param(false);
     } else if (IsSym(&slot)) {
         const auto i = reinterpret_cast<intptr_t>(slotRawSymbol(&slot));
-        return v1::symbol_value(static_cast<uint64_t>(i));
+        return v1::create_param(static_cast<uint64_t>(i));
     } else if (IsObj(&slot)) {
         PyrObject* obj { slotRawObject(&slot) };
         if (obj->classptr == class_string) {
             if (obj->IsImmutable()) {
                 auto* str = reinterpret_cast<PyrString*>(obj);
-                return v1::character_array(str->s, static_cast<uint32_t>(str->size), false);
+                return v1::create_param(str->s, static_cast<uint32_t>(str->size), false);
             } else {
                 auto* str = reinterpret_cast<PyrString*>(obj);
                 char* ptr = (char*)malloc(str->size * sizeof(char));
                 std::memcpy(ptr, str->s, str->size * sizeof(char));
-                return v1::character_array(ptr, static_cast<uint32_t>(str->size), true);
+                return v1::create_param(ptr, static_cast<uint32_t>(str->size), true);
             }
         } else if (obj->classptr == class_int8array) {
             auto* u8array = reinterpret_cast<PyrInt8Array*>(obj);
-            return v1::u8_array(u8array->b, static_cast<uint32_t>(u8array->size), false);
+            return v1::create_param(u8array->b, static_cast<uint32_t>(u8array->size), false);
         } else if (obj->classptr == class_doublearray) {
             auto* f64array = reinterpret_cast<PyrDoubleArray*>(obj);
-            return v1::f64_array(f64array->d, static_cast<uint32_t>(f64array->size), false);
+            return v1::create_param(f64array->d, static_cast<uint32_t>(f64array->size), false);
         } else if (obj->classptr == class_floatarray) {
             auto* f32array = reinterpret_cast<PyrFloatArray*>(obj);
-            return v1::f32_array(f32array->f, static_cast<uint32_t>(f32array->size), false);
+            return v1::create_param(f32array->f, static_cast<uint32_t>(f32array->size), false);
         } else if (obj->classptr == class_array) {
             sc_gluon_param_v1_t* param_array = (sc_gluon_param_v1_t*)malloc(sizeof(sc_gluon_param_v1_t) * obj->size);
             if (param_array == nullptr)
@@ -214,7 +128,7 @@ sc_gluon_param_v1_t slot_to_param(PyrSlot slot) {
                 throw;
             }
 
-            return v1::param_array(param_array, static_cast<uint32_t>(obj->size), true);
+            return v1::create_param(param_array, static_cast<uint32_t>(obj->size), true);
         } else {
             throw std::runtime_error { "Cannot convert slot to sc_gluon_param_v1_t" };
         }
@@ -304,7 +218,87 @@ PyrSlot move_param_to_slot(sc_gluon_param_v1_t&& param, VMGlobals* g) noexcept {
     return out;
 }
 
-void free_param(sc_gluon_param_v1_t&& param) noexcept(true) { sc_gluon_free_param_v1(param); }
+LibraryID sc_gluon::GluonManager::register_library_v1(void* library_handle, PyrSlot* first_parameter_slot,
+                                                      int num_parameters) noexcept(false) {
+#ifndef _WIN32
+    const void* loader_f = dlsym(library_handle, "sc_gluon_load_library");
+    const char* load_error = dlerror();
+    if (load_error != nullptr || loader_f == nullptr) {
+        dlclose(library_handle);
+        throw std::runtime_error { std::string { load_error } };
+    }
+
+    const void* unloader_f = dlsym(library_handle, "sc_gluon_unload_library");
+    const void* post_load_p = dlsym(library_handle, "sc_gluon_post_load_library");
+
+    const auto close_library = [=]() { dlclose(library_handle); };
+#else
+    const void* loader_f = (void*)GetProcAddress((HMODULE)library_handle, "sc_gluon_load_library");
+    if (loader_f == nullptr) {
+        FreeLibrary((HMODULE)library_handle);
+        throw std::runtime_error { "Could not load sc_gluon_load_library" };
+    }
+
+    const void* unloader_f = (void*)GetProcAddress((HMODULE)library_handle, "sc_gluon_unload_library");
+    const void* post_load_p = (void*)GetProcAddress((HMODULE)library_handle, "sc_gluon_post_load_library");
+
+    const auto close_library = [=]() { FreeLibrary((HMODULE)library_handle); };
+
+#endif
+    const auto loader = (sc_gluon_load_library_v1_f)loader_f;
+    const sc_gluon_unload_library_v1_f unloader = (sc_gluon_unload_library_v1_f)unloader_f;
+    const sc_gluon_post_load_library_v1_f post_loader = (sc_gluon_post_load_library_v1_f)post_load_p;
+
+    sc_gluon_function_declarations_v1_t* func_decls; // uninitialised
+    uint32_t func_decls_size { 0 };
+
+    std::vector<sc_gluon_param_v1_t> params;
+    params.reserve(num_parameters);
+
+    const auto destroy_params = [](std::vector<sc_gluon_param_v1_t>&& ps) {
+        for (sc_gluon_param_v1_t p : ps)
+            if (p.owns_data)
+                sc_gluon_free_param_if_owned_v1(p);
+    };
+
+    for (uint32_t i { 0 }; i < (num_parameters); ++i) {
+        params.push_back(slot_to_param(*first_parameter_slot));
+        ++first_parameter_slot;
+    }
+
+    sc_gluon_library_data_v1_t library_data;
+    const auto error_code = loader(params.data(), static_cast<uint32_t>(params.size()), do_callback, release_callback,
+                                   &func_decls, &func_decls_size, &library_data);
+
+    destroy_params(std::move(params));
+
+    if (error_code) {
+        close_library();
+        throw std::runtime_error { "Failed to load functions from library" };
+    }
+
+    std::vector<PyrSymbol*> function_names;
+    std::vector<details::FunctionDataV1> function_data;
+
+    for (uint32_t i { 0 }; i < func_decls_size; ++i) {
+        const auto decl = func_decls[i];
+        function_names.push_back(getsym(decl.name));
+        function_data.emplace_back(
+            details::FunctionDataV1 { decl.ptr, decl.num_parms, static_cast<bool>(decl.accepts_callback) });
+    }
+
+    if (post_loader) {
+        post_loader(library_data, func_decls, func_decls_size);
+    }
+
+    const LibraryID library_id = library_counter++;
+    libraries.emplace(library_id,
+                      LibraryVariant { details::LibraryV1 { library_handle, library_data, unloader,
+                                                            std::move(function_names), std::move(function_data) } });
+
+    return library_id;
+}
+
 
 void details::LibraryV1::evaluate(PyrSymbol* function_name, VMGlobals* g, PyrObject* maybe_callback,
                                   PyrSlot* return_slot, PyrSlot* first_argument_slot, int num_args_given) const {
@@ -330,7 +324,7 @@ void details::LibraryV1::evaluate(PyrSymbol* function_name, VMGlobals* g, PyrObj
     const auto destroy_params = [](std::vector<sc_gluon_param_v1_t>&& ps) {
         for (sc_gluon_param_v1_t p : ps)
             if (p.owns_data)
-                free_param(std::move(p));
+                sc_gluon_free_param_if_owned_v1(p);
     };
 
     for (uint32_t i { 0 }; i < (num_args_given); ++i) {
@@ -338,13 +332,11 @@ void details::LibraryV1::evaluate(PyrSymbol* function_name, VMGlobals* g, PyrObj
         ++first_argument_slot;
     }
 
-    bool stored_callback = false;
     if (maybe_callback != nullptr) {
         if (!data.accepts_callback) {
             destroy_params(std::move(params));
             throw std::runtime_error { "A callback was given to an FFI function that doesn't accepts callbacks." };
         }
-        stored_callback = true;
         g->gc->StoreExternalObject(maybe_callback);
     }
 
@@ -363,31 +355,20 @@ void details::LibraryV1::evaluate(PyrSymbol* function_name, VMGlobals* g, PyrObj
         SetNil(return_slot);
         std::string error { result.maybe_diagnostic };
         free((void*)result.maybe_diagnostic);
-
-        if (stored_callback)
-            g->gc->RemoveExternalObject(maybe_callback);
-
         throw std::runtime_error { error };
     }
     case sc_gluon_error_with_non_owned_diagnostic: {
         SetNil(return_slot);
-        if (stored_callback)
-            g->gc->RemoveExternalObject(maybe_callback);
-
         throw std::runtime_error { std::string { result.maybe_diagnostic } };
-    }
-    case sc_gluon_error_without_diagnostic: {
-        SetNil(return_slot);
-        if (stored_callback)
-            g->gc->RemoveExternalObject(maybe_callback);
-
-        throw std::runtime_error { "FFI function did not complete" };
     }
     }
 }
 
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// TESTING
+
 sc_gluon_out_param_tag_v1 test1(sc_gluon_library_data_v1_t library_data,
-                                sc_gluon_callable_object_v1_t maybe_callback_data, sc_gluon_param_v1_t* in_params,
+                                sc_gluon_callback_object_v1_t maybe_callback_data, sc_gluon_param_v1_t* in_params,
                                 uint32_t num_in_params, sc_gluon_out_param_or_maybe_diagnostic_v1* out_param) {
     if (num_in_params != 2) {
         out_param->maybe_diagnostic = "wrong number of in params";
@@ -418,7 +399,7 @@ sc_gluon_out_param_tag_v1 test1(sc_gluon_library_data_v1_t library_data,
 }
 
 sc_gluon_out_param_tag_v1 callback_test(sc_gluon_library_data_v1_t library_data,
-                                        sc_gluon_callable_object_v1_t maybe_callback_data,
+                                        sc_gluon_callback_object_v1_t maybe_callback_data,
                                         sc_gluon_param_v1_t* in_params, uint32_t num_in_params,
                                         sc_gluon_out_param_or_maybe_diagnostic_v1* out_param) {
     if (num_in_params != 1) {
@@ -440,8 +421,8 @@ sc_gluon_out_param_tag_v1 callback_test(sc_gluon_library_data_v1_t library_data,
     std::thread([=]() {
         std::this_thread::sleep_for(std::chrono::duration<double>(wait));
         if (maybe_callback_data) {
-            sc_gluon_callback_action_v1(maybe_callback_data, nullptr, 0);
-            sc_gluon_release_callback_object_v1(maybe_callback_data);
+            do_callback(maybe_callback_data, nullptr, 0);
+            release_callback(maybe_callback_data);
         }
     }).detach();
 
@@ -455,7 +436,7 @@ sc_gluon_out_param_tag_v1 callback_test(sc_gluon_library_data_v1_t library_data,
 }
 
 sc_gluon_out_param_tag_v1 many_callback_test(sc_gluon_library_data_v1_t library_data,
-                                             sc_gluon_callable_object_v1_t maybe_callback_data,
+                                             sc_gluon_callback_object_v1_t maybe_callback_data,
                                              sc_gluon_param_v1_t* in_params, uint32_t num_in_params,
                                              sc_gluon_out_param_or_maybe_diagnostic_v1* out_param) {
     if (num_in_params != 2) {
@@ -486,10 +467,10 @@ sc_gluon_out_param_tag_v1 many_callback_test(sc_gluon_library_data_v1_t library_
         for (size_t i { 0 }; i < iter; ++i) {
             std::this_thread::sleep_for(std::chrono::duration<double>(wait));
             if (maybe_callback_data) {
-                sc_gluon_callback_action_v1(maybe_callback_data, nullptr, 0);
+                do_callback(maybe_callback_data, nullptr, 0);
             }
         }
-        sc_gluon_release_callback_object_v1(maybe_callback_data);
+        release_callback(maybe_callback_data);
     }).detach();
 
 
@@ -503,7 +484,7 @@ sc_gluon_out_param_tag_v1 many_callback_test(sc_gluon_library_data_v1_t library_
 
 
 sc_gluon_out_param_tag_v1 callback_with_args_test(sc_gluon_library_data_v1_t library_data,
-                                                  sc_gluon_callable_object_v1_t maybe_callback_data,
+                                                  sc_gluon_callback_object_v1_t maybe_callback_data,
                                                   sc_gluon_param_v1_t* in_params, uint32_t num_in_params,
                                                   sc_gluon_out_param_or_maybe_diagnostic_v1* out_param) {
     if (num_in_params != 1) {
@@ -535,8 +516,8 @@ sc_gluon_out_param_tag_v1 callback_with_args_test(sc_gluon_library_data_v1_t lib
         ps[1].size = 1;
         ps[1].tag = sc_gluon_bool;
         if (maybe_callback_data) {
-            sc_gluon_callback_action_v1(maybe_callback_data, ps, 2);
-            sc_gluon_release_callback_object_v1(maybe_callback_data);
+            do_callback(maybe_callback_data, ps, 2);
+            release_callback(maybe_callback_data);
         }
     }).detach();
 
@@ -550,7 +531,7 @@ sc_gluon_out_param_tag_v1 callback_with_args_test(sc_gluon_library_data_v1_t lib
 }
 
 sc_gluon_out_param_tag_v1 array_sum(sc_gluon_library_data_v1_t library_data,
-                                    sc_gluon_callable_object_v1_t maybe_callback_data, sc_gluon_param_v1_t* in_params,
+                                    sc_gluon_callback_object_v1_t maybe_callback_data, sc_gluon_param_v1_t* in_params,
                                     uint32_t num_in_params, sc_gluon_out_param_or_maybe_diagnostic_v1* out_param) {
     if (num_in_params != 1) {
         out_param->maybe_diagnostic = "wrong number of in params";
@@ -586,7 +567,7 @@ sc_gluon_out_param_tag_v1 array_sum(sc_gluon_library_data_v1_t library_data,
 }
 
 sc_gluon_out_param_tag_v1 return_array_test(sc_gluon_library_data_v1_t library_data,
-                                            sc_gluon_callable_object_v1_t maybe_callback_data,
+                                            sc_gluon_callback_object_v1_t maybe_callback_data,
                                             sc_gluon_param_v1_t* in_params, uint32_t num_in_params,
                                             sc_gluon_out_param_or_maybe_diagnostic_v1* out_param) {
     out_param->out_param.data.param_array = new sc_gluon_param_v1_t[10] {};
@@ -630,66 +611,4 @@ void sc_gluon::GluonManager::create_testing_library_v1() {
 
     libraries.emplace(test_id, LibraryVariant { std::move(lib) });
     inbuilt_test_to_library_id.emplace(getsym("gluonTestV1"), test_id);
-}
-
-
-LibraryID sc_gluon::GluonManager::register_library_v1(void* library_handle) noexcept(false) {
-#ifndef _WIN32
-    const void* loader_f = dlsym(library_handle, "sc_gluon_load_library");
-    const char* load_error = dlerror();
-    if (load_error != nullptr || loader_f == nullptr) {
-        dlclose(library_handle);
-        throw std::runtime_error { std::string { load_error } };
-    }
-
-    const void* unloader_f = dlsym(library_handle, "sc_gluon_unload_library");
-    const void* post_load_p = dlsym(library_handle, "sc_gluon_post_load_library");
-
-    const auto close_library = [=]() { dlclose(library_handle); };
-#else
-    const void* loader_f = (void*)GetProcAddress((HMODULE)library_handle, "sc_gluon_load_library");
-    if (loader_f == nullptr) {
-        FreeLibrary((HMODULE)library_handle);
-        throw std::runtime_error { "Could not load sc_gluon_load_library" };
-    }
-
-    const void* unloader_f = (void*)GetProcAddress((HMODULE)library_handle, "sc_gluon_unload_library");
-    const void* post_load_p = (void*)GetProcAddress((HMODULE)library_handle, "sc_gluon_post_load_library");
-
-    const auto close_library = [=]() { FreeLibrary((HMODULE)library_handle); };
-
-#endif
-    const auto loader = (sc_gluon_load_library_v1_f)loader_f;
-    const sc_gluon_unload_library_v1_f unloader = (sc_gluon_unload_library_v1_f)unloader_f;
-    const sc_gluon_post_load_library_v1_f post_loader = (sc_gluon_post_load_library_v1_f)post_load_p;
-
-    sc_gluon_function_declarations_v1_t* func_decls; // uninitialised
-    uint32_t func_decls_size { 0 };
-
-    sc_gluon_library_data_v1_t library_data =
-        loader(sc_gluon_callback_action_v1, sc_gluon_release_callback_object_v1, &func_decls, &func_decls_size);
-    if (func_decls_size == 0) {
-        close_library();
-        throw std::runtime_error { "Failed to load functions from library" };
-    }
-
-    std::vector<PyrSymbol*> function_names;
-    std::vector<details::FunctionDataV1> function_data;
-
-    for (uint32_t i { 0 }; i < func_decls_size; ++i) {
-        const auto decl = func_decls[i];
-        function_names.push_back(getsym(decl.name));
-        function_data.emplace_back(details::FunctionDataV1 { decl.ptr, decl.num_parms, decl.accepts_callback });
-    }
-
-    if (post_loader) {
-        post_loader(library_data, func_decls, func_decls_size);
-    }
-
-    const LibraryID library_id = library_counter++;
-    libraries.emplace(library_id,
-                      LibraryVariant { details::LibraryV1 { library_handle, library_data, unloader,
-                                                            std::move(function_names), std::move(function_data) } });
-
-    return library_id;
 }

--- a/lang/LangSource/GluonFFIV1.cpp
+++ b/lang/LangSource/GluonFFIV1.cpp
@@ -105,7 +105,7 @@ param raw_pointer(void* p) {
     return priv_basic(d, sc_gluon_raw_pointer);
 }
 
-param symbol_value(intptr_t s) {
+param symbol_value(uint64_t s) {
     data d;
     d.symbol_value = s;
     return priv_basic(d, sc_gluon_symbol_value);
@@ -135,11 +135,6 @@ param character_array(char* a, uint32_t size, bool owns_data) {
     return priv_array(d, sc_gluon_char_array, size, owns_data);
 }
 
-param symbol_value_array(intptr_t* a, uint32_t size, bool owns_data) {
-    data d;
-    d.symbol_value_array = a;
-    return priv_array(d, sc_gluon_symbol_value_array, size, owns_data);
-}
 
 param param_array(param* a, uint32_t size, bool owns_data) {
     data d;
@@ -165,13 +160,20 @@ sc_gluon_param_v1_t slot_to_param(PyrSlot slot) {
     } else if (IsFalse(&slot)) {
         return v1::boolean(false);
     } else if (IsSym(&slot)) {
-        return v1::symbol_value(reinterpret_cast<intptr_t>(slotRawSymbol(&slot)));
+        const auto i = reinterpret_cast<intptr_t>(slotRawSymbol(&slot));
+        return v1::symbol_value(static_cast<uint64_t>(i));
     } else if (IsObj(&slot)) {
         PyrObject* obj { slotRawObject(&slot) };
         if (obj->classptr == class_string) {
-            auto* str = reinterpret_cast<PyrString*>(obj);
-            return v1::character_array(str->s, static_cast<uint32_t>(str->size), false);
-
+            if (obj->IsImmutable()) {
+                auto* str = reinterpret_cast<PyrString*>(obj);
+                return v1::character_array(str->s, static_cast<uint32_t>(str->size), false);
+            } else {
+                auto* str = reinterpret_cast<PyrString*>(obj);
+                char* ptr = (char*)malloc(str->size * sizeof(char));
+                std::memcpy(ptr, str->s, str->size * sizeof(char));
+                return v1::character_array(ptr, static_cast<uint32_t>(str->size), true);
+            }
         } else if (obj->classptr == class_int8array) {
             auto* u8array = reinterpret_cast<PyrInt8Array*>(obj);
             return v1::u8_array(u8array->b, static_cast<uint32_t>(u8array->size), false);
@@ -181,10 +183,6 @@ sc_gluon_param_v1_t slot_to_param(PyrSlot slot) {
         } else if (obj->classptr == class_floatarray) {
             auto* f32array = reinterpret_cast<PyrFloatArray*>(obj);
             return v1::f32_array(f32array->f, static_cast<uint32_t>(f32array->size), false);
-        } else if (obj->classptr == class_symbolarray) {
-            auto* symarray = reinterpret_cast<PyrSymbolArray*>(obj);
-            return v1::symbol_value_array(reinterpret_cast<intptr_t*>(symarray->symbols),
-                                          static_cast<uint32_t>(symarray->size), false);
         } else if (obj->classptr == class_array) {
             sc_gluon_param_v1_t* param_array = (sc_gluon_param_v1_t*)malloc(sizeof(sc_gluon_param_v1_t) * obj->size);
             if (param_array == nullptr)
@@ -203,7 +201,6 @@ sc_gluon_param_v1_t slot_to_param(PyrSlot slot) {
         } else {
             throw std::runtime_error { "Cannot convert slot to sc_gluon_param_v1_t" };
         }
-        //
     } else {
         throw std::runtime_error { "Cannot convert slot to sc_gluon_param_v1_t" };
     }
@@ -240,7 +237,8 @@ PyrSlot move_param_to_slot(sc_gluon_param_v1_t&& param, VMGlobals* g) noexcept {
         break;
     }
     case sc_gluon_symbol_value: {
-        SetSymbol(&out, (PyrSymbol*)param.data.symbol_value);
+        const auto v = static_cast<intptr_t>(param.data.symbol_value);
+        SetSymbol(&out, reinterpret_cast<PyrSymbol*>(v));
         break;
     }
     case sc_gluon_u8_array: {
@@ -272,14 +270,6 @@ PyrSlot move_param_to_slot(sc_gluon_param_v1_t&& param, VMGlobals* g) noexcept {
         auto new_array = newPyrString(g->gc, param.data.character_array, 0, false);
         if (param.owns_data)
             free(param.data.character_array);
-        SetObject(&out, new_array);
-        break;
-    }
-    case sc_gluon_symbol_value_array: {
-        auto new_array = newPyrSymbolArray(g->gc, param.size, 0, false);
-        std::memcpy(new_array->symbols, (PyrSymbol*)param.data.symbol_value_array, param.size * sizeof(PyrSymbol*));
-        if (param.owns_data)
-            free(param.data.symbol_value_array);
         SetObject(&out, new_array);
         break;
     }

--- a/lang/LangSource/GluonFFIV1.cpp
+++ b/lang/LangSource/GluonFFIV1.cpp
@@ -2,6 +2,7 @@
 #include <thread>
 #include <chrono>
 #include <filesystem>
+#include <iostream>
 
 #include "GluonFFI.hpp"
 #include "VMGlobals.h"
@@ -32,28 +33,43 @@ void sc_gluon_callback_action_v1(void* callback_data, sc_gluon_param_v1_t* param
         return;
 
     extern bool compiledOK;
-    std::lock_guard lock_guard { gLangMutex };
-    VMGlobals* g { gMainVMGlobals };
-    auto* obj { reinterpret_cast<PyrObject*>(callback_data) };
 
-    if (compiledOK) {
-        ++g->sp;
-        SetObject(g->sp, obj);
-        for (uint32_t i { 0 }; i < num_params; ++i) {
-            PyrSlot slot = move_param_to_slot(std::move(params[i]), g);
+    using namespace std::chrono_literals;
+    const bool locked = gLangMutex.try_lock_for(10s);
+    if (locked) {
+        VMGlobals* g { gMainVMGlobals };
+        auto* obj { reinterpret_cast<PyrObject*>(callback_data) };
+        if (compiledOK) {
             ++g->sp;
-            *g->sp = slot;
+            SetObject(g->sp, obj);
+            for (uint32_t i { 0 }; i < num_params; ++i) {
+                PyrSlot slot = move_param_to_slot(std::move(params[i]), g);
+                ++g->sp;
+                *g->sp = slot;
+            }
+            runInterpreter(g, s_value, 1 + num_params);
         }
-        runInterpreter(g, s_value, 1 + num_params);
+        gLangMutex.unlock();
+    } else {
+        std::cerr << "Gluon ffi library could not establish language lock, ensure callbacks are only triggered on a "
+                     "separate thread to the main callback function.";
     }
 }
 
 void sc_gluon_release_callback_object_v1(void* callback_data) {
     extern bool compiledOK;
-    std::lock_guard lock_guard { gLangMutex };
-    VMGlobals* g { gMainVMGlobals };
-    auto* obj { reinterpret_cast<PyrObject*>(callback_data) };
-    g->gc->RemoveExternalObject(obj);
+
+    using namespace std::chrono_literals;
+    const bool locked = gLangMutex.try_lock_for(10s);
+    if (locked) {
+        VMGlobals* g { gMainVMGlobals };
+        auto* obj { reinterpret_cast<PyrObject*>(callback_data) };
+        g->gc->RemoveExternalObject(obj);
+        gLangMutex.unlock();
+    } else {
+        std::cerr << "Gluon ffi library could not establish language lock, ensure callbacks are only release on a "
+                     "separate thread to the main callback function.";
+    }
 }
 
 
@@ -61,6 +77,7 @@ void sc_gluon_release_callback_object_v1(void* callback_data) {
 // Here are a bunch of helpers.
 
 namespace sc_gluon::v1 {
+
 using param = sc_gluon_param_v1_t;
 using data = sc_gluon_data_v1;
 

--- a/lang/LangSource/GluonFFIV1.cpp
+++ b/lang/LangSource/GluonFFIV1.cpp
@@ -1,0 +1,608 @@
+#include <cstring>
+#include <thread>
+#include <chrono>
+#include <filesystem>
+
+#include "GluonFFI.hpp"
+#include "VMGlobals.h"
+#include "GC.h"
+#include "PyrObject.h"
+#include "PyrKernel.h"
+#include "PyrSignal.h"
+#include "PyrSched.h"
+#include "PyrInterpreter.h"
+#include "PyrSlot.h"
+#include "PyrSymbolTable.h"
+
+
+#ifdef _WIN32
+#    include "SC_Win32Utils.h"
+#    include "SC_Codecvt.hpp"
+#else
+#    include <dlfcn.h>
+#endif
+
+using namespace sc_gluon;
+sc_gluon_param_v1_t slot_to_param(PyrSlot slot);
+PyrSlot move_param_to_slot(sc_gluon_param_v1_t&& param, VMGlobals* g) noexcept;
+
+void sc_gluon_callback_action_v1(void* callback_data, sc_gluon_param_v1_t* params, uint32_t num_params) {
+    assert(num_params > 0 ? (params != nullptr) : params == nullptr);
+    if (callback_data == nullptr)
+        return;
+
+    extern bool compiledOK;
+    std::lock_guard lock_guard { gLangMutex };
+    VMGlobals* g { gMainVMGlobals };
+    auto* obj { reinterpret_cast<PyrObject*>(callback_data) };
+
+    if (compiledOK) {
+        ++g->sp;
+        SetObject(g->sp, obj);
+        for (uint32_t i { 0 }; i < num_params; ++i) {
+            PyrSlot slot = move_param_to_slot(std::move(params[i]), g);
+            ++g->sp;
+            *g->sp = slot;
+        }
+        runInterpreter(g, s_value, 1 + num_params);
+    }
+}
+
+void sc_gluon_release_callback_object_v1(void* callback_data) {
+    extern bool compiledOK;
+    std::lock_guard lock_guard { gLangMutex };
+    VMGlobals* g { gMainVMGlobals };
+    auto* obj { reinterpret_cast<PyrObject*>(callback_data) };
+    g->gc->RemoveExternalObject(obj);
+}
+
+
+sc_gluon_param_v1_t slot_to_param(PyrSlot slot) {
+    if (IsNil(&slot)) {
+        return sc_gluon_param_v1_t { sc_gluon_data_v1 { .nil_ = 0 }, sc_gluon_nil, false, 1 };
+    } else if (IsInt(&slot)) {
+        return sc_gluon_param_v1_t { sc_gluon_data_v1 { .i32 = slotRawInt(&slot) }, sc_gluon_i32, false, 1 };
+    } else if (IsFloat(&slot)) {
+        return sc_gluon_param_v1_t { sc_gluon_data_v1 { .f64 = slotRawFloat(&slot) }, sc_gluon_f64, false, 1 };
+    } else if (IsChar(&slot)) {
+        return sc_gluon_param_v1_t { sc_gluon_data_v1 { .character = static_cast<char>(slotRawChar(&slot)) },
+                                     sc_gluon_char, false, 1 };
+    } else if (IsPtr(&slot)) {
+        return sc_gluon_param_v1_t { sc_gluon_data_v1 { .raw_pointer = slotRawPtr(&slot) }, sc_gluon_raw_pointer, false,
+                                     1 };
+    } else if (IsTrue(&slot)) {
+        return sc_gluon_param_v1_t { sc_gluon_data_v1 { .boolean = true }, sc_gluon_bool, false, 1 };
+    } else if (IsFalse(&slot)) {
+        return sc_gluon_param_v1_t { sc_gluon_data_v1 { .boolean = false }, sc_gluon_bool, false, 1 };
+    } else if (IsSym(&slot)) {
+        return sc_gluon_param_v1_t { sc_gluon_data_v1 { .symbol_value =
+                                                            reinterpret_cast<intptr_t>(slotRawSymbol(&slot)) },
+                                     sc_gluon_symbol_value, false, 1 };
+    } else if (IsObj(&slot)) {
+        PyrObject* obj { slotRawObject(&slot) };
+        if (obj->classptr == class_string) {
+            auto* str = reinterpret_cast<PyrString*>(obj);
+            return sc_gluon_param_v1_t { sc_gluon_data_v1 { .character_array = str->s }, sc_gluon_char_array, false,
+                                         (uint32_t)str->size };
+        } else if (obj->classptr == class_int8array) {
+            auto* u8array = reinterpret_cast<PyrInt8Array*>(obj);
+            return sc_gluon_param_v1_t {
+                sc_gluon_data_v1 { .u8_array = u8array->b },
+                sc_gluon_u8_array,
+                false,
+                (uint32_t)u8array->size,
+            };
+        } else if (obj->classptr == class_doublearray) {
+            auto* f64array = reinterpret_cast<PyrDoubleArray*>(obj);
+            return sc_gluon_param_v1_t { sc_gluon_data_v1 { .f64_array = f64array->d }, sc_gluon_f64_array, false,
+                                         (uint32_t)f64array->size };
+        } else if (obj->classptr == class_floatarray) {
+            auto* f32array = reinterpret_cast<PyrFloatArray*>(obj);
+            return sc_gluon_param_v1_t { sc_gluon_data_v1 { .f32_array = f32array->f }, sc_gluon_f32_array, false,
+                                         (uint32_t)f32array->size };
+        } else if (obj->classptr == class_symbolarray) {
+            auto* symarray = reinterpret_cast<PyrSymbolArray*>(obj);
+            return sc_gluon_param_v1_t { sc_gluon_data_v1 { .symbol_value_array = (intptr_t*)symarray->symbols },
+                                         sc_gluon_symbol_value_array, false, (uint32_t)symarray->size };
+        } else if (obj->classptr == class_array) {
+            sc_gluon_param_v1_t* param_array = (sc_gluon_param_v1_t*)malloc(sizeof(sc_gluon_param_v1_t) * obj->size);
+            if (param_array == nullptr)
+                throw std::runtime_error { "malloc failed" };
+
+            try {
+                for (int i { 0 }; i < obj->size; ++i) {
+                    param_array[i] = slot_to_param(obj->slots[i]);
+                }
+            } catch (...) {
+                free(param_array);
+                throw;
+            }
+
+            return sc_gluon_param_v1_t { sc_gluon_data_v1 { .param_array = param_array }, sc_gluon_param_array, true,
+                                         (uint32_t)obj->size };
+        } else {
+            throw std::runtime_error { "Cannot convert slot to sc_gluon_param_v1_t" };
+        }
+        //
+    } else {
+        throw std::runtime_error { "Cannot convert slot to sc_gluon_param_v1_t" };
+    }
+}
+
+PyrSlot move_param_to_slot(sc_gluon_param_v1_t&& param, VMGlobals* g) noexcept {
+    PyrSlot out;
+    switch (param.tag) {
+    case sc_gluon_nil: {
+        SetNil(&out);
+        break;
+    }
+    case sc_gluon_i32: {
+        SetInt(&out, param.data.i32);
+        break;
+    }
+    case sc_gluon_f64: {
+        SetFloat(&out, param.data.f64);
+        break;
+    }
+    case sc_gluon_char: {
+        SetChar(&out, param.data.character);
+        break;
+    }
+    case sc_gluon_bool: {
+        if (param.data.boolean)
+            SetTrue(&out);
+        else
+            SetFalse(&out);
+        break;
+    }
+    case sc_gluon_raw_pointer: {
+        SetPtr(&out, param.data.raw_pointer);
+        break;
+    }
+    case sc_gluon_symbol_value: {
+        SetSymbol(&out, (PyrSymbol*)param.data.symbol_value);
+        break;
+    }
+    case sc_gluon_u8_array: {
+        auto new_array = newPyrInt8Array(g->gc, param.size, 0, false);
+        std::memcpy(new_array->b, param.data.u8_array, param.size * sizeof(uint8_t));
+        if (param.owns_data)
+            free(param.data.u8_array);
+        SetObject(&out, new_array);
+        break;
+    }
+
+    case sc_gluon_f64_array: {
+        auto new_array = newPyrDoubleArray(g->gc, param.size, 0, false);
+        std::memcpy(new_array->d, param.data.f64_array, param.size * sizeof(double));
+        if (param.owns_data)
+            free(param.data.f64_array);
+        SetObject(&out, new_array);
+        break;
+    }
+    case sc_gluon_f32_array: {
+        auto new_array = newPyrSignal(g, param.size, false);
+        std::memcpy((float*)new_array->slots, param.data.f32_array, param.size * sizeof(double));
+        if (param.owns_data)
+            free(param.data.f32_array);
+        SetObject(&out, new_array);
+        break;
+    }
+    case sc_gluon_char_array: {
+        auto new_array = newPyrString(g->gc, param.data.character_array, 0, false);
+        if (param.owns_data)
+            free(param.data.character_array);
+        SetObject(&out, new_array);
+        break;
+    }
+    case sc_gluon_symbol_value_array: {
+        auto new_array = newPyrSymbolArray(g->gc, param.size, 0, false);
+        std::memcpy(new_array->symbols, (PyrSymbol*)param.data.symbol_value_array, param.size * sizeof(PyrSymbol*));
+        if (param.owns_data)
+            free(param.data.symbol_value_array);
+        SetObject(&out, new_array);
+        break;
+    }
+    case sc_gluon_param_array: {
+        auto array = newPyrArray(g->gc, param.size, 0, false);
+        for (uint32_t i { 0 }; i < param.size; ++i)
+            array->slots[i] = move_param_to_slot(std::move(param.data.param_array[i]), g);
+        array->size = param.size;
+        if (param.owns_data)
+            free(param.data.param_array);
+        SetObject(&out, array);
+        break;
+    }
+    }
+    return out;
+}
+
+void free_param(sc_gluon_param_v1_t&& param) noexcept(true) { sc_gluon_free_param_v1(param); }
+
+void details::LibraryV1::evaluate(PyrSymbol* function_name, VMGlobals* g, PyrObject* maybe_callback,
+                                  PyrSlot* return_slot, PyrSlot* first_argument_slot, int num_args_given) const {
+    size_t func_index { std::numeric_limits<size_t>::max() };
+    for (size_t i { 0 }; i < function_names.size(); ++i) {
+        if (function_names[i] == function_name) {
+            func_index = i;
+            break;
+        }
+    }
+    if (func_index == std::numeric_limits<size_t>::max()) {
+        throw std::runtime_error { "Could not find function name in library" };
+    }
+
+    const FunctionDataV1& data = function_data[func_index];
+    if (!data.accepts_variable_params() && num_args_given != data.num_params) {
+        throw std::runtime_error { "Incorrect number of arguments given to FFI function." };
+    }
+
+    std::vector<sc_gluon_param_v1_t> params;
+    params.reserve(num_args_given);
+
+    const auto destroy_params = [](std::vector<sc_gluon_param_v1_t>&& ps) {
+        for (sc_gluon_param_v1_t p : ps)
+            if (p.owns_data)
+                free_param(std::move(p));
+    };
+
+    for (uint32_t i { 0 }; i < (num_args_given); ++i) {
+        params.push_back(slot_to_param(*first_argument_slot));
+        ++first_argument_slot;
+    }
+
+    bool stored_callback = false;
+    if (maybe_callback != nullptr) {
+        if (!data.accepts_callback) {
+            destroy_params(std::move(params));
+            throw std::runtime_error { "A callback was given to an FFI function that doesn't accepts callbacks." };
+        }
+        stored_callback = true;
+        g->gc->StoreExternalObject(maybe_callback);
+    }
+
+    sc_gluon_out_param_or_maybe_diagnostic_v1 result;
+    sc_gluon_out_param_tag_v1 result_tag =
+        data.ptr(library_data, (void*)maybe_callback, params.data(), num_args_given, &result);
+
+    destroy_params(std::move(params));
+
+    switch (result_tag) {
+    case sc_gluon_produced_param: {
+        *return_slot = move_param_to_slot(std::move(result.out_param), g);
+        break;
+    }
+    case sc_gluon_error_with_owned_diagnostic: {
+        SetNil(return_slot);
+        std::string error { result.maybe_diagnostic };
+        free((void*)result.maybe_diagnostic);
+
+        if (stored_callback)
+            g->gc->RemoveExternalObject(maybe_callback);
+
+        throw std::runtime_error { error };
+    }
+    case sc_gluon_error_with_non_owned_diagnostic: {
+        SetNil(return_slot);
+        if (stored_callback)
+            g->gc->RemoveExternalObject(maybe_callback);
+
+        throw std::runtime_error { std::string { result.maybe_diagnostic } };
+    }
+    case sc_gluon_error_without_diagnostic: {
+        SetNil(return_slot);
+        if (stored_callback)
+            g->gc->RemoveExternalObject(maybe_callback);
+
+        throw std::runtime_error { "FFI function did not complete" };
+    }
+    }
+}
+
+sc_gluon_out_param_tag_v1 test1(sc_gluon_library_data_v1_t library_data,
+                                sc_gluon_callable_object_v1_t maybe_callback_data, sc_gluon_param_v1_t* in_params,
+                                uint32_t num_in_params, sc_gluon_out_param_or_maybe_diagnostic_v1* out_param) {
+    if (num_in_params != 2) {
+        out_param->maybe_diagnostic = "wrong number of in params";
+        return sc_gluon_error_with_non_owned_diagnostic;
+    }
+
+    const sc_gluon_param_v1_t& p1 = in_params[0];
+    const sc_gluon_param_v1_t& p2 = in_params[1];
+
+    if (p1.tag != sc_gluon_f64) {
+        out_param->maybe_diagnostic = "param 1 is not an f64";
+        return sc_gluon_error_with_non_owned_diagnostic;
+    }
+
+    if (p2.tag != sc_gluon_f64) {
+        out_param->maybe_diagnostic = "param 2 is not an f64";
+        return sc_gluon_error_with_non_owned_diagnostic;
+    }
+
+    const auto r = p1.data.f64 + p2.data.f64;
+
+    out_param->out_param.data.f64 = r;
+    out_param->out_param.tag = sc_gluon_f64;
+    out_param->out_param.owns_data = false;
+    out_param->out_param.size = 1;
+
+    return sc_gluon_produced_param;
+}
+
+sc_gluon_out_param_tag_v1 callback_test(sc_gluon_library_data_v1_t library_data,
+                                        sc_gluon_callable_object_v1_t maybe_callback_data,
+                                        sc_gluon_param_v1_t* in_params, uint32_t num_in_params,
+                                        sc_gluon_out_param_or_maybe_diagnostic_v1* out_param) {
+    if (num_in_params != 1) {
+        out_param->maybe_diagnostic = "wrong number of in params";
+        return sc_gluon_error_with_non_owned_diagnostic;
+    }
+    const sc_gluon_param_v1_t& p1 = in_params[0];
+
+    double wait;
+    if (p1.tag == sc_gluon_f64) {
+        wait = p1.data.f64;
+    } else if (p1.tag == sc_gluon_i32) {
+        wait = static_cast<double>(p1.data.i32);
+    } else {
+        out_param->maybe_diagnostic = "Expected an f64 or i32 for the first argument";
+        return sc_gluon_error_with_non_owned_diagnostic;
+    }
+
+    std::thread([=]() {
+        std::this_thread::sleep_for(std::chrono::duration<double>(wait));
+        if (maybe_callback_data) {
+            sc_gluon_callback_action_v1(maybe_callback_data, nullptr, 0);
+            sc_gluon_release_callback_object_v1(maybe_callback_data);
+        }
+    }).detach();
+
+
+    out_param->out_param.data.nil_ = {};
+    out_param->out_param.tag = sc_gluon_nil;
+    out_param->out_param.owns_data = false;
+    out_param->out_param.size = 1;
+
+    return sc_gluon_produced_param;
+}
+
+sc_gluon_out_param_tag_v1 many_callback_test(sc_gluon_library_data_v1_t library_data,
+                                             sc_gluon_callable_object_v1_t maybe_callback_data,
+                                             sc_gluon_param_v1_t* in_params, uint32_t num_in_params,
+                                             sc_gluon_out_param_or_maybe_diagnostic_v1* out_param) {
+    if (num_in_params != 2) {
+        out_param->maybe_diagnostic = "wrong number of in params";
+        return sc_gluon_error_with_non_owned_diagnostic;
+    }
+    const sc_gluon_param_v1_t& time_param = in_params[0];
+    const sc_gluon_param_v1_t& iteration_param = in_params[1];
+
+    double wait;
+    if (time_param.tag == sc_gluon_f64) {
+        wait = time_param.data.f64;
+    } else if (time_param.tag == sc_gluon_i32) {
+        wait = static_cast<double>(time_param.data.i32);
+    } else {
+        out_param->maybe_diagnostic = "Expected an f64 or i32 for the first argument";
+        return sc_gluon_error_with_non_owned_diagnostic;
+    }
+
+    if (iteration_param.tag != sc_gluon_i32) {
+        out_param->maybe_diagnostic = "Expected an i32 for the second argument";
+        return sc_gluon_error_with_non_owned_diagnostic;
+    }
+
+    const int32_t iter = iteration_param.data.i32;
+
+    std::thread([=]() {
+        for (size_t i { 0 }; i < iter; ++i) {
+            std::this_thread::sleep_for(std::chrono::duration<double>(wait));
+            if (maybe_callback_data) {
+                sc_gluon_callback_action_v1(maybe_callback_data, nullptr, 0);
+            }
+        }
+        sc_gluon_release_callback_object_v1(maybe_callback_data);
+    }).detach();
+
+
+    out_param->out_param.data.boolean = true;
+    out_param->out_param.tag = sc_gluon_bool;
+    out_param->out_param.owns_data = false;
+    out_param->out_param.size = 1;
+
+    return sc_gluon_produced_param;
+}
+
+
+sc_gluon_out_param_tag_v1 callback_with_args_test(sc_gluon_library_data_v1_t library_data,
+                                                  sc_gluon_callable_object_v1_t maybe_callback_data,
+                                                  sc_gluon_param_v1_t* in_params, uint32_t num_in_params,
+                                                  sc_gluon_out_param_or_maybe_diagnostic_v1* out_param) {
+    if (num_in_params != 1) {
+        out_param->maybe_diagnostic = "wrong number of in params";
+        return sc_gluon_error_with_non_owned_diagnostic;
+    }
+    const sc_gluon_param_v1_t& p1 = in_params[0];
+
+    double wait;
+    if (p1.tag == sc_gluon_f64) {
+        wait = p1.data.f64;
+    } else if (p1.tag == sc_gluon_i32) {
+        wait = static_cast<double>(p1.data.i32);
+    } else {
+        out_param->maybe_diagnostic = "Expected an f64 or i32 for the first argument";
+        return sc_gluon_error_with_non_owned_diagnostic;
+    }
+
+    std::thread([=]() {
+        std::this_thread::sleep_for(std::chrono::duration<double>(wait));
+        sc_gluon_param_v1_t ps[2];
+        ps[0].data.f64 = 2.1;
+        ps[0].owns_data = false;
+        ps[0].size = 1;
+        ps[0].tag = sc_gluon_f64;
+
+        ps[1].data.boolean = false;
+        ps[1].owns_data = false;
+        ps[1].size = 1;
+        ps[1].tag = sc_gluon_bool;
+        if (maybe_callback_data) {
+            sc_gluon_callback_action_v1(maybe_callback_data, ps, 2);
+            sc_gluon_release_callback_object_v1(maybe_callback_data);
+        }
+    }).detach();
+
+
+    out_param->out_param.data.nil_ = {};
+    out_param->out_param.tag = sc_gluon_nil;
+    out_param->out_param.owns_data = false;
+    out_param->out_param.size = 1;
+
+    return sc_gluon_produced_param;
+}
+
+sc_gluon_out_param_tag_v1 array_sum(sc_gluon_library_data_v1_t library_data,
+                                    sc_gluon_callable_object_v1_t maybe_callback_data, sc_gluon_param_v1_t* in_params,
+                                    uint32_t num_in_params, sc_gluon_out_param_or_maybe_diagnostic_v1* out_param) {
+    if (num_in_params != 1) {
+        out_param->maybe_diagnostic = "wrong number of in params";
+        return sc_gluon_error_with_non_owned_diagnostic;
+    }
+    const sc_gluon_param_v1_t& p1 = in_params[0];
+    if (p1.tag != sc_gluon_param_array) {
+        out_param->maybe_diagnostic = "Wrong parameter type expected a param array.";
+        return sc_gluon_error_with_non_owned_diagnostic;
+    }
+
+    const auto size = p1.size;
+
+    double sum { 0 };
+    for (size_t i { 0 }; i < size; ++i) {
+        const sc_gluon_param_v1_t& e = p1.data.param_array[i];
+        if (e.tag == sc_gluon_f64) {
+            sum += e.data.f64;
+        } else if (e.tag == sc_gluon_i32) {
+            sum += static_cast<double>(e.data.i32);
+        } else {
+            out_param->maybe_diagnostic = "Wrong parameter type inside of array, expected an f64";
+            return sc_gluon_error_with_non_owned_diagnostic;
+        }
+    }
+
+    out_param->out_param.data.f64 = sum;
+    out_param->out_param.tag = sc_gluon_f64;
+    out_param->out_param.owns_data = false;
+    out_param->out_param.size = 1;
+
+    return sc_gluon_produced_param;
+}
+
+sc_gluon_out_param_tag_v1 return_array_test(sc_gluon_library_data_v1_t library_data,
+                                            sc_gluon_callable_object_v1_t maybe_callback_data,
+                                            sc_gluon_param_v1_t* in_params, uint32_t num_in_params,
+                                            sc_gluon_out_param_or_maybe_diagnostic_v1* out_param) {
+    out_param->out_param.data.param_array = new sc_gluon_param_v1_t[10] {};
+    out_param->out_param.tag = sc_gluon_param_array;
+    out_param->out_param.owns_data = true;
+    out_param->out_param.size = 10;
+
+    for (size_t i { 0 }; i < 10; ++i) {
+        out_param->out_param.data.param_array[i].data.i32 = static_cast<int32_t>(i);
+        out_param->out_param.data.param_array[i].owns_data = false;
+        out_param->out_param.data.param_array[i].size = 1;
+        out_param->out_param.data.param_array[i].tag = sc_gluon_i32;
+    }
+
+    return sc_gluon_produced_param;
+}
+
+
+void sc_gluon::GluonManager::create_testing_library_v1() {
+    details::LibraryV1 lib {};
+
+    lib.function_names.push_back(getsym("addition_test"));
+    lib.function_data.emplace_back(details::FunctionDataV1 { test1, 2, false });
+
+    lib.function_names.push_back(getsym("callback_test"));
+    lib.function_data.emplace_back(details::FunctionDataV1 { callback_test, 1, true });
+
+    lib.function_names.push_back(getsym("many_callback_test"));
+    lib.function_data.emplace_back(details::FunctionDataV1 { many_callback_test, 2, true });
+
+    lib.function_names.push_back(getsym("callback_with_args_test"));
+    lib.function_data.emplace_back(details::FunctionDataV1 { callback_with_args_test, 1, true });
+
+    lib.function_names.push_back(getsym("array_sum"));
+    lib.function_data.emplace_back(details::FunctionDataV1 { array_sum, 1, false });
+
+    lib.function_names.push_back(getsym("return_array"));
+    lib.function_data.emplace_back(details::FunctionDataV1 { return_array_test, 0, false });
+
+    const auto test_id { library_counter++ };
+
+    libraries.emplace(test_id, LibraryVariant { std::move(lib) });
+    inbuilt_test_to_library_id.emplace(getsym("gluonTestV1"), test_id);
+}
+
+
+LibraryID sc_gluon::GluonManager::register_library_v1(void* library_handle) noexcept(false) {
+#ifndef _WIN32
+    const void* loader_f = dlsym(library_handle, "sc_gluon_load_library");
+    const char* load_error = dlerror();
+    if (load_error != nullptr || loader_f == nullptr) {
+        dlclose(library_handle);
+        throw std::runtime_error { std::string { load_error } };
+    }
+
+    const void* unloader_f = dlsym(library_handle, "sc_gluon_unload_library");
+    const void* post_load_p = dlsym(library_handle, "sc_gluon_post_load_library");
+
+    const auto close_library = [=]() { dlclose(library_handle); };
+#else
+    const void* loader_f = (void*)GetProcAddress((HMODULE)library_handle, "sc_gluon_load_library");
+    if (loader_f == nullptr) {
+        FreeLibrary((HMODULE)library_handle);
+        throw std::runtime_error { "Could not load sc_gluon_load_library" };
+    }
+
+    const void* unloader_f = (void*)GetProcAddress((HMODULE)library_handle, "sc_gluon_unload_library");
+    const void* post_load_p = (void*)GetProcAddress((HMODULE)library_handle, "sc_gluon_post_load_library");
+
+    const auto close_library = [=]() { FreeLibrary((HMODULE)library_handle); };
+
+#endif
+    const auto loader = (sc_gluon_load_library_v1_f)loader_f;
+    const sc_gluon_unload_library_v1_f unloader = (sc_gluon_unload_library_v1_f)unloader_f;
+    const sc_gluon_post_load_library_v1_f post_loader = (sc_gluon_post_load_library_v1_f)post_load_p;
+
+    sc_gluon_function_declarations_v1_t* func_decls; // uninitialised
+    uint32_t func_decls_size { 0 };
+
+    sc_gluon_library_data_v1_t library_data =
+        loader(sc_gluon_callback_action_v1, sc_gluon_release_callback_object_v1, &func_decls, &func_decls_size);
+    if (func_decls_size == 0) {
+        close_library();
+        throw std::runtime_error { "Failed to load functions from library" };
+    }
+
+    std::vector<PyrSymbol*> function_names;
+    std::vector<details::FunctionDataV1> function_data;
+
+    for (uint32_t i { 0 }; i < func_decls_size; ++i) {
+        const auto decl = func_decls[i];
+        function_names.push_back(getsym(decl.name));
+        function_data.emplace_back(details::FunctionDataV1 { decl.ptr, decl.num_parms, decl.accepts_callback });
+    }
+
+    if (post_loader) {
+        post_loader(library_data, func_decls, func_decls_size);
+    }
+
+    const LibraryID library_id = library_counter++;
+    libraries.emplace(library_id,
+                      LibraryVariant { details::LibraryV1 { library_handle, library_data, unloader,
+                                                            std::move(function_names), std::move(function_data) } });
+
+    return library_id;
+}

--- a/lang/LangSource/GluonFFIV1.cpp
+++ b/lang/LangSource/GluonFFIV1.cpp
@@ -57,53 +57,134 @@ void sc_gluon_release_callback_object_v1(void* callback_data) {
 }
 
 
+// Because MSVC doesn't support designated initializers, unions are annoying to initialise.
+// Here are a bunch of helpers.
+
+namespace sc_gluon::v1 {
+using param = sc_gluon_param_v1_t;
+using data = sc_gluon_data_v1;
+
+param priv_basic(sc_gluon_data_v1 data, sc_gluon_param_tag_v1 tag) { return { data, 1, tag, false }; }
+param priv_array(sc_gluon_data_v1 data, sc_gluon_param_tag_v1 tag, uint32_t size, bool owns_data) {
+    return { data, size, tag, owns_data };
+}
+
+param nil_() {
+    data d;
+    d.nil_ = {};
+    return priv_basic(d, sc_gluon_nil);
+}
+
+param i32(int32_t i) {
+    data d;
+    d.i32 = i;
+    return priv_basic(d, sc_gluon_i32);
+}
+
+param f64(double f) {
+    data d;
+    d.f64 = f;
+    return priv_basic(d, sc_gluon_f64);
+}
+
+param character(char c) {
+    data d;
+    d.character = c;
+    return priv_basic(d, sc_gluon_char);
+}
+
+param boolean(bool b) {
+    data d;
+    d.boolean = b;
+    return priv_basic(d, sc_gluon_bool);
+}
+
+param raw_pointer(void* p) {
+    data d;
+    d.raw_pointer = p;
+    return priv_basic(d, sc_gluon_raw_pointer);
+}
+
+param symbol_value(intptr_t s) {
+    data d;
+    d.symbol_value = s;
+    return priv_basic(d, sc_gluon_symbol_value);
+}
+
+param u8_array(uint8_t* a, uint32_t size, bool owns_data) {
+    data d;
+    d.u8_array = a;
+    return priv_array(d, sc_gluon_u8_array, size, owns_data);
+}
+
+param f64_array(double* a, uint32_t size, bool owns_data) {
+    data d;
+    d.f64_array = a;
+    return priv_array(d, sc_gluon_f64_array, size, owns_data);
+}
+
+param f32_array(float* a, uint32_t size, bool owns_data) {
+    data d;
+    d.f32_array = a;
+    return priv_array(d, sc_gluon_f32_array, size, owns_data);
+}
+
+param character_array(char* a, uint32_t size, bool owns_data) {
+    data d;
+    d.character_array = a;
+    return priv_array(d, sc_gluon_char_array, size, owns_data);
+}
+
+param symbol_value_array(intptr_t* a, uint32_t size, bool owns_data) {
+    data d;
+    d.symbol_value_array = a;
+    return priv_array(d, sc_gluon_symbol_value_array, size, owns_data);
+}
+
+param param_array(param* a, uint32_t size, bool owns_data) {
+    data d;
+    d.param_array = a;
+    return priv_array(d, sc_gluon_param_array, size, owns_data);
+}
+}
+
+
 sc_gluon_param_v1_t slot_to_param(PyrSlot slot) {
     if (IsNil(&slot)) {
-        return sc_gluon_param_v1_t { sc_gluon_data_v1 { .nil_ = 0 }, sc_gluon_nil, false, 1 };
+        return v1::nil_();
     } else if (IsInt(&slot)) {
-        return sc_gluon_param_v1_t { sc_gluon_data_v1 { .i32 = slotRawInt(&slot) }, sc_gluon_i32, false, 1 };
+        return v1::i32(slotRawInt(&slot));
     } else if (IsFloat(&slot)) {
-        return sc_gluon_param_v1_t { sc_gluon_data_v1 { .f64 = slotRawFloat(&slot) }, sc_gluon_f64, false, 1 };
+        return v1::f64(slotRawFloat(&slot));
     } else if (IsChar(&slot)) {
-        return sc_gluon_param_v1_t { sc_gluon_data_v1 { .character = static_cast<char>(slotRawChar(&slot)) },
-                                     sc_gluon_char, false, 1 };
+        return v1::character(static_cast<char>(slotRawChar(&slot)));
     } else if (IsPtr(&slot)) {
-        return sc_gluon_param_v1_t { sc_gluon_data_v1 { .raw_pointer = slotRawPtr(&slot) }, sc_gluon_raw_pointer, false,
-                                     1 };
+        return v1::raw_pointer(slotRawPtr(&slot));
     } else if (IsTrue(&slot)) {
-        return sc_gluon_param_v1_t { sc_gluon_data_v1 { .boolean = true }, sc_gluon_bool, false, 1 };
+        return v1::boolean(true);
     } else if (IsFalse(&slot)) {
-        return sc_gluon_param_v1_t { sc_gluon_data_v1 { .boolean = false }, sc_gluon_bool, false, 1 };
+        return v1::boolean(false);
     } else if (IsSym(&slot)) {
-        return sc_gluon_param_v1_t { sc_gluon_data_v1 { .symbol_value =
-                                                            reinterpret_cast<intptr_t>(slotRawSymbol(&slot)) },
-                                     sc_gluon_symbol_value, false, 1 };
+        return v1::symbol_value(reinterpret_cast<intptr_t>(slotRawSymbol(&slot)));
     } else if (IsObj(&slot)) {
         PyrObject* obj { slotRawObject(&slot) };
         if (obj->classptr == class_string) {
             auto* str = reinterpret_cast<PyrString*>(obj);
-            return sc_gluon_param_v1_t { sc_gluon_data_v1 { .character_array = str->s }, sc_gluon_char_array, false,
-                                         (uint32_t)str->size };
+            return v1::character_array(str->s, static_cast<uint32_t>(str->size), false);
+
         } else if (obj->classptr == class_int8array) {
             auto* u8array = reinterpret_cast<PyrInt8Array*>(obj);
-            return sc_gluon_param_v1_t {
-                sc_gluon_data_v1 { .u8_array = u8array->b },
-                sc_gluon_u8_array,
-                false,
-                (uint32_t)u8array->size,
-            };
+            return v1::u8_array(u8array->b, static_cast<uint32_t>(u8array->size), false);
         } else if (obj->classptr == class_doublearray) {
             auto* f64array = reinterpret_cast<PyrDoubleArray*>(obj);
-            return sc_gluon_param_v1_t { sc_gluon_data_v1 { .f64_array = f64array->d }, sc_gluon_f64_array, false,
-                                         (uint32_t)f64array->size };
+            return v1::f64_array(f64array->d, static_cast<uint32_t>(f64array->size), false);
         } else if (obj->classptr == class_floatarray) {
             auto* f32array = reinterpret_cast<PyrFloatArray*>(obj);
-            return sc_gluon_param_v1_t { sc_gluon_data_v1 { .f32_array = f32array->f }, sc_gluon_f32_array, false,
-                                         (uint32_t)f32array->size };
+            return v1::f32_array(f32array->f, static_cast<uint32_t>(f32array->size), false);
         } else if (obj->classptr == class_symbolarray) {
             auto* symarray = reinterpret_cast<PyrSymbolArray*>(obj);
-            return sc_gluon_param_v1_t { sc_gluon_data_v1 { .symbol_value_array = (intptr_t*)symarray->symbols },
-                                         sc_gluon_symbol_value_array, false, (uint32_t)symarray->size };
+            return v1::symbol_value_array(reinterpret_cast<intptr_t*>(symarray->symbols),
+                                          static_cast<uint32_t>(symarray->size), false);
         } else if (obj->classptr == class_array) {
             sc_gluon_param_v1_t* param_array = (sc_gluon_param_v1_t*)malloc(sizeof(sc_gluon_param_v1_t) * obj->size);
             if (param_array == nullptr)
@@ -118,8 +199,7 @@ sc_gluon_param_v1_t slot_to_param(PyrSlot slot) {
                 throw;
             }
 
-            return sc_gluon_param_v1_t { sc_gluon_data_v1 { .param_array = param_array }, sc_gluon_param_array, true,
-                                         (uint32_t)obj->size };
+            return v1::param_array(param_array, static_cast<uint32_t>(obj->size), true);
         } else {
             throw std::runtime_error { "Cannot convert slot to sc_gluon_param_v1_t" };
         }

--- a/lang/LangSource/PyrInterpreter3.cpp
+++ b/lang/LangSource/PyrInterpreter3.cpp
@@ -347,6 +347,9 @@ bool initRuntime(VMGlobals* g, int poolSize, AllocPool* inPool) {
     // initialize process random number generator
     g->rgen = (RGen*)(slotRawObject(&g->thread->randData)->slots);
 
+    g->gluonManager.reset_or_prep_for_close();
+    g->gluonManager.create_testing_library();
+
     initThreads();
     initPatterns();
     initUniqueMethods();

--- a/lang/LangSource/PyrMessage.cpp
+++ b/lang/LangSource/PyrMessage.cpp
@@ -576,13 +576,11 @@ HOT void returnFromBlock(VMGlobals* g) {
         }
 
     } else {
-        ////// this should never happen .
-        error("return from Function at top of call stack.\n");
-        g->method = nullptr;
-        g->block = nullptr;
-        g->frame = nullptr;
-        g->sp = g->gc->Stack()->slots - 1;
-        longjmp(g->escapeInterpreter, 1);
+        fatalerror(
+            "Returned from a Function at top of call stack. This has probably occurred when a thread tried to run "
+            "'runInterpreter' with a 'Function' object at the top of the stack. Instead, wrap the function "
+            "object in a class so a method can be called and return. This is a fatal error because it corrupts the "
+            "stack in subtle ways.\n");
     }
     // if (gTraceInterpreter) postfl("<-returnFromBlock\n");
 #ifdef GC_SANITYCHECK

--- a/lang/LangSource/PyrSignal.cpp
+++ b/lang/LangSource/PyrSignal.cpp
@@ -41,10 +41,10 @@
 #include "SCBase.h"
 #include "InitAlloc.h"
 
-PyrObject* newPyrSignal(VMGlobals* g, std::int64_t size) {
+PyrObject* newPyrSignal(VMGlobals* g, std::int64_t size, bool collect) {
     PyrObject* signal;
     std::int64_t numbytes = size * sizeof(float);
-    signal = (PyrObject*)g->gc->New(numbytes, 0, obj_float, true);
+    signal = (PyrObject*)g->gc->New(numbytes, 0, obj_float, collect);
     if (signal) {
         signal->classptr = class_signal;
         signal->size = size;

--- a/lang/LangSource/PyrSignal.h
+++ b/lang/LangSource/PyrSignal.h
@@ -30,7 +30,7 @@ enum {
     kSignalNextNode
 };
 
-PyrObject* newPyrSignal(VMGlobals* g, std::int64_t size);
+PyrObject* newPyrSignal(VMGlobals* g, std::int64_t size, bool collect = true);
 
 #define UNROLL8_CODE(size, var, stmt)                                                                                  \
     {                                                                                                                  \

--- a/lang/LangSource/VMGlobals.cpp
+++ b/lang/LangSource/VMGlobals.cpp
@@ -21,22 +21,7 @@
 
 #include "VMGlobals.h"
 
-VMGlobals::VMGlobals():
-    allocPool(nullptr),
-    process(nullptr),
-    gc(nullptr),
-    classvars(nullptr),
-    canCallOS(false),
-    thread(nullptr),
-    method(nullptr),
-    block(nullptr),
-    frame(nullptr),
-    primitiveMethod(nullptr),
-    ip(nullptr),
-    sp(nullptr),
-    numpop(0),
-    primitiveIndex(0),
-    execMethod(0) {
+VMGlobals::VMGlobals() {
     SetNil(&receiver);
     SetNil(&result);
 }

--- a/lang/LangSource/VMGlobals.h
+++ b/lang/LangSource/VMGlobals.h
@@ -31,6 +31,8 @@ Each virtual machine has a copy of VMGlobals, which contains the state of the vi
 #include <setjmp.h>
 #include <map>
 #include <cstdint>
+#include "GluonFFI.hpp"
+
 
 #define TAILCALLOPTIMIZE 1
 
@@ -46,39 +48,53 @@ struct FifoMsg {
     std::int64_t dataWord[2];
 };
 
+
+// WARNING: This object is created in the global scope, meaning it is susceptible to the global destructor bug.
+// Additionally, it isn't possible to call functions like `getsym' in the constructor of this object as they require
+// a specific extern global variable to be set.
+// This means all members must also obey these constraints.
+// VMGlobals is actually initialised in `initRuntime'.
+// TODO: It would be nice to refact `initRuntime' so proper c++ constructors can be used.
 struct VMGlobals {
     VMGlobals();
+    VMGlobals(VMGlobals&&) = delete;
+    VMGlobals(const VMGlobals&) = delete;
+    VMGlobals& operator=(VMGlobals&&) = delete;
+    VMGlobals& operator=(const VMGlobals&) = delete;
 
     // global context
-    class AllocPool* allocPool;
-    struct PyrProcess* process;
-    class SymbolTable* symbolTable;
-    class PyrGC* gc; // garbage collector for this process
-    PyrObject* classvars;
-    int tailCall; // next byte code is a tail call.
-    bool canCallOS;
+    class AllocPool* allocPool { nullptr };
+    struct PyrProcess* process { nullptr };
+    class SymbolTable* symbolTable { nullptr };
+    class PyrGC* gc { nullptr }; // garbage collector for this process
+    PyrObject* classvars { nullptr };
+    sc_gluon::GluonManager gluonManager {};
+#if TAILCALLOPTIMIZE
+    int tailCall {}; // next byte code is a tail call.
+#endif
+    bool canCallOS { false };
 
     // thread context
-    struct PyrThread* thread;
-    struct PyrMethod* method;
-    struct PyrBlock* block;
-    struct PyrFrame* frame;
-    struct PyrMethod* primitiveMethod;
-    unsigned char* ip; // current instruction pointer
-    PyrSlot* sp; // current stack ptr
-    PyrSlot* args;
-    PyrSlot receiver; // the receiver
-    PyrSlot result;
-    int numpop; // number of args to pop for primitive
-    std::int64_t primitiveIndex;
-    RGen* rgen;
+    struct PyrThread* thread { nullptr };
+    struct PyrMethod* method { nullptr };
+    struct PyrBlock* block { nullptr };
+    struct PyrFrame* frame { nullptr };
+    struct PyrMethod* primitiveMethod { nullptr };
+    unsigned char* ip { nullptr }; // current instruction pointer
+    PyrSlot* sp { nullptr }; // current stack ptr
+    PyrSlot* args { nullptr };
+    PyrSlot receiver; // init to nil in cpp
+    PyrSlot result; // init to nil in cpp
+    int numpop { 0 }; // number of args to pop for primitive
+    std::int64_t primitiveIndex { 0 };
+    RGen* rgen { nullptr };
     jmp_buf escapeInterpreter;
 
     // scratch context
-    std::int64_t execMethod;
+    std::int64_t execMethod { 0 };
 
     // primitive exceptions
-    std::map<PyrThread*, std::pair<std::exception_ptr, PyrMethod*>> lastExceptions;
+    std::map<PyrThread*, std::pair<std::exception_ptr, PyrMethod*>> lastExceptions {};
 };
 
 inline void FifoMsg::Perform(struct VMGlobals* g) { (func)(g, this); }

--- a/testsuite/CMakeLists.txt
+++ b/testsuite/CMakeLists.txt
@@ -1,2 +1,3 @@
 add_subdirectory(server)
 add_subdirectory(sclang)
+add_subdirectory(gluon_ffi_v1)

--- a/testsuite/classlibrary/TestGluon.sc
+++ b/testsuite/classlibrary/TestGluon.sc
@@ -1,0 +1,85 @@
+TestGluon : UnitTest{
+	test_addition {
+		var l = Gluon.inbuilt(\gluonTestV1);
+		this.assertEquals(1.2 + 5.2, l.addition_test(1.2, 5.2), "Basic addition test");
+	}
+
+	test_callback {
+		var l = Gluon.inbuilt(\gluonTestV1);
+
+		var c = CondVar();
+		var c_test = false;
+
+		l.callback_test(0.2, callback: {
+			c_test = true;
+			c.signalAll;
+		});
+
+		// do something to trigger the garbage collector.
+		2000.do { () };
+
+		c.waitFor(1.0) { c_test };
+
+		this.assert(c_test, "Basic callback should work");
+	}
+
+	test_callback_with_args {
+		var l = Gluon.inbuilt(\gluonTestV1);
+
+		var c = CondVar();
+		var c_test = false;
+		var a;
+
+		l.callback_with_args_test(0.2, callback: { |...args|
+			c_test = true;
+			a = args;
+			c.signalAll;
+		});
+
+		// do something to trigger the garbage collector.
+		2000.do { () };
+
+		c.waitFor(1.0) { c_test };
+
+		this.assertEquals(a, [2.1, false], "Callback with arguments should work");
+	}
+
+
+	test_many_callback {
+		var l = Gluon.inbuilt(\gluonTestV1);
+
+		var c = CondVar();
+		var count = 5;
+		var c_count = 0;
+
+		l.many_callback_test(0.1, count, callback: {
+			c_count = c_count + 1;
+			c.signalAll;
+		});
+
+		// do something to trigger the garbage collector.
+		2000.do { () };
+
+		c.waitFor(1.0 * count) { c_count == count };
+		this.assert(c_count == count, "Many callbacks should work");
+	}
+
+	test_param_array {
+		var l = Gluon.inbuilt(\gluonTestV1);
+		var a = [1, 1.1, 2.0, -3.2];
+		this.assertEquals(
+			l.array_sum(a),
+			a.sum,
+			"Parameter arrays should work"
+		);
+	}
+
+	test_return_array {
+		var l = Gluon.inbuilt(\gluonTestV1);
+		this.assertEquals(
+			l.return_array,
+			[0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
+			"Returning heap allocated param arrays should work"
+		);
+	}
+}

--- a/testsuite/gluon_ffi_v1/CMakeLists.txt
+++ b/testsuite/gluon_ffi_v1/CMakeLists.txt
@@ -1,0 +1,25 @@
+add_library(gluon_ffi_v1_test SHARED lib.cpp)
+
+set(CMAKE_SHARED_LIBRARY_SUFFIX ".gluon")
+set(CMAKE_SHARED_LIBRARY_PREFIX "")
+
+target_include_directories(gluon_ffi_v1_test
+	PUBLIC ${CMAKE_SOURCE_DIR}/include/gluon_ffi_interface
+)
+
+install(TARGETS gluon_ffi_v1_test)
+
+file(GLOB tests *.scd)
+
+foreach(test ${tests})
+    get_filename_component(test_name ${test} NAME_WE)
+    set(test_target ${test_name}_run)
+
+	add_test(
+		NAME ${test_target} 
+		COMMAND sclang -l ${CMAKE_BINARY_DIR}/build_sclang.cfg ${test} gluon_ffi_v1_test.gluon
+	)
+	SET_TESTS_PROPERTIES(${test_target}
+                     PROPERTIES DEPENDS gluon_ffi_v1_test DEPENDS sclang)
+endforeach()
+

--- a/testsuite/gluon_ffi_v1/ffi_v1_test.scd
+++ b/testsuite/gluon_ffi_v1/ffi_v1_test.scd
@@ -1,0 +1,83 @@
+
+
+fork {
+try {
+	var library_name = thisProcess.argv[0];
+	var all_good = false;
+	
+	var expect = { |action, expected, test_name|
+		try {
+			var r = action.();
+			if (r != expected) {
+				var s = "failure: % expect % received %".format(test_name, expected, r);
+				s.postln;
+				Error(s).throw
+			} {
+				"success: %".format(test_name).postln
+			}
+		} { |err|
+			err.reportError;
+			all_good = false;
+		}
+	};
+
+	var expect_callback_block = { |action_maker, expected, expectedFromCallback, repetitions, test_name|
+		try {
+			var c = CondVar();
+			var result = Ref(nil);
+			
+			var r = action_maker.(c, result).();
+			
+			if (r != expected) {
+				var s = "failure: % expect % received %".format(test_name, expected, r);
+				s.postln;
+				Error(s).throw
+			};
+
+            repetitions.do {
+                10000.do{ () }; // trigger gc 
+                c.waitFor (10) { result.get.notNil };
+                10000.do{ () }; // trigger gc 
+                if (result.get.isNil) {
+                    var s = "failure: % time out".format(test_name);
+                    s.postln;
+                    Error(s).throw
+                };
+                result.set(nil);
+            }
+		} { |err|
+			err.reportError;
+			all_good = false;
+			
+		}
+	};
+	
+	var lib_path = File.getcwd +/+ library_name; 
+	
+	Gluon.with(lib_path, { |g|
+		all_good = true;
+		
+		expect.({ g.add_f64(1.0, 2.0) }, 3.0, "Basic call back");
+		expect.({ g.add_many_f64(1.0, 2.0, -1.0) }, 2.0, "Variable args callback");
+		
+		expect_callback_block.({| cond_var, result|
+            {
+                g.with_call_back("hello", callback: { |...args, kwargs|
+                    result.set(args ++ kwargs);
+                    cond_var.signalAll;
+                });
+            }
+		}, 1, [nil, "hello"], 2, "Callback test");
+
+
+	});
+	
+	if(all_good) { 0.exit } { 1.exit }
+	
+} { |er|
+	
+	er.reportError;
+	1.exit;
+	
+}
+}

--- a/testsuite/gluon_ffi_v1/ffi_v1_test.scd
+++ b/testsuite/gluon_ffi_v1/ffi_v1_test.scd
@@ -53,6 +53,9 @@ try {
 	};
 	
 	var lib_path = File.getcwd +/+ library_name; 
+
+
+	"LIBRARY PATH = %".format(lib_path).postln;
 	
 	Gluon.with(lib_path, { |g|
 		all_good = true;

--- a/testsuite/gluon_ffi_v1/lib.cpp
+++ b/testsuite/gluon_ffi_v1/lib.cpp
@@ -13,7 +13,7 @@ struct LibraryData {
 };
 
 sc_gluon_out_param_tag_v1 add_f64(sc_gluon_library_data_v1_t library_data,
-                                  sc_gluon_callable_object_v1_t maybe_callback_data, sc_gluon_param_v1_t* in_params,
+                                  sc_gluon_callback_object_v1_t maybe_callback_data, sc_gluon_param_v1_t* in_params,
                                   uint32_t num_in_params, sc_gluon_out_param_or_maybe_diagnostic_v1* out_param) {
     if (num_in_params != 2) {
         out_param->maybe_diagnostic = "wrong number of in params";
@@ -44,7 +44,7 @@ sc_gluon_out_param_tag_v1 add_f64(sc_gluon_library_data_v1_t library_data,
 }
 
 sc_gluon_out_param_tag_v1 add_many_f64(sc_gluon_library_data_v1_t library_data,
-                                       sc_gluon_callable_object_v1_t maybe_callback_data,
+                                       sc_gluon_callback_object_v1_t maybe_callback_data,
                                        sc_gluon_param_v1_t* in_params, uint32_t num_in_params,
                                        sc_gluon_out_param_or_maybe_diagnostic_v1* out_param) {
     double rolling { 0.0 };
@@ -67,7 +67,7 @@ sc_gluon_out_param_tag_v1 add_many_f64(sc_gluon_library_data_v1_t library_data,
 }
 
 sc_gluon_out_param_tag_v1 with_call_back(sc_gluon_library_data_v1_t library_data,
-                                         sc_gluon_callable_object_v1_t maybe_callback_data,
+                                         sc_gluon_callback_object_v1_t maybe_callback_data,
                                          sc_gluon_param_v1_t* in_params, uint32_t num_in_params,
                                          sc_gluon_out_param_or_maybe_diagnostic_v1* out_param) {
     auto* lib = static_cast<LibraryData*>(library_data);
@@ -77,23 +77,23 @@ sc_gluon_out_param_tag_v1 with_call_back(sc_gluon_library_data_v1_t library_data
         return sc_gluon_error_with_non_owned_diagnostic;
     }
 
-    std::thread([=, param_copy = sc_gluon_copy_param_data_v1(in_params[0])]() mutable {
+    std::thread([=, param_copy = sc_gluon_copy_param_v1(in_params[0])]() mutable {
         using namespace std::chrono_literals;
         std::this_thread::sleep_for(1s);
 
         if (maybe_callback_data) {
-            param_t ps[2] = { create_param(), sc_gluon_copy_param_data_v1(param_copy) };
+            param_t ps[2] = { create_param(), sc_gluon_copy_param_v1(param_copy) };
             lib->callback_f(maybe_callback_data, ps, 2);
         }
 
         std::this_thread::sleep_for(1s);
 
         if (maybe_callback_data) {
-            param_t ps[2] = { create_param(), sc_gluon_copy_param_data_v1(param_copy) };
+            param_t ps[2] = { create_param(), sc_gluon_copy_param_v1(param_copy) };
             lib->callback_f(maybe_callback_data, ps, 2);
         }
 
-        sc_gluon_free_param_v1(param_copy);
+        sc_gluon_free_param_if_owned_v1(param_copy);
 
         if (maybe_callback_data)
             lib->release_callback_f(maybe_callback_data);
@@ -109,16 +109,19 @@ sc_gluon_out_param_tag_v1 with_call_back(sc_gluon_library_data_v1_t library_data
 SC_GLUON_EXPORT uint32_t sc_gluon_version() { return 1; }
 
 std::array<sc_gluon_function_declarations_v1_t, 3> decls {
-    sc_gluon_function_declarations_v1_t { "add_f64", add_f64, 2, false },
-    sc_gluon_function_declarations_v1_t { "add_many_f64", add_many_f64, -1, false },
-    sc_gluon_function_declarations_v1_t { "with_call_back", with_call_back, 1, true },
+    sc_gluon_function_declarations_v1_t { "add_f64", add_f64, 2, 0 },
+    sc_gluon_function_declarations_v1_t { "add_many_f64", add_many_f64, -1, 0 },
+    sc_gluon_function_declarations_v1_t { "with_call_back", with_call_back, 1, 1 },
 };
 
 
-SC_GLUON_EXPORT sc_gluon_library_data_v1_t
-sc_gluon_load_library(sc_gluon_do_callback_v1_f callback_f, sc_gluon_release_callback_object_v1_f release_callback_f,
-                      sc_gluon_function_declarations_v1_t** const out_decls, uint32_t* out_size) {
+SC_GLUON_EXPORT uint8_t sc_gluon_load_library(sc_gluon_param_v1_t* in_params, uint32_t num_in_params,
+                                              sc_gluon_do_callback_v1_f do_callback,
+                                              sc_gluon_release_callback_object_v1_f release_callback,
+                                              sc_gluon_function_declarations_v1_t** const out_decls,
+                                              uint32_t* out_decls_size, sc_gluon_library_data_v1_t* out_library_data) {
     *out_decls = decls.data();
-    *out_size = decls.size();
-    return new LibraryData { callback_f, release_callback_f };
+    *out_decls_size = decls.size();
+    *out_library_data = new LibraryData { do_callback, release_callback };
+    return 0;
 }

--- a/testsuite/gluon_ffi_v1/lib.cpp
+++ b/testsuite/gluon_ffi_v1/lib.cpp
@@ -1,0 +1,124 @@
+#include "sc_gluon_v1_types.h"
+#include "sc_gluon_v1_entry_points.h"
+
+#include "cpp/sc_gluon_v1_util.hpp"
+#include <thread>
+#include <iostream>
+#include <chrono>
+
+using namespace sc_gluon::v1;
+struct LibraryData {
+    sc_gluon_do_callback_v1_f callback_f;
+    sc_gluon_release_callback_object_v1_f release_callback_f;
+};
+
+sc_gluon_out_param_tag_v1 add_f64(sc_gluon_library_data_v1_t library_data,
+                                  sc_gluon_callable_object_v1_t maybe_callback_data, sc_gluon_param_v1_t* in_params,
+                                  uint32_t num_in_params, sc_gluon_out_param_or_maybe_diagnostic_v1* out_param) {
+    if (num_in_params != 2) {
+        out_param->maybe_diagnostic = "wrong number of in params";
+        return sc_gluon_error_with_non_owned_diagnostic;
+    }
+
+    const sc_gluon_param_v1_t& p1 = in_params[0];
+    const sc_gluon_param_v1_t& p2 = in_params[1];
+
+    if (p1.tag != sc_gluon_f64) {
+        out_param->maybe_diagnostic = "param 1 is not an f64";
+        return sc_gluon_error_with_non_owned_diagnostic;
+    }
+
+    if (p2.tag != sc_gluon_f64) {
+        out_param->maybe_diagnostic = "param 2 is not an f64";
+        return sc_gluon_error_with_non_owned_diagnostic;
+    }
+
+    const auto r = p1.data.f64 + p2.data.f64;
+
+    out_param->out_param.data.f64 = r;
+    out_param->out_param.tag = sc_gluon_f64;
+    out_param->out_param.owns_data = false;
+    out_param->out_param.size = 1;
+
+    return sc_gluon_produced_param;
+}
+
+sc_gluon_out_param_tag_v1 add_many_f64(sc_gluon_library_data_v1_t library_data,
+                                       sc_gluon_callable_object_v1_t maybe_callback_data,
+                                       sc_gluon_param_v1_t* in_params, uint32_t num_in_params,
+                                       sc_gluon_out_param_or_maybe_diagnostic_v1* out_param) {
+    double rolling { 0.0 };
+
+    for (size_t i { 0 }; i < num_in_params; ++i) {
+        if (in_params[i].tag != sc_gluon_f64) {
+            out_param->maybe_diagnostic = "all parameters should be doubles";
+            return sc_gluon_error_with_non_owned_diagnostic;
+        }
+
+        rolling += in_params[i].data.f64;
+    }
+
+    out_param->out_param.data.f64 = rolling;
+    out_param->out_param.tag = sc_gluon_f64;
+    out_param->out_param.owns_data = false;
+    out_param->out_param.size = 1;
+
+    return sc_gluon_produced_param;
+}
+
+sc_gluon_out_param_tag_v1 with_call_back(sc_gluon_library_data_v1_t library_data,
+                                         sc_gluon_callable_object_v1_t maybe_callback_data,
+                                         sc_gluon_param_v1_t* in_params, uint32_t num_in_params,
+                                         sc_gluon_out_param_or_maybe_diagnostic_v1* out_param) {
+    auto* lib = static_cast<LibraryData*>(library_data);
+
+    if (num_in_params != 1) {
+        out_param->maybe_diagnostic = "wrong number of in params";
+        return sc_gluon_error_with_non_owned_diagnostic;
+    }
+
+    std::thread([=, param_copy = sc_gluon_copy_param_data_v1(in_params[0])]() mutable {
+        using namespace std::chrono_literals;
+        std::this_thread::sleep_for(1s);
+
+        if (maybe_callback_data) {
+            param_t ps[2] = { create_param(), sc_gluon_copy_param_data_v1(param_copy) };
+            lib->callback_f(maybe_callback_data, ps, 2);
+        }
+
+        std::this_thread::sleep_for(1s);
+
+        if (maybe_callback_data) {
+            param_t ps[2] = { create_param(), sc_gluon_copy_param_data_v1(param_copy) };
+            lib->callback_f(maybe_callback_data, ps, 2);
+        }
+
+        sc_gluon_free_param_v1(param_copy);
+
+        if (maybe_callback_data)
+            lib->release_callback_f(maybe_callback_data);
+
+        return;
+    }).detach();
+
+    out_param->out_param = create_param(1);
+    return sc_gluon_produced_param;
+}
+
+
+SC_GLUON_EXPORT uint32_t sc_gluon_version() { return 1; }
+
+std::array<sc_gluon_function_declarations_v1_t, 3> decls {
+    sc_gluon_function_declarations_v1_t { "add_f64", add_f64, 2, false },
+    sc_gluon_function_declarations_v1_t { "add_many_f64", add_many_f64, -1, false },
+    sc_gluon_function_declarations_v1_t { "with_call_back", with_call_back, 1, true },
+};
+
+
+SC_GLUON_EXPORT sc_gluon_library_data_v1_t
+sc_gluon_load_library(sc_gluon_do_callback_v1_f callback_f, sc_gluon_release_callback_object_v1_f release_callback_f,
+                      sc_gluon_function_declarations_v1_t** const out_decls, uint32_t* out_size) {
+    *out_decls = decls.data();
+    *out_size = decls.size();
+    return new LibraryData { callback_f, release_callback_f };
+}

--- a/testsuite/server/CMakeLists.txt
+++ b/testsuite/server/CMakeLists.txt
@@ -1,8 +1,8 @@
-add_library(boost_test STATIC boost_test.cpp)
-target_link_libraries(boost_test PUBLIC Boost::unit_test_framework)
+# add_library(boost_test STATIC boost_test.cpp)
+# target_link_libraries(boost_test PUBLIC Boost::unit_test_framework)
 
-add_subdirectory(scsynth)
-if (SUPERNOVA)
-  add_subdirectory(supernova)
-endif()
+# add_subdirectory(scsynth)
+# if (SUPERNOVA)
+#   add_subdirectory(supernova)
+# endif()
 


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

Create an a way of calling dynamic libraries from inside sc.

See `include/gluons_ffi_interface` for the c api.

There are also tests using an inbuilt library, `TestGluon.run`, and some c tests using a testing library.

## Current state of this PR

Here is some code that currently works.

```supercollider
~l = Gluon.open("...");
~l.foo(2.0, 4.2); // 6.2 
~l.close

// or
Gluon.with("...") { |l|
   l.foo(2.0, 4.2)
};
```

Here is the implementation of `foo`
```cpp
sc_gluon_out_param_tag_v1 add_f64(sc_gluon_library_data_v1_t library_data,
                                  sc_gluon_callback_object_v1_t maybe_callback_data, sc_gluon_param_v1_t* in_params,
                                  uint32_t num_in_params, sc_gluon_out_param_or_maybe_diagnostic_v1* out_param) {
    if (num_in_params != 2) {
        out_param->maybe_diagnostic = "wrong number of in params";
        return sc_gluon_error_with_non_owned_diagnostic;
    }

    const sc_gluon_param_v1_t& p1 = in_params[0];
    const sc_gluon_param_v1_t& p2 = in_params[1];

    if (p1.tag != sc_gluon_f64) {
        out_param->maybe_diagnostic = "param 1 is not an f64";
        return sc_gluon_error_with_non_owned_diagnostic;
    }

    if (p2.tag != sc_gluon_f64) {
        out_param->maybe_diagnostic = "param 2 is not an f64";
        return sc_gluon_error_with_non_owned_diagnostic;
    }

    const auto r = p1.data.f64 + p2.data.f64;

    out_param->out_param.data.f64 = r;
    out_param->out_param.tag = sc_gluon_f64;
    out_param->out_param.owns_data = false;
    out_param->out_param.size = 1;

    return sc_gluon_produced_param;
}

```

Additionally, callbacks can be used.

```supercollider
Gluon.with("...") { |l|
   l.with_call_back("hello", callback: { |count, a|
      [count, a].postln
  });
}; // returns 1.2

// waits for 1
// prints [1, "hello"]
// waits for 1
// prints  [2, "hello"]

```

Here is the implementation of that.
```cpp

sc_gluon_out_param_tag_v1 with_call_back(sc_gluon_library_data_v1_t library_data,
                                         sc_gluon_callback_object_v1_t maybe_callback_data,
                                         sc_gluon_param_v1_t* in_params, uint32_t num_in_params,
                                         sc_gluon_out_param_or_maybe_diagnostic_v1* out_param) {
    auto* lib = static_cast<LibraryData*>(library_data);

    if (num_in_params != 1) {
        out_param->maybe_diagnostic = "wrong number of in params";
        return sc_gluon_error_with_non_owned_diagnostic;
    }

    std::thread([=, param_copy = sc_gluon_copy_param_v1(in_params[0])]() mutable {
        using namespace std::chrono_literals;
        std::this_thread::sleep_for(1s);

        if (maybe_callback_data) {
            param_t ps[2] = { create_param(1), sc_gluon_copy_param_v1(param_copy) };
            lib->callback_f(maybe_callback_data, ps, 2);
        }

        std::this_thread::sleep_for(1s);

        if (maybe_callback_data) {
            param_t ps[2] = { create_param(2), sc_gluon_copy_param_v1(param_copy) };
            lib->callback_f(maybe_callback_data, ps, 2);
        }

        sc_gluon_free_param_if_owned_v1(param_copy);

        if (maybe_callback_data)
            lib->release_callback_f(maybe_callback_data);

        return;
    }).detach();

    out_param->out_param = create_param(1.2);
    return sc_gluon_produced_param;
}
```

## Types of changes
- New feature

## To-do list

- [x] Implement windows version of `dlopen` and friends  ??? Current the CI is doing something odd.
- [x] Test the param type more, currently, only basics types have been tested, these could leak if they are done wrong.
- [x] Test callbacks
- [x] Figure out if the headers should be in their own repo — No
- [x] Investigate returnFromBlock at the top of the stack, doesn't seem to cause any issues, so why did it post a warning?  Answer: it causes subtle stack issues, I've made it a fatal error now as it will eventually crash the interpreter.
- [x] This PR is ready for review 

