### PR TITLE
various Server plugin changes/fixes

### DIFF
--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -1,8 +1,3 @@
-if (NOT APPLE AND NOT WIN32)
-	# on apple we leave this undefined so it defaults to .scx (in the code)
-	add_definitions("-DSC_PLUGIN_EXT=\".so\"")
-endif()
-
 if(UNIX AND NOT APPLE)
 	set(LIB_SUFFIX "" CACHE STRING "Install plugins to suffixed lib directory: eg. `64` for `lib64`")
 	set(LINUX_SC_PLUGIN_DIR ${CMAKE_INSTALL_PREFIX}/lib${LIB_SUFFIX}/SuperCollider/plugins)

--- a/server/plugins/CMakeLists.txt
+++ b/server/plugins/CMakeLists.txt
@@ -53,9 +53,7 @@ set(plugins "")
 set(supernova_plugins "")
 
 set(CMAKE_SHARED_MODULE_PREFIX "")
-if(APPLE OR WIN32)
-	set(CMAKE_SHARED_MODULE_SUFFIX ".scx")
-endif()
+set(CMAKE_SHARED_MODULE_SUFFIX ".scx")
 
 foreach(plugin ${plugin_sources})
 	string(REPLACE .cpp "" plugin_name ${plugin} )

--- a/server/scsynth/SC_Lib_Cintf.cpp
+++ b/server/scsynth/SC_Lib_Cintf.cpp
@@ -77,7 +77,11 @@ SC_LibCmd* gCmdArray[NUMBER_OF_COMMANDS];
 #endif
 
 void initMiscCommands();
