### PR TITLE
Standardise `key–value pair` usage and `argument terminology` across documentation

### DIFF
--- a/HelpSource/Classes/Boolean.schelp
+++ b/HelpSource/Classes/Boolean.schelp
@@ -60,4 +60,4 @@ Returns:: The receiver. The same message is understood by link::Classes/SimpleNu
 
 method::keywordWarnings
 
-turn on/off warnings if a keyword argument is not found
+turn on/off warnings if an link::Reference/Syntax-Shortcuts::#arbitrary keyword argument#arbitrary keyword argument:: is not found.

--- a/HelpSource/Classes/CallOnce.schelp
+++ b/HelpSource/Classes/CallOnce.schelp
@@ -42,9 +42,8 @@ argument::  ... args
 Arguments to use in the call to the wrapped function, if the call happens. If code::didEvaluate:: already returns code::true:: (before the current call to code::value::) then the current code::args:: are irrelevant because the wrapped function is not called anymore.
 
 argument:: kwargs
-Array of key-value pairs for keyword arguments.
-See link::Classes/Function#-value::, and link::Reference/Syntax-Shortcuts#creating Arrays with key-value pairs::.
-returns::
+link::Classes/Array:: of link::Reference/Syntax-Shortcuts#creating Arrays with key-value pairs#key-value pairs:: for link::Reference/Functions#Arbitrary Keyword Arguments#arbitrary keyword arguments::.
+See link::Classes/Function#-value::.
 
 returns::
 list::

--- a/HelpSource/Classes/CallOnce.schelp
+++ b/HelpSource/Classes/CallOnce.schelp
@@ -42,7 +42,9 @@ argument::  ... args
 Arguments to use in the call to the wrapped function, if the call happens. If code::didEvaluate:: already returns code::true:: (before the current call to code::value::) then the current code::args:: are irrelevant because the wrapped function is not called anymore.
 
 argument:: kwargs
-Array of key-value pairs for keyword arguments. See link::Classes/Function#-value::.
+Array of key-value pairs for keyword arguments.
+See link::Classes/Function#-value::, and link::Reference/Syntax-Shortcuts#creating Arrays with key-value pairs::.
+returns::
 
 returns::
 list::

--- a/HelpSource/Classes/Collection.schelp
+++ b/HelpSource/Classes/Collection.schelp
@@ -7,6 +7,32 @@ DESCRIPTION::
 Collection is an abstract class. You do not create direct instances of Collection.
 There are many types of Collections including link::Classes/List::, link::Classes/Array::, link::Classes/Dictionary::, link::Classes/Bag::, link::Classes/Set::, link::Classes/SortedList::, etc. See link::Overviews/Collections:: for a complete class tree.
 
+note::
+Many subclasses of link::Classes/Collection:: support a shorthand syntax for placing key–value pairs directly inside their literal form.
+This syntax is distinct from link::Classes/Event:: literals and may be unfamiliar to new users. For example:
+
+code::
+// commonly used as an Array:
+[\freq: 440, \amp: 1]    // -> [\freq, 440, \amp, 1]
+
+// but also valid for other Collections:
+List[\freq: 440, \amp: 1]       // -> List[\freq, 440, \amp, 1]
+Set[\freq: 440, \amp: 1]        // -> Set[\freq, 440, \amp, 1]
+Bag[\freq: 440, \amp: 1]        // -> Bag[\freq, 440, \amp, 1]
+SortedList[\freq: 440, \amp: 1] // -> SortedList[\freq, 440, \amp, 1]
+SparseArray[\freq: 440, \amp: 1] // -> SparseArray[\freq, 440, \amp, 1]
+IdentitySet[\freq: 440, \amp: 1] // -> IdentitySet[\freq, 440, \amp, 1]
+...
+::
+
+Only expressions that form a valid key–value pair are interpreted this way.
+Expressions that do not form a pair (e.g., code::[\a: 3, \b]::) follow normal Collection parsing rules,
+and triplet forms such as code::[\a: 3: \b]:: will result in a syntax error.
+
+See link::Reference/Syntax-Shortcuts#creating Arrays with key-value pairs::
+::
+
+
 CLASSMETHODS::
 
 method::newFrom

--- a/HelpSource/Classes/Collection.schelp
+++ b/HelpSource/Classes/Collection.schelp
@@ -8,7 +8,7 @@ Collection is an abstract class. You do not create direct instances of Collectio
 There are many types of Collections including link::Classes/List::, link::Classes/Array::, link::Classes/Dictionary::, link::Classes/Bag::, link::Classes/Set::, link::Classes/SortedList::, etc. See link::Overviews/Collections:: for a complete class tree.
 
 note::
-Many subclasses of link::Classes/Collection:: support a shorthand syntax for placing key–value pairs directly inside their literal form.
+Many subclasses of link::Classes/Collection:: support a shorthand syntax for placing key-value pairs directly inside their literal form.
 This syntax is distinct from link::Classes/Event:: literals and may be unfamiliar to new users. For example:
 
 code::
@@ -25,7 +25,7 @@ IdentitySet[\freq: 440, \amp: 1] // -> IdentitySet[\freq, 440, \amp, 1]
 ...
 ::
 
-Only expressions that form a valid key–value pair are interpreted this way.
+Only expressions that form a valid key-value pair are interpreted this way.
 Expressions that do not form a pair (e.g., code::[\a: 3, \b]::) follow normal Collection parsing rules,
 and triplet forms such as code::[\a: 3: \b]:: will result in a syntax error.
 

--- a/HelpSource/Classes/Collection.schelp
+++ b/HelpSource/Classes/Collection.schelp
@@ -8,28 +8,26 @@ Collection is an abstract class. You do not create direct instances of Collectio
 There are many types of Collections including link::Classes/List::, link::Classes/Array::, link::Classes/Dictionary::, link::Classes/Bag::, link::Classes/Set::, link::Classes/SortedList::, etc. See link::Overviews/Collections:: for a complete class tree.
 
 note::
-Many subclasses of link::Classes/Collection:: support a shorthand syntax for placing key-value pairs directly inside their literal form.
+Many subclasses of link::Classes/Collection:: support link::Reference/Syntax-Shortcuts#creating Arrays with key-value pairs#a shorthand syntax for placing key–value pairs:: directly inside their literal form.
 This syntax is distinct from link::Classes/Event:: literals and may be unfamiliar to new users. For example:
 
 code::
 // commonly used as an Array:
-[\freq: 440, \amp: 1]    // -> [\freq, 440, \amp, 1]
+[freq: 440, amp: 1]    // -> [freq, 440, amp, 1]
 
 // but also valid for other Collections:
-List[\freq: 440, \amp: 1]       // -> List[\freq, 440, \amp, 1]
-Set[\freq: 440, \amp: 1]        // -> Set[\freq, 440, \amp, 1]
-Bag[\freq: 440, \amp: 1]        // -> Bag[\freq, 440, \amp, 1]
-SortedList[\freq: 440, \amp: 1] // -> SortedList[\freq, 440, \amp, 1]
-SparseArray[\freq: 440, \amp: 1] // -> SparseArray[\freq, 440, \amp, 1]
-IdentitySet[\freq: 440, \amp: 1] // -> IdentitySet[\freq, 440, \amp, 1]
+List[freq: 440, amp: 1]       // -> List[freq, 440, amp, 1]
+Set[freq: 440, amp: 1]        // -> Set[440, freq, amp, 1]
+Bag[freq: 440, amp: 1]        // -> Bag[440, freq, amp, 1]
+SortedList[freq: 440, amp: 1] // -> SortedList[1, amp, 440, freq]
+SparseArray[freq: 440, amp: 1] // -> SparseArray[freq, 440, amp, 1]
+IdentitySet[freq: 440, amp: 1] // -> IdentitySet[1, freq, 440, amp]
 ...
 ::
 
-Only expressions that form a valid key-value pair are interpreted this way.
-Expressions that do not form a pair (e.g., code::[\a: 3, \b]::) follow normal Collection parsing rules,
-and triplet forms such as code::[\a: 3: \b]:: will result in a syntax error.
-
-See link::Reference/Syntax-Shortcuts#creating Arrays with key-value pairs::
+Only expressions that form a valid key–value pair are interpreted this way.
+Expressions that do not form a pair (e.g., code::(var b; [a: 3, b]):: or code::[a: 3, \b]::) follow normal Collection parsing rules,
+and triplet forms such as code::[a: 3: b]:: will result in a syntax error.
 ::
 
 

--- a/HelpSource/Classes/DoesNotUnderstandError.schelp
+++ b/HelpSource/Classes/DoesNotUnderstandError.schelp
@@ -26,7 +26,7 @@ argument:: args
 Arguments passed to the unknown method.
 
 argument:: keywordArgumentPairs
-The keyword arguments that were passed to the link::Classes/DoesNotUnderstandError::.
+The link::Reference/Functions#Arbitrary Keyword Arguments#arbitrary keyword arguments:: that were passed to the link::Classes/DoesNotUnderstandError::.
 
 instancemethods::
 

--- a/HelpSource/Classes/Event.schelp
+++ b/HelpSource/Classes/Event.schelp
@@ -242,7 +242,7 @@ q.y;			// [100, 200, 300]
 
 subsection::Syntax subtleties
 
-Events have a very special meaning in a musical context within SuperCollider, especially when it comes to sequencing with Patterns. Nevertheless, as the class inherits from link::Classes/IdentityDictionary::, it is often used as a convenient-to-type replacement for (Identity)Dictionary-like objects. The syntax very much reminds of the declaration of keyword arguments in function or method calls. However, there is a subtle difference:
+Events have a very special meaning in a musical context within SuperCollider, especially when it comes to sequencing with Patterns. Nevertheless, as the class inherits from link::Classes/IdentityDictionary::, it is often used as a convenient-to-type replacement for (Identity)Dictionary-like objects. The syntax very much reminds of the declaration of link::Reference/Messages#keyword argument calls#keyword argument calls:: in function or method calls. However, there is a subtle difference:
 
 code::
 e = (a: 10);  // -> ('a': 10)

--- a/HelpSource/Classes/Function.schelp
+++ b/HelpSource/Classes/Function.schelp
@@ -70,9 +70,9 @@ Evaluates the FunctionDef referred to by the Function. The Function is passed th
 
 code::
  // different way of expressing the same:
-{ |a, b| a * b }.value(3, 10);
-{ |a, b| a * b }.value(a: 3, b: 10); // keyword arguments
-{ |a, b| a * b }.(3, 10); // short syntax: "value" can be dropped.
+{ |a, b| a * b }.value(3, 10);       // positional argument calls
+{ |a, b| a * b }.value(a: 3, b: 10); // keyword argument calls
+{ |a, b| a * b }.(3, 10);            // short syntax: "value" can be dropped.
 ::
 
 Default arguments can be omitted in the call:
