### PR TITLE
classlib: limit use of `respondsTo` and post warning

### DIFF
--- a/HelpSource/Classes/Object.schelp
+++ b/HelpSource/Classes/Object.schelp
@@ -98,6 +98,13 @@ code::
 
 method::respondsTo
 
+warning:: 
+This method is NOT recommended as it breaks polymorphism and doesn't allow the effects of code::doesNotUnderstand:: to take place.
+Using this method means the code is subtly broken in ways that will be hard to predict!
+It will post a warning when called.
+Instead see code::tryPerform:: which in the vast majority of use cases is the correct approach.
+::
+
 Answer a link::Classes/Boolean:: whether the receiver understands the message selector or array of message selectors.
 
 code::
@@ -110,6 +117,9 @@ code::
 
 argument::aSymbol
 A selector name. Must be a link::Classes/Symbol::.
+
+argument::postWarning
+A boolean, can be used to disable the warning if it is absolutely necessary.
 
 method::isKindOf
 

--- a/SCClassLibrary/Common/Audio/SynthDef.sc
+++ b/SCClassLibrary/Common/Audio/SynthDef.sc
@@ -544,7 +544,7 @@ SynthDef {
 			var inputs, ugenName;
 			if (ugen.inputs.notNil) {
 				inputs = ugen.inputs.collect {|in|
-					if (in.respondsTo(\dumpName)) { in.dumpName }{ in };
+					in.tryPerform(\dumpName) ?? { in }
 				};
 			};
 			[ugen.dumpName, ugen.rate, inputs].postln;

--- a/SCClassLibrary/Common/Audio/SynthDefOld.sc
+++ b/SCClassLibrary/Common/Audio/SynthDefOld.sc
@@ -90,10 +90,7 @@ SynthDefOld : SynthDef {
 			}
 		} { // catch
 			arg e;
-			if (file.respondsTo(\close)) {
-				file.close;
-			};
-			Error("SynthDefOld: could not write def: %".format(e.what())).throw;
+			file.tryPerform(\close) ??  { Error("SynthDefOld: could not write def: %".format(e.what())).throw };
 		}
 	}
 

--- a/SCClassLibrary/Common/Audio/UGen.sc
+++ b/SCClassLibrary/Common/Audio/UGen.sc
@@ -390,11 +390,11 @@ UGen : AbstractFunction {
 		CheckBadValues.perform(this.methodSelectorForRate, this, id, post);
 	}
 
