### PR TITLE
sclang: delete implicit casting in slot constructor

### DIFF
--- a/lang/LangPrimSource/PyrPrimitive.cpp
+++ b/lang/LangPrimSource/PyrPrimitive.cpp
@@ -2727,7 +2727,7 @@ void switchToThread(VMGlobals* g, PyrThread* newthread, int oldstate, int* numAr
     SetRaw(&newthread->sp, (void*)nullptr);
     SetNil(&newthread->receiver);
 
-    SetRaw(&newthread->state, tRunning);
+    SetRaw(&newthread->state, static_cast<int>(tRunning));
 
 
     // set new environment
@@ -3092,7 +3092,7 @@ int prRoutineReset(struct VMGlobals* g, int numArgsPushed) {
     state = slotRawInt(&thread->state);
     // post("->prRoutineReset %d\n", state);
     if (state == tSuspended) {
-        SetRaw(&thread->state, tInit);
+        SetRaw(&thread->state, static_cast<int>(tInit));
         slotRawObject(&thread->stack)->size = 0;
         SetNil(&thread->method);
         SetNil(&thread->block);
@@ -3104,7 +3104,7 @@ int prRoutineReset(struct VMGlobals* g, int numArgsPushed) {
         SetRaw(&thread->numpop, 0);
         SetNil(&thread->parent);
     } else if (state == tDone) {
-        SetRaw(&thread->state, tInit);
+        SetRaw(&thread->state, static_cast<int>(tInit));
         slotRawObject(&thread->stack)->size = 0;
         SetNil(&thread->method);
         SetNil(&thread->block);
@@ -3143,7 +3143,7 @@ int prRoutineStop(struct VMGlobals* g, int numArgsPushed) {
 
     if (state == tSuspended || state == tInit) {
         SetNil(&g->thread->terminalValue);
-        SetRaw(&thread->state, tDone);
+        SetRaw(&thread->state, static_cast<int>(tDone));
         slotRawObject(&thread->stack)->size = 0;
     } else if (state == tDone) {
         // do nothing

--- a/lang/LangSource/PyrObject.h
+++ b/lang/LangSource/PyrObject.h
@@ -24,75 +24,13 @@ PyrObject represents the structure of all SC Objects.
 */
 
 #pragma once
+#include "PyrObjectHdr.h"
 
 #include "PyrSlot.h"
 
 #include <vector>
 #include <cstdint>
 
-/* special gc colors */
-enum {
-    obj_permanent = 1, // sent to gc->New as a flag
-    obj_gcmarker = 2 // gc treadmill marker
-};
-
-/* obj flag fields */
-enum { obj_inaccessible = 4, obj_immutable = 16, obj_marked = 128 };
-
-/* format types : */
-enum {
-    obj_notindexed,
-    obj_slot,
-    obj_double,
-    obj_float,
-    obj_int32,
-    obj_int16,
-    obj_int8,
-    obj_char,
-    obj_symbol,
-
-    NUMOBJFORMATS
-};
-
-
-/*
-    PyrObjectHdr : object header fields
-    prev, next : pointers in the GC treadmill
-    classptr : pointer to the object's class
-    size : number of slots or indexable elements.
-
-    obj_format : what kind of data this object holds
-    obj_sizeclass : power of two size class of the object
-    obj_flags :
-        immutable : set if object may not be updated.
-        finalize : set if object requires finalization.
-        marked : used by garbage collector debug sanity check. may be used by primitives but must be cleared before
-   exiting primitive.
-   gc_color : GC color : black, grey, white, free, permanent
-   scratch1 : undefined value. may be used within primitives as a temporary scratch value.
-*/
-
-struct PyrObjectHdr {
-    struct PyrObjectHdr *prev, *next;
-    struct PyrClass* classptr;
-    int size;
-
-    unsigned char obj_format;
-    unsigned char obj_sizeclass;
-    unsigned char obj_flags;
-    unsigned char gc_color;
-
-    int scratch1;
-
-    int SizeClass() { return obj_sizeclass; }
-
-    void SetMark() { obj_flags |= obj_marked; }
-    void ClearMark() { obj_flags &= ~obj_marked; }
-    bool IsMarked() const { return obj_flags & obj_marked; }
-    bool IsPermanent() const { return gc_color == obj_permanent; }
-    bool IsImmutable() const { return obj_flags & obj_immutable; }
-    bool IsMutable() const { return !IsImmutable(); }
-};
 
 struct PyrObject : public PyrObjectHdr {
     PyrSlot slots[1];

--- a/lang/LangSource/PyrObjectHdr.h
+++ b/lang/LangSource/PyrObjectHdr.h
@@ -1,0 +1,67 @@
+
+#pragma once
+
+/* special gc colors */
+enum {
+    obj_permanent = 1, // sent to gc->New as a flag
+    obj_gcmarker = 2 // gc treadmill marker
+};
+
+/* obj flag fields */
+enum { obj_inaccessible = 4, obj_immutable = 16, obj_marked = 128 };
+
+/* format types : */
+enum {
+    obj_notindexed,
+    obj_slot,
+    obj_double,
+    obj_float,
+    obj_int32,
+    obj_int16,
+    obj_int8,
+    obj_char,
+    obj_symbol,
+
+    NUMOBJFORMATS
+};
+
+
+/*
+    PyrObject represents the structure of all SC Objects.
+    PyrObjectHdr : object header fields
+    prev, next : pointers in the GC treadmill
+    classptr : pointer to the object's class
+    size : number of slots or indexable elements.
+
+    obj_format : what kind of data this object holds
+    obj_sizeclass : power of two size class of the object
+    obj_flags :
+        immutable : set if object may not be updated.
+        finalize : set if object requires finalization.
+        marked : used by garbage collector debug sanity check. may be used by primitives but must be cleared before
+   exiting primitive.
+   gc_color : GC color : black, grey, white, free, permanent
+   scratch1 : undefined value. may be used within primitives as a temporary scratch value.
+*/
+
+struct PyrObjectHdr {
+    struct PyrObjectHdr *prev, *next;
+    struct PyrClass* classptr;
+    int size;
+
+    unsigned char obj_format;
+    unsigned char obj_sizeclass;
+    unsigned char obj_flags;
+    unsigned char gc_color;
+
+    int scratch1;
+
+    int SizeClass() { return obj_sizeclass; }
+
+    void SetMark() { obj_flags |= obj_marked; }
+    void ClearMark() { obj_flags &= ~obj_marked; }
+    bool IsMarked() const { return obj_flags & obj_marked; }
+    bool IsPermanent() const { return gc_color == obj_permanent; }
+    bool IsImmutable() const { return obj_flags & obj_immutable; }
+    bool IsMutable() const { return !IsImmutable(); }
+};

--- a/lang/LangSource/PyrSlot.h
+++ b/lang/LangSource/PyrSlot.h
@@ -335,26 +335,25 @@ public:
         return { PrivateTag(), Tags::charTag, static_cast<uint64_t>(details::bit_cast<uint8_t>(c)) };
     }
 
-    [[nodiscard]] inline static PyrSlot make(PyrObjectHdr* o) {
+    [[nodiscard]] inline static PyrSlot make(PyrObjectHdr* o) noexcept {
         return { PrivateTag(), Tags::objHdrTag, static_cast<uint64_t>(reinterpret_cast<uintptr_t>(o)) };
     }
-    [[nodiscard]] inline static PyrSlot make(PyrObjectHdr& o) {
+    [[nodiscard]] inline static PyrSlot make(PyrObjectHdr& o) noexcept {
         return { PrivateTag(), Tags::objHdrTag, static_cast<uint64_t>(reinterpret_cast<uintptr_t>(&o)) };
     }
-    [[nodiscard]] inline static PyrSlot make(PyrObjectHdr o) = delete;
 
-    [[nodiscard]] inline static PyrSlot make(PyrSymbol* o) {
+    [[nodiscard]] inline static PyrSlot make(PyrSymbol* o) noexcept {
         return { PrivateTag(), Tags::symTag, static_cast<uint64_t>(reinterpret_cast<uintptr_t>(o)) };
     }
-    [[nodiscard]] inline static PyrSlot make(PyrSymbol& o) {
+    [[nodiscard]] inline static PyrSlot make(PyrSymbol& o) noexcept {
         return { PrivateTag(), Tags::symTag, static_cast<uint64_t>(reinterpret_cast<uintptr_t>(&o)) };
     }
-    [[nodiscard]] inline static PyrSlot make(PyrSymbol o) = delete;
 
-    [[nodiscard]] inline static PyrSlot make(int32_t i) {
+    [[nodiscard]] inline static PyrSlot make(int32_t i) noexcept {
         return { PrivateTag(), Tags::intTag, static_cast<uint64_t>(details::bit_cast<uint32_t>(i)) };
     }
-    [[nodiscard]] inline static PyrSlot make(void* o) {
+    [[nodiscard]] inline static PyrSlot make(void* o) noexcept {
+        static_assert(sizeof(uintptr_t) <= sizeof(uint64_t)); // probably always true?
         return { PrivateTag(), Tags::ptrTag, static_cast<uint64_t>(reinterpret_cast<uintptr_t>(o)) };
     }
     [[nodiscard]] inline static PyrSlot make() noexcept { return {}; }
@@ -415,6 +414,8 @@ public:
         assert(isBoxed());
         if (isObjectHdr())
             return reinterpret_cast<T*>(u_objectHeader.getPtr());
+        // Previously, these values have all been used to mean nullptr. This is quite confusing, but would be a large
+        // breaking change that affected the langauge, so they remain.
         assert(isNil() || (isInt() && getInt() == 0) || (isDouble() && getDouble() == 0));
         return nullptr;
     }

--- a/lang/LangSource/PyrSlot.h
+++ b/lang/LangSource/PyrSlot.h
@@ -26,6 +26,7 @@
 #include <cassert>
 #include <cstring>
 #include <cmath>
+#include "PyrObjectHdr.h"
 #include "PyrErrors.h"
 #include "function_attributes.h"
 #include "Hash.h"
@@ -333,22 +334,42 @@ public:
     [[nodiscard]] inline static PyrSlot make(char c) noexcept {
         return { PrivateTag(), Tags::charTag, static_cast<uint64_t>(details::bit_cast<uint8_t>(c)) };
     }
-    [[nodiscard]] inline static PyrSlot make(struct PyrObjectHdr* o) {
+
+    [[nodiscard]] inline static PyrSlot make(PyrObjectHdr* o) {
         return { PrivateTag(), Tags::objHdrTag, static_cast<uint64_t>(reinterpret_cast<uintptr_t>(o)) };
     }
-    [[nodiscard]] inline static PyrSlot make(struct PyrSymbol* o) {
+    [[nodiscard]] inline static PyrSlot make(PyrObjectHdr& o) {
+        return { PrivateTag(), Tags::objHdrTag, static_cast<uint64_t>(reinterpret_cast<uintptr_t>(&o)) };
+    }
+    [[nodiscard]] inline static PyrSlot make(PyrObjectHdr o) = delete;
+
+    [[nodiscard]] inline static PyrSlot make(PyrSymbol* o) {
         return { PrivateTag(), Tags::symTag, static_cast<uint64_t>(reinterpret_cast<uintptr_t>(o)) };
     }
+    [[nodiscard]] inline static PyrSlot make(PyrSymbol& o) {
+        return { PrivateTag(), Tags::symTag, static_cast<uint64_t>(reinterpret_cast<uintptr_t>(&o)) };
+    }
+    [[nodiscard]] inline static PyrSlot make(PyrSymbol o) = delete;
+
     [[nodiscard]] inline static PyrSlot make(int32_t i) {
         return { PrivateTag(), Tags::intTag, static_cast<uint64_t>(details::bit_cast<uint32_t>(i)) };
     }
     [[nodiscard]] inline static PyrSlot make(void* o) {
         return { PrivateTag(), Tags::ptrTag, static_cast<uint64_t>(reinterpret_cast<uintptr_t>(o)) };
     }
+    [[nodiscard]] inline static PyrSlot make() noexcept { return {}; }
     [[nodiscard]] inline static PyrSlot make(PyrNil) noexcept { return {}; }
     [[nodiscard]] inline static PyrSlot make(bool b) noexcept {
         return { PrivateTag(), b ? Tags::trueTag : Tags::falseTag };
     }
+
+    // This is a bit hard to read (SFINAE), but basically says 'If you aren't derived from PyrObjectHdr, we will not do
+    // any casts for you'. One day, when we upgrade to c++ 20, this can be replaced by a simple concept.
+    // This also means we will not do the implicit casting to void* if you give it a pointer, this is good, because
+    // thats a very powerful overload which you should only use if you really intend to.
+    template <typename T,
+              std::enable_if_t<!std::is_base_of_v<PyrObjectHdr, typename std::remove_pointer<T>::type>, bool> = true>
+    [[nodiscard]] static PyrSlot make(T) = delete;
 
     [[nodiscard]] bool inline isDouble() const noexcept { return !isBoxed(); }
     [[nodiscard]] inline bool isChar() const noexcept { return tagChecker<Tags::charTag>(); }

--- a/testsuite/interpreter/CMakeLists.txt
+++ b/testsuite/interpreter/CMakeLists.txt
@@ -2,6 +2,14 @@ set(test_sources
 	slot.cpp
 )
 
+# These are tests that will fail to compile.
+set(negative_tests
+	pyrslot_int64.cpp
+	pyrslot_int8.cpp
+	pyrslot_ptr.cpp
+	pyrslot_enum.cpp
+)
+
 foreach(test ${test_sources})
 	string(REPLACE .cpp "" test_name ${test} )
 	add_executable(${test_name} ${test})
@@ -28,4 +36,39 @@ foreach(test ${test_sources})
 
   add_test(interpreter__${test_name} ${test_name})
   set_property(TARGET ${test_name} PROPERTY FOLDER Test/Interpreter)
+endforeach(test)
+
+
+
+
+
+foreach(test ${negative_tests})
+	string(REPLACE .cpp "" test_name ${test} )
+	add_executable(${test_name} ${test})
+
+	# Don't build these normally
+	set_target_properties(${test_name} PROPERTIES
+                      EXCLUDE_FROM_ALL TRUE
+                      EXCLUDE_FROM_DEFAULT_BUILD TRUE)
+
+	target_link_libraries(${test_name} boost_test libsclang)
+
+	target_include_directories(${test_name} PUBLIC 
+					${boost_include_dirs}
+					${CMAKE_SOURCE_DIR}/include/common
+                    ${CMAKE_SOURCE_DIR}/include/lang
+                    ${CMAKE_SOURCE_DIR}/include/plugin_interface
+                    ${CMAKE_SOURCE_DIR}/include/server
+                    ${CMAKE_SOURCE_DIR}/common
+
+                    ${CMAKE_SOURCE_DIR}/lang
+                    ${CMAKE_SOURCE_DIR}/lang/LangSource
+                    ${CMAKE_SOURCE_DIR}/lang/LangPrimSource
+	)
+
+	add_test(NAME failing_${test_name}
+         COMMAND ${CMAKE_COMMAND} --build . --target ${test_name} --config $<CONFIGURATION>
+         WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+
+	set_tests_properties(failing_${test_name} PROPERTIES WILL_FAIL TRUE)
 endforeach(test)

--- a/testsuite/interpreter/pyrslot_enum.cpp
+++ b/testsuite/interpreter/pyrslot_enum.cpp
@@ -1,0 +1,3 @@
+#include "PyrSlot.h"
+enum { Bang };
+const auto a = PyrSlot::make(Bang);

--- a/testsuite/interpreter/pyrslot_int64.cpp
+++ b/testsuite/interpreter/pyrslot_int64.cpp
@@ -1,0 +1,2 @@
+#include "PyrSlot.h"
+const auto a = PyrSlot::make(std::int64_t {});

--- a/testsuite/interpreter/pyrslot_int8.cpp
+++ b/testsuite/interpreter/pyrslot_int8.cpp
@@ -1,0 +1,2 @@
+#include "PyrSlot.h"
+const auto a = PyrSlot::make(std::int8_t {});

--- a/testsuite/interpreter/pyrslot_ptr.cpp
+++ b/testsuite/interpreter/pyrslot_ptr.cpp
@@ -1,0 +1,3 @@
+#include "PyrSlot.h"
+const int i { 10 };
+const auto a = PyrSlot::make(&i);

--- a/testsuite/interpreter/slot.cpp
+++ b/testsuite/interpreter/slot.cpp
@@ -33,7 +33,7 @@ BOOST_TEST_REQUIRE(i.getInt() == 32);
 {
     int a = 10;
     int* ap = &a;
-    PyrSlot s_p = PyrSlot::make(ap);
+    PyrSlot s_p = PyrSlot::make((void*)ap);
     BOOST_TEST_REQUIRE(s_p.isPtr());
     BOOST_TEST_REQUIRE(!s_p.isDouble());
     BOOST_TEST_REQUIRE(!s_p.isSymbol());
@@ -163,23 +163,4 @@ BOOST_AUTO_TEST_CASE(bool_test) {
     BOOST_TEST(false_slot.isFalse());
     BOOST_TEST(!true_slot.isFalse());
     BOOST_TEST(!false_slot.isTrue());
-}
-
-
-// We can't test this simply, but these should hold.
-// If anyone comes up with a good way to check that code *doesn't* compile, do let me know! (Jordan)
-// These look like they should be static_asserts with std::is_invokable_v, but even when I wrap it, it won't work.
-// When we get c++20, we can make the PyrSlot constructor constexpr, and this can be used as a NTTP and SFINAE can be
-// used in a static assert.
-BOOST_AUTO_TEST_CASE(should_not_compile) {
-    const auto a = PyrSlot::make(std::int64_t {});
-    const auto b = PyrSlot::make(std::uint64_t {});
-    const auto c = PyrSlot::make(std::uint8_t {});
-    const auto d = PyrSlot::make(std::string {});
-
-    // check pointers don't turn to void*.
-    const std::int64_t i {};
-    const auto e = PyrSlot::make(&i);
-    // This is fine! Just be explicit.
-    const auto f = PyrSlot::make((void*)&i);
 }

--- a/testsuite/interpreter/slot.cpp
+++ b/testsuite/interpreter/slot.cpp
@@ -1,6 +1,7 @@
 #include <boost/test/unit_test.hpp>
 #include <cstdint>
 #include <sys/types.h>
+#include <type_traits>
 
 #include "PyrSlot.h"
 #include "PyrObject.h"
@@ -162,4 +163,23 @@ BOOST_AUTO_TEST_CASE(bool_test) {
     BOOST_TEST(false_slot.isFalse());
     BOOST_TEST(!true_slot.isFalse());
     BOOST_TEST(!false_slot.isTrue());
+}
+
+
+// We can't test this simply, but these should hold.
+// If anyone comes up with a good way to check that code *doesn't* compile, do let me know! (Jordan)
+// These look like they should be static_asserts with std::is_invokable_v, but even when I wrap it, it won't work.
+// When we get c++20, we can make the PyrSlot constructor constexpr, and this can be used as a NTTP and SFINAE can be
+// used in a static assert.
+BOOST_AUTO_TEST_CASE(should_not_compile) {
+    const auto a = PyrSlot::make(std::int64_t {});
+    const auto b = PyrSlot::make(std::uint64_t {});
+    const auto c = PyrSlot::make(std::uint8_t {});
+    const auto d = PyrSlot::make(std::string {});
+
+    // check pointers don't turn to void*.
+    const std::int64_t i {};
+    const auto e = PyrSlot::make(&i);
+    // This is fine! Just be explicit.
+    const auto f = PyrSlot::make((void*)&i);
 }


### PR DESCRIPTION

## Description

You should always know what type you are putting in the slot, therefore, you should be explicit. C++ is not explicit, but does offer a way to enforce this by deleting a generic template function.

Also, adds ctests that fail to compile, ensuring this behavior doesn't creep into the code base. This is a bit weird, but check our the `pyrslot_*.cpp` files and the cmake list for how that works. Ideally, these would be `static_asserts` with `std::invokable` but I couldn't get it to work.

## Purpose and Motivation

Safety. Does your integer cast in the way you expect? What about your enum? What about your pointer? This attempts to remove the ambiguity.

