### PR TITLE
More cmake cleanup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -400,16 +400,16 @@ if(WIN32)
 endif()
 
 if(MSVC)
-  foreach(flag CMAKE_C_FLAGS CMAKE_CXX_FLAGS)
-    set(${flag} "${${flag}} /wd4018") # signed/unsigned mismatch
-    set(${flag} "${${flag}} /wd4102") # unreferenced label
-    set(${flag} "${${flag}} /wd4267") # conversion from 'size_t' to 'int', possible loss of data
-    set(${flag} "${${flag}} /wd4244") # conversion from '__int64' to 'int', possible loss of data
-    set(${flag} "${${flag}} /wd4305") # '=' : truncation from 'double' to 'float'
-    set(${flag} "${${flag}} /wd4309") # '=' : truncation of constant value
-    set(${flag} "${${flag}} /wd4800") # forcing value to bool 'true' or 'false' (performance warning)
-    set(${flag} "${${flag}} /wd4996") # The POSIX name for this item is deprecated.
-  endforeach()
+  add_compile_options(
+    /wd4018 # signed/unsigned mismatch
+    /wd4102 # unreferenced label
+    /wd4267 # conversion from 'size_t' to 'int', possible loss of data
+    /wd4244 # conversion from '__int64' to 'int', possible loss of data
+    /wd4305 # '=' : truncation from 'double' to 'float'
+    /wd4309 # '=' : truncation of constant value
+    /wd4800 # forcing value to bool 'true' or 'false' (performance warning)
+    /wd4996 # The POSIX name for this item is deprecated.
+  )
 
 # this flag causes MSVC to correctly report __cplusplus, which prevents a compiler error
 # caused by some versions of libsndfile's C++ header redefining nullptr as NULL.
@@ -420,7 +420,7 @@ if(MSVC)
 
 # _ENABLE_ATOMIC_ALIGNMENT_FIX prevents the build from breaking when VS2015 update 2 upwards are used
 # see http://boost.2283326.n4.nabble.com/lockfree-ENABLE-ATOMIC-ALIGNMENT-FIX-for-VS-2015-Update-2-td4685955.html
-  add_definitions(-D_CRT_SECURE_NO_WARNINGS -D_SCL_SECURE_NO_WARNINGS -D_ENABLE_ATOMIC_ALIGNMENT_FIX)
+  add_compile_definitions(_CRT_SECURE_NO_WARNINGS _SCL_SECURE_NO_WARNINGS _ENABLE_ATOMIC_ALIGNMENT_FIX)
 endif(MSVC)
 
 if(MINGW)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,21 +59,16 @@ if(WIN32)
         SET(CMAKE_LIBRARY_ARCHITECTURE "x86" CACHE STRING "Architecture of target system (for 32bit)")
     endif()
 
-    # installing to default application-location creates an error (a privileges and/or path syntax problem)
-    if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
-        SET(CMAKE_INSTALL_PREFIX "${CMAKE_BINARY_DIR}/Install" CACHE PATH "Cmake install path" FORCE)
-    endif()
-
 endif(WIN32)
 
-if(APPLE)
+# install settings
+if(APPLE OR WIN32)
 	if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
-		set(CMAKE_INSTALL_PREFIX "${CMAKE_BINARY_DIR}/Install" CACHE STRING "Cmake install path" FORCE)
+		set(CMAKE_INSTALL_PREFIX "${CMAKE_BINARY_DIR}/Install" CACHE PATH "Cmake install path" FORCE)
 	endif()
 elseif(UNIX)
-	add_definitions(-DSC_DATA_DIR="${CMAKE_INSTALL_PREFIX}/share/SuperCollider")
+	add_compile_definitions(SC_DATA_DIR="${CMAKE_INSTALL_PREFIX}/share/SuperCollider")
 endif()
-
 
 #############################################
 # Options

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -171,6 +171,11 @@ if(APPLE)
     option(SC_VERIFY_APP "Run verify_app on the app bundle" OFF)
 endif()
 
+if(SC_DISABLE_XCODE_CODESIGNING)
+    set(CMAKE_XCODE_ATTRIBUTE_CODE_SIGNING_REQUIRED "NO")
+    set(CMAKE_XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY "")
+endif()
+
 #############################################
 # Detect CCache
 
@@ -278,8 +283,6 @@ else()
   set(SYSTEM_YAMLCPP OFF)
 endif()
 
-set(CMAKE_CXX_STANDARD 17)
-
 #############################################
 # compiler settings - hardware
 
@@ -345,6 +348,8 @@ endif()
 
 #############################################
 # other compiler flags
+
+set(CMAKE_CXX_STANDARD 17)
 
 # set default symbol visibility
 SET(CMAKE_CXX_VISIBILITY_PRESET hidden)
@@ -418,22 +423,16 @@ if(MSVC)
   add_definitions(-D_CRT_SECURE_NO_WARNINGS -D_SCL_SECURE_NO_WARNINGS -D_ENABLE_ATOMIC_ALIGNMENT_FIX)
 endif(MSVC)
 
