### PR TITLE
Histogram class

### DIFF
--- a/HelpSource/Classes/Histogram.schelp
+++ b/HelpSource/Classes/Histogram.schelp
@@ -1,0 +1,117 @@
+title:: Histogram
+summary:: Representation of a distribution on some data.
+categories:: Math, Random
+related:: Classes/Plotter
+
+The Histogram object is 1. a container for some data along with the distributions derived from it,
+and 2. implements a plot method that facilitates creation of plots representing histograms.
+The primary intended use is to call it via its link::-.plot:: instance method.
+For general information regarding histogram representations,
+see link::https://en.wikipedia.org/wiki/Histogram##wikipedia:: or the statistics textbook of your choice.
+
+code::
+a = {9.3.sum3rand}.dup(500); // make up some "data"
+Histogram(a).plot; // and plot a histogram
+// equivalent to:
+a.histo.plot;
+a.plotHisto;
+// it is possible to instantiate a Histogram object without plotting it:
+h = Histogram(a) // same as a.histo;
+// and to change a parameter on an existing histogram.
+h.n_bins = 15;
+// notice that the plot (if it exists already) is automatically redrawn;
+// no need to call h.plot again!
+
+// it is also possible to plot multiple histograms simultaneously:
+// (provided the input collections are of the same size)
+// make some more data
+b = { 9.3.bilinrand }.dup(500)
+[a, b].histo.plot
+// if they're not of the same size:
+c = { 9.3.rand2 }.dup(100)
+a.size > c.size // -> true
+[a, b, c].histo.plot
+// comparison still possible but more data points == more better
+::
+
+classmethods::
+method:: new
+	argument:: data
+	a Collection of quantitative data. (i.e., of Numbers, not symbols)
+	argument:: n_bins
+	number of bins in the histogram. Default is code::data.size.sqrt.asInteger::.
+	If data is an array of arrays, the size of the first subarray decides the number of bins.
+	argument:: min
+	lower limit of the histogram; data points below this value will be counted as outliers.
+	argument:: max
+	upper limit of the histogram; data points above this value will be counted as outliers.
+	argument:: x_warp
+	set whether the range is linearly or geometrically subdivided into bins.
+	Geometric aka exponential aka logarithmic scaling is another obvious option (code::\exp::),
+	Linear (code::\lin::) is default.
+	but any object that implements code::.asWarp:: is possible.
+
+	returns:: a Histogram object, on which you can call link::##-.plot##::
+
+
+
+
+instancemethods::
+private:: prUpdateHistogram, prMakeFreqsArray, prPrepareDomainSpec
+method:: plot
+	returns a link::Classes/Plotter:: with the relevant attributes (domain, domainSpec, y-spec, limits, labels, plotMode) preset for you by the histogram instance.
+	If the present histogram intance has already created a plotter instance through an earlier call to this method,
+	that plotter is updated, no new plotter is created, and the parent argument will be ignored.
+	argument:: name
+	name of the plotter window
+	argument:: bounds
+	bounds of the plotter
+	argument:: parent
+	parent window of the plotter
+
+examples::
+subsection:: Compare some random number generators
+code::
+// turn methods into lambda functions through partial application syntax:
+f = [_.rand2, _.sum3rand, _.bilinrand, _.rand, _.linrand, exprand(0.001,_)];
+
+// write a funtion that generates distributions from these functions:
+d = { | func, range, n  |
+	{ func.(range) }.dup(n)
+};
+
+// and now, make the histogram for each function in the array f:
+g = f.collect { |fu| d.(fu, 5.0, 5000) } ;
+g.histo.plot
+
+// note that these do not all have the same ranges! ([-5,5], [0, 5], [0.001, 5].
+// By default, the histo class will set its min and max according to the min and max in all of the data
+// (e.g., even for the plot of the geometric distribution exprand, the min will be around -5,
+// because one of the other functions such as .rand2 or will have returned it).
+
+// n_bins will be calculated according to the first set of data (i.e., g[0] here),
+// via the squareroot of the number of data points in this dataset.
+// This is a rough rule of thumb only, and you should experiment with different n_bins.
+::
+
+subsection:: Histograms on discrete distributions
+code::
+// The Poisson distribution is discrete, i.e., it will return only integers.
+// convert the Ppoisson pattern to a Routine via .asStream
+// and then create 10000 "data points" via .nextN:
+p = Ppoisson(mean: 21).asStream.nextN(10000)
+
+// check if they're really all integers
+p.every(_.isInteger) // -> true (told you so)
+
+h = p.histo(15, 1, 41)
+h.plot
+// If the data is all integers, Histogram might adjust your n_bins for you!
+// (Check the post window.)
+
+// if you don't like this, convert to floating point first:
+p.asFloat.histo(15, 1, 41).plot // do as thou wilt
+
+// or use an exponential warp (when the range doesn't include zero):
+p.histo(55, 10, 41, x_warp: \exp).plot
+::

