### PR TITLE
Display method docs in autocomplete menu

### DIFF
--- a/editors/sc-ide/widgets/code_editor/autocompleter.cpp
+++ b/editors/sc-ide/widgets/code_editor/autocompleter.cpp
@@ -757,12 +757,13 @@ void AutoCompleter::fillClassHelp(DocNode* node, QString& infos) {
                 .arg(mCompletion.menu->currentText());
 }
 
-void AutoCompleter::fillMethodHelp(DocNode* node, QString& infos, const QString& methodName, const QString& className) {
+void AutoCompleter::fillMethodHelp(const DocNode& node, QString& infos, const QString& methodName,
+                                   const QString& className) {
     QString instanceMethods = getMethodDocs(node, methodName, false);
     infos = QStringLiteral("<h4>%1-%2</h4>%3").arg(className).arg(methodName).arg(instanceMethods);
 }
 
-void AutoCompleter::fillClassMethodHelp(DocNode* node, QString& infos, const QString& methodName,
+void AutoCompleter::fillClassMethodHelp(const DocNode& node, QString& infos, const QString& methodName,
                                         const QString& className) {
     QString instanceMethods = getMethodDocs(node, methodName, true);
     infos = QStringLiteral("<h4>%1#%2</h4>%3").arg(className).arg(methodName).arg(instanceMethods);
@@ -798,10 +799,10 @@ void AutoCompleter::updateCompletionMenuInfo() {
         fillClassHelp(node, infos);
         break;
     case MethodCompletion:
-        fillMethodHelp(node, infos, methodName, className);
+        fillMethodHelp(*node, infos, methodName, className);
         break;
     case ClassMethodCompletion:
-        fillClassMethodHelp(node, infos, methodName, className);
+        fillClassMethodHelp(*node, infos, methodName, className);
         break;
     case InvalidCompletion:
         break;
@@ -1228,29 +1229,29 @@ QString AutoCompleter::parseClassElement(DocNode* node, QString element) {
     return QString();
 }
 
-bool isMatchingMethod(DocNode* node, QString methodName) {
-    if (QString(node->id) == "METHODNAMES" && node->n_childs > 0 && node->children[0]->text == methodName) {
+bool isMatchingMethod(const DocNode& node, QString methodName) {
+    if (QString(node.id) == "METHODNAMES" && node.n_childs > 0 && node.children[0]->text == methodName) {
         return true;
     }
-    for (int i = 0; i < node->n_childs; i++) {
-        if (isMatchingMethod(node->children[i], methodName))
+    for (int i = 0; i < node.n_childs; i++) {
+        if (isMatchingMethod(*node.children[i], methodName))
             return true;
     }
     return false;
 }
 
-QString AutoCompleter::getMethodDocs(DocNode* node, QString methodName, bool isClassMethod) {
-    if (QString(node->id) == (isClassMethod ? "CMETHOD" : "IMETHOD") && isMatchingMethod(node, methodName)
-        && node->n_childs >= 2) {
+QString AutoCompleter::getMethodDocs(const DocNode& node, QString methodName, bool isClassMethod) const {
+    if (QString(node.id) == (isClassMethod ? "CMETHOD" : "IMETHOD") && isMatchingMethod(node, methodName)
+        && node.n_childs >= 2) {
         QString str;
         // first child is method name, which we want to skip here
         // we want straight access to the body of the method doc
-        parseClassNode(node->children[1], &str);
+        parseClassNode(node.children[1], &str);
         return str;
     }
 
-    for (int i = 0; i < node->n_childs; i++) {
-        QString ret = getMethodDocs(node->children[i], methodName, isClassMethod);
+    for (int i = 0; i < node.n_childs; i++) {
+        QString ret = getMethodDocs(*node.children[i], methodName, isClassMethod);
         if (!ret.isEmpty())
             return ret;
     }

--- a/editors/sc-ide/widgets/code_editor/autocompleter.cpp
+++ b/editors/sc-ide/widgets/code_editor/autocompleter.cpp
@@ -1235,7 +1235,7 @@ bool isMatchingMethod(DocNode* node, QString methodName) {
     return false;
 }
 
-QString AutoCompleter::getMethodDocs(DocNode* node, QString methodName, bool isClassMethod = false) {
+QString AutoCompleter::getMethodDocs(DocNode* node, QString methodName, bool isClassMethod) {
     if (QString(node->id) == (isClassMethod ? "CMETHOD" : "IMETHOD") && isMatchingMethod(node, methodName)
         && node->n_childs >= 2) {
         QString str;

--- a/editors/sc-ide/widgets/code_editor/autocompleter.cpp
+++ b/editors/sc-ide/widgets/code_editor/autocompleter.cpp
@@ -763,10 +763,10 @@ void AutoCompleter::fillMethodHelp(DocNode* node, QString& infos, const QString&
     infos = QStringLiteral("<h4>%1-%2</h4>%3").arg(className).arg(methodName).arg(instanceMethods);
 }
 
-void AutoCompleter::fillClassMethodHelp(DocNode* node, QString& infos, const QString& methodName) {
-    // @todo derive via meta class
-    QString instanceMethods = parseClassElement(node, "CLASSMETHODS");
-    infos = QStringLiteral("<h4>Class Method %1</h4>%2").arg(methodName).arg(instanceMethods);
+void AutoCompleter::fillClassMethodHelp(DocNode* node, QString& infos, const QString& methodName,
+                                        const QString& className) {
+    QString instanceMethods = getMethodDocs(node, methodName, true);
+    infos = QStringLiteral("<h4>%1#%2</h4>%3").arg(className).arg(methodName).arg(instanceMethods);
 }
 
 void AutoCompleter::updateCompletionMenuInfo() {
@@ -775,6 +775,11 @@ void AutoCompleter::updateCompletionMenuInfo() {
         return;
     }
     auto className = klass->name.get();
+    // strip Meta_ prefix for resolution of docs
+    if (className.startsWith("Meta_")) {
+        className.remove(0, 5);
+    }
+
     DocNode* node = parseHelpClass(findHelpClass(className));
     if (!node) {
         mCompletion.menu->addInfo(QString());
@@ -793,7 +798,7 @@ void AutoCompleter::updateCompletionMenuInfo() {
         fillMethodHelp(node, infos, methodName, className);
         break;
     case ClassMethodCompletion:
-        fillClassMethodHelp(node, infos, methodName);
+        fillClassMethodHelp(node, infos, methodName, className);
         break;
     case InvalidCompletion:
         break;
@@ -1250,8 +1255,6 @@ QString AutoCompleter::getMethodDocs(DocNode* node, QString methodName, bool isC
 
 void AutoCompleter::parseClassNode(DocNode* node, QString* str) {
     QString id = node->id;
-
-    std::cout << node->id << std::endl;
 
     if (id == "NOTE")
         str->append("<br><br>Note:<br>");

--- a/editors/sc-ide/widgets/code_editor/autocompleter.cpp
+++ b/editors/sc-ide/widgets/code_editor/autocompleter.cpp
@@ -760,13 +760,13 @@ void AutoCompleter::fillClassHelp(DocNode* node, QString& infos) {
 void AutoCompleter::fillMethodHelp(const DocNode& node, QString& infos, const QString& methodName,
                                    const QString& className) {
     QString instanceMethods = getMethodDocs(node, methodName, false);
-    infos = QStringLiteral("<h4>%1-%2</h4>%3").arg(className).arg(methodName).arg(instanceMethods);
+    infos = QStringLiteral("<h4><code>%1-%2</code></h4>%3").arg(className).arg(methodName).arg(instanceMethods);
 }
 
 void AutoCompleter::fillClassMethodHelp(const DocNode& node, QString& infos, const QString& methodName,
                                         const QString& className) {
     QString instanceMethods = getMethodDocs(node, methodName, true);
-    infos = QStringLiteral("<h4>%1#%2</h4>%3").arg(className).arg(methodName).arg(instanceMethods);
+    infos = QStringLiteral("<h4><code>%1#%2</code></h4>%3").arg(className).arg(methodName).arg(instanceMethods);
 }
 
 void AutoCompleter::updateCompletionMenuInfo() {

--- a/editors/sc-ide/widgets/code_editor/autocompleter.cpp
+++ b/editors/sc-ide/widgets/code_editor/autocompleter.cpp
@@ -507,7 +507,9 @@ CompletionMenu* AutoCompleter::menuForClassCompletion(CompletionDescription cons
 
     for (ClassMap::const_iterator it = matchStart; it != matchEnd; ++it) {
         Class* klass = it->second.data();
-        menu->addItem(new QStandardItem(klass->name));
+        auto item = new QStandardItem(klass->name);
+        item->setData(QVariant::fromValue(klass), CompletionMenu::ClassRole);
+        menu->addItem(item);
     }
 
     menu->adapt();
@@ -569,6 +571,7 @@ CompletionMenu* AutoCompleter::menuForClassMethodCompletion(CompletionDescriptio
         QStandardItem* item = new QStandardItem();
         item->setText(methodName + detail.arg(method->ownerClass->name));
         item->setData(QVariant::fromValue(method), CompletionMenu::MethodRole);
+        item->setData(QVariant::fromValue(method->ownerClass), CompletionMenu::ClassRole);
         item->setData(methodName, CompletionMenu::CompletionRole);
         menu->addItem(item);
     }
@@ -616,6 +619,7 @@ CompletionMenu* AutoCompleter::menuForMethodCompletion(CompletionDescription con
             item->setText(methodName + detail.arg(count));
 
         item->setData(methodName, CompletionMenu::CompletionRole);
+        item->setData(QVariant::fromValue(method->ownerClass), CompletionMenu::ClassRole);
 
         menu->addItem(item);
 
@@ -720,7 +724,7 @@ void AutoCompleter::updateCompletionMenu(bool forceShow) {
     } else
         menu->hide();
 
-    if (mCompletion.type == ClassCompletion && Main::settings()->value("IDE/editor/showAutocompleteHelp").toBool())
+    if (Main::settings()->value("IDE/editor/showAutocompleteHelp").toBool())
         updateCompletionMenuInfo();
 }
 
@@ -751,23 +755,57 @@ void AutoCompleter::onCompletionMenuFinished(int result) {
     // quitCompletion("cancelled");
 }
 
-void AutoCompleter::updateCompletionMenuInfo() {
-    DocNode* node = parseHelpClass(findHelpClass(mCompletion.menu->currentText()));
-    if (!node) {
-        mCompletion.menu->addInfo(QString());
-        return;
-    }
-
+void AutoCompleter::fillClassHelp(DocNode* node, QString& infos) {
     QString examples = parseClassElement(node, "EXAMPLES");
     if (!examples.isEmpty())
         examples.prepend("<h4>Examples</h4>");
     // MSVStudio 2013 does not concatenate multiple QStringliterals ("""") properly
     // see http://blog.qt.io/blog/2014/06/13/qt-weekly-13-qstringliteral/
-    QString infos = QStringLiteral("<h4>%1</h4>%2%3<p><a href=\"%4\">go to help</a>")
-                        .arg(parseClassElement(node, "SUMMARY"))
-                        .arg(parseClassElement(node, "DESCRIPTION"))
-                        .arg(examples)
-                        .arg(mCompletion.menu->currentText());
+    infos = QStringLiteral("<h4>%1</h4>%2%3<p><a href=\"%4\">go to help</a>")
+                .arg(parseClassElement(node, "SUMMARY"))
+                .arg(parseClassElement(node, "DESCRIPTION"))
+                .arg(examples)
+                .arg(mCompletion.menu->currentText());
+}
+
+void AutoCompleter::fillMethodHelp(DocNode* node, QString& infos, const QString& methodName) {
+    QString instanceMethods = parseClassElement(node, "INSTANCEMETHODS");
+    infos = QStringLiteral("<h4>Method %1</h4>%2").arg(methodName).arg(instanceMethods);
+}
+
+void AutoCompleter::fillClassMethodHelp(DocNode* node, QString& infos, const QString& methodName) {
+    QString instanceMethods = parseClassElement(node, "CLASSMETHODS");
+    infos = QStringLiteral("<h4>Class Method %1</h4>%2").arg(methodName).arg(instanceMethods);
+}
+
+void AutoCompleter::updateCompletionMenuInfo() {
+    auto klass = mCompletion.menu->currentClass();
+    if (!klass) {
+        return;
+    }
+    auto className = klass->name.get();
+    DocNode* node = parseHelpClass(findHelpClass(className));
+    if (!node) {
+        mCompletion.menu->addInfo(QString());
+        return;
+    }
+
+    QString infos;
+
+    auto methodName = mCompletion.menu->currentText();
+
+    switch (mCompletion.type) {
+    case ClassCompletion:
+        fillClassHelp(node, infos);
+        break;
+    case MethodCompletion:
+        fillMethodHelp(node, infos, methodName);
+        break;
+    case ClassMethodCompletion:
+        break;
+    case InvalidCompletion:
+        break;
+    };
     mCompletion.menu->addInfo(infos);
     doc_node_free_tree(node);
 }
@@ -916,6 +954,7 @@ const ScLanguage::Method* AutoCompleter::disambiguateMethod(const QString& metho
             QStandardItem* item = new QStandardItem();
             item->setText(method->name + " (" + method->ownerClass->name + ')');
             item->setData(QVariant::fromValue(method), CompletionMenu::MethodRole);
+            item->setData(QVariant::fromValue(method->ownerClass), CompletionMenu::ClassRole);
             menu->addItem(item);
         }
 

--- a/editors/sc-ide/widgets/code_editor/autocompleter.cpp
+++ b/editors/sc-ide/widgets/code_editor/autocompleter.cpp
@@ -769,7 +769,7 @@ void AutoCompleter::fillClassMethodHelp(DocNode* node, QString& infos, const QSt
 }
 
 void AutoCompleter::updateCompletionMenuInfo() {
-    auto klass = mCompletion.menu->currentClass();
+    const auto* klass = mCompletion.menu->currentClass();
     if (!klass) {
         return;
     }

--- a/editors/sc-ide/widgets/code_editor/autocompleter.cpp
+++ b/editors/sc-ide/widgets/code_editor/autocompleter.cpp
@@ -33,6 +33,7 @@
 #    include "../help_browser.hpp"
 #endif // SC_USE_QTWEBENGINE
 
+#include <iostream>
 #include <yaml-cpp/node/node.h>
 #include <yaml-cpp/parser.h>
 
@@ -479,7 +480,7 @@ void AutoCompleter::showCompletionMenu(bool forceShow) {
 
     updateCompletionMenu(forceShow);
 
-    if (mCompletion.type == ClassCompletion && Main::settings()->value("IDE/editor/showAutocompleteHelp").toBool()) {
+    if (Main::settings()->value("IDE/editor/showAutocompleteHelp").toBool()) {
         connect(menu, &CompletionMenu::itemChanged, this, &AutoCompleter::updateCompletionMenuInfo);
         connect(menu, &CompletionMenu::infoClicked, this, &AutoCompleter::gotoHelp);
         updateCompletionMenuInfo();
@@ -601,29 +602,18 @@ CompletionMenu* AutoCompleter::menuForMethodCompletion(CompletionDescription con
     CompletionMenu* menu = new CompletionMenu(editor);
     menu->setCompletionRole(CompletionMenu::CompletionRole);
 
-    for (MethodMap::const_iterator it = matchStart; it != matchEnd;) {
+    for (MethodMap::const_iterator it = matchStart; it != matchEnd; ++it) {
         const Method* method = it->second.data();
-
-        std::pair<MethodMap::const_iterator, MethodMap::const_iterator> range = methods.equal_range(it->first);
-
-        int count = std::distance(range.first, range.second);
 
         QStandardItem* item = new QStandardItem();
 
         QString methodName = method->name.get();
-        QString detail(" [ %1 ]");
-        if (count == 1) {
-            item->setText(methodName + detail.arg(method->ownerClass->name));
-            item->setData(QVariant::fromValue(method), CompletionMenu::MethodRole);
-        } else
-            item->setText(methodName + detail.arg(count));
-
+        item->setText(methodName + QStringLiteral(" [ %1 ]").arg(method->ownerClass->name));
+        item->setData(QVariant::fromValue(method), CompletionMenu::MethodRole);
         item->setData(methodName, CompletionMenu::CompletionRole);
         item->setData(QVariant::fromValue(method->ownerClass), CompletionMenu::ClassRole);
 
         menu->addItem(item);
-
-        it = range.second;
     }
 
     menu->adapt();
@@ -768,12 +758,13 @@ void AutoCompleter::fillClassHelp(DocNode* node, QString& infos) {
                 .arg(mCompletion.menu->currentText());
 }
 
-void AutoCompleter::fillMethodHelp(DocNode* node, QString& infos, const QString& methodName) {
-    QString instanceMethods = parseClassElement(node, "INSTANCEMETHODS");
-    infos = QStringLiteral("<h4>Method %1</h4>%2").arg(methodName).arg(instanceMethods);
+void AutoCompleter::fillMethodHelp(DocNode* node, QString& infos, const QString& methodName, const QString& className) {
+    QString instanceMethods = getMethodDocs(node, methodName, false);
+    infos = QStringLiteral("<h4>%1-%2</h4>%3").arg(className).arg(methodName).arg(instanceMethods);
 }
 
 void AutoCompleter::fillClassMethodHelp(DocNode* node, QString& infos, const QString& methodName) {
+    // @todo derive via meta class
     QString instanceMethods = parseClassElement(node, "CLASSMETHODS");
     infos = QStringLiteral("<h4>Class Method %1</h4>%2").arg(methodName).arg(instanceMethods);
 }
@@ -799,9 +790,10 @@ void AutoCompleter::updateCompletionMenuInfo() {
         fillClassHelp(node, infos);
         break;
     case MethodCompletion:
-        fillMethodHelp(node, infos, methodName);
+        fillMethodHelp(node, infos, methodName, className);
         break;
     case ClassMethodCompletion:
+        fillClassMethodHelp(node, infos, methodName);
         break;
     case InvalidCompletion:
         break;
@@ -1228,11 +1220,44 @@ QString AutoCompleter::parseClassElement(DocNode* node, QString element) {
     return QString();
 }
 
+bool isMatchingMethod(DocNode* node, QString methodName) {
+    if (QString(node->id) == "METHODNAMES" && node->n_childs > 0 && node->children[0]->text == methodName) {
+        return true;
+    }
+    for (int i = 0; i < node->n_childs; i++) {
+        if (isMatchingMethod(node->children[i], methodName))
+            return true;
+    }
+    return false;
+}
+
+QString AutoCompleter::getMethodDocs(DocNode* node, QString methodName, bool isClassMethod = false) {
+    if (QString(node->id) == (isClassMethod ? "CMETHOD" : "IMETHOD") && isMatchingMethod(node, methodName)
+        && node->n_childs > 0) {
+        QString str;
+        parseClassNode(node->children[1], &str);
+        return str;
+    }
+
+    for (int i = 0; i < node->n_childs; i++) {
+        QString ret = getMethodDocs(node->children[i], methodName, isClassMethod);
+        if (!ret.isEmpty())
+            return ret;
+    }
+
+    return QString();
+}
+
 void AutoCompleter::parseClassNode(DocNode* node, QString* str) {
     QString id = node->id;
 
+    std::cout << node->id << std::endl;
+
     if (id == "NOTE")
         str->append("<br><br>Note:<br>");
+
+    if (id == "ARGUMENTS")
+        str->append("<br>");
 
     if (node->text) {
         if (id == "LINK") {
@@ -1247,6 +1272,8 @@ void AutoCompleter::parseClassNode(DocNode* node, QString* str) {
             str->append(QStringLiteral("<code>%1</code>").arg(node->text));
         } else if (id == "CODEBLOCK") {
             str->append(QStringLiteral("<pre><code>%1</code></pre>").arg(node->text));
+        } else if (id == "ARGUMENT") {
+            str->append(QStringLiteral("<br><code><b>%1</b></code>: ").arg(node->text));
         } else {
             str->append(node->text);
         }

--- a/editors/sc-ide/widgets/code_editor/autocompleter.cpp
+++ b/editors/sc-ide/widgets/code_editor/autocompleter.cpp
@@ -788,6 +788,11 @@ void AutoCompleter::updateCompletionMenuInfo() {
     QString infos;
 
     auto methodName = mCompletion.menu->currentText();
+    // setter methods are appended with `_`, but SCDoc maps does not have documentation for a setter method,
+    // so we fall back to the getter method.
+    if (methodName.endsWith("_")) {
+        methodName.chop(1);
+    }
 
     switch (mCompletion.type) {
     case ClassCompletion:

--- a/editors/sc-ide/widgets/code_editor/autocompleter.cpp
+++ b/editors/sc-ide/widgets/code_editor/autocompleter.cpp
@@ -744,29 +744,28 @@ void AutoCompleter::onCompletionMenuFinished(int result) {
     // quitCompletion("cancelled");
 }
 
-void AutoCompleter::fillClassHelp(DocNode* node, QString& infos) {
+QString AutoCompleter::fillClassHelp(DocNode* node) const {
     QString examples = parseClassElement(node, "EXAMPLES");
     if (!examples.isEmpty())
         examples.prepend("<h4>Examples</h4>");
     // MSVStudio 2013 does not concatenate multiple QStringliterals ("""") properly
     // see http://blog.qt.io/blog/2014/06/13/qt-weekly-13-qstringliteral/
-    infos = QStringLiteral("<h4>%1</h4>%2%3<p><a href=\"%4\">go to help</a>")
-                .arg(parseClassElement(node, "SUMMARY"))
-                .arg(parseClassElement(node, "DESCRIPTION"))
-                .arg(examples)
-                .arg(mCompletion.menu->currentText());
+    return QStringLiteral("<h4>%1</h4>%2%3<p><a href=\"%4\">go to help</a>")
+        .arg(parseClassElement(node, "SUMMARY"))
+        .arg(parseClassElement(node, "DESCRIPTION"))
+        .arg(examples)
+        .arg(mCompletion.menu->currentText());
 }
 
-void AutoCompleter::fillMethodHelp(const DocNode& node, QString& infos, const QString& methodName,
-                                   const QString& className) {
+QString AutoCompleter::fillMethodHelp(const DocNode& node, const QString& methodName, const QString& className) const {
     QString instanceMethods = getMethodDocs(node, methodName, false);
-    infos = QStringLiteral("<h4><code>%1-%2</code></h4>%3").arg(className).arg(methodName).arg(instanceMethods);
+    return QStringLiteral("<h4><code>%1-%2</code></h4>%3").arg(className).arg(methodName).arg(instanceMethods);
 }
 
-void AutoCompleter::fillClassMethodHelp(const DocNode& node, QString& infos, const QString& methodName,
-                                        const QString& className) {
+QString AutoCompleter::fillClassMethodHelp(const DocNode& node, const QString& methodName,
+                                           const QString& className) const {
     QString instanceMethods = getMethodDocs(node, methodName, true);
-    infos = QStringLiteral("<h4><code>%1#%2</code></h4>%3").arg(className).arg(methodName).arg(instanceMethods);
+    return QStringLiteral("<h4><code>%1#%2</code></h4>%3").arg(className).arg(methodName).arg(instanceMethods);
 }
 
 void AutoCompleter::updateCompletionMenuInfo() {
@@ -793,21 +792,21 @@ void AutoCompleter::updateCompletionMenuInfo() {
         methodName.chop(1);
     }
 
-    QString infos;
+    QString info;
     switch (mCompletion.type) {
     case ClassCompletion:
-        fillClassHelp(node, infos);
+        info = fillClassHelp(node);
         break;
     case MethodCompletion:
-        fillMethodHelp(*node, infos, methodName, className);
+        info = fillMethodHelp(*node, methodName, className);
         break;
     case ClassMethodCompletion:
-        fillClassMethodHelp(*node, infos, methodName, className);
+        info = fillClassMethodHelp(*node, methodName, className);
         break;
     case InvalidCompletion:
         break;
     };
-    mCompletion.menu->addInfo(infos);
+    mCompletion.menu->addInfo(info);
     doc_node_free_tree(node);
 }
 

--- a/editors/sc-ide/widgets/code_editor/autocompleter.cpp
+++ b/editors/sc-ide/widgets/code_editor/autocompleter.cpp
@@ -507,9 +507,9 @@ CompletionMenu* AutoCompleter::menuForClassCompletion(CompletionDescription cons
 
     for (ClassMap::const_iterator it = matchStart; it != matchEnd; ++it) {
         Class* klass = it->second.data();
-        auto item = new QStandardItem(klass->name);
-        item->setData(QVariant::fromValue(klass), CompletionMenu::ClassRole);
+        auto* item = new QStandardItem(klass->name);
         menu->addItem(item);
+        item->setData(QVariant::fromValue(klass), CompletionMenu::ClassRole);
     }
 
     menu->adapt();

--- a/editors/sc-ide/widgets/code_editor/autocompleter.cpp
+++ b/editors/sc-ide/widgets/code_editor/autocompleter.cpp
@@ -33,7 +33,6 @@
 #    include "../help_browser.hpp"
 #endif // SC_USE_QTWEBENGINE
 
-#include <iostream>
 #include <yaml-cpp/node/node.h>
 #include <yaml-cpp/parser.h>
 

--- a/editors/sc-ide/widgets/code_editor/autocompleter.cpp
+++ b/editors/sc-ide/widgets/code_editor/autocompleter.cpp
@@ -1237,8 +1237,10 @@ bool isMatchingMethod(DocNode* node, QString methodName) {
 
 QString AutoCompleter::getMethodDocs(DocNode* node, QString methodName, bool isClassMethod = false) {
     if (QString(node->id) == (isClassMethod ? "CMETHOD" : "IMETHOD") && isMatchingMethod(node, methodName)
-        && node->n_childs > 0) {
+        && node->n_childs >= 2) {
         QString str;
+        // first child is method name, which we want to skip here
+        // we want straight access to the body of the method doc
         parseClassNode(node->children[1], &str);
         return str;
     }

--- a/editors/sc-ide/widgets/code_editor/autocompleter.cpp
+++ b/editors/sc-ide/widgets/code_editor/autocompleter.cpp
@@ -785,8 +785,6 @@ void AutoCompleter::updateCompletionMenuInfo() {
         return;
     }
 
-    QString infos;
-
     auto methodName = mCompletion.menu->currentText();
     // setter methods are appended with `_`, but SCDoc maps does not have documentation for a setter method,
     // so we fall back to the getter method.
@@ -794,6 +792,7 @@ void AutoCompleter::updateCompletionMenuInfo() {
         methodName.chop(1);
     }
 
+    QString infos;
     switch (mCompletion.type) {
     case ClassCompletion:
         fillClassHelp(node, infos);

--- a/editors/sc-ide/widgets/code_editor/autocompleter.hpp
+++ b/editors/sc-ide/widgets/code_editor/autocompleter.hpp
@@ -61,7 +61,7 @@ private slots:
     void onCursorChanged();
     void onCompletionMenuFinished(int result);
     void fillClassHelp(DocNode* node, QString& infos);
-    void fillMethodHelp(DocNode* node, QString& infos, const QString& methodName);
+    void fillMethodHelp(DocNode* node, QString& infos, const QString& methodName, const QString& className);
     void fillClassMethodHelp(DocNode* node, QString& infos, const QString& methodName);
     void updateCompletionMenuInfo();
     void clearMethodCallStack();
@@ -135,6 +135,7 @@ private:
     static QString findHelpClass(QString klass);
     static DocNode* parseHelpClass(QString file);
     static QString parseClassElement(DocNode* node, QString element);
+    QString getMethodDocs(DocNode* node, QString methodName, bool isClassMethod);
     static void parseClassNode(DocNode* node, QString* str);
 
     // data

--- a/editors/sc-ide/widgets/code_editor/autocompleter.hpp
+++ b/editors/sc-ide/widgets/code_editor/autocompleter.hpp
@@ -60,6 +60,9 @@ private slots:
     void onContentsChange(int pos, int removed, int added);
     void onCursorChanged();
     void onCompletionMenuFinished(int result);
+    void fillClassHelp(DocNode* node, QString& infos);
+    void fillMethodHelp(DocNode* node, QString& infos, const QString& methodName);
+    void fillClassMethodHelp(DocNode* node, QString& infos, const QString& methodName);
     void updateCompletionMenuInfo();
     void clearMethodCallStack();
     void hideWidgets();

--- a/editors/sc-ide/widgets/code_editor/autocompleter.hpp
+++ b/editors/sc-ide/widgets/code_editor/autocompleter.hpp
@@ -62,7 +62,7 @@ private slots:
     void onCompletionMenuFinished(int result);
     void fillClassHelp(DocNode* node, QString& infos);
     void fillMethodHelp(DocNode* node, QString& infos, const QString& methodName, const QString& className);
-    void fillClassMethodHelp(DocNode* node, QString& infos, const QString& methodName);
+    void fillClassMethodHelp(DocNode* node, QString& infos, const QString& methodName, const QString& className);
     void updateCompletionMenuInfo();
     void clearMethodCallStack();
     void hideWidgets();

--- a/editors/sc-ide/widgets/code_editor/autocompleter.hpp
+++ b/editors/sc-ide/widgets/code_editor/autocompleter.hpp
@@ -132,14 +132,14 @@ private:
     static QString findHelpClass(QString klass);
     static DocNode* parseHelpClass(QString file);
     static QString parseClassElement(DocNode* node, QString element);
-    QString getMethodDocs(DocNode* node, QString methodName, bool isClassMethod);
+    QString getMethodDocs(const DocNode& node, QString methodName, bool isClassMethod) const;
     static void parseClassNode(DocNode* node, QString* str);
 
     // fill info box w/ docs
 
     void fillClassHelp(DocNode* node, QString& infos);
-    void fillMethodHelp(DocNode* node, QString& infos, const QString& methodName, const QString& className);
-    void fillClassMethodHelp(DocNode* node, QString& infos, const QString& methodName, const QString& className);
+    void fillMethodHelp(const DocNode& node, QString& infos, const QString& methodName, const QString& className);
+    void fillClassMethodHelp(const DocNode& node, QString& infos, const QString& methodName, const QString& className);
 
     // data
 

--- a/editors/sc-ide/widgets/code_editor/autocompleter.hpp
+++ b/editors/sc-ide/widgets/code_editor/autocompleter.hpp
@@ -60,9 +60,6 @@ private slots:
     void onContentsChange(int pos, int removed, int added);
     void onCursorChanged();
     void onCompletionMenuFinished(int result);
-    void fillClassHelp(DocNode* node, QString& infos);
-    void fillMethodHelp(DocNode* node, QString& infos, const QString& methodName, const QString& className);
-    void fillClassMethodHelp(DocNode* node, QString& infos, const QString& methodName, const QString& className);
     void updateCompletionMenuInfo();
     void clearMethodCallStack();
     void hideWidgets();
@@ -137,6 +134,12 @@ private:
     static QString parseClassElement(DocNode* node, QString element);
     QString getMethodDocs(DocNode* node, QString methodName, bool isClassMethod);
     static void parseClassNode(DocNode* node, QString* str);
+
+    // fill info box w/ docs
+
+    void fillClassHelp(DocNode* node, QString& infos);
+    void fillMethodHelp(DocNode* node, QString& infos, const QString& methodName, const QString& className);
+    void fillClassMethodHelp(DocNode* node, QString& infos, const QString& methodName, const QString& className);
 
     // data
 

--- a/editors/sc-ide/widgets/code_editor/autocompleter.hpp
+++ b/editors/sc-ide/widgets/code_editor/autocompleter.hpp
@@ -137,9 +137,9 @@ private:
 
     // fill info box w/ docs
 
-    void fillClassHelp(DocNode* node, QString& infos);
-    void fillMethodHelp(const DocNode& node, QString& infos, const QString& methodName, const QString& className);
-    void fillClassMethodHelp(const DocNode& node, QString& infos, const QString& methodName, const QString& className);
+    QString fillClassHelp(DocNode* node) const;
+    QString fillMethodHelp(const DocNode& node, const QString& methodName, const QString& className) const;
+    QString fillClassMethodHelp(const DocNode& node, const QString& methodName, const QString& className) const;
 
     // data
 

--- a/editors/sc-ide/widgets/code_editor/completion_menu.cpp
+++ b/editors/sc-ide/widgets/code_editor/completion_menu.cpp
@@ -89,7 +89,6 @@ const ScLanguage::Method* CompletionMenu::currentMethod() {
 }
 
 ScLanguage::Class* CompletionMenu::currentClass() {
-    // @todo use std::optional as return value
     QStandardItem* item = mModel->itemFromIndex(mFilterModel->mapToSource(mListView->currentIndex()));
 
     return item ? item->data(ClassRole).value<ScLanguage::Class*>() : nullptr;

--- a/editors/sc-ide/widgets/code_editor/completion_menu.cpp
+++ b/editors/sc-ide/widgets/code_editor/completion_menu.cpp
@@ -88,6 +88,14 @@ const ScLanguage::Method* CompletionMenu::currentMethod() {
     return item ? item->data(MethodRole).value<const ScLanguage::Method*>() : 0;
 }
 
+ScLanguage::Class* CompletionMenu::currentClass() {
+    // @todo use std::optional as return value
+    QStandardItem* item = mModel->itemFromIndex(mFilterModel->mapToSource(mListView->currentIndex()));
+
+    return item ? item->data(ClassRole).value<ScLanguage::Class*>() : nullptr;
+}
+
+
 QString CompletionMenu::exec(const QRect& rect) {
     QString result;
     QPointer<CompletionMenu> self = this;

--- a/editors/sc-ide/widgets/code_editor/completion_menu.cpp
+++ b/editors/sc-ide/widgets/code_editor/completion_menu.cpp
@@ -88,7 +88,7 @@ const ScLanguage::Method* CompletionMenu::currentMethod() {
     return item ? item->data(MethodRole).value<const ScLanguage::Method*>() : 0;
 }
 
-ScLanguage::Class* CompletionMenu::currentClass() {
+ScLanguage::Class* CompletionMenu::currentClass() const {
     QStandardItem* item = mModel->itemFromIndex(mFilterModel->mapToSource(mListView->currentIndex()));
 
     return item ? item->data(ClassRole).value<ScLanguage::Class*>() : nullptr;

--- a/editors/sc-ide/widgets/code_editor/completion_menu.hpp
+++ b/editors/sc-ide/widgets/code_editor/completion_menu.hpp
@@ -58,7 +58,7 @@ public:
     void setCompletionRole(int role);
     QString currentText();
     const ScLanguage::Method* currentMethod();
-    ScLanguage::Class* currentClass();
+    ScLanguage::Class* currentClass() const;
     QString exec(const QRect& rect);
     QSortFilterProxyModel* model();
     QListView* view();

--- a/editors/sc-ide/widgets/code_editor/completion_menu.hpp
+++ b/editors/sc-ide/widgets/code_editor/completion_menu.hpp
@@ -49,7 +49,7 @@ class CompletionMenu : public PopUpWidget {
     Q_OBJECT
 
 public:
-    enum DataRole { CompletionRole = Qt::UserRole, MethodRole };
+    enum DataRole { CompletionRole = Qt::UserRole, MethodRole, ClassRole };
 
     CompletionMenu(QWidget* parent = 0);
     void addItem(QStandardItem* item);
@@ -58,6 +58,7 @@ public:
     void setCompletionRole(int role);
     QString currentText();
     const ScLanguage::Method* currentMethod();
+    ScLanguage::Class* currentClass();
     QString exec(const QRect& rect);
     QSortFilterProxyModel* model();
     QListView* view();


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

Closes #7629.

## Purpose and Motivation

This PR displays the docs of methods in the autocomplete dialog of methods in a similar manner to the already existing class docs

https://github.com/user-attachments/assets/3f54409f-be72-46fb-9cfd-ff130fadde04

One change I did here was to explode the same methods instead of collapsing them. This is the current behavior

old | new
--- | ---
<img width="784" height="460" alt="Image" src="https://github.com/user-attachments/assets/81e42738-0554-44fc-9f5f-5e68bbd7927f" /> | <img width="880" height="323" alt="Image" src="https://github.com/user-attachments/assets/cf013ea3-bd42-464b-b2df-6cb2cba8e6f3" />

This introduces some (excessive?) scrolling if one wants to skim through all available methods, but I'd argue that b/c of the minimum of three chars this has never been intended for that usage.
This may change w/ some proper introspection from a future LSP, which is hopefully due in 3.16.

But IMO already a completion like this is very helpful in everyday usage

<img width="957" height="215" alt="image" src="https://github.com/user-attachments/assets/ce1e7efa-471d-484e-9274-35789cdc455c" />


## Types of changes

<!-- Delete lines that don't apply -->

- New feature

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
