### PR TITLE
sclang: fix large allocation bug,

### DIFF
--- a/lang/LangSource/GC.cpp
+++ b/lang/LangSource/GC.cpp
@@ -24,6 +24,7 @@
 #include "PyrObjectProto.h"
 #include "PyrSymbol.h"
 #include "InitAlloc.h"
+#include <limits>
 #include <string.h>
 #include <stdexcept>
 #include "PyrLexer.h"
@@ -342,13 +343,16 @@ HOT PyrObject* PyrGC::New(size_t inNumBytes, std::int64_t inFlags, std::int64_t 
 #endif
 
     // obtain size info
-    const int64_t alignedSize = (inNumBytes + kAlignMask) & ~kAlignMask; // 16 byte align
-    const int64_t numSlotsMaybe0 = alignedSize / sizeof(PyrSlot);
-    const int64_t numSlots = numSlotsMaybe0 < 1 ? 1 : numSlotsMaybe0;
-    const int64_t unboundedSizeclass = LOG2CEIL(numSlots);
-    const int64_t sizeclass = sc_min(unboundedSizeclass, kNumGCSizeClasses - 1);
-
-    const int64_t credit = 1LL << sizeclass;
+    const size_t alignedSize = (inNumBytes + kAlignMask) & ~kAlignMask; // 16 byte align
+    const size_t numSlotsMaybe0 = alignedSize / sizeof(PyrSlot);
+    const size_t numSlots = numSlotsMaybe0 < 1 ? 1 : numSlotsMaybe0;
+    assert(numSlots <= std::numeric_limits<int>::max());
+    // LOG2CEIL only accepts int as it uses compiler builtins.
+    const int unboundedSizeclass = LOG2CEIL(static_cast<int>(numSlots));
+    const int sizeclass = std::min<int>(unboundedSizeclass, kNumGCSizeClasses - 1);
+    assert(sizeclass >= 0);
+    static_assert(kNumGCSizeClasses < 64);
+    const uint64_t credit = 1ULL << sizeclass;
     mAllocTotal += credit;
     mNumAllocs++;
 

--- a/lang/LangSource/GC.cpp
+++ b/lang/LangSource/GC.cpp
@@ -351,20 +351,21 @@ HOT PyrObject* PyrGC::New(size_t inNumBytes, std::int64_t inFlags, std::int64_t 
     // LOG2CEIL currently only accepts ints, so we make sure that numSlots does not exceed
     // the maximum sizeclass value (which is guaranteed to fit into an int32).
     static constexpr auto maxSizeClass = kNumGCSizeClasses - 1;
+
     static constexpr size_t maxCredit = 1ULL << (maxSizeClass);
     static_assert(maxCredit <= std::numeric_limits<int32>::max());
 
-    const size_t credit = (numSlots > maxCredit) ? maxCredit : NEXTPOWEROFTWO(static_cast<int32>(numSlots));
+    // If numSlots is smaller than maxSizeClass, it is also guaranteed to fit into an int32
+    // and so it is safe to call LOG2CEIL (which currently only accepts 32-bit integers)
+    const int32 sizeclass = (numSlots >= maxCredit) ? maxSizeClass : LOG2CEIL(static_cast<int32>(numSlots));
+
+    // If the object fits inside a size band, credit is the true number of slots allocated.
+    // If is doesn't, then this is dealt with separately through classification as a 'large' object.
+    const size_t credit = 1ULL << sizeclass;
 
     mAllocTotal += credit;
     mNumToScan += credit;
     mNumAllocs++;
-
-    // If numSlots is outside int32 range, we can't cast it to perform LOG2CEIL (which only works on ints), so return
-    // max sizeclass.
-    const int32 sizeclass = (numSlots > std::numeric_limits<int32>::max())
-        ? maxSizeClass
-        : std::min<int32>(LOG2CEIL(static_cast<int32>(numSlots)), maxSizeClass);
 
     // Now we can allocate.
     PyrObject* obj = Allocate(inNumBytes, sizeclass, inRunCollection);

--- a/lang/LangSource/GC.cpp
+++ b/lang/LangSource/GC.cpp
@@ -334,30 +334,26 @@ void PyrGC::BecomeImmutable(PyrObject* inObject) { inObject->obj_flags |= obj_im
 void DumpBackTrace(VMGlobals* g);
 
 HOT PyrObject* PyrGC::New(size_t inNumBytes, std::int64_t inFlags, std::int64_t inFormat, bool inRunCollection) {
-    PyrObject* obj = nullptr;
-
-    if (inFlags & obj_permanent) {
+    if (inFlags & obj_permanent)
         return NewPermanent(inNumBytes, inFlags, inFormat);
-    }
 
 #ifdef GC_SANITYCHECK
     SanityCheck();
 #endif
 
     // obtain size info
+    const int32 alignedSize = (inNumBytes + kAlignMask) & ~kAlignMask; // 16 byte align
+    const int32 numSlotsMaybe0 = alignedSize / sizeof(PyrSlot);
+    const int32 numSlots = numSlotsMaybe0 < 1 ? 1 : numSlotsMaybe0;
+    const int32 unboundedSizeclass = LOG2CEIL(numSlots);
+    const int32 sizeclass = sc_min(unboundedSizeclass, kNumGCSizeClasses - 1);
 
-    int32 alignedSize = (inNumBytes + kAlignMask) & ~kAlignMask; // 16 byte align
-    int32 numSlots = alignedSize / sizeof(PyrSlot);
-    numSlots = numSlots < 1 ? 1 : numSlots;
-    int32 sizeclass = LOG2CEIL(numSlots);
-    sizeclass = sc_min(sizeclass, kNumGCSizeClasses - 1);
-
-    int32 credit = 1LL << sizeclass;
+    const int32 credit = 1LL << sizeclass;
     mAllocTotal += credit;
     mNumAllocs++;
 
     mNumToScan += credit;
-    obj = Allocate(inNumBytes, sizeclass, inRunCollection);
+    PyrObject* obj = Allocate(inNumBytes, sizeclass, inRunCollection);
 
     obj->obj_format = inFormat;
     obj->obj_flags = inFlags & 255;

--- a/lang/LangSource/GC.cpp
+++ b/lang/LangSource/GC.cpp
@@ -345,22 +345,33 @@ HOT PyrObject* PyrGC::New(size_t inNumBytes, std::int64_t inFlags, std::int64_t 
     // obtain size info
     const size_t alignedSize = (inNumBytes + kAlignMask) & ~kAlignMask; // 16 byte align
     const size_t numSlotsMaybe0 = alignedSize / sizeof(PyrSlot);
-    const size_t numSlots = numSlotsMaybe0 < 1 ? 1 : numSlotsMaybe0;
-    assert(numSlots <= std::numeric_limits<int>::max());
-    // LOG2CEIL only accepts int as it uses compiler builtins.
-    const int unboundedSizeclass = LOG2CEIL(static_cast<int>(numSlots));
-    const int sizeclass = std::min<int>(unboundedSizeclass, kNumGCSizeClasses - 1);
-    assert(sizeclass >= 0);
-    static_assert(kNumGCSizeClasses < 64);
-    const uint64_t credit = 1ULL << sizeclass;
+
+    const size_t numSlots = std::max<size_t>(alignedSize / sizeof(PyrSlot), 1);
+
+    // LOG2CEIL currently only accepts ints, so we make sure that numSlots does not exceed
+    // the maximum sizeclass value (which is guaranteed to fit into an int32).
+    static constexpr auto maxSizeClass = kNumGCSizeClasses - 1;
+    static constexpr size_t maxCredit = 1ULL << (maxSizeClass);
+    static_assert(maxCredit <= std::numeric_limits<int32>::max());
+
+    const size_t credit = (numSlots > maxCredit) ? maxCredit : NEXTPOWEROFTWO(static_cast<int32>(numSlots));
+
     mAllocTotal += credit;
+    mNumToScan += credit;
     mNumAllocs++;
 
-    mNumToScan += credit;
+    // If numSlots is outside int32 range, we can't cast it to perform LOG2CEIL (which only works on ints), so return
+    // max sizeclass.
+    const int32 sizeclass = (numSlots > std::numeric_limits<int32>::max())
+        ? maxSizeClass
+        : std::min<int32>(LOG2CEIL(static_cast<int32>(numSlots)), maxSizeClass);
+
+    // Now we can allocate.
     PyrObject* obj = Allocate(inNumBytes, sizeclass, inRunCollection);
 
     obj->obj_format = inFormat;
     obj->obj_flags = inFlags & 255;
+    // The size of the object is set to zero and the data inside the object is uninitialized memory.
     obj->size = 0;
     obj->classptr = class_object;
     obj->gc_color = mWhiteColor;

--- a/lang/LangSource/GC.cpp
+++ b/lang/LangSource/GC.cpp
@@ -344,7 +344,6 @@ HOT PyrObject* PyrGC::New(size_t inNumBytes, std::int64_t inFlags, std::int64_t 
 
     // obtain size info
     const size_t alignedSize = (inNumBytes + kAlignMask) & ~kAlignMask; // 16 byte align
-    const size_t numSlotsMaybe0 = alignedSize / sizeof(PyrSlot);
 
     const size_t numSlots = std::max<size_t>(alignedSize / sizeof(PyrSlot), 1);
 
@@ -356,7 +355,7 @@ HOT PyrObject* PyrGC::New(size_t inNumBytes, std::int64_t inFlags, std::int64_t 
     static_assert(maxCredit <= std::numeric_limits<int32>::max());
 
     // If numSlots is smaller than maxSizeClass, it is also guaranteed to fit into an int32
-    // and so it is safe to call LOG2CEIL (which currently only accepts 32-bit integers)
+    // and so it is safe to call LOG2CEIL.
     const int32 sizeclass = (numSlots >= maxCredit) ? maxSizeClass : LOG2CEIL(static_cast<int32>(numSlots));
 
     // If the object fits inside a size band, credit is the true number of slots allocated.

--- a/lang/LangSource/GC.cpp
+++ b/lang/LangSource/GC.cpp
@@ -483,7 +483,6 @@ void PyrGC::SweepBigObjects() {
             } while (!IsMarker(obj));
         }
     }
-    mCanSweep = false;
 }
 
 void PyrGC::CompletePartialScan(PyrObject* obj) {

--- a/lang/LangSource/GC.cpp
+++ b/lang/LangSource/GC.cpp
@@ -342,11 +342,11 @@ HOT PyrObject* PyrGC::New(size_t inNumBytes, std::int64_t inFlags, std::int64_t 
 #endif
 
     // obtain size info
-    const int32 alignedSize = (inNumBytes + kAlignMask) & ~kAlignMask; // 16 byte align
-    const int32 numSlotsMaybe0 = alignedSize / sizeof(PyrSlot);
-    const int32 numSlots = numSlotsMaybe0 < 1 ? 1 : numSlotsMaybe0;
-    const int32 unboundedSizeclass = LOG2CEIL(numSlots);
-    const int32 sizeclass = sc_min(unboundedSizeclass, kNumGCSizeClasses - 1);
+    const int64_t alignedSize = (inNumBytes + kAlignMask) & ~kAlignMask; // 16 byte align
+    const int64_t numSlotsMaybe0 = alignedSize / sizeof(PyrSlot);
+    const int64_t numSlots = numSlotsMaybe0 < 1 ? 1 : numSlotsMaybe0;
+    const int64_t unboundedSizeclass = LOG2CEIL(numSlots);
+    const int64_t sizeclass = sc_min(unboundedSizeclass, kNumGCSizeClasses - 1);
 
     const int32 credit = 1LL << sizeclass;
     mAllocTotal += credit;

--- a/lang/LangSource/GC.cpp
+++ b/lang/LangSource/GC.cpp
@@ -649,7 +649,8 @@ void PyrGC::FullCollection() {
 }
 
 void PyrGC::Collect(uint64 inNumToScan) {
-    mNumToScan = std::max<size_t>(mNumToScan, inNumToScan);
+    assert(inNumToScan <= std::numeric_limits<int64>::max());
+    mNumToScan = std::max<int64>(mNumToScan, inNumToScan);
     Collect(); // collect space
 }
 

--- a/lang/LangSource/GC.cpp
+++ b/lang/LangSource/GC.cpp
@@ -348,7 +348,7 @@ HOT PyrObject* PyrGC::New(size_t inNumBytes, std::int64_t inFlags, std::int64_t 
     const int64_t unboundedSizeclass = LOG2CEIL(numSlots);
     const int64_t sizeclass = sc_min(unboundedSizeclass, kNumGCSizeClasses - 1);
 
-    const int32 credit = 1LL << sizeclass;
+    const int64_t credit = 1LL << sizeclass;
     mAllocTotal += credit;
     mNumAllocs++;
 
@@ -645,7 +645,7 @@ void PyrGC::FullCollection() {
     SweepBigObjects();
 }
 
-void PyrGC::Collect(int32 inNumToScan) {
+void PyrGC::Collect(int64_t inNumToScan) {
     mNumToScan = sc_max(mNumToScan, inNumToScan);
     Collect(); // collect space
 }

--- a/lang/LangSource/GC.cpp
+++ b/lang/LangSource/GC.cpp
@@ -648,8 +648,8 @@ void PyrGC::FullCollection() {
     SweepBigObjects();
 }
 
-void PyrGC::Collect(int64_t inNumToScan) {
-    mNumToScan = sc_max(mNumToScan, inNumToScan);
+void PyrGC::Collect(uint64 inNumToScan) {
+    mNumToScan = std::max<size_t>(mNumToScan, inNumToScan);
     Collect(); // collect space
 }
 

--- a/lang/LangSource/GC.h
+++ b/lang/LangSource/GC.h
@@ -38,7 +38,7 @@ const int kMaxPoolSet = 7;
 const int kNumGCSizeClasses = 28;
 const int kFinalizerSet = kNumGCSizeClasses;
 const int kNumGCSets = kNumGCSizeClasses + 1;
-const std::int64_t kScanThreshold = 256LL;
+const uint64_t kScanThreshold = 256LL;
 
 
 class GCSet {
@@ -149,7 +149,7 @@ public:
     // users should not call anything below.
 
     void Collect();
-    void Collect(int64_t inNumToScan);
+    void Collect(uint64 inNumToScan);
     void LazyCollect() {
         if (mUncollectedAllocations > kLazyCollectThreshold)
             Collect();
@@ -220,7 +220,7 @@ private:
     PyrObjectHdr mGrey;
 
     int32 mPartialScanSlot;
-    std::int64_t mNumToScan;
+    uint64 mNumToScan;
     int32 mNumGrey;
 
     int64_t mAllocTotal;

--- a/lang/LangSource/GC.h
+++ b/lang/LangSource/GC.h
@@ -220,7 +220,7 @@ private:
     PyrObjectHdr mGrey;
 
     int32 mPartialScanSlot;
-    uint64 mNumToScan;
+    int64 mNumToScan;
     int32 mNumGrey;
 
     int64_t mAllocTotal;

--- a/lang/LangSource/GC.h
+++ b/lang/LangSource/GC.h
@@ -149,7 +149,7 @@ public:
     // users should not call anything below.
 
     void Collect();
-    void Collect(int32 inNumToScan);
+    void Collect(int64_t inNumToScan);
     void LazyCollect() {
         if (mUncollectedAllocations > kLazyCollectThreshold)
             Collect();
@@ -223,8 +223,8 @@ private:
     std::int64_t mNumToScan;
     int32 mNumGrey;
 
-    int32 mFlips, mCollects, mAllocTotal, mScans, mNumAllocs, mStackScans, mNumPartialScans, mSlotsScanned,
-        mUncollectedAllocations;
+    int64_t mAllocTotal;
+    int32 mFlips, mCollects, mScans, mNumAllocs, mStackScans, mNumPartialScans, mSlotsScanned, mUncollectedAllocations;
 
     unsigned char mBlackColor, mGreyColor, mWhiteColor, mFreeColor;
     bool mCanSweep;

--- a/lang/LangSource/GC.h
+++ b/lang/LangSource/GC.h
@@ -347,11 +347,13 @@ inline PyrObject* PyrGC::Allocate(size_t inNumBytes, int32 sizeclass, bool inRun
         assert(obj->obj_sizeclass == sizeclass);
     } else {
         if (sizeclass > kMaxPoolSet) {
+            // If the sizeclass has reached the cap, then allocSize (as calculated below) might not be large enough.
             SweepBigObjects();
-            size_t allocSize = sizeof(PyrObjectHdr) + (sizeof(PyrSlot) << sizeclass);
-            obj = (PyrObject*)mPool->Alloc(allocSize);
+            const size_t allocSize = sizeof(PyrObjectHdr) + (sizeof(PyrSlot) << sizeclass);
+            obj = (PyrObject*)mPool->Alloc(std::max(allocSize, inNumBytes));
         } else {
             size_t allocSize = sizeof(PyrObjectHdr) + (sizeof(PyrSlot) << sizeclass);
+            assert(allocSize >= inNumBytes);
             obj = (PyrObject*)mNewPool.Alloc(allocSize);
         }
         if (!obj)

--- a/lang/LangSource/GC.h
+++ b/lang/LangSource/GC.h
@@ -223,7 +223,7 @@ private:
     int64 mNumToScan;
     int32 mNumGrey;
 
-    int64_t mAllocTotal;
+    int64 mAllocTotal;
     int32 mFlips, mCollects, mScans, mNumAllocs, mStackScans, mNumPartialScans, mSlotsScanned, mUncollectedAllocations;
 
     unsigned char mBlackColor, mGreyColor, mWhiteColor, mFreeColor;

--- a/lang/LangSource/GC.h
+++ b/lang/LangSource/GC.h
@@ -338,6 +338,7 @@ inline PyrObject* PyrGC::Allocate(size_t inNumBytes, int32 sizeclass, bool inRun
             ++mUncollectedAllocations;
     }
 
+    assert(sizeclass >= 0);
     GCSet* gcs = mSets + sizeclass;
 
     PyrObject* obj = (PyrObject*)gcs->mFree;

--- a/testsuite/sclang/sclang_large_alloc_crash.scd
+++ b/testsuite/sclang/sclang_large_alloc_crash.scd
@@ -1,5 +1,9 @@
 // Largest array possible.
 // As PyrSlot is 8 bytes and we use an int32 to store the size (num elements) and the byte size, this means we can only represent 2^28 - 1 values.
-(1.. 2.pow(28).asInteger - 1);
+
+// Cannot do this on 32 bit systems, we just let the system run out of memory in that case.
+if (Platform.architecture == \x86_64 or: {Platform.architecture == \AArch64}) {
+    (1.. 2.pow(28).asInteger - 1);
+};
 
 0.exit;

--- a/testsuite/sclang/sclang_large_alloc_crash.scd
+++ b/testsuite/sclang/sclang_large_alloc_crash.scd
@@ -1,0 +1,5 @@
+// Largest array possible.
+// As PyrSlot is 8 bytes and we use an int32 to store the size (num elements) and the byte size, this means we can only represent 2^28 - 1 values.
+(1.. 2.pow(28).asInteger - 1);
+
+0.exit;


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

Closes #7331
```supercollider
(1.. 134917722) // crash
``` 

Why.

`PyrGC:Allocate` was not allocating enough memory as it was using the sizeclass to recalculate the requested amount of bytes, this is fine in all cases expect when the required memory exceeds the size classes (2^27). With the introduction of nan boxing, we have doubled the possible size of the array we can represent, meaning this bug has become apparent.

Make internal calculation use int64 as these overflow in extreme cases.

Add tests to ensure we can always have arrays of sizes `2^28 -1`, which is the maximum we can represent. Why is it the maximum. We store the item count **and** the num bytes as an int32, that means we need to be able to represent the value `itemCount * sizeof(PyrSlot)`. 

Additionally, there was a bug in `SweepBigObjects` where if you called it multiple times, only the first one would sweep. Obviously this was added as a performance tweak, but it is actually a bug as the only way to reset it is to perform a full gc flip, which can make you easily run out of RAM as they occur rarely. This will have a performance impact when allocating large objects, but seems reasonable to avoid consuming all memory on the system.

## Types of changes

- Major bug fix in allocators :crocodile: 

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
