### PR TITLE
Fix indentation and hierarchy in Function.play documentation

### DIFF
--- a/HelpSource/Classes/Function.schelp
+++ b/HelpSource/Classes/Function.schelp
@@ -489,15 +489,14 @@ The add action for the synth.  For a list of valid addActions see link::Classes/
 argument::args
 An array of key value pairs of control names and control values which are used when starting the synth.
 
+discussion::
+
 note::
 Some UGens are added in this process.
 list::
 ## an link::Classes/Out:: UGen for playing the audio to the first audio busses. If the function returns an Out UGen, this is omitted. ##an envelope with a code::\gate:: control for releasing and crossfading. If the function provides its own releasable envelope, this is omitted.
 ::
 ::
-
-
-
 
 code::
 x = { |freq = 440| SinOsc.ar(freq, 0, 0.3) }.play; // this returns a Synth object;


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation
The play method for Function has incorrect indentation and hierarchy. The “Note” section and the content below it are not part of the args argument.
This PR fixes the indentation and structure accordingly.

### Before this PR:
<img width="1163" height="1047" alt="Screenshot 2026-08-14 at 14 06 12" src="https://github.com/user-attachments/assets/27417e81-091c-4ddb-ab40-02b6a11b0176" />

### With this PR:
<img width="865" height="1053" alt="Screenshot 2026-08-14 at 14 03 56" src="https://github.com/user-attachments/assets/ba21246e-d0d0-441a-95cc-c2127d020e4b" />

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->

- Documentation

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
