### PR TITLE
build: remove Intel compiler flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,11 +80,6 @@ if (${CMAKE_COMPILER_IS_GNUCXX})
 		message(FATAL_ERROR "SuperCollider requires at least gcc-4.8 when compiled with gcc.")
 	endif()
 
-elseif(${CMAKE_CXX_COMPILER} MATCHES icpc)
-	set(CMAKE_COMPILER_IS_INTEL 1)
-	add_definitions(-Wno-unknown-pragmas)
-	add_definitions(-simd)
-
 elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
     set(CMAKE_COMPILER_IS_CLANG 1)
 endif()
@@ -368,17 +363,6 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
 	endif()
 
 	add_definitions(-fvisibility=hidden)
-endif()
-
-if (CMAKE_COMPILER_IS_INTEL AND NOT WIN32)
-	if (SSE)
-		add_definitions(-mia32)
-	endif()
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
-
-	# disable warnings
-	add_definitions(-diag-disable 170) # pointer points outside of underlying object ... used heavily in sclang
-	add_definitions(-diag-disable 279) # controlling expression is constant
 endif()
 
 if(WIN32)


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

Does anybody know if we still need these settings for the Intel compiler? They were added 15 years ago.
I don't think we've ever officially supported it and at least the `-std=c++11` part is outdated.

## Types of changes

<!-- Delete lines that don't apply -->

- Cleanup

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [n/a] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
