### PR TITLE
Group.queryTree: implement optional arg, updated example in Group.schelp

### DIFF
--- a/HelpSource/Classes/Group.schelp
+++ b/HelpSource/Classes/Group.schelp
@@ -147,7 +147,7 @@ method:: queryTree
 Near-duplicate of code::.dumpTree.:: Queries the server for a message describing this group's node subtree.
 Sends a server message of the type teletype::/g_queryTree::; the server's reply is automatically parsed in the post window.
 When you use the code::.queryTree:: method, you cannot customize this parsing; this is only possible when sending the server command directly.
-See teletype::/g_queryTree:: in the link::Reference/Server-Command-Reference#g_queryTree#Server Command Reference::.
+See teletype::/g_queryTree:: in the link::Reference/Server-Command-Reference#/g_queryTree#Server Command Reference::.
 
 
 Examples::

--- a/HelpSource/Classes/Group.schelp
+++ b/HelpSource/Classes/Group.schelp
@@ -144,11 +144,13 @@ If code::postControls:: is true, then the current Control (arg) values for any s
 The default is false.
 
 method:: queryTree
-Near-duplicate of code::.dumpTree.:: Queries the server for a message describing this group's node subtree.
-Sends a server message of the type teletype::/g_queryTree::; if no argument is provided, the server's reply is automatically parsed in the post window.
-Alternatively, a link::Classes/Function:: can be provided as an teletype::action:: argument, for instance: 
-code:: 
-Group().queryTree( { |msg| msg.postln });
+Queries the server for a message describing this group's node subtree.
+Similar to to code::.dumpTree::, but with the difference that code::.queryTree:: permits
+custom handling of the server's reply message when an teletype::action:: argument is provided. 
+When no argument is provided to code::.queryTree::, the output resembles that of code::.dumpTree::.
+code::
+Group().queryTree; // default reply handler.
+Group().queryTree( { |msg| msg.postln }); // custom (but very boring) reply handler.
 ::
 See teletype::/g_queryTree:: in the link::Reference/Server-Command-Reference#/g_queryTree#Server Command Reference::.
 

--- a/HelpSource/Classes/Group.schelp
+++ b/HelpSource/Classes/Group.schelp
@@ -139,10 +139,15 @@ method:: deepFree, deepFreeMsg
 Free all Synths in the group, and all Synths in any enclosed groups, but do not free this group or any of its enclosed groups.
 
 method:: dumpTree
-Post a representation of this group's node subtree. (Sends a message of the type g_dumpTree.) If code::postControls:: is true, then the current Control (arg) values for any synths contained in this group will be posted as well. The default is false.
+Post a representation of this group's node subtree. (Sends a message of the type teletype::g_dumpTree::.)
+If code::postControls:: is true, then the current Control (arg) values for any synths contained in this group will be posted as well.
+The default is false.
 
 method:: queryTree
-Queries the server for a message describing this group's node subtree. (Sends a message of the type g_queryTree.) This reply is passed to the action function as an argument. See g_queryTree in link::Reference/Server-Command-Reference:: or the example below for information on how the reply is structured.
+Near-duplicate of code::.dumpTree.:: Queries the server for a message describing this group's node subtree.
+Sends a server message of the type teletype::/g_queryTree::; the server's reply is automatically parsed in the post window.
+When you use the code::.queryTree:: method, you cannot customize this parsing; this is only possible when sending the server command directly.
+See teletype::/g_queryTree:: in the link::Reference/Server-Command-Reference#g_queryTree#Server Command Reference::.
 
 
 Examples::
@@ -233,28 +238,8 @@ g.query;
 });
 )
 
-// now query my tree and post a graph of it (duplicates dumpTree)
-// msg format is ['/g_querytree.reply', node1-ID, numChildren, defName, child1-ID, numChildren, ...]
-(
-g.queryTree({ |msg|
-	var i = 1, tabs = 0, dumpFunc;
-	("NODE TREE Group" + msg[1]).postln;
-	if(msg[2] > 0, {
-		dumpFunc = { |numChildren|
-			tabs = tabs + 1;
-			numChildren.do({
-				i = i + 3;
-				tabs.do({ "   ".post });
-				msg[i].post;
-				(" " ++ msg[i + 2]).postln;
-				if(msg[i + 1] > 0, { dumpFunc.value(msg[i + 1]) });
-			});
-			tabs = tabs - 1;
-		};
-		dumpFunc.value(msg[2]);
-	});
-});
-)
+// now query my tree and post a graph of it (mostly duplicates dumpTree)
+g.queryTree;
 
 // kill me and my children
 g.free;

--- a/HelpSource/Classes/Group.schelp
+++ b/HelpSource/Classes/Group.schelp
@@ -145,8 +145,11 @@ The default is false.
 
 method:: queryTree
 Near-duplicate of code::.dumpTree.:: Queries the server for a message describing this group's node subtree.
