### PR TITLE
plugins: add `else` to alignment checks in `PanUGens`

### DIFF
--- a/server/plugins/PanUGens.cpp
+++ b/server/plugins/PanUGens.cpp
@@ -153,7 +153,7 @@ void LinPan2_Ctor(LinPan2* unit) {
 #ifdef NOVA_SIMD
         if (BUFLENGTH == 64)
             SETCALC(LinPan2_next_ak_nova_64);
-        if (boost::alignment::is_aligned(BUFLENGTH, 16))
+        else if (boost::alignment::is_aligned(BUFLENGTH, 16))
             SETCALC(LinPan2_next_ak_nova);
         else
 #endif
@@ -429,7 +429,7 @@ void XFade2_Ctor(XFade2* unit) {
 #ifdef NOVA_SIMD
         if (BUFLENGTH == 64)
             SETCALC(XFade2_next_ak_nova_64);
-        if (boost::alignment::is_aligned(BUFLENGTH, 16))
+        else if (boost::alignment::is_aligned(BUFLENGTH, 16))
             SETCALC(XFade2_next_ak_nova);
         else
 #endif
@@ -796,7 +796,7 @@ void Pan2_Ctor(Pan2* unit) {
 #if defined(NOVA_SIMD)
         if (BUFLENGTH == 64)
             SETCALC(Pan2_next_ak_nova_64);
-        if (boost::alignment::is_aligned(BUFLENGTH, 16))
+        else if (boost::alignment::is_aligned(BUFLENGTH, 16))
             SETCALC(Pan2_next_ak_nova);
         else
             SETCALC(Pan2_next_ak);


### PR DESCRIPTION
cascading ifs led to a value being immediately overwritten if it was true; this change adds an `else`

<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->
In `PanUGens.cpp`, for `LinPan2`, `XFade2`, and `Pan2`, there is the following sort of check:
```cpp
#ifdef NOVA_SIMD
        if (BUFLENGTH == 64)
            SETCALC(algorithm_nova_64);
        if (boost::alignment::is_aligned(BUFLENGTH, 16))
            SETCALC(algorithm_nova);
        else
#endif
            SETCALC(algorithm);
```

Since 64 is always aligned to 16: if `BUFLENGTH == 64`, you can expect this to always resolve to `SETCALC(algorithm_nova)` and completely bypass the `nova_64` variants for `LinPan2`, `XFade2`, and `Pan2`.

Notably, there is already an `else` for this check in the `Balance2` ctor:
https://github.com/passyur/supercollider/blob/79884629f61951908b4289c2bc847b5715c05fcb/server/plugins/PanUGens.cpp#L273-L279

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
