### PR TITLE
Helpbrowser: redirect http links to system browser

### DIFF
--- a/HelpSource/Classes/HelpBrowser.schelp
+++ b/HelpSource/Classes/HelpBrowser.schelp
@@ -34,7 +34,7 @@ table::
 ::
 
 classmethods::
-private:: getOldWrapUrl, initClass, prRedirectToSystemBrowser
+private:: getOldWrapUrl, initClass, prShouldRedirect, prRedirectMenu, prIDEorHelpBrowser
 
 method:: instance
 The singleton HelpBrowser instance.

--- a/HelpSource/Classes/HelpBrowser.schelp
+++ b/HelpSource/Classes/HelpBrowser.schelp
@@ -38,28 +38,36 @@ private:: getOldWrapUrl, initClass, prShouldRedirect, prRedirectMenu, prIDEorHel
 
 method:: instance
 The singleton HelpBrowser instance.
+emphasis::Does not concern the SCIDE's built-in helpbrowser.::
 
 method:: new
 Create a new HelpBrowser instance with given home URL.
+emphasis::Does not concern the SCIDE's built-in helpbrowser.::
 
 method:: defaultHomeUrl
 Get or set the default home URL.
 
 method:: openNewWindows
+emphasis::Does not concern the SCIDE's built-in helpbrowser.::
 Get or set the default for "open in new windows" toggle.
 When set to teletype::false:: (default), this class behaves like a singleton class.
 
 method:: redirectEnabled
-When set to true (default), redirects links that match code::redirectPattern:: to the system's default Web browser.
-Disable at your own risk: SC's help browser is not web safe.
+When set to teletype::true:: (default), clicking on links whose target matches code::redirectPattern:: will open a menu giving the user the choice to open the link in the system's default Web browser (recommended),
+or in SuperCollider's own help browser (strong::not:: recommended for remote links, because not safe for web browsing).
+warning::Disable at your own risk: SC's help browser is not web safe.
+
+This concerns both the SCIDE's built-in help browser and help browser instances created
+through code::HelpBrowser.new()::.::
 
 method:: redirectPattern