-Sends a server message of the type teletype::/g_queryTree::; the server's reply is automatically parsed in the post window.
-When you use the code::.queryTree:: method, you cannot customize this parsing; this is only possible when sending the server command directly.
+Sends a server message of the type teletype::/g_queryTree::; if no argument is provided, the server's reply is automatically parsed in the post window.
+Alternatively, a link::Classes/Function:: can be provided as an teletype::action:: argument, for instance: 
+code:: 
+Group().queryTree( { |msg| msg.postln });
+::
 See teletype::/g_queryTree:: in the link::Reference/Server-Command-Reference#/g_queryTree#Server Command Reference::.
 
 
@@ -240,6 +243,9 @@ g.query;
 
 // now query my tree and post a graph of it (mostly duplicates dumpTree)
 g.queryTree;
+
+// or if you prefer it unformatted:
+g.queryTree( { |msg| msg.postln });
 
 // kill me and my children
 g.free;

--- a/SCClassLibrary/Common/Control/Node.sc
+++ b/SCClassLibrary/Common/Control/Node.sc
@@ -350,53 +350,59 @@ AbstractGroup : Node {
 		server.sendMsg("/g_dumpTree", nodeID, postControls.binaryValue)
 	}
 
-	queryTree { //|action|
-		var resp, done = false;
-		resp = OSCFunc({ arg msg;
-			var i = 2, tabs = 0, printControls = false, dumpFunc;
-			if(msg[1] != 0, { printControls = true });
-			("NODE TREE Group" + msg[2]).postln;
-			if(msg[3] > 0, {
-				dumpFunc = {|numChildren|
-					var j;
-					tabs = tabs + 1;
-					numChildren.do({
-						if(msg[i + 1] >=0, {i = i + 2}, {
-							i = i + 3 + if(printControls, { msg[i + 3] * 2 + 1 }, { 0 });
-						});
-						tabs.do({ "  ".post });
-						msg[i].post; // nodeID
-						if(msg[i + 1] >= 0, {
-							" group".postln;
-							if(msg[i + 1] > 0, { dumpFunc.value(msg[i + 1]) });
-						}, {
-							(" " ++ msg[i + 2]).postln; // defname
-							if(printControls, {
-								if(msg[i + 3] > 0, {
-									" ".post;
-									tabs.do({ "  ".post });
-								});
-								j = 0;
-								msg[i + 3].do({
-									" ".post;
-									if(msg[i + 4 + j].isMemberOf(Symbol), {
-										(msg[i + 4 + j] ++ ": ").post;
+	queryTree { | action |
+		// FIXME: this only works in scsynth. in supernova, the handle_g_queryTree primitive fails
+		// it needs to be passed an endpoint arg, and this somehow doesn't happen.
+		
+		// when a custom action is provided,
+		// suppress server-failed-to-respond warning by setting done to true
+		var resp, done = action.notNil;
+		action = action ?? {
+			{ arg msg;
+				var i = 2, tabs = 0, printControls = false, dumpFunc;
+				if(msg[1] != 0, { printControls = true });
+				("NODE TREE Group" + msg[2]).postln;
+				if(msg[3] > 0, {
+					dumpFunc = {|numChildren|
+						var j;
+						tabs = tabs + 1;
+						numChildren.do({
+							if(msg[i + 1] >=0, {i = i + 2}, {
+								i = i + 3 + if(printControls, { msg[i + 3] * 2 + 1 }, { 0 });
+							});
+							tabs.do({ "  ".post });
+							msg[i].post; // nodeID
+							if(msg[i + 1] >= 0, {
+								" group".postln;
+								if(msg[i + 1] > 0, { dumpFunc.value(msg[i + 1]) });
+							}, {
+								(" " ++ msg[i + 2]).postln; // defname
+								if(printControls, {
+									if(msg[i + 3] > 0, {
+										" ".post;
+										tabs.do({ "  ".post });
 									});
-									msg[i + 5 + j].post;
-									j = j + 2;
+									j = 0;
+									msg[i + 3].do({
+										" ".post;
+										if(msg[i + 4 + j].isMemberOf(Symbol), {
+											(msg[i + 4 + j] ++ ": ").post;
+										});
+										msg[i + 5 + j].post;
+										j = j + 2;
+									});
+									"\n".post;
 								});
-								"\n".post;
 							});
 						});
-					});
-					tabs = tabs - 1;
-				};
-				dumpFunc.value(msg[3]);
-			});
-
-			//				action.value(msg);
-			done = true;
-		}, '/g_queryTree.reply', server.addr).oneShot;
+						tabs = tabs - 1;
+					};
+					dumpFunc.value(msg[3]);
+				});
+				done = true;
+			}
+		};
+		resp = OSCFunc(action, '/g_queryTree.reply', server.addr).oneShot;
 
 		server.sendMsg("/g_queryTree", nodeID);
 


### PR DESCRIPTION
Group.query tree does not take arguments since 2007, ~~so the current method description and the example are outdated~~ but now it does. This PR
* adds the option to pass an arg
* ~~removes the example~~ simplifies the example
* _sligthly_ updates the method description
*  also formatting changes to method desc of dumpTree

Types of changes:
- Documentation
- class library

I think this still qualifies as a minor change, even though it's more than a quick fix... I'll leave the PR up until next weekend,  ~~then I'll merge it myself unless someone disagrees or just merges it themselves~~ nah I forgot I still need an approving review before I can merge.

Thanks!