### PR TITLE
sclang: redefine that passing nil as arg means reset to default

### DIFF
--- a/HelpSource/LanguageSpecification/ArgumentPassing.schelp
+++ b/HelpSource/LanguageSpecification/ArgumentPassing.schelp
@@ -1,0 +1,48 @@
+title:: Argument Passing
+summary:: How arguments are passed to function/methods
+categories:: LanguageSpecification
+
+SuperCollider supports positional arguments, keyword arguments, environmental argument lookup, and default arguments.
+These features all combine to sometimes create confusing results. 
+This document provides the rules for how one can expect these conflicts to be ressolved.
+
+section:: Nil and defaults
+
+One major source of confusion is what code::nil:: means at the call sight.
+
+In previous SuperCollider versions the behaviour changed depending on subtle things like the syntax used to declare default argument values. 
+This has since been removed, now code::nil:: has a precise meaning...
+
+code::nil:: means to reset the argument to the default value. If no default value is provided, this is code::nil:: itself.
+
+Here are some examples.
+
+code::
+f = { |a = 1| a };
+
+f.(); // 1
+
+f.(10); // 10
+f.(a: 10); // 10
+
+f.(nil) // 1
+f.(a: nil) // 1
+
+f.(10, a: nil) // 1 - also posts warning about argument collision
+::
+
+
+This must hold true regardless of how the default argument is declared or internally evaluated.
+
+
+section:: Argument Collisions
+
+When positional arguments (arguments without keywords) and keyword arguments collide, the right most argument is the final value.
+
+code::
+f = { |a = 1| a };
+f.(10, a: nil, a: 20, a: 11) // 11
+::
+
+To break this example down: first code::a:: is set to the default of code::1::, then to code::10::, followed by returning to code::1:: as code::nil:: resets to the default, before setting to code::20::, followed by code::11::.
+Ultimately, this means all but the final keyword assignment is irrelevent and the code should just be code::f.(a: 11):: or code::f.(11)::.

--- a/SCClassLibrary/Common/Audio/Env.sc
+++ b/SCClassLibrary/Common/Audio/Env.sc
@@ -219,13 +219,15 @@ Env {
 		^releaseNode.notNil
 	}
 
