### PR TITLE
qt: remove outdated qt preprocessor definitions

### DIFF
--- a/editors/sc-ide/widgets/code_editor/line_indicator.cpp
+++ b/editors/sc-ide/widgets/code_editor/line_indicator.cpp
@@ -81,11 +81,7 @@ int LineIndicator::widthForLineCount(int lineCount) {
         ++digits;
     }
 
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 11, 0))
     return 6 + fontMetrics().horizontalAdvance('9') * digits;
-#else
-    return 6 + fontMetrics().width('9') * digits;
-#endif
 }
 
 void LineIndicator::setHideLineIndicator(bool hide) { hideLineIndicator = hide; }

--- a/editors/sc-ide/widgets/help_browser.cpp
+++ b/editors/sc-ide/widgets/help_browser.cpp
@@ -117,12 +117,9 @@ HelpBrowser::HelpBrowser(QWidget* parent): QWidget(parent) {
     // FIXME: should actually respond to class library shutdown, but we don't have that signal
     connect(scProcess, &ScProcess::classLibraryRecompiled, mLoadProgressIndicator, &LoadProgressIndicator::stop);
 
-    // Legacy mac build support -- with Qt 5.9.3 this causes a segfault on application exit.
-#    if QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)
     // Delete the help browser's page to avoid an assert/crash during shutdown. See QTBUG-56441, QTBUG-50160.
     // Note that putting this in the destructor doesn't work.
     connect(QApplication::instance(), &QApplication::aboutToQuit, [this]() { delete mWebView->page(); });
-#    endif
 
     createActions();
 


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

This PR removes some old preprocessor guards for qt versions we can no longer build against (<5.15). I believe the removed code was not used anymore.

I think these were the last outdated qt version checks.

## Types of changes

<!-- Delete lines that don't apply -->

- Cleanup

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [n/a] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
