### PR TITLE
Add Flatpak build

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -133,8 +133,15 @@ jobs:
             s3-artifact-extension: 'zip'
             s3-create-latest-link: true # create link to pointing to the "latest" build
 
+          - artifact-suffix: flatpak-x86
+            s3-os-name: flatpak-x86
+            s3-artifact-prefix: '-flatpak-x86'
+            s3-artifact-suffix: ''
+            s3-artifact-extension: 'zip'
+            s3-create-latest-link: true # create link to pointing to the "latest" build; activate only one per branch per s3-os-name
+
     if: github.repository_owner == 'supercollider' && github.event_name != 'pull_request' # run in the main repo, but not on pull requests
-    needs: [lint, version-getter, build-macos, build-windows]
+    needs: [lint, version-getter, build-macos, build-windows, build-flatpak]
     runs-on: ubuntu-latest
     name: 'deploy ${{ matrix.artifact-suffix }} to s3'
     env:

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -207,7 +207,7 @@ jobs:
   # release - list of files uploaded to GH release is specified in the *upload* step
   deploy_gh:
     if: startsWith(github.ref, 'refs/tags/') # run on tagged commits
-    needs: [lint, version-getter, build-macos, build-windows]
+    needs: [lint, version-getter, build-macos, build-windows, build-flatpak]
     runs-on: ubuntu-latest
     name: 'deploy release'
     env:
