### PR TITLE
sclang: fix keyword arguments bug

### DIFF
--- a/lang/LangSource/PyrMessage.cpp
+++ b/lang/LangSource/PyrMessage.cpp
@@ -402,10 +402,10 @@ void prepareArgsForExecute(VMGlobals* g, PyrBlock* block, PyrFrame* callFrame, s
     int keywordArgumentSize = 0;
 
     const auto findKeywordArgIndex = [=](const PyrSymbol* argName) -> std::optional<uint32_t> {
-        for (size_t namei = 0; namei < methNumNormArgs; ++namei) {
-            const auto indexOffsetFromThis = namei + (isMethod ? 1 : 0);
-            if (methArgNames[indexOffsetFromThis] == argName)
-                return indexOffsetFromThis;
+        for (size_t namei = (isMethod ? 1 : 0); namei < methNumNormArgs; ++namei) {
+            const auto considering = methArgNames[namei];
+            if (considering == argName)
+                return namei;
         }
         return std::nullopt;
     };

--- a/testsuite/classlibrary/TestKwargs.sc
+++ b/testsuite/classlibrary/TestKwargs.sc
@@ -1,98 +1,155 @@
 TestKwargs_Obj {
-    foo { |a, b...args, kwargs|
-        var x = 100;
-        var y = 101;
-         ^(a: a, b: b, args: args, kwargs: kwargs)
-    }
-    doesNotUnderstand { |selector ...args, kwargs|
-        ^(selector: selector, args: args, kwargs: kwargs)
-    }
+	foo { |a, b...args, kwargs|
+		var x = 100;
+		var y = 101;
+		^(a: a, b: b, args: args, kwargs: kwargs)
+	}
+	doesNotUnderstand { |selector ...args, kwargs|
+		^(selector: selector, args: args, kwargs: kwargs)
+	}
 }
 
 TestKwargs : UnitTest {
-    test_basic_arg_passing {
-        this.assertEquals(
-            TestKwargs_Obj().foo(1),
-            (a: 1, args: [], kwargs: [])
-        );
+	test_basic_arg_passing {
+		this.assertEquals(
+			TestKwargs_Obj().foo(1),
+			(a: 1, args: [], kwargs: [])
+		);
 
-        this.assertEquals(
-            TestKwargs_Obj().foo(1, 2, 3, 4),
-            (a: 1, b: 2, args: [3, 4], kwargs: [])
-        );
+		this.assertEquals(
+			TestKwargs_Obj().foo(1, 2, 3, 4),
+			(a: 1, b: 2, args: [3, 4], kwargs: [])
+		);
 
-        this.assertEquals(
-            TestKwargs_Obj().foo(a: 1, b: 2),
-            (a: 1, b: 2, args: [], kwargs: [])
-        );
+		this.assertEquals(
+			TestKwargs_Obj().foo(a: 1, b: 2),
+			(a: 1, b: 2, args: [], kwargs: [])
+		);
 
-        this.assertEquals(
-            TestKwargs_Obj().foo(1, 2, 3, e: 1, f: 2),
-            (a: 1, b: 2, args: [3], kwargs: [\e, 1, \f, 2])
-        );
-    }
+		this.assertEquals(
+			TestKwargs_Obj().foo(1, 2, 3, e: 1, f: 2),
+			(a: 1, b: 2, args: [3], kwargs: [\e, 1, \f, 2])
+		);
+	}
 
-    test_doesNotUnderstand {
-        this.assertEquals(
-            TestKwargs_Obj().bar(1,2, a: 3, b: 4),
-            (selector: \bar, args: [1, 2], kwargs: [a: 3, b: 4])
-        )
-    }
+	test_collision_with_args {
+		this.assertEquals(
+			TestKwargs_Obj().foo(args: 2),
+			(args: [], kwargs: [args: 2]),
+			"Should be able to pass 'args' along to the method"
+		);
+		this.assertEquals(
+			TestKwargs_Obj().b(args: 2),
+			(selector: \b, args: [], kwargs: [args: 2]),
+			"Should be able to pass 'args' along to the method"
+		);
+		this.assertEquals(
+			TestKwargs_Obj().foo(1, b: 2, args: 2),
+			(a: 1, b: 2, args: [], kwargs: [args: 2]),
+			"Should be able to pass 'args' along to the method"
+		);
+		this.assertEquals(
+			TestKwargs_Obj().foo(1, b: 2, args: 2, kwargs: 20),
+			(a: 1, b: 2, args: [], kwargs: [args: 2, kwargs: 20]),
+			"Should be able to pass 'args' along to the method"
+		);
+		this.assertEquals(
+			TestKwargs_Obj().foo(args: 2, kwargs: 20),
+			(args: [], kwargs: [args: 2, kwargs: 20]),
+			"Should be able to pass 'args' along to the method"
+		);
+		this.assertEquals(
+			TestKwargs_Obj().foo(1, 2, 3, args: 2, kwargs: 20),
+			(a: 1, b: 2, args: [3], kwargs: [args: 2, kwargs: 20]),
+			"Should be able to pass 'args' along to the method"
+		);
+	}
 
-    test_function_perform_list {
-        var f = {|a, b, c... args, kwargs| (a: a, b: b, c: c, args: args, kwargs: kwargs) };
-        this.assertEquals(
-            f.(1, *[2, 3, 4], foo: 10),
-            (a: 1, b: 2, c: 3, args: [4], kwargs: [\foo, 10])
-        );
-        this.assertEquals(
-            f.performList(\value, 1, [2, 3, 4], foo: 10),
-            (a: 1, b: 2, c: 3, args: [4], kwargs: [\foo, 10])
-        );
-        this.assertEquals(
-            f.functionPerformList(\value, 1, [2, 3, 4], foo: 10),
-            (a: 1, b: 2, c: 3, args: [4], kwargs: [\foo, 10])
-        );
-    }
+	test_collision_with_args_block {
+		var f = { |a, b ...args, kwargs|
+			(a: a, b: b, args: args, kwargs: kwargs);
+		};
+		this.assertEquals(
+			f.(1, b: 2, args: 10, kwargs: 20),
+			(a: 1, b: 2, args: [], kwargs: [\args, 10, \kwargs: 20]),
+			"Should be able to pass 'args' and 'kwargs' to methods"
+		)
+	}
 
-    test_wrappers {
-        var inlined = { |func|
-        	{ |...args, kwargs|
-        		func.performArgs(\value, args, kwargs)
-        	}
-        };
-        var asVar = { |func|
-        	{ |...args, kwargs|
-        		var val = func.performArgs(\value, args, kwargs);
-        		val
-        	}
-        };
+	test_collision_with_kwargs {
+		this.assertEquals(
+			TestKwargs_Obj().foo(kwargs: 2),
+			(args: [], kwargs: [kwargs: 2]),
+			"Should be able to pass 'kwargs' along to the method"
+		);
+		this.assertEquals(
+			TestKwargs_Obj().b(kwargs: 2),
+			(selector: \b, args: [], kwargs: [kwargs: 2]),
+			"Should be able to pass 'kwargs' along to the method"
+		);
+	}
 
-        this.assertEquals(
-         inlined.({ |a, b=100, c| [a, b, c] }).([1, 2]),
-         [[1, 2], 100, nil]
-        );
-        this.assertEquals(
-         asVar.({ |a, b=100, c| [a, b, c] }).([1, 2]),
-         [[1, 2], 100, nil]
-        );
+	test_doesNotUnderstand {
+		this.assertEquals(
+			TestKwargs_Obj().bar(1,2, a: 3, b: 4),
+			(selector: \bar, args: [1, 2], kwargs: [a: 3, b: 4])
+		)
+	}
 
-        this.assertEquals(
-         inlined.({ |a, b=100, c| [a, b, c] }).([1, 2], 42),
-         [[1, 2], 42, nil]
-        );
-        this.assertEquals(
-         asVar.({ |a, b=100, c| [a, b, c] }).([1, 2], 42),
-         [[1, 2], 42, nil]
-        );
+	test_function_perform_list {
+		var f = {|a, b, c... args, kwargs| (a: a, b: b, c: c, args: args, kwargs: kwargs) };
+		this.assertEquals(
+			f.(1, *[2, 3, 4], foo: 10),
+			(a: 1, b: 2, c: 3, args: [4], kwargs: [\foo, 10])
+		);
+		this.assertEquals(
+			f.performList(\value, 1, [2, 3, 4], foo: 10),
+			(a: 1, b: 2, c: 3, args: [4], kwargs: [\foo, 10])
+		);
+		this.assertEquals(
+			f.functionPerformList(\value, 1, [2, 3, 4], foo: 10),
+			(a: 1, b: 2, c: 3, args: [4], kwargs: [\foo, 10])
+		);
+	}
 
-        this.assertEquals(
-         inlined.({ |a, b=100, c| [a, b, c] }).([1, 2], 42, c: 23),
-         [[1, 2], 42, 23]
-        );
-        this.assertEquals(
-         asVar.({ |a, b=100, c| [a, b, c] }).([1, 2], 42, c: 23),
-         [[1, 2], 42, 23]
-        );
-    }
+	test_wrappers {
+		var inlined = { |func|
+			{ |...args, kwargs|
+				func.performArgs(\value, args, kwargs)
+			}
+		};
+		var asVar = { |func|
+			{ |...args, kwargs|
+				var val = func.performArgs(\value, args, kwargs);
+				val
+			}
+		};
+
+		this.assertEquals(
+			inlined.({ |a, b=100, c| [a, b, c] }).([1, 2]),
+			[[1, 2], 100, nil]
+		);
+		this.assertEquals(
+			asVar.({ |a, b=100, c| [a, b, c] }).([1, 2]),
+			[[1, 2], 100, nil]
+		);
+
+		this.assertEquals(
+			inlined.({ |a, b=100, c| [a, b, c] }).([1, 2], 42),
+			[[1, 2], 42, nil]
+		);
+		this.assertEquals(
+			asVar.({ |a, b=100, c| [a, b, c] }).([1, 2], 42),
+			[[1, 2], 42, nil]
+		);
+
+		this.assertEquals(
+			inlined.({ |a, b=100, c| [a, b, c] }).([1, 2], 42, c: 23),
+			[[1, 2], 42, 23]
+		);
+		this.assertEquals(
+			asVar.({ |a, b=100, c| [a, b, c] }).([1, 2], 42, c: 23),
+			[[1, 2], 42, 23]
+		);
+	}
 }


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

In the previous kwargs commit, we had agreed you couldn't set the 'args' variable directly, i.e., this shouldn't work.
```
f = { |...args, kwargs|
    [args, kwargs]
};
f.(args: 10) != 10 // should be [[], [args: 10]]
```
This sometimes worked (it worked in a block as above, but didn't work in a method), instead the 'args' parameter would be omitted from the 'kwargs' array.

This was a bug (off by one error) made by me, but it is a simple fix. I've also added a bunch more testing to ensure this won't happen again.

----

EDIT by @dyfer:

To clarify, if someone comes back to this: the issue can only be reproduced in a method of a class. With a following class defined:

```supercollider
KwargsTest {
	foo { |...args, kwargs|
		^[args, kwargs]
	}
}
```
This is the correct behavior:
```supercollider
KwargsTest().foo(args: 10); // returns [[], [args: 10]]
```
Before this PR, the method would incorrectly return `[[], []]`.

----

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix


## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
