### PR TITLE
Recorder options handling

### DIFF
--- a/SCClassLibrary/Common/Control/Recorder.sc
+++ b/SCClassLibrary/Common/Control/Recorder.sc
@@ -1,14 +1,24 @@
 Recorder {
 
 	var <server, <>recChannels;
-	var >recHeaderFormat, >recSampleFormat, >recBufSize;
+	var <>recHeaderFormat, <>recSampleFormat, <>recBufSize;
 	var recordBuf, recordNode, synthDef;
 	var <paused = false, <duration = 0, <>notifyServer = false;
 	var <>filePrefix = "SC_";
 	var responder, id;
 
 	*new { |server|
-		^super.newCopyArgs(server)
+		^super.newCopyArgs(server).initOptions
+	}
+
+	initOptions {
+		recHeaderFormat = server.options.recHeaderFormat;
+		recSampleFormat = server.options.recSampleFormat;
+		recChannels = server.options.recChannels;
+		recBufSize = server.options.recBufSize; //nil in most cases if server not booted
+		if (recBufSize == nil) { 
+			server.doWhenBooted { recBufSize = server.sampleRate.nextPowerOfTwo }; 
+		}
 	}
 
 	numChannels { ^recChannels }
@@ -101,14 +111,14 @@ Recorder {
 		}
 	}
 
