### PR TITLE
Lincurve/curvelin scalar curve control fix

### DIFF
--- a/SCClassLibrary/Common/Audio/UGen.sc
+++ b/SCClassLibrary/Common/Audio/UGen.sc
@@ -227,7 +227,7 @@ UGen : AbstractFunction {
 			/ log(inMax/inMin)) * outMin;
 	}
 
-    lincurve { arg inMin = 0, inMax = 1, outMin = 0, outMax = 1, curve = -4, clip = \minmax;
+	lincurve { arg inMin = 0, inMax = 1, outMin = 0, outMax = 1, curve = -4, clip = \minmax;
 		var grow, a, b, scaled, curvedResult;
 		var tooClose = abs(curve) < 0.001;
 		var curveIsNum = curve.isNumber;

--- a/SCClassLibrary/Common/Audio/UGen.sc
+++ b/SCClassLibrary/Common/Audio/UGen.sc
@@ -229,8 +229,8 @@ UGen : AbstractFunction {
 
     lincurve { arg inMin = 0, inMax = 1, outMin = 0, outMax = 1, curve = -4, clip = \minmax;
 		var grow, a, b, scaled, curvedResult;
-        var tooClose = abs(curve) < 0.001;
-        var curveIsNum = curve.isNumber;
+		var tooClose = abs(curve) < 0.001;
+		var curveIsNum = curve.isNumber;
 		if ( curveIsNum and: { tooClose }) {
 			^this.linlin(inMin, inMax, outMin, outMax, clip)
 		};
@@ -253,8 +253,8 @@ UGen : AbstractFunction {
 
 	curvelin { arg inMin = 0, inMax = 1, outMin = 0, outMax = 1, curve = -4, clip = \minmax;
 		var grow, a, b, scaled, linResult;
-        var tooClose = abs(curve) < 0.001;
-        var curveIsNum = curve.isNumber;
+		var tooClose = abs(curve) < 0.001;
+		var curveIsNum = curve.isNumber;
 		if ( curveIsNum and: { tooClose }) {
 			^this.linlin(inMin, inMax, outMin, outMax, clip)
 		};

--- a/SCClassLibrary/Common/Audio/UGen.sc
+++ b/SCClassLibrary/Common/Audio/UGen.sc
@@ -227,31 +227,35 @@ UGen : AbstractFunction {
 			/ log(inMax/inMin)) * outMin;
 	}
 
-	lincurve { arg inMin = 0, inMax = 1, outMin = 0, outMax = 1, curve = -4, clip = \minmax;
+    lincurve { arg inMin = 0, inMax = 1, outMin = 0, outMax = 1, curve = -4, clip = \minmax;
 		var grow, a, b, scaled, curvedResult;
-		if (curve.isNumber and: { abs(curve) < 0.125 }) {
+        var tooClose = abs(curve) < 0.001;
+        var curveIsNum = curve.isNumber;
+		if ( curveIsNum and: { tooClose }) {
 			^this.linlin(inMin, inMax, outMin, outMax, clip)
 		};
+
 		grow = exp(curve);
 		a = outMax - outMin / (1.0 - grow);
 		b = outMin + a;
 		scaled = (this.prune(inMin, inMax, clip) - inMin) / (inMax - inMin);
-
 		curvedResult = b - (a * pow(grow, scaled));
 
-		if (curve.rate == \scalar) {
+		if (curveIsNum) {
 			^curvedResult
 		} {
-			^Select.perform(this.methodSelectorForRate, abs(curve) >= 0.125, [
-				this.linlin(inMin, inMax, outMin, outMax, clip),
-				curvedResult
+			^Select.perform(this.methodSelectorForRate, tooClose, [
+				curvedResult,
+				this.linlin(inMin, inMax, outMin, outMax, clip)
 			])
 		}
 	}
 
 	curvelin { arg inMin = 0, inMax = 1, outMin = 0, outMax = 1, curve = -4, clip = \minmax;
 		var grow, a, b, scaled, linResult;
-		if (curve.isNumber and: { abs(curve) < 0.125 }) {
+        var tooClose = abs(curve) < 0.001;
+        var curveIsNum = curve.isNumber;
+		if ( curveIsNum and: { tooClose }) {
 			^this.linlin(inMin, inMax, outMin, outMax, clip)
 		};
 		grow = exp(curve);
@@ -260,12 +264,12 @@ UGen : AbstractFunction {
 
 		linResult = log( (b - this.prune(inMin, inMax, clip)) / a ) * (outMax - outMin) / curve + outMin;
 
-		if (curve.rate == \scalar) {
+		if (curveIsNum) {
 			^linResult
 		} {
-			^Select.perform(this.methodSelectorForRate, abs(curve) >= 0.125, [
-				this.linlin(inMin, inMax, outMin, outMax, clip),
-				linResult
+			^Select.perform(this.methodSelectorForRate, tooClose, [
+				linResult,
+				this.linlin(inMin, inMax, outMin, outMax, clip)
 			])
 		}
 	}


### PR DESCRIPTION
(I thought I already did this months ago)...

Before this PR, the method switched to linlin when curve arg is 0 to avoid a divide by zero and consequent nan output; , but only when the curve arg is either a number or a non-scalar control. This PR fixes that.

Also, the switch from lincurve to linlin previously happened at curve.abs < 2.pow(-3); I adapted this to 2.pow(-10) < 0.001 roughly which is still very cautious. 

## Purpose and Motivation

1. in UGen's lincurve method, there are some precautions to avoid a divide by 0, such that in most cases one can write things like

```
SinOsc.ar.lincurve(-1,1,0.3,0.9,0)
```
and use it as a linear map, because it forwards to linlin internally.

But those precautions don't work so well when the `curve` arg is an .ir control, so it slips past the relevant conditional:
There is one check for `curve.isNumber` ... controls are not numbers, so we don't get to do linlin here;
on the other hand, there is another check for `curve.rate == \scalar`, and only if that test returns false are we redirected to the linlin. But ir controls _are_ scalar...

2. Regarding the adjustment of _when_ (at what value) the switch to linear mapping happens (i.e., at curve.abs = 0.125 or 0.001) : Theoretically we want this value (that I've named `tooClose`) reasonably close to zero, because the further away, the greater the resulting discontinuity can be when `curve` is modulated. E.g.
```
0.5.linlin(0,1,0,1) // -> 0.5 
0.5.lincurve(0,1,0,1, 0.001) // -> 0.49988
0.5.lincurve(0,1,0,1, 0.125) // -> 0.48438
```
This concerns signals (Single-precision), the divide by zero in `numerator/ (1- exp(curve))` will happen whenever  `curve.abs < 2.pow(-24)`. I've tried this out a bit with
```
a = Signal.newClear(1).fill(2.pow(-24)) //
b = Signal.newClear(1).fill(1) //
(b - a.exp ) > 0; // true
// whereas
c = Signal.newClear(1).fill(2.pow(-25)) //
(b - c.exp) > 0 // false

```
By contrast, the present pr uses 0.001 which is roughly `2.pow(-10)`. This is still excessively cautious, but better than 2.pow(-3) = 0.125 just seemed unnecessary.


## Types of changes


- Bug fix
