### PR TITLE
Recorder.prRecord: addAction becomes \addAfter if target node isKindOf(Synth)

### DIFF
--- a/SCClassLibrary/Common/Control/Recorder.sc
+++ b/SCClassLibrary/Common/Control/Recorder.sc
@@ -138,7 +138,11 @@ Recorder {
 	/* private implementation */
 
 	prRecord { |bus, node, dur|
-		recordNode = Synth.tail(node ? RootNode(server), synthDef.name, [\bufnum, recordBuf, \in, bus, \duration, dur ? -1]);
+		recordNode = Synth(synthDef.name, 
+						args: [\bufnum, recordBuf, \in, bus, \duration, dur ? -1],
+						target: node ? RootNode(server), 
+						addAction: if(node.isKindOf(Synth), \addAfter, \addToTail)
+		);
 		recordNode.register(true);
 		recordNode.onFree { this.stopRecording };
 		if(responder.isNil) {


### PR DESCRIPTION
(I promise this is my last Recorder-related pr.)

Recorder currently always uses the `\addToTail` addAction for the recording synth, on the assumption that the target is a **Group** (even if the argument is called "node"); it may be useful occasionally to specify a specific **Synth** to record after. Currently, supplying a Synth as `node` arg fails, because Synths don't have tails; only groups do. 

**This simply checks whether the target node `isKindOf(Synth)`, and if it is not, everything is as before (\addToTail); if it _is_ a Synth, \addAfter instead.** 


## Purpose and Motivatio
Mainly I don't want to have to explain in the docs that the `node` argument needs to be, in fact, a group. And renaming the argument might break things. 
Also, presumably user-friendly, if user happens to think in terms of Synths rather than groups.

Possible niche application: 
SomeSignal (Dry) -> SomeFxInsert (Wet), where we want to record dry and wet simultaneously and the insert uses a ReplaceOut (i.e., you wouldn't be able to simply record separate busses). 

## Types of changes
- New feature 

