### PR TITLE
Add warning against bundling external Extensions inside Quarks

### DIFF
--- a/HelpSource/Guides/UsingQuarks.schelp
+++ b/HelpSource/Guides/UsingQuarks.schelp
@@ -202,7 +202,7 @@ Quarks.addFolder("~/supercollider/quarks");
 Now you can (un)install your own packages from your local folder.
 
 warning::
-If your Quark relies on any extension that is not a Quark, list it as a dependency in your README instead of relying on the Quarks to install that extension.
+If your Quark relies on any extension that is not a Quark, list it as a dependency in your README instead of relying on the Quarks system to install that extension.
 ::
 
 Managing your code with git is optional, but you should consider using it early on. Even if you do not intend to share your code with anyone else, git provides a backup system and a time machine if you break something.

--- a/HelpSource/Guides/UsingQuarks.schelp
+++ b/HelpSource/Guides/UsingQuarks.schelp
@@ -211,11 +211,7 @@ Quarks.addFolder("~/supercollider/quarks");
 Now you can (un)install your own packages from your local folder.
 
 warning::
-Do not include plugins, extensions, or classes distributed by others directly inside
-your Quark folder. SuperCollider loads Extensions globally, so placing an external
-Extension inside a Quark can cause duplicate class errors for users who have already
-installed that Extension separately, according to that extension’s installation
-instructions.
+Do not include plugins, extensions, or classes distributed by others directly inside your Quark folder. SuperCollider loads Extensions globally, so placing an external Extension inside a Quark can cause duplicate class errors for users who have already installed that Extension separately, according to that extension’s installation instructions.
 
 Example:
 
@@ -225,8 +221,7 @@ ERROR: duplicate Class found: 'SomeClassName'
 ~/Library/Application Support/SuperCollider/downloaded-quarks/YourQuark/classes/...
 ::
 
-If your Quark depends on an external Extension, declare it as a dependency in your
-README file or in the Quark metadata, rather than bundling the Extension itself.
+If your Quark depends on an external Extension, declare it as a dependency in your README file or in the Quark metadata, rather than bundling the Extension itself.
 ::
 
 Managing your code with git is optional, but you should consider using it early on. Even if you do not intend to share your code with anyone else, git provides a backup system and a time machine if you break something.

--- a/HelpSource/Guides/UsingQuarks.schelp
+++ b/HelpSource/Guides/UsingQuarks.schelp
@@ -215,7 +215,6 @@ ERROR: duplicate Class found: 'SomeClassName'
 
 If your Quark depends on an external Extension, declare it as a dependency in your
 README file or in the Quark metadata, rather than bundling the Extension itself.
-
 ::
 
 Managing your code with git is optional, but you should consider using it early on. Even if you do not intend to share your code with anyone else, git provides a backup system and a time machine if you break something.

--- a/HelpSource/Guides/UsingQuarks.schelp
+++ b/HelpSource/Guides/UsingQuarks.schelp
@@ -28,6 +28,18 @@ list::
 
 section:: Installing/uninstalling/updating quarks
 
+warning::
+soft::&hsp;::Some Quarks are not actively maintained and may cause errors during compilation or usage. The most frequently encountered errors are:
+
+list::
+## teletype::ERROR: duplicate Class found::
+## teletype::ERROR: Found duplicate instance variable name::
+::
+
+If you encounter such issues, you can report the problem by creating an issue in the Quark's repository. More proactive users are encouraged to fork the repository, resolve the issue, and open a Pull Request.
+
+In these situations, rather than relying solely on the built-in documentation, you may need to independently troubleshoot the problem. We recommend actively seeking help on link::https://scsynth.org:: or other social network services.
+::
 
 subsection::using the GUI
 

--- a/HelpSource/Guides/UsingQuarks.schelp
+++ b/HelpSource/Guides/UsingQuarks.schelp
@@ -29,7 +29,7 @@ list::
 section:: Installing/uninstalling/updating quarks
 
 warning::
-soft::&hsp;::Some Quarks are not actively maintained and may cause errors during compilation or usage. The most frequently encountered errors are:
+Some Quarks are not actively maintained and may cause errors during compilation or usage. The most frequently encountered errors are:
 
 list::
 ## teletype::ERROR: duplicate Class found::

