### PR TITLE
Download ASIO headers in cmake

### DIFF
--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -67,7 +67,6 @@ jobs:
     env:
       BUILD_PATH: ${{ github.workspace }}/build
       INSTALL_PATH: ${{ github.workspace }}/build/Install
-      LIBS_DOWNLOAD_PATH: ${{ github.workspace }}/../3rd-party
       FFTW_INSTALL_DIR: "C:/Program Files/fftw"
       ARTIFACT_FILE: "SuperCollider-${{ inputs.sc-version }}-${{ matrix.artifact-suffix }}"
       INSTALLER_FILE: "SuperCollider-${{ inputs.sc-version }}-${{ matrix.installer-suffix }}"
@@ -134,17 +133,6 @@ jobs:
         run: |
           call "${{ matrix.vcvars-script-path }}"
           lib.exe /machine:${{ matrix.fftw-arch }} /def:libfftw3f-3.def
-
-      - name: install asio sdk
-        shell: bash
-        env:
-          ASIO_PATH: ${{ env.LIBS_DOWNLOAD_PATH }}/asio_sdk
-        run: |
-          mkdir -p $ASIO_PATH && cd $ASIO_PATH
-          curl -L https://www.steinberg.net/asiosdk -o asio.zip
-          7z x asio.zip -y
-          shopt -s nocaseglob
-          mv asiosdk* $GITHUB_WORKSPACE/external_libraries/portaudio/asiosdk
 
       - name: install readline
         if: matrix.vcpkg-triplet

--- a/external_libraries/portaudio/CMakeLists.txt
+++ b/external_libraries/portaudio/CMakeLists.txt
@@ -18,6 +18,42 @@ if(WIN32)
     set(PA_USE_DS OFF CACHE BOOL "Enable support for DirectSound" FORCE)
     set(PA_USE_WMME OFF CACHE BOOL "Enable support for MME" FORCE)
     set(PA_USE_WDMKS OFF CACHE BOOL "Enable support for WDMKS" FORCE)
+
+	# automatically download ASIO SDK if headers are not present
+	# asio is expected in the subdirectory "external_libraries/portaudio/as*"
+	# e.g. "external_libraries/portaudio/asiosdk"
+	# with header file at "external_libraries/portaudio/asiosdk/common/asio.h"
+	# FIXME: remove this after the portaudio submodule is updated above v19.7.0
+	# as the newer PortAudio provides the asio sdk download functionality
+	file(GLOB HEADER_FILE "${CMAKE_CURRENT_SOURCE_DIR}/as*/common/asio.h")
+	if(NOT HEADER_FILE)
+		if(CMAKE_VERSION VERSION_LESS 3.18)
+			message(STATUS "ASIO SDK NOT found. Download the ASIO SDK ZIP from "
+				"https://www.steinberg.net/asiosdk and extract its contents to "
+				"${CMAKE_CURRENT_SOURCE_DIR}/asiosdk"
+			)
+		else()
+			if(NOT ASIO_SDK_ZIP_PATH)
+				set(ASIO_SDK_ZIP_PATH "${CMAKE_CURRENT_BINARY_DIR}/asiosdk.zip")
+			endif()
+			message(STATUS "Downloading ASIO SDK... ${ASIO_SDK_ZIP_PATH}")
+			file(DOWNLOAD "https://www.steinberg.net/asiosdk"
+				"${ASIO_SDK_ZIP_PATH}"
+				STATUS ASIO_DOWNLOAD_STATUS
+			)
+			list(GET ASIO_DOWNLOAD_STATUS 0 DOWNLOAD_CODE)
+			if(DOWNLOAD_CODE EQUAL 0)
+				message(STATUS "ASIO SDK downloaded successfully")
+			else()
+				list(GET ASIO_DOWNLOAD_STATUS 1 DOWNLOAD_ERROR)
+				message(STATUS "Error downloading ASIO SDK: ${DOWNLOAD_ERROR}")
+			endif()
+			if(EXISTS "${ASIO_SDK_ZIP_PATH}")
+				message(STATUS "Extracting ASIO SDK ZIP archive: ${ASIO_SDK_ZIP_PATH}")
+				file(ARCHIVE_EXTRACT INPUT "${ASIO_SDK_ZIP_PATH}" DESTINATION "${CMAKE_CURRENT_SOURCE_DIR}")
+			endif()
+		endif()
+	endif()
 endif()
 
 # bump up cmake version to fix compatibility with cmake 4


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

On Windows, PortAudio needs ASIO headers in order to build the ASIO backend (practically required for low latency operation on Windows). ASIO headers can't be distributed with other projects for licensing reasons.

There a few ways to handle asio sdk download:
- require automatic downloading and extracting to a specific location in our source tree (current solution)
- automatic download in newer version of PortAudio (currently in their `master` branch, but not part of a release yet)
- automatic download in our cmake (this PR)
- switching to PortAudio from vcpkg (provides an option to download asio sdk automatically as a dependency). However, this approach exposes obsolete backends, which we [disabled](https://github.com/supercollider/supercollider/pull/6900) in the SC distribution.

The upcoming version of PortAudio provides automatic downloading of ASIO headers. Assuming we don't want to update our PortAudio code to a non-release version, I propose to add this automatic downloading functionality to our cmake to simplify building on Windows _for the time being_ (until a new version of PortAudio is released).

I was thinking about this for some time, but more recently when working on #7493, which explores the idea of using PortAudio from vcpkg (which does provide an option to automatically download asio sdk). However, I realized that providing our own version of PortAudio is still beneficial, since we can disable obsolete backends, as indicated above.

For reference, here's the [download code in upstream PortAudio](https://github.com/PortAudio/portaudio/blob/master/CMakeLists.txt#L208-L217), which I based the proposed implementation off of.

BTW the headers will only be downloaded once. [Here's a run where I left downloading the headers manually](https://github.com/dyfer/supercollider/actions/runs/29858405234/job/88745697682#step:13:43), and downloading in cmake is properly skipped.

What do you think?

## Types of changes

<!-- Delete lines that don't apply -->

- Maintenance
- New feature (?)

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [ ] All tests are passing
- [ ] Updated documentation - I'm not updating the documentation in this PR, since I'm reworking Windows docs separately in #7641
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
