### PR TITLE
FreqScope singleton behavior: change test in *new so instance can be accessed after creation

### DIFF
--- a/HelpSource/Classes/FreqScope.schelp
+++ b/HelpSource/Classes/FreqScope.schelp
@@ -29,8 +29,13 @@ argument:: bgColor
 An instance of link::Classes/Color::. The background color of the scope.
 argument:: server
 the server whose buses to show on scope.
-discussion::
-Example:
+
+method:: getInstance
+Returns the (singleton) instance of the FreqScope.
+
+
+subsection:: Usage example
+
 code::
 s.boot;
 
@@ -48,6 +53,12 @@ FreqScope.new(400, 200, 0, server: s);
 
 // all harmonics
 { Blip.ar(200, Line.kr(1, 100, 10), 0.2) }.play(s);
+
+// access the FreqScopeView object to set properties of the Qt Object:
+FreqScope.getInstance	// get the FreqScope instance
+	.scope				// and its FreqScopeView
+	.setProperty(\updateInterval, 1000)
+	// set updateInterval to 1000 ms because of reasons
 ::
 
 subsection:: Subclassing and Internal Methods
@@ -56,6 +67,8 @@ The following methods are usually not used directly or are called by a primitive
 
 method:: scopeOpen
 Returns a link::Classes/Boolean::, whether the scope is open.
+
+private:: instance
 
 InstanceMethods::
 

--- a/SCClassLibrary/Common/GUI/PlusGUI/Control/FreqScope.sc
+++ b/SCClassLibrary/Common/GUI/PlusGUI/Control/FreqScope.sc
@@ -333,163 +333,163 @@ FreqScope {
 				"Only one instance of FreqScope can exist simultenously.\n"
 				"To access the current instance, use:\n\n"
 				"FreqScope.getInstance\n\n"
-			)
-		} {
-			//make scope
+			);
+			^nil
+		}
+		//make scope
 
-			scopeColor = scopeColor ?? { Color.new255(255, 218, 000) };
+		scopeColor = scopeColor ?? { Color.new255(255, 218, 000) };
 
-			scopeOpen = true;
+		scopeOpen = true;
 
-			server = server ? Server.default;
+		server = server ? Server.default;
 
-			rect = Rect(0, 0, width, height);
-			pad = [30, 48, 14, 10]; // l,r,t,b
-			font = Font.monospace(9);
-			freqLabel = Array.newClear(12);
-			freqLabelDist = rect.width/(freqLabel.size-1);
-			dbLabel = Array.newClear(17);
-			dbLabelDist = rect.height/(dbLabel.size-1);
+		rect = Rect(0, 0, width, height);
+		pad = [30, 48, 14, 10]; // l,r,t,b
+		font = Font.monospace(9);
+		freqLabel = Array.newClear(12);
+		freqLabelDist = rect.width/(freqLabel.size-1);
+		dbLabel = Array.newClear(17);
+		dbLabelDist = rect.height/(dbLabel.size-1);
 
-			nyquistKHz = server.sampleRate;
-			if( (nyquistKHz == 0) || nyquistKHz.isNil, {
-				nyquistKHz = 22.05 // best guess?
-			},{
-				nyquistKHz = nyquistKHz * 0.0005;
-			});
+		nyquistKHz = server.sampleRate;
+		if( (nyquistKHz == 0) || nyquistKHz.isNil, {
+			nyquistKHz = 22.05 // best guess?
+		},{
+			nyquistKHz = nyquistKHz * 0.0005;
+		});
 
