### PR TITLE
Document non-standard behavior for trunc and div; specify standard methods

### DIFF
--- a/HelpSource/Classes/SimpleNumber.schelp
+++ b/HelpSource/Classes/SimpleNumber.schelp
@@ -41,7 +41,18 @@ method:: mod
 Modulo
 
 method:: div
-Integer Division
+Divide teletype::this:: by teletype::aNumber:: and rounds to next-lower integer.
+For positive integers strong::only::, this is equivalent to standard integer division.
+Warning::
+This is a non-standard implementation of integer division,
+which has been preserved in SuperCollider for backward compatibility reasons,
+and is equivalent to code::floor(this/aNumber)::.
+
+For standard integer division, use code::truncate(this/aNumber):: or link::#-divide::
+::
+
+method:: divide
+Standard integer division, divides teletype::this:: by teletype::aNumber:: and rounds towards 0.
 
 method:: **
 Exponentiation
@@ -71,7 +82,10 @@ method:: round
 Round to multiple of aNumber
 
 method:: roundUp
-Round up to a multiple of aNumber. For roundDown use link::Classes/SimpleNumber#-trunc#trunc::.
+Round up to a multiple of aNumber.
+
+method:: roundDown
+Round down to a multiple of aNumber. 
 
 method:: smallButNotZero
 Check if the value is closer to zero than a threshold, but not zero.
@@ -80,7 +94,20 @@ argument::thresh
 The threshold to use for comparison.
 
 method:: trunc
