### PR TITLE
Recorder.prRecord: default node: replace integer 0 with RootNode(server)

### DIFF
--- a/SCClassLibrary/Common/Control/Recorder.sc
+++ b/SCClassLibrary/Common/Control/Recorder.sc
@@ -138,7 +138,7 @@ Recorder {
 	/* private implementation */
 
 	prRecord { |bus, node, dur|
-		recordNode = Synth.tail(node ? 0, synthDef.name, [\bufnum, recordBuf, \in, bus, \duration, dur ? -1]);
+		recordNode = Synth.tail(node ? RootNode(server), synthDef.name, [\bufnum, recordBuf, \in, bus, \duration, dur ? -1]);
 		recordNode.register(true);
 		recordNode.onFree { this.stopRecording };
 		if(responder.isNil) {


### PR DESCRIPTION
as discussed in #7246; separating the classlib change from the help changes, which are getting more involved.

integer 0 will default to the RootNode on the _default_ server, even if the recorder is supposedly on another server. 
This changes this to default to the RootNode of the recorder's server, even when that is not the default server.

This is a non-breaking change.