### PR TITLE
QuarksGui:  refresh displayed version list after check for update (#6589 solved)

### DIFF
--- a/SCClassLibrary/Common/Quarks/GUI/QuarksGui.sc
+++ b/SCClassLibrary/Common/Quarks/GUI/QuarksGui.sc
@@ -640,22 +640,18 @@ QuarkRowView {
 	refreshDirectoryView {
 	var selectedPath, newQuark;
 
-	// remember what is selected in detail view (if any)
 	selectedPath = detailView.model.notNil.if({ detailView.model.localPath }, { nil });
 
-	// hard reset like closing + reopening the window
 	treeView.clear;
 	quarkRows = Dictionary.new;
 	initialized = false;
 
-	// rebuild rows from the updated model directory
 	this.update;
 
-	// restore selection so detail view + Versions tree rebuilds too
 	if(selectedPath.notNil) {
 		newQuark = model.all.detect({ |q| q.localPath == selectedPath });
 		if(newQuark.notNil) {
-			detailView.model = newQuark; // triggers detailView.update via model_
+			detailView.model = newQuark; 
 		} {
 			detailView.model = nil;
 		};

--- a/SCClassLibrary/Common/Quarks/GUI/QuarksGui.sc
+++ b/SCClassLibrary/Common/Quarks/GUI/QuarksGui.sc
@@ -628,10 +628,7 @@ QuarkRowView {
 		isInstalled = quark.isInstalled;
 		btn.value = isInstalled.binaryValue;
 
-		// this column has invisible text
-		// its used to sort the rows so that installed quarks are at the top
 		treeItem.setString(0, isInstalled.if("Y", { quark.isDownloaded.if("N", "") }));
-		// 1 is the install button. its not possible to sort by this column
 		treeItem.setString(2, quark.name ? "");
 		treeItem.setString(3, (quark.version ? "").asString);
 		treeItem.setString(4, (quark.summary ? "").replace(Char.nl.asString," ").replace(Char.tab.asString, ""));

--- a/SCClassLibrary/Common/Quarks/GUI/QuarksGui.sc
+++ b/SCClassLibrary/Common/Quarks/GUI/QuarksGui.sc
@@ -49,7 +49,7 @@ QuarksGui {
 				this.checkForUpdates({
 					treeView.enabled = true;
 					btnUpdateDirectory.value = 0;
-					this.update;
+					this.refreshDirectoryView;
 					this.setMsg("Directory has been updated.", \success);
 				}, {
 					treeView.enabled = true;
@@ -636,4 +636,30 @@ QuarkRowView {
 		treeItem.setString(3, (quark.version ? "").asString);
 		treeItem.setString(4, (quark.summary ? "").replace(Char.nl.asString," ").replace(Char.tab.asString, ""));
 	}
+
+	refreshDirectoryView {
+	var selectedPath, newQuark;
+
+	// remember what is selected in detail view (if any)
+	selectedPath = detailView.model.notNil.if({ detailView.model.localPath }, { nil });
+
+	// hard reset like closing + reopening the window
+	treeView.clear;
+	quarkRows = Dictionary.new;
+	initialized = false;
+
+	// rebuild rows from the updated model directory
+	this.update;
+
+	// restore selection so detail view + Versions tree rebuilds too
+	if(selectedPath.notNil) {
+		newQuark = model.all.detect({ |q| q.localPath == selectedPath });
+		if(newQuark.notNil) {
+			detailView.model = newQuark; // triggers detailView.update via model_
+		} {
+			detailView.model = nil;
+		};
+	};
+}
+
 }


### PR DESCRIPTION
Issue (#6589):
After running "Check for updates", the Quarks GUI updated the directory data but did not refresh the displayed version list for the currently selected quark. The updated versions only appeared after closing and reopening the Quarks window.

Changes:
Added a refreshDirectoryView method to QuarksGui. This method: Clears the TreeView, resets the internal quarkRows cache, rebuilds the GUI state, restores the previously selected quark. The second change was replaced this.update with this.refreshDirectoryView after a successful directory update.