### PR TITLE
test_oscillators_startAtCorrectPhase: add target

### DIFF
--- a/testsuite/classlibrary/TestCoreUGens.sc
+++ b/testsuite/classlibrary/TestCoreUGens.sc
@@ -1092,6 +1092,7 @@ TestCoreUGens : UnitTest {
 				{
 					VarSaw.perform(rate, freq, iPhase, 0.5) // width must be 0.5 for this test
 				}.loadToFloatArray(freq.reciprocal,         // must be one period only
+					server,
 					action: { |data|
 						this.assertEquals(data.indexOf(data.maxItem), maxIdx,
 							"VarSaw.% should start correct phase (initPhase: %, maxIdx: %)".format(rate, iPhase, maxIdx)


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

`{}.loadToFloatArray` was missing a target and it was using a default server, instead of the one designated for this test. 
I looked over the testsuite and it seems to have been the only place where the target argument for `{}.loadToFloatArray` was missing.

I believe this made the testsuite end up with an extra default server object dangling at the end... (not sure).

## Types of changes

<!-- Delete lines that don't apply -->

- Documentation
- Bug fix (?)

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [n/a] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
