### PR TITLE
qt: add workaround for triggering Menu actions on macOS

### DIFF
--- a/QtCollider/widgets/QcMenu.cpp
+++ b/QtCollider/widgets/QcMenu.cpp
@@ -57,6 +57,17 @@ void QcMenu::removeAction(QAction* action) {
     }
 }
 
+#ifdef Q_OS_MAC
+// workaround to trigger menu actions on macOS
+void QcMenu::mousePressEvent(QMouseEvent* event) {
+    if (QAction* action = actionAt(event->pos())) {
+        action->trigger();
+        hide();
+    }
+    QMenu::mousePressEvent(event);
+}
+#endif
+
 void QcToolBar::addAction(QAction* action) {
     if (action) {
         QToolBar::addAction(action);

--- a/QtCollider/widgets/QcMenu.cpp
+++ b/QtCollider/widgets/QcMenu.cpp
@@ -76,16 +76,52 @@ void QcMenu::showEvent(QShowEvent* event) {
     QMenu::showEvent(event);
 }
 
-void QcMenu::hideEvent(QHideEvent* event) {
-    // Only apply the manual trigger if the native Qt routing failed
-    if (!m_actionTriggered && (QGuiApplication::mouseButtons() & Qt::LeftButton)) {
-        QPoint localPos = mapFromGlobal(QCursor::pos());
-        if (QAction* act = actionAt(localPos)) {
-            m_actionTriggered = true; // prevent double firing
-            QTimer::singleShot(0, act, &QAction::trigger); // defer execution
+bool QcMenu::event(QEvent* event) {
+    // if the event close arrive first
+    if (event->type() == QEvent::Close || event->type() == QEvent::Hide) {
+        if (!m_actionTriggered && (QGuiApplication::mouseButtons() & Qt::LeftButton)) {
+            QPoint localPos = mapFromGlobal(QCursor::pos());
+            if (QAction* act = actionAt(localPos)) {
+                m_actionTriggered = true; // indicate handled action
+                QTimer::singleShot(0, act, &QAction::trigger); // fire the action
+            }
         }
     }
-    QMenu::hideEvent(event);
+
+    // if the mousepress arrives first
+    if (event->type() == QEvent::MouseButtonPress) {
+        QMouseEvent* mouseEvent = static_cast<QMouseEvent*>(event);
+        if (QAction* act = actionAt(mouseEvent->pos())) {
+            if (!m_actionTriggered) {
+                m_actionTriggered = true; // indicate handled action
+                QTimer::singleShot(0, act, &QAction::trigger); // fire the action
+            }
+            return true; // consume event
+        }
+    }
+
+    // avoid double-triggering
+    if (event->type() == QEvent::MouseButtonRelease) {
+        if (m_actionTriggered) {
+            return true; // consume event
+        }
+    }
+
+    // handle keyboard
+    if (event->type() == QEvent::KeyPress) {
+        QKeyEvent* keyEvent = static_cast<QKeyEvent*>(event);
+        if (keyEvent->key() == Qt::Key_Enter || keyEvent->key() == Qt::Key_Return || keyEvent->key() == Qt::Key_Space) {
+            if (QAction* act = activeAction()) {
+                if (!m_actionTriggered) {
+                    m_actionTriggered = true; // indicate handled action
+                    QTimer::singleShot(0, act, &QAction::trigger);
+                }
+                return true; // consume event
+            }
+        }
+    }
+
+    return QMenu::event(event);
 }
 #endif
 

--- a/QtCollider/widgets/QcMenu.cpp
+++ b/QtCollider/widgets/QcMenu.cpp
@@ -31,7 +31,18 @@ QC_DECLARE_QWIDGET_FACTORY(QcToolBar);
 QC_DECLARE_QOBJECT_FACTORY(QcAction);
 QC_DECLARE_QOBJECT_FACTORY(QcWidgetAction);
 
-QcMenu::QcMenu(): QMenu(NULL) { setAttribute(Qt::WA_DeleteOnClose, false); }
+#ifdef Q_OS_MAC
+#    include <QTimer>
+#    include <QGuiApplication>
+#    include <QCursor>
+#endif
+
+QcMenu::QcMenu(): QMenu(NULL) {
+    setAttribute(Qt::WA_DeleteOnClose, false);
+#ifdef Q_OS_MAC
+    connect(this, &QMenu::triggered, this, [this]() { m_actionTriggered = true; });
+#endif
+}
 
 void QcMenu::popup(QPointF pos, QAction* action) { QMenu::popup(QPoint(pos.x(), pos.y()), action); }
 
@@ -59,16 +70,22 @@ void QcMenu::removeAction(QAction* action) {
 
 #ifdef Q_OS_MAC
 // workaround to trigger menu actions on macOS
-bool QcMenu::event(QEvent* event) {
-    if (event->type() == QEvent::MouseButtonPress || event->type() == QEvent::MouseButtonRelease) {
-        QMouseEvent* mouseEvent = static_cast<QMouseEvent*>(event);
-        if (QAction* act = actionAt(mouseEvent->pos())) {
-            act->trigger();
-            hide();
-            return true; // Consume the event
+
+void QcMenu::showEvent(QShowEvent* event) {
+    m_actionTriggered = false; // reset the flag when the menu is shown
+    QMenu::showEvent(event);
+}
+
+void QcMenu::hideEvent(QHideEvent* event) {
+    // Only apply the manual trigger if the native Qt routing failed
+    if (!m_actionTriggered && (QGuiApplication::mouseButtons() & Qt::LeftButton)) {
+        QPoint localPos = mapFromGlobal(QCursor::pos());
+        if (QAction* act = actionAt(localPos)) {
+            m_actionTriggered = true; // prevent double firing
+            QTimer::singleShot(0, act, &QAction::trigger); // defer execution
         }
     }
-    return QMenu::event(event);
+    QMenu::hideEvent(event);
 }
 #endif
 

--- a/QtCollider/widgets/QcMenu.cpp
+++ b/QtCollider/widgets/QcMenu.cpp
@@ -37,7 +37,7 @@ QC_DECLARE_QOBJECT_FACTORY(QcWidgetAction);
 #    include <QCursor>
 #endif
 
-QcMenu::QcMenu(): QMenu(NULL) {
+QcMenu::QcMenu(): QMenu(nullptr) {
     setAttribute(Qt::WA_DeleteOnClose, false);
 #ifdef Q_OS_MAC
     connect(this, &QMenu::triggered, this, [this]() { m_actionTriggered = true; });
@@ -90,7 +90,7 @@ bool QcMenu::event(QEvent* event) {
 
     // if the mousepress arrives first
     if (event->type() == QEvent::MouseButtonPress) {
-        QMouseEvent* mouseEvent = static_cast<QMouseEvent*>(event);
+        auto* mouseEvent = static_cast<QMouseEvent*>(event);
         if (QAction* act = actionAt(mouseEvent->pos())) {
             if (!m_actionTriggered) {
                 m_actionTriggered = true; // indicate handled action
@@ -109,7 +109,7 @@ bool QcMenu::event(QEvent* event) {
 
     // handle keyboard
     if (event->type() == QEvent::KeyPress) {
-        QKeyEvent* keyEvent = static_cast<QKeyEvent*>(event);
+        auto* keyEvent = static_cast<QKeyEvent*>(event);
         if (keyEvent->key() == Qt::Key_Enter || keyEvent->key() == Qt::Key_Return || keyEvent->key() == Qt::Key_Space) {
             if (QAction* act = activeAction()) {
                 if (!m_actionTriggered) {

--- a/QtCollider/widgets/QcMenu.cpp
+++ b/QtCollider/widgets/QcMenu.cpp
@@ -59,12 +59,16 @@ void QcMenu::removeAction(QAction* action) {
 
 #ifdef Q_OS_MAC
 // workaround to trigger menu actions on macOS
-void QcMenu::mousePressEvent(QMouseEvent* event) {
-    if (QAction* action = actionAt(event->pos())) {
-        action->trigger();
-        hide();
+bool QcMenu::event(QEvent* event) {
+    if (event->type() == QEvent::MouseButtonPress || event->type() == QEvent::MouseButtonRelease) {
+        QMouseEvent* mouseEvent = static_cast<QMouseEvent*>(event);
+        if (QAction* act = actionAt(mouseEvent->pos())) {
+            act->trigger();
+            hide();
+            return true; // Consume the event
+        }
     }
-    QMenu::mousePressEvent(event);
+    return QMenu::event(event);
 }
 #endif
 

--- a/QtCollider/widgets/QcMenu.h
+++ b/QtCollider/widgets/QcMenu.h
@@ -101,7 +101,11 @@ public:
 
 #ifdef Q_OS_MAC
 protected:
-    bool event(QEvent* event) override;
+    void showEvent(QShowEvent* event) override;
+    void hideEvent(QHideEvent* event) override;
+
+private:
+    bool m_actionTriggered = false;
 #endif
 };
 

--- a/QtCollider/widgets/QcMenu.h
+++ b/QtCollider/widgets/QcMenu.h
@@ -102,7 +102,7 @@ public:
 #ifdef Q_OS_MAC
 protected:
     void showEvent(QShowEvent* event) override;
-    void hideEvent(QHideEvent* event) override;
+    bool event(QEvent* event) override;
 
 private:
     bool m_actionTriggered = false;

--- a/QtCollider/widgets/QcMenu.h
+++ b/QtCollider/widgets/QcMenu.h
@@ -98,6 +98,11 @@ public:
     Q_INVOKABLE void removeAction(QAction* action);
 
     Q_INVOKABLE void clear() { QMenu::clear(); }
+
+#ifdef Q_OS_MAC
+protected:
+    void mousePressEvent(QMouseEvent* event) override;
+#endif
 };
 
 class QcToolBar : public QToolBar {

--- a/QtCollider/widgets/QcMenu.h
+++ b/QtCollider/widgets/QcMenu.h
@@ -101,7 +101,7 @@ public:
 
 #ifdef Q_OS_MAC
 protected:
-    void mousePressEvent(QMouseEvent* event) override;
+    bool event(QEvent* event) override;
 #endif
 };
 


### PR DESCRIPTION


<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

After investigating https://github.com/supercollider/supercollider/issues/7436, it seems that the way menu interactions are handled in qt6 on macOS is that the menu was being destroyed before being able to fire the callback. One LLM suggestion was to open it synchronously using [exec](https://doc.qt.io/qt-6/qmenu.html#exec-1), but that of course doesn't work since it blocks the language.

~~I propose a workaround, intercepting the mousedown event and firing the signal. I'm not sure if we can do any better with the current implementation of qt/sclang communication.~~ It turned out, that this solution may not always work. Now testing the event interception method.

This fix was heavily LLM-assisted, but I went pretty far into changing the menu from popup to tool/tooltip kind, before realizing that it would never activate (highlight items) properly when sclang is in the background and I settled on this solution instead.

Fixes https://github.com/supercollider/supercollider/issues/7436.

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [n/a] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
