### PR TITLE
Document ellipsis syntax in function argument lists in Syntax Shortcuts

### DIFF
--- a/HelpSource/Reference/Syntax-Shortcuts.schelp
+++ b/HelpSource/Reference/Syntax-Shortcuts.schelp
@@ -51,13 +51,12 @@ When using the new code::||:: syntax, the default value needs to be enclosed in 
 
 subsection:: ellipsis in function arguments
 
+The code:: arg :: and code:: | | :: syntaxes are equivalent. The following pairs are identical:
 table::
-## instead of writing: || you can write:
 ## code:: { arg ... args; args.postln } :: || code:: { |... args| args.postln } ::
 ## code:: { arg a ... rest; [a, rest].postln } :: || code:: { |a ... rest| [a, rest].postln } ::
 ## code:: { arg a, b ... rest; [a, b, rest].postln } :: || code:: { |a, b ... rest| [a, b, rest].postln } ::
-
-code:: { |a b ... rest| [a, b, rest].postln } ::
+## code:: { arg a, b ... rest; [a, b, rest].postln } :: || code:: { |a b ... rest| [a, b, rest].postln } ::
 ::
 
 note::
@@ -65,27 +64,16 @@ Use code::...:: in function argument lists when the inputs are not fixed in adva
 
 code::
 // It may collect all arguments:
-x = { arg ... args; args };
-x.(1, 2, 3);    // -> [1, 2, 3]
-
 x = { |... args| args };
-x.(1, 2, 3, 4, 5); // -> [1, 2, 3, 4, 5]
+x.(1, 2, 3);         // -> [ 1, 2, 3 ]
+x.(1, 2, 3, 4, 5);   // -> [ 1, 2, 3, 4, 5 ]
 
 // Or it may collect only the arguments that remain after earlier ones have been matched:
-x = { arg a ... rest; [a, rest] };
-x.(1, 2, 3, 4, 5);       // -> [ 1, [ 2, 3, 4, 5 ] ]
-
 x = { |a ... rest| [a, rest] };
-x.(1, 2, 3, 4, 5);          // -> [ 1, [ 2, 3, 4, 5 ] ]
+x.(1, 2, 3, 4, 5);   // -> [ 1, [ 2, 3, 4, 5 ] ]
 
-x = { arg a, b ... rest; [a, b, rest] };
-x.(1, 2, 3, 4, 5); // -> [ 1, 2, [ 3, 4, 5 ] ]
-
-x = { |a, b ... rest| [a, b, rest] }
-x.(1, 2, 3, 4, 5);    // -> [ 1, 2, [ 3, 4, 5 ] ]
-
-x = { |a b ... rest| [a, b, rest] }
-x.(1, 2, 3, 4, 5);     // -> [ 1, 2, [ 3, 4, 5 ] ]
+x = { |a, b ... rest| [a, b, rest] };
+x.(1, 2, 3, 4, 5);   // -> [ 1, 2, [ 3, 4, 5 ] ]
 ::
 ::
 

--- a/HelpSource/Reference/Syntax-Shortcuts.schelp
+++ b/HelpSource/Reference/Syntax-Shortcuts.schelp
@@ -49,6 +49,46 @@ note::
 When using the new code::||:: syntax, the default value needs to be enclosed in parenthesis if it's not a literal.
 ::
 
+subsection:: ellipsis in function arguments
+
+table::
+## instead of writing: || you can write:
+## code:: { arg ... args; args.postln } :: || code:: { |... args| args.postln } ::
+## code:: { arg a ... rest; [a, rest].postln } :: || code:: { |a ... rest| [a, rest].postln } ::
+## code:: { arg a, b ... rest; [a, b, rest].postln } :: || code:: { |a, b ... rest| [a, b, rest].postln } ::
+
+code:: { |a b ... rest| [a, b, rest].postln } ::
+::
+
+note::
+Use code::...:: in function argument lists when the inputs are not fixed in advance, either in the number of arguments or in the names of arguments. Arguments matched by code::...:: are collected into a single link::Classes/Array:: instance.
+
+code::
+// It may collect all arguments:
+x = { arg ... args; args };
+x.(1, 2, 3);    // -> [1, 2, 3]
+
+x = { |... args| args };
+x.(1, 2, 3, 4, 5); // -> [1, 2, 3, 4, 5]
+
+// Or it may collect only the arguments that remain after earlier ones have been matched:
+x = { arg a ... rest; [a, rest] };
+x.(1, 2, 3, 4, 5);       // -> [ 1, [ 2, 3, 4, 5 ] ]
+
+x = { |a ... rest| [a, rest] };
+x.(1, 2, 3, 4, 5);          // -> [ 1, [ 2, 3, 4, 5 ] ]
+
+x = { arg a, b ... rest; [a, b, rest] };
+x.(1, 2, 3, 4, 5); // -> [ 1, 2, [ 3, 4, 5 ] ]
+
+x = { |a, b ... rest| [a, b, rest] }
+x.(1, 2, 3, 4, 5);    // -> [ 1, 2, [ 3, 4, 5 ] ]
+
+x = { |a b ... rest| [a, b, rest] }
+x.(1, 2, 3, 4, 5);     // -> [ 1, 2, [ 3, 4, 5 ] ]
+::
+::
+
 subsection:: partial application
 table::
 ## instead of writing: || you can write:

