### PR TITLE
Add `asInteger` to `numFrames` & `numChannels` of `Buffer.alloc` & `Buffer.getToFloatArray`

### DIFF
--- a/SCClassLibrary/Common/Control/Buffer.sc
+++ b/SCClassLibrary/Common/Control/Buffer.sc
@@ -312,7 +312,7 @@ Buffer {
 		pos = index = index.asInteger;
 		// treat -1 and nil the same
 		if(count == -1 || count.isNil) {
-			count = (numFrames * numChannels).asInteger - index;
+			count = (numFrames.asInteger * numChannels.asInteger).asInteger - index;
 		};
 		array = FloatArray.newClear(count);
 		refcount = (count / 1633).roundUp;

--- a/SCClassLibrary/Common/Control/Buffer.sc
+++ b/SCClassLibrary/Common/Control/Buffer.sc
@@ -31,8 +31,8 @@ Buffer {
 		^super.newCopyArgs(
 			server,
 			bufnum,
-			numFrames,
-			numChannels,
+			numFrames.asInteger,
+			numChannels.asInteger,
 			sampleRate
 		).alloc(completionMessage).cache
 	}


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->
fixes #7462 

## Purpose and Motivation

This PR resolves the error triggered by evaluating the following example code from #7462:

```supercollider
b = Buffer.alloc(s, 6890.625, 10);

// actually, you don't need any data
a = { RecordBuf.ar(Array.fill(10, { WhiteNoise.ar }), b, loop: 0, doneAction: 2); Silent.ar(1) }.play;

b.getToFloatArray(wait: -1, timeout: 10, action: { |data| data.postln });
```
However, if this example code is not expected to throw an error without truncating `6890.625`, then I have misunderstood the issue, and this PR should probably be closed.

As far as I understand it, there are two possible ways to address the issue:

1. [Add `.asInteger` to `var count` in the `getToFloatArray` method](https://github.com/supercollider/supercollider/commit/6c39387de2c8a66b3d5f753e6ac972755abb10ed).  
   At the moment, the implementation applies `.asInteger` to `(numFrames * numChannels)`, which may lead to an incorrect calculation.

2. [Add `.asInteger` to `numFrames` and `numChannels` in `Buffer.alloc`](https://github.com/supercollider/supercollider/commit/ac71924dfa49ec9e10f1878eb20beafa240ce8b3).  
   The documentation says that `numFrames` and `numChannels` are truncated, but the corresponding method does not currently do this. This commit would make the implementation consistent with the documentation.

I put the second approach in a separate PR (#7471), but my impression is that it is better left as a draft for now. That is why I opened this new PR instead.

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
