### PR TITLE
cmake: set/update compiler hardware optimizations, take 2

### DIFF
--- a/.github/workflows/build_macos.yml
+++ b/.github/workflows/build_macos.yml
@@ -43,7 +43,7 @@ jobs:
             # homebrew-uninstall: "readline" # use this instead when cross-compiling for x86_64 on arm64
             # vcpkg-packages: "readline portaudio libsndfile fftw3" # use this instead when cross-compiling for x86_64 on arm64
             vcpkg-triplet: x64-osx-release-supercollider # required for build-libsndfile
-            extra-cmake-flags: ""
+            extra-cmake-flags: "-D SC_COMPILER_ARCH_FLAGS='-march=ivybridge'"
             artifact-suffix: "macOS-x64-legacy" # set if needed - will trigger artifact upload
             ctest: false
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,14 +106,6 @@ option(USE_CCACHE "Use ccache if available." ON)
 
 option(FFT_GREEN "Use internal 'Green' FFT lib rather than FFTW. (Not recommended.)" OFF)
 
-if(${CMAKE_SYSTEM_PROCESSOR} MATCHES "^AMD64|EM64T|x86_64|X86|i386|i686")
-    option(SSE "Compile with support for SSE instructions." ON)
-    option(SSE2 "Compile with support for SSE2 instructions." ON)
-else() # non-x86 platforms do not have SSE
-    set(SSE OFF)
-    set(SSE2 OFF)
-endif()
-
 set(AUDIOAPI "default" CACHE STRING "Audio API to use (one of {default,coreaudio,jack,portaudio,bela})")
 
 if (AUDIOAPI STREQUAL jack)
@@ -317,24 +309,66 @@ endif()
 set(CMAKE_CXX_STANDARD 17)
 
 #############################################
-# some preprocessor flags
-if (CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_CLANG)
-	if (SSE)
-		set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS}   -msse")
-		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -msse")
-		if(NOT APPLE AND NOT CMAKE_COMPILER_IS_CLANG)
-			set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -mfpmath=sse")
-			set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mfpmath=sse")
+# compiler settings - hardware
+
+set(SC_COMPILER_ARCH_FLAGS "" CACHE STRING "Architecture specific compiler flags")
+
+if("${SC_COMPILER_ARCH_FLAGS}" STREQUAL "")
+
+	set(_detected_flags "")
+
+	if(APPLE AND CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+		if (NATIVE)
+			list(APPEND _detected_flags "-march=native")
+		else()
+			if("x86_64" IN_LIST CMAKE_OSX_ARCHITECTURES AND "arm64" IN_LIST CMAKE_OSX_ARCHITECTURES) # universal binary
+				list(APPEND _detected_flags "-Xarch_x86_64" "-march=haswell" "-Xarch_arm64" "-mcpu=apple-m1")
+			elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64")
+				list(APPEND _detected_flags "-march=haswell")
+			elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "arm64")
+				list(APPEND _detected_flags "-mcpu=apple-m1")
+			endif()
+		endif()
+
+	elseif(MSVC)
+		if(CMAKE_CXX_COMPILER_ARCHITECTURE_ID MATCHES "x64" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "19.40")
+			list(APPEND _detected_flags "/arch:SSE4.2")
+		elseif(CMAKE_CXX_COMPILER_ARCHITECTURE_ID MATCHES "ARM64" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "19.40")
+			list(APPEND _detected_flags "/arch:armv8.0")
+		endif()
+
+	elseif(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+		if (NATIVE)
+			list(APPEND _detected_flags "-march=native")
+		else()
+			if(CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64|amd64|AMD64")
+				if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "12.0" OR (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "11.0"))
+					list(APPEND _detected_flags "-march=x86-64-v2")
+				else() # fallback for older compilers
+					list(APPEND _detected_flags "-msse4.2")
+				endif()
+			elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|arm64")
+				list(APPEND _detected_flags "-march=armv8-a")
+			elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "armv7")
+				list(APPEND _detected_flags "-march=armv7-a" "-mfpu=neon" "-mfloat-abi=hard")
+			elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "armv6")
+				list(APPEND _detected_flags "-march=armv6" "-mtune=arm1176jzf-s" "-mfpu=vfp" "-mfloat-abi=hard")
+			else()
+				message(STATUS "${CMAKE_CXX_COMPILER_ID}: No hardware optimization flags set for ${CMAKE_SYSTEM_PROCESSOR}")
+			endif()
 		endif()
 	endif()
-	if (SSE2)
-		set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -msse2")
-		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -msse2")
+
+	if(NOT "${_detected_flags}" STREQUAL "")
+		set(SC_COMPILER_ARCH_FLAGS "${_detected_flags}" CACHE STRING "Architecture specific compiler flags" FORCE)
 	endif()
-	if (NATIVE)
-		set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -march=native")
-		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=native")
-	endif()
+
+endif()
+
+if(NOT "${SC_COMPILER_ARCH_FLAGS}" STREQUAL "")
+	separate_arguments(SC_COMPILER_ARCH_FLAGS)
+	message(STATUS "Compiler architecture flags: ${SC_COMPILER_ARCH_FLAGS}")
+	add_compile_options(${SC_COMPILER_ARCH_FLAGS})
 endif()
 
 #############################################
@@ -420,21 +454,6 @@ endif()
 
 if(MINGW)
 	add_compile_options(-mstackrealign)
