### PR TITLE
qt6: update type to typeId

### DIFF
--- a/QtCollider/QObjectProxy.cpp
+++ b/QtCollider/QObjectProxy.cpp
@@ -173,7 +173,11 @@ bool QObjectProxy::invokeMethod(const char* method, PyrSlot* retSlot, PyrSlot* a
     // construct the return data object
     QGenericReturnArgument rarg;
     const char* rtype_name = mm.typeName();
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
     int rtype_id = QMetaType::type(rtype_name);
+#else
+    int rtype_id = QMetaType::fromName(rtype_name).id();
+#endif
 
     MetaValue returnVal;
 

--- a/QtCollider/QcSignalSpy.h
+++ b/QtCollider/QcSignalSpy.h
@@ -67,7 +67,11 @@ public:
         QList<QByteArray> params = mm.parameterTypes();
 
         for (int i = 0; i < params.count(); ++i) {
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
             int type = QMetaType::type(params.at(i).constData());
+#else
+            int type = QMetaType::fromName(params.at(i)).id();
+#endif
             if (type == QMetaType::Void)
                 qcErrorMsg(QString("QObject:connect: Don't know how to handle '%1', "
                                    "use qRegisterMetaType to register it.")

--- a/QtCollider/widgets/QcGraph.cpp
+++ b/QtCollider/widgets/QcGraph.cpp
@@ -181,7 +181,11 @@ void QcGraph::setCurves(const QVariantList& curves) {
         const QVariant& data = curves[i];
         QcGraphElement::CurveType type;
         double curvature;
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
         if (data.type() == QVariant::Int) {
+#else
+        if (data.typeId() == QMetaType::Int) {
+#endif
             type = (QcGraphElement::CurveType)data.toInt();
             curvature = 0.0;
         } else {

--- a/editors/sc-ide/core/settings/serialization.cpp
+++ b/editors/sc-ide/core/settings/serialization.cpp
@@ -214,19 +214,24 @@ static void writeTextFormat(const QTextCharFormat& fm, YAML::Emitter& out) {
 }
 
 static void writeValue(const QVariant& var, YAML::Emitter& out) {
-    switch (var.type()) {
-    case QVariant::Invalid: {
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+    int typeId = var.userType();
+#else
+    int typeId = var.typeId();
+#endif
+    switch (typeId) {
+    case QMetaType::UnknownType: {
         out << YAML::Null;
         break;
     }
-    case QVariant::KeySequence: {
+    case QMetaType::QKeySequence: {
         QKeySequence kseq = var.value<QKeySequence>();
 
         out << kseq.toString(QKeySequence::PortableText).toUtf8().constData();
 
         break;
     }
-    case QVariant::List: {
+    case QMetaType::QVariantList: {
         out << YAML::LocalTag("QVariantList") << YAML::BeginSeq;
 
         QVariantList list = var.value<QVariantList>();
@@ -237,7 +242,7 @@ static void writeValue(const QVariant& var, YAML::Emitter& out) {
 
         break;
     }
-    case QVariant::Map: {
+    case QMetaType::QVariantMap: {
         out << YAML::LocalTag("QVariantMap") << YAML::BeginMap;
 
         QVariantMap map = var.value<QVariantMap>();
@@ -252,18 +257,13 @@ static void writeValue(const QVariant& var, YAML::Emitter& out) {
 
         break;
     }
-    case QVariant::UserType: {
-        int utype = var.userType();
-
-        if (utype == qMetaTypeId<QTextCharFormat>()) {
+    default: {
+        if (typeId == qMetaTypeId<QTextCharFormat>()) {
             writeTextFormat(var.value<QTextCharFormat>(), out);
         } else {
             out << var.toString().toUtf8().constData();
         }
         break;
-    }
-    default: {
-        out << var.toString().toUtf8().constData();
     }
     }
 }
@@ -336,12 +336,17 @@ void printSettings(const QSettings* settings) {
 
     cout << "config filename: " << settings->fileName().toStdString() << endl;
     QStringList keys = settings->allKeys();
-    cout << "num keys: " << keys.count() << endl;
+    cout << "num keys: " << keys.size() << endl;
     Q_FOREACH (QString key, keys) {
         QVariant var = settings->value(key);
-        if (var.type() == QVariant::Invalid)
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+        int typeId = var.userType();
+#else
+        int typeId = var.typeId();
+#endif
+        if (typeId == QMetaType::UnknownType)
             cout << key.toStdString() << ": <null>" << endl;
-        else if (var.type() == QVariant::String)
+        else if (typeId == QMetaType::QString)
             cout << key.toStdString() << ": " << var.toString().toStdString() << endl;
         else
             cout << key.toStdString() << ": <unknown value type>" << endl;

--- a/editors/sc-ide/widgets/multi_editor.cpp
+++ b/editors/sc-ide/widgets/multi_editor.cpp
@@ -825,12 +825,17 @@ void MultiEditor::loadSplitterState(MultiSplitter* splitter, const QVariantMap& 
 
     QVariantList childrenData = data.value("elements").value<QVariantList>();
     foreach (const QVariant& childVar, childrenData) {
-        if (childVar.type() == QVariant::List) {
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+        int typeId = childVar.userType();
+#else
+        int typeId = childVar.typeId();
+#endif
+        if (typeId == QMetaType::QVariantList) {
             CodeEditorBox* childBox = newBox(splitter);
             splitter->addWidget(childBox);
             QVariantList childBoxData = childVar.value<QVariantList>();
             loadBoxState(childBox, childBoxData, documentList);
-        } else if (childVar.type() == QVariant::Map) {
+        } else if (typeId == QMetaType::QVariantMap) {
             MultiSplitter* childSplitter = new MultiSplitter(this);
             splitter->addWidget(childSplitter);
             QVariantMap childSplitterData = childVar.value<QVariantMap>();


### PR DESCRIPTION


<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

I'm going through our codebase to remove qt deprecations. The changes here are the most "noisy" so I'd like them to be reviewed separately.

I used a LLM to find these fixes, but I didn't put in any of the code optimizations it suggested, just replaced the qt objects.

I personally would like to still keep supporting Qt 5.15, hence all the ifdefs. But if other devs really would like to drop it, we could discuss that as well.

## Types of changes

<!-- Delete lines that don't apply -->

- Maintanance

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [ ] Code is tested - I'm not sure how to test these changes...
- [x] All tests are passing
- [n/a] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
