### PR TITLE
Signal.hammingWindow size fix

### DIFF
--- a/SCClassLibrary/Common/Math/Signal.sc
+++ b/SCClassLibrary/Common/Math/Signal.sc
@@ -17,7 +17,7 @@ Signal[float] : FloatArray {
 		if (pad == 0, {
 			^this.newClear(size).fill(0.53836).addSine(1, 0.46164, -0.5pi);
 		},{
-			^this.newClear(size).fill(0.53836).addSine(1, 0.46164, -0.5pi) ++ this.newClear(pad);
+			^this.newClear(size-pad).fill(0.53836).addSine(1, 0.46164, -0.5pi) ++ this.newClear(pad);
 		});
 	}
 	*hanningWindow { arg size, pad=0;


### PR DESCRIPTION
When pad is not 0, the  non-pad part of the Signal should have that many fewer samples. This was overlooked for hamming, and led to an error with .asWavetable...
e.g.,
```
Signal.hammingWindow(1024, 512).size // -> 1536, not good.
Signal.hanningWindow(1024, 512).size // -> 1024, as required for wavetable.
```

Fixing this was a matter of changing a `size` to `size-pad`
when you look at the code for the other windows, it's pretty obvious that this is a simple oversight:



```
Signal[float] : FloatArray {

	*hammingWindow_old { arg size, pad=0;
		if (pad == 0, {
			^this.newClear(size).fill(0.5).addSine(1, 0.39, -0.5pi);
		},{
			^this.newClear(size-pad).fill(0.5).addSine(1, 0.39, -0.5pi) ++ this.newClear(pad);
		});
	}
	*hammingWindow { arg size, pad=0;
		if (pad == 0, {
			^this.newClear(size).fill(0.53836).addSine(1, 0.46164, -0.5pi);
		},{
HERE.    ------> ^this.newClear(size).fill(0.53836).addSine(1, 0.46164, -0.5pi) ++ this.newClear(pad);
		});
	}
	*hanningWindow { arg size, pad=0;
		if (pad == 0, {
			^this.newClear(size).fill(0.5).addSine(1, 0.5, -0.5pi);
		},{
			^this.newClear(size-pad).fill(0.5).addSine(1, 0.5, -0.5pi) ++ this.newClear(pad);
		});
	}
	*welchWindow { arg size, pad=0;
		if (pad == 0, {
			^this.newClear(size).addSine(0.5, 1, 0);
		},{
			^this.newClear(size-pad).addSine(0.5, 1, 0) ++ this.newClear(pad);
		});
	}
	*rectWindow { arg size, pad=0;
		if (pad == 0, {
			^this.newClear(size).fill(1.0);
		},{
			^this.newClear(size-pad).fill(1.0) ++ this.newClear(pad);
		});
	}
```