### PR TITLE
Fix keyboard shortcuts and font reset behavior in HelpBrowser

### DIFF
--- a/editors/sc-ide/widgets/help_browser.cpp
+++ b/editors/sc-ide/widgets/help_browser.cpp
@@ -197,6 +197,7 @@ void HelpBrowser::applySettings(Settings::Manager* settings) {
 
     mActions[ResetZoom]->setShortcut(settings->shortcut("editor-reset-font-size"));
 
+    mActions[Reload]->setShortcut(QKeySequence::Refresh);
     QList<QKeySequence> evalShortcuts;
     evalShortcuts.append(settings->shortcut("editor-eval-line"));
     evalShortcuts.append(QKeySequence(Qt::Key_Enter));

--- a/editors/sc-ide/widgets/help_browser.cpp
+++ b/editors/sc-ide/widgets/help_browser.cpp
@@ -183,8 +183,7 @@ void HelpBrowser::createActions() {
     };
     mActions[Back] = proxyPageAction(mWebView->pageAction(QWebEnginePage::Back));
     mActions[Forward] = proxyPageAction(mWebView->pageAction(QWebEnginePage::Forward));
-    mActions[Reload] = new QAction(tr("Reload"), this);
-    connect(mActions[Reload], &QAction::triggered, this, &HelpBrowser::onReload);
+    mActions[Reload] = proxyPageAction(mWebView->pageAction(QWebEnginePage::Reload));
 }
 
 void HelpBrowser::applySettings(Settings::Manager* settings) {
@@ -192,17 +191,11 @@ void HelpBrowser::applySettings(Settings::Manager* settings) {
 
     mActions[DocClose]->setShortcut(settings->shortcut("ide-document-close"));
 
-#    ifdef Q_OS_MAC
-    mActions[ZoomIn]->setShortcut(QKeySequence(Qt::META + Qt::Key_Equal));
-    mActions[ZoomOut]->setShortcut(QKeySequence(Qt::META + Qt::Key_Minus));
-    mActions[ResetZoom]->setShortcut(QKeySequence(Qt::META + Qt::Key_0));
-    mActions[Reload]->setShortcut(QKeySequence(Qt::META + Qt::Key_R));
-#    else
     mActions[ZoomIn]->setShortcut(settings->shortcut("editor-enlarge-font"));
+
     mActions[ZoomOut]->setShortcut(settings->shortcut("editor-shrink-font"));
+
     mActions[ResetZoom]->setShortcut(settings->shortcut("editor-reset-font-size"));
-    mActions[Reload]->setShortcut(QKeySequence::Refresh);
-#    endif
 
     QList<QKeySequence> evalShortcuts;
     evalShortcuts.append(settings->shortcut("editor-eval-line"));
@@ -326,24 +319,12 @@ bool HelpBrowser::eventFilter(QObject* object, QEvent* event) {
 
             QKeySequence sequence = OverridingAction::keySequence(kevent);
 
-            // HelpBrowser 액션 확인 (Reload 제외)
             for (int i = 0; i < ActionCount; ++i) {
-                if (i == Reload)
-                    continue;
                 if (mActions[i] && mActions[i]->shortcuts().contains(sequence)) {
                     event->accept();
                     return true;
                 }
             }
-
-            // Reload는 HelpBrowser 포커스 시에만
-            if (mActions[Reload] && mActions[Reload]->shortcuts().contains(sequence)) {
-                if (helpBrowserHasFocus()) {
-                    event->accept();
-                    return true;
-                }
-            }
-
             break;
         }
         default:

--- a/editors/sc-ide/widgets/help_browser.cpp
+++ b/editors/sc-ide/widgets/help_browser.cpp
@@ -157,7 +157,7 @@ void HelpBrowser::createActions() {
     ovrAction->addToWidget(this);
 
     mActions[ResetZoom] = ovrAction = new OverridingAction(tr("Reset Zoom"), this);
-    connect(ovrAction, &QAction::triggered, this, &HelpBrowser::zoomOut);
+    connect(ovrAction, &QAction::triggered, this, &HelpBrowser::resetZoom);
     ovrAction->addToWidget(this);
 
     // eval actions are added to mWebView->focusProxy() in onPageLoad()

--- a/editors/sc-ide/widgets/help_browser.cpp
+++ b/editors/sc-ide/widgets/help_browser.cpp
@@ -183,7 +183,8 @@ void HelpBrowser::createActions() {
     };
     mActions[Back] = proxyPageAction(mWebView->pageAction(QWebEnginePage::Back));
     mActions[Forward] = proxyPageAction(mWebView->pageAction(QWebEnginePage::Forward));
-    mActions[Reload] = proxyPageAction(mWebView->pageAction(QWebEnginePage::Reload));
+    mActions[Reload] = new QAction(tr("Reload"), this);
+    connect(mActions[Reload], &QAction::triggered, this, &HelpBrowser::onReload);
 }
 
 void HelpBrowser::applySettings(Settings::Manager* settings) {
@@ -191,16 +192,16 @@ void HelpBrowser::applySettings(Settings::Manager* settings) {
 
     mActions[DocClose]->setShortcut(settings->shortcut("ide-document-close"));
 
-    mActions[ZoomIn]->setShortcut(settings->shortcut("editor-enlarge-font"));
-
-    mActions[ZoomOut]->setShortcut(settings->shortcut("editor-shrink-font"));
-
-    mActions[ResetZoom]->setShortcut(settings->shortcut("editor-reset-font-size"));
-
 #    ifdef Q_OS_MAC
-    mActions[Reload]->setShortcut(QKeySequence(Qt::META + Qt::Key_R)); // macOS: Cmd+R
+    mActions[ZoomIn]->setShortcut(QKeySequence(Qt::META + Qt::Key_Equal));
+    mActions[ZoomOut]->setShortcut(QKeySequence(Qt::META + Qt::Key_Minus));
+    mActions[ResetZoom]->setShortcut(QKeySequence(Qt::META + Qt::Key_0));
+    mActions[Reload]->setShortcut(QKeySequence(Qt::META + Qt::Key_R));
 #    else
-    mActions[Reload]->setShortcut(QKeySequence::Refresh); // Windows/Linux
+    mActions[ZoomIn]->setShortcut(settings->shortcut("editor-enlarge-font"));
+    mActions[ZoomOut]->setShortcut(settings->shortcut("editor-shrink-font"));
+    mActions[ResetZoom]->setShortcut(settings->shortcut("editor-reset-font-size"));
+    mActions[Reload]->setShortcut(QKeySequence::Refresh);
 #    endif
 
     QList<QKeySequence> evalShortcuts;
@@ -325,19 +326,27 @@ bool HelpBrowser::eventFilter(QObject* object, QEvent* event) {
 
             QKeySequence sequence = OverridingAction::keySequence(kevent);
 
+            // HelpBrowser 액션 확인 (Reload 제외)
             for (int i = 0; i < ActionCount; ++i) {
+                if (i == Reload)
+                    continue;
                 if (mActions[i] && mActions[i]->shortcuts().contains(sequence)) {
                     event->accept();
                     return true;
                 }
             }
+
+            // Reload는 HelpBrowser 포커스 시에만
+            if (mActions[Reload] && mActions[Reload]->shortcuts().contains(sequence)) {
+                if (helpBrowserHasFocus()) {
+                    event->accept();
+                    return true;
+                }
+            }
+
             break;
         }
-        default:
-            break;
-        }
-    }
-    return false;
+            return false;
 }
 
 void HelpBrowser::sendRequest(const QString& code) {

--- a/editors/sc-ide/widgets/help_browser.cpp
+++ b/editors/sc-ide/widgets/help_browser.cpp
@@ -315,8 +315,12 @@ bool HelpBrowser::eventFilter(QObject* object, QEvent* event) {
             break;
         }
         case QEvent::ShortcutOverride: {
-            event->accept();
-            return true;
+            QKeyEvent* kevent = static_cast<QKeyEvent*>(event);
+            if (kevent->key() == Qt::Key_Escape) {
+                event->accept();
+                return true;
+            }
+            break;
         }
         default:
             break;

--- a/editors/sc-ide/widgets/help_browser.cpp
+++ b/editors/sc-ide/widgets/help_browser.cpp
@@ -197,7 +197,12 @@ void HelpBrowser::applySettings(Settings::Manager* settings) {
 
     mActions[ResetZoom]->setShortcut(settings->shortcut("editor-reset-font-size"));
 
-    mActions[Reload]->setShortcut(QKeySequence::Refresh);
+#    ifdef Q_OS_MAC
+    mActions[Reload]->setShortcut(QKeySequence(Qt::META + Qt::Key_R)); // macOS: Cmd+R
+#    else
+    mActions[Reload]->setShortcut(QKeySequence::Refresh); // Windows/Linux
+#    endif
+
     QList<QKeySequence> evalShortcuts;
     evalShortcuts.append(settings->shortcut("editor-eval-line"));
     evalShortcuts.append(QKeySequence(Qt::Key_Enter));

--- a/editors/sc-ide/widgets/help_browser.cpp
+++ b/editors/sc-ide/widgets/help_browser.cpp
@@ -315,7 +315,9 @@ bool HelpBrowser::eventFilter(QObject* object, QEvent* event) {
             break;
         }
         case QEvent::ShortcutOverride: {
-            QKeyEvent* kevent = static_cast<QKeyEvent*>(event);
+            // check if any widget action shortcut matches the observed keyEvent
+            // if yes, capture the event, else, bubble up the event
+            auto keyEvent = static_cast<QKeyEvent*>(event);
 
             QKeySequence sequence = OverridingAction::keySequence(kevent);
 

--- a/editors/sc-ide/widgets/help_browser.cpp
+++ b/editors/sc-ide/widgets/help_browser.cpp
@@ -319,7 +319,7 @@ bool HelpBrowser::eventFilter(QObject* object, QEvent* event) {
             // if yes, capture the event, else, bubble up the event
             auto keyEvent = static_cast<QKeyEvent*>(event);
 
-            QKeySequence sequence = OverridingAction::keySequence(kevent);
+            auto sequence = OverridingAction::keySequence(keyEvent);
 
             for (int i = 0; i < ActionCount; ++i) {
                 if (mActions[i] && mActions[i]->shortcuts().contains(sequence)) {

--- a/editors/sc-ide/widgets/help_browser.cpp
+++ b/editors/sc-ide/widgets/help_browser.cpp
@@ -346,7 +346,11 @@ bool HelpBrowser::eventFilter(QObject* object, QEvent* event) {
 
             break;
         }
-            return false;
+        default:
+            break;
+        }
+    }
+    return false;
 }
 
 void HelpBrowser::sendRequest(const QString& code) {

--- a/editors/sc-ide/widgets/help_browser.cpp
+++ b/editors/sc-ide/widgets/help_browser.cpp
@@ -316,9 +316,14 @@ bool HelpBrowser::eventFilter(QObject* object, QEvent* event) {
         }
         case QEvent::ShortcutOverride: {
             QKeyEvent* kevent = static_cast<QKeyEvent*>(event);
-            if (kevent->key() == Qt::Key_Escape) {
-                event->accept();
-                return true;
+
+            QKeySequence sequence = OverridingAction::keySequence(kevent);
+
+            for (int i = 0; i < ActionCount; ++i) {
+                if (mActions[i] && mActions[i]->shortcuts().contains(sequence)) {
+                    event->accept();
+                    return true;
+                }
             }
             break;
         }


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->
closes: #7426, #7130, #6820, #6629

**NOTE:**
This PR was assisted by GitHub Copilot.

## Purpose and Motivation

This PR fixes the following:

- **Resetting font size in HelpBrowser**  
  - Before:  
    Pressing `Cmd + 0` (macOS) or `Ctrl + 0` (Windows) reduced the font size instead of resetting it.  
  - With this PR:  
    Pressing `Cmd + 0` (macOS) or `Ctrl + 0` (Windows) correctly resets the font size.

- **Keyboard shortcuts in code editors in HelpBrowser on macOS**  
  The following shortcuts now work as expected:  
  - `Cmd + B`  
  - `Cmd + M`  
  - `Cmd + Shift + M`  
  - `Cmd + Alt + M`  
  - `Cmd + T`  
  - `Cmd + Shift + T`  
  - `Cmd + Alt + T`  
  - `Cmd + I`  
  - `Cmd + Shift + P`  
  - `Cmd + Shift + L`  
  - `Cmd + D`

The following issues are **not** fixed by this PR:

- On macOS, `Cmd + R` in the HelpBrowser code editors does not refresh the document. 
- On macOS, `Cmd + 0`, `Cmd + =`, and `Cmd + -` do not change the font size inside the code editor areas.  
  (These shortcuts work correctly outside the code editor.)

These issues should be addressed in a separate PR.

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
