### PR TITLE
class library: expose Pipe -pid

### DIFF
--- a/HelpSource/Classes/Pipe.schelp
+++ b/HelpSource/Classes/Pipe.schelp
@@ -51,6 +51,9 @@ Closes the pipe, waiting for the command to finish. You must do this explicitly 
 
 returns:: The exit status of the command (an Integer).
 
+method::pid
+returns:: The operating system's PID (process ID) of the executing command (an Integer).
+
 Examples::
 
 code::

--- a/SCClassLibrary/Common/Files/File.sc
+++ b/SCClassLibrary/Common/Files/File.sc
@@ -173,7 +173,7 @@ File : UnixFILE {
 
 
 Pipe : UnixFILE {
-	var pid;
+	var <pid;
 
 	// pipe stdin to, or stdout from, a unix shell command.
 	*new { arg commandLine, mode;


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

I think we should be able to get the PID of a command started with a Pipe.

I think I encountered this before; it came up again when I wanted to improve reliability of a [test that uses Pipe](https://github.com/supercollider/supercollider/blob/develop/testsuite/classlibrary/TestServer_dumpTree.sc#L20) to close the server process by PID, if we miss the OSC message.

I assume this is only an omission, I don't see why we shouldn't be able to query PID from an open Pipe...?

Tested on macOS only.

## Types of changes

<!-- Delete lines that don't apply -->

- Documentation
- New feature

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested (on macOS)
- [ ] All tests are passing
- [ ] Updated documentation
- [ ] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
