### PR TITLE
classlib: AbstractPlayControl:makeProxyControl remove stale postln

### DIFF
--- a/SCClassLibrary/JITLib/ProxySpace/wrapForNodeProxy.sc
+++ b/SCClassLibrary/JITLib/ProxySpace/wrapForNodeProxy.sc
@@ -320,7 +320,7 @@
 						in = NamedControl(\in, 0!proxy.numChannels, proxy.rate);
 						XOut.perform(rateArg, out, env, SelectX.perform(rateArg, wetAmp, [
 							in,
-							SynthDef.wrap(func, nil, [in]).postln
+							SynthDef.wrap(func, nil, [in])
 						]))
 					} {
 						// there are other sources that send a signal to the internal bus 'out',


### PR DESCRIPTION
## Purpose and Motivation

stale `postln` in JITLib/ProxySpace/wrapForNodeProxy-sc

## Types of changes

- Bug fix (minor)

## To-do list

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review
