### PR TITLE
Convolution UGen fixes

### DIFF
--- a/server/plugins/Convolution.cpp
+++ b/server/plugins/Convolution.cpp
@@ -244,22 +244,31 @@ void Convolution_next(Convolution* unit, int numSamples) {
 
 
 // include local buffer test in one place
-static SndBuf* ConvGetBuffer(Unit* unit, uint32 bufnum, const char* ugenName, int inNumSamples) {
+// TODO: reevaluate the error handling behavior. Should the Unit really stop processing just
+// because it (temporarily) received an invalid buffer number? Probably not.
+static SndBuf* ConvGetBuffer(Unit* unit, int32 bufnum, const char* ugenName, int inNumSamples) {
     SndBuf* buf;
     World* world = unit->mWorld;
 
-    if (bufnum >= world->mNumSndBufs) {
-        int localBufNum = bufnum - world->mNumSndBufs;
-        Graph* parent = unit->mParent;
-        if (localBufNum <= parent->localMaxBufNum) {
-            buf = parent->mLocalSndBufs + localBufNum;
+    // first check if bufnum is positive!
+    if (bufnum >= 0) {
+        if (bufnum >= world->mNumSndBufs) {
+            int localBufNum = bufnum - world->mNumSndBufs;
+            Graph* parent = unit->mParent;
+            if (localBufNum <= parent->localMaxBufNum) {
+                buf = parent->mLocalSndBufs + localBufNum;
+            } else {
+                if (unit->mWorld->mVerbosity > -1)
+                    Print("%s: invalid buffer number (%d).\n", ugenName, bufnum);
+                goto handle_failure;
+            }
         } else {
-            if (unit->mWorld->mVerbosity > -1)
-                Print("%s: invalid buffer number (%d).\n", ugenName, bufnum);
-            goto handle_failure;
+            buf = world->mSndBufs + bufnum;
         }
     } else {
-        buf = world->mSndBufs + bufnum;
+        if (unit->mWorld->mVerbosity > -1)
+            Print("%s: invalid buffer number (%d).\n", ugenName, bufnum);
+        goto handle_failure;
     }
 
     if (buf->data == nullptr) {
@@ -279,8 +288,8 @@ handle_failure:
 
 void Convolution2_Ctor(Convolution2* unit) {
     // require size N+M-1 to be a power of two
-    unit->m_framesize = (int)ZIN0(3);
-    uint32 kernelbufnum = (int)ZIN0(1);
+    unit->m_framesize = (int32)ZIN0(3);
+    int32 kernelbufnum = (int32)ZIN0(1);
     World* world = unit->mWorld;
 
     unit->m_inbuf1 = unit->m_fftbuf1 = unit->m_fftbuf2 = unit->m_outbuf = unit->m_overlapbuf = nullptr;
@@ -386,9 +395,11 @@ void Convolution2_next(Convolution2* unit, int wrongNumSamples) {
     unit->m_pos += numSamples;
 
     if (unit->m_prevtrig <= 0.f && curtrig > 0.f) {
-        SndBuf* kernelbuf = ConvGetBuffer(unit, (uint32)ZIN0(1), "Convolution2", numSamples);
+        int32 kernelbufnum = (int32)ZIN0(1);
+        SndBuf* kernelbuf = ConvGetBuffer(unit, kernelbufnum, "Convolution2", numSamples);
         if (!kernelbuf)
             return;
+
         LOCK_SNDBUF_SHARED(kernelbuf);
 
         // we cannot use a kernel larger than the fft size, so truncate if needed. the kernel may be smaller though.
@@ -475,7 +486,7 @@ void Convolution2L_Ctor(Convolution2L* unit) {
 
     ClearUnitIfMemFailed(unit->m_inbuf1 && unit->m_fftbuf1 && unit->m_fftbuf2 && unit->m_fftbuf3 && unit->m_tempbuf);
 
-    uint32 bufnum = (int)ZIN0(1); // fbufnum;
+    int32 bufnum = (int32)ZIN0(1); // fbufnum;
 
     SndBuf* buf = ConvGetBuffer(unit, bufnum, "Convolution2L", 1);
 
@@ -551,7 +562,7 @@ void Convolution2L_next(Convolution2L* unit, int numSamples) {
     unit->m_pos += numSamples;
 
     if (unit->m_prevtrig <= 0.f && curtrig > 0.f) {
-        uint32 bufnum = (int)ZIN0(1);
+        int32 bufnum = (int32)ZIN0(1);
         SndBuf* buf = ConvGetBuffer(unit, bufnum, "Convolution2L", numSamples);
         if (!buf)
             return;
@@ -756,11 +767,9 @@ void StereoConvolution2L_Ctor(StereoConvolution2L* unit) {
     ClearUnitIfMemFailed(unit->m_scfft1 && unit->m_scfft2[0] && unit->m_scfft3[0] && unit->m_scfftR[0]
                          && unit->m_scfftR2[0]);
     ClearUnitIfMemFailed(unit->m_scfft2[1] && unit->m_scfft3[1] && unit->m_scfftR[1] && unit->m_scfftR2[1]);
-    float fbufnum = ZIN0(1);
-    uint32 bufnumL = (int)fbufnum;
-    fbufnum = ZIN0(2);
-    uint32 bufnumR = (int)fbufnum;
-    // printf("bufnum %i \n", bufnum);
+    int32 bufnumL = (int32)ZIN0(1);
+    int32 bufnumR = (int32)ZIN0(2);
+    // printf("bufnumL: %d, bufnumR: %d\n", bufnumL, bufnumR);
 
     // unit->m_log2n = LOG2CEIL(unit->m_fftsize);
     // int log2n = unit->m_log2n;
@@ -842,11 +851,9 @@ void StereoConvolution2L_next(StereoConvolution2L* unit, int wrongNumSamples) {
     unit->m_pos += numSamples;
 
     if (unit->m_prevtrig <= 0.f && curtrig > 0.f) {
-        float fbufnum = ZIN0(1);
-        uint32 bufnumL = (int)fbufnum;
-        fbufnum = ZIN0(2);
-        uint32 bufnumR = (int)fbufnum;
-        unit->m_cflength = (int)ZIN0(5);
+        int32 bufnumL = (int32)ZIN0(1);
+        int32 bufnumR = (int32)ZIN0(2);
+        unit->m_cflength = (int32)ZIN0(5);
 
         SndBuf* bufL = ConvGetBuffer(unit, bufnumL, "StereoConvolution2L", numSamples);
         SndBuf* bufR = ConvGetBuffer(unit, bufnumR, "StereoConvolution2L", numSamples);
@@ -1015,10 +1022,9 @@ void StereoConvolution2L_next(StereoConvolution2L* unit, int wrongNumSamples) {
 }
 
 void Convolution3_Ctor(Convolution3* unit) {
-    unit->m_framesize = (int)ZIN0(3);
+    unit->m_framesize = (int32)ZIN0(3);
 
-    float fbufnum = ZIN0(1);
-    uint32 bufnum = (int)fbufnum;
+    int32 bufnum = (int32)ZIN0(1);
 
     SndBuf* buf = ConvGetBuffer(unit, bufnum, "Convolution3", 1);
 
@@ -1074,9 +1080,11 @@ void Convolution3_next_a(Convolution3* unit) {
 
     if (unit->m_prevtrig <= 0.f && curtrig > 0.f) {
         uint32 framesize_f = unit->m_framesize * sizeof(float);
-        float fbufnum = ZIN0(1);
-        uint32 bufnum = (int)fbufnum;
+        int32 bufnum = (int32)ZIN0(1);
         SndBuf* buf = ConvGetBuffer(unit, bufnum, "Convolution3", numSamples);
+        if (!buf)
+            return;
+
         LOCK_SNDBUF_SHARED(buf);
         memcpy(unit->m_inbuf2, buf->data, framesize_f);
     }
@@ -1117,15 +1125,13 @@ void Convolution3_next_k(Convolution3* unit) {
 
     uint32 framesize_f = unit->m_framesize * sizeof(float);
 
-
     if (unit->m_prevtrig <= 0.f && curtrig > 0.f) {
-        float fbufnum = ZIN0(1);
-        uint32 bufnum = (int)fbufnum;
+        int32 bufnum = (int32)ZIN0(1);
         SndBuf* buf = ConvGetBuffer(unit, bufnum, "Convolution3", 1);
         if (!buf)
             return;
-        LOCK_SNDBUF_SHARED(buf);
 
+        LOCK_SNDBUF_SHARED(buf);
         memcpy(unit->m_inbuf2, buf->data, framesize_f);
     }
 

--- a/testsuite/classlibrary/TestUGen_RTAlloc.sc
+++ b/testsuite/classlibrary/TestUGen_RTAlloc.sc
@@ -187,6 +187,10 @@ TestUGen_RTAlloc : UnitTest {
 		var allocSeconds = this.memSizeSeconds;
 		var allocSamples = nextPowerOfTwo(this.memSizeFloats);
 		var blockSize = server.options.blockSize;
+
+		var convBufFrames = blockSize * 8;
+		var convBuf = Buffer.loadCollection(server, 1!convBufFrames);
+
 		var testArgs = [
 			["AllpassC", { AllpassC.ar(DC.ar(1), allocSeconds) }],
 			["AllpassL", { AllpassL.ar(DC.ar(1), allocSeconds) }],
@@ -226,15 +230,16 @@ TestUGen_RTAlloc : UnitTest {
 			// memSizeSeconds * 340 produces an allocation of memSizeFloats floats
 			["GVerb", { GVerb.ar(DC.ar(1), 1, maxroomsize: this.memSizeSeconds * 340) }],
 
-			// Convolution UGens don't need a valid 
 			// note: when trying to run tests in parallel, these required a separate batch or would crash the server
 			["Convolution", { Convolution.ar(DC.ar(1), DC.ar(1), allocSamples) }],
-			["Convolution2", { Convolution2.ar(DC.ar(1), -1, 0, allocSamples) }],
-			["Convolution2L", { Convolution2L.ar(DC.ar(1), -1, 0, allocSamples) }],
-			["Convolution3", { Convolution3.ar(DC.ar(1), -1, 0, allocSamples) }],
-			["StereoConvolution2L", { StereoConvolution2L.ar(DC.ar(1), -1, -1, 0, allocSamples) }],
-			["PartConv", { PartConv.ar(DC.ar(1), allocSamples, -1) }, server.options.blockSize * 2],
+			["Convolution2", { Convolution2.ar(DC.ar(1), convBuf, 0, allocSamples) }],
+			["Convolution2L", { Convolution2L.ar(DC.ar(1), convBuf, 0, allocSamples) }],
+			["Convolution3", { Convolution3.ar(DC.ar(1), convBuf, 0, allocSamples) }],
+			["StereoConvolution2L", { StereoConvolution2L.ar(DC.ar(1), convBuf, convBuf, 0, allocSamples) }],
+			["PartConv", { PartConv.ar(DC.ar(1), allocSamples, convBuf) }, server.options.blockSize * 2],
 		];
+
+		server.sync; // for convBuf;
 
 		// testArgs.collect { |args| { this.assertAllocFail(*args) } }.fork;
 		testArgs.do { |args| this.assertAllocFail(*args) };
@@ -260,7 +265,7 @@ TestUGen_RTAlloc : UnitTest {
 		var blockSize = server.options.blockSize;
 		var fftSize = blockSize;
 		var out = this.awaitSynthOutput({ FFT(LocalBuf(fftSize), DC.ar(1), hop:1) });
-		this.assert(out.notNil, 
+		this.assert(out.notNil,
 			"successful alloc test should complete (fftSize: %)".format(fftSize),
 			onFailure: \stop);
 		this.assert(out.any(_ > 0), "should return a valid bufnum (bufnum: %)".format(out));


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

The Convolution UGens wrongly used `uint32` for buffer numbers, which caused issues with negative numbers.

This PR makes sure that all buffer numbers are signed. It also fixes the logic in the `ConvGetBuffer()` helper function to account for negative numbers.

Finally, it fixes the `test_allUGens_allocFail` test method of `TestUGen_RTAlloc` by passing an actual valid Buffer instead of -1 to the Convolution UGens. Otherwise the UGens constructors would return before attempting to allocate any RT memory.

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
