### PR TITLE
supernova: /notify reply not including the max logins

### DIFF
--- a/server/supernova/sc/sc_osc_handler.cpp
+++ b/server/supernova/sc/sc_osc_handler.cpp
@@ -234,6 +234,16 @@ void send_done_message(endpoint_ptr const& endpoint, const char* cmd, osc::int32
     }
 }
 
+void send_done_message(endpoint_ptr const& endpoint, const char* cmd, osc::int32 index, osc::int32 index2) {
+    if (endpoint) {
+        char buffer[1024];
+        osc::OutboundPacketStream p(buffer, 1024);
+        p << osc::BeginMessage("/done") << cmd << index << index2 << osc::EndMessage;
+
+        endpoint->send(p.Data(), p.Size());
+    }
+}
+
 void send_fail_message(endpoint_ptr const& endpoint, const char* cmd, const char* content) {
     if (endpoint) {
         char buffer[8192];
@@ -961,7 +971,7 @@ template <bool realtime> void handle_notify(ReceivedMessage const& message, endp
         }
 
         if (observer >= 0)
-            send_done_message(endpoint, "/notify", observer);
+            send_done_message(endpoint, "/notify", observer, (osc::int32)server_arguments::instance().max_logins);
     });
 }
 

--- a/server/supernova/server/server_args.cpp
+++ b/server/supernova/server/server_args.cpp
@@ -61,7 +61,7 @@ server_arguments::server_arguments(int argc, char* argv[]) {
         ("randomseeds,r", value<uint32_t>(&rng_count)->default_value(64), "number of random number generators")
         ("load-synthdefs,D", value<uint16_t>(&load_synthdefs)->default_value(1), "load synthdefs? (1 or 0)")
         ("rendezvous,R", value<uint16_t>()->default_value(1), "publish to Rendezvous? (1 or 0)")
-        ("max-logins,l", value<uint32_t>()->default_value(64), "maximum number of named return addresses")
+        ("max-logins,l", value<uint32_t>(&max_logins)->default_value(64), "maximum number of named return addresses")
         ("password,p", value<string>(&server_password)->default_value(""),
                                                             "When using TCP, the session password must be the first command sent.\n"
                                                             "The default is no password.\n"

--- a/server/supernova/server/server_args.hpp
+++ b/server/supernova/server/server_args.hpp
@@ -55,7 +55,7 @@ public:
     uint32_t control_busses, audio_busses;
     uint32_t blocksize, samplerate;
     int32_t hardware_buffer_size;
-    uint32_t buffers, max_nodes, max_synthdefs;
+    uint32_t buffers, max_nodes, max_synthdefs, max_logins;
     uint16_t use_system_clock;
 
     uint32_t rt_pool_size;

--- a/testsuite/classlibrary/TestServer_notifyReply.sc
+++ b/testsuite/classlibrary/TestServer_notifyReply.sc
@@ -1,0 +1,51 @@
+TestServer_notifyReply : UnitTest {
+
+	notifyReply { |program, port, logins = 1|
+		var ip = "127.0.0.1",
+			addr,
+			responder,
+			reply,
+			condvar = CondVar(),
+			gotReply = false,
+			attempts = 0;
+		(program ++ ServerOptions().maxLogins_(logins).bindAddress_(ip).asOptionsString(port)).unixCmd;
+		addr = NetAddr(ip, port);
+		responder = OSCFunc({ |msg| reply = msg; gotReply = true; condvar.signalOne }, '/done', addr);
+		// poll while the server boots: a /notify sent over UDP before the server
+		// is listening is simply dropped, so resend until the /done reply arrives.
+		// normally this takes about a second, the cap is a give-up for a server
+		// that never comes up (25 * 0.2s = 5s).
+		while ({ gotReply.not and: { attempts < 25 } }) {
+			addr.sendMsg("/notify", 1);
+			condvar.waitFor(0.2);
+			attempts = attempts + 1;
+		};
+		responder.free;
+		// resend /quit a few times: a single UDP packet can be dropped while the
+		// server is still finishing its boot, which would leave it running.
+		3.do { addr.sendMsg("/quit"); 0.05.wait };
+		^ reply
+	}
+
+	test_notifyReply_includesMaxLogins {
+		this.assertEquals(
+			(this.notifyReply(Server.program, 57398) ?? { [] }).size,
+			4,
+			"scsynth /done /notify reply should include the client ID and max logins"
+		);
+		this.assertEquals(
+			(this.notifyReply(Server.program.replace("scsynth", "supernova"), 57399) ?? { [] }).size,
+			4,
+			"supernova /done /notify reply should include the client ID and max logins"
+		);
+	}
+
+	test_notifyReply_reportsConfiguredMaxLogins {
+		this.assertEquals(
+			(this.notifyReply(Server.program.replace("scsynth", "supernova"), 57397, 7) ?? { [] })[3],
+			7,
+			"supernova /done /notify should report the configured max logins"
+		);
+	}
+
+}


### PR DESCRIPTION
scsynth replies to /notify with /done /notify clientID maxLogins but supernova only sent /done /notify clientID. the max-logins option was also never stored in supernova, the parser dropped it, so -l did nothing. now the option is read into the server arguments and the value is sent in the reply like scsynth.

added a test that checks the /done /notify reply on scsynth and supernova includes the max logins, and that the configured -l value is reported back.

closes #3337