### PR TITLE
supernova: n_order applying the add action to every node

### DIFF
--- a/server/supernova/sc/sc_osc_handler.cpp
+++ b/server/supernova/sc/sc_osc_handler.cpp
@@ -1749,6 +1749,7 @@ void handle_n_order(ReceivedMessage const& msg) {
         target_parent = static_cast<abstract_group*>(target);
     }
 
+    server_node* previous = nullptr;
     while (!args.Eos()) {
         osc::int32 node_id;
         args >> node_id;
@@ -1761,12 +1762,15 @@ void handle_n_order(ReceivedMessage const& msg) {
 
         /** TODO: this can be optimized if node_parent == target_parent */
         node_parent->remove_child(node);
-        if (action == before || action == after)
+        if (previous != nullptr)
+            target_parent->add_child(node, make_pair(previous, after));
+        else if (action == before || action == after)
             target_parent->add_child(node, make_pair(target, node_position(action)));
         else
             target_parent->add_child(node, node_position(action));
 
         instance->notification_node_moved(node);
+        previous = node;
     }
     instance->request_dsp_queue_update();
 }

--- a/testsuite/classlibrary/TestServer_nodeOrder.sc
+++ b/testsuite/classlibrary/TestServer_nodeOrder.sc
@@ -1,0 +1,61 @@
+TestServer_nodeOrder : UnitTest {
+
+	var pipe;
+
+	tearDown {
+		if (pipe.notNil) {
+			pipe.close;
+		};
+	}
+
+	orderAfter { |program, action, target, nodes|
+		var order = List[],
+			ip = "127.0.0.1",
+			port = 57110,
+			addr = NetAddr(ip, port),
+			line,
+			match;
+		pipe = Pipe.new(program ++ ServerOptions().bindAddress_(ip).asOptionsString(port), "r");
+		line = pipe.getLine;
+		while ({ line.notNil && line.contains("ready").not }) {
+			line = pipe.getLine;
+		};
+		addr.sendMsg("/g_new", 1000, 0, 0);
+		addr.sendMsg("/g_new", 1001, 3, 1000);
+		addr.sendMsg("/g_new", 1002, 3, 1001);
+		addr.sendMsg("/n_order", action, target, *nodes);
+		addr.sendMsg("/g_dumpTree", 0, 0);
+		addr.sendMsg("/quit");
+		line = pipe.getLine;
+		while ({ line.notNil }) {
+			match = line.findRegexp("^\\s+([0-9]+) group");
+			if (match.notEmpty and: { match[1][1].asInteger != 0 }) {
+				order.add(match[1][1].asInteger);
+			};
+			line = pipe.getLine;
+		};
+		pipe.close;
+		^ order
+	}
+
+	test_nOrder_head {
+		[Server.program, Server.program.replace("scsynth", "supernova")].do { |program|
+			this.assertEquals(
+				this.orderAfter(program, 0, 0, [1002, 1001, 1000]),
+				List[1002, 1001, 1000],
+				program.basename ++ " /n_order head should apply the listed order at the group head",
+			);
+		};
+	}
+
+	test_nOrder_after {
+		[Server.program, Server.program.replace("scsynth", "supernova")].do { |program|
+			this.assertEquals(
+				this.orderAfter(program, 3, 1000, [1002, 1001]),
+				List[1000, 1002, 1001],
+				program.basename ++ " /n_order after should chain the listed order behind the target",
+			);
+		};
+	}
+
+}


### PR DESCRIPTION
supernova applied the order action to every node in the list instead of only the first one, so head and after came out in the wrong order and the example in #3100 did not change at all. scsynth anchors the first node by the action then chains the rest after the previous one, this does the same.

added a test that checks the resulting order on scsynth and supernova so they stay in sync.

closes #3100