### PR TITLE
help: add deprecated argument note to Window help

### DIFF
--- a/HelpSource/Classes/Window.schelp
+++ b/HelpSource/Classes/Window.schelp
@@ -46,6 +46,8 @@ METHOD:: new
 		The default is code::true::.
 	argument:: border
 		A Boolean indicating whether this window has a border. Borderless windows have no title bar and thus can only be closed in code. The default is code::true::.
+	argument:: deprecatedServerArgument
+		This argument is deprecated, it was kept for SwingOSC compatibility.
 	argument:: scroll
 		A Boolean indicating whether this window will add scrollbars if its contents exceed its bounds. If this is set to code::true::, then link::Classes/View#-resize:: settings will be ignored for contained views. The default is false.
 


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

`Window` help was missing an argument:

```
WARNING: SCDoc: In .../SuperCollider/SuperCollider.app/Contents/Resources/HelpSource/Classes/Window.schelp
  Method *new has 6 args, but doc has 5 argument:: tags.
WARNING: SCDoc: In .../SuperCollider/SuperCollider.app/Contents/Resources/HelpSource/Classes/Window.schelp
  Method *new has arg named 'deprecatedServerArgument', but doc has 'argument:: scroll'.
```

Edit:
Closes #6171 

## Types of changes

<!-- Delete lines that don't apply -->

- Documentation

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [n/a] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
