### PR TITLE
sclexer: redefine newline, making \r, \v, and \f errors, make all newlines in literals '\n'

### DIFF
--- a/lang/LangSource/PyrLexer.cpp
+++ b/lang/LangSource/PyrLexer.cpp
@@ -608,6 +608,13 @@ private:
         bool escaped = false;
         auto from_it = start;
         for (; from_it != end; from_it += 1) {
+            if (from_it[0] == '\r' && from_it[1] == '\n') {
+                temp_buffer.push_back('\n');
+                // It doesn't matter if you esacpe the newline character or not, it does nothing.
+                escaped = false;
+                from_it += 1; // skip '\n' aswell
+                continue;
+            }
             if (*from_it == '\\' && !escaped) {
                 escaped = true;
                 // don't write
@@ -689,7 +696,7 @@ void print_error_line(const char* filepath, const char* txt, size_t txt_len, sc:
                 if (cp_iter.current_location() <= selection_start) {
                     ss << sc::lex::codepoint_as_whitespace(*cp);
                 } else if (cp_iter.current_location() <= selection_end) {
-                    const auto w { sc::lex::codepoint_width(*cp) };
+                    const auto w = std::max<std::uint8_t>(sc::lex::codepoint_width(*cp), 1);
                     for (size_t i { 0 }; i < w; ++i)
                         ss << '^';
                 } else
@@ -837,9 +844,11 @@ struct GlobalBisonLexerState {
                 const auto desc = std::string { "This multiline comment does not have a closing */." };
                 print_error_line(gCompilingFileSym->name, char_stream.source, char_stream.source_length, o.range,
                                  desc.c_str());
-            }
-
-            else {
+            } else if (o.is(TokenType::ErFoundInvalidNewlineCharaceter)) {
+                print_error_line(gCompilingFileSym->name, char_stream.source, char_stream.source_length, o.range,
+                                 "\'\\v\' and \'\\f\' are no longer supported, please replace them with a new line "
+                                 "character \'\\n\'.");
+            } else {
                 print_error_line(gCompilingFileSym->name, char_stream.source, char_stream.source_length, o.range);
             }
         }
@@ -976,10 +985,13 @@ int yylex() {
                     str += '\v';
                 else
                     str += *b;
-                escaped = false;
+            } else if (b[0] == '\r' && b[1] == '\n') {
+                str += '\n';
+                b += 1;
             } else {
                 str += *b;
             }
+            escaped = false;
         }
 
         prev = out;
@@ -1850,6 +1862,7 @@ SCLANG_DLLEXPORT_C void runLibrary(PyrSymbol* selector) {
 
 bool startLexer(PyrSymbol* fileSym, const fs::path& p, int startPos, int endPos, int lineOffset) {
     const char* filename = fileSym->name;
+    gCompilingFileSym = fileSym;
 
     gCompilinTextLen = -1;
 

--- a/lang/LangSource/PyrParseNode.cpp
+++ b/lang/LangSource/PyrParseNode.cpp
@@ -4227,7 +4227,16 @@ void PyrBlockNode::compile(PyrSlot* slotResult) {
         SetNil(&block->contextDef);
 
         PyrString* string = newPyrStringN(compileGC(), location.size(), flags, false);
-        memcpy(string->s, gCompilingText + location.begin.absolute, location.size());
+        const auto end = location.end.absolute;
+        for (size_t read { location.begin.absolute }, write { 0 }; read < end; ++read, ++write) {
+            const auto c = gCompilingText[read];
+            if (c == '\r') {
+                ++read;
+                // This should be enforced by the lexer.
+                assert(gCompilingText[read] == '\n');
+            }
+            string->s[write] = gCompilingText[read];
+        }
         SetObject(&block->sourceCode, string);
     }
 

--- a/langutils/sc_lexer/include/codepoint.hpp
+++ b/langutils/sc_lexer/include/codepoint.hpp
@@ -33,10 +33,9 @@ inline constexpr CodePoint invalid_utf8_flag { std::numeric_limits<CodePoint>::m
 
 
 // Note: these are supercollider's defintions, not unicode's.
-[[nodiscard]] bool is_newline(CodePoint c) noexcept;
+[[nodiscard]] bool is_single_newline(CodePoint c) noexcept;
 [[nodiscard]] bool is_space(CodePoint c) noexcept;
 [[nodiscard]] bool is_tab(CodePoint c) noexcept;
-[[nodiscard]] bool is_whitespace(CodePoint c) noexcept;
 [[nodiscard]] bool is_control_code(CodePoint c) noexcept;
 [[nodiscard]] bool is_lower(CodePoint c) noexcept;
 [[nodiscard]] bool is_upper(CodePoint c) noexcept;

--- a/langutils/sc_lexer/include/codepoint_stream.hpp
+++ b/langutils/sc_lexer/include/codepoint_stream.hpp
@@ -6,6 +6,7 @@
 
 #include <text_location.hpp>
 #include <codepoint.hpp>
+#include <type_traits>
 
 namespace sc::lex {
 
@@ -41,7 +42,6 @@ class CodePointStream {
         std::size_t current_line_number { 0 };
         // Doesn't work with tabs, fix this once the main parser no longer needs this.
         std::size_t current_column_count { 0 };
-        bool prev_was_newline { false };
         void update(CodePoint next, std::uint8_t sz) noexcept;
     } state {};
 
@@ -139,12 +139,28 @@ public:
 
     // Null terminator is NEVER accepted as a predicate.
     template <typename Predicate> std::size_t advance_while_count(Predicate&& predicate) {
-        auto discard_null_then_predicate = [&](auto c) {
-            return (c == 0 || state.next_byte_offest >= source_length) ? false : predicate(c);
-        };
-        std::size_t i { 0 };
-        for (auto c = peek(); discard_null_then_predicate(c); c = advance_and_peek(), ++i) {}
-        return i;
+        if constexpr (std::is_invocable_v<Predicate, CodePoint, CodePoint>) {
+            auto discard_null_then_predicate = [&](auto c, auto n) {
+                return (c == 0 || state.next_byte_offest >= source_length) ? false : predicate(c, n);
+            };
+            std::size_t i { 0 };
+            while (true) {
+                auto p = peek_n<2>();
+                if (discard_null_then_predicate(p.at<0>(), p.at<1>())) {
+                    advance();
+                    ++i;
+                } else {
+                    return i;
+                }
+            }
+        } else {
+            auto discard_null_then_predicate = [&](auto c) {
+                return (c == 0 || state.next_byte_offest >= source_length) ? false : predicate(c);
+            };
+            std::size_t i { 0 };
+            for (auto c = peek(); discard_null_then_predicate(c); c = advance_and_peek(), ++i) {}
+            return i;
+        }
     }
 
     template <typename Predicate> SourceCodeLocation advance_while(Predicate&& predicate) {

--- a/langutils/sc_lexer/include/lexer.hpp
+++ b/langutils/sc_lexer/include/lexer.hpp
@@ -262,6 +262,23 @@ decltype(auto) lexer_digits(CodePointStream& stream, Action& action, SourceCodeL
 
 }
 
+inline void consume_new_lines(CodePointStream& stream) {
+    while (true) {
+        const auto [c, n] = stream.peek_n<2>().characters;
+        if (is_single_newline(c)) {
+            stream.advance();
+            continue;
+        } else if (c == '\r' && n == '\n') {
+            stream.advance();
+            stream.advance();
+            continue;
+        }
+        return;
+    }
+}
+
+
+// Before calling this, you must ensure validate_source_format has been called.
 template <typename Action> auto lexer(CodePointStream& stream, Action& action) noexcept -> typename Action::Output {
     using namespace details;
 
@@ -290,11 +307,22 @@ next_token : {
         return *r;
     }
 
-    if (is_newline(code_point)) {
-        stream.advance_while(is_newline);
-        return_orelse_next_token(action.template process<TokenType::NewLine>({ token_start, stream.end_token() }));
+    if (code_point == '\r') {
+        const auto n = stream.peek();
+        if (n == '\n') {
+            stream.advance(); // consume '\n'
+            consume_new_lines(stream);
+            return_orelse_next_token(action.template process<TokenType::NewLine>({ token_start, stream.end_token() }));
+        } else {
+            return_orelse_next_token(action.template process<TokenType::ErFoundInvalidNewlineCharaceter>(
+                { token_start, stream.end_token() }));
+        }
     }
 
+    if (is_single_newline(code_point)) {
+        consume_new_lines(stream);
+        return_orelse_next_token(action.template process<TokenType::NewLine>({ token_start, stream.end_token() }));
+    }
 
     if (code_point == '\t') {
         stream.advance_while(is_tab);
@@ -306,7 +334,6 @@ next_token : {
         return_orelse_next_token(action.template process<TokenType::Space>({ token_start, stream.end_token() }));
     }
 
-    // ASCII tokens. Their ASCII value is their token type value.
     switch (code_point) {
     case '^':
         return_orelse_next_token(
@@ -333,6 +360,10 @@ next_token : {
         return_orelse_next_token(action.template process<TokenType::CloseSquare>({ token_start, stream.end_token() }));
     case '}':
         return_orelse_next_token(action.template process<TokenType::CloseCurly>({ token_start, stream.end_token() }));
+    case '\v':
+    case '\f':
+        return_orelse_next_token(
+            action.template process<TokenType::ErFoundInvalidNewlineCharaceter>({ token_start, stream.end_token() }));
     }
 
     if (code_point == '#') {
@@ -351,37 +382,54 @@ next_token : {
 
         // '/*'
         if (p == '*') {
-            stream.advance();
-            CodePoint it_1 = 0, it = 0;
+            stream.advance(); // consume '*';
             size_t level = 1;
-            stream.advance_while([&](auto c) {
-                it_1 = it;
-                it = c;
-                if (it_1 == '/' && it == '*') {
-                    level += 1;
-                    it = 0; // consume
-                    return true;
-                }
-                if (it_1 == '*' && it == '/') {
+            while (true) {
+                const auto [c, n] = stream.peek_n<2>().characters;
+                if (c == '*' && n == '/') {
+                    stream.advance();
+                    stream.advance();
                     level -= 1;
-                    it = 0; // consume
-                    return level != 0;
+                    if (level == 0) {
+                        return_orelse_next_token(
+                            action.template process<TokenType::MultilineComment>({ token_start, stream.end_token() }));
+                    }
+                    continue;
+                } else if (c == '/' && n == '*') {
+                    stream.advance();
+                    stream.advance();
+                    level += 1;
+                    continue;
+                } else if ((c == '\r' && n != '\n') || c == '\v' || c == '\f') {
+                    stream.advance();
+                    return_orelse_next_token(action.template process<TokenType::ErFoundInvalidNewlineCharaceter>(
+                        { token_start, stream.end_token() }));
+                } else if (c == 0) {
+                    return_orelse_next_token(action.template process<TokenType::ErMultilineCommentUnclosed>(
+                        { token_start, stream.end_token() }));
+                } else {
+                    stream.advance();
+                    continue;
                 }
-                return true;
-            });
-            const auto delimit = stream.advance();
-            if (delimit == 0) {
-                return_orelse_next_token(action.template process<TokenType::ErMultilineCommentUnclosed>(
-                    { token_start, stream.end_token() }));
             }
-            return_orelse_next_token(
-                action.template process<TokenType::MultilineComment>({ token_start, stream.end_token() }));
         }
 
         // '//'
         else if (p == '/') {
-            stream.advance_while([](auto c) { return !is_newline(c); });
-            return_orelse_next_token(action.template process<TokenType::Comment>({ token_start, stream.end_token() }));
+            while (true) {
+                const auto [c, n] = stream.peek_n<2>().characters;
+                if ((c == '\r' && n != '\n') || c == '\v' || c == '\f') {
+                    stream.advance();
+                    return_orelse_next_token(action.template process<TokenType::ErFoundInvalidNewlineCharaceter>(
+                        { token_start, stream.end_token() }));
+                } else if ((c == '\r' && n == '\n') || is_single_newline(c) || c == 0) {
+                    return_orelse_next_token(
+                        action.template process<TokenType::Comment>({ token_start, stream.end_token() }));
+                } else {
+                    stream.advance();
+                    continue;
+                }
+            }
         }
 
         // Its a binary operator.
@@ -400,13 +448,26 @@ next_token : {
     if (code_point == '$') {
         if (stream.peek() == '\\') {
             stream.advance(); // consume '\'
-            stream.advance(); // consume whatever happens after it.
+        }
+        const auto [c, n] = stream.peek_n<2>().characters;
+        if (c > 127 || c < 0) {
+            // Can only be ascii.
+            return_orelse_next_token(
+                action.template process<TokenType::ErUnicodeInCharacter>({ token_start, stream.end_token() }));
+        }
+        if (c == '\r' && n == '\n') {
+            stream.advance(); // consume \r
+            stream.advance(); // consume \n
+            return_orelse_next_token(action.template process<TokenType::ErFoundInvalidNewlineCharaceter>(
+                { token_start, stream.end_token() }));
+        } else if (c == '\r' || c == '\v' || c == '\f' || is_single_newline(c) || c == 0 || is_tab(c)) {
+            stream.advance(); // consume white space
+            return_orelse_next_token(action.template process<TokenType::ErFoundInvalidNewlineCharaceter>(
+                { token_start, stream.end_token() }));
+        } else {
+            stream.advance(); // consume
             return_orelse_next_token(action.template process<TokenType::Ascii>({ token_start, stream.end_token() }));
         }
-
-        stream.advance(); // consume whatever character comes after the '$'
-
-        return_orelse_next_token(action.template process<TokenType::Ascii>({ token_start, stream.end_token() }));
     }
 
     if (is_starting_identifier(code_point) || code_point == '_')
@@ -422,21 +483,32 @@ next_token : {
 
     // Strings
     if (code_point == '"') {
-        const auto end = stream.advance_while([escaped = false](auto c) mutable {
-            if (c == '\\' && !escaped) {
+        bool escaped { false };
+        while (true) {
+            const auto [c, n] = stream.peek_n<2>().characters;
+            if ((c == '\r' && n != '\n') || c == '\v' || c == '\f') {
+                // bad newline
+                stream.advance();
+                return_orelse_next_token(action.template process<TokenType::ErFoundInvalidNewlineCharaceter>(
+                    { token_start, stream.end_token() }));
+            } else if (c == '\\' && !escaped) {
                 escaped = true;
-                return true;
+                stream.advance();
+                continue;
+            } else if (c == '"' && !escaped) {
+                // end of string.
+                stream.advance();
+                return_orelse_next_token(
+                    action.template process<TokenType::StringLine>({ token_start, stream.end_token() }));
+            } else if (c == 0) {
+                return_orelse_next_token(
+                    action.template process<TokenType::ErStringUnclosed>({ token_start, stream.end_token() }));
+            } else {
+                escaped = false;
+                stream.advance();
+                continue;
             }
-            if (c == '"' && !escaped)
-                return false;
-            escaped = false;
-            return true;
-        });
-
-        if (stream.advance() != '"')
-            return_orelse_next_token(action.template process<TokenType::ErStringUnclosed>({ token_start, end }));
-
-        return_orelse_next_token(action.template process<TokenType::StringLine>({ token_start, stream.end_token() }));
+        }
     }
 
     // Symbol that begin with a '\'. Note: first character is used to alter what is acceptable in the following.
@@ -459,24 +531,52 @@ next_token : {
 
     // Symbol quotes 'asdf'
     if (code_point == '\'') {
-        const auto content_end = stream.advance_while([escape = false](auto c) mutable {
-            if (is_newline(c) && !escape) // you can escape the new line characters
-                return false;
-            if (c == '\'' && !escape)
-                return false;
-            if (c == '\\' && !escape) {
-                escape = true;
-                return true;
-            }
-            escape = false;
-            return true;
-        });
-        if (stream.peek() != '\'')
-            return_orelse_next_token(
-                action.template process<TokenType::ErSymbolQuoteUnclosed>({ token_start, content_end }));
+        // NOTE: should you be able to escape these newline literal characters?
 
-        stream.advance();
-        return_orelse_next_token(action.template process<TokenType::SymbolQuote>({ token_start, stream.end_token() }));
+        bool escape { false };
+        while (true) {
+            const auto [c, n] = stream.peek_n<2>().characters;
+
+            if ((c == '\r' && n != '\n') || c == '\v' || c == '\f') {
+                // bad newline
+                stream.advance();
+                return_orelse_next_token(action.template process<TokenType::ErFoundInvalidNewlineCharaceter>(
+                    { token_start, stream.end_token() }));
+            } else if (((c == '\r' && n == '\n') || is_single_newline(c)) && !escape) {
+                // Valid new line, but not esacped.
+                stream.advance();
+                return_orelse_next_token(
+                    action.template process<TokenType::ErSymbolQuoteUnclosed>({ token_start, stream.end_token() }));
+            } else if (c == '\'' && escape) {
+                escape = false;
+                stream.advance();
+                continue;
+            } else if (c == '\'' && !escape) {
+                stream.advance();
+                return_orelse_next_token(
+                    action.template process<TokenType::SymbolQuote>({ token_start, stream.end_token() }));
+            } else if (c == '\\') {
+                escape = !escape;
+                stream.advance();
+                continue;
+            } else if (c == 0) {
+                return_orelse_next_token(
+                    action.template process<TokenType::ErSymbolQuoteUnclosed>({ token_start, stream.end_token() }));
+            } else if (c == '\r' && n == '\n' && escape) {
+                stream.advance();
+                stream.advance();
+                escape = false;
+                continue;
+            } else if (is_single_newline(c) && escape) {
+                stream.advance();
+                escape = false;
+                continue;
+            } else {
+                stream.advance();
+                escape = false;
+                continue;
+            }
+        }
     }
 
     // These are the control codes, throw them away!

--- a/langutils/sc_lexer/include/source_utils.hpp
+++ b/langutils/sc_lexer/include/source_utils.hpp
@@ -22,6 +22,7 @@ public:
     CodePointIterator& operator=(const CodePointIterator&) = delete;
 
     std::optional<CodePoint> forwards() noexcept;
+    // Note: this requires valid utf8.
     std::optional<CodePoint> backwards() noexcept;
 
     void jump(std::int64_t m) noexcept { txt_iter += m; }

--- a/langutils/sc_lexer/include/text_location.hpp
+++ b/langutils/sc_lexer/include/text_location.hpp
@@ -26,12 +26,12 @@ struct SourceCodeLocation {
 
 // A location point inside an entire file
 struct FileCodeLocation {
-    [[nodiscard]] bool operator==(const SourceCodeLocation& o) const noexcept;
-    [[nodiscard]] bool operator!=(const SourceCodeLocation& o) const noexcept;
-    [[nodiscard]] bool operator<(const SourceCodeLocation& o) const noexcept;
-    [[nodiscard]] bool operator>(const SourceCodeLocation& o) const noexcept;
-    [[nodiscard]] bool operator<=(const SourceCodeLocation& o) const noexcept;
-    [[nodiscard]] bool operator>=(const SourceCodeLocation& o) const noexcept;
+    [[nodiscard]] bool operator==(const FileCodeLocation& o) const noexcept;
+    [[nodiscard]] bool operator!=(const FileCodeLocation& o) const noexcept;
+    [[nodiscard]] bool operator<(const FileCodeLocation& o) const noexcept;
+    [[nodiscard]] bool operator>(const FileCodeLocation& o) const noexcept;
+    [[nodiscard]] bool operator<=(const FileCodeLocation& o) const noexcept;
+    [[nodiscard]] bool operator>=(const FileCodeLocation& o) const noexcept;
 
     // Offset as a byte index into the text.
     std::size_t absolute { 0 };
@@ -47,6 +47,12 @@ struct SourceCodeRange {
     [[nodiscard]] static SourceCodeRange range(SourceCodeRange left, SourceCodeRange right);
     [[nodiscard]] std::size_t size() const;
     [[nodiscard]] std::size_t line_count() const;
+    [[nodiscard]] bool operator==(const SourceCodeRange& o) const noexcept;
+    [[nodiscard]] bool operator!=(const SourceCodeRange& o) const noexcept;
+    [[nodiscard]] bool operator<(const SourceCodeRange& o) const noexcept;
+    [[nodiscard]] bool operator>(const SourceCodeRange& o) const noexcept;
+    [[nodiscard]] bool operator<=(const SourceCodeRange& o) const noexcept;
+    [[nodiscard]] bool operator>=(const SourceCodeRange& o) const noexcept;
 
     SourceCodeLocation begin, end;
 };
@@ -56,7 +62,12 @@ struct FileCodeRange {
     [[nodiscard]] static FileCodeRange range(FileCodeRange left, FileCodeRange right);
     [[nodiscard]] std::size_t size() const;
     [[nodiscard]] std::size_t line_count() const;
-
+    [[nodiscard]] bool operator==(const FileCodeRange& o) const noexcept;
+    [[nodiscard]] bool operator!=(const FileCodeRange& o) const noexcept;
+    [[nodiscard]] bool operator<(const FileCodeRange& o) const noexcept;
+    [[nodiscard]] bool operator>(const FileCodeRange& o) const noexcept;
+    [[nodiscard]] bool operator<=(const FileCodeRange& o) const noexcept;
+    [[nodiscard]] bool operator>=(const FileCodeRange& o) const noexcept;
     FileCodeLocation begin, end;
 };
 

--- a/langutils/sc_lexer/include/tokens.hpp
+++ b/langutils/sc_lexer/include/tokens.hpp
@@ -137,6 +137,10 @@ enum struct TokenType : unsigned int {
         ErMissingExponent,
         ErInvalidToken,
         ErInvalidUTF8,
+        ErUnicodeInCharacter,
+
+        ErFoundInvalidNewlineCharaceter, // '\v' or '\f', replace with '\n'
+
         ErUnknown,
 
         START_OF_USER_DEFINED_ERRORS,

--- a/langutils/sc_lexer/src/codepoint.cpp
+++ b/langutils/sc_lexer/src/codepoint.cpp
@@ -13,6 +13,7 @@ namespace sc::lex {
     if (width_or_error < 0)
         // Note: all these '1' need to be initalised like std::uint8_t{1} because MSVC thinks '1' is an int and can't
         // see the conversion is fine.
+        // Zero is valid ONLY when dealing with the null terminator.
         return { invalid_utf8_flag, std::uint8_t { 1 } };
     else
         return { cp, width };
@@ -37,10 +38,9 @@ namespace sc::lex {
     CodePoint cp;
     const auto width_or_error = utf8proc_iterate(c, count, &cp);
     const auto width { static_cast<std::uint8_t>(width_or_error) };
-    if (width_or_error < 0)
-        return { invalid_utf8_flag, std::uint8_t { 1 } };
-    else
-        return { cp, width };
+    // Zero is valid ONLY when dealing with the null terminator.
+    return width_or_error < 0 ? std::tuple<CodePoint, std::uint8_t> { invalid_utf8_flag, std::uint8_t { 1 } }
+                              : std::tuple<CodePoint, std::uint8_t> { cp, width };
 }
 
 [[nodiscard]] std::uint8_t codepoint_size(CodePoint uc) noexcept {
@@ -87,11 +87,12 @@ namespace sc::lex {
         ;
 }
 
-[[nodiscard]] bool is_newline(CodePoint c) noexcept {
+// Does not work for \r\n
+[[nodiscard]] bool is_single_newline(CodePoint c) noexcept {
+    // Carriage return does not count.
+    // Code that used a bare carriage return for a new line must be updated.
+    // Likewise vertical tab and form feed are not counted, replace these with a '\n'.
     return c == '\n' // line feed
-        || c == '\v' // vertical tab (not classified as a tab)
-        || c == '\f' // form feed
-        || c == '\r' // carrage return
         || c == 0x0085 // next line
         || c == 0x2028 // line separator
         || c == 0x2029 // paragraph separator
@@ -99,8 +100,6 @@ namespace sc::lex {
 }
 
 [[nodiscard]] bool is_tab(CodePoint c) noexcept { return c == '\t'; }
-
-[[nodiscard]] bool is_whitespace(CodePoint c) noexcept { return is_newline(c) || is_space(c) || is_tab(c); }
 
 [[nodiscard]] bool is_control_code(CodePoint c) noexcept {
     return (1 <= c && c <= 8) || (14 <= c && c <= 31) || c == 127;

--- a/langutils/sc_lexer/src/codepoint_stream.cpp
+++ b/langutils/sc_lexer/src/codepoint_stream.cpp
@@ -1,4 +1,5 @@
 #include "codepoint_stream.hpp"
+#include "codepoint.hpp"
 
 namespace sc::lex {
 
@@ -26,15 +27,12 @@ CodePointStream::CodePointStream(const char* src, std::size_t src_len, FileCodeL
 }
 
 void CodePointStream::State::update(CodePoint next, std::uint8_t sz) noexcept {
-    if (prev_was_newline) {
+    if (is_single_newline(next)) {
         current_line_number += 1;
         current_column_count = 0;
-        prev_was_newline = false;
     } else {
-        // TODO: this is wrong and should be removed.
-        current_column_count += 1; // codepoint_width(next);
+        current_column_count += 1;
     }
-    prev_was_newline = is_newline(next);
     next_byte_offest += sz;
 }
 

--- a/langutils/sc_lexer/src/source_utils.cpp
+++ b/langutils/sc_lexer/src/source_utils.cpp
@@ -54,7 +54,7 @@ std::optional<LineIter> LineIter::make(const char* txt_start, const char* txt_en
 std::optional<LineIter::Result> LineIter::forwards() noexcept {
     if (previous_dir == Backward) {
         const auto [cp, sz] = cp_iter.current_codepoint();
-        if (is_newline(cp)) {
+        if (is_single_newline(cp)) {
             cp_iter.forwards();
             current_line += 1;
         }
@@ -65,7 +65,7 @@ std::optional<LineIter::Result> LineIter::forwards() noexcept {
 
     bool ends_in_newline_char = false;
     for (auto r = cp_iter.forwards(); r; r = cp_iter.forwards()) {
-        if (is_newline(*r)) {
+        if (is_single_newline(*r)) {
             ends_in_newline_char = true;
             break;
         }
@@ -85,9 +85,9 @@ std::optional<LineIter::Result> LineIter::backwards() noexcept {
     if (previous_dir == Forwards) {}
     previous_dir = Backward;
     const auto end = cp_iter.current_location();
-    bool ends_in_newline_char = is_newline(std::get<0>(cp_iter.current_codepoint()));
+    bool ends_in_newline_char = is_single_newline(std::get<0>(cp_iter.current_codepoint()));
     for (auto r = cp_iter.backwards(); r; r = cp_iter.backwards()) {
-        if (is_newline(*r)) {
+        if (is_single_newline(*r)) {
             cp_iter.forwards(); // undo
             break;
         }

--- a/langutils/sc_lexer/src/text_location.cpp
+++ b/langutils/sc_lexer/src/text_location.cpp
@@ -5,12 +5,10 @@ using namespace sc::lex;
 // assuming the line number and column are correct and that the source text is the same means we only need to comare
 // the absolute byte offset.
 [[nodiscard]] bool SourceCodeLocation::operator==(const SourceCodeLocation& o) const noexcept {
-    return absolute == o.absolute;
+    return absolute == o.absolute && lineNumber == o.lineNumber && column == o.column;
 }
 
-[[nodiscard]] bool SourceCodeLocation::operator!=(const SourceCodeLocation& o) const noexcept {
-    return absolute != o.absolute;
-}
+[[nodiscard]] bool SourceCodeLocation::operator!=(const SourceCodeLocation& o) const noexcept { return !(*this == o); }
 
 [[nodiscard]] bool SourceCodeLocation::operator<(const SourceCodeLocation& o) const noexcept {
     return absolute < o.absolute;
@@ -28,27 +26,25 @@ using namespace sc::lex;
     return absolute >= o.absolute;
 }
 
-[[nodiscard]] bool FileCodeLocation::operator==(const SourceCodeLocation& o) const noexcept {
-    return absolute == o.absolute;
+[[nodiscard]] bool FileCodeLocation::operator==(const FileCodeLocation& o) const noexcept {
+    return absolute == o.absolute && lineNumber == o.lineNumber && column == o.column;
 }
 
-[[nodiscard]] bool FileCodeLocation::operator!=(const SourceCodeLocation& o) const noexcept {
-    return absolute != o.absolute;
-}
+[[nodiscard]] bool FileCodeLocation::operator!=(const FileCodeLocation& o) const noexcept { return !(*this == o); }
 
-[[nodiscard]] bool FileCodeLocation::operator<(const SourceCodeLocation& o) const noexcept {
+[[nodiscard]] bool FileCodeLocation::operator<(const FileCodeLocation& o) const noexcept {
     return absolute < o.absolute;
 }
 
-[[nodiscard]] bool FileCodeLocation::operator>(const SourceCodeLocation& o) const noexcept {
+[[nodiscard]] bool FileCodeLocation::operator>(const FileCodeLocation& o) const noexcept {
     return absolute > o.absolute;
 }
 
-[[nodiscard]] bool FileCodeLocation::operator<=(const SourceCodeLocation& o) const noexcept {
+[[nodiscard]] bool FileCodeLocation::operator<=(const FileCodeLocation& o) const noexcept {
     return absolute <= o.absolute;
 }
 
-[[nodiscard]] bool FileCodeLocation::operator>=(const SourceCodeLocation& o) const noexcept {
+[[nodiscard]] bool FileCodeLocation::operator>=(const FileCodeLocation& o) const noexcept {
     return absolute >= o.absolute;
 }
 
@@ -62,6 +58,19 @@ using namespace sc::lex;
     return (end.lineNumber - begin.lineNumber) + 1;
 }
 
+[[nodiscard]] bool sc::lex::SourceCodeRange::operator==(const SourceCodeRange& o) const noexcept {
+    return begin == o.begin && end == o.end;
+}
+[[nodiscard]] bool sc::lex::SourceCodeRange::operator!=(const SourceCodeRange& o) const noexcept {
+    return !(*this == o);
+}
+[[nodiscard]] bool sc::lex::SourceCodeRange::operator<(const SourceCodeRange& o) const noexcept {
+    return begin < o.begin && end < o.begin;
+}
+[[nodiscard]] bool sc::lex::SourceCodeRange::operator>(const SourceCodeRange& o) const noexcept {
+    return begin < o.end && end > o.end;
+}
+
 [[nodiscard]] sc::lex::FileCodeRange sc::lex::FileCodeRange::range(FileCodeRange left, FileCodeRange right) {
     return { left.begin, right.end };
 }
@@ -69,3 +78,14 @@ using namespace sc::lex;
 [[nodiscard]] std::size_t sc::lex::FileCodeRange::size() const { return end.absolute - begin.absolute; }
 
 [[nodiscard]] std::size_t sc::lex::FileCodeRange::line_count() const { return (end.lineNumber - begin.lineNumber) + 1; }
+
+[[nodiscard]] bool sc::lex::FileCodeRange::operator==(const FileCodeRange& o) const noexcept {
+    return begin == o.begin && end == o.end;
+}
+[[nodiscard]] bool sc::lex::FileCodeRange::operator!=(const FileCodeRange& o) const noexcept { return !(*this == o); }
+[[nodiscard]] bool sc::lex::FileCodeRange::operator<(const FileCodeRange& o) const noexcept {
+    return begin < o.begin && end < o.begin;
+}
+[[nodiscard]] bool sc::lex::FileCodeRange::operator>(const FileCodeRange& o) const noexcept {
+    return begin < o.end && end > o.end;
+}

--- a/langutils/sc_lexer/src/tokens.cpp
+++ b/langutils/sc_lexer/src/tokens.cpp
@@ -138,6 +138,10 @@
         return "ErInvalidUTF8";
     case TokenType::ErUnknown:
         return "ErUnknown";
+    case TokenType::ErFoundInvalidNewlineCharaceter:
+        return "ErFoundInvalidNewlineCharaceter";
+    case TokenType::ErUnicodeInCharacter:
+        return "ErUnicodeInCharacter";
     default:
         return "Unknown token";
     }

--- a/langutils/sc_lexer/test/tests.cpp
+++ b/langutils/sc_lexer/test/tests.cpp
@@ -1,4 +1,6 @@
+#include "text_location.hpp"
 #define BOOST_TEST_MODULE sc_lexer_tests
+#include "tokens.hpp"
 #include <boost/test/included/unit_test.hpp>
 #include <cstddef>
 #include <source_utils.hpp>
@@ -6,9 +8,11 @@
 
 using namespace sc::lex;
 // MSVC needs this.
-using TT = sc::lex::TokenType;
+using T = sc::lex::TokenType;
 
 BOOST_TEST_DONT_PRINT_LOG_VALUE(sc::lex::TokenType);
+BOOST_TEST_DONT_PRINT_LOG_VALUE(sc::lex::SourceCodeLocation);
+BOOST_TEST_DONT_PRINT_LOG_VALUE(sc::lex::SourceCodeRange);
 
 BOOST_AUTO_TEST_CASE(codepointer_iterator_forward) {
     using CPI = utils::CodePointIterator;
@@ -134,33 +138,45 @@ BOOST_AUTO_TEST_CASE(line_iter_backwards) {
 
 
 static constexpr std::array default_gobble {
-    TT::Space, TT::NewLine, TT::Tab, TT::Comment, TT::MultilineComment,
+    T::Space, T::NewLine, T::Tab, T::Comment, T::MultilineComment,
 };
 
 template <size_t N, size_t M>
-void match(const char* text, const std::array<TT, N>& to_find, const std::array<TT, M>& to_gobble) {
+void match(const char* text, const std::array<T, N>& to_find, const std::array<T, M>& to_gobble, bool print = false) {
+    if (print)
+        std::cout << "MATCHING: " << text << std::endl;
     const auto text_len = strlen(text);
 
     CodePointStream stream { text, text_len, {} };
 
     sc::lex::actions::TypeAndLocationAction action {};
 
-    for (const TT t : to_find) {
+    for (const T t : to_find) {
         auto o = lexer(stream, action);
 
         while (std::find(to_gobble.begin(), to_gobble.end(), o.type) != to_gobble.end()) {
             o = lexer(stream, action);
         }
 
+        if (print)
+            std::cout << to_string(o.type) << " ";
+
         BOOST_TEST(o.type == t);
     }
 
     auto o = lexer(stream, action);
-    while (std::find(to_gobble.begin(), to_gobble.end(), o.type) != to_gobble.end() && o.type != TT::EndOfFile) {
+    while (std::find(to_gobble.begin(), to_gobble.end(), o.type) != to_gobble.end() && o.type != T::EndOfFile) {
         o = lexer(stream, action);
     }
+    if (print)
+        std::cout << to_string(o.type) << " ";
 
-    BOOST_TEST(o.type == TT::EndOfFile);
+    BOOST_TEST(o.type == T::EndOfFile);
+
+    if (print) {
+        std::cout << std::endl;
+        std::cout << std::endl;
+    }
 }
 
 BOOST_AUTO_TEST_CASE(basic) {
@@ -172,47 +188,47 @@ BOOST_AUTO_TEST_CASE(basic) {
     // NO gobble
     match(text,
           std::array {
-              TT::Space,
-              TT::Name,
-              TT::Space,
-              TT::Float,
-              TT::Space,
-              TT::SymbolSlash,
-              TT::Space,
-              TT::NewLine,
-              TT::Space,
-              TT::SymbolQuote,
-              TT::SemiColon,
-              TT::Space,
-              TT::NewLine,
-              TT::Minus,
-              TT::Float,
-              TT::Space,
-              TT::Tab,
-              TT::Space,
-              TT::PrimitiveName,
-              TT::Space,
-              TT::ClassName,
-              TT::Space,
-              TT::KeywordBinaryOperator,
-              TT::SymbolSlash,
-              TT::OpenParen,
-              TT::Space,
-              TT::EndOfFile,
+              T::Space,
+              T::Name,
+              T::Space,
+              T::Float,
+              T::Space,
+              T::SymbolSlash,
+              T::Space,
+              T::NewLine,
+              T::Space,
+              T::SymbolQuote,
+              T::SemiColon,
+              T::Space,
+              T::NewLine,
+              T::Minus,
+              T::Float,
+              T::Space,
+              T::Tab,
+              T::Space,
+              T::PrimitiveName,
+              T::Space,
+              T::ClassName,
+              T::Space,
+              T::KeywordBinaryOperator,
+              T::SymbolSlash,
+              T::OpenParen,
+              T::Space,
+              T::EndOfFile,
           },
-          std::array<TT, 0> {});
+          std::array<T, 0> {});
 
-    match("    *new ", std::array { TT::Multiply, TT::Name }, default_gobble);
+    match("    *new ", std::array { T::Multiply, T::Name }, default_gobble);
 
     match("    const nl = \"\\n\"; \n\t*new ",
           std::array {
-              TT::Const,
-              TT::Name,
-              TT::EqualsSign,
-              TT::StringLine,
-              TT::SemiColon,
-              TT::Multiply,
-              TT::Name,
+              T::Const,
+              T::Name,
+              T::EqualsSign,
+              T::StringLine,
+              T::SemiColon,
+              T::Multiply,
+              T::Name,
           },
           default_gobble);
 }
@@ -222,48 +238,58 @@ BOOST_AUTO_TEST_CASE(fn) {
 
     match(text,
           std::array {
-              TT::Var,
-              TT::Name,
-              TT::EqualsSign,
-              TT::OpenCurly,
-              TT::Pipe,
-              TT::Name,
-              TT::Comma,
-              TT::Name,
-              TT::Comma,
-              TT::Name,
-              TT::Pipe,
-              TT::Name,
-              TT::Add,
-              TT::Name,
-              TT::Add,
-              TT::Name,
-              TT::CloseCurly,
-              TT::SemiColon,
+              T::Var,
+              T::Name,
+              T::EqualsSign,
+              T::OpenCurly,
+              T::Pipe,
+              T::Name,
+              T::Comma,
+              T::Name,
+              T::Comma,
+              T::Name,
+              T::Pipe,
+              T::Name,
+              T::Add,
+              T::Name,
+              T::Add,
+              T::Name,
+              T::CloseCurly,
+              T::SemiColon,
           },
           default_gobble);
 }
 
 BOOST_AUTO_TEST_CASE(strings) {
-    match(R"%(   "(\""   )%", std::array { TT::StringLine }, default_gobble);
-    match(R"%( "(\"" )%", std::array { TT::StringLine }, default_gobble);
-    match(R"%( "\")" abs )%", std::array { TT::StringLine, TT::Name }, default_gobble);
-    match(R"%( "◎" bang )%", std::array { TT::StringLine, TT::Name }, default_gobble);
+    match(R"%(   "(\""   )%", std::array { T::StringLine }, default_gobble);
+    match(R"%( "(\"" )%", std::array { T::StringLine }, default_gobble);
+    match(R"%( "\")" abs )%", std::array { T::StringLine, T::Name }, default_gobble);
+    match(R"%( "◎" bang )%", std::array { T::StringLine, T::Name }, default_gobble);
     match(R"%( 
 			"The function % should behave the same for a PatternProxy and its source:\n%\n"
     )%",
-          std::array { TT::StringLine }, default_gobble);
+          std::array { T::StringLine }, default_gobble);
 }
 
-BOOST_AUTO_TEST_CASE(symbol) { match("\\)", std::array { TT::SymbolSlash, TT::CloseParen }, default_gobble); }
+BOOST_AUTO_TEST_CASE(symbol) { match("\\)", std::array { T::SymbolSlash, T::CloseParen }, default_gobble); }
 
 BOOST_AUTO_TEST_CASE(ascii) {
-    match("$a", std::array { TT::Ascii }, default_gobble);
-    match("$a)", std::array { TT::Ascii, TT::CloseParen }, default_gobble);
-    match("$\\n", std::array { TT::Ascii }, default_gobble);
-    match("$\\n)", std::array { TT::Ascii, TT::CloseParen }, default_gobble);
-    match("$ ", std::array { TT::Ascii }, default_gobble);
-    match("$    bang  ", std::array { TT::Ascii, TT::Name }, default_gobble);
+    match("$a", std::array { T::Ascii }, default_gobble);
+    match("$a)", std::array { T::Ascii, T::CloseParen }, default_gobble);
+    match("$n", std::array { T::Ascii }, default_gobble);
+    match("$\n", std::array { T::ErFoundInvalidNewlineCharaceter }, default_gobble);
+    match("$\\n)", std::array { T::Ascii, T::CloseParen }, default_gobble);
+    match("$\\\n)", std::array { T::ErFoundInvalidNewlineCharaceter, T::CloseParen }, default_gobble);
+
+    match("$\r\n)", std::array { T::ErFoundInvalidNewlineCharaceter, T::CloseParen }, default_gobble);
+    match("$\\\r\n)", std::array { T::ErFoundInvalidNewlineCharaceter, T::CloseParen }, default_gobble);
+
+    match("$\v)", std::array { T::ErFoundInvalidNewlineCharaceter, T::CloseParen }, default_gobble);
+    match("$\\\v)", std::array { T::ErFoundInvalidNewlineCharaceter, T::CloseParen }, default_gobble);
+
+    match("$ ", std::array { T::Ascii }, default_gobble);
+    match("$\\ ", std::array { T::Ascii }, default_gobble);
+    match("$    bang  ", std::array { T::Ascii, T::Name }, default_gobble);
 }
 
 BOOST_AUTO_TEST_CASE(larger_obj) {
@@ -275,19 +301,18 @@ Object {
 
 	*new { arg maxSize = 0; _BasicNew
     )%%";
-    using T = TT;
     // clang-format off
     match(txt,
           std::array {
-              T::ClassName,  TT::OpenCurly, 
+              T::ClassName,  T::OpenCurly, 
               T::ClassVar,
-              TT::LessThan, T::Name, TT::Comma,
-              T::Name, TT::Comma,
-              T::Name,TT::Comma, 
-              TT::LessThan, T::Name,TT::SemiColon, 
-              T::Const, T::Name, TT::EqualsSign, T::StringLine, TT::SemiColon,
-              TT::Multiply, T::Name, TT::OpenCurly,
-              T::Arg, T::Name, TT::EqualsSign, T::Integer, TT::SemiColon,
+              T::LessThan, T::Name, T::Comma,
+              T::Name, T::Comma,
+              T::Name,T::Comma, 
+              T::LessThan, T::Name,T::SemiColon, 
+              T::Const, T::Name, T::EqualsSign, T::StringLine, T::SemiColon,
+              T::Multiply, T::Name, T::OpenCurly,
+              T::Arg, T::Name, T::EqualsSign, T::Integer, T::SemiColon,
               T::PrimitiveName
           },
           default_gobble);
@@ -302,25 +327,166 @@ Recorder {
 	var >recHeaderFormat, >recSampleFormat, >recBufSize;
 	var recordBuf, recordNode, synthDef;
     )%%";
-    using T = TT;
     // clang-format off
     match(txt,
           std::array {
-              T::ClassName,  TT::OpenCurly, 
+              T::ClassName,  T::OpenCurly, 
               T::Var,
-              TT::LessThan, T::Name, TT::Comma,
-              T::ReadWriteVar, T::Name, TT::SemiColon,
+              T::LessThan, T::Name, T::Comma,
+              T::ReadWriteVar, T::Name, T::SemiColon,
 
               T::Var,
-              TT::GreaterThan, T::Name, TT::Comma,
-              TT::GreaterThan, T::Name, TT::Comma,
-              TT::GreaterThan, T::Name, TT::SemiColon,
+              T::GreaterThan, T::Name, T::Comma,
+              T::GreaterThan, T::Name, T::Comma,
+              T::GreaterThan, T::Name, T::SemiColon,
 
               T::Var,
-              T::Name, TT::Comma,
-              T::Name, TT::Comma,
-              T::Name, TT::SemiColon,
+              T::Name, T::Comma,
+              T::Name, T::Comma,
+              T::Name, T::SemiColon,
           },
           default_gobble);
     // clang-format on
+}
+
+BOOST_AUTO_TEST_CASE(unicode_comments_1) {
+    const auto txt = R"%%(// delta is only used to compute § )%%";
+    match(txt, std::array { T::Comment }, std::array<T, 0> {});
+}
+
+BOOST_AUTO_TEST_CASE(unicode_comments_2) {
+    const auto txt = R"%%(// © 2003 Lance Putnam
+1)%%";
+    match(txt, std::array { T::Comment, T::NewLine, T::Integer }, std::array<T, 0> {});
+}
+
+
+BOOST_AUTO_TEST_CASE(bare_carriage) {
+    const auto bare_carriage = "foo bar \r 1";
+    match(bare_carriage,
+          std::array { T::Name, T::Space, T::Name, T::Space, T::ErFoundInvalidNewlineCharaceter, T::Space, T::Integer },
+          std::array<T, 0> {});
+}
+
+BOOST_AUTO_TEST_CASE(windows_new_line) {
+    const auto windows_new_line = "foo bar \r\n 1";
+    match(windows_new_line, std::array { T::Name, T::Space, T::Name, T::Space, T::NewLine, T::Space, T::Integer },
+          std::array<T, 0> {});
+}
+
+BOOST_AUTO_TEST_CASE(invalid_new_line) {
+    const auto invalid_new_line = "\v\f";
+    match(invalid_new_line, std::array { T::ErFoundInvalidNewlineCharaceter, T::ErFoundInvalidNewlineCharaceter },
+          std::array<T, 0> {});
+}
+
+BOOST_AUTO_TEST_CASE(line_comment) {
+    match("// I am a comment\nfoo", std::array { T::Comment, T::NewLine, T::Name }, std::array<T, 0> {});
+
+    match("// I am a comment\r\nfoo", std::array { T::Comment, T::NewLine, T::Name }, std::array<T, 0> {});
+
+    match("// I am a comment\rfoo", std::array { T::ErFoundInvalidNewlineCharaceter, T::Name }, std::array<T, 0> {});
+
+    match("// I am a comment\vfoo", std::array { T::ErFoundInvalidNewlineCharaceter, T::Name }, std::array<T, 0> {});
+
+    match("// I am a comment\ffoo", std::array { T::ErFoundInvalidNewlineCharaceter, T::Name }, std::array<T, 0> {});
+}
+
+
+BOOST_AUTO_TEST_CASE(quote_symbol) {
+    // Yes you can escape the new line character.
+    match("''", std::array { T::SymbolQuote }, std::array<T, 0> {});
+
+    match("'symbol\\\nabc'", std::array { T::SymbolQuote }, std::array<T, 0> {});
+
+    match("'symbol\\\r\nabc'", std::array { T::SymbolQuote }, std::array<T, 0> {});
+
+    match("'symbol\\\rabc'", std::array { T::ErFoundInvalidNewlineCharaceter, T::Name, T::ErSymbolQuoteUnclosed },
+          std::array<T, 0> {});
+
+    match("'symbol\\\vabc'", std::array { T::ErFoundInvalidNewlineCharaceter, T::Name, T::ErSymbolQuoteUnclosed },
+          std::array<T, 0> {});
+
+    match("'symbol\\\fabc'", std::array { T::ErFoundInvalidNewlineCharaceter, T::Name, T::ErSymbolQuoteUnclosed },
+          std::array<T, 0> {});
+
+    match("'symbol\\fabc'", std::array { T::SymbolQuote }, std::array<T, 0> {});
+}
+
+
+BOOST_AUTO_TEST_CASE(new_lines) {
+    match("foo\r\nbar", std::array { T::Name, T::NewLine, T::Name }, std::array<T, 0> {});
+    match("foo\nbar", std::array { T::Name, T::NewLine, T::Name }, std::array<T, 0> {});
+    //
+    match("foo\vbar", std::array { T::Name, T::ErFoundInvalidNewlineCharaceter, T::Name }, std::array<T, 0> {});
+    match("foo\fbar", std::array { T::Name, T::ErFoundInvalidNewlineCharaceter, T::Name }, std::array<T, 0> {});
+    match("foo\rbar", std::array { T::Name, T::ErFoundInvalidNewlineCharaceter, T::Name }, std::array<T, 0> {});
+
+
+    match("\"foo\r\nbar\"", std::array { T::StringLine }, std::array<T, 0> {});
+    match("\"foo\nbar\"", std::array { T::StringLine }, std::array<T, 0> {});
+    //
+    match("\"foo\vbar\"", std::array { T::ErFoundInvalidNewlineCharaceter, T::Name, T::ErStringUnclosed },
+          std::array<T, 0> {});
+    match("\"foo\fbar\"", std::array { T::ErFoundInvalidNewlineCharaceter, T::Name, T::ErStringUnclosed },
+          std::array<T, 0> {});
+    match("\"foo\rbar\"", std::array { T::ErFoundInvalidNewlineCharaceter, T::Name, T::ErStringUnclosed },
+          std::array<T, 0> {});
+}
+
+
+template <std::size_t N>
+void check_newline(const char* txt, std::array<sc::lex::SourceCodeRange, N> locs, bool print = false) {
+    const auto text_len = strlen(txt);
+
+    if (print)
+        std::cout << "check_newline: " << txt << "\n";
+
+    CodePointStream stream { txt, text_len, {} };
+
+    sc::lex::actions::TypeAndLocationAction action {};
+    const auto print_scrange = [](const sc::lex::SourceCodeRange& r) {
+        std::cout << "begin[ " << r.begin.absolute << ':' << r.begin.lineNumber << ':' << r.begin.column << "], end["
+                  << r.end.absolute << ':' << r.end.lineNumber << ':' << r.end.column << "]";
+    };
+
+    for (auto l : locs) {
+        const auto o = lexer(stream, action);
+
+        if (print) {
+            std::cout << to_string(o.type);
+            std::cout << " \tgot: ";
+            print_scrange(o.range);
+            std::cout << " \texpected: ";
+            print_scrange(l);
+            std::cout << "\n";
+        }
+        BOOST_TEST(o.range == l);
+    }
+    const auto o = lexer(stream, action);
+    BOOST_TEST(o.type == sc::lex::TokenType::EndOfFile);
+}
+
+BOOST_AUTO_TEST_CASE(new_checks) {
+    using L = sc::lex::SourceCodeRange;
+
+    check_newline("\"meow\nwoof\";\n1+1;",
+                  std::array {
+                      // string
+                      L { { 0, 0, 0 }, { 11, 1, 5 } },
+                      //;
+                      L { { 11, 1, 5 }, { 12, 1, 6 } },
+                      //\n
+                      L { { 12, 1, 6 }, { 13, 2, 0 } },
+                      // 1
+                      L { { 13, 2, 0 }, { 14, 2, 1 } },
+                      // +
+                      L { { 14, 2, 1 }, { 15, 2, 2 } },
+                      // 1
+                      L { { 15, 2, 2 }, { 16, 2, 3 } },
+                      // ;
+                      L { { 16, 2, 3 }, { 17, 2, 4 } },
+                      // EOF
+                      L { { 17, 2, 4 }, { 17, 2, 4 } },
+                  });
 }


### PR DESCRIPTION
This PR does three things:

1. Make all instances of bare `\r`, `\v` or `\f` errors. These are not allowed in the source code because editors cannot agree on how to display them. This means old Mac code (pre osx) needs updating.

1. All literals that contain new lines are turned into `\n` (even if they are `\r\n`) — see #7520 for a description of why this is bad.

1. Syntax for the character literal cannot contain a newline 
```
$
;
```
This is not allowed, you instead must do `$\n`. Note: `$ ` is still allowed as this is a space.

---


In the old lexer there was no definition of a new line, this led to the parser/compiling thinking code was on a line it wasn't.
As an example, it counted '\r' as a line break, but it also counted '\n', meaning the windows new line '\r\n' was counted twice.
Likewise, you could use the vertical tab '\v' or formfeed '\f' as whitespace, but neither of these were counted as new lines.
This gets really confusing as certain IDEs would/wouldn't display this as a new line.
For example, SCIDE would display a little squre with a question mark in for the vertical tab, but the terminal will display the vertical tab correctly (like a new line).
This means you could have single line comments over several lines in certain editors....

This PR defines new lines to be either '\n', '\r\n', or a couple of specific unicode new lines (these are unambiguious and if an editor supports utf8 and doesn't display them as a newline, it is wrong, not us).
The bare carriage return '\r', vertical tab '\v' and form feed '\f' are all made illegal and cannot appear in any source code.

This is **very** important if we want to know where in the file our source code comes from, which is a requirement for both good error messages and a debugger!



---


<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

For an example of the issues caused by fix 2, see #7520 

An example of issue 1 from the sc3 plugins is as follows...


The file BiquadEq.sc in scide
```
/*
RMEQ {
/*
Dattoro
Effect Design
Part 1: Reverberator and Other Filters
JAES, vol 45, no 9, 1997

	Synth.fftScope({
		n = WhiteNoise.ar(0.1);
		f = MouseX.kr( 0.1, 24 );
		b = MouseY.kr( -12, 12 ) * 2;
		[
			RegaliaMitraEQ.ar( n, 5000, f.midiratio - 1, b),
			RBJPeakingEQ.ar( n, 5000, f.midiratio - 1, b )
		]
	})
	
	Synth.fftScope({RegaliaMitraEQ.ar( WhiteNoise.ar(-20.dbamp), MouseY.kr(100, 1000, \exponential), 12.midirq, MouseX.kr(-20, 20))})	
	scope({RegaliaMitraEQ.ar( WhiteNoise.ar(-60.dbamp), LFNoise2.kr(1, 50, 300), LFNoise2.kr( 5, 6, 15).midiratio - 1, LFNoise1.kr( 2.1, 12, 30))})	.




... blah blah blah it looks good!
```
printing in the terminal using `less` , using neovim, and displaying in github
```
/*
RMEQ {^M/*^MDattoro^MEffect Design^MPart 1: Reverberator and Other Filters^MJAES, vol 45, no 9, 1997^M  Synth.fftScope({^M              n = WhiteNoise.ar(0.1);^M            f = MouseX.kr( 0.1, 24 );^M             b = MouseY.kr( -12, 12 ) * 2;^M         [^M                     RegaliaMitraEQ.ar( n, 5000, f.midiratio - 1, b),^M                   RBJPeakingEQ.ar( n, 5000, f.midiratio - 1, b )^M                ]^M     })^M    ^M      Synth.fftScope({RegaliaMitraEQ.ar( WhiteNoise.ar(-20.dbamp), MouseY.kr(100, 1000, \exponential), 12.midirq, MouseX.kr(-20, 20))})    ^M      scope({RegaliaMitraEQ.ar( WhiteNoise.ar(-60.dbamp), LFNoise2.kr(1, 50, 300), LFNoise2.kr( 5, 6, 15).midiratio - 1, LFNoise1.kr( 2.1, 12, 30))})      ^M*/^M  *ar { arg in, freq=440, rq=0.1, dbgain=0;^M          ^M              var wc, w2, w1, dw, q, beta, sr, y;^M           var b0, b1, b2, a0, a1, a2, az, k;^M                 ^M              k = dbgain.dbamp;^M                             ^M              sr = 2pi / SampleRate.ir;^M             wc = sr * freq;                              // freq in radians^M            dw = rq * wc;                           // bandwidth in radians^M               dw = (dw/2).tan;                     // delta is only used to compute <A7>^M         beta = (1 - dw) / (1 + dw);     // <A7>^M               y = cos(wc).neg;                             // lattice coefficient^M                ^M              b0 = beta;^M            b1 = y * (1 + beta);^M          b2 = 1;^M                    ^M              a0 = 1;^M               a1 = b1;        // y * (1 + beta);^M            a2 = beta;^M            ^M//            az = SOS.ar( in, b0/a0, b1/a0, b2/a0, a1/a0.neg, a2/a0.neg );^M              az = SOS.ar( in, b0, b1, b2, a1.neg, a2.neg );^M        ^M              ^( k * (in - az) ) + (in + az) * 0.5^M       }^M}
*/
^M/*^MImplementation of filters as described at:^M<http://www.harmony-central.com/Computer/Programming/Audio-EQ-Cookbook.txt>^M*/^M/*^MPeakingEQ {^M         /*^M            scope({RBJPeakingEQ.ar( WhiteNoise.ar(-60.dbamp), MouseY.kr(100, 1000, \exponential), 12.midiratio - 1, MouseX.kr(0, 45))})          ^M              scope({RBJPeakingEQ.ar( WhiteNoise.ar(-60.dbamp), LFNoise2.kr(1, 50, 300), LFNoise2.kr( 5, 6, 15).midiratio - 1, LFNoise1.kr( 2.1, 12, 30))})        ^M      */^M    *ar { arg in, freq=440, rq=0.1, dbgain=0, mul=1, add=0;^M               var b0, b1, b2, a0, a1, a2;^M                var a, omega, sin, cos, alpha, a0n;^M           var aovera, atimesa;^M          a = dbgain.dbamp;       ^M              omega = 2pi * freq/SampleRate.ir;^M          sin = omega.sin;^M              cos = omega.cos;^M              alpha = sin * rq / 2;^M         aovera = (alpha/a);^M                atimesa = (alpha*a);^M          ^M              a0 = 1 + aovera;^M              a1 = -2 * cos;^M                a2 = 1 - aovera;^M                   b0 = 1 + atimesa;^M             b1 = a1;^M              b2 = 1 - atimesa;^M             ^M              a0n = a0.neg;^M         ^SOS.ar( in, b0/a0, b1/a0, b2/a0, a1/a0n, a2/a0n, mul, add )^M       }^M}^M*/^MNotch  {^M    /*^M            Synth.fftScope({RBJNotch.ar( WhiteNoise.ar(0.1), 4400, MouseX.kr(0.01, 2))}) ^M              Synth.fftScope({RBJNotch.ar( SinOsc.ar(LFTri.kr(0.1, 1000, 1100), 0, 0.1), 500, MouseX.kr(0.01, 2))})   ^M           */^M    *ar { arg in, freq=440, rq=0.1, mul=1, add=0;^M         var b0, b1, b2, a0, a1, a2;^M           var a, omega, sin, cos, alpha, beta, q;^M            ^M              omega = 2pi * freq/SampleRate.ir;^M             sin = omega.sin;^M              cos = omega.cos;^M              alpha = rq * sin/2;^M                a0 = 1 + alpha;^M               a1 = -2 * cos;^M                a2 = 1 - alpha;^M               b0 = 1;^M                    b1 = a1;        // -2 * cos;^M          b2 = 1;^M               ^SOS.ar( in, b0/a0, b1/a0, b2/a0, a1/a0.neg, a2/a0.neg, mul, add )^M    }^M}

LowShelf  {^M   /*^M            Synth.fftScope({RBJLowShelf.ar( WhiteNoise.ar(0.1), 400, 1, MouseX.kr(-24, 24))})       ^M      */^M    *ar { arg in, freq=440, shelfslope=1, dbgain=0, mul=1, add=0;^M              var am1, ap1, bs, am1cos, ap1cos, q;^M          var b0, b1, b2, a0, a1, a2;^M                var a, omega, sin, cos, alpha, beta;^M          ^M              a = dbgain.dbamp;       ^M              omega = 2pi * freq/SampleRate.ir;^M                  sin = omega.sin;^M              cos = omega.cos;^M              beta = a.sqrt * ((a+a.reciprocal) * (shelfslope.reciprocal - 1) + 2).sqrt;^M//               beta = (((a.squared + 1) / shelfslope) - (a - 1).squared).sqrt;^M//             q = ((a + a.reciprocal) * (shelfslope.reciprocal - 1) + 2).sqrt.reciprocal;^M//              q.postln;^M//           beta = a.sqrt / q;^M            am1 = a-1;^M            ap1 = a+1;^M                 am1cos = am1 * cos;^M           ap1cos = ap1 * cos;^M           bs = beta * sin;^M              ^M              a0 = ap1 + am1cos + bs;^M                    a1 = -2 * ( am1 + ap1cos );^M           a2 = ap1 + am1cos - bs;^M               b0 = a * ( ap1 - am1cos + bs );^M               b1 = 2 * a * ( am1 - ap1cos );^M             b2 = a * ( ap1 - am1cos - bs );^M               ^SOS.ar( in, b0/a0, b1/a0, b2/a0, a1/a0.neg, a2/a0.neg, mul, add )^M }^M}
^MHighShelf  {^M        /*^M            Synth.fftScope({RBJHighShelf.ar( WhiteNoise.ar(0.1), 11000, 1, MouseX.kr(-6, 6))})      ^M      */^M    *ar { arg in, freq=440, shelfslope=1, dbgain=0, mul=1, add=0;^M              var am1, ap1, bs, am1cos, ap1cos;^M             var b0, b1, b2, a0, a1, a2, a0n;^M           var a, omega, sin, cos, alpha, beta, q;^M               ^M              a = dbgain.dbamp;       ^M              omega = 2pi * freq/SampleRate.ir;^M          sin = omega.sin;^M              cos = omega.cos;^M//            beta = (((a.squared + 1) / shelfslope) - (a - 1).squared).sqrt;^M            beta = a.sqrt * ((a+a.reciprocal)*(shelfslope.reciprocal-1)+2).sqrt;^M//                q = ((a + a.reciprocal) * (shelfslope.reciprocal - 1) + 2).sqrt.reciprocal;^M//              beta = a.sqrt / q;^M            am1 = a-1;^M            ap1 = a+1;^M            am1cos = am1 * cos;^M                ap1cos = ap1 * cos;^M           bs = beta * sin;^M              ^M              a0 = ap1 - am1cos + bs;^M               a1 = 2 * ( am1 - ap1cos );^M         a2 = ap1 - am1cos - bs;^M               b0 = a * ( ap1 + am1cos + bs );^M               b1 = -2 * a * ( am1 + ap1cos );^M                    b2 = a * ( ap1 + am1cos - bs );^M               ^M              a0n = a0.neg;^M         ^SOS.ar( in, b0/a0, b1/a0, b2/a0, a1/a0n, a2/a0n, mul, add )^M       }^M}

// old verbose names
RegaliaMitraEQ : RMEQ {}
//RBJPeakingEQ : PeakingEQ {}
RBJNotch : Notch {}^MRBJHighShelf : HighShelf {}
RBJLowShelf : LowShelf {}
```

printing in the terminal using `cat`
```
/*
JAES, voscope({RegaliaMitraEQ.ar( WhiteNoise.ar(-60.dbamp), LFNoise2.kr(1, 50, 300), LFNoise2.kr( 5, 6, 15).midiratio - 1, LFNoise1.kr( 2.1, 12, 30))}/      }ar { ar^( k * (in - az) ) + (in + az) * 0.5 a2.neg );g, a2/a0.neg );tto compute �
*/
PeakingE/*{.harmscope({RBJPeakingEQ.ar( WhiteNoise.ar(-60.dbamp), LFNoise2.kr(1, 50, 300), LFNoise2.kr( 5, 6, 15).midiratio - 1, LFNoise1.kr( 2.1, 12}otch  {}ar { ar^SOS.ar( in, b0/a0, b1/a0, b2/a0, a1/a0.neg, a2/a0.neg, mul, add )0, 0.1), 500, MouseX.kr(0.01, 2))})

}/wShelf}ar { ar^SOS.ar( in, b0/a0, b1/a0, b2/a0, a1/a0.neg, a2/a0.neg, mul, add )ciprocal;24))})
}/ghShel}ar { ar^SOS.ar( in, b0/a0, b1/a0, b2/a0, a1/a0n, a2/a0n, mul, add )qrt.reciprocal;, 6))})

// old verbose names
RegaliaMitraEQ : RMEQ {}
//RBJPeakingEQ : PeakingEQ {}
RBJHighShelf : HighShelf {}
RBJLowShelf : LowShelf {}
```

As you can see, the second option displays the bare carriage returns as `^M`, but the third actually does this properly and goes back to the beginning of the line and overwrites the text, essentially writing everything on one line...

There is a similar issue regarding vertical tab, where this doesn't end a comment and is allowed in quoted symbols. IDEs may choose to render this on a new line (correctly).
```
\\ a comment ? more comment
```
or
```
\\ a comment 
           more comment
```

This is bad because it not only means we don't know what line anything is on, but what is an isn't **read*** by the user as code changes.

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix
- Breaking change

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [ ] Updated documentation ??? 
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->
- [ ]  Need to retest error printing and line number logic because that changed.

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
