### PR TITLE
Make `.asFraction` useful by adding rational handling methods  

### DIFF
--- a/SCClassLibrary/Common/Collections/Array.sc
+++ b/SCClassLibrary/Common/Collections/Array.sc
@@ -309,4 +309,36 @@ Array[slot] : ArrayedCollection {
 		this.do {|obj| obj.initFromArchive };
 		^this.first
 	}
+	{ arg slotArray;
+		slotArray.pairsDo {|index, slots| this[index].setSlots(slots) };
+		this.do {|obj| obj.initFromArchive };
+		^this.first
+	}
+	isValidFraction {
+		^(this.size == 2) && this[0].isNumber && this[1].isNumber && (this[1] != 0)
+	}
+	getRational {
+		if (this.isValidFraction) {
+			^(numerator: this[0], denominator: this[1])
+		} {
+			"Two numbers required: first = numerator, second = denominator (not 0).".warn;
+			^nil
+		}
+	}
+	getQuotient {
+		^if(this.isValidFraction) {
+			(this[0] / this[1])
+		} {
+			"Two numbers required: first = numerator, second = denominator (not 0).".warn;
+			nil
+		}
+	}
+	getModulus {
+		^if(this.isValidFraction) {
+			(this[0] % this[1])
+		} {
+			"Two numbers required: first = numerator, second = denominator (not 0).".warn;
+			nil
+		}
+	}
 }

--- a/SCClassLibrary/Common/Collections/Array.sc
+++ b/SCClassLibrary/Common/Collections/Array.sc
@@ -309,11 +309,6 @@ Array[slot] : ArrayedCollection {
 		this.do {|obj| obj.initFromArchive };
 		^this.first
 	}
-	{ arg slotArray;
-		slotArray.pairsDo {|index, slots| this[index].setSlots(slots) };
-		this.do {|obj| obj.initFromArchive };
-		^this.first
-	}
 	isValidFraction {
 		^(this.size == 2) && this[0].isNumber && this[1].isNumber && (this[1] != 0)
 	}

--- a/SCClassLibrary/Common/Collections/Event.sc
+++ b/SCClassLibrary/Common/Collections/Event.sc
@@ -1076,4 +1076,26 @@ Event : Environment {
 
 		defaultParentEvent = parentEvents.default;
 	}
+
+	getQuotient {
+		^if (
+			(this.keys == Set[\numerator, \denominator]) && (this[\denominator] != 0)
+		) {
+			(this[\numerator] / this[\denominator])
+		} {
+			"Two numbers required: first = numerator, second = denominator (not 0).".warn;
+			nil
+		}
+	}
+	
+	getModulus {
+		^if (
+			(this.keys == Set[\numerator, \denominator]) && (this[\denominator] != 0)
+		) {
+			(this[\numerator] % this[\denominator])
+		} {
+			"Two numbers required: first = numerator, second = denominator (not 0).".warn;
+			nil
+		}
+	}
 }


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

At present, `.asFraction` returns an `Array`, but arrays do not provide any methods to treat the result as a fraction. This makes the output essentially useless:  

```supercollider
a = (2/3).asFraction; // -> [2, 3]

a;        // -> [2, 3]
a.class;  // -> Array
```  

This limitation was noted in the following scsynth post: 
https://scsynth.org/t/fractions-simplenumber-magnitude/12683/2?u=prko

## Description of Proposed Feature  

### Basic Functionality
This PR introduces new methods to make the result of `.asFraction` genuinely useful:  

- **`getQuotient`**: returns the quotient of the fraction.  
  ```supercollider
  a.getQuotient; // -> 0.66666666666667
  ```  

- **`getModulus`**: returns the modulus of the fraction.  
  ```supercollider
  a.getModulus; // -> 2
  ```  

Additionally, to provide a more explicit representation of numerator and denominator, the array can be converted into an `Event` with the same functionality:  

```supercollider
b = a.getRational; // -> ('numerator': 2, 'denominator': 3)

b;        // -> ('numerator': 2, 'denominator': 3)
b.class;  // -> Event

b.getQuotient; // -> 0.66666666666667
b.getModulus;  // -> 2
```  

The methods also work directly on arrays:  
```supercollider
[2, 3].getQuotient; // -> 0.66666666666667
[4, 3].getModulus;  // -> 1
```  

### Error Handling  
If the conditions for forming a valid fraction are not met, a warning is issued and `nil` is returned:  

```supercollider
[3, 0].getRational;
// WARNING: Two numbers required: first = numerator, second = denominator (not 0).
// -> nil

[1, a].getRational;
// WARNING: Two numbers required: first = numerator, second = denominator (not 0).
// -> nil

[1, 2, 3].getQuotient;
// WARNING: Two numbers required: first = numerator, second = denominator (not 0).
// -> nil

[1, 2, 3].getModulus;
// WARNING: Two numbers required: first = numerator, second = denominator (not 0).
// -> nil
```  

## Types of changes

<!-- Delete lines that don't apply -->

- Documentation (not yet; I will add documentation if this PR receives positive feedback.)
- New feature

## To-do list
Currently, only numeric values are accepted as the numerator and denominator. I do not think it is appropriate to allow arbitrary mathematical expressions. For this complex feature, I believe it would be better to integrate the already existing Quarks discussed in #7286 into the core library.
<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [ ] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
