### PR TITLE
sclang: fix duplicate keys in inlined switch crash

### DIFF
--- a/lang/LangSource/PyrParseNode.cpp
+++ b/lang/LangSource/PyrParseNode.cpp
@@ -2885,44 +2885,30 @@ void compileSwitchMsg(PyrCallNode* node) {
         int offset = 0;
         int lastOffset = 0;
 
-        std::vector<PyrSlot> visitedKeys;
+        // Maintain a record of the visited keys, if there are duplicates, post a compiler error.
+        using Key = std::pair<PyrSlot, PyrParseNode*>;
+        std::vector<Key> visitedKeys {};
         visitedKeys.reserve(numArgs);
-        const auto hasDuplicateKeyPostErrorAndPrepareForReturn = [&](auto node, PyrSlot key) -> bool {
-            if (const auto duplicateKey = std::find(visitedKeys.begin(), visitedKeys.end(), key);
-                duplicateKey != visitedKeys.end()) {
-                error("Duplicate key found in inlined switch statement\n");
-                nodePostErrorLine(node);
-                compileErrors++;
-                return true;
-            } else
-                return false;
-        };
 
         for (; argnode; argnode = nextargnode) {
             nextargnode = argnode->mNext;
             if (nextargnode != nullptr) {
                 ByteCodes byteCodes = compileSubExpressionWithGoto((PyrPushLitNode*)nextargnode, 0x6666, true);
+                PyrPushLitNode* keyargnode = (PyrPushLitNode*)argnode;
 
                 PyrSlot* key;
-                PyrSlot value;
-                SetInt(&value, offset);
-                PyrPushLitNode* keyargnode = (PyrPushLitNode*)argnode;
                 if (isAtomicLiteral(argnode)) {
                     key = &keyargnode->mSlot;
-                    if (hasDuplicateKeyPostErrorAndPrepareForReturn(keyargnode, *key))
-                        return;
+                    visitedKeys.push_back({ *key, keyargnode });
                 } else {
                     PyrBlockNode* bnode = (PyrBlockNode*)slotRawPtr(&keyargnode->mSlot);
                     PyrDropNode* dropnode = (PyrDropNode*)bnode->mBody;
                     PyrPushLitNode* litnode = (PyrPushLitNode*)dropnode->mExpr1;
                     key = &litnode->mSlot;
-                    if (hasDuplicateKeyPostErrorAndPrepareForReturn(litnode, *key))
-                        return;
+                    visitedKeys.push_back({ *key, litnode });
                 }
 
-                visitedKeys.push_back(*key);
-
-                int index = arrayAtIdentityHashInPairs(array, key);
+                const int index = arrayAtIdentityHashInPairs(array, key);
                 PyrSlot* slot = array->slots + index;
                 slotCopy(slot, key);
                 SetInt(slot + 1, offset);
@@ -2954,6 +2940,60 @@ void compileSwitchMsg(PyrCallNode* node) {
                     offset += 1;
                 }
             }
+        }
+
+        const auto keyLessThan = [](const Key& lhs, const Key& rhs) -> bool {
+            return lhs.first.rawBytes() < rhs.first.rawBytes();
+        };
+        std::sort(visitedKeys.begin(), visitedKeys.end(), keyLessThan);
+
+        // Note, we don't need to use the proper pyrslot ==, (or < if there was one) operator as that respects nans and
+        // other double comparison rules. Here we know the user doesn't have a nan in their inlineable switch, as it is
+        // impossible to create one — 'nan' is not a keyword.
+        // ... and even if there was, the PyrSlot requires that all nans take on the same byte representation.
+        // Also, it doesn't really make sense to switch on a nan since it compares equal with nothing.
+        const auto keyByteIdentical = [](const Key& lhs, const Key& rhs) -> bool {
+            return lhs.first.rawBytes() == rhs.first.rawBytes();
+        };
+        if (const auto maybe_duplicate = std::adjacent_find(visitedKeys.begin(), visitedKeys.end(), keyByteIdentical);
+            maybe_duplicate != visitedKeys.end()) {
+            const auto key = maybe_duplicate->first;
+            switch (key.getTag()) {
+            case tagInt:
+                error("Duplicate key '%d' found in inlined switch statement.\n", key.getInt());
+                break;
+            case tagFloat:
+                error("Duplicate key '%f' found in inlined switch statement.\n", key.getDouble());
+                break;
+            case tagChar:
+                error("Duplicate key '%c' found in inlined switch statement.\n", key.getChar());
+                break;
+            case tagSym:
+                error("Duplicate key '%s' found in inlined switch statement.\n", key.getSymbol()->name);
+                break;
+            case tagNil:
+                error("Duplicate key 'nil' found in inlined switch statement.\n");
+                break;
+            case tagFalse:
+                error("Duplicate key 'false' found in inlined switch statement.\n");
+                break;
+            case tagTrue:
+                error("Duplicate key 'true' found in inlined switch statement.\n");
+                break;
+            // These shouldn't be possible as it must be inlined, but I've made a default anyway.
+            case tagObj:
+                [[fallthrough]];
+            case tagPtr:
+                [[fallthrough]];
+            default: {
+                assert(false);
+                error("Duplicate key found in inlined switch statement.\n");
+                break;
+            }
+            }
+            nodePostErrorLine(maybe_duplicate->second);
+            compileErrors++;
+            return;
         }
 
         Byte* bytes = gCompilingByteCodes->bytes + absoluteOffset;

--- a/lang/LangSource/PyrParseNode.cpp
+++ b/lang/LangSource/PyrParseNode.cpp
@@ -2860,166 +2860,7 @@ void compileSwitchMsg(PyrCallNode* node) {
             nextargnode = function_node->mNext;
         }
     }
