### PR TITLE
Add support for multi‑line strings in HelpBrowser’s code editor

### DIFF
--- a/HelpSource/static/editor.js
+++ b/HelpSource/static/editor.js
@@ -18,7 +18,7 @@ const init = () => {
             { regex: /^\$\\?./, token: 'char' },
             { regex: /^~\w+/, token: 'env-var' },
             { regex: /^\/\/[^\r\n]*/, token: 'comment single-line-comment' },
-            { regex: /"(?:[^\\]|\\.)*?(?:"|$)/, token: 'string' },
+            { regex: /"(?:[^\\]|\\.)*?"/, token: 'string' },
             { regex: /^[-.,;#()\[\]{}]/, token: 'text punctuation' },
             { regex: /\/\*/, push: 'comment', token: 'comment multi-line-comment' },
             { regex: /^[+\-*/&\|\^%<>=!?]+/, token: 'text operator' },


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->
fixes: #7210
## Purpose and Motivation

Currently, the code editor in the HelpBrowser does not accept multi‑line strings, which results in syntax errors when using Cmd/Ctrl+Enter, as illustrated in #7210.  
This PR resolves the issue.

However, the colour of multi‑line strings remains black, and this should also be addressed.  
I believe that a proper implementation of """ would be the best solution for this.

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
