### PR TITLE
ide: fix double newlines posting on Windows

### DIFF
--- a/editors/sc-ide/core/sc_process.cpp
+++ b/editors/sc-ide/core/sc_process.cpp
@@ -160,7 +160,7 @@ void ScProcess::startLanguage(void) {
     };
     emit scPost(tr("Starting interpreter with \"") + startMessageContent + "\" in \"" + workingDirectory + "\"\n");
 
-    QProcess::start(sclangCommand, sclangArguments);
+    QProcess::start(sclangCommand, sclangArguments, QIODevice::ReadWrite | QIODevice::Text);
     bool processStarted = QProcess::waitForStarted();
     if (!processStarted)
         emit statusMessage(tr("Failed to start interpreter!"));

--- a/editors/sc-ide/core/sc_process.cpp
+++ b/editors/sc-ide/core/sc_process.cpp
@@ -218,6 +218,9 @@ void ScProcess::onReadAllStandardOutput(void) {
 
     QByteArray out = readAllStandardOutput();
     QString postString = QString::fromUtf8(out);
+#ifdef Q_OS_WIN
+    postString.remove('\r');
+#endif
     emit scPost(postString);
 }
 
@@ -228,7 +231,11 @@ void ScProcess::onReadAllStandardError(void) {
             return;
     }
     QByteArray out = readAllStandardError();
-    emit scPost("ERROR: " + QString::fromUtf8(out));
+    QString errorString = QString::fromUtf8(out);
+#ifdef Q_OS_WIN
+    errorString.remove('\r');
+#endif
+    emit scPost("ERROR: " + errorString);
 }
 
 void ScProcess::evaluateCode(QString const& commandString, bool silent) {

--- a/editors/sc-ide/core/sc_process.cpp
+++ b/editors/sc-ide/core/sc_process.cpp
@@ -218,9 +218,6 @@ void ScProcess::onReadAllStandardOutput(void) {
 
     QByteArray out = readAllStandardOutput();
     QString postString = QString::fromUtf8(out);
-#ifdef Q_OS_WIN
-    postString.remove('\r');
-#endif
     emit scPost(postString);
 }
 
@@ -231,11 +228,7 @@ void ScProcess::onReadAllStandardError(void) {
             return;
     }
     QByteArray out = readAllStandardError();
-    QString errorString = QString::fromUtf8(out);
-#ifdef Q_OS_WIN
-    errorString.remove('\r');
-#endif
-    emit scPost("ERROR: " + errorString);
+    emit scPost("ERROR: " + QString::fromUtf8(out));
 }
 
 void ScProcess::evaluateCode(QString const& commandString, bool silent) {


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

Avoid double newline posting in the IDE on Windows by swallowing carriage return symbols (`\r`).

This seems to work okay, ~~but I don't know why this behavior started in the first place - it did not occur in the 3.14.1 release (which e.g. also uses Qt 6).~~ One change that happened was in https://github.com/supercollider/supercollider/pull/6971, changing `QProcess::readAll()` (which inherits from [QIODevice](https://doc.qt.io/qt-6/qiodevice.html#readAll)) to `QProcess::readAllStandardOutput()`. There's something about newline conversion mentioned in the QIODevice docs - I haven't followed this closely and how it behaves when inherited by QProcess, but maybe this is what triggered the original issue... BUT the old method did not seem to explicitly set the newline conversion, so I'm not sure.

Fixes #7523

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [n/a] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
