### PR TITLE
ci: display 30 slowest ci tests

### DIFF
--- a/testsuite/scripts/print_results.scd
+++ b/testsuite/scripts/print_results.scd
@@ -6,6 +6,7 @@ var useColors = \Document.asClass.isNil; // use colors if we're running sclang d
 var exitWhenDone = \Document.asClass.isNil; // exit if we're running sclang directly
 var failedList = List();
 
+var numSlowestTestToDisplay = 30;
 var roundTime = { |time| 
 	// three most significant digits
 	var log = time.log10.round;
@@ -106,7 +107,7 @@ results.do({|dict|
 "Longest running tests:\n".postln;
 results.select{ |d| d[\duration].notNil}
 	.sort{ |l, r| l[\duration] > r[\duration] }
-	.copySeries(0, nil, 30)
+	.keep(numSlowestTestToDisplay)
 	.do { |dict|
 		"\t%\t%".format(
 			makeBold.("%:%".format(dict[\suite], dict[\test])),

--- a/testsuite/scripts/print_results.scd
+++ b/testsuite/scripts/print_results.scd
@@ -109,7 +109,7 @@ results.select{ |d| d[\duration].notNil}
 	.sort{ |l, r| l[\duration] > r[\duration] }
 	.keep(numSlowestTestToDisplay)
 	.do { |dict|
-		makeBold.("\t%:%".format(dict[\suite], dict[\test])).pad(50) ++ makeRed.(roundTime.(dict[\duration])).postln;
+		makeBold.("\t%:%".format(dict[\suite], dict[\test])).padRight(50) ++ makeRed.(roundTime.(dict[\duration])).postln;
 	}
 ;
 "\t------------------------------".postln;

--- a/testsuite/scripts/print_results.scd
+++ b/testsuite/scripts/print_results.scd
@@ -129,8 +129,6 @@ if(failed > 0) {
 	"\t------------------------------".postln;
 };
 
-
-
 if(exitWhenDone) {(failed > 0).asInteger.exit};
 
 )

--- a/testsuite/scripts/print_results.scd
+++ b/testsuite/scripts/print_results.scd
@@ -109,7 +109,7 @@ results.select{ |d| d[\duration].notNil}
 	.sort{ |l, r| l[\duration] > r[\duration] }
 	.keep(numSlowestTestToDisplay)
 	.do { |dict|
-		(makeBold.("\t%:%".format(dict[\suite], dict[\test])).padRight(100) ++ makeRed.(roundTime.(dict[\duration]))).postln;
+		(makeBold.("\t%:%".format(dict[\suite], dict[\test])).padRight(100) ++ roundTime.(dict[\duration]) ++ "s").postln;
 	}
 ;
 "\t------------------------------".postln;

--- a/testsuite/scripts/print_results.scd
+++ b/testsuite/scripts/print_results.scd
@@ -5,8 +5,12 @@ var results, path, tmpPath, file;
 var useColors = \Document.asClass.isNil; // use colors if we're running sclang directly
 var exitWhenDone = \Document.asClass.isNil; // exit if we're running sclang directly
 var failedList = List();
-var timeRes = 0.0001;
-var times;
+
+var roundTime = { |time| 
+	// three most significant digits
+	var log = time.log10.round;
+	time.round(10.pow(log - 2))
+};
 
 if(thisProcess.argv.size > 0) {
 	path = thisProcess.argv[0];
@@ -67,7 +71,7 @@ results.do({|dict|
 			} {
 				header = makeRed.(header);
 			};
-			groupMsg = "\t%\t% (%s)".format(header, name, (dict[\duration] ? 0).round(timeRes)).postln;
+			groupMsg = "\t%\t% (%s)".format(header, name, roundTime.(dict[\duration] ? 0)).postln;
 			dict[\results].do({|resDict|
 				if(resDict[\pass]) {
 					header = makeGreen.("*");
@@ -82,19 +86,36 @@ results.do({|dict|
 			})
 		};
 		if(dict[\completed] != true) {
-			"\t%\t% did not complete%".format(makeRed.("[!]"), name, if(dict[\duration].notNil) {" (%s)".format(dict[\duration].round(timeRes))} {""}).postln;
+			"\t%\t% did not complete%".format(makeRed.("[!]"), name, if(dict[\duration].notNil) {" (%s)".format( roundTime.(dict[\duration]) )} {""}).postln;
 			failed = failed + 1;
-			failedList.add("\t%\t% did not complete%".format(makeRed.("[!]"), name, if(dict[\duration].notNil) {" (%s)".format(dict[\duration].round(timeRes))} {""}));
+			failedList.add("\t%\t% did not complete%".format(makeRed.("[!]"), name, if(dict[\duration].notNil) {" (%s)".format(roundTime.(dict[\duration]))} {""}));
 		} {
 			if(allResults == 0) { // marked as completed, but no results were recorded...
 				// "\t%\t% (%s)".format(makeRed.("[!]"), name, (dict[\duration] ? 0).round(0.01)).postln;
 				// failed = failed + 1;
 				// tests that didn't produce any results didn't necessarily fail (e.g. TestSerialPort on macOS)
-				"\t%\t% did not produce any results%".format(makeYellow.("[?]"), name, if(dict[\duration].notNil) {" (%s)".format(dict[\duration].round(timeRes))} {""}).postln;
+				"\t%\t% did not produce any results%".format(makeYellow.("[?]"), name, if(dict[\duration].notNil) {" (%s)".format(roundTime.(dict[\duration]))} {""}).postln;
 			}
 		}
 	};
 });
+
+
+"".postln;
+"\t------------------------------".postln;
+"Longest running tests:\n".postln;
+results.select{ |d| d[\duration].notNil}
+	.sort{ |l, r| l[\duration] > r[\duration] }
+	.copySeries(0, nil, 30)
+	.do { |dict|
+		"\t%\t%".format(
+			makeBold.("%:%".format(dict[\suite], dict[\test])),
+			makeRed.(roundTime.(dict[\duration]))
+		).postln;
+	}
+;
+"\t------------------------------".postln;
+
 
 if(failed > 0) {
 	"\nFailed tests:\n".postln;
@@ -110,18 +131,6 @@ if(failed > 0) {
 	"\t------------------------------".postln;
 };
 
-"".postln;
-"Longest running tests:\n".postln;
-"\t------------------------------".postln;
-results = results.select{|d| d[\duration].notNil};
-results = results.sort{|l, r| l[\duration] > r[\duration] };
-results[0..30].do { |dict|
-	"\t%\t%".format(
-		makeBold.("%:%".format(dict[\suite], dict[\test])),
-		makeRed.(dict[\duration])
-	).postln;
-};
-"\t------------------------------".postln;
 
 
 if(exitWhenDone) {(failed > 0).asInteger.exit};

--- a/testsuite/scripts/print_results.scd
+++ b/testsuite/scripts/print_results.scd
@@ -109,7 +109,7 @@ results.select{ |d| d[\duration].notNil}
 	.sort{ |l, r| l[\duration] > r[\duration] }
 	.keep(numSlowestTestToDisplay)
 	.do { |dict|
-		makeBold.("\t%:%".format(dict[\suite], dict[\test])).padRight(50) ++ makeRed.(roundTime.(dict[\duration])).postln;
+		(makeBold.("\t%:%".format(dict[\suite], dict[\test])).padRight(50) ++ makeRed.(roundTime.(dict[\duration]))).postln;
 	}
 ;
 "\t------------------------------".postln;

--- a/testsuite/scripts/print_results.scd
+++ b/testsuite/scripts/print_results.scd
@@ -109,7 +109,7 @@ results.select{ |d| d[\duration].notNil}
 	.sort{ |l, r| l[\duration] > r[\duration] }
 	.keep(numSlowestTestToDisplay)
 	.do { |dict|
-		(makeBold.("\t%:%".format(dict[\suite], dict[\test])).padRight(50) ++ makeRed.(roundTime.(dict[\duration]))).postln;
+		(makeBold.("\t%:%".format(dict[\suite], dict[\test])).padRight(100) ++ makeRed.(roundTime.(dict[\duration]))).postln;
 	}
 ;
 "\t------------------------------".postln;

--- a/testsuite/scripts/print_results.scd
+++ b/testsuite/scripts/print_results.scd
@@ -5,6 +5,8 @@ var results, path, tmpPath, file;
 var useColors = \Document.asClass.isNil; // use colors if we're running sclang directly
 var exitWhenDone = \Document.asClass.isNil; // exit if we're running sclang directly
 var failedList = List();
+var timeRes = 0.0001;
+var times;
 
 if(thisProcess.argv.size > 0) {
 	path = thisProcess.argv[0];
@@ -65,7 +67,7 @@ results.do({|dict|
 			} {
 				header = makeRed.(header);
 			};
-			groupMsg = "\t%\t% (%s)".format(header, name, (dict[\duration] ? 0).round(0.01)).postln;
+			groupMsg = "\t%\t% (%s)".format(header, name, (dict[\duration] ? 0).round(timeRes)).postln;
 			dict[\results].do({|resDict|
 				if(resDict[\pass]) {
 					header = makeGreen.("*");
@@ -80,15 +82,15 @@ results.do({|dict|
 			})
 		};
 		if(dict[\completed] != true) {
-			"\t%\t% did not complete%".format(makeRed.("[!]"), name, if(dict[\duration].notNil) {" (%s)".format(dict[\duration].round(0.01))} {""}).postln;
+			"\t%\t% did not complete%".format(makeRed.("[!]"), name, if(dict[\duration].notNil) {" (%s)".format(dict[\duration].round(timeRes))} {""}).postln;
 			failed = failed + 1;
-			failedList.add("\t%\t% did not complete%".format(makeRed.("[!]"), name, if(dict[\duration].notNil) {" (%s)".format(dict[\duration].round(0.01))} {""}));
+			failedList.add("\t%\t% did not complete%".format(makeRed.("[!]"), name, if(dict[\duration].notNil) {" (%s)".format(dict[\duration].round(timeRes))} {""}));
 		} {
 			if(allResults == 0) { // marked as completed, but no results were recorded...
 				// "\t%\t% (%s)".format(makeRed.("[!]"), name, (dict[\duration] ? 0).round(0.01)).postln;
 				// failed = failed + 1;
 				// tests that didn't produce any results didn't necessarily fail (e.g. TestSerialPort on macOS)
-				"\t%\t% did not produce any results%".format(makeYellow.("[?]"), name, if(dict[\duration].notNil) {" (%s)".format(dict[\duration].round(0.01))} {""}).postln;
+				"\t%\t% did not produce any results%".format(makeYellow.("[?]"), name, if(dict[\duration].notNil) {" (%s)".format(dict[\duration].round(timeRes))} {""}).postln;
 			}
 		}
 	};
@@ -107,6 +109,20 @@ if(failed > 0) {
 	"\t%, %".format(makeGreen.("% TESTS PASSED".format(passed)), makeYellow.("% skipped".format(skipped))).postln;
 	"\t------------------------------".postln;
 };
+
+"".postln;
+"Longest running tests:\n".postln;
+"\t------------------------------".postln;
+results = results.select{|d| d[\duration].notNil};
+results = results.sort{|l, r| l[\duration] > r[\duration] };
+results[0..30].do { |dict|
+	"\t%\t%".format(
+		makeBold.("%:%".format(dict[\suite], dict[\test])),
+		makeRed.(dict[\duration])
+	).postln;
+};
+"\t------------------------------".postln;
+
 
 if(exitWhenDone) {(failed > 0).asInteger.exit};
 

--- a/testsuite/scripts/print_results.scd
+++ b/testsuite/scripts/print_results.scd
@@ -104,15 +104,12 @@ results.do({|dict|
 
 "".postln;
 "\t------------------------------".postln;
-"Longest running tests:\n".postln;
+"Longest running tests:".postln;
 results.select{ |d| d[\duration].notNil}
 	.sort{ |l, r| l[\duration] > r[\duration] }
 	.keep(numSlowestTestToDisplay)
 	.do { |dict|
-		"\t%\t%".format(
-			makeBold.("%:%".format(dict[\suite], dict[\test])),
-			makeRed.(roundTime.(dict[\duration]))
-		).postln;
+		makeBold.("\t%:%".format(dict[\suite], dict[\test])).pad(50) ++ makeRed.(roundTime.(dict[\duration])).postln;
 	}
 ;
 "\t------------------------------".postln;


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

Lets us see what takes a long time quickly
linux
```
Longest running tests:
	------------------------------
	TestCoreUGens:test_muladd	10.927407026291
	TestReblock:test_IOUGensWithReblocking	9.3519344329834
	TestCoreUGens:test_ugen_generator_equivalences	9.1730098724365
	TestResample:test_IOUGensWithResampling	8.9819416999817
	TestSerialPort:test_rxErrors_bufferOverflow	8.8854944705963
	TestPV_ChainUGen:test_whiteframe_noop	7.818101644516
	TestCoreUGens:test_oscillators_startAtCorrectPhase	7.6269097328186
	TestUGen_RTAlloc:test_allUGens_allocPass	5.8858337402344
	TestUnitCommand:test_asynchronousUnitCommandInSupernova	5.697847366333
	TestServer_boot:test_rebootOffServer	5.0078065395355
	TestUGen_RTAlloc:test_allUGens_allocFail	4.996435880661
	TestUnitCommand:test_asynchronousUnitCommandInScsynth	4.9659898281097
	TestPluginCommand:test_asyncPluginCommandInSupernova	4.6461930274963
	TestNodeProxy_Server:test_schedAfterFade_afterQuant	4.5878174304962
	TestEnvGen_server:test_trig_gate_nonsustain_env	4.5546383857727
	TestPluginCommand:test_asyncPluginCommandInScsynth	3.9308972358704
	TestCoreUGens:test_impulse	3.9222793579102
	TestSynthDefVersions_Server:test_supernovaLoadsAllSynthDefVersions	3.8324584960938
	TestPV_ChainUGen:test_whiteframe_zeroing	3.6876583099365
	TestServer_boot:test_rebootRunningServer	3.6440603733063
	TestSynthDefVersions_Server:test_supernovaHandlesCorruptSynthDefs	3.6406016349792
	TestUnitCommand:test_synchronousUnitCommandInSupernova	3.5306947231293
	TestCoreUGens:test_pitchtrackers	3.4586033821106
	TestSynthDefVersions_Server:test_scsynthLoadsAllSynthDefVersions	3.1277573108673
	TestVolume:test_remoteSetVolume	3.095531463623
	TestLinkUGens:test_phase	3.0810575485229
	TestNodeProxy_Server:test_schedAfterFade_notBeforeQuant	2.9495484828949
	TestServer:test_syncAll	2.9197700023651
	TestServer_boot:test_notifyAndServerTreeActions	2.8687388896942
	TestUnitCommand:test_synchronousUnitCommandInScsynth	2.8508129119873
	TestServer_boot:test_notifyAndServerBootActions	2.8415672779083
	------------------------------
```
mac
```
Longest running tests:

	------------------------------
	TestResample:test_IOUGensWithResampling	7.9305810928345
	TestReblock:test_IOUGensWithReblocking	7.7926700115204
	TestCoreUGens:test_muladd	6.5688638687134
	TestPV_ChainUGen:test_whiteframe_noop	5.6800258159637
	TestCoreUGens:test_ugen_generator_equivalences	5.6225988864899
	TestUnitCommand:test_asynchronousUnitCommandInScsynth	5.3407349586487
	TestCoreUGens:test_oscillators_startAtCorrectPhase	5.2976701259613
	TestUnitCommand:test_asynchronousUnitCommandInSupernova	5.1864111423492
	TestBuffer_Server:test_getToFloatArray	5.0313110351562
	TestServer_boot:test_rebootOffServer	5.0145599842072
	TestNodeProxy_Server:test_schedAfterFade_afterQuant	4.7545170783997
	TestPluginCommand:test_asyncPluginCommandInScsynth	4.2015030384064
	TestPluginCommand:test_asyncPluginCommandInSupernova	4.1000289916992
	TestUGen_RTAlloc:test_allUGens_allocPass	4.0557188987732
	TestServer_boot:test_rebootRunningServer	3.7850592136383
	TestUGen_RTAlloc:test_allUGens_allocFail	3.4408829212189
	TestSynthDefVersions_Server:test_supernovaHandlesCorruptSynthDefs	3.4257500171661
	TestLinkUGens:test_phase	3.3106219768524
	TestCoreUGens:test_impulse	3.2646110057831
	TestSynthDefVersions_Server:test_supernovaLoadsAllSynthDefVersions	3.23495221138
	TestSynthDefVersions_Server:test_scsynthLoadsAllSynthDefVersions	3.1395490169525
	TestServer_boot:test_notifyAndServerBootActions	3.1295161247253
	TestSynthDefVersions_Server:test_scsynthHandlesCorruptSynthDefs	3.1225159168243
	TestServer_boot:test_waitForBoot	3.1150190830231
	TestUnitCommand:test_synchronousUnitCommandInScsynth	3.1126358509064
	TestVolume:test_remoteSetVolume	3.1110939979553
	TestUnitCommand:test_synchronousUnitCommandInSupernova	3.0592691898346
	TestPV_ChainUGen:test_whiteframe_zeroing	3.0046548843384
	TestNodeProxy_Server:test_schedAfterFade_notBeforeQuant	2.9615910053253
	TestServer:test_syncAll	2.9406719207764
	TestCoreUGens:test_bufugens	2.8510007858276
	------------------------------
```

windows
```
Longest running tests:

	------------------------------
	TestCoreUGens:test_muladd	10.957692861557
	TestCoreUGens:test_ugen_generator_equivalences	9.1679067611694
	TestResample:test_IOUGensWithResampling	8.9750854969025
	TestReblock:test_IOUGensWithReblocking	8.8466608524323
	TestPV_ChainUGen:test_whiteframe_noop	7.8392043113708
	TestCoreUGens:test_oscillators_startAtCorrectPhase	7.6546423435211
	TestUGen_RTAlloc:test_allUGens_allocPass	5.8599202632904
	TestUGen_RTAlloc:test_allUGens_allocFail	5.0144770145416
	TestServer_boot:test_rebootOffServer	5.0070099830627
	TestUnitCommand:test_asynchronousUnitCommandInSupernova	4.8798158168793
	TestUnitCommand:test_asynchronousUnitCommandInScsynth	4.8624494075775
	TestNodeProxy_Server:test_schedAfterFade_afterQuant	4.4997639656067
	TestCoreUGens:test_impulse	3.9077422618866
	TestEnvGen_server:test_trig_gate_nonsustain_env	3.8510143756866
	TestPluginCommand:test_asyncPluginCommandInSupernova	3.8395125865936
	TestPluginCommand:test_asyncPluginCommandInScsynth	3.8198354244232
	TestServer_boot:test_rebootRunningServer	3.716459274292
	TestPV_ChainUGen:test_whiteframe_zeroing	3.5099258422852
	TestCoreUGens:test_pitchtrackers	3.3826892375946
	TestCoreUGens:test_bufugens	3.2427759170532
	TestVolume:test_remoteSetVolume	3.0722143650055
	TestLinkUGens:test_phase	3.0684733390808
	TestSynthDefVersions_Server:test_scsynthLoadsAllSynthDefVersions	3.0045523643494
	TestUnitCommand:test_synchronousUnitCommandInScsynth	3.0008852481842
	TestNodeProxy_Server:test_schedAfterFade_notBeforeQuant	2.9492883682251
	TestSynthDefVersions_Server:test_supernovaLoadsAllSynthDefVersions	2.9418246746063
	TestUGen_RTAlloc:test_PVUGens	2.8931505680084
	TestServer_boot:test_notifyAndServerTreeActions	2.8929262161255
	TestServer_boot:test_notifyAndServerBootActions	2.8817512989044
	TestServer:test_syncAll	2.8771059513092
	TestUnitCommand:test_synchronousUnitCommandInSupernova	2.8483560085297
	------------------------------
```
## Types of changes

<!-- Delete lines that don't apply -->

- CI

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
