### PR TITLE
Update qt6 deprecations

### DIFF
--- a/QtCollider/QWidgetProxy.cpp
+++ b/QtCollider/QWidgetProxy.cpp
@@ -478,7 +478,11 @@ bool QWidgetProxy::interpretDragEvent(QObject* o, QEvent* e, QList<QVariant>& ar
         if (!internal)
             interpretMimeData(data, args);
     } else {
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
         QPoint pos = dnd->pos();
+#else
+        QPoint pos = dnd->position().toPoint();
+#endif
         args << pos.x() << pos.y();
     }
 

--- a/QtCollider/QWidgetProxy.cpp
+++ b/QtCollider/QWidgetProxy.cpp
@@ -413,7 +413,7 @@ bool QWidgetProxy::interpretKeyEvent(QObject* o, QEvent* e, QList<QVariant>& arg
 #endif
     {
         QString text(ke->text());
-        if (text.count())
+        if (!text.isEmpty())
             character = text[0];
     }
 

--- a/QtCollider/QcApplication.cpp
+++ b/QtCollider/QcApplication.cpp
@@ -74,7 +74,9 @@ QcApplication::QcApplication(int& argc, char** argv): QApplication(argc, argv, Q
     _mutex.lock();
     _instance = this;
     _mutex.unlock();
+#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
     this->setAttribute(Qt::AA_UseHighDpiPixmaps);
+#endif
 
 #ifdef Q_OS_MAC
     QtCollider::Mac::DisableAutomaticWindowTabbing();

--- a/QtCollider/primitives/prim_QPen.cpp
+++ b/QtCollider/primitives/prim_QPen.cpp
@@ -308,14 +308,14 @@ QC_QPEN_PRIMITIVE(QPen_Rotate, 3, PyrSlot* r, PyrSlot* a, VMGlobals* g) {
 
 QC_QPEN_PRIMITIVE(QPen_SetTransform, 1, PyrSlot* r, PyrSlot* a, VMGlobals* g) {
     QVariantList list = QtCollider::get(a);
-    if (list.count() < 6)
+    if (list.size() < 6)
         return errWrongType;
     float f[6];
     int i = 6;
     while (i) {
         --i;
         const QVariant& var = list[i];
-        if (!var.canConvert(QVariant::Double))
+        if (!var.canConvert<double>())
             return errWrongType;
         f[i] = var.value<float>();
     }

--- a/QtCollider/widgets/image_painter.h
+++ b/QtCollider/widgets/image_painter.h
@@ -123,7 +123,7 @@ struct ImagePainter {
         case AlignVCenter:
             rect.moveTop(targetRect.top() + targetRect.height() / 2 - rect.height() / 2);
             break;
-        case AlignRight:
+        case AlignBottom:
             rect.moveBottom(targetRect.bottom());
             break;
         default:

--- a/editors/sc-ide/core/sc_lexer.cpp
+++ b/editors/sc-ide/core/sc_lexer.cpp
@@ -150,8 +150,14 @@ Token::Type ScLexer::nextTokenInCode(int& lengthResult) {
 
         for (; it != end; ++it) {
             LexicalRule const& rule = *it;
+
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
             QRegularExpressionMatch match = rule.expr.match(mText, mOffset, QRegularExpression::NormalMatch,
                                                             QRegularExpression::AnchoredMatchOption);
+#else
+            QRegularExpressionMatch match = rule.expr.match(mText, mOffset, QRegularExpression::NormalMatch,
+                                                            QRegularExpression::AnchorAtOffsetMatchOption);
+#endif
             if (match.hasMatch()) {
                 // a guard to ensure all regexps match only at the beginning of the string:
                 Q_ASSERT(match.capturedStart() == mOffset);

--- a/editors/sc-ide/widgets/code_editor/editor.cpp
+++ b/editors/sc-ide/widgets/code_editor/editor.cpp
@@ -637,7 +637,7 @@ void GenericCodeEditor::doKeyAction(QKeyEvent* ke) {
 #endif
     {
         QString text(ke->text());
-        if (text.count()) {
+        if (!text.isEmpty()) {
             character = text[0];
         } else {
             character = QChar(QChar::ReplacementCharacter);

--- a/editors/sc-ide/widgets/multi_editor.cpp
+++ b/editors/sc-ide/widgets/multi_editor.cpp
@@ -222,7 +222,13 @@ void EditorTabBar::mouseDoubleClickEvent(QMouseEvent* event) {
 }
 
 void EditorTabBar::showContextMenu(QMouseEvent* event) {
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
     mTabUnderCursor = tabAt(event->pos());
+    QPoint globalPos = event->screenPos().toPoint();
+#else
+    mTabUnderCursor = tabAt(event->position().toPoint());
+    QPoint globalPos = event->globalPosition().toPoint();
+#endif
 
     QMenu* menu = new QMenu(this);
     // Cannot have a close tab action if we are not over a tab
@@ -234,7 +240,7 @@ void EditorTabBar::showContextMenu(QMouseEvent* event) {
         menu->addAction(tr("Close Tabs to the Right"), this, SLOT(onCloseTabsToTheRight()));
     }
 
-    menu->popup(event->screenPos().toPoint());
+    menu->popup(globalPos);
 }
 
 void EditorTabBar::onCloseTab() {

--- a/editors/sc-ide/widgets/settings/editor_page.cpp
+++ b/editors/sc-ide/widgets/settings/editor_page.cpp
@@ -39,7 +39,7 @@ EditorPage::EditorPage(QWidget* parent):
     QWidget(parent),
 #if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
     fontDatabase(new QFontDatabase),
-#endif()
+#endif
     ui(new Ui::EditorConfigPage) {
     ui->setupUi(this);
 

--- a/editors/sc-ide/widgets/settings/editor_page.cpp
+++ b/editors/sc-ide/widgets/settings/editor_page.cpp
@@ -52,7 +52,11 @@ EditorPage::EditorPage(QWidget* parent):
 #else
     connect(ui->fontSize, &QSpinBox::valueChanged, this, &EditorPage::updateFontPreview);
 #endif
+#if QT_VERSION < QT_VERSION_CHECK(6, 7, 0)
     connect(ui->fontAntialias, &QCheckBox::stateChanged, this, &EditorPage::updateFontPreview);
+#else
+    connect(ui->fontAntialias, &QCheckBox::checkStateChanged, this, &EditorPage::updateFontPreview);
+#endif
 
     connect(ui->themeCombo, &QComboBox::currentTextChanged, this, &EditorPage::updateTheme);
     connect(ui->themeCopyBtn, &QPushButton::clicked, this, &EditorPage::dialogCopyTheme);

--- a/editors/sc-ide/widgets/settings/sclang_page.cpp
+++ b/editors/sc-ide/widgets/settings/sclang_page.cpp
@@ -62,8 +62,13 @@ SclangPage::SclangPage(QWidget* parent): QWidget(parent), ui(new Ui::SclangConfi
     connect(ui->sclang_remove_include, &QToolButton::clicked, this, &SclangPage::removeIncludePath);
     connect(ui->sclang_remove_exclude, &QToolButton::clicked, this, &SclangPage::removeExcludePath);
 
+#if QT_VERSION < QT_VERSION_CHECK(6, 7, 0)
     connect(ui->sclang_post_inline_warnings, &QCheckBox::stateChanged, this, &SclangPage::sclangConfigChanged);
     connect(ui->sclang_exclude_default_paths, &QCheckBox::stateChanged, this, &SclangPage::sclangConfigChanged);
+#else
+    connect(ui->sclang_post_inline_warnings, &QCheckBox::checkStateChanged, this, &SclangPage::sclangConfigChanged);
+    connect(ui->sclang_exclude_default_paths, &QCheckBox::checkStateChanged, this, &SclangPage::sclangConfigChanged);
+#endif
 
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
     connect(ui->sclang_port, SIGNAL(valueChanged(int)), this, SLOT(showLanguageRestartDialogOnSave()));

--- a/editors/sc-ide/widgets/util/key_sequence_edit.hpp
+++ b/editors/sc-ide/widgets/util/key_sequence_edit.hpp
@@ -37,13 +37,27 @@ public:
         setReadOnly(true);
     }
 
-    QKeySequence sequence() { return QKeySequence(k1, k2, k3, k4); }
+    QKeySequence sequence() {
+#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
+        return QKeySequence(k1, k2, k3, k4);
+#else
+        return QKeySequence(QKeyCombination::fromCombined(k1), QKeyCombination::fromCombined(k2),
+                            QKeyCombination::fromCombined(k3), QKeyCombination::fromCombined(k4));
+#endif
+    }
 
     void setSequence(const QKeySequence& seq) {
+#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
         k1 = seq[0];
         k2 = seq[1];
         k3 = seq[2];
         k4 = seq[3];
+#else
+        k1 = seq[0].toCombined();
+        k2 = seq[1].toCombined();
+        k3 = seq[2].toCombined();
+        k4 = seq[3].toCombined();
+#endif
 
         if (mEditing)
             finishEditing();


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

When building against qt6 (tested with 6.11), we get many notifications of deprecated functions. This PR removes all of them as far as I can tell.

It seems there are other qt-related warnings are about [overridden functions](https://github.com/supercollider/supercollider/actions/runs/28212234133/job/83576002289#step:16:10040), but that's for a separate PR.

The fixes were suggested by an LLM, but they seem straightforward and I haven't observed any issues.

## Types of changes

<!-- Delete lines that don't apply -->

- Maintenance
- Bug fix


## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [n/a] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