-			setFreqLabelVals = { arg mode, bufsize;
-				var kfreq, factor, halfSize;
+		setFreqLabelVals = { arg mode, bufsize;
+			var kfreq, factor, halfSize;
 
-				factor = 1/(freqLabel.size-1);
-				halfSize = bufsize * 0.5;
-
-				freqLabel.size.do({ arg i;
-					if(mode == 1, {
-						kfreq = (halfSize.pow(i * factor) - 1)/(halfSize-1) * nyquistKHz;
-					},{
-						kfreq = i * factor * nyquistKHz;
-					});
-
-					if(kfreq > 1.0, {
-						freqLabel[i].string_( kfreq.asString.keep(4) ++ "k" )
-					},{
-						freqLabel[i].string_( (kfreq*1000).asInteger.asString)
-					});
-				});
-			};
-
-			setDBLabelVals = { arg db;
-				dbLabel.size.do({ arg i;
-					dbLabel[i].string = (i * db/(dbLabel.size-1)).asInteger.neg.asString;
-				});
-			};
-
-			window = Window("Freq Analyzer", resizable: false)
-			.bounds_(rect.resizeBy(pad[0] + pad[1] + 4, pad[2] + pad[3] + 4))
-			.moveToBottom;
+			factor = 1/(freqLabel.size-1);
+			halfSize = bufsize * 0.5;
 
 			freqLabel.size.do({ arg i;
-				freqLabel[i] = StaticText(window, Rect(pad[0] - (freqLabelDist*0.5) + (i*freqLabelDist), pad[2] - 10, freqLabelDist, 10))
-					.font_(font)
-					.align_(\center)
-				;
-				StaticText(window, Rect(pad[0] + (i*freqLabelDist), pad[2], 1, rect.height))
-					.string_("")
-				;
+				if(mode == 1, {
+					kfreq = (halfSize.pow(i * factor) - 1)/(halfSize-1) * nyquistKHz;
+				},{
+					kfreq = i * factor * nyquistKHz;
+				});
+
+				if(kfreq > 1.0, {
+					freqLabel[i].string_( kfreq.asString.keep(4) ++ "k" )
+				},{
+					freqLabel[i].string_( (kfreq*1000).asInteger.asString)
+				});
 			});
-
-			dbLabel.size.do({ arg i;
-				dbLabel[i] = StaticText(window, Rect(0, pad[2] + (i*dbLabelDist), pad[0], 10))
-					.font_(font)
-					.align_(\left)
-				;
-				StaticText(window, Rect(pad[0], dbLabel[i].bounds.top, rect.width, 1))
-					.string_("")
-				;
-			});
-
-			scope = FreqScopeView(window, rect.moveBy(pad[0], pad[2]), server);
-			scope.xZoom_((scope.bufSize*0.25) / width);
-
-			setFreqLabelVals.value(scope.freqMode, 2048);
-			setDBLabelVals.value(scope.dbRange);
-
-			Button(window, Rect(pad[0] + rect.width, pad[2], pad[1], 16))
-				.states_([["stop", Color.white, Color.green(0.5)], ["start", Color.white, Color.red(0.5)]])
-				.action_({ arg view;
-					if(view.value == 0, {
-						scope.active_(true);
-					},{
-						scope.active_(false);
-					});
-				})
-				.font_(font)
-				.canFocus_(false)
-			;
-
-			StaticText(window, Rect(pad[0] + rect.width, pad[2]+20, pad[1], 10))
-				.string_("BusIn")
-				.font_(font)
-			;
-
-			NumberBox(window, Rect(pad[0] + rect.width, pad[2]+30, pad[1], 14))
-				.action_({ arg view;
-					view.value_(view.value.asInteger.clip(0, server.options.numAudioBusChannels));
-					scope.inBus_(view.value);
-				})
-				.value_(busNum)
-				.font_(font)
-			;
-
-			StaticText(window, Rect(pad[0] + rect.width, pad[2]+48, pad[1], 10))
-				.string_("FrqScl")
-				.font_(font)
-			;
-			PopUpMenu(window, Rect(pad[0] + rect.width, pad[2]+58, pad[1], 16))
-				.items_(["lin", "log"])
-				.action_({ arg view;
-					scope.freqMode_(view.value);
-					setFreqLabelVals.value(scope.freqMode, 2048);
-				})
-				.canFocus_(false)
-				.font_(font)
-				.valueAction_(1)
-			;
-
-			StaticText(window, Rect(pad[0] + rect.width, pad[2]+76, pad[1], 10))
-				.string_("dbCut")
-				.font_(font)
-			;
-			PopUpMenu(window, Rect(pad[0] + rect.width, pad[2]+86, pad[1], 16))
-				.items_(Array.series(12, 12, 12).collect({ arg item; item.asString }))
-				.action_({ arg view;
-					scope.dbRange_((view.value + 1) * 12);
-					setDBLabelVals.value(scope.dbRange);
-				})
-				.canFocus_(false)
-				.font_(font)
-				.value_(7)
-			;
-
-			scope
-				.inBus_(busNum)
-				.active_(true)
-				.style_(1)
-				.waveColors_([scopeColor.alpha_(1)])
-				.canFocus_(false)
-			;
-
-			if (bgColor.notNil) {
-				scope.background_(bgColor)
-			};
-
-			window.onClose_({
-				scope.kill;
-				scopeOpen = false;
-			}).front;
-			instance = super.newCopyArgs(scope, window);
-			^instance
 		};
