### PR TITLE
 Clarify f.(*array) vs f.(array) in function call examples in SymbolicNotations.schelp

### DIFF
--- a/HelpSource/Overviews/SymbolicNotations.schelp
+++ b/HelpSource/Overviews/SymbolicNotations.schelp
@@ -314,10 +314,14 @@ definitionlist::
 ## code:: f.(*argList) :: || evaluate the function with the arguments in an array
 ## code:: f.(anArgName: value) :: || keyword addressing of function or method arguments
 code::
-f = { |a, b| a * b };
-f.(2, 4);
-f.(*[2, 4]);
-f.(a: 2, b: 4);
+f = { |a, b| [a, b] };
+
+f.(2, 4);        // -> [ 2, 4 ]
+
+f.(*[2, 4]);     // -> [ 2, 4 ]
+f.([2, 4]);      // -> [ [ 2, 4 ], nil ]
+
+f.(a: 2, b: 4);  // -> [ 2, 4 ]
 ::
 ## code:: SomeClass.[index] :: || Equivalent to SomeClass.at(index) -- Instr.at is a good example
 ## code:: myObject.method(*array) :: || call the method with the arguments in an array


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

For beginners, clarify the difference between `f.(*array)` and `f.(array)` in the function call examples.

The current example shows how to pass arguments from an array with `*`, but it does not directly contrast that form with passing the array as a normal single argument.

Adding that comparison makes the behavior clearer and helps prevent confusion about what `*` changes in a function call.

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->

- Documentation

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