-	*methodSelectorForRate { arg rate;
+	*methodSelectorForRate { |rate|
 		if(rate == \audio,{ ^\ar });
 		if(rate == \control, { ^\kr });
 		if(rate == \scalar, {
-			if(this.respondsTo(\ir),{
+			if(this.respondsTo(\ir, postWarning: false),{
 				^\ir
 			},{
 				^\new
@@ -463,11 +463,14 @@ UGen : AbstractFunction {
 		if (rate == \demand, { ^3 });
 		^0 // scalar
 	}
+
+	// TODO: this method should be implemented in subclasses instead.
+	// Using respondsTo like this breaks polymorphism and is bad smalltalk design.
 	methodSelectorForRate {
 		if(rate == \audio,{ ^\ar });
 		if(rate == \control, { ^\kr });
 		if(rate == \scalar, {
-			if(this.class.respondsTo(\ir),{
+			if(this.class.respondsTo(\ir, postWarning: false),{
 				^\ir
 			},{
 				^\new

--- a/SCClassLibrary/Common/Collections/Association.sc
+++ b/SCClassLibrary/Common/Collections/Association.sc
@@ -5,8 +5,9 @@ Association : Magnitude {
 		^super.newCopyArgs(key, value)
 	}
 
-	== { arg anAssociation;
-		^anAssociation respondsTo: \key and: { key == anAssociation.key }
+	== { |other|
+		var otherKey = other.tryPerform(\key); 
+		^otherKey !? { otherKey == key } ?? { false }
 	}
 
 	hash {

--- a/SCClassLibrary/Common/Collections/Dictionary.sc
+++ b/SCClassLibrary/Common/Collections/Dictionary.sc
@@ -23,9 +23,7 @@ Dictionary : Set {
 		^nil
 	}
 	trueAt { arg key;
-		var val = this.at(key);
-		if(val.respondsTo(\booleanValue).not) { ^false };
-		^val.booleanValue
+		^this.at(key).tryPerform(\booleanValue) ?? {false}
 	}
 	falseAt { arg key;
 		^this.trueAt(key).not
@@ -551,10 +549,7 @@ IdentityDictionary : Dictionary {
 
         if (selector.isSetter) {
             selector = selector.asGetter;
-            if(this.respondsTo(selector)) {
-                warn(selector.asCompileString
-                    + "exists as a method name, so you can't use it as a pseudo-method.")
-            };
+			// Impossible to tell if you can or can't use a method name ahead of time.
             ^this[selector] = args[0];
         };
 

--- a/SCClassLibrary/Common/Collections/EnvironmentRedirect.sc
+++ b/SCClassLibrary/Common/Collections/EnvironmentRedirect.sc
@@ -193,7 +193,7 @@ EnvironmentRedirect {
 	// networking
 	dispatch_ { arg disp;
 		dispatch = disp;
-		if(disp.respondsTo(\envir_)) { disp.envir_(this) };
+		disp.tryPerform(\envir_, this)
 	}
 	envir_ { arg argEnvir;
 		envir = argEnvir;

--- a/SCClassLibrary/Common/Collections/Event.sc
+++ b/SCClassLibrary/Common/Collections/Event.sc
@@ -193,19 +193,13 @@ Event : Environment {
 				note: #{
 					(~degree + ~mtranspose).degreeToKey(
 						~scale,
-						~scale.respondsTo(\stepsPerOctave).if(
-							{ ~scale.stepsPerOctave },
-							~stepsPerOctave
-						)
+						~scale.tryPerform(\stepsPerOctave) ?? {~stepsPerOctave}
 					);
 				},
 				midinote: #{
-					(((~note.value + ~gtranspose + ~root) /
-						~scale.respondsTo(\stepsPerOctave).if(
-							{ ~scale.stepsPerOctave },
-							~stepsPerOctave) + ~octave - 5.0) *
-						(12.0 * ~scale.respondsTo(\octaveRatio).if
-							({ ~scale.octaveRatio }, ~octaveRatio).log2) + 60.0);
+					((~note.value + ~gtranspose + ~root) /
+						(~scale.tryPerform(\stepsPerOctave) ?? {~stepsPerOctave} + ~octave - 5.0) 
+						* (12.0 * (~scale.tryPerform(\octaveRatio) ?? { ~octaveRatio }).log2) + 60.0);
 				},
 				detunedFreq: #{
 					~freq.value + ~detune
@@ -215,20 +209,15 @@ Event : Environment {
 				},
 				freqToNote: #{ arg self, freq; // conversion from frequency to note value
 					self.use {
-						var midinote;
-						var steps = ~scale.respondsTo(\stepsPerOctave).if(
-							{ ~scale.stepsPerOctave }, ~stepsPerOctave
-						);
-						midinote = cpsmidi((freq / ~harmonic) - ~ctranspose);
+						var steps = ~scale.tryPerform(\stepsPerOctave) !? { ~stepsPerOctave };
+						var midinote = cpsmidi((freq / ~harmonic) - ~ctranspose);
 						midinote / 12.0 - ~octave * steps - ~root - ~gtranspose
 					}
 				},
 				freqToScale: #{ arg self, freq;
 					// conversion from frequency to scale value.
 					self.use {
-						var steps = ~scale.respondsTo(\stepsPerOctave).if(
-							{ ~scale.stepsPerOctave }, ~stepsPerOctave
-						);
+						var steps = ~scale.tryPerform(\stepsPerOctave) !? { ~stepsPerOctave };
 						var degree = self.freqToNote(freq).keyToDegree(~scale, steps)
 						- ~mtranspose;
 						degree.asArray.collect {|x, i|

--- a/SCClassLibrary/Common/Collections/Event.sc
+++ b/SCClassLibrary/Common/Collections/Event.sc
@@ -194,12 +194,16 @@ Event : Environment {
 					(~degree + ~mtranspose).degreeToKey(
 						~scale,
 						~scale.tryPerform(\stepsPerOctave) ?? {~stepsPerOctave}
-					);
+					)
 				},
 				midinote: #{
-					((~note.value + ~gtranspose + ~root) /
-						(~scale.tryPerform(\stepsPerOctave) ?? {~stepsPerOctave} + ~octave - 5.0) 
-						* (12.0 * (~scale.tryPerform(\octaveRatio) ?? { ~octaveRatio }).log2) + 60.0);
+					(
+						(~note.value + ~gtranspose + ~root) 
+						/ (~scale.tryPerform(\stepsPerOctave) ?? {~stepsPerOctave})
+						+ ~octave - 5.0
+					) 
+					* (12.0 * (~scale.tryPerform(\octaveRatio) ?? { ~octaveRatio }).log2) 
+					+ 60.0
 				},
 				detunedFreq: #{
 					~freq.value + ~detune

--- a/SCClassLibrary/Common/Collections/Pair.sc
+++ b/SCClassLibrary/Common/Collections/Pair.sc
@@ -17,31 +17,30 @@ Pair : Collection {
 		^this.new(linkDown, linkAcross)
 	}
 
+	size {
+		var i = 0, link = linkAcross;
+		while { link = link.tryPerform('linkAcross'); link.notNil}{
+			i = i + 1
+		};
+		^i
+	}
 
-	size { var i = 0, link;
-		link = linkAcross;
-		while ({ link.respondsTo('linkAcross') },{
-			i = i + 1;
-			link = link.linkAcross;
-		});
+	depth { 
+		var i = 0, link = linkDown;
+		while { link = link.tryPerform('linkDown'); link.notNil} {
+			i = i + 1
+		};
 		^i
 	}
-	depth { var i = 0, link;
-		link = linkDown;
-		while ({ link.respondsTo('linkDown') },{
-			i = i + 1;
-			link = link.linkDown;
-		});
-		^i
-	}
-	do { arg function;
-		var i = 0, link, res;
+
+	do { |function|
+		var i = 0, link, nextLink, res;
 		link = linkAcross;
-		while ({ link.respondsTo('linkAcross') },{
+		while { nextLink = link.tryPerform('linkAcross'); nextLink.notNil} {
 			i = i + 1;
 			res = function.value(link, i);
-			link = link.linkAcross;
-		});
+			link = nextLink;
+		};
 		^res
 	}
 
@@ -52,43 +51,33 @@ Pair : Collection {
 		// the default traversal order
 		^this.depthFirstPreOrderTraversal(function)
 	}
-	depthFirstPreOrderTraversal { arg function;
-		var link;
+
+	depthFirstPreOrderTraversal { |function|
+		var link, nextLinkDown;
 		function.value(this);
-		if ( linkDown.respondsTo('depthFirstPreOrderTraversal'), {
-			linkDown.depthFirstPreOrderTraversal(function);
-		});
+		linkDown.tryPerform('depthFirstPreOrderTraversal', function);
 		// iterate linkAcross to conserve stack depth
 		link = linkAcross;
-		while ({ link.notNil },{
+		while { link.notNil } {
 			function.value(link);
-			if (link.respondsTo(\linkDown) and:
-				{ link.linkDown.respondsTo('depthFirstPreOrderTraversal') }, {
-					link.linkDown.depthFirstPreOrderTraversal(function);
-			});
-			if(link.respondsTo('linkAcross')) {
-				link = link.linkAcross;
-			} { link = nil };
-		});
+			nextLinkDown = link.tryPerform('linkDown');
+			nextLinkDown !? { nextLinkDown.tryPerform('depthFirstPreOrderTraversal', function) };
+			link = link.tryPerform('linkAcross');
+		};
 	}
-	depthFirstPostOrderTraversal { arg function;
-		var link;
-		if ( linkDown.respondsTo('depthFirstPostOrderTraversal'), {
-			linkDown.depthFirstPostOrderTraversal(function);
-		});
+
+	depthFirstPostOrderTraversal { |function|
+		var link, nextLinkDown;
+		linkDown.tryPerform('depthFirstPreOrderTraversal', function);
 		function.value(this);
 		// iterate linkAcross to conserve stack depth
 		link = linkAcross;
-		while ({ link.notNil },{
-			if (link.respondsTo(\linkDown) and:
-				{ link.linkDown.respondsTo('depthFirstPostOrderTraversal') }, {
-				link.linkDown.depthFirstPostOrderTraversal(function);
-			});
+		while { link.notNil } {
+			nextLinkDown = link.tryPerform(\linkDown);
+			nextLinkDown !? { nextLinkDown.tryPerform('depthFirstPostOrderTraversal, function') };
 			function.value(link);
-			if(link.respondsTo('linkAcross')) {
-				link = link.linkAcross;
-			} { link = nil };
-		});
+			link = link.tryPerform('linkAcross');
+		};
 	}
 
 	storeArgs { arg stream;
@@ -98,6 +87,7 @@ Pair : Collection {
 	printOn { arg stream;
 		stream << this.class.name << "(" <<* this.storeArgs << ")"
 	}
+
 	storeOn { arg stream;
 		stream << this.class.name << "(" <<<* this.storeArgs << ")"
 	}

--- a/SCClassLibrary/Common/Collections/SequenceableCollection.sc
+++ b/SCClassLibrary/Common/Collections/SequenceableCollection.sc
@@ -497,7 +497,7 @@ SequenceableCollection : Collection {
 
 		list = this.species.new(this.size);
 		this.do{ |item|
-			itemFlatten = item.tryPerform(\flatten);
+			itemFlatten = item.tryPerform(\flatten, numLevels);
 			itemFlatten !? { list = list.addAll(itemFlatten) } ?? { list = list.add(item) }
 		};
 		^list

--- a/SCClassLibrary/Common/Collections/SequenceableCollection.sc
+++ b/SCClassLibrary/Common/Collections/SequenceableCollection.sc
@@ -490,19 +490,16 @@ SequenceableCollection : Collection {
 	}
 
 	flatten { arg numLevels=1;
-		var list;
+		var list, itemFlatten;
 
 		if (numLevels <= 0, { ^this });
 		numLevels = numLevels - 1;
 
 		list = this.species.new(this.size);
-		this.do({ arg item;
-			if (item.respondsTo('flatten'), {
-				list = list.addAll(item.flatten(numLevels));
-			},{
-				list = list.add(item);
-			});
-		});
+		this.do{ |item|
+			itemFlatten = item.tryPerform(\flatten);
+			itemFlatten !? { list = list.addAll(itemFlatten) } ?? { list = list.add(item) }
+		};
 		^list
 	}
 
@@ -510,13 +507,7 @@ SequenceableCollection : Collection {
 
 		if (level <=0) { ^this.flat };
 		level = level - 1;
-		^this.collect { |item|
-			if (item.respondsTo(\flatBelow)) {
-				item.flatBelow(level)
-			} {
-				item
-			}
-		}
+		^this.collect { |item| item.tryPerform(\flatBelow) !? { item } }
 	}
 
 	// bidirectional flattening
@@ -531,25 +522,25 @@ SequenceableCollection : Collection {
 	}
 
 	prFlat { |list|
-		this.do({ arg item, i;
-			if (item.respondsTo('prFlat'), {
-				list = item.prFlat(list);
-			},{
-				list = list.add(item);
-			});
-		});
+		var prFlat;
+		this.do{ |item, i|
+			prFlat = item.tryPerform(\prFlat, list) ;
+			prFlat !? { list = prFlat } ?? { list = list.add(item) };
+		};
 		^list
 	}
 
 	flatIf { |func|
 		var list = this.species.new(this.size); // as we don't know the size, just guess
-		this.do({ arg item, i;
-			if (item.respondsTo('flatIf') and: { func.value(item, i) }, {
-				list = list.addAll(item.flatIf(func));
-			},{
-				list = list.add(item);
-			});
-		});
+		var r;
+		this.do { |item, i|
+			if (func.(item, i)) {
+				r = item.tryPerform(\flatIf, func);
+				list = r !? {  list.addAll(r) } ?? { list.add(item) };
+			} {
+				list = list.add(item)
+			}
+		};
 		^list
 	}
 

--- a/SCClassLibrary/Common/Collections/String.sc
+++ b/SCClassLibrary/Common/Collections/String.sc
@@ -477,28 +477,28 @@ String[char] : RawArray {
 	}
 
 	// path concatenate
-	+/+ { arg path;
+	+/+ { |path|
 		var sep = thisProcess.platform.pathSeparator;
 		var hasLeftSep, hasRightSep;
 
-		if (path.respondsTo(\fullPath)) {
-			^PathName(this +/+ path.fullPath)
+		var fullPath = path.tryPerform(\fullPath) ?? {
+			// convert to string before concatenation.
+			path = path.asString;
+			hasLeftSep = this.notEmpty and: { this.last.isPathSeparator };
+			hasRightSep = path.notEmpty and: { path.first.isPathSeparator };
+			if(hasLeftSep && hasRightSep) {
+				// prefer using the LHS separator
+				^this ++ path.drop(1)
+			};
+
+			if(hasLeftSep || hasRightSep) {
+				^this ++ path
+			};
+
+			^this ++ sep ++ path
 		};
 
-		// convert to string before concatenation.
-		path = path.asString;
-		hasLeftSep = this.notEmpty and: { this.last.isPathSeparator };
-		hasRightSep = path.notEmpty and: { path.first.isPathSeparator };
-		if(hasLeftSep && hasRightSep) {
-			// prefer using the LHS separator
-			^this ++ path.drop(1)
-		};
-
-		if(hasLeftSep || hasRightSep) {
-			^this ++ path
-		};
-
-		^this ++ sep ++ path
+		^PathName(this +/+ fullPath)
 	}
 
 	asRelativePath { |relativeTo|

--- a/SCClassLibrary/Common/Core/Char.sc
+++ b/SCClassLibrary/Common/Core/Char.sc
@@ -98,7 +98,10 @@ Char : Magnitude {
 	< { arg aChar;
 		^this.ascii < aChar.ascii
 	}
-	== { arg aChar;  ^aChar respondsTo: \ascii and: { this.ascii == aChar.ascii } }
+	== { |aChar|  
+		var c = aChar.tryPerform(\ascii);
+		^c !? { this.ascii == c } ?? { false };
+	}
 
 	++ { |that| ^this.asString ++ that }
 

--- a/SCClassLibrary/Common/Core/CondVar.sc
+++ b/SCClassLibrary/Common/Core/CondVar.sc
@@ -102,11 +102,9 @@ CondVar {
 
 	// Precondition checks for `waitFor` timeout. May throw.
 	prConvertTimeoutBeatsToSafeValue { |n|
-		n = case
-			{ n.class === Float or: { n.class === Integer } } { n }
-			{ n.respondsTo(\asInteger) } { n.asInteger }
-			{ n.respondsTo(\asFloat) } { n.asFloat }
-			{ n };
+		n = if ( n.class === Float or: { n.class === Integer } ) { n } {
+			n.tryPerform(\asInteger) ?? { n.tryPerform(\asFloat) ?? { n } }
+		};
 
 		if(n.class !== Float and: { n.class !== Integer }) {
 			Error("Timeout must be a Float or Integer, or convertible to one").throw

--- a/SCClassLibrary/Common/Core/Object.sc
+++ b/SCClassLibrary/Common/Core/Object.sc
@@ -69,7 +69,16 @@ Object {
 	class { _ObjectClass; ^this.primitiveFailed }
 	isKindOf { arg aClass; _ObjectIsKindOf; ^this.primitiveFailed }
 	isMemberOf { arg aClass; _ObjectIsMemberOf; ^this.primitiveFailed }
-	respondsTo { arg aSymbol; _ObjectRespondsTo; ^this.primitiveFailed }
+	respondsTo { |aSymbol, postWarning=true|
+		if(postWarning) {
+			"respondsTo limits polymorphism, do not use it as it will subtly break in unexpected way! Instead use tryPerform".warn
+		};
+		^this.prBrokenRespondsTo(aSymbol)
+	}
+	prBrokenRespondsTo { |aSymbol|
+		_ObjectRespondsTo;
+		^this.primitiveFailed
+	}
 
     // args and kwargs should be arrays here, not variable arguments!
 	performArgs { |selector, args, kwargs|
@@ -113,10 +122,18 @@ Object {
 		^this.primitiveFailed
 	}
 
-	tryPerform { |  ... args, kwargs|
-		^if(this.respondsTo(args[0]), {
-			this.performArgs(args[0],  args[1..], kwargs)
-		})
+	tryPerform { |...args, kwargs|
+	 	var r;
+		try {
+			r = this.performArgs(args[0], args[1..], kwargs)
+		} { |er|
+			if(er.isKindOf(DoesNotUnderstandError) and: { er.selector === args[0]} ) {
+				r = nil; // Failure. Old interface returned nil. If the method returns nil to, there is no way to tell the difference.
+			} {
+				er.throw;
+			}
+		}
+		^r
 	}
 
 	multiChannelPerform { arg selector ... args;
@@ -183,6 +200,7 @@ Object {
 	=== { arg obj; _Identical; ^this.primitiveFailed }
 	!== { arg obj;_NotIdentical; ^this.primitiveFailed }
 	equals { arg that, properties;
+		"WARNING: this method is inherently broken and cannot be fixed as it uses respondsTo, avoid it.".postln;
 		^that.respondsTo(properties) and: {
 			properties.every { |selector| this.perform(selector) == that.perform(selector) }
 		}

--- a/SCClassLibrary/Common/Files/PathName.sc
+++ b/SCClassLibrary/Common/Files/PathName.sc
@@ -158,7 +158,7 @@ PathName {
 
 	/* concatenation */
 	+/+ { | path |
-		var otherFullPath = path.respondsTo(\fullPath).if({ path.fullPath }, { path.asString });
+		var otherFullPath = path.tryPerform(\fullPath) ?? { path.asString };
 		^this.class.new(fullPath +/+ otherFullPath)
 	}
 

--- a/SCClassLibrary/Common/GUI/Base/QView.sc
+++ b/SCClassLibrary/Common/GUI/Base/QView.sc
@@ -579,9 +579,10 @@ View : QObject {
 		this.setEventHandler( QObject.keyDownEvent, \keyDownEvent, true, enabled: handleKeyDown );
 		this.setEventHandler( QObject.keyUpEvent, \keyUpEvent, true, enabled: handleKeyUp );
 
+		// TODO: Why are we calling this.respondsTo... we know what this is!?
 		// mouse events
 		overridesMouseDown = this.overrides( \mouseDown );
-		if( this.respondsTo(\defaultGetDrag) || overridesMouseDown )
+		if( this.respondsTo(\defaultGetDrag, false) || overridesMouseDown )
 		{this.setEventHandler( QObject.mouseDownEvent, \mouseDownEvent, true )};
 		if( overridesMouseDown )
 		{this.setEventHandler( QObject.mouseDblClickEvent, \mouseDownEvent, true )};
@@ -597,7 +598,7 @@ View : QObject {
 		{this.setEventHandler( QObject.mouseWheelEvent, \mouseWheelEvent, true )};
 
 		// DnD events
-		handleDrag = this.respondsTo(\defaultCanReceiveDrag) or: {this.respondsTo(\defaultReceiveDrag)};
+		handleDrag = this.respondsTo(\defaultCanReceiveDrag, false) or: {this.respondsTo(\defaultReceiveDrag, false)};
 		this.setEventHandler( 60, \dragEnterEvent, true, enabled:handleDrag );
 		this.setEventHandler( 61, \dragMoveEvent, true, enabled:handleDrag );
 		this.setEventHandler( 63, \dropEvent, true, enabled:handleDrag );

--- a/SCClassLibrary/Common/GUI/Base/QtGUI.sc
+++ b/SCClassLibrary/Common/GUI/Base/QtGUI.sc
@@ -136,11 +136,8 @@ QtGUI {
 
 	*selectedText {
 		var view = this.focusView;
-		if( view.notNil ) {
-			if( view.respondsTo(\selectedText) ) { ^view.selectedText };
-			if( view.respondsTo(\selectedString) ) { ^view.selectedString };
-		};
-		^"";
+		if (view.isNil) { ^"" };
+		^view.tryPerform(\selectedText) ?? { view.tryPerform(\selectedString) } ?? { "" }
 	}
 
 	// private ///////////////////////////////////////////////////////////

--- a/SCClassLibrary/Common/GUI/PlusGUI/Core/ClassBrowser.sc
+++ b/SCClassLibrary/Common/GUI/PlusGUI/Core/ClassBrowser.sc
@@ -207,8 +207,15 @@ ClassBrowser {
 			} {
 				~state = state;
 			};
-			if(extraValuesDict.respondsTo(\keysValuesDo)) {
+			try {
 				currentEnvironment.putAll(extraValuesDict);
+			} { |er|
+				if (er.isKindOf(DoesNotUnderstandError) and: { er.selector = \keysValuesDo }) {
+					// carry on
+				} {
+					// some unrelated issue
+					er.throw
+				}
 			};
 			~state.envirGet[\init].value;
 			~subclassViewIndex = ~subclassViewIndex.value ? 0;

--- a/SCClassLibrary/Common/GUI/backwardsCompatibility/SCViewHolder.sc
+++ b/SCClassLibrary/Common/GUI/backwardsCompatibility/SCViewHolder.sc
@@ -47,13 +47,17 @@ SCViewHolder {
 
 	// delegate to the view
 	doesNotUnderstand { |selector ... args|
-		var	result;
-		view.respondsTo(selector).if({
+		var result;
+		try {
 			result = view.performList(selector, args);
-			^(result === view).if({ this }, { result });
-		}, {
-			DoesNotUnderstandError(this, selector, args).throw;
-		});
+		} { |er|
+			if (er.isKindOf(DoesNotUnderstandError) and: {er.selector === selector}) {
+				DoesNotUnderstandError(this, selector, args).throw;
+			} {
+				er.throw
+			}
+		};
+		^(result === view).if({ this }, { result });
 	}
 }
 

--- a/SCClassLibrary/Common/GUI/tools/HelpBrowser.sc
+++ b/SCClassLibrary/Common/GUI/tools/HelpBrowser.sc
@@ -136,6 +136,7 @@ HelpBrowser {
 		var winRect;
 		var x, y, w, h;
 		var str;
+		var boxClass;
 
 		homeUrl = aHomeUrl;
 
@@ -183,7 +184,8 @@ HelpBrowser {
 
 		openNewWin = aNewWin;
 		x = x + w + 10;
-		if(GUI.current.respondsTo(\checkBox)) {
+
+		GUI.current.tryPerform(\checkBox) !? {
 			str = "Open links in new window";
 			w = str.bounds.width + 50;
 			CheckBox.new (window, Rect(x, y, w, h) )
@@ -191,7 +193,7 @@ HelpBrowser {
 				.string_(str)
 				.value_(openNewWin)
 				.action_({ |b| openNewWin = b.value; });
-		} {
+		} ?? {
 			str = "Open links in same window";
 			w = str.bounds.width + 5;
 			Button.new( window, Rect(x, y, w, h) )
@@ -200,6 +202,7 @@ HelpBrowser {
 				.value_(openNewWin.asInteger)
 				.action_({ |b| openNewWin = b.value.asBoolean; });
 		};
+
 
 		x = 0;
 		y = marg + h + 5;

--- a/SCClassLibrary/Common/GUI/tools/guicrucial/ObjectGui.sc
+++ b/SCClassLibrary/Common/GUI/tools/guicrucial/ObjectGui.sc
@@ -17,9 +17,9 @@ ObjectGui : SCViewHolder {
 		// this is a lazy way to write simple guis for simple objects
 		// where model/gui code separation is not especially important
 		// and where the controller class doesn't need to maintain any state or vars
-		if(model.respondsTo(\guiBody) and: {model.isKindOf(ObjectGui).not},{
-			model.guiBody(layout,bounds,*args)
-		})
+		if (model.isKindOf(ObjectGui).not) {
+			model.tryPerform(\guiBody, layout, bounds, *args)
+		}
 	}
 
 	*new { arg model;

--- a/SCClassLibrary/Common/GUI/tools/guicrucial/PageLayout.sc
+++ b/SCClassLibrary/Common/GUI/tools/guicrucial/PageLayout.sc
@@ -118,18 +118,17 @@ PageLayout  {
 		autoRemoves = autoRemoves.add(dependant);
 	}
 
-	resizeToFit { arg reflow=false,center=false;
-		var fs, b,wb,wbw,wbh;
+	resizeToFit { |reflow=false, center=false|
+		var fs, b, wb, wbw, wbh;
 
 		b = this.view.resizeToFit(reflow);
 		wbw = b.width + 11;
 		wbh = b.height + 15;
 		window.setInnerExtent(wbw,wbh);
 
-		if(center and: {window.respondsTo(\setTopLeftBounds)}) {
-			// this should be a window method
-			fs = GUI.window.screenBounds;
-			wb = window.bounds;
+		if (center) {
+			fs = GUI.window.screenBounds.copy;
+			wb = window.bounds.copy;
 			// bounds are inaccurate until the end of the code cycle/refresh
 			wb.width = wbw;
 			wb.height = wbh;
@@ -142,9 +141,11 @@ PageLayout  {
 			});
 			// center it horizontally
 			wb.left = (fs.width - wbw) / 2;
-			window.setTopLeftBounds(wb);
+
+			window.tryPerform(\setTopLeftBounds, wb);
 		}
 	}
+
 	reflowAll {
 		view.reflowAll;
 	}

--- a/SCClassLibrary/Common/Math/Polar.sc
+++ b/SCClassLibrary/Common/Math/Polar.sc
@@ -30,9 +30,13 @@ Polar : Number {
 	* { arg aNumber;  ^this.asComplex * aNumber  }
 	/ { arg aNumber;  ^this.asComplex / aNumber  }
 
-	== { arg aPolar;
-		^aPolar respondsTo: #[\rho, \theta] and: {
-			rho == aPolar.rho and: { theta == aPolar.theta }
+	== { |aPolar|
+		var r = aPolar.tryPerform(\rho);
+		var t = aPolar.tryPerform(\theta);
+		^if (r.notNil and: { t.notNil }) {
+			rho == r and: { theta == t }
+		} {
+			false
 		}
 	}
 

--- a/SCClassLibrary/Common/Streams/TabFileReader.sc
+++ b/SCClassLibrary/Common/Streams/TabFileReader.sc
@@ -5,6 +5,8 @@ FileReader : Stream {
 
 	*new { |pathOrFile, skipEmptyLines = false, skipBlanks = false, delimiter|
 		var stream;
+
+		// TODO: this usage of respondsTo seem highly problematic.
 		if(pathOrFile.respondsTo(\getChar) ) {
 			stream = pathOrFile
 		} {

--- a/SCClassLibrary/Common/UnitTesting/UnitTest.sc
+++ b/SCClassLibrary/Common/UnitTesting/UnitTest.sc
@@ -324,12 +324,10 @@ UnitTest {
 			("No test class found for " + class).inform;
 			^this
 		};
-		if(testClass.respondsTo(\run).not) {
-			("Attempting to run UnitTests on class that is not a subclass of UnitTest"
-				+ testClass).error;
-			^this
-		};
-		testClass.run(reset,report)
+		testClass.tryPerform(\run, reset, report) ?? { 
+			("Attempting to run UnitTests on class that does not have a 'run' method" + testClass).error;
+			^this;
+		}
 	}
 
 	*findTestClass { | forClass |

--- a/SCClassLibrary/JITLib/GUI/EnvirGui.sc
+++ b/SCClassLibrary/JITLib/GUI/EnvirGui.sc
@@ -326,11 +326,8 @@ EnvirGui : JITGui {
 	// if none found, guess an initial spec and remember it.
 	// note: for specs attached to proxies, use JITLibExtensions quark
 	getSpec { |key, value|
-		var spec;
-		if (object.respondsTo(\findFirstSpecFor)) {
-			spec = object.findFirstSpecFor(key);
-			if (spec.notNil) { ^spec };
-		};
+		var spec = object.tryPerform(\findFirstSpecFor, key);
+		spec !? { ^spec };
 
 		spec = specs[key] ?? { key.asSpec };
 		if (spec.isNil) {

--- a/SCClassLibrary/JITLib/GUI/JITGui.sc
+++ b/SCClassLibrary/JITLib/GUI/JITGui.sc
@@ -102,7 +102,7 @@ JITGui {
 		^nameView.notNil and: { nameView.string.notNil }
 	}
 
-	getName { ^if (object.respondsTo(\key)) { object.key } { 'anon' } }
+	getName { ^object.tryPerform(\key) ?? { 'anon' } }
 	winName { |name| ^this.class.name ++ $_ ++ (name ?? { this.getName }) }
 
 	calcBounds {

--- a/SCClassLibrary/JITLib/GUI/TaskProxyGui.sc
+++ b/SCClassLibrary/JITLib/GUI/TaskProxyGui.sc
@@ -5,9 +5,7 @@ TaskProxyGui : JITGui {
 
 	*observedClass { ^TaskProxy }
 
-	getObjectKey {
-		^if (object.respondsTo(\key)) { object.key } { 'anon' };
-	}
+	getObjectKey { ^object.tryPerform(\key) ?? { 'anon'} }
 
 	setDefaults { |options|
 		defPos = 10@260;
@@ -268,11 +266,7 @@ TaskProxyAllGui :JITGui {
 	*observedClass { ^TaskProxy }
 	*tpGuiClass { ^TaskProxyGui }
 
-	*observedAll {
-		^if (this.observedClass.respondsTo(\all)) {
-			this.observedClass.all
-		} { nil };
-	}
+	*observedAll { ^this.observedClass.tryPerform(\all) }
 
 	*new { |numItems = 16, parent, bounds, makeSkip = true, options = #[]|
 		^super.new(this.observedAll, numItems, parent, bounds, makeSkip, options );

--- a/SCClassLibrary/JITLib/ProxySpace/BusPlug.sc
+++ b/SCClassLibrary/JITLib/ProxySpace/BusPlug.sc
@@ -109,15 +109,16 @@ BusPlug : AbstractFunction {
 	//  math support
 
 	value { | something |
-		var n;
+		var n, r;
 		if(UGen.buildSynthDef.isNil) { ^this }; // only return when in ugen graph.
 		something !? { n = something.numChannels };
-		^if(something.respondsTo(\rate) and: { something.rate == 'audio'} or: { this.rate == \audio }) {
+		r = something.tryPerform(\rate);
+
+		^if (r === \audio or: { this.rate === \audio}) {
 			this.ar(n)
 		} {
 			this.kr(n)
 		}
-
 	}
 
 	composeUnaryOp { | aSelector |

--- a/SCClassLibrary/JITLib/ProxySpace/NodeMap.sc
+++ b/SCClassLibrary/JITLib/ProxySpace/NodeMap.sc
@@ -132,9 +132,8 @@ ProxyNodeMap : NodeMap {
 	controlNames {
 		var res = Array.new;
 		this.keysValuesDo { |key, value|
-			var rate = if(value.respondsTo(\rate) and:{
-				value.rate == \audio
-			}) { \audio } { \control };
+			var r = value.tryPerform(\rate);
+			var rate = if (r != \audio) { \control } { \audio };
 			res = res.add(ControlName(key, nil, rate, value))
 		};
 		^res

--- a/SCClassLibrary/JITLib/ProxySpace/NodeProxy.sc
+++ b/SCClassLibrary/JITLib/ProxySpace/NodeProxy.sc
@@ -1046,22 +1046,20 @@ NodeProxy : BusPlug {
 	findFirstSpecFor { |controlName|
 		var spec;
 		this.objects.do { |obj|
-			if (obj.respondsTo(\findSpecFor)) {
-				spec = obj.findSpecFor(controlName);
-				if (spec.notNil) {
-					^spec
-				}
-			}
+			spec = obj.tryPerform(\findSpecFor, controlName);
+			spec !? { ^spec };
 		};
 		^nil
 	}
 
 	specs {
 		var specs = ();
+		var objSpec;
 		this.objects.do {
 			|obj|
-			if (obj.respondsTo(\specs)) {
-				specs = specs.merge(obj.specs, {
+			objSpec = obj.tryPerform(\specs);
+			objSpec !? {
+				specs = specs.merge(objSpec, {
 					|a, b, key|
 					"Duplicate specs for key: % - only one will be used.".format(key).warn;
 					a;

--- a/SCClassLibrary/JITLib/ProxySpace/operators.sc
+++ b/SCClassLibrary/JITLib/ProxySpace/operators.sc
@@ -83,9 +83,8 @@ BinaryOpPlug : AbstractOpPlug  {
 	rate {
 		// \audio < \control < \scalar
 		// note that function.rate is defined as \stream
-		var arate = \scalar, brate = \scalar;
-		if(a.respondsTo(\rate)) { arate = a.rate };
-		if(b.respondsTo(\rate)) { brate = b.rate };
+		var arate = a.tryPerform(\rate) ?? { \scalar };
+		var brate = b.tryPerform(\rate) ?? { \scalar };
 		^if(arate < brate) { arate } { brate }
 	}
 

--- a/SCClassLibrary/SCDoc/SCDoc.sc
+++ b/SCClassLibrary/SCDoc/SCDoc.sc
@@ -101,6 +101,7 @@ SCDocEntry {
 	*newUndocClass {|name|
 		var doc = super.new.init(nil,"Classes/"++name.asString);
 		var f, cats, implements, c;
+		var categories;
 		doc.klass = name.asSymbol.asClass;
 		doc.isClassDoc = true;
 		doc.isUndocumentedClass = true;
@@ -111,6 +112,8 @@ SCDocEntry {
 		doc.undoccmethods = doc.klass.class.methods.collectAs({|m|m.name.asGetter},IdentitySet);
 		doc.undocimethods = doc.klass.methods.collectAs({|m|m.name.asGetter},IdentitySet);
 
+		// TODO: the following doesn't appear to be used in the class library, but fails when you implement *doesNotUnderstand 
+		/*
 		if((implements=doc.klass.tryPerform(\implementsClass)).class===Symbol) {
 			(c = implements.asClass) !? {
 				doc.implements = c;
@@ -119,15 +122,20 @@ SCDocEntry {
 				^doc;
 			};
 		};
+		*/
 		doc.summary = "(Undocumented class)";
 		cats = ["Undocumented classes"];
 		if(SCDoc.classHasArKrIr(doc.klass)) {
 			cats = cats.add("UGens>Undocumented");
 		};
-		if(doc.klass.respondsTo('categories') and: {doc.klass.categories.notNil}) {
-			cats = cats ++ doc.klass.categories;
-		};
+		// TODO: this calls categories on the class object.
+		// That is a huge coupling that should be avoided.
+		// There are currently no instances in the class library that implement this method.
+		/*
+		categories = doc.klass.tryPerform('categories');
+		categories !? { cats = cats ++ categories };
 		doc.categories = cats;
+		*/
 
 		^doc;
 	}
@@ -503,10 +511,7 @@ SCDoc {
 			doc = SCDocEntry.newUndocClass(x);
 			documents[doc.path] = doc;
 		};
-		if(Help.respondsTo('tree')) {
-			this.postMsg("Indexing old helpfiles...");
-			this.indexOldHelp;
-		};
+
 		this.postMsg("Exporting docmap.js...",1);
 		this.exportDocMapJS(this.helpTargetDir +/+ "docmap.js");
 		this.postMsg("Indexed % documents in % seconds".format(documents.size,round(Main.elapsedTime-now,0.01)),0);
@@ -920,9 +925,9 @@ SCDoc {
 		sym = str.asSymbol;
 		if(sym.asClass.notNil) {
 			^pfx ++ (if(this.documents["Classes/"++str].isUndocumentedClass) {
-				(old = if(Help.respondsTo('findHelpFile'),{Help.findHelpFile(str)})) !? {
+				old = Help.tryPerform('findHelpFile') ?? {
 					"/OldHelpWrapper.html#"++old++"?"++SCDoc.helpTargetUrl ++ "/Classes/" ++ str ++ ".html"
-				}
+				};
 			} ?? { "/Classes/" ++ str ++ ".html" });
 		};
 

--- a/SCClassLibrary/SCDoc/SCDocRenderer.sc
+++ b/SCClassLibrary/SCDoc/SCDocRenderer.sc
@@ -382,8 +382,8 @@ SCDocHTMLRenderer {
 		};
 
 		// FIXME: Remove this when conversion to new help system is done!
-		if(doc.isUndocumentedClass and: {Help.respondsTo('findHelpFile')}) {
-			x = Help.findHelpFile(name);
+		if (doc.isUndocumentedClass) {
+			x = Help.tryPerform('findHelpFile');
 			x !? {
 				stream << ("[ <a href='" ++ baseDir ++ "/OldHelpWrapper.html#"
 				++x++"?"++SCDoc.helpTargetDir +/+ doc.path ++ ".html"

--- a/SCClassLibrary/deprecated/3.10/osc/OSCpathResponder.sc
+++ b/SCClassLibrary/deprecated/3.10/osc/OSCpathResponder.sc
@@ -95,8 +95,9 @@ OSCpathResponder : OSCresponder {
 		dispatcher.removeChild(this);
 	}
 
-	== { arg that;
-		^that respondsTo: \path and: { path == that.path }
+	== { |that|
+		var thatPath = that.tryPerform(\path);
+		^thatPath !? { path == thatPath } ?? { false }
 	}
 	hash { ^path.hash }
 }

--- a/SCClassLibrary/deprecated/3.10/osc/OSCresponder.sc
+++ b/SCClassLibrary/deprecated/3.10/osc/OSCresponder.sc
@@ -85,9 +85,12 @@ OSCresponder {
 	value { arg time, msg, addr;
 		action.value(time, this, msg, addr);
 	}
-	== { arg that;
-		^that respondsTo: #[\cmdName, \addr]
-			and: { cmdName == that.cmdName and: { addr == that.addr }}
+	== { |that|
+		var thatCmdName = that.tryPerform(\cmdName);
+		var thatAddr = that.tryPerform(\addr);
+		^if (thatCmdName.notNil and: {thatAddr.notNil}) {
+			cmdName == thatCmdName and: { addr == thatAddr }
+		} { false }
 	}
 	hash {
 		^addr.hash bitXor: cmdName.hash

--- a/testsuite/classlibrary/TestEvent.sc
+++ b/testsuite/classlibrary/TestEvent.sc
@@ -240,12 +240,12 @@ TestEvent : UnitTest {
 
 		msg1 = prevMsg[0];
 		i = msg1.indexOf(\freq);
-		this.assert(msg1[i+1].cpsmidi == 73, "note 0 octave 6 ctranspose 1 equals midinote 73");
-		this.assert(msg1[4] == 1, "synth created in root node");
+		this.assertEquals(msg1[i+1].cpsmidi, 73, "note 0 octave 6 ctranspose 1 equals midinote 73");
+		this.assertEquals(msg1[4], 1, "synth created in root node");
 		this.assert(msg1.includes(\zzzz), "SynthDesc provides parameters to send in message");
 		this.assert(event[\hasGate] == true, "Event detects gate in SynthDesc");
 		this.assert(finishTest, "Event evaluates finish action");
-		this.assert(prevLatency == 0,
+		this.assertEquals(prevLatency, 0,
 			"latency specified in the event should override server latency");
 		this.cleanUpMessages;
 	}


### PR DESCRIPTION
## Purpose and Motivation

`respondsTo` is bad smalltalk design as it doesn't allow of `doesNotUnderstand` to take effect. While this is currently a minor issue in the class library, as we move towards AbtractObject, this will become a major pain.

This PR removes the vast majority of uses from the class library as they are trivially replaceable with `tryPerform`, the remaining places require dependency inversion to solve.

Also makes `respondsTo` post a warning when used, this can be disabled.

<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->

- Documentation
- Bug fix
- New feature
- Breaking change

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
