### PR TITLE
sclang: fix lexer ambiguity with scale degrees and whitespace/infix binary ops

### DIFF
--- a/lang/LangSource/PyrLexer.cpp
+++ b/lang/LangSource/PyrLexer.cpp
@@ -681,8 +681,7 @@ digits_1: /* number started with digits */
             goto accidental2;
         if (std::isalpha(d)) {
             yytext[yylen] = 0;
-            post("encountered an accidental '%s' with unknown trailing text. Ensure there is whitespace after "
-                 "accidentals.\n",
+            post("encountered an accidental '%s' with unknown trailing text. Ensure there is whitespace after it.\n",
                  yytext);
             goto error1;
         }

--- a/lang/LangSource/PyrLexer.cpp
+++ b/lang/LangSource/PyrLexer.cpp
@@ -19,6 +19,7 @@
     Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
 */
 
+#include <cctype>
 #include <stdlib.h>
 #include <string.h>
 #include <float.h>
@@ -678,6 +679,13 @@ digits_1: /* number started with digits */
             goto accidental1;
         if (d == c)
             goto accidental2;
+        if (std::isalpha(d)) {
+            yytext[yylen] = 0;
+            post("encountered an accidental '%s' with unknown trailing text. Ensure there is whitespace after "
+                 "accidentals.\n",
+                 yytext);
+            goto error1;
+        }
         goto accidental3;
     accidental1:
         d = input();


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

Closes #2568

`16spow: 2` is parsed as (16s).pow(2). This should be an error. 

This is technically a breaking change, but seems very unlikely that someone will be relying on it.


<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix
- Breaking change

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
