### PR TITLE
sclang: fix kw and inlined method crash

### DIFF
--- a/lang/LangSource/PyrParseNode.cpp
+++ b/lang/LangSource/PyrParseNode.cpp
@@ -4039,13 +4039,13 @@ int conjureSelectorIndex(PyrParseNode* node, PyrBlock* func, bool isSuper, PyrSy
             return opmLoop;
         } else if (selector == gSpecialSelectors[opmQuestionMark]) {
             *selType = selQuestionMark;
-            return opmAnd; // TODO: why are we returning opmAnd (14) ? Okay the value is ignored.
+            return opmQuestionMark;
         } else if (selector == gSpecialSelectors[opmDoubleQuestionMark]) {
             *selType = selDoubleQuestionMark;
-            return opmAnd; // TODO: why are we returning opmAnd (14) ? Okay the value is ingored
+            return opmDoubleQuestionMark;
         } else if (selector == gSpecialSelectors[opmExclamationQuestionMark]) {
             *selType = selExclamationQuestionMark;
-            return opmAnd; // TODO: why are we returning opmAnd (14) ?  Okay the value is ingored
+            return opmExclamationQuestionMark;
         }
 
         for (i = 0; i < opmNumSpecialSelectors; ++i) {

--- a/lang/LangSource/PyrParseNode.cpp
+++ b/lang/LangSource/PyrParseNode.cpp
@@ -1880,11 +1880,8 @@ void PyrCallNode::compileCall(PyrSlot* result) {
                 SendSpecialMsgX.emit(Operands::ArgumentCount::fromRaw(numArgs + 2 * numKeyArgs),
                                      Operands::KwArgumentCount::fromRaw(numKeyArgs), Operands::Index::fromRaw(index));
                 break;
-            case selUnary:
-            case selBinary:
-                index = conjureLiteralSlotIndex((PyrParseNode*)mSelector, gCompilingBlock, &mSelector->mSlot);
-                // fall through
             default:
+                index = conjureLiteralSlotIndex((PyrParseNode*)mSelector, gCompilingBlock, &mSelector->mSlot);
                 emitTailCall();
                 SendMsgX.emit(Operands::ArgumentCount::fromRaw(numArgs + 2 * numKeyArgs),
                               Operands::KwArgumentCount::fromRaw(numKeyArgs), Operands::Index::fromRaw(index));

--- a/lang/LangSource/PyrParseNode.cpp
+++ b/lang/LangSource/PyrParseNode.cpp
@@ -1897,7 +1897,7 @@ void PyrCallNode::compileCall(PyrSlot* result) {
             }
 
             default:
-                // In this case, the selector is a special one, and we can use the send speical message.
+                // In this case, the selector is a special one, and we can use the send special message.
                 emitTailCall();
                 SendSpecialMsgX.emit(Operands::ArgumentCount::fromRaw(numArgs + 2 * numKeyArgs),
                                      Operands::KwArgumentCount::fromRaw(numKeyArgs),

--- a/lang/LangSource/PyrParseNode.cpp
+++ b/lang/LangSource/PyrParseNode.cpp
@@ -1879,6 +1879,23 @@ void PyrCallNode::compileCall(PyrSlot* result) {
                               Operands::KwArgumentCount::fromRaw(numKeyArgs),
                               Operands::Index::fromRaw(selectorSlotOrSpecialIndex));
                 break;
+
+            case selUnary:
+                [[fallthrough]];
+            case selBinary: {
+                // When the selector is of the type unary or binary, no selector has been emited to the function def.
+                // This is because it is indented to be called with special bytes codes for the unary and binary message
+                // format respectively, however, these do not take kwargs. Therefore, we put the selector into the
+                // function def and use its index for a normal message send.
+                const auto selectorSlotIndex =
+                    conjureLiteralSlotIndex((PyrParseNode*)mSelector, gCompilingBlock, &mSelector->mSlot);
+                emitTailCall();
+                SendMsgX.emit(Operands::ArgumentCount::fromRaw(numArgs + 2 * numKeyArgs),
+                              Operands::KwArgumentCount::fromRaw(numKeyArgs),
+                              Operands::Index::fromRaw(selectorSlotIndex));
+                break;
+            }
+
             default:
                 // In this case, the selector is a special one, and we can use the send speical message.
                 emitTailCall();

--- a/lang/LangSource/PyrParseNode.cpp
+++ b/lang/LangSource/PyrParseNode.cpp
@@ -1842,9 +1842,7 @@ bool isSeries(PyrParseNode* node, PyrParseNode** args) {
 }
 
 void PyrCallNode::compileCall(PyrSlot* result) {
-    int index, selType;
     PyrSlot dummy;
-    bool varFound;
     PyrParseNode* argnode2;
 
     PyrParseNode* argnode = mArglist;
@@ -1855,8 +1853,9 @@ void PyrCallNode::compileCall(PyrSlot* result) {
     int numBlockArgs = METHRAW(gCompilingBlock)->numargs;
 
     slotRawSymbol(&mSelector->mSlot)->flags |= sym_Called;
-    index = conjureSelectorIndex((PyrParseNode*)mSelector, gCompilingBlock, isSuper, slotRawSymbol(&mSelector->mSlot),
-                                 &selType);
+    int selType;
+    auto selectorSlotOrSpecialIndex = conjureSelectorIndex((PyrParseNode*)mSelector, gCompilingBlock, isSuper,
+                                                           slotRawSymbol(&mSelector->mSlot), &selType);
 
     if (numKeyArgs > 0 || (numArgs > 15 && !(selType == selSwitch || selType == selCase))) {
         for (; argnode; argnode = argnode->mNext)
@@ -1866,25 +1865,26 @@ void PyrCallNode::compileCall(PyrSlot* result) {
 
         if (isSuper) {
             emitTailCall();
+            assert(selType == selNormal);
             SendSuperMsgX.emit(Operands::ArgumentCount::fromRaw(numArgs + 2 * numKeyArgs),
-                               Operands::KwArgumentCount::fromRaw(numKeyArgs), Operands::Index::fromRaw(index));
+                               Operands::KwArgumentCount::fromRaw(numKeyArgs),
+                               Operands::Index::fromRaw(selectorSlotOrSpecialIndex));
         } else {
             switch (selType) {
             case selNormal:
+                // When the selector type is normal, conjureSelectorIndex has added the symbol to the functiondef's
+                // selector array and we just send a normal message.
                 emitTailCall();
                 SendMsgX.emit(Operands::ArgumentCount::fromRaw(numArgs + 2 * numKeyArgs),
-                              Operands::KwArgumentCount::fromRaw(numKeyArgs), Operands::Index::fromRaw(index));
-                break;
-            case selSpecial:
-                emitTailCall();
-                SendSpecialMsgX.emit(Operands::ArgumentCount::fromRaw(numArgs + 2 * numKeyArgs),
-                                     Operands::KwArgumentCount::fromRaw(numKeyArgs), Operands::Index::fromRaw(index));
+                              Operands::KwArgumentCount::fromRaw(numKeyArgs),
+                              Operands::Index::fromRaw(selectorSlotOrSpecialIndex));
                 break;
             default:
-                index = conjureLiteralSlotIndex((PyrParseNode*)mSelector, gCompilingBlock, &mSelector->mSlot);
+                // In this case, the selector is a special one, and we can use the send speical message.
                 emitTailCall();
-                SendMsgX.emit(Operands::ArgumentCount::fromRaw(numArgs + 2 * numKeyArgs),
-                              Operands::KwArgumentCount::fromRaw(numKeyArgs), Operands::Index::fromRaw(index));
+                SendSpecialMsgX.emit(Operands::ArgumentCount::fromRaw(numArgs + 2 * numKeyArgs),
+                                     Operands::KwArgumentCount::fromRaw(numKeyArgs),
+                                     Operands::Index::fromRaw(selectorSlotOrSpecialIndex));
                 break;
             }
         }
@@ -1893,16 +1893,16 @@ void PyrCallNode::compileCall(PyrSlot* result) {
             // No need to compile the 'this' arg.
             gFunctionCantBeClosed = true;
             emitTailCall();
-            SendSuperMsgThisOpt.emit(Operands::Index::fromRaw(index));
+            SendSuperMsgThisOpt.emit(Operands::Index::fromRaw(selectorSlotOrSpecialIndex));
         } else {
             for (; argnode; argnode = argnode->mNext)
                 COMPILENODE(argnode, &dummy, false);
             emitTailCall();
             if (SendSuperMsg.validNibble(numArgs)) {
-                SendSuperMsg.emit(numArgs, Operands::Index::fromRaw(index));
+                SendSuperMsg.emit(numArgs, Operands::Index::fromRaw(selectorSlotOrSpecialIndex));
             } else {
                 SendSuperMsgX.emit(Operands::ArgumentCount::fromRaw(numArgs), Operands::KwArgumentCount::fromRaw(0),
-                                   Operands::Index::fromRaw(index));
+                                   Operands::Index::fromRaw(selectorSlotOrSpecialIndex));
             }
         }
 
@@ -1917,7 +1917,7 @@ void PyrCallNode::compileCall(PyrSlot* result) {
         case selNormal: {
             if (numArgs == 1 && varname == s_this) {
                 emitTailCall();
-                SendMsgThisOpt.emit(Operands::Index::fromRaw(index));
+                SendMsgThisOpt.emit(Operands::Index::fromRaw(selectorSlotOrSpecialIndex));
             } else if (numArgs > 1 && numArgs == numBlockArgs) {
                 switch (checkPushAllArgs(argnode, numArgs)) {
                 case push_Normal:
@@ -1925,13 +1925,13 @@ void PyrCallNode::compileCall(PyrSlot* result) {
 
                 case push_AllArgs: {
                     emitTailCall();
-                    PushAllArgsAndSendMsg.emit(Operands::Index::fromRaw(index));
+                    PushAllArgsAndSendMsg.emit(Operands::Index::fromRaw(selectorSlotOrSpecialIndex));
                 } break;
 
                 case push_AllButFirstArg: {
                     COMPILENODE(argnode, &dummy, false);
                     emitTailCall();
-                    PushAllButFirstArgAndSendMsg.emit(Operands::Index::fromRaw(index));
+                    PushAllButFirstArgAndSendMsg.emit(Operands::Index::fromRaw(selectorSlotOrSpecialIndex));
                 } break;
 
                 default:
@@ -1947,7 +1947,7 @@ void PyrCallNode::compileCall(PyrSlot* result) {
                     COMPILENODE(argnode, &dummy, false);
                     COMPILENODE(argnode->mNext, &dummy, false);
                     emitTailCall();
-                    PushAllButFirstTwoArgsAndSendMsg.emit(Operands::Index::fromRaw(index));
+                    PushAllButFirstTwoArgsAndSendMsg.emit(Operands::Index::fromRaw(selectorSlotOrSpecialIndex));
                 } break;
 
                 default:
@@ -1961,10 +1961,10 @@ void PyrCallNode::compileCall(PyrSlot* result) {
                 emitTailCall();
 
                 if (SendMsg.validNibble(numArgs))
-                    SendMsg.emit(numArgs, Operands::Index::fromRaw(index));
+                    SendMsg.emit(numArgs, Operands::Index::fromRaw(selectorSlotOrSpecialIndex));
                 else
                     SendMsgX.emit(Operands::ArgumentCount::fromRaw(numArgs), Operands::KwArgumentCount::fromRaw(0),
-                                  Operands::Index::fromRaw(index));
+                                  Operands::Index::fromRaw(selectorSlotOrSpecialIndex));
             }
         } break;
 
@@ -1972,21 +1972,21 @@ void PyrCallNode::compileCall(PyrSlot* result) {
             if (numArgs == 1) {
                 if (varname == s_this) {
                     emitTailCall();
-                    SendSpecialMsgThisOpt.emit(Operands::Index::fromRaw(index));
+                    SendSpecialMsgThisOpt.emit(Operands::Index::fromRaw(selectorSlotOrSpecialIndex));
                 } else if (varname) {
                     if (const auto result = findVarName(gCompilingBlock, gCompilingClass, varname);
                         result && result->varType == varInst) {
                         emitTailCall();
                         PushInstVarAndSendSpecialMsg.emit(Operands::Index::fromRaw(result->index),
-                                                          Operands::Index::fromRaw(index));
+                                                          Operands::Index::fromRaw(selectorSlotOrSpecialIndex));
                     } else
                         goto special;
 
                 } else
                     goto special;
 
-            } else if (index == opmDo && isSeries(argnode, &argnode)) {
-                index = opmForSeries;
+            } else if (selectorSlotOrSpecialIndex == opmDo && isSeries(argnode, &argnode)) {
+                selectorSlotOrSpecialIndex = opmForSeries;
                 mArglist = linkNextNode(argnode, mArglist->mNext);
                 numArgs = nodeListLength(mArglist);
                 goto special;
@@ -1998,13 +1998,13 @@ void PyrCallNode::compileCall(PyrSlot* result) {
 
                 case push_AllArgs: {
                     emitTailCall();
-                    PushAllArgsAndSendSpecialMsg.emit(Operands::Index::fromRaw(index));
+                    PushAllArgsAndSendSpecialMsg.emit(Operands::Index::fromRaw(selectorSlotOrSpecialIndex));
                 } break;
 
                 case push_AllButFirstArg: {
                     COMPILENODE(argnode, &dummy, false);
                     emitTailCall();
-                    PushAllButFirstArgAndSendSpecialMsg.emit(Operands::Index::fromRaw(index));
+                    PushAllButFirstArgAndSendSpecialMsg.emit(Operands::Index::fromRaw(selectorSlotOrSpecialIndex));
                 } break;
 
                 default:
@@ -2020,7 +2020,7 @@ void PyrCallNode::compileCall(PyrSlot* result) {
                     COMPILENODE(argnode, &dummy, false);
                     COMPILENODE(argnode->mNext, &dummy, false);
                     emitTailCall();
-                    PushAllButFirstTwoArgsAndSendSpecialMsg.emit(Operands::Index::fromRaw(index));
+                    PushAllButFirstTwoArgsAndSendSpecialMsg.emit(Operands::Index::fromRaw(selectorSlotOrSpecialIndex));
                 } break;
 
                 default:
@@ -2033,36 +2033,40 @@ void PyrCallNode::compileCall(PyrSlot* result) {
                     COMPILENODE(argnode, &dummy, false);
                 emitTailCall();
                 if (SendSpecialMsg.validNibble(numArgs))
-                    SendSpecialMsg.emit(numArgs, Operands::SpecialSelectors::fromRaw(index));
+                    SendSpecialMsg.emit(numArgs, Operands::SpecialSelectors::fromRaw(selectorSlotOrSpecialIndex));
                 else
                     SendSpecialMsgX.emit(Operands::ArgumentCount::fromRaw(numArgs),
-                                         Operands::KwArgumentCount::fromRaw(0), Operands::Index::fromRaw(index));
+                                         Operands::KwArgumentCount::fromRaw(0),
+                                         Operands::Index::fromRaw(selectorSlotOrSpecialIndex));
             }
             break;
 
         case selUnary: {
             if (numArgs != 1) {
-                index = conjureLiteralSlotIndex((PyrParseNode*)mSelector, gCompilingBlock, &mSelector->mSlot);
+                selectorSlotOrSpecialIndex =
+                    conjureLiteralSlotIndex((PyrParseNode*)mSelector, gCompilingBlock, &mSelector->mSlot);
                 goto defaultCase;
             }
             for (; argnode; argnode = argnode->mNext)
                 COMPILENODE(argnode, &dummy, false);
 
             emitTailCall();
-            SendSpecialUnaryArithMsgX.emit(Operands::UnaryMath::fromRaw(index));
+            SendSpecialUnaryArithMsgX.emit(Operands::UnaryMath::fromRaw(selectorSlotOrSpecialIndex));
         } break;
 
         case selBinary:
             if (numArgs != 2) {
-                index = conjureLiteralSlotIndex((PyrParseNode*)mSelector, gCompilingBlock, &mSelector->mSlot);
+                selectorSlotOrSpecialIndex =
+                    conjureLiteralSlotIndex((PyrParseNode*)mSelector, gCompilingBlock, &mSelector->mSlot);
                 goto defaultCase;
             }
             argnode2 = argnode->mNext;
-            if (index == static_cast<int>(OpBinaryMath::Add) && argnode2->mClassno == pn_PushLitNode
-                && IsInt(&((PyrPushLitNode*)argnode2)->mSlot) && slotRawInt(&((PyrPushLitNode*)argnode2)->mSlot) == 1) {
+            if (selectorSlotOrSpecialIndex == static_cast<int>(OpBinaryMath::Add)
+                && argnode2->mClassno == pn_PushLitNode && IsInt(&((PyrPushLitNode*)argnode2)->mSlot)
+                && slotRawInt(&((PyrPushLitNode*)argnode2)->mSlot) == 1) {
                 COMPILENODE(argnode, &dummy, false);
                 PushOneAndAddOne.emit();
-            } else if (index == opSub && argnode2->mClassno == pn_PushLitNode
+            } else if (selectorSlotOrSpecialIndex == opSub && argnode2->mClassno == pn_PushLitNode
                        && IsInt(&((PyrPushLitNode*)argnode2)->mSlot)
                        && slotRawInt(&((PyrPushLitNode*)argnode2)->mSlot) == 1) {
                 COMPILENODE(argnode, &dummy, false);
@@ -2071,10 +2075,10 @@ void PyrCallNode::compileCall(PyrSlot* result) {
                 COMPILENODE(argnode, &dummy, false);
                 COMPILENODE(argnode->mNext, &dummy, false);
                 emitTailCall();
-                if (index < 16)
-                    SendSpecialBinaryArithMsg.emit(Operands::BinaryMathNibble::fromRaw(index));
+                if (selectorSlotOrSpecialIndex < 16)
+                    SendSpecialBinaryArithMsg.emit(Operands::BinaryMathNibble::fromRaw(selectorSlotOrSpecialIndex));
                 else
-                    SendSpecialBinaryArithMsgX.emit(Operands::BinaryMath::fromRaw(index));
+                    SendSpecialBinaryArithMsgX.emit(Operands::BinaryMath::fromRaw(selectorSlotOrSpecialIndex));
             }
             break;
 
@@ -2131,17 +2135,17 @@ void PyrCallNode::compileCall(PyrSlot* result) {
         defaultCase:
             if (numArgs == 1 && varname == s_this) {
                 emitTailCall();
-                SendMsgThisOpt.emit(Operands::Index::fromRaw(index));
+                SendMsgThisOpt.emit(Operands::Index::fromRaw(selectorSlotOrSpecialIndex));
             } else {
                 for (; argnode; argnode = argnode->mNext)
                     COMPILENODE(argnode, &dummy, false);
 
                 emitTailCall();
                 if (SendMsg.validNibble(numArgs))
-                    SendMsg.emit(numArgs, Operands::Index::fromRaw(index));
+                    SendMsg.emit(numArgs, Operands::Index::fromRaw(selectorSlotOrSpecialIndex));
                 else
                     SendMsgX.emit(Operands::ArgumentCount::fromRaw(numArgs), Operands::KwArgumentCount::fromRaw(0),
-                                  Operands::Index::fromRaw(index));
+                                  Operands::Index::fromRaw(selectorSlotOrSpecialIndex));
             }
             break;
         }

--- a/testsuite/classlibrary/TestKwargs.sc
+++ b/testsuite/classlibrary/TestKwargs.sc
@@ -152,4 +152,19 @@ TestKwargs : UnitTest {
 			[[1, 2], 42, 23]
 		);
 	}
+
+	test_control_flow {
+		// These all used to crash.
+		this.assertEquals(true.if(trueFunc: {'s'}), 's');
+		this.assertEquals(true.if(falseFunc: {'s'}), nil);
+
+		this.assertEquals(false.if(trueFunc: {'s'}), nil);
+		this.assertEquals(false.if(falseFunc: {'s'}), 's');
+
+		// Posts a warning, but that is fine.
+		this.assertEquals(100.loop(xyz: 1).(), 100);
+
+		this.assertEquals(true.and(that: {1}), 1);
+		this.assertEquals(false.and(that: {1}), false);
+	}
 }

--- a/testsuite/classlibrary/TestKwargs.sc
+++ b/testsuite/classlibrary/TestKwargs.sc
@@ -154,6 +154,7 @@ TestKwargs : UnitTest {
 	}
 
 	test_control_flow {
+		var i = 0;
 		// These all used to crash.
 		this.assertEquals(true.if(trueFunc: {'s'}), 's');
 		this.assertEquals(true.if(falseFunc: {'s'}), nil);
@@ -167,7 +168,15 @@ TestKwargs : UnitTest {
 		this.assertEquals(true.and(that: {1}), 1);
 		this.assertEquals(false.and(that: {1}), false);
 
+		// Unary messages
 		this.assertEquals(true.not(asd: 1), false);
 		this.assertEquals(false.not(asd: 1), true);
+
+		// Binary, note the unusual syntax needed to call these with keywords!
+		this.assertEquals( (!?)(1, obj: 2),  2);
+		this.assertEquals((+)(1, aNumber: 10 ), 11);
+
+		while({ i < 10 }, body: { i = i + 1 });
+		this.assertEquals(i, 10);
 	}
 }

--- a/testsuite/classlibrary/TestKwargs.sc
+++ b/testsuite/classlibrary/TestKwargs.sc
@@ -166,5 +166,8 @@ TestKwargs : UnitTest {
 
 		this.assertEquals(true.and(that: {1}), 1);
 		this.assertEquals(false.and(that: {1}), false);
+
+		this.assertEquals(true.not(asd: 1), false);
+		this.assertEquals(false.not(asd: 1), true);
 	}
 }


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

Closes #4474

Closes #5429

Passing keywords to control flow no longer crashes the interpreter. It will never inline the methods though.

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
