### PR TITLE
cmake: hide function visibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -302,6 +302,8 @@ else()
 		add_definitions(-DBOOST_DATE_TIME_NO_LIB -DBOOST_ALL_NO_LIB)
 		# use session manager to set shared memory location, see issue 2409
 		add_definitions(-DBOOST_INTERPROCESS_BOOTSTAMP_IS_SESSION_MANAGER_BASED)
+	else()
+		add_definitions(-DBOOST_ASIO_DISABLE_VISIBILITY -DBOOST_DISABLE_EXPLICIT_SYMBOL_VISIBILITY)
 	endif()
 	add_definitions(-DBOOST_CHRONO_HEADER_ONLY -DBOOST_CONFIG_SUPPRESS_OUTDATED_MESSAGE)
 endif() 
@@ -338,6 +340,11 @@ endif()
 #############################################
 # other compiler settings
 
+# set default symbol visibility
+SET(CMAKE_CXX_VISIBILITY_PRESET hidden)
+SET(CMAKE_C_VISIBILITY_PRESET hidden)
+SET(CMAKE_VISIBILITY_INLINES_HIDDEN ON)
+
 if(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
 	add_compile_options(
 		-Werror=return-type      # Error out if function definitions lack a return type
@@ -367,7 +374,6 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
 		add_compile_definitions("_FORTIFY_SOURCE=2")
 	endif()
 
-	add_definitions(-fvisibility=hidden)
 endif()
 
 if (CMAKE_COMPILER_IS_INTEL AND NOT WIN32)

--- a/server/plugins/CMakeLists.txt
+++ b/server/plugins/CMakeLists.txt
@@ -59,9 +59,6 @@ endif()
 
 if (${CMAKE_COMPILER_IS_GNUCXX})
 	add_definitions(-fno-finite-math-only)
-	if(NOT WIN32)
-		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fvisibility-inlines-hidden")
-	endif()
 endif()
 
 foreach(plugin ${plugin_sources})


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

This PR hides function visibility and limits visibility of boost functions as well. 

<details><summary>With these changes only 30+ symbols are visible in the release build of sclang, comparing to 300+ previously.</summary>

```
nm -gjU /Volumes/SuperCollider/SuperCollider.app/Contents/MacOS/sclang
__ZGVN4asio6detail10call_stackINS0_14strand_service11strand_implEhE4top_E
__ZGVN4asio6detail10call_stackINS0_14thread_contextENS0_16thread_info_baseEE4top_E
__ZGVN4asio6detail10call_stackINS0_23strand_executor_service11strand_implEhE4top_E
__ZGVN4asio6detail12service_baseINS0_14strand_serviceEE2idE
__ZGVN4asio6detail30execution_context_service_baseINS0_14kqueue_reactorEE2idE
__ZGVN4asio6detail30execution_context_service_baseINS0_22deadline_timer_serviceINS0_18chrono_time_traitsINSt3__16chrono12system_clockENS_11wait_traitsIS6_EEEEEEE2idE
__ZGVN4asio6detail30execution_context_service_baseINS0_23reactive_socket_serviceINS_2ip3udpEEEE2idE
__ZGVN4asio6detail30execution_context_service_baseINS0_9schedulerEE2idE
__ZGVZN4asio15system_categoryEvE8instance
__ZGVZN4asio5error17get_misc_categoryEvE8instance
__ZGVZN4asio5error18get_netdb_categoryEvE8instance
__ZGVZN4asio5error21get_addrinfo_categoryEvE8instance
__ZN4asio6detail10call_stackINS0_14strand_service11strand_implEhE4top_E
__ZN4asio6detail10call_stackINS0_14thread_contextENS0_16thread_info_baseEE4top_E
__ZN4asio6detail10call_stackINS0_23strand_executor_service11strand_implEhE4top_E
__ZN4asio6detail16service_registry6createINS0_14kqueue_reactorENS_17execution_contextEEEPNS4_7serviceEPv
__ZN4asio6detail16service_registry6createINS0_22deadline_timer_serviceINS0_18chrono_time_traitsINSt3__16chrono12system_clockENS_11wait_traitsIS7_EEEEEENS_10io_contextEEEPNS_17execution_context7serviceEPv
__ZN4asio6detail16service_registry6createINS0_23reactive_socket_serviceINS_2ip3udpEEENS_10io_contextEEEPNS_17execution_context7serviceEPv
__ZN4asio6detail16service_registry6createINS0_9schedulerENS_17execution_contextEEEPNS4_7serviceEPv
__ZN4asio6detail30execution_context_service_baseINS0_14kqueue_reactorEE2idE
__ZN4asio6detail30execution_context_service_baseINS0_22deadline_timer_serviceINS0_18chrono_time_traitsINSt3__16chrono12system_clockENS_11wait_traitsIS6_EEEEEEE2idE
__ZN4asio6detail30execution_context_service_baseINS0_23reactive_socket_serviceINS_2ip3udpEEEE2idE
__ZN4asio6detail30execution_context_service_baseINS0_9schedulerEE2idE
__ZZN4asio15system_categoryEvE8instance
__ZZN4asio5error17get_misc_categoryEvE8instance
__ZZN4asio5error18get_netdb_categoryEvE8instance
__ZZN4asio5error21get_addrinfo_categoryEvE8instance
__mh_execute_header
_asio_detail_posix_thread_function
```
</details>

This PR will likely supersede #7232

I'd appreciate any feedback on this. I'm out of my depth here.


## Types of changes

<!-- Delete lines that don't apply -->

- Cleanup?
- Bug fix?

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [ ] Code is tested
- [x] All tests are passing
- [ ] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
