### PR TITLE
classlibrary: ensure forkIfNeeded respects the requested clock

### DIFF
--- a/SCClassLibrary/Common/Core/Function.sc
+++ b/SCClassLibrary/Common/Core/Function.sc
@@ -158,7 +158,7 @@ Function : AbstractFunction {
 		// We should fork if the clocks don't match.
 		// We should also fork if the quants/stackSize don't match, but that doesn't seem possible.
 		if(thisThread.isKindOf(Routine) 
-			and: { clock !? { clock == thisThread.clock} ?? {true} },
+			and: { clock.isNil or: { clock == thisThread.clock }},
 			this, 
 			{ ^this.fork(clock, quant, stackSize) }
 		);

--- a/SCClassLibrary/Common/Core/Function.sc
+++ b/SCClassLibrary/Common/Core/Function.sc
@@ -155,7 +155,13 @@ Function : AbstractFunction {
 	}
 
 	forkIfNeeded { arg clock, quant, stackSize;
-		if(thisThread.isKindOf(Routine), this, { ^this.fork(clock, quant, stackSize) });
+		// We should fork if the clocks don't match.
+		// We should also fork if the quants/stackSize don't match, but that doesn't seem possible.
+		if(thisThread.isKindOf(Routine) 
+			and: { clock !? { clock == thisThread.clock} ?? {true} },
+			this, 
+			{ ^this.fork(clock, quant, stackSize) }
+		);
 		^thisThread;
 	}
 


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

forkIfNeeded should fork if the clocks don't match.

```
fork {
   {
        ... I need ClockA,  previously this would not work.
   }.forkIfNeeded(ClockA)
}
```

I haven't updated any docs, because I assumed this is a bug.

A part of https://github.com/supercollider/supercollider/pull/7574

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix
- New feature


## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [ ] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

## Release Note (added after merge)

when using `forkIfNeeded` passing a clock as argument that is not the same as the current thread's clock, we need to fork. This was previously not done, now it is. This may subtly change some behaviour.

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
