### PR TITLE
fix sclang unity builds in msvc

### DIFF
--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -21,6 +21,7 @@ jobs:
             use-syslibs: false
             shared-libscsynth: false
             ctest: false
+            unity-build: false
 
           - job-name: ""
             os-version: "22.04"
@@ -29,6 +30,7 @@ jobs:
             use-syslibs: false
             shared-libscsynth: false
             ctest: false
+            unity-build: false
 
           - job-name: "with ctest"
             os-version: "22.04"
@@ -38,6 +40,7 @@ jobs:
             shared-libscsynth: false
             artifact-suffix: "ubuntu-22.04-gcc12" # will trigger artifact upload; after changing this update the test-linux artifact-file in actions.yml
             ctest: true
+            unity-build: false
 
           - job-name: "use system libraries with ctest"
             os-version: "24.04"
@@ -46,6 +49,7 @@ jobs:
             use-syslibs: true
             shared-libscsynth: false
             ctest: true
+            unity-build: false
 
           - job-name: "shared libscsynth"
             os-version: "24.04"
@@ -54,6 +58,7 @@ jobs:
             use-syslibs: false
             shared-libscsynth: true
             ctest: false
+            unity-build: false
             
           - job-name: ""
             os-version: "22.04"
@@ -62,6 +67,7 @@ jobs:
             use-syslibs: false
             shared-libscsynth: false
             ctest: false
+            unity-build: false
 
           - job-name: ""
             os-version: "24.04"
@@ -70,6 +76,7 @@ jobs:
             use-syslibs: false
             shared-libscsynth: false
             ctest: false
+            unity-build: false
 
           - job-name: ""
             os-version: "24.04"
@@ -79,13 +86,14 @@ jobs:
             shared-libscsynth: false
             ctest: false
 
-          - job-name: ""
+          - job-name: "unity build"
             os-version: "24.04"
             c-compiler: "clang-17"
             cxx-compiler: "clang++-17"
             use-syslibs: false
             shared-libscsynth: false
             ctest: false
+            unity-build: true
 
           - job-name: "with ctest"
             os-version: "24.04"
@@ -94,6 +102,7 @@ jobs:
             use-syslibs: false
             shared-libscsynth: false
             ctest: true
+            unity-build: false
 
           - job-name: "arm64 with ctest"
             os-version: "24.04-arm"
@@ -102,6 +111,7 @@ jobs:
             use-syslibs: false
             shared-libscsynth: false
             ctest: true
+            unity-build: false
 
     name: Ubuntu ${{ matrix.os-version }} ${{ matrix.c-compiler }} ${{ matrix.job-name }}
     env:
@@ -109,6 +119,7 @@ jobs:
       INSTALL_PATH: ${{ github.workspace }}/build/Install
       USE_SYSLIBS: ${{ matrix.use-syslibs }}
       SHARED_LIBSCSYNTH: ${{ matrix.shared-libscsynth }}
+      UNITY_BUILD: ${{ matrix.unity-build }}
       CC: ${{ matrix.c-compiler }}
       CXX: ${{ matrix.cxx-compiler }}
       ARTIFACT_FILE: "SuperCollider-${{ inputs.sc-version }}-${{ matrix.artifact-suffix }}"
@@ -159,6 +170,8 @@ jobs:
           if $USE_SYSLIBS; then EXTRA_CMAKE_FLAGS="-DSYSTEM_BOOST=ON -DSYSTEM_YAMLCPP=ON"; fi
 
           if $SHARED_LIBSCSYNTH; then EXTRA_CMAKE_FLAGS="-DLIBSCSYNTH=ON $EXTRA_CMAKE_FLAGS"; fi
+
+          if $UNITY_BUILD; then EXTRA_CMAKE_FLAGS="-DFINAL_BUILD=ON $EXTRA_CMAKE_FLAGS"; fi
 
           cmake $EXTRA_CMAKE_FLAGS -DSC_EL=ON -DSC_VIM=ON -DSC_QT=ON -DSC_IDE=ON  -DCMAKE_INSTALL_PREFIX:PATH=$INSTALL_PATH -DCMAKE_BUILD_TYPE=Release .. # --debug-output
 

--- a/.github/workflows/build_macos.yml
+++ b/.github/workflows/build_macos.yml
@@ -58,7 +58,7 @@ jobs:
             extra-cmake-flags: "-D SYSTEM_PORTAUDIO=ON -D SYSTEM_BOOST=ON -D SYSTEM_YAMLCPP=ON"
             ctest: true
 
-          - job-name: "arm64 shared libscsynth"
+          - job-name: "arm64 shared libscsynth unity build"
             os-version: "15"
             xcode-version: "16.0"
             qt-modules: 'qtwebengine qtwebchannel qtwebsockets qtpositioning'
@@ -67,7 +67,7 @@ jobs:
             homebrew-packages: "qt@6 libsndfile readline"
             vcpkg-packages: ""
             vcpkg-triplet: ""
