### PR TITLE
Synth reblocking and upsampling

### DIFF
--- a/HelpSource/Classes/Reblock.schelp
+++ b/HelpSource/Classes/Reblock.schelp
@@ -6,9 +6,9 @@ related:: Classes/Resample, Classes/SynthDef
 DESCRIPTION::
 For certain algorithms it is necessary to run a link::Classes/Synth:: at a small block size. Instead of decreasing the block size of the whole Server, which could be rather wasteful, you can use the Reblock object inside a link::Classes/SynthDef:: to only change the block size of specific Synths. (Keep in mind that very small block sizes will increase the CPU usage.)
 
-The block size can be a fixed number, or it can be set dynamically at runtime via a Synth argument/control.
+The block size can be a constant number or it can be set dynamically via a Synth control (except for Supernova). See link::#*new:: for more information.
 
-note::For technical reasons, Supernova only supports fixed block sizes.::
+note::For technical reasons, Supernova requires a fixed resampling factor. Trying to use a Synth control results in a warning.::
 
 For example, this can be used to implement very short feedback loops:
 
@@ -46,6 +46,16 @@ METHOD:: new
 Specify the block size of the Synth. You should only create this once per SynthDef. Duplicate instances generate a warning and are ignored.
 
 ARGUMENT:: blockSize
-the block size. A non-zero block size must be a power of two. If the value is 0, the Server block size will be used.
+the block size. This can either be a constant number (e.g. 1) or a Synth control. With the latter, the block size can be set independently for each Synth. However, it cannot be modulated after the Synth has been instantiated on the Server.
 
-Currently, only downblocking is supported, i.e. the block size must be smaller than or equal to the Server block size. Otherwise you get a warning.
+The block size must be a power of two. A value of 0 means that the Server block size should be used (= no reblocking).
+
+Currently, only downblocking is supported! A block size greater than the Server block size is ignored and results in a warning.
+
+DISCUSSION::
+
+Note that the Reblock object is not a UGen and there are certain restrictions on the types of arguments it accepts. In particular, you cannot use UGen expressions. (UGens are only evaluated after the Synth has been initialized. At this point, the block size must have already been set.) For example, the following does not work and will throw an error:
+code::
+// futile attempt at generating a random block size:
+Reblock(2 ** IRand(0, 4)); // -> throws an error
+::

--- a/HelpSource/Classes/Reblock.schelp
+++ b/HelpSource/Classes/Reblock.schelp
@@ -54,7 +54,7 @@ Currently, only downblocking is supported! A block size greater than the Server 
 
 DISCUSSION::
 
-Note that the Reblock object is not a UGen and there are certain restrictions on the types of arguments it accepts. In particular, you cannot use UGen expressions. (UGens are only evaluated after the Synth has been initialized. At this point, the block size must have already been set.) For example, the following does not work and will throw an error:
+Note that the Reblock object is strong::not:: a UGen and there are certain restrictions on the types of arguments it accepts. In particular, you cannot use UGen expressions. (UGens are only evaluated after the Synth has been initialized. At this point, the block size must have already been set.) For example, the following does not work and will throw an error:
 code::
 // futile attempt at generating a random block size:
 Reblock(2 ** IRand(0, 4)); // -> throws an error

--- a/HelpSource/Classes/Reblock.schelp
+++ b/HelpSource/Classes/Reblock.schelp
@@ -1,0 +1,51 @@
+TITLE:: Reblock
+summary:: Change the block size of a SynthDef/Synth
+categories:: Server>Abstractions
+related:: Classes/Resample, Classes/SynthDef
+
+DESCRIPTION::
+For certain algorithms it is necessary to run a link::Classes/Synth:: at a small block size. Instead of decreasing the block size of the whole Server, which could be rather wasteful, you can use the Reblock object inside a link::Classes/SynthDef:: to only change the block size of specific Synths. (Keep in mind that very small block sizes will increase the CPU usage.)
+
+The block size can be a fixed number, or it can be set dynamically at runtime via a Synth argument/control.
+
+note::For technical reasons, Supernova only supports fixed block sizes.::
+
+For example, this can be used to implement very short feedback loops:
+
+code::
+// Karplus-Strong with different block sizes
+(
+SynthDef(\delay, { |out, blockSize|
+    var source, local;
+
+	Reblock(blockSize);
+
+    source = Decay.ar(Impulse.ar(2), 0.1) * WhiteNoise.ar(0.2);
+    local = LocalIn.ar(2) + [source, 0]; // read feedback, add to source
+	local = DelayC.ar(local, 0.5, MouseX.kr.pow(2) * 0.5); // delay sound
+
+    // reverse channels to give ping pong effect, apply decay factor
+	LocalOut.ar(local.reverse * MouseY.kr.pow(0.5).clip(0, 0.999));
+
+	Out.ar(out, local);
+}).add
+)
+
+// by default, the min. delay length is the Server block size
+Synth(\delay);
+// try with smaller block sizes:
+Synth(\delay, [ blockSize: 16 ]);
+Synth(\delay, [ blockSize: 4 ]);
+Synth(\delay, [ blockSize: 1 ]);
+::
+
+CLASSMETHODS::
+
+METHOD:: new
+
+Specify the block size of the Synth. You should only create this once per SynthDef. Duplicate instances generate a warning and are ignored.
+
+ARGUMENT:: blockSize
+the block size. A non-zero block size must be a power of two. If the value is 0, the Server block size will be used.
+
+Currently, only downblocking is supported, i.e. the block size must be smaller than or equal to the Server block size. Otherwise you get a warning.

