### PR TITLE
coc: no ai slop

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -46,7 +46,6 @@ If you see someone who is making an extra effort to ensure our community is welc
 * Self-promotion postings should be in courteous volumes and preferably include good descriptions.
 
 ### Usage of AI tools
-
 * The community values the thoughts and ideas of others, using an AI to *develop* one's thoughts is acceptable, but posting the output of an AI 'as if' it came from a human is not.
 * AI slop and AI based low effort contributions are not tolerated and will be judged by moderators discretion on a case by case basis.
 * Ensure all AI‑generated text or code has been carefully reviewed and edited by yourself.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -52,7 +52,7 @@ If you see someone who is making an extra effort to ensure our community is welc
 * Do not paste other user's content or code into LLMs without their consent.
 * AI tools, such as translators, may be used to help one participate and contribute to the community, 
 but they should be used in moderation, or as a last resort. 
-The community would rather engage with human imperfect than a sterile machine.  
+The community would rather engage with human imperfection than a sterile machine.  
 
 ## Unacceptable Behavior
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -52,7 +52,7 @@ If you see someone who is making an extra effort to ensure our community is welc
 * Do not paste other user's content or code into LLMs without their consent.
 * AI tools, such as translators, may be used to help one participate and contribute to the community, 
 but they should be used in moderation, or as a last resort. 
-The community would rather engage with human imperfection than a sterile machine.  
+The community would rather engage with human imperfection than a confident machine.
 
 ## Unacceptable Behavior
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -45,6 +45,20 @@ If you see someone who is making an extra effort to ensure our community is welc
 * Avoid using the community as a platform to advertise commercial products that lack direct connections to the software.
 * Self-promotion postings should be in courteous volumes and preferably include good descriptions.
 
+### Usage of AI tools
+* AI slop and AI based low effort contributions are not tolerated and will be judged by moderators discretion on a case by case basis.
+
+* Using LLMs for debate or discussion is not acceptable! Do not post a generated response as–if it was your own thought. 
+
+* Since almost all LLM providers also train on their input data it is not allowed to paste other users content or code into LLMs without their consent.
+
+* AI tools such as translators or even LLMs may be used at your discretion to help with participation or contribution to the community, 
+but should be used in moderation, or as a last resort.
+“Imperfection” and “your own words” is preferred over AI-generated or polished content. 
+The SC community appreciates the error over generic content. 
+
+* If AI tools are used, community expects complete transparency about it.
+
 ## Unacceptable Behavior
 
 Unacceptable behaviors include: intimidating, harassing, abusive, culturally appropriative, discriminatory, derogatory or demeaning speech or actions by any participant in our community online, at all related events and in one-on-one communications carried out in the context of community business. Community event venues may be shared with members of the public; please be respectful to all patrons of these locations.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -47,14 +47,13 @@ If you see someone who is making an extra effort to ensure our community is welc
 
 ### Usage of AI tools
 
+* The community values the thoughts and ideas of others, using an AI to *develop* one's thoughts is acceptable, but posting the output of an AI 'as if' it came from a human is not.
 * AI slop and AI based low effort contributions are not tolerated and will be judged by moderators discretion on a case by case basis.
-* Using LLMs for debate or discussion is not acceptable! Do not post a generated response as–if it was your own thought. 
-* Since almost all LLM providers also train on their input data it is not allowed to paste other users content or code into LLMs without their consent.
-* AI tools such as translators or even LLMs may be used at your discretion to help with participation or contribution to the community, 
-but should be used in moderation, or as a last resort.
-“Imperfection” and “your own words” is preferred over AI-generated or polished content. 
-The SC community appreciates the error over generic content. 
-* If AI tools are used, community expects complete transparency about it.
+* Ensure all AI‑generated text or code has been carefully reviewed and edited by yourself.
+* Do not paste other user's content or code into LLMs without their consent.
+* AI tools, such as translators, may be used to help one participate and contribute to the community, 
+but they should be used in moderation, or as a last resort. 
+The community would rather engage with human imperfect than a sterile machine.  
 
 ## Unacceptable Behavior
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -46,6 +46,7 @@ If you see someone who is making an extra effort to ensure our community is welc
 * Self-promotion postings should be in courteous volumes and preferably include good descriptions.
 
 ### Usage of AI tools
+
 * The community values the thoughts and ideas of others, using an AI to *develop* one's thoughts is acceptable, but posting the output of an AI 'as if' it came from a human is not.
 * AI slop and AI based low effort contributions are not tolerated and will be judged by moderators discretion on a case by case basis.
 * Ensure all AI‑generated text or code has been carefully reviewed and edited by yourself.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -51,9 +51,7 @@ If you see someone who is making an extra effort to ensure our community is welc
 * AI slop and AI based low effort contributions are not tolerated and will be judged by moderators discretion on a case by case basis.
 * Ensure all AI‑generated text or code has been carefully reviewed and edited by yourself.
 * Do not paste other user's content or code into LLMs without their consent.
-* AI tools, such as translators, may be used to help one participate and contribute to the community, 
-but they should be used in moderation, or as a last resort. 
-The community would rather engage with human imperfection than a confident machine.
+* AI tools, such as translators, may be used to help one participate and contribute to the community, but they should be used in moderation, or as a last resort.  The community would rather engage with human imperfection than a confident machine.
 
 ## Unacceptable Behavior
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -49,6 +49,7 @@ If you see someone who is making an extra effort to ensure our community is welc
 
 * The community values the thoughts and ideas of others, using an AI to *develop* one's thoughts is acceptable, but posting the output of an AI 'as if' it came from a human is not.
 * AI slop and AI based low effort contributions are not tolerated and will be judged by moderators discretion on a case by case basis.
+* Do not use any kind of autonomous bots (i.e. OpenClaw etc.) for any kind of interaction with the community or development!
 * Ensure all AI‑generated text or code has been carefully reviewed and edited by yourself.
 * Do not paste other user's content or code into LLMs without their consent.
 * AI tools, such as translators, may be used to help one participate and contribute to the community, but they should be used in moderation, or as a last resort.  The community would rather engage with human imperfection than a confident machine.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -46,17 +46,14 @@ If you see someone who is making an extra effort to ensure our community is welc
 * Self-promotion postings should be in courteous volumes and preferably include good descriptions.
 
 ### Usage of AI tools
+
 * AI slop and AI based low effort contributions are not tolerated and will be judged by moderators discretion on a case by case basis.
-
 * Using LLMs for debate or discussion is not acceptable! Do not post a generated response as–if it was your own thought. 
-
 * Since almost all LLM providers also train on their input data it is not allowed to paste other users content or code into LLMs without their consent.
-
 * AI tools such as translators or even LLMs may be used at your discretion to help with participation or contribution to the community, 
 but should be used in moderation, or as a last resort.
 “Imperfection” and “your own words” is preferred over AI-generated or polished content. 
 The SC community appreciates the error over generic content. 
-
 * If AI tools are used, community expects complete transparency about it.
 
 ## Unacceptable Behavior


### PR DESCRIPTION
Introduce a 'no ai slop' section to the code of conduct. This text is (slightly) adapted from luka's response on the forum, which is in turn a adaptation of @capital-G's proposal.

https://scsynth.org/t/add-no-ai-slop-to-community-guidelines/12672/18?u=jordan

@jamshark70 has suggested the following procedure:

1. This PR be reviewed and edited until a consensus is reached.
2. This then be shared over on the forum (and where ever else).
3. Only then should this be merged.

Please avoid turning this into a discussion on AI in general (perhaps open a new issue), this is about halting the proliferation of 'low effort'/'ai slop' throughout the community.
