### PR TITLE
build: expose static plugins as a build option

### DIFF
--- a/.github/workflows/build_wasm.yml
+++ b/.github/workflows/build_wasm.yml
@@ -41,6 +41,7 @@ jobs:
             -DSUPERNOVA=no \
             -DSC_HIDAPI=no \
             -DNO_LIBSNDFILE=yes \
+            -DSTATIC_PLUGINS=yes \
             -DSC_QT=no \
             -DNO_AVAHI=yes \
             -DSC_ABLETON_LINK=no \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,6 +96,7 @@ if (AUDIOAPI STREQUAL jack)
 endif()
 
 option(LIBSCSYNTH "Compile libscsynth as shared library" OFF)
+option(STATIC_PLUGINS "Compile plugins as static libraries (scsynth only)" OFF)
 
 option(INSTALL_HELP "Install help docs and examples along with the software" ON)
 option(SC_DOC_RENDER "Pre-render SCDoc documentation. (For putting online, etc)" OFF)

--- a/README_WASM.md
+++ b/README_WASM.md
@@ -116,6 +116,7 @@ emcmake cmake \
   -DSUPERNOVA=no \
   -DSC_HIDAPI=no \
   -DNO_LIBSNDFILE=yes \
+  -DSTATIC_PLUGINS=yes \
   -DSC_QT=no \
   -DNO_AVAHI=yes \
   -DSC_ABLETON_LINK=no \

--- a/server/plugins/CMakeLists.txt
+++ b/server/plugins/CMakeLists.txt
@@ -89,9 +89,11 @@ endif()
 
 if(NOT NO_X11)
 	if (APPLE)
-		add_library(UIUGens MODULE UIUGens.mm)
+		set(ui_sources UIUGens.mm)
+		add_library(UIUGens MODULE ${ui_sources})
 	else()
-		add_library(UIUGens MODULE UIUGens.cpp)
+		set(ui_sources UIUGens.cpp)
+		add_library(UIUGens MODULE ${ui_sources})
 		target_link_libraries(UIUGens PRIVATE ${PTHREADS_LIBRARY})
 	endif()
 
@@ -376,11 +378,13 @@ set_property(TARGET ${plugins} ${supernova_plugins} PROPERTY FOLDER UnitGenerato
 set(plugins "${plugins}" PARENT_SCOPE)
 set(supernova_plugins "${supernova_plugins}" PARENT_SCOPE)
 
-if(EMSCRIPTEN)
+if(STATIC_PLUGINS)
 	set(all_plugin_sources
 		${plugin_sources}
 		${FFT_sources}
 		${PV_ThirdParty_sources}
 		${ML_sources}
+		${diskio_sources}
+		${ui_sources}
 	PARENT_SCOPE)
 endif()

--- a/server/scsynth/CMakeLists.txt
+++ b/server/scsynth/CMakeLists.txt
@@ -147,24 +147,25 @@ elseif (AUDIOAPI STREQUAL bela)
 elseif (AUDIOAPI STREQUAL webaudio)
     add_definitions(
             "-DSC_AUDIO_API=SC_AUDIO_API_WEBAUDIO"
-            "-DSTATIC_PLUGINS"
     )
     list(REMOVE_ITEM scsynth_sources
             SC_ComPort.cpp
             ${CMAKE_SOURCE_DIR}/common/SC_Reply.cpp
     )
+    list(APPEND scsynth_sources
+            SC_WebAudio.cpp
+            ${CMAKE_SOURCE_DIR}/platform/wasm/SC_WebOsc.cpp
+    )
+endif()
+
+if(STATIC_PLUGINS)
     # the plugins are linked statically, their sources must be included
     set(plugin_sources_abs "")
     foreach(plugin ${all_plugin_sources})
         string(CONCAT plugin_abs ${CMAKE_SOURCE_DIR}/server/plugins/ ${plugin} )
         list(APPEND plugin_sources_abs ${plugin_abs})
     endforeach(plugin)
-
-    list(APPEND scsynth_sources
-            SC_WebAudio.cpp
-            ${CMAKE_SOURCE_DIR}/platform/wasm/SC_WebOsc.cpp
-            ${plugin_sources_abs}
-    )
+    list(APPEND scsynth_sources ${plugin_sources_abs})
 endif()
 
 set (FINAL_BUILD 0) # disable final build for scsynth
@@ -226,6 +227,13 @@ endif()
 
 if(UNIX AND NOT APPLE)
 	target_compile_definitions(libscsynth PUBLIC "SC_PLUGIN_DIR=\"${LINUX_SC_PLUGIN_DIR}\"")
+endif()
+
+if(STATIC_PLUGINS)
+    target_compile_definitions(libscsynth PRIVATE "-DSTATIC_PLUGINS")
+endif()
+if(NO_X11)
+	target_compile_definitions(libscsynth PRIVATE "-DNO_X11")
 endif()
 
 if(NOT NO_AVAHI)

--- a/server/scsynth/SC_Lib_Cintf.cpp
+++ b/server/scsynth/SC_Lib_Cintf.cpp
@@ -118,7 +118,7 @@ extern void Pan_Load(InterfaceTable* table);
 extern void Reverb_Load(InterfaceTable* table);
 extern void Trigger_Load(InterfaceTable* table);
 extern void UnaryOp_Load(InterfaceTable* table);
-#    ifndef __EMSCRIPTEN__
+#    ifndef NO_LIBSNDFILE
 extern void DiskIO_Load(InterfaceTable* table);
 #    endif
 extern void Test_Load(InterfaceTable* table);
@@ -128,14 +128,20 @@ extern void DynNoise_Load(InterfaceTable* table);
 extern void FFT_UGens_Load(InterfaceTable* table);
 extern void iPhone_Load(InterfaceTable* table);
 
+#    ifndef NO_LIBSNDFILE
 extern void DiskIO_Unload(void);
+#    endif
+#    ifndef NO_X11
 extern void UIUGens_Unload(void);
+#    endif
 #endif // STATIC_PLUGINS
 
 void deinitialize_library() {
 #ifdef STATIC_PLUGINS
-#    ifndef __EMSCRIPTEN__
+#    ifndef NO_LIBSNDFILE
     DiskIO_Unload();
+#    endif
+#    ifndef NO_X11
     UIUGens_Unload();
 #    endif
 #endif // STATIC_PLUGINS
@@ -186,7 +192,7 @@ void initialize_library(const char* uGensPluginPath) {
     Reverb_Load(&gInterfaceTable);
     Trigger_Load(&gInterfaceTable);
     UnaryOp_Load(&gInterfaceTable);
-#    ifndef __EMSCRIPTEN__
+#    ifndef NO_LIBSNDFILE
     DiskIO_Load(&gInterfaceTable);
 #    endif
     PhysicalModeling_Load(&gInterfaceTable);


### PR DESCRIPTION

<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

This PR builds on the recently re-enabled static plugins option in the wasm build.

I'd like to propose exposing static plugins option in cmake. I'm not sure if we need it for anything else, but I think this is cleaner from the logical standpoint than the current implementation.

## Types of changes

<!-- Delete lines that don't apply -->

- Documentation
- New feature (e.g. build scsynth with static plugins on macOS)

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
