### PR TITLE
Switch to type safe qt connections within IDE

### DIFF
--- a/editors/sc-ide/core/doc_manager.cpp
+++ b/editors/sc-ide/core/doc_manager.cpp
@@ -57,7 +57,7 @@ Document::Document(bool isPlainText, const QByteArray& id, const QString& title,
     mTmpCoalCount = 0;
     mTmpCoalTimer.setInterval(RESTORE_COAL_MSECS);
     mTmpCoalTimer.setSingleShot(true);
-    connect(&mTmpCoalTimer, SIGNAL(timeout()), this, SLOT(onTmpCoalUsecs()));
+    connect(&mTmpCoalTimer, &QTimer::timeout, this, &Document::onTmpCoalUsecs);
 
     if (mId.isEmpty())
         mId = QUuid::createUuid().toString().toLatin1();
@@ -69,8 +69,7 @@ Document::Document(bool isPlainText, const QByteArray& id, const QString& title,
     if (!isPlainText)
         mHighlighter = new SyntaxHighlighter(mDoc);
 
-    connect(Main::instance(), SIGNAL(applySettingsRequest(Settings::Manager*)), this,
-            SLOT(applySettings(Settings::Manager*)));
+    connect(Main::instance(), &Main::applySettingsRequest, this, &Document::applySettings);
 
     applySettings(Main::settings());
 }
@@ -257,9 +256,9 @@ DocumentManager::DocumentManager(Main* main, Settings::Manager* settings):
     mGlobalKeyDownEnabled(false),
     mGlobalKeyUpEnabled(false) {
     mDocumentModel = new QStandardItemModel(this);
-    connect(&mFsWatcher, SIGNAL(fileChanged(QString)), this, SLOT(onFileChanged(QString)));
+    connect(&mFsWatcher, &QFileSystemWatcher::fileChanged, this, &DocumentManager::onFileChanged);
 
-    connect(main, SIGNAL(storeSettingsRequest(Settings::Manager*)), this, SLOT(storeSettings(Settings::Manager*)));
+    connect(main, &Main::storeSettingsRequest, this, &DocumentManager::storeSettings);
 
     loadRecentDocuments(settings);
 }
@@ -274,14 +273,14 @@ Document* DocumentManager::createDocument(bool isPlainText, const QByteArray& id
     item->setData(QVariant::fromValue(doc));
     mDocumentModel->appendRow(item);
     QTextDocument* tdoc = doc->textDocument();
-    connect(tdoc, SIGNAL(modificationChanged(bool)), doc, SLOT(onModificationChanged(bool)));
+    connect(tdoc, &QTextDocument::modificationChanged, doc, &Document::onModificationChanged);
     return doc;
 }
 
 void DocumentManager::create() {
     Document* doc = createDocument();
 
-    connect(doc->textDocument(), SIGNAL(contentsChanged()), doc, SLOT(storeTmpFile()));
+    connect(doc->textDocument(), &QTextDocument::contentsChanged, doc, &Document::storeTmpFile);
     syncLangDocument(doc);
     Q_EMIT(opened(doc, 0, 0));
 }
@@ -343,7 +342,7 @@ Document* DocumentManager::open(const QString& path, int initialCursorPosition, 
     doc->setTitle(fileTitle);
     doc->mSaveTime = info.lastModified();
     doc->setInitialSelection(initialCursorPosition, selectionLength);
-    connect(doc->textDocument(), SIGNAL(contentsChanged()), doc, SLOT(storeTmpFile()));
+    connect(doc->textDocument(), &QTextDocument::contentsChanged, doc, &Document::storeTmpFile);
 
     if (!isRTF)
         mFsWatcher.addPath(cpath);
@@ -411,7 +410,7 @@ void DocumentManager::restore() {
         doc->mTmpFilePath = path;
         syncLangDocument(doc);
         Q_EMIT(opened(doc, 0, 0));
-        connect(doc->textDocument(), SIGNAL(contentsChanged()), doc, SLOT(storeTmpFile()));
+        connect(doc->textDocument(), &QTextDocument::contentsChanged, doc, &Document::storeTmpFile);
     }
 }
 
@@ -803,15 +802,15 @@ void DocumentManager::handleSetDocTextScRequest(const QString& data) {
             if (document) {
                 // avoid a loop
                 if (document == mCurrentDocument) {
-                    disconnect(document->textDocument(), SIGNAL(contentsChange(int, int, int)), this,
-                               SLOT(updateCurrentDocContents(int, int, int)));
+                    disconnect(document->textDocument(), &QTextDocument::contentsChange, this,
+                               &DocumentManager::updateCurrentDocContents);
                 }
 
                 document->setTextInRange(QString::fromUtf8(text.c_str()), start, range);
 
                 if (document == mCurrentDocument) {
-                    connect(document->textDocument(), SIGNAL(contentsChange(int, int, int)), this,
-                            SLOT(updateCurrentDocContents(int, int, int)));
+                    connect(document->textDocument(), &QTextDocument::contentsChange, this,
+                            &DocumentManager::updateCurrentDocContents);
                 }
 
                 // Only execute a call if a function name was passed.
@@ -1162,12 +1161,12 @@ void DocumentManager::syncLangDocument(Document* doc) {
 
 void DocumentManager::setActiveDocument(Document* document) {
     if (mCurrentDocument)
-        disconnect(mCurrentDocument->textDocument(), SIGNAL(contentsChange(int, int, int)), this,
-                   SLOT(updateCurrentDocContents(int, int, int)));
+        disconnect(mCurrentDocument->textDocument(), &QTextDocument::contentsChange, this,
+                   &DocumentManager::updateCurrentDocContents);
     if (document) {
         mCurrentDocumentPath = document->filePath();
-        connect(document->textDocument(), SIGNAL(contentsChange(int, int, int)), this,
-                SLOT(updateCurrentDocContents(int, int, int)));
+        connect(document->textDocument(), &QTextDocument::contentsChange, this,
+                &DocumentManager::updateCurrentDocContents);
         mCurrentDocument = document;
     } else {
         mCurrentDocumentPath.clear();

--- a/editors/sc-ide/core/main.cpp
+++ b/editors/sc-ide/core/main.cpp
@@ -78,7 +78,7 @@ bool SingleInstanceGuard::tryConnect(QStringList const& arguments) {
 
         bool listening = mIpcServer->listen(serverName);
         if (listening) {
-            connect(mIpcServer, SIGNAL(newConnection()), this, SLOT(onNewIpcConnection()));
+            connect(mIpcServer, &QLocalServer::newConnection, this, &SingleInstanceGuard::onNewIpcConnection);
             return false;
         }
     }
@@ -140,7 +140,7 @@ Main::Main(void):
     QtCollider::Mac::DisableAutomaticWindowTabbing();
 #endif
 
-    connect(mScProcess, SIGNAL(response(QString, QString)), mDocManager, SLOT(handleScLangMessage(QString, QString)));
+    connect(mScProcess, &ScProcess::response, mDocManager, &DocumentManager::handleScLangMessage);
 
     qApp->installEventFilter(this);
     qApp->installNativeEventFilter(this);

--- a/editors/sc-ide/core/main.hpp
+++ b/editors/sc-ide/core/main.hpp
@@ -49,8 +49,8 @@ public:
 public Q_SLOTS:
     void onNewIpcConnection() {
         mIpcSocket = mIpcServer->nextPendingConnection();
-        connect(mIpcSocket, SIGNAL(disconnected()), mIpcSocket, SLOT(deleteLater()));
-        connect(mIpcSocket, SIGNAL(readyRead()), this, SLOT(onIpcData()));
+        connect(mIpcSocket, &QLocalSocket::disconnected, mIpcSocket, &QLocalSocket::deleteLater);
+        connect(mIpcSocket, &QLocalSocket::readyRead, this, &SingleInstanceGuard::onIpcData);
     }
 
     void onIpcData();

--- a/editors/sc-ide/core/sc_process.cpp
+++ b/editors/sc-ide/core/sc_process.cpp
@@ -49,11 +49,10 @@ ScProcess::ScProcess(Settings::Manager* settings, QObject* parent):
     mCompiled(false) {
     prepareActions(settings);
 
-    connect(this, SIGNAL(readyReadStandardOutput()), this, SLOT(onReadAllStandardOutput()));
-    connect(this, SIGNAL(readyReadStandardError()), this, SLOT(onReadAllStandardError()));
-    connect(mIpcServer, SIGNAL(newConnection()), this, SLOT(onNewIpcConnection()));
-    connect(this, SIGNAL(stateChanged(QProcess::ProcessState)), this,
-            SLOT(onProcessStateChanged(QProcess::ProcessState)));
+    connect(this, &ScProcess::readyReadStandardOutput, this, &ScProcess::onReadAllStandardOutput);
+    connect(this, &ScProcess::readyReadStandardError, this, &ScProcess::onReadAllStandardError);
+    connect(mIpcServer, &QLocalServer::newConnection, this, &ScProcess::onNewIpcConnection);
+    connect(this, &ScProcess::stateChanged, this, &ScProcess::onProcessStateChanged);
     this->setProcessChannelMode(QProcess::SeparateChannels);
 }
 
@@ -65,39 +64,39 @@ void ScProcess::prepareActions(Settings::Manager* settings) {
     mActions[ToggleRunning] = action = new QAction(tr("Boot or Quit Interpreter"), this);
     // the default QAction::TextHeuristicRole incorrectly detects a quit role on macOS
     action->setMenuRole(QAction::NoRole);
-    connect(action, SIGNAL(triggered()), this, SLOT(toggleRunning()));
+    connect(action, &QAction::triggered, this, &ScProcess::toggleRunning);
     // settings->addAction( action, "interpreter-toggle-running", interpreterCategory);
 
     mActions[Start] = action = new QAction(QIcon::fromTheme("system-run"), tr("Boot Interpreter"), this);
-    connect(action, SIGNAL(triggered()), this, SLOT(startLanguage()));
+    connect(action, &QAction::triggered, this, &ScProcess::startLanguage);
     settings->addAction(action, "interpreter-start", interpreterCategory);
 
     mActions[Stop] = action = new QAction(QIcon::fromTheme("system-shutdown"), tr("Quit Interpreter"), this);
-    connect(action, SIGNAL(triggered()), this, SLOT(stopLanguage()));
+    connect(action, &QAction::triggered, this, &ScProcess::stopLanguage);
     settings->addAction(action, "interpreter-stop", interpreterCategory);
 
     mActions[Restart] = action = new QAction(QIcon::fromTheme("system-reboot"), tr("Reboot Interpreter"), this);
-    connect(action, SIGNAL(triggered()), this, SLOT(restartLanguage()));
+    connect(action, &QAction::triggered, this, &ScProcess::restartLanguage);
     settings->addAction(action, "interpreter-restart", interpreterCategory);
 
     mActions[RecompileClassLibrary] = action =
         new QAction(QIcon::fromTheme("system-reboot"), tr("Recompile Class Library"), this);
     action->setShortcut(tr("Ctrl+Shift+l", "Recompile Class Library)"));
-    connect(action, SIGNAL(triggered()), this, SLOT(recompileClassLibrary()));
+    connect(action, &QAction::triggered, this, &ScProcess::recompileClassLibrary);
     settings->addAction(action, "interpreter-recompile-lib", interpreterCategory);
 
     mActions[StopMain] = action = new QAction(QIcon::fromTheme("media-playback-stop"), tr("Stop"), this);
     action->setShortcut(tr("Ctrl+.", "Stop (a.k.a. cmd-period)"));
     action->setShortcutContext(Qt::ApplicationShortcut);
-    connect(action, SIGNAL(triggered()), this, SLOT(stopMain()));
+    connect(action, &QAction::triggered, this, &ScProcess::stopMain);
     settings->addAction(action, "interpreter-main-stop", interpreterCategory);
 
     mActions[ShowQuarks] = action = new QAction(tr("Quarks"), this);
-    connect(action, SIGNAL(triggered()), this, SLOT(showQuarks()));
+    connect(action, &QAction::triggered, this, &ScProcess::showQuarks);
     settings->addAction(action, "interpreter-show-quarks-gui", interpreterCategory);
 
-    connect(mActions[Start], SIGNAL(changed()), this, SLOT(updateToggleRunningAction()));
-    connect(mActions[Stop], SIGNAL(changed()), this, SLOT(updateToggleRunningAction()));
+    connect(mActions[Start], &QAction::triggered, this, &ScProcess::updateToggleRunningAction);
+    connect(mActions[Stop], &QAction::triggered, this, &ScProcess::updateToggleRunningAction);
 
     onProcessStateChanged(QProcess::NotRunning);
 }
@@ -250,8 +249,8 @@ void ScProcess::onNewIpcConnection() {
         mIpcSocket->disconnect();
 
     mIpcSocket = mIpcServer->nextPendingConnection();
-    connect(mIpcSocket, SIGNAL(disconnected()), this, SLOT(finalizeConnection()));
-    connect(mIpcSocket, SIGNAL(readyRead()), this, SLOT(onIpcData()));
+    connect(mIpcSocket, &QLocalSocket::disconnected, this, &ScProcess::finalizeConnection);
+    connect(mIpcSocket, &QLocalSocket::readyRead, this, &ScProcess::onIpcData);
 }
 
 void ScProcess::finalizeConnection() {

--- a/editors/sc-ide/core/sc_process.hpp
+++ b/editors/sc-ide/core/sc_process.hpp
@@ -125,9 +125,9 @@ class ScRequest : public QObject {
     Q_OBJECT
 public:
     ScRequest(ScProcess* sc, QObject* parent = 0): QObject(parent), mSc(sc) {
-        connect(mSc, SIGNAL(response(QString, QString)), this, SLOT(onResponse(QString, QString)));
+        connect(mSc, &ScProcess::response, this, &ScRequest::onResponse);
 
-        connect(mSc, SIGNAL(classLibraryRecompiled()), this, SLOT(cancel()));
+        connect(mSc, &ScProcess::classLibraryRecompiled, this, &ScRequest::cancel);
     }
 
     void send(const QString& command, const QString& data) {

--- a/editors/sc-ide/core/sc_server.cpp
+++ b/editors/sc-ide/core/sc_server.cpp
@@ -47,10 +47,9 @@ ScServer::ScServer(ScProcess* scLang, Settings::Manager* settings, QObject* pare
     mUdpSocket = new QUdpSocket(this);
     startTimer(333);
 
-    connect(scLang, SIGNAL(stateChanged(QProcess::ProcessState)), this,
-            SLOT(onScLangStateChanged(QProcess::ProcessState)));
-    connect(scLang, SIGNAL(response(QString, QString)), this, SLOT(onScLangReponse(QString, QString)));
-    connect(mUdpSocket, SIGNAL(readyRead()), this, SLOT(onServerDataArrived()));
+    connect(scLang, &ScProcess::stateChanged, this, &ScServer::onScLangStateChanged);
+    connect(scLang, &ScProcess::response, this, &ScServer::onScLangReponse);
+    connect(mUdpSocket, &QUdpSocket::readyRead, this, &ScServer::onServerDataArrived);
 }
 
 void ScServer::createActions(Settings::Manager* settings) {
@@ -61,66 +60,66 @@ void ScServer::createActions(Settings::Manager* settings) {
     mActions[ToggleRunning] = action = new QAction(tr("Boot or quit default server"), this);
     // the default QAction::TextHeuristicRole incorrectly detects a quit role on macOS
     action->setMenuRole(QAction::NoRole);
-    connect(action, SIGNAL(triggered()), this, SLOT(toggleRunning()));
+    connect(action, &QAction::triggered, this, &ScServer::toggleRunning);
     // settings->addAction( action, "synth-server-toggle-running", synthServerCategory);
 
     mActions[Boot] = action = new QAction(QIcon::fromTheme("system-run"), tr("&Boot Server"), this);
     action->setShortcut(tr("Ctrl+B", "Boot default server"));
-    connect(action, SIGNAL(triggered()), this, SLOT(boot()));
+    connect(action, &QAction::triggered, this, &ScServer::boot);
     settings->addAction(action, "synth-server-boot", synthServerCategory);
 
     mActions[Quit] = action = new QAction(QIcon::fromTheme("system-shutdown"), tr("&Quit Server"), this);
-    connect(action, SIGNAL(triggered()), this, SLOT(quit()));
+    connect(action, &QAction::triggered, this, &ScServer::quit);
     settings->addAction(action, "synth-server-quit", synthServerCategory);
 
     mActions[KillAll] = action = new QAction(QIcon::fromTheme("system-killall"), tr("&Kill All Servers"), this);
-    connect(action, SIGNAL(triggered()), this, SLOT(killAll()));
+    connect(action, &QAction::triggered, this, &ScServer::killAll);
     settings->addAction(action, "synth-server-killall", synthServerCategory);
 
     mActions[Reboot] = action = new QAction(QIcon::fromTheme("system-reboot"), tr("&Reboot Server"), this);
-    connect(action, SIGNAL(triggered()), this, SLOT(reboot()));
+    connect(action, &QAction::triggered, this, &ScServer::reboot);
     settings->addAction(action, "synth-server-reboot", synthServerCategory);
 
     mActions[ShowMeters] = action = new QAction(tr("Show Server Meter"), this);
     action->setShortcut(tr("Ctrl+M", "Show server meter"));
-    connect(action, SIGNAL(triggered()), this, SLOT(showMeters()));
+    connect(action, &QAction::triggered, this, &ScServer::showMeters);
     settings->addAction(action, "synth-server-meter", synthServerCategory);
 
     mActions[ShowScope] = action = new QAction(tr("Show Scope"), this);
     action->setShortcut(tr("Ctrl+Shift+M", "Show scope"));
-    connect(action, SIGNAL(triggered()), this, SLOT(showScope()));
+    connect(action, &QAction::triggered, this, &ScServer::showScope);
     settings->addAction(action, "synth-server-scope", synthServerCategory);
 
     mActions[ShowFreqScope] = action = new QAction(tr("Show Freqscope"), this);
     action->setShortcut(tr("Ctrl+Alt+M", "Show freqscope"));
-    connect(action, SIGNAL(triggered()), this, SLOT(showFreqScope()));
+    connect(action, &QAction::triggered, this, &ScServer::showFreqScope);
     settings->addAction(action, "synth-server-freqscope", synthServerCategory);
 
     mActions[DumpNodeTree] = action = new QAction(tr("Dump Node Tree"), this);
     action->setShortcut(tr("Ctrl+T", "Dump node tree"));
-    connect(action, SIGNAL(triggered()), this, SLOT(dumpNodeTree()));
+    connect(action, &QAction::triggered, this, &ScServer::dumpNodeTree);
     settings->addAction(action, "synth-server-dump-nodes", synthServerCategory);
 
     mActions[DumpNodeTreeWithControls] = action = new QAction(tr("Dump Node Tree with Controls"), this);
     action->setShortcut(tr("Ctrl+Shift+T", "Dump node tree with controls"));
-    connect(action, SIGNAL(triggered()), this, SLOT(dumpNodeTreeWithControls()));
+    connect(action, &QAction::triggered, this, &ScServer::dumpNodeTreeWithControls);
     settings->addAction(action, "synth-server-dump-nodes-with-controls", synthServerCategory);
 
     mActions[PlotTree] = action = new QAction(tr("Show Node Tree"), this);
     action->setShortcut(tr("Ctrl+Alt+T", "Show node tree"));
-    connect(action, SIGNAL(triggered()), this, SLOT(plotTree()));
+    connect(action, &QAction::triggered, this, &ScServer::plotTree);
     settings->addAction(action, "synth-server-plot-tree", synthServerCategory);
 
     mActions[DumpOSC] = action = new QAction(tr("Server Dump OSC"), this);
     action->setCheckable(true);
-    connect(action, SIGNAL(triggered(bool)), this, SLOT(sendDumpingOSC(bool)));
+    connect(action, &QAction::triggered, this, &ScServer::sendDumpingOSC);
     settings->addAction(action, "synth-server-dumpOSC", synthServerCategory);
 
     mActions[Mute] = action = new QAction(tr("Mute"), this);
     action->setShortcut(tr("Ctrl+Alt+End", "Mute sound output."));
     action->setCheckable(true);
-    connect(action, SIGNAL(triggered(bool)), this, SLOT(sendMuted(bool)));
-    connect(action, SIGNAL(toggled(bool)), this, SIGNAL(mutedChanged(bool)));
+    connect(action, &QAction::triggered, this, &ScServer::sendMuted);
+    connect(action, &QAction::toggled, this, &ScServer::mutedChanged);
     settings->addAction(action, "synth-server-mute", synthServerCategory);
 
     mVolumeWidget = new VolumeWidget;
@@ -129,41 +128,41 @@ void ScServer::createActions(Settings::Manager* settings) {
     widgetAction->setDefaultWidget(mVolumeWidget);
 
     connect(mVolumeWidget, &VolumeWidget::volumeChangeRequested, [this](float newValue) { setVolume(newValue); });
-    connect(this, SIGNAL(volumeChanged(float)), mVolumeWidget, SLOT(setVolume(float)));
-    connect(this, SIGNAL(volumeRangeChanged(float, float)), mVolumeWidget, SLOT(setVolumeRange(float, float)));
+    connect(this, &ScServer::volumeChanged, mVolumeWidget, &VolumeWidget::setVolume);
+    connect(this, &ScServer::volumeRangeChanged, mVolumeWidget, &VolumeWidget::setVolumeRange);
     emit volumeChanged(mVolume);
     emit volumeRangeChanged(mVolumeMin, mVolumeMax);
 
     mActions[VolumeUp] = action = new QAction(tr("Increase Volume"), this);
     action->setShortcut(tr("Ctrl+Alt+PgUp", "Increase volume"));
-    connect(action, SIGNAL(triggered()), this, SLOT(increaseVolume()));
+    connect(action, &QAction::triggered, this, &ScServer::increaseVolume);
     settings->addAction(action, "synth-server-volume-up", synthServerCategory);
 
     mActions[VolumeDown] = action = new QAction(tr("Decrease Volume"), this);
     action->setShortcut(tr("Ctrl+Alt+PgDown", "Decrease volume"));
-    connect(action, SIGNAL(triggered()), this, SLOT(decreaseVolume()));
+    connect(action, &QAction::triggered, this, &ScServer::decreaseVolume);
     settings->addAction(action, "synth-server-volume-down", synthServerCategory);
 
     mActions[VolumeRestore] = action = new QAction(tr("Restore Volume to 0 dB"), this);
     action->setShortcut(tr("Ctrl+Alt+Home", "Restore volume"));
-    connect(action, SIGNAL(triggered()), this, SLOT(restoreVolume()));
+    connect(action, &QAction::triggered, this, &ScServer::restoreVolume);
     settings->addAction(action, "synth-server-volume-restore", synthServerCategory);
 
     mActions[Record] = action = new QAction(tr("Recording"), this);
     action->setCheckable(true);
-    connect(action, SIGNAL(triggered(bool)), this, SLOT(sendRecording(bool)));
-    connect(action, SIGNAL(toggled(bool)), this, SIGNAL(recordingChanged(bool)));
+    connect(action, &QAction::triggered, this, &ScServer::sendRecording);
+    connect(action, &QAction::toggled, this, &ScServer::recordingChanged);
     settings->addAction(action, "synth-server-record", synthServerCategory);
 
     mActions[PauseRecord] = action = new QAction(tr("Pause Recording"), this);
     action->setCheckable(true);
-    connect(action, SIGNAL(triggered(bool)), this, SLOT(pauseRecording(bool)));
-    connect(action, SIGNAL(toggled(bool)), this, SIGNAL(pauseChanged(bool)));
+    connect(action, &QAction::triggered, this, &ScServer::pauseRecording);
+    connect(action, &QAction::toggled, this, &ScServer::pauseChanged);
     settings->addAction(action, "synth-server-pause-recording", synthServerCategory);
 
 
-    connect(mActions[Boot], SIGNAL(changed()), this, SLOT(updateToggleRunningAction()));
-    connect(mActions[Quit], SIGNAL(changed()), this, SLOT(updateToggleRunningAction()));
+    connect(mActions[Boot], &QAction::changed, this, &ScServer::updateToggleRunningAction);
+    connect(mActions[Quit], &QAction::changed, this, &ScServer::updateToggleRunningAction);
 
     updateToggleRunningAction();
     updateRecordingAction();

--- a/editors/sc-ide/primitives/sc_ipc_client.cpp
+++ b/editors/sc-ide/primitives/sc_ipc_client.cpp
@@ -41,7 +41,7 @@
 SCIpcClient::SCIpcClient(const char* ideName): mSocket(NULL) {
     mSocket = new QLocalSocket();
     mSocket->connectToServer(QString(ideName));
-    connect(mSocket, SIGNAL(readyRead()), this, SLOT(readIDEData()));
+    connect(mSocket, &QLocalSocket::readyRead, this, &SCIpcClient::readIDEData);
 }
 
 void SCIpcClient::send(const char* data, size_t length) { mSocket->write(data, length); }

--- a/editors/sc-ide/widgets/audio_status_box.cpp
+++ b/editors/sc-ide/widgets/audio_status_box.cpp
@@ -75,13 +75,11 @@ AudioStatusBox::AudioStatusBox(ScServer* server, QWidget* parent): StatusBox(par
     addAction(server->action(ScServer::Volume));
 
     // server -> box
-    connect(server, SIGNAL(runningStateChanged(bool, QString, int, bool)), this,
-            SLOT(onServerRunningChanged(bool, QString, int, bool)));
-    connect(server, SIGNAL(updateServerStatus(int, int, int, int, float, float)), this,
-            SLOT(updateStatistics(int, int, int, int, float, float)));
-    connect(server, SIGNAL(volumeChanged(float)), this, SLOT(updateVolumeLabel(float)));
-    connect(server, SIGNAL(mutedChanged(bool)), this, SLOT(updateMuteLabel(bool)));
-    connect(server, SIGNAL(recordingChanged(bool)), this, SLOT(updateRecordLabel(bool)));
+    connect(server, &ScServer::runningStateChanged, this, &AudioStatusBox::onServerRunningChanged);
+    connect(server, &ScServer::updateServerStatus, this, &AudioStatusBox::updateStatistics);
+    connect(server, &ScServer::volumeChanged, this, &AudioStatusBox::updateVolumeLabel);
+    connect(server, &ScServer::mutedChanged, this, &AudioStatusBox::updateMuteLabel);
+    connect(server, &ScServer::recordingChanged, this, &AudioStatusBox::updateRecordLabel);
 
     auto const main = Main::instance();
     applySettings(main->settings());

--- a/editors/sc-ide/widgets/code_editor/autocompleter.cpp
+++ b/editors/sc-ide/widgets/code_editor/autocompleter.cpp
@@ -182,14 +182,14 @@ AutoCompleter::AutoCompleter(ScCodeEditor* editor): QObject(editor), mEditor(edi
     mCompletion.on = false;
     mEditor->installEventFilter(this);
 
-    connect(editor, SIGNAL(cursorPositionChanged()), this, SLOT(onCursorChanged()));
-    connect(editor->horizontalScrollBar(), SIGNAL(valueChanged(int)), this, SLOT(hideWidgets()));
-    connect(editor->verticalScrollBar(), SIGNAL(valueChanged(int)), this, SLOT(hideWidgets()));
-    connect(Main::scProcess(), SIGNAL(introspectionChanged()), this, SLOT(clearMethodCallStack()));
+    connect(editor, &ScCodeEditor::cursorPositionChanged, this, &AutoCompleter::onCursorChanged);
+    connect(editor->horizontalScrollBar(), &QScrollBar::valueChanged, this, &AutoCompleter::hideWidgets);
+    connect(editor->verticalScrollBar(), &QScrollBar::valueChanged, this, &AutoCompleter::hideWidgets);
+    connect(Main::scProcess(), &ScProcess::introspectionChanged, this, &AutoCompleter::clearMethodCallStack);
 }
 
 void AutoCompleter::documentChanged(QTextDocument* doc) {
-    connect(doc, SIGNAL(contentsChange(int, int, int)), this, SLOT(onContentsChange(int, int, int)));
+    connect(doc, &QTextDocument::contentsChange, this, &AutoCompleter::onContentsChange);
 }
 
 inline QTextDocument* AutoCompleter::document() { return static_cast<QPlainTextEdit*>(mEditor)->document(); }
@@ -471,7 +471,7 @@ void AutoCompleter::showCompletionMenu(bool forceShow) {
 
     mCompletion.menu = menu;
 
-    connect(menu, SIGNAL(finished(int)), this, SLOT(onCompletionMenuFinished(int)));
+    connect(menu, &CompletionMenu::finished, this, &AutoCompleter::onCompletionMenuFinished);
 
     QRect popupTargetRect = globalCursorRect(mCompletion.pos).adjusted(0, -5, 0, 5);
 
@@ -480,8 +480,8 @@ void AutoCompleter::showCompletionMenu(bool forceShow) {
     updateCompletionMenu(forceShow);
 
     if (mCompletion.type == ClassCompletion && Main::settings()->value("IDE/editor/showAutocompleteHelp").toBool()) {
-        connect(menu, SIGNAL(itemChanged(int)), this, SLOT(updateCompletionMenuInfo()));
-        connect(menu, SIGNAL(infoClicked(QString)), this, SLOT(gotoHelp(QString)));
+        connect(menu, &CompletionMenu::itemChanged, this, &AutoCompleter::updateCompletionMenuInfo);
+        connect(menu, &CompletionMenu::infoClicked, this, &AutoCompleter::gotoHelp);
         updateCompletionMenuInfo();
     }
 }

--- a/editors/sc-ide/widgets/code_editor/completion_menu.cpp
+++ b/editors/sc-ide/widgets/code_editor/completion_menu.cpp
@@ -48,8 +48,8 @@ CompletionMenu::CompletionMenu(QWidget* parent): PopUpWidget(parent), mCompletio
     mLayout->addWidget(mTextBrowser);
     mLayout->setContentsMargins(1, 1, 1, 1);
 
-    connect(mListView, SIGNAL(clicked(QModelIndex)), this, SLOT(accept()));
-    connect(mTextBrowser, SIGNAL(anchorClicked(const QUrl)), this, SLOT(onAnchorClicked(const QUrl)));
+    connect(mListView, &QListView::clicked, this, &CompletionMenu::accept);
+    connect(mTextBrowser, &CompletionTextBrowser::anchorClicked, this, &CompletionMenu::onAnchorClicked);
 
     mListView->setFocus(Qt::OtherFocusReason);
 

--- a/editors/sc-ide/widgets/code_editor/editor.cpp
+++ b/editors/sc-ide/widgets/code_editor/editor.cpp
@@ -80,20 +80,19 @@ GenericCodeEditor::GenericCodeEditor(Document* doc, QWidget* parent):
 
     mOverlayAnimator = new OverlayAnimator(this, mOverlay);
 
-    connect(mDoc, SIGNAL(defaultFontChanged()), this, SLOT(onDocumentFontChanged()));
+    connect(mDoc, &Document::defaultFontChanged, this, &GenericCodeEditor::onDocumentFontChanged);
 
-    connect(this, SIGNAL(blockCountChanged(int)), mLineIndicator, SLOT(setLineCount(int)));
+    connect(this, &GenericCodeEditor::blockCountChanged, mLineIndicator, &LineIndicator::setLineCount);
 
-    connect(mLineIndicator, SIGNAL(widthChanged()), this, SLOT(updateLayout()));
+    connect(mLineIndicator, &LineIndicator::widthChanged, this, &GenericCodeEditor::updateLayout);
 
-    connect(this, SIGNAL(updateRequest(QRect, int)), this, SLOT(updateLineIndicator(QRect, int)));
+    connect(this, &GenericCodeEditor::updateRequest, this, &GenericCodeEditor::updateLineIndicator);
 
-    connect(this, SIGNAL(selectionChanged()), mLineIndicator, SLOT(update()));
-    connect(this, SIGNAL(selectionChanged()), this, SLOT(updateDocLastSelection()));
-    connect(this, SIGNAL(cursorPositionChanged()), this, SLOT(onCursorPositionChanged()));
+    connect(this, &GenericCodeEditor::selectionChanged, mLineIndicator, [=]() { mLineIndicator->update(); });
+    connect(this, &GenericCodeEditor::selectionChanged, this, &GenericCodeEditor::updateDocLastSelection);
+    connect(this, &GenericCodeEditor::cursorPositionChanged, this, &GenericCodeEditor::onCursorPositionChanged);
 
-    connect(Main::instance(), SIGNAL(applySettingsRequest(Settings::Manager*)), this,
-            SLOT(applySettings(Settings::Manager*)));
+    connect(Main::instance(), &Main::applySettingsRequest, this, &GenericCodeEditor::applySettings);
 
     QTextDocument* tdoc = doc->textDocument();
     QPlainTextEdit::setDocument(tdoc);

--- a/editors/sc-ide/widgets/code_editor/highlighter.cpp
+++ b/editors/sc-ide/widgets/code_editor/highlighter.cpp
@@ -41,33 +41,33 @@ SyntaxHighlighterGlobals::SyntaxHighlighterGlobals(Main* main, Settings::Manager
     // initialize formats from settings:
     applySettings(settings);
 
-    connect(main, SIGNAL(applySettingsRequest(Settings::Manager*)), this, SLOT(applySettings(Settings::Manager*)));
+    connect(main, &Main::applySettingsRequest, this, &SyntaxHighlighterGlobals::applySettings);
 }
 
 void SyntaxHighlighterGlobals::applySettings(Settings::Manager* s) {
-    applySettings(s, "whitespace", WhitespaceFormat);
-    applySettings(s, "keyword", KeywordFormat);
-    applySettings(s, "built-in", BuiltinFormat);
-    applySettings(s, "primitive", PrimitiveFormat);
-    applySettings(s, "class", ClassFormat);
-    applySettings(s, "number", NumberFormat);
-    applySettings(s, "symbol", SymbolFormat);
-    applySettings(s, "env-var", EnvVarFormat);
-    applySettings(s, "string", StringFormat);
-    applySettings(s, "char", CharFormat);
-    applySettings(s, "comment", CommentFormat);
+    applySettingsKey(s, "whitespace", WhitespaceFormat);
+    applySettingsKey(s, "keyword", KeywordFormat);
+    applySettingsKey(s, "built-in", BuiltinFormat);
+    applySettingsKey(s, "primitive", PrimitiveFormat);
+    applySettingsKey(s, "class", ClassFormat);
+    applySettingsKey(s, "number", NumberFormat);
+    applySettingsKey(s, "symbol", SymbolFormat);
+    applySettingsKey(s, "env-var", EnvVarFormat);
+    applySettingsKey(s, "string", StringFormat);
+    applySettingsKey(s, "char", CharFormat);
+    applySettingsKey(s, "comment", CommentFormat);
 
     Q_EMIT(syntaxFormatsChanged());
 }
 
-void SyntaxHighlighterGlobals::applySettings(Settings::Manager* s, const QString& key, SyntaxFormat type) {
+void SyntaxHighlighterGlobals::applySettingsKey(Settings::Manager* s, const QString& key, SyntaxFormat type) {
     mFormats[type] = s->getThemeVal(key);
 }
 
 SyntaxHighlighter::SyntaxHighlighter(QTextDocument* parent): QSyntaxHighlighter(parent) {
     mGlobals = SyntaxHighlighterGlobals::instance();
 
-    connect(mGlobals, SIGNAL(syntaxFormatsChanged()), this, SLOT(rehighlight()));
+    connect(mGlobals, &SyntaxHighlighterGlobals::syntaxFormatsChanged, this, &SyntaxHighlighter::rehighlight);
 
     connect(Main::scProcess(), &ScProcess::introspectionChanged, this, &SyntaxHighlighter::rehighlight);
 }

--- a/editors/sc-ide/widgets/code_editor/highlighter.hpp
+++ b/editors/sc-ide/widgets/code_editor/highlighter.hpp
@@ -75,7 +75,7 @@ Q_SIGNALS:
 private:
     friend class SyntaxHighlighter;
 
-    void applySettings(Settings::Manager* s, const QString& key, SyntaxFormat);
+    void applySettingsKey(Settings::Manager* s, const QString& key, SyntaxFormat);
 
     QTextCharFormat mFormats[FormatCount];
 

--- a/editors/sc-ide/widgets/code_editor/overlay.cpp
+++ b/editors/sc-ide/widgets/code_editor/overlay.cpp
@@ -198,7 +198,7 @@ void ScCodeEditor::blinkCode(const QTextCursor& c) {
     anim->setEasingCurve(QEasingCurve::InCubic);
     anim->start();
 
-    connect(anim, SIGNAL(finished()), item, SLOT(deleteLater()));
+    connect(anim, &QPropertyAnimation::finished, item, &CodeFragmentOverlay::deleteLater);
 }
 
 } // namespace ScIDE

--- a/editors/sc-ide/widgets/code_editor/sc_editor.cpp
+++ b/editors/sc-ide/widgets/code_editor/sc_editor.cpp
@@ -49,10 +49,9 @@ ScCodeEditor::ScCodeEditor(Document* doc, QWidget* parent):
     mAutoCompleter(new AutoCompleter(this)) {
     Q_ASSERT(mDoc != 0);
 
-    connect(this, SIGNAL(cursorPositionChanged()), this, SLOT(matchBrackets()));
+    connect(this, &ScCodeEditor::cursorPositionChanged, this, &ScCodeEditor::matchBrackets);
 
-    connect(Main::instance(), SIGNAL(applySettingsRequest(Settings::Manager*)), this,
-            SLOT(applySettings(Settings::Manager*)));
+    connect(Main::instance(), &Main::applySettingsRequest, this, &ScCodeEditor::applySettings);
 
     mAutoCompleter->documentChanged(textDocument());
 

--- a/editors/sc-ide/widgets/doc_list.cpp
+++ b/editors/sc-ide/widgets/doc_list.cpp
@@ -31,10 +31,10 @@ DocumentListWidget::DocumentListWidget(DocumentManager* manager, QWidget* parent
     mDocModifiedIcon(QApplication::style()->standardIcon(QStyle::SP_DialogSaveButton)) {
     setFrameShape(QFrame::NoFrame);
 
-    connect(manager, SIGNAL(opened(Document*, int, int)), this, SLOT(onOpen(Document*, int, int)));
-    connect(manager, SIGNAL(closed(Document*)), this, SLOT(onClose(Document*)));
-    connect(manager, SIGNAL(saved(Document*)), this, SLOT(onSaved(Document*)));
-    connect(this, SIGNAL(itemPressed(QListWidgetItem*)), this, SLOT(onItemClicked(QListWidgetItem*)));
+    connect(manager, &DocumentManager::opened, this, &DocumentListWidget::onOpen);
+    connect(manager, &DocumentManager::closed, this, &DocumentListWidget::onClose);
+    connect(manager, &DocumentManager::saved, this, &DocumentListWidget::onSaved);
+    connect(this, &DocumentListWidget::itemPressed, this, &DocumentListWidget::onItemClicked);
 
     setDragDropMode(QAbstractItemView::InternalMove);
 }

--- a/editors/sc-ide/widgets/documents_dialog.cpp
+++ b/editors/sc-ide/widgets/documents_dialog.cpp
@@ -40,7 +40,7 @@ DocumentsDialog::DocumentsDialog(const QList<Document*>& docs, Mode mode, QWidge
 
 void DocumentsDialog::init(Mode mode, const QList<Document*>& docs) {
     DocumentManager* mng = Main::documentManager();
-    connect(mng, SIGNAL(changedExternally(Document*)), this, SLOT(onDocumentChangedExternally(Document*)));
+    connect(mng, &DocumentManager::changedExternally, this, &DocumentsDialog::onDocumentChangedExternally);
 
     mMode = mode;
 
@@ -83,38 +83,38 @@ void DocumentsDialog::init(Mode mode, const QList<Document*>& docs) {
     if (mode == ExternalChange) {
         defaultBtn = btn = dialogBtnBox->addButton(tr("&Reload"), QDialogButtonBox::ActionRole);
         btn->setIcon(QIcon::fromTheme("view-refresh"));
-        connect(btn, SIGNAL(clicked()), this, SLOT(reloadSelected()));
+        connect(btn, &QPushButton::clicked, this, &DocumentsDialog::reloadSelected);
 
         btn = dialogBtnBox->addButton(tr("Over&write"), QDialogButtonBox::ActionRole);
         btn->setIcon(QIcon::fromTheme("document-save"));
-        connect(btn, SIGNAL(clicked()), this, SLOT(saveSelected()));
+        connect(btn, &QPushButton::clicked, this, &DocumentsDialog::saveSelected);
 
         btn = dialogBtnBox->addButton(tr("&Ignore"), QDialogButtonBox::AcceptRole);
         btn->setIcon(QIcon::fromTheme("window-close"));
-        connect(btn, SIGNAL(clicked()), this, SLOT(ignoreSelected()));
+        connect(btn, &QPushButton::clicked, this, &DocumentsDialog::ignoreSelected);
 
         btn = dialogBtnBox->addButton(tr("&Close"), QDialogButtonBox::AcceptRole);
         btn->setIcon(QIcon::fromTheme("window-close"));
-        connect(btn, SIGNAL(clicked()), this, SLOT(closeSelected()));
+        connect(btn, &QPushButton::clicked, this, &DocumentsDialog::closeSelected);
     } else {
         defaultBtn = btn = dialogBtnBox->addButton(tr("&Save"), QDialogButtonBox::ActionRole);
         btn->setIcon(QIcon::fromTheme("document-save"));
-        connect(btn, SIGNAL(clicked()), this, SLOT(saveSelected()));
+        connect(btn, &QPushButton::clicked, this, &DocumentsDialog::saveSelected);
 
         btn = dialogBtnBox->addButton(tr("&Discard"), QDialogButtonBox::ActionRole);
         btn->setIcon(QIcon::fromTheme("window-close"));
-        connect(btn, SIGNAL(clicked()), this, SLOT(ignoreSelected()));
+        connect(btn, &QPushButton::clicked, this, &DocumentsDialog::ignoreSelected);
 
         btn = dialogBtnBox->addButton(tr("&Cancel"), QDialogButtonBox::RejectRole);
         btn->setIcon(QIcon::fromTheme("window-close"));
-        connect(btn, SIGNAL(clicked()), this, SLOT(reject()));
+        connect(btn, &QPushButton::clicked, this, &DocumentsDialog::reject);
     }
 
     QPushButton* selectAllBtn = new QPushButton(tr("Select &All"));
-    connect(selectAllBtn, SIGNAL(clicked()), this, SLOT(selectAll()));
+    connect(selectAllBtn, &QPushButton::clicked, this, &DocumentsDialog::selectAll);
 
     QPushButton* selectNoneBtn = new QPushButton(tr("Select N&one"));
-    connect(selectNoneBtn, SIGNAL(clicked()), this, SLOT(selectNone()));
+    connect(selectNoneBtn, &QPushButton::clicked, this, &DocumentsDialog::selectNone);
 
     QLabel* iconLabel = new QLabel;
     iconLabel->setPixmap(QApplication::style()->standardIcon(QStyle::SP_MessageBoxWarning).pixmap(48, 48));

--- a/editors/sc-ide/widgets/editor_box.cpp
+++ b/editors/sc-ide/widgets/editor_box.cpp
@@ -52,16 +52,15 @@ CodeEditorBox::CodeEditorBox(MultiSplitter* splitter, QWidget* parent): QWidget(
     mProxyModel->sort(0);
     mDocComboBox->setModel(mProxyModel);
 
-    connect(mDocComboBox, SIGNAL(currentIndexChanged(int)), this, SLOT(onComboSelectionChanged(int)),
+    connect(mDocComboBox, &QComboBox::currentIndexChanged, this, &CodeEditorBox::onComboSelectionChanged,
             Qt::QueuedConnection);
 
-    connect(Main::documentManager(), SIGNAL(closed(Document*)), this, SLOT(onDocumentClosed(Document*)));
-    connect(Main::documentManager(), SIGNAL(saved(Document*)), this, SLOT(onDocumentSaved(Document*)));
-    connect(Main::instance(), SIGNAL(applySettingsRequest(Settings::Manager*)), this,
-            SLOT(applySettings(Settings::Manager*)));
+    connect(Main::documentManager(), &DocumentManager::closed, this, &CodeEditorBox::onDocumentClosed);
+    connect(Main::documentManager(), &DocumentManager::saved, this, &CodeEditorBox::onDocumentSaved);
+    connect(Main::instance(), &Main::applySettingsRequest, this, &CodeEditorBox::applySettings);
 
-    connect(mSplitter->editor(), SIGNAL(splitViewActivated()), this, SLOT(comboBoxWhenSplitting()));
-    connect(mSplitter->editor(), SIGNAL(splitViewDeactivated()), this, SLOT(tabsWhenRemovingSplits()));
+    connect(mSplitter->editor(), &MultiEditor::splitViewActivated, this, &CodeEditorBox::comboBoxWhenSplitting);
+    connect(mSplitter->editor(), &MultiEditor::splitViewDeactivated, this, &CodeEditorBox::tabsWhenRemovingSplits);
 
     applySettings(Main::settings());
 }
@@ -121,7 +120,7 @@ void CodeEditorBox::setDocument(Document* doc, int pos, int selectionLength) {
             editor->installEventFilter(this);
             mHistory.prepend(editor);
             mLayout->addWidget(editor);
-            connect(this, SIGNAL(activeChanged(bool)), editor, SLOT(setActiveAppearance(bool)));
+            connect(this, &CodeEditorBox::activeChanged, editor, &GenericCodeEditor::setActiveAppearance);
         } else {
             mHistory.removeOne(editor);
             mHistory.prepend(editor);

--- a/editors/sc-ide/widgets/editor_box.cpp
+++ b/editors/sc-ide/widgets/editor_box.cpp
@@ -51,10 +51,14 @@ CodeEditorBox::CodeEditorBox(MultiSplitter* splitter, QWidget* parent): QWidget(
     mProxyModel->setSortCaseSensitivity(Qt::CaseInsensitive);
     mProxyModel->sort(0);
     mDocComboBox->setModel(mProxyModel);
-
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+    // overload can not be resolved, so we use a lambda function
+    connect(mDocComboBox, &QComboBox::currentIndexChanged, this,
+            [=](int index) { this->onComboSelectionChanged(index); });
+#else
     connect(mDocComboBox, &QComboBox::currentIndexChanged, this, &CodeEditorBox::onComboSelectionChanged,
             Qt::QueuedConnection);
-
+#endif
     connect(Main::documentManager(), &DocumentManager::closed, this, &CodeEditorBox::onDocumentClosed);
     connect(Main::documentManager(), &DocumentManager::saved, this, &CodeEditorBox::onDocumentSaved);
     connect(Main::instance(), &Main::applySettingsRequest, this, &CodeEditorBox::applySettings);

--- a/editors/sc-ide/widgets/editor_box.cpp
+++ b/editors/sc-ide/widgets/editor_box.cpp
@@ -52,9 +52,9 @@ CodeEditorBox::CodeEditorBox(MultiSplitter* splitter, QWidget* parent): QWidget(
     mProxyModel->sort(0);
     mDocComboBox->setModel(mProxyModel);
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
-    // overload can not be resolved, so we use a lambda function
-    connect(mDocComboBox, &QComboBox::currentIndexChanged, this,
-            [=](int index) { this->onComboSelectionChanged(index); });
+    // use old connect style b/c of problems regarding overloaded signal which is resolved in Qt6
+    connect(mDocComboBox, SIGNAL(currentIndexChanged(int)), this, SLOT(onComboSelectionChanged(int)),
+            Qt::QueuedConnection);
 #else
     connect(mDocComboBox, &QComboBox::currentIndexChanged, this, &CodeEditorBox::onComboSelectionChanged,
             Qt::QueuedConnection);

--- a/editors/sc-ide/widgets/find_replace_tool.cpp
+++ b/editors/sc-ide/widgets/find_replace_tool.cpp
@@ -109,27 +109,27 @@ TextFindReplacePanel::TextFindReplacePanel(QWidget* parent):
     QWidget::setTabOrder(mFindField, mReplaceField);
     mFindField->installEventFilter(this);
 
-    connect(mNextBtn, SIGNAL(clicked()), this, SLOT(findNext()));
-    connect(mPrevBtn, SIGNAL(clicked()), this, SLOT(findPrevious()));
-    connect(mReplaceBtn, SIGNAL(clicked()), this, SLOT(replace()));
-    connect(mReplaceAllBtn, SIGNAL(clicked()), this, SLOT(replaceAll()));
-    connect(mFindField, SIGNAL(returnPressed()), this, SLOT(onFindFieldReturn()));
-    connect(mFindField, SIGNAL(textChanged(QString)), this, SLOT(onFindFieldTextChanged()));
-    connect(mReplaceField, SIGNAL(returnPressed()), this, SLOT(replace()));
+    connect(mNextBtn, &QToolButton::clicked, this, &TextFindReplacePanel::findNext);
+    connect(mPrevBtn, &QToolButton::clicked, this, &TextFindReplacePanel::findPrevious);
+    connect(mReplaceBtn, &QToolButton::clicked, this, &TextFindReplacePanel::replace);
+    connect(mReplaceAllBtn, &QToolButton::clicked, this, &TextFindReplacePanel::replaceAll);
+    connect(mFindField, &QLineEdit::returnPressed, this, &TextFindReplacePanel::onFindFieldReturn);
+    connect(mFindField, &QLineEdit::textChanged, this, &TextFindReplacePanel::onFindFieldTextChanged);
+    connect(mReplaceField, &QLineEdit::returnPressed, this, &TextFindReplacePanel::replace);
     // Update search results when options change:
-    connect(optMenu, SIGNAL(triggered(QAction*)), this, SLOT(findAll()));
+    connect(optMenu, &QMenu::triggered, this, &TextFindReplacePanel::findAll);
 
     Settings::Manager* settings = Main::settings();
     QAction* action;
 
     action = mActions[FindNext] = new QAction(tr("Find Next"), this);
     action->setShortcut(tr("Ctrl+G", "Find Next"));
-    connect(action, SIGNAL(triggered()), this, SLOT(findNext()));
+    connect(action, &QAction::triggered, this, &TextFindReplacePanel::findNext);
     settings->addAction(action, "editor-find-next", tr("Text Editor"));
 
     action = mActions[FindPrevious] = new QAction(tr("Find Previous"), this);
     action->setShortcut(tr("Ctrl+Shift+G", "Find Previous"));
-    connect(action, SIGNAL(triggered()), this, SLOT(findPrevious()));
+    connect(action, &QAction::triggered, this, &TextFindReplacePanel::findPrevious);
     settings->addAction(action, "editor-find-previous", tr("Text Editor"));
 }
 

--- a/editors/sc-ide/widgets/goto_line_tool.hpp
+++ b/editors/sc-ide/widgets/goto_line_tool.hpp
@@ -60,8 +60,8 @@ public:
 
         setFocusProxy(mSpinBox);
 
-        connect(goBtn, SIGNAL(clicked()), this, SLOT(go()));
-        connect(mSpinBox, SIGNAL(editingFinished()), this, SLOT(onEditingFinished()));
+        connect(goBtn, &QToolButton::clicked, this, &GoToLineTool::go);
+        connect(mSpinBox, &QSpinBox::editingFinished, this, &GoToLineTool::onEditingFinished);
     }
 
     void setEditor(GenericCodeEditor* editor) {
@@ -71,7 +71,7 @@ public:
         mEditor = editor;
 
         if (mEditor) {
-            connect(mEditor, SIGNAL(blockCountChanged(int)), this, SLOT(setMaximum(int)));
+            connect(mEditor, &GenericCodeEditor::blockCountChanged, this, &GoToLineTool::setMaximum);
             setMaximum(mEditor->blockCount());
         } else
             setMaximum(0);

--- a/editors/sc-ide/widgets/help_browser.cpp
+++ b/editors/sc-ide/widgets/help_browser.cpp
@@ -108,7 +108,12 @@ HelpBrowser::HelpBrowser(QWidget* parent): QWidget(parent) {
 
     ScProcess* scProcess = Main::scProcess();
     connect(scProcess, &ScProcess::response, this, &HelpBrowser::onScResponse);
+#    if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+    // use lambda function b/c argument mismatch is not resolved within Qt5 and creates an error
+    connect(scProcess, &ScProcess::finished, mLoadProgressIndicator, [=]() { mLoadProgressIndicator->stop(); });
+#    else
     connect(scProcess, &ScProcess::finished, mLoadProgressIndicator, &LoadProgressIndicator::stop);
+#    endif
     // FIXME: should actually respond to class library shutdown, but we don't have that signal
     connect(scProcess, &ScProcess::classLibraryRecompiled, mLoadProgressIndicator, &LoadProgressIndicator::stop);
 

--- a/editors/sc-ide/widgets/help_browser.cpp
+++ b/editors/sc-ide/widgets/help_browser.cpp
@@ -58,6 +58,8 @@
 
 namespace ScIDE {
 
+using namespace QtCollider;
+
 HelpBrowser::HelpBrowser(QWidget* parent): QWidget(parent) {
     QRect availableScreenRect = qApp->primaryScreen()->availableGeometry();
     mSizeHint = QSize(availableScreenRect.width() * 0.4, availableScreenRect.height() * 0.7);
@@ -69,7 +71,7 @@ HelpBrowser::HelpBrowser(QWidget* parent): QWidget(parent) {
     profile->setPersistentCookiesPolicy(QWebEngineProfile::ForcePersistentCookies);
 
     // setPage does not take ownership of webPage; it must be deleted manually later (see below)
-    mWebView = new QtCollider::WebView(this, profile);
+    mWebView = new WebView(this, profile);
     mWebView->setContextMenuPolicy(Qt::CustomContextMenu);
 
     // Set the style's standard palette to avoid system's palette incoherencies
@@ -93,22 +95,22 @@ HelpBrowser::HelpBrowser(QWidget* parent): QWidget(parent) {
     layout->addWidget(mWebView);
     setLayout(layout);
 
-    connect(mWebView, SIGNAL(loadStarted()), mLoadProgressIndicator, SLOT(start()));
-    connect(mWebView, SIGNAL(loadFinished(bool)), this, SLOT(onPageLoad()));
-    connect(mWebView, SIGNAL(customContextMenuRequested(QPoint)), this, SLOT(onContextMenuRequest(QPoint)));
+    connect(mWebView, &WebView::loadStarted, mLoadProgressIndicator, [=]() { mLoadProgressIndicator->start(); });
+    connect(mWebView, &WebView::loadFinished, this, &HelpBrowser::onPageLoad);
+    connect(mWebView, &WebView::customContextMenuRequested, this, &HelpBrowser::onContextMenuRequest);
 
     mWebView->setOverrideNavigation(true);
     connect(mWebView->page(), SIGNAL(navigationRequested(const QUrl&, QWebEnginePage::NavigationType, bool)), this,
             SLOT(onLinkClicked(const QUrl&, QWebEnginePage::NavigationType, bool)));
     mWebView->setDelegateReload(true);
-    connect(mWebView->page()->action(QWebEnginePage::Reload), SIGNAL(triggered(bool)), this, SLOT(onReload()));
-    connect(mWebView, SIGNAL(jsConsoleMsg(QString, int, QString)), this, SLOT(onJsConsoleMsg(QString, int, QString)));
+    connect(mWebView->page()->action(QWebEnginePage::Reload), &QAction::triggered, this, &HelpBrowser::onReload);
+    connect(mWebView, &WebView::jsConsoleMsg, this, &HelpBrowser::onJsConsoleMsg);
 
     ScProcess* scProcess = Main::scProcess();
-    connect(scProcess, SIGNAL(response(QString, QString)), this, SLOT(onScResponse(QString, QString)));
-    connect(scProcess, SIGNAL(finished(int)), mLoadProgressIndicator, SLOT(stop()));
+    connect(scProcess, &ScProcess::response, this, &HelpBrowser::onScResponse);
+    connect(scProcess, &ScProcess::finished, mLoadProgressIndicator, &LoadProgressIndicator::stop);
     // FIXME: should actually respond to class library shutdown, but we don't have that signal
-    connect(scProcess, SIGNAL(classLibraryRecompiled()), mLoadProgressIndicator, SLOT(stop()));
+    connect(scProcess, &ScProcess::classLibraryRecompiled, mLoadProgressIndicator, &LoadProgressIndicator::stop);
 
     // Legacy mac build support -- with Qt 5.9.3 this causes a segfault on application exit.
 #    if QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)
@@ -138,27 +140,27 @@ void HelpBrowser::createActions() {
     OverridingAction* ovrAction;
 
     mActions[GoHome] = action = new QAction(tr("Home"), this);
-    connect(action, SIGNAL(triggered()), this, SLOT(goHome()));
+    connect(action, &QAction::triggered, this, &HelpBrowser::goHome);
 
     mActions[DocClose] = ovrAction = new OverridingAction(tr("Close"), this);
-    connect(ovrAction, SIGNAL(triggered()), this, SLOT(closeDocument()));
+    connect(ovrAction, &QAction::triggered, this, &HelpBrowser::closeDocument);
     ovrAction->addToWidget(this);
 
     mActions[ZoomIn] = ovrAction = new OverridingAction(tr("Zoom In"), this);
-    connect(ovrAction, SIGNAL(triggered()), this, SLOT(zoomIn()));
+    connect(ovrAction, &QAction::triggered, this, &HelpBrowser::zoomIn);
     ovrAction->addToWidget(this);
 
     mActions[ZoomOut] = ovrAction = new OverridingAction(tr("Zoom Out"), this);
-    connect(ovrAction, SIGNAL(triggered()), this, SLOT(zoomOut()));
+    connect(ovrAction, &QAction::triggered, this, &HelpBrowser::zoomOut);
     ovrAction->addToWidget(this);
 
     mActions[ResetZoom] = ovrAction = new OverridingAction(tr("Reset Zoom"), this);
-    connect(ovrAction, SIGNAL(triggered()), this, SLOT(resetZoom()));
+    connect(ovrAction, &QAction::triggered, this, &HelpBrowser::zoomOut);
     ovrAction->addToWidget(this);
 
     // eval actions are added to mWebView->focusProxy() in onPageLoad()
     mActions[Evaluate] = ovrAction = new OverridingAction(tr("Evaluate as Code"), this);
-    connect(ovrAction, SIGNAL(triggered()), this, SLOT(evaluateSelection()));
+    connect(ovrAction, &QAction::triggered, this, &HelpBrowser::evaluateSelection);
     mActions[EvaluateRegion] = new OverridingAction(tr("Evaluate as Code Region"), this);
     connect(mActions[EvaluateRegion], &OverridingAction::triggered, this, [=]() { this->evaluateSelection(true); });
     // For the sake of display:
@@ -170,7 +172,7 @@ void HelpBrowser::createActions() {
     auto proxyPageAction = [this](QAction* pageAction) {
         // OverridingAction limits shortcut context to this widget
         auto ovrAction = new OverridingAction(pageAction->icon(), pageAction->text(), this);
-        connect(ovrAction, SIGNAL(triggered()), pageAction, SLOT(trigger()));
+        connect(ovrAction, &OverridingAction::triggered, pageAction, &QAction::trigger);
         // disable pageAction shortcut and assign it to ovrAction instead
         ovrAction->setShortcut(pageAction->shortcut());
         pageAction->setShortcut(QKeySequence());
@@ -510,17 +512,17 @@ HelpBrowserDocklet::HelpBrowserDocklet(QWidget* parent): Docklet(tr("Help browse
     toolBar()->addAction(mHelpBrowser->mActions[HelpBrowser::Reload]);
     toolBar()->addWidget(mFindBox);
 
-    connect(mFindBox, SIGNAL(query(QString, bool)), mHelpBrowser, SLOT(findText(QString, bool)));
+    connect(mFindBox, &HelpBrowserFindBox::query, mHelpBrowser, &HelpBrowser::findText);
 
-    connect(Main::scProcess(), SIGNAL(started()), this, SLOT(onInterpreterStart()));
+    connect(Main::scProcess(), &ScProcess::started, this, &HelpBrowserDocklet::onInterpreterStart);
 
     OverridingAction* action;
     action = new OverridingAction(this);
     action->setShortcut(QKeySequence::Find);
     action->addToWidget(mHelpBrowser);
     action->addToWidget(toolBar());
-    connect(action, SIGNAL(triggered(bool)), mFindBox, SLOT(setFocus()));
-    connect(action, SIGNAL(triggered(bool)), mFindBox, SLOT(selectAll()));
+    connect(action, &QAction::triggered, mFindBox, [=]() { mFindBox->setFocus(); });
+    connect(action, &QAction::triggered, mFindBox, &HelpBrowserFindBox::selectAll);
 }
 
 } // namespace ScIDE

--- a/editors/sc-ide/widgets/help_browser.cpp
+++ b/editors/sc-ide/widgets/help_browser.cpp
@@ -109,8 +109,8 @@ HelpBrowser::HelpBrowser(QWidget* parent): QWidget(parent) {
     ScProcess* scProcess = Main::scProcess();
     connect(scProcess, &ScProcess::response, this, &HelpBrowser::onScResponse);
 #    if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
-    // use lambda function b/c argument mismatch is not resolved within Qt5 and creates an error
-    connect(scProcess, &ScProcess::finished, mLoadProgressIndicator, [=]() { mLoadProgressIndicator->stop(); });
+    // use old connect style b/c of problems regarding overloaded signal which is resolved in Qt6
+    connect(scProcess, SIGNAL(finished(int)), mLoadProgressIndicator, SLOT(stop()));
 #    else
     connect(scProcess, &ScProcess::finished, mLoadProgressIndicator, &LoadProgressIndicator::stop);
 #    endif

--- a/editors/sc-ide/widgets/lang_status_box.cpp
+++ b/editors/sc-ide/widgets/lang_status_box.cpp
@@ -38,8 +38,7 @@ LangStatusBox::LangStatusBox(ScProcess* lang, QWidget* parent): StatusBox(parent
     addAction(lang->action(ScProcess::Restart));
     addAction(lang->action(ScProcess::RecompileClassLibrary));
 
-    connect(lang, SIGNAL(stateChanged(QProcess::ProcessState)), this,
-            SLOT(onInterpreterStateChanged(QProcess::ProcessState)));
+    connect(lang, &ScProcess::stateChanged, this, &LangStatusBox::onInterpreterStateChanged);
 
     // initialize formats from settings:
     auto const main = Main::instance();

--- a/editors/sc-ide/widgets/lookup_dialog.cpp
+++ b/editors/sc-ide/widgets/lookup_dialog.cpp
@@ -65,9 +65,9 @@ GenericLookupDialog::GenericLookupDialog(QWidget* parent): QDialog(parent) {
 
     setLayout(layout);
 
-    connect(mQueryEdit, SIGNAL(returnPressed()), this, SLOT(performQuery()));
-    connect(mResult, SIGNAL(doubleClicked(QModelIndex)), this, SLOT(onAccepted(QModelIndex)));
-    connect(mResult, SIGNAL(activated(QModelIndex)), this, SLOT(onAccepted(QModelIndex)));
+    connect(mQueryEdit, &QLineEdit::returnPressed, this, &GenericLookupDialog::performQuery);
+    connect(mResult, &QTreeView::doubleClicked, this, &GenericLookupDialog::onAccepted);
+    connect(mResult, &QTreeView::activated, this, &GenericLookupDialog::onAccepted);
 
     mResult->installEventFilter(this);
 
@@ -95,8 +95,8 @@ void GenericLookupDialog::setModel(QStandardItemModel* model) {
 
     if (mResult->selectionModel()) {
         mPreviewEditor->setActiveAppearance(true);
-        connect(mResult->selectionModel(), SIGNAL(currentChanged(const QModelIndex&, const QModelIndex&)), this,
-                SLOT(currentChanged(const QModelIndex&, const QModelIndex&)));
+        connect(mResult->selectionModel(), &QItemSelectionModel::currentChanged, this,
+                &GenericLookupDialog::currentChanged);
     } else {
         mPreviewEditor->setActiveAppearance(false);
     }
@@ -466,8 +466,8 @@ bool LookupDialog::performPartialQuery(const QString& queryString) {
 
 ReferencesDialog::ReferencesDialog(QWidget* parent): LookupDialog(parent) {
     mRequest = new SymbolReferenceRequest(Main::scProcess(), this);
-    connect(mRequest, SIGNAL(response(QString, QString)), this, SLOT(onResposeFromLanguage(QString, QString)));
-    connect(mRequest, SIGNAL(cancelled()), this, SLOT(requestCancelled()));
+    connect(mRequest, &SymbolReferenceRequest::response, this, &ReferencesDialog::onResposeFromLanguage);
+    connect(mRequest, &SymbolReferenceRequest::cancelled, this, &ReferencesDialog::requestCancelled);
 
     setWindowTitle(tr("Look Up References"));
 

--- a/editors/sc-ide/widgets/main_window.cpp
+++ b/editors/sc-ide/widgets/main_window.cpp
@@ -117,12 +117,12 @@ MainWindow::MainWindow(Main* main): mMain(main), mClockLabel(0), mDocDialog(0) {
     // Tools
 
     mCmdLine = new CmdLine(tr("Command Line:"));
-    connect(mCmdLine, SIGNAL(invoked(QString, bool)), main->scProcess(), SLOT(evaluateCode(QString, bool)));
+    connect(mCmdLine, &CmdLine::invoked, main->scProcess(), &ScProcess::evaluateCode);
 
     mFindReplaceTool = new TextFindReplacePanel;
 
     mGoToLineTool = new GoToLineTool();
-    connect(mGoToLineTool, SIGNAL(activated(int)), this, SLOT(hideToolBox()));
+    connect(mGoToLineTool, &GoToLineTool::activated, this, &MainWindow::hideToolBox);
 
     mToolBox = new ToolBox;
     mToolBox->addWidget(mCmdLine);
@@ -159,42 +159,40 @@ MainWindow::MainWindow(Main* main): mMain(main), mClockLabel(0), mDocDialog(0) {
     setCentralWidget(central);
 
     // Session management
-    connect(main->sessionManager(), SIGNAL(saveSessionRequest(Session*)), this, SLOT(saveSession(Session*)));
-    connect(main->sessionManager(), SIGNAL(switchSessionRequest(Session*)), this, SLOT(switchSession(Session*)));
+    connect(main->sessionManager(), &SessionManager::saveSessionRequest, this, &MainWindow::saveSession);
+    connect(main->sessionManager(), &SessionManager::switchSessionRequest, this, &MainWindow::switchSession);
     connect(main->sessionManager(), SIGNAL(currentSessionNameChanged()), this, SLOT(updateWindowTitle()));
     // A system for easy evaluation of pre-defined code:
-    connect(this, SIGNAL(evaluateCode(QString, bool)), main->scProcess(), SLOT(evaluateCode(QString, bool)));
+    connect(this, &MainWindow::evaluateCode, main->scProcess(), &ScProcess::evaluateCode);
     // Interpreter: post output
-    connect(main->scProcess(), SIGNAL(scPost(QString)), mPostDocklet->mPostWindow, SLOT(post(QString)));
+    connect(main->scProcess(), &ScProcess::scPost, mPostDocklet->mPostWindow, &PostWindow::post);
     // Interpreter: monitor running state
-    connect(main->scProcess(), SIGNAL(stateChanged(QProcess::ProcessState)), this,
-            SLOT(onInterpreterStateChanged(QProcess::ProcessState)));
+    connect(main->scProcess(), &ScProcess::stateChanged, this, &MainWindow::onInterpreterStateChanged);
     // Interpreter: forward status messages
-    connect(main->scProcess(), SIGNAL(statusMessage(const QString&)), this, SLOT(showStatusMessage(const QString&)));
+    connect(main->scProcess(), &ScProcess::statusMessage, this, &MainWindow::showStatusMessage);
 
     // Document list interaction
-    connect(mDocumentsDocklet->list(), SIGNAL(clicked(Document*)), mEditors, SLOT(setCurrent(Document*)));
-    connect(mEditors, SIGNAL(currentDocumentChanged(Document*)), mDocumentsDocklet->list(), SLOT(setCurrent(Document*)),
+    connect(mDocumentsDocklet->list(), &DocumentListWidget::clicked, mEditors, &MultiEditor::setCurrent);
+    connect(mEditors, &MultiEditor::currentDocumentChanged, mDocumentsDocklet->list(), &DocumentListWidget::setCurrent,
             Qt::QueuedConnection);
-    connect(mDocumentsDocklet->list(), SIGNAL(updateTabsOrder(QList<Document*>)), mEditors,
-            SLOT(updateTabsOrder(QList<Document*>)));
-    connect(mEditors, SIGNAL(updateDockletOrder(int, int)), mDocumentsDocklet->list(),
-            SLOT(updateDockletOrder(int, int)), Qt::QueuedConnection);
+    connect(mDocumentsDocklet->list(), &DocumentListWidget::updateTabsOrder, mEditors, &MultiEditor::updateTabsOrder);
+    connect(mEditors, &MultiEditor::updateDockletOrder, mDocumentsDocklet->list(),
+            &DocumentListWidget::updateDockletOrder, Qt::QueuedConnection);
 
     // Update actions on document change
-    connect(mEditors, SIGNAL(currentDocumentChanged(Document*)), this, SLOT(onCurrentDocumentChanged(Document*)));
+    connect(mEditors, &MultiEditor::currentDocumentChanged, this, &MainWindow::onCurrentDocumentChanged);
     // Document management
     DocumentManager* docMng = main->documentManager();
-    connect(docMng, SIGNAL(changedExternally(Document*)), this, SLOT(onDocumentChangedExternally(Document*)));
-    connect(docMng, SIGNAL(recentsChanged()), this, SLOT(updateRecentDocsMenu()));
-    connect(docMng, SIGNAL(saved(Document*)), this, SLOT(updateWindowTitle()));
-    connect(docMng, SIGNAL(titleChanged(Document*)), this, SLOT(updateWindowTitle()));
+    connect(docMng, &DocumentManager::changedExternally, this, &MainWindow::onDocumentChangedExternally);
+    connect(docMng, &DocumentManager::recentsChanged, this, &MainWindow::updateRecentDocsMenu);
+    connect(docMng, &DocumentManager::saved, this, &MainWindow::updateWindowTitle);
+    connect(docMng, &DocumentManager::titleChanged, this, &MainWindow::updateWindowTitle);
 
-    connect(main, SIGNAL(applySettingsRequest(Settings::Manager*)), this, SLOT(applySettings(Settings::Manager*)));
-    connect(main, SIGNAL(storeSettingsRequest(Settings::Manager*)), this, SLOT(storeSettings(Settings::Manager*)));
+    connect(main, &Main::applySettingsRequest, this, &MainWindow::applySettings);
+    connect(main, &Main::storeSettingsRequest, this, &MainWindow::storeSettings);
 
     // ToolBox
-    connect(mToolBox->closeButton(), SIGNAL(clicked()), this, SLOT(hideToolBox()));
+    connect(mToolBox->closeButton(), &QAbstractButton::clicked, this, &MainWindow::hideToolBox);
 
     createActions();
     createMenus();
@@ -250,91 +248,91 @@ void MainWindow::createActions() {
     mActions[DocNew] = action = new QAction(QIcon::fromTheme("document-new"), tr("&New"), this);
     action->setShortcut(tr("Ctrl+N", "New document"));
     action->setStatusTip(tr("Create a new document"));
-    connect(action, SIGNAL(triggered()), this, SLOT(newDocument()));
+    connect(action, &QAction::triggered, this, &MainWindow::newDocument);
     settings->addAction(action, "ide-document-new", ideCategory);
 
     mActions[DocOpen] = action = new QAction(QIcon::fromTheme("document-open"), tr("&Open..."), this);
     action->setShortcut(tr("Ctrl+O", "Open document"));
     action->setStatusTip(tr("Open an existing file"));
-    connect(action, SIGNAL(triggered()), this, SLOT(openDocument()));
+    connect(action, &QAction::triggered, this, &MainWindow::openDocument);
     settings->addAction(action, "ide-document-open", ideCategory);
 
     mActions[DocOpenStartup] = action = new QAction(QIcon::fromTheme("document-open"), tr("Open startup file"), this);
     action->setStatusTip(tr("Open startup file"));
-    connect(action, SIGNAL(triggered()), this, SLOT(openStartupFile()));
+    connect(action, &QAction::triggered, this, &MainWindow::openStartupFile);
     settings->addAction(action, "ide-document-open-startup", ideCategory);
 
     mActions[DocOpenSupportDir] = action =
         new QAction(QIcon::fromTheme("document-open"), tr("Open user support directory"), this);
     action->setStatusTip(tr("Open user support directory"));
-    connect(action, SIGNAL(triggered()), this, SLOT(openUserSupportDirectory()));
+    connect(action, &QAction::triggered, this, &MainWindow::openUserSupportDirectory);
     settings->addAction(action, "ide-document-open-support-directory", ideCategory);
 
     mActions[DocOpenExamplesDir] = action =
         new QAction(QIcon::fromTheme("document-example"), tr("Open examples directory"), this);
     action->setStatusTip(tr("Open examples directory"));
-    connect(action, SIGNAL(triggered()), this, SLOT(openExamplesDirectory()));
+    connect(action, &QAction::triggered, this, &MainWindow::openExamplesDirectory);
     settings->addAction(action, "ide-document-open-examples-directory", ideCategory);
 
     mActions[DocSave] = action = new QAction(QIcon::fromTheme("document-save"), tr("&Save"), this);
     action->setShortcut(tr("Ctrl+S", "Save document"));
     action->setStatusTip(tr("Save the current document"));
-    connect(action, SIGNAL(triggered()), this, SLOT(saveDocument()));
+    connect(action, &QAction::triggered, this, &MainWindow::saveDocument);
     settings->addAction(action, "ide-document-save", ideCategory);
 
     mActions[DocSaveAs] = action = new QAction(QIcon::fromTheme("document-save-as"), tr("Save &As..."), this);
     action->setShortcut(tr("Ctrl+Shift+S", "Save &As..."));
     action->setStatusTip(tr("Save the current document into a different file"));
-    connect(action, SIGNAL(triggered()), this, SLOT(saveDocumentAs()));
+    connect(action, &QAction::triggered, this, &MainWindow::saveDocumentAs);
     settings->addAction(action, "ide-document-save-as", ideCategory);
 
     mActions[DocSaveAsExtension] = action =
         new QAction(QIcon::fromTheme("document-save-as"), tr("Save As Extension..."), this);
     action->setStatusTip(tr("Save the current document into a different file in the extensions folder"));
-    connect(action, SIGNAL(triggered()), this, SLOT(saveDocumentAsExtension()));
+    connect(action, &QAction::triggered, this, &MainWindow::saveDocumentAsExtension);
     settings->addAction(action, "ide-document-save-as-extension", ideCategory);
 
     mActions[DocSaveAll] = action = new QAction(QIcon::fromTheme("document-save"), tr("Save All..."), this);
     action->setShortcut(tr("Ctrl+Alt+S", "Save all documents"));
     action->setStatusTip(tr("Save all open documents"));
-    connect(action, SIGNAL(triggered()), this, SLOT(saveAllDocuments()));
+    connect(action, &QAction::triggered, this, &MainWindow::saveAllDocuments);
     settings->addAction(action, "ide-document-save-all", ideCategory);
 
     mActions[DocCloseAll] = action = new QAction(QIcon::fromTheme("window-close"), tr("Close All..."), this);
     action->setShortcut(tr("Ctrl+Shift+W", "Close all documents"));
     action->setStatusTip(tr("Close all documents"));
-    connect(action, SIGNAL(triggered()), this, SLOT(closeAllDocuments()));
+    connect(action, &QAction::triggered, this, &MainWindow::closeAllDocuments);
     settings->addAction(action, "ide-document-close-all", ideCategory);
 
     mActions[DocReload] = action = new QAction(QIcon::fromTheme("view-refresh"), tr("&Reload"), this);
     action->setShortcut(tr("F5", "Reload document"));
     action->setStatusTip(tr("Reload the current document"));
-    connect(action, SIGNAL(triggered()), this, SLOT(reloadDocument()));
+    connect(action, &QAction::triggered, this, &MainWindow::reloadDocument);
     settings->addAction(action, "ide-document-reload", ideCategory);
 
     mActions[ClearRecentDocs] = action = new QAction(tr("Clear", "Clear recent documents"), this);
     action->setStatusTip(tr("Clear list of recent documents"));
-    connect(action, SIGNAL(triggered()), Main::instance()->documentManager(), SLOT(clearRecents()));
+    connect(action, &QAction::triggered, Main::instance()->documentManager(), &DocumentManager::clearRecents);
     settings->addAction(action, "ide-clear-recent-documents", ideCategory);
 
     // Sessions
     mActions[NewSession] = action = new QAction(QIcon::fromTheme("document-new"), tr("&New Session"), this);
     action->setStatusTip(tr("Open a new session"));
-    connect(action, SIGNAL(triggered()), this, SLOT(newSession()));
+    connect(action, &QAction::triggered, this, &MainWindow::newSession);
     settings->addAction(action, "ide-session-new", ideCategory);
 
     mActions[SaveSessionAs] = action =
         new QAction(QIcon::fromTheme("document-save-as"), tr("Save Session &As..."), this);
     action->setStatusTip(tr("Save the current session with a different name"));
-    connect(action, SIGNAL(triggered()), this, SLOT(saveCurrentSessionAs()));
+    connect(action, &QAction::triggered, this, &MainWindow::saveCurrentSessionAs);
     settings->addAction(action, "ide-session-save-as", ideCategory);
 
     mActions[ManageSessions] = action = new QAction(tr("&Manage Sessions..."), this);
-    connect(action, SIGNAL(triggered()), this, SLOT(openSessionsDialog()));
+    connect(action, &QAction::triggered, this, &MainWindow::openSessionsDialog);
     settings->addAction(action, "ide-session-manage", ideCategory);
 
     mActions[OpenSessionSwitchDialog] = action = new QAction(tr("&Switch Session..."), this);
-    connect(action, SIGNAL(triggered()), this, SLOT(showSwitchSessionDialog()));
+    connect(action, &QAction::triggered, this, &MainWindow::showSwitchSessionDialog);
     action->setShortcut(tr("Ctrl+Shift+Q", "Switch Session"));
     settings->addAction(action, "ide-session-switch", ideCategory);
 
@@ -342,50 +340,50 @@ void MainWindow::createActions() {
     mActions[Find] = action = new QAction(QIcon::fromTheme("edit-find"), tr("&Find..."), this);
     action->setShortcut(tr("Ctrl+F", "Find"));
     action->setStatusTip(tr("Find text in document"));
-    connect(action, SIGNAL(triggered()), this, SLOT(showFindTool()));
+    connect(action, &QAction::triggered, this, &MainWindow::showFindTool);
     settings->addAction(action, "editor-find", editorCategory);
 
     mActions[Replace] = action = new QAction(QIcon::fromTheme("edit-replace"), tr("&Replace..."), this);
     action->setShortcut(tr("Ctrl+R", "Replace"));
     action->setStatusTip(tr("Find and replace text in document"));
-    connect(action, SIGNAL(triggered()), this, SLOT(showReplaceTool()));
+    connect(action, &QAction::triggered, this, &MainWindow::showReplaceTool);
     settings->addAction(action, "editor-replace", editorCategory);
 
     // View
     mActions[ShowCmdLine] = action = new QAction(tr("&Command Line"), this);
     action->setStatusTip(tr("Command line for quick code evaluation"));
     action->setShortcut(tr("Ctrl+E", "Show command line"));
-    connect(action, SIGNAL(triggered()), this, SLOT(showCmdLine()));
+    connect(action, &QAction::triggered, this, [=]() { this->showCmdLine(); });
     settings->addAction(action, "ide-command-line-show", ideCategory);
 
     mActions[CmdLineForCursor] = action = new QAction(tr("&Command Line from selection"), this);
     action->setShortcut(tr("Ctrl+Shift+E", "Fill command line with current selection"));
-    connect(action, SIGNAL(triggered()), this, SLOT(cmdLineForCursor()));
+    connect(action, &QAction::triggered, this, &MainWindow::cmdLineForCursor);
     settings->addAction(action, "ide-command-line-fill", ideCategory);
 
 
     mActions[ShowGoToLineTool] = action = new QAction(tr("&Go To Line"), this);
     action->setStatusTip(tr("Tool to jump to a line by number"));
     action->setShortcut(tr("Ctrl+L", "Show go-to-line tool"));
-    connect(action, SIGNAL(triggered()), this, SLOT(showGoToLineTool()));
+    connect(action, &QAction::triggered, this, &MainWindow::showGoToLineTool);
     settings->addAction(action, "editor-go-to-line", editorCategory);
 
     mActions[CloseToolBox] = action = new QAction(QIcon::fromTheme("window-close"), tr("&Close Tool Panel"), this);
     action->setStatusTip(tr("Close any open tool panel"));
     action->setShortcut(tr("Esc", "Close tool box"));
-    connect(action, SIGNAL(triggered()), this, SLOT(hideToolBox()));
+    connect(action, &QAction::triggered, this, &MainWindow::hideToolBox);
     settings->addAction(action, "ide-tool-panel-hide", ideCategory);
 
     mActions[ShowFullScreen] = action = new QAction(tr("&Full Screen"), this);
     action->setCheckable(false);
     action->setShortcut(tr("Ctrl+Shift+F", "Show ScIDE in Full Screen"));
-    connect(action, SIGNAL(triggered()), this, SLOT(toggleFullScreen()));
+    connect(action, &QAction::triggered, this, &MainWindow::toggleFullScreen);
     settings->addAction(action, "ide-show-fullscreen", ideCategory);
 
     mActions[FocusPostWindow] = action = new QAction(tr("Focus Post Window"), this);
     action->setStatusTip(tr("Focus post window"));
     action->setShortcut(tr("Ctrl+P", "Focus post window"));
-    connect(action, SIGNAL(triggered()), mPostDocklet, SLOT(focus()));
+    connect(action, &QAction::triggered, mPostDocklet, &PostDocklet::focus);
     settings->addAction(action, "post-focus", ideCategory);
 
     // Language
@@ -393,26 +391,26 @@ void MainWindow::createActions() {
         new QAction(QIcon::fromTheme("window-lookupdefinition"), tr("Look Up Implementations..."), this);
     action->setShortcut(tr("Ctrl+Shift+I", "Look Up Implementations"));
     action->setStatusTip(tr("Open dialog to look up implementations of a class or a method"));
-    connect(action, SIGNAL(triggered()), this, SLOT(lookupImplementation()));
+    connect(action, &QAction::triggered, this, &MainWindow::lookupImplementation);
     settings->addAction(action, "ide-lookup-implementation", ideCategory);
 
     mActions[LookupImplementationForCursor] = action = new QAction(tr("Look Up Implementations for Cursor"), this);
     action->setShortcut(tr("Ctrl+I", "Look Up Implementations for Cursor"));
     action->setStatusTip(tr("Look up implementations of class or method under cursor"));
-    connect(action, SIGNAL(triggered(bool)), this, SLOT(lookupImplementationForCursor()));
+    connect(action, &QAction::triggered, this, &MainWindow::lookupImplementationForCursor);
     settings->addAction(action, "ide-lookup-implementation-for-cursor", ideCategory);
 
     mActions[LookupReferences] = action =
         new QAction(QIcon::fromTheme("window-lookupreferences"), tr("Look Up References..."), this);
     action->setShortcut(tr("Ctrl+Shift+U", "Look Up References"));
     action->setStatusTip(tr("Open dialog to look up references to a class or a method"));
-    connect(action, SIGNAL(triggered()), this, SLOT(lookupReferences()));
+    connect(action, &QAction::triggered, this, &MainWindow::lookupReferences);
     settings->addAction(action, "ide-lookup-references", ideCategory);
 
     mActions[LookupReferencesForCursor] = action = new QAction(tr("Look Up References for Cursor"), this);
     action->setShortcut(tr("Ctrl+U", "Look Up References For Selection"));
     action->setStatusTip(tr("Look up references to class or method under cursor"));
-    connect(action, SIGNAL(triggered(bool)), this, SLOT(lookupReferencesForCursor()));
+    connect(action, &QAction::triggered, this, &MainWindow::lookupReferencesForCursor);
     settings->addAction(action, "ide-lookup-references-for-cursor", ideCategory);
 
     // Settings
@@ -421,44 +419,44 @@ void MainWindow::createActions() {
     action->setShortcut(tr("Ctrl+,", "Show configuration dialog"));
 #endif
     action->setStatusTip(tr("Show configuration dialog"));
-    connect(action, SIGNAL(triggered()), this, SLOT(showSettings()));
+    connect(action, &QAction::triggered, this, &MainWindow::showSettings);
     settings->addAction(action, "ide-settings-dialog", ideCategory);
 
     // Help
     mActions[ReportABug] = action = new QAction(QIcon::fromTheme("system-help"), tr("Report a bug..."), this);
     action->setStatusTip(tr("Report a bug"));
-    connect(action, SIGNAL(triggered()), this, SLOT(doBugReport()));
+    connect(action, &QAction::triggered, this, &MainWindow::doBugReport);
 
 #ifdef SC_USE_QTWEBENGINE
     mActions[Help] = action = new QAction(tr("Show &Help Browser"), this);
     action->setStatusTip(tr("Show and focus the Help Browser"));
-    connect(action, SIGNAL(triggered()), this, SLOT(openHelp()));
+    connect(action, &QAction::triggered, this, &MainWindow::openHelp);
     settings->addAction(action, "help-browser", helpCategory);
 
     mActions[HelpAboutIDE] = action =
         new QAction(QIcon::fromTheme("system-help"), tr("How to Use SuperCollider IDE"), this);
     action->setStatusTip(tr("Open the SuperCollider IDE guide"));
-    connect(action, SIGNAL(triggered()), this, SLOT(openHelpAboutIDE()));
+    connect(action, &QAction::triggered, this, &MainWindow::openHelpAboutIDE);
 
     mActions[LookupDocumentationForCursor] = action = new QAction(tr("Look Up Documentation for Cursor"), this);
     action->setShortcut(tr("Ctrl+D", "Look Up Documentation for Cursor"));
     action->setStatusTip(tr("Look up documentation for text under cursor"));
-    connect(action, SIGNAL(triggered()), this, SLOT(lookupDocumentationForCursor()));
+    connect(action, &QAction::triggered, this, &MainWindow::lookupDocumentationForCursor);
     settings->addAction(action, "help-lookup-for-cursor", helpCategory);
 
     mActions[LookupDocumentation] = action = new QAction(tr("Look Up Documentation..."), this);
     action->setShortcut(tr("Ctrl+Shift+D", "Look Up Documentation"));
     action->setStatusTip(tr("Enter text to look up in documentation"));
-    connect(action, SIGNAL(triggered()), this, SLOT(lookupDocumentation()));
+    connect(action, &QAction::triggered, this, &MainWindow::lookupDocumentation);
     settings->addAction(action, "help-lookup", helpCategory);
 #endif // SC_USE_QTWEBENGINE
 
     mActions[ShowAbout] = action = new QAction(QIcon::fromTheme("help-about"), tr("&About SuperCollider"), this);
-    connect(action, SIGNAL(triggered()), this, SLOT(showAbout()));
+    connect(action, &QAction::triggered, this, &MainWindow::showAbout);
     settings->addAction(action, "ide-about", ideCategory);
 
     mActions[ShowAboutQT] = action = new QAction(QIcon::fromTheme("show-about-qt"), tr("About &Qt"), this);
-    connect(action, SIGNAL(triggered()), this, SLOT(showAboutQT()));
+    connect(action, &QAction::triggered, this, &MainWindow::showAboutQT);
     settings->addAction(action, "ide-about-qt", ideCategory);
 
     // Add external actions to settings:
@@ -525,7 +523,7 @@ void MainWindow::createMenus() {
     menu->addAction(mActions[DocNew]);
     menu->addAction(mActions[DocOpen]);
     mRecentDocsMenu = menu->addMenu(tr("Open Recent", "Open a recent document"));
-    connect(mRecentDocsMenu, SIGNAL(triggered(QAction*)), this, SLOT(onOpenRecentDocument(QAction*)));
+    connect(mRecentDocsMenu, &QMenu::triggered, this, &MainWindow::onOpenRecentDocument);
     menu->addAction(mActions[DocOpenStartup]);
     menu->addAction(mActions[DocOpenSupportDir]);
     menu->addAction(mActions[DocOpenExamplesDir]);
@@ -547,7 +545,7 @@ void MainWindow::createMenus() {
     menu->addAction(mActions[NewSession]);
     menu->addAction(mActions[SaveSessionAs]);
     submenu = menu->addMenu(tr("&Open Session"));
-    connect(submenu, SIGNAL(triggered(QAction*)), this, SLOT(onOpenSessionAction(QAction*)));
+    connect(submenu, &QMenu::triggered, this, &MainWindow::onOpenSessionAction);
     mSessionsMenu = submenu;
     updateSessionsMenu();
     menu->addSeparator();
@@ -845,7 +843,7 @@ void MainWindow::onDocumentChangedExternally(Document* doc) {
 
     mDocDialog = new DocumentsDialog(DocumentsDialog::ExternalChange, this);
     mDocDialog->addDocument(doc);
-    connect(mDocDialog, SIGNAL(finished(int)), this, SLOT(onDocDialogFinished()));
+    connect(mDocDialog, &DocumentsDialog::finished, this, &MainWindow::onDocDialogFinished);
     mDocDialog->open();
 }
 

--- a/editors/sc-ide/widgets/multi_editor.cpp
+++ b/editors/sc-ide/widgets/multi_editor.cpp
@@ -71,7 +71,7 @@ public:
         layout->addWidget(mListView);
         layout->setContentsMargins(1, 1, 1, 1);
 
-        connect(mListView, SIGNAL(activated(QModelIndex)), this, SLOT(accept()));
+        connect(mListView, &QListView::activated, this, &DocumentSelectPopUp::accept);
 
         mListView->setFocus(Qt::OtherFocusReason);
 
@@ -293,7 +293,7 @@ MultiEditor::MultiEditor(Main* main, QWidget* parent):
 
     makeSignalConnections();
 
-    connect(main, SIGNAL(applySettingsRequest(Settings::Manager*)), this, SLOT(applySettings(Settings::Manager*)));
+    connect(main, &Main::applySettingsRequest, this, &MultiEditor::applySettings);
 
     createActions();
 
@@ -305,15 +305,15 @@ MultiEditor::MultiEditor(Main* main, QWidget* parent):
 void MultiEditor::makeSignalConnections() {
     DocumentManager* docManager = Main::documentManager();
 
-    connect(docManager, SIGNAL(opened(Document*, int, int)), this, SLOT(onOpen(Document*, int, int)));
-    connect(docManager, SIGNAL(closed(Document*)), this, SLOT(onClose(Document*)));
-    connect(docManager, SIGNAL(saved(Document*)), this, SLOT(update(Document*)));
-    connect(docManager, SIGNAL(showRequest(Document*, int, int)), this, SLOT(show(Document*, int, int)));
-    connect(docManager, SIGNAL(titleChanged(Document*)), this, SLOT(update(Document*)));
+    connect(docManager, &DocumentManager::opened, this, &MultiEditor::onOpen);
+    connect(docManager, &DocumentManager::closed, this, &MultiEditor::onClose);
+    connect(docManager, &DocumentManager::saved, this, &MultiEditor::update);
+    connect(docManager, &DocumentManager::showRequest, this, &MultiEditor::show);
+    connect(docManager, &DocumentManager::titleChanged, this, &MultiEditor::update);
 
-    connect(mTabs, SIGNAL(currentChanged(int)), this, SLOT(onCurrentTabChanged(int)));
-    connect(mTabs, SIGNAL(tabCloseRequested(int)), this, SLOT(onCloseRequest(int)));
-    connect(mTabs, SIGNAL(tabMoved(int, int)), this, SLOT(updateDocOrder(int, int)));
+    connect(mTabs, &QTabBar::currentChanged, this, &MultiEditor::onCurrentTabChanged);
+    connect(mTabs, &QTabBar::tabCloseRequested, this, &MultiEditor::onCloseRequest);
+    connect(mTabs, &QTabBar::tabMoved, this, &MultiEditor::updateDocOrder);
 
     mBoxSigMux->connect(SIGNAL(currentChanged(GenericCodeEditor*)), this,
                         SLOT(onCurrentEditorChanged(GenericCodeEditor*)));
@@ -535,19 +535,19 @@ void MultiEditor::createActions() {
 #else
     action->setShortcut(QKeySequence(Qt::ALT | Qt::Key_E, Qt::ALT | Qt::Key_V));
 #endif
-    connect(action, SIGNAL(triggered(bool)), this, SLOT(setShowWhitespace(bool)));
+    connect(action, &QAction::triggered, this, &MultiEditor::setShowWhitespace);
     settings->addAction(action, "editor-toggle-show-whitespace", editorCategory);
 
     mActions[ShowLinenumber] = action = new QAction(tr("Show Line Number"), this);
     action->setCheckable(true);
     action->setShortcut(tr("Ctrl+Alt+#", "Show Line Number"));
     action->setShortcutContext(Qt::WidgetWithChildrenShortcut);
-    connect(action, SIGNAL(triggered(bool)), this, SLOT(setShowLinenumber(bool)));
+    connect(action, &QAction::triggered, this, &MultiEditor::setShowLinenumber);
     settings->addAction(action, "editor-toggle-show-line-number", editorCategory);
 
     mActions[ShowAutocompleteHelp] = action = new QAction(tr("Show Autocomplete Help"), this);
     action->setCheckable(true);
-    connect(action, SIGNAL(triggered(bool)), this, SLOT(setShowAutocompleteHelp(bool)));
+    connect(action, &QAction::triggered, this, &MultiEditor::setShowAutocompleteHelp);
     settings->addAction(action, "editor-toggle-show-autocomplete-help", editorCategory);
 
     mActions[IndentWithSpaces] = action = new QAction(tr("Use Spaces for Indentation"), this);
@@ -564,7 +564,7 @@ void MultiEditor::createActions() {
 #else
     action->setShortcut(tr("Meta+Tab", "Next Document"));
 #endif
-    connect(action, SIGNAL(triggered()), this, SLOT(showNextDocument()));
+    connect(action, &QAction::triggered, this, &MultiEditor::showNextDocument);
     settings->addAction(action, "editor-document-next", editorCategory);
 
     mActions[PreviousDocument] = action = new QAction(tr("Previous Document"), this);
@@ -573,31 +573,31 @@ void MultiEditor::createActions() {
 #else
     action->setShortcut(tr("Meta+Shift+Tab", "Previous Document"));
 #endif
-    connect(action, SIGNAL(triggered()), this, SLOT(showPreviousDocument()));
+    connect(action, &QAction::triggered, this, &MultiEditor::showPreviousDocument);
     settings->addAction(action, "editor-document-previous", editorCategory);
 
     mActions[SwitchDocument] = action = new QAction(tr("Switch Document"), this);
-    connect(action, SIGNAL(triggered()), this, SLOT(switchDocument()));
+    connect(action, &QAction::triggered, this, &MultiEditor::switchDocument);
     settings->addAction(action, "editor-document-switch", editorCategory);
 
     mActions[SplitHorizontally] = action = new QAction(tr("Split To Right"), this);
     // action->setShortcut( tr("Ctrl+P, 3", "Split To Right"));
-    connect(action, SIGNAL(triggered()), this, SLOT(splitHorizontally()));
+    connect(action, &QAction::triggered, this, &MultiEditor::splitHorizontally);
     settings->addAction(action, "editor-split-right", editorCategory);
 
     mActions[SplitVertically] = action = new QAction(tr("Split To Bottom"), this);
     // action->setShortcut( tr("Ctrl+P, 2", "Split To Bottom"));
-    connect(action, SIGNAL(triggered()), this, SLOT(splitVertically()));
+    connect(action, &QAction::triggered, this, &MultiEditor::splitVertically);
     settings->addAction(action, "editor-split-bottom", editorCategory);
 
     mActions[RemoveCurrentSplit] = action = new QAction(tr("Remove Current Split"), this);
     // action->setShortcut( tr("Ctrl+P, 1", "Remove Current Split"));
-    connect(action, SIGNAL(triggered()), this, SLOT(removeCurrentSplit()));
+    connect(action, &QAction::triggered, this, &MultiEditor::removeCurrentSplit);
     settings->addAction(action, "editor-split-remove", editorCategory);
 
     mActions[RemoveAllSplits] = action = new QAction(tr("Remove All Splits"), this);
     // action->setShortcut( tr("Ctrl+P, 0", "Remove All Splits"));
-    connect(action, SIGNAL(triggered()), this, SLOT(removeAllSplits()));
+    connect(action, &QAction::triggered, this, &MultiEditor::removeAllSplits);
     settings->addAction(action, "editor-split-remove-all", editorCategory);
 
     // Language
@@ -1092,7 +1092,7 @@ int MultiEditor::tabForDocument(Document* doc) {
 CodeEditorBox* MultiEditor::newBox(MultiSplitter* currSplitter) {
     CodeEditorBox* box = new CodeEditorBox(currSplitter);
 
-    connect(box, SIGNAL(activated(CodeEditorBox*)), this, SLOT(onBoxActivated(CodeEditorBox*)));
+    connect(box, &CodeEditorBox::activated, this, &MultiEditor::onBoxActivated);
 
     return box;
 }

--- a/editors/sc-ide/widgets/post_window.cpp
+++ b/editors/sc-ide/widgets/post_window.cpp
@@ -54,7 +54,7 @@ PostWindow::PostWindow(QWidget* parent): QPlainTextEdit(parent) {
 
     setContextMenuPolicy(Qt::ActionsContextMenu);
 
-    connect(this, SIGNAL(scrollToBottomRequest()), this, SLOT(scrollToBottom()), Qt::QueuedConnection);
+    connect(this, &PostWindow::scrollToBottomRequest, this, &PostWindow::scrollToBottom, Qt::QueuedConnection);
 
     grabGesture(Qt::PinchGesture);
     setAttribute(Qt::WA_AcceptTouchEvents);
@@ -72,8 +72,8 @@ void PostWindow::createActions(Settings::Manager* settings) {
     action->setShortcut(QKeySequence::Copy);
     action->setShortcutContext(Qt::WidgetShortcut);
     action->setEnabled(false);
-    connect(action, SIGNAL(triggered()), this, SLOT(copy()));
-    connect(this, SIGNAL(copyAvailable(bool)), action, SLOT(setEnabled(bool)));
+    connect(action, &QAction::triggered, this, &PostWindow::copy);
+    connect(this, &PostWindow::copyAvailable, action, &QAction::setEnabled);
     addAction(action);
 
     mActions[Clear] = action = new QAction(tr("Clear"), this);
@@ -81,7 +81,7 @@ void PostWindow::createActions(Settings::Manager* settings) {
     action->setShortcutContext(Qt::ApplicationShortcut);
     action->setShortcut(tr("Ctrl+Shift+P", "Clear post window"));
     settings->addAction(action, "post-clear", postCategory);
-    connect(action, SIGNAL(triggered()), this, SLOT(clear()));
+    connect(action, &QAction::triggered, this, &PostWindow::clear);
     addAction(action);
 
     action = new QAction(this);
@@ -90,23 +90,23 @@ void PostWindow::createActions(Settings::Manager* settings) {
 
     mActions[DocClose] = ovrAction = new OverridingAction(tr("Close"), this);
     action->setStatusTip(tr("Close the current document"));
-    connect(ovrAction, SIGNAL(triggered()), this, SLOT(closeDocument()));
+    connect(ovrAction, &QAction::triggered, this, &PostWindow::closeDocument);
     ovrAction->addToWidget(this);
 
     mActions[ZoomIn] = ovrAction = new OverridingAction(tr("Enlarge Font"), this);
     ovrAction->setIconText("+");
     ovrAction->setStatusTip(tr("Enlarge post window font"));
-    connect(ovrAction, SIGNAL(triggered()), this, SLOT(zoomIn()));
+    connect(ovrAction, &QAction::triggered, this, &PostWindow::zoomIn);
     ovrAction->addToWidget(this);
 
     mActions[ZoomOut] = ovrAction = new OverridingAction(tr("Shrink Font"), this);
     ovrAction->setIconText("-");
     ovrAction->setStatusTip(tr("Shrink post window font"));
-    connect(ovrAction, SIGNAL(triggered()), this, SLOT(zoomOut()));
+    connect(ovrAction, &QAction::triggered, this, &PostWindow::zoomOut);
     ovrAction->addToWidget(this);
 
     mActions[ResetZoom] = ovrAction = new OverridingAction(tr("Reset Font Size"), this);
-    connect(ovrAction, SIGNAL(triggered()), this, SLOT(resetZoom()));
+    connect(ovrAction, &QAction::triggered, this, &PostWindow::resetZoom);
     ovrAction->addToWidget(this);
 
     action = new QAction(this);
@@ -117,14 +117,14 @@ void PostWindow::createActions(Settings::Manager* settings) {
     action->setStatusTip(tr("Wrap lines wider than the post window"));
     action->setCheckable(true);
     addAction(action);
-    connect(action, SIGNAL(triggered(bool)), this, SLOT(setLineWrap(bool)));
+    connect(action, &QAction::triggered, this, &PostWindow::setLineWrap);
     settings->addAction(action, "post-line-wrap", postCategory);
 
     mActions[AutoScroll] = action = new QAction(tr("Auto Scroll"), this);
     action->setStatusTip(tr("Scroll to bottom on new posts"));
     action->setCheckable(true);
     action->setChecked(true);
-    connect(action, SIGNAL(triggered(bool)), this, SLOT(onAutoScrollTriggered(bool)));
+    connect(action, &QAction::triggered, this, &PostWindow::onAutoScrollTriggered);
     addAction(action);
     settings->addAction(action, "post-auto-scroll", postCategory);
 }

--- a/editors/sc-ide/widgets/session_switch_dialog.cpp
+++ b/editors/sc-ide/widgets/session_switch_dialog.cpp
@@ -50,7 +50,7 @@ SessionSwitchDialog::SessionSwitchDialog(QWidget* parent): QDialog(parent) {
     if (currentSessionIndex != -1)
         mSessions->setCurrentRow(currentSessionIndex);
 
-    connect(mSessions, SIGNAL(itemActivated(QListWidgetItem*)), this, SLOT(onItemActivated(QListWidgetItem*)));
+    connect(mSessions, &QListWidget::itemActivated, this, &SessionSwitchDialog::onItemActivated);
 }
 
 void SessionSwitchDialog::onItemActivated(QListWidgetItem* item) { accept(); }

--- a/editors/sc-ide/widgets/sessions_dialog.hpp
+++ b/editors/sc-ide/widgets/sessions_dialog.hpp
@@ -62,9 +62,9 @@ public:
 
         setLayout(layout);
 
-        connect(removeBtn, SIGNAL(clicked()), this, SLOT(removeCurrent()));
-        connect(renameBtn, SIGNAL(clicked()), this, SLOT(renameCurrent()));
-        connect(dialogBtns, SIGNAL(accepted()), this, SLOT(accept()));
+        connect(removeBtn, &QPushButton::clicked, this, &SessionsDialog::removeCurrent);
+        connect(renameBtn, &QPushButton::clicked, this, &SessionsDialog::renameCurrent);
+        connect(dialogBtns, &QDialogButtonBox::accepted, this, &SessionsDialog::accept);
 
         updateSessions();
     }

--- a/editors/sc-ide/widgets/settings/dialog.cpp
+++ b/editors/sc-ide/widgets/settings/dialog.cpp
@@ -19,6 +19,9 @@
 */
 
 #include "dialog.hpp"
+
+#include <QButtonGroup>
+
 #include "ui_settings_dialog.h"
 #include "general_page.hpp"
 #include "sclang_page.hpp"
@@ -41,36 +44,35 @@ namespace ScIDE { namespace Settings {
 Dialog::Dialog(Manager* settings, QWidget* parent): QDialog(parent), mManager(settings), ui(new Ui::ConfigDialog) {
     ui->setupUi(this);
 
-    QWidget* w;
+    auto* general_page = new GeneralPage;
 
-    w = new GeneralPage;
-    ui->configPageStack->addWidget(w);
+    ui->configPageStack->addWidget(general_page);
     ui->configPageList->addItem(new QListWidgetItem(tr("General")));
-    connect(this, SIGNAL(storeRequest(Manager*)), w, SLOT(store(Manager*)));
-    connect(this, SIGNAL(loadRequest(Manager*)), w, SLOT(load(Manager*)));
+    connect(this, &Dialog::storeRequest, general_page, &GeneralPage::store);
+    connect(this, &Dialog::loadRequest, general_page, &GeneralPage::load);
 
-    w = new SclangPage;
-    ui->configPageStack->addWidget(w);
+    auto* sclang_page = new SclangPage;
+    ui->configPageStack->addWidget(sclang_page);
     ui->configPageList->addItem(new QListWidgetItem(tr("Interpreter")));
-    connect(this, SIGNAL(storeRequest(Manager*)), w, SLOT(store(Manager*)));
-    connect(this, SIGNAL(loadRequest(Manager*)), w, SLOT(load(Manager*)));
+    connect(this, &Dialog::storeRequest, sclang_page, &SclangPage::store);
+    connect(this, &Dialog::loadRequest, sclang_page, &SclangPage::load);
 
-    w = new EditorPage;
-    ui->configPageStack->addWidget(w);
+    auto* editor_page = new EditorPage;
+    ui->configPageStack->addWidget(editor_page);
     ui->configPageList->addItem(new QListWidgetItem(tr("Editor")));
-    connect(this, SIGNAL(storeRequest(Manager*)), w, SLOT(store(Manager*)));
-    connect(this, SIGNAL(loadRequest(Manager*)), w, SLOT(load(Manager*)));
+    connect(this, &Dialog::storeRequest, editor_page, &EditorPage::store);
+    connect(this, &Dialog::loadRequest, editor_page, &EditorPage::load);
 
-    w = new ShortcutsPage;
-    ui->configPageStack->addWidget(w);
+    auto* shortcut_page = new ShortcutsPage;
+    ui->configPageStack->addWidget(shortcut_page);
     ui->configPageList->addItem(new QListWidgetItem(tr("Shortcuts")));
-    connect(this, SIGNAL(storeRequest(Manager*)), w, SLOT(store(Manager*)));
-    connect(this, SIGNAL(loadRequest(Manager*)), w, SLOT(load(Manager*)));
+    connect(this, &Dialog::storeRequest, shortcut_page, &ShortcutsPage::store);
+    connect(this, &Dialog::loadRequest, shortcut_page, &ShortcutsPage::load);
 
-    connect(ui->buttonBox, SIGNAL(accepted()), this, SLOT(accept()));
-    connect(ui->buttonBox, SIGNAL(rejected()), this, SLOT(reject()));
-    connect(ui->buttonBox->button(QDialogButtonBox::Apply), SIGNAL(clicked()), this, SLOT(apply()));
-    connect(ui->buttonBox->button(QDialogButtonBox::Reset), SIGNAL(clicked()), this, SLOT(reset()));
+    connect(ui->buttonBox, &QDialogButtonBox::accepted, this, &Dialog::accept);
+    connect(ui->buttonBox, &QDialogButtonBox::rejected, this, &Dialog::reject);
+    connect(ui->buttonBox->button(QDialogButtonBox::Apply), &QPushButton::clicked, this, &Dialog::apply);
+    connect(ui->buttonBox->button(QDialogButtonBox::Reset), &QPushButton::clicked, this, &Dialog::reset);
 
 
     ui->configPageList->setMinimumWidth(ui->configPageList->sizeHintForColumn(0));

--- a/editors/sc-ide/widgets/settings/editor_page.cpp
+++ b/editors/sc-ide/widgets/settings/editor_page.cpp
@@ -43,26 +43,25 @@ EditorPage::EditorPage(QWidget* parent):
     ui(new Ui::EditorConfigPage) {
     ui->setupUi(this);
 
-    connect(ui->tabs, SIGNAL(currentChanged(int)), this, SLOT(onCurrentTabChanged(int)));
+    connect(ui->tabs, &QTabWidget::currentChanged, this, &EditorPage::onCurrentTabChanged);
 
-    connect(ui->onlyMonoFonts, SIGNAL(toggled(bool)), this, SLOT(onMonospaceToggle(bool)));
+    connect(ui->onlyMonoFonts, &QCheckBox::toggled, this, &EditorPage::onMonospaceToggle);
     connect(ui->fontCombo, &QComboBox::currentTextChanged, this, &EditorPage::updateFontPreview);
-    connect(ui->fontSize, SIGNAL(valueChanged(int)), this, SLOT(updateFontPreview()));
-    connect(ui->fontAntialias, SIGNAL(stateChanged(int)), this, SLOT(updateFontPreview()));
+    connect(ui->fontSize, &QSpinBox::valueChanged, this, &EditorPage::updateFontPreview);
+    connect(ui->fontAntialias, &QCheckBox::stateChanged, this, &EditorPage::updateFontPreview);
 
     connect(ui->themeCombo, &QComboBox::currentTextChanged, this, &EditorPage::updateTheme);
-    connect(ui->themeCopyBtn, SIGNAL(clicked()), this, SLOT(dialogCopyTheme()));
-    connect(ui->themeDeleteBtn, SIGNAL(clicked()), this, SLOT(deleteTheme()));
-    connect(ui->textFormats, SIGNAL(currentItemChanged(QTreeWidgetItem*, QTreeWidgetItem*)), this,
-            SLOT(updateTextFormatEdit()));
-    connect(ui->fgPicker, SIGNAL(colorPicked(QColor)), this, SLOT(updateTextFormatDisplay()));
-    connect(ui->bgPicker, SIGNAL(colorPicked(QColor)), this, SLOT(updateTextFormatDisplay()));
-    connect(ui->italicOption, SIGNAL(clicked()), this, SLOT(updateTextFormatDisplay()));
-    connect(ui->boldOption, SIGNAL(clicked()), this, SLOT(updateTextFormatDisplay()));
-    connect(ui->fgClearBtn, SIGNAL(clicked()), ui->fgPicker, SLOT(clear()));
-    connect(ui->fgClearBtn, SIGNAL(clicked()), this, SLOT(updateTextFormatDisplay()));
-    connect(ui->bgClearBtn, SIGNAL(clicked()), ui->bgPicker, SLOT(clear()));
-    connect(ui->bgClearBtn, SIGNAL(clicked()), this, SLOT(updateTextFormatDisplay()));
+    connect(ui->themeCopyBtn, &QPushButton::clicked, this, &EditorPage::dialogCopyTheme);
+    connect(ui->themeDeleteBtn, &QPushButton::clicked, this, &EditorPage::deleteTheme);
+    connect(ui->textFormats, &QTreeWidget::currentItemChanged, this, &EditorPage::updateTextFormatEdit);
+    connect(ui->fgPicker, &ColorWidget::colorPicked, this, &EditorPage::updateTextFormatDisplayGeneric);
+    connect(ui->bgPicker, &ColorWidget::colorPicked, this, &EditorPage::updateTextFormatDisplayGeneric);
+    connect(ui->italicOption, &QCheckBox::clicked, this, &EditorPage::updateTextFormatDisplayGeneric);
+    connect(ui->boldOption, &QCheckBox::clicked, this, &EditorPage::updateTextFormatDisplayGeneric);
+    connect(ui->fgClearBtn, &QCheckBox::clicked, ui->fgPicker, &ColorWidget::clear);
+    connect(ui->fgClearBtn, &QCheckBox::clicked, this, &EditorPage::updateTextFormatDisplayGeneric);
+    connect(ui->bgClearBtn, &QCheckBox::clicked, ui->bgPicker, &ColorWidget::clear);
+    connect(ui->bgClearBtn, &QCheckBox::clicked, this, &EditorPage::updateTextFormatDisplayGeneric);
 
     updateTextFormatEdit();
 }
@@ -424,7 +423,7 @@ void EditorPage::updateTextFormatEdit() {
     }
 }
 
-void EditorPage::updateTextFormatDisplay() {
+void EditorPage::updateTextFormatDisplayGeneric() {
     QTreeWidgetItem* item = ui->textFormats->currentItem();
     bool canEdit = item && item->data(0, TextFormatConfigKeyRole).isValid();
     if (!canEdit)

--- a/editors/sc-ide/widgets/settings/editor_page.cpp
+++ b/editors/sc-ide/widgets/settings/editor_page.cpp
@@ -47,7 +47,11 @@ EditorPage::EditorPage(QWidget* parent):
 
     connect(ui->onlyMonoFonts, &QCheckBox::toggled, this, &EditorPage::onMonospaceToggle);
     connect(ui->fontCombo, &QComboBox::currentTextChanged, this, &EditorPage::updateFontPreview);
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+    connect(ui->fontSize, SIGNAL(valueChanged(int)), this, SLOT(updateFontPreview()));
+#else
     connect(ui->fontSize, &QSpinBox::valueChanged, this, &EditorPage::updateFontPreview);
+#endif
     connect(ui->fontAntialias, &QCheckBox::stateChanged, this, &EditorPage::updateFontPreview);
 
     connect(ui->themeCombo, &QComboBox::currentTextChanged, this, &EditorPage::updateTheme);

--- a/editors/sc-ide/widgets/settings/editor_page.hpp
+++ b/editors/sc-ide/widgets/settings/editor_page.hpp
@@ -55,7 +55,7 @@ private Q_SLOTS:
     void updateFontPreview();
 
     void updateTextFormatEdit();
-    void updateTextFormatDisplay();
+    void updateTextFormatDisplayGeneric();
     void updateTextFormatDisplayCommons();
     void updateTheme(QString name);
 

--- a/editors/sc-ide/widgets/settings/general_page.cpp
+++ b/editors/sc-ide/widgets/settings/general_page.cpp
@@ -30,7 +30,7 @@ namespace ScIDE { namespace Settings {
 GeneralPage::GeneralPage(QWidget* parent): QWidget(parent), ui(new Ui::GeneralConfigPage) {
     ui->setupUi(this);
 
-    connect(ui->startSessionName, SIGNAL(textChanged(QString)), this, SLOT(onStartSessionNameChanged(QString)));
+    connect(ui->startSessionName, &QLineEdit::textChanged, this, &GeneralPage::onStartSessionNameChanged);
 }
 
 GeneralPage::~GeneralPage() { delete ui; }

--- a/editors/sc-ide/widgets/settings/sclang_page.cpp
+++ b/editors/sc-ide/widgets/settings/sclang_page.cpp
@@ -53,17 +53,17 @@ SclangPage::SclangPage(QWidget* parent): QWidget(parent), ui(new Ui::SclangConfi
     connect(ui->activeConfigFileComboBox, &QComboBox::currentTextChanged, this,
             &SclangPage::changeSelectedLanguageConfig);
 
-    connect(ui->sclang_add_configfile, SIGNAL(clicked()), this, SLOT(dialogCreateNewConfigFile()));
-    connect(ui->sclang_remove_configfile, SIGNAL(clicked()), this, SLOT(dialogDeleteCurrentConfigFile()));
+    connect(ui->sclang_add_configfile, &QToolButton::clicked, this, &SclangPage::dialogCreateNewConfigFile);
+    connect(ui->sclang_remove_configfile, &QToolButton::clicked, this, &SclangPage::dialogDeleteCurrentConfigFile);
 
-    connect(ui->sclang_add_include, SIGNAL(clicked()), this, SLOT(addIncludePath()));
-    connect(ui->sclang_add_exclude, SIGNAL(clicked()), this, SLOT(addExcludePath()));
+    connect(ui->sclang_add_include, &QToolButton::clicked, this, &SclangPage::addIncludePath);
+    connect(ui->sclang_add_exclude, &QToolButton::clicked, this, &SclangPage::addExcludePath);
 
-    connect(ui->sclang_remove_include, SIGNAL(clicked()), this, SLOT(removeIncludePath()));
-    connect(ui->sclang_remove_exclude, SIGNAL(clicked()), this, SLOT(removeExcludePath()));
+    connect(ui->sclang_remove_include, &QToolButton::clicked, this, &SclangPage::removeIncludePath);
+    connect(ui->sclang_remove_exclude, &QToolButton::clicked, this, &SclangPage::removeExcludePath);
 
-    connect(ui->sclang_post_inline_warnings, SIGNAL(stateChanged(int)), this, SLOT(sclangConfigChanged()));
-    connect(ui->sclang_exclude_default_paths, SIGNAL(stateChanged(int)), this, SLOT(sclangConfigChanged()));
+    connect(ui->sclang_post_inline_warnings, &QCheckBox::stateChanged, this, &SclangPage::markSclangConfigDirty);
+    connect(ui->sclang_exclude_default_paths, &QCheckBox::stateChanged, this, &SclangPage::markSclangConfigDirty);
 
     connect(ui->sclang_port, SIGNAL(valueChanged(int)), this, SLOT(showLanguageRestartDialogOnSave()));
 }

--- a/editors/sc-ide/widgets/settings/sclang_page.cpp
+++ b/editors/sc-ide/widgets/settings/sclang_page.cpp
@@ -65,7 +65,11 @@ SclangPage::SclangPage(QWidget* parent): QWidget(parent), ui(new Ui::SclangConfi
     connect(ui->sclang_post_inline_warnings, &QCheckBox::stateChanged, this, &SclangPage::sclangConfigChanged);
     connect(ui->sclang_exclude_default_paths, &QCheckBox::stateChanged, this, &SclangPage::sclangConfigChanged);
 
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
     connect(ui->sclang_port, SIGNAL(valueChanged(int)), this, SLOT(showLanguageRestartDialogOnSave()));
+#else
+    connect(ui->sclang_port, &QSpinBox::valueChanged, this, &SclangPage::showLanguageRestartDialogOnSave);
+#endif
 }
 
 SclangPage::~SclangPage() { delete ui; }

--- a/editors/sc-ide/widgets/settings/sclang_page.cpp
+++ b/editors/sc-ide/widgets/settings/sclang_page.cpp
@@ -62,8 +62,8 @@ SclangPage::SclangPage(QWidget* parent): QWidget(parent), ui(new Ui::SclangConfi
     connect(ui->sclang_remove_include, &QToolButton::clicked, this, &SclangPage::removeIncludePath);
     connect(ui->sclang_remove_exclude, &QToolButton::clicked, this, &SclangPage::removeExcludePath);
 
-    connect(ui->sclang_post_inline_warnings, &QCheckBox::stateChanged, this, &SclangPage::markSclangConfigDirty);
-    connect(ui->sclang_exclude_default_paths, &QCheckBox::stateChanged, this, &SclangPage::markSclangConfigDirty);
+    connect(ui->sclang_post_inline_warnings, &QCheckBox::stateChanged, this, &SclangPage::sclangConfigChanged);
+    connect(ui->sclang_exclude_default_paths, &QCheckBox::stateChanged, this, &SclangPage::sclangConfigChanged);
 
     connect(ui->sclang_port, SIGNAL(valueChanged(int)), this, SLOT(showLanguageRestartDialogOnSave()));
 }

--- a/editors/sc-ide/widgets/settings/shortcuts_page.cpp
+++ b/editors/sc-ide/widgets/settings/shortcuts_page.cpp
@@ -39,21 +39,20 @@ ShortcutsPage::ShortcutsPage(QWidget* parent): QWidget(parent), ui(new Ui::Short
 
     ui->clearSeq->setIcon(style()->standardIcon(QStyle::SP_DockWidgetCloseButton));
 
-    connect(ui->filter, SIGNAL(textChanged(QString)), this, SLOT(filterBy(QString)));
-    connect(ui->actionTree, SIGNAL(currentItemChanged(QTreeWidgetItem*, QTreeWidgetItem*)), this,
-            SLOT(showItem(QTreeWidgetItem*, QTreeWidgetItem*)));
+    connect(ui->filter, &QLineEdit::textChanged, this, &ShortcutsPage::filterBy);
+    connect(ui->actionTree, &QTreeWidget::currentItemChanged, this, &ShortcutsPage::showItem);
 
     // automation
-    connect(ui->defaultOpt, SIGNAL(clicked()), ui->customSeq, SLOT(reset()));
-    connect(ui->customOpt, SIGNAL(clicked()), ui->customSeq, SLOT(setFocus()));
-    connect(ui->customSeq, SIGNAL(editingStarted()), ui->customOpt, SLOT(toggle()));
-    connect(ui->clearSeq, SIGNAL(clicked()), ui->customSeq, SLOT(reset()));
-    connect(ui->clearSeq, SIGNAL(clicked()), ui->customOpt, SLOT(click()));
+    connect(ui->defaultOpt, &QRadioButton::clicked, ui->customSeq, &KeySequenceEdit::reset);
+    connect(ui->customOpt, &QRadioButton::clicked, ui->customSeq, [=]() { ui->customSeq->setFocus(); });
+    connect(ui->customSeq, &KeySequenceEdit::editingStarted, ui->customOpt, &QRadioButton::toggle);
+    connect(ui->clearSeq, &QToolButton::clicked, ui->customSeq, &KeySequenceEdit::reset);
+    connect(ui->clearSeq, &QToolButton::clicked, ui->customOpt, &QRadioButton::click);
 
     // value application
-    connect(ui->defaultOpt, SIGNAL(clicked()), this, SLOT(apply()));
-    connect(ui->customOpt, SIGNAL(clicked()), this, SLOT(apply()));
-    connect(ui->customSeq, SIGNAL(editingFinished()), this, SLOT(apply()));
+    connect(ui->defaultOpt, &QRadioButton::clicked, this, &ShortcutsPage::apply);
+    connect(ui->customOpt, &QRadioButton::clicked, this, &ShortcutsPage::apply);
+    connect(ui->customSeq, &KeySequenceEdit::editingFinished, this, &ShortcutsPage::apply);
 }
 
 ShortcutsPage::~ShortcutsPage() { delete ui; }

--- a/editors/sc-ide/widgets/util/docklet.cpp
+++ b/editors/sc-ide/widgets/util/docklet.cpp
@@ -132,23 +132,22 @@ Docklet::Docklet(const QString& title, QWidget* parent): QObject(parent), mWindo
 
     mDockAction = action = optionsMenu->addAction(tr("Undock"));
     action->setEnabled(features & QDockWidget::DockWidgetFloatable);
-    connect(action, SIGNAL(triggered(bool)), this, SLOT(toggleFloating()));
+    connect(action, &QAction::triggered, this, &Docklet::toggleFloating);
 
     mDetachAction = action = optionsMenu->addAction(tr("Detach"));
     action->setEnabled(features & QDockWidget::DockWidgetFloatable);
-    connect(action, SIGNAL(triggered(bool)), this, SLOT(toggleDetached()));
+    connect(action, &QAction::triggered, this, &Docklet::toggleDetached);
 
     action = optionsMenu->addAction(tr("Close"));
     action->setEnabled(features & QDockWidget::DockWidgetClosable);
-    connect(action, SIGNAL(triggered(bool)), this, SLOT(close()));
+    connect(action, &QAction::triggered, this, &Docklet::close);
 
     mVisibilityAction = action = new QAction(title, this);
     action->setCheckable(true);
-    connect(action, SIGNAL(triggered(bool)), this, SLOT(setVisible(bool)));
+    connect(action, &QAction::triggered, this, &Docklet::setVisible);
 
-    connect(mDockWidget, SIGNAL(topLevelChanged(bool)), this, SLOT(updateDockAction()));
-    connect(mDockWidget, SIGNAL(featuresChanged(QDockWidget::DockWidgetFeatures)), this,
-            SLOT(onFeaturesChanged(QDockWidget::DockWidgetFeatures)));
+    connect(mDockWidget, &QDockWidget::topLevelChanged, this, &Docklet::updateDockAction);
+    connect(mDockWidget, &QDockWidget::featuresChanged, this, &Docklet::onFeaturesChanged);
 }
 
 void Docklet::toggleFloating() {

--- a/editors/sc-ide/widgets/util/path_chooser_widget.hpp
+++ b/editors/sc-ide/widgets/util/path_chooser_widget.hpp
@@ -50,7 +50,7 @@ public:
         box->setContentsMargins(0, 0, 0, 0);
         box->setSpacing(1);
 
-        connect(mButton, SIGNAL(clicked()), this, SLOT(execDialog()), Qt::QueuedConnection);
+        connect(mButton, &QPushButton::clicked, this, &PathChooserWidget::execDialog, Qt::QueuedConnection);
     }
 
     QString text() const { return mTextField->text(); }

--- a/editors/sc-ide/widgets/util/text_format_list_widget.cpp
+++ b/editors/sc-ide/widgets/util/text_format_list_widget.cpp
@@ -90,7 +90,7 @@ TextFormatListWidget::TextFormatListWidget(QWidget* parent): QTreeView(parent) {
 
     setContextMenuPolicy(Qt::CustomContextMenu);
 
-    connect(this, SIGNAL(doubleClicked(const QModelIndex&)), this, SLOT(onDoubleClicked(const QModelIndex&)));
+    connect(this, &TextFormatListWidget::doubleClicked, this, &TextFormatListWidget::onDoubleClicked);
 }
 
 void TextFormatListWidget::addFormat(const QString& name, const QTextCharFormat& format) {


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

Closes #6824

This PR replaces many (but not all) connections with their implicit "SIGNAL/SLOT" syntax with a more type safe variant where we pass function pointers.
This hopefully reduces runtime errors while also improves clarity within the codebase and also allows to be clear where each signal is used. Though I am unsure which kind of checks the SIGNAL/SLOT syntax was performing internally, if it was performed during runtime or compile time.

While writing this I did not use XCode as a generator but Ninja. When using XCode I had errors all over the place - for the old and the new syntax, see

<img width="1077" height="618" alt="grafik" src="https://github.com/user-attachments/assets/004d5a95-f8b8-4203-a1f4-ef7b87fe72f2" />

If anyone can give me a hint on why and how to fix that - this would be greatly appreciated! I do not see this errors in VSCode w/ XCode, though I also don't see any errors when I create wrong connections. Maybe @timblechmann or @jleben can provide some advice what the best setup is w/o relying on the Qt Creator?

There are two connections which I did not replace, mainly

https://github.com/supercollider/supercollider/blob/develop/editors/sc-ide/widgets/help_browser.cpp#L101-L102

https://github.com/supercollider/supercollider/blob/develop/editors/sc-ide/widgets/help_browser.cpp#L458

I think those could be broken b/c the types do not match in any way - maybe we should fix those? Though I did not want to make this PR become more excessive than it already is.

I also did not touch any connections made through https://github.com/supercollider/supercollider/blob/develop/editors/sc-ide/core/sig_mux.cpp - I do not really understand what this is doing as there is no documentation, so it is probably best to delay its implementation in another PR.

Additionally, there is a strange bug I am experiencing, though I am unsure if this got introduced by this change:
* If I open the Qt IDE with a debugger, it crashes
* If I open the Qt IDE when moved to `/Applications` it crashes

Otherwise this runs fine (so running it any other place and w/o a debugger), so I am a bit unsure where the problem is here. Would therefore be great if someone could build this on their local computer and verify this.

Regarding review: Please double check if I did not screw up any signals.

E.g. 

```diff
-connect(&mTmpCoalTimer, SIGNAL(timeout()), this, SLOT(onTmpCoalUsecs()));
+connect(&mTmpCoalTimer, &QTimer::timeout, this, &Document::onTmpCoalUsecs);
```

the 2nd and 4th parameters are crucial here - they should be the same, though only typed now.

edit: While looking through the code I noticed that we have some memory leaks within the IDE - we should fix those by making resources member variables instead of allocating new objects which are never freed.

## Types of changes

<!-- Delete lines that don't apply -->

- Maintenance
