### PR TITLE
Recorder-related documentation changes (Recorder, Server, ServerOptions)

### DIFF
--- a/HelpSource/Classes/Recorder.schelp
+++ b/HelpSource/Classes/Recorder.schelp
@@ -10,7 +10,8 @@ code::
 (
 { SinOsc.ar(
 	SinOsc.ar(
-		XLine.kr(1, 100, 5)).exprange(*XLine.kr([20, 800], [7000, 200], 10)
+		XLine.kr(1, 100, 5)
+		).exprange(*XLine.kr([20, 800], [7000, 200], 10)
     )
    ) * 0.1
 
@@ -80,7 +81,10 @@ argument:: numChannels
 The number of output channels to record.
 
 argument:: node
-The link::Classes/Node:: to record immediately after. By default, this is the default group 1.
+The link::Classes/Node:: to record immediately after.
+By default, this is the default group 1.
+While the node ID can be represented by an link::Classes/Integer::, 
+this should avoided when using more than one server simultaneously (see link::Reference/asTarget::). 
 
 argument:: duration
 If set, this limits recording to a given time in seconds.
@@ -157,20 +161,15 @@ section::Examples
 code::
 // something to record
 (
-SynthDef("bubbles", { |out|
+SynthDef(\bubbles, { |out|
 	var f, sound;
 	f = LFSaw.kr(0.4, 0, 24, LFSaw.kr([8, 7.23], 0, 3, 80)).midicps; // glissando function
 	sound = CombN.ar(SinOsc.ar(f, 0, 0.04), 0.2, 0.2, 4); // echoing sine wave
 	Out.ar(out, sound);
 }).add;
-
-SynthDef("tpulse", { |out = 0, freq = 700, sawFreq = 440.0|
-	Out.ar(out, SyncSaw.ar(freq, sawFreq, 0.1))
-}).add;
-
 )
 
-x = Synth.new("bubbles");
+x = Synth(\bubbles);
 
 s.prepareForRecord; // if you want to start recording on a precise moment in time, you have to call this first.
 
@@ -192,7 +191,7 @@ code::
 thisProcess.platform.recordingsDir = "/home/user/";
 
 // instantiate the Recorder
-r = Recorder.new(s);
+r = Recorder(s);
 
 // record into a flac file
 r.recHeaderFormat = "flac";

--- a/SCClassLibrary/Common/Control/Recorder.sc
+++ b/SCClassLibrary/Common/Control/Recorder.sc
@@ -138,7 +138,7 @@ Recorder {
 	/* private implementation */
 
 	prRecord { |bus, node, dur|
-		recordNode = Synth.tail(node ? RootNode(server), synthDef.name, [\bufnum, recordBuf, \in, bus, \duration, dur ? -1]);
+		recordNode = Synth.tail(node ? 0, synthDef.name, [\bufnum, recordBuf, \in, bus, \duration, dur ? -1]);
 		recordNode.register(true);
 		recordNode.onFree { this.stopRecording };
 		if(responder.isNil) {

--- a/SCClassLibrary/Common/Control/Recorder.sc
+++ b/SCClassLibrary/Common/Control/Recorder.sc
@@ -138,7 +138,7 @@ Recorder {
 	/* private implementation */
 
 	prRecord { |bus, node, dur|
-		recordNode = Synth.tail(node ? server.asTarget, synthDef.name, [\bufnum, recordBuf, \in, bus, \duration, dur ? -1]);
+		recordNode = Synth.tail(node ? RootNode(server), synthDef.name, [\bufnum, recordBuf, \in, bus, \duration, dur ? -1]);
 		recordNode.register(true);
 		recordNode.onFree { this.stopRecording };
 		if(responder.isNil) {

--- a/SCClassLibrary/Common/Control/Recorder.sc
+++ b/SCClassLibrary/Common/Control/Recorder.sc
@@ -138,7 +138,7 @@ Recorder {
 	/* private implementation */
 
 	prRecord { |bus, node, dur|
-		recordNode = Synth.tail(node ? 0, synthDef.name, [\bufnum, recordBuf, \in, bus, \duration, dur ? -1]);
+		recordNode = Synth.tail(node ? server.asTarget, synthDef.name, [\bufnum, recordBuf, \in, bus, \duration, dur ? -1]);
 		recordNode.register(true);
 		recordNode.onFree { this.stopRecording };
 		if(responder.isNil) {


### PR DESCRIPTION
<details><summary>Classlib change moved to 7249</summary>
<p>Recorder.prRecord created the recording synth on target `0` when no node was explicitly specified.

This will always translate to Group 0 on the *default* server, which creates problems when trying to record on any other server. 
I changed `0` to ~~`server.asTarget`~~ `RootNode(server)`, where `server` is an instance variable (each Recorder is assigned to a server). ~~`asTarget` then translates to the default Group on that server.~~ (.asTarget gets called in Synth.new anyway).

<details><summary>More or less settled after help from @cdbzb: `0` is `RootNode(server.default)`. </summary>
<p>
 Maybe consider before merging: `0.asTarget` returns `Group(0)` on the default server, whereas after my change (to `server.asTarget`), the corresponding expression returns `Group(1)`. 
I did not find a way to make it return Group(0). Is there any good reason one would _want_ Group(0) here? From what I understand, the default group is meant to be Group(1). But what is Group(0) supposed to be?
</p>
</details>
</p>
</details>
Will add more doc changes in a bit!

improved (?) indentation in the very first example
Removed an unused (an unexciting) synthdef; 
changed "SynthDefName" to \synthdefname
added note to the node argument of Recorder.record.

## Purpose and Motivation
I'm discovering the joys of using multiple servers/cpu cores. 

## Types of changes

- Documentation
- Bug fix