### PR TITLE
fix: wasm respect realTimeMemorySize option

### DIFF
--- a/server/scsynth/SC_WebAudio.cpp
+++ b/server/scsynth/SC_WebAudio.cpp
@@ -90,6 +90,7 @@ WorldOptions toScWorld(ScWebAudioOptions* userOptions) {
     options.mNumOutputBusChannels = userOptions->numOutputBusChannels;
     options.mNumControlBusChannels = userOptions->numControlBusChannels;
     options.mBufLength = userOptions->bufLength;
+    options.mRealTimeMemorySize = userOptions->realTimeMemorySize;
 
     // hardcoded options
     options.mLoadGraphDefs = false;


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

realTimeMemorySize exists technically but is ignored when set via scsynth.boot (js side)

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [ ] Code is tested
- [ ] All tests are passing
- [ ] Updated documentation
- [ ] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

not sure yet how to test properly. but this one line fix seems trivial

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
