### PR TITLE
sclang: undefined primitives shouldn't be errors

### DIFF
--- a/lang/LangSource/PyrParseNode.cpp
+++ b/lang/LangSource/PyrParseNode.cpp
@@ -1605,32 +1605,32 @@ void PyrMethodNode::compile(PyrSlot* result) {
 
     if (mPrimitiveName) {
         auto prim = gPrimitiveTable.table[methraw->specialIndex];
-        if (prim.func == undefinedPrimitive) {
-            error("Method %s:%s has an undefined primitive.\n",
-                  slotRawSymbol(&slotRawClass(&method->ownerclass)->name)->name, slotRawSymbol(&method->name)->name);
-            nodePostErrorLine((PyrParseNode*)mPrimitiveName);
-            compileErrors++;
-        }
+        // Having an undefined primitive is not an error because we often want ship the whole class library but not
+        // include things like qt.
+        if (prim.func != undefinedPrimitive) {
+            if (prim.numNormalArguments != numArgs) {
+                error("Method %s:%s's number of arguments does not match the primitive.\n",
+                      slotRawSymbol(&slotRawClass(&method->ownerclass)->name)->name,
+                      slotRawSymbol(&method->name)->name);
+                nodePostErrorLine((PyrParseNode*)mPrimitiveName);
+                compileErrors++;
+            }
 
-        if (prim.numNormalArguments != numArgs) {
-            error("Method %s:%s's number of arguments does not match the primitive.\n",
-                  slotRawSymbol(&slotRawClass(&method->ownerclass)->name)->name, slotRawSymbol(&method->name)->name);
-            nodePostErrorLine((PyrParseNode*)mPrimitiveName);
-            compileErrors++;
-        }
+            if (prim.hasVariablePositionalArguments && methraw->numVariableArguments < 1) {
+                error("Primitive has variable arguments but method %s:%s does not.\n",
+                      slotRawSymbol(&slotRawClass(&method->ownerclass)->name)->name,
+                      slotRawSymbol(&method->name)->name);
+                nodePostErrorLine((PyrParseNode*)mPrimitiveName);
+                compileErrors++;
+            }
 
-        if (prim.hasVariablePositionalArguments && methraw->numVariableArguments < 1) {
-            error("Primitive has variable arguments but method %s:%s does not.\n",
-                  slotRawSymbol(&slotRawClass(&method->ownerclass)->name)->name, slotRawSymbol(&method->name)->name);
-            nodePostErrorLine((PyrParseNode*)mPrimitiveName);
-            compileErrors++;
-        }
-
-        if (prim.hasVariableKeywordArguments && methraw->numVariableArguments < 2) {
-            error("Primitive has variable keyword arguments but method %s:%s does not.\n",
-                  slotRawSymbol(&slotRawClass(&method->ownerclass)->name)->name, slotRawSymbol(&method->name)->name);
-            nodePostErrorLine((PyrParseNode*)mPrimitiveName);
-            compileErrors++;
+            if (prim.hasVariableKeywordArguments && methraw->numVariableArguments < 2) {
+                error("Primitive has variable keyword arguments but method %s:%s does not.\n",
+                      slotRawSymbol(&slotRawClass(&method->ownerclass)->name)->name,
+                      slotRawSymbol(&method->name)->name);
+                nodePostErrorLine((PyrParseNode*)mPrimitiveName);
+                compileErrors++;
+            }
         }
     }
 

--- a/testsuite/classlibrary/TestPrimitive.sc
+++ b/testsuite/classlibrary/TestPrimitive.sc
@@ -16,6 +16,11 @@ TestPrimitive_Obj {
 		1 + 1;
 		^this.primitiveFailed
 	}
+
+	//  This should still compile and not crash even though _Meow does not exist
+	undefinedPrimitive {
+		_Meow
+	}
 }
 
 TestPrimitive_Obj_NoError {
@@ -108,5 +113,10 @@ TestPrimitives : UnitTest {
 	test_kw_with_var_args {
 		this.with_kw_and_var_args(TestPrimitive_Obj());
 		this.with_kw_and_var_args(TestPrimitive_Obj_NoError());
+	}
+	test_undefined {
+		var a = TestPrimitive_Obj();
+		// should not crash, will post error.
+		a.undefinedPrimitive;
 	}
 }


### PR DESCRIPTION
We want to ship the whole class library but the runtime might not include the primitives to actually run it (this happens with qt). This makes calling undefined primitives a runtime error, not a compile time one.

This way, the error occurs not when some one writes gui code in a headless build, but when the user tries to display it.

<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [ ] Code is tested
- [ ] All tests are passing
- [ ] Updated documentation
- [ ] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