--- a/SCClassLibrary/Common/Collections/Collection.sc
+++ b/SCClassLibrary/Common/Collections/Collection.sc
@@ -633,41 +633,6 @@ Collection {
 		^res
 	}
 
-	histo { arg steps = 100, min, max;
-		var freqs, freqIndex, lastIndex, stepSize, outliers = 0;
-		if(this.isEmpty) { ^this.species.new };
-		min = min ?? { this.minItem };
-		max = max ?? { this.maxItem };
-
-		freqs = Array.fill(steps, 0);
-		lastIndex = steps - 1;
-		stepSize = steps / (max - min);
-
-		this.do { arg el;
-			freqIndex = ((el - min) * stepSize).asInteger;
-
-			if (freqIndex.inclusivelyBetween(0, lastIndex)) {
-				freqs[freqIndex] = freqs[freqIndex] + 1;
-			} {
-						// if max is derived from maxItem, count it in:
-				if (el == max) {
-					freqs[steps-1] = freqs[steps-1] + 1;
-				} { 		// else it is an outlier.
-					outliers =  outliers + 1;
-				};
-			};
-		};
-
-        if (outliers > 0) {
-            postf(
-                "Histogram : % of % values in the collection are out of the histogram range [%, %].\n",
-                outliers, this.size, min, max
-            )
-        };
-
-		^freqs;
-	}
-
 //	printAll { this.do { | item | item.postln; }; } // convenience method
 	printAll { |before, after|
 		if (before.isNil and: after.isNil) {

--- a/SCClassLibrary/Common/Collections/Histogram.sc
+++ b/SCClassLibrary/Common/Collections/Histogram.sc
@@ -8,93 +8,100 @@ Histogram  {
     var <plotter;
 
     *new { | data, n_bins, min, max, x_warp(\lin) |
-		if(data.isEmpty) { MethodError("Histogram.new: data is empty"); ^nil };
-        data = Histogram.prCheckData(data);
+		if(data.isEmpty) { MethodError("Histogram.new: data is empty").throw; };
         ^super.newCopyArgs(data, n_bins, min, max, x_warp)
             .prUpdateHistogram;
 	}
 
-    *prCheckData { |data|
-        if(not(data[0].isCollection)) {
-            data = [data]; // prepare for loop in prMakeFreqsArray
-        } {
-            if(data.collect(_.size).differentiate[1..].sum > 0) {
-                warn("Histogram.new: data arrays not of same sample size; \
-                    comparison may not be sensible")
-            };
-        };
-        ^data
-    }
-
     prUpdateHistogram {
         domainSpec = this.prPrepareDomainSpec;
-        freqsArray = this.prMakeFreqsArray;
-
-        // the data points should align with the middle of each bin,
-        // not at its left boundary.
-        // so we offset the Plotter's domain by half a bin width:
-        // UNLESS the plotmode does this already!? --> Verify
-        domain = domainSpec.map(Array.series(n_bins, 1 / (2  * n_bins), 1/n_bins));
+        if(data.maxDepth == 1) {
+            #freqsArray, outliers = this.prMakeFreqsArray(data);
+        } {
+            #freqsArray, outliers = data.collect (this.prMakeFreqsArray(_)).flop;
+        };
+        domain = domainSpec.map(Array.series(n_bins, 0, 1/(n_bins)));
+        // the values in domain give the lower bounds of each bins.
+        // this means that domain.last will be < max.
         yspec = [0, freqsArray.flat.maxItem * 1.05, \lin].asSpec;
         plotter !? { this.plot };
         ^this
     }
 
     prPrepareDomainSpec {
-        var range, binWidth;
-        n_bins = n_bins ?? { data[0].size.sqrt.ceil };
-        min = min ?? { data[0].minItem };
-		max = max ?? { data[0].maxItem };
+        // flat copy: mem abuse?
+        var range, binWidth, new_n_bins, new_max, dataflat = data.flat;
+        n_bins = n_bins ?? { data.shape.last.sqrt.ceil };
+        min = min ?? { dataflat.minItem };
+		max = max ?? { dataflat.maxItem };
         range = max - min;
-        if(data.every(_.every(_.isInteger)) and: { x_warp === \lin }) {
-            if (n_bins > range) {
-                n_bins = range.asInteger
-            } { // binWidth needs to be integer;
-                // so we round up n_bins
-                binWidth = (range/n_bins).ceil;
-                n_bins = (range/binWidth).ceil.asInteger;
+        if(x_warp === \lin and: { dataflat.every(_.isInteger) } ) {
+            range = range + 1; // this +1 is for the max (e.g.: 4 - 2 = 2, but interval [2, 4] includes 3 integers)
+            if (n_bins >= range) {
+                new_n_bins = range.asInteger;
+            } { // binWidth should be integer.
+                // if not, there may be artifacts where certain bins contain more integers than others
+                // e.g.: the intervals (bins) [1.9, 3.1) and  [2.1, 3.3), are of the same size,
+                // but the former contains 2 integer values (2 and 3); contains only 1 (3);
+                // first, establish bin width closest to specified extremes and n_bins:
+                if (not(range.isPrime)) {
+                    binWidth = range/(n_bins + [0, 1, -1, 2, -2]);
+                    binWidth = binWidth.detect { |x| x.floor == x }
+                };
+                binWidth = binWidth ?? { (range/n_bins).round.asInteger };
+                // we may in turn have to round n_bins as well:
+                new_n_bins = (range/binWidth).round.asInteger;
                 // update max accordingly
-                max = n_bins * binWidth + min;
+                new_max = new_n_bins * binWidth + min - 1;
+                if ( new_max != max or: { new_n_bins != n_bins } ) {
+                    n_bins = new_n_bins;
+                    max = new_max;
+                    postln("Histogram: adjustments for integer domain: \n"
+                        "adjusted max and/or n_bins to permit integer bin width and avoid artifacts.\n"
+                        "bin width = %; width of rightmost bin may be larger by 1. \n"
+                        "using n_bins = %, max = %".format(binWidth, n_bins, max))
+                }
             }
-        }
+        };
         ^[min, max, x_warp].asSpec;
     }
 
-    prMakeFreqsArray {
-		var freqs, freqIndexArray, lastIndex;
-		lastIndex = n_bins - 1;
-		freqs = 0.dup([data.size, n_bins]);
-        outliers = 0.dup(data.size);
+    prMakeFreqsArray { | data1d |
+		var freqs, freqIndex, outliers1d;
+		freqs = 0.dup(n_bins);
+        outliers1d = 0;
 
-        data.do { | dataset, datasetIndex |
-            freqIndexArray = (domainSpec.unmap(dataset) * lastIndex).floor.asInteger ;
-		    freqIndexArray.do { |freqIndex, i|
-                // freqIndex is now constrained (by the unmapping) to [0, lastIndex];
-                // so we need to distinguish clipped outliers from actual first/last bin values
-                if (freqIndex != 0 and: { freqIndex != lastIndex } or: { dataset[i].inclusivelyBetween(min, max) } ) {
-                    freqs[datasetIndex][freqIndex] = freqs[datasetIndex][freqIndex] + 1;
-                } { // else it is an outlier.
-                    outliers[datasetIndex] =  outliers[datasetIndex] + 1;
-                };
-            };
+        data1d.do { | x |
+            freqIndex = (domainSpec.unmap(x) * n_bins).asInteger;
+            // Note that (only) when x >= max, this will output n_bins,
+            // even though the last index of freqs is n_bins - 1.
+            // this is intentional; the last bin interval is closed on both sides,
+            // i.e., it should include the max, and this slight asymmetry requires special treatment.
+            // special cases:
+            // 1. freqIndex == n_bins; this happens when x == max and with outliers (i.e., x > max)
+            // 2. freqIndex == 0; this happens when x is in the first bin (not just when x == min !), and with outliers (x < min).
+            case
+                {freqIndex.exclusivelyBetween(0, n_bins)} { freqs[freqIndex] = freqs[freqIndex] + 1 }
+                { x == max } { freqs[n_bins-1] = freqs[n_bins-1] + 1 }
+                { x > max } { outliers1d = outliers1d + 1 }
+                { x >= min } { freqs[0] = freqs[0] + 1 }
+                { outliers1d = outliers1d + 1 }
         };
 
-        if (outliers.any(_ > 0)) {
-                data.size.do { |i|
-                    postf("Histogram : % of % values in the collection are out of the histogram range [%, %].\n",
-                    outliers[i], data[i].size, min, max)
-                }
+        if (outliers1d > 0) {
+                postf("Histogram : % of % values in the collection are out of the histogram range [%, %].\n",
+                outliers1d, data1d.size, min, max)
         };
+		^[freqs, outliers1d];
+    }
 
-		^freqs;
-	}
 
     data_ { | new_data |
         data = Histogram.prCheckdata(new_data);
         this.prUpdateHistogram
     }
 
-    n_bins_ {| new_n_bins |
+    n_bins_ { | new_n_bins |
         n_bins = new_n_bins;
         this.prUpdateHistogram
     }

--- a/SCClassLibrary/Common/Collections/Histogram.sc
+++ b/SCClassLibrary/Common/Collections/Histogram.sc
@@ -30,22 +30,23 @@ Histogram  {
 
     prPrepareDomainSpec {
         // flat copy: mem abuse?
-        var range, binWidth, new_n_bins, new_max, dataflat = data.flat;
+        var range, binWidth, new_n_bins, new_max, dataflat = data.asArray.flat;
         n_bins = n_bins ?? { data.shape.last.sqrt.ceil };
         min = min ?? { dataflat.minItem };
 		max = max ?? { dataflat.maxItem };
         range = max - min;
-        if(x_warp === \lin and: { dataflat.every(_.isInteger) } ) {
-            range = range + 1; // this +1 is for the max (e.g.: 4 - 2 = 2, but interval [2, 4] includes 3 integers)
+        if(x_warp === \lin or: { x_warp === \linear } and: { dataflat.every(_.isInteger) } ) {
+            range = range + 1; // this +1 is to include the max (e.g.: 4 - 2 = 2, but interval [2, 4] includes 3 integers)
             if (n_bins >= range) {
-                new_n_bins = range.asInteger;
+                n_bins = range.asInteger;
             } { // binWidth should be integer.
                 // if not, there may be artifacts where certain bins contain more integers than others
                 // e.g.: the intervals (bins) [1.9, 3.1) and  [2.1, 3.3), are of the same size,
                 // but the former contains 2 integer values (2 and 3); contains only 1 (3);
                 // first, establish bin width closest to specified extremes and n_bins:
                 if (not(range.isPrime)) {
-                    binWidth = range/(n_bins + [0, 1, -1, 2, -2]);
+                    // test if other possible values for n_bins result in Integer binWidth
+                    binWidth = range/(n_bins + ([0] ++ (1..n_bins.div(4)) *.x [1, -1]));
                     binWidth = binWidth.detect { |x| x.floor == x }
                 };
                 binWidth = binWidth ?? { (range/n_bins).round.asInteger };
@@ -58,7 +59,7 @@ Histogram  {
                     max = new_max;
                     postln("Histogram: adjustments for integer domain: \n"
                         "adjusted max and/or n_bins to permit integer bin width and avoid artifacts.\n"
-                        "bin width = %; width of rightmost bin may be larger by 1. \n"
+                        "bin width = %; width of rightmost bin may still be larger by 1. \n"
                         "using n_bins = %, max = %".format(binWidth, n_bins, max))
                 }
             }
@@ -121,10 +122,13 @@ Histogram  {
         this.prUpdateHistogram
     }
 
-    plot {
+    plot { | name, bounds, parent |
         // if a plotter already exists, update its values rather than making a new one.
-        plotter = plotter !? { plotter.value = freqsArray } ?? { freqsArray.plot };
-        plotter.domainSpecs_([domainSpec])
+        plotter = plotter !? { plotter.value = freqsArray } ?? { freqsArray.plot(name, bounds, parent: parent) };
+        plotter
+            .name_(name ?? { plotter.name })
+            .bounds_(bounds ?? { plotter.bounds })
+            .domainSpecs_([domainSpec])
             .domain_(domain)
             .specs_([yspec])
             .plotMode_(\bars)

--- a/SCClassLibrary/Common/Collections/Histogram.sc
+++ b/SCClassLibrary/Common/Collections/Histogram.sc
@@ -1,0 +1,141 @@
+Histogram  {
+    var <data, <n_bins, <min, <max, <x_warp; //these have dedicated setters further down
+    var <freqsArray;
+    var <domain;
+    var <domainSpec;
+    var <yspec;
+    var <outliers;
+    var <plotter;
+
+    *new { | data, n_bins, min, max, x_warp(\lin) |
+		if(data.isEmpty) { MethodError("Histogram.new: data is empty"); ^nil };
+        data = Histogram.prCheckData(data);
+        ^super.newCopyArgs(data, n_bins, min, max, x_warp)
+            .prUpdateHistogram;
+	}
+
+    *prCheckData { |data|
+        if(not(data[0].isCollection)) {
+            data = [data]; // prepare for loop in prMakeFreqsArray
+        } {
+            if(data.collect(_.size).differentiate[1..].sum > 0) {
+                warn("Histogram.new: data arrays not of same sample size; \
+                    comparison may not be sensible")
+            };
+        };
+        ^data
+    }
+
+    prUpdateHistogram {
+        domainSpec = this.prPrepareDomainSpec;
+        freqsArray = this.prMakeFreqsArray;
+
+        // the data points should align with the middle of each bin,
+        // not at its left boundary.
+        // so we offset the Plotter's domain by half a bin width:
+        // UNLESS the plotmode does this already!? --> Verify
+        domain = domainSpec.map(Array.series(n_bins, 1 / (2  * n_bins), 1/n_bins));
+        yspec = [0, freqsArray.flat.maxItem * 1.05, \lin].asSpec;
+        plotter !? { this.plot };
+        ^this
+    }
+
+    prPrepareDomainSpec {
+        var range, binWidth;
+        n_bins = n_bins ?? { data[0].size.sqrt.ceil };
+        min = min ?? { data[0].minItem };
+		max = max ?? { data[0].maxItem };
+        range = max - min;
+        if(data.every(_.every(_.isInteger)) and: { x_warp === \lin }) {
+            if (n_bins > range) {
+                n_bins = range.asInteger
+            } { // binWidth needs to be integer;
+                // so we round up n_bins
+                binWidth = (range/n_bins).ceil;
+                n_bins = (range/binWidth).ceil.asInteger;
+                // update max accordingly
+                max = n_bins * binWidth + min;
+            }
+        }
+        ^[min, max, x_warp].asSpec;
+    }
+
+    prMakeFreqsArray {
+		var freqs, freqIndexArray, lastIndex;
+		lastIndex = n_bins - 1;
+		freqs = 0.dup([data.size, n_bins]);
+        outliers = 0.dup(data.size);
+
+        data.do { | dataset, datasetIndex |
+            freqIndexArray = (domainSpec.unmap(dataset) * lastIndex).floor.asInteger ;
+		    freqIndexArray.do { |freqIndex, i|
+                // freqIndex is now constrained (by the unmapping) to [0, lastIndex];
+                // so we need to distinguish clipped outliers from actual first/last bin values
+                if (freqIndex != 0 and: { freqIndex != lastIndex } or: { dataset[i].inclusivelyBetween(min, max) } ) {
+                    freqs[datasetIndex][freqIndex] = freqs[datasetIndex][freqIndex] + 1;
+                } { // else it is an outlier.
+                    outliers[datasetIndex] =  outliers[datasetIndex] + 1;
+                };
+            };
+        };
+
+        if (outliers.any(_ > 0)) {
+                data.size.do { |i|
+                    postf("Histogram : % of % values in the collection are out of the histogram range [%, %].\n",
+                    outliers[i], data[i].size, min, max)
+                }
+        };
+
+		^freqs;
+	}
+
+    data_ { | new_data |
+        data = Histogram.prCheckdata(new_data);
+        this.prUpdateHistogram
+    }
+
+    n_bins_ {| new_n_bins |
+        n_bins = new_n_bins;
+        this.prUpdateHistogram
+    }
+
+    min_ { | new_min |
+        min = new_min;
+        this.prUpdateHistogram
+    }
+
+    max_ {| new_max |
+        max = new_max;
+        this.prUpdateHistogram
+    }
+
+    x_warp_ {| new_warp |
+        x_warp = new_warp;
+        this.prUpdateHistogram
+    }
+
+    plot {
+        // if a plotter already exists, update its values rather than making a new one.
+        plotter = plotter !? { plotter.value = freqsArray } ?? { freqsArray.plot };
+        plotter.domainSpecs_([domainSpec])
+            .domain_(domain)
+            .specs_([yspec])
+            .plotMode_(\bars)
+            .axisLabelY_("Occurrences")
+            .axisLabelX_("Bins")
+            .refresh;
+        ^plotter;
+    }
+
+}
+
++ Collection {
+    // from Collection
+    histo { |n_bins, min, max, x_warp|
+        ^Histogram.new(this, n_bins, min, max, x_warp)
+    }
+    // from PlotView.sc
+    plotHisto { |n_bins, min, max, x_warp|
+        ^Histogram.new(this, n_bins, min, max, x_warp).plot;
+    }
+}

--- a/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
+++ b/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
@@ -1424,6 +1424,7 @@ Plotter {
 			case
 			{ elem.isKindOf(Env) }       { elem.asMultichannelSignal.flop }
 			{ elem.isKindOf(Wavetable) } { elem.asSignal }
+			{ elem.isKindOf(Histogram) } { ^this.collect(_.data).histo(min: minval, max: maxval).plot(name, bounds, parent) }
 			{ elem.isNil }               { Error("Cannot plot array: non-numeric value at index %".format(i)).throw }
 			{ hasSubArrays }             { elem.asArray }
 			{ elem };

--- a/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
+++ b/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
@@ -1442,24 +1442,6 @@ Plotter {
 	}
 }
 
-+ Collection {
-	plotHisto { arg steps = 100, min, max;
-		var histo = this.histo(steps, min, max);
-		var plotter = histo.plot;
-		var minmax = [min ?? { this.minItem }, max ?? { this.maxItem }];
-		var binwidth = minmax[1] - minmax[0] / steps;
-
-		^plotter
-		.domainSpecs_([minmax.asSpec])
-		.specs_([[0, histo.maxItem * 1.05, \linear, 1].asSpec])
-		.plotMode_(\steps)
-		.axisLabelY_("Occurrences")
-		.axisLabelX_("Bins")
-		.domain_(binwidth * (0..steps-1) + minmax[0])
-		;
-	}
-}
-
 
 + Function {
 	plot { |duration = 0.01, target, bounds, minval, maxval, separately = false, parent|

--- a/testsuite/classlibrary/TestHistogram.sc
+++ b/testsuite/classlibrary/TestHistogram.sc
@@ -1,0 +1,80 @@
+TestHistogram : UnitTest {
+    test_data_recoverable {
+        // not sure if this really needs to be tested for...
+        // but maybe regression etc.
+        var data = {2.0.rand}!25;
+        this.assertEquals(data, data.histo.data,
+            "Histogram should allow acces to the data used to generate it")
+    }
+
+    test_number_of_bins_smaller_than_number_of_datapoints {
+        // a modest assumption. Won't hold if n = 1, sadly
+        var n = 7;
+        var data = {2.0.rand}!n;
+        this.assert(data.histo.n_bins < n,
+        "Histogram: when n_bins is automatically assigned (default), it should be smaller than number of datapoints")
+    }
+
+
+    test_auto_minmax_precludes_outliers {
+        var data = {27.0.rand}.dup(100);
+
+        this.assertEquals(data.histo.outliers, 0,
+        "Histogram: when min and max are automatically assigned (default), no outliers should occur")
+    }
+
+    test_all_datapoints_accounted_for1 {
+        var data = {7.0.rand}.dup(100);
+        var histo = data.histo;
+
+        this.assertEquals(data.size, histo.freqsArray.sum + histo.outliers,
+        "Histogram: sum of frequencies plus outliers should equal number of data points")
+    }
+
+    test_all_datapoints_accounted_for2 {
+        var data = {7.0.sum3rand}.dup(100);
+        var histo = data.histo(25, 2, 5);
+
+        this.assertEquals(data.size, histo.freqsArray.sum + histo.outliers,
+        "Histogram: sum of frequencies plus outliers should equal number of data points")
+    }
+
+        // ok, this won't work
+    test_avoid_integer_aliasing {
+        var data = {200.rand}.dup(170);
+        var min = 10, max = 189; //this might produce pseudo outliers
+        var n_bins = 16; // this is close, but should get corrected
+        var histo = data.histo(n_bins, min, max);
+        this.assert( histo.range == 179 and: ( histo.n_bins == 16 ) and: (histo.binSize == 12),
+        "Histogram: when data is Integers, only allow integer bin sizes")
+    }
+
+    test_permit_change_of_histo_params_on_existing_data {
+        var data = {200.rand}.dup(170);
+        var histo = data.histo;
+        var histoChanged = histo.copy().n_bins_(10).x_warp_(\exp).min_(20).max_(70);
+
+        this.assertEquals(histo.data, histoChanged.data,
+        "Histogram: changes in the histo parameters should not affect underlying data")
+    }
+
+    test_empty_data_error {
+        var data = [];
+        this.assertException({data.histo}, MethodError,
+            "Histogram: empty data should throw error"
+        )
+    }
+
+    test_domain_geometric {
+        var data = Array.series(1000, 1, 29/999); //linearly uniform distro
+        var n_bins = 10;
+        var min = 1, max = 30;
+        var x_warp = \exp; // but histo domain is exp
+        var histo = data.histo(n_bins, min, max, x_warp);
+        // expected result: higher bins get more hits than lower bins
+        this.assert( histo.freqsArray.last > histo.freqsArray.first,
+        "Histogram: when domain is geometrically scaled (x_warp=\exp), bins should also be allotted geometrically"
+        )
+
+    }
+}

--- a/testsuite/classlibrary/TestHistogram.sc
+++ b/testsuite/classlibrary/TestHistogram.sc
@@ -39,18 +39,18 @@ TestHistogram : UnitTest {
         "Histogram: sum of frequencies plus outliers should equal number of data points")
     }
 
-        // ok, this won't work
     test_avoid_integer_aliasing {
-        var data = {200.rand}.dup(170);
-        var min = 10, max = 189; //this might produce pseudo outliers
-        var n_bins = 16; // this is close, but should get corrected
+        var data = {rrand(10, 189)}.dup(170);
+        var min = 10, max = 189; //
+        var n_bins = 16; // this is close, but should get corrected to 15
         var histo = data.histo(n_bins, min, max);
-        this.assert( histo.range == 179 and: ( histo.n_bins == 16 ) and: (histo.binSize == 12),
+        var binWidth = (histo.domain[1] - histo.domain[0]).round;
+        this.assert( (histo.max - histo.min) == 179 and: { histo.n_bins == 15 } and: { binWidth == 12},
         "Histogram: when data is Integers, only allow integer bin sizes")
     }
 
     test_permit_change_of_histo_params_on_existing_data {
-        var data = {200.rand}.dup(170);
+        var data = { rrand(0.001, 2000) }.dup(170);
         var histo = data.histo;
         var histoChanged = histo.copy().n_bins_(10).x_warp_(\exp).min_(20).max_(70);
 


### PR DESCRIPTION


I noticed that there are currently two slightly different ways to draw Histograms in sc:
Collection.histo.plot and Collection.plotHisto, where the latter looks a bit better.

So I figured I'd make a Histogram class on the basis of those two that would unify the histogramming in sc.

With this PR, collection.histo.plot and collection.plotHisto both become aliases
of Histogram.new(collection).plot.

The class and its methods were originally mostly reshuffled material from the above collection methods, but I've tinkered with that a fair bit to enable the following:
- exponential (or even arbitrary) scaling of domain via warp
- will also take arrays of arrays as data arg, roughly like .plot does
- some niceties regarding special cases (i.e., when all the data are integers).
- rule-of-thumb auto calculation of number of bins when not provided (data.size.sqrt).

- 
Anyway, looks better and should be a non-breaking change.
also added some tests, but they are outdated. let's see if they still pass ... 


## Types of changes

- New feature

## To-do list

**TODO: determine where in the class library this file should sit. Is `common/collections` ok?**
TODO: schelp update in Collection.schelp for plotHisto and histo methods!
~~TODO: some aliasing that happens with plotmode \bars on the plotter side when there are lots of bins, I had a simple fix for it but I forgot where I saved that.~~


- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review