--- a/HelpSource/Guides/UsingQuarks.schelp
+++ b/HelpSource/Guides/UsingQuarks.schelp
@@ -29,12 +29,7 @@ list::
 section:: Installing/uninstalling/updating quarks
 
 warning::
-Some Quarks are not actively maintained and may cause errors during compilation or usage. The most frequently encountered errors are:
-
-list::
-## teletype::ERROR: duplicate Class found::
-## teletype::ERROR: Found duplicate instance variable name::
-::
+Some Quarks are not actively maintained and may cause errors during compilation or usage.
 
 If you encounter such issues, you can report the problem by creating an issue in the Quark's repository. More proactive users are encouraged to fork the repository, resolve the issue, and open a Pull Request.
 

--- a/HelpSource/Guides/UsingQuarks.schelp
+++ b/HelpSource/Guides/UsingQuarks.schelp
@@ -198,6 +198,26 @@ Quarks.addFolder("~/supercollider/quarks");
 
 Now you can (un)install your own packages from your local folder.
 
+warning::
+Do not include plugins, extensions, or classes distributed by others directly inside
+your Quark folder. SuperCollider loads Extensions globally, so placing an external
+Extension inside a Quark can cause duplicate class errors for users who have already
+installed that Extension separately, according to that extension’s installation
+instructions.
+
+Example:
+
+teletype::
+ERROR: duplicate Class found: 'SomeClassName'
+~/Library/Application Support/SuperCollider/Extensions/SomeExtension/classes/...
+~/Library/Application Support/SuperCollider/downloaded-quarks/YourQuark/classes/...
+::
+
+If your Quark depends on an external Extension, declare it as a dependency in your
+README file or in the Quark metadata, rather than bundling the Extension itself.
+
+::
+
 Managing your code with git is optional, but you should consider using it early on. Even if you do not intend to share your code with anyone else, git provides a backup system and a time machine if you break something.
 
 code::

--- a/HelpSource/Guides/UsingQuarks.schelp
+++ b/HelpSource/Guides/UsingQuarks.schelp
@@ -202,17 +202,7 @@ Quarks.addFolder("~/supercollider/quarks");
 Now you can (un)install your own packages from your local folder.
 
 warning::
-Do not include plugins, extensions, or classes distributed by others directly inside your Quark folder. SuperCollider loads Extensions globally, so placing an external Extension inside a Quark can cause duplicate class errors for users who have already installed that Extension separately, according to that extension’s installation instructions.
-
-Example:
-
-teletype::
-ERROR: duplicate Class found: 'SomeClassName'
-~/Library/Application Support/SuperCollider/Extensions/SomeExtension/classes/...
-~/Library/Application Support/SuperCollider/downloaded-quarks/YourQuark/classes/...
-::
-
-If your Quark depends on an external Extension, declare it as a dependency in your README file or in the Quark metadata, rather than bundling the Extension itself.
+If your Quark relies on any extension that is not a Quark, list it as a dependency in your README instead of relying on the Quarks to install that extension.
 ::
 
 Managing your code with git is optional, but you should consider using it early on. Even if you do not intend to share your code with anyone else, git provides a backup system and a time machine if you break something.

--- a/HelpSource/Guides/UsingQuarks.schelp
+++ b/HelpSource/Guides/UsingQuarks.schelp
@@ -30,10 +30,6 @@ section:: Installing/uninstalling/updating quarks
 
 warning::
 Some Quarks are not actively maintained and may cause errors during compilation or usage.
-
-If you encounter such issues, you can report the problem by creating an issue in the Quark's repository. More proactive users are encouraged to fork the repository, resolve the issue, and open a Pull Request.
-
-In these situations, rather than relying solely on the built-in documentation, you may need to independently troubleshoot the problem. We recommend actively seeking help on link::https://scsynth.org:: or other social network services.
 ::
 
 subsection::using the GUI


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

Recently, I encountered a Quark that included an external Extension both as a
declared dependency and also bundled the Extension inside its own directory:
https://scsynth.org/t/performative-a-toolkit-for-creating-performance-instruments-and-designing-parameters-in-supercollider/13461/11?u=prko

This caused unnecessary errors, forcing users to remove the Extension from the
SC-IDE Preferences path and manually delete the folder in Finder or any equivalent
file manager.

This PR adds a warning to address this problematic practice among some Quark authors.

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->

- Documentation

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
