### PR TITLE
gha: add timeout to post test results on Windows

### DIFF
--- a/.github/workflows/test_windows.yml
+++ b/.github/workflows/test_windows.yml
@@ -65,4 +65,4 @@ jobs:
       - name: Post test results
         shell: bash
         run: |
-          $SCLANG $SCRIPT_PRINT_RESULTS $TEST_LIST_RESULT
+          timeout 1m $SCLANG $SCRIPT_PRINT_RESULTS $TEST_LIST_RESULT


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

I noticed that if there's an error in posting on Windows, the test runner hangs (e.g. [here](https://github.com/supercollider/supercollider/actions/runs/27506237756/job/81298738591#step:7:9093)). 
Turns out we were missing a timeout guard on Windows, which is present on [Linux](https://github.com/supercollider/supercollider/blob/develop/.github/workflows/test_linux.yml#L66) and [macOS](https://github.com/supercollider/supercollider/blob/develop/.github/workflows/test_macos.yml#L62).

## Types of changes

<!-- Delete lines that don't apply -->


- Bug fix


## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [ ] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
