### PR TITLE
docs: Reference/Classes.schlep: added missing 'code::' formatting tag

### DIFF
--- a/HelpSource/Reference/Classes.schelp
+++ b/HelpSource/Reference/Classes.schelp
@@ -56,7 +56,7 @@ The messages of a class' interface are implemented in the methods of the class. 
 Method definitions follow the class variable and instance variable declarations in the class.
 
 Method definitions are similar to FunctionDefs in syntax. Method definitions begin with the message selector. The message selector must be an identifier or a binary operator. Methods have arguments and variable declarations with the same syntax as in FunctionDefs.
-Methods however have an implicit first argument named this which is the receiver of the message. The variable code::this:: may be referred to just like any of the other arguments and variables in the method. You may not assign a value to code::this::.
+Methods however have an implicit first argument named code::this:: which is the receiver of the message. The variable code::this:: may be referred to just like any of the other arguments and variables in the method. You may not assign a value to code::this::.
 
 section:: Class Methods
 


### PR DESCRIPTION
<img width="840" height="690" alt="image_2026-06-25_060300694" src="https://github.com/user-attachments/assets/ae351595-b81d-49c4-9f7c-bb8b7393b27f" />