### PR TITLE
build: fix precommit for bison

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,6 +35,7 @@ repos:
         name: Run Bison parser checking for any errors
         # NOTE: this command is a copy from tools/generate_parser_bison.sh
         entry: bison -Werror --defines=lang/LangSource/Bison/lang11d_tab.h --output=lang/LangSource/Bison/lang11d_tab.cpp lang/LangSource/Bison/lang11d
-        files: lang/LangSource/Bison/*
+        files: lang/LangSource/Bison/.+
         pass_filenames: false
         language: system
+        stages: [pre-commit, pre-merge-commit, pre-push]


### PR DESCRIPTION
Sometimes the pre commit will give an error about incorrect use of a regex, this fixes that by using the correct glob.


To format all files you now run `FULL_CHECK=1 pre-commit run --hook-stage manual --all-files`


<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->

- Documentation
- Bug fix
- New feature
- Breaking change

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [ ] Code is tested
- [ ] All tests are passing
- [ ] Updated documentation
- [ ] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
