### PR TITLE
sclang: fix strict weak ordering of slot in operator <

### DIFF
--- a/lang/LangSource/PyrSlot.h
+++ b/lang/LangSource/PyrSlot.h
@@ -20,6 +20,8 @@
 
 #pragma once
 
+#include <functional>
+#include <algorithm>
 #include <string>
 #include <cstdint>
 #include <type_traits>
@@ -307,6 +309,13 @@ private:
         return getTagAsU16(u_raw) == getTagAsU16(T);
     }
 
+    // Because doubles have odd rules we need to process them differently.
+    // Try to avoid introducing any more types with strange comparison rules.
+    template <template <typename> typename OP>
+    [[nodiscard]] static decltype(auto) apply_binary_op(PyrSlot a, PyrSlot b) noexcept {
+        return a.isDouble() && b.isDouble() ? OP {}(a.getDouble(), b.getDouble()) : OP {}(a.u_raw, b.u_raw);
+    }
+
 public:
     PyrSlot() noexcept: u_raw(Tags::nilTag) {}
     ~PyrSlot() noexcept = default;
@@ -315,13 +324,27 @@ public:
     PyrSlot& operator=(PyrSlot&&) noexcept = default;
     PyrSlot& operator=(const PyrSlot&) noexcept = default;
 
+    // This is identity, not equality in supercollider.
     [[nodiscard]] friend inline bool operator==(PyrSlot lhs, PyrSlot rhs) noexcept {
-        // This is identity, not equality in supercollider.
-        // Doubles have odd comparison rules, otherwise compare the raw data.
-        return (lhs.isDouble() && rhs.isDouble()) ? lhs.getDouble() == rhs.getDouble() : lhs.u_raw == rhs.u_raw;
+        return apply_binary_op<std::equal_to>(lhs, rhs);
     }
+    [[nodiscard]] friend inline bool operator!=(PyrSlot lhs, PyrSlot rhs) noexcept {
+        return apply_binary_op<std::not_equal_to>(lhs, rhs);
+    }
+
+    // NOTE: these comparisons do NOT compare the value in the slot.
+    // They are used for sorting and ordering slots.
     [[nodiscard]] friend inline bool operator<(PyrSlot lhs, PyrSlot rhs) noexcept {
-        return (lhs.isDouble() && rhs.isDouble()) ? lhs.getDouble() < rhs.getDouble() : lhs.u_raw <= rhs.u_raw;
+        return apply_binary_op<std::less>(lhs, rhs);
+    }
+    [[nodiscard]] friend inline bool operator<=(PyrSlot lhs, PyrSlot rhs) noexcept {
+        return apply_binary_op<std::less_equal>(lhs, rhs);
+    }
+    [[nodiscard]] friend inline bool operator>(PyrSlot lhs, PyrSlot rhs) noexcept {
+        return apply_binary_op<std::greater>(lhs, rhs);
+    }
+    [[nodiscard]] friend inline bool operator>=(PyrSlot lhs, PyrSlot rhs) noexcept {
+        return apply_binary_op<std::greater_equal>(lhs, rhs);
     }
 
     template <AssertDouble Check = AssertDouble::Okay> [[nodiscard]] inline static PyrSlot make(double d) noexcept {

--- a/lang/LangSource/PyrSlot.h
+++ b/lang/LangSource/PyrSlot.h
@@ -326,25 +326,25 @@ public:
 
     // This is identity, not equality in supercollider.
     [[nodiscard]] friend inline bool operator==(PyrSlot lhs, PyrSlot rhs) noexcept {
-        return apply_binary_op<std::equal_to>(lhs, rhs);
+        return PyrSlot::apply_binary_op<std::equal_to>(lhs, rhs);
     }
     [[nodiscard]] friend inline bool operator!=(PyrSlot lhs, PyrSlot rhs) noexcept {
-        return apply_binary_op<std::not_equal_to>(lhs, rhs);
+        return PyrSlot::apply_binary_op<std::not_equal_to>(lhs, rhs);
     }
 
     // NOTE: these comparisons do NOT compare the value in the slot.
     // They are used for sorting and ordering slots.
     [[nodiscard]] friend inline bool operator<(PyrSlot lhs, PyrSlot rhs) noexcept {
-        return apply_binary_op<std::less>(lhs, rhs);
+        return PyrSlot::apply_binary_op<std::less>(lhs, rhs);
     }
     [[nodiscard]] friend inline bool operator<=(PyrSlot lhs, PyrSlot rhs) noexcept {
-        return apply_binary_op<std::less_equal>(lhs, rhs);
+        return PyrSlot::apply_binary_op<std::less_equal>(lhs, rhs);
     }
     [[nodiscard]] friend inline bool operator>(PyrSlot lhs, PyrSlot rhs) noexcept {
-        return apply_binary_op<std::greater>(lhs, rhs);
+        return PyrSlot::apply_binary_op<std::greater>(lhs, rhs);
     }
     [[nodiscard]] friend inline bool operator>=(PyrSlot lhs, PyrSlot rhs) noexcept {
-        return apply_binary_op<std::greater_equal>(lhs, rhs);
+        return PyrSlot::apply_binary_op<std::greater_equal>(lhs, rhs);
     }
 
     template <AssertDouble Check = AssertDouble::Okay> [[nodiscard]] inline static PyrSlot make(double d) noexcept {

--- a/testsuite/interpreter/slot.cpp
+++ b/testsuite/interpreter/slot.cpp
@@ -7,6 +7,8 @@
 #include "PyrObject.h"
 #include "PyrKernel.h"
 
+BOOST_TEST_DONT_PRINT_LOG_VALUE(PyrSlot)
+
 BOOST_AUTO_TEST_CASE(slot_test) { { PyrSlot i = PyrSlot::make(static_cast<int32_t>(32));
 BOOST_TEST_REQUIRE(i.isInt());
 BOOST_TEST_REQUIRE(!i.isPtr());
@@ -163,4 +165,20 @@ BOOST_AUTO_TEST_CASE(bool_test) {
     BOOST_TEST(false_slot.isFalse());
     BOOST_TEST(!true_slot.isFalse());
     BOOST_TEST(!false_slot.isTrue());
+}
+
+BOOST_AUTO_TEST_CASE(ordering_test) {
+    const auto a = PyrSlot::make(0.1);
+    const auto b = PyrSlot::make(0.2);
+    const auto c = PyrSlot::make(2);
+
+    BOOST_TEST(a < b);
+    BOOST_TEST(a <= b);
+
+    // strict weak ordering
+    BOOST_TEST((a < a) == false);
+
+    BOOST_TEST((a < b));
+    BOOST_TEST(b < c);
+    BOOST_TEST(a < c);
 }


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation
Closes #7476

Small typo that did the wrong comparison rules meaning calling sort on an array of slots was technically broken.

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [ ] Code is tested
- [ ] All tests are passing
- [ ] Updated documentation
- [ ] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
