### PR TITLE
Introduce rich text editor

### DIFF
--- a/cmake_modules/MacOSXBundleInfo.plist.in
+++ b/cmake_modules/MacOSXBundleInfo.plist.in
@@ -124,6 +124,24 @@
 			<key>LSTypeIsPackage</key>
 			<false/>
 		</dict>
+		<dict>
+			<key>CFBundleTypeExtensions</key>
+			<array>
+				<string>scr</string>
+			</array>
+			<key>CFBundleTypeIconFile</key>
+			<string>scd</string>
+			<key>CFBundleTypeName</key>
+			<string>SuperCollider Rich Text</string>
+			<key>CFBundleTypeMIMETypes</key>
+			<array>
+				<string>text/html</string>
+			</array>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>LSTypeIsPackage</key>
+			<false/>
+		</dict>
 	</array>
 	<key>CFBundleExecutable</key>
 	<string>${MACOSX_BUNDLE_BUNDLE_NAME}</string>
@@ -196,6 +214,24 @@
 				<array>
 					<string>sc</string>
 					<string>scd</string>
+				</array>
+			</dict>
+		</dict>
+		<dict>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.text</string>
+				<string>public.html</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>SuperCollider Rich Text</string>
+			<key>UTTypeIdentifier</key>
+			<string>org.supercollider.scr</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>scr</string>
 				</array>
 			</dict>
 		</dict>

