### PR TITLE
classlib: add "quiet" flag to git commands

### DIFF
--- a/SCClassLibrary/Common/Quarks/Git.sc
+++ b/SCClassLibrary/Common/Quarks/Git.sc
@@ -11,20 +11,21 @@ Git {
 	clone { |url|
 		this.git([
 			"clone",
+			"--quiet", // suppresses progress report on stderr
 			url,
 			thisProcess.platform.formatPathForCmdLine(localPath)
 		], false);
 		this.url = url;
 	}
 	pull {
-		this.git(["pull", "origin", this.defaultBranchName ? ""])
+		this.git(["pull", "--quiet", "origin", this.defaultBranchName ? ""])
 	}
 	checkout { |refspec|
-		this.git(["checkout", refspec])
+		this.git(["checkout", "--quiet", refspec])
 	}
 	fetch {
 		tags = remoteLatest = nil;
-		this.git(["fetch"]);
+		this.git(["fetch", "--quiet"]);
 	}
 	isDirty {
 		^this.git(["--no-pager diff HEAD --"]).size != 0


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

This adds `-q` (`quiet`) flag to the git commands. It should prevent from status updates being reported by git to stderr (and thus being displayed with the `ERROR: ` note in the IDE.

IMO displaying status messages would be nice, but we don't have an easy way to differentiate between status update and an error, as `git` outputs status updates to stderr. In this PR I _believe_ actual errors would still be reported/posted (even if we [can't catch them](https://github.com/supercollider/supercollider/issues/4283)...).

Fixes #7602, if only in appearance.

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix (more like a workaround...)


## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [n/a] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
