### PR TITLE
plugins: Median: clip length to 1 to fix out-of-bounds server crash

### DIFF
--- a/HelpSource/Classes/Median.schelp
+++ b/HelpSource/Classes/Median.schelp
@@ -18,7 +18,8 @@ argument::length
 Number of input points in which to find the median. Must be an
 odd number from 1 to 31. If
 code::length::  is 1
-then Median has no effect.
+then Median has no effect. Values below 1 are clipped to 1, values
+above 31 are clipped to 31.
 
 
 argument::in

--- a/server/plugins/FilterUGens.cpp
+++ b/server/plugins/FilterUGens.cpp
@@ -2626,7 +2626,9 @@ void Median_Ctor(Median* unit) {
     // printf("Median_Reset\n");
     SETCALC(Median_next);
     float in = ZIN0(1);
-    unit->m_medianSize = sc_clip((int)ZIN0(0), 0, kMAXMEDIANSIZE);
+    // a length below 1 leaves pos at -1 in Median_InsertMedian, which then indexes
+    // m_medianValue out of bounds; 1 is the documented minimum and is a no-op
+    unit->m_medianSize = sc_clip((int)ZIN0(0), 1, kMAXMEDIANSIZE);
     Median_InitMedian(unit, unit->m_medianSize, in);
     ZOUT0(0) = Median_InsertMedian(unit, in);
 }

--- a/testsuite/classlibrary/TestFilterUGens.sc
+++ b/testsuite/classlibrary/TestFilterUGens.sc
@@ -167,16 +167,23 @@ TestFilterUGens : UnitTest {
 	// A length below 1 left the insertion index at -1 in Median_InsertMedian,
 	// which then indexed the median buffer out of bounds and took the server
 	// down with it. Median's own help file documents the valid range as 1 to 31.
-	test_Median_length_below_one_does_not_crash_server {
-		[0.5, 0, -1].do { |length|
-			{ Median.ar(length, DC.ar(0)) }.play(target: server);
-		};
+	test_medianLengthBelowOne {
+		var condition = CondVar();
+		var signal;
 
-		server.sync;
+		{ Median.ar(length: [0.5, 0, -1], in: DC.ar(0)) }.loadToFloatArray(
+			duration: 0.01,
+			target: server,
+			action: { |array| signal = array; condition.signalOne }
+		);
 
 		this.assert(
-			server.serverRunning and: { server.unresponsive.not },
-			"server should survive Median.ar with a length below 1"
+			condition.waitFor(5),
+			"Median.ar with a length below 1 should render instead of taking the server down"
+		);
+		this.assert(
+			signal.notNil and: { signal.every { |sample| sample == 0.0 } },
+			"a length below 1 should clip to 1, which passes the input through unchanged"
 		);
 	}
 

--- a/testsuite/classlibrary/TestFilterUGens.sc
+++ b/testsuite/classlibrary/TestFilterUGens.sc
@@ -172,7 +172,7 @@ TestFilterUGens : UnitTest {
 			{ Median.ar(length, DC.ar(0)) }.play(target: server);
 		};
 
-		0.5.wait;
+		server.sync;
 
 		this.assert(
 			server.serverRunning and: { server.unresponsive.not },

--- a/testsuite/classlibrary/TestFilterUGens.sc
+++ b/testsuite/classlibrary/TestFilterUGens.sc
@@ -164,6 +164,22 @@ TestFilterUGens : UnitTest {
 		this.assertEquals(result, 1, "Integral of a single 1 should be 1");
 	}
 
+	// A length below 1 left the insertion index at -1 in Median_InsertMedian,
+	// which then indexed the median buffer out of bounds and took the server
+	// down with it. Median's own help file documents the valid range as 1 to 31.
+	test_Median_length_below_one_does_not_crash_server {
+		[0.5, 0, -1].do { |length|
+			{ Median.ar(length, DC.ar(0)) }.play(target: server);
+		};
+
+		0.5.wait;
+
+		this.assert(
+			server.serverRunning and: { server.unresponsive.not },
+			"server should survive Median.ar with a length below 1"
+		);
+	}
+
 	test_ugen_generator_equivalences {
 		var condvar = CondVar();
 		var completed = 0;


### PR DESCRIPTION
## Purpose and Motivation

Fixes #7645.

`Median_Ctor` clips the length argument with a lower bound of 0, so `Median.ar(0.5, ...)` ends up with `m_medianSize == 0`. In `Median_InsertMedian` that makes `last` -1, the ageing loop never runs, and `pos` is still -1 when the loop ends. It then reads `m_medianValue[pos - 1]` and writes `m_medianValue[pos]`, both out of bounds, and scsynth dies. Negative lengths clip to 0 and hit the same path.

Clipping to 1 instead. Median.schelp already gives the valid range as 1 to 31, and Pitch guards its own median with `if (unit->m_medianSize > 1)`, so nothing was meant to run below that. Length 1 is already the pass-through case: `pos` becomes 0, neither while loop runs, and the input sample comes back unchanged.

## Types of changes

- Documentation
- Bug fix

## To-do list

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review

I confirmed the overflow and the fix with AddressSanitizer and the plugin builds clean, but I couldn't get the class library suite to run locally (headless sclang never finished booting the server here), so CI is the first real run of the new test. Leaving that box unchecked until it goes green.
