### PR TITLE
server: do not skip .so files in 'top-level' directories

### DIFF
--- a/server/scsynth/SC_Lib_Cintf.cpp
+++ b/server/scsynth/SC_Lib_Cintf.cpp
@@ -68,9 +68,12 @@ SC_LibCmd* gCmdArray[NUMBER_OF_COMMANDS];
 
 // The generic .so extension has been deprecated in SC 3.15 so developers can ship shared libraries
 // along their plugins. We do the following to provide a smooth upgrade path:
-// If there has been a plugin with the SC_PLUGIN_EXT extension in the same folder or one of its
-// parent folders we simply ignore the .so file because we can assume it is a dependency.
+// If there has been a plugin with the SC_PLUGIN_EXT extension in the same folder or one of its parent
+// folders we simply ignore the .so file because we can assume it is a dependency.
 // Otherwise we load the .so file and post a warning.
+// We have to make an exception for 'top-level' search paths because system-wide extensions install their
+// plugin binaries in the same directory as the core plugins. Since the latter already use the new extension,
+// any plugins that still use the old .so extension would be skipped silently.
 // NOTE: we should remove this workaround in the future!
 #ifdef __linux__
 #    define LINUX_PLUGIN_WORKAROUND
@@ -78,7 +81,7 @@ SC_LibCmd* gCmdArray[NUMBER_OF_COMMANDS];
 
 void initMiscCommands();
 #ifdef LINUX_PLUGIN_WORKAROUND
-static bool PlugIn_LoadDir(const fs::path& dir, bool reportError, bool foundScxFile = false);
+static bool PlugIn_LoadDir(const fs::path& dir, bool reportError, bool isTopLevel = true, bool foundScxFile = false);
 #else
 static bool PlugIn_LoadDir(const fs::path& dir, bool reportError);
 #endif
