### PR TITLE
ClassLib: wrapForNodeProxy: allow `\filter` and `\filterIn` roles to also be used when connecting NodeProxies via `<<>`

### DIFF
--- a/HelpSource/Reference/NodeProxy_roles.schelp
+++ b/HelpSource/Reference/NodeProxy_roles.schelp
@@ -177,7 +177,7 @@ a.clear(3);
 ::
 
 ## \filter -> function
-|| Filter the audio on the proxy's own bus, using the first argument to pass in the sound. The function is any valid UGen function, which may be control or audio rate. Default controls are wet++index, where strong::index:: is the slot of the proxy (default 0), in the example below, the control is code::\wet1::, and it crossfades between the incoming sound source and the effect (wet) signal output.
+|| Filter an incoming signal, either from code::\in.ar:: (if used in primary slot) or from the proxy's own bus (if used in slot indices > 0). The first argument to the function is used to pass in the sound. The function is any valid UGen function, which may be control or audio rate. Default controls are code::wet++index::, where strong::index:: is the slot of the proxy (default 0). In the example below, the control is code::\wet1::, and it crossfades between the incoming sound source and the effected (wet) signal output.
 
 code::
 a = NodeProxy(s).play;

--- a/HelpSource/Reference/NodeProxy_roles.schelp
+++ b/HelpSource/Reference/NodeProxy_roles.schelp
@@ -177,7 +177,7 @@ a.clear(3);
 ::
 
 ## \filter -> function
-|| Filter an incoming signal, either from code::\in.ar:: (if used in primary slot) or from the proxy's own bus (if used in slot indices > 0). The first argument to the function is used to pass in the sound. The function is any valid UGen function, which may be control or audio rate. Default controls are code::wet++index::, where strong::index:: is the slot of the proxy (default 0). In the example below, the control is code::\wet1::, and it crossfades between the incoming sound source and the effected (wet) signal output.
+|| Filter an incoming signal, either from code::\in.ar:: (if used in primary slot) or from the proxy's own bus (if used in slot indices > 0). The first argument to the function is used to pass in the sound. The function is any valid UGen function, which may be control or audio rate. Default controls are code::wet++index::, where strong::index:: is the slot of the proxy (default 0). In the example below, the control is code::\wet1::, and it crossfades between the incoming sound source and the effect (wet) signal output.
 
 code::
 a = NodeProxy(s).play;

--- a/SCClassLibrary/JITLib/ProxySpace/wrapForNodeProxy.sc
+++ b/SCClassLibrary/JITLib/ProxySpace/wrapForNodeProxy.sc
@@ -304,16 +304,33 @@
 				};
 
 				{ | out |
-					var env, ctl = NamedControl.kr("wet" ++ (index ? 0), 1.0);
-					if(proxy.rate === 'audio') {
-						env = ctl * EnvGate(i_level: 0, doneAction:2, curve:\sin);
-						XOut.ar(out, env, SynthDef.wrap(func, nil, [In.ar(out, proxy.numChannels)]))
-					} {
-						env = ctl * EnvGate(i_level: 0, doneAction:2, curve:\lin);
-						XOut.kr(out, env, SynthDef.wrap(func, nil, [In.kr(out, proxy.numChannels)]))
-					};
-				}.buildForProxy( proxy, channelOffset, index )
+					var isAudioRate = (proxy.rate === 'audio');
+					var rateArg = isAudioRate.if(\ar, \kr);
+					var wetAmp = NamedControl.kr("wet" ++ (index ? 0), 1.0, spec: ControlSpec(0, 1, 'linear'));
+					var env = EnvGate(
+						i_level: 0,
+						doneAction:2,
+						curve: isAudioRate.if(\sin, \lin)
+					);
+					var in;
 
+					(index == 0).if({
+						// we're at the top of the nopdeproxy sources, i.e. there is nothing on the bus yet to listen to.
+						// instead, we use \in.kr to listen to external signals
+						in = NamedControl(\in, 0!proxy.numChannels, proxy.rate);
+						XOut.perform(rateArg, out, env, SelectX.perform(rateArg, wetAmp, [
+							in,
+							SynthDef.wrap(func, nil, [in]).postln
+						]))
+					}, {
+						// there are other sources that send a signal to the internal bus 'out',
+						// i.e. we use In.ar/kr(out) as input
+						in = In.perform(rateArg, out, proxy.numChannels);
+						XOut.perform(rateArg, out, wetAmp * env, SynthDef.wrap(func, nil, [in]))
+					});
+
+
+				}.buildForProxy( proxy, channelOffset, index )
 			},
 			set: #{ | pattern, proxy, channelOffset = 0, index |
 				var args = proxy.controlNames.collect(_.name);
