### PR TITLE
docs: Expand Window.schelp

### DIFF
--- a/HelpSource/Classes/Window.schelp
+++ b/HelpSource/Classes/Window.schelp
@@ -366,6 +366,7 @@ v.background = Color.gray;
 t = TextView(v, Rect(10, 10, 80, 30));
 c = StaticText(x, Rect(90, 30, 50, 25));
 c.string = "test";
+x.front;
 )
 ::
 

--- a/HelpSource/Classes/Window.schelp
+++ b/HelpSource/Classes/Window.schelp
@@ -404,15 +404,15 @@ subsubsection:: Adjusting bounds from top-left
 To position a window relative to the top, subtract from the height.
 
 code::
-/* Hard‑coded example (using a fixed pixel offset): */
+/* Example that positions the window using a fixed pixel offset: */
 (
-x = Window("hard-coded position",
+x = Window("fixed-offset position"",
     Rect(100, Window.screenBounds.height - 200, 300, 100)
 );
 x.front;
 )
 
-/* Scaling avoids hard‑coded (fixed‑pixel) offsets: */
+/* Scaling the offset relative to the screen height: */
 (
 ~factor = 0; // 0: top, 1: bottom
 ~rectHeight = 100;

--- a/HelpSource/Classes/Window.schelp
+++ b/HelpSource/Classes/Window.schelp
@@ -336,7 +336,7 @@ w = Window.new("test");
 w.front;
 )
 
-/* Hard‑coded example (using a fixed pixel offset): */
+// Set window position using a fixed pixel offset:
 (
 w.bounds = Rect(100, 100, 400, 400); // 100 avoids collision with OS GUI elements.
 w.front;

--- a/HelpSource/Classes/Window.schelp
+++ b/HelpSource/Classes/Window.schelp
@@ -327,13 +327,13 @@ it is generally safer to scale positions relative to the screen or available are
 
 subsubsection:: Adjusting bounds from bottom-left
 
-Window coordinates use a bottom-left origin. The following examples show how to
+link::Classes/Window:: class coordinates use a bottom-left origin. The following examples show how to
 adjust bounds after creating a window.
 
 code::
 /* Create a window at the default position and size: */
 (
-w = Window("test");
+w = Window.new("test");
 w.front;
 )
 
@@ -341,7 +341,7 @@ w.front;
 w.bounds_(Rect(0, 0, 400, 400)).front; // May conflict with OS GUI elements at the bottom.
 
 (
-w.bounds = Rect(0, 100, 400, 400); // 100 avoids collision with OS GUI elements.
+w.bounds = Rect(100, 100, 400, 400); // 100 avoids collision with OS GUI elements.
 w.front;
 )
 
@@ -355,12 +355,35 @@ w.bounds_(Rect(0, Window.availableBounds.height * ~factor, 400, 400));
 
 (
 ~factor = 0.035; // 0: bottom, 1: top
-w.bounds_(Rect(0, Window.screenBounds.height * ~factor, 400, 400));
+w.bounds_(Rect(100, Window.screenBounds.height * ~factor, 400, 400));
 // Window.screenBounds includes the full display area.
 // Use this when OS GUI elements are hidden.
 )
 
 w.close;
+::
+
+note::
+The origin differs from the coordinate system used inside a link::Classes/View:: or link::Classes/Window:: class, which use a top-left origin:
+
+code::
+(
+x = Window("test", Rect(100, 100, 300, 100)); // origin: bottom-left
+
+b = Button(x, Rect(90, 0, 50, 25));           // origin: top-left
+v = View(x, Rect(0, 0, 100, 50));             // origin: top-left
+v.background = Color.gray;
+
+t = TextView(v, Rect(10, 10, 80, 30));        // origin: top-left
+
+c = StaticText(x, Rect(90, 30, 50, 25));      // origin: top-left
+c.string = "test";
+
+x.front;
+)
+
+x.close;
+::
 ::
 
 subsubsection:: Adjusting bounds from top-left
@@ -370,23 +393,32 @@ To position a window relative to the top, subtract from the height.
 code::
 /* Hard‑coded example (using a fixed pixel offset): */
 (
-x = Window.new("hard-coded position",
-Rect(100, Window.screenBounds.height - 200, 300, 100)
+x = Window("hard-coded position",
+    Rect(100, Window.screenBounds.height - 200, 300, 100)
 );
 x.front;
 )
 
 /* Scaling avoids hard‑coded (fixed‑pixel) offsets: */
 (
-var factor = 0; // 0: top, 1: bottom
-var rectHeight = 100;
-var titleHeight = 32; // The title bar height varies depending on OS and display setting.
-var normalizedPosition = Window.screenBounds.height * factor + rectHeight + titleHeight;
+~factor = 0; // 0: top, 1: bottom
+~rectHeight = 100;
+~titleHeight = 32; // The title bar height varies depending on OS and display setting.
+~screenHeight = Window.screenBounds.height;
+~normalizedOffset = ~screenHeight * ~factor + ~rectHeight + ~titleHeight;
 
-y = Window.new("scaled position",
-Rect(100, Window.screenBounds.height - normalizedPosition, 300, rectHeight)
+y = Window("scaled position",
+    Rect(100, ~screenHeight - ~normalizedOffset, 300, ~rectHeight)
 );
 y.front;
+)
+
+(
+~yHeight = y.bounds.height;
+~normalizedOffset  = ~screenHeight * 0.1 + ~yHeight + ~titleHeight;
+y.bounds_(
+	Rect(100, ~screenHeight - ~normalizedOffset, y.bounds.width, ~yHeight)
+).front
 )
 
 x.close;
@@ -401,8 +433,8 @@ around a point. Use code::Window.screenBounds:: when OS GUI elements are hidden.
 code::
 (
 w = Window("centered window",
-Rect.aboutPoint(Window.availableBounds.center, 200, 100)
-// Rect.aboutPoint(point: center, dx: halfWidth, dy: halfHeight)
+    Rect.aboutPoint(Window.availableBounds.center, 200, 100)
+    // Rect.aboutPoint(point: center, dx: halfWidth, dy: halfHeight)
 );
 w.front;
 )
@@ -418,8 +450,8 @@ edges of the available display area.
 code::
 (
 w = Window("window with margins",
-Window.availableBounds.insetBy(300, 200)
-// Rect.insetBy(h: hMargin, v: vMargin)
+    Window.availableBounds.insetBy(300, 200)
+    // Rect.insetBy(h: hMargin, v: vMargin)
 );
 // Use Window.screenBounds when OS GUI elements are hidden.
 w.front;

--- a/HelpSource/Classes/Window.schelp
+++ b/HelpSource/Classes/Window.schelp
@@ -321,9 +321,8 @@ w.front;
 
 subsection:: Setting Bounds
 
-When positioning windows, remember that screen sizes and available display areas
-vary across systems. Instead of using a fixed pixel offset (a hard‑coded value),
-it is generally safer to scale positions relative to the screen or available area.
+Because screen sizes vary, scaling window coordinates relative to the screen bounds can offer 
+flexibility when using your GUI on different systems.
 
 subsubsection:: Adjusting bounds from bottom-left
 
@@ -338,8 +337,6 @@ w.front;
 )
 
 /* Hard‑coded example (using a fixed pixel offset): */
-w.bounds_(Rect(0, 0, 400, 400)).front; // May conflict with OS GUI elements at the bottom.
-
 (
 w.bounds = Rect(100, 100, 400, 400); // 100 avoids collision with OS GUI elements.
 w.front;
@@ -348,14 +345,14 @@ w.front;
 /* Scaling avoids hard‑coded (fixed‑pixel) offsets: */
 (
 ~factor = 0.037; // 0: bottom, 1: top
-w.bounds_(Rect(0, Window.availableBounds.height * ~factor, 400, 400));
+w.bounds_(Rect(0, Window.availableBounds.height * ~factor, 400, 400)).front;
 // Window.availableBounds excludes menu bars (macOS, Linux) and taskbars (Windows).
 // Use this when OS GUI elements are visible.
 )
 
 (
 ~factor = 0.035; // 0: bottom, 1: top
-w.bounds_(Rect(100, Window.screenBounds.height * ~factor, 400, 400));
+w.bounds_(Rect(100, Window.screenBounds.height * ~factor, 400, 400)).front;
 // Window.screenBounds includes the full display area.
 // Use this when OS GUI elements are hidden.
 )

--- a/HelpSource/Classes/Window.schelp
+++ b/HelpSource/Classes/Window.schelp
@@ -351,7 +351,7 @@ y.front;
 
 code::
 /* Changing bounds after window creation */
-x.bounds_(Rect(100, 300, 300, 100));
+x.bounds_(Rect(100, 300, 300, 100)).front;
 // The second argument of Rect is named 'top', but for Window it represents
 // the distance from the screen's bottom-left origin — not from the top.
 // Note: this value (300) is the complement of the calculation above

--- a/HelpSource/Classes/Window.schelp
+++ b/HelpSource/Classes/Window.schelp
@@ -321,91 +321,111 @@ w.front;
 
 subsection:: Setting Bounds
 
-subsubsection:: Hard code examples
+When positioning windows, remember that screen sizes and available display areas
+vary across systems. Instead of using a fixed pixel offset (a hard‑coded value),
+it is generally safer to scale positions relative to the screen or available area.
 
-The following examples show how to set a window's position relative to the top of
-the display, but these hard-coded values may not be appropriate across various
-screen resolutions. (To get a safer result, see link::#Flexible code examples::.)
-Note also the difference between code::Window.screenBounds:: and
-code::Window.availableBounds:::
+subsubsection:: Adjusting bounds from bottom-left
+
+Window coordinates use a bottom-left origin. The following examples show how to
+adjust bounds after creating a window.
 
 code::
-/* Use screenBounds to place a window relative to the top of the display */
+/* Create a window at the default position and size: */
 (
-x = Window.new("test", Rect(100, Window.screenBounds.height - 300, 300, 100));
+w = Window("test");
+w.front;
+)
+
+/* Hard‑coded example (using a fixed pixel offset): */
+w.bounds_(Rect(0, 0, 400, 400)).front; // May conflict with OS GUI elements at the bottom.
+
+(
+w.bounds = Rect(0, 100, 400, 400); // 100 avoids collision with OS GUI elements.
+w.front;
+)
+
+/* Scaling avoids hard‑coded (fixed‑pixel) offsets: */
+(
+~factor = 0.037; // 0: bottom, 1: top
+w.bounds_(Rect(0, Window.availableBounds.height * ~factor, 400, 400));
+// Window.availableBounds excludes menu bars (macOS, Linux) and taskbars (Windows).
+// Use this when OS GUI elements are visible.
+)
+
+(
+~factor = 0.035; // 0: bottom, 1: top
+w.bounds_(Rect(0, Window.screenBounds.height * ~factor, 400, 400));
+// Window.screenBounds includes the full display area.
+// Use this when OS GUI elements are hidden.
+)
+
+w.close;
+::
+
+subsubsection:: Adjusting bounds from top-left
+
+To position a window relative to the top, subtract from the height.
+
+code::
+/* Hard‑coded example (using a fixed pixel offset): */
+(
+x = Window.new("hard-coded position",
+Rect(100, Window.screenBounds.height - 200, 300, 100)
+);
 x.front;
 )
-// Window positions use screen coordinates measured from a bottom-left origin.
-// To place a window near the top, subtract an offset from Window.screenBounds.height
-// (300 is chosen arbitrarily here to illustrate the concept).
 
-/* Using availableBounds instead accounts for taskbars/menu bars */
+/* Scaling avoids hard‑coded (fixed‑pixel) offsets: */
 (
-y = Window.new("test", Rect(100, Window.availableBounds.height - 300, 300, 100));
+var factor = 0; // 0: top, 1: bottom
+var rectHeight = 100;
+var titleHeight = 32; // The title bar height varies depending on OS and display setting.
+var normalizedPosition = Window.screenBounds.height * factor + rectHeight + titleHeight;
+
+y = Window.new("scaled position",
+Rect(100, Window.screenBounds.height - normalizedPosition, 300, rectHeight)
+);
 y.front;
 )
-// Window.availableBounds.height may differ from Window.screenBounds.height
-// depending on the OS (e.g., macOS menu bar, Windows taskbar).
-// This makes the top margin more accurate in practice.
+
+x.close;
+y.close;
 ::
 
-code::
-/* Changing bounds after window creation */
-x.bounds_(Rect(100, 300, 300, 100)).front;
-// The second argument of Rect is named 'top', but for Window it represents
-// the distance from the screen's bottom-left origin — not from the top.
-// Note: this value (300) is the complement of the calculation above
-// (screenBounds.height - 300), placing the window at the same vertical position.
+subsubsection:: Centering a window
 
-// This bottom-left origin differs from the coordinate system used within a View and a
-// Window, where the origin is at the top-left:
+Use code::Rect.aboutPoint(point, dx, dy):: to center a window
+around a point. Use code::Window.screenBounds:: when OS GUI elements are hidden.
+
+code::
 (
-b = Button(x, Rect(90, 0, 50, 25));
-v = View(x, Rect(0, 0, 100, 50));
-v.background = Color.gray;
-t = TextView(v, Rect(10, 10, 80, 30));
-c = StaticText(x, Rect(90, 30, 50, 25));
-c.string = "test";
-x.front;
+w = Window("centered window",
+Rect.aboutPoint(Window.availableBounds.center, 200, 100)
+// Rect.aboutPoint(point: center, dx: halfWidth, dy: halfHeight)
+);
+w.front;
 )
+
+w.close;
 ::
 
-subsubsection:: Flexible code examples
+subsubsection:: Applying margins
+
+Use code::Rect.insetBy(h, v):: to apply consistent margins from the
+edges of the available display area.
 
 code::
-/* Centering a window using Rect.aboutPoint */
 (
-w = Window("centered window using screenBounds",
-    Rect.aboutPoint(Window.screenBounds.center, 200, 100));
+w = Window("window with margins",
+Window.availableBounds.insetBy(300, 200)
+// Rect.insetBy(h: hMargin, v: vMargin)
+);
+// Use Window.screenBounds when OS GUI elements are hidden.
 w.front;
 )
-// Rect.aboutPoint takes a center point and half-extents (width/2, height/2),
-// expanding outward to produce a Rect — an intuitive way to center a window.
 
-// However, Window.availableBounds is often safer as it excludes taskbars/menu bars:
-(
-w = Window("centered window using availableBounds",
-    Rect.aboutPoint(Window.availableBounds.center, 200, 100));
-w.front;
-)
-::
-
-code::
-/* Using insetBy for padding-based window positioning */
-(
-w = Window("window with margins using screenBounds",
-    Window.screenBounds.insetBy(300, 100));
-w.front;
-)
-// insetBy shrinks a Rect by the given amounts on each side,
-// creating consistent margins from the screen edges regardless of resolution.
-
-// Using availableBounds instead avoids overlap with taskbars/menu bars:
-(
-w = Window("window with margins using availableBounds",
-    Window.availableBounds.insetBy(300, 100));
-w.front;
-)
+w.close;
 ::
 
 

--- a/HelpSource/Classes/Window.schelp
+++ b/HelpSource/Classes/Window.schelp
@@ -321,13 +321,11 @@ w.front;
 
 subsection:: Setting Bounds
 
-Because screen sizes vary, scaling window coordinates relative to the screen bounds can offer 
-flexibility when using your GUI on different systems.
+Because screen sizes vary, scaling window coordinates relative to the screen bounds can offer flexibility when using your GUI on different systems.
 
 subsubsection:: Adjusting bounds from bottom-left
 
-link::Classes/Window:: class coordinates use a bottom-left origin. The following examples show how to
-adjust bounds after creating a window.
+link::Classes/Window:: class coordinates use a bottom-left origin. The following examples show how to adjust bounds after creating a window.
 
 code::
 /* Create a window at the default position and size: */
@@ -350,6 +348,24 @@ w.bounds_(Rect(0, Window.availableBounds.height * ~factor, 400, 400)).front;
 // Use this when OS GUI elements are visible.
 )
 
+// The same approach can also be extended to all bounds values:
+(
+var b = Window.availableBounds;
+var x = b.left + (b.width * 0.0);
+var y = b.bottom + (b.height * 0.037);
+var width = b.width * 0.3;
+var height = b.height * 0.3;
+w.bounds_(Rect(x, y, width, height)).front;
+)
+
+// The same can also be written more compactly:
+(
+~factors = [0, 0.037, 0.3, 0.3]; // fractions of respective dimensions
+~bds = Window.availableBounds.asArray[[2, 3, 2, 3]];
+w.bounds_(Rect(*(~factors * ~bds))).front;
+)
+
+// Set window position (and size) with respect to full display bounds:
 (
 ~factor = 0.035; // 0: bottom, 1: top
 w.bounds_(Rect(100, Window.screenBounds.height * ~factor, 400, 400)).front;
@@ -424,14 +440,12 @@ y.close;
 
 subsubsection:: Centering a window
 
-Use code::Rect.aboutPoint(point, dx, dy):: to center a window
-around a point. Use code::Window.screenBounds:: when OS GUI elements are hidden.
+Use code::Rect.aboutPoint(point, dx, dy):: to center a window around a point. Use code::Window.screenBounds:: when OS GUI elements are hidden.
 
 code::
 (
 w = Window("centered window",
     Rect.aboutPoint(Window.availableBounds.center, 200, 100)
-    // Rect.aboutPoint(point: center, dx: halfWidth, dy: halfHeight)
 );
 w.front;
 )
@@ -441,14 +455,12 @@ w.close;
 
 subsubsection:: Applying margins
 
-Use code::Rect.insetBy(h, v):: to apply consistent margins from the
-edges of the available display area.
+Use code::Rect.insetBy(h, v):: to apply consistent margins from the edges of the available display area.
 
 code::
 (
 w = Window("window with margins",
     Window.availableBounds.insetBy(300, 200)
-    // Rect.insetBy(h: hMargin, v: vMargin)
 );
 // Use Window.screenBounds when OS GUI elements are hidden.
 w.front;

--- a/HelpSource/Classes/Window.schelp
+++ b/HelpSource/Classes/Window.schelp
@@ -320,15 +320,90 @@ w.front;
 
 subsection:: Setting Bounds
 
-code::
-// use screenbounds for precise placement from the top
-(
-x = Window.new("test", Rect(100, Window.screenBounds.height-180, 300, 100)); x.front;
-)
+subsubsection:: Hard code examples
 
-// bounds.top refers to the bottom edge of the window,
-// measured from the bottom of the screen. Different than in View.
-x.bounds_(Rect(100, 400, 300, 300));
+The following examples show how to set a window's position relative to the top of
+the display, but these hard-coded values may not be appropriate across various
+screen resolutions. (To get a safer result, see link::#Flexible code examples::.)
+Note also the difference between code::Window.screenBounds:: and
+code::Window.availableBounds:::
+
+code::
+/* Use screenBounds to place a window relative to the top of the display */
+(
+x = Window.new("test", Rect(100, Window.screenBounds.height - 300, 300, 100));
+x.front;
+)
+// Window positions use screen coordinates measured from a bottom-left origin.
+// To place a window near the top, subtract an offset from Window.screenBounds.height
+// (300 is chosen arbitrarily here to illustrate the concept).
+
+/* Using availableBounds instead accounts for taskbars/menu bars */
+(
+y = Window.new("test", Rect(100, Window.availableBounds.height - 300, 300, 100));
+y.front;
+)
+// Window.availableBounds.height may differ from Window.screenBounds.height
+// depending on the OS (e.g., macOS menu bar, Windows taskbar).
+// This makes the top margin more accurate in practice.
+::
+
+code::
+/* Changing bounds after window creation */
+x.bounds_(Rect(100, 300, 300, 100));
+// The second argument of Rect is named 'top', but for Window it represents
+// the distance from the screen's bottom-left origin — not from the top.
+// Note: this value (300) is the complement of the calculation above
+// (screenBounds.height - 300), placing the window at the same vertical position.
+
+// This bottom-left origin differs from the coordinate system used within a View and a
+// Window, where the origin is at the top-left:
+(
+b = Button(x, Rect(90, 0, 50, 25));
+v = View(x, Rect(0, 0, 100, 50));
+v.background = Color.gray;
+t = TextView(v, Rect(10, 10, 80, 30));
+c = StaticText(x, Rect(90, 30, 50, 25));
+c.string = "test";
+)
+::
+
+subsubsection:: Flexible code examples
+
+code::
+/* Centering a window using Rect.aboutPoint */
+(
+w = Window("centered window using screenBounds",
+    Rect.aboutPoint(Window.screenBounds.center, 200, 100));
+w.front;
+)
+// Rect.aboutPoint takes a center point and half-extents (width/2, height/2),
+// expanding outward to produce a Rect — an intuitive way to center a window.
+
+// However, Window.availableBounds is often safer as it excludes taskbars/menu bars:
+(
+w = Window("centered window using availableBounds",
+    Rect.aboutPoint(Window.availableBounds.center, 200, 100));
+w.front;
+)
+::
+
+code::
+/* Using insetBy for padding-based window positioning */
+(
+w = Window("window with margins using screenBounds",
+    Window.screenBounds.insetBy(300, 100));
+w.front;
+)
+// insetBy shrinks a Rect by the given amounts on each side,
+// creating consistent margins from the screen edges regardless of resolution.
+
+// Using availableBounds instead avoids overlap with taskbars/menu bars:
+(
+w = Window("window with margins using availableBounds",
+    Window.availableBounds.insetBy(300, 100));
+w.front;
+)
 ::
 
 

--- a/HelpSource/Classes/Window.schelp
+++ b/HelpSource/Classes/Window.schelp
@@ -41,6 +41,7 @@ METHOD:: new
 		note::
 			The default position may vary depending on screen resolution, platform, and operating system settings.
 			::
+		See link::#Setting Bounds::.
 	argument:: resizable
 		A Boolean indicating whether the window is resizable by the user.
 		The default is code::true::.

--- a/HelpSource/Classes/Window.schelp
+++ b/HelpSource/Classes/Window.schelp
@@ -342,7 +342,7 @@ w.bounds = Rect(100, 100, 400, 400); // 100 avoids collision with OS GUI element
 w.front;
 )
 
-/* Scaling avoids hard‑coded (fixed‑pixel) offsets: */
+// Set window position (and size) with respect to available pixels in display's resolution:
 (
 ~factor = 0.037; // 0: bottom, 1: top
 w.bounds_(Rect(0, Window.availableBounds.height * ~factor, 400, 400)).front;


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->
This PR enhances the SuperCollider `Window.schelp` help documentation by adding comprehensive examples for setting window bounds.

Window bounds configuration is a common source of confusion for beginners, particularly the distinction between screen-relative and window-relative coordinate systems. This PR addresses that issue by providing detailed, well-structured examples with clear explanations.

The additions include:
- Hard-coded examples demonstrating direct coordinate usage and the difference between `Window.screenBounds` and `Window.availableBounds`
- Flexible examples showcasing practical methods such as `Rect.aboutPoint`, `insetBy`, and centre-point calculations
- Comparative explanations of coordinate system origins (bottom-left for windows vs. top-left for views)

These examples serve as practical reference material, enabling users to write more robust and maintainable code for window positioning across different screen resolutions and operating systems.
 
## Types of changes

<!-- Delete lines that don't apply -->

- Documentation

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->