### PR TITLE
Specify sclang port within IDE settings

### DIFF
--- a/editors/sc-ide/core/sc_process.cpp
+++ b/editors/sc-ide/core/sc_process.cpp
@@ -131,6 +131,7 @@ void ScProcess::startLanguage(void) {
 
     QString workingDirectory = settings->value("runtimeDir").toString();
     QString configFile = settings->value("configFile").toString();
+    QString languagePort = settings->value("sclangPort").toString();
 
     settings->endGroup();
 
@@ -146,6 +147,10 @@ void ScProcess::startLanguage(void) {
         sclangArguments << "-l" << configFile;
     sclangArguments << "-i"
                     << "scqt";
+
+    if (!languagePort.isEmpty()) {
+        sclangArguments << "--port" << languagePort;
+    }
 
     if (!workingDirectory.isEmpty())
         setWorkingDirectory(workingDirectory);

--- a/editors/sc-ide/forms/settings_sclang.ui
+++ b/editors/sc-ide/forms/settings_sclang.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>613</width>
-    <height>421</height>
+    <height>433</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -18,7 +18,13 @@
     <widget class="QWidget" name="widget" native="true">
      <layout class="QFormLayout" name="formLayout">
       <property name="fieldGrowthPolicy">
-       <enum>QFormLayout::ExpandingFieldsGrow</enum>
+       <enum>QFormLayout::FieldGrowthPolicy::ExpandingFieldsGrow</enum>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>12</number>
       </property>
       <item row="0" column="1">
        <widget class="QCheckBox" name="autoStart">
@@ -28,23 +34,41 @@
        </widget>
       </item>
       <item row="1" column="0">
-       <widget class="QLabel" name="label_3">
+       <widget class="QLabel" name="sclang_port_label">
         <property name="text">
-         <string>Runtime Directory:</string>
+         <string>Language port</string>
         </property>
        </widget>
       </item>
       <item row="1" column="1">
-       <widget class="ScIDE::PathChooserWidget" name="runtimeDir"/>
-      </item>
-      <item row="2" column="0">
-       <widget class="QLabel" name="activeConfigFileLabel">
-        <property name="text">
-         <string>Active config file:</string>
+       <widget class="QSpinBox" name="sclang_port">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="toolTip">
+         <string>Default port is 57120</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+        </property>
+        <property name="minimum">
+         <number>1000</number>
+        </property>
+        <property name="maximum">
+         <number>100000</number>
+        </property>
+        <property name="value">
+         <number>57120</number>
         </property>
        </widget>
       </item>
       <item row="2" column="1">
+       <widget class="ScIDE::PathChooserWidget" name="runtimeDir"/>
+      </item>
+      <item row="4" column="1">
        <layout class="QHBoxLayout" name="horizontalLayout">
         <item>
          <widget class="QComboBox" name="activeConfigFileComboBox">
@@ -87,6 +111,20 @@
         </item>
        </layout>
       </item>
+      <item row="4" column="0">
+       <widget class="QLabel" name="activeConfigFileLabel">
+        <property name="text">
+         <string>Active config file:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="label_3">
+        <property name="text">
+         <string>Runtime Directory:</string>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>
@@ -115,7 +153,7 @@
      </property>
      <layout class="QFormLayout" name="formLayout_2">
       <property name="fieldGrowthPolicy">
-       <enum>QFormLayout::ExpandingFieldsGrow</enum>
+       <enum>QFormLayout::FieldGrowthPolicy::ExpandingFieldsGrow</enum>
       </property>
       <item row="2" column="0">
        <widget class="QLabel" name="label">
@@ -134,11 +172,8 @@
         </property>
         <layout class="QGridLayout" name="gridLayout">
          <property name="sizeConstraint">
-          <enum>QLayout::SetDefaultConstraint</enum>
+          <enum>QLayout::SizeConstraint::SetDefaultConstraint</enum>
          </property>
-         <item row="0" column="0" rowspan="2">
-          <widget class="QListWidget" name="sclang_include_directories"/>
-         </item>
          <item row="0" column="2">
           <layout class="QVBoxLayout" name="verticalLayout_3">
            <item>
@@ -162,6 +197,9 @@
             </widget>
            </item>
           </layout>
+         </item>
+         <item row="0" column="0" rowspan="2">
+          <widget class="QListWidget" name="sclang_include_directories"/>
          </item>
         </layout>
        </widget>

--- a/editors/sc-ide/forms/settings_sclang.ui
+++ b/editors/sc-ide/forms/settings_sclang.ui
@@ -55,10 +55,10 @@
          <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
         </property>
         <property name="minimum">
-         <number>1000</number>
+         <number>0</number>
         </property>
         <property name="maximum">
-         <number>100000</number>
+         <number>65535</number>
         </property>
         <property name="value">
          <number>57120</number>

--- a/editors/sc-ide/widgets/settings/sclang_page.cpp
+++ b/editors/sc-ide/widgets/settings/sclang_page.cpp
@@ -64,6 +64,8 @@ SclangPage::SclangPage(QWidget* parent): QWidget(parent), ui(new Ui::SclangConfi
 
     connect(ui->sclang_post_inline_warnings, SIGNAL(stateChanged(int)), this, SLOT(markSclangConfigDirty()));
     connect(ui->sclang_exclude_default_paths, SIGNAL(stateChanged(int)), this, SLOT(markSclangConfigDirty()));
+
+    connect(ui->sclang_port, SIGNAL(valueChanged(int)), this, SLOT(markSclangConfigDirty()));
 }
 
 SclangPage::~SclangPage() { delete ui; }

--- a/editors/sc-ide/widgets/settings/sclang_page.cpp
+++ b/editors/sc-ide/widgets/settings/sclang_page.cpp
@@ -73,6 +73,11 @@ void SclangPage::load(Manager* s) {
 
     ui->autoStart->setChecked(s->value("autoStart").toBool());
     ui->runtimeDir->setText(s->value("runtimeDir").toString());
+    if (s->value("sclangPort").isNull()) {
+        ui->sclang_port->setValue(57120);
+    } else {
+        ui->sclang_port->setValue(s->value("sclangPort").toInt());
+    }
 
     QStringList availConfigFiles = availableLanguageConfigFiles();
     QString configSelectedLanguageConfigFile = s->value("configFile").toString();
@@ -96,6 +101,7 @@ void SclangPage::store(Manager* s) {
     s->beginGroup("IDE/interpreter");
     s->setValue("autoStart", ui->autoStart->isChecked());
     s->setValue("runtimeDir", ui->runtimeDir->text());
+    s->setValue("sclangPort", ui->sclang_port->value());
     s->setValue("configFile", ui->activeConfigFileComboBox->currentText());
     s->endGroup();
 

--- a/editors/sc-ide/widgets/settings/sclang_page.cpp
+++ b/editors/sc-ide/widgets/settings/sclang_page.cpp
@@ -65,7 +65,7 @@ SclangPage::SclangPage(QWidget* parent): QWidget(parent), ui(new Ui::SclangConfi
     connect(ui->sclang_post_inline_warnings, SIGNAL(stateChanged(int)), this, SLOT(markSclangConfigDirty()));
     connect(ui->sclang_exclude_default_paths, SIGNAL(stateChanged(int)), this, SLOT(markSclangConfigDirty()));
 
-    connect(ui->sclang_port, SIGNAL(valueChanged(int)), this, SLOT(markSclangConfigDirty()));
+    connect(ui->sclang_port, SIGNAL(valueChanged(int)), this, SLOT(markSclangConfigChanged()));
 }
 
 SclangPage::~SclangPage() { delete ui; }

--- a/editors/sc-ide/widgets/settings/sclang_page.cpp
+++ b/editors/sc-ide/widgets/settings/sclang_page.cpp
@@ -107,8 +107,8 @@ void SclangPage::store(Manager* s) {
     if (mSclangConfigChanged) {
         writeLanguageConfig();
     }
-    if (mShowLanguageRestartDialogOnSave) {
-        dialogConfigFileUpdated();
+    if (mShowDialogRestartLanguageOnSave) {
+        dialogRestartLanguage();
     }
 }
 
@@ -144,7 +144,6 @@ void SclangPage::removeExcludePath() {
 
 void SclangPage::changeSelectedLanguageConfig(const QString& configPath) {
     mSelectedLanguageConfigFile = configPath;
-    mShowLanguageRestartDialogOnSave = true;
     readLanguageConfig();
 }
 
@@ -208,6 +207,8 @@ void SclangPage::readLanguageConfig() {
 }
 
 void SclangPage::writeLanguageConfig() {
+    mShowDialogRestartLanguageOnSave = true;
+
     using namespace YAML;
     using std::ofstream;
     Emitter out;
@@ -303,8 +304,8 @@ void SclangPage::dialogDeleteCurrentConfigFile() {
     }
 }
 
-void SclangPage::dialogConfigFileUpdated() {
-    mShowLanguageRestartDialogOnSave = false;
+void SclangPage::dialogRestartLanguage() {
+    mShowDialogRestartLanguageOnSave = false;
     QMessageBox::StandardButton reply =
         QMessageBox::question(this, tr("Sclang configuration file updated"),
                               tr("The SuperCollider language configuration has been updated.\n"

--- a/editors/sc-ide/widgets/settings/sclang_page.cpp
+++ b/editors/sc-ide/widgets/settings/sclang_page.cpp
@@ -62,10 +62,10 @@ SclangPage::SclangPage(QWidget* parent): QWidget(parent), ui(new Ui::SclangConfi
     connect(ui->sclang_remove_include, SIGNAL(clicked()), this, SLOT(removeIncludePath()));
     connect(ui->sclang_remove_exclude, SIGNAL(clicked()), this, SLOT(removeExcludePath()));
 
-    connect(ui->sclang_post_inline_warnings, SIGNAL(stateChanged(int)), this, SLOT(markSclangConfigDirty()));
-    connect(ui->sclang_exclude_default_paths, SIGNAL(stateChanged(int)), this, SLOT(markSclangConfigDirty()));
+    connect(ui->sclang_post_inline_warnings, SIGNAL(stateChanged(int)), this, SLOT(sclangConfigChanged()));
+    connect(ui->sclang_exclude_default_paths, SIGNAL(stateChanged(int)), this, SLOT(sclangConfigChanged()));
 
-    connect(ui->sclang_port, SIGNAL(valueChanged(int)), this, SLOT(markSclangConfigChanged()));
+    connect(ui->sclang_port, SIGNAL(valueChanged(int)), this, SLOT(showLanguageRestartDialogOnSave()));
 }
 
 SclangPage::~SclangPage() { delete ui; }
@@ -89,12 +89,10 @@ void SclangPage::load(Manager* s) {
     int index = availConfigFiles.indexOf(configSelectedLanguageConfigFile);
     if (index != -1)
         ui->activeConfigFileComboBox->setCurrentIndex(index);
-    selectedLanguageConfigFile = configSelectedLanguageConfigFile; // Happens after setting the combobox entries, since
-                                                                   // the code triggers stateChanged event.
+    mSelectedLanguageConfigFile = configSelectedLanguageConfigFile; // Happens after setting the combobox entries, since
+                                                                    // the code triggers stateChanged event.
 
     s->endGroup();
-
-    sclangConfigChanged = false;
 
     readLanguageConfig();
 }
@@ -107,14 +105,19 @@ void SclangPage::store(Manager* s) {
     s->setValue("configFile", ui->activeConfigFileComboBox->currentText());
     s->endGroup();
 
-    writeLanguageConfig();
+    if (mSclangConfigChanged) {
+        writeLanguageConfig();
+    }
+    if (mShowLanguageRestartDialogOnSave) {
+        dialogConfigFileUpdated();
+    }
 }
 
 void SclangPage::addIncludePath() {
     QString path = QFileDialog::getExistingDirectory(this, tr("ScLang include directories"));
     if (path.size())
         ui->sclang_include_directories->addItem(path);
-    sclangConfigDirty = true;
+    mSclangConfigChanged = true;
 }
 
 void SclangPage::removeIncludePath() {
@@ -122,14 +125,14 @@ void SclangPage::removeIncludePath() {
         ui->sclang_include_directories->removeItemWidget(item);
         delete item;
     }
-    sclangConfigDirty = true;
+    mSclangConfigChanged = true;
 }
 
 void SclangPage::addExcludePath() {
     QString path = QFileDialog::getExistingDirectory(this, tr("ScLang exclude directories"));
     if (path.size())
         ui->sclang_exclude_directories->addItem(path);
-    sclangConfigDirty = true;
+    mSclangConfigChanged = true;
 }
 
 void SclangPage::removeExcludePath() {
@@ -137,12 +140,12 @@ void SclangPage::removeExcludePath() {
         ui->sclang_exclude_directories->removeItemWidget(item);
         delete item;
     }
-    sclangConfigDirty = true;
+    mSclangConfigChanged = true;
 }
 
 void SclangPage::changeSelectedLanguageConfig(const QString& configPath) {
-    selectedLanguageConfigFile = configPath;
-    sclangConfigChanged = true;
+    mSelectedLanguageConfigFile = configPath;
+    mShowLanguageRestartDialogOnSave = true;
     readLanguageConfig();
 }
 
@@ -203,19 +206,9 @@ void SclangPage::readLanguageConfig() {
             }
         }
     } catch (std::exception&) {}
-
-    sclangConfigDirty = false;
 }
 
 void SclangPage::writeLanguageConfig() {
-    if (!sclangConfigDirty) {
-        if (sclangConfigChanged) {
-            dialogConfigFileUpdated();
-            sclangConfigChanged = false; // avoid double invocation
-        }
-        return;
-    }
-
     using namespace YAML;
     using std::ofstream;
     Emitter out;
@@ -249,16 +242,14 @@ void SclangPage::writeLanguageConfig() {
     ofstream fout(languageConfigFile().toStdString().c_str());
     fout << out.c_str();
 
-    dialogConfigFileUpdated();
-
-    sclangConfigDirty = false;
+    mSclangConfigChanged = false;
 }
 
 QString SclangPage::languageConfigFile() {
-    if (selectedLanguageConfigFile.isEmpty()) {
-        selectedLanguageConfigFile = standardDirectory(ScConfigUserDir) + "/" + QStringLiteral("sclang_conf.yaml");
+    if (mSelectedLanguageConfigFile.isEmpty()) {
+        mSelectedLanguageConfigFile = standardDirectory(ScConfigUserDir) + "/" + QStringLiteral("sclang_conf.yaml");
     }
-    return selectedLanguageConfigFile;
+    return mSelectedLanguageConfigFile;
 }
 
 QStringList SclangPage::availableLanguageConfigFiles() {
@@ -285,12 +276,12 @@ void SclangPage::dialogCreateNewConfigFile() {
             QMessageBox::information(this, tr("File Already Exists"),
                                      tr("Configuration file already exists:\n%1").arg(proposedLanguageConfigFile));
         } else {
-            selectedLanguageConfigFile = proposedLanguageConfigFile;
-            sclangConfigDirty = true;
+            mSelectedLanguageConfigFile = proposedLanguageConfigFile;
+            mSclangConfigChanged = true;
             writeLanguageConfig();
 
             int index = ui->activeConfigFileComboBox->count();
-            ui->activeConfigFileComboBox->addItem(selectedLanguageConfigFile);
+            ui->activeConfigFileComboBox->addItem(mSelectedLanguageConfigFile);
             ui->activeConfigFileComboBox->setCurrentIndex(index);
         }
     }
@@ -300,11 +291,11 @@ void SclangPage::dialogDeleteCurrentConfigFile() {
     int ret = QMessageBox::warning(this, tr("Delete Configuration File"),
                                    tr("Are you sure you want to delete the following configuration file?\nThis action "
                                       "is immediate and cannot be undone.\n")
-                                       + selectedLanguageConfigFile,
+                                       + mSelectedLanguageConfigFile,
                                    QMessageBox::Ok | QMessageBox::Cancel, QMessageBox::Cancel);
 
     if (ret == QMessageBox::Ok) {
-        QString pathBeingRemoved = selectedLanguageConfigFile;
+        QString pathBeingRemoved = mSelectedLanguageConfigFile;
         QFile::remove(pathBeingRemoved);
         ui->activeConfigFileComboBox->removeItem(ui->activeConfigFileComboBox->findText(pathBeingRemoved));
         if (ui->activeConfigFileComboBox->count() != 0) {
@@ -314,6 +305,7 @@ void SclangPage::dialogDeleteCurrentConfigFile() {
 }
 
 void SclangPage::dialogConfigFileUpdated() {
+    mShowLanguageRestartDialogOnSave = false;
     QMessageBox::StandardButton reply =
         QMessageBox::question(this, tr("Sclang configuration file updated"),
                               tr("The SuperCollider language configuration has been updated.\n"

--- a/editors/sc-ide/widgets/settings/sclang_page.cpp
+++ b/editors/sc-ide/widgets/settings/sclang_page.cpp
@@ -75,9 +75,8 @@ void SclangPage::load(Manager* s) {
 
     ui->autoStart->setChecked(s->value("autoStart").toBool());
     ui->runtimeDir->setText(s->value("runtimeDir").toString());
-    if (s->value("sclangPort").isNull()) {
-        ui->sclang_port->setValue(57120);
-    } else {
+    // Qt UI definition holds default value implicitly - no need to repeat it here again
+    if (!s->value("sclangPort").isNull()) {
         ui->sclang_port->setValue(s->value("sclangPort").toInt());
     }
 

--- a/editors/sc-ide/widgets/settings/sclang_page.hpp
+++ b/editors/sc-ide/widgets/settings/sclang_page.hpp
@@ -47,8 +47,11 @@ private Q_SLOTS:
 
     void addExcludePath();
     void removeExcludePath();
-    void sclangConfigChanged() { mSclangConfigChanged = true; }
-    void showLanguageRestartDialogOnSave() { mShowLanguageRestartDialogOnSave = true; }
+    void sclangConfigChanged() {
+        mSclangConfigChanged = true;
+        mShowDialogRestartLanguageOnSave = true;
+    }
+    void showLanguageRestartDialogOnSave() { mShowDialogRestartLanguageOnSave = true; }
     void changeSelectedLanguageConfig(const QString& configPath);
     void dialogCreateNewConfigFile();
     void dialogDeleteCurrentConfigFile();
@@ -58,12 +61,12 @@ private:
     void writeLanguageConfig();
     QString languageConfigFile();
     QStringList availableLanguageConfigFiles();
-    void dialogConfigFileUpdated();
+    void dialogRestartLanguage();
 
     Ui::SclangConfigPage* ui;
 
     bool mSclangConfigChanged = false;
-    bool mShowLanguageRestartDialogOnSave = false;
+    bool mShowDialogRestartLanguageOnSave = false;
     QString mSelectedLanguageConfigFile;
 };
 

--- a/editors/sc-ide/widgets/settings/sclang_page.hpp
+++ b/editors/sc-ide/widgets/settings/sclang_page.hpp
@@ -48,6 +48,7 @@ private Q_SLOTS:
     void addExcludePath();
     void removeExcludePath();
     void markSclangConfigDirty() { sclangConfigDirty = true; }
+    void markSclangConfigChanged() { sclangConfigChanged = true; }
     void changeSelectedLanguageConfig(const QString& configPath);
     void dialogCreateNewConfigFile();
     void dialogDeleteCurrentConfigFile();

--- a/editors/sc-ide/widgets/settings/sclang_page.hpp
+++ b/editors/sc-ide/widgets/settings/sclang_page.hpp
@@ -47,8 +47,8 @@ private Q_SLOTS:
 
     void addExcludePath();
     void removeExcludePath();
-    void markSclangConfigDirty() { sclangConfigDirty = true; }
-    void markSclangConfigChanged() { sclangConfigChanged = true; }
+    void sclangConfigChanged() { mSclangConfigChanged = true; }
+    void showLanguageRestartDialogOnSave() { mShowLanguageRestartDialogOnSave = true; }
     void changeSelectedLanguageConfig(const QString& configPath);
     void dialogCreateNewConfigFile();
     void dialogDeleteCurrentConfigFile();
@@ -62,9 +62,9 @@ private:
 
     Ui::SclangConfigPage* ui;
 
-    bool sclangConfigDirty;
-    bool sclangConfigChanged;
-    QString selectedLanguageConfigFile;
+    bool mSclangConfigChanged = false;
+    bool mShowLanguageRestartDialogOnSave = false;
+    QString mSelectedLanguageConfigFile;
 };
 
 }} // namespace ScIDE::Settings


### PR DESCRIPTION
value gets stored in the `sc_ide_conf.yaml` and defaults to 57120 if not present in the yaml file

<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

Allows to specify which port sclang should use and stores this value in the `scide_ide_conf.yaml`

<img width="980" height="592" alt="image" src="https://github.com/user-attachments/assets/75bae28f-1dd3-434b-ae85-3635c5f9b4dd" />

Sadly I am not the best in Qt Designer, so this looks quite off.... I decided to make it right-bound for some reason.

This came up in https://scsynth.org/t/default-sclang-port-change/12715

## Types of changes

- New feature

## To-do list

Please test b/c it works for me outside of `/Application`, but once I move `SuperCollider.app` into `/Application` sc-ide crashes - but this is also my current behavior on `develop` branch - I may have to clear my build dir... 
