### PR TITLE
Improve discoverability of `|==|` by adding `==` in UGen.schelp

### DIFF
--- a/HelpSource/Classes/UGen.schelp
+++ b/HelpSource/Classes/UGen.schelp
@@ -358,7 +358,7 @@ Outputs 1, representing true for negative, 0 representing false for positive or 
 
 method:: ==
 note::
-code::==:: compares UGen objects by identity.
+code::==:: compares UGen objects by equality.
 Use code::|==|:: to compare the signals they produce.
 ::
 

--- a/HelpSource/Classes/UGen.schelp
+++ b/HelpSource/Classes/UGen.schelp
@@ -356,9 +356,18 @@ Outputs 1, representing true for positive, 0 representing false for negative or 
 method::isNegative
 Outputs 1, representing true for negative, 0 representing false for positive or zero input values.
 
+method:: ==
+note::
+code::==:: compares UGen objects by identity.
+Use code::|==|:: to compare the signals they produce.
+::
 
 method::|==|
-Outputs 1, representing true, when the receiver and argument signal coincide. Note that this may be ambivalent in many cases, because of floating point arithmetic. A special sign is needed, because code::==:: compares the UGen objects, and not the signal they produce.
+Returns 1 (true) when the receiver and argument signals are equal.
+Because of floating‑point arithmetic, results may vary in practice.
+note::
+For object identity comparison, use code::==:: instead.
+::
 
 code::
 // an example of floating point relevance for the |==| operator.


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

The current documentation in `UGen.schelp` places the explanation of `==` within the entry for `|==|`. 
This arrangement presumes that readers are already familiar with both concepts, which makes the information 
less accessible. In practice, users who only know `==` may find it difficult to discover `|==|`, as the 
connection is not immediately obvious.

By adding a dedicated note under `==`, this pull request improves discoverability and clarity. It ensures 
that users searching for `==` are guided towards the correct usage of `|==|` when comparing signals, while 
retaining the distinction that `==` compares UGen objects themselves. This change aligns the documentation 
with common expectations, reduces potential confusion, and makes the learning process more straightforward 
for new users.

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->

- Documentation

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
