### PR TITLE
Plugin command and unit command extensions

### DIFF
--- a/SCClassLibrary/Common/Audio/DemoUGens.sc
+++ b/SCClassLibrary/Common/Audio/DemoUGens.sc
@@ -1,0 +1,6 @@
+// See server/plugins/DemoUGens.cpp
+UnitCmdDemo : UGen {
+	*kr {
+		^this.multiNew('audio');
+	}
+}

--- a/include/plugin_interface/SC_Command.h
+++ b/include/plugin_interface/SC_Command.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "SC_Types.h"
+
+struct Unit;
+struct World;
+struct sc_msg_iter;
+
+typedef void (*UnitCmdFunc)(struct Unit* unit, struct sc_msg_iter* args);
+typedef void (*UnitCmdFuncEx)(struct Unit* unit, struct sc_msg_iter* args, void* replyAddr);
+typedef void (*PlugInCmdFunc)(struct World* inWorld, void* inUserData, struct sc_msg_iter* args, void* replyAddr);
+
+typedef SCBool (*AsyncStageFn)(struct World* inWorld, void* cmdData);
+typedef SCBool (*AsyncStageFnEx)(struct World* inWorld, void* cmdData, void* replyAddress);
+typedef SCBool (*AsyncUnitStageFn)(struct Unit* unit, void* cmdData, void* replyAddress);
+typedef void (*AsyncFreeFn)(struct World* inWorld, void* cmdData);

