### PR TITLE
Apply theme font styles to autocomplete menu

### DIFF
--- a/editors/sc-ide/widgets/code_editor/autocompleter.cpp
+++ b/editors/sc-ide/widgets/code_editor/autocompleter.cpp
@@ -68,33 +68,17 @@ public:
         mLabel->setTextFormat(Qt::RichText);
         mLabel->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
 
-        // Qt 4 had a class called "QGtkStyle" which allowed Qt to access the
-        // native style of the window manager in Linux and other *nix systems.
-        // It was removed in Qt 5, so we don't have that option anymore. We have
-        // to hardcode the colors now. In the future, this should be configurable
-        // by the user.
+        auto font = mLabel->font();
+        font.setPointSizeF(parent->font().pointSizeF() * 0.8f);
+        mLabel->setFont(font);
 
-        // This #if used to be "#if defined(Q_WS_X11)", and then NetBSD was
-        // excluded (commit c3017f5) because QGtkStyle was not defined on that
-        // system. Qt 5 got rid of the Q_WS_ macros, so we changed Q_WS_X11 to
-        // Q_OS_UNIX && !Q_OS_MAC as a best guess. The NetBSD check is probably
-        // vestigial, but we REALLY needed to get this fix through since Linux
-        // users have had unreadable autocomplete widgets for almost 18 months
-        // now. We figured it was best to leave it alone.
+        auto palette = mLabel->palette();
+        auto textTheme = Main::settings()->getThemeVal("text");
+        palette.setColor(QPalette::ToolTipText, textTheme.foreground().color());
+        palette.setColor(QPalette::ToolTipBase, textTheme.background().color());
+        mLabel->setPalette(palette);
 