@@ -228,4 +228,6 @@ jobs:
             ${{ env.INSTALL_PATH }}/${{ env.ARTIFACT_FILE_PREFIX }}-macOS-x64-legacy.dmg/*
             ${{ env.INSTALL_PATH }}/${{ env.ARTIFACT_FILE_PREFIX }}-win64-installer/*
             ${{ env.INSTALL_PATH }}/${{ env.ARTIFACT_FILE_PREFIX }}-win64/*
+            ${{ env.INSTALL_PATH }}/${{ env.ARTIFACT_FILE_PREFIX }}-x86_64.flatpak/*
+            ${{ env.INSTALL_PATH }}/${{ env.ARTIFACT_FILE_PREFIX }}-aarch64.flatpak/*
           draft: true

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -133,11 +133,12 @@ jobs:
             s3-artifact-extension: 'zip'
             s3-create-latest-link: true # create link to pointing to the "latest" build
 
-          - artifact-suffix: flatpak-x86
-            s3-os-name: flatpak-x86
-            s3-artifact-prefix: '-flatpak-x86'
+          - artifact-suffix: x86_64.flatpak
+            s3-os-name: x86_64-flatpak
+            s3-artifact-prefix: 'x86_64-flatpak '
             s3-artifact-suffix: ''
-            s3-artifact-extension: 'zip'
+            s3-artifact-extension: 'flatpak'
+            artifact-extension: '.flatpak'
             s3-create-latest-link: true # create link to pointing to the "latest" build; activate only one per branch per s3-os-name
 
     if: github.repository_owner == 'supercollider' && github.event_name != 'pull_request' # run in the main repo, but not on pull requests

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -64,6 +64,13 @@ jobs:
       sc-version: ${{ needs.version-getter.outputs.sc-version }}
     secrets: inherit
 
+  build-flatpak:
+    needs: [lint, version-getter]
+    uses: ./.github/workflows/build_flatpak.yml
+    with:
+      sc-version: ${{ needs.version-getter.outputs.sc-version }}
+    secrets: inherit
+
   build-macos:
     needs: [lint, version-getter]
     uses: ./.github/workflows/build_macos.yml

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -133,9 +133,17 @@ jobs:
             s3-artifact-extension: 'zip'
             s3-create-latest-link: true # create link to pointing to the "latest" build
 
-          - artifact-suffix: x86_64.flatpak
-            s3-os-name: x86_64-flatpak
-            s3-artifact-prefix: 'x86_64-flatpak '
+          - artifact-suffix: "x86_64.flatpak"
+            s3-os-name: flatpak-x86_64
+            s3-artifact-prefix: '-x86_64-flatpak'
+            s3-artifact-suffix: ''
+            s3-artifact-extension: 'flatpak'
+            artifact-extension: '.flatpak'
+            s3-create-latest-link: true # create link to pointing to the "latest" build; activate only one per branch per s3-os-name
+
+          - artifact-suffix: "arm64.flatpak"
+            s3-os-name: flatpak-arm64
+            s3-artifact-prefix: '-arm64-flatpak'
             s3-artifact-suffix: ''
             s3-artifact-extension: 'flatpak'
             artifact-extension: '.flatpak'
@@ -237,5 +245,5 @@ jobs:
             ${{ env.INSTALL_PATH }}/${{ env.ARTIFACT_FILE_PREFIX }}-win64-installer/*
             ${{ env.INSTALL_PATH }}/${{ env.ARTIFACT_FILE_PREFIX }}-win64/*
             ${{ env.INSTALL_PATH }}/${{ env.ARTIFACT_FILE_PREFIX }}-x86_64.flatpak/*
-            ${{ env.INSTALL_PATH }}/${{ env.ARTIFACT_FILE_PREFIX }}-aarch64.flatpak/*
+            ${{ env.INSTALL_PATH }}/${{ env.ARTIFACT_FILE_PREFIX }}-arm64.flatpak/*
           draft: true

--- a/.github/workflows/build_flatpak.yml
+++ b/.github/workflows/build_flatpak.yml
@@ -15,11 +15,11 @@ jobs:
         include:
           - arch: x86_64
             runner: ubuntu-24.04
-            jobname: "x86 64bit"
+            job-name: "x86 64bit"
             artifact-suffix: "x86_64.flatpak"
           - arch: aarch64
             runner: ubuntu-24.04-arm
-            jobname: "arm64"
+            job-name: "arm64"
             artifact-suffix: "arm64.flatpak"
 
     steps:

--- a/.github/workflows/build_flatpak.yml
+++ b/.github/workflows/build_flatpak.yml
@@ -15,8 +15,12 @@ jobs:
         include:
           - arch: x86_64
             runner: ubuntu-24.04
+            jobname: "x86 64bit"
+            artifact-suffix: "x86_64.flatpak"
           - arch: aarch64
             runner: ubuntu-24.04-arm
+            jobname: "arm64"
+            artifact-suffix: "arm64.flatpak"
 
     steps:
       - uses: actions/checkout@v6
@@ -48,10 +52,10 @@ jobs:
 
       - name: Create bundle
         run: |
-          flatpak build-bundle repo "SuperCollider-${{ inputs.sc-version }}-${{ matrix.arch }}.flatpak" online.supercollider.SuperCollider
+          flatpak build-bundle repo "SuperCollider-${{ inputs.sc-version }}-${{ matrix.artifact-suffix }}.flatpak" online.supercollider.SuperCollider
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: "SuperCollider-${{ inputs.sc-version }}-${{ matrix.arch }}.flatpak"
-          path: "SuperCollider-${{ inputs.sc-version }}-${{ matrix.arch }}.flatpak"
+          name: "SuperCollider-${{ inputs.sc-version }}-${{ matrix.artifact-suffix }}.flatpak"
+          path: "SuperCollider-${{ inputs.sc-version }}-${{ matrix.artifact-suffix }}.flatpak"

--- a/.github/workflows/build_flatpak.yml
+++ b/.github/workflows/build_flatpak.yml
@@ -22,6 +22,8 @@ jobs:
             job-name: "arm64"
             artifact-suffix: "arm64"
 
+    name: flatpak ${{ matrix.job-name }}
+
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/build_flatpak.yml
+++ b/.github/workflows/build_flatpak.yml
@@ -1,0 +1,57 @@
+name: Build Flatpak
+on:
+  workflow_call:
+    inputs:
+      sc-version:
+        required: true
+        type: string
+
+jobs:
+  build-flatpak:
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x86_64
+            runner: ubuntu-24.04
+          - arch: aarch64
+            runner: ubuntu-24.04-arm
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
+      - name: Install flatpak and flatpak-builder
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y flatpak flatpak-builder
+
+      - name: Add Flathub remote
+        run: |
+          flatpak remote-add --user --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
+
+      - name: Install SDK and runtime
+        run: |
+          flatpak install --user --noninteractive \
+            flathub org.kde.Platform//6.10 \
+            org.kde.Sdk//6.10 \
+            io.qt.qtwebengine.BaseApp//6.10
+
+      - name: Build Flatpak
+        run: |
+          flatpak-builder \
+            --force-clean \
+            --repo=repo builddir \
+            platform/linux/online.supercollider.SuperCollider.yml
+
+      - name: Create bundle
+        run: |
+          flatpak build-bundle repo "SuperCollider-${{ inputs.sc-version }}-${{ matrix.arch }}.flatpak" online.supercollider.SuperCollider
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: "SuperCollider-${{ inputs.sc-version }}-${{ matrix.arch }}.flatpak"
+          path: "SuperCollider-${{ inputs.sc-version }}-${{ matrix.arch }}.flatpak"

--- a/.github/workflows/build_flatpak.yml
+++ b/.github/workflows/build_flatpak.yml
@@ -43,9 +43,17 @@ jobs:
             org.kde.Sdk//6.10 \
             io.qt.qtwebengine.BaseApp//6.10
 
+      - name: cache ccache
+        uses: actions/cache@v5
+        with:
+          path: .flatpak-builder
+          key: flatpak-${{ matrix.arch }}-${{ hashFiles('platform/linux/online.supercollider.SuperCollider.yml') }}
+          restore-keys: flatpak-${{ matrix.arch }}-
+
       - name: Build Flatpak
         run: |
           flatpak-builder \
+            --ccache \
             --force-clean \
             --repo=repo builddir \
             platform/linux/online.supercollider.SuperCollider.yml

--- a/.github/workflows/build_flatpak.yml
+++ b/.github/workflows/build_flatpak.yml
@@ -16,11 +16,11 @@ jobs:
           - arch: x86_64
             runner: ubuntu-24.04
             job-name: "x86 64bit"
-            artifact-suffix: "x86_64.flatpak"
+            artifact-suffix: "x86_64"
           - arch: aarch64
             runner: ubuntu-24.04-arm
             job-name: "arm64"
-            artifact-suffix: "arm64.flatpak"
+            artifact-suffix: "arm64"
 
     steps:
       - uses: actions/checkout@v6

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Install
 
 macOS and Windows builds for stable releases are provided at our [downloads page][downloads page]. See the [macOS README](README_MACOS.md) and [Windows README](README_WINDOWS.md) for instructions on usage, and how to build SC yourself.
 
-To get the latest stable version, Linux users will need to build SuperCollider themselves. See the [Linux README](README_LINUX.md) for instructions.
+To get the latest stable version, Linux users will need to build SuperCollider themselves or use the Flatpak build. See the [Linux README](README_LINUX.md) for instructions.
 
 See the [Raspberry Pi](README_RASPBERRY_PI.md) and [Bela](README_BELA.md) READMEs for instructions on building on those platforms.
 

--- a/README_LINUX.md
+++ b/README_LINUX.md
@@ -1,4 +1,39 @@
-# Building SuperCollider on Linux
+# SuperCollider on Linux
+
+## Flatpak
+
+> This is currently an exerimental feature - please provide feedback regarding jack/pipewire support
+
+[Flatpaks](https://flatpak.org/)  are sandboxed binaries which can run on a variety of linux distributions and desktop environments. and are self-contained.
+They provide an alternative to the distribution via distro-package-managers, which use dynamic linking.
+This allows to run an abitrary version of SuperCollider without the necessity of building SuperCollider locally and the version being available via the distro package manager.
+The flatpak installation can co-exist to your local installation, though it is advised to choose one in order to avoid confusion about multiple SuperCollider installations.
+
+SuperCollider Flatpaks are currently not available through [flathub](https://flathub.org).
+The flatpak binaries are instead available via the [official SuperCollider website](https://supercollider.github.io/) or via the CI artifacts.
+
+Before installing the flatpak file via a double click or using `flatpak install`, it is necessary to add the flathub repo index to get access to the Qt runtime for the IDE.
+
+```shell
+flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
+```
+
+Flatpak can only expose one binary to the environment, which is `scide`.
+Access to `sclang` via CLI has therefore be indirected through flatpak, i.e.
+
+```shell
+flatpak run --command=sclang online.supercollider.SuperCollider
+```
+
+The following can be added to a `~/.zshrc` file to make `sclang` etc. available as expected
+
+```shell
+alias sclang="flatpak run --command=sclang online.supercollider.SuperCollider"
+alias scsynth="flatpak run --command=scsynth online.supercollider.SuperCollider"
+alias supernova="flatpak run --command=supernova online.supercollider.SuperCollider"
+```
+
+To build the flatpak file locally, follow the build instructions from the CI, see [.github/workflows/build_flatpak.yaml](.github/workflows/build_flatpak.yaml).
 
 ## Build requirements
 

--- a/platform/linux/online.supercollider.SuperCollider.metainfo.xml
+++ b/platform/linux/online.supercollider.SuperCollider.metainfo.xml
@@ -12,7 +12,7 @@
   <url type="bugtracker">https://github.com/supercollider/supercollider/issues/</url>
   <url type="help">https://scsynth.org/</url>
   <url type="contribute">https://github.com/supercollider/supercollider/blob/develop/CONTRIBUTING.md</url>
-  <launchable type="desktop-id">SuperColliderIDE.desktop</launchable>
+  <launchable type="desktop-id">online.supercollider.SuperCollider.desktop</launchable>
 
   <description>
     <p>

--- a/platform/linux/online.supercollider.SuperCollider.yml
+++ b/platform/linux/online.supercollider.SuperCollider.yml
@@ -33,18 +33,7 @@ modules:
     config-opts:
       - -DCMAKE_BUILD_TYPE=Release
       - -DAUDIOAPI=jack
-      - -DSC_QT=ON
-      - -DSC_IDE=ON
-      - -DSC_USE_QTWEBENGINE=ON
-      - -DSUPERNOVA=ON
-      - -DSC_ABLETON_LINK=ON
-      - -DSC_HIDAPI=ON
-      - -DSYSTEM_BOOST=OFF
-      - -DSYSTEM_YAMLCPP=OFF
-      - -DNO_AVAHI=OFF
-      - -DINSTALL_HELP=ON
       - -DENABLE_TESTSUITE=OFF
-      - -DSC_SYMLINK_CLASSLIB=OFF
       - -DCMAKE_INSTALL_PREFIX=/app
     sources:
       - type: dir

--- a/platform/linux/online.supercollider.SuperCollider.yml
+++ b/platform/linux/online.supercollider.SuperCollider.yml
@@ -34,7 +34,7 @@ modules:
       - -DAUDIOAPI=jack
       - -DSC_QT=ON
       - -DSC_IDE=ON
-      - -DSC_USE_QTWEBENGINE=ON  # arm does not support qt webengine
+      - -DSC_USE_QTWEBENGINE=ON
       - -DSUPERNOVA=ON
       - -DSC_ABLETON_LINK=OFF
       - -DSC_HIDAPI=ON

--- a/platform/linux/online.supercollider.SuperCollider.yml
+++ b/platform/linux/online.supercollider.SuperCollider.yml
@@ -15,6 +15,7 @@ finish-args:
   - --filesystem=host
   # scsynth uses jack, but pipewire is jack compatible
   - --filesystem=xdg-run/pipewire-0
+  - --system-talk-name=org.freedesktop.Avahi
 
 # remove dev files from build
 cleanup:
@@ -36,11 +37,11 @@ modules:
       - -DSC_IDE=ON
       - -DSC_USE_QTWEBENGINE=ON
       - -DSUPERNOVA=ON
-      - -DSC_ABLETON_LINK=OFF
+      - -DSC_ABLETON_LINK=ON
       - -DSC_HIDAPI=ON
       - -DSYSTEM_BOOST=OFF
       - -DSYSTEM_YAMLCPP=OFF
-      - -DNO_AVAHI=ON
+      - -DNO_AVAHI=OFF
       - -DINSTALL_HELP=ON
       - -DENABLE_TESTSUITE=OFF
       - -DSC_SYMLINK_CLASSLIB=OFF

--- a/platform/linux/online.supercollider.SuperCollider.yml
+++ b/platform/linux/online.supercollider.SuperCollider.yml
@@ -1,0 +1,60 @@
+app-id: online.supercollider.SuperCollider
+runtime: org.kde.Platform
+runtime-version: '6.10'
+sdk: org.kde.Sdk
+base: io.qt.qtwebengine.BaseApp
+base-version: '6.10'
+command: scide
+
+finish-args:
+  - --share=ipc
+  - --socket=fallback-x11
+  - --socket=wayland
+  - --share=network
+  - --device=all
+  - --filesystem=host
+  # scsynth uses jack, but pipewire is jack compatible
+  - --filesystem=xdg-run/pipewire-0
+
+# remove dev files from build
+cleanup:
+  - /include
+  - /lib/cmake
+  - /lib/pkgconfig
+  - /share/man
+  - '*.a'
+  - '*.la'
+
+modules:
+  - name: supercollider
+    buildsystem: cmake-ninja
+    builddir: true
+    config-opts:
+      - -DCMAKE_BUILD_TYPE=Release
+      - -DAUDIOAPI=jack
+      - -DSC_QT=ON
+      - -DSC_IDE=ON
+      - -DSC_USE_QTWEBENGINE=ON  # arm does not support qt webengine
+      - -DSUPERNOVA=ON
+      - -DSC_ABLETON_LINK=OFF
+      - -DSC_HIDAPI=ON
+      - -DSYSTEM_BOOST=OFF
+      - -DSYSTEM_YAMLCPP=OFF
+      - -DNO_AVAHI=ON
+      - -DINSTALL_HELP=ON
+      - -DENABLE_TESTSUITE=OFF
+      - -DSC_SYMLINK_CLASSLIB=OFF
+      - -DCMAKE_INSTALL_PREFIX=/app
+    sources:
+      - type: dir
+        path: ../../
+    post-install:
+      - mv /app/share/applications/SuperColliderIDE.desktop
+        /app/share/applications/online.supercollider.SuperCollider.desktop
+      - desktop-file-edit
+        --set-key=Icon --set-value=online.supercollider.SuperCollider
+        /app/share/applications/online.supercollider.SuperCollider.desktop
+      - mv /app/share/icons/hicolor/scalable/apps/sc_ide.svg
+        /app/share/icons/hicolor/scalable/apps/online.supercollider.SuperCollider.svg
+      - install -Dm644 $FLATPAK_BUILDER_BUILDDIR/icons/sc_ide_128.png
+        /app/share/icons/hicolor/128x128/apps/online.supercollider.SuperCollider.png


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

Closes https://github.com/supercollider/supercollider/issues/3604

Flatpak is a way to install software on linux w/o going through the native package manager of the OS. This leads to beefier binaries and resources-usage, but allows people to use the newest SC version w/o having to build it themselves or wait for their package manager to update SC.
This makes the installation of SC in linux much more easier.

Used https://docs.flatpak.org/en/latest/sandbox-permissions.html and https://docs.flatpak.org/en/latest/module-sources.html for the more "advanced" sandboxing and bundling stuff.

I tested this on my fedora 42 x86 laptop (build and run the flatpak) and on the virtual fedora 42 arm virtual machine via my macbook and it also played back sound.
Please check if you can run this on your linux machine - it should be as easy as downloading the binary artifact and double-click on the file which will install SC via flatpak on your system (assuming that flatpak is installed).
It allowed me to install a flatpak sc beneath a native-build sc - it may be possible to have multiple flatpak sc next to each other by looking into flatpak branches, but I leave this to the linux users.

The next step could be to publish this also via flathub - but I am not too eager about that b/c this requires some synchronization w/ the flathub team b/c we can't simply upload the binaries through our CI and we have to create a dedicated repo for that... Maybe someone who actually uses linux could take care of this ;) I am personally fine w/ providing this as download, maybe we could add this as nightly build download to the website.

Before we merge, we should be sure that this is actually a wanted feature: The feedback I got when I communicated that there will be a flatpak soon was "why flatpak and not [appimage](https://appimage.org/)". This also seems nice, but is even more statically linked which is even more worrying, but I let the linux heads decide on that ;) But after working some time w/ flatpak now, I don't consider it that nice tbh - it feels more like an appstore thing instead of "get this running".

## Types of changes

<!-- Delete lines that don't apply -->
- New feature

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [ ] Read into jack support, e.g.  https://github.com/flatpak/flatpak/issues/3622#issuecomment-704606905 
- [ ] Test `sclang` and `scsynth` as commands
- [ ] Test multi-channel audio
- [x] Code is tested
- [x] All tests are passing
- [ ] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