--- a/HelpSource/Classes/Resample.schelp
+++ b/HelpSource/Classes/Resample.schelp
@@ -53,7 +53,7 @@ Currently, only upsampling is supported! Any attempt at downsampling (e.g. a fac
 
 DISCUSSION::
 
-Note that the Resample object is not a UGen and there are certain restrictions on the types of arguments it accepts. In particular, you cannot use UGen expressions. (UGens are only evaluated after the Synth has been initialized. At this point, the resampling factor must have already been set.) For example, the following does not work and will throw an error:
+Note that the Resample object is strong::not:: a UGen and there are certain restrictions on the types of arguments it accepts. In particular, you cannot use UGen expressions. (UGens are only evaluated after the Synth has been initialized. At this point, the resampling factor must have already been set.) For example, the following does not work and will throw an error:
 code::
 // futile attempt at generating a random resampling factor:
 Resample(2 ** IRand(0, 4)); // -> throws an error

--- a/HelpSource/Classes/Resample.schelp
+++ b/HelpSource/Classes/Resample.schelp
@@ -1,0 +1,51 @@
+TITLE:: Resample
+summary:: Change the sample rate of a SynthDef/Synth
+categories:: Server>Abstractions
+related:: Classes/Reblock, Classes/SynthDef
+
+DESCRIPTION::
+For certain applications it is beneficial to run a link::Classes/Synth:: at a higher sample rate. Instead of increasing the sample rate of the whole Server, which could be very wasteful, you can use the Resample object inside a link::Classes/SynthDef:: to only change the sample rate of specific Synths.
+
+For example, with a factor of 4.0, the Synth will run at four times the Server's sample rate. Keep in mind that upsampling increases the CPU usage roughly proportionally to the upsampling factor.
+
+The resample factor can be a fixed number, or it can be set dynamically at runtime via a Synth argument/control.
+
+note::For technical reasons, Supernova only supports fixed resample factors.::
+
+For example, this can be used to implement anti-aliasing via oversampling + filtering:
+
+code::
+// reduce aliasing with upsampling + filtering
+(
+SynthDef(\hardsync, { |out, upsample=1.0|
+	var sig, cutoff = 18000;
+
+	Resample(upsample);
+
+	sig = SyncSaw.ar(MouseY.kr(1, 1000, 2), MouseX.kr(100, 4000, 2));
+
+	// crude anti-alisaing filter
+	sig = LPF.ar(sig, cutoff);
+	sig = LPF.ar(sig, cutoff);
+	Out.ar(out, sig * 0.05 ! 2);
+}).add;
+)
+
+// lots of aliasing
+Synth(\hardsync);
+// watch aliasing disappear with increasing upsample factors
+Synth(\hardsync, [ upsample: 2.0 ]);
+Synth(\hardsync, [ upsample: 4.0 ]);
+Synth(\hardsync, [ upsample: 8.0 ]);
+::
+
+CLASSMETHODS::
+
+METHOD:: new
+
+Specify the resample factor of the Synth. You should only create this once per SynthDef. Duplicate instances generate a warning and are ignored.
+
+ARGUMENT:: factor
+the resample factor, either as a constant number or as a Synth argument resp. link::Classes/NamedControl::. A value of 0.0 means no resampling (= a factor of 1.0).
+
+Currently, only upsampling is supported, i.e. the factor must be greater than or equal to 1.0 (= no resampling). Otherwise you get a warning.

--- a/HelpSource/Classes/Resample.schelp
+++ b/HelpSource/Classes/Resample.schelp
@@ -8,16 +8,15 @@ For certain applications it is beneficial to run a link::Classes/Synth:: at a hi
 
 For example, with a factor of 4.0, the Synth will run at four times the Server's sample rate. Keep in mind that upsampling increases the CPU usage roughly proportionally to the upsampling factor.
 
-The resample factor can be a fixed number, or it can be set dynamically at runtime via a Synth argument/control.
+The resampling factor can be a constant number or it can be set dynamically via a Synth control (except for Supernova). See link::#*new:: for more information.
 
-note::For technical reasons, Supernova only supports fixed resample factors.::
+note::For technical reasons, Supernova requires a fixed resampling factor. Trying to use a Synth control results in a warning.::
 
-For example, this can be used to implement anti-aliasing via oversampling + filtering:
+For example, you can use upsampling + filtering to reduce the effects of aliasing:
 
 code::
-// reduce aliasing with upsampling + filtering
 (
-SynthDef(\hardsync, { |out, upsample=1.0|
+SynthDef(\hardsync, { |out, upsample|
 	var sig, cutoff = 18000;
 
 	Resample(upsample);
@@ -31,9 +30,9 @@ SynthDef(\hardsync, { |out, upsample=1.0|
 }).add;
 )
 
-// lots of aliasing
+// no upsampling -> lots of aliasing
 Synth(\hardsync);
-// watch aliasing disappear with increasing upsample factors
+// watch aliasing disappear with increasing upsampling factors
 Synth(\hardsync, [ upsample: 2.0 ]);
 Synth(\hardsync, [ upsample: 4.0 ]);
 Synth(\hardsync, [ upsample: 8.0 ]);
@@ -43,9 +42,19 @@ CLASSMETHODS::
 
 METHOD:: new
 
-Specify the resample factor of the Synth. You should only create this once per SynthDef. Duplicate instances generate a warning and are ignored.
+Specify the resampling factor of the Synth. You should only create this once per SynthDef. Duplicate instances generate a warning and are ignored.
 
 ARGUMENT:: factor
-the resample factor, either as a constant number or as a Synth argument resp. link::Classes/NamedControl::. A value of 0.0 means no resampling (= a factor of 1.0).
+the resampling factor. This can either be a constant number (e.g. 2.0) or a Synth control. With the latter, the resampling factor can be set independently for each Synth. However, it cannot be modulated after the Synth has been instantiated on the Server.
 
-Currently, only upsampling is supported, i.e. the factor must be greater than or equal to 1.0 (= no resampling). Otherwise you get a warning.
+The resampling factor must be power of two. A value of 0.0 is the same as 1.0 (= no resampling).
+
+Currently, only upsampling is supported! Any attempt at downsampling (e.g. a factor of 0.5) is ignored and results in a warning.
+
+DISCUSSION::
+
+Note that the Resample object is not a UGen and there are certain restrictions on the types of arguments it accepts. In particular, you cannot use UGen expressions. (UGens are only evaluated after the Synth has been initialized. At this point, the resampling factor must have already been set.) For example, the following does not work and will throw an error:
+code::
+// futile attempt at generating a random resampling factor:
+Resample(2 ** IRand(0, 4)); // -> throws an error
+::

--- a/HelpSource/Classes/SynthDef.schelp
+++ b/HelpSource/Classes/SynthDef.schelp
@@ -91,7 +91,7 @@ b = Synth(\help_isRand); // a different randomly selected freq
 
 subsection:: Reblocking and Resampling
 
-Since SC 3.15, Synths can be downblocked to smaller block sizes and upsampled to higher sample rates than the Server's own block size resp. sample rate. This enables things like single-sample feedback or anti-aliasing.
+Since SC 3.15, Synths can be downblocked to smaller block sizes and upsampled to higher sample rates than the Server's own block size resp. sample rate. This enables things like single-sample feedback or anti-aliasing through upsampling and filtering.
 
 Reblocking and resampling is done with the link::Classes/Reblock:: and link::Classes/Resample:: objects. You can put these in your SynthDef and either pass a fixed number or a Synth argument/control.
 

--- a/HelpSource/Classes/SynthDef.schelp
+++ b/HelpSource/Classes/SynthDef.schelp
@@ -89,6 +89,23 @@ a = Synth(\help_isRand);
 b = Synth(\help_isRand); // a different randomly selected freq
 ::
 
+subsection:: Reblocking and Resampling
+
+Since SC 3.15, Synths can be downblocked to smaller block sizes and upsampled to higher sample rates than the Server's own block size resp. sample rate. This enables things like single-sample feedback or anti-aliasing.
+
+Reblocking and resampling is done with the link::Classes/Reblock:: and link::Classes/Resample:: objects. You can put these in your SynthDef and either pass a fixed number or a Synth argument/control.
+
+code::
+(
+SynthDef(\reblock_and_resample, { |out, blockSize=4|
+	Resample(2); // 2x upsampling
+	BlockSize(blockSize); // downblocking
+	Out.ar(out, SinOsc.ar(440) * 0.1);
+}).add;
+)
+::
+
+See the respective help files for more information and some practical examples.
 
 ClassMethods::
 private:: initClass, prNew

--- a/HelpSource/Reference/Synth-Definition-File-Format.schelp
+++ b/HelpSource/Reference/Synth-Definition-File-Format.schelp
@@ -53,8 +53,8 @@ list::
 ## int32 - the synth block size. If the value is 0, the server block size will be used.
 If the value is -1, the block size is taken from the specified parameter (see next field).
 ## int32 - the parameter index for the block size. This is only used if the block size field above is -1.
-## float32 - the synth resample factor. For no resampling, the value should be 1.0. If the value is -1.0, the resample factor is taken from the specified parameter (see next field).
-## int32 - the parameter index for the resample factor. This is only used if the resample factor field above is -1.0.
+## float32 - the synth resampling factor. For no resampling, the value should be 0.0 or 1.0. If the value is -1.0, the resampling factor is taken from the specified parameter (see next field).
+## int32 - the parameter index for the resampling factor. This is only used if the resampling factor field above is -1.0.
 ::
 
 a strong::param-name:: is :
@@ -157,8 +157,8 @@ tree::
     ## int32 - the synth block size. If the value is 0, the server block size will be used.
     If the value is -1, the block size is taken from the specified parameter (see next field).
     ## int32 - the parameter index for the block size. This is only used if the block size field above is -1.
-    ## float32 - the synth resample factor. For no resampling, the value should be 1.0. If the value is -1.0, the resample factor is taken from the specified parameter (see next field).
-    ## int32 - the parameter index for the resample factor. This is only used if the resample factor field above is -1.0.
+    ## float32 - the synth resampling factor. For no resampling, the value should be 0.0 or 1.0. If the value is -1.0, the resampling factor is taken from the specified parameter (see next field).
+    ## int32 - the parameter index for the resampling factor. This is only used if the resampling factor field above is -1.0.
     ::
 ::
 

--- a/HelpSource/Reference/Synth-Definition-File-Format.schelp
+++ b/HelpSource/Reference/Synth-Definition-File-Format.schelp
@@ -50,6 +50,11 @@ list::
 ## [ strong::ugen-spec:: ] * U
 ## int16 - number of variants (V)
 ## [ strong::variant-spec:: ] * V
+## int32 - the synth block size. If the value is 0, the server block size will be used.
+If the value is -1, the block size is taken from the specified parameter (see next field).
+## int32 - the parameter index for the block size. This is only used if the block size field above is -1.
+## float32 - the synth resample factor. For no resampling, the value should be 1.0. If the value is -1.0, the resample factor is taken from the specified parameter (see next field).
+## int32 - the parameter index for the resample factor. This is only used if the resample factor field above is -1.0.
 ::
 
 a strong::param-name:: is :
@@ -149,6 +154,11 @@ tree::
         ## pstring - the name of the variant
         ## [float32] * P - variant initial parameter values
         ::
+    ## int32 - the synth block size. If the value is 0, the server block size will be used.
+    If the value is -1, the block size is taken from the specified parameter (see next field).
+    ## int32 - the parameter index for the block size. This is only used if the block size field above is -1.
+    ## float32 - the synth resample factor. For no resampling, the value should be 1.0. If the value is -1.0, the resample factor is taken from the specified parameter (see next field).
+    ## int32 - the parameter index for the resample factor. This is only used if the resample factor field above is -1.0.
     ::
 ::
 

--- a/SCClassLibrary/Common/Audio/SynthDef.sc
+++ b/SCClassLibrary/Common/Audio/SynthDef.sc
@@ -9,6 +9,8 @@ SynthDef {
 	var <>constants;
 	var <>constantSet;
 	var <>maxLocalBufs;
+	var <reblock;
+	var <resample;
 
 	// topo sort
 	var <>available;
@@ -79,6 +81,8 @@ SynthDef {
 		controls = nil;
 		controlIndex = 0;
 		maxLocalBufs = nil;
+		reblock = nil;
+		resample = nil;
 	}
 	buildUgenGraph { arg func, rates, prependArgs;
 		var result;
@@ -405,6 +409,12 @@ SynthDef {
 			};
 
 			if (version > 2) {
+				// reblock
+				(this.reblock ?? { Reblock() }).writeDef(file);
+
+				// resample
+				(this.resample ?? { Resample() }).writeDef(file);
+
 				// calculate total size in bytes
 				endPos = file.pos;
 				byteSize = endPos - startPos;
@@ -449,6 +459,27 @@ SynthDef {
 		^true
 	}
 
+	reblock_ { arg obj;
+		if (obj.isKindOf(Reblock).not) {
+			Error("wrong argument to reblock_").throw;
+		};
+		if (reblock.isNil) {
+			reblock = obj;
+		} {
+			"ignore duplicate Reblock object".warn;
+		};
+	}
+
+	resample_ { arg obj;
+		if (obj.isKindOf(Resample).not) {
+			Error("wrong argument to resample_").throw;
+		};
+		if (resample.isNil) {
+			resample = obj;
+		} {
+			"ignore duplicate Resample object".warn;
+		};
+	}
 
 	// UGens do these
 	addUGen { arg ugen;
@@ -739,4 +770,95 @@ SynthDef {
 		^synth
 	}
 
+}
+
+Reblock {
+	var <>synthDef;
+	var <>blockSize;
+	var <>controlIndex;
+
+	*new { arg blockSize=0;
+		^super.new.init(blockSize);
+	}
+
+	init { arg blockSize;
+		synthDef = UGen.buildSynthDef;
+		if (blockSize.isKindOf(SimpleNumber)) {
+			blockSize = blockSize.asInteger;
+			// 0 means no reblocking
+			if ((blockSize != 0) and: { blockSize.isPowerOfTwo.not }) {
+				Error("block size % is not a power of two".format(blockSize)).throw;
+			};
+			this.blockSize = blockSize;
+		} {
+			if (blockSize.isKindOf(OutputProxy)) {
+				controlIndex = blockSize.controlIndex
+			};
+			if (controlIndex.isNil) {
+				Error("Reblock requires a number or Synth Control").throw;
+			}
+		};
+		if (synthDef.notNil) {
+			synthDef.reblock = this;
+		}
+	}
+
+	writeDef { arg stream;
+		if (controlIndex.notNil) {
+			// use control index
+			stream.putInt32(-1);
+			stream.putInt32(controlIndex);
+		} {
+			// constant block size
+			stream.putInt32(blockSize);
+			stream.putInt32(0);
+		}
+	}
+}
+
+Resample {
+	var <>synthDef;
+	var <>factor;
+	var <>controlIndex;
+
+	*new { arg factor=1.0;
+		^super.new.init(factor);
+	}
+
+	init { arg factor;
+		synthDef = UGen.buildSynthDef;
+		if (factor.isKindOf(SimpleNumber)) {
+			factor = factor.asFloat;
+			// 0.0 means no resampling
+			if (factor == 0.0) { factor = 1.0 };
+			// make sure that 'factor' is a power of two (with positive or negative exponent)
+			if ((factor.asInteger.isPowerOfTwo.not) and:
+				{ factor.reciprocal.asInteger.isPowerOfTwo.not }) {
+				Error("resample factor % is not a power of two".format(factor)).throw;
+			};
+			this.factor = factor;
+		} {
+			if (factor.isKindOf(OutputProxy)) {
+				controlIndex = factor.controlIndex
+			};
+			if (controlIndex.isNil) {
+				Error("Resample requires a number or Synth Control").throw;
+			}
+		};
+		if (synthDef.notNil) {
+			synthDef.resample = this;
+		}
+	}
+
+	writeDef { arg stream;
+		if (controlIndex.notNil) {
+			// control index
+			stream.putFloat(-1.0);
+			stream.putInt32(controlIndex);
+		} {
+			// constant factor
+			stream.putFloat(factor);
+			stream.putInt32(0);
+		}
+	}
 }

--- a/SCClassLibrary/Common/Audio/SynthDesc.sc
+++ b/SCClassLibrary/Common/Audio/SynthDesc.sc
@@ -244,6 +244,16 @@ SynthDesc {
 			stream.read(variantValues);
 		};
 
+		if (version > 2) {
+			// read reblock and resample fields, just to detect corrupt SynthDef files.
+			stream.getInt32; // block size value
+			stream.getInt32; // block size control index
+			stream.getFloat; // resample factor
+			stream.getInt32; // resample control index
+			// just ignore all remaining (optional) fields.
+			// these will be skipped in the readSynthDef3 method.
+		};
+
 		def.constants = Dictionary.new;
 		constants.do {|k,i| def.constants.put(k,i) };
 		if (keepDef.not) {

--- a/SCClassLibrary/Common/Audio/UGen.sc
+++ b/SCClassLibrary/Common/Audio/UGen.sc
@@ -636,7 +636,7 @@ OutputProxy : UGen {
 	}
 
 	controlIndex {
-		if (source.isKindOf(Control).not) { ^nil };
+		if (source.class.isControlUGen.not) { ^nil };
 		^source.specialIndex + outputIndex
 	}
 

--- a/SCClassLibrary/Common/Audio/UGen.sc
+++ b/SCClassLibrary/Common/Audio/UGen.sc
@@ -630,17 +630,14 @@ OutputProxy : UGen {
 	}
 
 	controlName {
-		var counter = 0, index = 0;
-
-		this.synthDef.children.do({
-			arg ugen;
-			if(this.source.synthIndex == ugen.synthIndex,
-				{ index = counter + this.outputIndex; });
-			if(ugen.isKindOf(Control),
-				{ counter = counter + ugen.channels.size; });
-		});
-
+		var index = this.controlIndex;
+		if (index.isNil) { ^nil };
 		^synthDef.controlNames.detect({ |c| c.index == index });
+	}
+
+	controlIndex {
+		if (source.isKindOf(Control).not) { ^nil };
+		^source.specialIndex + outputIndex
 	}
 
 	spec_{ arg spec;

--- a/include/plugin_interface/SC_Graph.h
+++ b/include/plugin_interface/SC_Graph.h
@@ -24,6 +24,10 @@
 #include "SC_Rate.h"
 #include "SC_SndBuf.h"
 
+enum { kGraph_Reblock = 0x1, kGraph_Resample = 0x2 };
+
+#define kGraph_ReblockOrResample (kGraph_Reblock | kGraph_Resample)
+
 /*
  changes to this struct likely also mean that a change is needed for
     static const int sc_api_version = x;
@@ -33,10 +37,18 @@ struct Graph {
     Node mNode;
     int32 mRefCount;
 
-    uint32 mNumWires;
-    struct Wire* mWire;
+    uint16 mNumTicks;
+    uint16 mTickCounter;
 
+    uint32 mFlags;
+
+    Rate* mFullRate;
+    Rate* mBufRate;
+
+    uint32 mNumWires;
     uint32 mNumControls;
+
+    struct Wire* mWire;
     float* mControls;
     float** mMapControls;
     int32* mAudioBusOffsets;
@@ -45,18 +57,18 @@ struct Graph {
     int32* mControlRates;
 
     uint32 mNumUnits;
-    struct Unit** mUnits;
-
     uint32 mNumCalcUnits;
+
+    struct Unit** mUnits;
     struct Unit** mCalcUnits; // excludes i-rate units.
 
     int32 mSampleOffset;
+    float mSubsampleOffset;
+
     struct RGen* mRGen;
 
     struct Unit* mLocalAudioBusUnit;
     struct Unit* mLocalControlBusUnit;
-
-    float mSubsampleOffset;
 
     SndBuf* mLocalSndBufs;
     int32 localBufNum;

--- a/include/plugin_interface/SC_InterfaceTable.h
+++ b/include/plugin_interface/SC_InterfaceTable.h
@@ -23,7 +23,10 @@
 // TODO next time this is updated, change SC_PlugIn.hpp `in`, `zin`, etc. to take uint32s
 // TODO next time this is updated, change SC_PlugIn.hpp `numInputs`, `numOutputs` to have correct
 // return type
-static const int sc_api_version = 5;
+// NOTE: The plugin API version has been temporarily bumped to avoid potential crashes
+// with existing plugins on the develop branch. After all plugin API changes have been
+// made for SC 3.15, the API version should be restored to 4.
+static const int sc_api_version = 6;
 
 #include "SC_Types.h"
 #include "SC_World.h"

--- a/include/plugin_interface/SC_Unit.h
+++ b/include/plugin_interface/SC_Unit.h
@@ -120,9 +120,10 @@ template <typename ToType, typename Value>
 #define BUFLENGTH (unit->mBufLength)
 #define BUFRATE (unit->mRate->mBufRate)
 #define BUFDUR (unit->mRate->mBufDuration)
-#define FULLRATE (unit->mWorld->mFullRate.mSampleRate)
-#define FULLBUFLENGTH (unit->mWorld->mFullRate.mBufLength)
-#define FULLSAMPLEDUR (unit->mWorld->mFullRate.mSampleDur)
+#define FULLRATE (unit->mParent->mFullRate->mSampleRate)
+#define FULLSAMPLEDUR (unit->mParent->mFullRate->mSampleDur)
+#define FULLBUFLENGTH (unit->mParent->mFullRate->mBufLength)
+#define REBLOCK_OR_RESAMPLE (unit->mParent->mFlags & kGraph_ReblockOrResample)
 
 #ifdef SUPERNOVA
 

--- a/include/server/ErrorMessage.hpp
+++ b/include/server/ErrorMessage.hpp
@@ -71,7 +71,9 @@ std::string apiVersionMismatch(std::string const& utf8Filename, int const expect
     assert(expectedVersion != actualVersion);
 
     // both 1 and 2 were introduced in 3.6
-    static map<int, string> const scVersionForAPIVersion = { { 1, "3.6.0" }, { 2, "3.6.0" }, { 3, "3.9.0" } };
+    static map<int, string> const scVersionForAPIVersion = {
+        { 1, "3.6.0" }, { 2, "3.6.0" }, { 3, "3.9.0" }, { 4, "3.14" }
+    };
 
     stringstream message;
     message << "ERROR: API version mismatch: " << utf8Filename << "\n";

--- a/include/server/ErrorMessage.hpp
+++ b/include/server/ErrorMessage.hpp
@@ -72,7 +72,7 @@ std::string apiVersionMismatch(std::string const& utf8Filename, int const expect
 
     // both 1 and 2 were introduced in 3.6
     static map<int, string> const scVersionForAPIVersion = {
-        { 1, "3.6.0" }, { 2, "3.6.0" }, { 3, "3.9.0" }, { 4, "3.14" }
+        { 1, "3.6.0" }, { 2, "3.6.0" }, { 3, "3.9.0" }, { 4, "3.15" }
     };
 
     stringstream message;

--- a/server/plugins/DelayUGens.cpp
+++ b/server/plugins/DelayUGens.cpp
@@ -439,7 +439,7 @@ void SampleDur_Ctor(Unit* unit, int inNumSamples) { ZOUT0(0) = FULLSAMPLEDUR; }
 
 void ControlDur_Ctor(Unit* unit, int inNumSamples) { ZOUT0(0) = BUFDUR; }
 
-void RadiansPerSample_Ctor(Unit* unit, int inNumSamples) { ZOUT0(0) = unit->mWorld->mFullRate.mRadiansPerSample; }
+void RadiansPerSample_Ctor(Unit* unit, int inNumSamples) { ZOUT0(0) = unit->mParent->mFullRate->mRadiansPerSample; }
 
 void BlockSize_Ctor(Unit* unit, int inNumSamples) { ZOUT0(0) = FULLBUFLENGTH; }
 

--- a/server/plugins/IOUGens.cpp
+++ b/server/plugins/IOUGens.cpp
@@ -224,16 +224,19 @@ template <bool LockShared> struct AudioBusGuard {
     AudioBusGuard(const Unit* unit, int32 currentChannel, int32 maxChannel):
         unit(unit),
         mCurrentChannel(currentChannel),
-        isValid(currentChannel < maxChannel) {
-        if (isValid)
+        mIsValid(currentChannel < maxChannel) {
+        if (mIsValid)
             lock();
     }
 
     ~AudioBusGuard() {
-        if (isValid)
+        if (mIsValid)
             unlock();
     }
 
+    bool isValid() const { return mIsValid; }
+
+private:
     void lock() {
         if (LockShared)
             ACQUIRE_BUS_AUDIO_SHARED(mCurrentChannel);
@@ -248,9 +251,10 @@ template <bool LockShared> struct AudioBusGuard {
             RELEASE_BUS_AUDIO(mCurrentChannel);
     }
 
-    const Unit* unit;
+
+    const Unit* unit; // for macros
     const int32 mCurrentChannel;
-    const bool isValid;
+    const bool mIsValid;
 };
 
 static inline float readControlBus(const float* bus, int channelIndex, int maxChannel) {
@@ -265,7 +269,7 @@ static inline float readControlBus(const float* bus, int channelIndex, int maxCh
 static inline void IO_a_update_channels(IOUnit* unit, World* world, float fbusChannel, int numChannels, int bufLength) {
     if (fbusChannel != unit->m_fbusChannel) {
         unit->m_fbusChannel = fbusChannel;
-        int busChannel = (uint32)fbusChannel;
+        int busChannel = (int32)fbusChannel;
         int lastChannel = busChannel + numChannels;
 
         if (!(busChannel < 0 || lastChannel > (int)world->mNumAudioBusChannels)) {
@@ -706,7 +710,7 @@ FLATTEN void In_next_a_nova(In* unit, int inNumSamples) {
 
         float* out = OUT(i);
 
-        if (guard.isValid && (touched[i] == bufCounter))
+        if (guard.isValid() && (touched[i] == bufCounter))
             nova::copyvec_simd(out, in, inNumSamples);
         else
             nova::zerovec_simd(out, inNumSamples);
@@ -730,7 +734,7 @@ FLATTEN void In_next_a_nova_64(In* unit, int inNumSamples) {
         AudioBusGuard<true> guard(unit, fbusChannel + i, maxChannel);
 
         float* out = OUT(i);
-        if (guard.isValid && (touched[i] == bufCounter))
+        if (guard.isValid() && (touched[i] == bufCounter))
             nova::copyvec_simd<64>(out, in);
         else
             nova::zerovec_simd<64>(out);
@@ -756,7 +760,7 @@ void In_next_a(In* unit, int inNumSamples) {
         AudioBusGuard<true> guard(unit, fbusChannel + i, maxChannel);
 
         float* out = OUT(i);
-        if (guard.isValid && (touched[i] == bufCounter))
+        if (guard.isValid() && (touched[i] == bufCounter))
             Copy(inNumSamples, out, in);
         else
             Clear(inNumSamples, out);
@@ -788,7 +792,7 @@ void In_next_a_reblock(In* unit, int inNumSamples) {
         }
 
         float* out = OUT(i);
-        if (guard.isValid && (touched[i] == bufCounter)) {
+        if (guard.isValid() && (touched[i] == bufCounter)) {
             // copy with reblocking/resampling
             for (int j = 0; j < inNumSamples; ++j) {
                 int index = j * resample;
@@ -818,7 +822,7 @@ void vIn_next_a(In* unit, int inNumSamples) {
         AudioBusGuard<true> guard(unit, fbusChannel + i, maxChannel);
 
         float* out = OUT(i);
-        if (guard.isValid && (touched[i] == bufCounter))
+        if (guard.isValid() && (touched[i] == bufCounter))
             vcopy(out, in, inNumSamples);
         else
             vfill(out, 0.f, inNumSamples);
@@ -997,14 +1001,14 @@ void InFeedback_next_a_reblock(InFeedback* unit, int inNumSamples) {
         }
         int diff = bufCounter - touched[i];
 
-        if (guard.isValid && diff == 0) {
+        if (guard.isValid() && diff == 0) {
             // copy with reblocking/resampling
             for (int j = 0; j < inNumSamples; ++j) {
                 int index = j * resample;
                 out[j] = in[index];
             }
             unit->m_busUsedInPrevCycle[i] = true;
-        } else if (guard.isValid && diff == 1) {
+        } else if (guard.isValid() && diff == 1) {
             if (unit->m_busUsedInPrevCycle[i]) {
                 Clear(inNumSamples, out);
                 // only update on last tick!!
@@ -1046,10 +1050,10 @@ void InFeedback_next_a(InFeedback* unit, int inNumSamples) {
         float* out = OUT(i);
         int diff = bufCounter - touched[i];
 
-        if (guard.isValid && diff == 0) {
+        if (guard.isValid() && diff == 0) {
             Copy(inNumSamples, out, in);
             unit->m_busUsedInPrevCycle[i] = true;
-        } else if (guard.isValid && diff == 1) {
+        } else if (guard.isValid() && diff == 1) {
             if (unit->m_busUsedInPrevCycle[i]) {
                 Clear(inNumSamples, out);
                 unit->m_busUsedInPrevCycle[i] = false;
@@ -1177,7 +1181,7 @@ void ReplaceOut_next_a_reblock(ReplaceOut* unit, int inNumSamples) {
     for (int i = 0; i < numChannels; ++i, out += bufLength) {
         AudioBusGuard<false> guard(unit, fbusChannel + i, maxChannel);
 
-        if (guard.isValid) {
+        if (guard.isValid()) {
             float* in = IN(i + 1);
             for (int j = 0; j < outSamples; ++j) {
                 int index = j * resample;
@@ -1204,7 +1208,7 @@ void ReplaceOut_next_a(ReplaceOut* unit, int inNumSamples) {
     for (int i = 0; i < numChannels; ++i, out += bufLength) {
         AudioBusGuard<false> guard(unit, fbusChannel + i, maxChannel);
 
-        if (guard.isValid) {
+        if (guard.isValid()) {
             float* in = IN(i + 1);
             Copy(inNumSamples, out, in);
             touched[i] = bufCounter;
@@ -1229,7 +1233,7 @@ FLATTEN void ReplaceOut_next_a_nova(ReplaceOut* unit, int inNumSamples) {
     for (int i = 0; i < numChannels; ++i, out += bufLength) {
         AudioBusGuard<false> guard(unit, fbusChannel + i, maxChannel);
 
-        if (guard.isValid) {
+        if (guard.isValid()) {
             float* in = IN(i + 1);
             nova::copyvec_simd(out, in, inNumSamples);
             touched[i] = bufCounter;
@@ -1253,7 +1257,7 @@ FLATTEN void ReplaceOut_next_a_nova_64(ReplaceOut* unit, int inNumSamples) {
     for (int i = 0; i < numChannels; ++i, out += bufLength) {
         AudioBusGuard<false> guard(unit, fbusChannel + i, maxChannel);
 
-        if (guard.isValid) {
+        if (guard.isValid()) {
             float* in = IN(i + 1);
             nova::copyvec_simd<64>(out, in);
             touched[i] = bufCounter;
@@ -1340,7 +1344,7 @@ void Out_next_a_reblock(Out* unit, int inNumSamples) {
     for (int i = 0; i < numChannels; ++i, out += bufLength) {
         AudioBusGuard<false> guard(unit, fbusChannel + i, maxChannel);
 
-        if (guard.isValid) {
+        if (guard.isValid()) {
             if (tick == 0) {
                 // If this is the first tick, check if we are the first
                 // one writing to the bus. If yes, zero the *whole* channel
@@ -1380,7 +1384,7 @@ void Out_next_a(Out* unit, int inNumSamples) {
     for (int i = 0; i < numChannels; ++i, out += bufLength) {
         AudioBusGuard<false> guard(unit, fbusChannel + i, maxChannel);
 
-        if (guard.isValid) {
+        if (guard.isValid()) {
             float* in = IN(i + 1);
             if (touched[i] == bufCounter)
                 Accum(inNumSamples, out, in);
@@ -1409,7 +1413,7 @@ void vOut_next_a(Out* unit, int inNumSamples) {
     for (int i = 0; i < numChannels; ++i, out += bufLength) {
         AudioBusGuard<false> guard(unit, fbusChannel + i, maxChannel);
 
-        if (guard.isValid) {
+        if (guard.isValid()) {
             float* in = IN(i + 1);
             if (touched[i] == bufCounter) {
                 vadd(out, out, in, inNumSamples);
@@ -1440,7 +1444,7 @@ FLATTEN void Out_next_a_nova(Out* unit, int inNumSamples) {
     for (int i = 0; i < numChannels; ++i, out += bufLength) {
         AudioBusGuard<false> guard(unit, fbusChannel + i, maxChannel);
 
-        if (guard.isValid) {
+        if (guard.isValid()) {
             float* in = IN(i + 1);
             if (touched[i] == bufCounter)
                 nova::addvec_simd(out, in, inNumSamples);
@@ -1469,7 +1473,7 @@ FLATTEN void Out_next_a_nova_64(Out* unit, int inNumSamples) {
     for (int i = 0; i < numChannels; ++i, out += bufLength) {
         AudioBusGuard<false> guard(unit, fbusChannel + i, maxChannel);
 
-        if (guard.isValid) {
+        if (guard.isValid()) {
             float* in = IN(i + 1);
             if (touched[i] == bufCounter)
                 nova::addvec_simd<64>(out, in);
@@ -1580,7 +1584,7 @@ void XOut_next_a_reblock(XOut* unit, int inNumSamples) {
         for (int i = 0; i < numChannels; ++i, out += bufLength) {
             AudioBusGuard<false> guard(unit, fbusChannel + i, maxChannel);
 
-            if (guard.isValid) {
+            if (guard.isValid()) {
                 if (tick == 0) {
                     // If this is the first tick, check if we are the first
                     // one writing to the bus. If yes, zero the *whole* channel
@@ -1607,7 +1611,7 @@ void XOut_next_a_reblock(XOut* unit, int inNumSamples) {
         for (int i = 0; i < numChannels; ++i, out += bufLength) {
             AudioBusGuard<false> guard(unit, fbusChannel + i, maxChannel);
 
-            if (guard.isValid) {
+            if (guard.isValid()) {
                 float* in = IN(i + 2);
                 for (int j = 0; j < outSamples; ++j) {
                     int index = j * resample;
@@ -1621,7 +1625,8 @@ void XOut_next_a_reblock(XOut* unit, int inNumSamples) {
     } else {
         for (int i = 0; i < numChannels; ++i, out += bufLength) {
             AudioBusGuard<false> guard(unit, fbusChannel + i, maxChannel);
-            if (guard.isValid) {
+
+            if (guard.isValid()) {
                 if (tick == 0) {
                     // See comment above.
                     if (touched[i] != bufCounter) {
@@ -1663,7 +1668,7 @@ void XOut_next_a(XOut* unit, int inNumSamples) {
         for (int i = 0; i < numChannels; ++i, out += bufLength) {
             AudioBusGuard<false> guard(unit, fbusChannel + i, maxChannel);
 
-            if (guard.isValid) {
+            if (guard.isValid()) {
                 float xfade = xfade0;
                 float* in = IN(i + 2);
                 if (touched[i] == bufCounter) {
@@ -1683,7 +1688,7 @@ void XOut_next_a(XOut* unit, int inNumSamples) {
         for (int i = 0; i < numChannels; ++i, out += bufLength) {
             AudioBusGuard<false> guard(unit, fbusChannel + i, maxChannel);
 
-            if (guard.isValid) {
+            if (guard.isValid()) {
                 float* in = IN(i + 2);
                 Copy(inNumSamples, out, in);
                 touched[i] = bufCounter;
@@ -1694,7 +1699,8 @@ void XOut_next_a(XOut* unit, int inNumSamples) {
     } else {
         for (int i = 0; i < numChannels; ++i, out += bufLength) {
             AudioBusGuard<false> guard(unit, fbusChannel + i, maxChannel);
-            if (guard.isValid) {
+
+            if (guard.isValid()) {
                 float* in = IN(i + 2);
                 if (touched[i] == bufCounter) {
                     for (int j = 0; j < inNumSamples; ++j) {
@@ -1734,7 +1740,7 @@ FLATTEN void XOut_next_a_nova(XOut* unit, int inNumSamples) {
         for (int i = 0; i < numChannels; ++i, out += bufLength) {
             AudioBusGuard<false> guard(unit, fbusChannel + i, maxChannel);
 
-            if (guard.isValid) {
+            if (guard.isValid()) {
                 float xfade = xfade0;
                 float* in = IN(i + 2);
                 if (touched[i] == bufCounter)
@@ -1751,7 +1757,7 @@ FLATTEN void XOut_next_a_nova(XOut* unit, int inNumSamples) {
         for (int i = 0; i < numChannels; ++i, out += bufLength) {
             AudioBusGuard<false> guard(unit, fbusChannel + i, maxChannel);
 
-            if (guard.isValid) {
+            if (guard.isValid()) {
                 float* in = IN(i + 2);
                 nova::copyvec_simd(out, in, inNumSamples);
                 touched[i] = bufCounter;
@@ -1762,7 +1768,8 @@ FLATTEN void XOut_next_a_nova(XOut* unit, int inNumSamples) {
     } else {
         for (int i = 0; i < numChannels; ++i, out += bufLength) {
             AudioBusGuard<false> guard(unit, fbusChannel + i, maxChannel);
-            if (guard.isValid) {
+
+            if (guard.isValid()) {
                 float* in = IN(i + 2);
                 if (touched[i] == bufCounter)
                     nova::mix_vec_simd(out, out, 1 - xfade0, in, xfade0, inNumSamples);
@@ -1870,7 +1877,7 @@ void OffsetOut_next_a_reblock(OffsetOut* unit, int inNumSamples) {
 
         float* in = IN(i + 1);
 
-        if (guard.isValid) {
+        if (guard.isValid()) {
             if (tick == 0) {
                 // If this is the first tick, copy/accumulate the saved input
                 // from the previous period and clear the remaining channel so
@@ -1946,7 +1953,7 @@ void OffsetOut_next_a(OffsetOut* unit, int inNumSamples) {
         //	i, touched[i] == bufCounter, unit->m_empty,
         //	offset, remain);
 
-        if (guard.isValid) {
+        if (guard.isValid()) {
             if (touched[i] == bufCounter) {
                 if (unit->m_empty) {
                     // Print("touched offset %d\n", offset);

--- a/server/plugins/IOUGens.cpp
+++ b/server/plugins/IOUGens.cpp
@@ -136,8 +136,8 @@ void Control_next_1(Control* unit, int inNumSamples);
 
 void AudioControl_Ctor(AudioControl* inUnit);
 void AudioControl_Dtor(AudioControl* inUnit);
-void AudioControl_next_reblock(AudioControl* unit, int inNumSamples);
-void AudioControl_next_k(AudioControl* unit, int inNumSamples);
+void AudioControl_next_a_reblock(AudioControl* unit, int inNumSamples);
+void AudioControl_next_a(AudioControl* unit, int inNumSamples);
 void AudioControl_next_1(AudioControl* unit, int inNumSamples);
 
 void TrigControl_Ctor(TrigControl* inUnit);
@@ -147,67 +147,71 @@ void TrigControl_next_1(TrigControl* unit, int inNumSamples);
 void LagControl_Ctor(LagControl* inUnit);
 void LagControl_Dtor(LagControl* inUnit);
 void LagControl_next_k(LagControl* unit, int inNumSamples);
+void LagControl_next_k_reblock(LagControl* unit, int inNumSamples);
 void LagControl_next_1(LagControl* unit, int inNumSamples);
-
-void InTrig_Ctor(InTrig* unit);
-void InTrig_next_reblock(InTrig* unit, int inNumSamples);
-void InTrig_next_k(InTrig* unit, int inNumSamples);
+void LagControl_next_1_reblock(LagControl* unit, int inNumSamples);
 
 void In_Ctor(In* unit);
 void In_Dtor(In* unit);
-void In_next_reblock(In* unit, int inNumSamples);
+void In_next_a_reblock(In* unit, int inNumSamples);
 void In_next_a(In* unit, int inNumSamples);
 void In_next_k(In* unit, int inNumSamples);
 
 void LagIn_Ctor(LagIn* unit);
 void LagIn_next_0(LagIn* unit, int inNumSamples);
 void LagIn_next_k(LagIn* unit, int inNumSamples);
+void LagIn_next_k_reblock(LagIn* unit, int inNumSamples);
 
 void InFeedback_Ctor(InFeedback* unit);
 void InFeedback_Dtor(InFeedback* unit);
-void InFeedback_next_reblock(InFeedback* unit, int inNumSamples);
+void InFeedback_next_a_reblock(InFeedback* unit, int inNumSamples);
 void InFeedback_next_a(InFeedback* unit, int inNumSamples);
 
+void InTrig_Ctor(InTrig* unit);
+void InTrig_next_k_reblock(InTrig* unit, int inNumSamples);
+void InTrig_next_k(InTrig* unit, int inNumSamples);
+
+void ReplaceOut_Ctor(ReplaceOut* unit);
+void ReplaceOut_next_a_reblock(ReplaceOut* unit, int inNumSamples);
+void ReplaceOut_next_a(ReplaceOut* unit, int inNumSamples);
+void ReplaceOut_next_k_reblock(ReplaceOut* unit, int inNumSamples);
+void ReplaceOut_next_k(ReplaceOut* unit, int inNumSamples);
+
 void Out_Ctor(Out* unit);
-void Out_next_reblock(Out* unit, int inNumSamples);
+void Out_next_a_reblock(Out* unit, int inNumSamples);
 void Out_next_a(Out* unit, int inNumSamples);
+void Out_next_k_reblock(Out* unit, int inNumSamples);
 void Out_next_k(Out* unit, int inNumSamples);
 
 void XOut_Ctor(XOut* unit);
-void XOut_next_reblock(XOut* unit, int inNumSamples);
+void XOut_next_a_reblock(XOut* unit, int inNumSamples);
 void XOut_next_a(XOut* unit, int inNumSamples);
+void XOut_next_k_reblock(XOut* unit, int inNumSamples);
 void XOut_next_k(XOut* unit, int inNumSamples);
-
-void ReplaceOut_Ctor(ReplaceOut* unit);
-void ReplaceOut_next_reblock(ReplaceOut* unit, int inNumSamples);
-void ReplaceOut_next_a(ReplaceOut* unit, int inNumSamples);
-void ReplaceOut_next_k(ReplaceOut* unit, int inNumSamples);
 
 void OffsetOut_Ctor(OffsetOut* unit);
 void OffsetOut_Dtor(OffsetOut* unit);
-void OffsetOut_next_reblock(OffsetOut* unit, int inNumSamples);
+void OffsetOut_next_a_reblock(OffsetOut* unit, int inNumSamples);
 void OffsetOut_next_a(OffsetOut* unit, int inNumSamples);
 
-void LocalIn_Ctor(LocalIn* unit);
-void LocalIn_Dtor(LocalIn* unit);
-void LocalIn_next_reblock(LocalIn* unit, int inNumSamples);
-void LocalIn_next_a(LocalIn* unit, int inNumSamples);
-void LocalIn_next_k(LocalIn* unit, int inNumSamples);
-
-void LocalOut_Ctor(LocalOut* unit);
-void LocalOut_next_reblock(LocalOut* unit, int inNumSamples);
-void LocalOut_next_a(LocalOut* unit, int inNumSamples);
-void LocalOut_next_k(LocalOut* unit, int inNumSamples);
-
 void SharedIn_Ctor(SharedIn* unit);
-void SharedIn_next_reblock(SharedIn* unit, int inNumSamples);
-void SharedIn_next_a(SharedIn* unit, int inNumSamples);
 void SharedIn_next_k(SharedIn* unit, int inNumSamples);
 
 void SharedOut_Ctor(SharedOut* unit);
-void SharedOut_next_reblock(SharedOut* unit, int inNumSamples);
-void SharedOut_next_a(SharedOut* unit, int inNumSamples);
 void SharedOut_next_k(SharedOut* unit, int inNumSamples);
+
+void LocalIn_Ctor(LocalIn* unit);
+void LocalIn_Dtor(LocalIn* unit);
+void LocalIn_next_a_reblock(LocalIn* unit, int inNumSamples);
+void LocalIn_next_a(LocalIn* unit, int inNumSamples);
+void LocalIn_next_k_reblock(LocalIn* unit, int inNumSamples);
+void LocalIn_next_k(LocalIn* unit, int inNumSamples);
+
+void LocalOut_Ctor(LocalOut* unit);
+void LocalOut_next_a_reblock(LocalOut* unit, int inNumSamples);
+void LocalOut_next_a(LocalOut* unit, int inNumSamples);
+void LocalOut_next_k_reblock(LocalOut* unit, int inNumSamples);
+void LocalOut_next_k(LocalOut* unit, int inNumSamples);
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////
@@ -305,6 +309,7 @@ void Control_next_1(Control* unit, int inNumSamples) {
 }
 
 void Control_Ctor(Control* unit) {
+    // There is no need for dedicated reblocking calc functions.
     if (unit->mNumOutputs == 1) {
         SETCALC(Control_next_1);
         Control_next_1(unit, 1);
@@ -317,7 +322,7 @@ void Control_Ctor(Control* unit) {
 //////////////////////////////////////////////////////////////////////////////////////////////////
 
 // This is the reblocking version of AudioControl_next_channel().
-inline void AudioControl_next_reblock_channel(AudioControl* unit, int i, float* mapin, int mapRate, double resample,
+inline void AudioControl_next_channel_reblock(AudioControl* unit, int i, float* mapin, int mapRate, double resample,
                                               int inNumSamples) {
     float* out = OUT(i);
 
@@ -330,29 +335,36 @@ inline void AudioControl_next_reblock_channel(AudioControl* unit, int i, float* 
     case calc_BufRate: {
         float nextVal = mapin[0];
         float curVal = unit->m_prevVal[i];
-        // We must adjust the slope for the resample factor!
-        // Example: with 2x upsampling the output is double the
-        // size of the input, so we would have to half the slope.
-        float valSlope = CALCSLOPE(nextVal, curVal) * resample;
+        const int32 tick = unit->mParent->mTickCounter;
+        const int32 numTicks = unit->mParent->mNumTicks;
+        // Output the slope segment for the current tick.
+        // In the case of upsampling, the slope values will be sampled with zero-order-hold,
+        // just like regular audio signals. This means that we must use the *global* slope factor!
+        float valSlope = (nextVal - curVal) * unit->mWorld->mFullRate.mSlopeFactor;
+        int offset = tick * inNumSamples;
         for (int j = 0; j < inNumSamples; j++) {
-            out[j] = curVal; // should be prevVal
-            curVal += valSlope;
+            int index = (offset + j) * resample;
+            out[j] = curVal + valSlope * index;
         }
-        unit->m_prevVal[i] = curVal;
+        // only update on last tick
+        if (tick == numTicks - 1)
+            unit->m_prevVal[i] = nextVal;
     } break;
     case calc_FullRate: {
         // see comment in AudioControl_next_channel()
         World* world = unit->mWorld;
+        const int32 tick = unit->mParent->mTickCounter;
+        const int32 numTicks = unit->mParent->mNumTicks;
         int32* channelOffsets = unit->mParent->mAudioBusOffsets;
         int thisChannelOffset = channelOffsets[unit->mSpecialIndex + i];
         if (thisChannelOffset >= 0) {
-            int offset = unit->mParent->mTickCounter * inNumSamples * resample;
+            int offset = tick * inNumSamples * resample;
             float* in = mapin + offset;
 
             AudioBusGuard<true> guard(unit, thisChannelOffset, world->mNumAudioBusChannels);
 
             // cache current bus touching values on first tick
-            if (unit->mParent->mTickCounter == 0) {
+            if (tick == 0) {
                 unit->m_busTouchedCache[i] = world->mAudioBusTouched[thisChannelOffset];
             }
 
@@ -368,7 +380,9 @@ inline void AudioControl_next_reblock_channel(AudioControl* unit, int i, float* 
             } else if (diff == 1) {
                 if (unit->m_busUsedInPrevCycle[i]) {
                     Clear(inNumSamples, out);
-                    unit->m_busUsedInPrevCycle[i] = false;
+                    // only update on last tick!!
+                    if (tick == numTicks - 1)
+                        unit->m_busUsedInPrevCycle[i] = false;
                 } else {
                     // copy with reblocking/resampling
                     for (int i = 0; i < inNumSamples; ++i) {
@@ -388,7 +402,7 @@ inline void AudioControl_next_reblock_channel(AudioControl* unit, int i, float* 
     }
 }
 
-void AudioControl_next_reblock(AudioControl* unit, int inNumSamples) {
+void AudioControl_next_a_reblock(AudioControl* unit, int inNumSamples) {
     uint32 numChannels = unit->mNumOutputs;
     float** mapin = unit->mParent->mMapControls + unit->mSpecialIndex;
     int* mapRates = unit->mParent->mControlRates + unit->mSpecialIndex;
@@ -403,7 +417,7 @@ void AudioControl_next_reblock(AudioControl* unit, int inNumSamples) {
     double resample = unit->mWorld->mSampleRate / SAMPLERATE;
 
     for (uint32 i = 0; i < numChannels; ++i) {
-        AudioControl_next_reblock_channel(unit, i, mapin[i], mapRates[i], resample, inNumSamples);
+        AudioControl_next_channel_reblock(unit, i, mapin[i], mapRates[i], resample, inNumSamples);
     }
 }
 
@@ -468,7 +482,7 @@ inline void AudioControl_next_channel(AudioControl* unit, int i, float* mapin, i
     }
 }
 
-void AudioControl_next_k(AudioControl* unit, int inNumSamples) {
+void AudioControl_next_a(AudioControl* unit, int inNumSamples) {
     uint32 numChannels = unit->mNumOutputs;
     float** mapin = unit->mParent->mMapControls + unit->mSpecialIndex;
     int* mapRates = unit->mParent->mControlRates + unit->mSpecialIndex;
@@ -499,6 +513,7 @@ void AudioControl_next_1(AudioControl* unit, int inNumSamples) {
 
 void AudioControl_Ctor(AudioControl* unit) {
     World* world = unit->mWorld;
+    float** mapControls = unit->mParent->mMapControls + unit->mSpecialIndex;
     int numChannels = unit->mNumOutputs;
 
     unit->m_prevBus = nullptr;
@@ -516,7 +531,9 @@ void AudioControl_Ctor(AudioControl* unit) {
 
         unit->m_prevVal = (float*)mem; // see AudioControl_Dtor()!
         mem += numChannels * sizeof(float);
-        std::fill_n(unit->m_prevVal, numChannels, 0.f);
+        for (int i = 0; i < numChannels; ++i) {
+            unit->m_prevVal[i] = mapControls[i][0];
+        }
 
         unit->m_busTouchedCache = (int32*)mem;
         mem += numChannels * sizeof(int32);
@@ -525,8 +542,8 @@ void AudioControl_Ctor(AudioControl* unit) {
         unit->m_busUsedInPrevCycle = (bool*)mem;
         std::fill_n(unit->m_busUsedInPrevCycle, numChannels, false);
 
-        SETCALC(AudioControl_next_reblock);
-        AudioControl_next_reblock(unit, 1);
+        SETCALC(AudioControl_next_a_reblock);
+        AudioControl_next_a_reblock(unit, 1);
     } else {
         size_t memSize = numChannels * (sizeof(float) + sizeof(bool));
         char* mem = (char*)RTAlloc(world, memSize);
@@ -534,7 +551,9 @@ void AudioControl_Ctor(AudioControl* unit) {
 
         unit->m_prevVal = (float*)mem; // see AudioControl_Dtor()!
         mem += numChannels * sizeof(float);
-        std::fill_n(unit->m_prevVal, numChannels, 0.f);
+        for (int i = 0; i < numChannels; ++i) {
+            unit->m_prevVal[i] = mapControls[i][0];
+        }
 
         unit->m_busUsedInPrevCycle = (bool*)mem;
         std::fill_n(unit->m_busUsedInPrevCycle, numChannels, false);
@@ -545,8 +564,8 @@ void AudioControl_Ctor(AudioControl* unit) {
             SETCALC(AudioControl_next_1);
             AudioControl_next_1(unit, 1);
         } else {
-            SETCALC(AudioControl_next_k);
-            AudioControl_next_k(unit, 1);
+            SETCALC(AudioControl_next_a);
+            AudioControl_next_a(unit, 1);
         }
     }
 }
@@ -571,7 +590,7 @@ void TrigControl_next_k(TrigControl* unit, int inNumSamples) {
     }
 }
 
-void TrigControl_next_1(Unit* unit, int inNumSamples) {
+void TrigControl_next_1(TrigControl* unit, int inNumSamples) {
     int specialIndex = unit->mSpecialIndex;
     Graph* parent = unit->mParent;
     float** mapin = parent->mMapControls + specialIndex;
@@ -583,6 +602,7 @@ void TrigControl_next_1(Unit* unit, int inNumSamples) {
 
 void TrigControl_Ctor(TrigControl* unit) {
     // Print("TrigControl_Ctor\n");
+    // There is no need for dedicated reblocking calc functions.
     if (unit->mNumOutputs == 1) {
         SETCALC(TrigControl_next_1);
     } else {
@@ -597,19 +617,37 @@ void LagControl_next_k(LagControl* unit, int inNumSamples) {
     uint32 numChannels = unit->mNumOutputs;
     float** mapin = unit->mParent->mMapControls + unit->mSpecialIndex;
     for (uint32 i = 0; i < numChannels; ++i) {
-        float* out = OUT(i);
         float z = mapin[i][0];
         float x = z + unit->m_b1[i] * (unit->m_y1[i] - z);
-        *out = unit->m_y1[i] = zapgremlins(x);
+        OUT0(i) = unit->m_y1[i] = zapgremlins(x);
+    }
+}
+
+void LagControl_next_k_reblock(LagControl* unit, int inNumSamples) {
+    // only compute the lagged value on the first tick!
+    if (unit->mParent->mTickCounter == 0) {
+        LagControl_next_k(unit, inNumSamples);
+    } else {
+        for (int i = 0; i < unit->mNumOutputs; ++i) {
+            OUT0(i) = unit->m_y1[i];
+        }
     }
 }
 
 void LagControl_next_1(LagControl* unit, int inNumSamples) {
     float** mapin = unit->mParent->mMapControls + unit->mSpecialIndex;
-    float* out = OUT(0);
     float z = mapin[0][0];
     float x = z + unit->m_b1[0] * (unit->m_y1[0] - z);
-    *out = unit->m_y1[0] = zapgremlins(x);
+    OUT0(0) = unit->m_y1[0] = zapgremlins(x);
+}
+
+void LagControl_next_1_reblock(LagControl* unit, int inNumSamples) {
+    // only compute the lagged value on the first tick!
+    if (unit->mParent->mTickCounter == 0) {
+        LagControl_next_k(unit, inNumSamples);
+    } else {
+        OUT0(0) = unit->m_y1[0];
+    }
 }
 
 void LagControl_Ctor(LagControl* unit) {
@@ -621,17 +659,26 @@ void LagControl_Ctor(LagControl* unit) {
     unit->m_y1 = chunk;
     unit->m_b1 = chunk + numChannels;
 
+    // NOTE: we only compute the lagged value once per control block, which means
+    // that the coefficient must be computed from the *global* sample rate!
+    double sr = unit->mWorld->mBufRate.mSampleRate;
     for (int i = 0; i < numChannels; ++i) {
         unit->m_y1[i] = mapin[i][0];
-        float lag = ZIN0(i);
-        unit->m_b1[i] = lag == 0.f ? 0.f : (float)exp(log001 / (lag * SAMPLERATE));
+        float lag = IN0(i);
+        unit->m_b1[i] = lag == 0.f ? 0.f : (float)exp(log001 / (lag * sr));
     }
 
     if (unit->mNumOutputs == 1) {
-        SETCALC(LagControl_next_1);
+        if (REBLOCK_OR_RESAMPLE)
+            SETCALC(LagControl_next_1_reblock);
+        else
+            SETCALC(LagControl_next_1);
         LagControl_next_1(unit, 1);
     } else {
-        SETCALC(LagControl_next_k);
+        if (REBLOCK_OR_RESAMPLE)
+            SETCALC(LagControl_next_k_reblock);
+        else
+            SETCALC(LagControl_next_k);
         LagControl_next_k(unit, 1);
     }
 }
@@ -716,7 +763,7 @@ void In_next_a(In* unit, int inNumSamples) {
     }
 }
 
-void In_next_reblock(In* unit, int inNumSamples) {
+void In_next_a_reblock(In* unit, int inNumSamples) {
     World* world = unit->mWorld;
     int bufLength = world->mBufLength;
     int numChannels = unit->mNumOutputs;
@@ -809,7 +856,7 @@ void In_Ctor(In* unit) {
             ClearUnitIfMemFailed(unit->m_busTouchedCache);
             std::fill_n(unit->m_busTouchedCache, numChannels, -1);
 
-            SETCALC(In_next_reblock);
+            SETCALC(In_next_a_reblock);
         }
 #ifdef NOVA_SIMD
         else if (BUFLENGTH == 64)
@@ -823,6 +870,7 @@ void In_Ctor(In* unit) {
         unit->m_busTouched = world->mAudioBusTouched;
         In_next_a(unit, 1);
     } else {
+        // There is no need for a dedicated reblocking calc function.
         SETCALC(In_next_k);
         unit->m_bus = world->mControlBus;
         // unit->m_busTouched = world->mControlBusTouched;
@@ -850,11 +898,30 @@ void LagIn_next_k(LagIn* unit, int inNumSamples) {
     float* y1 = unit->m_y1;
 
     for (int i = 0; i < numChannels; ++i) {
-        ACQUIRE_BUS_CONTROL(firstOutputChannel + i);
-        float z = readControlBus(bus + i, firstOutputChannel + i, maxChannel);
-        RELEASE_BUS_CONTROL(firstOutputChannel + i);
-        float x = z + b1 * (y1[i] - z);
-        OUT0(i) = y1[i] = zapgremlins(x);
+        if (i < kMaxLags) {
+            ACQUIRE_BUS_CONTROL(firstOutputChannel + i);
+            float z = readControlBus(bus + i, firstOutputChannel + i, maxChannel);
+            RELEASE_BUS_CONTROL(firstOutputChannel + i);
+            float x = z + b1 * (y1[i] - z);
+            OUT0(i) = y1[i] = zapgremlins(x);
+        } else {
+            OUT0(i) = 0.0;
+        }
+    }
+}
+
+void LagIn_next_k_reblock(LagIn* unit, int inNumSamples) {
+    // only compute the lagged value on the first tick!
+    if (unit->mParent->mTickCounter == 0) {
+        LagIn_next_k(unit, inNumSamples);
+    } else {
+        for (int i = 0; i < unit->mNumOutputs; ++i) {
+            if (i < kMaxLags) {
+                OUT0(i) = unit->m_y1[i];
+            } else {
+                OUT0(i) = 0.0;
+            }
+        }
     }
 }
 
@@ -870,9 +937,13 @@ void LagIn_next_0(LagIn* unit, int inNumSamples) {
     const float* bus = unit->m_bus;
     float* y1 = unit->m_y1;
     for (int i = 0; i < numChannels; ++i) {
-        ACQUIRE_BUS_CONTROL(firstOutputChannel + i);
-        OUT0(i) = y1[i] = readControlBus(bus + i, firstOutputChannel + i, maxChannel);
-        RELEASE_BUS_CONTROL(firstOutputChannel + i);
+        if (i < kMaxLags) {
+            ACQUIRE_BUS_CONTROL(firstOutputChannel + i);
+            OUT0(i) = y1[i] = readControlBus(bus + i, firstOutputChannel + i, maxChannel);
+            RELEASE_BUS_CONTROL(firstOutputChannel + i);
+        } else {
+            OUT0(i) = 0.0;
+        }
     }
 }
 
@@ -881,16 +952,21 @@ void LagIn_Ctor(LagIn* unit) {
     unit->m_fbusChannel = -1.;
 
     float lag = ZIN0(1);
-    unit->m_b1 = lag == 0.f ? 0.f : (float)exp(log001 / (lag * SAMPLERATE));
-
-    SETCALC(LagIn_next_k);
+    // NOTE: we only compute the lagged value once per control block, which means
+    // that the coefficient must be computed from the *global* sample rate!
+    double sr = world->mBufRate.mSampleRate;
+    unit->m_b1 = lag == 0.f ? 0.f : (float)exp(log001 / (lag * sr));
+    if (REBLOCK_OR_RESAMPLE)
+        SETCALC(LagIn_next_k_reblock);
+    else
+        SETCALC(LagIn_next_k);
     unit->m_bus = world->mControlBus;
     LagIn_next_0(unit, 1);
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////
 
-void InFeedback_next_reblock(InFeedback* unit, int inNumSamples) {
+void InFeedback_next_a_reblock(InFeedback* unit, int inNumSamples) {
     World* world = unit->mWorld;
     int bufLength = world->mBufLength;
     int numChannels = unit->mNumOutputs;
@@ -1010,8 +1086,8 @@ void InFeedback_Ctor(InFeedback* unit) {
         ClearUnitIfMemFailed(unit->m_busTouchedCache);
         std::fill_n(unit->m_busTouchedCache, numChannels, -1);
 
-        SETCALC(InFeedback_next_reblock);
-        InFeedback_next_reblock(unit, 1);
+        SETCALC(InFeedback_next_a_reblock);
+        InFeedback_next_a_reblock(unit, 1);
     } else {
         SETCALC(InFeedback_next_a);
         InFeedback_next_a(unit, 1);
@@ -1026,37 +1102,6 @@ void InFeedback_Dtor(InFeedback* unit) {
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////
-
-void InTrig_next_reblock(InTrig* unit, int inNumSamples) {
-    World* world = unit->mWorld;
-    int numChannels = unit->mNumOutputs;
-
-    float fbusChannel = ZIN0(0);
-    IO_k_update_channels<true>(unit, world, fbusChannel, numChannels);
-    const int32 maxChannel = world->mNumControlBusChannels;
-    const int32 firstOutputChannel = (int)fbusChannel;
-
-    const float* in = unit->m_bus;
-    int32* touched = unit->m_busTouched;
-    int32 bufCounter = unit->mWorld->mBufCounter;
-
-    // only trigger on the first sub-tick!
-    // NB: we do not need to cache the buffer touch value
-    // because we only read it on the first tick.
-    if (unit->mParent->mTickCounter == 0) {
-        for (int i = 0; i < numChannels; ++i, in++) {
-            ACQUIRE_BUS_CONTROL(firstOutputChannel + i);
-            if (touched[i] == bufCounter)
-                OUT0(i) = readControlBus(in, firstOutputChannel + i, maxChannel);
-            else
-                OUT0(i) = 0.f;
-            RELEASE_BUS_CONTROL(firstOutputChannel + i);
-        }
-    } else {
-        for (int i = 0; i < numChannels; ++i)
-            OUT0(i) = 0.f;
-    }
-}
 
 void InTrig_next_k(InTrig* unit, int inNumSamples) {
     World* world = unit->mWorld;
@@ -1081,6 +1126,17 @@ void InTrig_next_k(InTrig* unit, int inNumSamples) {
     }
 }
 
+void InTrig_next_k_reblock(InTrig* unit, int inNumSamples) {
+    // only trigger on the first tick!
+    // NB: we do not need to cache the buffer touch value because we only read it on the first tick.
+    if (unit->mParent->mTickCounter == 0) {
+        InTrig_next_k(unit, inNumSamples);
+    } else {
+        for (int i = 0; i < unit->mNumOutputs; ++i)
+            OUT0(i) = 0.f;
+    }
+}
+
 void InTrig_Ctor(InTrig* unit) {
     World* world = unit->mWorld;
     unit->m_fbusChannel = -1.;
@@ -1094,18 +1150,16 @@ void InTrig_Ctor(InTrig* unit) {
     unit->m_bus = world->mControlBus;
     unit->m_busTouched = world->mControlBusTouched;
 
-    if (REBLOCK_OR_RESAMPLE) {
-        SETCALC(InTrig_next_reblock);
-        InTrig_next_reblock(unit, 1);
-    } else {
+    if (REBLOCK_OR_RESAMPLE)
+        SETCALC(InTrig_next_k_reblock);
+    else
         SETCALC(InTrig_next_k);
-        InTrig_next_k(unit, 1);
-    }
+    InTrig_next_k(unit, 1);
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////
 
-void ReplaceOut_next_reblock(ReplaceOut* unit, int inNumSamples) {
+void ReplaceOut_next_a_reblock(ReplaceOut* unit, int inNumSamples) {
     World* world = unit->mWorld;
     int bufLength = world->mBufLength;
     int numChannels = unit->mNumInputs - 1;
@@ -1156,35 +1210,6 @@ void ReplaceOut_next_a(ReplaceOut* unit, int inNumSamples) {
             touched[i] = bufCounter;
         }
     }
-}
-
-void ReplaceOut_next_k(ReplaceOut* unit, int inNumSamples) {
-    World* world = unit->mWorld;
-    int numChannels = unit->mNumInputs - 1;
-
-    float fbusChannel = ZIN0(0);
-    IO_k_update_channels<true>(unit, world, fbusChannel, numChannels);
-    const int32 maxChannel = world->mNumControlBusChannels;
-    const int32 firstOutputChannel = (int)fbusChannel;
-
-    float* out = unit->m_bus;
-    int32* touched = unit->m_busTouched;
-    int32 bufCounter = unit->mWorld->mBufCounter;
-    for (int i = 0; i < numChannels; ++i, out++) {
-        if (firstOutputChannel + i < maxChannel) {
-            float* in = IN(i + 1);
-            ACQUIRE_BUS_CONTROL((int32)fbusChannel + i);
-            *out = *in;
-            touched[i] = bufCounter;
-            RELEASE_BUS_CONTROL((int32)fbusChannel + i);
-        }
-    }
-}
-
-void ReplaceOut_next_k_reblock(ReplaceOut* unit, int inNumSamples) {
-    // only output on the first tick!
-    if (unit->mParent->mTickCounter == 0)
-        ReplaceOut_next_k(unit, inNumSamples);
 }
 
 #ifdef NOVA_SIMD
@@ -1238,13 +1263,42 @@ FLATTEN void ReplaceOut_next_a_nova_64(ReplaceOut* unit, int inNumSamples) {
 
 #endif /* NOVA_SIMD */
 
+void ReplaceOut_next_k(ReplaceOut* unit, int inNumSamples) {
+    World* world = unit->mWorld;
+    int numChannels = unit->mNumInputs - 1;
+
+    float fbusChannel = ZIN0(0);
+    IO_k_update_channels<true>(unit, world, fbusChannel, numChannels);
+    const int32 maxChannel = world->mNumControlBusChannels;
+    const int32 firstOutputChannel = (int)fbusChannel;
+
+    float* out = unit->m_bus;
+    int32* touched = unit->m_busTouched;
+    int32 bufCounter = unit->mWorld->mBufCounter;
+    for (int i = 0; i < numChannels; ++i, out++) {
+        if (firstOutputChannel + i < maxChannel) {
+            float* in = IN(i + 1);
+            ACQUIRE_BUS_CONTROL((int32)fbusChannel + i);
+            *out = *in;
+            touched[i] = bufCounter;
+            RELEASE_BUS_CONTROL((int32)fbusChannel + i);
+        }
+    }
+}
+
+void ReplaceOut_next_k_reblock(ReplaceOut* unit, int inNumSamples) {
+    // only output on first tick!
+    if (unit->mParent->mTickCounter == 0)
+        ReplaceOut_next_k(unit, inNumSamples);
+}
+
 void ReplaceOut_Ctor(ReplaceOut* unit) {
     World* world = unit->mWorld;
     unit->m_fbusChannel = -1.;
 
     if (unit->mCalcRate == calc_FullRate) {
         if (REBLOCK_OR_RESAMPLE)
-            SETCALC(ReplaceOut_next_reblock);
+            SETCALC(ReplaceOut_next_a_reblock);
 #ifdef NOVA_SIMD
         else if (BUFLENGTH == 64)
             SETCALC(ReplaceOut_next_a_nova_64);
@@ -1267,7 +1321,7 @@ void ReplaceOut_Ctor(ReplaceOut* unit) {
 
 //////////////////////////////////////////////////////////////////////////////////////////////////
 
-void Out_next_reblock(Out* unit, int inNumSamples) {
+void Out_next_a_reblock(Out* unit, int inNumSamples) {
     World* world = unit->mWorld;
     int bufLength = world->mBufLength;
     int numChannels = unit->mNumInputs - 1;
@@ -1468,7 +1522,7 @@ void Out_Ctor(Out* unit) {
 
     if (unit->mCalcRate == calc_FullRate) {
         if (REBLOCK_OR_RESAMPLE)
-            SETCALC(Out_next_reblock);
+            SETCALC(Out_next_a_reblock);
 #if defined(NOVA_SIMD)
         else if (BUFLENGTH == 64)
             SETCALC(Out_next_a_nova_64);
@@ -1500,7 +1554,7 @@ void Out_Ctor(Out* unit) {
 //////////////////////////////////////////////////////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////////////////////////
 
-void XOut_next_reblock(XOut* unit, int inNumSamples) {
+void XOut_next_a_reblock(XOut* unit, int inNumSamples) {
     World* world = unit->mWorld;
     int bufLength = world->mBufLength;
     int numChannels = unit->mNumInputs - 2;
@@ -1766,7 +1820,7 @@ void XOut_Ctor(XOut* unit) {
     unit->m_xfade = ZIN0(1);
     if (unit->mCalcRate == calc_FullRate) {
         if (REBLOCK_OR_RESAMPLE)
-            SETCALC(XOut_next_reblock);
+            SETCALC(XOut_next_a_reblock);
 #ifdef NOVA_SIMD
         else if (boost::alignment::is_aligned(BUFLENGTH, 16))
             SETCALC(XOut_next_a_nova);
@@ -1788,7 +1842,7 @@ void XOut_Ctor(XOut* unit) {
 
 //////////////////////////////////////////////////////////////////////////////////////////////////
 
-void OffsetOut_next_reblock(OffsetOut* unit, int inNumSamples) {
+void OffsetOut_next_a_reblock(OffsetOut* unit, int inNumSamples) {
     World* world = unit->mWorld;
     int bufLength = world->mBufLength;
     int numChannels = unit->mNumInputs - 1;
@@ -1925,7 +1979,7 @@ void OffsetOut_Ctor(OffsetOut* unit) {
     unit->m_fbusChannel = -1.;
 
     if (REBLOCK_OR_RESAMPLE)
-        SETCALC(OffsetOut_next_reblock);
+        SETCALC(OffsetOut_next_a_reblock);
     else
         SETCALC(OffsetOut_next_a);
     unit->m_bus = world->mAudioBus;
@@ -2013,6 +2067,7 @@ void SharedIn_Ctor(SharedIn* unit) {
     World* world = unit->mWorld;
     unit->m_fbusChannel = -1.;
 
+    // There is no need for a dedicated reblocking calc function.
     SETCALC(SharedIn_next_k);
     unit->m_bus = world->mSharedControls;
     SharedIn_next_k(unit, 1);
@@ -2053,6 +2108,7 @@ void SharedOut_Ctor(SharedOut* unit) {
     World* world = unit->mWorld;
     unit->m_fbusChannel = -1.;
 
+    // There is no need for a dedicated reblocking calc function.
     SETCALC(SharedOut_next_k);
     unit->m_bus = world->mSharedControls;
     SharedOut_next_k(unit, 1);
@@ -2062,7 +2118,7 @@ void SharedOut_Ctor(SharedOut* unit) {
 
 //////////////////////////////////////////////////////////////////////////////////////////////////
 
-void LocalIn_next_reblock(LocalIn* unit, int inNumSamples) {
+void LocalIn_next_a_reblock(LocalIn* unit, int inNumSamples) {
     int bufLength = unit->mBufLength;
     int numChannels = unit->mNumOutputs;
 
@@ -2074,7 +2130,7 @@ void LocalIn_next_reblock(LocalIn* unit, int inNumSamples) {
     int64 tickCounter = unit->mParent->mTickCounter;
     int64 numTicks = unit->mParent->mNumTicks;
     int64 counter = bufCounter * numTicks + tickCounter;
-    // Print("LocalIn_next_reblock: counter: %d\n", counter);
+    // Print("LocalIn_next_a_reblock: counter: %d\n", counter);
 
     for (int i = 0; i < numChannels; ++i, in += bufLength) {
         float* out = OUT(i);
@@ -2150,7 +2206,6 @@ FLATTEN void LocalIn_next_a_nova_64(LocalIn* unit, int inNumSamples) {
 
 void LocalIn_next_k_reblock(LocalIn* unit, int inNumSamples) {
     int numChannels = unit->mNumOutputs;
-
     float* in = unit->m_bus;
     int64* touched = unit->m_busTouched;
     // This keeps track of buffer touching for every subtick.
@@ -2171,7 +2226,6 @@ void LocalIn_next_k_reblock(LocalIn* unit, int inNumSamples) {
 
 void LocalIn_next_k(LocalIn* unit, int inNumSamples) {
     uint32 numChannels = unit->mNumOutputs;
-
     float* in = unit->m_bus;
     int64* touched = unit->m_busTouched;
     int32 bufCounter = unit->mWorld->mBufCounter;
@@ -2192,13 +2246,13 @@ void LocalIn_Ctor(LocalIn* unit) {
 
     int busDataSize = numChannels * BUFLENGTH;
 
-    // align the buffer to 256 bytes so that we can use avx instructions
+    // align the buffer to 32 bytes so that we can use avx instructions
     unit->m_realData =
         (float*)RTAlloc(world, busDataSize * sizeof(float) + numChannels * sizeof(int64) + 32 * sizeof(float));
     ClearUnitIfMemFailed(unit->m_realData);
-    size_t alignment = (size_t)unit->m_realData & 31;
+    size_t alignment = (uintptr_t)unit->m_realData & 31;
 
-    unit->m_bus = alignment ? (float*)(size_t(unit->m_realData + 32) & ~31) : unit->m_realData;
+    unit->m_bus = alignment ? (float*)(((uintptr_t)unit->m_realData + 32) & ~31) : unit->m_realData;
 
     unit->m_busTouched = (int64*)(unit->m_bus + busDataSize);
     std::fill_n(unit->m_busTouched, numChannels, -1);
@@ -2211,7 +2265,7 @@ void LocalIn_Ctor(LocalIn* unit) {
         }
         unit->mParent->mLocalAudioBusUnit = unit;
         if (REBLOCK_OR_RESAMPLE)
-            SETCALC(LocalIn_next_reblock);
+            SETCALC(LocalIn_next_a_reblock);
 #ifdef NOVA_SIMD
         else if (BUFLENGTH == 64)
             SETCALC(LocalIn_next_a_nova_64);
@@ -2241,8 +2295,8 @@ void LocalIn_Dtor(LocalIn* unit) { RTFree(unit->mWorld, unit->m_realData); }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////
 
-void LocalOut_next_reblock(LocalOut* unit, int inNumSamples) {
-    // Print("LocalOut_next_reblock %d\n", unit->mNumInputs);
+void LocalOut_next_a_reblock(LocalOut* unit, int inNumSamples) {
+    // Print("LocalOut_next_a_reblock %d\n", unit->mNumInputs);
     int bufLength = unit->mBufLength;
     int numChannels = unit->mNumInputs;
 
@@ -2259,7 +2313,7 @@ void LocalOut_next_reblock(LocalOut* unit, int inNumSamples) {
     int64 tickCounter = unit->mParent->mTickCounter;
     int64 numTicks = unit->mParent->mNumTicks;
     int64 counter = bufCounter * numTicks + tickCounter;
-    // Print("LocalOut_next_reblock: counter: %d\n", counter);
+    // Print("LocalOut_next_a_reblock: counter: %d\n", counter);
 
     for (int i = 0; i < numChannels; ++i, out += bufLength) {
         float* in = IN(i);
@@ -2362,7 +2416,7 @@ FLATTEN void LocalOut_next_a_nova_64(LocalOut* unit, int inNumSamples) {
 void LocalOut_next_k_reblock(LocalOut* unit, int inNumSamples) {
     int numChannels = unit->mNumInputs;
 
-    LocalIn* localIn = (LocalIn*)unit->mParent->mLocalAudioBusUnit;
+    LocalIn* localIn = (LocalIn*)unit->mParent->mLocalControlBusUnit;
     if (!localIn)
         return;
 
@@ -2415,7 +2469,7 @@ void LocalOut_Ctor(LocalOut* unit) {
 
     if (unit->mCalcRate == calc_FullRate) {
         if (REBLOCK_OR_RESAMPLE)
-            SETCALC(LocalOut_next_reblock);
+            SETCALC(LocalOut_next_a_reblock);
 #ifdef NOVA_SIMD
         else if (BUFLENGTH == 64)
             SETCALC(LocalOut_next_a_nova_64);

--- a/server/plugins/IOUGens.cpp
+++ b/server/plugins/IOUGens.cpp
@@ -1883,23 +1883,28 @@ void OffsetOut_next_a_reblock(OffsetOut* unit, int inNumSamples) {
                 // from the previous period and clear the remaining channel so
                 // that every tick can simply accumulate its input.
                 // (This also works in ParGroups because only one Ugen gets
-                // to updatemBufTouched!)
-                if (touched[i] != bufCounter) {
-                    touched[i] = bufCounter;
+                // to update mBufTouched!)
+                if (touched[i] == bufCounter) {
+                    if (unit->m_empty) {
+                        // Print("touched offset %d\n", offset);
+                    } else {
+                        Accum(offset, out, saved);
+                    }
+                } else {
                     if (unit->m_empty) {
                         // clear whole channel
                         Clear(bufLength, out);
+                        // Print("untouched offset %d\n", offset);
                     } else {
                         Copy(offset, out, saved);
                         Clear(remain, out + offset);
                     }
-                } else {
-                    Accum(offset, out, saved);
+                    touched[i] = bufCounter;
                 }
             }
 
-            // accumulate the current input into the bus
-            // (shifted by 'offset' samples)
+            // accumulate the current input (up to 'remain' samples)
+            // into the bus, shifted by 'offset' samples
             int n = sc_min(remain - outPhase, outSamples);
             if (n > 0) {
                 for (int j = 0; j < n; ++j) {
@@ -1910,16 +1915,15 @@ void OffsetOut_next_a_reblock(OffsetOut* unit, int inNumSamples) {
             }
         }
 
-        // from here we do not touch the bus so we can unlock it.
-        guard.unlock();
-
-        // save remaining input samples (with reblocking)
+        // save remaining input samples (with reblocking).
+        // Also do this if the buf channel was out-of-range.
         int n = sc_min(outPhase + outSamples - remain, outSamples);
         if (n > 0) {
+            // j starts at the offset within 'outSamples'.
             for (int j = outSamples - n; j < outSamples; ++j) {
-                int index = j + outPhase;
+                int index = outPhase + j - remain;
                 int k = j * resample;
-                saved[index - remain] = in[k];
+                saved[index] = in[k];
             }
         }
     }
@@ -1973,6 +1977,7 @@ void OffsetOut_next_a(OffsetOut* unit, int inNumSamples) {
             }
         }
 
+        // always copy the remaining input, even if the buf channel was out-of-range.
         Copy(offset, saved, in + remain);
 
         // Print("out %d %d %d  %g %g\n", i, in[0], out[0]);
@@ -2019,21 +2024,25 @@ void OffsetOut_Dtor(OffsetOut* unit) {
         float* saved = unit->m_saved;
         int32* touched = unit->m_busTouched;
         int32 bufCounter = unit->mWorld->mBufCounter;
-        for (int i = 0; i < numChannels; ++i, out += bufLength, saved += offset) {
-            // Print("out %d  %d %d  %d %d\n",
-            //	i, touched[i] == bufCounter, unit->m_empty,
-            //	offset, remain);
+        int32 bufChannel = (int32)unit->m_fbusChannel;
+        int32 maxChannel = world->mNumAudioBusChannels;
 
-            if (!unit->m_empty) {
-                if (touched[i] == bufCounter) {
-                    Accum(offset, out, saved);
-                } else {
-                    Copy(offset, out, saved);
-                    Clear(remain, out + offset);
-                    touched[i] = bufCounter;
+        for (int i = 0; i < numChannels; ++i, out += bufLength, saved += offset) {
+            if ((bufChannel + i) < maxChannel) {
+                // Print("out %d  %d %d  %d %d\n",
+                //	i, touched[i] == bufCounter, unit->m_empty,
+                //	offset, remain);
+                if (!unit->m_empty) {
+                    if (touched[i] == bufCounter) {
+                        Accum(offset, out, saved);
+                    } else {
+                        Copy(offset, out, saved);
+                        Clear(remain, out + offset);
+                        touched[i] = bufCounter;
+                    }
                 }
+                // Print("out %d %d %d  %g %g\n", i, in[0], out[0]);
             }
-            // Print("out %d %d %d  %g %g\n", i, in[0], out[0]);
         }
 
         RTFree(unit->mWorld, unit->m_saved);

--- a/server/plugins/IOUGens.cpp
+++ b/server/plugins/IOUGens.cpp
@@ -374,14 +374,14 @@ inline void AudioControl_next_channel_reblock(AudioControl* unit, int i, float* 
 
             int diff = world->mBufCounter - unit->m_busTouchedCache[i];
 
-            if (diff == 0) {
+            if (guard.isValid() && diff == 0) {
                 // copy with reblocking/resampling
                 for (int i = 0; i < inNumSamples; ++i) {
                     int index = i * resample;
                     out[i] = in[index];
                 }
                 unit->m_busUsedInPrevCycle[i] = true;
-            } else if (diff == 1) {
+            } else if (guard.isValid() && diff == 1) {
                 if (unit->m_busUsedInPrevCycle[i]) {
                     Clear(inNumSamples, out);
                     // only update on last tick!!
@@ -464,10 +464,10 @@ inline void AudioControl_next_channel(AudioControl* unit, int i, float* mapin, i
 
             int diff = world->mBufCounter - world->mAudioBusTouched[thisChannelOffset];
 
-            if (diff == 0) {
+            if (guard.isValid() && diff == 0) {
                 Copy(inNumSamples, out, mapin);
                 unit->m_busUsedInPrevCycle[i] = true;
-            } else if (diff == 1) {
+            } else if (guard.isValid() && diff == 1) {
                 if (unit->m_busUsedInPrevCycle[i]) {
                     Clear(inNumSamples, out);
                     unit->m_busUsedInPrevCycle[i] = false;

--- a/server/scsynth/SC_Graph.cpp
+++ b/server/scsynth/SC_Graph.cpp
@@ -35,6 +35,7 @@
 #include "SC_Errors.h"
 #include "Unroll.h"
 #include "SC_ReplyImpl.hpp"
+#include "clz.h"
 
 void Unit_ChooseMulAddFunc(Unit* unit);
 
@@ -65,6 +66,11 @@ static void Graph_Dtor(Graph* inGraph) {
                 (dtor)(unit);
         }
     }
+
+    // NOTE: mBufRate is allocated as part of mFullRate, see Graph_Ctor()!
+    if (inGraph->mFullRate != &world->mFullRate)
+        World_Free(world, inGraph->mFullRate);
+
     // free queued Unit commands
     // AFAICT this can only happen if a Graph is created, Unit commands are sent and
     // the Graph is deleted all at in the same control block.
@@ -133,9 +139,8 @@ bool Graph_HasParent(const Graph* inGraph) { return inGraph->mNode.mParent != nu
 
 static void Graph_Ctor(World* inWorld, GraphDef* inGraphDef, Graph* graph, sc_msg_iter* msg, bool argtype);
 
-SCErr Graph_New(World* inWorld, GraphDef* inGraphDef, int32 inID, sc_msg_iter* args, Graph** outGraph,
-                bool argtype) // true for normal args , false for setn type args
-{
+// 'argtype' is true for normal args, false for setn type args
+SCErr Graph_New(World* inWorld, GraphDef* inGraphDef, int32 inID, sc_msg_iter* args, Graph** outGraph, bool argtype) {
     Graph* graph;
     int err = Node_New(inWorld, &inGraphDef->mNodeDef, inID, (Node**)&graph);
     if (err)
@@ -145,9 +150,8 @@ SCErr Graph_New(World* inWorld, GraphDef* inGraphDef, int32 inID, sc_msg_iter* a
     return err;
 }
 
-static void Graph_Ctor(World* inWorld, GraphDef* inGraphDef, Graph* graph, sc_msg_iter* msg,
-                       bool argtype) // true for normal args , false for setn type args
-{
+// 'argtype' is true for normal args, false for setn type args
+static void Graph_Ctor(World* inWorld, GraphDef* inGraphDef, Graph* graph, sc_msg_iter* msg, bool argtype) {
     // scprintf("->Graph_Ctor\n");
 
     // hit the memory allocator only once.
@@ -420,6 +424,102 @@ static void Graph_Ctor(World* inWorld, GraphDef* inGraphDef, Graph* graph, sc_ms
     graph->localBufNum = 0;
     graph->localMaxBufNum = 0; // this is set from synth
 
+    graph->mFlags = 0;
+
+    int32 blockSize = inGraphDef->mBlockSize;
+    if (blockSize < 0) {
+        // get block size from Synth Control
+        uint32 index = inGraphDef->mBlockSizeIndex;
+        if (index < graph->mNumControls) {
+            blockSize = graph->mMapControls[index][0];
+        } else {
+            scprintf("ERROR: block size control index %d out of range!\n", index);
+            blockSize = 0;
+        }
+    }
+    // note: 0 means no reblocking.
+
+    float upsample = inGraphDef->mResampleFactor;
+    if (upsample < 0.0) {
+        // get resample factor from Synth Control
+        uint32 index = inGraphDef->mResampleIndex;
+        if (index < graph->mNumControls) {
+            upsample = graph->mMapControls[index][0];
+        } else {
+            scprintf("ERROR: resample control index %d out of range!\n", index);
+            upsample = 1.0;
+        }
+    }
+    // treat 0.0 as no resampling
+    if (upsample == 0.0) {
+        upsample = 1.0;
+    }
+
+    if (blockSize == 0 && upsample == 1.0) {
+        // no reblocking and no upsampling -> use the global rates
+        graph->mNumTicks = 1;
+        graph->mTickCounter = 0;
+        graph->mFullRate = &inWorld->mFullRate;
+        graph->mBufRate = &inWorld->mBufRate;
+    } else {
+        // reblocking or upsampling
+        if (upsample > 1.0) {
+            // make sure that 'upsample' is a power of two!
+            if (ISPOWEROFTWO((int)upsample)) {
+                upsample = (int)upsample;
+                graph->mFlags |= kGraph_Resample; // ok
+            } else {
+                scprintf("WARNING: Synth: upsample factor (%f) not a power of two\n", upsample);
+                upsample = 1.0;
+            }
+        } else if (upsample < 0.0) {
+            scprintf("WARNING: Synth: bad resample factor (%f)\n", upsample);
+            upsample = 1.0;
+        } else if (upsample < 1.0) {
+            scprintf("WARNING: Synth: downsampling (%f) not supported (yet)\n", upsample);
+            upsample = 1.0;
+        }
+
+        if (blockSize != 0) {
+            // block size cannot be larger than wire buffer size (yet)!
+            if (blockSize > inWorld->mBufLength) {
+                scprintf("WARNING: Synth: block size (%d) cannot be larger than Server "
+                         "block size (%d)\n",
+                         blockSize, inWorld->mBufLength);
+                // use Server block size
+                blockSize = inWorld->mBufLength;
+            } else if (!ISPOWEROFTWO(blockSize)) {
+                scprintf("WARNING: Synth: block size (%d) not a power of two\n", blockSize);
+                // use Server block size
+                blockSize = inWorld->mBufLength;
+            } else {
+                graph->mFlags |= kGraph_Reblock; // ok
+            }
+        } else {
+            // use Server block size
+            blockSize = inWorld->mBufLength;
+        }
+
+        graph->mNumTicks = (inWorld->mBufLength / blockSize) * upsample;
+        graph->mTickCounter = 0;
+        double sampleRate = inWorld->mSampleRate * upsample;
+
+        // Hit allocator only once, see Graph_Dtor().
+        // (Ideally the rates should be allocated as part of the Synth itself.
+        // This means we would have to detect potential reblocking/resampling
+        // already in the SynthDef and increase mAllocSize accordingly.)
+        Rate* chunk = (Rate*)World_Alloc(inWorld, sizeof(Rate) * 2);
+
+        graph->mFullRate = chunk;
+        Rate_Init(graph->mFullRate, sampleRate, blockSize);
+
+        graph->mBufRate = chunk + 1;
+        Rate_Init(graph->mBufRate, sampleRate / blockSize, 1);
+    }
+
+    //  scprintf("Graph_Ctor: block size: %d, upsample: %f, ticks: %d\n",
+    //           blockSize, upsample, graph->mNumTicks);
+
     // so far mPrivate is only used for queued unit commands,
     // i.e. it just points to the head of the list.
     graph->mPrivate = nullptr;
@@ -435,7 +535,7 @@ static void Graph_Ctor(World* inWorld, GraphDef* inGraphDef, Graph* graph, sc_ms
     UnitSpec* unitSpec = inGraphDef->mUnitSpecs;
     for (uint32 i = 0; i < numUnits; ++i, ++unitSpec) {
         // construct unit from spec
-        Unit* unit = Unit_New(inWorld, unitSpec, memory);
+        Unit* unit = Unit_New(inWorld, graph, unitSpec, memory);
 
         // set parent
         unit->mParent = graph;
@@ -591,39 +691,47 @@ void Graph_Calc(Graph* inGraph) {
 
     int unroll8 = numCalcUnits / 8;
     int remain8 = numCalcUnits % 8;
-    int i = 0;
-
-    for (int j = 0; j != unroll8; i += 8, ++j) {
-        Graph_Calc_unit(calcUnits[i]);
-        Graph_Calc_unit(calcUnits[i + 1]);
-        Graph_Calc_unit(calcUnits[i + 2]);
-        Graph_Calc_unit(calcUnits[i + 3]);
-        Graph_Calc_unit(calcUnits[i + 4]);
-        Graph_Calc_unit(calcUnits[i + 5]);
-        Graph_Calc_unit(calcUnits[i + 6]);
-        Graph_Calc_unit(calcUnits[i + 7]);
-    }
-
     int unroll4 = remain8 / 4;
     int remain4 = remain8 % 4;
-    if (unroll4) {
-        Graph_Calc_unit(calcUnits[i]);
-        Graph_Calc_unit(calcUnits[i + 1]);
-        Graph_Calc_unit(calcUnits[i + 2]);
-        Graph_Calc_unit(calcUnits[i + 3]);
-        i += 4;
-    }
-
     int unroll2 = remain4 / 2;
     int remain2 = remain4 % 2;
-    if (unroll2) {
-        Graph_Calc_unit(calcUnits[i]);
-        Graph_Calc_unit(calcUnits[i + 1]);
-        i += 2;
-    }
 
-    if (remain2)
-        Graph_Calc_unit(calcUnits[i]);
+    int numTicks = inGraph->mNumTicks;
+
+    for (int k = 0; k < numTicks; ++k) {
+        // set before calling Graph_Calc_unit()!
+        inGraph->mTickCounter = k;
+
+        int i = 0;
+
+        for (int j = 0; j != unroll8; i += 8, ++j) {
+            Graph_Calc_unit(calcUnits[i]);
+            Graph_Calc_unit(calcUnits[i + 1]);
+            Graph_Calc_unit(calcUnits[i + 2]);
+            Graph_Calc_unit(calcUnits[i + 3]);
+            Graph_Calc_unit(calcUnits[i + 4]);
+            Graph_Calc_unit(calcUnits[i + 5]);
+            Graph_Calc_unit(calcUnits[i + 6]);
+            Graph_Calc_unit(calcUnits[i + 7]);
+        }
+
+        if (unroll4) {
+            Graph_Calc_unit(calcUnits[i]);
+            Graph_Calc_unit(calcUnits[i + 1]);
+            Graph_Calc_unit(calcUnits[i + 2]);
+            Graph_Calc_unit(calcUnits[i + 3]);
+            i += 4;
+        }
+
+        if (unroll2) {
+            Graph_Calc_unit(calcUnits[i]);
+            Graph_Calc_unit(calcUnits[i + 1]);
+            i += 2;
+        }
+
+        if (remain2)
+            Graph_Calc_unit(calcUnits[i]);
+    }
 
     // scprintf("<-Graph_Calc\n");
 }
@@ -632,21 +740,39 @@ void Graph_CalcTrace(Graph* inGraph);
 void Graph_CalcTrace(Graph* inGraph) {
     uint32 numCalcUnits = inGraph->mNumCalcUnits;
     Unit** calcUnits = inGraph->mCalcUnits;
-    scprintf("\nTRACE %d  %s    #units: %d\n", inGraph->mNode.mID, inGraph->mNode.mDef->mName, numCalcUnits);
-    for (uint32 i = 0; i < numCalcUnits; ++i) {
-        Unit* unit = calcUnits[i];
-        scprintf("  unit %d %s\n    in ", i, (char*)unit->mUnitDef->mUnitDefName);
-        for (uint32 j = 0; j < unit->mNumInputs; ++j) {
-            scprintf(" %g", ZIN0(j));
-        }
-        scprintf("\n");
-        (unit->mCalcFunc)(unit, unit->mBufLength);
-        scprintf("    out");
-        for (uint32 j = 0; j < unit->mNumOutputs; ++j) {
-            scprintf(" %g", ZOUT0(j));
-        }
-        scprintf("\n");
+
+    if (inGraph->mFlags & kGraph_ReblockOrResample) {
+        scprintf("\nTRACE %d  %s    #units: %d, block size: %d, sr: %d\n", inGraph->mNode.mID,
+                 inGraph->mNode.mDef->mName, numCalcUnits, inGraph->mFullRate->mBufLength,
+                 (int)inGraph->mFullRate->mSampleRate);
+    } else {
+        scprintf("\nTRACE %d  %s    #units: %d\n", inGraph->mNode.mID, inGraph->mNode.mDef->mName, numCalcUnits);
     }
+
+    int numTicks = inGraph->mNumTicks;
+
+    for (int k = 0; k < numTicks; ++k) {
+        if (numTicks > 1)
+            scprintf("tick %d of %d:\n", k + 1, numTicks);
+
+        inGraph->mTickCounter = k;
+
+        for (uint32 i = 0; i < numCalcUnits; ++i) {
+            Unit* unit = calcUnits[i];
+            scprintf("  unit %d %s\n    in ", i, (char*)unit->mUnitDef->mUnitDefName);
+            for (uint32 j = 0; j < unit->mNumInputs; ++j) {
+                scprintf(" %g", ZIN0(j));
+            }
+            scprintf("\n");
+            (unit->mCalcFunc)(unit, unit->mBufLength);
+            scprintf("    out");
+            for (uint32 j = 0; j < unit->mNumOutputs; ++j) {
+                scprintf(" %g", ZOUT0(j));
+            }
+            scprintf("\n");
+        }
+    }
+
     inGraph->mNode.mCalcFunc = (NodeCalcFunc)&Graph_Calc;
 }
 

--- a/server/scsynth/SC_GraphDef.cpp
+++ b/server/scsynth/SC_GraphDef.cpp
@@ -347,6 +347,20 @@ GraphDef* GraphDef_Read(World* inWorld, const char*& buffer, const char* end, Gr
         }
     }
 
+    if (inVersion > 2) {
+        // reblock
+        graphDef->mBlockSize = readInt32_be(buffer, end);
+        graphDef->mBlockSizeIndex = readInt32_be(buffer, end);
+        // resample
+        graphDef->mResampleFactor = readFloat_be(buffer, end);
+        graphDef->mResampleIndex = readInt32_be(buffer, end);
+    } else {
+        graphDef->mBlockSize = 0;
+        graphDef->mBlockSizeIndex = 0;
+        graphDef->mResampleFactor = 1.0;
+        graphDef->mResampleIndex = 0;
+    }
+
     // finally add to list
     graphDef->mNext = inList;
     graphDef->mRefCount = 1;

--- a/server/scsynth/SC_GraphDef.h
+++ b/server/scsynth/SC_GraphDef.h
@@ -62,6 +62,12 @@ struct GraphDef {
     ParamSpec* mParamSpecs;
     ParamSpecTable* mParamSpecTable;
 
+    int32 mBlockSize;
+    uint32 mBlockSizeIndex;
+
+    float32 mResampleFactor;
+    uint32 mResampleIndex;
+
     int mRefCount;
     struct GraphDef* mNext;
 

--- a/server/scsynth/SC_MiscCmds.cpp
+++ b/server/scsynth/SC_MiscCmds.cpp
@@ -746,9 +746,8 @@ SCErr meth_d_free(World* inWorld, int inSize, char* inData, ReplyAddress* inRepl
     return kSCErr_None;
 }
 
-
-SCErr meth_s_new(World* inWorld, int inSize, char* inData, ReplyAddress* inReply);
-SCErr meth_s_new(World* inWorld, int inSize, char* inData, ReplyAddress* /*inReply*/) {
+// 'argtype' is false for setn type args
+SCErr meth_s_do_new(World* inWorld, int inSize, char* inData, bool argtype) {
     SCErr err;
     sc_msg_iter msg(inSize, inData);
     int32* defname = msg.gets4();
@@ -770,7 +769,7 @@ SCErr meth_s_new(World* inWorld, int inSize, char* inData, ReplyAddress* /*inRep
         Group* group = Msg_GetGroup(inWorld, msg);
         if (!group)
             return kSCErr_GroupNotFound;
-        err = Graph_New(inWorld, def, nodeID, &msg, &graph, true); // true for normal args
+        err = Graph_New(inWorld, def, nodeID, &msg, &graph, argtype);
         if (err)
             return err;
         if (!graph)
@@ -781,7 +780,7 @@ SCErr meth_s_new(World* inWorld, int inSize, char* inData, ReplyAddress* /*inRep
         Group* group = Msg_GetGroup(inWorld, msg);
         if (!group)
             return kSCErr_GroupNotFound;
-        err = Graph_New(inWorld, def, nodeID, &msg, &graph, true);
+        err = Graph_New(inWorld, def, nodeID, &msg, &graph, argtype);
         if (err)
             return err;
         Group_AddTail(group, &graph->mNode);
@@ -790,7 +789,7 @@ SCErr meth_s_new(World* inWorld, int inSize, char* inData, ReplyAddress* /*inRep
         Node* beforeThisNode = Msg_GetNode(inWorld, msg);
         if (!beforeThisNode)
             return kSCErr_NodeNotFound;
-        err = Graph_New(inWorld, def, nodeID, &msg, &graph, true);
+        err = Graph_New(inWorld, def, nodeID, &msg, &graph, argtype);
         if (err)
             return err;
         Node_AddBefore(&graph->mNode, beforeThisNode);
@@ -799,7 +798,7 @@ SCErr meth_s_new(World* inWorld, int inSize, char* inData, ReplyAddress* /*inRep
         Node* afterThisNode = Msg_GetNode(inWorld, msg);
         if (!afterThisNode)
             return kSCErr_NodeNotFound;
-        err = Graph_New(inWorld, def, nodeID, &msg, &graph, true);
+        err = Graph_New(inWorld, def, nodeID, &msg, &graph, argtype);
         if (err)
             return err;
         Node_AddAfter(&graph->mNode, afterThisNode);
@@ -808,9 +807,7 @@ SCErr meth_s_new(World* inWorld, int inSize, char* inData, ReplyAddress* /*inRep
         Node* replaceThisNode = Msg_GetNode(inWorld, msg);
         if (!replaceThisNode)
             return kSCErr_NodeNotFound;
-        Node_RemoveID(replaceThisNode);
-
-        err = Graph_New(inWorld, def, nodeID, &msg, &graph, true);
+        err = Graph_New(inWorld, def, nodeID, &msg, &graph, argtype);
         if (err)
             return err;
         Node_Replace(&graph->mNode, replaceThisNode);
@@ -822,77 +819,14 @@ SCErr meth_s_new(World* inWorld, int inSize, char* inData, ReplyAddress* /*inRep
     return kSCErr_None;
 }
 
+SCErr meth_s_new(World* inWorld, int inSize, char* inData, ReplyAddress* inReply);
+SCErr meth_s_new(World* inWorld, int inSize, char* inData, ReplyAddress*) {
+    return meth_s_do_new(inWorld, inSize, inData, true);
+}
+
 SCErr meth_s_newargs(World* inWorld, int inSize, char* inData, ReplyAddress* inReply);
-SCErr meth_s_newargs(World* inWorld, int inSize, char* inData, ReplyAddress* /*inReply*/) {
-    SCErr err;
-    sc_msg_iter msg(inSize, inData);
-    int32* defname = msg.gets4();
-    if (!defname)
-        return kSCErr_WrongArgType;
-
-    int32 nodeID = msg.geti();
-    int32 addAction = msg.geti();
-
-    GraphDef* def = World_GetGraphDef(inWorld, defname);
-    if (!def) {
-        scprintf("*** ERROR: SynthDef %s not found\n", (char*)defname);
-        return kSCErr_SynthDefNotFound;
-    }
-
-    Graph* graph = nullptr;
-    switch (addAction) {
-    case 0: {
-        Group* group = Msg_GetGroup(inWorld, msg);
-        if (!group)
-            return kSCErr_GroupNotFound;
-        err = Graph_New(inWorld, def, nodeID, &msg, &graph, false); // false for setn type args
-        if (err)
-            return err;
-        if (!graph)
-            return kSCErr_Failed;
-        Group_AddHead(group, &graph->mNode);
-    } break;
-    case 1: {
-        Group* group = Msg_GetGroup(inWorld, msg);
-        if (!group)
-            return kSCErr_GroupNotFound;
-        err = Graph_New(inWorld, def, nodeID, &msg, &graph, false);
-        if (err)
-            return err;
-        Group_AddTail(group, &graph->mNode);
-    } break;
-    case 2: {
-        Node* beforeThisNode = Msg_GetNode(inWorld, msg);
-        if (!beforeThisNode)
-            return kSCErr_NodeNotFound;
-        err = Graph_New(inWorld, def, nodeID, &msg, &graph, false);
-        if (err)
-            return err;
-        Node_AddBefore(&graph->mNode, beforeThisNode);
-    } break;
-    case 3: {
-        Node* afterThisNode = Msg_GetNode(inWorld, msg);
-        if (!afterThisNode)
-            return kSCErr_NodeNotFound;
-        err = Graph_New(inWorld, def, nodeID, &msg, &graph, false);
-        if (err)
-            return err;
-        Node_AddAfter(&graph->mNode, afterThisNode);
-    } break;
-    case 4: {
-        Node* replaceThisNode = Msg_GetNode(inWorld, msg);
-        if (!replaceThisNode)
-            return kSCErr_NodeNotFound;
-        err = Graph_New(inWorld, def, nodeID, &msg, &graph, false);
-        if (err)
-            return err;
-        Node_Replace(&graph->mNode, replaceThisNode);
-    } break;
-    default:
-        return kSCErr_Failed;
-    }
-    Node_StateMsg(&graph->mNode, kNode_Go);
-    return kSCErr_None;
+SCErr meth_s_newargs(World* inWorld, int inSize, char* inData, ReplyAddress*) {
+    return meth_s_do_new(inWorld, inSize, inData, false);
 }
 
 SCErr meth_g_new(World* inWorld, int inSize, char* inData, ReplyAddress* inReply);

--- a/server/scsynth/SC_Prototypes.h
+++ b/server/scsynth/SC_Prototypes.h
@@ -182,7 +182,7 @@ void Group_QueryTreeAndControls(Group* inGroup, big_scpacket* packet);
 
 ////////////////////////////////////////////////////////////////////////
 
-struct Unit* Unit_New(World* inWorld, struct UnitSpec* inUnitSpec, char*& memory);
+struct Unit* Unit_New(World* inWorld, struct Graph* graph, struct UnitSpec* inUnitSpec, char*& memory);
 void Unit_EndCalc(struct Unit* inUnit, int inNumSamples);
 void Unit_End(struct Unit* inUnit);
 

--- a/server/scsynth/SC_Unit.cpp
+++ b/server/scsynth/SC_Unit.cpp
@@ -21,6 +21,7 @@
 
 #include <stdio.h>
 #include "SC_Endian.h"
+#include "SC_Graph.h"
 #include "SC_Unit.h"
 #include "SC_UnitSpec.h"
 #include "SC_UnitDef.h"
@@ -31,7 +32,7 @@
 
 void Unit_ChooseMulAddFunc(Unit* unit);
 
-Unit* Unit_New(World* inWorld, UnitSpec* inUnitSpec, char*& memory) {
+Unit* Unit_New(World* inWorld, Graph* graph, UnitSpec* inUnitSpec, char*& memory) {
     UnitDef* def = inUnitSpec->mUnitDef;
 
     Unit* unit = (Unit*)memory;
@@ -58,8 +59,8 @@ Unit* Unit_New(World* inWorld, UnitSpec* inUnitSpec, char*& memory) {
 
     unit->mCalcRate = inUnitSpec->mCalcRate;
     unit->mSpecialIndex = inUnitSpec->mSpecialIndex;
-    Rate* rateInfo = unit->mRate = inUnitSpec->mRateInfo;
-    unit->mBufLength = rateInfo->mBufLength;
+    unit->mRate = unit->mCalcRate == calc_FullRate ? graph->mFullRate : graph->mBufRate;
+    unit->mBufLength = unit->mRate->mBufLength;
 
     unit->mDone = false;
 

--- a/server/supernova/sc/sc_plugin_interface.cpp
+++ b/server/supernova/sc/sc_plugin_interface.cpp
@@ -601,7 +601,7 @@ SCBool send_message_to_RT(World* world, struct FifoMsg* msg) {
 namespace nova {
 
 
-inline void initialize_rate(Rate& rate, double sample_rate, int blocksize) {
+void initialize_rate(Rate& rate, double sample_rate, int blocksize) {
     rate.mSampleRate = sample_rate;
     rate.mSampleDur = 1. / sample_rate;
     rate.mRadiansPerSample = 2 * boost::math::constants::pi<double>() / sample_rate;

--- a/server/supernova/sc/sc_plugin_interface.hpp
+++ b/server/supernova/sc/sc_plugin_interface.hpp
@@ -33,6 +33,8 @@
 
 namespace nova {
 
+void initialize_rate(Rate& rate, double sample_rate, int blocksize);
+
 class sc_done_action_handler {
 public:
     void add_pause_node(server_node* node) {

--- a/server/supernova/sc/sc_synth.cpp
+++ b/server/supernova/sc/sc_synth.cpp
@@ -47,6 +47,61 @@ sc_synth::sc_synth(int node_id, sc_synth_definition_ptr const& prototype): abstr
     localBufNum = 0;
     localMaxBufNum = 0;
 
+    int block_size = prototype->block_size;
+    float upsample = prototype->resample_factor;
+    // For now Supernova only supports fixed reblocking and resampling arguments.
+    // This is enforced in sc_synthdef::read_synthdef().
+    assert(block_size >= 0 && upsample >= 0.0);
+    // 0.0 means no resampling
+    if (upsample == 0.0) {
+        upsample = 1.0;
+    }
+
+    if (block_size == 0 && upsample == 1.0) {
+        // no reblocking or resampling
+        mNumTicks = 1;
+        mTickCounter = 0;
+        block_size = world.mBufLength;
+    } else {
+        // reblocking and/or upsampling
+        if (upsample > 1.0) {
+            // make sure that 'upsample' is a power of two!
+            if (ispoweroftwo((int)upsample)) {
+                upsample = (int)upsample;
+                mFlags |= kGraph_Resample; // ok
+            } else {
+                log_printf("WARNING: Synth: upsample factor (%f) not a power of two\n", upsample);
+                upsample = 1.0;
+            }
+        } else if (upsample < 1.0) {
+            log_printf("WARNING: Synth: downsampling (%f) not supported (yet)\n", upsample);
+            upsample = 1.0;
+        }
+
+        if (block_size != 0) {
+            // block size cannot be larger than wire buffer size (yet)!
+            if (block_size > world.mBufLength) {
+                log_printf("WARNING: Synth: block size (%d) cannot be larger than Server "
+                           "block size (%d)\n",
+                           block_size, world.mBufLength);
+                // use Server block size
+                block_size = world.mBufLength;
+            } else if (!ispoweroftwo(block_size)) {
+                log_printf("WARNING: Synth: block size (%d) not a power of two\n", block_size);
+                // use Server block size
+                block_size = world.mBufLength;
+            } else {
+                mFlags |= kGraph_Reblock; // ok
+            }
+        } else {
+            // use Server block size
+            block_size = world.mBufLength;
+        }
+
+        mNumTicks = (world.mBufLength / block_size) * upsample;
+        mTickCounter = 0;
+    }
+
     // so far mPrivate is only used for queued unit commands,
     // i.e. it just points to the head of the list.
     mPrivate = nullptr;
@@ -60,10 +115,11 @@ sc_synth::sc_synth(int node_id, sc_synth_definition_ptr const& prototype): abstr
     const size_t wire_buffer_alignment = 64 * 8; // align to cache line boundaries
     const size_t alloc_size = prototype->memory_requirement();
 
-    const size_t sample_alloc_size =
-        world.mBufLength * synthdef.buffer_count + wire_buffer_alignment /* for alignment */;
+    const size_t rate_alloc_size = mFlags & kGraph_ReblockOrResample ? sizeof(Rate) * 2 : 0;
 
-    const size_t total_alloc_size = alloc_size + sample_alloc_size * sizeof(sample);
+    const size_t sample_alloc_size = block_size * synthdef.buffer_count + wire_buffer_alignment; /* for alignment */
+
+    const size_t total_alloc_size = alloc_size + rate_alloc_size + sample_alloc_size * sizeof(sample);
 
     char* raw_chunk = rt_synthesis ? (char*)rt_pool.malloc(total_alloc_size) : (char*)malloc(total_alloc_size);
 
@@ -73,6 +129,7 @@ sc_synth::sc_synth(int node_id, sc_synth_definition_ptr const& prototype): abstr
     linear_allocator allocator(raw_chunk);
 
     /* prepare controls */
+    /* NB: mControls must be allocated first, see sc_synth::finalize()! */
     mNumControls = parameter_count;
     mControls = allocator.alloc<float>(parameter_count);
     mControlRates = allocator.alloc<int>(parameter_count);
@@ -85,6 +142,21 @@ sc_synth::sc_synth(int node_id, sc_synth_definition_ptr const& prototype): abstr
         mMapControls[i] = &mControls[i]; /* map to control values */
         mControlRates[i] = 0; /* init to 0*/
         mAudioBusOffsets[i] = -1; /* init to -1: not mapped to an audio bus yet */
+    }
+
+    /* allocate and init Rates */
+    if (rate_alloc_size > 0) {
+        /* reblocking and/or resampling */
+        mFullRate = allocator.alloc<Rate>();
+        mBufRate = allocator.alloc<Rate>();
+
+        double sample_rate = world.mSampleRate * upsample;
+        initialize_rate(*mFullRate, sample_rate, block_size);
+        initialize_rate(*mBufRate, sample_rate / block_size, 1);
+    } else {
+        /* use Server block size and sample rate */
+        mFullRate = &world.mFullRate;
+        mBufRate = &world.mBufRate;
     }
 
     /* allocate constant wires */
@@ -331,15 +403,7 @@ void sc_synth::run(void) { perform(); }
 
 extern spin_lock log_guard;
 
-#if defined(__GNUC__) && !defined(__APPLE__)
-#    define thread_local __thread
-#endif
-
-#ifdef thread_local
 static thread_local std::array<char, 262144> trace_scratchpad;
-#else
-static std::array<char, 262144> trace_scratchpad;
-#endif
 
 struct scratchpad_printer {
     scratchpad_printer(char* str): string(str), position(0) { clear(); }
@@ -370,52 +434,54 @@ private:
 void sc_synth::run_traced(void) {
     trace = 0;
 
-#ifndef thread_local
-    spin_lock::scoped_lock lock(log_guard);
-#endif
-
     scratchpad_printer printer(trace_scratchpad.data());
 
-    printer.printf("\nTRACE %d  %s    #units: %d\n", id(), this->definition_name(), calc_unit_count);
+    if (mFlags & kGraph_ReblockOrResample)
+        printer.printf("\nTRACE %d  %s    #units: %d, block size: %d, sr: %d\n", id(), this->definition_name(),
+                       calc_unit_count, mFullRate->mBufLength, (int)mFullRate->mSampleRate);
+    else
+        printer.printf("\nTRACE %d  %s    #units: %d\n", id(), this->definition_name(), calc_unit_count);
 
-    for (size_t calc_unit_index = 0; calc_unit_index != calc_unit_count; ++calc_unit_index) {
-        Unit* unit = calc_units[calc_unit_index];
+    size_t tick_count = mNumTicks;
 
-        sc_ugen_def* def = reinterpret_cast<sc_ugen_def*>(unit->mUnitDef);
-        printer.printf("  unit %zd %s\n    in ", calc_unit_index, def->name());
-        for (uint16_t j = 0; j != unit->mNumInputs; ++j) {
-            printer.printf(" %g", unit->mInBuf[j][0]);
-            if (printer.shouldFlush()) {
-#ifdef thread_local
-                spin_lock::scoped_lock lock(log_guard);
-#endif
-                log(printer.data());
-                printer.clear();
+    for (size_t k = 0; k != tick_count; ++k) {
+        if (tick_count > 1)
+            printer.printf("tick %d of %d:\n", k + 1, tick_count);
+
+        mTickCounter = k;
+
+        for (size_t calc_unit_index = 0; calc_unit_index != calc_unit_count; ++calc_unit_index) {
+            Unit* unit = calc_units[calc_unit_index];
+
+            sc_ugen_def* def = reinterpret_cast<sc_ugen_def*>(unit->mUnitDef);
+            printer.printf("  unit %zd %s\n    in ", calc_unit_index, def->name());
+            for (uint16_t j = 0; j != unit->mNumInputs; ++j) {
+                printer.printf(" %g", unit->mInBuf[j][0]);
+                if (printer.shouldFlush()) {
+                    spin_lock::scoped_lock lock(log_guard);
+                    log(printer.data());
+                    printer.clear();
+                }
             }
-        }
 
-        printer.printf("\n");
+            printer.printf("\n");
 
-        (unit->mCalcFunc)(unit, unit->mBufLength);
+            (unit->mCalcFunc)(unit, unit->mBufLength);
 
-        printer.printf("    out");
-        for (int j = 0; j < unit->mNumOutputs; ++j) {
-            printer.printf(" %g", unit->mOutBuf[j][0]);
-            if (printer.shouldFlush()) {
-#ifdef thread_local
-                spin_lock::scoped_lock lock(log_guard);
-#endif
-                log(printer.data());
-                printer.clear();
+            printer.printf("    out");
+            for (int j = 0; j < unit->mNumOutputs; ++j) {
+                printer.printf(" %g", unit->mOutBuf[j][0]);
+                if (printer.shouldFlush()) {
+                    spin_lock::scoped_lock lock(log_guard);
+                    log(printer.data());
+                    printer.clear();
+                }
             }
+            printer.printf("\n");
         }
         printer.printf("\n");
     }
-    printer.printf("\n");
-
-#ifdef thread_local
     spin_lock::scoped_lock lock(log_guard);
-#endif
     log(printer.data());
 }
 

--- a/server/supernova/sc/sc_synth.hpp
+++ b/server/supernova/sc/sc_synth.hpp
@@ -58,56 +58,59 @@ public:
             prepare();
 
         if (likely(trace == 0)) {
-            const size_t count = calc_unit_count;
-            Unit** units = calc_units;
+            const size_t preroll = calc_unit_count & 7;
+            const size_t unroll = calc_unit_count / 8;
 
-            const size_t preroll = count & 7;
+            size_t tick_count = mNumTicks;
 
-            for (size_t i = 0; i != preroll; ++i) {
-                Unit* unit = units[i];
-                prefetch(units[i + 1]);
-                (unit->mCalcFunc)(unit, unit->mBufLength);
-            }
+            for (size_t k = 0; k != tick_count; ++k) {
+                mTickCounter = k;
 
-            units += preroll;
+                Unit** units = calc_units;
 
-            const size_t unroll = count / 8;
-            if (unroll == 0)
-                return;
+                for (size_t i = 0; i != preroll; ++i) {
+                    Unit* unit = units[i];
+                    prefetch(units[i + 1]);
+                    (unit->mCalcFunc)(unit, unit->mBufLength);
+                }
 
-            for (size_t i = 0; i != unroll; ++i) {
-                Unit* unit = units[0];
-                prefetch(units[1]);
-                (unit->mCalcFunc)(unit, unit->mBufLength);
+                units += preroll;
 
-                unit = units[1];
-                prefetch(units[2]);
-                (unit->mCalcFunc)(unit, unit->mBufLength);
+                for (size_t i = 0; i != unroll; ++i) {
+                    Unit* unit = units[0];
+                    prefetch(units[1]);
+                    (unit->mCalcFunc)(unit, unit->mBufLength);
 
-                unit = units[2];
-                prefetch(units[3]);
-                (unit->mCalcFunc)(unit, unit->mBufLength);
+                    unit = units[1];
+                    prefetch(units[2]);
+                    (unit->mCalcFunc)(unit, unit->mBufLength);
 
-                unit = units[3];
-                prefetch(units[4]);
-                (unit->mCalcFunc)(unit, unit->mBufLength);
+                    unit = units[2];
+                    prefetch(units[3]);
+                    (unit->mCalcFunc)(unit, unit->mBufLength);
 
-                unit = units[4];
-                prefetch(units[5]);
-                (unit->mCalcFunc)(unit, unit->mBufLength);
+                    unit = units[3];
+                    prefetch(units[4]);
+                    (unit->mCalcFunc)(unit, unit->mBufLength);
 
-                unit = units[5];
-                prefetch(units[6]);
-                (unit->mCalcFunc)(unit, unit->mBufLength);
+                    unit = units[4];
+                    prefetch(units[5]);
+                    (unit->mCalcFunc)(unit, unit->mBufLength);
 
-                unit = units[6];
-                prefetch(units[7]);
-                (unit->mCalcFunc)(unit, unit->mBufLength);
+                    unit = units[5];
+                    prefetch(units[6]);
+                    (unit->mCalcFunc)(unit, unit->mBufLength);
 
-                unit = units[7];
-                prefetch(units[8]);
-                (unit->mCalcFunc)(unit, unit->mBufLength);
-                units += 8;
+                    unit = units[6];
+                    prefetch(units[7]);
+                    (unit->mCalcFunc)(unit, unit->mBufLength);
+
+                    unit = units[7];
+                    prefetch(units[8]);
+                    (unit->mCalcFunc)(unit, unit->mBufLength);
+
+                    units += 8;
+                }
             }
         } else
             run_traced();

--- a/server/supernova/sc/sc_synth_definition.hpp
+++ b/server/supernova/sc/sc_synth_definition.hpp
@@ -40,7 +40,7 @@ public:
 private:
     friend class sc_synth;
 
-    virtual abstract_synth* create_instance(int) override;
+    virtual abstract_synth* create_instance(int node_id) override;
 };
 
 typedef boost::intrusive_ptr<sc_synth_definition> sc_synth_definition_ptr;

--- a/server/supernova/sc/sc_synthdef.cpp
+++ b/server/supernova/sc/sc_synthdef.cpp
@@ -262,6 +262,40 @@ void sc_synthdef::read_synthdef(const char*& buffer, const char* buffer_end, int
         }
     }
 
+    if (version > 2) {
+        /* Unfortunately, we cannot set the block size or resample factor via a Control
+         * because of the way that Supernova constructs Synths. (The Synth arguments are
+         * only parsed and set after the Synth has been fully constructed. At this point
+         * it is already too late.) If we detect that the user wants to use Controls,
+         * we just post a warning and bash the value to the default.
+         */
+
+        /* reblock */
+        block_size = read_int32(buffer, buffer_end);
+        block_size_index = read_int32(buffer, buffer_end);
+        if (block_size < 0) {
+            /* get block size from Synth Control - not supported yet */
+            std::cout << "WARNING: SynthDef: block size must be a constant (Controls are not supported yet)"
+                      << std::endl;
+            block_size = 0; /* no reblocking */
+        }
+
+        /* resample */
+        resample_factor = read_float(buffer, buffer_end);
+        resample_index = read_int32(buffer, buffer_end);
+        if (resample_factor < 0.0) {
+            /* get resample factor from Synth Control - not supported yet */
+            std::cout << "WARNING: SynthDef: resample factor must be a constant (Controls are not supported yet)"
+                      << std::endl;
+            resample_factor = 1.0; /* no resampling */
+        }
+    } else {
+        block_size = 0;
+        block_size_index = 0;
+        resample_factor = 1.0;
+        resample_index = 0;
+    }
+
     prepare();
 }
 

--- a/server/supernova/sc/sc_synthdef.hpp
+++ b/server/supernova/sc/sc_synthdef.hpp
@@ -127,6 +127,12 @@ private:
     float_vector parameters;
     parameter_index_map_t parameter_map;
 
+    int32_t block_size; /**< Synth block size. 0 = same as Server. -1 = take from control */
+    uint32_t block_size_index; /**< control index for block size */
+
+    float resample_factor; /**< resample factor. 1.0 = no resampling. -1.0 = take from control */
+    uint32_t resample_index; /**< control index for resample factor */
+
     graph_t graph;
     unsigned int buffer_count;
     calc_units_t calc_unit_indices; /**< indices of the units, that need to be calculated */

--- a/server/supernova/sc/sc_ugen_factory.cpp
+++ b/server/supernova/sc/sc_ugen_factory.cpp
@@ -51,7 +51,7 @@ std::unique_ptr<sc_ugen_factory> sc_factory;
 
 Unit* sc_ugen_def::construct(sc_synthdef::unit_spec_t const& unit_spec, sc_synth* parent, int parentIndex, World* world,
                              linear_allocator& allocator) {
-    const int buffer_length = world->mBufLength;
+    const int buffer_length = parent->mFullRate->mBufLength;
 
     const size_t output_count = unit_spec.output_specs.size();
 
@@ -79,10 +79,10 @@ Unit* sc_ugen_def::construct(sc_synthdef::unit_spec_t const& unit_spec, sc_synth
     /* initialize members from synth */
     unit->mParent = static_cast<Graph*>(parent);
     unit->mParentIndex = parentIndex;
-    if (unit_spec.rate == 2)
-        unit->mRate = &world->mFullRate;
+    if (unit_spec.rate == calc_FullRate)
+        unit->mRate = parent->mFullRate;
     else
-        unit->mRate = &world->mBufRate;
+        unit->mRate = parent->mBufRate;
 
     unit->mBufLength = unit->mRate->mBufLength;
 
@@ -98,7 +98,7 @@ Unit* sc_ugen_def::construct(sc_synthdef::unit_spec_t const& unit_spec, sc_synth
         w->mBuffer = nullptr;
         w->mScalarValue = 0;
 
-        if (unit->mCalcRate == 2) {
+        if (unit->mCalcRate == calc_FullRate) {
             /* allocate a new buffer */
             assert(unit_spec.buffer_mapping[i] >= 0);
             std::size_t buffer_id = unit_spec.buffer_mapping[i];

--- a/testsuite/classlibrary/TestReblock.sc
+++ b/testsuite/classlibrary/TestReblock.sc
@@ -1,0 +1,466 @@
+TestReblockBase : UnitTest {
+	var server;
+
+	setUp {
+		server = Server(this.class.name);
+		server.options.blockSize = 64;
+		server.options.sampleRate = 48000;
+		this.bootServer(server);
+	}
+
+	tearDown {
+		server.quit;
+		server.remove;
+	}
+
+	// 'func' takes a bus and should produce an Array of two Synths (A and B).
+	// A and B should write their output to the first resp. second channel of the bus.
+	// A third Synth reads both channels and records the difference into a Buffer.
+	// Finally, we read the content of the Buffer and check that the output of A and B match.
+	performABTest { arg func, rate, message, verbose=false;
+		var success, cond = Condition();
+		var bus, buffer, testSig, compName, synths, comp;
+
+		if (rate == \ar) {
+			bus = Bus.audio(server, 4);
+			buffer = Buffer.alloc(server, 1024, 4);
+			SynthDef(\abTest, { |busA, busB, buffer|
+				var a = In.ar(busA, 2);
+				var b = In.ar(busB, 2);
+				RecordBuf.ar(a ++ b, buffer, loop: 0.0, doneAction: Done.freeSelf);
+			}).add;
+		} {
+			if (rate != \kr) { Error("bad rate argument").throw };
+			bus = Bus.control(server, 4);
+			buffer = Buffer.alloc(server, 16, 4);
+			SynthDef(\abTest, { |busA, busB, buffer|
+				var a = In.kr(busA, 2);
+				var b = In.kr(busB, 2);
+				RecordBuf.kr(a ++ b, buffer, loop: 0.0, doneAction: Done.freeSelf);
+			}).add;
+		};
+
+		server.sync;
+
+		server.bind {
+			synths = func.value(bus.index, bus.index + 2);
+			comp = Synth(\abTest, [ busA: bus.index, busB: bus.index + 2, buffer: buffer ], server, \addToTail);
+			if (verbose) {
+				server.queryAllNodes;
+			}
+		};
+
+		cond.test = false;
+		OSCFunc({
+			cond.test_(true).signal
+		}, '/n_end', nil, nil, [ comp.nodeID ]).oneShot;
+		cond.wait;
+
+		synths.do(_.free);
+
+		cond.test = false;
+		buffer.loadToFloatArray(action: { |data|
+			success = true;
+			data.clump(4).do { |array, i|
+				var a0, a1, b0, b1;
+				#a0, a1, b0, b1 = array;
+				if (verbose and: { i < 128 }) {
+					"#%\ta0: %, b0: %\n\ta1: %, b1: %".format(i, a0, b0, a1, b1).postln;
+				};
+				if (a0.equalWithPrecision(b0).not or: { a1.equalWithPrecision(b1).not }) { success = false };
+			};
+			cond.test_(true).signal;
+		});
+		cond.wait;
+
+		this.assert(success, message);
+	}
+}
+
+TestReblock : TestReblockBase {
+	test_reblockWithConstantBlockSizeWorks {
+		var bus = Bus.control(server);
+		var blockSizes = [ 0, 1, 2, 4, 8, 16, 32, 64 ];
+		var results = Array.fill(blockSizes.size, nil);
+		var success;
+		blockSizes.do { |blockSize, index|
+			var cond = Condition(), synth;
+			SynthDef(\testReblockConstant, { |out|
+				Reblock(blockSize);
+				Out.kr(out, BlockSize.ir);
+			}).add;
+			server.sync;
+			synth = Synth(\testReblockConstant, [ out: bus ]);
+			server.sync; // let it compute at least one block
+			bus.get { |f|
+				results[index] = f;
+				cond.test_(true).signal;
+			};
+			cond.wait;
+			synth.free;
+		};
+		this.assert(results[0] == server.options.blockSize, "Reblock with argument 0 matches Server block size");
+		success = [ blockSizes[1..], results[1..] ].flop.every { |pair| pair[0] == pair[1] };
+		this.assert(success, "Reblock with constant argument matches BlockSize output");
+	}
+
+	test_reblockWithBadInputThrows {
+		this.assertException({
+			SynthDef(\test, { Reblock(-1) });
+		}, Error, "Reblock with negative block size throws exception");
+
+		this.assertException({
+			SynthDef(\test, { Reblock(3) });
+		}, Error, "Reblock with non-power-of-two block size throws exception");
+
+		this.assertException({
+			SynthDef(\test, { |blockSize| Reblock(blockSize + 1) })
+		}, Error, "Reblock with Outproxy that is not an immediate control throws exception");
+
+		this.assertException({
+			SynthDef(\test, { Reblock(DC.ar(1)) })
+		}, Error, "Reblock with UGen other than OutputProxy throws exception");
+	}
+
+	test_reblockWithControlBlockSizeWorks {
+		var bus = Bus.control(server);
+		var blockSizes = [ 0, 1, 2, 4, 8, 16, 32, 64 ];
+		var results = Array.fill(blockSizes.size, nil);
+		var success;
+
+		SynthDef(\testReblockControl, { |out, blockSize|
+			Reblock(blockSize);
+			Out.kr(out, BlockSize.ir);
+		}).add;
+		server.sync;
+
+		blockSizes.do { |blockSize, index|
+			var cond = Condition();
+			var synth = Synth(\testReblockControl, [ out: bus, blockSize: blockSize ]);
+			server.sync; // let it compute at least one block
+			bus.get { |f|
+				results[index] = f;
+				cond.test_(true).signal;
+			};
+			cond.wait;
+			synth.free;
+		};
+		this.assert(results[0] == server.options.blockSize, "Reblock with control default argument matches Server block size");
+		success = [ blockSizes[1..], results[1..] ].flop.every { |pair| pair[0] == pair[1] };
+		this.assert(success, "Reblock with control argument matches BlockSize output");
+	}
+
+	test_reblockWithBadControlBlockSizeUsesDefault {
+		var bus = Bus.control(server);
+		var blockSizes = [ -1, 3, 7 ];
+		var results = Array.fill(blockSizes.size, nil);
+		var success;
+		SynthDef(\testReblockControlFail, { |out, blockSize|
+			Reblock(blockSize);
+			Out.kr(out, BlockSize.ir);
+		}).add;
+		server.sync;
+		blockSizes.do { |blockSize, index|
+			var cond = Condition();
+			var synth = Synth(\testReblockControlFail, [ out: bus, blockSize: blockSize ]);
+			server.sync; // let it compute at least one block
+			bus.get { |f|
+				results[index] = f;
+				cond.test_(true).signal;
+			};
+			cond.wait;
+			synth.free;
+		};
+		success = results.every { |x| x == server.options.blockSize };
+		this.assert(success, "Reblock with bad control argument falls back to Server block size");
+	}
+
+	test_reblockIgnoresDuplicates {
+		var bus = Bus.control(server);
+		var blockSizes = [ 1, 2, 4, 8 ];
+		var cond = Condition(), value;
+		var synth = {
+			blockSizes.do { |x| Reblock(x) };
+			Out.kr(bus, BlockSize.ir);
+		}.play(server);
+		server.sync; // let it compute at least one block
+		bus.get { |f|
+			value = f;
+			cond.test_(true).signal;
+		};
+		cond.wait;
+		synth.free;
+		this.assert(value == blockSizes[0], "Duplicate Reblock instances are ignored with a warning");
+	}
+
+	test_IOUGensWithReblocking {
+		var arTestSig, krTestSig, simpleAB;
+		var trigBusA = Bus.control(server, 2);
+		var trigBusB = Bus.control(server, 2);
+		var arTestBus = Bus.audio(server, 2);
+		var krTestBus = Bus.control(server, 2);
+		var testBlockSize = 1;
+
+		simpleAB = { |defName|
+			{ |busA, busB|
+				[
+					Synth(defName, [ out: busA, blockSize: testBlockSize ], server, \addToTail),
+					Synth(defName, [ out: busB ], server, \addToTail)
+				]
+			}
+		};
+
+		arTestSig = { Out.ar(arTestBus, SinOsc.ar([220, 440])) }.play(server);
+
+		krTestSig = { Out.kr(krTestBus, SinOsc.kr([220, 440])) }.play(server);
+
+		server.sync;
+
+		//------------------ UGens ----------------------//
+
+		// Out.ar/Out.kr
+
+		SynthDef(\testOutAr, { |out, blockSize|
+			var sig = [ Line.ar, SinOsc.ar ];
+			Reblock(blockSize);
+			// make sure that summing works
+			Out.ar(out, sig);
+			Out.ar(out, sig);
+		}).add;
+
+		server.sync;
+
+		this.performABTest(simpleAB.(\testOutAr), \ar, "Out.ar works with reblocking");
+
+		SynthDef(\testOutKr, { |out, blockSize|
+			var sig = [ Line.kr, SinOsc.kr ];
+			Reblock(blockSize);
+			// make sure that summing works
+			Out.kr(out, sig);
+			Out.kr(out, sig);
+		}).add;
+
+		server.sync;
+
+		this.performABTest(simpleAB.(\testOutKr), \kr, "Out.kr works with reblocking");
+
+		// ReplaceOut.ar / ReplaceOut.kr
+
+		SynthDef(\testReplaceOutAr, { |out, blockSize|
+			Reblock(blockSize);
+			ReplaceOut.ar(out, [ Line.ar, SinOsc.ar ]);
+		}).add;
+
+		server.sync;
+
+		this.performABTest(simpleAB.(\testReplaceOutAr), \ar, "ReplaceOut.ar works with reblocking");
+
+		SynthDef(\testReplaceOutKr, { |out, blockSize|
+			Reblock(blockSize);
+			ReplaceOut.kr(out, [ Line.kr, SinOsc.kr ]);
+		}).add;
+
+		server.sync;
+
+		this.performABTest(simpleAB.(\testReplaceOutKr), \kr, "ReplaceOut.kr works with reblocking");
+
+		// OffsetOut.ar
+
+		SynthDef(\testOffsetOutAr, { |out, blockSize|
+			var sig = [ Line.ar, SinOsc.ar ];
+			Reblock(blockSize);
+			// make sure that summing works
+			OffsetOut.ar(out, sig);
+			OffsetOut.ar(out, sig);
+		}).add;
+
+		server.sync;
+
+		this.performABTest(simpleAB.(\testOffsetOutAr), \ar, "OffsetOut.ar works with reblocking");
+
+		// XOut.ar / XOut.kr
+
+		SynthDef(\testXOutAr, { |out, blockSize|
+			Reblock(blockSize);
+			XOut.ar(out, 0.5, [ Line.ar, SinOsc.ar ]);
+		}).add;
+
+		server.sync;
+
+		this.performABTest(simpleAB.(\testXOutAr), \ar, "XOut.ar works with reblocking");
+
+		SynthDef(\testXOutKr, { |out, blockSize|
+			Reblock(blockSize);
+			XOut.kr(out, 0.5, [ Line.kr, SinOsc.kr ]);
+		}).add;
+
+		server.sync;
+
+		this.performABTest(simpleAB.(\testXOutKr), \kr, "XOut.kr works with reblocking");
+
+		// In.ar / In.kr
+
+		SynthDef(\testInAr, { |out, blockSize|
+			Reblock(blockSize);
+			ReplaceOut.ar(out, In.ar(arTestBus, 2));
+		}).add;
+
+		server.sync;
+
+		this.performABTest(simpleAB.(\testInAr), \ar, "In.ar works with reblocking");
+
+		SynthDef(\testInKr, { |out, blockSize|
+			Reblock(blockSize);
+			ReplaceOut.kr(out, In.kr(krTestBus, 2));
+		}).add;
+
+		server.sync;
+
+		this.performABTest(simpleAB.(\testInKr), \kr, "In.kr works with reblocking");
+
+		// FeedbackIn.ar
+
+		SynthDef(\testInFeedbackAr, { |out, blockSize|
+			Reblock(blockSize);
+			ReplaceOut.ar(out, InFeedback.ar(arTestBus, 2));
+		}).add;
+
+		server.sync;
+
+		this.performABTest(simpleAB.(\testInFeedbackAr), \ar, "InFeedback.ar works with reblocking");
+
+		// LagIn.kr
+
+		SynthDef(\testLagInKr, { |out, blockSize|
+			Reblock(blockSize);
+			ReplaceOut.kr(out, LagIn.kr(krTestBus, 2));
+		}).add;
+
+		server.sync;
+
+		this.performABTest(simpleAB.(\testLagInKr), \kr, "LagIn.kr works with reblocking");
+
+		// InTrig.kr
+
+		SynthDef(\testInTrigKr, { |in, out, blockSize|
+			Reblock(blockSize);
+			ReplaceOut.kr(out, InTrig.kr(in, 2));
+		}).add;
+
+		server.sync;
+
+		this.performABTest({ |busA, busB|
+			trigBusA.set(1, 1);
+			trigBusB.set(1, 1);
+			[
+				Synth(\testInTrigKr, [ in: trigBusA, out: busA, blockSize: testBlockSize ], server, \addToTail),
+				Synth(\testInTrigKr, [ in: trigBusB, out: busB ], server, \addToTail)
+			]
+		}, \kr, "InTrig.kr works with reblocking");
+
+		// Control
+
+		SynthDef(\testControl, { |out, blockSize|
+			Reblock(blockSize);
+			ReplaceOut.kr(out, \ctl.kr([ 0.5, 1.5 ]));
+		}).add;
+
+		server.sync;
+
+		this.performABTest(simpleAB.(\testControl), \kr, "Control with default value works with reblocking");
+
+		this.performABTest({ |busA, busB|
+			var a = Synth(\testControl, [ out: busA, blockSize: testBlockSize ], server, \addToTail).map(\ctl, krTestBus);
+			var b = Synth(\testControl, [ out: busB ], server, \addToTail).map(\ctl, krTestBus);
+			[ a, b ]
+		}, \kr, "Control mapped to control bus works with reblocking");
+
+		// AudioControl
+
+		SynthDef(\testAudioControl, { |out, blockSize|
+			Reblock(blockSize);
+			ReplaceOut.ar(out, \ctl.ar([ 0.5, 1.5 ]));
+		}).add;
+
+		server.sync;
+
+		this.performABTest(simpleAB.(\testAudioControl), \ar, "AudioControl with default value works with reblocking");
+
+		this.performABTest({ |busA, busB|
+			var a = Synth(\testAudioControl, [ out: busA, blockSize: testBlockSize ], server, \addToTail).map(\ctl, arTestBus);
+			var b = Synth(\testAudioControl, [ out: busB ], server, \addToTail).map(\ctl, arTestBus);
+			[ a, b ]
+		}, \ar, "AudioControl mapped to audio bus works with reblocking");
+
+		this.performABTest({ |busA, busB|
+			var a = Synth(\testAudioControl, [ out: busA, blockSize: testBlockSize ], server, \addToTail).map(\ctl, krTestBus);
+			var b = Synth(\testAudioControl, [ out: busB ], server, \addToTail).map(\ctl, krTestBus);
+			[ a, b ]
+		}, \ar, "AudioControl mapped to control bus works with reblocking");
+
+		// LagControl
+
+		SynthDef(\testLagControl, { |out, blockSize|
+			Reblock(blockSize);
+			ReplaceOut.kr(out, \ctl.kr([ 0.5, 1.5 ], 0.1, true));
+		}).add;
+
+		server.sync;
+
+		this.performABTest(simpleAB.(\testLagControl), \kr, "LagControl with default value works with reblocking");
+
+		this.performABTest({ |busA, busB|
+			var a = Synth(\testLagControl, [ out: busA, blockSize: testBlockSize ], server, \addToTail).map(\ctl, krTestBus);
+			var b = Synth(\testLagControl, [ out: busB ], server, \addToTail).map(\ctl, krTestBus);
+			[ a, b ]
+		}, \kr, "LagControl mapped to control bus works with reblocking");
+
+		// TrigControl
+
+		SynthDef(\testTrigControl, { |out, blockSize|
+			Reblock(blockSize);
+			ReplaceOut.kr(out, \ctl.tr([1, 1]));
+		}).add;
+
+		server.sync;
+
+		this.performABTest(simpleAB.(\testTrigControl), \kr, "TrigControl with default value works with reblocking");
+
+		this.performABTest({ |busA, busB|
+			var a, b;
+			trigBusA.set(1, 1);
+			trigBusB.set(1, 1);
+			a = Synth(\testTrigControl, [ out: busA, blockSize: testBlockSize ], server, \addToTail).map(\ctl, trigBusA);
+			b = Synth(\testTrigControl, [ out: busB ], server, \addToTail).map(\ctl, trigBusB);
+			[ a, b ]
+		}, \kr, "TrigControl mapped to control bus works with reblocking");
+
+		// LocalIn / LocalOut
+
+		SynthDef(\testLocalBusAr, { |out, blockSize|
+			var sig = SinOsc.ar([220, 440]);
+			Reblock(blockSize);
+			// make sure that summing works
+			LocalOut.ar(sig);
+			LocalOut.ar(sig);
+			Out.ar(out, LocalIn.ar(2));
+		}).add;
+
+		server.sync;
+
+		this.performABTest(simpleAB.(\testLocalBusAr), \ar, "LocalIn.ar and LocalOut.ar work with reblocking");
+
+		SynthDef(\testLocalBusKr, { |out, blockSize|
+			var sig = SinOsc.kr([220, 440]);
+			Reblock(blockSize);
+			// make sure that summing works
+			LocalOut.kr(sig);
+			LocalOut.kr(sig);
+			Out.kr(out, LocalIn.kr(2));
+		}).add;
+
+		server.sync;
+
+		this.performABTest(simpleAB.(\testLocalBusKr), \kr, "LocalIn.kr and LocalOut.kr work with reblocking");
+	}
+}

--- a/testsuite/classlibrary/TestResample.sc
+++ b/testsuite/classlibrary/TestResample.sc
@@ -1,0 +1,392 @@
+TestResample : TestReblockBase {
+	test_resampleWithConstantFactorWorks {
+		var bus = Bus.control(server);
+		var factors = [ 0, 1, 2, 4, 8 ];
+		var results = Array.fill(factors.size, nil);
+		var success, sr = server.options.sampleRate;
+		sr.postln;
+
+		factors.do { |factor, index|
+			var cond = Condition(), synth;
+			SynthDef(\testResampleConstant, { |out|
+				Resample(factor);
+				Out.kr(out, SampleRate.ir);
+			}).add;
+			server.sync;
+			synth = Synth(\testResampleConstant, [ out: bus ]);
+			server.sync; // let it compute at least one block
+			bus.get { |f|
+				results[index] = f;
+				cond.test_(true).signal;
+			};
+			cond.wait;
+			synth.free;
+		};
+		this.assert(results[0] == sr, "Resample with argument 0.0 matches Server sample rate");
+		success = [ factors[1..], results[1..] ].flop.every { |pair|
+			(pair[0] * sr) == pair[1]
+		};
+		this.assert(success, "Resample with constant argument matches SampleRate output");
+	}
+
+	test_resampleWithBadInputThrows {
+		this.assertException({
+			SynthDef(\test, { Resample(-1) });
+		}, Error, "Resample with negative factor throws exception");
+
+		this.assertException({
+			SynthDef(\test, { Resample(3) });
+		}, Error, "Resample with non-power-of-two factor throws exception");
+
+		this.assertException({
+			SynthDef(\test, { |resample| Resample(resample * 2) })
+		}, Error, "Resample with Outproxy that is not an immediate control throws exception");
+
+		this.assertException({
+			SynthDef(\test, { Resample(DC.ar(2)) })
+		}, Error, "Resample with UGen other than OutputProxy throws exception");
+	}
+
+	test_resampleWithControlFactorWorks {
+		var bus = Bus.control(server);
+		var factors = [ 0, 1, 2, 4, 8 ];
+		var results = Array.fill(factors.size, nil);
+		var success, sr = server.options.sampleRate;
+
+		SynthDef(\testResampleControl, { |out, resample|
+			Resample(resample);
+			Out.kr(out, SampleRate.ir);
+		}).add;
+		server.sync;
+
+		factors.do { |factor, index|
+			var cond = Condition();
+			var synth = Synth(\testResampleControl, [ out: bus, resample: factor ]);
+			server.sync; // let it compute at least one block
+			bus.get { |f|
+				results[index] = f;
+				cond.test_(true).signal;
+			};
+			cond.wait;
+			synth.free;
+		};
+		this.assert(results[0] == sr, "Resample with control default argument matches Server sample rate");
+		success = [ factors[1..], results[1..] ].flop.every { |pair| (pair[0] * sr) == pair[1] };
+		this.assert(success, "Resample with control argument matches SampleRate output");
+	}
+
+	test_resampleWithBadControlFactorUsesDefault {
+		var bus = Bus.control(server);
+		var factors = [ -1, 0.9, 3, 7 ];
+		var results = Array.fill(factors.size, nil);
+		var success, sr = server.options.sampleRate;
+		SynthDef(\testResampleControlFail, { |out, resample|
+			Resample(resample);
+			Out.kr(out, SampleRate.ir);
+		}).add;
+		server.sync;
+		factors.do { |factor, index|
+			var cond = Condition();
+			var synth = Synth(\testResampleControlFail, [ out: bus, resample: factor ]);
+			server.sync; // let it compute at least one block
+			bus.get { |f|
+				results[index] = f;
+				cond.test_(true).signal;
+			};
+			cond.wait;
+			synth.free;
+		};
+		success = results.every { |x| x == sr };
+		this.assert(success, "Resample with bad control argument falls back to Server sample rate");
+	}
+
+	test_resampleIgnoresDuplicates {
+		var bus = Bus.control(server);
+		var factors = [ 1, 2, 4, 8 ];
+		var cond = Condition(), value, synth;
+		var sr = server.options.sampleRate;
+		synth = {
+			factors.do { |x| Resample(x) };
+			Out.kr(bus, SampleRate.ir);
+		}.play(server);
+		server.sync; // let it compute at least one block
+		bus.get { |f|
+			value = f;
+			cond.test_(true).signal;
+		};
+		cond.wait;
+		synth.free;
+		this.assert(value == (factors[0] * sr), "Duplicate Resample instances are ignored with a warning");
+	}
+
+	test_IOUGensWithResampling {
+		var arTestSig, krTestSig, simpleAB;
+		var trigBusA = Bus.control(server, 2);
+		var trigBusB = Bus.control(server, 2);
+		var arTestBus = Bus.audio(server, 2);
+		var krTestBus = Bus.control(server, 2);
+		var testFactor = 1;
+
+		simpleAB = { |defName|
+			{ |busA, busB|
+				[
+					Synth(defName, [ out: busA, resample: testFactor ], server, \addToTail),
+					Synth(defName, [ out: busB ], server, \addToTail)
+				]
+			}
+		};
+
+		arTestSig = { Out.ar(arTestBus, SinOsc.ar([220, 440])) }.play(server);
+
+		krTestSig = { Out.kr(krTestBus, SinOsc.kr([220, 440])) }.play(server);
+
+		server.sync;
+
+		//------------------ UGens ----------------------//
+
+		// Out.ar/Out.kr
+
+		SynthDef(\testOutAr, { |out, resample|
+			var sig = [ Line.ar, SinOsc.ar ];
+			Resample(resample);
+			// make sure that summing works
+			Out.ar(out, sig);
+			Out.ar(out, sig);
+		}).add;
+
+		server.sync;
+
+		this.performABTest(simpleAB.(\testOutAr), \ar, "Out.ar works with resampling");
+
+		SynthDef(\testOutKr, { |out, resample|
+			var sig = [ Line.kr, SinOsc.kr ];
+			Resample(resample);
+			// make sure that summing works
+			Out.kr(out, sig);
+			Out.kr(out, sig);
+		}).add;
+
+		server.sync;
+
+		this.performABTest(simpleAB.(\testOutKr), \kr, "Out.kr works with resampling");
+
+		// ReplaceOut.ar / ReplaceOut.kr
+
+		SynthDef(\testReplaceOutAr, { |out, resample|
+			Resample(resample);
+			ReplaceOut.ar(out, [ Line.ar, SinOsc.ar ]);
+		}).add;
+
+		server.sync;
+
+		this.performABTest(simpleAB.(\testReplaceOutAr), \ar, "ReplaceOut.ar works with resampling");
+
+		SynthDef(\testReplaceOutKr, { |out, resample|
+			Resample(resample);
+			ReplaceOut.kr(out, [ Line.kr, SinOsc.kr ]);
+		}).add;
+
+		server.sync;
+
+		this.performABTest(simpleAB.(\testReplaceOutKr), \kr, "ReplaceOut.kr works with resampling");
+
+		// OffsetOut.ar
+
+		SynthDef(\testOffsetOutAr, { |out, resample|
+			var sig = [ Line.ar, SinOsc.ar ];
+			Resample(resample);
+			// make sure that summing works
+			OffsetOut.ar(out, sig);
+			OffsetOut.ar(out, sig);
+		}).add;
+
+		server.sync;
+
+		this.performABTest(simpleAB.(\testOffsetOutAr), \ar, "OffsetOut.ar works with resampling");
+
+		// XOut.ar / XOut.kr
+
+		SynthDef(\testXOutAr, { |out, resample|
+			Resample(resample);
+			XOut.ar(out, 0.5, [ Line.ar, SinOsc.ar ]);
+		}).add;
+
+		server.sync;
+
+		this.performABTest(simpleAB.(\testXOutAr), \ar, "XOut.ar works with resampling");
+
+		SynthDef(\testXOutKr, { |out, resample|
+			Resample(resample);
+			XOut.kr(out, 0.5, [ Line.kr, SinOsc.kr ]);
+		}).add;
+
+		server.sync;
+
+		this.performABTest(simpleAB.(\testXOutKr), \kr, "XOut.kr works with resampling");
+
+		// In.ar / In.kr
+
+		SynthDef(\testInAr, { |out, resample|
+			Resample(resample);
+			ReplaceOut.ar(out, In.ar(arTestBus, 2));
+		}).add;
+
+		server.sync;
+
+		this.performABTest(simpleAB.(\testInAr), \ar, "In.ar works with resampling");
+
+		SynthDef(\testInKr, { |out, resample|
+			Resample(resample);
+			ReplaceOut.kr(out, In.kr(krTestBus, 2));
+		}).add;
+
+		server.sync;
+
+		this.performABTest(simpleAB.(\testInKr), \kr, "In.kr works with resampling");
+
+		// FeedbackIn.ar
+
+		SynthDef(\testInFeedbackAr, { |out, resample|
+			Resample(resample);
+			ReplaceOut.ar(out, InFeedback.ar(arTestBus, 2));
+		}).add;
+
+		server.sync;
+
+		this.performABTest(simpleAB.(\testInFeedbackAr), \ar, "InFeedback.ar works with resampling");
+
+		// LagIn.kr
+
+		SynthDef(\testLagInKr, { |out, resample|
+			Resample(resample);
+			ReplaceOut.kr(out, LagIn.kr(krTestBus, 2));
+		}).add;
+
+		server.sync;
+
+		this.performABTest(simpleAB.(\testLagInKr), \kr, "LagIn.kr works with resampling");
+
+		// InTrig.kr
+
+		SynthDef(\testInTrigKr, { |in, out, resample|
+			Resample(resample);
+			ReplaceOut.kr(out, InTrig.kr(in, 2));
+		}).add;
+
+		server.sync;
+
+		this.performABTest({ |busA, busB|
+			trigBusA.set(1, 1);
+			trigBusB.set(1, 1);
+			[
+				Synth(\testInTrigKr, [ in: trigBusA, out: busA, resample: testFactor ], server, \addToTail),
+				Synth(\testInTrigKr, [ in: trigBusB, out: busB ], server, \addToTail)
+			]
+		}, \kr, "InTrig.kr works with resampling");
+
+		// Control
+
+		SynthDef(\testControl, { |out, resample|
+			Resample(resample);
+			ReplaceOut.kr(out, \ctl.kr([ 0.5, 1.5 ]));
+		}).add;
+
+		server.sync;
+
+		this.performABTest(simpleAB.(\testControl), \kr, "Control with default value works with resampling");
+
+		this.performABTest({ |busA, busB|
+			var a = Synth(\testControl, [ out: busA, resample: testFactor ], server, \addToTail).map(\ctl, krTestBus);
+			var b = Synth(\testControl, [ out: busB ], server, \addToTail).map(\ctl, krTestBus);
+			[ a, b ]
+		}, \kr, "Control mapped to control bus works with resampling");
+
+		// AudioControl
+
+		SynthDef(\testAudioControl, { |out, resample|
+			Resample(resample);
+			ReplaceOut.ar(out, \ctl.ar([ 0.5, 1.5 ]));
+		}).add;
+
+		server.sync;
+
+		this.performABTest(simpleAB.(\testAudioControl), \ar, "AudioControl with default value works with resampling");
+
+		this.performABTest({ |busA, busB|
+			var a = Synth(\testAudioControl, [ out: busA, resample: testFactor ], server, \addToTail).map(\ctl, arTestBus);
+			var b = Synth(\testAudioControl, [ out: busB ], server, \addToTail).map(\ctl, arTestBus);
+			[ a, b ]
+		}, \ar, "AudioControl mapped to audio bus works with resampling");
+
+		this.performABTest({ |busA, busB|
+			var a = Synth(\testAudioControl, [ out: busA, resample: testFactor ], server, \addToTail).map(\ctl, krTestBus);
+			var b = Synth(\testAudioControl, [ out: busB ], server, \addToTail).map(\ctl, krTestBus);
+			[ a, b ]
+		}, \ar, "AudioControl mapped to control bus works with resampling");
+
+		// LagControl
+
+		SynthDef(\testLagControl, { |out, resample|
+			Resample(resample);
+			ReplaceOut.kr(out, \ctl.kr([ 0.5, 1.5 ], 0.1, true));
+		}).add;
+
+		server.sync;
+
+		this.performABTest(simpleAB.(\testLagControl), \kr, "LagControl with default value works with resampling");
+
+		this.performABTest({ |busA, busB|
+			var a = Synth(\testLagControl, [ out: busA, resample: testFactor ], server, \addToTail).map(\ctl, krTestBus);
+			var b = Synth(\testLagControl, [ out: busB ], server, \addToTail).map(\ctl, krTestBus);
+			[ a, b ]
+		}, \kr, "LagControl mapped to control bus works with resampling");
+
+		// TrigControl
+
+		SynthDef(\testTrigControl, { |out, resample|
+			Resample(resample);
+			ReplaceOut.kr(out, \ctl.tr([1, 1]));
+		}).add;
+
+		server.sync;
+
+		this.performABTest(simpleAB.(\testTrigControl), \kr, "TrigControl with default value works with resampling");
+
+		this.performABTest({ |busA, busB|
+			var a, b;
+			trigBusA.set(1, 1);
+			trigBusB.set(1, 1);
+			a = Synth(\testTrigControl, [ out: busA, resample: testFactor ], server, \addToTail).map(\ctl, trigBusA);
+			b = Synth(\testTrigControl, [ out: busB ], server, \addToTail).map(\ctl, trigBusB);
+			[ a, b ]
+		}, \kr, "TrigControl mapped to control bus works with resampling");
+
+		// LocalIn / LocalOut
+
+		SynthDef(\testLocalBusAr, { |out, resample|
+			var sig = SinOsc.ar([220, 440]);
+			Resample(resample);
+			// make sure that summing works
+			LocalOut.ar(sig);
+			LocalOut.ar(sig);
+			Out.ar(out, LocalIn.ar(2));
+		}).add;
+
+		server.sync;
+
+		this.performABTest(simpleAB.(\testLocalBusAr), \ar, "LocalIn.ar and LocalOut.ar work with reblocking");
+
+		SynthDef(\testLocalBusKr, { |out, resample|
+			var sig = SinOsc.kr([220, 440]);
+			Resample(resample);
+			// make sure that summing works
+			LocalOut.kr(sig);
+			LocalOut.kr(sig);
+			Out.kr(out, LocalIn.kr(2));
+		}).add;
+
+		server.sync;
+
+		this.performABTest(simpleAB.(\testLocalBusKr), \kr, "LocalIn.kr and LocalOut.kr work with reblocking");
+	}
+}


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

This is a revamp of #6702. See the latter for previous discussions.

## Purpose and Motivation

This PR allows Synths to run at different block sizes or samplerates. This enables two important techniques that haven't been possible so far:
- tight feedback loops, down to a single sample
- upsampling + filtering to remove/reduce aliasing, e.g. for distortion, hard-syncing, osciallators and any other type of synthesis that is prone to aliasing

---

### For users

There are two new objects that can be used in SynthDefs:
- `Reblock`: the constructor receives the desired block size, either as a fixed number or as a Synth argument/control. If the value is 0, the Server block size is used. The new block size must be a power of two. Currently, it cannot be larger than the Server block size, i.e. we only support *downblocking*. This may change in the future.
- `Resample`: the constructor receives the resample factor, either as a fixed number or as a Synth argument/control. 1.0 means no resampling. The factor must be a power of two. Currently, it cannot be smaller than 1.0, i.e. we only support *upsampling*. This may change in the future.

*NOTE*: Supernova currently does not support Synth arguments/controls as arguments to `Reblock` and `Resample`, i.e. the block size and resample factor must be constants. This may change in the future.

Here are two practical examples:
```sc
// 1. Karplus-String with small block size
(
SynthDef(\delay, { |out, blockSize|
    var source, local;

    Reblock(blockSize);

    source = Decay.ar(Impulse.ar(2), 0.1) * WhiteNoise.ar(0.2);
    local = LocalIn.ar(2) + [source, 0]; // read feedback, add to source
    local = DelayC.ar(local, 0.5, MouseX.kr.pow(2) * 0.5); // delay sound

    // reverse channels to give ping pong effect, apply decay factor
    LocalOut.ar(local.reverse * MouseY.kr.pow(0.5).clip(0, 0.999));

    Out.ar(out, local);
}).add
)

// min. delay length: Server block size
Synth(\delay);
// try with smaller block sizes:
Synth(\delay, [ blockSize: 16 ]);
Synth(\delay, [ blockSize: 4 ]);
Synth(\delay, [ blockSize: 1 ]);

// 2. anti-aliasing with upsampling + filtering
(
SynthDef(\hardsync, { |out, upsample=1.0|
     var sig, cutoff = 18000;

    Resample(upsample);
    
    sig = SyncSaw.ar(MouseY.kr(1, 1000, 2), MouseX.kr(100, 4000, 2));
    sig = LPF.ar(sig, cutoff);
    sig = LPF.ar(sig, cutoff);
    Out.ar(out, sig * 0.05 ! 2);
}).add;
)

// lots of aliasing
Synth(\hardsync); 
// watch aliasing disappear with increasing upsample factors
Synth(\hardsync, [ upsample: 2.0 ]);
Synth(\hardsync, [ upsample: 4.0 ]);
Synth(\hardsync, [ upsample: 8.0 ]);
```

---

### For plugin authors

On the implementation side, this adds new `mBufRate` and `mFullRate` members to `Graph`. For "normal" Synths, these just point to the global `Rate` members in `World`. If the Synth is reblocking and/or upsampling, it has its own `Rate` instances.

UGens "just work" as long as they consistently use the `SAMPLERATE`, `BUFLENGTH`, `FULLRATE`, `FULLBUFLENGTH` etc. macros in `SC_Unit.h` resp. the corresponding C++ methods in `SC_Plugin.hpp`, because they now refer to the Graph's rates instead of the global World rates.

The only UGens that need to aware of reblocking and upsampling are I/O UGens because they are responsible for reblocking/resampling when reading from / writing to Busses. (Actually, this applies to all UGens that use Busses, but there are very few third-party plugins that do, as far as I am aware.)

---

### Implementation

This PR adds four new fields to the synth definition in SynthDef version 3:

- int32 - the block size. 0 = use Server block size. -1 = take the value from the given control index (see next field)
- int32 - the block size control index. Only used if the block size value above is -1
- float32 - the resample factor. -1.0 = take the value from the given control index (see next field)
- int32 - the resample control index. Only used if the resample factor value above is -1.0

Similarly, the (private) GraphDef` structure has four new fields:
```cpp
int32 mBlockSize;
uint32 mBlockSizeIndex;
float32 mResampleFactor;
uint32 mResampleIndex;
```

In `Graph_Ctor`, this is used to set the block size and resample factor either from the values itself or from the specified controls. 

In Supernova, we currently only accept literal values due to the way Synths are created. Currently, all Synth arguments are only parsed and set *after* the Synth has been fully constructed. At this point it is too late for setting the block size or sample rate. If the user attempts to use controls, we post a warning and use the default values. In the future, we may support using controls by refactoring the Synth construction code.

**NOTE**: this feature requires a break in the plugin API because I had to make changes to the (public) `Graph` struct. Fortunately, the plugin API has already been bumped in 3.15-dev because of #7329, so this PR should be included in 3.15 to avoid breaking the API again. See also this meta-issue: https://github.com/supercollider/supercollider/issues/6102

---

### Testing

It would be great if you could test this PR by running your existing SynthDefs at different combinations of block sizes and upsampling factors and check if they still work/sound as expected.

Here are two important guide lines to avoid false positives:

- the Synth sounds different at lower block sizes -> please check that this isn't also the case when setting the global Server block size to the same value (ideally with the official SC build)
- the Synth sounds different when upsampled -> please check that this isn't also the case when running the Server at the corresponding global sample rate  (ideally with the official SC build)

UGens might behave weirdly in a reblocked/upsampled Synth, but they should never crash the Server.

There have been no real issues reported so far with the original PR (#6702).

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->

- New feature
- Breaking change

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
