### PR TITLE
scide: make urls clickable in the post window

### DIFF
--- a/HelpSource/Classes/PostWindowURLHandler.schelp
+++ b/HelpSource/Classes/PostWindowURLHandler.schelp
@@ -1,0 +1,42 @@
+CLASS::PostWindowURLHandler
+summary::Used to respond when clicking links in the post window.
+related::Classes/ScIDE, Classes/Document
+categories:: Frontends, IDE
+
+DESCRIPTION::
+Used to respond to specific URLs when clicking links in the post window.
+For example, when clicking on a code::file://:: link, by default this will open the file.
+
+
+Here is an example of how this class can be used.
+
+When the user clicks on a URL in the post window with the scheme code::scdoc::, open the help file in the IDE help browser.
+code::
+PostWindowURLHandler.register(\scdoc, {|url|
+	var prefix = "scdoc://";
+	ScIDE.openHelpUrl("file://" ++ SCDoc.helpTargetDir +/+ url[prefix.size..])
+});
+::
+
+CLASSMETHODS::
+PRIVATE:: prDefault
+
+method:: register
+
+argument:: name 
+
+A link::Classes/Symbol:: representing the scheme of the URI. 
+For example, if the URL is code::bang://hello:: then the code::name:: should be code::\bang::.
+
+argument:: fn
+A link::Classes/Function:: accepting one argument, which is the full url as a link::Classes/String::.
+
+method:: new
+
+Used to trigger any registered action for the scheme if present, otherwise calls a default action, which posts a warning.
+This is no usually called by the user, but by the IDE backend.
+argument:: scheme
+The scheme of the URI.
+
+argument:: url
+The full url, including the scheme.

--- a/SCClassLibrary/scide_scqt/ScIDE.sc
+++ b/SCClassLibrary/scide_scqt/ScIDE.sc
@@ -15,11 +15,13 @@ ScIDE {
 		Class.initClassTree(PostWindowURLHandler);
 
 		PostWindowURLHandler.register(\scdoc, {|url|
-			ScIDE.openHelpUrl("file://" ++ SCDoc.helpTargetDir +/+ url[8..])
+			var prefix = "scdoc://";
+			ScIDE.openHelpUrl("file://" ++ SCDoc.helpTargetDir +/+ url[prefix.size..])
 		});
 
 		PostWindowURLHandler.register(\file, {|url|
-			var parts = url[7..].split($:);
+			var prefix = "file://";
+			var parts = url[prefix.size..].split($:);
 			{ Document.open("/" ++ parts[0], parts[1] ?? { 0 }, parts[2] ?? [0]) }.fork(AppClock)
 		});
 
@@ -457,7 +459,7 @@ PostWindowURLHandler {
 	}
 
 	*prDefault { |url|
-		"PostWindowURLHandler does not know how to handle the URL '%'".format(url).postln
+		" PostWindowURLHandler does not know how to handle the URL '%'".format(url).warn.postln
 	}
 }
 

