### PR TITLE
ide: editor: fix Cmd+Backspace and Cmd+Delete shortcuts on macOS

### DIFF
--- a/editors/sc-ide/widgets/code_editor/editor.cpp
+++ b/editors/sc-ide/widgets/code_editor/editor.cpp
@@ -569,7 +569,7 @@ void GenericCodeEditor::handleKeyUp(QKeyEvent* event, QTextCursor& textCursor) {
 }
 
 void GenericCodeEditor::handleKeyDelete(QKeyEvent* event, QTextCursor& textCursor) {
-    if (event->modifiers() & Qt::META) {
+    if (event->modifiers() & Qt::CTRL) {
         textCursor.movePosition(QTextCursor::EndOfBlock, QTextCursor::KeepAnchor);
         textCursor.removeSelectedText();
     } else
@@ -577,7 +577,7 @@ void GenericCodeEditor::handleKeyDelete(QKeyEvent* event, QTextCursor& textCurso
 }
 
 void GenericCodeEditor::handleKeyBackspace(QKeyEvent* event, QTextCursor& textCursor, bool& updateCursor) {
-    if (event->modifiers() & Qt::META) {
+    if (event->modifiers() & Qt::CTRL) {
         textCursor.movePosition(QTextCursor::StartOfBlock, QTextCursor::KeepAnchor);
         textCursor.removeSelectedText();
     } else {


### PR DESCRIPTION
## Purpose and Motivation

Fixes #7316

Cmd+Backspace and Cmd+Delete should delete to line boundaries, consistent with other macOS editors like [Xcode](https://keycombiner.com/collections/xcode/) and [VS Code](https://go.microsoft.com/fwlink/?linkid=832143).

Currently, both shortcuts do nothing. The feature works with Control+Backspace/Delete instead (non-standard on macOS).

**Root cause:** The code checks for `Qt::META` instead of `Qt::CTRL`. On macOS, Qt maps:
- `Qt::CTRL` → Command key (⌘)
- `Qt::META` → Control key (⌃)

This fix changes `Qt::META` to `Qt::CTRL` in `handleKeyDelete()` and `handleKeyBackspace()` of `editor.cpp`.

## Types of changes

- Bug fix

## To-do list

- [x] Code is tested
- [x] All tests are passing
- [ ] Updated documentation
- [x] This PR is ready for review

## Alternative approach

Open to supporting both modifiers (Cmd and Control) for backward compatibility, in case users have adapted to using Control+Backspace/Delete.