### PR TITLE
Try to make Buffer method arguments (`numChannels`, `index`, and `numFrames`-related arguments) consistent

### DIFF
--- a/SCClassLibrary/Common/Control/Buffer.sc
+++ b/SCClassLibrary/Common/Control/Buffer.sc
@@ -60,14 +60,14 @@ Buffer {
 
 	allocRead { arg argpath, startFrame = 0, numFrames = -1, completionMessage;
 		path = argpath;
-		this.startFrame = startFrame;
-		server.listSendMsg(this.allocReadMsg(argpath, startFrame, numFrames.asInteger, completionMessage))
+		this.startFrame = startFrame.asInteger;
+		server.listSendMsg(this.allocReadMsg(argpath, startFrame.asInteger, numFrames.asInteger, completionMessage))
 	}
 
 	allocReadChannel { arg argpath, startFrame = 0, numFrames = -1, channels, completionMessage;
 		path = argpath;
-		this.startFrame = startFrame;
-		server.listSendMsg(this.allocReadChannelMsg(argpath, startFrame, numFrames.asInteger, channels,
+		this.startFrame = startFrame.asInteger;
+		server.listSendMsg(this.allocReadChannelMsg(argpath, startFrame.asInteger, numFrames.asInteger, channels,
 			completionMessage))
 	}
 
@@ -79,14 +79,14 @@ Buffer {
 	allocReadMsg { arg argpath, startFrame = 0, numFrames = -1, completionMessage;
 		this.cache;
 		path = argpath;
-		this.startFrame = startFrame;
+		this.startFrame = startFrame.asInteger;
 		^["/b_allocRead", bufnum, path, startFrame.asInteger, (numFrames ? -1).asInteger, completionMessage.value(this)]
 	}
 
 	allocReadChannelMsg { arg argpath, startFrame = 0, numFrames = -1, channels, completionMessage;
 		this.cache;
 		path = argpath;
-		this.startFrame = startFrame;
+		this.startFrame = startFrame.asInteger;
 		completionMessage !? { completionMessage = [completionMessage.value(this)] };
 		^["/b_allocReadChannel", bufnum, path, startFrame.asInteger, (numFrames ? -1).asInteger] ++ channels ++ completionMessage
 	}
@@ -98,7 +98,7 @@ Buffer {
 		bufnum ?? { bufnum = server.nextBufferNumber(1) };
 		^super.newCopyArgs(server, bufnum)
 			.doOnInfo_(action).cache
-			.allocRead(path, startFrame, numFrames.asInteger, {|buf|["/b_query", buf.bufnum] })
+			.allocRead(path, startFrame.asInteger, numFrames.asInteger, {|buf|["/b_query", buf.bufnum] })
 	}
 
 	read { arg argpath, fileStartFrame = 0, numFrames = -1, bufStartFrame = 0, leaveOpen = false, action;
@@ -115,7 +115,7 @@ Buffer {
 		bufnum ?? { bufnum = server.nextBufferNumber(1) };
 		^super.newCopyArgs(server, bufnum)
 			.doOnInfo_(action).cache
-			.allocReadChannel(path, startFrame, numFrames.asInteger, channels,
+			.allocReadChannel(path, startFrame.asInteger, numFrames.asInteger, channels,
 				{|buf|["/b_query", buf.bufnum]})
 	}
 
@@ -132,7 +132,7 @@ Buffer {
 	*readNoUpdate { arg server, path, startFrame = 0, numFrames = -1, bufnum, completionMessage;
 		server = server ? Server.default;
 		bufnum ?? { bufnum = server.nextBufferNumber(1) };
-		^super.newCopyArgs(server, bufnum).allocRead(path, startFrame, numFrames.asInteger, completionMessage)
+		^super.newCopyArgs(server, bufnum).allocRead(path, startFrame.asInteger, numFrames.asInteger, completionMessage)
 	}
 
 	readNoUpdate { arg argpath, fileStartFrame = 0, numFrames = -1,
@@ -164,14 +164,14 @@ Buffer {
 	*cueSoundFile { arg server, path, startFrame = 0, numChannels= 2, bufferSize=32768, completionMessage;
 		^this.alloc(server, bufferSize, numChannels, { arg buffer;
 			buffer.path_(path);
-			buffer.cueSoundFileMsg(path, startFrame, completionMessage);
+			buffer.cueSoundFileMsg(path, startFrame.asInteger, completionMessage);
 		}).cache
 	}
 
 	cueSoundFile { arg path, startFrame, completionMessage;
 		this.path_(path);
 		server.listSendMsg(
-			this.cueSoundFileMsg(path, startFrame, completionMessage)
+			this.cueSoundFileMsg(path, startFrame.asInteger, completionMessage)
 		)
 	}
 
@@ -221,7 +221,7 @@ Buffer {
 				{
 					sndfile.writeData(data);
 					sndfile.close;
-					this.read(path, bufStartFrame: startFrame, action: { |buf|
+					this.read(path, bufStartFrame: startFrame.asInteger, action: { |buf|
 						if(File.delete(path), { buf.path = nil },
 							{("Could not delete data file:" + path).warn });
 						action.value(buf)
@@ -254,7 +254,7 @@ Buffer {
 			if ( collsize > ((numFrames - startFrame) * numChannels),
 				{ "Collection larger than available number of Frames".warn });
 
-			this.streamCollection(collstream, collsize, startFrame * numChannels, wait, action)
+			this.streamCollection(collstream, collsize, startFrame.asInteger * numChannels, wait, action)
 		} {
 			MethodError("Invalid arguments to Buffer:sendCollection", this).throw
 		}
@@ -271,7 +271,7 @@ Buffer {
 			while { pos < collsize } {
 				// 1626 max size for setn under udp
 				bundsize = min(1626, collsize - pos);
-				server.listSendMsg(['/b_setn', bufnum, pos + startFrame, bundsize]
+				server.listSendMsg(['/b_setn', bufnum, pos + startFrame.asInteger, bundsize]
 					++ Array.fill(bundsize, { collstream.next }));
 				pos = collstream.pos;
 				if(wait >= 0) { wait.wait } { server.sync };
@@ -352,7 +352,7 @@ Buffer {
 		path = path ?? { thisProcess.platform.recordingsDir +/+ "SC_" ++ Date.localtime.stamp ++ "." ++ headerFormat };
 		server.listSendMsg(
 			this.writeMsg(path,
-				headerFormat, sampleFormat, numFrames.asInteger, startFrame,
+				headerFormat, sampleFormat, numFrames.asInteger, startFrame.asInteger,
 				leaveOpen, completionMessage
 			)
 		)
@@ -696,7 +696,7 @@ Buffer {
 		buffer = super.newCopyArgs(server, bufnum).cache;
 		Dialog.openPanel({ arg path;
 			buffer.doOnInfo_(action)
-				.allocRead(path, startFrame, numFrames.asInteger, { ["/b_query", buffer.bufnum] })
+				.allocRead(path, startFrame.asInteger, numFrames.asInteger, { ["/b_query", buffer.bufnum] })
 		});
 		^buffer
 	}
@@ -708,7 +708,7 @@ Buffer {
 		buffer = super.newCopyArgs(server, bufnum).cache;
 		Dialog.openPanel({ arg path;
 			buffer.doOnInfo_(action)
-			.allocReadChannel(path, startFrame, numFrames.asInteger, channels,
+			.allocReadChannel(path, startFrame.asInteger, numFrames.asInteger, channels,
 				{|buf|["/b_query", buf.bufnum]})
 		});
 		^buffer

--- a/SCClassLibrary/Common/Control/Buffer.sc
+++ b/SCClassLibrary/Common/Control/Buffer.sc
@@ -67,7 +67,7 @@ Buffer {
 	allocReadChannel { arg argpath, startFrame = 0, numFrames = -1, channels, completionMessage;
 		path = argpath;
 		this.startFrame = startFrame.asInteger;
-		server.listSendMsg(this.allocReadChannelMsg(argpath, startFrame.asInteger, numFrames.asInteger, channels,
+		server.listSendMsg(this.allocReadChannelMsg(argpath, startFrame.asInteger, numFrames.asInteger, channels.asInteger,
 			completionMessage))
 	}
 
@@ -88,7 +88,7 @@ Buffer {
 		path = argpath;
 		this.startFrame = startFrame.asInteger;
 		completionMessage !? { completionMessage = [completionMessage.value(this)] };
-		^["/b_allocReadChannel", bufnum, path, startFrame.asInteger, (numFrames ? -1).asInteger] ++ channels ++ completionMessage
+		^["/b_allocReadChannel", bufnum, path, startFrame.asInteger, (numFrames ? -1).asInteger] ++ channels.asInteger ++ completionMessage
 	}
 
 	// read whole file into memory for PlayBuf etc.
@@ -115,7 +115,7 @@ Buffer {
 		bufnum ?? { bufnum = server.nextBufferNumber(1) };
 		^super.newCopyArgs(server, bufnum)
 			.doOnInfo_(action).cache
-			.allocReadChannel(path, startFrame.asInteger, numFrames.asInteger, channels,
+			.allocReadChannel(path, startFrame.asInteger, numFrames.asInteger, channels.asInteger,
 				{|buf|["/b_query", buf.bufnum]})
 	}
 
@@ -125,7 +125,7 @@ Buffer {
 		doOnInfo = action;
 		server.listSendMsg(
 			this.readChannelMsg(argpath, fileStartFrame.asInteger, numFrames.asInteger, bufStartFrame.asInteger,
-				leaveOpen, channels, {|buf| ["/b_query", buf.bufnum] })
+				leaveOpen, channels.asInteger, {|buf| ["/b_query", buf.bufnum] })
 		)
 	}
 
@@ -156,7 +156,7 @@ Buffer {
 		bufStartFrame = 0, leaveOpen = false, channels, completionMessage;
 		path = argpath;
 		^["/b_readChannel", bufnum, path, fileStartFrame.asInteger, (numFrames ? -1).asInteger,
-			bufStartFrame.asInteger, leaveOpen.binaryValue] ++ channels ++ [completionMessage.value(this)]
+			bufStartFrame.asInteger, leaveOpen.binaryValue] ++ channels.asInteger ++ [completionMessage.value(this)]
 		// doesn't set my numChannels etc.
 	}
 
@@ -708,7 +708,7 @@ Buffer {
 		buffer = super.newCopyArgs(server, bufnum).cache;
 		Dialog.openPanel({ arg path;
 			buffer.doOnInfo_(action)
-			.allocReadChannel(path, startFrame.asInteger, numFrames.asInteger, channels,
+			.allocReadChannel(path, startFrame.asInteger, numFrames.asInteger, channels.asInteger,
 				{|buf|["/b_query", buf.bufnum]})
 		});
 		^buffer

--- a/SCClassLibrary/Common/Control/Buffer.sc
+++ b/SCClassLibrary/Common/Control/Buffer.sc
@@ -18,8 +18,8 @@ Buffer {
 		^super.newCopyArgs(
 			server,
 			bufnum,
-			numFrames.asInteger,
-			numChannels.asInteger,
+			numFrames,
+			numChannels,
 			sampleRate
 		).cache
 	}
@@ -60,14 +60,14 @@ Buffer {
 
 	allocRead { arg argpath, startFrame = 0, numFrames = -1, completionMessage;
 		path = argpath;
-		this.startFrame = startFrame.asInteger;
-		server.listSendMsg(this.allocReadMsg(argpath, startFrame.asInteger, numFrames.asInteger, completionMessage))
+		this.startFrame = startFrame;
+		server.listSendMsg(this.allocReadMsg( argpath, startFrame, numFrames, completionMessage))
 	}
 
 	allocReadChannel { arg argpath, startFrame = 0, numFrames = -1, channels, completionMessage;
 		path = argpath;
-		this.startFrame = startFrame.asInteger;
-		server.listSendMsg(this.allocReadChannelMsg(argpath, startFrame.asInteger, numFrames.asInteger, channels.asInteger,
+		this.startFrame = startFrame;
+		server.listSendMsg(this.allocReadChannelMsg( argpath, startFrame, numFrames, channels,
 			completionMessage))
 	}
 
@@ -79,16 +79,16 @@ Buffer {
 	allocReadMsg { arg argpath, startFrame = 0, numFrames = -1, completionMessage;
 		this.cache;
 		path = argpath;
-		this.startFrame = startFrame.asInteger;
+		this.startFrame = startFrame;
 		^["/b_allocRead", bufnum, path, startFrame.asInteger, (numFrames ? -1).asInteger, completionMessage.value(this)]
 	}
 
 	allocReadChannelMsg { arg argpath, startFrame = 0, numFrames = -1, channels, completionMessage;
 		this.cache;
 		path = argpath;
-		this.startFrame = startFrame.asInteger;
+		this.startFrame = startFrame;
 		completionMessage !? { completionMessage = [completionMessage.value(this)] };
-		^["/b_allocReadChannel", bufnum, path, startFrame.asInteger, (numFrames ? -1).asInteger] ++ channels.asInteger ++ completionMessage
+		^["/b_allocReadChannel", bufnum, path, startFrame.asInteger, (numFrames ? -1).asInteger] ++ channels ++ completionMessage
 	}
 
 	// read whole file into memory for PlayBuf etc.
@@ -98,14 +98,14 @@ Buffer {
 		bufnum ?? { bufnum = server.nextBufferNumber(1) };
 		^super.newCopyArgs(server, bufnum)
 			.doOnInfo_(action).cache
-			.allocRead(path, startFrame.asInteger, numFrames.asInteger, {|buf|["/b_query", buf.bufnum] })
+			.allocRead(path, startFrame, numFrames, {|buf|["/b_query", buf.bufnum] })
 	}
 
 	read { arg argpath, fileStartFrame = 0, numFrames = -1, bufStartFrame = 0, leaveOpen = false, action;
 		this.cache;
 		doOnInfo = action;
 		server.listSendMsg(
-			this.readMsg(argpath, fileStartFrame.asInteger, numFrames.asInteger, bufStartFrame.asInteger,
+			this.readMsg(argpath, fileStartFrame, numFrames, bufStartFrame,
 				leaveOpen, {|buf| ["/b_query", buf.bufnum] })
 		);
 	}
@@ -115,7 +115,7 @@ Buffer {
 		bufnum ?? { bufnum = server.nextBufferNumber(1) };
 		^super.newCopyArgs(server, bufnum)
 			.doOnInfo_(action).cache
-			.allocReadChannel(path, startFrame.asInteger, numFrames.asInteger, channels.asInteger,
+			.allocReadChannel(path, startFrame, numFrames, channels,
 				{|buf|["/b_query", buf.bufnum]})
 	}
 
@@ -124,22 +124,22 @@ Buffer {
 		this.cache;
 		doOnInfo = action;
 		server.listSendMsg(
-			this.readChannelMsg(argpath, fileStartFrame.asInteger, numFrames.asInteger, bufStartFrame.asInteger,
-				leaveOpen, channels.asInteger, {|buf| ["/b_query", buf.bufnum] })
+			this.readChannelMsg(argpath, fileStartFrame, numFrames, bufStartFrame,
+				leaveOpen, channels, {|buf| ["/b_query", buf.bufnum] })
 		)
 	}
 
 	*readNoUpdate { arg server, path, startFrame = 0, numFrames = -1, bufnum, completionMessage;
 		server = server ? Server.default;
 		bufnum ?? { bufnum = server.nextBufferNumber(1) };
-		^super.newCopyArgs(server, bufnum).allocRead(path, startFrame.asInteger, numFrames.asInteger, completionMessage)
+		^super.newCopyArgs(server, bufnum).allocRead(path, startFrame, numFrames, completionMessage)
 	}
 
 	readNoUpdate { arg argpath, fileStartFrame = 0, numFrames = -1,
 		bufStartFrame = 0, leaveOpen = false, completionMessage;
 		server.listSendMsg(
 			this.readMsg(
-				argpath, fileStartFrame.asInteger, numFrames.asInteger, bufStartFrame.asInteger, leaveOpen, completionMessage
+				argpath, fileStartFrame, numFrames, bufStartFrame, leaveOpen, completionMessage
 			)
 		)
 	}
@@ -156,22 +156,22 @@ Buffer {
 		bufStartFrame = 0, leaveOpen = false, channels, completionMessage;
 		path = argpath;
 		^["/b_readChannel", bufnum, path, fileStartFrame.asInteger, (numFrames ? -1).asInteger,
-			bufStartFrame.asInteger, leaveOpen.binaryValue] ++ channels.asInteger ++ [completionMessage.value(this)]
+			bufStartFrame.asInteger, leaveOpen.binaryValue] ++ channels ++ [completionMessage.value(this)]
 		// doesn't set my numChannels etc.
 	}
 
 	// preload a buffer for use with DiskIn
 	*cueSoundFile { arg server, path, startFrame = 0, numChannels= 2, bufferSize=32768, completionMessage;
-		^this.alloc(server, bufferSize, numChannels.asInteger, { arg buffer;
+		^this.alloc(server, bufferSize, numChannels, { arg buffer;
 			buffer.path_(path);
-			buffer.cueSoundFileMsg(path, startFrame.asInteger, completionMessage);
+			buffer.cueSoundFileMsg(path, startFrame, completionMessage);
 		}).cache
 	}
 
 	cueSoundFile { arg path, startFrame, completionMessage;
 		this.path_(path);
 		server.listSendMsg(
-			this.cueSoundFileMsg(path, startFrame.asInteger, completionMessage)
+			this.cueSoundFileMsg(path, startFrame, completionMessage)
 		)
 	}
 
@@ -188,7 +188,7 @@ Buffer {
 			if(collection.isKindOf(RawArray).not) { collection = collection.as(FloatArray) };
 			sndfile = SoundFile.new;
 			sndfile.sampleRate = server.sampleRate;
-			sndfile.numChannels = numChannels.asInteger;
+			sndfile.numChannels = numChannels;
 			path = PathName.tmp ++ sndfile.hash.asString;
 			if(sndfile.openWrite(path),
 				{
@@ -215,13 +215,13 @@ Buffer {
 				{ "Collection larger than available number of Frames".warn });
 			sndfile = SoundFile.new;
 			sndfile.sampleRate = server.sampleRate;
-			sndfile.numChannels = numChannels.asInteger;
+			sndfile.numChannels = numChannels;
 			path = PathName.tmp ++ sndfile.hash.asString;
 			if(sndfile.openWrite(path),
 				{
 					sndfile.writeData(data);
 					sndfile.close;
-					this.read(path, bufStartFrame: startFrame.asInteger, action: { |buf|
+					this.read(path, bufStartFrame: startFrame, action: { |buf|
 						if(File.delete(path), { buf.path = nil },
 							{("Could not delete data file:" + path).warn });
 						action.value(buf)
@@ -233,7 +233,7 @@ Buffer {
 
 	// send a Collection to a buffer one UDP sized packet at a time
 	*sendCollection { arg server, collection, numChannels = 1, wait = -1, action;
-		var buffer = this.new(server, ceil(collection.size / numChannels.asInteger), numChannels.asInteger);
+		var buffer = this.new(server, ceil(collection.size / numChannels), numChannels);
 		forkIfNeeded {
 			buffer.alloc;
 			server.sync;
@@ -254,7 +254,7 @@ Buffer {
 			if ( collsize > ((numFrames - startFrame) * numChannels),
 				{ "Collection larger than available number of Frames".warn });
 
-			this.streamCollection(collstream, collsize, startFrame.asInteger * numChannels.asInteger, wait, action)
+			this.streamCollection(collstream, collsize, startFrame * numChannels, wait, action)
 		} {
 			MethodError("Invalid arguments to Buffer:sendCollection", this).throw
 		}
@@ -271,7 +271,7 @@ Buffer {
 			while { pos < collsize } {
 				// 1626 max size for setn under udp
 				bundsize = min(1626, collsize - pos);
-				server.listSendMsg(['/b_setn', bufnum, pos + startFrame.asInteger, bundsize]
+				server.listSendMsg(['/b_setn', bufnum, pos + startFrame, bundsize]
 					++ Array.fill(bundsize, { collstream.next }));
 				pos = collstream.pos;
 				if(wait >= 0) { wait.wait } { server.sync };
@@ -288,7 +288,7 @@ Buffer {
 		var msg, cond, path, file, array;
 		{
 			path = PathName.tmp ++ this.hash.asString;
-			msg = this.write(path, "aiff", "float", count, index.asInteger);
+			msg = this.write(path, "aiff", "float", count, index);
 			server.sync;
 			file = SoundFile.new;
 			protect {
@@ -312,7 +312,7 @@ Buffer {
 		pos = index = index.asInteger;
 		// treat -1 and nil the same
 		if(count == -1 || count.isNil) {
-			count = (numFrames.asInteger * numChannels.asInteger).asInteger - index;
+			count = (numFrames * numChannels).asInteger - index;
 		};
 		array = FloatArray.newClear(count);
 		refcount = (count / 1633).roundUp;
@@ -352,7 +352,7 @@ Buffer {
 		path = path ?? { thisProcess.platform.recordingsDir +/+ "SC_" ++ Date.localtime.stamp ++ "." ++ headerFormat };
 		server.listSendMsg(
 			this.writeMsg(path,
-				headerFormat, sampleFormat, numFrames.asInteger, startFrame.asInteger,
+				headerFormat, sampleFormat, numFrames, startFrame,
 				leaveOpen, completionMessage
 			)
 		)
@@ -405,7 +405,7 @@ Buffer {
 	}
 
 	set { arg index, float ... morePairs;
-		server.listSendMsg(this.setMsg(index.asInteger, float, *morePairs));
+		server.listSendMsg(this.setMsg(index, float, *morePairs));
 	}
 
 	setMsg { arg index, float ... morePairs;
@@ -440,7 +440,7 @@ Buffer {
 		// note: do not try to optimize this by moving 'getMsg' to the end
 		// we need 'getMsg' to check the buffer's validity *before* making the OSCFunc
 		// 'getMsg' must be first!
-		var msg = this.getMsg(index.asInteger);
+		var msg = this.getMsg(index);
 		OSCFunc({ |message|
 			// The server replies with a message of the form [/b_set, bufnum, index, value].
 			// We want "value," which is at index 3.
@@ -458,7 +458,7 @@ Buffer {
 		// note: do not try to optimize this by moving 'getnMsg' to the end
 		// we need 'getnMsg' to check the buffer's validity *before* making the OSCFunc
 		// 'getnMsg' must be first!
-		var msg = this.getnMsg(index.asInteger, count);  // action is not used
+		var msg = this.getnMsg(index, count);  // action is not used
 		OSCFunc({ |message|
 			// The server replies with a message of the form
 			// [/b_setn, bufnum, starting index, length, ...sample values].
@@ -474,7 +474,7 @@ Buffer {
 	}
 
 	fill { arg startAt, numFrames, value ... more;
-		server.listSendMsg(this.fillMsg(startAt, numFrames.asInteger, value, *more));
+		server.listSendMsg(this.fillMsg(startAt, numFrames, value, *more));
 	}
 
 	fillMsg { arg startAt, numFrames, value ... more;
@@ -584,7 +584,7 @@ Buffer {
 		action = action ?? {
 			{ |oscAddrPattern, bufnum, numFrames, numChannels, sampleRate|
 				postf("bufnum: %\nnumFrames: %\nnumChannels: %\nsampleRate: %\n",
-					bufnum, numFrames.asInteger, numChannels.asInteger, sampleRate
+					bufnum, numFrames, numChannels, sampleRate
 				);
 			}
 		};
@@ -686,7 +686,7 @@ Buffer {
 	}
 
 	printOn { arg stream;
-		stream << this.class.name << "(" <<* [bufnum, numFrames, numChannels.asInteger, sampleRate, path] <<")"
+		stream << this.class.name << "(" <<* [bufnum, numFrames, numChannels, sampleRate, path] <<")"
 	}
 
 	*loadDialog { arg server, startFrame = 0, numFrames, action, bufnum;
@@ -696,7 +696,7 @@ Buffer {
 		buffer = super.newCopyArgs(server, bufnum).cache;
 		Dialog.openPanel({ arg path;
 			buffer.doOnInfo_(action)
-				.allocRead(path, startFrame.asInteger, numFrames.asInteger, { ["/b_query", buffer.bufnum] })
+				.allocRead(path, startFrame, numFrames, { ["/b_query", buffer.bufnum] })
 		});
 		^buffer
 	}
@@ -708,7 +708,7 @@ Buffer {
 		buffer = super.newCopyArgs(server, bufnum).cache;
 		Dialog.openPanel({ arg path;
 			buffer.doOnInfo_(action)
-			.allocReadChannel(path, startFrame.asInteger, numFrames.asInteger, channels.asInteger,
+			.allocReadChannel(path, startFrame, numFrames, channels,
 				{|buf|["/b_query", buf.bufnum]})
 		});
 		^buffer
@@ -717,7 +717,7 @@ Buffer {
 	play { arg loop = false, mul = 1;
 		if(bufnum.isNil) { Error("Cannot play a % that has been freed".format(this.class.name)).throw };
 		^{ var player;
-			player = PlayBuf.ar(numChannels.asInteger, bufnum, BufRateScale.kr(bufnum),
+			player = PlayBuf.ar(numChannels, bufnum, BufRateScale.kr(bufnum),
 				loop: loop.binaryValue);
 			if(loop.not, FreeSelfWhenDone.kr(player));
 			player * mul;

--- a/SCClassLibrary/Common/Control/Buffer.sc
+++ b/SCClassLibrary/Common/Control/Buffer.sc
@@ -105,7 +105,7 @@ Buffer {
 		this.cache;
 		doOnInfo = action;
 		server.listSendMsg(
-			this.readMsg(argpath, fileStartFrame, numFrames.asInteger, bufStartFrame.asInteger,
+			this.readMsg(argpath, fileStartFrame.asInteger, numFrames.asInteger, bufStartFrame.asInteger,
 				leaveOpen, {|buf| ["/b_query", buf.bufnum] })
 		);
 	}
@@ -124,7 +124,7 @@ Buffer {
 		this.cache;
 		doOnInfo = action;
 		server.listSendMsg(
-			this.readChannelMsg(argpath, fileStartFrame, numFrames.asInteger, bufStartFrame.asInteger,
+			this.readChannelMsg(argpath, fileStartFrame.asInteger, numFrames.asInteger, bufStartFrame.asInteger,
 				leaveOpen, channels, {|buf| ["/b_query", buf.bufnum] })
 		)
 	}
@@ -139,7 +139,7 @@ Buffer {
 		bufStartFrame = 0, leaveOpen = false, completionMessage;
 		server.listSendMsg(
 			this.readMsg(
-				argpath, fileStartFrame, numFrames.asInteger, bufStartFrame.asInteger, leaveOpen, completionMessage
+				argpath, fileStartFrame.asInteger, numFrames.asInteger, bufStartFrame.asInteger, leaveOpen, completionMessage
 			)
 		)
 	}

--- a/SCClassLibrary/Common/Control/Buffer.sc
+++ b/SCClassLibrary/Common/Control/Buffer.sc
@@ -18,7 +18,7 @@ Buffer {
 		^super.newCopyArgs(
 			server,
 			bufnum,
-			numFrames,
+			numFrames.asInteger,
 			numChannels,
 			sampleRate
 		).cache
@@ -31,7 +31,7 @@ Buffer {
 		^super.newCopyArgs(
 			server,
 			bufnum,
-			numFrames,
+			numFrames.asInteger,
 			numChannels,
 			sampleRate
 		).alloc(completionMessage).cache
@@ -61,13 +61,13 @@ Buffer {
 	allocRead { arg argpath, startFrame = 0, numFrames = -1, completionMessage;
 		path = argpath;
 		this.startFrame = startFrame;
-		server.listSendMsg(this.allocReadMsg( argpath, startFrame, numFrames, completionMessage))
+		server.listSendMsg(this.allocReadMsg(argpath, startFrame, numFrames.asInteger, completionMessage))
 	}
 
 	allocReadChannel { arg argpath, startFrame = 0, numFrames = -1, channels, completionMessage;
 		path = argpath;
 		this.startFrame = startFrame;
-		server.listSendMsg(this.allocReadChannelMsg( argpath, startFrame, numFrames, channels,
+		server.listSendMsg(this.allocReadChannelMsg(argpath, startFrame, numFrames.asInteger, channels,
 			completionMessage))
 	}
 
@@ -98,14 +98,14 @@ Buffer {
 		bufnum ?? { bufnum = server.nextBufferNumber(1) };
 		^super.newCopyArgs(server, bufnum)
 			.doOnInfo_(action).cache
-			.allocRead(path, startFrame, numFrames, {|buf|["/b_query", buf.bufnum] })
+			.allocRead(path, startFrame, numFrames.asInteger, {|buf|["/b_query", buf.bufnum] })
 	}
 
 	read { arg argpath, fileStartFrame = 0, numFrames = -1, bufStartFrame = 0, leaveOpen = false, action;
 		this.cache;
 		doOnInfo = action;
 		server.listSendMsg(
-			this.readMsg(argpath, fileStartFrame, numFrames, bufStartFrame,
+			this.readMsg(argpath, fileStartFrame, numFrames.asInteger, bufStartFrame,
 				leaveOpen, {|buf| ["/b_query", buf.bufnum] })
 		);
 	}
@@ -115,7 +115,7 @@ Buffer {
 		bufnum ?? { bufnum = server.nextBufferNumber(1) };
 		^super.newCopyArgs(server, bufnum)
 			.doOnInfo_(action).cache
-			.allocReadChannel(path, startFrame, numFrames, channels,
+			.allocReadChannel(path, startFrame, numFrames.asInteger, channels,
 				{|buf|["/b_query", buf.bufnum]})
 	}
 
@@ -124,7 +124,7 @@ Buffer {
 		this.cache;
 		doOnInfo = action;
 		server.listSendMsg(
-			this.readChannelMsg(argpath, fileStartFrame, numFrames, bufStartFrame,
+			this.readChannelMsg(argpath, fileStartFrame, numFrames.asInteger, bufStartFrame,
 				leaveOpen, channels, {|buf| ["/b_query", buf.bufnum] })
 		)
 	}
@@ -132,14 +132,14 @@ Buffer {
 	*readNoUpdate { arg server, path, startFrame = 0, numFrames = -1, bufnum, completionMessage;
 		server = server ? Server.default;
 		bufnum ?? { bufnum = server.nextBufferNumber(1) };
-		^super.newCopyArgs(server, bufnum).allocRead(path, startFrame, numFrames, completionMessage)
+		^super.newCopyArgs(server, bufnum).allocRead(path, startFrame, numFrames.asInteger, completionMessage)
 	}
 
 	readNoUpdate { arg argpath, fileStartFrame = 0, numFrames = -1,
 		bufStartFrame = 0, leaveOpen = false, completionMessage;
 		server.listSendMsg(
 			this.readMsg(
-				argpath, fileStartFrame, numFrames, bufStartFrame, leaveOpen, completionMessage
+				argpath, fileStartFrame, numFrames.asInteger, bufStartFrame, leaveOpen, completionMessage
 			)
 		)
 	}
@@ -352,7 +352,7 @@ Buffer {
 		path = path ?? { thisProcess.platform.recordingsDir +/+ "SC_" ++ Date.localtime.stamp ++ "." ++ headerFormat };
 		server.listSendMsg(
 			this.writeMsg(path,
-				headerFormat, sampleFormat, numFrames, startFrame,
+				headerFormat, sampleFormat, numFrames.asInteger, startFrame,
 				leaveOpen, completionMessage
 			)
 		)
@@ -474,7 +474,7 @@ Buffer {
 	}
 
 	fill { arg startAt, numFrames, value ... more;
-		server.listSendMsg(this.fillMsg(startAt, numFrames, value, *more));
+		server.listSendMsg(this.fillMsg(startAt, numFrames.asInteger, value, *more));
 	}
 
 	fillMsg { arg startAt, numFrames, value ... more;
@@ -584,7 +584,7 @@ Buffer {
 		action = action ?? {
 			{ |oscAddrPattern, bufnum, numFrames, numChannels, sampleRate|
 				postf("bufnum: %\nnumFrames: %\nnumChannels: %\nsampleRate: %\n",
-					bufnum, numFrames, numChannels, sampleRate
+					bufnum, numFrames.asInteger, numChannels, sampleRate
 				);
 			}
 		};
@@ -696,7 +696,7 @@ Buffer {
 		buffer = super.newCopyArgs(server, bufnum).cache;
 		Dialog.openPanel({ arg path;
 			buffer.doOnInfo_(action)
-				.allocRead(path, startFrame, numFrames, { ["/b_query", buffer.bufnum] })
+				.allocRead(path, startFrame, numFrames.asInteger, { ["/b_query", buffer.bufnum] })
 		});
 		^buffer
 	}
@@ -708,7 +708,7 @@ Buffer {
 		buffer = super.newCopyArgs(server, bufnum).cache;
 		Dialog.openPanel({ arg path;
 			buffer.doOnInfo_(action)
-			.allocReadChannel(path, startFrame, numFrames, channels,
+			.allocReadChannel(path, startFrame, numFrames.asInteger, channels,
 				{|buf|["/b_query", buf.bufnum]})
 		});
 		^buffer

--- a/SCClassLibrary/Common/Control/Buffer.sc
+++ b/SCClassLibrary/Common/Control/Buffer.sc
@@ -105,7 +105,7 @@ Buffer {
 		this.cache;
 		doOnInfo = action;
 		server.listSendMsg(
-			this.readMsg(argpath, fileStartFrame, numFrames.asInteger, bufStartFrame,
+			this.readMsg(argpath, fileStartFrame, numFrames.asInteger, bufStartFrame.asInteger,
 				leaveOpen, {|buf| ["/b_query", buf.bufnum] })
 		);
 	}
@@ -124,7 +124,7 @@ Buffer {
 		this.cache;
 		doOnInfo = action;
 		server.listSendMsg(
-			this.readChannelMsg(argpath, fileStartFrame, numFrames.asInteger, bufStartFrame,
+			this.readChannelMsg(argpath, fileStartFrame, numFrames.asInteger, bufStartFrame.asInteger,
 				leaveOpen, channels, {|buf| ["/b_query", buf.bufnum] })
 		)
 	}
@@ -139,7 +139,7 @@ Buffer {
 		bufStartFrame = 0, leaveOpen = false, completionMessage;
 		server.listSendMsg(
 			this.readMsg(
-				argpath, fileStartFrame, numFrames.asInteger, bufStartFrame, leaveOpen, completionMessage
+				argpath, fileStartFrame, numFrames.asInteger, bufStartFrame.asInteger, leaveOpen, completionMessage
 			)
 		)
 	}

--- a/SCClassLibrary/Common/Control/Buffer.sc
+++ b/SCClassLibrary/Common/Control/Buffer.sc
@@ -288,7 +288,7 @@ Buffer {
 		var msg, cond, path, file, array;
 		{
 			path = PathName.tmp ++ this.hash.asString;
-			msg = this.write(path, "aiff", "float", count, index);
+			msg = this.write(path, "aiff", "float", count, index.asInteger);
 			server.sync;
 			file = SoundFile.new;
 			protect {
@@ -405,7 +405,7 @@ Buffer {
 	}
 
 	set { arg index, float ... morePairs;
-		server.listSendMsg(this.setMsg(index, float, *morePairs));
+		server.listSendMsg(this.setMsg(index.asInteger, float, *morePairs));
 	}
 
 	setMsg { arg index, float ... morePairs;
@@ -440,7 +440,7 @@ Buffer {
 		// note: do not try to optimize this by moving 'getMsg' to the end
 		// we need 'getMsg' to check the buffer's validity *before* making the OSCFunc
 		// 'getMsg' must be first!
-		var msg = this.getMsg(index);
+		var msg = this.getMsg(index.asInteger);
 		OSCFunc({ |message|
 			// The server replies with a message of the form [/b_set, bufnum, index, value].
 			// We want "value," which is at index 3.
@@ -458,7 +458,7 @@ Buffer {
 		// note: do not try to optimize this by moving 'getnMsg' to the end
 		// we need 'getnMsg' to check the buffer's validity *before* making the OSCFunc
 		// 'getnMsg' must be first!
-		var msg = this.getnMsg(index, count);  // action is not used
+		var msg = this.getnMsg(index.asInteger, count);  // action is not used
 		OSCFunc({ |message|
 			// The server replies with a message of the form
 			// [/b_setn, bufnum, starting index, length, ...sample values].

--- a/SCClassLibrary/Common/Control/Buffer.sc
+++ b/SCClassLibrary/Common/Control/Buffer.sc
@@ -312,7 +312,7 @@ Buffer {
 		pos = index = index.asInteger;
 		// treat -1 and nil the same
 		if(count == -1 || count.isNil) {
-			count = (numFrames * numChannels.asInteger).asInteger - index;
+			count = (numFrames.asInteger * numChannels.asInteger).asInteger - index;
 		};
 		array = FloatArray.newClear(count);
 		refcount = (count / 1633).roundUp;

--- a/SCClassLibrary/Common/Control/Buffer.sc
+++ b/SCClassLibrary/Common/Control/Buffer.sc
@@ -19,7 +19,7 @@ Buffer {
 			server,
 			bufnum,
 			numFrames.asInteger,
-			numChannels,
+			numChannels.asInteger,
 			sampleRate
 		).cache
 	}
@@ -32,7 +32,7 @@ Buffer {
 			server,
 			bufnum,
 			numFrames.asInteger,
-			numChannels,
+			numChannels.asInteger,
 			sampleRate
 		).alloc(completionMessage).cache
 	}
@@ -162,7 +162,7 @@ Buffer {
 
 	// preload a buffer for use with DiskIn
 	*cueSoundFile { arg server, path, startFrame = 0, numChannels= 2, bufferSize=32768, completionMessage;
-		^this.alloc(server, bufferSize, numChannels, { arg buffer;
+		^this.alloc(server, bufferSize, numChannels.asInteger, { arg buffer;
 			buffer.path_(path);
 			buffer.cueSoundFileMsg(path, startFrame.asInteger, completionMessage);
 		}).cache
@@ -188,7 +188,7 @@ Buffer {
 			if(collection.isKindOf(RawArray).not) { collection = collection.as(FloatArray) };
 			sndfile = SoundFile.new;
 			sndfile.sampleRate = server.sampleRate;
-			sndfile.numChannels = numChannels;
+			sndfile.numChannels = numChannels.asInteger;
 			path = PathName.tmp ++ sndfile.hash.asString;
 			if(sndfile.openWrite(path),
 				{
@@ -215,7 +215,7 @@ Buffer {
 				{ "Collection larger than available number of Frames".warn });
 			sndfile = SoundFile.new;
 			sndfile.sampleRate = server.sampleRate;
-			sndfile.numChannels = numChannels;
+			sndfile.numChannels = numChannels.asInteger;
 			path = PathName.tmp ++ sndfile.hash.asString;
 			if(sndfile.openWrite(path),
 				{
@@ -233,7 +233,7 @@ Buffer {
 
 	// send a Collection to a buffer one UDP sized packet at a time
 	*sendCollection { arg server, collection, numChannels = 1, wait = -1, action;
-		var buffer = this.new(server, ceil(collection.size / numChannels), numChannels);
+		var buffer = this.new(server, ceil(collection.size / numChannels.asInteger), numChannels.asInteger);
 		forkIfNeeded {
 			buffer.alloc;
 			server.sync;
@@ -254,7 +254,7 @@ Buffer {
 			if ( collsize > ((numFrames - startFrame) * numChannels),
 				{ "Collection larger than available number of Frames".warn });
 
-			this.streamCollection(collstream, collsize, startFrame.asInteger * numChannels, wait, action)
+			this.streamCollection(collstream, collsize, startFrame.asInteger * numChannels.asInteger, wait, action)
 		} {
 			MethodError("Invalid arguments to Buffer:sendCollection", this).throw
 		}
@@ -312,7 +312,7 @@ Buffer {
 		pos = index = index.asInteger;
 		// treat -1 and nil the same
 		if(count == -1 || count.isNil) {
-			count = (numFrames * numChannels).asInteger - index;
+			count = (numFrames * numChannels.asInteger).asInteger - index;
 		};
 		array = FloatArray.newClear(count);
 		refcount = (count / 1633).roundUp;
@@ -584,7 +584,7 @@ Buffer {
 		action = action ?? {
 			{ |oscAddrPattern, bufnum, numFrames, numChannels, sampleRate|
 				postf("bufnum: %\nnumFrames: %\nnumChannels: %\nsampleRate: %\n",
-					bufnum, numFrames.asInteger, numChannels, sampleRate
+					bufnum, numFrames.asInteger, numChannels.asInteger, sampleRate
 				);
 			}
 		};
@@ -686,7 +686,7 @@ Buffer {
 	}
 
 	printOn { arg stream;
-		stream << this.class.name << "(" <<* [bufnum, numFrames, numChannels, sampleRate, path] <<")"
+		stream << this.class.name << "(" <<* [bufnum, numFrames, numChannels.asInteger, sampleRate, path] <<")"
 	}
 
 	*loadDialog { arg server, startFrame = 0, numFrames, action, bufnum;
@@ -717,7 +717,7 @@ Buffer {
 	play { arg loop = false, mul = 1;
 		if(bufnum.isNil) { Error("Cannot play a % that has been freed".format(this.class.name)).throw };
 		^{ var player;
-			player = PlayBuf.ar(numChannels, bufnum, BufRateScale.kr(bufnum),
+			player = PlayBuf.ar(numChannels.asInteger, bufnum, BufRateScale.kr(bufnum),
 				loop: loop.binaryValue);
 			if(loop.not, FreeSelfWhenDone.kr(player));
 			player * mul;


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

fixes #7462 

## Purpose and Motivation

I tried adding `.asInteger` in all possible places, but it produced the following error:
```
ERROR: Message 'asInteger' not understood.
RECEIVER:
   nil
ARGS:
KEYWORD ARGUMENTS:

PROTECTED CALL STACK:
	Meta_MethodError:new	0x1533ed940
		arg this = DoesNotUnderstandError
		arg what = nil
		arg receiver = nil
	Meta_DoesNotUnderstandError:new	0x1533efd00
		arg this = DoesNotUnderstandError
		arg receiver = nil
		arg selector = asInteger
		arg args = []
		arg keywordArgumentPairs = []
	Object:doesNotUnderstand	0x1747c7640
		arg this = nil
		arg selector = asInteger
		arg args = nil
		arg kwargs = nil
	Meta_Buffer:new	0x159cd9680
		arg this = Buffer
		arg server = localhost
		arg numFrames = nil
		arg numChannels = nil
		arg bufnum = 0
		arg sampleRate = 48000.0
	a FunctionDef	0x15adc6e80
		sourceCode = "<an open Function>"
		arg i = 0
	Integer:do	0x31148dbc0
		arg this = 100
		arg function = a Function
		var i = 0
	Meta_Collection:fill	0x15adc6a80
		arg this = Array
		arg size = 100
		arg function = a Function
		var obj = []
	Meta_SayBuf:prepRRBufs	0x17342e900
		arg this = SayBuf
		arg server = localhost
		arg numBufs = 100
	Function:doOnServerBoot	0x152a371c0
		arg this = a Function
		arg server = localhost
	ArrayedCollection:do	0x329363a00
		arg this = [a Function, a Function]
		arg function = a Function
		var i = 1
	List:do	0x32932ed00
		arg this = List[a Function, a Function]
		arg function = a Function
	Meta_AbstractServerAction:performFunction	0x1731c6080
		arg this = ServerBoot
		arg server = localhost
		arg function = a Function
	Meta_AbstractServerAction:run	0x1731c6540
		arg this = ServerBoot
		arg server = localhost
		var selector = doOnServerBoot
	a FunctionDef	0x329469a00
		sourceCode = "<an open Function>"
	Routine:prStart	0x15a374900
		arg this = a Routine
		arg inval = 42657.560064459

CALL STACK:
	DoesNotUnderstandError:reportError
		arg this = <instance of DoesNotUnderstandError>
	< closed FunctionDef >
		arg error = <instance of DoesNotUnderstandError>
	Function:try
		arg this = <instance of Function>
		arg handler = <instance of Function>
		var result = <instance of DoesNotUnderstandError>
	< FunctionDef in Method Scheduler:seconds_ >
		arg time = 42657.560064459
		arg item = <instance of Routine>
	< FunctionDef in Method SequenceableCollection:pairsDo >
		arg i = 0
	Integer:forBy
		arg this = 0
		arg endval = 0
		arg stepval = 2
		arg function = <instance of Function>
		var i = 0
		var j = 0
	SequenceableCollection:pairsDo
		arg this = [*2]
		arg function = <instance of Function>
	Scheduler:seconds_
		arg this = <instance of Scheduler>
		arg newSeconds = 42657.560113542
	Meta_AppClock:tick
		arg this = <instance of Meta_AppClock>
		var saveClock = <instance of Meta_SystemClock>
	Process:tick
		arg this = <instance of Main>

^^ ERROR: Message 'asInteger' not understood.
RECEIVER: nil

Message with a similar name understood by the receiver:
	isInteger

Many other objects respond to the message 'asInteger' (found 9 superclasses).
```
After removing `.asInteger` from `Buffer.new`, I was able to avoid this particular error. However, the same error still occurred when evaluating `.free` (an instance method of `Buffer`).

So, in the end, I applied this change only to `Buffer.alloc`.

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