-endif()
-
-# support for building on Raspberry Pi 1/2/3 and BBB
-if(CMAKE_COMPILER_IS_GNUCXX AND CMAKE_SYSTEM_PROCESSOR STREQUAL "armv7l")
-  foreach(flag CMAKE_C_FLAGS CMAKE_CXX_FLAGS)
-    set(${flag} "${${flag}} -mfloat-abi=hard")
-    set(${flag} "${${flag}} -mfpu=neon")
-  endforeach()
-elseif(CMAKE_COMPILER_IS_GNUCXX AND CMAKE_SYSTEM_PROCESSOR STREQUAL "armv6l")
-  foreach(flag CMAKE_C_FLAGS CMAKE_CXX_FLAGS)
-    set(${flag} "${${flag}} -march=armv6")
-    set(${flag} "${${flag}} -mtune=arm1176jzf-s")
-    set(${flag} "${${flag}} -mfloat-abi=hard")
-    set(${flag} "${${flag}} -mfpu=vfp")
-  endforeach()
 endif()
 
 if (NO_GPL3)

--- a/README_LINUX.md
+++ b/README_LINUX.md
@@ -296,6 +296,15 @@ If you're compiling SC only for use on your own machine (that is, you aren't cro
 cmake -DNATIVE=ON ..
 ```
 
+If the Native option is OFF, the binary is still optimized to run on certain hardware.
+The `SC_COMPILER_ARCH_FLAGS` option can set the architecture or architecture level for the resulting binary.
+See https://en.wikipedia.org/wiki/X86-64#Microarchitecture_levels for more information.
+
+```shell
+cmake -D SC_COMPILER_ARCH_FLAGS="-march=x86-64-v2" .. # default on x86_64
+cmake -D SC_COMPILER_ARCH_FLAGS="-march=armv8-a" .. # default on arm64
+```
+
 #### Install location
 
 By default, SuperCollider installs in `/usr/local`, a system-wide install.

--- a/README_MACOS.md
+++ b/README_MACOS.md
@@ -211,6 +211,14 @@ Common arguments to control the build configuration are:
 
     `-DNATIVE=ON`
 
+  * Set architecture level (`-march`) and/or cpu type (`-mcpu`) when Native is OFF
+
+    ```shell
+    -D SC_COMPILER_ARCH_FLAGS="-march=haswell" # default for x86_64
+    -D SC_COMPILER_ARCH_FLAGS="-mcpu=apple-m1" # default for arm64
+    -D SC_COMPILER_ARCH_FLAGS="-Xarch_x86_64 -march=haswell -Xarch_arm64 -mcpu=apple-m1" # default for universal builds
+    ```
+
   * Build the *supernova* server:
 
     `-DSUPERNOVA=ON`

--- a/README_WINDOWS.md
+++ b/README_WINDOWS.md
@@ -1212,6 +1212,14 @@ Note:
 - For 32-bit builds use `x86-windows` instead of `x64-windows` triplet when installing `readline`
 - At the time of writing this, `readline` would not build using a triplet for MinGW
 
+### CPU optimizations
+
+The `SC_COMPILER_ARCH_FLAGS` option can be used to set the optimizations for advanced CPU instructions, like SSE4.2, AVX, AVX2 etc. Newer versions of MSVC 2022 allow to set this to `SSE4.2`, which SC uses by default if available. If not set, MSVC compiles with `SSE2`. 
+If you don't need to support older and/or lower-end processors, you can set this to `AVX` or higher. 
+See https://learn.microsoft.com/en-us/cpp/build/reference/arch-x64 for more information.
+
+      -D SC_COMPILER_ARCH_FLAGS="/arch:SSE4.2" ..
+
 Known issues
 ============
 


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

This is a slightly different (cleaner?) implementation of #7248. It exposes a single cmake flag with all hardware-related compiler flags, which I hope makes it easier to use and maintain.

The rest of the description, copied from 7248, since the functionality is basically the same:

Previously we didn't explicitly use compiler optimizations for newer CPU instructions and features (like SSE4), but only SSE/SSE2.

I reorganized and updated compiler settings optimizing for modern hardware:

- GCC/Clang - Linux (and MinGW):
  - for GCC 11+ and Clang 12+ on x86_64 I used "architecture level" matching Haswell processors (2012-era)
    - for older compilers I default to SSE4 which I believe maps to 2009-era CPUs; I don't think it's needed to target anything older than that
  - for Arm64 I used `armv8-a` but I'm not sure how safe/conservative that is
  - optimizations for older 32-bit ARM (v6 and v7 - Rpi 1 - 2 - 3) were left in place, though using a newer CMake conventions; they are untested, unfortunately
 - Apple Clang:
   - I used "CPU family" approach for arm64 and "architecture level" for x86_64; for the latter the default is now set to Haswell processors (Apple hardware from 2013 onward); note that in the legacy build I set this to an earlier value (Ivy Bridge) to catch one generation of hardware that the legacy build can still run on (2012 MacBook Pro running macOS 10.15)
   - for arm64 (Apple CPU) the default value `apple-m1` doesn't change anything; however exposing it allows taking potential advantage of newer Apple chips
-  Windows MSVC:
   - I added the newer `SSE4.2` optimization, which is a relatively recent addition to MSVC (previously the first "higher" option that the default SSE2 was AVX); I didn't use AVX optimizations since some [lower-end chips from as late as 2021](https://en.wikipedia.org/wiki/Tremont_(microarchitecture)) still don't support it. If we decided to create a Windows legacy build, maintaining the basic SSE4.2 optimization, we could consider optimizing the main build for newer CPUs with e.g. AVX512.
 
FYI I haven't tested the actual performance of these changes.

IIUC these settings do not affect explicit uses of SSE/NEON instructions; e.g. in the nova-simd library.

## Types of changes

<!-- Delete lines that don't apply -->

- Documentation
- New feature

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested - at least the configurations we build in the CI
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
