### PR TITLE
ide: Explicitly convert KeyboardModifiers to an integer type

### DIFF
--- a/editors/sc-ide/widgets/code_editor/editor.cpp
+++ b/editors/sc-ide/widgets/code_editor/editor.cpp
@@ -698,7 +698,7 @@ void GenericCodeEditor::mousePressEvent(QMouseEvent* e) {
                                          .arg(e->position().x())
                                          .arg(e->position().y())
 #endif
-                                         .arg(e->modifiers())
+                                         .arg(static_cast<Qt::KeyboardModifiers::Int>(e->modifiers()))
                                          .arg(button),
                                      true);
     }
@@ -732,7 +732,7 @@ void GenericCodeEditor::mouseDoubleClickEvent(QMouseEvent* e) {
                                          .arg(e->position().x())
                                          .arg(e->position().y())
 #endif
-                                         .arg(e->modifiers())
+                                         .arg(static_cast<Qt::KeyboardModifiers::Int>(e->modifiers()))
                                          .arg(button),
                                      true);
     }
@@ -766,7 +766,7 @@ void GenericCodeEditor::mouseReleaseEvent(QMouseEvent* e) {
                                          .arg(e->position().x())
                                          .arg(e->position().y())
 #endif
-                                         .arg(e->modifiers())
+                                         .arg(static_cast<Qt::KeyboardModifiers::Int>(e->modifiers()))
                                          .arg(button),
                                      true);
     }


### PR DESCRIPTION
## Purpose and Motivation

Fix Qt 6.10.1 build. I tested this on Arch Linux with Qt 6.10.1. Close #7279.
I mainly followed the documentation posted by capital-G. Thanks!
<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [ ] All tests are passing
- [ ] Updated documentation
- [x] This PR is ready for review

I found a way to test the result:
```Document.current.mouseUpAction = { |doc, x, y, modifiers, buttonNumber| modifiers.isCtrl.postln}```



(Notes: I believe Qt 6.10 is actually fine.)
