### PR TITLE
Scale.directory, Tuning.directory: nicer formatting for output

### DIFF
--- a/SCClassLibrary/Common/Collections/Scale.sc
+++ b/SCClassLibrary/Common/Collections/Scale.sc
@@ -164,7 +164,7 @@ Scale {
 
 	*directory {
 		var columnHeaders = ["key / method selector   name of scale"];
-		^(columnHeaders ++ this.names.collect({ |k| $\\ ++ k.asString.padRight(25) ++ all.at(k).name } )).join("\n")
+		^(columnHeaders ++ this.names.collect({ |k| $\\ ++ k.asString.padRight(24) ++ all.at(k).name } )).join("\n")
 	}
 
 	storeArgs { ^[degrees, pitchesPerOctave, tuning, name] }

--- a/SCClassLibrary/Common/Collections/Scale.sc
+++ b/SCClassLibrary/Common/Collections/Scale.sc
@@ -163,7 +163,9 @@ Scale {
 	}
 
 	*directory {
-		^this.names.collect({ |k| "\\%: %".format(k, all.at(k).name) }).join("\n")
+		var columnHeaders = ["key / method selector   name of scale"];
+		var spaces = {|symbol| String.fill(25 - symbol.asString.size, $ )};
+		^(columnHeaders ++ this.names.collect({ |k| "%% %%".format($\\, k, spaces.(k), all.at(k).name) })).join("\n")
 	}
 
 	storeArgs { ^[degrees, pitchesPerOctave, tuning, name] }
@@ -290,7 +292,9 @@ Tuning {
 	}
 
 	*directory {
-		^this.names.collect({ |k| "\\%: %".format(k, all.at(k).name) }).join("\n")
+		var columnHeaders = ["key / method selector   name of tuning"];
+		var spaces = {|symbol| String.fill(25 - symbol.asString.size, $ )};
+		^(columnHeaders ++ this.names.collect({ |k| "%% %%".format($\\, k, spaces.(k), all.at(k).name) })).join("\n")
 	}
 }
 

--- a/SCClassLibrary/Common/Collections/Scale.sc
+++ b/SCClassLibrary/Common/Collections/Scale.sc
@@ -163,8 +163,7 @@ Scale {
 	}
 
 	*directory {
-		var columnHeaders = ["key / method selector   name of scale"];
-		^(columnHeaders ++ this.names.collect({ |k| $\\ ++ k.asString.padRight(26) ++ all.at(k).name } )).join("\n")
+		^this.names.collect({ |k| $\\ ++ k.asString.padRight(26) ++ all.at(k).name } ).join("\n")
 	}
 
 	storeArgs { ^[degrees, pitchesPerOctave, tuning, name] }
@@ -291,9 +290,7 @@ Tuning {
 	}
 
 	*directory {
-		var columnHeaders = ["key / method selector   name of tuning"];
-		var spaces = {|symbol| String.fill(25 - symbol.asString.size, $ )};
-		^(columnHeaders ++ this.names.collect({ |k| "%% %%".format($\\, k, spaces.(k), all.at(k).name) })).join("\n")
+		^this.names.collect({ |k| $\\ ++ k.asString.padRight(26) ++ all.at(k).name } ).join("\n")
 	}
 }
 

--- a/SCClassLibrary/Common/Collections/Scale.sc
+++ b/SCClassLibrary/Common/Collections/Scale.sc
@@ -164,7 +164,7 @@ Scale {
 
 	*directory {
 		var columnHeaders = ["key / method selector   name of scale"];
-		^(columnHeaders ++ this.names.collect({ |k| $\\ ++ k.asString.padRight(24) ++ all.at(k).name } )).join("\n")
+		^(columnHeaders ++ this.names.collect({ |k| $\\ ++ k.asString.padRight(26) ++ all.at(k).name } )).join("\n")
 	}
 
 	storeArgs { ^[degrees, pitchesPerOctave, tuning, name] }

--- a/SCClassLibrary/Common/Collections/Scale.sc
+++ b/SCClassLibrary/Common/Collections/Scale.sc
@@ -164,8 +164,7 @@ Scale {
 
 	*directory {
 		var columnHeaders = ["key / method selector   name of scale"];
-		var spaces = {|symbol| String.fill(25 - symbol.asString.size, $ )};
-		^(columnHeaders ++ this.names.collect({ |k| "%% %%".format($\\, k, spaces.(k), all.at(k).name) })).join("\n")
+		^(columnHeaders ++ this.names.collect({ |k| $\\ ++ k.asString.padRight(25) ++ all.at(k).name } )).join("\n")
 	}
 
 	storeArgs { ^[degrees, pitchesPerOctave, tuning, name] }

--- a/SCClassLibrary/Common/Collections/Scale.sc
+++ b/SCClassLibrary/Common/Collections/Scale.sc
@@ -163,7 +163,7 @@ Scale {
 	}
 
 	*directory {
-		^this.names.collect({ |k| "\\ %: %".format(k, all.at(k).name) }).join("\n")
+		^this.names.collect({ |k| "\\%: %".format(k, all.at(k).name) }).join("\n")
 	}
 
 	storeArgs { ^[degrees, pitchesPerOctave, tuning, name] }
@@ -290,7 +290,7 @@ Tuning {
 	}
 
 	*directory {
-		^this.names.collect({ |k| "\\ %: %".format(k, all.at(k).name) }).join("\n")
+		^this.names.collect({ |k| "\\%: %".format(k, all.at(k).name) }).join("\n")
 	}
 }
 


### PR DESCRIPTION
this was supposed to be a very minimal change here to the `Scale.directory` and `Tuning.directory` methods. but here goes another half an hour:

output before change: \ key: name
i.e., a confusing space between the \ and the key.

e.g.,
```
\ ahirbhairav: Ahirbhairav
\ ajam: Ajam
\ atharKurd: Athar Kurd
\ augmented: Augmented
\ augmented2: Augmented 2
\ bartok: Bartok
\ bastanikar: Bastanikar
\ bayati: Bayati
\ bhairav: Bhairav
\ chinese: Chinese
\ chromatic: Chromatic
```
output after:  an ok looking table that even includes a header.
```
-> key / method selector  name of scale
\aeolian                  Aeolian
\ahirbhairav              Ahirbhairav
\ajam                     Ajam
\atharKurd                Athar Kurd
\augmented                Augmented
\augmented2               Augmented 2
\bartok                   Bartok
\bastanikar               Bastanikar
etc.

```
Found this while poking around in the french language section of scsynth. A new user seems to have been confused as to what the selector should have been (e.g. for Scale.major, they thought it might be Scale.Major). Although I think this was probably a more general misunderstanding of the syntax, the unnecessary space certainly doesn't help. All this could also be documented better but I'm trying to be more focused with my contribution, so that's for another time.

(https://scsynth.org/t/a-propos-de-gamme/8981)
