### PR TITLE
Fix help browser code editor highlighting

### DIFF
--- a/HelpSource/static/editor.js
+++ b/HelpSource/static/editor.js
@@ -81,10 +81,10 @@ const selectRegion = (options = { flash: true }) => {
         let token = editor.getTokenTypeAt(cursor) || ''
         if (cursorLeft.hitSide)
             return cursorLeft
+        if (token.match(/(comment|string|symbol|char)/))
+            return findLeftParen(cursorLeft)
         let ch = editor.getLine(cursorLeft.line)
             .slice(cursorLeft.ch, cursorLeft.ch+1)
-        if (token.match(/^(comment|string|symbol|char)/))
-            return findLeftParen(cursorLeft)
         if (ch === ')')
             return findLeftParen(findLeftParen(cursorLeft))
         if (ch === '(')
@@ -97,14 +97,14 @@ const selectRegion = (options = { flash: true }) => {
         let token = editor.getTokenTypeAt(cursor) || ''
         if (cursorRight.hitSide)
             return cursorRight
+        if (token.match(/(comment|string|symbol|char)/))
+            return findRightParen(cursorRight)
         let ch = editor.getLine(cursorRight.line)
             .slice(cursorRight.ch-1, cursorRight.ch)
         if (ch === '(')
             return findRightParen(findRightParen(cursorRight))
         if (ch === ')')
             return cursorRight
-        if (token.match(/^(comment|string|symbol|char)/))
-            return findRightParen(cursorRight)
         return findRightParen(cursorRight)
     }
 

--- a/SCClassLibrary/SCDoc/SCDoc.sc
+++ b/SCClassLibrary/SCDoc/SCDoc.sc
@@ -384,7 +384,7 @@ SCDocNode {
 SCDoc {
 
 	// Increment this whenever we make a change to the SCDoc system or its static files so that all help-files should be processed again
-	classvar version = 77;
+	classvar version = 78;
 
 	classvar <helpTargetDir;
 	classvar <helpTargetUrl;


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

This fixes the issue with treating commented out parentheses as valid ones:
```supercollider
(
1.postln;
2.postln;
)
3.postln; // <<<< this was still selected when double clicking or evaluating the previous block with cmd-enter, causing a syntax error due to missing semicolon beforehand
// )
```

I just asked an LLM to figure out how to fix this. I don't think we want to spend too much effort on maintaining the web code editor, so if this is confirmed to work (I only tested on macOS), then I think it should be okay.

EDIT: @prko tested on macOS and [Windows](https://github.com/supercollider/supercollider/pull/7553#issuecomment-4900832821) and confirmed this seems to be working.


## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix


## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [n/a] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
