### PR TITLE
sclang: make duplicate class vars a warning in 3.15, error from 3.16

### DIFF
--- a/common/SC_Version.hpp.in
+++ b/common/SC_Version.hpp.in
@@ -25,12 +25,17 @@
 
 // Does not support tweaks.
 // Useful for branches in the code as this inherits tuple's lexigraphical comparisons.
+// Initialise with {Major, Minor, Patch}.
 struct SemanticVersion : public std::tuple<uint32_t, uint32_t, uint32_t> {
-    using std::tuple<uint32_t,uint32_t, uint32_t>::tuple;
+    using std::tuple<uint32_t, uint32_t, uint32_t>::tuple;
+
+    [[nodiscard]] constexpr uint32_t major() const { return std::get<0>(*this); } 
+    [[nodiscard]] constexpr uint32_t minor() const { return std::get<1>(*this); } 
+    [[nodiscard]] constexpr uint32_t patch() const { return std::get<2>(*this); } 
 
     [[nodiscard]] std::string asString() const {
         std::stringstream out;
-        out << std::get<0>(*this) << "." << std::get<1>(*this) << "." << std::get<2>(*this);
+        out << major() << "." << minor() << "." << patch();
         return out.str();
     }
  };

--- a/common/SC_Version.hpp.in
+++ b/common/SC_Version.hpp.in
@@ -20,27 +20,42 @@
 
 #include <string>
 #include <sstream>
+#include <cstdint>
+#include <tuple>
 
-static const int SC_VersionMajor = @SC_VERSION_MAJOR@;
-static const int SC_VersionMinor = @SC_VERSION_MINOR@;
-static const int SC_VersionPatch = @SC_VERSION_PATCH@;
-static const char SC_VersionTweak[] = "@SC_VERSION_TWEAK@";
-static const char SC_RefType[] = "@GIT_REF_TYPE@";
-static const char SC_BranchOrTag[] = "@GIT_BRANCH_OR_TAG@";
-static const char SC_CommitHash[] = "@GIT_COMMIT_HASH@";
+// Does not support tweaks.
+// Useful for branches in the code as this inherits tuple's lexigraphical comparisons.
+struct SemanticVersion : public std::tuple<uint32_t, uint32_t, uint32_t> {
+    using std::tuple<uint32_t,uint32_t, uint32_t>::tuple;
+
+    [[nodiscard]] std::string asString() const {
+        std::stringstream out;
+        out << std::get<0>(*this) << "." << std::get<1>(*this) << "." << std::get<2>(*this);
+        return out.str();
+    }
+ };
+
+static constexpr uint32_t SC_VersionMajor = @SC_VERSION_MAJOR@;
+static constexpr uint32_t SC_VersionMinor = @SC_VERSION_MINOR@;
+static constexpr uint32_t SC_VersionPatch = @SC_VERSION_PATCH@;
+static constexpr char SC_VersionTweak[] = "@SC_VERSION_TWEAK@";
+static constexpr char SC_RefType[] = "@GIT_REF_TYPE@";
+static constexpr char SC_BranchOrTag[] = "@GIT_BRANCH_OR_TAG@";
+static constexpr char SC_CommitHash[] = "@GIT_COMMIT_HASH@";
+
+static constexpr SemanticVersion SC_Version {SC_VersionMajor, SC_VersionMinor, SC_VersionPatch};
+
 
 // For backward compatibility in scsynth and supernova only.
-static const char SC_VersionPostfix[] = ".@SC_VERSION_PATCH@@SC_VERSION_TWEAK@";
+static constexpr char SC_VersionPostfix[] = ".@SC_VERSION_PATCH@@SC_VERSION_TWEAK@";
 
