### PR TITLE
sclang: fix crash when encountering undefined variable, insert missing return

### DIFF
--- a/lang/LangSource/PyrParseNode.cpp
+++ b/lang/LangSource/PyrParseNode.cpp
@@ -3387,6 +3387,7 @@ void compileAssignVar(PyrParseNode* node, PyrSymbol* varName, bool drop) {
         error("Variable '%s' not defined.\n", varName->name);
         nodePostErrorLine(node);
         compileErrors++;
+        return;
     }
 
     const FindVarNameResult findResult = *result;


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

Should close #7336

Missing return statement.

## Types of changes

<!-- Delete lines that don't apply -->

Simple bug fix.

This bug was introduced by me in with the bytecode refactor. The part of the code that looks up variables is quite fragile as it does a lot of extra stuff, this bug was a simple mistake when copying and pasting the code.

Small rant, I really like zig's language side optionals as it makes this type of thing much harder to mess up, C++'s `if` statement inverts the scope, nesting the success path, not the error.
```zig
const result = maybeResult orelse { 
   std.log.err(...); 
   return;  // leaves function, not scope.
};
```

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