-            extra-cmake-flags: "-D LIBSCSYNTH=ON"
+            extra-cmake-flags: "-D LIBSCSYNTH=ON -D FINAL_BUILD=ON"
             ctest: false
 
     name: macOS ${{ matrix.job-name }}

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - job-name: "32-bit with ctest"
+          - job-name: "32-bit with ctest unity build"
             fftw-arch: "x86"
             cmake-arch: "Win32"
             os-version: "2022"
@@ -30,6 +30,7 @@ jobs:
             # artifact-suffix: "win32" # set if needed - will trigger artifact upload
             # create-installer: ${{ startsWith(github.ref, 'refs/tags/') }}
             # installer-suffix: "win32-installer"
+            extra-cmake-flags: "-D FINAL_BUILD=ON"
 
           - job-name: "64-bit MSVC 2022 with ctest"
             fftw-arch: "x64"
@@ -159,7 +160,7 @@ jobs:
 
           mkdir $BUILD_PATH && cd $BUILD_PATH
 
-          cmake -G "${{ matrix.cmake-generator }}" -A "${{ matrix.cmake-arch }}" -D SC_USE_QTWEBENGINE=${{ matrix.use-qtwebengine }} -D CMAKE_BUILD_TYPE=Release -DVCPKG_TARGET_TRIPLET="${{ matrix.vcpkg-triplet }}" .. # build type is specified here for MinGW build and for vcpkg
+          cmake -G "${{ matrix.cmake-generator }}" -A "${{ matrix.cmake-arch }}" -D SC_USE_QTWEBENGINE=${{ matrix.use-qtwebengine }} -D CMAKE_BUILD_TYPE=Release -DVCPKG_TARGET_TRIPLET="${{ matrix.vcpkg-triplet }}" "${{ matrix.extra-cmake-flags }}" .. # build type is specified here for MinGW build and for vcpkg
 
       - name: build
         shell: bash

--- a/lang/CMakeLists.txt
+++ b/lang/CMakeLists.txt
@@ -189,6 +189,21 @@ add_library(libsclang STATIC ${sclang_sources} ${sclang_parser_source})
 
 if(FINAL_BUILD)
 	set_source_files_properties(${sclang_parser_source} PROPERTIES SKIP_UNITY_BUILD_INCLUSION ON)
+    set_source_files_properties(${CMAKE_SOURCE_DIR}/SCDoc/lex.scdoc.cpp PROPERTIES SKIP_UNITY_BUILD_INCLUSION ON)
+    if(WIN32)
+        set_source_files_properties(${CMAKE_SOURCE_DIR}/common/SC_Filesystem_win.cpp PROPERTIES SKIP_UNITY_BUILD_INCLUSION ON)
+        set_source_files_properties(${CMAKE_SOURCE_DIR}/common/SC_PaUtils.cpp PROPERTIES SKIP_UNITY_BUILD_INCLUSION ON)
+        set_source_files_properties(${CMAKE_SOURCE_DIR}/common/SC_Win32Utils.cpp PROPERTIES SKIP_UNITY_BUILD_INCLUSION ON)
+        set_source_files_properties(${CMAKE_SOURCE_DIR}/lang/LangPrimSource/PyrFilePrim.cpp PROPERTIES SKIP_UNITY_BUILD_INCLUSION ON)
+        set_source_files_properties(${CMAKE_SOURCE_DIR}/lang/LangPrimSource/PyrPlatformPrim.cpp PROPERTIES SKIP_UNITY_BUILD_INCLUSION ON)
+        set_source_files_properties(${CMAKE_SOURCE_DIR}/lang/LangPrimSource/PyrSched.cpp PROPERTIES SKIP_UNITY_BUILD_INCLUSION ON)
+        set_source_files_properties(${CMAKE_SOURCE_DIR}/lang/LangPrimSource/SC_AudioDevicePrim.cpp PROPERTIES SKIP_UNITY_BUILD_INCLUSION ON)
+        set_source_files_properties(${CMAKE_SOURCE_DIR}/lang/LangPrimSource/SC_ComPort.cpp PROPERTIES SKIP_UNITY_BUILD_INCLUSION ON)
+        set_source_files_properties(${CMAKE_SOURCE_DIR}/lang/LangSource/PyrLexer.cpp PROPERTIES SKIP_UNITY_BUILD_INCLUSION ON)
+    endif()
+    if(MSVC)
+        target_compile_options(libsclang PRIVATE "/bigobj")
+    endif()
 	set_target_properties(libsclang PROPERTIES 
 		UNITY_BUILD ON
 		UNITY_BUILD_BATCH_SIZE 16 


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

This PR fixes unity build for sclang under MSVC. 
This was achieved by excluding files from the unity build. The need to exclude multiple files comes from naming/macro clashes with Windows headers, AFAIU

Additionally, I've turned on unity build for a single non-release build on each platform.

I plan to fix unity builds for other components, and once that is done, we can decide if we want to use unity builds by default or not.

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [n/a] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
