### PR TITLE
classlib, unittest: incorrect default argument assignment used

### DIFF
--- a/SCClassLibrary/Common/UnitTesting/UnitTest.sc
+++ b/SCClassLibrary/Common/UnitTesting/UnitTest.sc
@@ -427,7 +427,7 @@ UnitTestResult {
 
 	var <testClass, <testMethod, <message, <details, <debug;
 
-	*new { |testClass, testMethod, message = "", details, debug|
+	*new { |testClass, testMethod, message(""), details, debug|
 		^super.newCopyArgs(testClass ? this, testMethod ? thisMethod, message, details, debug)
 	}
 


### PR DESCRIPTION
## Purpose and Motivation

If you assert without a message then the default isn't applied .....
```supercollider
SomeTest : UnitTest {
   test_blah { this.assert(false) }
}

UnitTestResult {
	*new { |testClass, testMethod, message="", details, debug|
                                           ^^not applied
		^super.newCopyArgs(testClass ? this, testMethod ? thisMethod, message, details, debug)
	}
}
...and then this fails...

newFailures.do {|fail|
	test[\results].add((
		\pass: false,
		\test: ("" ++ fail.message.split($\n)[0])[0..1000],
		\reason: (fail.message.split($\n)[1..])[0..1000]
	))
};
```
... as fail.message is nil which doesn't respond to split.

Unless we want to check for nil every time, it is better to actually apply the default in call cases  — probably the author's intention...

The assert without a message happened in TestSerialPort.

See #7413 for a long dicussion on the topic.


## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix


## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