--- a/editors/sc-ide/CMakeLists.txt
+++ b/editors/sc-ide/CMakeLists.txt
@@ -92,6 +92,8 @@ set ( ide_moc_hdr
     widgets/code_editor/overlay.hpp
     widgets/code_editor/autocompleter.hpp
     widgets/code_editor/completion_menu.hpp
+    widgets/code_editor/rich_editor.hpp
+    widgets/code_editor/rich_toolbar.hpp
     widgets/settings/dialog.hpp
     widgets/settings/general_page.hpp
     widgets/settings/sclang_page.hpp
@@ -144,6 +146,8 @@ set ( ide_src
     widgets/code_editor/overlay.cpp
     widgets/code_editor/autocompleter.cpp
     widgets/code_editor/completion_menu.cpp
+    widgets/code_editor/rich_editor.cpp
+    widgets/code_editor/rich_toolbar.cpp
     widgets/settings/dialog.cpp
     widgets/settings/general_page.cpp
     widgets/settings/sclang_page.cpp

--- a/editors/sc-ide/core/doc_manager.cpp
+++ b/editors/sc-ide/core/doc_manager.cpp
@@ -38,8 +38,9 @@
 
 using namespace ScIDE;
 
-Document::Document(bool isPlainText, const QByteArray& id, const QString& title, const QString& text):
+Document::Document(DocumentType docType, const QByteArray& id, const QString& title, const QString& text):
     mId(id),
+    mDocType(docType),
     mDoc(new QTextDocument(text, this)),
     mTitle(title),
     mIndentWidth(4),
@@ -64,9 +65,12 @@ Document::Document(bool isPlainText, const QByteArray& id, const QString& title,
     if (mTitle.isEmpty())
         mTitle = tr("Untitled");
 
-    mDoc->setDocumentLayout(new QPlainTextDocumentLayout(mDoc));
+    // Rich text documents use QTextDocumentLayout (default), others use QPlainTextDocumentLayout
+    if (docType != RichText)
+        mDoc->setDocumentLayout(new QPlainTextDocumentLayout(mDoc));
 
-    if (!isPlainText)
+    // Only SuperCollider documents get syntax highlighting
+    if (docType == SuperCollider)
         mHighlighter = new SyntaxHighlighter(mDoc);
 
     connect(Main::instance(), &Main::applySettingsRequest, this, &Document::applySettings);
@@ -74,14 +78,17 @@ Document::Document(bool isPlainText, const QByteArray& id, const QString& title,
     applySettings(Main::settings());
 }
 
-void Document::setPlainText(bool set_plain_text) {
-    if (isPlainText() == set_plain_text)
+void Document::setDocumentType(DocumentType docType) {
+    if (mDocType == docType)
         return;
+
+    mDocType = docType;
 
     delete mHighlighter;
     mHighlighter = 0;
 
-    if (!set_plain_text)
+    // Only SuperCollider documents get syntax highlighting
+    if (docType == SuperCollider)
         mHighlighter = new SyntaxHighlighter(mDoc);
 }
 
@@ -263,9 +270,9 @@ DocumentManager::DocumentManager(Main* main, Settings::Manager* settings):
     loadRecentDocuments(settings);
 }
 
-Document* DocumentManager::createDocument(bool isPlainText, const QByteArray& id, const QString& title,
+Document* DocumentManager::createDocument(Document::DocumentType docType, const QByteArray& id, const QString& title,
                                           const QString& text) {
-    Document* doc = new Document(isPlainText, id, title, text);
+    Document* doc = new Document(docType, id, title, text);
     mDocHash.insert(doc->id(), doc);
 
     QStandardItem* item = new QStandardItem(doc->title());
@@ -279,6 +286,14 @@ Document* DocumentManager::createDocument(bool isPlainText, const QByteArray& id
 
 void DocumentManager::create() {
     Document* doc = createDocument();
+
+    connect(doc->textDocument(), &QTextDocument::contentsChanged, doc, &Document::storeTmpFile);
+    syncLangDocument(doc);
+    Q_EMIT(opened(doc, 0, 0));
+}
+
+void DocumentManager::createRichDocument() {
+    Document* doc = createDocument(Document::RichText);
 
     connect(doc->textDocument(), &QTextDocument::contentsChanged, doc, &Document::storeTmpFile);
     syncLangDocument(doc);
@@ -331,11 +346,16 @@ Document* DocumentManager::open(const QString& path, int initialCursorPosition, 
 
     closeSingleUntitledIfUnmodified();
 
-    const bool fileIsPlainText = !(info.suffix() == QStringLiteral("sc") || (info.suffix() == QStringLiteral("scd"))
-                                   || (info.suffix() == QStringLiteral("schelp")));
+    auto docType = getDocumentTypeFromFileSuffix(info.suffix());
 
-    Document* doc = createDocument(fileIsPlainText, id);
-    doc->mDoc->setPlainText(decodeDocument(bytes));
+    Document* doc = createDocument(docType, id);
+
+    // Rich text documents are stored as HTML
+    if (docType == Document::RichText) {
+        doc->mDoc->setHtml(decodeDocument(bytes));
+    } else {
+        doc->mDoc->setPlainText(decodeDocument(bytes));
+    }
     doc->mDoc->setModified(false);
     doc->mFilePath = filePath;
     QString fileTitle = info.fileName();
@@ -406,7 +426,8 @@ void DocumentManager::restore() {
             MainWindow::instance()->showStatusMessage(tr("Cannot open file for reading: %1").arg(path));
         QByteArray bytes(file.readAll());
         file.close();
-        Document* doc = createDocument(false, QByteArray(), QFileInfo(path).baseName(), decodeDocument(bytes));
+        Document* doc =
+            createDocument(Document::SuperCollider, QByteArray(), QFileInfo(path).baseName(), decodeDocument(bytes));
         doc->mTmpFilePath = path;
         syncLangDocument(doc);
         Q_EMIT(opened(doc, 0, 0));
@@ -481,11 +502,22 @@ bool DocumentManager::saveAs(Document* doc, const QString& path) {
     return ok;
 }
 
+Document::DocumentType DocumentManager::getDocumentTypeFromFileSuffix(QString suffix) {
+    if (suffix == QStringLiteral("scr")) {
+        return Document::RichText;
+    }
+    if (suffix == QStringLiteral("sc") || suffix == QStringLiteral("scd") || suffix == QStringLiteral("schelp")) {
+        return Document::SuperCollider;
+    }
+    return Document::PlainText;
+}
+
 bool DocumentManager::doSaveAs(Document* doc, const QString& path) {
     Q_ASSERT(doc);
 
-    doc->deleteTrailingSpaces();
-
+    // Don't delete trailing spaces for rich text documents
+    if (!doc->isRichText())
+        doc->deleteTrailingSpaces();
 
     QFile file(path);
     if (!file.open(QIODevice::WriteOnly)) {
@@ -500,15 +532,20 @@ bool DocumentManager::doSaveAs(Document* doc, const QString& path) {
     if (pathChanged)
         mFsWatcher.removePath(doc->filePath());
 
-    QString str = doc->textDocument()->toPlainText();
+    // Rich text documents are saved as HTML, others as plain text
+    QString str;
+    if (doc->isRichText()) {
+        str = doc->textDocument()->toHtml();
+    } else {
+        str = doc->textDocument()->toPlainText();
+    }
     file.write(str.toUtf8());
     file.flush();
     file.close();
 
     info.refresh();
 
-    const bool fileIsPlainText = !(info.suffix() == QStringLiteral("sc") || (info.suffix() == QStringLiteral("scd"))
-                                   || (info.suffix() == QStringLiteral("schelp")));
+    auto docType = getDocumentTypeFromFileSuffix(info.suffix());
 
     // It's possible the mod time has not been updated - if it looks like that is the case,
     // just set it one second in the future, so we don't trip the external modification alarm.
@@ -522,7 +559,7 @@ bool DocumentManager::doSaveAs(Document* doc, const QString& path) {
     QString fileTitle = info.fileName();
     doc->setTitle(fileTitle);
     doc->mDoc->setModified(false);
-    doc->setPlainText(fileIsPlainText);
+    doc->setDocumentType(docType);
     doc->removeTmpFile();
 
     // Always try to start watching, because the file could have been removed:
@@ -725,8 +762,8 @@ void DocumentManager::handleNewDocScRequest(const QString& data) {
             std::string text = doc[1].as<std::string>();
             std::string id = doc[2].as<std::string>();
 
-            Document* document =
-                createDocument(false, id.c_str(), QString::fromUtf8(title.c_str()), QString::fromUtf8(text.c_str()));
+            Document* document = createDocument(Document::SuperCollider, id.c_str(), QString::fromUtf8(title.c_str()),
+                                                QString::fromUtf8(text.c_str()));
             syncLangDocument(document);
             Q_EMIT(opened(document, 0, 0));
         }

--- a/editors/sc-ide/core/doc_manager.hpp
+++ b/editors/sc-ide/core/doc_manager.hpp
@@ -55,7 +55,9 @@ class Document : public QObject {
     friend class DocumentManager;
 
 public:
-    Document(bool isPlainText, const QByteArray& id = QByteArray(), const QString& title = QString(),
+    enum DocumentType { PlainText, SuperCollider, RichText };
+
+    Document(DocumentType docType, const QByteArray& id = QByteArray(), const QString& title = QString(),
              const QString& text = QString());
 
     QTextDocument* textDocument() { return mDoc; }
@@ -75,7 +77,10 @@ public:
 
     void deleteTrailingSpaces();
 
-    bool isPlainText() const { return mHighlighter == NULL; }
+    DocumentType documentType() const { return mDocType; }
+    bool isPlainText() const { return mDocType == PlainText; }
+    bool isRichText() const { return mDocType == RichText; }
+    bool isSuperCollider() const { return mDocType == SuperCollider; }
     bool isModified() const { return mDoc->isModified(); }
 
     QStandardItem* modelItem() { return mModelItem; }
@@ -131,9 +136,10 @@ signals:
     void defaultFontChanged();
 
 private:
-    void setPlainText(bool flag);
+    void setDocumentType(DocumentType docType);
 
     QByteArray mId;
+    DocumentType mDocType;
     QTextDocument* mDoc;
     QString mFilePath;
     QString mTitle;
@@ -169,6 +175,7 @@ public:
     void close(Document*);
     bool save(Document*);
     bool saveAs(Document*, const QString& path);
+    static Document::DocumentType getDocumentTypeFromFileSuffix(QString suffix);
     bool reload(Document*);
     bool needRestore();
     void restore();
@@ -204,9 +211,13 @@ private slots:
     void onFileChanged(const QString& path);
     void updateCurrentDocContents(int position, int charsRemoved, int charsAdded);
 
+public slots:
+    void createRichDocument();
+
 private:
-    Document* createDocument(bool isPlainText = false, const QByteArray& id = QByteArray(),
-                             const QString& title = QString(), const QString& text = QString());
+    Document* createDocument(Document::DocumentType docType = Document::SuperCollider,
+                             const QByteArray& id = QByteArray(), const QString& title = QString(),
+                             const QString& text = QString());
     bool doSaveAs(Document*, const QString& path);
     void addToRecent(Document*);
     void loadRecentDocuments(Settings::Manager*);

--- a/editors/sc-ide/widgets/code_editor/rich_editor.cpp
+++ b/editors/sc-ide/widgets/code_editor/rich_editor.cpp
@@ -1,0 +1,424 @@
+#include "rich_editor.hpp"
+#include "rich_toolbar.hpp"
+#include "tokens.hpp"
+#include "../../core/main.hpp"
+#include "../../core/doc_manager.hpp"
+#include "../../core/sc_lexer.hpp"
+#include "../../core/settings/manager.hpp"
+#include "../../core/settings/theme.hpp"
+
+#include <QApplication>
+#include <QDebug>
+#include <QGraphicsView>
+#include <QKeyEvent>
+#include <QPropertyAnimation>
+#include <QScrollBar>
+#include <QTextBlock>
+#include <QTimer>
+#include <QVBoxLayout>
+
+#include "help_browser.hpp"
+#include "main_window.hpp"
+#include "sc_editor.hpp"
+
+namespace ScIDE {
+
+/*! @class RichTextEditor
+ *  @brief This is based on ScCodeEditor and GenericCodeEditor
+ *
+ *  @discussion There are some differences to the GenericCodeEditor:
+ *  * Bracket/Region based evaluation is not implemented yet. The necessary code can be found at
+ *    `ScCodeEditor::evaluateRegion`, but it seems better to properly move this into a dedicated
+ *    independent implementation so it can be re-used by both editors.
+ *  * Since the pinch zooming on the GenericCodeEditor simply re-scales the font size of its text,
+ *  we would need a different approach here, therefore this feature is not implemented.
+ *  * The line indicator (mLineIndicator) is not implemented here.
+ *  * Find/replace/go-to widgets are not implemented
+ */
+RichTextEditor::RichTextEditor(Document* doc, QWidget* parent):
+    QTextEdit(parent),
+    mDoc(doc),
+    mSettings(Main::settings()),
+    mToolbar(nullptr),
+    mOverlay(nullptr),
+    mOverlayWidget(nullptr),
+    mBlinkDuration(600),
+    mEditorBoxIsActive(false),
+    mInactiveFadeAlpha(0) {
+    Q_ASSERT(mDoc != nullptr);
+
+    setFrameShape(QFrame::NoFrame);
+
+    // Set up the overlay for blink animation
+    mOverlay = new QGraphicsScene(this);
+
+    QPalette overlayPalette;
+    overlayPalette.setBrush(QPalette::Base, Qt::NoBrush);
+
+    QGraphicsView* overlayView = new QGraphicsView(mOverlay, this);
+    overlayView->setFrameShape(QFrame::NoFrame);
+    overlayView->setPalette(overlayPalette);
+    overlayView->setFocusPolicy(Qt::NoFocus);
+    overlayView->setAttribute(Qt::WA_TransparentForMouseEvents, true);
+    overlayView->setSceneRect(QRectF(0, 0, 1, 1));
+    overlayView->setAlignment(Qt::AlignLeft | Qt::AlignTop);
+
+    mOverlayWidget = overlayView;
+
+    // Create and set up toolbar
+    setupToolbar();
+
+    // Connect to document signals
+    connect(mDoc, &Document::defaultFontChanged, this, [this]() { setFont(mDoc->defaultFont()); });
+    connect(this, &QTextEdit::selectionChanged, this, &RichTextEditor::updateDocLastSelection);
+    connect(Main::instance(), &Main::applySettingsRequest, this, &RichTextEditor::applySettings);
+
+    QTextEdit::setDocument(doc->textDocument());
+
+    applySettings(mSettings);
+}
+
+RichTextEditor::~RichTextEditor() {}
+
+void RichTextEditor::setupToolbar() {
+    mToolbar = new RichTextToolbar(this, this, mSettings->codeFont());
+    // Toolbar height will be used to set viewport margins
+    int toolbarHeight = mToolbar->sizeHint().height();
+    setViewportMargins(0, toolbarHeight, 0, 0);
+    mToolbar->move(0, 0);
+}
+
+/*! This only resizes the toolbar currently, not the document */
+void RichTextEditor::resizeEvent(QResizeEvent* event) {
+    QTextEdit::resizeEvent(event);
+
+    // Resize the toolbar to match editor width
+    if (mToolbar) {
+        mToolbar->resize(width(), mToolbar->sizeHint().height());
+    }
+
+    // Resize the overlay widget to match the viewport
+    if (mOverlayWidget) {
+        mOverlayWidget->resize(viewport()->size());
+        mOverlayWidget->move(viewport()->pos());
+    }
+}
+
+void RichTextEditor::applySettings(Settings::Manager* settings) {
+    settings->beginGroup("IDE/editor");
+
+    bool lineWrap = settings->value("lineWrap").toBool();
+    mInactiveFadeAlpha = settings->value("inactiveEditorFadeAlpha").toInt();
+    mBlinkDuration = settings->value("blinkDuration").toInt();
+
+    QPalette palette;
+
+    const QTextCharFormat* format = &settings->getThemeVal("text");
+    QBrush bg = format->background();
+    QBrush fg = format->foreground();
+    if (bg.style() != Qt::NoBrush)
+        palette.setBrush(QPalette::Base, bg);
+    if (fg.style() != Qt::NoBrush)
+        palette.setBrush(QPalette::Text, fg);
+
+    format = &settings->getThemeVal("selection");
+    bg = format->background();
+    fg = format->foreground();
+    if (bg.style() != Qt::NoBrush)
+        palette.setBrush(QPalette::Highlight, bg);
+    if (fg.style() != Qt::NoBrush)
+        palette.setBrush(QPalette::HighlightedText, fg);
+
+    setPalette(palette);
+
+    setLineWrapMode(lineWrap ? WidgetWidth : NoWrap);
+
+    settings->endGroup();
+}
+
+void RichTextEditor::setActiveAppearance(bool active) { mEditorBoxIsActive = active; }
+
+void RichTextEditor::showPosition(int charPosition, int selectionLength) {
+    QTextCursor cursor(textDocument());
+    cursor.setPosition(charPosition);
+    if (selectionLength > 0)
+        cursor.setPosition(charPosition + selectionLength, QTextCursor::KeepAnchor);
+    setTextCursor(cursor);
+    ensureCursorVisible();
+}
+
+QString RichTextEditor::symbolUnderCursor() {
+    QTextCursor cursor = textCursor();
+    cursor.select(QTextCursor::WordUnderCursor);
+    return cursor.selectedText();
+}
+
+bool RichTextEditor::openDocumentation() { return Main::openDocumentation(symbolUnderCursor()); }
+
+void RichTextEditor::openDefinition() { Main::openDefinition(symbolUnderCursor(), this); }
+
+void RichTextEditor::openCommandLine() { Main::openCommandLine(symbolUnderCursor()); }
+
+void RichTextEditor::findReferences() { Main::findReferences(symbolUnderCursor(), this); }
+
+void RichTextEditor::evaluateLine() {
+#ifdef SC_USE_QTWEBENGINE
+    HelpBrowserDocklet* help = MainWindow::instance()->helpBrowserDocklet();
+    if (help && help->browser()->helpBrowserHasFocus()) {
+        help->browser()->evaluateSelection(true);
+        return; // early return
+    }
+#endif // SC_USE_QTWEBENGINE
+
+    QString text;
+
+    QTextCursor cursor = textCursor();
+    if (cursor.hasSelection()) {
+        text = cursor.selectedText();
+    } else {
+        text = cursor.block().text();
+
+        // Adjust cursor for code blinking
+        cursor.movePosition(QTextCursor::StartOfBlock);
+        cursor.movePosition(QTextCursor::EndOfBlock, QTextCursor::KeepAnchor);
+    }
+
+    if (text.isEmpty())
+        return;
+
+    // Replace paragraph separators with newlines
+    text.replace(QChar(0x2029), QChar('\n'));
+
+    Main::evaluateCode(text);
+    blinkCode(cursor);
+}
+
+void RichTextEditor::evaluateRegion() {
+#ifdef SC_USE_QTWEBENGINE
+    HelpBrowserDocklet* help = MainWindow::instance()->helpBrowserDocklet();
+    if (help && help->browser()->helpBrowserHasFocus()) {
+        help->browser()->evaluateSelection(true);
+        return; // early return
+    }
+#endif // SC_USE_QTWEBENGINE
+
+    // In rich text, we don't have bracket-based regions
+    // Just evaluate selection or current line
+    evaluateLine();
+}
+
+void RichTextEditor::evaluateDocument() {
+    QString documentText = textDocument()->toPlainText();
+    Main::evaluateCode(documentText);
+}
+
+void RichTextEditor::blinkCode(const QTextCursor& c) {
+    if (!c.document() || !c.hasSelection())
+        return;
+
+    // For QTextEdit, we use extra selections to highlight the evaluated code
+    Settings::Manager* settings = Main::settings();
+    QTextCharFormat evalCodeTextFormat = settings->getThemeVal("evaluatedCode");
+
+    QTextEdit::ExtraSelection selection;
+    selection.cursor = c;
+    selection.format = evalCodeTextFormat;
+
+    QList<QTextEdit::ExtraSelection> extraSelections;
+    extraSelections.append(selection);
+    setExtraSelections(extraSelections);
+
+    // Use a timer to clear the highlight after the blink duration
+    QTimer::singleShot(mBlinkDuration, this, [this]() { setExtraSelections(QList<QTextEdit::ExtraSelection>()); });
+}
+
+void RichTextEditor::applyCodeFormat() {
+    QTextCursor cursor = textCursor();
+    if (!cursor.hasSelection())
+        return;
+
+    QFont codeFont = mSettings->codeFont();
+
+    // Get theme formats
+    const QTextCharFormat& textFormat = mSettings->getThemeVal("text");
+    const QTextCharFormat& keywordFormat = mSettings->getThemeVal("keyword");
+    const QTextCharFormat& builtinFormat = mSettings->getThemeVal("built-in");
+    const QTextCharFormat& primitiveFormat = mSettings->getThemeVal("primitive");
+    const QTextCharFormat& classFormat = mSettings->getThemeVal("class");
+    const QTextCharFormat& numberFormat = mSettings->getThemeVal("number");
+    const QTextCharFormat& symbolFormat = mSettings->getThemeVal("symbol");
+    const QTextCharFormat& envVarFormat = mSettings->getThemeVal("env-var");
+    const QTextCharFormat& stringFormat = mSettings->getThemeVal("string");
+    const QTextCharFormat& charFormat = mSettings->getThemeVal("char");
+    const QTextCharFormat& commentFormat = mSettings->getThemeVal("comment");
+
+    int selectionStart = cursor.selectionStart();
+    QString selectedText = cursor.selectedText();
+
+    // Replace paragraph separators with newlines for lexer
+    selectedText.replace(QChar(0x2029), QChar('\n'));
+
+    // First, apply base code font to entire selection
+    QTextCharFormat baseFormat;
+    baseFormat.setFont(codeFont);
+    if (textFormat.foreground().style() != Qt::NoBrush)
+        baseFormat.setForeground(textFormat.foreground());
+    cursor.mergeCharFormat(baseFormat);
+
+    // Now tokenize and apply syntax highlighting
+    ScLexer lexer(selectedText);
+
+    while (lexer.offset() < selectedText.length()) {
+        int tokenLength = 0;
+        int tokenStart = lexer.offset();
+        Token::Type tokenType = lexer.nextToken(tokenLength);
+
+        if (tokenLength == 0)
+            break;
+
+        const QTextCharFormat* formatToApply = nullptr;
+
+        switch (tokenType) {
+        case Token::Keyword:
+            formatToApply = &keywordFormat;
+            break;
+        case Token::Builtin:
+            formatToApply = &builtinFormat;
+            break;
+        case Token::Primitive:
+            formatToApply = &primitiveFormat;
+            break;
+        case Token::Class:
+            formatToApply = &classFormat;
+            break;
+        case Token::Float:
+        case Token::HexInt:
+        case Token::ScaleDegreeFloat:
+        case Token::RadixFloat:
+            formatToApply = &numberFormat;
+            break;
+        case Token::Symbol:
+        case Token::SymbolArg:
+        case Token::SymbolMark:
+            formatToApply = &symbolFormat;
+            break;
+        case Token::EnvVar:
+            formatToApply = &envVarFormat;
+            break;
+        case Token::StringMark:
+            formatToApply = &stringFormat;
+            break;
+        case Token::Char:
+            formatToApply = &charFormat;
+            break;
+        case Token::SingleLineComment:
+        case Token::MultiLineCommentStart:
+        case Token::MultiLineCommentEnd:
+            formatToApply = &commentFormat;
+            break;
+        default:
+            break;
+        }
+
+        if (formatToApply && formatToApply->foreground().style() != Qt::NoBrush) {
+            QTextCursor tokenCursor(textDocument());
+            tokenCursor.setPosition(selectionStart + tokenStart);
+            tokenCursor.setPosition(selectionStart + tokenStart + tokenLength, QTextCursor::KeepAnchor);
+
+            QTextCharFormat tokenFormat;
+            tokenFormat.setForeground(formatToApply->foreground());
+            if (formatToApply->fontWeight() != QFont::Normal)
+                tokenFormat.setFontWeight(formatToApply->fontWeight());
+            if (formatToApply->fontItalic())
+                tokenFormat.setFontItalic(true);
+
+            tokenCursor.mergeCharFormat(tokenFormat);
+        }
+    }
+
+    setTextCursor(cursor);
+}
+
+void RichTextEditor::setSelectionFont(const QFont& font) {
+    QTextCursor cursor = textCursor();
+    // if (!cursor.hasSelection())
+    //     return;
+
+    QTextCharFormat format;
+    format.setFontFamilies(QStringList() << font.family());
+    cursor.mergeCharFormat(format);
+    setTextCursor(cursor);
+}
+
+void RichTextEditor::setSelectionFontSize(int size) {
+    QTextCursor cursor = textCursor();
+    if (!cursor.hasSelection())
+        return;
+
+    QTextCharFormat format;
+    format.setFontPointSize(size);
+    cursor.mergeCharFormat(format);
+    setTextCursor(cursor);
+}
+
+void RichTextEditor::setSelectionColor(const QColor& color) {
+    QTextCursor cursor = textCursor();
+    if (!cursor.hasSelection())
+        return;
+
+    QTextCharFormat format;
+    format.setForeground(color);
+    cursor.mergeCharFormat(format);
+    setTextCursor(cursor);
+}
+
+void RichTextEditor::toggleBold() {
+    QTextCursor cursor = textCursor();
+    QTextCharFormat format = cursor.charFormat();
+    bool isBold = format.fontWeight() >= QFont::Bold;
+
+    QTextCharFormat newFormat;
+    newFormat.setFontWeight(isBold ? QFont::Normal : QFont::Bold);
+    cursor.mergeCharFormat(newFormat);
+    setTextCursor(cursor);
+}
+
+void RichTextEditor::toggleItalic() {
+    QTextCursor cursor = textCursor();
+    QTextCharFormat format = cursor.charFormat();
+
+    QTextCharFormat newFormat;
+    newFormat.setFontItalic(!format.fontItalic());
+    cursor.mergeCharFormat(newFormat);
+    setTextCursor(cursor);
+}
+
+void RichTextEditor::toggleUnderline() {
+    QTextCursor cursor = textCursor();
+    QTextCharFormat format = cursor.charFormat();
+
+    QTextCharFormat newFormat;
+    newFormat.setFontUnderline(!format.fontUnderline());
+    cursor.mergeCharFormat(newFormat);
+    setTextCursor(cursor);
+}
+
+void RichTextEditor::toggleStrikeOut() {
+    QTextCursor cursor = textCursor();
+    QTextCharFormat format = cursor.charFormat();
+
+    QTextCharFormat newFormat;
+    newFormat.setFontStrikeOut(!format.fontStrikeOut());
+    cursor.mergeCharFormat(newFormat);
+    setTextCursor(cursor);
+}
+
+
+void RichTextEditor::closeDocument() { Main::documentManager()->close(mDoc); }
+
+void RichTextEditor::updateDocLastSelection() {
+    QTextCursor cursor = textCursor();
+    mDoc->setInitialSelection(cursor.selectionStart(), cursor.selectionEnd() - cursor.selectionStart());
+}
+
+} // namespace ScIDE

--- a/editors/sc-ide/widgets/code_editor/rich_editor.cpp
+++ b/editors/sc-ide/widgets/code_editor/rich_editor.cpp
@@ -17,9 +17,11 @@
 #include <QTimer>
 #include <QVBoxLayout>
 
-#include "help_browser.hpp"
 #include "main_window.hpp"
 #include "sc_editor.hpp"
+#ifdef SC_USE_QTWEBENGINE
+#    include "help_browser.hpp"
+#endif
 
 namespace ScIDE {
 

--- a/editors/sc-ide/widgets/code_editor/rich_editor.hpp
+++ b/editors/sc-ide/widgets/code_editor/rich_editor.hpp
@@ -1,0 +1,104 @@
+/*
+    SuperCollider Qt IDE
+    Copyright (c) 2012 Jakob Leben & Tim Blechmann
+    http://www.audiosynth.com
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
+*/
+
+#pragma once
+
+#include <qgesture.h>
+#include <QTextEdit>
+#include <QGraphicsScene>
+
+namespace ScIDE {
+
+namespace Settings {
+class Manager;
+}
+
+class Document;
+class RichTextToolbar;
+
+class RichTextEditor : public QTextEdit {
+    Q_OBJECT
+
+public:
+    RichTextEditor(Document* doc, QWidget* parent = nullptr);
+    ~RichTextEditor();
+
+    // Rule of 5 - delete copy/move operations
+    RichTextEditor(const RichTextEditor& other) = delete;
+    RichTextEditor& operator=(const RichTextEditor& other) = delete;
+    RichTextEditor(RichTextEditor&& other) = delete;
+    RichTextEditor& operator=(RichTextEditor&& other) = delete;
+
+    Document* document() { return mDoc; }
+    QTextDocument* textDocument() { return QTextEdit::document(); }
+
+    void showPosition(int charPosition, int selectionLength = 0);
+    QString symbolUnderCursor();
+
+    // Lookup methods (invoked by MainWindow via meta-object)
+    Q_INVOKABLE bool openDocumentation();
+    Q_INVOKABLE void openDefinition();
+    Q_INVOKABLE void openCommandLine();
+    Q_INVOKABLE void findReferences();
+
+    RichTextToolbar* toolbar() { return mToolbar; }
+
+    void blinkCode(const QTextCursor& c);
+
+public slots:
+    void applySettings(Settings::Manager*);
+    void setActiveAppearance(bool active);
+
+    // Code execution
+    void evaluateLine();
+    void evaluateRegion();
+    void evaluateDocument();
+
+    // Formatting
+    void applyCodeFormat();
+    void setSelectionFont(const QFont& font);
+    void setSelectionFontSize(int size);
+    void setSelectionColor(const QColor& color);
+    void toggleBold();
+    void toggleItalic();
+    void toggleUnderline();
+    void toggleStrikeOut();
+
+    void closeDocument();
+    void updateDocLastSelection();
+
+protected:
+    void resizeEvent(QResizeEvent* event) override;
+
+private:
+    void setupToolbar();
+
+    Document* const mDoc;
+    Settings::Manager* mSettings;
+    RichTextToolbar* mToolbar;
+    QGraphicsScene* mOverlay;
+    QWidget* mOverlayWidget;
+
+    int mBlinkDuration;
+    bool mEditorBoxIsActive;
+    int mInactiveFadeAlpha;
+};
+
+} // namespace ScIDE

--- a/editors/sc-ide/widgets/code_editor/rich_toolbar.cpp
+++ b/editors/sc-ide/widgets/code_editor/rich_toolbar.cpp
@@ -1,0 +1,231 @@
+#include "rich_toolbar.hpp"
+#include "rich_editor.hpp"
+
+#include <QColorDialog>
+#include <QFontComboBox>
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QPixmap>
+#include <QSpinBox>
+#include <QTextCursor>
+#include <QToolButton>
+
+namespace ScIDE {
+
+RichTextToolbar::RichTextToolbar(RichTextEditor* editor, QWidget* parent, QFont defaultFont):
+    QToolBar(parent),
+    mEditor(editor),
+    mCurrentColor(Qt::black) {
+    setMovable(false);
+    setFloatable(false);
+    setIconSize(QSize(16, 16));
+
+    // Font family combo box
+    mFontCombo = new QFontComboBox(this);
+    mFontCombo->setToolTip(tr("Font Family"));
+    mFontCombo->setMaximumWidth(250);
+    mFontCombo->setCurrentFont(defaultFont);
+    addWidget(mFontCombo);
+
+    addSeparator();
+
+    // Font size spin box
+    QLabel* sizeLabel = new QLabel(tr("Size:"), this);
+    addWidget(sizeLabel);
+
+    mSizeSpinBox = new QSpinBox(this);
+    mSizeSpinBox->setToolTip(tr("Font Size"));
+    mSizeSpinBox->setRange(4, 180);
+    mSizeSpinBox->setValue(12);
+    mSizeSpinBox->setMaximumWidth(100);
+    addWidget(mSizeSpinBox);
+
+    addSeparator();
+
+    // Color button
+    mColorButton = new QToolButton(this);
+    mColorButton->setToolTip(tr("Text Color"));
+    updateColorButtonIcon(mCurrentColor);
+    addWidget(mColorButton);
+
+    addSeparator();
+
+    // Bold button
+    mBoldButton = new QToolButton(this);
+    mBoldButton->setText(tr("B"));
+    mBoldButton->setToolTip(tr("Bold"));
+    mBoldButton->setCheckable(true);
+    mBoldButton->setFont(QFont(mBoldButton->font().family(), 14, QFont::Bold));
+    addWidget(mBoldButton);
+
+    // Italic button
+    mItalicButton = new QToolButton(this);
+    mItalicButton->setText(tr("I"));
+    mItalicButton->setToolTip(tr("Italic"));
+    mItalicButton->setCheckable(true);
+    QFont italicFont = mItalicButton->font();
+    italicFont.setItalic(true);
+    italicFont.setPointSize(14);
+    mItalicButton->setFont(italicFont);
+    addWidget(mItalicButton);
+
+    // Underline button
+    mUnderlineButton = new QToolButton(this);
+    mUnderlineButton->setText(tr("U"));
+    mUnderlineButton->setToolTip(tr("Underline"));
+    mUnderlineButton->setCheckable(true);
+    QFont underlineFont = mUnderlineButton->font();
+    underlineFont.setUnderline(true);
+    underlineFont.setPointSize(14);
+    mUnderlineButton->setFont(underlineFont);
+    addWidget(mUnderlineButton);
+
+    // Strikeout button
+    mStrikeOutButton = new QToolButton(this);
+    mStrikeOutButton->setText(tr("S"));
+    mStrikeOutButton->setToolTip(tr("Strikeout"));
+    mStrikeOutButton->setCheckable(true);
+    QFont strikeFont = mStrikeOutButton->font();
+    strikeFont.setStrikeOut(true);
+    strikeFont.setPointSize(14);
+    mStrikeOutButton->setFont(strikeFont);
+    addWidget(mStrikeOutButton);
+
+    addSeparator();
+
+    // Code format button
+    mCodeButton = new QToolButton(this);
+    mCodeButton->setText(tr("Code"));
+    mCodeButton->setToolTip(tr("Apply Code Format"));
+    QFont codeFont = QFontDatabase::systemFont(QFontDatabase::FixedFont);
+    codeFont.setPointSize(14);
+    mCodeButton->setFont(codeFont);
+    addWidget(mCodeButton);
+
+    // Connect signals
+    connect(mFontCombo, &QFontComboBox::currentFontChanged, this, &RichTextToolbar::onFontFamilyChanged);
+
+    connect(mSizeSpinBox, QOverload<int>::of(&QSpinBox::valueChanged), this, &RichTextToolbar::onFontSizeChanged);
+
+    connect(mBoldButton, &QToolButton::clicked, this, &RichTextToolbar::onBoldClicked);
+
+    connect(mItalicButton, &QToolButton::clicked, this, &RichTextToolbar::onItalicClicked);
+
+    connect(mUnderlineButton, &QToolButton::clicked, this, &RichTextToolbar::onUnderlineClicked);
+
+    connect(mStrikeOutButton, &QToolButton::clicked, this, &RichTextToolbar::onStrikeOutClicked);
+
+    connect(mColorButton, &QToolButton::clicked, this, &RichTextToolbar::onColorButtonClicked);
+
+    connect(mCodeButton, &QToolButton::clicked, this, &RichTextToolbar::onCodeFormatClicked);
+
+    // Update toolbar state when selection changes
+    connect(mEditor, &QTextEdit::cursorPositionChanged, this, &RichTextToolbar::updateFromSelection);
+
+    // Initialize toolbar state from current selection
+    updateFromSelection();
+}
+
+QSize RichTextToolbar::sizeHint() const {
+    QSize hint = QToolBar::sizeHint();
+    hint.setHeight(qMin(hint.height(), 32));
+    return hint;
+}
+
+void RichTextToolbar::onFontFamilyChanged(const QFont& font) {
+    mEditor->setSelectionFont(font);
+    mEditor->setFocus();
+}
+
+void RichTextToolbar::onFontSizeChanged(int size) {
+    mEditor->setSelectionFontSize(size);
+    mEditor->setFocus();
+}
+
+void RichTextToolbar::onBoldClicked() {
+    mEditor->toggleBold();
+    mEditor->setFocus();
+}
+
+void RichTextToolbar::onItalicClicked() {
+    mEditor->toggleItalic();
+    mEditor->setFocus();
+}
+
+void RichTextToolbar::onUnderlineClicked() {
+    mEditor->toggleUnderline();
+    mEditor->setFocus();
+}
+
+void RichTextToolbar::onStrikeOutClicked() {
+    mEditor->toggleStrikeOut();
+    mEditor->setFocus();
+}
+
+void RichTextToolbar::onColorButtonClicked() {
+    QColor color = QColorDialog::getColor(mCurrentColor, this, tr("Select Text Color"));
+    if (color.isValid()) {
+        mCurrentColor = color;
+        updateColorButtonIcon(color);
+        mEditor->setSelectionColor(color);
+    }
+    mEditor->setFocus();
+}
+
+void RichTextToolbar::onCodeFormatClicked() {
+    mEditor->applyCodeFormat();
+    mEditor->setFocus();
+}
+
+void RichTextToolbar::updateFromSelection() {
+    QTextCursor cursor = mEditor->textCursor();
+    QTextCharFormat format = cursor.charFormat();
+
+    // Block signals while updating to prevent feedback loops
+    mFontCombo->blockSignals(true);
+    mSizeSpinBox->blockSignals(true);
+    mBoldButton->blockSignals(true);
+    mItalicButton->blockSignals(true);
+    mUnderlineButton->blockSignals(true);
+    mStrikeOutButton->blockSignals(true);
+
+    // Update font family
+    QString fontFamily = format.fontFamilies().toStringList().value(0, mFontCombo->currentFont().family());
+    if (!fontFamily.isEmpty()) {
+        mFontCombo->setCurrentFont(QFont(fontFamily));
+    }
+
+    // Update font size
+    qreal pointSize = format.fontPointSize();
+    if (pointSize > 0) {
+        mSizeSpinBox->setValue(static_cast<int>(pointSize));
+    }
+
+    // Update bold/italic/underline/strikeout buttons
+    mBoldButton->setChecked(format.fontWeight() >= QFont::Bold);
+    mItalicButton->setChecked(format.fontItalic());
+    mUnderlineButton->setChecked(format.fontUnderline());
+    mStrikeOutButton->setChecked(format.fontStrikeOut());
+
+    // Update color
+    QColor textColor = format.foreground().color();
+    if (textColor.isValid()) {
+        mCurrentColor = textColor;
+        updateColorButtonIcon(textColor);
+    }
+
+    mFontCombo->blockSignals(false);
+    mSizeSpinBox->blockSignals(false);
+    mBoldButton->blockSignals(false);
+    mItalicButton->blockSignals(false);
+    mUnderlineButton->blockSignals(false);
+    mStrikeOutButton->blockSignals(false);
+}
+
+void RichTextToolbar::updateColorButtonIcon(const QColor& color) {
+    QPixmap pixmap(28, 28);
+    pixmap.fill(color);
+    mColorButton->setIcon(QIcon(pixmap));
+}
+
+} // namespace ScIDE

--- a/editors/sc-ide/widgets/code_editor/rich_toolbar.hpp
+++ b/editors/sc-ide/widgets/code_editor/rich_toolbar.hpp
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <QToolBar>
+
+class QFontComboBox;
+class QSpinBox;
+class QToolButton;
+
+namespace ScIDE {
+
+class RichTextEditor;
+
+class RichTextToolbar : public QToolBar {
+    Q_OBJECT
+
+public:
+    RichTextToolbar(RichTextEditor* editor, QWidget* parent = nullptr, QFont defaultFont = {});
+    void setStartFont(const QFont& font);
+
+    QSize sizeHint() const override;
+
+private slots:
+    void onFontFamilyChanged(const QFont& font);
+    void onFontSizeChanged(int size);
+    void onBoldClicked();
+    void onItalicClicked();
+    void onUnderlineClicked();
+    void onStrikeOutClicked();
+    void onColorButtonClicked();
+    void onCodeFormatClicked();
+    void updateFromSelection();
+
+private:
+    void updateColorButtonIcon(const QColor& color);
+
+    RichTextEditor* mEditor;
+    QFontComboBox* mFontCombo;
+    QSpinBox* mSizeSpinBox;
+    QToolButton* mBoldButton;
+    QToolButton* mItalicButton;
+    QToolButton* mUnderlineButton;
+    QToolButton* mStrikeOutButton;
+    QToolButton* mColorButton;
+    QToolButton* mCodeButton;
+    QColor mCurrentColor;
+};
+
+} // namespace ScIDE

--- a/editors/sc-ide/widgets/editor_box.cpp
+++ b/editors/sc-ide/widgets/editor_box.cpp
@@ -20,6 +20,7 @@
 
 #include "editor_box.hpp"
 #include "code_editor/sc_editor.hpp"
+#include "code_editor/rich_editor.hpp"
 #include "../core/main.hpp"
 
 #include <QPainter>
@@ -114,23 +115,42 @@ void CodeEditorBox::setDocument(Document* doc, int pos, int selectionLength) {
     if (!doc)
         return;
 
-    GenericCodeEditor* editor = currentEditor();
-    bool switchEditor = !editor || editor->document() != doc;
+    QWidget* editor = currentEditor();
+    bool switchEditor = !editor || documentForEditor(editor) != doc;
 
     if (switchEditor) {
         editor = editorForDocument(doc);
         if (!editor) {
-            editor = doc->isPlainText() ? new GenericCodeEditor(doc) : new ScCodeEditor(doc);
-            editor->installEventFilter(this);
-            mHistory.prepend(editor);
-            mLayout->addWidget(editor);
-            connect(this, &CodeEditorBox::activeChanged, editor, &GenericCodeEditor::setActiveAppearance);
+            // Create appropriate editor type based on document type
+            if (doc->isRichText()) {
+                RichTextEditor* richEditor = new RichTextEditor(doc);
+                editor = richEditor;
+                editor->installEventFilter(this);
+                mHistory.prepend(editor);
+                mLayout->addWidget(editor);
+                connect(this, &CodeEditorBox::activeChanged, richEditor, &RichTextEditor::setActiveAppearance);
+            } else {
+                GenericCodeEditor* codeEditor = doc->isPlainText() ? new GenericCodeEditor(doc) : new ScCodeEditor(doc);
+                editor = codeEditor;
+                editor->installEventFilter(this);
+                mHistory.prepend(editor);
+                mLayout->addWidget(editor);
+                connect(this, &CodeEditorBox::activeChanged, codeEditor, &GenericCodeEditor::setActiveAppearance);
+            }
         } else {
             mHistory.removeOne(editor);
             mHistory.prepend(editor);
         }
-        editor->setActiveAppearance(this->isActive());
-        editor->setReadOnly(!doc->editable());
+
+        // Set active appearance and read-only state
+        if (GenericCodeEditor* codeEditor = qobject_cast<GenericCodeEditor*>(editor)) {
+            codeEditor->setActiveAppearance(this->isActive());
+            codeEditor->setReadOnly(!doc->editable());
+        } else if (RichTextEditor* richEditor = qobject_cast<RichTextEditor*>(editor)) {
+            richEditor->setActiveAppearance(this->isActive());
+            richEditor->setReadOnly(!doc->editable());
+        }
+
         mLayout->setCurrentWidget(editor);
         setFocusProxy(editor);
         int modelIndex = doc->modelItem()->index().row();
@@ -145,15 +165,20 @@ void CodeEditorBox::setDocument(Document* doc, int pos, int selectionLength) {
         }
     }
 
-    if (pos != -1)
-        editor->showPosition(pos, selectionLength);
+    if (pos != -1) {
+        if (GenericCodeEditor* codeEditor = qobject_cast<GenericCodeEditor*>(editor)) {
+            codeEditor->showPosition(pos, selectionLength);
+        } else if (RichTextEditor* richEditor = qobject_cast<RichTextEditor*>(editor)) {
+            richEditor->showPosition(pos, selectionLength);
+        }
+    }
 
     if (switchEditor)
         emit currentChanged(editor);
 }
 
 void CodeEditorBox::onDocumentClosed(Document* doc) {
-    GenericCodeEditor* editor = editorForDocument(doc);
+    QWidget* editor = editorForDocument(doc);
     if (editor) {
         bool wasCurrent = editor == currentEditor();
         mHistory.removeAll(editor);
@@ -176,60 +201,113 @@ void CodeEditorBox::onDocumentSaved(Document* doc) {
     if (history_idx == -1)
         return;
 
-    GenericCodeEditor* editor = mHistory[history_idx];
-    if (doc->isPlainText() == (qobject_cast<ScCodeEditor*>(editor) == 0))
+    QWidget* editorWidget = mHistory[history_idx];
+
+    // Check if editor type matches document type
+    bool needsReplacement = false;
+    if (doc->isRichText()) {
+        // Rich text document needs RichTextEditor
+        needsReplacement = (qobject_cast<RichTextEditor*>(editorWidget) == nullptr);
+    } else if (doc->isPlainText()) {
+        // Plain text needs GenericCodeEditor (not ScCodeEditor)
+        needsReplacement = (qobject_cast<ScCodeEditor*>(editorWidget) != nullptr)
+            || (qobject_cast<RichTextEditor*>(editorWidget) != nullptr);
+    } else {
+        // SuperCollider document needs ScCodeEditor
+        needsReplacement = (qobject_cast<ScCodeEditor*>(editorWidget) == nullptr);
+    }
+
+    if (!needsReplacement)
         return;
 
-    bool was_current = editor == currentEditor();
-    bool was_focused = editor->window()->focusWidget() == editor;
-    int cursor_position = editor->textCursor().position();
-    int scroll_position = editor->verticalScrollBar()->value();
+    bool was_current = editorWidget == currentEditor();
+    bool was_focused = editorWidget->window()->focusWidget() == editorWidget;
+
+    // Get cursor and scroll position from old editor
+    int cursor_position = 0;
+    int scroll_position = 0;
+    if (GenericCodeEditor* codeEditor = qobject_cast<GenericCodeEditor*>(editorWidget)) {
+        cursor_position = codeEditor->textCursor().position();
+        scroll_position = codeEditor->verticalScrollBar()->value();
+    } else if (RichTextEditor* richEditor = qobject_cast<RichTextEditor*>(editorWidget)) {
+        cursor_position = richEditor->textCursor().position();
+        scroll_position = richEditor->verticalScrollBar()->value();
+    }
 
     mHistory.removeAt(history_idx);
-    delete editor;
+    delete editorWidget;
 
-    editor = doc->isPlainText() ? new GenericCodeEditor(doc) : new ScCodeEditor(doc);
-    editor->installEventFilter(this);
-    mHistory.insert(history_idx, editor);
-    mLayout->addWidget(editor);
+    // Create new editor of appropriate type
+    QWidget* newEditor = nullptr;
+    if (doc->isRichText()) {
+        RichTextEditor* richEditor = new RichTextEditor(doc);
+        newEditor = richEditor;
+        richEditor->installEventFilter(this);
+        mHistory.insert(history_idx, newEditor);
+        mLayout->addWidget(newEditor);
 
-    QTextCursor cursor(editor->textDocument());
-    cursor.setPosition(cursor_position);
-    editor->setTextCursor(cursor);
+        QTextCursor cursor(richEditor->textDocument());
+        cursor.setPosition(cursor_position);
+        richEditor->setTextCursor(cursor);
+        richEditor->verticalScrollBar()->setValue(scroll_position);
+    } else {
+        GenericCodeEditor* codeEditor = doc->isPlainText() ? new GenericCodeEditor(doc) : new ScCodeEditor(doc);
+        newEditor = codeEditor;
+        codeEditor->installEventFilter(this);
+        mHistory.insert(history_idx, newEditor);
+        mLayout->addWidget(newEditor);
 
-    editor->verticalScrollBar()->setValue(scroll_position);
+        QTextCursor cursor(codeEditor->textDocument());
+        cursor.setPosition(cursor_position);
+        codeEditor->setTextCursor(cursor);
+        codeEditor->verticalScrollBar()->setValue(scroll_position);
+    }
 
     if (was_current) {
-        mLayout->setCurrentWidget(editor);
-        setFocusProxy(editor);
+        mLayout->setCurrentWidget(newEditor);
+        setFocusProxy(newEditor);
     }
 
     if (was_focused)
-        editor->setFocus(Qt::OtherFocusReason);
+        newEditor->setFocus(Qt::OtherFocusReason);
 
-    emit currentChanged(editor);
+    emit currentChanged(newEditor);
 }
 
-GenericCodeEditor* CodeEditorBox::currentEditor() {
+QWidget* CodeEditorBox::currentEditor() {
     if (mHistory.count())
         return mHistory.first();
     else
-        return 0;
+        return nullptr;
+}
+
+GenericCodeEditor* CodeEditorBox::currentGenericEditor() { return qobject_cast<GenericCodeEditor*>(currentEditor()); }
+
+RichTextEditor* CodeEditorBox::currentRichTextEditor() { return qobject_cast<RichTextEditor*>(currentEditor()); }
+
+Document* CodeEditorBox::documentForEditor(QWidget* editor) {
+    if (GenericCodeEditor* codeEditor = qobject_cast<GenericCodeEditor*>(editor))
+        return codeEditor->document();
+    if (RichTextEditor* richEditor = qobject_cast<RichTextEditor*>(editor))
+        return richEditor->document();
+    return nullptr;
 }
 
 int CodeEditorBox::historyIndexOf(Document* doc) {
     int count = mHistory.count();
-    for (int idx = 0; idx < count; ++idx)
-        if (mHistory[idx]->document() == doc)
+    for (int idx = 0; idx < count; ++idx) {
+        if (documentForEditor(mHistory[idx]) == doc)
             return idx;
+    }
     return -1;
 }
 
-GenericCodeEditor* CodeEditorBox::editorForDocument(Document* doc) {
-    foreach (GenericCodeEditor* editor, mHistory)
-        if (editor->document() == doc)
+QWidget* CodeEditorBox::editorForDocument(Document* doc) {
+    foreach (QWidget* editor, mHistory) {
+        if (documentForEditor(editor) == doc)
             return editor;
-    return 0;
+    }
+    return nullptr;
 }
 
 bool CodeEditorBox::eventFilter(QObject* object, QEvent* event) {
@@ -244,10 +322,7 @@ bool CodeEditorBox::eventFilter(QObject* object, QEvent* event) {
 
 void CodeEditorBox::focusInEvent(QFocusEvent*) { setActive(); }
 
-Document* CodeEditorBox::currentDocument() {
-    GenericCodeEditor* editor = currentEditor();
-    return editor ? editor->document() : 0;
-}
+Document* CodeEditorBox::currentDocument() { return documentForEditor(currentEditor()); }
 
 void CodeEditorBox::paintEvent(QPaintEvent*) {
     if (mLayout->currentWidget() == 0) {

--- a/editors/sc-ide/widgets/editor_box.hpp
+++ b/editors/sc-ide/widgets/editor_box.hpp
@@ -37,6 +37,7 @@ namespace ScIDE {
 
 class Document;
 class GenericCodeEditor;
+class RichTextEditor;
 class MultiSplitter;
 
 /*
@@ -61,13 +62,15 @@ class CodeEditorBox : public QWidget {
     Q_OBJECT
 
 public:
-    typedef QList<GenericCodeEditor*> History;
+    typedef QList<QWidget*> History;
 
     CodeEditorBox(MultiSplitter* splitter, QWidget* parent = 0);
 
     void setDocument(Document*, int pos = -1, int selectionLength = 0);
 
-    GenericCodeEditor* currentEditor();
+    QWidget* currentEditor();
+    GenericCodeEditor* currentGenericEditor();
+    RichTextEditor* currentRichTextEditor();
     Document* currentDocument();
 
     const History& history() { return mHistory; }
@@ -98,7 +101,7 @@ public:
     void showComboBox(bool);
 
 signals:
-    void currentChanged(GenericCodeEditor*);
+    void currentChanged(QWidget*);
     void activated(CodeEditorBox* me);
     void activeChanged(bool active);
 
@@ -114,7 +117,8 @@ private slots:
 
 private:
     int historyIndexOf(Document*);
-    GenericCodeEditor* editorForDocument(Document*);
+    QWidget* editorForDocument(Document*);
+    Document* documentForEditor(QWidget* editor);
     bool eventFilter(QObject*, QEvent*);
     void focusInEvent(QFocusEvent*);
     void paintEvent(QPaintEvent*);

--- a/editors/sc-ide/widgets/lookup_dialog.cpp
+++ b/editors/sc-ide/widgets/lookup_dialog.cpp
@@ -50,7 +50,7 @@ GenericLookupDialog::GenericLookupDialog(QWidget* parent): QDialog(parent) {
     mResult->setHeaderHidden(true);
     mResult->header()->setStretchLastSection(false);
 
-    mPreviewDocument = new Document(false);
+    mPreviewDocument = new Document(Document::SuperCollider);
     mPreviewEditor = new ScCodeEditor(mPreviewDocument);
     mPreviewEditor->setReadOnly(true);
     mPreviewEditor->setVisible(false);

--- a/editors/sc-ide/widgets/main_window.cpp
+++ b/editors/sc-ide/widgets/main_window.cpp
@@ -28,6 +28,7 @@
 #include "lookup_dialog.hpp"
 #include "main_window.hpp"
 #include "multi_editor.hpp"
+#include "editor_box.hpp"
 #include "popup_text_input.hpp"
 #include "post_window.hpp"
 #include "session_switch_dialog.hpp"
@@ -250,6 +251,12 @@ void MainWindow::createActions() {
     action->setStatusTip(tr("Create a new document"));
     connect(action, &QAction::triggered, this, &MainWindow::newDocument);
     settings->addAction(action, "ide-document-new", ideCategory);
+
+    mActions[DocNewRich] = action = new QAction(QIcon::fromTheme("document-new"), tr("New &Rich Document"), this);
+    action->setShortcut(tr("Ctrl+Shift+N", "New rich text document"));
+    action->setStatusTip(tr("Create a new rich text document"));
+    connect(action, &QAction::triggered, this, &MainWindow::newRichDocument);
+    settings->addAction(action, "ide-document-new-rich", ideCategory);
 
     mActions[DocOpen] = action = new QAction(QIcon::fromTheme("document-open"), tr("&Open..."), this);
     action->setShortcut(tr("Ctrl+O", "Open document"));
@@ -521,6 +528,7 @@ void MainWindow::createMenus() {
 
     menu = new QMenu(tr("&File"), this);
     menu->addAction(mActions[DocNew]);
+    menu->addAction(mActions[DocNewRich]);
     menu->addAction(mActions[DocOpen]);
     mRecentDocsMenu = menu->addMenu(tr("Open Recent", "Open a recent document"));
     connect(mRecentDocsMenu, &QMenu::triggered, this, &MainWindow::onOpenRecentDocument);
@@ -573,6 +581,8 @@ void MainWindow::createMenus() {
     menu->addAction(mEditors->action(MultiEditor::ToggleOverwriteMode));
     menu->addAction(mEditors->action(MultiEditor::SelectRegion));
     menu->addAction(mEditors->action(MultiEditor::SelectEnclosingBlock));
+    menu->addSeparator();
+    menu->addAction(mEditors->action(MultiEditor::ApplyCodeFormat));
 
     menu->addSeparator();
     menu->addAction(mActions[ShowSettings]);
@@ -832,7 +842,7 @@ void MainWindow::onCurrentDocumentChanged(Document* doc) {
     mActions[DocSaveAs]->setEnabled(doc);
     mActions[DocSaveAsExtension]->setEnabled(doc);
 
-    GenericCodeEditor* editor = mEditors->currentEditor();
+    GenericCodeEditor* editor = mEditors->currentGenericEditor();
     mFindReplaceTool->setEditor(editor);
     mGoToLineTool->setEditor(editor);
 }
@@ -978,7 +988,7 @@ bool MainWindow::save(Document* doc, bool forceChoose, bool saveInExtensionFolde
 
         QStringList filters = QStringList()
             << tr("All Files (*)") << tr("SuperCollider Document (*.scd)") << tr("SuperCollider Class File (*.sc)")
-            << tr("SuperCollider Help Source (*.schelp)");
+            << tr("SuperCollider Help Source (*.schelp)") << tr("SuperCollider Rich Text (*.scr)");
 
         dialog.setNameFilters(filters);
 
@@ -1034,10 +1044,12 @@ bool MainWindow::save(Document* doc, bool forceChoose, bool saveInExtensionFolde
 
 void MainWindow::newDocument() { mMain->documentManager()->create(); }
 
+void MainWindow::newRichDocument() { mMain->documentManager()->createRichDocument(); }
+
 QString MainWindow::documentOpenPath() const {
-    GenericCodeEditor* currentEditor = mEditors->currentEditor();
-    if (currentEditor) {
-        QString currentEditorPath = currentEditor->document()->filePath();
+    Document* currentDoc = mEditors->currentBox() ? mEditors->currentBox()->currentDocument() : nullptr;
+    if (currentDoc) {
+        QString currentEditorPath = currentDoc->filePath();
         if (!currentEditorPath.isEmpty())
             return currentEditorPath;
     }
@@ -1068,7 +1080,8 @@ void MainWindow::openDocument() {
         dialog.setDirectory(path_info.dir());
 
     QStringList filters;
-    filters << tr("All Files (*)") << tr("SuperCollider (*.scd *.sc)") << tr("SuperCollider Help Source (*.schelp)");
+    filters << tr("All Files (*)") << tr("SuperCollider (*.scd *.sc)") << tr("SuperCollider Help Source (*.schelp)")
+            << tr("SuperCollider Rich Text (*.scr)");
     dialog.setNameFilters(filters);
 
     if (dialog.exec()) {
@@ -1130,34 +1143,25 @@ void MainWindow::openExamplesDirectory() {
 }
 
 void MainWindow::saveDocument() {
-    GenericCodeEditor* editor = mEditors->currentEditor();
-    if (!editor)
+    Document* doc = mEditors->currentBox() ? mEditors->currentBox()->currentDocument() : nullptr;
+    if (!doc)
         return;
-
-    Document* doc = editor->document();
-    Q_ASSERT(doc);
 
     MainWindow::save(doc);
 }
 
 void MainWindow::saveDocumentAs() {
-    GenericCodeEditor* editor = mEditors->currentEditor();
-    if (!editor)
+    Document* doc = mEditors->currentBox() ? mEditors->currentBox()->currentDocument() : nullptr;
+    if (!doc)
         return;
-
-    Document* doc = editor->document();
-    Q_ASSERT(doc);
 
     MainWindow::save(doc, true);
 }
 
 void MainWindow::saveDocumentAsExtension() {
-    GenericCodeEditor* editor = mEditors->currentEditor();
-    if (!editor)
+    Document* doc = mEditors->currentBox() ? mEditors->currentBox()->currentDocument() : nullptr;
+    if (!doc)
         return;
-
-    Document* doc = editor->document();
-    Q_ASSERT(doc);
 
     MainWindow::save(doc, true, true);
 }
@@ -1170,21 +1174,19 @@ void MainWindow::saveAllDocuments() {
 }
 
 void MainWindow::reloadDocument() {
-    GenericCodeEditor* editor = mEditors->currentEditor();
-    if (!editor)
+    Document* doc = mEditors->currentBox() ? mEditors->currentBox()->currentDocument() : nullptr;
+    if (!doc)
         return;
 
-    Q_ASSERT(editor->document());
-    MainWindow::reload(editor->document());
+    MainWindow::reload(doc);
 }
 
 void MainWindow::closeDocument() {
-    GenericCodeEditor* editor = mEditors->currentEditor();
-    if (!editor)
+    Document* doc = mEditors->currentBox() ? mEditors->currentBox()->currentDocument() : nullptr;
+    if (!doc)
         return;
 
-    Q_ASSERT(editor->document());
-    MainWindow::close(editor->document());
+    MainWindow::close(doc);
 }
 
 void MainWindow::closeAllDocuments() {
@@ -1216,8 +1218,7 @@ bool MainWindow::promptSaveDocs() {
 
 void MainWindow::updateWindowTitle() {
     Session* session = mMain->sessionManager()->currentSession();
-    GenericCodeEditor* editor = mEditors->currentEditor();
-    Document* doc = editor ? editor->document() : 0;
+    Document* doc = mEditors->currentBox() ? mEditors->currentBox()->currentDocument() : nullptr;
 
     QString title;
 
@@ -1377,7 +1378,7 @@ void MainWindow::cmdLineForCursor() {
 }
 
 void MainWindow::showGoToLineTool() {
-    GenericCodeEditor* editor = mEditors->currentEditor();
+    GenericCodeEditor* editor = mEditors->currentGenericEditor();
     mGoToLineTool->setValue(editor ? editor->textCursor().blockNumber() + 1 : 0);
 
     mToolBox->setCurrentWidget(mGoToLineTool);
@@ -1407,13 +1408,17 @@ void MainWindow::showReplaceTool() {
 }
 
 void MainWindow::hideToolBox() {
-    GenericCodeEditor* editor = mEditors->currentEditor();
+    GenericCodeEditor* editor = mEditors->currentGenericEditor();
     if (editor) {
         // This slot is mapped to Escape, so also clear highlighting
         // whenever invoked:
         editor->clearSearchHighlighting();
         if (!editor->hasFocus())
             editor->setFocus(Qt::OtherFocusReason);
+    } else if (mEditors->currentEditor()) {
+        // For non-code editors (like RichTextEditor), just focus
+        if (!mEditors->currentEditor()->hasFocus())
+            mEditors->currentEditor()->setFocus(Qt::OtherFocusReason);
     }
 
     mToolBox->hide();
@@ -1529,7 +1534,8 @@ void MainWindow::dragEnterEvent(QDragEnterEvent* event) {
 }
 
 bool MainWindow::checkFileExtension(const QString& fpath) {
-    if (fpath.endsWith(".sc") || fpath.endsWith(".scd") || fpath.endsWith(".txt") || fpath.endsWith(".schelp")) {
+    if (fpath.endsWith(".sc") || fpath.endsWith(".scd") || fpath.endsWith(".txt") || fpath.endsWith(".schelp")
+        || fpath.endsWith(".scr")) {
         return true;
     }
     int ret = QMessageBox::question(this, tr("Open binary file?"),

--- a/editors/sc-ide/widgets/main_window.hpp
+++ b/editors/sc-ide/widgets/main_window.hpp
@@ -58,6 +58,7 @@ public:
         // File
         Quit = 0,
         DocNew,
+        DocNewRich,
         DocOpen,
         DocOpenStartup,
         DocOpenSupportDir,
@@ -147,6 +148,7 @@ public Q_SLOTS:
     void openSessionsDialog();
 
     void newDocument();
+    void newRichDocument();
     void openDocument();
     void saveDocument();
     void saveDocumentAs();

--- a/editors/sc-ide/widgets/multi_editor.cpp
+++ b/editors/sc-ide/widgets/multi_editor.cpp
@@ -23,6 +23,7 @@
 #include "main_window.hpp"
 #include "lookup_dialog.hpp"
 #include "code_editor/sc_editor.hpp"
+#include "code_editor/rich_editor.hpp"
 #include "util/multi_splitter.hpp"
 #include "../core/doc_manager.hpp"
 #include "../core/sig_mux.hpp"
@@ -165,8 +166,15 @@ private:
 
     void populateModel(const CodeEditorBox::History& history) {
         QList<Document*> displayDocuments;
-        foreach (GenericCodeEditor* editor, history)
-            displayDocuments << editor->document();
+        foreach (QWidget* editorWidget, history) {
+            Document* doc = nullptr;
+            if (GenericCodeEditor* editor = qobject_cast<GenericCodeEditor*>(editorWidget))
+                doc = editor->document();
+            else if (RichTextEditor* richEditor = qobject_cast<RichTextEditor*>(editorWidget))
+                doc = richEditor->document();
+            if (doc)
+                displayDocuments << doc;
+        }
 
         QList<Document*> managerDocuments = Main::documentManager()->documents();
         foreach (Document* document, managerDocuments)
@@ -315,8 +323,7 @@ void MultiEditor::makeSignalConnections() {
     connect(mTabs, &QTabBar::tabCloseRequested, this, &MultiEditor::onCloseRequest);
     connect(mTabs, &QTabBar::tabMoved, this, &MultiEditor::updateDocOrder);
 
-    mBoxSigMux->connect(SIGNAL(currentChanged(GenericCodeEditor*)), this,
-                        SLOT(onCurrentEditorChanged(GenericCodeEditor*)));
+    mBoxSigMux->connect(SIGNAL(currentChanged(QWidget*)), this, SLOT(onCurrentEditorChanged(QWidget*)));
 }
 
 void MultiEditor::updateDocOrder(int from, int to) { Q_EMIT(updateDockletOrder(from, to)); }
@@ -626,6 +633,14 @@ void MultiEditor::createActions() {
     mEditorSigMux->connect(action, SIGNAL(triggered()), SLOT(evaluateLine()), SignalMultiplexer::ConnectionOptional);
     settings->addAction(action, "editor-eval-line", editorCategory);
 
+    // Rich Text
+    mActions[ApplyCodeFormat] = action = new QAction(tr("Apply Code Format"), this);
+    action->setShortcut(tr("Ctrl+Shift+C", "Apply Code Format"));
+    action->setStatusTip(tr("Apply code formatting to selection"));
+    action->setShortcutContext(Qt::WidgetWithChildrenShortcut);
+    mEditorSigMux->connect(action, SIGNAL(triggered()), SLOT(applyCodeFormat()), SignalMultiplexer::ConnectionOptional);
+    settings->addAction(action, "editor-apply-code-format", editorCategory);
+
     // These actions are not added to any menu, so they have to be added
     // at least to this widget, in order for the shortcuts to always respond:
     addAction(mActions[TriggerAutoCompletion]);
@@ -661,47 +676,66 @@ void MultiEditor::createActions() {
     addAction(mActions[GotoPreviousEmptyLine]);
     addAction(mActions[GotoNextEmptyLine]);
     addAction(mActions[SelectRegion]);
+    addAction(mActions[ApplyCodeFormat]);
 }
 
 void MultiEditor::updateActions() {
-    GenericCodeEditor* editor = currentEditor();
-    ScCodeEditor* scEditor = qobject_cast<ScCodeEditor*>(editor);
-    QTextDocument* doc = editor ? editor->textDocument() : 0;
+    QWidget* editorWidget = currentEditor();
+    GenericCodeEditor* genericEditor = qobject_cast<GenericCodeEditor*>(editorWidget);
+    ScCodeEditor* scEditor = qobject_cast<ScCodeEditor*>(editorWidget);
+    RichTextEditor* richEditor = qobject_cast<RichTextEditor*>(editorWidget);
+
+    QTextDocument* doc = nullptr;
+    bool hasSelection = false;
+    if (genericEditor) {
+        doc = genericEditor->textDocument();
+        hasSelection = genericEditor->textCursor().hasSelection();
+    } else if (richEditor) {
+        doc = richEditor->textDocument();
+        hasSelection = richEditor->textCursor().hasSelection();
+    }
+
+    bool hasEditor = (editorWidget != nullptr);
 
     mActions[Undo]->setEnabled(doc && doc->isUndoAvailable());
     mActions[Redo]->setEnabled(doc && doc->isRedoAvailable());
-    mActions[Copy]->setEnabled(editor && editor->textCursor().hasSelection());
+    mActions[Copy]->setEnabled(hasEditor && hasSelection);
     mActions[Cut]->setEnabled(mActions[Copy]->isEnabled());
-    mActions[Paste]->setEnabled(editor);
-    mActions[ToggleOverwriteMode]->setEnabled(editor);
-    mActions[CopyLineUp]->setEnabled(editor);
-    mActions[CopyLineDown]->setEnabled(editor);
-    mActions[MoveLineUp]->setEnabled(editor);
-    mActions[MoveLineDown]->setEnabled(editor);
-    mActions[DeleteWord]->setEnabled(editor);
-    mActions[GotoPreviousEmptyLine]->setEnabled(editor);
-    mActions[GotoNextEmptyLine]->setEnabled(editor);
-    mActions[DocClose]->setEnabled(editor);
-    mActions[EnlargeFont]->setEnabled(editor);
-    mActions[ShrinkFont]->setEnabled(editor);
-    mActions[ResetFontSize]->setEnabled(editor);
-    mActions[IndentWithSpaces]->setEnabled(scEditor);
+    mActions[Paste]->setEnabled(hasEditor);
+    mActions[ToggleOverwriteMode]->setEnabled(genericEditor != nullptr);
+    mActions[CopyLineUp]->setEnabled(genericEditor != nullptr);
+    mActions[CopyLineDown]->setEnabled(genericEditor != nullptr);
+    mActions[MoveLineUp]->setEnabled(genericEditor != nullptr);
+    mActions[MoveLineDown]->setEnabled(genericEditor != nullptr);
+    mActions[DeleteWord]->setEnabled(genericEditor != nullptr);
+    mActions[GotoPreviousEmptyLine]->setEnabled(genericEditor != nullptr);
+    mActions[GotoNextEmptyLine]->setEnabled(genericEditor != nullptr);
+    mActions[DocClose]->setEnabled(hasEditor);
+    mActions[EnlargeFont]->setEnabled(hasEditor);
+    mActions[ShrinkFont]->setEnabled(hasEditor);
+    mActions[ResetFontSize]->setEnabled(hasEditor);
+    mActions[IndentWithSpaces]->setEnabled(scEditor != nullptr);
     mActions[IndentWithSpaces]->setChecked(scEditor && scEditor->spaceIndent());
 
     // ScLang-specific actions
-    bool editorIsScCodeEditor = qobject_cast<ScCodeEditor*>(editor); // NOOP at the moment, but
-    mActions[ToggleComment]->setEnabled(editor && editorIsScCodeEditor);
-    mActions[GotoPreviousBlock]->setEnabled(editor && editorIsScCodeEditor);
-    mActions[GotoNextBlock]->setEnabled(editor && editorIsScCodeEditor);
-    mActions[SelectEnclosingBlock]->setEnabled(editor && editorIsScCodeEditor);
-    mActions[GotoPreviousRegion]->setEnabled(editor && editorIsScCodeEditor);
-    mActions[GotoNextRegion]->setEnabled(editor && editorIsScCodeEditor);
-    mActions[SelectRegion]->setEnabled(editor && editorIsScCodeEditor);
-    mActions[IndentLineOrRegion]->setEnabled(editor && editorIsScCodeEditor);
+    bool editorIsScCodeEditor = (scEditor != nullptr);
+    mActions[ToggleComment]->setEnabled(editorIsScCodeEditor);
+    mActions[GotoPreviousBlock]->setEnabled(editorIsScCodeEditor);
+    mActions[GotoNextBlock]->setEnabled(editorIsScCodeEditor);
+    mActions[SelectEnclosingBlock]->setEnabled(editorIsScCodeEditor);
+    mActions[GotoPreviousRegion]->setEnabled(editorIsScCodeEditor);
+    mActions[GotoNextRegion]->setEnabled(editorIsScCodeEditor);
+    mActions[SelectRegion]->setEnabled(editorIsScCodeEditor);
+    mActions[IndentLineOrRegion]->setEnabled(editorIsScCodeEditor);
 
-    mActions[EvaluateCurrentDocument]->setEnabled(editor && editorIsScCodeEditor);
-    mActions[EvaluateRegion]->setEnabled(editor && editorIsScCodeEditor);
-    mActions[EvaluateLine]->setEnabled(editor && editorIsScCodeEditor);
+    // Evaluation actions - available for both ScCodeEditor and RichTextEditor
+    bool canEvaluate = (scEditor != nullptr) || (richEditor != nullptr);
+    mActions[EvaluateCurrentDocument]->setEnabled(canEvaluate);
+    mActions[EvaluateRegion]->setEnabled(canEvaluate);
+    mActions[EvaluateLine]->setEnabled(canEvaluate);
+
+    // Rich text specific actions
+    mActions[ApplyCodeFormat]->setEnabled(richEditor != nullptr);
 }
 
 void MultiEditor::applySettings(Settings::Manager* settings) {
@@ -746,13 +780,24 @@ static QVariantList saveBoxState(CodeEditorBox* box, const QList<Document*>& doc
     QVariantList boxData;
     int idx = box->history().count();
     while (idx--) {
-        GenericCodeEditor* editor = box->history()[idx];
-        if (!editor->document()->filePath().isEmpty()) {
-            int documentIndex = documentList.indexOf(editor->document());
+        QWidget* editorWidget = box->history()[idx];
+        Document* doc = nullptr;
+        int cursorPosition = 0;
+
+        if (GenericCodeEditor* editor = qobject_cast<GenericCodeEditor*>(editorWidget)) {
+            doc = editor->document();
+            cursorPosition = editor->textCursor().position();
+        } else if (RichTextEditor* richEditor = qobject_cast<RichTextEditor*>(editorWidget)) {
+            doc = richEditor->document();
+            cursorPosition = richEditor->textCursor().position();
+        }
+
+        if (doc && !doc->filePath().isEmpty()) {
+            int documentIndex = documentList.indexOf(doc);
             Q_ASSERT(documentIndex >= 0);
             QVariantMap editorData;
             editorData.insert("documentIndex", documentIndex);
-            editorData.insert("position", editor->textCursor().position());
+            editorData.insert("position", cursorPosition);
             boxData.append(editorData);
         }
     }
@@ -1043,8 +1088,14 @@ void MultiEditor::update(Document* doc) {
         mTabs->setTabText(tabIdx, doc->title());
 
     // update thisProcess.nowExecutingPath
-    GenericCodeEditor* editor = currentEditor();
-    if (editor->document() == doc)
+    QWidget* editorWidget = currentEditor();
+    Document* currentDoc = nullptr;
+    if (GenericCodeEditor* editor = qobject_cast<GenericCodeEditor*>(editorWidget))
+        currentDoc = editor->document();
+    else if (RichTextEditor* richEditor = qobject_cast<RichTextEditor*>(editorWidget))
+        currentDoc = richEditor->document();
+
+    if (currentDoc == doc)
         Main::documentManager()->setActiveDocument(doc);
 }
 
@@ -1067,7 +1118,7 @@ void MultiEditor::onCurrentTabChanged(int index) {
     curBox->setFocus(Qt::OtherFocusReason);
 }
 
-void MultiEditor::onCurrentEditorChanged(GenericCodeEditor* editor) { setCurrentEditor(editor); }
+void MultiEditor::onCurrentEditorChanged(QWidget* editor) { setCurrentEditor(editor); }
 
 void MultiEditor::onBoxActivated(CodeEditorBox* box) { setCurrentBox(box); }
 
@@ -1108,30 +1159,51 @@ void MultiEditor::setCurrentBox(CodeEditorBox* box) {
     mCurrentEditorBox->setActive();
 }
 
-void MultiEditor::setCurrentEditor(GenericCodeEditor* editor) {
-    if (editor) {
-        int tabIndex = tabForDocument(editor->document());
-        if (tabIndex != -1)
-            mTabs->setCurrentIndex(tabIndex);
+void MultiEditor::setCurrentEditor(QWidget* editorWidget) {
+    Document* currentDocument = nullptr;
+
+    if (editorWidget) {
+        if (GenericCodeEditor* editor = qobject_cast<GenericCodeEditor*>(editorWidget))
+            currentDocument = editor->document();
+        else if (RichTextEditor* richEditor = qobject_cast<RichTextEditor*>(editorWidget))
+            currentDocument = richEditor->document();
+
+        if (currentDocument) {
+            int tabIndex = tabForDocument(currentDocument);
+            if (tabIndex != -1)
+                mTabs->setCurrentIndex(tabIndex);
+        }
     }
 
-    mEditorSigMux->setCurrentObject(editor);
+    mEditorSigMux->setCurrentObject(editorWidget);
     updateActions();
 
-    Document* currentDocument = editor ? editor->document() : 0;
     Main::documentManager()->setActiveDocument(currentDocument);
     emit currentDocumentChanged(currentDocument);
 }
 
-GenericCodeEditor* MultiEditor::currentEditor() { return currentBox()->currentEditor(); }
+QWidget* MultiEditor::currentEditor() { return currentBox()->currentEditor(); }
+
+GenericCodeEditor* MultiEditor::currentGenericEditor() { return currentBox()->currentGenericEditor(); }
 
 void MultiEditor::split(Qt::Orientation splitDirection) {
     CodeEditorBox* box = newBox(mSplitter);
     CodeEditorBox* curBox = currentBox();
-    GenericCodeEditor* curEditor = curBox->currentEditor();
+    QWidget* curEditorWidget = curBox->currentEditor();
 
-    if (curEditor)
-        box->setDocument(curEditor->document(), curEditor->textCursor().position());
+    if (curEditorWidget) {
+        Document* doc = nullptr;
+        int cursorPosition = 0;
+        if (GenericCodeEditor* editor = qobject_cast<GenericCodeEditor*>(curEditorWidget)) {
+            doc = editor->document();
+            cursorPosition = editor->textCursor().position();
+        } else if (RichTextEditor* richEditor = qobject_cast<RichTextEditor*>(curEditorWidget)) {
+            doc = richEditor->document();
+            cursorPosition = richEditor->textCursor().position();
+        }
+        if (doc)
+            box->setDocument(doc, cursorPosition);
+    }
 
     mSplitter->insertWidget(box, curBox, splitDirection);
     box->setFocus(Qt::OtherFocusReason);
@@ -1178,9 +1250,20 @@ void MultiEditor::removeAllSplits() {
     CodeEditorBox* nBox = newBox(newSplitter);
     newSplitter->addWidget(nBox);
 
-    GenericCodeEditor* curEditor = box->currentEditor();
-    if (curEditor)
-        nBox->setDocument(curEditor->document(), curEditor->textCursor().position());
+    QWidget* curEditorWidget = box->currentEditor();
+    if (curEditorWidget) {
+        Document* doc = nullptr;
+        int cursorPosition = 0;
+        if (GenericCodeEditor* editor = qobject_cast<GenericCodeEditor*>(curEditorWidget)) {
+            doc = editor->document();
+            cursorPosition = editor->textCursor().position();
+        } else if (RichTextEditor* richEditor = qobject_cast<RichTextEditor*>(curEditorWidget)) {
+            doc = richEditor->document();
+            cursorPosition = richEditor->textCursor().position();
+        }
+        if (doc)
+            nBox->setDocument(doc, cursorPosition);
+    }
 
     delete mSplitter;
     mSplitter = newSplitter;

--- a/editors/sc-ide/widgets/multi_editor.hpp
+++ b/editors/sc-ide/widgets/multi_editor.hpp
@@ -127,6 +127,9 @@ public:
         EvaluateRegion,
         EvaluateLine,
 
+        // Rich Text
+        ApplyCodeFormat,
+
         ActionRoleCount
     };
 
@@ -136,7 +139,8 @@ public:
     Document* documentForTab(int index);
     int tabForDocument(Document* doc);
 
-    GenericCodeEditor* currentEditor();
+    QWidget* currentEditor();
+    GenericCodeEditor* currentGenericEditor();
     CodeEditorBox* currentBox() { return mCurrentEditorBox; }
     void split(Qt::Orientation direction);
 
@@ -179,7 +183,7 @@ private slots:
     void update(Document*);
     void onCloseRequest(int index);
     void onCurrentTabChanged(int index);
-    void onCurrentEditorChanged(GenericCodeEditor*);
+    void onCurrentEditorChanged(QWidget*);
     void onBoxActivated(CodeEditorBox*);
     void onDocModified(Document*);
     void updateDocOrder(int, int);
@@ -200,7 +204,7 @@ private:
     int insertTab(Document* doc, int insertIndex = -1);
     CodeEditorBox* newBox(MultiSplitter*);
     void setCurrentBox(CodeEditorBox*);
-    void setCurrentEditor(GenericCodeEditor*);
+    void setCurrentEditor(QWidget*);
     void loadBoxState(CodeEditorBox* box, const QVariantList& data, const QList<Document*>& documentList);
     void loadSplitterState(MultiSplitter*, const QVariantMap& data, const QList<Document*>& documentList);
     void showEditorTabs(bool);


### PR DESCRIPTION
**DISCLAIMER**: This PR was vibe coded! This was my first try to figure out how vibe-coding is like. It took around 1 hour in total (with 3 sessions b/c I was hitting the quota of each 5hr session easily)  to guide and generate using claude code within CLion. Afterwards I looked over every LOC and tried to understand the change which took another 4-5 hours (I also changed/re-factored/tweaked some stuff while at it), so consider this reviewed by me, but this still needs another pair of eyes - especially the dynamic casting and if we can not incooperate this better into the type level, but I am not deep enough into the editor and C++ to see the possibilities.
I wanted to use this feature as a test balloon to see what models are capable of these days (I must say, I am really impressed).
I had this idea for a longer time and looked into this but stepped away from it b/c the editor only separates between highlighted and non-highlighted code through a binary flag, which appears in all kind of situations, which needed to be turned into an enum and which created all sorts of type problems as well. I think I could have written this by myself in around 3-4 days of work, so I saved some time using an LLM.
I think this could be a good test candidate for #7284 - I am also fine if this is considered AI slop and we do not merge it, but I think w/ a disclaimer and since I reviewed every LOC I wouldn't consider it slop. I hope this doesn't break the flood gates, but I think it is better to understand/evaluate/test how these models can be applied rather than having a total stance against them - they probably will not go away...
Since the SC codebase has probably been scraped by these models already, I think it was fine to let an LLM operate on it.

<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

This (re-)introduces a new file format `scr` and a rich-text editor for this file format which allows to format the font-family and some font-attributes (bold/italic/underline/strike/color) of a selected text region.

<img width="1281" height="789" alt="grafik" src="https://github.com/user-attachments/assets/64888044-8b76-4186-ba5b-6016a6bd9969" />

The editing toolbar at the top is only visible when a `scr` document is opened.
The normal syntax highlighting can be applied by selecting the code and pressing `cmd shift c` (or through a menu action).
The code needs to be indented manually though! Also, automatic region evaluation is not existing yet - one has to select the region manually, normal evaluation only evaluates the line of the cursor.

The file-format is based on Qts rich text format which is based on HTML, so a `scr` file can also be viewed in the browser.

<img width="605" height="800" alt="grafik" src="https://github.com/user-attachments/assets/37d7f832-5a14-4058-92f2-861ca00fa37d" />

A quick view at `head test.scr`

```html
<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN" "http://www.w3.org/TR/REC-html40/strict.dtd">
<html><head><meta name="qrichtext" content="1" /><meta charset="utf-8" /><style type="text/css">
p, li { white-space: pre-wrap; }
hr { height: 1px; border-width: 0; }
li.unchecked::marker { content: "\2610"; }
li.checked::marker { content: "\2612"; }
</style></head><body style=" font-family:'EB Garamond'; font-size:13pt; font-weight:400; font-style:normal;">
<p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"><span style=" font-size:110pt; font-weight:700; color:#f20404;">Hello</span></p>
<p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"><span style=" font-family:'Hack Nerd Font Mono'; font-size:18pt; text-decoration: underline;">we can have now</span></p>
<p style="-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:'Hack Nerd Font Mono'; font-size:18pt;"><br /></p>
```

Since formatting and a themed editor are a opposite features your mileage may vary when opening an `scr` file in the browser or an editor with a different theme.
Hence, I would not include `scr` files into a repo as it makes reviewing hard and b/c of the themed IDE this can create all kind of problems


<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->

- New feature

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [ ] Code is tested
- [ ] All tests are passing
- [ ] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
