### PR TITLE
gha: update macOS build to qt 6.8.3

### DIFF
--- a/.github/workflows/build_macos.yml
+++ b/.github/workflows/build_macos.yml
@@ -16,9 +16,9 @@ jobs:
           - job-name: "universal arm64 x64 with ctest"
             os-version: "15"
             xcode-version: "16.0"
-            qt-version: "6.7.3" # will use qt from aqtinstall
+            qt-version: "6.8.3" # will use qt from aqtinstall
             qt-modules: 'qtwebengine qtwebchannel qtwebsockets qtpositioning'
-            deployment-target: "11"
+            deployment-target: "12"
             cmake-architectures: "x86_64;arm64"
             homebrew-packages: ""
             homebrew-uninstall: "readline"

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ SuperCollider is tested with:
 
 SuperCollider is known to support these platforms:
 - Windows 10, 11
-- macOS 11-15
+- macOS 12-15, 26
 - Ubuntu 22.04-24.04
 
 


### PR DESCRIPTION


<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

Preliminary tests indicate that updating Qt on macOS fixes some display issues in the help browser.

Note: this raises the minimum supported version from macOS 11 to **12** for the main build. But since version 12 was released in 2021, I think it's okay, considering that we also have a legacy build to support older OSs.

If confirmed, this fixes #6895.

## Types of changes

<!-- Delete lines that don't apply -->

- Maintenance
- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
