### PR TITLE
Fix no discard warnings in slot conversions

### DIFF
--- a/QtCollider/primitives/prim_QObject.cpp
+++ b/QtCollider/primitives/prim_QObject.cpp
@@ -349,7 +349,8 @@ QC_LANG_PRIMITIVE(QObject_SetEventHandler, 4, PyrSlot* r, PyrSlot* a, VMGlobals*
         return errWrongType;
     int eventType = QtCollider::get(a + 0);
     PyrSymbol* method = 0;
-    slotSymbolVal(a + 1, &method);
+    if (slotSymbolVal(a + 1, &method))
+        assert(false);
     Synchronicity sync = IsTrue(a + 2) ? Synchronous : Asynchronous;
     bool enabled = IsTrue(a + 3);
 

--- a/QtCollider/type_codec.cpp
+++ b/QtCollider/type_codec.cpp
@@ -139,8 +139,10 @@ void TypeCodec<QRectF>::write(PyrSlot* slot, const QRectF& r) {
 QSizeF TypeCodec<QSizeF>::read(PyrSlot* slot) {
     PyrSlot* slots = slotRawObject(slot)->slots;
     float w = 0.f, h = 0.f;
-    slotFloatVal(slots + 0, &w);
-    slotFloatVal(slots + 1, &h);
+    if (slotFloatVal(slots + 0, &w))
+        assert(false);
+    if (slotFloatVal(slots + 1, &h))
+        assert(false);
 
     return QSizeF(w, h);
 }
@@ -168,10 +170,14 @@ inline QColor asColor(PyrObject* obj) {
 
     float r, g, b, a;
     r = g = b = a = 0.f;
-    slotFloatVal(slots + 0, &r);
-    slotFloatVal(slots + 1, &g);
-    slotFloatVal(slots + 2, &b);
-    slotFloatVal(slots + 3, &a);
+    if (slotFloatVal(slots + 0, &r))
+        assert(false);
+    if (slotFloatVal(slots + 1, &g))
+        assert(false);
+    if (slotFloatVal(slots + 2, &b))
+        assert(false);
+    if (slotFloatVal(slots + 3, &a))
+        assert(false);
     return QColor(r * 255, g * 255, b * 255, a * 255);
 }
 

--- a/QtCollider/type_codec.hpp
+++ b/QtCollider/type_codec.hpp
@@ -138,7 +138,8 @@ template <> struct TypeCodec<float> {
 template <> struct TypeCodec<double> {
     static double read(PyrSlot* slot) {
         double d;
-        slotVal(slot, &d);
+        if (slotVal(slot, &d))
+            assert(false);
         return d;
     }
 

--- a/lang/LangPrimSource/PyrFilePrim.cpp
+++ b/lang/LangPrimSource/PyrFilePrim.cpp
@@ -1709,8 +1709,10 @@ int prSFOpenWrite(struct VMGlobals* g, int numArgsPushed) {
     if (error)
         return errFailed;
     // slotIntVal(slotRawObject(a)->slots + 3, &info.frames);
-    slotIntVal(slotRawObject(a)->slots + 4, &info.channels);
-    slotIntVal(slotRawObject(a)->slots + 5, &info.samplerate);
+    if (slotIntVal(slotRawObject(a)->slots + 4, &info.channels))
+        assert(false);
+    if (slotIntVal(slotRawObject(a)->slots + 5, &info.samplerate))
+        assert(false);
 
     file = sndfileOpenFromCStr(filename, SFM_WRITE, &info);
 

--- a/lang/LangPrimSource/SC_AudioDevicePrim.cpp
+++ b/lang/LangPrimSource/SC_AudioDevicePrim.cpp
@@ -18,6 +18,7 @@
     Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
 */
 
+#include "PyrErrors.h"
 #if defined(SC_AUDIO_API_COREAUDIO)
 #    include <CoreAudio/AudioHardware.h>
 #elif defined(SC_AUDIO_API_PORTAUDIO)
@@ -180,8 +181,10 @@ int listDevices(VMGlobals* g, int type) {
 int prListAudioDevices(VMGlobals* g, int numArgsPushed) {
     int in = 0;
     int out = 0;
-    slotIntVal(g->sp, &out);
-    slotIntVal(g->sp - 1, &in);
+    if (slotIntVal(g->sp, &out))
+        assert(false);
+    if (slotIntVal(g->sp - 1, &in))
+        assert(false);
 
     int type;
     if (in && out)


### PR DESCRIPTION
This uses asserts as no error checking previously took place.

<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

Satisfy warning of discarding error values in slot conversion.

## Types of changes

<!-- Delete lines that don't apply -->

- minor change
- 
## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [ ] Code is tested
- [ ] All tests are passing
- [ ] Updated documentation
- [ ] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

