### PR TITLE
Fix BufRd interpolation documentation

### DIFF
--- a/HelpSource/Classes/BufRd.schelp
+++ b/HelpSource/Classes/BufRd.schelp
@@ -39,7 +39,7 @@ argument::interpolation
 1 means no interpolation, 2 is linear, 4 is cubic interpolation. 
 (The numbers one, two, and emphasis::four:: correspond to the number of consecutive
 samples needed to compute each type of interpolation.)
-Any other values for this argument will silently default to no interpolation.
+Any other values for this argument will silently default to cubic interpolation.
 
 instancemethods::
 private:: init, argNamesInputsOffset, checkInputs


### PR DESCRIPTION
Fallback interpolation is cubic interpolation in the BufRd implementation, not no interpolation. See https://github.com/supercollider/supercollider/issues/7575#issuecomment-4750843064

Closes #7575

## Types of changes

<!-- Delete lines that don't apply -->

- Documentation
- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
