### PR TITLE
Rewrite keyword/positional arguments doc for clarity and beginner accessibility

### DIFF
--- a/HelpSource/Reference/Messages.schelp
+++ b/HelpSource/Reference/Messages.schelp
@@ -133,7 +133,7 @@ SinOsc.ar(800, pi, 0.2, 0); // all positional arguments: freq, phase, mul, add
 // freq = 800, mul = 0.2, others get default values.
 SinOsc.ar(800, mul: 0.2); // 800 is a positional argument, and 0.2 is a keyword one
 
-// all keyword arguments: freq = 800, phase = pi, mul = 0.2, add gets its default value of zero.
+// freq = 800, phase = pi, mul = 0.2, add gets its default value of zero.
 SinOsc.ar(phase: pi, mul: 0.2, freq: 800); // all keyword arguments:
 
 // keyword value of 1200 overrides the positional arg value of 800

--- a/HelpSource/Reference/Messages.schelp
+++ b/HelpSource/Reference/Messages.schelp
@@ -109,42 +109,56 @@ z = x.value(10, 5);     // z is set to 15. (a is 10, b is 5)
 z = x.value(10, 5, 9);  // z is set to 15. (a is 10, b is 5, 9 is ignored)
 ::
 
-section:: Keyword Arguments
+section:: Keyword Arguments and Positional Arguments
 
-Arguments to Methods may be specified by the name by which they are declared in a method's definition. Such arguments are called keyword arguments.
+Arguments to methods and functions may be specified either by position or by name.
+Arguments specified by position are called emphasis::positional arguments::, and are interpreted according to the order in which they are declared in the method or function definition.
+Arguments specified by name (followed by a colon) are called emphasis::keyword arguments::.
 Any argument may be passed as a keyword argument except for the receiver code::this::.
-Keyword arguments must come after any normal (aka emphasis::positional::) arguments, and may be specified in any order.
-If a keyword is specified and there is no matching argument then it is ignored and a warning will be printed. This warning may be turned off globally by making the following call:
+
+Keyword arguments must come after any positional arguments, may be specified in any order among themselves, and once a keyword argument is used, no positional argument may follow.
+In other words, if you skip any argument defined before the one you want to specify, you must use keyword arguments. So once you use a keyword argument, all subsequent arguments must also be keyword arguments.
+
+If a keyword is specified and there is no matching argument, it is ignored and a warning will be printed. This warning may be turned off globally by making the following call:
 code::
 keywordWarnings(false)
 ::
-If a keyword argument and a positional argument specify the same argument, then the keyword argument value overrides the positional argument value.
 
-For example the code::ar:: class method of the SinOsc class takes arguments named freq, phase, mul, and add in that order. All of the following are legal calls to that method.
+If a keyword argument and a positional argument specify the same argument, the keyword argument value overrides the positional argument value. Note that this usage, while legal, is discouraged as it can be confusing.
+
+For example, the code::ar:: class method of the SinOsc class takes arguments named freq, phase, mul, and add in that order. All of the following are legal calls to that method.
 code::
-SinOsc.ar(800, pi, 0.2, 0); // all normal arguments: freq, phase, mul, add
+SinOsc.ar(800, pi, 0.2, 0); // all positional arguments: freq, phase, mul, add
 
 // freq = 800, mul = 0.2, others get default values.
-SinOsc.ar(800, mul: 0.2);
+SinOsc.ar(800, mul: 0.2); // 800 is a positional argument, and 0.2 is a keyword one
 
-// freq = 800, phase = pi, mul = 0.2, add gets its default value of zero.
-SinOsc.ar(phase: pi, mul: 0.2, freq: 800);
+// all keyword arguments: freq = 800, phase = pi, mul = 0.2, add gets its default value of zero.
+SinOsc.ar(phase: pi, mul: 0.2, freq: 800); // all keyword arguments:
 
 // keyword value of 1200 overrides the positional arg value of 800
-SinOsc.ar(800, freq: 1200);
+SinOsc.ar(800, freq: 1200); // should not be used.
 ::
 code::
-SinOsc.ar(zorg: 999); // invalid keyword prints warning
+SinOsc.ar(zorg: 999); // invalid keyword prints warning. should not be used.
 ::
-The arguments to a Function may also be specified by keyword arguments when using the 'value' message.
+
+The arguments to a link::Classes/Function:: instance work the same way when using the 'value' message.
 code::
-// function args may be specified by keyword.
+// function args specified positionally from the first argument defined in the function.
+{ arg a=1, b=2, c=3; [a, b, c].postln }.value(7, 8);
+// -> [ 7, 8, 3 ]
+
+// function args specified by keyword, skipping the first argument defined in the function.
 { arg a=1, b=2, c=3; [a, b, c].postln }.value(b: 7, c: 8);
+// -> [ 1, 7, 8 ]
 ::
+
 You may also use keyword arguments when using the 'perform' method.
 code::
 SinOsc.perform('ar', phase: pi, mul: 0.2, freq: 800);
 ::
+
 subsection:: Cost of using keyword arguments
 
 When using keyword arguments there is a runtime cost to do the matching that you should be aware of. The cost can be worth the convenience when speed is not critical.

--- a/HelpSource/Reference/Messages.schelp
+++ b/HelpSource/Reference/Messages.schelp
@@ -124,7 +124,11 @@ code::
 keywordWarnings(false)
 ::
 
-If a keyword argument and a positional argument specify the same argument, the keyword argument value overrides the positional argument value. Note that this usage, while legal, is discouraged as it can be confusing.
+If the same argument is specified more than once, whether by positional or keyword arguments, the rightmost value overrides all previous ones. Note that this usage, while legal, is discouraged as it can be confusing.
+code::
+f = { | a | a };
+f.(1, a: 2, a: 3); // -> 3, the rightmost value wins
+::
 
 For example, the code::ar:: class method of the SinOsc class takes arguments named freq, phase, mul, and add in that order. All of the following are legal calls to that method.
 code::
@@ -134,9 +138,9 @@ SinOsc.ar(800, pi, 0.2, 0); // all positional arguments: freq, phase, mul, add
 SinOsc.ar(800, mul: 0.2); // 800 is a positional argument, and 0.2 is a keyword one
 
 // freq = 800, phase = pi, mul = 0.2, add gets its default value of zero.
-SinOsc.ar(phase: pi, mul: 0.2, freq: 800); // all keyword arguments:
+SinOsc.ar(phase: pi, mul: 0.2, freq: 800); // all keyword arguments
 
-// keyword value of 1200 overrides the positional arg value of 800
+// the rightmost value of 1200 overrides the positional arg value of 800
 SinOsc.ar(800, freq: 1200); // should not be used.
 ::
 code::


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation
The current documentation briefly mentioned positional arguments and assumed prior knowledge of how keyword arguments work. This PR rewrites the section to explicitly define both positional and keyword arguments, clarifies the rules for mixing them, and adds inline comments to code examples to make the behaviour immediately clear to beginners.
<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->

- Documentation

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
