### PR TITLE
Add path change in `SCDocStyling.schelp`

### DIFF
--- a/HelpSource/Reference/SCDocStyling.schelp
+++ b/HelpSource/Reference/SCDocStyling.schelp
@@ -41,9 +41,9 @@ File.copy(
 After pasting, open the custom.css file and
 use the Find/Replace feature to replace ../images with /images in the following locations:
 - Line 153: background-image: url("../images/SC_icon.png");
-- Line 614: background: url("./../images/vline.png") repeat-y;
-- Line 628: background: url("./../images/node.png") no-repeat;
-- Line 634: background: var(--color-bg) url("./../images/lastnode.png") no-repeat;
+- Line 614: background: url("../images/vline.png") repeat-y;
+- Line 628: background: url("../images/node.png") no-repeat;
+- Line 634: background: var(--color-bg) url("../images/lastnode.png") no-repeat;
 */
 )
 

--- a/HelpSource/Reference/SCDocStyling.schelp
+++ b/HelpSource/Reference/SCDocStyling.schelp
@@ -37,6 +37,14 @@ File.copy(
 	SCDoc.helpTargetDir +/+ "static" +/+ "themes" +/+ "default.css",
 	SCDoc.helpTargetDir +/+ "custom.css"
 )
+/*
+After pasting, open the custom.css file and
+use the Find/Replace feature to replace ../images with /images in the following locations:
+- Line 153: background-image: url("../images/SC_icon.png");
+- Line 614: background: url("./../images/vline.png") repeat-y;
+- Line 628: background: url("./../images/node.png") no-repeat;
+- Line 634: background: var(--color-bg) url("./../images/lastnode.png") no-repeat;
+*/
 )
 
 // open directory with all themes

--- a/HelpSource/static/scdoc.css
+++ b/HelpSource/static/scdoc.css
@@ -611,7 +611,7 @@ ul.toc li a:hover {
 
 ul.tree, ul.tree ul {
  list-style-type: none;
- background: url("./../images/vline.png") repeat-y;
+ background: url("../images/vline.png") repeat-y;
  margin: 0;
  padding: 0;
  margin-left: 1em;
@@ -625,13 +625,13 @@ ul.tree li {
  margin: 0;
  padding: 0 12px;
  line-height: 20px;
- background: url("./../images/node.png") no-repeat;
+ background: url("../images/node.png") no-repeat;
 /* color: #369;
  font-weight: bold;*/
 }
 
 ul.tree li:last-child {
- background: var(--color-bg) url("./../images/lastnode.png") no-repeat;
+ background: var(--color-bg) url("../images/lastnode.png") no-repeat;
 }
 
 /* is this still used? */


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation
`SCDocStyling.schelp` provides a copy‑and‑paste code example as a starting point for `custom.css`. However, this causes users to encounter issues with missing images.  
This PR resolves the problem by updating the image paths in `SCDocStyling.schelp`.
<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->

- Documentation

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