-static inline std::string SC_VersionString()
-{
+static inline std::string SC_VersionString() {
 	std::stringstream out;
 	out << SC_VersionMajor << "." << SC_VersionMinor << "." << SC_VersionPatch << SC_VersionTweak;
 	return out.str();
 }
 
-static inline std::string SC_BuildString()
-{
+static inline std::string SC_BuildString() {
     std::stringstream out;
     out << "Built from " << SC_RefType << " '" << SC_BranchOrTag << "' [" << SC_CommitHash << "]";
     return out.str();

--- a/lang/LangPrimSource/PyrPrimitive.cpp
+++ b/lang/LangPrimSource/PyrPrimitive.cpp
@@ -40,7 +40,6 @@
 #include "SC_AudioDevicePrim.hpp"
 #include "SC_LanguageConfig.hpp"
 #include "SC_Filesystem.hpp"
-#include "SC_Version.hpp"
 
 #include <map>
 #include <cstdlib>

--- a/lang/LangSource/PyrParseNode.cpp
+++ b/lang/LangSource/PyrParseNode.cpp
@@ -42,6 +42,7 @@
 #include "SC_LanguageConfig.hpp"
 #include "SC_Codecvt.hpp"
 #include "SpecialSelectorsOperatorsAndClasses.h"
+#include "SC_Version.hpp"
 
 namespace fs = std::filesystem;
 
@@ -105,6 +106,18 @@ const char* nodename[] = { "ClassNode", "ClassExtNode", "MethodNode", "BlockNode
 
                            "ReturnNode", "BlockReturnNode" };
 
+/// Creates a compiler error if current version is greater than or equal to 'version'.
+/// Otherwise posts a warning informing the user to fix their code before updating.
+void emitCompilerErrorFromVersion(SemanticVersion version) {
+    if (SC_Version >= version) {
+        compileErrors++;
+    } else {
+        const auto str = version.asString();
+        post("WARNING: From version %s onwards the preceding error will be a compilation failure, please fix the code "
+             "before updating.\n\n",
+             str.c_str());
+    }
+}
 
 // Forward declare helpers.
 // This means they aren't a part of the public interface of the header.
@@ -820,22 +833,19 @@ void fillClassPrototypes(PyrClassNode* node, PyrClass* classobj, PyrClass* super
     if (const auto duplicate = findDuplicateName(slotRawSymbolArray(&classobj->instVarNames))) {
         error("Found duplicate instance variable name '%s'\n", (*duplicate)->name);
         attemptToPrintDuplicateLocation(*duplicate, varInst);
-        compileErrors++;
-        return;
+        emitCompilerErrorFromVersion({ 3, 16, 0 });
     }
 
     if (const auto duplicate = findDuplicateName(slotRawSymbolArray(&classobj->classVarNames))) {
         error("Found duplicate class variable name '%s'\n", (*duplicate)->name);
         attemptToPrintDuplicateLocation(*duplicate, varClass);
-        compileErrors++;
-        return;
+        emitCompilerErrorFromVersion({ 3, 16, 0 });
     }
 
     if (const auto duplicate = findDuplicateName(slotRawSymbolArray(&classobj->constNames))) {
         error("Found duplicate const variable name '%s'\n", (*duplicate)->name);
         attemptToPrintDuplicateLocation(*duplicate, varConst);
-        compileErrors++;
-        return;
+        emitCompilerErrorFromVersion({ 3, 16, 0 });
     }
 }
 

--- a/lang/LangSource/PyrParseNode.cpp
+++ b/lang/LangSource/PyrParseNode.cpp
@@ -42,7 +42,6 @@
 #include "SC_LanguageConfig.hpp"
 #include "SC_Codecvt.hpp"
 #include "SpecialSelectorsOperatorsAndClasses.h"
-#include "SC_Version.hpp"
 
 namespace fs = std::filesystem;
 
@@ -106,8 +105,6 @@ const char* nodename[] = { "ClassNode", "ClassExtNode", "MethodNode", "BlockNode
 
                            "ReturnNode", "BlockReturnNode" };
 
-/// Creates a compiler error if current version is greater than or equal to 'version'.
-/// Otherwise posts a warning informing the user to fix their code before updating.
 void emitCompilerErrorFromVersion(SemanticVersion version) {
     if (SC_Version >= version) {
         compileErrors++;

--- a/lang/LangSource/PyrParseNode.h
+++ b/lang/LangSource/PyrParseNode.h
@@ -22,6 +22,7 @@
 
 #include "PyrSlot.h"
 #include "PyrKernel.h"
+#include "SC_Version.hpp"
 #include "ByteCodeArray.h"
 #include "Opcodes.h"
 #include "AdvancingAllocPool.h"
@@ -468,6 +469,11 @@ PyrParseNode* linkNextNode(PyrParseNode* a, PyrParseNode* b);
 PyrParseNode* linkAfterHead(PyrParseNode* a, PyrParseNode* b);
 
 extern int compileErrors;
+
+/// Creates a compiler error if current version is greater than or equal to 'version'.
+/// Otherwise posts a warning informing the user to fix their code before updating.
+void emitCompilerErrorFromVersion(SemanticVersion version);
+
 extern int numOverwrites;
 extern std::string overwriteMsg;
 


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

Turns recent duplicate class var into a warning for version 3.15, but a compilation error from 3.16. Also introduces a way to make this easier as this is something we might want to use going forward.  


Now the output is
```
ERROR: Found duplicate instance variable name 'name'
  in file '/home/jordan/.local/share/SuperCollider/downloaded-quarks/wslib/wslib-classes/Main Features/File management/FolderLibrary.sc'
  line 97 char 10:

        var <name;
            
  
-----------------------------------
WARNING: From version 3.16.0 onwards the preceding error will be a compilation failure, please fix the code before updating.

```

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->

- New feature

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [ ] Code is tested
- [ ] All tests are passing
- [ ] Updated documentation
- [ ] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
