### PR TITLE
Remove 255-arg limit for SynthDefs

### DIFF
--- a/SCClassLibrary/Common/Audio/SynthDesc.sc
+++ b/SCClassLibrary/Common/Audio/SynthDesc.sc
@@ -436,9 +436,11 @@ SynthDesc {
 	}
 
 	makeMsgFunc {
-		var	string, comma=false;
+		var	string, strings, comma = false;
 		var	names = IdentitySet.new,
 		suffix = this.hash.asHexString(8);
+		var index = 0, count;
+		var return;
 		// if a control name is duplicated, the msgFunc will be invalid
 		// that "shouldn't" happen but it might; better to check for it
 		// and throw a proper error
@@ -451,11 +453,15 @@ SynthDesc {
 					.format(name).warn;
 					comma = true;
 				} {
-					names.add(name);
+					if(msgFuncKeepGate or: { name != \gate }) {
+						names.add(name);
+					};
 				};
 			};
 		});
-		if(names.size > 255) { Error("A synthDef cannot have more than 255 control names.").throw };
+		if(names.size == 0) {
+			^ #{ Array.new }
+		};
 		// reusing variable to know if I should continue or not
 		if(comma) {
 			"\nYour synthdef has been saved in the library and loaded on the server, if running.
@@ -464,54 +470,90 @@ Use of this synth in Patterns will not detect argument names automatically becau
 			^this
 		};
 		comma = false;
-		names = 0;	// now, count the args actually added to the func
 
-		string = String.streamContents {|stream|
-			stream << "#{ ";
-			if (controlNames.size > 0) {
-				stream << "arg " ;
-			};
-			controls.do {|controlName, i|
-				var name, name2;
-				name = controlName.name.asString;
-				if (name != "?") {
-					if (name == "gate") {
-						hasGate = true;
-						if(msgFuncKeepGate) {
-							if (comma) { stream << ", " } { comma = true };
-							stream << name;
-							names = names + 1;
-						}
-					}{
-						if (name[1] == $_) { name2 = name.drop(2) } { name2 = name };
-						if (comma) { stream << ", " } { comma = true };
-						stream << name2;
-						names = names + 1;
-					};
-				};
-			};
-			if (controlNames.size > 0) {
-				stream << ";\n" ;
-			};
-			stream << "\tvar\tx" << suffix << " = Array.new(" << (names*2) << ");\n";
-			comma = false;
-			controls.do {|controlName, i|
-				var name, name2;
-				name = controlName.name.asString;
-				if (name != "?") {
-					if (msgFuncKeepGate or: { name != "gate" }) {
-						if (name[1] == $_) { name2 = name.drop(2) } { name2 = name };
-						stream << "\t" << name2 << " !? { x" << suffix
-						<< ".add('" << name << "').add(" << name2 << ") };\n";
-						names = names + 1;
-					};
-				};
-			};
-			stream << "\tx" << suffix << "\n}"
+		while {
+			// makeOneMsgFunc splits at a limit of 250 control names per func
+			return = this.makeOneMsgFunc(controls, suffix, index);
+			return.notNil
+		} {
+			#count, string = return;
+			strings = strings.add(string);
+			index = index + count;
 		};
 
-		// do not compile the string if no argnames were added
-		if(names > 0) { msgFunc = string.compile.value };
+		if(strings.size == 1) {
+			// <= 250 args, use the simplest form
+			msgFunc = strings[0].compile.value;
+		} {
+			// merge results from the split-up queries
+			msgFunc = String.streamContents({ |stream|
+				stream << "#{\n";
+				stream << "\tvar y" << suffix << " = Array(" << (names.size*2) << ");\n";
+				strings.do { |str|
+					stream << "\ty" << suffix
+					<< " = y" << suffix << ".addAll("
+					<< str << ".valueEnvir"
+					<< ");\n";
+				};
+				stream << "\ty" << suffix << ";\n}"
+			})
+			.compile.value
+		};
+	}
+
+	makeOneMsgFunc { |controlNames, suffix, index = 0, limit = 250|
+		var names = 0;
+		var string;
+		var scanned = 0, written = 0;
+		if(index < controlNames.size) {
+			string = String.streamContents { |stream|
+				var controlName, name, name2;
+				var comma = false;
+				stream << "#{ arg ";
+				while {
+					names < limit and: {
+						(index + scanned) < controlNames.size
+					}
+				} {
+					controlName = controlNames[index + scanned];
+					name = controlName.name.asString;
+					if (name != "?") {
+						if (name == "gate") {
+							hasGate = true;
+							if(msgFuncKeepGate) {
+								if (comma) { stream << ", " } { comma = true };
+								stream << name;
+								names = names + 1;
+							}
+						}{
+							if (name[1] == $_) { name2 = name.drop(2) } { name2 = name };
+							if (comma) { stream << ", " } { comma = true };
+							stream << name2;
+							names = names + 1;
+						};
+					};
+					scanned = scanned + 1;
+				};
+				stream << ";\n" ;
+				stream << "\tvar\tx" << suffix << " = Array.new(" << (names*2) << ");\n";
+				comma = false;
+				while {
+					written < scanned
+				} {
+					name = controlNames[index + written].name.asString;
+					if (name != "?") {
+						if (msgFuncKeepGate or: { name != "gate" }) {
+							if (name[1] == $_) { name2 = name.drop(2) } { name2 = name };
+							stream << "\t" << name2 << " !? { x" << suffix
+							<< ".add('" << name << "').add(" << name2 << ") };\n";
+						};
+					};
+					written = written + 1;
+				};
+				stream << "\tx" << suffix << "\n}"
+			};
+			^[written, string]
+		} { ^nil }
 	}
 
 	msgFuncKeepGate_ { |bool = false|

--- a/SCClassLibrary/Common/Audio/SynthDesc.sc
+++ b/SCClassLibrary/Common/Audio/SynthDesc.sc
@@ -461,7 +461,7 @@ SynthDesc {
 			};
 		});
 		// note, don't remove this check;
