### PR TITLE
classlib: implement `indexOf` for `List`

### DIFF
--- a/SCClassLibrary/Common/Collections/List.sc
+++ b/SCClassLibrary/Common/Collections/List.sc
@@ -34,6 +34,7 @@ List : SequenceableCollection {
 	}
 
 	// accessing
+	indexOf { arg item; ^array.indexOf(item) }
 
 	at { arg i; ^array.at(i) }
 	clipAt { arg i; i = i.asInteger.clip(0, this.size - 1); ^array.at(i) }


### PR DESCRIPTION


<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

This fixes an unknown bug #7182 by making `List` defer to its array for indexOf, rather than using a custom `do` loop and equality comparison.

This doesn't actually solve the bug, because I still don't know why it happens. Stack corruption due to unusual extended opcodes? maybe, perhap GC graph related?

Nevertheless, this is a large performance gain for this method.
## Types of changes

<!-- Delete lines that don't apply -->

- Performance gain
- Bug fix, but more by accident as I still don't know exactly why.

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [ ] Code is tested
- [ ] All tests are passing
- [ ] Updated documentation
- [ ] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