--- a/SCClassLibrary/scide_scqt/ScIDE.sc
+++ b/SCClassLibrary/scide_scqt/ScIDE.sc
@@ -11,6 +11,17 @@ ScIDE {
 		subListSorter = { | a b | a[0].perform('<', b[0]) };
 
 		Class.initClassTree(Server);
+		Class.initClassTree(SCDoc);
+		Class.initClassTree(PostWindowURLHandler);
+
+		PostWindowURLHandler.register(\scdoc, {|url|
+			ScIDE.openHelpUrl("file://" ++ SCDoc.helpTargetDir +/+ url[8..])
+		});
+
+		PostWindowURLHandler.register(\file, {|url|
+			var parts = url[7..].split($:);
+			{ Document.open("/" ++ parts[0], parts[1] ?? { 0 }, parts[2] ?? [0]) }.fork(AppClock)
+		});
 
 		StartUp.add {
 			if (this.connected) {
@@ -423,6 +434,30 @@ ScIDE {
 	*prConnect {|ideName|
 		_ScIDE_Connect
 		this.primitiveFailed
+	}
+}
+
+PostWindowURLHandler {
+	classvar registered;
+
+	*initClass {
+		Class.initClassTree(IdentityDictionary);
+		registered = IdentityDictionary();
+	}
+
+	*register { |name, fn| registered[name] = fn }
+	
+	*new { |scheme, url|
+		var found = registered[scheme.asSymbol];
+		^if(found.isNil){
+			this.prDefault(url)
+		} {
+			found.(url)
+		}
+	}
+
+	*prDefault { |url|
+		"PostWindowURLHandler does not know how to handle the URL '%'".format(url).postln
 	}
 }
 

--- a/SCClassLibrary/scide_scqt/ScIDE.sc
+++ b/SCClassLibrary/scide_scqt/ScIDE.sc
@@ -459,7 +459,7 @@ PostWindowURLHandler {
 	}
 
 	*prDefault { |url|
-		" PostWindowURLHandler does not know how to handle the URL '%'".format(url).warn.postln
+		"PostWindowURLHandler does not know how to handle the URL '%'".format(url).warn
 	}
 }
 

--- a/editors/sc-ide/widgets/main_window.cpp
+++ b/editors/sc-ide/widgets/main_window.cpp
@@ -166,6 +166,8 @@ MainWindow::MainWindow(Main* main): mMain(main), mClockLabel(0), mDocDialog(0) {
     connect(this, &MainWindow::evaluateCode, main->scProcess(), &ScProcess::evaluateCode);
     // Interpreter: post output
     connect(main->scProcess(), &ScProcess::scPost, mPostDocklet->mPostWindow, &PostWindow::post);
+
+    connect(mPostDocklet->mPostWindow, &PostWindow::handleClickedURL, main->scProcess(), &ScProcess::evaluateCode);
     // Interpreter: monitor running state
     connect(main->scProcess(), &ScProcess::stateChanged, this, &MainWindow::onInterpreterStateChanged);
     // Interpreter: forward status messages

--- a/editors/sc-ide/widgets/post_window.cpp
+++ b/editors/sc-ide/widgets/post_window.cpp
@@ -351,6 +351,22 @@ void PostWindow::wheelEvent(QWheelEvent* e) {
 #endif
 }
 
+void PostWindow::mousePressEvent(QMouseEvent* e) {
+    clickedAnchor = (e->button() & Qt::LeftButton) ? anchorAt(e->pos()) : QString();
+    QPlainTextEdit::mousePressEvent(e);
+}
+
+void PostWindow::mouseReleaseEvent(QMouseEvent* e) {
+    // Make sure that the release event was over the same anchor it started on.
+    if (e->button() & Qt::LeftButton && !clickedAnchor.isEmpty() && anchorAt(e->pos()) == clickedAnchor) {
+        QUrl url { clickedAnchor };
+        auto command =
+            QString("PostWindowURLHandler(\"") + url.scheme() + QString("\", \"") + clickedAnchor + QString("\");");
+        emit handleClickedURL(command, true);
+    }
+    QPlainTextEdit::mouseReleaseEvent(e);
+}
+
 void PostWindow::focusOutEvent(QFocusEvent* event) {
     if (event->reason() == Qt::TabFocusReason)
         MainWindow::instance()->focusCodeEditor();
@@ -424,5 +440,6 @@ void PostDocklet::onFloatingChanged(bool floating) {
     if (floating)
         dockWidget()->resize(dockWidget()->size() - QSize(1, 1));
 }
+
 
 } // namespace ScIDE

--- a/editors/sc-ide/widgets/post_window.cpp
+++ b/editors/sc-ide/widgets/post_window.cpp
@@ -38,6 +38,10 @@
 #include <QKeyEvent>
 #include <QTextDocumentFragment>
 #include <QMimeData>
+#include <qtextcursor.h>
+#include <qtextformat.h>
+#include <qtypes.h>
+#include <qurl.h>
 
 namespace ScIDE {
 
@@ -190,29 +194,56 @@ QString PostWindow::symbolUnderCursor() {
 }
 
 void PostWindow::post(const QString& text) {
-    bool scroll = mActions[AutoScroll]->isChecked();
+    const bool scroll = mActions[AutoScroll]->isChecked();
     QTextCursor cursor(document());
-    QChar linebreak = QChar('\n');
 
-    int startPos = 0, position = 0;
-    foreach (const QChar chr, text) {
-        if (previousChar == linebreak) {
-            cursor.movePosition(QTextCursor::End);
-            cursor.insertText(text.mid(startPos, position - startPos), currentFormat);
-            startPos = position;
-
-            QString newLine = text.mid(position, text.length() - 1);
-            currentFormat = formatForPostLine(newLine);
-        }
-
-        previousChar = chr;
-        position++;
-    }
-
-    // handle remaining chars if not \n terminated
-    if (startPos < text.length()) {
+    if (text == "\n") {
         cursor.movePosition(QTextCursor::End);
-        cursor.insertText(text.mid(startPos, text.length() - startPos), currentFormat);
+        cursor.insertText(text, currentFormat);
+    } else {
+        const auto ends_with_new_line = text.back() == '\n';
+        const auto lines = text.split("\n");
+        const auto line_count = lines.size();
+        for (size_t i { 0 }; i < line_count; ++i) {
+            const auto line = lines[i];
+            const auto line_format = formatForPostLine(line);
+            cursor.movePosition(QTextCursor::End);
+
+            // If there is some text that looks like a URI and contains '://' then turn it into a html anchor so we can
+            // click it.
+            if (line.contains("://")) {
+                // words are just text separated by spaces.
+                const auto words = line.split(" ");
+                const auto words_count = words.size();
+                for (size_t w { 0 }; w < words_count; ++w) {
+                    const auto& word = words[w];
+                    cursor.movePosition(QTextCursor::End);
+
+                    if (const auto maybe_url = QUrl(word, QUrl::ParsingMode::StrictMode);
+                        maybe_url.isValid() && word.contains("://")) {
+                        cursor.insertHtml(QString("<a href='") + word + QString("'>") + word + QString("<\\a>"));
+                    } else {
+                        cursor.insertText(word, line_format);
+                    }
+
+                    // Put space back in, if not last word.
+                    if (w + 1 == words_count) {
+                        break;
+                    } else {
+                        cursor.insertText(" ", line_format);
+                    }
+                }
+            } else {
+                cursor.insertText(line, line_format);
+            }
+
+            // Don't write a new line in the final case.
+            if (i + 1 == line_count) {
+                break;
+            } else {
+                cursor.insertText("\n", line_format);
+            }
+        }
     }
 
     if (scroll)

--- a/editors/sc-ide/widgets/post_window.cpp
+++ b/editors/sc-ide/widgets/post_window.cpp
@@ -40,7 +40,6 @@
 #include <QMimeData>
 #include <qtextcursor.h>
 #include <qtextformat.h>
-#include <qtypes.h>
 #include <qurl.h>
 
 namespace ScIDE {

--- a/editors/sc-ide/widgets/post_window.cpp
+++ b/editors/sc-ide/widgets/post_window.cpp
@@ -199,50 +199,48 @@ void PostWindow::post(const QString& text) {
     if (text == "\n") {
         cursor.movePosition(QTextCursor::End);
         cursor.insertText(text, currentFormat);
-    } else {
-        const auto ends_with_new_line = text.back() == '\n';
-        const auto lines = text.split("\n");
-        const auto line_count = lines.size();
-        for (size_t i { 0 }; i < line_count; ++i) {
-            const auto line = lines[i];
-            const auto line_format = formatForPostLine(line);
-            cursor.movePosition(QTextCursor::End);
 
-            // If there is some text that looks like a URI and contains '://' then turn it into a html anchor so we can
-            // click it.
-            if (line.contains("://")) {
-                // words are just text separated by spaces.
-                const auto words = line.split(" ");
-                const auto words_count = words.size();
-                for (size_t w { 0 }; w < words_count; ++w) {
-                    const auto& word = words[w];
-                    cursor.movePosition(QTextCursor::End);
+        if (scroll)
+            emit(scrollToBottomRequest());
+        return;
+    }
 
-                    if (const auto maybe_url = QUrl(word, QUrl::ParsingMode::StrictMode);
-                        maybe_url.isValid() && word.contains("://")) {
-                        cursor.insertHtml(QString("<a href='") + word + QString("'>") + word + QString("<\\a>"));
-                    } else {
-                        cursor.insertText(word, line_format);
-                    }
+    const auto ends_with_new_line = text.back() == '\n';
+    const auto lines = text.split("\n");
+    const auto line_count = lines.size();
+    for (size_t i { 0 }; i < line_count; ++i) {
+        const auto line = lines[i];
+        const auto line_format = formatForPostLine(line);
+        cursor.movePosition(QTextCursor::End);
 
-                    // Put space back in, if not last word.
-                    if (w + 1 == words_count) {
-                        break;
-                    } else {
-                        cursor.insertText(" ", line_format);
-                    }
+        // If there is some text that looks like a URI and contains '://' then turn it into a html anchor so we can
+        // click it.
+        if (!line.contains("://")) {
+            cursor.insertText(line, line_format);
+        } else {
+            // words are just text separated by spaces.
+            const auto words = line.split(" ");
+            const auto words_count = words.size();
+            for (size_t w { 0 }; w < words_count; ++w) {
+                const auto& word = words[w];
+                cursor.movePosition(QTextCursor::End);
+
+                if (const auto maybe_url = QUrl(word, QUrl::ParsingMode::StrictMode);
+                    maybe_url.isValid() && word.contains("://")) {
+                    cursor.insertHtml(QString("<a href='") + word + QString("'>") + word + QString("<\\a>"));
+                } else {
+                    cursor.insertText(word, line_format);
                 }
-            } else {
-                cursor.insertText(line, line_format);
-            }
 
-            // Don't write a new line in the final case.
-            if (i + 1 == line_count) {
-                break;
-            } else {
-                cursor.insertText("\n", line_format);
+                // Put space back in, if not last word.
+                if (w + 1 != words_count)
+                    cursor.insertText(" ", line_format);
             }
         }
+
+        // Don't write a new line in the final case.
+        if (i + 1 != line_count)
+            cursor.insertText("\n", line_format);
     }
 
     if (scroll)

--- a/editors/sc-ide/widgets/post_window.hpp
+++ b/editors/sc-ide/widgets/post_window.hpp
@@ -126,6 +126,10 @@ private:
     QChar previousChar;
     QTextCharFormat currentFormat;
 
+    /// Stores the html anchor that the user clicked on.
+    /// This is to facilitate clickable URL links in the post window.
+    /// Will be empty when no anchor has been clicked
+    /// Used in conjuction with anchorAt(QPos)
     QString clickedAnchor;
 };
 

--- a/editors/sc-ide/widgets/post_window.hpp
+++ b/editors/sc-ide/widgets/post_window.hpp
@@ -24,6 +24,7 @@
 #include <QAction>
 #include <QGestureEvent>
 #include <QPlainTextEdit>
+#include <qurl.h>
 
 namespace ScIDE {
 
@@ -61,8 +62,26 @@ public:
     QSize minimumSizeHint() const { return QSize(50, 50); }
     QString symbolUnderCursor();
 
+    void mousePressEvent(QMouseEvent* e) override {
+        clickedAnchor = (e->button() & Qt::LeftButton) ? anchorAt(e->pos()) : QString();
+        QPlainTextEdit::mousePressEvent(e);
+    }
+
+    void mouseReleaseEvent(QMouseEvent* e) override {
+        // Make sure that the release event was over the same anchor it started on.
+        if (e->button() & Qt::LeftButton && !clickedAnchor.isEmpty() && anchorAt(e->pos()) == clickedAnchor) {
+            QUrl url { clickedAnchor };
+            auto command =
+                QString("PostWindowURLHandler(\"") + url.scheme() + QString("\", \"") + clickedAnchor + QString("\");");
+            emit handleClickedURL(command, true);
+        }
+        QPlainTextEdit::mouseReleaseEvent(e);
+    }
+
+
 signals:
     void scrollToBottomRequest();
+    void handleClickedURL(const QString& command, bool silent);
 
 public slots:
     void post(const QString& text);
@@ -106,6 +125,8 @@ private:
     QSize mSizeHint;
     QChar previousChar;
     QTextCharFormat currentFormat;
+
+    QString clickedAnchor;
 };
 
 

--- a/editors/sc-ide/widgets/post_window.hpp
+++ b/editors/sc-ide/widgets/post_window.hpp
@@ -62,21 +62,9 @@ public:
     QSize minimumSizeHint() const { return QSize(50, 50); }
     QString symbolUnderCursor();
 
-    void mousePressEvent(QMouseEvent* e) override {
-        clickedAnchor = (e->button() & Qt::LeftButton) ? anchorAt(e->pos()) : QString();
-        QPlainTextEdit::mousePressEvent(e);
-    }
+    void mousePressEvent(QMouseEvent* e) override;
 
-    void mouseReleaseEvent(QMouseEvent* e) override {
-        // Make sure that the release event was over the same anchor it started on.
-        if (e->button() & Qt::LeftButton && !clickedAnchor.isEmpty() && anchorAt(e->pos()) == clickedAnchor) {
-            QUrl url { clickedAnchor };
-            auto command =
-                QString("PostWindowURLHandler(\"") + url.scheme() + QString("\", \"") + clickedAnchor + QString("\");");
-            emit handleClickedURL(command, true);
-        }
-        QPlainTextEdit::mouseReleaseEvent(e);
-    }
+    void mouseReleaseEvent(QMouseEvent* e) override;
 
 
 signals:


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation
Closes #7362


```
"scdoc://Classes/Array.html#-put"
```


<img width="574" height="90" alt="dddd" src="https://github.com/user-attachments/assets/2ade7c8b-0bb4-4b7d-bb4e-2b169df31a6e" />

When you click on the link it takes you to the `put` method of `Array`.


This also works on files...

```
file://Some/Abs/Path/test.scd:10
```
which will open the file and set the cursor to the tenth character.


Additionally, one can register their url handler simply.

```
PostWindowURLHandler.register(\bang, {|url| ...  });

"bang://blah"
```

This only works in ScIDE.


I ***think*** the URL is in an acceptable standard format? We use `file://` internally to open the help docs so that is what I based it off.


I primarily intent to use this for clickable links in error messages.

## Types of changes

<!-- Delete lines that don't apply -->

- New feature

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
