### PR TITLE
build: add some gcc flags to clang

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -342,11 +342,8 @@ SET(CMAKE_VISIBILITY_INLINES_HIDDEN ON)
 
 if(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
 	add_compile_options(
-		-Werror=return-type      # Error out if function definitions lack a return type
 		-fno-math-errno          # Optimize math functions by not setting errno
 		-fno-signaling-nans      # Assume no signaling NaNs for better optimization
-		-fsigned-zeros           # Maintain distinction between -0.0 and +0.0
-		-fno-associative-math    # Prevent reordering of floating-point operations
 	)
 
 	if(APPLE)
@@ -357,6 +354,11 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
 endif()
 
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+	if(NOT APPLE)
+		add_compile_options(
+			-fno-math-errno      # On Apple and most BSDs, math library functions never set errno, and so -fno-math-errno is the default
+		)
+	endif()
 	if(NOT SC_CLANG_USES_LIBSTDCPP)
 		# the default
 		add_compile_options("-stdlib=libc++")
@@ -365,6 +367,12 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 endif()
 
 if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+	add_compile_options(
+		-Werror=return-type      # Error out if function definitions lack a return type
+		-fsigned-zeros           # Maintain distinction between -0.0 and +0.0
+		-fno-associative-math    # Prevent reordering of floating-point operations
+	)
+
 	if(FORTIFY)
 		add_compile_definitions("_FORTIFY_SOURCE=2")
 	endif()
@@ -391,6 +399,8 @@ if(MSVC)
 # caused by some versions of libsndfile's C++ header redefining nullptr as NULL.
 # See https://devblogs.microsoft.com/cppblog/msvc-now-correctly-reports-__cplusplus/
   add_compile_options("/Zc:__cplusplus")
+
+# for math operations, we expect the default /fp:precise flag to be used, so that we match settings for gcc/clang
 
 # _ENABLE_ATOMIC_ALIGNMENT_FIX prevents the build from breaking when VS2015 update 2 upwards are used
 # see http://boost.2283326.n4.nabble.com/lockfree-ENABLE-ATOMIC-ALIGNMENT-FIX-for-VS-2015-Update-2-td4685955.html

--- a/server/plugins/CMakeLists.txt
+++ b/server/plugins/CMakeLists.txt
@@ -57,10 +57,6 @@ if(APPLE OR WIN32)
 	set(CMAKE_SHARED_MODULE_SUFFIX ".scx")
 endif()
 
-if (${CMAKE_COMPILER_IS_GNUCXX})
-	add_definitions(-fno-finite-math-only)
-endif()
-
 foreach(plugin ${plugin_sources})
 	string(REPLACE .cpp "" plugin_name ${plugin} )
 	add_library(${plugin_name} MODULE ${plugin})


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

This adds flags that I _think_ are valid for both compilers to the clang section.

I don't know how to enable something like `-Werror=return-type` on MSVC... or if any of the other flags have equivalents.

## Types of changes

<!-- Delete lines that don't apply -->

- New feature (?)

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [ ] Code is tested
- [ ] All tests are passing
- [ ] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
