### PR TITLE
TestServer_dumpTree: switch to NRT server

### DIFF
--- a/testsuite/classlibrary/TestServer_dumpTree.sc
+++ b/testsuite/classlibrary/TestServer_dumpTree.sc
@@ -45,8 +45,7 @@ TestServer_dumpTree : UnitTest {
 				// ignore output until we see matching start
 				if (line.beginsWith("NODE TREE")) {nodeTreeOutputDectected = true};
 				// once we see matching beginning, capture output
-				// strip carriage return because of Windows
-				if (nodeTreeOutputDectected) {actualOutput.add(line.replace("\r", ""))};
+				if (nodeTreeOutputDectected) {actualOutput.add(line)};
 				// stop capturing when we see matching end
 				if (line.beginsWith("END NODE")) {nodeTreeOutputDectected = false};
 				line = logFile.getLine;

--- a/testsuite/classlibrary/TestServer_dumpTree.sc
+++ b/testsuite/classlibrary/TestServer_dumpTree.sc
@@ -22,14 +22,14 @@ TestServer_dumpTree : UnitTest {
 		// this overwrites the automatically created default group, so that we only get the root group in the output
 		score.score = ([
 			[0.0, ['/g_dumpTree', 0, 0]],
-			[0.1, [0]] // stop
+			[2.0, [0]] // stop
 		]);
 		// write osc score to a file
 		score.writeOSCFile(oscPath);
 		// construct the nrt command
 		cmd = "% -N % _ % 44100 AIFF int16 > % 2>&1".format(program, oscPath.quote, outPath.quote, logPath.quote);
 		// run command and capture output to a log file
-		pid = cmd.unixCmd({pid = nil; cond.signalOne});
+		pid = cmd.unixCmd({|e| "exit code: %\n".postf(e); pid = nil; cond.signalOne});
 		cond.waitFor(60);
 		// failsafe shutdown
 		pid !? {
@@ -44,6 +44,8 @@ TestServer_dumpTree : UnitTest {
 				line.postln; // inspect output
 				// ignore output until we see matching start
 				if (line.beginsWith("NODE TREE")) {nodeTreeOutputDectected = true};
+				// strip carriage return on Windows
+				if(thisProcess.platform.name == \windows) {line = line.replace("\r", "")};
 				// once we see matching beginning, capture output
 				if (nodeTreeOutputDectected) {actualOutput.add(line)};
 				// stop capturing when we see matching end

--- a/testsuite/classlibrary/TestServer_dumpTree.sc
+++ b/testsuite/classlibrary/TestServer_dumpTree.sc
@@ -28,8 +28,6 @@ TestServer_dumpTree : UnitTest {
 		score.writeOSCFile(oscPath);
 		// construct the nrt command
 		cmd = "% -N % _ % 44100 AIFF int16 > % 2>&1".format(program, oscPath.quote, outPath.quote, logPath.quote);
-		// protect against quote-stripping on Windows
-		if(thisProcess.platform.name == \windows) {cmd = cmd.quote};
 		// run command and capture output to a log file
 		pid = cmd.unixCmd({pid = nil; cond.signalOne});
 		cond.waitFor(60);
@@ -47,7 +45,8 @@ TestServer_dumpTree : UnitTest {
 				// ignore output until we see matching start
 				if (line.beginsWith("NODE TREE")) {nodeTreeOutputDectected = true};
 				// once we see matching beginning, capture output
-				if (nodeTreeOutputDectected) {actualOutput.add(line)};
+				// strip carriage return because of Windows
+				if (nodeTreeOutputDectected) {actualOutput.add(line.replace("\r", ""))};
 				// stop capturing when we see matching end
 				if (line.beginsWith("END NODE")) {nodeTreeOutputDectected = false};
 				line = logFile.getLine;

--- a/testsuite/classlibrary/TestServer_dumpTree.sc
+++ b/testsuite/classlibrary/TestServer_dumpTree.sc
@@ -1,21 +1,22 @@
 TestServer_dumpTree : UnitTest {
 
-	var pipe;
+	var pid;
 
 	setUp {
 	}
 
 	tearDown {
-		if (pipe.notNil) {
-			pipe.close;
-		};
+		pid !? {thisProcess.platform.killProcessByID(pid, true, true)};
 	}
 
 	getOutput { |program|
 		var actualOutput = List[],
 		oscPath = PathName.tmp +/+ "dumpTree_test.osc",
 		outPath = PathName.tmp +/+ "dummy_out.aiff",
-		cmd, line, score, nodeTreeOutputDectected = false;
+		logPath = PathName.tmp +/+ "nrt_output.log",
+		cond = CondVar(),
+		nodeTreeOutputDectected = false,
+		cmd, line, score, logFile;
 
 		score = Score();
 		// this overwrites the automatically created default group, so that we only get the root group in the output
@@ -26,25 +27,37 @@ TestServer_dumpTree : UnitTest {
 		// write osc score to a file
 		score.writeOSCFile(oscPath);
 		// construct the nrt command
-		cmd = "% -N % _ % 44100 AIFF int16".format(program, oscPath.quote, outPath.quote);
-		// run it and capture stdout
-		pipe = Pipe.new(cmd, "r");
-		line = pipe.getLine;
-		while ({ line.notNil }) {
-			line.postln; // inspect output
-			// ignore output until we see matching start
-			if (line.beginsWith("NODE TREE")) {nodeTreeOutputDectected = true};
-			// once we see matching beginning, capture output
-			if (nodeTreeOutputDectected) {actualOutput.add(line)};
-			// stop capturing when we see matching end
-			if (line.beginsWith("END NODE")) {nodeTreeOutputDectected = false};
-			line = pipe.getLine;
+		cmd = "% -N % _ % 44100 AIFF int16 > % 2>&1".format(program, oscPath.quote, outPath.quote, logPath.quote);
+		// protect against quote-stripping on Windows
+		if(thisProcess.platform.name == \windows) {cmd = cmd.quote};
+		// run command and capture output to a log file
+		pid = cmd.unixCmd({pid = nil; cond.signalOne});
+		cond.waitFor(60);
+		// failsafe shutdown
+		pid !? {
+			"server process % (pid %) took too long, shutting down...".format(program.quote, pid).warn;
+			thisProcess.platform.killProcessByID(pid, true, true)
+		};
+		// read output from the log file
+		if(File.exists(logPath)) {
+            logFile = File(logPath, "r");
+			line = logFile.getLine;
+			while ({ line.notNil }) {
+				// line.postln; // inspect output
+				// ignore output until we see matching start
+				if (line.beginsWith("NODE TREE")) {nodeTreeOutputDectected = true};
+				// once we see matching beginning, capture output
+				if (nodeTreeOutputDectected) {actualOutput.add(line)};
+				// stop capturing when we see matching end
+				if (line.beginsWith("END NODE")) {nodeTreeOutputDectected = false};
+				line = logFile.getLine;
+			};
+			logFile.close;
 		};
 		// cleanup
-		pipe.close;
-		if (File.exists(oscPath)) { File.delete(oscPath)};
-		if (File.exists(outPath)) { File.delete(outPath)};
-
+		[oscPath, outPath, logPath].do({|path|
+            if(File.exists(path)) {File.delete(path)};
+		});
 		^actualOutput;
 	}
 

--- a/testsuite/classlibrary/TestServer_dumpTree.sc
+++ b/testsuite/classlibrary/TestServer_dumpTree.sc
@@ -31,7 +31,7 @@ TestServer_dumpTree : UnitTest {
 		pipe = Pipe.new(cmd, "r");
 		line = pipe.getLine;
 		while ({ line.notNil }) {
-			// line.postln; // inspect output
+			line.postln; // inspect output
 			// ignore output until we see matching start
 			if (line.beginsWith("NODE TREE")) {nodeTreeOutputDectected = true};
 			// once we see matching beginning, capture output

--- a/testsuite/classlibrary/TestServer_dumpTree.sc
+++ b/testsuite/classlibrary/TestServer_dumpTree.sc
@@ -43,7 +43,7 @@ TestServer_dumpTree : UnitTest {
             logFile = File(logPath, "r");
 			line = logFile.getLine;
 			while ({ line.notNil }) {
-				// line.postln; // inspect output
+				line.postln; // inspect output
 				// ignore output until we see matching start
 				if (line.beginsWith("NODE TREE")) {nodeTreeOutputDectected = true};
 				// once we see matching beginning, capture output

--- a/testsuite/classlibrary/TestServer_dumpTree.sc
+++ b/testsuite/classlibrary/TestServer_dumpTree.sc
@@ -1,66 +1,74 @@
 TestServer_dumpTree : UnitTest {
 
-    var pipe;
+	var pipe;
 
-    setUp {
-    }
+	setUp {
+	}
 
-    tearDown {
-        if (pipe.notNil) {
-            pipe.close;
-        };
-    }
+	tearDown {
+		if (pipe.notNil) {
+			pipe.close;
+		};
+	}
 
-    getOutput { |program, expectedOutput|
-        var actualOutput = List[],
-            ip = "127.0.0.1",
-            port = 57110,
-            addr = NetAddr(ip, port),
-            line;
-        pipe = Pipe.new(program ++ ServerOptions().bindAddress_(ip).asOptionsString(port), "r");
-        // consume lines until the server is ready
-        line = pipe.getLine;
-        while ({ line.notNil && line.contains("ready").not }) {
-            line = pipe.getLine;
-        };
-        // dump the tree, quit the server
-        addr.sendMsg("/g_dumpTree", 0, 0);
-        addr.sendMsg("/quit");
-        // consume lines until no more remain
-        line = pipe.getLine;
-        while ({ line.notNil }) {
-            // Ignore transient unrelated warnings
-            if (
-                line.beginsWith("Warning:").not,
-                { actualOutput.add(line); }
-            );
-            line = pipe.getLine;
-        };
-        pipe.close;
-        ^ actualOutput;
-    }	
+	getOutput { |program|
+		var actualOutput = List[],
+		oscPath = PathName.tmp +/+ "dumpTree_test.osc",
+		outPath = PathName.tmp +/+ "dummy_out.aiff",
+		cmd, line, score, nodeTreeOutputDectected = false;
 
-    test_dumpTree_scsynth {
-        this.assertEquals(
-            this.getOutput(Server.program),
-            List[
-                "NODE TREE Group 0",
-                "END NODE TREE Group 0",
-            ],
-            "scsynth /g_dumpTree output should match expected",
-        );
-    }
+		score = Score();
+		// this overwrites the automatically created default group, so that we only get the root group in the output
+		score.score = ([
+			[0.0, ['/g_dumpTree', 0, 0]],
+			[0.1, [0]] // stop
+		]);
+		// write osc score to a file
+		score.writeOSCFile(oscPath);
+		// construct the nrt command
+		cmd = "% -N % _ % 44100 AIFF int16".format(program, oscPath.quote, outPath.quote);
+		// run it and capture stdout
+		pipe = Pipe.new(cmd, "r");
+		line = pipe.getLine;
+		while ({ line.notNil }) {
+			// line.postln; // inspect output
+			// ignore output until we see matching start
+			if (line.beginsWith("NODE TREE")) {nodeTreeOutputDectected = true};
+			// once we see matching beginning, capture output
+			if (nodeTreeOutputDectected) {actualOutput.add(line)};
+			// stop capturing when we see matching end
+			if (line.beginsWith("END NODE")) {nodeTreeOutputDectected = false};
+			line = pipe.getLine;
+		};
+		// cleanup
+		pipe.close;
+		if (File.exists(oscPath)) { File.delete(oscPath)};
+		if (File.exists(outPath)) { File.delete(outPath)};
 
-    test_dumpTree_supernova {
-        this.assertEquals(
-            this.getOutput(Server.program.replace("scsynth", "supernova")),
-            List[
-                "NODE TREE Group 0",
-                "   0 group",
-                "END NODE TREE Group 0",
-            ],
-            "supernova /g_dumpTree output should match expected",
-        );
-    }
+		^actualOutput;
+	}
+
+	test_dumpTree_scsynth {
+		this.assertEquals(
+			this.getOutput(Server.program),
+			List[
+				"NODE TREE Group 0",
+				"END NODE TREE Group 0",
+			],
+			"scsynth /g_dumpTree output should match expected output",
+		);
+	}
+
+	test_dumpTree_supernova {
+		this.assertEquals(
+			this.getOutput(Server.program.replace("scsynth", "supernova")),
+			List[
+				"NODE TREE Group 0",
+				"   0 group",
+				"END NODE TREE Group 0",
+			],
+			"supernova /g_dumpTree output should match expected output",
+		);
+	}
 
 }


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

The supernova version of the `TestServer_dumpTree` test seems to hang at times:
https://github.com/supercollider/supercollider/actions/runs/27577542122/job/81532796978#step:7:12155
I was able to recreate failure by putting artificial load on my system and running the test locally. 

```sh
CORES=$(sysctl -n hw.physicalcpu); echo "Running 'yes' on $CORES cores..."; for i in $(seq 1 $CORES); do yes > /dev/null & done; wait; echo "Done."
```
Under load we tend to miss UDP packets and the process never quits, particularly in supernova. Since this test specifically depends on arrival of a single packet to trigger dumpTree and to quit, and since there's no way to unhang sclang when it waits for the input from the pipe, I propose that these tests are switched to using a non-realtime server.

The output parsing is a bit arbitrary (we're waiting for specific strings to appear), but I think it's in line with the original implementation.

The diff is noisy since I applied default IDE's formatting (the original was submitted with spaces not tabs).

BTW looking at another failure, we should probably do the same for the [TestServer_nodeMove test](https://github.com/supercollider/supercollider/actions/runs/27581418135/job/81543585825#step:7:304), which also depends on capturing server's output with a Pipe.

EDIT: it turns out that on Linux we don't get a full output out of supernova - I tried with redirecting logging to a file and it's the same as reading output directly, so I think it's unlikely just an output buffering issue. LLM suggests it's an issue of the logging thread being shut down before it manages to process all output, but I don't know if that's the right track. Leaving this as a draft for now.

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix


## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [ ] Code is tested
- [ ] All tests are passing
- [n/a] Updated documentation
- [ ] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
