### PR TITLE
Help: fix search with UTF-8 characters

### DIFF
--- a/HelpSource/OldHelpWrapper.html
+++ b/HelpSource/OldHelpWrapper.html
@@ -19,7 +19,7 @@
     </style>
     <script>
         function checkHash() {
-            var urls = unescape(window.location.hash.slice(1)).split("?");
+            var urls = decodeURIComponent(window.location.hash.slice(1)).split("?");
             document.getElementById("oldframe").setAttribute("src", urls[0]);
             document.getElementById("newlink").setAttribute("href", urls[1]);
             document.getElementById("filename").innerHTML = urls[0];

--- a/HelpSource/Overviews/Methods.html
+++ b/HelpSource/Overviews/Methods.html
@@ -160,7 +160,7 @@ function showMethod(mname, node) {
 }
 
 function did_load() {
-    var hash = unescape(window.location.hash.slice(1));
+    var hash = decodeURIComponent(window.location.hash.slice(1));
 
     helpRoot=".."; fixTOC();
 
@@ -170,7 +170,7 @@ function did_load() {
 }
 
 function showmethods() {
-    var hash = unescape(window.location.hash.slice(1));
+    var hash = decodeURIComponent(window.location.hash.slice(1));
     var res = document.getElementById("methods");
     res.innerHTML = "";
 

--- a/HelpSource/static/browse.js
+++ b/HelpSource/static/browse.js
@@ -3,7 +3,7 @@ var path = [];
 
 function GotoPath(p) {
     path = p.split(">");
-    var x = escape(p);
+    var x = encodeURIComponent(p);
     if(window.location.hash != x)
         window.location.hash = x;
     updateTree();
@@ -168,9 +168,9 @@ window.onload = function() {
     filter.onchange = onChange;
 
     buildCategoryTree();
-    GotoPath(unescape(window.location.hash.slice(1)));
+    GotoPath(decodeURIComponent(window.location.hash.slice(1)));
 }
 
 window.onhashchange = function() {
-    GotoPath(unescape(window.location.hash.slice(1)));
+    GotoPath(decodeURIComponent(window.location.hash.slice(1)));
 }

--- a/HelpSource/static/search.js
+++ b/HelpSource/static/search.js
@@ -96,7 +96,7 @@ function onLoad() {
 }
 
 function checkHash() {
-    var x = unescape(window.location.hash.slice(1));
+    var x = decodeURIComponent(window.location.hash.slice(1));
     if(x!="" && newinput!=x) {
         document.getElementById("search_input").value = x;
         newinput = x;

--- a/SCClassLibrary/SCDoc/SCDoc.sc
+++ b/SCClassLibrary/SCDoc/SCDoc.sc
@@ -384,7 +384,7 @@ SCDocNode {
 SCDoc {
 
 	// Increment this whenever we make a change to the SCDoc system or its static files so that all help-files should be processed again
-	classvar version = 76;
+	classvar version = 77;
 
 	classvar <helpTargetDir;
 	classvar <helpTargetUrl;


### PR DESCRIPTION


<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

This fixes processing URIs in the help browser, so that UTF characters are passed down properly.

A LLM helped to track this down, indicating that JavaScript `unescape`/`escape` functions are deprecated and should be replaced by `(en|de)codeURIComponent`. This seems to be confirmed by the docs on the Mozilla website: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/unescape

I replaced all occurrences of `unescape`/`escape`, as it seems to be a straightforward maintenance step. I hope nothing else broke in this process :)

Fixes #7511

To test this, run any of the examples from the linked issue and confirm that the text in the help browser's search bar is displayed correctly.

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix


## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [n/a] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