-		// it prevents wrong syntax from being generated in makeOneMsgFunc
+		// it prevents wrong syntax from being generated in prMakeOneMsgFunc
 		if(names.size == 0) {
 			msgFunc = #{ Array.new };
 			^this
@@ -475,7 +475,7 @@ Use of this synth in Patterns will not detect argument names automatically becau
 
 		while {
 			// makeOneMsgFunc splits at a limit of 250 control names per func
-			return = this.makeOneMsgFunc(controls, suffix, index);
+			return = this.prMakeOneMsgFunc(controls, suffix, index);
 			return.notNil
 		} {
 			#count, string = return;
@@ -503,7 +503,7 @@ Use of this synth in Patterns will not detect argument names automatically becau
 		};
 	}
 
-	makeOneMsgFunc { |controlNames, suffix, index = 0, limit = 250|
+	prMakeOneMsgFunc { |controlNames, suffix, index = 0, limit = 250|
 		var names = 0;
 		var scanned = 0;
 		var argStream, fillStream;

--- a/SCClassLibrary/Common/Audio/SynthDesc.sc
+++ b/SCClassLibrary/Common/Audio/SynthDesc.sc
@@ -460,8 +460,11 @@ SynthDesc {
 				};
 			};
 		});
+		// note, don't remove this check;
+		// it prevents wrong syntax from being generated in makeOneMsgFunc
 		if(names.size == 0) {
-			^ #{ Array.new }
+			msgFunc = #{ Array.new };
+			^this
 		};
 		if(hasDuplicateNames) {
 			"\nYour synthdef has been saved in the library and loaded on the server, if running.
@@ -540,14 +543,12 @@ Use of this synth in Patterns will not detect argument names automatically becau
 				};
 				scanned = scanned + 1;
 			};
-			if(names > 0) {
-				^[scanned, String.streamContents { |stream|
-					stream << "#{ arg " << argStream.collection << ";\n";
-					stream << "\tvar\tx" << suffix << " = Array.new(" << (names*2) << ");\n";
-					stream << fillStream.collection;
-					stream << "\tx" << suffix << "\n}"
-				}]
-			} { ^nil }
+			^[scanned, String.streamContents { |stream|
+				stream << "#{ arg " << argStream.collection << ";\n";
+				stream << "\tvar\tx" << suffix << " = Array.new(" << (names*2) << ");\n";
+				stream << fillStream.collection;
+				stream << "\tx" << suffix << "\n}"
+			}]
 		} { ^nil }
 	}
 

--- a/SCClassLibrary/Common/Audio/SynthDesc.sc
+++ b/SCClassLibrary/Common/Audio/SynthDesc.sc
@@ -57,8 +57,8 @@ SynthDesc {
 		};
 		^dict;
 	}
-		// path is for metadata -- only this method has direct access to the new SynthDesc
-		// really this should be a private method -- use *read instead
+	// path is for metadata -- only this method has direct access to the new SynthDesc
+	// really this should be a private method -- use *read instead
 	*readFile { arg stream, keepDefs=false, dict, path;
 		var numDefs, magic, version;
 		dict = dict ?? { IdentityDictionary.new };
@@ -83,8 +83,8 @@ SynthDesc {
 			};
 
 			dict.put(desc.name.asSymbol, desc);
-				// AbstractMDPlugin dynamically determines the md archive type
-				// from the file extension
+			// AbstractMDPlugin dynamically determines the md archive type
+			// from the file extension
 			if(path.notNil) {
 				desc.metadata = AbstractMDPlugin.readMetadata(path);
 			};
@@ -95,7 +95,7 @@ SynthDesc {
 					desc.def.metadata.putAll(desc.metadata);
 				};
 				desc.def.metadata.put(\shouldNotSend, true)
-					.put(\loadPath, path);
+				.put(\loadPath, path);
 			};
 		}
 		^dict
