### PR TITLE
Plot - centered stepwise plotmodes on geometric domainSpecs

### DIFF
--- a/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
+++ b/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
@@ -12,7 +12,7 @@ Plot {
 	var <>labelMargin = 2;  // margin around tick or axis labels
 	var <>borderMargin = 3; // margin separating the edge of the view from its inner elements
 	var <>hideLabelsHeightRatio = 1.2, <>hideLabelsWidthRatio = 1.5; // hide labels below plot:labels ratio
-	var domainPad = 0.0, halfBinWidthPx = 0.0; // for steplike data width
+	var plotXPad = 0.0, halfBinWidthPx = 0.0; // for steplike data width
 	var valueCache, resolution;
 
 	*initClass {
@@ -225,22 +225,20 @@ Plot {
 		domainSpec = sp;
 
 		// update private domain specs to give visual padding to the beginning and end of the data
-		if(value.size > 1) {
-			domainPad = if(this.hasCenteredSteplikeDisplay) {
-				if(plotter.domain.isNil)
-				{ 0.5 } // domain step defaults to 1
-				{ plotter.domain.differentiate.drop(1).minItem / 2 }
+		// this padding is a fraction of the plotBounds (e.g. 1/200 for data of size 100)
+		plotXPad = if(this.hasCenteredSteplikeDisplay) {
+				(value.size).reciprocal/2
 			} {
 				0.0
 			};
-
+		if(value.size > 1) {
 			prDomainSpec = domainSpec.copy;
 			prDomainSpec
-			.minval_(domainSpec.minval - domainPad)
-			.maxval_(domainSpec.maxval + domainPad);
+				.minval_(domainSpec.warp.map(0 - plotXPad))
+				.maxval_(domainSpec.warp.map(1 + plotXPad));
+			// warp.map can take args outside [0, 1], which spec.map would clip
 		} {
 			prDomainSpec = domainSpec;
-			domainPad = if(this.hasCenteredSteplikeDisplay) { 0.5 } { 0.0 };
 		};
 
 		if(gridOnX and: { prDomainSpec.notNil }) {
@@ -398,7 +396,7 @@ Plot {
 	}
 
 	domainCoordinates { |size|
-		var vals, domainRange;
+		var vals; // linear in [0, 1]
 
 		if (plotter.domain.notNil) {
 			vals = prDomainSpec.unmap(plotter.domain);
@@ -406,15 +404,11 @@ Plot {
 			if (size == 1 or: { domainSpec.range == 0.0 }) {
 				vals = 0.5.dup(size) // put the values in the middle of the plot
 			} {
-				vals = prDomainSpec.unmap(
-					Array.interpolation(size, domainSpec.minval, domainSpec.maxval)
-				);
+				vals = Array.interpolation(size, plotXPad, 1 - plotXPad)
 			}
 		};
 
-		domainRange = prDomainSpec.range;
-		if(domainRange == 0) { domainRange = 1 };
-		halfBinWidthPx = domainPad / domainRange * plotBounds.width;
+		halfBinWidthPx = plotXPad * plotBounds.width;
 
 		^plotBounds.left + (vals * plotBounds.width);
 	}
@@ -587,7 +581,7 @@ Plot {
 		var barWidth = halfBinWidthPx * 2 - (2 * gap);
 		var centery = 0.linlin(this.spec.minval, this.spec.maxval, plotBounds.bottom, plotBounds.top, clip: nil);
 
-		Pen.smoothing_(false);
+		Pen.smoothing_(true);
 
 		y.size.do { |i|
 			var p = x[i] @ y[i];

--- a/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
+++ b/SCClassLibrary/Common/GUI/PlusGUI/Math/PlotView.sc
@@ -576,12 +576,13 @@ Plot {
 	}
 
 	bars { |x, y|
-		var gap = halfBinWidthPx * 0.1;
+		// if gaps would be < 1 pixel, don't draw gaps at all.
+		var gap = if(halfBinWidthPx >= 5) { halfBinWidthPx * 0.1 } { 0 };
 		var xOffset = halfBinWidthPx.neg + gap;
 		var barWidth = halfBinWidthPx * 2 - (2 * gap);
 		var centery = 0.linlin(this.spec.minval, this.spec.maxval, plotBounds.bottom, plotBounds.top, clip: nil);
 
-		Pen.smoothing_(true);
+		Pen.smoothing_(false);
 
 		y.size.do { |i|
 			var p = x[i] @ y[i];


### PR DESCRIPTION
Noticed this when I did my histogram PR: 
The current implementation of the stepwise-centered plot modes introduced by @mtmccrea only works when the domainSpec is linear; for geometric (i.e. /exp) domainSpecs, the x - location of the data points is off,  because of the  halfBinWidthPx calculation  and in the case of the \bars plotmode, this results in bars that are too thin, too thick, what have you. 

The reason is a muddling of the data's x coordinate (e.g., the independent variable x of a function y(x)) and the plot's x coordinate (the horizontal component of the input to Pen, in pixels). But because the plot's x coordinate is linear, this only really becomes apparent when the data's x coordinate is not.

The variable previously named `domainPad` (which I rename to plotXPad) actually is more easily specified with respect _not_ to the data's x coordinate (`domain`, `domainSpec`) but with respect to the plot's x coordinate, which is equivalent to `Array.interpolation(domain.size) * plotBounds.width`, aka `(0..size-1)/(size - 1) * plotBounds.width`, i.e. some fraction of the plotBounds.

So the thing that needed to be changed is this:
```
domainPad = { plotter.domain.differentiate.drop(1).minItem / 2 } 

```
(i.e., half the difference between the first two items)
which needed to be divided by domainRange further down to express a fraction of
the plotBounds:
```
halfBinWidthPx = (domainPad / domainRange) * plotBounds.width
```

the problem is the detour via domain, which only works when said domain is linear.
turns out the detour is unnecessary, as we can express the fraction without recourse to the domain:

```
plotXPad = (value.size).reciprocal/2
halfBinWidthPx = plotXPad * plotBounds.width
```
this also means that the domainRange variable (not used anywhere else) becomes unnecessary, and that it becomes easier to deal with geometric domainSpecs.

additional changes reflect the fact that domainXPad is now a fraction in [0,1] rather than a magnitude in the domain, which permitted some simplifications.

What _still_ doesn't work (and is not worth fixing imo, though I've thought about it) is when domain values are irregular with respect to some warp, because then a fixed halfBinWidthPx won't do. As an example: If domainspec is linear but there should be bars at x = 1, 2, 4, 8, 16... then bin width is itself dependent on x position. This is doable in principle but I doubt anyone cares.

- Tested with the "centered stepwise" examples from Plotter.schelp. 

## Some pictures:
```
x = Array.geom(25, 1, 25.pow(1/24))
y = 2 * x
y.plot.plotMode_(\bars).domainSpecs_([[1,25,\exp]])
```


Before:
<img width="400" height="324" alt="image" src="https://github.com/user-attachments/assets/093e9a10-e442-4e72-b0b8-ac59855d976d" />

After: 
<img width="400" height="324" alt="image" src="https://github.com/user-attachments/assets/3255ef3c-564c-4968-bbd6-1a766e08fed6" />