@@ -192,34 +195,28 @@ void initialize_library(const char* uGensPluginPath) {
 #endif // STATIC_PLUGINS
 
     // If uGensPluginPath is supplied, it is exclusive.
-    bool loadUGensExtDirs = true;
     if (uGensPluginPath) {
-        loadUGensExtDirs = false;
         SC_StringParser sp(uGensPluginPath, SC_STRPARSE_PATHDELIMITER);
         while (!sp.AtEnd()) {
             PlugIn_LoadDir(const_cast<char*>(sp.NextToken()), true);
         }
-    }
+    } else {
+        using DirName = SC_Filesystem::DirName;
 
-    using DirName = SC_Filesystem::DirName;
-
-    if (loadUGensExtDirs) {
 #ifdef SC_PLUGIN_DIR
         // load globally installed plugins
         if (fs::is_directory(SC_PLUGIN_DIR)) {
             PlugIn_LoadDir(SC_PLUGIN_DIR, true);
         }
 #endif // SC_PLUGIN_DIR
-       // load default plugin directory
+
+        // load default plugin directory
         const fs::path pluginDir = SC_Filesystem::instance().getDirectory(DirName::Resource) / SC_PLUGIN_DIR_NAME;
 
         if (fs::is_directory(pluginDir)) {
             PlugIn_LoadDir(pluginDir, true);
         }
-    }
 
-    // get extension directories
-    if (loadUGensExtDirs) {
         // load system extension plugins
         const fs::path sysExtDir = SC_Filesystem::instance().getDirectory(DirName::SystemExtension);
         PlugIn_LoadDir(sysExtDir, false);
@@ -399,7 +396,7 @@ static bool PlugIn_LoadDir(const fs::path& dir, bool reportError) {
 #else
 // if 'foundScxFile' is true, it means that we have alredy found a .scx file in one of the parent
 // directories. In this case, we treat all .so files as shared libraries and ignore them.
-static bool PlugIn_LoadDir(const fs::path& dir, bool reportError, bool foundScxFile) {
+static bool PlugIn_LoadDir(const fs::path& dir, bool reportError, bool isTopLevel, bool foundScxFile) {
 #endif
     std::error_code ec;
     fs::directory_iterator iter(dir, fs::directory_options::follow_directory_symlink, ec);
@@ -465,20 +462,22 @@ static bool PlugIn_LoadDir(const fs::path& dir, bool reportError, bool foundScxF
             const fs::path& path = entry.path();
 
             if (fs::is_directory(path)) {
-                PlugIn_LoadDir(path, reportError, foundScxFile);
-            } else if (!foundScxFile && path.extension() == ".so") {
+                PlugIn_LoadDir(path, reportError, false, foundScxFile);
+            } else if ((isTopLevel || !foundScxFile) && path.extension() == ".so") {
                 // No .scx plugins were found in this directory or any parent directory -> assume the .so file is a
                 // plugin.
                 if (PlugIn_Load(path)) {
-                    scprintf("*** WARNING: '%s': the .so extension has been deprecated!\n",
+                    scprintf("WARNING: '%s': the .so extension has been deprecated!\n",
                              SC_Codecvt::path_to_utf8_str(path).c_str());
 
                     static bool didWarn = false;
                     if (!didWarn) {
                         scprintf("*** Please try to upgrade any SC extension where the UGen plugin still has the .so "
-                                 "extension. If you already have the latest version, please ask the developer to "
-                                 "update the extension. To suppress this warning in the meantime, you can manually "
-                                 "change the extension to .scx.\n");
+                                 "extension.\n");
+                        scprintf("*** If you already have the latest version, please ask the developer to update the "
+                                 "extension.\n");
+                        scprintf("*** To suppress this warning in the meantime, you can manually change the extension "
+                                 "to .scx.\n");
                         didWarn = true;
                     }
                 }

--- a/server/supernova/sc/sc_ugen_factory.cpp
+++ b/server/supernova/sc/sc_ugen_factory.cpp
@@ -37,9 +37,12 @@
 
 // The generic .so extension has been deprecated in SC 3.15 so developers can ship shared libraries
 // along their plugins. We do the following to provide a smooth upgrade path:
-// If there has been a plugin with the SC_PLUGIN_EXT extension in the same folder or one of its
-// parent folders we simply ignore the .so file because we can assume it is a dependency.
+// If there has been a plugin with the SC_PLUGIN_EXT extension in the same folder or one of its parent
+// folders we simply ignore the .so file because we can assume it is a dependency.
 // Otherwise we load the .so file and post a warning.
+// We have to make an exception for 'top-level' search paths because system-wide extensions install their
+// plugin binaries in the same directory as the core plugins. Since the latter already use the new extension,
+// any plugins that still use the old .so extension would be skipped silently.
 // NOTE: we should remove this workaround in the future!
 #ifdef __linux__
 #    define LINUX_PLUGIN_WORKAROUND
@@ -212,7 +215,7 @@ bool sc_plugin_container::run_cmd_plugin(World* world, const char* name, sc_msg_
 
 void sc_ugen_factory::load_plugin_folder(std::filesystem::path const& dir) {
 #ifdef LINUX_PLUGIN_WORKAROUND
-    load_plugin_folder(dir, false);
+    load_plugin_folder(dir, true, false);
 #else
     namespace fs = std::filesystem;
 
@@ -242,7 +245,7 @@ void sc_ugen_factory::load_plugin_folder(std::filesystem::path const& dir) {
 #ifdef LINUX_PLUGIN_WORKAROUND
 // if 'found_scx_file' is true, it means that we have alredy found a .scx file in one of the parent
 // directories. In this case, we treat all .so files as shared libraries and ignore them.
-void sc_ugen_factory::load_plugin_folder(std::filesystem::path const& dir, bool found_scx_file) {
+void sc_ugen_factory::load_plugin_folder(std::filesystem::path const& dir, bool is_top_level, bool found_scx_file) {
     namespace fs = std::filesystem;
 
     fs::directory_iterator end;
@@ -267,19 +270,21 @@ void sc_ugen_factory::load_plugin_folder(std::filesystem::path const& dir, bool 
     // then iterate over subdirectories and .so files
     for (const auto& entry : fs::directory_iterator(dir, options)) {
         if (fs::is_directory(entry.path())) {
-            load_plugin_folder(entry.path(), found_scx_file);
-        } else if (!found_scx_file && entry.path().extension() == ".so") {
+            load_plugin_folder(entry.path(), false, found_scx_file);
+        } else if ((is_top_level || !found_scx_file) && entry.path().extension() == ".so") {
             // No .scx plugins were found in this directory or any parent directory -> assume the .so file is a plugin.
             load_plugin(entry.path());
-            std::cout << "*** WARNING: '" << SC_Codecvt::path_to_utf8_str(entry.path()).c_str()
+            std::cout << "WARNING: '" << SC_Codecvt::path_to_utf8_str(entry.path()).c_str()
                       << "': the .so extension has been deprecated!" << std::endl;
 
             static bool didWarn = false;
             if (!didWarn) {
                 std::cout << "*** Please try to upgrade any SC extension where the UGen plugin still has the .so "
-                          << "extension. If you already have the latest version, please ask the developer to update "
-                          << "the extension. To suppress this warning in the meantime, you can manually change the "
-                          << "extension to .scx." << std::endl;
+                          << "extension.\n"
+                          << "*** If you already have the latest version, please ask the developer to update the "
+                          << "extension.\n"
+                          << "*** To suppress this warning in the meantime, you can manually change the extensions to "
+                          << ".scx." << std::endl;
                 didWarn = true;
             }
         }

--- a/server/supernova/sc/sc_ugen_factory.hpp
+++ b/server/supernova/sc/sc_ugen_factory.hpp
@@ -206,7 +206,7 @@ public:
     void load_plugin(std::filesystem::path const& path);
 
 private:
-    void load_plugin_folder(std::filesystem::path const& dir, bool found_scx_file);
+    void load_plugin_folder(std::filesystem::path const& dir, bool is_top_level, bool found_scx_file);
 
     void close_handles(void);
 


### PR DESCRIPTION
This fixes an issue with system-wide extensions where the plugins are installed in the same location as the core plugins. Since the latter already use the new .scx extensions, any plugins with the old .so extension would be silently skipped.

Initially reported by @jamshark70 on the SC forum: https://scsynth.org/t/3-15-so-extension-has-been-deprecated/13245

<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
