### PR TITLE
Pgbrown: make .calcNext properly geometric

### DIFF
--- a/SCClassLibrary/Common/Streams/Patterns.sc
+++ b/SCClassLibrary/Common/Streams/Patterns.sc
@@ -492,7 +492,7 @@ Pbrown : Pattern {
 
 Pgbrown : Pbrown {
 	calcNext { arg cur, step;
-		^cur * (1 + step.xrand2)
+		^cur * exprand((1 + step).reciprocal, 1 + step)
 	}
 }
 


### PR DESCRIPTION
as discussed in issue #6654. Currently (before this PR) the distribution skews downward, which it shouldn't.
Note that the "wraparound" (that one gets if the return value from `calcNext` is outside the limits `lo, hi`) will still be linear., not geometric. I thought about fixing that too, but since this is handled by the `embedInStream` method, this is more complicated; and likely not worth the hassle; it only happens with unreasonable step sizes anyway.
So I opted for a very minimal fix, easier to review.

## Purpose and Motivation

see #6654

## Types of changes


- Bug fix

