### PR TITLE
gha: update ubuntu images

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   lint:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v7
@@ -41,7 +41,7 @@ jobs:
           FULL_CHECK: 1
 
   version-getter:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     outputs:
       sc-version: ${{ steps.set-version.outputs.version }}
 

--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -56,9 +56,9 @@ jobs:
             ctest: true
             
           - job-name: ""
-            os-version: "22.04"
-            c-compiler: "clang-11"
-            cxx-compiler: "clang++-11"
+            os-version: "24.04"
+            c-compiler: "clang-14"
+            cxx-compiler: "clang++-14"
             use-syslibs: false
             shared-libscsynth: false
             ctest: false

--- a/.github/workflows/lint_non_code.yml
+++ b/.github/workflows/lint_non_code.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   lint-non-code-files:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v7


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

Update oldest clang build to use ubuntu 24.04, where the oldest available clang is 14. The underlying reason is to stop using 22.04 images, as these will be deprecated and removed eventually.

I also updated the "utility" jobs to use `ubuntu-latest` image. This will make them use the latest stable image.

This should've been a part of #7662 but I missed it, sorry

## Types of changes

<!-- Delete lines that don't apply -->

- Maintenance

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [ ] Code is tested
- [ ] All tests are passing
- [ ] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
