### PR TITLE
sclang: disable inlining in switch when a case is nil

### DIFF
--- a/lang/LangSource/PyrParseNode.cpp
+++ b/lang/LangSource/PyrParseNode.cpp
@@ -20,7 +20,6 @@
 
 #include "PyrObject.h"
 #include "PyrSlot.h"
-#include "PyrSymbol.h"
 #include "SCBase.h"
 #include "PyrParseNode.h"
 #include "PyrLexer.h"
@@ -40,11 +39,8 @@
 #include <stdlib.h>
 #include <stdarg.h>
 #include <cctype>
-#include "InitAlloc.h"
 #include "PredefinedSymbols.h"
 #include "SimpleStack.h"
-#include "PyrPrimitive.h"
-#include "SC_Win32Utils.h"
 #include "SC_LanguageConfig.hpp"
 #include "SC_Codecvt.hpp"
 #include "SpecialSelectorsOperatorsAndClasses.h"
@@ -2291,6 +2287,78 @@ bool isAtomicLiteral(PyrParseNode* node) {
     return res;
 }
 
+enum struct MaybePostNonInlineableWarning { True, False };
+
+/// Return the value of a literal, allows literal to be wrap in a single pair of curly braces.
+/// Will post a warning by default if it can't produce a value and is a block.
+template <MaybePostNonInlineableWarning Post = MaybePostNonInlineableWarning::True>
+std::optional<PyrSlot> getAtomicValueFromLiteralOrBlockMaybePostWarning(const PyrParseNode& node) {
+    if (node.mClassno != pn_PushLitNode)
+        return std::nullopt;
+
+    const auto& lit = static_cast<const PyrPushLitNode&>(node);
+    const auto& slot = lit.mSlot;
+
+    // There are no literal objects, arrays don't currently count as literals.
+    if (slot.isObjectHdr())
+        return std::nullopt;
+
+    // A literal object stored in the slot.
+    if (!slot.isPtr())
+        return { slot };
+
+    // The only thing we store in a pointer at this point in the parsing are other parse nodes.
+    // This is a little bit risky, but is wide spread.
+    const auto& maybeBlock = *reinterpret_cast<PyrParseNode*>(slot.getPtr());
+
+    // We are now expecting a block node, then a drop node containing a block return node containing a literal.
+
+    if (maybeBlock.mClassno != pn_BlockNode)
+        return std::nullopt;
+
+    const auto& block = static_cast<const PyrBlockNode&>(maybeBlock);
+
+    // Having arguments and variables mean we can't inline it, therefore, it isn't a literal.
+    if (block.mArglist || block.mVarlist) {
+        if constexpr (Post == MaybePostNonInlineableWarning::True) {
+            gNumUninlinedFunctions += 1;
+            if (SC_LanguageConfig::getPostInlineWarnings()) {
+                post("WARNING: FunctionDef contains variable declarations and so"
+                     " will not be inlined.\n");
+                if (block.mArglist)
+                    nodePostErrorLine((PyrParseNode*)block.mArglist);
+                else
+                    nodePostErrorLine((PyrParseNode*)block.mVarlist);
+            }
+        }
+        return std::nullopt;
+    }
+
+
+    if (block.mBody->mClassno != pn_DropNode)
+        return std::nullopt;
+
+    const auto& dropNode = *static_cast<PyrDropNode*>(block.mBody);
+
+    // Not a single return statement, e.g., { 1 },
+    if (dropNode.mExpr2->mClassno != pn_BlockReturnNode)
+        return std::nullopt;
+
+    if (dropNode.mExpr1->mClassno != pn_PushLitNode)
+        return std::nullopt;
+
+    const auto& blockedLit = static_cast<PyrPushLitNode&>(*dropNode.mExpr1);
+    const auto& blockedSlot = blockedLit.mSlot;
+    if (blockedSlot.isObjectHdr())
+        return std::nullopt;
+    // We don't allow functions to be literals, e.g., here the value returned would be a function`{ {1} }` but that is
+    // not a literal. Otherwise we could do recursion with tail call for this function.
+    if (blockedSlot.isPtr())
+        return std::nullopt;
+
+    return blockedSlot;
+}
+
 bool isWhileTrue(PyrParseNode* node) {
     bool res = false;
     if (node->mClassno == pn_PushLitNode) {
@@ -2710,33 +2778,38 @@ void compileSwitchMsg(PyrCallNode* node) {
 
         PyrParseNode* nextargnode = nullptr;
         for (; argnode; argnode = nextargnode) {
-            // This loop is confusing, argnode can refer to either the case of the default depending on whether the
+            // This loop is confusing, argnode can refer to either the case or the default depending on whether the
             // nextargnode is nullptr or not.
             nextargnode = argnode->mNext;
-            if (nextargnode != nullptr) {
-                if (!isAtomicLiteral(argnode) && !isAnInlineableAtomicLiteralBlock(argnode)) {
+            if (nextargnode == nullptr) {
+                // argnode is the default, this is how this loop terminates.
+                if (!isAnInlineableBlock(argnode))
                     canInline = false;
-                    break;
-                }
-                if (!isAnInlineableBlock(nextargnode)) {
-                    canInline = false;
-                    break;
-                }
+                break; // nothing left, leave.
+            }
 
-                // If the case is 'nil', do not inline as the empty element in the identity dictionary is nil.
-                if (argnode->mClassno == pn_PushLitNode) {
-                    if (const auto& lit = *static_cast<PyrPushLitNode*>(argnode); lit.mSlot.isNil()) {
-                        canInline = false;
-                        break;
-                    }
-                }
-                nextargnode = nextargnode->mNext;
-            } else {
-                if (!isAnInlineableBlock(argnode)) {
-                    canInline = false;
-                }
+            const auto& case_node = argnode;
+            const auto& function_node = nextargnode;
+
+            const auto case_literal = getAtomicValueFromLiteralOrBlockMaybePostWarning(*case_node);
+            if (!case_literal.has_value()) {
+                canInline = false;
                 break;
             }
+
+            // If the case is 'nil', do not inline as the empty element in the identity dictionary is nil.
+            if (case_literal->isNil()) {
+                canInline = false;
+                break;
+            }
+
+            // Check the function after the case.
+            if (!isAnInlineableBlock(function_node)) {
+                canInline = false;
+                break;
+            }
+
+            nextargnode = function_node->mNext;
         }
     }
 

--- a/lang/LangSource/PyrParseNode.cpp
+++ b/lang/LangSource/PyrParseNode.cpp
@@ -2710,6 +2710,8 @@ void compileSwitchMsg(PyrCallNode* node) {
 
         PyrParseNode* nextargnode = nullptr;
         for (; argnode; argnode = nextargnode) {
+            // This loop is confusing, argnode can refer to either the case of the default depending on whether the
+            // nextargnode is nullptr or not.
             nextargnode = argnode->mNext;
             if (nextargnode != nullptr) {
                 if (!isAtomicLiteral(argnode) && !isAnInlineableAtomicLiteralBlock(argnode)) {
@@ -2719,6 +2721,14 @@ void compileSwitchMsg(PyrCallNode* node) {
                 if (!isAnInlineableBlock(nextargnode)) {
                     canInline = false;
                     break;
+                }
+
+                // If the case is 'nil', do not inline as the empty element in the identity dictionary is nil.
+                if (argnode->mClassno == pn_PushLitNode) {
+                    if (const auto& lit = *static_cast<PyrPushLitNode*>(argnode); lit.mSlot.isNil()) {
+                        canInline = false;
+                        break;
+                    }
                 }
                 nextargnode = nextargnode->mNext;
             } else {

--- a/lang/LangSource/PyrParseNode.cpp
+++ b/lang/LangSource/PyrParseNode.cpp
@@ -2311,7 +2311,8 @@ std::optional<PyrSlot> getAtomicValueFromLiteralOrBlockMaybePostWarning(const Py
     // This is a little bit risky, but is wide spread.
     const auto& maybeBlock = *reinterpret_cast<PyrParseNode*>(slot.getPtr());
 
-    // We are now expecting a block node, then a drop node containing a block return node containing a literal.
+    // We are now expecting a block node, then a drop node containing a literal (as expression 1) and a block node
+    // return (as expression 2).
 
     if (maybeBlock.mClassno != pn_BlockNode)
         return std::nullopt;

--- a/lang/LangSource/PyrParseNode.cpp
+++ b/lang/LangSource/PyrParseNode.cpp
@@ -31,8 +31,6 @@
 #include "PyrObjectProto.h"
 #include "GC.h"
 #include <algorithm>
-#include <iterator>
-#include <new>
 #include <string>
 #include <optional>
 #include <string.h>

--- a/lang/LangSource/PyrParseNode.cpp
+++ b/lang/LangSource/PyrParseNode.cpp
@@ -2285,11 +2285,11 @@ bool isAtomicLiteral(PyrParseNode* node) {
     return res;
 }
 
-enum struct MaybePostNonInlineableWarning { True, False };
+enum struct UninlinableWarningOption { PostWarning, DontPostWarning };
 
 /// Return the value of a literal, allows literal to be wrap in a single pair of curly braces.
 /// Will post a warning by default if it can't produce a value and is a block.
-template <MaybePostNonInlineableWarning Post = MaybePostNonInlineableWarning::True>
+template <UninlinableWarningOption Warning = UninlinableWarningOption::PostWarning>
 std::optional<PyrSlot> getAtomicValueFromLiteralOrBlockMaybePostWarning(const PyrParseNode& node) {
     if (node.mClassno != pn_PushLitNode)
         return std::nullopt;
@@ -2318,21 +2318,25 @@ std::optional<PyrSlot> getAtomicValueFromLiteralOrBlockMaybePostWarning(const Py
     const auto& block = static_cast<const PyrBlockNode&>(maybeBlock);
 
     // Having arguments and variables mean we can't inline it, therefore, it isn't a literal.
-    if (block.mArglist || block.mVarlist) {
-        if constexpr (Post == MaybePostNonInlineableWarning::True) {
-            gNumUninlinedFunctions += 1;
-            if (SC_LanguageConfig::getPostInlineWarnings()) {
-                post("WARNING: FunctionDef contains variable declarations and so"
-                     " will not be inlined.\n");
-                if (block.mArglist)
-                    nodePostErrorLine((PyrParseNode*)block.mArglist);
-                else
-                    nodePostErrorLine((PyrParseNode*)block.mVarlist);
-            }
+    // Printing warnings first if requested to.
+    if constexpr (Warning == UninlinableWarningOption::PostWarning) {
+        const auto postWarning = SC_LanguageConfig::getPostInlineWarnings();
+        if (block.mArglist && postWarning) {
+            post("WARNING: FunctionDef contains argument declarations and so will not be inlined.\n");
+            nodePostErrorLine((PyrParseNode*)block.mArglist);
         }
-        return std::nullopt;
+        if (block.mVarlist && postWarning) {
+            post("WARNING: FunctionDef contains variable declarations and so will not be inlined.\n");
+            nodePostErrorLine((PyrParseNode*)block.mVarlist);
+        }
+        if (block.mArglist || block.mVarlist) {
+            gNumUninlinedFunctions += 1;
+            return std::nullopt;
+        }
+    } else {
+        if (block.mArglist || block.mVarlist)
+            return std::nullopt;
     }
-
 
     if (block.mBody->mClassno != pn_DropNode)
         return std::nullopt;

--- a/testsuite/classlibrary/TestSwitch.sc
+++ b/testsuite/classlibrary/TestSwitch.sc
@@ -1,0 +1,40 @@
+TestSwitch : UnitTest {
+	test_nil {
+		// This is indeterminate, but quite likely, 50 was more than enough to trigger this bug in practice.
+		50.do {
+			this.assertEquals(
+				switch([], nil, { $0 }, { $1 }),
+				$1,
+				"having nil in a switch statement shouldn't cause the nil case to be taken sometimes.",
+				report: false
+			);
+		};
+
+		50.do {
+			this.assertEquals(
+				switch([], {nil}, { $0 }, { $1 }),
+				$1,
+				"having nil in a switch statement shouldn't cause the nil case to be taken sometimes.",
+				report: false
+			);
+		};
+
+		this.assertEquals(
+			switch(nil, nil, { $0 }, { $1 }),
+			$0,
+			"Switch case of nil should behave correctly."
+		);
+
+		this.assertEquals(
+			switch(nil, {nil}, { $0 }, { $1 }),
+			$0,
+			"Switch case of nil should behave correctly."
+		);
+
+		this.assertEquals(
+			switch(\bang, {nil}, { $0 }, { $1 }),
+			$1,
+			"Switch case with nil should behave correctly."
+		);
+	}
+}


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

Closes #4178

Run this a bunch, it is random.
```
switch([], nil, { $0 }, { $X });
```

This is because the default case is stored as a `nil` in the inlined jump offset array so when the hash of the array (`[]`) (aka its address) is used to offset into the jump offsets, it picks either branch depending on what it encounters first.

This PR disables inlining when there is a literal nil as a case.


<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
