### PR TITLE
sclang: introduce AbstractObject

### DIFF
--- a/SCClassLibrary/Common/Core/ExperimentalAbstractObject.sc
+++ b/SCClassLibrary/Common/Core/ExperimentalAbstractObject.sc
@@ -1,18 +1,18 @@
-// ExperimentalAbstractObject represent the minimum interface needed to get the interpreter to work (it will cause the IDE to post an error as it doesn't support printing).
+// AbstractObjectExperimental represent the minimum interface needed to get the interpreter to work (it will cause the IDE to post an error as it doesn't support printing).
 // This make it very useful as a wrapper class and to implement some specific features.
 
 // !!! --- PLEASE NEVER ADD A NORMAL PASCAL CASE METHOD TO ABSTRACT OBJECT --- !!!
-// The whole point of this class is to be minimal, ExperimentalAbstractObjects are not Objects, allowing those who subclass it to create their own definition of what an object is and isn't.
+// The whole point of this class is to be minimal, AbstractObjectExperimentals are not Objects, allowing those who subclass it to create their own definition of what an object is and isn't.
 
-ExperimentalAbstractObject {
+AbstractObjectExperimental {
 
 	/////// 1. Core and Interpreter functionality, do not override.
 
 	*new { |maxSize = 0| _BasicNew; ^this.sc_abstract_object_primitive_failed }
 	*newCopyArgs { | ... args, kwargs | _BasicNewCopyArgsToInstVars; ^this.sc_abstract_object_primitive_failed }
 
-	// ExperimentalAbstractObject support identity, this is required by the interpreter and cannot actually be overridden.
-	// When you put ExperimentalAbstractObjects into an identity dictionary the interpreter uses its own implementation, this should match the sclang implementation or things will get confusing.
+	// AbstractObjectExperimental support identity, this is required by the interpreter and cannot actually be overridden.
+	// When you put AbstractObjectExperimentals into an identity dictionary the interpreter uses its own implementation, this should match the sclang implementation or things will get confusing.
 	// Identity operators are also provided, this isn't strictly necessary, but we usually think of identity and these operators as a set.
 	identityHash { _ObjectHash; ^this.sc_abstract_object_primitive_failed }
 	=== { arg obj; _Identical; ^this.sc_abstract_object_primitive_failed }
@@ -20,7 +20,7 @@ ExperimentalAbstractObject {
 
 	// Interpreter will engage in undefined behavior if this method does not throw.
 	// It is not possible to implement a boolean abstract object as the compiler assumes its internal slot layout.
-	mustBeBoolean {  MustBeBooleanError(nil, "ExperimentalAbstractObject").throw }
+	mustBeBoolean {  MustBeBooleanError(nil, "AbstractObjectExperimental").throw }
 
 	// It is not possible to implement a 'nil' abstract object due to the compiler inlining the definition of these when used inside 'if' control flow.
 	// You cannot override these methods.
@@ -37,8 +37,8 @@ ExperimentalAbstractObject {
 	// Note: Interpreter will segfault if this isn't provided so a default is given.
 	// You will need to override doesNotUnderstand to anything useful will abstract objects,
 	//   hence why it throws a SubclassResponsibilityError rather than a DoesNotUnderstandError.
-	// "ExperimentalAbstractObject" is passed as a string here, rather than 'this', as 'this' may not support the 'toString' method, which would cause the error handling to get stuck in a loop.
-	doesNotUnderstand { |selector ...args, kwargs| SubclassResponsibilityError("ExperimentalAbstractObject", thisMethod, ExperimentalAbstractObject).throw }
+	// "AbstractObjectExperimental" is passed as a string here, rather than 'this', as 'this' may not support the 'toString' method, which would cause the error handling to get stuck in a loop.
+	doesNotUnderstand { |selector ...args, kwargs| SubclassResponsibilityError("AbstractObjectExperimental", thisMethod, AbstractObjectExperimental).throw }
 
 
 
@@ -47,7 +47,7 @@ ExperimentalAbstractObject {
 	// These methods may be used *only* to implement other abstract objects, do not call them from outside the definition of an abstract object.
 	// They are here so that other's may use primitive implementations, without making the primitives themselves publicly available.
 
-	sc_abstract_object_primitive_failed { PrimitiveFailedError("ExperimentalAbstractObject").throw }
+	sc_abstract_object_primitive_failed { PrimitiveFailedError("AbstractObjectExperimental").throw }
 
 	sc_abstract_object_hash { _ObjectHash; ^this.sc_abstract_object_primitive_failed }
 	sc_abstract_object_copy_shallow { _ObjectShallowCopy; ^this.sc_abstract_object_primitive_failed }
@@ -55,7 +55,7 @@ ExperimentalAbstractObject {
 	sc_abstract_object_copy_deep { _ObjectDeepCopy; ^this.sc_abstract_object_primitive_failed }
 
 	// Yielding — must be implemented as primitives as special methods are provided.
-	// Note that idle is not provided because it requires calling 'value' on the ExperimentalAbstractObject'.
+	// Note that idle is not provided because it requires calling 'value' on the AbstractObjectExperimental'.
 	sc_abstract_object_yield {	_RoutineYield; ^this.sc_abstract_object_primitive_failed }
 	sc_abstract_object_always_yield { _RoutineAlwaysYield; ^this.sc_abstract_object_primitive_failed }
 	sc_abstract_object_yield_and_reset { |reset = true| _RoutineYieldAndReset; ^this.sc_abstract_object_primitive_failed }
@@ -63,7 +63,7 @@ ExperimentalAbstractObject {
 	// This is often necessary in abstract objects to determine if we have an abstract object, use isKindOf in normal use.
 	sc_abstract_object_is_kind_of { |aClass| _ObjectIsKindOf; ^this.sc_abstract_object_primitive_failed }
 
-	// Needed when we want to do the normal method calling in an ExperimentalAbstractObject.
+	// Needed when we want to do the normal method calling in an AbstractObjectExperimental.
 	// In many cases, the 'perform*' messages should defer to these as most of the time, you actually want to implement doesNotUnderstand.
 	sc_abstract_object_perform_args { |selector, args, kwargs|	_ObjectPerformArgs;	^this.sc_abstract_object_primitive_failed }
 	sc_abstract_object_super_perform_args { |selector, args, kwargs| _ObjectSuperPerformArgs; ^this.sc_abstract_object_primitive_failed }

--- a/SCClassLibrary/Common/Core/ExperimentalAbstractObject.sc
+++ b/SCClassLibrary/Common/Core/ExperimentalAbstractObject.sc
@@ -1,5 +1,5 @@
 // AbstractObjectExperimental represent the minimum interface needed to get the interpreter to work (it will cause the IDE to post an error as it doesn't support printing).
-// This make it very useful as a wrapper class and to implement some specific features.
+// This make it useful as a wrapper class and to implement some specific features.
 
 // !!! --- PLEASE NEVER ADD A NORMAL PASCAL CASE METHOD TO ABSTRACT OBJECT --- !!!
 // The whole point of this class is to be minimal, AbstractObjectExperimentals are not Objects, allowing those who subclass it to create their own definition of what an object is and isn't.
@@ -32,11 +32,11 @@ AbstractObjectExperimental {
 
 
 
-	/////// 2. Main interface, override this method.
+	/////// 2. Main interface, override these method.
 
 	// Note: Interpreter will segfault if this isn't provided so a default is given.
 	// You will need to override doesNotUnderstand to anything useful will abstract objects,
-	//   hence why it throws a SubclassResponsibilityError rather than a DoesNotUnderstandError.
+	//   hence it throws a SubclassResponsibilityError rather than a DoesNotUnderstandError.
 	// "AbstractObjectExperimental" is passed as a string here, rather than 'this', as 'this' may not support the 'toString' method, which would cause the error handling to get stuck in a loop.
 	doesNotUnderstand { |selector ...args, kwargs| SubclassResponsibilityError("AbstractObjectExperimental", thisMethod, AbstractObjectExperimental).throw }
 
@@ -45,7 +45,7 @@ AbstractObjectExperimental {
 	/////// 3. Helper methods and primitive implementations
 
 	// These methods may be used *only* to implement other abstract objects, do not call them from outside the definition of an abstract object.
-	// They are here so that other's may use primitive implementations, without making the primitives themselves publicly available.
+	// They are here so that other objects may use primitive implementations, without making the primitives themselves publicly available.
 
 	sc_abstract_object_primitive_failed { PrimitiveFailedError("AbstractObjectExperimental").throw }
 

--- a/SCClassLibrary/Common/Core/ExperimentalAbstractObject.sc
+++ b/SCClassLibrary/Common/Core/ExperimentalAbstractObject.sc
@@ -1,5 +1,5 @@
 // AbstractObjectExperimental represents the minimum interface needed to get the interpreter to work (it will cause the IDE to post an error as it doesn't support printing).
-// This make it useful as a wrapper class and to implement some specific features.
+// This makes it useful as a wrapper class and to implement some specific features.
 
 // !!! --- PLEASE NEVER ADD A NORMAL PASCAL CASE METHOD TO ABSTRACT OBJECT --- !!!
 // The whole point of this class is to be minimal.

--- a/SCClassLibrary/Common/Core/ExperimentalAbstractObject.sc
+++ b/SCClassLibrary/Common/Core/ExperimentalAbstractObject.sc
@@ -1,0 +1,74 @@
+// ExperimentalAbstractObject represent the minimum interface needed to get the interpreter to work (it will cause the IDE to post an error as it doesn't support printing).
+// This make it very useful as a wrapper class and to implement some specific features.
+
+// !!! --- PLEASE NEVER ADD A NORMAL PASCAL CASE METHOD TO ABSTRACT OBJECT --- !!!
+// The whole point of this class is to be minimal, ExperimentalAbstractObjects are not Objects, allowing those who subclass it to create their own definition of what an object is and isn't.
+
+ExperimentalAbstractObject {
+
+	/////// 1. Core and Interpreter functionality, do not override.
+
+	*new { |maxSize = 0| _BasicNew; ^this.sc_abstract_object_primitive_failed }
+	*newCopyArgs { | ... args, kwargs | _BasicNewCopyArgsToInstVars; ^this.sc_abstract_object_primitive_failed }
+
+	// ExperimentalAbstractObject support identity, this is required by the interpreter and cannot actually be overridden.
+	// When you put ExperimentalAbstractObjects into an identity dictionary the interpreter uses its own implementation, this should match the sclang implementation or things will get confusing.
+	// Identity operators are also provided, this isn't strictly necessary, but we usually think of identity and these operators as a set.
+	identityHash { _ObjectHash; ^this.sc_abstract_object_primitive_failed }
+	=== { arg obj; _Identical; ^this.sc_abstract_object_primitive_failed }
+	!== { arg obj;_NotIdentical; ^this.sc_abstract_object_primitive_failed }
+
+	// Interpreter will engage in undefined behavior if this method does not throw.
+	// It is not possible to implement a boolean abstract object as the compiler assumes its internal slot layout.
+	mustBeBoolean {  MustBeBooleanError(nil, "ExperimentalAbstractObject").throw }
+
+	// It is not possible to implement a 'nil' abstract object due to the compiler inlining the definition of these when used inside 'if' control flow.
+	// You cannot override these methods.
+	isNil { ^false }
+	notNil { ^true }
+	? { |obj| ^this }
+	?? { |obj| ^this }
+	!? { |obj| ^obj.value(this) }
+
+
+
+	/////// 2. Main interface, override this method.
+
+	// Note: Interpreter will segfault if this isn't provided so a default is given.
+	// You will need to override doesNotUnderstand to anything useful will abstract objects,
+	//   hence why it throws a SubclassResponsibilityError rather than a DoesNotUnderstandError.
+	// "ExperimentalAbstractObject" is passed as a string here, rather than 'this', as 'this' may not support the 'toString' method, which would cause the error handling to get stuck in a loop.
+	doesNotUnderstand { |selector ...args, kwargs| SubclassResponsibilityError("ExperimentalAbstractObject", thisMethod, ExperimentalAbstractObject).throw }
+
+
+
+	/////// 3. Helper methods and primitive implementations
+
+	// These methods may be used *only* to implement other abstract objects, do not call them from outside the definition of an abstract object.
+	// They are here so that other's may use primitive implementations, without making the primitives themselves publicly available.
+
+	sc_abstract_object_primitive_failed { PrimitiveFailedError("ExperimentalAbstractObject").throw }
+
+	sc_abstract_object_hash { _ObjectHash; ^this.sc_abstract_object_primitive_failed }
+	sc_abstract_object_copy_shallow { _ObjectShallowCopy; ^this.sc_abstract_object_primitive_failed }
+	sc_abstract_object_copy_immutable { _ObjectCopyImmutable; ^this.sc_abstract_object_primitive_failed }
+	sc_abstract_object_copy_deep { _ObjectDeepCopy; ^this.sc_abstract_object_primitive_failed }
+
+	// Yielding — must be implemented as primitives as special methods are provided.
+	// Note that idle is not provided because it requires calling 'value' on the ExperimentalAbstractObject'.
+	sc_abstract_object_yield {	_RoutineYield; ^this.sc_abstract_object_primitive_failed }
+	sc_abstract_object_always_yield { _RoutineAlwaysYield; ^this.sc_abstract_object_primitive_failed }
+	sc_abstract_object_yield_and_reset { |reset = true| _RoutineYieldAndReset; ^this.sc_abstract_object_primitive_failed }
+
+	// This is often necessary in abstract objects to determine if we have an abstract object, use isKindOf in normal use.
+	sc_abstract_object_is_kind_of { |aClass| _ObjectIsKindOf; ^this.sc_abstract_object_primitive_failed }
+
+	// Needed when we want to do the normal method calling in an ExperimentalAbstractObject.
+	// In many cases, the 'perform*' messages should defer to these as most of the time, you actually want to implement doesNotUnderstand.
+	sc_abstract_object_perform_args { |selector, args, kwargs|	_ObjectPerformArgs;	^this.sc_abstract_object_primitive_failed }
+	sc_abstract_object_super_perform_args { |selector, args, kwargs| _ObjectSuperPerformArgs; ^this.sc_abstract_object_primitive_failed }
+	sc_abstract_object_perform_msg { |msg| _ObjectPerformMsg; ^this.sc_abstract_object_primitive_failed }
+	sc_abstract_object_perform { |selector ... args| _ObjectPerform; ^this.sc_abstract_object_primitive_failed }
+	// Note that this is used to implement syntax, it is very strange to change this, please don't.
+	sc_abstract_object_perform_list { | ...args, kwargs| _ObjectPerformList; ^this.sc_abstract_object_primitive_failed }
+}

--- a/SCClassLibrary/Common/Core/ExperimentalAbstractObject.sc
+++ b/SCClassLibrary/Common/Core/ExperimentalAbstractObject.sc
@@ -68,7 +68,7 @@ AbstractObjectExperimental {
 	sc_abstract_object_perform_args { |selector, args, kwargs|	_ObjectPerformArgs;	^this.sc_abstract_object_primitive_failed }
 	sc_abstract_object_super_perform_args { |selector, args, kwargs| _ObjectSuperPerformArgs; ^this.sc_abstract_object_primitive_failed }
 	sc_abstract_object_perform_msg { |msg| _ObjectPerformMsg; ^this.sc_abstract_object_primitive_failed }
-	sc_abstract_object_perform { |selector ... args| _ObjectPerform; ^this.sc_abstract_object_primitive_failed }
+	sc_abstract_object_perform { |selector ... args, kwargs| _ObjectPerform; ^this.sc_abstract_object_primitive_failed }
 	// Note that this is used to implement syntax, it is very strange to change this, please don't.
 	sc_abstract_object_perform_list { | ...args, kwargs| _ObjectPerformList; ^this.sc_abstract_object_primitive_failed }
 }

--- a/SCClassLibrary/Common/Core/ExperimentalAbstractObject.sc
+++ b/SCClassLibrary/Common/Core/ExperimentalAbstractObject.sc
@@ -1,8 +1,9 @@
-// AbstractObjectExperimental represent the minimum interface needed to get the interpreter to work (it will cause the IDE to post an error as it doesn't support printing).
+// AbstractObjectExperimental represents the minimum interface needed to get the interpreter to work (it will cause the IDE to post an error as it doesn't support printing).
 // This make it useful as a wrapper class and to implement some specific features.
 
 // !!! --- PLEASE NEVER ADD A NORMAL PASCAL CASE METHOD TO ABSTRACT OBJECT --- !!!
-// The whole point of this class is to be minimal, AbstractObjectExperimentals are not Objects, allowing those who subclass it to create their own definition of what an object is and isn't.
+// The whole point of this class is to be minimal.
+// AbstractObjectExperimentals are not full Objects, allowing those who subclass it to create their own definition of what an object is and isn't.
 
 AbstractObjectExperimental {
 
@@ -35,17 +36,21 @@ AbstractObjectExperimental {
 	/////// 2. Main interface, override these method.
 
 	// Note: Interpreter will segfault if this isn't provided so a default is given.
-	// You will need to override doesNotUnderstand to anything useful will abstract objects,
+	// You will need to override doesNotUnderstand to do anything useful with abstract objects,
 	//   hence it throws a SubclassResponsibilityError rather than a DoesNotUnderstandError.
-	// "AbstractObjectExperimental" is passed as a string here, rather than 'this', as 'this' may not support the 'toString' method, which would cause the error handling to get stuck in a loop.
-	doesNotUnderstand { |selector ...args, kwargs| SubclassResponsibilityError("AbstractObjectExperimental", thisMethod, AbstractObjectExperimental).throw }
+	// "AbstractObjectExperimental" is passed as a string here, rather than 'this', because 'this' may not support the 'toString' method, 	
+	// which would cause the error handling to get stuck in a loop.
+	
+	doesNotUnderstand { |selector ...args, kwargs| 
+		SubclassResponsibilityError("AbstractObjectExperimental", thisMethod, AbstractObjectExperimental).throw 
+	}
 
 
 
 	/////// 3. Helper methods and primitive implementations
 
 	// These methods may be used *only* to implement other abstract objects, do not call them from outside the definition of an abstract object.
-	// They are here so that other objects may use primitive implementations, without making the primitives themselves publicly available.
+	// They are here so that other objects may use primitive implementations without making the primitives themselves publicly available.
 
 	sc_abstract_object_primitive_failed { PrimitiveFailedError("AbstractObjectExperimental").throw }
 
@@ -54,7 +59,7 @@ AbstractObjectExperimental {
 	sc_abstract_object_copy_immutable { _ObjectCopyImmutable; ^this.sc_abstract_object_primitive_failed }
 	sc_abstract_object_copy_deep { _ObjectDeepCopy; ^this.sc_abstract_object_primitive_failed }
 
-	// Yielding — must be implemented as primitives as special methods are provided.
+	// Yielding from a routine — must be implemented as primitives as special methods are provided.
 	// Note that idle is not provided because it requires calling 'value' on the AbstractObjectExperimental'.
 	sc_abstract_object_yield {	_RoutineYield; ^this.sc_abstract_object_primitive_failed }
 	sc_abstract_object_always_yield { _RoutineAlwaysYield; ^this.sc_abstract_object_primitive_failed }

--- a/SCClassLibrary/Common/Core/Kernel.sc
+++ b/SCClassLibrary/Common/Core/Kernel.sc
@@ -240,6 +240,7 @@ Process {
 		Class.initClassTree(AppClock); // AppClock first in case of error
 		time = this.class.elapsedTime;
 		Class.initClassTree(Object);
+		Class.initClassTree(ExperimentalAbstractObject);
 		("Class tree inited in" + (this.class.elapsedTime - time).round(0.01) + "seconds").postln;
 		Class.classesInited = nil;
 

--- a/SCClassLibrary/Common/Core/Kernel.sc
+++ b/SCClassLibrary/Common/Core/Kernel.sc
@@ -240,7 +240,7 @@ Process {
 		Class.initClassTree(AppClock); // AppClock first in case of error
 		time = this.class.elapsedTime;
 		Class.initClassTree(Object);
-		Class.initClassTree(ExperimentalAbstractObject);
+		Class.initClassTree(AbstractObjectExperimental);
 		("Class tree inited in" + (this.class.elapsedTime - time).round(0.01) + "seconds").postln;
 		Class.classesInited = nil;
 

--- a/SCClassLibrary/Common/Core/Object.sc
+++ b/SCClassLibrary/Common/Core/Object.sc
@@ -1,4 +1,4 @@
-Object : ExperimentalAbstractObject {
+Object : AbstractObjectExperimental {
 	classvar <dependantsDictionary, currentEnvironment, topEnvironment, <uniqueMethods;
 
 	const nl = "\n";

--- a/SCClassLibrary/Common/Core/Object.sc
+++ b/SCClassLibrary/Common/Core/Object.sc
@@ -1,20 +1,7 @@
-Object {
+Object : ExperimentalAbstractObject {
 	classvar <dependantsDictionary, currentEnvironment, topEnvironment, <uniqueMethods;
 
 	const nl = "\n";
-
-	*new { arg maxSize = 0;
-		_BasicNew
-		^this.primitiveFailed
-		// creates a new instance that can hold up to maxSize
-		// indexable slots. the indexed size will be zero.
-		// to actually put things in the object you need to
-		// add them.
-	}
-	*newCopyArgs { | ... args, kwargs |
-		_BasicNewCopyArgsToInstVars
-		^this.primitiveFailed
-	}
 
 	// debugging and diagnostics
 	dump {
@@ -180,8 +167,6 @@ Object {
 	// equality, identity
 	== { arg obj; ^this === obj }
 	!= { arg obj; ^not(this == obj) }
-	=== { arg obj; _Identical; ^this.primitiveFailed }
-	!== { arg obj;_NotIdentical; ^this.primitiveFailed }
 	equals { arg that, properties;
 		^that.respondsTo(properties) and: {
 			properties.every { |selector| this.perform(selector) == that.perform(selector) }
@@ -223,7 +208,6 @@ Object {
 
 	basicHash { _ObjectHash; ^this.primitiveFailed }
 	hash { _ObjectHash; ^this.primitiveFailed }
-	identityHash { _ObjectHash; ^this.primitiveFailed }
 
 	// lazy equality: same as == for objects
 	// "composed" for lazy operands (patterns, UGens)
@@ -298,13 +282,6 @@ Object {
 	threadPlayer {}
 	threadPlayer_ {}
 
-	// testing
-	? { arg obj; ^this }
-	?? { arg obj; ^this }
-	!? { arg obj; ^obj.value(this) }
-
-	isNil { ^false }
-	notNil { ^true }
 	isNumber { ^false }
 	isInteger { ^false }
 	isFloat { ^false }
@@ -348,6 +325,7 @@ Object {
 	subclassResponsibility { arg method;
 		SubclassResponsibilityError(this, method, this.class).throw;
 	}
+	// Overloaded from abstract object as 'this' is now safe.
 	doesNotUnderstand { |selector ...args, kwargs|
 		DoesNotUnderstandError(this, selector, args, kwargs).throw;
 	}
@@ -365,6 +343,7 @@ Object {
 		DeprecatedError(this, method, alternateMethod, this.class).throw;
 	}
 
+	// Overloaded from abstract object as 'this' is now safe.
 	mustBeBoolean { MustBeBooleanError(nil, this).throw; }
 	notYetImplemented { NotYetImplementedError(nil, this).throw; }
 

--- a/lang/LangSource/PyrLexer.cpp
+++ b/lang/LangSource/PyrLexer.cpp
@@ -1227,7 +1227,7 @@ void traverseFullDepTree() {
     initParser(); // sets compiler errors to 0
     gParserResult = -1;
 
-    traverseDepTree(s_object->classdep, 0);
+    traverseDepTree(s_abstract_object->classdep, 0);
     compileDepTree(); // compiles backwards using the order defined in gClassCompileOrder
     compileClassExtensions();
 
@@ -1326,7 +1326,7 @@ void traverseFullDepTree2() {
         gNumClasses = 0;
 
         // now I index them during pass one
-        indexClassTree(class_object, 0);
+        indexClassTree(class_abstract_object, 0);
         setSelectorFlags();
         if (2 * numClassDeps != gNumClasses) {
             error("There is a discrepancy.\n");
@@ -1421,7 +1421,7 @@ bool parseOneClass(PyrSymbol* fileSym) {
                 return false;
             }
         } else if (out.type == TokenType::OpenCurly) {
-            if (className == s_object)
+            if (className == s_abstract_object)
                 superClassName = s_none;
             else
                 superClassName = s_object;
@@ -1697,7 +1697,6 @@ bool passOne_ProcessOneFile(const fs::path& path) {
 
 void schedRun();
 
-void compileSucceeded();
 void compileSucceeded() {
     gCompiledOK = !(gParseFailed || compileErrors);
     if (gCompiledOK) {

--- a/lang/LangSource/PyrObject.cpp
+++ b/lang/LangSource/PyrObject.cpp
@@ -192,7 +192,7 @@ void initSymbols() {
 
     // classes
     s_object = getsym("Object");
-    s_abstract_object = getsym("ExperimentalAbstractObject");
+    s_abstract_object = getsym("AbstractObjectExperimental");
     s_ref = getsym("Ref");
     s_dictionary = getsym("Dictionary");
     s_bag = getsym("Bag");
@@ -1494,7 +1494,7 @@ PyrClass* makeIntrinsicClass(PyrSymbol* className, PyrSymbol* superClassName, in
         metaSuperClass = metaSuperClassName->u.classobj;
         superInstVars = numSuperInstVars(superClass);
     } else {
-        // else it must be ExperimentalAbstractObject and so has no superclass
+        // else it must be AbstractObjectExperimental and so has no superclass
         metaSuperClassName = nullptr;
         superInstVars = 0;
     }

--- a/lang/LangSource/PyrObject.cpp
+++ b/lang/LangSource/PyrObject.cpp
@@ -73,6 +73,7 @@ int gFormatElemTag[NUMOBJFORMATS];
 PyrMethod* gNullMethod; // used to fill row table
 PyrClass* gTagClassTable[16];
 
+PyrClass* class_abstract_object;
 PyrClass* class_object;
 PyrClass* class_dict;
 PyrClass* class_array;
@@ -105,6 +106,7 @@ PyrClass* class_finalizer;
 PyrClass* class_server_shm_interface;
 
 PyrSymbol* s_none;
+PyrSymbol* s_abstract_object;
 PyrSymbol* s_object;
 PyrSymbol* s_bag;
 PyrSymbol* s_set;
@@ -162,6 +164,7 @@ PyrSymbol* s_performArgs;
 PyrSymbol *s_series, *s_copyseries, *s_putseries;
 PyrSymbol *s_envirGet, *s_envirPut;
 PyrSymbol *s_synth, *s_environment, *s_event;
+PyrSymbol* s_proto_object;
 PyrSymbol* s_shutdown;
 PyrSymbol *s_super, *s_this;
 
@@ -189,6 +192,7 @@ void initSymbols() {
 
     // classes
     s_object = getsym("Object");
+    s_abstract_object = getsym("ExperimentalAbstractObject");
     s_ref = getsym("Ref");
     s_dictionary = getsym("Dictionary");
     s_bag = getsym("Bag");
@@ -247,6 +251,7 @@ void initSymbols() {
     s_synth = getsym("Synth");
     s_environment = getsym("Environment");
     s_event = getsym("Event");
+    s_proto_object = getsym("ProtoObject");
 
     // interpreter
     s_interpretCmdLine = getsym("interpretCmdLine");
@@ -1188,11 +1193,12 @@ void buildBigMethodMatrix() {
 #endif
     filledClassIndices.wait();
 #ifdef _MSC_VER
-    size_t numentries = fillClassRows(class_object, bigTable);
+    size_t numentries = fillClassRows(class_abstract_object, bigTable);
 #else
-    size_t numentries = fillClassRows(class_object, bigTable, pool);
+    size_t numentries = fillClassRows(class_abstract_object, bigTable, pool);
 #endif
-    post("\tnumentries = %lu / %d = %.2g\n", numentries, bigTableSize, (double)numentries / (double)bigTableSize);
+    post("\tnum entries = %lu, big table size = %d, num entries / big table size = %.2g\n", numentries, bigTableSize,
+         (double)numentries / (double)bigTableSize);
 
 
     ColumnDescriptor* filledSelectors = filledSelectorsFuture.get();
@@ -1488,7 +1494,7 @@ PyrClass* makeIntrinsicClass(PyrSymbol* className, PyrSymbol* superClassName, in
         metaSuperClass = metaSuperClassName->u.classobj;
         superInstVars = numSuperInstVars(superClass);
     } else {
-        // else it must be Object and so has no superclass
+        // else it must be ExperimentalAbstractObject and so has no superclass
         metaSuperClassName = nullptr;
         superInstVars = 0;
     }
@@ -1544,28 +1550,32 @@ void addIntrinsicClassVar(PyrClass* classobj, const char* varName, PyrSlot* slot
 }
 
 void initClasses() {
-    PyrClass* class_object_meta;
-    PyrMethodRaw* methraw;
-
     // BOOTSTRAP THE OBJECT HIERARCHY
-
     gNumClassVars = 0;
     gClassList = nullptr;
     gNullMethod = newPyrMethod();
     SetSymbol(&gNullMethod->name, (PyrSymbol*)nullptr);
-    methraw = METHRAW(gNullMethod);
+    PyrMethodRaw* methraw = METHRAW(gNullMethod);
     methraw->methType = methNormal;
 
     // build intrinsic classes
     class_class = nullptr;
-    class_object = makeIntrinsicClass(s_object, nullptr, 0, 4);
+    class_abstract_object = makeIntrinsicClass(s_abstract_object, nullptr, 0, 0);
+    class_object = makeIntrinsicClass(s_object, s_abstract_object, 0, 4);
     class_class = makeIntrinsicClass(s_class, s_object, classClassNumInstVars, 1);
 
     // now fix class_class ptrs that were just previously installed erroneously
-    class_object->classptr->classptr = class_class;
-    class_class->classptr->classptr = class_class;
-    class_object_meta = class_object->classptr;
-    class_object_meta->superclass = class_class->name;
+    PyrClass* class_object_meta = class_object->classptr;
+    PyrClass* class_abstract_object_meta = class_abstract_object->classptr;
+
+    class_object_meta->classptr = class_class;
+    class_abstract_object_meta->classptr = class_class;
+
+    PyrClass* class_class_meta = class_class->classptr;
+    class_class_meta->classptr = class_class;
+
+    class_abstract_object_meta->superclass = class_class->name;
+    class_object_meta->superclass = class_abstract_object_meta->name;
 
     addIntrinsicClassVar(class_object, "dependantsDictionary", &o_nil);
     addIntrinsicClassVar(class_object, "currentEnvironment", &o_nil);
@@ -1606,9 +1616,14 @@ void initClasses() {
     memcpy(slotRawSymbolArray(&class_object_meta->instVarNames)->symbols,
            slotRawSymbolArray(&class_class->instVarNames)->symbols, sizeof(PyrSymbol*) * classClassNumInstVars);
 
-    memcpy(slotRawObject(&class_class->classptr->iprototype)->slots, slotRawObject(&class_class->iprototype)->slots,
+    memcpy(slotRawObject(&class_abstract_object_meta->iprototype)->slots,
+           slotRawObject(&class_class->iprototype)->slots, sizeof(PyrSlot) * classClassNumInstVars);
+    memcpy(slotRawSymbolArray(&class_abstract_object_meta->instVarNames)->symbols,
+           slotRawSymbolArray(&class_class->instVarNames)->symbols, sizeof(PyrSymbol*) * classClassNumInstVars);
+
+    memcpy(slotRawObject(&class_class_meta->iprototype)->slots, slotRawObject(&class_class->iprototype)->slots,
            sizeof(PyrSlot) * classClassNumInstVars);
-    memcpy(slotRawSymbolArray(&class_class->classptr->instVarNames)->symbols,
+    memcpy(slotRawSymbolArray(&class_class_meta->instVarNames)->symbols,
            slotRawSymbolArray(&class_class->instVarNames)->symbols, sizeof(PyrSymbol*) * classClassNumInstVars);
 
 
@@ -1623,8 +1638,9 @@ void initClasses() {
 
     // now fix array classptrs in already created classes
     fixClassArrays(class_class);
-    fixClassArrays(class_class->classptr);
+    fixClassArrays(class_class_meta);
     fixClassArrays(class_object_meta);
+    fixClassArrays(class_abstract_object_meta);
     fixClassArrays(class_collection);
     fixClassArrays(class_sequenceable_collection);
     fixClassArrays(class_arrayed_collection);

--- a/lang/LangSource/PyrObject.h
+++ b/lang/LangSource/PyrObject.h
@@ -68,6 +68,7 @@ struct PyrSymbolArray : public PyrObjectHdr {
     PyrSymbol* symbols[1];
 };
 
+extern struct PyrClass* class_abstract_object;
 extern struct PyrClass* class_object;
 extern struct PyrClass* class_array;
 extern struct PyrClass *class_list, *class_method, *class_fundef, *class_frame, *class_class;
@@ -99,6 +100,7 @@ extern struct PyrClass* class_finalizer;
 extern struct PyrClass* class_server_shm_interface;
 
 extern PyrSymbol* s_none;
+extern PyrSymbol* s_abstract_object;
 extern PyrSymbol* s_object;
 extern PyrSymbol* s_bag;
 extern PyrSymbol* s_set;
@@ -145,7 +147,7 @@ extern PyrSymbol* s_performList;
 extern PyrSymbol* s_superPerformList;
 extern PyrSymbol* s_performArgs;
 extern PyrSymbol *s_new, *s_ref;
-extern PyrSymbol *s_synth, *s_environment, *s_event;
+extern PyrSymbol *s_synth, *s_environment, *s_event, *s_proto_object;
 extern PyrSymbol* s_interpreter;
 extern PyrSymbol* s_finalizer;
 extern PyrSymbol* s_awake;

--- a/lang/LangSource/PyrParseNode.cpp
+++ b/lang/LangSource/PyrParseNode.cpp
@@ -575,9 +575,9 @@ PyrClass* getNodeSuperclass(PyrClassNode* node) {
             compileErrors++;
         }
     } else {
-        if (slotRawSymbol(&node->mClassName->mSlot) != s_object) {
+        if (slotRawSymbol(&node->mClassName->mSlot) != s_abstract_object) {
             superclassobj = class_object;
-        } // else this is object and there is no superclass
+        } // else this is abstract object and there is no superclass
     }
     return superclassobj;
 }

--- a/lang/LangSource/PyrSlot.h
+++ b/lang/LangSource/PyrSlot.h
@@ -632,7 +632,7 @@ extern PyrSlot o_fhalf, o_fnegone, o_fzero, o_fone, o_ftwo;
 extern PyrSlot o_negone, o_zero, o_one, o_two;
 extern PyrSlot o_emptyarray, o_onenilarray, o_argnamethis;
 
-extern PyrSymbol* s_abstract_object; // "ExperimentalAbstractObject"
+extern PyrSymbol* s_abstract_object; // "AbstractObjectExperimental"
 extern PyrSymbol* s_object; // "Object"
 extern PyrSymbol* s_this; // "this"
 extern PyrSymbol* s_super; // "super"

--- a/lang/LangSource/PyrSlot.h
+++ b/lang/LangSource/PyrSlot.h
@@ -632,6 +632,7 @@ extern PyrSlot o_fhalf, o_fnegone, o_fzero, o_fone, o_ftwo;
 extern PyrSlot o_negone, o_zero, o_one, o_two;
 extern PyrSlot o_emptyarray, o_onenilarray, o_argnamethis;
 
+extern PyrSymbol* s_abstract_object; // "ExperimentalAbstractObject"
 extern PyrSymbol* s_object; // "Object"
 extern PyrSymbol* s_this; // "this"
 extern PyrSymbol* s_super; // "super"

--- a/testsuite/classlibrary/TestAbstractObject.sc
+++ b/testsuite/classlibrary/TestAbstractObject.sc
@@ -1,37 +1,37 @@
-TestExperimentalAbstractObject : UnitTest {
-	// Note that some of these tests cannot be written as ExperimentalAbstractObject isn't a real object, and therefore doesn't work in many common sc contexts, such as, print to the interpreter, or using it is a 'try' block.
+TestAbstractObjectExperimental : UnitTest {
+	// Note that some of these tests cannot be written as AbstractObjectExperimental isn't a real object, and therefore doesn't work in many common sc contexts, such as, print to the interpreter, or using it is a 'try' block.
 
 	test_dont_crash {
-		// Can't wrap this in a this.assertNoException as ExperimentalAbstractObject doesn't support isException.
-		ExperimentalAbstractObject();
+		// Can't wrap this in a this.assertNoException as AbstractObjectExperimental doesn't support isException.
+		AbstractObjectExperimental();
 	}
 
 	test_object_superclass {
-		this.assertEquals(Object.superclass, ExperimentalAbstractObject);
+		this.assertEquals(Object.superclass, AbstractObjectExperimental);
 	}
 	test_abstract_object_superclass {
-		this.assertEquals(ExperimentalAbstractObject.superclass, nil)
+		this.assertEquals(AbstractObjectExperimental.superclass, nil)
 	}
 	test_abstract_object_class {
-		this.assertEquals(ExperimentalAbstractObject.class, Meta_ExperimentalAbstractObject)
+		this.assertEquals(AbstractObjectExperimental.class, Meta_AbstractObjectExperimental)
 	}
 	test_meta_abstract_object_class {
-		this.assertEquals(Meta_ExperimentalAbstractObject.class, Class)
+		this.assertEquals(Meta_AbstractObjectExperimental.class, Class)
 	}
 
 	test_identity {
-		var o = ExperimentalAbstractObject();
-		var i = ExperimentalAbstractObject();
+		var o = AbstractObjectExperimental();
+		var i = AbstractObjectExperimental();
 
 		this.assert(o === o);
 		this.assert(o !== i);
 
 		// This method cannot be written because isException isn't implemented.
-		// this.assertException({ o == i }, DoesNotUnderstandError, "ExperimentalAbstractObject should not support equality by itself.");
+		// this.assertException({ o == i }, DoesNotUnderstandError, "AbstractObjectExperimental should not support equality by itself.");
 	}
 
 	test_copy {
-		var a = ExperimentalAbstractObject();
-		this.assert(a.identityHash != ExperimentalAbstractObject().identityHash, "ExperimentalAbstractObjects should have unique hashes, technically this could be a false negative, but seems unlikely.");
+		var a = AbstractObjectExperimental();
+		this.assert(a.identityHash != AbstractObjectExperimental().identityHash, "AbstractObjectExperimentals should have unique hashes, technically this could be a false negative, but seems unlikely.");
 	}
 }

--- a/testsuite/classlibrary/TestAbstractObject.sc
+++ b/testsuite/classlibrary/TestAbstractObject.sc
@@ -1,0 +1,37 @@
+TestExperimentalAbstractObject : UnitTest {
+	// Note that some of these tests cannot be written as ExperimentalAbstractObject isn't a real object, and therefore doesn't work in many common sc contexts, such as, print to the interpreter, or using it is a 'try' block.
+
+	test_dont_crash {
+		// Can't wrap this in a this.assertNoException as ExperimentalAbstractObject doesn't support isException.
+		ExperimentalAbstractObject();
+	}
+
+	test_object_superclass {
+		this.assertEquals(Object.superclass, ExperimentalAbstractObject);
+	}
+	test_abstract_object_superclass {
+		this.assertEquals(ExperimentalAbstractObject.superclass, nil)
+	}
+	test_abstract_object_class {
+		this.assertEquals(ExperimentalAbstractObject.class, Meta_ExperimentalAbstractObject)
+	}
+	test_meta_abstract_object_class {
+		this.assertEquals(Meta_ExperimentalAbstractObject.class, Class)
+	}
+
+	test_identity {
+		var o = ExperimentalAbstractObject();
+		var i = ExperimentalAbstractObject();
+
+		this.assert(o === o);
+		this.assert(o !== i);
+
+		// This method cannot be written because isException isn't implemented.
+		// this.assertException({ o == i }, DoesNotUnderstandError, "ExperimentalAbstractObject should not support equality by itself.");
+	}
+
+	test_copy {
+		var a = ExperimentalAbstractObject();
+		this.assert(a.identityHash != ExperimentalAbstractObject().identityHash, "ExperimentalAbstractObjects should have unique hashes, technically this could be a false negative, but seems unlikely.");
+	}
+}


### PR DESCRIPTION
Introduce abstract object changing the class hierarchy.

Note, AbstractObject is by definition an **incomplete** object, using it directly will break the interpreter, that is the whole point, it is the user's responsibility to implement all these features. 

This was @telephon's idea from an RFC from way back, and I only just got around to implementing it.


This PR depends on #7206.

<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->

- Documentation
- Bug fix
- New feature
- Breaking change

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
