### PR TITLE
improve reblocking

### DIFF
--- a/HelpSource/Classes/Reblock.schelp
+++ b/HelpSource/Classes/Reblock.schelp
@@ -4,21 +4,24 @@ categories:: Server>Abstractions
 related:: Classes/Resample, Classes/SynthDef
 
 DESCRIPTION::
-For certain algorithms it is necessary to run a link::Classes/Synth:: at a small block size. Instead of decreasing the block size of the whole Server, which could be rather wasteful, you can use the Reblock object inside a link::Classes/SynthDef:: to only change the block size of specific Synths. (Keep in mind that very small block sizes will increase the CPU usage.)
+For certain algorithms it is necessary to run a link::Classes/Synth:: at a small block size. Instead of decreasing the Server block size, which could be rather wasteful, you can use the Reblock object inside a link::Classes/SynthDef:: to only change the block size of specific Synths. (Keep in mind that very small block sizes will increase the CPU usage.)
 
 The block size can be a constant number or it can be set dynamically via a Synth control (except for Supernova). See link::#*new:: for more information.
 
-note::For technical reasons, Supernova requires a fixed blockSize value. Trying to use a Synth control results in a warning.::
+note::For technical reasons, Supernova requires a fixed block size value. Trying to use a Synth control results in a warning.::
 
 For example, this can be used to implement very short feedback loops:
 
 code::
 // Karplus-Strong with different block sizes
 (
-SynthDef(\delay, { |out, blockSize|
+SynthDef(\delay, { |out, blockSize, upsample|
     var source, local;
 
 	Reblock(blockSize);
+	Resample(upsample);
+	BlockSize.ir.poll(1, "block size");
+	SampleRate.ir.poll(1, "sr");
 
     source = Decay.ar(Impulse.ar(2), 0.1) * WhiteNoise.ar(0.2);
     local = LocalIn.ar(2) + [source, 0]; // read feedback, add to source
@@ -33,11 +36,23 @@ SynthDef(\delay, { |out, blockSize|
 
 // by default, the min. delay length is the Server block size
 Synth(\delay);
+
 // try with smaller block sizes:
 Synth(\delay, [ blockSize: 16 ]);
 Synth(\delay, [ blockSize: 4 ]);
 Synth(\delay, [ blockSize: 1 ]);
 ::
+
+When combined with upsampling, you can get even shorter feedback loops:
+
+code::
+// run the feedback loop at twice the Server sample rate:
+Synth(\delay, [ blockSize: 1, upsample: 2 ]);
+// or even faster:
+Synth(\delay, [ blockSize: 1, upsample: 4 ]);
+::
+
+You can also emphasis::increase:: the block size, but only up to code::Server block size * upsample factor::. This can be used to save some CPU while upsampling (see link::Classes/Resample::). It can also be beneficial for FFT processing, particularly for convolving the inputs or outputs with an FIR filter kernel. (If the FFT resp. kernel size is the same as the block size, no buffering is needed and the FFT will introduce no delay.)
 
 CLASSMETHODS::
 
@@ -50,7 +65,7 @@ the block size. This can either be a constant number (e.g. 1) or a Synth control
 
 The block size must be a power of two. A value of 0 means that the Server block size should be used (= no reblocking).
 
-Currently, only downblocking is supported! A block size greater than the Server block size is ignored and results in a warning.
+At the moment, the block size can not be larger than code::Server block size * resample factor:: (see link::Classes/Resample::). For example, with 4x upsampling and a Server block size of 64 samples, the block size can be up to 256 samples. If you try to go higher, you will get a warning.
 
 DISCUSSION::
 

--- a/HelpSource/Classes/Resample.schelp
+++ b/HelpSource/Classes/Resample.schelp
@@ -16,7 +16,7 @@ For example, you can use upsampling + filtering to reduce the effects of aliasin
 
 code::
 (
-SynthDef(\hardsync, { |out, upsample|
+SynthDef(\hardsync, { |out, upsample, blocksize|
 	var sig, cutoff = 18000;
 
 	Resample(upsample);
@@ -32,6 +32,7 @@ SynthDef(\hardsync, { |out, upsample|
 
 // no upsampling -> lots of aliasing
 Synth(\hardsync);
+
 // watch aliasing disappear with increasing upsampling factors
 Synth(\hardsync, [ upsample: 2.0 ]);
 Synth(\hardsync, [ upsample: 4.0 ]);

--- a/HelpSource/Classes/SynthDef.schelp
+++ b/HelpSource/Classes/SynthDef.schelp
@@ -91,7 +91,7 @@ b = Synth(\help_isRand); // a different randomly selected freq
 
 subsection:: Reblocking and Resampling
 
-Since SC 3.15, Synths can be downblocked to smaller block sizes and upsampled to higher sample rates than the Server's own block size resp. sample rate. This enables things like single-sample feedback or anti-aliasing through upsampling and filtering.
+Since SC 3.15, Synths can have block sizes other than the Server block size and they can be upsampled to higher sample rates than the Server sample rate. This enables things like single-sample feedback or anti-aliasing via upsampling and filtering.
 
 Reblocking and resampling is done with the link::Classes/Reblock:: and link::Classes/Resample:: objects. You can put these in your SynthDef and either pass a fixed number or a Synth argument/control.
 

--- a/include/plugin_interface/SC_Graph.h
+++ b/include/plugin_interface/SC_Graph.h
@@ -28,17 +28,15 @@ enum { kGraph_Reblock = 0x1, kGraph_Resample = 0x2 };
 
 #define kGraph_ReblockOrResample (kGraph_Reblock | kGraph_Resample)
 
-/*
- changes to this struct likely also mean that a change is needed for
-    static const int sc_api_version = x;
- value in SC_InterfaceTable.h file.
+/* NOTE: any changes to this struct cause an ABI break and therefore require
+ * bumping the plugin API version number in SC_InterfaceTable.h!
  */
 struct Graph {
     Node mNode;
     int32 mRefCount;
 
-    uint16 mNumTicks;
-    uint16 mTickCounter;
+    uint32 mNumTicks;
+    uint32 mTickCounter;
 
     uint32 mFlags;
 

--- a/include/plugin_interface/SC_InterfaceTable.h
+++ b/include/plugin_interface/SC_InterfaceTable.h
@@ -26,7 +26,7 @@
 // NOTE: The plugin API version has been temporarily bumped to avoid potential crashes
 // with existing plugins on the develop branch. After all plugin API changes have been
 // made for SC 3.15, the API version should be restored to 4.
-static const int sc_api_version = 6;
+static const int sc_api_version = 7;
 
 #include "SC_Types.h"
 #include "SC_World.h"

--- a/server/plugins/IOUGens.cpp
+++ b/server/plugins/IOUGens.cpp
@@ -266,7 +266,8 @@ static inline float readControlBus(const float* bus, int channelIndex, int maxCh
 }
 
 // Update the relevant IOUnit instance members if the audio bus number has changed
-static inline void IO_a_update_channels(IOUnit* unit, World* world, float fbusChannel, int numChannels, int bufLength) {
+static inline void IO_a_update_channels(IOUnit* unit, const World* world, float fbusChannel, int numChannels,
+                                        int bufLength) {
     if (fbusChannel != unit->m_fbusChannel) {
         unit->m_fbusChannel = fbusChannel;
         int busChannel = (int32)fbusChannel;
@@ -283,7 +284,7 @@ static inline void IO_a_update_channels(IOUnit* unit, World* world, float fbusCh
 // As a small optimization, UpdateTouched tells whether we actually need to
 // update the m_busTouched member.
 template <bool UpdateTouched>
-static inline void IO_k_update_channels(IOUnit* unit, World* world, float fbusChannel, int numChannels) {
+static inline void IO_k_update_channels(IOUnit* unit, const World* world, float fbusChannel, int numChannels) {
     if (fbusChannel != unit->m_fbusChannel) {
         unit->m_fbusChannel = fbusChannel;
         int busChannel = (int)fbusChannel;
@@ -1164,16 +1165,34 @@ void InTrig_Ctor(InTrig* unit) {
 //////////////////////////////////////////////////////////////////////////////////////////////////
 
 void ReplaceOut_next_a_reblock(ReplaceOut* unit, int inNumSamples) {
-    World* world = unit->mWorld;
-    int bufLength = world->mBufLength;
-    int numChannels = unit->mNumInputs - 1;
+    const World* world = unit->mWorld;
+    const int bufLength = world->mBufLength;
+    const int numChannels = unit->mNumInputs - 1;
 
-    float fbusChannel = ZIN0(0);
+    const float fbusChannel = ZIN0(0);
     IO_a_update_channels(unit, world, fbusChannel, numChannels, bufLength);
 
-    double resample = SAMPLERATE / world->mSampleRate;
-    int outSamples = inNumSamples / resample;
-    float* out = unit->m_bus + unit->mParent->mTickCounter * outSamples;
+    const float resample = SAMPLERATE / world->mSampleRate;
+    if (resample < 1.f) {
+        // downsampling not supported (yet)
+        Print("ERROR: ReplaceOut: bad resample factor (%f)\n", resample);
+        return;
+    }
+
+    // in case of upsampling, we only write every N samples (N = resample factor)
+    const int tick = unit->mParent->mTickCounter;
+    const int upsample = static_cast<int>(resample);
+    assert(ISPOWEROFTWO(upsample));
+    const int inputOffset = tick * inNumSamples;
+    if (inputOffset & (upsample - 1)) {
+        // All samples in this block would be skipped by downsampling, so we can return early.
+        // This also ensures that the code below works for the case where inNumSamples < upsample.
+        return;
+    }
+
+    const uint32_t shift = LOG2CEIL(upsample);
+    const int outSamples = std::max<int>(inNumSamples >> shift, 1);
+    float* out = unit->m_bus + (inputOffset >> shift);
     int32* touched = unit->m_busTouched;
     const int32 bufCounter = unit->mWorld->mBufCounter;
     const int32 maxChannel = world->mNumAudioBusChannels;
@@ -1184,9 +1203,9 @@ void ReplaceOut_next_a_reblock(ReplaceOut* unit, int inNumSamples) {
         if (guard.isValid()) {
             float* in = IN(i + 1);
             for (int j = 0; j < outSamples; ++j) {
-                int index = j * resample;
-                out[j] = in[index];
+                out[j] = in[j << shift];
             }
+
             touched[i] = bufCounter;
         }
     }
@@ -1326,17 +1345,34 @@ void ReplaceOut_Ctor(ReplaceOut* unit) {
 //////////////////////////////////////////////////////////////////////////////////////////////////
 
 void Out_next_a_reblock(Out* unit, int inNumSamples) {
-    World* world = unit->mWorld;
-    int bufLength = world->mBufLength;
-    int numChannels = unit->mNumInputs - 1;
+    const World* world = unit->mWorld;
+    const int bufLength = world->mBufLength;
+    const int numChannels = unit->mNumInputs - 1;
 
-    float fbusChannel = ZIN0(0);
+    const float fbusChannel = ZIN0(0);
     IO_a_update_channels(unit, world, fbusChannel, numChannels, bufLength);
 
-    int tick = unit->mParent->mTickCounter;
-    double resample = SAMPLERATE / world->mSampleRate;
-    int outSamples = inNumSamples / resample;
-    float* out = unit->m_bus + tick * outSamples;
+    const float resample = SAMPLERATE / world->mSampleRate;
+    if (resample < 1.f) {
+        // downsampling not supported (yet)
+        Print("ERROR: Out: bad resample factor (%f)\n", resample);
+        return;
+    }
+
+    // in case of upsampling, we only write every N samples (N = resample factor)
+    const int tick = unit->mParent->mTickCounter;
+    const int upsample = static_cast<int>(resample);
+    assert(ISPOWEROFTWO(upsample));
+    const int inputOffset = tick * inNumSamples;
+    if (inputOffset & (upsample - 1)) {
+        // All samples in this block would be skipped by downsampling, so we can return early.
+        // This also ensures that the code below works for the case where inNumSamples < upsample.
+        return;
+    }
+
+    const uint32_t shift = LOG2CEIL(upsample);
+    const int outSamples = std::max<int>(inNumSamples >> shift, 1);
+    float* out = unit->m_bus + (inputOffset >> shift);
     int32* touched = unit->m_busTouched;
     const int32 bufCounter = unit->mWorld->mBufCounter;
     const int32 maxChannel = world->mNumAudioBusChannels;
@@ -1345,23 +1381,19 @@ void Out_next_a_reblock(Out* unit, int inNumSamples) {
         AudioBusGuard<false> guard(unit, fbusChannel + i, maxChannel);
 
         if (guard.isValid()) {
-            if (tick == 0) {
-                // If this is the first tick, check if we are the first
-                // one writing to the bus. If yes, zero the *whole* channel
-                // so every tick can simply accumulate.
-                // (This also works in ParGroups because only one Ugen
-                // gets to update mBufTouched!)
-                if (touched[i] != bufCounter) {
-                    touched[i] = bufCounter;
-                    Clear(bufLength, unit->m_bus + bufLength * i);
-                }
+            // If this is the first tick, check if we are the first one touching the bus.
+            // If yes, zero the *whole* channel so every tick can simply accumulate.
+            // This way we don't have to cache the bus touch values. (This also works
+            // in ParGroups because only one UGen gets to update mBufTouched!)
+            if (tick == 0 && touched[i] != bufCounter) {
+                touched[i] = bufCounter;
+                Clear(bufLength, unit->m_bus + bufLength * i);
             }
 
             // accumulate
             float* in = IN(i + 1);
             for (int j = 0; j < outSamples; ++j) {
-                int index = j * resample;
-                out[j] += in[index];
+                out[j] += in[j << shift];
             }
         }
     }
@@ -1559,63 +1591,78 @@ void Out_Ctor(Out* unit) {
 //////////////////////////////////////////////////////////////////////////////////////////////////
 
 void XOut_next_a_reblock(XOut* unit, int inNumSamples) {
-    World* world = unit->mWorld;
-    int bufLength = world->mBufLength;
-    int numChannels = unit->mNumInputs - 2;
+    const World* world = unit->mWorld;
+    const int bufLength = world->mBufLength;
+    const int numChannels = unit->mNumInputs - 2;
 
-    float fbusChannel = ZIN0(0);
+    const float fbusChannel = ZIN0(0);
     IO_a_update_channels(unit, world, fbusChannel, numChannels, bufLength);
 
-    float next_xfade = ZIN0(1);
-    float xfade0 = unit->m_xfade;
-    int tick = unit->mParent->mTickCounter;
-    double resample = SAMPLERATE / world->mSampleRate;
-    int outSamples = inNumSamples / resample;
-    float* out = unit->m_bus + tick * outSamples;
+    const float resample = SAMPLERATE / world->mSampleRate;
+    if (resample < 1.f) {
+        // downsampling not supported (yet)
+        Print("ERROR: XOut: bad resample factor (%f)\n", resample);
+        return;
+    }
+
+    // in case of upsampling, we only write every N samples (N = resample factor)
+    const int tick = unit->mParent->mTickCounter;
+    const int upsample = static_cast<int>(resample);
+    assert(ISPOWEROFTWO(upsample));
+    const int inputOffset = tick * inNumSamples;
+    if (inputOffset & (upsample - 1)) {
+        // All samples in this block would be skipped by downsampling, so we can return early.
+        // This also ensures that the code below works for the case where inNumSamples < upsample.
+        return;
+    }
+
+    const float next_xfade = ZIN0(1);
+    const float xfade0 = unit->m_xfade;
+    const uint32_t shift = LOG2CEIL(upsample);
+    const int outSamples = std::max<int>(inNumSamples >> shift, 1);
+    float* out = unit->m_bus + (inputOffset >> shift);
     int32* touched = unit->m_busTouched;
     const int32 bufCounter = unit->mWorld->mBufCounter;
     const int32 maxChannel = world->mNumAudioBusChannels;
 
     if (xfade0 != next_xfade) {
-        // We must adjust the slope for the resample factor!
-        // Example: with 2x upsampling the output has only half the
-        // size of the input, so we would have to double the slope.
+        // new crossfade level -> ramp from new to old value while crossfading with previous bus content.
+        //
+        // NOTE: We must adjust the slope for the resample factor!
+        // Example: with 2x upsampling the output has only half the size of the input,
+        // so we would have to double the slope.
         float slope = CALCSLOPE(next_xfade, xfade0) * resample;
         for (int i = 0; i < numChannels; ++i, out += bufLength) {
             AudioBusGuard<false> guard(unit, fbusChannel + i, maxChannel);
 
             if (guard.isValid()) {
-                if (tick == 0) {
-                    // If this is the first tick, check if we are the first
-                    // one writing to the bus. If yes, zero the *whole* channel
-                    // so every tick can simply accumulate.
-                    // (This also works in ParGroups because only one Ugen
-                    // gets to update mBufTouched!)
-                    if (touched[i] != bufCounter) {
-                        touched[i] = bufCounter;
-                        Clear(bufLength, unit->m_bus + bufLength * i);
-                    }
+                // If this is the first tick, check if we are the first one touching the bus.
+                // If yes, zero the *whole* channel so every tick can simply accumulate.
+                // This way we don't have to cache the bus touch values.
+                // (This also works in ParGroups because only one Ugen gets to update mBufTouched!)
+                if (tick == 0 && touched[i] != bufCounter) {
+                    touched[i] = bufCounter;
+                    Clear(bufLength, unit->m_bus + bufLength * i);
                 }
 
                 // accumulate
                 float xfade = xfade0;
                 float* in = IN(i + 2);
                 for (int j = 0; j < outSamples; ++j, xfade += slope) {
-                    int index = j * resample;
                     float zout = out[j];
-                    out[j] = zout + xfade * (in[index] - zout);
+                    out[j] = zout + xfade * (in[j << shift] - zout);
                 }
             }
         }
     } else if (xfade0 == 1.f) {
+        // replace bus content
         for (int i = 0; i < numChannels; ++i, out += bufLength) {
             AudioBusGuard<false> guard(unit, fbusChannel + i, maxChannel);
 
             if (guard.isValid()) {
                 float* in = IN(i + 2);
                 for (int j = 0; j < outSamples; ++j) {
-                    int index = j * resample;
-                    out[j] = in[index];
+                    out[j] += in[j << shift];
                 }
                 touched[i] = bufCounter;
             }
@@ -1623,24 +1670,22 @@ void XOut_next_a_reblock(XOut* unit, int inNumSamples) {
     } else if (xfade0 == 0.f) {
         // do nothing.
     } else {
+        // crossfade with previous content
         for (int i = 0; i < numChannels; ++i, out += bufLength) {
             AudioBusGuard<false> guard(unit, fbusChannel + i, maxChannel);
 
             if (guard.isValid()) {
-                if (tick == 0) {
-                    // See comment above.
-                    if (touched[i] != bufCounter) {
-                        touched[i] = bufCounter;
-                        Clear(bufLength, unit->m_bus + bufLength * i);
-                    }
+                // see comment in xfade0 != next_xfade branch.
+                if (tick == 0 && touched[i] != bufCounter) {
+                    touched[i] = bufCounter;
+                    Clear(bufLength, unit->m_bus + bufLength * i);
                 }
 
                 // accumulate
                 float* in = IN(i + 2);
                 for (int j = 0; j < outSamples; ++j) {
-                    int index = j * resample;
                     float zout = out[j];
-                    out[j] = zout + xfade0 * (in[index] - zout);
+                    out[j] = zout + xfade0 * (in[j << shift] - zout);
                 }
             }
         }
@@ -1664,6 +1709,8 @@ void XOut_next_a(XOut* unit, int inNumSamples) {
     const int32 maxChannel = world->mNumAudioBusChannels;
 
     if (xfade0 != next_xfade) {
+        // new crossfade level -> ramp from new to old value
+        // while crossfading with previous bus content.
         float slope = CALCSLOPE(next_xfade, xfade0);
         for (int i = 0; i < numChannels; ++i, out += bufLength) {
             AudioBusGuard<false> guard(unit, fbusChannel + i, maxChannel);
@@ -1685,6 +1732,7 @@ void XOut_next_a(XOut* unit, int inNumSamples) {
             }
         }
     } else if (xfade0 == 1.f) {
+        // replace bus content
         for (int i = 0; i < numChannels; ++i, out += bufLength) {
             AudioBusGuard<false> guard(unit, fbusChannel + i, maxChannel);
 
@@ -1697,6 +1745,7 @@ void XOut_next_a(XOut* unit, int inNumSamples) {
     } else if (xfade0 == 0.f) {
         // do nothing.
     } else {
+        // crossfade with previous content
         for (int i = 0; i < numChannels; ++i, out += bufLength) {
             AudioBusGuard<false> guard(unit, fbusChannel + i, maxChannel);
 
@@ -1736,6 +1785,8 @@ FLATTEN void XOut_next_a_nova(XOut* unit, int inNumSamples) {
     const int32 maxChannel = world->mNumAudioBusChannels;
 
     if (xfade0 != next_xfade) {
+        // new crossfade level -> ramp from new to old value
+        // while crossfading with previous bus content.
         float slope = CALCSLOPE(next_xfade, xfade0);
         for (int i = 0; i < numChannels; ++i, out += bufLength) {
             AudioBusGuard<false> guard(unit, fbusChannel + i, maxChannel);
@@ -1754,6 +1805,7 @@ FLATTEN void XOut_next_a_nova(XOut* unit, int inNumSamples) {
         }
         unit->m_xfade = next_xfade;
     } else if (xfade0 == 1.f) {
+        // replace content
         for (int i = 0; i < numChannels; ++i, out += bufLength) {
             AudioBusGuard<false> guard(unit, fbusChannel + i, maxChannel);
 
@@ -1766,6 +1818,7 @@ FLATTEN void XOut_next_a_nova(XOut* unit, int inNumSamples) {
     } else if (xfade0 == 0.f) {
         // do nothing.
     } else {
+        // crossfade with previous content
         for (int i = 0; i < numChannels; ++i, out += bufLength) {
             AudioBusGuard<false> guard(unit, fbusChannel + i, maxChannel);
 
@@ -1850,47 +1903,74 @@ void XOut_Ctor(XOut* unit) {
 //////////////////////////////////////////////////////////////////////////////////////////////////
 
 void OffsetOut_next_a_reblock(OffsetOut* unit, int inNumSamples) {
-    World* world = unit->mWorld;
-    int bufLength = world->mBufLength;
-    int numChannels = unit->mNumInputs - 1;
+    const World* world = unit->mWorld;
+    const int bufLength = world->mBufLength;
+    const int numChannels = unit->mNumInputs - 1;
 
-    float fbusChannel = ZIN0(0);
+    const float fbusChannel = ZIN0(0);
     IO_a_update_channels(unit, world, fbusChannel, numChannels, bufLength);
 
-    int32 offset = unit->mParent->mSampleOffset;
-    int32 remain = bufLength - offset;
+    const float resample = SAMPLERATE / world->mSampleRate;
+    if (resample < 1.f) {
+        // downsampling not supported (yet)
+        Print("ERROR: OffsetOut: bad resample factor (%f)\n", resample);
+        return;
+    }
 
-    int tick = unit->mParent->mTickCounter;
-    int numTicks = unit->mParent->mNumTicks;
-    double resample = SAMPLERATE / world->mSampleRate;
-    int32 outSamples = inNumSamples / resample;
-    int32 outPhase = tick * outSamples;
+    // in case of upsampling, we only write every N samples (N = resample factor)
+    const int tick = unit->mParent->mTickCounter;
+    const int numTicks = unit->mParent->mNumTicks;
+    const int upsample = static_cast<int>(resample);
+    assert(ISPOWEROFTWO(upsample));
+    const int inPhase = tick * inNumSamples;
+    if (inPhase & (upsample - 1)) {
+        // All samples in this block would be skipped by downsampling, so we can return early.
+        // This also ensures that the code below works for the case where inNumSamples < upsample.
+        return;
+    }
 
+    const int32 offset = unit->mParent->mSampleOffset;
+    const int32 remain = bufLength - offset;
+
+    const uint32_t shift = LOG2CEIL(upsample);
+    const int outSamples = std::max<int>(inNumSamples >> shift, 1);
+    const int outPhase = inPhase >> shift;
     float* out = unit->m_bus;
     float* saved = unit->m_saved;
     int32* touched = unit->m_busTouched;
     const int32 bufCounter = unit->mWorld->mBufCounter;
     const int32 maxChannel = world->mNumAudioBusChannels;
 
+    // This one is a bit tricky, but the following example might help understand it:
+    //
+    // Server block size = 64 samples, graph block size = 16 samples (= 4 ticks),
+    // sample offset = 48 samples
+    //
+    //           ┌―――――――――――――――――――――――――――――――――――――――┐
+    //           ▼                                       │
+    //    saved: █        ← offset →        █            │
+    //           │                                       │
+    //           │                                       │
+    //           │                      in: █ ← remain → ║       ← offset →         █
+    //           │                 inPhase: █---------|---------|---------|---------█
+    //           │                          │
+    //           ▼                          ▼
+    //      out: █        ← offset →        ║ ← remain → █
+    // outPhase: █---------|---------|---------|---------█
+
     for (int i = 0; i < numChannels; ++i, out += bufLength, saved += offset) {
         AudioBusGuard<false> guard(unit, fbusChannel + i, maxChannel);
 
-        float* in = IN(i + 1);
+        const float* in = IN(i + 1);
+        const int diff1 = remain - outPhase;
 
         if (guard.isValid()) {
             if (tick == 0) {
-                // If this is the first tick, copy/accumulate the saved input
-                // from the previous period and clear the remaining channel so
-                // that every tick can simply accumulate its input.
-                // (This also works in ParGroups because only one Ugen gets
-                // to update mBufTouched!)
-                if (touched[i] == bufCounter) {
-                    if (unit->m_empty) {
-                        // Print("touched offset %d\n", offset);
-                    } else {
-                        Accum(offset, out, saved);
-                    }
-                } else {
+                // copy/accumulate the saved input from the previous control period.
+                if (touched[i] != bufCounter) {
+                    // If we are the first one touching the bus, clear the remaining channel
+                    // so that every tick can simply accumulate. (This also works in ParGroups
+                    // because only one Ugen gets to update mBufTouched!)
                     if (unit->m_empty) {
                         // clear whole channel
                         Clear(bufLength, out);
@@ -1900,36 +1980,41 @@ void OffsetOut_next_a_reblock(OffsetOut* unit, int inNumSamples) {
                         Clear(remain, out + offset);
                     }
                     touched[i] = bufCounter;
+                } else {
+                    if (unit->m_empty) {
+                        // just keep bus content
+                        // Print("touched offset %d\n", offset);
+                    } else {
+                        Accum(offset, out, saved);
+                    }
                 }
             }
 
-            // accumulate the current input (up to 'remain' samples)
-            // into the bus, shifted by 'offset' samples
-            int n = sc_min(remain - outPhase, outSamples);
-            if (n > 0) {
+            if (diff1 > 0) {
+                // accumulate the current input (up to 'remain' samples)
+                // into the bus, shifted by 'offset' samples.
+                const int n = std::min<int>(diff1, outSamples);
                 for (int j = 0; j < n; ++j) {
-                    int index = outPhase + j;
-                    int k = j * resample;
-                    out[index + offset] += in[k];
+                    const int outIndex = offset + outPhase + j;
+                    out[outIndex] += in[j << shift];
                 }
             }
         }
 
-        // save remaining input samples (with reblocking).
-        // Also do this if the buf channel was out-of-range.
-        int n = sc_min(outPhase + outSamples - remain, outSamples);
-        if (n > 0) {
-            // j starts at the offset within 'outSamples'.
+        const int diff2 = outSamples - diff1;
+        if (diff2 > 0) {
+            // save remaining input samples (with downsampling),
+            // even if the buf channel was out-of-range.
+            const int n = std::min<int>(diff2, outSamples);
+            // j starts at the input block offset
             for (int j = outSamples - n; j < outSamples; ++j) {
-                int index = outPhase + j - remain;
-                int k = j * resample;
-                saved[index] = in[k];
+                const int outIndex = j - diff1;
+                saved[outIndex] = in[j << shift];
             }
         }
     }
-    // only on the last tick!
-    if (tick == numTicks - 1)
-        unit->m_empty = false;
+
+    unit->m_empty = false;
 }
 
 void OffsetOut_next_a(OffsetOut* unit, int inNumSamples) {
@@ -1958,49 +2043,58 @@ void OffsetOut_next_a(OffsetOut* unit, int inNumSamples) {
         //	offset, remain);
 
         if (guard.isValid()) {
-            if (touched[i] == bufCounter) {
+            if (touched[i] != bufCounter) {
+                // we are the first to touch the bus
                 if (unit->m_empty) {
-                    // Print("touched offset %d\n", offset);
-                } else {
-                    Accum(offset, out, saved);
-                }
-                Accum(remain, out + offset, in);
-            } else {
-                if (unit->m_empty) {
+                    // clear the first bus section
                     Clear(offset, out);
                     // Print("untouched offset %d\n", offset);
                 } else {
+                    // copy the saved content into the first bus section
                     Copy(offset, out, saved);
                 }
+                // copy the input into the second bus section
                 Copy(remain, out + offset, in);
                 touched[i] = bufCounter;
+            } else {
+                if (unit->m_empty) {
+                    // just keep the existing bus content
+                    // Print("touched offset %d\n", offset);
+                } else {
+                    // accumulate the saved content into the first bus section
+                    Accum(offset, out, saved);
+                }
+                // accumulate the input into the second bus section
+                Accum(remain, out + offset, in);
             }
         }
 
-        // always copy the remaining input, even if the buf channel was out-of-range.
+        // always save the remaining input, even if the buf channel was out-of-range.
         Copy(offset, saved, in + remain);
 
         // Print("out %d %d %d  %g %g\n", i, in[0], out[0]);
     }
+
     unit->m_empty = false;
 }
 
 void OffsetOut_Ctor(OffsetOut* unit) {
     // Print("->Out_Ctor\n");
-    World* world = unit->mWorld;
+    const World* world = unit->mWorld;
     unit->m_fbusChannel = -1.;
 
-    if (REBLOCK_OR_RESAMPLE)
+    if (REBLOCK_OR_RESAMPLE) {
         SETCALC(OffsetOut_next_a_reblock);
-    else
+    } else {
         SETCALC(OffsetOut_next_a);
+    }
     unit->m_bus = world->mAudioBus;
     unit->m_busTouched = world->mAudioBusTouched;
-    int32 offset = unit->mParent->mSampleOffset;
-    int numChannels = unit->mNumInputs - 1;
     // NB: if mSampleOffset is 0, RTAlloc() might return a nullptr and
     // trigger ClearUnitIfMemFailed(), so we have to handle it specially.
+    const int32 offset = unit->mParent->mSampleOffset;
     if (offset > 0) {
+        const int numChannels = unit->mNumInputs - 1;
         unit->m_saved = (float*)RTAlloc(unit->mWorld, offset * numChannels * sizeof(float));
         ClearUnitIfMemFailed(unit->m_saved);
     } else {
@@ -2013,19 +2107,19 @@ void OffsetOut_Ctor(OffsetOut* unit) {
 void OffsetOut_Dtor(OffsetOut* unit) {
     // Write remaining samples (if any)
     if (unit->m_saved) {
-        World* world = unit->mWorld;
-        int bufLength = world->mBufLength;
-        int numChannels = unit->mNumInputs - 1;
+        const World* world = unit->mWorld;
+        const int bufLength = world->mBufLength;
+        const int numChannels = unit->mNumInputs - 1;
 
-        int32 offset = unit->mParent->mSampleOffset;
-        int32 remain = bufLength - offset; // Do not use BUFLENGTH!
+        const int32 offset = unit->mParent->mSampleOffset;
+        const int32 remain = bufLength - offset; // Do not use BUFLENGTH!
 
         float* out = unit->m_bus;
         float* saved = unit->m_saved;
         int32* touched = unit->m_busTouched;
-        int32 bufCounter = unit->mWorld->mBufCounter;
-        int32 bufChannel = (int32)unit->m_fbusChannel;
-        int32 maxChannel = world->mNumAudioBusChannels;
+        const int32 bufCounter = unit->mWorld->mBufCounter;
+        const int32 bufChannel = (int32)unit->m_fbusChannel;
+        const int32 maxChannel = world->mNumAudioBusChannels;
 
         for (int i = 0; i < numChannels; ++i, out += bufLength, saved += offset) {
             if ((bufChannel + i) < maxChannel) {
@@ -2033,12 +2127,12 @@ void OffsetOut_Dtor(OffsetOut* unit) {
                 //	i, touched[i] == bufCounter, unit->m_empty,
                 //	offset, remain);
                 if (!unit->m_empty) {
-                    if (touched[i] == bufCounter) {
-                        Accum(offset, out, saved);
-                    } else {
+                    if (touched[i] != bufCounter) {
                         Copy(offset, out, saved);
                         Clear(remain, out + offset);
                         touched[i] = bufCounter;
+                    } else {
+                        Accum(offset, out, saved);
                     }
                 }
                 // Print("out %d %d %d  %g %g\n", i, in[0], out[0]);

--- a/server/scsynth/SC_Graph.cpp
+++ b/server/scsynth/SC_Graph.cpp
@@ -421,6 +421,7 @@ static void Graph_Ctor(World* inWorld, GraphDef* inGraphDef, Graph* graph, sc_ms
     graph->mLocalAudioBusUnit = nullptr;
     graph->mLocalControlBusUnit = nullptr;
 
+    graph->mLocalSndBufs = nullptr;
     graph->localBufNum = 0;
     graph->localMaxBufNum = 0; // this is set from synth
 
@@ -461,6 +462,7 @@ static void Graph_Ctor(World* inWorld, GraphDef* inGraphDef, Graph* graph, sc_ms
         graph->mTickCounter = 0;
         graph->mFullRate = &inWorld->mFullRate;
         graph->mBufRate = &inWorld->mBufRate;
+        blockSize = inWorld->mBufLength;
     } else {
         // reblocking or upsampling
         if (upsample > 1.0) {
@@ -481,18 +483,41 @@ static void Graph_Ctor(World* inWorld, GraphDef* inGraphDef, Graph* graph, sc_ms
         }
 
         if (blockSize != 0) {
-            // block size cannot be larger than wire buffer size (yet)!
-            if (blockSize > inWorld->mBufLength) {
-                scprintf("WARNING: Synth: block size (%d) cannot be larger than Server "
-                         "block size (%d)\n",
-                         blockSize, inWorld->mBufLength);
-                // use Server block size
-                blockSize = inWorld->mBufLength;
-            } else if (!ISPOWEROFTWO(blockSize)) {
+            if (!ISPOWEROFTWO(blockSize)) {
                 scprintf("WARNING: Synth: block size (%d) not a power of two\n", blockSize);
                 // use Server block size
                 blockSize = inWorld->mBufLength;
-            } else {
+            }
+
+            const int32_t effectiveBlockSize = blockSize / static_cast<int32_t>(upsample);
+            if (effectiveBlockSize > inWorld->mBufLength) {
+                // The effective block size cannot be larger than the Server block size.
+                // For now, let's keep the upsample factor and adjust the block size accordingly.
+                const int32_t originalBlockSize = blockSize;
+                blockSize = inWorld->mBufLength * static_cast<int32_t>(upsample);
+                scprintf("WARNING: Synth: block size (%d) too large for resample factor (%f). "
+                         "Adjusting block size to %d samples.\n",
+                         originalBlockSize, upsample, blockSize);
+            }
+
+            // Make sure we have enough wire buffer space!
+            // This is necessary so that we can later safely set the wire buffer pointers.
+            if (blockSize > inWorld->mBufLength) {
+                const int32_t availableBufferSpace = inWorld->hw->mMaxWireBufs * inWorld->mBufLength;
+                const int32_t requiredBufferSpace = inGraphDef->mNumWireBufs * blockSize;
+                if (requiredBufferSpace > availableBufferSpace) {
+                    const int32_t originalBlockSize = blockSize;
+                    blockSize = availableBufferSpace / inGraphDef->mNumWireBufs;
+                    assert(blockSize >= inWorld->mBufLength);
+                    const int32_t minNumWireBufs = requiredBufferSpace / inWorld->mBufLength;
+                    scprintf("WARNING: Synth: too little wire buffer space for block size (%d) and "
+                             "resample factor (%f). Adjusting block size to %d samples. Please increase "
+                             "the number of wire buffers in the Server Options to at least %d. \n",
+                             originalBlockSize, upsample, blockSize, minNumWireBufs);
+                }
+            }
+
+            if (blockSize != inWorld->mBufLength) {
                 graph->mFlags |= kGraph_Reblock; // ok
             }
         } else {
@@ -500,7 +525,7 @@ static void Graph_Ctor(World* inWorld, GraphDef* inGraphDef, Graph* graph, sc_ms
             blockSize = inWorld->mBufLength;
         }
 
-        graph->mNumTicks = (inWorld->mBufLength / blockSize) * upsample;
+        graph->mNumTicks = (inWorld->mBufLength * upsample) / blockSize;
         graph->mTickCounter = 0;
         double sampleRate = inWorld->mSampleRate * upsample;
 
@@ -571,7 +596,12 @@ static void Graph_Ctor(World* inWorld, GraphDef* inGraphDef, Graph* graph, sc_ms
                 for (uint32 j = 0; j < numOutputs; ++j, ++wire, ++outputSpec) {
                     wire->mFromUnit = unit;
                     wire->mCalcRate = calc_FullRate;
-                    wire->mBuffer = bufspace + outputSpec->mBufferIndex;
+                    // In a normal Graph, wire buffers have the same size as the Server block size.
+                    // A reblocked Graph, however, needs a different buffer size, especially when
+                    // its own block size is *larger* than the Server block size. (Otherwise we would
+                    // overwrite subsequent buffers.) Since the wire buffer space is a single large
+                    // array, we can simply multiply the wire buffer index by the Graph block size.
+                    wire->mBuffer = bufspace + outputSpec->mBufferIndex * blockSize;
                     unitOutput[j] = wire;
                     unitOutBuf[j] = wire->mBuffer;
                 }

--- a/server/scsynth/SC_GraphDef.cpp
+++ b/server/scsynth/SC_GraphDef.cpp
@@ -701,16 +701,4 @@ void DoBufferColoring(World* inWorld, GraphDef* inGraphDef) {
             inWorld->hw->mMaxWireBufs = sc_max(inWorld->hw->mMaxWireBufs, inGraphDef->mNumWireBufs);
         }
     }
-
-    // multiply buf indices by buf length for proper offset
-    int bufLength = inWorld->mBufLength;
-    for (uint32 j = 0; j < inGraphDef->mNumUnitSpecs; ++j) {
-        UnitSpec* unitSpec = inGraphDef->mUnitSpecs + j;
-        for (uint32 i = 0; i < unitSpec->mNumOutputs; ++i) {
-            OutputSpec* outputSpec = unitSpec->mOutputSpec + i;
-            if (outputSpec->mCalcRate == calc_FullRate) {
-                outputSpec->mBufferIndex *= bufLength;
-            }
-        }
-    }
 }

--- a/server/supernova/sc/sc_synth.cpp
+++ b/server/supernova/sc/sc_synth.cpp
@@ -44,8 +44,11 @@ sc_synth::sc_synth(int node_id, sc_synth_definition_ptr const& prototype): abstr
     mLocalAudioBusUnit = nullptr;
     mLocalControlBusUnit = nullptr;
 
+    mLocalSndBufs = nullptr;
     localBufNum = 0;
     localMaxBufNum = 0;
+
+    mFlags = 0;
 
     int block_size = prototype->block_size;
     float upsample = prototype->resample_factor;
@@ -79,18 +82,24 @@ sc_synth::sc_synth(int node_id, sc_synth_definition_ptr const& prototype): abstr
         }
 
         if (block_size != 0) {
-            // block size cannot be larger than wire buffer size (yet)!
-            if (block_size > world.mBufLength) {
-                log_printf("WARNING: Synth: block size (%d) cannot be larger than Server "
-                           "block size (%d)\n",
-                           block_size, world.mBufLength);
-                // use Server block size
-                block_size = world.mBufLength;
-            } else if (!ispoweroftwo(block_size)) {
+            if (!ispoweroftwo(block_size)) {
                 log_printf("WARNING: Synth: block size (%d) not a power of two\n", block_size);
                 // use Server block size
                 block_size = world.mBufLength;
-            } else {
+            }
+
+            const int32_t effective_block_size = block_size / static_cast<int32>(upsample);
+            if (effective_block_size > world.mBufLength) {
+                // The effective block size cannot be larger than the Server block size.
+                // For now, let's keep the upsample factor and adjust the block size accordingly.
+                const int32_t wanted_block_size = block_size;
+                block_size = world.mBufLength * static_cast<int32_t>(upsample);
+                log_printf("WARNING: Synth: block size (%d) too large for resample factor (%f). "
+                           "Adjusting block size to %d samples.\n",
+                           wanted_block_size, upsample, block_size);
+            }
+
+            if (block_size != world.mBufLength) {
                 mFlags |= kGraph_Reblock; // ok
             }
         } else {
@@ -98,7 +107,7 @@ sc_synth::sc_synth(int node_id, sc_synth_definition_ptr const& prototype): abstr
             block_size = world.mBufLength;
         }
 
-        mNumTicks = (world.mBufLength / block_size) * upsample;
+        mNumTicks = (world.mBufLength * upsample) / block_size;
         mTickCounter = 0;
     }
 

--- a/testsuite/classlibrary/TestReblock.sc
+++ b/testsuite/classlibrary/TestReblock.sc
@@ -145,14 +145,58 @@ TestReblock : TestReblockBase {
 			cond.wait;
 			synth.free;
 		};
+
+		// a block size of 0 should yield the Server block size
 		this.assert(results[0] == server.options.blockSize, "Reblock with control default argument matches Server block size");
+
+		// the remaining block sizes should be set as is.
 		success = [ blockSizes[1..], results[1..] ].flop.every { |pair| pair[0] == pair[1] };
 		this.assert(success, "Reblock with control argument matches BlockSize output");
 	}
 
+	test_reblockWithUpsamplingWorks {
+		var bus = Bus.control(server);
+		// with 4x upsampling we can reblock up to 256 samples.
+		// the last value (512) is out of range and should be clamped to 256.
+		var upsampleFactor = 4;
+		var blockSizes = [ 0, 1, 2, 4, 8, 16, 32, 64, 128, 256, 512 ];
+		var results = Array.fill(blockSizes.size, nil);
+		var success;
+
+		SynthDef(\testReblockControl, { |out, blockSize|
+			Reblock(blockSize);
+			Resample(upsampleFactor);
+			Out.kr(out, BlockSize.ir);
+		}).add;
+		server.sync;
+
+		blockSizes.do { |blockSize, index|
+			var cond = Condition();
+			var synth = Synth(\testReblockControl, [ out: bus, blockSize: blockSize ]);
+			server.sync; // let it compute at least one block
+			bus.get { |f|
+				results[index] = f;
+				cond.test_(true).signal;
+			};
+			cond.wait;
+			synth.free;
+		};
+
+		// a block size of 0 should yield the Server block size
+		this.assert(results[0] == server.options.blockSize, "Reblock with default argument + upsampling matches Server block size");
+
+		// a block size larger than Server block size * upsample factor should be adjust to the latter.
+		this.assert(results.wrapAt(-1) == blockSizes.wrapAt(-2), "Block size larger than Server block size * upsample factor is adjusted properly");
+
+		// the remaining block sizes should be set as is.
+		success = [ blockSizes, results ].flop.drop(1).drop(-1).every { |pair| pair[0] == pair[1] };
+		this.assert(success, "Reblock with argument + upsampling matches BlockSize output");
+	}
+
 	test_reblockWithBadControlBlockSizeUsesDefault {
 		var bus = Bus.control(server);
-		var blockSizes = [ -1, 3, 7 ];
+		// Note: the block size can not exceed Server block size * upsample factor (here: 1)
+		var blockSizes = [ -1, 3, 7, server.options.blockSize * 2 ];
 		var results = Array.fill(blockSizes.size, nil);
 		var success;
 		SynthDef(\testReblockControlFail, { |out, blockSize|

--- a/testsuite/classlibrary/TestReblock.sc
+++ b/testsuite/classlibrary/TestReblock.sc
@@ -200,11 +200,12 @@ TestReblock : TestReblockBase {
 		var arTestBus = Bus.audio(server, 2);
 		var krTestBus = Bus.control(server, 2);
 		var testBlockSize = 1;
+		var testFactor = testBlockSize * 4;
 
-		simpleAB = { |defName|
+		simpleAB = { |defName, resample=false|
 			{ |busA, busB|
 				[
-					Synth(defName, [ out: busA, blockSize: testBlockSize ], server, \addToTail),
+					Synth(defName, [ out: busA, blockSize: testBlockSize, resample: if (resample, testFactor, 1) ], server, \addToTail),
 					Synth(defName, [ out: busB ], server, \addToTail)
 				]
 			}
@@ -231,6 +232,7 @@ TestReblock : TestReblockBase {
 		server.sync;
 
 		this.performABTest(simpleAB.(\testOutAr), \ar, "Out.ar works with reblocking");
+		this.performABTest(simpleAB.(\testOutAr, true), \ar, "Out.ar works with reblocking and resampling");
 
 		SynthDef(\testOutKr, { |out, blockSize|
 			var sig = [ Line.kr, SinOsc.kr ];
@@ -243,6 +245,7 @@ TestReblock : TestReblockBase {
 		server.sync;
 
 		this.performABTest(simpleAB.(\testOutKr), \kr, "Out.kr works with reblocking");
+		this.performABTest(simpleAB.(\testOutKr, true), \kr, "Out.kr works with reblocking and resampling");
 
 		// ReplaceOut.ar / ReplaceOut.kr
 
@@ -254,6 +257,7 @@ TestReblock : TestReblockBase {
 		server.sync;
 
 		this.performABTest(simpleAB.(\testReplaceOutAr), \ar, "ReplaceOut.ar works with reblocking");
+		this.performABTest(simpleAB.(\testReplaceOutAr, true), \ar, "ReplaceOut.ar works with reblocking and resampling");
 
 		SynthDef(\testReplaceOutKr, { |out, blockSize|
 			Reblock(blockSize);
@@ -263,6 +267,7 @@ TestReblock : TestReblockBase {
 		server.sync;
 
 		this.performABTest(simpleAB.(\testReplaceOutKr), \kr, "ReplaceOut.kr works with reblocking");
+		this.performABTest(simpleAB.(\testReplaceOutKr, true), \kr, "ReplaceOut.kr works with reblocking and resampling");
 
 		// OffsetOut.ar
 
@@ -277,6 +282,7 @@ TestReblock : TestReblockBase {
 		server.sync;
 
 		this.performABTest(simpleAB.(\testOffsetOutAr), \ar, "OffsetOut.ar works with reblocking");
+		this.performABTest(simpleAB.(\testOffsetOutAr, true), \ar, "OffsetOut.ar works with reblocking and resampling");
 
 		// XOut.ar / XOut.kr
 
@@ -288,6 +294,7 @@ TestReblock : TestReblockBase {
 		server.sync;
 
 		this.performABTest(simpleAB.(\testXOutAr), \ar, "XOut.ar works with reblocking");
+		this.performABTest(simpleAB.(\testXOutAr, true), \ar, "XOut.ar works with reblocking and resampling");
 
 		SynthDef(\testXOutKr, { |out, blockSize|
 			Reblock(blockSize);
@@ -297,6 +304,7 @@ TestReblock : TestReblockBase {
 		server.sync;
 
 		this.performABTest(simpleAB.(\testXOutKr), \kr, "XOut.kr works with reblocking");
+		this.performABTest(simpleAB.(\testXOutKr, true), \kr, "XOut.kr works with reblocking and resampling");
 
 		// In.ar / In.kr
 
@@ -308,6 +316,7 @@ TestReblock : TestReblockBase {
 		server.sync;
 
 		this.performABTest(simpleAB.(\testInAr), \ar, "In.ar works with reblocking");
+		this.performABTest(simpleAB.(\testInAr, true), \ar, "In.ar works with reblocking and resampling");
 
 		SynthDef(\testInKr, { |out, blockSize|
 			Reblock(blockSize);
@@ -317,6 +326,7 @@ TestReblock : TestReblockBase {
 		server.sync;
 
 		this.performABTest(simpleAB.(\testInKr), \kr, "In.kr works with reblocking");
+		this.performABTest(simpleAB.(\testInKr, true), \kr, "In.kr works with reblocking and resampling");
 
 		// FeedbackIn.ar
 
@@ -328,6 +338,7 @@ TestReblock : TestReblockBase {
 		server.sync;
 
 		this.performABTest(simpleAB.(\testInFeedbackAr), \ar, "InFeedback.ar works with reblocking");
+		this.performABTest(simpleAB.(\testInFeedbackAr, true), \ar, "InFeedback.ar works with reblocking and resampling");
 
 		// LagIn.kr
 
@@ -339,6 +350,7 @@ TestReblock : TestReblockBase {
 		server.sync;
 
 		this.performABTest(simpleAB.(\testLagInKr), \kr, "LagIn.kr works with reblocking");
+		this.performABTest(simpleAB.(\testLagInKr, true), \kr, "LagIn.kr works with reblocking and resampling");
 
 		// InTrig.kr
 
@@ -368,6 +380,7 @@ TestReblock : TestReblockBase {
 		server.sync;
 
 		this.performABTest(simpleAB.(\testControl), \kr, "Control with default value works with reblocking");
+		this.performABTest(simpleAB.(\testControl, true), \kr, "Control with default value works with reblocking and resampling");
 
 		this.performABTest({ |busA, busB|
 			var a = Synth(\testControl, [ out: busA, blockSize: testBlockSize ], server, \addToTail).map(\ctl, krTestBus);
@@ -385,6 +398,7 @@ TestReblock : TestReblockBase {
 		server.sync;
 
 		this.performABTest(simpleAB.(\testAudioControl), \ar, "AudioControl with default value works with reblocking");
+		this.performABTest(simpleAB.(\testAudioControl, true), \ar, "AudioControl with default value works with reblocking and resampling");
 
 		this.performABTest({ |busA, busB|
 			var a = Synth(\testAudioControl, [ out: busA, blockSize: testBlockSize ], server, \addToTail).map(\ctl, arTestBus);
@@ -408,6 +422,7 @@ TestReblock : TestReblockBase {
 		server.sync;
 
 		this.performABTest(simpleAB.(\testLagControl), \kr, "LagControl with default value works with reblocking");
+		this.performABTest(simpleAB.(\testLagControl, true), \kr, "LagControl with default value works with reblocking and resampling");
 
 		this.performABTest({ |busA, busB|
 			var a = Synth(\testLagControl, [ out: busA, blockSize: testBlockSize ], server, \addToTail).map(\ctl, krTestBus);
@@ -425,6 +440,7 @@ TestReblock : TestReblockBase {
 		server.sync;
 
 		this.performABTest(simpleAB.(\testTrigControl), \kr, "TrigControl with default value works with reblocking");
+		this.performABTest(simpleAB.(\testTrigControl, true), \kr, "TrigControl with default value works with reblocking and resampling");
 
 		this.performABTest({ |busA, busB|
 			var a, b;
@@ -449,6 +465,7 @@ TestReblock : TestReblockBase {
 		server.sync;
 
 		this.performABTest(simpleAB.(\testLocalBusAr), \ar, "LocalIn.ar and LocalOut.ar work with reblocking");
+		this.performABTest(simpleAB.(\testLocalBusAr, true), \ar, "LocalIn.ar and LocalOut.ar work with reblocking and resampling");
 
 		SynthDef(\testLocalBusKr, { |out, blockSize|
 			var sig = SinOsc.kr([220, 440]);
@@ -462,5 +479,6 @@ TestReblock : TestReblockBase {
 		server.sync;
 
 		this.performABTest(simpleAB.(\testLocalBusKr), \kr, "LocalIn.kr and LocalOut.kr work with reblocking");
+		this.performABTest(simpleAB.(\testLocalBusKr, true), \kr, "LocalIn.kr and LocalOut.kr work with reblocking and resampling");
 	}
 }

--- a/testsuite/classlibrary/TestResample.sc
+++ b/testsuite/classlibrary/TestResample.sc
@@ -125,7 +125,7 @@ TestResample : TestReblockBase {
 		var trigBusB = Bus.control(server, 2);
 		var arTestBus = Bus.audio(server, 2);
 		var krTestBus = Bus.control(server, 2);
-		var testFactor = 1;
+		var testFactor = 4;
 
 		simpleAB = { |defName|
 			{ |busA, busB|


### PR DESCRIPTION
- allow block sizes smaller than the resample factor. For example, you can run a Synth with a block size of 1 and an upsampling factor of 4. This would allow feedback loops that are faster than the Server sample rate. Previously, this would produce no output. This required a rewrite of the reblocking/resampling logic in `Out`, `ReplaceOut`, `XOut` and `OffsetOut`.

- allow larger block sizes, as long as the effective block size (`block size / resample`) does not exceed the Server block size. If the effective block size is larger than the Server block size, we issue a warning and adjust the block size. Larger block sizes need less CPU and they can also be beneficial for FFT processing. (Example: convolving with a filter kernel without delay.)

- scsynth: do not multiply the buffer indexes in the SynthDef; instead do it in the Graph constructor so we can multiply the indexes by the Graph block size. If the block size is larger than the Server block size, make sure we have enough wire buffer space!

- Graph: change the type of `mNumTicks` and `mTickCounter` to uint32. Temporarily bump the plugin API version to 7.

- supernova: fix missing `mRate` initialization

<!-- For information about contributing see: https://github.com/supercollider/supercollider/wiki/Contributing-directory -->

## Purpose and Motivation

<!-- Please provide a description, even if you are linking to a related Issue or PR. -->
<!-- If this fixes an open issue, link to it by writing "Fixes #555." -->

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix
- Breaking change

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [x] This PR is ready for review <!-- If not ready for review, consider making a Draft PR instead, or describe what kind of specific feedback you want. -->

<!-- ## Merge notes
(optional) You may also add notes of:
     - Dependencies: if this PR depends on any other PRs or actions
     - Merge Note: any considerations regarding merging this PR
     - Release Notes: text you think would be useful to include in the Release Notes
-->

<!-- Note: The recommended commit message format is:
     component: sub-component: short description of changes
For example:
     classlib: ClassBrowser: fix search with empty query string
Common `comp:` labels:
     help, classlib, sclang, scsynth, plugins, tests, docs, SCDoc
See wiki for more info: Wiki->Creating Pull Requests->git-commit-message-format
-->
