### PR TITLE
SCDoc: Remove ghost characters and replace non-standard white spaces

### DIFF
--- a/HelpSource/Classes/Dswitch1.schelp
+++ b/HelpSource/Classes/Dswitch1.schelp
@@ -42,7 +42,7 @@ code::
 (
 {
 	var a, freq, trig;
-	a = Dswitch1({ |i| Dseq((0..i*3), inf) } ! 5, MouseX.kr(0, 4));
+	a = Dswitch1({ |i| Dseq((0..i*3), inf) } ! 5, MouseX.kr(0, 4));
 	trig = Impulse.kr(6);
 	freq = Demand.kr(trig, 0, a) * 30 + 340;
 	SinOsc.ar(freq) * 0.1

--- a/HelpSource/Classes/ObjectGui.schelp
+++ b/HelpSource/Classes/ObjectGui.schelp
@@ -8,7 +8,7 @@ In the MVC architecture this is the Controller, which creates Views for manipula
 
 Each class specifies its Gui class via the guiClass method.
 
-The default guiClass for an Object is ObjectGui.  So if a class does not implement guiClass at all, then at least there is a default ObjectGui that will display the name.
+The default guiClass for an Object is ObjectGui. So if a class does not implement guiClass at all, then at least there is a default ObjectGui that will display the name.
 
 Many subclasses override the guiClass method to specify a different class, one that subclasses ObjectGui.
 
@@ -164,7 +164,7 @@ YourGuiClass : ObjectGui {
 		
 		// display some param on screen.
 		// here we assume that someParam is something that
-		//  has a suitable gui class
+		// has a suitable gui class
 		// implemented, or that the default ObjectGui is sufficient.
 		model.someParam.gui(layout);
 		
@@ -200,7 +200,7 @@ YourGuiClass : ObjectGui {
 			*/
 			numberEditor.value = model.howFast;
 			/*
-				note that 
+				note that
 					numberEditor.value = model.howFast;
 				is passive, and does not fire the numberEditor's action.	
 

--- a/HelpSource/Classes/TDuty.schelp
+++ b/HelpSource/Classes/TDuty.schelp
@@ -59,7 +59,7 @@ s.boot;
 
 // play a little rhythm
 
-{ TDuty.ar(Dseq([0.1, 0.2, 0.4, 0.3], inf)) }.play; // demand ugen as durations
+{ TDuty.ar(Dseq([0.1, 0.2, 0.4, 0.3], inf)) }.play; // demand ugen as durations
 
 
 
@@ -149,7 +149,7 @@ fork { 10.do { s.sendBundle(0.2, ["/s_new", "delta_demand2", -1]); 1.0.rand.wait
 		t = TDuty.ar(
 				Drand([Dgeom(0.1, 0.8, 20), 1, 2], inf) ! 2,
 				0,
-				[Drand({ 1.0.rand } ! 8, inf), Dseq({ 1.0.rand } ! 8, inf)] * 2
+				[Drand({ 1.0.rand } ! 8, inf), Dseq({ 1.0.rand } ! 8, inf)] * 2
 			);
 		x = Ringz.ar(t, [400, 700], 0.1) * 0.1;
 

--- a/HelpSource/Tutorials/A-Practical-Guide/PG_06b_Time_Based_Patterns.schelp
+++ b/HelpSource/Tutorials/A-Practical-Guide/PG_06b_Time_Based_Patterns.schelp
@@ -82,7 +82,7 @@ p.stop;
 
 The code::releaseNode:: and code::loopNode:: envelope parameters do not take effect, because they are meaningful only when used in a Synth with a gated EnvGen.
 
-When the envelope ends, the stream will hold the final level indefinitely. The code::Pif(Ptime(inf) < totalTime, Env(...)):: trick can make it stop instead.
+When the envelope ends, the stream will hold the final level indefinitely. The code::Pif(Ptime(inf) < totalTime, Env(...)):: trick can make it stop instead.
 
 code::
 // Use an envelope to pan notes from left to right and back

--- a/HelpSource/Tutorials/A-Practical-Guide/PG_06c_Composition_of_Patterns.schelp
+++ b/HelpSource/Tutorials/A-Practical-Guide/PG_06c_Composition_of_Patterns.schelp
@@ -18,7 +18,7 @@ g(x) = x * 2
 g · f = g(f(x)) = (x + 1) * 2
 ::
 
-code::g · f:: means to evaluate code::f:: first, then pass its result to code::g::. The code::·:: operator is written as code::<>:: in SuperCollider.
+code::g · f:: means to evaluate code::f:: first, then pass its result to code::g::. The code::·:: operator is written as code::<>:: in SuperCollider.
 
 code::
 f = { |x| x + 1 };

--- a/HelpSource/Tutorials/Mark_Polishook_tutorial/Japanese_version/13.schelp
+++ b/HelpSource/Tutorials/Mark_Polishook_tutorial/Japanese_version/13.schelp
@@ -235,7 +235,7 @@ Synth.head(~source, "filteredDust");
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
-For context, here, below, is the complete text of the strong::01 Why SuperCollider:: document (by James McCartney) from the SuperCollider 2 distribution.
+For context, here, below, is the complete text of the strong::01 Why SuperCollider:: document (by James McCartney) from the SuperCollider 2 distribution.
 
 section::Why SuperCollider 2.0 ?
 


### PR DESCRIPTION
…with standard white spaces

<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation
I Found some ghost characters and non-standard white spaces in schelp files.
I removed ghost characters and replaced non-standard white spaces with regular white spaces.

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->

- Documentation

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