-
-    if (canInline) {
-        PyrParseNode* argnode = node->mArglist;
-
-        int flags = compilingCmdLine ? obj_immutable : obj_permanent | obj_immutable;
-        int arraySize = NEXTPOWEROFTWO(numArgs * 2);
-        PyrObject* array = newPyrArray(compileGC(), arraySize, flags, false);
-        array->size = arraySize;
-        nilSlots(array->slots, arraySize);
-
-        PyrSlot slot;
-        SetObject(&slot, array);
-
-        COMPILENODE(argnode, &dummy, false);
-        compilePushConstant(node, &slot);
-
-        Extended::Switch.emit();
-
-        argnode = argnode->mNext; // skip first arg.
-
-        PyrParseNode* nextargnode = nullptr;
-        int absoluteOffset = byteCodeLength(gCompilingByteCodes);
-        int offset = 0;
-        int lastOffset = 0;
-
-        // Maintain a record of the visited keys, if there are duplicates, post a compiler error.
-        using Key = std::pair<PyrSlot, PyrParseNode*>;
-        std::vector<Key> visitedKeys {};
-        visitedKeys.reserve(numArgs);
-
-        for (; argnode; argnode = nextargnode) {
-            nextargnode = argnode->mNext;
-            if (nextargnode != nullptr) {
-                ByteCodes byteCodes = compileSubExpressionWithGoto((PyrPushLitNode*)nextargnode, 0x6666, true);
-                PyrPushLitNode* keyargnode = (PyrPushLitNode*)argnode;
-
-                PyrSlot* key;
-                if (isAtomicLiteral(argnode)) {
-                    key = &keyargnode->mSlot;
-                    visitedKeys.push_back({ *key, keyargnode });
-                } else {
-                    PyrBlockNode* bnode = (PyrBlockNode*)slotRawPtr(&keyargnode->mSlot);
-                    PyrDropNode* dropnode = (PyrDropNode*)bnode->mBody;
-                    PyrPushLitNode* litnode = (PyrPushLitNode*)dropnode->mExpr1;
-                    key = &litnode->mSlot;
-                    visitedKeys.push_back({ *key, litnode });
-                }
-
-                const int index = arrayAtIdentityHashInPairs(array, key);
-                PyrSlot* slot = array->slots + index;
-                slotCopy(slot, key);
-                SetInt(slot + 1, offset);
-
-                if (byteCodes) {
-                    offset += byteCodeLength(byteCodes);
-                    compileAndFreeByteCodes(byteCodes);
-                } else {
-                    PushSpecialValue.emit(OpSpecialValue::Nil_);
-                    offset += 1;
-                }
-
-                nextargnode = nextargnode->mNext;
-                if (nextargnode == nullptr) {
-                    PushSpecialValue.emit(OpSpecialValue::Nil_);
-                    lastOffset = offset;
-                    offset += 1;
-                }
-            } else {
-                ByteCodes byteCodes = compileSubExpressionWithGoto((PyrPushLitNode*)argnode, 0, true);
-
-                lastOffset = offset;
-                if (byteCodes) {
-                    offset += byteCodeLength(byteCodes);
-                    compileAndFreeByteCodes(byteCodes);
-                } else {
-                    PushSpecialValue.emit(OpSpecialValue::Nil_);
-                    lastOffset = offset;
-                    offset += 1;
-                }
-            }
-        }
-
-        const auto keyLessThan = [](const Key& lhs, const Key& rhs) -> bool {
-            return lhs.first.rawBytes() < rhs.first.rawBytes();
-        };
-        std::sort(visitedKeys.begin(), visitedKeys.end(), keyLessThan);
-
-        // Note, we don't need to use the proper pyrslot ==, (or < if there was one) operator as that respects nans and
-        // other double comparison rules. Here we know the user doesn't have a nan in their inlineable switch, as it is
-        // impossible to create one — 'nan' is not a keyword.
-        // ... and even if there was, the PyrSlot requires that all nans take on the same byte representation.
-        // Also, it doesn't really make sense to switch on a nan since it compares equal with nothing.
-        const auto keyByteIdentical = [](const Key& lhs, const Key& rhs) -> bool {
-            return lhs.first.rawBytes() == rhs.first.rawBytes();
-        };
-        if (const auto maybe_duplicate = std::adjacent_find(visitedKeys.begin(), visitedKeys.end(), keyByteIdentical);
-            maybe_duplicate != visitedKeys.end()) {
-            const auto key = maybe_duplicate->first;
-            switch (key.getTag()) {
-            case tagInt:
-                error("Duplicate key '%d' found in inlined switch statement.\n", key.getInt());
-                break;
-            case tagFloat:
-                error("Duplicate key '%f' found in inlined switch statement.\n", key.getDouble());
-                break;
-            case tagChar:
-                error("Duplicate key '%c' found in inlined switch statement.\n", key.getChar());
-                break;
-            case tagSym:
-                error("Duplicate key '%s' found in inlined switch statement.\n", key.getSymbol()->name);
-                break;
-            case tagNil:
-                error("Duplicate key 'nil' found in inlined switch statement.\n");
-                break;
-            case tagFalse:
-                error("Duplicate key 'false' found in inlined switch statement.\n");
-                break;
-            case tagTrue:
-                error("Duplicate key 'true' found in inlined switch statement.\n");
-                break;
-            // These shouldn't be possible as it must be inlined, but I've made a default anyway.
-            case tagObj:
-                [[fallthrough]];
-            case tagPtr:
-                [[fallthrough]];
-            default: {
-                assert(false);
-                error("Duplicate key found in inlined switch statement.\n");
-                break;
-            }
-            }
-            nodePostErrorLine(maybe_duplicate->second);
-            compileErrors++;
-            return;
-        }
-
-        Byte* bytes = gCompilingByteCodes->bytes + absoluteOffset;
-        PyrSlot* slots = array->slots;
-        {
-            int jumplen = offset - lastOffset;
-            bytes[lastOffset - 2] = (jumplen >> 8) & 255;
-            bytes[lastOffset - 1] = jumplen & 255;
-        }
-        for (int i = 0; i < arraySize; i += 2) {
-            PyrSlot* key = slots + i;
-            PyrSlot* value = key + 1;
-
-            if (IsNil(value)) {
-                SetInt(value, lastOffset);
-            } else {
-                int offsetToHere = slotRawInt(value);
-                if (offsetToHere) {
-                    int jumplen = offset - offsetToHere;
-                    bytes[offsetToHere - 2] = (jumplen >> 8) & 255;
-                    bytes[offsetToHere - 1] = jumplen & 255;
-                }
-            }
-        }
-
-    } else {
+    if (!canInline) {
         PyrParseNode* argnode = node->mArglist;
         for (; argnode; argnode = argnode->mNext) {
             COMPILENODE(argnode, &dummy, false);
@@ -3030,6 +2871,153 @@ void compileSwitchMsg(PyrCallNode* node) {
         else
             SendSpecialMsgX.emit(Operands::ArgumentCount::fromRaw(numArgs), Operands::KwArgumentCount::fromRaw(0),
                                  Operands::Index::fromRaw(static_cast<int>(OpSpecialSelectors::Switch)));
+
+        return;
+    }
+
+    PyrParseNode* argnode = node->mArglist;
+
+    int flags = compilingCmdLine ? obj_immutable : obj_permanent | obj_immutable;
+    int arraySize = NEXTPOWEROFTWO(numArgs * 2);
+    PyrObject* array = newPyrArray(compileGC(), arraySize, flags, false);
+    array->size = arraySize;
+    nilSlots(array->slots, arraySize);
+
+    PyrSlot slot;
+    SetObject(&slot, array);
+
+    COMPILENODE(argnode, &dummy, false);
+    compilePushConstant(node, &slot);
+
+    Extended::Switch.emit();
+
+    argnode = argnode->mNext; // skip first arg.
+
+    PyrParseNode* nextargnode = nullptr;
+    int absoluteOffset = byteCodeLength(gCompilingByteCodes);
+    int offset = 0;
+    int lastOffset = 0;
+
+    // Maintain a record of the visited keys, if there are duplicates, post a compiler error.
+    using Key = std::pair<PyrSlot, PyrParseNode*>;
+    std::vector<Key> visitedKeys {};
+    visitedKeys.reserve(numArgs);
+
+    for (; argnode; argnode = nextargnode) {
+        nextargnode = argnode->mNext;
+        if (nextargnode != nullptr) {
+            ByteCodes byteCodes = compileSubExpressionWithGoto((PyrPushLitNode*)nextargnode, 0x6666, true);
+            PyrPushLitNode* keyargnode = (PyrPushLitNode*)argnode;
+
+            PyrSlot* key;
+            if (isAtomicLiteral(argnode)) {
+                key = &keyargnode->mSlot;
+                visitedKeys.push_back({ *key, keyargnode });
+            } else {
+                PyrBlockNode* bnode = (PyrBlockNode*)slotRawPtr(&keyargnode->mSlot);
+                PyrDropNode* dropnode = (PyrDropNode*)bnode->mBody;
+                PyrPushLitNode* litnode = (PyrPushLitNode*)dropnode->mExpr1;
+                key = &litnode->mSlot;
+                visitedKeys.push_back({ *key, litnode });
+            }
+
+            const int index = arrayAtIdentityHashInPairs(array, key);
+            PyrSlot* slot = array->slots + index;
+            slotCopy(slot, key);
+            SetInt(slot + 1, offset);
+
+            if (byteCodes) {
+                offset += byteCodeLength(byteCodes);
+                compileAndFreeByteCodes(byteCodes);
+            } else {
+                PushSpecialValue.emit(OpSpecialValue::Nil_);
+                offset += 1;
+            }
+
+            nextargnode = nextargnode->mNext;
+            if (nextargnode == nullptr) {
+                PushSpecialValue.emit(OpSpecialValue::Nil_);
+                lastOffset = offset;
+                offset += 1;
+            }
+        } else {
+            ByteCodes byteCodes = compileSubExpressionWithGoto((PyrPushLitNode*)argnode, 0, true);
+
+            lastOffset = offset;
+            if (byteCodes) {
+                offset += byteCodeLength(byteCodes);
+                compileAndFreeByteCodes(byteCodes);
+            } else {
+                PushSpecialValue.emit(OpSpecialValue::Nil_);
+                lastOffset = offset;
+                offset += 1;
+            }
+        }
+    }
+
+    std::sort(visitedKeys.begin(), visitedKeys.end());
+    if (const auto maybe_duplicate = std::adjacent_find(visitedKeys.begin(), visitedKeys.end());
+        maybe_duplicate != visitedKeys.end()) {
+        const auto key = maybe_duplicate->first;
+        switch (key.getTag()) {
+        case tagInt:
+            error("Duplicate key '%d' found in inlined switch statement.\n", key.getInt());
+            break;
+        case tagFloat:
+            error("Duplicate key '%f' found in inlined switch statement.\n", key.getDouble());
+            break;
+        case tagChar:
+            error("Duplicate key '%c' found in inlined switch statement.\n", key.getChar());
+            break;
+        case tagSym:
+            error("Duplicate key '%s' found in inlined switch statement.\n", key.getSymbol()->name);
+            break;
+        case tagNil:
+            error("Duplicate key 'nil' found in inlined switch statement.\n");
+            break;
+        case tagFalse:
+            error("Duplicate key 'false' found in inlined switch statement.\n");
+            break;
+        case tagTrue:
+            error("Duplicate key 'true' found in inlined switch statement.\n");
+            break;
+        // These shouldn't be possible as it must be inlined, but I've made a default anyway.
+        case tagObj:
+            [[fallthrough]];
+        case tagPtr:
+            [[fallthrough]];
+        default: {
+            assert(false); // This shouldn't happen
+            error("Duplicate key found in inlined switch statement.\n");
+            break;
+        }
+        }
+        nodePostErrorLine(maybe_duplicate->second);
+        compileErrors++;
+        return;
+    }
+
+    Byte* bytes = gCompilingByteCodes->bytes + absoluteOffset;
+    PyrSlot* slots = array->slots;
+    {
+        int jumplen = offset - lastOffset;
+        bytes[lastOffset - 2] = (jumplen >> 8) & 255;
+        bytes[lastOffset - 1] = jumplen & 255;
+    }
+    for (int i = 0; i < arraySize; i += 2) {
+        PyrSlot* key = slots + i;
+        PyrSlot* value = key + 1;
+
+        if (IsNil(value)) {
+            SetInt(value, lastOffset);
+        } else {
+            int offsetToHere = slotRawInt(value);
+            if (offsetToHere) {
+                int jumplen = offset - offsetToHere;
+                bytes[offsetToHere - 2] = (jumplen >> 8) & 255;
+                bytes[offsetToHere - 1] = jumplen & 255;
+            }
+        }
     }
 }
 

--- a/lang/LangSource/PyrParseNode.cpp
+++ b/lang/LangSource/PyrParseNode.cpp
@@ -2884,6 +2884,20 @@ void compileSwitchMsg(PyrCallNode* node) {
         int absoluteOffset = byteCodeLength(gCompilingByteCodes);
         int offset = 0;
         int lastOffset = 0;
+
+        std::vector<PyrSlot> visitedKeys;
+        visitedKeys.reserve(numArgs);
+        const auto hasDuplicateKeyPostErrorAndPrepareForReturn = [&](auto node, PyrSlot key) -> bool {
+            if (const auto duplicateKey = std::find(visitedKeys.begin(), visitedKeys.end(), key);
+                duplicateKey != visitedKeys.end()) {
+                error("Duplicate key found in inlined switch statement\n");
+                nodePostErrorLine(node);
+                compileErrors++;
+                return true;
+            } else
+                return false;
+        };
+
         for (; argnode; argnode = nextargnode) {
             nextargnode = argnode->mNext;
             if (nextargnode != nullptr) {
@@ -2895,12 +2909,18 @@ void compileSwitchMsg(PyrCallNode* node) {
                 PyrPushLitNode* keyargnode = (PyrPushLitNode*)argnode;
                 if (isAtomicLiteral(argnode)) {
                     key = &keyargnode->mSlot;
+                    if (hasDuplicateKeyPostErrorAndPrepareForReturn(keyargnode, *key))
+                        return;
                 } else {
                     PyrBlockNode* bnode = (PyrBlockNode*)slotRawPtr(&keyargnode->mSlot);
                     PyrDropNode* dropnode = (PyrDropNode*)bnode->mBody;
                     PyrPushLitNode* litnode = (PyrPushLitNode*)dropnode->mExpr1;
                     key = &litnode->mSlot;
+                    if (hasDuplicateKeyPostErrorAndPrepareForReturn(litnode, *key))
+                        return;
                 }
+
+                visitedKeys.push_back(*key);
 
                 int index = arrayAtIdentityHashInPairs(array, key);
                 PyrSlot* slot = array->slots + index;

--- a/lang/LangSource/PyrSlot.h
+++ b/lang/LangSource/PyrSlot.h
@@ -319,8 +319,9 @@ public:
         // Doubles have odd comparison rules, otherwise compare the raw data.
         return (lhs.isDouble() && rhs.isDouble()) ? lhs.getDouble() == rhs.getDouble() : lhs.u_raw == rhs.u_raw;
     }
-
-    [[nodiscard]] inline uint64_t rawBytes() const noexcept { return u_raw; }
+    [[nodiscard]] friend inline bool operator<(PyrSlot lhs, PyrSlot rhs) noexcept {
+        return (lhs.isDouble() && rhs.isDouble()) ? lhs.getDouble() < rhs.getDouble() : lhs.u_raw <= rhs.u_raw;
+    }
 
     template <AssertDouble Check = AssertDouble::Okay> [[nodiscard]] inline static PyrSlot make(double d) noexcept {
         // There are many safe nan values, but a few are not safe.

--- a/lang/LangSource/PyrSlot.h
+++ b/lang/LangSource/PyrSlot.h
@@ -320,6 +320,8 @@ public:
         return (lhs.isDouble() && rhs.isDouble()) ? lhs.getDouble() == rhs.getDouble() : lhs.u_raw == rhs.u_raw;
     }
 
+    [[nodiscard]] inline uint64_t rawBytes() const noexcept { return u_raw; }
+
     template <AssertDouble Check = AssertDouble::Okay> [[nodiscard]] inline static PyrSlot make(double d) noexcept {
         // There are many safe nan values, but a few are not safe.
         // The server's Convolution3 is a known source of unsafe nans.


### PR DESCRIPTION
Only check inlined switches as the crash occurs when the jump offset is incorrectly calculated. Also, there is no way to peek into the generic uninlined cases so this is the best we can do here.

<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

Closes #1005

```supercollider
a = \one;
(
b = switch (a,
    \one, {1},
	\two, {2},
    \three, {3},
    \four, {4},
	\two, {2}
);
)
// crash
```

Bytecode jump offsets are calculated incorrectly. Now we just check there are no duplicate keys.

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix



## Error Results


```supercollider
switch (1,
	\one, {1},
	\two, {2},
	\three, {3},
	\four, {4},
	\two, {2}
);
```
```
ERROR: Duplicate key 'two' found in inlined switch statement.
  in interpreted text
  line 5 char 5:

  	\two, {2},
       
  	\three, {3},
-----------------------------------
-> nil
```

```supercollider
switch (1,
	1, {1},
	1, {2},
	2, {3},
	3, {4},
	4, {2}
);
```
```
ERROR: Duplicate key '1' found in inlined switch statement.
  in interpreted text
  line 3 char 2:

  	1, {1},
    
  	1, {2},
-----------------------------------
-> nil
```


```supercollider
switch (1,
	inf, {1},
	inf, {2},
	2, {3},
	3, {4},
	4, {2}
);
```
```
ERROR: Duplicate key 'inf' found in inlined switch statement.
  in interpreted text
  line 3 char 4:

  	inf, {1},
      
  	inf, {2},
-----------------------------------
-> nil
```

```supercollider
switch (1,
	-inf, {1},
	2, {3},
	3, {4},
	4, {2},
	-inf, {2},
);
```
```
ERROR: Duplicate key '-inf' found in inlined switch statement.
  in interpreted text
  line 3 char 5:

  	-inf, {1},
       
  	2, {3},
-----------------------------------
-> nil
```


I don't know why the line posting result is so ugly, but I think that is another issue.
## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