-Get or set the regex pattern (a link::Classes/String#Regular expressions#String::) that determines which links are forwarded to the system's default browser.
-When the link matches this pattern, it will be opened in the system's default browser (provided code::redirectEnabled:: is teletype::true::.)
-By default, this is set to code::"^http":: (i.e., it redirects all links that begin with teletype::http::).
+Get or set the regex pattern (a link::Classes/String#Regular expressions#String::) that determines which links will open the menu described above (link::#*redirectEnabled::).
+By default, this is set to code::"^http":: (i.e., it opens the menu all links that begin with teletype::http::).
+To exclude addresses such as teletype::localhost:: from this behavior, append a link::https://en.wikipedia.org/wiki/Regular_expression#Assertions#negative lookahead::, e.g.: code::"^https?:\/\/(?!localhost|127\..*)"::.
 
 method:: goTo
-Go to url with singleton instance or a new window, depending on the code::openNewWindows:: setting.
+When using the SCIDE, go to teletype::url:: in the built-in helpbrowser;
+otherwise, go to url with singleton code::HelpBrowser:: instance or a new window, depending on the code::openNewWindows:: setting.
 
 method:: openHelpFor
 Open the relevant help page for given text in the singleton HelpBrowser instance.

--- a/HelpSource/Classes/HelpBrowser.schelp
+++ b/HelpSource/Classes/HelpBrowser.schelp
@@ -34,7 +34,7 @@ table::
 ::
 
 classmethods::
-private:: getOldWrapUrl, initClass
+private:: getOldWrapUrl, initClass, prRedirectToSystemBrowser
 
 method:: instance
 The singleton HelpBrowser instance.

--- a/HelpSource/Classes/HelpBrowser.schelp
+++ b/HelpSource/Classes/HelpBrowser.schelp
@@ -34,7 +34,7 @@ table::
 ::
 
 classmethods::
-private:: getOldWrapUrl, initClass, prShouldRedirect, prRedirectMenu, prIDEorHelpBrowser
+private:: getOldWrapUrl, initClass, init, prShouldRedirect, prOpenRedirectMenu, prOpenInIDEorHelpBrowser
 
 method:: instance
 The singleton HelpBrowser instance.

--- a/HelpSource/Classes/HelpBrowser.schelp
+++ b/HelpSource/Classes/HelpBrowser.schelp
@@ -48,6 +48,15 @@ Get or set the default home URL.
 method:: openNewWindows
 Get or set the default for "open in new windows" toggle.
 
+method:: redirectEnabled
+When set to true (default), redirects links that match code::redirectPattern:: to the system's default Web browser.
+Disable at your own risk: SC's help browser is not web safe.
+
+method:: redirectPattern
+Get or set the regex pattern (a link::Classes/String#Regular expressions#String::) that determines which links are forwarded to the system's default browser.
+When the link matches this pattern, it will be opened in the system's default browser (provided code::redirectEnabled:: is teletype::true::.)
+By default, this is set to code::"^http":: (i.e., it redirects all links that begin with teletype::http::).
+
 method:: goTo
 Go to url with singleton instance or a new window, depending on the code::openNewWindows:: setting.
 

--- a/HelpSource/Classes/HelpBrowser.schelp
+++ b/HelpSource/Classes/HelpBrowser.schelp
@@ -47,6 +47,7 @@ Get or set the default home URL.
 
 method:: openNewWindows
 Get or set the default for "open in new windows" toggle.
+When set to teletype::false:: (default), this class behaves like a singleton class.
 
 method:: redirectEnabled
 When set to true (default), redirects links that match code::redirectPattern:: to the system's default Web browser.

--- a/SCClassLibrary/Common/GUI/tools/HelpBrowser.sc
+++ b/SCClassLibrary/Common/GUI/tools/HelpBrowser.sc
@@ -45,7 +45,7 @@ HelpBrowser {
 	}
 
 	*prRedirectMenu { |url, openInSCIDE|
-		var info = MenuAction("Choose how to open external link:\n").enabled_(false);
+		var info = MenuAction("Choose how to open external link:").enabled_(false);
 		var domain = MenuAction(if(url.size < 75) {url} {url.replaceRegexp("https?:\/\/|(/.*)", "")} ).enabled_(false);
 		var separator = MenuAction().separator_(true);
 		var systemDefaultBrowser = MenuAction("Open in system default browser");

--- a/SCClassLibrary/Common/GUI/tools/HelpBrowser.sc
+++ b/SCClassLibrary/Common/GUI/tools/HelpBrowser.sc
@@ -4,6 +4,10 @@ HelpBrowser {
 	classvar <>openNewWindows = false;
 	classvar <>scrollStep = 40;
 	classvar <>scrollPageStep = 350;
+	classvar <>redirectEnabled = true;
+	// redirect link addresses that match redirectPattern to default system browser
+	classvar <>redirectPattern = "^http";
+	// all http gets redirected
 
 	var <>homeUrl;
 	var <window;
@@ -38,11 +42,10 @@ HelpBrowser {
 
 
 	*prRedirectToSystemBrowser { |url|
-			var redirectPattern = "^https?:\/\/(?!127.*|localhost)";
 			url = url.asString;
-			// matches all http except for loopback/localhost (IPv4)
-			if(redirectPattern.matchRegexp(url)) {
+			if(redirectEnabled and: { redirectPattern.matchRegexp(url) }) {
 				url.openOS;
+				(url ++ " opened in system browser").postln;
 				^true
 			} {
 				^false
@@ -53,7 +56,7 @@ HelpBrowser {
 		var ideClass = \ScIDE.asClass;
 		var redirected = HelpBrowser.prRedirectToSystemBrowser(url);
 		case
-		{ redirected } { (url ++ " opened in system browser").postln; }
+		{ redirected } { ^nil }
 		{ ideClass.notNil } { ideClass.openHelpUrl(url) }
 		{ this.front.goTo(url) };
 	}
@@ -253,10 +256,8 @@ HelpBrowser {
 
 		webView.onLinkActivated = {|wv, url|
 			var redirected, newPath, oldPath;
-			case
-			{ HelpBrowser.prRedirectToSystemBrowser(url) } { (url ++ " opened in system browser").postln; }
-			{ this.redirectTextFile(url) } { ^nil }
-			{
+			redirected = this.redirectTextFile(url) or: { HelpBrowser.prRedirectToSystemBrowser(url) };
+			if (not(redirected)) {
 				#newPath, oldPath = [url,webView.url].collect {|x|
 					if(x.notEmpty) {x.findRegexp("(^\\w+://)?([^#]+)(#.*)?")[1..].flop[1][1]}
 				};

--- a/SCClassLibrary/Common/GUI/tools/HelpBrowser.sc
+++ b/SCClassLibrary/Common/GUI/tools/HelpBrowser.sc
@@ -38,10 +38,10 @@ HelpBrowser {
 
 
 	*prRedirectToSystemBrowser { |url|
+			var redirectPattern = "^https?:\/\/(?!127.*|localhost)";
 			url = url.asString;
-			redirectPattern = "^https?:\/\/(?!127.*|localhost)";
 			// matches all http except for loopback/localhost (IPv4)
-			if(redirectPattern.matchRegex(url)) {
+			if(redirectPattern.matchRegexp(url)) {
 				url.openOS;
 				^true
 			} {

--- a/SCClassLibrary/Common/GUI/tools/HelpBrowser.sc
+++ b/SCClassLibrary/Common/GUI/tools/HelpBrowser.sc
@@ -36,13 +36,24 @@ HelpBrowser {
 		^super.new.init( aHomeUrl ? defaultHomeUrl, newWin ?? { openNewWindows } );
 	}
 
+
+	*redirectToSystemBrowser { |url|
+			if(url.contains("http")) {
+				url.replaceRegexp("https?", "https").openOS;
+				(url ++ " opened in system browser").postln;
+				^true
+			} {
+				^false
+			}
+	}
+
 	*goTo {|url|
 		var ideClass = \ScIDE.asClass;
-		if ( ideClass.notNil ) {
-			ideClass.openHelpUrl(url);
-		}{
-			this.front.goTo(url);
-		}
+		var redirected = HelpBrowser.redirectToSystemBrowser(url);
+		case
+		{ redirected } { ^nil }
+		{ ideClass.notNil } { ideClass.openHelpUrl(url) }
+		{ this.front.goTo(url) };
 	}
 
 	*front {
@@ -240,7 +251,7 @@ HelpBrowser {
 
 		webView.onLinkActivated = {|wv, url|
 			var redirected, newPath, oldPath;
-			redirected = this.redirectTextFile(url);
+			redirected = this.redirectTextFile(url) or: { HelpBrowser.redirectToSystemBrowser(url) };
 			if (not(redirected)) {
 				#newPath, oldPath = [url,webView.url].collect {|x|
 					if(x.notEmpty) {x.findRegexp("(^\\w+://)?([^#]+)(#.*)?")[1..].flop[1][1]}

--- a/SCClassLibrary/Common/GUI/tools/HelpBrowser.sc
+++ b/SCClassLibrary/Common/GUI/tools/HelpBrowser.sc
@@ -4,10 +4,10 @@ HelpBrowser {
 	classvar <>openNewWindows = false;
 	classvar <>scrollStep = 40;
 	classvar <>scrollPageStep = 350;
-	classvar <>redirectEnabled = true;
+
 	// redirect link addresses that match redirectPattern to default system browser
+	classvar <>redirectEnabled = true;
 	classvar <>redirectPattern = "^http";
-	// all http gets redirected
 
 	var <>homeUrl;
 	var <window;
@@ -44,7 +44,7 @@ HelpBrowser {
 		^(redirectEnabled and: { redirectPattern.matchRegexp(url) })
 	}
 
-	*prRedirectMenu { |url, openInSCIDE|
+	*prOpenRedirectMenu { |url, useSCIDE|
 		var info = MenuAction("Choose how to open external link:").enabled_(false);
 		var domain = MenuAction(if(url.size < 75) {url} {url.replaceRegexp("https?:\/\/|(/.*)", "")} ).enabled_(false);
 		var separator = MenuAction().separator_(true);
@@ -54,15 +54,14 @@ HelpBrowser {
 		var menu = Menu(info, domain, separator, systemDefaultBrowser, helpBrowser, closeMenu);
 		var removeDependants = { [systemDefaultBrowser, helpBrowser, closeMenu].do(_.removeDependant)  };
 		systemDefaultBrowser.addDependant { |action, what| if (what == \triggered) { url.openOS; removeDependants.() } };
-		helpBrowser.addDependant { |action, what| if (what == \triggered) { this.prIDEorHelpBrowser(url, openInSCIDE); removeDependants.() } };
+		helpBrowser.addDependant { |action, what| if (what == \triggered) { this.prOpenInIDEorHelpBrowser(url, useSCIDE); removeDependants.() } };
 		^menu.front;
 	}
 
-	*prIDEorHelpBrowser { | url, openInSCIDE |
-		// when openInSCIDE = false, will open in a HelpBrowser instance.
+	*prOpenInIDEorHelpBrowser { | url, useSCIDE(true) |
+		// when useSCIDE = false, will open in a HelpBrowser instance.
 		var ideClass = \ScIDE.asClass;
-		openInSCIDE ?? { openInSCIDE = true };
-		if(ideClass.notNil and: openInSCIDE) {
+		if(ideClass.notNil and: useSCIDE) {
 			ideClass.openHelpUrl(url)
 		} {
 			this.front.goTo(url)
@@ -71,9 +70,9 @@ HelpBrowser {
 
 	*goTo {|url|
 		if(this.prShouldRedirect(url)) {
-			this.prRedirectMenu(url)
+			this.prOpenRedirectMenu(url)
 		} {
-			this.prIDEorHelpBrowser(url)
+			this.prOpenInIDEorHelpBrowser(url)
 		}
 	}
 
@@ -275,7 +274,7 @@ HelpBrowser {
 			var newPath, oldPath;
 			if( not(this.redirectTextFile(url)) ) {
 				if( HelpBrowser.prShouldRedirect(url)) {
-					HelpBrowser.prRedirectMenu(url, openInSCIDE: false)
+					HelpBrowser.prOpenRedirectMenu(url, useSCIDE: false);
 				} {
 					#newPath, oldPath = [url,webView.url].collect {|x|
 					if(x.notEmpty) {x.findRegexp("(^\\w+://)?([^#]+)(#.*)?")[1..].flop[1][1]}

--- a/SCClassLibrary/Common/GUI/tools/HelpBrowser.sc
+++ b/SCClassLibrary/Common/GUI/tools/HelpBrowser.sc
@@ -37,10 +37,12 @@ HelpBrowser {
 	}
 
 
-	*redirectToSystemBrowser { |url|
-			if(url.contains("http")) {
-				url.replaceRegexp("https?", "https").openOS;
-				(url ++ " opened in system browser").postln;
+	*prRedirectToSystemBrowser { |url|
+			url = url.asString;
+			redirectPattern = "^https?:\/\/(?!127.*|localhost)";
+			// matches all http except for loopback/localhost (IPv4)
+			if(redirectPattern.matchRegex(url)) {
+				url.openOS;
 				^true
 			} {
 				^false
@@ -49,9 +51,9 @@ HelpBrowser {
 
 	*goTo {|url|
 		var ideClass = \ScIDE.asClass;
-		var redirected = HelpBrowser.redirectToSystemBrowser(url);
+		var redirected = HelpBrowser.prRedirectToSystemBrowser(url);
 		case
-		{ redirected } { ^nil }
+		{ redirected } { (url ++ " opened in system browser").postln; }
 		{ ideClass.notNil } { ideClass.openHelpUrl(url) }
 		{ this.front.goTo(url) };
 	}
@@ -251,8 +253,10 @@ HelpBrowser {
 
 		webView.onLinkActivated = {|wv, url|
 			var redirected, newPath, oldPath;
-			redirected = this.redirectTextFile(url) or: { HelpBrowser.redirectToSystemBrowser(url) };
-			if (not(redirected)) {
+			case
+			{ HelpBrowser.prRedirectToSystemBrowser(url) } { (url ++ " opened in system browser").postln; }
+			{ this.redirectTextFile(url) } { ^nil }
+			{
 				#newPath, oldPath = [url,webView.url].collect {|x|
 					if(x.notEmpty) {x.findRegexp("(^\\w+://)?([^#]+)(#.*)?")[1..].flop[1][1]}
 				};

--- a/SCClassLibrary/Common/GUI/tools/HelpBrowser.sc
+++ b/SCClassLibrary/Common/GUI/tools/HelpBrowser.sc
@@ -45,19 +45,23 @@ HelpBrowser {
 	}
 
 	*prRedirectMenu { |url, openInSCIDE|
+		var info = MenuAction("Choose how to open external link:\n").enabled_(false);
+		var domain = MenuAction(if(url.size < 75) {url} {url.replaceRegexp("https?:\/\/|(/.*)", "")} ).enabled_(false);
+		var separator = MenuAction().separator_(true);
 		var systemDefaultBrowser = MenuAction("Open in system default browser");
-		var helpBrowser = MenuAction("Open in sclang HelpBrowser (unsafe)");
-		var closeMenu = MenuAction("Do not open");
-		var menu = Menu(systemDefaultBrowser, helpBrowser, closeMenu);
+		var helpBrowser = MenuAction("Open in SuperCollider's help browser (unsafe)");
+		var closeMenu = MenuAction("Cancel");
+		var menu = Menu(info, domain, separator, systemDefaultBrowser, helpBrowser, closeMenu);
 		var removeDependants = { [systemDefaultBrowser, helpBrowser, closeMenu].do(_.removeDependant)  };
 		systemDefaultBrowser.addDependant { |action, what| if (what == \triggered) { url.openOS; removeDependants.() } };
 		helpBrowser.addDependant { |action, what| if (what == \triggered) { this.prIDEorHelpBrowser(url, openInSCIDE); removeDependants.() } };
 		^menu.front;
 	}
 
-	*prIDEorHelpBrowser { | url, openInSCIDE = true |
+	*prIDEorHelpBrowser { | url, openInSCIDE |
 		// when openInSCIDE = false, will open in a HelpBrowser instance.
 		var ideClass = \ScIDE.asClass;
+		openInSCIDE ?? { openInSCIDE = true };
 		if(ideClass.notNil and: openInSCIDE) {
 			ideClass.openHelpUrl(url)
 		} {

--- a/SCClassLibrary/Common/GUI/tools/HelpBrowser.sc
+++ b/SCClassLibrary/Common/GUI/tools/HelpBrowser.sc
@@ -40,25 +40,37 @@ HelpBrowser {
 		^super.new.init( aHomeUrl ? defaultHomeUrl, newWin ?? { openNewWindows } );
 	}
 
+	*prShouldRedirect {|url|
+		^(redirectEnabled and: { redirectPattern.matchRegexp(url) })
+	}
 
-	*prRedirectToSystemBrowser { |url|
-			url = url.asString;
-			if(redirectEnabled and: { redirectPattern.matchRegexp(url) }) {
-				url.openOS;
-				(url ++ " opened in system browser").postln;
-				^true
-			} {
-				^false
-			}
+	*prRedirectMenu { |url, openInSCIDE|
+		var systemDefaultBrowser = MenuAction("Open in system default browser");
+		var helpBrowser = MenuAction("Open in sclang HelpBrowser (unsafe)");
+		var closeMenu = MenuAction("Do not open");
+		var menu = Menu(systemDefaultBrowser, helpBrowser, closeMenu);
+		var removeDependants = { [systemDefaultBrowser, helpBrowser, closeMenu].do(_.removeDependant)  };
+		systemDefaultBrowser.addDependant { |action, what| if (what == \triggered) { url.openOS; removeDependants.() } };
+		helpBrowser.addDependant { |action, what| if (what == \triggered) { this.prIDEorHelpBrowser(url, openInSCIDE); removeDependants.() } };
+		^menu.front;
+	}
+
+	*prIDEorHelpBrowser { | url, openInSCIDE = true |
+		// when openInSCIDE = false, will open in a HelpBrowser instance.
+		var ideClass = \ScIDE.asClass;
+		if(ideClass.notNil and: openInSCIDE) {
+			ideClass.openHelpUrl(url)
+		} {
+			this.front.goTo(url)
+		}
 	}
 
 	*goTo {|url|
-		var ideClass = \ScIDE.asClass;
-		var redirected = HelpBrowser.prRedirectToSystemBrowser(url);
-		case
-		{ redirected } { ^nil }
-		{ ideClass.notNil } { ideClass.openHelpUrl(url) }
-		{ this.front.goTo(url) };
+		if(this.prShouldRedirect(url)) {
+			this.prRedirectMenu(url)
+		} {
+			this.prIDEorHelpBrowser(url)
+		}
 	}
 
 	*front {
@@ -153,6 +165,7 @@ HelpBrowser {
 		var x, y, w, h;
 		var str;
 
+		if (not(openNewWindows)) { singleton = this };
 		homeUrl = aHomeUrl;
 
 		winRect = Rect(0, 0, 800, (Window.screenBounds.height * 0.8).floor);
@@ -255,18 +268,21 @@ HelpBrowser {
 		webView.onLoadFailed = { this.stopAnim };
 
 		webView.onLinkActivated = {|wv, url|
-			var redirected, newPath, oldPath;
-			redirected = this.redirectTextFile(url) or: { HelpBrowser.prRedirectToSystemBrowser(url) };
-			if (not(redirected)) {
-				#newPath, oldPath = [url,webView.url].collect {|x|
-					if(x.notEmpty) {x.findRegexp("(^\\w+://)?([^#]+)(#.*)?")[1..].flop[1][1]}
-				};
-
-				if(newPath != oldPath && openNewWin) {
-						HelpBrowser.new(newWin:openNewWin).goTo(url);
+			var newPath, oldPath;
+			if( not(this.redirectTextFile(url)) ) {
+				if( HelpBrowser.prShouldRedirect(url)) {
+					HelpBrowser.prRedirectMenu(url, openInSCIDE: false)
 				} {
-					this.goTo(url);
-				};
+					#newPath, oldPath = [url,webView.url].collect {|x|
+					if(x.notEmpty) {x.findRegexp("(^\\w+://)?([^#]+)(#.*)?")[1..].flop[1][1]}
+					};
+			
+					if(newPath != oldPath && openNewWin) {
+							HelpBrowser.new(newWin:openNewWin).goTo(url);
+					} {
+						this.goTo(url);
+					}
+				}
 			}
 		};
 


### PR DESCRIPTION
Clicking on web links now opens a menu that gives user the option to open the link in either system default web browser or the web-unsafe built-in help browser.
I made sure this works both in the SCIDE helpbrowser and the one created through HelpBrowser.new(). 

added classvars:
redirectEnabled: whether to open that menu at all
redirectPattern: the regex pattern that determines what gets redirected.

added methods:
prShouldRedirect (a test whether to redirect at all)
prRedirectMenu (code for the actual menu)
prIDEorHelpBrowser (we need slightly different behavior depending on whether you're working with the IDE help browser or an instance of HelpBrowser).

code is tested and documented.

<details><summary>out of date or resolved</summary>
<p>

add *redirectToSystemBrowser class method to HelpBrowser class, 
which is used in *goTo (for IDE Helpbrowser) and 
webView.onLinkActivated in HelpBrowser.init.

Tested both and they work, for all I can tell. 
What they don't (and probably can't) do is bring the system browser to front, 
so instead they post to the post window to let the user know that the web site has indeed been opened. 
I wonder if there's an easy way to make this message a different color, or make it bold? I could see the message getting overlooked, and people not realizing that the site has opened in another application. 
(Otoh, this is neither a warning nor an error, so I don't want to use either .warn or .error)

@prko suggested that the forwarding to system browser should not happen with loopback addresses. For now I haven't added this (basically just another test), because I'm not sure why one would use this in the helpbrowser (I had to look up what loopback addresses even are). But no problem to add that if someone gives me an example.

The .replaceRegex to ensure https may be unnecessary, I can imagine that the scdoc parser already does something similar... 

What we don't have with this PR is a way to force opening websites in the helpbrowser (ide or not), say by ctrl-clicking or something. This isn't something I know how to do off the bat, but probably we don't need it anyway?

</p>
</details> 
