### PR TITLE
classlibrary: allow setting server paths through envvars

### DIFF
--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -286,6 +286,8 @@ Server {
 
 		default = local = Server.new(\localhost, NetAddr("127.0.0.1", 57110));
 		internal = Server.new(\internal, NetAddr.new);
+
+		program = "SC_SCSYNTH_PATH".getenv; // can be nil
 	}
 
 	*fromName { |name|
@@ -1355,13 +1357,38 @@ Server {
 		}
 	}
 
-	*scsynth {
-		this.program = this.program.replace("supernova", "scsynth")
+	*scsynth { this.program = this.scsynthProgram }
+
+	*supernova { this.program = this.supernovaProgram }
+
+	*scsynthProgram { |scsynthPath ("SC_SCSYNTH_PATH".getenv), oldProgram (this.program)|
+		^this.prReplaceProgram(
+			oldProgram, 
+			if (scsynthPath === \undefined) { nil } { scsynthPath } , 
+			"supernova", 
+			"scsynth"
+		);
 	}
 
-	*supernova {
-		this.program = this.program.replace("scsynth", "supernova")
+	*supernovaProgram { |supernovaPath ("SC_SUPERNOVA_PATH".getenv), oldProgram (this.program)|
+		^this.prReplaceProgram(
+			oldProgram,
+		 	if (supernovaPath === \undefined) { nil } { supernovaPath },
+		   	"scsynth",
+		    "supernova"
+		);
 	}
+
+	*prReplaceProgram { | programText, newPath, oldStub, newStub | 
+		newPath ?? { ^programText.replace(oldStub, newStub) };
+		^programText
+			.split($ )
+			.collect { |s|
+				if (s.contains(oldStub)) { newPath } { s }
+			}
+			.join($ )
+	}
+
 
 	warnIfNotRunning { |method|
 		if (this.serverRunning.not) {

--- a/SCClassLibrary/Platform/linux/LinuxPlatform.sc
+++ b/SCClassLibrary/Platform/linux/LinuxPlatform.sc
@@ -16,7 +16,7 @@ LinuxPlatform : UnixPlatform {
 
 		// Server setup. first looks for scsynth in the dir containing the sclang executable;
 		// if nothing is found, falls back to PATH
-		Server.program = "PATH=$(dirname $(readlink /proc/$PPID/exe)):$PATH; exec scsynth";
+		Server.program = Server.program ?? {"PATH=$(dirname $(readlink /proc/$PPID/exe)):$PATH; exec scsynth"};
 
 		// Score setup
 		Score.program = Server.program;

--- a/SCClassLibrary/Platform/osx/OSXPlatform.sc
+++ b/SCClassLibrary/Platform/osx/OSXPlatform.sc
@@ -21,7 +21,7 @@ OSXPlatform : UnixPlatform {
 	}
 
 	startup {
-		Server.program = "exec %/scsynth".format((Platform.resourceDir +/+ "../Resources").shellQuote);
+		Server.program =  Server.program ?? {"exec %/scsynth".format((Platform.resourceDir +/+ "../Resources").shellQuote)};
 
 		Score.program = Server.program;
 

--- a/SCClassLibrary/Platform/windows/WindowsPlatform.sc
+++ b/SCClassLibrary/Platform/windows/WindowsPlatform.sc
@@ -15,7 +15,7 @@ WindowsPlatform : Platform {
 
 	startup {
 		// Server setup
-		Server.program = (Platform.resourceDir +/+ "scsynth.exe").quote;
+		Server.program = Server.program ?? {(Platform.resourceDir +/+ "scsynth.exe").quote};
 
 		// Score setup
 		Score.program = Server.program;

--- a/testsuite/classlibrary/TestServer_program.sc
+++ b/testsuite/classlibrary/TestServer_program.sc
@@ -1,0 +1,13 @@
+TestServer_program : UnitTest {
+	test_replaceProgram {
+		this.assertEquals(
+			Server.prReplaceProgram("old program string /path/to/supernova meow", "/scsynth/path", "supernova", "scsynth"),
+			"old program string /scsynth/path meow"
+		);
+		this.assertEquals(
+			Server.prReplaceProgram("old program string /path/to/supernova meow", nil, "supernova", "scsynth"),
+			"old program string /path/to/scsynth meow"
+		);
+	}
+
+}


### PR DESCRIPTION
Introduces SC_SCYNTH_PATH and SC_SUPERNOVA_PATH as environment variables. These can be used to specify the paths from the command line rather than using the complex auto resolve logic. This is notablely useful for testing debug builds without installing.

I have not documented this. I don't really think we should as it should only really be used in testing and I'd quite like to keep it as a development feature. Perhaps it could be documented on the wiki, if someone can point me to the correct place!

A part of #7574

## Types of changes

- New feature

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [ ] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
