### PR TITLE
Add `.help` to `String` as a shortcut for `HelpBrowser.goTo("address")`

### DIFF
--- a/HelpSource/Classes/String.schelp
+++ b/HelpSource/Classes/String.schelp
@@ -955,10 +955,13 @@ code::
 ::
 
 method::help
-Performs link::#-findHelpFile:: on this, and opens the file it if it exists, otherwise opens the main helpfile.
+Opens the given string in the help system.
+If the string resembles an HTML filename or a URL, it is opened directly via link::Classes/HelpBrowser#*goTo::.
+Otherwise, the corresponding documentation is opened when available. If multiple related documents exist—or none is found—the help search page displays the results.
 code::
-"Document".help;
-"foobar".help;
+"https://dev.docs.supercollider.online/".help
+"Document".help
+"foobar".help
 ::
 
 subsection::Misc methods

--- a/SCClassLibrary/Common/GUI/PlusGUI/Collections/StringPlusGUI.sc
+++ b/SCClassLibrary/Common/GUI/PlusGUI/Collections/StringPlusGUI.sc
@@ -76,10 +76,14 @@
 	}
 
 	help {
-		if (Platform.openHelpFileAction.notNil) {
-			Platform.openHelpFileAction.value(this)
+		if(".htm(|l)|http(|s)://".matchRegexp(this)) {
+			HelpBrowser.goTo(this)
 		} {
-			HelpBrowser.openHelpFor(this);
+			if (Platform.openHelpFileAction.notNil) {
+				Platform.openHelpFileAction.value(this)
+			} {
+				HelpBrowser.openHelpFor(this);
+			}
 		}
 	}
 }


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

Many Quarks do not provide `.schelp` files; instead, they include documentation in formats such as `.scd`, `README.md`, or `HTML`.  
This PR makes it easier for users to open such documentation directly, for example:

- ```supercollider
   "https://github.com/jmuxfeldt/jostMlib".include
   "https://github.com/jmuxfeldt/jostMlib".help
   ```
- ```supercollider
   "https://github.com/smoge/Rastrum".include
   "https://github.com/smoge/Rastrum".help
   ```
- `"local/path/to/any/html/file.html".help`

`SCD` files can be accessed via GitHub online.
<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->

- Documentation
- Bug fix
- New feature
- Breaking change

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
