### PR TITLE
fix TOC links including `"`, `\`, `,`, `'`, `<`, `>` and ` in Documentation

### DIFF
--- a/SCClassLibrary/SCDoc/SCDoc.sc
+++ b/SCClassLibrary/SCDoc/SCDoc.sc
@@ -384,7 +384,7 @@ SCDocNode {
 SCDoc {
 
 	// Increment this whenever we make a change to the SCDoc system or its static files so that all help-files should be processed again
-	classvar version = 79;
+	classvar version = 80;
 
 	classvar <helpTargetDir;
 	classvar <helpTargetUrl;

--- a/SCClassLibrary/SCDoc/SCDocRenderer.sc
+++ b/SCClassLibrary/SCDoc/SCDocRenderer.sc
@@ -49,6 +49,13 @@ SCDocHTMLRenderer {
 	}
 	*escapeSpacesInAnchor { |str|
 		^str.replace(" ", "%20")
+		.replace("\"", "%22")
+		.replace("'", "%27")
+		.replace(",", "%2C")
+		.replace("<", "%3C")
+		.replace(">", "%3E")
+		.replace("`", "%60")
+	}
 	}
 
 	// Find the target (what goes after href=) for a link that stays inside the hlp system

--- a/SCClassLibrary/SCDoc/SCDocRenderer.sc
+++ b/SCClassLibrary/SCDoc/SCDocRenderer.sc
@@ -56,7 +56,6 @@ SCDocHTMLRenderer {
 		.replace(">", "%3E")
 		.replace("`", "%60")
 	}
-	}
 
 	// Find the target (what goes after href=) for a link that stays inside the hlp system
 	*prLinkTargetForInternalLink { |linkBase, linkAnchor, originalLink|


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->
fixes: #6930 #6278
## Purpose and Motivation
As described in #6930 and #6278 `section::`, `subsection::`, `subsubsection::` including `"`, `\`, `,`, `'`, `<`, `>` and ``` ` ``` are not functional. This PR fixes these wrong behaviour.

Due to #7690 and #7694, I did not change the version of SCDoc.

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->

- Documentation
- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
