### PR TITLE
Remove CompletionMessage from Buffer instance methods .read and .readChannel

### DIFF
--- a/HelpSource/Classes/Buffer.schelp
+++ b/HelpSource/Classes/Buffer.schelp
@@ -560,8 +560,7 @@ A boolean indicating whether or not the Buffer should be left 'open'. For use wi
 A common number is 32768 frames. cueSoundFile below, provides a simpler way of doing this.) The default is false which is the correct value for all other cases.
 argument:: action
 A Function to be evaluated once the file has been read and this Buffer's instance variables have been updated. The function will be passed this Buffer as an argument.
-argument:: completionMessage
-A valid OSC message or a Function which will return one. A Function will be passed this Buffer as an argument when evaluated.
+
 method:: readMsg
 	construct the message for a read command. args are like those for read,
 	except that last arg is completionMessage.
@@ -586,8 +585,6 @@ argument:: channels
 An Array of channels to be read from the soundfile. Indices start from zero. These will be read in the order provided. The number of channels requested must match this Buffer's numChannels.
 argument:: action
 A Function to be evaluated once the file has been read and this Buffer's instance variables have been updated. The function will be passed this Buffer as an argument.
-argument:: completionMessage
-A valid OSC message or a Function which will return one. A Function will be passed this Buffer as an argument when evaluated.
 
 method:: readChannelMsg
 	as above for single channel, with last arg being completionMessage.


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->
closes: #7325 
## Purpose and Motivation
Remove the CompletionMessage argument from the Buffer instance methods `.read` and `.readChannel`, as it should no longer appear in the documentation. 
I discovered this issue while working on #7311: https://github.com/supercollider/supercollider/pull/7311/commits/08e6d5c3fbba41daacc293dc288d39d639e2b779


<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->

- Documentation
## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
