### PR TITLE
build: enable supernova on all platforms by default

### DIFF
--- a/.github/workflows/build_macos.yml
+++ b/.github/workflows/build_macos.yml
@@ -26,7 +26,7 @@ jobs:
             vcpkg-triplet: "arm64-osx-release-supercollider"
             vcpkg-triplet-other: "x64-osx-release-supercollider"
             vcpkg-triplet-universal: "universal" # we are not actually installing using this triplet, the packages will be manually copied there
-            extra-cmake-flags: "-D SYSTEM_PORTAUDIO=OFF" # -D SC_VERIFY_APP=ON # verify app doesn't seem to work with official qt6
+            extra-cmake-flags: "" # -D SC_VERIFY_APP=ON # verify app doesn't seem to work with official qt6
             artifact-suffix: "macOS-universal"
             ctest: true
 
@@ -55,7 +55,7 @@ jobs:
             homebrew-packages: "qt@6 libsndfile readline portaudio yaml-cpp boost"
             vcpkg-packages: ""
             vcpkg-triplet: ""
-            extra-cmake-flags: "-D SYSTEM_BOOST=ON -D SYSTEM_YAMLCPP=ON"
+            extra-cmake-flags: "-D SYSTEM_PORTAUDIO=ON -D SYSTEM_BOOST=ON -D SYSTEM_YAMLCPP=ON"
             ctest: true
 
           - job-name: "arm64 shared libscsynth"
@@ -64,7 +64,7 @@ jobs:
             qt-modules: 'qtwebengine qtwebchannel qtwebsockets qtpositioning'
             deployment-target: ""
             cmake-architectures: "arm64"
-            homebrew-packages: "qt@6 libsndfile readline portaudio"
+            homebrew-packages: "qt@6 libsndfile readline"
             vcpkg-packages: ""
             vcpkg-triplet: ""
             extra-cmake-flags: "-D LIBSCSYNTH=ON"
@@ -183,7 +183,7 @@ jobs:
         run: |
           mkdir $BUILD_PATH && cd $BUILD_PATH
 
-          CMAKE_FLAGS="-G Xcode -D SUPERNOVA=ON  ${{ matrix.extra-cmake-flags }}"
+          CMAKE_FLAGS="-G Xcode ${{ matrix.extra-cmake-flags }}"
 
           if [[ -n "${{ matrix.vcpkg-triplet-universal }}" ]]; then
             export VCPKG_ROOT=$VCPKG_INSTALLATION_ROOT

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -159,7 +159,7 @@ jobs:
 
           mkdir $BUILD_PATH && cd $BUILD_PATH
 
