### PR TITLE
scide: fix highlight selection by querying javascript, rather than QWebEngineView

### DIFF
--- a/editors/sc-ide/widgets/help_browser.cpp
+++ b/editors/sc-ide/widgets/help_browser.cpp
@@ -381,13 +381,12 @@ void HelpBrowser::evaluateSelection(bool evaluateRegion) {
         if (!selection.isEmpty()) {
             Main::scProcess()->evaluateCode(selection);
         } else {
-            mWebView->page()->runJavaScript(evaluateRegion ? jsSelectRegion : jsSelectLine,
-                                            [](QVariant res) {
-                                                QString selectionResult = res.toString();
-                                                if (!selectionResult.isEmpty()) {
-                                                    Main::scProcess()->evaluateCode(selectionResult);
-                                                }
-                                            });
+            mWebView->page()->runJavaScript(evaluateRegion ? jsSelectRegion : jsSelectLine, [](QVariant res) {
+                QString selectionResult = res.toString();
+                if (!selectionResult.isEmpty()) {
+                    Main::scProcess()->evaluateCode(selectionResult);
+                }
+            });
         }
     });
 }

--- a/editors/sc-ide/widgets/help_browser.cpp
+++ b/editors/sc-ide/widgets/help_browser.cpp
@@ -21,7 +21,6 @@
 #ifdef SC_USE_QTWEBENGINE
 
 #    define QT_NO_DEBUG_OUTPUT
-
 #    include "help_browser.hpp"
 #    include "main_window.hpp"
 #    include "../core/sc_process.hpp"
@@ -32,6 +31,7 @@
 #    include <SC_Filesystem.hpp>
 #    include "standard_dirs.hpp"
 
+#    include <qvariant.h>
 #    include <QVBoxLayout>
 #    include <QToolBar>
 #    include <QAction>
@@ -376,17 +376,20 @@ void HelpBrowser::evaluateSelection(bool evaluateRegion) {
     static const QString jsSelectLine("selectLine()");
     static const QString jsSelectRegion("selectRegion()");
 
-    QString selected = mWebView->selectedText();
-    if (!selected.isEmpty()) {
-        Main::scProcess()->evaluateCode(selected);
-    } else {
-        mWebView->page()->runJavaScript(evaluateRegion ? jsSelectRegion : jsSelectLine, [this](QVariant res) {
-            QString selectionResult = res.toString();
-            if (!selectionResult.isEmpty()) {
-                Main::scProcess()->evaluateCode(selectionResult);
-            }
-        });
-    }
+    mWebView->page()->runJavaScript("window.getSelection().toString()", [this, evaluateRegion](const QVariant& res) {
+        QString selection = res.toString();
+        if (!selection.isEmpty()) {
+            Main::scProcess()->evaluateCode(selection);
+        } else {
+            mWebView->page()->runJavaScript(evaluateRegion ? jsSelectRegion : jsSelectLine,
+                                            [this, evaluateRegion](QVariant res) {
+                                                QString selectionResult = res.toString();
+                                                if (!selectionResult.isEmpty()) {
+                                                    Main::scProcess()->evaluateCode(selectionResult);
+                                                }
+                                            });
+        }
+    });
 }
 
 void HelpBrowser::onJsConsoleMsg(const QString& arg1, int arg2, const QString& arg3) {

--- a/editors/sc-ide/widgets/help_browser.cpp
+++ b/editors/sc-ide/widgets/help_browser.cpp
@@ -382,7 +382,7 @@ void HelpBrowser::evaluateSelection(bool evaluateRegion) {
             Main::scProcess()->evaluateCode(selection);
         } else {
             mWebView->page()->runJavaScript(evaluateRegion ? jsSelectRegion : jsSelectLine,
-                                            [this, evaluateRegion](QVariant res) {
+                                            [](QVariant res) {
                                                 QString selectionResult = res.toString();
                                                 if (!selectionResult.isEmpty()) {
                                                     Main::scProcess()->evaluateCode(selectionResult);


### PR DESCRIPTION
…## Purpose and Motivation

Fixes #7544

The highlighted selection wasn't updating in the help browser, don't know why, this just bypasses the qt stuff and goes straight to javascript. 

Tested on linux, @prko, don't suppose you'd mind giving this a whirl?
## Types of changes

<!-- Delete lines that don't apply -->

- Documentation
- Bug fix
- New feature
- Breaking change

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
