### PR TITLE
cmake: fix sclang final build

### DIFF
--- a/QtCollider/primitives/primitives.h
+++ b/QtCollider/primitives/primitives.h
@@ -19,6 +19,8 @@
  *
  ************************************************************************/
 
+#pragma once
+
 #include <PyrPrimitive.h>
 #include <VMGlobals.h>
 #include <PyrSlot.h>

--- a/common/SC_Version.hpp.in
+++ b/common/SC_Version.hpp.in
@@ -18,6 +18,8 @@
  *    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
  */
 
+#pragma once
+
 #include <string>
 #include <sstream>
 #include <cstdint>

--- a/lang/CMakeLists.txt
+++ b/lang/CMakeLists.txt
@@ -187,11 +187,14 @@ endif()
 include(../SCDoc/CMakeLists.txt)
 list(APPEND sclang_sources ${SCDOC_SRCS})
 
-if(0 AND FINAL_BUILD) # sclang final-builds are broken
-	CREATE_FINAL_FILE(libsclang_final.cpp ${sclang_sources})
-	add_library(libsclang STATIC libsclang_final.cpp ${sclang_parser_source})
-else()
-	add_library(libsclang STATIC ${sclang_sources} ${sclang_parser_source})
+add_library(libsclang STATIC ${sclang_sources} ${sclang_parser_source})
+
+if(FINAL_BUILD)
+	set_source_files_properties(${sclang_parser_source} PROPERTIES SKIP_UNITY_BUILD_INCLUSION ON)
+	set_target_properties(libsclang PROPERTIES 
+		UNITY_BUILD ON
+		UNITY_BUILD_BATCH_SIZE 16 
+	)
 endif()
 
 target_compile_definitions(libsclang PRIVATE YYSTACK_USE_ALLOC)

--- a/lang/LangPrimSource/OSCData.cpp
+++ b/lang/LangPrimSource/OSCData.cpp
@@ -618,8 +618,6 @@ static PyrInt8Array* MsgToInt8Array(sc_msg_iter& msg, bool runGC) {
     return obj;
 }
 
-static const double dInfinity = std::numeric_limits<double>::infinity();
-
 // Convert raw OSC message to Array.
 static PyrObject* ConvertOSCMessage(int inSize, const char* inData) {
     if ((inSize & 3) != 0) {

--- a/lang/LangPrimSource/PyrSched.cpp
+++ b/lang/LangPrimSource/PyrSched.cpp
@@ -55,7 +55,6 @@
 #    include <sys/time.h>
 #endif
 
-static const double dInfinity = std::numeric_limits<double>::infinity();
 
 void runAwakeMessage(VMGlobals* g);
 

--- a/lang/LangPrimSource/SC_ComPort.cpp
+++ b/lang/LangPrimSource/SC_ComPort.cpp
@@ -268,7 +268,7 @@ void UDP::initHandler(HandlerType handlerType) {
 void UDP::startReceiveUDP() {
     using namespace boost;
     mUdpSocket.async_receive_from(
-        asio::buffer(mRecvBuffer), mRemoteEndpoint,
+        boost::asio::buffer(mRecvBuffer), mRemoteEndpoint,
         [this](auto error, auto bytesTransferred) { handleReceivedUDP(error, bytesTransferred); });
 }
 

--- a/lang/LangSource/PyrSched.h
+++ b/lang/LangSource/PyrSched.h
@@ -73,3 +73,5 @@ inline int lockLanguageOrQuit(std::atomic<bool> const& shouldBeRunning) {
     }
     return 0;
 }
+
+inline constexpr double dInfinity = std::numeric_limits<double>::infinity();

--- a/lang/LangSource/SC_CLIOptions.hpp
+++ b/lang/LangSource/SC_CLIOptions.hpp
@@ -1,3 +1,5 @@
+#pragma once
+
 #include "boost/program_options.hpp"
 #include <string>
 #include <optional>


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

Unity build aka final build for the sclang target was previously broken.

I fixed it by excluding Bison file from it, adding some `#pragma once` guards and moving one cpp definition to a header file.
I also used the modern cmake functionality to make the unity build - I plan to do this throughout the project in separate PRs.

I think that cmake and preprocessor changes are straightforward, but please partiularly review the `dInfinity = std::numeric_limits<double>::infinity();` change - I'm not sure if this is the best way to do it and it was suggested by a LLM. Also, is there a better place to put it?

How I tested this:
```sh
cmake -D FINAL_BUILD=ON ..
cmake --build . --target sclang --config RelWithDebInfo
```

EDIT: we don't make unity builds in CI - should we? maybe one of the linux builds?

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [ ] All tests are passing
- [n/a] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
