### PR TITLE
Refactor Post Window return output: replace `-> `, fix SC‑IDE colour, and improve return markers

### DIFF
--- a/SCClassLibrary/Common/Core/Kernel.sc
+++ b/SCClassLibrary/Common/Core/Kernel.sc
@@ -716,7 +716,7 @@ Interpreter {
 		res = func.value;
 		thisProcess.nowExecutingPath = nil;
 		codeDump.value(code, res, func, this);
-		("-> " ++ res).postln;
+		("​‌‍⁠" ++ res).postln;
 	}
 
 	interpret { arg string ... args;

--- a/SCClassLibrary/Common/Core/Kernel.sc
+++ b/SCClassLibrary/Common/Core/Kernel.sc
@@ -716,7 +716,7 @@ Interpreter {
 		res = func.value;
 		thisProcess.nowExecutingPath = nil;
 		codeDump.value(code, res, func, this);
-		("​‌‍⁠::LAST::" ++ res).postln;
+		("​‌‍⁠::LAST::\n" ++ res ++ "\n──────────────────────────────").postln;
 	}
 
 	interpret { arg string ... args;

--- a/SCClassLibrary/Common/Core/Kernel.sc
+++ b/SCClassLibrary/Common/Core/Kernel.sc
@@ -716,7 +716,7 @@ Interpreter {
 		res = func.value;
 		thisProcess.nowExecutingPath = nil;
 		codeDump.value(code, res, func, this);
-		("​‌‍⁠::LAST::>\n" ++ res ++ "\n──────────────────────────────").postln;
+		("⁠⁠::LAST::>\n" ++ res ++ "\n──────────────────────────────").postln;
 	}
 
 	interpret { arg string ... args;

--- a/SCClassLibrary/Common/Core/Kernel.sc
+++ b/SCClassLibrary/Common/Core/Kernel.sc
@@ -716,7 +716,7 @@ Interpreter {
 		res = func.value;
 		thisProcess.nowExecutingPath = nil;
 		codeDump.value(code, res, func, this);
-		("​‌‍⁠" ++ res).postln;
+		("​‌‍⁠::LAST::" ++ res).postln;
 	}
 
 	interpret { arg string ... args;

--- a/SCClassLibrary/Common/Core/Kernel.sc
+++ b/SCClassLibrary/Common/Core/Kernel.sc
@@ -716,7 +716,7 @@ Interpreter {
 		res = func.value;
 		thisProcess.nowExecutingPath = nil;
 		codeDump.value(code, res, func, this);
-		("​‌‍⁠::LAST::\n" ++ res ++ "\n──────────────────────────────").postln;
+		("​‌‍⁠::LAST::>\n" ++ res ++ "\n──────────────────────────────").postln;
 	}
 
 	interpret { arg string ... args;

--- a/editors/sc-ide/widgets/post_window.cpp
+++ b/editors/sc-ide/widgets/post_window.cpp
@@ -206,11 +206,12 @@ void PostWindow::post(const QString& text) {
     }
 
     const auto lines = text.split("\n");
-    const size_t line_count = lines.size();
+    const auto line_count = lines.size();
     QTextCharFormat result_format = formatForPostLine("->");
 
     for (size_t i { 0 }; i < line_count; ++i) {
-        const QString& line = lines[i];
+        const auto line = lines[i];
+        const auto line_format = formatForPostLine(line);
         cursor.movePosition(QTextCursor::End);
 
         if (line.startsWith("->"))
@@ -225,7 +226,7 @@ void PostWindow::post(const QString& text) {
         } else {
             // words are just text separated by spaces.
             const auto words = line.split(" ");
-            const size_t words_count = words.size();
+            const auto words_count = words.size();
             for (size_t w { 0 }; w < words_count; ++w) {
                 const auto& word = words[w];
                 cursor.movePosition(QTextCursor::End);

--- a/editors/sc-ide/widgets/post_window.cpp
+++ b/editors/sc-ide/widgets/post_window.cpp
@@ -199,46 +199,39 @@ void PostWindow::post(const QString& text) {
     if (text == "\n") {
         cursor.movePosition(QTextCursor::End);
         cursor.insertText(text, currentFormat);
+        mInResultBlock = false;
 
         if (scroll)
-            emit(scrollToBottomRequest());
+            emit scrollToBottomRequest();
         return;
     }
 
-    const auto ends_with_new_line = text.back() == '\n';
     const auto lines = text.split("\n");
-    const auto line_count = lines.size();
+    const int line_count = lines.size();
 
-    // ★ 이 호출이 "결과 블록"인지 한 번만 판단
-    const bool is_result_block = !lines.isEmpty() && lines.first().startsWith("->");
+    QTextCharFormat result_format = formatForPostLine("->");
 
-    // 결과 블록일 때 쓸 포맷을 미리 준비
-    QTextCharFormat result_format;
-    if (is_result_block) {
-        result_format = formatForPostLine("->");
-    }
-
-    for (size_t i { 0 }; i < line_count; ++i) {
-        const auto line = lines[i];
-
-        // ★ 결과 블록이면 모든 줄에 result_format,
-        //   아니면 기존처럼 줄마다 formatForPostLine(line)
-        const auto line_format = is_result_block ? result_format : formatForPostLine(line);
+    for (int i = 0; i < line_count; ++i) {
+        const QString& line = lines[i];
 
         cursor.movePosition(QTextCursor::End);
+
+        if (line.startsWith("->"))
+            mInResultBlock = true;
+
+        QTextCharFormat line_format = mInResultBlock ? result_format : formatForPostLine(line);
 
         if (!line.contains("://")) {
             cursor.insertText(line, line_format);
         } else {
             const auto words = line.split(" ");
-            const auto words_count = words.size();
-            for (size_t w { 0 }; w < words_count; ++w) {
+            const int words_count = words.size();
+            for (int w = 0; w < words_count; ++w) {
                 const auto& word = words[w];
                 cursor.movePosition(QTextCursor::End);
 
-                if (const auto maybe_url = QUrl(word, QUrl::ParsingMode::StrictMode);
-                    maybe_url.isValid() && word.contains("://")) {
-                    cursor.insertHtml(QString("<a href='") + word + QString("'>") + word + QString("<\\a>"));
+                if (const auto maybe_url = QUrl(word, QUrl::StrictMode); maybe_url.isValid() && word.contains("://")) {
+                    cursor.insertHtml("<a href='" + word + "'>" + word + "</a>");
                 } else {
                     cursor.insertText(word, line_format);
                 }
@@ -250,10 +243,13 @@ void PostWindow::post(const QString& text) {
 
         if (i + 1 != line_count)
             cursor.insertText("\n", line_format);
+
+        if (line.isEmpty())
+            mInResultBlock = false;
     }
 
     if (scroll)
-        emit(scrollToBottomRequest());
+        emit scrollToBottomRequest();
 }
 
 QTextCharFormat PostWindow::formatForPostLine(QString line) {

--- a/editors/sc-ide/widgets/post_window.cpp
+++ b/editors/sc-ide/widgets/post_window.cpp
@@ -200,20 +200,17 @@ void PostWindow::post(const QString& text) {
         cursor.movePosition(QTextCursor::End);
         cursor.insertText(text, currentFormat);
         mInResultBlock = false;
-
         if (scroll)
-            emit scrollToBottomRequest();
+            emit(scrollToBottomRequest());
         return;
     }
 
     const auto lines = text.split("\n");
-    const int line_count = lines.size();
-
+    const size_t line_count = lines.size();
     QTextCharFormat result_format = formatForPostLine("->");
 
-    for (int i = 0; i < line_count; ++i) {
+    for (size_t i { 0 }; i < line_count; ++i) {
         const QString& line = lines[i];
-
         cursor.movePosition(QTextCursor::End);
 
         if (line.startsWith("->"))
@@ -221,26 +218,32 @@ void PostWindow::post(const QString& text) {
 
         QTextCharFormat line_format = mInResultBlock ? result_format : formatForPostLine(line);
 
+        // If there is some text that looks like a URI and contains '://' then turn it into a html anchor so we can
+        // click it.
         if (!line.contains("://")) {
             cursor.insertText(line, line_format);
         } else {
+            // words are just text separated by spaces.
             const auto words = line.split(" ");
-            const int words_count = words.size();
-            for (int w = 0; w < words_count; ++w) {
+            const size_t words_count = words.size();
+            for (size_t w { 0 }; w < words_count; ++w) {
                 const auto& word = words[w];
                 cursor.movePosition(QTextCursor::End);
 
-                if (const auto maybe_url = QUrl(word, QUrl::StrictMode); maybe_url.isValid() && word.contains("://")) {
-                    cursor.insertHtml("<a href='" + word + "'>" + word + "</a>");
+                if (const auto maybe_url = QUrl(word, QUrl::ParsingMode::StrictMode);
+                    maybe_url.isValid() && word.contains("://")) {
+                    cursor.insertHtml(QString("<a href='") + word + QString("'>") + word + QString("<\\a>"));
                 } else {
                     cursor.insertText(word, line_format);
                 }
 
+                // Put space back in, if not last word.
                 if (w + 1 != words_count)
                     cursor.insertText(" ", line_format);
             }
         }
 
+        // Don't write a new line in the final case.
         if (i + 1 != line_count)
             cursor.insertText("\n", line_format);
 
@@ -249,7 +252,7 @@ void PostWindow::post(const QString& text) {
     }
 
     if (scroll)
-        emit scrollToBottomRequest();
+        emit(scrollToBottomRequest());
 }
 
 QTextCharFormat PostWindow::formatForPostLine(QString line) {

--- a/editors/sc-ide/widgets/post_window.cpp
+++ b/editors/sc-ide/widgets/post_window.cpp
@@ -44,7 +44,7 @@
 
 namespace ScIDE {
 
-static const QString RESULT_MARKER = QString::fromUtf8(u8"\u200B\u200C\u200D\u2060");
+static const QString RESULT_MARKER = QString::fromUtf8(u8"\u2060\u2060");
 
 PostWindow::PostWindow(QWidget* parent): QPlainTextEdit(parent) {
     setReadOnly(true);

--- a/editors/sc-ide/widgets/post_window.cpp
+++ b/editors/sc-ide/widgets/post_window.cpp
@@ -196,10 +196,12 @@ void PostWindow::post(const QString& text) {
     const bool scroll = mActions[AutoScroll]->isChecked();
     QTextCursor cursor(document());
 
+    mInResultBlock = false;
+
     if (text == "\n") {
         cursor.movePosition(QTextCursor::End);
         cursor.insertText(text, currentFormat);
-        mInResultBlock = false;
+
         if (scroll)
             emit(scrollToBottomRequest());
         return;
@@ -213,8 +215,10 @@ void PostWindow::post(const QString& text) {
         const auto line = lines[i];
         cursor.movePosition(QTextCursor::End);
 
-        if (line.startsWith("->"))
+        bool isResultLine = line.startsWith("->");
+        if (isResultLine) {
             mInResultBlock = true;
+        }
 
         QTextCharFormat line_format = mInResultBlock ? result_format : formatForPostLine(line);
 
@@ -246,9 +250,6 @@ void PostWindow::post(const QString& text) {
         // Don't write a new line in the final case.
         if (i + 1 != line_count)
             cursor.insertText("\n", line_format);
-
-        if (line.isEmpty())
-            mInResultBlock = false;
     }
 
     if (scroll)

--- a/editors/sc-ide/widgets/post_window.cpp
+++ b/editors/sc-ide/widgets/post_window.cpp
@@ -211,7 +211,6 @@ void PostWindow::post(const QString& text) {
 
     for (size_t i { 0 }; i < line_count; ++i) {
         const auto line = lines[i];
-        const auto line_format = formatForPostLine(line);
         cursor.movePosition(QTextCursor::End);
 
         if (line.startsWith("->"))

--- a/editors/sc-ide/widgets/post_window.cpp
+++ b/editors/sc-ide/widgets/post_window.cpp
@@ -44,6 +44,8 @@
 
 namespace ScIDE {
 
+static const QString RESULT_MARKER = QString::fromUtf8(u8"\u200B\u200C\u200D\u2060");
+
 PostWindow::PostWindow(QWidget* parent): QPlainTextEdit(parent) {
     setReadOnly(true);
     setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOn);
@@ -209,18 +211,38 @@ void PostWindow::post(const QString& text) {
 
     const auto lines = text.split("\n");
     const auto line_count = lines.size();
-    QTextCharFormat result_format = formatForPostLine("->");
+
+    QTextCharFormat result_format = formatForPostLine(RESULT_MARKER);
+
 
     for (size_t i { 0 }; i < line_count; ++i) {
         const auto line = lines[i];
         cursor.movePosition(QTextCursor::End);
 
-        bool isResultLine = line.startsWith("->");
-        if (isResultLine) {
+        // Detect result prefix
+        int idx = line.indexOf(RESULT_MARKER);
+
+        if (idx == 0) {
+            // Entire line is result block
             mInResultBlock = true;
         }
 
         QTextCharFormat line_format = mInResultBlock ? result_format : formatForPostLine(line);
+
+        // Case: printed + result stuck together in one line
+        if (!mInResultBlock && idx > 0) {
+            QString before = line.left(idx);
+            QString after = line.mid(idx); // after starts with RESULT_MARKER
+
+            cursor.insertText(before, formatForPostLine(before));
+            cursor.insertText(after, result_format);
+
+            mInResultBlock = true;
+
+            if (i + 1 != line_count)
+                cursor.insertText("\n", result_format);
+            continue;
+        }
 
         // If there is some text that looks like a URI and contains '://' then turn it into a html anchor so we can
         // click it.
@@ -249,7 +271,7 @@ void PostWindow::post(const QString& text) {
 
         // Don't write a new line in the final case.
         if (i + 1 != line_count)
-            cursor.insertText("\n", line_format);
+            cursor.insertText("\n", mInResultBlock ? result_format : line_format);
     }
 
     if (scroll)
@@ -269,7 +291,7 @@ QTextCharFormat PostWindow::formatForPostLine(QString line) {
         format.merge(postWindowError);
     else if (line.startsWith("WARNING:", Qt::CaseInsensitive) || line.startsWith("?"))
         format.merge(postWindowWarning);
-    else if (line.startsWith("->"))
+    else if (line.startsWith(RESULT_MARKER))
         format.merge(postWindowSuccess);
     else if (line.startsWith("***"))
         format.merge(postWindowEmphasis);

--- a/editors/sc-ide/widgets/post_window.cpp
+++ b/editors/sc-ide/widgets/post_window.cpp
@@ -206,10 +206,11 @@ void PostWindow::post(const QString& text) {
     }
 
     QTextCharFormat resultFormat = formatForPostLine("->");
-    + +cursor.movePosition(QTextCursor::End);
-    +cursor.beginEditBlock();
-    +cursor.insertText(text, resultFormat);
-    +cursor.endEditBlock();
+
+    cursor.movePosition(QTextCursor::End);
+    cursor.beginEditBlock();
+    cursor.insertText(text, resultFormat);
+    cursor.endEditBlock();
 
     if (scroll)
         emit(scrollToBottomRequest());

--- a/editors/sc-ide/widgets/post_window.cpp
+++ b/editors/sc-ide/widgets/post_window.cpp
@@ -205,12 +205,52 @@ void PostWindow::post(const QString& text) {
         return;
     }
 
-    QTextCharFormat resultFormat = formatForPostLine("->");
+    const auto ends_with_new_line = text.back() == '\n';
+    const auto lines = text.split("\n");
+    const auto line_count = lines.size();
 
-    cursor.movePosition(QTextCursor::End);
-    cursor.beginEditBlock();
-    cursor.insertText(text, resultFormat);
-    cursor.endEditBlock();
+    // ★ 이 호출이 "결과 블록"인지 한 번만 판단
+    const bool is_result_block = !lines.isEmpty() && lines.first().startsWith("->");
+
+    // 결과 블록일 때 쓸 포맷을 미리 준비
+    QTextCharFormat result_format;
+    if (is_result_block) {
+        result_format = formatForPostLine("->");
+    }
+
+    for (size_t i { 0 }; i < line_count; ++i) {
+        const auto line = lines[i];
+
+        // ★ 결과 블록이면 모든 줄에 result_format,
+        //   아니면 기존처럼 줄마다 formatForPostLine(line)
+        const auto line_format = is_result_block ? result_format : formatForPostLine(line);
+
+        cursor.movePosition(QTextCursor::End);
+
+        if (!line.contains("://")) {
+            cursor.insertText(line, line_format);
+        } else {
+            const auto words = line.split(" ");
+            const auto words_count = words.size();
+            for (size_t w { 0 }; w < words_count; ++w) {
+                const auto& word = words[w];
+                cursor.movePosition(QTextCursor::End);
+
+                if (const auto maybe_url = QUrl(word, QUrl::ParsingMode::StrictMode);
+                    maybe_url.isValid() && word.contains("://")) {
+                    cursor.insertHtml(QString("<a href='") + word + QString("'>") + word + QString("<\\a>"));
+                } else {
+                    cursor.insertText(word, line_format);
+                }
+
+                if (w + 1 != words_count)
+                    cursor.insertText(" ", line_format);
+            }
+        }
+
+        if (i + 1 != line_count)
+            cursor.insertText("\n", line_format);
+    }
 
     if (scroll)
         emit(scrollToBottomRequest());

--- a/editors/sc-ide/widgets/post_window.cpp
+++ b/editors/sc-ide/widgets/post_window.cpp
@@ -205,43 +205,11 @@ void PostWindow::post(const QString& text) {
         return;
     }
 
-    const auto ends_with_new_line = text.back() == '\n';
-    const auto lines = text.split("\n");
-    const auto line_count = lines.size();
-    for (size_t i { 0 }; i < line_count; ++i) {
-        const auto line = lines[i];
-        const auto line_format = formatForPostLine(line);
-        cursor.movePosition(QTextCursor::End);
-
-        // If there is some text that looks like a URI and contains '://' then turn it into a html anchor so we can
-        // click it.
-        if (!line.contains("://")) {
-            cursor.insertText(line, line_format);
-        } else {
-            // words are just text separated by spaces.
-            const auto words = line.split(" ");
-            const auto words_count = words.size();
-            for (size_t w { 0 }; w < words_count; ++w) {
-                const auto& word = words[w];
-                cursor.movePosition(QTextCursor::End);
-
-                if (const auto maybe_url = QUrl(word, QUrl::ParsingMode::StrictMode);
-                    maybe_url.isValid() && word.contains("://")) {
-                    cursor.insertHtml(QString("<a href='") + word + QString("'>") + word + QString("<\\a>"));
-                } else {
-                    cursor.insertText(word, line_format);
-                }
-
-                // Put space back in, if not last word.
-                if (w + 1 != words_count)
-                    cursor.insertText(" ", line_format);
-            }
-        }
-
-        // Don't write a new line in the final case.
-        if (i + 1 != line_count)
-            cursor.insertText("\n", line_format);
-    }
+    QTextCharFormat resultFormat = formatForPostLine("->");
+    + +cursor.movePosition(QTextCursor::End);
+    +cursor.beginEditBlock();
+    +cursor.insertText(text, resultFormat);
+    +cursor.endEditBlock();
 
     if (scroll)
         emit(scrollToBottomRequest());

--- a/editors/sc-ide/widgets/post_window.hpp
+++ b/editors/sc-ide/widgets/post_window.hpp
@@ -120,7 +120,7 @@ private:
     /// Used in conjuction with anchorAt(QPos)
     QString clickedAnchor;
 
-    // State for multi-line result block formatting
+    /// State for multi-line result block formatting
     bool mInResultBlock = false;
 };
 

--- a/editors/sc-ide/widgets/post_window.hpp
+++ b/editors/sc-ide/widgets/post_window.hpp
@@ -103,6 +103,7 @@ private:
     void updateActionShortcuts(Settings::Manager*);
     void zoomFont(int steps);
     void zoomFont(float scaler);
+    bool mInResultBlock = false;
     QTextCharFormat formatForPostLine(QString line);
 
     QAction* mActions[ActionCount];

--- a/editors/sc-ide/widgets/post_window.hpp
+++ b/editors/sc-ide/widgets/post_window.hpp
@@ -103,7 +103,6 @@ private:
     void updateActionShortcuts(Settings::Manager*);
     void zoomFont(int steps);
     void zoomFont(float scaler);
-    bool mInResultBlock = false;
     QTextCharFormat formatForPostLine(QString line);
 
     QAction* mActions[ActionCount];
@@ -120,6 +119,9 @@ private:
     /// Will be empty when no anchor has been clicked
     /// Used in conjuction with anchorAt(QPos)
     QString clickedAnchor;
+
+    // State for multi-line result block formatting
+    bool mInResultBlock = false;
 };
 
 


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->
fixes: #7524
## Purpose and Motivation
Currently, the multi‑line output in the Post window displays the green colour only for the first line after `->`, as shown below:
<img width="1143" height="149" alt="Screenshot 2026-05-29 at 14 50 21 copy" src="https://github.com/user-attachments/assets/f373d1bc-3115-4534-b49d-16be427723de" />

This pull request changes that behaviour so that all subsequent lines belonging to the same result block are displayed in green:
<img width="1071" height="147" alt="Screenshot 2026-05-29 at 14 44 35 copy" src="https://github.com/user-attachments/assets/fe41434d-4374-40b0-8ebe-7af0f3d2d9ce" />
 test code:
```supercollider
(
"line one\
line two\
line three".postcs
)

(
'line one\
line two\
line three'
.postcs
)

("1
2
3
4
5
"
)
```
----

I would like to submit this pull request with full respect for the SuperCollider Code of Conduct and with appreciation for the concerns raised regarding the use of AI‑assisted development.

To be transparent: I did not manually review every individual line of the AI‑generated changes. Instead, I followed the AI‑guided workflow and focused my efforts on thorough testing. My intention was not to shift the burden of verification onto reviewers, but to ensure—within my current technical abilities—that the resulting behaviour was correct and consistent across platforms.

Although I am not familiar with C++, working through this issue has been a meaningful learning experience for me. Even if my understanding remains limited, the process has helped me gain a clearer sense of how this part of the codebase behaves, and I am grateful for the opportunity to learn through practical experimentation.

I repeatedly built and tested the results on an M1 Max Mac, a virtualised Windows environment, and Ubuntu 24.04.3 ARM64. I also downloaded and tested the GitHub Actions artefacts several times to confirm that the changes functioned reliably. The following builds were produced and confirmed to run successfully on macOS, Windows, and Linux:

### ✔ macOS (Universal)
SuperCollider‑cc9f597d5ab1224b289a8858db87b8c447dd0693‑macOS‑universal.dmg  
[https://github.com/prko/supercollider/actions/runs/26616098521/artifacts/7282519077](https://github.com/prko/supercollider/actions/runs/26616098521/artifacts/7282519077)

### ✔ Ubuntu 22.04 (gcc12)
SuperCollider‑cc9f597d5ab1224b289a8858db87b8c447dd0693‑ubuntu‑22.04‑gcc12  
[https://github.com/prko/supercollider/actions/runs/26616098521/artifacts/7282499904](https://github.com/prko/supercollider/actions/runs/26616098521/artifacts/7282499904)

### ✔ Windows 64‑bit
SuperCollider‑cc9f597d5ab1224b289a8858db87b8c447dd0693‑win64  
[https://github.com/prko/supercollider/actions/runs/26616098521/artifacts/7282530155](https://github.com/prko/supercollider/actions/runs/26616098521/artifacts/7282530155)

Since I have personally verified that the resulting builds run correctly on all three major platforms, I hope that my testing can be of practical help. I also hope that this reduces the burden on reviewers to validate the behaviour across different operating systems.

In addition, I confirmed that the following code snippets behave identically with and without this patch applied:

```
Buffer.read(s, ExampleFiles.child).play

post("-> [1, 2,\n");   // mInResultBlock = true
post("  3, 4,\n");     // remains true (success style) -> OK
post("ERROR: something\n"); // previously: ERROR printed in success style
post("  5, 6]\n");     // also printed in success style
```

I also asked DeepSeek to explain the modified code to me, and although it described the logic as only partially sound, all of the examples it raised as potential concerns behaved correctly in my testing. Based on this, my current understanding is that the changes are acceptable, though I remain open to correction.

I would also appreciate it if the reviewers could take into account that my previous pull request—although seemingly simpler than this one—did not succeed despite my efforts. In contrast, this contribution has undergone much more extensive testing and iteration, and I hope that it will be more useful to the project.

If any part of this contribution requires revision, clarification, or a different approach, I am very willing to adjust it. I appreciate the guidance offered by the maintainers and reviewers, and I welcome any feedback that can help improve this work.

**If, for any reason, this contribution cannot be accepted in its current form, I would be very glad if someone else could build upon the ideas here and create a new pull request so that this improvement may still find its way into the project.**

Thank you for your time and consideration.

----

## Types of changes

<!-- Delete lines that don't apply -->

- New feature

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [ ] Code is tested
- [x] All tests are passing
- [ ] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
