### PR TITLE
Make doc heading sticky but collapse upon scrolling

### DIFF
--- a/HelpSource/static/scdoc.css
+++ b/HelpSource/static/scdoc.css
@@ -54,8 +54,13 @@ p {
 
 a {
     /* The menu bar takes some pixels which we need to respect
-    when jumping to an anchor. */
-    scroll-margin-top: var(--menu-bar-height);
+    when jumping to an anchor.
+    Additionally, some offset is added b/c of the dynamic height
+    of the collapsing header (see .header.collapsed).
+    At some point, this should be dynamically linked via a css property
+    instead of hardcoding heights...
+     */
+    scroll-margin-top: calc(var(--menu-bar-height) + 70px);
 }
 
 a:link, a:visited, a:link:hover {

--- a/HelpSource/static/scdoc.css
+++ b/HelpSource/static/scdoc.css
@@ -125,7 +125,7 @@ a.subclass_toggle:hover {
     padding: 0.5em 0;
     background-color: var(--color-bg);
     box-shadow: 0em 0em 0.25em var(--color-fg-200);
-    z-index: 2;
+    z-index: 3;
 }
 
 #nav {
@@ -246,9 +246,21 @@ li.menuitem a.menu-link.home {
     border: 1px solid var(--color-fg-100);
 }
 
-
 .header {
-  padding-bottom: 0.18em;
+    padding-bottom: 0.18em;
+    position: sticky;
+    top: var(--menu-bar-height);
+    background: var(--color-bg);
+    z-index: 2;
+    border-bottom: 1px solid var(--color-fg-100);
+
+    h1 {
+        transition: font-size 0.4s;
+    }
+
+    &.collapsed h1 {
+        font-size: 1.3em;
+    }
 }
 
 #label {

--- a/HelpSource/static/scdoc.js
+++ b/HelpSource/static/scdoc.js
@@ -378,3 +378,22 @@ function toggleLineNumbers(v) {
       t.editor.setOption("lineNumbers", v);
     });
 }
+
+
+// collapse the header of the docs while scrolling
+function setStickyHeaderResize() {
+    document.addEventListener('DOMContentLoaded', function () {
+        const header = document.querySelector('.header');
+        if (!header) return;
+
+        window.addEventListener('scroll', function () {
+            if (window.scrollY > 80) {
+                header.classList.add('collapsed');
+            } else {
+                header.classList.remove('collapsed');
+            }
+        });
+    });
+}
+
+setStickyHeaderResize();

--- a/SCClassLibrary/SCDoc/SCDoc.sc
+++ b/SCClassLibrary/SCDoc/SCDoc.sc
@@ -384,7 +384,7 @@ SCDocNode {
 SCDoc {
 
 	// Increment this whenever we make a change to the SCDoc system or its static files so that all help-files should be processed again
-	classvar version = 78;
+	classvar version = 79;
 
 	classvar <helpTargetDir;
 	classvar <helpTargetUrl;


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

Closes https://github.com/supercollider/supercollider/issues/7655

Makes the class name/header sticky and collapse it upon scrolling such that it doesn't consume too much screen estate. Adds even more JS though ;/

Maybe prko can test this on some site, i.e. search, home, browse, etc - on my quick test I hadn't run into any issues

https://github.com/user-attachments/assets/687b38a0-1a3b-4a00-b8a0-0c15178dfb56

## Types of changes

<!-- Delete lines that don't apply -->
- New feature

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [ ] Code is tested
- [ ] All tests are passing
- [ ] Updated documentation
- [ ] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->

