### PR TITLE
sclexer: fix console encoding for Windows in lexer standalone

### DIFF
--- a/langutils/sc_lexer/standalone/main.cpp
+++ b/langutils/sc_lexer/standalone/main.cpp
@@ -23,9 +23,9 @@ template <typename Stream> void print(Stream& s, SourceCodeRange r) {
 std::string utf8_encode(const std::wstring& wstr) {
     if (wstr.empty())
         return std::string();
-    int size_needed = WideCharToMultiByte(CP_UTF8, 0, &wstr[0], static_cast<int>(wstr.size()), NULL, 0, NULL, NULL);
+    int size_needed = WideCharToMultiByte(CP_UTF8, 0, wstr.data(), static_cast<int>(wstr.size()), NULL, 0, NULL, NULL);
     std::string strTo(static_cast<size_t>(size_needed), 0);
-    WideCharToMultiByte(CP_UTF8, 0, &wstr[0], static_cast<int>(wstr.size()), &strTo[0], size_needed, NULL, NULL);
+    WideCharToMultiByte(CP_UTF8, 0, wstr.data(), static_cast<int>(wstr.size()), strTo.data(), size_needed, NULL, NULL);
     return strTo;
 }
 

--- a/langutils/sc_lexer/standalone/main.cpp
+++ b/langutils/sc_lexer/standalone/main.cpp
@@ -6,6 +6,9 @@
 #include <iostream>
 #include <lexer.hpp>
 #include <sstream>
+#ifdef _MSC_VER
+#    include <windows.h>
+#endif // _MSC_VER
 
 using namespace sc::lex;
 
@@ -14,7 +17,23 @@ template <typename Stream> void print(Stream& s, SourceCodeRange r) {
       << r.end.column << "]}";
 }
 
+#ifdef _MSC_VER
+// utility function to convert default Windows stdin encoding to UTF-8
+// https://stackoverflow.com/questions/215963/how-do-you-properly-use-widechartomultibyte
+std::string utf8_encode(const std::wstring& wstr) {
+    if (wstr.empty())
+        return std::string();
+    int size_needed = WideCharToMultiByte(CP_UTF8, 0, &wstr[0], static_cast<int>(wstr.size()), NULL, 0, NULL, NULL);
+    std::string strTo(static_cast<size_t>(size_needed), 0);
+    WideCharToMultiByte(CP_UTF8, 0, &wstr[0], static_cast<int>(wstr.size()), &strTo[0], size_needed, NULL, NULL);
+    return strTo;
+}
+
+// need wmain for Windows default stdin encoding
+int wmain(int argc, wchar_t* argv[]) {
+#else
 int main(int argc, char* argv[]) {
+#endif // _MSC_VER
     if (argc != 2) {
         std::cerr
             << "ERROR: incorrect number of arguments to sc_lexer_standalone, expected only supercollider source code.\n"
@@ -22,9 +41,19 @@ int main(int argc, char* argv[]) {
         return EXIT_FAILURE;
     }
 
-    const auto* const source = argv[1];
-    const auto source_len = strlen(source);
+#ifdef _MSC_VER
+    // need this in order to ensure console output encoding handles UTF-8 properly
+    if (SetConsoleOutputCP(CP_UTF8) == 0) {
+        std::cerr << "ERROR: can't set console output codepage to UTF-8." << std::endl;
+    }
 
+    const std::string source_str = utf8_encode(std::wstring(argv[1]));
+    const auto* source = source_str.c_str();
+#else
+    const auto* const source = argv[1];
+#endif // _MSC_VER
+
+    const auto source_len = strlen(source);
 
     CodePointStream stream { source, source_len, {} };
     actions::TypeAndLocationAction action {};


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->
Partial fix for #7509. On Windows, the console defaults to 16-bit wide char encoding, so it's necessary to convert stdin to UTF-8 before passing to the lexer. The console output codepage must also be changed to UTF-8 to properly display all characters.

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