-if (SC_MEMORY_DEBUGGING)
-	add_definitions(-DDISABLE_MEMORY_POOLS)
-	add_definitions(-DENABLE_MEMORY_CHECKS)
-endif()
-
 if(MINGW)
 	add_compile_options(-mstackrealign)
 endif()
 
 if (NO_GPL3)
-	add_definitions(-DNO_GPL3)
+	add_compile_definitions(NO_GPL3)
 endif()
 
-if(SC_DISABLE_XCODE_CODESIGNING)
-    set(CMAKE_XCODE_ATTRIBUTE_CODE_SIGNING_REQUIRED "NO")
-    set(CMAKE_XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY "")
+if (SC_MEMORY_DEBUGGING)
+	add_compile_definitions(DISABLE_MEMORY_POOLS ENABLE_MEMORY_CHECKS)
 endif()
 
 #############################################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,24 +66,6 @@ if(WIN32)
 
 endif(WIN32)
 
-#############################################
-# Compiler flags etc
-
-if (${CMAKE_COMPILER_IS_GNUCXX})
-    execute_process(
-            COMMAND ${CMAKE_CXX_COMPILER} -dumpversion
-            OUTPUT_VARIABLE _gcc_version
-            OUTPUT_STRIP_TRAILING_WHITESPACE
-    )
-
-	if(${_gcc_version} VERSION_LESS 4.8)
-		message(FATAL_ERROR "SuperCollider requires at least gcc-4.8 when compiled with gcc.")
-	endif()
-
-elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
-    set(CMAKE_COMPILER_IS_CLANG 1)
-endif()
-
 if(APPLE)
 	if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
 		set(CMAKE_INSTALL_PREFIX "${CMAKE_BINARY_DIR}/Install" CACHE STRING "Cmake install path" FORCE)
@@ -148,11 +130,11 @@ option(NO_GPL3 "Disable GPL3 code, for pure-GPL2 situations. (Not recommended.)"
 
 option(SCLANG_SERVER "Build with internal server." ON)
 
-if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_CLANG)
+if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
     option(NATIVE "Optimize binary for this architecture (binaries may not run on other machines).")
 endif()
 
-if(CMAKE_COMPILER_IS_GNUCXX)
+if(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
     option(LTO "Use GCC's link time optimizer' (experimental).")
 endif()
 
@@ -367,7 +349,7 @@ if(NOT "${SC_COMPILER_ARCH_FLAGS}" STREQUAL "")
 endif()
 
 #############################################
-# other compiler settings
+# other compiler flags
 
 # set default symbol visibility
 SET(CMAKE_CXX_VISIBILITY_PRESET hidden)

--- a/SCDoc/CMakeLists.txt
+++ b/SCDoc/CMakeLists.txt
@@ -9,7 +9,7 @@ set(SCDOC_SRCS
     ${SCDOC_DIR}/SCDocPrim.h
 )
 
-if(CMAKE_COMPILER_IS_CLANG)
+if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   set_source_files_properties(
     ${SCDOC_DIR}/lex.scdoc.cpp
     PROPERTIES COMPILE_FLAGS "-Wno-null-conversion")

--- a/server/plugins/CMakeLists.txt
+++ b/server/plugins/CMakeLists.txt
@@ -71,7 +71,7 @@ if(AUDIOAPI STREQUAL bela)
     find_package(Xenomai REQUIRED)
     find_package(Bela REQUIRED)
     message(STATUS "Found Bela libraries: ${BELA_LIBRARIES}")
-    if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_CLANG)
+    if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
         # recommended compile flags for beaglebone etc; set here because bela api flag directly implies the architecture
         set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${BELA_C_FLAGS}")
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${BELA_CXX_FLAGS}")

--- a/server/scsynth/CMakeLists.txt
+++ b/server/scsynth/CMakeLists.txt
@@ -56,7 +56,7 @@ elseif(AUDIOAPI STREQUAL bela)
     find_package(Xenomai REQUIRED)
     find_package(Bela REQUIRED)
     message(STATUS "Found Bela libraries: ${BELA_LIBRARIES}")
-    if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_CLANG)
+    if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
         # recommended compile flags for beaglebone etc; set here because bela api flag directly implies the architecture
         set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${BELA_C_FLAGS}")
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${BELA_CXX_FLAGS}")


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

Another PR in the series of "Cmake cleanup" work.

- use modern compiler discovery and remove custom flag `CMAKE_COMPILER_IS_CLANG`
- replace `add_definitions` with `add_compile_definitions`
- replace direct setting of flags with `add_compile_definitions`
- remove obsolete code (checking for gcc version etc)
- reorganize code, hopefully improving logical grouping of functionality

This PR should not introduce any functional changes.

## Types of changes

<!-- Delete lines that don't apply -->

- Cleanup

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [ ] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
