### PR TITLE
sclang: fix unitialised in constexpr warning

### DIFF
--- a/lang/LangSource/OpcodeDetails.h
+++ b/lang/LangSource/OpcodeDetails.h
@@ -2,13 +2,11 @@
 #include "ByteCodeArray.h"
 #include <cassert>
 #include <tuple>
-#include <cstdint>
 #include <cstring>
-#include <optional>
 
 namespace Opcode::details {
 template <typename I> constexpr static Byte to_byte(I i) {
-    Byte to;
+    Byte to {};
     std::memcpy(&to, &i, sizeof(Byte));
     return to;
 }


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation
Just fixes a warning. Also removes some unnecessary headers.