### PR TITLE
TempoClock.beats_ forward to TempoClock.default.beats_

### DIFF
--- a/SCClassLibrary/Common/Core/Clock.sc
+++ b/SCClassLibrary/Common/Core/Clock.sc
@@ -370,39 +370,42 @@ elapsed time is whatever the system clock says it is right now. elapsed time is 
 	}
 
 	// these methods allow TempoClock to act as TempoClock.default
+	*isRunning { ^this.default.isRunning }
 	*stop { TempoClock.default.stop	}
 	*play { | task, quant | TempoClock.default.play(task, quant)	 }
 	*sched { | delta, item | TempoClock.default.sched(delta, item)  }
 	*schedAbs { | beat, item | TempoClock.default.schedAbs(beat, item)  }
 	*clear { | releaseNodes | TempoClock.default.clear(releaseNodes)	 }
-	*tempo_ { | newTempo | TempoClock.default.tempo_(newTempo)  }
-	*etempo_ { | newTempo | TempoClock.default.etempo_(newTempo)	 }
 
 	*tempo { ^TempoClock.default.tempo }
+	*tempo_ { | newTempo | TempoClock.default.tempo_(newTempo)  }
+	*etempo_ { | newTempo | TempoClock.default.etempo_(newTempo)	 }
+	*setTempoAtBeat { | newTempo, beats | TempoClock.default.setTempoAtBeat(newTempo, beats)	 }
+	*setTempoAtSec { | newTempo, secs | TempoClock.default.setTempoAtSec(newTempo, secs)	 }
+
 	*beats { ^TempoClock.default.beats }
+	*beats_ { |beats|  ^TempoClock.default.beats_(beats) }
+	*beatDur { ^TempoClock.default.beatDur  }
+	*elapsedBeats { ^TempoClock.default.elapsedBeats	 }
+
 	*beats2secs { | beats | ^TempoClock.default.beats2secs(beats)  }
 	*secs2beats { | secs | ^TempoClock.default.secs2beats(secs)	}
+	*beats2bars { | beats | ^TempoClock.default.beats2bars(beats)  }
+	*bars2beats { | bars | ^TempoClock.default.bars2beats(bars)	}
+
 	*nextTimeOnGrid { | quant = 1, phase = 0, referenceBeat | ^TempoClock.default.nextTimeOnGrid(quant, phase, referenceBeat) }
 	*timeToNextBeat { | quant = 1 | ^TempoClock.default.timeToNextBeat(quant)  }
 
-	*setTempoAtBeat { | newTempo, beats | TempoClock.default.setTempoAtBeat(newTempo, beats)	 }
-	*setTempoAtSec { | newTempo, secs | TempoClock.default.setTempoAtSec(newTempo, secs)	 }
-	*setMeterAtBeat { | newBeatsPerBar, beats | TempoClock.default.setMeterAtBeat(newBeatsPerBar, beats)	 }
-
-	*beatsPerBar { ^TempoClock.default.beatsPerBar  }
-	*baseBarBeat { ^TempoClock.default.baseBarBeat  }
-	*baseBar { ^TempoClock.default.baseBar  }
-	*playNextBar { | task | ^TempoClock.default.playNextBar(task)  }
-	*beatDur { ^TempoClock.default.beatDur  }
-	*elapsedBeats { ^TempoClock.default.elapsedBeats	 }
-	*beatsPerBar_ { | newBeatsPerBar | TempoClock.default.beatsPerBar_(newBeatsPerBar)  }
-	*beats2bars { | beats | ^TempoClock.default.beats2bars(beats)  }
-	*bars2beats { | bars | ^TempoClock.default.bars2beats(bars)	}
 	*bar { ^TempoClock.default.bar  }
 	*nextBar { | beat | ^TempoClock.default.nextBar(beat)  }
+	*beatsPerBar { ^TempoClock.default.beatsPerBar  }
+	*beatsPerBar_ { | newBeatsPerBar | TempoClock.default.beatsPerBar_(newBeatsPerBar)  }
+	*setMeterAtBeat { | newBeatsPerBar, beats | TempoClock.default.setMeterAtBeat(newBeatsPerBar, beats)	 }
 	*beatInBar { ^TempoClock.default.beatInBar  }
+	*baseBarBeat { ^TempoClock.default.baseBarBeat  }
+	*baseBar { ^TempoClock.default.baseBar  }
 
-	*isRunning { ^this.default.isRunning }
+	*playNextBar { | task | ^TempoClock.default.playNextBar(task)  }
 
 	archiveAsCompileString { ^true }
 }


### PR DESCRIPTION
As stated in the summary; brought up by @jamshark70 on the forum (https://scsynth.org/t/misleading-help-bit-in-tempoclock-forwarding/12526). If there are any good reasons to _not_ also have the setter forward to the default TempoClock (I can't think of any, but who knows), this would imply a doc change instead of this classlib change - please let me know if that is the case.   

Also organizes the other lines in the Class methods that forward to default, so this is less of a jumble hopefully.

the actual addition is this:
```
	*beats_ { |beats|  ^TempoClock.default.beats_(beats) }
```
The other changed lines are just cosmetics: The order in which the methods were listed was pretty random, so I grouped/reordered them a bit while I was in there. I double checked to make sure I didn't actually cut a method there.