+
+		setDBLabelVals = { arg db;
+			dbLabel.size.do({ arg i;
+				dbLabel[i].string = (i * db/(dbLabel.size-1)).asInteger.neg.asString;
+			});
+		};
+
+		window = Window("Freq Analyzer", resizable: false)
+		.bounds_(rect.resizeBy(pad[0] + pad[1] + 4, pad[2] + pad[3] + 4))
+		.moveToBottom;
+
+		freqLabel.size.do({ arg i;
+			freqLabel[i] = StaticText(window, Rect(pad[0] - (freqLabelDist*0.5) + (i*freqLabelDist), pad[2] - 10, freqLabelDist, 10))
+				.font_(font)
+				.align_(\center)
+			;
+			StaticText(window, Rect(pad[0] + (i*freqLabelDist), pad[2], 1, rect.height))
+				.string_("")
+			;
+		});
+
+		dbLabel.size.do({ arg i;
+			dbLabel[i] = StaticText(window, Rect(0, pad[2] + (i*dbLabelDist), pad[0], 10))
+				.font_(font)
+				.align_(\left)
+			;
+			StaticText(window, Rect(pad[0], dbLabel[i].bounds.top, rect.width, 1))
+				.string_("")
+			;
+		});
+
+		scope = FreqScopeView(window, rect.moveBy(pad[0], pad[2]), server);
+		scope.xZoom_((scope.bufSize*0.25) / width);
+
+		setFreqLabelVals.value(scope.freqMode, 2048);
+		setDBLabelVals.value(scope.dbRange);
+
+		Button(window, Rect(pad[0] + rect.width, pad[2], pad[1], 16))
+			.states_([["stop", Color.white, Color.green(0.5)], ["start", Color.white, Color.red(0.5)]])
+			.action_({ arg view;
+				if(view.value == 0, {
+					scope.active_(true);
+				},{
+					scope.active_(false);
+				});
+			})
+			.font_(font)
+			.canFocus_(false)
+		;
+
+		StaticText(window, Rect(pad[0] + rect.width, pad[2]+20, pad[1], 10))
+			.string_("BusIn")
+			.font_(font)
+		;
+
+		NumberBox(window, Rect(pad[0] + rect.width, pad[2]+30, pad[1], 14))
+			.action_({ arg view;
+				view.value_(view.value.asInteger.clip(0, server.options.numAudioBusChannels));
+				scope.inBus_(view.value);
+			})
+			.value_(busNum)
+			.font_(font)
+		;
+
+		StaticText(window, Rect(pad[0] + rect.width, pad[2]+48, pad[1], 10))
+			.string_("FrqScl")
+			.font_(font)
+		;
+		PopUpMenu(window, Rect(pad[0] + rect.width, pad[2]+58, pad[1], 16))
+			.items_(["lin", "log"])
+			.action_({ arg view;
+				scope.freqMode_(view.value);
+				setFreqLabelVals.value(scope.freqMode, 2048);
+			})
+			.canFocus_(false)
+			.font_(font)
+			.valueAction_(1)
+		;
+
+		StaticText(window, Rect(pad[0] + rect.width, pad[2]+76, pad[1], 10))
+			.string_("dbCut")
+			.font_(font)
+		;
+		PopUpMenu(window, Rect(pad[0] + rect.width, pad[2]+86, pad[1], 16))
+			.items_(Array.series(12, 12, 12).collect({ arg item; item.asString }))
+			.action_({ arg view;
+				scope.dbRange_((view.value + 1) * 12);
+				setDBLabelVals.value(scope.dbRange);
+			})
+			.canFocus_(false)
+			.font_(font)
+			.value_(7)
+		;
+
+		scope
+			.inBus_(busNum)
+			.active_(true)
+			.style_(1)
+			.waveColors_([scopeColor.alpha_(1)])
+			.canFocus_(false)
+		;
+
+		if (bgColor.notNil) {
+			scope.background_(bgColor)
+		};
+
+		window.onClose_({
+			scope.kill;
+			scopeOpen = false;
+		}).front;
+		instance = super.newCopyArgs(scope, window);
+		^instance
 	}
 }