-          cmake -G "${{ matrix.cmake-generator }}" -A "${{ matrix.cmake-arch }}" -D SUPERNOVA=ON -D SC_USE_QTWEBENGINE=${{ matrix.use-qtwebengine }} -D CMAKE_BUILD_TYPE=Release -DVCPKG_TARGET_TRIPLET="${{ matrix.vcpkg-triplet }}" .. # build type is specified here for MinGW build and for vcpkg
+          cmake -G "${{ matrix.cmake-generator }}" -A "${{ matrix.cmake-arch }}" -D SC_USE_QTWEBENGINE=${{ matrix.use-qtwebengine }} -D CMAKE_BUILD_TYPE=Release -DVCPKG_TARGET_TRIPLET="${{ matrix.vcpkg-triplet }}" .. # build type is specified here for MinGW build and for vcpkg
 
       - name: build
         shell: bash

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,8 +113,7 @@ option(NO_X11 "Disables the building of plugins that require the X11 library (fo
 
 option(ENABLE_TESTSUITE "Compile testsuite." ON)
 
-# Build supernova by default only when on Linux or BSD systems
-option(SUPERNOVA "Build with supernova as optional audio synthesis server" ${LINUX_OR_BSD})
+option(SUPERNOVA "Build with supernova as an alternative audio synthesis server" ON)
 
 option(SN_MEMORY_DEBUGGING "Build supernova for memory debugging (disable memory pools).")
 option(SC_MEMORY_DEBUGGING "Build sclang&scsynth for memory debugging (disable memory pools).")
@@ -149,7 +148,7 @@ option(SYSTEM_ABLETON_LINK "Use link from system" OFF)
 option(SYSTEM_BOOST   "Use boost libraries from system" OFF)
 option(SYSTEM_YAMLCPP "Use yaml-cpp library from system" OFF)
 option(SYSTEM_PORTAUDIO "Use PortAudio libraries from system" ON)
-if(WIN32)
+if(WIN32 OR (APPLE AND SUPERNOVA))
     set(SYSTEM_PORTAUDIO OFF)
 else()
     mark_as_advanced(SYSTEM_PORTAUDIO)

--- a/README_MACOS.md
+++ b/README_MACOS.md
@@ -46,9 +46,6 @@ Prerequisites:
 - **git, cmake >= 3.12, libsndfile, readline, and qt6 >= 6.2**, installed via homebrew:
   `brew install git cmake libsndfile readline qt@6`
 
-- If you want to build with the *supernova* server, you need **portaudio** package, which can also be installed via homebrew:
-  `brew install portaudio`
-
 Obtaining the source code
 -------------------------
 
@@ -67,8 +64,6 @@ Build instructions
     mkdir -p build
     cd build
     cmake -G Xcode ..
-    # or, if you want to build with supernova:
-    cmake -G Xcode -DSUPERNOVA=ON ..
     # then start the build
     cmake --build . --target install --config RelWithDebInfo
 
@@ -221,10 +216,10 @@ Common arguments to control the build configuration are:
 
   * Build the *supernova* server:
 
-    `-DSUPERNOVA=ON`
+    `-DSUPERNOVA=ON # ON by default`
 
-    Using supernova requires the `portaudio` audio backend, so you need to install it
-    (Homebrew and MacPorts both provide packages).
+    Using supernova requires the `portaudio` audio backend, which will be built from source by default.
+    In order to use portaudio installed via Homebrew, additionally set the `-DSYSTEM_PORTAUDIO=ON` flag.
 
     *Note*: When you build with supernova, an alternative server executable and a supernova
     version of each plugin is built. If you also use the sc3-plugins package, make sure to

--- a/README_MACOS.md
+++ b/README_MACOS.md
@@ -216,19 +216,22 @@ Common arguments to control the build configuration are:
 
   * Build the *supernova* server:
 
-    `-DSUPERNOVA=ON # ON by default`
-
-    Using supernova requires the `portaudio` audio backend, which will be built from source by default.
-    In order to use portaudio installed via Homebrew, additionally set the `-DSYSTEM_PORTAUDIO=ON` flag.
-
-    *Note*: When you build with supernova, an alternative server executable and a supernova
-    version of each plugin is built. If you also use the sc3-plugins package, make sure to
+    Starting with 3.15, supernova is built by default on all platforms, including macOS.
+    To not build supernova, set the configure variable `-DSUPERNOVA=OFF`.
+  
+    Using supernova requires the portaudio audio backend, which will be built from source by  default. In order to use portaudio installed via Homebrew, additionally set the  `-DSYSTEM_PORTAUDIO=ON` flag.
+    
+    *Note*: Supernova adds an alternative server executable and a supernova version of each plugin is built. If you also use the sc3-plugins package, make sure to
     compile them with supernova support too.
-
+  
     Within SC you will be able to switch between scsynth and supernova by evaluating one of:
+    
+    ```supercollider
+    Server.supernova; // use supernova
+    Server.scsynth; // use scsynth - default
 
-    `Server.supernova`
-    `Server.scsynth`
+    s.boot; // start the server
+    ```
 
     Check sc help for `ParGroup` to see how to make use of multi-core hardware.
 

--- a/README_MACOS.md
+++ b/README_MACOS.md
@@ -219,7 +219,7 @@ Common arguments to control the build configuration are:
     Starting with 3.15, supernova is built by default on all platforms, including macOS.
     To not build supernova, set the configure variable `-DSUPERNOVA=OFF`.
   
-    Using supernova requires the portaudio audio backend, which will be built from source by  default. In order to use portaudio installed via Homebrew, additionally set the  `-DSYSTEM_PORTAUDIO=ON` flag.
+    Using supernova requires the portaudio audio backend, which will be built from source by default. In order to use portaudio installed via Homebrew, additionally set the  `-DSYSTEM_PORTAUDIO=ON` flag.
     
     *Note*: Supernova adds an alternative server executable and a supernova version of each plugin is built. If you also use the sc3-plugins package, make sure to
     compile them with supernova support too.

--- a/README_WINDOWS.md
+++ b/README_WINDOWS.md
@@ -387,9 +387,9 @@ than `Release`.
 
 ### SuperNova
 
-If you want to build supernova, add `-D SUPERNOVA=ON`
+Building supernova is enabled by default. If you want to build without supernova, add `-D SUPERNOVA=OFF`
 
-    cmake -D SUPERNOVA=ON ..
+    cmake -D SUPERNOVA=OFF ..
 
 ### Other targets (install, installer)
 
@@ -1039,7 +1039,7 @@ Commonly used variables to modify the build configuration are:
 
 * Build the *supernova* server:
 
-      -D SUPERNOVA=ON
+      -D SUPERNOVA=ON # ON by default
 
   *Note*: When you build with supernova, an alternative server executable and
   a supernova version of each plugin is built. If you also use the 'sc3-plugins'


### PR DESCRIPTION


<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

Supernova previously was enabled by default only on Linux/BSD, but not on macOS or Windows, although we have been providing supernova in the releases for the latter platforms for a while.

This PR changes the default so that supernova is built by default on all platforms.

One minor build change: I also changed the default on macOS to build portaudio from source. This removes the need to additionally install portaudio from homebrew.
Note that we have already been using the built-in portaudio (for supernova) in macOS releases for some time - it's much easier to obtain a universal binary that way. It's just that in this PR it becomes a default setting.

I checked the main macOS and Windows builds and supernova is still included.

## Types of changes

<!-- Delete lines that don't apply -->

- New feature ? not really

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [ ] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
