### PR TITLE
sclang: compile error when duplicate var name is found

### DIFF
--- a/lang/LangSource/PyrParseNode.cpp
+++ b/lang/LangSource/PyrParseNode.cpp
@@ -18,6 +18,9 @@
     Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
 */
 
+#include "PyrObject.h"
+#include "PyrSlot.h"
+#include "PyrSymbol.h"
 #include "SCBase.h"
 #include "PyrParseNode.h"
 #include "PyrLexer.h"
@@ -28,6 +31,8 @@
 #include "PyrKernelProto.h"
 #include "PyrObjectProto.h"
 #include "GC.h"
+#include <algorithm>
+#include <iterator>
 #include <new>
 #include <string>
 #include <optional>
@@ -565,13 +570,13 @@ PyrClass* getNodeSuperclass(PyrClassNode* node) {
 }
 
 void fillClassPrototypes(PyrClassNode* node, PyrClass* classobj, PyrClass* superclassobj) {
-    PyrVarListNode* varlist;
-    PyrVarDefNode* vardef;
-    PyrSlot *islot, *cslot, *kslot;
-    PyrSymbol **inameslot, **cnameslot, **knameslot;
-    PyrClass* metaclassobj;
-    PyrMethod* method;
-    PyrMethodRaw* methraw;
+    PyrVarListNode* varlist = nullptr;
+    PyrVarDefNode* vardef = nullptr;
+    PyrSlot *islot = nullptr, *cslot = nullptr, *kslot = nullptr;
+    PyrSymbol **inameslot = nullptr, **cnameslot = nullptr, **knameslot = nullptr;
+    PyrClass* metaclassobj = nullptr;
+    PyrMethod* method = nullptr;
+    PyrMethodRaw* methraw = nullptr;
     int instVarIndex, classVarIndex;
 
     // copy superclass's prototype to here
@@ -782,6 +787,48 @@ void fillClassPrototypes(PyrClassNode* node, PyrClass* classobj, PyrClass* super
             }
             break;
         }
+    }
+
+    // Is vector faster than a set? Since symbols are just pointers, one would hope for really good auto vectorization.
+    // That and it is unlikely we will have that many members?
+    auto findDuplicateName =
+        [names = std::vector<PyrSymbol*>()](const PyrSymbolArray* array) mutable -> std::optional<PyrSymbol*> {
+        if (array == nullptr)
+            return std::nullopt; // Arrays can be null, meaning, empty.
+        if (names.capacity() < array->size)
+            names.reserve(array->size);
+
+        std::copy(array->symbols, array->symbols + array->size, std::back_inserter(names));
+        std::sort(names.begin(), names.end());
+        const auto maybe_duplicate = std::adjacent_find(names.begin(), names.end());
+
+        if (maybe_duplicate != names.end()) {
+            return { *maybe_duplicate };
+        }
+
+        names.clear();
+        return std::nullopt;
+    };
+
+    if (const auto duplicate = findDuplicateName(slotRawSymbolArray(&classobj->instVarNames)); duplicate) {
+        error("Found duplicate instance variable name '%s'\n", (*duplicate)->name);
+        nodePostErrorLine((PyrParseNode*)node->mVarlists);
+        compileErrors++;
+        return;
+    }
+
+    if (const auto duplicate = findDuplicateName(slotRawSymbolArray(&classobj->classVarNames)); duplicate) {
+        error("Found duplicate class variable name '%s'\n", (*duplicate)->name);
+        nodePostErrorLine((PyrParseNode*)node->mVarlists);
+        compileErrors++;
+        return;
+    }
+
+    if (const auto duplicate = findDuplicateName(slotRawSymbolArray(&classobj->constNames)); duplicate) {
+        error("Found duplicate const variable name '%s'\n", (*duplicate)->name);
+        nodePostErrorLine((PyrParseNode*)node->mVarlists);
+        compileErrors++;
+        return;
     }
 }
 

--- a/lang/LangSource/PyrParseNode.cpp
+++ b/lang/LangSource/PyrParseNode.cpp
@@ -789,42 +789,35 @@ void fillClassPrototypes(PyrClassNode* node, PyrClass* classobj, PyrClass* super
         }
     }
 
-    // Is vector faster than a set? Since symbols are just pointers, one would hope for really good auto vectorization.
-    // That and it is unlikely we will have that many members?
+    // Vector seems faster than set here, this could change if we have a lot (100s) of members, but that seems unlikely.
     auto findDuplicateName =
         [names = std::vector<PyrSymbol*>()](const PyrSymbolArray* array) mutable -> std::optional<PyrSymbol*> {
-        if (array == nullptr)
-            return std::nullopt; // Arrays can be null, meaning, empty.
-        if (names.capacity() < array->size)
-            names.reserve(array->size);
+        names.clear();
+        if (array == nullptr || array->size == 0)
+            return std::nullopt; // can be null, meaning, empty.
 
-        std::copy(array->symbols, array->symbols + array->size, std::back_inserter(names));
+        names.insert(names.end(), array->symbols, array->symbols + array->size);
         std::sort(names.begin(), names.end());
         const auto maybe_duplicate = std::adjacent_find(names.begin(), names.end());
 
-        if (maybe_duplicate != names.end()) {
-            return { *maybe_duplicate };
-        }
-
-        names.clear();
-        return std::nullopt;
+        return (maybe_duplicate != names.end()) ? std::optional<PyrSymbol*> { *maybe_duplicate } : std::nullopt;
     };
 
-    if (const auto duplicate = findDuplicateName(slotRawSymbolArray(&classobj->instVarNames)); duplicate) {
+    if (const auto duplicate = findDuplicateName(slotRawSymbolArray(&classobj->instVarNames))) {
         error("Found duplicate instance variable name '%s'\n", (*duplicate)->name);
         nodePostErrorLine((PyrParseNode*)node->mVarlists);
         compileErrors++;
         return;
     }
 
-    if (const auto duplicate = findDuplicateName(slotRawSymbolArray(&classobj->classVarNames)); duplicate) {
+    if (const auto duplicate = findDuplicateName(slotRawSymbolArray(&classobj->classVarNames))) {
         error("Found duplicate class variable name '%s'\n", (*duplicate)->name);
         nodePostErrorLine((PyrParseNode*)node->mVarlists);
         compileErrors++;
         return;
     }
 
-    if (const auto duplicate = findDuplicateName(slotRawSymbolArray(&classobj->constNames)); duplicate) {
+    if (const auto duplicate = findDuplicateName(slotRawSymbolArray(&classobj->constNames))) {
         error("Found duplicate const variable name '%s'\n", (*duplicate)->name);
         nodePostErrorLine((PyrParseNode*)node->mVarlists);
         compileErrors++;


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

Closes #1201
Closes #3263

Old
```supercollider
TestClass {
  var <var1 = 2;
  var <var1 = 3;
}
TestClass().var1 // doesn't work
```

New
```
ERROR: Found duplicate instance variable name 'var1'
  in file '/home/jordan/.repo/SuperCollider/SCClassLibrary/Common/Core/Object.sc'
  line 2 char 16:

    var <var1 = 2;
                  
    var <var1 = 3;
-----------------------------------
ERROR: Library has not been compiled successfully.
```

Also works for classvars and const vars.

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [ ] Code is tested
- [ ] All tests are passing
- [ ] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