@@ -367,20 +384,43 @@
 				};
 
 				{ | out |
-					var in, env;
-					var wetamp = NamedControl.kr("wet" ++ (index ? 0), 1.0);
-					var dryamp = 1 - wetamp;
-					var sig = { |in| SynthDef.wrap(func, nil, [in * wetamp]) + (dryamp * in) };
+					var isAudioRate = (proxy.rate === 'audio');
+					var rateArg = isAudioRate.if(\ar, \kr);
+					var env = EnvGate(
+						i_level: 0,
+						doneAction:2,
+						curve: isAudioRate.if(\sin, \lin)
+					);
+					var in;
 
-					if(proxy.rate === 'audio') {
-						in = In.ar(out, proxy.numChannels);
-						env = EnvGate(i_level: 0, doneAction:2, curve:\sin);
-						XOut.ar(out, env, sig.(in))
-					} {
-						in = In.kr(out, proxy.numChannels);
-						env = EnvGate(i_level: 0, doneAction:2, curve:\lin);
-						XOut.kr(out, env, sig.(in))
-					};
+
+					var wetamp = NamedControl.kr("wet" ++ (index ? 0), 1.0, spec: ControlSpec(0, 1, 'linear'));
+					var dryamp = 1 - wetamp;
+					var sig = { |in|  SynthDef.wrap(func, nil, [in * wetamp]) + (dryamp * in)};
+
+
+					(index == 0).if({
+						// we're at the top of the nopdeproxy sources, i.e. there is nothing on the bus yet to listen to.
+						// instead, we use \in.kr to listen to external signals
+						in = NamedControl(\in, 0!proxy.numChannels, proxy.rate);
+						XOut.perform(rateArg,
+							out,
+							env,
+							SelectX.perform(rateArg, wetamp, [
+								in,
+								sig.(in)
+							])
+						)
+					}, {
+						// there are other sources that send a signal to the internal bus 'out',
+						// i.e. we use In.ar/kr(out) as input
+						in = In.perform(rateArg, out, proxy.numChannels);
+						XOut.perform(rateArg,
+							out,
+							wetamp * env,
+							sig.(in)
+						)
+					});
 				}.buildForProxy( proxy, channelOffset, index )
 			},
 

--- a/SCClassLibrary/JITLib/ProxySpace/wrapForNodeProxy.sc
+++ b/SCClassLibrary/JITLib/ProxySpace/wrapForNodeProxy.sc
@@ -305,16 +305,16 @@
 
 				{ | out |
 					var isAudioRate = (proxy.rate === 'audio');
-					var rateArg = isAudioRate.if(\ar, \kr);
+					var rateArg = if(isAudioRate, \ar, \kr);
 					var wetAmp = NamedControl.kr("wet" ++ (index ? 0), 1.0, spec: ControlSpec(0, 1, 'linear'));
 					var env = EnvGate(
 						i_level: 0,
 						doneAction:2,
-						curve: isAudioRate.if(\sin, \lin)
+						curve: if(isAudioRate, \sin, \lin)
 					);
 					var in;
 
-					(index == 0).if({
+					if(index == 0) {
 						// we're at the top of the nopdeproxy sources, i.e. there is nothing on the bus yet to listen to.
 						// instead, we use \in.kr to listen to external signals
 						in = NamedControl(\in, 0!proxy.numChannels, proxy.rate);
@@ -322,12 +322,12 @@
 							in,
 							SynthDef.wrap(func, nil, [in]).postln
 						]))
-					}, {
+					} {
 						// there are other sources that send a signal to the internal bus 'out',
 						// i.e. we use In.ar/kr(out) as input
 						in = In.perform(rateArg, out, proxy.numChannels);
 						XOut.perform(rateArg, out, wetAmp * env, SynthDef.wrap(func, nil, [in]))
-					});
+					};
 
 
 				}.buildForProxy( proxy, channelOffset, index )