@@ -108,30 +108,30 @@ SynthDesc {
 
 		protect {
 
-		inputs = [];
-		outputs = [];
-		controlDict = IdentityDictionary.new;
+			inputs = [];
+			outputs = [];
+			controlDict = IdentityDictionary.new;
 
-		name = stream.getPascalString;
+			name = stream.getPascalString;
 
-		def = SynthDef.prNew(name);
-		UGen.buildSynthDef = def;
+			def = SynthDef.prNew(name);
+			UGen.buildSynthDef = def;
 
-		numConstants = stream.getInt16;
-		constants = FloatArray.newClear(numConstants);
-		stream.read(constants);
+			numConstants = stream.getInt16;
+			constants = FloatArray.newClear(numConstants);
+			stream.read(constants);
 
-		numControls = stream.getInt16;
-		def.controls = FloatArray.newClear(numControls);
-		stream.read(def.controls);
+			numControls = stream.getInt16;
+			def.controls = FloatArray.newClear(numControls);
+			stream.read(def.controls);
 
-		controls = Array.fill(numControls)
+			controls = Array.fill(numControls)
 			{ |i|
 				ControlName('?', i, '?', def.controls[i]);
 			};
 
-		numControlNames = stream.getInt16;
-		numControlNames.do
+			numControlNames = stream.getInt16;
+			numControlNames.do
 			{
 				var controlName, controlIndex;
 				controlName = stream.getPascalString.asSymbol;
@@ -141,38 +141,38 @@ SynthDesc {
 				controlDict[controlName] = controls[controlIndex];
 			};
 
-		numUGens = stream.getInt16;
-		numUGens.do {
-			this.readUGenSpec(stream);
-		};
+			numUGens = stream.getInt16;
+			numUGens.do {
+				this.readUGenSpec(stream);
+			};
 
-		controls.inject(nil) {|z,y|
-			if(y.name=='?') { z.defaultValue = z.defaultValue.asArray.add(y.defaultValue); z } { y }
-		};
+			controls.inject(nil) {|z,y|
+				if(y.name=='?') { z.defaultValue = z.defaultValue.asArray.add(y.defaultValue); z } { y }
+			};
 
-		def.controlNames = controls.select {|x| x.name.notNil };
-		hasArrayArgs = controls.any { |cn| cn.name == '?' };
+			def.controlNames = controls.select {|x| x.name.notNil };
+			hasArrayArgs = controls.any { |cn| cn.name == '?' };
 
-		numVariants = stream.getInt16;
-		hasVariants = numVariants > 0;
-		// maybe later, read in variant names and values.
-		// this is harder than it might seem at first.
-		// we could just skip the data, but instead we read it
-		// so we can detect corrupt SynthDef files.
-		variantValues = FloatArray.newClear(numControls);
-		numVariants.do {
-			stream.getPascalString;
-			stream.read(variantValues);
-		};
+			numVariants = stream.getInt16;
+			hasVariants = numVariants > 0;
+			// maybe later, read in variant names and values.
+			// this is harder than it might seem at first.
+			// we could just skip the data, but instead we read it
+			// so we can detect corrupt SynthDef files.
+			variantValues = FloatArray.newClear(numControls);
+			numVariants.do {
+				stream.getPascalString;
+				stream.read(variantValues);
+			};
 
-		def.constants = Dictionary.new;
-		constants.do {|k,i| def.constants.put(k,i) };
-		if (keepDef.not) {
-			// throw away unneeded stuff
-			def = nil;
-			constants = nil;
-		};
-		this.makeMsgFunc;
+			def.constants = Dictionary.new;
+			constants.do {|k,i| def.constants.put(k,i) };
+			if (keepDef.not) {
+				// throw away unneeded stuff
+				def = nil;
+				constants = nil;
+			};
+			this.makeMsgFunc;
 
 		} {
 			UGen.buildSynthDef = nil;
@@ -187,30 +187,30 @@ SynthDesc {
 
 		protect {
 
-		inputs = [];
-		outputs = [];
-		controlDict = IdentityDictionary.new;
+			inputs = [];
+			outputs = [];
+			controlDict = IdentityDictionary.new;
 
-		name = stream.getPascalString;
+			name = stream.getPascalString;
 
-		def = SynthDef.prNew(name);
-		UGen.buildSynthDef = def;
+			def = SynthDef.prNew(name);
+			UGen.buildSynthDef = def;
 
-		numConstants = stream.getInt32;
-		constants = FloatArray.newClear(numConstants);
-		stream.read(constants);
+			numConstants = stream.getInt32;
+			constants = FloatArray.newClear(numConstants);
+			stream.read(constants);
 
-		numControls = stream.getInt32;
-		def.controls = FloatArray.newClear(numControls);
-		stream.read(def.controls);
+			numControls = stream.getInt32;
+			def.controls = FloatArray.newClear(numControls);
+			stream.read(def.controls);
 
-		controls = Array.fill(numControls)
+			controls = Array.fill(numControls)
 			{ |i|
 				ControlName('?', i, '?', def.controls[i]);
 			};
 
-		numControlNames = stream.getInt32;
-		numControlNames.do
+			numControlNames = stream.getInt32;
+			numControlNames.do
 			{
 				var controlName, controlIndex;
 				controlName = stream.getPascalString.asSymbol;
@@ -220,48 +220,48 @@ SynthDesc {
 				controlDict[controlName] = controls[controlIndex];
 			};
 
-		numUGens = stream.getInt32;
-		numUGens.do {
-			this.readUGenSpec2(stream);
-		};
+			numUGens = stream.getInt32;
+			numUGens.do {
+				this.readUGenSpec2(stream);
+			};
 
-		controls.inject(nil) {|z,y|
-			if(y.name=='?') { z.defaultValue = z.defaultValue.asArray.add(y.defaultValue); z } { y }
-		};
+			controls.inject(nil) {|z,y|
+				if(y.name=='?') { z.defaultValue = z.defaultValue.asArray.add(y.defaultValue); z } { y }
+			};
 
-		def.controlNames = controls.select {|x| x.name.notNil };
-		hasArrayArgs = controls.any { |cn| cn.name == '?' };
+			def.controlNames = controls.select {|x| x.name.notNil };
+			hasArrayArgs = controls.any { |cn| cn.name == '?' };
 
-		numVariants = stream.getInt16;
-		hasVariants = numVariants > 0;
-		// maybe later, read in variant names and values.
-		// this is harder than it might seem at first.
-		// we could just skip the data, but instead we read it
-		// so we can detect corrupt SynthDef files.
-		variantValues = FloatArray.newClear(numControls);
-		numVariants.do {
-			stream.getPascalString;
-			stream.read(variantValues);
-		};
+			numVariants = stream.getInt16;
+			hasVariants = numVariants > 0;
+			// maybe later, read in variant names and values.
+			// this is harder than it might seem at first.
+			// we could just skip the data, but instead we read it
+			// so we can detect corrupt SynthDef files.
+			variantValues = FloatArray.newClear(numControls);
+			numVariants.do {
+				stream.getPascalString;
+				stream.read(variantValues);
+			};
 
-		if (version > 2) {
-			// read reblock and resample fields, just to detect corrupt SynthDef files.
-			stream.getInt32; // block size value
-			stream.getInt32; // block size control index
-			stream.getFloat; // resample factor
-			stream.getInt32; // resample control index
-			// just ignore all remaining (optional) fields.
-			// these will be skipped in the readSynthDef3 method.
-		};
+			if (version > 2) {
+				// read reblock and resample fields, just to detect corrupt SynthDef files.
+				stream.getInt32; // block size value
+				stream.getInt32; // block size control index
+				stream.getFloat; // resample factor
+				stream.getInt32; // resample control index
+				// just ignore all remaining (optional) fields.
+				// these will be skipped in the readSynthDef3 method.
+			};
 
-		def.constants = Dictionary.new;
-		constants.do {|k,i| def.constants.put(k,i) };
-		if (keepDef.not) {
-			// throw away unneeded stuff
-			def = nil;
-			constants = nil;
-		};
-		this.makeMsgFunc;
+			def.constants = Dictionary.new;
+			constants.do {|k,i| def.constants.put(k,i) };
+			if (keepDef.not) {
+				// throw away unneeded stuff
+				def = nil;
+				constants = nil;
+			};
+			this.makeMsgFunc;
 
 		} {
 			UGen.buildSynthDef = nil;
@@ -318,16 +318,16 @@ SynthDesc {
 			ugenIndex = inputSpecs[i];
 			outputIndex = inputSpecs[i+1];
 			input = if (ugenIndex < 0)
-				{
-					constants[outputIndex]
+			{
+				constants[outputIndex]
+			}{
+				ugen = def.children[ugenIndex];
+				if (ugen.isKindOf(MultiOutUGen)) {
+					ugen.channels[outputIndex]
 				}{
-					ugen = def.children[ugenIndex];
-					if (ugen.isKindOf(MultiOutUGen)) {
-						ugen.channels[outputIndex]
-					}{
-						ugen
-					}
-				};
+					ugen
+				}
+			};
 			ugenInputs = ugenInputs.add(input);
 		};
 
@@ -392,16 +392,16 @@ SynthDesc {
 			ugenIndex = inputSpecs[i];
 			outputIndex = inputSpecs[i+1];
 			input = if (ugenIndex < 0)
-				{
-					constants[outputIndex]
+			{
+				constants[outputIndex]
+			}{
+				ugen = def.children[ugenIndex];
+				if (ugen.isKindOf(MultiOutUGen)) {
+					ugen.channels[outputIndex]
 				}{
-					ugen = def.children[ugenIndex];
-					if (ugen.isKindOf(MultiOutUGen)) {
-						ugen.channels[outputIndex]
-					}{
-						ugen
-					}
-				};
+					ugen
+				}
+			};
 			ugenInputs = ugenInputs.add(input);
 		};
 
@@ -438,17 +438,17 @@ SynthDesc {
 	makeMsgFunc {
 		var	string, comma=false;
 		var	names = IdentitySet.new,
-			suffix = this.hash.asHexString(8);
-			// if a control name is duplicated, the msgFunc will be invalid
-			// that "shouldn't" happen but it might; better to check for it
-			// and throw a proper error
+		suffix = this.hash.asHexString(8);
+		// if a control name is duplicated, the msgFunc will be invalid
+		// that "shouldn't" happen but it might; better to check for it
+		// and throw a proper error
 		controls.do({ |controlName|
 			var	name;
 			if(controlName.name.asString.first.isAlpha) {
 				name = controlName.name.asSymbol;
 				if(names.includes(name)) {
 					"Could not build msgFunc for this SynthDesc: duplicate control name %"
-						.format(name).warn;
+					.format(name).warn;
 					comma = true;
 				} {
 					names.add(name);
@@ -456,9 +456,9 @@ SynthDesc {
 			};
 		});
 		if(names.size > 255) { Error("A synthDef cannot have more than 255 control names.").throw };
-			// reusing variable to know if I should continue or not
+		// reusing variable to know if I should continue or not
 		if(comma) {
-"\nYour synthdef has been saved in the library and loaded on the server, if running.
+			"\nYour synthdef has been saved in the library and loaded on the server, if running.
 Use of this synth in Patterns will not detect argument names automatically because of the duplicate name(s).".postln;
 			msgFunc = nil;
 			^this
@@ -502,7 +502,7 @@ Use of this synth in Patterns will not detect argument names automatically becau
 					if (msgFuncKeepGate or: { name != "gate" }) {
 						if (name[1] == $_) { name2 = name.drop(2) } { name2 = name };
 						stream << "\t" << name2 << " !? { x" << suffix
-							<< ".add('" << name << "').add(" << name2 << ") };\n";
+						<< ".add('" << name << "').add(" << name2 << ") };\n";
 						names = names + 1;
 					};
 				};
@@ -510,7 +510,7 @@ Use of this synth in Patterns will not detect argument names automatically becau
 			stream << "\tx" << suffix << "\n}"
 		};
 
-			// do not compile the string if no argnames were added
+		// do not compile the string if no argnames were added
 		if(names > 0) { msgFunc = string.compile.value };
 	}
 
@@ -629,9 +629,9 @@ SynthDescLib {
 		var	keyString = key.asString, dotIndex = keyString.indexOf($.), desc;
 		if(dotIndex.isNil) { ^synthDescs.at(key.asSymbol) };
 		if((desc = synthDescs[keyString[..dotIndex-1].asSymbol]).notNil
-				and: { desc.hasVariants })
-			{ ^desc }
-			{ ^synthDescs.at(key.asSymbol) }
+			and: { desc.hasVariants })
+		{ ^desc }
+		{ ^synthDescs.at(key.asSymbol) }
 	}
 	*match { |key| ^global.match(key) }
 
@@ -690,8 +690,8 @@ SynthDescLib {
 			};
 			synthDescs.put(desc.name.asSymbol, desc);
 			resultSet.add(desc);
-				// AbstractMDPlugin dynamically determines the md archive type
-				// from the file extension
+			// AbstractMDPlugin dynamically determines the md archive type
+			// from the file extension
 			if(path.notNil) {
 				desc.metadata = AbstractMDPlugin.readMetadata(path);
 			};
@@ -702,7 +702,7 @@ SynthDescLib {
 					desc.def.metadata.putAll(desc.metadata);
 				};
 				desc.def.metadata.put(\shouldNotSend, true)
-					.put(\loadPath, path);
+				.put(\loadPath, path);
 			};
 		};
 		resultSet.do({|newDesc| this.changed(\synthDescAdded, newDesc); });
@@ -755,17 +755,17 @@ AbstractMDPlugin {
 	}
 	*writeMetadataFile {}
 
-		// clearMetadata should ensure that only one MD file ever exists
-		// therefore we can check the subclasses in turn
-		// and return the first MD found
-		// every subclass should have a unique extension
+	// clearMetadata should ensure that only one MD file ever exists
+	// therefore we can check the subclasses in turn
+	// and return the first MD found
+	// every subclass should have a unique extension
 	*readMetadata { |path|
 		var	pathTmp, classList, i;
 		path = path.splitext[0] ++ ".";
 		classList = this.allSubclasses;
-			// ensure that SynthDescLib.mdPlugin is preferred for reading,
-			// with other plugins as a fallback
-			// it will also be possible to use Events or Protos as plugins this way
+		// ensure that SynthDescLib.mdPlugin is preferred for reading,
+		// with other plugins as a fallback
+		// it will also be possible to use Events or Protos as plugins this way
 		if((i = classList.indexOf(SynthDesc.mdPlugin)).notNil and: { i > 0 }) {
 			classList = classList.copy.swap(0, i);
 		} {

--- a/SCClassLibrary/Common/Audio/SynthDesc.sc
+++ b/SCClassLibrary/Common/Audio/SynthDesc.sc
@@ -540,12 +540,14 @@ Use of this synth in Patterns will not detect argument names automatically becau
 				};
 				scanned = scanned + 1;
 			};
-			^[scanned, String.streamContents { |stream|
-				stream << "#{ arg " << argStream.collection << ";\n";
-				stream << "\tvar\tx" << suffix << " = Array.new(" << (names*2) << ");\n";
-				stream << fillStream.collection;
-				stream << "\tx" << suffix << "\n}"
-			}]
+			if(names > 0) {
+				^[scanned, String.streamContents { |stream|
+					stream << "#{ arg " << argStream.collection << ";\n";
+					stream << "\tvar\tx" << suffix << " = Array.new(" << (names*2) << ");\n";
+					stream << fillStream.collection;
+					stream << "\tx" << suffix << "\n}"
+				}]
+			} { ^nil }
 		} { ^nil }
 	}
 

--- a/SCClassLibrary/Common/Audio/SynthDesc.sc
+++ b/SCClassLibrary/Common/Audio/SynthDesc.sc
@@ -436,9 +436,10 @@ SynthDesc {
 	}
 
 	makeMsgFunc {
-		var	string, strings, comma = false;
-		var	names = IdentitySet.new,
-		suffix = this.hash.asHexString(8);
+		var string, strings;
+		var hasDuplicateNames = false;
+		var names = IdentitySet.new;
+		var suffix = this.hash.asHexString(8);
 		var index = 0, count;
 		var return;
 		// if a control name is duplicated, the msgFunc will be invalid
@@ -451,7 +452,7 @@ SynthDesc {
 				if(names.includes(name)) {
 					"Could not build msgFunc for this SynthDesc: duplicate control name %"
 					.format(name).warn;
-					comma = true;
+					hasDuplicateNames = true;
 				} {
 					if(msgFuncKeepGate or: { name != \gate }) {
 						names.add(name);
@@ -462,14 +463,12 @@ SynthDesc {
 		if(names.size == 0) {
 			^ #{ Array.new }
 		};
-		// reusing variable to know if I should continue or not
-		if(comma) {
+		if(hasDuplicateNames) {
 			"\nYour synthdef has been saved in the library and loaded on the server, if running.
 Use of this synth in Patterns will not detect argument names automatically because of the duplicate name(s).".postln;
 			msgFunc = nil;
 			^this
 		};
-		comma = false;
 
 		while {
 			// makeOneMsgFunc splits at a limit of 250 control names per func
@@ -503,56 +502,50 @@ Use of this synth in Patterns will not detect argument names automatically becau
 
 	makeOneMsgFunc { |controlNames, suffix, index = 0, limit = 250|
 		var names = 0;
-		var string;
-		var scanned = 0, written = 0;
+		var scanned = 0;
+		var argStream, fillStream;
+		var controlName, name;
+		var comma = false;
+		var streamName = { |name|
+			var name2;
+			if (name[1] == $_) { name2 = name.drop(2) } { name2 = name };
+			argStream << name2;
+			fillStream << "\t" << name2 << " !? { x" << suffix
+			<< ".add('" << name << "').add(" << name2 << ") };\n";
+		};
 		if(index < controlNames.size) {
-			string = String.streamContents { |stream|
-				var controlName, name, name2;
-				var comma = false;
-				stream << "#{ arg ";
-				while {
-					names < limit and: {
-						(index + scanned) < controlNames.size
+			argStream = CollStream.new;
+			fillStream = CollStream.new;
+			while {
+				names < limit and: {
+					(index + scanned) < controlNames.size
+				}
+			} {
+				controlName = controlNames[index + scanned];
+				name = controlName.name.asString;
+				case
+				{ name == "gate" } {
+					hasGate = true;
+					if(msgFuncKeepGate) {
+						if (comma) { argStream << ", " } { comma = true };
+						streamName.(name);
+						names = names + 1;
 					}
-				} {
-					controlName = controlNames[index + scanned];
-					name = controlName.name.asString;
-					if (name != "?") {
-						if (name == "gate") {
-							hasGate = true;
-							if(msgFuncKeepGate) {
-								if (comma) { stream << ", " } { comma = true };
-								stream << name;
-								names = names + 1;
-							}
-						}{
-							if (name[1] == $_) { name2 = name.drop(2) } { name2 = name };
-							if (comma) { stream << ", " } { comma = true };
-							stream << name2;
-							names = names + 1;
-						};
-					};
-					scanned = scanned + 1;
+				}
+				// "?" is a placeholder for arrayed controls
+				{ name != "?" } {
+					if (comma) { argStream << ", " } { comma = true };
+					streamName.(name);
+					names = names + 1;
 				};
-				stream << ";\n" ;
-				stream << "\tvar\tx" << suffix << " = Array.new(" << (names*2) << ");\n";
-				comma = false;
-				while {
-					written < scanned
-				} {
-					name = controlNames[index + written].name.asString;
-					if (name != "?") {
-						if (msgFuncKeepGate or: { name != "gate" }) {
-							if (name[1] == $_) { name2 = name.drop(2) } { name2 = name };
-							stream << "\t" << name2 << " !? { x" << suffix
-							<< ".add('" << name << "').add(" << name2 << ") };\n";
-						};
-					};
-					written = written + 1;
-				};
-				stream << "\tx" << suffix << "\n}"
+				scanned = scanned + 1;
 			};
-			^[written, string]
+			^[scanned, String.streamContents { |stream|
+				stream << "#{ arg " << argStream.collection << ";\n";
+				stream << "\tvar\tx" << suffix << " = Array.new(" << (names*2) << ");\n";
+				stream << fillStream.collection;
+				stream << "\tx" << suffix << "\n}"
+			}]
 		} { ^nil }
 	}
 

--- a/testsuite/classlibrary/TestSynthDescMsgFunc.sc
+++ b/testsuite/classlibrary/TestSynthDescMsgFunc.sc
@@ -84,6 +84,21 @@ TestSynthDescMsgFunc : UnitTest {
 		)
 	}
 
+	test_SynthDesc_msgFunc_for_empty_arg_list_is_empty_array {
+		// by default, 'gate' is excluded.
+		// SynthDesc should recognizes that there's nothing else to include,
+		// and produce an empty-array msgFunc
+		SynthDef(\testempty, { |gate = 1|
+			Out.kr(1000, gate)
+		}).add;
+
+		this.assertEquals(
+			SynthDescLib.at(\testempty).msgFunc.value,
+			Array.new,
+			"The msgFunc for a SynthDef with no eligible controls should return an empty array"
+		);
+	}
+
 	unorderedPairsEqual { |a, b|
 		var aDict = a.asDict(class: IdentityDictionary);
 		var bDict = b.asDict(class: IdentityDictionary);

--- a/testsuite/classlibrary/TestSynthDescMsgFunc.sc
+++ b/testsuite/classlibrary/TestSynthDescMsgFunc.sc
@@ -1,0 +1,100 @@
+TestSynthDescMsgFunc : UnitTest {
+	test_SynthDesc_normal_SynthDef_event_args {
+		var event, args;
+		SynthDef(\normal_test_args, {
+			arg out = 0, gate = 1, freq = 440, ffreq = 2000, rq = 0.2, amp = 0.1, t_trig = 1;
+			// note, we don't need actual DSP, only checking args
+			Out.ar(0, DC.ar(0))
+		}).add;
+
+		event = (out: 4, gate: 1, freq: 800, ffreq: 8234, amp: 0.2, trig: 1,
+			t_trig: 2, undefined: 600);
+		event.use {
+			args = SynthDescLib.at(\normal_test_args).msgFunc.valueEnvir;
+		};
+
+		this.assert(
+			this.unorderedPairsEqual(
+				args,
+				[out: 4, freq: 800, ffreq: 8234, amp: 0.2, t_trig: 1]
+			),
+			"Arg list from event should include specified args, skip omitted and undefined"
+		)
+	}
+
+	test_SynthDesc_300_args_from_event {
+		var event, indices, argsFromDesc, inputArgs;
+		SynthDef('300_controls', {
+			var ctl = Control.names(
+				Array.fill(300, { |i| ("ctl" ++ i).asSymbol })
+			).kr(Array.fill(300, { |i| i/300 }));
+			Out.ar(0, DC.ar(0))
+		}).add;
+
+		event = ();
+		indices = (0, 7 .. 299);
+		inputArgs = Array(indices.size * 2);
+		indices.do { |i|
+			var x = 1.0.rand2;
+			event[("ctl" ++ i).asSymbol] = x;
+			inputArgs.add(("ctl" ++ i).asSymbol).add(x);
+		};
+		event.use {
+			argsFromDesc = SynthDescLib.at('300_controls').msgFunc.valueEnvir;
+		};
+
+		this.assert(
+			this.unorderedPairsEqual(
+				argsFromDesc,
+				inputArgs
+			),
+			"Arg list from event should include specified args, skip omitted and undefined"
+		)
+	}
+
+	test_SynthDesc_large_control_count_with_arrayed_controls {
+		var event, indices, argsFromDesc, inputArgs;
+		var numPerCtl = Array.fill(300, { rrand(1, 3) });
+
+		SynthDef(\large_with_arrays, {
+			var ctl = Control.names(
+				Array.fill(300, { |i| ("ctl" ++ i).asSymbol })
+			).kr(Array.fill(300, { |i| Array.fill(numPerCtl[i], 0) }));
+			Out.ar(0, DC.ar(0))
+		}).add;
+
+		event = ();
+		indices = (0, 7 .. 299);
+		inputArgs = Array(indices.size * 2);
+		indices.do { |i|
+			var x = Array.fill(numPerCtl[i], { 1.0.rand2 });
+			event[("ctl" ++ i).asSymbol] = x;
+			inputArgs.add(("ctl" ++ i).asSymbol).add(x);
+		};
+		event.use {
+			argsFromDesc = SynthDescLib.at(\large_with_arrays).msgFunc.valueEnvir;
+		};
+
+		this.assert(
+			this.unorderedPairsEqual(
+				argsFromDesc,
+				inputArgs
+			),
+			"Arg list from event should include specified args, skip omitted and undefined"
+		)
+	}
+
+	unorderedPairsEqual { |a, b|
+		var aDict = a.asDict(class: IdentityDictionary);
+		var bDict = b.asDict(class: IdentityDictionary);
+		if((aDict.keys symmetricDifference: bDict.keys).size > 0) {
+			^false  // one contains items not present in the other
+		};
+		// having already established they both have the same keys,
+		// we can check unidirectionally
+		aDict.keysValuesDo { |k, v|
+			if(bDict[k] != v) { ^false }
+		};
+		^true
+	}
+}


### PR DESCRIPTION
## Purpose and Motivation

https://scsynth.org/t/increasing-the-limits-classvars-function-args-and-serveroptions/13234 pointed out that, even when using NamedControls, SynthDefs are limited to 255 control names, not by anything structural in SynthDef, but rather due to an optimization in SynthDesc: the way that msgFunc uses function arguments to access event keys en masse.

An optimization should not impose limits that would otherwise not be present. (labeling this as a bug fix for that reason).

This change clumps control names into blocks of 250.

- Normal case: If <= 250, the behavior is unchanged. `msgFunc` is generated exactly as before.
- Large-def case: If > 250, `makeMsgFunc` constructs multiple message functions and uses an outer-level function to merge their results into a single array.

```
// normal case: no change
SynthDescLib.at(\default).msgFunc.postcs; ""

#{ arg out, freq, amp, pan;
	var	x9218BE44 = Array.new(8);
	out !? { x9218BE44.add('out').add(out) };
	freq !? { x9218BE44.add('freq').add(freq) };
	amp !? { x9218BE44.add('amp').add(amp) };
	pan !? { x9218BE44.add('pan').add(pan) };
	x9218BE44
}

// big case
SynthDef('300_controls', {
	var ctl = Control.names(
		Array.fill(300, { |i| ("ctl" ++ i).asSymbol })
	).kr(Array.fill(300, { |i| i/300 }));
	Out.ar(0, DC.ar(0))
}).add;

SynthDescLib.at('300_controls').msgFunc.postcs; ""

#{
	var yAD7B1D38 = Array(600);
	yAD7B1D38 = yAD7B1D38.addAll(#{ arg ctl0, ctl1, ctl2, /* snip... */ ctl248, ctl249;
	var	xAD7B1D38 = Array.new(500);
	ctl0 !? { xAD7B1D38.add('ctl0').add(ctl0) };
	ctl1 !? { xAD7B1D38.add('ctl1').add(ctl1) };
	ctl2 !? { xAD7B1D38.add('ctl2').add(ctl2) };
	/* snip... */
	ctl248 !? { xAD7B1D38.add('ctl248').add(ctl248) };
	ctl249 !? { xAD7B1D38.add('ctl249').add(ctl249) };
	xAD7B1D38
}.valueEnvir);
	yAD7B1D38 = yAD7B1D38.addAll(#{ arg ctl250, ctl251, /* snip... */ ctl298, ctl299;
	var	xAD7B1D38 = Array.new(100);
	ctl250 !? { xAD7B1D38.add('ctl250').add(ctl250) };
	ctl251 !? { xAD7B1D38.add('ctl251').add(ctl251) };
	/* snip... */
	ctl298 !? { xAD7B1D38.add('ctl298').add(ctl298) };
	ctl299 !? { xAD7B1D38.add('ctl299').add(ctl299) };
	xAD7B1D38
}.valueEnvir);
	yAD7B1D38;
}
```

Large case: One `#{ ... }.valueEnvir` covers the first 250 control names, then another, and another if needed. All control names are covered (the unit test verifies this), and it's still using the optimized `valueEnvir` approach rather than a `do` loop. (Yes, it looks dumb when printed out, but readability isn't an issue, and it's good to avoid the overhead of `do`.)

In the normal case, there should be no performance impact on event.play (because `msgFunc` has not changed at all). Of course, for a large number of control names, performance would be slower anyway. I think this design minimizes performance impact.

Also, we never had a unit test for msgFunc, so I added one here.

## Types of changes

- Bug fix

## To-do list

- [x] Code is tested
- [x] All tests are passing
- [ ] Updated documentation n/a
- [x] This PR is ready for review