### PR TITLE
typo correctioin

### DIFF
--- a/HelpSource/Classes/SortedList.schelp
+++ b/HelpSource/Classes/SortedList.schelp
@@ -9,7 +9,7 @@ Creates a SortedList with the initial capacity given by strong::size:: and a com
 
 The function must accept two arguments and return true if and only if the first argument comes before the second argument in the sort order.  
 If omitted, defaults to code::{|a, b| a < b}::.  
-(Note that this is slightly different from what link::Classes/SequentialCollection#-.sort:: does by default, which uses the code::<=:: operator instead.)
+(Note that this is slightly different from what link::Classes/SequenceableCollection#-.sort:: does by default, which uses the code::<=:: operator instead.)
 
 code::
 t = SortedList.new(8, {|a,b| a.first < b.first });


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

This PR fixes a typo introduced in #7649.
<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->

- Documentation

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