-Truncate to multiple of aNumber (e.g. it rounds numbers down to a multiple of aNumber).
+Round down to a multiple of teletype::aNumber::. (Alias of link::#-roundDown::)
+For positive integers strong::only::, this is equivalent to standard truncation.
+Warning::
+This is a non-standard implementation of truncation, 
+which has been preserved in SuperCollider for backward compatibility reasons.
+
+For standard truncation, use link::#-truncate::.
+::
+
+method:: truncate
+Removes digits after the decimal separator and returns an integer:
+code::
+-3.9.truncate == -3
+::
 
 method:: softRound
 Rounds the value to a multiple of strong::resolution::. By using strong::margin:: and strong::strength:: you can control which values will be rounded, and by how much.

--- a/SCClassLibrary/Common/Collections/SequenceableCollection.sc
+++ b/SCClassLibrary/Common/Collections/SequenceableCollection.sc
@@ -861,6 +861,7 @@ SequenceableCollection : Collection {
 	* { arg aNumber, adverb; ^this.performBinaryOp('*', aNumber, adverb) }
 	/ { arg aNumber, adverb; ^this.performBinaryOp('/', aNumber, adverb) }
 	div { arg aNumber, adverb; ^this.performBinaryOp('div', aNumber, adverb) }
+	divide { arg aNumber, adverb; ^this.performBinaryOp('divide', aNumber, adverb) }
 	mod { arg aNumber, adverb; ^this.performBinaryOp('mod', aNumber, adverb) }
 	modSeaside { arg aNumber, adverb; ^this.performBinaryOp('modSeaside', aNumber, adverb) }
 	pow { arg aNumber, adverb; ^this.performBinaryOp('pow', aNumber, adverb) }

--- a/SCClassLibrary/Common/Collections/SequenceableCollection.sc
+++ b/SCClassLibrary/Common/Collections/SequenceableCollection.sc
@@ -884,7 +884,9 @@ SequenceableCollection : Collection {
 	gcd { arg aNumber, adverb; ^this.performBinaryOp('gcd', aNumber, adverb) }
 	round { arg aNumber=1, adverb; ^this.performBinaryOp('round', aNumber, adverb) }
 	roundUp { arg aNumber=1, adverb; ^this.performBinaryOp('roundUp', aNumber, adverb) }
+	roundDown { arg aNumber=1, adverb; ^this.performBinaryOp('trunc', aNumber, adverb) }
 	trunc { arg aNumber=1, adverb; ^this.performBinaryOp('trunc', aNumber, adverb) }
+	truncate { arg aNumber=1, adverb; ^this.performBinaryOp('truncate', aNumber, adverb) }
 	atan2 { arg aNumber, adverb; ^this.performBinaryOp('atan2', aNumber, adverb) }
 	hypot { arg aNumber, adverb; ^this.performBinaryOp('hypot', aNumber, adverb) }
 	hypotApx { arg aNumber, adverb; ^this.performBinaryOp('hypotApx', aNumber, adverb) }

--- a/SCClassLibrary/Common/Core/AbstractFunction.sc
+++ b/SCClassLibrary/Common/Core/AbstractFunction.sc
@@ -127,7 +127,9 @@ AbstractFunction {
 	gcd { arg function, adverb; ^this.composeBinaryOp('gcd', function, adverb) }
 	round { arg function=1, adverb; ^this.composeBinaryOp('round', function, adverb) }
 	roundUp { arg function=1, adverb; ^this.composeBinaryOp('roundUp', function, adverb) }
+	roundDown { arg function=1, adverb; ^this.composeBinaryOp('trunc', function, adverb) }
 	trunc { arg function=1, adverb; ^this.composeBinaryOp('trunc', function, adverb) }
+	truncate { arg function=1, adverb; ^this.composeBinaryOp('truncate', function, adverb) }
 	atan2 { arg function, adverb; ^this.composeBinaryOp('atan2', function, adverb) }
 	hypot { arg function, adverb; ^this.composeBinaryOp('hypot', function, adverb) }
 	hypotApx { arg function, adverb; ^this.composeBinaryOp('hypotApx', function, adverb) }

--- a/SCClassLibrary/Common/Core/AbstractFunction.sc
+++ b/SCClassLibrary/Common/Core/AbstractFunction.sc
@@ -99,6 +99,7 @@ AbstractFunction {
 	* { arg function, adverb; ^this.composeBinaryOp('*', function, adverb) }
 	/ { arg function, adverb; ^this.composeBinaryOp('/', function, adverb) }
 	div { arg function, adverb; ^this.composeBinaryOp('div', function, adverb) }
+	divide { arg function, adverb; ^this.composeBinaryOp('divide', function, adverb) }
 	mod { arg function, adverb; ^this.composeBinaryOp('mod', function, adverb) }
 	modSeaside { arg function, adverb; ^this.composeBinaryOp('modSeaside', function, adverb) }
 	pow { arg function, adverb; ^this.composeBinaryOp('pow', function, adverb) }

--- a/SCClassLibrary/Common/Geometry/Point.sc
+++ b/SCClassLibrary/Common/Geometry/Point.sc
@@ -52,6 +52,13 @@ Point {
 		scalePoint = scale.asPoint;
 		^Point(this.x div: scalePoint.x, this.y div: scalePoint.y)
 	}
+
+	divide { arg scale;
+		var scalePoint;
+		scalePoint = scale.asPoint;
+		^Point(this.x divide: scalePoint.x, this.y divide: scalePoint.y)
+	}
+
 	translate { arg delta;
 		^Point(this.x + delta.x, this.y + delta.y)
 	}

--- a/SCClassLibrary/Common/Geometry/Point.sc
+++ b/SCClassLibrary/Common/Geometry/Point.sc
@@ -66,6 +66,7 @@ Point {
 	}
 
 	abs { ^Point(x.abs, y.abs) }
+	truncate { ^Point(x.truncate, y.truncate) }
 
 	rho { ^hypot(x, y) }
 	theta { ^atan2(y, x) }

--- a/SCClassLibrary/Common/Math/Number.sc
+++ b/SCClassLibrary/Common/Math/Number.sc
@@ -8,6 +8,7 @@ Number : Magnitude {
 	mod { arg aNumber; ^this.subclassResponsibility(thisMethod) }
 	modSeaside { arg aNumber; ^this.subclassResponsibility(thisMethod) }
 	div { arg aNumber; ^this.subclassResponsibility(thisMethod) }
+	divide { arg aNumber; ^this.subclassResponsibility(thisMethod) }
 	pow { arg aNumber; ^this.subclassResponsibility(thisMethod) }
 
 	performBinaryOpOnSeqColl { arg aSelector, aSeqColl, adverb;

--- a/SCClassLibrary/Common/Math/Signal.sc
+++ b/SCClassLibrary/Common/Math/Signal.sc
@@ -269,6 +269,7 @@ Signal[float] : FloatArray {
 	mod { arg aNumber; _Mod; ^aNumber.performBinaryOpOnSignal('mod', this) }
 	modSeaside { arg aNumber; _Mod; ^aNumber.performBinaryOpOnSignal('mod', this) }
 	div { arg aNumber; _IDiv; ^aNumber.performBinaryOpOnSignal('div', this) }
+	divide { arg aNumber; _IDivide; ^aNumber.performBinaryOpOnSignal('divide', this) }
 	pow { arg aNumber; _Pow; ^aNumber.performBinaryOpOnSignal('pow', this) }
 	min { arg aNumber; _Min; ^aNumber.performBinaryOpOnSignal('min', this) }
 	max { arg aNumber; _Max; ^aNumber.performBinaryOpOnSignal('max', this) }

--- a/SCClassLibrary/Common/Math/SimpleNumber.sc
+++ b/SCClassLibrary/Common/Math/SimpleNumber.sc
@@ -14,6 +14,7 @@ SimpleNumber : Number {
 	abs { _Abs; ^this.primitiveFailed }
 	ceil { _Ceil; ^this.primitiveFailed }
 	floor { _Floor; ^this.primitiveFailed }
+	truncate { _Truncate; ^this.primitiveFailed }
 	frac { _Frac; ^this.primitiveFailed }
 	sign { _Sign; ^this.primitiveFailed }
 	squared { _Squared; ^this.primitiveFailed }
@@ -72,6 +73,7 @@ SimpleNumber : Number {
 	/ { |aNumber, adverb| _FDiv; ^aNumber.performBinaryOpOnSimpleNumber('/', this, adverb) }
 	mod { |aNumber, adverb| _Mod; ^aNumber.performBinaryOpOnSimpleNumber('mod', this, adverb) }
 	div { |aNumber, adverb| _IDiv; ^aNumber.performBinaryOpOnSimpleNumber('div', this, adverb) }
+	divide { |aNumber, adverb| _IDiv; ^aNumber.performBinaryOpOnSimpleNumber('divide', this, adverb) }
 	pow { |aNumber, adverb| _Pow; ^aNumber.performBinaryOpOnSimpleNumber('pow', this, adverb) }
 	min { |aNumber, adverb| _Min; ^aNumber.performBinaryOpOnSimpleNumber('min', this, adverb) }
 	max { |aNumber=0.0, adverb| _Max; ^aNumber.performBinaryOpOnSimpleNumber('max', this, adverb) }
@@ -84,7 +86,9 @@ SimpleNumber : Number {
 	gcd { |aNumber, adverb| _GCD; ^aNumber.performBinaryOpOnSimpleNumber('gcd', this, adverb) }
 	round { |aNumber=1.0, adverb| _Round; ^aNumber.performBinaryOpOnSimpleNumber('round', this, adverb) }
 	roundUp { |aNumber=1.0, adverb| _RoundUp; ^aNumber.performBinaryOpOnSimpleNumber('roundUp', this, adverb) }
+	roundDown { |aNumber=1.0, adverb| _Trunc; ^aNumber.performBinaryOpOnSimpleNumber('trunc', this, adverb) }
 	smallButNotZero { |thresh=1e-12| ^this != 0 and: {  this.abs < thresh  } }
+	// this is sc_trunc, equivalent to floor(receiver/aNumber) * aNumber
 	trunc { |aNumber=1.0, adverb| _Trunc; ^aNumber.performBinaryOpOnSimpleNumber('trunc', this, adverb) }
 	atan2 { |aNumber, adverb| _Atan2; ^aNumber.performBinaryOpOnSimpleNumber('atan2', this, adverb) }
 	hypot { |aNumber, adverb| _Hypot; ^aNumber.performBinaryOpOnSimpleNumber('hypot', this, adverb) }

--- a/lang/LangPrimSource/PyrPrimitive.cpp
+++ b/lang/LangPrimSource/PyrPrimitive.cpp
@@ -3758,6 +3758,7 @@ void initPrimitives() {
     definePrimitive(base, opAsInteger, "_AsInteger", doSpecialUnaryArithMsg, 1, 0);
     definePrimitive(base, opCeil, "_Ceil", doSpecialUnaryArithMsg, 1, 0); // 5
     definePrimitive(base, opFloor, "_Floor", doSpecialUnaryArithMsg, 1, 0);
+    definePrimitive(base, opTruncate, "_Truncate", doSpecialUnaryArithMsg, 1, 0);
     definePrimitive(base, opFrac, "_Frac", doSpecialUnaryArithMsg, 1, 0);
     definePrimitive(base, opSign, "_Sign", doSpecialUnaryArithMsg, 1, 0);
     definePrimitive(base, opSquared, "_Squared", doSpecialUnaryArithMsg, 1, 0);
@@ -3819,6 +3820,7 @@ void initPrimitives() {
     definePrimitive(base, opSub, "_Sub", prSubNum, 2, 0);
     definePrimitive(base, opMul, "_Mul", prMulNum, 2, 0);
 
+    definePrimitive(base, opIDivide, "_IDivide", prSpecialBinaryArithMsg, 3, 0);
     definePrimitive(base, opIDiv, "_IDiv", prSpecialBinaryArithMsg, 3, 0);
     definePrimitive(base, opFDiv, "_FDiv", prSpecialBinaryArithMsg, 3, 0);
     definePrimitive(base, opMod, "_Mod", prSpecialBinaryArithMsg, 3, 0);

--- a/lang/LangSource/PyrMathOps.cpp
+++ b/lang/LangSource/PyrMathOps.cpp
@@ -83,6 +83,9 @@ int doSpecialUnaryArithMsg(VMGlobals* g, int numArgsPushed) {
         case opFloor:
             SetRaw(a, slotRawInt(a));
             break;
+        case opTruncate:
+            SetRaw(a, slotRawInt(a));
+            break;
         case opFrac:
             SetRaw(a, 0);
             break;
@@ -428,6 +431,9 @@ int doSpecialUnaryArithMsg(VMGlobals* g, int numArgsPushed) {
         case opFloor:
             SetRaw(a, floor(slotRawFloat(a)));
             break;
+        case opTruncate:
+            SetRaw(a, trunc(slotRawFloat(a)));
+            break;
         case opFrac:
             SetRaw(a, sc_frac(slotRawFloat(a)));
             break;
@@ -606,6 +612,9 @@ int doSpecialBinaryArithMsg(VMGlobals* g, int numArgsPushed, bool isPrimitive) {
                 break;
             case opIDiv:
                 SetRaw(a, sc_div(slotRawInt(a), slotRawInt(b)));
+                break;
+            case opIDivide:
+                SetRaw(a, slotRawInt(a) / slotRawInt(b));
                 break;
             case opFDiv:
                 SetFloat(a, (double)slotRawInt(a) / (double)slotRawInt(b));
@@ -793,6 +802,9 @@ int doSpecialBinaryArithMsg(VMGlobals* g, int numArgsPushed, bool isPrimitive) {
                 case opIDiv:
                     SetObject(a, signal_div_fx(g, slotRawInt(a), slotRawFloatArray(b)));
                     break;
+                case opIDivide:
+                    SetObject(a, signal_div_fx(g, slotRawInt(a), slotRawFloatArray(b)));
+                    break;
                 case opFDiv:
                     SetObject(a, signal_div_fx(g, slotRawInt(a), slotRawFloatArray(b)));
                     break;
@@ -879,6 +891,9 @@ int doSpecialBinaryArithMsg(VMGlobals* g, int numArgsPushed, bool isPrimitive) {
                 break;
             case opIDiv:
                 SetRaw(a, static_cast<int32_t>(floor(slotRawInt(a) / slotRawFloat(b))));
+                break;
+            case opIDivide:
+                SetRaw(a, static_cast<int32_t>(trunc(slotRawInt(a) / slotRawFloat(b))));
                 break;
             case opFDiv:
                 SetFloat(a, slotRawInt(a) / slotRawFloat(b));
@@ -1082,6 +1097,9 @@ int doSpecialBinaryArithMsg(VMGlobals* g, int numArgsPushed, bool isPrimitive) {
                 case opIDiv:
                     SetRaw(a, signal_div_xf(g, slotRawFloatArray(a), slotRawInt(b)));
                     break;
+                case opIDivide:
+                    SetRaw(a, signal_div_xf(g, slotRawFloatArray(a), slotRawInt(b)));
+                    break;
                 case opFDiv:
                     SetRaw(a, signal_div_xf(g, slotRawFloatArray(a), slotRawInt(b)));
                     break;
@@ -1188,6 +1206,9 @@ int doSpecialBinaryArithMsg(VMGlobals* g, int numArgsPushed, bool isPrimitive) {
                     case opIDiv:
                         SetRaw(a, signal_div_xx(g, slotRawFloatArray(a), slotRawFloatArray(b)));
                         break;
+                    case opIDivide:
+                        SetRaw(a, signal_div_xx(g, slotRawFloatArray(a), slotRawFloatArray(b)));
+                        break;
                     case opFDiv:
                         SetRaw(a, signal_div_xx(g, slotRawFloatArray(a), slotRawFloatArray(b)));
                         break;
@@ -1278,6 +1299,9 @@ int doSpecialBinaryArithMsg(VMGlobals* g, int numArgsPushed, bool isPrimitive) {
                     SetRaw(a, signal_mul_xf(g, slotRawFloatArray(a), slotRawFloat(b)));
                     break;
                 case opIDiv:
+                    SetRaw(a, signal_div_xf(g, slotRawFloatArray(a), slotRawFloat(b)));
+                    break;
+                case opIDivide:
                     SetRaw(a, signal_div_xf(g, slotRawFloatArray(a), slotRawFloat(b)));
                     break;
                 case opFDiv:
@@ -1379,6 +1403,9 @@ int doSpecialBinaryArithMsg(VMGlobals* g, int numArgsPushed, bool isPrimitive) {
                 break;
             case opIDiv:
                 SetInt(a, (std::int64_t)floor(slotRawFloat(a) / slotRawInt(b)));
+                break;
+            case opIDivide:
+                SetInt(a, (std::int64_t)trunc(slotRawFloat(a) / slotRawInt(b)));
                 break;
             case opFDiv:
                 SetRaw(a, slotRawFloat(a) / slotRawInt(b));
@@ -1612,6 +1639,9 @@ int doSpecialBinaryArithMsg(VMGlobals* g, int numArgsPushed, bool isPrimitive) {
                 break;
             case opIDiv:
                 SetInt(a, (std::int64_t)floor(slotRawFloat(a) / slotRawFloat(b)));
+                break;
+            case opIDivide:
+                SetInt(a, (std::int64_t)trunc(slotRawFloat(a) / slotRawFloat(b)));
                 break;
             case opFDiv:
                 SetRaw(a, slotRawFloat(a) / slotRawFloat(b));

--- a/lang/LangSource/SpecialSelectorsOperatorsAndClasses.h
+++ b/lang/LangSource/SpecialSelectorsOperatorsAndClasses.h
@@ -15,7 +15,7 @@ enum {
     opAsFloat,
     opAsInteger,
     opCeil, // 5
-    opFloor,
+    opFloor, // opTruncate is at the bottom. erroneous opTrunc is in binops
     opFrac,
     opSign,
     opSquared,
@@ -70,6 +70,7 @@ enum {
 
     opRamp,
     opSCurve,
+    opTruncate,
 
     opNumUnarySelectors
 };
@@ -83,7 +84,7 @@ enum {
     opAdd,
     opSub,
     opMul,
-    opIDiv,
+    opIDiv, // opIdivide is at the bottom
     opFDiv,
     opMod,
     opEQ,
@@ -132,6 +133,7 @@ enum {
     opFirstArg,
     opRandRange,
     opExpRandRange,
+    opIDivide,
 
     opNumBinarySelectors
 };

--- a/server/plugins/BinaryOpUGens.cpp
+++ b/server/plugins/BinaryOpUGens.cpp
@@ -211,7 +211,7 @@ enum {
     opAdd,
     opSub,
     opMul,
-    opIDiv,
+    opIDiv, // IDivide at bottom
     opFDiv,
     opMod,
     opEQ,
@@ -260,6 +260,7 @@ enum {
     opFirstArg,
     opRandRange,
     opExpRandRange,
+    opIDivide,
 
     opNumBinarySelectors
 };
@@ -707,6 +708,19 @@ void idiv_d(BinaryOpUGen* unit, int inNumSamples) {
         RESETINPUT(1);
     }
 }
+
+
+void idivide_d(BinaryOpUGen* unit, int inNumSamples) {
+    if (inNumSamples) {
+        float a = DEMANDINPUT_A(0, inNumSamples);
+        float b = DEMANDINPUT_A(1, inNumSamples);
+        OUT0(0) = sc_isnan(a) || sc_isnan(b) ? NAN : trunc(a / b);
+    } else {
+        RESETINPUT(0);
+        RESETINPUT(1);
+    }
+}
+
 
 void mod_d(BinaryOpUGen* unit, int inNumSamples) {
     if (inNumSamples) {
@@ -1182,6 +1196,8 @@ void mul_1(BinaryOpUGen* unit, int inNumSamples) { ZOUT0(0) = ZIN0(0) * ZIN0(1);
 void div_1(BinaryOpUGen* unit, int inNumSamples) { ZOUT0(0) = ZIN0(0) / ZIN0(1); }
 
 void idiv_1(BinaryOpUGen* unit, int inNumSamples) { ZOUT0(0) = floor(ZIN0(0) / ZIN0(1)); }
+
+void idivide_1(BinaryOpUGen* unit, int inNumSamples) { ZOUT0(0) = trunc(ZIN0(0) / ZIN0(1)); }
 
 void mod_1(BinaryOpUGen* unit, int inNumSamples) {
     float xa = ZIN0(0);
@@ -2070,6 +2086,66 @@ void idiv_ai(BinaryOpUGen* unit, int inNumSamples) {
     float xb = ZIN0(1);
 
     LOOP1(inNumSamples, ZXP(out) = floor(ZXP(a) / xb););
+}
+
+
+void idivide_aa(BinaryOpUGen* unit, int inNumSamples) {
+    float* out = ZOUT(0);
+    float* a = ZIN(0);
+    float* b = ZIN(1);
+
+    LOOP1(inNumSamples, ZXP(out) = trunc(ZXP(a) / ZXP(b)););
+}
+
+void idivide_ak(BinaryOpUGen* unit, int inNumSamples) {
+    float* out = ZOUT(0);
+    float* a = ZIN(0);
+    float xb = unit->mPrevB;
+    float next_b = ZIN0(1);
+
+    if (xb == next_b) {
+        ZXP(out) = trunc(ZXP(a) / xb);
+    } else {
+        float slope = CALCSLOPE(next_b, xb);
+        LOOP1(inNumSamples, ZXP(out) = trunc(ZXP(a) / xb); xb += slope;);
+        unit->mPrevB = xb;
+    }
+}
+
+void idivide_ka(BinaryOpUGen* unit, int inNumSamples) {
+    float* out = ZOUT(0);
+    float xa = unit->mPrevA;
+    float* b = ZIN(1);
+    float next_a = ZIN0(0);
+
+    if (xa == next_a) {
+        if (xa == 0.f) {
+            ZClear(inNumSamples, out);
+        } else {
+            LOOP1(inNumSamples, ZXP(out) = trunc(xa / ZXP(b)););
+        }
+    } else {
+        float slope = CALCSLOPE(next_a, xa);
+        LOOP1(inNumSamples, ZXP(out) = trunc(xa / ZXP(b)); xa += slope;);
+        unit->mPrevA = xa;
+    }
+}
+
+void idivide_ia(BinaryOpUGen* unit, int inNumSamples) {
+    float* out = ZOUT(0);
+    float xa = ZIN0(0);
+    float* b = ZIN(1);
+
+    LOOP1(inNumSamples, ZXP(out) = trunc(xa / ZXP(b)););
+}
+
+
+void idivide_ai(BinaryOpUGen* unit, int inNumSamples) {
+    float* out = ZOUT(0);
+    float* a = ZIN(0);
+    float xb = ZIN0(1);
+
+    LOOP1(inNumSamples, ZXP(out) = trunc(ZXP(a) / xb););
 }
 
 
@@ -4684,6 +4760,9 @@ static BinaryOpFunc ChooseOneSampleFunc(BinaryOpUGen* unit) {
     case opIDiv:
         func = &idiv_1;
         break;
+    case opIDivide:
+        func = &idivide_1;
+        break;
     case opMod:
         func = &mod_1;
         break;
@@ -4838,6 +4917,9 @@ static BinaryOpFunc ChooseDemandFunc(BinaryOpUGen* unit) {
         break;
     case opIDiv:
         func = &idiv_d;
+        break;
+    case opIDivide:
+        func = &idivide_d;
         break;
     case opMod:
         func = &mod_d;
@@ -5002,6 +5084,9 @@ static BinaryOpFunc ChooseNormalFunc(BinaryOpUGen* unit) {
             case opIDiv:
                 func = &idiv_aa;
                 break;
+            case opIDivide:
+                func = &idivide_aa;
+                break;
             case opMod:
                 func = &mod_aa;
                 break;
@@ -5154,6 +5239,9 @@ static BinaryOpFunc ChooseNormalFunc(BinaryOpUGen* unit) {
             case opIDiv:
                 func = &idiv_ak;
                 break;
+            case opIDivide:
+                func = &idivide_ak;
+                break;
             case opMod:
                 func = &mod_ak;
                 break;
@@ -5304,6 +5392,9 @@ static BinaryOpFunc ChooseNormalFunc(BinaryOpUGen* unit) {
                 func = &div_ai;
                 break;
             case opIDiv:
+                func = &idiv_ai;
+                break;
+            case opIDivide:
                 func = &idiv_ai;
                 break;
             case opMod:
@@ -5458,6 +5549,9 @@ static BinaryOpFunc ChooseNormalFunc(BinaryOpUGen* unit) {
             case opIDiv:
                 func = &idiv_ka;
                 break;
+            case opIDivide:
+                func = &idivide_ka;
+                break;
             case opMod:
                 func = &mod_ka;
                 break;
@@ -5610,6 +5704,9 @@ static BinaryOpFunc ChooseNormalFunc(BinaryOpUGen* unit) {
                 break;
             case opIDiv:
                 func = &idiv_ia;
+                break;
+            case opIDivide:
+                func = &idivide_ia;
                 break;
             case opMod:
                 func = &mod_ia;
@@ -5778,6 +5875,9 @@ static BinaryOpFunc ChooseNovaSimdFunc_64(BinaryOpUGen* unit) {
             case opIDiv:
                 func = &idiv_aa;
                 break;
+            case opIDivide:
+                func = &idivide_aa;
+                break;
             case opMod:
                 func = &mod_aa;
                 break;
@@ -5928,6 +6028,9 @@ static BinaryOpFunc ChooseNovaSimdFunc_64(BinaryOpUGen* unit) {
             case opIDiv:
                 func = &idiv_ak;
                 break;
+            case opIDivide:
+                func = &idivide_ak;
+                break;
             case opMod:
                 func = &mod_ak;
                 break;
@@ -6077,6 +6180,9 @@ static BinaryOpFunc ChooseNovaSimdFunc_64(BinaryOpUGen* unit) {
                 break;
             case opIDiv:
                 func = &idiv_ai;
+                break;
+            case opIDivide:
+                func = &idivide_ai;
                 break;
             case opMod:
                 func = &mod_ai;
@@ -6230,6 +6336,9 @@ static BinaryOpFunc ChooseNovaSimdFunc_64(BinaryOpUGen* unit) {
             case opIDiv:
                 func = &idiv_ka;
                 break;
+            case opIDivide:
+                func = &idivide_ka;
+                break;
             case opMod:
                 func = &mod_ka;
                 break;
@@ -6382,6 +6491,9 @@ static BinaryOpFunc ChooseNovaSimdFunc_64(BinaryOpUGen* unit) {
                 break;
             case opIDiv:
                 func = &idiv_ia;
+                break;
+            case opIDivide:
+                func = &idivide_ia;
                 break;
             case opMod:
                 func = &mod_ia;
@@ -6553,6 +6665,9 @@ static BinaryOpFunc ChooseNovaSimdFunc(BinaryOpUGen* unit) {
             case opIDiv:
                 func = &idiv_aa;
                 break;
+            case opIDivide:
+                func = &idivide_aa;
+                break;
             case opMod:
                 func = &mod_aa;
                 break;
@@ -6703,6 +6818,9 @@ static BinaryOpFunc ChooseNovaSimdFunc(BinaryOpUGen* unit) {
             case opIDiv:
                 func = &idiv_ak;
                 break;
+            case opIDivide:
+                func = &idivide_ak;
+                break;
             case opMod:
                 func = &mod_ak;
                 break;
@@ -6852,6 +6970,9 @@ static BinaryOpFunc ChooseNovaSimdFunc(BinaryOpUGen* unit) {
                 break;
             case opIDiv:
                 func = &idiv_ai;
+                break;
+            case opIDivide:
+                func = &idivide_ai;
                 break;
             case opMod:
                 func = &mod_ai;
@@ -7005,6 +7126,9 @@ static BinaryOpFunc ChooseNovaSimdFunc(BinaryOpUGen* unit) {
             case opIDiv:
                 func = &idiv_ka;
                 break;
+            case opIDivide:
+                func = &idivide_ka;
+                break;
             case opMod:
                 func = &mod_ka;
                 break;
@@ -7157,6 +7281,9 @@ static BinaryOpFunc ChooseNovaSimdFunc(BinaryOpUGen* unit) {
                 break;
             case opIDiv:
                 func = &idiv_ia;
+                break;
+            case opIDivide:
+                func = &idivide_ia;
                 break;
             case opMod:
                 func = &mod_ia;

--- a/server/plugins/UnaryOpUGens.cpp
+++ b/server/plugins/UnaryOpUGens.cpp
@@ -1018,7 +1018,7 @@ static UnaryOpFunc ChooseNovaSimdFunc(UnaryOpUGen* unit) {
             func = &floor_nova_64;
             break;
         case opTruncate:
-            func = &trunc_nova_64;
+            func = &truncate_nova_64;
             break;
         case opFrac:
             func = &frac_nova_64;
@@ -1182,7 +1182,7 @@ static UnaryOpFunc ChooseNovaSimdFunc(UnaryOpUGen* unit) {
         func = &floor_nova;
         break;
     case opTruncate:
-        func = &trunc_nova;
+        func = &truncate_nova;
         break;
     case opFrac:
         func = &frac_nova;

--- a/server/plugins/UnaryOpUGens.cpp
+++ b/server/plugins/UnaryOpUGens.cpp
@@ -122,7 +122,7 @@ enum {
     opAsFloat,
     opAsInteger,
     opCeil,
-    opFloor,
+    opFloor, // truncate is at bottom
     opFrac,
     opSign,
     opSquared,
@@ -172,6 +172,7 @@ enum {
 
     opRamp,
     opSCurve,
+    opTruncate,
 
     opNumUnarySelectors
 };
@@ -275,10 +276,12 @@ FLATTEN void recip_nova_64(UnaryOpUGen* unit, int inNumSamples) { nova::reciproc
 
 DEFINE_UNARY_OP_FUNCS(floor, floor)
 DEFINE_UNARY_OP_FUNCS(ceil, ceil)
+DEFINE_UNARY_OP_FUNCS(truncate, trunc)
 
 #ifdef NOVA_SIMD
 NOVA_WRAPPER_CT_UNROLL(floor, floor)
 NOVA_WRAPPER_CT_UNROLL(ceil, ceil)
+NOVA_WRAPPER_CT_UNROLL(truncate, trunc)
 #endif
 
 DEFINE_UNARY_OP_FUNCS(sin, sin)
@@ -484,7 +487,7 @@ void coin_d(UnaryOpUGen* unit, int inNumSamples) {
 ////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 static UnaryOpFunc ChooseNormalFunc(UnaryOpUGen* unit) {
-    void (*func)(UnaryOpUGen * unit, int inNumSamples);
+    void (*func)(UnaryOpUGen* unit, int inNumSamples);
 
     switch (unit->mSpecialIndex) {
     case opSilence:
@@ -510,6 +513,9 @@ static UnaryOpFunc ChooseNormalFunc(UnaryOpUGen* unit) {
         break;
     case opFloor:
         func = &floor_a;
+        break;
+    case opTruncate:
+        func = &truncate_a;
         break;
     case opFrac:
         func = &frac_a;
@@ -648,7 +654,7 @@ static UnaryOpFunc ChooseNormalFunc(UnaryOpUGen* unit) {
 }
 
 static UnaryOpFunc ChooseOneFunc(UnaryOpUGen* unit) {
-    void (*func)(UnaryOpUGen * unit, int inNumSamples);
+    void (*func)(UnaryOpUGen* unit, int inNumSamples);
 
     switch (unit->mSpecialIndex) {
     case opSilence:
@@ -674,6 +680,9 @@ static UnaryOpFunc ChooseOneFunc(UnaryOpUGen* unit) {
         break;
     case opFloor:
         func = &floor_1;
+        break;
+    case opTruncate:
+        func = &truncate_1;
         break;
     case opFrac:
         func = &frac_1;
@@ -813,7 +822,7 @@ static UnaryOpFunc ChooseOneFunc(UnaryOpUGen* unit) {
 
 
 static UnaryOpFunc ChooseDemandFunc(UnaryOpUGen* unit) {
-    void (*func)(UnaryOpUGen * unit, int inNumSamples);
+    void (*func)(UnaryOpUGen* unit, int inNumSamples);
 
     switch (unit->mSpecialIndex) {
     case opSilence:
@@ -839,6 +848,9 @@ static UnaryOpFunc ChooseDemandFunc(UnaryOpUGen* unit) {
         break;
     case opFloor:
         func = &floor_d;
+        break;
+    case opTruncate:
+        func = &truncate_d;
         break;
     case opFrac:
         func = &frac_d;
@@ -980,7 +992,7 @@ static UnaryOpFunc ChooseDemandFunc(UnaryOpUGen* unit) {
 #ifdef NOVA_SIMD
 
 static UnaryOpFunc ChooseNovaSimdFunc(UnaryOpUGen* unit) {
-    void (*func)(UnaryOpUGen * unit, int inNumSamples);
+    void (*func)(UnaryOpUGen* unit, int inNumSamples);
 
     if (BUFLENGTH == 64) {
         switch (unit->mSpecialIndex) {
@@ -1004,6 +1016,9 @@ static UnaryOpFunc ChooseNovaSimdFunc(UnaryOpUGen* unit) {
             break;
         case opFloor:
             func = &floor_nova_64;
+            break;
+        case opTruncate:
+            func = &trunc_nova_64;
             break;
         case opFrac:
             func = &frac_nova_64;
@@ -1165,6 +1180,9 @@ static UnaryOpFunc ChooseNovaSimdFunc(UnaryOpUGen* unit) {
         break;
     case opFloor:
         func = &floor_nova;
+        break;
+    case opTruncate:
+        func = &trunc_nova;
         break;
     case opFrac:
         func = &frac_nova;

--- a/server/plugins/UnaryOpUGens.cpp
+++ b/server/plugins/UnaryOpUGens.cpp
@@ -487,7 +487,7 @@ void coin_d(UnaryOpUGen* unit, int inNumSamples) {
 ////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 static UnaryOpFunc ChooseNormalFunc(UnaryOpUGen* unit) {
-    void (*func)(UnaryOpUGen* unit, int inNumSamples);
+    void (*func)(UnaryOpUGen * unit, int inNumSamples);
 
     switch (unit->mSpecialIndex) {
     case opSilence:
@@ -654,7 +654,7 @@ static UnaryOpFunc ChooseNormalFunc(UnaryOpUGen* unit) {
 }
 
 static UnaryOpFunc ChooseOneFunc(UnaryOpUGen* unit) {
-    void (*func)(UnaryOpUGen* unit, int inNumSamples);
+    void (*func)(UnaryOpUGen * unit, int inNumSamples);
 
     switch (unit->mSpecialIndex) {
     case opSilence:
@@ -822,7 +822,7 @@ static UnaryOpFunc ChooseOneFunc(UnaryOpUGen* unit) {
 
 
 static UnaryOpFunc ChooseDemandFunc(UnaryOpUGen* unit) {
-    void (*func)(UnaryOpUGen* unit, int inNumSamples);
+    void (*func)(UnaryOpUGen * unit, int inNumSamples);
 
     switch (unit->mSpecialIndex) {
     case opSilence:
@@ -992,7 +992,7 @@ static UnaryOpFunc ChooseDemandFunc(UnaryOpUGen* unit) {
 #ifdef NOVA_SIMD
 
 static UnaryOpFunc ChooseNovaSimdFunc(UnaryOpUGen* unit) {
-    void (*func)(UnaryOpUGen* unit, int inNumSamples);
+    void (*func)(UnaryOpUGen * unit, int inNumSamples);
 
     if (BUFLENGTH == 64) {
         switch (unit->mSpecialIndex) {


### PR DESCRIPTION
EDIT: seemed more sensible to close this one and re-open from another branch.

<details><summary>deleted from older PR description</summary>
<p>

This PR adds three methods.
(I've gone ahead and started down this route, but I don't mind reverting it if necessary.)

The other suggestions included in the doc are:
- `divide`: The name is in analogy to trunc/truncate, where div/trunc are the supercollider versions, divide and truncate the "standard" versions. 

- `roundDown` (optional alias for the old trunc; `roundUp` exists already). This is maybe unnecessary but it is probably a better name for what sc's trunc actually does. 

Since these haven't been discussed it would be cool to have some kind of feedback whether this is a good idea or not. If not, I can limit this PR to trunc/ate.
At any rate these are additions, hence should be non-breaking.

TODO:
Implementation. The "dones" are tentative, in that I expect to have to do some debugging and probably overlooked a lot of things.
If I understand correctly how this works, I'Il need to:
- add methods in the class library (done)
- define the primitive in `PyrPrimitive.cpp` (done)
- assign the opcode in `PyrMathOps.cpp` (done)
- (and possibly define a `sc_truncate` in `SC_InlineBinaryOp.h`, if it's to be in analogy to sc's current `trunc`. )
- UGens  (done)
- and then actually get it to build and work... Currently, all the builds with ctest fail, etc. 

</p>
</details> 
