### PR TITLE
sclang: fix duplication typo from rebase.

### DIFF
--- a/lang/LangSource/PyrInterpreter3.cpp
+++ b/lang/LangSource/PyrInterpreter3.cpp
@@ -2454,10 +2454,6 @@ HOT void Interpret(VMGlobals* g) {
                 sp = g->sp;
                 selector = slotRawSymbol(&meth->selectors);
                 classobj = slotRawSymbol(&slotRawClass(&meth->ownerclass)->superclass)->u.classobj;
-                classobj = slotRawSymbol(&slotRawClass(&meth->ownerclass)->superclass)->u.classobj;
-
-                classobj = slotRawSymbol(&slotRawClass(&meth->ownerclass)->superclass)->u.classobj;
-
                 goto msg_lookup;
 
             case methForwardInstVar:
@@ -2469,10 +2465,6 @@ HOT void Interpret(VMGlobals* g) {
                 index = methraw->specialIndex;
                 slotCopy(slot, &slotRawObject(slot)->slots[index]);
                 classobj = classOfSlot(slot);
-                classobj = classOfSlot(slot);
-
-                classobj = classOfSlot(slot);
-
                 goto msg_lookup;
 
             case methForwardClassVar:
@@ -2483,10 +2475,6 @@ HOT void Interpret(VMGlobals* g) {
                 selector = slotRawSymbol(&meth->selectors);
                 slotCopy(slot, &g->classvars->slots[methraw->specialIndex]);
                 classobj = classOfSlot(slot);
-                classobj = classOfSlot(slot);
-
-                classobj = classOfSlot(slot);
-
                 goto msg_lookup;
 
             case methPrimitive:


### PR DESCRIPTION


<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

Completely my mistake when rebasing! This is a simple fix and changes no behaviour.

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [ ] Code is tested
- [ ] All tests are passing
- [ ] Updated documentation
- [ ] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
