### PR TITLE
Typo corrections in `post_window.cpp`

### DIFF
--- a/HelpSource/Reference/gui.schelp
+++ b/HelpSource/Reference/gui.schelp
@@ -37,12 +37,12 @@ This is the default implementation for Object, and is thus the implementation fo
 definitionlist::
 ## parent ||
 list::
-## a Window,
-## a FlowView
-## CompositeVIew
-## HLayoutView
-## VLayoutView
-## nil (which will create a Window with a FlowView on it) 
+##  a Window,
+##  a FlowView
+##  CompositeVIew
+##  HLayoutView
+##  VLayoutView
+##  nil (which will create a Window with a FlowView on it) 
 ::
 ## bounds ||
 list::

--- a/HelpSource/Reference/gui.schelp
+++ b/HelpSource/Reference/gui.schelp
@@ -37,14 +37,15 @@ This is the default implementation for Object, and is thus the implementation fo
 definitionlist::
 ## parent ||
 list::
-##  a Window,
-##  a FlowView
-##  CompositeVIew
-##  HLayoutView
-##  VLayoutView
-##  nil (which will create a Window with a FlowView on it) 
+## a Window,
+## a FlowView
+## CompositeVIew
+## HLayoutView
+## VLayoutView
+## nil (which will create a Window with a FlowView on it) 
 ::
 ## bounds ||
+
 list::
 ## anything that responds to asRect:
 ## Nil - the gui will use its own default size

--- a/HelpSource/Reference/gui.schelp
+++ b/HelpSource/Reference/gui.schelp
@@ -45,7 +45,6 @@ list::
 ## nil (which will create a Window with a FlowView on it) 
 ::
 ## bounds ||
-
 list::
 ## anything that responds to asRect:
 ## Nil - the gui will use its own default size

--- a/editors/sc-ide/widgets/post_window.cpp
+++ b/editors/sc-ide/widgets/post_window.cpp
@@ -227,9 +227,7 @@ void PostWindow::post(const QString& text) {
 
                 if (const auto maybe_url = QUrl(word, QUrl::ParsingMode::StrictMode);
                     maybe_url.isValid() && word.contains("://")) {
-                    const QString href = maybe_url.toString(QUrl::PreferLocalFile);
-                    const QString text = word.toHtmlEscaped();
-                    cursor.insertHtml(QString("<a href='%1'>%2</a>").arg(href, text));
+                    cursor.insertHtml(QString("<a href='") + word + QString("'>") + word + QString("</a>"));
                 } else {
                     cursor.insertText(word, line_format);
                 }

--- a/editors/sc-ide/widgets/post_window.cpp
+++ b/editors/sc-ide/widgets/post_window.cpp
@@ -227,7 +227,9 @@ void PostWindow::post(const QString& text) {
 
                 if (const auto maybe_url = QUrl(word, QUrl::ParsingMode::StrictMode);
                     maybe_url.isValid() && word.contains("://")) {
-                    cursor.insertHtml(QString("<a href='") + word + QString("'>") + word + QString("<\\a>"));
+                    const QString href = maybe_url.toString(QUrl::FullyEncoded);
+                    const QString text = word.toHtmlEscaped();
+                    cursor.insertHtml(QString("<a href='%1'>%2</a>").arg(href, text));
                 } else {
                     cursor.insertText(word, line_format);
                 }

--- a/editors/sc-ide/widgets/post_window.cpp
+++ b/editors/sc-ide/widgets/post_window.cpp
@@ -227,7 +227,7 @@ void PostWindow::post(const QString& text) {
 
                 if (const auto maybe_url = QUrl(word, QUrl::ParsingMode::StrictMode);
                     maybe_url.isValid() && word.contains("://")) {
-                    const QString href = maybe_url.toString(QUrl::FullyEncoded);
+                    const QString href = maybe_url.toString(QUrl::PreferLocalFile);
                     const QString text = word.toHtmlEscaped();
                     cursor.insertHtml(QString("<a href='%1'>%2</a>").arg(href, text));
                 } else {


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->
closes: #7531
## Purpose and Motivation

Typo corrections in two files:

- **[EDT]** Fixed double spaces in `gui.schelp`. **(<- restored)**
- The change in `post_window.cpp` has been tested on macOS, Windows, and Ubuntu.
   **NOTE 1:** The last commit is flagged as “unsafe” by Microsoft Copilot, but the alternative it suggests does not work on Ubuntu.
   **NOTE 2:** The issue where mouse‑click navigation does not work on Windows is not caused by the modifications in this PR.
I tested the current development version [4d4e9ec], and the feature is also not working on Windows in that version.

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->

- Documentation
- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
