### PR TITLE
sclexer: enable all warnings and make them all errors

### DIFF
--- a/cmake_modules/CompilerWarnings.cmake
+++ b/cmake_modules/CompilerWarnings.cmake
@@ -3,7 +3,7 @@
 #
 # https://github.com/lefticus/cppbestpractices/blob/master/02-Use_the_Tools_Available.md
 
-function(set_project_warnings project_name)
+function(set_target_warnings target_name)
   set(MSVC_WARNINGS
       /W4 # Baseline reasonable warnings
       /w14242 # 'identifier': conversion from 'type1' to 'type1', possible loss of data

--- a/cmake_modules/CompilerWarnings.cmake
+++ b/cmake_modules/CompilerWarnings.cmake
@@ -1,0 +1,77 @@
+# This file is copied from here! https://github.com/lefticus/cpp_weekly/blob/master/cmake/CompilerWarnings.cmake
+# from here:
+#
+# https://github.com/lefticus/cppbestpractices/blob/master/02-Use_the_Tools_Available.md
+
+function(set_project_warnings project_name)
+  set(MSVC_WARNINGS
+      /W4 # Baseline reasonable warnings
+      /w14242 # 'identifier': conversion from 'type1' to 'type1', possible loss of data
+      /w14254 # 'operator': conversion from 'type1:field_bits' to 'type2:field_bits', possible loss of data
+      /w14263 # 'function': member function does not override any base class virtual member function
+      /w14265 # 'classname': class has virtual functions, but destructor is not virtual instances of this class may not
+              # be destructed correctly
+      /w14287 # 'operator': unsigned/negative constant mismatch
+      /we4289 # nonstandard extension used: 'variable': loop control variable declared in the for-loop is used outside
+              # the for-loop scope
+      /w14296 # 'operator': expression is always 'boolean_value'
+      /w14311 # 'variable': pointer truncation from 'type1' to 'type2'
+      /w14545 # expression before comma evaluates to a function which is missing an argument list
+      /w14546 # function call before comma missing argument list
+      /w14547 # 'operator': operator before comma has no effect; expected operator with side-effect
+      /w14549 # 'operator': operator before comma has no effect; did you intend 'operator'?
+      /w14555 # expression has no effect; expected expression with side- effect
+      /w14619 # pragma warning: there is no warning number 'number'
+      /w14640 # Enable warning on thread un-safe static member initialization
+      /w14826 # Conversion from 'type1' to 'type_2' is sign-extended. This may cause unexpected runtime behavior.
+      /w14905 # wide string literal cast to 'LPSTR'
+      /w14906 # string literal cast to 'LPWSTR'
+      /w14928 # illegal copy-initialization; more than one user-defined conversion has been implicitly applied
+      /permissive- # standards conformance mode for MSVC compiler.
+  )
+
+  set(CLANG_WARNINGS
+      -Wall
+      -Wextra # reasonable and standard
+      -Wshadow # warn the user if a variable declaration shadows one from a parent context
+      -Wnon-virtual-dtor # warn the user if a class with virtual functions has a non-virtual destructor. This helps
+                         # catch hard to track down memory errors
+      -Wold-style-cast # warn for c-style casts
+      -Wcast-align # warn for potential performance problem casts
+      -Wunused # warn on anything being unused
+      -Woverloaded-virtual # warn if you overload (not override) a virtual function
+      -Wpedantic # warn if non-standard C++ is used
+      -Wconversion # warn on type conversions that may lose data
+      -Wsign-conversion # warn on sign conversions
+      -Wnull-dereference # warn if a null dereference is detected
+      -Wdouble-promotion # warn if float is implicit promoted to double
+      -Wformat=2 # warn on security issues around functions that format output (ie printf)
+  )
+
+  set(CLANG_WARNINGS ${CLANG_WARNINGS} -Werror)
+  set(MSVC_WARNINGS ${MSVC_WARNINGS} /WX)
+
+  set(GCC_WARNINGS
+      ${CLANG_WARNINGS}
+      -Weffc++
+      -Wstrict-null-sentinel
+      -Wmisleading-indentation # warn if indentation implies blocks where blocks do not exist
+      -Wduplicated-cond # warn if if / else chain has duplicated conditions
+      -Wduplicated-branches # warn if if / else branches have duplicated code
+      -Wlogical-op # warn about logical operations being used where bitwise were probably wanted
+      -Wuseless-cast # warn if you perform a cast to the same type
+  )
+
+  if(MSVC)
+    set(PROJECT_WARNINGS ${MSVC_WARNINGS})
+  elseif(CMAKE_CXX_COMPILER_ID MATCHES ".*Clang")
+    set(PROJECT_WARNINGS ${CLANG_WARNINGS})
+  elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    set(PROJECT_WARNINGS ${GCC_WARNINGS})
+  else()
+    message(AUTHOR_WARNING "No compiler warnings set for '${CMAKE_CXX_COMPILER_ID}' compiler.")
+  endif()
+
+  target_compile_options(${project_name} PRIVATE ${PROJECT_WARNINGS})
+
+endfunction()

--- a/cmake_modules/CompilerWarnings.cmake
+++ b/cmake_modules/CompilerWarnings.cmake
@@ -3,7 +3,7 @@
 #
 # https://github.com/lefticus/cppbestpractices/blob/master/02-Use_the_Tools_Available.md
 
-function(set_target_warnings target_name)
+function(set_target_compiler_strict_errors target_name)
   set(MSVC_WARNINGS
       /W4 # Baseline reasonable warnings
       /w14242 # 'identifier': conversion from 'type1' to 'type1', possible loss of data
@@ -63,15 +63,15 @@ function(set_target_warnings target_name)
   )
 
   if(MSVC)
-    set(PROJECT_WARNINGS ${MSVC_WARNINGS})
+    set(TARGET_WARNINGS ${MSVC_WARNINGS})
   elseif(CMAKE_CXX_COMPILER_ID MATCHES ".*Clang")
-    set(PROJECT_WARNINGS ${CLANG_WARNINGS})
+    set(TARGET_WARNINGS ${CLANG_WARNINGS})
   elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-    set(PROJECT_WARNINGS ${GCC_WARNINGS})
+    set(TARGET_WARNINGS ${GCC_WARNINGS})
   else()
     message(AUTHOR_WARNING "No compiler warnings set for '${CMAKE_CXX_COMPILER_ID}' compiler.")
   endif()
 
-  target_compile_options(${project_name} PRIVATE ${PROJECT_WARNINGS})
+  target_compile_options(${target_name} PRIVATE ${TARGET_WARNINGS})
 
 endfunction()

--- a/langutils/sc_lexer/CMakeLists.txt
+++ b/langutils/sc_lexer/CMakeLists.txt
@@ -1,3 +1,5 @@
+include(${CMAKE_SOURCE_DIR}/cmake_modules/CompilerWarnings.cmake)
+
 add_library(sc_lexer STATIC 
 	src/codepoint_stream.cpp
 	src/codepoint.cpp
@@ -8,7 +10,9 @@ add_library(sc_lexer STATIC
 
 target_include_directories(sc_lexer PUBLIC include)
 
+
 target_link_libraries(sc_lexer PRIVATE utf8proc)
+set_project_warnings(sc_lexer)
 set_property(TARGET sc_lexer PROPERTY FOLDER Libs)
 
 add_subdirectory(standalone)

--- a/langutils/sc_lexer/CMakeLists.txt
+++ b/langutils/sc_lexer/CMakeLists.txt
@@ -12,7 +12,7 @@ target_include_directories(sc_lexer PUBLIC include)
 
 
 target_link_libraries(sc_lexer PRIVATE utf8proc)
-set_target_warnings(sc_lexer)
+set_target_compiler_strict_errors(sc_lexer)
 set_property(TARGET sc_lexer PROPERTY FOLDER Libs)
 
 add_subdirectory(standalone)

--- a/langutils/sc_lexer/CMakeLists.txt
+++ b/langutils/sc_lexer/CMakeLists.txt
@@ -10,7 +10,6 @@ add_library(sc_lexer STATIC
 
 target_include_directories(sc_lexer PUBLIC include)
 
-
 target_link_libraries(sc_lexer PRIVATE utf8proc)
 set_target_compiler_strict_errors(sc_lexer)
 set_property(TARGET sc_lexer PROPERTY FOLDER Libs)

--- a/langutils/sc_lexer/CMakeLists.txt
+++ b/langutils/sc_lexer/CMakeLists.txt
@@ -12,7 +12,7 @@ target_include_directories(sc_lexer PUBLIC include)
 
 
 target_link_libraries(sc_lexer PRIVATE utf8proc)
-set_project_warnings(sc_lexer)
+set_target_warnings(sc_lexer)
 set_property(TARGET sc_lexer PROPERTY FOLDER Libs)
 
 add_subdirectory(standalone)

--- a/langutils/sc_lexer/include/codepoint_stream.hpp
+++ b/langutils/sc_lexer/include/codepoint_stream.hpp
@@ -18,7 +18,7 @@ template <std::size_t N> struct Peek {
         std::array<CodePoint, M> out;
         std::copy(characters.data(), characters.data() + characters.size(), out.data());
         return { out };
-    };
+    }
 
     [[nodiscard]] constexpr CodePoint operator[](std::size_t i) const { return characters[i]; }
 
@@ -46,7 +46,7 @@ class CodePointStream {
     } state {};
 
 public:
-    CodePointStream(const char* source, std::size_t source_length, FileCodeLocation source_start_in_file);
+    CodePointStream(const char* src, std::size_t src_len, FileCodeLocation src_start_in_file);
     CodePointStream() = delete;
     CodePointStream(CodePointStream&&) noexcept = default;
     CodePointStream(const CodePointStream&) = default;
@@ -118,7 +118,7 @@ public:
             return true;
         }
         return false;
-    };
+    }
 
     // Like peek_advance_if, but must match all in order rather than just one.
     // Advances stream by sizeof...(C)
