### PR TITLE
class library: fix -absolutePath and -isAbsolutePath overrides for Windows

### DIFF
--- a/SCClassLibrary/Platform/windows/SystemOverwrites/overwrites.sc
+++ b/SCClassLibrary/Platform/windows/SystemOverwrites/overwrites.sc
@@ -1,31 +1,29 @@
 + String {
+	// See https://learn.microsoft.com/en-us/dotnet/standard/io/file-path-formats for reference.
 	absolutePath {
-		var first, sep;
-		sep = thisProcess.platform.pathSeparator;
-			// 2 styles of absolute path:
-			// C:\... or \\machine_name\...
-		if((this[0].isAlpha and: { this[1] == $: and: { this[2] == sep } })
-				or: { this[0] == sep and: { this[1] == sep } }) {
+		// First check if the path is already absolute.
+		// There are 3 styles of absolute paths:
+		// 1. C:\..., 2. C:/...  and 3. \\<machine>\... (= UNC path)
+		if((this[0].isAlpha and: { this[1] == $: and: { this[2] == $\\ or: { this[2] == $/ } } })
+				or: { this[0] == $\\ and: { this[1] == $\\ } }) {
 			^this
 		} {
-				// let's also try to convert unix-style dirs
-				// assume starting from root dir of drive letter where SC is installed
-			if(this[0] == $/ and: { this[1] != $/ }) {
+			// \... and /... start from the current drive.
+			// Let's use the drive where SC is installed.
+			if(this[0] == $\\ or: { this[0] == $/ }) {
 				^File.getcwd[..1] ++ this
 			};
-				// currently we can't support this on windows
-				// though it would be nice to have a primitive to get the user's home dir
-//			if(first == $~){^this.standardizePath};
-			^File.getcwd ++ sep ++ this;
+			// Resolve ~ to the user's home directory.
+			if(this[0] == $~){^this.standardizePath};
+			^File.getcwd +/+ this;
 		}
 	}
 }
 
 + PathName {
 	isAbsolutePath {
-		var	sep = thisProcess.platform.pathSeparator;
-		^(fullPath[0].isAlpha and: { fullPath[1] == $: and: { fullPath[2] == sep } })
-				or: { fullPath[0] == sep and: { fullPath[1] == sep } }
-				or: { fullPath[0] == $/ and: { fullPath[1] != $/ } }
+		// See String -absolutePath
+		^(fullPath[0].isAlpha and: { fullPath[1] == $: and: { fullPath[2] == $\\ or: { fullPath[2] == $/ } } })
+				or: { fullPath[0] == $\\ and: { fullPath[1] == $\\ } }
 	}
 }

--- a/testsuite/classlibrary/TestPathName.sc
+++ b/testsuite/classlibrary/TestPathName.sc
@@ -1,0 +1,19 @@
+TestPathName : UnitTest {
+	test_isAbsolutePath_Windows {
+		if (thisProcess.platform.name == \windows) {
+			// absolute paths
+			this.assert(PathName("C:/test").isAbsolutePath, "absolute path <drive>:/");
+			this.assert(PathName("C:\\test").isAbsolutePath, "absolute path <drive>:\\");
+			this.assert(PathName("\\\\system07\\test").isAbsolutePath, "absolute path UNC");
+			// only because PathName calls standardizePath
+			this.assert(PathName("~/test").isAbsolutePath, "path starting with ~ is treated as absolute");
+
+			// relative paths
+			this.assert(PathName("test").isAbsolutePath.not, "relative path");
+			this.assert(PathName("./test").isAbsolutePath.not, "relative path with leading ./");
+			this.assert(PathName(".\\test").isAbsolutePath.not, "relative path with leading .\\");
+			this.assert(PathName("/test").isAbsolutePath.not, "path starting with / is relative (to the current drive)");
+			this.assert(PathName("\\test").isAbsolutePath.not, "path starting with \\ is relative (to the current drive)");
+		}
+	}
+}

--- a/testsuite/classlibrary/TestString.sc
+++ b/testsuite/classlibrary/TestString.sc
@@ -165,6 +165,20 @@ TestString : UnitTest {
 		this.assertEquals(result, expected);
 	}
 
+	test_absolutePath_Windows {
+		var drive;
+		if (thisProcess.platform.name == \windows) {
+			drive = Platform.resourceDir[..1];
+			this.assertEquals("C:/test".absolutePath, "C:/test", "absolute path <drive>:/");
+			this.assertEquals("C:\\test".absolutePath, "C:\\test", "absolute path <drive>:\\");
+			this.assertEquals("\\\\system07\\test".absolutePath, "\\\\system07\\test", "absolute path UNC");
+			this.assertEquals("/test".absolutePath, drive ++ "/test", "path starting with /");
+			this.assertEquals("\\test".absolutePath, drive ++ "\\test", "path starting with \\");
+			this.assertEquals("~/test".absolutePath, "~/test".standardizePath, "path starting with ~");
+			this.assertEquals("test".absolutePath, File.getcwd +/+ "test", "relative path");
+		}
+	}
+
 	// ------- time-related operations -----------------------------------------------
 
 	test_asSecs_stringDddHhMmSsSss_convertsToSeconds {


### PR DESCRIPTION
`String -absolutePath` is currently broken on Windows. Most notably, a path like `C:/foo` is not detected as an absolute path because the method (incorrectly) only assumes backward slashes. As a consequence, the path will be resolved to the current working directory and you get a bogus path like `C:\Program Files\SuperCollider-3.14.0/C:/foo`.

Note that Windows supports both forward and backward slashes in path names. This is also explicitly stated in the SC docs, see the section "Pathname Support" in String.schelp:

> On Windows, both forward slash "/" and backward slash "\\" are path separators.

In fact, the logic in `String -absolutePath` and `PathName -isAbsolutePath` had several flaws and I made the following fixes:
1. make sure that both methods use the exact same logic for detecting an absolute path
2. use the official MS docs as a reference (https://learn.microsoft.com/en-us/dotnet/standard/io/file-path-formats); most importantly, support forward slashes!
3. a leading forward slash is not "unix-style", it is specified by MS to be relative to the current drive. It can also be a backward slash. Finally, successive slashes are allowed, they are simply ignored.
4. `standardizePath` actually works on Windows, so let's use it.

I've used the following test:
```sc
"C:/test".absolutePath; // -> C:/test
"C:\\test".absolutePath; // -> C:\test
"\\\\system07\\test".absolutePath; // UNC path -> \\system07\test
"/test".absolutePath; // -> C:/test
"\\test".absolutePath; // -> C:\test
"~/test".absolutePath; // -> C:\Users\Christof\test
"test".absolutePath; // C:\Program Files\SuperCollider-3.14.0\test

PathName("C:/test").isAbsolutePath; // -> true
PathName("C:\\test").isAbsolutePath; // -> true
PathName("\\\\system07\test").isAbsolutePath; // UNC path -> true
PathName("/test").isAbsolutePath; // -> false
PathName("\\test").isAbsolutePath; // -> false
// Note: the following returns true because PathName internally calls standardizePath
PathName("~/test").isAbsolutePath; // -> true
PathName("test").isAbsolutePath; // -> false
```

<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
