### PR TITLE
gha windows: use MSVC 2026

### DIFF
--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -31,15 +31,15 @@ jobs:
             # create-installer: ${{ startsWith(github.ref, 'refs/tags/') }}
             # installer-suffix: "win32-installer"
 
-          - job-name: "64-bit MSVC 2022 with ctest"
+          - job-name: "64-bit MSVC 2026 with ctest"
             fftw-arch: "x64"
             cmake-arch: "x64"
-            os-version: "2022"
+            os-version: "2025-vs2026"
             qt-version: "6.8.3"
             qt-arch: "win64_msvc2022_64"
             fftw-url: "ftp://ftp.fftw.org/pub/fftw/fftw-3.3.5-dll64.zip"
-            cmake-generator: "Visual Studio 17 2022"
-            vcvars-script-path: "C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Auxiliary/Build/vcvars64.bat"
+            cmake-generator: "Visual Studio 18 2026"
+            vcvars-script-path: "C:/Program Files/Microsoft Visual Studio/18/Enterprise/VC/Auxiliary/Build/vcvars64.bat"
             vcpkg-triplet: x64-windows-release
             use-qtwebengine: "ON" # might need to be turned off for MinGW
             qt-modules: 'qtwebengine qtwebchannel qtwebsockets qtpositioning'


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

Should we use MSVC 2026 for the Windows build?

Note: currently this causes the `scsynth_test_run` ctest to timeout. @JordanHendersonMusic do you have any idea about that? I know that ctests on Windows generally need work...

This PR is more of a question than a suggestion, hence I'm submitting it as a draft for now.

If we don't feel this is the right time to do this, I'm happy close this without merging.

## Types of changes

<!-- Delete lines that don't apply -->

- Maintenance

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [ ] Code is tested
- [ ] All tests are passing
- [ ] Updated documentation
- [ ] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
