### PR TITLE
Recorder: Use String instead of Symbol for file path in Post window

### DIFF
--- a/SCClassLibrary/Common/Control/Recorder.sc
+++ b/SCClassLibrary/Common/Control/Recorder.sc
@@ -35,7 +35,7 @@ Recorder {
 			if(this.isRecording.not) {
 				this.prRecord(bus, node, duration);
 				this.changedServer(\recording, true);
-				"Recording channels % ... \npath: '%'\n"
+				"Recording channels % ... \npath: \"%\"\n"
 				.postf(bus + (0..this.numChannels - 1), recordBuf.path);
 			} {
 				if(paused) {
@@ -69,7 +69,7 @@ Recorder {
 		if(recordNode.isPlaying) {
 			recordNode.run(false);
 			this.changedServer(\pausedRecording);
-			"... paused recording.\npath: '%'\n".postf(recordBuf.path);
+			"... paused recording.\npath: \"%\"\n".postf(recordBuf.path);
 		} {
 			"Not Recording".warn
 		};
@@ -81,7 +81,7 @@ Recorder {
 			if(paused) {
 				recordNode.run(true);
 				this.changedServer(\recording, true);
-				"Resumed recording ...\npath: '%'\n".postf(recordBuf.path);
+				"Resumed recording ...\npath: \"%\"\n".postf(recordBuf.path);
 			}
 		} {
 			"Not Recording".warn


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

**File paths are typically used as Strings, and using Symbols for file paths is uncommon. This PR improves workflow efficiency by ensuring that copied file paths behave as expected. `.openOS` below is just an example of using pasted file paths from the Post window.**

This PR fixes an issue in several recorder‑related log messages where the percent sign indicating the path of the recorded file was printed using single quotes, for example:
```supercollder
"Recording channels % ... \npath: '%'\n".postf(recordBuf.path);
"Resumed recording ...\npath: '%'\n".postf(recordBuf.path);
"... paused recording.\npath: '%'\n".postf(recordBuf.path);
```
When users copy the printed path from the Post window
```text
-> localhost
Preparing recording on 'localhost'
Recording channels [0, 1] ... 
path: '/Users/prko/Music/SuperCollider Recordings/SC_260731_131303.wav'
Recording Stopped: (SC_260731_131303.wav)
```
 and attempt to open it via:
```supercollider
'/Users/prko/Music/SuperCollider Recordings/SC_260731_131303.wav'.openOS // <- <copied path>.openOS;
```
SuperCollider interprets the copied value as a Symbol, not a String, which results in the following error:
```text
ERROR: Message 'openOS' not understood.
RECEIVER:
   Symbol '/Users/.../SC_260731_131303.wav'
```
Only String objects respond to openOS, so this behaviour prevents users from opening recorded files directly from the copied output.

To resolve this, the percent sign is now printed inside double quotes:
```supercollider
"Recording channels % ... \npath: \"%\"\n".postf(recordBuf.path);
"Resumed recording ...\npath: \"%\"\n".postf(recordBuf.path);
"... paused recording.\npath: \"%\"\n".postf(recordBuf.path);
```
<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->

- Improve workflow

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