-	recHeaderFormat { ^recHeaderFormat ? server.recHeaderFormat }
-	recSampleFormat { ^recSampleFormat ? server.recSampleFormat }
-	recBufSize { ^recBufSize ?? { server.recBufSize } ?? { server.sampleRate.nextPowerOfTwo } }
+	// recHeaderFormat { ^recHeaderFormat ? server.recHeaderFormat }
+	// recSampleFormat { ^recSampleFormat ? server.recSampleFormat }
+	// recBufSize { ^recBufSize ?? { server.recBufSize } ?? { server.sampleRate.nextPowerOfTwo } }
 
 	prepareForRecord { | path, numChannels |
 		var dir;
 
-		numChannels = numChannels ? server.recChannels;
+		numChannels = numChannels ? this.recChannels;
 
 		path = if(path.isNil) { this.makePath } { path.standardizePath };
 		dir = path.dirname;
@@ -183,6 +193,5 @@ Recorder {
 	changedServer { | what ... moreArgs |
 		if(notifyServer) { server.changed(what, *moreArgs) }
 	}
-
 
 }

--- a/SCClassLibrary/Common/Control/Recorder.sc
+++ b/SCClassLibrary/Common/Control/Recorder.sc
@@ -8,17 +8,19 @@ Recorder {
 	var responder, id;
 
 	*new { |server|
-		^super.newCopyArgs(server).initOptions
-	}
-
-	initOptions {
-		recHeaderFormat = server.options.recHeaderFormat;
-		recSampleFormat = server.options.recSampleFormat;
-		recChannels = server.options.recChannels;
-		recBufSize = server.options.recBufSize; //nil in most cases if server not booted
-		if (recBufSize == nil) { 
-			server.doWhenBooted { recBufSize = server.sampleRate.nextPowerOfTwo }; 
-		}
+		var self = super.newCopyArgs(
+			server: server,
+			recChannels: server.options.recChannels,
+			recSampleFormat: server.options.recSampleFormat,
+			recHeaderFormat: server.options.recHeaderFormat,
+			recBufSize: server.options.recBufSize
+		);
+		if(self.recBufSize.isNil) {
+			server.doWhenBooted { 
+				self.recBufSize = server.options.recBufSize
+			};
+		};	
+		^self
 	}
 
 	numChannels { ^recChannels }
@@ -111,14 +113,10 @@ Recorder {
 		}
 	}
 
-	// recHeaderFormat { ^recHeaderFormat ? server.recHeaderFormat }
-	// recSampleFormat { ^recSampleFormat ? server.recSampleFormat }
-	// recBufSize { ^recBufSize ?? { server.recBufSize } ?? { server.sampleRate.nextPowerOfTwo } }
-
 	prepareForRecord { | path, numChannels |
 		var dir;
 
-		numChannels = numChannels ? this.recChannels;
+		numChannels = numChannels ?? { this.recChannels; }
 
 		path = if(path.isNil) { this.makePath } { path.standardizePath };
 		dir = path.dirname;

--- a/SCClassLibrary/Common/Control/Recorder.sc
+++ b/SCClassLibrary/Common/Control/Recorder.sc
@@ -116,7 +116,7 @@ Recorder {
 	prepareForRecord { | path, numChannels |
 		var dir;
 
-		numChannels = numChannels ?? { this.recChannels; }
+		numChannels = numChannels ?? { this.recChannels; };
 
 		path = if(path.isNil) { this.makePath } { path.standardizePath };
 		dir = path.dirname;

--- a/SCClassLibrary/Common/Control/Recorder.sc
+++ b/SCClassLibrary/Common/Control/Recorder.sc
@@ -17,7 +17,7 @@ Recorder {
 		);
 		if(self.recBufSize.isNil) {
 			server.doWhenBooted { 
-				self.recBufSize = server.options.recBufSize
+				self.recBufSize = server.sampleRate.nextPowerOfTwo
 			};
 		};	
 		^self
@@ -115,6 +115,11 @@ Recorder {
 
 	prepareForRecord { | path, numChannels |
 		var dir;
+
+		if (not(server.serverRunning)) { 
+			"Server % not running: unable to prepare for recording".format(server).warn; 
+			^this
+		};
 
 		numChannels = numChannels ?? { this.recChannels; };
 

--- a/SCClassLibrary/Common/Control/Recorder.sc
+++ b/SCClassLibrary/Common/Control/Recorder.sc
@@ -1,6 +1,6 @@
 Recorder {
 
-	var <server, <>numChannels;
+	var <server, <>recChannels;
 	var >recHeaderFormat, >recSampleFormat, >recBufSize;
 	var recordBuf, recordNode, synthDef;
 	var <paused = false, <duration = 0, <>notifyServer = false;
@@ -10,6 +10,9 @@ Recorder {
 	*new { |server|
 		^super.newCopyArgs(server)
 	}
+
+	numChannels { ^recChannels }
+	numChannels_ { |n| recChannels = n }
 
 	record { |path, bus, numChannels, node, duration|
 
@@ -23,7 +26,7 @@ Recorder {
 				this.record(path, bus, numChannels, node, duration) // now we are ready
 			}
 		} {
-			if(numChannels.notNil and: { numChannels != this.numChannels }) {
+			if(numChannels.notNil and: { numChannels != this.recChannels }) {
 				"Cannot change recording number of channels while running".warn;
 				^this
 			};
@@ -36,7 +39,7 @@ Recorder {
 				this.prRecord(bus, node, duration);
 				this.changedServer(\recording, true);
 				"Recording channels % ... \npath: '%'\n"
-				.postf(bus + (0..this.numChannels - 1), recordBuf.path);
+				.postf(bus + (0..this.recChannels - 1), recordBuf.path);
 			} {
 				if(paused) {
 					this.resumeRecording
@@ -120,7 +123,7 @@ Recorder {
 		);
 		if(recordBuf.isNil) { Error("could not allocate buffer").throw };
 		recordBuf.path = path;
-		this.numChannels = numChannels;
+		this.recChannels = numChannels;
 		id = UniqueID.next;
 
 		synthDef = SynthDef(SystemSynthDefs.generateTempName, { |in, bufnum, duration|

--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -899,14 +899,14 @@ Server {
 
 	/* recording formats */
 
-	recHeaderFormat { ^options.recHeaderFormat }
-	recHeaderFormat_ { |string| options.recHeaderFormat_(string) }
-	recSampleFormat { ^options.recSampleFormat }
-	recSampleFormat_ { |string| options.recSampleFormat_(string) }
-	recChannels { ^options.recChannels }
-	recChannels_ { |n| options.recChannels_(n) }
-	recBufSize { ^options.recBufSize }
-	recBufSize_ { |n| options.recBufSize_(n) }
+	recHeaderFormat { ^recorder.recHeaderFormat }
+	recHeaderFormat_ { |string| recorder.recHeaderFormat_(string) }
+	recSampleFormat { ^recorder.recSampleFormat }
+	recSampleFormat_ { |string| recorder.recSampleFormat_(string) }
+	recChannels { ^recorder.recChannels }
+	recChannels_ { |n| recorder.recChannels_(n) }
+	recBufSize { ^recorder.recBufSize }
+	recBufSize_ { |n| recorder.recBufSize_(n) }
 
 	/* server status */
 


### PR DESCRIPTION
Sorry for this wall of text. All of this is more complicated to explain that to implement.

Looking over the docs for the Recorder object, I have some other suggestions for changes to the class library code.
They have to do with consistency in the naming of methods and arguments and the role of the defaults. (Very marginal gains there I think but oh well)

They have to do with four instance variables that I'll collectively refer to as "recorder options":`recHeaderFormat, recSampleFormat, recBufSize, recChannels/numChannels`.
These currently exists in two (three) distinct places: `ServerOptions `and `Recorder `(and `Server`, where those variables forward to the eponymous variables in the servers `.options`, i.e., its `ServerOptions` instance). This can be confusing, as it's not always clear which set of options takes precedence and when. If I were to just document the current state of affairs, this would probably end up being kind of convoluted.


In Recorder.sc this looks like this:
```supercollider
	recHeaderFormat { ^recHeaderFormat ? server.recHeaderFormat }
	recSampleFormat { ^recSampleFormat ? server.recSampleFormat }
	recBufSize { ^recBufSize ?? { server.recBufSize } ?? { server.sampleRate.nextPowerOfTwo } }
```
numChannels is a special case. It doesn't have an explicit setter/getter, but it does get set in
```
 prepareForRecord { | path, numChannels |
		numChannels = numChannels ? server.recChannels;
        ... do some stuff ...
        this.numChannels = numChannels;
		}
```

Finally, the options in the Server class simply forward to its own options instance variable, a ServerOptions:
```supercollider

	/* recording formats */

	recHeaderFormat { ^options.recHeaderFormat }
	recHeaderFormat_ { |string| options.recHeaderFormat_(string) }
	recSampleFormat { ^options.recSampleFormat }
	recSampleFormat_ { |string| options.recSampleFormat_(string) }
	recChannels { ^options.recChannels }
	recChannels_ { |n| options.recChannels_(n) }
	recBufSize { ^options.recBufSize }
	recBufSize_ { |n| options.recBufSize_(n) }
```
-------------------------------------------
As for the **proposed changes:**


1. is straightforward: because `recChannels` (in `Server `and `ServerOptions`) provides the default for `numChannels `in `Recorder`, it would be good to name this consistently: i.e., rename `Recorder.numChannels` to `Recorder.recChannels`. But `Recorder.numChannels` can stay around as an alias (maybe deprecated if people agree on that). I.e. this need not be a breaking change.

2. Change the way Recorder initializes these options.
    Currently, the Recorder's `recHeaderFormat, recSampleFormat, recBufSize` variables are set from the defaults in `server` (which in turn simply forward to `server.options`) the first time `prepareForRecord `is called, *unless* they have been explicitly set before that time, or called from within some other instance method (e.g. `makePath`). `numChannels `is even more confusing: because `prepareForRecord` takes an optional `numChannels` *argument* as well, the order is as follows: `argument ? server.options.numChannels`, which means that if `numChannels` is already set in the recorder, this is actually ignored at this stage, and simply overwritten either with the argument or the `server`/`server.options` variable.

    I think this confusion is because of the shortcut `s.record` (and similar), which internally forwards to `s.recorder.record`, but makes it not terribly obvious whether the recording and the related options are the `Server` object's or the `Recorder` object's business.
    I propose to simplify as follows (but see exception re `recBufSize` at the bottom):
        When a *new* `Recorder `object is created (and only then), take the defaults for the recorder options from `server.options` (including `numChannles/recChannels`)
        When `prepareForRecord` is called, use whatever options are in the `Recorder` object, not those that are in the `server` or `server.options`
        Change the forwarding of these variables in `Server` such that they forward to `server.recorder` rather than `server.options`; that way, *all* the recorder related methods in `Server` forward to its Recorder.

    The idea is to reduce complexity:
    treat all four variables the same;
    and treat all the `Server` methods that involve the recorder the same, i.e., forward them *all* to `Recorder`.


**What would this break**? If I've thought this through correctly, the only situation where this would change behavior is if one were to

1. Have recorder call prepareForRecord, or otherwise have already set the Recorder instance variables (say, `recBufSize`)
2. Explicitly set `server.options.recBufSize` (which is currently undocumented) instead of `server.recBufSize`
3. Rely on that change to propagate to the existing recorder when `prepareForRecord` is next called. Currently, this would propagate; with the proposed change, it wouldn't.

----
Exception re: `recBufSize.` = the number of frames for the Buffer in the DiskOut in the recording synth. Note that this memory is only actually allocated once prepareForRecord is called, and deallocated when the recording is done.
 Because this is currently set to default so server.sampleRate.nextPowerOfTwo, and sampleRate is nil until the server is booted, this cannot strictly speaking be set on initialization of the Server object in the language... so I inserted a `doWhenBooted`. But I wonder if this could not also simply default to some integer, e.g. 2^16... this could then be overwritten as needed both in the server.options and the Recorder. 
DiskOut.schelp suggests 2^18 ( 262144, which is 192000.nextPowerOfTwo, and roughly 6s in 44.1k, 1.3s in 192k; I don't know how much that is in bytes (262144 * 8 = 3MB presumably?), and I also don't know whether the DiskOut buffer has maybe become less important with SSDs. A lot of the recorder related docs seem pretty ancient.
