### PR TITLE
Fix bare `\r` and clean up formatting

### DIFF
--- a/examples/demonstrations/bit_reduction.scd
+++ b/examples/demonstrations/bit_reduction.scd
@@ -5,21 +5,10 @@
 //--samplerate decrease
 (
 {	var snd = Blip.ar(LFNoise2.kr(8, 200, 300), LFNoise2.kr(3, 10, 20));
-
-
-
-
 	var samplerate = MouseX.kr(1000, s.sampleRate * 0.1, \exponential);
 	Latch.ar(snd, Impulse.ar(samplerate));
- }.play;
+}.play;
 )
-
-
-
-
-
-
-
 
 //--bitrate decrease
 (

--- a/examples/demonstrations/bit_reduction.scd
+++ b/examples/demonstrations/bit_reduction.scd
@@ -4,9 +4,30 @@
 
 //--samplerate decrease
 (
-{	var snd = Blip.ar(LFNoise2.kr(8, 200, 300), LFNoise2.kr(3, 10, 20));	var samplerate = MouseX.kr(1000, s.sampleRate * 0.1, \exponential);	Latch.ar(snd, Impulse.ar(samplerate)); }.play;)
+{	var snd = Blip.ar(LFNoise2.kr(8, 200, 300), LFNoise2.kr(3, 10, 20));
+
+
+
+
+	var samplerate = MouseX.kr(1000, s.sampleRate * 0.1, \exponential);
+	Latch.ar(snd, Impulse.ar(samplerate));
+ }.play;
+)
+
+
+
+
+
+
+
 
 //--bitrate decrease
 (
 {	var snd = Blip.ar(LFNoise2.kr(8, 200, 300), LFNoise2.kr(3, 10, 20));
-	var samplerate = MouseX.kr(1000, s.sampleRate * 0.5, \exponential);	var bitSize = MouseY.kr(1, 24, \exponential);	var downsamp = Latch.ar(snd, Impulse.ar(samplerate));	var bitRedux = downsamp.round(0.5 ** bitSize);	[downsamp, bitRedux];}.play)
+	var samplerate = MouseX.kr(1000, s.sampleRate * 0.5, \exponential);
+	var bitSize = MouseY.kr(1, 24, \exponential);
+	var downsamp = Latch.ar(snd, Impulse.ar(samplerate));
+	var bitRedux = downsamp.round(0.5 ** bitSize);
+	[downsamp, bitRedux];
+}.play
+)


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation
While trying to understand #7510, I found an `.scd` file in the `examples/demonstrations` folder that contains a bare `\r` (i.e., `\r(?!\n)`).  
I replaced the first `\r` with `\n`, but the file also had multiple consecutive empty lines and a single indentation issue.  
This PR fixes these problems.  
I kept the two commits separate to show the individual correction steps.

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->

- Documentation

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation (Example scd)
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
