### PR TITLE
gha: add Windows MSVC 2026 build

### DIFF
--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -46,6 +46,20 @@ jobs:
             installer-suffix: "win64-installer"
             ctest-cmd: "RUN_TESTS"
 
+          - job-name: "64-bit MSVC 2026"
+            cmake-arch: "x64"
+            os-version: "2025-vs2026"
+            qt-version: "6.8.3"
+            qt-arch: "win64_msvc2022_64"
+            cmake-generator: "Visual Studio 18 2026"
+            vcpkg-triplet: x64-windows-release
+            qt-modules: 'qtwebengine qtwebchannel qtwebsockets qtpositioning'
+            artifact-suffix: "win64-msvc2026" # set if needed - will trigger artifact upload
+            # create-installer: ${{ startsWith(github.ref, 'refs/tags/') }}
+            # installer-suffix: "win64-installer"
+            # ctest: true
+            # ctest-cmd: "RUN_TESTS"
+
           - job-name: "64-bit MinGW with ctest"
             fftw-arch: "x64"
             os-version: "2022"


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

It would be nice to test building SC with Visual Studio 2026, which we should support.

Some ctests hang with MSVC 2026, so I didn't enable ctests for that job... hopefully we can get to this at some point.

I've kept the regular release still using MSVC 2022, but I added artifact upload for 2026 (zip only, not the installer) so that the msvc 2026 build can be tested locally.

## Types of changes

<!-- Delete lines that don't apply -->

- New feature (...)

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [n/a] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
