### PR TITLE
build: msvc add diagnostic:caret

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -404,6 +404,7 @@ if(MSVC)
     /wd4101 # unreferenced local variable
     /wd4102 # unreferenced label
     /wd4200 # nonstandard extension used: zero-sized array in struct/union
+	/diagnostics:caret # better diagnostics, shows source code location in error repot
   )
 
 # this flag causes MSVC to correctly report __cplusplus, which prevents a compiler error


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

before:

```
example.cpp
<source>(7): error C2220: the following warning is treated as an error
<source>(7): warning C4189: 'i': local variable is initialized but not referenced
```
after
```
example.cpp
<source>(7,24): error C2220: the following warning is treated as an error
    const std::uint8_t i {0};
                       ^
<source>(7,24): warning C4189: 'i': local variable is initialized but not referenced
```