--- a/SCClassLibrary/Common/GUI/PlusGUI/Control/FreqScope.sc
+++ b/SCClassLibrary/Common/GUI/PlusGUI/Control/FreqScope.sc
@@ -321,16 +321,6 @@ FreqScope {
 	*getInstance {
 		^instance
 	}
-
-	*newReplace { arg width=522, height=300, busNum=0, scopeColor, bgColor, server;
-		if (scopeOpen) { 
-			instance.window.close; 
-			instance.scope.kill;
-			scopeOpen = false 
-		};
-		instance = this.new(width, height, busNum, scopeColor, bgColor, server);
-		^instance
-	}
 	
 	*new { arg width=522, height=300, busNum=0, scopeColor, bgColor, server;
 		var rect, scope, window, pad, font, freqLabel, freqLabelDist, dbLabel, dbLabelDist;
@@ -343,10 +333,8 @@ FreqScope {
 				"Only one instance of FreqScope can exist simultenously.\n"
 				"To access the current instance, use:\n\n"
 				"FreqScope.getInstance\n\n"
-				"To replace the current instance, use\n\n"
-				"Freqscope.newReplace\n"
 			)
-		} { 
+		} {
 			//make scope
 
 			scopeColor = scopeColor ?? { Color.new255(255, 218, 000) };

--- a/SCClassLibrary/Common/GUI/PlusGUI/Control/FreqScope.sc
+++ b/SCClassLibrary/Common/GUI/PlusGUI/Control/FreqScope.sc
@@ -313,7 +313,8 @@ FreqScopeView {
 }
 
 FreqScope {
-	classvar <scopeOpen;
+	classvar <scopeOpen = false;
+	classvar singleInstance;
 
 	var <scope, <window;
 
@@ -322,7 +323,9 @@ FreqScope {
 		var setFreqLabelVals, setDBLabelVals;
 		var nyquistKHz;
 		busNum = busNum.asControlInput;
-		if(scopeOpen != true, { // block the stacking up of scope windows
+		if(scopeOpen) {
+			^singleInstance 
+		} { 
 			//make scope
 
 			scopeColor = scopeColor ?? { Color.new255(255, 218, 000) };
@@ -476,7 +479,8 @@ FreqScope {
 				scope.kill;
 				scopeOpen = false;
 			}).front;
-			^super.newCopyArgs(scope, window)
-		});
+			singleInstance = super.newCopyArgs(scope, window);
+			^singleInstance
+		};
 	}
 }

--- a/SCClassLibrary/Common/GUI/PlusGUI/Control/FreqScope.sc
+++ b/SCClassLibrary/Common/GUI/PlusGUI/Control/FreqScope.sc
@@ -314,17 +314,38 @@ FreqScopeView {
 
 FreqScope {
 	classvar <scopeOpen = false;
-	classvar singleInstance;
+	classvar instance; //singleton
 
 	var <scope, <window;
 
+	*getInstance {
+		^instance
+	}
+
+	*newReplace { arg width=522, height=300, busNum=0, scopeColor, bgColor, server;
+		if (scopeOpen) { 
+			instance.window.close; 
+			instance.scope.kill;
+			scopeOpen = false 
+		};
+		instance = this.new(width, height, busNum, scopeColor, bgColor, server);
+		^instance
+	}
+	
 	*new { arg width=522, height=300, busNum=0, scopeColor, bgColor, server;
 		var rect, scope, window, pad, font, freqLabel, freqLabelDist, dbLabel, dbLabelDist;
 		var setFreqLabelVals, setDBLabelVals;
 		var nyquistKHz;
 		busNum = busNum.asControlInput;
-		if(scopeOpen) {
-			^singleInstance 
+		if(scopeOpen) { 
+			warn(
+				"FreqScope is already open.\n"
+				"Only one instance of FreqScope can exist simultenously.\n"
+				"To access the current instance, use:\n\n"
+				"FreqScope.getInstance\n\n"
+				"To replace the current instance, use\n\n"
+				"Freqscope.newReplace\n"
+			)
 		} { 
 			//make scope
 
@@ -479,8 +500,8 @@ FreqScope {
 				scope.kill;
 				scopeOpen = false;
 			}).front;
-			singleInstance = super.newCopyArgs(scope, window);
-			^singleInstance
+			instance = super.newCopyArgs(scope, window);
+			^instance
 		};
 	}
 }

--- a/SCClassLibrary/Common/GUI/PlusGUI/Control/FreqScope.sc
+++ b/SCClassLibrary/Common/GUI/PlusGUI/Control/FreqScope.sc
@@ -335,7 +335,7 @@ FreqScope {
 				"FreqScope.getInstance\n\n"
 			);
 			^nil
-		}
+		};
 		//make scope
 
 		scopeColor = scopeColor ?? { Color.new255(255, 218, 000) };


