### PR TITLE
sclang: rework name resolution 

### DIFF
--- a/HelpSource/LanguageSpecification/NameResolution.schelp
+++ b/HelpSource/LanguageSpecification/NameResolution.schelp
@@ -1,0 +1,140 @@
+title:: Name Resolution 
+summary:: Looking up variables, arguments, and other named things.
+categories:: LanguageSpecification
+
+section:: Intended Behavior
+
+SuperCollider strives to be a top-to-bottom left-to-right language, this means things happen as in the order that western languages read text.
+
+
+Here is an example of an error.
+code::
+{
+	arg a1 = x1; // x1 is not declared yet!
+	var x1 = 4;
+	a1
+}
+::
+
+The error that is posted relates to code::x1:: not being found, this is because SuperCollider only ever looks above and to the left of the declaration.
+
+By declaring code::x1:: above the function, that variable is used.
+code::
+var x1 = 10;
+{
+	arg a1 = x1; // x1 is 10
+	var x1 = 4; // this x1 'clobbers' the previous, meaning you can't access the old one after this line.
+	a1 + x1 // 10 + 4
+}.() // returns 14;
+::
+
+
+It is possible to access the same identifier when initializing it, but only inside a new function.
+
+This is useful when defining functions recursively.
+
+code::
+var f = { |n|
+	if (n < 2) { 1 } { f.( n - 1 ) + f.( n - 2 ) }
+};
+::
+
+
+section:: History
+
+In previous versions of SuperCollider it was possible to access things in a bottom-to-top right-to-left order.
+While not a common issue, this was very confusing when it occurred.
+
+Here are some examples, note, these won't work in version 3.16 and onwards.
+
+code::
+{
+	arg a1 = x1 + 1;  // <<
+	var x1 = 2 + 2;
+	a1
+}.()
+::
+
+On the highlighted line, code::x1:: is accessed before it is declared. 
+This is no longer allowed, but previously this function would have returned code::nil::.
+However, had code::x1:: been initialized with a constant, say code::var x1 = 4;:: then the function would have returned code::4::.
+
+What is confusing here is that the default value of the argument code::a1:: depends on whether code::x1:: is initialized with a literal constant or an expression.
+
+
+section:: Migration Help and Common Issues
+
+In version 3.15 an error message is displayed to the user informing them that some for of initialization bug has occurred and that they need to update their code.
+From version 3.16, this will not produce an error, but instead attempt to find the variable in the parent scope, following the top-to-bottom left-to-right ordering SuperCollider strives for.
+
+Importantly, if a user didn't run their code on version 3.15, they might never get to see the error message informing them that their code's behavior is going to change.
+This is something to watch out for, however, the hope is that most people won't be affected by this change.
+
+
+subsection:: Mutually Recursive functions
+
+In previous versions of supercollider the following code would have worked.
+
+code::
+var f = {|n| if (n % 2 == 0) { g.(n) } { g.(n - 1) } };
+var g = {|n| if (n > 0) { f.(n - 1)} { 10 }};
+::
+
+Howver from version 3.16 and onwards, the only way to write this is to declare each variable upfront.
+
+code::
+var f, g;
+f = {|n| if (n % 2 == 0) { g.(n) } { g.(n - 1) } };
+g = {|n| if (n > 0) { f.(n - 1)} { 10 }};
+::
+
+Such relationships between identifiers are rare, but they do occur.
+
+
+subsection:: Interpreter Variables
+
+One place where this behaviour may be confusing is when using interpreter variables, like the single letter variables.
+
+In the past, the following code would have returned code::1::.
+
+code::
+{
+	arg c = s;
+	var s = 1;
+	c
+}.()
+::
+
+However, from version 3.16 and onwards, code::c:: is initialised to the interpreter variables code::s::, which is of course code::Server.default::!	
+This is something to watch out for, however, version 3.15 does emit a warning allowing the user to update their code to hopefully avoid an unexpected suprise.
+
+
+subsection:: Why do this?
+
+There are three main reasons. 
+
+First, given code usually executes down the page, being able to refer to something later on is essentially like time-travel.
+This is very confusing.
+
+Second, since this behaviour depends on whether the compiler can turn this into a constant expression (whether it can compute the value at compile time), 
+predicting what will happen requires intimate knownledge of the compiler.
+Since the compiler can change between versions, this means users need to read the source code every version to understand what their code will do.
+This is clearly not good.
+
+Third, if in the future supercollider allows you to declare variables in the middle of a function, then adding variables later on in the code will affect
+previous variables.
+Consider this example.
+
+code::
+
+var foo = 1;
+{
+	arg bar = foo;
+	... many many lines of code ...
+	var foo = 10; /// <<<
+}
+::
+
+Inserting the line code::var foo = 10:: changes the behaviour of line code::arg bar = foo::, despite the fact it might be declared several, or even hundreds, 
+of lines above.
+This would be quite confusing.

