### PR TITLE
Make http:// and https:// link-click functional in the Post window

### DIFF
--- a/SCClassLibrary/scide_scqt/ScIDE.sc
+++ b/SCClassLibrary/scide_scqt/ScIDE.sc
@@ -26,7 +26,6 @@ ScIDE {
 		});
 
 		PostWindowURLHandler.register(\http, {|url|
-			var prefix = "http://";
 			HelpBrowser.goTo(url)
 		});
 

--- a/SCClassLibrary/scide_scqt/ScIDE.sc
+++ b/SCClassLibrary/scide_scqt/ScIDE.sc
@@ -27,12 +27,12 @@ ScIDE {
 
 		PostWindowURLHandler.register(\http, {|url|
 			var prefix = "http://";
-			PostWindowURLHandler.prOpenRedirectMenu(url)
+			HelpBrowser.goTo(url)
 		});
 
 		PostWindowURLHandler.register(\https, {|url|
 			var prefix = "http://";
-			PostWindowURLHandler.prOpenRedirectMenu(url)
+			HelpBrowser.goTo(url)
 		});
 
 		StartUp.add {
@@ -470,26 +470,6 @@ PostWindowURLHandler {
 
 	*prDefault { |url|
 		"PostWindowURLHandler does not know how to handle the URL '%'".format(url).warn
-	}
-	*prOpenRedirectMenu { |url, useSCIDE|
-		var info = MenuAction("Choose how to open external link:").enabled_(false);
-		var domain = MenuAction(if(url.size < 75) {url} {url.replaceRegexp("https?:\/\/|(/.*)", "")} ).enabled_(false);
-		var separator = MenuAction().separator_(true);
-		var systemDefaultBrowser = MenuAction("Open in system default browser");
-		var helpBrowser = MenuAction("Open in SuperCollider's help browser (unsafe)");
-		var closeMenu = MenuAction("Cancel");
-		var menu = Menu(info, domain, separator, systemDefaultBrowser, helpBrowser, closeMenu);
-		var removeDependants = { [systemDefaultBrowser, helpBrowser, closeMenu].do(_.removeDependant)  };
-		systemDefaultBrowser.addDependant { |action, what| if (what == \triggered) { url.openOS; removeDependants.() } };
-		helpBrowser.addDependant { |action, what| if (what == \triggered) {
-			var redirectEnabledBeforeTrigger = HelpBrowser.redirectEnabled;
-			HelpBrowser.redirectEnabled_(false);
-			HelpBrowser.goTo(url);
-			HelpBrowser.redirectEnabled_(redirectEnabledBeforeTrigger);
-			removeDependants.()
-		}
-		};
-		^menu.front;
 	}
 }
 

--- a/SCClassLibrary/scide_scqt/ScIDE.sc
+++ b/SCClassLibrary/scide_scqt/ScIDE.sc
@@ -25,6 +25,16 @@ ScIDE {
 			{ Document.open("/" ++ parts[0], parts[1] ?? { 0 }, parts[2] ?? [0]) }.fork(AppClock)
 		});
 
+		PostWindowURLHandler.register(\http, {|url|
+			var prefix = "http://";
+			PostWindowURLHandler.prOpenRedirectMenu(url)
+		});
+
+		PostWindowURLHandler.register(\https, {|url|
+			var prefix = "http://";
+			PostWindowURLHandler.prOpenRedirectMenu(url)
+		});
+
 		StartUp.add {
 			if (this.connected) {
 				this.handshake
@@ -448,7 +458,7 @@ PostWindowURLHandler {
 	}
 
 	*register { |name, fn| registered[name] = fn }
-	
+
 	*new { |scheme, url|
 		var found = registered[scheme.asSymbol];
 		^if(found.isNil){
@@ -460,6 +470,26 @@ PostWindowURLHandler {
 
 	*prDefault { |url|
 		"PostWindowURLHandler does not know how to handle the URL '%'".format(url).warn
+	}
+	*prOpenRedirectMenu { |url, useSCIDE|
+		var info = MenuAction("Choose how to open external link:").enabled_(false);
+		var domain = MenuAction(if(url.size < 75) {url} {url.replaceRegexp("https?:\/\/|(/.*)", "")} ).enabled_(false);
+		var separator = MenuAction().separator_(true);
+		var systemDefaultBrowser = MenuAction("Open in system default browser");
+		var helpBrowser = MenuAction("Open in SuperCollider's help browser (unsafe)");
+		var closeMenu = MenuAction("Cancel");
+		var menu = Menu(info, domain, separator, systemDefaultBrowser, helpBrowser, closeMenu);
+		var removeDependants = { [systemDefaultBrowser, helpBrowser, closeMenu].do(_.removeDependant)  };
+		systemDefaultBrowser.addDependant { |action, what| if (what == \triggered) { url.openOS; removeDependants.() } };
+		helpBrowser.addDependant { |action, what| if (what == \triggered) {
+			var redirectEnabledBeforeTrigger = HelpBrowser.redirectEnabled;
+			HelpBrowser.redirectEnabled_(false);
+			HelpBrowser.goTo(url);
+			HelpBrowser.redirectEnabled_(redirectEnabledBeforeTrigger);
+			removeDependants.()
+		}
+		};
+		^menu.front;
 	}
 }
 

--- a/SCClassLibrary/scide_scqt/ScIDE.sc
+++ b/SCClassLibrary/scide_scqt/ScIDE.sc
@@ -30,7 +30,6 @@ ScIDE {
 		});
 
 		PostWindowURLHandler.register(\https, {|url|
-			var prefix = "http://";
 			HelpBrowser.goTo(url)
 		});
 


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->
fixes: #7634
## Purpose and Motivation

This PR makes http:// and https:// links clickable in the Post window.
Before this PR. clicking http:// and https:// was warned as below:
>WARNING: PostWindowURLHandler does not know how to handle the URL 'https://github.com/supercollider/supercollider'
<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix
- New feature

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
