### PR TITLE
classlib: use escape codes in terminal to highlight links

### DIFF
--- a/SCClassLibrary/Common/Collections/String.sc
+++ b/SCClassLibrary/Common/Collections/String.sc
@@ -172,6 +172,11 @@ String[char] : RawArray {
 		^str.format(*resArgs)
 	}
 
+	// 'this' is the uri
+	createHyperlinkForTerminal { |text(this)|
+		^0x1b.asAscii ++ "]8;;" ++ this ++ 0x1b.asAscii ++ $\\ ++ text ++ 0x1b.asAscii ++ "]8;;" ++ 0x1b.asAscii ++ $\\;
+	}
+
 	die { arg ... culprits;
 		if(culprits.notEmpty,{
 			("\n\nFATAL ERROR: ").postln;

--- a/editors/sc-ide/widgets/post_window.cpp
+++ b/editors/sc-ide/widgets/post_window.cpp
@@ -213,6 +213,7 @@ void PostWindow::post(const QString& text) {
         const auto line_format = formatForPostLine(line);
         cursor.movePosition(QTextCursor::End);
 
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
         if (!line.contains("\x1b]8;;")) {
             cursor.insertText(line, line_format);
         } else {
@@ -235,7 +236,11 @@ void PostWindow::post(const QString& text) {
                 cursor.insertText(line.sliced(textEnd + 7), line_format);
             }
         }
-
+#else
+        // No escape codes in qt5, could add this by supporting older QString methods, but it is already no officially
+        // supported. Remove this in the future.
+        cursor.insertText(line, line_format);
+#endif
         // Don't write a new line in the final case.
         if (i + 1 != line_count)
             cursor.insertText("\n", line_format);

--- a/editors/sc-ide/widgets/post_window.cpp
+++ b/editors/sc-ide/widgets/post_window.cpp
@@ -213,28 +213,26 @@ void PostWindow::post(const QString& text) {
         const auto line_format = formatForPostLine(line);
         cursor.movePosition(QTextCursor::End);
 
-        // If there is some text that looks like a URI and contains '://' then turn it into a html anchor so we can
-        // click it.
-        if (!line.contains("://")) {
+        if (!line.contains("\x1b]8;;")) {
             cursor.insertText(line, line_format);
         } else {
-            // words are just text separated by spaces.
-            const auto words = line.split(" ");
-            const auto words_count = words.size();
-            for (size_t w { 0 }; w < words_count; ++w) {
-                const auto& word = words[w];
-                cursor.movePosition(QTextCursor::End);
+            const auto openingPos = line.indexOf("\x1b]8;;");
+            const auto uriStart = openingPos + 5;
+            const auto uriEnd = line.sliced(uriStart).indexOf("\x1b\\") + uriStart;
+            const auto textStart = uriEnd + 2;
+            const auto textEnd = line.sliced(textStart, line.size() - textStart).indexOf("\x1b]8;;\x1b\\") + textStart;
 
-                if (const auto maybe_url = QUrl(word, QUrl::ParsingMode::StrictMode);
-                    maybe_url.isValid() && word.contains("://")) {
-                    cursor.insertHtml(QString("<a href='") + word + QString("'>") + word + QString("</a>"));
-                } else {
-                    cursor.insertText(word, line_format);
-                }
+            if (openingPos < 0 || uriStart < 0 || uriEnd < 0 || textStart < 0 || textEnd < 0) {
+                cursor.insertText(line, line_format);
+            } else {
+                const auto before = line.first(openingPos);
+                if (openingPos != 0)
+                    cursor.insertText(before, line_format);
 
-                // Put space back in, if not last word.
-                if (w + 1 != words_count)
-                    cursor.insertText(" ", line_format);
+                const auto uri = line.sliced(uriStart, uriEnd - uriStart);
+                const auto text = line.sliced(textStart, textEnd - textStart);
+                cursor.insertHtml(QString("<a href='") + uri + QString("'>") + text + QString("</a>"));
+                cursor.insertText(line.sliced(textEnd + 7), line_format);
             }
         }
 


### PR DESCRIPTION
<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation
See #7694 — the old way of doing links in the terminal window was nasty and impossible to parse. Now it uses OSC 8 hyperlinks.
An sclang method is added to string to make this easier.
The big benefit of this, is that it works in all terminals now.

(Other terminal escape sequences are not supported...yet).


Example:
```supercollider

"meow:/meow .txt".createHyperlinkForTerminal("link")
```
produces a highlighted hyperlink with the text 'link', that when clicked on produces this error.
```
WARNING: PostWindowURLHandler does not know how to handle the URL 'meow:/meow .txt'
```

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix
- New feature
- Breaking change

## To-do list


I have not yet updated all the places these are emitted. That will require altering #7500, so I'd rather wait until after that. That is why this is a draft.

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [ ] Code is tested
- [ ] All tests are passing
- [ ] Updated documentation
- [ ] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
