### PR TITLE
Linux: Server.program to use scsynth bin from the same dir as sclang bin.

### DIFF
--- a/SCClassLibrary/Platform/linux/LinuxPlatform.sc
+++ b/SCClassLibrary/Platform/linux/LinuxPlatform.sc
@@ -14,8 +14,9 @@ LinuxPlatform : UnixPlatform {
 
 		helpDir = this.systemAppSupportDir++"/Help";
 
-		// Server setup
-		Server.program = "exec $(dirname $(readlink /proc/%/exe))/scsynth".format(thisProcess.pid);
+		// Server setup. first looks for scsynth in the dir containing the sclang executable;
+		// if nothing is found, falls back to PATH
+		Server.program = "PATH=$(dirname $(readlink /proc/$PPID/exe)):$PATH; exec scsynth";
 
 		// Score setup
 		Score.program = Server.program;

--- a/SCClassLibrary/Platform/linux/LinuxPlatform.sc
+++ b/SCClassLibrary/Platform/linux/LinuxPlatform.sc
@@ -15,7 +15,7 @@ LinuxPlatform : UnixPlatform {
 		helpDir = this.systemAppSupportDir++"/Help";
 
 		// Server setup
-		Server.program = "exec scsynth";
+		Server.program = "exec $(dirname $(readlink /proc/%/exe))/scsynth".format(thisProcess.pid);
 
 		// Score setup
 		Score.program = Server.program;


### PR DESCRIPTION
For uniformity across platforms (analogous to win behavior) and less trouble with multiple builds on some systems:

From #7388: 

I recently noticed (the hard way) that on linux, the default for Server.program (set in UnixPlatform.sc) is "exec scsynth", i.e. it looks in the $PATH.
This causes trouble when there exist multiple builds of sc on the same machine. For instance, I was scratching my head about why some UGen wasn't found in one build, only to notice that of course it was using the wrong scsynth binary...

I wonder if it's reasonable to change the default to something like:
```
Server.program = "exec $(dirname $(readlink /proc/%/exe))/scsynth".format(thisProcess.pid)
```
I.e., check which binary is being used for sclang and use the scsynth in the same directory.
Which would assume that the user wants to use the scsynth that is in the same directory as the sclang currently being used; I think this is generally a reasonable assumption; and it makes it easier to handle multiple builds on the same computer.
And like the previous default for Server.program, it can of course be overwritten.

---------------------

Alternative, without asking the shell:
```
Server.program = "exec %/scsynth".format((Platform.resourceDir +/+ "../../bin").shellQuote);
```

I think the other suggestion is slightly better because afaik there is no easy way to build sc that would spread the binaries across multiple folders(?). I.e., `scide, sclang, scsynth` are reliably in the same folder, but the path to them from `resourceDir` might be different if `SC_DATA_DIR` has been set during build.  It could be that `SC_DATADIR`, which optionally sets the `resourceDir` at build time, might  be different from the install path (which determines where the binaries go). 

------------------------------

Compare win behavior:
`WindowsPlatform.sc` uses the scsynth in resourceDir 
```
Server.program = (Platform.resourceDir +/+ "scsynth.exe").quote;
```

and `resourceDir is defined as the one that sclang is in.
`SC_Filesystem_win.cpp`:
```
Path SC_Filesystem::defaultResourceDirectory() {
    WCHAR buf[MAX_PATH];
    GetModuleFileNameW(nullptr, buf, MAX_PATH);
    return Path(buf).parent_path();
}
```
OSX is more complicated but also sets resource dir to current path of sclang, and 
```
Server.program = "exec %/scsynth".format((Platform.resourceDir +/+ "../Resources").shellQuote);
```
where the scsynth isn't directly in the resourceDir but anyway within the same app package.

-------------


## types of change

- classlib, using shell commands from the gnu coreutils
- Breaking change (technically; for people who rely on $PATH/scsynth)
(what one **could** do to smoothe over that change is check whether a scsynth at the new default location exists, and if not, fall back to PATH and emit a warning)

## TODO

- Update documentation - [this](https://github.com/supercollider/supercollider/wiki/Path-searching)  mostly, which needs to be updated anyway
- I'm not terribly confident in my shell skillz, so someone who is should look this over. Of course it works fine for me, but idk what could go wrong etc. 
