### PR TITLE
sclang: fix non-local return

### DIFF
--- a/lang/LangPrimSource/PyrPrimitive.cpp
+++ b/lang/LangPrimSource/PyrPrimitive.cpp
@@ -1003,6 +1003,7 @@ HOT int blockValueWithKeys(struct VMGlobals* g, int allArgsPushed, int numKeyArg
     g->sp = args - 1;
     g->ip = slotRawInt8Array(&block->code)->b - 1;
     g->frame = frame;
+    g->frame->expected_stack_depth_after_return = PyrSlot::make(static_cast<int>(g->gc->StackDepth() + 1));
     g->block = block;
 
     return errNone;
@@ -3612,7 +3613,7 @@ void doPrimitive(VMGlobals* g, PyrMethod* meth, int numArgsPushed) {
         // slotRawSymbol(&meth->name)->name);
         SetInt(&g->thread->primitiveIndex, methraw->specialIndex);
         SetInt(&g->thread->primitiveError, err);
-        executeMethod(g, meth, numArgsNeeded, 0);
+        setupForMethod(g, meth, numArgsNeeded, 0);
     }
 #ifdef GC_SANITYCHECK
     g->gc->SanityCheck();
@@ -3658,7 +3659,7 @@ void doPrimitiveWithKeys(VMGlobals* g, PyrMethod* meth, int allArgsPushed, int n
             // post("primerr %d\n", err);
             SetInt(&g->thread->primitiveIndex, methraw->specialIndex);
             SetInt(&g->thread->primitiveError, err);
-            executeMethod(g, meth, allArgsPushed, numKeyArgsPushed);
+            setupForMethod(g, meth, allArgsPushed, numKeyArgsPushed);
         }
 #ifdef GC_SANITYCHECK
         g->gc->SanityCheck();
@@ -3736,7 +3737,7 @@ void doPrimitiveWithKeys(VMGlobals* g, PyrMethod* meth, int allArgsPushed, int n
         // post("primerr %d\n", err);
         SetInt(&g->thread->primitiveIndex, methraw->specialIndex);
         SetInt(&g->thread->primitiveError, err);
-        executeMethod(g, meth, numArgsNeeded, 0);
+        setupForMethod(g, meth, numArgsNeeded, 0);
     }
 #ifdef GC_SANITYCHECK
     g->gc->SanityCheck();

--- a/lang/LangSource/GC.cpp
+++ b/lang/LangSource/GC.cpp
@@ -26,7 +26,6 @@
 #include "InitAlloc.h"
 #include <limits>
 #include <string.h>
-#include <stdexcept>
 #include "PyrLexer.h"
 
 #define PAUSETIMES 0
@@ -391,17 +390,28 @@ HOT PyrObject* PyrGC::NewFrame(size_t inNumBytes, std::int64_t inFlags, std::int
 #endif
 
     // obtain size info
+    // obtain size info
+    const size_t alignedSize = (inNumBytes + kAlignMask) & ~kAlignMask; // 16 byte align
+    const size_t numSlots = std::max<size_t>(alignedSize / sizeof(PyrSlot), 1);
 
-    int32 alignedSize = (inNumBytes + kAlignMask) & ~kAlignMask; // 16 byte align
-    int32 numSlots = alignedSize / sizeof(PyrSlot);
-    numSlots = numSlots < 1 ? 1 : numSlots;
-    int32 sizeclass = LOG2CEIL(numSlots);
-    sizeclass = sc_min(sizeclass, kNumGCSizeClasses - 1);
+    // LOG2CEIL currently only accepts ints, so we make sure that numSlots does not exceed
+    // the maximum sizeclass value (which is guaranteed to fit into an int32).
+    static constexpr auto maxSizeClass = kNumGCSizeClasses - 1;
 
-    int32 credit = 1LL << sizeclass;
+    static constexpr size_t maxCredit = 1ULL << (maxSizeClass);
+    static_assert(maxCredit <= std::numeric_limits<int32>::max());
+
+    // If numSlots is smaller than maxSizeClass, it is also guaranteed to fit into an int32
+    // and so it is safe to call LOG2CEIL.
+    const int32 sizeclass = (numSlots >= maxCredit) ? maxSizeClass : LOG2CEIL(static_cast<int32>(numSlots));
+
+    // If the object fits inside a size band, credit is the true number of slots allocated.
+    // If is doesn't, then this is dealt with separately through classification as a 'large' object.
+    const size_t credit = 1ULL << sizeclass;
+
     mAllocTotal += credit;
-    mNumAllocs++;
     mNumToScan += credit;
+    mNumAllocs++;
 
     obj = Allocate(inNumBytes, sizeclass, inAccount);
 

--- a/lang/LangSource/PyrInterpreter3.cpp
+++ b/lang/LangSource/PyrInterpreter3.cpp
@@ -39,6 +39,7 @@
 #include <string.h>
 #include <signal.h>
 #include "SpecialSelectorsOperatorsAndClasses.h"
+#include "VMGlobals.h"
 
 #include <float.h>
 #define kBigBigFloat DBL_MAX
@@ -511,14 +512,24 @@ static inline void checkStackDepth(VMGlobals* g, PyrSlot* sp) {
 #    pragma GCC optimize("-fno-gcse")
 #endif
 
+// Enable this to print each opcode and the stack size
+#if 0
+#    include <iostream>
+#    define LogOpcode(NAME)                                                                                            \
+        { std::cout << NAME.name << ' ' << g->gc->StackDepth() << '\n'; };
+#else
+#    define LogOpcode(NAME)
+#endif
 
 /// Pass the name of an Opcode struct, e.g. InterpretOpcode(SendMsgX)
 /// Setups of a switch case and a label for the computed gotos.
 #define InterpretOpcode(NAME)                                                                                          \
     case NAME.code:                                                                                                    \
-        opcode_label_##NAME:
+        opcode_label_##NAME : LogOpcode(NAME);
 
-#define InterpretExtendedOpcode(NAME) case Extended::NAME.code:
+#define InterpretExtendedOpcode(NAME)                                                                                  \
+    case Extended::NAME.code:                                                                                          \
+        LogOpcode(NAME);
 
 /// Pass the name of an Opcode struct that has 16 variants in the second nibble, e.g. InterpretOpcode16(PushInstVar)
 /// Setups of a switch case and a label for the computed gotos.
@@ -539,7 +550,7 @@ static inline void checkStackDepth(VMGlobals* g, PyrSlot* sp) {
     case NAME.codeOffset<13>():                                                                                        \
     case NAME.codeOffset<14>():                                                                                        \
     case NAME.codeOffset<15>():                                                                                        \
-        opcode_label_##NAME:
+        opcode_label_##NAME : LogOpcode(NAME)
 
 #define InterpretOpcode15(NAME)                                                                                        \
     case NAME.codeOffset<0>():                                                                                         \
@@ -557,7 +568,7 @@ static inline void checkStackDepth(VMGlobals* g, PyrSlot* sp) {
     case NAME.codeOffset<12>():                                                                                        \
     case NAME.codeOffset<13>():                                                                                        \
     case NAME.codeOffset<14>():                                                                                        \
-        opcode_label_##NAME:
+        opcode_label_##NAME : LogOpcode(NAME)
 
 #define InterpretOpcode14(NAME)                                                                                        \
     case NAME.codeOffset<0>():                                                                                         \
@@ -574,7 +585,7 @@ static inline void checkStackDepth(VMGlobals* g, PyrSlot* sp) {
     case NAME.codeOffset<11>():                                                                                        \
     case NAME.codeOffset<12>():                                                                                        \
     case NAME.codeOffset<13>():                                                                                        \
-        opcode_label_##NAME:
+        opcode_label_##NAME : LogOpcode(NAME)
 
 #define InterpretOpcode7(NAME)                                                                                         \
     case NAME.codeOffset<0>():                                                                                         \
@@ -584,7 +595,7 @@ static inline void checkStackDepth(VMGlobals* g, PyrSlot* sp) {
     case NAME.codeOffset<4>():                                                                                         \
     case NAME.codeOffset<5>():                                                                                         \
     case NAME.codeOffset<6>():                                                                                         \
-        opcode_label_##NAME:
+        opcode_label_##NAME : LogOpcode(NAME)
 
 #define InterpretOpcode8(NAME)                                                                                         \
     case NAME.codeOffset<0>():                                                                                         \
@@ -595,7 +606,7 @@ static inline void checkStackDepth(VMGlobals* g, PyrSlot* sp) {
     case NAME.codeOffset<5>():                                                                                         \
     case NAME.codeOffset<6>():                                                                                         \
     case NAME.codeOffset<7>():                                                                                         \
-        opcode_label_##NAME:
+        opcode_label_##NAME : LogOpcode(NAME)
 
 #define InterpretOpcode9(NAME)                                                                                         \
     case NAME.codeOffset<0>():                                                                                         \
@@ -607,14 +618,14 @@ static inline void checkStackDepth(VMGlobals* g, PyrSlot* sp) {
     case NAME.codeOffset<6>():                                                                                         \
     case NAME.codeOffset<7>():                                                                                         \
     case NAME.codeOffset<8>():                                                                                         \
-        opcode_label_##NAME:
+        opcode_label_##NAME : LogOpcode(NAME)
 
 #define InterpretOpcode4(NAME)                                                                                         \
     case NAME.codeOffset<0>():                                                                                         \
     case NAME.codeOffset<1>():                                                                                         \
     case NAME.codeOffset<2>():                                                                                         \
     case NAME.codeOffset<3>():                                                                                         \
-        opcode_label_##NAME:
+        opcode_label_##NAME : LogOpcode(NAME)
 
 HOT void Interpret(VMGlobals* g) {
     // byte code values
@@ -2261,7 +2272,7 @@ HOT void Interpret(VMGlobals* g) {
 
             switch (methraw->methType) {
             case methNormal:
-                storeLoadSpAndIp([&]() { executeMethod(g, meth, numArgsPushed, 0); });
+                storeLoadSpAndIp([&]() { setupForMethod(g, meth, numArgsPushed, 0); });
                 break;
 
             case methReturnSelf:
@@ -2374,7 +2385,7 @@ HOT void Interpret(VMGlobals* g) {
 
             switch (methraw->methType) {
             case methNormal:
-                storeLoadSpAndIp([&]() { executeMethod(g, meth, numArgsPushed, numKeyArgsPushed); });
+                storeLoadSpAndIp([&]() { setupForMethod(g, meth, numArgsPushed, numKeyArgsPushed); });
                 break;
 
             case methReturnSelf:

--- a/lang/LangSource/PyrInterpreter3.cpp
+++ b/lang/LangSource/PyrInterpreter3.cpp
@@ -512,24 +512,14 @@ static inline void checkStackDepth(VMGlobals* g, PyrSlot* sp) {
 #    pragma GCC optimize("-fno-gcse")
 #endif
 
-// Enable this to print each opcode and the stack size
-#if 0
-#    include <iostream>
-#    define LogOpcode(NAME)                                                                                            \
-        { std::cout << NAME.name << ' ' << g->gc->StackDepth() << '\n'; };
-#else
-#    define LogOpcode(NAME)
-#endif
 
 /// Pass the name of an Opcode struct, e.g. InterpretOpcode(SendMsgX)
 /// Setups of a switch case and a label for the computed gotos.
 #define InterpretOpcode(NAME)                                                                                          \
     case NAME.code:                                                                                                    \
-        opcode_label_##NAME : LogOpcode(NAME);
+        opcode_label_##NAME:
 
-#define InterpretExtendedOpcode(NAME)                                                                                  \
-    case Extended::NAME.code:                                                                                          \
-        LogOpcode(NAME);
+#define InterpretExtendedOpcode(NAME) case Extended::NAME.code:
 
 /// Pass the name of an Opcode struct that has 16 variants in the second nibble, e.g. InterpretOpcode16(PushInstVar)
 /// Setups of a switch case and a label for the computed gotos.
@@ -550,7 +540,7 @@ static inline void checkStackDepth(VMGlobals* g, PyrSlot* sp) {
     case NAME.codeOffset<13>():                                                                                        \
     case NAME.codeOffset<14>():                                                                                        \
     case NAME.codeOffset<15>():                                                                                        \
-        opcode_label_##NAME : LogOpcode(NAME)
+        opcode_label_##NAME:
 
 #define InterpretOpcode15(NAME)                                                                                        \
     case NAME.codeOffset<0>():                                                                                         \
@@ -568,7 +558,7 @@ static inline void checkStackDepth(VMGlobals* g, PyrSlot* sp) {
     case NAME.codeOffset<12>():                                                                                        \
     case NAME.codeOffset<13>():                                                                                        \
     case NAME.codeOffset<14>():                                                                                        \
-        opcode_label_##NAME : LogOpcode(NAME)
+        opcode_label_##NAME:
 
 #define InterpretOpcode14(NAME)                                                                                        \
     case NAME.codeOffset<0>():                                                                                         \
@@ -585,7 +575,7 @@ static inline void checkStackDepth(VMGlobals* g, PyrSlot* sp) {
     case NAME.codeOffset<11>():                                                                                        \
     case NAME.codeOffset<12>():                                                                                        \
     case NAME.codeOffset<13>():                                                                                        \
-        opcode_label_##NAME : LogOpcode(NAME)
+        opcode_label_##NAME:
 
 #define InterpretOpcode7(NAME)                                                                                         \
     case NAME.codeOffset<0>():                                                                                         \
@@ -595,7 +585,7 @@ static inline void checkStackDepth(VMGlobals* g, PyrSlot* sp) {
     case NAME.codeOffset<4>():                                                                                         \
     case NAME.codeOffset<5>():                                                                                         \
     case NAME.codeOffset<6>():                                                                                         \
-        opcode_label_##NAME : LogOpcode(NAME)
+        opcode_label_##NAME:
 
 #define InterpretOpcode8(NAME)                                                                                         \
     case NAME.codeOffset<0>():                                                                                         \
@@ -606,7 +596,7 @@ static inline void checkStackDepth(VMGlobals* g, PyrSlot* sp) {
     case NAME.codeOffset<5>():                                                                                         \
     case NAME.codeOffset<6>():                                                                                         \
     case NAME.codeOffset<7>():                                                                                         \
-        opcode_label_##NAME : LogOpcode(NAME)
+        opcode_label_##NAME:
 
 #define InterpretOpcode9(NAME)                                                                                         \
     case NAME.codeOffset<0>():                                                                                         \
@@ -618,14 +608,14 @@ static inline void checkStackDepth(VMGlobals* g, PyrSlot* sp) {
     case NAME.codeOffset<6>():                                                                                         \
     case NAME.codeOffset<7>():                                                                                         \
     case NAME.codeOffset<8>():                                                                                         \
-        opcode_label_##NAME : LogOpcode(NAME)
+        opcode_label_##NAME:
 
 #define InterpretOpcode4(NAME)                                                                                         \
     case NAME.codeOffset<0>():                                                                                         \
     case NAME.codeOffset<1>():                                                                                         \
     case NAME.codeOffset<2>():                                                                                         \
     case NAME.codeOffset<3>():                                                                                         \
-        opcode_label_##NAME : LogOpcode(NAME)
+        opcode_label_##NAME:
 
 HOT void Interpret(VMGlobals* g) {
     // byte code values

--- a/lang/LangSource/PyrKernel.h
+++ b/lang/LangSource/PyrKernel.h
@@ -82,10 +82,13 @@ struct PyrFrame : public PyrObjectHdr {
     PyrSlot context;
     PyrSlot homeContext;
     PyrSlot ip;
+    // For non-local returns, sometimes we need to remove stuff from the stack.
+    // This allows us to do that.
+    PyrSlot expected_stack_depth_after_return;
     PyrSlot vars[1];
 };
 
-#define FRAMESIZE 5
+#define FRAMESIZE 6
 
 struct PyrProcess : public PyrObjectHdr {
     PyrSlot classVars;

--- a/lang/LangSource/PyrMessage.cpp
+++ b/lang/LangSource/PyrMessage.cpp
@@ -19,10 +19,12 @@
 */
 
 #include "PyrMessage.h"
+#include "PyrParseNode.h"
 #include "PyrPrimitiveProto.h"
 #include "PyrInterpreter.h"
 #include "PyrPrimitive.h"
 #include "PyrListPrim.h"
+#include "PyrSlot.h"
 #include "PyrSymbol.h"
 #include "GC.h"
 #include "PredefinedSymbols.h"
@@ -149,7 +151,7 @@ lookup_again:
     // The rest are some form of optimization.
     switch (methodRaw->methType) {
     case methNormal:
-        return executeMethod(g, method, numArgsPushed, numKeyArgsPushed);
+        return setupForMethod(g, method, numArgsPushed, numKeyArgsPushed);
 
     case methReturnSelf: {
         g->sp -= numArgsPushed - 1; // Remove all args but the receiver.
@@ -354,7 +356,7 @@ void doesNotUnderstand(VMGlobals* g, PyrSymbol* selector, std::int64_t numArgsPu
     if (tryUniqueMethod(g, method, receiverSlot, selectorSlot, numArgsPushed, numKeyArgsPushed))
         return;
 
-    executeMethod(g, method, numArgsPushed + 1, numKeyArgsPushed);
+    setupForMethod(g, method, numArgsPushed + 1, numKeyArgsPushed);
 }
 
 
@@ -508,6 +510,7 @@ inline PyrFrame* createFrameForExecuteMethod(VMGlobals* g, PyrBlock* block) {
     SetObject(&frame->method, block);
     SetObject(&frame->homeContext, frame);
     SetObject(&frame->context, frame);
+    frame->expected_stack_depth_after_return = PyrSlot {};
     if (PyrFrame* caller = g->frame; caller != nullptr) {
         SetPtr(&caller->ip, g->ip);
         SetObject(&frame->caller, caller);
@@ -518,7 +521,7 @@ inline PyrFrame* createFrameForExecuteMethod(VMGlobals* g, PyrBlock* block) {
     return frame;
 }
 
-HOT void executeMethod(VMGlobals* g, PyrBlock* meth, std::int64_t totalNumArgsPushed, std::int64_t numKwArgsPushed) {
+HOT void setupForMethod(VMGlobals* g, PyrBlock* meth, std::int64_t totalNumArgsPushed, std::int64_t numKwArgsPushed) {
     prepForTailCall(g);
     const GCSanityChecker gc_sanity_checker(g, "executeMethod");
 
@@ -532,6 +535,9 @@ HOT void executeMethod(VMGlobals* g, PyrBlock* meth, std::int64_t totalNumArgsPu
     g->block = (PyrBlock*)meth;
     g->sp -= totalNumArgsPushed;
     slotCopy(&g->receiver, callFrame->vars);
+
+    // Here, we are expecting this method to return one value to the stack (as all methods do).
+    g->frame->expected_stack_depth_after_return = PyrSlot::make(static_cast<int>(g->gc->StackDepth() + 1));
 }
 
 void switchToThread(VMGlobals* g, PyrThread* newthread, int oldstate, int* numArgsPushed);
@@ -636,6 +642,7 @@ HOT void returnFromMethod(VMGlobals* g) {
         g->frame = nullptr;
         longjmp(g->escapeInterpreter, 2);
     } else {
+        bool yieled = false;
         returnFrame = slotRawFrame(&homeContext->caller);
 
         if (returnFrame == nullptr)
@@ -659,6 +666,7 @@ HOT void returnFromMethod(VMGlobals* g) {
                         slotCopy(g->sp, &value);
 
                         curframe = tempFrame = g->frame;
+                        yieled = true;
                     } else {
                         slotCopy(&g->sp[2], &g->sp[0]);
                         slotCopy(g->sp, &g->receiver);
@@ -672,6 +680,9 @@ HOT void returnFromMethod(VMGlobals* g) {
             }
         }
 
+        std::uint32_t distance { 0 };
+        PyrFrame* one_before_return_frame { nullptr };
+
         {
             PyrFrame* tempFrame = curframe;
             while (tempFrame != returnFrame) {
@@ -684,6 +695,8 @@ HOT void returnFromMethod(VMGlobals* g) {
                     if (tempFrame != homeContext)
                         SetInt(&tempFrame->caller, 0);
                 }
+                ++distance;
+                one_before_return_frame = tempFrame;
                 tempFrame = nextFrame;
             }
         }
@@ -707,6 +720,20 @@ HOT void returnFromMethod(VMGlobals* g) {
 
         g->method = meth;
         slotCopy(&g->receiver, &homeContext->vars[0]);
+
+        // When doing non-local returns, when we have something like.. `try {f.(1, 2, 3, 4, nil[\a])}`
+        // The values f, 1, 2, 3, 4, DoesNotUnderstandError are on the stack.
+        // We need to remove f, 1, 2, 3, 4, leaving the DoesNotUnderstandError.
+        // Don't do this when doing a tail call, that isn't a true non-local return.
+        // Don't do this if yielded to another thread.
+        if (g->tailCall == 0 && !yieled && distance > 1 && one_before_return_frame) {
+            const auto expected = one_before_return_frame->expected_stack_depth_after_return.getInt();
+            const auto current = g->gc->StackDepth();
+            if (expected < current) {
+                g->sp = g->gc->Stack()->slots + std::max(0, expected - 1);
+                *g->sp = g->gc->Stack()->slots[std::max<size_t>(0, current - 1)];
+            }
+        }
     }
 }
 

--- a/lang/LangSource/PyrMessage.h
+++ b/lang/LangSource/PyrMessage.h
@@ -33,7 +33,9 @@ void initUniqueMethods();
 void prepareArgsForExecute(VMGlobals* g, PyrBlock* block, PyrFrame* callFrame, std::int64_t totalSuppliedArgs,
                            std::int64_t numKwArgsSupplied, bool isMethod, PyrObject* optionalEnvirLookup = nullptr);
 
-void executeMethod(VMGlobals* g, PyrBlock* meth, std::int64_t totalNumArgsPushed, std::int64_t numKwArgsPushed);
+// Creates frame, filling it with arguments, and mutates the stack and instruction pointers to execute it.
+// Return to the main interpeter function to execute the method.
+void setupForMethod(VMGlobals* g, PyrBlock* meth, std::int64_t totalNumArgsPushed, std::int64_t numKwArgsPushed);
 
 void sendMessage(VMGlobals* g, PyrSymbol* selector, std::int64_t numArgsPushed, std::int64_t numKeyArgsPushed);
 void sendSuperMessage(VMGlobals* g, PyrSymbol* selector, std::int64_t numArgsPushed, std::int64_t numKeyArgsPushed);

--- a/testsuite/classlibrary/TestNonLocalReturn.sc
+++ b/testsuite/classlibrary/TestNonLocalReturn.sc
@@ -33,8 +33,90 @@ TestNonLocalReturn : UnitTest {
 			try { max(1, x) == 2 }
 		});
 
-		after = this.stackDepth;
 		this.assertEquals(r, x);
+		after = this.stackDepth;
 		this.assertEquals(before, after, "Non local returns should not leave things on the stack");
+	}
+
+	test_throw_in_tail_call {
+		var before = this.stackDepth;
+		var after;
+
+		var r = try {this.tail_call};
+
+		this.assertEquals(r, 2);
+
+		after = this.stackDepth;
+		this.assertEquals(before, after, "Non local returns should not leave things on the stack");
+	}
+
+	test_throw_in_tail_call_that_throw {
+		var before = this.stackDepth;
+		var after;
+
+		var r = try { this.tail_call_that_throws };
+
+		this.assertEquals(r, nil);
+
+		after = this.stackDepth;
+		this.assertEquals(before, after, "Non local returns should not leave things on the stack");
+	}
+
+	test_throw_in_tail_call_things_on_stack {
+		var before = this.stackDepth;
+		var after;
+
+		var r = try { this.tail_call_that_throws_with_things_on_stack };
+
+		this.assertEquals(r, nil);
+
+		after = this.stackDepth;
+		this.assertEquals(before, after, "Non local returns should not leave things on the stack");
+	}
+
+
+	test_throw_in_tail_call_1 {
+		var before = this.stackDepth;
+		var after;
+
+		var r = try { nil.(1, 2, 3, this.tail_call) };
+
+		this.assertEquals(r, nil);
+
+		after = this.stackDepth;
+		this.assertEquals(before, after, "Non local returns should not leave things on the stack");
+	}
+
+	test_throw_in_tail_call_that_throw_1 {
+		var before = this.stackDepth;
+		var after;
+
+		var r = try { nil.(1, 2, 3, this.tail_call_that_throws) };
+
+		this.assertEquals(r, nil);
+
+		after = this.stackDepth;
+		this.assertEquals(before, after, "Non local returns should not leave things on the stack");
+	}
+
+	test_throw_in_tail_call_things_on_stack_1 {
+		var before = this.stackDepth;
+		var after;
+
+		var r = try { nil.(1, 2, 3, this.tail_call_that_throws_with_things_on_stack) };
+
+		this.assertEquals(r, nil);
+
+		after = this.stackDepth;
+		this.assertEquals(before, after, "Non local returns should not leave things on the stack");
+	}
+
+
+	tail_call{ ^1 + 1 }
+	tail_call_that_throws { ^Error("throwing").throw }
+	tail_call_that_throws_with_things_on_stack {
+		// Yes this is weird because 1 is on the stack.
+		// As of 2026, Function.forkIfNeeded does this.
+		^if(false, 1, {Error("throwing").throw})
 	}
 }

--- a/testsuite/classlibrary/TestNonLocalReturn.sc
+++ b/testsuite/classlibrary/TestNonLocalReturn.sc
@@ -1,0 +1,40 @@
+TestNonLocalReturn : UnitTest {
+	test_try {
+		var before = this.stackDepth;
+		var after;
+		var f;
+
+		try { f.(1, 2, 3, 4, 5, Error("blah").throw ) };
+
+		after = this.stackDepth;
+
+		this.assertEquals(before, after, "Non local returns should not leave things on the stack");
+	}
+
+	test_dont_crash {
+		var before = this.stackDepth;
+		var after;
+
+		// Caused a stack overflow and segfault.
+		// see issue 7448
+		1000.do{  try {  ()[nil[\a]] }  };
+
+		after = this.stackDepth;
+
+		this.assertEquals(before, after, "Non local returns should not leave things on the stack");
+	}
+
+	test_old_issue_from_2012 {
+		// see issue 232
+		var before = this.stackDepth;
+		var after;
+		var x = [nil];
+		var r = x.do({ |item|
+			try { max(1, x) == 2 }
+		});
+
+		after = this.stackDepth;
+		this.assertEquals(r, x);
+		this.assertEquals(before, after, "Non local returns should not leave things on the stack");
+	}
+}


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

Non local returns don't unwind the stack.

Closes #7448

Closes #232  (I think...)

## Types of changes

- Bug fix
- Breaking change? I don't think so, but technically people might have relied on the borked behaviour.


## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