@@ -385,11 +385,11 @@
 
 				{ | out |
 					var isAudioRate = (proxy.rate === 'audio');
-					var rateArg = isAudioRate.if(\ar, \kr);
+					var rateArg = if(isAudioRate, \ar, \kr);
 					var env = EnvGate(
 						i_level: 0,
 						doneAction:2,
-						curve: isAudioRate.if(\sin, \lin)
+						curve: if(isAudioRate, \sin, \lin)
 					);
 					var in;
 
@@ -399,7 +399,7 @@
 					var sig = { |in|  SynthDef.wrap(func, nil, [in * wetamp]) + (dryamp * in)};
 
 
-					(index == 0).if({
+					if(index == 0) {
 						// we're at the top of the nopdeproxy sources, i.e. there is nothing on the bus yet to listen to.
 						// instead, we use \in.kr to listen to external signals
 						in = NamedControl(\in, 0!proxy.numChannels, proxy.rate);
@@ -411,7 +411,7 @@
 								sig.(in)
 							])
 						)
-					}, {
+					} {
 						// there are other sources that send a signal to the internal bus 'out',
 						// i.e. we use In.ar/kr(out) as input
 						in = In.perform(rateArg, out, proxy.numChannels);
@@ -420,7 +420,7 @@
 							wetamp * env,
 							sig.(in)
 						)
-					});
+					};
 				}.buildForProxy( proxy, channelOffset, index )
 			},
 


### PR DESCRIPTION
## Purpose and Motivation

currently, proxy roles `filter` and `\filterIn` only work within a single NodeProxy to connect slots with each other.
This PR allows to use both roles when interconnecting NodeProxies via `<<>` resp. `<>>`.

For functionality examples, see tests below.

## Types of changes

- Documentation
- New feature

## To-do list


- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review

## Tests

```sc
/////////// ar — <>>
s.boot;

Ndef(\a).ar(1);
Ndef(\b).ar(1);
Ndef(\a).edit;
Ndef(\b).edit;

Ndef(\a, {PinkNoise.ar});
Ndef(\b).fadeTime = 10;
Ndef(\a) <>> Ndef(\b)

Ndef(\b, \filter -> {|in| SinOsc.ar(1000)});
Ndef(\b, \filter -> {|in| SinOsc.ar( 200)});
Ndef(\b, \filter -> {|in| LPF.ar(in)});

Ndef(\b, \filterIn -> {|in| FreeVerb.ar(in)});



Ndef(\b).scope



Ndef(\a).clear;
Ndef(\b).clear;

/////////// ar — single slot proxy (regression test)
Ndef(\a).edit;
Ndef(\a).fadeTime = 10;

Ndef(\a)[0] = {PinkNoise.ar};
Ndef(\a)[1] = \filter -> {|in| SinOsc.ar(1000)};
Ndef(\a)[1] = \filter -> {|in| SinOsc.ar( 200)};
Ndef(\a)[1] = \filterIn -> {|in| FreeVerb.ar(in)};
Ndef(\a)[1] = \filterIn -> {|in| LPF.ar(in)};
Ndef(\a)[1] = \filterIn -> {|in| SinOsc.ar(200)};

Ndef(\a).clear;

/////////// kr — <>>

Ndef(\kr_b).scope;
Ndef(\kr_a).kr(1);
Ndef(\kr_b).kr(1);

Ndef(\kr_a, {LFTri.kr(1)});
Ndef(\kr_a) <>> Ndef(\kr_b)
Ndef(\kr_b, \filter -> {|in| in.poll; in.tanh});
Ndef(\kr_b).fadeTime = 10;
Ndef(\kr_b, \filter -> {|in| in.wrap(-0.5, 0.5)});
Ndef(\kr_b, \filterIn -> {|in| in.poll; SinOsc.kr(freq: 0, phase: in * pi)});


Ndef(\kr_a).clear
Ndef(\kr_b).clear

/////////// kr — single slot proxy (regression test)


Ndef(\kr_a).kr(1);
Ndef(\kr_a).scope

Ndef(\kr_a)[0] = {LFTri.kr(1)};
Ndef(\kr_a)[1] =  \filter -> {|in| in.wrap(-0.5, 0.5)};
Ndef(\kr_a)[1] =  \filter -> {|in| in.poll; in.tanh};
Ndef(\kr_a)[1] =  \filterIn -> {|in| in.poll; SinOsc.kr(freq: 0, phase: in * pi)};
```