-static bool PlugIn_LoadDir(const fs::path& dir, bool reportError, bool didFindPlugin = false);
+#ifdef LINUX_PLUGIN_WORKAROUND
+static bool PlugIn_LoadDir(const fs::path& dir, bool reportError, bool foundScxFile = false);
+#else
+static bool PlugIn_LoadDir(const fs::path& dir, bool reportError);
+#endif
 std::vector<void*> open_handles;
 #ifdef __APPLE__
 void read_section(const struct mach_header* mhp, unsigned long slide, const char* segname, const char* sectname) {
@@ -390,7 +394,13 @@ static bool PlugIn_Load(const fs::path& filename) {
 #endif // _WIN32
 }
 
-static bool PlugIn_LoadDir(const fs::path& dir, bool reportError, bool didFindPlugin) {
+#ifndef LINUX_PLUGIN_WORKAROUND
+static bool PlugIn_LoadDir(const fs::path& dir, bool reportError) {
+#else
+// if 'foundScxFile' is true, it means that we have alredy found a .scx file in one of the parent
+// directories. In this case, we treat all .so files as shared libraries and ignore them.
+static bool PlugIn_LoadDir(const fs::path& dir, bool reportError, bool foundScxFile) {
+#endif
     std::error_code ec;
     fs::directory_iterator iter(dir, fs::directory_options::follow_directory_symlink, ec);
     fs::directory_iterator end;
@@ -435,7 +445,7 @@ static bool PlugIn_LoadDir(const fs::path& dir, bool reportError, bool didFindPl
 
         if (fs::is_regular_file(iter->status()) && path.extension() == SC_PLUGIN_EXT) {
             PlugIn_Load(path);
-            didFindPlugin = true;
+            foundScxFile = true;
         }
 
         iter.increment(ec);
@@ -455,8 +465,8 @@ static bool PlugIn_LoadDir(const fs::path& dir, bool reportError, bool didFindPl
             const fs::path& path = entry.path();
 
             if (fs::is_directory(path)) {
-                PlugIn_LoadDir(path, reportError, didFindPlugin);
-            } else if (!didFindPlugin && path.extension() == ".so") {
+                PlugIn_LoadDir(path, reportError, foundScxFile);
+            } else if (!foundScxFile && path.extension() == ".so") {
                 // No .scx plugins were found in this directory or any parent directory -> assume the .so file is a
                 // plugin.
                 if (PlugIn_Load(path)) {

--- a/server/scsynth/SC_Lib_Cintf.cpp
+++ b/server/scsynth/SC_Lib_Cintf.cpp
@@ -66,8 +66,18 @@ HashTable<struct PlugInCmd, Malloc>* gPlugInCmds = nullptr;
 extern struct InterfaceTable gInterfaceTable;
 SC_LibCmd* gCmdArray[NUMBER_OF_COMMANDS];
 
+// The generic .so extension has been deprecated in SC 3.15 so developers can ship shared libraries
+// along their plugins. We do the following to provide a smooth upgrade path:
+// If there has been a plugin with the SC_PLUGIN_EXT extension in the same folder or one of its
+// parent folders we simply ignore the .so file because we can assume it is a dependency.
+// Otherwise we load the .so file and post a warning.
+// NOTE: we should remove this workaround in the future!
+#ifdef __linux__
+#    define LINUX_PLUGIN_WORKAROUND
+#endif
+
 void initMiscCommands();
-static bool PlugIn_LoadDir(const fs::path& dir, bool reportError);
+static bool PlugIn_LoadDir(const fs::path& dir, bool reportError, bool didFindPlugin = false);
 std::vector<void*> open_handles;
 #ifdef __APPLE__
 void read_section(const struct mach_header* mhp, unsigned long slide, const char* segname, const char* sectname) {
@@ -380,9 +390,10 @@ static bool PlugIn_Load(const fs::path& filename) {
 #endif // _WIN32
 }
 
-static bool PlugIn_LoadDir(const fs::path& dir, bool reportError) {
+static bool PlugIn_LoadDir(const fs::path& dir, bool reportError, bool didFindPlugin) {
     std::error_code ec;
-    fs::recursive_directory_iterator rditer(dir, fs::directory_options::follow_directory_symlink, ec);
+    fs::directory_iterator iter(dir, fs::directory_options::follow_directory_symlink, ec);
+    fs::directory_iterator end;
 
     if (ec) {
         if (reportError) {
@@ -393,30 +404,75 @@ static bool PlugIn_LoadDir(const fs::path& dir, bool reportError) {
         return false;
     }
 
-    while (rditer != fs::end(rditer)) {
-        const fs::path path = *rditer;
+    if (SC_Filesystem::instance().shouldNotCompileDirectory(dir)) {
+        return true;
+    }
 
-        if (fs::is_directory(path)) {
-            if (SC_Filesystem::instance().shouldNotCompileDirectory(path))
-                rditer.disable_recursion_pending();
-            else
-                ; // do nothing; recursion for free
+#ifndef LINUX_PLUGIN_WORKAROUND
+    while (iter != end) {
+        const fs::path path = *iter;
+
+        if (fs::is_directory(iter->status())) {
+            PlugIn_LoadDir(path, reportError);
         } else if (path.extension() == SC_PLUGIN_EXT) {
             // don't need to check result: PlugIn_Load does its own error handling and printing.
             // A `false` return value here just means that loading didn't occur, which is not
             // an error condition for us.
             PlugIn_Load(path);
-        } else {
-            // not a plugin, do nothing
         }
 
-        rditer.increment(ec);
+        iter.increment(ec);
         if (ec) {
             scprintf("*** ERROR: Could not iterate on directory '%s': %s\n", SC_Codecvt::path_to_utf8_str(path).c_str(),
                      ec.message().c_str());
             return false;
         }
     }
+#else
+    // first only iterate over .scx files
+    while (iter != end) {
+        const fs::path path = *iter; // copy!
+
+        if (fs::is_regular_file(iter->status()) && path.extension() == SC_PLUGIN_EXT) {
+            PlugIn_Load(path);
+            didFindPlugin = true;
+        }
+
+        iter.increment(ec);
+        if (ec) {
+            scprintf("*** ERROR: Could not iterate on directory '%s': %s\n", SC_Codecvt::path_to_utf8_str(path).c_str(),
+                     ec.message().c_str());
+            return false;
+        }
+    }
+
+    // then iterate over subdirectories and .so files. Since we have already iterated over all files,
+    // we don't necessarily have to check for errors again.
+    try {
+        fs::directory_iterator iter(dir, fs::directory_options::follow_directory_symlink);
+
+        for (const auto& entry : iter) {
+            const fs::path& path = entry.path();
+
+            if (fs::is_directory(path)) {
+                PlugIn_LoadDir(path, reportError, didFindPlugin);
+            } else if (!didFindPlugin && path.extension() == ".so") {
+                // No .scx plugins were found in this directory or any parent directory -> assume the .so file is a plugin.
+                if (PlugIn_Load(path)) {
+                    scprintf("*** WARNING: '%s': the .so extension has been deprecated!\n", SC_Codecvt::path_to_utf8_str(path).c_str());
+
+                    static bool didWarn = false;
+                    if (!didWarn) {
+                        scprintf("*** Please try to upgrade any SC extension where the UGen plugin still has the .so extension. "
+                                 "If you already have the latest version, please ask the developer to update the extension. "
+                                 "To suppress this warning in the meantime, you can manually change the extension to .scx.\n");
+                        didWarn = true;
+                    }
+                }
+            }
+        }
+    } catch (...) {}
+#endif
 
     return true;
 }

--- a/server/scsynth/SC_Lib_Cintf.cpp
+++ b/server/scsynth/SC_Lib_Cintf.cpp
@@ -349,7 +349,6 @@ static bool PlugIn_Load(const fs::path& filename) {
 
     if (!handle) {
         scprintf("*** ERROR: dlopen '%s' err '%s'\n", filename.c_str(), dlerror());
-        dlclose(handle);
         return false;
     }
 

--- a/server/scsynth/SC_Lib_Cintf.cpp
+++ b/server/scsynth/SC_Lib_Cintf.cpp
@@ -37,6 +37,7 @@
 #endif // _MSC_VER
 
 #ifdef _WIN32
+#    include <windows.h>
 #    include "SC_Win32Utils.h"
 #    include "SC_Codecvt.hpp"
 #else
@@ -294,12 +295,16 @@ bool checkServerVersion(void* f, const char* filename) {
 
 static bool PlugIn_Load(const fs::path& filename) {
 #ifdef _WIN32
-    HINSTANCE hinstance = LoadLibraryW(filename.wstring().c_str());
+    // This allows plugins to place DLL dependencies in the same directory.
+    SetDllDirectoryW(filename.parent_path().c_str());
+    HINSTANCE hinstance = LoadLibraryW(filename.c_str());
+    // Reset DLL directory
+    SetDllDirectoryW(nullptr);
     // here, we have to use a utf-8 version of the string for printing
     // because the native encoding on Windows is utf-16.
     const std::string filename_utf8_str = SC_Codecvt::path_to_utf8_str(filename);
     if (!hinstance) {
-        wchar_t* s;
+        wchar_t* s = nullptr;
         DWORD lastErr = GetLastError();
         FormatMessageW(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
                        NULL, lastErr, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (wchar_t*)&s, 0, NULL);

--- a/server/scsynth/SC_Lib_Cintf.cpp
+++ b/server/scsynth/SC_Lib_Cintf.cpp
@@ -457,15 +457,18 @@ static bool PlugIn_LoadDir(const fs::path& dir, bool reportError, bool didFindPl
             if (fs::is_directory(path)) {
                 PlugIn_LoadDir(path, reportError, didFindPlugin);
             } else if (!didFindPlugin && path.extension() == ".so") {
-                // No .scx plugins were found in this directory or any parent directory -> assume the .so file is a plugin.
+                // No .scx plugins were found in this directory or any parent directory -> assume the .so file is a
+                // plugin.
                 if (PlugIn_Load(path)) {
-                    scprintf("*** WARNING: '%s': the .so extension has been deprecated!\n", SC_Codecvt::path_to_utf8_str(path).c_str());
+                    scprintf("*** WARNING: '%s': the .so extension has been deprecated!\n",
+                             SC_Codecvt::path_to_utf8_str(path).c_str());
 
                     static bool didWarn = false;
                     if (!didWarn) {
-                        scprintf("*** Please try to upgrade any SC extension where the UGen plugin still has the .so extension. "
-                                 "If you already have the latest version, please ask the developer to update the extension. "
-                                 "To suppress this warning in the meantime, you can manually change the extension to .scx.\n");
+                        scprintf("*** Please try to upgrade any SC extension where the UGen plugin still has the .so "
+                                 "extension. If you already have the latest version, please ask the developer to "
+                                 "update the extension. To suppress this warning in the meantime, you can manually "
+                                 "change the extension to .scx.\n");
                         didWarn = true;
                     }
                 }

--- a/server/scsynth/SC_World.cpp
+++ b/server/scsynth/SC_World.cpp
@@ -927,9 +927,6 @@ void World_Cleanup(World* world, bool unload_plugins) {
         scsynth::stopAsioThread();
     }
 
-    if (unload_plugins)
-        deinitialize_library();
-
     HiddenWorld* hw = world->hw;
 
     if (hw && world->mRealTime)
@@ -939,6 +936,11 @@ void World_Cleanup(World* world, bool unload_plugins) {
 
     if (world->mTopGroup)
         Group_DeleteAll(world->mTopGroup);
+
+    // NOTE: only unload plugins after all Nodes have been destroyed,
+    // but before the World is cleaned up!
+    if (unload_plugins)
+        deinitialize_library();
 
     reinterpret_cast<SC_Lock*>(world->mDriverLock)->lock();
     if (hw) {

--- a/server/supernova/sc/sc_ugen_factory.cpp
+++ b/server/supernova/sc/sc_ugen_factory.cpp
@@ -317,8 +317,13 @@ void sc_ugen_factory::load_plugin(std::filesystem::path const& path) {
         return;
     }
 
+    // This allows plugins to place DLL dependencies in the same directory.
+    SetDllDirectoryW(path.parent_path().c_str());
     // std::cout << "try open plugin: " << path << std::endl;
     HINSTANCE hinstance = LoadLibraryW(path.wstring().c_str());
+    // Reset DLL directory
+    SetDllDirectoryW(nullptr);
+
     if (!hinstance) {
         wchar_t* s;
         DWORD lastErr = GetLastError();

--- a/server/supernova/sc/sc_ugen_factory.cpp
+++ b/server/supernova/sc/sc_ugen_factory.cpp
@@ -224,7 +224,12 @@ void sc_ugen_factory::load_plugin_folder(std::filesystem::path const& path) {
     if (!is_directory(path))
         return;
 
-    for (directory_iterator it(path); it != end; ++it) {
+    if (SC_Filesystem::instance().shouldNotCompileDirectory(path)) {
+        return;
+    }
+
+    auto options = std::filesystem::directory_options::follow_directory_symlink;
+    for (directory_iterator it(path, options); it != end; ++it) {
         if (is_regular_file(it->status()))
             load_plugin(it->path());
         if (is_directory(it->status()))

--- a/server/supernova/sc/sc_ugen_factory.cpp
+++ b/server/supernova/sc/sc_ugen_factory.cpp
@@ -318,7 +318,6 @@ void sc_ugen_factory::load_plugin(std::filesystem::path const& path) {
     }
 
     // std::cout << "try open plugin: " << path << std::endl;
-    const char* filename = path.string().c_str();
     HINSTANCE hinstance = LoadLibraryW(path.wstring().c_str());
     if (!hinstance) {
         wchar_t* s;
@@ -334,7 +333,7 @@ void sc_ugen_factory::load_plugin(std::filesystem::path const& path) {
     typedef int (*info_function)();
     info_function api_version = reinterpret_cast<info_function>(GetProcAddress(hinstance, "api_version"));
 
-    if (!check_api_version(api_version, filename)) {
+    if (!check_api_version(api_version, path.string())) {
         FreeLibrary(hinstance);
         return;
     }
@@ -357,7 +356,7 @@ void sc_ugen_factory::load_plugin(std::filesystem::path const& path) {
         FormatMessageW(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
                        nullptr, GetLastError(), MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (wchar_t*)&s, 0, NULL);
 
-        std::cout << "*** ERROR: GetProcAddress err " << SC_Codecvt::utf16_wcstr_to_utf8_string(s).c_str() << std::endl;
+        std::cout << "*** ERROR: GetProcAddress err " << SC_Codecvt::utf16_wcstr_to_utf8_string(s) << std::endl;
         LocalFree(s);
 
         FreeLibrary(hinstance);

--- a/server/supernova/sc/sc_ugen_factory.cpp
+++ b/server/supernova/sc/sc_ugen_factory.cpp
@@ -255,7 +255,9 @@ void sc_ugen_factory::load_plugin_folder(std::filesystem::path const& dir) {
 }
 
 #ifdef LINUX_PLUGIN_WORKAROUND
-void sc_ugen_factory::load_plugin_folder(std::filesystem::path const& dir, bool did_find_plugin) {
+// if 'found_scx_file' is true, it means that we have alredy found a .scx file in one of the parent
+// directories. In this case, we treat all .so files as shared libraries and ignore them.
+void sc_ugen_factory::load_plugin_folder(std::filesystem::path const& dir, bool found_scx_file) {
     namespace fs = std::filesystem;
 
     fs::directory_iterator end;
@@ -273,15 +275,15 @@ void sc_ugen_factory::load_plugin_folder(std::filesystem::path const& dir, bool 
     for (const auto& entry : fs::directory_iterator(dir, options)) {
         if (fs::is_regular_file(entry.status()) && entry.path().extension() == SC_PLUGIN_EXT) {
             load_plugin(entry.path());
-            did_find_plugin = true;
+            found_scx_file = true;
         }
     }
 
     // then iterate over subdirectories and .so files
     for (const auto& entry : fs::directory_iterator(dir, options)) {
         if (fs::is_directory(entry.path())) {
-            load_plugin_folder(entry.path(), did_find_plugin);
-        } else if (!did_find_plugin && entry.path().extension() == ".so") {
+            load_plugin_folder(entry.path(), found_scx_file);
+        } else if (!found_scx_file && entry.path().extension() == ".so") {
             // No .scx plugins were found in this directory or any parent directory -> assume the .so file is a plugin.
             load_plugin(entry.path());
             std::cout << "*** WARNING: '" << SC_Codecvt::path_to_utf8_str(entry.path()).c_str()

--- a/server/supernova/sc/sc_ugen_factory.cpp
+++ b/server/supernova/sc/sc_ugen_factory.cpp
@@ -289,10 +289,10 @@ void sc_ugen_factory::load_plugin_folder(std::filesystem::path const& dir, bool 
 
             static bool didWarn = false;
             if (!didWarn) {
-                std::cout << "*** Please try to upgrade any SC extension where the UGen plugin still has the .so extension. "
-                          << "If you already have the latest version, please ask the developer to update the extension. "
-                          << "To suppress this warning in the meantime, you can manually change the extension to .scx."
-                          << std::endl;
+                std::cout << "*** Please try to upgrade any SC extension where the UGen plugin still has the .so "
+                          << "extension. If you already have the latest version, please ask the developer to update "
+                          << "the extension. To suppress this warning in the meantime, you can manually change the "
+                          << "extension to .scx." << std::endl;
                 didWarn = true;
             }
         }

--- a/server/supernova/sc/sc_ugen_factory.cpp
+++ b/server/supernova/sc/sc_ugen_factory.cpp
@@ -35,6 +35,16 @@
 #include "ErrorMessage.hpp"
 #include "SC_Filesystem.hpp" // SC_PLUGIN_EXT
 
+// The generic .so extension has been deprecated in SC 3.15 so developers can ship shared libraries
+// along their plugins. We do the following to provide a smooth upgrade path:
+// If there has been a plugin with the SC_PLUGIN_EXT extension in the same folder or one of its
+// parent folders we simply ignore the .so file because we can assume it is a dependency.
+// Otherwise we load the .so file and post a warning.
+// NOTE: we should remove this workaround in the future!
+#ifdef __linux__
+#    define LINUX_PLUGIN_WORKAROUND
+#endif
+
 namespace nova {
 
 std::unique_ptr<sc_ugen_factory> sc_factory;
@@ -215,27 +225,80 @@ bool sc_plugin_container::run_cmd_plugin(World* world, const char* name, struct 
     return true;
 }
 
+void sc_ugen_factory::load_plugin_folder(std::filesystem::path const& dir) {
+#ifdef LINUX_PLUGIN_WORKAROUND
+    load_plugin_folder(dir, false);
+#else
+    namespace fs = std::filesystem;
 
-void sc_ugen_factory::load_plugin_folder(std::filesystem::path const& path) {
-    using namespace std::filesystem;
+    fs::directory_iterator end;
 
-    directory_iterator end;
-
-    if (!is_directory(path))
+    if (!fs::is_directory(dir))
         return;
 
-    if (SC_Filesystem::instance().shouldNotCompileDirectory(path)) {
+    if (SC_Filesystem::instance().shouldNotCompileDirectory(dir)) {
         return;
     }
 
-    auto options = std::filesystem::directory_options::follow_directory_symlink;
-    for (directory_iterator it(path, options); it != end; ++it) {
-        if (is_regular_file(it->status()))
-            load_plugin(it->path());
-        if (is_directory(it->status()))
-            load_plugin_folder(it->path());
+    fs::directory_iterator iter(dir, fs::directory_options::follow_directory_symlink);
+    for (const auto& entry : iter) {
+        if (fs::is_regular_file(entry.status())) {
+            // Ignore files that don't have the extension of an SC plugin
+            if (entry.path().extension() == SC_PLUGIN_EXT) {
+                load_plugin(entry.path());
+            }
+        } else if (fs::is_directory(entry.status())) {
+            load_plugin_folder(entry.path());
+        }
+    }
+#endif
+}
+
+#ifdef LINUX_PLUGIN_WORKAROUND
+void sc_ugen_factory::load_plugin_folder(std::filesystem::path const& dir, bool did_find_plugin) {
+    namespace fs = std::filesystem;
+
+    fs::directory_iterator end;
+
+    if (!is_directory(dir))
+        return;
+
+    if (SC_Filesystem::instance().shouldNotCompileDirectory(dir)) {
+        return;
+    }
+
+    auto options = fs::directory_options::follow_directory_symlink;
+
+    // first only iterate over .scx files
+    for (const auto& entry : fs::directory_iterator(dir, options)) {
+        if (fs::is_regular_file(entry.status()) && entry.path().extension() == SC_PLUGIN_EXT) {
+            load_plugin(entry.path());
+            did_find_plugin = true;
+        }
+    }
+
+    // then iterate over subdirectories and .so files
+    for (const auto& entry : fs::directory_iterator(dir, options)) {
+        if (fs::is_directory(entry.path())) {
+            load_plugin_folder(entry.path(), did_find_plugin);
+        } else if (!did_find_plugin && entry.path().extension() == ".so") {
+            // No .scx plugins were found in this directory or any parent directory -> assume the .so file is a plugin.
+            load_plugin(entry.path());
+            std::cout << "*** WARNING: '" << SC_Codecvt::path_to_utf8_str(entry.path()).c_str()
+                      << "': the .so extension has been deprecated!" << std::endl;
+
+            static bool didWarn = false;
+            if (!didWarn) {
+                std::cout << "*** Please try to upgrade any SC extension where the UGen plugin still has the .so extension. "
+                          << "If you already have the latest version, please ask the developer to update the extension. "
+                          << "To suppress this warning in the meantime, you can manually change the extension to .scx."
+                          << std::endl;
+                didWarn = true;
+            }
+        }
     }
 }
+#endif // LINUX_PLUGIN_WORKAROUND
 
 static bool check_api_version(int (*api_version)(), std::string const& filename) {
     using namespace std;
@@ -256,13 +319,6 @@ static bool check_api_version(int (*api_version)(), std::string const& filename)
 
 #ifdef DLOPEN
 void sc_ugen_factory::load_plugin(std::filesystem::path const& path) {
-    using namespace std;
-
-    // Ignore files that don't have the extension of an SC plugin
-    if (path.extension() != SC_PLUGIN_EXT) {
-        return;
-    }
-
     void* handle = dlopen(path.string().c_str(), RTLD_NOW | RTLD_LOCAL);
     if (handle == nullptr)
         return;
@@ -285,7 +341,7 @@ void sc_ugen_factory::load_plugin(std::filesystem::path const& path) {
 
     void* load_symbol = dlsym(handle, "load");
     if (!load_symbol) {
-        cout << "Problem when loading plugin: \"load\" function undefined" << path << endl;
+        std::cout << "Problem when loading plugin: \"load\" function undefined" << path << std::endl;
         dlclose(handle);
         return;
     }
@@ -312,11 +368,6 @@ void sc_ugen_factory::close_handles(void) {
 #elif defined(_WIN32)
 
 void sc_ugen_factory::load_plugin(std::filesystem::path const& path) {
-    // Ignore files that don't have the extension of an SC plugin
-    if (path.extension() != SC_PLUGIN_EXT) {
-        return;
-    }
-
     // This allows plugins to place DLL dependencies in the same directory.
     SetDllDirectoryW(path.parent_path().c_str());
     // std::cout << "try open plugin: " << path << std::endl;

--- a/server/supernova/sc/sc_ugen_factory.hpp
+++ b/server/supernova/sc/sc_ugen_factory.hpp
@@ -177,10 +177,12 @@ public:
     uint32_t ugen_count(void) const { return ugen_count_; }
     /* @} */
 
-    void load_plugin_folder(std::filesystem::path const& path);
+    void load_plugin_folder(std::filesystem::path const& dir);
     void load_plugin(std::filesystem::path const& path);
 
 private:
+    void load_plugin_folder(std::filesystem::path const& dir, bool did_find_plugin);
+
     void close_handles(void);
 
     uint32_t ugen_count_ = 0;

--- a/server/supernova/sc/sc_ugen_factory.hpp
+++ b/server/supernova/sc/sc_ugen_factory.hpp
@@ -181,7 +181,7 @@ public:
     void load_plugin(std::filesystem::path const& path);
 
 private:
-    void load_plugin_folder(std::filesystem::path const& dir, bool did_find_plugin);
+    void load_plugin_folder(std::filesystem::path const& dir, bool found_scx_file);
 
     void close_handles(void);
 

--- a/server/supernova/server/server.cpp
+++ b/server/supernova/server/server.cpp
@@ -102,7 +102,6 @@ void nova_server::prepare_backend(void) {
 
 nova_server::~nova_server(void) {
     // we should delete but get chrashes at the moment on linux and macosx
-    // delete sc_factory;
 #if defined(JACK_BACKEND) || defined(PORTAUDIO_BACKEND)
     deactivate_audio();
 #endif
@@ -112,6 +111,8 @@ nova_server::~nova_server(void) {
     scheduler<thread_init_functor>::terminate();
     io_interpreter.join_thread();
 
+    // NOTE: this will also unload all plugins. Make sure to do this
+    // after we have destroyed all Nodes!
     sc_factory.reset();
     instance = nullptr;
 }

--- a/testsuite/server/plugins/CMakeLists.txt
+++ b/testsuite/server/plugins/CMakeLists.txt
@@ -4,9 +4,7 @@ set(plugin_tests
 )
 
 set(CMAKE_SHARED_MODULE_PREFIX "")
-if (APPLE OR WIN32)
-    set(CMAKE_SHARED_MODULE_SUFFIX ".scx")
-endif()
+set(CMAKE_SHARED_MODULE_SUFFIX ".scx")
 
 # let plugins find their dependencies in the same folder
 set(CMAKE_INSTALL_RPATH $ORIGIN)

--- a/testsuite/server/plugins/CMakeLists.txt
+++ b/testsuite/server/plugins/CMakeLists.txt
@@ -9,7 +9,7 @@ if (APPLE OR WIN32)
 endif()
 
 # let plugins find their dependencies in the same folder
-set(CMAKE_BUILD_RPATH_USE_ORIGIN ON)
+set(CMAKE_INSTALL_RPATH $ORIGIN)
 
 foreach(test_file ${plugin_tests})
     get_filename_component(test_name ${test_file} NAME_WE)
@@ -35,5 +35,9 @@ endforeach()
 
 # DLL for shared_lib_test(_supernova)
 add_library(testlib SHARED testlib.cpp)
+# export symbols!
+set_target_properties(testlib PROPERTIES
+  CXX_VISIBILITY_PRESET default
+)
 target_link_libraries(shared_lib_test PRIVATE testlib)
 target_link_libraries(shared_lib_test_supernova PRIVATE testlib)

--- a/testsuite/server/plugins/CMakeLists.txt
+++ b/testsuite/server/plugins/CMakeLists.txt
@@ -1,8 +1,39 @@
-
-add_library(c_api_test MODULE c_api_test.c)
-
-target_include_directories(
-    c_api_test
-    PRIVATE ${CMAKE_SOURCE_DIR}/include/common
-    PRIVATE ${CMAKE_SOURCE_DIR}/include/plugin_interface
+set(plugin_tests
+    c_api_test.c
+    shared_lib_test.cpp
 )
+
+set(CMAKE_SHARED_MODULE_PREFIX "")
+if (APPLE OR WIN32)
+    set(CMAKE_SHARED_MODULE_SUFFIX ".scx")
+endif()
+
+# let plugins find their dependencies in the same folder
+set(CMAKE_BUILD_RPATH_USE_ORIGIN ON)
+
+foreach(test_file ${plugin_tests})
+    get_filename_component(test_name ${test_file} NAME_WE)
+
+    add_library(${test_name} MODULE ${test_file})
+    target_include_directories(
+        ${test_name} PRIVATE
+        ${CMAKE_SOURCE_DIR}/include/common
+        ${CMAKE_SOURCE_DIR}/include/plugin_interface
+    )
+
+    # C plugins cannot be built for Supernova (yet)
+    if (NOT ${test_name} STREQUAL c_api_test)
+        add_library(${test_name}_supernova MODULE ${test_file})
+        target_compile_definitions(${test_name}_supernova PRIVATE SUPERNOVA)
+        target_include_directories(
+            ${test_name}_supernova PRIVATE
+            ${CMAKE_SOURCE_DIR}/include/common
+            ${CMAKE_SOURCE_DIR}/include/plugin_interface
+        )
+    endif()
+endforeach()
+
+# DLL for shared_lib_test(_supernova)
+add_library(testlib SHARED testlib.cpp)
+target_link_libraries(shared_lib_test PRIVATE testlib)
+target_link_libraries(shared_lib_test_supernova PRIVATE testlib)

--- a/testsuite/server/plugins/shared_lib_test.cpp
+++ b/testsuite/server/plugins/shared_lib_test.cpp
@@ -6,7 +6,7 @@ static InterfaceTable* ft;
 #ifdef _WIN32
 __declspec(dllimport)
 #endif
-void printGreeting(const char* who);
+    void printGreeting(const char* who);
 
 PluginLoad(ML_UGens) {
     ft = inTable;

--- a/testsuite/server/plugins/shared_lib_test.cpp
+++ b/testsuite/server/plugins/shared_lib_test.cpp
@@ -1,0 +1,19 @@
+#include "SC_PlugIn.h"
+
+static InterfaceTable* ft;
+
+// this function is defined in the accompanying shared library
+#ifdef _WIN32
+__declspec(dllimport)
+#endif
+void printGreeting(const char* who);
+
+PluginLoad(ML_UGens) {
+    ft = inTable;
+
+#ifdef SUPERNOVA
+    printGreeting("Supernova");
+#else
+    printGreeting("scsynth");
+#endif
+}

--- a/testsuite/server/plugins/testlib.cpp
+++ b/testsuite/server/plugins/testlib.cpp
@@ -3,6 +3,6 @@
 #ifdef _WIN32
 __declspec(dllexport)
 #endif
-void printGreeting(const char* who) {
+    void printGreeting(const char* who) {
     std::cout << "Hello " << who << "!" << std::endl;
 }

--- a/testsuite/server/plugins/testlib.cpp
+++ b/testsuite/server/plugins/testlib.cpp
@@ -1,0 +1,8 @@
+#include <iostream>
+
+#ifdef _WIN32
+__declspec(dllexport)
+#endif
+void printGreeting(const char* who) {
+    std::cout << "Hello " << who << "!" << std::endl;
+}


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

This PR fixes several issues regarding Server plugins. The motivation is to ensure a uniform behavior across platforms. Most importantly:
1. use the same plugin extension (`.scx`) on all platforms
2. allow to ship shared library dependencies (`.dll`, `.dylib`, `.so`) together with the plugin

I have added a simple test plugin in `testsuite/server/plugins` that implements a function in a shared library. I can now successfully load this plugin on all three platforms!

## Changes

- Linux: change the plugin extension from `.so` to `.scx`. This means people can finally ship shared library dependencies together with their UGen plugins, without having to put them in special folders. **This is a breaking change!** However, I have provided the following upgrade path:
    
    If a `.so` file is in the same directory as a `.scx` file, or in any subdirectory, we assume it is a dependency of the `.scx` file and therefore ignore it. Otherwise we try to open the `.so` file as a plugin and post a warning to the console. We also post a (one-time) message that tells the user what they can do to avoid the warning.
    
    We can remove this workaround in SC 3.16 or SC 3.17
    
- Windows: call `SetDllDirectory` with the current plugin directory so that plugins can find DLLs in the same directory

- Linux/scsynth: fix segfault when `dlopen` fails.

- scsynth: only unload plugins after all Nodes have been destroyed.

- Supernova: follow symlinks when loading plugins and ignore special folders to ensure the same behavior as scsynth.

Closes #6040 and #7342.

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix
- Breaking change

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [ ] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