### PR DESCRIPTION
newest update on this PR, 20/02/2026:

Keeping this PR minimal for now; might do more FreqScope changes later on but that seems more complicated, one would have to refactor the new method quite a bit. 

So the actual changes are:

1.  classvar `instance`
2. `getInstance` method 
3. `new` posts a warning when `scopeOpen = true`.


FreqScope is meant to only have one instance, but after creation of that one instance, there is no way to programmatically  access that instance if it hasn't been assigned to something when it was first instantiated. This PR  changes the *new method to ~~return the single instance not only when it is created, but also if it has already been created earlier~~ post a warning that points user to the getInstance method if an instance of FreqScope already exists.

## Purpose and Motivation
Problem:
```
Freqscope() // open the freqscope but forget to assign it (or its instance vars)
// try to assign it now:
f = Freqscope();
f; // nil
```
In these cases, one has to restart the interpreter to be able to access the scope.  (Maybe there are other ways, but they're not terribly obvious to me).



## Types of changes

See code:
Previously *new checked whether classvar `scopeOpen` is True, and if it was, did nothing. If it was not true, it built the instance, returned it, and set `scopeOpen` to True.
 That's good for not making lots of new Freqscopes, but bad for the above cases. 

<details><summary>questions resolved in discussion</summary>
<p>


With this PR, this is changed to simply return the instance if `scopeOpen` is true. This won't create new freqscopes but lets you use the .new method to access the existing instance.

## Questions (that of course occurred to me only after the fact)

Is it even reasonable to use the *new method (i.e., constructor) for this (i.e., returning the isntance if it exists) ? 

I checked with the [wiki](https://en.wikipedia.org/wiki/Singleton_pattern) article on Singletons, and the examples in there have public .getInstance methods that call the private constructors if necessary and otherwise return the instance. This is a bit like what *new is doing in the present case, except it's called `new` rather than `getInstance`.

Should the `classvar singleInstance` have a getter method (i.e., be `classvar <singleInstance`)?

</p>
</details> 


