### PR TITLE
Keep consistency between getting and setting the s.options.device

### DIFF
--- a/HelpSource/Classes/ServerOptions.schelp
+++ b/HelpSource/Classes/ServerOptions.schelp
@@ -36,7 +36,7 @@ method:: blockSize
 The number of samples in one control period. The default is 64.
 
 method:: device
-A String that allows you to choose a sound device to use as input and output. The default, code::nil::, will use the system's default input and output device(s). See link::Reference/AudioDeviceSelection:: for more details.
+A String or a 2-element Array of Strings that allows you to choose a sound device to use as input and output. The default, code::nil::, will use the system's default input and output device(s). See link::Reference/AudioDeviceSelection:: for more details.
 
 method:: inDevice
 A String that allows you to choose an input sound device. The default, code::nil::, will use the system's default input device. See link::Reference/AudioDeviceSelection:: for more details.
@@ -182,6 +182,7 @@ o.numOutputBusChannels = 6; // The next time it boots, this will take effect
 
 o.device = "MOTU Traveler"; 	// use a specific soundcard
 o.device = nil;			// use the system default soundcard
+o.device = ["MOTU Traveler", "Backhole 16ch"]; 	// use a specific soundcard of input and another output
 
 // finally, boot the server
 

--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -124,7 +124,14 @@ ServerOptions {
 	}
 
 	device_ { |dev|
-		inDevice = outDevice = dev;
+		if (dev.isKindOf(String)) {
+			inDevice = outDevice = dev;
+		};
+
+		if (dev.isKindOf(Array)) {
+			inDevice = dev.wrapAt[0];
+			outDevice = dev.wrapAt[1];
+		}
 	}
 
 	asOptionsString { | port = 57110 |


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

Currently if you set different `s.options.inDevice` and `s.options.outDevice`, when you get the `s.options.device` it returns an array consisting of `[inDevice, outDevice]`. 

The problem is that if you try to set `s.options.device` to an array, this will fail when booting because `s.options.device_` is  setting both `inDevice` and `outDevice` to the value it is set, so both `inDevice` and `outDevice` are set as the array. Example:

```
s.options.device = ["Test", "Test2"]
-> a ServerOptions
s.options.inDevice.postln;
[Test, Test2]
s.options.outDevice.postln;
[Test, Test2]
```

It becomes a bigger issue because if you do something like:

```
s.options.inDevice = "Test";
s.options.outDevice = "Test2";
```

And then do:
`s.options.device = s.options.device;`

This will fail to boot, which I believe is a bad behavior. 

In this PR I add the possibility of setting the `s.options.device` as a two-element array, so it is compatible with the getter pattern, keeping the method consistent. I also updated the documentation.

## Types of changes

- Documentation
- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [ ] Code is tested
- [ ] All tests are passing
- [ ] Updated documentation
- [ ] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
