### PR TITLE
Add `ratiocent` and `centratio` methods

### DIFF
--- a/HelpSource/Classes/AbstractFunction.schelp
+++ b/HelpSource/Classes/AbstractFunction.schelp
@@ -121,6 +121,8 @@ a = Pseries(220, 220, inf).cpsmidi; a.asStream.nextN(12); // overtone series as 
 
 method::midiratio
 method::ratiomidi
+method::centratio
+method::ratiocent
 method::ampdb
 method::dbamp
 method::octcps

--- a/HelpSource/Classes/SequenceableCollection.schelp
+++ b/HelpSource/Classes/SequenceableCollection.schelp
@@ -753,7 +753,7 @@ subsection::Math Support - Unary Messages
 
 All of the following messages send the message link::#-performUnaryOp:: to the receiver with the unary message selector as an argument.
 
-method::neg, reciprocal, bitNot, abs, asFloat, ceil, floor, frac, sign, squared, cubed, sqrt, exp, midicps, cpsmidi, midiratio, ratiomidi, ampdb, dbamp, octcps, cpsoct, log, log2, log10, sin, cos, tan, asin, acos, atan, sinh, cosh, tanh, rand, rand2, linrand, bilinrand, sum3rand, distort, softclip, coin, even, odd, isPositive, isNegative, isStrictlyPositive, real, imag, magnitude, magnitudeApx, phase, angle, rho, theta, asFloat, asInteger
+method::neg, reciprocal, bitNot, abs, asFloat, ceil, floor, frac, sign, squared, cubed, sqrt, exp, midicps, cpsmidi, midiratio, ratiomidi, centratio, ratiocent, ampdb, dbamp, octcps, cpsoct, log, log2, log10, sin, cos, tan, asin, acos, atan, sinh, cosh, tanh, rand, rand2, linrand, bilinrand, sum3rand, distort, softclip, coin, even, odd, isPositive, isNegative, isStrictlyPositive, real, imag, magnitude, magnitudeApx, phase, angle, rho, theta, asFloat, asInteger
 
 method::performUnaryOp
 Creates a new collection of the results of applying the selector to all elements in the receiver.

--- a/HelpSource/Classes/SimpleNumber.schelp
+++ b/HelpSource/Classes/SimpleNumber.schelp
@@ -953,6 +953,14 @@ method:: ratiomidi
 Convert a ratio to an interval in semitones.
 returns:: an interval in semitones
 
+method:: centratio
+Convert an interval in cents to a ratio.
+returns:: a ratio
+
+method:: ratiocent
+Convert a ratio to an interval in cents.
+returns:: an interval in cents
+
 method:: ampdb
 Convert a linear amplitude to decibels.
 

--- a/HelpSource/Overviews/Operators.schelp
+++ b/HelpSource/Overviews/Operators.schelp
@@ -108,6 +108,12 @@ Convert an interval in MIDI notes into a frequency ratio.
 method:: ratiomidi
 Convert a frequency ratio to an interval in MIDI notes.
 
+method:: centratio
+Convert an interval in cents into a frequency ratio.
+
+method:: ratiocent
+Convert a frequency ratio to an interval in cents.
+
 method:: dbamp
 Convert decibels to linear amplitude.
 

--- a/SCClassLibrary/Common/Collections/SequenceableCollection.sc
+++ b/SCClassLibrary/Common/Collections/SequenceableCollection.sc
@@ -793,6 +793,8 @@ SequenceableCollection : Collection {
 	midicps { ^this.performUnaryOp('midicps') }
 	cpsmidi { ^this.performUnaryOp('cpsmidi') }
 	midiratio { ^this.performUnaryOp('midiratio') }
+	ratiocent { ^this.performUnaryOp('ratiocent') }
+	centratio { ^this.performUnaryOp('centratio') }
 	ratiomidi { ^this.performUnaryOp('ratiomidi') }
 	ampdb { ^this.performUnaryOp('ampdb') }
 	dbamp { ^this.performUnaryOp('dbamp') }

--- a/SCClassLibrary/Common/Core/AbstractFunction.sc
+++ b/SCClassLibrary/Common/Core/AbstractFunction.sc
@@ -48,6 +48,8 @@ AbstractFunction {
 	cpsmidi { ^this.composeUnaryOp('cpsmidi') }
 	midiratio { ^this.composeUnaryOp('midiratio') }
 	ratiomidi { ^this.composeUnaryOp('ratiomidi') }
+	ratiocent { ^this.composeUnaryOp('ratiocent') }
+	centratio { ^this.composeUnaryOp('centratio') }
 	ampdb { ^this.composeUnaryOp('ampdb') }
 	dbamp { ^this.composeUnaryOp('dbamp') }
 	octcps { ^this.composeUnaryOp('octcps') }

--- a/SCClassLibrary/Common/Core/Symbol.sc
+++ b/SCClassLibrary/Common/Core/Symbol.sc
@@ -124,6 +124,8 @@ Symbol {
 	cpsmidi { ^this }
 	midiratio { ^this }
 	ratiomidi { ^this }
+	centratio { ^this }
+	ratiocent { ^this }
 	ampdb { ^this }
 	dbamp { ^this }
 	octcps { ^this }

--- a/SCClassLibrary/Common/Math/Signal.sc
+++ b/SCClassLibrary/Common/Math/Signal.sc
@@ -235,6 +235,8 @@ Signal[float] : FloatArray {
 	//cpsmidi { _CPSMIDI; ^this.primitiveFailed }
 	//midiratio { _MIDIRatio; ^this.primitiveFailed }
 	//ratiomidi { _RatioMIDI; ^this.primitiveFailed }
+	//centratio { _MIDIRatio; ^this.primitiveFailed }
+	//ratiocent { _RatioMIDI; ^this.primitiveFailed }
 	//ampdb { _AmpDb; ^this.primitiveFailed }
 	//dbamp { _DbAmp; ^this.primitiveFailed }
 	//octcps { _OctCPS; ^this.primitiveFailed }

--- a/SCClassLibrary/Common/Math/SimpleNumber.sc
+++ b/SCClassLibrary/Common/Math/SimpleNumber.sc
@@ -25,6 +25,8 @@ SimpleNumber : Number {
 	cpsmidi { _CPSMIDI; ^this.primitiveFailed }
 	midiratio { _MIDIRatio; ^this.primitiveFailed }
 	ratiomidi { _RatioMIDI; ^this.primitiveFailed }
+	centratio { ^(this / 100).midiratio }
+	ratiocent { ^(this.ratiomidi * 100) }
 	ampdb { _AmpDb; ^this.primitiveFailed }
 	dbamp { _DbAmp; ^this.primitiveFailed }
 	octcps { _OctCPS; ^this.primitiveFailed }


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation
This PR adds `ratiocent` and `centratio`.

Ideally, as with the other unary operators, these methods would be implemented as primitives. In that case, the SC methods would delegate to corresponding primitives such as `_RatioCent` and `_CentRatio`. Doing so would also require adding the new method names to the lexer and providing the corresponding C++ implementations.

For the moment, however, I have taken a simpler approach by reusing the existing midiratio and ratiomidi methods.

My impression is that this may not be regarded as the preferred long-term implementation. Even so, I thought it might still be useful to put together a minimal working version first and offer it as a starting point for discussion.

## Types of changes

<!-- Delete lines that don't apply -->

- Documentation
- New feature
## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
