### PR TITLE
build: remove redundant flags for supernova

### DIFF
--- a/server/supernova/CMakeLists.txt
+++ b/server/supernova/CMakeLists.txt
@@ -1,16 +1,3 @@
-if(CMAKE_COMPILER_IS_GNUCXX)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -ftemplate-depth-4096")
-  set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -fomit-frame-pointer")
-
-  if(APPLE)
-    if(CMAKE_SIZEOF_VOID_P MATCHES "4")
-      # cmpxchg8b is available on all intel apples
-      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=i686 -msse -msse2 -mfpmath=sse")
-    endif()
-  endif()
-
-endif(CMAKE_COMPILER_IS_GNUCXX)
-
 # here we choose who provides us with the FFT lib
 # this is done independently for scsynth and supernova
 # for historical reasons, as the vDSP implementation


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->
~~Honestly I don't know what these flags do exactly, but since we build with clang on macOS I thought it would be good to have the parity and apply the same parameters to GCC and Clang.~~

The removed part with flags like `-msse` was for 32-bit Intel macOS builds, not supported anymore.

EDIT: the template depth argument doesn't seem to be needed, so I removed it.

EDIT 2: `-fomit-frame-pointer` is already defined in https://github.com/supercollider/supercollider/blob/develop/CMakeLists.txt#L82 so I removed it as well.

## Types of changes

<!-- Delete lines that don't apply -->

- Cleanup

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [ ] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