-	asMultichannelSignal { arg length = 400, class = (Signal);
+	asMultichannelSignal { arg length = 400, class;
 		var multiChannelArray = this.asMultichannelArray;
 		var channelCount = multiChannelArray.size;
 
 		var totalDur = this.totalDuration;
 
 		length = max(length, levels.size);
+
+		class = class ?? {Signal};
 
 		^multiChannelArray.collect { |chan|
 			var signal, ratio;

--- a/SCClassLibrary/Common/Audio/SynthDefOld.sc
+++ b/SCClassLibrary/Common/Audio/SynthDefOld.sc
@@ -165,11 +165,12 @@ SynthDefOld : SynthDef {
 
 + Object {
 
-	writeDefFileOld { arg name, dir, overwrite = (true);
+	writeDefFileOld { arg name, dir, overwrite;
 
 		StartUp.defer { // make sure the synth defs are written to the right path
 			var file;
 			dir = dir ? SynthDef.synthDefDir;
+			overwrite = overwrite ? true;
 			if (name.isNil) { Error("missing SynthDef file name").throw } {
 				name = dir +/+ name ++ ".scsyndef";
 				if(overwrite or: { pathMatch(name).isEmpty })

--- a/SCClassLibrary/Common/Audio/UGen.sc
+++ b/SCClassLibrary/Common/Audio/UGen.sc
@@ -64,17 +64,17 @@ UGen : AbstractFunction {
 	}
 	exprange { arg lo = 0.01, hi = 1.0;
 		^if (this.signalRange == \bipolar) {
-			this.linexp(-1, 1, lo, hi, nil)
+			this.linexp(-1, 1, lo, hi, \none)
 		} {
-			this.linexp(0, 1, lo, hi, nil)
+			this.linexp(0, 1, lo, hi, \none)
 		};
 	}
 
 	curverange { arg lo = 0.00, hi = 1.0, curve = -4;
 		^if (this.signalRange == \bipolar) {
-			this.lincurve(-1, 1, lo, hi, curve, nil)
+			this.lincurve(-1, 1, lo, hi, curve, \none)
 		} {
-			this.lincurve(0, 1, lo, hi, curve, nil)
+			this.lincurve(0, 1, lo, hi, curve, \none)
 		};
 	}
 
@@ -189,6 +189,9 @@ UGen : AbstractFunction {
 			},
 			\max, {
 				^this.min(max);
+			},
+			\none, {
+				^this;
 			}
 		);
 		^this

--- a/SCClassLibrary/Common/Control/Buffer.sc
+++ b/SCClassLibrary/Common/Control/Buffer.sc
@@ -306,7 +306,7 @@ Buffer {
 	}
 
 	// risky without wait
-	getToFloatArray { arg index = 0, count = -1, wait = 0.01, timeout = 3, action;
+	getToFloatArray { arg index = 0, count, wait = 0.01, timeout = 3, action;
 		var refcount, array, pos, getsize, resp, done = false;
 
 		pos = index = index.asInteger;

--- a/SCClassLibrary/Common/Control/GraphBuilder.sc
+++ b/SCClassLibrary/Common/Control/GraphBuilder.sc
@@ -20,8 +20,8 @@ GraphBuilder {
 		})
 	}
 
-	*makeFadeEnv { arg fadeTime = (0.02);
-		var dt = NamedControl.kr(\fadeTime, fadeTime);
+	*makeFadeEnv { arg fadeTime;
+		var dt = NamedControl.kr(\fadeTime, fadeTime ?? {0.02});
 		var gate = NamedControl.kr(\gate, 1.0);
 		var startVal = (dt <= 0);
 

--- a/SCClassLibrary/Common/Control/Spec.sc
+++ b/SCClassLibrary/Common/Control/Spec.sc
@@ -41,8 +41,9 @@ ControlSpec : Spec {
 	var <minval, <maxval, <warp, <step, <>default, <>units, >grid;
 	var <clipLo, <clipHi;
 
-	*new { arg minval = (0.0), maxval = (1.0), warp = ('lin'), step = (0.0), default, units, grid;
-		^super.newCopyArgs(minval, maxval, warp, step, default ? minval, units ? "", grid).init
+	*new { arg minval, maxval, warp, step, default, units, grid;
+		// In version 3.16, these args can simply be `args minval = 0.0`, including `default = minval`.
+		^super.newCopyArgs(minval ?? {0.0}, maxval ?? {1.0}, warp ?? {'lin'}, step ?? {0.0}, default ?? {minval}, units ?? {""}, grid).init
 	}
 
 	*newFrom { arg similar;

--- a/SCClassLibrary/Common/Core/Object.sc
+++ b/SCClassLibrary/Common/Core/Object.sc
@@ -705,11 +705,12 @@ Object {
 		^this.performBinaryOpOnSomething(aSelector, thing, adverb)
 	}
 
-	writeDefFile { arg name, dir, overwrite = (true);
+	writeDefFile { arg name, dir, overwrite;
 
 		StartUp.defer { // make sure the synth defs are written to the right path
 			var file;
 			dir = dir ? SynthDef.synthDefDir;
+			overwrite = overwrite ? true;
 			if (name.isNil or: { name.asString.isEmpty }) { Error("missing SynthDef file name").throw } {
 				name = dir +/+ name ++ ".scsyndef";
 				if(overwrite or: { pathMatch(name).isEmpty })

--- a/SCClassLibrary/Common/Core/Thread.sc
+++ b/SCClassLibrary/Common/Core/Thread.sc
@@ -18,8 +18,9 @@ Thread : Stream {
 	var <executingPath, <oldExecutingPath;
 	var rescheduledTime;
 
-	*new { arg func, stackSize = (512);
-		^super.new.init(func, stackSize)
+	*new { arg func, stackSize;
+		// In version 3.16 this can simply be `arg stackSize = 512`;
+		^super.new.init(func, stackSize ?? { 512 })
 	}
 	init { arg argFunc, argStackSize = 512;
 		_Thread_Init

--- a/SCClassLibrary/Common/GUI/PlusGUI/Control/server-scope.sc
+++ b/SCClassLibrary/Common/GUI/PlusGUI/Control/server-scope.sc
@@ -1,6 +1,8 @@
 + Server {
-	scope { arg numChannels, index = 0, bufsize = 4096, zoom = (1), rate = \audio;
+	scope { arg numChannels, index = 0, bufsize = 4096, zoom, rate = \audio;
 		numChannels = numChannels ?? { if (index == 0) { options.numOutputBusChannels } { 2 } };
+
+		zoom = zoom ?? { 1 };
 
 		if(scopeWindow.isNil) {
 			scopeWindow = Stethoscope(this, numChannels, index, bufsize, zoom, rate, nil,

--- a/SCClassLibrary/Common/Streams/Stream.sc
+++ b/SCClassLibrary/Common/Streams/Stream.sc
@@ -337,13 +337,14 @@ PauseStream : Stream {
 
 	isPlaying { ^stream.notNil }
 
-	play { arg argClock, doReset = (false), quant;
+	play { arg argClock, doReset, quant;
 		// check 'quant' first, before changing any state variables
 		// if there is an error, this object should be unaffected
 		var tempClock = argClock ? clock ? TempoClock.default;
 		var time = quant.asQuant.nextTimeOnGrid(tempClock);
 
 		if (stream.notNil, { "already playing".postln; ^this });
+		doReset = doReset ?? { false };
 		if (doReset, { this.reset });
 		clock = tempClock;
 		streamHasEnded = false;
@@ -560,13 +561,14 @@ EventStreamPlayer : PauseStream {
 
 	asEventStreamPlayer { ^this }
 
-	play { arg argClock, doReset = (false), quant;
+	play { arg argClock, doReset, quant;
 		// check 'quant' first, before changing any state variables
 		// if there is an error, this object should be unaffected
 		var tempClock = argClock ? clock ? TempoClock.default;
 		var time = quant.asQuant.nextTimeOnGrid(tempClock);
 
 		if (stream.notNil, { "already playing".postln; ^this });
+		doReset = doReset ?? { false };
 		if (doReset, { this.reset });
 		clock = tempClock;
 		streamHasEnded = false;

--- a/SCClassLibrary/Common/UnitTesting/UnitTest.sc
+++ b/SCClassLibrary/Common/UnitTesting/UnitTest.sc
@@ -427,8 +427,9 @@ UnitTestResult {
 
 	var <testClass, <testMethod, <message, <details, <debug;
 
-	*new { |testClass, testMethod, message = "", details, debug|
-		^super.newCopyArgs(testClass ? this, testMethod ? thisMethod, message, details, debug)
+	*new { |testClass, testMethod, message, details, debug|
+		// In version 3.16 this can simply be |message = ""|.
+		^super.newCopyArgs(testClass ? this, testMethod ? thisMethod, message ?? {""}, details, debug)
 	}
 
 	report { |brief=false|

--- a/SCClassLibrary/JITLib/ProxySpace/InBus.sc
+++ b/SCClassLibrary/JITLib/ProxySpace/InBus.sc
@@ -310,11 +310,11 @@ Monitor {
 		this.playNToBundle(bundle, outs, amps, ins, vol, fadeTime, group, addAction, multi: multi)
 	}
 
-	newGroupToBundle { | bundle, target, addAction=(\addToTail) |
+	newGroupToBundle { | bundle, target, addAction |
 		target = target.asGroup;
 		group = Group.basicNew(target.server);
 		group.isPlaying = true;
-		bundle.add(group.newMsg(target, addAction));
+		bundle.add(group.newMsg(target, addAction ?? {\addToTail}));
 		NodeWatcher.register(group);
 	}
 

--- a/SCClassLibrary/JITLib/ProxySpace/NodeProxy.sc
+++ b/SCClassLibrary/JITLib/ProxySpace/NodeProxy.sc
@@ -187,8 +187,9 @@ NodeProxy : BusPlug {
 
 
 
-	putAll { | list, index = (0), channelOffset = 0 |
+	putAll { | list, index, channelOffset = 0 |
 		channelOffset = channelOffset.asArray;
+		index = index ?? {0};
 		if(index.isSequenceableCollection) {
 			max(list.size, index.size).do { |i|
 				this.put(index.wrapAt(i), list.wrapAt(i), channelOffset.wrapAt(i))

--- a/SCClassLibrary/JITLib/ProxySpace/NodeProxy.sc
+++ b/SCClassLibrary/JITLib/ProxySpace/NodeProxy.sc
@@ -47,19 +47,19 @@ NodeProxy : BusPlug {
 
 	isPlaying { ^group.isPlaying }
 
-	free { | fadeTime, freeGroup = true |
+	free { | fadeTime = (this.fadeTime), freeGroup = true |
 		var bundle, freetime;
 		var oldGroup = group;
 		if(this.isPlaying) {
 			bundle = MixedBundle.new;
-			if(fadeTime.notNil) {
+			if(fadeTime != 0) {
 				bundle.add([15, group.nodeID, "fadeTime", fadeTime]) // n_set
 			};
 			this.stopAllToBundle(bundle, fadeTime);
 			if(freeGroup) {
 				oldGroup = group;
 				group = nil;
-				freetime = (fadeTime ? this.fadeTime) + (server.latency ? 0) + 1e-9; // delay a tiny little
+				freetime = fadeTime + (server.latency ? 0) + 1e-9; // delay a tiny little
 				server.sendBundle(freetime, [11, oldGroup.nodeID]); // n_free
 			};
 			bundle.send(server);

--- a/common/SC_Version.hpp.in
+++ b/common/SC_Version.hpp.in
@@ -18,6 +18,7 @@
  *    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
  */
 
+#pragma once
 #include <string>
 #include <sstream>
 #include <cstdint>

--- a/lang/LangSource/PyrInterpreter3.cpp
+++ b/lang/LangSource/PyrInterpreter3.cpp
@@ -2287,7 +2287,9 @@ HOT void Interpret(VMGlobals* g) {
                     auto protoframe = meth->prototypeFrame.getPyrObjType<PyrObject>();
                     if (index < numArgsPushed) {
                         if (sp[index].isNil() && !protoframe->slots[index].isNil())
-                            v_errors::PassingNilToLiteralInitArg::print_error();
+                            v_errors::PassingNilToLiteralInitArg::print_error(
+                                meth->ownerclass.getPyrObjType<PyrClass>()->name.getSymbol()->name,
+                                meth->name.getSymbol()->name);
                         slotCopy(sp, sp + index);
                     } else {
                         slotCopy(sp, &slotRawObject(&meth->prototypeFrame)->slots[index]);
@@ -2415,7 +2417,9 @@ HOT void Interpret(VMGlobals* g) {
                     auto protoframe = meth->prototypeFrame.getPyrObjType<PyrObject>();
                     if (index < numArgsPushed) {
                         if (sp[index].isNil() && !protoframe->slots[index].isNil())
-                            v_errors::PassingNilToLiteralInitArg::print_error();
+                            v_errors::PassingNilToLiteralInitArg::print_error(
+                                meth->ownerclass.getPyrObjType<PyrClass>()->name.getSymbol()->name,
+                                meth->name.getSymbol()->name);
                         slotCopy(sp, sp + index);
                     } else {
                         slotCopy(sp, &slotRawObject(&meth->prototypeFrame)->slots[index]);

--- a/lang/LangSource/PyrInterpreter3.cpp
+++ b/lang/LangSource/PyrInterpreter3.cpp
@@ -40,6 +40,8 @@
 #include <signal.h>
 #include "SpecialSelectorsOperatorsAndClasses.h"
 
+#include "VersionedErrors.h"
+
 #include <float.h>
 #define kBigBigFloat DBL_MAX
 #define kSmallSmallFloat DBL_MIN
@@ -2276,10 +2278,21 @@ HOT void Interpret(VMGlobals* g) {
             case methReturnArg:
                 sp -= numArgsPushed - 1;
                 index = methraw->specialIndex; // zero is index of the first argument
-                if (index < numArgsPushed && !(sp + index)->isNil())
-                    slotCopy(sp, sp + index);
-                else
-                    slotCopy(sp, &slotRawObject(&meth->prototypeFrame)->slots[index]);
+                if constexpr (v_errors::PassingNilToLiteralInitArg::do_new()) {
+                    if (index < numArgsPushed && !(sp + index)->isNil())
+                        slotCopy(sp, sp + index);
+                    else
+                        slotCopy(sp, &slotRawObject(&meth->prototypeFrame)->slots[index]);
+                } else {
+                    auto protoframe = meth->prototypeFrame.getPyrObjType<PyrObject>();
+                    if (index < numArgsPushed) {
+                        if (sp[index].isNil() && !protoframe->slots[index].isNil())
+                            v_errors::PassingNilToLiteralInitArg::print_error();
+                        slotCopy(sp, sp + index);
+                    } else {
+                        slotCopy(sp, &slotRawObject(&meth->prototypeFrame)->slots[index]);
+                    }
+                }
                 break;
 
             case methReturnInstVar:
@@ -2393,10 +2406,20 @@ HOT void Interpret(VMGlobals* g) {
                 sp = g->sp;
                 sp -= numArgsPushed - 1;
                 index = methraw->specialIndex; // zero is index of the first argument
-                if (index < numArgsPushed && !(sp + index)->isNil()) {
-                    slotCopy(sp, sp + index);
+                if constexpr (v_errors::PassingNilToLiteralInitArg::do_new()) {
+                    if (index < numArgsPushed && !(sp + index)->isNil())
+                        slotCopy(sp, sp + index);
+                    else
+                        slotCopy(sp, &slotRawObject(&meth->prototypeFrame)->slots[index]);
                 } else {
-                    slotCopy(sp, &slotRawObject(&meth->prototypeFrame)->slots[index]);
+                    auto protoframe = meth->prototypeFrame.getPyrObjType<PyrObject>();
+                    if (index < numArgsPushed) {
+                        if (sp[index].isNil() && !protoframe->slots[index].isNil())
+                            v_errors::PassingNilToLiteralInitArg::print_error();
+                        slotCopy(sp, sp + index);
+                    } else {
+                        slotCopy(sp, &slotRawObject(&meth->prototypeFrame)->slots[index]);
+                    }
                 }
                 break;
 

--- a/lang/LangSource/PyrInterpreter3.cpp
+++ b/lang/LangSource/PyrInterpreter3.cpp
@@ -2276,7 +2276,7 @@ HOT void Interpret(VMGlobals* g) {
             case methReturnArg:
                 sp -= numArgsPushed - 1;
                 index = methraw->specialIndex; // zero is index of the first argument
-                if (index < numArgsPushed)
+                if (index < numArgsPushed && !(sp + index)->isNil())
                     slotCopy(sp, sp + index);
                 else
                     slotCopy(sp, &slotRawObject(&meth->prototypeFrame)->slots[index]);
@@ -2393,7 +2393,7 @@ HOT void Interpret(VMGlobals* g) {
                 sp = g->sp;
                 sp -= numArgsPushed - 1;
                 index = methraw->specialIndex; // zero is index of the first argument
-                if (index < numArgsPushed) {
+                if (index < numArgsPushed && !(sp + index)->isNil()) {
                     slotCopy(sp, sp + index);
                 } else {
                     slotCopy(sp, &slotRawObject(&meth->prototypeFrame)->slots[index]);

--- a/lang/LangSource/PyrMessage.cpp
+++ b/lang/LangSource/PyrMessage.cpp
@@ -449,10 +449,14 @@ void prepareArgsForExecute(VMGlobals* g, PyrBlock* block, PyrFrame* callFrame, s
         size_t i { 0 };
         for (PyrSlot* it { pushedArgs }; it < (pushedArgs + numNormalArgsAdded); ++it, ++i) {
             if (it->isNil() && !proto->slots[i].isNil()) {
-                auto m = callFrame->method.getPyrObjType<PyrMethod>();
-                v_errors::PassingNilToLiteralInitArg::print_error(
-                    m->ownerclass.getPyrObjType<PyrClass>()->name.getSymbol()->name,
-                    callFrame->method.getPyrObjType<PyrMethod>()->name.getSymbol()->name);
+                if (isMethod) {
+                    auto m = callFrame->method.getPyrObjType<PyrMethod>();
+                    v_errors::PassingNilToLiteralInitArg::print_error(
+                        m->ownerclass.getPyrObjType<PyrClass>()->name.getSymbol()->name,
+                        callFrame->method.getPyrObjType<PyrMethod>()->name.getSymbol()->name);
+                } else {
+                    v_errors::PassingNilToLiteralInitArg::print_error("Function", "value");
+                }
             }
             outCallFrameStack[i] = *it;
         }
@@ -485,10 +489,14 @@ void prepareArgsForExecute(VMGlobals* g, PyrBlock* block, PyrFrame* callFrame, s
                     *(outCallFrameStack + *argIndex) = *argValue;
             } else {
                 if (argValue->isNil() && !proto->slots[*argIndex].isNil()) {
-                    auto m = callFrame->method.getPyrObjType<PyrMethod>();
-                    v_errors::PassingNilToLiteralInitArg::print_error(
-                        m->ownerclass.getPyrObjType<PyrClass>()->name.getSymbol()->name,
-                        callFrame->method.getPyrObjType<PyrMethod>()->name.getSymbol()->name);
+                    if (isMethod) {
+                        auto m = callFrame->method.getPyrObjType<PyrMethod>();
+                        v_errors::PassingNilToLiteralInitArg::print_error(
+                            m->ownerclass.getPyrObjType<PyrClass>()->name.getSymbol()->name,
+                            callFrame->method.getPyrObjType<PyrMethod>()->name.getSymbol()->name);
+                    } else {
+                        v_errors::PassingNilToLiteralInitArg::print_error("Function", "value");
+                    }
                 }
                 *(outCallFrameStack + *argIndex) = *argValue;
             }

--- a/lang/LangSource/PyrMessage.cpp
+++ b/lang/LangSource/PyrMessage.cpp
@@ -169,12 +169,26 @@ lookup_again:
         if (numKeyArgsPushed > 0)
             applyKeywords();
         g->sp -= numArgsPushed - 1; // Remove all args but the receiver.
-        const auto argIndex = methodRaw->specialIndex; // Zero is index of the first argument.
-        if (argIndex < numArgsPushed && !(g->sp + argIndex)->isNil())
-            slotCopy(g->sp, g->sp + argIndex);
-        else
-            slotCopy(g->sp, &slotRawObject(&method->prototypeFrame)->slots[argIndex]);
-        return;
+
+        const auto index = methodRaw->specialIndex; // Zero is index of the first argument.
+
+        if constexpr (v_errors::PassingNilToLiteralInitArg::do_new()) {
+            if (index < numArgsPushed && !(g->sp + index)->isNil())
+                slotCopy(g->sp, g->sp + index);
+            else
+                slotCopy(g->sp, &slotRawObject(&g->method->prototypeFrame)->slots[index]);
+        } else {
+            auto protoframe = g->method->prototypeFrame.getPyrObjType<PyrObject>();
+            if (index < numArgsPushed) {
+                if (g->sp[index].isNil() && !protoframe->slots[index].isNil())
+                    v_errors::PassingNilToLiteralInitArg::print_error(
+                        g->method->ownerclass.getPyrObjType<PyrClass>()->name.getSymbol()->name,
+                        g->method->name.getSymbol()->name);
+                slotCopy(g->sp, g->sp + index);
+            } else {
+                slotCopy(g->sp, &slotRawObject(&g->method->prototypeFrame)->slots[index]);
+            }
+        }
     }
 
     case methReturnInstVar: { // Return instance variable.

--- a/lang/LangSource/PyrMessage.cpp
+++ b/lang/LangSource/PyrMessage.cpp
@@ -19,6 +19,7 @@
 */
 
 #include "PyrMessage.h"
+#include "PyrKernel.h"
 #include "PyrPrimitiveProto.h"
 #include "PyrInterpreter.h"
 #include "PyrPrimitive.h"
@@ -433,8 +434,12 @@ void prepareArgsForExecute(VMGlobals* g, PyrBlock* block, PyrFrame* callFrame, s
     } else {
         size_t i { 0 };
         for (PyrSlot* it { pushedArgs }; it < (pushedArgs + numNormalArgsAdded); ++it, ++i) {
-            if (it->isNil() && !proto->slots[i].isNil())
-                v_errors::PassingNilToLiteralInitArg::print_error();
+            if (it->isNil() && !proto->slots[i].isNil()) {
+                auto m = callFrame->method.getPyrObjType<PyrMethod>();
+                v_errors::PassingNilToLiteralInitArg::print_error(
+                    m->ownerclass.getPyrObjType<PyrClass>()->name.getSymbol()->name,
+                    callFrame->method.getPyrObjType<PyrMethod>()->name.getSymbol()->name);
+            }
             outCallFrameStack[i] = *it;
         }
     }
@@ -465,8 +470,12 @@ void prepareArgsForExecute(VMGlobals* g, PyrBlock* block, PyrFrame* callFrame, s
                 else
                     *(outCallFrameStack + *argIndex) = *argValue;
             } else {
-                if (argValue->isNil() && !proto->slots[*argIndex].isNil())
-                    v_errors::PassingNilToLiteralInitArg::print_error();
+                if (argValue->isNil() && !proto->slots[*argIndex].isNil()) {
+                    auto m = callFrame->method.getPyrObjType<PyrMethod>();
+                    v_errors::PassingNilToLiteralInitArg::print_error(
+                        m->ownerclass.getPyrObjType<PyrClass>()->name.getSymbol()->name,
+                        callFrame->method.getPyrObjType<PyrMethod>()->name.getSymbol()->name);
+                }
                 *(outCallFrameStack + *argIndex) = *argValue;
             }
 

--- a/lang/LangSource/PyrMessage.cpp
+++ b/lang/LangSource/PyrMessage.cpp
@@ -29,6 +29,7 @@
 #include "PredefinedSymbols.h"
 #include "PyrObjectProto.h"
 #include "SCBase.h"
+#include "VersionedErrors.h"
 
 #include <optional>
 #include <csetjmp>
@@ -425,8 +426,18 @@ void prepareArgsForExecute(VMGlobals* g, PyrBlock* block, PyrFrame* callFrame, s
 
     // Number that will actually be pushed to resulting call frame.
     const auto numNormalArgsAdded = std::min<uint32>(numNormalSuppliedArgs, methNumNormArgs);
-    // Replace arguments if they are not nil.
-    replaceNotNil(outCallFrameStack, pushedArgs, pushedArgs + numNormalArgsAdded);
+
+    if constexpr (v_errors::PassingNilToLiteralInitArg::do_new()) {
+        // Replace arguments if they are not nil.
+        replaceNotNil(outCallFrameStack, pushedArgs, pushedArgs + numNormalArgsAdded);
+    } else {
+        size_t i { 0 };
+        for (PyrSlot* it { pushedArgs }; it < (pushedArgs + numNormalArgsAdded); ++it, ++i) {
+            if (it->isNil() && !proto->slots[i].isNil())
+                v_errors::PassingNilToLiteralInitArg::print_error();
+            outCallFrameStack[i] = *it;
+        }
+    }
 
     if (numNormalSuppliedArgs > methNumNormArgs && methHasVarArg) {
         // Too many args.
@@ -444,13 +455,20 @@ void prepareArgsForExecute(VMGlobals* g, PyrBlock* block, PyrFrame* callFrame, s
 
         // If found in method.
         if (const auto argIndex = findKeywordArgIndex(argKeyword); argIndex.has_value()) {
-            if (argValue->isNil())
-                // Put it back to the default value. Passing nil is the same as saying, reset to default.
-                // It is important to use the proto default here in the case of a previous positional arguments being
-                // present and having overriden the value.
-                *(outCallFrameStack + *argIndex) = proto->slots[*argIndex];
-            else
+            // Found keyword.
+            if constexpr (v_errors::PassingNilToLiteralInitArg::do_new()) {
+                // Passing nil is the same as saying, reset to default.
+                // It is important to use the proto default here in the case of a previous positional arguments
+                // being present and having overriden the value.
+                if (argValue->isNil())
+                    *(outCallFrameStack + *argIndex) = proto->slots[*argIndex];
+                else
+                    *(outCallFrameStack + *argIndex) = *argValue;
+            } else {
+                if (argValue->isNil() && !proto->slots[*argIndex].isNil())
+                    v_errors::PassingNilToLiteralInitArg::print_error();
                 *(outCallFrameStack + *argIndex) = *argValue;
+            }
 
             // SC docs show that in the case of colliding args, the last one added should always be the result.
             if (*argIndex < numNormalArgsAdded) {

--- a/lang/LangSource/PyrMessage.cpp
+++ b/lang/LangSource/PyrMessage.cpp
@@ -23,6 +23,7 @@
 #include "PyrInterpreter.h"
 #include "PyrPrimitive.h"
 #include "PyrListPrim.h"
+#include "PyrSlot.h"
 #include "PyrSymbol.h"
 #include "GC.h"
 #include "PredefinedSymbols.h"
@@ -166,11 +167,11 @@ lookup_again:
         if (numKeyArgsPushed > 0)
             applyKeywords();
         g->sp -= numArgsPushed - 1; // Remove all args but the receiver.
-        const auto classIndex = methodRaw->specialIndex; // Zero is index of the first argument.
-        if (classIndex < numArgsPushed)
-            slotCopy(g->sp, g->sp + classIndex);
+        const auto argIndex = methodRaw->specialIndex; // Zero is index of the first argument.
+        if (argIndex < numArgsPushed && !(g->sp + argIndex)->isNil())
+            slotCopy(g->sp, g->sp + argIndex);
         else
-            slotCopy(g->sp, &slotRawObject(&method->prototypeFrame)->slots[classIndex]);
+            slotCopy(g->sp, &slotRawObject(&method->prototypeFrame)->slots[argIndex]);
         return;
     }
 
@@ -410,9 +411,22 @@ void prepareArgsForExecute(VMGlobals* g, PyrBlock* block, PyrFrame* callFrame, s
         return std::nullopt;
     };
 
+    // Put defaults on the stack first.
+    std::copy(proto->slots, proto->slots + methNumNormArgs, outCallFrameStack);
+
+    // Override defaults with envir, if provided.
+    if (optionalEnvirLookup)
+        // ident dicts can't have nil inside them, so no need to check the default.
+        for (auto i = 0; i < methNumNormArgs; ++i) {
+            PyrSlot keyslot;
+            SetSymbol(&keyslot, methArgNames[i]);
+            identDict_lookupNonNil(optionalEnvirLookup, &keyslot, calcHash(&keyslot), &outCallFrameStack[i]);
+        }
+
     // Number that will actually be pushed to resulting call frame.
     const auto numNormalArgsAdded = std::min<uint32>(numNormalSuppliedArgs, methNumNormArgs);
-    std::copy(pushedArgs, pushedArgs + numNormalArgsAdded, outCallFrameStack);
+    // Replace arguments if they are not nil.
+    replaceNotNil(outCallFrameStack, pushedArgs, pushedArgs + numNormalArgsAdded);
 
     if (numNormalSuppliedArgs > methNumNormArgs && methHasVarArg) {
         // Too many args.
@@ -421,19 +435,6 @@ void prepareArgsForExecute(VMGlobals* g, PyrBlock* block, PyrFrame* callFrame, s
         variableArgumentsArray = newPyrArray(g->gc, size, 0, false);
         variableArgumentsArray->size = size;
         std::copy(pushedArgs + numNormalArgsAdded, pushedArgs + numNormalSuppliedArgs, variableArgumentsArray->slots);
-
-    } else if (numNormalSuppliedArgs < methNumNormArgs) {
-        // Too few args, push defaults.
-        std::copy(proto->slots + numNormalArgsAdded, proto->slots + methNumNormArgs,
-                  outCallFrameStack + numNormalArgsAdded);
-
-        // This is the only case where the optional environment is used to lookup arguments.
-        if (optionalEnvirLookup)
-            for (auto i = numNormalArgsAdded; i < methNumNormArgs; ++i) {
-                PyrSlot keyslot;
-                SetSymbol(&keyslot, methArgNames[i]);
-                identDict_lookupNonNil(optionalEnvirLookup, &keyslot, calcHash(&keyslot), &outCallFrameStack[i]);
-            }
     }
 
     // Deal with the keywords.
@@ -443,7 +444,13 @@ void prepareArgsForExecute(VMGlobals* g, PyrBlock* block, PyrFrame* callFrame, s
 
         // If found in method.
         if (const auto argIndex = findKeywordArgIndex(argKeyword); argIndex.has_value()) {
-            outCallFrameStack[*argIndex] = *argValue;
+            if (argValue->isNil())
+                // Put it back to the default value. Passing nil is the same as saying, reset to default.
+                // It is important to use the proto default here in the case of a previous positional arguments being
+                // present and having overriden the value.
+                *(outCallFrameStack + *argIndex) = proto->slots[*argIndex];
+            else
+                *(outCallFrameStack + *argIndex) = *argValue;
 
             // SC docs show that in the case of colliding args, the last one added should always be the result.
             if (*argIndex < numNormalArgsAdded) {

--- a/lang/LangSource/PyrSlot.h
+++ b/lang/LangSource/PyrSlot.h
@@ -604,3 +604,15 @@ bool postString(PyrSlot* slot, char* str);
 template <typename numeric_type> inline void setSlotVal(PyrSlot* slot, numeric_type value) noexcept;
 template <> inline void setSlotVal<int>(PyrSlot* slot, int value) noexcept { SetInt(slot, value); }
 template <> inline void setSlotVal<double>(PyrSlot* slot, double value) noexcept { SetFloat(slot, value); }
+
+
+inline void replaceNotNil(PyrSlot* dest, PyrSlot src) {
+    if (!src.isNil())
+        *dest = src;
+}
+
+inline void replaceNotNil(PyrSlot* dest, PyrSlot* src_begin, PyrSlot* src_end) {
+    assert(src_begin <= src_end);
+    for (auto it = src_begin; it < src_end; ++it, ++dest)
+        replaceNotNil(dest, *it);
+}

--- a/lang/LangSource/VersionedErrors.h
+++ b/lang/LangSource/VersionedErrors.h
@@ -1,0 +1,17 @@
+#pragma once
+#include "SCBase.h"
+#include "SC_Version.hpp"
+
+namespace v_errors {
+
+struct PassingNilToLiteralInitArg {
+    static constexpr auto version { SemanticVersion { 3, 16, 0 } };
+    constexpr static bool do_new() { return SC_Version >= PassingNilToLiteralInitArg::version; }
+    static void print_error() {
+        post("ERROR: in version 3.16 and onwards, passing nil to a default initialised argument will have "
+             "different behaviour.\n"
+             "See **** for more information and for how to update your code.\n");
+    }
+};
+
+}

--- a/lang/LangSource/VersionedErrors.h
+++ b/lang/LangSource/VersionedErrors.h
@@ -7,10 +7,12 @@ namespace v_errors {
 struct PassingNilToLiteralInitArg {
     static constexpr auto version { SemanticVersion { 3, 16, 0 } };
     constexpr static bool do_new() { return SC_Version >= PassingNilToLiteralInitArg::version; }
-    static void print_error() {
+    static void print_error(const char* class_name, const char* method_name) {
         post("ERROR: in version 3.16 and onwards, passing nil to a default initialised argument will have "
              "different behaviour.\n"
-             "See **** for more information and for how to update your code.\n");
+             "See **** for more information and for how to update your code.\n"
+             "Occured while calling %s:%s.\n",
+             class_name, method_name);
     }
 };
 

--- a/testsuite/classlibrary/TestArgumentNil.sc
+++ b/testsuite/classlibrary/TestArgumentNil.sc
@@ -1,9 +1,9 @@
 TestArgumentNil : UnitTest {
-	meth_arg { 
+	meth_arg {
 		arg a = 1, b(1), c((1)), d(2 - 1), e = 2 - 1;
 		^[a, b, c, d, e]
 	}
-	meth_pipe { 
+	meth_pipe {
 		|a = 1, b 1, c((1)), d(2 - 1), e = (2 - 1)|
 		^[a, b, c, d, e]
 	}
@@ -18,8 +18,13 @@ TestArgumentNil : UnitTest {
 		this.assertEquals(this.meth_pipe(a: nil, b: nil, c: nil, d: nil, e: nil), [1, 1, 1, 1, 1], "pipe kw");
 	}
 	test_kw_replace {
-		this.assertEquals(this.meth_arg(1, 1, 1, 1, 1, a: nil, b: nil, c: nil, d: nil, e: nil), [1, 1, 1, 1, 1], "arg kw replace");
-		this.assertEquals(this.meth_pipe(1, 1, 1, 1, 1, a: nil, b: nil, c: nil, d: nil, e: nil), [1, 1, 1, 1, 1], "pipe kw replace");
+		this.assertEquals(this.meth_arg(12, 12, 12, 12, 12, a: nil, b: nil, c: nil, d: nil, e: nil), [1, 1, 1, 1, 1], "arg kw replace");
+		this.assertEquals(this.meth_pipe(12, 12, 12, 12, 12, a: nil, b: nil, c: nil, d: nil, e: nil), [1, 1, 1, 1, 1], "pipe kw replace");
+	}
+
+	test_ex_pos {
+		this.assertEquals(this.meth_arg(*[nil, nil, nil, nil, nil]), [1, 1, 1, 1, 1], "arg ex");
+		this.assertEquals(this.meth_pipe(*[nil, nil, nil, nil, nil]), [1, 1, 1, 1, 1], "pipe ex");
 	}
 
 	r_arg { |a = 1| ^a }

--- a/testsuite/classlibrary/TestArgumentNil.sc
+++ b/testsuite/classlibrary/TestArgumentNil.sc
@@ -1,0 +1,32 @@
+TestArgumentNil : UnitTest {
+	meth_arg { 
+		arg a = 1, b(1), c((1)), d(2 - 1), e = 2 - 1;
+		^[a, b, c, d, e]
+	}
+	meth_pipe { 
+		|a = 1, b 1, c((1)), d(2 - 1), e = (2 - 1)|
+		^[a, b, c, d, e]
+	}
+	test_pos {
+		this.assertEquals(this.meth_arg, [1, 1, 1, 1, 1], "arg default");
+		this.assertEquals(this.meth_arg(nil, nil, nil, nil, nil), [1, 1, 1, 1, 1], "arg explicit nil");
+		this.assertEquals(this.meth_pipe, [1, 1, 1, 1, 1], "pipe default");
+		this.assertEquals(this.meth_pipe(nil, nil, nil, nil, nil), [1, 1, 1, 1, 1], "pipe explicit nil");
+	}
+	test_kw {
+		this.assertEquals(this.meth_arg(a: nil, b: nil, c: nil, d: nil, e: nil), [1, 1, 1, 1, 1], "arg kw");
+		this.assertEquals(this.meth_pipe(a: nil, b: nil, c: nil, d: nil, e: nil), [1, 1, 1, 1, 1], "pipe kw");
+	}
+	test_kw_replace {
+		this.assertEquals(this.meth_arg(1, 1, 1, 1, 1, a: nil, b: nil, c: nil, d: nil, e: nil), [1, 1, 1, 1, 1], "arg kw replace");
+		this.assertEquals(this.meth_pipe(1, 1, 1, 1, 1, a: nil, b: nil, c: nil, d: nil, e: nil), [1, 1, 1, 1, 1], "pipe kw replace");
+	}
+
+	r_arg { |a = 1| ^a }
+	test_r_pos {
+		this.assertEquals(this.r_arg, 1, "r arg default");
+		this.assertEquals(this.r_arg(nil), 1, "r arg explicit nil");
+		this.assertEquals(this.r_arg(a: 2), 2, "r arg new value");
+		this.assertEquals(this.r_arg(2, a: nil), 1, "r arg kw nil resets to default");
+	}
+}

--- a/testsuite/classlibrary/TestArgumentNil.sc
+++ b/testsuite/classlibrary/TestArgumentNil.sc
@@ -8,30 +8,40 @@ TestArgumentNil : UnitTest {
 		^[a, b, c, d, e]
 	}
 	test_pos {
-		this.assertEquals(this.meth_arg, [1, 1, 1, 1, 1], "arg default");
-		this.assertEquals(this.meth_arg(nil, nil, nil, nil, nil), [1, 1, 1, 1, 1], "arg explicit nil");
-		this.assertEquals(this.meth_pipe, [1, 1, 1, 1, 1], "pipe default");
-		this.assertEquals(this.meth_pipe(nil, nil, nil, nil, nil), [1, 1, 1, 1, 1], "pipe explicit nil");
+		if(Main.versionAtLeast(3, 16)){
+			this.assertEquals(this.meth_arg, [1, 1, 1, 1, 1], "arg default");
+			this.assertEquals(this.meth_arg(nil, nil, nil, nil, nil), [1, 1, 1, 1, 1], "arg explicit nil");
+			this.assertEquals(this.meth_pipe, [1, 1, 1, 1, 1], "pipe default");
+			this.assertEquals(this.meth_pipe(nil, nil, nil, nil, nil), [1, 1, 1, 1, 1], "pipe explicit nil");
+		}
 	}
 	test_kw {
-		this.assertEquals(this.meth_arg(a: nil, b: nil, c: nil, d: nil, e: nil), [1, 1, 1, 1, 1], "arg kw");
-		this.assertEquals(this.meth_pipe(a: nil, b: nil, c: nil, d: nil, e: nil), [1, 1, 1, 1, 1], "pipe kw");
+		if(Main.versionAtLeast(3, 16)){
+			this.assertEquals(this.meth_arg(a: nil, b: nil, c: nil, d: nil, e: nil), [1, 1, 1, 1, 1], "arg kw");
+				this.assertEquals(this.meth_pipe(a: nil, b: nil, c: nil, d: nil, e: nil), [1, 1, 1, 1, 1], "pipe kw");
+		}
 	}
 	test_kw_replace {
-		this.assertEquals(this.meth_arg(12, 12, 12, 12, 12, a: nil, b: nil, c: nil, d: nil, e: nil), [1, 1, 1, 1, 1], "arg kw replace");
-		this.assertEquals(this.meth_pipe(12, 12, 12, 12, 12, a: nil, b: nil, c: nil, d: nil, e: nil), [1, 1, 1, 1, 1], "pipe kw replace");
+		if(Main.versionAtLeast(3, 16)){
+			this.assertEquals(this.meth_arg(12, 12, 12, 12, 12, a: nil, b: nil, c: nil, d: nil, e: nil), [1, 1, 1, 1, 1], "arg kw replace");
+			this.assertEquals(this.meth_pipe(12, 12, 12, 12, 12, a: nil, b: nil, c: nil, d: nil, e: nil), [1, 1, 1, 1, 1], "pipe kw replace");
+		}
 	}
 
 	test_ex_pos {
-		this.assertEquals(this.meth_arg(*[nil, nil, nil, nil, nil]), [1, 1, 1, 1, 1], "arg ex");
-		this.assertEquals(this.meth_pipe(*[nil, nil, nil, nil, nil]), [1, 1, 1, 1, 1], "pipe ex");
+		if(Main.versionAtLeast(3, 16)){
+			this.assertEquals(this.meth_arg(*[nil, nil, nil, nil, nil]), [1, 1, 1, 1, 1], "arg ex");
+			this.assertEquals(this.meth_pipe(*[nil, nil, nil, nil, nil]), [1, 1, 1, 1, 1], "pipe ex");
+		}
 	}
 
 	r_arg { |a = 1| ^a }
 	test_r_pos {
-		this.assertEquals(this.r_arg, 1, "r arg default");
-		this.assertEquals(this.r_arg(nil), 1, "r arg explicit nil");
-		this.assertEquals(this.r_arg(a: 2), 2, "r arg new value");
-		this.assertEquals(this.r_arg(2, a: nil), 1, "r arg kw nil resets to default");
+		if(Main.versionAtLeast(3, 16)){
+			this.assertEquals(this.r_arg, 1, "r arg default");
+			this.assertEquals(this.r_arg(nil), 1, "r arg explicit nil");
+			this.assertEquals(this.r_arg(a: 2), 2, "r arg new value");
+			this.assertEquals(this.r_arg(2, a: nil), 1, "r arg kw nil resets to default");
+		}
 	}
 }


### PR DESCRIPTION
## Purpose and Motivation

Closes #7385

Fixes bug when explicitly passing `nil` would override the default argument value when it was a literal.

Adds documentation regarding what the intended behaviour is from now on.

This aligns sc's behaviour with lua. Usually python is the standard, but you can't call functions with too few arguments there so the issue doesn't arise.

Old behaviour.

```supercollider
f = { arg a1 = 1; a1 };
g = { arg a1=(1); a1 };
h = { arg a1(1); a1 };
i = { arg a1((1)); a1 };
j = { | a1 1| a1 };

f.(nil) // nil
g.(nil) // 1
h.(nil) // 1
i.(nil) // 1
j.(nil) // nil
```

After this PR, passing `nil` means, 'reset to default', therefore all the above return `1`.


One of the places where this is very annoying is here...

```supercollider
f { |a =10| ^a };
g { |a| ^this.f(a) };
```

... as `g`'s `a` is `nil` and this overrides `f`'s default,  so `g() == nil`.


Note, this is a breaking change in two cases:
- When the argument was declared as a literal, if it was an expression, or had brackets (?), you could not pass `nil` and the default was used (correctly).
- `f.(10, a1: nil)` You could also get the argument to be nil if you had a collision. Now this means, 'reset to default', and therefore returns `1`.  See documentation for examples.


## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix
- Breaking change

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->
- [ ] Update `NodeProxy:clear`.
- [x] Code is tested
- [x] All tests are passing
- [ ] Updated documentation
- [ ] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