--- a/HelpSource/Reference/Syntax-Shortcuts.schelp
+++ b/HelpSource/Reference/Syntax-Shortcuts.schelp
@@ -106,6 +106,14 @@ f.(1, 2, 3, 4, x: 5, y: 6);        // -> [ 1, 2, [ 3, 4 ], [ x, 5, y, 6 ] ]
 f.(1, 2, 3, 4, 5, 6, x: 7, y: 8);  // -> [ 1, 2, [ 3, 4, 5, 6 ], [ x, 7, y, 8 ] ]
 ::
 
+note::
+See
+list::
+## link::Classes/Object#performList::
+## link::Classes/Object#performArgs::
+::
+::
+
 subsection:: partial application
 table::
 ## instead of writing: || you can write:

--- a/HelpSource/Reference/Syntax-Shortcuts.schelp
+++ b/HelpSource/Reference/Syntax-Shortcuts.schelp
@@ -51,16 +51,31 @@ When using the new code::||:: syntax, the default value needs to be enclosed in 
 
 subsection:: ellipsis in function arguments
 
-The code:: arg :: and code:: | | :: syntaxes are equivalent. The following pairs are identical:
+The code:: arg :: and pipe notation (code:: | | ::) syntaxes are equivalent. The following pairs are identical:
 table::
 ## code:: { arg ... args; args.postln } :: || code:: { |... args| args.postln } ::
 ## code:: { arg a ... rest; [a, rest].postln } :: || code:: { |a ... rest| [a, rest].postln } ::
 ## code:: { arg a, b ... rest; [a, b, rest].postln } :: || code:: { |a, b ... rest| [a, b, rest].postln } ::
 ## code:: { arg a, b ... rest; [a, b, rest].postln } :: || code:: { |a b ... rest| [a, b, rest].postln } ::
+## (pipe notation only) || code:: { |a, b ... rest, kwargs| [a, b, rest, kwargs].postln } ::
 ::
 
 note::
-Use code::...:: in function argument lists when the inputs are not fixed in advance, either in the number of arguments or in the names of arguments. Arguments matched by code::...:: are collected into a single link::Classes/Array:: instance.
+See:
+list::
+## link::Reference/Messages#Keyword Arguments and Positional Arguments::
+## link::Classes/FunctionDef#numArgs::
+## link::Classes/FunctionDef#numVars::
+## link::Classes/FunctionDef#varArgs::
+## link::Classes/FunctionDef#hasKwArgs::
+## link::Classes/FunctionDef#varArgsValue::
+## link::Classes/FunctionDef#.hasVarArgs::
+::
+::
+
+subsubsection:: variable arguments (varargs)
+
+Use code::...:: in function argument lists when the number of arguments is not fixed in advance. Arguments matched by code::...:: are collected into a single link::Classes/Array:: instance.
 
 code::
 // It may collect all arguments:
@@ -75,6 +90,20 @@ x.(1, 2, 3, 4, 5);   // -> [ 1, [ 2, 3, 4, 5 ] ]
 x = { |a, b ... rest| [a, b, rest] };
 x.(1, 2, 3, 4, 5);   // -> [ 1, 2, [ 3, 4, 5 ] ]
 ::
+
+subsubsection:: keyword arguments (kwargs)
+
+Use code::...args, kwargs:: to capture arbitrary keyword arguments that are not explicitly named. The keyword arguments are collected into a single link::Classes/Array:: instance of key-value pairs. Note that kwargs are only supported with the pipe notation (code:: | | ::), not with code:: arg ::.
+
+code::
+// Capture arbitrary keyword arguments:
+f = { |... args, kwargs| kwargs };
+f.(x: 3, y: 4);      // -> [ x, 3, y, 4 ]
+
+// Named arguments are matched first; the rest go into args or kwargs:
+f = { |a, b ... args, kwargs| [a, b, args, kwargs] };
+f.(1, 2, 3, 4, x: 5, y: 6);        // -> [ 1, 2, [ 3, 4 ], [ x, 5, y, 6 ] ]
+f.(1, 2, 3, 4, 5, 6, x: 7, y: 8);  // -> [ 1, 2, [ 3, 4, 5, 6 ], [ x, 7, y, 8 ] ]
 ::
 
 subsection:: partial application


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation
This documents the `...` syntax in function argument lists and shows its equivalence between the old `arg` form and the pipe argument form.

`...` in function arguments is not currently documented here, and this is the most natural place for it alongside other function-definition syntax shortcuts.

### Changes

- add `subsection:: ellipsis in function arguments`
- show equivalences between `arg` syntax and `|...|` syntax
- explain that arguments matched by `...` are collected into an `Array`
- include examples for collecting all arguments and for collecting only the remaining arguments
- include the comma-less pipe form `|a b ... rest|`

### Placement

This goes into `Syntax-Shortcuts` rather than `SymbolicNotations`, since it is better categorized as function-argument syntax and syntax equivalence.

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->

- Documentation
## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