--- a/include/plugin_interface/SC_Graph.h
+++ b/include/plugin_interface/SC_Graph.h
@@ -31,6 +31,7 @@
  */
 struct Graph {
     Node mNode;
+    int32 mRefCount;
 
     uint32 mNumWires;
     struct Wire* mWire;

--- a/include/plugin_interface/SC_InterfaceTable.h
+++ b/include/plugin_interface/SC_InterfaceTable.h
@@ -33,11 +33,9 @@ static const int sc_api_version = 4;
 #include "SC_FifoMsg.h"
 #include "SC_fftlib.h"
 #include "SC_Export.h"
+#include "SC_Command.h"
 
 typedef struct SF_INFO SF_INFO;
-
-typedef SCBool (*AsyncStageFn)(World* inWorld, void* cmdData);
-typedef void (*AsyncFreeFn)(World* inWorld, void* cmdData);
 
 struct ScopeBufferHnd {
     void* internalData;

--- a/include/plugin_interface/SC_InterfaceTable.h
+++ b/include/plugin_interface/SC_InterfaceTable.h
@@ -135,6 +135,12 @@ struct InterfaceTable {
         AsyncStageFnEx stage4, // stage4 is non real time - sends done if stage4 returns true
         AsyncFreeFn cleanup, int32 completionMsgSize, const void* completionMsgData);
 
+    SCErr (*fDoAsyncUnitCommand)(
+        Unit* inUnit, void* replyAddr, const char* cmdName, void* cmdData,
+        AsyncUnitStageFn stage2, // stage2 is non real time
+        AsyncUnitStageFn stage3, // stage3 is real time - completion msg performed if stage3 returns true
+        AsyncUnitStageFn stage4, // stage4 is non real time - sends done if stage4 returns true
+        AsyncFreeFn cleanup, int32 completionMsgSize, const void* completionMsgData);
 
     // fBufAlloc should only be called within a BufGenFunc
     SCErr (*fBufAlloc)(SndBuf* inBuf, int32 inChannels, int32 inFrames, double inSampleRate);
@@ -204,6 +210,8 @@ typedef struct InterfaceTable InterfaceTable;
 #define DoAsynchronousCommand (*ft->fDoAsynchronousCommand)
 
 #define DoAsynchronousCommandEx (*ft->fDoAsynchronousCommandEx)
+
+#define DoAsyncUnitCommand (*ft->fDoAsyncUnitCommand)
 
 #define DefineSimpleUnit(name) (*ft->fDefineUnit)(#name, sizeof(name), (UnitCtorFunc)&name##_Ctor, 0, 0);
 

--- a/include/plugin_interface/SC_InterfaceTable.h
+++ b/include/plugin_interface/SC_InterfaceTable.h
@@ -124,6 +124,13 @@ struct InterfaceTable {
         AsyncStageFn stage4, // stage4 is non real time - sends done if stage4 returns true
         AsyncFreeFn cleanup, int32 completionMsgSize, const void* completionMsgData);
 
+    SCErr (*fDoAsynchronousCommandEx)(
+        World* inWorld, void* replyAddr, const char* cmdName, void* cmdData,
+        AsyncStageFnEx stage2, // stage2 is non real time
+        AsyncStageFnEx stage3, // stage3 is real time - completion msg performed if stage3 returns true
+        AsyncStageFnEx stage4, // stage4 is non real time - sends done if stage4 returns true
+        AsyncFreeFn cleanup, int32 completionMsgSize, const void* completionMsgData);
+
 
     // fBufAlloc should only be called within a BufGenFunc
     SCErr (*fBufAlloc)(SndBuf* inBuf, int32 inChannels, int32 inFrames, double inSampleRate);
@@ -190,6 +197,8 @@ typedef struct InterfaceTable InterfaceTable;
 #define SndFileFormatInfoFromStrings (*ft->fSndFileFormatInfoFromStrings)
 
 #define DoAsynchronousCommand (*ft->fDoAsynchronousCommand)
+
+#define DoAsynchronousCommandEx (*ft->fDoAsynchronousCommandEx)
 
 #define DefineSimpleUnit(name) (*ft->fDefineUnit)(#name, sizeof(name), (UnitCtorFunc)&name##_Ctor, 0, 0);
 

--- a/include/plugin_interface/SC_InterfaceTable.h
+++ b/include/plugin_interface/SC_InterfaceTable.h
@@ -72,6 +72,10 @@ struct InterfaceTable {
     // define a command for a unit generator  /u_cmd
     SCBool (*fDefineUnitCmd)(const char* inUnitClassName, const char* inCmdName, UnitCmdFunc inFunc);
 
+    // define a command for a unit generator  /u_cmd.
+    // this is an extended version of fDefineUnitCmd that takes a UnitCmdFuncEx instead of UnitCmdFunc.
+    SCBool (*fDefineUnitCmdEx)(const char* inUnitClassName, const char* inCmdName, UnitCmdFuncEx inFunc);
+
     // define a buf gen
     SCBool (*fDefineBufGen)(const char* inName, BufGenFunc inFunc);
 
@@ -163,6 +167,7 @@ typedef struct InterfaceTable InterfaceTable;
 #define DefineUnit (*ft->fDefineUnit)
 #define DefinePlugInCmd (*ft->fDefinePlugInCmd)
 #define DefineUnitCmd (*ft->fDefineUnitCmd)
+#define DefineUnitCmdEx (*ft->fDefineUnitCmdEx)
 #define DefineBufGen (*ft->fDefineBufGen)
 #define ClearUnitOutputs (*ft->fClearUnitOutputs)
 #define SendTrigger (*ft->fSendTrigger)

--- a/include/plugin_interface/SC_InterfaceTable.h
+++ b/include/plugin_interface/SC_InterfaceTable.h
@@ -23,7 +23,7 @@
 // TODO next time this is updated, change SC_PlugIn.hpp `in`, `zin`, etc. to take uint32s
 // TODO next time this is updated, change SC_PlugIn.hpp `numInputs`, `numOutputs` to have correct
 // return type
-static const int sc_api_version = 4;
+static const int sc_api_version = 5;
 
 #include "SC_Types.h"
 #include "SC_World.h"

--- a/include/plugin_interface/SC_Unit.h
+++ b/include/plugin_interface/SC_Unit.h
@@ -381,9 +381,3 @@ template <bool shared> struct buffer_lock {
     rgen.s1 = s1;                                                                                                      \
     rgen.s2 = s2;                                                                                                      \
     rgen.s3 = s3;
-
-
-struct sc_msg_iter;
-
-typedef void (*UnitCmdFunc)(struct Unit* unit, struct sc_msg_iter* args);
-typedef void (*PlugInCmdFunc)(World* inWorld, void* inUserData, struct sc_msg_iter* args, void* replyAddr);

--- a/server/plugins/DemoUGens.cpp
+++ b/server/plugins/DemoUGens.cpp
@@ -20,9 +20,13 @@
 
 #include "SC_PlugIn.h"
 
+#include <algorithm>
+
 static InterfaceTable* ft;
 
 // example of implementing a plugin command with async execution.
+// NOTE: the "pluginCmdDemo" command is used by the TestPluginCommand unit test!
+// If you change this code, make sure to update testsuite/classlibrary/TestPluginCommand.sc.
 
 struct MyPluginData // data for the global instance of the plugin
 {
@@ -42,11 +46,24 @@ SCBool cmdStage2(World* world, void* inUserData, void* inReplyAddress) {
     // user data is the command.
     MyCmdData* myCmdData = (MyCmdData*)inUserData;
 
-    // just print out the values
-    Print("cmdStage2 a %g  b %g  x %g  y %g  name %s\n", myCmdData->myPlugin->a, myCmdData->myPlugin->b, myCmdData->x,
-          myCmdData->y, myCmdData->name);
+    // just for demonstration purposes, let's assume that a string that says "fail" causes the command to fail.
+    if (strcmp(myCmdData->name, "fail") != 0) {
+        // "success" -> just print out the values
+        Print("cmdStage2 a %g  b %g  x %g  y %g  name %s\n", myCmdData->myPlugin->a, myCmdData->myPlugin->b, myCmdData->x,
+              myCmdData->y, myCmdData->name);
 
-    return true;
+        // return 'true' to continue with stage3.
+        return true;
+    } else {
+        // "fail"
+        Print("cmdStage2 a %g  b %g  x %g  y %g  failed!\n", myCmdData->myPlugin->a, myCmdData->myPlugin->b,
+              myCmdData->x, myCmdData->y);
+
+        // return 'false' to cancel the command. scsynth will not continue with stage3 and instead go jump
+        // to the cleanup function. this also means that no completion message will be performed and no
+        // /done message will be sent.
+        return false;
+    }
 }
 
 SCBool cmdStage3(World* world, void* inUserData, void* inReplyAddress) {
@@ -57,7 +74,7 @@ SCBool cmdStage3(World* world, void* inUserData, void* inReplyAddress) {
     Print("cmdStage3 a %g  b %g  x %g  y %g  name %s\n", myCmdData->myPlugin->a, myCmdData->myPlugin->b, myCmdData->x,
           myCmdData->y, myCmdData->name);
 
-    // scsynth will perform completion message after this returns
+    // if you return 'true' scsynth will perform the completion message (if any) and then continue with stage4.
     return true;
 }
 
@@ -69,7 +86,8 @@ SCBool cmdStage4(World* world, void* inUserData, void* inReplyAddress) {
     Print("cmdStage4 a %g  b %g  x %g  y %g  name %s\n", myCmdData->myPlugin->a, myCmdData->myPlugin->b, myCmdData->x,
           myCmdData->y, myCmdData->name);
 
-    // scsynth will send /done after this returns
+    // return 'true' to send a /done message (if the command name is not NULL).
+    // either way, we will continue with the cleanup function.
     return true;
 }
 
@@ -82,7 +100,6 @@ void cmdCleanup(World* world, void* inUserData) {
 
     RTFree(world, myCmdData->name); // free the string
     RTFree(world, myCmdData); // free command data
-    // scsynth will delete the completion message for you.
 }
 
 void cmdDemoFunc(World* inWorld, void* inUserData, struct sc_msg_iter* args, void* replyAddr) {
@@ -106,7 +123,9 @@ void cmdDemoFunc(World* inWorld, void* inUserData, struct sc_msg_iter* args, voi
     myCmdData->y = args->getf();
 
     // how to pass a string argument:
-    const char* name = args->gets("(empty)"); // get the string argument
+    const char* name = args->gets(); // get the string argument
+    if (!name)
+        name = "";
     size_t nameSize = strlen(name) + 1;
     myCmdData->name = (char*)RTAlloc(inWorld, nameSize); // allocate space, free it in cmdCleanup.
     if (!myCmdData->name) {
@@ -146,15 +165,22 @@ s.sendMsg('/cmd', \pluginCmdDemo, 7, 9, \mno);
 s.sendMsg('/cmd', \pluginCmdDemo, 7, 9);
 s.sendMsg('/cmd', \pluginCmdDemo, 7);
 s.sendMsg('/cmd', \pluginCmdDemo);
+// sending a \fail string causes the command to "fail".
+// no completion message is performed and no /done message is sent.
+s.sendMsg('/cmd', \pluginCmdDemo, 7, 9, \fail, ['/s_new', \sine, 900, 0, 0]);
 
 */
 
 //////////////////////////////////////////////////////////////////////////////////////////////////
 
 // example of implementing a plugin with unit commands
+// NOTE: the "UnitCmdDemo" UGen and its unit commands are used by the TestUnitCommand unit test!
+// If you change this code, make sure to update testsuite/classlibrary/TestUnitCommand.sc.
 
 struct UnitCmdDemo : public Unit {
     float value;
+    float* data;
+    size_t size;
 };
 
 void UnitCmdDemo_next(UnitCmdDemo* unit, int inNumSamples) { OUT0(0) = unit->value; }
@@ -162,6 +188,8 @@ void UnitCmdDemo_next(UnitCmdDemo* unit, int inNumSamples) { OUT0(0) = unit->val
 void UnitCmdDemo_Ctor(UnitCmdDemo* unit) {
     SETCALC(UnitCmdDemo_next);
     unit->value = 0.f;
+    unit->data = nullptr;
+    unit->size = 0;
     UnitCmdDemo_next(unit, 1);
 }
 
@@ -170,30 +198,165 @@ void UnitCmdDemo_setValue(UnitCmdDemo* unit, sc_msg_iter* args) {
     Print("UnitCmdTest: set value to %f\n", unit->value);
 }
 
-/*
- * to test the above, send the server these commands:
- *
- *
- * SynthDef(\u_cmd_test, { UnitCmdDemo.kr; }).add;
- * s.sync;
- * u = Synth(\u_cmd_test);
- * // You have to know the index of the UGen within the Synth.
- * // Here we have a SynthDef with a single UGen and without Synth controls,
- * // so the index will be 0.
- * s.sendMsg(\u_cmd, u.nodeID, 0, \setValue, 4.5);
- * s.sendMsg(\u_cmd, u.nodeID, 0, \setValue, -3.0);
- *
- */
+struct UnitCmdDemoData {
+    float* data;
+    size_t size;
+    float value;
+};
+
+SCBool UnitCmdDemo_stage2(Unit* unit, void* rawData, void* replyAddr) {
+    auto cmdData = (UnitCmdDemoData*)rawData;
+
+    // just for demonstration purposes, let's assume that a negative value causes the command to fail.
+    if (cmdData->value >= 0.f) {
+        Print("UnitCmdDemo_stage2 (NRT): allocate %d floats\n", cmdData->size);
+        cmdData->data = (float*)malloc(cmdData->size * sizeof(float));
+        std::fill_n(cmdData->data, cmdData->size, cmdData->value);
+        // return 'true' to continue with stage3.
+        return true;
+    } else {
+        Print("UnitCmdDemo: 'testCommand' failed with %f\n", cmdData->value);
+        // return 'false' to cancel the command. scsynth will not continue with stage3 and instead jump
+        // to the cleanup function. this also means that no completion message will be performed and no
+        // /done message will be sent.
+        return false;
+    }
+
+}
+
+SCBool UnitCmdDemo_stage3(Unit* unit, void* rawData, void* replyAddr) {
+    auto cmdData = (UnitCmdDemoData*)rawData;
+
+    if (unit) {
+        // Unit is still alive
+        Print("UnitCmdDemo_stage3 (RT): swap data\n");
+        auto demoUnit = (UnitCmdDemo*)unit;
+        auto oldData = demoUnit->data;
+        demoUnit->data = cmdData->data;
+        demoUnit->size = cmdData->size;
+        cmdData->data = oldData;
+
+        // if you return 'true' scsynth will perform the completion message (if any)
+        // and then continue with stage4. Otherwise we jump to the cleanup function.
+        return true;
+    } else {
+        // The owning Synth has been freed concurrently.
+        // We still have to continue with stage4 because we need to free our data.
+        // The completion message, however, will *not* be performed.
+        Print("WARNING: UnitCmdDemo has been freed while 'testCommand' was still running.\n");
+        return true;
+    }
+}
+
+SCBool UnitCmdDemo_stage4(Unit* unit, void* rawData, void* replyAddr) {
+    UnitCmdDemoData* cmdData = (UnitCmdDemoData*)rawData;
+
+    Print("UnitCmdDemo_stage4 (NRT): free data\n");
+    free(cmdData->data);
+
+    // return 'true' to send a /done message (if the command name is not NULL)
+    // either way, we will continue with the cleanup function.
+    return true;
+}
+
+void UnitCmdDemo_cleanup(World* world, void* rawData) { RTFree(world, rawData); }
+
+void UnitCmdDemo_testCommand(UnitCmdDemo* unit, sc_msg_iter* args, void* replyAddr) {
+    // get and verify arguments before allocating the command struct
+    int size = args->geti();
+    if (size <= 0) {
+        Print("UnitCmdDemo: bad size %d for 'testCommand'\n", size);
+        return;
+    }
+    float value = args->getf();
+    // how to pass an (optional) completion message.
+    // NOTE: there is no need to copy the data!
+    // DoAsyncUnitCommand will internally make a copy as needed.
+    size_t msgSize = args->getbsize();
+    const void* msgData = args->rdpos + 4;
+
+    auto cmdData = (UnitCmdDemoData*)RTAlloc(unit->mWorld, sizeof(UnitCmdDemoData));
+
+    cmdData->data = nullptr;
+    cmdData->size = size;
+    cmdData->value = value;
+
+    DoAsyncUnitCommand(unit, replyAddr, "testCommand", cmdData, UnitCmdDemo_stage2, UnitCmdDemo_stage3,
+                       UnitCmdDemo_stage4, UnitCmdDemo_cleanup, msgSize, msgData);
+}
+
+void UnitCmdDemo_Dtor(UnitCmdDemo* unit) {
+    if (unit->data) {
+        // delete on NRT thread. We cannot call DoAsyncUnitCommand() in the destructor
+        // since the owning Graph is already being deleted. Instead we use SendMsgFromRT().
+        FifoMsg msg;
+        msg.mWorld = unit->mWorld;
+        msg.mData = unit->data;
+        msg.mPerformFunc = [](FifoMsg* msg) {
+            Print("UnitCmdDemo: free data on NRT thread.\n");
+            free(msg->mData);
+        };
+        msg.mFreeFunc = nullptr;
+        SendMsgFromRT(unit->mWorld, msg);
+    }
+}
+
+/* to test the above, send the server these commands:
+
+(
+SynthDef(\sine, {
+    Out.ar(0, SinOsc.ar(800,0,0.2) * 0.01)
+}).add;
+
+SynthDef(\u_cmd_test, { UnitCmdDemo.kr; }).add;
+
+// listen for /done message
+OSCdef(\u_cmd_test, {
+    "testCommand done!".postln;
+}, '/done', nil, nil, [ 'testCommand' ]);
+)
+
+u = Synth(\u_cmd_test);
+
+// First test the simple (synchronous) unit command:
+// You have to know the index of the UGen within the Synth.
+// Here we have a SynthDef with a single UGen and without Synth controls,
+// so the index will be 0.
+s.sendMsg('/u_cmd', u.nodeID, 0, \setValue, 4.5);
+s.sendMsg('/u_cmd', u.nodeID, 0, \setValue, -3.0);
+
+// Now let's also test the asynchronous unit command:
+s.sendMsg('/u_cmd', u.nodeID, 0, \testCommand, 48000, 0.5, ['/s_new', \sine, 900, 0, 0]);
+s.sendMsg('/n_free', 900);
+s.sendMsg('/u_cmd', u.nodeID, 0, \testCommand, 48000, 0.5);
+// no completion message is performed and no /done message is sent.
+s.sendMsg('/u_cmd', u.nodeID, 0, \testCommand, 48000, -1.0, ['/s_new', \sine, 900, 0, 0]);
+
+// Note how the asynchronous unit command is safely cancelled
+// in case the owning Synth is freed concurrently:
+(
+s.sendMsg('/u_cmd', u.nodeID, 0, \testCommand, 48000, 0.5);
+u.free;
+)
+
+*/
 
 PluginLoad(DemoUGens) {
     ft = inTable;
 
     // define a plugin command - example code
+
     gMyPlugin.a = 1.2f;
     gMyPlugin.b = 3.4f;
     DefinePlugInCmd("pluginCmdDemo", cmdDemoFunc, (void*)&gMyPlugin);
 
     // define a unit command - example code
-    DefineSimpleUnit(UnitCmdDemo);
+
+    // First define the unit.
+    DefineDtorUnit(UnitCmdDemo);
+    // Then define a simple (synchronous) unit command.
     DefineUnitCmd("UnitCmdDemo", "setValue", (UnitCmdFunc)&UnitCmdDemo_setValue);
+    // Let's also define an extended (asynchronous) unit command.
+    // ('testCommand' calls DoAsyncUnitCommand.)
+    DefineUnitCmdEx("UnitCmdDemo", "testCommand", (UnitCmdFuncEx)&UnitCmdDemo_testCommand);
 }

--- a/server/plugins/DemoUGens.cpp
+++ b/server/plugins/DemoUGens.cpp
@@ -22,7 +22,7 @@
 
 static InterfaceTable* ft;
 
-// example of implementing a plug in command with async execution.
+// example of implementing a plugin command with async execution.
 
 struct MyPluginData // data for the global instance of the plugin
 {
@@ -38,7 +38,7 @@ struct MyCmdData // data for each command
 
 MyPluginData gMyPlugin; // global
 
-SCBool cmdStage2(World* world, void* inUserData) {
+SCBool cmdStage2(World* world, void* inUserData, void* inReplyAddress) {
     // user data is the command.
     MyCmdData* myCmdData = (MyCmdData*)inUserData;
 
@@ -49,7 +49,7 @@ SCBool cmdStage2(World* world, void* inUserData) {
     return true;
 }
 
-SCBool cmdStage3(World* world, void* inUserData) {
+SCBool cmdStage3(World* world, void* inUserData, void* inReplyAddress) {
     // user data is the command.
     MyCmdData* myCmdData = (MyCmdData*)inUserData;
 
@@ -61,7 +61,7 @@ SCBool cmdStage3(World* world, void* inUserData) {
     return true;
 }
 
-SCBool cmdStage4(World* world, void* inUserData) {
+SCBool cmdStage4(World* world, void* inUserData, void* inReplyAddress) {
     // user data is the command.
     MyCmdData* myCmdData = (MyCmdData*)inUserData;
 
@@ -100,62 +100,58 @@ void cmdDemoFunc(World* inWorld, void* inUserData, struct sc_msg_iter* args, voi
     myCmdData->myPlugin = thePlugInData;
 
     // ..get data from args..
-    myCmdData->x = 0.;
-    myCmdData->y = 0.;
-    myCmdData->name = 0;
 
     // float arguments
     myCmdData->x = args->getf();
     myCmdData->y = args->getf();
 
     // how to pass a string argument:
-    const char* name = args->gets(); // get the string argument
-    if (name) {
-        myCmdData->name = (char*)RTAlloc(inWorld, strlen(name) + 1); // allocate space, free it in cmdCleanup.
-        if (!myCmdData->name) {
-            Print("cmdDemoFunc: memory allocation failed!\n");
-            return;
-        }
-        strcpy(myCmdData->name, name); // copy the string
+    const char* name = args->gets("(empty)"); // get the string argument
+    size_t nameSize = strlen(name) + 1;
+    myCmdData->name = (char*)RTAlloc(inWorld, nameSize); // allocate space, free it in cmdCleanup.
+    if (!myCmdData->name) {
+        Print("cmdDemoFunc: memory allocation failed!\n");
+        return;
     }
+    memcpy(myCmdData->name, name, nameSize); // copy the string
 
-    // how to pass a completion message
-    int msgSize = args->getbsize();
-    char* msgData = 0;
-    if (msgSize) {
-        // allocate space for completion message
-        // scsynth will delete the completion message for you.
-        msgData = (char*)RTAlloc(inWorld, msgSize);
-        if (!msgData) {
-            Print("cmdDemoFunc: memory allocation failed!\n");
-            return;
-        }
-        args->getb(msgData, msgSize); // copy completion message.
-    }
+    // how to pass an (optional) completion message.
+    // NOTE: there is no need to copy the data!
+    // DoAsynchronousCommand will internally make a copy as needed.
+    size_t msgSize = args->getbsize();
+    const void* msgData = args->rdpos + 4;
 
-    DoAsynchronousCommand(inWorld, replyAddr, "cmdDemoFunc", (void*)myCmdData, (AsyncStageFn)cmdStage2,
-                          (AsyncStageFn)cmdStage3, (AsyncStageFn)cmdStage4, cmdCleanup, msgSize, msgData);
+    DoAsynchronousCommandEx(inWorld, replyAddr, "pluginCmdDemo", myCmdData, cmdStage2, cmdStage3, cmdStage4, cmdCleanup,
+                            msgSize, msgData);
 
     Print("<-cmdDemoFunc\n");
 }
 
-/*
- * to test the above, send the server these commands:
- *
- *
- * SynthDef(\sine, { Out.ar(0, SinOsc.ar(800,0,0.2)) }).load(s);
- * s.sendMsg(\cmd, \pluginCmdDemo, 7, 9, \mno, [\s_new, \sine, 900, 0, 0]);
- * s.sendMsg(\n_free, 900);
- * s.sendMsg(\cmd, \pluginCmdDemo, 7, 9, \mno);
- * s.sendMsg(\cmd, \pluginCmdDemo, 7, 9);
- * s.sendMsg(\cmd, \pluginCmdDemo, 7);
- * s.sendMsg(\cmd, \pluginCmdDemo);
- *
- */
+/* to test the above, send the server these commands:
+
+(
+SynthDef(\sine, {
+    Out.ar(0, SinOsc.ar(800,0,0.2) * 0.01)
+}).add;
+
+// listen for /done message
+OSCdef(\cmd_test, {
+    "pluginCmdDemo done!".postln;
+}, '/done', nil, nil, [ \pluginCmdDemo ]);
+)
+
+s.sendMsg('/cmd', \pluginCmdDemo, 7, 9, \mno, ['/s_new', \sine, 900, 0, 0]);
+s.sendMsg('/n_free', 900);
+s.sendMsg('/cmd', \pluginCmdDemo, 7, 9, \mno);
+s.sendMsg('/cmd', \pluginCmdDemo, 7, 9);
+s.sendMsg('/cmd', \pluginCmdDemo, 7);
+s.sendMsg('/cmd', \pluginCmdDemo);
+
+*/
 
 //////////////////////////////////////////////////////////////////////////////////////////////////
 
-// example of implementing a plug in with unit commands
+// example of implementing a plugin with unit commands
 
 struct UnitCmdDemo : public Unit {
     float value;

--- a/server/plugins/DemoUGens.cpp
+++ b/server/plugins/DemoUGens.cpp
@@ -49,8 +49,8 @@ SCBool cmdStage2(World* world, void* inUserData, void* inReplyAddress) {
     // just for demonstration purposes, let's assume that a string that says "fail" causes the command to fail.
     if (strcmp(myCmdData->name, "fail") != 0) {
         // "success" -> just print out the values
-        Print("cmdStage2 a %g  b %g  x %g  y %g  name %s\n", myCmdData->myPlugin->a, myCmdData->myPlugin->b, myCmdData->x,
-              myCmdData->y, myCmdData->name);
+        Print("cmdStage2 a %g  b %g  x %g  y %g  name %s\n", myCmdData->myPlugin->a, myCmdData->myPlugin->b,
+              myCmdData->x, myCmdData->y, myCmdData->name);
 
         // return 'true' to continue with stage3.
         return true;
@@ -221,7 +221,6 @@ SCBool UnitCmdDemo_stage2(Unit* unit, void* rawData, void* replyAddr) {
         // /done message will be sent.
         return false;
     }
-
 }
 
 SCBool UnitCmdDemo_stage3(Unit* unit, void* rawData, void* replyAddr) {

--- a/server/scsynth/SC_Graph.cpp
+++ b/server/scsynth/SC_Graph.cpp
@@ -34,11 +34,13 @@
 #include "SC_Prototypes.h"
 #include "SC_Errors.h"
 #include "Unroll.h"
+#include "SC_ReplyImpl.hpp"
 
 void Unit_ChooseMulAddFunc(Unit* unit);
 
 struct QueuedCmd {
     struct QueuedCmd* mNext;
+    ReplyAddress mReplyAddress;
     int mSize;
     char mData[1];
 };
@@ -64,8 +66,8 @@ void Graph_Dtor(Graph* inGraph) {
         }
     }
     // free queued Unit commands
-    // AFAICT this can only happen if a Graph is created, Unit commands are sent and the Graph
-    // is deleted all at the same time stamp.
+    // AFAICT this can only happen if a Graph is created, Unit commands are sent and
+    // the Graph is deleted all at in the same control block.
     QueuedCmd* cmd = (QueuedCmd*)inGraph->mPrivate;
     while (cmd) {
         QueuedCmd* next = cmd->mNext;
@@ -450,12 +452,16 @@ void Graph_Ctor(World* inWorld, GraphDef* inGraphDef, Graph* graph, sc_msg_iter*
     inGraphDef->mRefCount++;
 }
 
-void Graph_QueueUnitCmd(Graph* inGraph, int inSize, const char* inData) {
+void Graph_QueueUnitCmd(Graph* inGraph, int inSize, const char* inData, const ReplyAddress* inReplyAddress) {
     // put the unit command on a queue and dispatch it right after the first
     // calc function, i.e. after calling the unit constructors.
     // scprintf("->Graph_QueueUnitCmd\n");
     QueuedCmd* cmd = (QueuedCmd*)World_Alloc(inGraph->mNode.mWorld, sizeof(QueuedCmd) + inSize);
     cmd->mNext = nullptr;
+    if (inReplyAddress)
+        cmd->mReplyAddress = *inReplyAddress;
+    else
+        cmd->mReplyAddress.mReplyFunc = null_reply_func;
     cmd->mSize = inSize;
     memcpy(cmd->mData, inData, inSize);
     if (inGraph->mPrivate) {
@@ -487,7 +493,7 @@ static void Graph_DispatchUnitCmds(Graph* inGraph) {
         int32* cmdName = msg.gets4();
         UnitCmd* cmd = unitDef->mCmds->Get(cmdName);
 
-        (cmd->mFunc)(unit, &msg);
+        Unit_RunCommand(cmd, unit, &msg, &item->mReplyAddress);
 
         World_Free(inGraph->mNode.mWorld, item);
 

--- a/server/scsynth/SC_Graph.cpp
+++ b/server/scsynth/SC_Graph.cpp
@@ -50,7 +50,7 @@ struct QueuedCmd {
 void Graph_FirstCalc(Graph* inGraph);
 void Graph_NullFirstCalc(Graph* inGraph);
 
-void Graph_Dtor(Graph* inGraph) {
+static void Graph_Dtor(Graph* inGraph) {
     // scprintf("->Graph_Dtor %d\n", inGraph->mNode.mID);
     World* world = inGraph->mNode.mWorld;
     uint32 numUnits = inGraph->mNumUnits;
@@ -89,9 +89,51 @@ void Graph_Dtor(Graph* inGraph) {
     // scprintf("<-Graph_Dtor\n");
 }
 
+// This is called by asynchronous unit commands to prevent the Graph
+// from being destroyed while the command is still pending.
+void Graph_AddRef(Graph* inGraph) {
+    // this should only be called on Graphs that are still alive!
+    assert(inGraph->mRefCount > 0);
+    inGraph->mRefCount++;
+}
+
+// This is called by asynchronous unit commands after they have finished.
+// If the reference count reaches zero, the Graph will finally be destroyed.
+void Graph_Release(Graph* inGraph) {
+    assert(inGraph->mRefCount > 0);
+    if (--inGraph->mRefCount == 0) {
+        Graph_Dtor(inGraph);
+    }
+}
+
+// This is called when a Graph resp. one of its parent Nodes is freed by the user.
+void Graph_Delete(Graph* inGraph) {
+    assert(inGraph->mRefCount > 0);
+    int newRefCount = --inGraph->mRefCount;
+    if (newRefCount > 0) {
+        // the Graph is being referenced by one or more asynchronous unit commands.
+        // We keep it alive, but remove it from the Node tree. Async unit commands
+        // can call Graph_HasParent() to check whether the Graph has been removed.
+        Node_Remove(&inGraph->mNode);
+        // Also remove the Node from the World so that the ID becomes free again.
+        // This also prevents users from (accidentally) re-adding the Graph to
+        // the Server tree.
+        World_RemoveNode(inGraph->mNode.mWorld, &inGraph->mNode);
+    } else {
+        // Nobody else is referencing the Graph, so we can immediately destroy it.
+        Graph_Dtor(inGraph);
+    }
+}
+
+// This is called by asynchronous unit commands to check whether the
+// owning Graph has been removed.
+bool Graph_HasParent(const Graph* inGraph) { return inGraph->mNode.mParent != nullptr; }
+
 ////////////////////////////////////////////////////////////////////////////////
 
-SCErr Graph_New(World* inWorld, struct GraphDef* inGraphDef, int32 inID, struct sc_msg_iter* args, Graph** outGraph,
+static void Graph_Ctor(World* inWorld, GraphDef* inGraphDef, Graph* graph, sc_msg_iter* msg, bool argtype);
+
+SCErr Graph_New(World* inWorld, GraphDef* inGraphDef, int32 inID, sc_msg_iter* args, Graph** outGraph,
                 bool argtype) // true for normal args , false for setn type args
 {
     Graph* graph;
@@ -103,8 +145,8 @@ SCErr Graph_New(World* inWorld, struct GraphDef* inGraphDef, int32 inID, struct 
     return err;
 }
 
-void Graph_Ctor(World* inWorld, GraphDef* inGraphDef, Graph* graph, sc_msg_iter* msg,
-                bool argtype) // true for normal args , false for setn type args
+static void Graph_Ctor(World* inWorld, GraphDef* inGraphDef, Graph* graph, sc_msg_iter* msg,
+                       bool argtype) // true for normal args , false for setn type args
 {
     // scprintf("->Graph_Ctor\n");
 
@@ -448,6 +490,8 @@ void Graph_Ctor(World* inWorld, GraphDef* inGraphDef, Graph* graph, sc_msg_iter*
             }
         }
     }
+
+    graph->mRefCount = 1;
 
     inGraphDef->mRefCount++;
 }

--- a/server/scsynth/SC_GraphDef.h
+++ b/server/scsynth/SC_GraphDef.h
@@ -70,7 +70,6 @@ struct GraphDef {
     uint32 mNumVariants;
     struct GraphDef* mVariants;
 };
-typedef struct GraphDef GraphDef;
 
 GraphDef* GraphDef_Recv(World* inWorld, const char* buffer, size_t size, GraphDef* inList);
 GraphDef* GraphDef_Load(World* inWorld, const std::filesystem::path& path, GraphDef* inList);

--- a/server/scsynth/SC_MiscCmds.cpp
+++ b/server/scsynth/SC_MiscCmds.cpp
@@ -163,8 +163,8 @@ SCErr meth_b_zero(World* inWorld, int inSize, char* inData, ReplyAddress* inRepl
 
 
 SCErr meth_u_cmd(World* inWorld, int inSize, char* inData, ReplyAddress* inReply);
-SCErr meth_u_cmd(World* inWorld, int inSize, char* inData, ReplyAddress* /*inReply*/) {
-    return Unit_DoCmd(inWorld, inSize, inData);
+SCErr meth_u_cmd(World* inWorld, int inSize, char* inData, ReplyAddress* inReply) {
+    return Unit_DoCmd(inWorld, inSize, inData, inReply);
 };
 
 SCErr meth_cmd(World* inWorld, int inSize, char* inData, ReplyAddress* inReply);

--- a/server/scsynth/SC_Node.cpp
+++ b/server/scsynth/SC_Node.cpp
@@ -85,6 +85,8 @@ void Node_Dtor(Node* inNode) {
 // remove a node from a group
 void Node_Remove(Node* s) {
     Group* group = s->mParent;
+    if (group == nullptr)
+        return;
 
     if (s->mPrev)
         s->mPrev->mNext = s->mNext;
@@ -132,7 +134,7 @@ void Node_Delete(Node* inNode) {
     if (inNode->mIsGroup)
         Group_Dtor((Group*)inNode);
     else
-        Graph_Dtor((Graph*)inNode);
+        Graph_Delete((Graph*)inNode);
 }
 
 // add a node after another one

--- a/server/scsynth/SC_Prototypes.h
+++ b/server/scsynth/SC_Prototypes.h
@@ -108,15 +108,15 @@ void Rate_Init(struct Rate* inRate, double inSampleRate, int inBufLength);
 #define GRAPHDEF(inGraph) ((GraphDef*)((inGraph)->mNode.mDef))
 #define GRAPH_PARAM_TABLE(inGraph) (GRAPHDEF(inGraph)->mParamSpecTable)
 
-SCErr Graph_New(World* inWorld, struct GraphDef* def, int32 inID, struct sc_msg_iter* args, struct Graph** outGraph,
-                bool argtype = true);
-void Graph_Ctor(World* inWorld, struct GraphDef* inGraphDef, struct Graph* graph, struct sc_msg_iter* msg,
-                bool argtype);
-void Graph_Dtor(struct Graph* inGraph);
-SCErr Graph_GetControl(struct Graph* inGraph, uint32 inIndex, float& outValue);
-SCErr Graph_GetControl(struct Graph* inGraph, int32 inHash, int32* inName, uint32 inIndex, float& outValue);
-void Graph_SetControl(struct Graph* inGraph, uint32 inIndex, float inValue);
-void Graph_SetControl(struct Graph* inGraph, int32 inHash, int32* inName, uint32 inIndex, float inValue);
+SCErr Graph_New(World* inWorld, GraphDef* def, int32 inID, sc_msg_iter* args, Graph** outGraph, bool argtype = true);
+void Graph_Delete(Graph* inGraph);
+void Graph_AddRef(Graph* inGraph);
+void Graph_Release(Graph* inGraph);
+bool Graph_HasParent(const Graph* inGraph);
+SCErr Graph_GetControl(Graph* inGraph, uint32 inIndex, float& outValue);
+SCErr Graph_GetControl(Graph* inGraph, int32 inHash, int32* inName, uint32 inIndex, float& outValue);
+void Graph_SetControl(Graph* inGraph, uint32 inIndex, float inValue);
+void Graph_SetControl(Graph* inGraph, int32 inHash, int32* inName, uint32 inIndex, float inValue);
 void Graph_MapControl(Graph* inGraph, uint32 inIndex, uint32 inBus);
 void Graph_MapControl(Graph* inGraph, int32 inHash, int32* inName, uint32 inIndex, uint32 inBus);
 void Graph_MapAudioControl(Graph* inGraph, uint32 inIndex, uint32 inBus);
@@ -225,6 +225,13 @@ SCErr PerformAsynchronousCommandEx(
     AsyncStageFnEx stage2, // stage2 is non real time
     AsyncStageFnEx stage3, // stage3 is real time - completion msg performed if stage3 returns true
     AsyncStageFnEx stage4, // stage4 is non real time - sends done if stage4 returns true
+    AsyncFreeFn cleanup, int completionMsgSize, const void* completionMsgData);
+
+SCErr PerformAsyncUnitCommand(
+    Unit* inUnit, void* replyAddr, const char* cmdName, void* cmdData,
+    AsyncUnitStageFn stage2, // stage2 is non real time
+    AsyncUnitStageFn stage3, // stage3 is real time - completion msg performed if stage3 returns true
+    AsyncUnitStageFn stage4, // stage4 is non real time - sends done if stage4 returns true
     AsyncFreeFn cleanup, int completionMsgSize, const void* completionMsgData);
 
 ////////////////////////////////////////////////////////////////////////

--- a/server/scsynth/SC_Prototypes.h
+++ b/server/scsynth/SC_Prototypes.h
@@ -26,6 +26,7 @@
 #include <cstring>
 
 #include "SC_Types.h"
+#include "SC_Command.h"
 #include "scsynthsend.h"
 
 ////////////////////////////////////////////////////////////////////////
@@ -211,9 +212,6 @@ int32 server_timeseed();
 }
 
 ////////////////////////////////////////////////////////////////////////
-
-typedef SCBool (*AsyncStageFn)(World* inWorld, void* cmdData);
-typedef void (*AsyncFreeFn)(World* inWorld, void* cmdData);
 
 SCErr PerformAsynchronousCommand(
     World* inWorld, void* replyAddr, const char* cmdName, void* cmdData,

--- a/server/scsynth/SC_Prototypes.h
+++ b/server/scsynth/SC_Prototypes.h
@@ -220,4 +220,11 @@ SCErr PerformAsynchronousCommand(
     AsyncStageFn stage4, // stage4 is non real time - sends done if stage4 returns true
     AsyncFreeFn cleanup, int completionMsgSize, const void* completionMsgData);
 
+SCErr PerformAsynchronousCommandEx(
+    World* inWorld, void* replyAddr, const char* cmdName, void* cmdData,
+    AsyncStageFnEx stage2, // stage2 is non real time
+    AsyncStageFnEx stage3, // stage3 is real time - completion msg performed if stage3 returns true
+    AsyncStageFnEx stage4, // stage4 is non real time - sends done if stage4 returns true
+    AsyncFreeFn cleanup, int completionMsgSize, const void* completionMsgData);
+
 ////////////////////////////////////////////////////////////////////////

--- a/server/scsynth/SC_SequencedCommand.cpp
+++ b/server/scsynth/SC_SequencedCommand.cpp
@@ -1594,3 +1594,95 @@ template <typename StageFn> void AsyncPlugInCmd_<StageFn>::Stage4() {
     if (result && mCmdName && mReplyAddress.mReplyFunc != null_reply_func)
         SendDone(mCmdName);
 }
+
+///////////////////////////////////////////////////////////////////////////
+
+SCErr PerformAsyncUnitCommand(
+    Unit* inUnit, void* replyAddr, const char* cmdName, void* cmdData,
+    AsyncUnitStageFn stage2, // stage2 is non real time
+    AsyncUnitStageFn stage3, // stage3 is real time - completion msg performed if stage3 returns true
+    AsyncUnitStageFn stage4, // stage4 is non real time - sends done if stage4 returns true
+    AsyncFreeFn cleanup, int completionMsgSize, const void* completionMsgData) {
+    if (!Graph_HasParent(inUnit->mParent)) {
+        // If Graph_HasParent() returns false, it means that the graph has been removed. This can only
+        // happen if DoAsyncUnitCommand() is called in a Unit destructor (which is not allowed).
+        // This check is important because it makes sure that we don't increment a reference count
+        // that has already gone to zero!
+        scprintf("ERROR: cannot call DoAsyncUnitCommand() in a Unit destructor!\n");
+        return kSCErr_Failed;
+    }
+
+    void* space = World_Alloc(inUnit->mWorld, sizeof(AsyncUnitCmd));
+    ReturnSCErrIfNil(space);
+    AsyncUnitCmd* cmd = new (space) AsyncUnitCmd(inUnit, (ReplyAddress*)replyAddr, cmdName, cmdData, stage2, stage3,
+                                                 stage4, cleanup, completionMsgSize, completionMsgData);
+    if (!cmd)
+        return kSCErr_Failed;
+    if (inUnit->mWorld->mRealTime)
+        cmd->CallNextStage();
+    else
+        cmd->CallEveryStage();
+    return kSCErr_None;
+}
+
+///////////////////////////////////////////////////////////////////////////
+
+AsyncUnitCmd::AsyncUnitCmd(
+    Unit* inUnit, ReplyAddress* inReplyAddress, const char* cmdName, void* cmdData,
+    AsyncUnitStageFn stage2, // stage2 is non real time
+    AsyncUnitStageFn stage3, // stage3 is real time - completion msg performed if stage3 returns true
+    AsyncUnitStageFn stage4, // stage4 is non real time - sends done if stage4 returns true
+    AsyncFreeFn cleanup, // cleanup is called in real time
+    int completionMsgSize, const void* completionMsgData):
+    SC_SequencedCommand(inUnit->mWorld, inReplyAddress),
+    mUnit(inUnit),
+    mCmdName(cmdName),
+    mCmdData(cmdData),
+    mStage2(stage2),
+    mStage3(stage3),
+    mStage4(stage4),
+    mCleanup(cleanup),
+    mAlive(true) {
+    // make sure that the owning Graph is kept alive for the whole duration of the command!
+    Graph_AddRef(inUnit->mParent);
+
+    if (completionMsgSize > 0 && completionMsgData) {
+        mMsgSize = completionMsgSize;
+        mMsgData = (char*)World_Alloc(mWorld, mMsgSize);
+        ThrowIfNil(mMsgData);
+        memcpy(mMsgData, completionMsgData, mMsgSize);
+    }
+}
+
+AsyncUnitCmd::~AsyncUnitCmd() {
+    if (mCleanup)
+        mCleanup(mWorld, mCmdData);
+    // finally release the owning Graph
+    Graph_Release(mUnit->mParent);
+}
+
+void AsyncUnitCmd::CallDestructor() { this->~AsyncUnitCmd(); }
+
+bool AsyncUnitCmd::Stage2() {
+    bool result = !mStage2 || (mStage2)(mUnit, mCmdData, &mReplyAddress);
+    return result;
+}
+
+bool AsyncUnitCmd::Stage3() {
+    // Check whether the owning Graph has been removed in the meantime. If yes, we pass
+    // nullptr as the Unit pointer so that the stage function can detect and properly
+    // handle the situation. For example, it may still have to release resources on stage4.
+    mAlive = Graph_HasParent(mUnit->mParent);
+    bool result = !mStage3 || (mStage3)(mAlive ? mUnit : nullptr, mCmdData, &mReplyAddress);
+    // Only send completition message if the Graph is still alive!
+    if (result && mAlive)
+        SEND_COMPLETION_MSG;
+    return result;
+}
+
+void AsyncUnitCmd::Stage4() {
+    bool result = !mStage4 || (mStage4)(mUnit, mCmdData, &mReplyAddress);
+    // Only send /done message if the Graph has been alive in stage3.
+    if (result && mAlive && mCmdName && mReplyAddress.mReplyFunc != null_reply_func)
+        SendDone(mCmdName);
+}

--- a/server/scsynth/SC_SequencedCommand.cpp
+++ b/server/scsynth/SC_SequencedCommand.cpp
@@ -20,6 +20,9 @@
 
 
 #include "SC_SequencedCommand.h"
+#include "SC_GraphDef.h"
+#include "SC_BufGen.h"
+#include "SC_Unit.h"
 #include "SC_CoreAudio.h"
 #include "SC_Errors.h"
 #include "scsynthsend.h"
@@ -1510,11 +1513,33 @@ SCErr PerformAsynchronousCommand(
 
 ///////////////////////////////////////////////////////////////////////////
 
-AsyncPlugInCmd::AsyncPlugInCmd(
+SCErr PerformAsynchronousCommandEx(
+    World* inWorld, void* replyAddr, const char* cmdName, void* cmdData,
+    AsyncStageFnEx stage2, // stage2 is non real time
+    AsyncStageFnEx stage3, // stage3 is real time - completion msg performed if stage3 returns true
+    AsyncStageFnEx stage4, // stage4 is non real time - sends done if stage4 returns true
+    AsyncFreeFn cleanup, int completionMsgSize, const void* completionMsgData) {
+    void* space = World_Alloc(inWorld, sizeof(AsyncPlugInCmdEx));
+    ReturnSCErrIfNil(space);
+    AsyncPlugInCmdEx* cmd = new (space) AsyncPlugInCmdEx(inWorld, (ReplyAddress*)replyAddr, cmdName, cmdData, stage2,
+                                                         stage3, stage4, cleanup, completionMsgSize, completionMsgData);
+    if (!cmd)
+        return kSCErr_Failed;
+    if (inWorld->mRealTime)
+        cmd->CallNextStage();
+    else
+        cmd->CallEveryStage();
+    return kSCErr_None;
+}
+
+///////////////////////////////////////////////////////////////////////////
+
+template <typename StageFn>
+AsyncPlugInCmd_<StageFn>::AsyncPlugInCmd_(
     World* inWorld, ReplyAddress* inReplyAddress, const char* cmdName, void* cmdData,
-    AsyncStageFn stage2, // stage2 is non real time
-    AsyncStageFn stage3, // stage3 is real time - completion msg performed if stage3 returns true
-    AsyncStageFn stage4, // stage4 is non real time - sends done if stage4 returns true
+    StageFn stage2, // stage2 is non real time
+    StageFn stage3, // stage3 is real time - completion msg performed if stage3 returns true
+    StageFn stage4, // stage4 is non real time - sends done if stage4 returns true
     AsyncFreeFn cleanup, // cleanup is called in real time
     int completionMsgSize, const void* completionMsgData):
     SC_SequencedCommand(inWorld, inReplyAddress),
@@ -1524,7 +1549,7 @@ AsyncPlugInCmd::AsyncPlugInCmd(
     mStage3(stage3),
     mStage4(stage4),
     mCleanup(cleanup) {
-    if (completionMsgSize && completionMsgData) {
+    if (completionMsgSize > 0 && completionMsgData) {
         mMsgSize = completionMsgSize;
         mMsgData = (char*)World_Alloc(mWorld, mMsgSize);
         ThrowIfNil(mMsgData);
@@ -1532,24 +1557,40 @@ AsyncPlugInCmd::AsyncPlugInCmd(
     }
 }
 
-AsyncPlugInCmd::~AsyncPlugInCmd() { (mCleanup)(mWorld, mCmdData); }
+template <typename StageFn> AsyncPlugInCmd_<StageFn>::~AsyncPlugInCmd_() {
+    // NOTE: before SC 3.15 the clean up function could not be NULL.
+    if (mCleanup)
+        mCleanup(mWorld, mCmdData);
+}
 
-void AsyncPlugInCmd::CallDestructor() { this->~AsyncPlugInCmd(); }
+template <typename StageFn> void AsyncPlugInCmd_<StageFn>::CallDestructor() { this->~AsyncPlugInCmd_(); }
 
-bool AsyncPlugInCmd::Stage2() {
-    bool result = !mStage2 || (mStage2)(mWorld, mCmdData);
+template <typename StageFn> bool AsyncPlugInCmd_<StageFn>::Stage2() {
+    bool result;
+    if constexpr (std::is_same_v<StageFn, AsyncStageFnEx>)
+        result = !mStage2 || (mStage2)(mWorld, mCmdData, &mReplyAddress);
+    else
+        result = !mStage2 || (mStage2)(mWorld, mCmdData);
     return result;
 }
 
-bool AsyncPlugInCmd::Stage3() {
-    bool result = !mStage3 || (mStage3)(mWorld, mCmdData);
+template <typename StageFn> bool AsyncPlugInCmd_<StageFn>::Stage3() {
+    bool result;
+    if constexpr (std::is_same_v<StageFn, AsyncStageFnEx>)
+        result = !mStage3 || (mStage3)(mWorld, mCmdData, &mReplyAddress);
+    else
+        result = !mStage3 || (mStage3)(mWorld, mCmdData);
     if (result)
         SEND_COMPLETION_MSG;
     return result;
 }
 
-void AsyncPlugInCmd::Stage4() {
-    bool result = !mStage4 || (mStage4)(mWorld, mCmdData);
+template <typename StageFn> void AsyncPlugInCmd_<StageFn>::Stage4() {
+    bool result;
+    if constexpr (std::is_same_v<StageFn, AsyncStageFnEx>)
+        result = !mStage4 || (mStage4)(mWorld, mCmdData, &mReplyAddress);
+    else
+        result = !mStage4 || (mStage4)(mWorld, mCmdData);
     if (result && mCmdName && mReplyAddress.mReplyFunc != null_reply_func)
-        SendDone((char*)mCmdName);
+        SendDone(mCmdName);
 }

--- a/server/scsynth/SC_SequencedCommand.h
+++ b/server/scsynth/SC_SequencedCommand.h
@@ -534,3 +534,30 @@ protected:
 
 using AsyncPlugInCmd = AsyncPlugInCmd_<AsyncStageFn>;
 using AsyncPlugInCmdEx = AsyncPlugInCmd_<AsyncStageFnEx>;
+
+///////////////////////////////////////////////////////////////////////////
+
+class AsyncUnitCmd : public SC_SequencedCommand {
+public:
+    AsyncUnitCmd(Unit* inUnit, ReplyAddress* inReplyAddress, const char* cmdName, void* cmdData,
+                 AsyncUnitStageFn stage2, // stage2 is non real time
+                 AsyncUnitStageFn stage3, // stage3 is real time - completion msg performed if stage3 returns true
+                 AsyncUnitStageFn stage4, // stage4 is non real time - sends done if stage4 returns true
+                 AsyncFreeFn cleanup, int completionMsgSize, const void* completionMsgData);
+
+    virtual ~AsyncUnitCmd();
+
+    virtual bool Stage2(); // non real time
+    virtual bool Stage3(); //     real time
+    virtual void Stage4(); // non real time
+
+protected:
+    Unit* mUnit;
+    const char* mCmdName;
+    void* mCmdData;
+    AsyncUnitStageFn mStage2, mStage3, mStage4;
+    AsyncFreeFn mCleanup;
+    bool mAlive;
+
+    virtual void CallDestructor();
+};

--- a/server/scsynth/SC_SequencedCommand.h
+++ b/server/scsynth/SC_SequencedCommand.h
@@ -28,13 +28,15 @@
 
 #pragma once
 
-#include "OSC_Packet.h"
 #include "SC_World.h"
 #include "SC_Command.h"
-#include "SC_BufGen.h"
 #include "sc_msg_iter.h"
 #include "SC_SndFileHelpers.hpp"
-#include <new>
+#include "SC_ReplyImpl.hpp"
+
+struct BufGen;
+struct GraphDef;
+struct Unit;
 
 #define CallSequencedCommand(T, inWorld, inSize, inData, inReply)                                                      \
     void* space = World_Alloc(inWorld, sizeof(T));                                                                     \
@@ -431,8 +433,6 @@ protected:
 
 ///////////////////////////////////////////////////////////////////////////
 
-#include "SC_GraphDef.h"
-
 class LoadSynthDefCmd : public SC_SequencedCommand {
 public:
     LoadSynthDefCmd(World* inWorld, ReplyAddress* inReplyAddress);
@@ -452,8 +452,6 @@ protected:
 };
 
 ///////////////////////////////////////////////////////////////////////////
-
-#include "SC_GraphDef.h"
 
 class RecvSynthDefCmd : public SC_SequencedCommand {
 public:
@@ -510,19 +508,16 @@ protected:
 
 ///////////////////////////////////////////////////////////////////////////
 
-
-typedef SCBool (*AsyncStageFn)(World* inWorld, void* cmdData);
-typedef void (*AsyncFreeFn)(World* inWorld, void* cmdData);
-
-class AsyncPlugInCmd : public SC_SequencedCommand {
+// AsyncPlugInCmd and AsyncPlugInCmdEx only differ in the type of stage function.
+template <typename StageFn> class AsyncPlugInCmd_ : public SC_SequencedCommand {
 public:
-    AsyncPlugInCmd(World* inWorld, ReplyAddress* inReplyAddress, const char* cmdName, void* cmdData,
-                   AsyncStageFn stage2, // stage2 is non real time
-                   AsyncStageFn stage3, // stage3 is real time - completion msg performed if stage3 returns true
-                   AsyncStageFn stage4, // stage4 is non real time - sends done if stage4 returns true
-                   AsyncFreeFn cleanup, int completionMsgSize, const void* completionMsgData);
+    AsyncPlugInCmd_(World* inWorld, ReplyAddress* inReplyAddress, const char* cmdName, void* cmdData,
+                    StageFn stage2, // stage2 is non real time
+                    StageFn stage3, // stage3 is real time - completion msg performed if stage3 returns true
+                    StageFn stage4, // stage4 is non real time - sends done if stage4 returns true
+                    AsyncFreeFn cleanup, int completionMsgSize, const void* completionMsgData);
 
-    virtual ~AsyncPlugInCmd();
+    virtual ~AsyncPlugInCmd_();
 
     virtual bool Stage2(); // non real time
     virtual bool Stage3(); //     real time
@@ -531,8 +526,11 @@ public:
 protected:
     const char* mCmdName;
     void* mCmdData;
-    AsyncStageFn mStage2, mStage3, mStage4;
+    StageFn mStage2, mStage3, mStage4;
     AsyncFreeFn mCleanup;
 
     virtual void CallDestructor();
 };
+
+using AsyncPlugInCmd = AsyncPlugInCmd_<AsyncStageFn>;
+using AsyncPlugInCmdEx = AsyncPlugInCmd_<AsyncStageFnEx>;

--- a/server/scsynth/SC_SequencedCommand.h
+++ b/server/scsynth/SC_SequencedCommand.h
@@ -30,6 +30,7 @@
 
 #include "OSC_Packet.h"
 #include "SC_World.h"
+#include "SC_Command.h"
 #include "SC_BufGen.h"
 #include "sc_msg_iter.h"
 #include "SC_SndFileHelpers.hpp"

--- a/server/scsynth/SC_UnitDef.cpp
+++ b/server/scsynth/SC_UnitDef.cpp
@@ -60,16 +60,12 @@ SCBool UnitDef_Create(const char* inName, size_t inAllocSize, UnitCtorFunc inCto
     return true;
 }
 
-
-SCBool UnitDef_AddCmd(const char* inUnitDefName, const char* inCmdName, UnitCmdFunc inFunc) {
-    if (strlen(inUnitDefName) >= kSCNameByteLen)
+template <typename Func> static SCBool UnitDef_DoAddCmd(const char* inUnitDefName, const char* inCmdName, Func inFunc) {
+    if (strlen(inUnitDefName) >= kSCNameByteLen || strlen(inCmdName) >= kSCNameByteLen)
         return false;
+
     int32 unitDefName[kSCNameLen];
-    memset(unitDefName, 0, kSCNameByteLen);
-    strcpy((char*)unitDefName, inUnitDefName);
-
-    if (strlen(inCmdName) >= kSCNameByteLen)
-        return false;
+    strncpy((char*)unitDefName, inUnitDefName, kSCNameByteLen);
 
     UnitDef* unitDef = GetUnitDef(unitDefName);
     if (!unitDef)
@@ -79,14 +75,27 @@ SCBool UnitDef_AddCmd(const char* inUnitDefName, const char* inCmdName, UnitCmdF
         unitDef->mCmds = new HashTable<UnitCmd, Malloc>(&gMalloc, 4, true);
 
     UnitCmd* cmd = new UnitCmd();
-    memset(cmd->mCmdName, 0, kSCNameByteLen);
-    strcpy((char*)cmd->mCmdName, inCmdName);
+    strncpy((char*)cmd->mCmdName, inCmdName, kSCNameByteLen);
 
-    cmd->mFunc = inFunc;
+    if constexpr (std::is_same_v<Func, UnitCmdFuncEx>) {
+        cmd->mFuncEx = inFunc;
+        cmd->mHasFuncEx = true;
+    } else {
+        cmd->mFunc = inFunc;
+        cmd->mHasFuncEx = false;
+    }
     cmd->mHash = Hash(cmd->mCmdName);
     unitDef->mCmds->Add(cmd);
 
     return true;
+}
+
+SCBool UnitDef_AddCmd(const char* inUnitDefName, const char* inCmdName, UnitCmdFunc inFunc) {
+    return UnitDef_DoAddCmd(inUnitDefName, inCmdName, inFunc);
+}
+
+SCBool UnitDef_AddCmdEx(const char* inUnitDefName, const char* inCmdName, UnitCmdFuncEx inFunc) {
+    return UnitDef_DoAddCmd(inUnitDefName, inCmdName, inFunc);
 }
 
 SCBool PlugIn_DefineCmd(const char* inCmdName, PlugInCmdFunc inFunc, void* inUserData) {
@@ -94,8 +103,7 @@ SCBool PlugIn_DefineCmd(const char* inCmdName, PlugInCmdFunc inFunc, void* inUse
         return false;
 
     PlugInCmd* cmd = new PlugInCmd();
-    memset(cmd->mCmdName, 0, kSCNameByteLen);
-    strcpy((char*)cmd->mCmdName, inCmdName);
+    strncpy((char*)cmd->mCmdName, inCmdName, kSCNameByteLen);
 
     cmd->mFunc = inFunc;
     cmd->mHash = Hash(cmd->mCmdName);
@@ -107,9 +115,9 @@ SCBool PlugIn_DefineCmd(const char* inCmdName, PlugInCmdFunc inFunc, void* inUse
 
 void Graph_FirstCalc(Graph* inGraph);
 void Graph_NullFirstCalc(Graph* inGraph);
-void Graph_QueueUnitCmd(Graph* inGraph, int inSize, const char* inData);
+void Graph_QueueUnitCmd(Graph* inGraph, int inSize, const char* inData, const ReplyAddress* inReplyAddress);
 
-SCErr Unit_DoCmd(World* inWorld, int inSize, char* inData) {
+SCErr Unit_DoCmd(World* inWorld, int inSize, const char* inData, ReplyAddress* inReplyAddress) {
     sc_msg_iter msg(inSize, inData);
     int nodeID = msg.geti();
     gMissingNodeID = nodeID;
@@ -138,12 +146,20 @@ SCErr Unit_DoCmd(World* inWorld, int inSize, char* inData) {
     // only run unit command if the ctor has been called!
     if (graph->mNode.mCalcFunc == (NodeCalcFunc)&Graph_FirstCalc
         || graph->mNode.mCalcFunc == (NodeCalcFunc)&Graph_NullFirstCalc) {
-        Graph_QueueUnitCmd(graph, inSize, inData);
+        Graph_QueueUnitCmd(graph, inSize, inData, inReplyAddress);
     } else {
-        (cmd->mFunc)(unit, &msg);
+        Unit_RunCommand(cmd, unit, &msg, inReplyAddress);
     }
 
     return kSCErr_None;
+}
+
+void Unit_RunCommand(const UnitCmd* cmd, Unit* unit, sc_msg_iter* msg, ReplyAddress* inReplyAddr) {
+    if (cmd->mHasFuncEx) {
+        cmd->mFuncEx(unit, msg, inReplyAddr);
+    } else {
+        cmd->mFunc(unit, msg);
+    }
 }
 
 SCErr PlugIn_DoCmd(World* inWorld, int inSize, char* inData, ReplyAddress* inReply) {

--- a/server/scsynth/SC_UnitDef.h
+++ b/server/scsynth/SC_UnitDef.h
@@ -22,6 +22,7 @@
 
 #include "SC_Types.h"
 #include "SC_Unit.h"
+#include "SC_Reply.h"
 #include "SC_Command.h"
 #include "HashTable.h"
 
@@ -35,7 +36,11 @@ struct PlugInCmd {
 struct UnitCmd {
     int32 mCmdName[kSCNameLen];
     int32 mHash;
-    UnitCmdFunc mFunc;
+    union {
+        UnitCmdFunc mFunc;
+        UnitCmdFuncEx mFuncEx;
+    };
+    bool mHasFuncEx;
 };
 
 struct UnitDef {
@@ -52,9 +57,12 @@ struct UnitDef {
 
 SCBool UnitDef_Create(const char* inName, size_t inAllocSize, UnitCtorFunc inCtor, UnitDtorFunc inDtor, uint32 inFlags);
 SCBool UnitDef_AddCmd(const char* inUnitDefName, const char* inCmdName, UnitCmdFunc inFunc);
+SCBool UnitDef_AddCmdEx(const char* inUnitDefName, const char* inCmdName, UnitCmdFuncEx inFunc);
+
 SCBool PlugIn_DefineCmd(const char* inCmdName, PlugInCmdFunc inFunc, void* inUserData);
 
-SCErr Unit_DoCmd(struct World* inWorld, int inSize, char* inData);
+SCErr Unit_DoCmd(struct World* inWorld, int inSize, const char* inData, ReplyAddress* inReplyAddr);
+void Unit_RunCommand(const UnitCmd* cmd, Unit* unit, sc_msg_iter* msg, ReplyAddress* inReplyAddr);
 
 inline int32* GetKey(UnitCmd* inCmd) { return inCmd->mCmdName; }
 inline int32 GetHash(UnitCmd* inCmd) { return inCmd->mHash; }

--- a/server/scsynth/SC_UnitDef.h
+++ b/server/scsynth/SC_UnitDef.h
@@ -22,6 +22,7 @@
 
 #include "SC_Types.h"
 #include "SC_Unit.h"
+#include "SC_Command.h"
 #include "HashTable.h"
 
 struct PlugInCmd {

--- a/server/scsynth/SC_World.cpp
+++ b/server/scsynth/SC_World.cpp
@@ -237,6 +237,7 @@ void InterfaceTable_Init() {
     ft->fGroup_DeleteAll = &Group_DeleteAll;
     ft->fDoneAction = &Unit_DoneAction;
     ft->fDoAsynchronousCommand = &PerformAsynchronousCommand;
+    ft->fDoAsynchronousCommandEx = &PerformAsynchronousCommandEx;
     ft->fBufAlloc = &bufAlloc;
 
     ft->fSCfftCreate = &scfft_create;

--- a/server/scsynth/SC_World.cpp
+++ b/server/scsynth/SC_World.cpp
@@ -239,6 +239,7 @@ void InterfaceTable_Init() {
     ft->fDoneAction = &Unit_DoneAction;
     ft->fDoAsynchronousCommand = &PerformAsynchronousCommand;
     ft->fDoAsynchronousCommandEx = &PerformAsynchronousCommandEx;
+    ft->fDoAsyncUnitCommand = &PerformAsyncUnitCommand;
     ft->fBufAlloc = &bufAlloc;
 
     ft->fSCfftCreate = &scfft_create;

--- a/server/scsynth/SC_World.cpp
+++ b/server/scsynth/SC_World.cpp
@@ -219,6 +219,7 @@ void InterfaceTable_Init() {
     ft->fSendNodeReply = &Node_SendReply;
 
     ft->fDefineUnitCmd = &UnitDef_AddCmd;
+    ft->fDefineUnitCmdEx = &UnitDef_AddCmdEx;
     ft->fDefinePlugInCmd = &PlugIn_DefineCmd;
 
     ft->fSendMsgFromRT = &SendMsgFromEngine;

--- a/server/supernova/sc/sc_endpoint.hpp
+++ b/server/supernova/sc/sc_endpoint.hpp
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <memory>
+
+namespace nova { namespace detail {
+
+struct nova_endpoint : public std::enable_shared_from_this<nova_endpoint> {
+    virtual void send(const char* data, size_t length) = 0;
+};
+
+typedef std::shared_ptr<nova_endpoint> endpoint_ptr;
+
+} /* namespace detail */ } /* namespace nova */

--- a/server/supernova/sc/sc_osc_handler.cpp
+++ b/server/supernova/sc/sc_osc_handler.cpp
@@ -3802,6 +3802,101 @@ template void sc_osc_handler::do_asynchronous_command<AsyncStageFnEx>(World*, vo
                                                                       AsyncStageFnEx, AsyncStageFnEx, AsyncFreeFn, int,
                                                                       const void*) const;
 
+template <bool realtime>
+void handle_async_unit_command(Unit* unit, const char* cmd_name, void* cmd_data, AsyncUnitStageFn stage2,
+                               AsyncUnitStageFn stage3, AsyncUnitStageFn stage4, AsyncFreeFn cleanup,
+                               completion_message&& message, endpoint_ptr&& endpoint) {
+    // See comment in handle_asynchronous_command().
+    spin_lock::scoped_lock lock(system_callback_allocator_lock);
+
+    // Get the owning synth
+    sc_synth* synth = static_cast<sc_synth*>(instance->find_synth(unit->mParent->mNode.mID));
+    assert(synth != nullptr);
+    // If the synth has no parent, it means that it has been removed. This can only happen
+    // if DoAsyncUnitCommand() is called in a Unit destructor (which is not allowed).
+    // This check is important because it makes sure that we don't increment the reference count
+    // that has already gone to zero!
+    if (synth->get_parent() == nullptr)
+        throw std::runtime_error("cannot call DoAsyncUnitCommand() in a Unit destructor!");
+
+    // make sure that the owning synth is kept alive for the whole duration of the command!
+    // This also means we can safely use the synth pointer inside the callbacks.
+    synth->add_ref();
+
+    cmd_dispatcher<realtime>::fire_system_callback(
+        [=, message = std::move(message), endpoint = std::move(endpoint)]() mutable {
+            // stage 2 (NRT thread)
+            bool result2 = !stage2 || stage2(unit, cmd_data, endpoint.get());
+
+            if (!result2) {
+                // free in RT thread!
+                cmd_dispatcher<realtime>::fire_rt_callback([=, message = std::move(message)]() mutable {
+                    if (cleanup)
+                        (cleanup)(unit->mWorld, cmd_data);
+                    consume(std::move(message));
+                    synth->release();
+                });
+                return;
+            }
+
+            cmd_dispatcher<realtime>::fire_rt_callback(
+                [=, message = std::move(message), endpoint = std::move(endpoint)]() mutable {
+                    // stage 3 (RT thread)
+                    // Check whether the owning synth has been removed in the meantime. If yes, we pass
+                    // nullptr as the Unit pointer so that the stage function can detect and properly
+                    // handle the situation. For example, it may still have to release resources on stage4.
+                    // If the node can't be found, it has been removed.
+                    bool alive = synth->get_parent() != nullptr;
+                    bool result3 = !stage3 || stage3(alive ? unit : nullptr, cmd_data, endpoint.get());
+
+                    if (!result3) {
+                        if (cleanup)
+                            (cleanup)(unit->mWorld, cmd_data);
+                        consume(std::move(message));
+                        synth->release();
+                        return;
+                    }
+
+                    // only perform completion message if the synth is still alive!
+                    if (alive)
+                        handle_completion_message(std::move(message), endpoint);
+                    else
+                        consume(std::move(message));
+
+                    cmd_dispatcher<realtime>::fire_io_callback([=, endpoint = std::move(endpoint)] {
+                        // stage 4 (NRT thread)
+                        bool result4 = !stage4 || stage4(unit, cmd_data, endpoint.get());
+
+                        // only send /done message if the synth has been alive in stage3.
+                        if (result4 && alive && cmd_name)
+                            send_done_message(endpoint, cmd_name);
+
+                        // free in RT thread!
+                        cmd_dispatcher<realtime>::fire_rt_callback([=] {
+                            if (cleanup)
+                                (cleanup)(unit->mWorld, cmd_data);
+                            synth->release();
+                        });
+                    });
+                });
+        });
+}
+
+void sc_osc_handler::do_async_unit_command(Unit* unit, void* replyAddr, const char* cmdName, void* cmdData,
+                                           AsyncUnitStageFn stage2, AsyncUnitStageFn stage3, AsyncUnitStageFn stage4,
+                                           AsyncFreeFn cleanup, int completionMsgSize,
+                                           const void* completionMsgData) const {
+    completion_message msg(completionMsgSize, completionMsgData);
+
+    nova_endpoint* endpoint = static_cast<nova_endpoint*>(replyAddr);
+    endpoint_ptr endpoint_ptr(endpoint ? endpoint->shared_from_this() : nullptr);
+
+    if (unit->mWorld->mRealTime)
+        handle_async_unit_command<true>(unit, cmdName, cmdData, stage2, stage3, stage4, cleanup, std::move(msg),
+                                        std::move(endpoint_ptr));
+    else
+        handle_async_unit_command<false>(unit, cmdName, cmdData, stage2, stage3, stage4, cleanup, std::move(msg),
+                                         std::move(endpoint_ptr));
 }
 
 // called from RT thread, perform in NRT thread, free in RT thread

--- a/server/supernova/sc/sc_osc_handler.cpp
+++ b/server/supernova/sc/sc_osc_handler.cpp
@@ -3017,7 +3017,7 @@ void handle_p_new(ReceivedMessage const& msg) {
     }
 }
 
-void handle_u_cmd(ReceivedMessage const& msg, int size) {
+void handle_u_cmd(ReceivedMessage const& msg, int size, endpoint_ptr const& endpoint) {
     int skip_bytes = addr_pattern_size(msg); // skip address pattern
     sc_msg_iter args(size - skip_bytes, msg.AddressPattern() + skip_bytes);
 
@@ -3033,7 +3033,7 @@ void handle_u_cmd(ReceivedMessage const& msg, int size) {
     int ugen_index = args.geti();
     const char* cmd_name = args.gets();
 
-    synth->apply_unit_cmd(cmd_name, ugen_index, &args);
+    synth->apply_unit_cmd(cmd_name, ugen_index, &args, endpoint);
 }
 
 void handle_cmd(ReceivedMessage const& msg, int size, endpoint_ptr const& endpoint) {
@@ -3189,7 +3189,7 @@ void sc_osc_handler::handle_message_int_address(ReceivedMessage const& message, 
         break;
 
     case cmd_u_cmd:
-        handle_u_cmd(message, msg_size);
+        handle_u_cmd(message, msg_size, endpoint);
         break;
 
     case cmd_b_free:
@@ -3651,7 +3651,7 @@ void sc_osc_handler::handle_message_sym_address(ReceivedMessage const& message, 
     }
 
     if (strcmp(address + 1, "u_cmd") == 0) {
-        handle_u_cmd(message, msg_size);
+        handle_u_cmd(message, msg_size, endpoint);
         return;
     }
 

--- a/server/supernova/sc/sc_osc_handler.cpp
+++ b/server/supernova/sc/sc_osc_handler.cpp
@@ -3036,13 +3036,13 @@ void handle_u_cmd(ReceivedMessage const& msg, int size) {
     synth->apply_unit_cmd(cmd_name, ugen_index, &args);
 }
 
-void handle_cmd(ReceivedMessage const& msg, int size, endpoint_ptr endpoint) {
+void handle_cmd(ReceivedMessage const& msg, int size, endpoint_ptr const& endpoint) {
     int skip_bytes = addr_pattern_size(msg); // skip address pattern
     sc_msg_iter args(size - skip_bytes, msg.AddressPattern() + skip_bytes);
 
     const char* cmd = args.gets();
 
-    sc_factory->run_cmd_plugin(&sc_factory->world, cmd, &args, endpoint.get());
+    sc_factory->run_cmd_plugin(&sc_factory->world, cmd, &args, endpoint);
 }
 
 } /* namespace */
@@ -3712,10 +3712,17 @@ void sc_osc_handler::handle_message_sym_address(ReceivedMessage const& message, 
 }
 
 
-template <bool realtime>
-void handle_asynchronous_command(World* world, const char* cmdName, void* cmdData, AsyncStageFn stage2,
-                                 AsyncStageFn stage3, AsyncStageFn stage4, AsyncFreeFn cleanup,
-                                 completion_message&& message, endpoint_ptr endpoint) {
+template <bool realtime, typename StageFn>
+void handle_asynchronous_command(World* world, const char* cmd_name, void* cmd_data, StageFn stage2, StageFn stage3,
+                                 StageFn stage4, AsyncFreeFn cleanup, completion_message&& message,
+                                 endpoint_ptr&& endpoint) {
+    auto call_stage_fn = [](StageFn fn, World* world, void* cmd_data, endpoint_ptr const& endpoint) {
+        if constexpr (std::is_same_v<StageFn, AsyncStageFnEx>)
+            return !fn || fn(world, cmd_data, endpoint.get());
+        else
+            return !fn || fn(world, cmd_data);
+    };
+
     // Usually, this API function is called in response to plugin/unit commands (handled *before* DSP computation).
     // We lock the memory pool nevertheless, just in case it's called from RT helper threads.
     // Actually, it's not a good idea to call it from within the perform routine because fire_system_callback()
@@ -3726,65 +3733,75 @@ void handle_asynchronous_command(World* world, const char* cmdName, void* cmdDat
     cmd_dispatcher<realtime>::fire_system_callback(
         [=, message = std::move(message), endpoint = std::move(endpoint)]() mutable {
             // stage 2 (NRT thread)
-            bool result2 = !stage2 || (stage2)(world, cmdData);
+            bool result2 = call_stage_fn(stage2, world, cmd_data, endpoint);
 
-            if (result2) {
-                cmd_dispatcher<realtime>::fire_rt_callback(
-                    [=, message = std::move(message), endpoint = std::move(endpoint)]() mutable {
-                        // stage 3 (RT thread)
-                        bool result3 = !stage3 || (stage3)(world, cmdData);
-
-                        if (result3) {
-                            handle_completion_message(std::move(message), endpoint);
-
-                            cmd_dispatcher<realtime>::fire_io_callback([=, endpoint = std::move(endpoint)] {
-                                // stage 4 (NRT thread)
-                                bool result4 = !stage4 || (stage4)(world, cmdData);
-
-                                if (result4 && cmdName)
-                                    send_done_message(endpoint, cmdName);
-
-                                // free in RT thread!
-                                cmd_dispatcher<realtime>::fire_rt_callback([=] {
-                                    if (cleanup)
-                                        (cleanup)(world, cmdData);
-                                });
-                            });
-                        } else {
-                            if (cleanup)
-                                (cleanup)(world, cmdData);
-                            consume(std::move(message));
-                        }
-                    });
-            } else {
+            if (!result2) {
                 // free in RT thread!
                 cmd_dispatcher<realtime>::fire_rt_callback([=, message = std::move(message)]() mutable {
                     if (cleanup)
-                        (cleanup)(world, cmdData);
+                        (cleanup)(world, cmd_data);
                     consume(std::move(message));
                 });
+                return;
             }
+
+            cmd_dispatcher<realtime>::fire_rt_callback(
+                [=, message = std::move(message), endpoint = std::move(endpoint)]() mutable {
+                    // stage 3 (RT thread)
+                    bool result3 = call_stage_fn(stage3, world, cmd_data, endpoint);
+
+                    if (!result3) {
+                        if (cleanup)
+                            (cleanup)(world, cmd_data);
+                        consume(std::move(message));
+                        return;
+                    }
+
+                    handle_completion_message(std::move(message), endpoint);
+
+                    cmd_dispatcher<realtime>::fire_io_callback([=, endpoint = std::move(endpoint)] {
+                        // stage 4 (NRT thread)
+                        bool result4 = call_stage_fn(stage4, world, cmd_data, endpoint);
+
+                        if (result4 && cmd_name)
+                            send_done_message(endpoint, cmd_name);
+
+                        // free in RT thread!
+                        cmd_dispatcher<realtime>::fire_rt_callback([=] {
+                            if (cleanup)
+                                (cleanup)(world, cmd_data);
+                        });
+                    });
+                });
         });
 }
 
+template <typename StageFn>
 void sc_osc_handler::do_asynchronous_command(World* world, void* replyAddr, const char* cmdName, void* cmdData,
-                                             AsyncStageFn stage2, AsyncStageFn stage3, AsyncStageFn stage4,
-                                             AsyncFreeFn cleanup, int completionMsgSize,
-                                             const void* completionMsgData) const {
+                                             StageFn stage2, StageFn stage3, StageFn stage4, AsyncFreeFn cleanup,
+                                             int completionMsgSize, const void* completionMsgData) const {
     completion_message msg(completionMsgSize, completionMsgData);
-    endpoint_ptr shared_endpoint;
 
-    nova_endpoint* endpoint = replyAddr ? static_cast<nova_endpoint*>(replyAddr) : nullptr;
-
-    if (endpoint)
-        shared_endpoint = endpoint->shared_from_this();
+    nova_endpoint* endpoint = static_cast<nova_endpoint*>(replyAddr);
+    endpoint_ptr endpoint_ptr(endpoint ? endpoint->shared_from_this() : nullptr);
 
     if (world->mRealTime)
         handle_asynchronous_command<true>(world, cmdName, cmdData, stage2, stage3, stage4, cleanup, std::move(msg),
-                                          shared_endpoint);
+                                          std::move(endpoint_ptr));
     else
         handle_asynchronous_command<false>(world, cmdName, cmdData, stage2, stage3, stage4, cleanup, std::move(msg),
-                                           shared_endpoint);
+                                           std::move(endpoint_ptr));
+}
+
+// explicit template instantiations for AsyncStageFn and AsyncStageFnEx
+template void sc_osc_handler::do_asynchronous_command<AsyncStageFn>(World*, void*, const char*, void*, AsyncStageFn,
+                                                                    AsyncStageFn, AsyncStageFn, AsyncFreeFn, int,
+                                                                    const void*) const;
+
+template void sc_osc_handler::do_asynchronous_command<AsyncStageFnEx>(World*, void*, const char*, void*, AsyncStageFnEx,
+                                                                      AsyncStageFnEx, AsyncStageFnEx, AsyncFreeFn, int,
+                                                                      const void*) const;
+
 }
 
 // called from RT thread, perform in NRT thread, free in RT thread

--- a/server/supernova/sc/sc_osc_handler.cpp
+++ b/server/supernova/sc/sc_osc_handler.cpp
@@ -931,7 +931,7 @@ int first_arg_as_int(ReceivedMessage const& message) {
     return val;
 }
 
-template <bool realtime> void handle_quit(endpoint_ptr endpoint) {
+template <bool realtime> void handle_quit(endpoint_ptr const& endpoint) {
     instance->quit_received = true;
     cmd_dispatcher<realtime>::fire_io_callback([=]() {
         instance->prepare_to_terminate();
@@ -1358,7 +1358,7 @@ void g_query_tree_fill_node(osc::OutboundPacketStream& p, bool flag, server_node
     }
 }
 
-template <bool realtime> void g_query_tree(int node_id, bool flag, endpoint_ptr endpoint) {
+template <bool realtime> void g_query_tree(int node_id, bool flag, endpoint_ptr const& endpoint) {
     server_node* node = find_node(node_id);
     if (!node || node->is_synth())
         return;
@@ -1387,7 +1387,7 @@ template <bool realtime> void g_query_tree(int node_id, bool flag, endpoint_ptr 
     }
 }
 
-template <bool realtime> void handle_g_queryTree(ReceivedMessage const& msg, endpoint_ptr endpoint) {
+template <bool realtime> void handle_g_queryTree(ReceivedMessage const& msg, endpoint_ptr const& endpoint) {
     osc::ReceivedMessageArgumentStream args = msg.ArgumentStream();
 
     while (!args.Eos()) {
@@ -1708,7 +1708,7 @@ template <nova::node_position Position> void handle_g_head_or_tail(ReceivedMessa
     instance->request_dsp_queue_update();
 }
 
-template <bool realtime> void handle_n_query(ReceivedMessage const& msg, endpoint_ptr endpoint) {
+template <bool realtime> void handle_n_query(ReceivedMessage const& msg, endpoint_ptr const& endpoint) {
     osc::ReceivedMessageArgumentStream args = msg.ArgumentStream();
 
     while (!args.Eos()) {
@@ -1847,7 +1847,7 @@ int32_t get_control_index(sc_synth* s, osc::ReceivedMessageArgumentIterator& it,
     return control;
 }
 
-template <bool realtime> void handle_s_get(ReceivedMessage const& msg, size_t msg_size, endpoint_ptr endpoint) {
+template <bool realtime> void handle_s_get(ReceivedMessage const& msg, size_t msg_size, endpoint_ptr const& endpoint) {
     osc::ReceivedMessageArgumentIterator it = msg.ArgumentsBegin();
 
     if (!it->IsInt32())
@@ -2013,13 +2013,13 @@ completion_message extract_completion_message(osc::ReceivedMessageArgumentIterat
 }
 
 // must be called from rt thread
-void handle_completion_message(completion_message&& message, endpoint_ptr endpoint) {
+void handle_completion_message(completion_message&& message, endpoint_ptr const& endpoint) {
     completion_message msg(std::forward<completion_message>(message));
     msg.handle(endpoint);
 }
 
 
-template <bool realtime> void handle_b_alloc(ReceivedMessage const& msg, endpoint_ptr endpoint) {
+template <bool realtime> void handle_b_alloc(ReceivedMessage const& msg, endpoint_ptr const& endpoint) {
     osc::ReceivedMessageArgumentStream args = msg.ArgumentStream();
 
     osc::int32 bufferIndex, frames, channels;
@@ -2064,7 +2064,7 @@ template <bool realtime> void handle_b_alloc(ReceivedMessage const& msg, endpoin
 }
 
 
-template <bool realtime> void handle_b_free(ReceivedMessage const& msg, endpoint_ptr endpoint) {
+template <bool realtime> void handle_b_free(ReceivedMessage const& msg, endpoint_ptr const& endpoint) {
     osc::ReceivedMessageArgumentStream args = msg.ArgumentStream();
 
     osc::int32 index;
@@ -2091,7 +2091,7 @@ template <bool realtime> void handle_b_free(ReceivedMessage const& msg, endpoint
 }
 
 
-template <bool realtime> void handle_b_allocRead(ReceivedMessage const& msg, endpoint_ptr endpoint) {
+template <bool realtime> void handle_b_allocRead(ReceivedMessage const& msg, endpoint_ptr const& endpoint) {
     osc::ReceivedMessageArgumentStream args = msg.ArgumentStream();
 
     osc::int32 bufferIndex;
@@ -2139,7 +2139,7 @@ template <bool realtime> void handle_b_allocRead(ReceivedMessage const& msg, end
 }
 
 
-template <bool realtime> void handle_b_allocReadChannel(ReceivedMessage const& msg, endpoint_ptr endpoint) {
+template <bool realtime> void handle_b_allocReadChannel(ReceivedMessage const& msg, endpoint_ptr const& endpoint) {
     osc::ReceivedMessageArgumentIterator arg = msg.ArgumentsBegin();
 
     osc::int32 bufnum = arg->AsInt32();
@@ -2208,7 +2208,7 @@ const char* b_write = "/b_write";
 
 void fire_b_write_exception(void) { throw std::runtime_error("wrong arguments for /b_write"); }
 
-template <bool realtime> void handle_b_write(ReceivedMessage const& msg, endpoint_ptr endpoint) {
+template <bool realtime> void handle_b_write(ReceivedMessage const& msg, endpoint_ptr const& endpoint) {
     osc::ReceivedMessageArgumentIterator arg = msg.ArgumentsBegin();
     osc::ReceivedMessageArgumentIterator end = msg.ArgumentsEnd();
 
@@ -2293,7 +2293,7 @@ const char* b_read = "/b_read";
 
 void fire_b_read_exception(void) { throw std::runtime_error("wrong arguments for /b_read"); }
 
-template <bool realtime> void handle_b_read(ReceivedMessage const& msg, endpoint_ptr endpoint) {
+template <bool realtime> void handle_b_read(ReceivedMessage const& msg, endpoint_ptr const& endpoint) {
     osc::ReceivedMessageArgumentIterator arg = msg.ArgumentsBegin();
     osc::ReceivedMessageArgumentIterator end = msg.ArgumentsEnd();
 
@@ -2376,7 +2376,7 @@ const char* b_readChannel = "/b_readChannel";
 
 void fire_b_readChannel_exception(void) { throw std::runtime_error("wrong arguments for /b_readChannel"); }
 
-template <bool realtime> void handle_b_readChannel(ReceivedMessage const& msg, endpoint_ptr endpoint) {
+template <bool realtime> void handle_b_readChannel(ReceivedMessage const& msg, endpoint_ptr const& endpoint) {
     osc::ReceivedMessageArgumentIterator arg = msg.ArgumentsBegin();
     osc::ReceivedMessageArgumentIterator end = msg.ArgumentsEnd();
 
@@ -2472,7 +2472,7 @@ fire_callback:
 
 const char* b_zero = "/b_zero";
 
-template <bool realtime> void handle_b_zero(ReceivedMessage const& msg, endpoint_ptr endpoint) {
+template <bool realtime> void handle_b_zero(ReceivedMessage const& msg, endpoint_ptr const& endpoint) {
     osc::ReceivedMessageArgumentStream args = msg.ArgumentStream();
 
     osc::int32 index;
@@ -2593,7 +2593,7 @@ void handle_b_fill(ReceivedMessage const& msg) {
     }
 }
 
-template <bool realtime> void handle_b_query(ReceivedMessage const& msg, endpoint_ptr endpoint) {
+template <bool realtime> void handle_b_query(ReceivedMessage const& msg, endpoint_ptr const& endpoint) {
     const size_t elem_size = 3 * sizeof(int) * sizeof(float);
 
     osc::ReceivedMessageArgumentStream args = msg.ArgumentStream();
@@ -2621,7 +2621,7 @@ template <bool realtime> void handle_b_query(ReceivedMessage const& msg, endpoin
 }
 
 
-template <bool realtime> void handle_b_close(ReceivedMessage const& msg, endpoint_ptr endpoint) {
+template <bool realtime> void handle_b_close(ReceivedMessage const& msg, endpoint_ptr const& endpoint) {
     osc::ReceivedMessageArgumentStream args = msg.ArgumentStream();
     osc::int32 index;
     args >> index;
@@ -2637,7 +2637,7 @@ template <bool realtime> void handle_b_close(ReceivedMessage const& msg, endpoin
     });
 }
 
-template <bool realtime> void handle_b_get(ReceivedMessage const& msg, endpoint_ptr endpoint) {
+template <bool realtime> void handle_b_get(ReceivedMessage const& msg, endpoint_ptr const& endpoint) {
     const size_t elem_size = sizeof(int) * sizeof(float);
     osc::ReceivedMessageArgumentStream args = msg.ArgumentStream();
     const size_t index_count = msg.ArgumentCount() - 1;
@@ -2688,7 +2688,7 @@ template <typename Alloc> struct getn_data {
     std::vector<float, Alloc> data_;
 };
 
-template <bool realtime> void handle_b_getn(ReceivedMessage const& msg, endpoint_ptr endpoint) {
+template <bool realtime> void handle_b_getn(ReceivedMessage const& msg, endpoint_ptr const& endpoint) {
     osc::ReceivedMessageArgumentStream args = msg.ArgumentStream();
 
     typedef getn_data<rt_pool_allocator<float>> getn_data;
@@ -2736,7 +2736,7 @@ template <bool realtime> void handle_b_getn(ReceivedMessage const& msg, endpoint
 }
 
 
-template <bool realtime> void handle_b_gen(ReceivedMessage const& msg, size_t msg_size, endpoint_ptr endpoint) {
+template <bool realtime> void handle_b_gen(ReceivedMessage const& msg, size_t msg_size, endpoint_ptr const& endpoint) {
     int skip_bytes = addr_pattern_size(msg); // skip address pattern
     movable_array<char> cmd(msg_size - skip_bytes, msg.AddressPattern() + skip_bytes);
 
@@ -2819,7 +2819,7 @@ void handle_c_fill(ReceivedMessage const& msg) {
     }
 }
 
-template <bool realtime> void handle_c_get(ReceivedMessage const& msg, endpoint_ptr endpoint) {
+template <bool realtime> void handle_c_get(ReceivedMessage const& msg, endpoint_ptr const& endpoint) {
     const size_t elem_size = sizeof(int) + sizeof(float);
     osc::ReceivedMessageArgumentStream args = msg.ArgumentStream();
     const size_t index_count = msg.ArgumentCount();
@@ -2843,7 +2843,7 @@ template <bool realtime> void handle_c_get(ReceivedMessage const& msg, endpoint_
     cmd_dispatcher<realtime>::fire_message(endpoint, std::move(message));
 }
 
-template <bool realtime> void handle_c_getn(ReceivedMessage const& msg, endpoint_ptr endpoint) {
+template <bool realtime> void handle_c_getn(ReceivedMessage const& msg, endpoint_ptr const& endpoint) {
     osc::ReceivedMessageArgumentStream args = msg.ArgumentStream();
 
     /* we pessimize, but better to allocate too much than too little */
@@ -2883,7 +2883,7 @@ static std::vector<sc_synth_definition_ptr> wrapSynthdefs(std::vector<sc_synthde
     return wrappedSynthdefs;
 }
 
-template <bool realtime> void handle_d_recv(ReceivedMessage const& msg, endpoint_ptr endpoint) {
+template <bool realtime> void handle_d_recv(ReceivedMessage const& msg, endpoint_ptr const& endpoint) {
     const void* synthdef_data;
     osc::osc_bundle_element_size_t synthdef_size;
 
@@ -2915,7 +2915,7 @@ template <bool realtime> void handle_d_recv(ReceivedMessage const& msg, endpoint
 }
 
 
-template <bool realtime> void handle_d_load(ReceivedMessage const& msg, endpoint_ptr endpoint) {
+template <bool realtime> void handle_d_load(ReceivedMessage const& msg, endpoint_ptr const& endpoint) {
     osc::ReceivedMessageArgumentIterator args = msg.ArgumentsBegin();
     const char* path = args->AsString();
     args++;
@@ -2946,7 +2946,7 @@ template <bool realtime> void handle_d_load(ReceivedMessage const& msg, endpoint
 }
 
 
-template <bool realtime> void handle_d_loadDir(ReceivedMessage const& msg, endpoint_ptr endpoint) {
+template <bool realtime> void handle_d_loadDir(ReceivedMessage const& msg, endpoint_ptr const& endpoint) {
     osc::ReceivedMessageArgumentStream args = msg.ArgumentStream();
     const char* path;
 

--- a/server/supernova/sc/sc_osc_handler.hpp
+++ b/server/supernova/sc/sc_osc_handler.hpp
@@ -336,6 +336,10 @@ public:
                                  StageFn stage3, StageFn stage4, AsyncFreeFn cleanup, int completionMsgSize,
                                  const void* completionMsgData) const;
 
+    void do_async_unit_command(Unit* unit, void* replyAddr, const char* cmdName, void* cmdData, AsyncUnitStageFn stage2,
+                               AsyncUnitStageFn stage3, AsyncUnitStageFn stage4, AsyncFreeFn cleanup,
+                               int completionMsgSize, const void* completionMsgData) const;
+
     void send_message_from_RT(const World* world, FifoMsg& msg) const;
 
     void send_message_to_RT(const World* world, FifoMsg& msg) const;

--- a/server/supernova/sc/sc_osc_handler.hpp
+++ b/server/supernova/sc/sc_osc_handler.hpp
@@ -50,6 +50,7 @@
 
 #include "SC_Command.h"
 
+#include "sc_endpoint.hpp"
 #include "../server/memory_pool.hpp"
 #include "../server/server_args.hpp"
 #include "../server/server_scheduler.hpp"
@@ -67,10 +68,6 @@ namespace detail {
 using namespace boost::asio;
 using namespace boost::asio::ip;
 
-struct nova_endpoint : public std::enable_shared_from_this<nova_endpoint> {
-    virtual void send(const char* data, size_t length) = 0;
-};
-
 class udp_endpoint : public nova_endpoint {
 public:
     udp_endpoint(udp::endpoint const& ep): endpoint_(ep) {}
@@ -82,8 +79,6 @@ private:
 
     udp::endpoint endpoint_;
 };
-
-typedef std::shared_ptr<nova_endpoint> endpoint_ptr;
 
 /**
  * observer to receive osc notifications
@@ -336,8 +331,9 @@ public:
     time_tag time_per_tick;
     /* @} */
 
-    void do_asynchronous_command(World* world, void* replyAddr, const char* cmdName, void* cmdData, AsyncStageFn stage2,
-                                 AsyncStageFn stage3, AsyncStageFn stage4, AsyncFreeFn cleanup, int completionMsgSize,
+    template <typename StageFn>
+    void do_asynchronous_command(World* world, void* replyAddr, const char* cmdName, void* cmdData, StageFn stage2,
+                                 StageFn stage3, StageFn stage4, AsyncFreeFn cleanup, int completionMsgSize,
                                  const void* completionMsgData) const;
 
     void send_message_from_RT(const World* world, FifoMsg& msg) const;

--- a/server/supernova/sc/sc_osc_handler.hpp
+++ b/server/supernova/sc/sc_osc_handler.hpp
@@ -48,6 +48,8 @@
 
 #include "osc/OscReceivedElements.h"
 
+#include "SC_Command.h"
+
 #include "../server/memory_pool.hpp"
 #include "../server/server_args.hpp"
 #include "../server/server_scheduler.hpp"
@@ -59,9 +61,6 @@
 struct FifoMsg;
 
 namespace nova {
-
-typedef SCBool (*AsyncStageFn)(World* inWorld, void* cmdData);
-typedef void (*AsyncFreeFn)(World* inWorld, void* cmdData);
 
 namespace detail {
 

--- a/server/supernova/sc/sc_plugin_interface.cpp
+++ b/server/supernova/sc/sc_plugin_interface.cpp
@@ -343,6 +343,10 @@ SCBool define_unitcmd(const char* unitClassName, const char* cmdName, UnitCmdFun
     return nova::sc_factory->register_ugen_command_function(unitClassName, cmdName, inFunc);
 }
 
+SCBool define_unitcmd_ex(const char* unitClassName, const char* cmdName, UnitCmdFuncEx inFunc) {
+    return nova::sc_factory->register_ugen_command_function(unitClassName, cmdName, inFunc);
+}
+
 SCBool define_plugincmd(const char* name, PlugInCmdFunc func, void* user_data) {
     return nova::sc_factory->register_cmd_plugin(name, func, user_data);
 }
@@ -620,6 +624,7 @@ void sc_plugin_interface::initialize(server_arguments const& args, float* contro
     sc_interface.fDefineBufGen = &define_bufgen;
     sc_interface.fDefinePlugInCmd = &define_plugincmd;
     sc_interface.fDefineUnitCmd = &define_unitcmd;
+    sc_interface.fDefineUnitCmdEx = &define_unitcmd_ex;
 
     /* interface functions */
     sc_interface.fNodeEnd = &node_end;

--- a/server/supernova/sc/sc_plugin_interface.cpp
+++ b/server/supernova/sc/sc_plugin_interface.cpp
@@ -575,6 +575,17 @@ SCErr do_asynchronous_command_ex(
     return 0;
 }
 
+SCErr do_async_unit_command(
+    Unit* inUnit, void* replyAddr, const char* cmdName, void* cmdData,
+    AsyncUnitStageFn stage2, // stage2 is non real time
+    AsyncUnitStageFn stage3, // stage3 is real time - completion msg performed if stage3 returns true
+    AsyncUnitStageFn stage4, // stage4 is non real time - sends done if stage4 returns true
+    AsyncFreeFn cleanup, int completionMsgSize, const void* completionMsgData) {
+    nova::instance->do_async_unit_command(inUnit, replyAddr, cmdName, cmdData, stage2, stage3, stage4, cleanup,
+                                          completionMsgSize, completionMsgData);
+    return 0;
+}
+
 SCBool send_message_from_RT(World* world, struct FifoMsg* msg) {
     nova::instance->send_message_from_RT(world, *msg);
     return true;
@@ -692,6 +703,7 @@ void sc_plugin_interface::initialize(server_arguments const& args, float* contro
     /* osc plugins */
     sc_interface.fDoAsynchronousCommand = &do_asynchronous_command;
     sc_interface.fDoAsynchronousCommandEx = &do_asynchronous_command_ex;
+    sc_interface.fDoAsyncUnitCommand = &do_async_unit_command;
 
     /* initialize world */
     /* control busses */

--- a/server/supernova/sc/sc_plugin_interface.cpp
+++ b/server/supernova/sc/sc_plugin_interface.cpp
@@ -560,6 +560,17 @@ SCErr do_asynchronous_command(
     return 0;
 }
 
+SCErr do_asynchronous_command_ex(
+    World* inWorld, void* replyAddr, const char* cmdName, void* cmdData,
+    AsyncStageFnEx stage2, // stage2 is non real time
+    AsyncStageFnEx stage3, // stage3 is real time - completion msg performed if stage3 returns true
+    AsyncStageFnEx stage4, // stage4 is non real time - sends done if stage4 returns true
+    AsyncFreeFn cleanup, int completionMsgSize, const void* completionMsgData) {
+    nova::instance->do_asynchronous_command(inWorld, replyAddr, cmdName, cmdData, stage2, stage3, stage4, cleanup,
+                                            completionMsgSize, completionMsgData);
+    return 0;
+}
+
 SCBool send_message_from_RT(World* world, struct FifoMsg* msg) {
     nova::instance->send_message_from_RT(world, *msg);
     return true;
@@ -675,6 +686,7 @@ void sc_plugin_interface::initialize(server_arguments const& args, float* contro
 
     /* osc plugins */
     sc_interface.fDoAsynchronousCommand = &do_asynchronous_command;
+    sc_interface.fDoAsynchronousCommandEx = &do_asynchronous_command_ex;
 
     /* initialize world */
     /* control busses */
@@ -1079,7 +1091,7 @@ void sc_plugin_interface::buffer_zero(uint32_t index) {
     zerovec(buf->data + unrolled, remain);
 }
 
-sample* sc_plugin_interface::buffer_generate(uint32_t buffer_index, const char* cmd_name, struct sc_msg_iter& msg) {
+sample* sc_plugin_interface::buffer_generate(uint32_t buffer_index, const char* cmd_name, sc_msg_iter& msg) {
     return sc_factory->run_bufgen(&world, cmd_name, buffer_index, &msg);
 }
 

--- a/server/supernova/sc/sc_plugin_interface.hpp
+++ b/server/supernova/sc/sc_plugin_interface.hpp
@@ -121,7 +121,7 @@ public:
     void buffer_zero(uint32_t index);
     void buffer_close(uint32_t index);
 
-    sample* buffer_generate(uint32_t index, const char* cmd_name, struct sc_msg_iter& msg);
+    sample* buffer_generate(uint32_t index, const char* cmd_name, sc_msg_iter& msg);
 
     void increment_write_updates(uint32_t index) { world.mSndBufUpdates[index].writes++; }
 

--- a/server/supernova/sc/sc_synth.cpp
+++ b/server/supernova/sc/sc_synth.cpp
@@ -123,7 +123,6 @@ sc_synth::sc_synth(int node_id, sc_synth_definition_ptr const& prototype): abstr
 sc_synth::~sc_synth(void) { assert(!initialized); }
 
 extern "C" {
-void* rt_alloc(World* dummy, size_t size);
 void* rt_free(World* dummy, void* ptr);
 }
 
@@ -143,20 +142,24 @@ void sc_synth::prepare(void) {
     initialized = true;
 
     // *finally* dispatch queued unit commands
-    auto cmd = (sc_unit_cmd*)mPrivate;
-    while (cmd) {
+    auto unit_cmds = (sc_unit_cmd*)mPrivate;
+    for (auto cmd = unit_cmds; cmd != nullptr;) {
         auto next = cmd->next;
 
         sc_msg_iter args(cmd->size, cmd->data);
-        // error checking has already be done in Unit_DoCmd()
+        // error checking has already be done in handle_u_cmd() and apply_unit_cmd().
         int node_id = args.geti();
         assert(node_id == mNode.mID);
-        int ugen_index = args.geti();
+        int unit_index = args.geti();
         const char* cmd_name = args.gets();
 
-        apply_unit_cmd(cmd_name, ugen_index, &args);
+        Unit* unit = units[unit_index];
+        sc_ugen_def* def = reinterpret_cast<sc_ugen_def*>(unit->mUnitDef);
 
-        // NOTE: we can't just do rt_pool.free() because other synths might be
+        def->run_unit_command(cmd_name, unit, &args, cmd->endpoint);
+
+        std::destroy_at(cmd);
+        // NOTE: we can't just call rt_pool.free() because other synths might be
         // calling rt_alloc()/rt_free() concurrently in their calc function!
         rt_free(nullptr, cmd);
 
@@ -164,7 +167,6 @@ void sc_synth::prepare(void) {
     }
     mPrivate = nullptr;
 }
-
 
 void sc_synth::finalize() {
     if (initialized) {
@@ -182,11 +184,13 @@ void sc_synth::finalize() {
     initialized = false;
 
     // free queued unit commands
-    // AFAICT this can only happen if a Graph is created, Unit commands are sent and the Graph
-    // is deleted all at the same time stamp.
-    auto* cmd = (sc_unit_cmd*)mPrivate;
-    while (cmd) {
+    // AFAICT this can only happen if a synth is created, unit commands are sent and
+    // the synth is freed all in the same control block.
+    auto* unit_cmds = (sc_unit_cmd*)mPrivate;
+    for (auto cmd = unit_cmds; cmd != nullptr;) {
         auto next = cmd->next;
+        std::destroy_at(cmd);
+        // finalize() is always called outside the calc function so this is thread-safe.
         rt_pool.free(cmd);
         cmd = next;
     }
@@ -280,37 +284,48 @@ void sc_synth::map_control_buses_audio(unsigned int slot_index, int audio_bus_in
         map_control_bus_audio(slot_index + i, audio_bus_index + i);
 }
 
-void sc_synth::apply_unit_cmd(const char* unit_cmd, unsigned int unit_index, struct sc_msg_iter* args) {
-    if (unit_index >= 0 && unit_index < unit_count) {
-        if (!initialized) {
+void sc_synth::apply_unit_cmd(const char* unit_cmd, unsigned int unit_index, sc_msg_iter* args,
+                              detail::endpoint_ptr const& endpoint) {
+    if (unit_index < unit_count) {
+        if (initialized) {
+            Unit* unit = units[unit_index];
+            sc_ugen_def* def = reinterpret_cast<sc_ugen_def*>(unit->mUnitDef);
+
+            def->run_unit_command(unit_cmd, unit, args, endpoint);
+        } else {
             // don't run the unit command if the unit constructor hasn't been called yet!
             // instead we put it on a queue and run it after the graph has been prepared.
-            // NOTE: we can't just use rt_pool.malloc() because other synths might be
-            // calling rt_alloc()/rt_free() concurrently in their calc function!
-            // log_printf("queue unit command\n");
-            auto cmd = (sc_unit_cmd*)rt_alloc(nullptr, sizeof(sc_unit_cmd) + args->size);
-            cmd->next = nullptr;
-            cmd->size = args->size;
-            memcpy(cmd->data, args->data, args->size);
-            if (mPrivate) {
-                // add to tail
-                auto ptr = (sc_unit_cmd*)mPrivate;
-                while (ptr->next)
-                    ptr = ptr->next;
-                ptr->next = cmd;
-            } else {
-                mPrivate = cmd;
-            }
+            queue_unit_cmd(args, endpoint);
             return;
         }
-        Unit* unit = units[unit_index];
-        sc_ugen_def* def = reinterpret_cast<sc_ugen_def*>(unit->mUnitDef);
-
-        def->run_unit_command(unit_cmd, unit, args);
     } else {
         log_printf("unit index %d out of range!\n", unit_index);
     }
 }
+
+void sc_synth::queue_unit_cmd(sc_msg_iter* args, detail::endpoint_ptr const& endpoint) {
+    // NOTE: we are not in a calc function, so we don't need to use rt_alloc()!
+    // log_printf("queue unit command\n");
+    void* mem = rt_pool.malloc(sizeof(sc_unit_cmd) + args->size);
+    if (mem == nullptr)
+        throw std::bad_alloc();
+
+    sc_unit_cmd* cmd = new (mem) sc_unit_cmd {};
+    cmd->next = nullptr;
+    cmd->endpoint = endpoint;
+    cmd->size = args->size;
+    memcpy(cmd->data, args->data, args->size);
+    if (mPrivate) {
+        // add to tail
+        auto ptr = (sc_unit_cmd*)mPrivate;
+        while (ptr->next)
+            ptr = ptr->next;
+        ptr->next = cmd;
+    } else {
+        mPrivate = cmd;
+    }
+}
+
 
 void sc_synth::run(void) { perform(); }
 

--- a/server/supernova/sc/sc_synth.cpp
+++ b/server/supernova/sc/sc_synth.cpp
@@ -120,7 +120,7 @@ sc_synth::sc_synth(int node_id, sc_synth_definition_ptr const& prototype): abstr
     assert((char*)mControls + alloc_size <= allocator.alloc<char>()); // ensure the memory boundaries
 }
 
-sc_synth::~sc_synth(void) { assert(!initialized); }
+sc_synth::~sc_synth(void) { finalize(); }
 
 extern "C" {
 void* rt_free(World* dummy, void* ptr);

--- a/server/supernova/sc/sc_synth.cpp
+++ b/server/supernova/sc/sc_synth.cpp
@@ -30,13 +30,14 @@
 namespace nova {
 
 sc_synth::sc_synth(int node_id, sc_synth_definition_ptr const& prototype): abstract_synth(node_id, prototype) {
-    World const& world = sc_factory->world;
+    World& world = sc_factory->world;
     const bool rt_synthesis = world.mRealTime;
 
-    mNode.mWorld = &sc_factory->world;
-    rgen.init((uint32_t)(uint64_t)this);
-
     /* initialize sc wrapper class */
+    mNode.mWorld = &world;
+    mNode.mID = node_id;
+
+    rgen.init(reinterpret_cast<uintptr_t>(this));
     mRGen = &rgen;
     mSubsampleOffset = world.mSubsampleOffset;
     mSampleOffset = world.mSampleOffset;
@@ -49,8 +50,6 @@ sc_synth::sc_synth(int node_id, sc_synth_definition_ptr const& prototype): abstr
     // so far mPrivate is only used for queued unit commands,
     // i.e. it just points to the head of the list.
     mPrivate = nullptr;
-
-    mNode.mID = node_id;
 
     sc_synthdef const& synthdef = *prototype;
 
@@ -110,7 +109,7 @@ sc_synth::sc_synth(int node_id, sc_synth_definition_ptr const& prototype): abstr
     sc_factory->allocate_ugens(synthdef.graph.size());
     for (size_t i = 0; i != synthdef.graph.size(); ++i) {
         sc_synthdef::unit_spec_t const& spec = synthdef.graph[i];
-        units[i] = spec.prototype->construct(spec, this, i, &sc_factory->world, allocator);
+        units[i] = spec.prototype->construct(spec, this, i, &world, allocator);
     }
 
     for (size_t i = 0; i != synthdef.calc_unit_indices.size(); ++i) {

--- a/server/supernova/sc/sc_synth.hpp
+++ b/server/supernova/sc/sc_synth.hpp
@@ -25,6 +25,9 @@
 #include "SC_RGen.h"
 #include "SC_Wire.h"
 
+struct sc_msg_iter;
+
+#include "sc_endpoint.hpp"
 #include "sc_synth_definition.hpp"
 
 #include "../server/synth.hpp"
@@ -34,6 +37,7 @@ namespace nova {
 
 struct sc_unit_cmd {
     sc_unit_cmd* next;
+    detail::endpoint_ptr endpoint;
     int size;
     char data[1];
 };
@@ -197,9 +201,12 @@ public:
 
     void enable_tracing(void) { trace = 1; }
 
-    void apply_unit_cmd(const char* unit_cmd, unsigned int unit_index, struct sc_msg_iter* args);
+    void apply_unit_cmd(const char* unit_cmd, unsigned int unit_index, sc_msg_iter* args,
+                        detail::endpoint_ptr const& endpoint);
 
 private:
+    void queue_unit_cmd(sc_msg_iter* args, detail::endpoint_ptr const& endpoint);
+
     void run_traced(void);
 
     sample get_constant(size_t index) { return static_cast<sc_synth_definition*>(class_ptr.get())->constants[index]; }

--- a/server/supernova/sc/sc_synth.hpp
+++ b/server/supernova/sc/sc_synth.hpp
@@ -53,14 +53,6 @@ public:
 
     ~sc_synth(void);
 
-    /** run ugen constructors and initialize first sample
-     *
-     *  to be executed after preparing the synth and setting the controls
-     */
-    void prepare(void);
-
-    void finalize(void);
-
     HOT inline void perform(void) {
         if (unlikely(!initialized))
             prepare();
@@ -121,6 +113,15 @@ public:
             run_traced();
     }
 
+private:
+    /** run ugen constructors and initialize first sample
+     *
+     *  to be executed after preparing the synth and setting the controls
+     */
+    void prepare(void);
+
+    void finalize(void);
+
     void prefetch(Unit* unit) {
         char* ptr = (char*)unit;
         char* end = (char*)unit + sizeof(Unit) + 2 * sizeof(Wire) /* + 4 * sizeof(void*)*/;
@@ -136,6 +137,7 @@ public:
         }
     }
 
+public:
     void run(void) override;
 
     void set(slot_index_t slot_index, sample val) override;

--- a/server/supernova/sc/sc_ugen_factory.cpp
+++ b/server/supernova/sc/sc_ugen_factory.cpp
@@ -131,23 +131,18 @@ Unit* sc_ugen_def::construct(sc_synthdef::unit_spec_t const& unit_spec, sc_synth
     return unit;
 }
 
-bool sc_ugen_def::add_command(const char* cmd_name, UnitCmdFunc func) {
-    sc_unitcmd_def* def = new sc_unitcmd_def(cmd_name, func);
-    unitcmd_set.insert(*def);
-    return true;
-}
-
-void sc_ugen_def::run_unit_command(const char* cmd_name, Unit* unit, struct sc_msg_iter* args) {
+void sc_ugen_def::run_unit_command(const char* cmd_name, Unit* unit, sc_msg_iter* args,
+                                   detail::endpoint_ptr const& endpoint) {
     unitcmd_set_type::iterator it = unitcmd_set.find(cmd_name, named_hash_hash(), named_hash_equal());
 
     if (it != unitcmd_set.end()) {
-        it->run(unit, args);
+        it->run(unit, args, endpoint);
     } else {
         std::cout << "can't find unit command: " << cmd_name << std::endl;
     }
 }
 
-sample* sc_bufgen_def::run(World* world, uint32_t buffer_index, struct sc_msg_iter* args) {
+sample* sc_bufgen_def::run(World* world, uint32_t buffer_index, sc_msg_iter* args) {
     SndBuf* buf = World_GetNRTBuf(world, buffer_index);
     sample* data = buf->data;
 
@@ -178,16 +173,6 @@ sc_ugen_def* sc_plugin_container::find_ugen(symbol const& name) {
     return &*it;
 }
 
-bool sc_plugin_container::register_ugen_command_function(const char* ugen_name, const char* cmd_name,
-                                                         UnitCmdFunc func) {
-    sc_ugen_def* def = find_ugen(symbol(ugen_name));
-    if (!def) {
-        std::cout << "unable to register ugen command: ugen '" << ugen_name << "' doesn't exist" << std::endl;
-        return false;
-    }
-    return def->add_command(cmd_name, func);
-}
-
 bool sc_plugin_container::register_cmd_plugin(const char* cmd_name, PlugInCmdFunc func, void* user_data) {
     cmdplugin_set_type::iterator it = cmdplugin_set.find(cmd_name, named_hash_hash(), named_hash_equal());
     if (it != cmdplugin_set.end()) {
@@ -201,8 +186,7 @@ bool sc_plugin_container::register_cmd_plugin(const char* cmd_name, PlugInCmdFun
     return true;
 }
 
-sample* sc_plugin_container::run_bufgen(World* world, const char* name, uint32_t buffer_index,
-                                        struct sc_msg_iter* args) {
+sample* sc_plugin_container::run_bufgen(World* world, const char* name, uint32_t buffer_index, sc_msg_iter* args) {
     bufgen_set_type::iterator it = bufgen_set.find(name, named_hash_hash(), named_hash_equal());
     if (it == bufgen_set.end()) {
         std::cout << "unable to find buffer generator: " << name << std::endl;

--- a/server/supernova/sc/sc_ugen_factory.cpp
+++ b/server/supernova/sc/sc_ugen_factory.cpp
@@ -213,14 +213,15 @@ sample* sc_plugin_container::run_bufgen(World* world, const char* name, uint32_t
 }
 
 
-bool sc_plugin_container::run_cmd_plugin(World* world, const char* name, struct sc_msg_iter* args, void* replyAddr) {
+bool sc_plugin_container::run_cmd_plugin(World* world, const char* name, sc_msg_iter* args,
+                                         detail::endpoint_ptr const& endpoint) {
     cmdplugin_set_type::iterator it = cmdplugin_set.find(name, named_hash_hash(), named_hash_equal());
     if (it == cmdplugin_set.end()) {
         std::cout << "unable to find cmd plugin: " << name << std::endl;
         return false;
     }
 
-    it->run(world, args, replyAddr);
+    it->run(world, args, endpoint);
 
     return true;
 }

--- a/server/supernova/sc/sc_ugen_factory.hpp
+++ b/server/supernova/sc/sc_ugen_factory.hpp
@@ -18,6 +18,8 @@
 
 #pragma once
 
+#include <variant>
+
 #include <boost/intrusive/set.hpp>
 #include <boost/intrusive/unordered_set.hpp>
 #include <boost/checked_delete.hpp>
@@ -35,11 +37,17 @@ namespace nova {
 namespace bi = boost::intrusive;
 
 struct sc_unitcmd_def : public named_hash_entry {
-    const UnitCmdFunc func;
+    const std::variant<UnitCmdFunc, UnitCmdFuncEx> func;
 
-    sc_unitcmd_def(const char* cmd_name, UnitCmdFunc func): named_hash_entry(cmd_name), func(func) {}
+    template <typename Func> sc_unitcmd_def(const char* cmd_name, Func func): named_hash_entry(cmd_name), func(func) {}
 
-    void run(Unit* unit, struct sc_msg_iter* args) { (func)(unit, args); }
+    void run(Unit* unit, sc_msg_iter* args, detail::endpoint_ptr const& endpoint) {
+        if (auto fn = std::get_if<UnitCmdFuncEx>(&func)) {
+            (*fn)(unit, args, endpoint.get());
+        } else {
+            std::get<UnitCmdFunc>(func)(unit, args);
+        }
+    }
 };
 
 class sc_ugen_def : public aligned_class, public named_hash_entry {
@@ -83,8 +91,13 @@ public:
         return alloc_size + 64; // overallocate to allow alignment
     }
 
-    bool add_command(const char* cmd_name, UnitCmdFunc func);
-    void run_unit_command(const char* cmd_name, Unit* unit, struct sc_msg_iter* args);
+    template <typename Func> bool add_command(const char* cmd_name, Func func) {
+        sc_unitcmd_def* def = new sc_unitcmd_def(cmd_name, func);
+        unitcmd_set.insert(*def);
+        return true;
+    }
+
+    void run_unit_command(const char* cmd_name, Unit* unit, sc_msg_iter* args, detail::endpoint_ptr const& endpoint);
 };
 
 struct sc_bufgen_def : public named_hash_entry {
@@ -154,12 +167,22 @@ public:
 
     sc_ugen_def* find_ugen(symbol const& name);
 
-    bool register_ugen_command_function(const char* ugen_name, const char* cmd_name, UnitCmdFunc);
+    template <typename Func> bool register_ugen_command_function(const char* ugen_name, const char* cmd_name, Func);
     bool register_cmd_plugin(const char* cmd_name, PlugInCmdFunc func, void* user_data);
 
     sample* run_bufgen(World* world, const char* name, uint32_t buffer_index, sc_msg_iter* args);
     bool run_cmd_plugin(World* world, const char* name, sc_msg_iter* args, detail::endpoint_ptr const& endpoint);
 };
+
+template <typename Func>
+bool sc_plugin_container::register_ugen_command_function(const char* ugen_name, const char* cmd_name, Func func) {
+    sc_ugen_def* def = find_ugen(symbol(ugen_name));
+    if (!def) {
+        std::cout << "unable to register ugen command: ugen '" << ugen_name << "' doesn't exist" << std::endl;
+        return false;
+    }
+    return def->add_command(cmd_name, func);
+}
 
 /** factory class for supercollider ugens
  *

--- a/server/supernova/sc/sc_ugen_factory.hpp
+++ b/server/supernova/sc/sc_ugen_factory.hpp
@@ -92,7 +92,7 @@ struct sc_bufgen_def : public named_hash_entry {
 
     sc_bufgen_def(const char* name, BufGenFunc func): named_hash_entry(name), func(func) {}
 
-    sample* run(World* world, uint32_t buffer_index, struct sc_msg_iter* args);
+    sample* run(World* world, uint32_t buffer_index, sc_msg_iter* args);
 };
 
 struct sc_cmdplugin_def : public named_hash_entry {
@@ -104,7 +104,9 @@ struct sc_cmdplugin_def : public named_hash_entry {
         func(func),
         user_data(user_data) {}
 
-    void run(World* world, struct sc_msg_iter* args, void* replyAddr) { (func)(world, user_data, args, replyAddr); }
+    void run(World* world, sc_msg_iter* args, detail::endpoint_ptr const& endpoint) {
+        (func)(world, user_data, args, endpoint.get());
+    }
 };
 
 class sc_plugin_container {
@@ -155,8 +157,8 @@ public:
     bool register_ugen_command_function(const char* ugen_name, const char* cmd_name, UnitCmdFunc);
     bool register_cmd_plugin(const char* cmd_name, PlugInCmdFunc func, void* user_data);
 
-    sample* run_bufgen(World* world, const char* name, uint32_t buffer_index, struct sc_msg_iter* args);
-    bool run_cmd_plugin(World* world, const char* name, struct sc_msg_iter* args, void* replyAddr);
+    sample* run_bufgen(World* world, const char* name, uint32_t buffer_index, sc_msg_iter* args);
+    bool run_cmd_plugin(World* world, const char* name, sc_msg_iter* args, detail::endpoint_ptr const& endpoint);
 };
 
 /** factory class for supercollider ugens

--- a/server/supernova/server/node_graph.hpp
+++ b/server/supernova/server/node_graph.hpp
@@ -185,6 +185,15 @@ public:
             return nullptr;
     }
 
+    // Some notes:
+    // - group_free_all() is only called by remove_node() and could actually be a private method.
+    // - group_free_deep() is not really called anywhere and could be removed.
+    // Since both methods are used in some tests, we keep them as they are.
+    //
+    // Note that the /g_freeAll and /g_deepFree commands are actually implemented in
+    // server::group_free_all() resp. server::group_free_deep()!
+    // This is pretty confusing as these methods have the same names. Even worse:
+    // since nova::server inherits from nova::node_graph, they actually *shadow* our methods.
     void group_free_all(abstract_group* group) {
         group_free_all(group, [](server_node&) {});
     }
@@ -215,8 +224,8 @@ public:
             if (node.is_synth()) {
                 release_node_id(&node);
                 synths += 1;
+                doOnFree(node);
             }
-            doOnFree(node);
         });
 
         group->free_synths_deep();

--- a/server/supernova/server/node_types.hpp
+++ b/server/supernova/server/node_types.hpp
@@ -18,7 +18,6 @@
 
 #pragma once
 
-#include <boost/detail/atomic_count.hpp>
 #include <boost/intrusive/list.hpp>
 #include <boost/intrusive/unordered_set.hpp>
 
@@ -41,7 +40,7 @@ class server_node : public bi::list_base_hook<bi::link_mode<bi::auto_unlink>>, /
                     public bi::unordered_set_base_hook<bi::link_mode<bi::auto_unlink>> /* for node_id mapping */
 {
 protected:
-    server_node(int32_t node_id, bool type): node_id(node_id), node_is_synth(type), use_count_(0) {}
+    server_node(int32_t node_id, bool type): node_id(node_id), node_is_synth(type) {}
 
     virtual ~server_node(void) { assert(parent_ == 0); }
 
@@ -158,7 +157,9 @@ public:
     }
 
 private:
-    boost::detail::atomic_count use_count_;
+    /* the ref count of server_nodes only changes during tree operations, which
+     * are never called concurrently. Therefore the ref count can be non-atomic. */
+    int32_t use_count_ = 0;
     /* @} */
 };
 

--- a/server/supernova/server/server.cpp
+++ b/server/supernova/server/server.cpp
@@ -167,14 +167,7 @@ void nova_server::set_node_slot(int node_id, const char* slot, float value) {
         node->set(slot, value);
 }
 
-void nova_server::finalize_node(server_node& node) {
-    if (node.is_synth()) {
-        sc_synth& synth = static_cast<sc_synth&>(node);
-        synth.finalize();
-    }
-    notification_node_ended(&node);
-}
-
+void nova_server::finalize_node(server_node& node) { notification_node_ended(&node); }
 
 void nova_server::free_node(server_node* node) {
     if (node->get_parent() == nullptr)

--- a/testsuite/classlibrary/TestPluginCommand.sc
+++ b/testsuite/classlibrary/TestPluginCommand.sc
@@ -1,0 +1,85 @@
+TestPluginCommand : UnitTest {
+
+	asyncPluginCommand { arg serverName;
+		var bus, cond = CondVar();
+		var done = false;
+		var value = 1.0, busValue = 0.0, nodeID = 900;
+		var server = Server(thisMethod.name ++ "_" ++ serverName);
+
+		this.bootServer(server);
+
+		bus = Bus.control(server, 1);
+
+		SynthDef(\number, { |bus|
+			Out.kr(bus, value);
+		}).add;
+
+		server.sync;
+
+		// listen for /done message
+		OSCdef(\cmd_test, {
+			"pluginCmdDemo done!".postln;
+			done = true;
+			cond.signalOne;
+		}, '/done', nil, nil, [ \pluginCmdDemo ]);
+
+		// 1. test plugin command success
+
+		// send command
+		server.sendMsg('/cmd', \pluginCmdDemo, 7, 9, \mno, ['/s_new', \number, nodeID, 0, 0, bus.index]);
+
+		cond.waitFor(3, { done });
+
+		this.assert(done, "%: async plugin command finished and sent /done message".format(serverName));
+
+		bus.get { |f|
+			busValue = f;
+		};
+
+		server.sync;
+
+		server.sendMsg('/n_free', nodeID);
+
+		this.assert(busValue == value, "%: async plugin command did perform completion message".format(serverName));
+
+		// 2. test plugin command failure
+
+		done = false;
+		busValue = 0.0;
+		bus.set(0.0);
+
+		// send command ('fail' should cause the command to fail)
+		server.sendMsg('/cmd', \pluginCmdDemo, 7, 9, \fail, ['/s_new', \number, 900, 0, 0, bus.index]);
+
+		cond.waitFor(1, { done });
+
+		this.assert(done.not, "%: failed async plugin command did not send /done message".format(serverName));
+
+		bus.get { |f|
+			busValue = f;
+		};
+
+		server.sync;
+
+		this.assert(busValue == 0.0, "%: failed async plugin command did not perform completion message".format(serverName));
+
+		if (server.serverRunning) {
+			server.quit;
+			// avoid UDP address in use errors when restarting the Server.
+			// Unfortunately, there is no way to wait for the Server to quit...
+			1.wait;
+		};
+	}
+
+	test_asyncPluginCommandInScsynth {
+		this.asyncPluginCommand("scsynth");
+	}
+
+	test_asyncPluginCommandInSupernova{
+		Server.supernova;
+		this.asyncPluginCommand("supernova");
+		// restore scsynth
+		Server.scsynth;
+	}
+
+}

--- a/testsuite/classlibrary/TestSynthDefVersions_Server.sc
+++ b/testsuite/classlibrary/TestSynthDefVersions_Server.sc
@@ -1,4 +1,4 @@
-TestServer_SynthDefVersions : UnitTest {
+TestSynthDefVersions_Server : UnitTest {
 	var compiledDefs;
 
 	setUp {

--- a/testsuite/classlibrary/TestUnitCommand.sc
+++ b/testsuite/classlibrary/TestUnitCommand.sc
@@ -1,0 +1,180 @@
+TestUnitCommand : UnitTest {
+	synchronousUnitCommand { arg serverName;
+		var bus, cond = CondVar();
+		var busValue = 0.0, synthIndex, u;
+		var server = Server(thisMethod.name ++ "_" ++ serverName);
+
+		this.bootServer(server);
+
+		bus = Bus.control(server, 1);
+
+		SynthDef(\u_cmd_test, { |bus|
+			Out.kr(bus, UnitCmdDemo.kr);
+		}).add;
+		// UnitCmdDemo has index 1
+		synthIndex = 1;
+
+		server.sync;
+
+		// 1. test queued unit command
+
+		u = Synth(\u_cmd_test, [ bus: bus ], server);
+
+		// send command
+		server.sendMsg('/u_cmd', u.nodeID, synthIndex, \setValue, 4.0);
+
+		server.sync; // give the UGen a chance to output the value
+
+		bus.get { |f|
+			busValue = f;
+		};
+
+		server.sync;
+
+		this.assert(busValue == 4.0, "%: synchronous unit command (queued) works".format(serverName));
+
+		// 2. test non-queued unit command
+
+		// send command
+		server.sendMsg('/u_cmd', u.nodeID, synthIndex, \setValue, -3.0);
+
+		server.sync; // give the UGen a chance to output the value
+
+		bus.get { |f|
+			busValue = f;
+		};
+
+		server.sync;
+
+		this.assert(busValue == -3.0, "%: synchronous unit command (non-queued) works".format(serverName));
+
+		if (server.serverRunning) {
+			server.quit;
+			// avoid UDP address in use errors when restarting the Server.
+			// Unfortunately, there is no way to wait for the Server to quit...
+			1.wait;
+		};
+	}
+
+	test_synchronousUnitCommandInScsynth {
+		this.synchronousUnitCommand("scsynth");
+	}
+
+	test_synchronousUnitCommandInSupernova{
+		Server.supernova;
+		this.synchronousUnitCommand("supernova");
+		// restore scsynth
+		Server.scsynth;
+	}
+
+	asynchronousUnitCommand { arg serverName;
+		var bus, cond = CondVar();
+		var done = false;
+		var value = 1.0, busValue = 0.0, nodeID = 900, synthIndex, u;
+		var server = Server(thisMethod.name ++ "_" ++ serverName);
+
+		this.bootServer(server);
+
+		bus = Bus.control(server, 1);
+
+		SynthDef(\number, { |bus|
+			Out.kr(bus, value);
+		}).add;
+
+		SynthDef(\u_cmd_test, { |bus|
+			Out.kr(bus, UnitCmdDemo.kr);
+		}).add;
+		// UnitCmdDemo has index 1
+		synthIndex = 1;
+
+		server.sync;
+
+		// listen for /done message
+		OSCdef(\u_cmd_test, {
+			"testCommand done!".postln;
+			done = true;
+			cond.signalOne;
+		}, '/done', nil, nil, [ \testCommand ]);
+
+		// 1. test unit command success
+
+		u = Synth(\u_cmd_test, nil, server);
+
+		// send command
+		server.sendMsg('/u_cmd', u.nodeID, synthIndex, \testCommand, 48000, 1.0, ['/s_new', \number, nodeID, 0, 0, bus.index]);
+
+		cond.waitFor(3, { done });
+
+		this.assert(done, "%: async unit command finished and sent /done message".format(serverName));
+
+		bus.get { |f|
+			busValue = f;
+		};
+
+		server.sync;
+
+		server.sendMsg('/n_free', nodeID);
+
+		this.assert(busValue == value, "%: async unit command did perform completion message".format(serverName));
+
+		// 2. test unit command failure
+
+		done = false;
+		busValue = 0.0;
+		bus.set(0.0);
+
+		// send command (-1.0 should cause the command to fail)
+		server.sendMsg('/u_cmd', u.nodeID, synthIndex, \testCommand, 48000, -1.0, ['/s_new', \number, nodeID, 0, 0, bus.index]);
+
+		cond.waitFor(1, { done });
+
+		this.assert(done.not, "%: failed async unit command did not send /done message".format(serverName));
+
+		bus.get { |f|
+			busValue = f;
+		};
+
+		server.sync;
+
+		this.assert(busValue == 0.0, "%: failed async unit command did not perform completion message".format(serverName));
+
+		// 3. make sure that the Server doesn't crash when the Synth is freed while an asynchronous unit command is still running.
+		// Also, there should be no completion message and no /done message.
+		done = false;
+		busValue = 0.0;
+		bus.set(0.0);
+
+		server.sendMsg('/u_cmd', u.nodeID, synthIndex, \testCommand, 48000, 1.0, ['/s_new', \number, nodeID, 0, 0, bus.index]);
+		u.free;
+
+		cond.waitFor(1, { done });
+
+		this.assert(done.not, "%: cancelled async unit command did not send /done message".format(serverName));
+
+		bus.get { |f|
+			busValue = f;
+		};
+
+		server.sync;
+
+		this.assert(busValue == 0.0, "%: cancelled async unit command did not perform completion message".format(serverName));
+
+		if (server.serverRunning) {
+			server.quit;
+			// avoid UDP address in use errors when restarting the Server.
+			// Unfortunately, there is no way to wait for the Server to quit...
+			1.wait;
+		};
+	}
+
+	test_asynchronousUnitCommandInScsynth {
+		this.asynchronousUnitCommand("scsynth");
+	}
+
+	test_asynchronousUnitCommandInSupernova{
+		Server.supernova;
+		this.asynchronousUnitCommand("supernova");
+		// restore scsynth
+		Server.scsynth;
+	}
+}


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

This PR adds the following extensions to the plugin API:

- `DoAsynchronousCommandEx`: this is the same as `DoAsynchronousCommand`, except it takes function pointers of type `AsyncStageFnEx` instead of `AsyncStageFn`. Contrary to the latter, `AsyncStageFnEx` also passes the reply address. This is necessary for future planned extensions that allow users to send arbitrary messages back to the client from the various stage functions. See also #5939.

- `DefineUnitCmdEx`: this is the same as `DefineUnitCmd`, except that it takes a `UnitCmdFuncEx` instead of `UnitCmdFunc`.
Contrary to the latter, `UnitCmdFuncEx` also passes the reply address. This is necessary so that users can call `DoAsyncUnitCommand` (see below)

- `DoAsyncUnitCommand`: this is similar to `DoAsynchronousCommandEx`, with the following important differences:
  - `AsyncUnitStageFn` takes a `Unit*` instead of a `World*` so that the user can access the Unit in the various stage functions. Typically, this is used in stage3 (= RT) to safely exchange data between the Unit and the user data struct.
  - `DoAsyncUnitCommand` keeps the owning Synth alive for the full duration of the command. This is done by incrementing/decrementing the reference count.
    - scsynth: I have added a `mRefCount` field to the `Graph` structure together with `Graph_AddRef` and `Graph_Release` functions.
    - supernova: incidentally, `server_node` already has its own reference counting mechanism.
    
    *This fixes a long-standing and critical lifetime issue with using async commands inside Units!*

  - Before we call the stage3 function (= RT), we check if the Graph/synth still has a parent. If not, this means that it has been freed by the user. In this case we pass NULL as the `Unit*` so that the user can detect the situation and safely cancel the operation. Note that they can still continue with the stage4 function, e.g. to free any resources they just allocated.

  - I had to slightly change the way Graphs/synths are freed:
    - scsynth: Previously, `Node_Delete` would directly call `Graph_Dtor`. Now it calls the new `Graph_Delete` function which only decrements the refcount. If the new refcount is not zero, it means there are still pending unit commands. In this case we only remove the Node from the Server tree and release the Node ID, but we do not actually destroy the Graph yet! `Graph_Dtor` is only called when the reference count goes to zero, i.e. after the last pending unit command has finished.

    - supernova: When a synth is freed by the user (directly or indirectly), the node gets removed from the node tree. This automatically decrements its refcount. Previously, `server::remove_node()` would always call `sc_synth::finalize()` on all synth children, which destroys all the units. However, we actually want to keep the units alive as long as they are being referenced by pending unit commands. Instead we simply call `finalize()` directly in `~sc_synth()`, i.e. right before the synth gets destroyed. (The one who decrements the refcount to zero destroys the synth.)

  Closes #7359.

I have updated the async plugin command and unit command examples in `DemoUGens.cpp`.

---

Minor fixes/changes/additions I made on the way:

- scsynth: the cleanup function passed to `DoAsynchronousCommand` can now be be `NULL`. (This was already the case in supernova.) The same is true for `DoAsynchronousCommandEx`.

- supernova: make `server_node` refcount non-atomic to avoid unnecessary atomic operations. The refcount is only ever incremented/decremented on the RT thread via operations on the node tree. Since these operations are not thread safe anyway, there is no reason why the refcount should be atomic.

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->

- Documentation
- Bug fix
- New feature
- Breaking change

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
