### PR TITLE
TestServer_clientID_booted: increase timeouts

### DIFF
--- a/testsuite/classlibrary/TestServer_clientID_booted.sc
+++ b/testsuite/classlibrary/TestServer_clientID_booted.sc
@@ -99,7 +99,7 @@ TestServer_clientID_booted : UnitTest {
 
 		cond = Condition.new;
 
-		timer = fork { 3.wait; cond.unhang };
+		timer = fork { 10.wait; cond.unhang };
 		server.doWhenBooted {
 			"% - server login timed out.\n".postf(thisMethod);
 			timer.stop;
@@ -141,7 +141,7 @@ TestServer_clientID_booted : UnitTest {
 		// login with standard Server.remote method to test for
 		remote1 = Server.remote(\remoteLogin1, options: options, clientID: 3);
 		cond = Condition.new;
-		timer = fork { 3.wait; cond.unhang };
+		timer = fork { 10.wait; cond.unhang };
 
 		remote1.doWhenBooted {
 			"% - server first login timed out.\n".postf(thisMethod);
@@ -160,7 +160,7 @@ TestServer_clientID_booted : UnitTest {
 
 		remote1.stopAliveThread.remove;
 		thisProcess.platform.killProcessByID(serverPid);
-		testsFinished = exitCond.waitFor(5); // wait for the server process to exit
+		testsFinished = exitCond.waitFor(10); // wait for the server process to exit
 		this.assert(testsFinished, "TIMEOUT: server process did not quit");
 	}
 
@@ -178,7 +178,7 @@ TestServer_clientID_booted : UnitTest {
 		// login with standard Server.remote method to test for
 		remote1 = Server.remote(\remoteLogin1, options: options, clientID: 3);
 		cond = Condition.new;
-		timer = fork { 3.wait; cond.unhang };
+		timer = fork { 10.wait; cond.unhang };
 
 		remote1.doWhenBooted {
 			"% - server first login timed out.\n".postf(thisMethod);
@@ -197,7 +197,7 @@ TestServer_clientID_booted : UnitTest {
 
 		remote2 = Server.remote(\remoteLogin2, options: options);
 		cond = Condition.new;
-		timer = fork { 3.wait; cond.unhang };
+		timer = fork { 10.wait; cond.unhang };
 
 		remote2.doWhenBooted {
 			"% - server repeated login timed out.\n".postf(thisMethod);
@@ -219,7 +219,7 @@ TestServer_clientID_booted : UnitTest {
 		remote1.stopAliveThread.remove;
 		remote2.stopAliveThread.remove;
 		thisProcess.platform.killProcessByID(serverPid);
-		testsFinished = exitCond.waitFor(5); // wait for the server process to exit
+		testsFinished = exitCond.waitFor(10); // wait for the server process to exit
 		this.assert(testsFinished, "TIMEOUT: server process did not quit")
 	}
 }


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

I noticed lately that some of the TestServer_clientID_booted tests failed...

This PR increases timeouts so that we wait longer for the server to finish booting and quitting.

In particular, [here](https://github.com/supercollider/supercollider/actions/runs/19241584129/job/55025336955#step:7:13376) it seems like the "watchdog" timer fired before the `doWhenBooted` - this message should've appeared before the `PASS` messages (here's the [test source](https://github.com/supercollider/supercollider/blob/develop/testsuite/classlibrary/TestServer_clientID_booted.sc#L131-L165)).
I'm not 100% sure this was the case, but I generally find the AppClock (which we run the testsuite with) in the CI to be extremely unstable so all timing requirements need to be very loose (TempoClock seems much better, but we can't run the whole testsuite with it). The longer timeout doesn't necessarily increase the testing time - the test still proceeds as soon as the server confirms its readiness. But it seems that sometimes in the CI this takes longer than the previously suggested 3 seconds.
I extended other wait times just in case. Again, if everything works as expected, we shouldn't ever reach them.

## Types of changes

<!-- Delete lines that don't apply -->


- Bug fix


## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [ ] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
