### PR TITLE
Fix Maybe documentation

### DIFF
--- a/HelpSource/Classes/Maybe.schelp
+++ b/HelpSource/Classes/Maybe.schelp
@@ -107,6 +107,7 @@ code::
 a = Array.fill(8, { |i| var k = (1/(i+1)).rand; Maybe({ |x| x * k }) });
 b = o(Maybe({ |x| x }), *a);
 b.value(1);
+::
 
 method::do
 Calls the source, like in link::Classes/Function::.


### PR DESCRIPTION
Currently the Maybe documentation is broken due to a missing closing tag, see https://dev.docs.supercollider.online/Classes/Maybe.html (this is also in 3.14, see https://docs.supercollider.online/Classes/Maybe.html)

This PR adds the missing closing tag.
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Types of changes

<!-- Delete lines that don't apply -->

- Documentation
- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