@@ -82,7 +82,7 @@ code::
 { |a=3, b=10| a * b }.value(b: 100); // set the second argument (b) without the first
 ::
 
-The results of functions composed with operators distribute the keyword arguments to each of the operands.
+The results of functions composed with operators distribute the link::Reference/Messages#keyword argument calls#keyword argument calls:: to each of the operands.
 
 code::
 f = { |a, b=1| a ** b } * { |a, c = 0| a + c };
@@ -336,14 +336,14 @@ This method is kept for backward compatibility. Use code::flop:: instead.
 method::inEnvir
 
 returns an "environment-safe" function. See Environment for more details.
-Note that the function returned takes no keyword arguments.
+Note that the function returned takes no link::Reference/Messages#keyword argument calls#keyword argument calls::.
 
 code::
 e = (a: "get it", b: "didn't");
 f = { ~b + ~a + "..." }.inEnvir(e);
 f.value;
 
-f = { |how = "", end = "..."| how + ~b + ~a + end }.inEnvir(e); // doesn't work with keyword arguments
+f = { |how = "", end = "..."| how + ~b + ~a + end }.inEnvir(e); // doesn't work with keyword argument calls
 f.value(how: "really"); // WARNING: keyword arg 'how' not found in call to function (see inEnvirWithArgs).
 
 

--- a/HelpSource/Classes/Function.schelp
+++ b/HelpSource/Classes/Function.schelp
@@ -3,7 +3,7 @@ summary::Implements a function
 categories::Core>Kernel
 related::Reference/Functions, Classes/AbstractFunction, Classes/FunctionDef
 
-This document deals with the usage of Function objects. 
+This document deals with the usage of Function objects.
 For a more general introduction and documentation of syntax, see link::Reference/Functions::.
 
 description::
@@ -173,6 +173,7 @@ argument::selector
 A Symbol representing a method selector.
 argument::pairs
 Array or List with key-value pairs.
+See link::Reference/Syntax-Shortcuts#creating Arrays with key-value pairs::.
 
 
 method::loop

--- a/HelpSource/Classes/FunctionDef.schelp
+++ b/HelpSource/Classes/FunctionDef.schelp
@@ -60,7 +60,7 @@ code::
 ::
 
 method::hasKwArgs
-Returns whether the function has variable keyword arguments
+Returns whether the function has link::Reference/Functions#Arbitrary Keyword Arguments#arbitrary keyword arguments::
 code::
 { |a, b, c| a + b * c }.def.hasKwArgs; // false
 { |a, b ... c| a + b * c }.def.hasKwArgs; // false
@@ -68,11 +68,11 @@ code::
 ::
 
 method::varArgsValue
-Returns how many sets of variable arguments the function has. 0 for none, 1 for ellipsis arguments, 2 for keyword arguments.
+Returns how many sets of link::Reference/Functions#Variable Arguments#variable arguments:: the function has. 0 for none, 1 for ellipsis arguments (link::Reference/Functions#Variadic Positional Arguments#variadic positional arguments::), 2 for link::Reference/Functions#Arbitrary Keyword Arguments#arbitrary keyword arguments::.
 code::
 { |a, b, c| a + b * c }.def.varArgsValue; // 0
 { |a, b ... c| a + b * c }.def.varArgsValue; // 1
-{ |a ... b, c| a * b }.def.varArgsValue; // 1
+{ |a ... b, c| a * b }.def.varArgsValue; // 2
 ::
 
 method::hasVarArgs
@@ -162,7 +162,7 @@ subsection::Generating Strings
 
 method::makeFuncModifierString
 
-Return a string that can be interpreted as code for a new function which extracts the arguments from the receiver. This can be used to build a hygienic macro which returns a function with valid keyword arguments, instead of just anonymously forwarding the arguments, like in code::{ |...args| func.valueArray(args) }::.
+Return a string that can be interpreted as code for a new function which extracts the arguments from the receiver. This can be used to build a hygienic macro which returns a function with valid link::Reference/Messages#keyword argument calls#keyword argument calls::, instead of just anonymously forwarding the arguments, like in code::{ |...args| func.valueArray(args) }::.
 
 For an implementation example link::Classes/Function#flop:: (as below).
 

--- a/HelpSource/Classes/GridLayout.schelp
+++ b/HelpSource/Classes/GridLayout.schelp
@@ -46,7 +46,7 @@ METHOD:: rows
 
     You can make an item span more than one cell by wrapping it into an Array, followed by pairs of (\rows, number) and/or (\columns, number). You can also assign an alignment to an item by following it with a pair of (\align, alignment). \rows, \columns, and \align can be abbreviated with \r, \c, and \a, respectively. For possible alignment values see link::Reference/gui_alignments::.
 
