### PR TITLE
Update README_LINUX.md (adds uninstall target)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -653,11 +653,13 @@ mark_as_advanced(SNDFILE SNDFILE_LIBRARY_DIR)
 mark_as_advanced(SC_HIDAPI)
 
 #############################################
-# Add uninstall target
-configure_file(
-  "${CMAKE_CURRENT_SOURCE_DIR}/cmake_uninstall.cmake.in"
-  "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake"
-  IMMEDIATE @ONLY)
+# uninstall target
+if(NOT TARGET uninstall)
+  configure_file(
+    "${CMAKE_CURRENT_SOURCE_DIR}/cmake_uninstall.cmake.in"
+    "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake"
+    IMMEDIATE @ONLY)
 
-add_custom_target(uninstall
-  COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake)
+  add_custom_target(uninstall
+    COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake)
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -651,3 +651,13 @@ mark_as_advanced(MATH_LIBRARY)
 mark_as_advanced(QT_QMAKE_EXECUTABLE)
 mark_as_advanced(SNDFILE SNDFILE_LIBRARY_DIR)
 mark_as_advanced(SC_HIDAPI)
+
+#############################################
+# Add uninstall target
+configure_file(
+  "${CMAKE_CURRENT_SOURCE_DIR}/cmake_uninstall.cmake.in"
+  "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake"
+  IMMEDIATE @ONLY)
+
+add_custom_target(uninstall
+  COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake)

--- a/README_LINUX.md
+++ b/README_LINUX.md
@@ -406,37 +406,11 @@ sudo ldconfig
 
 To uninstall:
 
-Since SuperCollider does not provide a make uninstall target, removing the files installed by sudo make install must be done manually. After deleting these files, only the Flatpak installation remains, and the duplicate entries in the Ubuntu start menu disappear.
+```shell
+sudo make uninstall
+```
 
-* Required:
-  ```shell
-  
-  sudo rm -f /usr/local/bin/sclang
-  sudo rm -f /usr/local/bin/scsynth
-  sudo rm -f /usr/local/bin/supernova
-  sudo rm -f /usr/local/bin/scide
-  
-  sudo rm -rf /usr/local/lib/SuperCollider
-  sudo rm -f /usr/local/lib/libsclang*
-  sudo rm -f /usr/local/lib/libscsynth*
-  sudo rm -f /usr/local/lib/libsupernova*
-  
-  sudo rm -rf /usr/local/include/SuperCollider
-  sudo rm -rf /usr/local/share/SuperCollider
-  
-  sudo rm -f /usr/local/share/applications/supercollider.desktop
-  ```
-* Optional:
-  ```shell
-  sudo ldconfig
-  ```
-* Verification:
-  ```shell
-  which sclang
-  which scsynth
-  which supernova
-  which scide
-  ```
+(or `make uninstall` if you did user-wide installation).
 
 ### Building a Debian package
 

--- a/README_LINUX.md
+++ b/README_LINUX.md
@@ -406,11 +406,37 @@ sudo ldconfig
 
 To uninstall:
 
-```shell
-sudo make uninstall
-```
+Since SuperCollider does not provide a make uninstall target, removing the files installed by sudo make install must be done manually. After deleting these files, only the Flatpak installation remains, and the duplicate entries in the Ubuntu start menu disappear.
 
-(or `make uninstall` if you did user-wide installation).
+* Required:
+  ```shell
+  
+  sudo rm -f /usr/local/bin/sclang
+  sudo rm -f /usr/local/bin/scsynth
+  sudo rm -f /usr/local/bin/supernova
+  sudo rm -f /usr/local/bin/scide
+  
+  sudo rm -rf /usr/local/lib/SuperCollider
+  sudo rm -f /usr/local/lib/libsclang*
+  sudo rm -f /usr/local/lib/libscsynth*
+  sudo rm -f /usr/local/lib/libsupernova*
+  
+  sudo rm -rf /usr/local/include/SuperCollider
+  sudo rm -rf /usr/local/share/SuperCollider
+  
+  sudo rm -f /usr/local/share/applications/supercollider.desktop
+  ```
+* Optional:
+  ```shell
+  sudo ldconfig
+  ```
+* Verification:
+  ```shell
+  which sclang
+  which scsynth
+  which supernova
+  which scide
+  ```
 
 ### Building a Debian package
 

--- a/cmake_uninstall.cmake.in
+++ b/cmake_uninstall.cmake.in
@@ -1,0 +1,21 @@
+if(NOT EXISTS "@CMAKE_BINARY_DIR@/install_manifest.txt")
+  message(FATAL_ERROR "Cannot find install manifest: @CMAKE_BINARY_DIR@/install_manifest.txt")
+endif()
+
+file(READ "@CMAKE_BINARY_DIR@/install_manifest.txt" files)
+string(REGEX REPLACE "\n" ";" files "${files}")
+foreach(file ${files})
+  message(STATUS "Uninstalling $ENV{DESTDIR}${file}")
+  if(IS_SYMLINK "$ENV{DESTDIR}${file}" OR EXISTS "$ENV{DESTDIR}${file}")
+    exec_program(
+      "@CMAKE_COMMAND@" ARGS "-E remove \"$ENV{DESTDIR}${file}\""
+      OUTPUT_VARIABLE rm_out
+      RETURN_VALUE rm_retval
+      )
+    if(NOT "${rm_retval}" STREQUAL 0)
+      message(FATAL_ERROR "Problem when removing $ENV{DESTDIR}${file}")
+    endif()
+  else(IS_SYMLINK "$ENV{DESTDIR}${file}" OR EXISTS "$ENV{DESTDIR}${file}")
+    message(STATUS "File $ENV{DESTDIR}${file} does not exist.")
+  endif()
+endforeach()

--- a/cmake_uninstall.cmake.in
+++ b/cmake_uninstall.cmake.in
@@ -7,10 +7,10 @@ string(REGEX REPLACE "\n" ";" files "${files}")
 foreach(file ${files})
   message(STATUS "Uninstalling $ENV{DESTDIR}${file}")
   if(IS_SYMLINK "$ENV{DESTDIR}${file}" OR EXISTS "$ENV{DESTDIR}${file}")
-    exec_program(
-      "@CMAKE_COMMAND@" ARGS "-E remove \"$ENV{DESTDIR}${file}\""
+    execute_process(
+      COMMAND "@CMAKE_COMMAND@" -E remove "$ENV{DESTDIR}${file}"
       OUTPUT_VARIABLE rm_out
-      RETURN_VALUE rm_retval
+      RESULT_VARIABLE rm_retval
       )
     if(NOT "${rm_retval}" STREQUAL 0)
       message(FATAL_ERROR "Problem when removing $ENV{DESTDIR}${file}")


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

closes: #6730

## Purpose and Motivation
On Linux, SuperCollider installations created via `sudo make install` or `make install` cannot be removed using `sudo make uninstall` or `make uninstall`, because the build system does not provide an uninstall target. Users must instead remove the installed files manually. This PR adds documentation describing the required steps.

The procedure was suggested by Microsoft Copilot, and I have verified that it works. However, as I am not a daily Linux user, there may still be edge cases I might have overlooked.

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->

- Documentation

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [ ] Code is tested
- [ ] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
