### PR TITLE
gha: switch gcc 11 build to Ubuntu 24.04

### DIFF
--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -15,7 +15,7 @@ jobs:
         include:
 
           - job-name: ""
-            os-version: "22.04"
+            os-version: "24.04"
             c-compiler: "gcc-11"
             cxx-compiler: "g++-11"
             use-syslibs: false


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

Ubuntu 22.04 images will be [deprecated in the next few months](https://github.com/actions/runner-images/issues/14254). 
We can still build using gcc 11, but let's do this using the newer OS.

The remaining 22.04 build will be replaced in a separate PR moving the test runner to a newer version.

## Types of changes

<!-- Delete lines that don't apply -->

- Maintanance

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [n/a] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
