### PR TITLE
Fix crash when receiving malformed OSC UDP packets

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -1,9 +1,10 @@
 {
   "configurations": [
     {
-      "name": "Mac",
-      "cppStandard": "c++17",
-      "configurationProvider": "ms-vscode.cmake-tools"
+      "name": "Windows",
+      "compilerPath": "cl.exe",
+      "intelliSenseMode": "windows-msvc-x64",
+      "cppStandard": "c++17"
     }
   ],
   "version": 4

--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -1,10 +1,9 @@
 {
   "configurations": [
     {
-      "name": "Windows",
-      "compilerPath": "cl.exe",
-      "intelliSenseMode": "windows-msvc-x64",
-      "cppStandard": "c++17"
+      "name": "Mac",
+      "cppStandard": "c++17",
+      "configurationProvider": "ms-vscode.cmake-tools"
     }
   ],
   "version": 4

--- a/lang/LangPrimSource/OSCData.cpp
+++ b/lang/LangPrimSource/OSCData.cpp
@@ -67,7 +67,7 @@ bool gUseDoubles = false;
 
 InternalSynthServerGlobals gInternalSynthServer = { nullptr, kNumDefaultSharedControls, gDefaultSharedControls };
 
-std::unique_ptr<InPort::UDP> gUDPport {};
+std::unique_ptr<InPort::UDP> gUDPport { };
 
 PyrString* newPyrString(VMGlobals* g, char* s, int flags, bool runGC);
 

--- a/lang/LangPrimSource/OSCData.cpp
+++ b/lang/LangPrimSource/OSCData.cpp
@@ -823,18 +823,10 @@ void PerformOSCMessage(int inSize, const char* inData, PyrObject* replyObj, int 
 
 // takes ownership of inPacket
 void ProcessOSCPacket(std::unique_ptr<OSC_Packet> inPacket, int inPortNum, double time) {
-    // Validate Packet before Processing;
+    // Guard against null/empty packets
     if (!inPacket || !inPacket->mData || inPacket->mSize <= 0) {
         return;
     }
-
-    char* data = inPacket->mData.get();
-
-    // OSC message must start with '/' or "#bundle";
-    if (data[0] != '/' && strncmp(data, "#bundle", 7) != 0) {
-        return;
-    }
-
     // post("recv '%s' %d\n", inPacket->mData, inPacket->mSize);
     const auto isBundle = IsBundle(inPacket->mData.get());
 
@@ -844,7 +836,7 @@ void ProcessOSCPacket(std::unique_ptr<OSC_Packet> inPacket, int inPortNum, doubl
         if (compiledOK) {
             if (isBundle) {
                 PerformOSCBundle(inPacket->mSize, inPacket->mData.get(), replyObj, inPortNum);
-            } else {
+            } else if (IsMessage(inPacket->mData.get())) {
                 PerformOSCMessage(inPacket->mSize, inPacket->mData.get(), replyObj, inPortNum, time);
             }
         }

--- a/lang/LangPrimSource/OSCData.cpp
+++ b/lang/LangPrimSource/OSCData.cpp
@@ -67,7 +67,7 @@ bool gUseDoubles = false;
 
 InternalSynthServerGlobals gInternalSynthServer = { nullptr, kNumDefaultSharedControls, gDefaultSharedControls };
 
-std::unique_ptr<InPort::UDP> gUDPport { };
+std::unique_ptr<InPort::UDP> gUDPport {};
 
 PyrString* newPyrString(VMGlobals* g, char* s, int flags, bool runGC);
 

--- a/lang/LangPrimSource/OSCData.cpp
+++ b/lang/LangPrimSource/OSCData.cpp
@@ -67,7 +67,7 @@ bool gUseDoubles = false;
 
 InternalSynthServerGlobals gInternalSynthServer = { nullptr, kNumDefaultSharedControls, gDefaultSharedControls };
 
-std::unique_ptr<InPort::UDP> gUDPport {};
+std::unique_ptr<InPort::UDP> gUDPport { };
 
 PyrString* newPyrString(VMGlobals* g, char* s, int flags, bool runGC);
 
@@ -823,17 +823,17 @@ void PerformOSCMessage(int inSize, const char* inData, PyrObject* replyObj, int 
 
 // takes ownership of inPacket
 void ProcessOSCPacket(std::unique_ptr<OSC_Packet> inPacket, int inPortNum, double time) {
-    //Validate Packet before Processing;
-    if(!inPacket || !inPacket->mData || inPacket->mSize <= 0){
+    // Validate Packet before Processing;
+    if (!inPacket || !inPacket->mData || inPacket->mSize <= 0) {
         return;
-	}
+    }
 
-	char* data = inPacket->mData.get();
+    char* data = inPacket->mData.get();
 
-	//OSC message must start with '/' or "#bundle";
-	if(data[0] != '/' && strncmp(data, "#bundle", 7) != 0){
+    // OSC message must start with '/' or "#bundle";
+    if (data[0] != '/' && strncmp(data, "#bundle", 7) != 0) {
         return;
-	}
+    }
 
     // post("recv '%s' %d\n", inPacket->mData, inPacket->mSize);
     const auto isBundle = IsBundle(inPacket->mData.get());

--- a/lang/LangPrimSource/OSCData.cpp
+++ b/lang/LangPrimSource/OSCData.cpp
@@ -823,6 +823,18 @@ void PerformOSCMessage(int inSize, const char* inData, PyrObject* replyObj, int 
 
 // takes ownership of inPacket
 void ProcessOSCPacket(std::unique_ptr<OSC_Packet> inPacket, int inPortNum, double time) {
+    //Validate Packet before Processing;
+    if(!inPacket || !inPacket->mData || inPacket->mSize <= 0){
+        return;
+	}
+
+	char* data = inPacket->mData.get();
+
+	//OSC message must start with '/' or "#bundle";
+	if(data[0] != '/' && strncmp(data, "#bundle", 7) != 0){
+        return;
+	}
+
     // post("recv '%s' %d\n", inPacket->mData, inPacket->mSize);
     const auto isBundle = IsBundle(inPacket->mData.get());
 


### PR DESCRIPTION
Fixes #7351
Solution
Add validation in ProcessOSCPacket to ensure that incoming packets begin with a valid OSC prefix (/ for OSC messages or #bundle for OSC bundles).
Packets that do not match the expected OSC structure are ignored instead of being passed to the OSC parser.

Testing

1. Reproduced the crash by sending malformed UDP packets to the language port (NetAddr.langPort).

2. Verified that the interpreter previously crashed when receiving invalid packets.

3. After the fix, malformed packets are ignored and sclang continues running normally.

4. Confirmed that valid OSC messages are still processed correctly.