--- a/HelpSource/VersionUpdateGuide/ArgAndVarOrdering.schelp
+++ b/HelpSource/VersionUpdateGuide/ArgAndVarOrdering.schelp
@@ -1,0 +1,37 @@
+title:: Argument and Varible declaration ordering.
+summary:: A guide to updating code that used the old argument and variable initialisation ordering.
+categories:: VersionUpdateGuide
+
+
+In previous versions of supercollider the following code returned code::1::
+
+code::
+{
+	arg c = s;
+	var s = 1;
+	c
+}.()
+::
+
+However, this code returned code::nil::
+
+code::
+{
+	arg c = s;
+	var s = 2 - 1;
+	c
+}.()
+::
+
+This was because when the variable code::s:: is initialised with a constant expression (e.g., a literal value like code::1::) 
+it is assigned before the argument.
+
+This is confusing, but more importantly, 
+if in the future supercollider allows you to declare variables anywhere within a block of code, 
+this means adding variables onto the end of a function will change the behaviour of previously declared arguments and variables.
+
+That would be even more confusing!
+
+For this reason, going forward, supercollider will only let you use variables and arguments after they have started being declared. 
+
+For a more complete guide to this new behaviour see link::LanguageSpecification/NameResolution::.

--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -1177,8 +1177,9 @@ Server {
 
 	prPingApp { |func, onFailure, timeout = 3|
 		var id = func.hash;
-		var resp = OSCFunc({ |msg| if(msg[1] == id, { func.value; task.stop }) }, "/synced", addr);
-		var task = timeout !? { fork { timeout.wait; resp.free;  onFailure.value } };
+		var resp, task;
+		resp = OSCFunc({ |msg| if(msg[1] == id, { func.value; task.stop }) }, "/synced", addr);
+		task = timeout !? { fork { timeout.wait; resp.free;  onFailure.value } };
 		addr.sendMsg("/sync", id);
 	}
 

--- a/SCClassLibrary/Common/Quarks/Quarks.sc
+++ b/SCClassLibrary/Common/Quarks/Quarks.sc
@@ -342,7 +342,7 @@ Quarks {
 			// and all Exceptions should respond to 'errorString'
 			// but "throw during error handling" is really really bad,
 			// so, be doubly sure it won't happen
-			var text = err.tryPerform(\errorString) ?? { text = err.asString };
+			var text = err.tryPerform(\errorString) ?? { err.asString };
 			("Failed to read quarks directory listing: %\n%".format(if(fetch, directoryUrl, dirTxtPath), text)).error;
 			if(fetch, {
 				// if fetch failed, try read from cache

--- a/SCClassLibrary/JITLib/GUI/EnvirGui.sc
+++ b/SCClassLibrary/JITLib/GUI/EnvirGui.sc
@@ -20,7 +20,9 @@ EnvirGui : JITGui {
 
 	removeReplaceKey { |replacer|
 		var pv = this.viewForParam(replacer);
-		var replaced = replaceKeys.removeAt(replaced);
+		// TODO: this looks wrong, what was the intention here?	
+		// Note that 'replaced' is not used!
+		var replaced = replaceKeys.removeAt(nil);
 		if (pv.notNil) { pv.label_(replacer) };
 	}
 

--- a/SCClassLibrary/JITLib/Patterns/Pdef.sc
+++ b/SCClassLibrary/JITLib/Patterns/Pdef.sc
@@ -51,7 +51,7 @@ PatternProxy : Pattern {
 
 	convertFunction { |func|
 		^Prout {
-			var inval = func.def.prototypeFrame !? { inval = this.defaultEvent };
+			var inval = func.def.prototypeFrame !? { this.defaultEvent };
 			func.value( inval ).embedInStream(inval)
 		}
 	}

--- a/common/SC_Version.hpp.in
+++ b/common/SC_Version.hpp.in
@@ -18,6 +18,7 @@
  *    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
  */
 
+#pragma once
 #include <string>
 #include <sstream>
 #include <cstdint>

--- a/common/SC_VersionSwitches.hpp
+++ b/common/SC_VersionSwitches.hpp
@@ -1,0 +1,7 @@
+#pragma once
+#include "SC_Version.hpp"
+
+namespace scVersionSwitches {
+
+static constexpr SemanticVersion nameResolutionChange { 3, 16, 0 };
+}

--- a/lang/LangSource/PyrParseNode.cpp
+++ b/lang/LangSource/PyrParseNode.cpp
@@ -37,11 +37,14 @@
 #include <stdlib.h>
 #include <stdarg.h>
 #include <cctype>
+#include <unordered_map>
 #include "PredefinedSymbols.h"
+#include "SC_Version.hpp"
 #include "SimpleStack.h"
 #include "SC_LanguageConfig.hpp"
 #include "SC_Codecvt.hpp"
 #include "SpecialSelectorsOperatorsAndClasses.h"
+#include "SC_VersionSwitches.hpp"
 
 namespace fs = std::filesystem;
 
@@ -69,6 +72,9 @@ PyrClass* gCompilingClass = nullptr;
 PyrMethod* gCompilingMethod = nullptr;
 PyrBlock* gCompilingBlock = nullptr;
 PyrBlock* gPartiallyAppliedFunction = nullptr;
+
+enum struct InitStates { NotStarted, Started, Finished };
+std::unordered_map<PyrBlock*, std::vector<InitStates>> gNamedIdentifierInitStates {};
 
 bool gIsTailCodeBranch = false;
 bool gTailIsMethodReturn = false;
@@ -132,8 +138,8 @@ void compileQMsg(PyrParseNode* arg1, PyrParseNode* arg2);
 void compileQQMsg(PyrParseNode* arg1, PyrParseNode* arg2);
 void compileXQMsg(PyrParseNode* arg1, PyrParseNode* arg2);
 void compileSwitchMsg(PyrCallNode* node);
-void compileAssignVar(PyrParseNode* node, PyrSymbol* varName, bool drop);
-void compilePushVar(PyrParseNode* node, PyrSymbol* varName);
+void compileAssignVar(PyrParseNode* node, PyrSymbol* varName, bool drop, bool ignoreInitErrors);
+void compilePushVar(PyrParseNode* node, PyrSymbol* varName, bool ignoreInitErrors = false);
 bool isAnInlineableBlock(PyrParseNode* node);
 bool isAnInlineableAtomicLiteralBlock(PyrParseNode* node);
 bool isAtomicLiteral(PyrParseNode* node);
@@ -155,8 +161,8 @@ void fillClassPrototypes(PyrClassNode* node, PyrClass* classobj, PyrClass* super
 bool isThisObjNode(PyrParseNode* node);
 int conjureSelectorIndex(PyrParseNode* node, PyrBlock* func, bool isSuper, PyrSymbol* selector, int* selType);
 Byte conjureLiteralSlotIndex(PyrParseNode* node, PyrBlock* func, PyrSlot* slot);
-bool findVarName(PyrBlock* func, PyrClass** classobj, PyrSymbol* name, int* varType, int* level, int* index,
-                 PyrBlock** tempfunc);
+bool findVarName(PyrParseNode* node, PyrBlock* func, PyrClass** classobj, PyrSymbol* name, int* varType, int* level,
+                 int* index, PyrBlock** tempfunc, bool ignoreInitErrors = false);
 void countClassVarDefs(PyrClassNode* node, int* numClassMethods, int* numInstMethods);
 void dumpNodeList(PyrParseNode* node);
 int compareCallArgs(PyrMethodNode* node, PyrCallNode* cnode, int* varIndex, PyrClass* specialClass);
@@ -253,18 +259,19 @@ struct FindVarNameResult {
     PyrClass* classobj;
 };
 
-std::optional<FindVarNameResult> findVarName(PyrBlock* func, PyrClass* classobjC, PyrSymbol* varName) {
+std::optional<FindVarNameResult> findVarName(PyrParseNode* node, PyrBlock* func, PyrClass* classobjC,
+                                             PyrSymbol* varName, bool ignoreInitErrors = false) {
     int level, index, varType;
     PyrClass* classobj = classobjC;
     PyrBlock* tempfunc;
 
-    if (findVarName(func, &classobj, varName, &varType, &level, &index, &tempfunc))
+    if (findVarName(node, func, &classobj, varName, &varType, &level, &index, &tempfunc, ignoreInitErrors))
         return FindVarNameResult { level, index, varType, tempfunc, classobj };
     else
         return std::nullopt;
 }
 
-void compilePushVar(PyrParseNode* node, PyrSymbol* varName) {
+void compilePushVar(PyrParseNode* node, PyrSymbol* varName, bool ignoreInitErrors) {
     if (std::isupper(varName->name[0])) {
         if (compilingCmdLine && varName->u.classobj == nullptr) {
             error("Class not defined.\n");
@@ -288,7 +295,7 @@ void compilePushVar(PyrParseNode* node, PyrSymbol* varName) {
         PushSpecialValue.emit(OpSpecialValue::False);
     } else if (varName == s_nil) {
         PushSpecialValue.emit(OpSpecialValue::Nil_);
-    } else if (const auto result = findVarName(gCompilingBlock, gCompilingClass, varName)) {
+    } else if (const auto result = findVarName(node, gCompilingBlock, gCompilingClass, varName, ignoreInitErrors)) {
         const FindVarNameResult findResult = *result;
         switch (findResult.varType) {
         case varInst:
@@ -1155,7 +1162,7 @@ int compareCallArgs(PyrMethodNode* node, PyrCallNode* cnode, int* varIndex, PyrC
         PyrClass* classobj;
 
         classobj = gCompilingClass;
-        varFound = findVarName(gCompilingBlock, &classobj, slotRawSymbol(&nameNode->mSlot), &varType, &varLevel,
+        varFound = findVarName(node, gCompilingBlock, &classobj, slotRawSymbol(&nameNode->mSlot), &varType, &varLevel,
                                varIndex, nullptr);
         if (!varFound)
             return methNormal;
@@ -1327,6 +1334,8 @@ void PyrMethodNode::compile(PyrSlot* result) {
     methraw->popSize = numSlots - 1;
     firstKeyIndex = numArgs + numVariableArgs + numKwArgs;
 
+    gNamedIdentifierInitStates[method] = std::vector<InitStates>(numSlots, InitStates::NotStarted);
+
     numArgNames = methraw->posargs;
 
     if (numSlots == 1) {
@@ -1487,6 +1496,15 @@ void PyrMethodNode::compile(PyrSlot* result) {
         }
     }
 
+    // If there are no initialiser expression, which would involve using the name resolution, then set all the
+    // gNamedIdentifiers to finished. This is done here because some optimised types of methods never actually call
+    // compile on their body. If there are initialiser expression, then the methType is about to be set to methNormal
+    // and it will be compiled as expected.
+    if (!hasVarExprs) {
+        for (auto& v : gNamedIdentifierInitStates[method])
+            v = InitStates::Finished;
+    }
+
     methType = methNormal;
     if (hasVarExprs) {
         methType = methNormal;
@@ -1634,16 +1652,26 @@ void PyrMethodNode::compile(PyrSlot* result) {
         compile_body:
             SetTailIsMethodReturn mr(false);
             PyrSlot dummy;
+            const auto numTotalArguments = methraw->posargs;
             if (mArglist) {
                 vardef = mArglist->mVarDefs;
                 for (i = 1; i < numArgs; ++i, vardef = (PyrVarDefNode*)vardef->mNext) {
+                    gNamedIdentifierInitStates[method][i] = InitStates::Started;
                     vardef->compileArg(&dummy);
+                    gNamedIdentifierInitStates[method][i] = InitStates::Finished;
                 }
+                // No need to compile, you can't set them.
+                if (mArglist->mRest)
+                    gNamedIdentifierInitStates[method][numArgs] = InitStates::Finished;
+                if (mArglist->mKeywordArgs)
+                    gNamedIdentifierInitStates[method][numArgs + 1] = InitStates::Finished;
             }
             if (mVarlist) {
                 vardef = mVarlist->mVarDefs;
                 for (i = 0; i < numVars; ++i, vardef = (PyrVarDefNode*)vardef->mNext) {
+                    gNamedIdentifierInitStates[method][numTotalArguments + i] = InitStates::Started;
                     vardef->compile(&dummy);
+                    gNamedIdentifierInitStates[method][numTotalArguments + i] = InitStates::Finished;
                 }
             }
             COMPILENODE(mBody, &dummy, true);
@@ -1651,11 +1679,13 @@ void PyrMethodNode::compile(PyrSlot* result) {
         installByteCodes((PyrBlock*)method);
     }
 
+
     if (!oldmethod) {
         addMethod(gCompilingClass, method);
     }
 
     gCompilingMethod = nullptr;
+    gNamedIdentifierInitStates.erase(method);
     gCompilingBlock = nullptr;
     gPartiallyAppliedFunction = nullptr;
 
@@ -1731,7 +1761,7 @@ bool PyrVarDefNode::hasExpr(PyrSlot* result) {
 void PyrVarDefNode::compile(PyrSlot* result) {
     if (hasExpr(nullptr)) {
         COMPILENODE(mDefVal, result, false);
-        compileAssignVar((PyrParseNode*)this, slotRawSymbol(&mVarName->mSlot), mDrop);
+        compileAssignVar((PyrParseNode*)this, slotRawSymbol(&mVarName->mSlot), mDrop, true);
     }
 }
 
@@ -1739,7 +1769,9 @@ void PyrVarDefNode::compileArg(PyrSlot* result) {
     if (hasExpr(nullptr)) {
         ByteCodes trueByteCodes;
 
-        compilePushVar((PyrParseNode*)this, slotRawSymbol(&mVarName->mSlot));
+        // Check if one was provided by the call sight.
+        // Here we ignore accessin it before it is declared.
+        compilePushVar((PyrParseNode*)this, slotRawSymbol(&mVarName->mSlot), true);
 
         mDrop = false;
         trueByteCodes = compileBodyWithGoto(this, 0, true);
@@ -1751,9 +1783,6 @@ void PyrVarDefNode::compileArg(PyrSlot* result) {
         compileAndFreeByteCodes(trueByteCodes);
         Drop.emit();
     }
-
-    // error("compilePyrVarDefNode: shouldn't get here.\n");
-    // compileErrors++;
 }
 
 
@@ -1840,6 +1869,7 @@ void PyrCallNodeBase::compilePartialApplication(int numCurryArgs, PyrSlot* resul
     methraw->numtemps = numCurryArgs;
     methraw->popSize = numCurryArgs;
     methraw->methType = methBlock;
+    gNamedIdentifierInitStates[block] = std::vector<InitStates>(numCurryArgs, InitStates::NotStarted);
 
     {
         PyrSymbol* s_empty = getsym("_");
@@ -1875,6 +1905,7 @@ void PyrCallNodeBase::compilePartialApplication(int numCurryArgs, PyrSlot* resul
     }
 
     gCompilingBlock = prevBlock;
+    gNamedIdentifierInitStates.erase(block);
     gCompilingClass = prevClass;
     gPartiallyAppliedFunction = prevPartiallyAppliedFunction;
     gFunctionCantBeClosed = gFunctionCantBeClosed || prevFunctionCantBeClosed;
@@ -2052,7 +2083,7 @@ void PyrCallNode::compileCall(PyrSlot* result) {
                     emitTailCall();
                     SendSpecialMsgThisOpt.emit(Operands::Index::fromRaw(selectorSlotOrSpecialIndex));
                 } else if (varname) {
-                    if (const auto result = findVarName(gCompilingBlock, gCompilingClass, varname);
+                    if (const auto result = findVarName(this, gCompilingBlock, gCompilingClass, varname);
                         result && result->varType == varInst) {
                         emitTailCall();
                         PushInstVarAndSendSpecialMsg.emit(Operands::Index::fromRaw(result->index),
@@ -3539,7 +3570,7 @@ bool isUnassignableSymbol(PyrSymbol* varName) {
         || varName == s_curMethod || varName == s_curBlock || varName == s_curClosure;
 }
 
-void compileAssignVar(PyrParseNode* node, PyrSymbol* varName, bool drop) {
+void compileAssignVar(PyrParseNode* node, PyrSymbol* varName, bool drop, bool ignoreInitErrors = false) {
     if (isUnassignableSymbol(varName)) {
         error("You may not assign to '%s'.", varName->name);
         nodePostErrorLine(node);
@@ -3553,7 +3584,7 @@ void compileAssignVar(PyrParseNode* node, PyrSymbol* varName, bool drop) {
         return;
     }
 
-    const auto result = findVarName(gCompilingBlock, gCompilingClass, varName);
+    const auto result = findVarName(node, gCompilingBlock, gCompilingClass, varName, ignoreInitErrors);
     if (!result) {
         error("Variable '%s' not defined.\n", varName->name);
         nodePostErrorLine(node);
@@ -3931,6 +3962,8 @@ void PyrBlockNode::compile(PyrSlot* slotResult) {
     methraw->numtemps = numSlots;
     methraw->popSize = numSlots;
 
+    gNamedIdentifierInitStates[block] = std::vector<InitStates>(numSlots, InitStates::NotStarted);
+
     numArgNames = methraw->posargs;
 
     if (numArgNames) {
@@ -4073,8 +4106,7 @@ void PyrBlockNode::compile(PyrSlot* slotResult) {
         for (i = 0; i < numArgs; ++i, vardef = (PyrVarDefNode*)vardef->mNext) {
             PyrSlot *slot, litval;
             slot = slotRawObject(&block->prototypeFrame)->slots + i;
-            if (vardef->hasExpr(&litval))
-                hasVarExprs = true;
+            vardef->hasExpr(&litval);
             *slot = litval;
         }
     }
@@ -4091,8 +4123,7 @@ void PyrBlockNode::compile(PyrSlot* slotResult) {
         for (i = 0; i < numVars; ++i, vardef = (PyrVarDefNode*)vardef->mNext) {
             PyrSlot *slot, litval;
             slot = slotRawObject(&block->prototypeFrame)->slots + i + numArgs + numVariableArgs;
-            if (vardef->hasExpr(&litval))
-                hasVarExprs = true;
+            vardef->hasExpr(&litval);
             *slot = litval;
         }
     }
@@ -4103,18 +4134,26 @@ void PyrBlockNode::compile(PyrSlot* slotResult) {
     {
         SetTailBranch branch(true);
         SetTailIsMethodReturn mr(false);
-        if (hasVarExprs) {
-            if (mArglist) {
-                vardef = mArglist->mVarDefs;
-                for (i = 0; i < numArgs; ++i, vardef = (PyrVarDefNode*)vardef->mNext) {
-                    vardef->compileArg(&dummy);
-                }
+        const auto numTotalArguments = methraw->posargs;
+        if (mArglist) {
+            vardef = mArglist->mVarDefs;
+            for (i = 0; i < numArgs; ++i, vardef = (PyrVarDefNode*)vardef->mNext) {
+                gNamedIdentifierInitStates[block][i] = InitStates::Started;
+                vardef->compileArg(&dummy);
+                gNamedIdentifierInitStates[block][i] = InitStates::Finished;
             }
-            if (mVarlist) {
-                vardef = mVarlist->mVarDefs;
-                for (i = 0; i < numVars; ++i, vardef = (PyrVarDefNode*)vardef->mNext) {
-                    vardef->compile(&dummy);
-                }
+            // No need to compile these because you can't set them.
+            if (mArglist->mRest)
+                gNamedIdentifierInitStates[block][numArgs] = InitStates::Finished;
+            if (mArglist->mKeywordArgs)
+                gNamedIdentifierInitStates[block][numArgs + 1] = InitStates::Finished;
+        }
+        if (mVarlist) {
+            vardef = mVarlist->mVarDefs;
+            for (i = 0; i < numVars; ++i, vardef = (PyrVarDefNode*)vardef->mNext) {
+                gNamedIdentifierInitStates[block][numTotalArguments + i] = InitStates::Started;
+                vardef->compile(&dummy);
+                gNamedIdentifierInitStates[block][numTotalArguments + i] = InitStates::Finished;
             }
         }
         if (mBody->mClassno == pn_BlockReturnNode) {
@@ -4137,6 +4176,7 @@ void PyrBlockNode::compile(PyrSlot* slotResult) {
     gCompilingBlock = prevBlock;
     gCompilingClass = prevClass;
     gPartiallyAppliedFunction = prevPartiallyAppliedFunction;
+    gNamedIdentifierInitStates.erase(block);
     gFunctionCantBeClosed = gFunctionCantBeClosed || prevFunctionCantBeClosed;
     gFunctionHighestExternalRef = sc_max(gFunctionHighestExternalRef - 1, prevFunctionHighestExternalRef);
 }
@@ -4360,102 +4400,153 @@ int conjureConstantIndex(PyrParseNode* node, PyrBlock* func, PyrSlot* slot) {
     return constants->size - 1;
 }
 
-bool findVarName(PyrBlock* func, PyrClass** classobj, PyrSymbol* name, int* varType, int* level, int* index,
-                 PyrBlock** tempfunc) {
-    int i, j, k;
-    int numargs;
-    PyrSymbol *argname, *varname;
-    PyrMethodRaw* methraw;
+bool findVarName(PyrParseNode* node, PyrBlock* startingFunc, PyrClass** classobj, PyrSymbol* name, int* varType,
+                 int* level, int* index, PyrBlock** tempfunc, bool ignoreInitErrors) {
+    assert(name);
+    assert(name->name);
+    // These can come first because you are not allowed to redefine them.
+    if (name == s_curProcess) {
+        *varType = varPseudo;
+        *index = opgProcess;
+        return true;
+    } else if (name == s_curThread) {
+        *varType = varPseudo;
+        *index = opgThread;
+        return true;
+    } else if (name == s_curMethod) {
+        *varType = varPseudo;
+        *index = opgMethod;
+        return true;
+    } else if (name == s_curBlock) {
+        *varType = varPseudo;
+        *index = opgFunctionDef;
+        return true;
+    } else if (name == s_curClosure) {
+        *varType = varPseudo;
+        *index = opgFunction;
+        return true;
+    } else if (std::isupper(name->name[0])) {
+        return false; // Never allowed to have a variable starting with an upper case letter.
+    }
 
-    // postfl("->findVarName %s\n", name->name);
-    // find var in enclosing blocks, instance, class
     if (name == s_super) {
         gFunctionCantBeClosed = true;
         name = s_this;
     }
-    if (name->name[0] >= 'A' && name->name[0] <= 'Z')
-        return false;
 
-    j = 0;
-    while (func != nullptr) {
-        methraw = METHRAW(func);
-        numargs = methraw->posargs;
-        for (i = 0; i < numargs; ++i) {
-            argname = slotRawSymbolArray(&func->argNames)->symbols[i];
-            // postfl("    %d %d arg '%s' '%s'\n", j, i, argname->name, name->name);
-            if (argname == name) {
-                *level = j;
-                *index = i;
-                *varType = varTemp;
-                if (tempfunc)
-                    *tempfunc = func;
-                if (j > gFunctionHighestExternalRef)
-                    gFunctionHighestExternalRef = j;
-                return true;
+    assert(name);
+    assert(name->name);
+
+
+    // Lambdas for walking the call stack
+
+    const auto getFrameIndexOfName = [&](PyrSymbolArray* names, size_t offsetInFrame,
+                                         PyrBlock* fdef) -> std::optional<int> {
+        if (!names)
+            return std::nullopt;
+
+        const auto size = names->size;
+        for (size_t index { 0 }; index < size; ++index) {
+            const auto frameIndex = offsetInFrame + index;
+
+            const auto consideringName = names->symbols[index];
+            if (consideringName != name)
+                continue;
+
+            if (ignoreInitErrors)
+                return { frameIndex };
+
+            const auto initialiser = gNamedIdentifierInitStates.find(fdef);
+            if (initialiser == std::end(gNamedIdentifierInitStates))
+                return { frameIndex };
+
+            const auto& states = initialiser->second;
+            assert(frameIndex < states.size());
+
+            const auto initState = states[offsetInFrame + index];
+            if (initState == InitStates::Finished)
+                return { frameIndex };
+
+            if (initState == InitStates::Started) {
+                // Lets you have recursive functions, but only functions, as they create a new FunctionDef
+                if (fdef != startingFunc) {
+                    return { frameIndex };
+                } else if constexpr (SC_Version < scVersionSwitches::nameResolutionChange) {
+                    error("Using the variable '%s' in its own initialiser ", name->name);
+                    nodePostErrorLine(node);
+                    emitCompilerErrorFromVersion(scVersionSwitches::nameResolutionChange);
+                    return { frameIndex };
+                }
             }
+
+            if constexpr (SC_Version < scVersionSwitches::nameResolutionChange) {
+                post("\n");
+                error("Accessing the named identifier '%s' before it was declared.\n"
+                      "From the next version of SuperCollider, this will be an error and your code will "
+                      "fail to compile or behave differently.\n"
+                      "Please fix the code before updating.\n"
+                      "For more information on this change see scdoc://VersionUpdateGuide/ArgAndVarOrdering.html\n",
+                      name->name);
+                nodePostErrorLine(node);
+                post("\n");
+                return { frameIndex };
+            }
+
+            // Not allowed from 3.16 onwards.
+            return std::nullopt;
         }
-        for (i = 0, k = numargs; i < methraw->numvars; ++i, ++k) {
-            varname = slotRawSymbolArray(&func->varNames)->symbols[i];
-            // postfl("    %d %d %d var '%s' '%s'\n", j, i, k, varname->name, name->name);
-            if (varname == name) {
-                *level = j;
-                *index = k;
-                *varType = varTemp;
-                if (tempfunc)
-                    *tempfunc = func;
-                if (j > gFunctionHighestExternalRef)
-                    gFunctionHighestExternalRef = j;
-                return true;
-            }
+        return std::nullopt;
+    };
+
+    int fdefLevel = 0;
+    for (auto* fdef = startingFunc; fdef; fdef = slotRawBlock(&fdef->contextDef), ++fdefLevel) {
+        const auto methraw = METHRAW(fdef);
+        const auto numTotalArguments = methraw->posargs;
+
+        // Look in the arguments.
+        if (const auto indexInFrame = getFrameIndexOfName(slotRawSymbolArray(&fdef->argNames), 0, fdef)) {
+            *level = fdefLevel;
+            *index = *indexInFrame;
+            *varType = varTemp;
+            if (tempfunc)
+                *tempfunc = fdef;
+            if (fdefLevel > gFunctionHighestExternalRef)
+                gFunctionHighestExternalRef = fdefLevel;
+            return true;
         }
 
-        func = slotRawBlock(&func->contextDef);
-        ++j;
+        // Look in the variables.
+        if (const auto indexInFrame =
+                getFrameIndexOfName(slotRawSymbolArray(&fdef->varNames), numTotalArguments, fdef)) {
+            *level = fdefLevel;
+            *index = *indexInFrame;
+            *varType = varTemp;
+            if (tempfunc)
+                *tempfunc = fdef;
+            if (fdefLevel > gFunctionHighestExternalRef)
+                gFunctionHighestExternalRef = fdefLevel;
+            return true;
+        }
     }
 
+    // These must come at the end.
+    // This means we cannot have class definitions inside of functions.
     if (classFindInstVar(*classobj, name, index)) {
         *level = 0;
         *varType = varInst;
         if (gCompilingClass != class_interpreter)
             gFunctionCantBeClosed = true;
         return true;
-    }
-    if (classFindClassVar(classobj, name, index)) {
+    } else if (classFindClassVar(classobj, name, index)) {
         *varType = varClass;
         if (gCompilingClass != class_interpreter)
             gFunctionCantBeClosed = true;
         return true;
-    }
-    if (classFindConst(classobj, name, index)) {
+    } else if (classFindConst(classobj, name, index)) {
         *varType = varConst;
-        // if (gCompilingClass != class_interpreter) gFunctionCantBeClosed = true;
         return true;
     }
-    if (name == s_curProcess) {
-        *varType = varPseudo;
-        *index = opgProcess;
-        return true;
-    }
-    if (name == s_curThread) {
-        *varType = varPseudo;
-        *index = opgThread;
-        return true;
-    }
-    if (name == s_curMethod) {
-        *varType = varPseudo;
-        *index = opgMethod;
-        return true;
-    }
-    if (name == s_curBlock) {
-        *varType = varPseudo;
-        *index = opgFunctionDef;
-        return true;
-    }
-    if (name == s_curClosure) {
-        *varType = varPseudo;
-        *index = opgFunction;
-        return true;
-    }
+
     return false;
 }
 

--- a/lang/LangSource/PyrParseNode.cpp
+++ b/lang/LangSource/PyrParseNode.cpp
@@ -4472,9 +4472,15 @@ bool findVarName(PyrParseNode* node, PyrBlock* startingFunc, PyrClass** classobj
                 if (fdef != startingFunc) {
                     return { frameIndex };
                 } else if constexpr (SC_Version < scVersionSwitches::nameResolutionChange) {
-                    error("Using the variable '%s' in its own initialiser ", name->name);
+                    post("\n");
+                    error("Using the variable '%s' in its own initialiser.\n"
+                          "From the next version of SuperCollider this will be an error and your code will fail to "
+                          "compile or behave differently.\n"
+                          "Please fix the code before updating.\n"
+                          "For more information on this change see scdoc://VersionUpdateGuide/ArgAndVarOrdering.html\n",
+                          name->name);
                     nodePostErrorLine(node);
-                    emitCompilerErrorFromVersion(scVersionSwitches::nameResolutionChange);
+                    post("\n");
                     return { frameIndex };
                 }
             }
@@ -4482,8 +4488,8 @@ bool findVarName(PyrParseNode* node, PyrBlock* startingFunc, PyrClass** classobj
             if constexpr (SC_Version < scVersionSwitches::nameResolutionChange) {
                 post("\n");
                 error("Accessing the named identifier '%s' before it was declared.\n"
-                      "From the next version of SuperCollider, this will be an error and your code will "
-                      "fail to compile or behave differently.\n"
+                      "From the next version of SuperCollider this will be an error and your code will fail to compile "
+                      "or behave differently.\n"
                       "Please fix the code before updating.\n"
                       "For more information on this change see scdoc://VersionUpdateGuide/ArgAndVarOrdering.html\n",
                       name->name);

--- a/testsuite/classlibrary/TestDocumentEnvir.sc
+++ b/testsuite/classlibrary/TestDocumentEnvir.sc
@@ -82,8 +82,8 @@ TestDocumentEnvironment : UnitTest {
 	}
 
 	test_onClose {
-		var test = { this.assertEquals(count, 1, "onClose should be called not more than once") };
 		var count = 0;
+		var test = { this.assertEquals(count, 1, "onClose should be called not more than once") };
 		var counter = { count = count + 1; test.value; };
 		doc.onClose = counter;
 		doc.close;
@@ -91,9 +91,8 @@ TestDocumentEnvironment : UnitTest {
 	}
 
 	test_endFront_on_close {
-
-		var test = { this.assertEquals(count, 1, "endFrontAction should be called not more than once") };
 		var count = 0;
+		var test = { this.assertEquals(count, 1, "endFrontAction should be called not more than once") };
 		var counter = { count = count + 1; test.value; };
 		doc.endFrontAction = counter;
 		doc.close;

--- a/testsuite/classlibrary/TestEvent.sc
+++ b/testsuite/classlibrary/TestEvent.sc
@@ -206,6 +206,7 @@ TestEvent : UnitTest {
 	}
 
 	test_server_messages_type_note {
+		var i, msg1, finishTest = false;
 		// type note
 		var event = (
 			type: \note,
@@ -218,7 +219,6 @@ TestEvent : UnitTest {
 			latency: 0,
 			finish: { finishTest = true }
 		);
-		var i, msg1, finishTest = false;
 		var isPlaying;
 
 		SynthDef(\xxx_test, { |freq, zzzz, gate = 1|

--- a/testsuite/classlibrary/TestTask.sc
+++ b/testsuite/classlibrary/TestTask.sc
@@ -41,8 +41,8 @@ TestTask : UnitTest {
 
 	makePlayTestWithClock { |clock, nameString|
 		var ok = false;
-		var task = Task { 0.001.wait; ok = true; cond.signalAll };
 		var cond = CondVar.new;
+		var task = Task { 0.001.wait; ok = true; cond.signalAll };
 		task.play(clock);
 		cond.waitFor(1, { ok });
 		task.stop;


### PR DESCRIPTION
This has become a bigger change than expected.

Essentially the issue was that while we can emit errors, a lot of the code actually makes sense, it just differs from what supercollider is currently doing (which is confusing and wrong).

For that reason, there are breaking changes in this PR, namely, you cannot have inline mutually recursive functions.

```supercollider
var f = {g.()};
var g = {f.()};
```

After this PR (and from version 3.16), this will have to be...
```supercollider
var f, g;
f = {g.()};
g = {f.()};
``` 


Please also see the new language specification help documentation I have made, it is just a start, but will be really useful to have some informal descriptions of what the language should do, rather than relying on what it happens to do.

## Purpose and Motivation

See the opening of Lucile Nihlen's keynote. @lnihlen.

https://www.youtube.com/watch?v=SM1nnjeHluI

TLDR:
```supercollider
var f = {
	arg a1 = x1;
	var x1 =2 + 2;
	a1
}; // returns nil, not 4.

var f = {
	arg a1 = x1;
	var x1 = 4;
	a1
} // returns 4
```

Here is another one that interacts with interpreter variables.

```supercollider
s; // server

f = {
	arg c = s;  // this 's' refers to the 's' on the next line.
	var s = 1;
	c
}

f.() // returns 1, not the server
```

This is a feature that shouldn't have ever existed as it causes far more problems that it solves, if a user is using this as as feature, they have one more version to change it before it is made invalid behaviour.

---


This PR changes the name resolution so you cannot access variables and arguments before they are declared.

To mitigate this breaking change, in version 3.15 an error message is produced informing the user they need to update.

From version 3.16, this will discount the variable that hasn't been declared yet, and instead look it up in the parent scope.

Here is what this looks like.


---

## Behavior in 3.15

### 1

```
{ arg a = b, b = 10; a }.()

ERROR: Accessing the named identifier 'b' before it was declared.
From the next version of SuperCollider, this will be an error and your code will fail to compile or behave differently.
Please fix the code before updating.
For more information on this change see scdoc://VersionUpdateGuide/ArgAndVarOrdering.html
  in interpreted text
  line 1 char 11:

  { arg a = b, b = 10; a }.() 
             
-----------------------------------

-> 10

```

### 2

Like 1, but uses expression not literal. All other examples behave the same as this if you replace the initialisation with an expression.

```
{ arg a = b, b = 2 + 2; a }.()

ERROR: Accessing the named identifier 'b' before it was declared.
From the next version of SuperCollider, this will be an error and your code will fail to compile or behave differently.
Please fix the code before updating.
For more information on this change see scdoc://VersionUpdateGuide/ArgAndVarOrdering.html
  in interpreted text
  line 1 char 11:

  { arg a = b, b = 2 + 2; a }.() 
             
-----------------------------------

-> nil
```
             
### 3

```
{ var x = y; var y; x }.()

ERROR: Accessing the named identifier 'y' before it was declared.
From the next version of SuperCollider, this will be an error and your code will fail to compile or behave differently.
Please fix the code before updating.
For more information on this change see scdoc://VersionUpdateGuide/ArgAndVarOrdering.html
  in interpreted text
  line 1 char 11:

  { var x = y; var y; x }.() 
             
-----------------------------------

-> nil
```

### 4

```
{ var x = x; x }.()

ERROR: Using the variable 'x' in its own initialiser.
From the next version of SuperCollider this will be an error and your code will fail to compile or behave differently.
Please fix the code before updating.
For more information on this change see scdoc://VersionUpdateGuide/ArgAndVarOrdering.html
  in interpreted text
  line 1 char 11:

  { var x = x; x }.() 
             
-----------------------------------

-> nil
```

### 5

This one produces no error.
This is to allow recursive functions.
```
{ var f = { f }; f }.()
```


### 6

```
{ var x = y; var y = 10; x }.()

ERROR: Accessing the named identifier 'y' before it was declared.
From the next version of SuperCollider this will be an error and your code will fail to compile or behave differently.
Please fix the code before updating.
For more information on this change see scdoc://VersionUpdateGuide/ArgAndVarOrdering.html
  in interpreted text
  line 1 char 11:

  { var x = y; var y = 10; x }.() 
             
-----------------------------------

-> 10

```

## Behavior in 3.16


```
{ arg a = b, b = 10; a }.()
-> nil
```

Why?? `b` is an interpreter variable!
```
b = \meow;
{ arg a = b, b = 10; a }.()
-> \meow
```


All of the possible errors produce the same error message because they are all trying to lookup the name strictly **before** the current initialization.

```
{ arg a1 = b1, b1 = 10; a1 }.()

ERROR: Variable 'b1' not previously declared.
  in interpreted text
  line 1 char 13:

  { arg a1 = b1, b1 = 10; a1 }.() 
               
-----------------------------------
-> nil
```

