### PR TITLE
trunc(ate), div(ide): document behavior and implement "fixed" versions.

### DIFF
--- a/HelpSource/Classes/SimpleNumber.schelp
+++ b/HelpSource/Classes/SimpleNumber.schelp
@@ -41,7 +41,18 @@ method:: mod
 Modulo
 
 method:: div
-Integer Division
+Divide teletype::this:: by teletype::aNumber:: and rounds to next-lower integer.
+For positive integers strong::only::, this is equivalent to standard integer division.
+Warning::
+This is a non-standard implementation of integer division,
+which has been preserved in SuperCollider for backward compatibility reasons,
+and is equivalent to code::floor(this/aNumber)::.
+
+For standard integer division, use code::truncate(this/aNumber):: or link::#-divide::
+::
+
+method:: divide
+Standard integer division, divides teletype::this:: by teletype::aNumber:: and rounds towards 0.
 
 method:: **
 Exponentiation
@@ -71,7 +82,10 @@ method:: round
 Round to multiple of aNumber
 
 method:: roundUp
-Round up to a multiple of aNumber. For roundDown use link::Classes/SimpleNumber#-trunc#trunc::.
+Round up to a multiple of aNumber.
+
+method:: roundDown
+Round down to a multiple of aNumber. 
 
 method:: smallButNotZero
 Check if the value is closer to zero than a threshold, but not zero.
@@ -80,7 +94,20 @@ argument::thresh
 The threshold to use for comparison.
 
 method:: trunc
-Truncate to multiple of aNumber (e.g. it rounds numbers down to a multiple of aNumber).
+Round down to a multiple of teletype::aNumber::. (Alias of link::#-roundDown::)
+For positive integers strong::only::, this is equivalent to standard truncation.
+Warning::
+This is a non-standard implementation of truncation, 
+which has been preserved in SuperCollider for backward compatibility reasons.
+
+For standard truncation, use link::#-truncate::.
+::
+
+method:: truncate
+Removes digits after the decimal separator and returns an integer:
+code::
+-3.9.truncate == -3
+::
 
 method:: softRound
 Rounds the value to a multiple of strong::resolution::. By using strong::margin:: and strong::strength:: you can control which values will be rounded, and by how much.


### PR DESCRIPTION
Thought it would be better to reopen this on another branch. Basically waiting for instructions now.
<details><summary>The story so far
</summary>
<p>

As discussed in that other issue (#2378). 

`div` actually has a similar problem, but we did not discuss it explicitly.
(i.e., `a.div(b) == floor(a/b)` but is normally equivalent to `std::trunc(a/b)`).  

We had a little "vote" in https://github.com/supercollider/supercollider/issues/2378#issuecomment-3623515421, and there are now 2 votes for `truncate` and 0 for `trunc2` as a name for the "standard" method, though I recall that this was tied 2-2 as some point.
(That quorum is, uh, suboptimal, but what can ya do.) 

</p>
</details> 

#### I think I've now figured out how to do this but I do need some direction/decision by more experienced folks as to _what_ exactly to do.
We've agreed on non-breaking changes, i.e., only  **adding** things rather than changing interfaces (i.e., not simply "fixing" the existing trunc). So at any rate, the resulting solution should not break code written in sclang. So that doesn't need to be discussed. The question is really about the Server side only. 

There are two main options:
1. Simply **add** new, "fixed" UGens (truncate and divide)
2. **Replace** the respective operations with corrected ones, and reimplement the backward-compatible trunc on the class library side.

1 of course is simplest. It just seems a bit inelegant and adds more code. Sort of a shantytown approach.
2 replaces some code in the server and adds very little to the class library.  

For 2, there would be 2 options: 
- a) Internally rename the operations in question (i.e., opTUGenrunc becomes opTruncate), such that a .truncate method would  call a _Truncate primitive). 
- b) don't rename them, only correct the math. I think this could become confusing.

Within 1, two more questions:
- a) For `truncate`, the question is:
    - Should it be a unary or a binary op?
        -  if it is to be strictly analogous to sc's `trunc` , then it would a binary op, with two extra multiplications. (Sc's `trunc` is currently `std::floor(a/b) * b`; a binary op `truncate` would be `std::trunc(a/b) *b`. ) 
         -  if it is to behave like c-style `trunc`, then it would be unary. 
- b) Should the extra code for that UGen be in a separate file, or at the end of the respective naryOpUGens file?

I think that's roughly it.