### PR TITLE
Keep IDE in focus

### DIFF
--- a/editors/sc-ide/core/sc_process.cpp
+++ b/editors/sc-ide/core/sc_process.cpp
@@ -368,6 +368,13 @@ void ScProcess::onResponse(const QString& selector, const QString& data) {
     else if (selector == QStringLiteral("classLibraryRecompiled")) {
         mCompiled = true;
         emit classLibraryRecompiled();
+
+        // bring the ide window to focus
+        static bool firstStart = true;
+        if (firstStart && MainWindow::instance()) {
+            MainWindow::instance()->raise();
+            firstStart = false;
+        }
     }
 
     else if (selector == QStringLiteral("requestCurrentPath"))

--- a/editors/sc-ide/widgets/help_browser.cpp
+++ b/editors/sc-ide/widgets/help_browser.cpp
@@ -366,8 +366,6 @@ void HelpBrowser::onScResponse(const QString& command, const QString& data) {
     mWebView->load(urlString);
 
     HelpBrowserDocklet* helpDock = MainWindow::instance()->helpBrowserDocklet();
-    if (helpDock)
-        helpDock->focus();
 
     emit urlChanged();
 }


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

This PR introduces two workarounds (?) to keep the code editor in focus:
- it brings the focus back after recompilation (fixes #3756)
- ~~it brings the focus back after~~ it keeps the editor focus when the help browser loads

Tested on macOS. I'm not sure how focusing behaves on ~~Windows and~~ various Linux environments. EDIT: I tested on Windows, it seems to be working fine (the focus ~~is brought back after~~ stays in the editor when loading the help).

Changes were implemented with a LLM help.

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [ ] Code is tested:
  - [x] on macOS
  - [x] on Windows
  - [ ] on Linux
- [x] All tests are passing
- [n/a] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