@@ -131,9 +131,10 @@ public:
         if (!valid)
             return false;
 
-        ((advance(), cs), ...);
+        // Cast to void to indicate we are discarding the value.
+        ((advance(), void(cs)), ...);
         return true;
-    };
+    }
 
 
     // Null terminator is NEVER accepted as a predicate.
@@ -144,7 +145,7 @@ public:
         std::size_t i { 0 };
         for (auto c = peek(); discard_null_then_predicate(c); c = advance_and_peek(), ++i) {}
         return i;
-    };
+    }
 
     template <typename Predicate> SourceCodeLocation advance_while(Predicate&& predicate) {
         advance_while_count(std::forward<Predicate>(predicate));

--- a/langutils/sc_lexer/include/lexer.hpp
+++ b/langutils/sc_lexer/include/lexer.hpp
@@ -36,7 +36,7 @@ struct TypeAndLocationAction {
 
 struct TypeOnlyAction {
     using Output = TokenType;
-    template <TokenType type> std::optional<Output> process(SourceCodeRange loc) { return { type }; }
+    template <TokenType type> std::optional<Output> process(SourceCodeRange) { return { type }; }
 };
 
 }
@@ -203,7 +203,7 @@ decltype(auto) lexer_digits(CodePointStream& stream, Action& action, SourceCodeL
         [[fallthrough]];
     case 'E': {
         stream.advance(); // drop e
-        const auto has_sign = stream.peek_advance_if('+', '-');
+        stream.peek_advance_if('+', '-');
         const auto count = stream.advance_while_count([](auto c) { return is_numeric(c); });
         if (count == 0)
             return action.template process<TokenType::ErMissingExponent>({ token_start, stream.end_token() });
@@ -218,7 +218,7 @@ decltype(auto) lexer_digits(CodePointStream& stream, Action& action, SourceCodeL
         stream.advance_while(is_numeric);
         if (const auto e = stream.peek(); e == 'e' || e == 'E') {
             stream.advance(); // drop e
-            const auto has_sign = stream.peek_advance_if('+', '-');
+            stream.peek_advance_if('+', '-');
             const auto count = stream.advance_while_count([](auto c) { return is_numeric(c); });
             if (count == 0)
                 return action.template process<TokenType::ErMissingExponent>({ token_start, stream.end_token() });
@@ -354,7 +354,7 @@ next_token : {
             stream.advance();
             CodePoint it_1 = 0, it = 0;
             size_t level = 1;
-            const auto end = stream.advance_while([&](auto c) {
+            stream.advance_while([&](auto c) {
                 it_1 = it;
                 it = c;
                 if (it_1 == '/' && it == '*') {
@@ -380,7 +380,7 @@ next_token : {
 
         // '//'
         else if (p == '/') {
-            const auto end = stream.advance_while([](auto c) { return !is_newline(c); });
+            stream.advance_while([](auto c) { return !is_newline(c); });
             return_orelse_next_token(action.template process<TokenType::Comment>({ token_start, stream.end_token() }));
         }
 

--- a/langutils/sc_lexer/include/source_utils.hpp
+++ b/langutils/sc_lexer/include/source_utils.hpp
@@ -29,12 +29,12 @@ public:
     void jump_backward(CodePoint cp) noexcept { txt_iter -= codepoint_size(cp); }
 
     [[nodiscard]] auto current_codepoint() const noexcept {
-        return utf8_sequence_to_codepoint(txt_iter, txt_end - txt_iter);
+        return utf8_sequence_to_codepoint(txt_iter, static_cast<std::size_t>(txt_end - txt_iter));
     }
     [[nodiscard]] const char* current_location() const noexcept { return txt_iter; }
 
 private:
-    CodePointIterator(const char* txt_start, const char* txt_end, const char* current_location) noexcept;
+    CodePointIterator(const char* text_start, const char* text_end, const char* cur_location) noexcept;
 
     const char* const txt_start;
     const char* const txt_end;

--- a/langutils/sc_lexer/src/codepoint.cpp
+++ b/langutils/sc_lexer/src/codepoint.cpp
@@ -7,33 +7,40 @@ namespace sc::lex {
 [[nodiscard]] std::tuple<CodePoint, std::uint8_t> utf8_sequence_to_codepoint(const char* utf8,
                                                                              std::size_t len) noexcept {
     CodePoint cp;
-    const auto width_or_error = utf8proc_iterate(reinterpret_cast<const std::uint8_t*>(utf8), len, &cp);
-    const auto width { static_cast<std::uint8_t>(width_or_error) };
-    return width_or_error < 0 ? std::tuple<CodePoint, std::uint8_t> { invalid_utf8_flag, 0 }
-                              : std::tuple<CodePoint, std::uint8_t> { cp, width };
+    const auto width_or_error =
+        utf8proc_iterate(reinterpret_cast<const std::uint8_t*>(utf8), static_cast<utf8proc_ssize_t>(len), &cp);
+    const auto width = static_cast<std::uint8_t>(width_or_error);
+    if (width_or_error < 0)
+        // Note: all these '0' need to be initalised like std::uint8_t{0} because MSVC thinks '0' is an int and can't
+        // see the conversion is fine.
+        return { invalid_utf8_flag, std::uint8_t { 0 } };
+    else
+        return { cp, width };
 }
 
 
 [[nodiscard]] std::tuple<CodePoint, std::uint8_t> utf8_sequence_to_codepoint_backwards(const char* utf8_start,
                                                                                        const char* current) noexcept {
-    const auto start { reinterpret_cast<const std::uint8_t* const>(utf8_start) };
+    const auto* const start = reinterpret_cast<const std::uint8_t*>(utf8_start);
     auto c { reinterpret_cast<const std::uint8_t*>(current) };
 
     const auto is_cont = [](std::uint8_t ch) -> bool { return (ch & 0xC0) == 0x80; };
 
-    std::size_t count { 1 };
+    utf8proc_ssize_t count { 1 };
     while (is_cont(*c)) {
         --c;
         ++count;
         if (c < start)
-            return { invalid_utf8_flag, 0 };
+            return { invalid_utf8_flag, std::uint8_t { 0 } };
     }
 
     CodePoint cp;
     const auto width_or_error = utf8proc_iterate(c, count, &cp);
     const auto width { static_cast<std::uint8_t>(width_or_error) };
-    return width_or_error < 0 ? std::tuple<CodePoint, std::uint8_t> { invalid_utf8_flag, 0 }
-                              : std::tuple<CodePoint, std::uint8_t> { cp, width };
+    if (width_or_error < 0)
+        return { invalid_utf8_flag, std::uint8_t { 0 } };
+    else
+        return { cp, width };
 }
 
 [[nodiscard]] std::uint8_t codepoint_size(CodePoint uc) noexcept {
@@ -48,7 +55,9 @@ namespace sc::lex {
         return 4;
 }
 
-[[nodiscard]] std::uint8_t codepoint_width(CodePoint c) noexcept { return utf8proc_charwidth(c); }
+[[nodiscard]] std::uint8_t codepoint_width(CodePoint c) noexcept {
+    return static_cast<std::uint8_t>(utf8proc_charwidth(c));
+}
 
 
 [[nodiscard]] const char* codepoint_as_whitespace(CodePoint c) noexcept {

--- a/langutils/sc_lexer/src/codepoint_stream.cpp
+++ b/langutils/sc_lexer/src/codepoint_stream.cpp
@@ -2,19 +2,19 @@
 
 namespace sc::lex {
 
-CodePointStream::CodePointStream(const char* source, std::size_t source_length, FileCodeLocation source_start_in_file):
-    source_start_in_file(source_start_in_file),
-    source(source),
-    source_length(source_length) {}
+CodePointStream::CodePointStream(const char* src, std::size_t src_len, FileCodeLocation src_start_in_file):
+    source_start_in_file(src_start_in_file),
+    source(src),
+    source_length(src_len) {}
 
 
-[[nodiscard]] FileCodeRange CodePointStream::source_to_file(const SourceCodeRange& source) const {
-    return FileCodeRange { source_to_file(source.begin), source_to_file(source.end) };
+[[nodiscard]] FileCodeRange CodePointStream::source_to_file(const SourceCodeRange& src) const {
+    return FileCodeRange { source_to_file(src.begin), source_to_file(src.end) };
 }
 
-[[nodiscard]] FileCodeLocation CodePointStream::source_to_file(const SourceCodeLocation& source) const {
-    return { source.absolute + source_start_in_file.absolute, source.lineNumber + source_start_in_file.lineNumber,
-             source.lineNumber == 0 ? source.column + source_start_in_file.column : source.column };
+[[nodiscard]] FileCodeLocation CodePointStream::source_to_file(const SourceCodeLocation& src) const {
+    return { src.absolute + source_start_in_file.absolute, src.lineNumber + source_start_in_file.lineNumber,
+             src.lineNumber == 0 ? src.column + source_start_in_file.column : src.column };
 }
 
 [[nodiscard]] std::tuple<SourceCodeLocation, CodePoint> CodePointStream::start_token() {

--- a/langutils/sc_lexer/src/source_utils.cpp
+++ b/langutils/sc_lexer/src/source_utils.cpp
@@ -4,10 +4,10 @@
 #include <optional>
 namespace sc::lex::utils {
 
-CodePointIterator::CodePointIterator(const char* txt_start, const char* txt_end, const char* current_location) noexcept:
-    txt_start(txt_start),
-    txt_end(txt_end),
-    txt_iter(current_location) {}
+CodePointIterator::CodePointIterator(const char* text_start, const char* text_end, const char* cur_location) noexcept:
+    txt_start(text_start),
+    txt_end(text_end),
+    txt_iter(cur_location) {}
 
 std::optional<CodePointIterator> CodePointIterator::make(const char* txt_start, const char* txt_end,
                                                          const char* current_location) {
@@ -23,7 +23,7 @@ std::optional<CodePointIterator> CodePointIterator::make(const char* txt_start, 
 std::optional<CodePoint> CodePointIterator::forwards() noexcept {
     if (txt_iter >= txt_end)
         return std::nullopt;
-    const auto [cp, sz] = utf8_sequence_to_codepoint(txt_iter, txt_end - txt_iter);
+    const auto [cp, sz] = utf8_sequence_to_codepoint(txt_iter, static_cast<std::size_t>(txt_end - txt_iter));
     if (cp == invalid_utf8_flag)
         return std::nullopt;
 
@@ -79,7 +79,7 @@ std::optional<LineIter::Result> LineIter::forwards() noexcept {
         current_line += 1; // assumming we don't overflow.
         return { { start, sz, current_line - 1, ends_in_newline_char } };
     }
-};
+}
 
 std::optional<LineIter::Result> LineIter::backwards() noexcept {
     if (previous_dir == Forwards) {}
@@ -102,6 +102,5 @@ std::optional<LineIter::Result> LineIter::backwards() noexcept {
             current_line -= 1; // avoid underflow if we are on line zero already.
         return { { start, sz, current_line + 1, ends_in_newline_char } };
     }
-};
-
+}
 }

--- a/langutils/sc_lexer/standalone/CMakeLists.txt
+++ b/langutils/sc_lexer/standalone/CMakeLists.txt
@@ -2,5 +2,5 @@ include(${CMAKE_SOURCE_DIR}/cmake_modules/CompilerWarnings.cmake)
 
 add_executable(sc_lexer_standalone main.cpp)
 target_link_libraries(sc_lexer_standalone PRIVATE sc_lexer)
-set_project_warnings(sc_lexer_standalone)
+set_target_warnings(sc_lexer_standalone)
 set_property(TARGET sc_lexer_standalone PROPERTY FOLDER Util)

--- a/langutils/sc_lexer/standalone/CMakeLists.txt
+++ b/langutils/sc_lexer/standalone/CMakeLists.txt
@@ -1,4 +1,6 @@
+include(${CMAKE_SOURCE_DIR}/cmake_modules/CompilerWarnings.cmake)
+
 add_executable(sc_lexer_standalone main.cpp)
 target_link_libraries(sc_lexer_standalone PRIVATE sc_lexer)
-
+set_project_warnings(sc_lexer_standalone)
 set_property(TARGET sc_lexer_standalone PROPERTY FOLDER Util)

--- a/langutils/sc_lexer/standalone/CMakeLists.txt
+++ b/langutils/sc_lexer/standalone/CMakeLists.txt
@@ -2,5 +2,5 @@ include(${CMAKE_SOURCE_DIR}/cmake_modules/CompilerWarnings.cmake)
 
 add_executable(sc_lexer_standalone main.cpp)
 target_link_libraries(sc_lexer_standalone PRIVATE sc_lexer)
-set_target_warnings(sc_lexer_standalone)
+set_target_compiler_strict_errors(sc_lexer_standalone)
 set_property(TARGET sc_lexer_standalone PROPERTY FOLDER Util)

--- a/langutils/sc_lexer/standalone/main.cpp
+++ b/langutils/sc_lexer/standalone/main.cpp
@@ -2,6 +2,7 @@
 #include "text_location.hpp"
 #include <cstdlib>
 #include <cstring>
+#include <ios>
 #include <iostream>
 #include <lexer.hpp>
 #include <sstream>
@@ -41,7 +42,7 @@ int main(int argc, char* argv[]) {
         ss << ", ";
         ss << "\"Text\": ";
         ss << "\"";
-        ss.write(ptr, sz);
+        ss.write(ptr, static_cast<std::streamsize>(sz));
         ss << "\"},\n";
     }
     ss << "}\n";


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

Enables all warnings and makes them all errors. About as safe as C++ can get.