-        // See: https://github.com/supercollider/supercollider/pull/2762
-
-#if defined(Q_OS_UNIX) && !defined(Q_OS_MAC) && !defined(__NetBSD__)
-        QPalette p;
-        p.setColor(QPalette::Window, QColor(255, 255, 220));
-        p.setColor(QPalette::WindowText, Qt::black);
-        setPalette(p);
-#else
-        QPalette p(palette());
-        p.setColor(QPalette::Window, p.color(QPalette::ToolTipBase));
-        setPalette(p);
-        mLabel->setForegroundRole(QPalette::ToolTipText);
-#endif
+        mHighlightColor = Main::settings()->getThemeVal("symbol").foreground().color();
     }
 
     void showMethod(const AutoCompleter::MethodCall& methodCall, int argNum, const QRect& cursorRect) {
@@ -104,7 +88,7 @@ public:
         QString text;
 
         if (methodCall.functionalNotation) {
-            addArgument(text, "receiver", QString(), argNum == 0);
+            addArgument(text, "receiver", QString(), argNum == 0, mHighlightColor);
             --argNum;
             if (argc)
                 text += ", &nbsp;&nbsp;";
@@ -113,7 +97,7 @@ public:
         for (int i = 0; i < argc; ++i) {
             const ScLanguage::Argument& arg = method->arguments[i];
 
-            addArgument(text, arg.name, arg.defaultValue, argNum == i);
+            addArgument(text, arg.name, arg.defaultValue, argNum == i, mHighlightColor);
 
             if (i != argc - 1)
                 text += ", &nbsp;&nbsp;";
@@ -128,12 +112,16 @@ public:
     }
 
 private:
-    void static addArgument(QString& text, const QString& argText, const QString& valText, bool highlight) {
+    void static addArgument(QString& text, const QString& argText, const QString& valText, bool highlight,
+                            const QColor& highlightColor) {
         if (highlight) {
-            text += QString("<span style=\""
-                            //"text-decoration: underline;"
-                            "font-weight: bold;"
-                            "\">");
+            text += QStringLiteral("<span style=\""
+                                   "font-weight: bold;"
+                                   "color: rgb(%1, %2, %3);"
+                                   "\">")
+                        .arg(highlightColor.red())
+                        .arg(highlightColor.green())
+                        .arg(highlightColor.blue());
         }
 
         text += argText;
@@ -176,6 +164,7 @@ private:
 
     QLabel* mLabel;
     QRect mTargetRect;
+    QColor mHighlightColor;
 };
 
 AutoCompleter::AutoCompleter(ScCodeEditor* editor): QObject(editor), mEditor(editor) {

--- a/editors/sc-ide/widgets/code_editor/completion_menu.cpp
+++ b/editors/sc-ide/widgets/code_editor/completion_menu.cpp
@@ -47,6 +47,14 @@ CompletionMenu::CompletionMenu(QWidget* parent): PopUpWidget(parent), mCompletio
     mLayout->addWidget(mTextBrowser);
     mLayout->setContentsMargins(1, 1, 1, 1);
 
+    auto font = parent->font();
+    mListView->setFont(font);
+
+    // modify font of help window so it matches the size of the editor font
+    auto browserFont = mTextBrowser->font();
+    browserFont.setPointSize(font.pointSize());
+    mTextBrowser->setFont(browserFont);
+
     connect(mListView, &QListView::clicked, this, &CompletionMenu::accept);
     connect(mTextBrowser, &CompletionTextBrowser::anchorClicked, this, &CompletionMenu::onAnchorClicked);
 

--- a/editors/sc-ide/widgets/code_editor/completion_menu.cpp
+++ b/editors/sc-ide/widgets/code_editor/completion_menu.cpp
@@ -60,7 +60,7 @@ CompletionMenu::CompletionMenu(QWidget* parent): PopUpWidget(parent), mCompletio
 
     // set links to match the color of symbol as highlight color
     // inject this via a style sheet
-    auto classFontColor = Main::settings()->getThemeVal("symbol").foreground().color();
+    const auto& classFontColor = Main::settings()->getThemeVal("symbol").foreground().color();
     mTextBrowser->document()->setDefaultStyleSheet(QStringLiteral("a { color: rgb(%1, %2, %3) }")
                                                        .arg(classFontColor.red())
                                                        .arg(classFontColor.green())

--- a/editors/sc-ide/widgets/code_editor/completion_menu.cpp
+++ b/editors/sc-ide/widgets/code_editor/completion_menu.cpp
@@ -49,12 +49,13 @@ CompletionMenu::CompletionMenu(QWidget* parent): PopUpWidget(parent), mCompletio
     mLayout->addWidget(mTextBrowser);
     mLayout->setContentsMargins(1, 1, 1, 1);
 
-    auto font = parent->font();
-    mListView->setFont(font);
+    auto parentFont = parent->font();
+    parentFont.setPointSizeF(parentFont.pointSizeF() * 0.8f);
+    mListView->setFont(parentFont);
 
-    // modify font of help window so it matches the size of the editor font
+    // modify font of help window so it is relative to the size of the editor font
     auto browserFont = mTextBrowser->font();
-    browserFont.setPointSize(font.pointSize());
+    browserFont.setPointSizeF(parentFont.pointSizeF() * 0.8f);
     mTextBrowser->setFont(browserFont);
 
     // set links to match the color of symbol as highlight color

--- a/editors/sc-ide/widgets/code_editor/completion_menu.cpp
+++ b/editors/sc-ide/widgets/code_editor/completion_menu.cpp
@@ -23,6 +23,8 @@
 #include <QKeyEvent>
 #include <QApplication>
 
+#include "main.hpp"
+
 namespace ScIDE {
 
 CompletionMenu::CompletionMenu(QWidget* parent): PopUpWidget(parent), mCompletionRole(Qt::DisplayRole) {
@@ -54,6 +56,14 @@ CompletionMenu::CompletionMenu(QWidget* parent): PopUpWidget(parent), mCompletio
     auto browserFont = mTextBrowser->font();
     browserFont.setPointSize(font.pointSize());
     mTextBrowser->setFont(browserFont);
+
+    // set links to match the color of symbol as highlight color
+    // inject this via a style sheet
+    auto classFontColor = Main::settings()->getThemeVal("symbol").foreground().color();
+    mTextBrowser->document()->setDefaultStyleSheet(QStringLiteral("a { color: rgb(%1, %2, %3) }")
+                                                       .arg(classFontColor.red())
+                                                       .arg(classFontColor.green())
+                                                       .arg(classFontColor.blue()));
 
     connect(mListView, &QListView::clicked, this, &CompletionMenu::accept);
     connect(mTextBrowser, &CompletionTextBrowser::anchorClicked, this, &CompletionMenu::onAnchorClicked);


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

### Autocomplete menu

* Use monofont for selecting method (seems to make more sense since code is mostly written using monospace)
* Uses 0.8f of the editor font size, so the content grows/shrinks relative to the font size of the editor 
* Use symbol color for links within docs - this mirrors the default link color within the docs

old | new
--- | ---
<img width="681" height="479" alt="image" src="https://github.com/user-attachments/assets/c0d8253e-715f-411e-a0a3-225ff86e79ba" /> |  <img width="642" height="482" alt="image" src="https://github.com/user-attachments/assets/42f97e31-6adc-47de-8d60-4a51857d3a5b" />


### Method complete menu

* Apply theme styling instead of traditional tooltip style
* Use 0.8f of editor font size

old | new
--- | ---
<img width="494" height="118" alt="image" src="https://github.com/user-attachments/assets/e4ddde6d-2165-4d52-bf41-e35489eafa91" /> | <img width="483" height="119" alt="image" src="https://github.com/user-attachments/assets/c981bbf6-035a-4736-a711-6bfe5ac22fd9" />


## Types of changes

<!-- Delete lines that don't apply -->

- New feature

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
