### PR TITLE
Add search paths to FindSndfile.cmake

### DIFF
--- a/cmake_modules/FindSndfile.cmake
+++ b/cmake_modules/FindSndfile.cmake
@@ -20,11 +20,17 @@ elseif (SNDFILE_INCLUDE_DIR AND SNDFILE_LIBRARY)
 elseif (APPLE)
 
   find_path(SNDFILE_INCLUDE_DIR sndfile.h
-    HINTS /usr/local/opt/libsndfile/include
+    HINTS 
+      /opt/homebrew
+      /usr/local/opt/libsndfile
+    PATH_SUFFIXES include
   )
 
   find_library(SNDFILE_LIBRARY NAMES libsndfile.dylib libsndfile.a
-    HINTS /usr/local/opt/libsndfile/lib
+    HINTS 
+      /opt/homebrew
+      /usr/local/opt/libsndfile
+    PATH_SUFFIXES lib
   )
 
   if(NOT SNDFILE_INCLUDE_DIR OR NOT SNDFILE_LIBRARY)


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

It seems that libsndfile from homebrew was found on macOS on Apple Silicon only because `/opt/homebrew` is added to global search paths. This PR explicitly adds them to the search paths.

I'm not sure if we really need this, but it seems to be a cleaner (if not strictly necessary) approach.

I thought it is related to #7579, but it is not.

## Types of changes

<!-- Delete lines that don't apply -->

- Maintenance...?

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [n/a] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
