### PR TITLE
classlib: 'delete' the newCopyArgs method on QObject preventing a segfaut

### DIFF
--- a/SCClassLibrary/Common/GUI/Base/QObject.sc
+++ b/SCClassLibrary/Common/GUI/Base/QObject.sc
@@ -48,6 +48,10 @@ QObject {
 		^super.new.initQObject( className, argumentArray );
 	}
 
+	*newCopyArgs { |...args, kwargs| 
+		Error("Please replace call to 'newCopyArgs' with a call to 'new'. All QObjects must call the 'new' method.").throw
+	}
+
 	*heap { ^heap.copy }
 
 	initQObject{ arg className, argumentArray;


### PR DESCRIPTION
## Purpose and Motivation

Closes #7685

Initialising a subclass of qobject without calling the 'new' method will result in a segfault.



## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix


## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [ ] Code is tested
- [ ] All tests are passing
- [ ] Updated documentation
- [ ] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
