### PR TITLE
Fix broken SCDoc clickable link caused by whitespace

### DIFF
--- a/SCClassLibrary/SCDoc/SCDoc.sc
+++ b/SCClassLibrary/SCDoc/SCDoc.sc
@@ -682,7 +682,7 @@ SCDoc {
 			^url;
 		};
 
-		warn("SCDoc: Broken link:" + url.asString);
+		warn("SCDoc: Broken link:" + url.asString.replace(" ", "%20"));
 		^nil;
 	}
 


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

Ths PR fixes the broken SCDoc clickable link caused by whitespace described in #7687.
- Before this PR:
   <img width="1159" height="42" alt="Screenshot 2026-08-21 at 14 17 36" src="https://github.com/user-attachments/assets/b9fbebef-1959-47d4-8376-905ff47f1764" />

- With this PR:
   <img width="1196" height="46" alt="Screenshot 2026-08-21 at 14 17 16" src="https://github.com/user-attachments/assets/59debb6b-8a35-43fd-8096-9cf24ff93d1d" />

I am not sure if this fixes all cases since the following parts are not touched:
- https://github.com/supercollider/supercollider/blob/6cc8ada78b87b7f4c3bb35a26919b5164930783c/SCClassLibrary/SCDoc/SCDocRenderer.sc#L72-L82
- https://github.com/supercollider/supercollider/blob/6cc8ada78b87b7f4c3bb35a26919b5164930783c/SCClassLibrary/SCDoc/SCDocRenderer.sc#L488-L493
- https://github.com/supercollider/supercollider/blob/6cc8ada78b87b7f4c3bb35a26919b5164930783c/SCClassLibrary/SCDoc/SCDocRenderer.sc#L529-L533
- https://github.com/supercollider/supercollider/blob/6cc8ada78b87b7f4c3bb35a26919b5164930783c/SCClassLibrary/SCDoc/SCDocRenderer.sc#L747-L756
- https://github.com/supercollider/supercollider/blob/6cc8ada78b87b7f4c3bb35a26919b5164930783c/SCClassLibrary/SCDoc/SCDocRenderer.sc#L791-L800
- https://github.com/supercollider/supercollider/blob/6cc8ada78b87b7f4c3bb35a26919b5164930783c/SCClassLibrary/SCDoc/SCDocRenderer.sc#L878-L882

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

**Due to #7690, I did not change the version of SCDoc.**
## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