-    The simplified syntax for placing key-value pairs into an array comes handy (see link::Reference/Syntax-Shortcuts#Creating Arrays with key-value pairs::, and the example below).
+    The simplified syntax for placing key-value pairs into an array comes handy (see link::Reference/Syntax-Shortcuts#creating Arrays with key-value pairs::, and the example below).
 
     Example:
 Code::

--- a/HelpSource/Classes/LineLayout.schelp
+++ b/HelpSource/Classes/LineLayout.schelp
@@ -31,7 +31,7 @@ Each item can be a strong::view::, a strong::layout::, strong::nil:: (for stretc
 
 discussion::
 
-You can assign a strong::stretch factor:: and/or strong::alignment:: to an item by wrapping it into an array, followed by pairs of ('stretch', factor) and/or ('align', alignment). 'stretch' and 'align' may be abbreviated with 's' and 'a'. Simplified syntax for placing key-value pairs into an array comes handy (see link::Reference/Syntax-Shortcuts#Creating arrays with key-value pairs::, and the example below). For possible alignment values see link::Reference/gui_alignments::.
+You can assign a strong::stretch factor:: and/or strong::alignment:: to an item by wrapping it into an array, followed by pairs of ('stretch', factor) and/or ('align', alignment). 'stretch' and 'align' may be abbreviated with 's' and 'a'. Simplified syntax for placing key-value pairs into an array comes handy (see link::Reference/Syntax-Shortcuts#creating Arrays with key-value pairs::, and the example below). For possible alignment values see link::Reference/gui_alignments::.
 
 If the item is a stretchable empty space (nil) alignment will have no effect; if the item is a fixed-size empty space (an Integer), it is unaffected by both the stretch factor and alignment.
 

--- a/HelpSource/Classes/Maybe.schelp
+++ b/HelpSource/Classes/Maybe.schelp
@@ -130,7 +130,8 @@ code::
 );
 
 
-// sets
+// sets:
+
 ~a = Set[0, 4, 5, 7];
 ~b = Set[4, 5];
 ~c = ~a union: ~b; // union of the two sets (note that the shortcut | does not work here.).
@@ -147,7 +148,8 @@ code::
 ~d.value; // but not part of the intersection
 
 
-// envirs
+// envirs:
+
 ~a = (note: [1, 2]);
 ~b = (dur: 1);
 ~c = ~a.putAll(~b) // provisionally put everything into the placholder
@@ -159,7 +161,8 @@ code::
 ~a = (note: [7.5]);
 ~d.value; // [7.5]
 
-// patterns
+// patterns:
+
 ~a = Pseq([1, 2, 3]);
 ~b = Pseq([5, ~a, ~a + 10], inf);
 ~b.value.asStream.nextN(10);
@@ -168,14 +171,14 @@ code::
 ~a = Prand([100, 200]);
 ~b.value.asStream.nextN(10);
 
-// keyword arguments
+// declared arguments with positional argument calls or keyword argument calls:
 
 ~a = { |x=0, y=0| x + y };
-~a.(2, 3);
-~a.(y:3);
+~a.(2, 3); // positional argument calls
+~a.(y:3);  // keyword argument call
 
 ~k = 1997;
-~a.(x:2, y:~k);
+~a.(x:2, y:~k); // keyword argument calls
 
 
 

--- a/HelpSource/Classes/Object.schelp
+++ b/HelpSource/Classes/Object.schelp
@@ -569,6 +569,7 @@ argument:: selector
 A Symbol representing a method selector.
 argument:: pairs
 Array or List with key-value pairs.
+See link::Reference/Syntax-Shortcuts#creating Arrays with key-value pairs::.
 discussion::
 code::
 a = { |a, b, c| postf("% plus % plus % is %\n", a, b, c, a + b + c); "" };

--- a/HelpSource/Classes/Object.schelp
+++ b/HelpSource/Classes/Object.schelp
@@ -520,7 +520,9 @@ a.performList(\value, [1, 2, 3]);
 ::
 
 method::performArgs
-Like link::#-perform::, but allows you to pass an link::Classes/Array:: of link::Reference/Syntax-Shortcuts#creating Arrays with key-value pairs#key-value pairs:: of link::Reference/Functions#Arbitrary Keyword Arguments#arbitrary keyword arguments::.
+Like link::#-perform::, but allows you to pass an link::Classes/Array:: of
+link::Reference/Syntax-Shortcuts#creating Arrays with key-value pairs#key–value pairs::
+representing link::Reference/Functions#Arbitrary Keyword Arguments#arbitrary keyword arguments::.
 Useful in link::#-doesNotUnderstand:: and other places where you might accept a variety of link::Reference/Functions#Arbitrary Keyword Arguments#arbitrary keyword arguments::.
 
 argument::selector

--- a/HelpSource/Classes/Object.schelp
+++ b/HelpSource/Classes/Object.schelp
@@ -520,8 +520,8 @@ a.performList(\value, [1, 2, 3]);
 ::
 
 method::performArgs
-Like link::#-perform::, but allows you to pass a key-value array of keyword arguments.
-Useful in link::#-doesNotUnderstand:: and other places where you might accept a variety of keyword arguments.
+Like link::#-perform::, but allows you to pass an link::Classes/Array:: of link::Reference/Syntax-Shortcuts#creating Arrays with key-value pairs#key-value pairs:: of link::Reference/Functions#Arbitrary Keyword Arguments#arbitrary keyword arguments::.
+Useful in link::#-doesNotUnderstand:: and other places where you might accept a variety of link::Reference/Functions#Arbitrary Keyword Arguments#arbitrary keyword arguments::.
 
 argument::selector
 A link::Classes/Symbol:: of the method name.
@@ -590,7 +590,7 @@ Set[1, 2, 3].tryPerform(\keysValuesDo, { |key, value| [key, value].postln });
 // Error occurs within keysValuesDo -- error is thrown back to halt execution
 (a: 1, b: 2, c: 3).tryPerform(\keysValuesDo, { |key, value| [key, value].flippityblargh });
 
-// keyword arguments are passed on
+// arbitrary keyword arguments are passed on
 [1, 2, 3, 4].tryPerform(\pyramid, patternType: 1)
 
 ::
@@ -613,7 +613,7 @@ method::superPerformArgs
 Like performLArgs, superPerformArgs calls a method, however it calls the method on the superclass.
 selector: A Symbol representing a method selector.
 args: Method arguments.
-kwargs: Keyword arguments, are passed as key value pairs.
+kwargs: link::Reference/Functions#Arbitrary Keyword Arguments#arbitrary keyword arguments::, are passed as key value pairs.
 
 method::multiChannelPerform
 Perform selector with multichannel expansion. See also: link::Guides/Multichannel-Expansion::.
@@ -696,7 +696,7 @@ argument::... args
 An link::Classes/Array:: of arguments.
 
 argument::kwargs
-An link::Classes/Array:: of keyword argument pairs.
+An link::Classes/Array:: of link::Reference/Functions#Arbitrary Keyword Arguments#arbitrary keyword argument:: pairs.
 
 method::throw
 

--- a/HelpSource/Classes/Pbind.schelp
+++ b/HelpSource/Classes/Pbind.schelp
@@ -19,7 +19,7 @@ code::
 Pbind(\note, Pseq([0, 4, 7]), \amp, 0.1, \dur, 0.2).play
 ::
 
-The message code::new:: converts keyword arguments into key value pairs, so that we can write:
+The message code::new:: converts link::Reference/Functions#Arbitrary Keyword Arguments#arbitrary keyword argument:: into link::Reference/Key-Value-Pairs#key value pairs#key value pairs::, so that we can write:
 
 code::
 Pbind(note: Pseq([0, 4, 7]), amp: 0.1, dur: 0.2).play
@@ -92,10 +92,10 @@ Pbind(
 ).play;
 ::
 
-The keys can be specified as keyword arguments, as above, or as a sequence of keys to patterns provided as arguments.
+The keys can be specified as link::Reference/Messages#keyword argument calls#keyword argument calls::, as above, or as a sequence of keys to patterns provided as arguments.
 Additionally, when an array of keys is provided, the pattern with be unpacked into two streams (see following example).
-However, this does not work when using keyword arguments, and therefore must go before them.
-For historical reasons, you are more likely to see the sequence of keys to patterns rather than keyword arguments.
+However, this does not work when using link::Reference/Messages#keyword argument calls#keyword argument calls::, and therefore must go before them.
+For historical reasons, you are more likely to see the sequence of keys to patterns rather than link::Reference/Messages#keyword argument calls#keyword argument calls::.
 
 code::
 // Both of these do the same thing.
@@ -114,7 +114,7 @@ SynthDef(\test, {
 )
 
 // Assignment to multiple keys using an Array.
-// Must come before any keyword arguments.
+// Must come before any keyword argument calls.
 Pbind(
 	[\freq, \sustain], Ptuple([
                           Pseq((1..16) * 50, 4),

--- a/HelpSource/Classes/PbindProxy.schelp
+++ b/HelpSource/Classes/PbindProxy.schelp
@@ -17,7 +17,7 @@ a.set(\note, Pseq([0, 6, 10]));
 a.stop;
 ::
 
-It also supports keyword argument syntax:
+It also supports link::Reference/Messages#keyword argument calls#keyword argument call:: syntax:
 
 code::
 a = PbindProxy(note: Pseq([0, 7, 9]), dur: 0.2).play;

--- a/HelpSource/Classes/Pbindef.schelp
+++ b/HelpSource/Classes/Pbindef.schelp
@@ -16,7 +16,7 @@ code::
 Pbindef(\x, \note, Pseq([0, 7, 9]), \dur, 0.2).play;
 ::
 
-It also supports keyword argument syntax:
+It also supports link::Reference/Messages#keyword argument calls#keyword argument call:: syntax:
 
 code::
 Pbindef(\x, note: Pseq([0, 7, 9]), dur: 0.2).play;

--- a/HelpSource/Classes/Synth.schelp
+++ b/HelpSource/Classes/Synth.schelp
@@ -41,10 +41,8 @@ A String or Symbol specifying the name of the SynthDef to use in creating the Sy
 argument:: args
 An optional link::Classes/Array:: specifying initial values for the link::Classes/SynthDef::'s arguments (controls). These are specified in pairs of control name or index and value. If names are used they can be specified with either link::Classes/String::s or link::Classes/Symbol::s. e.g. code:: [\frequency, 440, \amplitude, 1, ...] ::.
 
-key-value pair syntax may also be used:
-code::[\frequency: 440, \amplitude: 1, ...]::.
-
-See link::Reference/Syntax-Shortcuts#creating Arrays with key-value pairs::.
+Alternatively, the link::Reference/Syntax-Shortcuts#creating Arrays with key-value pairs#key‑value pair syntax:: can be used:
+code::[frequency: 440, amplitude: 1, ...]::.
 
 Values that are arrays are sent using OSC array type-tags ($[ and $]).  These values will be assigned to subsequent controls.
 

--- a/HelpSource/Classes/Synth.schelp
+++ b/HelpSource/Classes/Synth.schelp
@@ -41,7 +41,7 @@ A String or Symbol specifying the name of the SynthDef to use in creating the Sy
 argument:: args
 An optional link::Classes/Array:: specifying initial values for the link::Classes/SynthDef::'s arguments (controls). These are specified in pairs of control name or index and value. If names are used they can be specified with either link::Classes/String::s or link::Classes/Symbol::s. e.g. code:: [\frequency, 440, \amplitude, 1, ...] ::.
 
-Key–value pair syntax may also be used:
+key-value pair syntax may also be used:
 code::[\frequency: 440, \amplitude: 1, ...]::.
 
 See link::Reference/Syntax-Shortcuts#creating Arrays with key-value pairs::.

--- a/HelpSource/Classes/Synth.schelp
+++ b/HelpSource/Classes/Synth.schelp
@@ -40,6 +40,12 @@ A String or Symbol specifying the name of the SynthDef to use in creating the Sy
 
 argument:: args
 An optional link::Classes/Array:: specifying initial values for the link::Classes/SynthDef::'s arguments (controls). These are specified in pairs of control name or index and value. If names are used they can be specified with either link::Classes/String::s or link::Classes/Symbol::s. e.g. code:: [\frequency, 440, \amplitude, 1, ...] ::.
+
+Key–value pair syntax may also be used:
+code::[\frequency: 440, \amplitude: 1, ...]::.
+
+See link::Reference/Syntax-Shortcuts#creating Arrays with key-value pairs::.
+
 Values that are arrays are sent using OSC array type-tags ($[ and $]).  These values will be assigned to subsequent controls.
 
 argument:: target

--- a/HelpSource/Guides/WritingClasses.schelp
+++ b/HelpSource/Guides/WritingClasses.schelp
@@ -189,9 +189,9 @@ If initialisation logic that prepares the arguments before assignment is require
 ideally, it should go before the call to code::super.newCopyArgs::.
 This way the final object never exists in an invalid state — an alternative is the use of an code::init:: method and shall be shown shortly.
 
-However, when there is a hierarchy of classes, code::newCopyArgs:: requires that all the base class arguments be passed in the order they are defined. 
+However, when there is a hierarchy of classes, code::newCopyArgs:: requires that all the base class arguments be passed in the order they are defined.
 This makes changing the base class difficult.
-Here is one way to mitigate this issue using variable keyword arguments link::Reference/Functions#Variable Arguments:: and link::Classes/Object#-superPerformArgs::.
+Here is one way to mitigate this issue using link::Reference/Functions#Variable Arguments#variable arguments:: (pariculary link::Reference/Functions#Arbitrary Keyword Arguments#arbitrary keyword arguments::) and link::Classes/Object#-superPerformArgs::.
 
 code::
 Base {
@@ -221,13 +221,13 @@ Derived(d: 10) // If 'd' existed somewhere in the hierarchy, it would be assigne
 Although this approach might seem complex, the benefit is that the new instance variables can be added to either class and it will always be clear which one you meant to assign to.
 
 Should it be desirable to remove instance variables of the base class in the future,
-it is good to require that only keyword arguments be used.
+it is good to require that only link::Reference/Functions#Arbitrary Keyword Arguments#arbitrary keyword arguments:: be used.
 This can be achieved by removing the named arguments and throwing an error if code::args:: is not empty.
 One disadvantage here is that autocomplete in the IDE will not work.
 
 code::
 Foo {
-	*new { |... args, kwargs| 
+	*new { |... args, kwargs|
 		if(args.empty.not) { Error().throw };
 		^super.superPerformArgs(\newCopyArgs, #[], kwargs);
 	}
@@ -275,8 +275,8 @@ Derived : Base {
 }
 ::
 
-Warning:: 
-If both the code::Base:: and code::Derived:: class define an code::init:: method, the code::Derived:: class will override the code::Base::'s implementation, 
+Warning::
+If both the code::Base:: and code::Derived:: class define an code::init:: method, the code::Derived:: class will override the code::Base::'s implementation,
 meaning it will no longer be possible to call that implementation.
 In such cases, a unique method name like code::myclassInit:: should be used, or better yet, a specialised name that indicates what kind of initialization is performed.
 ::

--- a/HelpSource/Reference/Functions.schelp
+++ b/HelpSource/Reference/Functions.schelp
@@ -75,7 +75,7 @@ note::
 The use of three arguments is often paired with link::Classes/Object#-performArgs::.
 ::
 
-An argument list immediately follows the open curly bracket of a function definition. An argument list either begins with the reserved word code::arg::, or is contained between two vertical bars. If a function takes no arguments, then the argument list may be omitted.
+An argument list immediately follows the open curly bracket of a function definition. An argument list either begins with the reserved word code::arg::, or is contained between two vertical bars. If a function takes no arguments, then the argument list must be omitted.
 
 While you can pick any name for the emphasis::variadic positional arguments:: and emphasis::arbitrary keyword arguments::, they always refer to the unmatched emphasis::variadic positional arguments:: and emphasis::arbitrary keyword arguments::, so it is often best to name them code::args:: and code::kwargs::.
 

--- a/HelpSource/Reference/Functions.schelp
+++ b/HelpSource/Reference/Functions.schelp
@@ -52,25 +52,61 @@ image::functions.png#Functions::
 
 section:: Arguments
 
+Functions may take several kinds of arguments.
+SuperCollider language supports three categories of function arguments in the following order of an argument list:
+
+numberedlist::
+## Declared Arguments
+
+fixed, named arguments that may have default values.
+
+## Positional Variable Arguments
+
+a catch‑all for additional positional arguments.
+
+## Arbitrary Keyword Arguments
+
+a catch‑all for additional keyword arguments.
+::
+
+note::
+The use of three arguments is often paired with link::Classes/Object#-performArgs::.
+::
+
 An argument list immediately follows the open curly bracket of a function definition. An argument list either begins with the reserved word code::arg::, or is contained between two vertical bars. If a function takes no arguments, then the argument list may be omitted.
 
-Names of arguments in the list may be initialized to a default value using the following syntax forms. Arguments which are not explicitly initialized will be set to nil if no value is passed for them.
+While you can pick any name for the positional variable and arbitrary keyword arguments, they always refer to the unmatched positional and keyword arguments, so it is often best to name them code::args:: and code::kwargs::.
 
-"arg" style, default value is a literal:
+
+Names of arguments in the list may be initialized to a default value.
+Arguments which are not explicitly initialized will be set to code::nil:: if no value is passed for them.
+The following subsections describe each argument type in detail.
+
+
+subsection:: Declared Arguments
+
+Declared arguments are written first in the argument list.
+Names of arguments in the list may be initialized to a default value using the following syntax forms (literals or expressions):
+
+list::
+## "arg" style, default value is a literal:
 code::{ arg x = 1; .... } :: link::#[1]::
 
-"arg" style, default value is an expression:
+## "arg" style, default value is an expression:
 code::{ arg x = 10.rand; ... } :: link::#[2]::
 
-"arg" style, default value is a literal but you want to treat it like an expression:
+## "arg" style, default value is a literal but you want to treat it like an expression:
 code::{ arg x = (2); ... } :: link::#[2]::
 
-Pipe style, default value is a literal:
+## Pipe style, default value is a literal:
 code::{ |x = 1| ... } :: link::#[1]::
 
-Pipe style, default value is an expression:
+## Pipe style, default value is an expression:
 code::{ |x = (10.rand)| ... } :: link::#[2]::
+::
 
+Declared arguments behave differently depending on whether the default is a literal or an expression.
+Literal defaults are stored in the link::Classes/FunctionDef::, while expression defaults are evaluated at call time only when the passed value is code::nil::.
 
 In general arguments may be initialized to literals or expressions, but in the case of link::Classes/Function#-play:: or link::Classes/SynthDef#-play::, they may only be initialized to literals.
 code::
@@ -88,58 +124,10 @@ code::
 
 See link::Reference/Literals:: for more information.
 
-section:: Variable Arguments
-
-Variable arguments are how functions catch an unknown number of arguments or keyword arguments. 
-There are two possible variable arguments, the first for positional arguments, and second for keyword arguments.
-They are marked by an ellipsis after any normal arguments and separated by a comma.
-
-The first variable argument (positional) catches all remaining arguments in an link::Classes/Array::
-
-code::
-f = { |a ... args| "a: %, args: %".format(a, args) };
-
-f.(1, 2, 3) // a: 1, args: [2, 3]
-f.(1) // a: 1, args: []
-f.(a: 1) // a: 1, args: []
-
-// catches all arguments
-g = { |...args| "args: %".format(args) };
-
-g.(1, 2, 3) // args: [1, 2, 3]
-g.() // args: []
-::
-
-The second variable argument catches all keyword arguments.
-It puts them in an link::Classes/Array:: of key-value pairs.
-
-code::
-f = { |...args, kwargs| "args: %, kwargs: %".format(args, kwargs) };
-
-f.(1, 2, 3) // args: [1, 2, 3], kwargs: []
-
-f.(a: 10) // args: [], kwargs: [a, 10]
-
-f.(1, 2, 3, meow: 10, woof: 20) // args: [1, 2, 3], kwargs: [meow, 10, woof, 20]
-
-::
-
-The use of variable keyword arguments is often paired with link::Classes/Object#-performArgs::.
-
-While you can pick any name for the variable arguments, they always refer to the unmatched positional and keyword arguments, so it is often best to name them code::args:: and code::kwargs::.
-
-You cannot reassign the value of the variable arguments at the call–site even if they share the same name (see below for example).
-
-code::
-f = { |...args, kwargs| "args: %, kwargs: %".format(args, kwargs) };
-f.(args: 10, kwargs: 20) // args: [], kwargs: [args: 10, kwargs: 20]
-
-f = { |...a, b| "a: %, b: %".format(a, b) };
-f.(a: 10, b: 20) // a: [], b: [a: 10, b: 20]
-::
+The following subsections describe these two default styles.
 
 anchor::[1]::
-subsection:: [1] Literal argument defaults
+subsubsection:: [1] Literal argument defaults
 
 Argument defaults that are literals are stored as part of the link::Classes/FunctionDef::. Arguments passed at runtime — including nil — always override the defaults:
 
@@ -153,7 +141,7 @@ f.(nil);  // prints nil
 ::
 
 anchor::[2]::
-subsection:: [2] Expression argument defaults
+subsubsection:: [2] Expression argument defaults
 
 Since expressions are evaluated when the function is called, they cannot be stored in the link::Classes/FunctionDef::. They are executed only if the passed-in value is nil.
 
@@ -218,6 +206,62 @@ code::
 	x ?? { x = 10.rand };
 	x
 };
+::
+
+subsection:: Variable Arguments
+
+Variable arguments are how functions catch an unknown number of arguments or keyword arguments.
+There are two possible variable arguments, the first for positional arguments, and second for keyword arguments.
+They are marked by an ellipsis after any normal arguments and separated by a comma.
+
+You cannot reassign the value of the variable arguments at the call–site even if they share the same name:
+
+code::
+f = { |...args, kwargs| "args: %, kwargs: %".format(args, kwargs) };
+f.(args: 10, kwargs: 20) // args: [], kwargs: [args: 10, kwargs: 20]
+
+f = { |...a, b| "a: %, b: %".format(a, b) };
+f.(a: 10, b: 20) // a: [], b: [a: 10, b: 20]
+::
+
+subsubsection:: Positional Variable Arguments
+
+Positional variable arguments allow a function to catch an unknown number of positional arguments.
+They are written using an ellipsis code::...:: after any declared arguments.
+
+The collected arguments are placed into an link::Classes/Array:::
+
+code::
+f = { |a ... args| "a: %, args: %".format(a, args) };
+f.(1, 2, 3);   // a: 1, args: [2, 3]
+f.(1);         // a: 1, args: []
+f.(a: 1);      // a: 1, args: []
+::
+
+A function may consist solely of variable positional arguments:
+
+code::
+g = { |...args| "args: %".format(args) };
+
+g.(1, 2, 3) // args: [1, 2, 3]
+g.() // args: []
+::
+
+Variable positional arguments always collect unmatched positional arguments, regardless of name.
+
+subsubsection:: Arbitrary Keyword Arguments
+
+Arbitrary keyword arguments catches all keyword arguments.
+It puts them in an link::Classes/Array:: of key-value pairs.
+
+code::
+f = { |...args, kwargs| "args: %, kwargs: %".format(args, kwargs) };
+
+f.(1, 2, 3)                     // args: [1, 2, 3], kwargs: []
+
+f.(a: 10)                       // args: [], kwargs: [a, 10]
+
+f.(1, 2, 3, meow: 10, woof: 20) // args: [1, 2, 3], kwargs: [meow, 10, woof, 20]
 ::
 
 section:: Variables

--- a/HelpSource/Reference/Functions.schelp
+++ b/HelpSource/Reference/Functions.schelp
@@ -56,15 +56,17 @@ Functions may take several kinds of arguments.
 SuperCollider language supports three categories of function arguments in the following order of an argument list:
 
 numberedlist::
-## Declared Arguments
+## link::#Declared Arguments::
 
 fixed, named arguments that may have default values.
 
-## Positional Variable Arguments
+## link::#Variadic Positional Arguments::
 
 a catch‑all for additional positional arguments.
 
-## Arbitrary Keyword Arguments
+
+
+## link::#Arbitrary Keyword Arguments::
 
 a catch‑all for additional keyword arguments.
 ::
@@ -75,7 +77,7 @@ The use of three arguments is often paired with link::Classes/Object#-performArg
 
 An argument list immediately follows the open curly bracket of a function definition. An argument list either begins with the reserved word code::arg::, or is contained between two vertical bars. If a function takes no arguments, then the argument list may be omitted.
 
-While you can pick any name for the positional variable and arbitrary keyword arguments, they always refer to the unmatched positional and keyword arguments, so it is often best to name them code::args:: and code::kwargs::.
+While you can pick any name for the emphasis::variadic positional arguments:: and emphasis::arbitrary keyword arguments::, they always refer to the unmatched emphasis::variadic positional arguments:: and emphasis::arbitrary keyword arguments::, so it is often best to name them code::args:: and code::kwargs::.
 
 
 Names of arguments in the list may be initialized to a default value.
@@ -85,7 +87,7 @@ The following subsections describe each argument type in detail.
 
 subsection:: Declared Arguments
 
-Declared arguments are written first in the argument list.
+emphasis::Declared arguments:: are written first in the argument list.
 Names of arguments in the list may be initialized to a default value using the following syntax forms (literals or expressions):
 
 list::
@@ -105,7 +107,7 @@ code::{ |x = 1| ... } :: link::#[1]::
 code::{ |x = (10.rand)| ... } :: link::#[2]::
 ::
 
-Declared arguments behave differently depending on whether the default is a literal or an expression.
+emphasis::Declared arguments:: behave differently depending on whether the default is a literal or an expression.
 Literal defaults are stored in the link::Classes/FunctionDef::, while expression defaults are evaluated at call time only when the passed value is code::nil::.
 
 In general arguments may be initialized to literals or expressions, but in the case of link::Classes/Function#-play:: or link::Classes/SynthDef#-play::, they may only be initialized to literals.
@@ -210,8 +212,7 @@ code::
 
 subsection:: Variable Arguments
 
-Variable arguments are how functions catch an unknown number of arguments or keyword arguments.
-There are two possible variable arguments, the first for positional arguments, and second for keyword arguments.
+emphasis::Variable arguments:: are how functions catch an unknown number of arguments (link::#Variadic Positional Arguments#variadic positional arguments::) or optional keyword arguments (link::#Arbitrary Keyword Arguments#arbitrary keyword arguments::).
 They are marked by an ellipsis after any normal arguments and separated by a comma.
 
 You cannot reassign the value of the variable arguments at the call–site even if they share the same name:
@@ -224,44 +225,90 @@ f = { |...a, b| "a: %, b: %".format(a, b) };
 f.(a: 10, b: 20) // a: [], b: [a: 10, b: 20]
 ::
 
-subsubsection:: Positional Variable Arguments
+subsubsection:: Variadic Positional Arguments
 
-Positional variable arguments allow a function to catch an unknown number of positional arguments.
-They are written using an ellipsis code::...:: after any declared arguments.
+emphasis::Variadic positional arguments:: catch all remaining arguments in an link::Classes/Array:: and allow a function to catch an unknown number of positional arguments.
+They are written using an ellipsis code::...:: after any link::#Declared Arguments#declared arguments::.
+(See link::Reference/Syntax-Shortcuts#ellipsis in function arguments::.)
 
 The collected arguments are placed into an link::Classes/Array:::
 
 code::
 f = { |a ... args| "a: %, args: %".format(a, args) };
-f.(1, 2, 3);   // a: 1, args: [2, 3]
-f.(1);         // a: 1, args: []
-f.(a: 1);      // a: 1, args: []
-::
 
-A function may consist solely of variable positional arguments:
+f.(1, 2, 3, 4, 5);   // -> a: 1, args: [2, 3, 4, 5]
+f.(1, 2, 3);         // -> a: 1, args: [2, 3]
+f.(1);               // -> a: 1, args: []
+f.(a: 1);            // -> a: 1, args: []
+
+f.(a: 1, b: 2);
+// WARNING: keyword arg 'b' not found in call to function.
+// -> a: 1, args: []
+::
 
 code::
-g = { |...args| "args: %".format(args) };
+g = { |a, b ... rest| "a: %, b: %, rest: %".format(a, b, rest) };
 
-g.(1, 2, 3) // args: [1, 2, 3]
-g.() // args: []
+g.(1, 2, 3, 4, 5);   // -> a: 1, b: 2, rests: [3, 4, 5]
 ::
 
-Variable positional arguments always collect unmatched positional arguments, regardless of name.
+A function may consist solely of variadic positional arguments:
+
+code::
+h = { |...args| "args: %".format(args) };
+
+h.(1, 2, 3) // args: [1, 2, 3]
+h.(2, 3)    // args: [2, 3]
+h.()        // args: []
+::
+
+emphasis::Variadic positional arguments:: always collect unmatched positional arguments, regardless of name.
+
+note::
+See:
+list::
+## link::Reference/Messages#Keyword Argument Calls and Positional Argument Calls::
+## link::Classes/FunctionDef#-numArgs::
+## link::Classes/FunctionDef#-numVars::
+## link::Classes/FunctionDef#-varArgs::
+## link::Classes/FunctionDef#-varArgsValue::
+## link::Classes/FunctionDef#-hasVarArgs::
+::
+::
 
 subsubsection:: Arbitrary Keyword Arguments
 
-Arbitrary keyword arguments catches all keyword arguments.
-It puts them in an link::Classes/Array:: of key-value pairs.
+emphasis::Arbitrary keyword arguments:: catches all optional keyword arguments that are not explicitly named.
+(See link::Reference/Syntax-Shortcuts#ellipsis in function arguments::.)
+
+These are often called emphasis::keyword arguments::, but they are different from link::Reference/Messages#keyword argument calls#keyword argument calls::.
+
+They are supported only with the pipe notation (code:: | | ::), not with code:: arg ::.
+The identifier for emphasis::arbitrary keyword arguments:: may be any variable name beginning with a lowercase letter, though code::kwargs:: is a common choice.
+
+It puts them in an link::Classes/Array:: of link::Reference/Syntax-Shortcuts#creating Arrays with key-value pairs#key-value pairs:::
 
 code::
+// Capture arbitrary keyword arguments:
 f = { |...args, kwargs| "args: %, kwargs: %".format(args, kwargs) };
 
 f.(1, 2, 3)                     // args: [1, 2, 3], kwargs: []
-
 f.(a: 10)                       // args: [], kwargs: [a, 10]
-
 f.(1, 2, 3, meow: 10, woof: 20) // args: [1, 2, 3], kwargs: [meow, 10, woof, 20]
+
+// Named arguments are matched first; the rest go into args or kwargs:
+f = { |a, b ... args, kwargs| [a, b, args, kwargs] };
+f.(1, 2, 3, 4, x: 5, y: 6);        // -> [ 1, 2, [ 3, 4 ], [ x, 5, y, 6 ] ]
+f.(1, 2, 3, 4, 5, 6, x: 7, y: 8);  // -> [ 1, 2, [ 3, 4, 5, 6 ], [ x, 7, y, 8 ] ]
+::
+
+note::
+See
+list::
+## link::Classes/FunctionDef#-hasKwArgs::
+## link::Classes/Object#-performList::
+## link::Classes/Object#-performArgs::
+::
 ::
 
 section:: Variables

--- a/HelpSource/Reference/Key-Value-Pairs.schelp
+++ b/HelpSource/Reference/Key-Value-Pairs.schelp
@@ -17,27 +17,27 @@ See link::Reference/Syntax-Shortcuts#creating Arrays with key-value pairs:: for 
 
 note::
 
-link::Classes/Function:: calls also allow a syntax using keyword argument messages that resembles key–value pairs. For example:
+link::Classes/Function:: calls also allow a syntax using link::Reference/Messages#keyword argument calls#keyword argument calls:: that resembles key–value pairs. For example:
 
 code::
 x = { |a = 0, b = 0| "a: % b: % \t\t a - b = %".format(a.asString.padRight(7, " "), b, a - b) };
 
-// calling with positional arguments:
+// positional argument calls:
 x.(1, 2)       // -> a: 1       b: 2 		 a - b = -1
 x.([1, 2], 3)  // -> a: [1, 2]  b: 3 		 a - b = [-2, -1]
 x.(*[1, 2])    // -> a: 1       b: 2 		 a - b = -1
 
-// calling with keyword arguments (key–value pairs):
+// keyword argument calls (key–value pairs):
 x.(b: 1, a: 2) // -> a: 2       b: 1 		 a - b = 1
 x.(b: 1)       // -> a: 0       b: 1 		 a - b = -1
 ::
 
 (See link::Overviews/SymbolicNotations#Where f is a function::.)
 
-This syntax uses the keyword argument message to set link::Reference/Functions#declared arguments:: (see also link::Reference/Messages#Keyword Arguments and Positional Arguments::).
+This syntax uses the link::Reference/Messages#keyword argument calls#keyword argument calls:: to set link::Reference/Functions#declared arguments::.
 It should not be confused with the key–value pair syntax used in link::Classes/Array::.
 
-By contrast, when link::Reference/Syntax-Shortcuts#arbitrary keyword arguments (kwargs):: are used, the caller supplies name–value pairs, and sclang collects them into a key–value array:
+By contrast, when link::Reference/Functions#Arbitrary Keyword Arguments#arbitrary keyword arguments:: are used, the caller supplies name–value pairs, and sclang collects them into a key–value array:
 
 code::
 f = { |a ...args, kwargs| "a: %;\t args: %;\t kwargs: %".format(a, args, kwargs) }
@@ -46,7 +46,7 @@ f.("declared arg", "variable arg", x:"kwarg1", y:"kwarg1")
 // -> a: declared arg;	 args: [variable arg];	 kargs: [x, kwarg1, y, kwarg1]
 ::
 
-Arbitrary keyword arguments (code::kwargs::) are internally represented as key–value arrays.
+link::Reference/Functions#Arbitrary Keyword Arguments#Arbitrary keyword arguments:: are internally represented as key–value arrays.
 ::
 
 To make it easy to translate between these purposes and representations, there is a uniform set of methods:

--- a/HelpSource/Reference/Key-Value-Pairs.schelp
+++ b/HelpSource/Reference/Key-Value-Pairs.schelp
@@ -34,7 +34,7 @@ x.(b: 1)       // -> a: 0       b: 1 		 a - b = -1
 
 (See link::Overviews/SymbolicNotations#Where f is a function::.)
 
-This syntax uses the keyword argument message to set emphasis::declared arguments:: (see link::Reference/Messages#Keyword Arguments and Positional Arguments::).
+This syntax uses the keyword argument message to set link::Reference/Functions#declared arguments:: (see also link::Reference/Messages#Keyword Arguments and Positional Arguments::).
 It should not be confused with the key–value pair syntax used in link::Classes/Array::.
 
 By contrast, when link::Reference/Syntax-Shortcuts#arbitrary keyword arguments (kwargs):: are used, the caller supplies name–value pairs, and sclang collects them into a key–value array:

--- a/HelpSource/Reference/Key-Value-Pairs.schelp
+++ b/HelpSource/Reference/Key-Value-Pairs.schelp
@@ -8,30 +8,51 @@ SECTION::Motivation
 There are three very similar ways to represent maps between keys and values, each of which have a specific purpose:
 
 TABLE::
-## link::Reference/Syntax-Shortcuts#creating Arrays with key-value pairs#key value pairs:: || common representation of arguments for link::Classes/Synth:: calls || code::[freq: 452, amp: 0.2]::
-## collections of link::Classes/Association::s || ordering, link::Classes/Array:: and link::Classes/Collection:: methods || code::[0 -> [1, 2, 3], 1 -> [2, 1]]::
 ## dictionaries: fast lookup || link::Classes/Event:: compatibility || code::(instrument: \sine, freq: 561)::
+## collections of link::Classes/Association::s || ordering, link::Classes/Array:: and link::Classes/Collection:: methods || code::[0 -> [1, 2, 3], 1 -> [2, 1]]::
+## key value pairs || common representation of arguments for link::Classes/Synth:: calls || code::[\freq, 452, \amp, 0.2]::
 ::
+
+See link::Reference/Syntax-Shortcuts#creating Arrays with key-value pairs:: for the literal syntax of emphasis::key–value pairs::.
 
 note::
-link::Classes/Function:: calls also allow a syntax called keyword argument that resembles key–value pairs. For example:
+
+link::Classes/Function:: calls also allow a syntax using keyword argument messages that resembles key–value pairs. For example:
+
 code::
-x = { |a = 0, b = 0| a + b };
+x = { |a = 0, b = 0| "a: % b: % \t\t a - b = %".format(a.asString.padRight(7, " "), b, a - b) };
 
-// positional argument:
-x.(1, 2)
+// calling with positional arguments:
+x.(1, 2)       // -> a: 1       b: 2 		 a - b = -1
+x.([1, 2], 3)  // -> a: [1, 2]  b: 3 		 a - b = [-2, -1]
+x.(*[1, 2])    // -> a: 1       b: 2 		 a - b = -1
 
-// keyword argument (key-value pair):
-x.(b: 1)
-x.(b: 1, a: 2)
+// calling with keyword arguments (key–value pairs):
+x.(b: 1, a: 2) // -> a: 2       b: 1 		 a - b = 1
+x.(b: 1)       // -> a: 0       b: 1 		 a - b = -1
 ::
-It is unrelated to the collecton-based key–value pair syntax described in this document.
+
+(See link::Overviews/SymbolicNotations#Where f is a function::.)
+
+This syntax uses the keyword argument message to set emphasis::declared arguments:: (see link::Reference/Messages#Keyword Arguments and Positional Arguments::).
+It should not be confused with the key–value pair syntax used in link::Classes/Array::.
+
+By contrast, when link::Reference/Syntax-Shortcuts#arbitrary keyword arguments (kwargs):: are used, the caller supplies name–value pairs, and sclang collects them into a key–value array:
+
+code::
+f = { |a ...args, kwargs| "a: %;\t args: %;\t kwargs: %".format(a, args, kwargs) }
+
+f.("declared arg", "variable arg", x:"kwarg1", y:"kwarg1")
+// -> a: declared arg;	 args: [variable arg];	 kargs: [x, kwarg1, y, kwarg1]
+::
+
+Arbitrary keyword arguments (code::kwargs::) are internally represented as key–value arrays.
 ::
 
 To make it easy to translate between these purposes and representations, there is a uniform set of methods:
 
 TABLE::
-##code::asPairs:: || returns an array of key value pairs
+##code::asPairs:: || returns an array of key-value pairs
 ##code::asAssociations:: || returns an array of associations
 ##code::asDict:: || returns an IdentityDictionary.
 ::

--- a/HelpSource/Reference/Key-Value-Pairs.schelp
+++ b/HelpSource/Reference/Key-Value-Pairs.schelp
@@ -13,11 +13,11 @@ TABLE::
 ## key value pairs || common representation of arguments for link::Classes/Synth:: calls || code::[\freq, 452, \amp, 0.2]::
 ::
 
-See link::Reference/Syntax-Shortcuts#creating Arrays with key-value pairs:: for the literal syntax of emphasis::key-value pairs::.
+See link::Reference/Syntax-Shortcuts#creating Arrays with key-value pairs:: for the syntax shortcut.
 
 note::
 
-link::Classes/Function:: calls also allow a syntax using link::Reference/Messages#keyword argument calls#keyword argument calls:: that resembles key-value pairs. For example:
+link::Classes/Function:: calls also allow a syntax using link::Reference/Messages#keyword argument calls#keyword argument calls:: that resembles emphasis::key-value pairs::. For example:
 
 code::
 x = { |a = 0, b = 0| "a: % b: % \t\t a - b = %".format(a.asString.padRight(7, " "), b, a - b) };
@@ -35,9 +35,9 @@ x.(b: 1)       // -> a: 0       b: 1 		 a - b = -1
 (See link::Overviews/SymbolicNotations#Where f is a function::.)
 
 This syntax uses the link::Reference/Messages#keyword argument calls#keyword argument calls:: to set link::Reference/Functions#declared arguments::.
-It should not be confused with the key-value pair syntax used in link::Classes/Array::.
+It should not be confused with the link::Reference/Syntax-Shortcuts#creating Arrays with key-value pairs#key-value pair syntax used in Array::.
 
-By contrast, when link::Reference/Functions#Arbitrary Keyword Arguments#arbitrary keyword arguments:: are used, the caller supplies name–value pairs, and sclang collects them into a key-value array:
+By contrast, when link::Reference/Functions#Arbitrary Keyword Arguments#arbitrary keyword arguments:: are used, the caller supplies name–value pairs, and sclang collects them into a link::Reference/Syntax-Shortcuts#creating Arrays with key-value pairs#key-value array:::
 
 code::
 f = { |a ...args, kwargs| "a: %;\t args: %;\t kwargs: %".format(a, args, kwargs) }
@@ -46,7 +46,7 @@ f.("declared arg", "variable arg", x:"kwarg1", y:"kwarg1")
 // -> a: declared arg;	 args: [variable arg];	 kargs: [x, kwarg1, y, kwarg1]
 ::
 
-link::Reference/Functions#Arbitrary Keyword Arguments#Arbitrary keyword arguments:: are internally represented as key-value arrays.
+link::Reference/Functions#Arbitrary Keyword Arguments#Arbitrary keyword arguments:: are internally represented as link::Reference/Syntax-Shortcuts#creating Arrays with key-value pairs#key-value arrays::.
 ::
 
 To make it easy to translate between these purposes and representations, there is a uniform set of methods:

--- a/HelpSource/Reference/Key-Value-Pairs.schelp
+++ b/HelpSource/Reference/Key-Value-Pairs.schelp
@@ -8,9 +8,24 @@ SECTION::Motivation
 There are three very similar ways to represent maps between keys and values, each of which have a specific purpose:
 
 TABLE::
-## key value pairs || common representation of arguments || code::[\freq, 452, \amp, 0.2]::
-## collections of associations || ordering, array and collection methods || code::[0 -> [1, 2, 3], 1 -> [2, 1]]::
-## dictionaries: fast lookup || event compatibility || code::(instrument: \sine, freq: 561)::
+## link::Reference/Syntax-Shortcuts#creating Arrays with key-value pairs#key value pairs:: || common representation of arguments for link::Classes/Synth:: calls || code::[freq: 452, amp: 0.2]::
+## collections of link::Classes/Association::s || ordering, link::Classes/Array:: and link::Classes/Collection:: methods || code::[0 -> [1, 2, 3], 1 -> [2, 1]]::
+## dictionaries: fast lookup || link::Classes/Event:: compatibility || code::(instrument: \sine, freq: 561)::
+::
+
+note::
+link::Classes/Function:: calls also allow a syntax called keyword argument that resembles key–value pairs. For example:
+code::
+x = { |a = 0, b = 0| a + b };
+
+// positional argument:
+x.(1, 2)
+
+// keyword argument (key-value pair):
+x.(b: 1)
+x.(b: 1, a: 2)
+::
+It is unrelated to the collecton-based key–value pair syntax described in this document.
 ::
 
 To make it easy to translate between these purposes and representations, there is a uniform set of methods:

--- a/HelpSource/Reference/Key-Value-Pairs.schelp
+++ b/HelpSource/Reference/Key-Value-Pairs.schelp
@@ -13,11 +13,11 @@ TABLE::
 ## key value pairs || common representation of arguments for link::Classes/Synth:: calls || code::[\freq, 452, \amp, 0.2]::
 ::
 
-See link::Reference/Syntax-Shortcuts#creating Arrays with key-value pairs:: for the literal syntax of emphasis::key–value pairs::.
+See link::Reference/Syntax-Shortcuts#creating Arrays with key-value pairs:: for the literal syntax of emphasis::key-value pairs::.
 
 note::
 
-link::Classes/Function:: calls also allow a syntax using link::Reference/Messages#keyword argument calls#keyword argument calls:: that resembles key–value pairs. For example:
+link::Classes/Function:: calls also allow a syntax using link::Reference/Messages#keyword argument calls#keyword argument calls:: that resembles key-value pairs. For example:
 
 code::
 x = { |a = 0, b = 0| "a: % b: % \t\t a - b = %".format(a.asString.padRight(7, " "), b, a - b) };
@@ -27,7 +27,7 @@ x.(1, 2)       // -> a: 1       b: 2 		 a - b = -1
 x.([1, 2], 3)  // -> a: [1, 2]  b: 3 		 a - b = [-2, -1]
 x.(*[1, 2])    // -> a: 1       b: 2 		 a - b = -1
 
-// keyword argument calls (key–value pairs):
+// keyword argument calls (key-value pairs):
 x.(b: 1, a: 2) // -> a: 2       b: 1 		 a - b = 1
 x.(b: 1)       // -> a: 0       b: 1 		 a - b = -1
 ::
@@ -35,9 +35,9 @@ x.(b: 1)       // -> a: 0       b: 1 		 a - b = -1
 (See link::Overviews/SymbolicNotations#Where f is a function::.)
 
 This syntax uses the link::Reference/Messages#keyword argument calls#keyword argument calls:: to set link::Reference/Functions#declared arguments::.
-It should not be confused with the key–value pair syntax used in link::Classes/Array::.
+It should not be confused with the key-value pair syntax used in link::Classes/Array::.
 
-By contrast, when link::Reference/Functions#Arbitrary Keyword Arguments#arbitrary keyword arguments:: are used, the caller supplies name–value pairs, and sclang collects them into a key–value array:
+By contrast, when link::Reference/Functions#Arbitrary Keyword Arguments#arbitrary keyword arguments:: are used, the caller supplies name–value pairs, and sclang collects them into a key-value array:
 
 code::
 f = { |a ...args, kwargs| "a: %;\t args: %;\t kwargs: %".format(a, args, kwargs) }
@@ -46,7 +46,7 @@ f.("declared arg", "variable arg", x:"kwarg1", y:"kwarg1")
 // -> a: declared arg;	 args: [variable arg];	 kargs: [x, kwarg1, y, kwarg1]
 ::
 
-link::Reference/Functions#Arbitrary Keyword Arguments#Arbitrary keyword arguments:: are internally represented as key–value arrays.
+link::Reference/Functions#Arbitrary Keyword Arguments#Arbitrary keyword arguments:: are internally represented as key-value arrays.
 ::
 
 To make it easy to translate between these purposes and representations, there is a uniform set of methods:

--- a/HelpSource/Reference/Messages.schelp
+++ b/HelpSource/Reference/Messages.schelp
@@ -111,10 +111,17 @@ z = x.value(10, 5, 9);  // z is set to 15. (a is 10, b is 5, 9 is ignored)
 
 section:: Keyword Arguments and Positional Arguments
 
-Arguments to methods and functions may be specified either by position or by name.
-Arguments specified by position are called emphasis::positional arguments::, and are interpreted according to the order in which they are declared in the method or function definition.
-Arguments specified by name (followed by a colon) are called emphasis::keyword arguments::.
+Arguments to methods and functions may be specified either by position or by name:
+list::
+## Arguments specified by position are called emphasis::positional arguments::, and are interpreted according to the order in which they are declared in the method or function definition.
+## Arguments specified by name (followed by a colon) are called emphasis::keyword arguments::.
 Any argument may be passed as a keyword argument except for the receiver code::this::.
+
+note::
+These keyword arguments belong to the message-passing system, and should not be confused with the emphasis::arbitrary keyword arguments:: captured in Function definitions using code::|... args, kwargs|:: or code::|a, b ... args, kwargs|::.
+See link::Reference/Syntax-Shortcuts#arbitrary keyword arguments (kwargs)::
+::
+::
 
 Keyword arguments must come after any positional arguments, may be specified in any order among themselves, and once a keyword argument is used, no positional argument may follow.
 In other words, if you skip any argument defined before the one you want to specify, you must use keyword arguments. So once you use a keyword argument, all subsequent arguments must also be keyword arguments.
@@ -130,7 +137,9 @@ f = { | a | a };
 f.(1, a: 2, a: 3); // -> 3, the rightmost value wins
 ::
 
-For example, the code::ar:: class method of the SinOsc class takes arguments named freq, phase, mul, and add in that order. All of the following are legal calls to that method.
+For example, the code::ar:: class method of the link::Classes/SinOsc:: class takes arguments named code::freq::, code::phase::, code::mul::, and code::add:: in that order.
+All of the following are legal calls to that method.
+
 code::
 SinOsc.ar(800, pi, 0.2, 0); // all positional arguments: freq, phase, mul, add
 

--- a/HelpSource/Reference/Messages.schelp
+++ b/HelpSource/Reference/Messages.schelp
@@ -109,31 +109,36 @@ z = x.value(10, 5);     // z is set to 15. (a is 10, b is 5)
 z = x.value(10, 5, 9);  // z is set to 15. (a is 10, b is 5, 9 is ignored)
 ::
 
-section:: Keyword Arguments and Positional Arguments
+section:: Keyword Argument Calls and Positional Argument Calls
 
 Arguments to methods and functions may be specified either by position or by name:
 list::
-## Arguments specified by position are called emphasis::positional arguments::, and are interpreted according to the order in which they are declared in the method or function definition.
-## Arguments specified by name (followed by a colon) are called emphasis::keyword arguments::.
-Any argument may be passed as a keyword argument except for the receiver code::this::.
+## strong::Positional Argument Calls::: anchor::positional argument calls::
+
+Arguments specified by position.
+They are interpreted according to the order in which they are declared in the method or function definition.
+
+## strong::Keyword Argument Calls::: anchor::keyword argument calls::
+
+Arguments specified by name (followed by a colon).
+Any argument may be passed by keyword except for the receiver code::this::.
 
 note::
-These keyword arguments belong to the message-passing system, and should not be confused with the emphasis::arbitrary keyword arguments:: captured in Function definitions using code::|... args, kwargs|:: or code::|a, b ... args, kwargs|::.
-See link::Reference/Syntax-Shortcuts#arbitrary keyword arguments (kwargs)::
+emphasis::Keyword argument calls:: belong to the message-passing system and should not be confused with the link::Reference/Functions#Arbitrary Keyword Arguments#arbitrary keyword arguments:: captured in Function definitions using code::|... args, kwargs|:: or code::|a, b ... args, kwargs|::.
 ::
 ::
 
-Keyword arguments must come after any positional arguments, may be specified in any order among themselves, and once a keyword argument is used, no positional argument may follow.
-In other words, if you skip any argument defined before the one you want to specify, you must use keyword arguments. So once you use a keyword argument, all subsequent arguments must also be keyword arguments.
+emphasis::Keyword argument calls:: must come after any emphasis::positional argument calls::. They may be specified in any order among themselves, and once a emphasis::keyword argument call:: is used, no emphasis::positional argument call:: may follow.
+In other words, if you skip any argument defined before the one you want to specify, you must use a emphasis::keyword argument call::. Once you use a emphasis::keyword argument call::, all subsequent argument calls must also be emphasis::keyword argument calls::.
 
-If a keyword is specified and there is no matching argument, it is ignored and a warning will be printed. This warning may be turned off globally by making the following call:
+If a keyword is specified and there is no matching argument, it is ignored and a warning is printed. This warning may be turned off globally by making the following call:
 code::
 keywordWarnings(false)
 ::
 
-If the same argument is specified more than once, whether by positional or keyword arguments, the rightmost value overrides all previous ones. Note that this usage, while legal, is discouraged as it can be confusing.
+If the same argument is specified more than once, whether by emphasis::positional argument call:: or emphasis::keyword argument call::, the rightmost value overrides all previous ones. Note that this usage, while legal, is discouraged because it can be confusing.
 code::
-f = { | a | a };
+f = { |a| a };
 f.(1, a: 2, a: 3); // -> 3, the rightmost value wins
 ::
 
@@ -141,37 +146,38 @@ For example, the code::ar:: class method of the link::Classes/SinOsc:: class tak
 All of the following are legal calls to that method.
 
 code::
-SinOsc.ar(800, pi, 0.2, 0); // all positional arguments: freq, phase, mul, add
+SinOsc.ar(800, pi, 0.2, 0); // all positional argument calls: freq, phase, mul, add
 
 // freq = 800, mul = 0.2, others get default values.
-SinOsc.ar(800, mul: 0.2); // 800 is a positional argument, and 0.2 is a keyword one
+SinOsc.ar(800, mul: 0.2); // 800 is passed positionally, and 0.2 is passed by keyword
 
 // freq = 800, phase = pi, mul = 0.2, add gets its default value of zero.
-SinOsc.ar(phase: pi, mul: 0.2, freq: 800); // all keyword arguments
+SinOsc.ar(phase: pi, mul: 0.2, freq: 800); // all keyword argument calls
 
-// the rightmost value of 1200 overrides the positional arg value of 800
+// the rightmost value of 1200 overrides the positional value of 800
 SinOsc.ar(800, freq: 1200); // should not be used.
 ::
 code::
 SinOsc.ar(zorg: 999); // invalid keyword prints warning. should not be used.
 ::
 
-The arguments to a link::Classes/Function:: instance work the same way when using the 'value' message.
+Arguments to a link::Classes/Function:: instance work the same way when the function is called using the 'value' message.
+
 code::
-// function args specified positionally from the first argument defined in the function.
+// function arguments specified positionally from the first argument defined in the function.
 { arg a=1, b=2, c=3; [a, b, c].postln }.value(7, 8);
 // -> [ 7, 8, 3 ]
 
-// function args specified by keyword, skipping the first argument defined in the function.
+// function arguments specified by keyword, skipping the first argument defined in the function.
 { arg a=1, b=2, c=3; [a, b, c].postln }.value(b: 7, c: 8);
 // -> [ 1, 7, 8 ]
 ::
 
-You may also use keyword arguments when using the 'perform' method.
+You may also use emphasis::keyword argument calls:: when using the link::Classes/Object#-perform:: method.
 code::
 SinOsc.perform('ar', phase: pi, mul: 0.2, freq: 800);
 ::
 
-subsection:: Cost of using keyword arguments
+subsection:: Cost of using keyword argument calls
 
-When using keyword arguments there is a runtime cost to do the matching that you should be aware of. The cost can be worth the convenience when speed is not critical.
+When using link::#keyword argument calls::, there is a runtime cost for matching arguments to parameter names. The cost can be worth the convenience when speed is not critical.

--- a/HelpSource/Reference/Syntax-Shortcuts.schelp
+++ b/HelpSource/Reference/Syntax-Shortcuts.schelp
@@ -64,12 +64,12 @@ note::
 See:
 list::
 ## link::Reference/Messages#Keyword Arguments and Positional Arguments::
-## link::Classes/FunctionDef#numArgs::
-## link::Classes/FunctionDef#numVars::
-## link::Classes/FunctionDef#varArgs::
-## link::Classes/FunctionDef#hasKwArgs::
-## link::Classes/FunctionDef#varArgsValue::
-## link::Classes/FunctionDef#.hasVarArgs::
+## link::Classes/FunctionDef#-numArgs::
+## link::Classes/FunctionDef#-numVars::
+## link::Classes/FunctionDef#-varArgs::
+## link::Classes/FunctionDef#-hasKwArgs::
+## link::Classes/FunctionDef#-varArgsValue::
+## link::Classes/FunctionDef#-hasVarArgs::
 ::
 ::
 
@@ -91,9 +91,15 @@ x = { |a, b ... rest| [a, b, rest] };
 x.(1, 2, 3, 4, 5);   // -> [ 1, 2, [ 3, 4, 5 ] ]
 ::
 
-subsubsection:: keyword arguments (kwargs)
+subsubsection:: arbitrary keyword arguments (kwargs)
 
-Use code::...args, kwargs:: to capture arbitrary keyword arguments that are not explicitly named. The keyword arguments are collected into a single link::Classes/Array:: instance of key-value pairs. Note that kwargs are only supported with the pipe notation (code:: | | ::), not with code:: arg ::.
+Use code::...args, kwargs:: to capture emphasis::arbitrary keyword arguments:: that are not explicitly named.
+These are often called emphasis::keyword arguments::, but they are different from the emphasis::keyword arguments messages used for declared arguments:: described in link::Reference/Messages#Keyword Arguments and Positional Arguments::.
+
+All arbitrary keyword arguments are collected into a single link::Classes/Array:: instance of key-value pairs.
+They are supported only with the pipe notation (code:: | | ::), not with code:: arg ::.
+
+The identifier for emphasis::arbitrary keyword arguments:: may be any variable name beginning with a lowercase letter, though code::kwargs:: is a common choice.
 
 code::
 // Capture arbitrary keyword arguments:
@@ -109,8 +115,8 @@ f.(1, 2, 3, 4, 5, 6, x: 7, y: 8);  // -> [ 1, 2, [ 3, 4, 5, 6 ], [ x, 7, y, 8 ] 
 note::
 See
 list::
-## link::Classes/Object#performList::
-## link::Classes/Object#performArgs::
+## link::Classes/Object#-performList::
+## link::Classes/Object#-performArgs::
 ::
 ::
 

--- a/HelpSource/Reference/Syntax-Shortcuts.schelp
+++ b/HelpSource/Reference/Syntax-Shortcuts.schelp
@@ -73,7 +73,7 @@ list::
 ::
 ::
 
-subsubsection:: variable arguments (varargs)
+subsubsection:: positional variable arguments (varargs)
 
 Use code::...:: in function argument lists when the number of arguments is not fixed in advance. Arguments matched by code::...:: are collected into a single link::Classes/Array:: instance.
 

--- a/HelpSource/Reference/Syntax-Shortcuts.schelp
+++ b/HelpSource/Reference/Syntax-Shortcuts.schelp
@@ -60,65 +60,7 @@ table::
 ## (pipe notation only) || code:: { |a, b ... rest, kwargs| [a, b, rest, kwargs].postln } ::
 ::
 
-note::
-See:
-list::
-## link::Reference/Messages#Keyword Arguments and Positional Arguments::
-## link::Classes/FunctionDef#-numArgs::
-## link::Classes/FunctionDef#-numVars::
-## link::Classes/FunctionDef#-varArgs::
-## link::Classes/FunctionDef#-hasKwArgs::
-## link::Classes/FunctionDef#-varArgsValue::
-## link::Classes/FunctionDef#-hasVarArgs::
-::
-::
-
-subsubsection:: positional variable arguments (varargs)
-
-Use code::...:: in function argument lists when the number of arguments is not fixed in advance. Arguments matched by code::...:: are collected into a single link::Classes/Array:: instance.
-
-code::
-// It may collect all arguments:
-x = { |... args| args };
-x.(1, 2, 3);         // -> [ 1, 2, 3 ]
-x.(1, 2, 3, 4, 5);   // -> [ 1, 2, 3, 4, 5 ]
-
-// Or it may collect only the arguments that remain after earlier ones have been matched:
-x = { |a ... rest| [a, rest] };
-x.(1, 2, 3, 4, 5);   // -> [ 1, [ 2, 3, 4, 5 ] ]
-
-x = { |a, b ... rest| [a, b, rest] };
-x.(1, 2, 3, 4, 5);   // -> [ 1, 2, [ 3, 4, 5 ] ]
-::
-
-subsubsection:: arbitrary keyword arguments (kwargs)
-
-Use code::...args, kwargs:: to capture emphasis::arbitrary keyword arguments:: that are not explicitly named.
-These are often called emphasis::keyword arguments::, but they are different from the emphasis::keyword arguments messages used for declared arguments:: described in link::Reference/Messages#Keyword Arguments and Positional Arguments::.
-
-All arbitrary keyword arguments are collected into a single link::Classes/Array:: instance of key-value pairs.
-They are supported only with the pipe notation (code:: | | ::), not with code:: arg ::.
-
-The identifier for emphasis::arbitrary keyword arguments:: may be any variable name beginning with a lowercase letter, though code::kwargs:: is a common choice.
-
-code::
-// Capture arbitrary keyword arguments:
-f = { |... args, kwargs| kwargs };
-f.(x: 3, y: 4);      // -> [ x, 3, y, 4 ]
-
-// Named arguments are matched first; the rest go into args or kwargs:
-f = { |a, b ... args, kwargs| [a, b, args, kwargs] };
-f.(1, 2, 3, 4, x: 5, y: 6);        // -> [ 1, 2, [ 3, 4 ], [ x, 5, y, 6 ] ]
-f.(1, 2, 3, 4, 5, 6, x: 7, y: 8);  // -> [ 1, 2, [ 3, 4, 5, 6 ], [ x, 7, y, 8 ] ]
-::
-
-note::
-See
-list::
-## link::Classes/Object#-performList::
-## link::Classes/Object#-performArgs::
-::
-::
+See link::Reference/Functions#Variable Arguments::
 
 subsection:: partial application
 table::

--- a/HelpSource/Reference/Syntax-Shortcuts.schelp
+++ b/HelpSource/Reference/Syntax-Shortcuts.schelp
@@ -322,6 +322,7 @@ table::
 ## instead of writing: || you can write:
 ## code:: [\a, 1, \b, 2] :: || code:: [a: 1, b: 2] ::
 ::
+See link::Reference/Key-Value-Pairs:: and the note in link::Classes/Collection#description::.
 
 section:: Other shortcuts
 

--- a/HelpSource/Tutorials/A-Practical-Guide/PG_03_What_Is_Pbind.schelp
+++ b/HelpSource/Tutorials/A-Practical-Guide/PG_03_What_Is_Pbind.schelp
@@ -197,7 +197,7 @@ section::Rest events
 Beginning with version 3.5, rests may be indicated using instances of link::Classes/Rest::.
 
 list::
-## Rests may be given in any Pbind key-value pair. (Previously, rests could be indicated only in \type, \degree, \note, \midinote or \freq.)
+## Rests may be given in any Pbind link::Reference/Key-Value-Pairs##key-value pair::. (Previously, rests could be indicated only in \type, \degree, \note, \midinote or \freq.)
 ## A rest has a value, e.g. code::Rest(0.5)::, and will pass transparently through calculations.
 ## Addresses some problems with the former convention (to be discussed in brief below).
 ::

--- a/HelpSource/Tutorials/A-Practical-Guide/PG_03_What_Is_Pbind.schelp
+++ b/HelpSource/Tutorials/A-Practical-Guide/PG_03_What_Is_Pbind.schelp
@@ -7,7 +7,7 @@ section::What's that Pbind thing?
 
 Some of the examples in the last tutorial played notes using Pbind, and you might be wondering how it works in general and what else you can do with it.
 
-In the most general sense, link::Classes/Pbind:: is just a way to give names to values coming out of the types of patterns we just saw. When you ask a Pbind stream for its next value, the result is an object called an link::Classes/Event::. Like a link::Classes/Dictionary:: (which is a superclass of Event), an event is a set of "key-value pairs": each value is named by a key.
+In the most general sense, link::Classes/Pbind:: is just a way to give names to values coming out of the types of patterns we just saw. When you ask a Pbind stream for its next value, the result is an object called an link::Classes/Event::. Like a link::Classes/Dictionary:: (which is a superclass of Event), an event is a set of "link::Reference/Syntax-Shortcuts#creating Arrays with key-value pairs#key-value pairs::": each value is named by a key.
 
 code::
 e = (freq: 440, dur: 0.5);	// an Event

--- a/HelpSource/Tutorials/A-Practical-Guide/PG_060_Filter_Patterns.schelp
+++ b/HelpSource/Tutorials/A-Practical-Guide/PG_060_Filter_Patterns.schelp
@@ -41,8 +41,8 @@ subsection::Adding values into event patterns (Or, "Pattern Composition")
 link::Tutorials/A-Practical-Guide/PG_06c_Composition_of_Patterns::
 
 definitionList::
-## code::Pbindf(pattern, pairs):: || Adds new key-value pairs onto a pre-existing Pbind-style pattern.
-## code::Pchain(patterns):: || Chains separate Pbind-style patterns together, so that all their key-value pairs go into the same event.
+## code::Pbindf(pattern, pairs):: || Adds new link::Reference/Syntax-Shortcuts#creating Arrays with key-value pairs#key-value pairs:: onto a pre-existing Pbind-style pattern.
+## code::Pchain(patterns):: || Chains separate Pbind-style patterns together, so that all their link::Reference/Syntax-Shortcuts#creating Arrays with key-value pairs#key-value pairs:: go into the same event.
 ::
 
 subsection::Parallelizing event patterns

--- a/HelpSource/Tutorials/A-Practical-Guide/PG_06c_Composition_of_Patterns.schelp
+++ b/HelpSource/Tutorials/A-Practical-Guide/PG_06c_Composition_of_Patterns.schelp
@@ -41,8 +41,8 @@ g.value(f.value(1));
 Event patterns can be similarly composed.
 
 definitionList::
-## code::Pbindf(pattern, pairs):: || Adds new key-value pairs onto a pre-existing Pbind-style pattern. code::Pbindf(Pbind(\a, patternA), \b, patternB, \c, patternC):: gets the same result as code::Pbind(\a, patternA, \b, patternB, \c, patternC):: .
-## code::Pchain(patterns):: || Chains separate Pbind-style patterns together, so that all their key-value pairs go into the same event. For example, if one part of your code creates a Pbind instance code::a = Pbind(\a, patternA):: and another part creates code::b = Pbind(\b, patternB, \c, patternC)::, you could append code::\b:: and code::\c:: into the code::\a:: result using code::Pchain(b, a):: . The subpatterns evaluate in reverse order, in keeping with function composition notation.
+## code::Pbindf(pattern, pairs):: || Adds new link::Reference/Syntax-Shortcuts#creating Arrays with key-value pairs#key-value pairs:: onto a pre-existing Pbind-style pattern. code::Pbindf(Pbind(\a, patternA), \b, patternB, \c, patternC):: gets the same result as code::Pbind(\a, patternA, \b, patternB, \c, patternC):: .
+## code::Pchain(patterns):: || Chains separate Pbind-style patterns together, so that all their link::Reference/Syntax-Shortcuts#creating Arrays with key-value pairs#key-value pairs:: go into the same event. For example, if one part of your code creates a Pbind instance code::a = Pbind(\a, patternA):: and another part creates code::b = Pbind(\b, patternB, \c, patternC)::, you could append code::\b:: and code::\c:: into the code::\a:: result using code::Pchain(b, a):: . The subpatterns evaluate in reverse order, in keeping with function composition notation.
 
 For musical purposes, you could have one part of your code create a pattern defining rhythm and another part defining pitch material, then combine them with link::Classes/Pchain::.
 

--- a/HelpSource/Tutorials/Getting-Started/04-Functions-and-Other-Functionality.schelp
+++ b/HelpSource/Tutorials/Getting-Started/04-Functions-and-Other-Functionality.schelp
@@ -101,7 +101,7 @@ f.value(5, 3);
 
 Arguments are declared at the beginning of the Function, using the keyword code::'arg'::. You can then refer to them just like variables. When you call value on a Function, you can pass in arguments, in order, by putting them in parentheses: code::someFunc.value(arg1, arg2)::. This is the same with any method that takes arguments, not just value.
 
-You can specify different orders by using what are called keyword arguments:
+You can specify different orders by using what are called using link::Reference/Messages#keyword argument calls#keyword argument calls:::
 
 code::
 (

--- a/HelpSource/Tutorials/Mark_Polishook_tutorial/13_BinaryOp_synthesis.schelp
+++ b/HelpSource/Tutorials/Mark_Polishook_tutorial/13_BinaryOp_synthesis.schelp
@@ -106,9 +106,9 @@ code::
 
 Setting the doneAction argument (control) to 2 insures that after the envelope reaches its endpoint, SuperCollider will release the memory it used for the instances of the SinOsc and the EnvGen.
 
-section::Keyword arguments
+section::Keyword argument calls
 
-Keywords make code easier to read and they allow arguments to be presented in any order. Here, the doneAction and the timeScale arguments are expressed in keyword style.
+Keywords make code easier to read and they allow arguments to be presented in any order. Here, the doneAction and the timeScale arguments are expressed in keyword style. (See link::Reference/Messages#keyword argument calls#keyword argument calls::.)
 
 code::
 (


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

closes: #7491, #7207

---

**Note:** This PR is now larger than initially intended.  
It began with clarifying key–value pair usage, but it now also standardises
argument terminology throughout the documentation for consistency.
See the explanation in https://github.com/supercollider/supercollider/pull/7495/commits/d4a8ff716065274e7d61e1cfb6feb84699eb3b40. 

----

## Purpose and Motivation

Improves the documentation of key–value pair syntax for several subclasses of link::Classes/Collection::.
The explanation is written with beginners in mind, inspired by a recent question on the scsynth forum.
See #7491.
<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->

- Documentation

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
