### PR TITLE
Correct `Platforam.helpDir`

### DIFF
--- a/HelpSource/Classes/Platform.schelp
+++ b/HelpSource/Classes/Platform.schelp
@@ -38,11 +38,10 @@ subsection:: Directories and filesystem stuff
 method:: classLibraryDir
 location of the bundled class library
 
-method:: helpSourceDir
-location of the bundled help files
-
 method:: helpDir
-Location of the HTML help documents rendered from code::Platform.helpSourceDir::
+Returns the system-wide directory containing the help source files.
+This method will be deprecated.
+Use link::Classes/SCDoc#*helpSourceDir:: for the help source files and link::Classes/SCDoc#*helpTargetDir:: for the directories containing the rendered HTML files.
 
 method:: systemAppSupportDir
 system application support directory

--- a/HelpSource/Classes/Platform.schelp
+++ b/HelpSource/Classes/Platform.schelp
@@ -38,8 +38,11 @@ subsection:: Directories and filesystem stuff
 method:: classLibraryDir
 location of the bundled class library
 
-method:: helpDir
+method:: helpSourceDir
 location of the bundled help files
+
+method:: helpDir
+Location of the HTML help documents rendered from code::Platform.helpSourceDir::
 
 method:: systemAppSupportDir
 system application support directory

--- a/SCClassLibrary/Platform/Platform.sc
+++ b/SCClassLibrary/Platform/Platform.sc
@@ -4,7 +4,7 @@ Platform {
 	// IDE actions
 	classvar <>makeServerWindowAction, <>makeSynthDescWindowAction, <>openHelpFileAction, <>openHTMLFileAction;
 
-	var <classLibraryDir, <>recordingsDir, features;
+	var <classLibraryDir, <helpDir, <>recordingsDir, features;
 	var <>devpath;
 
 	*initClass {

--- a/SCClassLibrary/Platform/Platform.sc
+++ b/SCClassLibrary/Platform/Platform.sc
@@ -13,7 +13,7 @@ Platform {
 
 	initPlatform {
 		classLibraryDir = thisMethod.filenameSymbol.asString.dirname.dirname;
-		helpDir = thisMethod.filenameSymbol.asString.dirname.dirname.dirname ++ "/Help";
+		helpDir = thisProcess.platform.userAppSupportDir +/+ "Help";
 		features = IdentityDictionary.new;
 		recordingsDir = this.userAppSupportDir +/+ "Recordings";
 	}
@@ -31,6 +31,7 @@ Platform {
 	// directories
 	*classLibraryDir { ^thisProcess.platform.classLibraryDir }
 	*helpDir { ^thisProcess.platform.helpDir }
+	*helpSourceDir { ^thisMethod.filenameSymbol.asString.dirname.dirname.dirname +/+ "HelpSource"}
 
 	userHomeDir {
 		_Platform_userHomeDir

--- a/SCClassLibrary/Platform/Platform.sc
+++ b/SCClassLibrary/Platform/Platform.sc
@@ -4,7 +4,7 @@ Platform {
 	// IDE actions
 	classvar <>makeServerWindowAction, <>makeSynthDescWindowAction, <>openHelpFileAction, <>openHTMLFileAction;
 
-	var <classLibraryDir, <helpDir, <>recordingsDir, features;
+	var <classLibraryDir, <>recordingsDir, features;
 	var <>devpath;
 
 	*initClass {
@@ -13,7 +13,6 @@ Platform {
 
 	initPlatform {
 		classLibraryDir = thisMethod.filenameSymbol.asString.dirname.dirname;
-		helpDir = thisProcess.platform.userAppSupportDir +/+ "Help";
 		features = IdentityDictionary.new;
 		recordingsDir = this.userAppSupportDir +/+ "Recordings";
 	}
@@ -30,8 +29,7 @@ Platform {
 
 	// directories
 	*classLibraryDir { ^thisProcess.platform.classLibraryDir }
-	*helpDir { ^thisProcess.platform.helpDir }
-	*helpSourceDir { ^thisMethod.filenameSymbol.asString.dirname.dirname.dirname +/+ "HelpSource"}
+	*helpDir { ^this.classLibraryDir.dirname +/+ "HelpSource" }
 
 	userHomeDir {
 		_Platform_userHomeDir


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation
Currently, `Platform.helpDir` points to a non-existent folder.
This PR changes it so that:

- `Platform.helpDir` points to `Platform.userAppSupportDir +/+ "Help"`
- `Platform.helpSourceDir` points to `Platform.resourceDir +/+ "HelpSource"`

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix
- Documentation

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
